### PR TITLE
WIP: assert: Mark test helpers as such

### DIFF
--- a/assert/assert.go
+++ b/assert/assert.go
@@ -1,33 +1,38 @@
-// Package assert provides basic assert functions for tests
+// Package assert provides basic assert functions for tests.
 package assert
 
 import (
-	"errors"
 	"fmt"
 	"testing"
 )
 
-// basic assertion support
-
+// Deprecated: Use standard Go testing package.
 func Nil(t *testing.T, obj interface{}, msgs ...string) {
+	t.Helper()
 	if obj != nil {
-		t.Fatal(msgs, "error:", errors.New("Expected object to be nil"))
+		t.Fatal(msgs, "error: expected object to be nil")
 	}
 }
 
+// Deprecated: Use standard Go testing package.
 func NotNil(t *testing.T, obj interface{}, msgs ...string) {
+	t.Helper()
 	if obj == nil {
-		t.Fatal(msgs, "epxected a non-nil object")
+		t.Fatal(msgs, "expected a non-nil object")
 	}
 }
 
+// Deprecated: Use standard Go testing package.
 func True(t *testing.T, v bool, msgs ...string) {
+	t.Helper()
 	if !v {
 		t.Fatal(msgs)
 	}
 }
 
+// Deprecated: Use standard Go testing package.
 func Equal(t *testing.T, a interface{}, b interface{}, msg string) {
+	t.Helper()
 	if a == b {
 		return
 	}
@@ -37,16 +42,23 @@ func Equal(t *testing.T, a interface{}, b interface{}, msg string) {
 	t.Fatal(msg)
 }
 
+// Deprecated: Use standard Go testing package.
 func False(t *testing.T, v bool, msgs ...string) {
+	t.Helper()
 	True(t, !v, msgs...)
 }
 
+// Deprecated: Use standard Go testing package.
 func NoErr(t *testing.T, err error, msgs ...string) {
+	t.Helper()
 	if err != nil {
 		t.Fatal(msgs, "error:", err)
 	}
 }
+
+// Deprecated: Use standard Go testing package.
 func Err(t *testing.T, err error, msgs ...string) {
+	t.Helper()
 	if err == nil {
 		t.Fatal(msgs, "error:", err)
 	}

--- a/assert/assert_test.go
+++ b/assert/assert_test.go
@@ -1,0 +1,47 @@
+package assert_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/spacemeshos/go-spacemesh/assert"
+)
+
+func TestNil(t *testing.T) {
+	assert.Nil(t, nil, "should be nil")
+}
+
+func TestNotNil(t *testing.T) {
+	assert.NotNil(t, "", "should not be nil")
+}
+
+func TestTrue(t *testing.T) {
+	assert.True(t, true, "should be true")
+}
+
+func TestEqual(t *testing.T) {
+	var testCases = []struct {
+		a interface{}
+		b interface{}
+	}{
+		{"foo", "foo"},
+		{nil, nil},
+	}
+	for _, tc := range testCases {
+		msg := fmt.Sprintf("a '%v' should equal to b '%v'", tc.a, tc.b)
+		assert.Equal(t, tc.a, tc.b, msg)
+	}
+}
+
+func TestFalse(t *testing.T) {
+	assert.False(t, false, "should be false")
+}
+
+func TestNoErr(t *testing.T) {
+	assert.NoErr(t, nil, "should be no error")
+}
+
+func TestErr(t *testing.T) {
+	assert.Err(t, errors.New("test error"), "should have error")
+}


### PR DESCRIPTION

I marked this as Work In Progress. I'm not sure whether maintaining custom assert package is worth the effort. See TestEqual and TestEqualStd sample test cases. I'd be happier with the latter!

I'll update this WIP pull request based on discussion.

--------
- Add sample test cases.
- Go test will report correct line numbers on errors when test helper functions
identify as test helpers by calling t.Helper().