### PR TITLE
Change method signature for getNodeHash to manage errors instead of swallow them

### DIFF
--- a/merkle/branchnode_test.go
+++ b/merkle/branchnode_test.go
@@ -31,7 +31,8 @@ func TestBranchNodeCreation(t *testing.T) {
 	value := node.getValue()
 	assert.True(t, bytes.Equal(k3, value), "unexpected node value")
 
-	nodeHash, _ := node.getNodeHash()
+	nodeHash, err := node.getNodeHash()
+	assert.NoErr(t, err, "failed getting node hash")
 	binData, err := node.marshal()
 	assert.NoErr(t, err, "failed to marshal node")
 	assert.True(t, bytes.Equal(crypto.Sha256(binData), nodeHash), "unexpected node hash")

--- a/merkle/branchnode_test.go
+++ b/merkle/branchnode_test.go
@@ -3,9 +3,10 @@ package merkle
 import (
 	"bytes"
 	"encoding/hex"
+	"testing"
+
 	"github.com/spacemeshos/go-spacemesh/assert"
 	"github.com/spacemeshos/go-spacemesh/crypto"
-	"testing"
 )
 
 func TestBranchNodeCreation(t *testing.T) {
@@ -30,7 +31,7 @@ func TestBranchNodeCreation(t *testing.T) {
 	value := node.getValue()
 	assert.True(t, bytes.Equal(k3, value), "unexpected node value")
 
-	nodeHash := node.getNodeHash()
+	nodeHash, _ := node.getNodeHash()
 	binData, err := node.marshal()
 	assert.NoErr(t, err, "failed to marshal node")
 	assert.True(t, bytes.Equal(crypto.Sha256(binData), nodeHash), "unexpected node hash")

--- a/merkle/delete.go
+++ b/merkle/delete.go
@@ -3,6 +3,7 @@ package merkle
 import (
 	"encoding/hex"
 	"errors"
+
 	"github.com/spacemeshos/go-spacemesh/log"
 )
 

--- a/merkle/node_test.go
+++ b/merkle/node_test.go
@@ -3,10 +3,11 @@ package merkle
 import (
 	"bytes"
 	"encoding/hex"
+	"testing"
+
 	"github.com/spacemeshos/go-spacemesh/assert"
 	"github.com/spacemeshos/go-spacemesh/crypto"
 	"github.com/spacemeshos/go-spacemesh/merkle/pb"
-	"testing"
 )
 
 func TestChildren(t *testing.T) {
@@ -52,8 +53,9 @@ func TestBranchNodeContainer(t *testing.T) {
 	assert.True(t, node.getNodeType() == pb.NodeType_branch, "expected branch")
 	bn := node.getBranchNode()
 	assert.NotNil(t, bn, "expected branch node")
-
-	assert.True(t, bytes.Equal(bn.getNodeHash(), b.getNodeHash()), "hash mismatch")
+	bHash, _ := b.getNodeHash()
+	bnHash, _ := bn.getNodeHash()
+	assert.True(t, bytes.Equal(bnHash, bHash), "hash mismatch")
 
 	assert.Nil(t, node.getExtNode(), "expected branch node")
 	assert.Nil(t, node.getLeafNode(), "expected branch node")
@@ -61,7 +63,7 @@ func TestBranchNodeContainer(t *testing.T) {
 	data, err := node.marshal()
 	assert.NoErr(t, err, "failed to marshal branch node")
 
-	hash := node.getNodeHash()
+	hash, _ := node.getNodeHash()
 	assert.True(t, bytes.Equal(crypto.Sha256(data), hash), "hash mismatch")
 
 	node1, err := newBranchNodeContainer(entries, k3)
@@ -70,7 +72,9 @@ func TestBranchNodeContainer(t *testing.T) {
 	assert.True(t, node1.getNodeType() == pb.NodeType_branch, "expected branch")
 	bn = node.getBranchNode()
 	assert.NotNil(t, bn, "expected branch node")
-	assert.True(t, bytes.Equal(bn.getNodeHash(), b.getNodeHash()), "hash mismatch")
+	hash, _ = b.getNodeHash()
+	bnHash, _ = bn.getNodeHash()
+	assert.True(t, bytes.Equal(bnHash, hash), "hash mismatch")
 
 	assert.Nil(t, node1.getExtNode(), "expected branch node")
 	assert.Nil(t, node1.getLeafNode(), "expected branch node")
@@ -78,7 +82,7 @@ func TestBranchNodeContainer(t *testing.T) {
 	data, err = node1.marshal()
 	assert.NoErr(t, err, "failed to marshal branch node")
 
-	hash = node1.getNodeHash()
+	hash, _ = node1.getNodeHash()
 	assert.True(t, bytes.Equal(crypto.Sha256(data), hash), "hash mismatch")
 
 }
@@ -101,7 +105,10 @@ func TestLeafNodeContainer(t *testing.T) {
 	assert.True(t, node.getNodeType() == pb.NodeType_leaf, "expected leaf")
 	ln := node.getLeafNode()
 	assert.NotNil(t, ln, "expected leaf node")
-	assert.True(t, bytes.Equal(ln.getNodeHash(), leaf.getNodeHash()), "hash mismatch")
+
+	leafHash, _ := leaf.getNodeHash()
+	lnHash, _ := ln.getNodeHash()
+	assert.True(t, bytes.Equal(lnHash, leafHash), "hash mismatch")
 
 	assert.Nil(t, node.getExtNode(), "expected leaf node")
 	assert.Nil(t, node.getBranchNode(), "expected leaf node")
@@ -109,7 +116,7 @@ func TestLeafNodeContainer(t *testing.T) {
 	data1, err := node.marshal()
 	assert.NoErr(t, err, "failed to marshal leaf node")
 
-	hash := node.getNodeHash()
+	hash, _ := node.getNodeHash()
 	assert.True(t, bytes.Equal(crypto.Sha256(data1), hash), "hash mismatch")
 
 	node1, err := newLeafNodeContainer(l1Hex, l1)
@@ -120,7 +127,9 @@ func TestLeafNodeContainer(t *testing.T) {
 	ln = node1.getLeafNode()
 
 	assert.NotNil(t, ln, "expected leaf node")
-	assert.True(t, bytes.Equal(ln.getNodeHash(), leaf.getNodeHash()), "hash mismatch")
+	lnHash, _ = ln.getNodeHash()
+	leafHash, _ = leaf.getNodeHash()
+	assert.True(t, bytes.Equal(lnHash, leafHash), "hash mismatch")
 
 	assert.Nil(t, node1.getExtNode(), "expected leaf node")
 	assert.Nil(t, node1.getBranchNode(), "expected leaf node")
@@ -128,7 +137,7 @@ func TestLeafNodeContainer(t *testing.T) {
 	data1, err = node1.marshal()
 	assert.NoErr(t, err, "failed to marshal leaf node")
 
-	hash = node1.getNodeHash()
+	hash, _ = node1.getNodeHash()
 	assert.True(t, bytes.Equal(crypto.Sha256(data1), hash), "hash mismatch")
 }
 
@@ -150,7 +159,10 @@ func TestExtNodeContainer(t *testing.T) {
 	assert.True(t, node.getNodeType() == pb.NodeType_extension, "expected ext")
 	en := node.getExtNode()
 	assert.NotNil(t, en, "expected ext node")
-	assert.True(t, bytes.Equal(en.getNodeHash(), ext.getNodeHash()), "hash mismatch")
+
+	extHash, _ := ext.getNodeHash()
+	enHash, _ := en.getNodeHash()
+	assert.True(t, bytes.Equal(enHash, extHash), "hash mismatch")
 
 	assert.Nil(t, node.getLeafNode(), "expected ext node")
 	assert.Nil(t, node.getBranchNode(), "expected ext node")
@@ -158,7 +170,7 @@ func TestExtNodeContainer(t *testing.T) {
 	data1, err := node.marshal()
 	assert.NoErr(t, err, "failed to marshal ext node")
 
-	hash := node.getNodeHash()
+	hash, _ := node.getNodeHash()
 	assert.True(t, bytes.Equal(crypto.Sha256(data1), hash), "hash mismatch")
 
 	node1, err := newExtNodeContainer(e1Hex, e1)
@@ -169,7 +181,9 @@ func TestExtNodeContainer(t *testing.T) {
 	en = node1.getExtNode()
 
 	assert.NotNil(t, en, "expected leaf node")
-	assert.True(t, bytes.Equal(en.getNodeHash(), ext.getNodeHash()), "hash mismatch")
+	extHash, _ = ext.getNodeHash()
+	enHash, _ = en.getNodeHash()
+	assert.True(t, bytes.Equal(enHash, extHash), "hash mismatch")
 
 	assert.Nil(t, node1.getLeafNode(), "expected ext node")
 	assert.Nil(t, node1.getBranchNode(), "expected ext node")
@@ -177,7 +191,7 @@ func TestExtNodeContainer(t *testing.T) {
 	data1, err = node1.marshal()
 	assert.NoErr(t, err, "failed to marshal ext node")
 
-	hash = node1.getNodeHash()
+	hash, _ = node1.getNodeHash()
 	assert.True(t, bytes.Equal(crypto.Sha256(data1), hash), "hash mismatch")
 
 }

--- a/merkle/put.go
+++ b/merkle/put.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"errors"
+
 	"github.com/spacemeshos/go-spacemesh/crypto"
 	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/merkle/pb"
@@ -98,7 +99,11 @@ func (mt *merkleTreeImp) update(k string, s *stack) error {
 			pos -= len(n.getShortNode().getPath())
 
 			if lastRoot != nil {
-				n.setExtChild(lastRoot.getNodeHash())
+				hash, err := lastRoot.getNodeHash()
+				if err != nil {
+					return err
+				}
+				n.setExtChild(hash)
 			}
 
 		case pb.NodeType_leaf:

--- a/merkle/shortnode.go
+++ b/merkle/shortnode.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
+
 	"github.com/gogo/protobuf/proto"
 	"github.com/spacemeshos/go-spacemesh/crypto"
 	"github.com/spacemeshos/go-spacemesh/merkle/pb"
@@ -14,13 +15,13 @@ import (
 // For an ext node, value is a pointer to another node in tree-space data store
 // In both cases values are sha3s
 type shortNode interface {
-	isLeaf() bool             // extension node when false
-	getValue() []byte         // value for leaf node. Pointer to child node for an extension node
-	getPath() string          // hex encoded path to this node from parent
-	marshal() ([]byte, error) // to binary data
-	getNodeHash() []byte      // node binary data hash - determines the value of pointer to this node
-	setValue(v []byte)        // update the node value
-	setPath(p string)         // set the path
+	isLeaf() bool                 // extension node when false
+	getValue() []byte             // value for leaf node. Pointer to child node for an extension node
+	getPath() string              // hex encoded path to this node from parent
+	marshal() ([]byte, error)     // to binary data
+	getNodeHash() ([]byte, error) // node binary data hash - determines the value of pointer to this node
+	setValue(v []byte)            // update the node value
+	setPath(p string)             // set the path
 
 	print(userDb *userDb, getUserValue func(userDb *userDb, v []byte) string) string // returns debug info
 }
@@ -51,17 +52,17 @@ type shortNodeImpl struct {
 	nodeHash []byte
 }
 
-func (s *shortNodeImpl) getNodeHash() []byte {
+func (s *shortNodeImpl) getNodeHash() ([]byte, error) {
 	if s.nodeHash == nil || len(s.nodeHash) == 0 { // lazy eval
 		// calc hash based on current marshaled node data and store it
 		data, err := s.marshal()
 		if err != nil {
-			return []byte{}
+			return nil, err
 		}
 		s.nodeHash = crypto.Sha256(data)
 	}
 
-	return s.nodeHash
+	return s.nodeHash, nil
 }
 
 func (s *shortNodeImpl) setValue(v []byte) {
@@ -102,18 +103,28 @@ func (s *shortNodeImpl) marshal() ([]byte, error) {
 
 func (s *shortNodeImpl) print(userDb *userDb, getUserValue func(userDb *userDb, v []byte) string) string {
 	buffer := bytes.Buffer{}
+	hash, err := s.getNodeHash()
 	if s.isLeaf() {
 		userValue := getUserValue(userDb, s.value)
-		buffer.WriteString(fmt.Sprintf("Leaf: <%s> path: `%s`, value: `%s`\n",
-			hex.EncodeToString(s.getNodeHash())[:6],
-			s.path,
-			userValue))
-
+		if err == nil {
+			buffer.WriteString(fmt.Sprintf("Leaf: <%s> path: `%s`, value: `%s`\n",
+				hex.EncodeToString(hash)[:6],
+				s.path,
+				userValue))
+		}
 	} else {
-		buffer.WriteString(fmt.Sprintf("Ext: <%s> path: `%s`, value: <%s>\n",
-			hex.EncodeToString(s.getNodeHash())[:6],
-			s.path,
-			hex.EncodeToString(s.value)[:6]))
+		if err == nil {
+			buffer.WriteString(fmt.Sprintf("Ext: <%s> path: `%s`, value: <%s>\n",
+				hex.EncodeToString(hash)[:6],
+				s.path,
+				hex.EncodeToString(s.value)[:6]))
+		}
+		if err != nil {
+			buffer.WriteString(fmt.Sprintf("Path: `%s`, error: `%s`\n",
+				s.path,
+				err.Error()))
+		}
+
 	}
 
 	return buffer.String()

--- a/merkle/shortnode_test.go
+++ b/merkle/shortnode_test.go
@@ -3,10 +3,11 @@ package merkle
 import (
 	"bytes"
 	"encoding/hex"
+	"testing"
+
 	"github.com/spacemeshos/go-spacemesh/assert"
 	"github.com/spacemeshos/go-spacemesh/crypto"
 	"github.com/spacemeshos/go-spacemesh/merkle/pb"
-	"testing"
 )
 
 func TestLeafNode(t *testing.T) {
@@ -25,7 +26,7 @@ func TestLeafNode(t *testing.T) {
 	v := node.getValue()
 	assert.True(t, bytes.Equal(v, p1), "unexpected value")
 
-	nodeHash := node.getNodeHash()
+	nodeHash, _ := node.getNodeHash()
 	binData, err := node.marshal()
 	assert.NoErr(t, err, "failed to marshal node")
 	assert.True(t, bytes.Equal(crypto.Sha256(binData), nodeHash), "unexpected node hash")
@@ -48,7 +49,7 @@ func TestExtNode(t *testing.T) {
 	v := node.getValue()
 	assert.True(t, bytes.Equal(v, p1), "unexpected value")
 
-	nodeHash := node.getNodeHash()
+	nodeHash, _ := node.getNodeHash()
 	binData, err := node.marshal()
 	assert.NoErr(t, err, "failed to marshal node")
 	assert.True(t, bytes.Equal(crypto.Sha256(binData), nodeHash), "unexpected node hash")

--- a/merkle/test/merkle_test.go
+++ b/merkle/test/merkle_test.go
@@ -3,11 +3,12 @@ package test
 import (
 	"bytes"
 	"encoding/hex"
+	"testing"
+
 	"github.com/spacemeshos/go-spacemesh/assert"
 	"github.com/spacemeshos/go-spacemesh/crypto"
 	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/merkle"
-	"testing"
 )
 
 func TestEmptyTreeCreation(t *testing.T) {
@@ -19,7 +20,7 @@ func TestEmptyTreeCreation(t *testing.T) {
 	root := m.GetRootNode()
 	assert.Nil(t, root, "expected empty tree")
 
-	hash := m.GetRootHash()
+	hash, _ := m.GetRootHash()
 	assert.True(t, bytes.Equal(merkle.EmptyTreeRootHash, hash), "unexpected empty tree root hash")
 
 	err = m.CloseDataStores()
@@ -54,14 +55,14 @@ func TestSimpleTreeOps(t *testing.T) {
 	/////////////////////////
 
 	// restore tree to a new instance based on root hash
-	rootHash := m.GetRootHash()
-	m1, err := merkle.NewTreeFromDb(rootHash, userDb, treeDb)
+	rootHash, _ := m.GetRootHash()
+	m1, _ := merkle.NewTreeFromDb(rootHash, userDb, treeDb)
 	defer m1.CloseDataStores() // tell m1 to close data stores when we are done w it
 
 	root = m1.GetRootNode()
 	assert.NotNil(t, root, "expected non-empty tree")
 
-	rootHash1 := m1.GetRootHash()
+	rootHash1, _ := m1.GetRootHash()
 
 	assert.True(t, bytes.Equal(rootHash, rootHash1), "expected same root hash")
 
@@ -107,7 +108,8 @@ func TestComplexTreeOps(t *testing.T) {
 
 	r, err := m.ValidateStructure(m.GetRootNode())
 	assert.NoErr(t, err, "invalid tree structure")
-	assert.True(t, bytes.Equal(r, m.GetRootHash()), "unexpected root hash")
+	mHash, _ := m.GetRootHash()
+	assert.True(t, bytes.Equal(r, mHash), "unexpected root hash")
 
 	log.Info(m.Print())
 	validateGet(t, m, k1, v1)
@@ -120,7 +122,8 @@ func TestComplexTreeOps(t *testing.T) {
 
 	r, err = m.ValidateStructure(m.GetRootNode())
 	assert.NoErr(t, err, "invalid tree structure")
-	assert.True(t, bytes.Equal(r, m.GetRootHash()), "unexpected root hash")
+	mHash, _ = m.GetRootHash()
+	assert.True(t, bytes.Equal(r, mHash), "unexpected root hash")
 
 	data, _, err := m.Get(k3)
 	assert.True(t, len(data) == 0, "expected empty result")
@@ -144,7 +147,8 @@ func TestComplexTreeOps(t *testing.T) {
 	log.Info(m.Print())
 	r, err = m.ValidateStructure(m.GetRootNode())
 	assert.NoErr(t, err, "invalid tree structure")
-	assert.True(t, bytes.Equal(r, m.GetRootHash()), "unexpected root hash")
+	mHash, _ = m.GetRootHash()
+	assert.True(t, bytes.Equal(r, mHash), "unexpected root hash")
 
 	validateGet(t, m, k1, v1)
 	validateGet(t, m, k2, v2)
@@ -156,7 +160,8 @@ func TestComplexTreeOps(t *testing.T) {
 	log.Info(m.Print())
 	r, err = m.ValidateStructure(m.GetRootNode())
 	assert.NoErr(t, err, "invalid tree structure")
-	assert.True(t, bytes.Equal(r, m.GetRootHash()), "unexpected root hash")
+	mHash, _ = m.GetRootHash()
+	assert.True(t, bytes.Equal(r, mHash), "unexpected root hash")
 
 	validateGet(t, m, k1, v1)
 	validateGet(t, m, k2, v2)

--- a/merkle/test/merkle_test.go
+++ b/merkle/test/merkle_test.go
@@ -20,7 +20,8 @@ func TestEmptyTreeCreation(t *testing.T) {
 	root := m.GetRootNode()
 	assert.Nil(t, root, "expected empty tree")
 
-	hash, _ := m.GetRootHash()
+	hash, err := m.GetRootHash()
+	assert.NoErr(t, err, "error getting node hash")
 	assert.True(t, bytes.Equal(merkle.EmptyTreeRootHash, hash), "unexpected empty tree root hash")
 
 	err = m.CloseDataStores()
@@ -55,14 +56,16 @@ func TestSimpleTreeOps(t *testing.T) {
 	/////////////////////////
 
 	// restore tree to a new instance based on root hash
-	rootHash, _ := m.GetRootHash()
+	rootHash, err := m.GetRootHash()
+	assert.NoErr(t, err, "error getting node hash")
 	m1, _ := merkle.NewTreeFromDb(rootHash, userDb, treeDb)
 	defer m1.CloseDataStores() // tell m1 to close data stores when we are done w it
 
 	root = m1.GetRootNode()
 	assert.NotNil(t, root, "expected non-empty tree")
 
-	rootHash1, _ := m1.GetRootHash()
+	rootHash1, err := m1.GetRootHash()
+	assert.NoErr(t, err, "error getting node hash")
 
 	assert.True(t, bytes.Equal(rootHash, rootHash1), "expected same root hash")
 
@@ -108,7 +111,8 @@ func TestComplexTreeOps(t *testing.T) {
 
 	r, err := m.ValidateStructure(m.GetRootNode())
 	assert.NoErr(t, err, "invalid tree structure")
-	mHash, _ := m.GetRootHash()
+	mHash, err := m.GetRootHash()
+	assert.NoErr(t, err, "invalid tree structure")
 	assert.True(t, bytes.Equal(r, mHash), "unexpected root hash")
 
 	log.Info(m.Print())
@@ -122,7 +126,8 @@ func TestComplexTreeOps(t *testing.T) {
 
 	r, err = m.ValidateStructure(m.GetRootNode())
 	assert.NoErr(t, err, "invalid tree structure")
-	mHash, _ = m.GetRootHash()
+	mHash, err = m.GetRootHash()
+	assert.NoErr(t, err, "error getting node hash")
 	assert.True(t, bytes.Equal(r, mHash), "unexpected root hash")
 
 	data, _, err := m.Get(k3)
@@ -147,7 +152,8 @@ func TestComplexTreeOps(t *testing.T) {
 	log.Info(m.Print())
 	r, err = m.ValidateStructure(m.GetRootNode())
 	assert.NoErr(t, err, "invalid tree structure")
-	mHash, _ = m.GetRootHash()
+	mHash, err = m.GetRootHash()
+	assert.NoErr(t, err, "error getting node hash")
 	assert.True(t, bytes.Equal(r, mHash), "unexpected root hash")
 
 	validateGet(t, m, k1, v1)
@@ -160,7 +166,8 @@ func TestComplexTreeOps(t *testing.T) {
 	log.Info(m.Print())
 	r, err = m.ValidateStructure(m.GetRootNode())
 	assert.NoErr(t, err, "invalid tree structure")
-	mHash, _ = m.GetRootHash()
+	mHash, err = m.GetRootHash()
+	assert.NoErr(t, err, "error getting node hash")
 	assert.True(t, bytes.Equal(r, mHash), "unexpected root hash")
 
 	validateGet(t, m, k1, v1)

--- a/merkle/tree.go
+++ b/merkle/tree.go
@@ -14,7 +14,7 @@ type MerkleTree interface {
 	Put(k, v []byte) error                // store user key, value
 	Delete(k []byte) error                // delete user value indexed by key
 	Get(k []byte) ([]byte, *stack, error) // get user value indexed by key
-	GetRootHash() []byte                  // get tree root hash
+	GetRootHash() ([]byte, error)         // get tree root hash
 	GetRootNode() Node                    // get root node
 
 	CloseDataStores() error // call when done w the tree

--- a/merkle/validate.go
+++ b/merkle/validate.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+
 	"github.com/spacemeshos/go-spacemesh/merkle/pb"
 )
 
@@ -43,7 +44,7 @@ func (mt *merkleTreeImp) ValidateStructure(root Node) ([]byte, error) {
 			}
 		}
 
-		return root.getNodeHash(), nil
+		return root.getNodeHash()
 
 	case pb.NodeType_extension:
 		children := root.getAllChildren()
@@ -60,11 +61,11 @@ func (mt *merkleTreeImp) ValidateStructure(root Node) ([]byte, error) {
 			return nil, errors.New("hash mismatch")
 		}
 
-		return root.getNodeHash(), nil
+		return root.getNodeHash()
 
 	case pb.NodeType_leaf:
 
-		return root.getNodeHash(), nil
+		return root.getNodeHash()
 	}
 
 	return nil, errors.New("unexpected node type")


### PR DESCRIPTION
Instead of returning an empty string, getNodeHash returns an error. 

Print methods will render the error in order to process it later on.