### PR TITLE
app: Remove default GOMAXPROCS setting

### DIFF
--- a/app/main.go
+++ b/app/main.go
@@ -132,9 +132,6 @@ func (app *SpaceMeshApp) getAppInfo() string {
 
 func (app *SpaceMeshApp) before(ctx *cli.Context) error {
 
-	// max out box for now
-	runtime.GOMAXPROCS(runtime.NumCPU())
-
 	// exit gracefully - e.g. with app cleanup on sig abort (ctrl-c)
 	signalChan := make(chan os.Signal, 1)
 	signal.Notify(signalChan, os.Interrupt)


### PR DESCRIPTION
Go 1.5 release notes:
- By default, Go programs run with GOMAXPROCS set to the number of cores
  available; in prior releases it defaulted to 1.