### PR TITLE
Fix go vet reported issues

### DIFF
--- a/accounts/account.go
+++ b/accounts/account.go
@@ -91,12 +91,12 @@ func NewAccount(passphrase string) (*Account, error) {
 
 	// store kd data
 	kdParams := crypto.KDParams{
-		kdfParams.N,
-		kdfParams.R,
-		kdfParams.P,
-		kdfParams.SaltLen,
-		kdfParams.DKLen,
-		kdfParams.Salt,
+		N:kdfParams.N,
+		R: kdfParams.R,
+		P: kdfParams.P,
+		SaltLen: kdfParams.SaltLen,
+		DKLen: kdfParams.DKLen,
+		Salt: kdfParams.Salt,
 	}
 
 	// save all date in newly created account obj

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -44,7 +44,7 @@ func TestGrpcApi(t *testing.T) {
 	// Set up a connection to the server.
 	conn, err := grpc.Dial(addr, grpc.WithInsecure())
 	if err != nil {
-		t.Fatalf("did not connect", err)
+		t.Fatalf("did not connect. %v", err)
 	}
 	defer conn.Close()
 	c := pb.NewSpaceMeshServiceClient(conn)
@@ -52,7 +52,7 @@ func TestGrpcApi(t *testing.T) {
 	// call echo and validate result
 	r, err := c.Echo(context.Background(), &pb.SimpleMessage{Value: message})
 	if err != nil {
-		t.Fatalf("could not greet", err)
+		t.Fatalf("could not greet. %v", err)
 	}
 
 	assert.Equal(t, message, r.Value, "Expected message to be echoed")

--- a/ci/validate-lint.sh
+++ b/ci/validate-lint.sh
@@ -2,7 +2,7 @@
 
 pkgs=`go list ./... | grep -vF /vendor/`
 
-go vet $pkgs
+go vet -composites=false $pkgs
 if [ $? -eq 1 ]; then
 	exit 1
 fi

--- a/p2p/swarmhandlers.go
+++ b/p2p/swarmhandlers.go
@@ -75,7 +75,7 @@ func (s *swarmImpl) onConnectionRequest(req node.RemoteNodeData) {
 		conn, err = s.network.DialTCP(req.Ip(), s.localNode.Config().DialTimeout, s.localNode.Config().ConnKeepAlive)
 		if err != nil {
 			s.sendNodeEvent(req.Id(), DISCONNECTED)
-			s.localNode.Error("failed to connect to remote node %s on advertised ip %s", req.Pretty(), req.Ip)
+			s.localNode.Error("failed to connect to remote node %s on advertised ip %s", req.Pretty(), req.Ip())
 			return
 		}
 

--- a/p2p/swarmimpl.go
+++ b/p2p/swarmimpl.go
@@ -130,7 +130,7 @@ func (s *swarmImpl) sendNodeEvent(peerId string, state NodeState) {
 
 	evt := NodeEvent{peerId, state}
 	for _, c := range s.nec {
-		go func() { c <- evt }()
+		go func(c NodeEventCallback) { c <- evt }(c)
 	}
 }
 


### PR DESCRIPTION
Disable go vet keyed composites check for now. It is a matter of style. Pike highly recommend to enable it and use keys for all struct literals.