### PR TITLE
Graceful shutdown jsonapiserver

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -72,14 +72,15 @@ func TestJsonApi(t *testing.T) {
 	grpcService := NewGrpcService()
 	jsonService := NewJsonHttpServer()
 
-	started := make(chan bool, 2)
+	jsonStatus := make(chan bool, 2)
+	grpcStatus := make(chan bool, 2)
 
 	// start grp and json server
-	grpcService.StartService(started)
-	<-started
+	grpcService.StartService(grpcStatus)
+	<-grpcStatus
 
-	jsonService.StartService(started)
-	<-started
+	jsonService.StartService(jsonStatus)
+	<-jsonStatus
 
 	const message = "hello world!"
 	const contentType = "application/json"
@@ -121,6 +122,8 @@ func TestJsonApi(t *testing.T) {
 	}
 
 	// stop the services
-	jsonService.Stop()
+	jsonService.StopService()
+	<- jsonStatus
 	grpcService.StopService()
+	<- grpcStatus
 }

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -123,7 +123,7 @@ func TestJsonApi(t *testing.T) {
 
 	// stop the services
 	jsonService.StopService()
-	<- jsonStatus
+	<-jsonStatus
 	grpcService.StopService()
-	<- grpcStatus
+	<-grpcStatus
 }

--- a/api/grpc_server.go
+++ b/api/grpc_server.go
@@ -29,6 +29,8 @@ func (s SpaceMeshGrpcService) Echo(ctx context.Context, in *pb.SimpleMessage) (*
 func (s SpaceMeshGrpcService) StopService() {
 	log.Info("Stopping grpc service...")
 	s.Server.Stop()
+	log.Info("grpc service stopped...")
+
 }
 
 func NewGrpcService() *SpaceMeshGrpcService {
@@ -37,12 +39,12 @@ func NewGrpcService() *SpaceMeshGrpcService {
 	return &SpaceMeshGrpcService{Server: server, Port: port}
 }
 
-func (s SpaceMeshGrpcService) StartService(started chan bool) {
-	go s.startServiceInternal(started)
+func (s SpaceMeshGrpcService) StartService(status chan bool) {
+	go s.startServiceInternal(status)
 }
 
 // This is a blocking method designed to be called using a go routine
-func (s SpaceMeshGrpcService) startServiceInternal(started chan bool) {
+func (s SpaceMeshGrpcService) startServiceInternal(status chan bool) {
 	port := config.ConfigValues.GrpcServerPort
 	addr := ":" + strconv.Itoa(int(port))
 
@@ -59,12 +61,17 @@ func (s SpaceMeshGrpcService) startServiceInternal(started chan bool) {
 
 	log.Info("grpc API listening on port %d", port)
 
-	if started != nil {
-		started <- true
+	if status != nil {
+		status <- true
 	}
 
 	// start serving - this blocks until err or server is stopped
 	if err := s.Server.Serve(lis); err != nil {
 		log.Error("grpc stopped serving", err)
 	}
+
+	if status != nil {
+		status <- true
+	}
+
 }

--- a/api/http_server.go
+++ b/api/http_server.go
@@ -28,10 +28,12 @@ func NewJsonHttpServer() *JsonHttpServer {
 	return &JsonHttpServer{Port: config.ConfigValues.JsonServerPort, stop: make(chan bool)}
 }
 
+// Send a stop signal to the listener
 func (s JsonHttpServer) StopService() {
 	s.stop <- true
 }
 
+// Listens on gracefully stopping the server in the same routine
 func (s JsonHttpServer) listenStop() {
 	<-s.stop
 	log.Info("Shutting down json API server...")

--- a/api/http_server.go
+++ b/api/http_server.go
@@ -21,25 +21,31 @@ type JsonHttpServer struct {
 	Port   uint
 	server *http.Server
 	ctx    context.Context
+	stop chan bool
 }
 
 func NewJsonHttpServer() *JsonHttpServer {
-	return &JsonHttpServer{Port: config.ConfigValues.JsonServerPort}
+	return &JsonHttpServer{ Port: config.ConfigValues.JsonServerPort, stop: make(chan bool)}
 }
 
-func (s JsonHttpServer) Stop() {
-	log.Info("Stopping json-http service...")
-
-	// todo: fixme - this is panicking
-	//s.server.Shutdown(s.ctx)
+func (s JsonHttpServer) StopService() {
+	s.stop <- true
 }
 
-// Start the grpc server
-func (s JsonHttpServer) StartService(callback chan bool) {
-	go s.startInternal(callback)
+func (s JsonHttpServer) listenStop() {
+	<-s.stop
+	log.Info("Shutting down json API server...")
+	if err := s.server.Shutdown(s.ctx); err != nil {
+		log.Error("Error during shutdown json API server : %v", err)
+	}
 }
 
-func (s JsonHttpServer) startInternal(callback chan bool) {
+// Start the json http API server and listen for status (started, stopped)
+func (s JsonHttpServer) StartService(status chan bool) {
+	go s.startInternal(status)
+}
+
+func (s JsonHttpServer) startInternal(status chan bool) {
 	ctx := context.Background()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -60,8 +66,10 @@ func (s JsonHttpServer) startInternal(callback chan bool) {
 
 	log.Info("json API listening on port %d", s.Port)
 
-	if callback != nil {
-		callback <- true
+	go func() { s.listenStop() }()
+
+	if status != nil {
+		status <- true
 	}
 
 	s.server = &http.Server{Addr: addr, Handler: mux}
@@ -69,5 +77,9 @@ func (s JsonHttpServer) startInternal(callback chan bool) {
 
 	if err != nil {
 		log.Info("listen and serve stopped with status. %v", err)
+	}
+
+	if status != nil {
+		status <- true
 	}
 }

--- a/api/http_server.go
+++ b/api/http_server.go
@@ -21,11 +21,11 @@ type JsonHttpServer struct {
 	Port   uint
 	server *http.Server
 	ctx    context.Context
-	stop chan bool
+	stop   chan bool
 }
 
 func NewJsonHttpServer() *JsonHttpServer {
-	return &JsonHttpServer{ Port: config.ConfigValues.JsonServerPort, stop: make(chan bool)}
+	return &JsonHttpServer{Port: config.ConfigValues.JsonServerPort, stop: make(chan bool)}
 }
 
 func (s JsonHttpServer) StopService() {

--- a/app/main.go
+++ b/app/main.go
@@ -160,7 +160,7 @@ func (app *SpacemeshApp) cleanup(ctx *cli.Context) error {
 
 	log.Info("App cleanup starting...")
 	if app.jsonApiService != nil {
-		app.jsonApiService.Stop()
+		app.jsonApiService.StopService()
 	}
 
 	if app.grpcApiService != nil {


### PR DESCRIPTION
 Made the callback channel to return twice, once started and once stopped.
did some refactoring to make naming consistent.
Changed api test according to new design.