### PR TITLE
Fix logging bugs from last pr and more.

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -57,7 +57,7 @@ func CreateLogger(module string, dataFolderPath string, logFileName string) *log
 
 	backendConsoleLevel := logging.AddModuleLevel(backendFormatter)
 	backendFileLevel := logging.AddModuleLevel(fileBackendFormatter)
-	log.SetBackend(logging.SetBackend(backendConsoleLevel, backendFileLevel))
+	log.SetBackend(logging.MultiLogger(backendConsoleLevel, backendFileLevel))
 
 	return log
 }
@@ -90,7 +90,7 @@ func InitSpacemeshLoggingSystem(dataFolderPath string, logFileName string) {
 
 	backendConsoleLevel := logging.AddModuleLevel(backendFormatter)
 	backendFileLevel := logging.AddModuleLevel(fileBackendFormatter)
-	log.SetBackend(logging.SetBackend(backendConsoleLevel, backendFileLevel))
+	log.SetBackend(logging.MultiLogger(backendConsoleLevel, backendFileLevel))
 
 	smLogger = &SpacemeshLogger{Logger: log}
 }

--- a/p2p/localnodeimpl.go
+++ b/p2p/localnodeimpl.go
@@ -159,20 +159,20 @@ func (n *localNodeImp) Sign(data proto.Message) ([]byte, error) {
 
 // Info is used for info logging.
 func (n *localNodeImp) Info(format string, args ...interface{}) {
-	n.logger.Info(format, args)
+	n.logger.Info(format, args...)
 }
 
 // Debug is used to log debug data.
 func (n *localNodeImp) Debug(format string, args ...interface{}) {
-	n.logger.Debug(format, args)
+	n.logger.Debug(format, args...)
 }
 
 // Error is used to log runtime errors.
 func (n *localNodeImp) Error(format string, args ...interface{}) {
-	n.logger.Error(format, args)
+	n.logger.Error(format, args...)
 }
 
 // Warning is used to log runtime warnings.
 func (n *localNodeImp) Warning(format string, args ...interface{}) {
-	n.logger.Warning(format, args)
+	n.logger.Warning(format, args...)
 }

--- a/p2p/swarm.go
+++ b/p2p/swarm.go
@@ -5,6 +5,7 @@ package p2p
 import (
 	"github.com/spacemeshos/go-spacemesh/p2p/dht/table"
 	"github.com/spacemeshos/go-spacemesh/p2p/node"
+	"strconv"
 )
 
 // Swarm is p2p virtual network of spacemesh nodes as viewed by a local node
@@ -95,3 +96,15 @@ const (
 	SessionEstablished
 	Disconnected
 )
+
+// Created by stringer -type=NodeState
+const _NodeState_name = "UnknownRegisteredConnectingConnectedHandshakeStartedSessionEstablishedDisconnected"
+
+var _NodeState_index = [...]uint8{0, 7, 17, 27, 36, 52, 70, 82}
+
+func (i NodeState) String() string {
+	if i < 0 || i >= NodeState(len(_NodeState_index)-1) {
+		return "NodeState(" + strconv.FormatInt(int64(i), 10) + ")"
+	}
+	return _NodeState_name[_NodeState_index[i]:_NodeState_index[i+1]]
+}

--- a/p2p/swarm.go
+++ b/p2p/swarm.go
@@ -98,13 +98,13 @@ const (
 )
 
 // Created by stringer -type=NodeState
-const _NodeState_name = "UnknownRegisteredConnectingConnectedHandshakeStartedSessionEstablishedDisconnected"
+const nodeStateName = "UnknownRegisteredConnectingConnectedHandshakeStartedSessionEstablishedDisconnected"
 
-var _NodeState_index = [...]uint8{0, 7, 17, 27, 36, 52, 70, 82}
+var nodeStateIndex = [...]uint8{0, 7, 17, 27, 36, 52, 70, 82}
 
 func (i NodeState) String() string {
-	if i < 0 || i >= NodeState(len(_NodeState_index)-1) {
+	if i < 0 || i >= NodeState(len(nodeStateIndex)-1) {
 		return "NodeState(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
-	return _NodeState_name[_NodeState_index[i]:_NodeState_index[i+1]]
+	return nodeStateName[nodeStateIndex[i]:nodeStateIndex[i+1]]
 }

--- a/p2p/swarmimpl.go
+++ b/p2p/swarmimpl.go
@@ -105,7 +105,7 @@ func NewSwarm(tcpAddress string, l LocalNode) (Swarm, error) {
 	// findNode dht protocol
 	s.findNodeProtocol = NewFindNodeProtocol(s)
 
-	s.localNode.Info("Created swarm for local node %s", tcpAddress, l.Pretty())
+	s.localNode.Info("Created swarm for local node %s, %s", tcpAddress, l.Pretty())
 
 	s.handshakeProtocol = NewHandshakeProtocol(s)
 	s.handshakeProtocol.RegisterNewSessionCallback(s.newSessions)
@@ -127,7 +127,7 @@ func (s *swarmImpl) RegisterNodeEventsCallback(callback NodeEventCallback) {
 // Sends a connection event to all registered clients
 func (s *swarmImpl) sendNodeEvent(peerID string, state NodeState) {
 
-	s.localNode.Info(">> Node event for <%s>. State: %s", peerID[:6], state)
+	s.localNode.Info(">> Node event for <%s>. State: %+v", peerID[:6], state)
 
 	evt := NodeEvent{peerID, state}
 	for _, c := range s.nec {


### PR DESCRIPTION
- This time we're really assigning the loggers backends as we should with MultiLogger instead of assigning the whole app log level.
- fixed formatting bug in the localnode log methods.
- Added a String method (by golang's stringer) to NodeState to make more meaningful logging.