### PR TITLE
Dht bit manipulation improvment

### DIFF
--- a/p2p/dht/dhtid.go
+++ b/p2p/dht/dhtid.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"github.com/btcsuite/btcutil/base58"
 	"math/big"
-	"sort"
 	"math/bits"
+	"sort"
 )
 
 // ID is a dht-compatible ID using the XOR keyspace.

--- a/p2p/dht/dhtid.go
+++ b/p2p/dht/dhtid.go
@@ -8,6 +8,7 @@ import (
 	"github.com/btcsuite/btcutil/base58"
 	"math/big"
 	"sort"
+	"math/bits"
 )
 
 // ID is a dht-compatible ID using the XOR keyspace.
@@ -85,11 +86,11 @@ func (id ID) CommonPrefixLen(o ID) int {
 
 // ZeroPrefixLen returns the zero prefix length of the binary number represnted by ID in bits.
 func (id ID) ZeroPrefixLen() int {
-	for i := 0; i < len(id); i++ {
-		for j := 0; j < 8; j++ {
-			if (id[i]>>uint8(7-j))&0x1 != 0 {
-				return i*8 + j
-			}
+	zpl := 0
+	for i, b := range id {
+		zpl = bits.LeadingZeros8(b)
+		if zpl != 8 {
+			return i*8 + zpl
 		}
 	}
 	return len(id) * 8

--- a/p2p/dht/dhtid_test.go
+++ b/p2p/dht/dhtid_test.go
@@ -50,7 +50,6 @@ func TestDhtIds(t *testing.T) {
 	id7, _ := NewIDFromHexString("000000000000000000000000000000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF")
 	id8, _ := NewIDFromHexString("FF0000000000000000000000000000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF")
 
-
 	assert.Equal(t, len(id1), 32, "Expectd 256 bits / 32 bytes id")
 	assert.Equal(t, hex.EncodeToString(id1), hexData, "Unexpected id data")
 
@@ -71,7 +70,6 @@ func TestDhtIds(t *testing.T) {
 	pl = id8.ZeroPrefixLen()
 	//FF is a full byte (11111111) so there should be no zeros prefix
 	assert.True(t, pl == 0, "excpected no prefix zeros when id string starts with FF")
-
 
 	l := id1.CommonPrefixLen(id1)
 	assert.Equal(t, l, 256, "expected 256 cpl for id with itself")

--- a/p2p/dht/dhtid_test.go
+++ b/p2p/dht/dhtid_test.go
@@ -46,6 +46,10 @@ func TestDhtIds(t *testing.T) {
 	id3, _ := NewIDFromHexString("a726a40a408ff9fbdf627373cab566742114e2fd909eb4af4b6cbec67d6c6040")
 	id4, _ := NewIDFromHexString("b626a40a408ff9fbdf627373cab566742114e2fd909eb4af4b6cbec67d6c6040")
 	id5, _ := NewIDFromHexString("1000000000000000000000000000000000000000000000000000000000000000")
+	id6, _ := NewIDFromHexString("00000000000000000000000000000000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF")
+	id7, _ := NewIDFromHexString("000000000000000000000000000000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF")
+	id8, _ := NewIDFromHexString("FF0000000000000000000000000000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF")
+
 
 	assert.Equal(t, len(id1), 32, "Expectd 256 bits / 32 bytes id")
 	assert.Equal(t, hex.EncodeToString(id1), hexData, "Unexpected id data")
@@ -55,6 +59,19 @@ func TestDhtIds(t *testing.T) {
 
 	d := id1.Distance(id1)
 	assert.True(t, d.Cmp(big.NewInt(0)) == 0, "expected 0 distance from same id")
+
+	pl := id6.ZeroPrefixLen()
+	//16 nullbytes means 16*8 zeros ( rest of string is FF means no more zeros )
+	assert.True(t, pl == 128, "excpected 128 zeros prefix in half null string")
+
+	pl = id7.ZeroPrefixLen()
+	//14 nullbytes means 15*8 zeros ( rest of string is FF means no more zeros )
+	assert.True(t, pl == 120, "excpected 120 zeros prefix")
+
+	pl = id8.ZeroPrefixLen()
+	//FF is a full byte (11111111) so there should be no zeros prefix
+	assert.True(t, pl == 0, "excpected no prefix zeros when id string starts with FF")
+
 
 	l := id1.CommonPrefixLen(id1)
 	assert.Equal(t, l, 256, "expected 256 cpl for id with itself")


### PR DESCRIPTION
We now use go's math/bits lib to calculate the leading zeros of the id's in the dht.
The new function is faster and more readable.
added some tests to make sure everything works well.