### PR TITLE
Fix travis not passing test rbecause of race bug with ntp timeout

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -1,11 +1,11 @@
 package app
 
 import (
-	"github.com/spacemeshos/go-spacemesh/assert"
-	"github.com/spacemeshos/go-spacemesh/filesystem"
 	"os"
 	"testing"
-	"time"
+
+	"github.com/spacemeshos/go-spacemesh/assert"
+	"github.com/spacemeshos/go-spacemesh/filesystem"
 )
 
 func TestApp(t *testing.T) {
@@ -17,10 +17,11 @@ func TestApp(t *testing.T) {
 
 	go Main("", "master", "")
 
+	<-EntryPointCreated
+
 	assert.NotNil(t, App)
 
-	// let node warmup
-	time.Sleep(3 * time.Second)
+	<-App.NodeInitCallback
 
 	assert.NotNil(t, App.Node)
 	assert.NotNil(t, App)

--- a/app/main.go
+++ b/app/main.go
@@ -23,7 +23,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/p2p/timesync"
 )
 
-// EntryPointCreate channel is used to announce that the main App instance was created
+// EntryPointCreated channel is used to announce that the main App instance was created
 // mainly used for testing now.
 var EntryPointCreated = make(chan bool)
 

--- a/p2p/nodeconfig/config.go
+++ b/p2p/nodeconfig/config.go
@@ -22,7 +22,7 @@ var ConfigValues = Config{
 var TimeConfigValues = TimeConfig{
 	MaxAllowedDrift:       duration{"10s"},
 	NtpQueries:            5,
-	DefaultTimeoutLatency: duration{"30s"},
+	DefaultTimeoutLatency: duration{"10s"},
 	RefreshNtpInterval:    duration{"30m"},
 }
 

--- a/p2p/timesync/ntp.go
+++ b/p2p/timesync/ntp.go
@@ -126,14 +126,16 @@ func ntpTimeDrift() (time.Duration, error) {
 	errorChan := make(chan error)
 	req := &NtpPacket{Settings: 0x1B}
 
-	// Make 3 concurrent calls to different ntp servers
+	// Make NtpQueries concurrent calls to different ntp servers
+	// if more servers fail than succeed in DefaultTimeoutLatency timeout the node.
 	// TODO: possibly add retries when timeout
 	queriedServers := make(map[int]bool)
-	serverSeed := len(DefaultServers) - 1
+	rand.Seed(time.Now().Unix()) // we don't need too special seed for that
+	sl := len(DefaultServers) - 1
 	for i := 0; i < nodeconfig.TimeConfigValues.NtpQueries; i++ {
-		rndsrv := rand.Intn(serverSeed)
+		rndsrv := rand.Intn(sl)
 		for queriedServers[rndsrv] {
-			rndsrv = rand.Intn(serverSeed)
+			rndsrv = rand.Intn(sl)
 		}
 		queriedServers[rndsrv] = true
 		go func() {
@@ -149,14 +151,17 @@ func ntpTimeDrift() (time.Duration, error) {
 	}
 
 	all := sortableDurations{}
+	errors := []error{}
 	for i := 0; i < nodeconfig.TimeConfigValues.NtpQueries; i++ {
 		select {
 		case err := <-errorChan:
-			close(errorChan)
-			return 0, err
+			errors = append(errors, err)
 		case result := <-resultsChan:
 			all = append(all, result)
 		}
+	}
+	if len(errors) > len(all) {
+		return zeroDuration, fmt.Errorf("NTP server errors ", errors)
 	}
 	// remove edge cases from our results
 	all.RemoveExtremes()

--- a/p2p/timesync/ntp.go
+++ b/p2p/timesync/ntp.go
@@ -161,7 +161,7 @@ func ntpTimeDrift() (time.Duration, error) {
 		}
 	}
 	if len(errors) > len(all) {
-		return zeroDuration, fmt.Errorf("NTP server errors ", errors)
+		return zeroDuration, fmt.Errorf("NTP server errors %v", errors)
 	}
 	// remove edge cases from our results
 	all.RemoveExtremes()


### PR DESCRIPTION
Instead of letting the node warmup 3 seconds. 
we notify and block until we know everything is loaded or errors. 
This 3 seconds used to work but now we have ntp calls to internet that might take some time.
Also fixed ntp to handle errors and return results if there are more. 

this will make it easier for travis to pass and may be useful in the future 👍 