### PR TITLE
Fix config entrypoint bug

### DIFF
--- a/app/config/toml_test.go
+++ b/app/config/toml_test.go
@@ -40,6 +40,7 @@ func (d *duration) Duration(t *testing.T) (duration time.Duration) {
 
 type TestConfig struct {
 	TestParam     bool
+	TestLogFile   string
 	IntParam      int
 	StringParam   string
 	DurationParam duration
@@ -59,6 +60,13 @@ var (
 		Name:        "test.run",
 		Usage:       "the test run param",
 		Destination: &TestConfigValues.TestParam,
+	}
+
+	TestLogFileFlag = cli.StringFlag{
+		Name:        "test.testlogfile",
+		Usage:       "The file to log to",
+		Value:       TestConfigValues.TestLogFile,
+		Destination: &TestConfigValues.TestLogFile,
 	}
 
 	IntParamFlag = altsrc.NewIntFlag(cli.IntFlag{
@@ -146,6 +154,7 @@ func TestConfigLoading(t *testing.T) {
 	var appFlags = []cli.Flag{
 		TestFlag,
 		TestRunFlag,
+		TestLogFileFlag,
 		IntParamFlag,
 		StringParamFlag,
 		DurationParamFlag,

--- a/app/main.go
+++ b/app/main.go
@@ -25,7 +25,7 @@ import (
 
 // EntryPointCreated channel is used to announce that the main App instance was created
 // mainly used for testing now.
-var EntryPointCreated = make(chan bool)
+var EntryPointCreated = make(chan bool, 1)
 
 // SpacemeshApp is the cli app singleton
 type SpacemeshApp struct {


### PR DESCRIPTION
This was holding our client from starting, fixed now. 
also added a fix that made tests failed in config.