### PR TITLE
filesystem, ports tests solidness

### DIFF
--- a/accounts/account_test.go
+++ b/accounts/account_test.go
@@ -14,7 +14,7 @@ func TestAccountLoading(t *testing.T) {
 
 func TestAccountOps(t *testing.T) {
 
-	filesystem.DeleteSpacemeshDataFolders(t)
+	filesystem.SetupTestSpacemeshDataFolders(t, "account_ops")
 
 	const passphrase = "a-weak-passphrase-123"
 	accountsDataFolder, err := filesystem.GetAccountsDataDirectoryPath()
@@ -74,7 +74,7 @@ func TestAccountOps(t *testing.T) {
 
 func TestPersistence(t *testing.T) {
 
-	filesystem.DeleteSpacemeshDataFolders(t)
+	filesystem.SetupTestSpacemeshDataFolders(t, "account_persistence")
 
 	const passphrase = "a-weak-passphrase-1234"
 	const wrongPassphrase = "a-weak-passphrase-1245"

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -6,7 +6,7 @@ import (
 	config "github.com/spacemeshos/go-spacemesh/api/config"
 	pb "github.com/spacemeshos/go-spacemesh/api/pb"
 	"github.com/spacemeshos/go-spacemesh/assert"
-	"github.com/spacemeshos/go-spacemesh/crypto"
+	"github.com/spacemeshos/go-spacemesh/p2p/net"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"io/ioutil"
@@ -19,8 +19,12 @@ import (
 
 func TestServersConfig(t *testing.T) {
 
-	config.ConfigValues.GrpcServerPort = int(crypto.GetRandomUserPort())
-	config.ConfigValues.JSONServerPort = int(crypto.GetRandomUserPort())
+	port1, err := net.GetUnboundedPort()
+	port2, err := net.GetUnboundedPort()
+	assert.NoErr(t, err, "Should be able to establish a connection on a port")
+
+	config.ConfigValues.JSONServerPort = port1
+	config.ConfigValues.GrpcServerPort = port2
 
 	grpcService := NewGrpcService()
 	jsonService := NewJSONHTTPServer()
@@ -31,8 +35,12 @@ func TestServersConfig(t *testing.T) {
 
 func TestGrpcApi(t *testing.T) {
 
-	config.ConfigValues.GrpcServerPort = int(crypto.GetRandomUserPort())
-	config.ConfigValues.JSONServerPort = int(crypto.GetRandomUserPort())
+	port1, err := net.GetUnboundedPort()
+	port2, err := net.GetUnboundedPort()
+	assert.NoErr(t, err, "Should be able to establish a connection on a port")
+
+	config.ConfigValues.JSONServerPort = port1
+	config.ConfigValues.GrpcServerPort = port2
 
 	const message = "Hello World"
 
@@ -66,8 +74,12 @@ func TestGrpcApi(t *testing.T) {
 
 func TestJsonApi(t *testing.T) {
 
-	config.ConfigValues.GrpcServerPort = int(crypto.GetRandomUserPort())
-	config.ConfigValues.JSONServerPort = int(crypto.GetRandomUserPort())
+	port1, err := net.GetUnboundedPort()
+	port2, err := net.GetUnboundedPort()
+	assert.NoErr(t, err, "Should be able to establish a connection on a port")
+
+	config.ConfigValues.JSONServerPort = port1
+	config.ConfigValues.GrpcServerPort = port2
 
 	grpcService := NewGrpcService()
 	jsonService := NewJSONHTTPServer()

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestApp(t *testing.T) {
 
-	filesystem.DeleteSpacemeshDataFolders(t)
+	filesystem.SetupTestSpacemeshDataFolders(t, "app_test")
 
 	// remove all injected test flags for now
 	os.Args = []string{"/go-spacemesh", "-json-server"}

--- a/filesystem/dirs_test_helpers.go
+++ b/filesystem/dirs_test_helpers.go
@@ -1,12 +1,40 @@
 package filesystem
 
 import (
+	"encoding/binary"
 	"fmt"
+	"github.com/spacemeshos/go-spacemesh/app/config"
+	"github.com/spacemeshos/go-spacemesh/crypto"
 	"io/ioutil"
 	"os"
 	"os/user"
 	"testing"
 )
+
+// SetupTestSpacemeshDataFolders sets up a data folder to this specific test
+func SetupTestSpacemeshDataFolders(t *testing.T, n string) {
+	// just to make sure its isolated
+	r, err := crypto.GetRandomBytes(4)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	setupFolder := fmt.Sprintf("test%v_%v", n, binary.BigEndian.Uint32(r))
+	config.ConfigValues.DataFilePath = setupFolder
+
+	aPath, err := GetSpacemeshDataDirectoryPath()
+	if err != nil {
+		t.Fatalf("Failed to get spacemesh data dir: %s", err)
+	}
+
+	// remove
+	err = os.RemoveAll(aPath)
+	if err != nil {
+		t.Fatalf("Failed to delete spacemesh data dir: %s", err)
+	}
+
+}
 
 // DeleteSpacemeshDataFolders deletes all sub directories and files in the Spacemesh root data folder.
 func DeleteSpacemeshDataFolders(t *testing.T) {
@@ -21,6 +49,8 @@ func DeleteSpacemeshDataFolders(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to delete spacemesh data dir: %s", err)
 	}
+
+	config.ConfigValues.DataFilePath = "~/.spacemesh"
 }
 
 // TestEmptyFolder checks that the given folder has no contents

--- a/p2p/dht/dhtid_test.go
+++ b/p2p/dht/dhtid_test.go
@@ -2,9 +2,10 @@ package dht
 
 import (
 	"encoding/hex"
-	"github.com/spacemeshos/go-spacemesh/assert"
 	"math/big"
 	"testing"
+
+	"github.com/spacemeshos/go-spacemesh/assert"
 )
 
 func TestIds(t *testing.T) {

--- a/p2p/dht/table/tests/bucket_test.go
+++ b/p2p/dht/table/tests/bucket_test.go
@@ -1,24 +1,29 @@
 package tests
 
 import (
+	"math/rand"
+	"testing"
+
 	"github.com/spacemeshos/go-spacemesh/assert"
 	"github.com/spacemeshos/go-spacemesh/p2p"
 	"github.com/spacemeshos/go-spacemesh/p2p/dht/table"
 	"github.com/spacemeshos/go-spacemesh/p2p/node"
-	"math/rand"
-	"testing"
 )
 
 // Tests basic bucket features
 func TestBucket(t *testing.T) {
 	const n = 100
 
-	local := p2p.GenerateRandomNodeData()
+	local, err := p2p.GenerateRandomNodeData()
+	assert.NoErr(t, err, "Should be able to create node")
+
 	localID := local.DhtID()
 
 	// add 100 nodes to the table
 	b := table.NewBucket()
-	nodes := p2p.GenerateRandomNodesData(n)
+	nodes, err := p2p.GenerateRandomNodesData(n)
+	assert.NoErr(t, err, "Should be able to create multiple nodes")
+
 	for i := 0; i < n; i++ {
 		b.PushFront(nodes[i])
 	}

--- a/p2p/dht/table/tests/table_test.go
+++ b/p2p/dht/table/tests/table_test.go
@@ -1,20 +1,27 @@
 package tests
 
 import (
-	"github.com/spacemeshos/go-spacemesh/log"
-	"github.com/spacemeshos/go-spacemesh/p2p"
-	"github.com/spacemeshos/go-spacemesh/p2p/dht/table"
 	"math/rand"
 	"testing"
 	"time"
+
+	"github.com/spacemeshos/go-spacemesh/assert"
+	"github.com/spacemeshos/go-spacemesh/log"
+	"github.com/spacemeshos/go-spacemesh/p2p"
+	"github.com/spacemeshos/go-spacemesh/p2p/dht/table"
 )
 
 func TestTableCallbacks(t *testing.T) {
 	const n = 100
-	local := p2p.GenerateRandomNodeData()
+	local, err := p2p.GenerateRandomNodeData()
+
+	assert.NoErr(t, err, "Should be able to create a node")
+
 	localID := local.DhtID()
 
-	nodes := p2p.GenerateRandomNodesData(n)
+	nodes, err := p2p.GenerateRandomNodesData(n)
+
+	assert.NoErr(t, err, "Should be able to create multiple nodes")
 
 	rt := table.NewRoutingTable(10, localID)
 
@@ -79,12 +86,15 @@ Loop1:
 func TestTableUpdate(t *testing.T) {
 
 	const n = 100
-	local := p2p.GenerateRandomNodeData()
+	local, err := p2p.GenerateRandomNodeData()
+	assert.NoErr(t, err, "Should be able to create a node")
+
 	localID := local.DhtID()
 
 	rt := table.NewRoutingTable(20, localID)
 
-	nodes := p2p.GenerateRandomNodesData(n)
+	nodes, err := p2p.GenerateRandomNodesData(n)
+	assert.NoErr(t, err, "Should be able to create multiple nodes")
 
 	// Testing Update
 	for i := 0; i < 10000; i++ {
@@ -94,7 +104,8 @@ func TestTableUpdate(t *testing.T) {
 	for i := 0; i < n; i++ {
 
 		// create a new random node
-		n := p2p.GenerateRandomNodeData()
+		n, err := p2p.GenerateRandomNodeData()
+		assert.NoErr(t, err, "Should be able to create a node")
 
 		// create callback to receive result
 		callback := make(table.PeersOpChannel, 2)
@@ -117,12 +128,15 @@ func TestTableFind(t *testing.T) {
 
 	const n = 100
 
-	local := p2p.GenerateRandomNodeData()
+	local, err := p2p.GenerateRandomNodeData()
+	assert.NoErr(t, err, "Should be able to create a node")
+
 	localID := local.DhtID()
 
 	rt := table.NewRoutingTable(20, localID)
 
-	nodes := p2p.GenerateRandomNodesData(n)
+	nodes, err := p2p.GenerateRandomNodesData(n)
+	assert.NoErr(t, err, "Should be able to create a node")
 
 	for i := 0; i < 5; i++ {
 		rt.Update(nodes[i])
@@ -164,10 +178,13 @@ func TestTableFindCount(t *testing.T) {
 	const n = 100
 	const i = 15
 
-	local := p2p.GenerateRandomNodeData()
+	local, err := p2p.GenerateRandomNodeData()
+	assert.NoErr(t, err, "Should be able to create a node")
+
 	localID := local.DhtID()
 	rt := table.NewRoutingTable(20, localID)
-	nodes := p2p.GenerateRandomNodesData(n)
+	nodes, err := p2p.GenerateRandomNodesData(n)
+	assert.NoErr(t, err, "Should be able to create a node")
 
 	for i := 0; i < n; i++ {
 		rt.Update(nodes[i])
@@ -195,10 +212,13 @@ func TestTableMultiThreaded(t *testing.T) {
 	const n = 5000
 	const i = 15
 
-	local := p2p.GenerateRandomNodeData()
+	local, err := p2p.GenerateRandomNodeData()
+	assert.NoErr(t, err, "Should be able to create a node")
+
 	localID := local.DhtID()
 	rt := table.NewRoutingTable(20, localID)
-	nodes := p2p.GenerateRandomNodesData(n)
+	nodes, err := p2p.GenerateRandomNodesData(n)
+	assert.NoErr(t, err, "Should be able to create multiple nodes")
 
 	go func() {
 		for i := 0; i < 1000; i++ {
@@ -224,10 +244,17 @@ func TestTableMultiThreaded(t *testing.T) {
 
 func BenchmarkUpdates(b *testing.B) {
 	b.StopTimer()
-	local := p2p.GenerateRandomNodeData()
+	local, err := p2p.GenerateRandomNodeData()
+	if err != nil {
+		b.Errorf("Should be able to create node error:%v", err)
+	}
+
 	localID := local.DhtID()
 	rt := table.NewRoutingTable(20, localID)
-	nodes := p2p.GenerateRandomNodesData(b.N)
+	nodes, err := p2p.GenerateRandomNodesData(b.N)
+	if err != nil {
+		b.Errorf("Should be able to create multiple error:%v", err)
+	}
 
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
@@ -238,10 +265,17 @@ func BenchmarkUpdates(b *testing.B) {
 func BenchmarkFinds(b *testing.B) {
 	b.StopTimer()
 
-	local := p2p.GenerateRandomNodeData()
+	local, err := p2p.GenerateRandomNodeData()
+	if err != nil {
+		b.Errorf("Should be able to create node error:%v", err)
+	}
+
 	localID := local.DhtID()
 	rt := table.NewRoutingTable(20, localID)
-	nodes := p2p.GenerateRandomNodesData(b.N)
+	nodes, err := p2p.GenerateRandomNodesData(b.N)
+	if err != nil {
+		b.Errorf("Should be able to create node error:%v", err)
+	}
 
 	for i := 0; i < b.N; i++ {
 		rt.Update(nodes[i])

--- a/p2p/findnode_test.go
+++ b/p2p/findnode_test.go
@@ -2,11 +2,12 @@ package p2p
 
 import (
 	"bytes"
+	"testing"
+	"time"
+
 	"github.com/spacemeshos/go-spacemesh/assert"
 	"github.com/spacemeshos/go-spacemesh/crypto"
 	"github.com/spacemeshos/go-spacemesh/log"
-	"testing"
-	"time"
 )
 
 func TestFindNodeProtocolCore(t *testing.T) {

--- a/p2p/handshake_test.go
+++ b/p2p/handshake_test.go
@@ -5,20 +5,23 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"testing"
+
 	"github.com/gogo/protobuf/proto"
 	"github.com/spacemeshos/go-spacemesh/assert"
-	"github.com/spacemeshos/go-spacemesh/crypto"
 	"github.com/spacemeshos/go-spacemesh/log"
+	"github.com/spacemeshos/go-spacemesh/p2p/net"
 	"github.com/spacemeshos/go-spacemesh/p2p/nodeconfig"
 	"github.com/spacemeshos/go-spacemesh/p2p/pb"
-	"testing"
 )
 
 // Basic handshake protocol data test
 func TestHandshakeCoreData(t *testing.T) {
 
 	// node 1
-	port := crypto.GetRandomUserPort()
+	port, err := net.GetUnboundedPort()
+	assert.NoErr(t, err, "Should be able to establish a connection on a port")
+
 	address := fmt.Sprintf("0.0.0.0:%d", port)
 
 	node1Local, err := NewNodeIdentity(address, nodeconfig.ConfigValues, false)
@@ -31,7 +34,9 @@ func TestHandshakeCoreData(t *testing.T) {
 	node1Remote, _ := NewRemoteNode(node1Local.String(), address)
 
 	// node 2
-	port1 := crypto.GetRandomUserPort()
+	port1, err := net.GetUnboundedPort()
+	assert.NoErr(t, err, "Should be able to establish a connection on a port")
+
 	address1 := fmt.Sprintf("0.0.0.0:%d", port1)
 
 	node2Local, err := NewNodeIdentity(address1, nodeconfig.ConfigValues, false)
@@ -94,14 +99,19 @@ func TestHandshakeCoreData(t *testing.T) {
 func TestHandshakeProtocol(t *testing.T) {
 
 	// node 1
-	port := crypto.GetRandomUserPort()
+	port, err := net.GetUnboundedPort()
+	assert.NoErr(t, err, "Should be able to establish a connection on a port")
+
 	address := fmt.Sprintf("0.0.0.0:%d", port)
 
 	node1Local, _ := NewNodeIdentity(address, nodeconfig.ConfigValues, false)
 	node1Remote, _ := NewRemoteNode(node1Local.String(), address)
 
 	// node 2
-	port1 := crypto.GetRandomUserPort()
+
+	port1, err := net.GetUnboundedPort()
+	assert.NoErr(t, err, "Should be able to establish a connection on a port")
+
 	address1 := fmt.Sprintf("0.0.0.0:%d", port1)
 
 	node2Local, _ := NewNodeIdentity(address1, nodeconfig.ConfigValues, false)
@@ -194,14 +204,19 @@ func TestBadHandshakes(t *testing.T) {
 
 	testProtocol := func(cfg nodeconfig.Config, cfg2 nodeconfig.Config) error {
 		// node 1
-		port := crypto.GetRandomUserPort()
+
+		port, err := net.GetUnboundedPort()
+		assert.NoErr(t, err, "Should be able to establish a connection on a port")
+
 		address := fmt.Sprintf("0.0.0.0:%d", port)
 
 		node1Local, _ := NewNodeIdentity(address, cfg, false)
 		node1Remote, _ := NewRemoteNode(node1Local.String(), address)
 
 		// node 2
-		port1 := crypto.GetRandomUserPort()
+		port1, err := net.GetUnboundedPort()
+		assert.NoErr(t, err, "Should be able to establish a connection on a port")
+
 		address1 := fmt.Sprintf("0.0.0.0:%d", port1)
 
 		node2Local, _ := NewNodeIdentity(address1, cfg2, false)

--- a/p2p/localnodestore_test.go
+++ b/p2p/localnodestore_test.go
@@ -2,19 +2,18 @@ package p2p
 
 import (
 	"fmt"
-	"github.com/spacemeshos/go-spacemesh/app/config"
-	"github.com/spacemeshos/go-spacemesh/assert"
-	"github.com/spacemeshos/go-spacemesh/crypto"
-	"github.com/spacemeshos/go-spacemesh/filesystem"
-	"github.com/spacemeshos/go-spacemesh/p2p/nodeconfig"
 	"testing"
 	"time"
+
+	"github.com/spacemeshos/go-spacemesh/assert"
+	"github.com/spacemeshos/go-spacemesh/filesystem"
+	"github.com/spacemeshos/go-spacemesh/p2p/net"
+	"github.com/spacemeshos/go-spacemesh/p2p/nodeconfig"
 )
 
 func TestNodeLocalStore(t *testing.T) {
-	config.ConfigValues.DataFilePath = "~/.spacemesh-localnode-test-data"
 	// start clean
-	filesystem.DeleteSpacemeshDataFolders(t)
+	filesystem.SetupTestSpacemeshDataFolders(t, "localnode_store")
 
 	p, err := ensureNodesDataDirectory()
 	assert.NoErr(t, err, "failed to create or verify nodes data dir")
@@ -22,7 +21,9 @@ func TestNodeLocalStore(t *testing.T) {
 	err = filesystem.TestEmptyFolder(p)
 	assert.NoErr(t, err, "There should be no files in the node folder now")
 
-	port1 := crypto.GetRandomUserPort()
+	port1, err := net.GetUnboundedPort()
+	assert.NoErr(t, err, "Should be able to establish a connection on a port")
+
 	address := fmt.Sprintf("0.0.0.0:%d", port1)
 
 	node, err := NewNodeIdentity(address, nodeconfig.ConfigValues, false)

--- a/p2p/net/network_test.go
+++ b/p2p/net/network_test.go
@@ -2,19 +2,23 @@ package net
 
 import (
 	"fmt"
+	"testing"
+	"time"
+
 	"github.com/spacemeshos/go-spacemesh/assert"
 	"github.com/spacemeshos/go-spacemesh/crypto"
 	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/p2p/nodeconfig"
-	"testing"
-	"time"
 )
 
 func TestReadWrite(t *testing.T) {
 
 	msg := []byte("hello spacemesh")
 	msgID := crypto.UUID()
-	port := crypto.GetRandomUserPort()
+
+	port, err := GetUnboundedPort()
+	assert.NoErr(t, err, "Should be able to establish a connection on a port")
+
 	address := fmt.Sprintf("0.0.0.0:%d", port)
 	done := make(chan bool, 1)
 

--- a/p2p/net/network_test.go
+++ b/p2p/net/network_test.go
@@ -89,3 +89,9 @@ func TestReadWrite(t *testing.T) {
 	err = c.Close()
 	assert.NoErr(t, err, "error closing connection")
 }
+
+func TestGetUnboundedPort(t *testing.T) {
+	port, err := GetUnboundedPort()
+	_ = port // to make lint pass
+	assert.NoErr(t, err, "Should be able to get an unbounded port")
+}

--- a/p2p/net/network_test_helpers.go
+++ b/p2p/net/network_test_helpers.go
@@ -1,0 +1,33 @@
+package net
+
+import (
+	"errors"
+	"fmt"
+	"net"
+
+	"github.com/spacemeshos/go-spacemesh/crypto"
+)
+
+// CheckUserPort tries to listen on a port and check whether is usable or not
+func CheckUserPort(port uint32) bool {
+	address := fmt.Sprintf("0.0.0.0:%d", port)
+	l, e := net.Listen("tcp", address)
+	defer l.Close()
+	if e != nil {
+		return true
+	}
+	return false
+}
+
+// GetUnboundedPort returns a port that is for sure unbounded or an error.
+func GetUnboundedPort() (int, error) {
+	port := crypto.GetRandomUserPort()
+	retryCount := 0
+	for used := true; used && retryCount < 10; used, retryCount = CheckUserPort(port), retryCount+1 {
+		port = crypto.GetRandomUserPort()
+	}
+	if retryCount >= 10 {
+		return 0, errors.New("failed to establish network, probably no internet connection")
+	}
+	return int(port), nil
+}

--- a/p2p/net/network_test_helpers.go
+++ b/p2p/net/network_test_helpers.go
@@ -12,10 +12,10 @@ import (
 func CheckUserPort(port uint32) bool {
 	address := fmt.Sprintf("0.0.0.0:%d", port)
 	l, e := net.Listen("tcp", address)
-	defer l.Close()
 	if e != nil {
 		return true
 	}
+	l.Close()
 	return false
 }
 

--- a/p2p/ping_test.go
+++ b/p2p/ping_test.go
@@ -2,11 +2,12 @@ package p2p
 
 import (
 	"bytes"
+	"testing"
+	"time"
+
 	"github.com/spacemeshos/go-spacemesh/assert"
 	"github.com/spacemeshos/go-spacemesh/crypto"
 	"github.com/spacemeshos/go-spacemesh/p2p/node"
-	"testing"
-	"time"
 )
 
 func TestPingProtocol(t *testing.T) {

--- a/p2p/swarm_test.go
+++ b/p2p/swarm_test.go
@@ -3,11 +3,12 @@ package p2p
 import (
 	"bytes"
 	"fmt"
+	"testing"
+	"time"
+
 	"github.com/spacemeshos/go-spacemesh/assert"
 	"github.com/spacemeshos/go-spacemesh/crypto"
 	"github.com/spacemeshos/go-spacemesh/p2p/nodeconfig"
-	"testing"
-	"time"
 )
 
 // Basic session test

--- a/p2p/testshelpers.go
+++ b/p2p/testshelpers.go
@@ -3,6 +3,7 @@ package p2p
 import (
 	"fmt"
 	"github.com/spacemeshos/go-spacemesh/crypto"
+	"github.com/spacemeshos/go-spacemesh/p2p/net"
 	"github.com/spacemeshos/go-spacemesh/p2p/node"
 	"github.com/spacemeshos/go-spacemesh/p2p/nodeconfig"
 	"testing"
@@ -16,7 +17,11 @@ func GenerateTestNode(t *testing.T) (LocalNode, Peer) {
 // GenerateTestNodeWithConfig creates a local test node without persisting data to local store.
 func GenerateTestNodeWithConfig(t *testing.T, config nodeconfig.Config) (LocalNode, Peer) {
 
-	port := crypto.GetRandomUserPort()
+	port, err := net.GetUnboundedPort()
+	if err != nil {
+		t.Error("Failed to get a port to bind", err)
+	}
+
 	address := fmt.Sprintf("0.0.0.0:%d", port)
 
 	localNode, err := NewNodeIdentity(address, config, false)
@@ -33,18 +38,27 @@ func GenerateTestNodeWithConfig(t *testing.T, config nodeconfig.Config) (LocalNo
 }
 
 // GenerateRandomNodeData generates a remote random node data for testing.
-func GenerateRandomNodeData() node.RemoteNodeData {
-	port := crypto.GetRandomUserPort()
+func GenerateRandomNodeData() (node.RemoteNodeData, error) {
+
+	port, err := net.GetUnboundedPort()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get a port to bind %v", err)
+	}
+
 	address := fmt.Sprintf("0.0.0.0:%d", port)
 	_, pub, _ := crypto.GenerateKeyPair()
-	return node.NewRemoteNodeData(pub.String(), address)
+	return node.NewRemoteNodeData(pub.String(), address), nil
 }
 
 // GenerateRandomNodesData generates remote nodes data for testing.
-func GenerateRandomNodesData(n int) []node.RemoteNodeData {
+func GenerateRandomNodesData(n int) ([]node.RemoteNodeData, error) {
+	var err error
 	res := make([]node.RemoteNodeData, n)
 	for i := 0; i < n; i++ {
-		res[i] = GenerateRandomNodeData()
+		res[i], err = GenerateRandomNodeData()
+		if err != nil {
+			return nil, err
+		}
 	}
-	return res
+	return res, nil
 }


### PR DESCRIPTION
Apparently `go tests ./...` runs the test simultaneously. that means that tests that use the filesystem and network (ports) can fail because they overlap. 
Added some funcs to prevent this from happening and run the tests the same for now.