### PR TITLE
Comments cleanup and reformating.

### DIFF
--- a/accounts/account.go
+++ b/accounts/account.go
@@ -1,10 +1,11 @@
-// Package accounts provides types for working with Spacemesh blockchain accounts
+// Package accounts provides types for working with Spacemesh blockchain accounts.
 package accounts
 
 import (
 	"crypto/aes"
 	"encoding/hex"
 	"errors"
+
 	"github.com/spacemeshos/go-spacemesh/crypto"
 	"github.com/spacemeshos/go-spacemesh/log"
 )
@@ -15,7 +16,7 @@ type Registry struct {
 	Unlocked map[string]*Account
 }
 
-// Account is an end user blockchain account
+// Account is an end user blockchain account.
 type Account struct {
 	PrivKey    crypto.PrivateKey
 	PubKey     crypto.PublicKey
@@ -24,7 +25,7 @@ type Account struct {
 }
 
 var (
-	// Accounts Registry app singleton
+	// Accounts Registry app singleton.
 	Accounts *Registry
 )
 
@@ -36,7 +37,8 @@ func init() {
 }
 
 // NewAccount Creates a new account using the provided passphrase.
-// Clients should persist newly created accounts - without this the account only lasts for one app session.
+// Clients should persist newly create accounts - without this the
+// account only lasts for one app session.
 func NewAccount(passphrase string) (*Account, error) {
 
 	// account crypto data
@@ -74,7 +76,6 @@ func NewAccount(passphrase string) (*Account, error) {
 
 	// aes encrypt data
 	cipherText, err := crypto.AesCTRXOR(aesKey, privKeyBytes, nonce)
-
 	if err != nil {
 		log.Error("Failed to encrypt private key", err)
 		return nil, err

--- a/accounts/ops.go
+++ b/accounts/ops.go
@@ -5,20 +5,22 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+
 	"github.com/spacemeshos/go-spacemesh/crypto"
 	"github.com/spacemeshos/go-spacemesh/log"
 )
 
-// Pretty returns an account logging string
+// Pretty returns an account logging string.
 func (a *Account) Pretty() string {
 	return fmt.Sprintf("Account %s", a.PubKey.Pretty())
 }
 
+// String returns the stringed data of the account public key.
 func (a *Account) String() string {
 	return a.PubKey.String()
 }
 
-// Log account info
+// Log account info.
 func (a *Account) Log() {
 
 	pubKey := a.PubKey.String()
@@ -35,12 +37,12 @@ func (a *Account) Log() {
 	log.Info(" kdParams: %+v", a.kdParams)
 }
 
-// IsAccountLocked returns true iff account is locked.
+// IsAccountLocked returns true if account is locked.
 func (a *Account) IsAccountLocked() bool {
 	return a.PrivKey == nil
 }
 
-// IsAccountUnlocked returns true iff account is unlocked.
+// IsAccountUnlocked returns true if account is unlocked.
 func (a *Account) IsAccountUnlocked() bool {
 	return !a.IsAccountLocked()
 }
@@ -51,7 +53,7 @@ func (a *Account) LockAccount(passphrase string) {
 	delete(Accounts.Unlocked, a.String())
 }
 
-// UnlockAccount unlocks an account using the user provided passphrase
+// UnlockAccount unlocks an account using the user provided passphrase.
 func (a *Account) UnlockAccount(passphrase string) error {
 
 	if a.IsAccountUnlocked() {
@@ -113,7 +115,7 @@ func (a *Account) UnlockAccount(passphrase string) error {
 	return nil
 }
 
-// Validate that the account's private key matches the provided private key
+// ValidatePublicKey that the account's private key matches the provided private key.
 func (a *Account) validatePublicKey(privateKey crypto.PrivateKey) error {
 
 	publicKey := privateKey.GetPublicKey()

--- a/accounts/ops.go
+++ b/accounts/ops.go
@@ -115,7 +115,7 @@ func (a *Account) UnlockAccount(passphrase string) error {
 	return nil
 }
 
-// ValidatePublicKey that the account's private key matches the provided private key.
+// validatePublicKey validates that the account's private key matches the provided private key.
 func (a *Account) validatePublicKey(privateKey crypto.PrivateKey) error {
 
 	publicKey := privateKey.GetPublicKey()

--- a/api/config/config.go
+++ b/api/config/config.go
@@ -1,6 +1,6 @@
 package config
 
-// ConfigValues provide default config values
+// ConfigValues provide default config values.
 var ConfigValues = Config{
 	StartGrpcServer: false, // note: all bool flags default to false so don't set one of these to true here
 	GrpcServerPort:  9091,
@@ -12,7 +12,7 @@ func init() {
 	// todo: update default config params based on runtime env here
 }
 
-// Config defines the api config params
+// Config defines the api config params.
 type Config struct {
 	StartGrpcServer bool
 	GrpcServerPort  int

--- a/api/config/flags.go
+++ b/api/config/flags.go
@@ -5,15 +5,16 @@ import (
 	"gopkg.in/urfave/cli.v1/altsrc"
 )
 
+// Service flags for api servers.
 var (
-	// StartJSONApiServerFlag determines if json api server should be started
+	// StartJSONApiServerFlag determines if json api server should be started.
 	StartJSONApiServerFlag = altsrc.NewBoolFlag(cli.BoolFlag{
 		Name:        "json-server",
 		Usage:       "StartService the json http server. Note that starting the Json server also starts the grpc server.",
 		Destination: &ConfigValues.StartJSONServer,
 	})
 
-	// JSONServerPortFlag determines the json api server local listening port
+	// JSONServerPortFlag determines the json api server local listening port.
 	JSONServerPortFlag = altsrc.NewIntFlag(cli.IntFlag{
 		Name:        "json-port",
 		Usage:       "Json api server port",
@@ -21,14 +22,14 @@ var (
 		Destination: &ConfigValues.JSONServerPort,
 	})
 
-	// StartGrpcAPIServerFlag determines if the grpc server should be started
+	// StartGrpcAPIServerFlag determines if the grpc server should be started.
 	StartGrpcAPIServerFlag = altsrc.NewBoolFlag(cli.BoolFlag{
 		Name:        "grpc-server",
 		Usage:       "StartService the grpc server",
 		Destination: &ConfigValues.StartGrpcServer,
 	})
 
-	// GrpcServerPortFlag determines the grpc server local listening port
+	// GrpcServerPortFlag determines the grpc server local listening port.
 	GrpcServerPortFlag = altsrc.NewIntFlag(cli.IntFlag{
 		Name:        "grpc-port",
 		Usage:       "Grpc api server port",

--- a/api/grpc_server.go
+++ b/api/grpc_server.go
@@ -2,10 +2,11 @@
 package api
 
 import (
+	"strconv"
+
 	"github.com/spacemeshos/go-spacemesh/api/config"
 	"github.com/spacemeshos/go-spacemesh/api/pb"
 	"github.com/spacemeshos/go-spacemesh/log"
-	"strconv"
 
 	"net"
 
@@ -45,7 +46,7 @@ func (s SpaceMeshGrpcService) StartService(status chan bool) {
 	go s.startServiceInternal(status)
 }
 
-// This is a blocking method designed to be called using a go routine
+// startServiceInternal is a blocking method designed to be called using a go routine.
 func (s SpaceMeshGrpcService) startServiceInternal(status chan bool) {
 	port := config.ConfigValues.GrpcServerPort
 	addr := ":" + strconv.Itoa(int(port))

--- a/api/http_server.go
+++ b/api/http_server.go
@@ -2,19 +2,20 @@ package api
 
 import (
 	"flag"
+	"net/http"
+	"strconv"
+
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/spacemeshos/go-spacemesh/api/config"
 	"github.com/spacemeshos/go-spacemesh/log"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
-	"net/http"
-	"strconv"
 
 	gw "github.com/spacemeshos/go-spacemesh/api/pb"
 )
 
 // JSONHTTPServer is a JSON http server providing the Spacemesh API.
-// It is implemented using a grpc-gateway. See https://github.com/grpc-ecosystem/grpc-gateway .
+// It is implemented using a grpc-gateway. See https://github.com/grpc-ecosystem/grpc-gateway.
 type JSONHTTPServer struct {
 	Port   uint
 	server *http.Server

--- a/app/config/params.go
+++ b/app/config/params.go
@@ -1,6 +1,6 @@
 package config
 
-// app params are non-configured consts
+// App params are non-configured consts.
 const (
 	AppUsage              = "the go-spacemesh node"
 	AppAuthor             = "The go-spacemesh authors"

--- a/app/main.go
+++ b/app/main.go
@@ -198,7 +198,7 @@ func (app *SpacemeshApp) before(ctx *cli.Context) error {
 	return nil
 }
 
-// Spacemesh app cleanup tasks
+// Spacemesh app cleanup tasks.
 func (app *SpacemeshApp) cleanup(ctx *cli.Context) error {
 
 	log.Info("App cleanup starting...")

--- a/assert/assert.go
+++ b/assert/assert.go
@@ -9,7 +9,7 @@ import (
 
 // basic assertion support
 
-// Nil verifies that obj is nil
+// Nil verifies that obj is nil.
 func Nil(t *testing.T, obj interface{}, msgs ...string) {
 	t.Helper()
 	if obj != nil {
@@ -17,7 +17,7 @@ func Nil(t *testing.T, obj interface{}, msgs ...string) {
 	}
 }
 
-// NotNil verifies that obj is not nil
+// NotNil verifies that obj is not nil.
 func NotNil(t *testing.T, obj interface{}, msgs ...string) {
 	t.Helper()
 	if obj == nil {
@@ -25,7 +25,7 @@ func NotNil(t *testing.T, obj interface{}, msgs ...string) {
 	}
 }
 
-// True verifies that v is true
+// True verifies that v is true.
 func True(t *testing.T, v bool, msgs ...string) {
 	t.Helper()
 	if !v {
@@ -33,7 +33,7 @@ func True(t *testing.T, v bool, msgs ...string) {
 	}
 }
 
-// Equal verifies that a is equal to b
+// Equal verifies that a is equal to b.
 func Equal(t *testing.T, a interface{}, b interface{}, msg string) {
 	t.Helper()
 	if a == b {
@@ -45,13 +45,13 @@ func Equal(t *testing.T, a interface{}, b interface{}, msg string) {
 	t.Fatal(msg)
 }
 
-// False verifies that v is false
+// False verifies that v is false.
 func False(t *testing.T, v bool, msgs ...string) {
 	t.Helper()
 	True(t, !v, msgs...)
 }
 
-// NoErr verifies that err is nil
+// NoErr verifies that err is nil.
 func NoErr(t *testing.T, err error, msgs ...string) {
 	t.Helper()
 	if err != nil {
@@ -59,7 +59,7 @@ func NoErr(t *testing.T, err error, msgs ...string) {
 	}
 }
 
-// Err verifies that err is not nil
+// Err verifies that err is not nil.
 func Err(t *testing.T, err error, msgs ...string) {
 	t.Helper()
 	if err == nil {

--- a/crypto/aes.go
+++ b/crypto/aes.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 )
 
-// AesCTRXOR is an AES cipher following https://leanpub.com/gocrypto/read#leanpub-auto-aes-cbc .
+// AesCTRXOR is an AES cipher following https://leanpub.com/gocrypto/read#leanpub-auto-aes-cbc.
 func AesCTRXOR(key, input, nonce []byte) ([]byte, error) {
 	aesBlock, err := aes.NewCipher(key)
 	if err != nil {

--- a/crypto/keys.go
+++ b/crypto/keys.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcutil/base58"
 	"github.com/spacemeshos/go-spacemesh/log"
@@ -59,7 +60,7 @@ func GenerateKeyPair() (PrivateKey, PublicKey, error) {
 	return &privateKeyImpl{privKey}, &publicKeyImpl{privKey.PubKey()}, nil
 }
 
-// NewPrivateKey creates a new private key from data
+// NewPrivateKey creates a new private key from data.
 func NewPrivateKey(data []byte) (PrivateKey, error) {
 
 	if len(data) != 32 {
@@ -76,23 +77,23 @@ func NewPrivateKeyFromString(s string) (PrivateKey, error) {
 	return NewPrivateKey(data)
 }
 
-// InternalKey gets the internal key associated with a private key
+// InternalKey gets the internal key associated with a private key.
 func (p *privateKeyImpl) InternalKey() *btcec.PrivateKey {
 	return p.k
 }
 
-// Bytes returns the private key binary data
+// Bytes returns the private key binary data.
 func (p *privateKeyImpl) Bytes() []byte {
 	return p.k.Serialize()
 }
 
-// String returns a base58 encoded string of the private key binary data
+// String returns a base58 encoded string of the private key binary data.
 func (p *privateKeyImpl) String() string {
 	bytes := p.Bytes()
 	return base58.Encode(bytes)
 }
 
-// GetPublicKey generates and returns the public key associated with a private key
+// GetPublicKey generates and returns the public key associated with a private key.
 func (p *privateKeyImpl) GetPublicKey() PublicKey {
 	pubKey := p.k.PubKey()
 	return &publicKeyImpl{k: pubKey}
@@ -117,7 +118,7 @@ func (p *privateKeyImpl) Sign(in []byte) ([]byte, error) {
 	return signature.Serialize(), nil
 }
 
-// Decrypt decrypts data encrypted with a public key using its matching private key
+// Decrypt decrypts data encrypted with a public key using its matching private key.
 func (p *privateKeyImpl) Decrypt(in []byte) ([]byte, error) {
 	return btcec.Decrypt(p.k, in)
 }

--- a/crypto/randg.go
+++ b/crypto/randg.go
@@ -4,10 +4,12 @@ import (
 	"crypto/rand"
 	"encoding/binary"
 	"errors"
+
 	"github.com/spacemeshos/go-spacemesh/log"
 )
 
 // GetRandomBytesToBuffer puts n random bytes using go crypto.rand into provided buff slice.
+//
 // buff: a slice allocated by called to hold n bytes.
 func GetRandomBytesToBuffer(n int, buff []byte) error {
 

--- a/crypto/sha3.go
+++ b/crypto/sha3.go
@@ -5,7 +5,7 @@ import (
 )
 
 // Sha256 is a SHA-3-256 (not sha-256) hasher. It returns a 32 bytes (256 bits) hash of data.
-// data: arbitrary length bytes slice
+// data: arbitrary length bytes slice.
 func Sha256(data ...[]byte) []byte {
 	d := sha3.New256()
 	for _, b := range data {

--- a/crypto/sha3.go
+++ b/crypto/sha3.go
@@ -5,6 +5,7 @@ import (
 )
 
 // Sha256 is a SHA-3-256 (not sha-256) hasher. It returns a 32 bytes (256 bits) hash of data.
+//
 // data: arbitrary length bytes slice.
 func Sha256(data ...[]byte) []byte {
 	d := sha3.New256()

--- a/filesystem/dirs.go
+++ b/filesystem/dirs.go
@@ -2,16 +2,17 @@
 package filesystem
 
 import (
-	"github.com/spacemeshos/go-spacemesh/app/config"
-	"github.com/spacemeshos/go-spacemesh/log"
 	"os"
 	"os/user"
 	"path"
 	"path/filepath"
 	"strings"
+
+	"github.com/spacemeshos/go-spacemesh/app/config"
+	"github.com/spacemeshos/go-spacemesh/log"
 )
 
-// Using a function pointer to get the current user so we can more easily mock in tests
+// currentUsing is a function pointer to get the current user so we can more easily mock in tests.
 var currentUser = user.Current
 
 // Directory and paths funcs
@@ -22,7 +23,7 @@ const OwnerReadWriteExec = 0700
 // OwnerReadWrite is a standard owner read / write file permission.
 const OwnerReadWrite = 0600
 
-// PathExists returns true iff file exists in local store and is accessible.
+// PathExists returns true if file exists in local store and is accessible.
 func PathExists(path string) bool {
 	_, err := os.Stat(path)
 	if os.IsNotExist(err) {

--- a/filesystem/dirs.go
+++ b/filesystem/dirs.go
@@ -144,10 +144,14 @@ func GetUserHomeDirectory() string {
 }
 
 // GetCanonicalPath returns an os-specific full path following these rules:
+//
 // - replace ~ with user's home dir path
+//
 // - expand any ${vars} or $vars
+//
 // - resolve relative paths /.../
-// p: source path name
+//
+// Where p: source path name
 func GetCanonicalPath(p string) string {
 
 	if strings.HasPrefix(p, "~/") || strings.HasPrefix(p, "~\\") {

--- a/merkle/branchnode.go
+++ b/merkle/branchnode.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
+
 	"github.com/gogo/protobuf/proto"
 	"github.com/spacemeshos/go-spacemesh/crypto"
 	"github.com/spacemeshos/go-spacemesh/log"
@@ -25,7 +26,7 @@ type branchNode interface {
 
 }
 
-// Adds a child to the node
+// Adds a child to the node.
 func (b *branchNodeImpl) addChild(idx string, pointer []byte) error {
 
 	if len(idx) != 1 {
@@ -45,7 +46,7 @@ func (b *branchNodeImpl) addChild(idx string, pointer []byte) error {
 	return nil
 }
 
-// Removes a child from the node
+// Removes a child from the node.
 func (b *branchNodeImpl) removeChild(idx string) error {
 
 	if len(idx) != 1 {
@@ -95,7 +96,7 @@ func newBranchNodeEx(entries map[string][]byte, value []byte) branchNode {
 	}
 }
 
-// Creates a new branch node from persisted branch node data
+// Creates a new branch node from persisted branch node data.
 func newBranchNodeFromPersistedData(rawData []byte, data *pb.Node) branchNode {
 
 	n := &branchNodeImpl{
@@ -144,7 +145,7 @@ func (b *branchNodeImpl) print(userDb *userDb, getUserValue func(userDb *userDb,
 	return buffer.String()
 }
 
-// Returns a slice containing all pointers to child nodes
+// getAllChildNodePointers returns a slice containing all pointers to child nodes.
 func (b *branchNodeImpl) getAllChildNodePointers() [][]byte {
 	res := make([][]byte, 0)
 	for _, val := range b.entries {

--- a/merkle/delete.go
+++ b/merkle/delete.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 )
 
-// remove v keyed by k from the tree
+// Delete remove v keyed by k from the tree
 func (mt *merkleTreeImp) Delete(k []byte) error {
 
 	return errors.New("not implemented yet")
@@ -34,7 +34,7 @@ func (mt *merkleTreeImp) Delete(k []byte) error {
 	//	return nil
 }
 
-// Deletes value from node at top of the stack from the tree
+// delete removes value from node at top of the stack from the tree
 // Stack contains a path to a node to be deleted
 // eg. ext -> branch -> ext -> branch
 // k: path to path last node (top of stack)

--- a/merkle/get.go
+++ b/merkle/get.go
@@ -3,15 +3,16 @@ package merkle
 import (
 	"encoding/hex"
 	"errors"
+
 	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/merkle/pb"
 	"github.com/syndtr/goleveldb/leveldb"
 )
 
-// Gets user value associated with user key
-// returns value if found and nil otherwise
-// Returned stack - The tree path path closest to the value
-// Returned int - count of matched hex chars on the path
+// Get gets user value associated with user key
+// and returns value if found and nil otherwise.
+// Returned stack - The tree path path closest to the value.
+// Returned int - count of matched hex chars on the path.
 func (mt *merkleTreeImp) Get(k []byte) ([]byte, *stack, error) {
 
 	keyHexStr := hex.EncodeToString(k)
@@ -50,11 +51,11 @@ func (mt *merkleTreeImp) Get(k []byte) ([]byte, *stack, error) {
 	return value, s, err
 }
 
-// Get user value v keyed by k v from the tree
-// root: tree root to start looking from
-// pos: number of key hex chars (nibbles) already matched and the index in key to start matching from
-// k: hex-encoded path (always abs full path)
-// s: on return stack of nodes from root to where value should be or is in the tree
+// findValue get user value v keyed by k v from the tree.
+// root: tree root to start looking from.
+// pos: number of key hex chars (nibbles) already matched and the index in key to start matching from.
+// k: hex-encoded path (always abs full path).
+// s: on return stack of nodes from root to where value should be or is in the tree.
 func (mt *merkleTreeImp) findValue(root Node, k string, pos int, s *stack) ([]byte, error) {
 
 	if root == nil {

--- a/merkle/hex.go
+++ b/merkle/hex.go
@@ -1,6 +1,6 @@
 package merkle
 
-// Converts a hex ascii character into its binary value and a success flag.
+// fromHexChar converts a hex ascii character into its binary value and a success flag.
 // Adapted from https://golang.org/src/encoding/hex/hex.go - too bad it is private
 // Examples: '0' -> 0x0
 // Examples: 'f' -> 0xf
@@ -17,7 +17,7 @@ func fromHexChar(c byte) (byte, bool) {
 	return 0, false
 }
 
-// Returns hex-encoded string from binary value. e.g 0x0 -> '0', 0xf -> 'f'
+// toHexChar returns hex-encoded string from binary value. e.g 0x0 -> '0', 0xf -> 'f'
 func toHexChar(c byte) (string, bool) {
 	switch {
 	case c <= 9:
@@ -29,14 +29,14 @@ func toHexChar(c byte) (string, bool) {
 	}
 }
 
-// Returns the common prefix of 2 hex encoded strings
+// commonPrefix returns the common prefix of 2 hex encoded strings
 // Empty string is returned if there's no common suffix of len >= 1
 func commonPrefix(s string, s1 string) string {
 	l := lenPrefix(s, s1)
 	return s[:l]
 }
 
-// Returns the length of the common prefix of 2 hex encoded strings
+// lenPrefix returns the length of the common prefix of 2 hex encoded strings
 func lenPrefix(a, b string) int {
 	var i, length = 0, len(a)
 	if len(b) < length {

--- a/merkle/node.go
+++ b/merkle/node.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+
 	"github.com/gogo/protobuf/proto"
 	"github.com/spacemeshos/go-spacemesh/crypto"
 	"github.com/spacemeshos/go-spacemesh/log"
@@ -124,7 +125,7 @@ func newNodeFromData(data []byte) (Node, error) {
 	return c, nil
 }
 
-// Set extension node child node
+// setExtChild set's extension node child node
 // Pointer: pointer to child (and hash of child's value)
 func (n *nodeImp) setExtChild(pointer []byte) error {
 
@@ -143,7 +144,7 @@ func (n *nodeImp) setExtChild(pointer []byte) error {
 	return nil
 }
 
-// Adds a child node to a branch node
+// addBranchChild adds a child node to a branch node
 // idx: branch index (hex char representing a nibble) for the new child
 // child: child node
 // Side effect: if an existing child for index idx exists then it is removed from the tree
@@ -173,7 +174,7 @@ func (n *nodeImp) addBranchChild(idx string, child Node) error {
 	return nil
 }
 
-// Removes a child indexed with idx from a branch node
+// removeBranchChild removes a child indexed with idx from a branch node
 // todo: figure out if we should always remove the node from backing store. Otherwise, the removed child may never be removed from the local db.
 func (n *nodeImp) removeBranchChild(idx string) error {
 
@@ -228,7 +229,7 @@ func (n *nodeImp) getExtNode() shortNode {
 	return n.ext
 }
 
-// Returns a shortnode type of this node.
+// getShortNode returns a shortnode type of this node.
 // Returns nil for a branch or unknown node
 func (n *nodeImp) getShortNode() shortNode {
 	switch n.nodeType {
@@ -243,28 +244,28 @@ func (n *nodeImp) getShortNode() shortNode {
 	}
 }
 
-// Returns true iff node is a leaf node
+// isLeaf returns true iff node is a leaf node
 func (n *nodeImp) isLeaf() bool {
 	return n.nodeType == pb.NodeType_leaf
 }
 
-// Returns true iff node is an extension node
+// isExt returns true iff node is an extension node
 func (n *nodeImp) isExt() bool {
 	return n.nodeType == pb.NodeType_extension
 }
 
-// Returns true iff node is a branch node
+// isBranch returns true iff node is a branch node
 func (n *nodeImp) isBranch() bool {
 	return n.nodeType == pb.NodeType_branch
 }
 
-// Returns number of current node children.
+// getChildrenCount returns number of current node children.
 // Leaf nodes always have 0 children, ext nodes have 1 and branch node can have up to 16 children.
 func (n *nodeImp) getChildrenCount() int {
 	return len(n.children)
 }
 
-// Returns true iff node is a leaf or an extension node
+// isShortNode returns true iff node is a leaf or an extension node
 func (n *nodeImp) isShortNode() bool {
 	switch n.nodeType {
 	case pb.NodeType_leaf:
@@ -276,7 +277,7 @@ func (n *nodeImp) isShortNode() bool {
 	}
 }
 
-// Validates node hash without any side effects
+// validateHash validates node hash without any side effects
 func (n *nodeImp) validateHash() error {
 
 	data, err := n.marshal()
@@ -301,7 +302,7 @@ func (n *nodeImp) didLoadChildren() bool {
 	return n.childrenLoaded
 }
 
-// Loads node's direct child node(s) to memory from store
+// loadChildren loads node's direct child node(s) to memory from store
 func (n *nodeImp) loadChildren(db *treeDb) error {
 
 	if n.nodeType == pb.NodeType_leaf {

--- a/merkle/ops.go
+++ b/merkle/ops.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+
 	"github.com/spacemeshos/go-spacemesh/crypto"
 	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/syndtr/goleveldb/leveldb"
@@ -37,8 +38,8 @@ func (mt *merkleTreeImp) removeNodeFromStore(node Node) error {
 	return nil
 }
 
-// Persists user and tree data for given (userKey, userValue) and a Node (tree-space node)
-// node: tree node to store in the tree db
+// Persists user and tree data for given (userKey, userValue) and a Node (tree-space node).
+// node: tree node to store in the tree db.
 func (mt *merkleTreeImp) persistNode(node Node) error {
 
 	nodeKey := node.getNodeHash()

--- a/merkle/ops.go
+++ b/merkle/ops.go
@@ -38,7 +38,8 @@ func (mt *merkleTreeImp) removeNodeFromStore(node Node) error {
 	return nil
 }
 
-// Persists user and tree data for given (userKey, userValue) and a Node (tree-space node).
+// Persists user and tree data for given (userKey, userValue) and
+// a Node (tree-space node).
 // node: tree node to store in the tree db.
 func (mt *merkleTreeImp) persistNode(node Node) error {
 

--- a/merkle/tree.go
+++ b/merkle/tree.go
@@ -42,8 +42,10 @@ type merkleTreeImp struct {
 
 // NewEmptyTree creates a new empty Merkle tree with the provided paths to user and tree data db files.
 // The db files will be created on these paths if they don't already exist.
-// userDataFileName: full local os path and file name for the user data db for this tree
-// treeDataFileName: full local os path and file name for the internal tree db store for this tree
+//
+// userDataFileName: full local os path and file name for the user data db for this tree.
+//
+// treeDataFileName: full local os path and file name for the internal tree db store for this tree.
 func NewEmptyTree(userDataFileName string, treeDataFileName string) (Tree, error) {
 	userData, err := leveldb.OpenFile(userDataFileName, nil)
 	if err != nil {
@@ -66,8 +68,11 @@ func NewEmptyTree(userDataFileName string, treeDataFileName string) (Tree, error
 }
 
 // NewTreeFromDb creates a new tree from provided dbs file paths.
+//
 // rootHash: tree root hash - used to pull the root from the db
+//
 // userDataFileName: full local os path and file name for user data db for this tree
+//
 // treeDataFileName: full local os path and file name for the internal tree db store for this tree
 func NewTreeFromDb(rootHash []byte, userDataFileName string, treeDataFileName string) (Tree, error) {
 

--- a/merkle/tree.go
+++ b/merkle/tree.go
@@ -69,11 +69,11 @@ func NewEmptyTree(userDataFileName string, treeDataFileName string) (Tree, error
 
 // NewTreeFromDb creates a new tree from provided dbs file paths.
 //
-// rootHash: tree root hash - used to pull the root from the db
+// rootHash: tree root hash - used to pull the root from the db.
 //
-// userDataFileName: full local os path and file name for user data db for this tree
+// userDataFileName: full local os path and file name for user data db for this tree.
 //
-// treeDataFileName: full local os path and file name for the internal tree db store for this tree
+// treeDataFileName: full local os path and file name for the internal tree db store for this tree.
 func NewTreeFromDb(rootHash []byte, userDataFileName string, treeDataFileName string) (Tree, error) {
 
 	userData, err := leveldb.OpenFile(userDataFileName, nil)

--- a/p2p/delimited/chan.go
+++ b/p2p/delimited/chan.go
@@ -91,7 +91,7 @@ Loop:
 	s.CloseChan <- true
 }
 
-// Close the Chan
+// Close the Chan.
 func (s *Chan) Close() {
 	s.CloseChan <- true
 }

--- a/p2p/demux.go
+++ b/p2p/demux.go
@@ -4,14 +4,14 @@ import (
 	"github.com/spacemeshos/go-spacemesh/log"
 )
 
-// IncomingMessage defines an incoming a p2p protocol message components
+// IncomingMessage defines an incoming a p2p protocol message components.
 type IncomingMessage interface {
 	Sender() Peer
 	Protocol() string
 	Payload() []byte
 }
 
-// NewIncomingMessage creates a new IncomingMessage from provided components
+// NewIncomingMessage creates a new IncomingMessage from provided components.
 func NewIncomingMessage(sender Peer, protocol string, payload []byte) IncomingMessage {
 	return &IncomingMessageImpl{
 		sender:   sender,
@@ -20,38 +20,39 @@ func NewIncomingMessage(sender Peer, protocol string, payload []byte) IncomingMe
 	}
 }
 
-// IncomingMessageImpl implements IncomingMessage
+// IncomingMessageImpl implements IncomingMessage.
 type IncomingMessageImpl struct {
 	sender   Peer
 	protocol string
 	payload  []byte
 }
 
-// Sender returns the message sender peer
+// Sender returns the message sender peer.
 func (i *IncomingMessageImpl) Sender() Peer {
 	return i.sender
 }
 
-// Protocol returns the message protocol string
+// Protocol returns the message protocol string.
 func (i *IncomingMessageImpl) Protocol() string {
 	return i.protocol
 }
 
-// Payload returns the binary message payload
+// Payload returns the binary message payload.
 func (i *IncomingMessageImpl) Payload() []byte {
 	return i.payload
 }
 
-// MessagesChan is a channel of IncomingMessages
+// MessagesChan is a channel of IncomingMessages.
 type MessagesChan chan IncomingMessage
 
-// ProtocolRegistration defines required protocol demux registration data
+// ProtocolRegistration defines required protocol demux registration data.
 type ProtocolRegistration struct {
 	Protocol string
 	Handler  MessagesChan
 }
 
 // Demuxer is responsible for routing incoming network messages back to protocol handlers based on message protocols.
+//
 // Limitations - type only supports 1 handler per protocol for now.
 type Demuxer interface {
 	RegisterProtocolHandler(handler ProtocolRegistration)

--- a/p2p/dht/table/bucket.go
+++ b/p2p/dht/table/bucket.go
@@ -2,6 +2,7 @@ package table
 
 import (
 	"container/list"
+
 	"github.com/spacemeshos/go-spacemesh/p2p/dht"
 	node "github.com/spacemeshos/go-spacemesh/p2p/node"
 )
@@ -21,7 +22,7 @@ type Bucket interface {
 	List() *list.List
 }
 
-// Internal bucket implementation type
+// Internal bucket implementation type.
 type bucketimpl struct {
 	list *list.List
 }

--- a/p2p/findnode.go
+++ b/p2p/findnode.go
@@ -22,16 +22,14 @@ type FindNodeProtocol interface {
 
 	// FindNode sends a find_node request for data about a remote node, known only by id,
 	// to a specific known remote node.
-	//
 	// Results will include 0 or more nodes and up to count nodes which may or may not include
 	// data about id (as serverNodeId may not know about it).
 	//
 	// reqID: allows the client to match responses with requests by id.
-	//
 	// serverNodeId - node to send the find request to.
-	//
 	// id - node id to find
-	// TODO(): this should really be named FindClosestNodes
+	//
+	// TODO(devs): this should really be named FindClosestNodes
 	FindNode(reqID []byte, serverNodeID string, id string, callback chan FindNodeResp) error
 }
 

--- a/p2p/findnode.go
+++ b/p2p/findnode.go
@@ -2,6 +2,8 @@ package p2p
 
 import (
 	"encoding/hex"
+	"time"
+
 	"github.com/btcsuite/btcutil/base58"
 	"github.com/gogo/protobuf/proto"
 	"github.com/spacemeshos/go-spacemesh/crypto"
@@ -10,7 +12,6 @@ import (
 	"github.com/spacemeshos/go-spacemesh/p2p/dht/table"
 	"github.com/spacemeshos/go-spacemesh/p2p/node"
 	"github.com/spacemeshos/go-spacemesh/p2p/pb"
-	"time"
 )
 
 const findNodeReq = "/dht/1.0/find-node-req/"
@@ -19,13 +20,18 @@ const findNodeResp = "/dht/1.0/find-node-resp/"
 // FindNodeProtocol provides the dht protocol FIND-NODE message.
 type FindNodeProtocol interface {
 
-	// Send a find_node request for data about a remote node, known only by id, to a specific known remote node
-	// Results will include 0 or more nodes and up to count nodes which may or may not include data about id (as serverNodeId may not know about it)
-	// reqID: allows the client to match responses with requests by id
-	// serverNodeId - node to send the find request to
+	// FindNode sends a find_node request for data about a remote node, known only by id,
+	// to a specific known remote node.
+	//
+	// Results will include 0 or more nodes and up to count nodes which may or may not include
+	// data about id (as serverNodeId may not know about it).
+	//
+	// reqID: allows the client to match responses with requests by id.
+	//
+	// serverNodeId - node to send the find request to.
+	//
 	// id - node id to find
-
-	// this should really be named FindClosestNodes
+	// TODO(): this should really be named FindClosestNodes
 	FindNode(reqID []byte, serverNodeID string, id string, callback chan FindNodeResp) error
 }
 
@@ -79,7 +85,7 @@ func NewFindNodeProtocol(s Swarm) FindNodeProtocol {
 const maxNearestNodesResults = 20
 const tableQueryTimeout = time.Duration(time.Minute * 1)
 
-// Send a single find node request to a remote node
+// Send a single find node request to a remote node.
 // id: base58 encoded remote node id
 func (p *findNodeProtocolImpl) FindNode(reqID []byte, serverNodeID string, id string, callback chan FindNodeResp) error {
 

--- a/p2p/handshake.go
+++ b/p2p/handshake.go
@@ -11,13 +11,14 @@ import (
 	"io"
 	"time"
 
+	"strings"
+
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/gogo/protobuf/proto"
 	"github.com/spacemeshos/go-spacemesh/crypto"
 	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/p2p/nodeconfig"
 	"github.com/spacemeshos/go-spacemesh/p2p/pb"
-	"strings"
 )
 
 // HandshakeReq specifies the handshake protocol request message identifier. pattern is [protocol][version][method-name].
@@ -78,9 +79,13 @@ func (n *handshakeDataImp) SetError(err error) {
 }
 
 // HandshakeProtocol specifies the handshake protocol.
+//
 // Node1 -> Node 2: Req(HandshakeData)
+//
 // Node2 -> Node 1: Resp(HandshakeData)
-// After response is processed by node1 both sides have an auth session with a secret ephemeral aes sym key.
+//
+// After response is processed by node1 both sides have an auth session with a secret ephemeral
+// aes sym key.
 type HandshakeProtocol interface {
 	CreateSession(peer Peer)
 	RegisterNewSessionCallback(callback chan HandshakeData) // register a channel to receive session state changes

--- a/p2p/handshake.go
+++ b/p2p/handshake.go
@@ -88,7 +88,8 @@ func (n *handshakeDataImp) SetError(err error) {
 // aes sym key.
 type HandshakeProtocol interface {
 	CreateSession(peer Peer)
-	RegisterNewSessionCallback(callback chan HandshakeData) // register a channel to receive session state changes
+	// RegisterNewSessionCallback registers a channel to receive session state changes
+	RegisterNewSessionCallback(callback chan HandshakeData)
 }
 
 type handshakeProtocolImpl struct {

--- a/p2p/localnodeimpl.go
+++ b/p2p/localnodeimpl.go
@@ -3,6 +3,8 @@ package p2p
 import (
 	"encoding/hex"
 	"fmt"
+	"time"
+
 	"github.com/gogo/protobuf/proto"
 	"github.com/spacemeshos/go-spacemesh/crypto"
 	"github.com/spacemeshos/go-spacemesh/log"
@@ -11,7 +13,6 @@ import (
 	"github.com/spacemeshos/go-spacemesh/p2p/nodeconfig"
 	"github.com/spacemeshos/go-spacemesh/p2p/pb"
 	"gopkg.in/op/go-logging.v1"
-	"time"
 )
 
 // LocalNode implementation.
@@ -99,7 +100,8 @@ func (n *localNodeImp) Pretty() string {
 	return n.pubKey.Pretty()
 }
 
-// TCPAddress returns the TCP address that this node is listening on for incoming network connections.
+// TCPAddress returns the TCP address that this node is listening on
+// for incoming network connections.
 func (n *localNodeImp) TCPAddress() string {
 	return n.tcpAddress
 }
@@ -109,7 +111,8 @@ func (n *localNodeImp) PubTCPAddress() string {
 	return n.pubTCPAddress
 }
 
-// RefreshPubTCPAddress attempts to refresh the node public ip address and returns true if it was able to do so.
+// RefreshPubTCPAddress attempts to refresh the node public ip
+// address and returns true if it was able to do so.
 func (n *localNodeImp) RefreshPubTCPAddress() bool {
 
 	// Figure out node public ip address
@@ -139,7 +142,8 @@ func (n *localNodeImp) PublicKey() crypto.PublicKey {
 	return n.pubKey
 }
 
-// SignToString signs a protobufs message with this node's private key, and returns a hex-encoded string signature.
+// SignToString signs a protobufs message with this node's private key,
+// and returns a hex-encoded string signature.
 func (n *localNodeImp) SignToString(data proto.Message) (string, error) {
 	sign, err := n.Sign(data)
 	if err != nil {
@@ -148,7 +152,8 @@ func (n *localNodeImp) SignToString(data proto.Message) (string, error) {
 	return hex.EncodeToString(sign), nil
 }
 
-// Sign signs a protobufs message with this node's private key and returns the raw signature bytes.
+// Sign signs a protobufs message with this node's private key and returns
+// the raw signature bytes.
 func (n *localNodeImp) Sign(data proto.Message) ([]byte, error) {
 	bin, err := proto.Marshal(data)
 	if err != nil {

--- a/p2p/net/conn.go
+++ b/p2p/net/conn.go
@@ -1,14 +1,16 @@
 package net
 
 import (
+	"net"
+	"time"
+
 	"github.com/spacemeshos/go-spacemesh/crypto"
 	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/p2p/delimited"
-	"net"
-	"time"
 )
 
-// Connection is a closeable network connection, that can send and receive messages from a remote instance.
+// Connection is a closeable network connection, that can send and receive messages from
+// a remote instance.
 // Connection is an io.Writer and an io.Closer.
 type Connection interface {
 	ID() string
@@ -54,13 +56,13 @@ type OutgoingMessage struct {
 // ConnectionSource specifies the connection originator - local or remote node.
 type ConnectionSource int
 
-// ConnectionSource values
+// ConnectionSource values.
 const (
 	Local ConnectionSource = iota
 	Remote
 )
 
-// A network connection supporting full-duplex messaging
+// A network connection supporting full-duplex messaging.
 type connectionImpl struct {
 
 	// metadata for logging / debugging
@@ -76,7 +78,7 @@ type connectionImpl struct {
 	net  Net      // network context
 }
 
-// Create a new connection wrapping a net.Conn with a provided connection manager
+// Create a new connection wrapping a net.Conn with a provided connection manager.
 func newConnection(conn net.Conn, n Net, s ConnectionSource) Connection {
 
 	// todo parametrize incoming msgs chan buffer size - hard-coded for now
@@ -138,8 +140,8 @@ func (c *connectionImpl) LastOpTime() time.Time {
 	return c.lastOpTime
 }
 
-// Push outgoing message to the connections
-// Read from the incoming new messages and send down the connection
+// Push outgoing message to the connections.
+// Read from the incoming new messages and send down the connection.
 func (c *connectionImpl) beginEventProcessing() {
 
 Loop:

--- a/p2p/net/network.go
+++ b/p2p/net/network.go
@@ -2,19 +2,23 @@ package net
 
 import (
 	"fmt"
-	"github.com/spacemeshos/go-spacemesh/log"
-	"github.com/spacemeshos/go-spacemesh/p2p/nodeconfig"
 	"net"
 	"time"
+
+	"github.com/spacemeshos/go-spacemesh/log"
+	"github.com/spacemeshos/go-spacemesh/p2p/nodeconfig"
 )
 
-// Net is a connection manager able to dial remote endpoints
-// Net clients should register all callbacks
-// Connections may be initiated by DialTCP() or by remote clients connecting to the listen address
-// ConnManager includes a TCP server, and a TCP client
-// It provides full duplex messaging functionality over the same tcp/ip connection
-// Network should not know about higher-level networking types such as remoteNode, swarm and networkSession
-// Network main client is the swarm
+// Net is a connection manager able to dial remote endpoints.
+// Net clients should register all callbacks.
+//
+// Connections may be initiated by DialTCP() or by remote clients connecting to the listen address.
+// ConnManager includes a TCP server, and a TCP client.
+//
+// It provides full duplex messaging functionality over the same tcp/ip connection.
+// Network should not know about higher-level networking types such as remoteNode,
+// swarm and networkSession.
+// Network main client is the swarm.
 // Net has no channel events processing loops - clients are responsible for polling these channels and popping events from them
 type Net interface {
 	DialTCP(address string, timeOut time.Duration, keepAlive time.Duration) (Connection, error) // Connect to a remote node. Can send when no error.
@@ -44,7 +48,7 @@ type netImpl struct {
 }
 
 // NewNet creates a new network.
-// It attempts to tcp listen on address. e.g. localhost:1234 .
+// It attempts to tcp listen on address. e.g. localhost:1234.
 func NewNet(tcpListenAddress string, config nodeconfig.Config) (Net, error) {
 
 	n := &netImpl{
@@ -93,7 +97,7 @@ func (n *netImpl) GetMessageSendErrors() chan MessageSendError {
 	return n.messageSendErrors
 }
 
-// Dial a remote server with provided time out
+// Dial a remote server with provided time out.
 // address:: ip:port
 // Returns established connection that local clients can send messages to or error if failed
 // to establish a connection

--- a/p2p/node/remotenodedata.go
+++ b/p2p/node/remotenodedata.go
@@ -2,16 +2,17 @@ package node
 
 import (
 	"fmt"
+	"strings"
+	"time"
+
 	"github.com/btcsuite/btcutil/base58"
 	"github.com/spacemeshos/go-spacemesh/p2p/dht"
 	"github.com/spacemeshos/go-spacemesh/p2p/pb"
-	"strings"
-	"time"
 )
 
-// RemoteNodeData defines basic remote node data
-// Outside of swarm local node works with RemoteNodeData and not with Peers
-// Peers should only be used internally by swarm
+// RemoteNodeData defines basic remote node data.
+// Outside of swarm local node works with RemoteNodeData and not with Peers.
+// Peers should only be used internally by swarm.
 type RemoteNodeData interface {
 	ID() string    // base58 encoded node key/id
 	IP() string    // node tcp listener e.g. 127.0.0.1:3038
@@ -36,7 +37,8 @@ type remoteNodeDataImpl struct {
 }
 
 // ToNodeInfo returns marshaled protobufs node infos slice from a slice of RemoteNodeData.
-// filterId: node id to exclude from the result
+//
+// filterId: node id to exclude from the result.
 func ToNodeInfo(nodes []RemoteNodeData, filterID string) []*pb.NodeInfo {
 	// init empty slice
 	res := []*pb.NodeInfo{}
@@ -55,7 +57,9 @@ func ToNodeInfo(nodes []RemoteNodeData, filterID string) []*pb.NodeInfo {
 }
 
 // PickFindNodeServers picks up to count server who haven't been queried recently.
+//
 // nodeId - the target node id of this find node operation.
+//
 // Used in KAD node discovery.
 func PickFindNodeServers(nodes []RemoteNodeData, nodeID string, count int) []RemoteNodeData {
 
@@ -110,7 +114,7 @@ func FromNodeInfos(nodes []*pb.NodeInfo) []RemoteNodeData {
 	return res
 }
 
-// NewRemoteNodeData creates a new RemoteNodeData
+// NewRemoteNodeData creates a new RemoteNodeData.
 func NewRemoteNodeData(id string, ip string) RemoteNodeData {
 	bytes := base58.Decode(id)
 	dhtID := dht.NewIDFromNodeKey(bytes)
@@ -122,7 +126,8 @@ func NewRemoteNodeData(id string, ip string) RemoteNodeData {
 	}
 }
 
-// NewRemoteNodeDataFromString creates a remote node from a string in the following format: 126.0.0.1:3572/QmcjTLy94HGFo4JoYibudGeBV2DSBb6E4apBjFsBGnMsWa .
+// NewRemoteNodeDataFromString creates a remote node from a string in the following format:
+// 126.0.0.1:3572/QmcjTLy94HGFo4JoYibudGeBV2DSBb6E4apBjFsBGnMsWa .
 func NewRemoteNodeDataFromString(data string) RemoteNodeData {
 	items := strings.Split(data, "/")
 	if len(items) != 2 {
@@ -131,12 +136,12 @@ func NewRemoteNodeDataFromString(data string) RemoteNodeData {
 	return NewRemoteNodeData(items[1], items[0])
 }
 
-// GetLastFindNodeCall returns the time of the last find node call
+// GetLastFindNodeCall returns the time of the last find node call.
 func (rn *remoteNodeDataImpl) GetLastFindNodeCall(nodeID string) time.Time {
 	return rn.lastFindNodeCall[nodeID]
 }
 
-// SetLastFindNodeCall updates the time of the last find node call
+// SetLastFindNodeCall updates the time of the last find node call.
 func (rn *remoteNodeDataImpl) SetLastFindNodeCall(nodeID string, t time.Time) {
 	rn.lastFindNodeCall[nodeID] = t
 }

--- a/p2p/node/sorter.go
+++ b/p2p/node/sorter.go
@@ -2,8 +2,9 @@ package node
 
 import (
 	"container/list"
-	"github.com/spacemeshos/go-spacemesh/p2p/dht"
 	"sort"
+
+	"github.com/spacemeshos/go-spacemesh/p2p/dht"
 )
 
 // PeerDistance defines a distance from a node expressed as a dht id.
@@ -12,7 +13,7 @@ type PeerDistance struct {
 	Distance dht.ID
 }
 
-// PeerSorter is a sort.Interface of RemoteNodeData by XOR distance
+// PeerSorter is a sort.Interface of RemoteNodeData by XOR distance.
 type PeerSorter []*PeerDistance
 
 func (p PeerSorter) Len() int      { return len(p) }
@@ -21,7 +22,7 @@ func (p PeerSorter) Less(a, b int) bool {
 	return p[a].Distance.Less(p[b].Distance)
 }
 
-// CopyPeersFromList copies peers from the list and returns a PeerSorter for the list
+// CopyPeersFromList copies peers from the list and returns a PeerSorter for the list.
 func CopyPeersFromList(target dht.ID, dest PeerSorter, src *list.List) PeerSorter {
 	for e := src.Front(); e != nil; e = e.Next() {
 		p := e.Value.(RemoteNodeData)

--- a/p2p/nodeconfig/flags.go
+++ b/p2p/nodeconfig/flags.go
@@ -39,7 +39,7 @@ var (
 		Destination: &ConfigValues.ConnKeepAlive.string,
 	})
 
-	// NetworkIDFlag is a flag that holds the network id the node will run on
+	// NetworkIDFlag is a flag that holds the network id the node will run on.
 	NetworkIDFlag = altsrc.NewIntFlag(cli.IntFlag{
 		Name:        "network-id",
 		Usage:       "NetworkID to run on (0 - mainnet, 1 - testnet)",

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -9,9 +9,9 @@ import (
 
 // Peer is a remote network node.
 // At minimum local node knows its id (public key) and announced tcp address/port.
-// Peers are maintained by the swarm and are not visible to higher-level types on the network stack
-// All Peer methods are NOT thread-safe - they are designed to be used only from a singleton Swarm type
-// Peer handles swarm sessions and net connections with a remote node
+// Peers are maintained by the swarm and are not visible to higher-level types on the network stack.
+// All Peer methods are NOT thread-safe - they are designed to be used only from a singleton Swarm type.
+// Peer handles swarm sessions and net connections with a remote node.
 type Peer interface {
 	ID() []byte     // node id is public key bytes
 	String() string // node public key string
@@ -24,13 +24,13 @@ type Peer interface {
 
 	GetSessions() map[string]NetworkSession
 
-	// returns an authenticated session with the node if one exists
+	// GetAuthenticatedSession returns an authenticated session with the node if one exists
 	GetAuthenticatedSession() NetworkSession
 
-	// returns an active connection with the node if we have one
+	// GetActiveConnection returns an active connection with the node if we have one
 	GetActiveConnection() net.Connection
 
-	// returns RemoteNodeData for this peer
+	// GetRemoteNodeData returns RemoteNodeData for this peer
 	GetRemoteNodeData() node.RemoteNodeData
 }
 

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -24,13 +24,14 @@ type Peer interface {
 
 	GetSessions() map[string]NetworkSession
 
-	// GetAuthenticatedSession returns an authenticated session with the node if one exists
+	// GetAuthenticatedSession returns an authenticated session with
+	// the node if one exists.
 	GetAuthenticatedSession() NetworkSession
 
-	// GetActiveConnection returns an active connection with the node if we have one
+	// GetActiveConnection returns an active connection with the node if we have one.
 	GetActiveConnection() net.Connection
 
-	// GetRemoteNodeData returns RemoteNodeData for this peer
+	// GetRemoteNodeData returns RemoteNodeData for this peer.
 	GetRemoteNodeData() node.RemoteNodeData
 }
 

--- a/p2p/ping.go
+++ b/p2p/ping.go
@@ -2,6 +2,7 @@ package p2p
 
 import (
 	"encoding/hex"
+
 	"github.com/gogo/protobuf/proto"
 	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/p2p/pb"
@@ -10,11 +11,12 @@ import (
 const pingReq = "/ping/1.0/ping-req/"
 const pingResp = "/ping/1.0/ping-resp/"
 
-// Ping protocol
-// An example of a simple app-level p2p protocol
+// Ping protocol:
+// An example of a simple app-level p2p protocol.
 type Ping interface {
 
 	// Send sends a ping request to a remote node.
+	//
 	// reqIdD: allows the client to match responses with requests by id.
 	Send(msg string, reqID []byte, remoteNodeID string)
 
@@ -22,14 +24,14 @@ type Ping interface {
 	Register(callback chan SendPingResp)
 }
 
-// SendPingResp contains pong response data or error
+// SendPingResp contains pong response data or error.
 type SendPingResp struct {
 	*pb.PingRespData
 	err   error
 	reqID []byte
 }
 
-// Callbacks is a channel of SendPingResp channels
+// Callbacks is a channel of SendPingResp channels.
 type Callbacks chan chan SendPingResp
 
 type pingProtocolImpl struct {
@@ -43,7 +45,7 @@ type pingProtocolImpl struct {
 	callbacksRegReq   Callbacks // a channel of channels that receive callbacks to send ping
 }
 
-// NewPingProtocol creates a new Ping protocol implementation
+// NewPingProtocol creates a new Ping protocol implementation.
 func NewPingProtocol(s Swarm) Ping {
 
 	p := &pingProtocolImpl{

--- a/p2p/session.go
+++ b/p2p/session.go
@@ -5,15 +5,17 @@ import (
 	"crypto/cipher"
 	"encoding/hex"
 	"errors"
+	"time"
+
 	"github.com/spacemeshos/go-spacemesh/crypto"
 	"github.com/spacemeshos/go-spacemesh/log"
-	"time"
 )
 
 // NetworkSession is an authenticated network session between 2 peers.
 // Sessions may be used between 'connections' until they expire.
 // Session provides the encryptor/decryptor for all messages exchanged between 2 peers.
-// enc/dec is using an ephemeral sym key exchanged securely between the peers via the handshake protocol
+// enc/dec is using an ephemeral sym key exchanged securely between the peers via the
+// handshake protocol.
 // The handshake protocol goal is to create an authenticated network session.
 type NetworkSession interface {
 	ID() []byte         // Unique session id
@@ -51,12 +53,12 @@ type NetworkSessionImpl struct {
 	blockDecrypter cipher.BlockMode
 }
 
-//LocalNodeID returns the session's local node id.
+// LocalNodeID returns the session's local node id.
 func (n *NetworkSessionImpl) LocalNodeID() string {
 	return n.localNodeID
 }
 
-//RemoteNodeID returns the session's remote node id.
+// RemoteNodeID returns the session's remote node id.
 func (n *NetworkSessionImpl) RemoteNodeID() string {
 	return n.remoteNodeID
 }
@@ -129,7 +131,7 @@ func (n *NetworkSessionImpl) Decrypt(in []byte) ([]byte, error) {
 	return clearText, nil
 }
 
-// NewNetworkSession creates a new network session based on provided data
+// NewNetworkSession creates a new network session based on provided data.
 func NewNetworkSession(id, keyE, keyM, pubKey []byte, localNodeID, remoteNodeID string) (NetworkSession, error) {
 	s := &NetworkSessionImpl{
 		id:            id,

--- a/p2p/swarm.go
+++ b/p2p/swarm.go
@@ -3,32 +3,40 @@
 package p2p
 
 import (
+	"strconv"
+
 	"github.com/spacemeshos/go-spacemesh/p2p/dht/table"
 	"github.com/spacemeshos/go-spacemesh/p2p/node"
-	"strconv"
 )
 
-// Swarm is p2p virtual network of spacemesh nodes as viewed by a local node
+// Swarm is p2p virtual network of spacemesh nodes as viewed by a local node.
 type Swarm interface {
 
-	// Send a message to a specific remote node based just on its id without knowing its ip address
-	// In this case we will try to locate the node via dht node search
-	// and send the message if we obtained node ip address and were able to connect to it
+	// SendMessage sends a message to a specific remote node based just on its id
+	// without knowing its ip address.
+	// In this case we will try to locate the node via dht node search,
+	// and send the message if we obtained node ip address and were able to connect to it.
+	//
 	// req.msg should be marshaled protocol message. e.g. something like pb.PingReqData
+	//
 	// This is designed for standard messages that require a session
-	// This method is designed to be used by protocols implementations to send message to any destination
+	// This method is designed to be used by protocols implementations to send message
+	// to any destination
 	SendMessage(req SendMessageReq)
 
-	// TODO: support sending a message to all connected peers without any dest id provided by caller
+	// TODO(devs): support sending a message to all connected peers without any dest id provided by caller
 
-	// Register a node with the swarm based on its id and tcp address but don't attempt to connect to it
+	// RegisterNode registers a node with the swarm based on its id and tcp address but don't
+	// attempt to connect to it
 	RegisterNode(data node.RemoteNodeData)
 
-	// Attempt to establish a session with a remote node with a known id and tcp address
+	// ConnectTo attempts to establish a session with a remote node with a known
+	// id and tcp address.
 	// Used for bootstrapping known bootstrap nodes
 	ConnectTo(req node.RemoteNodeData)
 
-	// Connect to count random nodes - used for bootstrapping the swarm
+	// ConnectToRandomNodes connects to count random nodes - used for bootstrapping
+	// the swarm
 	ConnectToRandomNodes(count int)
 
 	// Forcefully disconnect form a node - close any connections and sessions with it
@@ -37,14 +45,14 @@ type Swarm interface {
 	// Send a handshake protocol message that is used to establish a session
 	sendHandshakeMessage(req SendMessageReq)
 
-	// Register a callback channel for state changes related to remote nodes
+	// Register a callback channel for state changes related to remote nodes.
 	// Currently used for testing network bootstrapping
 	RegisterNodeEventsCallback(callback NodeEventCallback)
 
-	// todo: allow client to register callback to get notified when swarm has shut down
+	// Todo(devs): allow client to register callback to get notified when swarm has shut down
 	Shutdown()
 
-	// services getters
+	// Services getters.
 	GetDemuxer() Demuxer
 	GetLocalNode() LocalNode
 
@@ -68,19 +76,19 @@ type SendError struct {
 	err   error  // error - nil if message was sent
 }
 
-// NodeResp defines node response data
+// NodeResp defines node response data.
 type NodeResp struct {
 	peerID string
 	err    error
 }
 
-// NodeEvent specifies node state data
+// NodeEvent specifies node state data.
 type NodeEvent struct {
 	PeerID string
 	State  NodeState
 }
 
-// NodeEventCallback is a channel of NodeEvents
+// NodeEventCallback is a channel of NodeEvents.
 type NodeEventCallback chan NodeEvent
 
 // NodeState specifies the node's connectivity state.

--- a/p2p/swarm.go
+++ b/p2p/swarm.go
@@ -17,36 +17,36 @@ type Swarm interface {
 	// In this case we will try to locate the node via dht node search,
 	// and send the message if we obtained node ip address and were able to connect to it.
 	//
-	// req.msg should be marshaled protocol message. e.g. something like pb.PingReqData
+	// req.msg should be marshaled protocol message. e.g. something like pb.PingReqData;
 	//
-	// This is designed for standard messages that require a session
+	// This is designed for standard messages that require a session.
 	// This method is designed to be used by protocols implementations to send message
-	// to any destination
+	// to any destination.
 	SendMessage(req SendMessageReq)
 
 	// TODO(devs): support sending a message to all connected peers without any dest id provided by caller
 
 	// RegisterNode registers a node with the swarm based on its id and tcp address but don't
-	// attempt to connect to it
+	// attempt to connect to it.
 	RegisterNode(data node.RemoteNodeData)
 
 	// ConnectTo attempts to establish a session with a remote node with a known
 	// id and tcp address.
-	// Used for bootstrapping known bootstrap nodes
+	// Used for bootstrapping known bootstrap nodes.
 	ConnectTo(req node.RemoteNodeData)
 
 	// ConnectToRandomNodes connects to count random nodes - used for bootstrapping
-	// the swarm
+	// the swarm.
 	ConnectToRandomNodes(count int)
 
-	// Forcefully disconnect form a node - close any connections and sessions with it
+	// Forcefully disconnect form a node - close any connections and sessions with it.
 	DisconnectFrom(req node.RemoteNodeData)
 
-	// Send a handshake protocol message that is used to establish a session
+	// Send a handshake protocol message that is used to establish a session.
 	sendHandshakeMessage(req SendMessageReq)
 
 	// Register a callback channel for state changes related to remote nodes.
-	// Currently used for testing network bootstrapping
+	// Currently used for testing network bootstrapping.
 	RegisterNodeEventsCallback(callback NodeEventCallback)
 
 	// Todo(devs): allow client to register callback to get notified when swarm has shut down
@@ -56,7 +56,7 @@ type Swarm interface {
 	GetDemuxer() Demuxer
 	GetLocalNode() LocalNode
 
-	// used by protocols and for testing
+	// These used by protocols and for testing.
 	getHandshakeProtocol() HandshakeProtocol
 	getRoutingTable() table.RoutingTable
 	getFindNodeProtocol() FindNodeProtocol

--- a/p2p/swarmhandlers.go
+++ b/p2p/swarmhandlers.go
@@ -17,8 +17,8 @@ import (
 // These should only be called from the swarms event processing main loop
 // or by other internal handlers but not from a random type or go routine
 
-// Handles a local request to register a remote node in the swarm
-// Register adds info about this node but doesn't attempt to connect to it
+// Handles a local request to register a remote node in the swarm.
+// Register adds info about this node but doesn't attempt to connect to it.
 func (s *swarmImpl) onRegisterNodeRequest(n node.RemoteNodeData) {
 
 	if s.peers[n.ID()] != nil {
@@ -41,7 +41,7 @@ func (s *swarmImpl) onRegisterNodeRequest(n node.RemoteNodeData) {
 
 }
 
-// Handles a local request to connect to a remote node
+// Handles a local request to connect to a remote node.
 func (s *swarmImpl) onConnectionRequest(req node.RemoteNodeData) {
 
 	s.localNode.Info("Local request to connect to node %s", req.Pretty())
@@ -108,7 +108,7 @@ func (s *swarmImpl) onConnectionRequest(req node.RemoteNodeData) {
 	}
 }
 
-// callback from handshake protocol when session state changes
+// callback from handshake protocol when session state changes.
 func (s *swarmImpl) onNewSession(data HandshakeData) {
 
 	if err := data.GetError(); err != nil {
@@ -277,7 +277,7 @@ func (s *swarmImpl) onRemoteClientConnected(c net.Connection) {
 	}
 }
 
-// Processes an incoming handshake protocol message
+// Processes an incoming handshake protocol message.
 func (s *swarmImpl) onRemoteClientHandshakeMessage(msg net.IncomingMessage) {
 
 	data := &pb.HandshakeData{}
@@ -326,8 +326,8 @@ func (s *swarmImpl) onRemoteClientHandshakeMessage(msg net.IncomingMessage) {
 	s.demuxer.RouteIncomingMessage(NewIncomingMessage(sender, data.Protocol, msg.Message))
 }
 
-// Pre-process a protocol message from a remote client handling decryption and authentication
-// Authenticated messages are forwarded to the demuxer for demuxing to protocol handlers
+// Pre-process a protocol message from a remote client handling decryption and authentication.
+// Authenticated messages are forwarded to the demuxer for demuxing to protocol handlers.
 func (s *swarmImpl) onRemoteClientProtocolMessage(msg net.IncomingMessage, c *pb.CommonMessageData) {
 
 	// Locate the session

--- a/p2p/swarmimpl.go
+++ b/p2p/swarmimpl.go
@@ -1,11 +1,12 @@
 package p2p
 
 import (
+	"time"
+
 	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/p2p/dht/table"
 	"github.com/spacemeshos/go-spacemesh/p2p/node"
 	"github.com/spacemeshos/go-spacemesh/p2p/nodeconfig"
-	"time"
 
 	//"github.com/spacemeshos/go-spacemesh/p2p/dht/table"
 	"github.com/spacemeshos/go-spacemesh/p2p/net"
@@ -120,12 +121,12 @@ func NewSwarm(tcpAddress string, l LocalNode) (Swarm, error) {
 	return s, err
 }
 
-// Register an event handler callback for connection state events
+// Register an event handler callback for connection state events.
 func (s *swarmImpl) RegisterNodeEventsCallback(callback NodeEventCallback) {
 	s.nec = append(s.nec, callback)
 }
 
-// Sends a connection event to all registered clients
+// Sends a connection event to all registered clients.
 func (s *swarmImpl) sendNodeEvent(peerID string, state NodeState) {
 
 	s.localNode.Info(">> Node event for <%s>. State: %+v", peerID[:6], state)
@@ -169,7 +170,7 @@ func (s *swarmImpl) GetLocalNode() LocalNode {
 	return s.localNode
 }
 
-// Starts the bootstrap process
+// Starts the bootstrap process.
 func (s *swarmImpl) bootstrap() {
 
 	s.localNode.Info("Starting bootstrap...")
@@ -196,7 +197,7 @@ func (s *swarmImpl) bootstrap() {
 	}
 }
 
-// Connect up to count random nodes
+// Connect up to count random nodes.
 func (s *swarmImpl) ConnectToRandomNodes(count int) {
 
 	if count <= 0 {

--- a/p2p/testshelpers.go
+++ b/p2p/testshelpers.go
@@ -2,18 +2,21 @@ package p2p
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/spacemeshos/go-spacemesh/crypto"
 	"github.com/spacemeshos/go-spacemesh/p2p/node"
 	"github.com/spacemeshos/go-spacemesh/p2p/nodeconfig"
-	"testing"
 )
 
-// GenerateTestNode generates a local test node without persisting data to local store and with default config value.
+// GenerateTestNode generates a local test node without persisting data to
+// local store and with default config value.
 func GenerateTestNode(t *testing.T) (LocalNode, Peer) {
 	return GenerateTestNodeWithConfig(t, nodeconfig.ConfigValues)
 }
 
-// GenerateTestNodeWithConfig creates a local test node without persisting data to local store.
+// GenerateTestNodeWithConfig creates a local test node without persisting
+// data to local store.
 func GenerateTestNodeWithConfig(t *testing.T, config nodeconfig.Config) (LocalNode, Peer) {
 
 	port := crypto.GetRandomUserPort()

--- a/p2p/timesync/ntp.go
+++ b/p2p/timesync/ntp.go
@@ -4,19 +4,20 @@ package timesync
 import (
 	"encoding/binary"
 	"fmt"
-	"github.com/spacemeshos/go-spacemesh/p2p/nodeconfig"
 	"math/rand"
 	"net"
 	"sort"
 	"time"
+
+	"github.com/spacemeshos/go-spacemesh/p2p/nodeconfig"
 )
 
 const (
-	// MaxAllowedMessageDrift is the time we limit we receive and handle delivered messages within
+	// MaxAllowedMessageDrift is the time we limit we receive and handle delivered messages within.
 	MaxAllowedMessageDrift = 10 * time.Minute
-	// NtpOffset is 70 years in seconds since ntp counts from 1900 and unix from 1970
+	// NtpOffset is 70 years in seconds since ntp counts from 1900 and unix from 1970.
 	NtpOffset = 2208988800
-	// DefaultNtpPort is the ntp protocol port
+	// DefaultNtpPort is the ntp protocol port.
 	DefaultNtpPort = "123"
 )
 
@@ -171,8 +172,8 @@ func ntpTimeDrift() (time.Duration, error) {
 	return all.Average(), nil
 }
 
-// CheckSystemClockDrift is comparing our clock to the collected ntp data
-// return the drift and an error when drift reading failed or exceeds our preset MaxAllowedDrift
+// CheckSystemClockDrift is comparing our clock to the collected ntp data, and
+// returns the drift and an error when drift reading failed or exceeds our preset MaxAllowedDrift
 func CheckSystemClockDrift() (time.Duration, error) {
 	// Read average drift form ntpTimeDrift
 	drift, err := ntpTimeDrift()

--- a/p2p/version.go
+++ b/p2p/version.go
@@ -6,7 +6,8 @@ import (
 	"strings"
 )
 
-// CheckNodeVersion checks if a request version is more recent then the given min version. returns a bool and an error
+// CheckNodeVersion checks if a request version is more recent then the given min version.
+// Returns a bool and an error
 func CheckNodeVersion(reqVersion string, minVersion string) (bool, error) {
 	// TODO : semantic versioning comparison is a pain, refine this or use a lib
 


### PR DESCRIPTION
Related to issue #90.

## What was done ?

- Ensured parameter comments showed on seperate lines.
- Ensured todos matched godoc's `TODO()` specification.
- Added function/method names to prefix certain comments.
- Ensured spacing between start of comments and `//`.
- Added newline spacing to areas detail parameters or rules for a method/function.
- Ran `goimports` on all files.

Most of the comments were originally without issue and only a few changes needed to be made. Please advice in review @avive.

P.S: Due to the change, `Godoc` may take a while to properly show all directories on main page of package. But paths to sub-directories still work. Noticed during confirmation on display.