### PR TITLE
BUG #198 - Session messages encrypt/decrypt order

### DIFF
--- a/p2p/connectionpool/connectionpool.go
+++ b/p2p/connectionpool/connectionpool.go
@@ -4,10 +4,10 @@ import (
 	"github.com/spacemeshos/go-spacemesh/crypto"
 	"github.com/spacemeshos/go-spacemesh/p2p/net"
 
+	"bytes"
 	"errors"
 	"gopkg.in/op/go-logging.v1"
 	"sync"
-	"bytes"
 )
 
 type dialResult struct {

--- a/p2p/dht/findnode_test.go
+++ b/p2p/dht/findnode_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func getTestLogger(test string, args ...interface{}) log.Log {
-	return log.New(fmt.Sprintf(test, args), "", "")
+	return log.New(fmt.Sprintf(test, args...), "", "")
 }
 
 func TestFindNodeProtocol_FindNode(t *testing.T) {

--- a/p2p/net/conn.go
+++ b/p2p/net/conn.go
@@ -68,7 +68,7 @@ type FormattedConnection struct {
 
 type networker interface {
 	HandlePreSessionIncomingMessage(c Connection, msg []byte) error
-	IncomingMessages() chan IncomingMessageEvent
+	EnqueueMessage(ime IncomingMessageEvent)
 	ClosingConnections() chan Connection
 	NetworkID() int8
 }
@@ -91,7 +91,7 @@ func newConnection(conn readWriteCloseAddresser, netw networker, formatter wire.
 		formatter:  formatter,
 		networker:  netw,
 		closeChan:  make(chan struct{}),
-		closed:		0,
+		closed:     0,
 	}
 
 	connection.formatter.Pipe(conn)
@@ -134,7 +134,7 @@ func (c *FormattedConnection) String() string {
 }
 
 func (c *FormattedConnection) publish(message []byte) {
-	c.networker.IncomingMessages() <- IncomingMessageEvent{c, message}
+	c.networker.EnqueueMessage(IncomingMessageEvent{c, message})
 }
 
 // incomingChannel returns the incoming messages channel
@@ -162,9 +162,8 @@ func (c *FormattedConnection) Closed() bool {
 	return atomic.LoadInt32(&c.closed) > 0
 }
 
-
 func (c *FormattedConnection) shutdown(err error) {
-	c.logger.Info("shutdown. err=%v", err)
+	c.logger.Info("shutdown. id=%s err=%v", c.id, err)
 	c.formatter.Close()
 	c.networker.ClosingConnections() <- c
 }
@@ -192,7 +191,7 @@ Loop:
 				}
 			} else {
 				// channel for protocol messages
-				go c.publish(msg)
+				c.publish(msg)
 			}
 
 		case <-c.closeChan:

--- a/p2p/net/conn.go
+++ b/p2p/net/conn.go
@@ -190,7 +190,6 @@ Loop:
 					break Loop
 				}
 			} else {
-				// channel for protocol messages
 				c.publish(msg)
 			}
 

--- a/p2p/net/conn_mock.go
+++ b/p2p/net/conn_mock.go
@@ -52,7 +52,6 @@ func (cm ConnectionMock) Session() NetworkSession {
 	return cm.session
 }
 
-
 func (cm ConnectionMock) IncomingChannel() chan []byte {
 	return nil
 }

--- a/p2p/net/conn_test.go
+++ b/p2p/net/conn_test.go
@@ -33,7 +33,7 @@ func TestSendReceiveMessage(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, len(msg)+1, len(rwcam.WriteOut())) // the +1 is because of the delimited wire format
 	rwcam.SetReadResult(rwcam.WriteOut(), nil)
-	data := <-netw.IncomingMessages()
+	data := <-netw.IncomingMessages()[0]
 	assert.Equal(t, []byte(msg), data.Message)
 }
 

--- a/p2p/net/network.go
+++ b/p2p/net/network.go
@@ -57,8 +57,6 @@ type Net struct {
 	regNewRemoteConn []chan Connection
 	regMutex         sync.RWMutex
 
-	incomingMessages chan IncomingMessageEvent
-
 	queuesCount           uint
 	queueSize             uint
 	incomingMessagesQueue []chan IncomingMessageEvent
@@ -84,7 +82,6 @@ func NewNet(conf config.Config, localEntity *node.LocalNode) (*Net, error) {
 		queuesCount:           qcount,
 		queueSize:             qsize,
 		incomingMessagesQueue: make([]chan IncomingMessageEvent, qcount, qcount),
-		incomingMessages:      make(chan IncomingMessageEvent),
 		closingConnections:    make(chan Connection, 20),
 		config:                conf,
 	}

--- a/p2p/net/network_mock.go
+++ b/p2p/net/network_mock.go
@@ -4,10 +4,10 @@ import (
 	"github.com/spacemeshos/go-spacemesh/crypto"
 	"github.com/spacemeshos/go-spacemesh/log"
 	"gopkg.in/op/go-logging.v1"
+	"math/rand"
 	"net"
 	"sync/atomic"
 	"time"
-	"math/rand"
 )
 
 // ReadWriteCloserMock is a mock of ReadWriteCloserMock
@@ -52,7 +52,7 @@ type NetworkMock struct {
 	regNewRemoteConn []chan Connection
 	networkId        int8
 	closingConn      chan Connection
-	incomingMessages chan IncomingMessageEvent
+	incomingMessages []chan IncomingMessageEvent
 	dialSessionID    []byte
 	logger           *logging.Logger
 }
@@ -63,7 +63,7 @@ func NewNetworkMock() *NetworkMock {
 		regNewRemoteConn: make([]chan Connection, 0),
 		closingConn:      make(chan Connection, 20),
 		logger:           getTestLogger("network mock"),
-		incomingMessages: make(chan IncomingMessageEvent),
+		incomingMessages: []chan IncomingMessageEvent{make(chan IncomingMessageEvent, 256)},
 	}
 }
 
@@ -135,8 +135,13 @@ func (n *NetworkMock) ClosingConnections() chan Connection {
 }
 
 // IncomingMessages return channel of IncomingMessages
-func (n *NetworkMock) IncomingMessages() chan IncomingMessageEvent {
+func (n *NetworkMock) IncomingMessages() []chan IncomingMessageEvent {
 	return n.incomingMessages
+}
+
+// IncomingMessages return channel of IncomingMessages
+func (n *NetworkMock) EnqueueMessage(event IncomingMessageEvent) {
+	n.incomingMessages[0] <- event
 }
 
 // PublishClosingConnection does just that

--- a/p2p/net/network_test.go
+++ b/p2p/net/network_test.go
@@ -38,6 +38,8 @@ func waitForCallbackOrTimeout(t *testing.T, outchan chan Connection, expectedSes
 	}
 }
 
+// TODO: Test queues
+
 func TestHandlePreSessionIncomingMessage(t *testing.T) {
 	//cfg := config.DefaultConfig()
 	localNode, _ := node.GenerateTestNode(t)
@@ -73,5 +75,4 @@ func TestHandlePreSessionIncomingMessage(t *testing.T) {
 	err = remoteNet.HandlePreSessionIncomingMessage(con, data)
 	assert.Error(t, err, "Sent message with wrong networkID")
 	//,_, er = GenerateHandshakeRequestData(localNode.PublicKey(), localNode.PrivateKey(),con.RemotePublicKey(), remoteNet.NetworkID() +1)
-
 }

--- a/p2p/net/network_test.go
+++ b/p2p/net/network_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/spacemeshos/go-spacemesh/p2p/config"
 	"github.com/spacemeshos/go-spacemesh/p2p/node"
 	"github.com/stretchr/testify/assert"
+	"math/rand"
+	"sync"
 	"testing"
 	"time"
 )
@@ -38,7 +40,38 @@ func waitForCallbackOrTimeout(t *testing.T, outchan chan Connection, expectedSes
 	}
 }
 
-// TODO: Test queues
+func Test_sumByteArray(t *testing.T) {
+	bytez := sumByteArray([]byte{0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1})
+	assert.Equal(t, bytez, uint(20))
+	bytez2 := sumByteArray([]byte{0x5, 0x5, 0x5, 0x5, 0x5, 0x5, 0x5, 0x5, 0x5, 0x5, 0x5, 0x5, 0x5, 0x5, 0x5, 0x5, 0x5, 0x5, 0x5, 0x5})
+	assert.Equal(t, bytez2, uint(100))
+}
+
+func TestNet_EnqueueMessage(t *testing.T) {
+	testnodes := 100
+	cfg := config.DefaultConfig()
+	ln, err := node.NewNodeIdentity(cfg, "0.0.0.0:0000", false)
+	assert.NoError(t, err)
+	n, err := NewNet(cfg, ln)
+	assert.NoError(t, err)
+	rnd := rand.New(rand.NewSource(time.Now().UnixNano()))
+	var wg sync.WaitGroup
+	for i := 0; i < testnodes; i++ {
+		wg.Add(1)
+		go func() {
+			rnode := node.GenerateRandomNodeData()
+			sum := sumByteArray(rnode.PublicKey().Bytes())
+			msg := make([]byte, 10, 10)
+			rnd.Read(msg)
+			n.EnqueueMessage(IncomingMessageEvent{NewConnectionMock(rnode.PublicKey()), msg})
+			s := <-n.IncomingMessages()[sum%n.queuesCount]
+			assert.Equal(t, s.Message, msg)
+			assert.Equal(t, s.Conn.RemotePublicKey(), rnode.PublicKey())
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+}
 
 func TestHandlePreSessionIncomingMessage(t *testing.T) {
 	//cfg := config.DefaultConfig()

--- a/p2p/net/session_mock.go
+++ b/p2p/net/session_mock.go
@@ -1,5 +1,7 @@
 package net
 
+import "sync"
+
 // SessionMock is a wonderful fluffy teddybear
 type SessionMock struct {
 	id        []byte
@@ -61,4 +63,8 @@ func (sm *SessionMock) SetEncrypt(res []byte, err error) {
 func (sm *SessionMock) SetDecrypt(res []byte, err error) {
 	sm.decResult = res
 	sm.decError = err
+}
+
+func (n SessionMock) EncryptGuard() *sync.Mutex {
+	return nil
 }

--- a/p2p/node/localnode.go
+++ b/p2p/node/localnode.go
@@ -10,7 +10,7 @@ import (
 // LocalNode implementation.
 type LocalNode struct {
 	Node
-	privKey       crypto.PrivateKey
+	privKey crypto.PrivateKey
 
 	networkID int8
 

--- a/p2p/swarm.go
+++ b/p2p/swarm.go
@@ -54,9 +54,11 @@ type swarm struct {
 
 	// Shutdown the loop
 	shutdown chan struct{} // local request to kill the swarm from outside. e.g when local node is shutting down
+	msgCnt   int
 }
 
-// newSwarm creates a new P2P instance
+// newSwarm creates a new P2P instance, configured by config, if newNode is true it will create a new node identity
+// and not load from disk. it creates a new `net`, connection pool and dht.
 func newSwarm(config config.Config, newNode bool) (*swarm, error) {
 
 	port := config.TCPPort
@@ -88,7 +90,7 @@ func newSwarm(config config.Config, newNode bool) (*swarm, error) {
 		network:          n,
 		cPool:            connectionpool.NewConnectionPool(n, l.PublicKey()),
 		shutdown:         make(chan struct{}), // non-buffered so requests to shutdown block until swarm is shut down
-
+		msgCnt:           0,
 	}
 
 	s.dht = dht.New(l, config.SwarmConfig, s)
@@ -96,6 +98,8 @@ func newSwarm(config config.Config, newNode bool) (*swarm, error) {
 	s.lNode.Debug("Created swarm for local node %s, %s", l.Address(), l.Pretty())
 
 	go s.listenToNetworkMessages()
+
+	go s.updateNewConnections()
 
 	if config.SwarmConfig.Bootstrap {
 		err := s.dht.Bootstrap()
@@ -223,38 +227,48 @@ func (s *swarm) SendMessage(peerPubKey string, protocol string, payload []byte) 
 		return err
 	}
 
-	err = authAuthor(protomessage)
-	if err != nil {
-		return err
-	}
-
 	data, err := proto.Marshal(protomessage)
 	if err != nil {
 		return fmt.Errorf("failed to encode signed message err: %v", err)
 	}
 
+	session.EncryptGuard().Lock()
+
+	// messages must be sent in the same order as the order that the messages were encrypted because the iv used to encrypt
+	// (and therefore decrypt) is the last encrypted block of the previous message that were encrypted
 	encPayload, err := session.Encrypt(data)
 	if err != nil {
+		session.EncryptGuard().Unlock()
 		e := fmt.Errorf("aborting send - failed to encrypt payload: %v", err)
 		return e
 	}
 
+	ts := time.Now().Unix()
+
 	cmd := &pb.CommonMessageData{
 		SessionId: session.ID(),
 		Payload:   encPayload,
-		Timestamp: time.Now().Unix(),
+		Timestamp: ts,
 	}
 
 	final, err := proto.Marshal(cmd)
 	if err != nil {
+		session.EncryptGuard().Unlock()
+		// since the encryption succeeded and the iv was modified for the next message, we must close the connection otherwise
+		// the missing message will prevent the receiver from decrypting any future message
+		s.lNode.Logger.Error("message was encrypted but wasn't sent, closing the connection")
+		conn.Close()
 		e := fmt.Errorf("aborting send - invalid msg format %v", err)
 		return e
 	}
 
 	// finally - send it away!
-	s.lNode.Debug("Sending protocol message down the connection to %v", log.PrettyID(peerPubKey))
+	s.lNode.Debug("Sending protocol message down the connection to %v, ts=%v", log.PrettyID(peerPubKey), ts)
 
-	return conn.Send(final)
+	err = conn.Send(final)
+	session.EncryptGuard().Unlock()
+
+	return err
 }
 
 // RegisterProtocol registers an handler for `protocol`
@@ -297,12 +311,33 @@ func (s *swarm) updateConnection(nc net.Connection) {
 
 // listenToNetworkMessages is waiting for network events from net as new connections or messages and handles them.
 func (s *swarm) listenToNetworkMessages() {
+
+	// We listen to each of the messages queues we get from `net
+	// It's net's responsibility to distribute the messages to the queues
+	// in a way that they're processing order will work
+	// swarm process all the queues concurrently but synchronously for each queue
+
+	netqueues := s.network.IncomingMessages()
+	for nq := range netqueues { // run a separate worker for each queue.
+		go func(c chan net.IncomingMessageEvent) {
+			for {
+				select {
+				case msg := <-c:
+					s.processMessage(msg)
+				case <-s.shutdown:
+					return
+				}
+			}
+		}(netqueues[nq])
+	}
+
+}
+
+func (s *swarm) updateNewConnections() {
 	newconnections := s.network.SubscribeOnNewRemoteConnections()
 Loop:
 	for {
 		select {
-		case ime := <-s.network.IncomingMessages():
-			go s.processMessage(ime)
 		case nc := <-newconnections:
 			go s.updateConnection(nc)
 		case <-s.shutdown:
@@ -358,6 +393,11 @@ var (
 // c: connection we got this message on
 // msg: binary protobufs encoded data
 func (s *swarm) onRemoteClientMessage(msg net.IncomingMessageEvent) error {
+
+	if msg.Message == nil || msg.Conn == nil {
+		return ErrBadFormat
+	}
+
 	s.lNode.Debug(fmt.Sprintf("Handle message from <<  %v", msg.Conn.RemotePublicKey().Pretty()))
 	c := &pb.CommonMessageData{}
 	err := proto.Unmarshal(msg.Message, c)
@@ -368,7 +408,7 @@ func (s *swarm) onRemoteClientMessage(msg net.IncomingMessageEvent) error {
 	// check that the message was send within a reasonable time
 	if ok := timesync.CheckMessageDrift(c.Timestamp); !ok {
 		// TODO: consider kill connection with this node and maybe blacklist
-		// TODO : Also consider moving send timestamp into metadata.
+		// TODO : Also consider moving send timestamp into metadata(encrypted).
 		return ErrOutOfSync
 	}
 
@@ -416,6 +456,7 @@ func (s *swarm) onRemoteClientMessage(msg net.IncomingMessageEvent) error {
 	}
 
 	s.lNode.Debug("Forwarding message to protocol")
+
 	msgchan <- protocolMessage{remoteNode, pm.Payload}
 
 	return nil

--- a/p2p/swarm.go
+++ b/p2p/swarm.go
@@ -96,9 +96,9 @@ func newSwarm(config config.Config, newNode bool) (*swarm, error) {
 
 	s.lNode.Debug("Created swarm for local node %s, %s", l.Address(), l.Pretty())
 
-	go s.listenToNetworkMessages()
-
 	go s.updateNewConnections()
+
+	s.listenToNetworkMessages() // fires up a goroutine for each queue of messages
 
 	if config.SwarmConfig.Bootstrap {
 		err := s.dht.Bootstrap()
@@ -394,6 +394,7 @@ var (
 func (s *swarm) onRemoteClientMessage(msg net.IncomingMessageEvent) error {
 
 	if msg.Message == nil || msg.Conn == nil {
+		s.lNode.Fatal("Fatal error: Got nil message or connection")
 		return ErrBadFormat
 	}
 

--- a/p2p/swarm.go
+++ b/p2p/swarm.go
@@ -54,6 +54,7 @@ type swarm struct {
 
 	// Shutdown the loop
 	shutdown chan struct{} // local request to kill the swarm from outside. e.g when local node is shutting down
+	msgCnt   int
 }
 
 // newSwarm creates a new P2P instance, configured by config, if newNode is true it will create a new node identity

--- a/p2p/swarm_test.go
+++ b/p2p/swarm_test.go
@@ -85,7 +85,7 @@ func TestSwarm_processMessage(t *testing.T) {
 	r := node.GenerateRandomNodeData()
 	c := &net.ConnectionMock{}
 	c.SetRemotePublicKey(r.PublicKey())
-	ime := net.IncomingMessageEvent{Message: nil, Conn: c}
+	ime := net.IncomingMessageEvent{Message: []byte("0"), Conn: c}
 	s.processMessage(ime) // should error
 
 	assert.True(t, c.Closed())


### PR DESCRIPTION
fixes #198 

To solve the bug, we serialized the message encryption and sending by using a Mutex exported from the `NetworkSession`  interface. this makes sure the last message encrypted is sent right.
To serialize message receiving, we stopped publishing from `conn.go` in a goroutine, extended the incoming messages queue in `net` to be multiple queues and distribute messages to these queues according to the result of the combination of both public keys sorted, hashed and summed to an integer.
this way do process messages concurrently, but synchronously for each connections.
