### PR TITLE
Fix for issue 194

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -28,7 +28,7 @@ func TestApp(t *testing.T) {
 	assert.Equal(t, App.Config.API.StartJSONServer, true)
 
 	// app should exit based on this signal
-	ExitApp <- true
+	Cancel()
 
 	filesystem.DeleteSpacemeshDataFolders(t)
 

--- a/app/main.go
+++ b/app/main.go
@@ -3,15 +3,12 @@ package app
 import (
 	"context"
 	"fmt"
-<<<<<<< HEAD
 	"github.com/spf13/pflag"
 	"os"
 	"os/signal"
 	"reflect"
 	"runtime"
 
-=======
->>>>>>> Fix for issue 194: Updated exit channel with a context with cancel
 	"github.com/spacemeshos/go-spacemesh/accounts"
 	"github.com/spacemeshos/go-spacemesh/api"
 	"github.com/spacemeshos/go-spacemesh/app/cmd"
@@ -22,9 +19,6 @@ import (
 	"github.com/spacemeshos/go-spacemesh/timesync"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"os"
-	"os/signal"
-	"runtime"
 )
 
 // SpacemeshApp is the cli app singleton
@@ -238,7 +232,7 @@ func (app *SpacemeshApp) startSpacemesh(cmd *cobra.Command, args []string) {
 
 	// start p2p services
 	log.Info("Initializing P2P services")
-	swarm, err := p2p.New(Ctx,app.Config.P2P)
+	swarm, err := p2p.New(Ctx, app.Config.P2P)
 	if err != nil {
 		log.Error("Error starting p2p services, err: %v", err)
 		panic("Error starting p2p services")
@@ -249,7 +243,6 @@ func (app *SpacemeshApp) startSpacemesh(cmd *cobra.Command, args []string) {
 		log.Error("Error starting p2p services, err: %v", err)
 		panic("Error starting p2p services")
 	}
-
 
 	app.P2P = swarm
 	app.NodeInitCallback <- true

--- a/p2p/dht/bootstrap.go
+++ b/p2p/dht/bootstrap.go
@@ -1,6 +1,7 @@
 package dht
 
 import (
+	"context"
 	"errors"
 	"github.com/spacemeshos/go-spacemesh/p2p/node"
 	"time"
@@ -24,12 +25,14 @@ var (
 	ErrFoundOurself = errors.New("found ourselves in the routing table")
 	// ErrFailedToBoot is returned when we exceed the BootstrapTimeout
 	ErrFailedToBoot = errors.New("failed to bootstrap within time limit")
+	// ErrBootAbort is returned when when bootstrap is canceled by context cancel
+	ErrBootAbort = errors.New("Bootstrap canceled by signal")
 )
 
 // Bootstrap issues a bootstrap by inserting the preloaded nodes to the routing table then querying them with our
 // ID with a FindNode (using `dht.Lookup`). the process involves updating all returned nodes to the routing table
 // while all the nodes that receive our query will add us to their routing tables and send us as response to a `FindNode`.
-func (d *KadDHT) Bootstrap() error {
+func (d *KadDHT) Bootstrap(ctx context.Context) error {
 
 	d.local.Debug("Starting node bootstrap ", d.local.String())
 
@@ -68,6 +71,8 @@ BOOTLOOP:
 		}()
 
 		select {
+		case <-ctx.Done():
+			return ErrBootAbort
 		case <-timeout.C:
 			return ErrFailedToBoot
 		case err := <-reschan:

--- a/p2p/dht/dht.go
+++ b/p2p/dht/dht.go
@@ -5,6 +5,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/p2p/config"
 	"github.com/spacemeshos/go-spacemesh/p2p/node"
 
+	"context"
 	"errors"
 	"github.com/spacemeshos/go-spacemesh/p2p/service"
 	"time"
@@ -16,7 +17,7 @@ type DHT interface {
 	Lookup(pubkey string) (node.Node, error)
 
 	SelectPeers(qty int) []node.Node
-	Bootstrap() error
+	Bootstrap(ctx context.Context) error
 
 	Size() int
 }

--- a/p2p/dht/dht_test.go
+++ b/p2p/dht/dht_test.go
@@ -210,6 +210,27 @@ func TestDHT_Bootstrap2(t *testing.T) {
 	}
 }
 
+func TestDHT_BootstrapAbort(t *testing.T) {
+	// Create a bootstrap node
+	sim := simulator.New()
+	bn, _ := simNodeWithDHT(t, config.DefaultConfig().SwarmConfig, sim)
+	// config for other nodes
+	cfg2 := config.DefaultConfig()
+	cfg2.SwarmConfig.RandomConnections = 2
+	cfg2.SwarmConfig.BootstrapNodes = []string{node.StringFromNode(bn.Node)}
+	_, dht := simNodeWithDHT(t, cfg2.SwarmConfig, sim)
+	// Create a bootstrap node to abort
+	Ctx, Cancel := context.WithCancel(context.Background())
+	// Abort bootstrap after 2 Seconds
+	go func() {
+		time.Sleep(2 * time.Second)
+		Cancel()
+	}()
+	// Should return error after 2 seconds
+	err := dht.Bootstrap(Ctx)
+	assert.EqualError(t, err, ErrBootAbort.Error(), "Should be able to abort bootstrap")
+}
+
 func Test_filterFindNodeServers(t *testing.T) {
 	//func filterFindNodeServers(nodes []node.Node, queried map[string]struct{}, alpha int) []node.Node {
 

--- a/p2p/dht/dht_test.go
+++ b/p2p/dht/dht_test.go
@@ -1,6 +1,7 @@
 package dht
 
 import (
+	"context"
 	"github.com/spacemeshos/go-spacemesh/p2p/config"
 	"github.com/spacemeshos/go-spacemesh/p2p/node"
 	"github.com/spacemeshos/go-spacemesh/p2p/simulator"
@@ -133,7 +134,7 @@ func simNodeWithDHT(t *testing.T, sc config.SwarmConfig, sim *simulator.Simulato
 }
 
 func bootAndWait(t *testing.T, dht DHT, errchan chan error) {
-	err := dht.Bootstrap()
+	err := dht.Bootstrap(context.TODO())
 	errchan <- err
 }
 

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -1,6 +1,7 @@
 package p2p
 
 import (
+	"context"
 	"github.com/spacemeshos/go-spacemesh/p2p/config"
 	"github.com/spacemeshos/go-spacemesh/p2p/service"
 )
@@ -9,6 +10,6 @@ import (
 type Service service.Service
 
 // New creates a new P2P service a.k.a `swarm` it tries to load node information from the disk.
-func New(config config.Config) (Service, error) {
-	return newSwarm(config, config.NewNode, true) // TODO ADD Persist param
+func New(ctx context.Context, config config.Config) (Service, error) {
+	return newSwarm(ctx, config, config.NewNode, true) // TODO ADD Persist param
 }

--- a/p2p/swarm.go
+++ b/p2p/swarm.go
@@ -3,22 +3,22 @@ package p2p
 import (
 	inet "net"
 
-	"github.com/spacemeshos/go-spacemesh/p2p/config"
-	"github.com/spacemeshos/go-spacemesh/p2p/dht"
-	"github.com/spacemeshos/go-spacemesh/p2p/net"
-	"github.com/spacemeshos/go-spacemesh/timesync"
-
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/gogo/protobuf/proto"
+	"github.com/spacemeshos/go-spacemesh/p2p/config"
 	"github.com/spacemeshos/go-spacemesh/p2p/connectionpool"
+	"github.com/spacemeshos/go-spacemesh/p2p/dht"
 	"github.com/spacemeshos/go-spacemesh/p2p/gossip"
 	"github.com/spacemeshos/go-spacemesh/p2p/message"
+	"github.com/spacemeshos/go-spacemesh/p2p/net"
 	"github.com/spacemeshos/go-spacemesh/p2p/node"
 	"github.com/spacemeshos/go-spacemesh/p2p/pb"
 	"github.com/spacemeshos/go-spacemesh/p2p/service"
+	"github.com/spacemeshos/go-spacemesh/timesync"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -39,11 +39,11 @@ func (pm protocolMessage) Data() []byte {
 }
 
 type swarm struct {
-	started uint32
-	bootErr error
-	bootChan chan struct{}
+	started   uint32
+	bootErr   error
+	bootChan  chan struct{}
 	gossipErr error
-	gossipC chan struct{}
+	gossipC   chan struct{}
 
 	config config.Config
 
@@ -85,7 +85,7 @@ func (s *swarm) waitForGossip() error {
 
 // newSwarm creates a new P2P instance, configured by config, if newNode is true it will create a new node identity
 // and not load from disk. it creates a new `net`, connection pool and dht.
-func newSwarm(config config.Config, newNode bool, persist bool) (*swarm, error) {
+func newSwarm(ctx context.Context, config config.Config, newNode bool, persist bool) (*swarm, error) {
 
 	port := config.TCPPort
 	address := inet.JoinHostPort("0.0.0.0", strconv.Itoa(port))
@@ -112,8 +112,8 @@ func newSwarm(config config.Config, newNode bool, persist bool) (*swarm, error) 
 	s := &swarm{
 		config:           config,
 		lNode:            l,
-		bootChan:	make(chan struct{}),
-		gossipC:	make(chan struct{}),
+		bootChan:         make(chan struct{}),
+		gossipC:          make(chan struct{}),
 		protocolHandlers: make(map[string]chan service.Message),
 		network:          n,
 		cPool:            connectionpool.NewConnectionPool(n, l.PublicKey()),

--- a/p2p/swarm_test.go
+++ b/p2p/swarm_test.go
@@ -5,9 +5,11 @@ import (
 	"testing"
 	"time"
 
+	"context"
 	"errors"
 	"fmt"
 	"github.com/gogo/protobuf/proto"
+	"github.com/spacemeshos/go-spacemesh/crypto"
 	"github.com/spacemeshos/go-spacemesh/p2p/config"
 	"github.com/spacemeshos/go-spacemesh/p2p/message"
 	"github.com/spacemeshos/go-spacemesh/p2p/net"
@@ -18,14 +20,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"math/rand"
 	"sync"
-	"github.com/spacemeshos/go-spacemesh/crypto"
 )
 
 func p2pTestInstance(t testing.TB, config config.Config) *swarm {
 	port, err := node.GetUnboundedPort()
 	assert.NoError(t, err, "Error getting a port", err)
 	config.TCPPort = port
-	p, err := newSwarm(config, true, true)
+	p, err := newSwarm(context.TODO(), config, true, true)
 	assert.NoError(t, err, "Error creating p2p stack, err: %v", err)
 	assert.NotNil(t, p)
 	p.Start()
@@ -36,7 +37,7 @@ const exampleProtocol = "EX"
 const examplePayload = "Example"
 
 func TestNew(t *testing.T) {
-	s, err := New(config.DefaultConfig())
+	s, err := New(context.TODO(), config.DefaultConfig())
 	assert.NoError(t, err, err)
 	err = s.Start()
 	assert.NoError(t, err, err)
@@ -47,7 +48,7 @@ func TestNew(t *testing.T) {
 func Test_newSwarm(t *testing.T) {
 	cfg := config.DefaultConfig()
 	cfg.TCPPort = int(crypto.GetRandomUserPort())
-	s, err := newSwarm(cfg, true, false)
+	s, err := newSwarm(context.TODO(), cfg, true, false)
 	assert.NoError(t, err)
 	err = s.Start()
 	assert.NoError(t, err, err)
@@ -58,7 +59,7 @@ func Test_newSwarm(t *testing.T) {
 func TestSwarm_Shutdown(t *testing.T) {
 	cfg := config.DefaultConfig()
 	cfg.TCPPort = int(crypto.GetRandomUserPort())
-	s, err := newSwarm(cfg, true, false)
+	s, err := newSwarm(context.TODO(), cfg, true, false)
 	assert.NoError(t, err)
 	err = s.Start()
 	assert.NoError(t, err, err)
@@ -86,7 +87,7 @@ func TestSwarm_RegisterProtocolNoStart(t *testing.T) {
 	s.Shutdown()
 }
 
-func  TestSwarm_processMessage(t *testing.T) {
+func TestSwarm_processMessage(t *testing.T) {
 	s := swarm{}
 	s.lNode, _ = node.GenerateTestNode(t)
 	r := node.GenerateRandomNodeData()

--- a/p2p/swarm_test.go
+++ b/p2p/swarm_test.go
@@ -74,13 +74,13 @@ func TestSwarm_Shutdown(t *testing.T) {
 }
 
 func TestSwarm_ShutdownNoStart(t *testing.T) {
-	s, err := newSwarm(config.DefaultConfig(), true, false)
+	s, err := newSwarm(context.TODO(), config.DefaultConfig(), true, false)
 	assert.NoError(t, err)
 	s.Shutdown()
 }
 
 func TestSwarm_RegisterProtocolNoStart(t *testing.T) {
-	s, err := newSwarm(config.DefaultConfig(), true, false)
+	s, err := newSwarm(context.TODO(), config.DefaultConfig(), true, false)
 	msgs := s.RegisterProtocol("Anton")
 	assert.NotNil(t, msgs)
 	assert.NoError(t, err)


### PR DESCRIPTION
When using a interrupt signal (CTRL+C) to stop the node we need to stop the bootstrap process.
There are two ways of doing this:
1- Share the channel to terminate `ExitApp`
2- Have the bootstrap process also to listen to the interrupt 
Here is implemented case number 2 since will prevent cross dependencies or global variables.
