### PR TITLE
Add test-tidy to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,11 @@ branches:
 
 jobs:
   include:
-  - stage: lint
+  - stage: test
+    name: lint
     install: true # this skips the installation step
     script: make lint
-  - stage: test
-    name: test
+  - name: test
     script:
       - make genproto
       - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,11 @@ jobs:
     install: true # this skips the installation step
     script: make lint
   - stage: test
+    name: test
     script:
       - make genproto
       - make test
-  - stage: tidy
+  - name: test-tidy
     script:
       - make genproto
       - make test-tidy

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,26 +2,30 @@ language: go
 sudo: false
 go: 1.11.x
 
-env:
-  - GO111MODULE=on
+env: GO111MODULE=on
 
-before_install:
-  # for some reason /usr/local is owned by a different user in travis, so we transfer ownership to the current user:
-  - sudo chown -R $(whoami) /usr/local
-  - make prepare
+# for some reason /usr/local is owned by a different user in travis, so we transfer ownership to the current user:
+before_install: sudo chown -R $(whoami) /usr/local
+
+install: make install
 
 branches:
   only:
   - develop
+
 jobs:
   include:
   - stage: lint
-    script:
-      - make lint
+    install: true # this skips the installation step
+    script: make lint
   - stage: test
     script:
       - make genproto
       - make test
+  - stage: tidy
+    script:
+      - make genproto
+      - make test-tidy
 
 cache:
   directories:

--- a/Makefile
+++ b/Makefile
@@ -1,44 +1,57 @@
 BINARY := go-spacemesh
 VERSION := 0.0.1
-COMMIT := $(shell git rev-parse HEAD)
-BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
-BIN_DIR := $(shell pwd)/build
-CURR_DIR := $(shell pwd)
+COMMIT = $(shell git rev-parse HEAD)
+BRANCH = $(shell git rev-parse --abbrev-ref HEAD)
+BIN_DIR = $(shell pwd)/build
+CURR_DIR = $(shell pwd)
 export GO111MODULE = on
 
 # Setup the -ldflags option to pass vars defined here to app vars
-LDFLAGS := -ldflags "-X main.version=${VERSION} -X main.commit=${COMMIT} -X main.branch=${BRANCH}"
+LDFLAGS = -ldflags "-X main.version=${VERSION} -X main.commit=${COMMIT} -X main.branch=${BRANCH}"
 
-PKGS := $(shell go list ./...)
+PKGS = $(shell go list ./...)
 
-PLATFORMS := windows linux darwin
+platforms := windows linux darwin
 os = $(word 1, $@)
 
-all:
-	make prepare
-	make build
+all: install build
+.PHONY: all
 
-prepare:
+install:
 	./setup_env.sh
+.PHONY: install
 
 genproto:
 	./scripts/genproto.sh
+.PHONY: genproto
 
 build:
 	make genproto
 	go build ${LDFLAGS} -o $(CURR_DIR)/$(BINARY)
+.PHONY: build
 
-$(PLATFORMS):
+tidy:
+	go mod tidy
+.PHONY: tidy
+
+$(platforms):
 	make genproto
 	GOOS=$(os) GOARCH=amd64 go build ${LDFLAGS} -o $(BIN_DIR)/$(BINARY)-$(VERSION)-$(os)-amd64
+.PHONY: $(platforms)
 
 test:
 	go test -p 1 ./...
+.PHONY: test
 
-.PHONY: all build test devtools cover $(PLATFORMS)
+test-tidy:
+	# We expect `go mod tidy` not to change anything, the test should fail otherwise
+	make tidy
+	git diff --exit-code
+.PHONY: test-tidy
 
 lint:
 	./scripts/validate-lint.sh
+.PHONY: lint
 
 cover:
 	@echo "mode: count" > cover-all.out
@@ -46,3 +59,4 @@ cover:
 		go test -coverprofile=cover.out -covermode=count $(pkg);\
 		tail -n +2 cover.out >> cover-all.out;)
 	go tool cover -html=cover-all.out
+.PHONY: cover

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ LDFLAGS = -ldflags "-X main.version=${VERSION} -X main.commit=${COMMIT} -X main.
 
 PKGS = $(shell go list ./...)
 
-platforms := windows linux darwin
+PLATFORMS := windows linux darwin
 os = $(word 1, $@)
 
 all: install build
@@ -34,10 +34,10 @@ tidy:
 	go mod tidy
 .PHONY: tidy
 
-$(platforms):
+$(PLATFORMS):
 	make genproto
 	GOOS=$(os) GOARCH=amd64 go build ${LDFLAGS} -o $(BIN_DIR)/$(BINARY)-$(VERSION)-$(os)-amd64
-.PHONY: $(platforms)
+.PHONY: $(PLATFORMS)
 
 test:
 	go test -p 1 ./...

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Since the project uses Go 1.11's Modules it's best to place the code **outside**
 ### Setting Up Local Environment
 Before building we need to install `protoc` (ProtoBuf compiler) and some tools required to generate ProtoBufs. Do this by running:
 ```bash
-make prepare
+make install
 ```
 This will invoke `setup_env.sh` which supports Linux and MacOS. On other platforms it should be straightforward to follow the steps in this script manually.
 


### PR DESCRIPTION
This phase tests that `go mod tidy` doesn't change anything in the repository. It forces us to run `make tidy` before merging a PR if any dependencies changed. This will keep `go.mod` and `go.sum` in cannonical form.

I've also used the opportunity to cleanup our Makefile and make our travis setup more efficient.