### PR TITLE
Fix GRPC tests failing randomly

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -74,9 +74,11 @@ func TestGrpcApi(t *testing.T) {
 	const message = "Hello World"
 
 	grpcService := NewGrpcService()
+	grpcStatus := make(chan bool, 2)
 
 	// start a server
-	grpcService.StartService(nil)
+	grpcService.StartService(grpcStatus)
+	<-grpcStatus
 
 	// start a client
 	addr := "localhost:" + strconv.Itoa(int(config.ConfigValues.GrpcServerPort))
@@ -99,6 +101,7 @@ func TestGrpcApi(t *testing.T) {
 
 	// stop the server
 	grpcService.StopService()
+	<-grpcStatus
 }
 
 func TestJsonApi(t *testing.T) {


### PR DESCRIPTION
Fix: #290 

The error occur when the client call Dial before the server start listen (since server start in a new goroutine).
We can reproduce it by put a sleep cmd here https://github.com/spacemeshos/go-spacemesh/blob/develop/api/grpc_server.go#L52

I have 2 solutions:
1. Add WithBlock when Dial like this:
```go
conn, err := grpc.Dial(addr, grpc.WithInsecure(), grpc.WithBlock())
```

2. Pass a status chan when start grpc and wait till the chan got new status, some thing like this:
```go
grpcStatus := make(chan bool, 2) 
grpcService.StartService(grpcStatus) 
<-grpcStatus
```

Since TestJsonApi use option 2, i use it in this PR to make it consistent