### PR TITLE
fix make build to generate a binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,6 @@ ifeq ($(OS),Windows_NT)
 else
 	./setup_env.sh
 endif
-
 .PHONY: install
 
 genproto:
@@ -33,7 +32,6 @@ ifeq ($(OS),Windows_NT)
 else
 	./scripts/genproto.sh
 endif
-
 .PHONY: genproto
 
 build:
@@ -42,7 +40,7 @@ ifeq ($(OS),Windows_NT)
 	go build ${LDFLAGS} -o $(CURR_DIR_WIN)/$(BINARY).exe
 else
 	make genproto
-	go build ${LDFLAGS} ./...
+	go build ${LDFLAGS} -o $(CURR_DIR)/$(BINARY)
 endif
 .PHONY: build
 
@@ -52,7 +50,7 @@ tidy:
 
 $(PLATFORMS):
 	make genproto
-	GOOS=$(os) GOARCH=amd64 go build ${LDFLAGS} ./...
+	GOOS=$(os) GOARCH=amd64 go build ${LDFLAGS} -o $(CURR_DIR)/$(BINARY)
 .PHONY: $(PLATFORMS)
 
 test:


### PR DESCRIPTION
This reverts d00b74e2ca660203d4229fb5f1b2316c6028bed0 and 1d865049b39954af5f58d2ea5340e6a9bfdee508, which erroneously removed the `-o` argument from the build command. This was originally done because compilation errors were not detected during the build and a recursive build fixed this. It turns out that the compilation errors were in code that was not called, which is what caused it not to be built.