### PR TITLE
Hare timedrifts

### DIFF
--- a/hare/algorithm.go
+++ b/hare/algorithm.go
@@ -51,6 +51,7 @@ type ConsensusProcess struct {
 	terminating     bool
 	cfg             config.Config
 	notifySent      bool
+	pending         map[string]*pb.HareMessage
 }
 
 func NewConsensusProcess(cfg config.Config, key crypto.PublicKey, instanceId InstanceId, s Set, oracle Rolacle, signing Signing, p2p NetworkService) *ConsensusProcess {
@@ -72,6 +73,7 @@ func NewConsensusProcess(cfg config.Config, key crypto.PublicKey, instanceId Ins
 	proc.terminating = false
 	proc.cfg = cfg
 	proc.notifySent = false
+	proc.pending = make(map[string]*pb.HareMessage, cfg.N)
 
 	return proc
 }
@@ -161,13 +163,32 @@ func roleFromRoundCounter(k uint32) Role {
 	}
 }
 
+func (proc *ConsensusProcess) onEarlyMessage(m *pb.HareMessage) {
+	pub, err := crypto.NewPublicKey(m.PubKey)
+	if err != nil {
+		log.Warning("Could not construct public key: ", err.Error())
+		return
+	}
+
+	if _, exist := proc.pending[pub.String()]; exist { // ignore, already received
+		return
+	}
+
+	proc.pending[pub.String()] = m
+}
+
 func (proc *ConsensusProcess) handleMessage(m *pb.HareMessage) {
 	// Note: instanceId is already verified by the broker
 
-	// validate message
+	// validate message for this or next round
 	if !proc.validator.ValidateMessage(m, proc.k) {
-		log.Warning("Message is not syntactically valid")
-		return
+		if !proc.validator.ValidateMessage(m, proc.k+1) {
+			log.Warning("Message is not syntactically valid for either round")
+			return
+		} else { // early message, keep it for later
+			log.Info("Early message detected. Keeping message")
+			proc.onEarlyMessage(m)
+		}
 	}
 
 	// TODO: validate claimedRole proof
@@ -276,6 +297,12 @@ func (proc *ConsensusProcess) beginRound4() {
 	proc.proposalTracker = nil
 }
 
+func (proc *ConsensusProcess) handlePending(pending map[string]*pb.HareMessage) {
+	for _, m := range pending {
+		proc.inbox <- m
+	}
+}
+
 func (proc *ConsensusProcess) onRoundBegin() {
 	proc.updateRole()
 
@@ -293,6 +320,10 @@ func (proc *ConsensusProcess) onRoundBegin() {
 		log.Error("Current round out of bounds. Expected: 0-4, Found: ", proc.currentRound())
 		panic("Current round out of bounds")
 	}
+
+	pendingProcess := proc.pending
+	proc.pending = make(map[string]*pb.HareMessage, proc.cfg.N)
+	go proc.handlePending(pendingProcess)
 }
 
 func (proc *ConsensusProcess) roleProof() Signature {

--- a/hare/algorithm.go
+++ b/hare/algorithm.go
@@ -171,6 +171,7 @@ func (proc *ConsensusProcess) onEarlyMessage(m *pb.HareMessage) {
 	}
 
 	if _, exist := proc.pending[pub.String()]; exist { // ignore, already received
+		log.Warning("Already received message from sender %v", pub.String())
 		return
 	}
 
@@ -185,7 +186,7 @@ func (proc *ConsensusProcess) handleMessage(m *pb.HareMessage) {
 		if !proc.validator.ValidateMessage(m, proc.k+1) {
 			log.Warning("Message is not syntactically valid for either round")
 			return
-		} else { // early message, keep it for later
+		} else { // a valid early message, keep it for later
 			log.Info("Early message detected. Keeping message")
 			proc.onEarlyMessage(m)
 		}

--- a/hare/algorithm.go
+++ b/hare/algorithm.go
@@ -209,7 +209,8 @@ func (proc *ConsensusProcess) handleMessage(m *pb.HareMessage) {
 	// validate message for this or next round
 	if !proc.validator.ValidateMessage(m, proc.k) {
 		if !proc.validator.ValidateMessage(m, proc.k+1) {
-			log.Warning("Message is not syntactically valid for either round")
+			// TODO: should return error from message validation to indicate what failed, should retry only for contextual failure
+			log.Warning("Message is not valid for either round")
 			return
 		} else { // a valid early message, keep it for later
 			log.Info("Early message detected. Keeping message")

--- a/hare/algorithm_test.go
+++ b/hare/algorithm_test.go
@@ -252,3 +252,13 @@ func TestConsensusProcess_currentRound(t *testing.T) {
 	proc.advanceToNextRound()
 	assert.Equal(t, Round4, proc.currentRound())
 }
+
+func TestConsensusProcess_onEarlyMessage(t *testing.T) {
+	proc := generateConsensusProcess(t)
+	m := BuildPreRoundMsg(generatePubKey(t), NewSmallEmptySet())
+	proc.advanceToNextRound()
+	proc.onEarlyMessage(m)
+	assert.Equal(t, 1, len(proc.pending))
+	proc.onEarlyMessage(m)
+	assert.Equal(t, 1, len(proc.pending))
+}

--- a/hare/messagevalidation.go
+++ b/hare/messagevalidation.go
@@ -19,14 +19,14 @@ func NewMessageValidator(signing Signing, threshold int, defaultSize int, valida
 }
 
 func (validator *MessageValidator) ValidateMessage(m *pb.HareMessage, k uint32) bool {
-	if !validator.isSyntacticallyValid(m) {
-		log.Warning("Validate message failed: message is not syntactically valid")
-		return false
-	}
-
 	// validate context
 	if !isContextuallyValid(m, k) {
 		log.Info("Validate message failed: message is not contextually valid")
+		return false
+	}
+
+	if !validator.isSyntacticallyValid(m) {
+		log.Warning("Validate message failed: message is not syntactically valid")
 		return false
 	}
 
@@ -47,6 +47,11 @@ func (validator *MessageValidator) ValidateMessage(m *pb.HareMessage, k uint32) 
 
 // verifies the message is contextually valid
 func isContextuallyValid(m *pb.HareMessage, expectedK uint32) bool {
+	if m.Message == nil {
+		log.Warning("Contextual validation failed: m.Message is nil")
+		return false
+	}
+
 	// PreRound & Notify are always contextually valid
 	switch MessageType(m.Message.Type) {
 	case PreRound:
@@ -60,7 +65,7 @@ func isContextuallyValid(m *pb.HareMessage, expectedK uint32) bool {
 		return true
 	}
 
-	log.Warning("Contextual validation failed: not same iteration. Expected: %v, Actual: %v", expectedK, m.Message.K)
+	log.Info("Contextual validation failed: not same iteration. Expected: %v, Actual: %v", expectedK, m.Message.K)
 	return false
 }
 


### PR DESCRIPTION
Added time drifts handling
Early messages are now buffered and handled later when the following round starts.