### PR TITLE
P2P - limit connections and swarm neighbors

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -34,8 +34,6 @@ func AddCommands(cmd *cobra.Command) {
 	cmd.PersistentFlags().IntVar(&config.LayerAvgSize, "layer-average-size",
 		config.LayerDurationSec, "Duration between layers in seconds")
 	/** ======================== P2P Flags ========================== **/
-	cmd.PersistentFlags().IntVar(&config.P2P.SecurityParam, "security-param",
-		config.P2P.SecurityParam, "Consensus protocol k security param")
 	cmd.PersistentFlags().IntVar(&config.P2P.TCPPort, "tcp-port",
 		config.P2P.TCPPort, "TCP Port to listen on")
 	cmd.PersistentFlags().DurationVar(&config.P2P.DialTimeout, "dial-timeout",
@@ -46,12 +44,20 @@ func AddCommands(cmd *cobra.Command) {
 		config.P2P.NetworkID, "NetworkID to run on (0 - mainnet, 1 - testnet)")
 	cmd.PersistentFlags().DurationVar(&config.P2P.ResponseTimeout, "response-timeout",
 		config.P2P.ResponseTimeout, "Timeout for waiting on resposne message")
+	cmd.PersistentFlags().DurationVar(&config.P2P.SessionTimeout, "session-timeout",
+		config.P2P.SessionTimeout, "Timeout for waiting on session message")
 	cmd.PersistentFlags().StringVar(&config.P2P.NodeID, "node-id",
 		config.P2P.NodeID, "Load node data by id (pub key) from local store")
 	cmd.PersistentFlags().BoolVar(&config.P2P.NewNode, "new-node",
 		config.P2P.NewNode, "Load node data by id (pub key) from local store")
 	cmd.PersistentFlags().IntVar(&config.P2P.BufferSize, "buffer-size",
 		config.P2P.BufferSize, "Size of the messages handler's buffer")
+	cmd.PersistentFlags().IntVar(&config.P2P.MaxPendingConnections, "max-pending-connections",
+		config.P2P.MaxPendingConnections, "The maximum number of pending connections")
+	cmd.PersistentFlags().IntVar(&config.P2P.OutboundPeersTarget, "outbound-target",
+		config.P2P.OutboundPeersTarget, "The outbound peer target we're trying to connect")
+	cmd.PersistentFlags().IntVar(&config.P2P.MaxInboundPeers, "max-inbound",
+		config.P2P.MaxInboundPeers, "The maximum number of inbound peers ")
 	cmd.PersistentFlags().BoolVar(&config.P2P.SwarmConfig.Gossip, "gossip",
 		config.P2P.SwarmConfig.Gossip, "should we start a gossiping node?")
 	cmd.PersistentFlags().BoolVar(&config.P2P.SwarmConfig.Bootstrap, "bootstrap",

--- a/config.toml
+++ b/config.toml
@@ -25,6 +25,10 @@ dial-timeout = "1m"
 conn-keepalive = "48h"
 network-id = 1 # 0 - MainNet, 1 - TestNet
 response-timeout = "2s"
+session-timeout = "2s"
+max-pending-connections = 50
+target-outbound = 10
+max-inbound = 100
 buffer-size = 100
 
 # Node Swarm Config

--- a/p2p/config/config.go
+++ b/p2p/config/config.go
@@ -26,8 +26,6 @@ func duration(duration string) (dur time.Duration) {
 
 // Config defines the configuration options for the Spacemesh peer-to-peer networking layer
 type Config struct {
-	SecurityParam   int           `mapstructure:"security-param"`
-	FastSync        bool          `mapstructure:"fast-sync"`
 	TCPPort         int           `mapstructure:"tcp-port"`
 	NodeID          string        `mapstructure:"node-id"`
 	NewNode         bool          `mapstructure:"new-node"`
@@ -35,6 +33,10 @@ type Config struct {
 	ConnKeepAlive   time.Duration `mapstructure:"conn-keepalive"`
 	NetworkID       int8          `mapstructure:"network-id"`
 	ResponseTimeout time.Duration `mapstructure:"response-timeout"`
+	SessionTimeout time.Duration `mapstructure:"session-timeout"`
+	MaxPendingConnections int `mapstructure:"max-pending-connections"`
+	OutboundPeersTarget int `mapstructure:"outbound-target"`
+	MaxInboundPeers int `mapstructure:"max-inbound"`
 	SwarmConfig     SwarmConfig   `mapstructure:"swarm"`
 	BufferSize      int           `mapstructure:"buffer-size"`
 }
@@ -64,8 +66,6 @@ func DefaultConfig() Config {
 	}
 
 	return Config{
-		SecurityParam:   20,
-		FastSync:        true,
 		TCPPort:         7513,
 		NodeID:          "",
 		NewNode:         false,
@@ -73,6 +73,10 @@ func DefaultConfig() Config {
 		ConnKeepAlive:   duration("48h"),
 		NetworkID:       TestNet,
 		ResponseTimeout: duration("15s"),
+		SessionTimeout: duration("5s"),
+		MaxPendingConnections: 50,
+		OutboundPeersTarget: 10,
+		MaxInboundPeers: 	100,
 		SwarmConfig:     SwarmConfigValues,
 		BufferSize:      100,
 	}

--- a/p2p/config/config.go
+++ b/p2p/config/config.go
@@ -26,19 +26,19 @@ func duration(duration string) (dur time.Duration) {
 
 // Config defines the configuration options for the Spacemesh peer-to-peer networking layer
 type Config struct {
-	TCPPort         int           `mapstructure:"tcp-port"`
-	NodeID          string        `mapstructure:"node-id"`
-	NewNode         bool          `mapstructure:"new-node"`
-	DialTimeout     time.Duration `mapstructure:"dial-timeout"`
-	ConnKeepAlive   time.Duration `mapstructure:"conn-keepalive"`
-	NetworkID       int8          `mapstructure:"network-id"`
-	ResponseTimeout time.Duration `mapstructure:"response-timeout"`
-	SessionTimeout time.Duration `mapstructure:"session-timeout"`
-	MaxPendingConnections int `mapstructure:"max-pending-connections"`
-	OutboundPeersTarget int `mapstructure:"outbound-target"`
-	MaxInboundPeers int `mapstructure:"max-inbound"`
-	SwarmConfig     SwarmConfig   `mapstructure:"swarm"`
-	BufferSize      int           `mapstructure:"buffer-size"`
+	TCPPort               int           `mapstructure:"tcp-port"`
+	NodeID                string        `mapstructure:"node-id"`
+	NewNode               bool          `mapstructure:"new-node"`
+	DialTimeout           time.Duration `mapstructure:"dial-timeout"`
+	ConnKeepAlive         time.Duration `mapstructure:"conn-keepalive"`
+	NetworkID             int8          `mapstructure:"network-id"`
+	ResponseTimeout       time.Duration `mapstructure:"response-timeout"`
+	SessionTimeout        time.Duration `mapstructure:"session-timeout"`
+	MaxPendingConnections int           `mapstructure:"max-pending-connections"`
+	OutboundPeersTarget   int           `mapstructure:"outbound-target"`
+	MaxInboundPeers       int           `mapstructure:"max-inbound"`
+	SwarmConfig           SwarmConfig   `mapstructure:"swarm"`
+	BufferSize            int           `mapstructure:"buffer-size"`
 }
 
 // SwarmConfig specifies swarm config params.
@@ -66,18 +66,18 @@ func DefaultConfig() Config {
 	}
 
 	return Config{
-		TCPPort:         7513,
-		NodeID:          "",
-		NewNode:         false,
-		DialTimeout:     duration("1m"),
-		ConnKeepAlive:   duration("48h"),
-		NetworkID:       TestNet,
-		ResponseTimeout: duration("15s"),
-		SessionTimeout: duration("5s"),
-		MaxPendingConnections: 50,
-		OutboundPeersTarget: 10,
-		MaxInboundPeers: 	100,
-		SwarmConfig:     SwarmConfigValues,
-		BufferSize:      100,
+		TCPPort:               7513,
+		NodeID:                "",
+		NewNode:               false,
+		DialTimeout:           duration("1m"),
+		ConnKeepAlive:         duration("48h"),
+		NetworkID:             TestNet,
+		ResponseTimeout:       duration("15s"),
+		SessionTimeout:        duration("5s"),
+		MaxPendingConnections: 100,
+		OutboundPeersTarget:   10,
+		MaxInboundPeers:       100,
+		SwarmConfig:           SwarmConfigValues,
+		BufferSize:            100,
 	}
 }

--- a/p2p/net/conn.go
+++ b/p2p/net/conn.go
@@ -178,12 +178,11 @@ func (c *FormattedConnection) shutdown(err error) {
 }
 
 var ErrTriedToSetupExistingConn = errors.New("tried to setup existing connection")
-var RemoteHandshakeTimeout = time.Second * 2
 var ErrIncomingSessionTimeout = errors.New("timeout waiting for handshake message")
 
-func (c *FormattedConnection) setupIncoming() error {
+func (c *FormattedConnection) setupIncoming(timeout time.Duration) error {
 	var err error
-	timeout := time.NewTimer(RemoteHandshakeTimeout)
+	tm := time.NewTimer(timeout)
 	select {
 	case msg, ok := <-c.formatter.In():
 		if !ok { // chan closed
@@ -200,7 +199,7 @@ func (c *FormattedConnection) setupIncoming() error {
 		}
 		err = ErrTriedToSetupExistingConn
 		break
-	case <-timeout.C:
+	case <-tm.C:
 		err = ErrIncomingSessionTimeout
 	}
 

--- a/p2p/net/conn_test.go
+++ b/p2p/net/conn_test.go
@@ -74,7 +74,7 @@ func TestPreSessionMessage(t *testing.T) {
 	formatter := delimited.NewChan(10)
 	conn := newConnection(rwcam, netw, formatter, rPub, nil, netw.logger)
 	rwcam.SetReadResult([]byte{3, 1, 1, 1}, nil)
-	err := conn.setupIncoming()
+	err := conn.setupIncoming(time.Second)
 	require.NoError(t, err)
 	require.Equal(t, conn.Closed(), false)
 	require.Equal(t, int32(1), netw.PreSessionCount())
@@ -100,7 +100,7 @@ func TestPreSessionError(t *testing.T) {
 	conn := newConnection(rwcam, netw, formatter, rPub, nil, netw.logger)
 	netw.SetPreSessionResult(fmt.Errorf("fail"))
 
-	err := conn.setupIncoming()
+	err := conn.setupIncoming(time.Second)
 	require.Error(t, err)
 }
 

--- a/p2p/net/network_test.go
+++ b/p2p/net/network_test.go
@@ -46,15 +46,14 @@ func TestNet_EnqueueMessage(t *testing.T) {
 	wg.Wait()
 }
 
-
 type mockListener struct {
-	calledCount int32
+	calledCount  int32
 	connReleaser chan struct{}
 	accpetResErr error
 }
 
 func newMockListener() *mockListener {
-	return &mockListener{connReleaser:make(chan struct{})}
+	return &mockListener{connReleaser: make(chan struct{})}
 }
 
 func (ml *mockListener) listenerFunc() (net.Listener, error) {
@@ -63,7 +62,7 @@ func (ml *mockListener) listenerFunc() (net.Listener, error) {
 
 func (ml *mockListener) Accept() (net.Conn, error) {
 	atomic.AddInt32(&ml.calledCount, 1)
-	<- ml.connReleaser
+	<-ml.connReleaser
 	var c net.Conn = nil
 	var c2 net.Conn = nil
 	if ml.accpetResErr == nil {
@@ -79,11 +78,11 @@ func (ml *mockListener) releaseConn() {
 	ml.connReleaser <- struct{}{}
 }
 
-func (ml *mockListener) Close() (error) {
+func (ml *mockListener) Close() error {
 	return nil
 }
-func (ml *mockListener) Addr() (net.Addr) {
-	return &net.IPAddr{IP:net.ParseIP("0.0.0.0"), Zone:"ipv4"}
+func (ml *mockListener) Addr() net.Addr {
+	return &net.IPAddr{IP: net.ParseIP("0.0.0.0"), Zone: "ipv4"}
 }
 
 func Test_Net_LimitedConnections(t *testing.T) {
@@ -105,7 +104,7 @@ func Test_Net_LimitedConnections(t *testing.T) {
 
 	require.Equal(t, atomic.LoadInt32(&listener.calledCount), int32(cfg.MaxPendingConnections))
 	done := make(chan struct{})
-	go func () {
+	go func() {
 		listener.releaseConn()
 		done <- struct{}{}
 	}()

--- a/p2p/net/network_test.go
+++ b/p2p/net/network_test.go
@@ -6,7 +6,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"math/rand"
+	"net"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -42,6 +44,74 @@ func TestNet_EnqueueMessage(t *testing.T) {
 		}()
 	}
 	wg.Wait()
+}
+
+
+type mockListener struct {
+	calledCount int32
+	connReleaser chan struct{}
+	accpetResErr error
+}
+
+func newMockListener() *mockListener {
+	return &mockListener{connReleaser:make(chan struct{})}
+}
+
+func (ml *mockListener) listenerFunc() (net.Listener, error) {
+	return ml, nil
+}
+
+func (ml *mockListener) Accept() (net.Conn, error) {
+	atomic.AddInt32(&ml.calledCount, 1)
+	<- ml.connReleaser
+	var c net.Conn = nil
+	var c2 net.Conn = nil
+	if ml.accpetResErr == nil {
+		c, c2 = net.Pipe() // just for the interface lolz
+		go func(con net.Conn) {
+
+		}(c2)
+	}
+	return c, ml.accpetResErr
+}
+
+func (ml *mockListener) releaseConn() {
+	ml.connReleaser <- struct{}{}
+}
+
+func (ml *mockListener) Close() (error) {
+	return nil
+}
+func (ml *mockListener) Addr() (net.Addr) {
+	return &net.IPAddr{IP:net.ParseIP("0.0.0.0"), Zone:"ipv4"}
+}
+
+func Test_Net_LimitedConnections(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.SessionTimeout = 1000 * time.Millisecond
+
+	ln, err := node.NewNodeIdentity(cfg, "0.0.0.0:0000", false)
+	require.NoError(t, err)
+	n, err := NewNet(cfg, ln)
+	//n.SubscribeOnNewRemoteConnections(counter)
+	listener := newMockListener()
+	err = n.listen(listener.listenerFunc)
+	require.NoError(t, err)
+	for i := 0; i < cfg.MaxPendingConnections-1; i++ {
+		listener.releaseConn()
+	}
+	n.config.SessionTimeout = 300 * time.Millisecond
+	listener.releaseConn()
+
+	require.Equal(t, atomic.LoadInt32(&listener.calledCount), int32(cfg.MaxPendingConnections))
+	done := make(chan struct{})
+	go func () {
+		listener.releaseConn()
+		done <- struct{}{}
+	}()
+	require.Equal(t, atomic.LoadInt32(&listener.calledCount), int32(cfg.MaxPendingConnections))
+	<-done
+	require.Equal(t, atomic.LoadInt32(&listener.calledCount), int32(cfg.MaxPendingConnections)+1)
 }
 
 func TestHandlePreSessionIncomingMessage2(t *testing.T) {

--- a/p2p/swarm_test.go
+++ b/p2p/swarm_test.go
@@ -115,7 +115,11 @@ func TestSwarm_Shutdown(t *testing.T) {
 func TestSwarm_ShutdownNoStart(t *testing.T) {
 	s, err := newSwarm(context.TODO(), config.DefaultConfig(), true, false)
 	assert.NoError(t, err)
+	err = s.Start()
+	assert.NoError(t, err)
 	s.Shutdown()
+	_, ok := <-s.shutdown
+	assert.False(t, ok)
 }
 
 func TestSwarm_RegisterProtocolNoStart(t *testing.T) {
@@ -833,4 +837,16 @@ func TestSwarm_AddIncomingPeer(t *testing.T) {
 
 	assert.True(t, ok)
 	assert.NotNil(t, peer)
+
+	nds := node.GenerateRandomNodesData(config.DefaultConfig().MaxInboundPeers)
+	for i := 0; i < len(nds); i++ {
+		p.addIncomingPeer(nds[i].PublicKey())
+	}
+
+	require.Equal(t, len(p.inpeers), config.DefaultConfig().MaxInboundPeers)
+	p.inpeersMutex.RLock()
+	peer, ok = p.inpeers[nds[len(nds)-1].PublicKey().String()]
+	p.inpeersMutex.RUnlock()
+	assert.False(t, ok)
+	assert.Nil(t, peer)
 }


### PR DESCRIPTION
The pending connection and the inbound neighbors limit is set to 100 to enable discovery to work through the neighborhood as well. numbers will be re-considered after discovery is separated.
this actually does #269 as well.