### PR TITLE
PoET validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,8 @@ require (
 	github.com/prometheus/common v0.2.0
 	github.com/prometheus/procfs v0.0.0-20190203183350-488faf799f86 // indirect
 	github.com/seehuhn/mt19937 v0.0.0-20180715112136-cc7708819361
-	github.com/spacemeshos/poet-ref v0.0.0-20190328115118-4a8d0d8b9b36
+	github.com/spacemeshos/merkle-tree v0.0.0-20190327145446-3651a544f849
+	github.com/spacemeshos/poet-ref v0.0.0-20190404082615-4bb5581dbcba
 	github.com/spf13/afero v1.2.0 // indirect
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/pflag v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -122,16 +122,8 @@ github.com/seehuhn/mt19937 v0.0.0-20180715112136-cc7708819361 h1:Nnks5IJM8QjJsF+
 github.com/seehuhn/mt19937 v0.0.0-20180715112136-cc7708819361/go.mod h1:w+IAy13Luqfsp+plFpT1RiqauADylJKmpkrWFwpjbsc=
 github.com/sirupsen/logrus v1.2.0 h1:juTguoYk5qI21pwyTXY3B3Y5cOTH3ZUyZCg1v/mihuo=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
-github.com/spacemeshos/merkle-tree v0.0.0-20190303120439-11079fe33c42 h1:rCf5SLMolpeg1yCaCK6v5fM2RSterniXkt7S5UkzpMY=
-github.com/spacemeshos/merkle-tree v0.0.0-20190303120439-11079fe33c42/go.mod h1:mPxjt4RONPxSUhxOq4bhSJyKVGQJ0VMSyRiE51dDLgE=
 github.com/spacemeshos/merkle-tree v0.0.0-20190327145446-3651a544f849 h1:RJw90V/KgsE3dKbcec+aFsgTdYzIwRlYwKRwu9DADPY=
 github.com/spacemeshos/merkle-tree v0.0.0-20190327145446-3651a544f849/go.mod h1:mPxjt4RONPxSUhxOq4bhSJyKVGQJ0VMSyRiE51dDLgE=
-github.com/spacemeshos/poet-ref v0.0.0-20190328115118-4a8d0d8b9b36 h1:IzD1BaF7svsoctzIYzHLX//cpDe3TXasYZIUZYF/CMM=
-github.com/spacemeshos/poet-ref v0.0.0-20190328115118-4a8d0d8b9b36/go.mod h1:G5EK3xH6qRybTTfk+kXLGAsC55pqgMa5b/MfvowhbWU=
-github.com/spacemeshos/poet-ref v0.0.0-20190403140808-6e02b73e8c1a h1:fOnPHijkejT3skvtIS57TDtwud23Fv9c+J037/Gad+Y=
-github.com/spacemeshos/poet-ref v0.0.0-20190403140808-6e02b73e8c1a/go.mod h1:mQDOJ2bhXYw7a30aPgtzOJGj1tRG+dkmcnfG5RsMONw=
-github.com/spacemeshos/poet-ref v0.0.0-20190404064416-cf975df52bd4 h1:m6k4GALCa+1ZvaXXyci2B/6fOqg38JHb/lBvKKrElnQ=
-github.com/spacemeshos/poet-ref v0.0.0-20190404064416-cf975df52bd4/go.mod h1:mQDOJ2bhXYw7a30aPgtzOJGj1tRG+dkmcnfG5RsMONw=
 github.com/spacemeshos/poet-ref v0.0.0-20190404082615-4bb5581dbcba h1:SD7ogYNWvANB0hZhDSsBeOpfOTujfJokCf5PcouJCHk=
 github.com/spacemeshos/poet-ref v0.0.0-20190404082615-4bb5581dbcba/go.mod h1:mQDOJ2bhXYw7a30aPgtzOJGj1tRG+dkmcnfG5RsMONw=
 github.com/spacemeshos/sha256-simd v0.0.0-20190111104731-8575aafc88c9 h1:Cc+np6ORem5wrvO+YHQ1sdu71ItiQVRiYB4ugazpgxM=

--- a/go.sum
+++ b/go.sum
@@ -124,8 +124,16 @@ github.com/sirupsen/logrus v1.2.0 h1:juTguoYk5qI21pwyTXY3B3Y5cOTH3ZUyZCg1v/mihuo
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/spacemeshos/merkle-tree v0.0.0-20190303120439-11079fe33c42 h1:rCf5SLMolpeg1yCaCK6v5fM2RSterniXkt7S5UkzpMY=
 github.com/spacemeshos/merkle-tree v0.0.0-20190303120439-11079fe33c42/go.mod h1:mPxjt4RONPxSUhxOq4bhSJyKVGQJ0VMSyRiE51dDLgE=
+github.com/spacemeshos/merkle-tree v0.0.0-20190327145446-3651a544f849 h1:RJw90V/KgsE3dKbcec+aFsgTdYzIwRlYwKRwu9DADPY=
+github.com/spacemeshos/merkle-tree v0.0.0-20190327145446-3651a544f849/go.mod h1:mPxjt4RONPxSUhxOq4bhSJyKVGQJ0VMSyRiE51dDLgE=
 github.com/spacemeshos/poet-ref v0.0.0-20190328115118-4a8d0d8b9b36 h1:IzD1BaF7svsoctzIYzHLX//cpDe3TXasYZIUZYF/CMM=
 github.com/spacemeshos/poet-ref v0.0.0-20190328115118-4a8d0d8b9b36/go.mod h1:G5EK3xH6qRybTTfk+kXLGAsC55pqgMa5b/MfvowhbWU=
+github.com/spacemeshos/poet-ref v0.0.0-20190403140808-6e02b73e8c1a h1:fOnPHijkejT3skvtIS57TDtwud23Fv9c+J037/Gad+Y=
+github.com/spacemeshos/poet-ref v0.0.0-20190403140808-6e02b73e8c1a/go.mod h1:mQDOJ2bhXYw7a30aPgtzOJGj1tRG+dkmcnfG5RsMONw=
+github.com/spacemeshos/poet-ref v0.0.0-20190404064416-cf975df52bd4 h1:m6k4GALCa+1ZvaXXyci2B/6fOqg38JHb/lBvKKrElnQ=
+github.com/spacemeshos/poet-ref v0.0.0-20190404064416-cf975df52bd4/go.mod h1:mQDOJ2bhXYw7a30aPgtzOJGj1tRG+dkmcnfG5RsMONw=
+github.com/spacemeshos/poet-ref v0.0.0-20190404082615-4bb5581dbcba h1:SD7ogYNWvANB0hZhDSsBeOpfOTujfJokCf5PcouJCHk=
+github.com/spacemeshos/poet-ref v0.0.0-20190404082615-4bb5581dbcba/go.mod h1:mQDOJ2bhXYw7a30aPgtzOJGj1tRG+dkmcnfG5RsMONw=
 github.com/spacemeshos/sha256-simd v0.0.0-20190111104731-8575aafc88c9 h1:Cc+np6ORem5wrvO+YHQ1sdu71ItiQVRiYB4ugazpgxM=
 github.com/spacemeshos/sha256-simd v0.0.0-20190111104731-8575aafc88c9/go.mod h1:Pz5LyRghtiEuSixOVGO0da5AxKBZa6+Yq8ZJfjTAPI0=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=

--- a/nipst/nipst.go
+++ b/nipst/nipst.go
@@ -1,7 +1,6 @@
 package nipst
 
 import (
-	"errors"
 	"fmt"
 	"github.com/spacemeshos/go-spacemesh/common"
 	"github.com/spacemeshos/go-spacemesh/crypto"
@@ -140,8 +139,8 @@ type NIPSTBuilder struct {
 	duration             SeqWorkTicks
 	postProver           PostProverClient
 	poetProver           PoetProvingServiceClient
-	verifyMembership     func(member *common.Hash, proof *membershipProof) bool
-	verifyPoet           func(p *poetProof) bool
+	verifyMembership     func(member *common.Hash, proof *membershipProof) (bool, error)
+	verifyPoet           func(p *poetProof) (bool, error)
 	verifyPoetMembership func(*membershipProof, *poetProof) bool
 
 	activationBuilder ActivationBuilder
@@ -159,8 +158,8 @@ func NewNIPSTBuilder(
 	duration SeqWorkTicks,
 	postProver PostProverClient,
 	poetProver PoetProvingServiceClient,
-	verifyMembership func(member *common.Hash, proof *membershipProof) bool,
-	verifyPoet func(p *poetProof) bool,
+	verifyMembership func(member *common.Hash, proof *membershipProof) (bool, error),
+	verifyPoet func(p *poetProof) (bool, error),
 	verifyPoetMembership func(*membershipProof, *poetProof) bool,
 	activationBuilder ActivationBuilder,
 ) *NIPSTBuilder {
@@ -205,20 +204,20 @@ func (nb *NIPSTBuilder) loop() {
 
 	// Phase 0: PoST initialization.
 	if nb.nipst.postCommitment == nil {
-		log.Info("starting PoST initialization, id: %x, space: %v",
+		log.Info("starting PoST initialization (id: %x, space: %v)",
 			nb.id, nb.space)
 
 		com, err := nb.postProver.initialize(nb.id, nb.space, defTimeout)
 		if err != nil {
-			nb.errChan <- fmt.Errorf("failed to initialize PoST: %v", err)
+			nb.error("failed to initialize PoST: %v", err)
 			return
 		}
 		if !com.valid() {
-			nb.errChan <- errors.New("received an invalid PoST commitment")
+			nb.error("received an invalid PoST commitment")
 			return
 		}
 
-		log.Info("finished PoST initialization, commitment: %x",
+		log.Info("finished PoST initialization (commitment: %x)",
 			*com)
 
 		nb.nipst.postCommitment = com
@@ -244,18 +243,18 @@ func (nb *NIPSTBuilder) loop() {
 				poetChallenge = crypto.Keccak256Hash(nb.nipst.prev.postProof.serialize())
 			}
 
-			log.Info("submitting challenge to PoET proving service, "+
-				"service id: %v, challenge: %x",
+			log.Info("submitting challenge to PoET proving service "+
+				"(service id: %v, challenge: %x)",
 				nb.poetProver.id(), poetChallenge)
 
 			round, err := nb.poetProver.submit(poetChallenge, nb.duration)
 			if err != nil {
-				nb.errChan <- fmt.Errorf("failed to submit challenge to poet service: %v", err)
+				nb.error("failed to submit challenge to poet service: %v", err)
 				break
 			}
 
-			log.Info("challenge submitted to PoET proving service, "+
-				"service id: %v, round id: %v",
+			log.Info("challenge submitted to PoET proving service "+
+				"(service id: %v, round id: %v)",
 				nb.poetProver.id(), round.id)
 
 			nb.nipst.poetChallenge = &poetChallenge
@@ -269,22 +268,28 @@ func (nb *NIPSTBuilder) loop() {
 
 		// Phase 2: Wait for PoET service round membership proof.
 		if nb.nipst.poetMembershipProof == nil {
-			log.Info("querying round membership proof from PoET proving service, "+
-				"service id: %v, round id: %v, challenge: %x",
+			log.Info("querying round membership proof from PoET proving service "+
+				"(service id: %v, round id: %v, challenge: %x)",
 				nb.poetProver.id(), nb.nipst.poetRound.id, nb.nipst.poetChallenge)
 
 			mproof, err := nb.poetProver.subscribeMembershipProof(nb.nipst.poetRound, *nb.nipst.poetChallenge, defTimeout)
 			if err != nil {
-				nb.errChan <- fmt.Errorf("failed to receive PoET round membership proof: %v", err)
-				break
-			}
-			if !nb.verifyMembership(nb.nipst.poetChallenge, mproof) {
-				nb.errChan <- errors.New("receive an invalid PoET round membership proof")
+				nb.error("failed to receive PoET round membership proof: %v", err)
 				break
 			}
 
-			log.Info("received a valid round membership proof from PoET proving service, "+
-				"service id: %v, round id: %v, challenge: %x",
+			res, err := nb.verifyMembership(nb.nipst.poetChallenge, mproof)
+			if err != nil {
+				nb.error("received an invalid PoET round membership proof: %v", err)
+				break
+			}
+			if !res {
+				nb.error("received an invalid PoET round membership proof")
+				break
+			}
+
+			log.Info("received a valid round membership proof from PoET proving service "+
+				"(service id: %v, round id: %v, challenge: %x)",
 				nb.poetProver.id(), nb.nipst.poetRound.id, nb.nipst.poetChallenge)
 
 			nb.nipst.poetMembershipProof = mproof
@@ -297,29 +302,34 @@ func (nb *NIPSTBuilder) loop() {
 
 		// Phase 3: Wait for PoET service proof.
 		if nb.nipst.poetProof == nil {
-			log.Info("waiting for PoET proof from PoET proving service, "+
-				"service id: %v, round id: %v, round root commitment: %x",
+			log.Info("waiting for PoET proof from PoET proving service "+
+				"(service id: %v, round id: %v, round root commitment: %x)",
 				nb.poetProver.id(), nb.nipst.poetRound.id, nb.nipst.poetMembershipProof.root)
 
 			proof, err := nb.poetProver.subscribeProof(nb.nipst.poetRound, defTimeout)
 			if err != nil {
-				nb.errChan <- fmt.Errorf("failed to receive PoET proof: %v", err)
+				nb.error("failed to receive PoET proof: %v", err)
 				break
 			}
 
 			if !nb.verifyPoetMembership(nb.nipst.poetMembershipProof, proof) {
-				nb.errChan <- fmt.Errorf("received an invalid PoET proof due to "+
-					"commitment value, found: %x, expected: %x",
-					proof.commitment, nb.nipst.poetMembershipProof.root)
+				nb.error("received an invalid PoET proof due to "+
+					"commitment value (expected: %x, found: %x)",
+					nb.nipst.poetMembershipProof.root, proof.commitment)
 			}
 
-			if !nb.verifyPoet(proof) {
-				nb.errChan <- fmt.Errorf("received an invalid PoET proof")
+			res, err := nb.verifyPoet(proof)
+			if err != nil {
+				nb.error("received an invalid PoET proof: %v", err)
+				break
+			}
+			if !res {
+				nb.error("received an invalid PoET proof")
 				break
 			}
 
-			log.Info("received a valid PoET proof from PoET proving service, "+
-				"service id: %v, round id: %v",
+			log.Info("received a valid PoET proof from PoET proving service "+
+				"(service id: %v, round id: %v)",
 				nb.poetProver.id(), nb.nipst.poetRound.id)
 
 			nb.nipst.poetProof = proof
@@ -335,20 +345,20 @@ func (nb *NIPSTBuilder) loop() {
 			// TODO(moshababo): check what exactly need to be hashed.
 			postChallenge := crypto.Keccak256Hash(nb.nipst.poetProof.serialize())
 
-			log.Info("starting PoST execution, challenge: %x",
+			log.Info("starting PoST execution (challenge: %x)",
 				postChallenge)
 
 			proof, err := nb.postProver.execute(nb.id, postChallenge, defTimeout)
 			if err != nil {
-				nb.errChan <- fmt.Errorf("failed to execute PoST: %v", err)
+				nb.error("failed to execute PoST: %v", err)
 				break
 			}
 			if !proof.valid() {
-				log.Error("received an invalid PoST proof")
+				nb.error("received an invalid PoST proof")
 				break
 			}
 
-			log.Info("finished PoST execution, proof: %x",
+			log.Info("finished PoST execution (proof: %x)",
 				*proof)
 
 			nb.nipst.postChallenge = &postChallenge
@@ -365,4 +375,10 @@ func (nb *NIPSTBuilder) loop() {
 		nb.nipst = initialNIPST(nb.id, nb.space, nb.duration, nb.nipst)
 		nb.nipst.persist()
 	}
+}
+
+func (nb *NIPSTBuilder) error(format string, a ...interface{}) {
+	err := fmt.Errorf(format, a...)
+	log.Error(err.Error())
+	nb.errChan <- err
 }

--- a/nipst/nipst_test.go
+++ b/nipst/nipst_test.go
@@ -52,8 +52,8 @@ func TestNIPSTBuilderWithMocks(t *testing.T) {
 
 	postProverMock := &PostProverClientMock{}
 	poetProverMock := &PoetProvingServiceClientMock{}
-	verifyMembershipMock := func(*common.Hash, *membershipProof) bool { return true }
-	verifyPoetMock := func(*poetProof) bool { return true }
+	verifyMembershipMock := func(*common.Hash, *membershipProof) (bool, error) { return true, nil }
+	verifyPoetMock := func(*poetProof) (bool, error) { return true, nil }
 	verifyPoetMembershipMock := func(*membershipProof, *poetProof) bool { return true }
 
 	nipstChan := make(chan *NIPST)

--- a/nipst/poet_test.go
+++ b/nipst/poet_test.go
@@ -68,12 +68,13 @@ func testRPCPoetClient(c *RPCPoetClient, assert *require.Assertions) {
 	mProof, err := c.subscribeMembershipProof(poetRound, ch, 10*time.Second)
 	assert.NoError(err)
 	assert.NotNil(mProof)
-	assert.True(mProof.valid())
+	assert.True(verifyMembership(&ch, mProof))
 
 	proof, err := c.subscribeProof(poetRound, 10*time.Second)
 	assert.NoError(err)
 	assert.NotNil(proof)
-	assert.True(proof.valid())
+	assert.True(verifyPoet(proof))
+	assert.True(verifyPoetMembership(mProof, proof))
 }
 
 func testRPCPoetClientTimeouts(c *RPCPoetClient, assert *require.Assertions) {

--- a/nipst/poet_test.go
+++ b/nipst/poet_test.go
@@ -68,12 +68,17 @@ func testRPCPoetClient(c *RPCPoetClient, assert *require.Assertions) {
 	mProof, err := c.subscribeMembershipProof(poetRound, ch, 10*time.Second)
 	assert.NoError(err)
 	assert.NotNil(mProof)
-	assert.True(verifyMembership(&ch, mProof))
+	res, err := verifyMembership(&ch, mProof)
+	assert.NoError(err)
+	assert.True(res)
 
 	proof, err := c.subscribeProof(poetRound, 10*time.Second)
 	assert.NoError(err)
 	assert.NotNil(proof)
-	assert.True(verifyPoet(proof))
+	res, err = verifyPoet(proof)
+	assert.NoError(err)
+	assert.True(res)
+
 	assert.True(verifyPoetMembership(mProof, proof))
 }
 


### PR DESCRIPTION
* Upgraded `poet-ref` & `merkle-tree`.
* Added validations for membership, poet, poetMembership to be used now in the NIPST constructions, and later in other places as well. 