### PR TITLE
Fix json api calls.

### DIFF
--- a/api/pb/api.proto
+++ b/api/pb/api.proto
@@ -15,8 +15,8 @@ message AccountId {
 message TransferFunds {
     AccountId sender =1;
     AccountId receiver =2;
-    uint64 Nonce =3;
-    uint64 Amount =4;
+    uint64 nonce =3;
+    uint64 amount =4;
 }
 
 message SignedTransaction {
@@ -27,7 +27,7 @@ message SignedTransaction {
 }
 
 message BroadcastMessage {
-    string Data = 1;
+    string data = 1;
 }
 
 message CommitmentSizeMessage {


### PR DESCRIPTION
in automation, we use JSON-API which is basically a proxy to our gRPC-API. the gRPC API generates the query structure from `prorobuf`'s `proto` files. using uppercase names in the `.proto` file results in uppercase members for the json equilivant. Using lowercase names won't affect the resulted `pb` files apart from the `json` structure tags.

conclusion: check the names in `.proto` file to validate.