### PR TITLE
Genesis epoch active-set-size as committee-size

### DIFF
--- a/hare/eligibility/oracle.go
+++ b/hare/eligibility/oracle.go
@@ -86,11 +86,10 @@ func (o *Oracle) buildVRFMessage(id types.NodeId, layer types.LayerID, round int
 	return w.Bytes(), nil
 }
 
-func (o *Oracle) activeSetSize(layer types.LayerID) (uint32, error) {
+func (o *Oracle) activeSetSize(layer types.LayerID, committeeSize int) (uint32, error) {
 	ep := safeLayer(layer).GetEpoch(o.layersPerEpoch)
 	if ep == 0 {
-		return 5, nil // TODO: agree on the inception problem
-		// return o.activeSetProvider.ActiveSetSize(0)
+		return uint32(committeeSize), nil
 	}
 	return o.activeSetProvider.ActiveSetSize(ep - 1)
 }
@@ -116,7 +115,7 @@ func (o *Oracle) Eligible(layer types.LayerID, round int32, committeeSize int, i
 	}
 
 	// get active set size
-	activeSetSize, err := o.activeSetSize(layer)
+	activeSetSize, err := o.activeSetSize(layer, committeeSize)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
This removes the active-set-size hardcoded value for genesis epoch. 