### PR TITLE
Fixed ticker issue

### DIFF
--- a/cmd/hare/hare.go
+++ b/cmd/hare/hare.go
@@ -164,7 +164,7 @@ func (app *HareApp) Start(cmd *cobra.Command, args []string) {
 	if err != nil {
 		log.Panic("error starting p2p err=%v", err)
 	}
-	app.clock.Start()
+	app.clock.StartNotifying()
 }
 
 func main() {

--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -438,7 +438,7 @@ func (app *SpacemeshApp) startServices() {
 	}
 	app.poetListener.Start()
 	app.atxBuilder.Start()
-	app.clock.Start()
+	app.clock.StartNotifying()
 }
 
 func (app SpacemeshApp) stopServices() {

--- a/mesh/mesh.go
+++ b/mesh/mesh.go
@@ -152,6 +152,7 @@ func (m *Mesh) ValidatedLayer() types.LayerID {
 	return m.validatedLayer
 }
 
+// LatestLayer - returns the latest layer we saw from the network
 func (m *Mesh) LatestLayer() types.LayerID {
 	defer m.lkMutex.RUnlock()
 	m.lkMutex.RLock()

--- a/sync/syncer.go
+++ b/sync/syncer.go
@@ -111,8 +111,8 @@ const (
 )
 
 func (s *Syncer) IsSynced() bool {
-	s.Log.Info("latest: %v, maxSynced %v", s.LatestLayer(), s.maxSyncLayer())
-	return s.LatestLayer()+1 >= s.maxSyncLayer()
+	s.Log.Info("latest: %v, maxSynced %v", s.LatestLayer(), s.lastTickedLayer())
+	return s.LatestLayer()+1 >= s.lastTickedLayer()
 }
 
 func (s *Syncer) Start() {
@@ -179,7 +179,7 @@ func NewSync(srv service.Service, layers *mesh.Mesh, txpool TxMemPool, atxpool A
 	return s
 }
 
-func (s *Syncer) maxSyncLayer() types.LayerID {
+func (s *Syncer) lastTickedLayer() types.LayerID {
 	defer s.currentLayerMutex.RUnlock()
 	s.currentLayerMutex.RLock()
 	return s.currentLayer
@@ -187,7 +187,7 @@ func (s *Syncer) maxSyncLayer() types.LayerID {
 
 func (s *Syncer) Synchronise() {
 	mu := sync.Mutex{}
-	for currentSyncLayer := s.ValidatedLayer() + 1; currentSyncLayer < s.maxSyncLayer(); currentSyncLayer++ {
+	for currentSyncLayer := s.ValidatedLayer() + 1; currentSyncLayer < s.lastTickedLayer(); currentSyncLayer++ {
 		s.Info("syncing layer %v current consensus layer is %d", currentSyncLayer, s.currentLayer)
 		lyr, err := s.GetLayer(types.LayerID(currentSyncLayer))
 		if err != nil {

--- a/sync/syncer_test.go
+++ b/sync/syncer_test.go
@@ -92,7 +92,7 @@ func SyncMockFactory(number int, conf Configuration, name string, dbType string,
 		txpool := miner.NewTypesTransactionIdMemPool()
 		atxpool := miner.NewTypesAtxIdMemPool()
 		sync := NewSync(net, getMesh(dbType, Path+name+"_"+time.Now().String()), txpool, atxpool, mockTxProcessor{}, blockValidator, poetDb(), conf, tk, 0, l)
-		ts.Start()
+		ts.StartNotifying()
 		nodes = append(nodes, sync)
 		p2ps = append(p2ps, net)
 	}
@@ -632,7 +632,7 @@ func Test_TwoNodes_SyncIntegrationSuite(t *testing.T) {
 		poetDb := activation.NewPoetDb(database.NewMemDatabase(), l.WithName("poetDb"))
 		sync := NewSync(s, msh, miner.NewTypesTransactionIdMemPool(), miner.NewTypesAtxIdMemPool(), mockTxProcessor{}, blockValidator, poetDb, conf, tk, 0, l)
 		sis.syncers = append(sis.syncers, sync)
-		ts.Start()
+		ts.StartNotifying()
 		atomic.AddUint32(&i, 1)
 	}
 	suite.Run(t, sis)
@@ -729,7 +729,7 @@ func Test_Multiple_SyncIntegrationSuite(t *testing.T) {
 		blockValidator := NewBlockValidator(BlockEligibilityValidatorMock{})
 		poetDb := activation.NewPoetDb(database.NewMemDatabase(), l.WithName("poetDb"))
 		sync := NewSync(s, msh, miner.NewTypesTransactionIdMemPool(), miner.NewTypesAtxIdMemPool(), mockTxProcessor{}, blockValidator, poetDb, conf, tk, 0, l)
-		ts.Start()
+		ts.StartNotifying()
 		sis.syncers = append(sis.syncers, sync)
 		atomic.AddUint32(&i, 1)
 	}


### PR DESCRIPTION
Two bugs:
1. init ticker (nextLayer) on NewTicker - important for users who assume they can use GetCurrentLayer before start
2. the name currentLayer is misleading and cause us to return the nextLayer instead of the current layer
