### PR TITLE
Syncer to handle nil response

### DIFF
--- a/sync/requests.go
+++ b/sync/requests.go
@@ -12,12 +12,13 @@ func LayerIdsReqFactory(lyr types.LayerID) RequestFactory {
 		resHandler := func(msg []byte) {
 			defer close(ch)
 			if msg == nil {
+				s.Info("received empty layer ids response")
 				return
 			}
 
 			ids, err := types.BytesToBlockIds(msg)
 			if err != nil {
-				s.Error("could not unmarshal mesh.LayerIDs response")
+				s.Error("could not unmarshal layer ids response: %v", err)
 				return
 			}
 
@@ -36,6 +37,7 @@ func HashReqFactory(lyr types.LayerID) RequestFactory {
 		resHandler := func(msg []byte) {
 			defer close(ch)
 			if msg == nil {
+				s.Info("received empty layer hash response")
 				return
 			}
 
@@ -66,13 +68,14 @@ func BlockReqFactory() BlockRequestFactory {
 		resHandler := func(msg []byte) {
 			defer close(ch)
 			if msg == nil {
+				s.Info("received empty block data response")
 				return
 			}
 
 			var block types.Block
 			err := types.BytesToInterface(msg, &block)
 			if err != nil {
-				s.Error("could not unmarshal block data", err)
+				s.Error("could not unmarshal block data response: %v", err)
 				return
 			}
 
@@ -94,13 +97,14 @@ func TxReqFactory(ids []types.TransactionId) RequestFactory {
 		resHandler := func(msg []byte) {
 			defer close(ch)
 			if msg == nil {
+				s.Info("received empty tx data response")
 				return
 			}
 
 			var tx []types.SerializableSignedTransaction
 			err := types.BytesToInterface(msg, &tx)
 			if err != nil {
-				s.Error("could not unmarshal tx data %v", err)
+				s.Error("could not unmarshal tx data response: %v", err)
 				return
 			}
 
@@ -123,16 +127,16 @@ func ATxReqFactory(ids []types.AtxId) RequestFactory {
 	return func(s *server.MessageServer, peer p2p.Peer) (chan interface{}, error) {
 		ch := make(chan interface{}, 1)
 		resHandler := func(msg []byte) {
-			s.Info("handle atx response ")
 			defer close(ch)
 			if msg == nil {
+				s.Info("received empty atx data response")
 				return
 			}
 
 			var tx []types.ActivationTx
 			err := types.BytesToInterface(msg, &tx)
 			if err != nil {
-				s.Error("could not unmarshal tx data %v", err)
+				s.Error("could not unmarshal atx data response: %v", err)
 				return
 			}
 
@@ -164,16 +168,16 @@ func PoetReqFactory(poetProofRef []byte) RequestFactory {
 	return func(s *server.MessageServer, peer p2p.Peer) (chan interface{}, error) {
 		ch := make(chan interface{}, 1)
 		resHandler := func(msg []byte) {
-			s.Info("handle PoET proof response")
 			defer close(ch)
 			if msg == nil {
+				s.Info("received empty PoET proof response")
 				return
 			}
 
 			var proofMessage types.PoetProofMessage
 			err := types.BytesToInterface(msg, &proofMessage)
 			if err != nil {
-				s.Error("could not unmarshal PoET proof message: %v", err)
+				s.Error("could not unmarshal PoET proof response: %v", err)
 				return
 			}
 

--- a/sync/requests.go
+++ b/sync/requests.go
@@ -9,16 +9,21 @@ import (
 func LayerIdsReqFactory(lyr types.LayerID) RequestFactory {
 	return func(s *server.MessageServer, peer p2p.Peer) (chan interface{}, error) {
 		ch := make(chan interface{}, 1)
-		foo := func(msg []byte) {
+		resHandler := func(msg []byte) {
 			defer close(ch)
+			if msg == nil {
+				return
+			}
+
 			ids, err := types.BytesToBlockIds(msg)
 			if err != nil {
 				s.Error("could not unmarshal mesh.LayerIDs response")
 				return
 			}
+
 			ch <- ids
 		}
-		if err := s.SendRequest(LAYER_IDS, lyr.ToBytes(), peer, foo); err != nil {
+		if err := s.SendRequest(LAYER_IDS, lyr.ToBytes(), peer, resHandler); err != nil {
 			return nil, err
 		}
 		return ch, nil
@@ -28,11 +33,15 @@ func LayerIdsReqFactory(lyr types.LayerID) RequestFactory {
 func HashReqFactory(lyr types.LayerID) RequestFactory {
 	return func(s *server.MessageServer, peer p2p.Peer) (chan interface{}, error) {
 		ch := make(chan interface{}, 1)
-		foo := func(msg []byte) {
+		resHandler := func(msg []byte) {
 			defer close(ch)
+			if msg == nil {
+				return
+			}
+
 			ch <- &peerHashPair{peer: peer, hash: msg}
 		}
-		if err := s.SendRequest(LAYER_HASH, lyr.ToBytes(), peer, foo); err != nil {
+		if err := s.SendRequest(LAYER_HASH, lyr.ToBytes(), peer, resHandler); err != nil {
 			return nil, err
 		}
 
@@ -54,18 +63,23 @@ func BlockReqFactory() BlockRequestFactory {
 	//convert to chan
 	return func(s *server.MessageServer, peer p2p.Peer, id types.BlockID) (chan interface{}, error) {
 		ch := make(chan interface{}, 1)
-		foo := func(msg []byte) {
+		resHandler := func(msg []byte) {
 			defer close(ch)
+			if msg == nil {
+				return
+			}
+
 			var block types.Block
 			err := types.BytesToInterface(msg, &block)
 			if err != nil {
 				s.Error("could not unmarshal block data", err)
 				return
 			}
+
 			ch <- &block
 		}
 
-		if err := s.SendRequest(MINI_BLOCK, id.ToBytes(), peer, foo); err != nil {
+		if err := s.SendRequest(MINI_BLOCK, id.ToBytes(), peer, resHandler); err != nil {
 			return nil, err
 		}
 
@@ -77,14 +91,19 @@ func BlockReqFactory() BlockRequestFactory {
 func TxReqFactory(ids []types.TransactionId) RequestFactory {
 	return func(s *server.MessageServer, peer p2p.Peer) (chan interface{}, error) {
 		ch := make(chan interface{}, 1)
-		foo := func(msg []byte) {
+		resHandler := func(msg []byte) {
 			defer close(ch)
+			if msg == nil {
+				return
+			}
+
 			var tx []types.SerializableSignedTransaction
 			err := types.BytesToInterface(msg, &tx)
 			if err != nil {
 				s.Error("could not unmarshal tx data %v", err)
 				return
 			}
+
 			ch <- tx
 		}
 
@@ -93,7 +112,7 @@ func TxReqFactory(ids []types.TransactionId) RequestFactory {
 			return nil, err
 		}
 
-		if err := s.SendRequest(TX, bts, peer, foo); err != nil {
+		if err := s.SendRequest(TX, bts, peer, resHandler); err != nil {
 			return nil, err
 		}
 		return ch, nil
@@ -103,9 +122,13 @@ func TxReqFactory(ids []types.TransactionId) RequestFactory {
 func ATxReqFactory(ids []types.AtxId) RequestFactory {
 	return func(s *server.MessageServer, peer p2p.Peer) (chan interface{}, error) {
 		ch := make(chan interface{}, 1)
-		foo := func(msg []byte) {
+		resHandler := func(msg []byte) {
 			s.Info("handle atx response ")
 			defer close(ch)
+			if msg == nil {
+				return
+			}
+
 			var tx []types.ActivationTx
 			err := types.BytesToInterface(msg, &tx)
 			if err != nil {
@@ -120,7 +143,7 @@ func ATxReqFactory(ids []types.AtxId) RequestFactory {
 		if err != nil {
 			return nil, err
 		}
-		if err := s.SendRequest(ATX, bts, peer, foo); err != nil {
+		if err := s.SendRequest(ATX, bts, peer, resHandler); err != nil {
 			return nil, err
 		}
 
@@ -134,6 +157,10 @@ func PoetReqFactory(poetProofRef []byte) RequestFactory {
 		resHandler := func(msg []byte) {
 			s.Info("handle PoET proof response")
 			defer close(ch)
+			if msg == nil {
+				return
+			}
+
 			var proofMessage types.PoetProofMessage
 			err := types.BytesToInterface(msg, &proofMessage)
 			if err != nil {

--- a/sync/syncer_test.go
+++ b/sync/syncer_test.go
@@ -233,7 +233,6 @@ func TestSyncProtocol_LayerHashRequest(t *testing.T) {
 	case <-timeout.C:
 		assert.Fail(t, "no message received on channel")
 	}
-
 }
 
 func TestSyncer_FetchPoetProofAvailableAndValid(t *testing.T) {
@@ -361,7 +360,6 @@ func TestSyncProtocol_LayerIdsRequest(t *testing.T) {
 	case <-timeout.C:
 		assert.Fail(t, "no message received on channel")
 	}
-
 }
 
 func TestSyncProtocol_FetchBlocks(t *testing.T) {
@@ -977,4 +975,88 @@ func TestSyncer_ConcurrentSynchronise(t *testing.T) {
 	f()
 	time.Sleep(100 * time.Millisecond) // handle go routine race
 	r.Equal(1, lv.calls)
+}
+
+func TestSyncProtocol_NilResponse(t *testing.T) {
+	syncs, nodes := SyncMockFactory(2, conf, "TestSyncProtocol_NilResponse", memoryDB, newMemPoetDb)
+	defer syncs[0].Close()
+	defer syncs[1].Close()
+
+	var nonExistingLayerId = types.LayerID(0)
+	var nonExistingBlockId = types.BlockID(0)
+	var nonExistingTxId types.TransactionId
+	var nonExistingAtxId types.AtxId
+	var nonExistingPoetRef []byte
+
+	timeout := 1 * time.Second
+	timeoutErrMsg := "no message received on channel"
+
+	// Layer Hash
+
+	wrk, output := NewPeersWorker(syncs[0], []p2p.Peer{nodes[1].PublicKey()}, &sync.Once{}, HashReqFactory(nonExistingLayerId))
+	go wrk.Work()
+
+	select {
+	case out := <-output:
+		assert.Nil(t, out)
+	case <-time.After(timeout):
+		assert.Fail(t, timeoutErrMsg)
+	}
+
+	// Layer Block Ids
+
+	wrk, output = NewPeersWorker(syncs[0], []p2p.Peer{nodes[1].PublicKey()}, &sync.Once{}, LayerIdsReqFactory(nonExistingLayerId))
+	go wrk.Work()
+
+	select {
+	case out := <-output:
+		assert.Nil(t, out)
+	case <-time.After(timeout):
+		assert.Fail(t, timeoutErrMsg)
+	}
+
+	// Block
+
+	output = syncs[0].fetchWithFactory(NewBlockWorker(syncs[0], 1, BlockReqFactory(), blockSliceToChan([]types.BlockID{nonExistingBlockId})))
+
+	select {
+	case out := <-output:
+		assert.Nil(t, out)
+	case <-time.After(timeout):
+		assert.Fail(t, timeoutErrMsg)
+	}
+
+	// Tx
+
+	wrk = NewNeighborhoodWorker(syncs[0], 1, TxReqFactory([]types.TransactionId{nonExistingTxId}))
+	go wrk.Work()
+
+	select {
+	case out := <-wrk.output:
+		assert.Nil(t, out)
+	case <-time.After(timeout):
+		assert.Fail(t, timeoutErrMsg)
+	}
+
+	// Atx
+
+	output = syncs[0].fetchWithFactory(NewNeighborhoodWorker(syncs[0], 1, ATxReqFactory([]types.AtxId{nonExistingAtxId})))
+
+	select {
+	case out := <-output:
+		assert.Nil(t, out)
+	case <-time.After(timeout):
+		assert.Fail(t, timeoutErrMsg)
+	}
+
+	// PoET
+
+	output = syncs[0].fetchWithFactory(NewNeighborhoodWorker(syncs[0], 1, PoetReqFactory(nonExistingPoetRef)))
+
+	select {
+	case out := <-output:
+		assert.Nil(t, out)
+	case <-time.After(timeout):
+		assert.Fail(t, timeoutErrMsg)
+	}
 }


### PR DESCRIPTION
Closing https://github.com/spacemeshos/go-spacemesh/issues/1199.

* checking for nil response in each handler mainly due to layer hash response, which doesn't get deserialized.
* the proposed (#1199) magic value wasn't added to responses. If you think it's a good idea LMK and i'll add it. @y0sher 