### PR TITLE
remove nipst poet proof ref

### DIFF
--- a/nipst/nipst.go
+++ b/nipst/nipst.go
@@ -179,7 +179,6 @@ func (nb *NIPSTBuilder) BuildNIPST(challenge *common.Hash) (*types.NIPST, error)
 			return nil, fmt.Errorf("not a member of this round (poetId: %x, roundId: %d)",
 				nb.state.PoetServiceId, nb.state.PoetRound.Id) // TODO(noamnelke): handle this case!
 		}
-		nipst.PoetProofRef = poetProofRef
 		nb.state.PoetProofRef = poetProofRef
 		nb.state.persist()
 	}
@@ -251,11 +250,10 @@ func NewNIPSTWithChallenge(challenge *common.Hash, poetRef []byte) *types.NIPST 
 		NipstChallenge: challenge,
 		PostProof: &types.PostProof{
 			Identity:     []byte(nil),
-			Challenge:    []byte(nil),
+			Challenge:    poetRef,
 			MerkleRoot:   []byte(nil),
 			ProofNodes:   [][]byte(nil),
 			ProvenLeaves: [][]byte(nil),
 		},
-		PoetProofRef: poetRef,
 	}
 }

--- a/sync/block_listener_test.go
+++ b/sync/block_listener_test.go
@@ -80,9 +80,9 @@ func TestBlockListener(t *testing.T) {
 	}
 	poetRef := sha256.Sum256(poetProofBytes)
 
-	atx1.Nipst.PoetProofRef = poetRef[:]
-	atx2.Nipst.PoetProofRef = poetRef[:]
-	atx3.Nipst.PoetProofRef = poetRef[:]
+	atx1.Nipst.PostProof.Challenge = poetRef[:]
+	atx2.Nipst.PostProof.Challenge = poetRef[:]
+	atx3.Nipst.PostProof.Challenge = poetRef[:]
 
 	bl1.ProcessAtx(atx1)
 	bl1.ProcessAtx(atx2)
@@ -147,7 +147,7 @@ func TestBlockListener_DataAvailability(t *testing.T) {
 	require.NoError(t, err)
 	poetRef := sha256.Sum256(poetProofBytes)
 
-	atx1.Nipst.PoetProofRef = poetRef[:]
+	atx1.Nipst.PostProof.Challenge = poetRef[:]
 
 	// Push a block with tx1 and and atx1 into bl1.
 
@@ -437,7 +437,7 @@ func TestBlockListener_ListenToGossipBlocks(t *testing.T) {
 		t.Error(err)
 	}
 	poetRef := sha256.Sum256(poetProofBytes)
-	atx.Nipst.PoetProofRef = poetRef[:]
+	atx.Nipst.PostProof.Challenge = poetRef[:]
 
 	bl2.AddBlockWithTxs(blk, []*types.AddressableSignedTransaction{tx}, []*types.ActivationTx{atx})
 

--- a/sync/syncer_test.go
+++ b/sync/syncer_test.go
@@ -284,7 +284,7 @@ func TestSyncer_SyncAtxs_FetchPoetProof(t *testing.T) {
 	poetRef := sha256.Sum256(poetProofBytes)
 
 	atx1 := atx()
-	atx1.Nipst.PoetProofRef = poetRef[:]
+	atx1.Nipst.PostProof.Challenge = poetRef[:]
 	s0.AtxDB.ProcessAtx(atx1)
 
 	// Make sure that s1 syncAtxs would fetch the missing poet proof.

--- a/types/activation.go
+++ b/types/activation.go
@@ -157,11 +157,11 @@ func (atx *ActivationTx) CalcAndSetId() {
 }
 
 func (atx *ActivationTx) GetPoetProofRef() []byte {
-	return atx.Nipst.PoetProofRef
+	return atx.Nipst.PostProof.Challenge
 }
 
 func (atx *ActivationTx) GetShortPoetProofRef() []byte {
-	return atx.Nipst.PoetProofRef[:common.Min(5, len(atx.Nipst.PoetProofRef))]
+	return atx.Nipst.PostProof.Challenge[:common.Min(5, len(atx.Nipst.PostProof.Challenge))]
 }
 
 type PoetProof struct {
@@ -209,9 +209,6 @@ type NIPST struct {
 	// postProof is the proof that the prover data
 	// is still stored (or was recomputed).
 	PostProof *PostProof
-
-	// reference to the PoET proof, should be available to all since the PoET proof is propagated over gossip
-	PoetProofRef []byte
 }
 
 type PostProof proving.Proof


### PR DESCRIPTION
It already appears as the challenge in the post proof and we never implemented validation that this field actually matches anything, causing a security issue.

Closes #1133 

### TODO:
- [x] Ensure that this change won't break the sync test due to pre-serialized old-structure data (use `test_sync.go` to test locally)