### PR TITLE
Fix resetting challenge

### DIFF
--- a/activation/activation.go
+++ b/activation/activation.go
@@ -270,7 +270,8 @@ func (b *Builder) PublishActivationTx(epoch types.EpochId) error {
 					log.Error("cannot discard challenge")
 				}
 			}
-		} else {
+		}
+		if b.challenge == nil {
 			err := b.buildNipstChallenge(epoch)
 			if err != nil {
 				if _, alreadyPublished := err.(alreadyPublishedErr); alreadyPublished {

--- a/activation/activation_test.go
+++ b/activation/activation_test.go
@@ -490,5 +490,7 @@ func TestBuilder_NipstPublishRecovery(t *testing.T) {
 	err = b.loadChallenge()
 	assert.NoError(t, err)
 	err = b.PublishActivationTx(3)
+	// This 👇 ensures that handing of the challenge succeeded and the code moved on to the next part
+	assert.EqualError(t, err, "cannot find pos atx in epoch 3: cannot find pos atx id: current posAtx (epoch 1) does not belong to the requested epoch (3)")
 	assert.True(t, db.hadNone)
 }


### PR DESCRIPTION
Previously, if we discarded the challenge we got left with no challenge at all, causing the following error:
```
getting challenge hash failed: error marshalling NIPST Challenge: xdr:Marshal: can't marshal nil pointer '*types.NIPSTChallenge'
```