### PR TITLE
Send notify message on last round

### DIFF
--- a/hare/algorithm.go
+++ b/hare/algorithm.go
@@ -580,6 +580,12 @@ func (proc *ConsensusProcess) endOfRound1() {
 }
 
 func (proc *ConsensusProcess) endOfRound3() {
+	// release proposal & commit trackers
+	defer func() {
+		proc.commitTracker = nil
+		proc.proposalTracker = nil
+	}()
+
 	if proc.proposalTracker.IsConflicting() {
 		proc.Warning("Round 3 ended: proposal is conflicting")
 		return
@@ -605,10 +611,6 @@ func (proc *ConsensusProcess) endOfRound3() {
 	// update set & matching certificate
 	proc.s = s
 	proc.certificate = cert
-
-	// release proposal & commit trackers
-	proc.commitTracker = nil
-	proc.proposalTracker = nil
 }
 
 func (proc *ConsensusProcess) shouldParticipate() bool {

--- a/hare/algorithm.go
+++ b/hare/algorithm.go
@@ -436,12 +436,6 @@ func (proc *ConsensusProcess) beginRound3() {
 }
 
 func (proc *ConsensusProcess) beginRound4() {
-	// release proposal & commit trackers
-	defer func() {
-		proc.commitTracker = nil
-		proc.proposalTracker = nil
-	}()
-
 	// send notify message only once
 	if proc.notifySent {
 		proc.Info("Notify already sent")
@@ -611,6 +605,10 @@ func (proc *ConsensusProcess) endOfRound3() {
 	// commit & send notification msg
 	proc.s = s
 	proc.certificate = cert
+
+	// release proposal & commit trackers
+	proc.commitTracker = nil
+	proc.proposalTracker = nil
 }
 
 func (proc *ConsensusProcess) shouldParticipate() bool {

--- a/hare/algorithm.go
+++ b/hare/algorithm.go
@@ -602,7 +602,7 @@ func (proc *ConsensusProcess) endOfRound3() {
 		return
 	}
 
-	// commit & send notification msg
+	// update set & matching certificate
 	proc.s = s
 	proc.certificate = cert
 

--- a/hare/algorithm_test.go
+++ b/hare/algorithm_test.go
@@ -551,15 +551,12 @@ func TestConsensusProcess_beginRound4(t *testing.T) {
 	proc.beginRound1()
 	proc.beginRound2()
 	proc.beginRound3()
-	r.NotNil(proc.commitTracker)
-	r.NotNil(proc.proposalTracker)
 
 	net := &mockNet{}
 	proc.network = net
 	proc.beginRound4()
 	r.Equal(1, net.callBroadcast)
-	r.Nil(proc.commitTracker)
-	r.Nil(proc.proposalTracker)
+	r.True(proc.notifySent)
 }
 
 func TestConsensusProcess_handlePending(t *testing.T) {
@@ -577,6 +574,8 @@ func TestConsensusProcess_handlePending(t *testing.T) {
 }
 
 func TestConsensusProcess_endOfRound3(t *testing.T) {
+	r := require.New(t)
+
 	proc := generateConsensusProcess(t)
 	net := &mockP2p{}
 	proc.network = net
@@ -585,28 +584,45 @@ func TestConsensusProcess_endOfRound3(t *testing.T) {
 	mct := &mockCommitTracker{}
 	proc.commitTracker = mct
 	proc.endOfRound3()
-	assert.Equal(t, 1, mpt.countIsConflicting)
+	r.Equal(1, mpt.countIsConflicting)
+	r.NotNil(proc.proposalTracker)
+	r.NotNil(proc.commitTracker)
+
 	mpt.isConflicting = true
 	proc.endOfRound3()
-	assert.Equal(t, 2, mpt.countIsConflicting)
-	assert.Equal(t, 1, mct.countHasEnoughCommits)
+	r.Equal(2, mpt.countIsConflicting)
+	r.Equal(1, mct.countHasEnoughCommits)
+	r.NotNil(proc.proposalTracker)
+	r.NotNil(proc.commitTracker)
+
 	mpt.isConflicting = false
 	mct.hasEnoughCommits = false
 	proc.endOfRound3()
-	assert.Equal(t, 0, mct.countBuildCertificate)
+	r.Equal(0, mct.countBuildCertificate)
+	r.NotNil(proc.proposalTracker)
+	r.NotNil(proc.commitTracker)
+
 	mct.hasEnoughCommits = true
 	mct.certificate = nil
 	proc.endOfRound3()
-	assert.Equal(t, 1, mct.countBuildCertificate)
-	assert.Equal(t, 0, mpt.countProposedSet)
+	r.Equal(1, mct.countBuildCertificate)
+	r.Equal(0, mpt.countProposedSet)
+	r.NotNil(proc.proposalTracker)
+	r.NotNil(proc.commitTracker)
+
 	mct.certificate = &Certificate{}
 	proc.endOfRound3()
 	mpt.proposedSet = nil
 	proc.s = NewSmallEmptySet()
 	proc.endOfRound3()
-	assert.NotNil(t, proc.s)
+	r.NotNil(proc.s)
+	r.NotNil(proc.proposalTracker)
+	r.NotNil(proc.commitTracker)
+
 	mpt.proposedSet = NewSetFromValues(value1)
 	proc.endOfRound3()
-	assert.True(t, proc.s.Equals(mpt.proposedSet))
-	assert.Equal(t, mct.certificate, proc.certificate)
+	r.True(proc.s.Equals(mpt.proposedSet))
+	r.Equal(mct.certificate, proc.certificate)
+	r.Nil(proc.proposalTracker)
+	r.Nil(proc.commitTracker)
 }

--- a/hare/algorithm_test.go
+++ b/hare/algorithm_test.go
@@ -580,45 +580,54 @@ func TestConsensusProcess_endOfRound3(t *testing.T) {
 	net := &mockP2p{}
 	proc.network = net
 	mpt := &mockProposalTracker{}
-	proc.proposalTracker = mpt
 	mct := &mockCommitTracker{}
+	proc.proposalTracker = mpt
 	proc.commitTracker = mct
 	proc.endOfRound3()
 	r.Equal(1, mpt.countIsConflicting)
-	r.NotNil(proc.proposalTracker)
-	r.NotNil(proc.commitTracker)
+	r.Nil(proc.proposalTracker)
+	r.Nil(proc.commitTracker)
 
+	proc.proposalTracker = mpt
+	proc.commitTracker = mct
 	mpt.isConflicting = true
 	proc.endOfRound3()
 	r.Equal(2, mpt.countIsConflicting)
 	r.Equal(1, mct.countHasEnoughCommits)
-	r.NotNil(proc.proposalTracker)
-	r.NotNil(proc.commitTracker)
+	r.Nil(proc.proposalTracker)
+	r.Nil(proc.commitTracker)
 
+	proc.proposalTracker = mpt
+	proc.commitTracker = mct
 	mpt.isConflicting = false
 	mct.hasEnoughCommits = false
 	proc.endOfRound3()
 	r.Equal(0, mct.countBuildCertificate)
-	r.NotNil(proc.proposalTracker)
-	r.NotNil(proc.commitTracker)
+	r.Nil(proc.proposalTracker)
+	r.Nil(proc.commitTracker)
 
+	proc.proposalTracker = mpt
+	proc.commitTracker = mct
 	mct.hasEnoughCommits = true
 	mct.certificate = nil
 	proc.endOfRound3()
 	r.Equal(1, mct.countBuildCertificate)
 	r.Equal(0, mpt.countProposedSet)
-	r.NotNil(proc.proposalTracker)
-	r.NotNil(proc.commitTracker)
+	r.Nil(proc.proposalTracker)
+	r.Nil(proc.commitTracker)
 
+	proc.proposalTracker = mpt
+	proc.commitTracker = mct
 	mct.certificate = &Certificate{}
-	proc.endOfRound3()
 	mpt.proposedSet = nil
 	proc.s = NewSmallEmptySet()
 	proc.endOfRound3()
 	r.NotNil(proc.s)
-	r.NotNil(proc.proposalTracker)
-	r.NotNil(proc.commitTracker)
+	r.Nil(proc.proposalTracker)
+	r.Nil(proc.commitTracker)
 
+	proc.proposalTracker = mpt
+	proc.commitTracker = mct
 	mpt.proposedSet = NewSetFromValues(value1)
 	proc.endOfRound3()
 	r.True(proc.s.Equals(mpt.proposedSet))

--- a/hare/notifytracker.go
+++ b/hare/notifytracker.go
@@ -56,6 +56,7 @@ func calcId(k int32, set *Set) uint32 {
 	binary.LittleEndian.PutUint32(buff, uint32(k)) // K>=0 because this not pre-round
 	hash.Write(buff)
 
+	// TODO: is this hash enough for this usage?
 	// write set objectId
 	buff = make([]byte, 4)
 	binary.LittleEndian.PutUint32(buff, uint32(set.Id()))

--- a/tests/queries.py
+++ b/tests/queries.py
@@ -301,7 +301,7 @@ def query_round_2(indx, ns, layer):
 
 
 def query_round_3(indx, ns, layer):
-    return query_message(indx, ns, ns, {'M': 'Round 3 ended: committing', 'layer_id': str(layer)}, False)
+    return query_message(indx, ns, ns, {'M': 'message sent', 'msg_type': 'Commit', 'layer_id': str(layer)}, False)
 
 
 def query_pre_round(indx, ns, layer):
@@ -322,6 +322,7 @@ def query_new_iteration(indx, ns):
 
 def query_mem_usage(indx, ns):
     return query_message(indx, ns, ns, {'M': 'json_mem_data'}, False)
+
 
 def query_atx_published(indx, ns, layer):
     return query_message(indx, ns, ns, {'M': 'atx published', 'layer_id': str(layer)}, False)


### PR DESCRIPTION
Send notification on last round instead of the end of the commit round.
This will make sure we use a different committee for the notify message.