### PR TITLE
Remove node id from Hare oracle

### DIFF
--- a/eligibility/fixedoracle.go
+++ b/eligibility/fixedoracle.go
@@ -180,11 +180,10 @@ func (fo *FixedRolacle) Eligible(layer types.LayerID, round int32, committeeSize
 	return exist, nil
 }
 
-func (fo *FixedRolacle) Proof(id types.NodeId, layer types.LayerID, round int32) ([]byte, error) {
+func (fo *FixedRolacle) Proof(layer types.LayerID, round int32) ([]byte, error) {
 	kInBytes := make([]byte, 4)
 	binary.LittleEndian.PutUint32(kInBytes, uint32(round))
 	hash := fnv.New32()
-	hash.Write([]byte(id.Key))
 	hash.Write(kInBytes)
 
 	hashBytes := make([]byte, 4)

--- a/hare/algorithm.go
+++ b/hare/algorithm.go
@@ -19,7 +19,7 @@ const protoName = "HARE_PROTOCOL"
 
 type Rolacle interface {
 	Eligible(layer types.LayerID, round int32, committeeSize int, id types.NodeId, sig []byte) (bool, error)
-	Proof(id types.NodeId, layer types.LayerID, round int32) ([]byte, error)
+	Proof(layer types.LayerID, round int32) ([]byte, error)
 	IsIdentityActiveOnConsensusView(edId string, layer types.LayerID) (bool, error)
 }
 
@@ -469,7 +469,7 @@ func (proc *ConsensusProcess) onRoundBegin() {
 func (proc *ConsensusProcess) initDefaultBuilder(s *Set) (*MessageBuilder, error) {
 	builder := NewMessageBuilder().SetInstanceId(proc.instanceId)
 	builder = builder.SetRoundCounter(proc.k).SetKi(proc.ki).SetValues(s)
-	proof, err := proc.oracle.Proof(proc.nid, types.LayerID(proc.instanceId), proc.k)
+	proof, err := proc.oracle.Proof(types.LayerID(proc.instanceId), proc.k)
 	if err != nil {
 		proc.Error("Could not initialize default builder err=%v", err)
 		return nil, err
@@ -628,7 +628,7 @@ func (proc *ConsensusProcess) shouldParticipate() bool {
 
 // Returns the role matching the current round if eligible for this round, false otherwise
 func (proc *ConsensusProcess) currentRole() Role {
-	proof, err := proc.oracle.Proof(proc.nid, types.LayerID(proc.instanceId), proc.k)
+	proof, err := proc.oracle.Proof(types.LayerID(proc.instanceId), proc.k)
 	if err != nil {
 		proc.Error("Could not retrieve proof from oracle err=%v", err)
 		return Passive

--- a/hare/algorithm_test.go
+++ b/hare/algorithm_test.go
@@ -45,7 +45,7 @@ func (mr *mockRolacle) Eligible(layer types.LayerID, round int32, committeeSize 
 	return mr.isEligible, mr.err
 }
 
-func (mr *mockRolacle) Proof(id types.NodeId, layer types.LayerID, round int32) ([]byte, error) {
+func (mr *mockRolacle) Proof(layer types.LayerID, round int32) ([]byte, error) {
 	return []byte{}, nil
 }
 

--- a/hare/eligibility/oracle.go
+++ b/hare/eligibility/oracle.go
@@ -116,13 +116,12 @@ func New(beacon valueProvider, activeSetFunc activeSetFunc, vrfVerifier Verifier
 
 type vrfMessage struct {
 	Beacon uint32
-	Id     types.NodeId
 	Layer  types.LayerID
 	Round  int32
 }
 
 // buildVRFMessage builds the VRF message used as input for the BLS (msg=Beacon##Id##Layer##Round)
-func (o *Oracle) buildVRFMessage(id types.NodeId, layer types.LayerID, round int32) ([]byte, error) {
+func (o *Oracle) buildVRFMessage(layer types.LayerID, round int32) ([]byte, error) {
 	v, err := o.beacon.Value(layer)
 	if err != nil {
 		o.Error("Could not get Beacon value: %v", err)
@@ -130,7 +129,7 @@ func (o *Oracle) buildVRFMessage(id types.NodeId, layer types.LayerID, round int
 	}
 
 	var w bytes.Buffer
-	msg := vrfMessage{v, id, layer, round}
+	msg := vrfMessage{v, layer, round}
 	_, err = xdr.Marshal(&w, &msg)
 	if err != nil {
 		o.Error("Fatal: could not marshal xdr")
@@ -156,7 +155,7 @@ func (o *Oracle) activeSetSize(layer types.LayerID) (uint32, error) {
 
 // Eligible checks if Id is eligible on the given Layer where msg is the VRF message, sig is the role proof and assuming commSize as the expected committee size
 func (o *Oracle) Eligible(layer types.LayerID, round int32, committeeSize int, id types.NodeId, sig []byte) (bool, error) {
-	msg, err := o.buildVRFMessage(id, layer, round)
+	msg, err := o.buildVRFMessage(layer, round)
 	if err != nil {
 		o.Error("Could not build VRF message")
 		return false, err
@@ -203,8 +202,8 @@ func (o *Oracle) Eligible(layer types.LayerID, round int32, committeeSize int, i
 }
 
 // Proof returns the role proof for the current Layer & Round
-func (o *Oracle) Proof(id types.NodeId, layer types.LayerID, round int32) ([]byte, error) {
-	msg, err := o.buildVRFMessage(id, layer, round)
+func (o *Oracle) Proof(layer types.LayerID, round int32) ([]byte, error) {
+	msg, err := o.buildVRFMessage(layer, round)
 	if err != nil {
 		o.Error("Proof: could not build VRF message err=%v", err)
 		return nil, err

--- a/hare/eligibility/oracle_test.go
+++ b/hare/eligibility/oracle_test.go
@@ -94,7 +94,7 @@ func (mc *mockCacher) Get(key interface{}) (value interface{}, ok bool) {
 func TestOracle_BuildVRFMessage(t *testing.T) {
 	o := Oracle{Log: log.NewDefault(t.Name())}
 	o.beacon = &mockValueProvider{1, someErr}
-	_, err := o.buildVRFMessage(types.NodeId{}, types.LayerID(1), 1)
+	_, err := o.buildVRFMessage(types.LayerID(1), 1)
 	assert.NotNil(t, err)
 }
 
@@ -227,7 +227,7 @@ func Test_BlsSignVerify(t *testing.T) {
 	sr := BLS381.NewBlsSigner(pr)
 	o := New(&mockValueProvider{1, nil}, (&mockActiveSetProvider{10}).ActiveSet, BLS381.Verify2, sr, 10, genActive, mockBlocksProvider{}, cfg, log.NewDefault(t.Name()))
 	id := types.NodeId{Key: "abc", VRFPublicKey: pu}
-	proof, err := o.Proof(id, 1, 1)
+	proof, err := o.Proof(1, 1)
 	assert.Nil(t, err)
 	res, err := o.Eligible(1, 1, 10, id, proof)
 	assert.Nil(t, err)
@@ -236,19 +236,19 @@ func Test_BlsSignVerify(t *testing.T) {
 
 func TestOracle_Proof(t *testing.T) {
 	o := New(&mockValueProvider{0, myErr}, (&mockActiveSetProvider{10}).ActiveSet, buildVerifier(true, nil), &signer{}, 10, genActive, mockBlocksProvider{}, cfg, log.NewDefault(t.Name()))
-	sig, err := o.Proof(types.NodeId{}, 2, 3)
+	sig, err := o.Proof(2, 3)
 	assert.Nil(t, sig)
 	assert.NotNil(t, err)
 	assert.Equal(t, myErr, err)
 	o.beacon = &mockValueProvider{0, nil}
 	o.vrfSigner = &signer{nil, myErr}
-	sig, err = o.Proof(types.NodeId{}, 2, 3)
+	sig, err = o.Proof(2, 3)
 	assert.Nil(t, sig)
 	assert.NotNil(t, err)
 	assert.Equal(t, myErr, err)
 	mySig := []byte{1, 2}
 	o.vrfSigner = &signer{mySig, nil}
-	sig, err = o.Proof(types.NodeId{}, 2, 3)
+	sig, err = o.Proof(2, 3)
 	assert.Nil(t, err)
 	assert.Equal(t, mySig, sig)
 }

--- a/hare/mock_oracle.go
+++ b/hare/mock_oracle.go
@@ -120,6 +120,6 @@ func (mock *MockHashOracle) Eligible(layer types.LayerID, round int32, committee
 	return false, nil
 }
 
-func (m *MockHashOracle) Proof(id types.NodeId, layer types.LayerID, round int32) ([]byte, error) {
+func (m *MockHashOracle) Proof(layer types.LayerID, round int32) ([]byte, error) {
 	return []byte{}, nil
 }

--- a/oracle/oracle.go
+++ b/oracle/oracle.go
@@ -33,8 +33,8 @@ func (bo *localOracle) Eligible(layer types.LayerID, round int32, committeeSize 
 	return bo.oc.Eligible(layer, round, committeeSize, id, sig)
 }
 
-func (bo *localOracle) Proof(id types.NodeId, layer types.LayerID, round int32) ([]byte, error) {
-	return bo.oc.Proof(id, layer, round)
+func (bo *localOracle) Proof(layer types.LayerID, round int32) ([]byte, error) {
+	return bo.oc.Proof(layer, round)
 }
 
 func NewLocalOracle(rolacle *eligibility.FixedRolacle, committeeSize int, nodeID types.NodeId) *localOracle {
@@ -67,6 +67,6 @@ func (bo *hareOracle) Eligible(layer types.LayerID, round int32, committeeSize i
 	return bo.oc.Eligible(layer, round, committeeSize, id, sig)
 }
 
-func (bo *hareOracle) Proof(id types.NodeId, layer types.LayerID, round int32) ([]byte, error) {
-	return bo.oc.Proof(id, layer, round)
+func (bo *hareOracle) Proof(layer types.LayerID, round int32) ([]byte, error) {
+	return bo.oc.Proof(layer, round)
 }

--- a/oracle/oracle_client.go
+++ b/oracle/oracle_client.go
@@ -188,7 +188,7 @@ func (oc *OracleClient) Eligible(layer types.LayerID, round int32, committeeSize
 	return valid, nil
 }
 
-func (o *OracleClient) Proof(id types.NodeId, layer types.LayerID, round int32) ([]byte, error) {
+func (o *OracleClient) Proof(layer types.LayerID, round int32) ([]byte, error) {
 	return []byte{}, nil
 }
 func (oc *OracleClient) IsIdentityActive(s string, id types.LayerID) (bool, error) {


### PR DESCRIPTION
The node id is not required for the VRF message in the Hare oracle and hence is removed.