### PR TITLE
Revert address in wallet API to string

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/spacemeshos/ed25519"
 	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/common/util"
 	"github.com/spacemeshos/go-spacemesh/p2p/p2pcrypto"
 	"github.com/spacemeshos/go-spacemesh/p2p/service"
 	"github.com/spacemeshos/go-spacemesh/signing"
@@ -216,7 +217,7 @@ func TestJsonWalletApi(t *testing.T) {
 	ap.balances[addr] = big.NewInt(100)
 
 	// generate request payload (api input params)
-	payload := marshalProto(t, &pb.AccountId{Address: addrBytes})
+	payload := marshalProto(t, &pb.AccountId{Address: util.Bytes2Hex(addrBytes)})
 
 	respBody, respStatus := callEndpoint(t, "v1/nonce", payload)
 	require.Equal(t, http.StatusOK, respStatus)
@@ -252,7 +253,7 @@ func TestJsonWalletApi(t *testing.T) {
 	assertSimpleMessage(t, respBody, genTime.t.String())
 
 	// test get rewards per account
-	payload = marshalProto(t, &pb.AccountId{Address: addrBytes})
+	payload = marshalProto(t, &pb.AccountId{Address: util.Bytes2Hex(addrBytes)})
 	respBody, respStatus = callEndpoint(t, "v1/accountrewards", payload)
 	require.Equal(t, http.StatusOK, respStatus)
 
@@ -261,7 +262,7 @@ func TestJsonWalletApi(t *testing.T) {
 	require.Empty(t, rewards.Rewards) // TODO: Test with actual data returned
 
 	// test get txs per account
-	payload = marshalProto(t, &pb.GetTxsSinceLayer{Account: &pb.AccountId{Address: addrBytes}, StartLayer: 1})
+	payload = marshalProto(t, &pb.GetTxsSinceLayer{Account: &pb.AccountId{Address: util.Bytes2Hex(addrBytes)}, StartLayer: 1})
 	respBody, respStatus = callEndpoint(t, "v1/accounttxs", payload)
 	require.Equal(t, http.StatusOK, respStatus)
 
@@ -270,7 +271,7 @@ func TestJsonWalletApi(t *testing.T) {
 	require.Empty(t, accounts.Txs) // TODO: Test with actual data returned
 
 	// test get txs per account with wrong layer error
-	payload = marshalProto(t, &pb.GetTxsSinceLayer{Account: &pb.AccountId{Address: addrBytes}, StartLayer: 11})
+	payload = marshalProto(t, &pb.GetTxsSinceLayer{Account: &pb.AccountId{Address: util.Bytes2Hex(addrBytes)}, StartLayer: 11})
 	respBody, respStatus = callEndpoint(t, "v1/accounttxs", payload)
 	require.Equal(t, http.StatusInternalServerError, respStatus)
 	const ErrInvalidStartLayer = "{\"error\":\"invalid start layer\",\"message\":\"invalid start layer\",\"code\":2}"
@@ -338,8 +339,8 @@ func assertTx(t *testing.T, respTx pb.Transaction, tx *types.Transaction, status
 	r.Equal(tx.Id().Bytes(), respTx.TxId.Id)
 	r.Equal(tx.Fee, respTx.Fee)
 	r.Equal(tx.Amount, respTx.Amount)
-	r.Equal(tx.Recipient.Bytes(), respTx.Receiver.Address)
-	r.Equal(tx.Origin().Bytes(), respTx.Sender.Address)
+	r.Equal(util.Bytes2Hex(tx.Recipient.Bytes()), respTx.Receiver.Address)
+	r.Equal(util.Bytes2Hex(tx.Origin().Bytes()), respTx.Sender.Address)
 	r.Equal(layerId, respTx.LayerId)
 	r.Equal(status, respTx.Status.String())
 	r.Equal(timestamp, respTx.Timestamp)
@@ -419,7 +420,7 @@ func TestJsonWalletApi_Errors(t *testing.T) {
 
 	// generate request payload (api input params)
 	addrBytes := []byte{0x02} // address that does not exist
-	payload := marshalProto(t, &pb.AccountId{Address: addrBytes})
+	payload := marshalProto(t, &pb.AccountId{Address: util.Bytes2Hex(addrBytes)})
 	const expectedResponse = "{\"error\":\"account does not exist\",\"message\":\"account does not exist\",\"code\":2}"
 
 	respBody, respStatus := callEndpoint(t, "v1/nonce", payload)

--- a/api/grpc_server.go
+++ b/api/grpc_server.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/api/config"
 	"github.com/spacemeshos/go-spacemesh/api/pb"
 	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/common/util"
 	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/miner"
 	"net"
@@ -79,10 +80,10 @@ func (s SpacemeshGrpcService) GetTransaction(ctx context.Context, txId *pb.Trans
 	return &pb.Transaction{
 		TxId: txId,
 		Sender: &pb.AccountId{
-			Address: tx.Origin().Bytes(),
+			Address: util.Bytes2Hex(tx.Origin().Bytes()),
 		},
 		Receiver: &pb.AccountId{
-			Address: tx.Recipient.Bytes(),
+			Address: util.Bytes2Hex(tx.Recipient.Bytes()),
 		},
 		Amount:    tx.Amount,
 		Fee:       tx.Fee,
@@ -100,7 +101,7 @@ func (s SpacemeshGrpcService) Echo(ctx context.Context, in *pb.SimpleMessage) (*
 // Echo returns the response for an echo api request
 func (s SpacemeshGrpcService) GetBalance(ctx context.Context, in *pb.AccountId) (*pb.SimpleMessage, error) {
 	log.Info("GRPC GetBalance msg")
-	addr := types.BytesToAddress(in.Address)
+	addr := types.HexToAddress(in.Address)
 	log.Info("GRPC GetBalance for address %x (len %v)", addr, len(addr))
 	if s.StateApi.Exist(addr) != true {
 		log.Error("GRPC GetBalance returned error msg: account does not exist, address %x", addr)
@@ -116,7 +117,7 @@ func (s SpacemeshGrpcService) GetBalance(ctx context.Context, in *pb.AccountId) 
 // Echo returns the response for an echo api request
 func (s SpacemeshGrpcService) GetNonce(ctx context.Context, in *pb.AccountId) (*pb.SimpleMessage, error) {
 	log.Info("GRPC GetNonce msg")
-	addr := types.BytesToAddress(in.Address)
+	addr := types.HexToAddress(in.Address)
 
 	if s.StateApi.Exist(addr) != true {
 		log.Error("GRPC GetNonce got error msg: account does not exist, %v", addr)
@@ -261,7 +262,7 @@ func (s SpacemeshGrpcService) StartMining(ctx context.Context, message *pb.InitP
 
 func (s SpacemeshGrpcService) SetAwardsAddress(ctx context.Context, id *pb.AccountId) (*pb.SimpleMessage, error) {
 	log.Info("GRPC SetAwardsAddress msg")
-	addr := types.BytesToAddress(id.Address)
+	addr := types.HexToAddress(id.Address)
 	s.Mining.SetCoinbaseAccount(addr)
 	return &pb.SimpleMessage{Value: "ok"}, nil
 }
@@ -305,7 +306,7 @@ func (s SpacemeshGrpcService) SetLoggerLevel(ctx context.Context, msg *pb.SetLog
 
 func (s SpacemeshGrpcService) GetAccountTxs(ctx context.Context, txsSinceLayer *pb.GetTxsSinceLayer) (*pb.AccountTxs, error) {
 	log.Info("GRPC GetAccountTxs msg")
-	acc := types.BytesToAddress(txsSinceLayer.Account.Address)
+	acc := types.HexToAddress(txsSinceLayer.Account.Address)
 	if txsSinceLayer.StartLayer > uint64(s.Tx.LatestLayer()) {
 		return &pb.AccountTxs{}, fmt.Errorf("invalid start layer")
 	}
@@ -326,7 +327,7 @@ func (s SpacemeshGrpcService) GetAccountTxs(ctx context.Context, txsSinceLayer *
 
 func (s SpacemeshGrpcService) GetAccountRewards(ctx context.Context, account *pb.AccountId) (*pb.AccountRewards, error) {
 	log.Info("GRPC GetAccountRewards msg")
-	acc := types.BytesToAddress(account.Address)
+	acc := types.HexToAddress(account.Address)
 
 	rewards := s.Tx.GetRewards(acc)
 	rewardsOut := pb.AccountRewards{}

--- a/api/pb/api.proto
+++ b/api/pb/api.proto
@@ -39,7 +39,7 @@ message Transaction {
 }
 
 message AccountId {
-    bytes address = 1;
+    string address = 1;
 }
 
 message TransferFunds {


### PR DESCRIPTION
The change to `bytes` wreaked havoc on the tests, as seen [here](https://travis-ci.org/spacemeshos/go-spacemesh/jobs/614053680).

This now passes: https://ci.spacemesh.io/job/CI/job/mining_tests/36/console ✅