### PR TITLE
Signed txs in tests

### DIFF
--- a/common/types/transaction.go
+++ b/common/types/transaction.go
@@ -93,21 +93,6 @@ type InnerTransaction struct {
 	Amount       uint64
 }
 
-// TEST ONLY
-func NewTxWithOrigin(nonce uint64, orig, rec Address, amount, gasLimit, fee uint64) *Transaction {
-	inner := InnerTransaction{
-		AccountNonce: nonce,
-		Recipient:    rec,
-		Amount:       amount,
-		GasLimit:     gasLimit,
-		Fee:          fee,
-	}
-	return &Transaction{
-		InnerTransaction: inner,
-		origin:           &orig,
-	}
-}
-
 type Reward struct {
 	Layer  LayerID
 	Amount uint64

--- a/mesh/mesh_test.go
+++ b/mesh/mesh_test.go
@@ -125,7 +125,7 @@ func TestLayers_AddBlock(t *testing.T) {
 	block2 := types.NewExistingBlock(2, []byte("data2"))
 	block3 := types.NewExistingBlock(3, []byte("data3"))
 
-	addTransactionsWithFee(layers.MeshDB, block1, 4, rand.Int63n(100))
+	addTransactionsWithFee(t, layers.MeshDB, block1, 4, rand.Int63n(100))
 
 	err := layers.AddBlock(block1)
 	assert.NoError(t, err)

--- a/mesh/meshdb_test.go
+++ b/mesh/meshdb_test.go
@@ -50,7 +50,7 @@ func TestMeshDB_AddBlock(t *testing.T) {
 
 	block1 := types.NewExistingBlock(1, []byte("data1"))
 
-	addTransactionsWithFee(mdb, block1, 4, rand.Int63n(100))
+	addTransactionsWithFee(t, mdb, block1, 4, rand.Int63n(100))
 
 	poetRef := []byte{0xba, 0x05}
 	atx := types.NewActivationTx(types.NodeId{"aaaa", []byte("bbb")}, coinbase, 1, types.AtxId{}, 5, 1, types.AtxId{}, 5, []types.BlockID{}, &types.NIPST{

--- a/signing/signer.go
+++ b/signing/signer.go
@@ -51,6 +51,7 @@ func NewEdSignerFromBuffer(buff []byte) (*EdSigner, error) {
 	sgn := &EdSigner{privKey: buff, pubKey: buff[32:]}
 	keyPair := ed25519.NewKeyFromSeed(sgn.privKey[:32])
 	if !bytes.Equal(keyPair[32:], sgn.pubKey) {
+		log.Info("%v", keyPair[32:])
 		log.Error("Public key and private key does not match")
 		return nil, errors.New("private and public does not match")
 	}

--- a/signing/signer.go
+++ b/signing/signer.go
@@ -51,7 +51,6 @@ func NewEdSignerFromBuffer(buff []byte) (*EdSigner, error) {
 	sgn := &EdSigner{privKey: buff, pubKey: buff[32:]}
 	keyPair := ed25519.NewKeyFromSeed(sgn.privKey[:32])
 	if !bytes.Equal(keyPair[32:], sgn.pubKey) {
-		log.Info("%v", keyPair[32:])
 		log.Error("Public key and private key does not match")
 		return nil, errors.New("private and public does not match")
 	}

--- a/state/processor_test.go
+++ b/state/processor_test.go
@@ -60,8 +60,10 @@ func createAccount(state *StateDB, addr types.Address, balance int64, nonce uint
 	return obj1
 }
 
-func createTransaction(nonce uint64, origin types.Address, destination types.Address, amount uint64) *types.Transaction {
-	return types.NewTxWithOrigin(nonce, origin, destination, amount, 100, 5)
+func createTransaction(t *testing.T, nonce uint64, destination types.Address, amount, fee uint64, signer *signing.EdSigner) *types.Transaction {
+	tx, err := mesh.NewSignedTx(nonce, destination, amount, 100, fee, signer)
+	assert.NoError(t, err)
+	return tx
 }
 
 func (s *ProcessorStateSuite) TestTransactionProcessor_ApplyTransaction() {
@@ -70,13 +72,20 @@ func (s *ProcessorStateSuite) TestTransactionProcessor_ApplyTransaction() {
 	//test insufficient funds
 	//test wrong nonce
 	//test account doesn't exist
-	obj1 := createAccount(s.state, toAddr([]byte{0x01}), 21, 0)
+	signerBuf := []byte("22222222222222222222222222222222")
+	signerBuf = append(signerBuf, []byte{
+		94, 33, 44, 9, 128, 228, 179, 159, 192, 151, 33, 19, 74, 160, 33, 9,
+		55, 78, 223, 210, 96, 192, 211, 208, 60, 181, 1, 200, 214, 84, 87, 169,
+	}...)
+	signer, err := signing.NewEdSignerFromBuffer(signerBuf)
+	assert.NoError(s.T(), err)
+	obj1 := createAccount(s.state, SignerToAddr(signer), 21, 0)
 	obj2 := createAccount(s.state, toAddr([]byte{0x01, 02}), 1, 10)
 	createAccount(s.state, toAddr([]byte{0x02}), 44, 0)
 	s.state.Commit(false)
 
 	transactions := []*types.Transaction{
-		createTransaction(obj1.Nonce(), obj1.address, obj2.address, 1),
+		createTransaction(s.T(), obj1.Nonce(), obj2.address, 1, 5, signer),
 	}
 
 	failed, err := s.processor.ApplyTransactions(1, transactions)
@@ -89,12 +98,8 @@ func (s *ProcessorStateSuite) TestTransactionProcessor_ApplyTransaction() {
 	assert.Equal(s.T(), uint64(1), s.state.GetNonce(obj1.address))
 
 	want := `{
-	"root": "8e80968ce4ed49cb0caf0036691d531fc0db419b7ea3018fe0a1263de9bd886c",
+	"root": "6de6ffd7eda4c1aa4de66051e4ad05afc1233e089f9e9afaf8174a4dc483fa57",
 	"accounts": {
-		"0000000000000000000000000000000000000001": {
-			"balance": "15",
-			"nonce": 1
-		},
 		"0000000000000000000000000000000000000002": {
 			"balance": "44",
 			"nonce": 0
@@ -102,12 +107,20 @@ func (s *ProcessorStateSuite) TestTransactionProcessor_ApplyTransaction() {
 		"0000000000000000000000000000000000000102": {
 			"balance": "2",
 			"nonce": 10
+		},
+		"4aa02109374edfd260c0d3d03cb501c8d65457a9": {
+			"balance": "15",
+			"nonce": 1
 		}
 	}
 }`
 	if got != want {
 		s.T().Errorf("dump mismatch:\ngot: %s\nwant: %s\n", got, want)
 	}
+}
+
+func SignerToAddr(signer *signing.EdSigner) types.Address {
+	return types.BytesToAddress(signer.PublicKey().Bytes())
 }
 
 /*func (s *ProcessorStateSuite) TestTransactionProcessor_ApplyTransaction_DoubleTrans() {
@@ -159,31 +172,30 @@ func (s *ProcessorStateSuite) TestTransactionProcessor_ApplyTransaction() {
 }*/
 
 func (s *ProcessorStateSuite) TestTransactionProcessor_ApplyTransaction_Errors() {
-	obj1 := createAccount(s.state, toAddr([]byte{0x01}), 21, 0)
+	signer1 := signing.NewEdSigner()
+	obj1 := createAccount(s.state, SignerToAddr(signer1), 21, 0)
 	obj2 := createAccount(s.state, toAddr([]byte{0x01, 02}), 1, 10)
 	createAccount(s.state, toAddr([]byte{0x02}), 44, 0)
 	s.state.Commit(false)
 
 	transactions := []*types.Transaction{
-		createTransaction(obj1.Nonce(), obj1.address, obj2.address, 1),
+		createTransaction(s.T(), obj1.Nonce(), obj2.address, 1, 5, signer1),
 	}
 
 	failed, err := s.processor.ApplyTransactions(1, transactions)
 	assert.NoError(s.T(), err)
 	assert.True(s.T(), failed == 0)
 
-	err = s.processor.ApplyTransaction(createTransaction(0, obj1.address, obj2.address, 1), 0)
+	err = s.processor.ApplyTransaction(createTransaction(s.T(), 0, obj2.address, 1, 5, signer1), 0)
 	assert.Error(s.T(), err)
 	assert.Equal(s.T(), err.Error(), ErrNonce)
 
-	err = s.processor.ApplyTransaction(createTransaction(obj1.Nonce(), obj1.address, obj2.address, 21), 0)
+	err = s.processor.ApplyTransaction(createTransaction(s.T(), obj1.Nonce(), obj2.address, 21, 5, signer1), 0)
 	assert.Error(s.T(), err)
 	assert.Equal(s.T(), err.Error(), ErrFunds)
 
-	addr := toAddr([]byte{0x01, 0x01})
-
 	//Test origin
-	err = s.processor.ApplyTransaction(createTransaction(obj1.Nonce(), addr, obj2.address, 21), 0)
+	err = s.processor.ApplyTransaction(createTransaction(s.T(), obj1.Nonce(), obj2.address, 21, 5, signing.NewEdSigner()), 0)
 	assert.Error(s.T(), err)
 	assert.Equal(s.T(), err.Error(), ErrOrigin)
 }
@@ -205,16 +217,23 @@ func (s *ProcessorStateSuite) TestTransactionProcessor_ApplyRewards() {
 }
 
 func (s *ProcessorStateSuite) TestTransactionProcessor_ApplyTransaction_OrderByNonce() {
-	obj1 := createAccount(s.state, toAddr([]byte{0x01}), 25, 0)
+	signerBuf := []byte("22222222222222222222222222222222")
+	signerBuf = append(signerBuf, []byte{
+		94, 33, 44, 9, 128, 228, 179, 159, 192, 151, 33, 19, 74, 160, 33, 9,
+		55, 78, 223, 210, 96, 192, 211, 208, 60, 181, 1, 200, 214, 84, 87, 169,
+	}...)
+	signer, err := signing.NewEdSignerFromBuffer(signerBuf)
+	assert.NoError(s.T(), err)
+	obj1 := createAccount(s.state, SignerToAddr(signer), 25, 0)
 	obj2 := createAccount(s.state, toAddr([]byte{0x01, 02}), 1, 10)
 	obj3 := createAccount(s.state, toAddr([]byte{0x02}), 44, 0)
 	s.state.Commit(false)
 
 	transactions := []*types.Transaction{
-		createTransaction(obj1.Nonce()+3, obj1.address, obj3.address, 1),
-		createTransaction(obj1.Nonce()+2, obj1.address, obj3.address, 1),
-		createTransaction(obj1.Nonce()+1, obj1.address, obj3.address, 1),
-		createTransaction(obj1.Nonce(), obj1.address, obj2.address, 1),
+		createTransaction(s.T(), obj1.Nonce()+3, obj3.address, 1, 5, signer),
+		createTransaction(s.T(), obj1.Nonce()+2, obj3.address, 1, 5, signer),
+		createTransaction(s.T(), obj1.Nonce()+1, obj3.address, 1, 5, signer),
+		createTransaction(s.T(), obj1.Nonce(), obj2.address, 1, 5, signer),
 	}
 
 	s.processor.ApplyTransactions(1, transactions)
@@ -226,12 +245,8 @@ func (s *ProcessorStateSuite) TestTransactionProcessor_ApplyTransaction_OrderByN
 	assert.Equal(s.T(), uint64(2), s.state.GetBalance(obj2.address))
 
 	want := `{
-	"root": "e5212ec1f253fc4d7f77a591f66770ccae676ece70823287638ad7c5f988bced",
+	"root": "0fb9e074115e49b9a1d33949de2578459c158d8885ca10ad9edcd5d3a84fd67c",
 	"accounts": {
-		"0000000000000000000000000000000000000001": {
-			"balance": "1",
-			"nonce": 4
-		},
 		"0000000000000000000000000000000000000002": {
 			"balance": "47",
 			"nonce": 0
@@ -239,6 +254,10 @@ func (s *ProcessorStateSuite) TestTransactionProcessor_ApplyTransaction_OrderByN
 		"0000000000000000000000000000000000000102": {
 			"balance": "2",
 			"nonce": 10
+		},
+		"4aa02109374edfd260c0d3d03cb501c8d65457a9": {
+			"balance": "1",
+			"nonce": 4
 		}
 	}
 }`
@@ -248,13 +267,28 @@ func (s *ProcessorStateSuite) TestTransactionProcessor_ApplyTransaction_OrderByN
 }
 
 func (s *ProcessorStateSuite) TestTransactionProcessor_Reset() {
-	obj1 := createAccount(s.state, toAddr([]byte{0x01}), 21, 0)
-	obj2 := createAccount(s.state, toAddr([]byte{0x01, 02}), 41, 10)
+	signer1Buf := []byte("22222222222222222222222222222222")
+	signer1Buf = append(signer1Buf, []byte{
+		94, 33, 44, 9, 128, 228, 179, 159, 192, 151, 33, 19, 74, 160, 33, 9,
+		55, 78, 223, 210, 96, 192, 211, 208, 60, 181, 1, 200, 214, 84, 87, 169,
+	}...)
+	signer2Buf := []byte("33333333333333333333333333333333")
+	signer2Buf = append(signer2Buf, []byte{
+		23, 203, 121, 251, 43, 65, 32, 242, 177, 236, 101, 228, 25, 141, 110, 8,
+		178, 142, 129, 63, 235, 1, 228, 164, 0, 131, 155, 133, 225, 128, 128, 206,
+	}...)
+
+	signer1, err := signing.NewEdSignerFromBuffer(signer1Buf)
+	assert.NoError(s.T(), err)
+	signer2, err := signing.NewEdSignerFromBuffer(signer2Buf)
+	assert.NoError(s.T(), err)
+	obj1 := createAccount(s.state, SignerToAddr(signer1), 21, 0)
+	obj2 := createAccount(s.state, SignerToAddr(signer2), 41, 10)
 	createAccount(s.state, toAddr([]byte{0x02}), 44, 0)
 	s.state.Commit(false)
 
 	transactions := []*types.Transaction{
-		createTransaction(obj1.Nonce(), obj1.address, obj2.address, 1),
+		createTransaction(s.T(), obj1.Nonce(), obj2.address, 1, 5, signer1),
 		//createTransaction(obj2.Nonce(),obj2.address, obj1.address, 1),
 	}
 
@@ -263,8 +297,8 @@ func (s *ProcessorStateSuite) TestTransactionProcessor_Reset() {
 	assert.True(s.T(), failed == 0)
 
 	transactions = []*types.Transaction{
-		createTransaction(obj1.Nonce(), obj1.address, obj2.address, 1),
-		createTransaction(obj2.Nonce(), obj2.address, obj1.address, 10),
+		createTransaction(s.T(), obj1.Nonce(), obj2.address, 1, 5, signer1),
+		createTransaction(s.T(), obj2.Nonce(), obj1.address, 10, 5, signer2),
 	}
 
 	failed, err = s.processor.ApplyTransactions(2, transactions)
@@ -274,19 +308,19 @@ func (s *ProcessorStateSuite) TestTransactionProcessor_Reset() {
 	got := string(s.processor.globalState.Dump())
 
 	want := `{
-	"root": "abe8e506a6a6aeb5e0eb14e7733c85d60f619a93cabe8579fc16c3c106a0ffb1",
+	"root": "4b7174d31e60ef1ed970137079e2b8044d9c381422dbcbe16e561d8a51a9f651",
 	"accounts": {
-		"0000000000000000000000000000000000000001": {
-			"balance": "19",
-			"nonce": 2
-		},
 		"0000000000000000000000000000000000000002": {
 			"balance": "44",
 			"nonce": 0
 		},
-		"0000000000000000000000000000000000000102": {
+		"198d6e08b28e813feb01e4a400839b85e18080ce": {
 			"balance": "28",
 			"nonce": 11
+		},
+		"4aa02109374edfd260c0d3d03cb501c8d65457a9": {
+			"balance": "19",
+			"nonce": 2
 		}
 	}
 }`
@@ -301,32 +335,25 @@ func (s *ProcessorStateSuite) TestTransactionProcessor_Reset() {
 	assert.Equal(s.T(), uint64(15), s.processor.globalState.GetBalance(obj1.address))
 
 	want = `{
-	"root": "351199c464a9be1b7c78aeecb6f83f04e38316fa98d7d45a2d9fc475d4c3b857",
+	"root": "9273645f6b9a62f32500021f5e0a89d3eb6ffd36b1b9f9f82fcaad4555951e97",
 	"accounts": {
-		"0000000000000000000000000000000000000001": {
-			"balance": "15",
-			"nonce": 1
-		},
 		"0000000000000000000000000000000000000002": {
 			"balance": "44",
 			"nonce": 0
 		},
-		"0000000000000000000000000000000000000102": {
+		"198d6e08b28e813feb01e4a400839b85e18080ce": {
 			"balance": "42",
 			"nonce": 10
+		},
+		"4aa02109374edfd260c0d3d03cb501c8d65457a9": {
+			"balance": "15",
+			"nonce": 1
 		}
 	}
 }`
 	if got != want {
 		s.T().Errorf("dump mismatch:\ngot: %s\nwant: %s\n", got, want)
 	}
-}
-
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
 }
 
 func (s *ProcessorStateSuite) TestTransactionProcessor_Multilayer() {
@@ -338,14 +365,20 @@ func (s *ProcessorStateSuite) TestTransactionProcessor_Multilayer() {
 	revertAfterLayer := rand.Intn(testCycles - revertToLayer) //rand.Intn(min(testCycles - revertToLayer,maxPastStates))
 	log.Info("starting test: revert on layer %v, after %v layers received since that layer ", revertToLayer, revertAfterLayer)
 
-	obj1 := createAccount(s.state, toAddr([]byte{0x01}), 5218762487624, 0)
-	obj2 := createAccount(s.state, toAddr([]byte{0x01, 02}), 341578872634786, 10)
-	obj3 := createAccount(s.state, toAddr([]byte{0x02}), 1044987234, 0)
+	signers := []*signing.EdSigner{
+		signing.NewEdSigner(),
+		signing.NewEdSigner(),
+		signing.NewEdSigner(),
+	}
+	accounts := []*StateObj{
+		createAccount(s.state, toAddr(signers[0].PublicKey().Bytes()), 5218762487624, 0),
+		createAccount(s.state, toAddr(signers[1].PublicKey().Bytes()), 341578872634786, 10),
+		createAccount(s.state, toAddr(signers[2].PublicKey().Bytes()), 1044987234, 0),
+	}
 
 	s.state.Commit(false)
 
 	written := s.db.Len()
-	accounts := []*StateObj{obj1, obj2, obj3}
 
 	var want string
 	for i := 0; i < testCycles; i++ {
@@ -354,7 +387,8 @@ func (s *ProcessorStateSuite) TestTransactionProcessor_Multilayer() {
 		nonceTrack := make(map[*StateObj]int)
 		for j := 0; j < numOfTransactions; j++ {
 
-			srcAccount := accounts[int(rand.Uint32()%(uint32(len(accounts)-1)))]
+			src := int(rand.Uint32() % (uint32(len(accounts) - 1)))
+			srcAccount := accounts[src]
 			dstAccount := accounts[int(rand.Uint32()%(uint32(len(accounts)-1)))]
 
 			if _, ok := nonceTrack[srcAccount]; !ok {
@@ -366,8 +400,7 @@ func (s *ProcessorStateSuite) TestTransactionProcessor_Multilayer() {
 			for dstAccount == srcAccount {
 				dstAccount = accounts[int(rand.Uint32()%(uint32(len(accounts)-1)))]
 			}
-			t := createTransaction(s.processor.globalState.GetNonce(srcAccount.address)+uint64(nonceTrack[srcAccount]),
-				srcAccount.address, dstAccount.address, (rand.Uint64()%srcAccount.Balance().Uint64())/100)
+			t := createTransaction(s.T(), s.processor.globalState.GetNonce(srcAccount.address)+uint64(nonceTrack[srcAccount]), dstAccount.address, (rand.Uint64()%srcAccount.Balance().Uint64())/100, 5, signers[src])
 			trns = append(trns, t)
 
 			log.Info("transaction %v nonce %v amount %v", t.Origin().Hex(), t.AccountNonce, t.Amount)
@@ -397,44 +430,47 @@ func (s *ProcessorStateSuite) TestTransactionProcessor_Multilayer() {
 	assert.True(s.T(), writtenMore > written)
 }
 
-func newTx(origin types.Address, nonce, totalAmount uint64) *types.Transaction {
+func newTx(t *testing.T, nonce, totalAmount uint64, signer *signing.EdSigner) *types.Transaction {
 	feeAmount := uint64(1)
-	return types.NewTxWithOrigin(nonce, origin, types.Address{}, totalAmount-feeAmount, 3, feeAmount)
+	return createTransaction(t, nonce, types.Address{}, totalAmount-feeAmount, feeAmount, signer)
 }
 
 func (s *ProcessorStateSuite) TestTransactionProcessor_ValidateNonceAndBalance() {
 	r := require.New(s.T())
-	origin := types.BytesToAddress([]byte("abc"))
+	signer := signing.NewEdSigner()
+	origin := types.BytesToAddress(signer.PublicKey().Bytes())
 	s.processor.globalState.SetBalance(origin, big.NewInt(100))
 	s.processor.globalState.SetNonce(origin, 5)
 	s.projector.balanceDiff = 10
 	s.projector.nonceDiff = 2
 
-	err := s.processor.ValidateNonceAndBalance(newTx(origin, 7, 10))
+	err := s.processor.ValidateNonceAndBalance(newTx(s.T(), 7, 10, signer))
 	r.NoError(err)
 }
 
 func (s *ProcessorStateSuite) TestTransactionProcessor_ValidateNonceAndBalance_WrongNonce() {
 	r := require.New(s.T())
-	origin := types.BytesToAddress([]byte("abc"))
+	signer := signing.NewEdSigner()
+	origin := types.BytesToAddress(signer.PublicKey().Bytes())
 	s.processor.globalState.SetBalance(origin, big.NewInt(100))
 	s.processor.globalState.SetNonce(origin, 5)
 	s.projector.balanceDiff = 10
 	s.projector.nonceDiff = 2
 
-	err := s.processor.ValidateNonceAndBalance(newTx(origin, 8, 10))
+	err := s.processor.ValidateNonceAndBalance(newTx(s.T(), 8, 10, signer))
 	r.EqualError(err, "incorrect account nonce! Expected: 7, Actual: 8")
 }
 
 func (s *ProcessorStateSuite) TestTransactionProcessor_ValidateNonceAndBalance_InsufficientBalance() {
 	r := require.New(s.T())
-	origin := types.BytesToAddress([]byte("abc"))
+	signer := signing.NewEdSigner()
+	origin := types.BytesToAddress(signer.PublicKey().Bytes())
 	s.processor.globalState.SetBalance(origin, big.NewInt(100))
 	s.processor.globalState.SetNonce(origin, 5)
 	s.projector.balanceDiff = 10
 	s.projector.nonceDiff = 2
 
-	err := s.processor.ValidateNonceAndBalance(newTx(origin, 7, 95))
+	err := s.processor.ValidateNonceAndBalance(newTx(s.T(), 7, 95, signer))
 	r.EqualError(err, "insufficient balance! Available: 90, Attempting to spend: 94[amount]+1[fee]=95")
 }
 

--- a/sync/block_listener_test.go
+++ b/sync/block_listener_test.go
@@ -587,7 +587,8 @@ func TestBlockListener_ListenToGossipBlocks(t *testing.T) {
 	bl1.Start()
 	bl2.Start()
 
-	tx := types.NewTxWithOrigin(0, types.BytesToAddress([]byte{0x01}), types.BytesToAddress([]byte{0x02}), 10, 10, 10)
+	tx, err := mesh.NewSignedTx(1, types.BytesToAddress([]byte{0x01}), 10, 100, 10, signing.NewEdSigner())
+	assert.NoError(t, err)
 	signer := signing.NewEdSigner()
 	atx := atx(signer.PublicKey().String())
 

--- a/sync/create_baseline_test.go
+++ b/sync/create_baseline_test.go
@@ -16,10 +16,23 @@ import (
 
 var proof []byte
 
+type blockBuilderMock struct{}
+
+func (blockBuilderMock) ValidateAndAddTxToPool(tx *types.Transaction) error {
+	return nil
+}
+
 func TestCreateBaseline(t *testing.T) {
-	t.Skip()
+	//t.Skip()
+
+	const (
+		numOfLayers    = 20 // 201
+		blocksPerLayer = 50 // 200
+		txPerBlock     = 10 // 50
+		atxPerBlock    = 5  // 5
+	)
+
 	id := Path
-	layerSize := 200
 	lg := log.New(id, "", "")
 	mshdb, _ := mesh.NewPersistentMeshDB(id, lg.WithOptions(log.Nop))
 	nipstStore, _ := database.NewLDBDatabase(id+"nipst", 0, 0, lg.WithName("nipstDbStore").WithOptions(log.Nop))
@@ -27,9 +40,10 @@ func TestCreateBaseline(t *testing.T) {
 	atxdbStore, _ := database.NewLDBDatabase(id+"atx", 0, 0, lg.WithOptions(log.Nop))
 	defer atxdbStore.Close()
 	atxdb := activation.NewActivationDb(atxdbStore, &MockIStore{}, mshdb, uint16(1000), &ValidatorMock{}, lg.WithName("atxDB").WithOptions(log.Nop))
-	trtl := tortoise.NewAlgorithm(int(layerSize), mshdb, 1, lg.WithName("trtl"))
+	trtl := tortoise.NewAlgorithm(blocksPerLayer, mshdb, 1, lg.WithName("trtl"))
 	msh := mesh.NewMesh(mshdb, atxdb, rewardConf, trtl, &MockTxMemPool{}, &MockAtxMemPool{}, &stateMock{}, lg.WithOptions(log.Nop))
 	defer msh.Close()
+	msh.SetBlockBuilder(&blockBuilderMock{})
 	poetDbStore, err := database.NewLDBDatabase(id+"poet", 0, 0, lg.WithName("poetDbStore").WithOptions(log.Nop))
 	if err != nil {
 		lg.Error("error: ", err)
@@ -46,18 +60,18 @@ func TestCreateBaseline(t *testing.T) {
 	poetDb.ValidateAndStore(&proofMessage)
 
 	lg.Info("start creating baseline")
-	createBaseline(msh, 201, layerSize, layerSize, 50, 5)
+	createBaseline(msh, numOfLayers, blocksPerLayer, blocksPerLayer, txPerBlock, atxPerBlock)
 
-	i := 1
-	for ; ; i++ {
-		if lyr, err2 := msh.GetLayer(types.LayerID(i)); err2 != nil || lyr == nil {
-			lg.Info("loaded %v layers from disk %v", i-1, err2)
-			break
-		} else {
-			lg.Info("loaded layer %v from disk ", i)
-			msh.ValidateLayer(lyr)
-		}
-	}
+	//i := 1
+	//for ; ; i++ {
+	//	if lyr, err2 := msh.GetLayer(types.LayerID(i)); err2 != nil || lyr == nil {
+	//		lg.Info("loaded %v layers from disk %v", i-1, err2)
+	//		break
+	//	} else {
+	//		lg.Info("loaded layer %v from disk ", i)
+	//		msh.ValidateLayer(lyr)
+	//	}
+	//}
 }
 
 func txs(num int) ([]*types.Transaction, []types.TransactionId) {
@@ -92,11 +106,11 @@ func createBaseline(msh *mesh.Mesh, layers int, layerSize int, patternSize int, 
 
 	lyrs = append(lyrs, l)
 	for i := 0; i < layers-1; i++ {
-		lg.Info("!!-------------------------new layer %v-------------------------!!!!", i)
+		lg.Debug("!!-------------------------new layer %v-------------------------!!!!", i)
 		start := time.Now()
 		lyr := createLayerWithRandVoting(msh, l.Index()+1, []*types.Layer{l}, layerSize, patternSize, txPerBlock, atxPerBlock)
 		lyrs = append(lyrs, lyr)
-		lg.Debug("Time inserting layer into db: %v ", time.Since(start))
+		lg.Info("Time inserting layer into db: %v ", time.Since(start))
 		l = lyr
 	}
 
@@ -119,11 +133,11 @@ func createLayerWithRandVoting(msh *mesh.Mesh, index types.LayerID, prev []*type
 		for idx, pat := range patterns {
 			for _, id := range pat {
 				b := prev[idx].Blocks()[id]
-				bl.AddVote(types.BlockID(b.Id()))
+				bl.AddVote(b.Id())
 			}
 		}
 		for _, prevBloc := range prev[0].Blocks() {
-			bl.AddView(types.BlockID(prevBloc.Id()))
+			bl.AddView(prevBloc.Id())
 		}
 
 		//add txs
@@ -136,7 +150,7 @@ func createLayerWithRandVoting(msh *mesh.Mesh, index types.LayerID, prev []*type
 
 		start := time.Now()
 		msh.AddBlockWithTxs(bl, txs, atxs)
-		log.Info("added block %v", time.Since(start))
+		log.Debug("added block %v", time.Since(start))
 		l.AddBlock(bl)
 
 	}

--- a/sync/syncer_test.go
+++ b/sync/syncer_test.go
@@ -883,10 +883,10 @@ end:
 func tx() *types.Transaction {
 	fee := rand.Uint64()
 	addr := rand.Int63n(1000000)
-	tx := types.NewTxWithOrigin(1, types.HexToAddress(rand.RandString(8)),
-		types.HexToAddress(strconv.FormatUint(uint64(addr), 10)),
-		10, 100, fee)
-
+	tx, err := mesh.NewSignedTx(1, types.HexToAddress(strconv.FormatUint(uint64(addr), 10)), 10, 100, fee, signing.NewEdSigner())
+	if err != nil {
+		log.Panic("failed to create transaction: %v", err)
+	}
 	return tx
 }
 


### PR DESCRIPTION
We used to have `NewTxWithOrigin` which created a transaction and set its `origin` field. The problem is that this field isn't serialized and is recreated from the signature whenever a transaction is stored in the DB or transmitted.

This caused a hard-to-track-down bug in tests, where the derived origin was identical between transactions that weren't supposed to be from the same origin.

To prevent this from happening in the future, I've entirely removed the `NewTxWithOrigin` method, to prevent misuse of it and replaced it with uses of `NewSignedTx`, which takes an `EdSigner` as input, instead of an origin.