### PR TITLE
Ping check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ arm6: genproto
 
 
 test: genproto
-	ulimit -n 500; go test -timeout 0 -p 1 ./...
+	ulimit -n 500; go test -v -timeout 0 -p 1 github.com/spacemeshos/go-spacemesh/p2p/discovery
 .PHONY: test
 
 

--- a/p2p/discovery/addrbook.go
+++ b/p2p/discovery/addrbook.go
@@ -90,6 +90,9 @@ type addrBook struct {
 	addrNew   [newBucketCount]map[node.ID]*KnownAddress
 	addrTried [triedBucketCount]map[node.ID]*KnownAddress
 
+	// Keep track of how recently we've successfully completed a roundtrip ping with an address.
+	addrPinged map[node.ID]*KnownAddress
+
 	//todo: lock local for updates
 	localAddress *node.NodeInfo
 

--- a/p2p/discovery/addrbook.go
+++ b/p2p/discovery/addrbook.go
@@ -247,14 +247,11 @@ func (a *addrBook) GetAddress() *KnownAddress {
 }
 
 func (a *addrBook) Lookup(addr p2pcrypto.PublicKey) (*node.NodeInfo, error) {
-	a.mtx.Lock()
-	d, ok := a.addrIndex[addr.Array()]
-	a.mtx.Unlock()
-	if !ok {
-		// Todo: just return empty without error ?
-		return nil, ErrLookupFailed
+	if d, err := a.LookupKnownAddress(addr); err != nil {
+		return nil, err
+	} else {
+		return d.na, nil
 	}
-	return d.na, nil
 }
 
 func (a *addrBook) LookupKnownAddress(addr p2pcrypto.PublicKey) (*KnownAddress, error) {

--- a/p2p/discovery/discovery.go
+++ b/p2p/discovery/discovery.go
@@ -38,6 +38,7 @@ type addressBook interface {
 	RemoveAddress(key p2pcrypto.PublicKey)
 	NeedNewAddresses() bool
 	Lookup(key p2pcrypto.PublicKey) (*node.NodeInfo, error)
+	LookupKnownAddress(key p2pcrypto.PublicKey) (*KnownAddress, error)
 	AddAddress(addr, srcAddr *node.NodeInfo)
 	AddAddresses(addrs []*node.NodeInfo, srcAddr *node.NodeInfo)
 	AddressCache() []*node.NodeInfo

--- a/p2p/discovery/discovery_mock.go
+++ b/p2p/discovery/discovery_mock.go
@@ -203,6 +203,11 @@ func (m *mockAddrBook) Lookup(pubkey p2pcrypto.PublicKey) (*node.NodeInfo, error
 	return m.lookupRes, m.lookupErr
 }
 
+// LookupKnownAddress mock
+func (m *mockAddrBook) LookupKnownAddress(addr p2pcrypto.PublicKey) (*KnownAddress, error) {
+	return m.GetAddress(), nil
+}
+
 // GetAddress mock
 func (m *mockAddrBook) GetAddress() *KnownAddress {
 	if m.GetAddressFunc != nil {

--- a/p2p/discovery/getaddress.go
+++ b/p2p/discovery/getaddress.go
@@ -17,7 +17,6 @@ func (p *protocol) newGetAddressesRequestHandler() func(msg server.Message) []by
 		t := time.Now()
 		plogger := p.logger.WithFields(log.String("type", "getaddresses"), log.String("from", msg.Sender().String()))
 		plogger.Debug("got request")
-		pi := &node.NodeInfo{}
 
 		// This peer should've sent a PING before GETADDRESSES, so they should already be
 		// in our address book. However, we still need to PING them at their advertised
@@ -36,7 +35,7 @@ func (p *protocol) newGetAddressesRequestHandler() func(msg server.Message) []by
 			if err := p.Ping(msg.Sender()); err != nil {
 				plogger.Warning("Peer failed to respond to ping, dropping getaddresses request and removing from addrbook: %v", peer.String())
 				// Go ahead and drop the peer from the address book
-				p.table.RemoveAddress(pi.PublicKey())
+				p.table.RemoveAddress(peer)
 				return nil
 			}
 		}

--- a/p2p/discovery/getaddress.go
+++ b/p2p/discovery/getaddress.go
@@ -22,17 +22,22 @@ func (p *protocol) newGetAddressesRequestHandler() func(msg server.Message) []by
 		// we must ensure that he's indeed listening on that address = check last pong
 		ka, err := p.table.LookupKnownAddress(msg.Sender())
 		if err != nil {
-			p.logger.Error("Error looking up message sender (GetAddress): %v", msg.Sender())
+			p.logger.Error("Error looking up message sender (GetAddress) Peer: %v", msg.Sender())
 			return nil
 		}
 		// Check if we've pinged this peer recently enough
+		// Should we attempt to send a ping here? It shouldn't be necessary, since the node
+		// requesting addresses should have pinged us first, and we should have already sent
+		// a ping in response.
 		if ka.NeedsPing() {
-			if err := p.Ping(msg.Sender()); err != nil {
-				p.logger.Error("Error pinging peer (GetAddress): %v", msg.Sender())
-				return nil
-			}
+			p.logger.Warning("Failed ping check (GetAddress) Peer: %v", msg.Sender())
+			return nil
+			//if err := p.Ping(msg.Sender()); err != nil {
+			//	p.logger.Error("Error pinging peer (GetAddress): %v", msg.Sender())
+			//	return nil
+			//}
 		}
-		p.logger.Debug("Passed ping check, recently pinged Peer %v", msg.Sender())
+		p.logger.Debug("Passed ping check, recently pinged (GetAddress) Peer: %v", msg.Sender())
 
 		results := p.table.AddressCache()
 		// remove the sender from the list

--- a/p2p/discovery/known_address.go
+++ b/p2p/discovery/known_address.go
@@ -15,7 +15,7 @@ type KnownAddress struct {
 	lastSeen    time.Time
 	lastattempt time.Time
 	lastsuccess time.Time
-	lastpong	time.Time // last successful ping response
+	lastping	time.Time // last successful ping response
 	tried       bool
 	refs        int // reference count of new buckets
 }
@@ -27,6 +27,19 @@ func (ka *KnownAddress) DiscNode() *node.NodeInfo {
 // LastAttempt returns the last time the known address was attempted.
 func (ka *KnownAddress) LastAttempt() time.Time {
 	return ka.lastattempt
+}
+
+// NeedsPing returns whether we need to ping this node again.
+func (ka *KnownAddress) NeedsPing() bool {
+	if ka.lastping.Before(time.Now().Add(-1 * pingInterval * time.Hour)) {
+		return true
+	}
+	return false
+}
+
+// Mark this address as having just been successfully roundtrip pinged.
+func (ka *KnownAddress) updatePing() {
+	ka.lastping = time.Now()
 }
 
 // chance returns the selection probability for a known address.  The priority

--- a/p2p/discovery/known_address.go
+++ b/p2p/discovery/known_address.go
@@ -15,6 +15,7 @@ type KnownAddress struct {
 	lastSeen    time.Time
 	lastattempt time.Time
 	lastsuccess time.Time
+	lastpong	time.Time // last successful ping response
 	tried       bool
 	refs        int // reference count of new buckets
 }

--- a/p2p/discovery/known_address.go
+++ b/p2p/discovery/known_address.go
@@ -31,10 +31,7 @@ func (ka *KnownAddress) LastAttempt() time.Time {
 
 // NeedsPing returns whether we need to ping this node again.
 func (ka *KnownAddress) NeedsPing() bool {
-	if ka.lastping.Before(time.Now().Add(-1 * pingInterval * time.Hour)) {
-		return true
-	}
-	return false
+	return ka.lastping.Before(time.Now().Add(-1 * pingInterval * time.Hour))
 }
 
 // Mark this address as having just been successfully roundtrip pinged.

--- a/p2p/discovery/known_address.go
+++ b/p2p/discovery/known_address.go
@@ -15,7 +15,7 @@ type KnownAddress struct {
 	lastSeen    time.Time
 	lastattempt time.Time
 	lastsuccess time.Time
-	lastping	time.Time // last successful ping response
+	lastping    time.Time // last successful ping response
 	tried       bool
 	refs        int // reference count of new buckets
 }

--- a/p2p/discovery/known_address_test.go
+++ b/p2p/discovery/known_address_test.go
@@ -151,6 +151,6 @@ func TestNeedsPing(t *testing.T) {
 	// and when it actually runs, so add a minute here to be safe.
 	if TstKnownAddressNeedsPing(TstNewKnownAddress(time.Now(),
 		0, time.Now(), time.Now(), threshold.Add(1 * time.Minute), false, 0)) {
-		t.Errorf("test case 5: address pinged just after threshold should not need ping.")
+		t.Errorf("test case 4: address pinged just after threshold should not need ping.")
 	}
 }

--- a/p2p/discovery/known_address_test.go
+++ b/p2p/discovery/known_address_test.go
@@ -136,7 +136,7 @@ func TestNeedsPing(t *testing.T) {
 	}
 	// Test an address that was never pinged.
 	if !TstKnownAddressNeedsPing(TstNewKnownAddress(time.Now(),
-			0, time.Now(), time.Now(), never, false, 0)) {
+		0, time.Now(), time.Now(), never, false, 0)) {
 		t.Errorf("test case 2: never-pinged address should need ping.")
 	}
 
@@ -150,7 +150,7 @@ func TestNeedsPing(t *testing.T) {
 	// Test an address pinged just after the threshold. NOTE: a few ms will elapse between when we construct this test
 	// and when it actually runs, so add a minute here to be safe.
 	if TstKnownAddressNeedsPing(TstNewKnownAddress(time.Now(),
-		0, time.Now(), time.Now(), threshold.Add(1 * time.Minute), false, 0)) {
+		0, time.Now(), time.Now(), threshold.Add(1*time.Minute), false, 0)) {
 		t.Errorf("test case 4: address pinged just after threshold should not need ping.")
 	}
 }

--- a/p2p/discovery/known_address_test.go
+++ b/p2p/discovery/known_address_test.go
@@ -14,10 +14,14 @@ func TstKnownAddressChance(ka *KnownAddress) float64 {
 	return ka.chance()
 }
 
+func TstKnownAddressNeedsPing(ka *KnownAddress) bool {
+	return ka.NeedsPing()
+}
+
 func TstNewKnownAddress(lastSeen time.Time, attempts int,
-	lastattempt, lastsuccess time.Time, tried bool, refs int) *KnownAddress {
+	lastattempt, lastsuccess time.Time, lastping time.Time, tried bool, refs int) *KnownAddress {
 	return &KnownAddress{lastSeen: lastSeen, attempts: attempts, lastattempt: lastattempt,
-		lastsuccess: lastsuccess, tried: tried, refs: refs}
+		lastsuccess: lastsuccess, lastping: lastping, tried: tried, refs: refs}
 }
 
 func TestChance(t *testing.T) {
@@ -29,27 +33,27 @@ func TestChance(t *testing.T) {
 		{
 			//Test normal case
 			TstNewKnownAddress(now.Add(-35*time.Second),
-				0, time.Now().Add(-30*time.Minute), time.Now(), false, 0),
+				0, time.Now().Add(-30*time.Minute), time.Now(), time.Now(), false, 0),
 			1.0,
 		}, {
 			//Test case in which lastseen < 0
 			TstNewKnownAddress(now.Add(20*time.Second),
-				0, time.Now().Add(-30*time.Minute), time.Now(), false, 0),
+				0, time.Now().Add(-30*time.Minute), time.Now(), time.Now(), false, 0),
 			1.0,
 		}, {
 			//Test case in which lastattempt < 0
 			TstNewKnownAddress(now.Add(-35*time.Second),
-				0, time.Now().Add(30*time.Minute), time.Now(), false, 0),
+				0, time.Now().Add(30*time.Minute), time.Now(), time.Now(), false, 0),
 			1.0 * .01,
 		}, {
 			//Test case in which lastattempt < ten minutes
 			TstNewKnownAddress(now.Add(-35*time.Second),
-				0, time.Now().Add(-5*time.Minute), time.Now(), false, 0),
+				0, time.Now().Add(-5*time.Minute), time.Now(), time.Now(), false, 0),
 			1.0 * .01,
 		}, {
 			//Test case with several failed attempts.
 			TstNewKnownAddress(now.Add(-35*time.Second),
-				2, time.Now().Add(-30*time.Minute), time.Now(), false, 0),
+				2, time.Now().Add(-30*time.Minute), time.Now(), time.Now(), false, 0),
 			1 * math.Pow(0.66, 2), // 2 attemps
 		},
 	}
@@ -78,44 +82,75 @@ func TestIsBad(t *testing.T) {
 	currentNa := secondsOld
 
 	//Test addresses that have been tried in the last minute.
-	if TstKnownAddressIsBad(TstNewKnownAddress(futureNa, 3, secondsOld, zeroTime, false, 0)) {
+	if TstKnownAddressIsBad(TstNewKnownAddress(futureNa, 3, secondsOld, zeroTime, time.Now(), false, 0)) {
 		t.Errorf("test case 1: addresses that have been tried in the last minute are not bad.")
 	}
-	if TstKnownAddressIsBad(TstNewKnownAddress(monthOldNa, 3, secondsOld, zeroTime, false, 0)) {
+	if TstKnownAddressIsBad(TstNewKnownAddress(monthOldNa, 3, secondsOld, zeroTime, time.Now(), false, 0)) {
 		t.Errorf("test case 2: addresses that have been tried in the last minute are not bad.")
 	}
-	if TstKnownAddressIsBad(TstNewKnownAddress(currentNa, 3, secondsOld, zeroTime, false, 0)) {
+	if TstKnownAddressIsBad(TstNewKnownAddress(currentNa, 3, secondsOld, zeroTime, time.Now(), false, 0)) {
 		t.Errorf("test case 3: addresses that have been tried in the last minute are not bad.")
 	}
-	if TstKnownAddressIsBad(TstNewKnownAddress(currentNa, 3, secondsOld, monthOld, true, 0)) {
+	if TstKnownAddressIsBad(TstNewKnownAddress(currentNa, 3, secondsOld, monthOld, time.Now(), true, 0)) {
 		t.Errorf("test case 4: addresses that have been tried in the last minute are not bad.")
 	}
-	if TstKnownAddressIsBad(TstNewKnownAddress(currentNa, 2, secondsOld, secondsOld, true, 0)) {
+	if TstKnownAddressIsBad(TstNewKnownAddress(currentNa, 2, secondsOld, secondsOld, time.Now(), true, 0)) {
 		t.Errorf("test case 5: addresses that have been tried in the last minute are not bad.")
 	}
 
 	//Test address that claims to be from the future.
-	if !TstKnownAddressIsBad(TstNewKnownAddress(futureNa, 0, minutesOld, hoursOld, true, 0)) {
+	if !TstKnownAddressIsBad(TstNewKnownAddress(futureNa, 0, minutesOld, hoursOld, time.Now(), true, 0)) {
 		t.Errorf("test case 6: addresses that claim to be from the future are bad.")
 	}
 
 	//Test address that has not been seen in over a month.
-	if !TstKnownAddressIsBad(TstNewKnownAddress(monthOldNa, 0, minutesOld, hoursOld, true, 0)) {
+	if !TstKnownAddressIsBad(TstNewKnownAddress(monthOldNa, 0, minutesOld, hoursOld, time.Now(), true, 0)) {
 		t.Errorf("test case 7: addresses more than a month old are bad.")
 	}
 
 	//It has failed at least three times and never succeeded.
-	if !TstKnownAddressIsBad(TstNewKnownAddress(minutesOldNa, 3, minutesOld, zeroTime, true, 0)) {
+	if !TstKnownAddressIsBad(TstNewKnownAddress(minutesOldNa, 3, minutesOld, zeroTime, time.Now(), true, 0)) {
 		t.Errorf("test case 8: addresses that have never succeeded are bad.")
 	}
 
 	//It has failed ten times in the last week
-	if !TstKnownAddressIsBad(TstNewKnownAddress(minutesOldNa, 10, minutesOld, monthOld, true, 0)) {
+	if !TstKnownAddressIsBad(TstNewKnownAddress(minutesOldNa, 10, minutesOld, monthOld, time.Now(), true, 0)) {
 		t.Errorf("test case 9: addresses that have not succeeded in too long are bad.")
 	}
 
 	//Test an address that should work.
-	if TstKnownAddressIsBad(TstNewKnownAddress(minutesOldNa, 2, minutesOld, hoursOld, true, 0)) {
+	if TstKnownAddressIsBad(TstNewKnownAddress(minutesOldNa, 2, minutesOld, hoursOld, time.Now(), true, 0)) {
 		t.Errorf("test case 10: This should be a valid address.")
+	}
+}
+
+func TestNeedsPing(t *testing.T) {
+	justnow := time.Now()
+	never := time.Unix(0, 0)
+	threshold := time.Now().Add(-1 * pingInterval * time.Hour)
+
+	// Test an address that was just pinged.
+	if TstKnownAddressNeedsPing(TstNewKnownAddress(time.Now(),
+		0, time.Now(), time.Now(), justnow, false, 0)) {
+		t.Errorf("test case 1: recently-pinged address should not need ping.")
+	}
+	// Test an address that was never pinged.
+	if !TstKnownAddressNeedsPing(TstNewKnownAddress(time.Now(),
+			0, time.Now(), time.Now(), never, false, 0)) {
+		t.Errorf("test case 2: never-pinged address should need ping.")
+	}
+
+	// CORNER CASES
+	// Test an address pinged just before the threshold.
+	if !TstKnownAddressNeedsPing(TstNewKnownAddress(time.Now(),
+		0, time.Now(), time.Now(), threshold.Add(-1), false, 0)) {
+		t.Errorf("test case 3: address pinged just before threshold should need ping.")
+	}
+
+	// Test an address pinged just after the threshold. NOTE: a few ms will elapse between when we construct this test
+	// and when it actually runs, so add a minute here to be safe.
+	if TstKnownAddressNeedsPing(TstNewKnownAddress(time.Now(),
+		0, time.Now(), time.Now(), threshold.Add(1 * time.Minute), false, 0)) {
+		t.Errorf("test case 5: address pinged just after threshold should not need ping.")
 	}
 }

--- a/p2p/discovery/ping.go
+++ b/p2p/discovery/ping.go
@@ -52,6 +52,9 @@ func (p *protocol) verifyPinger(from net.Addr, pi *node.NodeInfo) error {
 		return err
 	}
 
+	// Check the address provided by pinging it (if we haven't already, recently).
+	// This helps prevent reflective DoS attacks.
+
 	//TODO: only accept local (unspecified/loopback) IPs from other local ips.
 	ipfrom, _, _ := net.SplitHostPort(from.String())
 	pi.IP = net.ParseIP(ipfrom)

--- a/p2p/discovery/ping.go
+++ b/p2p/discovery/ping.go
@@ -38,7 +38,7 @@ func (p *protocol) newPingRequestHandler() func(msg server.Message) []byte {
 			return nil
 		}
 
-		plogger.Debug("Sending pong message")
+		plogger.Debug("Sending pong message in response to")
 		return payload
 	}
 }
@@ -68,6 +68,7 @@ func (p *protocol) verifyPinger(from net.Addr, pi *node.NodeInfo) error {
 	}
 	if ka.NeedsPing() {
 		peer := ka.na.PublicKey()
+		p.logger.Debug("Peer found in address book but needs ping, sending: %v", peer.String())
 		// Send the new Ping in a coroutine so we first respond to the incoming Ping
 		go func() {
 			if err := p.Ping(peer); err != nil {
@@ -94,7 +95,7 @@ func (p *protocol) Ping(peer p2pcrypto.PublicKey) error {
 	ch := make(chan []byte)
 	foo := func(msg []byte) {
 		defer close(ch)
-		plogger.Debug("handle response")
+		plogger.Debug("handle response to")
 		sender := &node.NodeInfo{}
 		err := types.BytesToInterface(msg, sender)
 

--- a/p2p/discovery/ping.go
+++ b/p2p/discovery/ping.go
@@ -65,10 +65,6 @@ func (p *protocol) verifyPinger(from net.Addr, pi *node.NodeInfo) error {
 					// and the peer will not be added to the pingable list.
 					p.logger.Warning("Failed response to ping to Peer: %v", peer.String())
 				}
-				//else {
-				//	p.logger.Debug("Successfully roundtrip pinged at advertised address Peer: %v", peer.String())
-				//	ka.updatePing()
-				//}
 			}
 			// Send the new Ping in a coroutine so we first respond to the incoming Ping
 			go foo()

--- a/p2p/discovery/ping.go
+++ b/p2p/discovery/ping.go
@@ -60,15 +60,14 @@ func (p *protocol) verifyPinger(from net.Addr, pi *node.NodeInfo) error {
 	}
 	if ka.NeedsPing() {
 		peer := ka.na.PublicKey()
-		foo := func() {
+		// Send the new Ping in a coroutine so we first respond to the incoming Ping
+		go func() {
 			if err := p.Ping(peer); err != nil {
 				// All we can do here is print a warning. We've already responded with a pong,
 				// and the peer will not be added to the pingable list.
 				p.logger.Warning("Failed response to ping to Peer: %v", peer.String())
 			}
-		}
-		// Send the new Ping in a coroutine so we first respond to the incoming Ping
-		go foo()
+		}()
 	}
 
 	//TODO: only accept local (unspecified/loopback) IPs from other local ips.

--- a/p2p/discovery/ping.go
+++ b/p2p/discovery/ping.go
@@ -45,7 +45,6 @@ func (p *protocol) newPingRequestHandler() func(msg server.Message) []byte {
 
 func (p *protocol) verifyPinger(from net.Addr, pi *node.NodeInfo) error {
 	// todo : Validate ToAddr or drop it.
-	// todo: check the address provided with an extra ping before updating. ( if we haven't checked it for a while )
 	// todo: decide on best way to know our ext address
 
 	if err := pi.Valid(); err != nil {
@@ -57,6 +56,9 @@ func (p *protocol) verifyPinger(from net.Addr, pi *node.NodeInfo) error {
 	ka, err := p.table.LookupKnownAddress(pi.PublicKey())
 	if err != nil {
 		return err
+	}
+	if ka == nil {
+		return errors.New("known address lookup failed")
 	}
 	if ka.NeedsPing() {
 		peer := ka.na.PublicKey()

--- a/p2p/discovery/ping.go
+++ b/p2p/discovery/ping.go
@@ -55,13 +55,13 @@ func (p *protocol) verifyPinger(from net.Addr, pi *node.NodeInfo) error {
 	// This helps prevent reflective DoS attacks.
 	ka, err := p.table.LookupKnownAddress(pi.PublicKey())
 	if err != nil {
-                //TODO: only accept local (unspecified/loopback) IPs from other local ips.
-                ipfrom, _, _ := net.SplitHostPort(from.String())
-                pi.IP = net.ParseIP(ipfrom)
+		//TODO: only accept local (unspecified/loopback) IPs from other local ips.
+		ipfrom, _, _ := net.SplitHostPort(from.String())
+		pi.IP = net.ParseIP(ipfrom)
 
-                // inbound ping is the actual source of this node info
-                p.table.AddAddress(pi, pi)
-	        ka, _ = p.table.LookupKnownAddress(pi.PublicKey())
+		// inbound ping is the actual source of this node info
+		p.table.AddAddress(pi, pi)
+		ka, _ = p.table.LookupKnownAddress(pi.PublicKey())
 	}
 	if ka == nil {
 		return errors.New("known address lookup unexpected failure")
@@ -74,7 +74,7 @@ func (p *protocol) verifyPinger(from net.Addr, pi *node.NodeInfo) error {
 				// All we can do here is print a warning. We've already responded with a pong,
 				// and the peer will not be added to the pingable list.
 				p.logger.Warning("Failed response to ping to Peer: %v", peer.String())
-                                p.table.RemoveAddress(pi.PublicKey())
+				p.table.RemoveAddress(pi.PublicKey())
 			}
 		}()
 	}

--- a/p2p/discovery/ping.go
+++ b/p2p/discovery/ping.go
@@ -98,7 +98,7 @@ func (p *protocol) Ping(peer p2pcrypto.PublicKey) error {
 	select {
 	case id := <-ch:
 		if id == nil {
-			return errors.New("failed sending message")
+			return errors.New("failed sending ping message")
 		}
 		if !bytes.Equal(id, peer.Bytes()) {
 			return errors.New("got pong with different public key")
@@ -110,7 +110,7 @@ func (p *protocol) Ping(peer p2pcrypto.PublicKey) error {
 			ka.updatePing()
 		}
 	case <-timeout.C:
-		return errors.New("ping timeouted")
+		return errors.New("ping timed out")
 	}
 
 	return nil

--- a/p2p/discovery/ping.go
+++ b/p2p/discovery/ping.go
@@ -55,10 +55,16 @@ func (p *protocol) verifyPinger(from net.Addr, pi *node.NodeInfo) error {
 	// This helps prevent reflective DoS attacks.
 	ka, err := p.table.LookupKnownAddress(pi.PublicKey())
 	if err != nil {
-		return err
+                //TODO: only accept local (unspecified/loopback) IPs from other local ips.
+                ipfrom, _, _ := net.SplitHostPort(from.String())
+                pi.IP = net.ParseIP(ipfrom)
+
+                // inbound ping is the actual source of this node info
+                p.table.AddAddress(pi, pi)
+	        ka, _ = p.table.LookupKnownAddress(pi.PublicKey())
 	}
 	if ka == nil {
-		return errors.New("known address lookup failed")
+		return errors.New("known address lookup unexpected failure")
 	}
 	if ka.NeedsPing() {
 		peer := ka.na.PublicKey()
@@ -68,16 +74,10 @@ func (p *protocol) verifyPinger(from net.Addr, pi *node.NodeInfo) error {
 				// All we can do here is print a warning. We've already responded with a pong,
 				// and the peer will not be added to the pingable list.
 				p.logger.Warning("Failed response to ping to Peer: %v", peer.String())
+                                p.table.RemoveAddress(pi.PublicKey())
 			}
 		}()
 	}
-
-	//TODO: only accept local (unspecified/loopback) IPs from other local ips.
-	ipfrom, _, _ := net.SplitHostPort(from.String())
-	pi.IP = net.ParseIP(ipfrom)
-
-	// inbound ping is the actual source of this node info
-	p.table.AddAddress(pi, pi)
 	return nil
 }
 

--- a/p2p/discovery/ping.go
+++ b/p2p/discovery/ping.go
@@ -54,21 +54,21 @@ func (p *protocol) verifyPinger(from net.Addr, pi *node.NodeInfo) error {
 
 	// Check the address provided by pinging it (if we haven't already, recently).
 	// This helps prevent reflective DoS attacks.
-	if ka, err := p.table.LookupKnownAddress(pi.PublicKey()); err != nil {
+	ka, err := p.table.LookupKnownAddress(pi.PublicKey())
+	if err != nil {
 		return err
-	} else {
-		if ka.NeedsPing() {
-			peer := ka.na.PublicKey()
-			foo := func() {
-				if err := p.Ping(peer); err != nil {
-					// All we can do here is print a warning. We've already responded with a pong,
-					// and the peer will not be added to the pingable list.
-					p.logger.Warning("Failed response to ping to Peer: %v", peer.String())
-				}
+	}
+	if ka.NeedsPing() {
+		peer := ka.na.PublicKey()
+		foo := func() {
+			if err := p.Ping(peer); err != nil {
+				// All we can do here is print a warning. We've already responded with a pong,
+				// and the peer will not be added to the pingable list.
+				p.logger.Warning("Failed response to ping to Peer: %v", peer.String())
 			}
-			// Send the new Ping in a coroutine so we first respond to the incoming Ping
-			go foo()
 		}
+		// Send the new Ping in a coroutine so we first respond to the incoming Ping
+		go foo()
 	}
 
 	//TODO: only accept local (unspecified/loopback) IPs from other local ips.

--- a/p2p/discovery/protocol.go
+++ b/p2p/discovery/protocol.go
@@ -3,6 +3,7 @@ package discovery
 import (
 	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/p2p/node"
+	"github.com/spacemeshos/go-spacemesh/p2p/p2pcrypto"
 	"github.com/spacemeshos/go-spacemesh/p2p/server"
 	"github.com/spacemeshos/go-spacemesh/p2p/service"
 	"time"
@@ -13,6 +14,7 @@ type protocolRoutingTable interface {
 	AddAddresses(n []*node.NodeInfo, src *node.NodeInfo)
 	AddAddress(n *node.NodeInfo, src *node.NodeInfo)
 	AddressCache() []*node.NodeInfo
+	LookupKnownAddress(a p2pcrypto.PublicKey) (*KnownAddress, error)
 }
 
 type protocol struct {

--- a/p2p/discovery/protocol.go
+++ b/p2p/discovery/protocol.go
@@ -40,7 +40,7 @@ const Name = "/udp/v2/discovery"
 const MessageBufSize = 1000
 
 // MessageTimeout is the timeout we tolerate when waiting for a message reply
-const MessageTimeout = time.Second * 5 // TODO: Parametrize
+const MessageTimeout = time.Second * 20 // TODO: Parametrize
 
 // PINGPONG is the ping protocol ID
 const PINGPONG = 0

--- a/p2p/discovery/protocol.go
+++ b/p2p/discovery/protocol.go
@@ -15,6 +15,7 @@ type protocolRoutingTable interface {
 	AddAddress(n *node.NodeInfo, src *node.NodeInfo)
 	AddressCache() []*node.NodeInfo
 	LookupKnownAddress(a p2pcrypto.PublicKey) (*KnownAddress, error)
+	RemoveAddress(key p2pcrypto.PublicKey)
 }
 
 type protocol struct {

--- a/p2p/discovery/protocol_test.go
+++ b/p2p/discovery/protocol_test.go
@@ -134,6 +134,8 @@ func TestPing_VerifyPinger(t *testing.T) {
 	// This lookup should succeed
 	err = p1.dscv.verifyPinger(Addr(), p2.svc.NodeInfo)
 	require.NoError(t, err)
+
+	// todo: verify that the ping gets sent (and received?)
 }
 
 func TestFindNodeProtocol_FindNode(t *testing.T) {

--- a/p2p/discovery/protocol_test.go
+++ b/p2p/discovery/protocol_test.go
@@ -206,8 +206,6 @@ func TestFindNodeProtocol_FindNode_Concurrency(t *testing.T) {
 			nx.d.LookupFunc = func(key p2pcrypto.PublicKey) (d *node.NodeInfo, e error) {
 				return n1.svc.NodeInfo, nil
 			}
-			// Node needs to be able to look up node1 when it receives the request
-			//nx.d.GetAddressRes = &KnownAddress{na: n1.svc.NodeInfo}
 			nx.dscv.table = nx.d
 			res, err := nx.dscv.GetAddresses(n1.svc.PublicKey())
 			if err != nil {

--- a/p2p/discovery/protocol_test.go
+++ b/p2p/discovery/protocol_test.go
@@ -113,7 +113,28 @@ func TestPing_Ping_Concurrency(t *testing.T) {
 	<-done
 }
 
-// todo : test verifypinger
+func Addr() net.Addr {
+	return &net.IPAddr{IP: net.ParseIP("0.0.0.0"), Zone: "ipv4"}
+}
+
+func TestPing_VerifyPinger(t *testing.T) {
+	sim := service.NewSimulator()
+	p1 := newTestNode(sim)
+	p2 := newTestNode(sim)
+
+	// This lookup should fail
+	err := p1.dscv.verifyPinger(Addr(), p2.svc.NodeInfo)
+	require.Error(t, err)
+
+	// Initialize the address book
+	p1.d.AddressCacheResult = []*node.NodeInfo{p2.svc.NodeInfo}
+	p1.d.GetAddressRes = &KnownAddress{na: p2.svc.NodeInfo}
+	p1.dscv.table = p1.d
+
+	// This lookup should succeed
+	err = p1.dscv.verifyPinger(Addr(), p2.svc.NodeInfo)
+	require.NoError(t, err)
+}
 
 func TestFindNodeProtocol_FindNode(t *testing.T) {
 

--- a/p2p/discovery/protocol_test.go
+++ b/p2p/discovery/protocol_test.go
@@ -127,9 +127,7 @@ func TestPing_VerifyPinger(t *testing.T) {
 	require.Error(t, err)
 
 	// Initialize the address book
-	p1.d.AddressCacheResult = []*node.NodeInfo{p2.svc.NodeInfo}
 	p1.d.GetAddressRes = &KnownAddress{na: p2.svc.NodeInfo}
-	p1.dscv.table = p1.d
 
 	// This lookup should succeed
 	err = p1.dscv.verifyPinger(Addr(), p2.svc.NodeInfo)

--- a/p2p/discovery/refresher.go
+++ b/p2p/discovery/refresher.go
@@ -195,7 +195,7 @@ func (r *refresher) requestAddresses(servers []*node.NodeInfo) []*node.NodeInfo 
 			if cr.err != nil {
 				//todo: consider error and maybe remove
 				//todo: count failed queries and remove not functioning
-				r.logger.Warning("Peer %v didn't respond to protocol queries - err:%v", cr.src.String(), cr.err)
+				r.logger.Warning("Peer %v didn't respond to protocol queries - err: %v", cr.src.String(), cr.err)
 				continue
 			}
 			if cr.res != nil && len(cr.res) > 0 {

--- a/p2p/discovery/refresher.go
+++ b/p2p/discovery/refresher.go
@@ -81,7 +81,7 @@ loop:
 		servers = srv[:util.Min(numpeers, len(srv))]
 		res := r.requestAddresses(servers)
 		tries++
-		r.logger.Info("Bootstrap : %d try gave %v results", tries, len(res))
+		r.logger.Info("Bootstrap: try %d gave %v results", tries, len(res))
 
 		newsize := r.book.NumAddresses()
 		wanted := numpeers

--- a/p2p/discovery/refresher.go
+++ b/p2p/discovery/refresher.go
@@ -195,7 +195,7 @@ func (r *refresher) requestAddresses(servers []*node.NodeInfo) []*node.NodeInfo 
 			if cr.err != nil {
 				//todo: consider error and maybe remove
 				//todo: count failed queries and remove not functioning
-				r.logger.Warning("Peer %v didn't response to protocol queries - err:%v", cr.src.String(), cr.err)
+				r.logger.Warning("Peer %v didn't respond to protocol queries - err:%v", cr.src.String(), cr.err)
 				continue
 			}
 			if cr.res != nil && len(cr.res) > 0 {

--- a/p2p/discovery/store.go
+++ b/p2p/discovery/store.go
@@ -20,6 +20,7 @@ type serializedKnownAddress struct {
 	LastSeen    int64
 	LastAttempt int64
 	LastSuccess int64
+	LastPing	int64
 	// no refcount or tried, that is available from context.
 }
 
@@ -51,6 +52,7 @@ func (a *addrBook) savePeers(path string) {
 		ska.Attempts = v.attempts
 		ska.LastAttempt = v.lastattempt.Unix()
 		ska.LastSuccess = v.lastsuccess.Unix()
+		ska.LastPing = v.lastping.Unix()
 		// Tried and refs are implicit in the rest of the structure
 		// and will be worked out from context on unserialisation.
 		sam.Addresses[i] = ska
@@ -148,6 +150,7 @@ func (a *addrBook) deserializePeers(filePath string) error {
 		ka.attempts = v.Attempts
 		ka.lastattempt = time.Unix(v.LastAttempt, 0)
 		ka.lastsuccess = time.Unix(v.LastSuccess, 0)
+		ka.lastping = time.Unix(v.LastPing, 0)
 		a.addrIndex[ka.na.ID] = ka
 	}
 

--- a/p2p/discovery/store.go
+++ b/p2p/discovery/store.go
@@ -20,7 +20,7 @@ type serializedKnownAddress struct {
 	LastSeen    int64
 	LastAttempt int64
 	LastSuccess int64
-	LastPing	int64
+	LastPing    int64
 	// no refcount or tried, that is available from context.
 }
 

--- a/p2p/server/msgserver.go
+++ b/p2p/server/msgserver.go
@@ -175,7 +175,7 @@ func (p *MessageServer) handleResponseMessage(headers *service.DataMsgWrapper) {
 	if okFoo {
 		foo(headers.Payload)
 	} else {
-		p.Error("Cant find handler %v", headers.ReqID)
+		p.Error("Can't find handler %v", headers.ReqID)
 	}
 	p.Debug("handleResponseMessage close")
 }


### PR DESCRIPTION
Closes #718 

WIP, still needs tests.

When successfully pinging a peer (pulled randomly out of the routing table/addrbook), mark the peer as having been successfully pinged.
When receiving a ping from a peer that's not already marked as having been successfully pinged, send a ping to their advertised addr/port.
Refuse to respond to GetAddresses from a peer that hasn't recently passed this ping check.