### PR TITLE
[Merged by Bors] - Genesis time API endpoint formatted as RFC3339 

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -314,7 +314,7 @@ func TestJsonWalletApi(t *testing.T) {
 	// test get genesisTime
 	respBody, respStatus = callEndpoint(t, "v1/genesis", "")
 	r.Equal(http.StatusOK, respStatus)
-	assertSimpleMessage(t, respBody, genTime.t.String())
+	assertSimpleMessage(t, respBody, genTime.t.Format(time.RFC3339))
 
 	// test get rewards per account
 	payload = marshalProto(t, &pb.AccountId{Address: util.Bytes2Hex(addr.Bytes())})

--- a/api/grpc_server.go
+++ b/api/grpc_server.go
@@ -321,7 +321,7 @@ func (s SpacemeshGrpcService) GetUpcomingAwards(ctx context.Context, empty *empt
 
 func (s SpacemeshGrpcService) GetGenesisTime(ctx context.Context, empty *empty.Empty) (*pb.SimpleMessage, error) {
 	log.Info("GRPC GetGenesisTime msg")
-	return &pb.SimpleMessage{Value: s.GenTime.GetGenesisTime().String()}, nil
+	return &pb.SimpleMessage{Value: s.GenTime.GetGenesisTime().Format(time.RFC3339)}, nil
 }
 
 func (s SpacemeshGrpcService) ResetPost(ctx context.Context, empty *empty.Empty) (*pb.SimpleMessage, error) {


### PR DESCRIPTION
## Motivation
consistency
Closes #1624
## Changes
<!-- Please describe in detail the changes made -->
Genesis time API endpoint formatted as RFC3999
## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->
API testing is in place

## TODO
<!-- This section should be removed when all items are complete -->

*NOTE* : this is pending a big todo in `smapp` @IlyaVi , 
we don't want to break compatibility with the wallet so waiting for your approval on merging this.

