### PR TITLE
[Merged by Bors] - remove leaking metrics in hare

### DIFF
--- a/hare/committracker.go
+++ b/hare/committracker.go
@@ -1,10 +1,5 @@
 package hare
 
-import (
-	"fmt"
-	"github.com/spacemeshos/go-spacemesh/hare/metrics"
-)
-
 type commitTrackerProvider interface {
 	OnCommit(msg *Msg)
 	HasEnoughCommits() bool
@@ -53,7 +48,6 @@ func (ct *commitTracker) OnCommit(msg *Msg) {
 	}
 
 	// add msg
-	metrics.CommitCounter.With("set_id", fmt.Sprint(s.Id())).Add(1)
 	ct.commits = append(ct.commits, msg.Message)
 }
 

--- a/hare/metrics/promehteus.go
+++ b/hare/metrics/promehteus.go
@@ -13,22 +13,6 @@ const (
 )
 
 var (
-	// CommitCounter is the number of valid commits for a set.
-	CommitCounter = prometheus.NewCounterFrom(stdprometheus.CounterOpts{
-		Namespace: Namespace,
-		Subsystem: Subsystem,
-		Name:      "commit_counter",
-		Help:      "Number of valid commit messages for a set",
-	}, []string{"set_id"})
-
-	// NotifyCounter is the number of valid notifications for a set.
-	NotifyCounter = prometheus.NewCounterFrom(stdprometheus.CounterOpts{
-		Namespace: Namespace,
-		Subsystem: Subsystem,
-		Name:      "notify_counter",
-		Help:      "Number of valid notifications for a set",
-	}, []string{"set_id"})
-
 	// MessageTypeCounter is the number of valid messages per type.
 	MessageTypeCounter = prometheus.NewCounterFrom(stdprometheus.CounterOpts{
 		Namespace: Namespace,

--- a/hare/notifytracker.go
+++ b/hare/notifytracker.go
@@ -2,8 +2,6 @@ package hare
 
 import (
 	"encoding/binary"
-	"fmt"
-	"github.com/spacemeshos/go-spacemesh/hare/metrics"
 	"hash/fnv"
 )
 
@@ -39,7 +37,6 @@ func (nt *notifyTracker) OnNotify(msg *Msg) bool {
 	s := NewSet(msg.InnerMsg.Values)
 	nt.onCertificate(msg.InnerMsg.Cert.AggMsgs.Messages[0].InnerMsg.K, s)
 	nt.tracker.Track(s.Id())
-	metrics.NotifyCounter.With("set_id", fmt.Sprint(s.Id())).Add(1)
 
 	return false
 }


### PR DESCRIPTION
## Motivation

these metrics label values grow indefinitely. we want to remove them in order to not blow up our metrics servers. 

Closes #
<!-- `Closes #XXXX, closes #XXXX, ...` links mentioned issues to this PR and automatically closes them when this it's merged -->

## Changes

remove leaking metrics
note: we'll have to revisit this in the future and impl in a way that will use less mem. 
currently we're not using these metrics and they are our heaviest. 
## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
