### PR TITLE
[Merged by Bors] - dont pass nil messages if channels are closing.

### DIFF
--- a/priorityq/priorityq.go
+++ b/priorityq/priorityq.go
@@ -57,8 +57,8 @@ func (pq *Queue) Write(prio Priority, m interface{}) error {
 func (pq *Queue) Read() (interface{}, error) {
 	<-pq.waitCh // wait for m
 
-	// pick by priority
 readLoop:
+	// pick by priority
 	for _, q := range pq.queues {
 		if q == nil { // if not set just continue
 			continue

--- a/priorityq/priorityq.go
+++ b/priorityq/priorityq.go
@@ -58,6 +58,7 @@ func (pq *Queue) Read() (interface{}, error) {
 	<-pq.waitCh // wait for m
 
 	// pick by priority
+readLoop:
 	for _, q := range pq.queues {
 		if q == nil { // if not set just continue
 			continue
@@ -65,7 +66,11 @@ func (pq *Queue) Read() (interface{}, error) {
 
 		// if set, try read
 		select {
-		case m := <-q:
+		case m, ok := <-q:
+			if !ok {
+				// channels are starting to close
+				break readLoop
+			}
 			return m, nil
 		default: // empty, try next
 			continue

--- a/priorityq/priorityq_test.go
+++ b/priorityq/priorityq_test.go
@@ -109,5 +109,5 @@ func TestPriorityQ_Read(t *testing.T) {
 	time.Sleep(1500 * time.Millisecond)
 	pq.Close()
 	rg.Wait()
-	r.Equal(3*defLen, i-1)
+	r.Equal(3*defLen, i)
 }

--- a/priorityq/priorityq_test.go
+++ b/priorityq/priorityq_test.go
@@ -92,14 +92,16 @@ func TestPriorityQ_Read(t *testing.T) {
 	go func() {
 		m, e := pq.Read()
 		for e == nil {
-			//fmt.Println("reading  ", m, e, i, len(pq.queues[0]), len(pq.queues[1]))
-			i++
 			prio, ok := m.(int)
+			//fmt.Println("reading  ", m, e, i, len(pq.queues[0]), len(pq.queues[1]))
 			if !ok {
-				break
+				// should never happen
+				t.FailNow()
 			}
+
 			r.False(prio < maxPrio)
 			maxPrio = prio
+			i++
 
 			m, e = pq.Read()
 		}


### PR DESCRIPTION
# Changes
when shutting down now, we're reading nil from the channels and we spam with messages about nil messages from the prioq. also that might result in a panic while trying to convert the message in p2p and receiving nil without an error. 

# Test plan
Updated tests