### PR TITLE
[Merged by Bors] - cancel the command if ntp is not sync

### DIFF
--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -579,7 +579,7 @@ func (app *SpacemeshApp) checkTimeDrifts() {
 			_, err := timesync.CheckSystemClockDrift()
 			if err != nil {
 				app.log.Error("System time couldn't synchronize %s", err)
-				app.stopServices()
+				cmdp.Cancel()
 				return
 			}
 		}


### PR DESCRIPTION
## Motivation

On a drift from NTP we shutdown the node. the old code called `stopServices` but didn't really stop the process.
## Changes

call `cmdp.Cancel` to cancel the context which will call the tear-down code. (equivalent to SIGINT signal)