### PR TITLE
[Merged by Bors] - Index all of a node's atxs

### DIFF
--- a/activation/activationdb_test.go
+++ b/activation/activationdb_test.go
@@ -413,8 +413,8 @@ func Test_DBSanity(t *testing.T) {
 	coinbase3 := types.HexToAddress("cccc")
 
 	atx1 := types.NewActivationTxForTests(id1, 0, *types.EmptyAtxId, 1, 0, *types.EmptyAtxId, coinbase1, 3, []types.BlockID{}, &types.NIPST{})
-	atx2 := types.NewActivationTxForTests(id1, 0, *types.EmptyAtxId, 1, 0, *types.EmptyAtxId, coinbase2, 3, []types.BlockID{}, &types.NIPST{})
-	atx3 := types.NewActivationTxForTests(id1, 0, *types.EmptyAtxId, 1, 0, *types.EmptyAtxId, coinbase3, 3, []types.BlockID{}, &types.NIPST{})
+	atx2 := types.NewActivationTxForTests(id1, 0, *types.EmptyAtxId, 1001, 0, *types.EmptyAtxId, coinbase2, 3, []types.BlockID{}, &types.NIPST{})
+	atx3 := types.NewActivationTxForTests(id1, 0, *types.EmptyAtxId, 2001, 0, *types.EmptyAtxId, coinbase3, 3, []types.BlockID{}, &types.NIPST{})
 
 	err := atxdb.storeAtxUnlocked(atx1)
 	assert.NoError(t, err)
@@ -428,6 +428,10 @@ func Test_DBSanity(t *testing.T) {
 	id, err := atxdb.GetNodeLastAtxId(id1)
 	assert.NoError(t, err)
 	assert.Equal(t, atx1.Id(), id)
+	assert.Equal(t, types.EpochId(1), atx1.TargetEpoch(atxdb.LayersPerEpoch))
+	id, err = atxdb.GetNodeAtxIdForEpoch(id1, atx1.TargetEpoch(atxdb.LayersPerEpoch))
+	assert.NoError(t, err)
+	assert.Equal(t, atx1.Id(), id)
 
 	err = atxdb.addAtxToNodeId(id2, atx2)
 	assert.NoError(t, err)
@@ -438,13 +442,21 @@ func Test_DBSanity(t *testing.T) {
 	id, err = atxdb.GetNodeLastAtxId(id2)
 	assert.NoError(t, err)
 	assert.Equal(t, atx2.Id(), id)
+	assert.Equal(t, types.EpochId(2), atx2.TargetEpoch(atxdb.LayersPerEpoch))
+	id, err = atxdb.GetNodeAtxIdForEpoch(id2, atx2.TargetEpoch(atxdb.LayersPerEpoch))
+	assert.NoError(t, err)
+	assert.Equal(t, atx2.Id(), id)
 
 	id, err = atxdb.GetNodeLastAtxId(id1)
 	assert.NoError(t, err)
 	assert.Equal(t, atx3.Id(), id)
+	assert.Equal(t, types.EpochId(3), atx3.TargetEpoch(atxdb.LayersPerEpoch))
+	id, err = atxdb.GetNodeAtxIdForEpoch(id1, atx3.TargetEpoch(atxdb.LayersPerEpoch))
+	assert.NoError(t, err)
+	assert.Equal(t, atx3.Id(), id)
 
 	id, err = atxdb.GetNodeLastAtxId(id3)
-	assert.Error(t, err)
+	assert.EqualError(t, err, fmt.Sprintf("atx for node %v does not exist", id3.ShortString()))
 	assert.Equal(t, *types.EmptyAtxId, id)
 }
 

--- a/activation/atxdb.go
+++ b/activation/atxdb.go
@@ -579,13 +579,20 @@ func (db *ActivationDb) addAtxToNodeId(nodeId types.NodeId, atx *types.Activatio
 
 // GetNodeLastAtxId returns the last atx id that was received for node nodeId
 func (db *ActivationDb) GetNodeLastAtxId(nodeId types.NodeId) (types.AtxId, error) {
-	db.log.Debug("fetching atxIDs for node %v", nodeId.ShortString())
-
 	nodeAtxsIterator := db.atxs.Find(getNodeAtxPrefix(nodeId))
 	if exists := nodeAtxsIterator.Last(); !exists {
 		return *types.EmptyAtxId, fmt.Errorf("atx for node %v does not exist", nodeId.ShortString())
 	}
 	return types.AtxId(types.BytesToHash(nodeAtxsIterator.Value())), nil
+}
+
+func (db *ActivationDb) GetNodeAtxIdForEpoch(nodeId types.NodeId, targetEpoch types.EpochId) (types.AtxId, error) {
+	id, err := db.atxs.Get(getNodeAtxKey(nodeId, targetEpoch))
+	if err != nil {
+		return *types.EmptyAtxId, fmt.Errorf("atx for node %v targeting epoch %v: %v",
+			nodeId.ShortString(), targetEpoch, err)
+	}
+	return types.AtxId(types.BytesToHash(id)), nil
 }
 
 // GetPosAtxId returns the best (highest layer id), currently known to this node, pos atx id

--- a/common/util/bytes.go
+++ b/common/util/bytes.go
@@ -20,6 +20,12 @@ func Uint64ToBytes(i uint64) []byte {
 	return a
 }
 
+func Uint64ToBytesBigEndian(i uint64) []byte {
+	a := make([]byte, 8)
+	binary.BigEndian.PutUint64(a, i)
+	return a
+}
+
 // CopyBytes returns an exact copy of the provided bytes.
 func CopyBytes(b []byte) (copiedBytes []byte) {
 	if b == nil {

--- a/mesh/atxdb_mock.go
+++ b/mesh/atxdb_mock.go
@@ -18,14 +18,6 @@ func NewAtxDbMock() *AtxDbMock {
 	}
 }
 
-func (*AtxDbMock) IsIdentityActive(edId string, layer types.LayerID) (*types.NodeId, bool, types.AtxId, error) {
-	return nil, true, *types.EmptyAtxId, nil
-}
-
-func (t *AtxDbMock) GetPosAtxId(id types.EpochId) (types.AtxId, error) {
-	return types.AtxId{}, nil /*todo: mock if needed */
-}
-
 func (t *AtxDbMock) GetAtxHeader(id types.AtxId) (*types.ActivationTxHeader, error) {
 	if id == *types.EmptyAtxId {
 		return nil, fmt.Errorf("trying to fetch empty atx id")
@@ -44,10 +36,6 @@ func (t *AtxDbMock) GetFullAtx(id types.AtxId) (*types.ActivationTx, error) {
 func (t *AtxDbMock) AddAtx(id types.AtxId, atx *types.ActivationTx) {
 	t.db[id] = atx
 	t.nipsts[id] = atx.Nipst
-}
-
-func (t *AtxDbMock) GetNipst(id types.AtxId) (*types.NIPST, error) {
-	return t.nipsts[id], nil
 }
 
 func (t *AtxDbMock) ProcessAtxs(atxs []*types.ActivationTx) error {

--- a/oracle/blockeligibilityvalidator.go
+++ b/oracle/blockeligibilityvalidator.go
@@ -64,7 +64,7 @@ func (v BlockEligibilityValidator) BlockSignedAndEligible(block *types.Block) (b
 		activeSetSize = v.genesisActiveSetSize
 	}
 
-	numberOfEligibleBlocks, err := getNumberOfEligibleBlocks(activeSetSize, v.committeeSize, v.layersPerEpoch, v.log)
+	numberOfEligibleBlocks, err := getNumberOfEligibleBlocks(activeSetSize, v.committeeSize, v.layersPerEpoch)
 	if err != nil {
 		return false, fmt.Errorf("failed to get number of eligible blocks: %v", err)
 	}

--- a/oracle/blockeligibilityvalidator_test.go
+++ b/oracle/blockeligibilityvalidator_test.go
@@ -19,7 +19,7 @@ func (m mockAtxDB) GetIdentity(edId string) (types.NodeId, error) {
 	return types.NodeId{Key: edId, VRFPublicKey: vrfPubkey}, nil
 }
 
-func (m mockAtxDB) GetNodeLastAtxId(node types.NodeId) (types.AtxId, error) {
+func (m mockAtxDB) GetNodeAtxIdForEpoch(nodeId types.NodeId, targetEpoch types.EpochId) (types.AtxId, error) {
 	return types.AtxId{}, m.err
 }
 

--- a/oracle/blockeligibilityvalidator_test.go
+++ b/oracle/blockeligibilityvalidator_test.go
@@ -15,10 +15,6 @@ type mockAtxDB struct {
 	err  error
 }
 
-func (m *mockAtxDB) IsIdentityActive(edId string, layer types.LayerID) (*types.NodeId, bool, types.AtxId, error) {
-	return &types.NodeId{}, false, types.AtxId{}, m.err
-}
-
 func (m mockAtxDB) GetIdentity(edId string) (types.NodeId, error) {
 	return types.NodeId{Key: edId, VRFPublicKey: vrfPubkey}, nil
 }

--- a/oracle/blockoracle.go
+++ b/oracle/blockoracle.go
@@ -14,7 +14,6 @@ type ActivationDb interface {
 	GetNodeLastAtxId(node types.NodeId) (types.AtxId, error)
 	GetAtxHeader(id types.AtxId) (*types.ActivationTxHeader, error)
 	GetIdentity(edId string) (types.NodeId, error)
-	IsIdentityActive(edId string, layer types.LayerID) (*types.NodeId, bool, types.AtxId, error)
 }
 
 type Signer interface {

--- a/oracle/blockoracle.go
+++ b/oracle/blockoracle.go
@@ -94,7 +94,7 @@ func (bo *MinerBlockOracle) calcEligibilityProofs(epochNumber types.EpochId) err
 		bo.log.Info("genesis epoch detected, using GenesisActiveSetSize (%v)", activeSetSize)
 	}
 
-	numberOfEligibleBlocks, err := getNumberOfEligibleBlocks(activeSetSize, bo.committeeSize, bo.layersPerEpoch, bo.log)
+	numberOfEligibleBlocks, err := getNumberOfEligibleBlocks(activeSetSize, bo.committeeSize, bo.layersPerEpoch)
 	if err != nil {
 		bo.log.Error("failed to get number of eligible blocks: %v", err)
 		return err
@@ -153,11 +153,11 @@ func calcEligibleLayer(epochNumber types.EpochId, layersPerEpoch uint16, vrfHash
 	return epochNumber.FirstLayer(layersPerEpoch).Add(uint16(eligibleLayerOffset))
 }
 
-func getNumberOfEligibleBlocks(activeSetSize uint32, committeeSize uint32, layersPerEpoch uint16, lg log.Log) (uint32, error) {
+func getNumberOfEligibleBlocks(activeSetSize, committeeSize uint32, layersPerEpoch uint16) (uint32, error) {
 	if activeSetSize == 0 {
 		return 0, errors.New("empty active set not allowed")
 	}
-	numberOfEligibleBlocks := uint32(committeeSize) * uint32(layersPerEpoch) / activeSetSize
+	numberOfEligibleBlocks := committeeSize * uint32(layersPerEpoch) / activeSetSize
 	if numberOfEligibleBlocks == 0 {
 		numberOfEligibleBlocks = 1
 	}

--- a/oracle/blockoracle_test.go
+++ b/oracle/blockoracle_test.go
@@ -34,8 +34,8 @@ func (a mockActivationDB) GetIdentity(edId string) (types.NodeId, error) {
 	return types.NodeId{Key: edId, VRFPublicKey: vrfPubkey}, nil
 }
 
-func (a mockActivationDB) GetNodeLastAtxId(node types.NodeId) (types.AtxId, error) {
-	if node.Key != nodeID.Key {
+func (a mockActivationDB) GetNodeAtxIdForEpoch(nodeId types.NodeId, targetEpoch types.EpochId) (types.AtxId, error) {
+	if nodeId.Key != nodeID.Key || targetEpoch.IsGenesis() {
 		return *types.EmptyAtxId, errors.New("not found")
 	}
 	return atxID, nil
@@ -179,7 +179,7 @@ func TestBlockOracleNoActivationsForNode(t *testing.T) {
 	blockOracle := NewMinerBlockOracle(committeeSize, activeSetSize, layersPerEpoch, activationDB, beaconProvider, vrfSigner, nodeID, func() bool { return true }, lg.WithName("blockOracle"))
 
 	_, proofs, err := blockOracle.BlockEligible(types.LayerID(layersPerEpoch * 2))
-	r.EqualError(err, "failed to get latest ATX: not in genesis (epoch 2) yet failed to get atx: not found")
+	r.EqualError(err, "failed to get latest ATX: failed to get ATX ID for target epoch 2: not found")
 	r.Nil(proofs)
 }
 

--- a/oracle/blockoracle_test.go
+++ b/oracle/blockoracle_test.go
@@ -30,15 +30,6 @@ type mockActivationDB struct {
 	atxs                map[string]map[types.LayerID]types.AtxId
 }
 
-func (a *mockActivationDB) IsIdentityActive(edId string, layer types.LayerID) (*types.NodeId, bool, types.AtxId, error) {
-	if idmap, ok := a.atxs[edId]; ok {
-		if atxid, ok := idmap[layer]; ok {
-			return &types.NodeId{Key: edId, VRFPublicKey: vrfPubkey}, true, atxid, nil
-		}
-	}
-	return &types.NodeId{Key: edId, VRFPublicKey: vrfPubkey}, true, *types.EmptyAtxId, nil
-}
-
 func (a mockActivationDB) GetIdentity(edId string) (types.NodeId, error) {
 	return types.NodeId{Key: edId, VRFPublicKey: vrfPubkey}, nil
 }


### PR DESCRIPTION
## Motivation
Closes #1682 

## Changes
Index all of a node's ATXs based on their target epoch. Use the desired target epoch to retrieve the relevant ATX.

## Test Plan
- [x] Add unit tests for new functionality.
- [ ] Add an automation test for restarting a node after publishing an ATX and ensure it calculated the correct eligible blocks within the same epoch. [?]