### PR TITLE
[Merged by Bors] - Store state root in processor

### DIFF
--- a/state/processor.go
+++ b/state/processor.go
@@ -165,7 +165,13 @@ func getStateRootLayerKey(layer types.LayerID) []byte {
 }
 
 func (tp *TransactionProcessor) addState(stateRoot types.Hash32, layer types.LayerID) error {
-	return tp.processorDb.Put(getStateRootLayerKey(layer), stateRoot.Bytes())
+	if err := tp.processorDb.Put(getStateRootLayerKey(layer), stateRoot.Bytes()); err != nil {
+		return err
+	}
+	tp.rootMu.Lock()
+	tp.rootHash = stateRoot
+	tp.rootMu.Unlock()
+	return nil
 }
 
 func (tp *TransactionProcessor) getLayerStateRoot(layer types.LayerID) (types.Hash32, error) {

--- a/state/processor_test.go
+++ b/state/processor_test.go
@@ -516,3 +516,17 @@ func TestValidateTxSignature(t *testing.T) {
 	assert.False(t, proc.AddressExists(tx.Origin()))
 	assert.Equal(t, PublicKeyToAccountAddress(pub), tx.Origin())
 }
+
+func TestTransactionProcessor_GetStateRoot(t *testing.T) {
+	r := require.New(t)
+
+	db := database.NewMemDatabase()
+	lg := log.New("proc_logger", "", "")
+	proc := NewTransactionProcessor(db, appliedTxsMock{}, &ProjectorMock{}, lg)
+
+	expectedRoot := types.Hash32{1, 2, 3}
+	r.NoError(proc.addState(expectedRoot, 1))
+
+	actualRoot := proc.GetStateRoot()
+	r.Equal(expectedRoot, actualRoot)
+}

--- a/tests/queries.py
+++ b/tests/queries.py
@@ -502,6 +502,7 @@ def assert_equal_layer_hashes(indx, ns):
 
 def compare_state_roots(hits):
     state_root = hits[0].state_root
+    assert state_root != '0' * 64
     for hit in hits:
         assert hit.state_root == state_root
     print(f"validated {len(hits)} equal state roots for layer {hits[0].layer_id}: {state_root}")


### PR DESCRIPTION
## Motivation
There was previously no assertion that the state root reported by nodes was not empty (zero), only that it was equal for all nodes. There was also no unit test for `TransactionProcessor.GetStateRoot()`.

This caused an undetected bug to emerge in #1713 where we didn't ever update the `TransactionProcessor.rootHash` and all reported root hashes were empty. @barakshani noticed this in recent runs.

## Changes
Update `TransactionProcessor.rootHash` whenever `addState()` is called.

## Test Plan
- Added an assertion for non-emptiness in `compare_state_roots()`.
- Added a unit test `TestTransactionProcessor_GetStateRoot` that ensures that the state root returned by `GetStateRoot()` matches what was passed to `addState()`.