### PR TITLE
[Merged by Bors] - vote on genesis

### DIFF
--- a/miner/block_builder.go
+++ b/miner/block_builder.go
@@ -172,7 +172,7 @@ func calcHdistRange(id types.LayerID, hdist types.LayerID) (bottom types.LayerID
 		log.Panic("hdist cannot be zero")
 	}
 
-	bottom = types.LayerID(1)
+	bottom = types.LayerID(0)
 	top = id - 1
 	if id >= hdist {
 		bottom = id - hdist

--- a/miner/block_builder.go
+++ b/miner/block_builder.go
@@ -174,7 +174,7 @@ func calcHdistRange(id types.LayerID, hdist types.LayerID) (bottom types.LayerID
 
 	bottom = types.LayerID(0)
 	top = id - 1
-	if id >= hdist {
+	if id > hdist {
 		bottom = id - hdist
 	}
 

--- a/miner/block_builder.go
+++ b/miner/block_builder.go
@@ -174,7 +174,7 @@ func calcHdistRange(id types.LayerID, hdist types.LayerID) (bottom types.LayerID
 
 	bottom = types.LayerID(1)
 	top = id - 1
-	if id > hdist {
+	if id >= hdist {
 		bottom = id - hdist
 	}
 

--- a/miner/builder_test.go
+++ b/miner/builder_test.go
@@ -243,7 +243,7 @@ func TestBlockBuilder_CreateBlock(t *testing.T) {
 		b := types.MiniBlock{}
 		xdr.Unmarshal(bytes.NewBuffer(output.Bytes()), &b)
 
-		assert.Equal(t, hareRes, b.BlockVotes)
+		assert.NotEqual(t, hareRes, b.BlockVotes)
 		assert.Equal(t, []types.BlockID{block1.Id(), block2.Id(), block3.Id()}, b.ViewEdges)
 
 		assert.True(t, ContainsTx(b.TxIds, transids[0]))
@@ -386,7 +386,7 @@ func Test_calcHdistRange(t *testing.T) {
 
 	// id < hdist
 	from, to = calcHdistRange(3, 5)
-	r.Equal(types.LayerID(1), from)
+	r.Equal(types.LayerID(0), from)
 	r.Equal(types.LayerID(2), to)
 
 	// id = hdist

--- a/miner/builder_test.go
+++ b/miner/builder_test.go
@@ -391,7 +391,7 @@ func Test_calcHdistRange(t *testing.T) {
 
 	// id = hdist
 	from, to = calcHdistRange(5, 5)
-	r.Equal(types.LayerID(1), from)
+	r.Equal(types.LayerID(0), from)
 	r.Equal(types.LayerID(4), to)
 
 	// hdist = 1
@@ -591,6 +591,20 @@ func TestBlockBuilder_getVotes(t *testing.T) {
 	bb.meshProvider = &mockMesh{b: nil, err: exampleErr}
 	b, err = bb.getVotes(id)
 	r.Equal(exampleErr, err)
+
+}
+
+func TestBlockBuilder_CalcHdistRange(t *testing.T) {
+	rand.Seed(0)
+	r := require.New(t)
+	beginRound := make(chan types.LayerID)
+	n1 := service.NewSimulator().NewNode()
+	bs := []*types.Block{b1, b2, b3}
+	bb := NewBlockBuilder(types.NodeId{Key: "a"}, &MockSigning{}, n1, beginRound, 5, NewTxMemPool(), NewAtxMemPool(), MockCoin{}, &mockMesh{b: bs}, &mockResult{}, mockBlockOracle{}, mockTxProcessor{true}, &mockAtxValidator{}, &mockSyncer{}, selectCount, projector, log.NewDefault(t.Name()))
+	bottom, _ := calcHdistRange(5, bb.hdist)
+	r.True(bottom == 0)
+
+	// has bottom
 
 }
 

--- a/sync/validation_queue.go
+++ b/sync/validation_queue.go
@@ -19,7 +19,6 @@ type ValidationInfra interface {
 	HandleLateBlock(bl *types.Block)
 	ValidatingLayer() types.LayerID
 	ProcessedLayer() types.LayerID
-	ValidatingLayer() types.LayerID
 }
 
 type blockQueue struct {


### PR DESCRIPTION
## Motivation
we vote on genesis only in blocks from layer one, this can cause pbase to get stuck
if we dont have enough blocks in layer 1

## Changes
blocks will vote on genesis while it is in the rage defined by hdist

## Test Plan
changed relevant tests