### PR TITLE
[Merged by Bors] - now not loading genesis accounts after state loaded from disk

### DIFF
--- a/cmd/node/app_test.go
+++ b/cmd/node/app_test.go
@@ -141,11 +141,14 @@ loop:
 		}
 	}
 	suite.validateBlocksAndATXs(types.LayerID(numberOfEpochs*suite.apps[0].Config.LayersPerEpoch) - 1)
+	oldRoot := suite.apps[0].state.GetStateRoot()
 	GracefulShutdown(suite.apps)
 
 	// this tests loading of pervious state, mabe it's not the best place to put this here...
 	smApp, err := InitSingleInstance(*cfg, 0, genesisTime, rng, path+"a", rolacle, poetClient, false, clock, net)
 	assert.NoError(suite.T(), err)
+	//test that loaded root equals
+	assert.Equal(suite.T(), oldRoot, smApp.state.GetStateRoot())
 	// start and stop and test for no panics
 	smApp.startServices()
 	smApp.stopServices()
@@ -525,7 +528,6 @@ func TestShutdown(t *testing.T) {
 	err = smApp.initServices(nodeID, swarm, dbStorepath, edSgn, false, hareOracle, uint32(smApp.Config.LayerAvgSize), postClient, poetClient, vrfSigner, uint16(smApp.Config.LayersPerEpoch), clock)
 
 	r.NoError(err)
-	smApp.setupGenesis()
 
 	smApp.startServices()
 	ActivateGrpcServer(smApp)

--- a/cmd/node/multi_node.go
+++ b/cmd/node/multi_node.go
@@ -219,7 +219,6 @@ func InitSingleInstance(cfg config.Config, i int, genesisTime string, rng *amcl.
 	if err != nil {
 		return nil, err
 	}
-	smApp.setupGenesis()
 
 	return smApp, err
 }

--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -293,7 +293,7 @@ func (app *SpacemeshApp) Cleanup(cmd *cobra.Command, args []string) (err error) 
 	return nil
 }
 
-func (app *SpacemeshApp) setupGenesis() {
+func (app *SpacemeshApp) setupGenesis(state *state.TransactionProcessor, msh *mesh.Mesh) {
 	var conf *apiCfg.GenesisConfig
 	if app.Config.GenesisConfPath != "" {
 		var err error
@@ -313,14 +313,20 @@ func (app *SpacemeshApp) setupGenesis() {
 		}
 
 		addr := types.BytesToAddress(bytes)
-		app.state.CreateAccount(addr)
-		app.state.AddBalance(addr, acc.Balance)
-		app.state.SetNonce(addr, acc.Nonce)
+		state.CreateAccount(addr)
+		state.AddBalance(addr, acc.Balance)
+		state.SetNonce(addr, acc.Nonce)
 		app.log.Info("Genesis account created: %s, Balance: %s", id, acc.Balance.Uint64())
 	}
 
-	app.state.Commit(false)
-	app.mesh.AddBlock(mesh.GenesisBlock)
+	_, err := state.Commit(false)
+	if err != nil {
+		log.Panic("cannot commit genesis state")
+	}
+	err = msh.AddBlock(mesh.GenesisBlock)
+	if err != nil {
+		log.Error("error adding genesis block %v", err)
+	}
 }
 
 func (app *SpacemeshApp) setupTestFeatures() {
@@ -501,6 +507,7 @@ func (app *SpacemeshApp) initServices(nodeID types.NodeId,
 	} else {
 		trtl = tortoise.NewAlgorithm(int(layerSize), mdb, app.Config.Hdist, app.addLogger(TrtlLogger, lg))
 		msh = mesh.NewMesh(mdb, atxdb, app.Config.REWARD, trtl, app.txPool, atxpool, processor, app.addLogger(MeshLogger, lg))
+		app.setupGenesis(processor, msh)
 	}
 
 	conf := sync.Configuration{Concurrency: 4, LayerSize: int(layerSize), LayersPerEpoch: layersPerEpoch, RequestTimeout: time.Duration(app.Config.SyncRequestTimeout) * time.Millisecond, Hdist: app.Config.Hdist, AtxsLimit: app.Config.AtxsPerBlock}
@@ -850,8 +857,6 @@ func (app *SpacemeshApp) Start(cmd *cobra.Command, args []string) {
 		log.Error("cannot start services %v", err.Error())
 		return
 	}
-
-	app.setupGenesis()
 
 	if app.Config.TestMode {
 		app.setupTestFeatures()

--- a/mesh/mesh.go
+++ b/mesh/mesh.go
@@ -137,13 +137,15 @@ func NewRecoveredMesh(db *MeshDB, atxDb AtxDB, rewardConfig Config, mesh MeshVal
 	// in case we load a state that was not fully played
 	if msh.LatestLayerInState()+1 < msh.MeshValidator.LatestComplete() {
 		// todo: add test for this case, or add random kill test on node
+		logger.Info("playing layers %v to %v to state", msh.LatestLayerInState()+1, msh.MeshValidator.LatestComplete())
 		msh.pushLayersToState(msh.LatestLayerInState()+1, msh.MeshValidator.LatestComplete())
 	}
 
 	msh.With().Info("recovered mesh from disk",
 		log.Uint64("latest_layer", msh.latestLayer.Uint64()),
 		log.Uint64("validated_layer", msh.processedLayer.Uint64()),
-		log.String("layer_hash", util.Bytes2Hex(msh.layerHash)))
+		log.String("layer_hash", util.Bytes2Hex(msh.layerHash)),
+		log.String("root_hash", pr.GetStateRoot().String()))
 
 	return msh
 }


### PR DESCRIPTION
## Motivation
Currently, we load genesis accounts after starting the node, even if the node has loaded a previous state, causing state inconsistencies.

## Changes
SetupGenesis now run only if node is not loaded from db. 

## Test Plan
added assert to test state root after loading mesh and comparing to state root of live node