### PR TITLE
[Merged by Bors] - Fixed CalcActiveSetFromView locks

### DIFF
--- a/activation/activation_test.go
+++ b/activation/activation_test.go
@@ -759,19 +759,6 @@ func TestStartPost(t *testing.T) {
 	assert.Equal(t, builder.commitment, execBuilder.commitment)
 }
 
-func TestSignAtx221(t *testing.T) {
-	var view []types.BlockID
-	view = append(view, block1.Id())
-	h, _ := types.CalcBlocksHash12(view)
-	activesetCache.Add(h, 5)
-
-	view = append(view, block1.Id())
-	h, _ = types.CalcBlocksHash12(view)
-	activesetCache.Add(h, 5)
-	v, b := activesetCache.Get(h)
-	fmt.Println(v, b, activesetCache.Len())
-}
-
 func gen_view() []types.BlockID {
 	l := rand.Int() % 100
 	var v []types.BlockID
@@ -782,7 +769,7 @@ func gen_view() []types.BlockID {
 	return v
 }
 
-func TestActivationDb_CalcActiveSetFromViewWithCac432he(t *testing.T) {
+func TestActivationDb_CalcActiveSetFromViewHighConcurrency(t *testing.T) {
 	activesetCache = NewActivesetCache(10) // small cache for collisions
 	atxdb, layers, _ := getAtxDb("t6")
 

--- a/activation/activationdb_test.go
+++ b/activation/activationdb_test.go
@@ -100,11 +100,12 @@ func (mock *ATXDBMock) CalcActiveSetFromView(view []types.BlockID, pubEpoch type
 }
 
 func (mock *ATXDBMock) CalcActiveSetSize(epoch types.EpochId, blocks map[types.BlockID]struct{}) (map[string]struct{}, error) {
-	mock.counter++
-	defer mock.workSymLock.Unlock()
-	log.Info("working")
+	log.Info("waiting lock")
 	mock.workSymLock.Lock()
-	log.Info("done working")
+	defer mock.workSymLock.Unlock()
+	log.Info("done wait")
+
+	mock.counter++
 	return map[string]struct{}{"aaaaac": {}, "aaabddb": {}, "aaaccc": {}}, nil
 }
 

--- a/activation/atxdb.go
+++ b/activation/atxdb.go
@@ -256,7 +256,6 @@ func (db *ActivationDb) CalcActiveSetFromView(view []types.BlockID, pubEpoch typ
 	if pubEpoch < 1 {
 		return 0, fmt.Errorf("publication epoch cannot be less than 1, found %v", pubEpoch)
 	}
-
 	viewHash, err := types.CalcBlocksHash12(view)
 	if err != nil {
 		return 0, fmt.Errorf("failed to calc sorted view hash: %v", err)
@@ -280,7 +279,8 @@ func (db *ActivationDb) CalcActiveSetFromView(view []types.BlockID, pubEpoch typ
 		// if not found, keep running mutex and calculate active set size
 	} else {
 		// if no running calc, insert new one
-		db.pendingActiveSet[viewHash] = &sync.Mutex{}
+		mu = &sync.Mutex{}
+		db.pendingActiveSet[viewHash] = mu
 		db.pendingActiveSet[viewHash].Lock()
 		db.assLock.Unlock()
 	}
@@ -292,21 +292,23 @@ func (db *ActivationDb) CalcActiveSetFromView(view []types.BlockID, pubEpoch typ
 
 	countedAtxs, err := db.calcActiveSetFunc(pubEpoch, mp)
 	if err != nil {
-		db.releaseRunningLock(viewHash)
+		mu.Unlock()
+		db.deleteLock(viewHash)
 		return 0, err
 	}
 	activesetCache.Add(viewHash, uint32(len(countedAtxs)))
-
-	db.releaseRunningLock(viewHash)
+	mu.Unlock()
+	db.deleteLock(viewHash)
 
 	return uint32(len(countedAtxs)), nil
 
 }
 
-func (db *ActivationDb) releaseRunningLock(viewHash types.Hash12) {
+func (db *ActivationDb) deleteLock(viewHash types.Hash12) {
 	db.assLock.Lock()
-	db.pendingActiveSet[viewHash].Unlock()
-	delete(db.pendingActiveSet, viewHash)
+	if _, exist := db.pendingActiveSet[viewHash]; exist {
+		delete(db.pendingActiveSet, viewHash)
+	}
 	db.assLock.Unlock()
 }
 


### PR DESCRIPTION
## Motivation
A panic of nil dereference that happened in an automation test (late nodes).

## Changes
Fixed locking and lock deletion behavior in CalcActiveSetFromView.

## Test Plan
Added a high scale UT that discovered the unlock and deletion issue locally.