### PR TITLE
[Merged by Bors] - fixed state root loaded to be 0 when running fresh node

### DIFF
--- a/activation/activationdb_test.go
+++ b/activation/activationdb_test.go
@@ -100,10 +100,10 @@ func (mock *ATXDBMock) CalcActiveSetFromView(view []types.BlockID, pubEpoch type
 }
 
 func (mock *ATXDBMock) CalcActiveSetSize(epoch types.EpochId, blocks map[types.BlockID]struct{}) (map[string]struct{}, error) {
-	log.Info("waiting lock")
+	log.Debug("waiting lock")
 	mock.workSymLock.Lock()
 	defer mock.workSymLock.Unlock()
-	log.Info("done wait")
+	log.Debug("done wait")
 
 	mock.counter++
 	return map[string]struct{}{"aaaaac": {}, "aaabddb": {}, "aaaccc": {}}, nil

--- a/state/processor.go
+++ b/state/processor.go
@@ -45,12 +45,14 @@ func NewTransactionProcessor(allStates, processorDb database.Database, projector
 	if err != nil {
 		log.Panic("cannot load state db, %v", err)
 	}
+	root := stateDb.IntermediateRoot(false)
+	log.Info("started processor with state root %v", root)
 	return &TransactionProcessor{
 		Log:          logger,
 		StateDB:      stateDb,
 		processorDb:  processorDb,
 		currentLayer: 0,
-		rootHash:     stateDb.IntermediateRoot(false),
+		rootHash:     root,
 		stateQueue:   list.List{},
 		projector:    projector,
 		trie:         stateDb.TrieDB(),

--- a/state/processor.go
+++ b/state/processor.go
@@ -50,7 +50,7 @@ func NewTransactionProcessor(allStates, processorDb database.Database, projector
 		StateDB:      stateDb,
 		processorDb:  processorDb,
 		currentLayer: 0,
-		rootHash:     types.Hash32{},
+		rootHash:     stateDb.IntermediateRoot(false),
 		stateQueue:   list.List{},
 		projector:    projector,
 		trie:         stateDb.TrieDB(),

--- a/state/processor_test.go
+++ b/state/processor_test.go
@@ -524,6 +524,8 @@ func TestTransactionProcessor_GetStateRoot(t *testing.T) {
 	lg := log.New("proc_logger", "", "")
 	proc := NewTransactionProcessor(db, appliedTxsMock{}, &ProjectorMock{}, lg)
 
+	r.NotEqual(types.Hash32{}, proc.rootHash)
+
 	expectedRoot := types.Hash32{1, 2, 3}
 	r.NoError(proc.addState(expectedRoot, 1))
 


### PR DESCRIPTION
## Motivation
State root needs to be initialized when running fresh node

## Changes
stateRoot is not inited using `IntermediateRoot` when loading 
## Test Plan
added UT to test processor loading with root hash != 0
## TODO
<!-- This section should be removed when all items are complete -->
- [ ] Explain motivation or link existing issue(s)
- [ ] Test changes and document test plan
- [ ] Update documentation as needed
