### PR TITLE
[Merged by Bors] - Sum reward from multiple blocks for layer reward

### DIFF
--- a/api/grpc_server.go
+++ b/api/grpc_server.go
@@ -123,9 +123,9 @@ func (s SpacemeshGrpcService) getProjection(addr types.Address) (nonce, balance 
 // and all known transactions in unapplied blocks and the mempool that originate from the given account. Unapplied
 // transactions coming INTO the given account (from mempool or unapplied blocks) are NOT counted.
 func (s SpacemeshGrpcService) GetBalance(ctx context.Context, in *pb.AccountId) (*pb.SimpleMessage, error) {
-	log.Info("GRPC GetBalance msg")
+	log.Debug("GRPC GetBalance msg")
 	addr := types.HexToAddress(in.Address)
-	log.Info("GRPC GetBalance for address %x (len %v)", addr, len(addr))
+	log.Debug("GRPC GetBalance for address %x (len %v)", addr, len(addr))
 	if s.StateApi.Exist(addr) != true {
 		log.Error("GRPC GetBalance returned error msg: account does not exist, address %x", addr)
 		return nil, fmt.Errorf("account does not exist")
@@ -136,7 +136,7 @@ func (s SpacemeshGrpcService) GetBalance(ctx context.Context, in *pb.AccountId) 
 		return nil, err
 	}
 	msg := &pb.SimpleMessage{Value: strconv.FormatUint(balance, 10)}
-	log.Info("GRPC GetBalance returned msg.Value %v", msg.Value)
+	log.Debug("GRPC GetBalance returned msg.Value %v", msg.Value)
 	return msg, nil
 }
 

--- a/api/grpc_server.go
+++ b/api/grpc_server.go
@@ -385,7 +385,7 @@ func (s SpacemeshGrpcService) SetLoggerLevel(ctx context.Context, msg *pb.SetLog
 }
 
 func (s SpacemeshGrpcService) GetAccountTxs(ctx context.Context, txsSinceLayer *pb.GetTxsSinceLayer) (*pb.AccountTxs, error) {
-	log.Info("GRPC GetAccountTxs msg")
+	log.Debug("GRPC GetAccountTxs msg")
 
 	currentPBase := s.Tx.LatestLayerInState()
 
@@ -422,7 +422,7 @@ func (s SpacemeshGrpcService) getTxIdsFromMesh(minLayer types.LayerID, addr type
 }
 
 func (s SpacemeshGrpcService) GetAccountRewards(ctx context.Context, account *pb.AccountId) (*pb.AccountRewards, error) {
-	log.Info("GRPC GetAccountRewards msg")
+	log.Debug("GRPC GetAccountRewards msg")
 	acc := types.HexToAddress(account.Address)
 
 	rewards, err := s.Tx.GetRewards(acc)

--- a/mesh/meshdb.go
+++ b/mesh/meshdb.go
@@ -399,9 +399,14 @@ type dbReward struct {
 }
 
 func (m *MeshDB) writeTransactionRewards(l types.LayerID, accounts []types.Address, totalReward, layerReward *big.Int) error {
-	batch := m.transactions.NewBatch()
+	actBlockCnt := make(map[types.Address]uint64)
 	for _, account := range accounts {
-		reward := dbReward{TotalReward: totalReward.Uint64(), LayerRewardEstimate: layerReward.Uint64()}
+		actBlockCnt[account]++
+	}
+
+	batch := m.transactions.NewBatch()
+	for account, cnt := range actBlockCnt {
+		reward := dbReward{TotalReward: cnt * totalReward.Uint64(), LayerRewardEstimate: cnt * layerReward.Uint64()}
 		if b, err := types.InterfaceToBytes(&reward); err != nil {
 			return fmt.Errorf("could not marshal reward for %v: %v", account.Short(), err)
 		} else if err := batch.Put(getRewardKey(l, account), b); err != nil {

--- a/mesh/meshdb_test.go
+++ b/mesh/meshdb_test.go
@@ -493,7 +493,7 @@ func TestMeshDB_testGetRewards(t *testing.T) {
 	err = mdb.writeTransactionRewards(2, []types.Address{addr1, addr2}, big.NewInt(20000), big.NewInt(19000))
 	r.NoError(err)
 
-	err = mdb.writeTransactionRewards(3, []types.Address{addr2}, big.NewInt(30000), big.NewInt(29000))
+	err = mdb.writeTransactionRewards(3, []types.Address{addr2, addr2}, big.NewInt(15000), big.NewInt(14500))
 	r.NoError(err)
 
 	rewards, err := mdb.GetRewards(addr2)


### PR DESCRIPTION
## Motivation
If a miner created more than one block in a layer the reward list reported to the wallet would only include one of those rewards, causing a discrepancy of amounts.

## Changes
Sum the rewards from all of a miner's blocks and report that as the layer reward.

## Test Plan
Unit test has been updated with this case.