### PR TITLE
[Merged by Bors] - skip redundant build on develop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,45 +34,48 @@ jobs:
     name: lint
     install: true # this skips the installation step
     script: make lint
+    if: branch = staging OR branch = trying OR type = pull_request
   - name: test
     script:
       - make genproto
       - make test
+    if: branch = staging OR branch = trying OR type = pull_request
   - name: test-tidy-fmt
     script:
       - make genproto
       - make test-tidy
       - make test-fmt
+    if: branch = staging OR branch = trying OR type = pull_request
   - stage: docker-push
     name: "Push to dockerHub"
     script:
       - make dockerpush
-    if: (branch = develop OR branch = staging OR branch = trying) AND type != pull_request
+    if: (branch = staging OR branch = trying) AND type != pull_request
   - stage: system-test
     name: "Run late nodes system test"
     script:
       - make dockertest-late-nodes
-    if: (branch = develop OR branch = staging OR branch = trying) AND type != pull_request
+    if: (branch = staging OR branch = trying) AND type != pull_request
   - name: "Run p2p system tests"
     script:
       - make dockertest-p2p
-    if: (branch = develop OR branch = staging OR branch = trying) AND type != pull_request
+    if: (branch = staging OR branch = trying) AND type != pull_request
   - name: "Run mining system tests"
     script:
       - make dockertest-mining
-    if: (branch = develop OR branch = staging OR branch = trying) AND type != pull_request
+    if: (branch = staging OR branch = trying) AND type != pull_request
   - name: "Run hare system tests"
     script:
       - make dockertest-hare
-    if: (branch = develop OR branch = staging OR branch = trying) AND type != pull_request
+    if: (branch = staging OR branch = trying) AND type != pull_request
   - name: "Run sync system tests"
     script:
       - make dockertest-sync
-    if: (branch = develop OR branch = staging OR branch = trying) AND type != pull_request
+    if: (branch = staging OR branch = trying) AND type != pull_request
   - name: "Run genesis votes test"
     script:
       - make dockertest-genesis-voting
-    if: (branch = develop OR branch = staging OR branch = trying) AND type != pull_request
+    if: (branch = staging OR branch = trying) AND type != pull_request
 
 cache:
   directories:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <a href="https://gitter.im/spacemesh-os/Lobby"><img src="https://img.shields.io/badge/gitter-%23spacemesh--os-blue.svg"/></a>
 <a href="https://spacemesh.io"><img src="https://img.shields.io/badge/madeby-spacemeshos-blue.svg"/></a>
 [![Go Report Card](https://goreportcard.com/badge/github.com/spacemeshos/go-spacemesh)](https://goreportcard.com/report/github.com/spacemeshos/go-spacemesh)
-<a href="https://travis-ci.org/spacemeshos/go-spacemesh"><img src="https://api.travis-ci.org/spacemeshos/go-spacemesh.svg?branch=develop" /></a>
+[![Bors enabled](https://bors.tech/images/badge_small.svg)](https://app.bors.tech/repositories/22421)
 <a href="https://godoc.org/github.com/spacemeshos/go-spacemesh"><img src="https://img.shields.io/badge/godoc-LGTM-blue.svg"/></a>
 </p>
 <p align="center">


### PR DESCRIPTION
## Motivation
Travis currently runs all tests after a PR is merged, which isn't needed because Bors does it before the merge. This causes other tests to wait for the redundant tests to finish, slowing everything down.

## Changes
Don't run a build on `develop`.

## Test Plan
N/A