### PR TITLE
[Merged by Bors] - Add testnet running instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,9 +135,11 @@ You specify these parameters by providing go-spacemesh with a toml config file. 
 ./go-spacemesh --grpc-server --json-server --tcp-port [a_port] --config [tomlFileLocation] -d [nodeDataFilesPath]
 ```
 
-For example:
+##### Example
+Assuming tn1.toml is a testnet config file saved in the same directory as go-spacemesh, use the following command to join the testnet. The data folder will be created in the same directory as go-spacemesh. The node will use TCP port 7152 and UDP port 7152 for p2p connections:
+
 ```bash
-./build/go-spacemesh --grpc-server --json-server --tcp-port 7153 --config tn1.toml -d ~/spacemesh_data
+./go-spacemesh --grpc-server --json-server --tcp-port 7152 --config tn1.toml -d sm_data
 ```
 
 4. Build the [CLI Wallet](https://github.com/spacemeshos/CLIWallet) from source code and run it:

--- a/README.md
+++ b/README.md
@@ -116,10 +116,39 @@ make darwin | linux | windows
 
 Platform-specific binaries are saved to the `/build` directory.
 
+---
+
 ### Running
+
+go-spacemesh is p2p software which is designed to form a decentralized network by connecting to other instances of go-spacemesh running on remote computers.
+
+To run go-spacemesh you need to specify the parameters shared between all instances on a specific network.
+
+You specify these parameters by providing go-spacemesh with a toml config file. Other CLI flags control local node behavior and override default values.
+
+#### Joining a Testnet
+1. Build go-spacemesh from source code.
+2. Obtain the testnet's toml config file.
+3. Start go-spacemesh with the following arguments:
+
+```bash
+./go-spacemesh --grpc-server --json-server --tcp-port [a_port] --config [tomlFileLocation] -d [nodeDataFilesPath]
 ```
-./build/go-spacemesh
+
+For example:
+```bash
+./build/go-spacemesh --grpc-server --json-server --tcp-port 7153 --config tn1.toml -d ~/spacemesh_data
 ```
+
+4. Build the [CLI Wallet](https://github.com/spacemeshos/CLIWallet) from source code and run it:
+
+5. Use the CLI Wallet commands to setup accounts, start smeshing and execute transactions.
+
+```bash
+./cli_wallet
+```
+
+---
 
 ### Testing
 
@@ -149,7 +178,7 @@ On windows you will need the following prerequisites:
 You can then run the command `make install` followed by `make build` as on unix based systems.
 
 ### Running a Local Testnet
-- You can run a local Spacemesh Testent with 6 full nodes, 6 user accounts, and 1 POET support service on your computer using docker. 
+- You can run a local Spacemesh Testent with 6 full nodes, 6 user accounts, and 1 POET support service on your computer using docker.
 - The local testnet full nodes are built from this repo.
 - This is a great way to get a feel for the protocol and the platform and to start hacking on Spacemesh.
 - Follow the steps in our [Local Testnet Guide](https://testnet.spacemesh.io/#/README)

--- a/README.md
+++ b/README.md
@@ -156,12 +156,12 @@ Assuming tn1.toml is a testnet config file saved in the same directory as go-spa
 2. Follow the steps for joining the testnet without mining but use these parameters when starting go-spacemesh:
 
 ```bash
-./go-spacemesh --grpc-server --json-server --tcp-port [a_port] --config [tomlFileLocation] -d [nodeDataFilesPath] --coinbase [an_account] --start-mining --post-size [post_size_bytes] --post-datadir [dir_for_post_data]
+./go-spacemesh --grpc-server --json-server --tcp-port [a_port] --config [tomlFileLocation] -d [nodeDataFilesPath] --coinbase [an_account] --start-mining --post-datadir [dir_for_post_data]
 ```
 
 ##### Example
 ```bash
-./go-spacemesh --grpc-server --json-server --tcp-port 7152 --config tn1.toml -d sm_data --coinbase 0x36168c60e06abbb4f5df6d1dd6a1b15655d71e75 --start-mining --post-size 4294967296 --post-datadir post_data
+./go-spacemesh --grpc-server --json-server --tcp-port 7152 --config tn1.toml -d sm_data --coinbase 0x36168c60e06abbb4f5df6d1dd6a1b15655d71e75 --start-mining --post-datadir post_data
 ```
 
 Tip: set the post-size to the value of the post-space param in the testnet's toml file.

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Assuming tn1.toml is a testnet config file saved in the same directory as go-spa
 
 ##### Example
 ```bash
-./go-spacemesh --grpc-server --json-server --tcp-port [a_port] --config tn1.toml -d sm_data --coinbase 0x36168c60e06abbb4f5df6d1dd6a1b15655d71e75 --start-mining --post-size 4294967296 --post-datadir post_data
+./go-spacemesh --grpc-server --json-server --tcp-port 7152 --config tn1.toml -d sm_data --coinbase 0x36168c60e06abbb4f5df6d1dd6a1b15655d71e75 --start-mining --post-size 4294967296 --post-datadir post_data
 ```
 
 Tip: set the post-size to the value of the post-space param in the testnet's toml file.

--- a/README.md
+++ b/README.md
@@ -164,8 +164,6 @@ Assuming tn1.toml is a testnet config file saved in the same directory as go-spa
 ./go-spacemesh --grpc-server --json-server --tcp-port 7152 --config tn1.toml -d sm_data --coinbase 0x36168c60e06abbb4f5df6d1dd6a1b15655d71e75 --start-mining --post-datadir post_data
 ```
 
-Tip: set the post-size to the value of the post-space param in the testnet's toml file.
-
 3. Use the CLI wallet to check your coinbase account balance and to transact
 
 ---

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ To run go-spacemesh you need to specify the parameters shared between all instan
 
 You specify these parameters by providing go-spacemesh with a toml config file. Other CLI flags control local node behavior and override default values.
 
-#### Joining a Testnet
+#### Joining a Testnet (without mining)
 1. Build go-spacemesh from source code.
 2. Obtain the testnet's toml config file.
 3. Start go-spacemesh with the following arguments:
@@ -146,9 +146,27 @@ Assuming tn1.toml is a testnet config file saved in the same directory as go-spa
 
 5. Use the CLI Wallet commands to setup accounts, start smeshing and execute transactions.
 
+
 ```bash
 ./cli_wallet
 ```
+
+### Joining the Testnet (with mining)
+1. Use the CLI Wallet to create a coinbase account.
+2. Follow the steps for joining the testnet without mining but use these parameters when starting go-spacemesh:
+
+```bash
+./go-spacemesh --grpc-server --json-server --tcp-port [a_port] --config [tomlFileLocation] -d [nodeDataFilesPath] --coinbase [an_account] --start-mining --post-size [post_size_bytes] --post-datadir [dir_for_post_data]
+```
+
+##### Example
+```bash
+./go-spacemesh --grpc-server --json-server --tcp-port [a_port] --config tn1.toml -d sm_data --coinbase 0x36168c60e06abbb4f5df6d1dd6a1b15655d71e75 --start-mining --post-size 4294967296 --post-datadir post_data
+```
+
+Tip: set the post-size to the value of the post-space param in the testnet's toml file.
+
+3. Use the CLI wallet to check your coinbase account balance and to transact
 
 ---
 


### PR DESCRIPTION
## Motivation
Provide useful instructions for running go-spacemesh by joining a testnet and using the CLI wallet with it, 

## Changes
./go-spacemesh - which is pretty much useless with details steps of how to build go-spacemesh from source code and join a testnet with it.

## Test Plan
As the CLI wallet is just another node API client, most tests should be client tests. We need to verify that users are able to set smeshing via the CLI wallet, switch coinbase and perform transactions.

## TODO
- [x] Explain motivation or link existing issue(s)
- [ ] Test changes and document test plan
- [x] Update documentation as needed
