### PR TITLE
[Merged by Bors] - support non routable nodes

### DIFF
--- a/p2p/integration_suite.go
+++ b/p2p/integration_suite.go
@@ -235,8 +235,8 @@ func StringIdentifiers(boot ...*swarm) []string {
 	s := make([]string, len(boot))
 	for i := 0; i < len(s); i++ {
 		pk := boot[i].LocalNode().PublicKey()
-		udp := boot[i].udpnetwork.LocalAddr().(*net.UDPAddr)
 		tcp := boot[i].network.LocalAddr().(*net.TCPAddr)
+		udp := boot[i].udpnetwork.LocalAddr().(*net.UDPAddr)
 		nodeinfo := node.NewNode(pk, net.IPv6loopback, uint16(tcp.Port), uint16(udp.Port))
 		s[i] = nodeinfo.String() //node.StringFromNode(node.New(boot[i].LocalNode().Node.PublicKey(), boot[i].udpnetwork.LocalAddr().String())) )
 	}

--- a/p2p/integration_test.go
+++ b/p2p/integration_test.go
@@ -136,6 +136,7 @@ func Test_SmallP2PIntegrationSuite(t *testing.T) {
 }
 
 func Test_BigP2PIntegrationSuite(t *testing.T) {
+	t.Skip()
 	s := new(P2PIntegrationSuite)
 	s.IntegrationTestSuite = new(IntegrationTestSuite)
 

--- a/p2p/integration_test.go
+++ b/p2p/integration_test.go
@@ -136,7 +136,6 @@ func Test_SmallP2PIntegrationSuite(t *testing.T) {
 }
 
 func Test_BigP2PIntegrationSuite(t *testing.T) {
-	t.Skip()
 	s := new(P2PIntegrationSuite)
 	s.IntegrationTestSuite = new(IntegrationTestSuite)
 

--- a/p2p/net/conn_mock.go
+++ b/p2p/net/conn_mock.go
@@ -5,10 +5,15 @@ import (
 	"github.com/spacemeshos/go-spacemesh/crypto"
 	"github.com/spacemeshos/go-spacemesh/p2p/p2pcrypto"
 	"net"
-	"strconv"
 	"sync/atomic"
 	"time"
 )
+
+var defaultAddr net.Addr = &net.TCPAddr{
+	IP:   IPv4LoopbackAddress,
+	Port: 7513,
+	Zone: "",
+}
 
 type ConnectionMock struct {
 	id        string
@@ -18,7 +23,7 @@ type ConnectionMock struct {
 
 	created time.Time
 
-	addr string
+	Addr net.Addr
 
 	sendDelayMs int
 	sendRes     error
@@ -55,15 +60,7 @@ func (cm *ConnectionMock) SetRemotePublicKey(key p2pcrypto.PublicKey) {
 }
 
 func (cm *ConnectionMock) RemoteAddr() net.Addr {
-
-	if cm.addr == "" {
-		return nil
-	}
-
-	addr, port, _ := net.SplitHostPort(cm.addr)
-	portstr, _ := strconv.Atoi(port)
-
-	return &net.TCPAddr{net.ParseIP(addr), portstr, ""}
+	return cm.Addr
 }
 
 func (cm *ConnectionMock) SetSession(session NetworkSession) {

--- a/p2p/net/conn_mock.go
+++ b/p2p/net/conn_mock.go
@@ -16,6 +16,8 @@ type ConnectionMock struct {
 	session   NetworkSession
 	source    ConnectionSource
 
+	created time.Time
+
 	addr string
 
 	sendDelayMs int
@@ -30,11 +32,18 @@ func NewConnectionMock(key p2pcrypto.PublicKey) *ConnectionMock {
 		id:        crypto.UUIDString(),
 		remotePub: key,
 		closed:    false,
+		created:   time.Now(),
 	}
 }
 
 func (cm ConnectionMock) ID() string {
 	return cm.id
+}
+func (cm ConnectionMock) Created() time.Time {
+	return cm.created
+}
+func (cm ConnectionMock) SetCreated(time2 time.Time) {
+	cm.created = time2
 }
 
 func (cm ConnectionMock) RemotePublicKey() p2pcrypto.PublicKey {

--- a/p2p/net/msgcon.go
+++ b/p2p/net/msgcon.go
@@ -1,62 +1,20 @@
 package net
 
 import (
-	"errors"
-	"github.com/spacemeshos/go-spacemesh/log"
-	"github.com/spacemeshos/go-spacemesh/p2p/config"
-	"github.com/spacemeshos/go-spacemesh/p2p/metrics"
-	"github.com/spacemeshos/go-spacemesh/p2p/net/wire/delimited"
-	"github.com/spacemeshos/go-spacemesh/p2p/p2pcrypto"
-	"time"
-
 	"fmt"
+	"github.com/spacemeshos/go-spacemesh/crypto"
+	"github.com/spacemeshos/go-spacemesh/log"
+	"github.com/spacemeshos/go-spacemesh/p2p/metrics"
+	"github.com/spacemeshos/go-spacemesh/p2p/p2pcrypto"
 	"io"
 	"net"
 	"sync"
-
-	"github.com/spacemeshos/go-spacemesh/crypto"
+	"time"
 )
-
-var (
-	// ErrClosedIncomingChannel is sent when the connection is closed because the underlying formatter incoming channel was closed
-	ErrClosedIncomingChannel = errors.New("unexpected closed incoming channel")
-	// ErrConnectionClosed is sent when the connection is closed after Close was called
-	ErrConnectionClosed = errors.New("connections was intentionally closed")
-)
-
-// ConnectionSource specifies the connection originator - local or remote node.
-type ConnectionSource int
-
-// ConnectionSource values
-const (
-	Local ConnectionSource = iota
-	Remote
-)
-
-const MessageQueueSize = 250
-
-// Connection is an interface stating the API of all secured connections in the system
-type Connection interface {
-	fmt.Stringer
-
-	ID() string
-	RemotePublicKey() p2pcrypto.PublicKey
-	SetRemotePublicKey(key p2pcrypto.PublicKey)
-	Created() time.Time
-
-	RemoteAddr() net.Addr
-
-	Session() NetworkSession
-	SetSession(session NetworkSession)
-
-	Send(m []byte) error
-	Close() error
-	Closed() bool
-}
 
 // FormattedConnection is an io.Writer and an io.Closer
 // A network connection supporting full-duplex messaging
-type FormattedConnection struct {
+type MsgConnection struct {
 	// metadata for logging / debugging
 	logger      log.Log
 	id          string // uuid for logging
@@ -67,9 +25,9 @@ type FormattedConnection struct {
 	session     NetworkSession
 	deadline    time.Duration
 	timeout     time.Duration
-	r           formattedReader
+	r           io.Reader
 	wmtx        sync.Mutex
-	w           formattedWriter
+	w           io.Writer
 	closed      bool
 	deadliner   deadliner
 	messages    chan []byte
@@ -79,46 +37,19 @@ type FormattedConnection struct {
 	msgSizeLimit int
 }
 
-type networker interface {
-	HandlePreSessionIncomingMessage(c Connection, msg []byte) error
-	EnqueueMessage(ime IncomingMessageEvent)
-	SubscribeClosingConnections(func(c ConnectionWithErr))
-	publishClosingConnection(c ConnectionWithErr)
-	NetworkID() int8
-}
-
-type readWriteCloseAddresser interface {
-	io.ReadWriteCloser
-	deadliner
-	RemoteAddr() net.Addr
-}
-
-type deadliner interface {
-	SetReadDeadline(t time.Time) error
-	SetWriteDeadline(t time.Time) error
-}
-
-type formattedReader interface {
-	Next() ([]byte, error)
-}
-
-type formattedWriter interface {
-	WriteRecord([]byte) (int, error)
-}
-
 // Create a new connection wrapping a net.Conn with a provided connection manager
-func newConnection(conn readWriteCloseAddresser, netw networker,
-	remotePub p2pcrypto.PublicKey, session NetworkSession, msgSizeLimit int, deadline time.Duration, log log.Log) *FormattedConnection {
+func newMsgonnection(conn readWriteCloseAddresser, netw networker,
+	remotePub p2pcrypto.PublicKey, session NetworkSession, msgSizeLimit int, deadline time.Duration, log log.Log) *MsgConnection {
 
 	// todo parametrize channel size - hard-coded for now
-	connection := &FormattedConnection{
+	connection := &MsgConnection{
 		logger:       log,
 		id:           crypto.UUIDString(),
 		created:      time.Now(),
 		remotePub:    remotePub,
 		remoteAddr:   conn.RemoteAddr(),
-		r:            delimited.NewReader(conn),
-		w:            delimited.NewWriter(conn),
+		r:            conn,
+		w:            conn,
 		close:        conn,
 		deadline:     deadline,
 		deadliner:    conn,
@@ -133,45 +64,45 @@ func newConnection(conn readWriteCloseAddresser, netw networker,
 }
 
 // ID returns the channel's ID
-func (c *FormattedConnection) ID() string {
+func (c *MsgConnection) ID() string {
 	return c.id
 }
 
 // RemoteAddr returns the channel's remote peer address
-func (c *FormattedConnection) RemoteAddr() net.Addr {
+func (c *MsgConnection) RemoteAddr() net.Addr {
 	return c.remoteAddr
 }
 
 // SetRemotePublicKey sets the remote peer's public key
-func (c *FormattedConnection) SetRemotePublicKey(key p2pcrypto.PublicKey) {
+func (c *MsgConnection) SetRemotePublicKey(key p2pcrypto.PublicKey) {
 	c.remotePub = key
 }
 
 // RemotePublicKey returns the remote peer's public key
-func (c *FormattedConnection) RemotePublicKey() p2pcrypto.PublicKey {
+func (c *MsgConnection) RemotePublicKey() p2pcrypto.PublicKey {
 	return c.remotePub
 }
 
 // SetSession sets the network session
-func (c *FormattedConnection) SetSession(session NetworkSession) {
+func (c *MsgConnection) SetSession(session NetworkSession) {
 	c.session = session
 }
 
 // Session returns the network session
-func (c *FormattedConnection) Session() NetworkSession {
+func (c *MsgConnection) Session() NetworkSession {
 	return c.session
 }
 
 // String returns a string describing the connection
-func (c *FormattedConnection) String() string {
+func (c *MsgConnection) String() string {
 	return c.id
 }
 
-func (c *FormattedConnection) Created() time.Time {
+func (c *MsgConnection) Created() time.Time {
 	return c.created
 }
 
-func (c *FormattedConnection) publish(message []byte) {
+func (c *MsgConnection) publish(message []byte) {
 	c.networker.EnqueueMessage(IncomingMessageEvent{c, message})
 }
 
@@ -203,7 +134,7 @@ func (c *FormattedConnection) publish(message []byte) {
 //	return cancel
 //}
 
-func (c *FormattedConnection) sendListener() {
+func (c *MsgConnection) sendListener() {
 	for {
 		select {
 		case buf := <-c.messages:
@@ -219,7 +150,7 @@ func (c *FormattedConnection) sendListener() {
 	}
 }
 
-func (c *FormattedConnection) Send(m []byte) error {
+func (c *MsgConnection) Send(m []byte) error {
 	c.wmtx.Lock()
 	if c.closed {
 		c.wmtx.Unlock()
@@ -230,7 +161,7 @@ func (c *FormattedConnection) Send(m []byte) error {
 	return nil
 }
 
-func (c *FormattedConnection) SendSock(m []byte) error {
+func (c *MsgConnection) SendSock(m []byte) error {
 	c.wmtx.Lock()
 	if c.closed {
 		c.wmtx.Unlock()
@@ -238,7 +169,7 @@ func (c *FormattedConnection) SendSock(m []byte) error {
 	}
 
 	c.deadliner.SetWriteDeadline(time.Now().Add(c.deadline))
-	_, err := c.w.WriteRecord(m)
+	_, err := c.w.Write(m)
 	if err != nil {
 		cerr := c.closeUnlocked()
 		c.wmtx.Unlock()
@@ -252,9 +183,7 @@ func (c *FormattedConnection) SendSock(m []byte) error {
 	return nil
 }
 
-var ErrAlreadyClosed = errors.New("connection is already closed")
-
-func (c *FormattedConnection) closeUnlocked() error {
+func (c *MsgConnection) closeUnlocked() error {
 	if c.closed {
 		return ErrAlreadyClosed
 	}
@@ -267,7 +196,7 @@ func (c *FormattedConnection) closeUnlocked() error {
 }
 
 // Close closes the connection (implements io.Closer). It is go safe.
-func (c *FormattedConnection) Close() error {
+func (c *MsgConnection) Close() error {
 	c.wmtx.Lock()
 	defer c.wmtx.Unlock()
 	err := c.closeUnlocked()
@@ -279,70 +208,66 @@ func (c *FormattedConnection) Close() error {
 }
 
 // Closed returns whether the connection is closed
-func (c *FormattedConnection) Closed() bool {
+func (c *MsgConnection) Closed() bool {
 	c.wmtx.Lock()
 	defer c.wmtx.Unlock()
 	return c.closed
 }
 
-var ErrTriedToSetupExistingConn = errors.New("tried to setup existing connection")
-var ErrIncomingSessionTimeout = errors.New("timeout waiting for handshake message")
-var ErrMsgExceededLimit = errors.New("message size exceeded limit")
-
-func (c *FormattedConnection) setupIncoming(timeout time.Duration) error {
-	be := make(chan struct {
-		b []byte
-		e error
-	})
-
-	go func() {
-		// TODO: some other way to make sure this groutine closes
-		c.deadliner.SetReadDeadline(time.Now().Add(timeout))
-		msg, err := c.r.Next()
-		c.deadliner.SetReadDeadline(time.Time{}) // disable read deadline
-		be <- struct {
-			b []byte
-			e error
-		}{b: msg, e: err}
-	}()
-
-	msgbe := <-be
-	msg := msgbe.b
-	err := msgbe.e
-
-	if err != nil {
-		c.Close()
-		return err
-	}
-
-	if c.msgSizeLimit != config.UnlimitedMsgSize && len(msg) > c.msgSizeLimit {
-		c.logger.With().Error("setupIncoming: message is too big",
-			log.Int("limit", c.msgSizeLimit), log.Int("actual", len(msg)))
-		return ErrMsgExceededLimit
-	}
-
-	if c.session != nil {
-		c.Close()
-		return errors.New("setup connection twice")
-	}
-
-	err = c.networker.HandlePreSessionIncomingMessage(c, msg)
-	if err != nil {
-		c.Close()
-		return err
-	}
-
-	return nil
-}
+//func (c *MsgConnection) setupIncoming(timeout time.Duration) error {
+//	be := make(chan struct {
+//		b []byte
+//		e error
+//	})
+//
+//	go func() {
+//		// TODO: some other way to make sure this groutine closes
+//		c.deadliner.SetReadDeadline(time.Now().Add(timeout))
+//		msg, err := c.r.Next()
+//		c.deadliner.SetReadDeadline(time.Time{}) // disable read deadline
+//		be <- struct {
+//			b []byte
+//			e error
+//		}{b: msg, e: err}
+//	}()
+//
+//	msgbe := <-be
+//	msg := msgbe.b
+//	err := msgbe.e
+//
+//	if err != nil {
+//		c.Close()
+//		return err
+//	}
+//
+//	if c.msgSizeLimit != config.UnlimitedMsgSize && len(msg) > c.msgSizeLimit {
+//		c.logger.With().Error("setupIncoming: message is too big",
+//			log.Int("limit", c.msgSizeLimit), log.Int("actual", len(msg)))
+//		return ErrMsgExceededLimit
+//	}
+//
+//	if c.session != nil {
+//		c.Close()
+//		return errors.New("setup connection twice")
+//	}
+//
+//	err = c.networker.HandlePreSessionIncomingMessage(c, msg)
+//	if err != nil {
+//		c.Close()
+//		return err
+//	}
+//
+//	return nil
+//}
 
 // Push outgoing message to the connections
 // Read from the incoming new messages and send down the connection
-func (c *FormattedConnection) beginEventProcessing() {
+func (c *MsgConnection) beginEventProcessing() {
 	//TODO: use a buffer pool
 	var err error
-	var buf []byte
 	for {
-		buf, err = c.r.Next()
+		buf := make([]byte, maxMessageSize)
+		size, err := c.r.Read(buf)
 		if err != nil && err != io.EOF {
 			break
 		}
@@ -353,8 +278,8 @@ func (c *FormattedConnection) beginEventProcessing() {
 		}
 
 		if len(buf) > 0 {
-			newbuf := make([]byte, len(buf))
-			copy(newbuf, buf)
+			newbuf := make([]byte, size)
+			copy(newbuf, buf[:size])
 			c.publish(newbuf)
 		}
 

--- a/p2p/net/msgcon.go
+++ b/p2p/net/msgcon.go
@@ -38,7 +38,7 @@ type MsgConnection struct {
 }
 
 // Create a new connection wrapping a net.Conn with a provided connection manager
-func newMsgonnection(conn readWriteCloseAddresser, netw networker,
+func newMsgConnection(conn readWriteCloseAddresser, netw networker,
 	remotePub p2pcrypto.PublicKey, session NetworkSession, msgSizeLimit int, deadline time.Duration, log log.Log) *MsgConnection {
 
 	// todo parametrize channel size - hard-coded for now
@@ -213,52 +213,6 @@ func (c *MsgConnection) Closed() bool {
 	defer c.wmtx.Unlock()
 	return c.closed
 }
-
-//func (c *MsgConnection) setupIncoming(timeout time.Duration) error {
-//	be := make(chan struct {
-//		b []byte
-//		e error
-//	})
-//
-//	go func() {
-//		// TODO: some other way to make sure this groutine closes
-//		c.deadliner.SetReadDeadline(time.Now().Add(timeout))
-//		msg, err := c.r.Next()
-//		c.deadliner.SetReadDeadline(time.Time{}) // disable read deadline
-//		be <- struct {
-//			b []byte
-//			e error
-//		}{b: msg, e: err}
-//	}()
-//
-//	msgbe := <-be
-//	msg := msgbe.b
-//	err := msgbe.e
-//
-//	if err != nil {
-//		c.Close()
-//		return err
-//	}
-//
-//	if c.msgSizeLimit != config.UnlimitedMsgSize && len(msg) > c.msgSizeLimit {
-//		c.logger.With().Error("setupIncoming: message is too big",
-//			log.Int("limit", c.msgSizeLimit), log.Int("actual", len(msg)))
-//		return ErrMsgExceededLimit
-//	}
-//
-//	if c.session != nil {
-//		c.Close()
-//		return errors.New("setup connection twice")
-//	}
-//
-//	err = c.networker.HandlePreSessionIncomingMessage(c, msg)
-//	if err != nil {
-//		c.Close()
-//		return err
-//	}
-//
-//	return nil
-//}
 
 // Push outgoing message to the connections
 // Read from the incoming new messages and send down the connection

--- a/p2p/net/network.go
+++ b/p2p/net/network.go
@@ -100,7 +100,11 @@ func NewNet(conf config.Config, localEntity node.LocalNode, addr *net.TCPAddr, l
 
 func (n *Net) Start() error { // todo: maybe add context
 	err := n.listen(n.newTcpListener)
-	return err
+	if err != nil {
+		return err
+	}
+	n.logger.Info("Started TCP server listener for connections on tcp:%v", n.listener.Addr().String())
+	return nil
 }
 
 // LocalAddr returns the local listening address. panics before calling Start or if Start errored
@@ -272,7 +276,6 @@ func (n *Net) listen(lis func() (listener net.Listener, err error)) error {
 	if err != nil {
 		return err
 	}
-	n.logger.Info("Started TCP server listening for connections on tcp:%v", listener.Addr().String())
 	go n.accept(listener)
 	return nil
 }

--- a/p2p/net/network_mock.go
+++ b/p2p/net/network_mock.go
@@ -28,7 +28,7 @@ func (m ReadWriteCloserMock) Close() error {
 	return nil
 }
 
-//RemoteAddr mocks remote addr return
+//RemoteAddr mocks remote Addr return
 func (m ReadWriteCloserMock) RemoteAddr() net.Addr {
 	r, err := net.ResolveTCPAddr("tcp", "127.0.0.0")
 	if err != nil {

--- a/p2p/net/network_mock.go
+++ b/p2p/net/network_mock.go
@@ -28,7 +28,7 @@ func (m ReadWriteCloserMock) Close() error {
 	return nil
 }
 
-//RemoteAddr mocks remote Addr return
+//RemoteAddr mocks remote addr return
 func (m ReadWriteCloserMock) RemoteAddr() net.Addr {
 	r, err := net.ResolveTCPAddr("tcp", "127.0.0.0")
 	if err != nil {

--- a/p2p/net/network_test.go
+++ b/p2p/net/network_test.go
@@ -154,7 +154,7 @@ func TestHandlePreSessionIncomingMessage2(t *testing.T) {
 	bobNode, bobNodeInfo := node.GenerateTestNode(t)
 
 	bobsAliceConn := NewConnectionMock(aliceNode.PublicKey())
-	bobsAliceConn.addr = fmt.Sprintf("%v:%v", aliceNodeInfo.IP.String(), aliceNodeInfo.ProtocolPort)
+	bobsAliceConn.Addr = &net.TCPAddr{IP: aliceNodeInfo.IP, Port: int(aliceNodeInfo.ProtocolPort)}
 
 	bobsAddr := &net.TCPAddr{bobNodeInfo.IP, int(bobNodeInfo.DiscoveryPort), ""}
 	bobsNet, err := NewNet(config.DefaultConfig(), bobNode, bobsAddr, log.NewDefault(t.Name()))

--- a/p2p/net/session_cache.go
+++ b/p2p/net/session_cache.go
@@ -8,7 +8,7 @@ import (
 )
 
 // simple cache for storing sessions
-const maxSessions = 5120
+const maxSessions = 2048
 
 type storedSession struct {
 	session NetworkSession

--- a/p2p/net/udp.go
+++ b/p2p/net/udp.go
@@ -1,16 +1,22 @@
 package net
 
 import (
+	"errors"
 	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/p2p/config"
 	"github.com/spacemeshos/go-spacemesh/p2p/node"
 	"github.com/spacemeshos/go-spacemesh/p2p/p2pcrypto"
 	"net"
+	"strconv"
+	"sync"
+	"time"
 )
 
 // TODO: we should remove this const. Should  not depend on the number of addresses.
 // TODO: the number of addresses should be derived from the limit provided in the config
 const maxMessageSize = 30000 // @see getAddrMax
+const maxUDPConn = 1024
+const maxUDPLife = time.Duration(time.Hour * 24)
 
 // UDPMessageEvent is an event about a udp message. passed through a channel
 type UDPMessageEvent struct {
@@ -25,26 +31,66 @@ type UDPNet struct {
 	logger     log.Log
 	udpAddress *net.UDPAddr
 	config     config.Config
-	msgChan    chan UDPMessageEvent
+	msgChan    chan IncomingMessageEvent
 	conn       *net.UDPConn
 	cache      *sessionCache
-	shutdown   chan struct{}
+
+	regMutex         sync.RWMutex
+	regNewRemoteConn []func(NewConnectionEvent)
+
+	clsMutex           sync.RWMutex
+	closingConnections []func(ConnectionWithErr)
+
+	incomingConn map[string]*udpConnWrapper
+
+	shutdown chan struct{}
 }
 
 // NewUDPNet creates a UDPNet. returns error if the listening can't be resolved
 func NewUDPNet(config config.Config, localEntity node.LocalNode, addr *net.UDPAddr, log log.Log) (*UDPNet, error) {
 	n := &UDPNet{
-		local:      localEntity,
-		logger:     log,
-		udpAddress: addr,
-		config:     config,
-		msgChan:    make(chan UDPMessageEvent, config.BufferSize),
-		shutdown:   make(chan struct{}),
+		local:        localEntity,
+		logger:       log,
+		udpAddress:   addr,
+		config:       config,
+		msgChan:      make(chan IncomingMessageEvent, config.BufferSize),
+		incomingConn: make(map[string]*udpConnWrapper, maxUDPConn),
+		shutdown:     make(chan struct{}),
 	}
 
 	n.cache = newSessionCache(n.initSession)
 
 	return n, nil
+}
+
+// SubscribeClosingConnections registers a callback for a new connection event. all registered callbacks are called before moving.
+func (n *UDPNet) SubscribeClosingConnections(f func(connection ConnectionWithErr)) {
+	n.clsMutex.Lock()
+	n.closingConnections = append(n.closingConnections, f)
+	n.clsMutex.Unlock()
+}
+
+func (n *UDPNet) publishClosingConnection(connection ConnectionWithErr) {
+	n.clsMutex.RLock()
+	for _, f := range n.closingConnections {
+		f(connection)
+	}
+	n.clsMutex.RUnlock()
+}
+
+// SubscribeOnNewRemoteConnections registers a callback for a new connection event. all registered callbacks are called before moving.
+func (n *UDPNet) SubscribeOnNewRemoteConnections(f func(event NewConnectionEvent)) {
+	n.regMutex.Lock()
+	n.regNewRemoteConn = append(n.regNewRemoteConn, f)
+	n.regMutex.Unlock()
+}
+
+func (n *UDPNet) publishNewRemoteConnectionEvent(conn Connection, node *node.NodeInfo) {
+	n.regMutex.RLock()
+	for _, f := range n.regNewRemoteConn {
+		f(NewConnectionEvent{conn, node})
+	}
+	n.regMutex.RUnlock()
 }
 
 // Start will trigger listening on the configured port
@@ -109,8 +155,42 @@ func (n *UDPNet) Send(to *node.NodeInfo, data []byte) error {
 }
 
 // IncomingMessages is a channel where incoming UDPMessagesEvents will stream
-func (n *UDPNet) IncomingMessages() chan UDPMessageEvent {
+func (n *UDPNet) IncomingMessages() chan IncomingMessageEvent {
 	return n.msgChan
+}
+
+//Dial(address inet.Addr, remotePublicKey p2pcrypto.PublicKey) (net.Connection, error) // Connect to a remote node. Can send when no error.
+//SubscribeOnNewRemoteConnections(func(event net.NewConnectionEvent))
+//SubscribeClosingConnections(func(net.ConnectionWithErr))
+
+func (n *UDPNet) Dial(address net.Addr, remotePublicKey p2pcrypto.PublicKey) (Connection, error) {
+	udpcon, err := net.DialUDP("udp", nil, address.(*net.UDPAddr))
+	if err != nil {
+		return nil, err
+	}
+
+	ns := n.cache.GetOrCreate(remotePublicKey)
+
+	conn := newMsgonnection(udpcon, n, remotePublicKey, ns, n.config.MsgSizeLimit, n.config.ResponseTimeout, n.logger)
+	go conn.beginEventProcessing()
+	return conn, nil
+}
+
+func (n *UDPNet) HandlePreSessionIncomingMessage(c Connection, msg []byte) error {
+	return errors.New("not implemented")
+}
+
+func (n *UDPNet) EnqueueMessage(ime IncomingMessageEvent) {
+	select {
+	case n.msgChan <- ime:
+		n.logger.With().Debug("recv udp message", log.String("from", ime.Conn.RemotePublicKey().String()), log.String("fromaddr", ime.Conn.RemoteAddr().String()), log.Int("len", len(ime.Message)))
+	case <-n.shutdown:
+		return
+	}
+}
+
+func (n *UDPNet) NetworkID() int8 {
+	return 0
 }
 
 // main listening loop
@@ -140,33 +220,113 @@ func (n *UDPNet) listenToUDPNetworkMessages(listener net.PacketConn) {
 		copybuf := make([]byte, size)
 		copy(copybuf, buf)
 
-		msg, pk, err := p2pcrypto.ExtractPubkey(copybuf)
+		conn, ok := n.incomingConn[addr.String()]
+		if !ok {
+			n.logger.Debug("Creating new connection ")
+			_, pk, err := p2pcrypto.ExtractPubkey(copybuf)
 
-		if err != nil {
-			n.logger.Warning("error can't extract public key from udp message. (addr=%v), err=%v", addr.String(), err)
-			continue
-		}
+			if err != nil {
+				n.logger.Warning("error can't extract public key from udp message. (addr=%v), err=%v", addr.String(), err)
+				continue
+			}
 
-		ns := n.cache.GetOrCreate(pk)
+			ns := n.cache.GetOrCreate(pk)
 
-		if ns == nil {
-			n.logger.Warning("coul'd not create session with %v:%v skipping message..", addr.String(), pk.String())
-			continue
-		}
+			if ns == nil {
+				n.logger.Warning("coul'd not create session with %v:%v skipping message..", addr.String(), pk.String())
+				continue
+			}
 
-		final, err := ns.OpenMessage(msg)
-		if err != nil {
-			n.logger.With().Warning("skipping udp with session message", log.Err(err), log.String("from", pk.String()), log.Int("msglen", len(msg)))
-			// todo: remove malfunctioning session, ban ip ?
-			continue
+			host, port, err := net.SplitHostPort(addr.String())
+			if err != nil {
+				n.logger.Warning("coudl'nt parse address skipping message from  %v %V", addr.String(), pk)
+				continue
+			}
+
+			iport, err := strconv.Atoi(port)
+			if err != nil {
+				n.logger.Warning("failed converting port to int %v", port)
+				continue
+			}
+
+			conn = &udpConnWrapper{
+				incChan:   make(chan []byte, 1000),
+				closeChan: make(chan struct{}, 1),
+				conn:      n.conn,
+				remote:    addr,
+			}
+
+			mconn := newMsgonnection(conn, n, pk, ns, n.config.MsgSizeLimit, n.config.DialTimeout, n.logger)
+			n.publishNewRemoteConnectionEvent(mconn, node.NewNode(pk, net.ParseIP(host), 0, uint16(iport)))
+			n.addConn(addr, conn)
+			go mconn.beginEventProcessing()
 		}
 
 		select {
-		case n.msgChan <- UDPMessageEvent{pk, addr, final}:
-			n.logger.With().Debug("recv udp message", log.String("from", pk.String()), log.String("fromaddr", addr.String()), log.Int("len", len(final)), log.Int("orig_size", size))
+		case conn.incChan <- copybuf:
+			continue
 		case <-n.shutdown:
 			return
 		}
 
 	}
+}
+
+func (n *UDPNet) addConn(addr net.Addr, ucw *udpConnWrapper) {
+	//if len(n.incomingConn) > maxUDPConn {
+	//	var expire string
+	//	//for k, c := range n.incomingConn {
+	//	//	expire = k
+	//	//	if time.Since(c.Created()) > maxUDPLife {
+	//	//		break
+	//	//	}
+	//	//}
+	//	//delete(n.incomingConn, expire)
+	//}
+	n.incomingConn[addr.String()] = ucw
+
+}
+
+type udpConnWrapper struct {
+	incChan   chan []byte
+	closeChan chan struct{}
+
+	rDeadline time.Time
+	wDeadline time.Time
+
+	conn   *net.UDPConn
+	remote net.Addr
+}
+
+func (ucw *udpConnWrapper) SetReadDeadline(t time.Time) error {
+	ucw.rDeadline = t
+	return nil
+}
+
+func (ucw *udpConnWrapper) SetWriteDeadline(t time.Time) error {
+	ucw.wDeadline = t
+	return nil
+}
+
+func (ucw *udpConnWrapper) RemoteAddr() net.Addr {
+	return ucw.remote
+}
+
+func (ucw *udpConnWrapper) Read(b []byte) (int, error) {
+	select {
+	case msg := <-ucw.incChan:
+		copy(b, msg)
+		log.Debug("passing message to conn ")
+		return len(msg), nil
+	case <-ucw.closeChan:
+		return 0, errors.New("closed")
+	}
+}
+func (ucw *udpConnWrapper) Write(b []byte) (int, error) {
+	return ucw.conn.WriteTo(b, ucw.remote)
+}
+
+func (ucw *udpConnWrapper) Close() error {
+	close(ucw.closeChan)
+	return nil
 }

--- a/p2p/net/udp_test.go
+++ b/p2p/net/udp_test.go
@@ -1,16 +1,23 @@
 package net
 
 import (
+	"errors"
 	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/p2p/config"
 	"github.com/spacemeshos/go-spacemesh/p2p/node"
 	"github.com/spacemeshos/go-spacemesh/p2p/p2pcrypto"
+	"github.com/spacemeshos/go-spacemesh/rand"
 	"github.com/stretchr/testify/require"
 	"net"
 	"sync/atomic"
 	"testing"
 	"time"
 )
+
+var testUDPAddr = func() *net.UDPAddr {
+	port := int(rand.Int31n(48127) + 1024)
+	return &net.UDPAddr{IP: IPv4LoopbackAddress, Port: port}
+}
 
 type mockCon struct {
 	local      net.Addr
@@ -107,13 +114,170 @@ func TestUDPNet_Sanity(t *testing.T) {
 
 	i := 0
 	for msg := range udpnet.IncomingMessages() {
-		require.Equal(t, msg.FromAddr, addr2)
-		require.Equal(t, msg.From, other.PublicKey())
-		require.Equal(t, msg.Message, []byte(testMsg))
+		require.Equal(t, msg.Conn.RemoteAddr(), addr2)
+		require.Equal(t, msg.Conn.RemotePublicKey(), other.PublicKey())
+		require.Equal(t, msg.Message, final)
 		i++
 		if i == 1 {
 			udpnet.Shutdown()
 			return
 		}
 	}
+}
+
+func TestUDPNet_Dial(t *testing.T) {
+
+}
+
+type udpConnMock struct {
+	CreatedFunc          func() time.Time
+	CloseFunc            func() error
+	PushIncomingFunc     func(b []byte) error
+	SetDeadlineFunc      func(t time.Time) error
+	SetReadDeadlineFunc  func(t time.Time) error
+	SetWriteDeadlineFunc func(t time.Time) error
+	LocalAddrFunc        func() net.Addr
+	RemoteAddrFunc       func() net.Addr
+	ReadFunc             func(b []byte) (int, error)
+	WriteFunc            func(b []byte) (int, error)
+}
+
+func (ucw *udpConnMock) PushIncoming(b []byte) error {
+	if ucw.PushIncomingFunc != nil {
+		return ucw.PushIncomingFunc(b)
+	}
+	return nil
+}
+
+func (ucw *udpConnMock) SetDeadline(t time.Time) error {
+	if ucw.SetDeadlineFunc != nil {
+		return ucw.SetDeadline(t)
+	}
+	return nil
+}
+
+func (ucw *udpConnMock) SetReadDeadline(t time.Time) error {
+	if ucw.SetReadDeadlineFunc != nil {
+		return ucw.SetReadDeadlineFunc(t)
+	}
+	return nil
+}
+
+func (ucw *udpConnMock) SetWriteDeadline(t time.Time) error {
+	if ucw.SetWriteDeadlineFunc != nil {
+		return ucw.SetWriteDeadlineFunc(t)
+	}
+	return nil
+}
+
+func (ucw *udpConnMock) Created() time.Time {
+	if ucw.CreatedFunc != nil {
+		return ucw.CreatedFunc()
+	}
+	return time.Now()
+}
+
+func (ucw *udpConnMock) LocalAddr() net.Addr {
+	if ucw.LocalAddrFunc != nil {
+		return ucw.LocalAddrFunc()
+	}
+	return nil
+}
+
+func (ucw *udpConnMock) RemoteAddr() net.Addr {
+	if ucw.RemoteAddrFunc != nil {
+		return ucw.RemoteAddrFunc()
+	}
+	return nil
+}
+
+func (ucw *udpConnMock) Read(b []byte) (int, error) {
+	if ucw.ReadFunc != nil {
+		return ucw.ReadFunc(b)
+	}
+	return 0, errors.New("not impl")
+}
+func (ucw *udpConnMock) Write(b []byte) (int, error) {
+	if ucw.WriteFunc != nil {
+		return ucw.WriteFunc(b)
+	}
+	return 0, errors.New("not impl")
+}
+
+func (ucw *udpConnMock) Close() error {
+	if ucw.CloseFunc != nil {
+		return ucw.CloseFunc()
+	}
+	return nil
+}
+
+func TestUDPNet_Cache(t *testing.T) {
+	localnode, _ := node.NewNodeIdentity()
+	addr := testUDPAddr()
+	n, err := NewUDPNet(config.DefaultConfig(), localnode, addr, log.NewDefault(t.Name()))
+	require.NoError(t, err)
+	require.NotNil(t, n)
+	addr2 := testUDPAddr()
+	n.addConn(addr2, &udpConnMock{CreatedFunc: func() time.Time {
+		return time.Now()
+	}})
+	require.Len(t, n.incomingConn, 1)
+
+	for i := 1; i < maxUDPConn; i++ {
+		addrx := testUDPAddr()
+		_, ok := n.incomingConn[addrx.String()]
+		for ok {
+			addrx = testUDPAddr()
+			_, ok = n.incomingConn[addrx.String()]
+		}
+		n.addConn(addrx, &udpConnMock{CreatedFunc: func() time.Time {
+			return time.Now()
+		}})
+	}
+
+	require.Len(t, n.incomingConn, maxUDPConn)
+
+	addrx := testUDPAddr()
+	_, ok := n.incomingConn[addrx.String()]
+	for ok {
+		addrx = testUDPAddr()
+		_, ok = n.incomingConn[addrx.String()]
+	}
+	n.addConn(addrx, &udpConnMock{CreatedFunc: func() time.Time {
+		return time.Now()
+	}})
+	require.Len(t, n.incomingConn, maxUDPConn)
+
+	i := 0
+	for k, _ := range n.incomingConn {
+		delete(n.incomingConn, k)
+		i++
+		if i == 2 {
+			break
+		}
+	}
+
+	closed := false
+
+	somecon := &udpConnMock{CreatedFunc: func() time.Time {
+		return time.Now().Add(-maxUDPLife - 5*time.Second)
+	}, CloseFunc: func() error {
+		closed = true
+		return nil
+	}}
+
+	addrxx := testUDPAddr()
+	_, okk := n.incomingConn[addrxx.String()]
+	for okk {
+		addrxx = testUDPAddr()
+		_, okk = n.incomingConn[addrxx.String()]
+	}
+
+	n.addConn(addrxx, somecon)
+
+	c, err := n.getConn(addrxx)
+	require.Error(t, err)
+	require.Nil(t, c)
+	require.True(t, closed)
+
 }

--- a/p2p/swarm.go
+++ b/p2p/swarm.go
@@ -187,7 +187,7 @@ func newSwarm(ctx context.Context, config config.Config, logger log.Log, datadir
 	// todo : if discovery on
 	s.discover = discovery.New(l, config.SwarmConfig, s.udpServer, datadir, s.logger) // create table and discovery protocol
 
-	cpool := connectionpool.NewConnectionPool(s.network, l.PublicKey())
+	cpool := connectionpool.NewConnectionPool(s.network.Dial, l.PublicKey(), logger)
 
 	s.network.SubscribeOnNewRemoteConnections(func(nce net.NewConnectionEvent) {
 		err := cpool.OnNewConnection(nce)

--- a/p2p/udp.go
+++ b/p2p/udp.go
@@ -27,7 +27,6 @@ type udpNetwork interface {
 	IncomingMessages() chan inet.IncomingMessageEvent
 	SubscribeOnNewRemoteConnections(f func(event inet.NewConnectionEvent))
 	SubscribeClosingConnections(f func(connection inet.ConnectionWithErr))
-	//Send(to *node.NodeInfo, data []byte) error
 }
 
 // UDPMux is a server for receiving and sending udp messages. through protocols.
@@ -253,7 +252,7 @@ func (mux *UDPMux) processUDPMessage(msg inet.IncomingMessageEvent) error {
 	pm := &ProtocolMessage{}
 	err = types.BytesToInterface(decPayload, pm)
 	if err != nil {
-		mux.logger.Error("proto marshaling err=", err)
+		mux.logger.Error("deserialization err=", err)
 		return ErrBadFormat2
 	}
 

--- a/p2p/udp.go
+++ b/p2p/udp.go
@@ -240,8 +240,13 @@ func (mux *UDPMux) processUDPMessage(msg inet.IncomingMessageEvent) error {
 
 	rawmsg, _, err := p2pcrypto.ExtractPubkey(msg.Message)
 
+	if err != nil {
+		return err
+	}
+
 	decPayload, err := session.OpenMessage(rawmsg)
 	if err != nil {
+		mux.logger.Warning("failed decrypting message err=%v", err)
 		return ErrFailDecrypt
 	}
 

--- a/p2p/udp_test.go
+++ b/p2p/udp_test.go
@@ -23,9 +23,6 @@ type mockUDPNetwork struct {
 
 	shutdownCalled bool
 
-	sendCalled bool
-	sendResult error
-
 	DialFunc func(address net2.Addr, remotepk p2pcrypto.PublicKey) (net.Connection, error)
 
 	inc chan net.IncomingMessageEvent
@@ -44,16 +41,19 @@ func (mun *mockUDPNetwork) IncomingMessages() chan net.IncomingMessageEvent {
 	return mun.inc
 }
 
-func (mun *mockUDPNetwork) Send(to *node.NodeInfo, data []byte) error {
-	mun.sendCalled = true
-	return mun.sendResult
-}
-
 func (mun *mockUDPNetwork) Dial(address net2.Addr, remotepk p2pcrypto.PublicKey) (net.Connection, error) {
 	if mun.DialFunc != nil {
 		return mun.DialFunc(address, remotepk)
 	}
 	return nil, errors.New("not impl")
+}
+
+func (mun *mockUDPNetwork) SubscribeClosingConnections(func(err net.ConnectionWithErr)) {
+
+}
+
+func (mun *mockUDPNetwork) SubscribeOnNewRemoteConnections(func(event net.NewConnectionEvent)) {
+
 }
 
 func TestNewUDPMux(t *testing.T) {
@@ -127,7 +127,6 @@ func TestUDPMux_sendMessageImpl(t *testing.T) {
 
 	require.Error(t, err)
 	require.True(t, lookupcalled)
-	require.False(t, udpMock.sendCalled)
 
 	lookupcalled = false
 	f = func(key p2pcrypto.PublicKey) (*node.NodeInfo, error) {
@@ -136,24 +135,48 @@ func TestUDPMux_sendMessageImpl(t *testing.T) {
 	}
 	m.lookuper = f
 
-	udpMock.sendResult = errors.New("err send")
+	udpMock.DialFunc = func(address net2.Addr, remotepk p2pcrypto.PublicKey) (connection net.Connection, err error) {
+		c := net.NewConnectionMock(remotepk)
+		c.Addr = address
+		return c, nil
+	}
 
 	err = m.sendMessageImpl(sendto.PublicKey(), test_str, data)
 
-	require.Error(t, err)
+	require.Equal(t, ErrNoSession, err)
 	require.True(t, lookupcalled)
-	require.True(t, udpMock.sendCalled)
 
 	lookupcalled = false
-	udpMock.sendResult = nil
-	udpMock.startCalled = false
+	senderr := errors.New("err send")
+	m.cpool.CloseConnection(sendto.PublicKey())
+
+	udpMock.DialFunc = func(address net2.Addr, remotepk p2pcrypto.PublicKey) (connection net.Connection, err error) {
+		c := net.NewConnectionMock(remotepk)
+		c.Addr = address
+		c.SetSession(net.NewSessionMock(remotepk))
+		c.SetSendResult(senderr)
+		return c, nil
+	}
+
+	err = m.sendMessageImpl(sendto.PublicKey(), test_str, data)
+
+	require.Equal(t, senderr, err)
+	require.True(t, lookupcalled)
+
+	m.cpool.CloseConnection(sendto.PublicKey())
+
+	udpMock.DialFunc = func(address net2.Addr, remotepk p2pcrypto.PublicKey) (connection net.Connection, err error) {
+		c := net.NewConnectionMock(remotepk)
+		c.Addr = address
+		c.SetSession(net.NewSessionMock(remotepk))
+		c.SetSendResult(nil)
+		return c, nil
+	}
 
 	err = m.sendMessageImpl(sendto.PublicKey(), test_str, data)
 
 	require.NoError(t, err)
 	require.True(t, lookupcalled)
-	require.True(t, udpMock.sendCalled)
-
 }
 
 func TestUDPMux_ProcessUDP(t *testing.T) {
@@ -171,12 +194,15 @@ func TestUDPMux_ProcessUDP(t *testing.T) {
 	//pb.NewUDPProtocolMessageMetadata(gotfrom.PublicKey(), int8(nd.NetworkID()), test_str)
 	msg.Payload = &Payload{Payload: data.Bytes()}
 
-	msgbuf, err := types.InterfaceToBytes(msg)
+	themsgbuf, err := types.InterfaceToBytes(msg)
 	require.NoError(t, err)
+
+	msgbuf := p2pcrypto.PrependPubkey(themsgbuf, gotfrom.PublicKey())
 
 	addr := &net2.UDPAddr{gotfrom.IP, int(gotfrom.DiscoveryPort), ""}
 
 	connmock := net.NewConnectionMock(gotfrom.PublicKey())
+	connmock.Addr = addr
 	err = m.processUDPMessage(net.IncomingMessageEvent{connmock, msgbuf})
 
 	require.Error(t, err) // no protocol
@@ -184,13 +210,19 @@ func TestUDPMux_ProcessUDP(t *testing.T) {
 	c := make(chan service.DirectMessage, 1)
 	m.RegisterDirectProtocolWithChannel(test_str, c)
 	err = m.processUDPMessage(net.IncomingMessageEvent{connmock, msgbuf})
+
+	require.Equal(t, err, ErrNoSession)
+
+	connmock.SetSession(net.NewSessionMock(gotfrom.PublicKey()))
+	err = m.processUDPMessage(net.IncomingMessageEvent{connmock, msgbuf})
+
 	require.NoError(t, err) // no protocol
 
 	select {
 	case msg := <-c:
-		require.Equal(t, msg.Metadata().FromAddress, addr)
-		require.Equal(t, msg.Sender(), gotfrom.PublicKey())
-		require.Equal(t, msg.Bytes(), data.Bytes())
+		require.Equal(t, addr, msg.Metadata().FromAddress)
+		require.Equal(t, gotfrom.PublicKey(), msg.Sender())
+		require.Equal(t, data.Bytes(), msg.Bytes())
 	default:
 		t.Fatal("didn't get msg")
 	}

--- a/p2p/udp_test.go
+++ b/p2p/udp_test.go
@@ -213,7 +213,16 @@ func TestUDPMux_ProcessUDP(t *testing.T) {
 
 	require.Equal(t, err, ErrNoSession)
 
-	connmock.SetSession(net.NewSessionMock(gotfrom.PublicKey()))
+	session := net.NewSessionMock(gotfrom.PublicKey())
+	connmock.SetSession(session)
+	err = m.processUDPMessage(net.IncomingMessageEvent{connmock, msgbuf})
+
+	require.Equal(t, err, ErrFailDecrypt)
+
+	session.OpenMessageFunc = func(boxedMessage []byte) (bytes []byte, err error) {
+		return boxedMessage, nil
+	}
+
 	err = m.processUDPMessage(net.IncomingMessageEvent{connmock, msgbuf})
 
 	require.NoError(t, err)

--- a/p2p/udp_test.go
+++ b/p2p/udp_test.go
@@ -216,7 +216,7 @@ func TestUDPMux_ProcessUDP(t *testing.T) {
 	connmock.SetSession(net.NewSessionMock(gotfrom.PublicKey()))
 	err = m.processUDPMessage(net.IncomingMessageEvent{connmock, msgbuf})
 
-	require.NoError(t, err) // no protocol
+	require.NoError(t, err)
 
 	select {
 	case msg := <-c:


### PR DESCRIPTION
## Motivation
Closes #1697

## Changes

uses src port tuple to return udp messages, uses `connect` syscall for udp abstraction

## Test Plan
added unit tests
## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
