### PR TITLE
[Merged by Bors] - on incoming message error, remove conn from cpool and peers.

### DIFF
--- a/p2p/swarm.go
+++ b/p2p/swarm.go
@@ -450,9 +450,12 @@ func (s *swarm) processMessage(ime net.IncomingMessageEvent) {
 
 	err := s.onRemoteClientMessage(ime)
 	if err != nil {
-		s.logger.Error("Err reading message from %v, closing connection err=%v", ime.Conn.RemotePublicKey(), err)
-		ime.Conn.Close()
 		// TODO: differentiate action on errors
+		s.logger.Error("Err reading message from %v, closing connection err=%v", ime.Conn.RemotePublicKey(), err)
+		if err := ime.Conn.Close(); err == nil {
+			s.cPool.CloseConnection(ime.Conn.RemotePublicKey())
+			s.Disconnect(ime.Conn.RemotePublicKey())
+		}
 	}
 }
 


### PR DESCRIPTION
## Motivation

We observed a bug in testnet where a connection is closed due to an error but protocols keep trying to send messages to this connection. 

Closes #1865 
## Changes
<!-- Please describe in detail the changes made -->

When a connection is closed due to an processing error of an incoming message, remove the connection from the connection pool and the neighbors list.

## Test Plan
added UT

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
