### PR TITLE
[Merged by Bors] - fixed wrong order between persist votes and pushLayersToState on lateblock

### DIFF
--- a/mesh/mesh.go
+++ b/mesh/mesh.go
@@ -235,10 +235,10 @@ func (m *validator) SetProcessedLayer(lyr types.LayerID) {
 func (v *validator) HandleLateBlock(b *types.Block) {
 	v.Info("Validate late block %s", b.Id())
 	oldPbase, newPbase := v.trtl.HandleLateBlock(b)
-	v.pushLayersToState(oldPbase, newPbase)
 	if err := v.trtl.PersistTortoise(); err != nil {
 		v.Error("could not persist Tortoise on late block %s from layer index %d", b.Id(), b.Layer())
 	}
+	v.pushLayersToState(oldPbase, newPbase)
 }
 
 func (v *validator) ValidateLayer(lyr *types.Layer) {

--- a/sync/syncer_test.go
+++ b/sync/syncer_test.go
@@ -1391,6 +1391,8 @@ func TestSyncProtocol_BadResponse(t *testing.T) {
 	syncs[1].RegisterBytesMsgHandler(TX, txHandlerMock)
 	syncs[1].RegisterBytesMsgHandler(ATX, atxHandlerMock)
 
+	// ugly hack, just to see if this fixed travis fail
+	time.Sleep(3 * time.Second)
 	// layer hash
 	_, err1 := syncs[0].getLayerFromNeighbors(types.LayerID(1))
 


### PR DESCRIPTION
fixed wrong order between persist votes and pushLayersToState on lateblock