### PR TITLE
[Merged by Bors] - De-parallelize cloud tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,33 +56,21 @@ jobs:
     script:
       - make dockertest-late-nodes
     if: (branch = staging OR branch = trying) AND type != pull_request
-  - name: "Run mining system tests"
-    script:
-      - make dockertest-mining
-    if: (branch = staging OR branch = trying) AND type != pull_request
   - name: "Run blocks add node test"
     script:
       - make dockertest-blocks-add-node
     if: (branch = staging OR branch = trying) AND type != pull_request
-  - name: "Run blocks remove node test"
+  - name: "Run hare+mining system tests"
     script:
-      - make dockertest-blocks-remove-node
+      - make dockertest-hare-mining
     if: (branch = staging OR branch = trying) AND type != pull_request
-  - name: "Run p2p system tests"
+  - name: "Run sync+blocks remove node test"
     script:
-      - make dockertest-p2p
+      - make dockertest-sync-blocks-remove-node
     if: (branch = staging OR branch = trying) AND type != pull_request
-  - name: "Run genesis votes test"
+  - name: "Run genesis+p2p system tests"
     script:
-      - make dockertest-genesis-voting
-    if: (branch = staging OR branch = trying) AND type != pull_request
-  - name: "Run sync system tests"
-    script:
-      - make dockertest-sync
-    if: (branch = staging OR branch = trying) AND type != pull_request
-  - name: "Run hare system tests"
-    script:
-      - make dockertest-hare
+      - make dockertest-genesis-voting-p2p
     if: (branch = staging OR branch = trying) AND type != pull_request
 
 cache:

--- a/Makefile
+++ b/Makefile
@@ -384,3 +384,12 @@ dockerrun-stress: dockerbuild-test dockerrun-blocks-stress dockerrun-grpc-stress
 
 dockertest-stress: dockerpush dockerrun-stress
 .PHONY: dockertest-stress
+
+dockertest-hare-mining: dockertest-hare dockertest-mining
+.PHONY: dockertest-hare-mining
+
+dockertest-sync-blocks-remove-node: dockertest-sync dockertest-blocks-remove-node
+.PHONY: dockertest-sync-blocks-remove-node
+
+dockertest-genesis-voting-p2p: dockertest-genesis-voting dockertest-p2p
+.PHONY: dockertest-genesis-voting-p2p


### PR DESCRIPTION
## Motivation
When we run too many cloud tests in parallel, our Elasticsearch instance indexes logs too slowly and assertions wrongly fail.

## Changes
Run the shorter tests in serial pairs, to have less concurrency.

For reference, these are the current test runtimes:
![image](https://user-images.githubusercontent.com/776358/77296543-88207200-6cf0-11ea-8df5-3d8a147ebb73.png)

I've therefore consolidated the following pairs:
```
Late nodes (44m)                     = 44m
Blocks add node (25m)                = 25m
Mining (24m) + Hare (7m)             = 31m
Blocks remove node (22m) + Sync (7m) = 29m
P2P (17m) + Genesys (13m)            = 30m
```

This way we'll have up to 5 tests running in parallel instead of 8 without extending the total run-time.

In each pair I've put the shortest test first.

## Test Plan
`bors try`