### PR TITLE
Code cleanup for rlp/

### DIFF
--- a/rlp/decode.go
+++ b/rlp/decode.go
@@ -553,8 +553,11 @@ func decodeDecoder(s *Stream, val reflect.Value) error {
 type Kind int
 
 const (
+	// Byte : a byte
 	Byte Kind = iota
+	// String : a string
 	String
+	// List : a list
 	List
 )
 

--- a/rlp/decode.go
+++ b/rlp/decode.go
@@ -29,18 +29,18 @@ import (
 )
 
 var (
-	// EOL is returned when the end of the current list
+	// errEol is returned when the end of the current list
 	// has been reached during streaming.
-	EOL = errors.New("rlp: end of list")
+	errEol = errors.New("rlp: end of list")
 
 	// Actual Errors
-	ErrExpectedString   = errors.New("rlp: expected String or Byte")
-	ErrExpectedList     = errors.New("rlp: expected List")
-	ErrCanonInt         = errors.New("rlp: non-canonical integer format")
-	ErrCanonSize        = errors.New("rlp: non-canonical size information")
-	ErrElemTooLarge     = errors.New("rlp: element is larger than containing list")
-	ErrValueTooLarge    = errors.New("rlp: value size exceeds available input length")
-	ErrMoreThanOneValue = errors.New("rlp: input contains more than one value")
+	errExpectedString   = errors.New("rlp: expected String or Byte")
+	errExpectedList     = errors.New("rlp: expected List")
+	errCanonInt         = errors.New("rlp: non-canonical integer format")
+	errCanonSize        = errors.New("rlp: non-canonical size information")
+	errElemTooLarge     = errors.New("rlp: element is larger than containing list")
+	errValueTooLarge    = errors.New("rlp: value size exceeds available input length")
+	errMoreThanOneValue = errors.New("rlp: input contains more than one value")
 
 	// internal errors
 	errNotInList     = errors.New("rlp: call of ListEnd outside of any list")
@@ -140,7 +140,7 @@ func DecodeBytes(b []byte, val interface{}) error {
 		return err
 	}
 	if r.Len() > 0 {
-		return ErrMoreThanOneValue
+		return errMoreThanOneValue
 	}
 	return nil
 }
@@ -164,13 +164,13 @@ func (err *decodeError) Error() string {
 
 func wrapStreamError(err error, typ reflect.Type) error {
 	switch err {
-	case ErrCanonInt:
+	case errCanonInt:
 		return &decodeError{msg: "non-canonical integer (leading zero bytes)", typ: typ}
-	case ErrCanonSize:
+	case errCanonSize:
 		return &decodeError{msg: "non-canonical size information", typ: typ}
-	case ErrExpectedList:
+	case errExpectedList:
 		return &decodeError{msg: "expected input list", typ: typ}
-	case ErrExpectedString:
+	case errExpectedString:
 		return &decodeError{msg: "expected input string or byte", typ: typ}
 	case errUintOverflow:
 		return &decodeError{msg: "input string too long", typ: typ}
@@ -280,7 +280,7 @@ func decodeBigInt(s *Stream, val reflect.Value) error {
 	}
 	// Reject leading zero bytes
 	if len(b) > 0 && b[0] == 0 {
-		return wrapStreamError(ErrCanonInt, val.Type())
+		return wrapStreamError(errCanonInt, val.Type())
 	}
 	i.SetBytes(b)
 	return nil
@@ -352,7 +352,7 @@ func decodeSliceElems(s *Stream, val reflect.Value, elemdec decoder) error {
 			val.SetLen(i + 1)
 		}
 		// decode into element
-		if err := elemdec(s, val.Index(i)); err == EOL {
+		if err := elemdec(s, val.Index(i)); err == errEol {
 			break
 		} else if err != nil {
 			return addErrorContext(err, fmt.Sprint("[", i, "]"))
@@ -371,7 +371,7 @@ func decodeListArray(s *Stream, val reflect.Value, elemdec decoder) error {
 	vlen := val.Len()
 	i := 0
 	for ; i < vlen; i++ {
-		if err := elemdec(s, val.Index(i)); err == EOL {
+		if err := elemdec(s, val.Index(i)); err == errEol {
 			break
 		} else if err != nil {
 			return addErrorContext(err, fmt.Sprint("[", i, "]"))
@@ -421,10 +421,10 @@ func decodeByteArray(s *Stream, val reflect.Value) error {
 		}
 		// Reject cases where single byte encoding should have been used.
 		if size == 1 && slice[0] < 128 {
-			return wrapStreamError(ErrCanonSize, val.Type())
+			return wrapStreamError(errCanonSize, val.Type())
 		}
 	case List:
-		return wrapStreamError(ErrExpectedString, val.Type())
+		return wrapStreamError(errExpectedString, val.Type())
 	}
 	return nil
 }
@@ -440,7 +440,7 @@ func makeStructDecoder(typ reflect.Type) (decoder, error) {
 		}
 		for _, f := range fields {
 			err := f.info.decoder(s, val.Field(f.index))
-			if err == EOL {
+			if err == errEol {
 				return &decodeError{msg: "too few elements", typ: typ}
 			} else if err != nil {
 				return addErrorContext(err, "."+typ.Field(f.index).Name)
@@ -614,13 +614,13 @@ type listpos struct{ pos, size uint64 }
 // If r implements the ByteReader interface, Stream will
 // not introduce any buffering.
 //
-// For non-toplevel values, Stream returns ErrElemTooLarge
+// For non-toplevel values, Stream returns errElemTooLarge
 // for values that do not fit into the enclosing list.
 //
 // Stream supports an optional input limit. If a limit is set, the
 // size of any toplevel value will be checked against the remaining
 // input length. Stream operations that encounter a value exceeding
-// the remaining input length will return ErrValueTooLarge. The limit
+// the remaining input length will return errValueTooLarge. The limit
 // can be set by passing a non-zero value for inputLimit.
 //
 // If r is a bytes.Reader or strings.Reader, the input limit is set to
@@ -644,7 +644,7 @@ func NewListStream(r io.Reader, len uint64) *Stream {
 
 // Bytes reads an RLP string and returns its contents as a byte slice.
 // If the input does not contain an RLP string, the returned
-// error will be ErrExpectedString.
+// error will be errExpectedString.
 func (s *Stream) Bytes() ([]byte, error) {
 	kind, size, err := s.Kind()
 	if err != nil {
@@ -660,11 +660,11 @@ func (s *Stream) Bytes() ([]byte, error) {
 			return nil, err
 		}
 		if size == 1 && b[0] < 128 {
-			return nil, ErrCanonSize
+			return nil, errCanonSize
 		}
 		return b, nil
 	default:
-		return nil, ErrExpectedString
+		return nil, errExpectedString
 	}
 }
 
@@ -695,7 +695,7 @@ func (s *Stream) Raw() ([]byte, error) {
 
 // Uint reads an RLP string of up to 8 bytes and returns its contents
 // as an unsigned integer. If the input does not contain an RLP string, the
-// returned error will be ErrExpectedString.
+// returned error will be errExpectedString.
 func (s *Stream) Uint() (uint64, error) {
 	return s.uint(64)
 }
@@ -708,7 +708,7 @@ func (s *Stream) uint(maxbits int) (uint64, error) {
 	switch kind {
 	case Byte:
 		if s.byteval == 0 {
-			return 0, ErrCanonInt
+			return 0, errCanonInt
 		}
 		s.kind = -1 // rearm Kind
 		return uint64(s.byteval), nil
@@ -718,24 +718,24 @@ func (s *Stream) uint(maxbits int) (uint64, error) {
 		}
 		v, err := s.readUint(byte(size))
 		switch {
-		case err == ErrCanonSize:
+		case err == errCanonSize:
 			// Adjust error because we're not reading a size right now.
-			return 0, ErrCanonInt
+			return 0, errCanonInt
 		case err != nil:
 			return 0, err
 		case size > 0 && v < 128:
-			return 0, ErrCanonSize
+			return 0, errCanonSize
 		default:
 			return v, nil
 		}
 	default:
-		return 0, ErrExpectedString
+		return 0, errExpectedString
 	}
 }
 
 // Bool reads an RLP string of up to 1 byte and returns its contents
 // as a boolean. If the input does not contain an RLP string, the
-// returned error will be ErrExpectedString.
+// returned error will be errExpectedString.
 func (s *Stream) Bool() (bool, error) {
 	num, err := s.uint(8)
 	if err != nil {
@@ -752,7 +752,7 @@ func (s *Stream) Bool() (bool, error) {
 }
 
 // List starts decoding an RLP list. If the input does not contain a
-// list, the returned error will be ErrExpectedList. When the list's
+// list, the returned error will be errExpectedList. When the list's
 // end has been reached, any Stream operation will return EOL.
 func (s *Stream) List() (size uint64, err error) {
 	kind, size, err := s.Kind()
@@ -760,7 +760,7 @@ func (s *Stream) List() (size uint64, err error) {
 		return 0, err
 	}
 	if kind != List {
-		return 0, ErrExpectedList
+		return 0, errExpectedList
 	}
 	s.stack = append(s.stack, listpos{0, size})
 	s.kind = -1
@@ -876,7 +876,7 @@ func (s *Stream) Kind() (kind Kind, size uint64, err error) {
 		// Don't read further if we're at the end of the
 		// innermost list.
 		if tos != nil && tos.pos == tos.size {
-			return 0, 0, EOL
+			return 0, 0, errEol
 		}
 		s.kind, s.size, s.kinderr = s.readKind()
 		if s.kinderr == nil {
@@ -884,12 +884,12 @@ func (s *Stream) Kind() (kind Kind, size uint64, err error) {
 				// At toplevel, check that the value is smaller
 				// than the remaining input length.
 				if s.limited && s.size > s.remaining {
-					s.kinderr = ErrValueTooLarge
+					s.kinderr = errValueTooLarge
 				}
 			} else {
 				// Inside a list, check that the value doesn't overflow the list.
 				if s.size > tos.size-tos.pos {
-					s.kinderr = ErrElemTooLarge
+					s.kinderr = errElemTooLarge
 				}
 			}
 		}
@@ -908,7 +908,7 @@ func (s *Stream) readKind() (kind Kind, size uint64, err error) {
 			switch err {
 			case io.ErrUnexpectedEOF:
 				err = io.EOF
-			case ErrValueTooLarge:
+			case errValueTooLarge:
 				err = io.EOF
 			}
 		}
@@ -936,7 +936,7 @@ func (s *Stream) readKind() (kind Kind, size uint64, err error) {
 		// the first byte is thus [0xB8, 0xBF].
 		size, err = s.readUint(b - 0xB7)
 		if err == nil && size < 56 {
-			err = ErrCanonSize
+			err = errCanonSize
 		}
 		return String, size, err
 	case b < 0xF8:
@@ -955,7 +955,7 @@ func (s *Stream) readKind() (kind Kind, size uint64, err error) {
 		// range of the first byte is thus [0xF8, 0xFF].
 		size, err = s.readUint(b - 0xF7)
 		if err == nil && size < 56 {
-			err = ErrCanonSize
+			err = errCanonSize
 		}
 		return List, size, err
 	}
@@ -980,8 +980,8 @@ func (s *Stream) readUint(size byte) (uint64, error) {
 		if s.uintbuf[start] == 0 {
 			// Note: readUint is also used to decode integer
 			// values. The error needs to be adjusted to become
-			// ErrCanonInt in this case.
-			return 0, ErrCanonSize
+			// errCanonInt in this case.
+			return 0, errCanonSize
 		}
 		return binary.BigEndian.Uint64(s.uintbuf), nil
 	}
@@ -1020,13 +1020,13 @@ func (s *Stream) willRead(n uint64) error {
 		// check list overflow
 		tos := s.stack[len(s.stack)-1]
 		if n > tos.size-tos.pos {
-			return ErrElemTooLarge
+			return errElemTooLarge
 		}
 		s.stack[len(s.stack)-1].pos += n
 	}
 	if s.limited {
 		if n > s.remaining {
-			return ErrValueTooLarge
+			return errValueTooLarge
 		}
 		s.remaining -= n
 	}

--- a/rlp/decode.go
+++ b/rlp/decode.go
@@ -126,7 +126,6 @@ type Decoder interface {
 //
 //     NewStream(r, limit).Decode(val)
 func Decode(r io.Reader, val interface{}) error {
-	// TODO: this could use a Stream from a pool.
 	return NewStream(r, 0).Decode(val)
 }
 
@@ -134,7 +133,6 @@ func Decode(r io.Reader, val interface{}) error {
 // Please see the documentation of Decode for the decoding rules.
 // The input must contain exactly one value and no trailing data.
 func DecodeBytes(b []byte, val interface{}) error {
-	// TODO: this could use a Stream from a pool.
 	r := bytes.NewReader(b)
 	if err := NewStream(r, uint64(len(b))).Decode(val); err != nil {
 		return err

--- a/rlp/decode_test.go
+++ b/rlp/decode_test.go
@@ -100,22 +100,22 @@ func TestStreamErrors(t *testing.T) {
 		newStream func([]byte) *Stream // uses bytes.Reader if nil
 		error     error
 	}{
-		{"C0", calls{"Bytes"}, nil, ErrExpectedString},
-		{"C0", calls{"Uint"}, nil, ErrExpectedString},
+		{"C0", calls{"Bytes"}, nil, errExpectedString},
+		{"C0", calls{"Uint"}, nil, errExpectedString},
 		{"89000000000000000001", calls{"Uint"}, nil, errUintOverflow},
-		{"00", calls{"List"}, nil, ErrExpectedList},
-		{"80", calls{"List"}, nil, ErrExpectedList},
+		{"00", calls{"List"}, nil, errExpectedList},
+		{"80", calls{"List"}, nil, errExpectedList},
 		{"C0", calls{"List", "Uint"}, nil, EOL},
-		{"C8C9010101010101010101", calls{"List", "Kind"}, nil, ErrElemTooLarge},
+		{"C8C9010101010101010101", calls{"List", "Kind"}, nil, errElemTooLarge},
 		{"C3C2010201", calls{"List", "List", "Uint", "Uint", "ListEnd", "Uint"}, nil, EOL},
 		{"00", calls{"ListEnd"}, nil, errNotInList},
 		{"C401020304", calls{"List", "Uint", "ListEnd"}, nil, errNotAtEOL},
 
 		// Non-canonical integers (e.g. leading zero bytes).
-		{"00", calls{"Uint"}, nil, ErrCanonInt},
-		{"820002", calls{"Uint"}, nil, ErrCanonInt},
-		{"8133", calls{"Uint"}, nil, ErrCanonSize},
-		{"817F", calls{"Uint"}, nil, ErrCanonSize},
+		{"00", calls{"Uint"}, nil, errCanonInt},
+		{"820002", calls{"Uint"}, nil, errCanonInt},
+		{"8133", calls{"Uint"}, nil, errCanonSize},
+		{"817F", calls{"Uint"}, nil, errCanonSize},
 		{"8180", calls{"Uint"}, nil, nil},
 
 		// Non-valid boolean
@@ -123,19 +123,19 @@ func TestStreamErrors(t *testing.T) {
 
 		// Size tags must use the smallest possible encoding.
 		// Leading zero bytes in the size tag are also rejected.
-		{"8100", calls{"Uint"}, nil, ErrCanonSize},
-		{"8100", calls{"Bytes"}, nil, ErrCanonSize},
-		{"8101", calls{"Bytes"}, nil, ErrCanonSize},
-		{"817F", calls{"Bytes"}, nil, ErrCanonSize},
+		{"8100", calls{"Uint"}, nil, errCanonSize},
+		{"8100", calls{"Bytes"}, nil, errCanonSize},
+		{"8101", calls{"Bytes"}, nil, errCanonSize},
+		{"817F", calls{"Bytes"}, nil, errCanonSize},
 		{"8180", calls{"Bytes"}, nil, nil},
-		{"B800", calls{"Kind"}, withoutInputLimit, ErrCanonSize},
-		{"B90000", calls{"Kind"}, withoutInputLimit, ErrCanonSize},
-		{"B90055", calls{"Kind"}, withoutInputLimit, ErrCanonSize},
-		{"BA0002FFFF", calls{"Bytes"}, withoutInputLimit, ErrCanonSize},
-		{"F800", calls{"Kind"}, withoutInputLimit, ErrCanonSize},
-		{"F90000", calls{"Kind"}, withoutInputLimit, ErrCanonSize},
-		{"F90055", calls{"Kind"}, withoutInputLimit, ErrCanonSize},
-		{"FA0002FFFF", calls{"List"}, withoutInputLimit, ErrCanonSize},
+		{"B800", calls{"Kind"}, withoutInputLimit, errCanonSize},
+		{"B90000", calls{"Kind"}, withoutInputLimit, errCanonSize},
+		{"B90055", calls{"Kind"}, withoutInputLimit, errCanonSize},
+		{"BA0002FFFF", calls{"Bytes"}, withoutInputLimit, errCanonSize},
+		{"F800", calls{"Kind"}, withoutInputLimit, errCanonSize},
+		{"F90000", calls{"Kind"}, withoutInputLimit, errCanonSize},
+		{"F90055", calls{"Kind"}, withoutInputLimit, errCanonSize},
+		{"FA0002FFFF", calls{"List"}, withoutInputLimit, errCanonSize},
 
 		// Expected EOF
 		{"", calls{"Kind"}, nil, io.EOF},
@@ -149,20 +149,20 @@ func TestStreamErrors(t *testing.T) {
 		{"C0", calls{"List", "ListEnd", "List"}, withoutInputLimit, io.EOF},
 
 		// Input limit errors.
-		{"81", calls{"Bytes"}, nil, ErrValueTooLarge},
-		{"81", calls{"Uint"}, nil, ErrValueTooLarge},
-		{"81", calls{"Raw"}, nil, ErrValueTooLarge},
-		{"BFFFFFFFFFFFFFFFFFFF", calls{"Bytes"}, nil, ErrValueTooLarge},
-		{"C801", calls{"List"}, nil, ErrValueTooLarge},
+		{"81", calls{"Bytes"}, nil, errValueTooLarge},
+		{"81", calls{"Uint"}, nil, errValueTooLarge},
+		{"81", calls{"Raw"}, nil, errValueTooLarge},
+		{"BFFFFFFFFFFFFFFFFFFF", calls{"Bytes"}, nil, errValueTooLarge},
+		{"C801", calls{"List"}, nil, errValueTooLarge},
 
 		// Test for list element size check overflow.
-		{"CD04040404FFFFFFFFFFFFFFFFFF0303", calls{"List", "Uint", "Uint", "Uint", "Uint", "List"}, nil, ErrElemTooLarge},
+		{"CD04040404FFFFFFFFFFFFFFFFFF0303", calls{"List", "Uint", "Uint", "Uint", "Uint", "List"}, nil, errElemTooLarge},
 
 		// Test for input limit overflow. Since we are counting the limit
 		// down toward zero in Stream.remaining, reading too far can overflow
 		// remaining to a large value, effectively disabling the limit.
 		{"C40102030401", calls{"Raw", "Uint"}, withCustomInputLimit(5), io.EOF},
-		{"C4010203048180", calls{"Raw", "Uint"}, withCustomInputLimit(6), ErrValueTooLarge},
+		{"C4010203048180", calls{"Raw", "Uint"}, withCustomInputLimit(6), errValueTooLarge},
 
 		// Check that the same calls are fine without a limit.
 		{"C40102030401", calls{"Raw", "Uint"}, withoutInputLimit, nil},

--- a/rlp/decode_test.go
+++ b/rlp/decode_test.go
@@ -247,8 +247,8 @@ func TestStreamList(t *testing.T) {
 		}
 	}
 
-	if _, err := s.Uint(); err != EOL {
-		t.Errorf("Uint error mismatch, got %v, want %v", err, EOL)
+	if _, err := s.Uint(); err != errEol {
+		t.Errorf("Uint error mismatch, got %v, want %v", err, errEol)
 	}
 	if err = s.ListEnd(); err != nil {
 		t.Fatalf("ListEnd error: %v", err)

--- a/rlp/decode_test.go
+++ b/rlp/decode_test.go
@@ -105,9 +105,9 @@ func TestStreamErrors(t *testing.T) {
 		{"89000000000000000001", calls{"Uint"}, nil, errUintOverflow},
 		{"00", calls{"List"}, nil, errExpectedList},
 		{"80", calls{"List"}, nil, errExpectedList},
-		{"C0", calls{"List", "Uint"}, nil, EOL},
+		{"C0", calls{"List", "Uint"}, nil, errEol},
 		{"C8C9010101010101010101", calls{"List", "Kind"}, nil, errElemTooLarge},
-		{"C3C2010201", calls{"List", "List", "Uint", "Uint", "ListEnd", "Uint"}, nil, EOL},
+		{"C3C2010201", calls{"List", "List", "Uint", "Uint", "ListEnd", "Uint"}, nil, errEol},
 		{"00", calls{"ListEnd"}, nil, errNotInList},
 		{"C401020304", calls{"List", "Uint", "ListEnd"}, nil, errNotAtEOL},
 
@@ -190,7 +190,7 @@ func TestStreamErrors(t *testing.T) {
 
 			"Bytes", // past final element
 			"Bytes", // this one should fail
-		}, nil, EOL},
+		}, nil, errEol},
 	}
 
 testfor:

--- a/rlp/decode_test.go
+++ b/rlp/decode_test.go
@@ -51,7 +51,7 @@ func TestStreamKind(t *testing.T) {
 	for i, test := range tests {
 		// using plainReader to inhibit input limit errors.
 		s := NewStream(newPlainReader(unhex(test.input)), 0)
-		kind, len, err := s.Kind()
+		kind, length, err := s.Kind()
 		if err != nil {
 			t.Errorf("test %d: Kind returned error: %v", i, err)
 			continue
@@ -59,8 +59,8 @@ func TestStreamKind(t *testing.T) {
 		if kind != test.wantKind {
 			t.Errorf("test %d: kind mismatch: got %d, want %d", i, kind, test.wantKind)
 		}
-		if len != test.wantLen {
-			t.Errorf("test %d: len mismatch: got %d, want %d", i, len, test.wantLen)
+		if length != test.wantLen {
+			t.Errorf("test %d: length mismatch: got %d, want %d", i, length, test.wantLen)
 		}
 	}
 }
@@ -229,12 +229,12 @@ testfor:
 func TestStreamList(t *testing.T) {
 	s := NewStream(bytes.NewReader(unhex("C80102030405060708")), 0)
 
-	len, err := s.List()
+	length, err := s.List()
 	if err != nil {
 		t.Fatalf("List error: %v", err)
 	}
-	if len != 8 {
-		t.Fatalf("List returned invalid length, got %d, want 8", len)
+	if length != 8 {
+		t.Fatalf("List returned invalid length, got %d, want 8", length)
 	}
 
 	for i := uint64(1); i <= 8; i++ {

--- a/rlp/encode.go
+++ b/rlp/encode.go
@@ -191,7 +191,6 @@ func (w *encbuf) encodeStringHeader(size int) {
 	if size < 56 {
 		w.str = append(w.str, 0x80+byte(size))
 	} else {
-		// TODO: encode to w.str directly
 		sizesize := putint(w.sizebuf[1:], uint64(size))
 		w.sizebuf[0] = 0xB7 + byte(sizesize)
 		w.str = append(w.str, w.sizebuf[:sizesize+1]...)
@@ -395,7 +394,6 @@ func writeUint(val reflect.Value, w *encbuf) error {
 		// fits single byte
 		w.str = append(w.str, byte(i))
 	} else {
-		// TODO: encode int to w.str directly
 		s := putint(w.sizebuf[1:], i)
 		w.sizebuf[0] = 0x80 + byte(s)
 		w.str = append(w.str, w.sizebuf[:s+1]...)

--- a/rlp/encode.go
+++ b/rlp/encode.go
@@ -27,8 +27,8 @@ import (
 var (
 	// Common encoded values.
 	// These are useful when implementing EncodeRLP.
-	EmptyString = []byte{0x80}
-	EmptyList   = []byte{0xC0}
+	emptyString = []byte{0x80}
+	emptyList   = []byte{0xC0}
 )
 
 // Encoder is implemented by types that require custom

--- a/rlp/encode.go
+++ b/rlp/encode.go
@@ -24,13 +24,6 @@ import (
 	"sync"
 )
 
-var (
-	// Common encoded values.
-	// These are useful when implementing EncodeRLP.
-	emptyString = []byte{0x80}
-	emptyList   = []byte{0xC0}
-)
-
 // Encoder is implemented by types that require custom
 // encoding rules or want to encode private fields.
 type Encoder interface {
@@ -444,9 +437,9 @@ func writeByteArray(val reflect.Value, w *encbuf) error {
 	if !val.CanAddr() {
 		// Slice requires the value to be addressable.
 		// Make it addressable by copying.
-		copy := reflect.New(val.Type()).Elem()
-		copy.Set(val)
-		val = copy
+		dupe := reflect.New(val.Type()).Elem()
+		dupe.Set(val)
+		val = dupe
 	}
 	size := val.Len()
 	slice := val.Slice(0, size).Bytes()

--- a/rlp/encode_test.go
+++ b/rlp/encode_test.go
@@ -45,6 +45,7 @@ func (e *testEncoder) EncodeRLP(w io.Writer) error {
 type byteEncoder byte
 
 func (e byteEncoder) EncodeRLP(w io.Writer) error {
+	var emptyList = []byte{0xC0}
 	w.Write(emptyList)
 	return nil
 }

--- a/rlp/encode_test.go
+++ b/rlp/encode_test.go
@@ -45,7 +45,7 @@ func (e *testEncoder) EncodeRLP(w io.Writer) error {
 type byteEncoder byte
 
 func (e byteEncoder) EncodeRLP(w io.Writer) error {
-	w.Write(EmptyList)
+	w.Write(emptyList)
 	return nil
 }
 

--- a/rlp/raw.go
+++ b/rlp/raw.go
@@ -28,12 +28,6 @@ type RawValue []byte
 
 var rawValueType = reflect.TypeOf(RawValue{})
 
-// ListSize returns the encoded size of an RLP list with the given
-// content size.
-func ListSize(contentSize uint64) uint64 {
-	return uint64(headsize(contentSize)) + contentSize
-}
-
 // Split returns the content of first RLP value and any
 // bytes after the value as subslices of b.
 func Split(b []byte) (k Kind, content, rest []byte, err error) {

--- a/rlp/raw.go
+++ b/rlp/raw.go
@@ -52,7 +52,7 @@ func SplitString(b []byte) (content, rest []byte, err error) {
 		return nil, b, err
 	}
 	if k == List {
-		return nil, b, ErrExpectedString
+		return nil, b, errExpectedString
 	}
 	return content, rest, nil
 }
@@ -65,7 +65,7 @@ func SplitList(b []byte) (content, rest []byte, err error) {
 		return nil, b, err
 	}
 	if k != List {
-		return nil, b, ErrExpectedList
+		return nil, b, errExpectedList
 	}
 	return content, rest, nil
 }
@@ -99,7 +99,7 @@ func readKind(buf []byte) (k Kind, tagsize, contentsize uint64, err error) {
 		contentsize = uint64(b - 0x80)
 		// Reject strings that should've been single bytes.
 		if contentsize == 1 && len(buf) > 1 && buf[1] < 128 {
-			return 0, 0, 0, ErrCanonSize
+			return 0, 0, 0, errCanonSize
 		}
 	case b < 0xC0:
 		k = String
@@ -119,7 +119,7 @@ func readKind(buf []byte) (k Kind, tagsize, contentsize uint64, err error) {
 	}
 	// Reject values larger than the input slice.
 	if contentsize > uint64(len(buf))-tagsize {
-		return 0, 0, 0, ErrValueTooLarge
+		return 0, 0, 0, errValueTooLarge
 	}
 	return k, tagsize, contentsize, err
 }
@@ -150,7 +150,7 @@ func readSize(b []byte, slen byte) (uint64, error) {
 	// Reject sizes < 56 (shouldn't have separate size) and sizes with
 	// leading zero bytes.
 	if s < 56 || b[0] == 0 {
-		return 0, ErrCanonSize
+		return 0, errCanonSize
 	}
 	return s, nil
 }

--- a/rlp/raw_test.go
+++ b/rlp/raw_test.go
@@ -39,9 +39,9 @@ func TestCountValues(t *testing.T) {
 		{"820101 820202 8403030303 04", 4, nil},
 
 		// size errors
-		{"8142", 0, ErrCanonSize},
-		{"01 01 8142", 0, ErrCanonSize},
-		{"02 84020202", 0, ErrValueTooLarge},
+		{"8142", 0, errCanonSize},
+		{"01 01 8142", 0, errCanonSize},
+		{"02 84020202", 0, errValueTooLarge},
 
 		{
 			input: "A12000BF49F440A1CD0527E4D06E2765654C0F56452257516D793A9B8D604DCFDF2AB853F851808D10000000000000000000000000A056E81F171BCC55A6FF8345E692C0F86E5B48E01B996CADC001622FB5E363B421A0C5D2460186F7233C927E7DB2DCC703C0E500B653CA82273B7BFAD8045D85A470",
@@ -60,14 +60,14 @@ func TestCountValues(t *testing.T) {
 }
 
 func TestSplitTypes(t *testing.T) {
-	if _, _, err := SplitString(unhex("C100")); err != ErrExpectedString {
-		t.Errorf("SplitString returned %q, want %q", err, ErrExpectedString)
+	if _, _, err := SplitString(unhex("C100")); err != errExpectedString {
+		t.Errorf("SplitString returned %q, want %q", err, errExpectedString)
 	}
-	if _, _, err := SplitList(unhex("01")); err != ErrExpectedList {
-		t.Errorf("SplitString returned %q, want %q", err, ErrExpectedList)
+	if _, _, err := SplitList(unhex("01")); err != errExpectedList {
+		t.Errorf("SplitString returned %q, want %q", err, errExpectedList)
 	}
-	if _, _, err := SplitList(unhex("81FF")); err != ErrExpectedList {
-		t.Errorf("SplitString returned %q, want %q", err, ErrExpectedList)
+	if _, _, err := SplitList(unhex("81FF")); err != errExpectedList {
+		t.Errorf("SplitString returned %q, want %q", err, errExpectedList)
 	}
 }
 
@@ -85,33 +85,33 @@ func TestSplit(t *testing.T) {
 		// errors
 		{input: "", err: io.ErrUnexpectedEOF},
 
-		{input: "8141", err: ErrCanonSize, rest: "8141"},
-		{input: "B800", err: ErrCanonSize, rest: "B800"},
-		{input: "B802FFFF", err: ErrCanonSize, rest: "B802FFFF"},
-		{input: "B90000", err: ErrCanonSize, rest: "B90000"},
-		{input: "B90055", err: ErrCanonSize, rest: "B90055"},
-		{input: "BA0002FFFF", err: ErrCanonSize, rest: "BA0002FFFF"},
-		{input: "F800", err: ErrCanonSize, rest: "F800"},
-		{input: "F90000", err: ErrCanonSize, rest: "F90000"},
-		{input: "F90055", err: ErrCanonSize, rest: "F90055"},
-		{input: "FA0002FFFF", err: ErrCanonSize, rest: "FA0002FFFF"},
+		{input: "8141", err: errCanonSize, rest: "8141"},
+		{input: "B800", err: errCanonSize, rest: "B800"},
+		{input: "B802FFFF", err: errCanonSize, rest: "B802FFFF"},
+		{input: "B90000", err: errCanonSize, rest: "B90000"},
+		{input: "B90055", err: errCanonSize, rest: "B90055"},
+		{input: "BA0002FFFF", err: errCanonSize, rest: "BA0002FFFF"},
+		{input: "F800", err: errCanonSize, rest: "F800"},
+		{input: "F90000", err: errCanonSize, rest: "F90000"},
+		{input: "F90055", err: errCanonSize, rest: "F90055"},
+		{input: "FA0002FFFF", err: errCanonSize, rest: "FA0002FFFF"},
 
-		{input: "81", err: ErrValueTooLarge, rest: "81"},
-		{input: "8501010101", err: ErrValueTooLarge, rest: "8501010101"},
-		{input: "C60607080902", err: ErrValueTooLarge, rest: "C60607080902"},
+		{input: "81", err: errValueTooLarge, rest: "81"},
+		{input: "8501010101", err: errValueTooLarge, rest: "8501010101"},
+		{input: "C60607080902", err: errValueTooLarge, rest: "C60607080902"},
 
 		// size check overflow
-		{input: "BFFFFFFFFFFFFFFFFF", err: ErrValueTooLarge, rest: "BFFFFFFFFFFFFFFFFF"},
-		{input: "FFFFFFFFFFFFFFFFFF", err: ErrValueTooLarge, rest: "FFFFFFFFFFFFFFFFFF"},
+		{input: "BFFFFFFFFFFFFFFFFF", err: errValueTooLarge, rest: "BFFFFFFFFFFFFFFFFF"},
+		{input: "FFFFFFFFFFFFFFFFFF", err: errValueTooLarge, rest: "FFFFFFFFFFFFFFFFFF"},
 
 		{
 			input: "B838FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
-			err:   ErrValueTooLarge,
+			err:   errValueTooLarge,
 			rest:  "B838FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
 		},
 		{
 			input: "F838FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
-			err:   ErrValueTooLarge,
+			err:   errValueTooLarge,
 			rest:  "F838FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
 		},
 
@@ -162,9 +162,9 @@ func TestReadSize(t *testing.T) {
 	}{
 		{input: "", slen: 1, err: io.ErrUnexpectedEOF},
 		{input: "FF", slen: 2, err: io.ErrUnexpectedEOF},
-		{input: "00", slen: 1, err: ErrCanonSize},
-		{input: "36", slen: 1, err: ErrCanonSize},
-		{input: "37", slen: 1, err: ErrCanonSize},
+		{input: "00", slen: 1, err: errCanonSize},
+		{input: "36", slen: 1, err: errCanonSize},
+		{input: "37", slen: 1, err: errCanonSize},
 		{input: "38", slen: 1, size: 0x38},
 		{input: "FF", slen: 1, size: 0xFF},
 		{input: "FFFF", slen: 2, size: 0xFFFF},


### PR DESCRIPTION
## Motivation
Ran linter and cleaned up issues in `rlp/*.go` per #1840 

- [X] `golint`
- [X] code analysis using goland
- [X] removed TODOs (#1945, #1946)
- [X] `govet`
- [ ] godoc (#1947)

## Changes
Just cosmetic changes: changed variable names to lowercase to prevent export and golint error when their usage is already clear/self-documented
