### PR TITLE
[Merged by Bors] - Change the way underlying errors are displayed

### DIFF
--- a/log/zap.go
+++ b/log/zap.go
@@ -127,7 +127,7 @@ func NodeId(val string) Field {
 
 // Err returns an error field
 func Err(v error) Field {
-	return Field(zap.Error(v))
+	return Field(zap.NamedError("message", v))
 }
 
 type LoggableField interface {


### PR DESCRIPTION
Don't use the word "error" per #1570. This makes it harder to search logs. Just report the underlying error as a "message."

## Motivation
We don't need to report an "error" surfaced inside e.g. a WARN or INFO line as an "error." Makes searching logs for real errors easier.
