### PR TITLE
[Merged by Bors] - Clean up log output

### DIFF
--- a/activation/activation.go
+++ b/activation/activation.go
@@ -191,7 +191,6 @@ func (b *Builder) loop() {
 			if _, stopRequested := err.(StopRequestedError); stopRequested {
 				return
 			}
-			b.log.With().Error("failed to publish ATX", log.Err(err))
 			events.Publish(events.AtxCreated{Created: false, Layer: uint64(b.currentEpoch())})
 			<-b.layerClock.AwaitLayer(b.layerClock.GetCurrentLayer() + 1)
 		}
@@ -441,6 +440,7 @@ func (b *Builder) PublishActivationTx() error {
 	defer b.db.UnsubscribeAtx(atx.ID())
 	size, err := b.signAndBroadcast(atx)
 	if err != nil {
+		b.log.With().Error("failed to publish atx", append(atx.Fields(b.layersPerEpoch, size), log.Err(err))...)
 		return err
 	}
 

--- a/activation/activation.go
+++ b/activation/activation.go
@@ -444,24 +444,7 @@ func (b *Builder) PublishActivationTx() error {
 		return err
 	}
 
-	commitStr := "nil"
-	if commitment != nil {
-		commitStr = commitment.String()
-	}
-	b.log.Event().Info("atx published!",
-		log.AtxID(atx.ShortString()),
-		log.String("prev_atx_id", atx.PrevATXID.ShortString()),
-		log.String("pos_atx_id", atx.PositioningATX.ShortString()),
-		log.LayerID(uint64(atx.PubLayerID)),
-		log.EpochID(uint64(atx.PubLayerID.GetEpoch(b.layersPerEpoch))),
-		log.Uint32("active_set", atx.ActiveSetSize),
-		log.String("miner", b.nodeID.ShortString()),
-		log.Int("viewlen", len(atx.View)),
-		log.Uint64("sequence_number", atx.Sequence),
-		log.String("NIPSTChallenge", hash.String()),
-		log.String("commitment", commitStr),
-		log.Int("atx_size", size),
-	)
+	b.log.Event().Info("atx published!", atx.Fields(b.layersPerEpoch, size)...)
 	events.Publish(events.AtxCreated{Created: true, ID: atx.ShortString(), Layer: uint64(b.currentEpoch())})
 
 	select {

--- a/activation/activation.go
+++ b/activation/activation.go
@@ -456,7 +456,7 @@ func (b *Builder) PublishActivationTx() error {
 		log.EpochID(uint64(atx.PubLayerID.GetEpoch(b.layersPerEpoch))),
 		log.Uint32("active_set", atx.ActiveSetSize),
 		log.String("miner", b.nodeID.ShortString()),
-		log.Int("view", len(atx.View)),
+		log.Int("viewlen", len(atx.View)),
 		log.Uint64("sequence_number", atx.Sequence),
 		log.String("NIPSTChallenge", hash.String()),
 		log.String("commitment", commitStr),

--- a/activation/atxdb.go
+++ b/activation/atxdb.go
@@ -246,7 +246,9 @@ func (db *DB) CalcActiveSetSize(epoch types.EpochID, blocks map[types.BlockID]st
 	if err != nil {
 		return nil, err
 	}
-	db.log.With().Info("done calculating active set size", log.String("duration", time.Now().Sub(startTime).String()))
+	db.log.With().Info("done calculating active set size",
+		log.Int("size", len(countedAtxs)),
+		log.String("duration", time.Now().Sub(startTime).String()))
 
 	result := make(map[string]struct{}, len(countedAtxs))
 	for k := range countedAtxs {

--- a/activation/nipst.go
+++ b/activation/nipst.go
@@ -223,10 +223,8 @@ func (nb *NIPSTBuilder) BuildNIPST(challenge *types.Hash32, atxExpired, stop cha
 			return nil, fmt.Errorf("failed to execute PoST: %v", err)
 		}
 
-		b, _ := types.InterfaceToBytes(proof)
 		nb.log.With().Info("finished PoST execution",
 			log.String("proof_merkle_root", fmt.Sprintf("%x", proof.MerkleRoot)),
-			log.Int("post_size", len(b)),
 			log.String("duration", time.Now().Sub(startTime).String()))
 
 		nipst.PostProof = proof

--- a/activation/nipst.go
+++ b/activation/nipst.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/post/config"
 	"github.com/spacemeshos/post/shared"
+	"time"
 )
 
 // PostProverClient provides proving functionality for PoST.
@@ -214,18 +215,19 @@ func (nb *NIPSTBuilder) BuildNIPST(challenge *types.Hash32, atxExpired, stop cha
 
 	// Phase 2: PoST execution.
 	if nipst.PostProof == nil {
-		nb.log.Info("starting PoST execution (challenge: %x)", nb.state.PoetProofRef)
-
+		nb.log.With().Info("starting PoST execution",
+			log.String("challenge", fmt.Sprintf("%x", nb.state.PoetProofRef)))
+		startTime := time.Now()
 		proof, err := nb.postProver.Execute(nb.state.PoetProofRef)
 		if err != nil {
 			return nil, fmt.Errorf("failed to execute PoST: %v", err)
 		}
 
-		//todo remove (#1923)
-		//this is just for debugging
 		b, _ := types.InterfaceToBytes(proof)
 		nb.log.With().Info("finished PoST execution",
-			log.String("proof merkle root", fmt.Sprintf("%x", proof.MerkleRoot)), log.Int("post_size", len(b)))
+			log.String("proof_merkle_root", fmt.Sprintf("%x", proof.MerkleRoot)),
+			log.Int("post_size", len(b)),
+			log.String("duration", time.Now().Sub(startTime).String()))
 
 		nipst.PostProof = proof
 		nb.persist()

--- a/cmd/base.go
+++ b/cmd/base.go
@@ -92,7 +92,7 @@ func parseConfig() (*bc.Config, error) {
 	vip := viper.New()
 	// read in default config if passed as param using viper
 	if err := bc.LoadConfig(fileLocation, vip); err != nil {
-		log.Error(fmt.Sprintf("couldn't load config file at location: %s swithing to defaults \n error: %v.",
+		log.Error(fmt.Sprintf("couldn't load config file at location: %s switching to defaults \n error: %v.",
 			fileLocation, err))
 		// return err
 	}

--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -549,7 +549,7 @@ func (app *SpacemeshApp) initServices(nodeID types.NodeID,
 	ha := app.HareFactory(mdb, swarm, sgn, nodeID, syncer, msh, hOracle, idStore, clock, lg)
 
 	stateAndMeshProjector := pendingtxs.NewStateAndMeshProjector(processor, msh)
-	blockProducer := miner.NewBlockBuilder(nodeID, sgn, swarm, clock.Subscribe(), app.Config.Hdist, app.txPool, atxpool, coinToss, msh, ha, blockOracle, processor, atxdb, syncer, app.Config.AtxsPerBlock, stateAndMeshProjector, app.addLogger(BlockBuilderLogger, lg))
+	blockProducer := miner.NewBlockBuilder(nodeID, sgn, swarm, clock.Subscribe(), app.Config.Hdist, app.txPool, atxpool, coinToss, msh, ha, blockOracle, processor, atxdb, syncer, app.Config.AtxsPerBlock, layersPerEpoch, stateAndMeshProjector, app.addLogger(BlockBuilderLogger, lg))
 	blockListener := sync.NewBlockListener(swarm, syncer, 4, app.addLogger(BlockListenerLogger, lg))
 
 	msh.SetBlockBuilder(blockProducer)

--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -175,7 +175,7 @@ func LoadConfigFromFile() (*cfg.Config, error) {
 	vip := viper.New()
 	// read in default config if passed as param using viper
 	if err := cfg.LoadConfig(fileLocation, vip); err != nil {
-		log.Error(fmt.Sprintf("couldn't load config file at location: %s swithing to defaults \n error: %v.",
+		log.Error(fmt.Sprintf("couldn't load config file at location: %s switching to defaults \n error: %v.",
 			fileLocation, err))
 		// return err
 	}

--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -524,8 +524,8 @@ func (app *SpacemeshApp) initServices(nodeID types.NodeID,
 		Hdist:           app.Config.Hdist,
 		AtxsLimit:       app.Config.AtxsPerBlock}
 
-	if app.Config.AtxsPerBlock > types.AtxsPerBlockLimit { // validate limit
-		app.log.Panic("Number of atxs per block required is bigger than the limit atxsPerBlock=%v limit=%v", app.Config.AtxsPerBlock, types.AtxsPerBlockLimit)
+	if app.Config.AtxsPerBlock > miner.AtxsPerBlockLimit { // validate limit
+		app.log.Panic("Number of atxs per block required is bigger than the limit atxsPerBlock=%v limit=%v", app.Config.AtxsPerBlock, miner.AtxsPerBlockLimit)
 	}
 
 	// we can't have an epoch offset which is greater/equal than the number of layers in an epoch

--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -524,8 +524,8 @@ func (app *SpacemeshApp) initServices(nodeID types.NodeID,
 		Hdist:           app.Config.Hdist,
 		AtxsLimit:       app.Config.AtxsPerBlock}
 
-	if app.Config.AtxsPerBlock > miner.AtxsPerBlockLimit { // validate limit
-		app.log.Panic("Number of atxs per block required is bigger than the limit atxsPerBlock=%v limit=%v", app.Config.AtxsPerBlock, miner.AtxsPerBlockLimit)
+	if app.Config.AtxsPerBlock > types.AtxsPerBlockLimit { // validate limit
+		app.log.Panic("Number of atxs per block required is bigger than the limit atxsPerBlock=%v limit=%v", app.Config.AtxsPerBlock, types.AtxsPerBlockLimit)
 	}
 
 	// we can't have an epoch offset which is greater/equal than the number of layers in an epoch

--- a/common/types/activation.go
+++ b/common/types/activation.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spacemeshos/poet/shared"
 	"github.com/spacemeshos/post/proving"
 	"github.com/spacemeshos/sha256-simd"
+	"strings"
 )
 
 // EpochID is the running epoch number. It's zero-based, so the genesis epoch has EpochID == 0.
@@ -205,14 +206,11 @@ func (atx *ActivationTx) Fields(layersPerEpoch uint16, size int) []log.LoggableF
 
 // AtxIdsField returns a list of loggable fields for a given list of ATXIDs
 func AtxIdsField(ids []ATXID) log.Field {
-	str := ""
-	for i, a := range ids {
-		str += a.ShortString()
-		if i < len(ids)-1 {
-			str += ", "
-		}
+	strs := []string{}
+	for _, a := range ids {
+		strs = append(strs, a.ShortString())
 	}
-	return log.String("atx_ids", str)
+	return log.String("atx_ids", strings.Join(strs, ", "))
 }
 
 // CalcAndSetID calculates and sets the cached ID field. This field must be set before calling the ID() method.

--- a/common/types/activation.go
+++ b/common/types/activation.go
@@ -33,7 +33,7 @@ func (l EpochID) Field() log.Field { return log.Uint64("epoch_id", uint64(l)) }
 // ATXID is a 32-bit hash used to identify an activation transaction.
 type ATXID Hash32
 
-// ShortString returns the first 5 characters of the ID, for logging purposes.
+// ShortString returns the first few characters of the ID, for logging purposes.
 func (t ATXID) ShortString() string {
 	return t.Hash32().MediumString()
 }

--- a/common/types/activation.go
+++ b/common/types/activation.go
@@ -176,7 +176,7 @@ func (atx *ActivationTx) InnerBytes() ([]byte, error) {
 
 // Fields returns an array of LoggableFields for logging
 func (atx *ActivationTx) Fields(layersPerEpoch uint16, size int) []log.LoggableField {
-	commitmentStr := "nil"
+	commitmentStr := ""
 	if atx.Commitment != nil {
 		commitmentStr = atx.Commitment.String()
 	}

--- a/common/types/activation.go
+++ b/common/types/activation.go
@@ -173,6 +173,11 @@ func (atx *ActivationTx) InnerBytes() ([]byte, error) {
 	return InterfaceToBytes(atx.InnerActivationTx)
 }
 
+// Fields returns an array of LoggableFields for logging
+func (atx *ActivationTx) Fields() []log.LoggableField {
+	return []log.LoggableField{log.String("hello", "hello"), log.String("world", "world")}
+}
+
 // CalcAndSetID calculates and sets the cached ID field. This field must be set before calling the ID() method.
 func (atx *ActivationTx) CalcAndSetID() {
 	id := ATXID(CalcATXHash32(atx))

--- a/common/types/activation.go
+++ b/common/types/activation.go
@@ -32,9 +32,9 @@ func (l EpochID) Field() log.Field { return log.Uint64("epoch_id", uint64(l)) }
 // ATXID is a 32-bit hash used to identify an activation transaction.
 type ATXID Hash32
 
-// ShortString returns a the first 5 characters of the ID, for logging purposes.
+// ShortString returns the first 5 characters of the ID, for logging purposes.
 func (t ATXID) ShortString() string {
-	return t.Hash32().ShortString()
+	return t.Hash32().MediumString()
 }
 
 // Hash32 returns the ATXID as a Hash32.
@@ -62,7 +62,7 @@ type ActivationTxHeader struct {
 	ActiveSetSize uint32
 }
 
-// ShortString returns a the first 5 characters of the ID, for logging purposes.
+// ShortString returns the first 5 characters of the ID, for logging purposes.
 func (atxh *ActivationTxHeader) ShortString() string {
 	return atxh.ID().ShortString()
 }

--- a/common/types/activation.go
+++ b/common/types/activation.go
@@ -174,8 +174,33 @@ func (atx *ActivationTx) InnerBytes() ([]byte, error) {
 }
 
 // Fields returns an array of LoggableFields for logging
-func (atx *ActivationTx) Fields() []log.LoggableField {
-	return []log.LoggableField{log.String("hello", "hello"), log.String("world", "world")}
+func (atx *ActivationTx) Fields(layersPerEpoch uint16, size int) []log.LoggableField {
+	commitmentStr := "nil"
+	if atx.Commitment != nil {
+		commitmentStr = atx.Commitment.String()
+	}
+
+	challenge := ""
+	h, err := atx.NIPSTChallenge.Hash()
+	if err == nil && h != nil {
+		challenge = h.String()
+
+	}
+
+	return []log.LoggableField{
+		log.AtxID(atx.ShortString()),
+		log.String("sender_id", atx.NodeID.ShortString()),
+		log.String("prev_atx_id", atx.PrevATXID.ShortString()),
+		log.String("pos_atx_id", atx.PositioningATX.ShortString()),
+		log.LayerID(uint64(atx.PubLayerID)),
+		log.EpochID(uint64(atx.PubLayerID.GetEpoch(layersPerEpoch))),
+		log.Uint32("active_set", atx.ActiveSetSize),
+		log.Int("viewlen", len(atx.View)),
+		log.Uint64("sequence_number", atx.Sequence),
+		log.String("NIPSTChallenge", challenge),
+		log.String("commitment", commitmentStr),
+		log.Int("atx_size", size),
+	}
 }
 
 // CalcAndSetID calculates and sets the cached ID field. This field must be set before calling the ID() method.

--- a/common/types/activation.go
+++ b/common/types/activation.go
@@ -189,12 +189,12 @@ func (atx *ActivationTx) Fields(layersPerEpoch uint16, size int) []log.LoggableF
 	}
 
 	return []log.LoggableField{
-		log.AtxID(atx.ShortString()),
+		atx.ID(),
 		log.String("sender_id", atx.NodeID.ShortString()),
 		log.String("prev_atx_id", atx.PrevATXID.ShortString()),
 		log.String("pos_atx_id", atx.PositioningATX.ShortString()),
-		log.LayerID(uint64(atx.PubLayerID)),
-		log.EpochID(uint64(atx.PubLayerID.GetEpoch(layersPerEpoch))),
+		atx.PubLayerID,
+		atx.PubLayerID.GetEpoch(layersPerEpoch),
 		log.Uint32("active_set", atx.ActiveSetSize),
 		log.Int("viewlen", len(atx.View)),
 		log.Uint64("sequence_number", atx.Sequence),

--- a/common/types/activation.go
+++ b/common/types/activation.go
@@ -203,6 +203,18 @@ func (atx *ActivationTx) Fields(layersPerEpoch uint16, size int) []log.LoggableF
 	}
 }
 
+// AtxIdsField returns a list of loggable fields for a given list of ATXIDs
+func AtxIdsField(ids []ATXID) log.Field {
+	str := ""
+	for i, a := range ids {
+		str += a.ShortString()
+		if i < len(ids)-1 {
+			str += ", "
+		}
+	}
+	return log.String("atx_ids", str)
+}
+
 // CalcAndSetID calculates and sets the cached ID field. This field must be set before calling the ID() method.
 func (atx *ActivationTx) CalcAndSetID() {
 	id := ATXID(CalcATXHash32(atx))

--- a/common/types/activation.go
+++ b/common/types/activation.go
@@ -185,7 +185,6 @@ func (atx *ActivationTx) Fields(layersPerEpoch uint16, size int) []log.LoggableF
 	h, err := atx.NIPSTChallenge.Hash()
 	if err == nil && h != nil {
 		challenge = h.String()
-
 	}
 
 	return []log.LoggableField{

--- a/common/types/activation.go
+++ b/common/types/activation.go
@@ -35,7 +35,7 @@ type ATXID Hash32
 
 // ShortString returns the first few characters of the ID, for logging purposes.
 func (t ATXID) ShortString() string {
-	return t.Hash32().MediumString()
+	return t.Hash32().ShortString()
 }
 
 // Hash32 returns the ATXID as a Hash32.

--- a/common/types/block.go
+++ b/common/types/block.go
@@ -11,9 +11,6 @@ import (
 	"sort"
 )
 
-// AtxsPerBlockLimit indicates the maximum number of atxs a block can reference
-const AtxsPerBlockLimit = 100
-
 // BlockID is a 20-byte sha256 sum of the serialized block, used to identify it.
 type BlockID Hash20
 

--- a/common/types/block.go
+++ b/common/types/block.go
@@ -149,6 +149,17 @@ func (b *Block) Bytes() []byte {
 	return blkBytes
 }
 
+// Fields returns an array of LoggableFields for logging
+func (b *Block) Fields() []log.LoggableField {
+	return []log.LoggableField{
+		log.BlockID(b.ID().String()),
+		log.LayerID(uint64(b.LayerIndex)),
+		log.Int("tx_count", len(b.TxIDs)),
+		log.Int("atx_count", len(b.ATXIDs)),
+		AtxIdsField(b.ATXIDs),
+	}
+}
+
 // ID returns the BlockID.
 func (b *Block) ID() BlockID {
 	return b.id

--- a/common/types/block.go
+++ b/common/types/block.go
@@ -17,7 +17,7 @@ const AtxsPerBlockLimit = 100
 // BlockID is a 20-byte sha256 sum of the serialized block, used to identify it.
 type BlockID Hash20
 
-// String returns the 5-character prefix of the hex representation of the ID.
+// String returns a short prefix of the hex representation of the ID.
 func (id BlockID) String() string {
 	return id.AsHash32().MediumString()
 }

--- a/common/types/block.go
+++ b/common/types/block.go
@@ -19,7 +19,7 @@ type BlockID Hash20
 
 // String returns a short prefix of the hex representation of the ID.
 func (id BlockID) String() string {
-	return id.AsHash32().MediumString()
+	return id.AsHash32().ShortString()
 }
 
 // Field returns a log field. Implements the LoggableField interface.

--- a/common/types/block.go
+++ b/common/types/block.go
@@ -159,6 +159,10 @@ func (b *Block) Fields() []log.LoggableField {
 	return []log.LoggableField{
 		log.BlockID(b.ID().String()),
 		log.LayerID(uint64(b.LayerIndex)),
+		log.MinerID(b.MinerID().ShortString()),
+		log.Int("view_edges", len(b.ViewEdges)),
+		log.Int("vote_count", len(b.BlockVotes)),
+		log.Uint32("eligibility_counter", b.EligibilityProof.J),
 		log.Int("tx_count", len(b.TxIDs)),
 		log.Int("atx_count", len(b.ATXIDs)),
 		AtxIdsField(b.ATXIDs),

--- a/common/types/block.go
+++ b/common/types/block.go
@@ -81,7 +81,7 @@ func (id NodeID) ToBytes() []byte {
 // ShortString returns a the first 5 characters of the ID, for logging purposes.
 func (id NodeID) ShortString() string {
 	name := id.Key
-	return Stringify(name, 5)
+	return Shorten(name, 5)
 }
 
 // Field returns a log field. Implements the LoggableField interface.

--- a/common/types/block.go
+++ b/common/types/block.go
@@ -157,9 +157,9 @@ func (b *Block) Bytes() []byte {
 // Fields returns an array of LoggableFields for logging
 func (b *Block) Fields() []log.LoggableField {
 	return []log.LoggableField{
-		log.BlockID(b.ID().String()),
-		log.LayerID(uint64(b.LayerIndex)),
-		log.MinerID(b.MinerID().ShortString()),
+		b.ID(),
+		b.LayerIndex,
+		b.MinerID(),
 		log.Int("view_edges", len(b.ViewEdges)),
 		log.Int("vote_count", len(b.BlockVotes)),
 		log.Uint32("eligibility_counter", b.EligibilityProof.J),

--- a/common/types/block.go
+++ b/common/types/block.go
@@ -20,7 +20,9 @@ func (id BlockID) String() string {
 }
 
 // Field returns a log field. Implements the LoggableField interface.
-func (id BlockID) Field() log.Field { return log.String("block_id", id.AsHash32().ShortString()) }
+func (id BlockID) Field() log.LoggableField {
+	return log.String("block_id", id.AsHash32().ShortString())
+}
 
 // Compare returns true if other (the given BlockID) is less than this BlockID, by lexicographic comparison.
 func (id BlockID) Compare(other BlockID) bool {
@@ -51,7 +53,7 @@ func (l LayerID) Uint64() uint64 {
 }
 
 // Field returns a log field. Implements the LoggableField interface.
-func (l LayerID) Field() log.Field { return log.Uint64("layer_id", uint64(l)) }
+func (l LayerID) Field() log.LoggableField { return log.Uint64("layer_id", uint64(l)) }
 
 // NodeID contains a miner's two public keys.
 type NodeID struct {
@@ -80,7 +82,7 @@ func (id NodeID) ShortString() string {
 }
 
 // Field returns a log field. Implements the LoggableField interface.
-func (id NodeID) Field() log.Field { return log.String("node_id", id.Key) }
+func (id NodeID) Field() log.LoggableField { return log.String("node_id", id.Key) }
 
 // BlockEligibilityProof includes the required values that, along with the miner's VRF public key, allow non-interactive
 // block eligibility validation.

--- a/common/types/block.go
+++ b/common/types/block.go
@@ -11,6 +11,9 @@ import (
 	"sort"
 )
 
+// AtxsPerBlockLimit indicates the maximum number of atxs a block can reference
+const AtxsPerBlockLimit = 100
+
 // BlockID is a 20-byte sha256 sum of the serialized block, used to identify it.
 type BlockID Hash20
 

--- a/common/types/block.go
+++ b/common/types/block.go
@@ -16,7 +16,7 @@ type BlockID Hash20
 
 // String returns the 5-character prefix of the hex representation of the ID.
 func (id BlockID) String() string {
-	return id.AsHash32().ShortString()
+	return id.AsHash32().MediumString()
 }
 
 // Field returns a log field. Implements the LoggableField interface.
@@ -76,10 +76,7 @@ func (id NodeID) ToBytes() []byte {
 // ShortString returns a the first 5 characters of the ID, for logging purposes.
 func (id NodeID) ShortString() string {
 	name := id.Key
-	if len(name) > 5 {
-		name = name[:5]
-	}
-	return name
+	return Stringify(name, 5)
 }
 
 // Field returns a log field. Implements the LoggableField interface.

--- a/common/types/block.go
+++ b/common/types/block.go
@@ -23,7 +23,7 @@ func (id BlockID) String() string {
 }
 
 // Field returns a log field. Implements the LoggableField interface.
-func (id BlockID) Field() log.LoggableField {
+func (id BlockID) Field() log.Field {
 	return log.String("block_id", id.AsHash32().ShortString())
 }
 
@@ -56,7 +56,7 @@ func (l LayerID) Uint64() uint64 {
 }
 
 // Field returns a log field. Implements the LoggableField interface.
-func (l LayerID) Field() log.LoggableField { return log.Uint64("layer_id", uint64(l)) }
+func (l LayerID) Field() log.Field { return log.Uint64("layer_id", uint64(l)) }
 
 // NodeID contains a miner's two public keys.
 type NodeID struct {
@@ -85,7 +85,7 @@ func (id NodeID) ShortString() string {
 }
 
 // Field returns a log field. Implements the LoggableField interface.
-func (id NodeID) Field() log.LoggableField { return log.String("node_id", id.Key) }
+func (id NodeID) Field() log.Field { return log.String("node_id", id.Key) }
 
 // BlockEligibilityProof includes the required values that, along with the miner's VRF public key, allow non-interactive
 // block eligibility validation.

--- a/common/types/block_test.go
+++ b/common/types/block_test.go
@@ -1,0 +1,44 @@
+package types
+
+import (
+	"github.com/spacemeshos/go-spacemesh/rand"
+	"testing"
+	"time"
+)
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
+func genByte32() [32]byte {
+	var x [32]byte
+	rand.Read(x[:])
+	return x
+}
+
+var txid1 = TransactionID(genByte32())
+var txid2 = TransactionID(genByte32())
+var txid3 = TransactionID(genByte32())
+
+var one = CalcHash32([]byte("1"))
+var two = CalcHash32([]byte("2"))
+var three = CalcHash32([]byte("3"))
+
+var atx1 = ATXID(one)
+var atx2 = ATXID(two)
+var atx3 = ATXID(three)
+
+// Make sure we can print out all the relevant log fields for a block
+func TestFields(t *testing.T) {
+	b := &Block{}
+	b.TxIDs = []TransactionID{txid1, txid2, txid1}
+	b.ATXIDs = []ATXID{atx1, atx2, atx3}
+
+	for i := 0; i <= AtxsPerBlockLimit; i++ {
+		b.ATXIDs = append(b.ATXIDs, atx1)
+	}
+
+	b.TxIDs = []TransactionID{}
+	b.ATXIDs = []ATXID{}
+	t.Log(b.Fields())
+}

--- a/common/types/block_test.go
+++ b/common/types/block_test.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/rand"
 	"testing"
 	"time"
@@ -33,12 +34,5 @@ func TestFields(t *testing.T) {
 	b := &Block{}
 	b.TxIDs = []TransactionID{txid1, txid2, txid1}
 	b.ATXIDs = []ATXID{atx1, atx2, atx3}
-
-	for i := 0; i <= AtxsPerBlockLimit; i++ {
-		b.ATXIDs = append(b.ATXIDs, atx1)
-	}
-
-	b.TxIDs = []TransactionID{}
-	b.ATXIDs = []ATXID{}
-	t.Log(b.Fields())
+	log.With().Info("got new block", b.Fields()...)
 }

--- a/common/types/hashes.go
+++ b/common/types/hashes.go
@@ -171,10 +171,22 @@ func (h Hash32) String() string {
 	return h.Hex()
 }
 
-// ShortString returns a the first 5 characters of the hash, for logging purposes.
+// MediumString returns the first 10 characters of the hash, for logging purposes.
+func (h Hash32) MediumString() string {
+	l := len(h.Hex())
+	return Stringify(h.Hex()[util.Min(2, l):], 12)
+}
+
+// ShortString returns the first 5 characters of the hash, for logging purposes.
 func (h Hash32) ShortString() string {
 	l := len(h.Hex())
-	return h.Hex()[util.Min(2, l):util.Min(7, l)]
+	return Stringify(h.Hex()[util.Min(2, l):], 5)
+}
+
+// Stringify shortens a string to a specified length
+func Stringify(s string, maxlen int) string {
+	l := len(s)
+	return s[:util.Min(maxlen, l)]
 }
 
 // Format implements fmt.Formatter, forcing the byte slice to be formatted as is,

--- a/common/types/hashes.go
+++ b/common/types/hashes.go
@@ -174,11 +174,11 @@ func (h Hash32) String() string {
 // ShortString returns the first 5 characters of the hash, for logging purposes.
 func (h Hash32) ShortString() string {
 	l := len(h.Hex())
-	return Stringify(h.Hex()[util.Min(2, l):], 10)
+	return Shorten(h.Hex()[util.Min(2, l):], 10)
 }
 
-// Stringify shortens a string to a specified length
-func Stringify(s string, maxlen int) string {
+// Shorten shortens a string to a specified length
+func Shorten(s string, maxlen int) string {
 	l := len(s)
 	return s[:util.Min(maxlen, l)]
 }

--- a/common/types/hashes.go
+++ b/common/types/hashes.go
@@ -171,16 +171,10 @@ func (h Hash32) String() string {
 	return h.Hex()
 }
 
-// MediumString returns the first 10 characters of the hash, for logging purposes.
-func (h Hash32) MediumString() string {
-	l := len(h.Hex())
-	return Stringify(h.Hex()[util.Min(2, l):], 12)
-}
-
 // ShortString returns the first 5 characters of the hash, for logging purposes.
 func (h Hash32) ShortString() string {
 	l := len(h.Hex())
-	return Stringify(h.Hex()[util.Min(2, l):], 5)
+	return Stringify(h.Hex()[util.Min(2, l):], 10)
 }
 
 // Stringify shortens a string to a specified length

--- a/common/types/transaction.go
+++ b/common/types/transaction.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/spacemeshos/ed25519"
 	"github.com/spacemeshos/go-spacemesh/log"
+	"strings"
 )
 
 // TransactionID is a 32-byte sha256 sum of the transaction, used as an identifier.
@@ -14,9 +15,9 @@ func (id TransactionID) Hash32() Hash32 {
 	return Hash32(id)
 }
 
-// ShortString returns a the first 5 characters of the ID, for logging purposes.
+// ShortString returns a the first 10 characters of the ID, for logging purposes.
 func (id TransactionID) ShortString() string {
-	return id.Hash32().ShortString()
+	return id.Hash32().MediumString()
 }
 
 // String returns a hexadecimal representation of the TransactionID with "0x" prepended, for logging purposes.
@@ -32,6 +33,15 @@ func (id TransactionID) Bytes() []byte {
 
 // Field returns a log field. Implements the LoggableField interface.
 func (id TransactionID) Field() log.Field { return id.Hash32().Field("tx_id") }
+
+// TxIdsField returns a list of loggable fields for a given list of IDs
+func TxIdsField(ids []TransactionID) log.Field {
+	strs := []string{}
+	for _, a := range ids {
+		strs = append(strs, a.ShortString())
+	}
+	return log.String("tx_ids", strings.Join(strs, ", "))
+}
 
 // EmptyTransactionID is a canonical empty TransactionID.
 var EmptyTransactionID = TransactionID{}

--- a/common/types/transaction.go
+++ b/common/types/transaction.go
@@ -17,7 +17,7 @@ func (id TransactionID) Hash32() Hash32 {
 
 // ShortString returns a the first 10 characters of the ID, for logging purposes.
 func (id TransactionID) ShortString() string {
-	return id.Hash32().MediumString()
+	return id.Hash32().ShortString()
 }
 
 // String returns a hexadecimal representation of the TransactionID with "0x" prepended, for logging purposes.

--- a/database/database.go
+++ b/database/database.go
@@ -60,7 +60,9 @@ func NewLDBDatabase(file string, cache int, handles int, logger log.Log) (*LDBDa
 	if handles < 16 {
 		handles = 16
 	}
-	logger.Info("Allocated cache and file handles", "cache", cache, "handles", handles)
+	logger.With().Info("Allocated cache and file handles",
+		log.Int("cache_size", cache),
+		log.Int("num_handles", handles))
 
 	// Open the db and recover any potential corruptions
 	db, err := leveldb.OpenFile(file, &opt.Options{

--- a/hare/algorithm.go
+++ b/hare/algorithm.go
@@ -361,14 +361,18 @@ func (proc *consensusProcess) handleMessage(m *Msg) {
 		// early message, keep for later
 		if err == errEarlyMsg {
 			proc.With().Debug("Early message detected, keeping",
-				log.String("msg_type", mType), log.String("sender_id", m.PubKey.ShortString()),
-				log.Int32("current_k", proc.k), log.Int32("msg_k", m.InnerMsg.K),
-				log.LayerID(uint64(proc.instanceID)), log.Err(err))
+				log.String("msg_type", mType),
+				log.String("sender_id", m.PubKey.ShortString()),
+				log.Int32("current_k", proc.k),
+				log.Int32("msg_k", m.InnerMsg.K),
+				log.LayerID(uint64(proc.instanceID)),
+				log.Err(err))
 
 			// validate syntax for early messages
 			if !proc.validator.SyntacticallyValidateMessage(m) {
 				proc.With().Warning("Early message failed syntactic validation",
-					log.String("msg_type", mType), log.String("sender_id", m.PubKey.ShortString()))
+					log.String("msg_type", mType),
+					log.String("sender_id", m.PubKey.ShortString()))
 				return
 			}
 
@@ -378,8 +382,10 @@ func (proc *consensusProcess) handleMessage(m *Msg) {
 
 		// not an early message but also contextually invalid
 		proc.With().Error("Late message failed contextual validation",
-			log.String("msg_type", mType), log.String("sender_id", m.PubKey.ShortString()),
-			log.Int32("current_k", proc.k), log.Int32("msg_k", m.InnerMsg.K),
+			log.String("msg_type", mType),
+			log.String("sender_id", m.PubKey.ShortString()),
+			log.Int32("current_k", proc.k),
+			log.Int32("msg_k", m.InnerMsg.K),
 			log.LayerID(uint64(proc.instanceID)), log.Err(err))
 		return
 	}
@@ -768,7 +774,8 @@ func (proc *consensusProcess) shouldParticipate() bool {
 
 	// should participate
 	proc.With().Info("should participate",
-		log.Int32("round", proc.k), log.Uint64("layer_id", uint64(proc.instanceID)))
+		log.Int32("round", proc.k),
+		log.Uint64("layer_id", uint64(proc.instanceID)))
 	return true
 }
 

--- a/hare/algorithm.go
+++ b/hare/algorithm.go
@@ -749,24 +749,26 @@ func (proc *consensusProcess) shouldParticipate() bool {
 	// query if identity is active
 	res, err := proc.oracle.IsIdentityActiveOnConsensusView(proc.signing.PublicKey().String(), types.LayerID(proc.instanceID))
 	if err != nil {
-		proc.With().Error("Should not participate: error checking our identity for activeness",
+		proc.With().Error("should not participate: error checking our identity for activeness",
 			log.Err(err), log.Uint64("layer_id", uint64(proc.instanceID)))
 		return false
 	}
 
 	if !res {
-		proc.With().Info("Should not participate: identity is not active",
+		proc.With().Info("should not participate: identity is not active",
 			log.Uint64("layer_id", uint64(proc.instanceID)))
 		return false
 	}
 
 	if role := proc.currentRole(); role == passive {
-		proc.With().Info("Should not participate: passive",
+		proc.With().Info("should not participate: passive",
 			log.Int32("round", proc.k), log.Uint64("layer_id", uint64(proc.instanceID)))
 		return false
 	}
 
 	// should participate
+	proc.With().Info("should participate",
+		log.Int32("round", proc.k), log.Uint64("layer_id", uint64(proc.instanceID)))
 	return true
 }
 

--- a/hare/algorithm.go
+++ b/hare/algorithm.go
@@ -360,11 +360,15 @@ func (proc *consensusProcess) handleMessage(m *Msg) {
 
 		// early message, keep for later
 		if err == errEarlyMsg {
-			proc.Debug("Early message of type %v detected. Keeping message, pubkey %v", mType, m.PubKey.ShortString())
+			proc.With().Debug("Early message detected, keeping",
+				log.String("msg_type", mType), log.String("sender_id", m.PubKey.ShortString()),
+				log.Int32("current_k", proc.k), log.Int32("msg_k", m.InnerMsg.K),
+				log.LayerID(uint64(proc.instanceID)), log.Err(err))
 
 			// validate syntax for early messages
 			if !proc.validator.SyntacticallyValidateMessage(m) {
-				proc.Warning("Syntactically validation failed, pubkey %v", m.PubKey.ShortString())
+				proc.With().Warning("Early message failed syntactic validation",
+					log.String("msg_type", mType), log.String("sender_id", m.PubKey.ShortString()))
 				return
 			}
 
@@ -373,7 +377,7 @@ func (proc *consensusProcess) handleMessage(m *Msg) {
 		}
 
 		// not an early message but also contextually invalid
-		proc.With().Error("Error contextually validating message",
+		proc.With().Error("Late message failed contextual validation",
 			log.String("msg_type", mType), log.String("sender_id", m.PubKey.ShortString()),
 			log.Int32("current_k", proc.k), log.Int32("msg_k", m.InnerMsg.K),
 			log.LayerID(uint64(proc.instanceID)), log.Err(err))

--- a/hare/eligibility/oracle.go
+++ b/hare/eligibility/oracle.go
@@ -185,19 +185,20 @@ func (o *Oracle) activeSetSize(layer types.LayerID) (uint32, error) {
 func (o *Oracle) Eligible(layer types.LayerID, round int32, committeeSize int, id types.NodeID, sig []byte) (bool, error) {
 	msg, err := o.buildVRFMessage(layer, round)
 	if err != nil {
-		o.Error("Eligible: could not build VRF message")
+		o.Error("eligibility: could not build VRF message")
 		return false, err
 	}
 
 	// validate message
 	res, err := o.vrfVerifier(msg, sig, id.VRFPublicKey)
 	if err != nil {
-		o.Error("Eligible: VRF verification failed: %v", err)
+		o.Error("eligibility: VRF verification failed: %v", err)
 		return false, err
 	}
 	if !res {
-		o.With().Info("Eligible: a node did not pass VRF signature verification",
-			log.String("id", id.ShortString()), log.Uint64("layer_id", uint64(layer)))
+		o.With().Info("eligibility: a node did not pass VRF signature verification",
+			log.String("id", id.ShortString()),
+			log.Uint64("layer_id", uint64(layer)))
 		return false, nil
 	}
 
@@ -209,7 +210,7 @@ func (o *Oracle) Eligible(layer types.LayerID, round int32, committeeSize int, i
 
 	// require activeSetSize > 0
 	if activeSetSize == 0 {
-		o.Warning("Eligible: active set size is zero")
+		o.Warning("eligibility: active set size is zero")
 		return false, errors.New("active set size is zero")
 	}
 
@@ -218,9 +219,11 @@ func (o *Oracle) Eligible(layer types.LayerID, round int32, committeeSize int, i
 	shaUint32 := binary.LittleEndian.Uint32(sha[:4])
 	// avoid division (no floating point) & do operations on uint64 to avoid overflow
 	if uint64(activeSetSize)*uint64(shaUint32) > uint64(committeeSize)*uint64(math.MaxUint32) {
-		o.With().Info("Eligible: a node did not pass VRF eligibility",
-			log.String("id", id.ShortString()), log.Int("committee_size", committeeSize),
-			log.Uint32("active_set_size", activeSetSize), log.Int32("round", round),
+		o.With().Info("eligibility: node did not pass VRF eligibility threshold",
+			log.String("id", id.ShortString()),
+			log.Int("committee_size", committeeSize),
+			log.Uint32("active_set_size", activeSetSize),
+			log.Int32("round", round),
 			log.Uint64("layer_id", uint64(layer)))
 		return false, nil
 	}

--- a/hare/eligibility/oracle.go
+++ b/hare/eligibility/oracle.go
@@ -197,8 +197,8 @@ func (o *Oracle) Eligible(layer types.LayerID, round int32, committeeSize int, i
 	}
 	if !res {
 		o.With().Info("eligibility: a node did not pass VRF signature verification",
-			log.String("id", id.ShortString()),
-			log.Uint64("layer_id", uint64(layer)))
+			id,
+			layer)
 		return false, nil
 	}
 
@@ -220,11 +220,11 @@ func (o *Oracle) Eligible(layer types.LayerID, round int32, committeeSize int, i
 	// avoid division (no floating point) & do operations on uint64 to avoid overflow
 	if uint64(activeSetSize)*uint64(shaUint32) > uint64(committeeSize)*uint64(math.MaxUint32) {
 		o.With().Info("eligibility: node did not pass VRF eligibility threshold",
-			log.String("id", id.ShortString()),
+			id,
 			log.Int("committee_size", committeeSize),
 			log.Uint32("active_set_size", activeSetSize),
 			log.Int32("round", round),
-			log.Uint64("layer_id", uint64(layer)))
+			layer)
 		return false, nil
 	}
 
@@ -279,8 +279,10 @@ func (o *Oracle) actives(layer types.LayerID) (map[string]struct{}, error) {
 	// no contextually valid blocks
 	if len(mp) == 0 {
 		o.With().Error("Could not calculate hare active set size: no contextually valid blocks",
-			log.Uint64("layer_id", uint64(layer)), log.Uint64("epoch_id", uint64(layer.GetEpoch(o.layersPerEpoch))),
-			log.Uint64("safe_layer_id", uint64(sl)), log.Uint64("safe_epoch_id", uint64(safeEp)))
+			layer,
+			log.Uint64("epoch_id", uint64(layer.GetEpoch(o.layersPerEpoch))),
+			log.Uint64("safe_layer_id", uint64(sl)),
+			log.Uint64("safe_epoch_id", uint64(safeEp)))
 		o.lock.Unlock()
 		return nil, errNoContextualBlocks
 	}

--- a/hare/hare.go
+++ b/hare/hare.go
@@ -252,8 +252,7 @@ func (h *Hare) onTick(id types.LayerID) {
 }
 
 var (
-	// ErrTooOld means the requested result has already been evacuated from the buffer because the layer is too old
-	ErrTooOld   = errors.New("layer has already been evacuated from buffer")
+	errTooOld   = errors.New("layer has already been evacuated from buffer")
 	errNoResult = errors.New("no result for the requested layer")
 )
 
@@ -262,7 +261,7 @@ var (
 func (h *Hare) GetResult(lid types.LayerID) ([]types.BlockID, error) {
 
 	if h.outOfBufferRange(instanceID(lid)) {
-		return nil, ErrTooOld
+		return nil, errTooOld
 	}
 
 	h.mu.RLock()

--- a/hare/hare_test.go
+++ b/hare/hare_test.go
@@ -166,7 +166,7 @@ func TestHare_GetResult2(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 
 	_, err = h.GetResult(0)
-	require.Equal(t, err, ErrTooOld)
+	require.Equal(t, err, errTooOld)
 }
 
 func TestHare_collectOutputCheckValidation(t *testing.T) {

--- a/hare/messagevalidation.go
+++ b/hare/messagevalidation.go
@@ -335,7 +335,7 @@ func (v *syntaxContextValidator) validateAggregatedMessage(aggMsg *aggregatedMes
 
 func (v *syntaxContextValidator) validateSVP(msg *Msg) bool {
 	defer func(startTime time.Time) {
-		v.With().Info("SVP validation duration", log.String("duration", time.Now().Sub(startTime).String()))
+		v.With().Debug("SVP validation duration", log.String("duration", time.Now().Sub(startTime).String()))
 	}(time.Now())
 	proposalIter := iterationFromCounter(msg.InnerMsg.K)
 	validateSameIteration := func(m *Msg) bool {
@@ -385,7 +385,7 @@ func (v *syntaxContextValidator) validateSVP(msg *Msg) bool {
 
 func (v *syntaxContextValidator) validateCertificate(cert *certificate) bool {
 	defer func(startTime time.Time) {
-		v.With().Info("certificate validation duration", log.String("duration", time.Now().Sub(startTime).String()))
+		v.With().Debug("certificate validation duration", log.String("duration", time.Now().Sub(startTime).String()))
 	}(time.Now())
 
 	if cert == nil {

--- a/log/zap.go
+++ b/log/zap.go
@@ -100,47 +100,47 @@ func Duration(name string, val time.Duration) Field {
 	return Field(zap.Duration(name, val))
 }
 
-// LayerID return a Uint64 field (key - "layer_id")
+// LayerID returns a Uint64 field (key - "layer_id")
 func LayerID(val uint64) Field {
 	return Uint64("layer_id", val)
 }
 
-// TxID return a String field (key - "tx_id")
+// TxID returns a String field (key - "tx_id")
 func TxID(val string) Field {
 	return String("tx_id", val)
 }
 
-// AtxID return a String field (key - "atx_id")
+// AtxID returns a String field (key - "atx_id")
 func AtxID(val string) Field {
 	return String("atx_id", val)
 }
 
-// BlockID return a Uint64 field (key - "block_id")
+// BlockID returns a Uint64 field (key - "block_id")
 func BlockID(val string) Field {
 	return String("block_id", val)
 }
 
-// EpochID return a Uint64 field (key - "epoch_id")
+// EpochID returns a Uint64 field (key - "epoch_id")
 func EpochID(val uint64) Field {
 	return Uint64("epoch_id", val)
 }
 
-// NodeID return a String field (key - "node_id")
+// NodeID returns a String field (key - "node_id")
 func NodeID(val string) Field {
 	return String("node_id", val)
 }
 
-// PeerID return a String field (key - "peer_id")
+// PeerID returns a String field (key - "peer_id")
 func PeerID(val string) Field {
 	return String("peer_id", val)
 }
 
-// MinerID return a String field (key - "miner_id")
+// MinerID returns a String field (key - "miner_id")
 func MinerID(val string) Field {
 	return String("miner_id", val)
 }
 
-// JobID return a String field (key - "job_id")
+// JobID returns a String field (key - "job_id")
 func JobID(val interface{}) Field {
 	return String("job_id", fmt.Sprintf("%v", val))
 }

--- a/log/zap.go
+++ b/log/zap.go
@@ -130,6 +130,21 @@ func NodeID(val string) Field {
 	return String("node_id", val)
 }
 
+// PeerID return a String field (key - "peer_id")
+func PeerID(val string) Field {
+	return String("peer_id", val)
+}
+
+// MinerID return a String field (key - "miner_id")
+func MinerID(val string) Field {
+	return String("miner_id", val)
+}
+
+// JobID return a String field (key - "job_id")
+func JobID(val interface{}) Field {
+	return String("job_id", fmt.Sprintf("%v", val))
+}
+
 // Err returns an error field
 func Err(v error) Field {
 	return Field(zap.NamedError("errmsg", v))

--- a/log/zap.go
+++ b/log/zap.go
@@ -132,7 +132,7 @@ func NodeID(val string) Field {
 
 // Err returns an error field
 func Err(v error) Field {
-	return Field(zap.NamedError("message", v))
+	return Field(zap.NamedError("errmsg", v))
 }
 
 // LoggableField as an interface to enable every type to be used as a log field.

--- a/log/zap.go
+++ b/log/zap.go
@@ -130,21 +130,6 @@ func NodeID(val string) Field {
 	return String("node_id", val)
 }
 
-// PeerID returns a String field (key - "peer_id")
-func PeerID(val string) Field {
-	return String("peer_id", val)
-}
-
-// MinerID returns a String field (key - "miner_id")
-func MinerID(val string) Field {
-	return String("miner_id", val)
-}
-
-// JobID returns a String field (key - "job_id")
-func JobID(val interface{}) Field {
-	return String("job_id", fmt.Sprintf("%v", val))
-}
-
 // Err returns an error field
 func Err(v error) Field {
 	return Field(zap.NamedError("errmsg", v))

--- a/mesh/mesh.go
+++ b/mesh/mesh.go
@@ -707,7 +707,7 @@ func (msh *Mesh) accumulateRewards(l *types.Layer, params Config) {
 
 	blockLayerReward, blockLayerRewardMod := calculateActualRewards(l.Index(), layerReward, numBlocks)
 	log.With().Info("Reward calculated",
-		log.LayerID(uint64(l.Index())),
+		l.Index(),
 		log.Uint64("num_blocks", numBlocks.Uint64()),
 		log.Uint64("total_reward", totalReward.Uint64()),
 		log.Uint64("layer_reward", layerReward.Uint64()),

--- a/mesh/mesh.go
+++ b/mesh/mesh.go
@@ -702,10 +702,20 @@ func (msh *Mesh) accumulateRewards(l *types.Layer, params Config) {
 
 	numBlocks := big.NewInt(int64(len(ids)))
 
-	blockTotalReward := calculateActualRewards(l.Index(), totalReward, numBlocks)
+	blockTotalReward, blockTotalRewardMod := calculateActualRewards(l.Index(), totalReward, numBlocks)
 	msh.ApplyRewards(l.Index(), ids, blockTotalReward)
 
-	blockLayerReward := calculateActualRewards(l.Index(), layerReward, numBlocks)
+	blockLayerReward, blockLayerRewardMod := calculateActualRewards(l.Index(), layerReward, numBlocks)
+	log.With().Info("Reward calculated",
+		log.LayerID(uint64(l.Index())),
+		log.Uint64("num_blocks", numBlocks.Uint64()),
+		log.Uint64("total_reward", totalReward.Uint64()),
+		log.Uint64("layer_reward", layerReward.Uint64()),
+		log.Uint64("block_total_reward", blockTotalReward.Uint64()),
+		log.Uint64("block_layer_reward", blockLayerReward.Uint64()),
+		log.Uint64("total_reward_remainder", blockTotalRewardMod.Uint64()),
+		log.Uint64("layer_reward_remainder", blockLayerRewardMod.Uint64()),
+	)
 	err := msh.writeTransactionRewards(l.Index(), ids, blockTotalReward, blockLayerReward)
 	if err != nil {
 		msh.Error("cannot write reward to db")

--- a/mesh/mesh.go
+++ b/mesh/mesh.go
@@ -560,7 +560,7 @@ func (msh *Mesh) SetZeroBlockLayer(lyr types.LayerID) error {
 // txs - block txs that we dont have in our tx database yet
 // atxs - block atxs that we dont have in our atx database yet
 func (msh *Mesh) AddBlockWithTxs(blk *types.Block, txs []*types.Transaction, atxs []*types.ActivationTx) error {
-	msh.With().Debug("adding block", log.BlockID(blk.ID().String()))
+	msh.With().Debug("adding block", blk.Fields()...)
 
 	// Store transactions (doesn't have to be rolled back if other writes fail)
 	if len(txs) > 0 {
@@ -596,7 +596,7 @@ func (msh *Mesh) AddBlockWithTxs(blk *types.Block, txs []*types.Transaction, atx
 	msh.invalidateFromPools(&blk.MiniBlock)
 
 	events.Publish(events.NewBlock{ID: blk.ID().String(), Atx: blk.ATXID.ShortString(), Layer: uint64(blk.LayerIndex)})
-	msh.With().Info("added block to database ", log.BlockID(blk.ID().String()), log.LayerID(uint64(blk.LayerIndex)))
+	msh.With().Info("added block to database", blk.Fields()...)
 	return nil
 }
 

--- a/mesh/reward.go
+++ b/mesh/reward.go
@@ -2,7 +2,6 @@ package mesh
 
 import (
 	"github.com/spacemeshos/go-spacemesh/common/types"
-	"github.com/spacemeshos/go-spacemesh/log"
 	"math"
 	"math/big"
 )
@@ -24,14 +23,7 @@ func calculateLayerReward(id types.LayerID, params Config) *big.Int {
 	return params.BaseReward
 }
 
-func calculateActualRewards(layer types.LayerID, rewards *big.Int, numBlocks *big.Int) *big.Int {
+func calculateActualRewards(layer types.LayerID, rewards *big.Int, numBlocks *big.Int) (*big.Int, *big.Int) {
 	div, mod := new(big.Int).DivMod(rewards, numBlocks, new(big.Int))
-	log.With().Info("Reward calculated",
-		log.LayerID(uint64(layer)),
-		log.Uint64("total_reward", rewards.Uint64()),
-		log.Uint64("num_blocks", numBlocks.Uint64()),
-		log.Uint64("block_reward", div.Uint64()),
-		log.Uint64("reward_remainder", mod.Uint64()),
-	)
-	return div
+	return div, mod
 }

--- a/mesh/reward_test.go
+++ b/mesh/reward_test.go
@@ -330,8 +330,9 @@ func TestMesh_AccumulateRewards(t *testing.T) {
 }
 
 func TestMesh_calcRewards(t *testing.T) {
-	reward := calculateActualRewards(1, big.NewInt(10000), big.NewInt(10))
+	reward, remainder := calculateActualRewards(1, big.NewInt(10000), big.NewInt(10))
 	assert.Equal(t, int64(1000), reward.Int64())
+	assert.Equal(t, int64(0), remainder.Int64())
 }
 
 func newActivationTx(nodeID types.NodeID, sequence uint64, prevATX types.ATXID, pubLayerID types.LayerID,

--- a/miner/block_builder.go
+++ b/miner/block_builder.go
@@ -26,6 +26,9 @@ const MaxTransactionsPerBlock = 200 //todo: move to config (#1924)
 const defaultGasLimit = 10
 const defaultFee = 1
 
+// AtxsPerBlockLimit indicates the maximum number of atxs a block can reference
+const AtxsPerBlockLimit = 100
+
 // IncomingTxProtocol is the protocol identifier for tx received by gossip that is used by the p2p
 const IncomingTxProtocol = "TxGossip"
 

--- a/miner/block_builder.go
+++ b/miner/block_builder.go
@@ -26,11 +26,11 @@ const MaxTransactionsPerBlock = 200 //todo: move to config (#1924)
 const defaultGasLimit = 10
 const defaultFee = 1
 
-// AtxsPerBlockLimit indicates the maximum number of atxs a block can reference
-const AtxsPerBlockLimit = 100
-
 // IncomingTxProtocol is the protocol identifier for tx received by gossip that is used by the p2p
 const IncomingTxProtocol = "TxGossip"
+
+// AtxsPerBlockLimit indicates the maximum number of atxs a block can reference
+const AtxsPerBlockLimit = 100
 
 type signer interface {
 	Sign(m []byte) []byte

--- a/miner/block_builder.go
+++ b/miner/block_builder.go
@@ -289,15 +289,15 @@ func (t *BlockBuilder) createBlock(id types.LayerID, atxID types.ATXID, eligibil
 	bl.Initialize()
 
 	t.Log.Event().Info("block created",
-		log.BlockID(bl.ShortString()),
-		log.LayerID(uint64(bl.LayerIndex)),
-		log.EpochID(uint64(bl.LayerIndex.GetEpoch(t.layersPerEpoch))),
-		log.String("miner_id", bl.MinerID().String()),
+		bl.ID(),
+		bl.LayerIndex,
+		bl.LayerIndex.GetEpoch(t.layersPerEpoch),
+		bl.MinerID(),
 		log.Int("tx_count", len(bl.TxIDs)),
 		log.Int("atx_count", len(bl.ATXIDs)),
 		log.Int("view_edges", len(bl.ViewEdges)),
 		log.Int("vote_count", len(bl.BlockVotes)),
-		log.AtxID(bl.ATXID.ShortString()),
+		bl.ATXID,
 		log.Uint32("eligibility_counter", bl.EligibilityProof.J),
 	)
 	return bl, nil

--- a/miner/block_builder.go
+++ b/miner/block_builder.go
@@ -408,30 +408,31 @@ func (t *BlockBuilder) handleGossipAtx(data service.GossipMessage) {
 	}
 	atx.CalcAndSetID()
 
-	commitmentStr := "nil"
-	if atx.Commitment != nil {
-		commitmentStr = atx.Commitment.String()
-	}
-
-	challenge := ""
-	h, err := atx.NIPSTChallenge.Hash()
-	if err == nil && h != nil {
-		challenge = h.String()
-
-	}
+	//commitmentStr := "nil"
+	//if atx.Commitment != nil {
+	//	commitmentStr = atx.Commitment.String()
+	//}
+	//
+	//challenge := ""
+	//h, err := atx.NIPSTChallenge.Hash()
+	//if err == nil && h != nil {
+	//	challenge = h.String()
+	//
+	//}
 
 	t.With().Info("got new ATX",
-		log.String("sender_id", atx.NodeID.ShortString()),
-		log.AtxID(atx.ShortString()),
-		log.String("prev_atx_id", atx.PrevATXID.ShortString()),
-		log.String("pos_atx_id", atx.PositioningATX.ShortString()),
-		log.LayerID(uint64(atx.PubLayerID)),
-		log.Uint32("active_set", atx.ActiveSetSize),
-		log.Int("view", len(atx.View)),
-		log.Uint64("sequence_number", atx.Sequence),
-		log.String("commitment", commitmentStr),
-		log.Int("atx_size", len(data.Bytes())),
-		log.String("NIPSTChallenge", challenge),
+		atx.Fields()...,
+	// log.String("sender_id", atx.NodeID.ShortString()),
+	// log.AtxID(atx.ShortString()),
+	// log.String("prev_atx_id", atx.PrevATXID.ShortString()),
+	// log.String("pos_atx_id", atx.PositioningATX.ShortString()),
+	// log.LayerID(uint64(atx.PubLayerID)),
+	// log.Uint32("active_set", atx.ActiveSetSize),
+	// log.Int("viewlen", len(atx.View)),
+	// log.Uint64("sequence_number", atx.Sequence),
+	// log.String("commitment", commitmentStr),
+	// log.Int("atx_size", len(data.Bytes())),
+	// log.String("NIPSTChallenge", challenge),
 	)
 
 	//todo fetch from neighbour (#1925)

--- a/miner/block_builder.go
+++ b/miner/block_builder.go
@@ -29,9 +29,6 @@ const defaultFee = 1
 // IncomingTxProtocol is the protocol identifier for tx received by gossip that is used by the p2p
 const IncomingTxProtocol = "TxGossip"
 
-// AtxsPerBlockLimit indicates the maximum number of atxs a block can reference
-const AtxsPerBlockLimit = 100
-
 type signer interface {
 	Sign(m []byte) []byte
 }

--- a/miner/block_builder.go
+++ b/miner/block_builder.go
@@ -223,7 +223,7 @@ func (t *BlockBuilder) getVotes(id types.LayerID) ([]types.BlockID, error) {
 	bottom, top := calcHdistRange(id, t.hdist)
 
 	if res, err := t.hareResult.GetResult(bottom); err != nil { // no result for bottom, take the whole layer
-		t.With().Warning("could not get result for bottom layer. adding the whole layer instead", log.Err(err),
+		t.With().Warning("Could not get result for bottom layer. Adding the whole layer instead.", log.Err(err),
 			log.Uint64("bottom", uint64(bottom)), log.Uint64("top", uint64(top)), log.Uint64("hdist", uint64(t.hdist)))
 		ids, e := t.meshProvider.LayerBlockIds(bottom)
 		if e != nil {

--- a/miner/block_builder.go
+++ b/miner/block_builder.go
@@ -292,14 +292,15 @@ func (t *BlockBuilder) createBlock(id types.LayerID, atxID types.ATXID, eligibil
 	bl.Initialize()
 
 	t.Log.Event().Info("block created",
-		bl.ID(),
-		bl.LayerIndex,
+		log.BlockID(bl.ShortString()),
+		log.LayerID(uint64(bl.LayerIndex)),
+		log.EpochID(uint64(bl.LayerIndex.GetEpoch(t.layersPerEpoch))),
 		log.String("miner_id", bl.MinerID().String()),
 		log.Int("tx_count", len(bl.TxIDs)),
 		log.Int("atx_count", len(bl.ATXIDs)),
 		log.Int("view_edges", len(bl.ViewEdges)),
 		log.Int("vote_count", len(bl.BlockVotes)),
-		bl.ATXID,
+		log.AtxID(bl.ATXID.ShortString()),
 		log.Uint32("eligibility_counter", bl.EligibilityProof.J),
 	)
 	return bl, nil

--- a/miner/builder_test.go
+++ b/miner/builder_test.go
@@ -310,7 +310,7 @@ func TestBlockBuilder_Validation(t *testing.T) {
 
 	poetRef := []byte{0xba, 0x38}
 	coinbase := types.HexToAddress("aaaa")
-	atx := types.NewActivationTxForTests(types.NodeID{Key: "aaaa", VRFPublicKey: []byte("bbb")}, 1, types.ATXID(types.Hash32{1}), 5, 1, types.ATXID{}, coinbase, 5, []types.BlockID{block1.ID(), block2.ID(), block3.ID()}, activation.NewNIPSTWithChallenge(&types.Hash32{}, poetRef))
+	atx := newActivationTx(types.NodeID{Key: "aaaa", VRFPublicKey: []byte("bbb")}, 0, types.ATXID(types.Hash32{1}), 5, 1, types.ATXID{}, coinbase, 5, []types.BlockID{block1.ID(), block2.ID(), block3.ID()}, activation.NewNIPSTWithChallenge(&types.Hash32{}, poetRef))
 
 	atxBytes, err := types.InterfaceToBytes(&atx)
 	assert.NoError(t, err)

--- a/miner/builder_test.go
+++ b/miner/builder_test.go
@@ -36,7 +36,7 @@ type MockHare struct {
 func (m MockHare) GetResult(id types.LayerID) ([]types.BlockID, error) {
 	blks, ok := m.res[id]
 	if !ok {
-		return nil, fmt.Errorf("hare result for layer%v was not in map", id)
+		return nil, fmt.Errorf("hare result for layer %v was not in map", id)
 	}
 	return blks, nil
 }

--- a/miner/builder_test.go
+++ b/miner/builder_test.go
@@ -21,6 +21,7 @@ import (
 )
 
 const selectCount = 100
+const layersPerEpoch = 10
 
 type MockCoin struct{}
 
@@ -120,7 +121,7 @@ func TestBlockBuilder_StartStop(t *testing.T) {
 
 	bs := []*types.Block{block1, block2, block3, block4}
 	orphans := &mockMesh{b: bs}
-	builder := NewBlockBuilder(types.NodeID{}, signing.NewEdSigner(), n, beginRound, 5, NewTxMemPool(), NewAtxMemPool(), MockCoin{}, orphans, hare, &mockBlockOracle{}, mockTxProcessor{}, &mockAtxValidator{}, &mockSyncer{}, selectCount, mockProjector, log.New(n.String(), "", ""))
+	builder := NewBlockBuilder(types.NodeID{}, signing.NewEdSigner(), n, beginRound, 5, NewTxMemPool(), NewAtxMemPool(), MockCoin{}, orphans, hare, &mockBlockOracle{}, mockTxProcessor{}, &mockAtxValidator{}, &mockSyncer{}, selectCount, layersPerEpoch, mockProjector, log.New(n.String(), "", ""))
 
 	err := builder.Start()
 	assert.NoError(t, err)
@@ -154,8 +155,8 @@ func TestBlockBuilder_BlockIdGeneration(t *testing.T) {
 	hare.res[0] = hareRes
 
 	st := []*types.Block{block2, block3, block4}
-	builder1 := NewBlockBuilder(types.NodeID{Key: "a"}, signing.NewEdSigner(), n1, beginRound, 5, NewTxMemPool(), NewAtxMemPool(), MockCoin{}, &mockMesh{b: st}, hare, &mockBlockOracle{}, mockTxProcessor{}, &mockAtxValidator{}, &mockSyncer{}, selectCount, mockProjector, log.New(n1.Info.ID.String(), "", ""))
-	builder2 := NewBlockBuilder(types.NodeID{Key: "b"}, signing.NewEdSigner(), n2, beginRound, 5, NewTxMemPool(), NewAtxMemPool(), MockCoin{}, &mockMesh{b: st}, hare, &mockBlockOracle{}, mockTxProcessor{}, &mockAtxValidator{}, &mockSyncer{}, selectCount, mockProjector, log.New(n2.Info.ID.String(), "", ""))
+	builder1 := NewBlockBuilder(types.NodeID{Key: "a"}, signing.NewEdSigner(), n1, beginRound, 5, NewTxMemPool(), NewAtxMemPool(), MockCoin{}, &mockMesh{b: st}, hare, &mockBlockOracle{}, mockTxProcessor{}, &mockAtxValidator{}, &mockSyncer{}, selectCount, layersPerEpoch, mockProjector, log.New(n1.Info.ID.String(), "", ""))
+	builder2 := NewBlockBuilder(types.NodeID{Key: "b"}, signing.NewEdSigner(), n2, beginRound, 5, NewTxMemPool(), NewAtxMemPool(), MockCoin{}, &mockMesh{b: st}, hare, &mockBlockOracle{}, mockTxProcessor{}, &mockAtxValidator{}, &mockSyncer{}, selectCount, layersPerEpoch, mockProjector, log.New(n2.Info.ID.String(), "", ""))
 
 	b1, _ := builder1.createBlock(1, types.ATXID{}, types.BlockEligibilityProof{}, nil, nil)
 
@@ -180,7 +181,7 @@ func TestBlockBuilder_CreateBlock(t *testing.T) {
 	hare.res[1] = hareRes
 
 	st := []*types.Block{block1, block2, block3}
-	builder := NewBlockBuilder(types.NodeID{Key: "anton", VRFPublicKey: []byte("anton")}, signing.NewEdSigner(), n, beginRound, 5, NewTxMemPool(), NewAtxMemPool(), MockCoin{}, &mockMesh{b: st}, hare, &mockBlockOracle{}, mockTxProcessor{}, &mockAtxValidator{}, &mockSyncer{}, selectCount, mockProjector, log.New(n.String(), "", ""))
+	builder := NewBlockBuilder(types.NodeID{Key: "anton", VRFPublicKey: []byte("anton")}, signing.NewEdSigner(), n, beginRound, 5, NewTxMemPool(), NewAtxMemPool(), MockCoin{}, &mockMesh{b: st}, hare, &mockBlockOracle{}, mockTxProcessor{}, &mockAtxValidator{}, &mockSyncer{}, selectCount, layersPerEpoch, mockProjector, log.New(n.String(), "", ""))
 
 	err := builder.Start()
 	assert.NoError(t, err)
@@ -290,7 +291,7 @@ func TestBlockBuilder_Validation(t *testing.T) {
 	hare.res[0] = hareRes
 
 	st := []*types.Block{block1, block2, block3}
-	builder1 := NewBlockBuilder(types.NodeID{Key: "a"}, signing.NewEdSigner(), n1, beginRound, 5, NewTxMemPool(), NewAtxMemPool(), MockCoin{}, &mockMesh{b: st}, hare, &mockBlockOracle{}, mockTxProcessor{true}, &mockAtxValidator{}, &mockSyncer{}, selectCount, mockProjector, log.New(n1.Info.ID.String(), "", ""))
+	builder1 := NewBlockBuilder(types.NodeID{Key: "a"}, signing.NewEdSigner(), n1, beginRound, 5, NewTxMemPool(), NewAtxMemPool(), MockCoin{}, &mockMesh{b: st}, hare, &mockBlockOracle{}, mockTxProcessor{true}, &mockAtxValidator{}, &mockSyncer{}, selectCount, layersPerEpoch, mockProjector, log.New(n1.Info.ID.String(), "", ""))
 	assert.NoError(t, builder1.Start())
 	tx := NewTx(t, 5, types.HexToAddress("0xFF"), signing.NewEdSigner())
 	b, e := types.InterfaceToBytes(tx)
@@ -335,7 +336,7 @@ func TestBlockBuilder_Gossip_NotSynced(t *testing.T) {
 	hare.res[0] = hareRes
 
 	st := []*types.Block{block2, block3, block4}
-	builder1 := NewBlockBuilder(types.NodeID{Key: "a"}, signing.NewEdSigner(), n1, beginRound, 5, NewTxMemPool(), NewAtxMemPool(), MockCoin{}, &mockMesh{b: st}, hare, &mockBlockOracle{}, mockTxProcessor{false}, &mockAtxValidator{}, &mockSyncerP{false}, selectCount, mockProjector, log.New(n1.Info.ID.String(),
+	builder1 := NewBlockBuilder(types.NodeID{Key: "a"}, signing.NewEdSigner(), n1, beginRound, 5, NewTxMemPool(), NewAtxMemPool(), MockCoin{}, &mockMesh{b: st}, hare, &mockBlockOracle{}, mockTxProcessor{false}, &mockAtxValidator{}, &mockSyncerP{false}, selectCount, layersPerEpoch, mockProjector, log.New(n1.Info.ID.String(),
 		"",
 		""))
 	assert.NoError(t, builder1.Start())
@@ -546,7 +547,7 @@ func TestBlockBuilder_getVotes(t *testing.T) {
 	beginRound := make(chan types.LayerID)
 	n1 := service.NewSimulator().NewNode()
 	allblocks := []*types.Block{b1, b2, b3, b4, b5, b6, b7}
-	bb := NewBlockBuilder(types.NodeID{Key: "a"}, signing.NewEdSigner(), n1, beginRound, 5, NewTxMemPool(), NewAtxMemPool(), MockCoin{}, &mockMesh{b: allblocks}, &mockResult{}, &mockBlockOracle{}, mockTxProcessor{true}, &mockAtxValidator{}, &mockSyncer{}, selectCount, mockProjector, log.NewDefault(t.Name()))
+	bb := NewBlockBuilder(types.NodeID{Key: "a"}, signing.NewEdSigner(), n1, beginRound, 5, NewTxMemPool(), NewAtxMemPool(), MockCoin{}, &mockMesh{b: allblocks}, &mockResult{}, &mockBlockOracle{}, mockTxProcessor{true}, &mockAtxValidator{}, &mockSyncer{}, selectCount, layersPerEpoch, mockProjector, log.NewDefault(t.Name()))
 	b, err := bb.getVotes(config.Genesis)
 	r.EqualError(err, "cannot create blockBytes in genesis layer")
 	r.Nil(b)
@@ -596,7 +597,7 @@ func TestBlockBuilder_CalcHdistRange(t *testing.T) {
 	beginRound := make(chan types.LayerID)
 	n1 := service.NewSimulator().NewNode()
 	bs := []*types.Block{b1, b2, b3}
-	bb := NewBlockBuilder(types.NodeID{Key: "a"}, signing.NewEdSigner(), n1, beginRound, 5, NewTxMemPool(), NewAtxMemPool(), MockCoin{}, &mockMesh{b: bs}, &mockResult{}, &mockBlockOracle{}, mockTxProcessor{true}, &mockAtxValidator{}, &mockSyncer{}, selectCount, mockProjector, log.NewDefault(t.Name()))
+	bb := NewBlockBuilder(types.NodeID{Key: "a"}, signing.NewEdSigner(), n1, beginRound, 5, NewTxMemPool(), NewAtxMemPool(), MockCoin{}, &mockMesh{b: bs}, &mockResult{}, &mockBlockOracle{}, mockTxProcessor{true}, &mockAtxValidator{}, &mockSyncer{}, selectCount, layersPerEpoch, mockProjector, log.NewDefault(t.Name()))
 	bottom, _ := calcHdistRange(5, bb.hdist)
 	r.True(bottom == 0)
 
@@ -614,7 +615,7 @@ func TestBlockBuilder_createBlock(t *testing.T) {
 	block3 := types.NewExistingBlock(0, []byte(rand.String(8)))
 	bs := []*types.Block{block1, block2, block3}
 	st := []types.BlockID{block1.ID(), block2.ID(), block3.ID()}
-	builder1 := NewBlockBuilder(types.NodeID{Key: "a"}, signing.NewEdSigner(), n1, beginRound, 5, NewTxMemPool(), NewAtxMemPool(), MockCoin{}, &mockMesh{b: bs}, hare, &mockBlockOracle{}, mockTxProcessor{true}, &mockAtxValidator{}, &mockSyncer{}, selectCount, mockProjector, log.NewDefault(t.Name()))
+	builder1 := NewBlockBuilder(types.NodeID{Key: "a"}, signing.NewEdSigner(), n1, beginRound, 5, NewTxMemPool(), NewAtxMemPool(), MockCoin{}, &mockMesh{b: bs}, hare, &mockBlockOracle{}, mockTxProcessor{true}, &mockAtxValidator{}, &mockSyncer{}, selectCount, layersPerEpoch, mockProjector, log.NewDefault(t.Name()))
 
 	builder1.hareResult = &mockResult{err: errExample, ids: nil}
 	b, err := builder1.createBlock(5, types.ATXID{}, types.BlockEligibilityProof{}, nil, nil)
@@ -639,7 +640,7 @@ func TestBlockBuilder_notSynced(t *testing.T) {
 	ms.notSynced = true
 	mbo := &mockBlockOracle{}
 	mbo.err = errors.New("err")
-	builder := NewBlockBuilder(types.NodeID{Key: "a"}, signing.NewEdSigner(), n1, beginRound, 5, NewTxMemPool(), NewAtxMemPool(), MockCoin{}, &mockMesh{b: bs}, hare, mbo, mockTxProcessor{true}, &mockAtxValidator{}, ms, selectCount, mockProjector, log.NewDefault(t.Name()))
+	builder := NewBlockBuilder(types.NodeID{Key: "a"}, signing.NewEdSigner(), n1, beginRound, 5, NewTxMemPool(), NewAtxMemPool(), MockCoin{}, &mockMesh{b: bs}, hare, mbo, mockTxProcessor{true}, &mockAtxValidator{}, ms, selectCount, layersPerEpoch, mockProjector, log.NewDefault(t.Name()))
 	go builder.acceptBlockData()
 	beginRound <- 1
 	beginRound <- 2
@@ -682,7 +683,7 @@ func Test_getVotesFiltered(t *testing.T) {
 	beginRound := make(chan types.LayerID)
 	n1 := service.NewSimulator().NewNode()
 	allblocks := []*types.Block{b5}
-	bb := NewBlockBuilder(types.NodeID{Key: "a"}, signing.NewEdSigner(), n1, beginRound, 5, NewTxMemPool(), NewAtxMemPool(), MockCoin{}, &mockMesh{b: allblocks}, &mockResult{}, &mockBlockOracle{}, mockTxProcessor{true}, &mockAtxValidator{}, &mockSyncer{}, selectCount, mockProjector, log.NewDefault(t.Name()))
+	bb := NewBlockBuilder(types.NodeID{Key: "a"}, signing.NewEdSigner(), n1, beginRound, 5, NewTxMemPool(), NewAtxMemPool(), MockCoin{}, &mockMesh{b: allblocks}, &mockResult{}, &mockBlockOracle{}, mockTxProcessor{true}, &mockAtxValidator{}, &mockSyncer{}, selectCount, layersPerEpoch, mockProjector, log.NewDefault(t.Name()))
 	// has bottom
 	mh := newMockResult()
 	mh.set(4)

--- a/miner/builder_test.go
+++ b/miner/builder_test.go
@@ -306,13 +306,25 @@ func TestBlockBuilder_Validation(t *testing.T) {
 	ids, err = builder1.TransactionPool.GetTxsForBlock(10, getState)
 	assert.NoError(t, err)
 	assert.Len(t, ids, 1)
+
+	poetRef := []byte{0xba, 0x38}
+	coinbase := types.HexToAddress("aaaa")
+	atx := types.NewActivationTxForTests(types.NodeID{Key: "aaaa", VRFPublicKey: []byte("bbb")}, 1, types.ATXID(types.Hash32{1}), 5, 1, types.ATXID{}, coinbase, 5, []types.BlockID{block1.ID(), block2.ID(), block3.ID()}, activation.NewNIPSTWithChallenge(&types.Hash32{}, poetRef))
+
+	atxBytes, err := types.InterfaceToBytes(&atx)
+	assert.NoError(t, err)
+	err = n1.Broadcast(activation.AtxProtocol, atxBytes)
+	assert.NoError(t, err)
+	time.Sleep(300 * time.Millisecond)
+	ids, err = builder1.TransactionPool.GetTxsForBlock(10, getState)
+	assert.NoError(t, err)
+	assert.Len(t, ids, 1)
 }
 
 func TestBlockBuilder_Gossip_NotSynced(t *testing.T) {
 	net := service.NewSimulator()
 	beginRound := make(chan types.LayerID)
 	n1 := net.NewNode()
-	coinbase := types.HexToAddress("aaaa")
 
 	block1 := types.NewExistingBlock(0, []byte(rand.String(8)))
 	block2 := types.NewExistingBlock(0, []byte(rand.String(8)))
@@ -338,6 +350,7 @@ func TestBlockBuilder_Gossip_NotSynced(t *testing.T) {
 	assert.Empty(t, ids)
 
 	poetRef := []byte{0xba, 0x38}
+	coinbase := types.HexToAddress("aaaa")
 	atx := newActivationTx(types.NodeID{Key: "aaaa", VRFPublicKey: []byte("bbb")}, 1, types.ATXID(types.Hash32{1}), 5, 1, types.ATXID{}, coinbase, 5, []types.BlockID{block1.ID(), block2.ID(), block3.ID()}, activation.NewNIPSTWithChallenge(&types.Hash32{}, poetRef))
 
 	atxBytes, err := types.InterfaceToBytes(&atx)

--- a/oracle/blockeligibilityvalidator_test.go
+++ b/oracle/blockeligibilityvalidator_test.go
@@ -38,7 +38,7 @@ func TestBlockEligibilityValidator_getValidAtx(t *testing.T) {
 	block.Signature = edSigner.Sign(block.Bytes())
 	block.Initialize()
 	_, err := v.getValidAtx(block)
-	r.EqualError(err, "getting ATX failed: some err 000000000000 ep(4)")
+	r.EqualError(err, "getting ATX failed: some err 0000000000 ep(4)")
 
 	v.activationDb = &mockAtxDB{atxH: &types.ActivationTxHeader{}} // not same epoch
 	_, err = v.getValidAtx(block)

--- a/oracle/blockeligibilityvalidator_test.go
+++ b/oracle/blockeligibilityvalidator_test.go
@@ -38,7 +38,7 @@ func TestBlockEligibilityValidator_getValidAtx(t *testing.T) {
 	block.Signature = edSigner.Sign(block.Bytes())
 	block.Initialize()
 	_, err := v.getValidAtx(block)
-	r.EqualError(err, "getting ATX failed: some err 00000 ep(4)")
+	r.EqualError(err, "getting ATX failed: some err 000000000000 ep(4)")
 
 	v.activationDb = &mockAtxDB{atxH: &types.ActivationTxHeader{}} // not same epoch
 	_, err = v.getValidAtx(block)

--- a/oracle/blockoracle.go
+++ b/oracle/blockoracle.go
@@ -76,8 +76,8 @@ func (bo *MinerBlockOracle) BlockEligible(layerID types.LayerID) (types.ATXID, [
 	proofs := bo.eligibilityProofs[layerID]
 	bo.eligibilityMutex.RUnlock()
 	bo.log.With().Info("eligible for blocks in layer",
-		log.NodeID(bo.nodeID.ShortString()),
-		layerID.Field(),
+		bo.nodeID,
+		layerID,
 		log.Int("num_blocks", len(proofs)))
 
 	return bo.atxID, proofs, nil

--- a/oracle/blockoracle.go
+++ b/oracle/blockoracle.go
@@ -145,7 +145,7 @@ func (bo *MinerBlockOracle) calcEligibilityProofs(epochNumber types.EpochID) err
 	// Pretty-print the number of blocks per eligible layer
 	strs := []string{}
 	for k := range keys {
-		strs = append(strs, fmt.Sprintf("Layer %d: %d", uint64(k), keys[k]))
+		strs = append(strs, fmt.Sprintf("Layer %d: %d", keys[k], len(bo.eligibilityProofs[k])))
 	}
 
 	bo.log.With().Info("eligibility for blocks in epoch",

--- a/oracle/blockoracle.go
+++ b/oracle/blockoracle.go
@@ -132,25 +132,25 @@ func (bo *MinerBlockOracle) calcEligibilityProofs(epochNumber types.EpochID) err
 	bo.eligibilityMutex.RLock()
 
 	// Sort the layer map so we can print the layer data in order
-	keys := []types.LayerID{}
+	keys := make([]types.LayerID, len(bo.eligibilityProofs))
+	i := 0
 	for k := range bo.eligibilityProofs {
-		if len(bo.eligibilityProofs[k]) > 0 {
-			keys = append(keys, k)
-		}
+		keys[i] = k
+		i++
 	}
 	sort.Slice(keys, func(i, j int) bool {
 		return uint64(keys[i]) < uint64(keys[j])
 	})
 
 	// Pretty-print the number of blocks per eligible layer
-	strs := []string{}
+	var strs []string
 	for k := range keys {
-		strs = append(strs, fmt.Sprintf("Layer %d: %d", keys[k], len(bo.eligibilityProofs[k])))
+		strs = append(strs, fmt.Sprintf("Layer %d: %d", keys[k], len(bo.eligibilityProofs[keys[k]])))
 	}
 
 	bo.log.With().Info("eligibility for blocks in epoch",
-		log.NodeID(bo.nodeID.ShortString()),
-		log.EpochID(uint64(epochNumber)),
+		bo.nodeID,
+		epochNumber,
 		log.Uint32("total_num_blocks", numberOfEligibleBlocks),
 		log.Int("num_layers_eligible", len(bo.eligibilityProofs)),
 		log.String("layers_and_num_blocks", strings.Join(strs, ", ")))

--- a/oracle/blockoracle.go
+++ b/oracle/blockoracle.go
@@ -7,6 +7,8 @@ import (
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/sha256-simd"
+	"sort"
+	"strings"
 	"sync"
 )
 
@@ -73,7 +75,11 @@ func (bo *MinerBlockOracle) BlockEligible(layerID types.LayerID) (types.ATXID, [
 	bo.eligibilityMutex.RLock()
 	proofs := bo.eligibilityProofs[layerID]
 	bo.eligibilityMutex.RUnlock()
-	bo.log.Info("miner %v found eligible for %d blocks in layer %d", bo.nodeID.Key[:5], len(proofs), layerID)
+	bo.log.With().Info("eligible for blocks in layer",
+		log.NodeID(bo.nodeID.ShortString()),
+		layerID.Field(),
+		log.Int("num_blocks", len(proofs)))
+
 	return bo.atxID, proofs, nil
 }
 
@@ -124,8 +130,30 @@ func (bo *MinerBlockOracle) calcEligibilityProofs(epochNumber types.EpochID) err
 	}
 	bo.proofsEpoch = epochNumber
 	bo.eligibilityMutex.RLock()
-	bo.log.Info("miner %v is eligible for %d blocks on %d layers in epoch %d",
-		bo.nodeID.Key[:5], numberOfEligibleBlocks, len(bo.eligibilityProofs), epochNumber)
+
+	// Sort the layer map so we can print the layer data in order
+	keys := []types.LayerID{}
+	for k := range bo.eligibilityProofs {
+		if len(bo.eligibilityProofs[k]) > 0 {
+			keys = append(keys, k)
+		}
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		return uint64(keys[i]) < uint64(keys[j])
+	})
+
+	// Pretty-print the number of blocks per eligible layer
+	strs := []string{}
+	for k := range keys {
+		strs = append(strs, fmt.Sprintf("Layer %d: %d", uint64(k), keys[k]))
+	}
+
+	bo.log.With().Info("eligibility for blocks in epoch",
+		log.NodeID(bo.nodeID.ShortString()),
+		log.EpochID(uint64(epochNumber)),
+		log.Uint32("total_num_blocks", numberOfEligibleBlocks),
+		log.Int("num_layers_eligible", len(bo.eligibilityProofs)),
+		log.String("layers_and_num_blocks", strings.Join(strs, ", ")))
 	bo.eligibilityMutex.RUnlock()
 	return nil
 }

--- a/p2p/discovery/refresher.go
+++ b/p2p/discovery/refresher.go
@@ -93,7 +93,7 @@ loop:
 		servers = srv[:util.Min(numpeers, len(srv))]
 		res := r.requestAddresses(ctx, servers)
 		tries++
-		r.logger.Info("Bootstrap : %d try gave %v results", tries, len(res))
+		r.logger.Info("Bootstrap: try %d gave %v results", tries, len(res))
 
 		newsize := r.book.NumAddresses()
 		wanted := numpeers

--- a/p2p/gossip/protocol.go
+++ b/p2p/gossip/protocol.go
@@ -164,7 +164,7 @@ func (p *Protocol) handlePQ() {
 		p.Log.With().Debug("new_gossip_message_relay",
 			log.String("from", m.Sender().String()),
 			log.String("protocol", m.Protocol()),
-			h.Field("hash")
+			h.Field("hash"))
 		p.propagateMessage(m.Message(), h, m.Protocol(), m.Sender())
 	}
 }

--- a/p2p/gossip/protocol.go
+++ b/p2p/gossip/protocol.go
@@ -139,7 +139,7 @@ peerLoop:
 				p.With().Warning("Failed sending",
 					log.String("protocol", nextProt),
 					h.Field("hash"),
-					log.String("to", pubkey.String()),
+					pubkey.Field("to"),
 					log.Err(err))
 			}
 			wg.Done()
@@ -162,7 +162,7 @@ func (p *Protocol) handlePQ() {
 		}
 		h := types.CalcMessageHash12(m.Message(), m.Protocol())
 		p.Log.With().Debug("new_gossip_message_relay",
-			log.String("from", m.Sender().String()),
+			m.Sender().Field("from"),
 			log.String("protocol", m.Protocol()),
 			h.Field("hash"))
 		p.propagateMessage(m.Message(), h, m.Protocol(), m.Sender())

--- a/p2p/gossip/protocol.go
+++ b/p2p/gossip/protocol.go
@@ -164,7 +164,7 @@ func (p *Protocol) handlePQ() {
 		p.Log.With().Debug("new_gossip_message_relay",
 			log.String("from", m.Sender().String()),
 			log.String("protocol", m.Protocol()),
-			log.String("hash", util.Bytes2Hex(h[:])))
+			h.Field("hash")
 		p.propagateMessage(m.Message(), h, m.Protocol(), m.Sender())
 	}
 }

--- a/p2p/gossip/protocol.go
+++ b/p2p/gossip/protocol.go
@@ -147,7 +147,7 @@ func (p *Protocol) handlePQ() {
 	for {
 		mi, err := p.pq.Read()
 		if err != nil {
-			p.With().Info("priority queue was closed, existing", log.Err(err))
+			p.With().Info("priority queue was closed, exiting", log.Err(err))
 			return
 		}
 		m, ok := mi.(service.MessageValidation)

--- a/p2p/p2pcrypto/crypto.go
+++ b/p2p/p2pcrypto/crypto.go
@@ -23,6 +23,7 @@ type Key interface {
 	raw() *[keySize]byte
 	Array() [32]byte
 	String() string
+	Field(key string) log.Field
 }
 
 // PrivateKey is a private key of 32 byte.
@@ -67,6 +68,11 @@ func (k key) Bytes() []byte {
 // String returns a base58 encoded string from the key.
 func (k key) String() string {
 	return base58.Encode(k.Bytes())
+}
+
+// Field returns a log field. Implements the LoggableField interface.
+func (k key) Field(key string) log.Field {
+	return log.String(key, k.String())
 }
 
 func getRandomNonce() [nonceSize]byte {

--- a/p2p/server/msgserver.go
+++ b/p2p/server/msgserver.go
@@ -220,7 +220,8 @@ func (p *MessageServer) SendRequest(msgType MessageType, payload []byte, address
 		p.With().Error("sending message failed",
 			log.Uint32("msg_type", uint32(msgType)),
 			log.String("recipient", address.String()),
-			log.Int("msglen", len(payload)), log.Err(sendErr))
+			log.Int("msglen", len(payload)),
+			log.Err(sendErr))
 		p.removeFromPending(reqID)
 		return sendErr
 	}

--- a/p2p/server/msgserver.go
+++ b/p2p/server/msgserver.go
@@ -12,7 +12,7 @@ import (
 	"time"
 )
 
-// MessageType is an int32 used to distinguish between server messages inside a single protocol.
+// MessageType is a uint32 used to distinguish between server messages inside a single protocol.
 type MessageType uint32
 
 // Message is helper type for `MessegeServer` messages.
@@ -217,7 +217,10 @@ func (p *MessageServer) SendRequest(msgType MessageType, payload []byte, address
 	p.pendMutex.Unlock()
 	msg := &service.DataMsgWrapper{Req: true, ReqID: reqID, MsgType: uint32(msgType), Payload: payload}
 	if sendErr := p.network.SendWrappedMessage(address, p.name, msg); sendErr != nil {
-		p.Error("sending message failed ", msg, " error: ", sendErr)
+		p.With().Error("sending message failed",
+			log.Uint32("msg_type", uint32(msgType)),
+			log.String("recipient", address.String()),
+			log.Int("msglen", len(payload)), log.Err(sendErr))
 		p.removeFromPending(reqID)
 		return sendErr
 	}

--- a/p2p/server/msgserver.go
+++ b/p2p/server/msgserver.go
@@ -219,7 +219,7 @@ func (p *MessageServer) SendRequest(msgType MessageType, payload []byte, address
 	if sendErr := p.network.SendWrappedMessage(address, p.name, msg); sendErr != nil {
 		p.With().Error("sending message failed",
 			log.Uint32("msg_type", uint32(msgType)),
-			log.String("recipient", address.String()),
+			address.Field("recipient"),
 			log.Int("msglen", len(payload)),
 			log.Err(sendErr))
 		p.removeFromPending(reqID)

--- a/p2p/server/msgserver.go
+++ b/p2p/server/msgserver.go
@@ -124,11 +124,11 @@ func (p *MessageServer) cleanStaleMessages() {
 				p.Debug("cleanStaleMessages remove request ", item.id)
 				p.removeFromPending(item.id)
 			} else {
-				p.Debug("cleanStaleMessages no more stale messages ")
+				p.Debug("cleanStaleMessages no more stale messages")
 				return
 			}
 		} else {
-			p.Debug("cleanStaleMessages queue empty ")
+			p.Debug("cleanStaleMessages queue empty")
 			return
 		}
 	}

--- a/p2p/server/msgserver_test.go
+++ b/p2p/server/msgserver_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/p2p/config"
+	"github.com/spacemeshos/go-spacemesh/p2p/p2pcrypto"
 	"github.com/spacemeshos/go-spacemesh/p2p/service"
 	"github.com/stretchr/testify/assert"
 	"testing"
@@ -40,6 +41,11 @@ func TestProtocol_SendRequest(t *testing.T) {
 
 	assert.EqualValues(t, "some value to return", msg, "value received did not match correct value")
 	assert.NoError(t, err, "Should not return error")
+
+	// Now try sending to a bad address
+	_, randkey, _ := p2pcrypto.GenerateKeyPair()
+	err = fnd2.SendRequest(1, nil, randkey, callback)
+	assert.Error(t, err, "Sending to bad address should return error")
 }
 
 func TestProtocol_CleanOldPendingMessages(t *testing.T) {

--- a/p2p/server/msgserver_test.go
+++ b/p2p/server/msgserver_test.go
@@ -43,7 +43,7 @@ func TestProtocol_SendRequest(t *testing.T) {
 	assert.NoError(t, err, "Should not return error")
 
 	// Now try sending to a bad address
-	_, randkey, _ := p2pcrypto.GenerateKeyPair()
+	randkey := p2pcrypto.NewRandomPubkey()
 	err = fnd2.SendRequest(1, nil, randkey, callback)
 	assert.Error(t, err, "Sending to bad address should return error")
 }

--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -294,7 +294,8 @@ func (s *Switch) Start() error {
 			size := s.discover.Size()
 			s.logger.Event().Info("discovery_bootstrap",
 				log.Bool("success", size >= s.config.SwarmConfig.RandomConnections && s.bootErr == nil),
-				log.Int("size", size), log.Duration("time_elapsed", time.Since(b)))
+				log.Int("size", size),
+				log.Duration("time_elapsed", time.Since(b)))
 		}()
 	}
 

--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -292,7 +292,8 @@ func (s *Switch) Start() error {
 			}
 			close(s.bootChan)
 			size := s.discover.Size()
-			s.logger.Event().Info("discovery_bootstrap", log.Bool("success", size >= s.config.SwarmConfig.RandomConnections && s.bootErr == nil),
+			s.logger.Event().Info("discovery_bootstrap",
+				log.Bool("success", size >= s.config.SwarmConfig.RandomConnections && s.bootErr == nil),
 				log.Int("size", size), log.Duration("time_elapsed", time.Since(b)))
 		}()
 	}
@@ -507,9 +508,9 @@ func (s *Switch) listenToNetworkMessages() {
 
 var (
 	// ErrBadFormat1 could'nt deserialize the payload
-	ErrBadFormat1 = errors.New("bad msg format, could'nt deserialize 1")
+	ErrBadFormat1 = errors.New("bad msg format, couldn't deserialize 1")
 	// ErrBadFormat2 could'nt deserialize the protocol message payload
-	ErrBadFormat2 = errors.New("bad msg format, could'nt deserialize 2")
+	ErrBadFormat2 = errors.New("bad msg format, couldn't deserialize 2")
 	// ErrOutOfSync is returned when message timestamp was out of sync
 	ErrOutOfSync = errors.New("received out of sync msg")
 	// ErrFailDecrypt session cant decrypt
@@ -570,7 +571,7 @@ func (s *Switch) onRemoteClientMessage(msg net.IncomingMessageEvent) error {
 	_, ok := s.gossipProtocolHandlers[pm.Metadata.NextProtocol]
 	s.protocolHandlerMutex.RUnlock()
 
-	s.logger.Debug("Handle %v message from <<  %v", pm.Metadata.NextProtocol, msg.Conn.RemotePublicKey().String())
+	s.logger.Debug("Handle %v message from << %v", pm.Metadata.NextProtocol, msg.Conn.RemotePublicKey().String())
 
 	if ok {
 		// if this message is tagged with a gossip protocol, relay it.

--- a/p2p/udp.go
+++ b/p2p/udp.go
@@ -29,7 +29,7 @@ type udpNetwork interface {
 	SubscribeClosingConnections(f func(connection inet.ConnectionWithErr))
 }
 
-// UDPMux is a server for receiving and sending udp messages. through protocols.
+// UDPMux is a server for receiving and sending udp messages through protocols.
 type UDPMux struct {
 	logger log.Log
 

--- a/signing/signer.go
+++ b/signing/signer.go
@@ -31,7 +31,7 @@ func (p *PublicKey) Bytes() []byte {
 	if p != nil {
 		return p.pub
 	}
-	return []byte{}
+	return nil
 }
 
 // String returns the public key as a hex representation string

--- a/signing/signer.go
+++ b/signing/signer.go
@@ -20,6 +20,11 @@ func NewPublicKey(pub []byte) *PublicKey {
 	return &PublicKey{pub}
 }
 
+// Field returns a log field. Implements the LoggableField interface.
+func (p *PublicKey) Field() log.Field {
+	return log.String("public_key", p.ShortString())
+}
+
 // Bytes returns the public key as byte array
 func (p *PublicKey) Bytes() []byte {
 	// Prevent segfault if unset
@@ -29,7 +34,7 @@ func (p *PublicKey) Bytes() []byte {
 	return []byte{}
 }
 
-// String returns the public key as an hex representation string
+// String returns the public key as a hex representation string
 func (p *PublicKey) String() string {
 	return util.Bytes2Hex(p.Bytes())
 }

--- a/signing/signer.go
+++ b/signing/signer.go
@@ -22,7 +22,11 @@ func NewPublicKey(pub []byte) *PublicKey {
 
 // Bytes returns the public key as byte array
 func (p *PublicKey) Bytes() []byte {
-	return p.pub
+	// Prevent segfault if unset
+	if p != nil {
+		return p.pub
+	}
+	return []byte{}
 }
 
 // String returns the public key as an hex representation string

--- a/sync/block_listener.go
+++ b/sync/block_listener.go
@@ -91,18 +91,7 @@ func (bl *BlockListener) handleBlock(data service.GossipMessage) {
 	//set the block id when received
 	blk.Initialize()
 
-	bl.Log.With().Info("got new block",
-		blk.ID(),
-		blk.LayerIndex,
-		blk.LayerIndex.GetEpoch(bl.LayersPerEpoch),
-		log.String("sender_id", blk.MinerID().ShortString()),
-		log.Int("tx_count", len(blk.TxIDs)),
-		log.Int("atx_count", len(blk.ATXIDs)),
-		log.Int("view_edges", len(blk.ViewEdges)),
-		log.Int("vote_count", len(blk.BlockVotes)),
-		blk.ATXID,
-		log.Uint32("eligibility_counter", blk.EligibilityProof.J),
-	)
+	bl.Log.With().Info("got new block", blk.Fields()...)
 	//check if known
 	if _, err := bl.GetBlock(blk.ID()); err == nil {
 		bl.With().Info("we already know this block", log.BlockID(blk.ID().String()))

--- a/sync/fetch_queue.go
+++ b/sync/fetch_queue.go
@@ -44,7 +44,7 @@ func (fq *fetchQueue) Close() {
 func concatShortIds(items []types.Hash32) string {
 	str := ""
 	for _, i := range items {
-		str += " " + i.ShortString()
+		str += " " + i.MediumString()
 	}
 	return str
 }

--- a/sync/fetch_queue.go
+++ b/sync/fetch_queue.go
@@ -44,7 +44,7 @@ func (fq *fetchQueue) Close() {
 func concatShortIds(items []types.Hash32) string {
 	str := ""
 	for i, h := range items {
-		str += h.MediumString()
+		str += h.ShortString()
 		if i < len(items)-1 {
 			str += " "
 		}

--- a/sync/fetch_queue.go
+++ b/sync/fetch_queue.go
@@ -43,8 +43,11 @@ func (fq *fetchQueue) Close() {
 
 func concatShortIds(items []types.Hash32) string {
 	str := ""
-	for _, i := range items {
-		str += " " + i.MediumString()
+	for i, h := range items {
+		str += h.MediumString()
+		if i < len(items)-1 {
+			str += " "
+		}
 	}
 	return str
 }
@@ -78,7 +81,7 @@ func (fq *fetchQueue) work() error {
 			return fmt.Errorf("channel closed")
 		}
 
-		fq.Info("fetched %s's %s", fq.name, concatShortIds(bjb.ids))
+		fq.Info("fetched %ss %s", fq.name, concatShortIds(bjb.ids))
 		fq.handleFetch(bjb)
 		fq.Debug("next batch")
 	}

--- a/sync/handler.go
+++ b/sync/handler.go
@@ -1,7 +1,6 @@
 package sync
 
 import (
-	"fmt"
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/common/util"
 	"github.com/spacemeshos/go-spacemesh/database"
@@ -103,24 +102,24 @@ func newTxsRequestHandler(s *Syncer, logger log.Log) func(msg []byte) []byte {
 			logger.Error("Error marshalling request", err)
 			return nil
 		}
-		logger.Info("handle tx request %s", log.String("atx_ids", fmt.Sprintf("%x", txids)))
+		logger.With().Info("handle tx request", types.TxIdsField(txids))
 		txs, missingDB := s.GetTransactions(txids)
 
 		for t := range missingDB {
 			if tx, err := s.txpool.Get(t); err == nil {
 				txs = append(txs, tx)
 			} else {
-				logger.With().Warning("unfamiliar tx was requested (id: %s)", log.TxID(t.ShortString()))
+				logger.With().Warning("unfamiliar tx was requested", log.TxID(t.ShortString()))
 			}
 		}
 
 		bbytes, err := types.InterfaceToBytes(txs)
 		if err != nil {
-			logger.Error("Error marshaling transactions response message , with ids %v and err:", txs, err)
+			logger.Error("Error marshaling transactions response message, with ids %v and err:", txs, err)
 			return nil
 		}
 
-		logger.Info("send tx response ")
+		logger.Info("send tx response")
 		return bbytes
 	}
 }

--- a/sync/handler.go
+++ b/sync/handler.go
@@ -133,11 +133,7 @@ func newAtxsRequestHandler(s *Syncer, logger log.Log) func(msg []byte) []byte {
 			logger.Error("Unable to marshal request", err)
 			return nil
 		}
-		atxFields := make([]log.LoggableField, len(atxids))
-		for i, a := range atxids {
-			atxFields[i] = log.AtxID(a.ShortString())
-		}
-		logger.With().Info("handle atx request", atxFields...)
+		logger.With().Info("handle atx request", types.AtxIdsField(atxids))
 		atxs, unknownAtx := s.GetATXs(atxids)
 		for _, t := range unknownAtx {
 			if tx, err := s.atxpool.Get(t); err == nil {

--- a/sync/syncer.go
+++ b/sync/syncer.go
@@ -644,7 +644,9 @@ func (s *Syncer) validateBlockView(blk *types.Block) bool {
 		s.Error(fmt.Sprintf("block %v not syntactically valid", blk.ID()), err)
 		return false
 	} else if res == false {
-		s.With().Info("block has no missing blocks in view", log.BlockID(blk.ID().String()), log.LayerID(uint64(blk.LayerIndex)))
+		s.With().Debug("no missing blocks in view",
+			log.BlockID(blk.ID().String()),
+			log.LayerID(uint64(blk.LayerIndex)))
 		return true
 	}
 

--- a/sync/syncer.go
+++ b/sync/syncer.go
@@ -717,7 +717,12 @@ func (s *Syncer) dataAvailability(blk *types.Block) ([]*types.Transaction, []*ty
 		return nil, nil, fmt.Errorf("failed fetching block %v activation transactions %v", blk.ID(), atxerr)
 	}
 
-	s.With().Info("fetched all block data ", log.BlockID(blk.ID().String()), log.LayerID(uint64(blk.LayerIndex)))
+	s.With().Info("fetched all block data",
+		log.BlockID(blk.ID().String()),
+		log.LayerID(uint64(blk.LayerIndex)),
+		log.Int("tx_count", len(blk.TxIDs)),
+		log.Int("atx_count", len(blk.ATXIDs)),
+		types.AtxIdsField(blk.ATXIDs))
 	return txres, atxres, nil
 }
 

--- a/sync/syncer.go
+++ b/sync/syncer.go
@@ -312,9 +312,9 @@ func (s *Syncer) synchronise() {
 	defer s.syncLock.Unlock()
 	curr := s.GetCurrentLayer()
 
-	//node is synced and blocks from current layer hav already been validated
+	//node is synced and blocks from current layer have already been validated
 	if curr == s.ProcessedLayer() {
-		s.Debug("node is synced ")
+		s.Debug("node is synced")
 		// fully-synced, make sure we listen to p2p
 		s.setGossipBufferingStatus(done)
 		return
@@ -330,7 +330,9 @@ func (s *Syncer) synchronise() {
 }
 
 func (s *Syncer) handleWeaklySynced() {
-	s.With().Info("Node is weakly synced ", s.LatestLayer(), s.GetCurrentLayer())
+	s.With().Info("Node is weakly synced",
+		s.LatestLayer().Field(),
+		s.GetCurrentLayer().Field())
 
 	// handle all layers from processed+1 to current -1
 	s.handleLayersTillCurrent()
@@ -522,7 +524,7 @@ func (s *Syncer) getLayerFromNeighbors(currentSyncLayer types.LayerID) (*types.L
 
 	blocksArr, err := s.syncLayer(currentSyncLayer, blockIds)
 	if len(blocksArr) == 0 || err != nil {
-		return nil, fmt.Errorf("could not get blocks for layer  %v %v", currentSyncLayer, err)
+		return nil, fmt.Errorf("could not get blocks for layer %v %v", currentSyncLayer, err)
 	}
 
 	return types.NewExistingLayer(types.LayerID(currentSyncLayer), blocksArr), nil
@@ -540,7 +542,7 @@ func (s *Syncer) syncLayer(layerID types.LayerID, blockIds []types.BlockID) ([]*
 	if res, err := s.blockQueue.addDependencies(layerID, blockIds, foo); err != nil {
 		return nil, fmt.Errorf("failed adding layer %v blocks to queue %v", layerID, err)
 	} else if res == false {
-		s.With().Info("no missing blocks for layer", log.LayerID(layerID.Uint64()))
+		s.With().Info("no missing blocks for layer", layerID.Field())
 		return s.LayerBlocks(layerID)
 	}
 
@@ -550,7 +552,7 @@ func (s *Syncer) syncLayer(layerID types.LayerID, blockIds []types.BlockID) ([]*
 		return nil, fmt.Errorf("recived interupt")
 	case result := <-ch:
 		if !result {
-			return nil, fmt.Errorf("could not get all blocks for layer  %v", layerID)
+			return nil, fmt.Errorf("could not get all blocks for layer %v", layerID)
 		}
 	}
 

--- a/sync/syncer.go
+++ b/sync/syncer.go
@@ -542,7 +542,7 @@ func (s *Syncer) syncLayer(layerID types.LayerID, blockIds []types.BlockID) ([]*
 	if res, err := s.blockQueue.addDependencies(layerID, blockIds, foo); err != nil {
 		return nil, fmt.Errorf("failed adding layer %v blocks to queue %v", layerID, err)
 	} else if res == false {
-		s.With().Info("no missing blocks for layer", layerID.Field())
+		s.With().Info("no missing blocks for layer", layerID)
 		return s.LayerBlocks(layerID)
 	}
 

--- a/sync/syncer.go
+++ b/sync/syncer.go
@@ -717,12 +717,7 @@ func (s *Syncer) dataAvailability(blk *types.Block) ([]*types.Transaction, []*ty
 		return nil, nil, fmt.Errorf("failed fetching block %v activation transactions %v", blk.ID(), atxerr)
 	}
 
-	s.With().Info("fetched all block data",
-		log.BlockID(blk.ID().String()),
-		log.LayerID(uint64(blk.LayerIndex)),
-		log.Int("tx_count", len(blk.TxIDs)),
-		log.Int("atx_count", len(blk.ATXIDs)),
-		types.AtxIdsField(blk.ATXIDs))
+	s.With().Info("fetched all block data", blk.Fields()...)
 	return txres, atxres, nil
 }
 

--- a/sync/syncer.go
+++ b/sync/syncer.go
@@ -634,9 +634,9 @@ func (s *Syncer) validateBlockView(blk *types.Block) bool {
 	defer close(ch)
 	foo := func(res bool) error {
 		s.With().Info("view validated",
-			log.BlockID(blk.ID().String()),
+			blk.ID(),
 			log.Bool("result", res),
-			log.LayerID(uint64(blk.LayerIndex)))
+			blk.LayerIndex)
 		ch <- res
 		return nil
 	}
@@ -645,8 +645,8 @@ func (s *Syncer) validateBlockView(blk *types.Block) bool {
 		return false
 	} else if res == false {
 		s.With().Debug("no missing blocks in view",
-			log.BlockID(blk.ID().String()),
-			log.LayerID(uint64(blk.LayerIndex)))
+			blk.ID(),
+			blk.LayerIndex)
 		return true
 	}
 

--- a/sync/syncer.go
+++ b/sync/syncer.go
@@ -343,7 +343,7 @@ func (s *Syncer) handleWeaklySynced() {
 
 	//validate current layer if more than s.ValidationDelta has passed
 	if err := s.handleCurrentLayer(); err != nil {
-		s.With().Error("Node is out of synce", log.Err(err))
+		s.With().Error("Node is out of sync", log.Err(err))
 		s.setGossipBufferingStatus(pending)
 		return
 	}
@@ -377,7 +377,7 @@ func (s *Syncer) handleLayersTillCurrent() {
 	return
 }
 
-//handle the current consensus layer if its is older than s.Validation Delta
+//handle the current consensus layer if its is older than s.ValidationDelta
 func (s *Syncer) handleCurrentLayer() error {
 	curr := s.GetCurrentLayer()
 	if s.LatestLayer() == curr && time.Now().Sub(s.LayerToTime(s.LatestLayer())) > s.ValidationDelta {

--- a/sync/syncer.go
+++ b/sync/syncer.go
@@ -186,7 +186,7 @@ func NewSync(srv service.Service, layers *mesh.Mesh, txpool txMemPool, atxpool a
 	srvr.RegisterBytesMsgHandler(blockMsg, newBlockRequestHandler(layers, logger))
 	srvr.RegisterBytesMsgHandler(layerIdsMsg, newLayerBlockIdsRequestHandler(layers, logger))
 	srvr.RegisterBytesMsgHandler(txMsg, newTxsRequestHandler(s, logger))
-	srvr.RegisterBytesMsgHandler(atxMsg, newATxsRequestHandler(s, logger))
+	srvr.RegisterBytesMsgHandler(atxMsg, newAtxsRequestHandler(s, logger))
 	srvr.RegisterBytesMsgHandler(poetMsg, newPoetRequestHandler(s, logger))
 
 	return s

--- a/sync/syncer.go
+++ b/sync/syncer.go
@@ -331,8 +331,8 @@ func (s *Syncer) synchronise() {
 
 func (s *Syncer) handleWeaklySynced() {
 	s.With().Info("Node is weakly synced",
-		s.LatestLayer().Field(),
-		s.GetCurrentLayer().Field())
+		s.LatestLayer(),
+		s.GetCurrentLayer())
 
 	// handle all layers from processed+1 to current -1
 	s.handleLayersTillCurrent()

--- a/sync/syncer_test.go
+++ b/sync/syncer_test.go
@@ -1588,7 +1588,7 @@ func TestSyncer_BlockSyntacticValidation(t *testing.T) {
 	_, _, err := s.blockSyntacticValidation(b)
 	r.EqualError(err, errDupTx.Error())
 
-	for i := 0; i <= types.AtxsPerBlockLimit; i++ {
+	for i := 0; i <= miner.AtxsPerBlockLimit; i++ {
 		b.ATXIDs = append(b.ATXIDs, atx1)
 	}
 	_, _, err = s.blockSyntacticValidation(b)

--- a/sync/syncer_test.go
+++ b/sync/syncer_test.go
@@ -1588,7 +1588,7 @@ func TestSyncer_BlockSyntacticValidation(t *testing.T) {
 	_, _, err := s.blockSyntacticValidation(b)
 	r.EqualError(err, errDupTx.Error())
 
-	for i := 0; i <= miner.AtxsPerBlockLimit; i++ {
+	for i := 0; i <= types.AtxsPerBlockLimit; i++ {
 		b.ATXIDs = append(b.ATXIDs, atx1)
 	}
 	_, _, err = s.blockSyntacticValidation(b)

--- a/sync/validation_queue.go
+++ b/sync/validation_queue.go
@@ -215,7 +215,7 @@ func (vq *blockQueue) addDependencies(jobID interface{}, blks []types.BlockID, f
 		if vq.inQueue(bid) {
 			vq.reverseDepMap[bid] = append(vq.reverseDepMap[bid], jobID)
 			vq.With().Debug("adding already queued block to pending map",
-				log.BlockID(id.String()),
+				id,
 				log.String("job_id", fmt.Sprintf("%v", jobID)))
 			dependencies[bid] = struct{}{}
 		} else {
@@ -224,7 +224,7 @@ func (vq *blockQueue) addDependencies(jobID interface{}, blks []types.BlockID, f
 				// add unknown block to queue
 				vq.reverseDepMap[bid] = append(vq.reverseDepMap[bid], jobID)
 				vq.With().Debug("adding unknown block to pending map",
-					log.BlockID(id.String()),
+					id,
 					log.String("job_id", fmt.Sprintf("%v", jobID)))
 				dependencies[bid] = struct{}{}
 				idsToPush = append(idsToPush, id.AsHash32())

--- a/sync/validation_queue.go
+++ b/sync/validation_queue.go
@@ -216,7 +216,7 @@ func (vq *blockQueue) addDependencies(jobID interface{}, blks []types.BlockID, f
 			vq.reverseDepMap[bid] = append(vq.reverseDepMap[bid], jobID)
 			vq.With().Debug("adding already queued block to pending map",
 				log.BlockID(id.String()),
-				log.JobID(jobID))
+				log.String("job_id", fmt.Sprintf("%v", jobID)))
 			dependencies[bid] = struct{}{}
 		} else {
 			//	check database
@@ -225,7 +225,7 @@ func (vq *blockQueue) addDependencies(jobID interface{}, blks []types.BlockID, f
 				vq.reverseDepMap[bid] = append(vq.reverseDepMap[bid], jobID)
 				vq.With().Debug("adding unknown block to pending map",
 					log.BlockID(id.String()),
-					log.JobID(jobID))
+					log.String("job_id", fmt.Sprintf("%v", jobID)))
 				dependencies[bid] = struct{}{}
 				idsToPush = append(idsToPush, id.AsHash32())
 			}
@@ -249,12 +249,12 @@ func (vq *blockQueue) addDependencies(jobID interface{}, blks []types.BlockID, f
 	if len(idsToPush) > 0 {
 		vq.With().Debug("adding dependencies to pending queue",
 			log.Int("count", len(idsToPush)),
-			log.JobID(jobID))
+			log.String("job_id", fmt.Sprintf("%v", jobID)))
 		vq.addToPending(idsToPush)
 	}
 
 	vq.With().Debug("finished adding dependencies",
 		log.Int("count", len(dependencies)),
-		log.JobID(jobID))
+		log.String("job_id", fmt.Sprintf("%v", jobID)))
 	return true, nil
 }

--- a/sync/worker.go
+++ b/sync/worker.go
@@ -151,7 +151,10 @@ func newFetchWorker(s networker, count int, reqFactory batchRequestFactory, idsC
 				peer := p
 				remainingItems := toSlice(leftToFetch)
 				idsStr := concatShortIds(remainingItems)
-				lg.Info("send %s fetch request to Peer: %v ids: %v", name, peer.String(), idsStr)
+				lg.With().Info("send fetch request",
+					log.String("type", name),
+					log.PeerID(peer.String()),
+					log.String("ids", idsStr))
 				ch, _ := reqFactory(s, peer, remainingItems)
 				timeout := time.After(s.GetTimeout())
 				select {
@@ -159,10 +162,16 @@ func newFetchWorker(s networker, count int, reqFactory batchRequestFactory, idsC
 					lg.Debug("worker received interrupt")
 					return
 				case <-timeout:
-					lg.Error("fetch %s request to %v on %v timed out %s", name, peer.String(), idsStr)
+					lg.With().Error("fetch request timed out",
+						log.String("type", name),
+						log.PeerID(peer.String()),
+						log.String("ids", idsStr))
 				case v := <-ch:
 					if v != nil && len(v) > 0 {
-						lg.Info("Peer: %v responded to fetch %s request %s", peer.String(), name, idsStr)
+						lg.With().Info("peer responded to fetch request",
+							log.String("type", name),
+							log.PeerID(peer.String()),
+							log.String("ids", idsStr))
 						// 	remove ids from leftToFetch add to fetched
 						for _, itm := range v {
 							fetched = append(fetched, itm)

--- a/sync/worker.go
+++ b/sync/worker.go
@@ -153,7 +153,7 @@ func newFetchWorker(s networker, count int, reqFactory batchRequestFactory, idsC
 				idsStr := concatShortIds(remainingItems)
 				lg.With().Info("send fetch request",
 					log.String("type", name),
-					log.PeerID(peer.String()),
+					peer.Field("peer_id"),
 					log.String("ids", idsStr))
 				ch, _ := reqFactory(s, peer, remainingItems)
 				timeout := time.After(s.GetTimeout())
@@ -164,13 +164,13 @@ func newFetchWorker(s networker, count int, reqFactory batchRequestFactory, idsC
 				case <-timeout:
 					lg.With().Error("fetch request timed out",
 						log.String("type", name),
-						log.PeerID(peer.String()),
+						peer.Field("peer_id"),
 						log.String("ids", idsStr))
 				case v := <-ch:
 					if v != nil && len(v) > 0 {
 						lg.With().Info("peer responded to fetch request",
 							log.String("type", name),
-							log.PeerID(peer.String()),
+							peer.Field("peer_id"),
 							log.String("ids", idsStr))
 						// 	remove ids from leftToFetch add to fetched
 						for _, itm := range v {

--- a/timesync/ticker.go
+++ b/timesync/ticker.go
@@ -113,7 +113,7 @@ func (t *Ticker) Notify() (int, error) {
 	// already ticked
 	if layer <= t.lastTickedLayer {
 		t.log.With().Warning("skipping tick to avoid double ticking the same layer (time was not monotonic)",
-			log.Uint64("current", uint64(layer)), log.Uint64("last_ticked_layer", uint64(t.lastTickedLayer)))
+			log.Uint64("current_layer", uint64(layer)), log.Uint64("last_ticked_layer", uint64(t.lastTickedLayer)))
 		t.m.Unlock()
 		return 0, errNotMonotonic
 	}

--- a/tortoise/ninja_tortoise.go
+++ b/tortoise/ninja_tortoise.go
@@ -13,7 +13,7 @@ import (
 )
 
 type vec [2]int
-type patternID uint32 //this hash dose not include the layer id
+type patternID uint32 //this hash does not include the layer id
 
 const ( //Threshold
 	window          = 10
@@ -317,7 +317,7 @@ func (ni *ninjaTortoise) updateCorrectionVectors(p votingPattern, bottomOfWindow
 				ni.TCorrect[b.id()][x.ID()] = vo.Negate() //Tcorrect[b][x] = -Tvote[p][x]
 				ni.logger.Debug("update correction vector for block %s layer %s , pattern %s vote %s for block %s ", b.id(), b.layer(), p, ni.TCorrect[b.id()][x.ID()], x.ID())
 			} else {
-				ni.logger.Debug("block %s from layer %s dose'nt explicitly vote for layer %s", b.id(), b.layer(), x.Layer())
+				ni.logger.Debug("block %s from layer %s doesn't explicitly vote for layer %s", b.id(), b.layer(), x.Layer())
 			}
 		}
 		return false, nil


### PR DESCRIPTION
## Motivation
Closes #1570
Closes #1923
Closes #1973

## Changes
One minor bugfix (489089398e1170232cf89947ae9a038458d98994). The rest of the changes are cosmetic, affecting log output only.

## TODO

- [x] Fix bytes representations to something readable: `Failed sending HARE_PROTOCOL msg [123 129 185 230 148 211 148 26 48 31 95 93] to` (already fixed in 1fc34b2a9e2578570b33077cb1371e6f8d743420)
- [x] In the message `Failed sending newBlock msg [22 91 102 90 183 144 70 218 165 121 166 12] to 6S3sSsvzYv4kb2oQLsbCHae2xS5GtLKU6JvTCMMfG6uP, reason=connection was closed` the peer name is not the correct peer we failed sending the message to.
- [x] In the log could not get result for layer in range there is "error":"no result for the requested layer" The word error should not appear (#1951)
- [x] Block id is now a short string/id of 5 characters -- causes too collisions (in the logs) -- should be longer (12 char. ?)
- [x] "got new ATX" should include all possible information: similar to the info in "ATX published!" + other ATX fields (in particular `epoch_id').
- [ ] fix JSON in starting build atx in epoch %v and re-entering atx creation in epoch %v (**CAN'T FIND**)
- [x] late hare messages (late preround / "contextually invalid message") should include the node_id that sent the message. "contextually invalid" is not a good name - should be "late" / "not in time" (if too early)
- [x] we have `sending message failed %!(EXTRA *service.DataMsgWrapper=&{true 6 1 [113 169 217 46 19 216 93 89 35 103 13 132 9 97 7 74 149 179 217 161 81 4 131 209 229 113 105 88 151 40 90 48]}, string= error: , *errors.errorString=connection was closed)` as well as `peer responded with nil to poet request DFjCnmocNHoa3Kyd16LWQpFTTcRZThP1CS6vuB8WvFEj%!(EXTRA []uint8=[113 169 217 46 19 216 93 89 35 103 13 132 9 97 7 74 149 179 217 161 81 4 131 209 229 113 105 88 151 40 90 48])` should fix the presentation to something comprehensible (in all relevant places)
- [x] see also:
`handle atx request {atx_ids %!s(zapcore.FieldType=15) %!s(int64=0) [ca1cfd21703c8ed26655722c3da2f37a009ec7aeabe2131140498422af57514a b1a56aa5afc2d523f7d1c907c88bd579ecaa29d5dbfaf947cbc9d06d84c19a67 d5b4af7d28cf9df9d8ef568e843a7544cd5a78d5a1760ee91971441d851a61c9 789885c3ac2307cad568ca9fa70de707dcb434b8353fe923f396cd1180ba8647 6c34150b8a2bd843246185c3b8f84a2f15424493ce4608c0ed25426db941026a ] <nil>}`
- [x] Reward calculated appears twice in each layer
- [x] Fix `atx size %!s(int=18956)%!(EXTRA log.Field={atx_id 15 0 f6f9c <nil>})`. It is better if this is part of the "ATX published!" log
- [x] Add epoch_id to "I've created a block"
- [x] `unfamiliar atx was requested (id: %s)`, fix %s
- [x] Add duration to "finished PoST execution"
- [x] Any log about the initial post creation / proof root etc.?
- [x] the function CalcActiveSetSize should print the calculated active set size. Can write it under done calculating active set size
- [x] `block created` should have associated ATX in short string
- [x] `fetched all block data` or `adding block` should have associated ATX in short string
- [ ] already synced for layer appears every 10 seconds. Consider the benefit of printing it (**CAN'T FIND**; `node is synced`?)
- [ ] "release tick" log statement should include epoch ID and node ID (#1980)
- [x] Blocks coming by fetching (as opposed to gossip) should have all the logs as in got new block. Currently some logs are under the start handle block log (in the handleBlock() function).
- [x] got new atx should have longer ids than 5 characters (atx_id, _sender_id etc.) to prevent collisions and displaying inaccurate information. (For dashboard purposes)
 - [x] `miner %v is eligible for %d blocks on %d layers in epoch %d` should print the actual layers not just no. of blocks in this epoch
 - [ ] `new state root` printed twice per layer (won't fix: https://github.com/spacemeshos/go-spacemesh/pull/1952#issuecomment-612502720)
 - [ ] @ilans: can every log line include node_id, epoch, and layer? (#1980)
 - [x] `certificate validation duration` and `SVP validation duration` => DEBUG
 - [x] Hare prints `Should not participate` but it doesn't print anything if the node is participating in this round
 - [x] `2020-03-26T03:28:45.451Z        INFO    21f52.sync              handle tx request {atx_ids %!s(zapcore.FieldType=15) %!s(int64=0) [30783166303036303034653361383433613438653630633031393830366330646531393865...`
- [x] ALL log messages regarding messages from p2p (not local things) should include the sender's node_id.
- [x] `block has no missing blocks in view` INFO -> DEBUG
- [x] `Allocated cache and file handles`