### PR TITLE
[Merged by Bors] - Only run protobuf for one remaining folder

### DIFF
--- a/scripts/genproto.sh
+++ b/scripts/genproto.sh
@@ -32,6 +32,6 @@ grpc_gateway_path=$(go list -m -f '{{.Dir}}' github.com/grpc-ecosystem/grpc-gate
 googleapis_path="$grpc_gateway_path/third_party/googleapis"
 
 echo "Generating protobuf for api/pb"
-compile -I. -I$googleapis_path --go_out=plugins=grpc:. api/pb/*.proto
+compile -I. -I$googleapis_path --go_out=plugins=grpc:. api/pb/api.proto
 compile -I. -I$googleapis_path --grpc-gateway_out=logtostderr=true:. api/pb/api.proto
 compile -I. -I$googleapis_path --swagger_out=logtostderr=true:. api/pb/api.proto

--- a/scripts/genproto.sh
+++ b/scripts/genproto.sh
@@ -28,14 +28,10 @@ fi
 
 echo "using protoc from $protoc"
 
-protobuf_directories=$(find . -not -path ./.git/ -not -path ./.idea/ -type d -name "pb")
 grpc_gateway_path=$(go list -m -f '{{.Dir}}' github.com/grpc-ecosystem/grpc-gateway)
 googleapis_path="$grpc_gateway_path/third_party/googleapis"
 
-while read -r p; do
-  echo "Generating protobuf for $p"
-  compile -I. -I$googleapis_path --go_out=plugins=grpc:. $p/*.proto
-done <<< "$protobuf_directories"
-
+echo "Generating protobuf for api/pb"
+compile -I. -I$googleapis_path --go_out=plugins=grpc:. api/pb/*.proto
 compile -I. -I$googleapis_path --grpc-gateway_out=logtostderr=true:. api/pb/api.proto
 compile -I. -I$googleapis_path --swagger_out=logtostderr=true:. api/pb/api.proto

--- a/scripts/win/genproto.bat
+++ b/scripts/win/genproto.bat
@@ -3,7 +3,7 @@ PowerShell.exe -NoProfile -ExecutionPolicy Bypass -Command "& './scripts/win/ver
 if %ERRORLEVEL% GTR 0 exit /B 1
 
 ECHO Generating protobuf for api/pb
-%USERPROFILE%\protoc-3.6.1\bin\protoc -I%~dp1 -I %GOPATH%\src\github.com\grpc-ecosystem\grpc-gateway\third_party\googleapis --go_out=plugins=grpc:%~dp1 api\pb
+%USERPROFILE%\protoc-3.6.1\bin\protoc -I%CD%\api\pb -I %GOPATH%\src\github.com\grpc-ecosystem\grpc-gateway\third_party\googleapis --go_out=plugins=grpc:%CD%\api\pb %CD%\api\pb\api.proto
 %USERPROFILE%\protoc-3.6.1\bin\protoc -I%CD%\api\pb -I %GOPATH%\src\github.com\grpc-ecosystem\grpc-gateway\third_party\googleapis --grpc-gateway_out=logtostderr=true:%CD%\api\pb %CD%\api\pb\api.proto
 %USERPROFILE%\protoc-3.6.1\bin\protoc -I%CD%\api\pb -I %GOPATH%\src\github.com\grpc-ecosystem\grpc-gateway\third_party\googleapis --swagger_out=logtostderr=true:%CD%\api\pb %CD%\api\pb\api.proto
 

--- a/scripts/win/genproto.bat
+++ b/scripts/win/genproto.bat
@@ -2,20 +2,8 @@
 PowerShell.exe -NoProfile -ExecutionPolicy Bypass -Command "& './scripts/win/verify-protoc-gen-go.ps1'"
 if %ERRORLEVEL% GTR 0 exit /B 1
 
-setlocal enableextensions
-FOR /F "usebackq tokens=*" %%G IN (`dir /s/b *.proto ^| find "pb"`) do (
-  call :func %%G
-)
-
+ECHO Generating protobuf for api/pb
+%USERPROFILE%\protoc-3.6.1\bin\protoc -I%~dp1 -I %GOPATH%\src\github.com\grpc-ecosystem\grpc-gateway\third_party\googleapis --go_out=plugins=grpc:%~dp1 api\pb
 %USERPROFILE%\protoc-3.6.1\bin\protoc -I%CD%\api\pb -I %GOPATH%\src\github.com\grpc-ecosystem\grpc-gateway\third_party\googleapis --grpc-gateway_out=logtostderr=true:%CD%\api\pb %CD%\api\pb\api.proto
 %USERPROFILE%\protoc-3.6.1\bin\protoc -I%CD%\api\pb -I %GOPATH%\src\github.com\grpc-ecosystem\grpc-gateway\third_party\googleapis --swagger_out=logtostderr=true:%CD%\api\pb %CD%\api\pb\api.proto
 
-goto :eof
-:func
-(
-  ECHO Generating protobuf for %1
-  %USERPROFILE%\protoc-3.6.1\bin\protoc  -I%~dp1 -I %GOPATH%\src\github.com\grpc-ecosystem\grpc-gateway\third_party\googleapis --go_out=plugins=grpc:%~dp1 %1
-  exit /b
-)
-:eof
-endlocal


### PR DESCRIPTION
Don't attempt to look for other folders as we only care about one now, per @noamnelke.

## Motivation
Closes #1942

## Changes
These scripts should not attempt to find other dirs containing protobuf files. We just hardcode a single directory.

## Test Plan
N/A

Requires #1954