### PR TITLE
[Merged by Bors] - remove parallelism and added other ntp servers.

### DIFF
--- a/p2p/switch_test.go
+++ b/p2p/switch_test.go
@@ -385,12 +385,10 @@ func TestSwarm_MultipleMessagesFromMultipleSenders(t *testing.T) {
 			c, ok := pend[sender]
 			if !ok {
 				c <- errors.New("not found")
-				delete(pend, sender)
 				mu.Unlock()
 				return
 			}
 			close(c)
-			delete(pend, sender)
 			mu.Unlock()
 		}
 	}()
@@ -403,7 +401,9 @@ func TestSwarm_MultipleMessagesFromMultipleSenders(t *testing.T) {
 		_, err := p.cPool.GetConnection(p1.network.LocalAddr(), p1.lNode.PublicKey())
 		require.NoError(t, err)
 		mychan := make(chan error)
+		mu.Lock()
 		pend[p.lNode.PublicKey().String()] = mychan
+		mu.Unlock()
 		payload := []byte(RandString(10))
 		err = p.SendMessage(p1.lNode.PublicKey(), exampleProtocol, payload)
 		require.NoError(t, err)
@@ -445,13 +445,11 @@ func TestSwarm_MultipleMessagesFromMultipleSendersToMultipleProtocols(t *testing
 				mu.Lock()
 				c, ok := pend[sender]
 				if !ok {
-					c <- errors.New("not foudn")
+					c <- errors.New("not found")
 					close(c)
-					delete(pend, sender)
 					mu.Unlock()
 				}
 				close(c)
-				delete(pend, sender)
 				mu.Unlock()
 			}
 		}()
@@ -469,7 +467,6 @@ func TestSwarm_MultipleMessagesFromMultipleSendersToMultipleProtocols(t *testing
 		mu.Lock()
 		pend[p.lNode.PublicKey().String()] = mychan
 		mu.Unlock()
-
 		randProto := rand.Int31n(Protos)
 		if randProto == Protos {
 			randProto--

--- a/timesync/ntp_test.go
+++ b/timesync/ntp_test.go
@@ -2,6 +2,7 @@ package timesync
 
 import (
 	"fmt"
+	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
 
@@ -30,7 +31,7 @@ func TestNtpPacket_Time(t *testing.T) {
 	}
 
 	// This will fail when our conversion doesn't function right because ntp count 70 years more than unix
-	assert.True(t, p.Time().Year() == sysTime.Year(), "Converted and system time should be the same year")
+	assert.Equal(t, p.Time().Year(), sysTime.Year(), "Converted and system time should be the same year")
 }
 
 func generateRandomDurations() (sortableDurations, error) {
@@ -90,15 +91,9 @@ func Test_queryNtpServerZeroTime(t *testing.T) {
 		ntpFunc = ntpRequest
 	}()
 
-	errChan := make(chan error)
-	resChan := make(chan time.Duration)
-	go queryNtpServer("mock", resChan, errChan)
+	d, err := queryNtpServer("mock")
 
-	select {
-	case err := <-errChan:
-		assert.NotNil(t, err)
-	case <-time.After(1 * time.Second):
-		assert.Fail(t, "error not received")
-	}
+	require.Error(t, err)
+	require.Equal(t, d, zeroDuration)
 
 }


### PR DESCRIPTION
## Motivation

```
Apr 5, 2020 @ 13:20:22.815 System time couldn't synchronize System clock is 351395h26m47.566704091s away from NTP servers. please synchronize your OS 
Apr 5, 2020 @ 13:20:22.815 ntp check from server 1.pool.ntp.org, drift: 1054186h20m22.708783068s, start_check: 2020-04-05 10:20:22.708793188 +0000 UTC, latency: 20.24µs, rsp: 1900-01-01 00:00:00 +0000 UTC
Apr 5, 2020 @ 13:20:22.738 ntp check from server 0.pool.ntp.org, drift: 1054186h20m22.709934637s, start_check: 2020-04-05 10:20:22.709943147 +0000 UTC, latency: 17.02µs, rsp: 1900-01-01 00:00:00 +0000 UTC
```

The `pool` ntp servers seemed to give some weird errors quite frequently.

## Changes

 I removed the parallelism from the call to ntp since it is not really needed and added some new ntp servers instead. 

## Test Plan
changed tests accordingly.