### PR TITLE
[Merged by Bors] - removed dockertest-harness from makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -250,9 +250,6 @@ endif
 dockertest-sync: dockerbuild-test dockerrun-sync
 .PHONY: dockertest-sync
 
-dockertest-harness: dockerbuild-test dockerrun-harness
-.PHONY: dockertest-harness
-
 # command for late nodes
 
 dockerrun-late-nodes:


### PR DESCRIPTION
## Motivation
a useless code line found by @noamnelke 