### PR TITLE
[Merged by Bors] - Update join testnet instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,11 +152,12 @@ Assuming tn1.toml is a testnet config file saved in the same directory as go-spa
 ```
 
 #### Joining a Testnet (with mining)
-1. Use the CLI Wallet to create a coinbase account.
-2. Follow the steps for joining the testnet without mining but use these parameters when starting go-spacemesh:
+1. Run go-spacemesh to join a testnet without mining (see above).
+2. Run the CLI Wallet to create a coinbase account. Save your coinbase account public address - you'll need it later.
+3. Stop go-spacemesh and start it with the following params:
 
 ```bash
-./go-spacemesh --grpc-server --json-server --tcp-port [a_port] --config [tomlFileLocation] -d [nodeDataFilesPath] --coinbase [an_account] --start-mining --post-datadir [dir_for_post_data]
+./go-spacemesh --grpc-server --json-server --tcp-port [a_port] --config [tomlFileLocation] -d [nodeDataFilesPath] --coinbase [coinbase_account] --start-mining --post-datadir [dir_for_post_data]
 ```
 
 ##### Example
@@ -164,11 +165,11 @@ Assuming tn1.toml is a testnet config file saved in the same directory as go-spa
 ./go-spacemesh --grpc-server --json-server --tcp-port 7152 --config ./tn1.toml -d ./sm_data --coinbase 0x36168c60e06abbb4f5df6d1dd6a1b15655d71e75 --start-mining --post-datadir ./post_data
 ```
 
-3. Use the CLI wallet to check your coinbase account balance and to transact
+4. Use the CLI wallet to check your coinbase account balance and to transact
 
 #### Joining Spacemesh 0.1 ([TweedleDee](https://testnet.spacemesh.io/#/?id=what-is-spacemesh-01-tweedledee)) Testnet
-- Build go-spacemesh source code from this github release: [go-spacemesh 0.1.8](https://github.com/spacemeshos/go-spacemesh/releases/tag/v0.1.8).
-- Use [Testnet 0.1 (TweedleDee) Config File](http://ae7809a90692211ea8d4d0ea80dce922-597797094.us-east-1.elb.amazonaws.com/).
+1. Build go-spacemesh source code from this github release: [go-spacemesh 0.1.9](https://github.com/spacemeshos/go-spacemesh/releases/tag/v0.1.9).
+2. Follow the instructions on how to join a testnet with mining (above) and use [Testnet 0.1 (TweedleDee) Config File](http://ae7809a90692211ea8d4d0ea80dce922-597797094.us-east-1.elb.amazonaws.com/) as your node's config file.  
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ You specify these parameters by providing go-spacemesh with a toml config file. 
 Assuming tn1.toml is a testnet config file saved in the same directory as go-spacemesh, use the following command to join the testnet. The data folder will be created in the same directory as go-spacemesh. The node will use TCP port 7152 and UDP port 7152 for p2p connections:
 
 ```bash
-./go-spacemesh --grpc-server --json-server --tcp-port 7152 --config ./tn1.toml -d ./sm_data
+./go-spacemesh --grpc-server --json-server --tcp-port 7152 --config ./[tn1.toml](http://ae7809a90692211ea8d4d0ea80dce922-597797094.us-east-1.elb.amazonaws.com/) -d ./sm_data
 ```
 
 4. Build the [CLI Wallet](https://github.com/spacemeshos/CLIWallet) from source code and run it:

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ You specify these parameters by providing go-spacemesh with a toml config file. 
 Assuming tn1.toml is a testnet config file saved in the same directory as go-spacemesh, use the following command to join the testnet. The data folder will be created in the same directory as go-spacemesh. The node will use TCP port 7152 and UDP port 7152 for p2p connections:
 
 ```bash
-./go-spacemesh --grpc-server --json-server --tcp-port 7152 --config tn1.toml -d sm_data
+./go-spacemesh --grpc-server --json-server --tcp-port 7152 --config ./tn1.toml -d ./sm_data
 ```
 
 4. Build the [CLI Wallet](https://github.com/spacemeshos/CLIWallet) from source code and run it:


### PR DESCRIPTION
## Motivation
The instructions on how to join any testnet and TweedleDee in the readme were wrong. Now they are correct.

## Changes
Just readme instructions change.

## Test Plan
Tested joining TweedeleDee with the updated instructions.

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
