### PR TITLE
[Merged by Bors] - make initialization failure stop from starting.

### DIFF
--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -89,7 +89,11 @@ var Cmd = &cobra.Command{
 		app := NewSpacemeshApp()
 		defer app.Cleanup(cmd, args)
 
-		app.Initialize(cmd, args)
+		err := app.Initialize(cmd, args)
+		if err != nil {
+			log.With().Error("Failed to initialize node.", log.Err(err))
+			return
+		}
 		app.Start(cmd, args)
 	},
 }


### PR DESCRIPTION
## Motivation
Initialization can have errors, for example ntp check drift being too big. currently we're ignoring these errors and starting anyway,

## Changes

check for an error in initialization and stop if found.

## Test Plan
not needed
