### PR TITLE
[Merged by Bors] - bootstrap will stop after 10 tries even if we didn't find anything, w…

### DIFF
--- a/p2p/discovery/discovery_mock.go
+++ b/p2p/discovery/discovery_mock.go
@@ -129,7 +129,6 @@ func (m *MockPeerStore) Attempt(key p2pcrypto.PublicKey) {
 // mockAddrBook
 type mockAddrBook struct {
 	addAddressFunc func(n, src *node.Info)
-	addressCount   int
 
 	LookupFunc func(p2pcrypto.PublicKey) (*node.Info, error)
 	lookupRes  *node.Info
@@ -140,13 +139,15 @@ type mockAddrBook struct {
 
 	NeedNewAddressesFunc func() bool
 
-	AddressCacheResult []*node.Info
+	AddressCacheFunc func() []*node.Info
 
 	GoodFunc    func(key p2pcrypto.PublicKey)
 	AttemptFunc func(key p2pcrypto.PublicKey)
 
 	IsLocalAddressFunc  func(info *node.Info) bool
 	AddLocalAddressFunc func(info *node.Info)
+
+	NumAddressesFunc func() int
 }
 
 func (m *mockAddrBook) Stop() {
@@ -208,7 +209,6 @@ func (m *mockAddrBook) AddAddress(n, src *node.Info) {
 	if m.addAddressFunc != nil {
 		m.addAddressFunc(n, src)
 	}
-	m.addressCount++
 }
 
 // AddAddresses mock
@@ -216,19 +216,16 @@ func (m *mockAddrBook) AddAddresses(n []*node.Info, src *node.Info) {
 	if m.addAddressFunc != nil {
 		for _, addr := range n {
 			m.addAddressFunc(addr, src)
-			m.addressCount++
 		}
 	}
 }
 
-// AddAddressCount counts AddAddress calls
-func (m *mockAddrBook) AddAddressCount() int {
-	return m.addressCount
-}
-
 // AddressCache mock
 func (m *mockAddrBook) AddressCache() []*node.Info {
-	return m.AddressCacheResult
+	if m.AddressCacheFunc != nil {
+		return m.AddressCacheFunc()
+	}
+	return nil
 }
 
 // Lookup mock
@@ -249,8 +246,11 @@ func (m *mockAddrBook) GetAddress() *KnownAddress {
 
 // NumAddresses mock
 func (m *mockAddrBook) NumAddresses() int {
-	//todo: mockAddrBook size
-	return m.addressCount
+	//todo: mockAddrBook sizem
+	if m.NumAddressesFunc != nil {
+		return m.NumAddressesFunc()
+	}
+	return 0
 }
 
 type refresherMock struct {

--- a/p2p/discovery/protocol_test.go
+++ b/p2p/discovery/protocol_test.go
@@ -123,7 +123,9 @@ func TestFindNodeProtocol_FindNode2(t *testing.T) {
 
 	gen := generateDiscNodes(100)
 
-	n2.d.AddressCacheResult = gen
+	n2.d.AddressCacheFunc = func() []*node.Info {
+		return gen
+	}
 
 	n2.dscv.table = n2.d
 
@@ -134,7 +136,9 @@ func TestFindNodeProtocol_FindNode2(t *testing.T) {
 	//
 	gen = append(gen, generateDiscNodes(100)...)
 
-	n2.d.AddressCacheResult = gen
+	n2.d.AddressCacheFunc = func() []*node.Info {
+		return gen
+	}
 
 	n2.dscv.table = n2.d
 
@@ -151,7 +155,9 @@ func TestFindNodeProtocol_FindNode_Concurrency(t *testing.T) {
 	sim := service.NewSimulator()
 	n1 := newTestNode(sim)
 	gen := generateDiscNodes(100)
-	n1.d.AddressCacheResult = gen
+	n1.d.AddressCacheFunc = func() []*node.Info {
+		return gen
+	}
 	n1.dscv.table = n1.d
 
 	retchans := make(chan []*node.Info)

--- a/p2p/discovery/refresher.go
+++ b/p2p/discovery/refresher.go
@@ -57,7 +57,7 @@ func newRefresher(local p2pcrypto.PublicKey, book addressBook, disc pingerGetAdd
 		book:         book,
 		disc:         disc,
 		bootNodes:    bootnodes,
-		backoffFunc:  defaultbackOffFunc,
+		backoffFunc:  defaultBackoffFunc,
 		lastQueries:  make(map[p2pcrypto.PublicKey]time.Time),
 	}
 }

--- a/p2p/discovery/refresher.go
+++ b/p2p/discovery/refresher.go
@@ -21,7 +21,11 @@ const (
 	lastQueriesCacheSize = 100
 
 	maxConcurrentRequests = 3
+
+	maxTries = 10
 )
+
+var defaultbackOffFunc = func(tries int) time.Duration { return time.Second * time.Duration(tries) }
 
 // ErrBootAbort is returned when when bootstrap is canceled by context cancel
 var ErrBootAbort = errors.New("bootstrap canceled by signal")
@@ -39,6 +43,8 @@ type refresher struct {
 	book      addressBook
 	bootNodes []*node.Info
 
+	backOffFunc func(tries int) time.Duration
+
 	disc        pingerGetAddresser
 	lastQueries map[p2pcrypto.PublicKey]time.Time
 }
@@ -51,6 +57,7 @@ func newRefresher(local p2pcrypto.PublicKey, book addressBook, disc pingerGetAdd
 		book:         book,
 		disc:         disc,
 		bootNodes:    bootnodes,
+		backOffFunc:  defaultbackOffFunc,
 		lastQueries:  make(map[p2pcrypto.PublicKey]time.Time),
 	}
 }
@@ -92,11 +99,17 @@ loop:
 		wanted := numpeers
 
 		if newsize-size >= wanted {
-			r.logger.Info("Stopping bootstrap, achieved %v need %v", newsize-size, wanted)
+			r.logger.Info("Achieved bootstrap objective, got %v needed %v", newsize-size, wanted)
 			break
 		}
 
-		timer := time.NewTimer(time.Duration(tries) * time.Second) // BACKOFF
+		if tries >= maxTries && newsize >= wanted {
+			// NOTE: maybe we need to set the error here ?
+			r.logger.Info("Stopping bootstrap after %v tries, address book already contains %v peers", tries, newsize)
+			break
+		}
+
+		timer := time.NewTimer(r.backOffFunc(tries)) // BACKOFF
 
 		//todo: stop refreshes with context
 		select {

--- a/p2p/discovery/refresher.go
+++ b/p2p/discovery/refresher.go
@@ -25,7 +25,7 @@ const (
 	maxTries = 10
 )
 
-var defaultbackOffFunc = func(tries int) time.Duration { return time.Second * time.Duration(tries) }
+var defaultBackoffFunc = func(tries int) time.Duration { return time.Second * time.Duration(tries) }
 
 // ErrBootAbort is returned when when bootstrap is canceled by context cancel
 var ErrBootAbort = errors.New("bootstrap canceled by signal")
@@ -43,7 +43,7 @@ type refresher struct {
 	book      addressBook
 	bootNodes []*node.Info
 
-	backOffFunc func(tries int) time.Duration
+	backoffFunc func(tries int) time.Duration
 
 	disc        pingerGetAddresser
 	lastQueries map[p2pcrypto.PublicKey]time.Time
@@ -57,7 +57,7 @@ func newRefresher(local p2pcrypto.PublicKey, book addressBook, disc pingerGetAdd
 		book:         book,
 		disc:         disc,
 		bootNodes:    bootnodes,
-		backOffFunc:  defaultbackOffFunc,
+		backoffFunc:  defaultbackOffFunc,
 		lastQueries:  make(map[p2pcrypto.PublicKey]time.Time),
 	}
 }
@@ -109,7 +109,7 @@ loop:
 			break
 		}
 
-		timer := time.NewTimer(r.backOffFunc(tries)) // BACKOFF
+		timer := time.NewTimer(r.backoffFunc(tries)) // BACKOFF
 
 		//todo: stop refreshes with context
 		select {

--- a/p2p/discovery/refresher_test.go
+++ b/p2p/discovery/refresher_test.go
@@ -248,10 +248,11 @@ func TestRefresher_BootstrapTries(t *testing.T) {
 	ref.backOffFunc = func(tries int) time.Duration {
 		return 80 * time.Millisecond
 	}
-	ctx, _ := context.WithTimeout(context.Background(), time.Second*1)
+	ctx, c := context.WithTimeout(context.Background(), time.Second*1)
 	err := ref.Bootstrap(ctx, 10)
 	require.EqualError(t, err, ErrBootAbort.Error())
 	require.True(t, counter > maxTries) // we got more than maxtries because we have no preloaded peers
+	c()
 
 	// Test refresher keeps going when we loaded less then required
 
@@ -264,10 +265,11 @@ func TestRefresher_BootstrapTries(t *testing.T) {
 		return generateDiscNodes(1)
 	}
 
-	ctx, _ = context.WithTimeout(context.Background(), time.Second*1)
+	ctx, c1 := context.WithTimeout(context.Background(), time.Second*1)
 	err = ref.Bootstrap(ctx, 10)
 	require.EqualError(t, err, ErrBootAbort.Error())
 	require.True(t, counter > maxTries)
+	c1()
 
 	ref.backOffFunc = func(tries int) time.Duration {
 		return 0
@@ -282,9 +284,10 @@ func TestRefresher_BootstrapTries(t *testing.T) {
 		return generateDiscNodes(10)
 	}
 
-	ctx, _ = context.WithTimeout(context.Background(), time.Second*1)
+	ctx, c2 := context.WithTimeout(context.Background(), time.Second*1)
 	err = ref.Bootstrap(ctx, 10)
 	require.NoError(t, err)
 	require.True(t, counter == maxTries) // we got more than maxtries because we have no preloaded peers
+	c2()
 
 }

--- a/p2p/discovery/refresher_test.go
+++ b/p2p/discovery/refresher_test.go
@@ -245,7 +245,7 @@ func TestRefresher_BootstrapTries(t *testing.T) {
 	}
 
 	ref := newRefresher(local.PublicKey(), &mckAddrbk, disc, boot, GetTestLogger("test.newRefresher"))
-	ref.backOffFunc = func(tries int) time.Duration {
+	ref.backoffFunc = func(tries int) time.Duration {
 		return 80 * time.Millisecond
 	}
 	ctx, c := context.WithTimeout(context.Background(), time.Second*1)
@@ -271,7 +271,7 @@ func TestRefresher_BootstrapTries(t *testing.T) {
 	require.True(t, counter > maxTries)
 	c1()
 
-	ref.backOffFunc = func(tries int) time.Duration {
+	ref.backoffFunc = func(tries int) time.Duration {
 		return 0
 	}
 	// Test refresher stops after maxTries tries when address book has exactly or more than required peers


### PR DESCRIPTION
## Motivation
We had an issue in testnet because the small number of peers, quite fast your addrbook is filled with all peers in the network and you can't find new nodes.
 currently a condition to finish bootstrap is that we found X new nodes, when you know all of them you won't find new nodes unless they join the network while you're doing this.

Closes #1997

## Changes
bootstrap will stop after 10 tries even if we didn't find anything, when the loaded addrbook is bigger than the required number of peers.

## Test Plan
added unit tests

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
