### PR TITLE
[Merged by Bors] - Append netid subfolder to data folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,10 +9,6 @@ cmd/tmp
 */**/.DS_Store
 /build
 
-#*
-.#*
-*#
-*~
 .project
 .settings
 .idea

--- a/cmd/base.go
+++ b/cmd/base.go
@@ -77,14 +77,14 @@ func setupLogging(config *bc.Config) {
 	}
 
 	// setup logging early
-	err := filesystem.ExistOrCreate(config.DataDir)
+	err := filesystem.ExistOrCreate(config.DataDir())
 	if err != nil {
 		fmt.Printf("Failed to setup spacemesh data dir")
 		log.Panic("Failed to setup spacemesh data dir", err)
 	}
 
 	// app-level logging
-	log.InitSpacemeshLoggingSystem(config.DataDir, "spacemesh.log")
+	log.InitSpacemeshLoggingSystem(config.DataDir(), "spacemesh.log")
 }
 
 func parseConfig() (*bc.Config, error) {

--- a/cmd/hare/hare.go
+++ b/cmd/hare/hare.go
@@ -142,7 +142,7 @@ func (app *HareApp) Start(cmd *cobra.Command, args []string) {
 	}
 
 	log.Info("Initializing P2P services")
-	swarm, err := p2p.New(cmdp.Ctx, app.Config.P2P, log.NewDefault("p2p_haretest"), app.Config.DataDir)
+	swarm, err := p2p.New(cmdp.Ctx, app.Config.P2P, log.NewDefault("p2p_haretest"), app.Config.DataDir())
 	app.p2p = swarm
 	if err != nil {
 		log.Panic("Error starting p2p services err=%v", err)

--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -243,7 +243,7 @@ func (app *SpacemeshApp) Initialize(cmd *cobra.Command, args []string) (err erro
 	timeCfg.TimeConfigValues = app.Config.TIME
 
 	// ensure all data folders exist
-	err = filesystem.ExistOrCreate(app.Config.DataDir)
+	err = filesystem.ExistOrCreate(app.Config.DataDir())
 	if err != nil {
 		return err
 	}
@@ -269,7 +269,7 @@ func (app *SpacemeshApp) setupLogging() {
 	}
 
 	// app-level logging
-	log.InitSpacemeshLoggingSystem(app.Config.DataDir, "spacemesh.log")
+	log.InitSpacemeshLoggingSystem(app.Config.DataDir(), "spacemesh.log")
 
 	log.Info("%s", app.getAppInfo())
 
@@ -798,9 +798,9 @@ func (app *SpacemeshApp) getIdentityFile() (string, error) {
 
 // Start starts the Spacemesh node and initializes all relevant services according to command line arguments provided.
 func (app *SpacemeshApp) Start(cmd *cobra.Command, args []string) {
-	log.With().Info("Starting Spacemesh", log.String("data-dir", app.Config.DataDir), log.String("post-dir", app.Config.POST.DataDir))
+	log.With().Info("Starting Spacemesh", log.String("data-dir", app.Config.DataDir()), log.String("post-dir", app.Config.POST.DataDir))
 
-	err := filesystem.ExistOrCreate(app.Config.DataDir)
+	err := filesystem.ExistOrCreate(app.Config.DataDir())
 	if err != nil {
 		log.Error("data-dir not found or could not be created err:%v", err)
 	}
@@ -871,7 +871,7 @@ func (app *SpacemeshApp) Start(cmd *cobra.Command, args []string) {
 	lg := log.NewDefault(nodeID.ShortString())
 
 	apiConf := &app.Config.API
-	dbStorepath := app.Config.DataDir
+	dbStorepath := app.Config.DataDir()
 	gTime, err := time.Parse(time.RFC3339, app.Config.GenesisTime)
 	if err != nil {
 		log.Error("cannot parse genesis time %v", err)

--- a/cmd/p2p/p2p.go
+++ b/cmd/p2p/p2p.go
@@ -65,7 +65,7 @@ func (app *P2PApp) Start(cmd *cobra.Command, args []string) {
 
 	logger := log.NewDefault("P2P_Test")
 
-	swarm, err := p2p.New(cmdp.Ctx, app.Config.P2P, logger, app.Config.DataDir)
+	swarm, err := p2p.New(cmdp.Ctx, app.Config.P2P, logger, app.Config.DataDir())
 	if err != nil {
 		log.Panic("Error init p2p services, err: %v", err)
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,8 +18,8 @@ func AddCommands(cmd *cobra.Command) {
 
 	cmd.PersistentFlags().StringVarP(&config.BaseConfig.ConfigFile,
 		"config", "c", config.BaseConfig.ConfigFile, "Set Load configuration from file")
-	cmd.PersistentFlags().StringVarP(&config.BaseConfig.DataDir, "data-folder", "d",
-		config.BaseConfig.DataDir, "Specify data directory for spacemesh")
+	cmd.PersistentFlags().StringVarP(&config.BaseConfig.DataDirParent, "data-folder", "d",
+		config.BaseConfig.DataDirParent, "Specify data directory for spacemesh")
 	cmd.PersistentFlags().BoolVar(&config.TestMode, "test-mode",
 		config.TestMode, "Initialize testing features")
 	cmd.PersistentFlags().BoolVar(&config.CollectMetrics, "metrics",

--- a/cmd/sync/sync.go
+++ b/cmd/sync/sync.go
@@ -32,7 +32,7 @@ var cmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("Starting sync")
 		syncApp := newSyncApp()
-		log.Info("Right after NewSyncApp %v", syncApp.Config.DataDir)
+		log.Info("Right after NewSyncApp %v", syncApp.Config.DataDir())
 		defer syncApp.Cleanup()
 		syncApp.Initialize(cmd)
 		syncApp.start(cmd, args)
@@ -73,7 +73,7 @@ func newSyncApp() *syncApp {
 }
 
 func (app *syncApp) Cleanup() {
-	err := os.RemoveAll(app.Config.DataDir)
+	err := os.RemoveAll(app.Config.DataDir())
 	if err != nil {
 		app.sync.Error("failed to cleanup sync: %v", err)
 	}
@@ -83,7 +83,7 @@ func (app *syncApp) start(cmd *cobra.Command, args []string) {
 	// start p2p services
 	lg := log.New("sync_test", "", "")
 	lg.Info("------------ Start sync test -----------")
-	lg.Info("data folder: ", app.Config.DataDir)
+	lg.Info("data folder: ", app.Config.DataDir())
 	lg.Info("storage path: ", bucket)
 	lg.Info("download from remote storage: ", remote)
 	lg.Info("expected layers: ", expectedLayers)
@@ -92,11 +92,11 @@ func (app *syncApp) start(cmd *cobra.Command, args []string) {
 	lg.Info("layers per epoch: ", app.Config.LayersPerEpoch)
 	lg.Info("hdist: ", app.Config.Hdist)
 
-	path := app.Config.DataDir + version
+	path := app.Config.DataDir() + version
 
 	lg.Info("local db path: ", path)
 
-	swarm, err := p2p.New(cmdp.Ctx, app.Config.P2P, lg.WithName("p2p"), app.Config.DataDir)
+	swarm, err := p2p.New(cmdp.Ctx, app.Config.P2P, lg.WithName("p2p"), app.Config.DataDir())
 
 	if err != nil {
 		panic("something got fudged while creating p2p service ")
@@ -114,7 +114,7 @@ func (app *syncApp) start(cmd *cobra.Command, args []string) {
 	}
 
 	if remote {
-		if err := getData(app.Config.DataDir, version, lg); err != nil {
+		if err := getData(app.Config.DataDir(), version, lg); err != nil {
 			lg.Error("could not download data for test", err)
 			return
 		}

--- a/cmd/sync/sync_test.go
+++ b/cmd/sync/sync_test.go
@@ -11,10 +11,10 @@ func TestSpacemeshApp_TestSyncCmd(t *testing.T) {
 	syncApp := newSyncApp()
 	defer syncApp.Cleanup()
 	syncApp.Initialize(cmd)
-	syncApp.Config.DataDir = "bin/data/"
+	syncApp.Config.DataDirParent = "bin/data/"
 	lg := log.New("", "", "")
 
-	if err := getData(syncApp.Config.DataDir, version, lg); err != nil {
+	if err := getData(syncApp.Config.DataDir(), version, lg); err != nil {
 		t.Error("could not download data for test", err)
 		return
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -47,6 +47,8 @@ type Config struct {
 	LOGGING         LoggerConfig          `mapstructure:"logging"`
 }
 
+// DataDir returns the absolute path to use for the node's data. This is the tilde-expanded path given in the config
+// with a subfolder named after the network ID.
 func (cfg *Config) DataDir() string {
 	return filepath.Join(filesystem.GetCanonicalPath(cfg.DataDirParent), fmt.Sprint(cfg.P2P.NetworkID))
 }

--- a/config/config.go
+++ b/config/config.go
@@ -20,10 +20,8 @@ import (
 )
 
 const (
-	defaultConfigFileName  = "./config.toml"
-	defaultLogFileName     = "spacemesh.log"
-	defaultAccountFileName = "accounts"
-	defaultDataDirName     = "spacemesh"
+	defaultConfigFileName = "./config.toml"
+	defaultDataDirName    = "spacemesh"
 	// Genesis indicates the genesis LayerID.
 	Genesis = mesh.Genesis
 	// NewBlockProtocol indicates the protocol name for new blocks arriving.
@@ -31,11 +29,9 @@ const (
 )
 
 var (
-	defaultHomeDir    = filesystem.GetUserHomeDirectory()
-	defaultDataDir    = filepath.Join(defaultHomeDir, defaultDataDirName, "/")
-	defaultLogDir     = filepath.Join(defaultHomeDir, defaultLogFileName)
-	defaultAccountDir = filepath.Join(defaultHomeDir, defaultAccountFileName)
-	defaultTestMode   = false
+	defaultHomeDir  = filesystem.GetUserHomeDirectory()
+	defaultDataDir  = filepath.Join(defaultHomeDir, defaultDataDirName, "/")
+	defaultTestMode = false
 )
 
 // Config defines the top level configuration for a spacemesh node
@@ -51,17 +47,15 @@ type Config struct {
 	LOGGING         LoggerConfig          `mapstructure:"logging"`
 }
 
+func (cfg *Config) DataDir() string {
+	return filepath.Join(filesystem.GetCanonicalPath(cfg.DataDirParent), fmt.Sprint(cfg.P2P.NetworkID))
+}
+
 // BaseConfig defines the default configuration options for spacemesh app
 type BaseConfig struct {
-	HomeDir string
-
-	DataDir string `mapstructure:"data-folder"`
+	DataDirParent string `mapstructure:"data-folder"`
 
 	ConfigFile string `mapstructure:"config"`
-
-	LogDir string `mapstructure:"log-dir"`
-
-	AccountDir string `mapstructure:"account-dir"`
 
 	TestMode bool `mapstructure:"test-mode"`
 
@@ -151,11 +145,8 @@ func DefaultConfig() Config {
 // DefaultBaseConfig returns a default configuration for spacemesh
 func defaultBaseConfig() BaseConfig {
 	return BaseConfig{
-		HomeDir:             defaultHomeDir,
-		DataDir:             defaultDataDir,
+		DataDirParent:       defaultDataDir,
 		ConfigFile:          defaultConfigFileName,
-		LogDir:              defaultLogDir,
-		AccountDir:          defaultAccountDir,
 		TestMode:            defaultTestMode,
 		CollectMetrics:      false,
 		MetricsPort:         1010,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,8 +1,10 @@
 package config
 
 import (
+	"github.com/spacemeshos/go-spacemesh/filesystem"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	"path/filepath"
 	"testing"
 )
 
@@ -10,5 +12,19 @@ func TestLoadConfig(t *testing.T) {
 	// todo: test more
 	vip := viper.New()
 	err := LoadConfig(".asdasda", vip)
-	assert.Error(t, err)
+	// verify that after attempting to load a non-existent file, an attempt is made to load the default config
+	assert.EqualError(t, err, "failed to read config file open ./config.toml: no such file or directory")
+}
+
+func TestConfig_DataDir(t *testing.T) {
+	sep := string(filepath.Separator)
+
+	config := DefaultConfig()
+	config.DataDirParent = "~" + sep + "space-a-mesh"
+	config.P2P.NetworkID = 88
+	expectedDataDir := filesystem.GetUserHomeDirectory() + sep + "space-a-mesh" + sep + "88"
+	assert.Equal(t, expectedDataDir, config.DataDir())
+
+	config.DataDirParent = "~" + sep + "space-a-mesh" + sep // trailing slash should be ignored
+	assert.Equal(t, expectedDataDir, config.DataDir())
 }

--- a/post/table_test.go
+++ b/post/table_test.go
@@ -13,7 +13,7 @@ func TestNewTable(t *testing.T) {
 
 	config := config.DefaultConfig()
 
-	table, err := NewTable(1, "test_post", config.DataDir)
+	table, err := NewTable(1, "test_post", config.DataDir())
 	assert.NoError(t, err, "expected no error")
 
 	err = table.deleteAllData()


### PR DESCRIPTION
## Motivation
Data from previous networks can accidentally pollute new test networks.

## Changes
- Append a netid subfolder to the data dir.
- Parse the configured data folder for `~` (previously a folder called `~` would be created in the local directory, which is obviously not the intended behavior).

## Test Plan
- [x] Add unit tests