### PR TITLE
[Merged by Bors] - Increase systest wait time

### DIFF
--- a/tests/block_atx/add_node/test_blocks_add_node.py
+++ b/tests/block_atx/add_node/test_blocks_add_node.py
@@ -37,7 +37,7 @@ def test_add_node_validate_atx(init_session, setup_network):
     # wait for 2 epochs
     last_layer = epochs_to_sleep * layers_per_epoch
     print(f"wait until second epoch to layer {last_layer}")
-    _ = q.wait_for_latest_layer(init_session, last_layer, layers_per_epoch)
+    _ = q.wait_for_latest_layer(init_session, last_layer, layers_per_epoch, num_miners)
 
     # ========================== epoch i+2 ==========================
     curr_epoch += epochs_to_sleep
@@ -50,7 +50,7 @@ def test_add_node_validate_atx(init_session, setup_network):
     # wait for next epoch
     last_layer = layers_per_epoch * (curr_epoch + 1)
     print(f"wait until next epoch to layer {last_layer}")
-    _ = q.wait_for_latest_layer(init_session, last_layer, layers_per_epoch)
+    _ = q.wait_for_latest_layer(init_session, last_layer, layers_per_epoch, num_miners)
 
     # ========================== epoch i+3 ==========================
     curr_epoch += 1
@@ -69,7 +69,7 @@ def test_add_node_validate_atx(init_session, setup_network):
     prev_layer = last_layer
     last_layer = layers_per_epoch * (curr_epoch + 1)
     print(f"wait until next epoch to layer {last_layer}")
-    _ = q.wait_for_latest_layer(init_session, last_layer, layers_per_epoch)
+    _ = q.wait_for_latest_layer(init_session, last_layer, layers_per_epoch, num_miners)
 
     # ========================== epoch i+4 ==========================
     curr_epoch += 1
@@ -87,7 +87,7 @@ def test_add_node_validate_atx(init_session, setup_network):
 
     last_layer = layers_per_epoch * (curr_epoch + 2)
     print(f"wait 2 epochs for layer {last_layer}")
-    _ = q.wait_for_latest_layer(init_session, last_layer, layers_per_epoch)
+    _ = q.wait_for_latest_layer(init_session, last_layer, layers_per_epoch, num_miners)
 
     # ========================== epoch i+6 ==========================
     curr_epoch += 2

--- a/tests/block_atx/add_node/test_blocks_add_node.py
+++ b/tests/block_atx/add_node/test_blocks_add_node.py
@@ -50,7 +50,7 @@ def test_add_node_validate_atx(init_session, setup_network):
     # wait for next epoch
     last_layer = layers_per_epoch * (curr_epoch + 1)
     print(f"wait until next epoch to layer {last_layer}")
-    _ = q.wait_for_latest_layer(init_session, last_layer, layers_per_epoch, num_miners)
+    _ = q.wait_for_latest_layer(init_session, last_layer, layers_per_epoch, num_miners+1)
 
     # ========================== epoch i+3 ==========================
     curr_epoch += 1
@@ -69,7 +69,7 @@ def test_add_node_validate_atx(init_session, setup_network):
     prev_layer = last_layer
     last_layer = layers_per_epoch * (curr_epoch + 1)
     print(f"wait until next epoch to layer {last_layer}")
-    _ = q.wait_for_latest_layer(init_session, last_layer, layers_per_epoch, num_miners)
+    _ = q.wait_for_latest_layer(init_session, last_layer, layers_per_epoch, num_miners+1)
 
     # ========================== epoch i+4 ==========================
     curr_epoch += 1
@@ -87,7 +87,7 @@ def test_add_node_validate_atx(init_session, setup_network):
 
     last_layer = layers_per_epoch * (curr_epoch + 2)
     print(f"wait 2 epochs for layer {last_layer}")
-    _ = q.wait_for_latest_layer(init_session, last_layer, layers_per_epoch, num_miners)
+    _ = q.wait_for_latest_layer(init_session, last_layer, layers_per_epoch, num_miners+1)
 
     # ========================== epoch i+6 ==========================
     curr_epoch += 2

--- a/tests/block_atx/remove_node/test_blocks_remove_node.py
+++ b/tests/block_atx/remove_node/test_blocks_remove_node.py
@@ -77,7 +77,7 @@ def test_remove_node_validate_atx(init_session, setup_mul_network):
     prev_layer = last_layer
     last_layer = layers_per_epoch * (curr_epoch + 1)
     print(f"-------- wait until next epoch to layer {last_layer} --------")
-    _ = q.wait_for_latest_layer(init_session, last_layer, layers_per_epoch, num_miners)
+    _ = q.wait_for_latest_layer(init_session, last_layer, layers_per_epoch, num_miners-1)
 
     # ========================== epoch i+3 ==========================
     curr_epoch += 1
@@ -95,7 +95,7 @@ def test_remove_node_validate_atx(init_session, setup_mul_network):
     prev_layer = last_layer
     last_layer = layers_per_epoch * (curr_epoch + 1)
     print(f"-------- wait until next epoch to layer {last_layer} --------")
-    _ = q.wait_for_latest_layer(init_session, last_layer, layers_per_epoch, num_miners)
+    _ = q.wait_for_latest_layer(init_session, last_layer, layers_per_epoch, num_miners-1)
 
     # ========================== epoch i+4 ==========================
     curr_epoch += 1
@@ -111,7 +111,7 @@ def test_remove_node_validate_atx(init_session, setup_mul_network):
     prev_layer = last_layer
     last_layer = layers_per_epoch * (curr_epoch + 1)
     print(f"wait until next epoch to layer {last_layer}")
-    _ = q.wait_for_latest_layer(init_session, last_layer, layers_per_epoch, num_miners)
+    _ = q.wait_for_latest_layer(init_session, last_layer, layers_per_epoch, num_miners-1)
 
     # ========================== epoch i+5 ==========================
     curr_epoch += 1
@@ -127,7 +127,7 @@ def test_remove_node_validate_atx(init_session, setup_mul_network):
     prev_layer = last_layer
     last_layer = layers_per_epoch * (curr_epoch + 1)
     print(f"wait until next epoch to layer {last_layer}")
-    _ = q.wait_for_latest_layer(init_session, last_layer, layers_per_epoch, num_miners)
+    _ = q.wait_for_latest_layer(init_session, last_layer, layers_per_epoch, num_miners-1)
 
     # ========================== epoch i+6 ==========================
     curr_epoch += 1

--- a/tests/block_atx/remove_node/test_blocks_remove_node.py
+++ b/tests/block_atx/remove_node/test_blocks_remove_node.py
@@ -50,7 +50,7 @@ def test_remove_node_validate_atx(init_session, setup_mul_network):
 
     last_layer = epochs_to_sleep * layers_per_epoch
     print(f"-------- wait until epoch number {epochs_to_sleep} to layer {last_layer} --------")
-    _ = q.wait_for_latest_layer(init_session, last_layer, layers_per_epoch)
+    _ = q.wait_for_latest_layer(init_session, last_layer, layers_per_epoch, num_miners)
 
     # ========================== epoch i+2 ==========================
     curr_epoch += epochs_to_sleep
@@ -77,7 +77,7 @@ def test_remove_node_validate_atx(init_session, setup_mul_network):
     prev_layer = last_layer
     last_layer = layers_per_epoch * (curr_epoch + 1)
     print(f"-------- wait until next epoch to layer {last_layer} --------")
-    _ = q.wait_for_latest_layer(init_session, last_layer, layers_per_epoch)
+    _ = q.wait_for_latest_layer(init_session, last_layer, layers_per_epoch, num_miners)
 
     # ========================== epoch i+3 ==========================
     curr_epoch += 1
@@ -95,7 +95,7 @@ def test_remove_node_validate_atx(init_session, setup_mul_network):
     prev_layer = last_layer
     last_layer = layers_per_epoch * (curr_epoch + 1)
     print(f"-------- wait until next epoch to layer {last_layer} --------")
-    _ = q.wait_for_latest_layer(init_session, last_layer, layers_per_epoch)
+    _ = q.wait_for_latest_layer(init_session, last_layer, layers_per_epoch, num_miners)
 
     # ========================== epoch i+4 ==========================
     curr_epoch += 1
@@ -111,7 +111,7 @@ def test_remove_node_validate_atx(init_session, setup_mul_network):
     prev_layer = last_layer
     last_layer = layers_per_epoch * (curr_epoch + 1)
     print(f"wait until next epoch to layer {last_layer}")
-    _ = q.wait_for_latest_layer(init_session, last_layer, layers_per_epoch)
+    _ = q.wait_for_latest_layer(init_session, last_layer, layers_per_epoch, num_miners)
 
     # ========================== epoch i+5 ==========================
     curr_epoch += 1
@@ -127,7 +127,7 @@ def test_remove_node_validate_atx(init_session, setup_mul_network):
     prev_layer = last_layer
     last_layer = layers_per_epoch * (curr_epoch + 1)
     print(f"wait until next epoch to layer {last_layer}")
-    _ = q.wait_for_latest_layer(init_session, last_layer, layers_per_epoch)
+    _ = q.wait_for_latest_layer(init_session, last_layer, layers_per_epoch, num_miners)
 
     # ========================== epoch i+6 ==========================
     curr_epoch += 1

--- a/tests/late_nodes/test_delayed.py
+++ b/tests/late_nodes/test_delayed.py
@@ -99,8 +99,8 @@ def test_add_delayed_nodes(init_session, add_curl, setup_bootstrap, start_poet, 
     f = int(test_config['client']['args']['hare-max-adversaries'])
 
     # validate
-    print("Waiting one layer for logs")
-    time.sleep(layer_duration)  # wait one layer for logs to propagate
+    print("Waiting 2 minutes for logs to propagate")
+    sleep_and_print(120)
 
     print("Running validation")
     expect_hare(current_index, ns, first_layer_of_last_epoch, total_layers - 1, total, f)  # validate hare

--- a/tests/queries.py
+++ b/tests/queries.py
@@ -298,7 +298,7 @@ def wait_for_latest_layer(deployment, min_layer_id, layers_per_epoch, num_miners
     while True:
         lyr = get_latest_layer(deployment, num_miners)
         print("current layer " + str(lyr))
-        if lyr >= min_layer_id and lyr % layers_per_epoch == 0:
+        if lyr is not None and lyr >= min_layer_id and lyr % layers_per_epoch == 0:
             return lyr
         time.sleep(10)
 

--- a/tests/queries.py
+++ b/tests/queries.py
@@ -287,7 +287,7 @@ def print_layer_stat(layers):
 # TODO this can be a util function
 def get_latest_layer(deployment):
     layers = get_layers(deployment)
-    layers.sort(reverse=True)
+    layers.sort()
     if len(layers) == 0:
         return 0
     return layers[0]

--- a/tests/stress/blocks_stress/test_stress_blocks.py
+++ b/tests/stress/blocks_stress/test_stress_blocks.py
@@ -14,5 +14,5 @@ def test_blocks_stress(init_session, setup_network):
     number_of_cl += 1  # add bootstrap node
 
     last_layer = layers_per_epoch * epochs_to_wait
-    layer_reached = wait_for_latest_layer(init_session, last_layer, layers_per_epoch)
+    layer_reached = wait_for_latest_layer(init_session, last_layer, layers_per_epoch, number_of_cl)
     analyse.analyze_mining(init_session, layer_reached, layers_per_epoch, layer_avg_size, number_of_cl)

--- a/tests/test_bs.py
+++ b/tests/test_bs.py
@@ -87,9 +87,9 @@ def test_mining(init_session, setup_network):
     epochs = 5
     last_layer = epochs * layers_per_epoch
 
-    layer_reached = queries.wait_for_latest_layer(testconfig["namespace"], last_layer, layers_per_epoch)
-
     total_pods = len(setup_network.clients.pods) + len(setup_network.bootstrap.pods)
+
+    layer_reached = queries.wait_for_latest_layer(testconfig["namespace"], last_layer, layers_per_epoch, total_pods)
 
     tts = 50
     sleep_print_backwards(tts)


### PR DESCRIPTION
## Motivation
Our system tests are still flaky :'(
Examples: [1](https://travis-ci.org/github/spacemeshos/go-spacemesh/jobs/692087880) [2](https://travis-ci.org/github/spacemeshos/go-spacemesh/jobs/692065871) [3](https://travis-ci.org/github/spacemeshos/go-spacemesh/jobs/692065874)

## Changes
`wait_for_latest_layer`: used to wait until at least one miner had a tick for the next epoch. Sometimes other miners' logs were slightly delayed causing failures. Now we wait until all miners reported a tick for the next epoch.

`test_add_delayed_nodes`: used to wait one layer (70 seconds) for logs. This wasn't always enough. Increased the wait time to 2 minutes.

## Test Plan
`bors try`