### PR TITLE
[Merged by Bors] - conversion naming methods convention

### DIFF
--- a/activation/activation_test.go
+++ b/activation/activation_test.go
@@ -91,7 +91,7 @@ func (n *NetMock) Broadcast(_ string, d []byte) error {
 }
 
 func (n *NetMock) hookToAtxPool(transmission []byte) {
-	if atx, err := types.BytesAsAtx(transmission); err == nil {
+	if atx, err := types.BytesToAtx(transmission); err == nil {
 		atx.CalcAndSetID()
 
 		if n.atxDb != nil {
@@ -258,7 +258,7 @@ func setActivesetSizeInCache(t *testing.T, activesetSize uint32) {
 	view, err := meshProviderMock.GetOrphanBlocksBefore(meshProviderMock.LatestLayer())
 	assert.NoError(t, err)
 	sort.Slice(view, func(i, j int) bool {
-		return bytes.Compare(view[i].ToBytes(), view[j].ToBytes()) < 0
+		return bytes.Compare(view[i].Bytes(), view[j].Bytes()) < 0
 	})
 	h := types.CalcBlocksHash12(view)
 	activesetCache.Add(h, activesetSize)
@@ -272,7 +272,7 @@ func lastTransmittedAtx(t *testing.T) types.ActivationTx {
 }
 
 func assertLastAtx(r *require.Assertions, posAtx, prevAtx *types.ActivationTxHeader, layersPerEpoch uint16) {
-	sigAtx, err := types.BytesAsAtx(net.lastTransmission)
+	sigAtx, err := types.BytesToAtx(net.lastTransmission)
 	r.NoError(err)
 
 	atx := sigAtx
@@ -339,7 +339,7 @@ func TestBuilder_PublishActivationTx_HappyFlow(t *testing.T) {
 	assertLastAtx(r, prevAtx.ActivationTxHeader, prevAtx.ActivationTxHeader, layersPerEpoch)
 
 	// create and publish another ATX
-	publishedAtx, err := types.BytesAsAtx(net.lastTransmission)
+	publishedAtx, err := types.BytesToAtx(net.lastTransmission)
 	r.NoError(err)
 	publishedAtx.CalcAndSetID()
 	published, _, err = publishAtx(b, postGenesisEpochLayer+layersPerEpoch+1, postGenesisEpoch+1, layersPerEpoch)
@@ -504,7 +504,7 @@ func TestBuilder_PublishActivationTx_DoesNotPublish2AtxsInSameEpoch(t *testing.T
 	r.True(published)
 	assertLastAtx(r, prevAtx.ActivationTxHeader, prevAtx.ActivationTxHeader, layersPerEpoch)
 
-	publishedAtx, err := types.BytesAsAtx(net.lastTransmission)
+	publishedAtx, err := types.BytesToAtx(net.lastTransmission)
 	r.NoError(err)
 	publishedAtx.CalcAndSetID()
 
@@ -514,7 +514,7 @@ func TestBuilder_PublishActivationTx_DoesNotPublish2AtxsInSameEpoch(t *testing.T
 	r.True(published)
 	assertLastAtx(r, publishedAtx.ActivationTxHeader, publishedAtx.ActivationTxHeader, layersPerEpoch)
 
-	publishedAtx2, err := types.BytesAsAtx(net.lastTransmission)
+	publishedAtx2, err := types.BytesToAtx(net.lastTransmission)
 	r.NoError(err)
 
 	r.Equal(publishedAtx.PubLayerID+layersPerEpoch, publishedAtx2.PubLayerID)
@@ -552,7 +552,7 @@ func TestBuilder_PublishActivationTx_Serialize(t *testing.T) {
 
 	bt, err := types.InterfaceToBytes(act)
 	assert.NoError(t, err)
-	a, err := types.BytesAsAtx(bt)
+	a, err := types.BytesToAtx(bt)
 	assert.NoError(t, err)
 	bt2, err := types.InterfaceToBytes(a)
 	assert.Equal(t, bt, bt2)

--- a/activation/activationdb_test.go
+++ b/activation/activationdb_test.go
@@ -340,7 +340,7 @@ func Test_CalcActiveSetFromView(t *testing.T) {
 
 	view := []types.BlockID{block2.ID(), block3.ID()}
 	sort.Slice(view, func(i, j int) bool {
-		return bytes.Compare(view[i].ToBytes(), view[j].ToBytes()) > 0 // sort view in wrong order
+		return bytes.Compare(view[i].Bytes(), view[j].Bytes()) > 0 // sort view in wrong order
 	})
 	atx2 := newActivationTx(id3, 0, *types.EmptyATXID, 1435, 0, *types.EmptyATXID, coinbase3, 6, view, &types.NIPST{})
 	num, err = atxdb.CalcActiveSetFromView(atx2.View, atx2.PubLayerID.GetEpoch(layersPerEpochBig))
@@ -357,7 +357,7 @@ func Test_CalcActiveSetFromView(t *testing.T) {
 	assert.Equal(t, 8, int(num))
 
 	// if the cache has the view in wrong order it should not be used
-	sorted := sort.SliceIsSorted(atx2.View, func(i, j int) bool { return bytes.Compare(atx2.View[i].ToBytes(), atx2.View[j].ToBytes()) > 0 })
+	sorted := sort.SliceIsSorted(atx2.View, func(i, j int) bool { return bytes.Compare(atx2.View[i].Bytes(), atx2.View[j].Bytes()) > 0 })
 	assert.True(t, sorted) // assert that the view is wrongly ordered
 	viewBytes, err := types.InterfaceToBytes(atx2.View)
 	assert.NoError(t, err)

--- a/activation/atxdb.go
+++ b/activation/atxdb.go
@@ -666,7 +666,7 @@ func (db *DB) GetFullAtx(id types.ATXID) (*types.ActivationTx, error) {
 	if err != nil {
 		return nil, err
 	}
-	atx, err := types.BytesAsAtx(atxBytes)
+	atx, err := types.BytesToAtx(atxBytes)
 	if err != nil {
 		return nil, err
 	}

--- a/api/grpc_server.go
+++ b/api/grpc_server.go
@@ -169,7 +169,7 @@ func (s SpacemeshGrpcService) GetNonce(ctx context.Context, in *pb.AccountId) (*
 func (s SpacemeshGrpcService) SubmitTransaction(ctx context.Context, in *pb.SignedTransaction) (*pb.TxConfirmation, error) {
 	log.Info("GRPC SubmitTransaction msg")
 
-	tx, err := types.BytesAsTransaction(in.Tx)
+	tx, err := types.BytesToTransaction(in.Tx)
 	if err != nil {
 		log.Error("failed to deserialize tx, error %v", err)
 		return nil, err

--- a/cmd/hare/oracle_client.go
+++ b/cmd/hare/oracle_client.go
@@ -120,7 +120,7 @@ func hashInstanceAndK(instanceID types.LayerID, K int32) uint32 {
 	kInBytes := make([]byte, 4)
 	binary.LittleEndian.PutUint32(kInBytes, uint32(K))
 	h := newHasherU32()
-	val := h.Hash(instanceID.ToBytes(), kInBytes)
+	val := h.Hash(instanceID.Bytes(), kInBytes)
 	return val
 }
 

--- a/common/types/activation.go
+++ b/common/types/activation.go
@@ -109,7 +109,7 @@ type NIPSTChallenge struct {
 
 // Hash serializes the NIPSTChallenge and returns its hash.
 func (challenge *NIPSTChallenge) Hash() (*Hash32, error) {
-	ncBytes, err := NIPSTChallengeAsBytes(challenge)
+	ncBytes, err := NIPSTChallengeToBytes(challenge)
 	if err != nil {
 		return nil, err
 	}

--- a/common/types/block.go
+++ b/common/types/block.go
@@ -26,7 +26,7 @@ func (id BlockID) Field() log.Field {
 
 // Compare returns true if other (the given BlockID) is less than this BlockID, by lexicographic comparison.
 func (id BlockID) Compare(other BlockID) bool {
-	return bytes.Compare(id.ToBytes(), other.ToBytes()) < 0
+	return bytes.Compare(id.Bytes(), other.Bytes()) < 0
 }
 
 // AsHash32 returns a Hash32 whose first 20 bytes are the bytes of this BlockID, it is right-padded with zeros.

--- a/common/types/encode.go
+++ b/common/types/encode.go
@@ -4,18 +4,19 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/nullstyle/go-xdr/xdr3"
+
+	xdr "github.com/nullstyle/go-xdr/xdr3"
 	"github.com/spacemeshos/go-spacemesh/common/util"
 )
 
-// ToBytes returns the BlockID as a byte slice.
-func (id BlockID) ToBytes() []byte { return id.AsHash32().Bytes() }
+// Bytes returns the BlockID as a byte slice.
+func (id BlockID) Bytes() []byte { return id.AsHash32().Bytes() }
 
-// ToBytes returns the byte representation of the LayerID, using little endian encoding.
-func (l LayerID) ToBytes() []byte { return util.Uint64ToBytes(uint64(l)) }
+// Bytes returns the byte representation of the LayerID, using little endian encoding.
+func (l LayerID) Bytes() []byte { return util.Uint64ToBytes(uint64(l)) }
 
-// BlockIdsAsBytes serializes a slice of BlockIDs.
-func BlockIdsAsBytes(ids []BlockID) ([]byte, error) {
+// BlockIdsToBytes serializes a slice of BlockIDs.
+func BlockIdsToBytes(ids []BlockID) ([]byte, error) {
 	var w bytes.Buffer
 	SortBlockIDs(ids)
 	if _, err := xdr.Marshal(&w, &ids); err != nil {
@@ -33,8 +34,8 @@ func BytesToBlockIds(blockIds []byte) ([]BlockID, error) {
 	return ids, nil
 }
 
-// BytesAsAtx deserializes an ActivationTx.
-func BytesAsAtx(b []byte) (*ActivationTx, error) {
+// BytesToAtx deserializes an ActivationTx.
+func BytesToAtx(b []byte) (*ActivationTx, error) {
 	buf := bytes.NewReader(b)
 	var atx ActivationTx
 	_, err := xdr.Unmarshal(buf, &atx)
@@ -44,8 +45,8 @@ func BytesAsAtx(b []byte) (*ActivationTx, error) {
 	return &atx, nil
 }
 
-// NIPSTChallengeAsBytes serializes a NIPSTChallenge.
-func NIPSTChallengeAsBytes(challenge *NIPSTChallenge) ([]byte, error) {
+// NIPSTChallengeToBytes serializes a NIPSTChallenge.
+func NIPSTChallengeToBytes(challenge *NIPSTChallenge) ([]byte, error) {
 	var w bytes.Buffer
 	if _, err := xdr.Marshal(&w, challenge); err != nil {
 		return nil, fmt.Errorf("error marshalling NIPST Challenge: %v", err)
@@ -53,8 +54,8 @@ func NIPSTChallengeAsBytes(challenge *NIPSTChallenge) ([]byte, error) {
 	return w.Bytes(), nil
 }
 
-// BytesAsTransaction deserializes a Transaction.
-func BytesAsTransaction(buf []byte) (*Transaction, error) {
+// BytesToTransaction deserializes a Transaction.
+func BytesToTransaction(buf []byte) (*Transaction, error) {
 	b := Transaction{}
 	_, err := xdr.Unmarshal(bytes.NewReader(buf), &b)
 	if err != nil {

--- a/common/types/hashes.go
+++ b/common/types/hashes.go
@@ -119,7 +119,7 @@ func CalcBlockHash32Presorted(sortedView []BlockID, additionalBytes []byte) Hash
 	hash := sha256.New()
 	hash.Write(additionalBytes)
 	for _, id := range sortedView {
-		hash.Write(id.ToBytes()) // this never returns an error: https://golang.org/pkg/hash/#Hash
+		hash.Write(id.Bytes()) // this never returns an error: https://golang.org/pkg/hash/#Hash
 	}
 	var res Hash32
 	hash.Sum(res[:0])

--- a/eligibility/fixedoracle.go
+++ b/eligibility/fixedoracle.go
@@ -157,7 +157,7 @@ func hashLayerAndRound(instanceID types.LayerID, round int32) uint32 {
 	kInBytes := make([]byte, 4)
 	binary.LittleEndian.PutUint32(kInBytes, uint32(round))
 	h := fnv.New32()
-	_, err := h.Write(instanceID.ToBytes())
+	_, err := h.Write(instanceID.Bytes())
 	_, err2 := h.Write(kInBytes)
 
 	if err != nil || err2 != nil {

--- a/hare/eligibility/beacon.go
+++ b/hare/eligibility/beacon.go
@@ -92,7 +92,7 @@ func calcValue(bids map[types.BlockID]struct{}) uint32 {
 	// calc
 	h := fnv.New32()
 	for i := 0; i < len(keys); i++ {
-		_, err := h.Write(keys[i].ToBytes())
+		_, err := h.Write(keys[i].Bytes())
 		if err != nil {
 			log.Panic("Could not calculate Beacon value. Hash write error=%v", err)
 		}

--- a/hare/hare_test.go
+++ b/hare/hare_test.go
@@ -129,7 +129,7 @@ func TestHare_GetResult(t *testing.T) {
 
 	res, err = h.GetResult(types.LayerID(0))
 	r.NoError(err)
-	r.Equal(res[0].ToBytes(), value1.ToBytes())
+	r.Equal(res[0].Bytes(), value1.Bytes())
 }
 
 func TestHare_GetResult2(t *testing.T) {
@@ -334,7 +334,7 @@ func TestHare_onTick(t *testing.T) {
 type BlockIDSlice []types.BlockID
 
 func (p BlockIDSlice) Len() int           { return len(p) }
-func (p BlockIDSlice) Less(i, j int) bool { return bytes.Compare(p[i].ToBytes(), p[j].ToBytes()) == -1 }
+func (p BlockIDSlice) Less(i, j int) bool { return bytes.Compare(p[i].Bytes(), p[j].Bytes()) == -1 }
 func (p BlockIDSlice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
 
 // Sort is a convenience method.

--- a/hare/haretypes.go
+++ b/hare/haretypes.go
@@ -169,7 +169,7 @@ func (s *Set) ToSlice() []types.BlockID {
 		keys[i] = k
 		i++
 	}
-	sort.Slice(keys, func(i, j int) bool { return bytes.Compare(keys[i].ToBytes(), keys[j].ToBytes()) == -1 })
+	sort.Slice(keys, func(i, j int) bool { return bytes.Compare(keys[i].Bytes(), keys[j].Bytes()) == -1 })
 
 	l := make([]types.BlockID, 0, len(s.values))
 	for i := range keys {
@@ -186,12 +186,12 @@ func (s *Set) updateID() {
 		keys[i] = k
 		i++
 	}
-	sort.Slice(keys, func(i, j int) bool { return bytes.Compare(keys[i].ToBytes(), keys[j].ToBytes()) == -1 })
+	sort.Slice(keys, func(i, j int) bool { return bytes.Compare(keys[i].Bytes(), keys[j].Bytes()) == -1 })
 
 	// calc
 	h := fnv.New32()
 	for i := 0; i < len(keys); i++ {
-		h.Write(keys[i].ToBytes())
+		h.Write(keys[i].Bytes())
 	}
 
 	// update

--- a/hare/haretypes_test.go
+++ b/hare/haretypes_test.go
@@ -105,6 +105,6 @@ func TestSet_ToSlice(t *testing.T) {
 	arr := []types.BlockID{value7, value1, value5, value6, value2, value3, value4}
 	s := NewSet(arr)
 	res := s.ToSlice()
-	sort.Slice(arr, func(i, j int) bool { return bytes.Compare(arr[i].ToBytes(), arr[j].ToBytes()) == -1 })
+	sort.Slice(arr, func(i, j int) bool { return bytes.Compare(arr[i].Bytes(), arr[j].Bytes()) == -1 })
 	assert.Equal(t, arr, res) // check result is sorted, required for order of set in commit msgs
 }

--- a/mesh/mesh_test.go
+++ b/mesh/mesh_test.go
@@ -485,6 +485,6 @@ func TestMesh_AddBlockWithTxs(t *testing.T) {
 
 	err := mesh.AddBlockWithTxs(blk, nil, nil)
 	r.EqualError(err, "failed to process ATXs: 💥")
-	_, err = meshDB.blocks.Get(blk.ID().ToBytes())
+	_, err = meshDB.blocks.Get(blk.ID().Bytes())
 	r.EqualError(err, "leveldb: not found")
 }

--- a/mesh/meshdb.go
+++ b/mesh/meshdb.go
@@ -225,7 +225,7 @@ func (m *DB) ForBlockInView(view map[types.BlockID]struct{}, layer types.LayerID
 
 // LayerBlockIds retrieves all block ids from a layer by layer index
 func (m *DB) LayerBlockIds(index types.LayerID) ([]types.BlockID, error) {
-	idsBytes, err := m.layers.Get(index.ToBytes())
+	idsBytes, err := m.layers.Get(index.Bytes())
 	if err != nil {
 		return nil, err
 	}
@@ -243,12 +243,12 @@ func (m *DB) LayerBlockIds(index types.LayerID) ([]types.BlockID, error) {
 }
 
 func (m *DB) getBlockBytes(id types.BlockID) ([]byte, error) {
-	return m.blocks.Get(id.ToBytes())
+	return m.blocks.Get(id.Bytes())
 }
 
 // ContextualValidity retrieves opinion on block from the database
 func (m *DB) ContextualValidity(id types.BlockID) (bool, error) {
-	b, err := m.contextualValidity.Get(id.ToBytes())
+	b, err := m.contextualValidity.Get(id.Bytes())
 	if err != nil {
 		return false, err
 	}
@@ -264,7 +264,7 @@ func (m *DB) SaveContextualValidity(id types.BlockID, valid bool) error {
 		v = constFalse
 	}
 	m.Debug("save contextual validity %v %v", id, valid)
-	return m.contextualValidity.Put(id.ToBytes(), v)
+	return m.contextualValidity.Put(id.Bytes(), v)
 }
 
 func (m *DB) writeBlock(bl *types.Block) error {
@@ -273,7 +273,7 @@ func (m *DB) writeBlock(bl *types.Block) error {
 		return fmt.Errorf("could not encode bl")
 	}
 
-	if err := m.blocks.Put(bl.ID().ToBytes(), bytes); err != nil {
+	if err := m.blocks.Put(bl.ID().Bytes(), bytes); err != nil {
 		return fmt.Errorf("could not add bl %v to database %v", bl.ID(), err)
 	}
 
@@ -289,7 +289,7 @@ func (m *DB) updateLayerWithBlock(blk *types.Block) error {
 	defer m.endLayerWorker(blk.LayerIndex)
 	lm.m.Lock()
 	defer lm.m.Unlock()
-	ids, err := m.layers.Get(blk.LayerIndex.ToBytes())
+	ids, err := m.layers.Get(blk.LayerIndex.Bytes())
 	var blockIds []types.BlockID
 	if err != nil {
 		// layer doesnt exist, need to insert new layer
@@ -302,11 +302,11 @@ func (m *DB) updateLayerWithBlock(blk *types.Block) error {
 	}
 	m.Debug("added block %v to layer %v", blk.ID(), blk.LayerIndex)
 	blockIds = append(blockIds, blk.ID())
-	w, err := types.BlockIdsAsBytes(blockIds)
+	w, err := types.BlockIdsToBytes(blockIds)
 	if err != nil {
 		return errors.New("could not encode layer blk ids")
 	}
-	m.layers.Put(blk.LayerIndex.ToBytes(), w)
+	m.layers.Put(blk.LayerIndex.Bytes(), w)
 	return nil
 }
 

--- a/miner/block_builder.go
+++ b/miner/block_builder.go
@@ -341,7 +341,7 @@ func (t *BlockBuilder) listenForTx() {
 				continue
 			}
 
-			tx, err := types.BytesAsTransaction(data.Bytes())
+			tx, err := types.BytesToTransaction(data.Bytes())
 			if err != nil {
 				t.With().Error("cannot parse incoming TX", log.Err(err))
 				continue
@@ -404,7 +404,7 @@ func (t *BlockBuilder) handleGossipAtx(data service.GossipMessage) {
 	if data == nil {
 		return
 	}
-	atx, err := types.BytesAsAtx(data.Bytes())
+	atx, err := types.BytesToAtx(data.Bytes())
 	if err != nil {
 		t.Error("cannot parse incoming ATX")
 		return

--- a/miner/builder_test.go
+++ b/miner/builder_test.go
@@ -4,7 +4,10 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/nullstyle/go-xdr/xdr3"
+	"testing"
+	"time"
+
+	xdr "github.com/nullstyle/go-xdr/xdr3"
 	"github.com/spacemeshos/go-spacemesh/activation"
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/config"
@@ -16,8 +19,6 @@ import (
 	"github.com/spacemeshos/go-spacemesh/signing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
-	"time"
 )
 
 const selectCount = 100
@@ -247,7 +248,7 @@ func TestBlockBuilder_SerializeTrans(t *testing.T) {
 	buf, err := types.InterfaceToBytes(tx)
 	assert.NoError(t, err)
 
-	ntx, err := types.BytesAsTransaction(buf)
+	ntx, err := types.BytesToTransaction(buf)
 	assert.NoError(t, err)
 	err = ntx.CalcAndSetOrigin()
 	assert.NoError(t, err)

--- a/state/processor.go
+++ b/state/processor.go
@@ -149,7 +149,7 @@ func (tp *TransactionProcessor) addStateToHistory(layer types.LayerID, newHash t
 }
 
 func getStateRootLayerKey(layer types.LayerID) []byte {
-	return append([]byte(newRootKey), layer.ToBytes()...)
+	return append([]byte(newRootKey), layer.Bytes()...)
 }
 
 func (tp *TransactionProcessor) addState(stateRoot types.Hash32, layer types.LayerID) error {
@@ -277,7 +277,7 @@ func (tp *TransactionProcessor) ApplyTransaction(trans *types.Transaction, layer
 
 	// subtract fee from account, fee will be sent to miners in layers after
 	tp.SubBalance(trans.Origin(), new(big.Int).SetUint64(trans.Fee))
-	if err := tp.processorDb.Put(trans.ID().Bytes(), layerID.ToBytes()); err != nil {
+	if err := tp.processorDb.Put(trans.ID().Bytes(), layerID.Bytes()); err != nil {
 		return fmt.Errorf("failed to add to applied txs: %v", err)
 	}
 	tp.With().Info("transaction processed", log.String("transaction", trans.String()))

--- a/sync/handler.go
+++ b/sync/handler.go
@@ -47,7 +47,7 @@ func newLayerBlockIdsRequestHandler(layers *mesh.Mesh, logger log.Log) func(msg 
 			ids = append(ids, b.ID())
 		}
 
-		idbytes, err := types.BlockIdsAsBytes(ids)
+		idbytes, err := types.BlockIdsToBytes(ids)
 		if err != nil {
 			logger.Error("Error marshaling response message, with blocks IDs: %v and error:", ids, err)
 			return nil

--- a/sync/requests.go
+++ b/sync/requests.go
@@ -34,7 +34,7 @@ func layerIdsReqFactory(lyr types.LayerID) requestFactory {
 			}
 			ch <- ids
 		}
-		if err := s.SendRequest(layerIdsMsg, lyr.ToBytes(), peer, foo); err != nil {
+		if err := s.SendRequest(layerIdsMsg, lyr.Bytes(), peer, foo); err != nil {
 			return nil, err
 		}
 		return ch, nil
@@ -58,7 +58,7 @@ func hashReqFactory(lyr types.LayerID) requestFactory {
 			h.SetBytes(msg)
 			ch <- &peerHashPair{peer: peer, hash: h}
 		}
-		if err := s.SendRequest(layerHashMsg, lyr.ToBytes(), peer, foo); err != nil {
+		if err := s.SendRequest(layerHashMsg, lyr.Bytes(), peer, foo); err != nil {
 			return nil, err
 		}
 

--- a/tortoise/ninja_tortoise.go
+++ b/tortoise/ninja_tortoise.go
@@ -278,7 +278,7 @@ func getID(bids []types.BlockID) patternID {
 	// calc
 	h := fnv.New32()
 	for i := 0; i < len(bids); i++ {
-		h.Write(bids[i].ToBytes())
+		h.Write(bids[i].Bytes())
 	}
 	// update
 	sum := h.Sum32()

--- a/turbohare/hare.go
+++ b/turbohare/hare.go
@@ -39,6 +39,6 @@ func (h *SuperHare) GetResult(id types.LayerID) ([]types.BlockID, error) {
 		log.Error("WTF SUPERHARE?? %v err: %v", id, err)
 		return nil, err
 	}
-	sort.Slice(blks, func(i, j int) bool { return bytes.Compare(blks[i].ToBytes(), blks[j].ToBytes()) == -1 })
+	sort.Slice(blks, func(i, j int) bool { return bytes.Compare(blks[i].Bytes(), blks[j].Bytes()) == -1 })
 	return blks, nil
 }


### PR DESCRIPTION
## Motivation

Closes #873

## Changes

Renamed functions in `common/types/encode.go`.
All other changed files are just impacted by rename in encode.go.

It appears that my VSCode environment re-ordered some of import statements.  Hopefully, that's not an issue.

## Test Plan

```
[sergei@mxflap go-spacemesh]$ make test
./scripts/genproto.sh
using protoc from ./devtools/bin/protoc
Generating protobuf for api/pb
ulimit -n 9999; go test -timeout 0 -p 1 ./...
?       github.com/spacemeshos/go-spacemesh     [no test files]
ok      github.com/spacemeshos/go-spacemesh/activation  (cached)
ok      github.com/spacemeshos/go-spacemesh/api (cached)
ok      github.com/spacemeshos/go-spacemesh/api/config  (cached)
?       github.com/spacemeshos/go-spacemesh/api/pb      [no test files]
?       github.com/spacemeshos/go-spacemesh/cmd [no test files]
ok      github.com/spacemeshos/go-spacemesh/cmd/hare    (cached)
?       github.com/spacemeshos/go-spacemesh/cmd/integration     [no test files]
?       github.com/spacemeshos/go-spacemesh/cmd/multi_node_sim  [no test files]
ok      github.com/spacemeshos/go-spacemesh/cmd/node    (cached)
?       github.com/spacemeshos/go-spacemesh/cmd/p2p     [no test files]
ok      github.com/spacemeshos/go-spacemesh/cmd/sync    (cached)
ok      github.com/spacemeshos/go-spacemesh/collector   (cached)
ok      github.com/spacemeshos/go-spacemesh/common/types        (cached)
ok      github.com/spacemeshos/go-spacemesh/common/util (cached)
ok      github.com/spacemeshos/go-spacemesh/config      (cached)
ok      github.com/spacemeshos/go-spacemesh/crypto      (cached)
ok      github.com/spacemeshos/go-spacemesh/crypto/sha3 (cached)
ok      github.com/spacemeshos/go-spacemesh/database    (cached)
ok      github.com/spacemeshos/go-spacemesh/eligibility (cached)
ok      github.com/spacemeshos/go-spacemesh/events      (cached)
ok      github.com/spacemeshos/go-spacemesh/filesystem  (cached)
ok      github.com/spacemeshos/go-spacemesh/hare        125.365s
?       github.com/spacemeshos/go-spacemesh/hare/config [no test files]
ok      github.com/spacemeshos/go-spacemesh/hare/eligibility    (cached)
?       github.com/spacemeshos/go-spacemesh/hare/eligibility/config     [no test files]
?       github.com/spacemeshos/go-spacemesh/hare/metrics        [no test files]
?       github.com/spacemeshos/go-spacemesh/log [no test files]
ok      github.com/spacemeshos/go-spacemesh/mesh        2.780s
ok      github.com/spacemeshos/go-spacemesh/metrics     (cached)
ok      github.com/spacemeshos/go-spacemesh/miner       (cached)
ok      github.com/spacemeshos/go-spacemesh/monitoring  (cached)
?       github.com/spacemeshos/go-spacemesh/monitoring/main     [no test files]
?       github.com/spacemeshos/go-spacemesh/nattraversal        [no test files]
?       github.com/spacemeshos/go-spacemesh/nattraversal/upnp   [no test files]
ok      github.com/spacemeshos/go-spacemesh/oracle      (cached)
ok      github.com/spacemeshos/go-spacemesh/p2p (cached)
?       github.com/spacemeshos/go-spacemesh/p2p/config  [no test files]
ok      github.com/spacemeshos/go-spacemesh/p2p/connectionpool  (cached)
ok      github.com/spacemeshos/go-spacemesh/p2p/discovery       (cached)
ok      github.com/spacemeshos/go-spacemesh/p2p/gossip  (cached)
?       github.com/spacemeshos/go-spacemesh/p2p/metrics [no test files]
ok      github.com/spacemeshos/go-spacemesh/p2p/net     (cached)
?       github.com/spacemeshos/go-spacemesh/p2p/net/wire        [no test files]
ok      github.com/spacemeshos/go-spacemesh/p2p/net/wire/delimited      (cached)
ok      github.com/spacemeshos/go-spacemesh/p2p/node    (cached)
ok      github.com/spacemeshos/go-spacemesh/p2p/p2pcrypto       (cached)
ok      github.com/spacemeshos/go-spacemesh/p2p/peers   (cached)
ok      github.com/spacemeshos/go-spacemesh/p2p/server  (cached)
?       github.com/spacemeshos/go-spacemesh/p2p/service [no test files]
ok      github.com/spacemeshos/go-spacemesh/p2p/version (cached)
ok      github.com/spacemeshos/go-spacemesh/pendingtxs  (cached)
ok      github.com/spacemeshos/go-spacemesh/post        (cached)
ok      github.com/spacemeshos/go-spacemesh/priorityq   (cached)
?       github.com/spacemeshos/go-spacemesh/prque       [no test files]
?       github.com/spacemeshos/go-spacemesh/rand        [no test files]
ok      github.com/spacemeshos/go-spacemesh/rlp (cached)
ok      github.com/spacemeshos/go-spacemesh/signing     (cached)
ok      github.com/spacemeshos/go-spacemesh/state       (cached)
ok      github.com/spacemeshos/go-spacemesh/sync        (cached)
ok      github.com/spacemeshos/go-spacemesh/timesync    (cached)
?       github.com/spacemeshos/go-spacemesh/timesync/config     [no test files]
ok      github.com/spacemeshos/go-spacemesh/tortoise    42.188s
ok      github.com/spacemeshos/go-spacemesh/trie        (cached)
?       github.com/spacemeshos/go-spacemesh/turbohare   [no test files]
```
