### PR TITLE
cleaned up log output (#2042)

### DIFF
--- a/oracle/blockoracle.go
+++ b/oracle/blockoracle.go
@@ -64,7 +64,9 @@ func (bo *MinerBlockOracle) BlockEligible(layerID types.LayerID) (types.ATXID, [
 		return types.ATXID{}, nil, fmt.Errorf("cannot calc eligibility, not synced yet")
 	}
 	epochNumber := layerID.GetEpoch(bo.layersPerEpoch)
-	bo.log.Info("asked for eligibility for epoch %d (cached: %d)", epochNumber, bo.proofsEpoch)
+	bo.log.With().Info("asked for eligibility for epoch",
+		log.EpochID(uint64(epochNumber)),
+		log.Uint64("cached_epoch", uint64(bo.proofsEpoch)))
 	if bo.proofsEpoch != epochNumber {
 		err := bo.calcEligibilityProofs(epochNumber)
 		if err != nil {


### PR DESCRIPTION
## Motivation
Closes #2042 

## Changes
cosmetic only, parameterized log statement as requested. the other statement has been fixed in: https://github.com/spacemeshos/go-spacemesh/pull/1952/files (blockoracle.go, line 76)

## Test Plan
tested for type/syntax errors in the change

## TODO
