### PR TITLE
[Merged by Bors] - Improve git diff check for CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,4 @@ spacemesh.json
 **/pb/*.swagger.json
 database/data
 *.pyc
-/devtools
+/FIXMEdevtools

--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,4 @@ spacemesh.json
 **/pb/*.swagger.json
 database/data
 *.pyc
-/FIXMEdevtools
+/devtools

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ spacemesh.json
 **/pb/*.swagger.json
 database/data
 *.pyc
+/devtools

--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ test-tidy:
 	git diff --quiet || (echo "\033[0;31mWorking directory not clean!\033[0m" && git diff && exit 1)
 	# We expect `go mod tidy` not to change anything, the test should fail otherwise
 	make tidy
-	git diff --exit-code || (git checkout . && exit 1)
+	git diff --exit-code || (git diff && git checkout . && exit 1)
 .PHONY: test-tidy
 
 
@@ -143,7 +143,7 @@ test-fmt:
 	git diff --quiet || (echo "\033[0;31mWorking directory not clean!\033[0m" && git diff && exit 1)
 	# We expect `go fmt` not to change anything, the test should fail otherwise
 	go fmt ./...
-	git diff --exit-code || (git checkout . && exit 1)
+	git diff --exit-code || (git diff && git checkout . && exit 1)
 .PHONY: test-fmt
 
 lint:

--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ test-only-app-test: genproto
 
 test-tidy:
 	# Working directory must be clean, or this test would be destructive
-	git diff --quiet || (echo "\033[0;31mWorking directory not clean!\033[0m" && exit 1)
+	git diff --quiet || (echo "\033[0;31mWorking directory not clean!\033[0m" && git diff && exit 1)
 	# We expect `go mod tidy` not to change anything, the test should fail otherwise
 	make tidy
 	git diff --exit-code || (git checkout . && exit 1)
@@ -140,7 +140,7 @@ test-tidy:
 
 
 test-fmt:
-	git diff --quiet || (echo "\033[0;31mWorking directory not clean!\033[0m" && exit 1)
+	git diff --quiet || (echo "\033[0;31mWorking directory not clean!\033[0m" && git diff && exit 1)
 	# We expect `go fmt` not to change anything, the test should fail otherwise
 	go fmt ./...
 	git diff --exit-code || (git checkout . && exit 1)


### PR DESCRIPTION
## Motivation

CI runs are failing with these errors:

```
$ make test-tidy
# Working directory must be clean, or this test would be destructive
git diff --quiet || (echo "\033[0;31mWorking directory not clean!\033[0m" && exit 1)
Working directory not clean!
Makefile:134: recipe for target 'test-tidy' failed
make: *** [test-tidy] Error 1
The command "make test-tidy" exited with 2.
0.01s$ make test-fmt
git diff --quiet || (echo "\033[0;31mWorking directory not clean!\033[0m" && exit 1)
Working directory not clean!
Makefile:143: recipe for target 'test-fmt' failed
make: *** [test-fmt] Error 1
The command "make test-fmt" exited with 2.
```

It's currently impossible to tell why they're failing. This PR fixes this issue.

The failures are not caused by the existence of untracked files, but the working directory does happen to have untracked files after running `make install`, which causes a directory called `devtools/` to appear (this was probably caused by #2001). This PR also adds this directory to gitignore.

## Changes
- Adds `git diff` to command output so it's clear why the checks fail
- Adds the directory to `.gitignore`
