### PR TITLE
[Merged by Bors] - Cleanup log fields

### DIFF
--- a/activation/atxdb.go
+++ b/activation/atxdb.go
@@ -129,7 +129,7 @@ func (db *DB) ProcessAtxs(atxs []*types.ActivationTx) error {
 			// TODO: Ensure that these are two different, syntactically valid ATXs for the same epoch, otherwise the
 			//  miner did nothing wrong
 			db.log.With().Error("found miner with multiple ATXs published in same block",
-				log.String("atx_node_id", atx.NodeID.ShortString()), log.AtxID(atx.ShortString()))
+				log.FieldNamed("atx_node_id", atx.NodeID), atx.ID())
 		}
 		err := db.ProcessAtx(atx)
 		if err != nil {
@@ -152,14 +152,14 @@ func (db *DB) ProcessAtx(atx *types.ActivationTx) error {
 		return nil
 	}
 	epoch := atx.PubLayerID.GetEpoch(db.LayersPerEpoch)
-	db.log.With().Info("processing atx", log.AtxID(atx.ShortString()), log.EpochID(uint64(epoch)),
-		log.String("atx_node_id", atx.NodeID.Key[:5]), log.LayerID(uint64(atx.PubLayerID)))
+	db.log.With().Info("processing atx", atx.ID(), epoch, log.FieldNamed("atx_node_id", atx.NodeID),
+		atx.PubLayerID)
 	err := db.ContextuallyValidateAtx(atx.ActivationTxHeader)
 	if err != nil {
-		db.log.With().Error("ATX failed contextual validation", log.AtxID(atx.ShortString()), log.Err(err))
+		db.log.With().Error("ATX failed contextual validation", atx.ID(), log.Err(err))
 		// TODO: Blacklist this miner
 	} else {
-		db.log.With().Info("ATX is valid", log.AtxID(atx.ShortString()))
+		db.log.With().Info("ATX is valid", atx.ID())
 	}
 	err = db.StoreAtx(epoch, atx)
 	if err != nil {
@@ -168,7 +168,8 @@ func (db *DB) ProcessAtx(atx *types.ActivationTx) error {
 
 	err = db.StoreNodeIdentity(atx.NodeID)
 	if err != nil {
-		db.log.With().Error("cannot store node identity", log.String("atx_node_id", atx.NodeID.ShortString()), log.AtxID(atx.ShortString()), log.Err(err))
+		db.log.With().Error("cannot store node identity", log.FieldNamed("atx_node_id", atx.NodeID),
+			atx.ID(), log.Err(err))
 	}
 	return nil
 }
@@ -192,17 +193,15 @@ func (db *DB) createTraversalActiveSetCounterFunc(countedAtxs map[string]types.A
 
 			// make sure the target epoch is our epoch
 			if atx.TargetEpoch(layersPerEpoch) != epoch {
-				db.log.With().Debug("atx found, but targeting epoch doesn't match publication epoch",
-					log.String("atx_id", atx.ShortString()),
-					log.Uint64("atx_target_epoch", uint64(atx.TargetEpoch(layersPerEpoch))),
-					log.Uint64("actual_epoch", uint64(epoch)))
+				db.log.With().Debug("atx found, but targeting epoch doesn't match publication epoch", atx.ID(),
+					log.FieldNamed("atx_target_epoch", atx.TargetEpoch(layersPerEpoch)),
+					log.FieldNamed("actual_epoch", epoch))
 				continue
 			}
 
 			// ignore atx from nodes in penalty
 			if _, exist := penalties[atx.NodeID.Key]; exist {
-				db.log.With().Debug("ignoring atx from node in penalty",
-					log.String("node_id", atx.NodeID.Key), log.String("atx_id", atx.ShortString()))
+				db.log.With().Debug("ignoring atx from node in penalty", atx.NodeID, atx.ID())
 				continue
 			}
 
@@ -210,7 +209,7 @@ func (db *DB) createTraversalActiveSetCounterFunc(countedAtxs map[string]types.A
 
 				if prevID != id { // different atx for same epoch
 					db.log.With().Error("Encountered second atx for the same miner on the same epoch",
-						log.String("first_atx", prevID.ShortString()), log.String("second_atx", id.ShortString()))
+						log.FieldNamed("first_atx", prevID), log.FieldNamed("second_atx", id))
 
 					penalties[atx.NodeID.Key] = struct{}{} // mark node in penalty
 					delete(countedAtxs, atx.NodeID.Key)    // remove the penalized node from counted
@@ -423,7 +422,7 @@ func (db *DB) SyntacticallyValidateAtx(atx *types.ActivationTx) error {
 	if err != nil {
 		return fmt.Errorf("cannot get NIPST Challenge hash: %v", err)
 	}
-	db.log.With().Info("Validated NIPST", log.String("challenge_hash", hash.String()), log.AtxID(atx.ShortString()))
+	db.log.With().Info("Validated NIPST", log.String("challenge_hash", hash.String()), atx.ID())
 
 	pubKey := signing.NewPublicKey(util.Hex2Bytes(atx.NodeID.Key))
 	if err = db.nipstValidator.Validate(*pubKey, atx.Nipst, *hash); err != nil {
@@ -439,8 +438,8 @@ func (db *DB) ContextuallyValidateAtx(atx *types.ActivationTxHeader) error {
 	if atx.PrevATXID != *types.EmptyATXID {
 		lastAtx, err := db.GetNodeLastAtxID(atx.NodeID)
 		if err != nil {
-			db.log.With().Error("could not fetch node last ATX",
-				log.AtxID(atx.ShortString()), log.String("atx_node_id", atx.NodeID.ShortString()), log.Err(err))
+			db.log.With().Error("could not fetch node last ATX", atx.ID(),
+				log.FieldNamed("atx_node_id", atx.NodeID), log.Err(err))
 			return fmt.Errorf("could not fetch node last ATX: %v", err)
 		}
 		// last atx is not the one referenced

--- a/api/grpc_server.go
+++ b/api/grpc_server.go
@@ -182,7 +182,7 @@ func (s SpacemeshGrpcService) SubmitTransaction(ctx context.Context, in *pb.Sign
 	}
 	if !s.Tx.AddressExists(tx.Origin()) {
 		log.With().Error("tx failed to validate signature",
-			log.TxID(tx.ID().ShortString()), log.String("origin", tx.Origin().Short()))
+			tx.ID(), log.String("origin", tx.Origin().Short()))
 		return nil, fmt.Errorf("transaction origin (%v) not found in global state", tx.Origin().Short())
 	}
 	if err := s.Tx.ValidateNonceAndBalance(tx); err != nil {

--- a/cmd/node/multi_node.go
+++ b/cmd/node/multi_node.go
@@ -247,7 +247,7 @@ func StartMultiNode(numOfinstances, layerAvgSize int, runTillLayer uint32, dbPat
 	if err != nil {
 		log.Error("cannot parse genesis time %v", err)
 	}
-	pubsubAddr := "tcp://localhost:56565"
+	pubsubAddr := "tcp://localhost:55666"
 	events.InitializeEventPubsub(pubsubAddr)
 	clock := NewManualClock(gTime)
 

--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -442,7 +442,7 @@ func (app *SpacemeshApp) initServices(nodeID types.NodeID,
 
 	name := nodeID.ShortString()
 
-	lg := log.NewDefault(name).WithFields(log.NodeID(name))
+	lg := log.NewDefault(name).WithFields(nodeID)
 
 	app.log = app.addLogger(AppLogger, lg)
 
@@ -612,11 +612,11 @@ func (app *SpacemeshApp) HareFactory(mdb *mesh.DB, swarm service.Service, sgn ha
 		for _, b := range ids {
 			res, err := mdb.GetBlock(b)
 			if err != nil {
-				app.log.With().Error("output set block not in database", log.BlockID(b.String()), log.Err(err))
+				app.log.With().Error("output set block not in database", b, log.Err(err))
 				return false
 			}
 			if res == nil {
-				app.log.With().Error("output set block not in database (BUG BUG BUG - GetBlock return err nil and res nil)", log.BlockID(b.String()))
+				app.log.With().Error("output set block not in database (BUG BUG BUG - GetBlock return err nil and res nil)", b)
 				return false
 			}
 

--- a/common/types/activation.go
+++ b/common/types/activation.go
@@ -189,9 +189,9 @@ func (atx *ActivationTx) Fields(layersPerEpoch uint16, size int) []log.LoggableF
 
 	return []log.LoggableField{
 		atx.ID(),
-		log.String("sender_id", atx.NodeID.ShortString()),
-		log.String("prev_atx_id", atx.PrevATXID.ShortString()),
-		log.String("pos_atx_id", atx.PositioningATX.ShortString()),
+		log.FieldNamed("sender_id", atx.NodeID),
+		log.FieldNamed("prev_atx_id", atx.PrevATXID),
+		log.FieldNamed("pos_atx_id", atx.PositioningATX),
 		atx.PubLayerID,
 		atx.PubLayerID.GetEpoch(layersPerEpoch),
 		log.Uint32("active_set", atx.ActiveSetSize),

--- a/hare/broker.go
+++ b/hare/broker.go
@@ -2,6 +2,7 @@ package hare
 
 import (
 	"errors"
+	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/p2p/service"
 	"github.com/spacemeshos/go-spacemesh/priorityq"
@@ -146,7 +147,7 @@ func (b *Broker) eventLoop() {
 		case msg := <-b.inbox:
 			if msg == nil {
 				b.With().Error("Broker message validation failed: called with nil",
-					log.Uint64("latest_layer", uint64(b.latestLayer)))
+					log.FieldNamed("latest_layer", types.LayerID(b.latestLayer)))
 				continue
 			}
 
@@ -158,28 +159,28 @@ func (b *Broker) eventLoop() {
 
 			if hareMsg.InnerMsg == nil {
 				b.With().Error("Broker message validation failed",
-					log.Err(errNilInner), log.Uint64("latest_layer", uint64(b.latestLayer)))
+					log.Err(errNilInner), log.FieldNamed("latest_layer", types.LayerID(b.latestLayer)))
 				continue
 			}
 
 			msgInstID := hareMsg.InnerMsg.InstanceID
 			// TODO: fix metrics
-			//metrics.MessageTypeCounter.With("type_id", hareMsg.InnerMsg.Type.String(), "layer", strconv.FormatUint(uint64(msgInstID), 10), "reporter", "brokerHandler").Add(1)
+			// metrics.MessageTypeCounter.With("type_id", hareMsg.InnerMsg.Type.String(), "layer", strconv.FormatUint(uint64(msgInstID), 10), "reporter", "brokerHandler").Add(1)
 			isEarly := false
 			if err := b.validate(hareMsg); err != nil {
 				if err != errEarlyMsg {
 					// not early, validation failed
 					b.With().Debug("Broker received a message to a CP that is not registered",
 						log.Err(err),
-						log.Uint64("msg_layer_id", uint64(msgInstID)),
-						log.Uint64("latest_layer", uint64(b.latestLayer)))
+						log.FieldNamed("msg_layer_id", types.LayerID(msgInstID)),
+						log.FieldNamed("latest_layer", types.LayerID(b.latestLayer)))
 					continue
 				}
 
 				b.With().Debug("early message detected",
 					log.Err(err),
-					log.Uint64("msg_layer_id", uint64(msgInstID)),
-					log.Uint64("latest_layer", uint64(b.latestLayer)))
+					log.FieldNamed("msg_layer_id", types.LayerID(msgInstID)),
+					log.FieldNamed("latest_layer", types.LayerID(b.latestLayer)))
 
 				isEarly = true
 			}
@@ -261,7 +262,7 @@ func (b *Broker) updateSynchronicity(id instanceID) {
 	// not exist means unknown, check & set
 
 	if !b.isNodeSynced() {
-		b.With().Info("Note: node is not synced. Marking layer as not synced", log.LayerID(uint64(id)))
+		b.With().Info("Note: node is not synced. Marking layer as not synced", types.LayerID(id))
 		b.syncState[id] = false // mark not synced
 		return
 	}

--- a/hare/eligibility/beacon.go
+++ b/hare/eligibility/beacon.go
@@ -61,14 +61,14 @@ func (b *Beacon) Value(layer types.LayerID) (uint32, error) {
 	v, err := b.patternProvider.ContextuallyValidBlock(sl)
 	if err != nil {
 		b.Log.With().Error("Could not get pattern ID",
-			log.Err(err), log.LayerID(uint64(layer)), log.Uint64("sl_id", uint64(sl)))
+			log.Err(err), layer, log.FieldNamed("sl_id", sl))
 		return nilVal, errors.New("could not calc Beacon value")
 	}
 
 	// notify if there are no contextually valid blocks
 	if len(v) == 0 {
 		b.Log.With().Warning("hare Beacon: zero contextually valid blocks (ignore if genesis first layers)",
-			log.LayerID(uint64(layer)), log.Uint64("sl_id", uint64(sl)))
+			layer, log.FieldNamed("sl_id", sl))
 	}
 
 	// calculate

--- a/hare/eligibility/oracle.go
+++ b/hare/eligibility/oracle.go
@@ -145,7 +145,7 @@ func (o *Oracle) buildVRFMessage(layer types.LayerID, round int32) ([]byte, erro
 	// get value from Beacon
 	v, err := o.beacon.Value(layer)
 	if err != nil {
-		o.With().Error("Could not get hare Beacon value", log.Err(err), log.LayerID(uint64(layer)), log.Int32("round", round))
+		o.With().Error("Could not get hare Beacon value", log.Err(err), layer, log.Int32("round", round))
 		o.lock.Unlock()
 		return nil, err
 	}
@@ -174,7 +174,7 @@ func (o *Oracle) activeSetSize(layer types.LayerID) (uint32, error) {
 			return uint32(o.genesisActiveSetSize), nil
 		}
 
-		o.With().Error("activeSetSize erred while calling actives func", log.Err(err), log.LayerID(uint64(layer)))
+		o.With().Error("activeSetSize erred while calling actives func", log.Err(err), layer)
 		return 0, err
 	}
 
@@ -279,19 +279,16 @@ func (o *Oracle) actives(layer types.LayerID) (map[string]struct{}, error) {
 	// no contextually valid blocks
 	if len(mp) == 0 {
 		o.With().Error("Could not calculate hare active set size: no contextually valid blocks",
-			layer,
-			log.Uint64("epoch_id", uint64(layer.GetEpoch(o.layersPerEpoch))),
-			log.Uint64("safe_layer_id", uint64(sl)),
-			log.Uint64("safe_epoch_id", uint64(safeEp)))
+			layer, layer.GetEpoch(o.layersPerEpoch),
+			log.FieldNamed("safe_layer_id", sl), log.FieldNamed("safe_epoch_id", safeEp))
 		o.lock.Unlock()
 		return nil, errNoContextualBlocks
 	}
 
 	activeMap, err := o.getActiveSet(safeEp, mp)
 	if err != nil {
-		o.With().Error("Could not retrieve active set size", log.Err(err),
-			log.Uint64("layer_id", uint64(layer)), log.Uint64("epoch_id", uint64(layer.GetEpoch(o.layersPerEpoch))),
-			log.Uint64("safe_layer_id", uint64(sl)), log.Uint64("safe_epoch_id", uint64(safeEp)))
+		o.With().Error("Could not retrieve active set size", log.Err(err), layer, layer.GetEpoch(o.layersPerEpoch),
+			log.FieldNamed("safe_layer_id", sl), log.FieldNamed("safe_epoch_id", safeEp))
 		o.lock.Unlock()
 		return nil, err
 	}
@@ -312,8 +309,7 @@ func (o *Oracle) IsIdentityActiveOnConsensusView(edID string, layer types.LayerI
 			return true, nil // all ids are active in genesis
 		}
 
-		o.With().Error("IsIdentityActiveOnConsensusView erred while calling actives func",
-			log.LayerID(uint64(layer)), log.Err(err))
+		o.With().Error("IsIdentityActiveOnConsensusView erred while calling actives func", layer, log.Err(err))
 		return false, err
 	}
 	_, exist := actives[edID]

--- a/hare/hare.go
+++ b/hare/hare.go
@@ -202,7 +202,7 @@ func (h *Hare) onTick(id types.LayerID) {
 	h.Debug("hare got tick, sleeping for %v", h.networkDelta)
 
 	if !h.broker.Synced(instanceID(id)) { // if not synced don't start consensus
-		h.With().Info("not starting hare since the node is not synced", log.LayerID(uint64(id)))
+		h.With().Info("not starting hare since the node is not synced", id)
 		return
 	}
 
@@ -222,7 +222,7 @@ func (h *Hare) onTick(id types.LayerID) {
 	// retrieve set form orphan blocks
 	blocks, err := h.msh.LayerBlockIds(h.lastLayer)
 	if err != nil {
-		h.With().Error("No blocks for consensus", log.LayerID(uint64(id)), log.Err(err))
+		h.With().Error("No blocks for consensus", id, log.Err(err))
 		return
 	}
 

--- a/hare/messagevalidation.go
+++ b/hare/messagevalidation.go
@@ -73,13 +73,13 @@ func (ev *eligibilityValidator) Validate(m *Msg) bool {
 	res, err := ev.validateRole(m)
 	if err != nil {
 		ev.With().Error("Error occurred while validating role", log.Err(err), log.String("sender_id", m.PubKey.ShortString()),
-			log.LayerID(uint64(m.InnerMsg.InstanceID)), log.String("msg_type", m.InnerMsg.Type.String()))
+			types.LayerID(m.InnerMsg.InstanceID), log.String("msg_type", m.InnerMsg.Type.String()))
 		return false
 	}
 	// verify role
 	if !res {
 		ev.With().Warning("Validate message failed: role is invalid", log.String("sender_id", m.PubKey.ShortString()),
-			log.LayerID(uint64(m.InnerMsg.InstanceID)), log.String("msg_type", m.InnerMsg.Type.String()))
+			types.LayerID(m.InnerMsg.InstanceID), log.String("msg_type", m.InnerMsg.Type.String()))
 		return false
 	}
 
@@ -223,13 +223,13 @@ func (v *syntaxContextValidator) SyntacticallyValidateMessage(m *Msg) bool {
 
 	if m.InnerMsg.Values == nil {
 		v.With().Warning("Syntax validation failed: set is nil",
-			log.String("sender_id", m.PubKey.ShortString()), log.LayerID(uint64(m.InnerMsg.InstanceID)), log.String("msg_type", m.InnerMsg.Type.String()))
+			log.String("sender_id", m.PubKey.ShortString()), types.LayerID(m.InnerMsg.InstanceID), log.String("msg_type", m.InnerMsg.Type.String()))
 		return false
 	}
 
 	if len(m.InnerMsg.Values) == 0 {
 		v.With().Warning("Syntax validation failed: set is empty",
-			log.String("sender_id", m.PubKey.ShortString()), log.LayerID(uint64(m.InnerMsg.InstanceID)), log.String("msg_type", m.InnerMsg.Type.String()))
+			log.String("sender_id", m.PubKey.ShortString()), types.LayerID(m.InnerMsg.InstanceID), log.String("msg_type", m.InnerMsg.Type.String()))
 		return false
 	}
 
@@ -342,7 +342,7 @@ func (v *syntaxContextValidator) validateSVP(msg *Msg) bool {
 		statusIter := iterationFromCounter(m.InnerMsg.K)
 		if proposalIter != statusIter { // not same iteration
 			v.With().Warning("Proposal validation failed: not same iteration",
-				log.String("sender_id", m.PubKey.ShortString()), log.LayerID(uint64(m.InnerMsg.InstanceID)),
+				log.String("sender_id", m.PubKey.ShortString()), types.LayerID(m.InnerMsg.InstanceID),
 				log.Int32("expected", proposalIter), log.Int32("actual", statusIter))
 			return false
 		}
@@ -352,7 +352,7 @@ func (v *syntaxContextValidator) validateSVP(msg *Msg) bool {
 	validators := []func(m *Msg) bool{validateStatusType, validateSameIteration, v.statusValidator}
 	if err := v.validateAggregatedMessage(msg.InnerMsg.Svp, validators); err != nil {
 		v.With().Warning("Proposal validation failed: failed to validate aggregated messages", log.Err(err),
-			log.String("sender_id", msg.PubKey.ShortString()), log.LayerID(uint64(msg.InnerMsg.InstanceID)))
+			log.String("sender_id", msg.PubKey.ShortString()), types.LayerID(msg.InnerMsg.InstanceID))
 		return false
 	}
 
@@ -369,13 +369,13 @@ func (v *syntaxContextValidator) validateSVP(msg *Msg) bool {
 	if maxKi == -1 { // type A
 		if !v.validateSVPTypeA(msg) {
 			v.Warning("Proposal validation failed: type A validation failed",
-				log.String("sender_id", msg.PubKey.ShortString()), log.LayerID(uint64(msg.InnerMsg.InstanceID)))
+				log.String("sender_id", msg.PubKey.ShortString()), types.LayerID(msg.InnerMsg.InstanceID))
 			return false
 		}
 	} else {
 		if !v.validateSVPTypeB(msg, NewSet(maxSet)) { // type B
 			v.Warning("Proposal validation failed: type B validation failed",
-				log.String("sender_id", msg.PubKey.ShortString()), log.LayerID(uint64(msg.InnerMsg.InstanceID)))
+				log.String("sender_id", msg.PubKey.ShortString()), types.LayerID(msg.InnerMsg.InstanceID))
 			return false
 		}
 	}

--- a/log/zap.go
+++ b/log/zap.go
@@ -55,6 +55,7 @@ type Field zap.Field
 // Field satisfy loggable field interface.
 func (f Field) Field() Field { return f }
 
+// FieldNamed returns a field with the provided name instead of the default.
 func FieldNamed(name string, field LoggableField) Field {
 	f := field.Field()
 	f.Key = name

--- a/log/zap.go
+++ b/log/zap.go
@@ -55,14 +55,15 @@ type Field zap.Field
 // Field satisfy loggable field interface.
 func (f Field) Field() Field { return f }
 
+func FieldNamed(name string, field LoggableField) Field {
+	f := field.Field()
+	f.Key = name
+	return f
+}
+
 // String returns a string Field
 func String(name, val string) Field {
 	return Field(zap.String(name, val))
-}
-
-// ByteString returns a byte string ([]byte) Field
-func ByteString(name string, val []byte) Field {
-	return Field(zap.ByteString(name, val))
 }
 
 // Int returns an int Field.
@@ -98,36 +99,6 @@ func Bool(name string, val bool) Field {
 // Duration returns a duration field
 func Duration(name string, val time.Duration) Field {
 	return Field(zap.Duration(name, val))
-}
-
-// LayerID returns a Uint64 field (key - "layer_id")
-func LayerID(val uint64) Field {
-	return Uint64("layer_id", val)
-}
-
-// TxID returns a String field (key - "tx_id")
-func TxID(val string) Field {
-	return String("tx_id", val)
-}
-
-// AtxID returns a String field (key - "atx_id")
-func AtxID(val string) Field {
-	return String("atx_id", val)
-}
-
-// BlockID returns a Uint64 field (key - "block_id")
-func BlockID(val string) Field {
-	return String("block_id", val)
-}
-
-// EpochID returns a Uint64 field (key - "epoch_id")
-func EpochID(val uint64) Field {
-	return Uint64("epoch_id", val)
-}
-
-// NodeID returns a String field (key - "node_id")
-func NodeID(val string) Field {
-	return String("node_id", val)
 }
 
 // Err returns an error field

--- a/mesh/mesh.go
+++ b/mesh/mesh.go
@@ -170,8 +170,8 @@ func NewRecoveredMesh(db *DB, atxDb AtxDB, rewardConfig Config, mesh tortoise, t
 	}
 
 	msh.With().Info("recovered mesh from disc",
-		log.Uint64("latest_layer", msh.latestLayer.Uint64()),
-		log.Uint64("validated_layer", msh.ProcessedLayer().Uint64()),
+		log.FieldNamed("latest_layer", msh.latestLayer),
+		log.FieldNamed("validated_layer", msh.ProcessedLayer()),
 		log.String("layer_hash", util.Bytes2Hex(msh.layerHash)),
 		log.String("root_hash", pr.GetStateRoot().String()))
 
@@ -290,7 +290,7 @@ func (msh *Mesh) pushLayersToState(oldPbase types.LayerID, newPbase types.LayerI
 		l, err := msh.GetLayer(layerID)
 		// TODO: propagate/handle error
 		if err != nil || l == nil {
-			msh.With().Error("failed to get layer", log.LayerID(layerID.Uint64()), log.Err(err))
+			msh.With().Error("failed to get layer", layerID, log.Err(err))
 			return
 		}
 		validBlocks, invalidBlocks := msh.BlocksByValidity(l.Blocks())
@@ -314,8 +314,7 @@ func (msh *Mesh) reInsertTxsToPool(validBlocks, invalidBlocks []*types.Block, l 
 		err := msh.blockBuilder.ValidateAndAddTxToPool(tx)
 		// We ignore errors here, since they mean that the tx is no longer valid and we shouldn't re-add it
 		if err == nil {
-			msh.With().Info("transaction from contextually invalid block re-added to mempool",
-				log.TxID(tx.ID().ShortString()))
+			msh.With().Info("transaction from contextually invalid block re-added to mempool", tx.ID())
 		}
 	}
 }
@@ -402,8 +401,7 @@ func (msh *Mesh) setLatestLayerInState(lyr types.LayerID) {
 }
 
 func (msh *Mesh) logStateRoot(layerID types.LayerID) {
-	msh.Event().Info("end of layer state root",
-		log.LayerID(layerID.Uint64()),
+	msh.Event().Info("end of layer state root", layerID,
 		log.String("state_root", util.Bytes2Hex(msh.txProcessor.GetStateRoot().Bytes())),
 	)
 }
@@ -412,14 +410,13 @@ func (msh *Mesh) setLayerHash(layer *types.Layer) {
 	validBlocks, _ := msh.BlocksByValidity(layer.Blocks())
 	msh.layerHash = types.CalcBlocksHash32(types.BlockIDs(validBlocks), msh.layerHash).Bytes()
 
-	msh.Event().Info("new layer hash",
-		log.LayerID(layer.Index().Uint64()),
+	msh.Event().Info("new layer hash", layer.Index(),
 		log.String("layer_hash", util.Bytes2Hex(msh.layerHash)))
 }
 
 func (msh *Mesh) persistLayerHash() {
 	if err := msh.general.Put(constLAYERHASH, msh.layerHash); err != nil {
-		msh.With().Error("failed to persist layer hash", log.Err(err), log.LayerID(msh.ProcessedLayer().Uint64()),
+		msh.With().Error("failed to persist layer hash", log.Err(err), msh.ProcessedLayer(),
 			log.String("layer_hash", util.Bytes2Hex(msh.layerHash)))
 	}
 }
@@ -482,14 +479,14 @@ func (msh *Mesh) pushTransactions(l *types.Layer) {
 	numFailedTxs, err := msh.ApplyTransactions(l.Index(), validBlockTxs)
 	if err != nil {
 		msh.With().Error("failed to apply transactions",
-			log.LayerID(l.Index().Uint64()), log.Int("num_failed_txs", numFailedTxs), log.Err(err))
+			l.Index(), log.Int("num_failed_txs", numFailedTxs), log.Err(err))
 		// TODO: We want to panic here once we have a way to "remember" that we didn't apply these txs
 		//  e.g. persist the last layer transactions were applied from and use that instead of `oldBase`
 	}
 	msh.removeFromUnappliedTxs(validBlockTxs)
 	msh.With().Info("applied transactions",
 		log.Int("valid_block_txs", len(validBlockTxs)),
-		log.LayerID(l.Index().Uint64()),
+		l.Index(),
 		log.Int("num_failed_txs", numFailedTxs),
 	)
 }
@@ -575,7 +572,7 @@ func (msh *Mesh) AddBlockWithTxs(blk *types.Block, txs []*types.Transaction, atx
 
 	// Store block (delete if storing ATXs fails)
 	if err := msh.DB.AddBlock(blk); err != nil && err != ErrAlreadyExist {
-		msh.With().Error("failed to add block", log.BlockID(blk.ID().String()), log.Err(err))
+		msh.With().Error("failed to add block", blk.ID(), log.Err(err))
 		return err
 	}
 
@@ -583,7 +580,7 @@ func (msh *Mesh) AddBlockWithTxs(blk *types.Block, txs []*types.Transaction, atx
 	if err := msh.AtxDB.ProcessAtxs(atxs); err != nil {
 		// Roll back adding the block (delete it)
 		if err := msh.blocks.Delete(blk.ID().Bytes()); err != nil {
-			msh.With().Warning("failed to roll back adding a block", log.Err(err), log.BlockID(blk.ID().String()))
+			msh.With().Warning("failed to roll back adding a block", log.Err(err), blk.ID())
 		}
 		return fmt.Errorf("failed to process ATXs: %v", err)
 	}
@@ -671,13 +668,12 @@ func (msh *Mesh) accumulateRewards(l *types.Layer, params Config) {
 	ids := make([]types.Address, 0, len(l.Blocks()))
 	for _, bl := range l.Blocks() {
 		if bl.ATXID == *types.EmptyATXID {
-			msh.With().Info("skipping reward distribution for block with no ATX",
-				log.LayerID(uint64(bl.LayerIndex)), log.BlockID(bl.ID().String()))
+			msh.With().Info("skipping reward distribution for block with no ATX", bl.LayerIndex, bl.ID())
 			continue
 		}
 		atx, err := msh.AtxDB.GetAtxHeader(bl.ATXID)
 		if err != nil {
-			msh.With().Warning("Atx from block not found in db", log.Err(err), log.BlockID(bl.ID().String()), log.AtxID(bl.ATXID.ShortString()))
+			msh.With().Warning("Atx from block not found in db", log.Err(err), bl.ID(), bl.ATXID)
 			continue
 		}
 		ids = append(ids, atx.Coinbase)
@@ -685,7 +681,7 @@ func (msh *Mesh) accumulateRewards(l *types.Layer, params Config) {
 	}
 
 	if len(ids) == 0 {
-		msh.With().Info("no valid blocks for layer ", log.LayerID(uint64(l.Index())))
+		msh.With().Info("no valid blocks for layer ", l.Index())
 		return
 	}
 

--- a/oracle/blockeligibilityvalidator.go
+++ b/oracle/blockeligibilityvalidator.go
@@ -46,7 +46,7 @@ func (v BlockEligibilityValidator) BlockSignedAndEligible(block *types.Block) (b
 	epochNumber := block.LayerIndex.GetEpoch(v.layersPerEpoch)
 	if epochNumber == 0 {
 		v.log.With().Warning("skipping epoch 0 block validation.",
-			log.BlockID(block.ID().String()), log.LayerID(block.LayerIndex.Uint64()))
+			block.ID(), block.LayerIndex)
 		return true, nil
 	}
 	if block.ATXID == *types.EmptyATXID {
@@ -63,7 +63,7 @@ func (v BlockEligibilityValidator) BlockSignedAndEligible(block *types.Block) (b
 	}
 	if epochNumber.IsGenesis() {
 		v.log.With().Info("using genesisActiveSetSize",
-			log.BlockID(block.ShortString()), log.Uint32("genesisActiveSetSize", v.genesisActiveSetSize))
+			block.ID(), log.Uint32("genesisActiveSetSize", v.genesisActiveSetSize))
 		activeSetSize = v.genesisActiveSetSize
 	}
 

--- a/oracle/blockoracle.go
+++ b/oracle/blockoracle.go
@@ -191,10 +191,10 @@ func getNumberOfEligibleBlocks(activeSetSize, committeeSize uint32, layersPerEpo
 func (bo *MinerBlockOracle) getATXIDForEpoch(targetEpoch types.EpochID) (types.ATXID, error) {
 	latestATXID, err := bo.atxDB.GetNodeAtxIDForEpoch(bo.nodeID, targetEpoch)
 	if err != nil {
-		bo.log.With().Info("did not find ATX IDs for node", log.String("atx_node_id", bo.nodeID.ShortString()), log.Err(err))
+		bo.log.With().Info("did not find ATX IDs for node", log.FieldNamed("atx_node_id", bo.nodeID), log.Err(err))
 		return types.ATXID{}, err
 	}
-	bo.log.With().Info("latest atx id found", log.AtxID(latestATXID.ShortString()))
+	bo.log.With().Info("latest atx id found", latestATXID)
 	return latestATXID, err
 }
 

--- a/state/processor.go
+++ b/state/processor.go
@@ -144,7 +144,7 @@ func (tp *TransactionProcessor) addStateToHistory(layer types.LayerID, newHash t
 	if err != nil {
 		return err
 	}
-	tp.Log.With().Info("new state root", log.LayerID(uint64(layer)), log.String("state_root", newHash.String()))
+	tp.Log.With().Info("new state root", layer, log.String("state_root", newHash.String()))
 	return nil
 }
 
@@ -178,7 +178,7 @@ func (tp *TransactionProcessor) ApplyRewards(layer types.LayerID, miners []types
 		tp.Log.With().Info("Reward applied",
 			log.String("account", account.Short()),
 			log.Uint64("reward", reward.Uint64()),
-			log.LayerID(uint64(layer)),
+			layer,
 		)
 		tp.AddBalance(account, reward)
 		events.Publish(events.RewardReceived{Coinbase: account.String(), Amount: reward.Uint64()})
@@ -225,7 +225,7 @@ func (tp *TransactionProcessor) Process(txs []*types.Transaction, layerID types.
 	for _, tx := range txs {
 		err := tp.ApplyTransaction(tx, layerID)
 		if err != nil {
-			tp.With().Warning("failed to apply transaction", log.TxID(tx.ID().ShortString()), log.Err(err))
+			tp.With().Warning("failed to apply transaction", tx.ID(), log.Err(err))
 			remaining = append(remaining, tx)
 		}
 		events.Publish(events.ValidTx{ID: tx.ID().String(), Valid: err == nil})

--- a/sync/block_listener.go
+++ b/sync/block_listener.go
@@ -10,7 +10,7 @@ import (
 	"time"
 )
 
-//BlockListener Listens to blocks propagated in gossip
+// BlockListener Listens to blocks propagated in gossip
 type BlockListener struct {
 	*Syncer
 	blockEligibilityValidator
@@ -24,7 +24,7 @@ type BlockListener struct {
 	exit                 chan struct{}
 }
 
-//Close closes all running goroutines
+// Close closes all running goroutines
 func (bl *BlockListener) Close() {
 	close(bl.exit)
 	bl.Info("block listener closing, waiting for gorutines")
@@ -33,14 +33,14 @@ func (bl *BlockListener) Close() {
 	bl.Info("block listener closed")
 }
 
-//Start starts the main listening goroutine
+// Start starts the main listening goroutine
 func (bl *BlockListener) Start() {
 	if bl.startLock.TryLock() {
 		go bl.listenToGossipBlocks()
 	}
 }
 
-//NewBlockListener creates a new instance of BlockListener
+// NewBlockListener creates a new instance of BlockListener
 func NewBlockListener(net service.Service, sync *Syncer, concurrency int, logger log.Log) *BlockListener {
 	bl := BlockListener{
 		Syncer:               sync,
@@ -88,23 +88,23 @@ func (bl *BlockListener) handleBlock(data service.GossipMessage) {
 		return
 	}
 
-	//set the block id when received
+	// set the block id when received
 	blk.Initialize()
 
 	bl.Log.With().Info("got new block", blk.Fields()...)
-	//check if known
+	// check if known
 	if _, err := bl.GetBlock(blk.ID()); err == nil {
-		bl.With().Info("we already know this block", log.BlockID(blk.ID().String()))
+		bl.With().Info("we already know this block", blk.ID())
 		return
 	}
 	txs, atxs, err := bl.blockSyntacticValidation(&blk)
 	if err != nil {
-		bl.With().Error("failed to validate block", log.BlockID(blk.ID().String()), log.Err(err))
+		bl.With().Error("failed to validate block", blk.ID(), log.Err(err))
 		return
 	}
 	data.ReportValidation(config.NewBlockProtocol)
 	if err := bl.AddBlockWithTxs(&blk, txs, atxs); err != nil {
-		bl.With().Error("failed to add block to database", log.BlockID(blk.ID().String()), log.Err(err))
+		bl.With().Error("failed to add block to database", blk.ID(), log.Err(err))
 		return
 	}
 

--- a/sync/validation_queue.go
+++ b/sync/validation_queue.go
@@ -143,7 +143,7 @@ func (vq *blockQueue) finishBlockCallback(block *types.Block) func(res bool) err
 			vq.HandleLateBlock(block)
 		}
 
-		vq.With().Info("finished block, valid", log.BlockID(block.ID().String()))
+		vq.With().Info("finished block, valid", block.ID())
 		return nil
 	}
 }

--- a/timesync/clock.go
+++ b/timesync/clock.go
@@ -55,7 +55,8 @@ func (t *TimeClock) startClock() {
 		nextTickTime := t.Ticker.LayerToTime(currLayer + 1) // get next tick time for the next layer
 		diff := nextTickTime.Sub(t.clock.Now())
 		tmr := time.NewTimer(diff)
-		t.log.With().Info("global clock going to sleep before next layer", log.String("diff", diff.String()), log.Uint64("next_layer", uint64(currLayer)))
+		t.log.With().Info("global clock going to sleep before next layer", log.String("diff", diff.String()),
+			log.FieldNamed("next_layer", currLayer))
 		select {
 		case <-tmr.C:
 			// notify subscribers

--- a/timesync/ticker.go
+++ b/timesync/ticker.go
@@ -114,12 +114,12 @@ func (t *Ticker) Notify() (int, error) {
 	// already ticked
 	if layer <= t.lastTickedLayer {
 		t.log.With().Warning("skipping tick to avoid double ticking the same layer (time was not monotonic)",
-			log.Uint64("current_layer", uint64(layer)), log.Uint64("last_ticked_layer", uint64(t.lastTickedLayer)))
+			log.FieldNamed("current_layer", layer), log.FieldNamed("last_ticked_layer", t.lastTickedLayer))
 		t.m.Unlock()
 		return 0, errNotMonotonic
 	}
 	missedTicks := 0
-	t.log.Event().Info("release tick", log.LayerID(uint64(layer)))
+	t.log.Event().Info("release tick", layer)
 	for ch := range t.subscribers { // notify all subscribers
 
 		// non-blocking notify
@@ -136,8 +136,7 @@ func (t *Ticker) Notify() (int, error) {
 	t.m.Unlock()
 
 	if missedTicks > 0 {
-		t.log.With().Error("missed ticks for layer",
-			log.LayerID(uint64(layer)), log.Int("missed_count", missedTicks))
+		t.log.With().Error("missed ticks for layer", layer, log.Int("missed_count", missedTicks))
 		return missedTicks, errMissedTicks
 	}
 

--- a/tortoise/algorithm.go
+++ b/tortoise/algorithm.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/mesh"
 )
 
-//Tortoise represents an instance of a vote counting algorithm
+// Tortoise represents an instance of a vote counting algorithm
 type Tortoise interface {
 	HandleLateBlock(b *types.Block) (types.LayerID, types.LayerID)
 	HandleIncomingLayer(ll *types.Layer) (types.LayerID, types.LayerID)
@@ -18,14 +18,14 @@ type tortoise struct {
 	*ninjaTortoise
 }
 
-//NewTortoise returns a new Tortoise instance
+// NewTortoise returns a new Tortoise instance
 func NewTortoise(layerSize int, mdb *mesh.DB, hdist int, lg log.Log) Tortoise {
 	alg := &tortoise{ninjaTortoise: newNinjaTortoise(layerSize, mdb, hdist, lg)}
 	alg.HandleIncomingLayer(mesh.GenesisLayer())
 	return alg
 }
 
-//NewRecoveredTortoise recovers a previously persisted tortoise copy from mesh.DB
+// NewRecoveredTortoise recovers a previously persisted tortoise copy from mesh.DB
 func NewRecoveredTortoise(mdb *mesh.DB, lg log.Log) Tortoise {
 	tmp, err := RecoverTortoise(mdb)
 	if err != nil {
@@ -41,18 +41,18 @@ func NewRecoveredTortoise(mdb *mesh.DB, lg log.Log) Tortoise {
 	return &tortoise{ninjaTortoise: trtl}
 }
 
-//HandleLateBlock processes a late blocks votes (for late block definition see white paper)
-//returns the old pbase and new pbase after taking into account the blocks votes
+// HandleLateBlock processes a late blocks votes (for late block definition see white paper)
+// returns the old pbase and new pbase after taking into account the blocks votes
 func (trtl *tortoise) HandleLateBlock(b *types.Block) (types.LayerID, types.LayerID) {
-	//todo feed all layers from b's layer to tortoise
+	// todo feed all layers from b's layer to tortoise
 	l := types.NewLayer(b.Layer())
 	l.AddBlock(b)
 	oldPbase, newPbase := trtl.HandleIncomingLayer(l)
-	log.With().Info("late block ", log.LayerID(uint64(b.Layer())), log.BlockID(b.ID().String()))
+	log.With().Info("late block", b.Layer(), b.ID())
 	return oldPbase, newPbase
 }
 
-//Persist saves a copy of the current tortoise state to the database
+// Persist saves a copy of the current tortoise state to the database
 func (trtl *tortoise) Persist() error {
 	trtl.mutex.Lock()
 	defer trtl.mutex.Unlock()
@@ -60,8 +60,8 @@ func (trtl *tortoise) Persist() error {
 	return trtl.ninjaTortoise.persist()
 }
 
-//HandleIncomingLayer processes all layer block votes
-//returns the old pbase and new pbase after taking into account the blocks votes
+// HandleIncomingLayer processes all layer block votes
+// returns the old pbase and new pbase after taking into account the blocks votes
 func (trtl *tortoise) HandleIncomingLayer(ll *types.Layer) (types.LayerID, types.LayerID) {
 	trtl.mutex.Lock()
 	defer trtl.mutex.Unlock()
@@ -72,7 +72,7 @@ func (trtl *tortoise) HandleIncomingLayer(ll *types.Layer) (types.LayerID, types
 	return oldPbase, newPbase
 }
 
-//LatestComplete returns the latest complete (a.k.a irreversible) layer
+// LatestComplete returns the latest complete (a.k.a irreversible) layer
 func (trtl *tortoise) LatestComplete() types.LayerID {
 	return trtl.latestComplete()
 }


### PR DESCRIPTION
## Motivation
Reduce confusion around how to use `LoggableField`s

## Changes
- Introduce `log.FieldNamed()` for cases where a field's default name isn't clear, or more than one field of same type are logged.
- Replace all usages of the old-style `log.<type>` and replace with bare logging.
- Remove old-style methods.

## Test Plan
Unit + system tests.