### PR TITLE
[Merged by Bors] - Require go 1.14.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 sudo: required
-go: 1.11.x
+go: 1.13.x
 
 env: GO111MODULE=on
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 sudo: required
-go: 1.13.x
+go: 1.14.x
 
 env: GO111MODULE=on
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Inspired by https://container-solutions.com/faster-builds-in-docker-with-go-1-11/
 # Base build image
-FROM golang:1.13.12-alpine3.12 AS build_base
+FROM golang:1.14.4-alpine3.12 AS build_base
 RUN apk add bash make git curl unzip rsync libc6-compat gcc musl-dev protobuf
 WORKDIR /go/src/github.com/spacemeshos/go-spacemesh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Inspired by https://container-solutions.com/faster-builds-in-docker-with-go-1-11/
 # Base build image
 FROM golang:1.13.12-alpine3.12 AS build_base
-RUN apk add bash make git curl unzip rsync libc6-compat gcc musl-dev
+RUN apk add bash make git curl unzip rsync libc6-compat gcc musl-dev protobuf
 WORKDIR /go/src/github.com/spacemeshos/go-spacemesh
 
 # Force the go compiler to use modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Inspired by https://container-solutions.com/faster-builds-in-docker-with-go-1-11/
 # Base build image
-FROM golang:1.11.9-alpine3.8 AS build_base
+FROM golang:1.13.12-alpine3.12 AS build_base
 RUN apk add bash make git curl unzip rsync libc6-compat gcc musl-dev
 WORKDIR /go/src/github.com/spacemeshos/go-spacemesh
 

--- a/Makefile
+++ b/Makefile
@@ -180,6 +180,8 @@ list-versions:
 
 
 dockerbuild-go:
+	# Must remove binaries or they will be copied into the container
+	rm -rf devtools/
 	docker build -t $(DOCKER_IMAGE_REPO):$(BRANCH) .
 .PHONY: dockerbuild-go
 

--- a/README.md
+++ b/README.md
@@ -86,13 +86,13 @@ _-- or --_
 
 Fork the project from https://github.com/spacemeshos/go-spacemesh
 
-Since the project uses Go 1.11's Modules it is best to place the code **outside** your `$GOPATH`. Read [this](https://github.com/golang/go/wiki/Modules#how-to-install-and-activate-module-support) for alternatives.
+Since the project uses Go Modules it is best to place the code **outside** your `$GOPATH`. Read [this](https://github.com/golang/go/wiki/Modules#how-to-install-and-activate-module-support) for alternatives.
 
 ### Setting Up Local Dev Environment
 
 Building is supported on OS X, Linux, FreeBSD, and Windows.
 
-Install [Go 1.11 or later](https://golang.org/dl/) for your platform, if you haven't already.
+Install [Go 1.13 or later](https://golang.org/dl/) for your platform, if you haven't already.
 
 On Windows you need to install `make` via [msys2](https://www.msys2.org/), [MingGW-w64](http://mingw-w64.org/doku.php) or [mingw] (https://chocolatey.org/packages/mingw)
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Since the project uses Go Modules it is best to place the code **outside** your 
 
 Building is supported on OS X, Linux, FreeBSD, and Windows.
 
-Install [Go 1.13 or later](https://golang.org/dl/) for your platform, if you haven't already.
+Install [Go 1.14 or later](https://golang.org/dl/) for your platform, if you haven't already.
 
 On Windows you need to install `make` via [msys2](https://www.msys2.org/), [MingGW-w64](http://mingw-w64.org/doku.php) or [mingw] (https://chocolatey.org/packages/mingw)
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ clone_folder: c:\gopath\src\github.com\spacemeshos\go-spacemesh\
 environment:
   GOPATH: c:\gopath
 
-stack: go 1.11
+stack: go 1.13
 
 before_build:
   - choco install make

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ clone_folder: c:\gopath\src\github.com\spacemeshos\go-spacemesh\
 environment:
   GOPATH: c:\gopath
 
-stack: go 1.13
+stack: go 1.14
 
 before_build:
   - choco install make

--- a/scripts/check-go-version.sh
+++ b/scripts/check-go-version.sh
@@ -12,9 +12,9 @@ if ! (hash go 2>/dev/null) ; then
     exit 1;
 fi
 
-# Ensure we use Go version 1.13+
+# Ensure we use Go version 1.14+
 read major minor patch <<< $(go version | sed 's/go version go\([0-9]*\)\.\([0-9]*\)\.\([0-9]*\).*/\1 \2 \3/')
-if [[ ${major} -ne 1 || ${minor} -lt 13 ]]; then
-    errcho "Go 1.13+ is required (v$major.$minor.$patch is installed at `which go`)"
+if [[ ${major} -ne 1 || ${minor} -lt 14 ]]; then
+    errcho "Go 1.14+ is required (v$major.$minor.$patch is installed at `which go`)"
     exit 1;
 fi

--- a/scripts/check-go-version.sh
+++ b/scripts/check-go-version.sh
@@ -13,7 +13,7 @@ if ! (hash go 2>/dev/null) ; then
 fi
 
 # Ensure we use Go version 1.13+
-read major minor patch <<< $(go version | sed 's/go version go\([0-9]*\)\.\([0-9]*\).*/\1 \2/') 
+read major minor patch <<< $(go version | sed 's/go version go\([0-9]*\)\.\([0-9]*\)\.\([0-9]*\).*/\1 \2 \3/')
 if [[ ${major} -ne 1 || ${minor} -lt 13 ]]; then
     errcho "Go 1.13+ is required (v$major.$minor.$patch is installed at `which go`)"
     exit 1;

--- a/scripts/check-go-version.sh
+++ b/scripts/check-go-version.sh
@@ -12,9 +12,9 @@ if ! (hash go 2>/dev/null) ; then
     exit 1;
 fi
 
-# Ensure we use Go version 1.11+
+# Ensure we use Go version 1.13+
 read major minor patch <<< $(go version | sed 's/go version go\([0-9]*\)\.\([0-9]*\).*/\1 \2/') 
-if [[ ${major} -ne 1 || ${minor} -lt 11 ]]; then
-    errcho "Go 1.11+ is required (v$major.$minor.$patch is installed at `which go`)"
+if [[ ${major} -ne 1 || ${minor} -lt 13 ]]; then
+    errcho "Go 1.13+ is required (v$major.$minor.$patch is installed at `which go`)"
     exit 1;
 fi

--- a/scripts/genproto.sh
+++ b/scripts/genproto.sh
@@ -21,7 +21,7 @@ errcho() {
 if [ ! -f $protoc ] ; then
     echo "Could not find protoc in $protoc. Trying to use protoc in PATH."
     protoc=protoc # try loading from PATH
-    if !(hash protoc 2>/dev/null) ; then
+    if ! (hash protoc 2>/dev/null) ; then
         errcho "Could not find protoc. Try running 'make install' or setting PROTOCPATH to your protoc bin file."
         exit 1;
     fi
@@ -36,7 +36,6 @@ grpc_gateway_path=$(go list -m -f '{{.Dir}}' github.com/grpc-ecosystem/grpc-gate
 googleapis_path="$grpc_gateway_path/third_party/googleapis"
 
 echo "Generating protobuf for api/pb"
-echo protoc -I. -Idevtools/include -I$googleapis_path --go_out=plugins=grpc:. api/pb/api.proto
 compile -I. -Idevtools/include -I$googleapis_path $freebsd_opts --go_out=plugins=grpc:. api/pb/api.proto
 compile -I. -Idevtools/include -I$googleapis_path $freebsd_opts --grpc-gateway_out=logtostderr=true:. api/pb/api.proto
 compile -I. -Idevtools/include -I$googleapis_path $freebsd_opts --swagger_out=logtostderr=true:. api/pb/api.proto

--- a/scripts/genproto.sh
+++ b/scripts/genproto.sh
@@ -19,7 +19,7 @@ errcho() {
 
 
 if [ ! -f $protoc ] ; then
-    errcho "Could not find protoc in $protoc. Trying to use protoc in PATH."
+    echo "Could not find protoc in $protoc. Trying to use protoc in PATH."
     protoc=protoc # try loading from PATH
     if !(hash protoc 2>/dev/null) ; then
         errcho "Could not find protoc. Try running 'make install' or setting PROTOCPATH to your protoc bin file."
@@ -36,6 +36,7 @@ grpc_gateway_path=$(go list -m -f '{{.Dir}}' github.com/grpc-ecosystem/grpc-gate
 googleapis_path="$grpc_gateway_path/third_party/googleapis"
 
 echo "Generating protobuf for api/pb"
-compile -I. -I$googleapis_path $freebsd_opts --go_out=plugins=grpc:. api/pb/api.proto
-compile -I. -I$googleapis_path $freebsd_opts --grpc-gateway_out=logtostderr=true:. api/pb/api.proto
-compile -I. -I$googleapis_path $freebsd_opts --swagger_out=logtostderr=true:. api/pb/api.proto
+echo protoc -I. -Idevtools/include -I$googleapis_path --go_out=plugins=grpc:. api/pb/api.proto
+compile -I. -Idevtools/include -I$googleapis_path $freebsd_opts --go_out=plugins=grpc:. api/pb/api.proto
+compile -I. -Idevtools/include -I$googleapis_path $freebsd_opts --grpc-gateway_out=logtostderr=true:. api/pb/api.proto
+compile -I. -Idevtools/include -I$googleapis_path $freebsd_opts --swagger_out=logtostderr=true:. api/pb/api.proto

--- a/scripts/install-protobuf.sh
+++ b/scripts/install-protobuf.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -e
+
 # Detect OS and architecture
 kernel=`uname -s`
 arch=`uname -m`
@@ -37,8 +38,14 @@ rm -rf devtools
 mkdir -p devtools/bin
 mkdir -p devtools/include
 
-echo "moving bin/protoc to ./devtools/bin/protoc"
-mv protoc3/bin/* devtools/bin/
+# Don't reinstall protoc if it's already installed
+if (hash protoc 2>/dev/null) ; then
+    echo "found systemwide protoc, not installing locally"
+else
+    echo "no systemwide protoc installation found"
+    echo "moving bin/protoc to ./devtools/bin/protoc"
+    mv protoc3/bin/* devtools/bin/
+fi
 
 # Move protoc3/include to /usr/local/include/
 echo "syncing include to ./devtools/include"

--- a/scripts/install-protobuf.sh
+++ b/scripts/install-protobuf.sh
@@ -28,11 +28,12 @@ echo "fetching ${protoc_url}"
 curl -L -o "protoc.zip" ${protoc_url}
 
 # Unzip
+rm -rf protoc3
 echo "extracting..."
 unzip -u protoc.zip -d protoc3
 
-
 # create local devtools dir.
+rm -rf devtools
 mkdir -p devtools/bin
 mkdir -p devtools/include
 

--- a/scripts/win/check-go-version.ps1
+++ b/scripts/win/check-go-version.ps1
@@ -10,8 +10,8 @@ $minor = $Matches[2]
 $patch = $Matches[3]
 $loc = (gcm go).Path
 
-if($major -ne 1 -or $minor -lt 11)
+if($major -ne 1 -or $minor -lt 13)
 {
-    $host.ui.WriteErrorLine("Go 1.11+ is required (v$major.$minor.$patch is installed at $loc)")
+    $host.ui.WriteErrorLine("Go 1.13+ is required (v$major.$minor.$patch is installed at $loc)")
     exit 1
 }

--- a/trie/database.go
+++ b/trie/database.go
@@ -109,9 +109,11 @@ type rawShortNode struct {
 	Val node
 }
 
-func (n rawShortNode) canUnload(uint16, uint16) bool { panic("this should never end up in a live trie") }
-func (n rawShortNode) cache() (hashNode, bool)       { panic("this should never end up in a live trie") }
-func (n rawShortNode) fstring(ind string) string     { panic("this should never end up in a live trie") }
+func (n rawShortNode) canUnload(uint16, uint16) bool {
+	panic("this should never end up in a live trie")
+}
+func (n rawShortNode) cache() (hashNode, bool)   { panic("this should never end up in a live trie") }
+func (n rawShortNode) fstring(ind string) string { panic("this should never end up in a live trie") }
 
 // cachedNode is all the information we know about a single cached node in the
 // memory database write layer.


### PR DESCRIPTION
## Motivation
Closes #2050 (see that issue for background)
This resolves the CI issues I've been seeing

## Changes
- Switch travis from go 1.11.x to 1.14.4
- setup_env scripts check for go >= 1.14
- fix minor regexp bug in check-go-version script