### PR TITLE
[Merged by Bors] - Move max tx per block into config

### DIFF
--- a/cmd/node/app_test.go
+++ b/cmd/node/app_test.go
@@ -519,6 +519,7 @@ func TestShutdown(t *testing.T) {
 	smApp.Config.CoinbaseAccount = "0x123"
 	smApp.Config.LayerAvgSize = 5
 	smApp.Config.LayersPerEpoch = 3
+	smApp.Config.TxsPerBlock = 100
 	smApp.Config.Hdist = 5
 	smApp.Config.GenesisTime = genesisTime.Format(time.RFC3339)
 	smApp.Config.LayerDurationSec = 20

--- a/cmd/node/app_test.go
+++ b/cmd/node/app_test.go
@@ -519,7 +519,7 @@ func TestShutdown(t *testing.T) {
 	smApp.Config.CoinbaseAccount = "0x123"
 	smApp.Config.LayerAvgSize = 5
 	smApp.Config.LayersPerEpoch = 3
-	smApp.Config.TxsPerBlock = 100
+	smApp.Config.TxsPerBlock = 200
 	smApp.Config.Hdist = 5
 	smApp.Config.GenesisTime = genesisTime.Format(time.RFC3339)
 	smApp.Config.LayerDurationSec = 20

--- a/cmd/node/multi_node.go
+++ b/cmd/node/multi_node.go
@@ -141,6 +141,7 @@ func getTestDefaultConfig() *config.Config {
 	cfg.HARE.SuperHare = true
 	cfg.LayerAvgSize = 5
 	cfg.LayersPerEpoch = 3
+	cfg.TxsPerBlock = 100
 	cfg.Hdist = 5
 
 	cfg.LayerDurationSec = 20

--- a/cmd/node/multi_node.go
+++ b/cmd/node/multi_node.go
@@ -141,7 +141,7 @@ func getTestDefaultConfig() *config.Config {
 	cfg.HARE.SuperHare = true
 	cfg.LayerAvgSize = 5
 	cfg.LayersPerEpoch = 3
-	cfg.TxsPerBlock = 100
+	cfg.TxsPerBlock = 200
 	cfg.Hdist = 5
 
 	cfg.LayerDurationSec = 20

--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -549,7 +549,10 @@ func (app *SpacemeshApp) initServices(nodeID types.NodeID,
 	ha := app.HareFactory(mdb, swarm, sgn, nodeID, syncer, msh, hOracle, idStore, clock, lg)
 
 	stateAndMeshProjector := pendingtxs.NewStateAndMeshProjector(processor, msh)
-	blockProducer := miner.NewBlockBuilder(nodeID, sgn, swarm, clock.Subscribe(), app.Config.Hdist, app.txPool, atxpool, coinToss, msh, ha, blockOracle, processor, atxdb, syncer, app.Config.AtxsPerBlock, layersPerEpoch, stateAndMeshProjector, app.addLogger(BlockBuilderLogger, lg))
+	blockProducer := miner.NewBlockBuilder(nodeID, sgn, swarm, clock.Subscribe(),
+		app.Config.Hdist, app.txPool, atxpool, coinToss, msh, ha, blockOracle, processor,
+		atxdb, syncer, app.Config.AtxsPerBlock, app.Config.TxsPerBlock, layersPerEpoch,
+		stateAndMeshProjector, app.addLogger(BlockBuilderLogger, lg))
 	blockListener := sync.NewBlockListener(swarm, syncer, 4, app.addLogger(BlockListenerLogger, lg))
 
 	msh.SetBlockBuilder(blockProducer)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -42,7 +42,6 @@ func AddCommands(cmd *cobra.Command) {
 		config.Hdist, "hdist")
 	cmd.PersistentFlags().BoolVar(&config.StartMining, "start-mining",
 		config.StartMining, "start mining")
-
 	cmd.PersistentFlags().StringVar(&config.MemProfile, "mem-profile",
 		config.MemProfile, "output memory profiling stat to filename")
 	cmd.PersistentFlags().StringVar(&config.CPUProfile, "cpu-profile",
@@ -53,21 +52,18 @@ func AddCommands(cmd *cobra.Command) {
 		config.GenesisConfPath, "add genesis configuration")
 	cmd.PersistentFlags().StringVar(&config.CoinbaseAccount, "coinbase",
 		config.CoinbaseAccount, "coinbase account to accumulate rewards")
-
 	cmd.PersistentFlags().IntVar(&config.GenesisActiveSet, "genesis-active-size",
 		config.GenesisActiveSet, "The active set size for the genesis flow")
-
 	cmd.PersistentFlags().IntVar(&config.BlockCacheSize, "block-cache-size",
 		config.BlockCacheSize, "size in layers of meshdb block cache")
-
 	cmd.PersistentFlags().StringVar(&config.PublishEventsURL, "events-url",
 		config.PublishEventsURL, "publish events on this url, if no url specified event will no be published")
-
 	cmd.PersistentFlags().IntVar(&config.SyncRequestTimeout, "sync-request-timeout",
-		2000, "the timeout in ms for direct requests in the sync")
-
+		config.SyncRequestTimeout, "the timeout in ms for direct requests in the sync")
 	cmd.PersistentFlags().IntVar(&config.AtxsPerBlock, "atxs-per-block",
-		100, "the number of atxs to select per block on block creation")
+		config.AtxsPerBlock, "the number of atxs to select per block on block creation")
+	cmd.PersistentFlags().IntVar(&config.TxsPerBlock, "txs-per-block",
+		config.TxsPerBlock, "max no. of transactions per block")
 
 	/** ======================== P2P Flags ========================== **/
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -63,7 +63,7 @@ func AddCommands(cmd *cobra.Command) {
 	cmd.PersistentFlags().IntVar(&config.AtxsPerBlock, "atxs-per-block",
 		config.AtxsPerBlock, "the number of atxs to select per block on block creation")
 	cmd.PersistentFlags().IntVar(&config.TxsPerBlock, "txs-per-block",
-		config.TxsPerBlock, "max no. of transactions per block")
+		config.TxsPerBlock, "the number of transactions to select per block on block creation")
 
 	/** ======================== P2P Flags ========================== **/
 

--- a/config/config.go
+++ b/config/config.go
@@ -99,6 +99,8 @@ type BaseConfig struct {
 
 	AtxsPerBlock int `mapstructure:"atxs-per-block"`
 
+	TxsPerBlock int `mapstructure:"txs-per-block"`
+
 	BlockCacheSize int `mapstructure:"block-cache-size"`
 }
 
@@ -165,6 +167,7 @@ func defaultBaseConfig() BaseConfig {
 		SyncInterval:        10,
 		SyncValidationDelta: 30,
 		AtxsPerBlock:        100,
+		TxsPerBlock:         100,
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -167,7 +167,7 @@ func defaultBaseConfig() BaseConfig {
 		SyncInterval:        10,
 		SyncValidationDelta: 30,
 		AtxsPerBlock:        100,
-		TxsPerBlock:         100,
+		TxsPerBlock:         200,
 	}
 }
 

--- a/miner/builder_test.go
+++ b/miner/builder_test.go
@@ -122,7 +122,7 @@ func TestBlockBuilder_StartStop(t *testing.T) {
 
 	bs := []*types.Block{block1, block2, block3, block4}
 	orphans := &mockMesh{b: bs}
-	builder := NewBlockBuilder(types.NodeID{}, signing.NewEdSigner(), n, beginRound, 5, NewTxMemPool(), NewAtxMemPool(), MockCoin{}, orphans, hare, &mockBlockOracle{}, mockTxProcessor{}, &mockAtxValidator{}, &mockSyncer{}, selectCount, layersPerEpoch, mockProjector, log.New(n.String(), "", ""))
+	builder := NewBlockBuilder(types.NodeID{}, signing.NewEdSigner(), n, beginRound, 5, NewTxMemPool(), NewAtxMemPool(), MockCoin{}, orphans, hare, &mockBlockOracle{}, mockTxProcessor{}, &mockAtxValidator{}, &mockSyncer{}, selectCount, selectCount, layersPerEpoch, mockProjector, log.New(n.String(), "", ""))
 
 	err := builder.Start()
 	assert.NoError(t, err)
@@ -156,8 +156,8 @@ func TestBlockBuilder_BlockIdGeneration(t *testing.T) {
 	hare.res[0] = hareRes
 
 	st := []*types.Block{block2, block3, block4}
-	builder1 := NewBlockBuilder(types.NodeID{Key: "a"}, signing.NewEdSigner(), n1, beginRound, 5, NewTxMemPool(), NewAtxMemPool(), MockCoin{}, &mockMesh{b: st}, hare, &mockBlockOracle{}, mockTxProcessor{}, &mockAtxValidator{}, &mockSyncer{}, selectCount, layersPerEpoch, mockProjector, log.New(n1.Info.ID.String(), "", ""))
-	builder2 := NewBlockBuilder(types.NodeID{Key: "b"}, signing.NewEdSigner(), n2, beginRound, 5, NewTxMemPool(), NewAtxMemPool(), MockCoin{}, &mockMesh{b: st}, hare, &mockBlockOracle{}, mockTxProcessor{}, &mockAtxValidator{}, &mockSyncer{}, selectCount, layersPerEpoch, mockProjector, log.New(n2.Info.ID.String(), "", ""))
+	builder1 := NewBlockBuilder(types.NodeID{Key: "a"}, signing.NewEdSigner(), n1, beginRound, 5, NewTxMemPool(), NewAtxMemPool(), MockCoin{}, &mockMesh{b: st}, hare, &mockBlockOracle{}, mockTxProcessor{}, &mockAtxValidator{}, &mockSyncer{}, selectCount, selectCount, layersPerEpoch, mockProjector, log.New(n1.Info.ID.String(), "", ""))
+	builder2 := NewBlockBuilder(types.NodeID{Key: "b"}, signing.NewEdSigner(), n2, beginRound, 5, NewTxMemPool(), NewAtxMemPool(), MockCoin{}, &mockMesh{b: st}, hare, &mockBlockOracle{}, mockTxProcessor{}, &mockAtxValidator{}, &mockSyncer{}, selectCount, selectCount, layersPerEpoch, mockProjector, log.New(n2.Info.ID.String(), "", ""))
 
 	b1, _ := builder1.createBlock(1, types.ATXID{}, types.BlockEligibilityProof{}, nil, nil)
 
@@ -182,7 +182,7 @@ func TestBlockBuilder_CreateBlock(t *testing.T) {
 	hare.res[1] = hareRes
 
 	st := []*types.Block{block1, block2, block3}
-	builder := NewBlockBuilder(types.NodeID{Key: "anton", VRFPublicKey: []byte("anton")}, signing.NewEdSigner(), n, beginRound, 5, NewTxMemPool(), NewAtxMemPool(), MockCoin{}, &mockMesh{b: st}, hare, &mockBlockOracle{}, mockTxProcessor{}, &mockAtxValidator{}, &mockSyncer{}, selectCount, layersPerEpoch, mockProjector, log.New(n.String(), "", ""))
+	builder := NewBlockBuilder(types.NodeID{Key: "anton", VRFPublicKey: []byte("anton")}, signing.NewEdSigner(), n, beginRound, 5, NewTxMemPool(), NewAtxMemPool(), MockCoin{}, &mockMesh{b: st}, hare, &mockBlockOracle{}, mockTxProcessor{}, &mockAtxValidator{}, &mockSyncer{}, selectCount, selectCount, layersPerEpoch, mockProjector, log.New(n.String(), "", ""))
 
 	err := builder.Start()
 	assert.NoError(t, err)
@@ -292,7 +292,7 @@ func TestBlockBuilder_Validation(t *testing.T) {
 	hare.res[0] = hareRes
 
 	st := []*types.Block{block1, block2, block3}
-	builder1 := NewBlockBuilder(types.NodeID{Key: "a"}, signing.NewEdSigner(), n1, beginRound, 5, NewTxMemPool(), NewAtxMemPool(), MockCoin{}, &mockMesh{b: st}, hare, &mockBlockOracle{}, mockTxProcessor{true}, &mockAtxValidator{}, &mockSyncer{}, selectCount, layersPerEpoch, mockProjector, log.New(n1.Info.ID.String(), "", ""))
+	builder1 := NewBlockBuilder(types.NodeID{Key: "a"}, signing.NewEdSigner(), n1, beginRound, 5, NewTxMemPool(), NewAtxMemPool(), MockCoin{}, &mockMesh{b: st}, hare, &mockBlockOracle{}, mockTxProcessor{true}, &mockAtxValidator{}, &mockSyncer{}, selectCount, selectCount, layersPerEpoch, mockProjector, log.New(n1.Info.ID.String(), "", ""))
 	assert.NoError(t, builder1.Start())
 	tx := NewTx(t, 5, types.HexToAddress("0xFF"), signing.NewEdSigner())
 	b, e := types.InterfaceToBytes(tx)
@@ -337,7 +337,7 @@ func TestBlockBuilder_Gossip_NotSynced(t *testing.T) {
 	hare.res[0] = hareRes
 
 	st := []*types.Block{block2, block3, block4}
-	builder1 := NewBlockBuilder(types.NodeID{Key: "a"}, signing.NewEdSigner(), n1, beginRound, 5, NewTxMemPool(), NewAtxMemPool(), MockCoin{}, &mockMesh{b: st}, hare, &mockBlockOracle{}, mockTxProcessor{false}, &mockAtxValidator{}, &mockSyncerP{false}, selectCount, layersPerEpoch, mockProjector, log.New(n1.Info.ID.String(),
+	builder1 := NewBlockBuilder(types.NodeID{Key: "a"}, signing.NewEdSigner(), n1, beginRound, 5, NewTxMemPool(), NewAtxMemPool(), MockCoin{}, &mockMesh{b: st}, hare, &mockBlockOracle{}, mockTxProcessor{false}, &mockAtxValidator{}, &mockSyncerP{false}, selectCount, selectCount, layersPerEpoch, mockProjector, log.New(n1.Info.ID.String(),
 		"",
 		""))
 	assert.NoError(t, builder1.Start())
@@ -548,7 +548,7 @@ func TestBlockBuilder_getVotes(t *testing.T) {
 	beginRound := make(chan types.LayerID)
 	n1 := service.NewSimulator().NewNode()
 	allblocks := []*types.Block{b1, b2, b3, b4, b5, b6, b7}
-	bb := NewBlockBuilder(types.NodeID{Key: "a"}, signing.NewEdSigner(), n1, beginRound, 5, NewTxMemPool(), NewAtxMemPool(), MockCoin{}, &mockMesh{b: allblocks}, &mockResult{}, &mockBlockOracle{}, mockTxProcessor{true}, &mockAtxValidator{}, &mockSyncer{}, selectCount, layersPerEpoch, mockProjector, log.NewDefault(t.Name()))
+	bb := NewBlockBuilder(types.NodeID{Key: "a"}, signing.NewEdSigner(), n1, beginRound, 5, NewTxMemPool(), NewAtxMemPool(), MockCoin{}, &mockMesh{b: allblocks}, &mockResult{}, &mockBlockOracle{}, mockTxProcessor{true}, &mockAtxValidator{}, &mockSyncer{}, selectCount, selectCount, layersPerEpoch, mockProjector, log.NewDefault(t.Name()))
 	b, err := bb.getVotes(config.Genesis)
 	r.EqualError(err, "cannot create blockBytes in genesis layer")
 	r.Nil(b)
@@ -598,7 +598,7 @@ func TestBlockBuilder_CalcHdistRange(t *testing.T) {
 	beginRound := make(chan types.LayerID)
 	n1 := service.NewSimulator().NewNode()
 	bs := []*types.Block{b1, b2, b3}
-	bb := NewBlockBuilder(types.NodeID{Key: "a"}, signing.NewEdSigner(), n1, beginRound, 5, NewTxMemPool(), NewAtxMemPool(), MockCoin{}, &mockMesh{b: bs}, &mockResult{}, &mockBlockOracle{}, mockTxProcessor{true}, &mockAtxValidator{}, &mockSyncer{}, selectCount, layersPerEpoch, mockProjector, log.NewDefault(t.Name()))
+	bb := NewBlockBuilder(types.NodeID{Key: "a"}, signing.NewEdSigner(), n1, beginRound, 5, NewTxMemPool(), NewAtxMemPool(), MockCoin{}, &mockMesh{b: bs}, &mockResult{}, &mockBlockOracle{}, mockTxProcessor{true}, &mockAtxValidator{}, &mockSyncer{}, selectCount, selectCount, layersPerEpoch, mockProjector, log.NewDefault(t.Name()))
 	bottom, _ := calcHdistRange(5, bb.hdist)
 	r.True(bottom == 0)
 
@@ -616,7 +616,7 @@ func TestBlockBuilder_createBlock(t *testing.T) {
 	block3 := types.NewExistingBlock(0, []byte(rand.String(8)))
 	bs := []*types.Block{block1, block2, block3}
 	st := []types.BlockID{block1.ID(), block2.ID(), block3.ID()}
-	builder1 := NewBlockBuilder(types.NodeID{Key: "a"}, signing.NewEdSigner(), n1, beginRound, 5, NewTxMemPool(), NewAtxMemPool(), MockCoin{}, &mockMesh{b: bs}, hare, &mockBlockOracle{}, mockTxProcessor{true}, &mockAtxValidator{}, &mockSyncer{}, selectCount, layersPerEpoch, mockProjector, log.NewDefault(t.Name()))
+	builder1 := NewBlockBuilder(types.NodeID{Key: "a"}, signing.NewEdSigner(), n1, beginRound, 5, NewTxMemPool(), NewAtxMemPool(), MockCoin{}, &mockMesh{b: bs}, hare, &mockBlockOracle{}, mockTxProcessor{true}, &mockAtxValidator{}, &mockSyncer{}, selectCount, selectCount, layersPerEpoch, mockProjector, log.NewDefault(t.Name()))
 
 	builder1.hareResult = &mockResult{err: errExample, ids: nil}
 	b, err := builder1.createBlock(5, types.ATXID{}, types.BlockEligibilityProof{}, nil, nil)
@@ -641,7 +641,7 @@ func TestBlockBuilder_notSynced(t *testing.T) {
 	ms.notSynced = true
 	mbo := &mockBlockOracle{}
 	mbo.err = errors.New("err")
-	builder := NewBlockBuilder(types.NodeID{Key: "a"}, signing.NewEdSigner(), n1, beginRound, 5, NewTxMemPool(), NewAtxMemPool(), MockCoin{}, &mockMesh{b: bs}, hare, mbo, mockTxProcessor{true}, &mockAtxValidator{}, ms, selectCount, layersPerEpoch, mockProjector, log.NewDefault(t.Name()))
+	builder := NewBlockBuilder(types.NodeID{Key: "a"}, signing.NewEdSigner(), n1, beginRound, 5, NewTxMemPool(), NewAtxMemPool(), MockCoin{}, &mockMesh{b: bs}, hare, mbo, mockTxProcessor{true}, &mockAtxValidator{}, ms, selectCount, selectCount, layersPerEpoch, mockProjector, log.NewDefault(t.Name()))
 	go builder.acceptBlockData()
 	beginRound <- 1
 	beginRound <- 2
@@ -684,7 +684,7 @@ func Test_getVotesFiltered(t *testing.T) {
 	beginRound := make(chan types.LayerID)
 	n1 := service.NewSimulator().NewNode()
 	allblocks := []*types.Block{b5}
-	bb := NewBlockBuilder(types.NodeID{Key: "a"}, signing.NewEdSigner(), n1, beginRound, 5, NewTxMemPool(), NewAtxMemPool(), MockCoin{}, &mockMesh{b: allblocks}, &mockResult{}, &mockBlockOracle{}, mockTxProcessor{true}, &mockAtxValidator{}, &mockSyncer{}, selectCount, layersPerEpoch, mockProjector, log.NewDefault(t.Name()))
+	bb := NewBlockBuilder(types.NodeID{Key: "a"}, signing.NewEdSigner(), n1, beginRound, 5, NewTxMemPool(), NewAtxMemPool(), MockCoin{}, &mockMesh{b: allblocks}, &mockResult{}, &mockBlockOracle{}, mockTxProcessor{true}, &mockAtxValidator{}, &mockSyncer{}, selectCount, selectCount, layersPerEpoch, mockProjector, log.NewDefault(t.Name()))
 	// has bottom
 	mh := newMockResult()
 	mh.set(4)


### PR DESCRIPTION
## Motivation
Closes #1924 

Also required by API changes

## Changes
- Add a new top-level config property TxsPerBlock, to replace the former hardcoded const in block_builder
- Update tests
- Adds a command line flag to set it
- Removes a couple of other hardcoded command line flag numbers, and instead uses the defaults set in config

## Test Plan
No new functionality added, so existing tests should suffice
