### PR TITLE
[Merged by Bors] - FreeBSD compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ LDFLAGS = -ldflags "-X main.version=${VERSION} -X main.commit=${COMMIT} -X main.
 
 PKGS = $(shell go list ./...)
 
-PLATFORMS := windows linux darwin
+PLATFORMS := windows linux darwin freebsd
 os = $(word 1, $@)
 
 ifeq ($(BRANCH),develop)

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Since the project uses Go 1.11's Modules it is best to place the code **outside*
 
 ### Setting Up Local Dev Environment
 
-Building is supported on OS X, Linux and Windows.
+Building is supported on OS X, Linux, FreeBSD, and Windows.
 
 Install [Go 1.11 or later](https://golang.org/dl/) for your platform, if you haven't already.
 
@@ -111,11 +111,13 @@ To build `go-spacemesh` for your current system architecture, from the project r
 make build
 ```
 
+(On FreeBSD, you should instead use `gmake build`. You can install `gmake` with `pkg install gmake` if it isn't already installed.)
+
 This will (re-)generate protobuf files and build the `go-spacemesh` binary, saving it in the `build/` directory.
 
 To build a binary for a specific architecture directory use:
 ```
-make darwin | linux | windows
+make darwin | linux | freebsd | windows
 ```
 
 Platform-specific binaries are saved to the `/build` directory.

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/spacemeshos/ed25519 v0.0.0-20190530014421-e235766d15a1
 	github.com/spacemeshos/merkle-tree v0.0.0-20191028110812-1908c3126c82
 	github.com/spacemeshos/poet v0.1.0
-	github.com/spacemeshos/post v0.0.0-20191225190235-dfb8a5803e6d
+	github.com/spacemeshos/post v0.0.0-20200707150818-013318bab6f4
 	github.com/spacemeshos/sha256-simd v0.0.0-20190111104731-8575aafc88c9
 	github.com/spf13/afero v1.2.0 // indirect
 	github.com/spf13/cobra v1.0.0
@@ -41,7 +41,5 @@ require (
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 	nanomsg.org/go-mangos v1.4.0
 )
-
-replace github.com/spacemeshos/post => github.com/tzdybal/post v0.0.0-20200629203636-775866cafc8f
 
 go 1.13

--- a/go.mod
+++ b/go.mod
@@ -42,4 +42,6 @@ require (
 	nanomsg.org/go-mangos v1.4.0
 )
 
+replace github.com/spacemeshos/post => github.com/tzdybal/post v0.0.0-20200629203636-775866cafc8f
+
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -212,6 +212,8 @@ github.com/spacemeshos/merkle-tree v0.0.0-20191028110812-1908c3126c82 h1:FmAao0S
 github.com/spacemeshos/merkle-tree v0.0.0-20191028110812-1908c3126c82/go.mod h1:mPxjt4RONPxSUhxOq4bhSJyKVGQJ0VMSyRiE51dDLgE=
 github.com/spacemeshos/poet v0.1.0 h1:WYBCUjwvjmITFOwUqXYT/kUF5Z2xJcJjpNoM9SUYl7U=
 github.com/spacemeshos/poet v0.1.0/go.mod h1:hxca04tOsB0MYhhQ3ydZID9KwlTaJauiKD81GBeNL4s=
+github.com/spacemeshos/post v0.0.0-20200707150818-013318bab6f4 h1:7JcHmiyOWSpVAlYX95OGDiYBT2iZAI2xTEj25A1QTcY=
+github.com/spacemeshos/post v0.0.0-20200707150818-013318bab6f4/go.mod h1:Xr3vr5eiA/n8cW0vM0j79g4HyNT6/0MbGqU8EAGLDJk=
 github.com/spacemeshos/sha256-simd v0.0.0-20190111104731-8575aafc88c9 h1:Cc+np6ORem5wrvO+YHQ1sdu71ItiQVRiYB4ugazpgxM=
 github.com/spacemeshos/sha256-simd v0.0.0-20190111104731-8575aafc88c9/go.mod h1:Pz5LyRghtiEuSixOVGO0da5AxKBZa6+Yq8ZJfjTAPI0=
 github.com/spacemeshos/smutil v0.0.0-20190604133034-b5189449f5c5 h1:a+uIX0wjwWdK2JpsQnNhSdp3KDkqGg6P7Jp3nMZP8BM=
@@ -252,8 +254,6 @@ github.com/syndtr/goleveldb v1.0.1-0.20190318030020-c3a204f8e965/go.mod h1:9OrXJ
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tzdybal/go-disk-usage v1.0.0 h1:Bh3SuXMq7q9nkHa3Pw6i2EtZajy+2TkB/uSEpdfl3X4=
 github.com/tzdybal/go-disk-usage v1.0.0/go.mod h1:iWeGcy1PXacIP9NgpklK6EVAkQaeVGRn9psjC1gzLlA=
-github.com/tzdybal/post v0.0.0-20200629203636-775866cafc8f h1:mWtKL9BOUmypIC7hnq/38qyBNaKwbjWaETNcF+vwNVw=
-github.com/tzdybal/post v0.0.0-20200629203636-775866cafc8f/go.mod h1:Xr3vr5eiA/n8cW0vM0j79g4HyNT6/0MbGqU8EAGLDJk=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=

--- a/go.sum
+++ b/go.sum
@@ -186,8 +186,6 @@ github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084 h1:sofwID9zm4tzrgykg80hfFph1mryUeLRsUfoocVVmRY=
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/ricochet2200/go-disk-usage v0.0.0-20150921141558-f0d1b743428f h1:w4VLAgWDnrcBDFSi8Ppn/MrB/Z1A570+MV90CvMtVVA=
-github.com/ricochet2200/go-disk-usage v0.0.0-20150921141558-f0d1b743428f/go.mod h1:yhevTRDiduxPJHQDCtlqUn53ojFPkRh/mKhMUzQUCpc=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -214,8 +212,6 @@ github.com/spacemeshos/merkle-tree v0.0.0-20191028110812-1908c3126c82 h1:FmAao0S
 github.com/spacemeshos/merkle-tree v0.0.0-20191028110812-1908c3126c82/go.mod h1:mPxjt4RONPxSUhxOq4bhSJyKVGQJ0VMSyRiE51dDLgE=
 github.com/spacemeshos/poet v0.1.0 h1:WYBCUjwvjmITFOwUqXYT/kUF5Z2xJcJjpNoM9SUYl7U=
 github.com/spacemeshos/poet v0.1.0/go.mod h1:hxca04tOsB0MYhhQ3ydZID9KwlTaJauiKD81GBeNL4s=
-github.com/spacemeshos/post v0.0.0-20191225190235-dfb8a5803e6d h1:P1lqL/7LBg3QmCMBVbFfnhIi7/AOXfJvRg4RKTXkb9I=
-github.com/spacemeshos/post v0.0.0-20191225190235-dfb8a5803e6d/go.mod h1:43GwKHD+nI5wUzzUMwRbpJdC2r9dURZ6V3Jkc9eUMSE=
 github.com/spacemeshos/sha256-simd v0.0.0-20190111104731-8575aafc88c9 h1:Cc+np6ORem5wrvO+YHQ1sdu71ItiQVRiYB4ugazpgxM=
 github.com/spacemeshos/sha256-simd v0.0.0-20190111104731-8575aafc88c9/go.mod h1:Pz5LyRghtiEuSixOVGO0da5AxKBZa6+Yq8ZJfjTAPI0=
 github.com/spacemeshos/smutil v0.0.0-20190604133034-b5189449f5c5 h1:a+uIX0wjwWdK2JpsQnNhSdp3KDkqGg6P7Jp3nMZP8BM=
@@ -254,6 +250,10 @@ github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpP
 github.com/syndtr/goleveldb v1.0.1-0.20190318030020-c3a204f8e965 h1:1oFLiOyVl+W7bnBzGhf7BbIv9loSFQcieWWYIjLqcAw=
 github.com/syndtr/goleveldb v1.0.1-0.20190318030020-c3a204f8e965/go.mod h1:9OrXJhf154huy1nPWmuSrkgjPUtUNhA+Zmy+6AESzuA=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
+github.com/tzdybal/go-disk-usage v1.0.0 h1:Bh3SuXMq7q9nkHa3Pw6i2EtZajy+2TkB/uSEpdfl3X4=
+github.com/tzdybal/go-disk-usage v1.0.0/go.mod h1:iWeGcy1PXacIP9NgpklK6EVAkQaeVGRn9psjC1gzLlA=
+github.com/tzdybal/post v0.0.0-20200629203636-775866cafc8f h1:mWtKL9BOUmypIC7hnq/38qyBNaKwbjWaETNcF+vwNVw=
+github.com/tzdybal/post v0.0.0-20200629203636-775866cafc8f/go.mod h1:Xr3vr5eiA/n8cW0vM0j79g4HyNT6/0MbGqU8EAGLDJk=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
@@ -325,6 +325,8 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190502145724-3ef323f4f1fd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b h1:ag/x1USPSsqHud38I9BAC88qdNLDHHtQ4mlgQIZPPNA=
 golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1 h1:ogLJMz+qpzav7lGMh10LMvAkM/fAoGlaiiHYiFYdm80=
+golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/scripts/check-go-version.sh
+++ b/scripts/check-go-version.sh
@@ -1,4 +1,5 @@
-#!/usr/bin/env -S bash -e
+#!/usr/bin/env bash
+set -e
 # Ensure we use Go installed
 errcho() {
     RED='\033[0;31m'

--- a/scripts/check-go-version.sh
+++ b/scripts/check-go-version.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env -S bash -e
 # Ensure we use Go installed
 errcho() {
     RED='\033[0;31m'

--- a/scripts/genproto.sh
+++ b/scripts/genproto.sh
@@ -1,4 +1,5 @@
-#!/usr/bin/env -S bash -e
+#!/usr/bin/env bash
+set -e
 ./scripts/verify-protoc-gen-go.sh
 
 protoc=./devtools/bin/protoc

--- a/scripts/genproto.sh
+++ b/scripts/genproto.sh
@@ -27,14 +27,14 @@ if [ ! -f $protoc ] ; then
 fi
 
 echo "using protoc from $protoc"
-if [[ $protoc == "protoc" ]]; then
-	devtools_opts="-I./devtools/include/"
+if [[ `uname -s` == "FreeBSD" ]]; then
+	freebsd_opts="-I/usr/local/include/"
 fi
 
 grpc_gateway_path=$(go list -m -f '{{.Dir}}' github.com/grpc-ecosystem/grpc-gateway)
 googleapis_path="$grpc_gateway_path/third_party/googleapis"
 
 echo "Generating protobuf for api/pb"
-compile -I. -I$googleapis_path $devtools_opts --go_out=plugins=grpc:. api/pb/api.proto
-compile -I. -I$googleapis_path $devtools_opts --grpc-gateway_out=logtostderr=true:. api/pb/api.proto
-compile -I. -I$googleapis_path $devtools_opts --swagger_out=logtostderr=true:. api/pb/api.proto
+compile -I. -I$googleapis_path $freebsd_opts --go_out=plugins=grpc:. api/pb/api.proto
+compile -I. -I$googleapis_path $freebsd_opts --grpc-gateway_out=logtostderr=true:. api/pb/api.proto
+compile -I. -I$googleapis_path $freebsd_opts --swagger_out=logtostderr=true:. api/pb/api.proto

--- a/scripts/genproto.sh
+++ b/scripts/genproto.sh
@@ -27,11 +27,14 @@ if [ ! -f $protoc ] ; then
 fi
 
 echo "using protoc from $protoc"
+if [[ $protoc == "protoc" ]]; then
+	devtools_opts="-I./devtools/include/"
+fi
 
 grpc_gateway_path=$(go list -m -f '{{.Dir}}' github.com/grpc-ecosystem/grpc-gateway)
 googleapis_path="$grpc_gateway_path/third_party/googleapis"
 
 echo "Generating protobuf for api/pb"
-compile -I. -I$googleapis_path --go_out=plugins=grpc:. api/pb/api.proto
-compile -I. -I$googleapis_path --grpc-gateway_out=logtostderr=true:. api/pb/api.proto
-compile -I. -I$googleapis_path --swagger_out=logtostderr=true:. api/pb/api.proto
+compile -I. -I$googleapis_path $devtools_opts --go_out=plugins=grpc:. api/pb/api.proto
+compile -I. -I$googleapis_path $devtools_opts --grpc-gateway_out=logtostderr=true:. api/pb/api.proto
+compile -I. -I$googleapis_path $devtools_opts --swagger_out=logtostderr=true:. api/pb/api.proto

--- a/scripts/genproto.sh
+++ b/scripts/genproto.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env -S bash -e
 ./scripts/verify-protoc-gen-go.sh
 
 protoc=./devtools/bin/protoc

--- a/scripts/install-protobuf.sh
+++ b/scripts/install-protobuf.sh
@@ -32,9 +32,8 @@ unzip -u protoc.zip -d protoc3
 
 
 # create local devtools dir.
-mkdir devtools
-mkdir devtools/bin
-mkdir devtools/include
+mkdir -p devtools/bin
+mkdir -p devtools/include
 
 echo "moving bin/protoc to ./devtools/bin/protoc"
 mv protoc3/bin/* devtools/bin/

--- a/scripts/install-protobuf.sh
+++ b/scripts/install-protobuf.sh
@@ -1,4 +1,5 @@
-#!/usr/bin/env -S bash -e
+#!/usr/bin/env bash
+set -e
 # Detect OS and architecture
 kernel=`uname -s`
 arch=`uname -m`

--- a/scripts/install-protobuf.sh
+++ b/scripts/install-protobuf.sh
@@ -11,7 +11,7 @@ elif [[ $kernel == "FreeBSD" ]]; then
 		echo "protoc already installed"
 		exit 0
 	else
-		echo "protoc not found in \$PATH, install it with: sudo pkg install protbuf"
+		echo "protoc not found in \$PATH, install it with: sudo pkg install protobuf"
 		exit 1
 	fi
 else

--- a/scripts/install-protobuf.sh
+++ b/scripts/install-protobuf.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env -S bash -e
 # Detect OS and architecture
 if [[ $(uname -s) == "Linux" ]]; then
     os="linux";

--- a/scripts/install-protobuf.sh
+++ b/scripts/install-protobuf.sh
@@ -1,14 +1,25 @@
 #!/usr/bin/env -S bash -e
 # Detect OS and architecture
-if [[ $(uname -s) == "Linux" ]]; then
+kernel=`uname -s`
+arch=`uname -m`
+if [[ $kernel == "Linux" ]]; then
     os="linux";
-elif [[ $(uname -s) == "Darwin" ]]; then # MacOS
+elif [[ $kernel == "Darwin" ]]; then # MacOS
     os="osx";
+elif [[ $kernel == "FreeBSD" ]]; then
+	if [[ -x `which protoc` ]]; then
+		echo "protoc already installed"
+		exit 0
+	else
+		echo "protoc not found in \$PATH, install it with: sudo pkg install protbuf"
+		exit 1
+	fi
 else
     echo "unsupported OS, protoc not installed"
     exit 1;
 fi
-arch=$(uname -m)
+
+
 protoc_url=https://github.com/protocolbuffers/protobuf/releases/download/v3.6.1/protoc-3.6.1-${os}-${arch}.zip
 
 # Make sure you grab the latest version

--- a/scripts/verify-protoc-gen-go.sh
+++ b/scripts/verify-protoc-gen-go.sh
@@ -1,4 +1,5 @@
-#!/usr/bin/env -S bash -e
+#!/usr/bin/env bash
+set -e
 # Ensure protoc-gen-go is installed
 errcho() {
     RED='\033[0;31m'

--- a/scripts/verify-protoc-gen-go.sh
+++ b/scripts/verify-protoc-gen-go.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env -S bash -e
 # Ensure protoc-gen-go is installed
 errcho() {
     RED='\033[0;31m'

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env -S bash -e
 ./scripts/check-go-version.sh
 ./scripts/install-protobuf.sh
 

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -1,4 +1,5 @@
-#!/usr/bin/env -S bash -e
+#!/usr/bin/env bash
+set -e
 ./scripts/check-go-version.sh
 ./scripts/install-protobuf.sh
 


### PR DESCRIPTION
## Motivation
This PR makes it possible to compile and run `go-spacemesh` on FreeBSD.

## Changes
Some fixes to makes build scripts more portable.
Temporal update `post` of dependency, before spacemeshos/post#38 is merged.

## Test Plan
1. Checkout code on FreeBSD machine.
2. Run `gmake`.
3. Run `./build/go-spacemesh`

I'm running my FreeBSD node for some time, without any issues.