### PR TITLE
[Merged by Bors] - Add cmdline flag for tcp interface

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -71,8 +71,7 @@ func AddCommands(cmd *cobra.Command) {
 	cmd.PersistentFlags().IntVar(&config.P2P.TCPPort, "tcp-port",
 		config.P2P.TCPPort, "inet port for P2P listener")
 	cmd.PersistentFlags().StringVar(&config.P2P.TCPInterface, "tcp-interface",
-		config.P2P.TCPInterface, "inet interface for P2P listener, "+
-			"specify as IP address, default is to listen on all interfaces")
+		config.P2P.TCPInterface, "inet interface for P2P listener, specify as IP address")
 	cmd.PersistentFlags().BoolVar(&config.P2P.AcquirePort, "acquire-port",
 		config.P2P.AcquirePort, "Should the node attempt to forward the port to this machine on a NAT?")
 	cmd.PersistentFlags().DurationVar(&config.P2P.DialTimeout, "dial-timeout",

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -69,7 +69,9 @@ func AddCommands(cmd *cobra.Command) {
 	/** ======================== P2P Flags ========================== **/
 
 	cmd.PersistentFlags().IntVar(&config.P2P.TCPPort, "tcp-port",
-		config.P2P.TCPPort, "TCP Port to listen on")
+		config.P2P.TCPPort, "inet port for P2P listener")
+	cmd.PersistentFlags().StringVar(&config.P2P.TCPInterface, "tcp-interface",
+		config.P2P.TCPInterface, "inet interface for P2P listener")
 	cmd.PersistentFlags().BoolVar(&config.P2P.AcquirePort, "acquire-port",
 		config.P2P.AcquirePort, "Should the node attempt to forward the port to this machine on a NAT?")
 	cmd.PersistentFlags().DurationVar(&config.P2P.DialTimeout, "dial-timeout",

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -71,7 +71,8 @@ func AddCommands(cmd *cobra.Command) {
 	cmd.PersistentFlags().IntVar(&config.P2P.TCPPort, "tcp-port",
 		config.P2P.TCPPort, "inet port for P2P listener")
 	cmd.PersistentFlags().StringVar(&config.P2P.TCPInterface, "tcp-interface",
-		config.P2P.TCPInterface, "inet interface for P2P listener")
+		config.P2P.TCPInterface, "inet interface for P2P listener, "+
+			"specify as IP address, default is to listen on all interfaces")
 	cmd.PersistentFlags().BoolVar(&config.P2P.AcquirePort, "acquire-port",
 		config.P2P.AcquirePort, "Should the node attempt to forward the port to this machine on a NAT?")
 	cmd.PersistentFlags().DurationVar(&config.P2P.DialTimeout, "dial-timeout",

--- a/p2p/config/config.go
+++ b/p2p/config/config.go
@@ -16,10 +16,10 @@ const (
 	NodesDirectoryName = "nodes"
 	// UnlimitedMsgSize is a constant used to check whether message size is set to unlimited size
 	UnlimitedMsgSize = 0
-	// defaultTcpPort is the inet port that P2P listens on by default
-	defaultTcpPort = 7513
-	// defaultTcpInterface is the inet interface that P2P listens on by default
-	defaultTcpInterface = "0.0.0.0"
+	// defaultTCPPort is the inet port that P2P listens on by default
+	defaultTCPPort = 7513
+	// defaultTCPInterface is the inet interface that P2P listens on by default
+	defaultTCPInterface = "0.0.0.0"
 )
 
 // Values specifies default values for node config params.
@@ -84,8 +84,8 @@ func DefaultConfig() Config {
 	}
 
 	return Config{
-		TCPPort:               defaultTcpPort,
-		TCPInterface:          defaultTcpInterface,
+		TCPPort:               defaultTCPPort,
+		TCPInterface:          defaultTCPInterface,
 		AcquirePort:           true,
 		NodeID:                "",
 		DialTimeout:           duration("1m"),

--- a/p2p/config/config.go
+++ b/p2p/config/config.go
@@ -16,6 +16,10 @@ const (
 	NodesDirectoryName = "nodes"
 	// UnlimitedMsgSize is a constant used to check whether message size is set to unlimited size
 	UnlimitedMsgSize = 0
+	// defaultTcpPort is the inet port that P2P listens on by default
+	defaultTcpPort = 7513
+	// defaultTcpInterface is the inet interface that P2P listens on by default
+	defaultTcpInterface = "0.0.0.0"
 )
 
 // Values specifies default values for node config params.
@@ -38,6 +42,7 @@ func duration(duration string) (dur time.Duration) {
 // Config defines the configuration options for the Spacemesh peer-to-peer networking layer
 type Config struct {
 	TCPPort               int           `mapstructure:"tcp-port"`
+	TCPInterface          string        `mapstructure:"tcp-interface"`
 	AcquirePort           bool          `mapstructure:"acquire-port"`
 	NodeID                string        `mapstructure:"node-id"`
 	DialTimeout           time.Duration `mapstructure:"dial-timeout"`
@@ -79,7 +84,8 @@ func DefaultConfig() Config {
 	}
 
 	return Config{
-		TCPPort:               7513,
+		TCPPort:               defaultTcpPort,
+		TCPInterface:          defaultTcpInterface,
 		AcquirePort:           true,
 		NodeID:                "",
 		DialTimeout:           duration("1m"),

--- a/p2p/net/network.go
+++ b/p2p/net/network.go
@@ -58,7 +58,7 @@ type Net struct {
 	logger    log.Log
 
 	listener      net.Listener
-	listenAddress *net.TCPAddr // Address to open connection: localhost:9999\
+	listenAddress *net.TCPAddr // Address to open connection: localhost:9999
 
 	isShuttingDown bool
 
@@ -252,6 +252,10 @@ func createSession(privkey p2pcrypto.PrivateKey, remotePubkey p2pcrypto.PublicKe
 // Returns established connection that local clients can send messages to or error if failed
 // to establish a connection, currently only secured connections are supported
 func (n *Net) Dial(ctx context.Context, address net.Addr, remotePubkey p2pcrypto.PublicKey) (Connection, error) {
+	if n.listenAddress == nil {
+		return nil, errors.New("net listenAddress must be set")
+	}
+
 	conn, err := n.createSecuredConnection(ctx, address, remotePubkey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to Dial. err: %v", err)

--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -350,14 +350,14 @@ func (s *Switch) sendMessageImpl(peerPubKey p2pcrypto.PublicKey, protocol string
 	var conn net.Connection
 
 	if s.discover.IsLocalAddress(&node.Info{ID: peerPubKey.Array()}) {
-		return errors.New("can't sent message to self")
+		return errors.New("can't send message to self")
 		//TODO: if this is our neighbor it should be removed right now.
 	}
 
 	conn, err = s.cPool.GetConnectionIfExists(peerPubKey)
 
 	if err != nil {
-		return errors.New("this peers isn't a neighbor or lost connection")
+		return errors.New("this peer isn't a neighbor or connection lost")
 	}
 
 	session := conn.Session()

--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -903,8 +903,6 @@ func (s *Switch) hasOutgoingPeer(peer p2pcrypto.PublicKey) bool {
 	return ok
 }
 
-var listeningIP = inet.ParseIP("0.0.0.0")
-
 // network methods used to accumulate os and router ports.
 
 func (s *Switch) getListeners(
@@ -927,6 +925,7 @@ func (s *Switch) getListeners(
 	}
 
 	upnpFails := 0
+	var listeningIP = inet.ParseIP(s.config.TCPInterface)
 	for {
 		tcpAddr := &inet.TCPAddr{IP: listeningIP, Port: port}
 		tcpListener, err := getTCPListener(tcpAddr)

--- a/p2p/switch_test.go
+++ b/p2p/switch_test.go
@@ -1127,7 +1127,7 @@ func TestSwarm_SendMessage(t *testing.T) {
 	//payload := service.DataBytes{Payload:[]byte("LOL")}
 
 	err := p.SendMessage(someky, proto, []byte("LOL"))
-	require.Equal(t, err, errors.New("can't sent message to self"))
+	require.Equal(t, err, errors.New("can't send message to self"))
 
 	ps.IsLocalAddressFunc = func(info *node.Info) bool {
 		return false
@@ -1138,7 +1138,7 @@ func TestSwarm_SendMessage(t *testing.T) {
 	}
 
 	err = p.SendMessage(someky, proto, []byte("LOL"))
-	require.Equal(t, err, errors.New("this peers isn't a neighbor or lost connection"))
+	require.Equal(t, err, errors.New("this peer isn't a neighbor or connection lost"))
 
 	cp.fExists = func(pk p2pcrypto.PublicKey) (connection net.Connection, err error) {
 		return net.NewConnectionMock(pk), nil


### PR DESCRIPTION
This, in combination with --acquire-port=false, prevents the obnoxious
warning popup in macOS.

## Motivation
Fixes the issue described in https://github.com/spacemeshos/go-spacemesh/issues/289#issuecomment-574906535 where macOS prompts the user to allow incoming connections every time the node is run. While this permission is cached by the OS for a production app, there is no way around it in development since it reappears each time the app is recompiled.

To prevent this popup, with this change, run go-spacemesh with `--acquire-port=false --tcp-interface 127.0.0.1` (a similar flag was added for the new GRPC server in a10ce1e146367942e275a9225eef1fee6f6e38f3).

## Changes
- adds a new commandline flag
- removes the hardcoded "0.0.0.0" from P2P listener

## Test Plan
- Run node with and without the new flag and check if it's listening on the right interface

## TODO
- [ ] Add test
