### PR TITLE
[Merged by Bors] - removes unused params from log InitSpacemeshLoggingSystem

### DIFF
--- a/cmd/base.go
+++ b/cmd/base.go
@@ -84,7 +84,7 @@ func setupLogging(config *bc.Config) {
 	}
 
 	// app-level logging
-	log.InitSpacemeshLoggingSystem(config.DataDir(), "spacemesh.log")
+	log.InitSpacemeshLoggingSystem()
 }
 
 func parseConfig() (*bc.Config, error) {

--- a/cmd/integration/harness.go
+++ b/cmd/integration/harness.go
@@ -81,7 +81,7 @@ func NewHarness(cfg *ServerConfig, args []string) (*Harness, error) {
 func main() {
 	// setup logger
 	log.JSONLog(true)
-	log.InitSpacemeshLoggingSystem("/tmp/", "spacemesh.log")
+	log.InitSpacemeshLoggingSystem()
 
 	dummyChan := make(chan string)
 	// os.Args[0] contains the current process path

--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -278,7 +278,7 @@ func (app *SpacemeshApp) setupLogging() {
 	}
 
 	// app-level logging
-	log.InitSpacemeshLoggingSystem(app.Config.DataDir(), "spacemesh.log")
+	log.InitSpacemeshLoggingSystem()
 
 	log.Info("%s", app.getAppInfo())
 

--- a/log/log.go
+++ b/log/log.go
@@ -124,7 +124,7 @@ func getFileWriter(dataFolderPath, logFileName string) io.Writer {
 }
 
 // InitSpacemeshLoggingSystem initializes app logging system.
-func InitSpacemeshLoggingSystem(dataFolderPath string, logFileName string) {
+func InitSpacemeshLoggingSystem() {
 	AppLog = NewDefault(mainLoggerName)
 }
 


### PR DESCRIPTION
## Motivation
The InitSpacemeshLoggingSystem function in log contains unused parameters.

Closes #2065

## Changes
Removes unused function parameters in log InitSpacemeshLoggingSystem.
Cleans us all instances it was called.

## Test Plan
Tested and checked manually, there doesn't look to be testing for log functions.

