### PR TITLE
Fix handling of module log levels

### DIFF
--- a/cmd/base.go
+++ b/cmd/base.go
@@ -84,7 +84,7 @@ func setupLogging(config *bc.Config) {
 	}
 
 	// app-level logging
-	log.InitSpacemeshLoggingSystem(config.DataDir(), "spacemesh.log")
+	log.InitSpacemeshLoggingSystem()
 }
 
 func parseConfig() (*bc.Config, error) {

--- a/cmd/integration/harness.go
+++ b/cmd/integration/harness.go
@@ -81,7 +81,7 @@ func NewHarness(cfg *ServerConfig, args []string) (*Harness, error) {
 func main() {
 	// setup logger
 	log.JSONLog(true)
-	log.InitSpacemeshLoggingSystem("/tmp/", "spacemesh.log")
+	log.InitSpacemeshLoggingSystem()
 
 	dummyChan := make(chan string)
 	// os.Args[0] contains the current process path

--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -456,11 +456,6 @@ func (app *SpacemeshApp) initServices(nodeID types.NodeID,
 	layersPerEpoch uint16, clock TickProvider) error {
 
 	app.nodeID = nodeID
-
-	//name := nodeID.ShortString()
-	//lg := log.NewDefault(name).WithFields(nodeID)
-	//lgDebug := log.NewWithLevel(name, zap.NewAtomicLevelAt(zapcore.DebugLevel)).WithFields(nodeID)
-
 	app.log = app.addLogger(nodeID, AppLogger)
 
 	postClient.SetLogger(app.addLogger(nodeID, PostLogger))
@@ -938,8 +933,6 @@ func (app *SpacemeshApp) Start(cmd *cobra.Command, args []string) {
 	}
 
 	/* Initialize all protocol services */
-	//lg := log.NewDefault(nodeID.ShortString())
-
 	dbStorepath := app.Config.DataDir()
 	gTime, err := time.Parse(time.RFC3339, app.Config.GenesisTime)
 	if err != nil {

--- a/log/log.go
+++ b/log/log.go
@@ -86,7 +86,7 @@ func NewWithLevel(module string, level zap.AtomicLevel, hooks ...func(zapcore.En
 	consoleCore := zapcore.NewCore(enc, consoleSyncer, zap.LevelEnablerFunc(level.Enabled))
 	core := zapcore.RegisterHooks(consoleCore, hooks...)
 	log := zap.New(core).Named(module)
-	return Log{log, log.Sugar(), &level}
+	return Log{log}
 }
 
 // New creates a logger for a module. e.g. p2p instance logger.
@@ -108,8 +108,7 @@ func New(module string, dataFolderPath string, logFileName string) Log {
 
 	log := zap.New(core)
 	log = log.Named(module)
-	lvl := zap.NewAtomicLevelAt(Level())
-	return Log{log, log.Sugar(), &lvl}
+	return Log{log}
 }
 
 // NewDefault creates a Log with not file output.

--- a/log/zap.go
+++ b/log/zap.go
@@ -9,14 +9,15 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-// NilLogger is a not initialized logger it will panic if you'll call methods on it.
-var NilLogger Log
-
 // Log is an exported type that embeds our logger.
 type Log struct {
 	logger *zap.Logger
 	sugar  *zap.SugaredLogger
 	lvl    *zap.AtomicLevel
+}
+
+func (l Log) Level() *zap.AtomicLevel {
+	return l.lvl
 }
 
 // Exported from Log basic logging options.

--- a/log/zap.go
+++ b/log/zap.go
@@ -12,35 +12,34 @@ import (
 // Log is an exported type that embeds our logger.
 type Log struct {
 	logger *zap.Logger
-	sugar  *zap.SugaredLogger
 }
 
 // Exported from Log basic logging options.
 
 // Info prints formatted info level log message.
 func (l Log) Info(format string, args ...interface{}) {
-	l.sugar.Infof(format, args...)
+	l.logger.Sugar().Infof(format, args...)
 }
 
 // Debug prints formatted debug level log message.
 func (l Log) Debug(format string, args ...interface{}) {
-	l.sugar.Debugf(format, args...)
+	l.logger.Sugar().Debugf(format, args...)
 }
 
 // Error prints formatted error level log message.
 func (l Log) Error(format string, args ...interface{}) {
-	l.sugar.Errorf(format, args...)
+	l.logger.Sugar().Errorf(format, args...)
 }
 
 // Warning prints formatted warning level log message.
 func (l Log) Warning(format string, args ...interface{}) {
-	l.sugar.Warnf(format, args...)
+	l.logger.Sugar().Warnf(format, args...)
 }
 
 // Panic prints the log message and then panics.
 func (l Log) Panic(format string, args ...interface{}) {
-	l.sugar.Error("Fatal: goroutine panicked. Stacktrace: ", string(debug.Stack()))
-	l.sugar.Panicf(format, args...)
+	l.logger.Sugar().Error("Fatal: goroutine panicked. Stacktrace: ", string(debug.Stack()))
+	l.logger.Sugar().Panicf(format, args...)
 }
 
 // Wrap and export field logic
@@ -129,19 +128,13 @@ func (l Log) With() FieldLogger {
 // WithName returns a logger the given fields
 func (l Log) WithName(prefix string) Log {
 	lgr := l.logger.Named(fmt.Sprintf("%-13s", prefix))
-	return Log{
-		lgr,
-		lgr.Sugar(),
-	}
+	return Log{lgr}
 }
 
 // WithFields returns a logger with fields permanently appended to it.
 func (l Log) WithFields(fields ...LoggableField) Log {
 	lgr := l.logger.With(unpack(fields)...)
-	return Log{
-		logger: lgr,
-		sugar:  lgr.Sugar(),
-	}
+	return Log{logger: lgr}
 }
 
 const eventKey = "event"
@@ -160,10 +153,7 @@ var Nop = zap.WrapCore(func(zapcore.Core) zapcore.Core {
 // returns the resulting Logger. It's safe to use concurrently.
 func (l Log) WithOptions(opts ...zap.Option) Log {
 	lgr := l.logger.WithOptions(opts...)
-	return Log{
-		logger: lgr,
-		sugar:  lgr.Sugar(),
-	}
+	return Log{logger: lgr}
 }
 
 // Info prints message with fields

--- a/log/zap.go
+++ b/log/zap.go
@@ -13,11 +13,6 @@ import (
 type Log struct {
 	logger *zap.Logger
 	sugar  *zap.SugaredLogger
-	lvl    *zap.AtomicLevel
-}
-
-func (l Log) Level() *zap.AtomicLevel {
-	return l.lvl
 }
 
 // Exported from Log basic logging options.
@@ -131,50 +126,14 @@ func (l Log) With() FieldLogger {
 	return FieldLogger{l.logger}
 }
 
-// SetLevel returns a logger with level as the log level derived from l.
-//func (l Log) SetLevel(level *zap.AtomicLevel) Log {
-//	lgr := l.logger.WithOptions(addDynamicLevel(level))
-//	return Log{
-//		lgr,
-//		lgr.Sugar(),
-//		level,
-//	}
-//}
-
 // WithName returns a logger the given fields
 func (l Log) WithName(prefix string) Log {
 	lgr := l.logger.Named(fmt.Sprintf("%-13s", prefix))
 	return Log{
 		lgr,
 		lgr.Sugar(),
-		l.lvl,
 	}
 }
-
-//func addDynamicLevel(level *zap.AtomicLevel) zap.Option {
-//	return zap.WrapCore(func(core zapcore.Core) zapcore.Core {
-//		return &coreWithLevel{
-//			Core: core,
-//			lvl:  level,
-//		}
-//	})
-//}
-
-//type coreWithLevel struct {
-//	zapcore.Core
-//	lvl *zap.AtomicLevel
-//}
-
-//func (c *coreWithLevel) Enabled(level zapcore.Level) bool {
-//	return c.lvl.Enabled(level)
-//}
-//
-//func (c *coreWithLevel) Check(e zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
-//	if !c.lvl.Enabled(e.Level) {
-//		return ce
-//	}
-//	return ce.AddCore(e, c.Core)
-//}
 
 // WithFields returns a logger with fields permanently appended to it.
 func (l Log) WithFields(fields ...LoggableField) Log {
@@ -182,7 +141,6 @@ func (l Log) WithFields(fields ...LoggableField) Log {
 	return Log{
 		logger: lgr,
 		sugar:  lgr.Sugar(),
-		lvl:    l.lvl,
 	}
 }
 
@@ -205,7 +163,6 @@ func (l Log) WithOptions(opts ...zap.Option) Log {
 	return Log{
 		logger: lgr,
 		sugar:  lgr.Sugar(),
-		lvl:    l.lvl,
 	}
 }
 

--- a/log/zap.go
+++ b/log/zap.go
@@ -132,18 +132,18 @@ func (l Log) With() FieldLogger {
 }
 
 // SetLevel returns a logger with level as the log level derived from l.
-func (l Log) SetLevel(level *zap.AtomicLevel) Log {
-	lgr := l.logger.WithOptions(addDynamicLevel(level))
-	return Log{
-		lgr,
-		lgr.Sugar(),
-		level,
-	}
-}
+//func (l Log) SetLevel(level *zap.AtomicLevel) Log {
+//	lgr := l.logger.WithOptions(addDynamicLevel(level))
+//	return Log{
+//		lgr,
+//		lgr.Sugar(),
+//		level,
+//	}
+//}
 
 // WithName returns a logger the given fields
 func (l Log) WithName(prefix string) Log {
-	lgr := l.logger.Named(fmt.Sprintf("%-13s", prefix)).WithOptions(addDynamicLevel(l.lvl))
+	lgr := l.logger.Named(fmt.Sprintf("%-13s", prefix))
 	return Log{
 		lgr,
 		lgr.Sugar(),
@@ -151,34 +151,34 @@ func (l Log) WithName(prefix string) Log {
 	}
 }
 
-func addDynamicLevel(level *zap.AtomicLevel) zap.Option {
-	return zap.WrapCore(func(core zapcore.Core) zapcore.Core {
-		return &coreWithLevel{
-			Core: core,
-			lvl:  level,
-		}
-	})
-}
+//func addDynamicLevel(level *zap.AtomicLevel) zap.Option {
+//	return zap.WrapCore(func(core zapcore.Core) zapcore.Core {
+//		return &coreWithLevel{
+//			Core: core,
+//			lvl:  level,
+//		}
+//	})
+//}
 
-type coreWithLevel struct {
-	zapcore.Core
-	lvl *zap.AtomicLevel
-}
+//type coreWithLevel struct {
+//	zapcore.Core
+//	lvl *zap.AtomicLevel
+//}
 
-func (c *coreWithLevel) Enabled(level zapcore.Level) bool {
-	return c.lvl.Enabled(level)
-}
-
-func (c *coreWithLevel) Check(e zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
-	if !c.lvl.Enabled(e.Level) {
-		return ce
-	}
-	return ce.AddCore(e, c.Core)
-}
+//func (c *coreWithLevel) Enabled(level zapcore.Level) bool {
+//	return c.lvl.Enabled(level)
+//}
+//
+//func (c *coreWithLevel) Check(e zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
+//	if !c.lvl.Enabled(e.Level) {
+//		return ce
+//	}
+//	return ce.AddCore(e, c.Core)
+//}
 
 // WithFields returns a logger with fields permanently appended to it.
 func (l Log) WithFields(fields ...LoggableField) Log {
-	lgr := l.logger.With(unpack(fields)...).WithOptions(addDynamicLevel(l.lvl))
+	lgr := l.logger.With(unpack(fields)...)
 	return Log{
 		logger: lgr,
 		sugar:  lgr.Sugar(),

--- a/log/zap.go
+++ b/log/zap.go
@@ -115,7 +115,7 @@ func unpack(fields []LoggableField) []zap.Field {
 	return flds
 }
 
-// FieldLogger is a logger that only logs messages with fields. it does not support formatting.g
+// FieldLogger is a logger that only logs messages with fields. It does not support formatting.
 type FieldLogger struct {
 	l *zap.Logger
 }


### PR DESCRIPTION
## Motivation
See #2090 

One way to fix this would be to instantiate a new logger for each module, but this would lose the hierarchy of loggers and the prefix with node ID. Another possible fix would be to lower the parent logger log level to the level of the lowest child logger. A third possibility is to keep an array/map of loggers, one per required log level.

## Changes
- store an array of app "root" loggers, one per log level, and reuse them when possible
- use these rather than trying to change levels of already-instantiated loggers
- introduce a simpler, cleaner way to instantiate a logger (`NewWithLevel`)
- includes some of the same changes as #2087

## Notes
- With level removed, there's not much need to have our own Log type in the first place. There's still some added niceties around field logging, but I think we could remove a ton of the Log logic and just use the underlying types for most, if not all, of this functionality.

## Test Plan
TBD

## To do
- add a test
- check if cmd/node.go functionality to change a module log level still works

Closes #2065
Closes #2090