### PR TITLE
[Merged by Bors] - Container from local build

### DIFF
--- a/DockerfilePrebuiltBinary
+++ b/DockerfilePrebuiltBinary
@@ -1,0 +1,16 @@
+FROM alpine AS spacemesh
+
+COPY go-spacemesh /bin/go-spacemesh
+COPY go-hare /bin/go-hare
+COPY go-p2p /bin/go-p2p
+COPY go-sync /bin/go-sync
+COPY go-harness /bin/go-harness
+
+ENTRYPOINT ["/bin/go-harness"]
+EXPOSE 7513
+
+# profiling port
+EXPOSE 6060
+
+# pubsub port
+EXPOSE 56565

--- a/Makefile
+++ b/Makefile
@@ -62,36 +62,36 @@ endif
 
 hare:
 ifeq ($(OS),Windows_NT)
-	cd cmd/hare ; go build -o $(BIN_DIR_WIN)/go-hare.exe; cd ..
+	cd cmd/hare ; go build -o $(BIN_DIR_WIN)/go-hare.exe
 else
-	cd cmd/hare ; go build -o $(BIN_DIR)/go-hare; cd ..
+	cd cmd/hare ; go build -o $(BIN_DIR)/go-hare
 endif
 .PHONY: hare
 
 
 p2p:
 ifeq ($(OS),WINDOWS_NT)
-	cd cmd/p2p ; go build -o $(BIN_DIR_WIN)/go-p2p.exe; cd ..
+	cd cmd/p2p ; go build -o $(BIN_DIR_WIN)/go-p2p.exe
 else
-	cd cmd/p2p ; go build -o $(BIN_DIR)/go-p2p; cd ..
+	cd cmd/p2p ; go build -o $(BIN_DIR)/go-p2p
 endif
 .PHONY: p2p
 
 
 sync:
 ifeq ($(OS),WINDOWS_NT)
-	cd cmd/sync ; go build -o $(BIN_DIR_WIN)/go-sync.exe; cd ..
+	cd cmd/sync ; go build -o $(BIN_DIR_WIN)/go-sync.exe
 else
-	cd cmd/sync ; go build -o $(BIN_DIR)/go-sync; cd ..
+	cd cmd/sync ; go build -o $(BIN_DIR)/go-sync
 endif
 .PHONY: sync
 
 
 harness:
 ifeq ($(OS),WINDOWS_NT)
-	cd cmd/integration ; go build -o $(BIN_DIR_WIN)/go-harness.exe; cd ..
+	cd cmd/integration ; go build -o $(BIN_DIR_WIN)/go-harness.exe
 else
-	cd cmd/integration ; go build -o $(BIN_DIR)/go-harness; cd ..
+	cd cmd/integration ; go build -o $(BIN_DIR)/go-harness
 endif
 .PHONY: harness
 
@@ -112,11 +112,11 @@ endif
 
 docker-local-build: genproto
 	GOOS=linux GOARCH=amd64 go build ${LDFLAGS} -o $(BIN_DIR)/$(BINARY)
-	cd cmd/hare ; GOOS=linux GOARCH=amd64 go build -o $(BIN_DIR)/go-hare; cd ..
-	cd cmd/p2p ; GOOS=linux GOARCH=amd64 go build -o $(BIN_DIR)/go-p2p; cd ..
-	cd cmd/sync ; GOOS=linux GOARCH=amd64 go build -o $(BIN_DIR)/go-sync; cd ..
-	cd cmd/integration ; GOOS=linux GOARCH=amd64 go build -o $(BIN_DIR)/go-harness; cd ..
-	cd build ; docker build -f ../DockerfilePrebuiltBinary -t $(DOCKER_IMAGE_REPO):$(BRANCH) . ; cd ..
+	cd cmd/hare ; GOOS=linux GOARCH=amd64 go build -o $(BIN_DIR)/go-hare
+	cd cmd/p2p ; GOOS=linux GOARCH=amd64 go build -o $(BIN_DIR)/go-p2p
+	cd cmd/sync ; GOOS=linux GOARCH=amd64 go build -o $(BIN_DIR)/go-sync
+	cd cmd/integration ; GOOS=linux GOARCH=amd64 go build -o $(BIN_DIR)/go-harness
+	cd build ; docker build -f ../DockerfilePrebuiltBinary -t $(DOCKER_IMAGE_REPO):$(BRANCH) .
 .PHONY: docker-local-build
 
 

--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -1,7 +1,6 @@
 // Package node contains the main executable for go-spacemesh node
 package node
 
-import "C"
 import (
 	"context"
 	"fmt"


### PR DESCRIPTION
## Motivation
I needed to run a build with a replace directive in `go.mod` referencing a locally changed dependency. Building like this inside a container requires copying the dependency's code into the container, which adds complexity.

## Changes
This code uses cross-compilation to make linux builds and just copy them into a fresh Docker container that can be deployed to our testing env.

## Test Plan
Tested by running on our testing env.

## Caveats
This depends on cross-compilation, so if we break it (e.g. by integrating SVM / GPU-PoST) this method will no longer work.