### PR TITLE
[Merged by Bors] - fixed panic bug on cache eviction. added scenario to test. 

### DIFF
--- a/p2p/net/udp.go
+++ b/p2p/net/udp.go
@@ -277,8 +277,8 @@ func (n *UDPNet) addConn(addr net.Addr, ucw udpConn) {
 		for k, c := range n.incomingConn {
 			lastk = k
 			if time.Since(c.Created()) > maxUDPLife {
-				n.incomingConn[k].Close()
 				delete(n.incomingConn, k)
+				c.Close()
 				evicted = true
 				break
 			}

--- a/p2p/net/udp.go
+++ b/p2p/net/udp.go
@@ -277,9 +277,9 @@ func (n *UDPNet) addConn(addr net.Addr, ucw udpConn) {
 		for k, c := range n.incomingConn {
 			lastk = k
 			if time.Since(c.Created()) > maxUDPLife {
+				n.incomingConn[k].Close()
 				delete(n.incomingConn, k)
 				evicted = true
-				n.incomingConn[k].Close()
 				break
 			}
 

--- a/p2p/net/udp_test.go
+++ b/p2p/net/udp_test.go
@@ -222,7 +222,7 @@ func TestUDPNet_Cache(t *testing.T) {
 	}})
 	require.Len(t, n.incomingConn, 1)
 
-	for i := 1; i < maxUDPConn; i++ {
+	for i := 1; i < maxUDPConn-1; i++ {
 		addrx := testUDPAddr()
 		_, ok := n.incomingConn[addrx.String()]
 		for ok {
@@ -234,7 +234,7 @@ func TestUDPNet_Cache(t *testing.T) {
 		}})
 	}
 
-	require.Len(t, n.incomingConn, maxUDPConn)
+	require.Len(t, n.incomingConn, maxUDPConn-1)
 
 	addrx := testUDPAddr()
 	_, ok := n.incomingConn[addrx.String()]
@@ -242,9 +242,23 @@ func TestUDPNet_Cache(t *testing.T) {
 		addrx = testUDPAddr()
 		_, ok = n.incomingConn[addrx.String()]
 	}
+
 	n.addConn(addrx, &udpConnMock{CreatedFunc: func() time.Time {
+		return time.Now().Add(-maxUDPLife - 1*time.Second)
+	}})
+
+	require.Len(t, n.incomingConn, maxUDPConn)
+
+	addrx2 := testUDPAddr()
+	_, ok2 := n.incomingConn[addrx2.String()]
+	for ok2 {
+		addrx2 = testUDPAddr()
+		_, ok = n.incomingConn[addrx2.String()]
+	}
+	n.addConn(addrx2, &udpConnMock{CreatedFunc: func() time.Time {
 		return time.Now()
 	}})
+
 	require.Len(t, n.incomingConn, maxUDPConn)
 
 	i := 0


### PR DESCRIPTION
## Motivation
When udp message from a new peer would arrive and the udp session state cache was full we try to evict one session. if one of the sessions in the state is older than 24hours we remove it first. this code path was never tested and had called `Close` on the connection after removing it from the map.

Closes #
<!-- `Closes #XXXX, closes #XXXX, ...` links mentioned issues to this PR and automatically closes them when this it's merged -->

## Changes

added test and fixed.

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
