### PR TITLE
[Merged by Bors] - only close the socket from the higher level. if encountered read/write…

### DIFF
--- a/p2p/net/msgcon.go
+++ b/p2p/net/msgcon.go
@@ -32,7 +32,6 @@ type MsgConnection struct {
 	deadliner   deadliner
 	messages    chan []byte
 	stopSending chan struct{}
-	close       io.Closer
 
 	msgSizeLimit int
 }
@@ -50,7 +49,6 @@ func newMsgConnection(conn readWriteCloseAddresser, netw networker,
 		remoteAddr:   conn.RemoteAddr(),
 		r:            conn,
 		w:            conn,
-		close:        conn,
 		deadline:     deadline,
 		deadliner:    conn,
 		networker:    netw,
@@ -193,11 +191,7 @@ func (c *MsgConnection) closeUnlocked() error {
 	if c.closed {
 		return ErrAlreadyClosed
 	}
-	err := c.close.Close()
 	c.closed = true
-	if err != nil {
-		return err
-	}
 	return nil
 }
 

--- a/p2p/net/udp.go
+++ b/p2p/net/udp.go
@@ -274,6 +274,7 @@ func (n *UDPNet) addConn(addr net.Addr, ucw udpConn) {
 	evicted := false
 	lastk := ""
 	if len(n.incomingConn) >= maxUDPConn {
+		n.logger.Debug("Removing some udp session")
 		for k, c := range n.incomingConn {
 			lastk = k
 			if time.Since(c.Created()) > maxUDPLife {
@@ -377,5 +378,5 @@ func (ucw *udpConnWrapper) Write(b []byte) (int, error) {
 
 func (ucw *udpConnWrapper) Close() error {
 	close(ucw.closeChan)
-	return nil
+	return ucw.conn.Close()
 }

--- a/p2p/net/udp_test.go
+++ b/p2p/net/udp_test.go
@@ -371,4 +371,7 @@ func TestUDPNet_Cache2(t *testing.T) {
 
 	require.Len(t, n.incomingConn, maxUDPConn)
 	createAndRunConn()
+
+	// Make sure one connection was evicted and replaced
+	require.Len(t, n.incomingConn, maxUDPConn)
 }

--- a/p2p/net/udp_test.go
+++ b/p2p/net/udp_test.go
@@ -329,9 +329,7 @@ func TestUDPNet_Cache2(t *testing.T) {
 				return tm
 			},
 			CloseFunc: func() error {
-				if closeval {
-					panic("CLOSE TWICE")
-				}
+				require.False(t, closeval, "attempt to close closed channel on connection eviction")
 				closeval = true
 				return nil
 			},

--- a/p2p/server/msgserver.go
+++ b/p2p/server/msgserver.go
@@ -164,7 +164,7 @@ func (p *MessageServer) handleRequestMessage(msg Message, data *service.DataMsgW
 
 	foo, okFoo := p.msgRequestHandlers[MessageType(data.MsgType)]
 	if !okFoo {
-		p.Error("handler missing for request %v payload %v", data.ReqID)
+		p.With().Error("handler missing for request", log.Uint64("request_id", data.ReqID), log.String("protocol", p.name), log.Uint32("msg_type", data.MsgType))
 		return
 	}
 


### PR DESCRIPTION
… error it's already closed.

## Motivation

Fix the bug that occurred in testnet. 
bug flow: once a connection had to be removed because our cache was full. we would call Close on this connection. which will close the closeChan channel. this will result in an error returned inside `MsgConnection`'s reading flow which will call the same `Close` again in result in close of a closed channel.

## Changes

only close the udp socket from the higher level. if encountered read/write error it's already closed.

## Test Plan
added testing.

