### PR TITLE
[Merged by Bors] - Use python 3.8 for tests

### DIFF
--- a/DockerFileTests
+++ b/DockerFileTests
@@ -1,4 +1,4 @@
-FROM python:latest AS tests_base
+FROM python:3.8 AS tests_base
 
 WORKDIR /go-spacemesh/tests
 


### PR DESCRIPTION
## Motivation
Our system tests use the Google Cloud Platform SDK, which is incompatible with Python 3.9, released on Oct. 5th, 2020.

Since our dockerfile specifies `python:latest` instead of a fixed version, the system tests stopped working.

## Changes
Specify Python 3.8 to be used for our system tests.

## Test Plan
Run `bors try`, triggering a full system test suite run.