### PR TITLE
Tell bors to check GH actions job statuses

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/spacemeshos/go-spacemesh)](https://goreportcard.com/report/github.com/spacemeshos/go-spacemesh)
 [![Bors enabled](https://bors.tech/images/badge_small.svg)](https://app.bors.tech/repositories/22421)
 <a href="https://godoc.org/github.com/spacemeshos/go-spacemesh"><img src="https://img.shields.io/badge/godoc-LGTM-blue.svg"/></a>
+[![CI](https://github.com/spacemeshos/go-spacemesh/workflows/CI/badge.svg)](https://github.com/spacemeshos/go-spacemesh/actions)
 </p>
 <p align="center">
 <a href="https://gitcoin.co/profile/spacemeshos" title="Push Open Source Forward">

--- a/bors.toml
+++ b/bors.toml
@@ -1,5 +1,10 @@
 status = [
   "continuous-integration/travis-ci/push",
+  "systemtest-latenodes",
+  "systemtest-blocks-add-node",
+  "systemtest-hare-mining",
+  "systemtest-sync-blocks",
+  "systemtest-genesis-p2p",
 ]
 
 required_approvals = 1


### PR DESCRIPTION
## Motivation
Missed this in #2060

## Changes
- adds GH actions job statuses to the list of statuses that bors checks for success before merge

For reference see https://github.com/bors-ng/bors-ng/issues/730

## Test Plan
N/A
