### PR TITLE
[Merged by Bors] - Fix p2p version comparison test and logic

### DIFF
--- a/p2p/version/version.go
+++ b/p2p/version/version.go
@@ -4,6 +4,7 @@ package version
 import (
 	"errors"
 	"fmt"
+	"github.com/spacemeshos/go-spacemesh/log"
 	"strconv"
 	"strings"
 )
@@ -44,7 +45,7 @@ func CheckNodeVersion(reqVersion string, minVersion string) (bool, error) {
 		}
 	}
 
-	for i := 0; i < 2; i++ {
+	for i := 0; i < 3; i++ {
 		if numa[i] > numb[i] {
 			return true, nil
 		}
@@ -54,5 +55,8 @@ func CheckNodeVersion(reqVersion string, minVersion string) (bool, error) {
 		}
 	}
 
-	return false, nil
+	// this should not happen, it means the versions perfectly match but we already tested that above
+	log.With().Error("error comparing node version strings",
+		log.String("reqVersion", reqVersion), log.String("minVersion", minVersion))
+	return false, errors.New("error comparing node version strings")
 }

--- a/p2p/version/version_test.go
+++ b/p2p/version/version_test.go
@@ -16,6 +16,7 @@ func TestCheckNodeVersion(t *testing.T) {
 
 	testNewClient := versionTest{
 		{"someclient/0.0.1", "0.0.1"},
+		{"someclient/0.0.2", "0.0.1"},
 		{"anotherclient/1.0.0", "0.0.1"},
 		{"someclient/0.2.1", "0.0.1"},
 		{"someclient/1.3.1", "1.0.1"},


### PR DESCRIPTION
## Motivation
See #2168 

## Changes
- Fix version comparison logic

## Test Plan
- Added regression test for logic

## TODO
- [x] Discuss and decide what to do about `test_diff_client_ver`: we probably want to try connecting an _older_ node rather than a _newer_ one here

