### PR TITLE
[Merged by Bors] - Restore multinode test

### DIFF
--- a/cmd/node/multi_node_test.go
+++ b/cmd/node/multi_node_test.go
@@ -5,6 +5,5 @@ import (
 )
 
 func TestMultiNode(t *testing.T) {
-	t.Skip()
 	StartMultiNode(5, 10, 10, "/tmp/data")
 }


### PR DESCRIPTION
## Motivation
The multi-node test was accidentally disabled. We should run it as part of CI.

## Changes
Restore multi-node test.

## Test Plan
Unit tests.