### PR TITLE
[Merged by Bors] - Sync causes blocks to be considered invalid fix

### DIFF
--- a/sync/syncer.go
+++ b/sync/syncer.go
@@ -336,11 +336,13 @@ func (s *Syncer) synchronise() {
 	// we have all the data of the prev layers so we can simply validate
 	if s.weaklySynced(curr) {
 		s.handleWeaklySynced()
+		err := s.syncEpochActivations(curr.GetEpoch())
+		if err != nil {
+			s.With().Error("cannot fetch epoch atxs ", curr, log.Err(err))
+		}
 	} else {
 		s.handleNotSynced(s.ProcessedLayer() + 1)
 	}
-
-	s.syncAtxs(curr)
 }
 
 func (s *Syncer) handleWeaklySynced() {
@@ -447,7 +449,7 @@ func (s *Syncer) handleNotSynced(currentSyncLayer types.LayerID) {
 				return
 			}
 		}
-
+		s.syncAtxs(currentSyncLayer)
 		s.ValidateLayer(lyr) // wait for layer validation
 	}
 


### PR DESCRIPTION
## Motivation
Blocks are invalid because sync ATXs does not end before node is marked synced- causing blocks to be invalid because ATXs are not yet found

## Changes
Re ordered syncing of ATXs do be done before layers are validated. 

## Test Plan
Standart tests

## TODO
<!-- This section should be removed when all items are complete -->
- [ ] Explain motivation or link existing issue(s)
- [ ] Test changes and document test plan
- [ ] Update documentation as needed
