### PR TITLE
[Merged by Bors] - fixed closing mesh before closing sync on shutdown

### DIFF
--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -829,6 +829,11 @@ func (app *SpacemeshApp) stopServices() {
 		app.P2P.Shutdown()
 	}
 
+	if app.syncer != nil {
+		app.log.Info("%v closing sync", app.nodeID.Key)
+		app.syncer.Close()
+	}
+
 	if app.mesh != nil {
 		app.log.Info("%v closing mesh", app.nodeID.Key)
 		app.mesh.Close()

--- a/sync/block_listener.go
+++ b/sync/block_listener.go
@@ -29,7 +29,6 @@ func (bl *BlockListener) Close() {
 	close(bl.exit)
 	bl.Info("block listener closing, waiting for gorutines")
 	bl.wg.Wait()
-	bl.Syncer.Close()
 	bl.Info("block listener closed")
 }
 


### PR DESCRIPTION
## Motivation
App test was flaky because sometimes sync tried to access db after it was closed. 
fixes #2178 