### PR TITLE
Output canonical address string (40 hex chars) instead of 7 in logs

### DIFF
--- a/api/grpc_server.go
+++ b/api/grpc_server.go
@@ -174,7 +174,7 @@ func (s SpacemeshGrpcService) SubmitTransaction(ctx context.Context, in *pb.Sign
 		return nil, err
 	}
 	log.Info("GRPC SubmitTransaction to address: %s (len: %v), amount: %v gaslimit: %v, fee: %v",
-		tx.Recipient.String(), len(tx.Recipient), tx.Amount, tx.GasLimit, tx.Fee)
+		tx.Recipient.Short(), len(tx.Recipient), tx.Amount, tx.GasLimit, tx.Fee)
 	if err := tx.CalcAndSetOrigin(); err != nil {
 		log.With().Error("failed to calc origin", log.Err(err))
 		return nil, err

--- a/api/grpc_server.go
+++ b/api/grpc_server.go
@@ -174,15 +174,15 @@ func (s SpacemeshGrpcService) SubmitTransaction(ctx context.Context, in *pb.Sign
 		return nil, err
 	}
 	log.Info("GRPC SubmitTransaction to address: %s (len: %v), amount: %v gaslimit: %v, fee: %v",
-		tx.Recipient.Short(), len(tx.Recipient), tx.Amount, tx.GasLimit, tx.Fee)
+		tx.Recipient.String(), len(tx.Recipient), tx.Amount, tx.GasLimit, tx.Fee)
 	if err := tx.CalcAndSetOrigin(); err != nil {
 		log.With().Error("failed to calc origin", log.Err(err))
 		return nil, err
 	}
 	if !s.Tx.AddressExists(tx.Origin()) {
 		log.With().Error("tx failed to validate signature",
-			tx.ID(), log.String("origin", tx.Origin().Short()))
-		return nil, fmt.Errorf("transaction origin (%v) not found in global state", tx.Origin().Short())
+			tx.ID(), log.String("origin", tx.Origin().String()))
+		return nil, fmt.Errorf("transaction origin (%v) not found in global state", tx.Origin().String())
 	}
 	if err := s.Tx.ValidateNonceAndBalance(tx); err != nil {
 		log.With().Error("tx failed nonce and balance check", log.Err(err))

--- a/api/grpcserver/transaction_service.go
+++ b/api/grpcserver/transaction_service.go
@@ -73,7 +73,7 @@ func (s TransactionService) SubmitTransaction(ctx context.Context, in *pb.Submit
 	}
 	if !s.Mesh.AddressExists(tx.Origin()) {
 		log.With().Error("tx origin address not found in global state",
-			tx.ID(), log.String("origin", tx.Origin().Short()))
+			tx.ID(), log.String("origin", tx.Origin().String()))
 		return nil, status.Error(codes.InvalidArgument, "`Transaction` origin account not found")
 	}
 	if err := s.Mesh.ValidateNonceAndBalance(tx); err != nil {

--- a/common/types/address.go
+++ b/common/types/address.go
@@ -103,7 +103,7 @@ func (a Address) Format(s fmt.State, c rune) {
 	_, _ = fmt.Fprintf(s, "%"+string(c), a[:])
 }
 
-// SetBytes sets the address to the value of b.
+// SetBytes sets the address to the last AddressLength bytes of b.
 // If b is larger than len(a) it will panic.
 func (a *Address) SetBytes(b []byte) {
 	if len(b) > len(a) {

--- a/common/types/address.go
+++ b/common/types/address.go
@@ -14,7 +14,8 @@ const (
 	AddressLength = 20
 )
 
-// Address represents the 20 byte address of an spacemesh account.
+// Address is an identifier of a Spacemesh account.
+// An Address for a user account is created by taking the last AddressLength bytes of the user's public key.
 type Address [AddressLength]byte
 
 // BytesToAddress returns Address with value b.

--- a/common/types/transaction.go
+++ b/common/types/transaction.go
@@ -114,7 +114,7 @@ func (t *Transaction) ShortString() string {
 // It implements the fmt.Stringer interface.
 func (t *Transaction) String() string {
 	return fmt.Sprintf("<id: %s, origin: %s, recipient: %s, amount: %v, nonce: %v, gas_limit: %v, fee: %v>",
-		t.ID().ShortString(), t.Origin().Short(), t.Recipient.Short(), t.Amount, t.AccountNonce, t.GasLimit, t.Fee)
+		t.ID().ShortString(), t.Origin().String(), t.Recipient.String(), t.Amount, t.AccountNonce, t.GasLimit, t.Fee)
 }
 
 // InnerTransaction includes all of a transaction's fields, except the signature (origin and id aren't stored).

--- a/mesh/meshdb.go
+++ b/mesh/meshdb.go
@@ -438,9 +438,9 @@ func (m *DB) writeTransactionRewards(l types.LayerID, accounts []types.Address, 
 	for account, cnt := range actBlockCnt {
 		reward := dbReward{TotalReward: cnt * totalReward.Uint64(), LayerRewardEstimate: cnt * layerReward.Uint64()}
 		if b, err := types.InterfaceToBytes(&reward); err != nil {
-			return fmt.Errorf("could not marshal reward for %v: %v", account.Short(), err)
+			return fmt.Errorf("could not marshal reward for %v: %v", account.String(), err)
 		} else if err := batch.Put(getRewardKey(l, account), b); err != nil {
-			return fmt.Errorf("could not write reward to %v to database: %v", account.Short(), err)
+			return fmt.Errorf("could not write reward to %v to database: %v", account.String(), err)
 		}
 	}
 	return batch.Write()
@@ -520,13 +520,13 @@ func (m *DB) removeFromAccountTxs(account types.Address, gAccepted map[types.Add
 	pending, err := m.getAccountPendingTxs(account)
 	if err != nil {
 		m.With().Error("failed to get account pending txs",
-			log.String("address", account.Short()), log.Err(err))
+			log.String("address", account.String()), log.Err(err))
 		return
 	}
 	pending.RemoveAccepted(gAccepted[account])
 	if err := m.storeAccountPendingTxs(account, pending); err != nil {
 		m.With().Error("failed to store account pending txs",
-			log.String("address", account.Short()), log.Err(err))
+			log.String("address", account.String()), log.Err(err))
 	}
 }
 
@@ -538,27 +538,27 @@ func (m *DB) removeRejectedFromAccountTxs(account types.Address, rejected map[ty
 	pending, err := m.getAccountPendingTxs(account)
 	if err != nil {
 		m.With().Error("failed to get account pending txs",
-			layer, log.String("address", account.Short()), log.Err(err))
+			layer, log.String("address", account.String()), log.Err(err))
 		return
 	}
 	pending.RemoveRejected(rejected[account], layer)
 	if err := m.storeAccountPendingTxs(account, pending); err != nil {
 		m.With().Error("failed to store account pending txs",
-			layer, log.String("address", account.Short()), log.Err(err))
+			layer, log.String("address", account.String()), log.Err(err))
 	}
 }
 
 func (m *DB) storeAccountPendingTxs(account types.Address, pending *pendingtxs.AccountPendingTxs) error {
 	if pending.IsEmpty() {
 		if err := m.unappliedTxs.Delete(account.Bytes()); err != nil {
-			return fmt.Errorf("failed to delete empty pending txs for account %v: %v", account.Short(), err)
+			return fmt.Errorf("failed to delete empty pending txs for account %v: %v", account.String(), err)
 		}
 		return nil
 	}
 	if accountTxsBytes, err := types.InterfaceToBytes(&pending); err != nil {
 		return fmt.Errorf("failed to marshal account pending txs: %v", err)
 	} else if err := m.unappliedTxs.Put(account.Bytes(), accountTxsBytes); err != nil {
-		return fmt.Errorf("failed to store mesh txs for address %s", account.Short())
+		return fmt.Errorf("failed to store mesh txs for address %s", account.String())
 	}
 	return nil
 }
@@ -566,7 +566,7 @@ func (m *DB) storeAccountPendingTxs(account types.Address, pending *pendingtxs.A
 func (m *DB) getAccountPendingTxs(addr types.Address) (*pendingtxs.AccountPendingTxs, error) {
 	accountTxsBytes, err := m.unappliedTxs.Get(addr.Bytes())
 	if err != nil && err != database.ErrNotFound {
-		return nil, fmt.Errorf("failed to get mesh txs for account %s", addr.Short())
+		return nil, fmt.Errorf("failed to get mesh txs for account %s", addr.String())
 	}
 	if err == database.ErrNotFound {
 		return pendingtxs.NewAccountPendingTxs(), nil

--- a/state/processor.go
+++ b/state/processor.go
@@ -104,7 +104,7 @@ func (tp *TransactionProcessor) ValidateNonceAndBalance(tx *types.Transaction) e
 	origin := tx.Origin()
 	nonce, balance, err := tp.projector.GetProjection(origin, tp.GetNonce(origin), tp.GetBalance(origin))
 	if err != nil {
-		return fmt.Errorf("failed to project state for account %v: %v", origin.Short(), err)
+		return fmt.Errorf("failed to project state for account %v: %v", origin.String(), err)
 	}
 	if tx.AccountNonce != nonce {
 		return fmt.Errorf("incorrect account nonce! Expected: %d, Actual: %d", nonce, tx.AccountNonce)
@@ -189,7 +189,7 @@ func (tp *TransactionProcessor) GetLayerStateRoot(layer types.LayerID) (types.Ha
 func (tp *TransactionProcessor) ApplyRewards(layer types.LayerID, miners []types.Address, reward *big.Int) {
 	for _, account := range miners {
 		tp.Log.With().Info("Reward applied",
-			log.String("account", account.Short()),
+			log.String("account", account.String()),
 			log.Uint64("reward", reward.Uint64()),
 			layer,
 		)
@@ -322,7 +322,7 @@ func (tp *TransactionProcessor) HandleTxData(data service.GossipMessage, syncer 
 	}
 	if !tp.AddressExists(tx.Origin()) {
 		tp.With().Error("transaction origin does not exist", log.String("transaction", tx.String()),
-			tx.ID(), log.String("origin", tx.Origin().Short()), log.Err(err))
+			tx.ID(), log.String("origin", tx.Origin().String()), log.Err(err))
 		return
 	}
 	if err := tp.ValidateNonceAndBalance(tx); err != nil {

--- a/state/tx_pool.go
+++ b/state/tx_pool.go
@@ -56,7 +56,7 @@ func (t *TxMempool) GetTxsForBlock(numOfTxs int, getState func(addr types.Addres
 		nonce, balance, err := getState(addr)
 		if err != nil {
 			t.mu.RUnlock()
-			return nil, nil, fmt.Errorf("failed to get state for addr %s: %v", addr.Short(), err)
+			return nil, nil, fmt.Errorf("failed to get state for addr %s: %v", addr.String(), err)
 		}
 		accountTxIds, _, _ := account.ValidTxs(nonce, balance)
 		txIds = append(txIds, accountTxIds...)


### PR DESCRIPTION
## Motivation
Output canonical address string (last 40 bytes of public key, hex formatted) instead of 7 for easier extraction of user addresses from log files and address related debugging. See #2180.

## Changes
Changed log related formatting calls to use a.String() instead of a.Short(). 

## Test Plan

## TODO
- [x] Explain motivation or link existing issue(s)
- [ ] Test changes and document test plan
- [x] Update documentation as needed
