### PR TITLE
Run CI quicktests on all platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,10 @@ jobs:
   ## these run on all pushes to all pull requests, all branches
   ## note that secrets may not be accessible in this phase
   quicktests:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     # should not take more than 2-3 mins
     timeout-minutes: 5
     steps:


### PR DESCRIPTION
## Motivation
We want to eventually run our unit tests and app tests on Windows and Mac, as well as on Linux. This is the first step towards that goal: it enables only the "quicktests" on Windows and Mac.

## Changes
- Runs the quicktests test suite on macOS and Windows as well as Linux

## Test Plan
N/A

## To Do
- [ ] fix warnings about line endings
- [ ] merge and test #2205, figure out why `type` command isn't working in CI
- [ ] fix #1712