### PR TITLE
[Merged by Bors] - Add atxId and smesherId to api block

### DIFF
--- a/api/grpcserver/grpcserver_test.go
+++ b/api/grpcserver/grpcserver_test.go
@@ -107,6 +107,7 @@ var (
 func init() {
 	// These create circular dependencies so they have to be initialized
 	// after the global vars
+	block1.ATXID = globalAtx.ID()
 	block1.TxIDs = []types.TransactionID{globalTx.ID(), globalTx2.ID()}
 	block1.ActiveSet = &[]types.ATXID{globalAtx.ID(), globalAtx2.ID()}
 	txAPI.returnTx[globalTx.ID()] = globalTx
@@ -1036,7 +1037,7 @@ func TestMeshService(t *testing.T) {
 		{"MaxTransactionsPerSecond", func(t *testing.T) {
 			response, err := c.MaxTransactionsPerSecond(context.Background(), &pb.MaxTransactionsPerSecondRequest{})
 			require.NoError(t, err)
-			require.Equal(t, uint64(layerAvgSize*txsPerBlock/layerDurationSec), response.Maxtxpersecond.Value)
+			require.Equal(t, uint64(layerAvgSize*txsPerBlock/layerDurationSec), response.MaxTxsPerSecond.Value)
 		}},
 		{"AccountMeshDataQuery", func(t *testing.T) {
 			subtests := []struct {
@@ -1848,6 +1849,9 @@ func checkLayer(t *testing.T, l *pb.Layer) {
 	}, "return layer does not contain expected activation data")
 
 	resBlock := l.Blocks[0]
+
+	require.NotNil(t, resBlock.ActivationId)
+	require.NotNil(t, resBlock.SmesherId)
 
 	require.Equal(t, len(block1.TxIDs), len(resBlock.Transactions))
 	require.Equal(t, block1.ID().Bytes(), resBlock.Id)

--- a/api/grpcserver/mesh_service.go
+++ b/api/grpcserver/mesh_service.go
@@ -98,7 +98,7 @@ func (s MeshService) LayerDuration(context.Context, *pb.LayerDurationRequest) (*
 // MaxTransactionsPerSecond returns the max number of tx per sec (a network parameter)
 func (s MeshService) MaxTransactionsPerSecond(context.Context, *pb.MaxTransactionsPerSecondRequest) (*pb.MaxTransactionsPerSecondResponse, error) {
 	log.Info("GRPC MeshService.MaxTransactionsPerSecond")
-	return &pb.MaxTransactionsPerSecondResponse{Maxtxpersecond: &pb.SimpleInt{
+	return &pb.MaxTransactionsPerSecondResponse{MaxTxsPerSecond: &pb.SimpleInt{
 		Value: uint64(s.TxsPerBlock * s.LayerAvgSize / s.LayerDurationSec),
 	}}, nil
 }
@@ -320,6 +320,8 @@ func (s MeshService) readLayer(layer *types.Layer, layerStatus pb.Layer_LayerSta
 		blocks = append(blocks, &pb.Block{
 			Id:           b.ID().Bytes(),
 			Transactions: pbTxs,
+			SmesherId:    &pb.SmesherId{Id: b.MinerID().Bytes()},
+			ActivationId: &pb.ActivationId{Id: b.ATXID.Bytes()},
 		})
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/spacemeshos/go-spacemesh
 
+replace github.com/spacemeshos/api/release/go => /Users/avive/dev/api/release/go
+
 require (
 	cloud.google.com/go v0.68.0 // indirect
 	cloud.google.com/go/storage v1.10.0

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/seehuhn/mt19937 v0.0.0-20180715112136-cc7708819361
 	github.com/smartystreets/goconvey v0.0.0-20190731233626-505e41936337 // indirect
 	github.com/spacemeshos/amcl v0.0.2
-	github.com/spacemeshos/api/release/go v0.0.0-20201103002846-7d0dfed55cc1
+	github.com/spacemeshos/api/release/go v0.0.0-20201210094223-105249951c66
 	github.com/spacemeshos/ed25519 v0.0.0-20190530014421-e235766d15a1
 	github.com/spacemeshos/merkle-tree v0.0.0-20191028110812-1908c3126c82
 	github.com/spacemeshos/poet v0.1.1-0.20201013202053-99eed195dc2d

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,5 @@
 module github.com/spacemeshos/go-spacemesh
 
-replace github.com/spacemeshos/api/release/go => /Users/avive/dev/api/release/go
-
 require (
 	cloud.google.com/go v0.68.0 // indirect
 	cloud.google.com/go/storage v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -301,8 +301,6 @@ github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4k
 github.com/spacemeshos/amcl v0.0.2 h1:YyYF1irv4GkArTe8hzb5/e2B6ReicL2SHeUUsvO3N0c=
 github.com/spacemeshos/amcl v0.0.2/go.mod h1:6/boG2CTNCJ3HBfuyU29Eg1fJxMrXUctpvBiJj1Q69o=
 github.com/spacemeshos/api/release/go v0.0.0-20201013155109-3facffccde82/go.mod h1:kNY4cuAimIxpUbMLPZSgU8jl7Zbv5ohQrLn87ybl0QI=
-github.com/spacemeshos/api/release/go v0.0.0-20201103002846-7d0dfed55cc1 h1:7GoyccHS/hWGM2wryRzNi5LEymBy5FbGvfRSx3wXjd8=
-github.com/spacemeshos/api/release/go v0.0.0-20201103002846-7d0dfed55cc1/go.mod h1:kNY4cuAimIxpUbMLPZSgU8jl7Zbv5ohQrLn87ybl0QI=
 github.com/spacemeshos/api/release/go v0.0.0-20201210094223-105249951c66 h1:6LUk0P+WbWPuJkpXYRuP08LRq1WNaunl+6sCkEqsJio=
 github.com/spacemeshos/api/release/go v0.0.0-20201210094223-105249951c66/go.mod h1:kNY4cuAimIxpUbMLPZSgU8jl7Zbv5ohQrLn87ybl0QI=
 github.com/spacemeshos/ed25519 v0.0.0-20190530014421-e235766d15a1 h1:INBIhbR/39yXEN8WVNfiGZehiKvkML+yrJfFuIwrmbU=

--- a/go.sum
+++ b/go.sum
@@ -303,6 +303,8 @@ github.com/spacemeshos/amcl v0.0.2/go.mod h1:6/boG2CTNCJ3HBfuyU29Eg1fJxMrXUctpvB
 github.com/spacemeshos/api/release/go v0.0.0-20201013155109-3facffccde82/go.mod h1:kNY4cuAimIxpUbMLPZSgU8jl7Zbv5ohQrLn87ybl0QI=
 github.com/spacemeshos/api/release/go v0.0.0-20201103002846-7d0dfed55cc1 h1:7GoyccHS/hWGM2wryRzNi5LEymBy5FbGvfRSx3wXjd8=
 github.com/spacemeshos/api/release/go v0.0.0-20201103002846-7d0dfed55cc1/go.mod h1:kNY4cuAimIxpUbMLPZSgU8jl7Zbv5ohQrLn87ybl0QI=
+github.com/spacemeshos/api/release/go v0.0.0-20201210094223-105249951c66 h1:6LUk0P+WbWPuJkpXYRuP08LRq1WNaunl+6sCkEqsJio=
+github.com/spacemeshos/api/release/go v0.0.0-20201210094223-105249951c66/go.mod h1:kNY4cuAimIxpUbMLPZSgU8jl7Zbv5ohQrLn87ybl0QI=
 github.com/spacemeshos/ed25519 v0.0.0-20190530014421-e235766d15a1 h1:INBIhbR/39yXEN8WVNfiGZehiKvkML+yrJfFuIwrmbU=
 github.com/spacemeshos/ed25519 v0.0.0-20190530014421-e235766d15a1/go.mod h1:lyZLUyZXvd7gp6KHwGS5ZgtS2ZvV++lBjdE4MLqmLnU=
 github.com/spacemeshos/merkle-tree v0.0.0-20190612125135-48574fd5f419 h1:h01wKBJ33d4/4yRTyCZv/LKcLMokl6mLcZCfitQk7xw=


### PR DESCRIPTION
Return activationId and smesherId in blocks returned by the api.
Works only with api branch `add-atx-to-bloc` so can only be merged after that branch is merged to api master branch.
