### PR TITLE
use Hash20 methods for BlockID

### DIFF
--- a/api/grpcserver/grpcserver_test.go
+++ b/api/grpcserver/grpcserver_test.go
@@ -1513,7 +1513,7 @@ func TestTransactionServiceSubmitUnsync(t *testing.T) {
 		context.Background(),
 		&pb.SubmitTransactionRequest{Transaction: serializedTx},
 	)
-	require.Error(err)
+	require.EqualError(err, "rpc error: code = FailedPrecondition desc = Cannot submit transaction, node is not in sync yet, try again later")
 	require.Nil(res)
 
 	syncer.isSynced = true

--- a/common/types/block.go
+++ b/common/types/block.go
@@ -17,14 +17,19 @@ import (
 // BlockID is a 20-byte sha256 sum of the serialized block, used to identify it.
 type BlockID Hash20
 
-// String returns a short prefix of the hex representation of the ID.
+// String returns the hex representation of the ID.
 func (id BlockID) String() string {
-	return id.AsHash32().ShortString()
+	return id.AsHash20().String()
+}
+
+// ShortString returns a short prefix of the hex representation of the ID.
+func (id BlockID) ShortString() string {
+	return id.AsHash20().ShortString()
 }
 
 // Field returns a log field. Implements the LoggableField interface.
 func (id BlockID) Field() log.Field {
-	return log.String("block_id", id.AsHash32().ShortString())
+	return log.String("block_id", id.ShortString())
 }
 
 // Compare returns true if other (the given BlockID) is less than this BlockID, by lexicographic comparison.
@@ -35,6 +40,11 @@ func (id BlockID) Compare(other BlockID) bool {
 // AsHash32 returns a Hash32 whose first 20 bytes are the bytes of this BlockID, it is right-padded with zeros.
 func (id BlockID) AsHash32() Hash32 {
 	return Hash20(id).ToHash32()
+}
+
+// AsHash20 returns this BlockID as a Hash20.
+func (id BlockID) AsHash20() Hash20 {
+	return Hash20(id)
 }
 
 var layersPerEpoch int32
@@ -228,7 +238,7 @@ func (b Block) Hash32() Hash32 {
 
 // ShortString returns a the first 5 characters of the ID, for logging purposes.
 func (b Block) ShortString() string {
-	return b.id.AsHash32().ShortString()
+	return b.id.ShortString()
 }
 
 // MinerID returns this block's miner's Edwards public key.

--- a/common/types/encode.go
+++ b/common/types/encode.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Bytes returns the BlockID as a byte slice.
-func (id BlockID) Bytes() []byte { return id.AsHash32().Bytes() }
+func (id BlockID) Bytes() []byte { return id.AsHash20().Bytes() }
 
 // Bytes returns the byte representation of the LayerID, using little endian encoding.
 func (l LayerID) Bytes() []byte { return util.Uint64ToBytes(uint64(l)) }

--- a/events/reporter.go
+++ b/events/reporter.go
@@ -118,7 +118,7 @@ func ReportRewardReceived(r Reward) {
 // ReportNewBlock reports a new block
 func ReportNewBlock(blk *types.Block) {
 	Publish(NewBlock{
-		ID:    blk.ID().String(),
+		ID:    blk.ID().ShortString(),
 		Atx:   blk.ATXID.ShortString(),
 		Layer: uint64(blk.LayerIndex),
 	})
@@ -127,7 +127,7 @@ func ReportNewBlock(blk *types.Block) {
 // ReportValidBlock reports a valid block
 func ReportValidBlock(blockID types.BlockID, valid bool) {
 	Publish(ValidBlock{
-		ID:    blockID.String(),
+		ID:    blockID.ShortString(),
 		Valid: valid,
 	})
 }

--- a/hare/haretypes.go
+++ b/hare/haretypes.go
@@ -212,7 +212,7 @@ func (s *Set) String() string {
 	// TODO: should improve
 	b := new(bytes.Buffer)
 	for v := range s.values {
-		fmt.Fprintf(b, "%v,", v.String())
+		fmt.Fprintf(b, "%v,", v.ShortString())
 	}
 	if b.Len() >= 1 {
 		return b.String()[:b.Len()-1]

--- a/layerfetcher/layers.go
+++ b/layerfetcher/layers.go
@@ -386,8 +386,8 @@ func (l *Logic) GetAtxs(IDs []types.ATXID) error {
 // or validated
 func (l *Logic) GetBlocks(IDs []types.BlockID) error {
 	hashes := make([]types.Hash32, 0, len(IDs))
-	for _, atxID := range IDs {
-		hashes = append(hashes, atxID.AsHash32())
+	for _, blockID := range IDs {
+		hashes = append(hashes, blockID.AsHash32())
 	}
 	results := l.fetcher.GetHashes(hashes, fetch.Hint(BlockDB), true)
 	for hash, resC := range results {

--- a/mesh/meshdb.go
+++ b/mesh/meshdb.go
@@ -169,7 +169,7 @@ func (m *DB) LayerBlocks(index types.LayerID) ([]*types.Block, error) {
 	for _, k := range ids {
 		block, err := m.GetBlock(k)
 		if err != nil {
-			return nil, fmt.Errorf("could not retrieve block %s %s", k.String(), err)
+			return nil, fmt.Errorf("could not retrieve block %s %s", k.ShortString(), err)
 		}
 		blocks = append(blocks, block)
 	}

--- a/sync/validation_queue.go
+++ b/sync/validation_queue.go
@@ -130,12 +130,12 @@ func (vq *blockQueue) finishBlockCallback(block *types.Block) func(res bool) err
 		// data availability
 		_, _, err := vq.dataAvailability(block)
 		if err != nil {
-			return fmt.Errorf("DataAvailabilty failed for block: %v errmsg: %v", block.ID().String(), err)
+			return fmt.Errorf("DataAvailabilty failed for block: %v errmsg: %v", block.ID().ShortString(), err)
 		}
 
 		// validate block's votes
 		if valid, err := validateVotes(block, vq.ForBlockInView, vq.Hdist, vq.Log); valid == false || err != nil {
-			return fmt.Errorf("validate votes failed for block: %s errmsg: %s", block.ID().String(), err)
+			return fmt.Errorf("validate votes failed for block: %s errmsg: %s", block.ID().ShortString(), err)
 		}
 
 		err = vq.AddBlockWithTxs(block)

--- a/sync/worker_test.go
+++ b/sync/worker_test.go
@@ -32,7 +32,7 @@ func TestNewPeerWorker(t *testing.T) {
 	timeout := time.NewTimer(1 * time.Second)
 	select {
 	case item := <-wrk.output:
-		assert.Equal(t, bl1.ID(), item.([]types.BlockID)[0], "wrong ids e: %v a: %v", bl1.ID().String(), item.([]types.BlockID)[0].String())
+		assert.Equal(t, bl1.ID(), item.([]types.BlockID)[0], "wrong ids e: %v a: %v", bl1.ID().ShortString(), item.([]types.BlockID)[0].ShortString())
 	case <-timeout.C:
 		assert.Fail(t, "no message received on channel")
 	}

--- a/tortoise/ninja_tortoise.go
+++ b/tortoise/ninja_tortoise.go
@@ -445,7 +445,7 @@ func (ni *ninjaTortoise) addPatternVote(p votingPattern, view map[types.BlockID]
 			if err != nil {
 				if ex.Layer() == 0 {
 					//todo: fix this so that zero votes are ok
-					log.Warning("block %v int layer %v voted on zero layer", blk.ID().String(), blk.Layer())
+					log.Warning("block %v int layer %v voted on zero layer", blk.ID().ShortString(), blk.Layer())
 					continue
 				}
 				ni.logger.Panic("could not retrieve layer block ids %v error %v", ex.Layer(), err)


### PR DESCRIPTION
## Motivation
@avive reported that the API returns block IDs in the following format:
```
"blocks": [
   {
    "id": "JYtHaDEC3+vFXE+J1tt3r/iCWV4AAAAAAAAAAAAAAAA="
   },
   {
    "id": "M+L13e+kWtfenEvf3lSWjoVod+sAAAAAAAAAAAAAAAA="
   },
   {
    "id": "75FxQYyoh1mWlN03AgGD3wJa4MgAAAAAAAAAAAAAAAA="
   }
]
```
The zero padding at the end (represented as `A`s) isn't what we want.

## Changes
Because `BlockID` is a `Hash20`, using `Hash32` methods causes the result to be zero padded. I replaced the usage of `Hash32` methods with equivalent `Hash20` methods. The method used by the API code is `Bytes()` and this just returns 20 bytes now (unpadded).

Additionally, the `String()` method used to return a `ShortString()` which is confusing, so I fixed that, too.

## Test Plan
No new tests needed.

## External effects
This changes the output format of blocks and may affect the dashboard and explorer.