### PR TITLE
[Merged by Bors] - Return 20-byte block ids in api

### DIFF
--- a/api/grpcserver/grpcserver_test.go
+++ b/api/grpcserver/grpcserver_test.go
@@ -1854,7 +1854,7 @@ func checkLayer(t *testing.T, l *pb.Layer) {
 	require.NotNil(t, resBlock.SmesherId)
 
 	require.Equal(t, len(block1.TxIDs), len(resBlock.Transactions))
-	require.Equal(t, block1.ID().Bytes(), resBlock.Id)
+	require.Equal(t, types.Hash20(block1.ID()).Bytes(), resBlock.Id)
 
 	// Check the tx as well
 	resTx := resBlock.Transactions[0]

--- a/api/grpcserver/mesh_service.go
+++ b/api/grpcserver/mesh_service.go
@@ -318,7 +318,7 @@ func (s MeshService) readLayer(layer *types.Layer, layerStatus pb.Layer_LayerSta
 			pbTxs = append(pbTxs, convertTransaction(t))
 		}
 		blocks = append(blocks, &pb.Block{
-			Id:           b.ID().Bytes(),
+			Id:           types.Hash20(b.ID()).Bytes(),
 			Transactions: pbTxs,
 			SmesherId:    &pb.SmesherId{Id: b.MinerID().Bytes()},
 			ActivationId: &pb.ActivationId{Id: b.ATXID.Bytes()},


### PR DESCRIPTION
## Motivation
## Motivation
@avive reported that the API returns block IDs in the following format:
```
"blocks": [
   {
    "id": "JYtHaDEC3+vFXE+J1tt3r/iCWV4AAAAAAAAAAAAAAAA="
   },
   {
    "id": "M+L13e+kWtfenEvf3lSWjoVod+sAAAAAAAAAAAAAAAA="
   },
   {
    "id": "75FxQYyoh1mWlN03AgGD3wJa4MgAAAAAAAAAAAAAAAA="
   }
]
```
The zero padding at the end (represented as `A`s) isn't what we want.

## Changes
Return only the actual 20 bytes of the block ID in the node's API.

Unlike #2229, this only changes the way the API output is formatted, nothing else is affected, so it should have no impact on #2213.

## Test Plan
No new tests needed.

## External effects
This changes the output format of blocks and may affect the dashboard and explorer.