### PR TITLE
[Merged by Bors] - fixed different active set size in block creation

### DIFF
--- a/blocks/blockoracle_test.go
+++ b/blocks/blockoracle_test.go
@@ -92,7 +92,7 @@ func testBlockOracleAndValidator(r *require.Assertions, activeSetSize uint32, co
 	for layer := layersPerEpoch * 2; layer < layersPerEpoch*uint16(numberOfEpochsToTest+2); layer++ {
 		activationDB.atxPublicationLayer = types.LayerID((layer/layersPerEpoch)*layersPerEpoch - 1)
 		layerID := types.LayerID(layer)
-		_, proofs, err := blockOracle.BlockEligible(layerID)
+		_, proofs, _, err := blockOracle.BlockEligible(layerID)
 		r.NoError(err)
 
 		for _, proof := range proofs {
@@ -130,7 +130,7 @@ func TestBlockOracleInGenesisReturnsNoAtx(t *testing.T) {
 	for layer := uint16(0); layer < layersPerEpoch; layer++ {
 		activationDB.atxPublicationLayer = types.LayerID((layer/layersPerEpoch)*layersPerEpoch - 1)
 		layerID := types.LayerID(layer)
-		atxID, _, err := blockOracle.BlockEligible(layerID)
+		atxID, _, _, err := blockOracle.BlockEligible(layerID)
 		r.NoError(err)
 		r.Equal(*types.EmptyATXID, atxID)
 	}
@@ -149,7 +149,7 @@ func TestBlockOracleEmptyActiveSet(t *testing.T) {
 	lg := log.NewDefault(nodeID.Key[:5])
 	blockOracle := NewMinerBlockOracle(committeeSize, activeSetSize, layersPerEpoch, activationDB, beaconProvider, vrfsgn, nodeID, func() bool { return true }, lg.WithName("blockOracle"))
 
-	_, proofs, err := blockOracle.BlockEligible(types.LayerID(layersPerEpoch * 3))
+	_, proofs, _, err := blockOracle.BlockEligible(types.LayerID(layersPerEpoch * 3))
 	r.EqualError(err, "empty active set not allowed")
 	r.Nil(proofs)
 }
@@ -191,7 +191,7 @@ func TestBlockOracleNoActivationsForNode(t *testing.T) {
 	lg := log.NewDefault(nID.Key[:5])
 	blockOracle := NewMinerBlockOracle(committeeSize, activeSetSize, layersPerEpoch, activationDB, beaconProvider, vrfsgn, nID, func() bool { return true }, lg.WithName("blockOracle"))
 
-	_, proofs, err := blockOracle.BlockEligible(types.LayerID(layersPerEpoch * 2))
+	_, proofs, _, err := blockOracle.BlockEligible(types.LayerID(layersPerEpoch * 2))
 	r.EqualError(err, "failed to get latest ATX: failed to get ATX ID for target epoch 2: not found")
 	r.Nil(proofs)
 }
@@ -211,7 +211,7 @@ func TestBlockOracleValidatorInvalidProof(t *testing.T) {
 
 	layerID := types.LayerID(layersPerEpoch * 2)
 
-	_, proofs, err := blockOracle.BlockEligible(layerID)
+	_, proofs, _, err := blockOracle.BlockEligible(layerID)
 	r.NoError(err)
 	r.NotNil(proofs)
 
@@ -241,7 +241,7 @@ func TestBlockOracleValidatorInvalidProof2(t *testing.T) {
 
 	layerID := types.LayerID(layersPerEpoch * 2)
 
-	_, proofs, err := blockOracle.BlockEligible(layerID)
+	_, proofs, _, err := blockOracle.BlockEligible(layerID)
 	r.NoError(err)
 	r.NotNil(proofs)
 
@@ -272,7 +272,7 @@ func TestBlockOracleValidatorInvalidProof3(t *testing.T) {
 
 	layerID := types.LayerID(layersPerEpoch * 2)
 
-	_, proofs, err := blockOracle.BlockEligible(layerID)
+	_, proofs, _, err := blockOracle.BlockEligible(layerID)
 	r.NoError(err)
 	r.NotNil(proofs)
 
@@ -313,7 +313,7 @@ func TestBlockEligibility_calc(t *testing.T) {
 	atxDb := &mockAtxDB{atxH: atxH.ActivationTxHeader}
 	genSetSize := uint32(0)
 	o := NewMinerBlockOracle(10, genSetSize, 1, atxDb, &EpochBeaconProvider{}, vrfsgn, nodeID, func() bool { return true }, log.NewDefault(t.Name()))
-	err := o.calcEligibilityProofs(1)
+	_, err := o.calcEligibilityProofs(1)
 	r.EqualError(err, "empty active set not allowed") // a hack to make sure we got genesis active set size on genesis
 }
 
@@ -333,7 +333,7 @@ func TestMinerBlockOracle_GetEligibleLayers(t *testing.T) {
 	for layer := layersPerEpoch * 2; layer < layersPerEpoch*uint16(numberOfEpochsToTest+2); layer++ {
 		activationDB.atxPublicationLayer = types.LayerID((layer/layersPerEpoch)*layersPerEpoch - 1)
 		layerID := types.LayerID(layer)
-		_, proofs, err := blockOracle.BlockEligible(layerID)
+		_, proofs, _, err := blockOracle.BlockEligible(layerID)
 		r.NoError(err)
 		if len(proofs) > 0 {
 			eligibleLayers++

--- a/blocks/blockoracle_test.go
+++ b/blocks/blockoracle_test.go
@@ -313,7 +313,7 @@ func TestBlockEligibility_calc(t *testing.T) {
 	atxDb := &mockAtxDB{atxH: atxH.ActivationTxHeader}
 	genSetSize := uint32(0)
 	o := NewMinerBlockOracle(10, genSetSize, 1, atxDb, &EpochBeaconProvider{}, vrfsgn, nodeID, func() bool { return true }, log.NewDefault(t.Name()))
-	_, err := o.calcEligibilityProofs(1)
+	err := o.calcEligibilityProofs(1)
 	r.EqualError(err, "empty active set not allowed") // a hack to make sure we got genesis active set size on genesis
 }
 

--- a/miner/builder_test.go
+++ b/miner/builder_test.go
@@ -49,9 +49,9 @@ type mockBlockOracle struct {
 	J     uint32
 }
 
-func (mbo *mockBlockOracle) BlockEligible(types.LayerID) (types.ATXID, []types.BlockEligibilityProof, error) {
+func (mbo *mockBlockOracle) BlockEligible(types.LayerID) (types.ATXID, []types.BlockEligibilityProof, []types.ATXID, error) {
 	mbo.calls++
-	return types.ATXID(types.Hash32{1, 2, 3}), []types.BlockEligibilityProof{{J: mbo.J, Sig: []byte{1}}}, mbo.err
+	return types.ATXID(types.Hash32{1, 2, 3}), []types.BlockEligibilityProof{{J: mbo.J, Sig: []byte{1}}}, []types.ATXID{atx1, atx2, atx3, atx4, atx5}, mbo.err
 }
 
 type mockAtxValidator struct{}
@@ -183,9 +183,9 @@ func TestBlockBuilder_BlockIdGeneration(t *testing.T) {
 	builder2.AtxDb = atxDbMock{}
 	builder1.AtxDb = atxDbMock{}
 
-	b1, err := builder1.createBlock(types.GetEffectiveGenesis()+2, types.ATXID{}, types.BlockEligibilityProof{}, nil)
+	b1, err := builder1.createBlock(types.GetEffectiveGenesis()+2, types.ATXID{}, types.BlockEligibilityProof{}, nil, nil)
 	assert.NoError(t, err)
-	b2, err := builder2.createBlock(types.GetEffectiveGenesis()+2, types.ATXID{}, types.BlockEligibilityProof{}, nil)
+	b2, err := builder2.createBlock(types.GetEffectiveGenesis()+2, types.ATXID{}, types.BlockEligibilityProof{}, nil, nil)
 	assert.NoError(t, err)
 
 	assert.True(t, b1.ID() != b2.ID(), "ids are identical")
@@ -297,7 +297,7 @@ func TestBlockBuilder_CreateBlockWithRef(t *testing.T) {
 
 	transids := []types.TransactionID{trans[0].ID(), trans[1].ID(), trans[2].ID()}
 
-	b, err := builder.createBlock(types.GetEffectiveGenesis()+1, types.ATXID(types.Hash32{1, 2, 3}), types.BlockEligibilityProof{J: 0, Sig: []byte{1}}, transids)
+	b, err := builder.createBlock(types.GetEffectiveGenesis()+1, types.ATXID(types.Hash32{1, 2, 3}), types.BlockEligibilityProof{J: 0, Sig: []byte{1}}, transids, []types.ATXID{atx1, atx2, atx3, atx4, atx5})
 	assert.NoError(t, err)
 
 	assert.NotEqual(t, hareRes, b.BlockVotes)
@@ -314,7 +314,7 @@ func TestBlockBuilder_CreateBlockWithRef(t *testing.T) {
 	assert.Equal(t, []types.ATXID{atx1, atx2, atx3, atx4, atx5}, *b.ActiveSet)
 
 	//test create second block
-	bl, err := builder.createBlock(types.GetEffectiveGenesis()+2, types.ATXID(types.Hash32{1, 2, 3}), types.BlockEligibilityProof{J: 1, Sig: []byte{1}}, transids)
+	bl, err := builder.createBlock(types.GetEffectiveGenesis()+2, types.ATXID(types.Hash32{1, 2, 3}), types.BlockEligibilityProof{J: 1, Sig: []byte{1}}, transids, nil)
 	assert.NoError(t, err)
 
 	assert.NotEqual(t, hareRes, bl.BlockVotes)
@@ -707,18 +707,18 @@ func TestBlockBuilder_createBlock(t *testing.T) {
 
 	builder1.hareResult = &mockResult{err: errExample, ids: nil}
 	builder1.AtxDb = atxDbMock{}
-	b, err := builder1.createBlock(7, types.ATXID{}, types.BlockEligibilityProof{}, nil)
+	b, err := builder1.createBlock(7, types.ATXID{}, types.BlockEligibilityProof{}, nil, nil)
 	r.Nil(err)
 	r.Equal(st, b.BlockVotes)
 
 	builder1.hareResult = &mockResult{err: nil, ids: nil}
-	b, err = builder1.createBlock(7, types.ATXID{}, types.BlockEligibilityProof{}, nil)
+	b, err = builder1.createBlock(7, types.ATXID{}, types.BlockEligibilityProof{}, nil, nil)
 	r.Nil(err)
 	r.Equal([]types.BlockID(nil), b.BlockVotes)
 	emptyID := types.BlockID{}
 	r.NotEqual(b.ID(), emptyID)
 
-	b, err = builder1.createBlock(5, types.ATXID{}, types.BlockEligibilityProof{}, nil)
+	b, err = builder1.createBlock(5, types.ATXID{}, types.BlockEligibilityProof{}, nil, nil)
 	r.EqualError(err, "cannot create blockBytes in genesis layer")
 }
 


### PR DESCRIPTION
We've had some issues with a race creating blocks and declaring active set size 
the race was when we were syncing and trying to create a block at the same time

this caused the active set size to sometimes be different from the time we calculate eligibility proofs to the time we actually declare the active set size

now we will use the same active set to calculate and to declare in blocks