### PR TITLE
[Merged by Bors] - Mark CI auto-success on documentation-only changes

### DIFF
--- a/.github/workflows/ci-markdown.yml
+++ b/.github/workflows/ci-markdown.yml
@@ -1,4 +1,9 @@
-# Much simpler CI for changes only to markdown documentation
+# Much simpler CI for changes only to markdown documentation.
+# If **only** markdown files were changed, the main CI workflow
+# does not run. Instead, this workflow runs and immediately
+# marks the stages as succeeded so that CI and bors immediately
+# pass. If other files were changed, both workflows run, but this
+# one does nothing.
 name: CI-markdown
 
 env:
@@ -10,20 +15,41 @@ on:
     branches:
       - staging
       - trying
-    # Only trigger if updating only docs
+    # Trigger if updating docs
     paths:
       - '**.md'
-      - '!**.md'
 
 jobs:
+  # check which files were changed
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      nondocchanges: ${{ steps.filter.outputs.nondoc }}
+    steps:
+    - uses: actions/checkout@v2
+    - uses: dorny/paths-filter@v2
+      id: filter
+      with:
+        # this should be auto-detected
+        #base: develop
+        filters: |
+          nondoc:
+            - '!**.md'
+
   # short-circuit and pass both stages
   ci-stage1:
+    # don't run if non-doc files were changed
+    needs: changes
+    if: ${{ needs.changes.outputs.nondocchanges == 'false' }}
     runs-on: ubuntu-latest
     steps:
       - name: Mark the job as succeeded
         run: exit 0
 
   ci-stage2:
+    # don't run if non-doc files were changed
+    needs: changes
+    if: ${{ needs.changes.outputs.nondocchanges == 'false' }}
     runs-on: ubuntu-latest
     steps:
       - uses: act10ns/slack@v1

--- a/.github/workflows/ci-markdown.yml
+++ b/.github/workflows/ci-markdown.yml
@@ -1,0 +1,32 @@
+# Much simpler CI for changes only to markdown documentation
+name: CI-markdown
+
+env:
+  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+# Trigger the workflow on the pushes that bors cares about
+on:
+  push:
+    branches:
+      - staging
+      - trying
+    # Only trigger if updating only docs
+    paths:
+      - '**.md'
+      - '!**.md'
+
+jobs:
+  # short-circuit and pass both stages
+  ci-stage1:
+    steps:
+      - name: Mark the job as succeeded
+        run: exit 0
+
+  ci-stage2:
+    steps:
+      - uses: act10ns/slack@v1
+        name: Slack notification
+        with:
+          status: success
+      - name: Mark the job as succeeded
+        run: exit 0

--- a/.github/workflows/ci-markdown.yml
+++ b/.github/workflows/ci-markdown.yml
@@ -18,11 +18,13 @@ on:
 jobs:
   # short-circuit and pass both stages
   ci-stage1:
+    runs-on: ubuntu-latest
     steps:
       - name: Mark the job as succeeded
         run: exit 0
 
   ci-stage2:
+    runs-on: ubuntu-latest
     steps:
       - uses: act10ns/slack@v1
         name: Slack notification


### PR DESCRIPTION
## Motivation
Closes #2271 

## Changes
Adds a new CI workflow that is triggered only on changes exclusively to markdown files, which instantly marks both CI stages as succeeded
