### PR TITLE
[Merged by Bors] - Correct path matching in CI-markdown

### DIFF
--- a/.github/workflows/ci-markdown.yml
+++ b/.github/workflows/ci-markdown.yml
@@ -31,7 +31,7 @@ jobs:
     - uses: dorny/paths-filter@v2
       id: filter
       with:
-        # this pattern matches using picomatch syntax (used by this Action), which is slightly
+        # this pattern matches using picomatch syntax (used by this third party Action), which is slightly
         # different than the GitHub syntax above: it also matches any file in any path ending in '.md'
         filters: |
           nondoc:

--- a/.github/workflows/ci-markdown.yml
+++ b/.github/workflows/ci-markdown.yml
@@ -34,7 +34,7 @@ jobs:
         #base: develop
         filters: |
           nondoc:
-            - '!**.md'
+            - '!**/**.md'
 
   # short-circuit and pass both stages
   ci-stage1:

--- a/.github/workflows/ci-markdown.yml
+++ b/.github/workflows/ci-markdown.yml
@@ -16,6 +16,7 @@ on:
       - staging
       - trying
     # Trigger if updating docs
+    # This pattern matches using GitHub syntax: any file in any path ending in '.md'
     paths:
       - '**.md'
 
@@ -30,11 +31,11 @@ jobs:
     - uses: dorny/paths-filter@v2
       id: filter
       with:
-        # this should be auto-detected
-        #base: develop
+        # this pattern matches using picomatch syntax (used by this Action), which is slightly
+        # different than the GitHub syntax above: it also matches any file in any path ending in '.md'
         filters: |
           nondoc:
-            - '!**/**.md'
+            - '!**/*.md'
 
   # short-circuit and pass both stages
   ci-stage1:


### PR DESCRIPTION
## Motivation
This was wrong in #2272, so when only markdown files are changed, currently, CI fails to run completely.

This happened because the glob syntax [used by GitHub](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet) slightly differs from that [used by picomatch](https://github.com/micromatch/picomatch#basic-globbing) (used under the hood in the library we're using here).

## Changes
- fix picomatch glob syntax to match all md files regardless of path

## Test Plan
N/A
