### PR TITLE
[Merged by Bors] - Fix p2p/peers TestPeers_RandomPeers test

### DIFF
--- a/p2p/peers/peers_test.go
+++ b/p2p/peers/peers_test.go
@@ -97,6 +97,7 @@ func TestPeers_RemovePeer(t *testing.T) {
 
 func TestPeers_RandomPeers(t *testing.T) {
 	pi, n, _ := getPeers(service.NewSimulator().NewNode())
+	pi.rand.Seed(0)
 	a := p2pcrypto.NewRandomPubkey()
 	b := p2pcrypto.NewRandomPubkey()
 	c := p2pcrypto.NewRandomPubkey()


### PR DESCRIPTION
## Motivation
`TestPeers_RandomPeers` test calls `GetPeers()` function, which returns peers in random order.
In particular, test checks two consecutive results from `GetPeers()`, they
shouldn't be equal. But somethimes it is.

## Changes
To make this test more predictable, rand `seed` have to be reset.