### PR TITLE
Make tortoise less reliant on hare for testnet [DO NOT MERGE]

### DIFF
--- a/miner/block_builder.go
+++ b/miner/block_builder.go
@@ -231,14 +231,14 @@ func (t *BlockBuilder) getVotes(id types.LayerID) ([]types.BlockID, error) {
 				return nil, e
 			}
 			// no hare result, vote for entire layer instead
-			t.With().Debug("adding votes for layer (no hare result)",
+			t.With().Info("adding votes for layer (no hare result)",
 				i,
 				log.FieldNamed("currentLayer", id),
 				log.Int("numVotes", len(ids)))
 			votes = append(votes, ids...)
 		} else {
 			// use hare result to set votes
-			t.With().Debug("adding votes for layer (using hare result)",
+			t.With().Info("adding votes for layer (using hare result)",
 				i,
 				log.FieldNamed("currentLayer", id),
 				log.Int("numVotes", len(res)))

--- a/miner/block_builder.go
+++ b/miner/block_builder.go
@@ -224,12 +224,14 @@ func (t *BlockBuilder) getVotes(id types.LayerID) ([]types.BlockID, error) {
 	// finished for this layer by now.
 	for i := bottom; i <= top; i++ {
 		if res, err := t.hareResult.GetResult(i); err != nil {
-			t.With().Warning("could not get result for layer in range", i, log.Err(err),
-				log.FieldNamed("bottom", bottom), log.FieldNamed("top", top), log.FieldNamed("hdist", t.hdist))
-			// no hare result, don't vote for anything
-			t.With().Info("voting for zero pattern this layer (no hare result)",
+			t.With().Warning("could not get hare result for layer in hdist range, voting for zero pattern",
 				i,
-				log.FieldNamed("currentLayer", id))
+				log.Err(err),
+				log.FieldNamed("bottom", bottom),
+				log.FieldNamed("top", top),
+				log.FieldNamed("currentLayer", id),
+				log.FieldNamed("hdist", t.hdist))
+			// no hare result, don't vote for anything
 		} else {
 			// use hare result to set votes
 			t.With().Info("adding votes for layer (using hare result)",

--- a/miner/builder_test.go
+++ b/miner/builder_test.go
@@ -674,7 +674,6 @@ func TestBlockBuilder_getVotes(t *testing.T) {
 
 	// no bottom
 	bb.meshProvider = &mockMesh{b: allblocks} // assume all blocks exist in DB --> no filtering applied
-	allids := []types.BlockID{b1.ID(), b2.ID(), b3.ID(), b4.ID(), b5.ID(), b6.ID(), b7.ID()}
 	mh = newMockResult()
 	mh.err = errors.New("no result")
 	b1arr := mh.set(bottom + 1)
@@ -683,15 +682,9 @@ func TestBlockBuilder_getVotes(t *testing.T) {
 	b, err = bb.getVotes(id)
 	r.Nil(err)
 	var exp []types.BlockID
-	exp = append(exp, allids...)
 	exp = append(exp, b1arr...)
 	exp = append(exp, tarr...)
 	r.Equal(exp, b)
-
-	// errExample on layer request
-	bb.meshProvider = &mockMesh{b: nil, err: errExample}
-	b, err = bb.getVotes(id)
-	r.Equal(errExample, err)
 }
 
 func TestBlockBuilder_createBlock(t *testing.T) {
@@ -702,14 +695,14 @@ func TestBlockBuilder_createBlock(t *testing.T) {
 	block2 := types.NewExistingBlock(6, []byte(rand.String(8)), nil)
 	block3 := types.NewExistingBlock(6, []byte(rand.String(8)), nil)
 	bs := []*types.Block{block1, block2, block3}
-	st := []types.BlockID{block1.ID(), block2.ID(), block3.ID()}
 	builder1 := createBlockBuilder("a", n1, bs)
 
+	// error from hare means no votes
 	builder1.hareResult = &mockResult{err: errExample, ids: nil}
 	builder1.AtxDb = atxDbMock{}
 	b, err := builder1.createBlock(7, types.ATXID{}, types.BlockEligibilityProof{}, nil, nil)
 	r.Nil(err)
-	r.Equal(st, b.BlockVotes)
+	r.Nil(b.BlockVotes) // expect empty slice
 
 	builder1.hareResult = &mockResult{err: nil, ids: nil}
 	b, err = builder1.createBlock(7, types.ATXID{}, types.BlockEligibilityProof{}, nil, nil)

--- a/tortoise/ninja_tortoise.go
+++ b/tortoise/ninja_tortoise.go
@@ -16,8 +16,9 @@ type vec [2]int
 type patternID uint32 // this hash does not include the layer id
 
 const ( // Threshold
-	window          = 10
-	globalThreshold = 0.6
+	window             = 10
+	globalThreshold    = 0.5
+	newlyGoodThreshold = 0.4
 )
 
 var ( // correction vectors type
@@ -382,10 +383,10 @@ func (ni *ninjaTortoise) findMinimalNewlyGoodLayer(lyr *types.Layer) types.Layer
 		// todo do this as part of previous for if possible
 		// for each p that was updated and not the good layer of j check if it is the good layer
 		for p := range sUpdated {
-			// if a majority supports p (p is good)
+			// if a minimum threshold supports p (p is good)
 			// according to tal we dont have to know the exact amount, we can multiply layer size by number of layers
 			jGood, found := ni.TGood[j]
-			threshold := 0.5 * float64(types.LayerID(ni.AvgLayerSize)*(ni.Last-p.Layer()))
+			threshold := newlyGoodThreshold * float64(types.LayerID(ni.AvgLayerSize)*(ni.Last-p.Layer()))
 			if (jGood != p || !found) && float64(ni.TSupport[p]) > threshold {
 				ni.TGood[p.Layer()] = p
 				// if p is the new minimal good layer

--- a/tortoise/ninja_tortoise.go
+++ b/tortoise/ninja_tortoise.go
@@ -385,7 +385,7 @@ func (ni *ninjaTortoise) findMinimalNewlyGoodLayer(lyr *types.Layer) types.Layer
 			// if a minimum threshold supports p (p is good)
 			// according to tal we dont have to know the exact amount, we can multiply layer size by number of layers
 			jGood, found := ni.TGood[j]
-			threshold := 0.5 * float64(types.LayerID(ni.AvgLayerSize)*(ni.Last-p.Layer()))
+			threshold := 0.4166666666666667 * float64(types.LayerID(ni.AvgLayerSize)*(ni.Last-p.Layer()))
 			if (jGood != p || !found) && float64(ni.TSupport[p]) > threshold {
 				ni.TGood[p.Layer()] = p
 				// if p is the new minimal good layer

--- a/tortoise/ninja_tortoise.go
+++ b/tortoise/ninja_tortoise.go
@@ -18,6 +18,7 @@ type patternID uint32 // this hash does not include the layer id
 const ( // Threshold
 	window             = 10
 	globalThreshold    = 0.5
+	newLayerThreshold  = 0.5 * (globalThreshold/0.6) // adjust to match global threshold
 )
 
 var ( // correction vectors type
@@ -385,7 +386,7 @@ func (ni *ninjaTortoise) findMinimalNewlyGoodLayer(lyr *types.Layer) types.Layer
 			// if a minimum threshold supports p (p is good)
 			// according to tal we dont have to know the exact amount, we can multiply layer size by number of layers
 			jGood, found := ni.TGood[j]
-			threshold := 0.4166666666666667 * float64(types.LayerID(ni.AvgLayerSize)*(ni.Last-p.Layer()))
+			threshold := newLayerThreshold * float64(types.LayerID(ni.AvgLayerSize)*(ni.Last-p.Layer()))
 			if (jGood != p || !found) && float64(ni.TSupport[p]) > threshold {
 				ni.TGood[p.Layer()] = p
 				// if p is the new minimal good layer

--- a/tortoise/ninja_tortoise.go
+++ b/tortoise/ninja_tortoise.go
@@ -18,7 +18,6 @@ type patternID uint32 // this hash does not include the layer id
 const ( // Threshold
 	window             = 10
 	globalThreshold    = 0.5
-	newlyGoodThreshold = 0.4
 )
 
 var ( // correction vectors type
@@ -294,7 +293,7 @@ func getIdsFromSet(bids map[types.BlockID]struct{}) patternID {
 }
 
 func globalOpinion(v vec, layerSize int, delta float64) vec {
-	threshold := float64(globalThreshold*delta) * float64(layerSize)
+	threshold := globalThreshold * delta * float64(layerSize)
 	if float64(v[0]) > threshold {
 		return support
 	} else if float64(v[1]) > threshold {
@@ -386,7 +385,7 @@ func (ni *ninjaTortoise) findMinimalNewlyGoodLayer(lyr *types.Layer) types.Layer
 			// if a minimum threshold supports p (p is good)
 			// according to tal we dont have to know the exact amount, we can multiply layer size by number of layers
 			jGood, found := ni.TGood[j]
-			threshold := newlyGoodThreshold * float64(types.LayerID(ni.AvgLayerSize)*(ni.Last-p.Layer()))
+			threshold := 0.5 * float64(types.LayerID(ni.AvgLayerSize)*(ni.Last-p.Layer()))
 			if (jGood != p || !found) && float64(ni.TSupport[p]) > threshold {
 				ni.TGood[p.Layer()] = p
 				// if p is the new minimal good layer

--- a/tortoise/ninja_tortoise.go
+++ b/tortoise/ninja_tortoise.go
@@ -16,9 +16,9 @@ type vec [2]int
 type patternID uint32 // this hash does not include the layer id
 
 const ( // Threshold
-	window             = 10
-	globalThreshold    = 0.5
-	newLayerThreshold  = 0.5 * (globalThreshold/0.6) // adjust to match global threshold
+	window            = 10
+	globalThreshold   = 0.5
+	newLayerThreshold = 0.5 * (globalThreshold / 0.6) // adjust to match global threshold
 )
 
 var ( // correction vectors type

--- a/tortoise/ninja_tortoise_test.go
+++ b/tortoise/ninja_tortoise_test.go
@@ -415,13 +415,13 @@ func TestNinjaTortoise_LayerWithNoVotes(t *testing.T) {
 
 	//require.Equal(t, types.LayerID(6), alg.PBase.Layer(), "unexpected pbase")
 
-	l9 := createLayer2(9, l8, []*types.Layer{l8, l7, l6, l5, l4}, 111)
+	l9 := createLayer2(9, l8, []*types.Layer{l8, l7, l6, l5, l4}, 112)
 	AddLayer(mdb, l9)
 	alg.handleIncomingLayer(l9)
 
 	//require.Equal(t, types.LayerID(6), alg.PBase.Layer(), "unexpected pbase")
 
-	l10 := createLayer2(10, l9, []*types.Layer{l9, l8, l7, l6, l5}, 123)
+	l10 := createLayer2(10, l9, []*types.Layer{l9, l8, l7, l6, l5}, 124)
 	AddLayer(mdb, l10)
 	alg.handleIncomingLayer(l10)
 

--- a/tortoise/ninja_tortoise_test.go
+++ b/tortoise/ninja_tortoise_test.go
@@ -477,73 +477,73 @@ func TestNinjaTortoise_LayerWithNoVotes2(t *testing.T) {
 	mdb := getInMemMesh()
 	alg := newNinjaTortoise(200, mdb, 5, lg)
 
-	l := createLayer2(0, nil, []*types.Layer{}, 154)
+	l := createLayer2(0, nil, []*types.Layer{}, 128)
 	AddLayer(mdb, l)
 	alg.handleIncomingLayer(l)
 
-	l1 := createLayer2(1, l, []*types.Layer{l}, 141)
+	l1 := createLayer2(1, l, []*types.Layer{l}, 117)
 	AddLayer(mdb, l1)
 	alg.handleIncomingLayer(l1)
 
-	l2 := createLayer2(2, l1, []*types.Layer{l1, l}, 129)
+	l2 := createLayer2(2, l1, []*types.Layer{l1, l}, 107)
 	AddLayer(mdb, l2)
 	alg.handleIncomingLayer(l2)
 
-	l3 := createLayer2(3, l2, []*types.Layer{l2, l1, l}, 132)
+	l3 := createLayer2(3, l2, []*types.Layer{l2, l1, l}, 116)
 	AddLayer(mdb, l3)
 	alg.handleIncomingLayer(l3)
 
-	l4 := createLayer2(4, l3, []*types.Layer{l3, l2, l1, l}, 138)
+	l4 := createLayer2(4, l3, []*types.Layer{l3, l2, l1, l}, 115)
 	AddLayer(mdb, l4)
 	alg.handleIncomingLayer(l4)
 
-	l5 := createLayer2(5, l4, []*types.Layer{l4, l3, l2, l1, l}, 158)
+	l5 := createLayer2(5, l4, []*types.Layer{l4, l3, l2, l1, l}, 132)
 	AddLayer(mdb, l5)
 	alg.handleIncomingLayer(l5)
 
-	l6 := createLayer2(6, l5, []*types.Layer{l5, l4, l3, l2, l1}, 155)
+	l6 := createLayer2(6, l5, []*types.Layer{l5, l4, l3, l2, l1}, 129)
 	AddLayer(mdb, l6)
 	alg.handleIncomingLayer(l6)
 	//
-	l7 := createLayer2(7, l6, []*types.Layer{l6, l5, l4, l3, l2}, 130)
+	l7 := createLayer2(7, l6, []*types.Layer{l6, l5, l4, l3, l2}, 108)
 	AddLayer(mdb, l7)
 	alg.handleIncomingLayer(l7)
 
-	l8 := createLayer2(8, l7, []*types.Layer{l6, l5, l4, l3}, 150)
+	l8 := createLayer2(8, l7, []*types.Layer{l6, l5, l4, l3}, 125)
 	AddLayer(mdb, l8)
 	alg.handleIncomingLayer(l8)
 
-	l9 := createLayer2(9, l8, []*types.Layer{l8, l7, l6, l5, l4}, 134)
+	l9 := createLayer2(9, l8, []*types.Layer{l8, l7, l6, l5, l4}, 112)
 	AddLayer(mdb, l9)
 	alg.handleIncomingLayer(l9)
 
-	l10 := createLayer2(10, l9, []*types.Layer{l9, l8, l7, l6, l5}, 148)
+	l10 := createLayer2(10, l9, []*types.Layer{l9, l8, l7, l6, l5}, 123)
 	AddLayer(mdb, l10)
 	alg.handleIncomingLayer(l10)
 
-	l11 := createLayer2(11, l10, []*types.Layer{l10, l9, l8, l7, l6}, 147)
+	l11 := createLayer2(11, l10, []*types.Layer{l10, l9, l8, l7, l6}, 122)
 	AddLayer(mdb, l11)
 	alg.handleIncomingLayer(l11)
 	require.Equal(t, types.LayerID(7), alg.PBase.Layer(), "unexpected pbase")
 
 	// l7 is missing exactly 1 vote to be contextually valid which will make 12 complete
-	l12 := createLayer2(12, l11, []*types.Layer{l11, l10, l9, l8, l7}, 171)
+	l12 := createLayer2(12, l11, []*types.Layer{l11, l10, l9, l8, l7}, 142)
 	AddLayer(mdb, l12)
 	alg.handleIncomingLayer(l12)
 
-	l13 := createLayer2(13, l12, []*types.Layer{l12, l11, l10, l9, l8}, 126)
+	l13 := createLayer2(13, l12, []*types.Layer{l12, l11, l10, l9, l8}, 105)
 	AddLayer(mdb, l13)
 	alg.handleIncomingLayer(l13)
 
-	l14 := createLayer2(14, l13, []*types.Layer{l13, l12, l11, l10, l9}, 148)
+	l14 := createLayer2(14, l13, []*types.Layer{l13, l12, l11, l10, l9}, 123)
 	AddLayer(mdb, l14)
 	alg.handleIncomingLayer(l14)
 
-	l15 := createLayer2(15, l14, []*types.Layer{l14, l13, l12, l11, l10}, 150)
+	l15 := createLayer2(15, l14, []*types.Layer{l14, l13, l12, l11, l10}, 125)
 	AddLayer(mdb, l15)
 	alg.handleIncomingLayer(l15)
 
-	l16 := createLayer2(16, l15, []*types.Layer{l15, l14, l13, l12, l11}, 121)
+	l16 := createLayer2(16, l15, []*types.Layer{l15, l14, l13, l12, l11}, 101)
 	AddLayer(mdb, l16)
 	alg.handleIncomingLayer(l16)
 	require.Equal(t, types.LayerID(7), alg.PBase.Layer(), "unexpected pbase")

--- a/tortoise/ninja_tortoise_test.go
+++ b/tortoise/ninja_tortoise_test.go
@@ -407,25 +407,17 @@ func TestNinjaTortoise_LayerWithNoVotes(t *testing.T) {
 	AddLayer(mdb, l7)
 	alg.handleIncomingLayer(l7)
 
-	//require.Equal(t, types.LayerID(6), alg.PBase.Layer(), "unexpected pbase")
-
 	l8 := createLayer2(8, l7, []*types.Layer{l6, l5, l4, l3}, 125)
 	AddLayer(mdb, l8)
 	alg.handleIncomingLayer(l8)
-
-	//require.Equal(t, types.LayerID(6), alg.PBase.Layer(), "unexpected pbase")
 
 	l9 := createLayer2(9, l8, []*types.Layer{l8, l7, l6, l5, l4}, 112)
 	AddLayer(mdb, l9)
 	alg.handleIncomingLayer(l9)
 
-	//require.Equal(t, types.LayerID(6), alg.PBase.Layer(), "unexpected pbase")
-
 	l10 := createLayer2(10, l9, []*types.Layer{l9, l8, l7, l6, l5}, 124)
 	AddLayer(mdb, l10)
 	alg.handleIncomingLayer(l10)
-
-	//require.Equal(t, types.LayerID(6), alg.PBase.Layer(), "unexpected pbase")
 
 	l11 := createLayer2(11, l10, []*types.Layer{l10, l9, l8, l7, l6}, 122)
 	AddLayer(mdb, l11)
@@ -433,7 +425,7 @@ func TestNinjaTortoise_LayerWithNoVotes(t *testing.T) {
 
 	require.Equal(t, types.LayerID(7), alg.PBase.Layer(), "unexpected pbase")
 
-	//now l7 one votes to be contextually valid in the eyes of layer 12 good pattern
+	// now l7 one votes to be contextually valid in the eyes of layer 12 good pattern
 	l12 := createLayer2(12, l11, []*types.Layer{l11, l10, l9, l8, l7}, 142)
 	AddLayer(mdb, l12)
 	alg.handleIncomingLayer(l12)
@@ -443,8 +435,6 @@ func TestNinjaTortoise_LayerWithNoVotes(t *testing.T) {
 	l13 := createLayer2(13, l12, []*types.Layer{l12, l11, l10, l9, l8}, 105)
 	AddLayer(mdb, l13)
 	alg.handleIncomingLayer(l13)
-
-	//require.Equal(t, types.LayerID(7), alg.PBase.Layer(), "unexpected pbase")
 
 	// now l7 has the exact amount of votes to be contextually valid which will make 12 good pattern complete
 	l12b := createLayer2(12, l11, []*types.Layer{l11, l10, l9, l8, l7}, 1)
@@ -456,8 +446,6 @@ func TestNinjaTortoise_LayerWithNoVotes(t *testing.T) {
 	l14 := createLayer2(14, l13, []*types.Layer{l13, l12, l12b, l11, l10, l9}, 123)
 	AddLayer(mdb, l14)
 	alg.handleIncomingLayer(l14)
-
-	//require.Equal(t, types.LayerID(7), alg.PBase.Layer(), "unexpected pbase")
 
 	l15 := createLayer2(15, l14, []*types.Layer{l14, l13, l12b, l12, l11, l10}, 125)
 	AddLayer(mdb, l15)

--- a/tortoise/ninja_tortoise_test.go
+++ b/tortoise/ninja_tortoise_test.go
@@ -375,66 +375,76 @@ func TestNinjaTortoise_LayerWithNoVotes(t *testing.T) {
 	mdb := getInMemMesh()
 	alg := newNinjaTortoise(200, mdb, 5, lg)
 
-	l := createLayer2(0, nil, []*types.Layer{}, 154)
+	l := createLayer2(0, nil, []*types.Layer{}, 128)
 	AddLayer(mdb, l)
 	alg.handleIncomingLayer(l)
 
-	l1 := createLayer2(1, l, []*types.Layer{l}, 141)
+	l1 := createLayer2(1, l, []*types.Layer{l}, 117)
 	AddLayer(mdb, l1)
 	alg.handleIncomingLayer(l1)
 
-	l2 := createLayer2(2, l1, []*types.Layer{l1, l}, 129)
+	l2 := createLayer2(2, l1, []*types.Layer{l1, l}, 107)
 	AddLayer(mdb, l2)
 	alg.handleIncomingLayer(l2)
 
-	l3 := createLayer2(3, l2, []*types.Layer{l2, l1, l}, 132)
+	l3 := createLayer2(3, l2, []*types.Layer{l2, l1, l}, 110)
 	AddLayer(mdb, l3)
 	alg.handleIncomingLayer(l3)
 
-	l4 := createLayer2(4, l3, []*types.Layer{l3, l2, l1, l}, 138)
+	l4 := createLayer2(4, l3, []*types.Layer{l3, l2, l1, l}, 115)
 	AddLayer(mdb, l4)
 	alg.handleIncomingLayer(l4)
 
-	l5 := createLayer2(5, l4, []*types.Layer{l4, l3, l2, l1, l}, 158)
+	l5 := createLayer2(5, l4, []*types.Layer{l4, l3, l2, l1, l}, 131)
 	AddLayer(mdb, l5)
 	alg.handleIncomingLayer(l5)
 
-	l6 := createLayer2(6, l5, []*types.Layer{l5, l4, l3, l2, l1}, 155)
+	l6 := createLayer2(6, l5, []*types.Layer{l5, l4, l3, l2, l1}, 129)
 	AddLayer(mdb, l6)
 	alg.handleIncomingLayer(l6)
 	//
-	l7 := createLayer2(7, l6, []*types.Layer{l6, l5, l4, l3, l2}, 130)
+	l7 := createLayer2(7, l6, []*types.Layer{l6, l5, l4, l3, l2}, 108)
 	AddLayer(mdb, l7)
 	alg.handleIncomingLayer(l7)
 
-	l8 := createLayer2(8, l7, []*types.Layer{l6, l5, l4, l3}, 150)
+	//require.Equal(t, types.LayerID(6), alg.PBase.Layer(), "unexpected pbase")
+
+	l8 := createLayer2(8, l7, []*types.Layer{l6, l5, l4, l3}, 125)
 	AddLayer(mdb, l8)
 	alg.handleIncomingLayer(l8)
 
-	l9 := createLayer2(9, l8, []*types.Layer{l8, l7, l6, l5, l4}, 134)
+	//require.Equal(t, types.LayerID(6), alg.PBase.Layer(), "unexpected pbase")
+
+	l9 := createLayer2(9, l8, []*types.Layer{l8, l7, l6, l5, l4}, 111)
 	AddLayer(mdb, l9)
 	alg.handleIncomingLayer(l9)
 
-	l10 := createLayer2(10, l9, []*types.Layer{l9, l8, l7, l6, l5}, 148)
+	//require.Equal(t, types.LayerID(6), alg.PBase.Layer(), "unexpected pbase")
+
+	l10 := createLayer2(10, l9, []*types.Layer{l9, l8, l7, l6, l5}, 123)
 	AddLayer(mdb, l10)
 	alg.handleIncomingLayer(l10)
 
-	l11 := createLayer2(11, l10, []*types.Layer{l10, l9, l8, l7, l6}, 147)
+	//require.Equal(t, types.LayerID(6), alg.PBase.Layer(), "unexpected pbase")
+
+	l11 := createLayer2(11, l10, []*types.Layer{l10, l9, l8, l7, l6}, 122)
 	AddLayer(mdb, l11)
 	alg.handleIncomingLayer(l11)
 
 	require.Equal(t, types.LayerID(7), alg.PBase.Layer(), "unexpected pbase")
 
 	//now l7 one votes to be contextually valid in the eyes of layer 12 good pattern
-	l12 := createLayer2(12, l11, []*types.Layer{l11, l10, l9, l8, l7}, 171)
+	l12 := createLayer2(12, l11, []*types.Layer{l11, l10, l9, l8, l7}, 142)
 	AddLayer(mdb, l12)
 	alg.handleIncomingLayer(l12)
 
 	require.Equal(t, types.LayerID(7), alg.PBase.Layer(), "unexpected pbase")
 
-	l13 := createLayer2(13, l12, []*types.Layer{l12, l11, l10, l9, l8}, 126)
+	l13 := createLayer2(13, l12, []*types.Layer{l12, l11, l10, l9, l8}, 105)
 	AddLayer(mdb, l13)
 	alg.handleIncomingLayer(l13)
+
+	//require.Equal(t, types.LayerID(7), alg.PBase.Layer(), "unexpected pbase")
 
 	// now l7 has the exact amount of votes to be contextually valid which will make 12 good pattern complete
 	l12b := createLayer2(12, l11, []*types.Layer{l11, l10, l9, l8, l7}, 1)
@@ -443,17 +453,19 @@ func TestNinjaTortoise_LayerWithNoVotes(t *testing.T) {
 
 	require.Equal(t, types.LayerID(7), alg.PBase.Layer(), "unexpected pbase")
 
-	l14 := createLayer2(14, l13, []*types.Layer{l13, l12, l12b, l11, l10, l9}, 148)
+	l14 := createLayer2(14, l13, []*types.Layer{l13, l12, l12b, l11, l10, l9}, 123)
 	AddLayer(mdb, l14)
 	alg.handleIncomingLayer(l14)
 
-	l15 := createLayer2(15, l14, []*types.Layer{l14, l13, l12b, l12, l11, l10}, 150)
+	//require.Equal(t, types.LayerID(7), alg.PBase.Layer(), "unexpected pbase")
+
+	l15 := createLayer2(15, l14, []*types.Layer{l14, l13, l12b, l12, l11, l10}, 125)
 	AddLayer(mdb, l15)
 	alg.handleIncomingLayer(l15)
 
 	require.Equal(t, types.LayerID(7), alg.PBase.Layer(), "unexpected pbase")
 
-	l16 := createLayer2(16, l15, []*types.Layer{l15, l14, l12b, l13, l12, l11}, 121)
+	l16 := createLayer2(16, l15, []*types.Layer{l15, l14, l12b, l13, l12, l11}, 100)
 	AddLayer(mdb, l16)
 	alg.handleIncomingLayer(l16)
 	require.Equal(t, types.LayerID(15), alg.PBase.Layer(), "unexpected pbase")

--- a/tortoise/ninja_tortoise_test.go
+++ b/tortoise/ninja_tortoise_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/mesh"
 	"github.com/spacemeshos/go-spacemesh/rand"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"math"
 	"os"
 	"runtime"
@@ -352,12 +353,12 @@ func createLayer2(index types.LayerID, view *types.Layer, votes []*types.Layer, 
 		for idx, pat := range patterns {
 			for _, id := range pat {
 				b := votes[idx].Blocks()[id]
-				bl.AddVote(types.BlockID(b.ID()))
+				bl.AddVote(b.ID())
 			}
 		}
 		if view != nil && len(view.Blocks()) > 0 {
 			for _, prevBloc := range view.Blocks() {
-				bl.AddView(types.BlockID(prevBloc.ID()))
+				bl.AddView(prevBloc.ID())
 			}
 		}
 
@@ -422,40 +423,40 @@ func TestNinjaTortoise_LayerWithNoVotes(t *testing.T) {
 	AddLayer(mdb, l11)
 	alg.handleIncomingLayer(l11)
 
-	assert.True(t, alg.PBase.Layer() == 7)
+	require.Equal(t, types.LayerID(7), alg.PBase.Layer(), "unexpected pbase")
 
 	//now l7 one votes to be contextually valid in the eyes of layer 12 good pattern
 	l12 := createLayer2(12, l11, []*types.Layer{l11, l10, l9, l8, l7}, 171)
 	AddLayer(mdb, l12)
 	alg.handleIncomingLayer(l12)
 
-	assert.True(t, alg.PBase.Layer() == 7)
+	require.Equal(t, types.LayerID(7), alg.PBase.Layer(), "unexpected pbase")
 
 	l13 := createLayer2(13, l12, []*types.Layer{l12, l11, l10, l9, l8}, 126)
 	AddLayer(mdb, l13)
 	alg.handleIncomingLayer(l13)
 
-	//now l7 has the exact amount of votes to be contextually valid which will make 12 good pattern complete
-	l121 := createLayer2(12, l11, []*types.Layer{l11, l10, l9, l8, l7}, 1)
-	AddLayer(mdb, l121)
-	alg.handleIncomingLayer(l121)
+	// now l7 has the exact amount of votes to be contextually valid which will make 12 good pattern complete
+	l12b := createLayer2(12, l11, []*types.Layer{l11, l10, l9, l8, l7}, 1)
+	AddLayer(mdb, l12b)
+	alg.handleIncomingLayer(l12b)
 
-	assert.True(t, alg.PBase.Layer() == 7)
+	require.Equal(t, types.LayerID(7), alg.PBase.Layer(), "unexpected pbase")
 
-	l14 := createLayer2(14, l13, []*types.Layer{l13, l12, l121, l11, l10, l9}, 148)
+	l14 := createLayer2(14, l13, []*types.Layer{l13, l12, l12b, l11, l10, l9}, 148)
 	AddLayer(mdb, l14)
 	alg.handleIncomingLayer(l14)
 
-	l15 := createLayer2(15, l14, []*types.Layer{l14, l13, l121, l12, l11, l10}, 150)
+	l15 := createLayer2(15, l14, []*types.Layer{l14, l13, l12b, l12, l11, l10}, 150)
 	AddLayer(mdb, l15)
 	alg.handleIncomingLayer(l15)
 
-	assert.True(t, alg.PBase.Layer() == 7)
+	require.Equal(t, types.LayerID(7), alg.PBase.Layer(), "unexpected pbase")
 
-	l16 := createLayer2(16, l15, []*types.Layer{l15, l14, l121, l13, l12, l11}, 121)
+	l16 := createLayer2(16, l15, []*types.Layer{l15, l14, l12b, l13, l12, l11}, 121)
 	AddLayer(mdb, l16)
 	alg.handleIncomingLayer(l16)
-	assert.True(t, alg.PBase.Layer() == 15)
+	require.Equal(t, types.LayerID(15), alg.PBase.Layer(), "unexpected pbase")
 }
 
 func TestNinjaTortoise_LayerWithNoVotes2(t *testing.T) {
@@ -511,7 +512,7 @@ func TestNinjaTortoise_LayerWithNoVotes2(t *testing.T) {
 	l11 := createLayer2(11, l10, []*types.Layer{l10, l9, l8, l7, l6}, 147)
 	AddLayer(mdb, l11)
 	alg.handleIncomingLayer(l11)
-	assert.True(t, alg.PBase.Layer() == 7)
+	require.Equal(t, types.LayerID(7), alg.PBase.Layer(), "unexpected pbase")
 
 	// l7 is missing exactly 1 vote to be contextually valid which will make 12 complete
 	l12 := createLayer2(12, l11, []*types.Layer{l11, l10, l9, l8, l7}, 171)
@@ -533,7 +534,7 @@ func TestNinjaTortoise_LayerWithNoVotes2(t *testing.T) {
 	l16 := createLayer2(16, l15, []*types.Layer{l15, l14, l13, l12, l11}, 121)
 	AddLayer(mdb, l16)
 	alg.handleIncomingLayer(l16)
-	assert.True(t, alg.PBase.Layer() == 7)
+	require.Equal(t, types.LayerID(7), alg.PBase.Layer(), "unexpected pbase")
 }
 
 func TestNinjaTortoise_OneMoreLayerWithNoVotes(t *testing.T) {


### PR DESCRIPTION
## Motivation
In the most recent testnets (123, 124), tortoise has failed because of hare failures. This makes tortoise less reliant on hare succeeding, so that the testnet should be able to continue to advance pbase even if hare fails completely.

## Changes
- Change how blocks vote when hare has failed
- Lower tortoise thresholds

## Test Plan
- Affected tests have been updated: block_builder tests have been updated to expect the right voting pattern, and tortoise tests have been updated to change the number of blocks per layer (and thus votes) proportional to the modified tortoise thresholds

## TODO
- [x] Change voting to vote _against_ all blocks in case of hare failure, per Tal
