### PR TITLE
[Merged by Bors] - Improve UX in genesis epochs

### DIFF
--- a/api/grpcserver/grpcserver_test.go
+++ b/api/grpcserver/grpcserver_test.go
@@ -68,8 +68,8 @@ const (
 
 var (
 	layerCurrent = 12
-	networkMock = NetworkMock{}
-	mempoolMock = MempoolMock{
+	networkMock  = NetworkMock{}
+	mempoolMock  = MempoolMock{
 		poolByAddress: make(map[types.Address]types.TransactionID),
 		poolByTxid:    make(map[types.TransactionID]*types.Transaction),
 	}

--- a/sync/syncer.go
+++ b/sync/syncer.go
@@ -348,9 +348,12 @@ func (s *Syncer) synchronise() {
 	// we have all the data of the prev layers so we can simply validate
 	if s.weaklySynced(curr) {
 		s.handleWeaklySynced()
-		err := s.syncEpochActivations(curr.GetEpoch())
-		if err != nil {
-			s.With().Error("cannot fetch epoch atxs ", curr, log.Err(err))
+		if err := s.syncEpochActivations(curr.GetEpoch()); err != nil {
+			if curr.GetEpoch().IsGenesis() {
+				s.With().Info("cannot fetch epoch atxs (expected during genesis)", curr, log.Err(err))
+			} else {
+				s.With().Error("cannot fetch epoch atxs", curr, log.Err(err))
+			}
 		}
 	} else {
 		s.handleNotSynced(s.ProcessedLayer() + 1)
@@ -394,16 +397,20 @@ func (s *Syncer) handleLayersTillCurrent() {
 		return
 	}
 
-	s.Info("handle layers %d to %d", s.ProcessedLayer()+1, s.GetCurrentLayer()-1)
+	s.With().Info("handle layers",
+		log.FieldNamed("from", s.ProcessedLayer()+1), log.FieldNamed("to", s.GetCurrentLayer()-1))
 	for currentSyncLayer := s.ProcessedLayer() + 1; currentSyncLayer < s.GetCurrentLayer(); currentSyncLayer++ {
 		if s.isClosed() {
 			return
 		}
 		if err := s.getAndValidateLayer(currentSyncLayer); err != nil {
 			if currentSyncLayer.GetEpoch().IsGenesis() {
-				log.Warning("failed getting layer even though we are weakly-synced currentLayer=%v lastTicked=%v err=%v ", currentSyncLayer, s.GetCurrentLayer(), err)
+				s.With().Info("failed getting layer even though we are weakly synced (expected during genesis)",
+					log.FieldNamed("currentSyncLayer", currentSyncLayer),
+					log.FieldNamed("currentLayer", s.GetCurrentLayer()),
+					log.Err(err))
 			} else {
-				s.Panic("failed getting layer even though we are weakly-synced currentLayer=%v lastTicked=%v err=%v ", currentSyncLayer, s.GetCurrentLayer(), err)
+				s.Panic("failed getting layer even though we are weakly synced currentLayer=%v lastTicked=%v err=%v", currentSyncLayer, s.GetCurrentLayer(), err)
 			}
 		}
 	}
@@ -481,9 +488,12 @@ func (s *Syncer) handleNotSynced(currentSyncLayer types.LayerID) {
 func (s *Syncer) syncAtxs(currentSyncLayer types.LayerID) {
 	lastLayerOfEpoch := (currentSyncLayer.GetEpoch() + 1).FirstLayer() - 1
 	if currentSyncLayer == lastLayerOfEpoch {
-		err := s.syncEpochActivations(currentSyncLayer.GetEpoch())
-		if err != nil {
-			s.With().Error("cannot fetch epoch atxs ", currentSyncLayer, log.Err(err))
+		if err := s.syncEpochActivations(currentSyncLayer.GetEpoch()); err != nil {
+			if currentSyncLayer.GetEpoch().IsGenesis() {
+				s.With().Info("cannot fetch epoch atxs (expected during genesis)", currentSyncLayer, log.Err(err))
+			} else {
+				s.With().Error("cannot fetch epoch atxs", currentSyncLayer, log.Err(err))
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Motivation
Right now when a user runs smapp and connects to a testnet during the genesis epochs, they see their node stuck syncing layer 575 (the final layer in the second epoch) for a very long time. This patch fixes this issue, and also reduces some spurious errors and warnings that are expected during the genesis epochs.

## Changes
- API now returns current layer rather than future, effective genesis
- Reduce errors and warnings that appear during genesis epochs to info

## Test Plan
N/A, no functionality changes

## DevOps Notes
- [ ] Does this code require configuration changes?
- [ ] Does this code affect public APIs?
- [ ] Does this code assume a new version of external services (PoET, elasticsearch, etc.)
- [x] Does this code make changes to log messages that our monitoring infrastructure may rely on?