### PR TITLE
[Merged by Bors] - Add 80 port for kibana service on tests

### DIFF
--- a/tests/elk/kibana/service.yaml
+++ b/tests/elk/kibana/service.yaml
@@ -12,5 +12,9 @@ spec:
       protocol: TCP
       name: http
       targetPort: 5601
+    - port: 80
+      protocol: TCP
+      name: http80
+      targetPort: 5601
   selector:
     app: kibana


### PR DESCRIPTION
## Motivation

Kibana can be accessible via ip:port. In order to add https://domain we need 80 port in k8s service.

## Test Plan

It is applied and working.

## DevOps Notes

Another option to do it is to create Ingress and cert-manager how it is done on ws-ops repository.