### PR TITLE
[Merged by Bors] - replace FailNow in test with Panic

### DIFF
--- a/priorityq/priorityq_test.go
+++ b/priorityq/priorityq_test.go
@@ -1,6 +1,7 @@
 package priorityq
 
 import (
+	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/stretchr/testify/require"
 	"sync"
 	"testing"
@@ -96,7 +97,7 @@ func TestPriorityQ_Read(t *testing.T) {
 			//fmt.Println("reading  ", m, e, i, len(pq.queues[0]), len(pq.queues[1]))
 			if !ok {
 				// should never happen
-				t.FailNow()
+				log.Panic("unable to read message priority")
 			}
 
 			r.False(prio < maxPrio)


### PR DESCRIPTION
## Motivation
Fixes #2348

## Changes
- replace `t.FailNow()` in non-test goroutine with Panic

## Test Plan
N/A

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [ ] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
