### PR TITLE
Make hare active set/eligibility check less fragile (take 2)

### DIFF
--- a/activation/atxdb.go
+++ b/activation/atxdb.go
@@ -258,8 +258,7 @@ func (db *DB) CalcActiveSetSize(epoch types.EpochID, blocks map[types.BlockID]st
 	traversalFunc := db.createTraversalActiveSetCounterFunc(countedAtxs, penalties, db.LayersPerEpoch, epoch)
 
 	startTime := time.Now()
-	err := db.meshDb.ForBlockInView(blocks, firstLayerOfPrevEpoch, traversalFunc)
-	if err != nil {
+	if err := db.meshDb.ForBlockInView(blocks, firstLayerOfPrevEpoch, traversalFunc); err != nil {
 		return nil, err
 	}
 	db.log.With().Info("done calculating active set size",

--- a/hare/eligibility/beacon_test.go
+++ b/hare/eligibility/beacon_test.go
@@ -31,7 +31,7 @@ func TestBeacon_Value(t *testing.T) {
 	r := require.New(t)
 
 	b := NewBeacon(nil, 0, log.NewDefault(t.Name()))
-	c := newMockCasher()
+	c := newMockCacher()
 	b.cache = c
 
 	genesisGoodPtrn := map[types.BlockID]struct{}{}

--- a/hare/eligibility/oracle.go
+++ b/hare/eligibility/oracle.go
@@ -19,7 +19,6 @@ const activesCacheSize = 5 // we don't expect to handle more than two layers con
 
 var (
 	errGenesis            = errors.New("no data about active nodes for genesis")
-	errNoContextualBlocks = errors.New("no contextually valid blocks")
 )
 
 type valueProvider interface {

--- a/hare/eligibility/oracle.go
+++ b/hare/eligibility/oracle.go
@@ -269,9 +269,9 @@ func (o *Oracle) actives(layer types.LayerID) (activeMap map[string]struct{}, er
 	}
 
 	// build a map of all blocks on the current layer
-	mp, err := o.blocksProvider.ContextuallyValidBlock(sl)
-	if err != nil {
-		return
+	mp, err2 := o.blocksProvider.ContextuallyValidBlock(sl)
+	if err2 != nil {
+		return nil, err2
 	}
 
 	// no contextually valid blocks: for now we just fall back on an empty active set. this will go away when we
@@ -282,7 +282,7 @@ func (o *Oracle) actives(layer types.LayerID) (activeMap map[string]struct{}, er
 			layer.GetEpoch(),
 			log.FieldNamed("safe_layer_id", sl),
 			log.FieldNamed("safe_epoch_id", safeEp))
-		return activeMap, nil
+		return
 	}
 
 	activeMap, err = o.getActiveSet(safeEp-1, mp)

--- a/hare/eligibility/oracle.go
+++ b/hare/eligibility/oracle.go
@@ -181,18 +181,18 @@ func (o *Oracle) activeSetSize(layer types.LayerID) (uint32, error) {
 func (o *Oracle) Eligible(layer types.LayerID, round int32, committeeSize int, id types.NodeID, sig []byte) (bool, error) {
 	msg, err := o.buildVRFMessage(layer, round)
 	if err != nil {
-		o.Error("eligibility: could not build VRF message")
+		o.Error("eligibility: could not build vrf message")
 		return false, err
 	}
 
 	// validate message
 	res, err := o.vrfVerifier(msg, sig, id.VRFPublicKey)
 	if err != nil {
-		o.Error("eligibility: VRF verification failed: %v", err)
+		o.With().Error("eligibility: vrf verification failed", log.Err(err))
 		return false, err
 	}
 	if !res {
-		o.With().Info("eligibility: a node did not pass VRF signature verification",
+		o.With().Info("eligibility: a node did not pass vrf signature verification",
 			id,
 			layer)
 		return false, nil
@@ -213,9 +213,10 @@ func (o *Oracle) Eligible(layer types.LayerID, round int32, committeeSize int, i
 	// calc hash & check threshold
 	sha := sha256.Sum256(sig)
 	shaUint32 := binary.LittleEndian.Uint32(sha[:4])
+
 	// avoid division (no floating point) & do operations on uint64 to avoid overflow
 	if uint64(activeSetSize)*uint64(shaUint32) > uint64(committeeSize)*uint64(math.MaxUint32) {
-		o.With().Info("eligibility: node did not pass VRF eligibility threshold",
+		o.With().Info("eligibility: node did not pass vrf eligibility threshold",
 			id,
 			log.Int("committee_size", committeeSize),
 			log.Uint32("active_set_size", activeSetSize),

--- a/hare/eligibility/oracle.go
+++ b/hare/eligibility/oracle.go
@@ -18,7 +18,7 @@ const vrfMsgCacheSize = 20 // numRounds per layer is <= 2. numConcurrentLayers<=
 const activesCacheSize = 5 // we don't expect to handle more than two layers concurrently
 
 var (
-	errGenesis            = errors.New("no data about active nodes for genesis")
+	errGenesis = errors.New("no data about active nodes for genesis")
 )
 
 type valueProvider interface {

--- a/hare/eligibility/oracle_test.go
+++ b/hare/eligibility/oracle_test.go
@@ -368,13 +368,14 @@ func TestOracle_roundedSafeLayer(t *testing.T) {
 
 func TestOracle_actives(t *testing.T) {
 	r := require.New(t)
+	types.SetLayersPerEpoch(10)
 	o := New(&mockValueProvider{1, nil}, nil, nil, nil, 5, genActive, mockBlocksProvider{}, cfg, log.NewDefault(t.Name()))
 	_, err := o.actives(1)
 	r.EqualError(err, errGenesis.Error())
 
 	o.blocksProvider = mockBlocksProvider{mp: make(map[types.BlockID]struct{})}
 	_, err = o.actives(100)
-	r.EqualError(err, errNoContextualBlocks.Error())
+	r.NoError(err)
 
 	o.blocksProvider = mockBlocksProvider{}
 	mp := createMapWithSize(9)
@@ -491,6 +492,7 @@ func TestOracle_activesNoContextuallyValid(t *testing.T) {
 
 func TestOracle_IsIdentityActive(t *testing.T) {
 	r := require.New(t)
+	types.SetLayersPerEpoch(10)
 	o := New(&mockValueProvider{1, nil}, nil, nil, nil, 5, genActive, mockBlocksProvider{}, cfg, log.NewDefault(t.Name()))
 	mp := make(map[string]struct{})
 	edid := "11111"
@@ -523,6 +525,7 @@ func TestOracle_IsIdentityActive(t *testing.T) {
 
 func TestOracle_Eligible2(t *testing.T) {
 	o := New(&mockValueProvider{1, nil}, nil, nil, nil, 5, genActive, mockBlocksProvider{}, cfg, log.NewDefault(t.Name()))
+	types.SetLayersPerEpoch(10)
 	o.getActiveSet = func(epoch types.EpochID, blocks map[types.BlockID]struct{}) (map[string]struct{}, error) {
 		return createMapWithSize(9), errFoo
 	}

--- a/hare/eligibility/oracle_test.go
+++ b/hare/eligibility/oracle_test.go
@@ -76,7 +76,7 @@ type mockCacher struct {
 	mutex  sync.Mutex
 }
 
-func newMockCasher() *mockCacher {
+func newMockCacher() *mockCacher {
 	return &mockCacher{make(map[interface{}]interface{}), 0, 0, sync.Mutex{}}
 }
 
@@ -101,7 +101,7 @@ func (mc *mockCacher) Get(key interface{}) (value interface{}, ok bool) {
 
 func TestOracle_BuildVRFMessage(t *testing.T) {
 	r := require.New(t)
-	o := Oracle{vrfMsgCache: newMockCasher(), Log: log.NewDefault(t.Name())}
+	o := Oracle{vrfMsgCache: newMockCacher(), Log: log.NewDefault(t.Name())}
 	o.beacon = &mockValueProvider{1, errFoo}
 	_, err := o.buildVRFMessage(types.LayerID(1), 1)
 	r.Equal(errFoo, err)
@@ -132,7 +132,7 @@ func TestOracle_BuildVRFMessage(t *testing.T) {
 func TestOracle_buildVRFMessageConcurrency(t *testing.T) {
 	r := require.New(t)
 	o := New(&mockValueProvider{1, nil}, (&mockActiveSetProvider{10}).ActiveSet, buildVerifier(true, nil), &mockSigner{[]byte{1, 2, 3}, nil}, 5, 5, mockBlocksProvider{}, cfg, log.NewDefault(t.Name()))
-	mCache := newMockCasher()
+	mCache := newMockCacher()
 	o.vrfMsgCache = mCache
 
 	total := 1000
@@ -381,7 +381,7 @@ func TestOracle_actives(t *testing.T) {
 	o.getActiveSet = func(epoch types.EpochID, blocks map[types.BlockID]struct{}) (map[string]struct{}, error) {
 		return mp, nil
 	}
-	o.activesCache = newMockCasher()
+	o.activesCache = newMockCacher()
 	v, err := o.actives(100)
 	r.NoError(err)
 	v2, err := o.actives(100)
@@ -403,7 +403,7 @@ func TestOracle_concurrentActives(t *testing.T) {
 	r := require.New(t)
 	o := New(&mockValueProvider{1, nil}, nil, nil, nil, 5, genActive, mockBlocksProvider{}, cfg, log.NewDefault(t.Name()))
 
-	mc := newMockCasher()
+	mc := newMockCacher()
 	o.activesCache = mc
 	mp := createMapWithSize(9)
 	o.getActiveSet = func(epoch types.EpochID, blocks map[types.BlockID]struct{}) (map[string]struct{}, error) {
@@ -439,7 +439,7 @@ func TestOracle_activesSafeLayer(t *testing.T) {
 	types.SetLayersPerEpoch(2)
 	o := New(&mockValueProvider{1, nil}, nil, nil, nil, 2, genActive, mockBlocksProvider{}, eCfg.Config{ConfidenceParam: 2, EpochOffset: 0}, log.NewDefault(t.Name()))
 	mp := createMapWithSize(9)
-	o.activesCache = newMockCasher()
+	o.activesCache = newMockCacher()
 	lyr := types.LayerID(10)
 	rsl := roundedSafeLayer(lyr, types.LayerID(o.cfg.ConfidenceParam), o.layersPerEpoch, types.LayerID(o.cfg.EpochOffset))
 	o.getActiveSet = func(epoch types.EpochID, blocks map[types.BlockID]struct{}) (map[string]struct{}, error) {


### PR DESCRIPTION
## Motivation
Closes #2356

## Changes
When calculating active set for a given epoch for hare eligibility, if there are no contextually valid blocks for the safe layer (e.g., if hare failed for this layer), just use zero as the active set size.

This issue caused the demise of testnet 126. Per Tal, this is the safest workaround for now, until eventually the tortoise beacon allows us to remove the dependency of hare beacon upon hare itself.

## Test Plan
Adds a regression test

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [ ] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
