### PR TITLE
[Merged by Bors] - Fix SetZeroBlockLayer logic

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -152,9 +152,9 @@ func (db *LDBDatabase) Close() {
 	}
 	err := db.db.Close()
 	if err == nil {
-		db.log.Info("Database closed")
+		db.log.With().Info("database closed", log.String("file", db.fn))
 	} else {
-		db.log.Error("Failed to close database", "err", err)
+		db.log.With().Error("failed to close database", log.String("file", db.fn), log.Err(err))
 	}
 }
 

--- a/mesh/mesh.go
+++ b/mesh/mesh.go
@@ -164,7 +164,7 @@ func NewRecoveredMesh(db *DB, atxDb AtxDB, rewardConfig Config, mesh tortoise, t
 		msh.pushLayersToState(msh.LatestLayerInState()+1, msh.trtl.LatestComplete())
 	}
 
-	msh.With().Info("recovered mesh from disc",
+	msh.With().Info("recovered mesh from disk",
 		log.FieldNamed("latest_layer", msh.latestLayer),
 		log.FieldNamed("validated_layer", msh.ProcessedLayer()),
 		log.String("layer_hash", util.Bytes2Hex(msh.layerHash)),
@@ -206,7 +206,7 @@ func (msh *Mesh) SetLatestLayer(idx types.LayerID) {
 	// Report the status update, as well as the layer itself.
 	layer, err := msh.GetLayer(idx)
 	if err != nil {
-		msh.Error("error reading layer data for layer", layer, log.Err(err))
+		msh.With().Error("error reading layer data", idx, log.Err(err))
 	} else {
 		events.ReportNewLayer(events.NewLayer{
 			Layer:  layer,

--- a/mesh/mesh.go
+++ b/mesh/mesh.go
@@ -220,7 +220,7 @@ func (msh *Mesh) SetLatestLayer(idx types.LayerID) {
 		msh.With().Info("set latest known layer", idx)
 		msh.latestLayer = idx
 		if err := msh.general.Put(constLATEST, idx.Bytes()); err != nil {
-			msh.Error("could not persist Latest layer index")
+			msh.Error("could not persist latest layer index")
 		}
 	}
 }

--- a/mesh/meshdb.go
+++ b/mesh/meshdb.go
@@ -103,10 +103,10 @@ func NewPersistentMeshDB(path string, blockCacheSize int, log log.Log) (*DB, err
 // PersistentData checks to see if db is empty
 func (m *DB) PersistentData() bool {
 	if _, err := m.general.Get(constLATEST); err == nil {
-		m.Info("found data to recover on disc")
+		m.Info("found data to recover on disk")
 		return true
 	}
-	m.Info("did not find data to recover on disc")
+	m.Info("did not find data to recover on disk")
 	return false
 }
 

--- a/sync/requests.go
+++ b/sync/requests.go
@@ -245,7 +245,7 @@ func inputVectorReqFactory(lyreq []byte) requestFactory {
 			s.Info("handle inputvec response")
 			defer close(ch)
 			if len(msg) == 0 || msg == nil {
-				s.Warning("peer responded with nil to inputvec request %v", peer, lyreq)
+				s.With().Warning("peer responded with nil to inputvec request", peer)
 				return
 			}
 

--- a/sync/syncer_test.go
+++ b/sync/syncer_test.go
@@ -1315,7 +1315,7 @@ func TestSyncer_handleNotSyncedFlow(t *testing.T) {
 // Make sure this can be called successfully several times for the same layer
 func TestSyncer_handleNotSyncedZeroBlocksLayer(t *testing.T) {
 	r := require.New(t)
-	ts := &mockClock{Layer: 10}
+	ts := &mockClock{Layer: 2}
 	syncs, nodes := SyncMockFactoryManClock(1, conf, t.Name(), memoryDB, newMockPoetDb, ts)
 	sync := syncs[0]
 	sync.peers = getPeersMock([]p2ppeers.Peer{nodes[0].PublicKey()})
@@ -1325,9 +1325,10 @@ func TestSyncer_handleNotSyncedZeroBlocksLayer(t *testing.T) {
 	r.NoError(sync.SetZeroBlockLayer(1))
 	r.Equal(0, lv.countValidated)
 	r.Equal(types.LayerID(0), lv.processedLayer)
-	sync.handleNotSynced(1)
-	r.Equal(1, lv.countValidated)
-	r.Equal(1, lv.processedLayer)
+	go sync.handleNotSynced(1)
+	time.Sleep(100 * time.Millisecond)
+	r.Equal(1, lv.countValidate)
+	r.Equal(types.LayerID(1), lv.processedLayer)
 }
 
 func TestSyncer_SetZeroBlockLayer(t *testing.T) {

--- a/sync/syncer_test.go
+++ b/sync/syncer_test.go
@@ -182,7 +182,6 @@ func createBlock(activationTx types.ActivationTx, signer *signing.EdSigner) *typ
 }
 
 func TestSyncer_Close(t *testing.T) {
-
 	syncs, _, _ := SyncMockFactory(2, conf, t.Name(), memoryDB, newMockPoetDb)
 
 	sync := syncs[0]
@@ -200,7 +199,6 @@ func TestSyncer_Close(t *testing.T) {
 	assert.True(t, !ok, "channel 'forceSync' still open")
 	_, ok = <-sync.exit
 	assert.True(t, !ok, "channel 'exit' still open")
-
 }
 
 func TestSyncProtocol_BlockRequest(t *testing.T) {
@@ -210,8 +208,9 @@ func TestSyncProtocol_BlockRequest(t *testing.T) {
 	assert.NoError(t, err)
 	syncs, nodes, _ := SyncMockFactory(2, conf, t.Name(), memoryDB, newMockPoetDb)
 	syncObj := syncs[0]
-	syncObj2 := syncs[1]
 	defer syncObj.Close()
+	syncObj2 := syncs[1]
+	defer syncObj2.Close()
 	block := types.NewExistingBlock(1, []byte(rand.String(8)), nil)
 	addTxsToPool(syncObj.txpool, []*types.Transaction{tx1})
 
@@ -232,7 +231,6 @@ func TestSyncProtocol_BlockRequest(t *testing.T) {
 	case <-timeout.C:
 		assert.Fail(t, "no message received on channel")
 	}
-
 }
 
 func TestSyncProtocol_LayerHashRequest(t *testing.T) {
@@ -573,7 +571,6 @@ loop:
 			time.Sleep(1 * time.Second)
 		}
 	}
-
 }
 
 func getPeersMock(peers []p2ppeers.Peer) *p2ppeers.Peers {
@@ -947,7 +944,6 @@ end:
 	log.Debug("sync 3 ", syncObj3.ProcessedLayer())
 	log.Debug("sync 4 ", syncObj4.ProcessedLayer())
 	log.Debug("sync 5 ", syncObj5.ProcessedLayer())
-	return
 }
 
 func tx() *types.Transaction {
@@ -1048,7 +1044,6 @@ func TestFetchLayerBlockIds(t *testing.T) {
 	l, err := syncObj3.GetLayer(2)
 	assert.NoError(t, err)
 	assert.True(t, len(l.Blocks()) == 0)
-
 }
 
 func TestFetchLayerBlockIdsNoResponse(t *testing.T) {
@@ -1165,7 +1160,6 @@ func TestFetchLayerBlockIdsNoResponse(t *testing.T) {
 	//check that we got layer 5
 	err = syncObj5.getAndValidateLayer(5)
 	assert.NoError(t, err)
-
 }
 
 type mockLayerValidator struct {
@@ -1234,6 +1228,7 @@ func TestSyncer_Synchronise2(t *testing.T) {
 	types.SetLayersPerEpoch(1)
 	syncs, _, _ := SyncMockFactory(1, conf, t.Name(), memoryDB, newMockPoetDb)
 	sync := syncs[0]
+	defer sync.Close()
 	gen := types.GetEffectiveGenesis()
 	sync.AddBlockWithTxs(types.NewExistingBlock(1+gen, []byte(rand.String(8)), nil))
 	sync.AddBlockWithTxs(types.NewExistingBlock(2+gen, []byte(rand.String(8)), nil))
@@ -1283,6 +1278,7 @@ func TestSyncer_ListenToGossip(t *testing.T) {
 	r := require.New(t)
 	syncs, _, _ := SyncMockFactory(1, conf, t.Name(), memoryDB, newMockPoetDb)
 	sync := syncs[0]
+	defer sync.Close()
 	sync.AddBlockWithTxs(types.NewExistingBlock(1, []byte(rand.String(8)), nil))
 	lv := &mockLayerValidator{0, 0, 0, nil}
 	sync.Mesh.Validator = lv
@@ -1304,6 +1300,7 @@ func TestSyncer_handleNotSyncedFlow(t *testing.T) {
 	atxpool := activation.NewAtxMemPool()
 	ts := &mockClock{Layer: 10}
 	sync := NewSync(service.NewSimulator().NewNode(), getMesh(memoryDB, Path+t.Name()+"_"+time.Now().String()), txpool, atxpool, blockEligibilityValidatorMock{}, newMockPoetDb(), conf, ts, log.NewDefault(t.Name()))
+	defer sync.Close()
 	lv := &mockLayerValidator{0, 0, 0, nil}
 	sync.Mesh.Validator = lv
 	sync.SetLatestLayer(20)
@@ -1315,9 +1312,12 @@ func TestSyncer_handleNotSyncedFlow(t *testing.T) {
 // Make sure this can be called successfully several times for the same layer
 func TestSyncer_handleNotSyncedZeroBlocksLayer(t *testing.T) {
 	r := require.New(t)
+	// layers per epoch must be > 1 so layer 0 has no genesis block
+	types.SetLayersPerEpoch(100)
 	ts := &mockClock{Layer: 2}
 	syncs, nodes := SyncMockFactoryManClock(1, conf, t.Name(), memoryDB, newMockPoetDb, ts)
 	sync := syncs[0]
+	defer sync.Close()
 	sync.peers = getPeersMock([]p2ppeers.Peer{nodes[0].PublicKey()})
 	lv := &mockLayerValidator{0, 0, 0, nil}
 	sync.Mesh.Validator = lv
@@ -1333,10 +1333,13 @@ func TestSyncer_handleNotSyncedZeroBlocksLayer(t *testing.T) {
 
 func TestSyncer_SetZeroBlockLayer(t *testing.T) {
 	r := require.New(t)
+	// layers per epoch must be > 1 so layer 0 has no genesis block
+	types.SetLayersPerEpoch(100)
 	txpool := state.NewTxMemPool()
 	atxpool := activation.NewAtxMemPool()
 	ts := &mockClock{Layer: 10}
 	sync := NewSync(service.NewSimulator().NewNode(), getMesh(memoryDB, Path+t.Name()+"_"+time.Now().String()), txpool, atxpool, blockEligibilityValidatorMock{}, newMockPoetDb(), conf, ts, log.NewDefault(t.Name()))
+	defer sync.Close()
 	sync.SetLatestLayer(1)
 
 	// We should be able to perform this successfully multiple times for the same layer
@@ -1854,6 +1857,7 @@ func TestSyncer_Await(t *testing.T) {
 
 	syncs, _, _ := SyncMockFactory(1, conf, t.Name(), memoryDB, newMockPoetDb)
 	syncer := syncs[0]
+	defer syncer.Close()
 	err := syncer.AddBlockWithTxs(types.NewExistingBlock(1, []byte(rand.String(8)), nil))
 	r.NoError(err)
 	lv := &mockLayerValidator{0, 0, 0, nil}


### PR DESCRIPTION
## Motivation
See https://github.com/spacemeshos/bug-reports/issues/1

## Changes
Fixes a bug in SetZeroBlockLayer to make it idempotent: the same layer can be marked as a zero block layer any number of times (not only once)

Print the name of each database file as it's being closed for debug purposes

Looks like the bug was introduced in #2011

## Test Plan
Includes two new tests

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [ ] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [ ] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
