### PR TITLE
true-current-layer

### DIFF
--- a/api/grpcserver/node_service.go
+++ b/api/grpcserver/node_service.go
@@ -87,13 +87,15 @@ func (s NodeService) Status(context.Context, *pb.StatusRequest) (*pb.StatusRespo
 func (s NodeService) getLayers() (curLayer, latestLayer, verifiedLayer uint32) {
 	// We cannot get meaningful data from the mesh during the genesis epochs since there are no blocks in these
 	// epochs, so just return the current layer instead
+	latestSyncedLayer := s.Mesh.ProcessedLayer() + 1
+
 	curLayerObj := s.GenTime.GetCurrentLayer()
 	curLayer = uint32(curLayerObj)
 	if curLayerObj.GetEpoch().IsGenesis() {
-		latestLayer = curLayer
+		latestLayer = uint32(latestSyncedLayer)
 		verifiedLayer = curLayer
 	} else {
-		latestLayer = uint32(s.Mesh.LatestLayer())
+		latestLayer = uint32(latestSyncedLayer)
 		verifiedLayer = uint32(s.Mesh.LatestLayerInState())
 	}
 	return


### PR DESCRIPTION
@lrettig 

see issue [#2333](https://github.com/spacemeshos/go-spacemesh/issues/2333)

After investigating the code base, it looks like `s.ProcessedLayer() + 1` is equivalent to the latest synced layer `currentSyncLayer` .


However, I am curious if the following are [truer](https://github.com/spacemeshos/go-spacemesh/blob/develop/api/grpcserver/mesh_service.go#L378) current sync layers.

`// Get the latest layers that passed both consensus engines.`
	`lastLayerPassedHare := s.Mesh.LatestLayerInState()`
	`lastLayerPassedTortoise := s.Mesh.ProcessedLayer()`

I was unable to modify the tests to check if this hunch was right as I do not have access to the protos 
`pb "github.com/spacemeshos/api/release/go/spacemesh/v1"`








