### PR TITLE
Prevent sync from stalling

### DIFF
--- a/blocks/blocks.go
+++ b/blocks/blocks.go
@@ -201,7 +201,6 @@ func (bh *BlockHandler) fastValidation(block *types.Block) error {
 		return err
 	}
 	return nil
-
 }
 
 func validateUniqueTxAtx(b *types.Block) error {

--- a/sync/fetch_queue.go
+++ b/sync/fetch_queue.go
@@ -83,11 +83,10 @@ func (fq *fetchQueue) work(ctx context.Context) {
 		log.String("queue", fmt.Sprint(fq.queue)),
 		log.String("queue_name", fq.name))
 	for i := 0; i < parallelWorkers; i++ {
-		go func(j int) {
+		go func(j int, ctxLocal context.Context) {
 			logger := logger.WithFields(log.Int("worker_num", j))
 			logger.Info("worker running work")
 			for out := range output {
-				ctxLocal := ctx
 				loggerLocal := logger
 				loggerLocal.Info("new batch out of queue")
 				if out == nil {
@@ -120,7 +119,7 @@ func (fq *fetchQueue) work(ctx context.Context) {
 				fq.handleFetch(ctxLocal, bjb)
 				loggerLocal.Info("done fetching, going to next batch")
 			}
-		}(i)
+		}(i, ctx)
 	}
 }
 

--- a/sync/syncer.go
+++ b/sync/syncer.go
@@ -988,8 +988,8 @@ func (s *Syncer) FetchAtxReferences(ctx context.Context, atx *types.ActivationTx
 
 func (s *Syncer) fetchBlock(ctx context.Context, ID types.BlockID) bool {
 	ch := make(chan bool, 1)
-	defer close(ch)
 	foo := func(ctx context.Context, res bool) error {
+		defer close(ch)
 		s.WithContext(ctx).With().Info("single block fetched",
 			ID,
 			log.Bool("result", res))

--- a/sync/syncer.go
+++ b/sync/syncer.go
@@ -725,6 +725,8 @@ func (s *Syncer) syncLayer(ctx context.Context, layerID types.LayerID, blockIds 
 	logger.With().Info("wait for layer blocks",
 		log.Int("num_blocks", len(blockIds)),
 		types.BlockIdsField(blockIds))
+
+	// LANE: need a timeout here
 	select {
 	case <-s.exit:
 		return nil, fmt.Errorf("received interupt")

--- a/sync/validation_queue.go
+++ b/sync/validation_queue.go
@@ -52,8 +52,7 @@ func newValidationQueue(ctx context.Context, srvr networker, conf Configuration,
 		syncer:        sy,
 	}
 	vq.handleFetch = vq.handleBlocks
-	go vq.work(ctx)
-
+	go vq.work(log.WithNewSessionID(ctx))
 	return vq
 }
 

--- a/sync/worker.go
+++ b/sync/worker.go
@@ -171,13 +171,13 @@ func newFetchWorker(ctx context.Context, s networker, count int, reqFactory batc
 						lg.With().Info("peer responded to fetch request",
 							log.String("type", name),
 							log.String("ids", idsStr))
-						// 	remove ids from leftToFetch add to fetched
+						// remove ids from leftToFetch and add to fetched
 						for _, itm := range v {
 							fetched = append(fetched, itm)
 							delete(leftToFetch, itm.Hash32())
 						}
 
-						//if no more left to fetch
+						// if no more left to fetch
 						if len(leftToFetch) == 0 {
 							break next
 						}
@@ -185,7 +185,7 @@ func newFetchWorker(ctx context.Context, s networker, count int, reqFactory batc
 					lg.Info("next peer")
 				}
 			}
-			//finished pass results to chan
+			// send results to chan
 			output <- fetchJob{ids: fr.ids, items: fetched, reqID: fr.reqID}
 		}
 	}


### PR DESCRIPTION
## Motivation
Add two more timeouts to sync, so that it doesn't get stuck forever, e.g., when the internet connection is temporarily lost

## Changes
Adds two sync timeouts, one on the high-level request to sync a layer, another on a lower-level request to fetch block data. Both of these can hang indefinitely waiting for a callback which may never be called. (I'm not totally sure why the callback is sometimes not called, but I've experienced this when my internet connection at home is temporarily interrupted.)

## Test Plan
N/A

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [ ] Test changes and document test plan
- [ ] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
