### PR TITLE
[Merged by Bors] - fix wrong variable naming that rarely created infinite loop

### DIFF
--- a/p2p/net/udp_test.go
+++ b/p2p/net/udp_test.go
@@ -326,7 +326,7 @@ func TestUDPNet_Cache(t *testing.T) {
 	_, ok2 := n.incomingConn[addrx2.String()]
 	for ok2 {
 		addrx2 = testUDPAddr()
-		_, ok = n.incomingConn[addrx2.String()]
+		_, ok2 = n.incomingConn[addrx2.String()]
 	}
 	n.addConn(addrx2, &udpConnMock{CreatedFunc: func() time.Time {
 		return time.Now()


### PR DESCRIPTION
## Motivation

fix wrong variable naming that rarely created infinite loop in tests.