### PR TITLE
[Merged by Bors] - Bye bye BLS

### DIFF
--- a/blocks/blockeligibilityvalidator.go
+++ b/blocks/blockeligibilityvalidator.go
@@ -10,7 +10,7 @@ import (
 )
 
 // VRFValidationFunction is the VRF validation function.
-type VRFValidationFunction func(message, signature, publicKey []byte) (bool, error)
+type VRFValidationFunction func(publicKey, message, signature []byte) bool
 
 type blockDB interface {
 	GetBlock(ID types.BlockID) (*types.Block, error)
@@ -94,12 +94,7 @@ func (v BlockEligibilityValidator) BlockSignedAndEligible(block *types.Block) (b
 	message := serializeVRFMessage(epochBeacon, epochNumber, counter)
 	vrfSig := block.EligibilityProof.Sig
 
-	res, err := v.validateVRF(message, vrfSig, vrfPubkey)
-	if err != nil {
-		return false, fmt.Errorf("eligibility VRF validation failed: %v", err)
-	}
-
-	if !res {
+	if !v.validateVRF(vrfPubkey, message, vrfSig) {
 		return false, fmt.Errorf("eligibility VRF validation failed")
 	}
 

--- a/blocks/blockeligibilityvalidator_test.go
+++ b/blocks/blockeligibilityvalidator_test.go
@@ -17,19 +17,19 @@ type mockAtxDB struct {
 	err  error
 }
 
-func (m mockAtxDB) GetEpochAtxs(epochID types.EpochID) []types.ATXID {
+func (m mockAtxDB) GetEpochAtxs(types.EpochID) []types.ATXID {
 	return []types.ATXID{}
 }
 
 func (m mockAtxDB) GetIdentity(edID string) (types.NodeID, error) {
-	return types.NodeID{Key: edID, VRFPublicKey: vrfPubkey}, nil
+	return types.NodeID{Key: edID, VRFPublicKey: nodeID.VRFPublicKey}, nil
 }
 
 func (m mockAtxDB) GetNodeAtxIDForEpoch(types.NodeID, types.EpochID) (types.ATXID, error) {
 	return types.ATXID{}, m.err
 }
 
-func (m mockAtxDB) GetAtxHeader(id types.ATXID) (*types.ActivationTxHeader, error) {
+func (m mockAtxDB) GetAtxHeader(types.ATXID) (*types.ActivationTxHeader, error) {
 	return m.atxH, m.err
 }
 

--- a/blocks/blockoracle.go
+++ b/blocks/blockoracle.go
@@ -22,7 +22,7 @@ type activationDB interface {
 }
 
 type vrfSigner interface {
-	Sign(msg []byte) ([]byte, error)
+	Sign(msg []byte) []byte
 }
 
 // DefaultProofsEpoch is set such that it will never equal the current epoch
@@ -144,11 +144,7 @@ func (bo *Oracle) calcEligibilityProofs(epochNumber types.EpochID) error {
 	bo.eligibilityMutex.Unlock()
 	for counter := uint32(0); counter < numberOfEligibleBlocks; counter++ {
 		message := serializeVRFMessage(epochBeacon, epochNumber, counter)
-		vrfSig, err := bo.vrfSigner.Sign(message)
-		if err != nil {
-			bo.log.With().Error("could not sign message", log.Err(err))
-			return err
-		}
+		vrfSig := bo.vrfSigner.Sign(message)
 		vrfHash := sha256.Sum256(vrfSig)
 		eligibleLayer := calcEligibleLayer(epochNumber, bo.layersPerEpoch, vrfHash)
 		bo.eligibilityMutex.Lock()

--- a/cmd/node/app_test.go
+++ b/cmd/node/app_test.go
@@ -16,8 +16,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/spacemeshos/amcl"
-	"github.com/spacemeshos/amcl/BLS381"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -74,12 +72,12 @@ func Test_PoETHarnessSanity(t *testing.T) {
 	require.NotNil(t, h)
 }
 
-func (suite *AppTestSuite) initMultipleInstances(cfg *config.Config, rolacle *eligibility.FixedRolacle, rng *amcl.RAND, numOfInstances int, storeFormat string, genesisTime string, poetClient *activation.HTTPPoetClient, clock TickProvider, network network) {
+func (suite *AppTestSuite) initMultipleInstances(cfg *config.Config, rolacle *eligibility.FixedRolacle, numOfInstances int, storeFormat string, genesisTime string, poetClient *activation.HTTPPoetClient, clock TickProvider, network network) {
 	name := 'a'
 	for i := 0; i < numOfInstances; i++ {
 		dbStorepath := storeFormat + string(name)
 		database.SwitchCreationContext(dbStorepath, string(name))
-		smApp, err := InitSingleInstance(*cfg, i, genesisTime, rng, dbStorepath, rolacle, poetClient, clock, network)
+		smApp, err := InitSingleInstance(*cfg, i, genesisTime, dbStorepath, rolacle, poetClient, clock, network)
 		assert.NoError(suite.T(), err)
 		suite.apps = append(suite.apps, smApp)
 		suite.dbs = append(suite.dbs, dbStorepath)
@@ -129,7 +127,6 @@ func (suite *AppTestSuite) TestMultipleNodes() {
 	}()
 
 	rolacle := eligibility.New()
-	rng := BLS381.DefaultSeed()
 
 	gTime, err := time.Parse(time.RFC3339, genesisTime)
 	if err != nil {
@@ -137,7 +134,7 @@ func (suite *AppTestSuite) TestMultipleNodes() {
 	}
 	ld := time.Duration(20) * time.Second
 	clock := timesync.NewClock(timesync.RealClock{}, ld, gTime, log.NewDefault("clock"))
-	suite.initMultipleInstances(cfg, rolacle, rng, 5, path, genesisTime, poetHarness.HTTPPoetClient, clock, net)
+	suite.initMultipleInstances(cfg, rolacle, 5, path, genesisTime, poetHarness.HTTPPoetClient, clock, net)
 
 	// We must shut down before running the rest of the tests or we'll get an error about resource unavailable
 	// when we try to allocate more database files. Wrap this context neatly in an inline func.
@@ -198,7 +195,7 @@ func (suite *AppTestSuite) TestMultipleNodes() {
 	}()
 
 	// this tests loading of previous state, maybe it's not the best place to put this here...
-	smApp, err := InitSingleInstance(*cfg, 0, genesisTime, rng, path+"a", rolacle, poetHarness.HTTPPoetClient, clock, net)
+	smApp, err := InitSingleInstance(*cfg, 0, genesisTime, path+"a", rolacle, poetHarness.HTTPPoetClient, clock, net)
 	assert.NoError(suite.T(), err)
 	// test that loaded root is equal
 	assert.Equal(suite.T(), oldRoot, smApp.state.GetStateRoot())
@@ -568,8 +565,8 @@ func TestShutdown(t *testing.T) {
 	poetHarness, err := activation.NewHTTPPoetHarness(false)
 	r.NoError(err, "failed creating poet client harness: %v", err)
 
-	vrfPriv, vrfPub := BLS381.GenKeyPair(BLS381.DefaultSeed())
-	vrfSigner := BLS381.NewBlsSigner(vrfPriv)
+	vrfSigner, vrfPub, err := signing.NewVRFSigner(pub.Bytes())
+	r.NoError(err, "failed to create vrf signer")
 	nodeID := types.NodeID{Key: pub.String(), VRFPublicKey: vrfPub}
 
 	swarm := net.NewNode()

--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -463,7 +463,7 @@ func (app *SpacemeshApp) SetLogLevel(name, loglevel string) error {
 }
 
 type vrfSigner interface {
-	Sign([]byte) ([]byte, error)
+	Sign([]byte) []byte
 }
 
 func (app *SpacemeshApp) initServices(ctx context.Context,

--- a/cmd/node/node_test.go
+++ b/cmd/node/node_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/spacemeshos/amcl/BLS381"
 	"github.com/spacemeshos/go-spacemesh/activation"
 	"github.com/spacemeshos/go-spacemesh/eligibility"
 	"github.com/spacemeshos/go-spacemesh/p2p/service"
@@ -575,7 +574,7 @@ func TestSpacemeshApp_NodeService(t *testing.T) {
 	cfg := getTestDefaultConfig()
 	poetHarness, err := activation.NewHTTPPoetHarness(false)
 	assert.NoError(t, err)
-	app, err := InitSingleInstance(*cfg, 0, time.Now().Add(1*time.Second).Format(time.RFC3339), BLS381.DefaultSeed(), path, eligibility.New(), poetHarness.HTTPPoetClient, clock, net)
+	app, err := InitSingleInstance(*cfg, 0, time.Now().Add(1*time.Second).Format(time.RFC3339), path, eligibility.New(), poetHarness.HTTPPoetClient, clock, net)
 
 	//app := NewSpacemeshApp()
 

--- a/crypto/keys.go
+++ b/crypto/keys.go
@@ -110,7 +110,7 @@ func (p *privateKeyImpl) Pretty() string {
 
 // Sign signs binary data with the private key.
 func (p *privateKeyImpl) Sign(msg []byte) []byte {
-	signature, err := p.k.Sign(in)
+	signature, err := p.k.Sign(msg)
 	if err != nil {
 		return nil
 	}

--- a/crypto/keys.go
+++ b/crypto/keys.go
@@ -21,7 +21,7 @@ type PrivateKey interface {
 	Key
 
 	GetPublicKey() PublicKey // get the pub key corresponding to this priv key
-	Sign([]byte) ([]byte, error)
+	Sign([]byte) []byte
 
 	// Decrypt binary data encrypted with the public key of this private key
 	Decrypt(in []byte) ([]byte, error)
@@ -109,12 +109,12 @@ func (p *privateKeyImpl) Pretty() string {
 }
 
 // Sign signs binary data with the private key.
-func (p *privateKeyImpl) Sign(in []byte) ([]byte, error) {
+func (p *privateKeyImpl) Sign(msg []byte) []byte {
 	signature, err := p.k.Sign(in)
 	if err != nil {
-		return nil, err
+		return nil
 	}
-	return signature.Serialize(), nil
+	return signature.Serialize()
 }
 
 // Decrypt decrypts data encrypted with a public key using its matching private key

--- a/crypto/keys_test.go
+++ b/crypto/keys_test.go
@@ -67,7 +67,7 @@ func TestCryptoApi(t *testing.T) {
 	msgData := []byte(msg)
 
 	// test signatures
-	signature, err := priv.Sign(msgData)
+	signature := priv.Sign(msgData)
 
 	assert.Nil(t, err, fmt.Sprintf("signing error: %v", err))
 	ok, err := pub.Verify(msgData, signature)
@@ -112,7 +112,7 @@ func BenchmarkVerify(b *testing.B) {
 	msgData := []byte(msg)
 
 	// test signatures
-	signature, err := priv.Sign(msgData)
+	signature := priv.Sign(msgData)
 
 	assert.Nil(b, err, fmt.Sprintf("signing error: %v", err))
 

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,6 @@ require (
 	github.com/prometheus/common v0.4.0
 	github.com/seehuhn/mt19937 v0.0.0-20180715112136-cc7708819361
 	github.com/smartystreets/goconvey v0.0.0-20190731233626-505e41936337 // indirect
-	github.com/spacemeshos/amcl v0.0.2
 	github.com/spacemeshos/api/release/go v0.0.0-20201210094223-105249951c66
 	github.com/spacemeshos/ed25519 v0.0.0-20190530014421-e235766d15a1
 	github.com/spacemeshos/merkle-tree v0.0.0-20191028110812-1908c3126c82

--- a/go.sum
+++ b/go.sum
@@ -300,8 +300,6 @@ github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1
 github.com/smartystreets/goconvey v0.0.0-20190731233626-505e41936337 h1:WN9BUFbdyOsSH/XohnWpXOlq9NBD5sGAB2FciQMUEe8=
 github.com/smartystreets/goconvey v0.0.0-20190731233626-505e41936337/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
-github.com/spacemeshos/amcl v0.0.2 h1:YyYF1irv4GkArTe8hzb5/e2B6ReicL2SHeUUsvO3N0c=
-github.com/spacemeshos/amcl v0.0.2/go.mod h1:6/boG2CTNCJ3HBfuyU29Eg1fJxMrXUctpvBiJj1Q69o=
 github.com/spacemeshos/api/release/go v0.0.0-20201013155109-3facffccde82/go.mod h1:kNY4cuAimIxpUbMLPZSgU8jl7Zbv5ohQrLn87ybl0QI=
 github.com/spacemeshos/api/release/go v0.0.0-20201210094223-105249951c66 h1:6LUk0P+WbWPuJkpXYRuP08LRq1WNaunl+6sCkEqsJio=
 github.com/spacemeshos/api/release/go v0.0.0-20201210094223-105249951c66/go.mod h1:kNY4cuAimIxpUbMLPZSgU8jl7Zbv5ohQrLn87ybl0QI=

--- a/hare/algorithm_test.go
+++ b/hare/algorithm_test.go
@@ -3,7 +3,6 @@ package hare
 import (
 	"context"
 	"errors"
-	"github.com/spacemeshos/amcl/BLS381"
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/eligibility"
 	"github.com/spacemeshos/go-spacemesh/hare/config"
@@ -276,12 +275,14 @@ func generateConsensusProcess(t *testing.T) *consensusProcess {
 
 	s := NewSetFromValues(value1)
 	oracle := eligibility.New()
-	signing := signing.NewEdSigner()
-	_, vrfPub := BLS381.GenKeyPair(BLS381.DefaultSeed())
-	oracle.Register(true, signing.PublicKey().String())
+	edSigner := signing.NewEdSigner()
+	edPubkey := edSigner.PublicKey()
+	_, vrfPub, err := signing.NewVRFSigner(edSigner.Sign(edPubkey.Bytes()))
+	assert.NoError(t, err)
+	oracle.Register(true, edPubkey.String())
 	output := make(chan TerminationOutput, 1)
 
-	return newConsensusProcess(cfg, instanceID1, s, oracle, NewMockStateQuerier(), 10, signing, types.NodeID{Key: signing.PublicKey().String(), VRFPublicKey: vrfPub}, n1, output, truer{}, log.NewDefault(signing.PublicKey().String()))
+	return newConsensusProcess(cfg, instanceID1, s, oracle, NewMockStateQuerier(), 10, edSigner, types.NodeID{Key: edPubkey.String(), VRFPublicKey: vrfPub}, n1, output, truer{}, log.NewDefault(edPubkey.String()))
 }
 
 func TestConsensusProcess_Id(t *testing.T) {

--- a/hare/eligibility/oracle_test.go
+++ b/hare/eligibility/oracle_test.go
@@ -62,7 +62,6 @@ func buildVerifier(result bool) verifierFunc {
 
 type mockSigner struct {
 	sig []byte
-	err error
 }
 
 func (s *mockSigner) Sign(msg []byte) []byte {
@@ -132,7 +131,7 @@ func TestOracle_BuildVRFMessage(t *testing.T) {
 
 func TestOracle_buildVRFMessageConcurrency(t *testing.T) {
 	r := require.New(t)
-	o := New(&mockValueProvider{1, nil}, (&mockActiveSetProvider{10}).ActiveSet, buildVerifier(true), &mockSigner{[]byte{1, 2, 3}, nil}, 5, 5, mockBlocksProvider{}, cfg, log.NewDefault(t.Name()))
+	o := New(&mockValueProvider{1, nil}, (&mockActiveSetProvider{10}).ActiveSet, buildVerifier(true), &mockSigner{[]byte{1, 2, 3}}, 5, 5, mockBlocksProvider{}, cfg, log.NewDefault(t.Name()))
 	mCache := newMockCacher()
 	o.vrfMsgCache = mCache
 
@@ -305,13 +304,12 @@ func TestOracle_Proof(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Equal(t, errMy, err)
 	o.beacon = &mockValueProvider{0, nil}
-	o.vrfSigner = &mockSigner{nil, errMy}
+	o.vrfSigner = &mockSigner{nil}
 	sig, err = o.Proof(context.TODO(), 2, 3)
 	assert.Nil(t, sig)
-	assert.NotNil(t, err)
-	assert.Equal(t, errMy, err)
+	assert.NoError(t, err)
 	mySig := []byte{1, 2}
-	o.vrfSigner = &mockSigner{mySig, nil}
+	o.vrfSigner = &mockSigner{mySig}
 	sig, err = o.Proof(context.TODO(), 2, 3)
 	assert.Nil(t, err)
 	assert.Equal(t, mySig, sig)

--- a/hare/flows_test.go
+++ b/hare/flows_test.go
@@ -3,8 +3,6 @@ package hare
 import (
 	"context"
 	"errors"
-	"github.com/spacemeshos/amcl"
-	"github.com/spacemeshos/amcl/BLS381"
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/hare/config"
 	"github.com/spacemeshos/go-spacemesh/log"
@@ -225,11 +223,13 @@ func (mbp *mockBlockProvider) LayerBlockIds(types.LayerID) ([]types.BlockID, err
 	return buildSet(), nil
 }
 
-func createMaatuf(tcfg config.Config, rng *amcl.RAND, layersCh chan types.LayerID, p2p NetworkService, rolacle Rolacle, name string) *Hare {
+func createMaatuf(tcfg config.Config, layersCh chan types.LayerID, p2p NetworkService, rolacle Rolacle, name string) *Hare {
 	ed := signing.NewEdSigner()
 	pub := ed.PublicKey()
-	_, vrfPub := BLS381.GenKeyPair(rng)
-	// vrfSigner := BLS381.NewBlsSigner(vrfPriv)
+	_, vrfPub, err := signing.NewVRFSigner(ed.Sign(pub.Bytes()))
+	if err != nil {
+		panic("failed to create vrf signer")
+	}
 	nodeID := types.NodeID{Key: pub.String(), VRFPublicKey: vrfPub}
 	hare := New(tcfg, p2p, ed, nodeID, validateBlock, isSynced, &mockBlockProvider{}, rolacle, 10, &mockIdentityP{nid: nodeID},
 		&MockStateQuerier{true, nil}, layersCh, log.NewDefault(name+"_"+ed.PublicKey().ShortString()))
@@ -245,7 +245,6 @@ func Test_multipleCPs(t *testing.T) {
 	test := newHareWrapper(totalCp)
 	totalNodes := 20
 	cfg := config.Config{N: totalNodes, F: totalNodes/2 - 1, RoundDuration: 5, ExpectedLeaders: 5, LimitIterations: 1000, LimitConcurrent: 100}
-	rng := BLS381.DefaultSeed()
 	sim := service.NewSimulator()
 	test.initialSets = make([]*Set, totalNodes)
 	oracle := &trueOracle{}
@@ -253,7 +252,7 @@ func Test_multipleCPs(t *testing.T) {
 		s := sim.NewNode()
 		// p2pm := &p2pManipulator{nd: s, err: errors.New("fake err")}
 		test.lCh = append(test.lCh, make(chan types.LayerID, 1))
-		h := createMaatuf(cfg, rng, test.lCh[i], s, oracle, t.Name())
+		h := createMaatuf(cfg, test.lCh[i], s, oracle, t.Name())
 		test.hare = append(test.hare, h)
 		e := h.Start(context.TODO())
 		r.NoError(e)
@@ -280,7 +279,6 @@ func Test_multipleCPsAndIterations(t *testing.T) {
 	test := newHareWrapper(totalCp)
 	totalNodes := 20
 	cfg := config.Config{N: totalNodes, F: totalNodes/2 - 1, RoundDuration: 3, ExpectedLeaders: 5, LimitIterations: 1000, LimitConcurrent: 100}
-	rng := BLS381.DefaultSeed()
 	sim := service.NewSimulator()
 	test.initialSets = make([]*Set, totalNodes)
 	oracle := &trueOracle{}
@@ -288,7 +286,7 @@ func Test_multipleCPsAndIterations(t *testing.T) {
 		s := sim.NewNode()
 		mp2p := &p2pManipulator{nd: s, stalledLayer: 1, err: errors.New("fake err")}
 		test.lCh = append(test.lCh, make(chan types.LayerID, 1))
-		h := createMaatuf(cfg, rng, test.lCh[i], mp2p, oracle, t.Name())
+		h := createMaatuf(cfg, test.lCh[i], mp2p, oracle, t.Name())
 		test.hare = append(test.hare, h)
 		e := h.Start(context.TODO())
 		r.NoError(e)

--- a/signing/vrfsigner.go
+++ b/signing/vrfsigner.go
@@ -8,12 +8,12 @@ import (
 
 // VRFSigner is a signer for VRF purposes
 type VRFSigner struct {
-	privKey []byte
+	privateKey []byte
 }
 
 // Sign signs a message for VRF purposes
-func (s VRFSigner) Sign(m []byte) ([]byte, error) {
-	return ed25519.Sign(s.privKey, m), nil
+func (s VRFSigner) Sign(msg []byte) []byte {
+	return ed25519.Sign(s.privateKey, msg)
 }
 
 // NewVRFSigner creates a new VRFSigner from a 32-byte seed
@@ -25,10 +25,10 @@ func NewVRFSigner(seed []byte) (*VRFSigner, []byte, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	return &VRFSigner{privKey: vrfPriv}, vrfPub, nil
+	return &VRFSigner{privateKey: vrfPriv}, vrfPub, nil
 }
 
 // VRFVerify verifies a message and signature, given a public key
-func VRFVerify(msg, sig, pub []byte) (bool, error) {
-	return ed25519.Verify(pub, msg, sig), nil
+func VRFVerify(pub, msg, sig []byte) bool {
+	return ed25519.Verify(pub, msg, sig)
 }

--- a/signing/vrfsigner.go
+++ b/signing/vrfsigner.go
@@ -1,0 +1,30 @@
+package signing
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/spacemeshos/ed25519"
+)
+
+type VRFSigner struct {
+	privKey []byte
+}
+
+func (s VRFSigner) Sign(m []byte) ([]byte, error) {
+	return ed25519.Sign(s.privKey, m), nil
+}
+
+func NewVRFSigner(seed []byte) (*VRFSigner, []byte, error) {
+	if len(seed) < ed25519.SeedSize {
+		return nil, nil, fmt.Errorf("seed must be >=%d bytes (len(seed)=%d)", ed25519.SeedSize, len(seed))
+	}
+	vrfPub, vrfPriv, err := ed25519.GenerateKey(bytes.NewReader(seed))
+	if err != nil {
+		return nil, nil, err
+	}
+	return &VRFSigner{privKey: vrfPriv}, vrfPub, nil
+}
+
+func VRFVerify(msg, sig, pub []byte) (bool, error) {
+	return ed25519.Verify(pub, msg, sig), nil
+}

--- a/signing/vrfsigner.go
+++ b/signing/vrfsigner.go
@@ -6,14 +6,17 @@ import (
 	"github.com/spacemeshos/ed25519"
 )
 
+// VRFSigner is a signer for VRF purposes
 type VRFSigner struct {
 	privKey []byte
 }
 
+// Sign signs a message for VRF purposes
 func (s VRFSigner) Sign(m []byte) ([]byte, error) {
 	return ed25519.Sign(s.privKey, m), nil
 }
 
+// NewVRFSigner creates a new VRFSigner from a 32-byte seed
 func NewVRFSigner(seed []byte) (*VRFSigner, []byte, error) {
 	if len(seed) < ed25519.SeedSize {
 		return nil, nil, fmt.Errorf("seed must be >=%d bytes (len(seed)=%d)", ed25519.SeedSize, len(seed))
@@ -25,6 +28,7 @@ func NewVRFSigner(seed []byte) (*VRFSigner, []byte, error) {
 	return &VRFSigner{privKey: vrfPriv}, vrfPub, nil
 }
 
+// VRFVerify verifies a message and signature, given a public key
 func VRFVerify(msg, sig, pub []byte) (bool, error) {
 	return ed25519.Verify(pub, msg, sig), nil
 }

--- a/signing/vrfsigner_test.go
+++ b/signing/vrfsigner_test.go
@@ -1,0 +1,76 @@
+package signing
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestNewVRFSigner(t *testing.T) {
+	a := assert.New(t)
+
+	signer, pubkey, err := NewVRFSigner(nil)
+	a.Nil(signer)
+	a.Nil(pubkey)
+	a.EqualError(err, "seed must be >=32 bytes (len(seed)=0)")
+
+	signer, pubkey, err = NewVRFSigner([]byte("too short"))
+	a.Nil(signer)
+	a.Nil(pubkey)
+	a.EqualError(err, "seed must be >=32 bytes (len(seed)=9)")
+
+	signer, pubkey, err = NewVRFSigner([]byte("this seed is 32 bytes long: good"))
+	a.NotNil(signer)
+	a.NotNil(pubkey)
+	a.NoError(err)
+
+	signer, pubkey, err = NewVRFSigner(make([]byte, 32)) // all zeros works
+	a.NotNil(signer)
+	a.NotNil(pubkey)
+	a.NoError(err)
+
+	signer, pubkey, err = NewVRFSigner([]byte("this seed is longer than 32 bytes, which also works"))
+	a.NotNil(signer)
+	a.NotNil(pubkey)
+	a.NoError(err)
+}
+
+func TestVRFSigner_Sign_Verify(t *testing.T) {
+	a := assert.New(t)
+
+	signer, pubkey, err := NewVRFSigner(make([]byte, 32))
+	a.NotNil(signer)
+	a.NotNil(pubkey)
+	a.NoError(err)
+
+	m := []byte("this is just some message")
+	sig := signer.Sign(m)
+	a.NotNil(sig)
+	a.Len(sig, 64)
+
+	valid := VRFVerify(pubkey, m, sig)
+	a.True(valid)
+
+	valid = VRFVerify(flipFirstBit(pubkey), m, sig)
+	a.False(valid)
+
+	valid = VRFVerify(pubkey, flipFirstBit(m), sig)
+	a.False(valid)
+
+	valid = VRFVerify(pubkey, m, flipFirstBit(sig))
+	a.False(valid)
+
+	valid = VRFVerify(pubkey, m, []byte{})
+	a.False(valid)
+
+	// Public key must be 32 bytes long
+	a.PanicsWithValue("ed25519: bad public key length: 31", func() {
+		VRFVerify(pubkey[:31], m, sig)
+	})
+}
+
+func flipFirstBit(b []byte) []byte {
+	flipped := make([]byte, len(b))
+	copy(flipped, b)
+	flipped[0] = flipped[0] ^ 1
+	return flipped
+}


### PR DESCRIPTION
## Motivation
Closes #1648 

Possibly addresses #2405, #2386

This is a temporary fix that replaces BLS with standard ED. Research is pending about which implementation of ED we should use for mainnet.

## Changes
Replace BLS signatures for VRF with regular ED signatures.

## Test Plan
Regular unit- and system-tests. Some were adapted to this change.

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
