### PR TITLE
[Merged by Bors] - Workarounds for concurrency issues in tests

### DIFF
--- a/sync/syncer_test.go
+++ b/sync/syncer_test.go
@@ -219,6 +219,7 @@ func SyncMockFactoryManClock(number int, conf Configuration, name string, dbType
 		poet := activation.NewPoetDb(poetDB, log.NewDefault("poetDb"))
 		//poet := poetDb()
 		layerFetcher.AddDBs(msh.Blocks(), atxDB, msh.Transactions(), poetDB, msh.InputVector())
+		// note: layer fetcher startup happens asynchronously, so it may not be fully running when this method returns
 		layerFetcher.Start()
 
 		sync := NewSync(context.TODO(), net, msh, txpool, atxpool, blockValidator, poet, conf, ticker, layerFetcher, l)
@@ -1125,6 +1126,7 @@ func TestSyncer_Txs(t *testing.T) {
 func TestFetchLayerBlockIds(t *testing.T) {
 	// check tx validation
 	syncs, nodes, clock := SyncMockFactory(3, conf, t.Name(), memoryDB, newMockPoetDb)
+	time.Sleep(time.Second)
 
 	defer clock.Close()
 
@@ -1479,6 +1481,7 @@ func TestSyncer_handleNotSyncedZeroBlocksLayer(t *testing.T) {
 	r.NoError(sync.SetZeroBlockLayer(1))
 	r.Equal(0, lv.countValidated)
 	r.Equal(types.LayerID(0), lv.processedLayer)
+	time.Sleep(time.Second) // give layer fetcher a chance to start
 	go sync.handleNotSynced(context.TODO(), 1)
 	select {
 	case <-time.After(10 * time.Second):

--- a/sync/syncer_test.go
+++ b/sync/syncer_test.go
@@ -1678,9 +1678,10 @@ func TestSyncer_ConcurrentSynchronise(t *testing.T) {
 	sync.ticker = &mockClock{Layer: 3}
 	lv := &mockTimedValidator{1 * time.Second, 0}
 	sync.Validator = lv
-	sync.AddBlock(types.NewExistingBlock(1, []byte(rand.String(8)), nil))
-	sync.AddBlock(types.NewExistingBlock(2, []byte(rand.String(8)), nil))
-	sync.AddBlock(types.NewExistingBlock(3, []byte(rand.String(8)), nil))
+	r.NoError(sync.AddBlock(types.NewExistingBlock(1, []byte(rand.String(8)), nil)))
+	r.NoError(sync.AddBlock(types.NewExistingBlock(2, []byte(rand.String(8)), nil)))
+	r.NoError(sync.AddBlock(types.NewExistingBlock(3, []byte(rand.String(8)), nil)))
+	time.Sleep(100 * time.Millisecond)
 	go sync.synchronise(context.TODO())
 	time.Sleep(100 * time.Millisecond)
 	sync.synchronise(context.TODO())


### PR DESCRIPTION
## Motivation
It looks like some recently-added tests fail nondeterministically since they rely on order of operations in concurrent goroutines. The real solution here is to make these deterministic using proper concurrency primitives. This is a temporary workaround that adds pauses to give the layer fetcher goroutine enough time to start up.

Related: #2067

## Changes
Add pauses to syncer tests

## Test Plan
N/A, this fixes broken tests

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [ ] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
