### PR TITLE
Remove short nodeID from log lines

### DIFF
--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -472,10 +472,8 @@ func (app *SpacemeshApp) initServices(ctx context.Context,
 
 	app.nodeID = nodeID
 
-	name := nodeID.ShortString()
-
 	// This base logger must be debug level so that other, derived loggers are not a lower level.
-	lg := log.NewWithLevel(name, zap.NewAtomicLevelAt(zapcore.DebugLevel)).WithFields(nodeID)
+	lg := log.NewWithLevel(zap.NewAtomicLevelAt(zapcore.DebugLevel)).WithFields(nodeID)
 
 	types.SetLayersPerEpoch(int32(app.Config.LayersPerEpoch))
 
@@ -1030,7 +1028,7 @@ func (app *SpacemeshApp) Start(*cobra.Command, []string) {
 	}
 
 	// This base logger must be debug level so that other, derived loggers are not a lower level.
-	lg := log.NewWithLevel(nodeID.ShortString(), zap.NewAtomicLevelAt(zapcore.DebugLevel)).WithFields(nodeID)
+	lg := log.NewWithLevel(zap.NewAtomicLevelAt(zapcore.DebugLevel)).WithFields(nodeID)
 
 	/* Initialize all protocol services */
 

--- a/log/log.go
+++ b/log/log.go
@@ -11,7 +11,7 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-const mainLoggerName = "00000.defaultLogger"
+const mainLoggerName = "defaultLogger"
 
 // determine the level of messages we show.
 var debugMode = false
@@ -79,18 +79,18 @@ func JSONLog(b bool) {
 }
 
 // NewWithLevel creates a logger with a fixed level and with a set of (optional) hooks
-func NewWithLevel(module string, level zap.AtomicLevel, hooks ...func(zapcore.Entry) error) Log {
+func NewWithLevel(level zap.AtomicLevel, hooks ...func(zapcore.Entry) error) Log {
 	consoleSyncer := zapcore.AddSync(logwriter)
 	enc := encoder()
 	consoleCore := zapcore.NewCore(enc, consoleSyncer, level)
 	core := zapcore.RegisterHooks(consoleCore, hooks...)
-	log := zap.New(core).Named(module)
-	return NewFromLog(log)
+	return NewFromLog(zap.New(core))
 }
 
 // NewDefault creates a Log with the default log level
 func NewDefault(module string) Log {
-	return NewWithLevel(module, zap.NewAtomicLevelAt(Level()))
+	logger := NewWithLevel(zap.NewAtomicLevelAt(Level()))
+	return NewFromLog(logger.logger.Named(module))
 }
 
 // NewFromLog creates a Log from an existing zap-compatible log.
@@ -101,7 +101,8 @@ func NewFromLog(l *zap.Logger) Log {
 // InitSpacemeshLoggingSystemWithHooks sets up a logging system with one or more
 // registered hooks
 func InitSpacemeshLoggingSystemWithHooks(hooks ...func(zapcore.Entry) error) {
-	AppLog = NewWithLevel(mainLoggerName, zap.NewAtomicLevelAt(Level()), hooks...)
+	logger := NewWithLevel(zap.NewAtomicLevelAt(Level()), hooks...)
+	AppLog = NewFromLog(logger.logger.Named(mainLoggerName))
 }
 
 // public wrappers abstracting away logging lib impl

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -39,13 +39,13 @@ func TestLogLevel(t *testing.T) {
 	// Capture the log output
 	var buf bytes.Buffer
 	logwriter = &buf
-	AppLog = NewWithLevel(mainLoggerName, zap.NewAtomicLevelAt(zapcore.DebugLevel))
+	AppLog = NewFromLog(NewWithLevel(zap.NewAtomicLevelAt(zapcore.DebugLevel)).logger.Named(mainLoggerName))
 
 	// Instantiate a logger and a sublogger
 	nid := FakeNodeID{key: "abc123"}
 	nidEncoded := fmt.Sprintf("{\"node_id\": \"%s\"}", nid.key)
 	loggerName := "logtest"
-	logger := NewWithLevel(loggerName, zap.NewAtomicLevelAt(zapcore.InfoLevel), hookFn).WithFields(nid)
+	logger := NewFromLog(NewWithLevel(zap.NewAtomicLevelAt(zapcore.InfoLevel), hookFn).WithFields(nid).logger.Named(loggerName))
 
 	lvl := zap.NewAtomicLevel()
 	r.NoError(lvl.UnmarshalText([]byte("INFO")))


### PR DESCRIPTION
## Motivation
The main motivation for the change is that elasticsearch [wildcard queries](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-wildcard-query.html#wildcard-query-ex-request) don't work well with a wildcard _prefix_. Right now, our `sm.N` log field consists of `nodeID.moduleName`, and this is very problematic in expensive searches for all output from a particular module. It's also redundant since every log line also includes the full nodeID.

## Changes
- removes nodeID prefix from log name

## Test Plan
relevant tests have been updated

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [ ] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [ ] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
