### PR TITLE
Parameterize outbound message queue size

### DIFF
--- a/p2p/config/config.go
+++ b/p2p/config/config.go
@@ -20,6 +20,8 @@ const (
 	defaultTCPPort = 7513
 	// defaultTCPInterface is the inet interface that P2P listens on by default
 	defaultTCPInterface = "0.0.0.0"
+	// defaultMessageQueueSize is the number of outbound messages we allow to be queued
+	defaultMessageQueueSize = 5000
 )
 
 // Values specifies default values for node config params.
@@ -34,7 +36,7 @@ func init() {
 func duration(duration string) (dur time.Duration) {
 	dur, err := time.ParseDuration(duration)
 	if err != nil {
-		log.Error("Could not parse duration string returning 0, error:", err)
+		log.With().Error("could not parse duration string returning 0", log.Err(err))
 	}
 	return dur
 }
@@ -56,6 +58,7 @@ type Config struct {
 	SwarmConfig           SwarmConfig   `mapstructure:"swarm"`
 	BufferSize            int           `mapstructure:"buffer-size"`
 	MsgSizeLimit          int           `mapstructure:"msg-size-limit"` // in bytes
+	MessageQueueSize      int           `mapstructure:"message-queue-size"`
 }
 
 // SwarmConfig specifies swarm config params.
@@ -99,5 +102,6 @@ func DefaultConfig() Config {
 		SwarmConfig:           SwarmConfigValues,
 		BufferSize:            10000,
 		MsgSizeLimit:          UnlimitedMsgSize,
+		MessageQueueSize:      defaultMessageQueueSize,
 	}
 }

--- a/p2p/config/config.go
+++ b/p2p/config/config.go
@@ -21,7 +21,7 @@ const (
 	// defaultTCPInterface is the inet interface that P2P listens on by default
 	defaultTCPInterface = "0.0.0.0"
 	// defaultMessageQueueSize is the number of outbound messages we allow to be queued
-	defaultMessageQueueSize = 5000
+	defaultMessageQueueSize = 250
 )
 
 // Values specifies default values for node config params.

--- a/p2p/net/conn_test.go
+++ b/p2p/net/conn_test.go
@@ -16,12 +16,13 @@ import (
 )
 
 var msgSizeLimit = config.DefaultConfig().P2P.MsgSizeLimit
+var msgQueueSize = config.DefaultConfig().P2P.MessageQueueSize
 
 func TestSendReceiveMessage(t *testing.T) {
 	netw := NewNetworkMock()
 	rwcam := NewReadWriteCloseAddresserMock()
 	rPub := p2pcrypto.NewRandomPubkey()
-	conn := newConnection(rwcam, netw, rPub, &networkSessionImpl{}, msgSizeLimit, time.Second, netw.logger)
+	conn := newConnection(rwcam, netw, rPub, &networkSessionImpl{}, msgSizeLimit, msgQueueSize, time.Second, netw.logger)
 	go conn.beginEventProcessing(context.TODO())
 	msg := "hello"
 	err := conn.SendSock([]byte(msg))
@@ -39,7 +40,7 @@ func TestSendMessage(t *testing.T) {
 	rwcam := NewReadWriteCloseAddresserMock()
 	rPub := p2pcrypto.NewRandomPubkey()
 	rwcam.writeWaitChan = make(chan []byte)
-	conn := newConnection(rwcam, netw, rPub, &networkSessionImpl{}, msgSizeLimit, time.Second, netw.logger)
+	conn := newConnection(rwcam, netw, rPub, &networkSessionImpl{}, msgSizeLimit, msgQueueSize, time.Second, netw.logger)
 	go conn.beginEventProcessing(context.TODO())
 	msg := "hello"
 	err := conn.Send(context.TODO(), []byte(msg))
@@ -58,7 +59,7 @@ func TestReceiveError(t *testing.T) {
 	netw := NewNetworkMock()
 	rwcam := NewReadWriteCloseAddresserMock()
 	rPub := p2pcrypto.NewRandomPubkey()
-	conn := newConnection(rwcam, netw, rPub, &networkSessionImpl{}, msgSizeLimit, time.Second, netw.logger)
+	conn := newConnection(rwcam, netw, rPub, &networkSessionImpl{}, msgSizeLimit, msgQueueSize, time.Second, netw.logger)
 
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -78,7 +79,7 @@ func TestSendError(t *testing.T) {
 	netw := NewNetworkMock()
 	rwcam := NewReadWriteCloseAddresserMock()
 	rPub := p2pcrypto.NewRandomPubkey()
-	conn := newConnection(rwcam, netw, rPub, &networkSessionImpl{}, msgSizeLimit, time.Second, netw.logger)
+	conn := newConnection(rwcam, netw, rPub, &networkSessionImpl{}, msgSizeLimit, msgQueueSize, time.Second, netw.logger)
 	go conn.beginEventProcessing(context.TODO())
 
 	rwcam.SetWriteResult(fmt.Errorf("fail"))
@@ -92,7 +93,7 @@ func TestPreSessionMessage(t *testing.T) {
 	netw := NewNetworkMock()
 	rwcam := NewReadWriteCloseAddresserMock()
 	rPub := p2pcrypto.NewRandomPubkey()
-	conn := newConnection(rwcam, netw, rPub, nil, msgSizeLimit, time.Second, netw.logger)
+	conn := newConnection(rwcam, netw, rPub, nil, msgSizeLimit, msgQueueSize, time.Second, netw.logger)
 	rwcam.SetReadResult([]byte{3, 1, 1, 1}, nil)
 	err := conn.setupIncoming(context.TODO(), time.Millisecond)
 	require.NoError(t, err)
@@ -104,7 +105,7 @@ func TestPreSessionMessageAfterSession(t *testing.T) {
 	netw := NewNetworkMock()
 	rwcam := NewReadWriteCloseAddresserMock()
 	rPub := p2pcrypto.NewRandomPubkey()
-	conn := newConnection(rwcam, netw, rPub, nil, msgSizeLimit, time.Second, netw.logger)
+	conn := newConnection(rwcam, netw, rPub, nil, msgSizeLimit, msgQueueSize, time.Second, netw.logger)
 	rwcam.SetReadResult([]byte{3, 1, 1, 1}, nil)
 	go conn.beginEventProcessing(context.TODO())
 	time.Sleep(50 * time.Millisecond)
@@ -115,7 +116,7 @@ func TestConn_Limit(t *testing.T) {
 	netw := NewNetworkMock()
 	rwcam := NewReadWriteCloseAddresserMock()
 	rPub := p2pcrypto.NewRandomPubkey()
-	conn := newConnection(rwcam, netw, rPub, nil, 1, time.Second, netw.logger)
+	conn := newConnection(rwcam, netw, rPub, nil, 1, msgQueueSize, time.Second, netw.logger)
 	rwcam.SetReadResult([]byte{5, 1, 2, 3, 4, 5, 6}, nil)
 	err := conn.setupIncoming(context.TODO(), time.Second)
 	assert.EqualError(t, err, ErrMsgExceededLimit.Error())
@@ -125,7 +126,7 @@ func TestPreSessionError(t *testing.T) {
 	netw := NewNetworkMock()
 	rwcam := NewReadWriteCloseAddresserMock()
 	rPub := p2pcrypto.NewRandomPubkey()
-	conn := newConnection(rwcam, netw, rPub, nil, msgSizeLimit, time.Second, netw.logger)
+	conn := newConnection(rwcam, netw, rPub, nil, msgSizeLimit, msgQueueSize, time.Second, netw.logger)
 	netw.SetPreSessionResult(fmt.Errorf("fail"))
 	rwcam.SetReadResult(append([]byte{1}, []byte("0")...), nil)
 	err := conn.setupIncoming(context.TODO(), time.Second)
@@ -136,7 +137,7 @@ func TestErrClose(t *testing.T) {
 	netw := NewNetworkMock()
 	rwcam := NewReadWriteCloseAddresserMock()
 	rPub := p2pcrypto.NewRandomPubkey()
-	conn := newConnection(rwcam, netw, rPub, &networkSessionImpl{}, msgSizeLimit, time.Second, netw.logger)
+	conn := newConnection(rwcam, netw, rPub, &networkSessionImpl{}, msgSizeLimit, msgQueueSize, time.Second, netw.logger)
 
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -154,7 +155,7 @@ func TestClose(t *testing.T) {
 	netw := NewNetworkMock()
 	rwcam := NewReadWriteCloseAddresserMock()
 	rPub := p2pcrypto.NewRandomPubkey()
-	conn := newConnection(rwcam, netw, rPub, &networkSessionImpl{}, msgSizeLimit, time.Second, netw.logger)
+	conn := newConnection(rwcam, netw, rPub, &networkSessionImpl{}, msgSizeLimit, msgQueueSize, time.Second, netw.logger)
 	c := make(chan struct{}, 1)
 	netw.SubscribeClosingConnections(func(ctx context.Context, connection ConnectionWithErr) {
 		c <- struct{}{}
@@ -176,7 +177,7 @@ func TestDoubleClose(t *testing.T) {
 	netw := NewNetworkMock()
 	rwcam := NewReadWriteCloseAddresserMock()
 	rPub := p2pcrypto.NewRandomPubkey()
-	conn := newConnection(rwcam, netw, rPub, &networkSessionImpl{}, msgSizeLimit, time.Second, netw.logger)
+	conn := newConnection(rwcam, netw, rPub, &networkSessionImpl{}, msgSizeLimit, msgQueueSize, time.Second, netw.logger)
 
 	go conn.beginEventProcessing(context.TODO())
 	conn.Close()
@@ -195,7 +196,7 @@ func TestGettersToBoostCoverage(t *testing.T) {
 	addr := net.TCPAddr{IP: net.ParseIP("1.1.1.1"), Port: 555}
 	rwcam.setRemoteAddrResult(&addr)
 	rPub := p2pcrypto.NewRandomPubkey()
-	conn := newConnection(rwcam, netw, rPub, &networkSessionImpl{}, msgSizeLimit, time.Second, netw.logger)
+	conn := newConnection(rwcam, netw, rPub, &networkSessionImpl{}, msgSizeLimit, msgQueueSize, time.Second, netw.logger)
 	assert.Equal(t, 36, len(conn.ID()))
 	assert.Equal(t, conn.ID(), conn.String())
 	rPub = p2pcrypto.NewRandomPubkey()

--- a/p2p/net/network.go
+++ b/p2p/net/network.go
@@ -224,7 +224,8 @@ func (n *Net) createConnection(ctx context.Context, address net.Addr, remotePub 
 	}
 
 	n.logger.Debug("Connected to %s...", address.String())
-	return newConnection(netConn, n, remotePub, session, n.config.MsgSizeLimit, n.config.ResponseTimeout, n.logger), nil
+	return newConnection(
+		netConn, n, remotePub, session, n.config.MsgSizeLimit, n.config.MessageQueueSize, n.config.ResponseTimeout, n.logger), nil
 }
 
 func (n *Net) createSecuredConnection(ctx context.Context, address net.Addr, remotePubkey p2pcrypto.PublicKey) (ManagedConnection, error) {
@@ -314,7 +315,8 @@ func (n *Net) accept(ctx context.Context, listen net.Listener, pending chan stru
 			log.String("network", netConn.RemoteAddr().Network()))
 		conn := netConn.(*net.TCPConn)
 		n.tcpSocketConfig(conn) // TODO maybe only set this after session handshake to prevent denial of service with big messages
-		c := newConnection(netConn, n, nil, nil, n.config.MsgSizeLimit, n.config.ResponseTimeout, n.logger.WithContext(ctx))
+		c := newConnection(
+			netConn, n, nil, nil, n.config.MsgSizeLimit, n.config.MessageQueueSize, n.config.ResponseTimeout, n.logger.WithContext(ctx))
 
 		// Handle the incoming connection asynchronously
 		go n.acceptAsync(ctx, c, pending)

--- a/p2p/net/udp.go
+++ b/p2p/net/udp.go
@@ -181,7 +181,8 @@ func (n *UDPNet) Dial(ctx context.Context, address net.Addr, remotePublicKey p2p
 
 	ns := n.cache.GetOrCreate(remotePublicKey)
 
-	conn := newMsgConnection(udpcon, n, remotePublicKey, ns, n.config.MsgSizeLimit, n.config.ResponseTimeout, n.logger)
+	conn := newMsgConnection(
+		udpcon, n, remotePublicKey, ns, n.config.MsgSizeLimit, n.config.MessageQueueSize, n.config.ResponseTimeout, n.logger)
 
 	// The connection is automatically closed when there's nothing more to read, no need to close it here
 	go conn.beginEventProcessing(log.WithNewSessionID(ctx, log.String("netproto", "udp")))
@@ -283,7 +284,8 @@ func (n *UDPNet) listenToUDPNetworkMessages(ctx context.Context, listener net.Pa
 				remote:    addr,
 			}
 
-			mconn := newMsgConnection(conn, n, pk, ns, n.config.MsgSizeLimit, n.config.DialTimeout, n.logger)
+			mconn := newMsgConnection(
+				conn, n, pk, ns, n.config.MsgSizeLimit, n.config.MessageQueueSize, n.config.DialTimeout, n.logger)
 			n.publishNewRemoteConnectionEvent(mconn, node.NewNode(pk, net.ParseIP(host), 0, uint16(iport)))
 			n.addConn(addr, conn, mconn)
 


### PR DESCRIPTION
## Motivation
See https://github.com/spacemeshos/go-spacemesh/issues/2386#issuecomment-848368226

## Changes
- adds a param for the outbound message queue size with a default value that's the same as the gossip message queue size in an attempt to remove a bottleneck

## Test Plan
TBD

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [ ] Test changes and document test plan
- [ ] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
