### PR TITLE
[Merged by Bors] - p2p: use the same shutdown context for all components

### DIFF
--- a/cmd/node/node_test.go
+++ b/cmd/node/node_test.go
@@ -910,7 +910,7 @@ func TestSpacemeshApp_P2PInterface(t *testing.T) {
 	// Initialize the network: we don't want to listen but this lets us dial out
 	l, err := node.NewNodeIdentity()
 	r.NoError(err)
-	p2pnet, err := net.NewNet(app.Config.P2P, l, log.AppLog)
+	p2pnet, err := net.NewNet(context.TODO(), app.Config.P2P, l, log.AppLog)
 	r.NoError(err)
 	// We need to listen on a different port
 	listener, err := inet.Listen("tcp", fmt.Sprintf("%s:%d", addr, 9270))

--- a/p2p/gossip/protocol.go
+++ b/p2p/gossip/protocol.go
@@ -205,11 +205,11 @@ func (p *Protocol) propagationEventLoop(ctx context.Context) {
 	go p.handlePQ(ctx)
 
 	for {
-		if p.isShuttingDown() {
-			return
-		}
 		select {
 		case msgV := <-p.propagateQ:
+			if p.isShuttingDown() {
+				return
+			}
 			if err := p.pq.Write(p.getPriority(msgV.Protocol()), msgV); err != nil {
 				p.WithContext(ctx).With().Error("could not write to priority queue",
 					log.Err(err),

--- a/p2p/gossip/protocol_test.go
+++ b/p2p/gossip/protocol_test.go
@@ -25,7 +25,7 @@ func TestProcessMessage(t *testing.T) {
 	defer ctrl.Finish()
 
 	net := NewMockbaseNetwork(ctrl)
-	protocol := NewProtocol(config.SwarmConfig{}, net, nil, nil, logger)
+	protocol := NewProtocol(context.TODO(), config.SwarmConfig{}, net, nil, nil, logger)
 
 	isSent := false
 	net.EXPECT().
@@ -48,7 +48,7 @@ func TestPropagateMessage(t *testing.T) {
 
 	net := NewMockbaseNetwork(ctrl)
 	peersManager := NewMockpeersManager(ctrl)
-	protocol := NewProtocol(config.SwarmConfig{}, net, peersManager, nil, logger)
+	protocol := NewProtocol(context.TODO(), config.SwarmConfig{}, net, peersManager, nil, logger)
 
 	peers := make([]p2ppeers.Peer, 30)
 	for i := range peers {
@@ -102,7 +102,8 @@ func (mpq *mockPriorityQueue) Close() {
 }
 
 func TestPropagationEventLoop(t *testing.T) {
-	protocol := NewProtocol(config.SwarmConfig{}, nil, nil, nil, log.AppLog)
+	ctx, cancel := context.WithCancel(context.Background())
+	protocol := NewProtocol(ctx, config.SwarmConfig{}, nil, nil, nil, log.AppLog)
 	called := make(chan struct{})
 	mpq := mockPriorityQueue{called: called, bus: make(chan struct{}, 10)}
 	protocol.pq = &mpq
@@ -115,7 +116,7 @@ func TestPropagationEventLoop(t *testing.T) {
 	assert.Equal(t, false, mpq.isClosed, "listener should not be shut down yet")
 
 	mpq.isWritten = false
-	protocol.shutdown <- struct{}{}
+	cancel()
 	<-called
 	assert.Equal(t, false, mpq.isWritten, "message should not be written")
 	assert.Equal(t, true, mpq.isClosed, "listener should be shut down")

--- a/p2p/net/network.go
+++ b/p2p/net/network.go
@@ -60,7 +60,7 @@ type Net struct {
 	listener      net.Listener
 	listenAddress *net.TCPAddr // Address to open connection: localhost:9999
 
-	isShuttingDown bool
+	shutdownCtx context.Context
 
 	regMutex         sync.RWMutex
 	regNewRemoteConn []func(NewConnectionEvent)
@@ -84,7 +84,7 @@ type NewConnectionEvent struct {
 
 // NewNet creates a new network.
 // It attempts to tcp listen on address. e.g. localhost:1234 .
-func NewNet(conf config.Config, localEntity node.LocalNode, logger log.Log) (*Net, error) {
+func NewNet(ctx context.Context, conf config.Config, localEntity node.LocalNode, logger log.Log) (*Net, error) {
 	qcount := DefaultQueueCount      // todo : get from cfg
 	qsize := DefaultMessageQueueSize // todo : get from cfg
 
@@ -97,6 +97,7 @@ func NewNet(conf config.Config, localEntity node.LocalNode, logger log.Log) (*Ne
 		queuesCount:           qcount,
 		incomingMessagesQueue: make([]chan IncomingMessageEvent, qcount),
 		config:                conf,
+		shutdownCtx:           ctx,
 	}
 
 	for imq := range n.incomingMessagesQueue {
@@ -213,7 +214,7 @@ func (n *Net) tcpSocketConfig(tcpconn *net.TCPConn) {
 }
 
 func (n *Net) createConnection(ctx context.Context, address net.Addr, remotePub p2pcrypto.PublicKey, session NetworkSession) (ManagedConnection, error) {
-	if n.isShuttingDown {
+	if n.isShuttingDown() {
 		return nil, fmt.Errorf("can't dial because the connection is shutting down")
 	}
 
@@ -276,13 +277,21 @@ func (n *Net) Dial(ctx context.Context, address net.Addr, remotePubkey p2pcrypto
 
 // Shutdown initiate a graceful closing of the TCP listener and all other internal routines
 func (n *Net) Shutdown() {
-	n.isShuttingDown = true
 	if n.listener != nil {
 		err := n.listener.Close()
 		if err != nil {
 			n.logger.With().Error("error closing listener", log.Err(err))
 		}
 	}
+}
+
+func (n *Net) isShuttingDown() bool {
+	select {
+	case <-n.shutdownCtx.Done():
+		return true
+	default:
+	}
+	return false
 }
 
 func (n *Net) accept(ctx context.Context, listen net.Listener, pending chan struct{}) {
@@ -293,7 +302,7 @@ func (n *Net) accept(ctx context.Context, listen net.Listener, pending chan stru
 		<-pending
 		netConn, err := listen.Accept()
 		if err != nil {
-			if n.isShuttingDown {
+			if n.isShuttingDown() {
 				return
 			}
 			if !Temporary(err) {

--- a/p2p/net/network_test.go
+++ b/p2p/net/network_test.go
@@ -29,7 +29,7 @@ func TestNet_EnqueueMessage(t *testing.T) {
 	cfg := config.DefaultConfig()
 	ln, err := node.NewNodeIdentity()
 	assert.NoError(t, err)
-	n, err := NewNet(cfg, ln, log.NewDefault(t.Name()))
+	n, err := NewNet(context.TODO(), cfg, ln, log.NewDefault(t.Name()))
 	require.NoError(t, err)
 
 	var rndmtx sync.Mutex
@@ -129,7 +129,7 @@ func Test_Net_LimitedConnections(t *testing.T) {
 
 	ln, err := node.NewNodeIdentity()
 	require.NoError(t, err)
-	n, err := NewNet(cfg, ln, log.NewDefault(t.Name()))
+	n, err := NewNet(context.TODO(), cfg, ln, log.NewDefault(t.Name()))
 	//n.SubscribeOnNewRemoteConnections(counter)
 	require.NoError(t, err)
 	listener := newMockListener()
@@ -164,7 +164,7 @@ func TestHandlePreSessionIncomingMessage2(t *testing.T) {
 	bobsAliceConn := NewConnectionMock(aliceNode.PublicKey())
 	bobsAliceConn.Addr = &net.TCPAddr{IP: aliceNodeInfo.IP, Port: int(aliceNodeInfo.ProtocolPort)}
 
-	bobsNet, err := NewNet(config.DefaultConfig(), bobNode, log.NewDefault(t.Name()))
+	bobsNet, err := NewNet(context.TODO(), config.DefaultConfig(), bobNode, log.NewDefault(t.Name()))
 	r.NoError(err)
 	bobsNet.SubscribeOnNewRemoteConnections(func(event NewConnectionEvent) {
 		r.Equal(aliceNode.PublicKey().String(), event.Conn.Session().ID().String(), "wrong session received")
@@ -199,7 +199,7 @@ func TestMaxPendingConnections(t *testing.T) {
 
 	ln, err := node.NewNodeIdentity()
 	require.NoError(t, err)
-	n, err := NewNet(cfg, ln, log.NewDefault(t.Name()))
+	n, err := NewNet(context.TODO(), cfg, ln, log.NewDefault(t.Name()))
 	require.NoError(t, err)
 
 	// Create many new connections

--- a/p2p/net/udp_test.go
+++ b/p2p/net/udp_test.go
@@ -75,7 +75,7 @@ const testMsg = "TEST"
 func TestUDPNet_Sanity(t *testing.T) {
 	local, localinfo := node.GenerateTestNode(t)
 	udpAddr := &net.UDPAddr{IP: net.IPv4zero, Port: int(localinfo.DiscoveryPort)}
-	udpnet, err := NewUDPNet(config.DefaultConfig(), local, log.NewDefault("TEST_"+t.Name()))
+	udpnet, err := NewUDPNet(context.TODO(), config.DefaultConfig(), local, log.NewDefault("TEST_"+t.Name()))
 	require.NoError(t, err)
 	require.NotNil(t, udpnet)
 
@@ -286,7 +286,7 @@ func (ucw *udpConnMock) Close() error {
 
 func TestUDPNet_Cache(t *testing.T) {
 	localnode, _ := node.NewNodeIdentity()
-	n, err := NewUDPNet(config.DefaultConfig(), localnode, log.NewDefault(t.Name()))
+	n, err := NewUDPNet(context.TODO(), config.DefaultConfig(), localnode, log.NewDefault(t.Name()))
 	require.NoError(t, err)
 	require.NotNil(t, n)
 	addr2 := testUDPAddr()
@@ -373,7 +373,7 @@ func TestUDPNet_Cache2(t *testing.T) {
 	// instead we now give up on "Closing" from within the "connection" when there's an error since
 	// we provide the errors from the level above anyway, so closing should be performed there.
 	localnode, _ := node.NewNodeIdentity()
-	n, err := NewUDPNet(config.DefaultConfig(), localnode, log.NewDefault(t.Name()))
+	n, err := NewUDPNet(context.TODO(), config.DefaultConfig(), localnode, log.NewDefault(t.Name()))
 	require.NoError(t, err)
 	require.NotNil(t, n)
 
@@ -466,11 +466,11 @@ func TestUDPNet_Cache2(t *testing.T) {
 func Test_UDPIncomingConnClose(t *testing.T) {
 	localnode, _ := node.NewNodeIdentity()
 	remotenode, _ := node.NewNodeIdentity()
-	n, err := NewUDPNet(config.DefaultConfig(), localnode, log.NewDefault(t.Name()+"_local"))
+	n, err := NewUDPNet(context.TODO(), config.DefaultConfig(), localnode, log.NewDefault(t.Name()+"_local"))
 	require.NoError(t, err)
 	require.NotNil(t, n)
 
-	remoten, rerr := NewUDPNet(config.DefaultConfig(), remotenode, log.NewDefault(t.Name()+"_remote"))
+	remoten, rerr := NewUDPNet(context.TODO(), config.DefaultConfig(), remotenode, log.NewDefault(t.Name()+"_remote"))
 	require.NoError(t, rerr)
 	require.NotNil(t, remoten)
 

--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -52,12 +52,12 @@ type Switch struct {
 	gossipC   chan struct{}
 	config    config.Config
 	logger    log.Log
+
 	// Context for cancel
-	ctx        context.Context
-	cancelFunc context.CancelFunc
+	shutdownCtx context.Context // this context will be shared with all sub components in p2p
+	cancelFunc  context.CancelFunc
 
 	shutdownOnce sync.Once
-	shutdown     chan struct{} // local request to kill the Switch from outside. e.g when local node is shutting down
 
 	// p2p identity with private key for signing
 	lNode node.LocalNode
@@ -156,22 +156,24 @@ func newSwarm(ctx context.Context, config config.Config, logger log.Log, datadir
 		}
 	}
 
+	shutdownCtx, cancel := context.WithCancel(ctx)
+
 	// Create networking
-	n, err := net.NewNet(config, l, logger.WithName("tcpnet"))
+	n, err := net.NewNet(shutdownCtx, config, l, logger.WithName("tcpnet"))
 	if err != nil {
+		cancel()
 		return nil, fmt.Errorf("can't create switch without a network, err: %v", err)
 	}
 
-	udpnet, err := net.NewUDPNet(config, l, logger.WithName("udpnet"))
+	udpnet, err := net.NewUDPNet(shutdownCtx, config, l, logger.WithName("udpnet"))
 	if err != nil {
+		cancel()
 		return nil, err
 	}
 
-	localCtx, cancel := context.WithCancel(ctx)
-
 	s := &Switch{
-		ctx:        localCtx,
-		cancelFunc: cancel,
+		shutdownCtx: shutdownCtx,
+		cancelFunc:  cancel,
 
 		config: config,
 		logger: logger,
@@ -180,7 +182,6 @@ func newSwarm(ctx context.Context, config config.Config, logger log.Log, datadir
 
 		bootChan: make(chan struct{}),
 		gossipC:  make(chan struct{}),
-		shutdown: make(chan struct{}), // non-buffered so requests to shutdown block until Switch is shut down
 
 		initial:           make(chan struct{}),
 		morePeersReq:      make(chan struct{}, config.MaxInboundPeers+config.OutboundPeersTarget),
@@ -198,12 +199,12 @@ func newSwarm(ctx context.Context, config config.Config, logger log.Log, datadir
 	}
 
 	// Create the udp version of Switch
-	mux := NewUDPMux(ctx, s.lNode, s.lookupFunc, udpnet, s.config.NetworkID, s.logger)
+	mux := NewUDPMux(ctx, s.shutdownCtx, s.lNode, s.lookupFunc, udpnet, s.config.NetworkID, s.logger)
 	s.udpServer = mux
 
 	// todo : if discovery on
 	s.discover = discovery.New(ctx, l, config.SwarmConfig, s.udpServer, datadir, s.logger) // create table and discovery protocol
-	cpool := connectionpool.NewConnectionPool(s.network.Dial, l.PublicKey(), logger)
+	cpool := connectionpool.NewConnectionPool(s.shutdownCtx, s.network.Dial, l.PublicKey(), logger)
 	s.network.SubscribeOnNewRemoteConnections(func(nce net.NewConnectionEvent) {
 		ctx := log.WithNewSessionID(ctx)
 		if err := cpool.OnNewConnection(ctx, nce); err != nil {
@@ -216,7 +217,7 @@ func newSwarm(ctx context.Context, config config.Config, logger log.Log, datadir
 	s.network.SubscribeClosingConnections(cpool.OnClosedConnection)
 	s.network.SubscribeClosingConnections(s.onClosedConnection)
 	s.cPool = cpool
-	s.gossip = gossip.NewProtocol(config.SwarmConfig, s, peers.NewPeers(s, s.logger), s.LocalNode().PublicKey(), s.logger)
+	s.gossip = gossip.NewProtocol(s.shutdownCtx, config.SwarmConfig, s, peers.NewPeers(s, s.logger), s.LocalNode().PublicKey(), s.logger)
 	s.logger.With().Debug("created new swarm", l.PublicKey())
 	return s, nil
 }
@@ -281,7 +282,7 @@ func (s *Switch) Start(ctx context.Context) error {
 	if s.config.SwarmConfig.Bootstrap {
 		go func() {
 			b := time.Now()
-			if err := s.discover.Bootstrap(s.ctx); err != nil {
+			if err := s.discover.Bootstrap(s.shutdownCtx); err != nil {
 				s.bootErr = err
 				close(s.bootChan)
 				s.Shutdown()
@@ -427,8 +428,6 @@ func (s *Switch) RegisterGossipProtocol(protocol string, prio priorityq.Priority
 func (s *Switch) Shutdown() {
 	s.shutdownOnce.Do(func() {
 		s.cancelFunc()
-		close(s.shutdown)
-		s.gossip.Close()
 		s.discover.Shutdown()
 		s.cPool.Shutdown()
 		s.network.Shutdown()
@@ -498,6 +497,15 @@ func (s *Switch) RegisterDirectProtocolWithChannel(protocol string, ingressChann
 	return ingressChannel
 }
 
+func (s *Switch) isShuttingDown() bool {
+	select {
+	case <-s.shutdownCtx.Done():
+		return true
+	default:
+	}
+	return false
+}
+
 // listenToNetworkMessages is listening on new messages from the opened connections and processes them.
 func (s *Switch) listenToNetworkMessages(ctx context.Context) {
 	// We listen to each of the messages queues we get from `net`
@@ -511,9 +519,12 @@ func (s *Switch) listenToNetworkMessages(ctx context.Context) {
 			for {
 				select {
 				case msg := <-c:
+					if s.isShuttingDown() {
+						return
+					}
 					// requestID will be restored from the saved message, no need to generate one here
 					s.processMessage(ctx, msg)
-				case <-s.shutdown:
+				case <-s.shutdownCtx.Done():
 					return
 				}
 			}
@@ -713,15 +724,17 @@ func (s *Switch) startNeighborhood(ctx context.Context) error {
 
 // peersLoop executes one routine at a time to connect new peers.
 func (s *Switch) peersLoop(ctx context.Context) {
-loop:
 	for {
 		select {
 		case <-s.morePeersReq:
+			if s.isShuttingDown() {
+				return
+			}
 			s.logger.WithContext(ctx).Debug("loop: got morePeersReq")
 			s.askForMorePeers(ctx)
 		//todo: try getting the connections (heartbeat)
-		case <-s.shutdown:
-			break loop // maybe error ?
+		case <-s.shutdownCtx.Done():
+			return
 		}
 	}
 }
@@ -793,7 +806,7 @@ func (s *Switch) askForMorePeers(ctx context.Context) {
 	tmr := time.NewTimer(NoResultsInterval)
 	defer tmr.Stop()
 	select {
-	case <-s.shutdown:
+	case <-s.shutdownCtx.Done():
 		return
 	case <-tmr.C:
 		s.morePeersReq <- struct{}{}
@@ -809,7 +822,7 @@ func (s *Switch) getMorePeers(ctx context.Context, numpeers int) int {
 	logger := s.logger.WithContext(ctx)
 
 	// discovery should provide us with random peers to connect to
-	nds := s.discover.SelectPeers(s.ctx, numpeers)
+	nds := s.discover.SelectPeers(s.shutdownCtx, numpeers)
 	ndsLen := len(nds)
 	if ndsLen == 0 {
 		logger.Debug("peer sampler returned nothing")
@@ -827,6 +840,9 @@ func (s *Switch) getMorePeers(ctx context.Context, numpeers int) int {
 	// Try a connection to each peer.
 	// TODO: try splitting the load and don't connect to more than X at a time
 	for i := 0; i < ndsLen; i++ {
+		if s.isShuttingDown() {
+			break
+		}
 		go func(nd *node.Info, reportChan chan cnErr) {
 			if nd.PublicKey() == s.lNode.PublicKey() {
 				reportChan <- cnErr{nd, errors.New("connection to self")}
@@ -886,7 +902,7 @@ loop:
 				log.FieldNamed("peer_id", cne.n.PublicKey()))
 		case <-tm.C:
 			break loop
-		case <-s.shutdown:
+		case <-s.shutdownCtx.Done():
 			break loop
 		}
 

--- a/p2p/switch_test.go
+++ b/p2p/switch_test.go
@@ -113,7 +113,7 @@ func TestSwarm_Shutdown(t *testing.T) {
 	s.Shutdown()
 
 	select {
-	case _, ok := <-s.shutdown:
+	case _, ok := <-s.shutdownCtx.Done():
 		assert.False(t, ok)
 	case <-time.After(1 * time.Second):
 		t.Error("Failed to shutdown")

--- a/p2p/udp_test.go
+++ b/p2p/udp_test.go
@@ -60,14 +60,14 @@ func (mun *mockUDPNetwork) SubscribeOnNewRemoteConnections(func(event net.NewCon
 func TestNewUDPMux(t *testing.T) {
 	nd, _ := node.NewNodeIdentity()
 	udpMock := &mockUDPNetwork{}
-	m := NewUDPMux(context.TODO(), nd, nil, udpMock, 1, log.NewDefault("test"))
+	m := NewUDPMux(context.TODO(), context.TODO(), nd, nil, udpMock, 1, log.NewDefault("test"))
 	require.NotNil(t, m)
 }
 
 func TestUDPMux_RegisterDirectProtocolWithChannel(t *testing.T) {
 	nd, _ := node.NewNodeIdentity()
 	udpMock := &mockUDPNetwork{}
-	m := NewUDPMux(context.TODO(), nd, nil, udpMock, 1, log.NewDefault(testStr))
+	m := NewUDPMux(context.TODO(), context.TODO(), nd, nil, udpMock, 1, log.NewDefault(testStr))
 	require.NotNil(t, m)
 	c := make(chan service.DirectMessage, 1)
 	m.RegisterDirectProtocolWithChannel(testStr, c)
@@ -80,7 +80,7 @@ func TestUDPMux_RegisterDirectProtocolWithChannel(t *testing.T) {
 func TestUDPMux_Start(t *testing.T) {
 	nd, _ := node.NewNodeIdentity()
 	udpMock := &mockUDPNetwork{}
-	m := NewUDPMux(context.TODO(), nd, nil, udpMock, 1, log.NewDefault(testStr))
+	m := NewUDPMux(context.TODO(), context.TODO(), nd, nil, udpMock, 1, log.NewDefault(testStr))
 	require.NotNil(t, m)
 	err := m.Start()
 	require.NoError(t, err)
@@ -89,7 +89,7 @@ func TestUDPMux_Start(t *testing.T) {
 func TestUDPMux_ProcessDirectProtocolMessage(t *testing.T) {
 	nd, _ := node.NewNodeIdentity()
 	udpMock := &mockUDPNetwork{}
-	m := NewUDPMux(context.TODO(), nd, nil, udpMock, 1, log.NewDefault(testStr))
+	m := NewUDPMux(context.TODO(), context.TODO(), nd, nil, udpMock, 1, log.NewDefault(testStr))
 	require.NotNil(t, m)
 
 	data := service.DataBytes{Payload: []byte(testStr)}
@@ -120,7 +120,7 @@ func TestUDPMux_sendMessageImpl(t *testing.T) {
 		return nil, errors.New("nonode")
 	}
 
-	m := NewUDPMux(context.TODO(), nd, f, udpMock, 1, log.NewDefault(testStr))
+	m := NewUDPMux(context.TODO(), context.TODO(), nd, f, udpMock, 1, log.NewDefault(testStr))
 	require.NotNil(t, m)
 	data := service.DataBytes{Payload: []byte(testStr)}
 
@@ -183,7 +183,7 @@ func TestUDPMux_sendMessageImpl(t *testing.T) {
 func TestUDPMux_ProcessUDP(t *testing.T) {
 	nd, _ := node.NewNodeIdentity()
 	udpMock := &mockUDPNetwork{}
-	m := NewUDPMux(context.TODO(), nd, nil, udpMock, 1, log.NewDefault(testStr))
+	m := NewUDPMux(context.TODO(), context.TODO(), nd, nil, udpMock, 1, log.NewDefault(testStr))
 	require.NotNil(t, m)
 	data := service.DataBytes{Payload: []byte(testStr)}
 	msg := &ProtocolMessage{}
@@ -241,17 +241,17 @@ func TestUDPMux_ProcessUDP(t *testing.T) {
 
 func Test_RoundTrip(t *testing.T) {
 	nd, ndinfo := node.GenerateTestNode(t)
-	udpnet, err := net.NewUDPNet(config.DefaultConfig(), nd, log.NewDefault(""))
+	udpnet, err := net.NewUDPNet(context.TODO(), config.DefaultConfig(), nd, log.NewDefault(""))
 	require.NoError(t, err)
 
-	m := NewUDPMux(context.TODO(), nd, nil, udpnet, 0, log.NewDefault(testStr))
+	m := NewUDPMux(context.TODO(), context.TODO(), nd, nil, udpnet, 0, log.NewDefault(testStr))
 	require.NotNil(t, m)
 
 	nd2, ndinfo2 := node.GenerateTestNode(t)
-	udpnet2, err := net.NewUDPNet(config.DefaultConfig(), nd2, log.NewDefault(""))
+	udpnet2, err := net.NewUDPNet(context.TODO(), config.DefaultConfig(), nd2, log.NewDefault(""))
 	require.NoError(t, err)
 
-	m2 := NewUDPMux(context.TODO(), nd2, nil, udpnet2, 0, log.NewDefault(testStr+"2"))
+	m2 := NewUDPMux(context.TODO(), context.TODO(), nd2, nil, udpnet2, 0, log.NewDefault(testStr+"2"))
 	require.NotNil(t, m2)
 
 	c := make(chan service.DirectMessage, 1)


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
Closes #1313 
<!-- `Closes #XXXX, closes #XXXX, ...` links mentioned issues to this PR and automatically closes them when this it's merged -->

## Changes
<!-- Please describe in detail the changes made -->
make all p2p components share the same shutdown context so they can be in sync wrt to shutdown timeing.

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->
unit tests

## TODO
<!-- This section should be removed when all items are complete -->
- [ ] Explain motivation or link existing issue(s)
- [ ] Test changes and document test plan
- [ ] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
