### PR TITLE
Grpc graceful shutdown

### DIFF
--- a/api/grpcserver/grpc.go
+++ b/api/grpcserver/grpc.go
@@ -2,12 +2,13 @@ package grpcserver
 
 import (
 	"fmt"
+	"net"
+	"time"
+
 	"github.com/spacemeshos/go-spacemesh/log"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/reflection"
-	"net"
-	"time"
 )
 
 // ServiceAPI allows individual grpc services to register the grpc server
@@ -59,7 +60,7 @@ func (s *Server) startInternal() {
 // Close stops the server
 func (s *Server) Close() error {
 	log.Info("Stopping new grpc server...")
-	s.GrpcServer.Stop()
+	s.GrpcServer.GracefulStop()
 
 	// We don't return any errors but we want to conform to io.Closer so return a nil error
 	return nil


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
allow grpc server to shutdown gracefully - allow any in-flight requests to complete and return status code Unavailable for any new requests.
<!-- `Closes #XXXX, closes #XXXX, ...` links mentioned issues to this PR and automatically closes them when this it's merged -->

## Changes
<!-- Please describe in detail the changes made -->
for grpc/http servers, the graceful shutdown can block for a while. launch the shutdown routine and shutdown other components before waiting for grpc/http servers to finish shutting down.

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->
make test

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [ ] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
