### PR TITLE
[Merged by Bors] - Only report receiving a block once

### DIFF
--- a/blocks/blocks.go
+++ b/blocks/blocks.go
@@ -87,15 +87,14 @@ func (bh *BlockHandler) HandleBlockData(ctx context.Context, data []byte, sync s
 
 	// set the block id when received
 	blk.Initialize()
-	logger := bh.WithContext(ctx)
-	logger.With().Info("got new block", blk.Fields()...)
-	logger = logger.WithFields(blk.ID(), blk.Layer())
+	logger := bh.WithContext(ctx).WithFields(blk.ID(), blk.Layer())
 
 	// check if known
 	if _, err := bh.mesh.GetBlock(blk.ID()); err == nil {
 		logger.Info("we already know this block")
 		return nil
 	}
+	logger.With().Info("got new block", blk.Fields()...)
 
 	if err := bh.blockSyntacticValidation(ctx, &blk, sync); err != nil {
 		logger.With().Error("failed to validate block", log.Err(err))


### PR DESCRIPTION
## Motivation
We've seen cases in system tests where nodes report getting several multiples of the number of blocks that are supposed to be in a layer. It appears to happen because we log receiving a block before checking if we know it already, at which point block processing stops.

## Changes
Log `got new block` only after checking for duplicates.

## Test Plan
Since this only affects logging, no new tests are needed.

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
