### PR TITLE
Add Pyroscope profiler to CI

### DIFF
--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -1013,9 +1013,13 @@ func (app *SpacemeshApp) Start(*cobra.Command, []string) {
 	nodeID := types.NodeID{Key: edPubkey.String(), VRFPublicKey: vrfPub}
 
 	if app.Config.ProfilerURL != "" {
+		appname := nodeID.ShortString()
+		if app.Config.ProfilerName != "" {
+			appname = app.Config.ProfilerName
+		}
 		p, err := profiler.Start(profiler.Config{
-			ApplicationName: nodeID.ShortString(),
-			// app.Config.ProfilerURL should be the pyroscope server address
+			ApplicationName: appname,
+			// app.Config.ProfilerURL should be the pyroscope server address (format http://ip:port)
 			// TODO: AuthToken? no need right now since server isn't public
 			ServerAddress: app.Config.ProfilerURL,
 			// by default all profilers are enabled,

--- a/config/config.go
+++ b/config/config.go
@@ -174,7 +174,7 @@ func defaultBaseConfig() BaseConfig {
 		CollectMetrics:      false,
 		MetricsPort:         1010,
 		ProfilerURL:         "",
-		ProfilerName:        "gp-spacemesh",
+		ProfilerName:        "",
 		OracleServer:        "http://localhost:3030",
 		OracleServerWorldID: 0,
 		GenesisTime:         time.Now().Format(time.RFC3339),

--- a/tests/config.py
+++ b/tests/config.py
@@ -11,6 +11,7 @@ FILEBEAT_CONF_DIR = './elk/filebeat/'
 FLUENT_BIT_CONF_DIR = './elk/fluent-bit/'
 KIBANA_CONF_DIR = './elk/kibana/'
 LOGSTASH_CONF_DIR = './elk/logstash/'
+PYROSCOPE_CONF_DIR = './elk/pyroscope/'
 
 ES_USER_LOCAL = ut.get_env("ES_USER")
 ES_PASS_LOCAL = ut.get_env("ES_PASS")
@@ -20,4 +21,5 @@ MAIN_ES_URL = f"{MAIN_ES_IP}:9200"
 
 BOOTSTRAP_PORT = 7513
 ORACLE_SERVER_PORT = 3030
+PROFILER_SERVER_PORT = 4040
 POET_SERVER_PORT = 80

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -323,10 +323,8 @@ def add_elk(init_session, request):
 @pytest.fixture(scope='module')
 def add_pyroscope(init_session, request):
     # get today's date for filebeat data index
-    index_date = datetime.utcnow().date().strftime("%Y.%m.%d")
     add_pyroscope_cluster(init_session)
-
-    # yield
+    # todo: teardown?
 
 
 def dump_es_to_main_server(init_session, index_date, testsfailed):

--- a/tests/elk/pyroscope/dep_order.txt
+++ b/tests/elk/pyroscope/dep_order.txt
@@ -1,0 +1,1 @@
+deployment.yaml, service.yaml

--- a/tests/elk/pyroscope/deployment.yaml
+++ b/tests/elk/pyroscope/deployment.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pyroscope
+  labels:
+    app: pyroscope
+    heritage: Helm
+  creationTimestamp: null
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: pyroscope
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        name: pyroscope
+    spec:
+      containers:
+      - args:
+        - pyroscope server
+        command:
+        - /bin/sh
+        - -c
+        image: pyroscope/pyroscope:latest
+        name: pyroscope
+        ports:
+        - containerPort: 4040
+        resources:
+          limits:
+            cpu: "1"
+            memory: 2Gi
+          requests:
+            cpu: "1"
+            memory: 2Gi
+
+

--- a/tests/elk/pyroscope/deployment.yaml
+++ b/tests/elk/pyroscope/deployment.yaml
@@ -5,35 +5,38 @@ metadata:
   labels:
     app: pyroscope
     heritage: Helm
-  creationTimestamp: null
 spec:
   replicas: 1
   selector:
     matchLabels:
-      name: pyroscope
-  strategy: {}
+      app: pyroscope
+  strategy:
+    type: Recreate
   template:
     metadata:
-      creationTimestamp: null
       labels:
-        name: pyroscope
+        app: pyroscope
     spec:
+      nodeSelector:
+        app: pyroscope
+      tolerations:
+        - key: "app"
+          operator: "Equal"
+          value: pyroscope
+          effect: "NoSchedule"
       containers:
-      - args:
-        - pyroscope server
-        command:
-        - /bin/sh
-        - -c
-        image: pyroscope/pyroscope:latest
-        name: pyroscope
-        ports:
-        - containerPort: 4040
-        resources:
-          limits:
-            cpu: "1"
-            memory: 2Gi
-          requests:
-            cpu: "1"
-            memory: 2Gi
+        - name: pyroscope
+          image: "pyroscope/pyroscope:latest"
+          imagePullPolicy: "IfNotPresent"
+          command: ["/bin/sh", "-c", "pyroscope server"]
+          ports:
+            - containerPort: 4040
+          resources:
+            limits:
+              cpu: "2"
+              memory: 4Gi
+            requests:
+              cpu: "2"
+              memory: 4Gi
 
 

--- a/tests/elk/pyroscope/service.yaml
+++ b/tests/elk/pyroscope/service.yaml
@@ -7,12 +7,11 @@ metadata:
     heritage: Helm
   creationTimestamp: null
 spec:
+  type: LoadBalancer
   ports:
   - name: http
+    protocol: TCP
     port: 4040
     targetPort: 4040
   selector:
-    name: pyroscope
-  type: NodePort
-status:
-  loadBalancer: {}
+    app: pyroscope

--- a/tests/elk/pyroscope/service.yaml
+++ b/tests/elk/pyroscope/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: pyroscope
+  labels:
+    app: pyroscope
+    heritage: Helm
+  creationTimestamp: null
+spec:
+  ports:
+  - name: http
+    port: 4040
+    targetPort: 4040
+  selector:
+    name: pyroscope
+  type: NodePort
+status:
+  loadBalancer: {}

--- a/tests/k8s/bootstrap-w-conf-ss.yml
+++ b/tests/k8s/bootstrap-w-conf-ss.yml
@@ -23,7 +23,7 @@ spec:
       - name: bootstrap
         image: spacemeshos/go-spacemesh:develop
         imagePullPolicy: Always
-        args: ['--config', '/etc/config/config.toml', '--grpc', 'gateway,globalstate,transaction', '--test-mode', '--coinbase', '0x1234', '--golden-atx', '0x5678', '--metrics', '--metrics-port', '2020', '--pprof-server']
+        args: ['--config', '/etc/config/config.toml', '--grpc', 'gateway,globalstate,transaction', '--test-mode', '--coinbase', '0x1234', '--golden-atx', '0x5678', '--metrics', '--metrics-port', '2020']
         resources:
           requests:
             memory: "512M"

--- a/tests/k8s/bootstrap-w-conf.yml
+++ b/tests/k8s/bootstrap-w-conf.yml
@@ -18,7 +18,7 @@ spec:
       - name: bootstrap
         image: spacemeshos/go-spacemesh:develop
         imagePullPolicy: Always
-        args: ['--config', '/etc/config/config.toml', '--oracle_server', 'http://10.12.3.110:3030', '--test-mode', '--metrics', '--metrics-port', '2020', '--pprof-server']
+        args: ['--config', '/etc/config/config.toml', '--oracle_server', 'http://10.12.3.110:3030', '--test-mode', '--metrics', '--metrics-port', '2020']
         resources:
           requests:
             memory: "512M"

--- a/tests/k8s/bootstrapoet-w-conf-ss.yml
+++ b/tests/k8s/bootstrapoet-w-conf-ss.yml
@@ -23,7 +23,7 @@ spec:
       - name: bootstrap
         image: spacemeshos/go-spacemesh:develop
         imagePullPolicy: Always
-        args: ['--config', '/etc/config/config.toml', '--grpc', 'gateway,globalstate,transaction', '--test-mode', '--coinbase', '0x1234', '--golden-atx', '0x5678', '--metrics', '--metrics-port', '2020', '--pprof-server', '--poet-server', '127.0.0.1:80']
+        args: ['--config', '/etc/config/config.toml', '--grpc', 'gateway,globalstate,transaction', '--test-mode', '--coinbase', '0x1234', '--golden-atx', '0x5678', '--metrics', '--metrics-port', '2020', '--poet-server', '127.0.0.1:80']
         resources:
           requests:
             memory: "512M"

--- a/tests/k8s/bootstrapoet-w-conf.yml
+++ b/tests/k8s/bootstrapoet-w-conf.yml
@@ -25,7 +25,7 @@ spec:
         - name: bootstrap
           image: spacemeshos/go-spacemesh:develop
           imagePullPolicy: Always
-          args: ['--config', '/etc/config/config.toml', '--oracle_server', 'http://10.40.5.12:3030', '--grpc', 'gateway,globalstate,transaction', '--test-mode', '--metrics', '--start-mining', '--metrics-port', '2020', '--pprof-server', '--poet-server', '127.0.0.1:80']
+          args: ['--config', '/etc/config/config.toml', '--oracle_server', 'http://10.40.5.12:3030', '--grpc', 'gateway,globalstate,transaction', '--test-mode', '--metrics', '--start-mining', '--metrics-port', '2020', '--poet-server', '127.0.0.1:80']
           resources:
             requests:
               memory: "512M"

--- a/tests/k8s/client-w-conf-ss.yml
+++ b/tests/k8s/client-w-conf-ss.yml
@@ -25,7 +25,7 @@ spec:
       - name: client
         image: spacemeshos/go-spacemesh:develop
         imagePullPolicy: Always
-        args: ['--randcon', '3', '--bootstrap', '--test-mode', '--oracle_server', 'http://10.12.3.14:3030', '--grpc', 'gateway,globalstate,transaction', '--json-server', '--bootnodes', '10.36.1.12:7513/26hRBJqMJPUnKgJ9VR6g3kH6aCQhZ9shBvhn3bEHDvRyv', '--metrics', '--metrics-port', '2020', '--pprof-server']
+        args: ['--randcon', '3', '--bootstrap', '--test-mode', '--oracle_server', 'http://10.12.3.14:3030', '--grpc', 'gateway,globalstate,transaction', '--json-server', '--bootnodes', '10.36.1.12:7513/26hRBJqMJPUnKgJ9VR6g3kH6aCQhZ9shBvhn3bEHDvRyv', '--metrics', '--metrics-port', '2020']
         resources:
           requests:
             memory: "512M"

--- a/tests/k8s/client-w-conf.yml
+++ b/tests/k8s/client-w-conf.yml
@@ -24,7 +24,7 @@ spec:
         - name: client
           image: spacemeshos/go-spacemesh:develop
           imagePullPolicy: Always
-          args: ['--randcon', '3', '--bootstrap','--start-mining', '--test-mode', '--oracle_server', 'http://10.12.3.14:3030', '--grpc', 'gateway,globalstate,transaction', '--json-server', '--bootnodes', '10.36.1.12:7513/26hRBJqMJPUnKgJ9VR6g3kH6aCQhZ9shBvhn3bEHDvRyv', '--metrics', '--metrics-port', '2020', '--pprof-server']
+          args: ['--randcon', '3', '--bootstrap','--start-mining', '--test-mode', '--oracle_server', 'http://10.12.3.14:3030', '--grpc', 'gateway,globalstate,transaction', '--json-server', '--bootnodes', '10.36.1.12:7513/26hRBJqMJPUnKgJ9VR6g3kH6aCQhZ9shBvhn3bEHDvRyv', '--metrics', '--metrics-port', '2020']
           resources:
             requests:
               memory: "512M"

--- a/tests/setup_network.py
+++ b/tests/setup_network.py
@@ -2,25 +2,29 @@ from datetime import datetime
 import pytest
 from pytest_testconfig import config as testconfig
 import pytz
-
+from tests.k8s_handler import get_external_ip
+from tests.config import PROFILER_SERVER_PORT
 from tests.conftest import NetworkDeploymentInfo, NetworkInfo
 from tests.utils import wait_genesis, get_genesis_time_delta
 
 
 @pytest.fixture(scope='module')
-def setup_network(init_session, add_elk, add_node_pool, add_curl, setup_bootstrap, start_poet, setup_clients):
+def setup_network(init_session, add_elk, add_pyroscope, add_node_pool, add_curl, setup_bootstrap, start_poet, setup_clients):
     # This fixture deploy a complete Spacemesh network and returns only after genesis time is over
     _session_id = init_session
     network_deployment = NetworkDeploymentInfo(dep_id=_session_id,
                                                bs_deployment_info=setup_bootstrap,
                                                cl_deployment_info=setup_clients)
-    # genesis time = when clients have been created + delta = time.now - time it took pods to come up + delta
+
+    pyroscope = get_external_ip(testconfig['namespace'], "pyroscope")
+    print("Pyroscope server URL : http://{0}:{1} ".format(pyroscope, PROFILER_SERVER_PORT))
+# genesis time = when clients have been created + delta = time.now - time it took pods to come up + delta
     wait_genesis(get_genesis_time_delta(testconfig['genesis_delta']), testconfig['genesis_delta'])
     return network_deployment
 
 
 @pytest.fixture(scope='module')
-def setup_mul_network(init_session, add_elk, add_node_pool, add_curl, setup_bootstrap, start_poet, setup_mul_clients):
+def setup_mul_network(init_session, add_elk, add_pyroscope, add_node_pool, add_curl, setup_bootstrap, start_poet, setup_mul_clients):
     # This fixture deploy a complete Spacemesh network and returns only after genesis time is over
     _session_id = init_session
     network_deployment = NetworkInfo(namespace=init_session,

--- a/tests/setup_utils.py
+++ b/tests/setup_utils.py
@@ -76,7 +76,7 @@ def _setup_dep_ss_file_path(file_path, dep_type, node_type):
     return dep_file_path, ss_file_path
 
 
-def setup_bootstrap_in_namespace(namespace, bs_deployment_info, bootstrap_config, gen_time_del, oracle=None, poet=None,
+def setup_bootstrap_in_namespace(namespace, bs_deployment_info, bootstrap_config, gen_time_del, oracle=None, poet=None, pyroscope=None,
                                  file_path=None, dep_time_out=180):
     """
     adds a bootstrap node to a specific namespace
@@ -87,6 +87,7 @@ def setup_bootstrap_in_namespace(namespace, bs_deployment_info, bootstrap_config
     :param gen_time_del: string, genesis time as set in suite specification file
     :param oracle: string, oracle ip
     :param poet: string, poet ip
+    :param pyroscope: string, pyroscope ip
     :param file_path: string, optional, full path to deployment yaml
     :param dep_time_out: int, deployment timeout
 
@@ -112,6 +113,9 @@ def setup_bootstrap_in_namespace(namespace, bs_deployment_info, bootstrap_config
 
     if poet:
         bootstrap_args['poet_server'] = '{0}:{1}'.format(poet, conf.POET_SERVER_PORT)
+
+    if pyroscope:
+        bootstrap_args['profiler-url'] = 'https://{0}:{1}'.format(pyroscope, conf.PROFILER_SERVER_PORT)
 
     gen_delta = get_genesis_time_delta(gen_time_del)
     cspec.append_args(genesis_time=gen_delta.isoformat('T', 'seconds'),
@@ -158,7 +162,7 @@ def setup_bootstrap_in_namespace(namespace, bs_deployment_info, bootstrap_config
 
 
 def setup_clients_in_namespace(namespace, bs_deployment_info, client_deployment_info, client_config, genesis_time,
-                               name="client", file_path=None, oracle=None, poet=None, dep_time_out=120):
+                               name="client", file_path=None, oracle=None, poet=None, pyroscope=None, dep_time_out=120):
     # setting stateful and deployment configuration files
     # default deployment method is 'deployment'
     dep_method = client_config.get("deployment_type", "deployment")
@@ -175,7 +179,7 @@ def setup_clients_in_namespace(namespace, bs_deployment_info, client_deployment_
         return client_deployment_info.deployment_name.split('-')[1]
 
     cspec = get_conf(bs_deployment_info, client_config, genesis_time, setup_oracle=oracle,
-                     setup_poet=poet)
+                     setup_poet=poet, setup_pyroscope=pyroscope)
 
     k8s_file, k8s_create_func = choose_k8s_object_create(client_config, dep_file_path, ss_file_path)
     resp = k8s_create_func(k8s_file, namespace,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -171,7 +171,7 @@ def get_genesis_time_delta(genesis_time: float) -> datetime:
     return pytz.utc.localize(datetime.utcnow() + timedelta(seconds=genesis_time))
 
 
-def get_conf(bs_info, client_config, genesis_time, setup_oracle=None, setup_poet=None, args=None):
+def get_conf(bs_info, client_config, genesis_time, setup_oracle=None, setup_poet=None, setup_pyroscope=None, args=None):
     """
     get_conf gather specification information into one ContainerSpec object
 
@@ -184,6 +184,7 @@ def get_conf(bs_info, client_config, genesis_time, setup_oracle=None, setup_poet
     :param genesis_time: string, genesis time as set in suite specification file
     :param setup_oracle: string, oracle ip
     :param setup_poet: string, poet ip
+    :param setup_pyroscope: string, poet pyroscope ip, name
     :param args: dictionary, arguments for appendage in specification
     :return: ContainerSpec
     """
@@ -201,7 +202,10 @@ def get_conf(bs_info, client_config, genesis_time, setup_oracle=None, setup_poet
 
     # append poet configuration
     if setup_poet:
-        client_args['poet_server'] = '{0}:{1}'.format(setup_poet, conf.POET_SERVER_PORT)
+        client_args['poet_server'] = '{0}:{1}'.format(setup_poet, conf.POET_SERVER_PORT)    # append poet configuration
+
+    if setup_pyroscope:
+        client_args['profiler-url'] = 'http://{0}:{1}'.format(setup_pyroscope, conf.PROFILER_SERVER_PORT)
 
     bootnodes = node_string(bs_info['key'], bs_info['pod_ip'], conf.BOOTSTRAP_PORT, conf.BOOTSTRAP_PORT)
     cspec.append_args(bootnodes=bootnodes, genesis_time=genesis_time_delta.isoformat('T', 'seconds'))


### PR DESCRIPTION
## Motivation

we want to be able to track memory and cpu using the infra structure

## Changes
- Start pyroscope server in each test
- Pass the server IP to the node
- use nodeid as application name in pyrocope

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [ ] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)

@narayanprusty - this means in spacecraft the change will be the nodeid and not the pod-name, before merging I might include a line to use the parameter only if passed otherwise use the nodeid.
Note: This is the only way this can work in our CI since we use one deployment for all the miners meaning they must have the same spec and arguments passed to them. so we can't pass a distinct name for each miner.

@antonlerner @noamnelke @sudachen , @other team members - Q:
do you think you'd prefer miner name vs nodeid? we might decide to invest in a workaround for this ..

The Pyroscope server IP:PORT printed on the test logs and currently lives only during the test, soon we'll add an option to keep it running.
