### PR TITLE
Handle SIGTERM

### DIFF
--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"runtime/debug"
+	"syscall"
 	"time"
 
 	"github.com/spacemeshos/go-spacemesh/fetch"
@@ -243,7 +244,7 @@ func (app *SpacemeshApp) introduction() {
 func (app *SpacemeshApp) Initialize(cmd *cobra.Command, args []string) (err error) {
 	// exit gracefully - e.g. with app Cleanup on sig abort (ctrl-c)
 	signalChan := make(chan os.Signal, 1)
-	signal.Notify(signalChan, os.Interrupt)
+	signal.Notify(signalChan, os.Interrupt, syscall.SIGTERM)
 
 	// Goroutine that listens for Ctrl ^ C command
 	// and triggers the quit app


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
k8s `kubctl delete pod` issue a SIGTERM to the binary. we want to listen to this signal to be able to shutdown gracefully
<!-- `Closes #XXXX, closes #XXXX, ...` links mentioned issues to this PR and automatically closes them when this it's merged -->

## Changes
<!-- Please describe in detail the changes made -->
add SIGTERM, in addition to os.interrupt, to the set of signals the binary listens to for shutting down

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->
make test

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
