### PR TITLE
Simple, periodic logging of memory usage

### DIFF
--- a/monitoring/memlog.go
+++ b/monitoring/memlog.go
@@ -1,0 +1,23 @@
+package monitoring
+
+import (
+	"github.com/spacemeshos/go-spacemesh/log"
+	"runtime"
+)
+
+// MemLogger stores state related to simple memory logging
+type MemLogger struct {
+	Logger log.Log
+}
+
+// LogMemoryUsage logs a snapshot of current memory usage
+func (ml MemLogger) LogMemoryUsage() {
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+	ml.Logger.With().Info("current memory profile",
+		log.String("alloc", bytesToMBFormmater(m.Alloc)),
+		log.String("total_alloc", bytesToMBFormmater(m.TotalAlloc)),
+		log.String("sys", bytesToMBFormmater(m.Sys)),
+		log.String("heap_alloc", bytesToMBFormmater(m.HeapAlloc)),
+		log.Uint64("heap_alloc", m.HeapObjects))
+}

--- a/sync/syncer.go
+++ b/sync/syncer.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"github.com/spacemeshos/go-spacemesh/events"
 	"github.com/spacemeshos/go-spacemesh/layerfetcher"
+	"github.com/spacemeshos/go-spacemesh/monitoring"
 	"sync"
 	"time"
 
@@ -325,7 +326,9 @@ func (s *Syncer) Start(ctx context.Context) {
 
 // fires a sync every sm.SyncInterval or on force sync from outside
 func (s *Syncer) run(ctx context.Context) {
-	s.WithContext(ctx).Debug("start running")
+	// memory profiler has nothing to do with sync but this is a convenient place to run it
+	memlogger := monitoring.MemLogger{Logger: log.AppLog.WithName("memlogger").WithContext(ctx)}
+	s.WithContext(ctx).Debug("syncer running")
 	for {
 		select {
 		case <-s.exit:
@@ -334,6 +337,7 @@ func (s *Syncer) run(ctx context.Context) {
 		case <-s.forceSync:
 			go s.synchronise(ctx)
 		case <-s.syncTimer.C:
+			memlogger.LogMemoryUsage()
 			go s.synchronise(ctx)
 		}
 	}


### PR DESCRIPTION
## Motivation
It's useful for troubleshooting memory issues, such as on the testnet

This has been included in the past few testnet builds

## Changes
- adds a simple memory logger that periodically prints memstats, called from the syncer

## Test Plan
N/A

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [ ] Test changes and document test plan
- [ ] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
