### PR TITLE
[Merged by Bors] - Require golang >= 1.15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 
 env:
-  go-version: '1.14.6'
+  go-version: '1.15.13'
   GCLOUD_KEY: ${{ secrets.GCLOUD_KEY }}
   PROJECT_NAME: ${{ secrets.PROJECT_NAME }}
   CLUSTER_NAME: ${{ secrets.CLUSTER_NAME }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Inspired by https://container-solutions.com/faster-builds-in-docker-with-go-1-11/
 # Base build image
-FROM golang:1.14.4-alpine3.12 AS build_base
+FROM golang:1.15.13-alpine AS build_base
 RUN apk add bash make git curl unzip rsync libc6-compat gcc musl-dev lsof
 WORKDIR /go/src/github.com/spacemeshos/go-spacemesh
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Since the project uses Go Modules it is best to place the code **outside** your 
 
 Building is supported on OS X, Linux, FreeBSD, and Windows.
 
-Install [Go 1.14 or later](https://golang.org/dl/) for your platform, if you haven't already.
+Install [Go 1.15 or later](https://golang.org/dl/) for your platform, if you haven't already.
 
 On Windows you need to install `make` via [msys2](https://www.msys2.org/), [MingGW-w64](http://mingw-w64.org/doku.php) or [mingw] (https://chocolatey.org/packages/mingw)
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ clone_folder: c:\gopath\src\github.com\spacemeshos\go-spacemesh\
 environment:
   GOPATH: c:\gopath
 
-stack: go 1.14
+stack: go 1.15
 
 before_build:
   - choco install make

--- a/go.mod
+++ b/go.mod
@@ -43,4 +43,4 @@ require (
 	nanomsg.org/go-mangos v1.4.0
 )
 
-go 1.14
+go 1.15

--- a/scripts/check-go-version.sh
+++ b/scripts/check-go-version.sh
@@ -9,7 +9,7 @@ errcho() {
 
 # Minimal Go version supported
 min_major=1
-min_minor=14
+min_minor=15
 
 # Ensure Go is installed
 if ! (hash go 2>/dev/null) ; then

--- a/scripts/win/check-go-version.ps1
+++ b/scripts/win/check-go-version.ps1
@@ -10,8 +10,8 @@ $minor = $Matches[2]
 $patch = $Matches[3]
 $loc = (gcm go).Path
 
-if($major -ne 1 -or $minor -lt 13)
+if($major -ne 1 -or $minor -lt 15)
 {
-    $host.ui.WriteErrorLine("Go 1.13+ is required (v$major.$minor.$patch is installed at $loc)")
+    $host.ui.WriteErrorLine("Go 1.15+ is required (v$major.$minor.$patch is installed at $loc)")
     exit 1
 }


### PR DESCRIPTION
## Motivation
Golang 1.15 has some [nice features](https://golang.org/doc/go1.15) such as `testing.TempDir`.

## Changes
This PR updates CI and scripts to require go >= 1.15.

## Test Plan
N/A

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [ ] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
