### PR TITLE
[Merged by Bors] - Tortoise: only count base block opinion that is within hdist

### DIFF
--- a/tortoise/verifying_tortoise.go
+++ b/tortoise/verifying_tortoise.go
@@ -225,7 +225,11 @@ func (t *turtle) BaseBlock() (types.BlockID, [][]types.BlockID, error) {
 	// Try to find a block counting only good blocks
 	// TODO: could we do better than just grabbing the first non-error, good block, as below?
 	// e.g., trying to minimize the size of the exception list instead
-	for i := t.Last; i > t.Last-t.Hdist; i-- {
+	window := types.LayerID(0)
+	if t.Hdist < t.Last {
+		window = t.Last - t.Hdist
+	}
+	for i := t.Last; i > window; i-- {
 		for block, opinion := range t.BlockOpinionsByLayer[i] {
 			if _, ok := t.GoodBlocksIndex[block]; !ok {
 				t.logger.With().Debug("skipping block not marked good",
@@ -395,6 +399,18 @@ func (t *turtle) processBlock(block *types.Block) error {
 	// TODO: save and vote against blocks that exceed the max exception list size (DoS prevention)
 	opinion := make(map[types.BlockID]vec)
 	for blk, vote := range baseBlockOpinion.BlocksOpinion {
+		fblk, err := t.bdp.GetBlock(blk)
+		if err != nil {
+			return fmt.Errorf("voted block not in db")
+		}
+		window := types.LayerID(0)
+		if block.LayerIndex > t.Hdist {
+			window = block.LayerIndex - t.Hdist
+		}
+		if fblk.LayerIndex < window {
+			continue
+		}
+
 		opinion[blk] = vote
 	}
 

--- a/tortoise/verifying_tortoise.go
+++ b/tortoise/verifying_tortoise.go
@@ -401,7 +401,7 @@ func (t *turtle) processBlock(block *types.Block) error {
 	for blk, vote := range baseBlockOpinion.BlocksOpinion {
 		fblk, err := t.bdp.GetBlock(blk)
 		if err != nil {
-			return fmt.Errorf("voted block not in db")
+			return fmt.Errorf("voted block not in db voting_block_id: %v, voting_block_layer_id: %v, voted_block_id: %v", block.ID().String(), block.LayerIndex, blk.String())
 		}
 		window := types.LayerID(0)
 		if block.LayerIndex > t.Hdist {

--- a/tortoise/verifying_tortoise_test.go
+++ b/tortoise/verifying_tortoise_test.go
@@ -198,7 +198,7 @@ func turtleSanity(t *testing.T, layers types.LayerID, blocksPerLayer, voteNegati
 		fmt.Println("Handled ", l, "========================================================================")
 		lastlyr := trtl.BlockOpinionsByLayer[l]
 		for _, v := range lastlyr {
-			fmt.Println("Block opinoin map size")
+			fmt.Println("block opinion map size", len(v.BlocksOpinion))
 			if (len(v.BlocksOpinion)) > int(blocksPerLayer*int(trtl.Hdist)) {
 				t.Errorf("layer opinion table exceeded max size, LEAK! size:%v, maxsize:%v", len(v.BlocksOpinion), int(blocksPerLayer*int(trtl.Hdist)))
 			}
@@ -340,18 +340,6 @@ func createTurtleLayer(l types.LayerID, msh *mesh.DB, bbp baseBlockProvider, ivp
 	return lyr
 }
 
-//func size(m map[types.LayerID]map[types.BlockID]Opinion) int {
-//	count := 0
-//	for i, v := range m {
-//		count += len(i.Bytes())
-//		for ii, vv := range v {
-//			count += len(ii.Bytes())
-//			count += len(ii.Bytes()) * len(vv.BlocksOpinion)
-//		}
-//	}
-//	return count
-//}
-
 func TestTurtle_Eviction(t *testing.T) {
 	defaultTestHdist = 12
 	layers := types.LayerID(defaultTestHdist * 5)
@@ -377,15 +365,6 @@ func TestTurtle_Eviction(t *testing.T) {
 		(defaultTestHdist+2)*avgPerLayer) // all blocks should be good
 	fmt.Println("Count good blocks ", len(trtl.GoodBlocksIndex))
 }
-
-//func TestTurtle_Eviction2(t *testing.T) {
-//	layers := types.LayerID(defaultTestHdist * 14)
-//	avgPerLayer := 30
-//	voteNegative := 5
-//	trtl, _, _ := turtleSanity(t, layers, avgPerLayer, voteNegative, 0)
-//	require.Equal(t, len(trtl.BlockOpinionsByLayer),
-//		(defaultTestHdist+2)*avgPerLayer)
-//}
 
 func TestTurtle_Recovery(t *testing.T) {
 	log.DebugMode(true)

--- a/tortoise/verifying_tortoise_test.go
+++ b/tortoise/verifying_tortoise_test.go
@@ -54,6 +54,14 @@ func requireVote(t *testing.T, trtl *turtle, vote vec, blocks ...types.BlockID) 
 		sum := abstain
 		blk, _ := trtl.bdp.GetBlock(i)
 
+		wind := types.LayerID(0)
+		if blk.LayerIndex > trtl.Hdist {
+			wind = trtl.Last - trtl.Hdist
+		}
+		if blk.LayerIndex < wind {
+			continue
+		}
+
 		for l := trtl.Last; l > blk.LayerIndex; l-- {
 
 			trtl.logger.Info("Counting votes of blocks in layer %v on %v (lyr: %v)", l, i.String(), blk.LayerIndex)


### PR DESCRIPTION
## Motivation
This was causing a memory leak where a new layer arrived and according to the original description of the SMIP we copied the base block opinion and added latest diffs, this resulted in an adding a larger and larger map to the table on each layer saving the entire history of votes from all preceding base blocks.

the memory leak wasn't easy to spot since the above map exist for each block for each layer and structured as - 
`map[LayerID]map[BlockID]OpinionMap(map[BlockID]opinon)`
the opinion map would be bigger each time though it will be cleared by eviction, a larger map will be added for next layer and so on.

## Changes
only count base block opinions that is within hdist. 
this results in much lower and consistent memory size of the tortoise.
## Test Plan
Added unit test check to ensure our table size stays persistent 

## TODO
- [ ] - discuss with research team