### PR TITLE
[Merged by Bors] - start CI tests from the longest to the shortest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,8 +176,9 @@ jobs:
     timeout-minutes: 80
     steps:
       - name: Sleep for 30 seconds
-        run: sleep 30s
-        shell: bash
+        uses: jakejarvis/wait-action@master
+        with:
+          time: '30s'
       - name: checkout
         uses: actions/checkout@v2
       - name: blocks add node test
@@ -192,8 +193,9 @@ jobs:
     timeout-minutes: 80
     steps:
       - name: Sleep for 90 seconds
-        run: sleep 90s
-        shell: bash
+        uses: jakejarvis/wait-action@master
+        with:
+          time: '90s'
       - name: checkout
         uses: actions/checkout@v2
       - name: remove node test
@@ -208,8 +210,9 @@ jobs:
     timeout-minutes: 80
     steps:
       - name: Sleep for 150 seconds
-        run: sleep 150s
-        shell: bash
+        uses: jakejarvis/wait-action@master
+        with:
+          time: '150s'
       - name: checkout
         uses: actions/checkout@v2
       - name: mining system test
@@ -224,8 +227,9 @@ jobs:
     timeout-minutes: 80
     steps:
       - name: Sleep for 210 seconds
-        run: sleep 210s
-        shell: bash
+        uses: jakejarvis/wait-action@master
+        with:
+          time: '210s'
       - name: checkout
         uses: actions/checkout@v2
       - name: p2p system test
@@ -240,8 +244,9 @@ jobs:
     timeout-minutes: 80
     steps:
       - name: Sleep for 270 seconds
-        run: sleep 270s
-        shell: bash
+        uses: jakejarvis/wait-action@master
+        with:
+          time: '270s'
       - name: checkout
         uses: actions/checkout@v2
       - name: hare system test
@@ -256,8 +261,9 @@ jobs:
     timeout-minutes: 80
     steps:
       - name: Sleep for 330 seconds
-        run: sleep 330s
-        shell: bash
+        uses: jakejarvis/wait-action@master
+        with:
+          time: '330s'
       - name: checkout
         uses: actions/checkout@v2
       - name: sync system test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,8 +175,9 @@ jobs:
       - dockerpush
     timeout-minutes: 80
     steps:
-      - name: sleep
-        run: sleep 30
+      - name: Sleep for 30 seconds
+        run: sleep 30s
+        shell: bash
       - name: checkout
         uses: actions/checkout@v2
       - name: blocks add node test
@@ -190,8 +191,9 @@ jobs:
       - dockerpush
     timeout-minutes: 80
     steps:
-      - name: sleep
-        run: sleep 90
+      - name: Sleep for 90 seconds
+        run: sleep 90s
+        shell: bash
       - name: checkout
         uses: actions/checkout@v2
       - name: remove node test
@@ -205,8 +207,9 @@ jobs:
       - dockerpush
     timeout-minutes: 80
     steps:
-      - name: sleep
-        run: sleep 150
+      - name: Sleep for 150 seconds
+        run: sleep 150s
+        shell: bash
       - name: checkout
         uses: actions/checkout@v2
       - name: mining system test
@@ -220,8 +223,9 @@ jobs:
       - dockerpush
     timeout-minutes: 80
     steps:
-      - name: sleep
-        run: sleep 210
+      - name: Sleep for 210 seconds
+        run: sleep 210s
+        shell: bash
       - name: checkout
         uses: actions/checkout@v2
       - name: p2p system test
@@ -235,8 +239,9 @@ jobs:
       - dockerpush
     timeout-minutes: 80
     steps:
-      - name: sleep
-        run: sleep 270
+      - name: Sleep for 270 seconds
+        run: sleep 270s
+        shell: bash
       - name: checkout
         uses: actions/checkout@v2
       - name: hare system test
@@ -250,8 +255,9 @@ jobs:
       - dockerpush
     timeout-minutes: 80
     steps:
-      - name: sleep
-        run: sleep 330
+      - name: Sleep for 330 seconds
+        run: sleep 330s
+        shell: bash
       - name: checkout
         uses: actions/checkout@v2
       - name: sync system test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,7 +166,7 @@ jobs:
         uses: actions/checkout@v2
       - name: late nodes system test
         run: make dockertest-late-nodes-elk
-  systemtest-blocks-add-node:
+  systemtest-mining:
     runs-on: ubuntu-latest
     # only run on push, not on pull_request
     if: ${{ needs.filter-changes.outputs.nondocchanges == 'true' && github.event_name == 'push' }}
@@ -181,8 +181,8 @@ jobs:
           time: '30s'
       - name: checkout
         uses: actions/checkout@v2
-      - name: blocks add node test
-        run: make dockertest-blocks-add-node-elk
+      - name: mining system test
+        run: make dockertest-mining-elk
   systemtest-blocks-remove-node:
     runs-on: ubuntu-latest
     # only run on push, not on pull_request
@@ -200,7 +200,7 @@ jobs:
         uses: actions/checkout@v2
       - name: remove node test
         run: make dockertest-blocks-remove-node-elk
-  systemtest-mining:
+  systemtest-blocks-add-node:
     runs-on: ubuntu-latest
     # only run on push, not on pull_request
     if: ${{ needs.filter-changes.outputs.nondocchanges == 'true' && github.event_name == 'push' }}
@@ -215,8 +215,8 @@ jobs:
           time: '150s'
       - name: checkout
         uses: actions/checkout@v2
-      - name: mining system test
-        run: make dockertest-mining-elk
+      - name: blocks add node test
+        run: make dockertest-blocks-add-node-elk
   systemtest-p2p:
     runs-on: ubuntu-latest
     # only run on push, not on pull_request
@@ -234,7 +234,7 @@ jobs:
         uses: actions/checkout@v2
       - name: p2p system test
         run: make dockertest-p2p-elk
-  systemtest-hare:
+  systemtest-sync:
     runs-on: ubuntu-latest
     # only run on push, not on pull_request
     if: ${{ needs.filter-changes.outputs.nondocchanges == 'true' && github.event_name == 'push' }}
@@ -249,9 +249,9 @@ jobs:
           time: '270s'
       - name: checkout
         uses: actions/checkout@v2
-      - name: hare system test
-        run: make dockertest-hare-elk
-  systemtest-sync:
+      - name: sync system test
+        run: make dockertest-sync-elk
+  systemtest-hare:
     runs-on: ubuntu-latest
     # only run on push, not on pull_request
     if: ${{ needs.filter-changes.outputs.nondocchanges == 'true' && github.event_name == 'push' }}
@@ -266,8 +266,8 @@ jobs:
           time: '330s'
       - name: checkout
         uses: actions/checkout@v2
-      - name: sync system test
-        run: make dockertest-sync-elk
+      - name: hare system test
+        run: make dockertest-hare-elk
 
 
   # this summary job is a shortcut that obviates the need to list every individual job in bors.toml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,8 @@ jobs:
       - dockerpush
     timeout-minutes: 80
     steps:
+      - name: sleep
+        run: sleep 30
       - name: checkout
         uses: actions/checkout@v2
       - name: blocks add node test
@@ -188,6 +190,8 @@ jobs:
       - dockerpush
     timeout-minutes: 80
     steps:
+      - name: sleep
+        run: sleep 90
       - name: checkout
         uses: actions/checkout@v2
       - name: remove node test
@@ -201,6 +205,8 @@ jobs:
       - dockerpush
     timeout-minutes: 80
     steps:
+      - name: sleep
+        run: sleep 150
       - name: checkout
         uses: actions/checkout@v2
       - name: mining system test
@@ -214,6 +220,8 @@ jobs:
       - dockerpush
     timeout-minutes: 80
     steps:
+      - name: sleep
+        run: sleep 210
       - name: checkout
         uses: actions/checkout@v2
       - name: p2p system test
@@ -227,6 +235,8 @@ jobs:
       - dockerpush
     timeout-minutes: 80
     steps:
+      - name: sleep
+        run: sleep 270
       - name: checkout
         uses: actions/checkout@v2
       - name: hare system test
@@ -240,6 +250,8 @@ jobs:
       - dockerpush
     timeout-minutes: 80
     steps:
+      - name: sleep
+        run: sleep 330
       - name: checkout
         uses: actions/checkout@v2
       - name: sync system test

--- a/tests/app_engine/resources/es_dump.py
+++ b/tests/app_engine/resources/es_dump.py
@@ -13,7 +13,7 @@ def wait_for_dump_to_end(src_ip, dst_ip, indx, usr, pwd, port=9200, timeout=8640
     print(f"source documents count: {src_docs_count}")
     dst_docs_count = 0
     interval = 10
-    while src_docs_count > dst_docs_count and timeout >= 0:
+    while timeout >= 0:
         # sleep first in order to allow index to be created at destination
         if src_docs_count > dst_docs_count:
             timeout -= interval


### PR DESCRIPTION
## Motivation
added sleep for CI tests to enable longer tests start earlier than shorter ones
