### PR TITLE
use last ticked layer to calculate ticker.timeSinceLastTick()

### DIFF
--- a/timesync/ticker.go
+++ b/timesync/ticker.go
@@ -145,7 +145,7 @@ func (t *Ticker) Notify() (int, error) {
 // TimeSinceLastTick returns the duration passed since the last layer that we ticked
 // note: the call is not lock-protected
 func (t *Ticker) timeSinceLastTick() time.Duration {
-	timeOfLastTick := t.LayerToTime(t.TimeToLayer(t.clock.Now()))
+	timeOfLastTick := t.LayerToTime(t.lastTickedLayer)
 	return t.clock.Now().Sub(timeOfLastTick)
 }
 

--- a/timesync/ticker_test.go
+++ b/timesync/ticker_test.go
@@ -1,11 +1,12 @@
 package timesync
 
 import (
-	"github.com/spacemeshos/go-spacemesh/common/types"
-	"github.com/stretchr/testify/require"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/stretchr/testify/require"
 )
 
 var conv = LayerConv{
@@ -75,7 +76,7 @@ func TestTicker_StartNotifying(t *testing.T) {
 	r.True(tr.started)
 	_, e = tr.Notify()
 	r.NoError(e)
-	r.Equal(3, mc.countToLayer)
+	r.Equal(2, mc.countToLayer)
 }
 
 func TestTicker_Notify(t *testing.T) {
@@ -143,7 +144,12 @@ func TestTicker_timeSinceLastTick(t *testing.T) {
 		duration: 100 * time.Millisecond,
 		genesis:  c.Now().Add(-320 * time.Millisecond),
 	})
-	r.True(tr.timeSinceLastTick() >= 20)
+	// 20ms is the diff between time.now() and start of the current layer i.e. t.LayerToTime(currentLayer)
+	sinceStartOfLayer := 20 * time.Millisecond
+	r.True(tr.timeSinceLastTick() == sinceStartOfLayer)
+	c.advance(sendTickThreshold)
+	r.True(tr.timeSinceLastTick() == sinceStartOfLayer+sendTickThreshold)
+
 }
 
 func TestTicker_AwaitLayer(t *testing.T) {


### PR DESCRIPTION
## Motivation
ticker.timeSinceLastTick() currently only returns the diff between time.now() and start of the current layer
the purpose of this utility function is to figure out whether our last ticked has be delayed by ticker.sendTickThreshold.
using ticker.lastTickedLayer to yield the current delay since last tick.

## Changes
use ticker.lastTickedLayer instead of converting time.Now() to layer number to calculate ticker.timeSinceLastTick() 

## Test Plan
added a test that failed before the change and passed after the change.

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
