### PR TITLE
[Merged by Bors] - continue processing a layer even when only one hash has blocks

### DIFF
--- a/layerfetcher/layers.go
+++ b/layerfetcher/layers.go
@@ -395,7 +395,7 @@ func (l *Logic) notifyLayerPromiseResult(id types.LayerID, expectedResults int, 
 func (l *Logic) receiveBlockHashes(ctx context.Context, layer types.LayerID, data []byte, expectedResults int, extErr error) {
 	//if we failed getting layer data - notify
 	if extErr != nil {
-		l.log.Error("received error %v for layer id %v", extErr, layer)
+		l.log.With().Error("received error", log.Err(extErr), layer)
 		l.notifyLayerPromiseResult(layer, expectedResults, extErr)
 		return
 	}

--- a/layerfetcher/layers_test.go
+++ b/layerfetcher/layers_test.go
@@ -234,7 +234,7 @@ func Test_receiveLayerHash(t *testing.T) {
 	// zero-block layer should not incur additional send
 	assert.Equal(t, 4, net.sendCalled)
 
-	// test two many errors
+	// test giving up on too many errors (numErrors > peers/2)
 	l.receiveLayerHash(context.TODO(), 1, net.peers[0], numOfPeers, hashRes.Bytes(), nil)
 	for i := 1; i < numOfPeers; i++ {
 		l.receiveLayerHash(context.TODO(), 1, net.peers[i], numOfPeers, nil, fmt.Errorf("error"))
@@ -257,7 +257,7 @@ func Test_notifyLayerPromiseResult_AllHaveData(t *testing.T) {
 	l.notifyLayerPromiseResult(layer, 3, nil)
 	res := <-result
 	assert.Equal(t, layer, res.Layer)
-	assert.Equal(t, nil, res.Err)
+	assert.Nil(t, res.Err)
 }
 
 func Test_notifyLayerPromiseResult_OneHasBlockData(t *testing.T) {


### PR DESCRIPTION
## Motivation
the code, as is, doesn't work when we receive layer blocks in the following order
t1: for layer hash1, we receive valid block data (err == nil)
t2: for layer hash2, we receive error 
sync.getLayerFromNeighbors() will determine there is error for this layer and stop processing.

## Changes
- make sync process a layer as long as there is a layer hash that returns non-empty blocks
- when there is an empty layer hash, and all other layer hashes return errors, determine this layer as empty

## Test Plan
added several unit tests. in particular, `Test_notifyLayerPromiseResult_OneHasBlockData()` fails before this change.

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
