### PR TITLE
[Merged by Bors] - Use uint32 to work with network id

### DIFF
--- a/api/grpcserver/mesh_service.go
+++ b/api/grpcserver/mesh_service.go
@@ -19,7 +19,7 @@ type MeshService struct {
 	Mempool          api.MempoolAPI
 	GenTime          api.GenesisTimeAPI
 	LayersPerEpoch   int
-	NetworkID        int8
+	NetworkID        uint32
 	LayerDurationSec int
 	LayerAvgSize     int
 	TxsPerBlock      int
@@ -33,7 +33,7 @@ func (s MeshService) RegisterService(server *Server) {
 // NewMeshService creates a new service using config data
 func NewMeshService(
 	tx api.TxAPI, mempool api.MempoolAPI, genTime api.GenesisTimeAPI,
-	layersPerEpoch int, networkID int8, layerDurationSec int,
+	layersPerEpoch int, networkID uint32, layerDurationSec int,
 	layerAvgSize int, txsPerBlock int) *MeshService {
 	return &MeshService{
 		Mesh:             tx,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -88,7 +88,7 @@ func AddCommands(cmd *cobra.Command) {
 		config.P2P.DialTimeout, "Network dial timeout duration")
 	cmd.PersistentFlags().DurationVar(&config.P2P.ConnKeepAlive, "conn-keepalive",
 		config.P2P.ConnKeepAlive, "Network connection keep alive")
-	cmd.PersistentFlags().Int8Var(&config.P2P.NetworkID, "network-id",
+	cmd.PersistentFlags().Uint32Var(&config.P2P.NetworkID, "network-id",
 		config.P2P.NetworkID, "NetworkID to run on (0 - mainnet, 1 - testnet)")
 	cmd.PersistentFlags().DurationVar(&config.P2P.ResponseTimeout, "response-timeout",
 		config.P2P.ResponseTimeout, "Timeout for waiting on response message")

--- a/p2p/config/config.go
+++ b/p2p/config/config.go
@@ -47,7 +47,7 @@ type Config struct {
 	NodeID                string        `mapstructure:"node-id"`
 	DialTimeout           time.Duration `mapstructure:"dial-timeout"`
 	ConnKeepAlive         time.Duration `mapstructure:"conn-keepalive"`
-	NetworkID             int8          `mapstructure:"network-id"`
+	NetworkID             uint32        `mapstructure:"network-id"`
 	ResponseTimeout       time.Duration `mapstructure:"response-timeout"`
 	SessionTimeout        time.Duration `mapstructure:"session-timeout"`
 	MaxPendingConnections int           `mapstructure:"max-pending-connections"`

--- a/p2p/net/conn.go
+++ b/p2p/net/conn.go
@@ -3,12 +3,13 @@ package net
 import (
 	"context"
 	"errors"
+	"time"
+
 	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/p2p/config"
 	"github.com/spacemeshos/go-spacemesh/p2p/metrics"
 	"github.com/spacemeshos/go-spacemesh/p2p/net/wire/delimited"
 	"github.com/spacemeshos/go-spacemesh/p2p/p2pcrypto"
-	"time"
 
 	"fmt"
 	"io"
@@ -89,7 +90,7 @@ type networker interface {
 	EnqueueMessage(ctx context.Context, ime IncomingMessageEvent)
 	SubscribeClosingConnections(func(context.Context, ConnectionWithErr))
 	publishClosingConnection(c ConnectionWithErr)
-	NetworkID() int8
+	NetworkID() uint32
 }
 
 type readWriteCloseAddresser interface {

--- a/p2p/net/conn_test.go
+++ b/p2p/net/conn_test.go
@@ -4,15 +4,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/spacemeshos/go-spacemesh/config"
-	"github.com/spacemeshos/go-spacemesh/p2p/p2pcrypto"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"net"
 	"runtime"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/spacemeshos/go-spacemesh/config"
+	"github.com/spacemeshos/go-spacemesh/p2p/p2pcrypto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var msgSizeLimit = config.DefaultTestConfig().P2P.MsgSizeLimit

--- a/p2p/net/handshake.go
+++ b/p2p/net/handshake.go
@@ -3,6 +3,6 @@ package net
 // HandshakeData is the handshake message struct
 type HandshakeData struct {
 	ClientVersion string
-	NetworkID     int32
+	NetworkID     uint32
 	Port          uint16
 }

--- a/p2p/net/network_mock.go
+++ b/p2p/net/network_mock.go
@@ -2,12 +2,13 @@ package net
 
 import (
 	"context"
-	"github.com/spacemeshos/go-spacemesh/log"
-	"github.com/spacemeshos/go-spacemesh/p2p/p2pcrypto"
-	"github.com/spacemeshos/go-spacemesh/rand"
 	"net"
 	"sync/atomic"
 	"time"
+
+	"github.com/spacemeshos/go-spacemesh/log"
+	"github.com/spacemeshos/go-spacemesh/p2p/p2pcrypto"
+	"github.com/spacemeshos/go-spacemesh/rand"
 )
 
 // ReadWriteCloserMock is a mock of ReadWriteCloserMock
@@ -50,7 +51,7 @@ type NetworkMock struct {
 	preSessionErr    error
 	preSessionCount  int32
 	regNewRemoteConn []func(NewConnectionEvent)
-	networkID        int8
+	networkID        uint32
 	closingConn      []func(context.Context, ConnectionWithErr)
 	incomingMessages []chan IncomingMessageEvent
 	dialSessionID    []byte
@@ -140,7 +141,7 @@ func (n NetworkMock) PublishClosingConnection(con ConnectionWithErr) {
 }
 
 // NetworkID is netid
-func (n *NetworkMock) NetworkID() int8 {
+func (n *NetworkMock) NetworkID() uint32 {
 	return n.networkID
 }
 

--- a/p2p/net/udp.go
+++ b/p2p/net/udp.go
@@ -4,14 +4,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/spacemeshos/go-spacemesh/log"
-	"github.com/spacemeshos/go-spacemesh/p2p/config"
-	"github.com/spacemeshos/go-spacemesh/p2p/node"
-	"github.com/spacemeshos/go-spacemesh/p2p/p2pcrypto"
 	"net"
 	"strconv"
 	"sync"
 	"time"
+
+	"github.com/spacemeshos/go-spacemesh/log"
+	"github.com/spacemeshos/go-spacemesh/p2p/config"
+	"github.com/spacemeshos/go-spacemesh/p2p/node"
+	"github.com/spacemeshos/go-spacemesh/p2p/p2pcrypto"
 )
 
 // TODO: we should remove this const. Should  not depend on the number of addresses.
@@ -206,7 +207,7 @@ func (n *UDPNet) EnqueueMessage(ctx context.Context, ime IncomingMessageEvent) {
 }
 
 // NetworkID returns the network id given and used for creating a session.
-func (n *UDPNet) NetworkID() int8 {
+func (n *UDPNet) NetworkID() uint32 {
 	return 0
 }
 

--- a/p2p/udp.go
+++ b/p2p/udp.go
@@ -4,18 +4,18 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/spacemeshos/go-spacemesh/common/types"
-	"github.com/spacemeshos/go-spacemesh/p2p/config"
-	"github.com/spacemeshos/go-spacemesh/p2p/connectionpool"
-	"github.com/spacemeshos/go-spacemesh/p2p/version"
 	"net"
 	"time"
 
+	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/log"
+	"github.com/spacemeshos/go-spacemesh/p2p/config"
+	"github.com/spacemeshos/go-spacemesh/p2p/connectionpool"
 	inet "github.com/spacemeshos/go-spacemesh/p2p/net"
 	"github.com/spacemeshos/go-spacemesh/p2p/node"
 	"github.com/spacemeshos/go-spacemesh/p2p/p2pcrypto"
 	"github.com/spacemeshos/go-spacemesh/p2p/service"
+	"github.com/spacemeshos/go-spacemesh/p2p/version"
 )
 
 // Lookuper is a service used to lookup for nodes we know already
@@ -34,7 +34,7 @@ type UDPMux struct {
 	logger log.Log
 
 	local     node.LocalNode
-	networkid int8
+	networkid uint32
 
 	cpool    cPool
 	lookuper Lookuper
@@ -45,7 +45,7 @@ type UDPMux struct {
 }
 
 // NewUDPMux creates a new udp protocol server
-func NewUDPMux(ctx, shutdownCtx context.Context, localNode node.LocalNode, lookuper Lookuper, udpNet udpNetwork, networkid int8, logger log.Log) *UDPMux {
+func NewUDPMux(ctx, shutdownCtx context.Context, localNode node.LocalNode, lookuper Lookuper, udpNet udpNetwork, networkid uint32, logger log.Log) *UDPMux {
 	cpool := connectionpool.NewConnectionPool(shutdownCtx, udpNet.Dial, localNode.PublicKey(), logger.WithName("udp_cpool"))
 
 	um := &UDPMux{


### PR DESCRIPTION
## Motivation
Int8 is too short and forces reuse of the same ids for testnets.
Closes: https://github.com/spacemeshos/go-spacemesh/issues/2113

## Changes
- NetworkID is stored internally as uint32 instead of int8.
- handshake data will use uint32 instead of int32 for consistency

## Test Plan
Existing unit and system tests.

## TODO
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [ ] Update documentation as needed

## DevOps Notes
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
