### PR TITLE
[Merged by Bors] - Use latest received layer in NodeService.Status response during genesis

### DIFF
--- a/api/grpcserver/grpcserver_test.go
+++ b/api/grpcserver/grpcserver_test.go
@@ -567,9 +567,9 @@ func TestNodeService(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, uint64(0), res.Status.ConnectedPeers)
 			require.Equal(t, false, res.Status.IsSynced)
-			require.Equal(t, uint32(layerCurrent), res.Status.SyncedLayer.Number)
+			require.Equal(t, uint32(layerLatest), res.Status.SyncedLayer.Number)
 			require.Equal(t, uint32(layerCurrent), res.Status.TopLayer.Number)
-			require.Equal(t, uint32(layerCurrent), res.Status.VerifiedLayer.Number)
+			require.Equal(t, uint32(layerLatest), res.Status.VerifiedLayer.Number)
 
 			// Now do a mock check post-genesis
 			layerCurrent = oldCurLayer

--- a/api/grpcserver/node_service.go
+++ b/api/grpcserver/node_service.go
@@ -91,8 +91,8 @@ func (s NodeService) getLayers() (curLayer, latestLayer, verifiedLayer uint32) {
 	curLayerObj := s.GenTime.GetCurrentLayer()
 	curLayer = uint32(curLayerObj)
 	if curLayerObj.GetEpoch().IsGenesis() {
-		latestLayer = curLayer
-		verifiedLayer = curLayer
+		latestLayer = uint32(s.Mesh.LatestLayer())
+		verifiedLayer = latestLayer
 	} else {
 		latestLayer = uint32(s.Mesh.LatestLayer())
 		verifiedLayer = uint32(s.Mesh.LatestLayerInState())


### PR DESCRIPTION
## Motivation
Closes https://github.com/spacemeshos/go-spacemesh/issues/2333

## Changes
During genesis, NodeService Status will return the latest received layer as the Synced and Verified layer.

## Test Plan
Existing tests

## TODO
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [ ] Update documentation as needed

## DevOps 
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
