### PR TITLE
[Merged by Bors] - syncer rewrite

### DIFF
--- a/activation/activation.go
+++ b/activation/activation.go
@@ -121,7 +121,7 @@ type layerClock interface {
 }
 
 type syncer interface {
-	AwaitSynced() chan struct{}
+	RegisterChForSynced(context.Context, chan struct{})
 }
 
 // NewBuilder returns an atx builder that will start a routine that will attempt to create an atx upon each new layer.
@@ -223,8 +223,10 @@ func (b *Builder) loop(ctx context.Context) {
 	}
 }
 
-func (b *Builder) buildNipstChallenge() error {
-	<-b.syncer.AwaitSynced()
+func (b *Builder) buildNipstChallenge(ctx context.Context) error {
+	syncedCh := make(chan struct{})
+	b.syncer.RegisterChForSynced(ctx, syncedCh)
+	<-syncedCh
 	challenge := &types.NIPSTChallenge{NodeID: b.nodeID}
 	atxID, pubLayerID, endTick, err := b.GetPositioningAtxInfo()
 	if err != nil {
@@ -384,7 +386,7 @@ func (b *Builder) PublishActivationTx(ctx context.Context) error {
 		b.log.With().Info("using existing atx challenge", b.currentEpoch())
 	} else {
 		b.log.With().Info("building new atx challenge", b.currentEpoch())
-		err := b.buildNipstChallenge()
+		err := b.buildNipstChallenge(ctx)
 		if err != nil {
 			b.log.With().Error("failed to build new atx challenge", log.Err(err))
 			return err
@@ -434,7 +436,9 @@ func (b *Builder) PublishActivationTx(ctx context.Context) error {
 	// we need to provide number of atx seen in the epoch of the positioning atx.
 
 	// ensure we are synced before generating the ATX's view
-	if err := b.waitOrStop(b.syncer.AwaitSynced()); err != nil {
+	syncedCh := make(chan struct{})
+	b.syncer.RegisterChForSynced(ctx, syncedCh)
+	if err := b.waitOrStop(syncedCh); err != nil {
 		return err
 	}
 
@@ -460,10 +464,12 @@ func (b *Builder) PublishActivationTx(ctx context.Context) error {
 	case <-atxReceived:
 		b.log.Info("atx received in db")
 	case <-b.layerClock.AwaitLayer((atx.TargetEpoch() + 1).FirstLayer()):
+		syncedCh := make(chan struct{})
+		b.syncer.RegisterChForSynced(ctx, syncedCh)
 		select {
 		case <-atxReceived:
 			b.log.Info("atx received in db (in the last moment)")
-		case <-b.syncer.AwaitSynced(): // ensure we've seen all blocks before concluding that the ATX was lost
+		case <-syncedCh: // ensure we've seen all blocks before concluding that the ATX was lost
 			b.log.With().Error("target epoch has passed before atx was added to database", atx.ID())
 			b.discardChallenge()
 			return fmt.Errorf("target epoch has passed")

--- a/activation/activation_test.go
+++ b/activation/activation_test.go
@@ -255,7 +255,9 @@ func (l *LayerClockMock) AwaitLayer(types.LayerID) chan struct{} {
 
 type mockSyncer struct{}
 
-func (m *mockSyncer) AwaitSynced() chan struct{} { return closedChan }
+func (m *mockSyncer) RegisterChForSynced(_ context.Context, ch chan struct{}) {
+	close(ch)
+}
 
 func newBuilder(activationDb atxDBProvider) *Builder {
 	net.atxDb = activationDb
@@ -724,7 +726,7 @@ func TestBuilder_NipstPublishRecovery(t *testing.T) {
 	assert.Equal(t, bts, net.lastTransmission)
 
 	b = NewBuilder(bc, id, 0, &MockSigning{}, activationDb, &FaultyNetMock{}, layers, layersPerEpoch, nipstBuilder, postProver, layerClockMock, &mockSyncer{}, db, lg.WithName("atxBuilder"))
-	err = b.buildNipstChallenge()
+	err = b.buildNipstChallenge(context.TODO())
 	assert.NoError(t, err)
 	db.hadNone = false
 	// test load challenge in later epoch - Nipst should be truncated

--- a/activation/activation_test.go
+++ b/activation/activation_test.go
@@ -255,7 +255,7 @@ func (l *LayerClockMock) AwaitLayer(types.LayerID) chan struct{} {
 
 type mockSyncer struct{}
 
-func (m *mockSyncer) Await() chan struct{} { return closedChan }
+func (m *mockSyncer) AwaitSynced() chan struct{} { return closedChan }
 
 func newBuilder(activationDb atxDBProvider) *Builder {
 	net.atxDb = activationDb

--- a/activation/atxdb.go
+++ b/activation/atxdb.go
@@ -734,11 +734,11 @@ func (db *DB) ValidateSignedAtx(pubKey signing.PublicKey, signedAtx *types.Activ
 }
 
 // HandleGossipAtx handles the atx gossip data channel
-func (db *DB) HandleGossipAtx(ctx context.Context, data service.GossipMessage, syncer service.Fetcher) {
+func (db *DB) HandleGossipAtx(ctx context.Context, data service.GossipMessage, fetcher service.Fetcher) {
 	if data == nil {
 		return
 	}
-	err := db.HandleAtxData(ctx, data.Bytes(), syncer)
+	err := db.HandleAtxData(ctx, data.Bytes(), fetcher)
 	if err != nil {
 		db.log.WithContext(ctx).With().Error("error handling atx data", log.Err(err))
 		return
@@ -747,7 +747,7 @@ func (db *DB) HandleGossipAtx(ctx context.Context, data service.GossipMessage, s
 }
 
 // HandleAtxData handles atxs received either by gossip or sync
-func (db *DB) HandleAtxData(ctx context.Context, data []byte, syncer service.Fetcher) error {
+func (db *DB) HandleAtxData(ctx context.Context, data []byte, fetcher service.Fetcher) error {
 	atx, err := types.BytesToAtx(data)
 	if err != nil {
 		return fmt.Errorf("cannot parse incoming atx")
@@ -763,12 +763,12 @@ func (db *DB) HandleAtxData(ctx context.Context, data []byte, syncer service.Fet
 		return fmt.Errorf("nil nipst in gossip")
 	}
 
-	if err := syncer.GetPoetProof(ctx, atx.GetPoetProofRef()); err != nil {
+	if err := fetcher.GetPoetProof(ctx, atx.GetPoetProofRef()); err != nil {
 		return fmt.Errorf("received atx (%v) with syntactically invalid or missing PoET proof (%x): %v",
 			atx.ShortString(), atx.GetPoetProofRef().ShortString(), err)
 	}
 
-	if err := db.FetchAtxReferences(ctx, atx, syncer); err != nil {
+	if err := db.FetchAtxReferences(ctx, atx, fetcher); err != nil {
 		return fmt.Errorf("received ATX with missing references of prev or pos id %v, %v, %v, %v",
 			atx.ID().ShortString(), atx.PrevATXID.ShortString(), atx.PositioningATX.ShortString(), log.Err(err))
 	}

--- a/blocks/blocks.go
+++ b/blocks/blocks.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/p2p/service"
@@ -62,7 +63,7 @@ func NewBlockHandler(cfg Config, m mesh, v blockValidator, lg log.Log) *BlockHan
 }
 
 // HandleBlock handles blocks from gossip
-func (bh *BlockHandler) HandleBlock(ctx context.Context, data service.GossipMessage, sync service.Fetcher) {
+func (bh *BlockHandler) HandleBlock(ctx context.Context, data service.GossipMessage, fetcher service.Fetcher) {
 	// restore the request ID and add context
 	if data.RequestID() != "" {
 		ctx = log.WithRequestID(ctx, data.RequestID())
@@ -71,7 +72,7 @@ func (bh *BlockHandler) HandleBlock(ctx context.Context, data service.GossipMess
 		bh.WithContext(ctx).Warning("got block from gossip with no requestId, generated new id")
 	}
 
-	if err := bh.HandleBlockData(ctx, data.Bytes(), sync); err != nil {
+	if err := bh.HandleBlockData(ctx, data.Bytes(), fetcher); err != nil {
 		bh.WithContext(ctx).With().Error("error handling block data", log.Err(err))
 		return
 	}
@@ -79,7 +80,7 @@ func (bh *BlockHandler) HandleBlock(ctx context.Context, data service.GossipMess
 }
 
 // HandleBlockData handles blocks from gossip and sync
-func (bh *BlockHandler) HandleBlockData(ctx context.Context, data []byte, sync service.Fetcher) error {
+func (bh *BlockHandler) HandleBlockData(ctx context.Context, data []byte, fetcher service.Fetcher) error {
 	var blk types.Block
 	if err := types.BytesToInterface(data, &blk); err != nil {
 		bh.WithContext(ctx).With().Error("received invalid block", log.Err(err))
@@ -96,7 +97,7 @@ func (bh *BlockHandler) HandleBlockData(ctx context.Context, data []byte, sync s
 	}
 	logger.With().Info("got new block", blk.Fields()...)
 
-	if err := bh.blockSyntacticValidation(ctx, &blk, sync); err != nil {
+	if err := bh.blockSyntacticValidation(ctx, &blk, fetcher); err != nil {
 		logger.With().Error("failed to validate block", log.Err(err))
 		return fmt.Errorf("failed to validate block %v", err)
 	}
@@ -121,7 +122,7 @@ func combineBlockDiffs(blk types.Block) []types.BlockID {
 	return append(blk.ForDiff, append(blk.AgainstDiff, blk.NeutralDiff...)...)
 }
 
-func (bh BlockHandler) blockSyntacticValidation(ctx context.Context, block *types.Block, syncer service.Fetcher) error {
+func (bh BlockHandler) blockSyntacticValidation(ctx context.Context, block *types.Block, fetcher service.Fetcher) error {
 	// Add layer to context, for logging purposes, since otherwise the context will be lost here below
 	if reqID, ok := log.ExtractRequestID(ctx); ok {
 		ctx = log.WithRequestID(ctx, reqID, block.Layer())
@@ -131,14 +132,14 @@ func (bh BlockHandler) blockSyntacticValidation(ctx context.Context, block *type
 
 	// if there is a reference block - first validate it
 	if block.RefBlock != nil {
-		err := syncer.FetchBlock(ctx, *block.RefBlock)
+		err := fetcher.FetchBlock(ctx, *block.RefBlock)
 		if err != nil {
 			return fmt.Errorf("failed to fetch ref block %v e: %v", *block.RefBlock, err)
 		}
 	}
 
 	// try fetch referenced ATXs
-	err := bh.fetchAllReferencedAtxs(ctx, block, syncer)
+	err := bh.fetchAllReferencedAtxs(ctx, block, fetcher)
 	if err != nil {
 		return err
 	}
@@ -151,14 +152,14 @@ func (bh BlockHandler) blockSyntacticValidation(ctx context.Context, block *type
 
 	// get the TXs
 	if len(block.TxIDs) > 0 {
-		err := syncer.GetTxs(ctx, block.TxIDs)
+		err := fetcher.GetTxs(ctx, block.TxIDs)
 		if err != nil {
 			return fmt.Errorf("failed to fetch txs %v e: %v", block.ID(), err)
 		}
 	}
 
 	// get and validate blocks views using the fetch
-	err = syncer.GetBlocks(ctx, combineBlockDiffs(*block))
+	err = fetcher.GetBlocks(ctx, combineBlockDiffs(*block))
 	if err != nil {
 		return fmt.Errorf("failed to fetch view %v e: %v", block.ID(), err)
 	}
@@ -167,7 +168,7 @@ func (bh BlockHandler) blockSyntacticValidation(ctx context.Context, block *type
 	return nil
 }
 
-func (bh *BlockHandler) fetchAllReferencedAtxs(ctx context.Context, blk *types.Block, syncer service.Fetcher) error {
+func (bh *BlockHandler) fetchAllReferencedAtxs(ctx context.Context, blk *types.Block, fetcher service.Fetcher) error {
 	bh.WithContext(ctx).With().Debug("block handler fetching all atxs referenced by block", blk.ID())
 
 	// As block with empty or Golden ATXID is considered syntactically invalid, explicit check is not needed here.
@@ -185,7 +186,7 @@ func (bh *BlockHandler) fetchAllReferencedAtxs(ctx context.Context, blk *types.B
 		}
 	}
 	if len(atxs) > 0 {
-		return syncer.GetAtxs(ctx, atxs)
+		return fetcher.GetAtxs(ctx, atxs)
 	}
 	return nil
 }

--- a/cmd/sync/mocks.go
+++ b/cmd/sync/mocks.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"context"
+	"math/big"
+	"time"
+
+	"github.com/golang/protobuf/ptypes/duration"
+	"github.com/spacemeshos/go-spacemesh/activation"
+	"github.com/spacemeshos/go-spacemesh/blocks"
+	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/database"
+	"github.com/spacemeshos/go-spacemesh/fetch"
+	"github.com/spacemeshos/go-spacemesh/layerfetcher"
+	"github.com/spacemeshos/go-spacemesh/log"
+	"github.com/spacemeshos/go-spacemesh/mesh"
+	"github.com/spacemeshos/go-spacemesh/p2p/service"
+	"github.com/spacemeshos/go-spacemesh/signing"
+	"github.com/spacemeshos/go-spacemesh/state"
+	"github.com/spacemeshos/go-spacemesh/syncer"
+	"github.com/spacemeshos/go-spacemesh/timesync"
+)
+
+type blockEligibilityValidatorMock struct{}
+
+func (blockEligibilityValidatorMock) BlockSignedAndEligible(*types.Block) (bool, error) {
+	return true, nil
+}
+
+type meshValidatorMock struct {
+	delay           time.Duration
+	calls           int
+	layers          *mesh.Mesh
+	vl              types.LayerID // the validated layer
+	countValidated  int
+	countValidate   int
+	validatedLayers map[types.LayerID]struct{}
+}
+
+func (m *meshValidatorMock) LatestComplete() types.LayerID { return m.vl }
+func (m *meshValidatorMock) Persist() error                { return nil }
+func (m *meshValidatorMock) HandleIncomingLayer(lyr *types.Layer) (types.LayerID, types.LayerID) {
+	m.countValidate++
+	m.calls++
+	m.vl = lyr.Index()
+	if m.validatedLayers == nil {
+		m.validatedLayers = make(map[types.LayerID]struct{})
+	}
+	m.validatedLayers[lyr.Index()] = struct{}{}
+	time.Sleep(m.delay)
+	return lyr.Index(), lyr.Index() - 1
+}
+func (m *meshValidatorMock) HandleLateBlock(bl *types.Block) (types.LayerID, types.LayerID) {
+	return bl.Layer(), bl.Layer() - 1
+}
+
+type mockState struct{}
+
+func (s mockState) ValidateAndAddTxToPool(_ *types.Transaction) error                { panic("implement me") }
+func (s mockState) LoadState(types.LayerID) error                                    { return nil }
+func (s mockState) GetStateRoot() types.Hash32                                       { return [32]byte{} }
+func (mockState) ValidateNonceAndBalance(*types.Transaction) error                   { panic("implement me") }
+func (mockState) GetLayerStateRoot(_ types.LayerID) (types.Hash32, error)            { panic("implement me") }
+func (mockState) GetLayerApplied(types.TransactionID) *types.LayerID                 { panic("implement me") }
+func (mockState) ApplyTransactions(types.LayerID, []*types.Transaction) (int, error) { return 0, nil }
+func (mockState) ApplyRewards(types.LayerID, []types.Address, *big.Int)              {}
+func (mockState) GetBalance(types.Address) uint64                                    { panic("implement me") }
+func (mockState) GetNonce(types.Address) uint64                                      { panic("implement me") }
+func (mockState) AddressExists(types.Address) bool                                   { return true }
+func (mockState) GetAllAccounts() (*types.MultipleAccountsState, error)              { panic("implement me") }
+
+type mockIStore struct{}
+
+func (*mockIStore) StoreNodeIdentity(types.NodeID) error { return nil }
+func (*mockIStore) GetIdentity(string) (types.NodeID, error) {
+	return types.NodeID{Key: "some string ", VRFPublicKey: []byte("bytes")}, nil
+}
+
+type validatorMock struct{}
+
+func (*validatorMock) Validate(signing.PublicKey, *types.NIPST, uint64, types.Hash32) error {
+	return nil
+}
+func (*validatorMock) VerifyPost(signing.PublicKey, *types.PostProof, uint64) error { return nil }
+
+type mockClock struct {
+	ch         map[timesync.LayerTimer]int
+	ids        map[int]timesync.LayerTimer
+	countSub   int
+	countUnsub int
+	Interval   duration.Duration
+	Layer      types.LayerID
+}
+
+func (m *mockClock) LayerToTime(types.LayerID) time.Time {
+	return time.Now().Add(1000 * time.Hour) // hack so this wont take affect in the mock
+}
+func (m *mockClock) Tick() {
+	l := m.GetCurrentLayer()
+	log.Info("tick %v", l)
+	for _, c := range m.ids {
+		c <- l
+	}
+}
+func (m *mockClock) GetCurrentLayer() types.LayerID { return m.Layer }
+func (m *mockClock) Subscribe() timesync.LayerTimer {
+	m.countSub++
+
+	if m.ch == nil {
+		m.ch = make(map[timesync.LayerTimer]int)
+		m.ids = make(map[int]timesync.LayerTimer)
+	}
+	newCh := make(chan types.LayerID, 1)
+	m.ch[newCh] = len(m.ch)
+	m.ids[len(m.ch)] = newCh
+
+	return newCh
+}
+func (m *mockClock) Unsubscribe(timer timesync.LayerTimer) {
+	m.countUnsub++
+	delete(m.ids, m.ch[timer])
+	delete(m.ch, timer)
+}
+func configTst() mesh.Config {
+	return mesh.Config{
+		BaseReward: big.NewInt(5000),
+	}
+}
+
+type mockTxProcessor struct{}
+
+func (m mockTxProcessor) HandleTxSyncData(_ []byte) error { return nil }
+
+type allDbs struct {
+	atxdb       *activation.DB
+	atxdbStore  *database.LDBDatabase
+	poetDb      *activation.PoetDb
+	poetStorage database.Database
+	mshdb       *mesh.DB
+}
+
+func createMockMesh(dbs *allDbs, txpool *state.TxMempool, lg log.Log) *mesh.Mesh {
+	var msh *mesh.Mesh
+	if dbs.mshdb.PersistentData() {
+		lg.Info("persistent data found")
+		msh = mesh.NewRecoveredMesh(dbs.mshdb, dbs.atxdb, configTst(), &meshValidatorMock{}, txpool, &mockState{}, lg)
+	} else {
+		lg.Info("no persistent data found")
+		msh = mesh.NewMesh(dbs.mshdb, dbs.atxdb, configTst(), &meshValidatorMock{}, txpool, &mockState{}, lg)
+	}
+	return msh
+}
+
+func createMockFetcher(dbs *allDbs, msh *mesh.Mesh, swarm service.Service, lg log.Log) *layerfetcher.Logic {
+	blockHandler := blocks.NewBlockHandler(blocks.Config{Depth: 10}, msh, blockEligibilityValidatorMock{}, lg)
+
+	fCfg := fetch.DefaultConfig()
+	fetcher := fetch.NewFetch(context.TODO(), fCfg, swarm, lg)
+
+	lCfg := layerfetcher.Config{RequestTimeout: 20}
+	layerFetch := layerfetcher.NewLogic(context.TODO(), lCfg, blockHandler, dbs.atxdb, dbs.poetDb, dbs.atxdb, mockTxProcessor{}, swarm, fetcher, msh, lg)
+	layerFetch.AddDBs(dbs.mshdb.Blocks(), dbs.atxdbStore, dbs.mshdb.Transactions(), dbs.poetStorage, dbs.mshdb.InputVector())
+	return layerFetch
+}
+
+func createSyncer(conf syncer.Configuration, msh *mesh.Mesh, layerFetch *layerfetcher.Logic, expectedLayers types.LayerID, lg log.Log) *syncer.Syncer {
+	clock := mockClock{Layer: expectedLayers + 1}
+	lg.Info("current layer %v", clock.GetCurrentLayer())
+
+	layerFetch.Start()
+	return syncer.NewSyncer(context.TODO(), conf, &clock, msh, layerFetch, lg)
+}

--- a/cmd/sync/mocks.go
+++ b/cmd/sync/mocks.go
@@ -139,7 +139,7 @@ type allDbs struct {
 	mshdb       *mesh.DB
 }
 
-func createMockMesh(dbs *allDbs, txpool *state.TxMempool, lg log.Log) *mesh.Mesh {
+func createMeshWithMock(dbs *allDbs, txpool *state.TxMempool, lg log.Log) *mesh.Mesh {
 	var msh *mesh.Mesh
 	if dbs.mshdb.PersistentData() {
 		lg.Info("persistent data found")
@@ -151,7 +151,7 @@ func createMockMesh(dbs *allDbs, txpool *state.TxMempool, lg log.Log) *mesh.Mesh
 	return msh
 }
 
-func createMockFetcher(dbs *allDbs, msh *mesh.Mesh, swarm service.Service, lg log.Log) *layerfetcher.Logic {
+func createFetcherWithMock(dbs *allDbs, msh *mesh.Mesh, swarm service.Service, lg log.Log) *layerfetcher.Logic {
 	blockHandler := blocks.NewBlockHandler(blocks.Config{Depth: 10}, msh, blockEligibilityValidatorMock{}, lg)
 
 	fCfg := fetch.DefaultConfig()

--- a/cmd/sync/sync.go
+++ b/cmd/sync/sync.go
@@ -8,13 +8,10 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"cloud.google.com/go/storage"
-	"github.com/spf13/cobra"
-	"google.golang.org/api/iterator"
-	"google.golang.org/api/option"
-
 	"github.com/spacemeshos/go-spacemesh/activation"
 	cmdp "github.com/spacemeshos/go-spacemesh/cmd"
 	"github.com/spacemeshos/go-spacemesh/common/types"
@@ -24,9 +21,10 @@ import (
 	"github.com/spacemeshos/go-spacemesh/mesh"
 	"github.com/spacemeshos/go-spacemesh/p2p"
 	"github.com/spacemeshos/go-spacemesh/state"
-	"github.com/spacemeshos/go-spacemesh/sync"
-	"github.com/spacemeshos/go-spacemesh/timesync"
-	"strings"
+	"github.com/spacemeshos/go-spacemesh/syncer"
+	"github.com/spf13/cobra"
+	"google.golang.org/api/iterator"
+	"google.golang.org/api/option"
 )
 
 // Sync cmd
@@ -68,8 +66,9 @@ func init() {
 
 type syncApp struct {
 	*cmdp.BaseApp
-	sync  *sync.Syncer
-	clock *timesync.Ticker
+	sync   *syncer.Syncer
+	msh    *mesh.Mesh
+	logger log.Log
 }
 
 func newSyncApp() *syncApp {
@@ -79,11 +78,11 @@ func newSyncApp() *syncApp {
 func (app *syncApp) Cleanup() {
 	err := os.RemoveAll(app.Config.DataDir())
 	if err != nil {
-		app.sync.With().Error("failed to cleanup sync", log.Err(err))
+		app.logger.With().Error("failed to cleanup sync", log.Err(err))
 	}
 }
 
-func (app *syncApp) start(cmd *cobra.Command, args []string) {
+func (app *syncApp) start(_ *cobra.Command, _ []string) {
 	// start p2p services
 	lg := log.NewDefault("sync_test")
 	lg.With().Info("------------ Start sync test -----------",
@@ -105,18 +104,6 @@ func (app *syncApp) start(cmd *cobra.Command, args []string) {
 	}
 
 	goldenATXID := types.ATXID(types.HexToHash32(app.Config.GoldenATXID))
-
-	conf := sync.Configuration{
-		Concurrency:     4,
-		AtxsLimit:       200,
-		LayerSize:       app.Config.LayerAvgSize,
-		RequestTimeout:  time.Duration(app.Config.SyncRequestTimeout) * time.Millisecond,
-		SyncInterval:    2 * 60 * time.Millisecond,
-		Hdist:           app.Config.Hdist,
-		ValidationDelta: 30 * time.Second,
-		LayersPerEpoch:  uint16(app.Config.LayersPerEpoch),
-		GoldenATXID:     goldenATXID,
-	}
 	types.SetLayersPerEpoch(int32(app.Config.LayersPerEpoch))
 	lg.Info("local db path: %v layers per epoch: %v", path, app.Config.LayersPerEpoch)
 
@@ -146,17 +133,36 @@ func (app *syncApp) start(cmd *cobra.Command, args []string) {
 	}
 
 	txpool := state.NewTxMemPool()
-	atxpool := activation.NewAtxMemPool()
 
-	app.sync = sync.NewSyncWithMocks(atxdbStore, mshdb, txpool, atxpool, swarm, poetDb, conf, goldenATXID, types.LayerID(expectedLayers), poetDbStore)
+	app.logger = log.NewDefault("sync_test")
+	app.logger.Info("new sync tester")
+
+	layersPerEpoch := app.Config.LayersPerEpoch
+	atxdb := activation.NewDB(atxdbStore, &mockIStore{}, mshdb, uint16(layersPerEpoch), goldenATXID, &validatorMock{}, lg.WithOptions(log.Nop))
+	dbs := &allDbs{
+		atxdb:       atxdb,
+		atxdbStore:  atxdbStore,
+		poetDb:      poetDb,
+		poetStorage: poetDbStore,
+		mshdb:       mshdb,
+	}
+	msh := createMockMesh(dbs, txpool, app.logger)
+	app.msh = msh
+	layerFetch := createMockFetcher(dbs, msh, swarm, app.logger)
+	layerFetch.Start()
+	syncerConf := syncer.Configuration{
+		SyncInterval:    2 * 60 * time.Millisecond,
+		ValidationDelta: 30 * time.Second,
+	}
+	app.sync = createSyncer(syncerConf, msh, layerFetch, types.LayerID(expectedLayers), app.logger)
 	if err = swarm.Start(cmdp.Ctx); err != nil {
 		log.With().Panic("error starting p2p", log.Err(err))
 	}
 
-	i := conf.LayersPerEpoch * 2
+	i := layersPerEpoch * 2
 	for ; ; i++ {
 		lg.With().Info("getting layer", types.LayerID(i))
-		if lyr, err2 := app.sync.GetLayer(types.LayerID(i)); err2 != nil || lyr == nil {
+		if lyr, err2 := msh.GetLayer(types.LayerID(i)); err2 != nil || lyr == nil {
 			l := types.LayerID(i)
 			if l > types.GetEffectiveGenesis() {
 				lg.With().Info("finished loading layers from disk",
@@ -167,24 +173,25 @@ func (app *syncApp) start(cmd *cobra.Command, args []string) {
 			}
 		} else {
 			lg.With().Info("loaded layer from disk", types.LayerID(i))
-			app.sync.ValidateLayer(lyr)
+			msh.ValidateLayer(lyr)
 		}
 	}
 
 	sleep := time.Duration(10) * time.Second
 	lg.Info("wait %v sec", sleep)
-	app.sync.Start(cmdp.Ctx)
-	for app.sync.ProcessedLayer() < types.LayerID(expectedLayers) {
-		app.sync.ForceSync()
+	time.Sleep(sleep)
+	go app.sync.Start(cmdp.Ctx)
+	for msh.ProcessedLayer() < types.LayerID(expectedLayers) {
 		lg.Info("sleep for %v sec", 30)
+		app.sync.ForceSync(context.TODO())
 		time.Sleep(30 * time.Second)
-
 	}
 
 	lg.Event().Info("sync done",
 		log.String("node_id", app.BaseApp.Config.P2P.NodeID),
-		log.FieldNamed("verified_layers", app.sync.ProcessedLayer()),
+		log.FieldNamed("verified_layers", msh.ProcessedLayer()),
 	)
+	app.sync.Close()
 	for {
 		lg.Info("keep busy sleep for %v sec", 60)
 		time.Sleep(60 * time.Second)
@@ -264,7 +271,7 @@ func ensureDirExists(path string) error {
 func main() {
 	if err := cmd.Execute(); err != nil {
 		log.With().Info("error", log.Err(err))
-		fmt.Fprintln(os.Stderr, err)
+		_, _ = fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }

--- a/cmd/sync/sync.go
+++ b/cmd/sync/sync.go
@@ -146,9 +146,9 @@ func (app *syncApp) start(_ *cobra.Command, _ []string) {
 		poetStorage: poetDbStore,
 		mshdb:       mshdb,
 	}
-	msh := createMockMesh(dbs, txpool, app.logger)
+	msh := createMeshWithMock(dbs, txpool, app.logger)
 	app.msh = msh
-	layerFetch := createMockFetcher(dbs, msh, swarm, app.logger)
+	layerFetch := createFetcherWithMock(dbs, msh, swarm, app.logger)
 	layerFetch.Start()
 	syncerConf := syncer.Configuration{
 		SyncInterval:    2 * 60 * time.Millisecond,

--- a/cmd/sync/sync_test.go
+++ b/cmd/sync/sync_test.go
@@ -1,10 +1,11 @@
 package main
 
 import (
-	"github.com/spacemeshos/go-spacemesh/log"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/spacemeshos/go-spacemesh/log"
 )
 
 func TestSpacemeshApp_TestSyncCmd(t *testing.T) {
@@ -42,7 +43,7 @@ func TestSpacemeshApp_TestSyncCmd(t *testing.T) {
 			t.Error("timed out ")
 			return
 		default:
-			if syncApp.sync.ProcessedLayer() > 20 {
+			if syncApp.msh.ProcessedLayer() > 20 {
 				t.Log("done!")
 				return
 			}

--- a/miner/block_builder.go
+++ b/miner/block_builder.go
@@ -30,8 +30,6 @@ type signer interface {
 }
 
 type syncer interface {
-	GetPoetProof(ctx context.Context, poetProofRef types.Hash32) error
-	ListenToGossip() bool
 	IsSynced(context.Context) bool
 }
 

--- a/p2p/service/gossip_listener.go
+++ b/p2p/service/gossip_listener.go
@@ -2,14 +2,15 @@ package service
 
 import (
 	"context"
+	"sync"
+
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/priorityq"
-	"sync"
 )
 
 // GossipDataHandler is the function type that will be called when data is
-type GossipDataHandler func(ctx context.Context, data GossipMessage, syncer Fetcher)
+type GossipDataHandler func(ctx context.Context, data GossipMessage, fetcher Fetcher)
 
 type enableGossipFunc func() bool
 
@@ -19,29 +20,20 @@ type Listener struct {
 	net                  Service
 	channels             []chan GossipMessage
 	stoppers             []chan struct{}
-	syncer               Fetcher
+	fetcher              Fetcher
 	wg                   sync.WaitGroup
 	shouldListenToGossip enableGossipFunc
 }
 
 // NewListener creates a new listener struct
-func NewListener(net Service, syncer Fetcher, shouldListenToGossip enableGossipFunc, log log.Log) *Listener {
+func NewListener(net Service, fetcher Fetcher, shouldListenToGossip enableGossipFunc, log log.Log) *Listener {
 	return &Listener{
 		Log:                  &log,
 		net:                  net,
-		syncer:               syncer,
+		fetcher:              fetcher,
 		shouldListenToGossip: shouldListenToGossip,
 		wg:                   sync.WaitGroup{},
 	}
-}
-
-// Syncer is interface for sync services
-type Syncer interface {
-	FetchAtxReferences(context.Context, *types.ActivationTx) error
-	FetchPoetProof(ctx context.Context, poetProofRef []byte) error
-	ListenToGossip() bool
-	GetBlock(ID types.BlockID) (*types.Block, error)
-	IsSynced(context.Context) bool
 }
 
 // Fetcher is a general interface that defines a component capable of fetching data from remote peers
@@ -52,8 +44,6 @@ type Fetcher interface {
 	GetTxs(context.Context, []types.TransactionID) error
 	GetBlocks(context.Context, []types.BlockID) error
 	GetAtxs(context.Context, []types.ATXID) error
-	ListenToGossip() bool
-	IsSynced(context.Context) bool
 }
 
 // AddListener adds a listener to a specific gossip channel
@@ -87,7 +77,7 @@ func (l *Listener) listenToGossip(ctx context.Context, dataHandler GossipDataHan
 				// not accepting data
 				continue
 			}
-			dataHandler(log.WithNewRequestID(ctx), data, l.syncer)
+			dataHandler(log.WithNewRequestID(ctx), data, l.fetcher)
 		}
 	}
 }

--- a/state/processor.go
+++ b/state/processor.go
@@ -15,7 +15,6 @@ import (
 	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/mesh"
 	"github.com/spacemeshos/go-spacemesh/p2p/service"
-	"github.com/spacemeshos/go-spacemesh/priorityq"
 	"github.com/spacemeshos/go-spacemesh/trie"
 )
 
@@ -32,11 +31,6 @@ type PreImages struct {
 // mem pool
 type Projector interface {
 	GetProjection(addr types.Address, prevNonce, prevBalance uint64) (nonce, balance uint64, err error)
-}
-
-// Gossip is the interface to Gossip network provider
-type Gossip interface {
-	AddListener(channel string, priority priorityq.Priority, dataHandler func(data service.GossipMessage, syncer service.Syncer))
 }
 
 // TransactionProcessor is the struct containing state db and is responsible for applying transactions into it

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -1,0 +1,402 @@
+package syncer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/events"
+	"github.com/spacemeshos/go-spacemesh/layerfetcher"
+	"github.com/spacemeshos/go-spacemesh/log"
+	"github.com/spacemeshos/go-spacemesh/mesh"
+)
+
+type layerTicker interface {
+	GetCurrentLayer() types.LayerID
+	LayerToTime(types.LayerID) time.Time
+}
+
+type layerFetcher interface {
+	PollLayer(ctx context.Context, id types.LayerID) chan layerfetcher.LayerPromiseResult
+	GetEpochATXs(ctx context.Context, id types.EpochID) error
+}
+
+// Configuration is the config params for syncer
+type Configuration struct {
+	SyncInterval time.Duration
+	// the sync process will try validate the current layer if ValidationDelta has elapsed.
+	ValidationDelta time.Duration
+	AlwaysListen    bool
+}
+
+const (
+	outOfSyncThreshold  types.LayerID = 2 // see notSynced
+	numGossipSyncLayers types.LayerID = 2 // see gossipSync
+)
+
+type syncState uint32
+
+const (
+	// notSynced is the state where the node is outOfSyncThreshold layers or more behind the current layer.
+	notSynced syncState = iota
+	// gossipSync is the state in which a node listens to at least one full layer of gossip before participating
+	// in the protocol. this is to protect the node from participating in the consensus without full information.
+	// for example, when a node wakes up in the middle of layer N, since it didn't receive all relevant messages and
+	// blocks of layer N, it shouldn't vote or produce blocks in layer N+1. it instead listens to gossip for all of
+	// layer N+1 and starts producing blocks and participates in hare committee in layer N+2
+	gossipSync
+	// synced is the phase where we are 2 layers or more behind the current layer
+	synced
+)
+
+func (s *syncState) String() string {
+	switch *s {
+	case 0:
+		return "notSynced"
+	case 1:
+		return "gossipSync"
+	case 2:
+		return "synced"
+	default:
+		return "unknown"
+	}
+}
+
+// Syncer is responsible to keep the node in sync with the network.
+type Syncer struct {
+	logger log.Log
+
+	conf      Configuration
+	ticker    layerTicker
+	mesh      *mesh.Mesh
+	fetcher   layerFetcher
+	syncOnce  sync.Once
+	syncState syncState
+	isBusy    uint32
+	syncTimer *time.Ticker
+	// targetSyncedLayer is used to signal at which layer we can set this node to synced state
+	targetSyncedLayer types.LayerID
+	// awaitSyncedCh is used to notify subscribes that this node is synced
+	awaitSyncedCh chan struct{}
+	awaitSyncedMu sync.Mutex
+
+	shutdownCtx context.Context
+	cancelFunc  context.CancelFunc
+
+	// recording the run # since started. for logging/debugging only.
+	run uint64
+}
+
+// NewSyncer creates a new Syncer instance.
+func NewSyncer(ctx context.Context, conf Configuration, ticker layerTicker, mesh *mesh.Mesh, fetcher layerFetcher, logger log.Log) *Syncer {
+	shutdownCtx, cancel := context.WithCancel(ctx)
+	return &Syncer{
+		logger:        logger,
+		conf:          conf,
+		ticker:        ticker,
+		mesh:          mesh,
+		fetcher:       fetcher,
+		syncState:     notSynced,
+		syncTimer:     time.NewTicker(conf.SyncInterval),
+		awaitSyncedCh: make(chan struct{}),
+		shutdownCtx:   shutdownCtx,
+		cancelFunc:    cancel,
+	}
+}
+
+// Close stops the syncing process and the goroutines syncer spawns.
+func (s *Syncer) Close() {
+	// TODO: ensure goroutines are all terminated before shutting down
+	s.cancelFunc()
+}
+
+// AwaitSynced returns the channel that will be notified whenever the node enters synced state.
+func (s *Syncer) AwaitSynced() chan struct{} {
+	s.awaitSyncedMu.Lock()
+	defer s.awaitSyncedMu.Unlock()
+	return s.awaitSyncedCh
+}
+
+// ListenToGossip returns true if the node is listening to gossip for blocks/TXs/ATXs data.
+func (s *Syncer) ListenToGossip() bool {
+	return s.conf.AlwaysListen || s.getSyncState() >= gossipSync
+}
+
+// IsSynced returns true if the nodes is fully in sync with the network.
+func (s *Syncer) IsSynced(ctx context.Context) bool {
+	res := s.getSyncState() == synced
+	s.logger.WithContext(ctx).With().Info("node sync state",
+		log.Bool("synced", res),
+		log.FieldNamed("current", s.ticker.GetCurrentLayer()),
+		log.FieldNamed("latest", s.mesh.LatestLayer()),
+		log.FieldNamed("validated", s.mesh.ProcessedLayer()))
+	return res
+}
+
+// Start starts the main sync loop that tries to sync data for every SyncInterval.
+func (s *Syncer) Start(ctx context.Context) {
+	s.syncOnce.Do(func() {
+		if s.ticker.GetCurrentLayer() == 0 {
+			s.setSyncState(ctx, synced)
+		}
+		for {
+			select {
+			case <-s.shutdownCtx.Done():
+				s.logger.WithContext(ctx).Info("stopping sync to shutdown")
+				return
+			case <-s.syncTimer.C:
+				s.synchronize(ctx)
+			}
+		}
+	})
+}
+
+// ForceSync manually start a sync process outside the main sync loop. If the node is already running a sync process,
+// ForceSync will be ignored.
+func (s *Syncer) ForceSync(ctx context.Context) {
+	s.logger.WithContext(ctx).Debug("executing ForceSync")
+	go s.synchronize(ctx)
+}
+
+func (s *Syncer) isClosed() bool {
+	select {
+	case <-s.shutdownCtx.Done():
+		return true
+	default:
+		return false
+	}
+}
+
+func (s *Syncer) getSyncState() syncState {
+	return (syncState)(atomic.LoadUint32((*uint32)(&s.syncState)))
+}
+
+func (s *Syncer) setSyncState(ctx context.Context, newState syncState) {
+	oldState := syncState(atomic.SwapUint32((*uint32)(&s.syncState), uint32(newState)))
+	if oldState != newState {
+		s.logger.WithContext(ctx).With().Info("sync state change",
+			log.String("from", oldState.String()),
+			log.String("to", newState.String()),
+			log.FieldNamed("current", s.ticker.GetCurrentLayer()),
+			log.FieldNamed("latest", s.mesh.LatestLayer()),
+			log.FieldNamed("validated", s.mesh.ProcessedLayer()))
+		events.ReportNodeStatusUpdate()
+		// notify subscribes
+		s.awaitSyncedMu.Lock()
+		defer s.awaitSyncedMu.Unlock()
+		if newState == synced {
+			close(s.awaitSyncedCh)
+		} else if oldState == synced {
+			s.awaitSyncedCh = make(chan struct{})
+		}
+	}
+}
+
+// startNewSyncProcess returns true if syncer is not currently synchronizing.
+func (s *Syncer) startNewSyncProcess() bool {
+	return atomic.CompareAndSwapUint32(&s.isBusy, 0, 1)
+}
+
+func (s *Syncer) endSyncProcess() {
+	atomic.StoreUint32(&s.isBusy, 0)
+}
+
+func (s *Syncer) setTargetSyncedLayer(ctx context.Context, layerID types.LayerID) {
+	newSyncLayer := uint64(layerID)
+	oldSyncLayer := atomic.SwapUint64((*uint64)(&s.targetSyncedLayer), newSyncLayer)
+	s.logger.WithContext(ctx).With().Info("target synced layer changed",
+		log.Uint64("from", oldSyncLayer),
+		log.Uint64("to", newSyncLayer),
+		log.FieldNamed("current", s.ticker.GetCurrentLayer()),
+		log.FieldNamed("latest", s.mesh.LatestLayer()),
+		log.FieldNamed("validated", s.mesh.ProcessedLayer()))
+}
+
+func (s *Syncer) getTargetSyncedLayer() types.LayerID {
+	return types.LayerID(atomic.LoadUint64((*uint64)(&s.targetSyncedLayer)))
+}
+
+func (s *Syncer) synchronize(ctx context.Context) bool {
+	logger := s.logger.WithContext(ctx)
+
+	if s.isClosed() {
+		logger.Warning("attempting to sync while shutting down")
+		return false
+	}
+
+	// at most one synchronize process can run at any time
+	if !s.startNewSyncProcess() {
+		logger.Info("sync is already running, giving up")
+		return false
+	}
+	// no need to worry about race condition for s.run. only one instance of synchronize can run at a time
+	s.run++
+	logger.Info("staring sync run #%v", s.run)
+
+	s.setStateBeforeSync(ctx)
+	// start a dedicated process for validation.
+	// do not use a unbuffered channel for vQueue. we don't want it to block if the receiver isn't ready. i.e.
+	// if validation for the last layer is still running
+	vQueue := make(chan *types.Layer, s.ticker.GetCurrentLayer())
+	vDone := make(chan struct{})
+	go s.startValidating(ctx, s.run, vQueue, vDone)
+	defer func() {
+		close(vQueue)
+		<-vDone
+		logger.With().Info("node is synced. validation done",
+			log.FieldNamed("current", s.ticker.GetCurrentLayer()),
+			log.FieldNamed("latest", s.mesh.LatestLayer()),
+			log.FieldNamed("validated", s.mesh.ProcessedLayer()))
+		logger.Info("finished sync run #%v", s.run)
+		s.endSyncProcess()
+	}()
+
+	// using ProcessedLayer() instead of LatestLayer() so we can validate layers on a best-efforts basis.
+	// TODO: is it safe to skip layer 0
+	for layerID := s.mesh.ProcessedLayer() + 1; layerID <= s.ticker.GetCurrentLayer(); layerID++ {
+		var layer *types.Layer
+		var err error
+		if layer, err = s.syncLayer(ctx, layerID); err != nil {
+			logger.With().Error("failed to sync to layer", log.Err(err))
+			return false
+		}
+
+		if len(layer.Blocks()) == 0 {
+			logger.Info("setting layer %v to zero-block", layerID)
+			if err := s.mesh.SetZeroBlockLayer(layerID); err != nil {
+				logger.With().Error("failed to set zero-block for layer", layerID, log.Err(err))
+				return false
+			}
+		}
+
+		if s.shouldValidateLayer(layerID) {
+			vQueue <- layer
+		}
+		logger.Info("finished data sync for layer %v", layerID)
+	}
+	s.setStateAfterSync(ctx)
+	logger.With().Info("node is synced. waiting for validation",
+		log.FieldNamed("current", s.ticker.GetCurrentLayer()),
+		log.FieldNamed("latest", s.mesh.LatestLayer()),
+		log.FieldNamed("validated", s.mesh.ProcessedLayer()))
+	return true
+}
+
+func (s *Syncer) setStateBeforeSync(ctx context.Context) {
+	current := s.ticker.GetCurrentLayer()
+	if current == 0 {
+		s.setSyncState(ctx, synced)
+	}
+	latest := s.mesh.LatestLayer()
+	if current > latest && current-latest >= outOfSyncThreshold {
+		s.logger.WithContext(ctx).With().Info("node is too far behind",
+			log.FieldNamed("current", current),
+			log.FieldNamed("latest", latest),
+			log.FieldNamed("behindThreshold", outOfSyncThreshold))
+		s.setSyncState(ctx, notSynced)
+	}
+}
+
+func (s *Syncer) setStateAfterSync(ctx context.Context) {
+	currSyncState := s.getSyncState()
+	current := s.ticker.GetCurrentLayer()
+	// if we have gossip-synced to the target synced layer, we are ready to participate in the consensus
+	if currSyncState == gossipSync && s.getTargetSyncedLayer() <= current {
+		s.setSyncState(ctx, synced)
+	} else if currSyncState == notSynced {
+		// wait till s.ticker.GetCurrentLayer() + numGossipSyncLayers to participate in consensus
+		s.setSyncState(ctx, gossipSync)
+		s.setTargetSyncedLayer(ctx, current+numGossipSyncLayers)
+	}
+}
+
+func (s *Syncer) syncLayer(ctx context.Context, layerID types.LayerID) (*types.Layer, error) {
+	if s.isClosed() {
+		return nil, errors.New("shutdown")
+	}
+
+	layer, err := s.getLayerFromPeers(ctx, layerID)
+	if err != nil {
+		s.logger.WithContext(ctx).With().Error("failed to get layer from neighbors", layerID, log.Err(err))
+		return nil, err
+	}
+
+	s.getATXs(ctx, layerID)
+	return layer, nil
+}
+
+func (s *Syncer) getLayerFromPeers(ctx context.Context, layerID types.LayerID) (*types.Layer, error) {
+	ch := s.fetcher.PollLayer(ctx, layerID)
+	res := <-ch
+	if res.Err != nil {
+		if res.Err == layerfetcher.ErrZeroLayer {
+			return types.NewLayer(layerID), nil
+		}
+		return nil, res.Err
+	}
+	return s.mesh.GetLayer(layerID)
+}
+
+func (s *Syncer) getATXs(ctx context.Context, layerID types.LayerID) {
+	if layerID.GetEpoch() == 0 {
+		s.logger.WithContext(ctx).Info("skip getting ATX in epoch 0")
+		return
+	}
+	lastLayerOfEpoch := (layerID.GetEpoch() + 1).FirstLayer() - 1
+	if layerID != lastLayerOfEpoch {
+		return
+	}
+	ctx = log.WithNewRequestID(ctx, layerID.GetEpoch())
+	if err := s.fetcher.GetEpochATXs(ctx, layerID.GetEpoch()); err != nil {
+		// TODO: is this really expected? we should have ATXs in epoch 1
+		if layerID.GetEpoch().IsGenesis() {
+			s.logger.WithContext(ctx).With().Info("failed to fetch epoch ATXs (expected during genesis)",
+				layerID,
+				log.Err(err))
+		} else {
+			s.logger.WithContext(ctx).With().Error("failed to fetch epoch ATXs", layerID, log.Err(err))
+		}
+	}
+}
+
+// always returns true if layerID is an old layer.
+// for current layer, only returns true if current layer already elapsed ValidationDelta
+func (s *Syncer) shouldValidateLayer(layerID types.LayerID) bool {
+	if layerID == 0 {
+		return false
+	}
+	current := s.ticker.GetCurrentLayer()
+	return layerID < current || time.Now().Sub(s.ticker.LayerToTime(current)) > s.conf.ValidationDelta
+}
+
+// start a dedicated process to validate layers one by one
+func (s *Syncer) startValidating(ctx context.Context, run uint64, queue chan *types.Layer, done chan struct{}) {
+	logger := s.logger.WithName("validation")
+	logger.Info("validation started for run #%v", run)
+	defer func() {
+		logger.Info("validation done for run #%v", run)
+		done <- struct{}{}
+	}()
+	for layer := range queue {
+		if s.isClosed() {
+			return
+		}
+		s.validateLayer(ctx, layer)
+	}
+}
+
+func (s *Syncer) validateLayer(ctx context.Context, layer *types.Layer) {
+	if s.isClosed() {
+		s.logger.WithContext(ctx).Error("shutting down")
+		return
+	}
+
+	s.logger.WithContext(ctx).With().Info("validating layer",
+		layer.Index(),
+		log.String("blocks", fmt.Sprint(types.BlockIDs(layer.Blocks()))))
+	s.mesh.ValidateLayer(layer)
+}

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -53,13 +53,13 @@ const (
 	synced
 )
 
-func (s *syncState) String() string {
-	switch *s {
-	case 0:
+func (s syncState) String() string {
+	switch s {
+	case notSynced:
 		return "notSynced"
-	case 1:
+	case gossipSync:
 		return "gossipSync"
-	case 2:
+	case synced:
 		return "synced"
 	default:
 		return "unknown"
@@ -259,7 +259,9 @@ func (s *Syncer) synchronize(ctx context.Context) bool {
 	defer func() {
 		close(vQueue)
 		<-vDone
-		logger.With().Info("node is synced. validation done",
+		logger.With().Info("validation done",
+			log.Bool("success", success),
+			log.String("sync_state", s.getSyncState().String()),
 			log.FieldNamed("current", s.ticker.GetCurrentLayer()),
 			log.FieldNamed("latest", s.mesh.LatestLayer()),
 			log.FieldNamed("validated", s.mesh.ProcessedLayer()))

--- a/syncer/syncer_test.go
+++ b/syncer/syncer_test.go
@@ -1,0 +1,405 @@
+package syncer
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/spacemeshos/go-spacemesh/layerfetcher"
+
+	"github.com/spacemeshos/go-spacemesh/activation"
+	"github.com/spacemeshos/go-spacemesh/log"
+
+	"github.com/spacemeshos/go-spacemesh/database"
+	"github.com/spacemeshos/go-spacemesh/mesh"
+
+	"github.com/spacemeshos/go-spacemesh/common/types"
+)
+
+const (
+	layersPerEpoch = 3
+)
+
+func init() {
+	types.SetLayersPerEpoch(layersPerEpoch)
+}
+
+type mockLayerTicker struct {
+	now            time.Time
+	current        types.LayerID
+	layerStartTime time.Time
+}
+
+func newMockLayerTicker() *mockLayerTicker {
+	return &mockLayerTicker{}
+}
+func (mlt *mockLayerTicker) advanceToLayer(layerID types.LayerID) {
+	atomic.StoreUint64((*uint64)(&mlt.current), uint64(layerID))
+}
+func (mlt *mockLayerTicker) GetCurrentLayer() types.LayerID {
+	return types.LayerID(atomic.LoadUint64((*uint64)(&mlt.current)))
+}
+func (mlt *mockLayerTicker) LayerToTime(_ types.LayerID) time.Time {
+	return mlt.layerStartTime
+}
+
+type mockFetcher struct {
+	mu     sync.Mutex
+	polled map[types.LayerID]chan struct{}
+	result map[types.LayerID]chan layerfetcher.LayerPromiseResult
+}
+
+func newMockFetcher() *mockFetcher {
+	numLayers := layersPerEpoch * 5
+	polled := make(map[types.LayerID]chan struct{}, numLayers)
+	result := make(map[types.LayerID]chan layerfetcher.LayerPromiseResult, numLayers)
+	for i := 0; i <= numLayers; i++ {
+		polled[types.LayerID(i)] = make(chan struct{}, 10)
+		result[types.LayerID(i)] = make(chan layerfetcher.LayerPromiseResult, 10)
+	}
+	return &mockFetcher{result: result, polled: polled}
+}
+func (mf *mockFetcher) PollLayer(_ context.Context, layerID types.LayerID) chan layerfetcher.LayerPromiseResult {
+	mf.mu.Lock()
+	defer mf.mu.Unlock()
+	mf.polled[layerID] <- struct{}{}
+	return mf.result[layerID]
+}
+func (mf *mockFetcher) GetEpochATXs(_ context.Context, _ types.EpochID) error { return nil }
+func (mf *mockFetcher) getLayerPollChan(layerID types.LayerID) chan struct{} {
+	mf.mu.Lock()
+	defer mf.mu.Unlock()
+	return mf.polled[layerID]
+}
+func (mf *mockFetcher) getLayerResultChan(layerID types.LayerID) chan layerfetcher.LayerPromiseResult {
+	mf.mu.Lock()
+	defer mf.mu.Unlock()
+	return mf.result[layerID]
+}
+func (mf *mockFetcher) feedLayerResult(from, to types.LayerID) {
+	for i := from; i <= to; i++ {
+		err := layerfetcher.ErrZeroLayer
+		if i == types.GetEffectiveGenesis() {
+			err = nil
+		}
+		mf.getLayerResultChan(i) <- layerfetcher.LayerPromiseResult{
+			Layer: i,
+			Err:   err,
+		}
+	}
+}
+
+type mockValidator struct{}
+
+func (mv *mockValidator) LatestComplete() types.LayerID { return 0 }
+func (mv *mockValidator) Persist() error                { return nil }
+func (mv *mockValidator) HandleIncomingLayer(layer *types.Layer) (types.LayerID, types.LayerID) {
+	return layer.Index(), layer.Index() - 1
+}
+func (mv *mockValidator) HandleLateBlock(block *types.Block) (types.LayerID, types.LayerID) {
+	return block.Layer(), block.Layer() - 1
+}
+
+func newMemMesh(lg log.Log) *mesh.Mesh {
+	memdb := mesh.NewMemMeshDB(lg.WithName("meshDB"))
+	atxStore := database.NewMemDatabase()
+	goldenATXID := types.ATXID(types.HexToHash32("77777"))
+	atxdb := activation.NewDB(atxStore, activation.NewIdentityStore(database.NewMemDatabase()), memdb, layersPerEpoch, goldenATXID, nil, log.NewDefault("storeAtx").WithName("atxDB"))
+	return mesh.NewMesh(memdb, atxdb, mesh.Config{}, &mockValidator{}, nil, nil, lg.WithName("mesh"))
+}
+
+var conf = Configuration{
+	SyncInterval:    100 * time.Millisecond,
+	ValidationDelta: 30 * time.Millisecond,
+	AlwaysListen:    false,
+}
+
+func TestStartAndShutdown(t *testing.T) {
+	lg := log.NewDefault("syncer")
+	ticker := newMockLayerTicker()
+	ctx, cancel := context.WithCancel(context.TODO())
+	syncer := NewSyncer(ctx, conf, ticker, newMemMesh(lg), newMockFetcher(), lg)
+
+	assert.False(t, syncer.IsSynced(context.TODO()))
+	assert.False(t, syncer.ListenToGossip())
+
+	// the node is synced when current layer is 0
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		syncer.Start(context.TODO())
+		wg.Done()
+	}()
+	<-syncer.AwaitSynced()
+	assert.True(t, syncer.IsSynced(context.TODO()))
+	assert.True(t, syncer.ListenToGossip())
+
+	cancel()
+	assert.True(t, syncer.isClosed())
+	assert.False(t, syncer.synchronize(context.TODO()))
+	wg.Wait()
+}
+
+func TestSynchronize_OnlyOneSynchronize(t *testing.T) {
+	lg := log.NewDefault("syncer")
+	ticker := newMockLayerTicker()
+	mf := newMockFetcher()
+	syncer := NewSyncer(context.TODO(), conf, ticker, newMemMesh(lg), mf, lg)
+	ticker.advanceToLayer(1)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	first, second := true, true
+	atLeastOneStarted := make(chan struct{}, 2)
+	go func() {
+		atLeastOneStarted <- struct{}{}
+		first = syncer.synchronize(context.TODO())
+		wg.Done()
+	}()
+	go func() {
+		atLeastOneStarted <- struct{}{}
+		second = syncer.synchronize(context.TODO())
+		wg.Done()
+	}()
+
+	// allow synchronize to finish
+	current := ticker.GetCurrentLayer()
+	<-atLeastOneStarted
+	mf.feedLayerResult(current, current)
+	wg.Wait()
+
+	// one of the synchronize call should fail
+	assert.False(t, first && second)
+	assert.Equal(t, uint64(1), syncer.run)
+}
+
+func TestSynchronize_AllGood(t *testing.T) {
+	lg := log.NewDefault("syncer")
+	ticker := newMockLayerTicker()
+	mf := newMockFetcher()
+	mm := newMemMesh(lg)
+	syncer := NewSyncer(context.TODO(), conf, ticker, mm, mf, lg)
+	ticker.advanceToLayer(mm.LatestLayer())
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		assert.True(t, syncer.synchronize(context.TODO()))
+		wg.Done()
+	}()
+
+	// allow synchronize to finish
+	mf.feedLayerResult(0, mm.LatestLayer())
+	wg.Wait()
+
+	assert.True(t, syncer.ListenToGossip())
+	assert.False(t, syncer.IsSynced(context.TODO()))
+}
+
+func TestSynchronize_SyncLayerFailed(t *testing.T) {
+	lg := log.NewDefault("syncer")
+	ticker := newMockLayerTicker()
+	mf := newMockFetcher()
+	mm := newMemMesh(lg)
+	syncer := NewSyncer(context.TODO(), conf, ticker, mm, mf, lg)
+	ticker.advanceToLayer(mm.LatestLayer())
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		assert.False(t, syncer.synchronize(context.TODO()))
+		wg.Done()
+	}()
+
+	// allow synchronize to finish
+	mf.getLayerResultChan(1) <- layerfetcher.LayerPromiseResult{
+		Layer: 1,
+		Err:   errors.New("something baaahhhhhhd"),
+	}
+	wg.Wait()
+
+	assert.False(t, syncer.ListenToGossip())
+	assert.False(t, syncer.IsSynced(context.TODO()))
+}
+
+func TestSynchronize_SyncZeroBlockFailed(t *testing.T) {
+	lg := log.NewDefault("syncer")
+	ticker := newMockLayerTicker()
+	mf := newMockFetcher()
+	mm := newMemMesh(lg)
+	syncer := NewSyncer(context.TODO(), conf, ticker, mm, mf, lg)
+	ticker.advanceToLayer(mm.LatestLayer())
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		assert.False(t, syncer.synchronize(context.TODO()))
+		wg.Done()
+	}()
+
+	gLayer := types.GetEffectiveGenesis()
+	mf.feedLayerResult(0, gLayer-1)
+	// genesis block has data. this LayerPromiseResult will cause SetZeroBlockLayer() to fail
+	mf.getLayerResultChan(gLayer) <- layerfetcher.LayerPromiseResult{
+		Layer: gLayer,
+		Err:   layerfetcher.ErrZeroLayer,
+	}
+	wg.Wait()
+
+	assert.False(t, syncer.ListenToGossip())
+	assert.False(t, syncer.IsSynced(context.TODO()))
+}
+
+// test the case where the node originally starts from notSynced and eventually becomes synced
+func TestFromNotSyncedToSynced(t *testing.T) {
+	lg := log.NewDefault("syncer")
+	ticker := newMockLayerTicker()
+	mf := newMockFetcher()
+	mm := newMemMesh(lg)
+	syncer := NewSyncer(context.TODO(), conf, ticker, mm, mf, lg)
+
+	assert.False(t, syncer.ListenToGossip())
+	assert.False(t, syncer.IsSynced(context.TODO()))
+
+	current := mm.LatestLayer()
+	ticker.advanceToLayer(current)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		assert.True(t, syncer.synchronize(context.TODO()))
+		wg.Done()
+	}()
+	mf.feedLayerResult(1, 1)
+	// wait till layer 1's content is requested to check whether sync state has changed
+	<-mf.getLayerPollChan(1)
+	// the node should remain not synced and not gossiping
+	assert.False(t, syncer.ListenToGossip())
+	assert.False(t, syncer.IsSynced(context.TODO()))
+	mf.feedLayerResult(2, current)
+	wg.Wait()
+	// node should be in gossip sync state
+	assert.True(t, syncer.ListenToGossip())
+	assert.False(t, syncer.IsSynced(context.TODO()))
+
+	waitOutGossipSync(t, current, syncer, ticker, mf)
+}
+
+// test the case where the node was originally synced, and somehow gets out of sync, but
+// eventually become synced again
+func TestFromSyncedToNotSynced(t *testing.T) {
+	lg := log.NewDefault("syncer")
+	ticker := newMockLayerTicker()
+	mf := newMockFetcher()
+	mm := newMemMesh(lg)
+	syncer := NewSyncer(context.TODO(), conf, ticker, mm, mf, lg)
+
+	assert.False(t, syncer.ListenToGossip())
+	assert.False(t, syncer.IsSynced(context.TODO()))
+
+	// the node is synced when it starts syncing when current layer is 0
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		assert.True(t, syncer.synchronize(context.TODO()))
+		wg.Done()
+	}()
+	<-syncer.AwaitSynced()
+	assert.True(t, syncer.IsSynced(context.TODO()))
+	// wait for the first synchronize to finish
+	wg.Wait()
+
+	// cause the syncer to get out of synced and then wait again
+	current := mm.LatestLayer() + outOfSyncThreshold
+	ticker.advanceToLayer(current)
+	wg.Add(1)
+	go func() {
+		assert.True(t, syncer.synchronize(context.TODO()))
+		wg.Done()
+	}()
+	mf.feedLayerResult(1, 1)
+	// wait till layer 1's content is requested to check whether sync state has changed
+	<-mf.getLayerPollChan(1)
+	// the node should realized it's behind now and set the node to be notSynced
+	assert.False(t, syncer.ListenToGossip())
+	assert.False(t, syncer.IsSynced(context.TODO()))
+
+	mf.feedLayerResult(2, current)
+	wg.Wait()
+	// node should be in gossip sync state
+	assert.True(t, syncer.ListenToGossip())
+	assert.False(t, syncer.IsSynced(context.TODO()))
+
+	waitOutGossipSync(t, current, syncer, ticker, mf)
+}
+
+func waitOutGossipSync(t *testing.T, current types.LayerID, syncer *Syncer, mlt *mockLayerTicker, mf *mockFetcher) {
+	assert.True(t, syncer.ListenToGossip())
+	assert.False(t, syncer.IsSynced(context.TODO()))
+
+	// next layer will be still gossip syncing
+	assert.Equal(t, types.LayerID(2), numGossipSyncLayers)
+	assert.Equal(t, current+numGossipSyncLayers, syncer.getTargetSyncedLayer())
+
+	var wg sync.WaitGroup
+	current++
+	mlt.advanceToLayer(current)
+	wg.Add(1)
+	go func() {
+		assert.True(t, syncer.synchronize(context.TODO()))
+		wg.Done()
+	}()
+	mf.feedLayerResult(syncer.mesh.ProcessedLayer()+1, current)
+	wg.Wait()
+	assert.True(t, syncer.ListenToGossip())
+	assert.False(t, syncer.IsSynced(context.TODO()))
+
+	// done one full layer of gossip sync, now it is synced
+	current++
+	mlt.advanceToLayer(current)
+	wg.Add(1)
+	go func() {
+		assert.True(t, syncer.synchronize(context.TODO()))
+		wg.Done()
+	}()
+	mf.feedLayerResult(syncer.mesh.ProcessedLayer()+1, current)
+	<-syncer.AwaitSynced()
+	assert.True(t, syncer.ListenToGossip())
+	assert.True(t, syncer.IsSynced(context.TODO()))
+	wg.Wait()
+}
+
+func TestForceSync(t *testing.T) {
+	lg := log.NewDefault("syncer")
+	syncer := NewSyncer(context.TODO(), conf, newMockLayerTicker(), newMemMesh(lg), newMockFetcher(), lg)
+
+	assert.False(t, syncer.ListenToGossip())
+	assert.False(t, syncer.IsSynced(context.TODO()))
+
+	syncer.ForceSync(context.TODO())
+	<-syncer.AwaitSynced()
+	assert.True(t, syncer.ListenToGossip())
+	assert.True(t, syncer.IsSynced(context.TODO()))
+}
+
+func TestShouldValidateLayer(t *testing.T) {
+	lg := log.NewDefault("syncer")
+	ticker := newMockLayerTicker()
+	syncer := NewSyncer(context.TODO(), conf, ticker, newMemMesh(lg), newMockFetcher(), lg)
+	assert.False(t, syncer.shouldValidateLayer(0))
+
+	ticker.advanceToLayer(3)
+	assert.False(t, syncer.shouldValidateLayer(0))
+	assert.True(t, syncer.shouldValidateLayer(1))
+	assert.True(t, syncer.shouldValidateLayer(2))
+	// current layer
+	ticker.layerStartTime = time.Now()
+	assert.False(t, syncer.shouldValidateLayer(3))
+	// but if current layer has elapsed ValidationDelta ms, we will validate
+	ticker.layerStartTime = time.Now().Add(-conf.ValidationDelta)
+	assert.True(t, syncer.shouldValidateLayer(3))
+}


### PR DESCRIPTION
## Motivation
Closes #2471

## Changes
simplify synchronize logic
- use one loop to capture both stead-state sync and catch up sync
- separate logic for data syncing and layer validation. this paves the road for parallelize data syncing while keeping validating layers in order

## Test Plan
unit test + make test + CI

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
