### PR TITLE
[Merged by Bors] - Raise kibana timeout from 30 to 240 seconds

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -265,7 +265,6 @@ def wait_for_minimal_elk_cluster_ready(namespace, es_ss_name=ES_SS_NAME,
 def get_kibana_ip(kibana_dep_name, namespace, retries=240, sleep_interval=1):
     def get_kibana_service(services_):
         for serv in services_.items:
-            print(serv.metadata.name)
             if serv.metadata.name == kibana_dep_name:
                 return serv
         return None
@@ -287,8 +286,6 @@ def get_kibana_ip(kibana_dep_name, namespace, retries=240, sleep_interval=1):
         kibana_service = get_kibana_service(services)
 
         if not kibana_service.status.load_balancer.ingress:
-            # Amit: sometimes service will be returned before being assigned with an IP address
-            print("KIBANA: service returned without ip address, retrying")
             time.sleep(sleep_interval)
             continue
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -262,7 +262,7 @@ def wait_for_minimal_elk_cluster_ready(namespace, es_ss_name=ES_SS_NAME,
     return es_sleep_time + kibana_sleep_time
 
 
-def get_kibana_ip(kibana_dep_name, namespace, retries=30, sleep_interval=1):
+def get_kibana_ip(kibana_dep_name, namespace, retries=240, sleep_interval=1):
     def get_kibana_service(services_):
         for serv in services_.items:
             print(serv.metadata.name)


### PR DESCRIPTION
## Motivation
Systemstests wait for IP assigned to kibana service by Google Cloud.
Sometimes it fails due to 30s timeout passed.

## Changes
Timeout raised from 30 to 240 seconds

## Test Plan
This should reduce the number of failures.

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)