### PR TITLE
Testnet hotfix: Warm active set cache for hare

### DIFF
--- a/hare/eligibility/oracle.go
+++ b/hare/eligibility/oracle.go
@@ -54,6 +54,7 @@ type Oracle struct {
 	genesisActiveSetSize int
 	blocksProvider       goodBlocksProvider
 	cfg                  eCfg.Config
+	lastSafeEpoch        types.EpochID
 	log.Log
 }
 
@@ -242,16 +243,45 @@ func (o *Oracle) Proof(ctx context.Context, layer types.LayerID, round int32) ([
 }
 
 // Returns a map of all active nodes in the specified layer id
-func (o *Oracle) actives(ctx context.Context, layer types.LayerID) (activeMap map[string]struct{}, err error) {
-	logger := o.WithContext(ctx)
+func (o *Oracle) actives(ctx context.Context, layer types.LayerID) (map[string]struct{}, error) {
 	sl := roundedSafeLayer(layer, types.LayerID(o.cfg.ConfidenceParam), o.layersPerEpoch, types.LayerID(o.cfg.EpochOffset))
 	safeEp := sl.GetEpoch()
+	logger := o.WithContext(ctx).WithFields(
+		log.FieldNamed("safe_layer", sl),
+		log.FieldNamed("safe_epoch", safeEp))
+	logger.With().Info("safe layer and epoch")
 
-	logger.With().Info("safe layer and epoch", sl, safeEp)
-	// check genesis
-	// genesis is for 3 epochs with hare since it can only count active identities found in blocks
-	if safeEp < 3 {
-		return nil, errGenesis
+	getBlocksAndActiveSet := func(ctx context.Context, safeLayer types.LayerID) (map[string]struct{}, error) {
+		logger := logger.WithContext(ctx)
+		// build a map of all blocks in the safe layer
+		mp, err := o.blocksProvider.ContextuallyValidBlock(sl)
+		if err != nil {
+			return nil, err
+		}
+
+		// no contextually valid blocks: for now we just fall back on an empty active set. this will go away when we
+		// upgrade hare eligibility to use the tortoise beacon.
+		if len(mp) == 0 {
+			logger.With().Warning("no contextually valid blocks in layer, using active set of size zero",
+				layer,
+				layer.GetEpoch(),
+				log.FieldNamed("safe_layer_id", sl),
+				log.FieldNamed("safe_epoch_id", safeEp))
+			return nil, nil
+		}
+
+		activeMap, err := o.getActiveSet(ctx, safeEp-1, mp)
+		if err != nil {
+			logger.With().Error("could not retrieve active set size",
+				log.Err(err),
+				layer,
+				layer.GetEpoch(),
+				log.FieldNamed("safe_layer_id", sl),
+				log.FieldNamed("safe_epoch_id", safeEp))
+			return nil, err
+		}
+
+		return activeMap, nil
 	}
 
 	// lock until any return
@@ -259,42 +289,48 @@ func (o *Oracle) actives(ctx context.Context, layer types.LayerID) (activeMap ma
 	o.lock.Lock()
 	defer o.lock.Unlock()
 
+	// check if we'll cross into a new safe epoch as of the next layer
+	slNext := roundedSafeLayer(layer.Add(1), types.LayerID(o.cfg.ConfidenceParam), o.layersPerEpoch, types.LayerID(o.cfg.EpochOffset))
+	if safeEp != slNext.GetEpoch() && o.lastSafeEpoch < slNext.GetEpoch() {
+		logger := logger.WithFields(log.FieldNamed("safe_epoch_next", slNext.GetEpoch()))
+		logger.Info("next layer will cross safe epoch boundary, warming active set cache")
+
+		// make sure we only run once for this epoch. this is thread safe since we are inside an exclusive lock.
+		o.lastSafeEpoch = slNext.GetEpoch()
+
+		go func(ctx context.Context) {
+			if activeMap, err := getBlocksAndActiveSet(ctx, slNext); err != nil {
+				logger.With().Error("error warming active set cache for next safe epoch", log.Err(err))
+			} else {
+				logger.With().Info("successfully warmed active set cache for next safe epoch",
+					log.Int("active_set_size", len(activeMap)))
+
+				// note: this may block on the outer method if that's still holding the lock, but there's no
+				// possibility of deadlock since it does not block on this goroutine.
+				o.lock.Lock()
+				defer o.lock.Unlock()
+				o.activesCache.Add(slNext.GetEpoch(), activeMap)
+			}
+		}(log.WithNewSessionID(ctx))
+	}
+
+	// check genesis
+	// genesis is for 3 epochs with hare since it can only count active identities found in blocks
+	if safeEp < 3 {
+		return nil, errGenesis
+	}
+
 	// check cache
 	if val, exist := o.activesCache.Get(safeEp); exist {
 		return val.(map[string]struct{}), nil
 	}
 
-	// build a map of all blocks on the current layer
-	mp, err2 := o.blocksProvider.ContextuallyValidBlock(sl)
-	if err2 != nil {
-		return nil, err2
-	}
-
-	// no contextually valid blocks: for now we just fall back on an empty active set. this will go away when we
-	// upgrade hare eligibility to use the tortoise beacon.
-	if len(mp) == 0 {
-		logger.With().Warning("no contextually valid blocks in layer, using active set of size zero",
-			layer,
-			layer.GetEpoch(),
-			log.FieldNamed("safe_layer_id", sl),
-			log.FieldNamed("safe_epoch_id", safeEp))
-		return
-	}
-
-	activeMap, err = o.getActiveSet(ctx, safeEp-1, mp)
+	activeMap, err := getBlocksAndActiveSet(ctx, sl)
 	if err != nil {
-		logger.With().Error("could not retrieve active set size",
-			log.Err(err),
-			layer,
-			layer.GetEpoch(),
-			log.FieldNamed("safe_layer_id", sl),
-			log.FieldNamed("safe_epoch_id", safeEp))
 		return nil, err
 	}
-
-	// update cache
 	o.activesCache.Add(safeEp, activeMap)
-	return
+	return activeMap, nil
 }
 
 // IsIdentityActiveOnConsensusView returns true if the provided identity is active on the consensus view derived

--- a/hare/eligibility/oracle_test.go
+++ b/hare/eligibility/oracle_test.go
@@ -560,17 +560,22 @@ func TestOracleActiveSetCacheWarming(t *testing.T) {
 		return mp, nil
 	}
 
-	firstLayer := types.LayerID(73)
+	// set firstLayer to two layers before a safe epoch boundary
+	r.Equal(2, cacheWarmingDistance)
+	firstLayer := types.LayerID(72)
 	sl1 := roundedSafeLayer(firstLayer, types.LayerID(o.cfg.ConfidenceParam), o.layersPerEpoch, types.LayerID(o.cfg.EpochOffset))
 	r.Equal(60, int(sl1))
 	sl2 := roundedSafeLayer(firstLayer.Add(1), types.LayerID(o.cfg.ConfidenceParam), o.layersPerEpoch, types.LayerID(o.cfg.EpochOffset))
 	r.Equal(60, int(sl2))
 	sl3 := roundedSafeLayer(firstLayer.Add(2), types.LayerID(o.cfg.ConfidenceParam), o.layersPerEpoch, types.LayerID(o.cfg.EpochOffset))
-	r.Equal(70, int(sl3))
+	r.Equal(60, int(sl3))
+	sl4 := roundedSafeLayer(firstLayer.Add(3), types.LayerID(o.cfg.ConfidenceParam), o.layersPerEpoch, types.LayerID(o.cfg.EpochOffset))
+	r.Equal(70, int(sl4))
 	r.Equal(int(sl1.GetEpoch()), int(sl2.GetEpoch()))
-	r.NotEqual(int(sl2.GetEpoch()), int(sl3.GetEpoch()))
+	r.Equal(int(sl2.GetEpoch()), int(sl3.GetEpoch()))
+	r.NotEqual(int(sl3.GetEpoch()), int(sl4.GetEpoch()))
 
-	// get active set two layers before transition to new safe epoch: no cache warming
+	// 3 layers before transition to new safe epoch: no cache warming
 	activeMap, err := o.actives(context.TODO(), firstLayer)
 	r.NoError(err)
 	r.Len(activeMap, mapSize)
@@ -578,7 +583,7 @@ func TestOracleActiveSetCacheWarming(t *testing.T) {
 	r.Equal(1, mc.numAdd)
 	r.Equal(1, mc.numGet)
 
-	// get active set one layer before transition to new safe epoch: should warm cache concurrently
+	// 2 layers before transition to new safe epoch: should warm cache concurrently
 	activeMap, err = o.actives(context.TODO(), firstLayer.Add(1))
 	r.NoError(err)
 	r.Len(activeMap, mapSize)
@@ -590,15 +595,33 @@ func TestOracleActiveSetCacheWarming(t *testing.T) {
 		return atomic.LoadInt32(&callCount) == int32(2) && mc.numAdd == 2
 	}, 2*time.Second, time.Millisecond*100)
 
-	// get active set first layer of new safe epoch: should be no delay
-	done := make(chan error)
+	// 1 layer before transition to new safe epoch: warming should've happened already
+	done1 := make(chan error)
 	go func() {
 		// should not block on active set generation
 		_, err = o.actives(context.TODO(), firstLayer.Add(2))
-		done <- err
+		done1 <- err
 	}()
 	select {
-	case err := <-done:
+	case err := <-done1:
+		t.Log("active set generation did not block")
+		r.NoError(err)
+	case <-time.After(500 * time.Millisecond):
+		r.Fail("timed out waiting for active set generation")
+	}
+	r.NoError(err)
+	r.Equal(2, mc.numAdd)
+	r.Equal(3, mc.numGet)
+
+	// get active set first layer of new safe epoch: should be no delay
+	done2 := make(chan error)
+	go func() {
+		// should not block on active set generation
+		_, err = o.actives(context.TODO(), firstLayer.Add(3))
+		done2 <- err
+	}()
+	select {
+	case err := <-done2:
 		t.Log("active set generation did not block")
 		r.NoError(err)
 	case <-time.After(500 * time.Millisecond):
@@ -606,5 +629,5 @@ func TestOracleActiveSetCacheWarming(t *testing.T) {
 	}
 	r.Equal(2, int(atomic.LoadInt32(&callCount)))
 	r.Equal(2, mc.numAdd)
-	r.Equal(3, mc.numGet)
+	r.Equal(4, mc.numGet)
 }


### PR DESCRIPTION
## Motivation
Testnet hotfix workaround for #2478

Unclear yet whether we want to apply this workaround to develop, or address the underlying issue in another way

## Changes
- When hare gets active set, it checks if it's near a safe epoch boundary, and if so, it warms the cache for the next layer/safe epoch ahead of time

## Test Plan
- Adds regression test

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [ ] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
