### PR TITLE
Raise kibana wait timeout

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -262,7 +262,7 @@ def wait_for_minimal_elk_cluster_ready(namespace, es_ss_name=ES_SS_NAME,
     return es_sleep_time + kibana_sleep_time
 
 
-def get_kibana_ip(kibana_dep_name, namespace, retries=240, sleep_interval=1):
+def get_kibana_ip(kibana_dep_name, namespace, retries=900, sleep_interval=1):
     def get_kibana_service(services_):
         for serv in services_.items:
             if serv.metadata.name == kibana_dep_name:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -248,7 +248,7 @@ def wait_for_minimal_elk_cluster_ready(namespace, es_ss_name=ES_SS_NAME,
         print("elasticsearch statefulset readiness check has failed with err:", e)
         raise Exception(f"elasticsearch took over than {es_timeout} to start")
 
-    kb_timeout = 240
+    kb_timeout = 900
     try:
         print("waiting for kibana to be ready")
         kibana_sleep_time = deployment.wait_to_deployment_to_be_ready(kibana_dep_name, namespace, time_out=kb_timeout)


### PR DESCRIPTION
## Motivation
Waiting 240s was not enough. Kibana pods are created on kibana-pool which is autoscaling.
It GKE need more instance in the pool it needs more time, that is why it takes more time.

## Changes
Raise kibana wait timeout from 240s to 900s

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
