### PR TITLE
[Merged by Bors] - Fix `make dockerpush` failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Inspired by https://container-solutions.com/faster-builds-in-docker-with-go-1-11/
 # Base build image
-FROM golang:1.15.13-alpine AS build_base
+FROM golang:1.15.13-alpine3.12 AS build_base
 RUN apk add bash make git curl unzip rsync libc6-compat gcc musl-dev lsof
 WORKDIR /go/src/github.com/spacemeshos/go-spacemesh
 


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
<!-- Closes # -->
<!-- `Closes #XXXX, closes #XXXX, ...` links mentioned issues to this PR and automatically closes them when this it's merged -->
`make dockerpush` fails with following errors:
1. `Could not find a Go installation, please install Go and try again.`
2.
```
Step 15/29 : RUN make build
 ---> Running in 98d655922daa
go build -ldflags "-X main.version= -X main.commit= -X main.branch=-dirty" -o /build/go-spacemesh
make: /bin/sh: Operation not permitted
make: git: Operation not permitted
make: git: Operation not permitted
make: git: Operation not permitted
make: cat: Operation not permitted
make: git: Operation not permitted
make: pwd: Operation not permitted
make: /bin/sh: Operation not permitted
make: *** [Makefile:108: build] Error 127
The command '/bin/sh -c make build' returned a non-zero code: 2
```

Some change in Alpine 3.14 causes those errors, so this PR sets its version to the previously used: 3.12

## Changes
<!-- Please describe in detail the changes made -->
Set Alpine version to 3.12 instead of latest

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
