### PR TITLE
[Merged by Bors] - Reduce verbosity of p2p logs

### DIFF
--- a/p2p/gossip/protocol.go
+++ b/p2p/gossip/protocol.go
@@ -178,14 +178,14 @@ func (p *Protocol) handlePQ(ctx context.Context) {
 		} else {
 			msgCtx = log.WithRequestID(ctx, m.RequestID(), extraFields...)
 		}
-		p.WithContext(msgCtx).With().Info("new_gossip_message_relay",
+		p.WithContext(msgCtx).With().Debug("new_gossip_message_relay",
 			log.Int("priority_queue_length", p.pq.Length()))
 		if p.pq.Length() > 50 {
 			p.WithContext(msgCtx).With().Warning("outbound gossip message queue backlog",
 				log.Int("priority_queue_length", p.pq.Length()))
 		}
 		p.propagateMessage(msgCtx, m.Message(), m.Protocol(), m.Sender())
-		p.WithContext(msgCtx).With().Info("finished propagating gossip message")
+		p.WithContext(msgCtx).With().Debug("finished propagating gossip message")
 	}
 }
 
@@ -224,7 +224,7 @@ func (p *Protocol) propagationEventLoop(ctx context.Context) {
 					log.Err(err),
 					log.String("protocol", msgV.Protocol()))
 			}
-			p.WithContext(ctx).With().Info("wrote inbound message to priority queue",
+			p.WithContext(ctx).With().Debug("wrote inbound message to priority queue",
 				log.String("protocol", msgV.Protocol()),
 				log.Int("priority_queue_length", p.pq.Length()),
 				log.Int("propagation_queue_length", len(p.propagateQ)))

--- a/p2p/service/gossip_listener.go
+++ b/p2p/service/gossip_listener.go
@@ -73,7 +73,7 @@ func (l *Listener) listenToGossip(ctx context.Context, dataHandler GossipDataHan
 			l.wg.Done()
 			return
 		case data := <-gossipChannel:
-			l.WithContext(ctx).With().Info("got gossip message, forwarding to data handler",
+			l.WithContext(ctx).With().Debug("got gossip message, forwarding to data handler",
 				log.String("protocol", channel),
 				log.Int("queue_length", len(gossipChannel)))
 			if !l.shouldListenToGossip() {


### PR DESCRIPTION
## Motivation
These were added in #2427 and carried over from testnet but we don't
need them to be so verbose

## Changes
Reduces verbosity of some log-level p2p logs

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
