### PR TITLE
[Merged by Bors] - remove MessageType duplication

### DIFF
--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -4,6 +4,9 @@ package fetch
 import (
 	"context"
 	"fmt"
+	"sync"
+	"time"
+
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/database"
 	"github.com/spacemeshos/go-spacemesh/log"
@@ -13,12 +16,20 @@ import (
 	"github.com/spacemeshos/go-spacemesh/p2p/server"
 	"github.com/spacemeshos/go-spacemesh/p2p/service"
 	"github.com/spacemeshos/go-spacemesh/rand"
-	"sync"
-	"time"
 )
 
 // Hint marks which DB should be queried for a certain provided hash
 type Hint string
+
+// DB hints per DB
+const (
+	BlockDB Hint = "blocksDB"
+	ATXDB   Hint = "ATXDB"
+	TXDB    Hint = "TXDB"
+	POETDB  Hint = "POETDB"
+	IVDB    Hint = "IVDB"
+	TBDB    Hint = "TBDB"
+)
 
 // priority defines whether Data will be fetched at once or batched and waited for up to "batchTimeout"
 // until fetched
@@ -33,9 +44,8 @@ const (
 )
 
 const (
-	fetch         server.MessageType = 1
-	fetchProtocol                    = "/sync/2.0/"
-	batchMaxSize                     = 20
+	fetchProtocol = "/sync/2.0/"
+	batchMaxSize  = 20
 )
 
 // ErrCouldNotSend is a special type of error indicating fetch could not be done because message could not be sent to peers
@@ -208,7 +218,7 @@ func NewFetch(ctx context.Context, cfg Config, network service.Service, logger l
 // Start starts handling fetch requests
 func (f *Fetch) Start() {
 	f.onlyOnce.Do(func() {
-		f.net.RegisterBytesMsgHandler(fetch, f.FetchRequestHandler)
+		f.net.RegisterBytesMsgHandler(server.Fetch, f.FetchRequestHandler)
 		go f.loop()
 	})
 }
@@ -471,7 +481,7 @@ func (f *Fetch) sendBatch(requests []requestMessage) {
 		// get random peer
 		p := GetRandomPeer(f.net.GetPeers())
 		f.log.Info("sending request batch %v items %v", batch.ID.Hex(), len(batch.Requests))
-		err := f.net.SendRequest(context.TODO(), fetch, bytes, p, f.receiveResponse, timeoutFunc)
+		err := f.net.SendRequest(context.TODO(), server.Fetch, bytes, p, f.receiveResponse, timeoutFunc)
 		// if call succeeded, continue to other requests
 		if err != nil {
 			retries++

--- a/p2p/discovery/ping.go
+++ b/p2p/discovery/ping.go
@@ -4,11 +4,11 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"github.com/spacemeshos/go-spacemesh/common/types"
-	"github.com/spacemeshos/go-spacemesh/log"
 	"net"
 	"time"
 
+	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/p2p/node"
 	"github.com/spacemeshos/go-spacemesh/p2p/p2pcrypto"
 	"github.com/spacemeshos/go-spacemesh/p2p/server"
@@ -89,7 +89,7 @@ func (p *protocol) Ping(ctx context.Context, peer p2pcrypto.PublicKey) error {
 		ch <- sender.ID.Bytes()
 	}
 
-	err = p.msgServer.SendRequest(ctx, PingPong, data, peer, foo, func(err error) {})
+	err = p.msgServer.SendRequest(ctx, server.PingPong, data, peer, foo, func(err error) {})
 
 	if err != nil {
 		return err

--- a/p2p/discovery/protocol.go
+++ b/p2p/discovery/protocol.go
@@ -2,13 +2,14 @@ package discovery
 
 import (
 	"context"
+	"net"
+	"time"
+
 	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/p2p/node"
 	"github.com/spacemeshos/go-spacemesh/p2p/p2pcrypto"
 	"github.com/spacemeshos/go-spacemesh/p2p/server"
 	"github.com/spacemeshos/go-spacemesh/p2p/service"
-	"net"
-	"time"
 )
 
 type protocolRoutingTable interface {
@@ -39,12 +40,6 @@ const MessageBufSize = 1000
 // MessageTimeout is the timeout we tolerate when waiting for a message reply
 const MessageTimeout = time.Second * 5 // TODO: Parametrize
 
-// PingPong is the ping protocol ID
-const PingPong = 0
-
-// GetAddresses is the findnode protocol ID
-const GetAddresses = 1
-
 // newProtocol is a constructor for a protocol protocol provider.
 func newProtocol(ctx context.Context, local p2pcrypto.PublicKey, rt protocolRoutingTable, svc server.Service, log log.Log) *protocol {
 	s := server.NewMsgServer(ctx, svc, Name, MessageTimeout, make(chan service.DirectMessage, MessageBufSize), log)
@@ -57,8 +52,8 @@ func newProtocol(ctx context.Context, local p2pcrypto.PublicKey, rt protocolRout
 
 	// XXX Reminder: for discovery protocol to work you must call SetLocalAddresses with updated ports from the socket.
 
-	d.msgServer.RegisterMsgHandler(PingPong, d.newPingRequestHandler())
-	d.msgServer.RegisterMsgHandler(GetAddresses, d.newGetAddressesRequestHandler())
+	d.msgServer.RegisterMsgHandler(server.PingPong, d.newPingRequestHandler())
+	d.msgServer.RegisterMsgHandler(server.GetAddresses, d.newGetAddressesRequestHandler())
 	return d
 }
 

--- a/p2p/server/msgserver.go
+++ b/p2p/server/msgserver.go
@@ -5,17 +5,35 @@ import (
 	"container/list"
 	"context"
 	"fmt"
-	"github.com/spacemeshos/go-spacemesh/log"
-	"github.com/spacemeshos/go-spacemesh/p2p/p2pcrypto"
-	"github.com/spacemeshos/go-spacemesh/p2p/service"
 	"runtime"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/spacemeshos/go-spacemesh/log"
+	"github.com/spacemeshos/go-spacemesh/p2p/p2pcrypto"
+	"github.com/spacemeshos/go-spacemesh/p2p/service"
 )
 
 // MessageType is a uint32 used to distinguish between server messages inside a single protocol.
 type MessageType uint32
+
+const (
+	// PingPong is the ping protocol ID
+	PingPong MessageType = iota
+	// GetAddresses is the findnode protocol ID
+	GetAddresses
+	// LayerHashMsg is used to fetch layer hash for a given layer ID
+	LayerHashMsg
+	// LayerBlocksMsg is used to fetch block IDs for a given layer hash
+	LayerBlocksMsg
+	// AtxIDsMsg is used to fetch ATXs for a given epoch
+	AtxIDsMsg
+	// TortoiseBeaconMsg is used to fetch tortoise beacon messages for a given epoch
+	TortoiseBeaconMsg
+	// Fetch is used to fetch data for a given hash
+	Fetch
+)
 
 // Message is helper type for `MessegeServer` messages.
 type Message interface {


### PR DESCRIPTION
## Motivation
current code the server.MessageType definition reside in the caller. this is error-prone since each client defines different types to the same constant. currently each caller create its instance of MessageServer so this is not a bug now.

move the definition to the service side has the following benefit
- avoid future coding error where multiple handler is registered to the same constant
- ease of debugging, since each MessageType 

same goes for fetch.Hint

## Changes
move MessageType definition to msgserver.go and Hint to fetch.go

## Test Plan
make test

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
