### PR TITLE
[Merged by Bors] - activation: nil nipst is expected behavior

### DIFF
--- a/activation/activationdb_test.go
+++ b/activation/activationdb_test.go
@@ -1,6 +1,7 @@
 package activation
 
 import (
+	"context"
 	"fmt"
 	"math/big"
 	"os"
@@ -1016,4 +1017,12 @@ func TestActivationDb_ContextuallyValidateAtx(t *testing.T) {
 	err = atxdb.ContextuallyValidateAtx(malformedAtx.ActivationTxHeader)
 	r.EqualError(err,
 		fmt.Sprintf("could not fetch node last atx: atx for node %v does not exist", nodeID.ShortString()))
+}
+
+func TestActivateDB_HandleAtxNilNipst(t *testing.T) {
+	atxdb, _, _ := getAtxDb(t.Name())
+	atx := newActivationTx(nodeID, 0, *types.EmptyATXID, *types.EmptyATXID, 0, 0, 0, 0, coinbase, nil)
+	buf, err := types.InterfaceToBytes(atx)
+	require.NoError(t, err)
+	require.Error(t, atxdb.HandleAtxData(context.TODO(), buf, nil))
 }

--- a/activation/atxdb.go
+++ b/activation/atxdb.go
@@ -757,10 +757,8 @@ func (db *DB) HandleAtxData(ctx context.Context, data []byte, fetcher service.Fe
 
 	logger.With().Info("got new atx", atx.Fields(len(data))...)
 
-	// todo fetch from neighbour (#1925)
 	if atx.Nipst == nil {
-		logger.Panic("nil nipst in gossip")
-		return fmt.Errorf("nil nipst in gossip")
+		return fmt.Errorf("nil nipst in gossip for atx %s", atx.ShortString())
 	}
 
 	if err := fetcher.GetPoetProof(ctx, atx.GetPoetProofRef()); err != nil {


### PR DESCRIPTION
## Motivation
closes: https://github.com/spacemeshos/go-spacemesh/issues/1925

Instead of panic'ing we will log an error that atx with nil nipst is received. It will prevent an adversary from crashing a network just by creating invalid atx.

## Changes
Error instead of panic if atx with nil nipst is received.

## Test Plan
Uni tests

## TODO
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [ ] Update documentation as needed

## DevOps Notes
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
