### PR TITLE
api, mesh: introduce MeshTransaction object that has information about layerID

### DIFF
--- a/api/grpcserver/grpcserver_test.go
+++ b/api/grpcserver/grpcserver_test.go
@@ -222,12 +222,12 @@ func (t *TxAPIMock) GetLayerApplied(txID types.TransactionID) *types.LayerID {
 	return t.layerApplied[txID]
 }
 
-func (t *TxAPIMock) GetTransaction(id types.TransactionID) (*types.Transaction, error) {
+func (t *TxAPIMock) GetTransaction(id types.TransactionID) (*types.MeshTransaction, error) {
 	tx, ok := t.returnTx[id]
 	if !ok {
 		return nil, errors.New("it ain't there")
 	}
-	return tx, nil
+	return &types.MeshTransaction{Transaction: *tx}, nil
 }
 
 func (t *TxAPIMock) GetRewards(types.Address) (rewards []types.Reward, err error) {
@@ -302,6 +302,17 @@ func (t *TxAPIMock) GetTransactions(txids []types.TransactionID) (txs []*types.T
 		for _, tx := range t.returnTx {
 			if tx.ID() == txid {
 				txs = append(txs, tx)
+			}
+		}
+	}
+	return
+}
+
+func (t *TxAPIMock) GetMeshTransactions(txids []types.TransactionID) (txs []*types.MeshTransaction, missing map[types.TransactionID]struct{}) {
+	for _, txid := range txids {
+		for _, tx := range t.returnTx {
+			if tx.ID() == txid {
+				txs = append(txs, &types.MeshTransaction{Transaction: *tx})
 			}
 		}
 	}
@@ -2356,17 +2367,17 @@ func checkAccountDataQueryItemReward(t *testing.T, dataItem interface{}) {
 
 func checkAccountMeshDataItemTx(t *testing.T, dataItem interface{}) {
 	switch x := dataItem.(type) {
-	case *pb.AccountMeshData_Transaction:
+	case *pb.AccountMeshData_MeshTransaction:
 		// Check the sender
-		require.Equal(t, globalTx.Origin().Bytes(), x.Transaction.Signature.PublicKey,
+		require.Equal(t, globalTx.Origin().Bytes(), x.MeshTransaction.Transaction.Signature.PublicKey,
 			"inner coin transfer tx has bad sender")
-		require.Equal(t, globalTx.Amount, x.Transaction.Amount.Value,
+		require.Equal(t, globalTx.Amount, x.MeshTransaction.Transaction.Amount.Value,
 			"inner coin transfer tx has bad amount")
-		require.Equal(t, globalTx.AccountNonce, x.Transaction.Counter,
+		require.Equal(t, globalTx.AccountNonce, x.MeshTransaction.Transaction.Counter,
 			"inner coin transfer tx has bad counter")
 
 		// Need to further check tx type
-		switch y := x.Transaction.Datum.(type) {
+		switch y := x.MeshTransaction.Transaction.Datum.(type) {
 		case *pb.Transaction_CoinTransfer:
 			require.Equal(t, globalTx.Recipient.Bytes(), y.CoinTransfer.Receiver.Address,
 				"inner coin transfer tx has bad recipient")

--- a/api/grpcserver/mesh_service.go
+++ b/api/grpcserver/mesh_service.go
@@ -195,7 +195,7 @@ func (s MeshService) AccountMeshDataQuery(ctx context.Context, in *pb.AccountMes
 				Datum: &pb.AccountMeshData_MeshTransaction{
 					MeshTransaction: &pb.MeshTransaction{
 						Transaction: convertTransaction(&t.Transaction),
-						LayerID:     &pb.LayerNumber{Number: uint32(t.LayerID)},
+						LayerId:     &pb.LayerNumber{Number: uint32(t.LayerID)},
 					},
 				},
 			})

--- a/api/grpcserver/transaction_service.go
+++ b/api/grpcserver/transaction_service.go
@@ -101,10 +101,10 @@ func (s TransactionService) SubmitTransaction(ctx context.Context, in *pb.Submit
 // we just return all nils.
 func (s TransactionService) getTransactionAndStatus(txID types.TransactionID) (retTx *types.Transaction, state pb.TransactionState_TransactionState) {
 	tx, err := s.Mesh.GetTransaction(txID) // have we seen this transaction in a block?
-	retTx = tx
+	retTx = &tx.Transaction
 	if err != nil {
-		tx, err = s.Mempool.Get(txID) // do we have it in the mempool?
-		if err != nil {               // we don't know this transaction
+		retTx, err = s.Mempool.Get(txID) // do we have it in the mempool?
+		if err != nil {                  // we don't know this transaction
 			return
 		}
 		state = pb.TransactionState_TRANSACTION_STATE_MEMPOOL
@@ -268,7 +268,7 @@ func (s TransactionService) TransactionsStateStream(in *pb.TransactionsStateStre
 								return status.Error(codes.Internal, "error retrieving tx data")
 							}
 
-							res.Transaction = convertTransaction(tx)
+							res.Transaction = convertTransaction(&tx.Transaction)
 						}
 						if err := stream.Send(res); err != nil {
 							return err

--- a/api/node.go
+++ b/api/node.go
@@ -44,11 +44,12 @@ type TxAPI interface {
 	GetLayer(types.LayerID) (*types.Layer, error)
 	GetRewards(types.Address) ([]types.Reward, error)
 	GetTransactions([]types.TransactionID) ([]*types.Transaction, map[types.TransactionID]struct{})
+	GetMeshTransactions([]types.TransactionID) ([]*types.MeshTransaction, map[types.TransactionID]struct{})
 	GetTransactionsByDestination(types.LayerID, types.Address) []types.TransactionID
 	GetTransactionsByOrigin(types.LayerID, types.Address) []types.TransactionID
 	LatestLayer() types.LayerID
 	GetLayerApplied(types.TransactionID) *types.LayerID
-	GetTransaction(types.TransactionID) (*types.Transaction, error)
+	GetTransaction(types.TransactionID) (*types.MeshTransaction, error)
 	GetProjection(types.Address, uint64, uint64) (uint64, uint64, error)
 	LatestLayerInState() types.LayerID
 	ProcessedLayer() types.LayerID

--- a/common/types/transaction.go
+++ b/common/types/transaction.go
@@ -118,6 +118,13 @@ func (t *Transaction) String() string {
 		t.ID().ShortString(), t.Origin().Short(), t.Recipient.Short(), t.Amount, t.AccountNonce, t.GasLimit, t.Fee)
 }
 
+// MeshTransaction is stored in the mesh and included in the block.
+type MeshTransaction struct {
+	Transaction
+	LayerID LayerID
+	BlockID BlockID
+}
+
 // InnerTransaction includes all of a transaction's fields, except the signature (origin and id aren't stored).
 type InnerTransaction struct {
 	AccountNonce uint64

--- a/mesh/mesh.go
+++ b/mesh/mesh.go
@@ -720,7 +720,7 @@ func (msh *Mesh) StoreTransactionsFromPool(blk *types.Block) error {
 		}
 		txs = append(txs, tx)
 	}
-	if err := msh.writeTransactions(blk.LayerIndex, txs); err != nil {
+	if err := msh.WriteTransactions(blk, txs...); err != nil {
 		return fmt.Errorf("could not write transactions of block %v database: %v", blk.ID(), err)
 	}
 

--- a/mesh/mesh_test.go
+++ b/mesh/mesh_test.go
@@ -4,6 +4,10 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"math/big"
+	"testing"
+	"time"
+
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/database"
 	"github.com/spacemeshos/go-spacemesh/log"
@@ -11,9 +15,6 @@ import (
 	"github.com/spacemeshos/go-spacemesh/signing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"math/big"
-	"testing"
-	"time"
 )
 
 type ContextualValidityMock struct {
@@ -484,7 +485,7 @@ func GetTransactionIds(txs ...*types.Transaction) []types.TransactionID {
 
 func addTxToMesh(r *require.Assertions, msh *Mesh, signer *signing.EdSigner, nonce uint64) *types.Transaction {
 	tx1 := newTx(r, signer, nonce, 111)
-	err := msh.writeTransactions(0, []*types.Transaction{tx1})
+	err := msh.WriteTransactions(&types.Block{}, tx1)
 	r.NoError(err)
 	return tx1
 }

--- a/mesh/meshdb.go
+++ b/mesh/meshdb.go
@@ -541,22 +541,35 @@ func getTransactionDestKeyPrefix(l types.LayerID, account types.Address) []byte 
 // DbTransaction is the transaction type stored in DB
 type DbTransaction struct {
 	*types.Transaction
-	Origin types.Address
+	Origin  types.Address
+	BlockID types.BlockID
+	LayerID types.LayerID
 }
 
-func newDbTransaction(tx *types.Transaction) *DbTransaction {
-	return &DbTransaction{Transaction: tx, Origin: tx.Origin()}
+func newDbTransaction(tx *types.Transaction, blockID types.BlockID, layerID types.LayerID) *DbTransaction {
+	return &DbTransaction{
+		Transaction: tx,
+		Origin:      tx.Origin(),
+		BlockID:     blockID,
+		LayerID:     layerID,
+	}
 }
 
-func (t DbTransaction) getTransaction() *types.Transaction {
+func (t DbTransaction) getTransaction() *types.MeshTransaction {
 	t.Transaction.SetOrigin(t.Origin)
-	return t.Transaction
+
+	return &types.MeshTransaction{
+		Transaction: *t.Transaction,
+		LayerID:     t.LayerID,
+		BlockID:     t.BlockID,
+	}
 }
 
-func (m *DB) writeTransactions(l types.LayerID, txs []*types.Transaction) error {
+// WriteTransactions writes all transactions associated with a block atomically.
+func (m *DB) WriteTransactions(block *types.Block, txs ...*types.Transaction) error {
 	batch := m.transactions.NewBatch()
 	for _, t := range txs {
-		bytes, err := types.InterfaceToBytes(newDbTransaction(t))
+		bytes, err := types.InterfaceToBytes(newDbTransaction(t, block.ID(), block.Layer()))
 		if err != nil {
 			return fmt.Errorf("could not marshall tx %v to bytes: %v", t.ID().ShortString(), err)
 		}
@@ -565,10 +578,10 @@ func (m *DB) writeTransactions(l types.LayerID, txs []*types.Transaction) error 
 			return fmt.Errorf("could not write tx %v to database: %v", t.ID().ShortString(), err)
 		}
 		// write extra index for querying txs by account
-		if err := batch.Put(getTransactionOriginKey(l, t), t.ID().Bytes()); err != nil {
+		if err := batch.Put(getTransactionOriginKey(block.Layer(), t), t.ID().Bytes()); err != nil {
 			return fmt.Errorf("could not write tx %v to database: %v", t.ID().ShortString(), err)
 		}
-		if err := batch.Put(getTransactionDestKey(l, t), t.ID().Bytes()); err != nil {
+		if err := batch.Put(getTransactionDestKey(block.Layer(), t), t.ID().Bytes()); err != nil {
 			return fmt.Errorf("could not write tx %v to database: %v", t.ID().ShortString(), err)
 		}
 		m.Debug("wrote tx %v to db", t.ID().ShortString())
@@ -577,27 +590,6 @@ func (m *DB) writeTransactions(l types.LayerID, txs []*types.Transaction) error 
 	if err != nil {
 		return fmt.Errorf("failed to write transactions: %v", err)
 	}
-	return nil
-}
-
-// WriteTransaction writes a single transaction to the db
-func (m *DB) WriteTransaction(l types.LayerID, t *types.Transaction) error {
-	bytes, err := types.InterfaceToBytes(newDbTransaction(t))
-	if err != nil {
-		return fmt.Errorf("could not marshall tx %v to bytes: %v", t.ID().ShortString(), err)
-	}
-	if err := m.transactions.Put(t.ID().Bytes(), bytes); err != nil {
-		return fmt.Errorf("could not write tx %v to database: %v", t.ID().ShortString(), err)
-	}
-	// write extra index for querying txs by account
-	if err := m.transactions.Put(getTransactionOriginKey(l, t), t.ID().Bytes()); err != nil {
-		return fmt.Errorf("could not write tx %v to database: %v", t.ID().ShortString(), err)
-	}
-	if err := m.transactions.Put(getTransactionDestKey(l, t), t.ID().Bytes()); err != nil {
-		return fmt.Errorf("could not write tx %v to database: %v", t.ID().ShortString(), err)
-	}
-	m.Debug("wrote tx %v to db", t.ID().ShortString())
-
 	return nil
 }
 
@@ -817,37 +809,44 @@ func (m *DB) GetProjection(addr types.Address, prevNonce, prevBalance uint64) (n
 	return nonce, balance, nil
 }
 
-type txGetter struct {
-	missingIds map[types.TransactionID]struct{}
-	txs        []*types.Transaction
-	mesh       *DB
-}
-
-func (g *txGetter) get(id types.TransactionID) {
-	t, err := g.mesh.GetTransaction(id)
-	if err != nil {
-		g.mesh.With().Warning("could not fetch tx", id, log.Err(err))
-		g.missingIds[id] = struct{}{}
-	} else {
-		g.txs = append(g.txs, t)
-	}
-}
-
-func newGetter(m *DB) *txGetter {
-	return &txGetter{mesh: m, missingIds: make(map[types.TransactionID]struct{})}
-}
-
 // GetTransactions retrieves a list of txs by their id's
 func (m *DB) GetTransactions(transactions []types.TransactionID) ([]*types.Transaction, map[types.TransactionID]struct{}) {
-	getter := newGetter(m)
+	var (
+		missing = map[types.TransactionID]struct{}{}
+		txs     = make([]*types.Transaction, 0, len(transactions))
+	)
 	for _, id := range transactions {
-		getter.get(id)
+		tx, err := m.GetTransaction(id)
+		if err != nil {
+			m.With().Warning("could not fetch tx", id, log.Err(err))
+			missing[id] = struct{}{}
+		} else {
+			txs = append(txs, &tx.Transaction)
+		}
 	}
-	return getter.txs, getter.missingIds
+	return txs, missing
+}
+
+// GetMeshTransactions retrieves list of txs with information in what blocks and layers they are included.
+func (m *DB) GetMeshTransactions(transactions []types.TransactionID) ([]*types.MeshTransaction, map[types.TransactionID]struct{}) {
+	var (
+		missing = map[types.TransactionID]struct{}{}
+		txs     = make([]*types.MeshTransaction, 0, len(transactions))
+	)
+	for _, id := range transactions {
+		tx, err := m.GetTransaction(id)
+		if err != nil {
+			m.With().Warning("could not fetch tx", id, log.Err(err))
+			missing[id] = struct{}{}
+		} else {
+			txs = append(txs, tx)
+		}
+	}
+	return txs, missing
 }
 
 // GetTransaction retrieves a tx by its id
-func (m *DB) GetTransaction(id types.TransactionID) (*types.Transaction, error) {
+func (m *DB) GetTransaction(id types.TransactionID) (*types.MeshTransaction, error) {
 	tBytes, err := m.transactions.Get(id[:])
 	if err != nil {
 		return nil, fmt.Errorf("could not find transaction in database %v err=%v", hex.EncodeToString(id[:]), err)

--- a/mesh/meshdb_test.go
+++ b/mesh/meshdb_test.go
@@ -430,12 +430,14 @@ func TestMeshDB_testGetTransactions(t *testing.T) {
 	signer1, addr1 := newSignerAndAddress(r, "thc")
 	signer2, _ := newSignerAndAddress(r, "cbd")
 	_, addr3 := newSignerAndAddress(r, "cbe")
-	err := mdb.writeTransactions(1, []*types.Transaction{
+	blk := &types.Block{}
+	blk.LayerIndex = 1
+	err := mdb.WriteTransactions(blk,
 		newTx(r, signer1, 420, 240),
 		newTx(r, signer1, 421, 241),
 		newTxWithDest(r, signer2, addr1, 0, 100),
 		newTxWithDest(r, signer2, addr1, 1, 101),
-	})
+	)
 	r.NoError(err)
 
 	txs := mdb.GetTransactionsByOrigin(1, addr1)

--- a/mesh/reward_test.go
+++ b/mesh/reward_test.go
@@ -81,7 +81,7 @@ func addTransactionsWithFee(t testing.TB, mesh *DB, bl *types.Block, numOfTxs in
 		totalFee += fee
 		txs = append(txs, tx)
 	}
-	err := mesh.writeTransactions(0, txs)
+	err := mesh.WriteTransactions(&types.Block{}, txs...)
 	assert.NoError(t, err)
 	return totalFee
 }


### PR DESCRIPTION
## Motivation
See https://github.com/spacemeshos/api/issues/153

## Changes
- new MeshTransaction object, extends Transaction and adds BlockID and LayerID references
- Removed WriteTransaction method (it wasn't used anywhere) and was almost duplicate of WriteTransactions
- change in the api. MeshService.AccountMeshDataQuery will now be extended with layerId (see https://github.com/spacemeshos/api/pull/155)

## Test Plan
TBD

## TODO
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [ ] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
