### PR TITLE
Testnet 135 candidate

### DIFF
--- a/api/grpcserver/mesh_service.go
+++ b/api/grpcserver/mesh_service.go
@@ -19,7 +19,7 @@ type MeshService struct {
 	Mempool           api.MempoolAPI
 	GenTime           api.GenesisTimeAPI
 	LayersPerEpoch    int
-	NetworkID         int8
+	NetworkID         uint32
 	LayerDurationSec  int
 	LayerAvgSize      int
 	TxsPerBlock       int
@@ -36,7 +36,7 @@ func (s MeshService) RegisterService(server *Server) {
 // NewMeshService creates a new service using config data
 func NewMeshService(
 	tx api.TxAPI, mempool api.MempoolAPI, genTime api.GenesisTimeAPI,
-	layersPerEpoch int, networkID int8, layerDurationSec int,
+	layersPerEpoch int, networkID uint32, layerDurationSec int,
 	layerAvgSize int, txsPerBlock int) *MeshService {
 	return &MeshService{
 		Mesh:             tx,

--- a/cmd/node/node_test.go
+++ b/cmd/node/node_test.go
@@ -913,7 +913,7 @@ func TestSpacemeshApp_P2PInterface(t *testing.T) {
 	// Initialize the network: we don't want to listen but this lets us dial out
 	l, err := node.NewNodeIdentity()
 	r.NoError(err)
-	p2pnet, err := net.NewNet(app.Config.P2P, l, log.AppLog)
+	p2pnet, err := net.NewNet(context.TODO(), app.Config.P2P, l, log.AppLog)
 	r.NoError(err)
 	// We need to listen on a different port
 	listener, err := inet.Listen("tcp", fmt.Sprintf("%s:%d", addr, 9270))

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -82,7 +82,7 @@ func AddCommands(cmd *cobra.Command) {
 		config.P2P.DialTimeout, "Network dial timeout duration")
 	cmd.PersistentFlags().DurationVar(&config.P2P.ConnKeepAlive, "conn-keepalive",
 		config.P2P.ConnKeepAlive, "Network connection keep alive")
-	cmd.PersistentFlags().Int8Var(&config.P2P.NetworkID, "network-id",
+	cmd.PersistentFlags().Uint32Var(&config.P2P.NetworkID, "network-id",
 		config.P2P.NetworkID, "NetworkID to run on (0 - mainnet, 1 - testnet)")
 	cmd.PersistentFlags().DurationVar(&config.P2P.ResponseTimeout, "response-timeout",
 		config.P2P.ResponseTimeout, "Timeout for waiting on resposne message")

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -147,6 +147,7 @@ type network interface {
 	GetRandomPeer() p2ppeers.Peer
 	SendRequest(ctx context.Context, msgType server.MessageType, payload []byte, address p2pcrypto.PublicKey, resHandler func(msg []byte), failHandler func(err error)) error
 	RegisterBytesMsgHandler(msgType server.MessageType, reqHandler func(context.Context, []byte) []byte)
+	Close()
 }
 
 // Fetch is the main struct that contains network peers and logic to batch and dispatch hash fetch requests
@@ -200,6 +201,7 @@ func (f *Fetch) Start(ctx context.Context) {
 func (f *Fetch) Stop() {
 	f.batchTimeout.Stop()
 	close(f.stop)
+	f.net.Close()
 	// wait for close to end
 	<-f.doneChan
 }

--- a/fetch/fetch_test.go
+++ b/fetch/fetch_test.go
@@ -70,6 +70,8 @@ func (m mockNet) Start(ctx context.Context) error {
 	return nil
 }
 
+func (m mockNet) Close() {}
+
 func (m mockNet) RegisterGossipProtocol(protocol string, prio priorityq.Priority) chan service.GossipMessage {
 	return nil
 }

--- a/hare/algorithm.go
+++ b/hare/algorithm.go
@@ -530,7 +530,9 @@ func (proc *consensusProcess) onRoundEnd(ctx context.Context) {
 			log.String("proposed_set", sStr),
 			log.Bool("is_conflicting", proc.proposalTracker.IsConflicting()))
 	case commitRound:
-		logger.With().Info("commit round ended", log.Int("set_size", proc.s.Size()))
+		logger.With().Info("commit round ended",
+			log.Int("set_size", proc.s.Size()),
+			log.Int("num_commits", proc.commitTracker.CommitCount()))
 	}
 }
 

--- a/hare/broker.go
+++ b/hare/broker.go
@@ -231,7 +231,7 @@ func (b *Broker) eventLoop(ctx context.Context) {
 				msgLogger.With().Error("broker message validation failed", log.Err(errNilInner))
 				continue
 			}
-			msgLogger.With().Info("broker received hare message")
+			msgLogger.With().Debug("broker received hare message")
 
 			// TODO: fix metrics
 			// metrics.MessageTypeCounter.With("type_id", hareMsg.InnerMsg.Type.String(), "layer", strconv.FormatUint(uint64(msgInstID), 10), "reporter", "brokerHandler").Add(1)

--- a/mesh/mesh.go
+++ b/mesh/mesh.go
@@ -280,6 +280,7 @@ func (vl *validator) ValidateLayer(lyr *types.Layer) {
 		return
 	}
 
+	// TODO LANE: make sure we record validity for blocks in all intervening layers (not just new pbase)
 	oldPbase, newPbase := vl.trtl.HandleIncomingLayer(lyr)
 	vl.SetProcessedLayer(lyr.Index())
 

--- a/p2p/config/config.go
+++ b/p2p/config/config.go
@@ -49,7 +49,7 @@ type Config struct {
 	NodeID                string        `mapstructure:"node-id"`
 	DialTimeout           time.Duration `mapstructure:"dial-timeout"`
 	ConnKeepAlive         time.Duration `mapstructure:"conn-keepalive"`
-	NetworkID             int8          `mapstructure:"network-id"`
+	NetworkID             uint32        `mapstructure:"network-id"`
 	ResponseTimeout       time.Duration `mapstructure:"response-timeout"`
 	SessionTimeout        time.Duration `mapstructure:"session-timeout"`
 	MaxPendingConnections int           `mapstructure:"max-pending-connections"`

--- a/p2p/connectionpool/connectionpool.go
+++ b/p2p/connectionpool/connectionpool.go
@@ -37,26 +37,22 @@ type ConnectionPool struct {
 	dialWait    sync.WaitGroup
 	logger      log.Log
 
-	shutdownCtx    context.Context
-	shutdownCancel context.CancelFunc
-	shutdown       bool
+	shutdownCtx  context.Context
+	shutdownOnce sync.Once
 }
 
 // NewConnectionPool creates new ConnectionPool
-func NewConnectionPool(dialFunc DialFunc, lPub p2pcrypto.PublicKey, logger log.Log) *ConnectionPool {
-	shutdownCtx, cancel := context.WithCancel(context.Background())
+func NewConnectionPool(ctx context.Context, dialFunc DialFunc, lPub p2pcrypto.PublicKey, logger log.Log) *ConnectionPool {
 	cPool := &ConnectionPool{
-		localPub:       lPub,
-		dialFunc:       dialFunc,
-		connections:    make(map[p2pcrypto.PublicKey]net.Connection),
-		connMutex:      sync.RWMutex{},
-		pending:        make(map[p2pcrypto.PublicKey][]chan dialResult),
-		pendMutex:      sync.Mutex{},
-		dialWait:       sync.WaitGroup{},
-		logger:         logger,
-		shutdown:       false,
-		shutdownCtx:    shutdownCtx,
-		shutdownCancel: cancel,
+		localPub:    lPub,
+		dialFunc:    dialFunc,
+		connections: make(map[p2pcrypto.PublicKey]net.Connection),
+		connMutex:   sync.RWMutex{},
+		pending:     make(map[p2pcrypto.PublicKey][]chan dialResult),
+		pendMutex:   sync.Mutex{},
+		dialWait:    sync.WaitGroup{},
+		logger:      logger,
+		shutdownCtx: ctx,
 	}
 
 	return cPool
@@ -84,30 +80,23 @@ func (cp *ConnectionPool) OnClosedConnection(ctx context.Context, cwe net.Connec
 }
 
 func (cp *ConnectionPool) isShuttingDown() bool {
-	var isd bool
-	cp.connMutex.RLock()
-	isd = cp.shutdown
-	cp.connMutex.RUnlock()
-	return isd
+	select {
+	case <-cp.shutdownCtx.Done():
+		return true
+	default:
+	}
+	return false
 }
 
 // Shutdown gracefully shuts down the ConnectionPool:
 // - Closes all open connections
 // - Waits for all Dial routines to complete and unblock any routines waiting for GetConnection
 func (cp *ConnectionPool) Shutdown() {
-	cp.shutdownCancel()
-	cp.connMutex.Lock()
-	if cp.shutdown {
-		cp.connMutex.Unlock()
-		cp.logger.Error("shutdown was already called")
-		return
-	}
-	cp.shutdown = true
-	cp.connMutex.Unlock()
-
-	cp.dialWait.Wait()
-	// we won't handle the closing connection events for these connections since we exit the loop once the teardown is done
-	cp.closeConnections()
+	cp.shutdownOnce.Do(func() {
+		cp.dialWait.Wait()
+		// we won't handle the closing connection events for these connections since we exit the loop once the teardown is done
+		cp.closeConnections()
+	})
 }
 
 func (cp *ConnectionPool) closeConnections() {
@@ -220,12 +209,10 @@ func (cp *ConnectionPool) handleClosedConnection(ctx context.Context, conn net.C
 
 // GetConnection fetches or creates if don't exist a connection to the address which is associated with the remote public key
 func (cp *ConnectionPool) GetConnection(ctx context.Context, address inet.Addr, remotePub p2pcrypto.PublicKey) (net.Connection, error) {
-	cp.connMutex.RLock()
-	if cp.shutdown {
-		cp.connMutex.RUnlock()
+	if cp.isShuttingDown() {
 		return nil, errors.New("ConnectionPool was shut down")
 	}
-
+	cp.connMutex.RLock()
 	// look for the connection in the pool
 	conn, found := cp.connections[remotePub]
 	if found {
@@ -263,11 +250,10 @@ func (cp *ConnectionPool) GetConnection(ctx context.Context, address inet.Addr, 
 
 // GetConnectionIfExists checks if the connection is exists or pending
 func (cp *ConnectionPool) GetConnectionIfExists(remotePub p2pcrypto.PublicKey) (net.Connection, error) {
-	cp.connMutex.RLock()
-	if cp.shutdown {
-		cp.connMutex.RUnlock()
+	if cp.isShuttingDown() {
 		return nil, errors.New("ConnectionPool was shut down")
 	}
+	cp.connMutex.RLock()
 	// look for the connection in the pool
 	if conn, found := cp.connections[remotePub]; found {
 		cp.connMutex.RUnlock()

--- a/p2p/connectionpool/connectionpool_test.go
+++ b/p2p/connectionpool/connectionpool_test.go
@@ -29,7 +29,7 @@ func TestGetConnectionWithNoConnection(t *testing.T) {
 	n := net.NewNetworkMock()
 	n.SetDialDelayMs(50)
 	n.SetDialResult(nil)
-	cPool := NewConnectionPool(n.Dial, generatePublicKey(), log.NewDefault(t.Name()))
+	cPool := NewConnectionPool(context.TODO(), n.Dial, generatePublicKey(), log.NewDefault(t.Name()))
 	remotePub := generatePublicKey()
 	addr := net2.TCPAddr{IP: net2.ParseIP("1.1.1.1")}
 	conn, err := cPool.GetConnection(context.TODO(), &addr, remotePub)
@@ -42,7 +42,7 @@ func TestGetConnectionWithConnection(t *testing.T) {
 	n := net.NewNetworkMock()
 	n.SetDialDelayMs(50)
 	n.SetDialResult(nil)
-	cPool := NewConnectionPool(n.Dial, generatePublicKey(), log.NewDefault(t.Name()))
+	cPool := NewConnectionPool(context.TODO(), n.Dial, generatePublicKey(), log.NewDefault(t.Name()))
 	remotePub := generatePublicKey()
 	addr := net2.TCPAddr{IP: net2.ParseIP("1.1.1.1")}
 	conn, err := cPool.GetConnection(context.TODO(), &addr, remotePub)
@@ -56,7 +56,7 @@ func TestGetConnectionWithError(t *testing.T) {
 	n.SetDialDelayMs(50)
 	eErr := errors.New("err")
 	n.SetDialResult(eErr)
-	cPool := NewConnectionPool(n.Dial, generatePublicKey(), log.NewDefault(t.Name()))
+	cPool := NewConnectionPool(context.TODO(), n.Dial, generatePublicKey(), log.NewDefault(t.Name()))
 	remotePub := generatePublicKey()
 	addr := net2.TCPAddr{IP: net2.ParseIP("1.1.1.1")}
 	conn, aErr := cPool.GetConnection(context.TODO(), &addr, remotePub)
@@ -72,7 +72,7 @@ func TestGetConnectionDuringDial(t *testing.T) {
 	n.SetDialDelayMs(100)
 	n.SetDialResult(nil)
 
-	cPool := NewConnectionPool(n.Dial, generatePublicKey(), log.NewDefault(t.Name()))
+	cPool := NewConnectionPool(context.TODO(), n.Dial, generatePublicKey(), log.NewDefault(t.Name()))
 	waitCh := make(chan net.Connection)
 	// dispatch 2 GetConnection calls
 	dispatchF := func(ch chan net.Connection) {
@@ -111,7 +111,7 @@ func TestRemoteConnectionWithNoConnection(t *testing.T) {
 	n.SetDialDelayMs(50)
 	n.SetDialResult(nil)
 
-	cPool := NewConnectionPool(n.Dial, generatePublicKey(), log.NewDefault(t.Name()))
+	cPool := NewConnectionPool(context.TODO(), n.Dial, generatePublicKey(), log.NewDefault(t.Name()))
 	rConn := net.NewConnectionMock(remotePub)
 	rConn.SetSession(net.NewSessionMock(remotePub))
 	err2 := cPool.OnNewConnection(context.TODO(), net.NewConnectionEvent{Conn: rConn})
@@ -128,7 +128,7 @@ func TestRemoteConnectionWithNoConnection(t *testing.T) {
 func TestRemoteConnectionWithExistingConnection(t *testing.T) {
 	n := net.NewNetworkMock()
 	addr := net2.TCPAddr{IP: net2.ParseIP("1.1.1.1")}
-	cPool := NewConnectionPool(n.Dial, generatePublicKey(), log.NewDefault(t.Name()))
+	cPool := NewConnectionPool(context.TODO(), n.Dial, generatePublicKey(), log.NewDefault(t.Name()))
 
 	lowPubkey, err := p2pcrypto.NewPublicKeyFromBase58("7gd5cD8ZanFaqnMHZrgUsUjDeVxMTxfpnu4gDPS69pBU")
 	assert.NoError(t, err)
@@ -177,13 +177,15 @@ func TestShutdown(t *testing.T) {
 	remotePub := generatePublicKey()
 	addr := net2.TCPAddr{IP: net2.ParseIP("1.1.1.1")}
 
-	cPool := NewConnectionPool(n.Dial, generatePublicKey(), log.NewDefault(t.Name()))
+	ctx, cancel := context.WithCancel(context.Background())
+	cPool := NewConnectionPool(ctx, n.Dial, generatePublicKey(), log.NewDefault(t.Name()))
 	newConns := make(chan net.Connection)
 	go func() {
 		conn, _ := cPool.GetConnection(context.TODO(), &addr, remotePub)
 		newConns <- conn
 	}()
 	time.Sleep(20 * time.Millisecond)
+	cancel()
 	cPool.Shutdown()
 	conn := <-newConns
 	require.Nil(t, conn)
@@ -196,7 +198,9 @@ func TestGetConnectionAfterShutdown(t *testing.T) {
 	remotePub := generatePublicKey()
 	addr := net2.TCPAddr{IP: net2.ParseIP("1.1.1.1")}
 
-	cPool := NewConnectionPool(n.Dial, generatePublicKey(), log.NewDefault(t.Name()))
+	ctx, cancel := context.WithCancel(context.Background())
+	cPool := NewConnectionPool(ctx, n.Dial, generatePublicKey(), log.NewDefault(t.Name()))
+	cancel()
 	cPool.Shutdown()
 	conn, err := cPool.GetConnection(context.TODO(), &addr, remotePub)
 	assert.NotNil(t, err)
@@ -208,7 +212,8 @@ func TestShutdownWithMultipleDials(t *testing.T) {
 	n.SetDialDelayMs(100)
 	n.SetDialResult(nil)
 
-	cPool := NewConnectionPool(n.Dial, generatePublicKey(), log.NewDefault(t.Name()))
+	ctx, cancel := context.WithCancel(context.Background())
+	cPool := NewConnectionPool(ctx, n.Dial, generatePublicKey(), log.NewDefault(t.Name()))
 	newConns := make(chan net.Connection, 20)
 	iterCnt := 20
 	for i := 0; i < iterCnt; i++ {
@@ -220,6 +225,7 @@ func TestShutdownWithMultipleDials(t *testing.T) {
 		}()
 	}
 	time.Sleep(20 * time.Millisecond)
+	cancel()
 	cPool.Shutdown()
 	var cnt int
 	for conn := range newConns {
@@ -235,7 +241,7 @@ func TestClosedConnection(t *testing.T) {
 	nMock := net.NewNetworkMock()
 	nMock.SetDialDelayMs(50)
 	nMock.SetDialResult(nil)
-	cPool := NewConnectionPool(nMock.Dial, generatePublicKey(), log.NewDefault(t.Name()))
+	cPool := NewConnectionPool(context.TODO(), nMock.Dial, generatePublicKey(), log.NewDefault(t.Name()))
 	remotePub := generatePublicKey()
 	addr := net2.TCPAddr{IP: net2.ParseIP("1.1.1.1")}
 
@@ -268,7 +274,7 @@ func TestRandom(t *testing.T) {
 	nMock := net.NewNetworkMock()
 	nMock.SetDialDelayMs(50)
 	nMock.SetDialResult(nil)
-	cPool := NewConnectionPool(nMock.Dial, generatePublicKey(), log.NewDefault(t.Name()))
+	cPool := NewConnectionPool(context.TODO(), nMock.Dial, generatePublicKey(), log.NewDefault(t.Name()))
 	for {
 		r := rand.Int31n(3)
 		if r == 0 {
@@ -317,7 +323,7 @@ func TestRandom(t *testing.T) {
 func TestConnectionPool_GetConnectionIfExists(t *testing.T) {
 	n := net.NewNetworkMock()
 	addr := "1.1.1.1"
-	cPool := NewConnectionPool(n.Dial, generatePublicKey(), log.NewDefault(t.Name()))
+	cPool := NewConnectionPool(context.TODO(), n.Dial, generatePublicKey(), log.NewDefault(t.Name()))
 
 	pk, err := p2pcrypto.NewPublicKeyFromBase58("7gd5cD8ZanFaqnMHZrgUsUjDeVxMTxfpnu4gDPS69pBU")
 	assert.NoError(t, err)
@@ -340,7 +346,7 @@ func TestConnectionPool_GetConnectionIfExists(t *testing.T) {
 func TestConnectionPool_GetConnectionIfExists_Concurrency(t *testing.T) {
 	n := net.NewNetworkMock()
 	addr := "1.1.1.1"
-	cPool := NewConnectionPool(n.Dial, generatePublicKey(), log.NewDefault(t.Name()))
+	cPool := NewConnectionPool(context.TODO(), n.Dial, generatePublicKey(), log.NewDefault(t.Name()))
 
 	pk, err := p2pcrypto.NewPublicKeyFromBase58("7gd5cD8ZanFaqnMHZrgUsUjDeVxMTxfpnu4gDPS69pBU")
 	assert.NoError(t, err)
@@ -377,7 +383,7 @@ func TestConnectionPool_GetConnectionIfExists_Concurrency(t *testing.T) {
 func TestConnectionPool_CloseConnection(t *testing.T) {
 	n := net.NewNetworkMock()
 	addr := "1.1.1.1"
-	cPool := NewConnectionPool(n.Dial, generatePublicKey(), log.NewDefault(t.Name()))
+	cPool := NewConnectionPool(context.TODO(), n.Dial, generatePublicKey(), log.NewDefault(t.Name()))
 
 	pk, err := p2pcrypto.NewPublicKeyFromBase58("7gd5cD8ZanFaqnMHZrgUsUjDeVxMTxfpnu4gDPS69pBU")
 	assert.NoError(t, err)

--- a/p2p/discovery/protocol.go
+++ b/p2p/discovery/protocol.go
@@ -45,7 +45,7 @@ const PingPong = 0
 // GetAddresses is the findnode protocol ID
 const GetAddresses = 1
 
-// newProtocol is a constructor for a protocol protocol provider.
+// newProtocol is a constructor for a protocol provider.
 func newProtocol(ctx context.Context, local p2pcrypto.PublicKey, rt protocolRoutingTable, svc server.Service, log log.Log) *protocol {
 	s := server.NewMsgServer(ctx, svc, Name, MessageTimeout, make(chan service.DirectMessage, MessageBufSize), log)
 	d := &protocol{

--- a/p2p/gossip/protocol.go
+++ b/p2p/gossip/protocol.go
@@ -41,7 +41,7 @@ type Protocol struct {
 
 	peers peersManager
 
-	shutdown chan struct{}
+	shutdownCtx context.Context
 
 	oldMessageQ *types.DoubleCache
 
@@ -51,7 +51,7 @@ type Protocol struct {
 }
 
 // NewProtocol creates a new gossip protocol instance.
-func NewProtocol(config config.SwarmConfig, base baseNetwork, peersManager peersManager, localNodePubkey p2pcrypto.PublicKey, logger log.Log) *Protocol {
+func NewProtocol(ctx context.Context, config config.SwarmConfig, base baseNetwork, peersManager peersManager, localNodePubkey p2pcrypto.PublicKey, logger log.Log) *Protocol {
 	// intentionally not subscribing to peers events so that the channels won't block in case executing Start delays
 	return &Protocol{
 		Log:             logger,
@@ -59,7 +59,7 @@ func NewProtocol(config config.SwarmConfig, base baseNetwork, peersManager peers
 		net:             base,
 		localNodePubkey: localNodePubkey,
 		peers:           peersManager,
-		shutdown:        make(chan struct{}),
+		shutdownCtx:     ctx,
 		oldMessageQ:     types.NewDoubleCache(oldMessageCacheSize), // todo : remember to drain this
 		propagateQ:      make(chan service.MessageValidation, propagateHandleBufferSize),
 		pq:              priorityq.New(propagateHandleBufferSize),
@@ -70,11 +70,6 @@ func NewProtocol(config config.SwarmConfig, base baseNetwork, peersManager peers
 // Start a loop that process peers events
 func (p *Protocol) Start(ctx context.Context) {
 	go p.propagationEventLoop(ctx) // TODO consider running several consumers
-}
-
-// Close stops all protocol routines.
-func (p *Protocol) Close() {
-	close(p.shutdown)
 }
 
 // Broadcast is the actual broadcast procedure - process the message internally and loop on peers and add the message to their queues
@@ -153,6 +148,9 @@ func (p *Protocol) propagateMessage(ctx context.Context, payload []byte, nextPro
 
 func (p *Protocol) handlePQ(ctx context.Context) {
 	for {
+		if p.isShuttingDown() {
+			return
+		}
 		mi, err := p.pq.Read()
 		if err != nil {
 			p.WithContext(ctx).With().Info("priority queue was closed, exiting", log.Err(err))
@@ -198,6 +196,15 @@ func (p *Protocol) getPriority(protoName string) priorityq.Priority {
 	return v
 }
 
+func (p *Protocol) isShuttingDown() bool {
+	select {
+	case <-p.shutdownCtx.Done():
+		return true
+	default:
+	}
+	return false
+}
+
 // pushes messages that passed validation into the priority queue
 func (p *Protocol) propagationEventLoop(ctx context.Context) {
 	go p.handlePQ(ctx)
@@ -205,6 +212,9 @@ func (p *Protocol) propagationEventLoop(ctx context.Context) {
 	for {
 		select {
 		case msgV := <-p.propagateQ:
+			if p.isShuttingDown() {
+				return
+			}
 			// Note: this will block iff the priority queue is full
 			if err := p.pq.Write(p.getPriority(msgV.Protocol()), msgV); err != nil {
 				p.WithContext(ctx).With().Error("could not write to priority queue",
@@ -217,7 +227,7 @@ func (p *Protocol) propagationEventLoop(ctx context.Context) {
 				log.Int("propagation_queue_length", len(p.propagateQ)))
 			metrics.PropagationQueueLen.Set(float64(len(p.propagateQ)))
 
-		case <-p.shutdown:
+		case <-p.shutdownCtx.Done():
 			p.pq.Close()
 			p.WithContext(ctx).Error("propagate event loop stopped: protocol shutdown")
 			return

--- a/p2p/gossip/protocol_test.go
+++ b/p2p/gossip/protocol_test.go
@@ -25,7 +25,7 @@ func TestProcessMessage(t *testing.T) {
 	defer ctrl.Finish()
 
 	net := NewMockbaseNetwork(ctrl)
-	protocol := NewProtocol(config.SwarmConfig{}, net, nil, nil, logger)
+	protocol := NewProtocol(context.TODO(), config.SwarmConfig{}, net, nil, nil, logger)
 
 	isSent := false
 	net.EXPECT().
@@ -48,7 +48,7 @@ func TestPropagateMessage(t *testing.T) {
 
 	net := NewMockbaseNetwork(ctrl)
 	peersManager := NewMockpeersManager(ctrl)
-	protocol := NewProtocol(config.SwarmConfig{}, net, peersManager, nil, logger)
+	protocol := NewProtocol(context.TODO(), config.SwarmConfig{}, net, peersManager, nil, logger)
 
 	peers := make([]p2ppeers.Peer, 30)
 	for i := range peers {
@@ -106,7 +106,8 @@ func (mpq *mockPriorityQueue) Length() int {
 }
 
 func TestPropagationEventLoop(t *testing.T) {
-	protocol := NewProtocol(config.SwarmConfig{}, nil, nil, nil, log.AppLog)
+	ctx, cancel := context.WithCancel(context.Background())
+	protocol := NewProtocol(ctx, config.SwarmConfig{}, nil, nil, nil, log.AppLog)
 	called := make(chan struct{})
 	mpq := mockPriorityQueue{called: called, bus: make(chan struct{}, 10)}
 	protocol.pq = &mpq
@@ -119,7 +120,7 @@ func TestPropagationEventLoop(t *testing.T) {
 	assert.Equal(t, false, mpq.isClosed, "listener should not be shut down yet")
 
 	mpq.isWritten = false
-	protocol.shutdown <- struct{}{}
+	cancel()
 	<-called
 	assert.Equal(t, false, mpq.isWritten, "message should not be written")
 	assert.Equal(t, true, mpq.isClosed, "listener should be shut down")

--- a/p2p/net/conn.go
+++ b/p2p/net/conn.go
@@ -3,12 +3,13 @@ package net
 import (
 	"context"
 	"errors"
+	"time"
+
 	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/p2p/config"
 	"github.com/spacemeshos/go-spacemesh/p2p/metrics"
 	"github.com/spacemeshos/go-spacemesh/p2p/net/wire/delimited"
 	"github.com/spacemeshos/go-spacemesh/p2p/p2pcrypto"
-	"time"
 
 	"fmt"
 	"io"
@@ -88,7 +89,7 @@ type networker interface {
 	EnqueueMessage(ctx context.Context, ime IncomingMessageEvent)
 	SubscribeClosingConnections(func(context.Context, ConnectionWithErr))
 	publishClosingConnection(c ConnectionWithErr)
-	NetworkID() int8
+	NetworkID() uint32
 }
 
 type readWriteCloseAddresser interface {

--- a/p2p/net/conn_test.go
+++ b/p2p/net/conn_test.go
@@ -4,15 +4,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/spacemeshos/go-spacemesh/config"
-	"github.com/spacemeshos/go-spacemesh/p2p/p2pcrypto"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"net"
 	"runtime"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/spacemeshos/go-spacemesh/config"
+	"github.com/spacemeshos/go-spacemesh/p2p/p2pcrypto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var msgSizeLimit = config.DefaultConfig().P2P.MsgSizeLimit

--- a/p2p/net/handshake.go
+++ b/p2p/net/handshake.go
@@ -3,6 +3,6 @@ package net
 // HandshakeData is the handshake message struct
 type HandshakeData struct {
 	ClientVersion string
-	NetworkID     int32
+	NetworkID     uint32
 	Port          uint16
 }

--- a/p2p/net/network.go
+++ b/p2p/net/network.go
@@ -5,16 +5,17 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
+	"strconv"
+	"sync"
+	"time"
+
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/p2p/config"
 	"github.com/spacemeshos/go-spacemesh/p2p/node"
 	"github.com/spacemeshos/go-spacemesh/p2p/p2pcrypto"
 	"github.com/spacemeshos/go-spacemesh/p2p/version"
-	"net"
-	"strconv"
-	"sync"
-	"time"
 )
 
 // DefaultQueueCount is the default number of messages queue we hold. messages queues are used to serialize message receiving
@@ -53,7 +54,7 @@ type ManagedConnection interface {
 // It provides full duplex messaging functionality over the same tcp/ip connection
 // Net has no channel events processing loops - clients are responsible for polling these channels and popping events from them
 type Net struct {
-	networkID int8
+	networkID uint32
 	localNode node.LocalNode
 	logger    log.Log
 
@@ -134,7 +135,7 @@ func (n *Net) Logger() log.Log {
 }
 
 // NetworkID retuers Net's network ID
-func (n *Net) NetworkID() int8 {
+func (n *Net) NetworkID() uint32 {
 	return n.networkID
 }
 
@@ -391,7 +392,7 @@ func (n *Net) HandlePreSessionIncomingMessage(c Connection, message []byte) erro
 	return nil
 }
 
-func verifyNetworkIDAndClientVersion(networkID int8, handshakeData *HandshakeData) error {
+func verifyNetworkIDAndClientVersion(networkID uint32, handshakeData *HandshakeData) error {
 	// compare that version to the min client version in config
 	ok, err := version.CheckNodeVersion(handshakeData.ClientVersion, config.MinClientVersion)
 	if err == nil && !ok {
@@ -402,17 +403,17 @@ func verifyNetworkIDAndClientVersion(networkID int8, handshakeData *HandshakeDat
 	}
 
 	// make sure we're on the same network
-	if handshakeData.NetworkID != int32(networkID) {
+	if handshakeData.NetworkID != networkID {
 		return fmt.Errorf("request net id (%d) is different than local net id (%d)", handshakeData.NetworkID, networkID)
 		//TODO : drop and blacklist this sender
 	}
 	return nil
 }
 
-func generateHandshakeMessage(session NetworkSession, networkID int8, localIncomingPort int, localPubkey p2pcrypto.PublicKey) ([]byte, error) {
+func generateHandshakeMessage(session NetworkSession, networkID uint32, localIncomingPort int, localPubkey p2pcrypto.PublicKey) ([]byte, error) {
 	handshakeData := &HandshakeData{
 		ClientVersion: config.ClientVersion,
-		NetworkID:     int32(networkID),
+		NetworkID:     networkID,
 		Port:          uint16(localIncomingPort),
 	}
 	handshakeMessage, err := types.InterfaceToBytes(handshakeData)

--- a/p2p/net/network_mock.go
+++ b/p2p/net/network_mock.go
@@ -2,12 +2,13 @@ package net
 
 import (
 	"context"
-	"github.com/spacemeshos/go-spacemesh/log"
-	"github.com/spacemeshos/go-spacemesh/p2p/p2pcrypto"
-	"github.com/spacemeshos/go-spacemesh/rand"
 	"net"
 	"sync/atomic"
 	"time"
+
+	"github.com/spacemeshos/go-spacemesh/log"
+	"github.com/spacemeshos/go-spacemesh/p2p/p2pcrypto"
+	"github.com/spacemeshos/go-spacemesh/rand"
 )
 
 // ReadWriteCloserMock is a mock of ReadWriteCloserMock
@@ -50,7 +51,7 @@ type NetworkMock struct {
 	preSessionErr    error
 	preSessionCount  int32
 	regNewRemoteConn []func(NewConnectionEvent)
-	networkID        int8
+	networkID        uint32
 	closingConn      []func(context.Context, ConnectionWithErr)
 	incomingMessages []chan IncomingMessageEvent
 	dialSessionID    []byte
@@ -140,7 +141,7 @@ func (n NetworkMock) PublishClosingConnection(con ConnectionWithErr) {
 }
 
 // NetworkID is netid
-func (n *NetworkMock) NetworkID() int8 {
+func (n *NetworkMock) NetworkID() uint32 {
 	return n.networkID
 }
 

--- a/p2p/net/network_test.go
+++ b/p2p/net/network_test.go
@@ -29,7 +29,7 @@ func TestNet_EnqueueMessage(t *testing.T) {
 	cfg := config.DefaultConfig()
 	ln, err := node.NewNodeIdentity()
 	assert.NoError(t, err)
-	n, err := NewNet(cfg, ln, log.NewDefault(t.Name()))
+	n, err := NewNet(context.TODO(), cfg, ln, log.NewDefault(t.Name()))
 	require.NoError(t, err)
 
 	var rndmtx sync.Mutex
@@ -129,7 +129,7 @@ func Test_Net_LimitedConnections(t *testing.T) {
 
 	ln, err := node.NewNodeIdentity()
 	require.NoError(t, err)
-	n, err := NewNet(cfg, ln, log.NewDefault(t.Name()))
+	n, err := NewNet(context.TODO(), cfg, ln, log.NewDefault(t.Name()))
 	//n.SubscribeOnNewRemoteConnections(counter)
 	require.NoError(t, err)
 	listener := newMockListener()
@@ -164,7 +164,7 @@ func TestHandlePreSessionIncomingMessage2(t *testing.T) {
 	bobsAliceConn := NewConnectionMock(aliceNode.PublicKey())
 	bobsAliceConn.Addr = &net.TCPAddr{IP: aliceNodeInfo.IP, Port: int(aliceNodeInfo.ProtocolPort)}
 
-	bobsNet, err := NewNet(config.DefaultConfig(), bobNode, log.NewDefault(t.Name()))
+	bobsNet, err := NewNet(context.TODO(), config.DefaultConfig(), bobNode, log.NewDefault(t.Name()))
 	r.NoError(err)
 	bobsNet.SubscribeOnNewRemoteConnections(func(event NewConnectionEvent) {
 		r.Equal(aliceNode.PublicKey().String(), event.Conn.Session().ID().String(), "wrong session received")
@@ -199,7 +199,7 @@ func TestMaxPendingConnections(t *testing.T) {
 
 	ln, err := node.NewNodeIdentity()
 	require.NoError(t, err)
-	n, err := NewNet(cfg, ln, log.NewDefault(t.Name()))
+	n, err := NewNet(context.TODO(), cfg, ln, log.NewDefault(t.Name()))
 	require.NoError(t, err)
 
 	// Create many new connections

--- a/p2p/net/udp.go
+++ b/p2p/net/udp.go
@@ -4,14 +4,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/spacemeshos/go-spacemesh/log"
-	"github.com/spacemeshos/go-spacemesh/p2p/config"
-	"github.com/spacemeshos/go-spacemesh/p2p/node"
-	"github.com/spacemeshos/go-spacemesh/p2p/p2pcrypto"
 	"net"
 	"strconv"
 	"sync"
 	"time"
+
+	"github.com/spacemeshos/go-spacemesh/log"
+	"github.com/spacemeshos/go-spacemesh/p2p/config"
+	"github.com/spacemeshos/go-spacemesh/p2p/node"
+	"github.com/spacemeshos/go-spacemesh/p2p/p2pcrypto"
 )
 
 // TODO: we should remove this const. Should  not depend on the number of addresses.
@@ -206,7 +207,7 @@ func (n *UDPNet) EnqueueMessage(ctx context.Context, ime IncomingMessageEvent) {
 }
 
 // NetworkID returns the network id given and used for creating a session.
-func (n *UDPNet) NetworkID() int8 {
+func (n *UDPNet) NetworkID() uint32 {
 	return 0
 }
 

--- a/p2p/net/udp.go
+++ b/p2p/net/udp.go
@@ -71,18 +71,18 @@ type UDPNet struct {
 
 	incomingConn map[string]connWrapper
 
-	shutdown chan struct{}
+	shutdownCtx context.Context
 }
 
 // NewUDPNet creates a UDPNet
-func NewUDPNet(config config.Config, localEntity node.LocalNode, log log.Log) (*UDPNet, error) {
+func NewUDPNet(ctx context.Context, config config.Config, localEntity node.LocalNode, log log.Log) (*UDPNet, error) {
 	n := &UDPNet{
 		local:        localEntity,
 		logger:       log,
 		config:       config,
 		msgChan:      make(chan IncomingMessageEvent, config.BufferSize),
 		incomingConn: make(map[string]connWrapper, maxUDPConn),
-		shutdown:     make(chan struct{}),
+		shutdownCtx:  ctx,
 	}
 
 	n.cache = newSessionCache(n.initSession)
@@ -135,7 +135,6 @@ func (n *UDPNet) LocalAddr() net.Addr {
 
 // Shutdown stops listening and closes the connection
 func (n *UDPNet) Shutdown() {
-	close(n.shutdown)
 	if n.conn != nil {
 		n.conn.Close()
 	}
@@ -201,7 +200,7 @@ func (n *UDPNet) EnqueueMessage(ctx context.Context, ime IncomingMessageEvent) {
 			log.String("from", ime.Conn.RemotePublicKey().String()),
 			log.String("fromaddr", ime.Conn.RemoteAddr().String()),
 			log.Int("len", len(ime.Message)))
-	case <-n.shutdown:
+	case <-n.shutdownCtx.Done():
 		return
 	}
 }

--- a/p2p/net/udp_test.go
+++ b/p2p/net/udp_test.go
@@ -75,7 +75,7 @@ const testMsg = "TEST"
 func TestUDPNet_Sanity(t *testing.T) {
 	local, localinfo := node.GenerateTestNode(t)
 	udpAddr := &net.UDPAddr{IP: net.IPv4zero, Port: int(localinfo.DiscoveryPort)}
-	udpnet, err := NewUDPNet(config.DefaultConfig(), local, log.NewDefault("TEST_"+t.Name()))
+	udpnet, err := NewUDPNet(context.TODO(), config.DefaultConfig(), local, log.NewDefault("TEST_"+t.Name()))
 	require.NoError(t, err)
 	require.NotNil(t, udpnet)
 
@@ -286,7 +286,7 @@ func (ucw *udpConnMock) Close() error {
 
 func TestUDPNet_Cache(t *testing.T) {
 	localnode, _ := node.NewNodeIdentity()
-	n, err := NewUDPNet(config.DefaultConfig(), localnode, log.NewDefault(t.Name()))
+	n, err := NewUDPNet(context.TODO(), config.DefaultConfig(), localnode, log.NewDefault(t.Name()))
 	require.NoError(t, err)
 	require.NotNil(t, n)
 	addr2 := testUDPAddr()
@@ -373,7 +373,7 @@ func TestUDPNet_Cache2(t *testing.T) {
 	// instead we now give up on "Closing" from within the "connection" when there's an error since
 	// we provide the errors from the level above anyway, so closing should be performed there.
 	localnode, _ := node.NewNodeIdentity()
-	n, err := NewUDPNet(config.DefaultConfig(), localnode, log.NewDefault(t.Name()))
+	n, err := NewUDPNet(context.TODO(), config.DefaultConfig(), localnode, log.NewDefault(t.Name()))
 	require.NoError(t, err)
 	require.NotNil(t, n)
 
@@ -466,11 +466,11 @@ func TestUDPNet_Cache2(t *testing.T) {
 func Test_UDPIncomingConnClose(t *testing.T) {
 	localnode, _ := node.NewNodeIdentity()
 	remotenode, _ := node.NewNodeIdentity()
-	n, err := NewUDPNet(config.DefaultConfig(), localnode, log.NewDefault(t.Name()+"_local"))
+	n, err := NewUDPNet(context.TODO(), config.DefaultConfig(), localnode, log.NewDefault(t.Name()+"_local"))
 	require.NoError(t, err)
 	require.NotNil(t, n)
 
-	remoten, rerr := NewUDPNet(config.DefaultConfig(), remotenode, log.NewDefault(t.Name()+"_remote"))
+	remoten, rerr := NewUDPNet(context.TODO(), config.DefaultConfig(), remotenode, log.NewDefault(t.Name()+"_remote"))
 	require.NoError(t, rerr)
 	require.NotNil(t, remoten)
 

--- a/p2p/peers/peers.go
+++ b/p2p/peers/peers.go
@@ -1,10 +1,9 @@
 package peers
 
 import (
-	"github.com/spacemeshos/go-spacemesh/events"
-	"math/rand"
 	"sync/atomic"
-	"time"
+
+	"github.com/spacemeshos/go-spacemesh/events"
 
 	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/p2p/p2pcrypto"
@@ -18,8 +17,6 @@ type Peers struct {
 	log.Log
 	snapshot *atomic.Value
 	exit     chan struct{}
-
-	rand *rand.Rand
 }
 
 // PeerSubscriptionProvider is the interface that provides us with peer events channels.
@@ -44,7 +41,6 @@ func NewPeersImpl(snapshot *atomic.Value, exit chan struct{}, lg log.Log) *Peers
 		snapshot: snapshot,
 		Log:      lg,
 		exit:     exit,
-		rand:     rand.New(rand.NewSource(time.Now().UnixNano()).(rand.Source64)),
 	}
 }
 
@@ -54,14 +50,9 @@ func (p *Peers) Close() {
 }
 
 // GetPeers returns a snapshot of the connected peers shuffled.
-// Method is not concurrent-safe.
 func (p *Peers) GetPeers() []Peer {
 	peers := p.snapshot.Load().([]Peer)
-	cpy := make([]Peer, len(peers))
-	copy(cpy, peers) // if we dont copy we will shuffle orig array
-	p.With().Info("now connected", log.Int("n_peers", len(cpy)))
-	p.rand.Shuffle(len(cpy), func(i, j int) { cpy[i], cpy[j] = cpy[j], cpy[i] }) // shuffle peers order
-	return cpy
+	return peers
 }
 
 // PeerCount returns the number of connected peers.
@@ -72,23 +63,27 @@ func (p *Peers) PeerCount() uint64 {
 
 func (p *Peers) listenToPeers(newPeerC, expiredPeerC chan p2pcrypto.PublicKey) {
 	peerSet := make(map[Peer]struct{}) // set of unique peers
-	defer p.Debug("run stopped")
 	for {
 		select {
 		case <-p.exit:
+			p.Debug("peers events listener is stopped")
 			return
 		case peer, ok := <-newPeerC:
 			if !ok {
 				return
 			}
-			p.With().Debug("new peer", log.String("peer", peer.String()))
 			peerSet[peer] = struct{}{}
+			p.With().Debug("new peer", log.String("peer", peer.String()),
+				log.Int("total", len(peerSet)),
+			)
 		case peer, ok := <-expiredPeerC:
 			if !ok {
 				return
 			}
-			p.With().Debug("expired peer", log.String("peer", peer.String()))
 			delete(peerSet, peer)
+			p.With().Debug("expired peer", log.String("peer", peer.String()),
+				log.Int("total", len(peerSet)),
+			)
 		}
 		keys := make([]Peer, 0, len(peerSet))
 		for k := range peerSet {

--- a/p2p/peers/peers_test.go
+++ b/p2p/peers/peers_test.go
@@ -1,8 +1,6 @@
 package peers
 
 import (
-	"bytes"
-	"fmt"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -93,37 +91,4 @@ func TestPeers_RemovePeer(t *testing.T) {
 	time.Sleep(10 * time.Millisecond) //allow context switch
 	peers = pi.GetPeers()
 	assert.True(t, len(peers) == 1, "number of peers incorrect, length was ", len(peers))
-}
-
-func TestPeers_RandomPeers(t *testing.T) {
-	pi, n, _ := getPeers(service.NewSimulator().NewNode())
-	pi.rand.Seed(0)
-	a := p2pcrypto.NewRandomPubkey()
-	b := p2pcrypto.NewRandomPubkey()
-	c := p2pcrypto.NewRandomPubkey()
-	d := p2pcrypto.NewRandomPubkey()
-	e := p2pcrypto.NewRandomPubkey()
-	n <- a
-	time.Sleep(10 * time.Millisecond) //allow context switch
-	peers := pi.GetPeers()
-	assert.True(t, len(peers) == 1, "number of peers incorrect, length was ", len(peers))
-	n <- b
-	n <- c
-	n <- d
-	n <- e
-	defer pi.Close()
-	time.Sleep(10 * time.Millisecond) //allow context switch
-	peers1 := pi.GetPeers()
-	peers2 := pi.GetPeers()
-	assert.True(t, len(peers1) == 5, "number of peers incorrect, length was ", len(peers1))
-
-	for p := range peers1 {
-		if !bytes.Equal(peers1[p].Bytes(), peers2[p].Bytes()) {
-			t.Log("test done")
-			return
-		}
-		t.Log(fmt.Sprintf("index %d same element %s %s", p, peers1[p].String(), peers2[p].String()))
-	}
-
-	t.Fail()
 }

--- a/p2p/server/msgserver.go
+++ b/p2p/server/msgserver.go
@@ -136,14 +136,14 @@ func (p *MessageServer) cleanStaleMessages(ctx context.Context) {
 	logger := p.WithContext(ctx)
 	for {
 		p.pendMutex.RLock()
-		logger.Debug("checking for stale messages in msgserver queue",
+		logger.With().Debug("checking for stale messages in msgserver queue",
 			log.Int("queue_length", p.pendingQueue.Len()))
 		elem := p.pendingQueue.Front()
 		p.pendMutex.RUnlock()
 		if elem != nil {
 			item := elem.Value.(Item)
 			if time.Since(item.timestamp) > p.requestLifetime {
-				logger.Debug("cleanStaleMessages remove request", log.Uint64("id", item.id))
+				logger.With().Debug("cleanStaleMessages remove request", log.Uint64("id", item.id))
 				p.pendMutex.RLock()
 				foo, okFoo := p.resHandlers[item.id]
 				p.pendMutex.RUnlock()

--- a/p2p/server/msgserver.go
+++ b/p2p/server/msgserver.go
@@ -87,9 +87,15 @@ func NewMsgServer(ctx context.Context, network Service, name string, requestLife
 
 // Close stops the MessageServer
 func (p *MessageServer) Close() {
-	close(p.exit)
-	<-p.closed
-	p.workerCount.Wait()
+	select {
+	case <-p.exit:
+		// channel already closed
+		// (since nothing is ever sent on this channel)
+	default:
+		close(p.exit)
+		<-p.closed
+		p.workerCount.Wait()
+	}
 }
 
 // readLoop reads incoming messages and matches them to requests or responses.

--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -52,12 +52,12 @@ type Switch struct {
 	gossipC   chan struct{}
 	config    config.Config
 	logger    log.Log
+
 	// Context for cancel
-	ctx        context.Context
-	cancelFunc context.CancelFunc
+	shutdownCtx context.Context // this context will be shared with all sub components in p2p
+	cancelFunc  context.CancelFunc
 
 	shutdownOnce sync.Once
-	shutdown     chan struct{} // local request to kill the Switch from outside. e.g when local node is shutting down
 
 	// p2p identity with private key for signing
 	lNode node.LocalNode
@@ -162,22 +162,24 @@ func newSwarm(ctx context.Context, config config.Config, logger log.Log, datadir
 		}
 	}
 
+	shutdownCtx, cancel := context.WithCancel(ctx)
+
 	// Create networking
-	n, err := net.NewNet(config, l, logger.WithName("tcpnet"))
+	n, err := net.NewNet(shutdownCtx, config, l, logger.WithName("tcpnet"))
 	if err != nil {
+		cancel()
 		return nil, fmt.Errorf("can't create switch without a network, err: %v", err)
 	}
 
-	udpnet, err := net.NewUDPNet(config, l, logger.WithName("udpnet"))
+	udpnet, err := net.NewUDPNet(shutdownCtx, config, l, logger.WithName("udpnet"))
 	if err != nil {
+		cancel()
 		return nil, err
 	}
 
-	localCtx, cancel := context.WithCancel(ctx)
-
 	s := &Switch{
-		ctx:        localCtx,
-		cancelFunc: cancel,
+		shutdownCtx: shutdownCtx,
+		cancelFunc:  cancel,
 
 		config: config,
 		logger: logger,
@@ -186,7 +188,6 @@ func newSwarm(ctx context.Context, config config.Config, logger log.Log, datadir
 
 		bootChan: make(chan struct{}),
 		gossipC:  make(chan struct{}),
-		shutdown: make(chan struct{}), // non-buffered so requests to shutdown block until Switch is shut down
 
 		initial:           make(chan struct{}),
 		morePeersReq:      make(chan struct{}, config.MaxInboundPeers+config.OutboundPeersTarget),
@@ -204,12 +205,12 @@ func newSwarm(ctx context.Context, config config.Config, logger log.Log, datadir
 	}
 
 	// Create the udp version of Switch
-	mux := NewUDPMux(ctx, s.lNode, s.lookupFunc, udpnet, s.config.NetworkID, s.logger)
+	mux := NewUDPMux(ctx, s.shutdownCtx, s.lNode, s.lookupFunc, udpnet, s.config.NetworkID, s.logger)
 	s.udpServer = mux
 
 	// todo : if discovery on
 	s.discover = discovery.New(ctx, l, config.SwarmConfig, s.udpServer, datadir, s.logger) // create table and discovery protocol
-	cpool := connectionpool.NewConnectionPool(s.network.Dial, l.PublicKey(), logger)
+	cpool := connectionpool.NewConnectionPool(s.shutdownCtx, s.network.Dial, l.PublicKey(), logger)
 	s.network.SubscribeOnNewRemoteConnections(func(nce net.NewConnectionEvent) {
 		ctx := log.WithNewSessionID(ctx)
 		if err := cpool.OnNewConnection(ctx, nce); err != nil {
@@ -222,7 +223,7 @@ func newSwarm(ctx context.Context, config config.Config, logger log.Log, datadir
 	s.network.SubscribeClosingConnections(cpool.OnClosedConnection)
 	s.network.SubscribeClosingConnections(s.onClosedConnection)
 	s.cPool = cpool
-	s.gossip = gossip.NewProtocol(config.SwarmConfig, s, peers.NewPeers(s, s.logger), s.LocalNode().PublicKey(), s.logger)
+	s.gossip = gossip.NewProtocol(s.shutdownCtx, config.SwarmConfig, s, peers.NewPeers(s, s.logger), s.LocalNode().PublicKey(), s.logger)
 	s.logger.With().Debug("created new swarm", l.PublicKey())
 	return s, nil
 }
@@ -287,7 +288,7 @@ func (s *Switch) Start(ctx context.Context) error {
 	if s.config.SwarmConfig.Bootstrap {
 		go func() {
 			b := time.Now()
-			if err := s.discover.Bootstrap(s.ctx); err != nil {
+			if err := s.discover.Bootstrap(s.shutdownCtx); err != nil {
 				s.bootErr = err
 				close(s.bootChan)
 				s.Shutdown()
@@ -429,8 +430,6 @@ func (s *Switch) RegisterGossipProtocol(protocol string, prio priorityq.Priority
 func (s *Switch) Shutdown() {
 	s.shutdownOnce.Do(func() {
 		s.cancelFunc()
-		close(s.shutdown)
-		s.gossip.Close()
 		s.discover.Shutdown()
 		s.cPool.Shutdown()
 		s.network.Shutdown()
@@ -500,6 +499,15 @@ func (s *Switch) RegisterDirectProtocolWithChannel(protocol string, ingressChann
 	return ingressChannel
 }
 
+func (s *Switch) isShuttingDown() bool {
+	select {
+	case <-s.shutdownCtx.Done():
+		return true
+	default:
+	}
+	return false
+}
+
 // listenToNetworkMessages is listening on new messages from the opened connections and processes them.
 func (s *Switch) listenToNetworkMessages(ctx context.Context) {
 	// We listen to each of the messages queues we get from `net`
@@ -513,9 +521,12 @@ func (s *Switch) listenToNetworkMessages(ctx context.Context) {
 			for {
 				select {
 				case msg := <-c:
+					if s.isShuttingDown() {
+						return
+					}
 					// requestID will be restored from the saved message, no need to generate one here
 					s.processMessage(ctx, msg)
-				case <-s.shutdown:
+				case <-s.shutdownCtx.Done():
 					return
 				}
 			}
@@ -715,15 +726,17 @@ func (s *Switch) startNeighborhood(ctx context.Context) error {
 
 // peersLoop executes one routine at a time to connect new peers.
 func (s *Switch) peersLoop(ctx context.Context) {
-loop:
 	for {
 		select {
 		case <-s.morePeersReq:
+			if s.isShuttingDown() {
+				return
+			}
 			s.logger.WithContext(ctx).Debug("loop: got morePeersReq")
 			s.askForMorePeers(ctx)
 		//todo: try getting the connections (heartbeat)
-		case <-s.shutdown:
-			break loop // maybe error ?
+		case <-s.shutdownCtx.Done():
+			return
 		}
 	}
 }
@@ -782,7 +795,7 @@ func (s *Switch) askForMorePeers(ctx context.Context) {
 	tmr := time.NewTimer(NoResultsInterval)
 	defer tmr.Stop()
 	select {
-	case <-s.shutdown:
+	case <-s.shutdownCtx.Done():
 		return
 	case <-tmr.C:
 		s.morePeersReq <- struct{}{}
@@ -798,7 +811,7 @@ func (s *Switch) getMorePeers(ctx context.Context, numpeers int) int {
 	logger := s.logger.WithContext(ctx)
 
 	// discovery should provide us with random peers to connect to
-	nds := s.discover.SelectPeers(s.ctx, numpeers)
+	nds := s.discover.SelectPeers(s.shutdownCtx, numpeers)
 	ndsLen := len(nds)
 	if ndsLen == 0 {
 		logger.Debug("peer sampler returned nothing")
@@ -816,6 +829,9 @@ func (s *Switch) getMorePeers(ctx context.Context, numpeers int) int {
 	// Try a connection to each peer.
 	// TODO: try splitting the load and don't connect to more than X at a time
 	for i := 0; i < ndsLen; i++ {
+		if s.isShuttingDown() {
+			break
+		}
 		go func(nd *node.Info, reportChan chan cnErr) {
 			if nd.PublicKey() == s.lNode.PublicKey() {
 				reportChan <- cnErr{nd, errors.New("connection to self")}
@@ -875,7 +891,7 @@ loop:
 				log.FieldNamed("peer_id", cne.n.PublicKey()))
 		case <-tm.C:
 			break loop
-		case <-s.shutdown:
+		case <-s.shutdownCtx.Done():
 			break loop
 		}
 

--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -668,7 +668,7 @@ func (s *Switch) publishNewPeer(peer p2pcrypto.PublicKey) {
 	for _, p := range s.newPeerSub {
 		select {
 		case p <- peer:
-		default:
+		case <-s.shutdownCtx.Done():
 		}
 	}
 	s.peerLock.RUnlock()
@@ -680,7 +680,7 @@ func (s *Switch) publishDelPeer(peer p2pcrypto.PublicKey) {
 	for _, p := range s.delPeerSub {
 		select {
 		case p <- peer:
-		default:
+		case <-s.shutdownCtx.Done():
 		}
 	}
 	s.peerLock.RUnlock()
@@ -688,8 +688,8 @@ func (s *Switch) publishDelPeer(peer p2pcrypto.PublicKey) {
 
 // SubscribePeerEvents lets clients listen on events inside the Switch about peers. first chan is new peers, second is deleted peers.
 func (s *Switch) SubscribePeerEvents() (conn, disc chan p2pcrypto.PublicKey) {
-	in := make(chan p2pcrypto.PublicKey, 30) // todo : the size should be determined after #269
-	del := make(chan p2pcrypto.PublicKey, 30)
+	in := make(chan p2pcrypto.PublicKey, s.config.MaxInboundPeers+s.config.OutboundPeersTarget)
+	del := make(chan p2pcrypto.PublicKey, s.config.MaxInboundPeers+s.config.OutboundPeersTarget)
 	s.peerLock.Lock()
 	s.newPeerSub = append(s.newPeerSub, in)
 	s.delPeerSub = append(s.delPeerSub, del)
@@ -913,7 +913,11 @@ func (s *Switch) Disconnect(peer p2pcrypto.PublicKey) {
 	// todo: don't remove if we know this is a valid peer for later
 	//s.discovery.Remove(peer) // address doesn't matter because we only check dhtid
 
-	s.morePeersReq <- struct{}{}
+	select {
+	case s.morePeersReq <- struct{}{}:
+	case <-s.shutdownCtx.Done():
+	}
+
 }
 
 // addIncomingPeer inserts a peer to the neighborhood as a remote peer.

--- a/p2p/switch_test.go
+++ b/p2p/switch_test.go
@@ -142,6 +142,7 @@ func TestSwarm_RegisterProtocolNoStart(t *testing.T) {
 
 func TestSwarm_processMessage(t *testing.T) {
 	s := Switch{
+		shutdownCtx:  context.TODO(),
 		inpeers:      make(map[p2pcrypto.PublicKey]struct{}),
 		outpeers:     make(map[p2pcrypto.PublicKey]struct{}),
 		delPeerSub:   make([]chan p2pcrypto.PublicKey, 0),

--- a/p2p/switch_test.go
+++ b/p2p/switch_test.go
@@ -113,7 +113,7 @@ func TestSwarm_Shutdown(t *testing.T) {
 	s.Shutdown()
 
 	select {
-	case _, ok := <-s.shutdown:
+	case _, ok := <-s.shutdownCtx.Done():
 		assert.False(t, ok)
 	case <-time.After(1 * time.Second):
 		t.Error("Failed to shutdown")

--- a/p2p/udp.go
+++ b/p2p/udp.go
@@ -40,22 +40,22 @@ type UDPMux struct {
 	lookuper Lookuper
 	network  udpNetwork
 
-	messages map[string]chan service.DirectMessage
-	shutdown chan struct{}
+	messages    map[string]chan service.DirectMessage
+	shutdownCtx context.Context
 }
 
 // NewUDPMux creates a new udp protocol server
-func NewUDPMux(ctx context.Context, localNode node.LocalNode, lookuper Lookuper, udpNet udpNetwork, networkid uint32, logger log.Log) *UDPMux {
-	cpool := connectionpool.NewConnectionPool(udpNet.Dial, localNode.PublicKey(), logger.WithName("udp_cpool"))
+func NewUDPMux(ctx, shutdownCtx context.Context, localNode node.LocalNode, lookuper Lookuper, udpNet udpNetwork, networkid uint32, logger log.Log) *UDPMux {
+	cpool := connectionpool.NewConnectionPool(shutdownCtx, udpNet.Dial, localNode.PublicKey(), logger.WithName("udp_cpool"))
 	um := &UDPMux{
-		logger:    logger,
-		local:     localNode,
-		networkid: networkid,
-		lookuper:  lookuper,
-		network:   udpNet,
-		cpool:     cpool,
-		messages:  make(map[string]chan service.DirectMessage),
-		shutdown:  make(chan struct{}, 1),
+		logger:      logger,
+		local:       localNode,
+		networkid:   networkid,
+		lookuper:    lookuper,
+		network:     udpNet,
+		cpool:       cpool,
+		messages:    make(map[string]chan service.DirectMessage),
+		shutdownCtx: shutdownCtx,
 	}
 
 	udpNet.SubscribeOnNewRemoteConnections(func(event inet.NewConnectionEvent) {
@@ -80,9 +80,17 @@ func (mux *UDPMux) Start() error {
 
 // Shutdown closes the server
 func (mux *UDPMux) Shutdown() {
-	close(mux.shutdown)
 	mux.network.Shutdown()
 	mux.cpool.Shutdown()
+}
+
+func (mux *UDPMux) isShuttingDown() bool {
+	select {
+	case <-mux.shutdownCtx.Done():
+		return true
+	default:
+	}
+	return false
 }
 
 // listens to messages from the network layer and handles them.
@@ -95,6 +103,9 @@ func (mux *UDPMux) listenToNetworkMessage() {
 				// closed
 				return
 			}
+			if mux.isShuttingDown() {
+				return
+			}
 			go func(event inet.IncomingMessageEvent) {
 				err := mux.processUDPMessage(event)
 				if err != nil {
@@ -102,7 +113,7 @@ func (mux *UDPMux) listenToNetworkMessage() {
 					// todo: blacklist ?
 				}
 			}(msg)
-		case <-mux.shutdown:
+		case <-mux.shutdownCtx.Done():
 			return
 		}
 	}

--- a/p2p/udp.go
+++ b/p2p/udp.go
@@ -4,18 +4,18 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/spacemeshos/go-spacemesh/common/types"
-	"github.com/spacemeshos/go-spacemesh/p2p/config"
-	"github.com/spacemeshos/go-spacemesh/p2p/connectionpool"
-	"github.com/spacemeshos/go-spacemesh/p2p/version"
 	"net"
 	"time"
 
+	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/log"
+	"github.com/spacemeshos/go-spacemesh/p2p/config"
+	"github.com/spacemeshos/go-spacemesh/p2p/connectionpool"
 	inet "github.com/spacemeshos/go-spacemesh/p2p/net"
 	"github.com/spacemeshos/go-spacemesh/p2p/node"
 	"github.com/spacemeshos/go-spacemesh/p2p/p2pcrypto"
 	"github.com/spacemeshos/go-spacemesh/p2p/service"
+	"github.com/spacemeshos/go-spacemesh/p2p/version"
 )
 
 // Lookuper is a service used to lookup for nodes we know already
@@ -34,7 +34,7 @@ type UDPMux struct {
 	logger log.Log
 
 	local     node.LocalNode
-	networkid int8
+	networkid uint32
 
 	cpool    cPool
 	lookuper Lookuper
@@ -45,9 +45,8 @@ type UDPMux struct {
 }
 
 // NewUDPMux creates a new udp protocol server
-func NewUDPMux(ctx context.Context, localNode node.LocalNode, lookuper Lookuper, udpNet udpNetwork, networkid int8, logger log.Log) *UDPMux {
+func NewUDPMux(ctx context.Context, localNode node.LocalNode, lookuper Lookuper, udpNet udpNetwork, networkid uint32, logger log.Log) *UDPMux {
 	cpool := connectionpool.NewConnectionPool(udpNet.Dial, localNode.PublicKey(), logger.WithName("udp_cpool"))
-
 	um := &UDPMux{
 		logger:    logger,
 		local:     localNode,

--- a/p2p/udp_test.go
+++ b/p2p/udp_test.go
@@ -60,14 +60,14 @@ func (mun *mockUDPNetwork) SubscribeOnNewRemoteConnections(func(event net.NewCon
 func TestNewUDPMux(t *testing.T) {
 	nd, _ := node.NewNodeIdentity()
 	udpMock := &mockUDPNetwork{}
-	m := NewUDPMux(context.TODO(), nd, nil, udpMock, 1, log.NewDefault("test"))
+	m := NewUDPMux(context.TODO(), context.TODO(), nd, nil, udpMock, 1, log.NewDefault("test"))
 	require.NotNil(t, m)
 }
 
 func TestUDPMux_RegisterDirectProtocolWithChannel(t *testing.T) {
 	nd, _ := node.NewNodeIdentity()
 	udpMock := &mockUDPNetwork{}
-	m := NewUDPMux(context.TODO(), nd, nil, udpMock, 1, log.NewDefault(testStr))
+	m := NewUDPMux(context.TODO(), context.TODO(), nd, nil, udpMock, 1, log.NewDefault(testStr))
 	require.NotNil(t, m)
 	c := make(chan service.DirectMessage, 1)
 	m.RegisterDirectProtocolWithChannel(testStr, c)
@@ -80,7 +80,7 @@ func TestUDPMux_RegisterDirectProtocolWithChannel(t *testing.T) {
 func TestUDPMux_Start(t *testing.T) {
 	nd, _ := node.NewNodeIdentity()
 	udpMock := &mockUDPNetwork{}
-	m := NewUDPMux(context.TODO(), nd, nil, udpMock, 1, log.NewDefault(testStr))
+	m := NewUDPMux(context.TODO(), context.TODO(), nd, nil, udpMock, 1, log.NewDefault(testStr))
 	require.NotNil(t, m)
 	err := m.Start()
 	require.NoError(t, err)
@@ -89,7 +89,7 @@ func TestUDPMux_Start(t *testing.T) {
 func TestUDPMux_ProcessDirectProtocolMessage(t *testing.T) {
 	nd, _ := node.NewNodeIdentity()
 	udpMock := &mockUDPNetwork{}
-	m := NewUDPMux(context.TODO(), nd, nil, udpMock, 1, log.NewDefault(testStr))
+	m := NewUDPMux(context.TODO(), context.TODO(), nd, nil, udpMock, 1, log.NewDefault(testStr))
 	require.NotNil(t, m)
 
 	data := service.DataBytes{Payload: []byte(testStr)}
@@ -120,7 +120,7 @@ func TestUDPMux_sendMessageImpl(t *testing.T) {
 		return nil, errors.New("nonode")
 	}
 
-	m := NewUDPMux(context.TODO(), nd, f, udpMock, 1, log.NewDefault(testStr))
+	m := NewUDPMux(context.TODO(), context.TODO(), nd, f, udpMock, 1, log.NewDefault(testStr))
 	require.NotNil(t, m)
 	data := service.DataBytes{Payload: []byte(testStr)}
 
@@ -183,7 +183,7 @@ func TestUDPMux_sendMessageImpl(t *testing.T) {
 func TestUDPMux_ProcessUDP(t *testing.T) {
 	nd, _ := node.NewNodeIdentity()
 	udpMock := &mockUDPNetwork{}
-	m := NewUDPMux(context.TODO(), nd, nil, udpMock, 1, log.NewDefault(testStr))
+	m := NewUDPMux(context.TODO(), context.TODO(), nd, nil, udpMock, 1, log.NewDefault(testStr))
 	require.NotNil(t, m)
 	data := service.DataBytes{Payload: []byte(testStr)}
 	msg := &ProtocolMessage{}
@@ -241,17 +241,17 @@ func TestUDPMux_ProcessUDP(t *testing.T) {
 
 func Test_RoundTrip(t *testing.T) {
 	nd, ndinfo := node.GenerateTestNode(t)
-	udpnet, err := net.NewUDPNet(config.DefaultConfig(), nd, log.NewDefault(""))
+	udpnet, err := net.NewUDPNet(context.TODO(), config.DefaultConfig(), nd, log.NewDefault(""))
 	require.NoError(t, err)
 
-	m := NewUDPMux(context.TODO(), nd, nil, udpnet, 0, log.NewDefault(testStr))
+	m := NewUDPMux(context.TODO(), context.TODO(), nd, nil, udpnet, 0, log.NewDefault(testStr))
 	require.NotNil(t, m)
 
 	nd2, ndinfo2 := node.GenerateTestNode(t)
-	udpnet2, err := net.NewUDPNet(config.DefaultConfig(), nd2, log.NewDefault(""))
+	udpnet2, err := net.NewUDPNet(context.TODO(), config.DefaultConfig(), nd2, log.NewDefault(""))
 	require.NoError(t, err)
 
-	m2 := NewUDPMux(context.TODO(), nd2, nil, udpnet2, 0, log.NewDefault(testStr+"2"))
+	m2 := NewUDPMux(context.TODO(), context.TODO(), nd2, nil, udpnet2, 0, log.NewDefault(testStr+"2"))
 	require.NotNil(t, m2)
 
 	c := make(chan service.DirectMessage, 1)

--- a/tortoise/ninja_tortoise.go
+++ b/tortoise/ninja_tortoise.go
@@ -157,6 +157,9 @@ func newNinjaTortoise(layerSize int, blocks database, hdist int, log log.Log) *n
 }
 
 func (ni *ninjaTortoise) saveOpinion() error {
+	ni.logger.With().Info("saving contextual validity for blocks at pbase",
+		ni.PBase,
+		log.Int("count", len(ni.TVote[ni.PBase])))
 	for b, vec := range ni.TVote[ni.PBase] {
 		valid := vec == support
 		ni.logger.With().Debug("saving block contextual validity",


### PR DESCRIPTION
Candidate for next testnet

## Changes
- properly close msgserver on exit (#2539)
- add context to msgserver logging
- #2490 
- #2479 
- #2433
- try a range of layers for active set (for hare eligibility) (in case there is one bad layer)