### PR TITLE
Properly close message server on exit

### DIFF
--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -171,7 +171,7 @@ func (f MessageNetwork) GetPeers() []p2ppeers.Peer {
 type network interface {
 	GetPeers() []p2ppeers.Peer
 	SendRequest(ctx context.Context, msgType server.MessageType, payload []byte, address p2pcrypto.PublicKey, resHandler func(msg []byte), failHandler func(err error)) error
-	RegisterBytesMsgHandler(msgType server.MessageType, reqHandler func(ctx context.Context, b []byte) []byte)
+	RegisterBytesMsgHandler(msgType server.MessageType, reqHandler func(context.Context, []byte) []byte)
 	Close()
 }
 
@@ -231,7 +231,6 @@ func (f *Fetch) Stop() {
 	close(f.stop)
 	f.activeReqM.Lock()
 	for _, batch := range f.activeRequests {
-
 		for _, req := range batch {
 			close(req.returnChan)
 		}

--- a/p2p/discovery/protocol.go
+++ b/p2p/discovery/protocol.go
@@ -40,7 +40,7 @@ const MessageBufSize = 1000
 // MessageTimeout is the timeout we tolerate when waiting for a message reply
 const MessageTimeout = time.Second * 5 // TODO: Parametrize
 
-// newProtocol is a constructor for a protocol protocol provider.
+// newProtocol is a constructor for a protocol provider.
 func newProtocol(ctx context.Context, local p2pcrypto.PublicKey, rt protocolRoutingTable, svc server.Service, log log.Log) *protocol {
 	s := server.NewMsgServer(ctx, svc, Name, MessageTimeout, make(chan service.DirectMessage, MessageBufSize), log)
 	d := &protocol{

--- a/p2p/server/msgserver.go
+++ b/p2p/server/msgserver.go
@@ -105,9 +105,15 @@ func NewMsgServer(ctx context.Context, network Service, name string, requestLife
 
 // Close stops the MessageServer
 func (p *MessageServer) Close() {
-	close(p.exit)
-	<-p.closed
-	p.workerCount.Wait()
+	select {
+	case <-p.exit:
+		// channel already closed
+		// (since nothing is ever sent on this channel)
+	default:
+		close(p.exit)
+		<-p.closed
+		p.workerCount.Wait()
+	}
 }
 
 // readLoop reads incoming messages and matches them to requests or responses.

--- a/p2p/server/msgserver.go
+++ b/p2p/server/msgserver.go
@@ -74,6 +74,7 @@ type MessageServer struct {
 	workerCount        sync.WaitGroup
 	workerLimiter      chan struct{}
 	exit               chan struct{}
+	closed             chan struct{}
 }
 
 // Service is the subset of method used by MessageServer for p2p communications.
@@ -94,6 +95,7 @@ func NewMsgServer(ctx context.Context, network Service, name string, requestLife
 		msgRequestHandlers: make(map[MessageType]func(context.Context, Message) []byte),
 		requestLifetime:    requestLifetime,
 		exit:               make(chan struct{}),
+		closed:             make(chan struct{}),
 		workerLimiter:      make(chan struct{}, runtime.NumCPU()),
 	}
 
@@ -103,29 +105,31 @@ func NewMsgServer(ctx context.Context, network Service, name string, requestLife
 
 // Close stops the MessageServer
 func (p *MessageServer) Close() {
-	p.exit <- struct{}{}
-	<-p.exit
+	close(p.exit)
+	<-p.closed
 	p.workerCount.Wait()
 }
 
 // readLoop reads incoming messages and matches them to requests or responses.
 func (p *MessageServer) readLoop(ctx context.Context) {
+	logger := p.WithContext(ctx)
+	logger.Info("new message server read loop")
 	timer := time.NewTicker(p.requestLifetime + time.Millisecond*100)
 	defer timer.Stop()
 	for {
 		select {
 		case <-p.exit:
-			p.With().Debug("shutting down protocol", log.String("protocol", p.name))
-			close(p.exit)
+			logger.With().Debug("shutting down protocol", log.String("protocol", p.name))
+			close(p.closed)
 			return
 		case <-timer.C:
-			go p.cleanStaleMessages()
+			go p.cleanStaleMessages(ctx)
 		case msg, ok := <-p.ingressChannel:
 			// generate new reqID for message
 			ctx := log.WithNewRequestID(ctx)
-			p.WithContext(ctx).Debug("new msg received from channel")
+			logger.Debug("new msg received from channel")
 			if !ok {
-				p.WithContext(ctx).Error("read loop channel was closed")
+				logger.Error("read loop channel was closed")
 				return
 			}
 			p.workerCount.Add(1)
@@ -140,17 +144,18 @@ func (p *MessageServer) readLoop(ctx context.Context) {
 }
 
 // clean stale messages after request life time expires
-func (p *MessageServer) cleanStaleMessages() {
+func (p *MessageServer) cleanStaleMessages(ctx context.Context) {
+	logger := p.WithContext(ctx)
 	for {
 		p.pendMutex.RLock()
-		p.With().Debug("checking for stale messages in msgserver queue",
+		logger.Debug("checking for stale messages in msgserver queue",
 			log.Int("queue_length", p.pendingQueue.Len()))
 		elem := p.pendingQueue.Front()
 		p.pendMutex.RUnlock()
 		if elem != nil {
 			item := elem.Value.(Item)
 			if time.Since(item.timestamp) > p.requestLifetime {
-				p.With().Debug("cleanStaleMessages remove request", log.Uint64("id", item.id))
+				logger.Debug("cleanStaleMessages remove request", log.Uint64("id", item.id))
 				p.pendMutex.RLock()
 				foo, okFoo := p.resHandlers[item.id]
 				p.pendMutex.RUnlock()
@@ -159,11 +164,11 @@ func (p *MessageServer) cleanStaleMessages() {
 				}
 				p.removeFromPending(item.id)
 			} else {
-				p.Debug("cleanStaleMessages no more stale messages")
+				logger.Debug("cleanStaleMessages no more stale messages")
 				return
 			}
 		} else {
-			p.Debug("cleanStaleMessages queue empty")
+			logger.Debug("cleanStaleMessages queue empty")
 			return
 		}
 	}


### PR DESCRIPTION
## Motivation
Msgserver sometimes hangs on node shutdown

## Changes
Fixes a concurrency issue in how the msgserver is shut down
Also improves logging and adds context

## Test Plan
tbd

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [ ] Test changes and document test plan
- [ ] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
