### PR TITLE
[Merged by Bors] - separate layer hash fetches and layer block data fetches

### DIFF
--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -92,6 +92,7 @@ const (
 	AtxBuilderLogger     = "atxBuilder"
 	GossipListener       = "gossipListener"
 	Fetcher              = "fetcher"
+	LayerFetcher         = "layerFetcher"
 )
 
 // Cmd is the cobra wrapper for the node, that allows adding parameters to it
@@ -603,7 +604,7 @@ func (app *SpacemeshApp) initServices(ctx context.Context,
 
 	remoteFetchService := fetch.NewFetch(ctx, app.Config.FETCH, swarm, app.addLogger(Fetcher, lg))
 
-	layerFetch := layerfetcher.NewLogic(ctx, app.Config.LAYERS, blockListener, atxdb, poetDb, atxdb, processor, swarm, remoteFetchService, msh, tBeaconDB, app.addLogger(Fetcher, lg))
+	layerFetch := layerfetcher.NewLogic(ctx, app.Config.LAYERS, blockListener, atxdb, poetDb, atxdb, processor, swarm, remoteFetchService, msh, tBeaconDB, app.addLogger(LayerFetcher, lg))
 	layerFetch.AddDBs(mdb.Blocks(), atxdbstore, mdb.Transactions(), poetDbStore, mdb.InputVector(), tBeaconDBStore)
 
 	syncerConf := syncer.Configuration{

--- a/layerfetcher/layers_test.go
+++ b/layerfetcher/layers_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/fetch"
 	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/p2p/p2pcrypto"
-	p2ppeers "github.com/spacemeshos/go-spacemesh/p2p/peers"
+	peers "github.com/spacemeshos/go-spacemesh/p2p/peers"
 	"github.com/spacemeshos/go-spacemesh/p2p/server"
 	"github.com/spacemeshos/go-spacemesh/p2p/service"
 	"github.com/spacemeshos/go-spacemesh/rand"
@@ -31,18 +31,18 @@ func RandomHash() types.Hash32 {
 }
 
 type mockNet struct {
-	peers               []p2ppeers.Peer
+	peers               []peers.Peer
 	callCallback        bool
 	callSuccessCallback bool
 	errToSend           error
 	sendCalled          int
 }
 
-func (m *mockNet) GetPeers() []p2ppeers.Peer {
+func (m *mockNet) GetPeers() []peers.Peer {
 	return m.peers
 }
 
-func (m *mockNet) GetRandomPeer() p2ppeers.Peer {
+func (m *mockNet) GetRandomPeer() peers.Peer {
 	return m.peers[0]
 }
 
@@ -153,7 +153,7 @@ func NewMockLogic(net *mockNet, layers layerDB, blocksDB gossipBlocks, blocks bl
 		log:                  log,
 		fetcher:              fetcher,
 		net:                  net,
-		layerHashResults:     make(map[types.LayerID]map[p2ppeers.Peer]*types.Hash32),
+		layerHashResults:     make(map[types.LayerID]map[peers.Peer]*types.Hash32),
 		blockHashResults:     make(map[types.LayerID][]error),
 		layerResultsChannels: make(map[types.LayerID][]chan LayerPromiseResult),
 		atxs:                 atxs,

--- a/layerfetcher/layers_test.go
+++ b/layerfetcher/layers_test.go
@@ -2,8 +2,7 @@ package layerfetcher
 
 import (
 	"context"
-	"fmt"
-	"sync"
+	"errors"
 	"testing"
 	"time"
 
@@ -12,14 +11,14 @@ import (
 	"github.com/spacemeshos/go-spacemesh/fetch"
 	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/p2p/p2pcrypto"
-	peers "github.com/spacemeshos/go-spacemesh/p2p/peers"
+	"github.com/spacemeshos/go-spacemesh/p2p/peers"
 	"github.com/spacemeshos/go-spacemesh/p2p/server"
 	"github.com/spacemeshos/go-spacemesh/p2p/service"
 	"github.com/spacemeshos/go-spacemesh/rand"
 	"github.com/stretchr/testify/assert"
 )
 
-func RandomHash() types.Hash32 {
+func randomHash() types.Hash32 {
 	rand.Seed(time.Now().UnixNano())
 	b := make([]byte, 8)
 	_, err := rand.Read(b)
@@ -31,61 +30,48 @@ func RandomHash() types.Hash32 {
 }
 
 type mockNet struct {
-	peers               []peers.Peer
-	callCallback        bool
-	callSuccessCallback bool
-	errToSend           error
-	sendCalled          int
+	peers       []peers.Peer
+	layerHashes map[peers.Peer][]byte
+	layerBlocks map[peers.Peer][]byte
+	errors      map[peers.Peer]error
+	timeouts    map[peers.Peer]struct{}
 }
 
-func (m *mockNet) GetPeers() []peers.Peer {
-	return m.peers
+func newMockNet() *mockNet {
+	return &mockNet{
+		layerHashes: make(map[peers.Peer][]byte),
+		layerBlocks: make(map[peers.Peer][]byte),
+		errors:      make(map[peers.Peer]error),
+		timeouts:    make(map[peers.Peer]struct{})}
 }
-
-func (m *mockNet) GetRandomPeer() peers.Peer {
-	return m.peers[0]
-}
-
-func (m *mockNet) SendRequest(ctx context.Context, msgType server.MessageType, payload []byte, address p2pcrypto.PublicKey, resHandler func(msg []byte), timeoutHandler func(err error)) error {
-	m.sendCalled++
-	if m.errToSend != nil {
-		return m.errToSend
-	}
-
-	if !m.callCallback {
+func (m *mockNet) GetPeers() []peers.Peer    { return m.peers }
+func (m *mockNet) GetRandomPeer() peers.Peer { return m.peers[0] }
+func (m *mockNet) SendRequest(_ context.Context, msgType server.MessageType, _ []byte, address p2pcrypto.PublicKey, resHandler func(msg []byte), timeoutHandler func(err error)) error {
+	if _, ok := m.timeouts[address]; ok {
+		timeoutHandler(errors.New("peer timeout"))
 		return nil
 	}
-
-	/*if m.callSuccessCallback {
-		return resHandler()
-	}*/
-
-	return nil
+	switch msgType {
+	case server.LayerHashMsg:
+		if data, ok := m.layerHashes[address]; ok {
+			resHandler(data)
+			return nil
+		}
+	case server.LayerBlocksMsg:
+		if data, ok := m.layerBlocks[address]; ok {
+			resHandler(data)
+			return nil
+		}
+	}
+	return m.errors[address]
 }
-
-func (mockNet) Close() {
-
-}
+func (mockNet) Close() {}
 
 type layerDBMock struct {
 	layers  map[types.Hash32][]types.BlockID
 	vectors map[types.Hash32][]types.BlockID
 	gossip  []types.BlockID
 	hashes  map[types.LayerID]types.Hash32
-}
-
-func (l *layerDBMock) GetLayerInputVector(hash types.Hash32) ([]types.BlockID, error) {
-	return l.vectors[hash], nil
-}
-
-func (l *layerDBMock) SaveLayerHashInputVector(id types.Hash32, data []byte) error {
-	var blocks []types.BlockID
-	err := types.BytesToInterface(data, blocks)
-	if err != nil {
-		return err
-	}
-	l.vectors[id] = blocks
-	return nil
 }
 
 func newLayerDBMock() *layerDBMock {
@@ -96,229 +82,336 @@ func newLayerDBMock() *layerDBMock {
 		hashes:  make(map[types.LayerID]types.Hash32),
 	}
 }
-
-func (l *layerDBMock) GetLayerHash(ID types.LayerID) types.Hash32 {
-	return l.hashes[ID]
+func (l *layerDBMock) GetLayerInputVector(hash types.Hash32) ([]types.BlockID, error) {
+	return l.vectors[hash], nil
 }
-
-func (l *layerDBMock) GetLayerHashBlocks(hash types.Hash32) []types.BlockID {
-	return l.layers[hash]
+func (l *layerDBMock) SaveLayerHashInputVector(id types.Hash32, data []byte) error {
+	var blocks []types.BlockID
+	err := types.BytesToInterface(data, blocks)
+	if err != nil {
+		return err
+	}
+	l.vectors[id] = blocks
+	return nil
 }
+func (l *layerDBMock) GetLayerHash(ID types.LayerID) types.Hash32           { return l.hashes[ID] }
+func (l *layerDBMock) GetLayerHashBlocks(hash types.Hash32) []types.BlockID { return l.layers[hash] }
+func (l layerDBMock) Get() []types.BlockID                                  { return l.gossip }
 
-func (l *layerDBMock) GetLayerVerifyingVector(hash types.Hash32) []types.BlockID {
-	return l.vectors[hash]
+type mockFetcher struct{}
+
+func (m mockFetcher) Stop()                                {}
+func (m mockFetcher) Start()                               {}
+func (m mockFetcher) AddDB(_ fetch.Hint, _ database.Store) {}
+func (m mockFetcher) GetHash(_ types.Hash32, _ fetch.Hint, _ bool) chan fetch.HashDataPromiseResult {
+	ch := make(chan fetch.HashDataPromiseResult, 1)
+	ch <- fetch.HashDataPromiseResult{
+		IsLocal: true,
+	}
+	return ch
 }
-
-func (l layerDBMock) Get() []types.BlockID {
-	return l.gossip
-}
-
-type mockFetcher struct {
-}
-
-func (m mockFetcher) Stop() {
-}
-
-func (m mockFetcher) Start() {
-}
-
-func (m mockFetcher) AddDB(hint fetch.Hint, db database.Store) {
-
-}
-
-func (m mockFetcher) GetHash(hash types.Hash32, h fetch.Hint, validateAndSubmit bool) chan fetch.HashDataPromiseResult {
+func (m mockFetcher) GetHashes(_ []types.Hash32, _ fetch.Hint, _ bool) map[types.Hash32]chan fetch.HashDataPromiseResult {
 	return nil
 }
 
-func (m mockFetcher) GetHashes(hash []types.Hash32, hint fetch.Hint, validateAndSubmit bool) map[types.Hash32]chan fetch.HashDataPromiseResult {
-	return nil
-}
+type mockBlocks struct{}
 
-type mockBlocks struct {
-}
-
-func (m mockBlocks) HandleBlockData(ctx context.Context, date []byte, fetcher service.Fetcher) error {
+func (m mockBlocks) HandleBlockData(_ context.Context, _ []byte, _ service.Fetcher) error {
 	panic("implement me")
 }
 
-type mockAtx struct {
-}
+type mockAtx struct{}
 
-func (m mockAtx) HandleAtxData(ctx context.Context, data []byte, syncer service.Fetcher) error {
+func (m mockAtx) HandleAtxData(_ context.Context, _ []byte, _ service.Fetcher) error {
 	panic("implement me")
 }
 
 func NewMockLogic(net *mockNet, layers layerDB, blocksDB gossipBlocks, blocks blockHandler, atxs atxHandler, fetcher fetch.Fetcher, log log.Log) *Logic {
 	var l = &Logic{
-		log:                  log,
-		fetcher:              fetcher,
-		net:                  net,
-		layerHashResults:     make(map[types.LayerID]map[peers.Peer]*types.Hash32),
-		blockHashResults:     make(map[types.LayerID][]error),
-		layerResultsChannels: make(map[types.LayerID][]chan LayerPromiseResult),
-		atxs:                 atxs,
-		blockHandler:         blocks,
-		layerDB:              layers,
-		gossipBlocks:         blocksDB,
-		layerResM:            sync.RWMutex{},
+		log:            log,
+		fetcher:        fetcher,
+		net:            net,
+		layerHashesRes: make(map[types.LayerID]map[peers.Peer]*peerResult),
+		layerHashesChs: make(map[types.LayerID][]chan LayerHashResult),
+		layerBlocksRes: make(map[types.LayerID]map[peers.Peer]*peerResult),
+		layerBlocksChs: make(map[types.LayerID][]chan LayerPromiseResult),
+		atxs:           atxs,
+		blockHandler:   blocks,
+		layerDB:        layers,
+		gossipBlocks:   blocksDB,
 	}
 	return l
 }
 
-func Test_LayerHashReceiver(t *testing.T) {
+func TestLayerHashReqReceiver(t *testing.T) {
 	db := newLayerDBMock()
 	layerID := types.LayerID(1)
-	l := NewMockLogic(&mockNet{}, db, db, &mockBlocks{}, &mockAtx{}, &mockFetcher{}, log.NewDefault("layerHash"))
-	h := RandomHash()
+	l := NewMockLogic(newMockNet(), db, db, &mockBlocks{}, &mockAtx{}, &mockFetcher{}, log.NewDefault("layerFetch"))
+	h := randomHash()
 	db.hashes[layerID] = h
-	l.LayerHashBlocksReceiver(context.TODO(), layerID.Bytes())
+	out := l.layerHashReqReceiver(context.TODO(), layerID.Bytes())
+	assert.Equal(t, h, types.BytesToHash(out))
 }
 
-func TestLogic_LayerHashBlocksReceiver(t *testing.T) {
+func TestLayerHashBlocksReqReceiver(t *testing.T) {
 	db := newLayerDBMock()
-	l := NewMockLogic(&mockNet{}, db, db, &mockBlocks{}, &mockAtx{}, &mockFetcher{}, log.NewDefault("layerHash"))
-	h := RandomHash()
+	l := NewMockLogic(newMockNet(), db, db, &mockBlocks{}, &mockAtx{}, &mockFetcher{}, log.NewDefault("layerFetch"))
+	h := randomHash()
 	db.layers[h] = []types.BlockID{types.RandomBlockID(), types.RandomBlockID(), types.RandomBlockID(), types.RandomBlockID()}
+	db.vectors[h] = []types.BlockID{types.RandomBlockID(), types.RandomBlockID(), types.RandomBlockID()}
 
-	outB := l.LayerHashBlocksReceiver(context.TODO(), h.Bytes())
-	var act []types.BlockID
+	outB := l.layerHashBlocksReqReceiver(context.TODO(), h.Bytes())
+
+	var act layerBlocks
 	err := types.BytesToInterface(outB, &act)
 	assert.NoError(t, err)
-	assert.Equal(t, db.layers[h], act)
+	assert.Equal(t, act.Blocks, db.layers[h])
+	assert.Equal(t, act.VerifyingVector, db.vectors[h])
+	assert.Nil(t, act.LatestBlocks)
 }
 
-func Test_receiveLayerHash(t *testing.T) {
+func TestPollLayerHash_NoPeers(t *testing.T) {
 	db := newLayerDBMock()
-	net := &mockNet{}
-	l := NewMockLogic(net, db, db, &mockBlocks{}, &mockAtx{}, &mockFetcher{}, log.NewDefault("layerHash"))
-	numOfPeers := 4
-	for i := 0; i < numOfPeers; i++ {
-		net.peers = append(net.peers, p2pcrypto.NewRandomPubkey())
-	}
-
-	hashRes := RandomHash()
-	// test happy flow - get 4 responses
-	l.receiveLayerHash(context.TODO(), 1, net.peers[0], numOfPeers, hashRes.Bytes(), nil)
-	assert.Equal(t, 0, net.sendCalled)
-
-	// test aggregation by hash
-	hashRes2 := RandomHash()
-	for i := 1; i < numOfPeers; i++ {
-		l.receiveLayerHash(context.TODO(), 1, net.peers[i], numOfPeers, hashRes2.Bytes(), nil)
-	}
-	assert.Equal(t, 2, net.sendCalled)
-
-	// test error flow
-	l.receiveLayerHash(context.TODO(), 1, net.peers[0], numOfPeers, hashRes.Bytes(), nil)
-
-	for i := 1; i < numOfPeers; i++ {
-		l.receiveLayerHash(context.TODO(), 1, net.peers[i], numOfPeers, nil, fmt.Errorf("error"))
-	}
-	// no additional sends should happen
-	assert.Equal(t, 2, net.sendCalled)
-
-	// test partial empty layer response
-	l.receiveLayerHash(context.TODO(), 1, net.peers[0], numOfPeers, hashRes.Bytes(), nil)
-	l.receiveLayerHash(context.TODO(), 1, net.peers[1], numOfPeers, emptyHash.Bytes(), nil)
-	for i := 2; i < numOfPeers; i++ {
-		l.receiveLayerHash(context.TODO(), 1, net.peers[i], numOfPeers, hashRes2.Bytes(), nil)
-	}
-	// not considered zero-block layer because there are 2 known hashes
-	assert.Equal(t, 4, net.sendCalled)
-
-	// test empty layer response
-	l.receiveLayerHash(context.TODO(), 1, net.peers[0], numOfPeers, nil, fmt.Errorf("error"))
-	for i := 1; i < numOfPeers; i++ {
-		l.receiveLayerHash(context.TODO(), 1, net.peers[i], numOfPeers, emptyHash.Bytes(), nil)
-	}
-	// zero-block layer should not incur additional send
-	assert.Equal(t, 4, net.sendCalled)
-
-	// test giving up on too many errors (numErrors > peers/2)
-	l.receiveLayerHash(context.TODO(), 1, net.peers[0], numOfPeers, hashRes.Bytes(), nil)
-	for i := 1; i < numOfPeers; i++ {
-		l.receiveLayerHash(context.TODO(), 1, net.peers[i], numOfPeers, nil, fmt.Errorf("error"))
-	}
-	// zero-block layer should not incur additional send
-	assert.Equal(t, 4, net.sendCalled)
+	l := NewMockLogic(newMockNet(), db, db, &mockBlocks{}, &mockAtx{}, &mockFetcher{}, log.NewDefault("layerFetch"))
+	layerID := types.LayerID(10)
+	res := <-l.PollLayerHash(context.TODO(), layerID)
+	assert.Equal(t, ErrNoPeers, res.Err)
+	assert.Nil(t, res.Hashes)
 }
 
-func Test_notifyLayerPromiseResult_AllHaveData(t *testing.T) {
+func TestPollLayerHash_TooManyErrors(t *testing.T) {
 	db := newLayerDBMock()
-	net := &mockNet{}
-	l := NewMockLogic(net, db, db, &mockBlocks{}, &mockAtx{}, &mockFetcher{}, log.NewDefault("layerHash"))
-	layer := types.LayerID(1)
-	result := make(chan LayerPromiseResult, 1)
-	l.layerResM.Lock()
-	l.layerResultsChannels[layer] = append(l.layerResultsChannels[1], result)
-	l.layerResM.Unlock()
-	l.notifyLayerPromiseResult(layer, 3, nil)
-	l.notifyLayerPromiseResult(layer, 3, nil)
-	l.notifyLayerPromiseResult(layer, 3, nil)
-	res := <-result
-	assert.Equal(t, layer, res.Layer)
+	net := newMockNet()
+	numPeers := 4
+	for i := 0; i < numPeers; i++ {
+		peer := p2pcrypto.NewRandomPubkey()
+		net.peers = append(net.peers, peer)
+		if i == 0 {
+			net.layerHashes[peer] = randomHash().Bytes()
+		} else {
+			net.errors[peer] = errors.New("SendRequest error")
+		}
+	}
+	l := NewMockLogic(net, db, db, &mockBlocks{}, &mockAtx{}, &mockFetcher{}, log.NewDefault("layerFetch"))
+
+	layerID := types.LayerID(10)
+	res := <-l.PollLayerHash(context.TODO(), layerID)
+	assert.Equal(t, ErrTooManyPeerErrors, res.Err)
+	assert.Nil(t, res.Hashes)
+}
+
+func TestPollLayerHash_TooManyErrors_Timeout(t *testing.T) {
+	db := newLayerDBMock()
+	net := newMockNet()
+	numPeers := 4
+	for i := 0; i < numPeers; i++ {
+		peer := p2pcrypto.NewRandomPubkey()
+		net.peers = append(net.peers, peer)
+		if i == 0 {
+			net.layerHashes[peer] = randomHash().Bytes()
+		} else {
+			net.timeouts[peer] = struct{}{}
+		}
+	}
+	l := NewMockLogic(net, db, db, &mockBlocks{}, &mockAtx{}, &mockFetcher{}, log.NewDefault("layerFetch"))
+
+	layerID := types.LayerID(10)
+	res := <-l.PollLayerHash(context.TODO(), layerID)
+	assert.Equal(t, ErrTooManyPeerErrors, res.Err)
+	assert.Nil(t, res.Hashes)
+}
+
+func TestPollLayerHash_SomeError(t *testing.T) {
+	db := newLayerDBMock()
+	net := newMockNet()
+	numPeers := 4
+	hash := randomHash()
+	for i := 0; i < numPeers; i++ {
+		peer := p2pcrypto.NewRandomPubkey()
+		net.peers = append(net.peers, peer)
+		if i%2 == 0 {
+			net.errors[peer] = errors.New("SendRequest error")
+		} else {
+			net.layerHashes[peer] = hash.Bytes()
+		}
+	}
+	l := NewMockLogic(net, db, db, &mockBlocks{}, &mockAtx{}, &mockFetcher{}, log.NewDefault("layerFetch"))
+
+	layerID := types.LayerID(10)
+	res := <-l.PollLayerHash(context.TODO(), layerID)
 	assert.Nil(t, res.Err)
+	assert.Equal(t, 1, len(res.Hashes))
+	assert.ElementsMatch(t, []peers.Peer{net.peers[1], net.peers[3]}, res.Hashes[hash])
 }
 
-func Test_notifyLayerPromiseResult_OneHasBlockData(t *testing.T) {
+func TestPollLayerHash_SomeTimeout(t *testing.T) {
 	db := newLayerDBMock()
-	net := &mockNet{}
-	l := NewMockLogic(net, db, db, &mockBlocks{}, &mockAtx{}, &mockFetcher{}, log.NewDefault("layerHash"))
-	layer := types.LayerID(1)
-	result := make(chan LayerPromiseResult, 1)
-	l.layerResM.Lock()
-	l.layerResultsChannels[layer] = append(l.layerResultsChannels[1], result)
-	l.layerResM.Unlock()
-	l.notifyLayerPromiseResult(layer, 3, nil)
-	l.notifyLayerPromiseResult(layer, 3, fmt.Errorf("error"))
-	l.notifyLayerPromiseResult(layer, 3, ErrZeroLayer)
-	res := <-result
-	assert.Equal(t, layer, res.Layer)
-	assert.Equal(t, nil, res.Err)
+	net := newMockNet()
+	numPeers := 4
+	hash := randomHash()
+	for i := 0; i < numPeers; i++ {
+		peer := p2pcrypto.NewRandomPubkey()
+		net.peers = append(net.peers, peer)
+		if i%2 == 0 {
+			net.timeouts[peer] = struct{}{}
+		} else {
+			net.layerHashes[peer] = hash.Bytes()
+		}
+	}
+	l := NewMockLogic(net, db, db, &mockBlocks{}, &mockAtx{}, &mockFetcher{}, log.NewDefault("layerFetch"))
+
+	layerID := types.LayerID(10)
+	res := <-l.PollLayerHash(context.TODO(), layerID)
+	assert.Nil(t, res.Err)
+	assert.Equal(t, 1, len(res.Hashes))
+	assert.ElementsMatch(t, []peers.Peer{net.peers[1], net.peers[3]}, res.Hashes[hash])
 }
 
-func Test_notifyLayerPromiseResult_OneZeroLayerAmongstErrors(t *testing.T) {
+func TestPollLayerHash_Aggregated(t *testing.T) {
 	db := newLayerDBMock()
-	net := &mockNet{}
-	l := NewMockLogic(net, db, db, &mockBlocks{}, &mockAtx{}, &mockFetcher{}, log.NewDefault("layerHash"))
-	layer := types.LayerID(1)
-	result := make(chan LayerPromiseResult, 1)
-	l.layerResM.Lock()
-	l.layerResultsChannels[layer] = append(l.layerResultsChannels[1], result)
-	l.layerResM.Unlock()
-	l.notifyLayerPromiseResult(layer, 3, fmt.Errorf("error 1"))
-	l.notifyLayerPromiseResult(layer, 3, fmt.Errorf("error 2"))
-	l.notifyLayerPromiseResult(layer, 3, ErrZeroLayer)
-	res := <-result
-	assert.Equal(t, layer, res.Layer)
-	assert.Equal(t, ErrZeroLayer, res.Err)
+	net := newMockNet()
+	numPeers := 4
+	evenHash := randomHash()
+	oddHash := randomHash()
+	for i := 0; i < numPeers; i++ {
+		peer := p2pcrypto.NewRandomPubkey()
+		net.peers = append(net.peers, peer)
+		if i%2 == 0 {
+			net.layerHashes[peer] = evenHash.Bytes()
+		} else {
+			net.layerHashes[peer] = oddHash.Bytes()
+		}
+	}
+	l := NewMockLogic(net, db, db, &mockBlocks{}, &mockAtx{}, &mockFetcher{}, log.NewDefault("layerFetch"))
+
+	layerID := types.LayerID(10)
+	res := <-l.PollLayerHash(context.TODO(), layerID)
+	assert.Nil(t, res.Err)
+	assert.Equal(t, numPeers/2, len(res.Hashes))
+	assert.ElementsMatch(t, []peers.Peer{net.peers[0], net.peers[2]}, res.Hashes[evenHash])
+	assert.ElementsMatch(t, []peers.Peer{net.peers[1], net.peers[3]}, res.Hashes[oddHash])
 }
 
-func Test_notifyLayerPromiseResult_ZeroLayer(t *testing.T) {
+func TestPollLayerHash_AllDifferent(t *testing.T) {
 	db := newLayerDBMock()
-	net := &mockNet{}
-	l := NewMockLogic(net, db, db, &mockBlocks{}, &mockAtx{}, &mockFetcher{}, log.NewDefault("layerHash"))
-	layer := types.LayerID(1)
-	result := make(chan LayerPromiseResult, 1)
-	l.layerResM.Lock()
-	l.layerResultsChannels[layer] = append(l.layerResultsChannels[1], result)
-	l.layerResM.Unlock()
-	l.notifyLayerPromiseResult(layer, 1, ErrZeroLayer)
-	res := <-result
-	assert.Equal(t, layer, res.Layer)
-	assert.Equal(t, ErrZeroLayer, res.Err)
+	net := newMockNet()
+	numPeers := 4
+	for i := 0; i < numPeers; i++ {
+		peer := p2pcrypto.NewRandomPubkey()
+		net.peers = append(net.peers, peer)
+		net.layerHashes[peer] = randomHash().Bytes()
+	}
+	l := NewMockLogic(net, db, db, &mockBlocks{}, &mockAtx{}, &mockFetcher{}, log.NewDefault("layerFetch"))
+
+	layerID := types.LayerID(10)
+	res := <-l.PollLayerHash(context.TODO(), layerID)
+	assert.Nil(t, res.Err)
+	assert.Equal(t, numPeers, len(res.Hashes))
 }
 
-func TestLogic_PollLayer(t *testing.T) {
-	db := layerDBMock{}
-	net := &mockNet{}
-	l := NewMockLogic(net, &db, db, &mockBlocks{}, &mockAtx{}, &mockFetcher{}, log.NewDefault("layerHash"))
-	numOfPeers := 4
-	for i := 0; i < numOfPeers; i++ {
-		net.peers = append(net.peers, p2pcrypto.NewRandomPubkey())
+func generateLayerBlocks() []byte {
+	lb := layerBlocks{
+		Blocks:          []types.BlockID{types.RandomBlockID(), types.RandomBlockID(), types.RandomBlockID(), types.RandomBlockID()},
+		VerifyingVector: []types.BlockID{types.RandomBlockID(), types.RandomBlockID(), types.RandomBlockID()},
+	}
+	out, _ := types.InterfaceToBytes(lb)
+	return out
+}
+
+func TestPollLayerBlocks_AllHaveBlockData(t *testing.T) {
+	db := newLayerDBMock()
+	net := newMockNet()
+	numPeers := 4
+	for i := 0; i < numPeers; i++ {
+		peer := p2pcrypto.NewRandomPubkey()
+		net.peers = append(net.peers, peer)
+		net.layerBlocks[peer] = generateLayerBlocks()
+	}
+	l := NewMockLogic(net, db, db, &mockBlocks{}, &mockAtx{}, &mockFetcher{}, log.NewDefault("layerFetch"))
+
+	layerID := types.LayerID(10)
+	// currently first peer for each hash is queried
+	layerHashes := map[types.Hash32][]peers.Peer{
+		randomHash(): {net.peers[2]},
+		randomHash(): {net.peers[1], net.peers[0]},
+		randomHash(): {net.peers[3]},
 	}
 
-	l.PollLayer(context.TODO(), 1)
+	res := <-l.PollLayerBlocks(context.TODO(), layerID, layerHashes)
+	assert.Nil(t, res.Err)
+	assert.Equal(t, layerID, res.Layer)
+}
 
-	assert.Equal(t, numOfPeers, net.sendCalled)
+func TestPollLayerBlocks_OnlyOneHasBlockData(t *testing.T) {
+	db := newLayerDBMock()
+	net := newMockNet()
+	numPeers := 4
+	for i := 0; i < numPeers; i++ {
+		peer := p2pcrypto.NewRandomPubkey()
+		net.peers = append(net.peers, peer)
+		if i == 2 {
+			net.layerBlocks[peer] = generateLayerBlocks()
+		} else {
+			net.errors[peer] = errors.New("SendRequest error")
+		}
+	}
+	l := NewMockLogic(net, db, db, &mockBlocks{}, &mockAtx{}, &mockFetcher{}, log.NewDefault("layerFetch"))
+
+	layerID := types.LayerID(10)
+	// currently first peer for each hash is queried
+	layerHashes := map[types.Hash32][]peers.Peer{
+		randomHash(): {net.peers[2]},
+		randomHash(): {net.peers[1], net.peers[0]},
+		randomHash(): {net.peers[3]},
+	}
+
+	res := <-l.PollLayerBlocks(context.TODO(), layerID, layerHashes)
+	assert.Nil(t, res.Err)
+	assert.Equal(t, layerID, res.Layer)
+}
+
+func TestPollLayerBlocks_OneZeroLayerAmongstErrors(t *testing.T) {
+	db := newLayerDBMock()
+	net := newMockNet()
+	numPeers := 4
+	for i := 0; i < numPeers; i++ {
+		peer := p2pcrypto.NewRandomPubkey()
+		net.peers = append(net.peers, peer)
+		net.errors[peer] = errors.New("SendRequest error")
+	}
+	l := NewMockLogic(net, db, db, &mockBlocks{}, &mockAtx{}, &mockFetcher{}, log.NewDefault("layerFetch"))
+
+	layerID := types.LayerID(10)
+	// currently first peer for each hash is queried
+	layerHashes := map[types.Hash32][]peers.Peer{
+		emptyHash:    {net.peers[2]},
+		randomHash(): {net.peers[1], net.peers[0]},
+		randomHash(): {net.peers[3]},
+	}
+
+	res := <-l.PollLayerBlocks(context.TODO(), layerID, layerHashes)
+	assert.Equal(t, ErrZeroLayer, res.Err)
+	assert.Equal(t, layerID, res.Layer)
+}
+
+func TestPollLayerBlocks_ZeroLayer(t *testing.T) {
+	db := newLayerDBMock()
+	net := newMockNet()
+	numPeers := 4
+	for i := 0; i < numPeers; i++ {
+		peer := p2pcrypto.NewRandomPubkey()
+		net.peers = append(net.peers, peer)
+		net.errors[peer] = errors.New("SendRequest error")
+	}
+	l := NewMockLogic(net, db, db, &mockBlocks{}, &mockAtx{}, &mockFetcher{}, log.NewDefault("layerFetch"))
+
+	layerID := types.LayerID(10)
+	// currently first peer for each hash is queried
+	layerHashes := map[types.Hash32][]peers.Peer{
+		emptyHash: {net.peers[2], net.peers[1], net.peers[0], net.peers[3]},
+	}
+
+	res := <-l.PollLayerBlocks(context.TODO(), layerID, layerHashes)
+	assert.Equal(t, ErrZeroLayer, res.Err)
+	assert.Equal(t, layerID, res.Layer)
 }

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/layerfetcher"
 	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/mesh"
+	"github.com/spacemeshos/go-spacemesh/p2p/peers"
 )
 
 type layerTicker interface {
@@ -21,7 +22,8 @@ type layerTicker interface {
 }
 
 type layerFetcher interface {
-	PollLayer(ctx context.Context, id types.LayerID) chan layerfetcher.LayerPromiseResult
+	PollLayerHash(ctx context.Context, layerID types.LayerID) chan layerfetcher.LayerHashResult
+	PollLayerBlocks(ctx context.Context, layerID types.LayerID, hashes map[types.Hash32][]peers.Peer) chan layerfetcher.LayerPromiseResult
 	GetEpochATXs(ctx context.Context, id types.EpochID) error
 	GetTortoiseBeacon(ctx context.Context, id types.EpochID) error
 }
@@ -361,8 +363,14 @@ func (s *Syncer) syncLayer(ctx context.Context, layerID types.LayerID) (*types.L
 }
 
 func (s *Syncer) getLayerFromPeers(ctx context.Context, layerID types.LayerID) (*types.Layer, error) {
-	ch := s.fetcher.PollLayer(ctx, layerID)
-	res := <-ch
+	ch := s.fetcher.PollLayerHash(ctx, layerID)
+	hashRes := <-ch
+	if hashRes.Err != nil {
+		return nil, hashRes.Err
+	}
+	// TODO: resolve hash with peers
+	bch := s.fetcher.PollLayerBlocks(ctx, layerID, hashRes.Hashes)
+	res := <-bch
 	if res.Err != nil {
 		if res.Err == layerfetcher.ErrZeroLayer {
 			return types.NewLayer(layerID), nil


### PR DESCRIPTION
## Motivation
Closes #2523

## Changes
separate layer hash fetches and block data fetches. this will allow us to resolve hash difference with peers before actually fetching block data.

## Test Plan
unit tests

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
