### PR TITLE
Nicer clock in tortoise beacon

### DIFF
--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -544,8 +544,7 @@ func (app *SpacemeshApp) initServices(ctx context.Context,
 	// TODO(nkryuchkov): Enable weak coin when finished.
 	//wc := weakcoin.NewWeakCoin(weakcoin.DefaultThreshold, swarm, BLS381.Verify2, vrfSigner, app.addLogger(WeakCoinLogger, lg))
 	wc := weakcoin.ValueMock{Value: false}
-	ld := time.Duration(app.Config.LayerDurationSec) * time.Second
-	tBeacon := tortoisebeacon.New(app.Config.TortoiseBeacon, nodeID, ld, swarm, atxdb, tBeaconDB, sgn, signing.VRFVerify, vrfSigner, wc, clock, app.addLogger(TBeaconLogger, lg))
+	tBeacon := tortoisebeacon.New(app.Config.TortoiseBeacon, nodeID, swarm, atxdb, tBeaconDB, sgn, signing.VRFVerify, vrfSigner, wc, clock, app.addLogger(TBeaconLogger, lg))
 	if err := tBeacon.Start(ctx); err != nil {
 		app.log.Panic("Failed to start tortoise beacon: %v", err)
 	}

--- a/tortoisebeacon/handlers.go
+++ b/tortoisebeacon/handlers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync/atomic"
 	"time"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
@@ -383,12 +384,5 @@ func (tb *TortoiseBeacon) verifyEligibilityProof(message interface{}, from types
 }
 
 func (tb *TortoiseBeacon) currentEpoch() types.EpochID {
-	return tb.currentLayer().GetEpoch()
-}
-
-func (tb *TortoiseBeacon) currentLayer() types.LayerID {
-	tb.layerMu.RLock()
-	defer tb.layerMu.RUnlock()
-
-	return tb.lastLayer
+	return types.EpochID(atomic.LoadUint64((*uint64)(&tb.epoch)))
 }

--- a/tortoisebeacon/handlers_test.go
+++ b/tortoisebeacon/handlers_test.go
@@ -83,6 +83,7 @@ func TestTortoiseBeacon_handleProposalMessage(t *testing.T) {
 	for _, tc := range tt {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			r := require.New(t)
 			t.Parallel()
 
 			tb := TortoiseBeacon{
@@ -93,7 +94,7 @@ func TestTortoiseBeacon_handleProposalMessage(t *testing.T) {
 				vrfVerifier:    signing.VRFVerify,
 				vrfSigner:      vrfSigner,
 				clock:          clock,
-				lastLayer:      epoch,
+				epoch:          epoch,
 			}
 
 			q, ok := new(big.Rat).SetString(tb.config.Q)
@@ -377,7 +378,7 @@ func TestTortoiseBeacon_handleFollowingVotingMessage(t *testing.T) {
 						},
 					},
 				},
-				lastLayer: epoch,
+				epoch: epoch,
 			}
 
 			sig, err := tb.signMessage(tc.message.FollowingVotingMessageBody)

--- a/tortoisebeacon/tortoise_beacon.go
+++ b/tortoisebeacon/tortoise_beacon.go
@@ -89,9 +89,6 @@ type TortoiseBeacon struct {
 
 	epoch types.EpochID
 
-	seenEpochsMu sync.Mutex
-	seenEpochs   map[types.EpochID]struct{}
-
 	clock                    layerClock
 	q                        *big.Rat
 	gracePeriodDuration      time.Duration
@@ -184,7 +181,6 @@ func New(
 		incomingVotes:                   map[epochRoundPair]votesPerPK{},
 		firstRoundIncomingVotes:         map[types.EpochID]firstRoundVotesPerPK{},
 		firstRoundOutcomingVotes:        map[types.EpochID]firstRoundVotes{},
-		seenEpochs:                      map[types.EpochID]struct{}{},
 	}
 }
 

--- a/tortoisebeacon/tortoise_beacon_test.go
+++ b/tortoisebeacon/tortoise_beacon_test.go
@@ -88,7 +88,7 @@ func TestTortoiseBeacon(t *testing.T) {
 	atxdb := activation.NewDB(database.NewMemDatabase(), idStore, memesh, 3, goldenATXID, &validatorMock{}, lg.WithName("atxDB"))
 	_ = atxdb
 
-	tb := New(conf, minerID, ld, n1, mockDB, nil, edSgn, signing.VRFVerify, vrfSigner, mwc, clock, logger)
+	tb := New(conf, minerID, n1, mockDB, nil, edSgn, signing.VRFVerify, vrfSigner, mwc, clock, logger)
 	requirer.NotNil(tb)
 
 	err = tb.Start(context.TODO())
@@ -96,6 +96,7 @@ func TestTortoiseBeacon(t *testing.T) {
 
 	t.Logf("Awaiting epoch %v", layer)
 	awaitLayer(clock, layer)
+	time.Sleep(time.Duration(conf.WaitAfterEpochStart) * time.Millisecond)
 
 	v, err := tb.GetBeacon(layer.GetEpoch())
 	requirer.NoError(err)


### PR DESCRIPTION
## Motivation
Inefficient use of the clock in tortoise beacon code.

## Changes
- Use layer timings to wait for pre-calculated tortoise beacon window start time.
- Check for clock timeouts.
- Avoid running multiple instances of the beacon code (was a bug).
- Use actual `waitAfterEpochStart` (was a bug).

## Test Plan
Existing unit and system tests.

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
