### PR TITLE
[Merged by Bors] - fix duplicate SendRequest for the same hash

### DIFF
--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -898,7 +898,7 @@ func (app *SpacemeshApp) stopServices() {
 	}
 
 	if app.layerFetch != nil {
-		app.log.Info("%v closing layerFetch", app.nodeID.Key)
+		app.log.Info("closing layerFetch")
 		app.layerFetch.Close()
 	}
 

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -177,10 +177,14 @@ type network interface {
 
 // Fetch is the main struct that contains network peers and logic to batch and dispatch hash fetch requests
 type Fetch struct {
-	cfg                  Config
-	log                  log.Log
-	dbs                  map[Hint]database.Store
-	activeRequests       map[types.Hash32][]*request
+	cfg Config
+	log log.Log
+	dbs map[Hint]database.Store
+	// activeRequests contains requests that are not processed
+	activeRequests map[types.Hash32][]*request
+	// pendingRequests contains requests that have been processed and are waiting for responses
+	pendingRequests map[types.Hash32][]*request
+	// activeBatches contains batches of requests in pendingRequests.
 	activeBatches        map[types.Hash32]requestBatch
 	net                  network
 	requestReceiver      chan request
@@ -204,6 +208,7 @@ func NewFetch(ctx context.Context, cfg Config, network service.Service, logger l
 		log:             logger,
 		dbs:             make(map[Hint]database.Store),
 		activeRequests:  make(map[types.Hash32][]*request),
+		pendingRequests: make(map[types.Hash32][]*request),
 		net:             srv,
 		requestReceiver: make(chan request),
 		batchTimeout:    time.NewTicker(time.Millisecond * 50),
@@ -231,7 +236,11 @@ func (f *Fetch) Stop() {
 	close(f.stop)
 	f.activeReqM.Lock()
 	for _, batch := range f.activeRequests {
-
+		for _, req := range batch {
+			close(req.returnChan)
+		}
+	}
+	for _, batch := range f.pendingRequests {
 		for _, req := range batch {
 			close(req.returnChan)
 		}
@@ -268,16 +277,22 @@ func (f *Fetch) loop() {
 	for {
 		select {
 		case req := <-f.requestReceiver:
-			// group requests by hash
+			sendNow := req.priority > Low
 			f.activeReqM.Lock()
-			f.activeRequests[req.hash] = append(f.activeRequests[req.hash], &req)
+			// group requests by hash
+			if sendNow {
+				f.pendingRequests[req.hash] = append(f.pendingRequests[req.hash], &req)
+			} else {
+				f.activeRequests[req.hash] = append(f.activeRequests[req.hash], &req)
+			}
 			rLen := len(f.activeRequests)
 			f.activeReqM.Unlock()
-			f.log.Info("request added to queue %v", req.hash.ShortString())
-			if req.priority > Low {
+			if sendNow {
+				f.log.Info("high priority request sent %v", req.hash.ShortString())
 				f.sendBatch([]requestMessage{{req.hint, req.hash}})
 				break
 			}
+			f.log.Info("request added to queue %v", req.hash.ShortString())
 			if rLen > batchMaxSize {
 				go f.requestHashBatchFromPeers() // Process the batch.
 			}
@@ -300,7 +315,7 @@ func (f *Fetch) FetchRequestHandler(ctx context.Context, data []byte) []byte {
 	var requestBatch requestBatch
 	err := types.BytesToInterface(data, &requestBatch)
 	if err != nil {
-		f.log.Error("cannot parse request %v", err)
+		f.log.WithContext(ctx).Error("cannot parse request %v", err)
 		return []byte{}
 	}
 	resBatch := responseBatch{
@@ -314,15 +329,15 @@ func (f *Fetch) FetchRequestHandler(ctx context.Context, data []byte) []byte {
 		db, ok := f.dbs[r.Hint]
 		f.dbLock.RUnlock()
 		if !ok {
-			f.log.Warning("db not found %v", r.Hint)
+			f.log.WithContext(ctx).Warning("db not found %v", r.Hint)
 			continue
 		}
 		res, err := db.Get(r.Hash.Bytes())
 		if err != nil {
-			f.log.Warning("remote peer requested non existing hash %v %v", r.Hash.Hex(), err)
+			f.log.WithContext(ctx).Warning("remote peer requested non existing hash %v %v", r.Hash.Hex(), err)
 			continue
 		} else {
-			f.log.Info("responded to hash req %v bytes %v", r.Hash.ShortString(), len(res))
+			f.log.WithContext(ctx).Info("responded to hash req %v bytes %v", r.Hash.ShortString(), len(res))
 		}
 		// add response to batch
 		m := responseMessage{
@@ -333,9 +348,9 @@ func (f *Fetch) FetchRequestHandler(ctx context.Context, data []byte) []byte {
 	}
 
 	bts, err := types.InterfaceToBytes(&resBatch)
-	f.log.Info("returning response batch Id %v responses %v total bytes %v", resBatch.ID.Hex(), len(resBatch.Responses), len(bts))
+	f.log.WithContext(ctx).Info("returning response batch Id %v responses %v total bytes %v", resBatch.ID.Hex(), len(resBatch.Responses), len(bts))
 	if err != nil {
-		f.log.Error("cannot parse message")
+		f.log.WithContext(ctx).Error("cannot parse message")
 		return nil
 	}
 	return bts
@@ -369,7 +384,7 @@ func (f *Fetch) receiveResponse(data []byte) {
 		//take lock here to make handling of a single hash atomic
 		f.activeReqM.Lock()
 		// for each hash, send Data on waiting channel
-		reqs := f.activeRequests[resID.Hash]
+		reqs := f.pendingRequests[resID.Hash]
 		for _, req := range reqs {
 			var err error
 			if req.validateResponseHash {
@@ -390,8 +405,8 @@ func (f *Fetch) receiveResponse(data []byte) {
 		//remove from map
 		delete(batchMap, resID.Hash)
 
-		// remove from active list
-		delete(f.activeRequests, resID.Hash)
+		// remove from pending list
+		delete(f.pendingRequests, resID.Hash)
 		f.activeReqM.Unlock()
 	}
 
@@ -403,9 +418,9 @@ func (f *Fetch) receiveResponse(data []byte) {
 		}
 		f.log.Warning("%v hash was not found in response %v", batchMap[h].Hint, h.ShortString())
 		f.activeReqM.Lock()
-		reqs := f.activeRequests[h]
+		reqs := f.pendingRequests[h]
 		invalidatedRequests := 0
-		for i, req := range reqs {
+		for _, req := range reqs {
 			req.retries++
 			if req.retries > f.cfg.MaxRetriesForRequest {
 				f.log.Error("returning error to request %v %v %v %p", req.hash.ShortString(), len(req.returnChan), len(reqs), req)
@@ -416,12 +431,15 @@ func (f *Fetch) receiveResponse(data []byte) {
 					IsLocal: false,
 				}
 				invalidatedRequests++
-				f.activeRequests[h] = reqs[i+1:]
+			} else {
+				// put the request back to the active list
+				f.activeRequests[req.hash] = append(f.activeRequests[req.hash], req)
 			}
 		}
-		if invalidatedRequests == len(reqs) {
-			delete(f.activeRequests, h)
-		}
+		// the remaining requests in pendingRequests is either invalid (exceed MaxRetriesForRequest) or
+		// put back to the active list.
+		// TODO should we notify channels of the invalid requests?
+		delete(f.pendingRequests, h)
 		f.activeReqM.Unlock()
 	}
 
@@ -434,12 +452,16 @@ func (f *Fetch) receiveResponse(data []byte) {
 // this is the main function that sends the hash request to the peer
 func (f *Fetch) requestHashBatchFromPeers() {
 	var requestList []requestMessage
-	f.activeReqM.RLock()
-	for hash, req := range f.activeRequests {
+	f.activeReqM.Lock()
+	// only send one request per hash
+	for hash, reqs := range f.activeRequests {
 		f.log.Debug("batching %v", hash.ShortString())
-		requestList = append(requestList, requestMessage{Hash: hash, Hint: req[0].hint})
+		requestList = append(requestList, requestMessage{Hash: hash, Hint: reqs[0].hint})
+		// move the processed requests to pending
+		f.pendingRequests[hash] = append(f.pendingRequests[hash], reqs...)
+		delete(f.activeRequests, hash)
 	}
-	f.activeReqM.RUnlock()
+	f.activeReqM.Unlock()
 
 	// send in batches
 	for i := 0; i < len(requestList); i += f.cfg.BatchSize {
@@ -511,8 +533,8 @@ func (f *Fetch) handleHashError(batchHash types.Hash32, err error) {
 	f.activeBatchM.RUnlock()
 	f.activeReqM.Lock()
 	for _, h := range batch.Requests {
-		for _, callback := range f.activeRequests[h.Hash] {
-			f.log.Error("hash error to request %v %v %v %p: %v", h.Hash.ShortString(), len(callback.returnChan), len(f.activeRequests[h.Hash]), callback, err)
+		for _, callback := range f.pendingRequests[h.Hash] {
+			f.log.Error("hash error to request %v %v %v %p: %v", h.Hash.ShortString(), len(callback.returnChan), len(f.pendingRequests[h.Hash]), callback, err)
 			callback.returnChan <- HashDataPromiseResult{
 				Err:     err,
 				Hash:    h.Hash,
@@ -520,7 +542,7 @@ func (f *Fetch) handleHashError(batchHash types.Hash32, err error) {
 				IsLocal: false,
 			}
 		}
-		delete(f.activeRequests, h.Hash)
+		delete(f.pendingRequests, h.Hash)
 	}
 	f.activeReqM.Unlock()
 

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -385,14 +385,16 @@ func (f *Fetch) receiveResponse(data []byte) {
 		f.activeReqM.Lock()
 		// for each hash, send Data on waiting channel
 		reqs := f.pendingRequests[resID.Hash]
+		var actualHash types.Hash32
 		for _, req := range reqs {
 			var err error
 			if req.validateResponseHash {
-				actual := types.CalcHash32(data)
-				if actual != resID.Hash {
-					err = fmt.Errorf("hash didnt match expected: %v, actual %v", resID.Hash.ShortString(), actual.ShortString())
+				if len(actualHash) == 0 {
+					actualHash = types.CalcHash32(data)
 				}
-
+				if actualHash != resID.Hash {
+					err = fmt.Errorf("hash didnt match expected: %v, actual %v", resID.Hash.ShortString(), actualHash.ShortString())
+				}
 			}
 			req.returnChan <- HashDataPromiseResult{
 				Err:     err,


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
Closes #2556

## Changes
- added a unit test that fails before this change and passes afterwards
- create a separate pending list for outstanding requests waiting for peer responses
- calculate the actual hash at most once for each response for a hash

## Test Plan
unit tests

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
