### PR TITLE
[Merged by Bors] - activation: remove read lock from GetAtxHeader

### DIFF
--- a/activation/activationdb_test.go
+++ b/activation/activationdb_test.go
@@ -1067,7 +1067,8 @@ func BenchmarkGetAtxHeaderWithConcurrentStoreAtx(b *testing.B) {
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		atxdb.GetAtxHeader(types.ATXID{1, 1, 1})
+		_, err := atxdb.GetAtxHeader(types.ATXID{1, 1, 1})
+		require.ErrorIs(b, err, database.ErrNotFound)
 	}
 	atomic.StoreUint64(&stop, 1)
 	wg.Wait()

--- a/activation/activationdb_test.go
+++ b/activation/activationdb_test.go
@@ -16,8 +16,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 
 	"github.com/spacemeshos/ed25519"
 	"github.com/spacemeshos/go-spacemesh/common/types"
@@ -1036,7 +1034,7 @@ func TestActivateDB_HandleAtxNilNipst(t *testing.T) {
 func BenchmarkGetAtxHeaderWithConcurrentStoreAtx(b *testing.B) {
 	path := b.TempDir()
 
-	lg := log.NewWithLevel("remove_noise", zap.NewAtomicLevelAt(zapcore.FatalLevel))
+	lg := log.NewNop()
 	iddbstore, err := database.NewLDBDatabase(filepath.Join(path, "ids"), 0, 0, lg)
 	require.NoError(b, err)
 	mdb, err := mesh.NewPersistentMeshDB(filepath.Join(path, "mesh"), 20, lg)

--- a/activation/activationdb_test.go
+++ b/activation/activationdb_test.go
@@ -1055,7 +1055,7 @@ func BenchmarkGetAtxHeaderWithConcurrentStoreAtx(b *testing.B) {
 			pub, _, _ := ed25519.GenerateKey(nil)
 			id := types.NodeID{Key: util.Bytes2Hex(pub), VRFPublicKey: []byte("22222")}
 			for i := 0; ; i++ {
-				atx := types.NewActivationTx(newChallenge(id, uint64(i), *types.EmptyATXID, goldenATXID, 0), [20]byte{}, nil, 0, nil)
+				atx := types.NewActivationTx(newChallenge(id, uint64(i), *types.EmptyATXID, goldenATXID, types.NewLayerID(0)), [20]byte{}, nil, 0, nil)
 				if !assert.NoError(b, atxdb.StoreAtx(types.EpochID(1), atx)) {
 					return
 				}

--- a/activation/atxdb.go
+++ b/activation/atxdb.go
@@ -649,9 +649,7 @@ func (db *DB) GetAtxHeader(id types.ATXID) (*types.ActivationTxHeader, error) {
 	if atxHeader, gotIt := db.atxHeaderCache.Get(id); gotIt {
 		return atxHeader, nil
 	}
-	db.RLock()
 	atxHeaderBytes, err := db.atxs.Get(getAtxHeaderKey(id))
-	db.RUnlock()
 	if err != nil {
 		return nil, err
 	}

--- a/log/log.go
+++ b/log/log.go
@@ -88,6 +88,11 @@ func NewWithLevel(module string, level zap.AtomicLevel, hooks ...func(zapcore.En
 	return NewFromLog(log)
 }
 
+// NewNop creates silent logger.
+func NewNop() Log {
+	return NewFromLog(zap.NewNop())
+}
+
 // NewDefault creates a Log with the default log level
 func NewDefault(module string) Log {
 	return NewWithLevel(module, zap.NewAtomicLevelAt(Level()))


### PR DESCRIPTION
## Motivation
The exclusive lock is acquired in StoreAtx, which may lead to contention if GetAtxHeader is called concurrently many times.
The difference in benchmark is significant:

```
benchmark                                          old ns/op     new ns/op     delta
BenchmarkGetAtxHeaderWithConcurrentStoreAtx-16     68058         13280         -80.49%
```

related: https://github.com/spacemeshos/go-spacemesh/issues/2478

## Changes
Read lock is not acquired when reading a single key from the database. 


## Test Plan
unit tests

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
