### PR TITLE
[Merged by Bors] - reduce logging level for high frequency events

### DIFF
--- a/blocks/blockoracle.go
+++ b/blocks/blockoracle.go
@@ -111,7 +111,7 @@ func (bo *Oracle) calcEligibilityProofs(epochNumber types.EpochID) (map[types.La
 
 	bo.log.With().Info("Got beacon",
 		log.Uint64("epoch_id", uint64(epochNumber)),
-		log.Err(err))
+		log.String("epoch_beacon", fmt.Sprint(epochBeacon)))
 
 	var weight uint64
 	// get the previous epoch's total weight

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -21,6 +21,8 @@ import (
 // Hint marks which DB should be queried for a certain provided hash
 type Hint string
 
+var emptyHash = types.Hash32{}
+
 // DB hints per DB
 const (
 	BlockDB Hint = "blocksDB"
@@ -401,11 +403,11 @@ func (f *Fetch) receiveResponse(data []byte) {
 		f.activeReqM.Lock()
 		// for each hash, send Data on waiting channel
 		reqs := f.pendingRequests[resID.Hash]
-		var actualHash types.Hash32
+		actualHash := emptyHash
 		for _, req := range reqs {
 			var err error
 			if req.validateResponseHash {
-				if len(actualHash) == 0 {
+				if actualHash == emptyHash {
 					actualHash = types.CalcHash32(data)
 				}
 				if actualHash != resID.Hash {

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -3,6 +3,7 @@ package fetch
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -12,7 +13,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/log"
 	p2pconf "github.com/spacemeshos/go-spacemesh/p2p/config"
 	"github.com/spacemeshos/go-spacemesh/p2p/p2pcrypto"
-	p2ppeers "github.com/spacemeshos/go-spacemesh/p2p/peers"
+	"github.com/spacemeshos/go-spacemesh/p2p/peers"
 	"github.com/spacemeshos/go-spacemesh/p2p/server"
 	"github.com/spacemeshos/go-spacemesh/p2p/service"
 	"github.com/spacemeshos/go-spacemesh/rand"
@@ -52,6 +53,9 @@ const (
 
 // ErrCouldNotSend is a special type of error indicating fetch could not be done because message could not be sent to peers
 type ErrCouldNotSend error
+
+// ErrExceedMaxRetries is returned when MaxRetriesForRequest attempts has been made to fetch data for a hash and failed
+var ErrExceedMaxRetries = errors.New("fetch failed after max retries for request")
 
 // Fetcher is the general interface of the fetching unit, capable of requesting bytes that corresponds to a hash
 // from other remote peers.
@@ -137,7 +141,7 @@ func DefaultConfig() Config {
 }
 
 type peersProvider interface {
-	GetPeers() []p2ppeers.Peer
+	GetPeers() []peers.Peer
 }
 
 // MessageNetwork is a network interface that allows fetch to communicate with other nodes with 'fetch servers'
@@ -151,13 +155,13 @@ type MessageNetwork struct {
 func NewMessageNetwork(ctx context.Context, requestTimeOut int, net service.Service, protocol string, log log.Log) *MessageNetwork {
 	return &MessageNetwork{
 		server.NewMsgServer(ctx, net.(server.Service), protocol, time.Duration(requestTimeOut)*time.Second, make(chan service.DirectMessage, p2pconf.Values.BufferSize), log),
-		p2ppeers.NewPeers(net, log.WithName("peers")),
+		peers.NewPeers(net, log.WithName("peers")),
 		log,
 	}
 }
 
 // GetRandomPeer returns a random peer from current peer list
-func GetRandomPeer(peers []p2ppeers.Peer) p2ppeers.Peer {
+func GetRandomPeer(peers []peers.Peer) peers.Peer {
 	if len(peers) == 0 {
 		log.Panic("cannot send fetch - no peers found")
 	}
@@ -166,12 +170,12 @@ func GetRandomPeer(peers []p2ppeers.Peer) p2ppeers.Peer {
 }
 
 // GetPeers return active peers
-func (f MessageNetwork) GetPeers() []p2ppeers.Peer {
+func (f MessageNetwork) GetPeers() []peers.Peer {
 	return f.peersProvider.GetPeers()
 }
 
 type network interface {
-	GetPeers() []p2ppeers.Peer
+	GetPeers() []peers.Peer
 	SendRequest(ctx context.Context, msgType server.MessageType, payload []byte, address p2pcrypto.PublicKey, resHandler func(msg []byte), failHandler func(err error)) error
 	RegisterBytesMsgHandler(msgType server.MessageType, reqHandler func(ctx context.Context, b []byte) []byte)
 	Close()
@@ -248,10 +252,10 @@ func (f *Fetch) Stop() {
 		}
 	}
 	f.activeReqM.Unlock()
-	f.log.Info("stopped fetch")
 
 	// wait for close to end
 	<-f.doneChan
+	f.log.Info("stopped fetch")
 }
 
 // stopped returns if we should stop
@@ -295,10 +299,10 @@ func (f *Fetch) handleNewRequest(req *request) bool {
 	f.activeReqM.Unlock()
 	if sendNow {
 		f.sendBatch([]requestMessage{{req.hint, req.hash}})
-		f.log.Info("high priority request sent %v", req.hash.ShortString())
+		f.log.Debug("high priority request sent %v", req.hash.ShortString())
 		return true
 	}
-	f.log.Info("request added to queue %v", req.hash.ShortString())
+	f.log.Debug("request added to queue %v", req.hash.ShortString())
 	if rLen > batchMaxSize {
 		go f.requestHashBatchFromPeers() // Process the batch.
 		return true
@@ -309,7 +313,7 @@ func (f *Fetch) handleNewRequest(req *request) bool {
 // here we receive all requests for hashes for all DBs and batch them together before we send the request to peer
 // there can be a priority request that will not be batched
 func (f *Fetch) loop() {
-	f.log.Info("starting main loop")
+	f.log.Info("starting fetch main loop")
 	for {
 		select {
 		case req := <-f.requestReceiver:
@@ -355,7 +359,7 @@ func (f *Fetch) FetchRequestHandler(ctx context.Context, data []byte) []byte {
 			f.log.WithContext(ctx).Warning("remote peer requested non existing hash %v %v", r.Hash.Hex(), err)
 			continue
 		} else {
-			f.log.WithContext(ctx).Info("responded to hash req %v bytes %v", r.Hash.ShortString(), len(res))
+			f.log.WithContext(ctx).Debug("responded to hash req %v bytes %v", r.Hash.ShortString(), len(res))
 		}
 		// add response to batch
 		m := responseMessage{
@@ -366,11 +370,11 @@ func (f *Fetch) FetchRequestHandler(ctx context.Context, data []byte) []byte {
 	}
 
 	bts, err := types.InterfaceToBytes(&resBatch)
-	f.log.WithContext(ctx).Info("returning response batch Id %v responses %v total bytes %v", resBatch.ID.Hex(), len(resBatch.Responses), len(bts))
 	if err != nil {
-		f.log.WithContext(ctx).Error("cannot parse message")
+		f.log.WithContext(ctx).Error("cannot parse message for batch ID %v", resBatch.ID.Hex())
 		return nil
 	}
+	f.log.WithContext(ctx).Debug("returning response batch Id %v responses %v total bytes %v", resBatch.ID.Hex(), len(resBatch.Responses), len(bts))
 	return bts
 }
 
@@ -383,7 +387,7 @@ func (f *Fetch) receiveResponse(data []byte) {
 	var response responseBatch
 	err := types.BytesToInterface(data, &response)
 	if err != nil {
-		f.log.Error("response was unclear, maybe leaking")
+		f.log.With().Error("response was unclear, maybe leaking", log.Err(err))
 		return
 	}
 
@@ -430,8 +434,8 @@ func (f *Fetch) receiveResponse(data []byte) {
 		f.activeReqM.Unlock()
 	}
 
-	//iterate all requests that didn't return value from peer and notify - they will be retried for MaxRetriesForRequest
-	err = fmt.Errorf("hash did not return")
+	// iterate all requests that didn't return value from peer and notify - they will be retried for MaxRetriesForRequest
+	err = fmt.Errorf("failed to fetch hash after max retries")
 	for h := range batchMap {
 		if f.stopped() {
 			return
@@ -443,9 +447,9 @@ func (f *Fetch) receiveResponse(data []byte) {
 		for _, req := range reqs {
 			req.retries++
 			if req.retries > f.cfg.MaxRetriesForRequest {
-				f.log.Error("returning error to request %v %v %v %p", req.hash.ShortString(), len(req.returnChan), len(reqs), req)
+				f.log.Debug("returning error to request %v %v %v %p", req.hash.ShortString(), len(req.returnChan), len(reqs), req)
 				req.returnChan <- HashDataPromiseResult{
-					Err:     err,
+					Err:     ErrExceedMaxRetries,
 					Hash:    req.hash,
 					Data:    []byte{},
 					IsLocal: false,
@@ -521,7 +525,7 @@ func (f *Fetch) sendBatch(requests []requestMessage) {
 
 		// get random peer
 		p := GetRandomPeer(f.net.GetPeers())
-		f.log.Info("sending request batch %v items %v", batch.ID.Hex(), len(batch.Requests))
+		f.log.Debug("sending request batch %v items %v peer %v", batch.ID.Hex(), len(batch.Requests), p)
 		err := f.net.SendRequest(context.TODO(), server.Fetch, bytes, p, f.receiveResponse, timeoutFunc)
 		// if call succeeded, continue to other requests
 		if err != nil {
@@ -541,7 +545,7 @@ func (f *Fetch) sendBatch(requests []requestMessage) {
 
 // handleHashError is called when an error occurred processing batches of the following hashes
 func (f *Fetch) handleHashError(batchHash types.Hash32, err error) {
-	f.log.Error("cannot fetch message %v err %v", batchHash.Hex(), err)
+	f.log.Debug("cannot fetch message %v err %v", batchHash.Hex(), err)
 	f.activeBatchM.RLock()
 	batch, ok := f.activeBatches[batchHash]
 	if !ok {
@@ -553,7 +557,7 @@ func (f *Fetch) handleHashError(batchHash types.Hash32, err error) {
 	f.activeReqM.Lock()
 	for _, h := range batch.Requests {
 		for _, callback := range f.pendingRequests[h.Hash] {
-			f.log.Error("hash error to request %v %v %v %p: %v", h.Hash.ShortString(), len(callback.returnChan), len(f.pendingRequests[h.Hash]), callback, err)
+			f.log.Debug("hash error to request %v %v %v %p: %v", h.Hash.ShortString(), len(callback.returnChan), len(f.pendingRequests[h.Hash]), callback, err)
 			callback.returnChan <- HashDataPromiseResult{
 				Err:     err,
 				Hash:    h.Hash,

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -298,7 +298,7 @@ func (s *Syncer) synchronize(ctx context.Context) bool {
 		if s.shouldValidateLayer(layerID) {
 			vQueue <- layer
 		}
-		logger.Info("finished data sync for layer %v", layerID)
+		logger.Debug("finished data sync for layer %v", layerID)
 	}
 	logger.With().Info("data is synced. waiting for validation",
 		log.FieldNamed("current", s.ticker.GetCurrentLayer()),
@@ -348,7 +348,6 @@ func (s *Syncer) syncLayer(ctx context.Context, layerID types.LayerID) (*types.L
 
 	layer, err := s.getLayerFromPeers(ctx, layerID)
 	if err != nil {
-		s.logger.WithContext(ctx).With().Error("failed to get layer from peers", layerID, log.Err(err))
 		return nil, err
 	}
 
@@ -393,7 +392,7 @@ func (s *Syncer) getATXs(ctx context.Context, layerID types.LayerID) error {
 	// - layerID is the last layer of a previous epoch
 	// i.e. for older epochs we sync ATXs once per epoch. for current epoch we sync ATXs in every layer
 	if epoch == currentEpoch || layerID == (epoch+1).FirstLayer().Sub(1) {
-		s.logger.WithContext(ctx).With().Info("getting ATXs", epoch, layerID)
+		s.logger.WithContext(ctx).With().Debug("getting ATXs", epoch, layerID)
 		ctx = log.WithNewRequestID(ctx, layerID.GetEpoch())
 		if err := s.fetcher.GetEpochATXs(ctx, epoch); err != nil {
 			s.logger.WithContext(ctx).With().Error("failed to fetch epoch ATXs", layerID, epoch, log.Err(err))
@@ -415,7 +414,7 @@ func (s *Syncer) getTortoiseBeacon(ctx context.Context, layerID types.LayerID) e
 	// - layerID is the last layer of a previous epoch
 	// i.e. for older epochs we sync tortoise beacons once per epoch. for current epoch we sync tortoise beacons in every layer
 	if epoch == currentEpoch || layerID == (epoch+1).FirstLayer().Sub(1) {
-		s.logger.WithContext(ctx).With().Info("getting tortoise beacons", epoch, layerID)
+		s.logger.WithContext(ctx).With().Debug("getting tortoise beacons", epoch, layerID)
 		ctx = log.WithNewRequestID(ctx, layerID.GetEpoch())
 		if err := s.fetcher.GetTortoiseBeacon(ctx, epoch); err != nil {
 			s.logger.WithContext(ctx).With().Error("failed to fetch epoch tortoise beacons", layerID, epoch, log.Err(err))
@@ -438,9 +437,9 @@ func (s *Syncer) shouldValidateLayer(layerID types.LayerID) bool {
 // start a dedicated process to validate layers one by one
 func (s *Syncer) startValidating(ctx context.Context, run uint64, queue chan *types.Layer, done chan struct{}) {
 	logger := s.logger.WithName("validation")
-	logger.Info("validation started for run #%v", run)
+	logger.Debug("validation started for run #%v", run)
 	defer func() {
-		logger.Info("validation done for run #%v", run)
+		logger.Debug("validation done for run #%v", run)
 		close(done)
 	}()
 	for layer := range queue {
@@ -457,7 +456,7 @@ func (s *Syncer) validateLayer(ctx context.Context, layer *types.Layer) {
 		return
 	}
 
-	s.logger.WithContext(ctx).With().Info("validating layer",
+	s.logger.WithContext(ctx).With().Debug("validating layer",
 		layer.Index(),
 		log.String("blocks", fmt.Sprint(types.BlockIDs(layer.Blocks()))))
 	s.mesh.ValidateLayer(layer)


### PR DESCRIPTION
## Motivation
- reduce logging level for high frequency events to reduce CI log size
- following up on review feedback for https://github.com/spacemeshos/go-spacemesh/pull/2557

## Changes
- change INFO -> DEBUG level for some high frequency events
- in fetcher.go, for high priority request, also make sure multiple SendRequest is not called.

## Test Plan
unit tests

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
