### PR TITLE
[Merged by Bors] - meshdb: do not recompute ID and MinerID when block is loaded from database

### DIFF
--- a/common/types/block.go
+++ b/common/types/block.go
@@ -280,6 +280,26 @@ func (b *Block) MinerID() *signing.PublicKey {
 	return b.minerID
 }
 
+// DBBlock is a Block structure as it is stored in DB.
+type DBBlock struct {
+	MiniBlock
+	// NOTE(dshulyak) this is a bit redundant to store ID here as well but less likely
+	// to break if in future key for database will be changed
+	ID        BlockID
+	Signature []byte
+	MinerID   []byte // derived from signature when block is received
+}
+
+// ToBlock create Block instance from data that is stored locally.
+func (b *DBBlock) ToBlock() *Block {
+	return &Block{
+		id:        b.ID,
+		MiniBlock: b.MiniBlock,
+		Signature: b.Signature,
+		minerID:   signing.NewPublicKey(b.MinerID),
+	}
+}
+
 // BlockIDs returns a slice of BlockIDs corresponding to the given blocks.
 func BlockIDs(blocks []*Block) []BlockID {
 	ids := make([]BlockID, 0, len(blocks))

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -56,7 +56,7 @@ type ErrCouldNotSend error
 type Fetcher interface {
 	GetHash(hash types.Hash32, h Hint, validateHash bool) chan HashDataPromiseResult
 	GetHashes(hash []types.Hash32, hint Hint, validateHash bool) map[types.Hash32]chan HashDataPromiseResult
-	AddDB(hint Hint, db database.Store)
+	AddDB(hint Hint, db database.Getter)
 	Stop()
 	Start()
 }
@@ -179,7 +179,7 @@ type network interface {
 type Fetch struct {
 	cfg                  Config
 	log                  log.Log
-	dbs                  map[Hint]database.Store
+	dbs                  map[Hint]database.Getter
 	activeRequests       map[types.Hash32][]*request
 	activeBatches        map[types.Hash32]requestBatch
 	net                  network
@@ -202,7 +202,7 @@ func NewFetch(ctx context.Context, cfg Config, network service.Service, logger l
 	f := &Fetch{
 		cfg:             cfg,
 		log:             logger,
-		dbs:             make(map[Hint]database.Store),
+		dbs:             make(map[Hint]database.Getter),
 		activeRequests:  make(map[types.Hash32][]*request),
 		net:             srv,
 		requestReceiver: make(chan request),
@@ -255,7 +255,7 @@ func (f *Fetch) stopped() bool {
 
 // AddDB adds a DB with corresponding hint
 // all network peersProvider will be able to query this DB
-func (f *Fetch) AddDB(hint Hint, db database.Store) {
+func (f *Fetch) AddDB(hint Hint, db database.Getter) {
 	f.dbLock.Lock()
 	f.dbs[hint] = db
 	f.dbLock.Unlock()

--- a/layerfetcher/layers.go
+++ b/layerfetcher/layers.go
@@ -166,7 +166,7 @@ func (l *Logic) Close() {
 }
 
 // AddDBs adds dbs that will be queried when sync requests are received. these databases will be exposed to external callers
-func (l *Logic) AddDBs(blockDB, AtxDB, TxDB, poetDB, IvDB, tbDB database.Store) {
+func (l *Logic) AddDBs(blockDB, AtxDB, TxDB, poetDB, IvDB, tbDB database.Getter) {
 	l.fetcher.AddDB(fetch.BlockDB, blockDB)
 	l.fetcher.AddDB(fetch.ATXDB, AtxDB)
 	l.fetcher.AddDB(fetch.TXDB, TxDB)

--- a/layerfetcher/layers_test.go
+++ b/layerfetcher/layers_test.go
@@ -122,7 +122,7 @@ func (m mockFetcher) Stop() {
 func (m mockFetcher) Start() {
 }
 
-func (m mockFetcher) AddDB(hint fetch.Hint, db database.Store) {
+func (m mockFetcher) AddDB(hint fetch.Hint, db database.Getter) {
 
 }
 

--- a/log/log.go
+++ b/log/log.go
@@ -78,6 +78,11 @@ func JSONLog(b bool) {
 	initLogging()
 }
 
+// NewNop creates silent logger.
+func NewNop() Log {
+	return NewFromLog(zap.NewNop())
+}
+
 // NewWithLevel creates a logger with a fixed level and with a set of (optional) hooks
 func NewWithLevel(module string, level zap.AtomicLevel, hooks ...func(zapcore.Entry) error) Log {
 	consoleSyncer := zapcore.AddSync(logwriter)

--- a/mesh/meshdb_test.go
+++ b/mesh/meshdb_test.go
@@ -73,9 +73,10 @@ func TestMeshDB_AddBlock(t *testing.T) {
 	rBlock1, err := mdb.GetBlock(block1.ID())
 	assert.NoError(t, err)
 
-	assert.True(t, len(rBlock1.TxIDs) == len(block1.TxIDs), "block content was wrong")
-	assert.True(t, len(*rBlock1.ActiveSet) == len(*block1.ActiveSet), "block content was wrong")
-	// assert.True(t, bytes.Compare(rBlock2.Data, []byte("data2")) == 0, "block content was wrong")
+	assert.Equal(t, block1.ID(), rBlock1.ID())
+	assert.Equal(t, block1.MinerID(), rBlock1.MinerID())
+	assert.Equal(t, len(rBlock1.TxIDs), len(block1.TxIDs), "block content was wrong")
+	assert.Equal(t, len(*rBlock1.ActiveSet), len(*block1.ActiveSet), "block content was wrong")
 }
 
 func chooseRandomPattern(blocksInLayer int, patternSize int) []int {
@@ -1009,8 +1010,9 @@ func BenchmarkGetBlockHeader(b *testing.B) {
 	// blocks is set to be twice as large as cache to avoid hitting the cache
 	cache := layerSize
 	blocks := make([]*types.Block, cache*2)
-	// 1 is passed as a cache size because it is actually multiplied by layerSize
-	db, err := NewPersistentMeshDB(b.TempDir(), 1, log.NewNop())
+	db, err := NewPersistentMeshDB(b.TempDir(),
+		1, /*size of the cache is multiplied by a constant (layerSize). for the benchmark it needs to be no more than layerSize*/
+		log.NewNop())
 	require.NoError(b, err)
 	for i := range blocks {
 		blocks[i] = types.NewExistingBlock(types.NewLayerID(1), []byte(rand.String(8)), nil)

--- a/mesh/meshdb_test.go
+++ b/mesh/meshdb_test.go
@@ -975,3 +975,24 @@ func TestMesh_FindOnce(t *testing.T) {
 		}
 	})
 }
+
+func BenchmarkGetBlockHeader(b *testing.B) {
+	// blocks is set to be twice as large as cache to avoid hitting the cache
+	cache := layerSize
+	blocks := make([]*types.Block, cache*2)
+	// 1 is passed as a cache size because it is actually multiplied by layerSize
+	db, err := NewPersistentMeshDB(b.TempDir(), 1, log.NewNop())
+	require.NoError(b, err)
+	for i := range blocks {
+		blocks[i] = types.NewExistingBlock(1, []byte(rand.String(8)), nil)
+		require.NoError(b, db.AddBlock(blocks[i]))
+	}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		block := blocks[i%len(blocks)]
+		_, err = db.GetBlock(block.ID())
+		require.NoError(b, err)
+	}
+}


### PR DESCRIPTION
## Motivation

blk.Initialize function is very slow, see the difference in benchmark:

```
benchmark                      old ns/op     new ns/op     delta
BenchmarkGetBlockHeader-16     119538        2810          -97.65%
```

It computes MinerID from signature and ID from encoded block every time when we load block from database.

related: https://github.com/spacemeshos/go-spacemesh/issues/2478

## Changes
Introduce DBBlock type that will encode ID and MinerID as a part of the block when block is saved to the local database.

## Test Plan
unit tests
## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
