### PR TITLE
[Merged by Bors] - fetcher batch timeout use config value

### DIFF
--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -217,7 +217,7 @@ func NewFetch(ctx context.Context, cfg Config, network service.Service, logger l
 		pendingRequests: make(map[types.Hash32][]*request),
 		net:             srv,
 		requestReceiver: make(chan request),
-		batchTimeout:    time.NewTicker(time.Millisecond * 50),
+		batchTimeout:    time.NewTicker(time.Second * time.Duration(cfg.BatchTimeout)),
 		stop:            make(chan struct{}),
 		activeBatches:   make(map[types.Hash32]requestBatch),
 		doneChan:        make(chan struct{}),

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -122,7 +122,7 @@ type responseBatch struct {
 
 // Config is the configuration file of the Fetch component
 type Config struct {
-	BatchTimeout         int // in seconds
+	BatchTimeout         int // in milliseconds
 	MaxRetiresForPeer    int
 	BatchSize            int
 	RequestTimeout       int // in seconds
@@ -132,7 +132,7 @@ type Config struct {
 // DefaultConfig is the default config for the fetch component
 func DefaultConfig() Config {
 	return Config{
-		BatchTimeout:         1,
+		BatchTimeout:         50,
 		MaxRetiresForPeer:    2,
 		BatchSize:            20,
 		RequestTimeout:       10,
@@ -217,7 +217,7 @@ func NewFetch(ctx context.Context, cfg Config, network service.Service, logger l
 		pendingRequests: make(map[types.Hash32][]*request),
 		net:             srv,
 		requestReceiver: make(chan request),
-		batchTimeout:    time.NewTicker(time.Second * time.Duration(cfg.BatchTimeout)),
+		batchTimeout:    time.NewTicker(time.Millisecond * time.Duration(cfg.BatchTimeout)),
 		stop:            make(chan struct{}),
 		activeBatches:   make(map[types.Hash32]requestBatch),
 		doneChan:        make(chan struct{}),

--- a/fetch/fetch_test.go
+++ b/fetch/fetch_test.go
@@ -126,7 +126,7 @@ var _ service.Service = (*mockNet)(nil)
 
 func defaultFetch() (*Fetch, *mockNet) {
 	cfg := Config{
-		3,
+		2000, // make sure we never hit the batch timeout
 		3,
 		3,
 		3,
@@ -162,7 +162,6 @@ func TestFetch_GetHash(t *testing.T) {
 	f, _ := defaultFetch()
 	defer f.Stop()
 	f.Start()
-	f.cfg.BatchTimeout = 2000 // make sure we never hit the batch timeout
 	h1 := randomHash()
 	hint := Hint("db")
 	hint2 := Hint("db2")


### PR DESCRIPTION
## Motivation
fetch batch timeout is hard-coded and the config value is ignored. we should use the config value.

## Changes
- use config.BatchTimeout for the fetch loop's time ticker value
- changed test to use a timeout so the ticker doesn't tick. TestFetch_requestHashFromPeers_BatchRequestMax is flaky because occasionally the ticker ticks and 2 batches become 3 batches

## Test Plan
unit test

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
