### PR TITLE
[Merged by Bors] - fetch: fix bug where random peer always gets the same peer

### DIFF
--- a/activation/activation.go
+++ b/activation/activation.go
@@ -495,18 +495,18 @@ func (b *Builder) PublishActivationTx(ctx context.Context) error {
 		return err
 	}
 
-	b.log.Event().Info("atx published", atx.Fields(size)...)
+	b.log.Event().Info(fmt.Sprintf("atx published %v", atx.ID().ShortString()), atx.Fields(size)...)
 	events.ReportAtxCreated(true, uint32(b.currentEpoch()), atx.ShortString())
 
 	select {
 	case <-atxReceived:
-		b.log.With().Info("received atx in db", atx.ID())
+		b.log.With().Info(fmt.Sprintf("received atx in db %v", atx.ID().ShortString()), atx.ID())
 	case <-b.layerClock.AwaitLayer((atx.TargetEpoch() + 1).FirstLayer()):
 		syncedCh := make(chan struct{})
 		b.syncer.RegisterChForSynced(ctx, syncedCh)
 		select {
 		case <-atxReceived:
-			b.log.With().Info("received atx in db (in the last moment)", atx.ID())
+			b.log.With().Info(fmt.Sprintf("received atx in db %v (in the last moment)", atx.ID().ShortString()), atx.ID())
 		case <-syncedCh: // ensure we've seen all blocks before concluding that the ATX was lost
 			b.discardChallenge()
 			return fmt.Errorf("%w: target epoch has passed", ErrATXChallengeExpired)

--- a/activation/atxdb.go
+++ b/activation/atxdb.go
@@ -724,7 +724,7 @@ func (db *DB) HandleAtxData(ctx context.Context, data []byte, fetcher service.Fe
 	atx.CalcAndSetID()
 	logger := db.log.WithContext(ctx).WithFields(atx.ID())
 
-	logger.With().Info("got new atx", atx.Fields(len(data))...)
+	logger.With().Info(fmt.Sprintf("got new atx %v", atx.ID().ShortString()), atx.Fields(len(data))...)
 
 	if atx.Nipst == nil {
 		return fmt.Errorf("nil nipst in gossip for atx %s", atx.ShortString())

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -137,10 +137,11 @@ type Config struct {
 // DefaultConfig is the default config for the fetch component
 func DefaultConfig() Config {
 	return Config{
-		BatchTimeout:         50,
-		MaxRetiresForPeer:    2,
-		BatchSize:            20,
-		RequestTimeout:       10,
+		BatchTimeout:      50,
+		MaxRetiresForPeer: 2,
+		BatchSize:         20,
+		RequestTimeout:    10,
+		// TODO change it back to 20
 		MaxRetriesForRequest: 2000,
 	}
 }
@@ -170,7 +171,6 @@ func GetRandomPeer(peers []peers.Peer) peers.Peer {
 	if len(peers) == 0 {
 		log.Panic("cannot send fetch - no peers found")
 	}
-	rand.Seed(time.Now().Unix()) // initialize global pseudo random generator
 	return peers[rand.Intn(len(peers))]
 }
 

--- a/fetch/fetch_test.go
+++ b/fetch/fetch_test.go
@@ -38,11 +38,6 @@ func (m mockNet) Close() {
 func (m mockNet) RegisterBytesMsgHandler(msgType server.MessageType, reqHandler func(context.Context, []byte) []byte) {
 }
 
-func (m mockNet) GetRandomPeer() peers.Peer {
-	_, pub1, _ := p2pcrypto.GenerateKeyPair()
-	return pub1
-}
-
 func (m mockNet) Start(ctx context.Context) error {
 	return nil
 }
@@ -446,4 +441,19 @@ func TestFetch_handleNewRequest_MultipleReqsForSameHashHighPriority(t *testing.T
 
 	}
 	assert.Equal(t, 2, net.TotalBatchCalls)
+}
+
+func TestFetch_GetRandomPeer(t *testing.T) {
+	peers := make([]peers.Peer, 1000)
+	for i := 0; i < len(peers); i++ {
+		_, pub, _ := p2pcrypto.GenerateKeyPair()
+		peers[i] = pub
+	}
+	allTheSame := true
+	for i := 0; i < 20; i++ {
+		if GetRandomPeer(peers) != GetRandomPeer(peers) {
+			allTheSame = false
+		}
+	}
+	assert.False(t, allTheSame)
 }

--- a/rand/rand.go
+++ b/rand/rand.go
@@ -6,6 +6,11 @@ import (
 	"time"
 )
 
+func init() {
+	// initialize global pseudo random generator
+	rand.Seed(time.Now().Unix())
+}
+
 /*
  * Top-level convenience functions
  */


### PR DESCRIPTION
## Motivation
rand only need to be seeded once, otherwise the pseudorandom will generate the same sequence with similar seed values
Closes: https://github.com/spacemeshos/go-spacemesh/issues/2575

## Changes
- only seed math/rand module once
- remember the peer in batch request and log it when hash is not found in response

## Test Plan
unit test

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
