### PR TITLE
[Merged by Bors] - cobra command splitted from app execution logic

### DIFF
--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -106,10 +106,6 @@ var Cmd = &cobra.Command{
 				log.With().Error("Failed to initialize node.", log.Err(err))
 				return err
 			}
-			if err := app.Initialize(); err != nil {
-				log.With().Error("Failed to initialize node.", log.Err(err))
-				return err
-			}
 			// This blocks until the context is finished or until an error is produced
 			err := app.Start()
 			if err != nil {
@@ -269,7 +265,7 @@ func (app *SpacemeshApp) InitializeCmd(cmd *cobra.Command, args []string) (err e
 		return err
 	}
 
-	return nil
+	return app.Initialize()
 }
 
 // Initialize sets up an exit signal, logging and checks the clock, returns error if clock is not in sync

--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -102,19 +102,23 @@ var Cmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		app := NewSpacemeshApp()
 		starter := func() error {
-			if err := app.Initialize(cmd, args); err != nil {
+			if err := app.InitializeCmd(cmd, args); err != nil {
+				log.With().Error("Failed to initialize node.", log.Err(err))
+				return err
+			}
+			if err := app.Initialize(); err != nil {
 				log.With().Error("Failed to initialize node.", log.Err(err))
 				return err
 			}
 			// This blocks until the context is finished or until an error is produced
-			err := app.Start(cmd, args)
+			err := app.Start()
 			if err != nil {
 				log.With().Error("Failed to start the node. See logs for details.", log.Err(err))
 			}
 			return err
 		}
 		err := starter()
-		app.Cleanup(cmd, args)
+		app.Cleanup()
 		if err != nil {
 			os.Exit(1)
 		}
@@ -246,20 +250,7 @@ func (app *SpacemeshApp) introduction() {
 }
 
 // Initialize does pre processing of flags and configuration files, it also initializes data dirs if they dont exist
-func (app *SpacemeshApp) Initialize(cmd *cobra.Command, args []string) (err error) {
-	// exit gracefully - e.g. with app Cleanup on sig abort (ctrl-c)
-	signalChan := make(chan os.Signal, 1)
-	signal.Notify(signalChan, os.Interrupt)
-
-	// Goroutine that listens for Ctrl ^ C command
-	// and triggers the quit app
-	go func() {
-		for range signalChan {
-			log.Info("Received an interrupt, stopping services...\n")
-			cmdp.Cancel()
-		}
-	}()
-
+func (app *SpacemeshApp) InitializeCmd(cmd *cobra.Command, args []string) (err error) {
 	// parse the config file based on flags et al
 	if err := app.ParseConfig(); err != nil {
 		log.Error(fmt.Sprintf("couldn't parse the config err=%v", err))
@@ -277,6 +268,24 @@ func (app *SpacemeshApp) Initialize(cmd *cobra.Command, args []string) (err erro
 	if err != nil {
 		return err
 	}
+
+	return nil
+}
+
+// Initialize does pre processing of flags and configuration files, it also initializes data dirs if they dont exist
+func (app *SpacemeshApp) Initialize() (err error) {
+	// exit gracefully - e.g. with app Cleanup on sig abort (ctrl-c)
+	signalChan := make(chan os.Signal, 1)
+	signal.Notify(signalChan, os.Interrupt)
+
+	// Goroutine that listens for Ctrl ^ C command
+	// and triggers the quit app
+	go func() {
+		for range signalChan {
+			log.Info("Received an interrupt, stopping services...\n")
+			cmdp.Cancel()
+		}
+	}()
 
 	app.setupLogging()
 
@@ -328,7 +337,7 @@ func (app *SpacemeshApp) getAppInfo() string {
 }
 
 // Cleanup stops all app services
-func (app *SpacemeshApp) Cleanup(*cobra.Command, []string) {
+func (app *SpacemeshApp) Cleanup() {
 	log.Info("app cleanup starting...")
 	app.stopServices()
 	// add any other Cleanup tasks here....
@@ -994,7 +1003,7 @@ func (app *SpacemeshApp) startSyncer(ctx context.Context) {
 }
 
 // Start starts the Spacemesh node and initializes all relevant services according to command line arguments provided.
-func (app *SpacemeshApp) Start(*cobra.Command, []string) error {
+func (app *SpacemeshApp) Start() error {
 	// we use the main app context
 	ctx := cmdp.Ctx
 	// Create a contextual logger for local usage (lower-level modules will create their own contextual loggers

--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -249,7 +249,7 @@ func (app *SpacemeshApp) introduction() {
 	log.Info("Welcome to Spacemesh. Spacemesh full node is starting...")
 }
 
-// Initialize does pre processing of flags and configuration files, it also initializes data dirs if they dont exist
+// InitializeCmd does pre processing of flags and configuration files, it also initializes data dirs if they dont exist
 func (app *SpacemeshApp) InitializeCmd(cmd *cobra.Command, args []string) (err error) {
 	// parse the config file based on flags et al
 	if err := app.ParseConfig(); err != nil {
@@ -272,7 +272,7 @@ func (app *SpacemeshApp) InitializeCmd(cmd *cobra.Command, args []string) (err e
 	return nil
 }
 
-// Initialize does pre processing of flags and configuration files, it also initializes data dirs if they dont exist
+// Initialize sets up an exit signal, logging and checks the clock, returns error if clock is not in sync
 func (app *SpacemeshApp) Initialize() (err error) {
 	// exit gracefully - e.g. with app Cleanup on sig abort (ctrl-c)
 	signalChan := make(chan os.Signal, 1)

--- a/cmd/node/node_test.go
+++ b/cmd/node/node_test.go
@@ -195,7 +195,7 @@ func TestSpacemeshApp_Cmd(t *testing.T) {
 
 	// Test a legal flag
 	Cmd.Run = func(cmd *cobra.Command, args []string) {
-		r.NoError(app.Initialize(cmd, args))
+		r.NoError(app.Initialize())
 	}
 	str, err = testArgs("--test-mode")
 
@@ -237,7 +237,7 @@ func TestSpacemeshApp_GrpcFlags(t *testing.T) {
 
 	// Try enabling an illegal service
 	Cmd.Run = func(cmd *cobra.Command, args []string) {
-		err := app.Initialize(cmd, args)
+		err := app.Initialize()
 		r.Error(err)
 		r.Equal("unrecognized GRPC service requested: illegal", err.Error())
 	}
@@ -286,7 +286,7 @@ func TestSpacemeshApp_GrpcFlags(t *testing.T) {
 
 	// This should work
 	Cmd.Run = func(cmd *cobra.Command, args []string) {
-		r.NoError(app.Initialize(cmd, args))
+		r.NoError(app.Initialize())
 	}
 	str, err = testArgs("--grpc", "node")
 	r.Empty(str)
@@ -342,7 +342,7 @@ func TestSpacemeshApp_JsonFlags(t *testing.T) {
 
 	// Try enabling just the JSON service (without the GRPC service)
 	Cmd.Run = func(cmd *cobra.Command, args []string) {
-		err := app.Initialize(cmd, args)
+		err := app.Initialize()
 		r.Error(err)
 		r.Equal("must enable at least one GRPC service along with JSON gateway service", err.Error())
 	}
@@ -357,7 +357,7 @@ func TestSpacemeshApp_JsonFlags(t *testing.T) {
 
 	// Try enabling both the JSON and the GRPC services
 	Cmd.Run = func(cmd *cobra.Command, args []string) {
-		r.NoError(app.Initialize(cmd, args))
+		r.NoError(app.Initialize())
 	}
 	str, err = testArgs("--grpc", "node", "--json-server")
 	r.NoError(err)
@@ -419,7 +419,7 @@ func TestSpacemeshApp_GrpcService(t *testing.T) {
 	path := t.TempDir()
 
 	Cmd.Run = func(cmd *cobra.Command, args []string) {
-		r.NoError(app.Initialize(cmd, args))
+		r.NoError(app.Initialize())
 		app.Config.API.GrpcServerPort = port
 		app.Config.DataDirParent = path
 		app.startAPIServices(context.TODO(), NetMock{})
@@ -490,7 +490,7 @@ func TestSpacemeshApp_JsonService(t *testing.T) {
 
 	// Make sure the service is not running by default
 	Cmd.Run = func(cmd *cobra.Command, args []string) {
-		r.NoError(app.Initialize(cmd, args))
+		r.NoError(app.Initialize())
 		app.Config.DataDirParent = path
 		app.startAPIServices(context.TODO(), NetMock{})
 	}
@@ -564,8 +564,8 @@ func TestSpacemeshApp_NodeService(t *testing.T) {
 	//app := NewSpacemeshApp()
 
 	Cmd.Run = func(cmd *cobra.Command, args []string) {
-		defer app.Cleanup(cmd, args)
-		require.NoError(t, app.Initialize(cmd, args))
+		defer app.Cleanup()
+		require.NoError(t, app.Initialize())
 
 		// Give the error channel a buffer
 		events.CloseEventReporter()
@@ -579,7 +579,7 @@ func TestSpacemeshApp_NodeService(t *testing.T) {
 		// This will block. We need to run the full app here to make sure that
 		// the various services are reporting events correctly. This could probably
 		// be done more surgically, and we don't need _all_ of the services.
-		require.NoError(t, app.Start(cmd, args))
+		require.NoError(t, app.Start())
 	}
 
 	// Run the app in a goroutine. As noted above, it blocks if it succeeds.
@@ -742,8 +742,8 @@ func TestSpacemeshApp_TransactionService(t *testing.T) {
 	app.Config = &cfg
 
 	Cmd.Run = func(cmd *cobra.Command, args []string) {
-		defer app.Cleanup(cmd, args)
-		r.NoError(app.Initialize(cmd, args))
+		defer app.Cleanup()
+		r.NoError(app.Initialize())
 
 		app.Config.DataDirParent = path
 
@@ -771,7 +771,7 @@ func TestSpacemeshApp_TransactionService(t *testing.T) {
 		// This will block. We need to run the full app here to make sure that
 		// the various services are reporting events correctly. This could probably
 		// be done more surgically, and we don't need _all_ of the services.
-		require.NoError(t, app.Start(cmd, args))
+		require.NoError(t, app.Start())
 	}
 
 	// Run the app in a goroutine. As noted above, it blocks if it succeeds.

--- a/cmd/node/node_test.go
+++ b/cmd/node/node_test.go
@@ -195,7 +195,7 @@ func TestSpacemeshApp_Cmd(t *testing.T) {
 
 	// Test a legal flag
 	Cmd.Run = func(cmd *cobra.Command, args []string) {
-		r.NoError(app.Initialize())
+		r.NoError(app.InitializeCmd(cmd, args))
 	}
 	str, err = testArgs("--test-mode")
 
@@ -237,7 +237,7 @@ func TestSpacemeshApp_GrpcFlags(t *testing.T) {
 
 	// Try enabling an illegal service
 	Cmd.Run = func(cmd *cobra.Command, args []string) {
-		err := app.Initialize()
+		err := app.InitializeCmd(cmd, args)
 		r.Error(err)
 		r.Equal("unrecognized GRPC service requested: illegal", err.Error())
 	}
@@ -286,7 +286,7 @@ func TestSpacemeshApp_GrpcFlags(t *testing.T) {
 
 	// This should work
 	Cmd.Run = func(cmd *cobra.Command, args []string) {
-		r.NoError(app.Initialize())
+		r.NoError(app.InitializeCmd(cmd, args))
 	}
 	str, err = testArgs("--grpc", "node")
 	r.Empty(str)
@@ -342,7 +342,7 @@ func TestSpacemeshApp_JsonFlags(t *testing.T) {
 
 	// Try enabling just the JSON service (without the GRPC service)
 	Cmd.Run = func(cmd *cobra.Command, args []string) {
-		err := app.Initialize()
+		err := app.InitializeCmd(cmd, args)
 		r.Error(err)
 		r.Equal("must enable at least one GRPC service along with JSON gateway service", err.Error())
 	}
@@ -357,7 +357,7 @@ func TestSpacemeshApp_JsonFlags(t *testing.T) {
 
 	// Try enabling both the JSON and the GRPC services
 	Cmd.Run = func(cmd *cobra.Command, args []string) {
-		r.NoError(app.Initialize())
+		r.NoError(app.InitializeCmd(cmd, args))
 	}
 	str, err = testArgs("--grpc", "node", "--json-server")
 	r.NoError(err)
@@ -419,7 +419,7 @@ func TestSpacemeshApp_GrpcService(t *testing.T) {
 	path := t.TempDir()
 
 	Cmd.Run = func(cmd *cobra.Command, args []string) {
-		r.NoError(app.Initialize())
+		r.NoError(app.InitializeCmd(cmd, args))
 		app.Config.API.GrpcServerPort = port
 		app.Config.DataDirParent = path
 		app.startAPIServices(context.TODO(), NetMock{})
@@ -490,7 +490,7 @@ func TestSpacemeshApp_JsonService(t *testing.T) {
 
 	// Make sure the service is not running by default
 	Cmd.Run = func(cmd *cobra.Command, args []string) {
-		r.NoError(app.Initialize())
+		r.NoError(app.InitializeCmd(cmd, args))
 		app.Config.DataDirParent = path
 		app.startAPIServices(context.TODO(), NetMock{})
 	}
@@ -565,6 +565,7 @@ func TestSpacemeshApp_NodeService(t *testing.T) {
 
 	Cmd.Run = func(cmd *cobra.Command, args []string) {
 		defer app.Cleanup()
+		require.NoError(t, app.InitializeCmd(cmd, args))
 		require.NoError(t, app.Initialize())
 
 		// Give the error channel a buffer


### PR DESCRIPTION
## Motivation
We want to be able to access the node package without being tied to using cobra.

Closes #2594 

## Changes

separate the methods that initialize and start `go-spacemesh` from the structs in `cobra`

