### PR TITLE
[Merged by Bors] - make sure rand is not seeded more than once in prod binary

### DIFF
--- a/activation/activationdb_test.go
+++ b/activation/activationdb_test.go
@@ -209,7 +209,6 @@ func createLayerWithAtx(t *testing.T, msh *mesh.Mesh, id types.LayerID, numOfBlo
 }
 
 func TestATX_ActiveSetForLayerView(t *testing.T) {
-	rand.Seed(1234573298579)
 	atxdb, layers, _ := getAtxDb(t.Name())
 	blocksMap := make(map[types.BlockID]struct{})
 	id1 := types.NodeID{Key: rndStr(), VRFPublicKey: []byte("anton")}

--- a/common/types/block.go
+++ b/common/types/block.go
@@ -8,12 +8,10 @@ import (
 	"strconv"
 	"strings"
 	"sync/atomic"
-	"time"
 
 	"github.com/spacemeshos/ed25519"
 	"github.com/spacemeshos/go-spacemesh/common/util"
 	"github.com/spacemeshos/go-spacemesh/log"
-	"github.com/spacemeshos/go-spacemesh/rand"
 	"github.com/spacemeshos/go-spacemesh/signing"
 )
 
@@ -444,16 +442,4 @@ func SortBlockIDs(ids []BlockID) []BlockID {
 func SortBlocks(ids []*Block) []*Block {
 	sort.Slice(ids, func(i, j int) bool { return ids[i].ID().Compare(ids[j].ID()) })
 	return ids
-}
-
-// RandomBlockID generates random block id
-func RandomBlockID() BlockID {
-	rand.Seed(time.Now().UnixNano())
-	b := make([]byte, 8)
-	_, err := rand.Read(b)
-	// Note that err == nil only if we read len(b) bytes.
-	if err != nil {
-		return BlockID{}
-	}
-	return BlockID(CalcHash32(b).ToHash20())
 }

--- a/common/types/block_test.go
+++ b/common/types/block_test.go
@@ -3,17 +3,12 @@ package types
 import (
 	"math"
 	"testing"
-	"time"
 
 	"github.com/spacemeshos/go-spacemesh/common/util"
 	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/rand"
 	"github.com/stretchr/testify/require"
 )
-
-func init() {
-	rand.Seed(time.Now().UnixNano())
-}
 
 func genByte32() [32]byte {
 	var x [32]byte

--- a/layerfetcher/layers_test.go
+++ b/layerfetcher/layers_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"testing"
-	"time"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/database"
@@ -19,7 +18,6 @@ import (
 )
 
 func randomHash() types.Hash32 {
-	rand.Seed(time.Now().UnixNano())
 	b := make([]byte, 8)
 	_, err := rand.Read(b)
 	// Note that Err == nil only if we read len(b) bytes.
@@ -27,6 +25,17 @@ func randomHash() types.Hash32 {
 		return types.Hash32{}
 	}
 	return types.CalcHash32(b)
+}
+
+// RandomBlockID generates random block id
+func randomBlockID() types.BlockID {
+	b := make([]byte, 8)
+	_, err := rand.Read(b)
+	// Note that err == nil only if we read len(b) bytes.
+	if err != nil {
+		return types.BlockID{}
+	}
+	return types.BlockID(types.CalcHash32(b).ToHash20())
 }
 
 type mockNet struct {
@@ -161,8 +170,8 @@ func TestLayerHashBlocksReqReceiver(t *testing.T) {
 	db := newLayerDBMock()
 	l := NewMockLogic(newMockNet(), db, db, &mockBlocks{}, &mockAtx{}, &mockFetcher{}, log.NewDefault("layerFetch"))
 	h := randomHash()
-	db.layers[h] = []types.BlockID{types.RandomBlockID(), types.RandomBlockID(), types.RandomBlockID(), types.RandomBlockID()}
-	db.vectors[h] = []types.BlockID{types.RandomBlockID(), types.RandomBlockID(), types.RandomBlockID()}
+	db.layers[h] = []types.BlockID{randomBlockID(), randomBlockID(), randomBlockID(), randomBlockID()}
+	db.vectors[h] = []types.BlockID{randomBlockID(), randomBlockID(), randomBlockID()}
 
 	outB := l.layerHashBlocksReqReceiver(context.TODO(), h.Bytes())
 
@@ -315,8 +324,8 @@ func TestPollLayerHash_AllDifferent(t *testing.T) {
 
 func generateLayerBlocks() []byte {
 	lb := layerBlocks{
-		Blocks:          []types.BlockID{types.RandomBlockID(), types.RandomBlockID(), types.RandomBlockID(), types.RandomBlockID()},
-		VerifyingVector: []types.BlockID{types.RandomBlockID(), types.RandomBlockID(), types.RandomBlockID()},
+		Blocks:          []types.BlockID{randomBlockID(), randomBlockID(), randomBlockID(), randomBlockID()},
+		VerifyingVector: []types.BlockID{randomBlockID(), randomBlockID(), randomBlockID()},
 	}
 	out, _ := types.InterfaceToBytes(lb)
 	return out

--- a/mesh/meshdb_test.go
+++ b/mesh/meshdb_test.go
@@ -79,7 +79,6 @@ func TestMeshDB_AddBlock(t *testing.T) {
 }
 
 func chooseRandomPattern(blocksInLayer int, patternSize int) []int {
-	rand.Seed(time.Now().UnixNano())
 	p := rand.Perm(blocksInLayer)
 	indexes := make([]int, 0, patternSize)
 	for _, r := range p[:patternSize] {

--- a/p2p/node/helpers.go
+++ b/p2p/node/helpers.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net"
 	"testing"
-	"time"
 
 	"github.com/spacemeshos/go-spacemesh/p2p/p2pcrypto"
 	"github.com/spacemeshos/go-spacemesh/rand"
@@ -47,7 +46,6 @@ func GenerateTestNodeWithConfig(t *testing.T) (LocalNode, *Info) {
 
 // GenerateRandomNodeData generates a remote random node data for testing.
 func GenerateRandomNodeData() *Info {
-	rand.Seed(time.Now().UnixNano())
 	port := uint16(rand.Int31n(48127) + 1024)
 	pub := p2pcrypto.NewRandomPubkey()
 	return NewNode(pub, localhost, port, port)

--- a/trie/proof_test.go
+++ b/trie/proof_test.go
@@ -19,17 +19,13 @@ package trie
 import (
 	"bytes"
 	crand "crypto/rand"
+	"testing"
+
 	"github.com/spacemeshos/go-spacemesh/common/util"
 	"github.com/spacemeshos/go-spacemesh/crypto"
 	"github.com/spacemeshos/go-spacemesh/database"
 	mrand "github.com/spacemeshos/go-spacemesh/rand"
-	"testing"
-	"time"
 )
-
-func init() {
-	mrand.Seed(time.Now().Unix())
-}
 
 // makeProvers creates Merkle trie provers based on different implementations to
 // test all variations.


### PR DESCRIPTION
## Motivation
for true pseudo-random, make sure we don't seed it multiple times in production code path

## Changes
apart from tests that uses special seed for rand, remove all other Seed calls that expect pseudo random.

## Test Plan
unit test

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
