### PR TITLE
set cgo ldflafs to environment, use $(make ldflags) command

### DIFF
--- a/Makefile.Inc
+++ b/Makefile.Inc
@@ -100,3 +100,8 @@ ldflags:
 	$(shell $(MAKE) -s get-gpu-setup 1>&2)
 	@echo 'export CGO_LDFLAGS="$(CGO_TEST_LDFLAGS)"' > /tmp/.go-spacemesh.ldflags
 	@echo . /tmp/.go-spacemesh.ldflags
+.PHONY: ldflags
+
+print-ldflags: get-gpu-setup
+	@echo $(CGO_TEST_LDFLAGS)
+.PHONY: print-ldflags

--- a/Makefile.Inc
+++ b/Makefile.Inc
@@ -94,7 +94,9 @@ print-test-targets:
 	done
 .PHONY: $(SUBDIRS_ALL) $(SUBDIRS_LVL2) $(SUBDIRS_ONLY) print-test-targets
 
+$(info $(word 1,$@))
+
 ldflags:
 	$(shell $(MAKE) -s get-gpu-setup 1>&2)
-	$(file >/tmp/.go-spacemesh.ldflags, export CGO_LDFLAGS="$(CGO_TEST_LDFLAGS)")
+	@echo 'export CGO_LDFLAGS="$(CGO_TEST_LDFLAGS)"' > /tmp/.go-spacemesh.ldflags
 	@echo . /tmp/.go-spacemesh.ldflags

--- a/Makefile.Inc
+++ b/Makefile.Inc
@@ -36,7 +36,9 @@ else
   endif
 endif
 
-$(info "OS: $(OS), HOST_OS: $(HOST_OS), GOOS: $(GOOS), GOARCH: $(GOARH), BIN_DIR: $(BIN_DIR), platform: $(platform)")
+ifneq ($(VERBOSE),)
+  $(info "OS: $(OS), HOST_OS: $(HOST_OS), GOOS: $(GOOS), GOARCH: $(GOARH), BIN_DIR: $(BIN_DIR), platform: $(platform)")
+endif
 
 GPU_SETUP_REV = 0.1.21
 GPU_SETUP_ZIP = libgpu-setup-$(platform)-$(GPU_SETUP_REV).zip
@@ -92,3 +94,7 @@ print-test-targets:
 	done
 .PHONY: $(SUBDIRS_ALL) $(SUBDIRS_LVL2) $(SUBDIRS_ONLY) print-test-targets
 
+ldflags:
+	$(shell $(MAKE) -s get-gpu-setup 1>&2)
+	$(file >/tmp/.go-spacemesh.ldflags, export CGO_LDFLAGS="$(CGO_TEST_LDFLAGS)")
+	@echo . /tmp/.go-spacemesh.ldflags


### PR DESCRIPTION
It sets CGO_LDFLAGS environment variable. Use it before start go test ... 

```
[sudachen/go-spacemesh|ldflags] ../go-spacemesh$ $(make ldflags)
[sudachen/go-spacemesh|ldflags] ../go-spacemesh$ go test ./activation
ok  	github.com/spacemeshos/go-spacemesh/activation	25.937s
```

To run tests in goland you need to setup environment variable in setting. To know the CGO_LDFLAGS value run in terminal `make print-ldflags`

![image](https://user-images.githubusercontent.com/1428/127210074-42d7f58e-ee59-4602-bd22-085c79efe285.png)
