### PR TITLE
[Merged by Bors] - fix flaky syncer test TestSynchronize_OnlyOneSynchronize

### DIFF
--- a/syncer/syncer_test.go
+++ b/syncer/syncer_test.go
@@ -209,21 +209,23 @@ func TestSynchronize_OnlyOneSynchronize(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(2)
 	first, second := true, true
-	atLeastOneStarted := make(chan struct{}, 2)
+	started := make(chan struct{}, 2)
 	go func() {
-		atLeastOneStarted <- struct{}{}
+		started <- struct{}{}
 		first = syncer.synchronize(context.TODO())
 		wg.Done()
 	}()
 	go func() {
-		atLeastOneStarted <- struct{}{}
+		started <- struct{}{}
 		second = syncer.synchronize(context.TODO())
 		wg.Done()
 	}()
 
-	// allow synchronize to finish
 	current := ticker.GetCurrentLayer()
-	<-atLeastOneStarted
+	// wait for both calls to start
+	<-started
+	<-started
+	// allow synchronize to finish
 	mf.feedLayerResult(current, current)
 	wg.Wait()
 


### PR DESCRIPTION
## Motivation
test is flaky. 

## Changes
make sure both goroutines are started before allowing one to finish

## Test Plan
unit test

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
