### PR TITLE
[Merged by Bors] - syncer don't work on current layer

### DIFF
--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -292,7 +292,6 @@ func (s *Syncer) synchronize(ctx context.Context) bool {
 			logger.Info("setting layer %v to zero-block", layerID)
 			if err := s.mesh.SetZeroBlockLayer(layerID); err != nil {
 				logger.With().Error("failed to set zero-block for layer", layerID, log.Err(err))
-				return false
 			}
 		}
 

--- a/syncer/syncer_test.go
+++ b/syncer/syncer_test.go
@@ -412,7 +412,7 @@ func TestSynchronize_SyncZeroBlockFailed(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
-		assert.False(t, syncer.synchronize(context.TODO()))
+		assert.True(t, syncer.synchronize(context.TODO()))
 		wg.Done()
 	}()
 
@@ -425,8 +425,10 @@ func TestSynchronize_SyncZeroBlockFailed(t *testing.T) {
 	}
 	wg.Wait()
 
-	assert.False(t, syncer.ListenToGossip())
+	assert.True(t, syncer.ListenToGossip())
 	assert.False(t, syncer.IsSynced(context.TODO()))
+
+	waitOutGossipSync(t, ticker.GetCurrentLayer(), syncer, ticker, mf)
 }
 
 // test the case where the node originally starts from notSynced and eventually becomes synced

--- a/syncer/syncer_test.go
+++ b/syncer/syncer_test.go
@@ -204,7 +204,7 @@ func TestSynchronize_OnlyOneSynchronize(t *testing.T) {
 	ticker := newMockLayerTicker()
 	mf := newMockFetcher()
 	syncer := NewSyncer(context.TODO(), conf, ticker, newMemMesh(lg), mf, lg)
-	ticker.advanceToLayer(types.NewLayerID(1))
+	ticker.advanceToLayer(types.NewLayerID(10))
 
 	var wg sync.WaitGroup
 	wg.Add(2)
@@ -215,21 +215,19 @@ func TestSynchronize_OnlyOneSynchronize(t *testing.T) {
 		first = syncer.synchronize(context.TODO())
 		wg.Done()
 	}()
+	<-started
 	go func() {
 		started <- struct{}{}
 		second = syncer.synchronize(context.TODO())
 		wg.Done()
 	}()
-
-	current := ticker.GetCurrentLayer()
-	// wait for both calls to start
-	<-started
 	<-started
 	// allow synchronize to finish
-	mf.feedLayerResult(current, current)
+	current := ticker.GetCurrentLayer()
+	mf.feedLayerResult(types.NewLayerID(1), current.Sub(1))
 	wg.Wait()
 
-	// one of the synchronize call should fail
+	// one of the synchronize calls should fail
 	assert.False(t, first && second)
 	assert.Equal(t, uint64(1), syncer.run)
 }
@@ -352,21 +350,21 @@ func TestSynchronize_getATXsFailedCurrentEpoch(t *testing.T) {
 	assert.True(t, syncer.IsSynced(context.TODO()))
 
 	mf.setATXsErrors(1, errors.New("no ATXs for current epoch. should fail sync at last layer"))
-	for i := uint32(0); i < layersPerEpoch-1; i++ {
-		ticker.advanceToLayer(types.NewLayerID(layersPerEpoch).Add(i))
+	mf.feedLayerResult(types.NewLayerID(1), types.NewLayerID(2*layersPerEpoch-1))
+	for i := types.NewLayerID(layersPerEpoch); i.Before(types.NewLayerID(2 * layersPerEpoch)); i = i.Add(1) {
+		ticker.advanceToLayer(i)
 		wg.Add(1)
 		go func() {
 			assert.True(t, syncer.synchronize(context.TODO()))
 			wg.Done()
 		}()
-		mf.feedLayerResult(types.NewLayerID(0), ticker.GetCurrentLayer())
 		wg.Wait()
 
 		assert.True(t, syncer.ListenToGossip())
 		assert.True(t, syncer.IsSynced(context.TODO()))
 	}
 
-	ticker.advanceToLayer(types.NewLayerID(2*layersPerEpoch - 1))
+	ticker.advanceToLayer(types.NewLayerID(2 * layersPerEpoch))
 	wg.Add(1)
 	go func() {
 		assert.False(t, syncer.synchronize(context.TODO()))
@@ -385,7 +383,7 @@ func TestSynchronize_getTBFailed(t *testing.T) {
 	mf := newMockFetcher()
 	mm := newMemMesh(lg)
 	syncer := NewSyncer(context.TODO(), conf, ticker, mm, mf, lg)
-	ticker.advanceToLayer(types.NewLayerID(layersPerEpoch * 3))
+	ticker.advanceToLayer(types.NewLayerID(layersPerEpoch * 3).Add(1))
 
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -408,7 +406,8 @@ func TestSynchronize_SyncZeroBlockFailed(t *testing.T) {
 	mf := newMockFetcher()
 	mm := newMemMesh(lg)
 	syncer := NewSyncer(context.TODO(), conf, ticker, mm, mf, lg)
-	ticker.advanceToLayer(mm.LatestLayer())
+	gLayer := types.GetEffectiveGenesis()
+	ticker.advanceToLayer(gLayer.Add(1))
 
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -417,7 +416,6 @@ func TestSynchronize_SyncZeroBlockFailed(t *testing.T) {
 		wg.Done()
 	}()
 
-	gLayer := types.GetEffectiveGenesis()
 	mf.feedLayerResult(types.NewLayerID(0), gLayer.Sub(1))
 	// genesis block has data. this LayerPromiseResult will cause SetZeroBlockLayer() to fail
 	mf.getLayerHashResultChan(gLayer) <- layerfetcher.LayerHashResult{}
@@ -467,7 +465,7 @@ func TestFromNotSyncedToSynced(t *testing.T) {
 }
 
 // test the case where the node originally starts from notSynced, advances to gossipSync, but falls behind
-// to notSynced..
+// to notSynced.
 func TestFromGossipSyncToNotSynced(t *testing.T) {
 	lg := log.NewDefault("syncer")
 	ticker := newMockLayerTicker()
@@ -493,28 +491,28 @@ func TestFromGossipSyncToNotSynced(t *testing.T) {
 	// the node should remain not synced and not gossiping
 	assert.False(t, syncer.ListenToGossip())
 	assert.False(t, syncer.IsSynced(context.TODO()))
-	mf.feedLayerResult(types.NewLayerID(2), current)
+	mf.feedLayerResult(firstLayer.Add(1), current.Sub(1))
 	wg.Wait()
 	// node should be in gossip sync state
 	assert.True(t, syncer.ListenToGossip())
 	assert.False(t, syncer.IsSynced(context.TODO()))
 
 	// cause the node to be out of sync again
-	newCurrent := current.Add(2)
+	newCurrent := current.Add(outOfSyncThreshold)
 	ticker.advanceToLayer(newCurrent)
 	wg.Add(1)
 	go func() {
 		assert.True(t, syncer.synchronize(context.TODO()))
 		wg.Done()
 	}()
-	mf.feedLayerResult(current.Add(1), current.Add(1))
-	<-mf.getLayerPollChan(current.Add(1))
-	// the node should falls to notSynced
+	mf.feedLayerResult(current, current)
+	<-mf.getLayerPollChan(current)
+	// the node should fall to notSynced
 	assert.False(t, syncer.ListenToGossip())
 	assert.False(t, syncer.IsSynced(context.TODO()))
 
 	// allow for sync to complete
-	mf.feedLayerResult(newCurrent, newCurrent)
+	mf.feedLayerResult(current.Add(1), newCurrent.Sub(1))
 	wg.Wait()
 
 	// the node should enter gossipSync again
@@ -562,11 +560,11 @@ func TestFromSyncedToNotSynced(t *testing.T) {
 	mf.feedLayerResult(firstLayer, firstLayer)
 	// wait till layer 1's content is requested to check whether sync state has changed
 	<-mf.getLayerPollChan(firstLayer)
-	// the node should realized it's behind now and set the node to be notSynced
+	// the node should realize it's behind now and set the node to be notSynced
 	assert.False(t, syncer.ListenToGossip())
 	assert.False(t, syncer.IsSynced(context.TODO()))
 
-	mf.feedLayerResult(types.NewLayerID(2), current)
+	mf.feedLayerResult(types.NewLayerID(2), current.Sub(1))
 	wg.Wait()
 	// node should be in gossip sync state
 	assert.True(t, syncer.ListenToGossip())
@@ -591,7 +589,7 @@ func waitOutGossipSync(t *testing.T, current types.LayerID, syncer *Syncer, mlt 
 		assert.True(t, syncer.synchronize(context.TODO()))
 		wg.Done()
 	}()
-	mf.feedLayerResult(syncer.mesh.ProcessedLayer().Add(1), current)
+	mf.feedLayerResult(syncer.mesh.ProcessedLayer().Add(1), current.Sub(1))
 	wg.Wait()
 	assert.True(t, syncer.ListenToGossip())
 	assert.False(t, syncer.IsSynced(context.TODO()))
@@ -606,7 +604,7 @@ func waitOutGossipSync(t *testing.T, current types.LayerID, syncer *Syncer, mlt 
 		assert.True(t, syncer.synchronize(context.TODO()))
 		wg.Done()
 	}()
-	mf.feedLayerResult(syncer.mesh.ProcessedLayer().Add(1), current)
+	mf.feedLayerResult(syncer.mesh.ProcessedLayer().Add(1), current.Sub(1))
 	<-syncedCh
 	assert.True(t, syncer.ListenToGossip())
 	assert.True(t, syncer.IsSynced(context.TODO()))


### PR DESCRIPTION
## Motivation
Closes #2610

## Changes
- syncer sync up to current-1 layer
- syncer doesn't validate a layer that hare plans to

## Test Plan
unit tests

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
