### PR TITLE
[Merged by Bors] - reduce test flakiness for TestJsonApi

### DIFF
--- a/api/grpcserver/grpcserver_test.go
+++ b/api/grpcserver/grpcserver_test.go
@@ -2627,8 +2627,8 @@ func TestJsonApi(t *testing.T) {
 	const message = "hello world!"
 
 	// we cannot start the gateway service without enabling at least one service
-	require.Equal(t, cfg.StartNodeService, false)
-	require.Equal(t, cfg.StartMeshService, false)
+	cfg.StartNodeService = false
+	cfg.StartMeshService = false
 	shutDown := launchServer(t)
 	payload := marshalProto(t, &pb.EchoRequest{Msg: &pb.SimpleString{Value: message}})
 	url := fmt.Sprintf("http://127.0.0.1:%d/%s", cfg.JSONServerPort, "v1/node/echo")
@@ -2647,6 +2647,7 @@ func TestJsonApi(t *testing.T) {
 	cfg.StartMeshService = true
 	shutDown = launchServer(t, svc1, svc2)
 	defer shutDown()
+	time.Sleep(time.Second)
 
 	// generate request payload (api input params)
 	payload = marshalProto(t, &pb.EchoRequest{Msg: &pb.SimpleString{Value: message}})


### PR DESCRIPTION
## Motivation
reduce test flakiness.

## Changes
allow grpc services time to start up

- before
`go test -v ./api/grpcserver/ -run TestJsonApi -count 5` would consistently fails
- after
`go test -v ./api/grpcserver/ -run TestJsonApi -count 100` passes

## Test Plan
unit test

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
