### PR TITLE
[Merged by Bors] - standardizing aggregated hash calculation

### DIFF
--- a/common/types/block.go
+++ b/common/types/block.go
@@ -401,7 +401,8 @@ func (l *Layer) Blocks() []*Block {
 	return l.blocks
 }
 
-// Hash returns the 32-byte sha256 sum of the block IDs in this layer, sorted in lexicographic order.
+// Hash returns the 32-byte sha256 sum of the block IDs of both contextually valid and invalid blocks in this layer,
+// sorted in lexicographic order.
 func (l Layer) Hash() Hash32 {
 	return CalcBlocksHash32(SortBlockIDs(BlockIDs(l.blocks)), nil)
 }

--- a/mesh/mesh.go
+++ b/mesh/mesh.go
@@ -163,7 +163,7 @@ func NewRecoveredMesh(db *DB, atxDb AtxDB, rewardConfig Config, trtl tortoise, t
 	msh.With().Info("recovered mesh from disk",
 		log.FieldNamed("latest_layer", msh.LatestLayer()),
 		log.FieldNamed("validated_layer", msh.ProcessedLayer()),
-		log.String("layer_hash", msh.ProcessedLayerHash().Hex()),
+		log.String("layer_hash", msh.ProcessedLayerHash().ShortString()),
 		log.String("root_hash", pr.GetStateRoot().String()))
 
 	return msh
@@ -256,7 +256,7 @@ func (msh *Mesh) setProcessedLayerFromRecoveredData(pLayer *ProcessedLayer) {
 	msh.mutex.Lock()
 	defer msh.mutex.Unlock()
 	msh.processedLayer = *pLayer
-	msh.Event().Info("processed layer set from recovered data", pLayer.ID, log.String("layer_hash", pLayer.Hash.Hex()))
+	msh.Event().Info("processed layer set from recovered data", pLayer.ID, log.String("layer_hash", pLayer.Hash.ShortString()))
 }
 
 func (msh *Mesh) setProcessedLayer(layer *types.Layer) {
@@ -296,12 +296,12 @@ func (msh *Mesh) setProcessedLayer(layer *types.Layer) {
 	}
 	msh.processedLayer = lastProcessed
 	events.ReportNodeStatusUpdate()
-	msh.Event().Info("processed layer set", msh.processedLayer.ID, log.String("layer_hash", msh.processedLayer.Hash.Hex()))
+	msh.Event().Info("processed layer set", msh.processedLayer.ID, log.String("layer_hash", msh.processedLayer.Hash.ShortString()))
 
 	if err := msh.persistProcessedLayer(&lastProcessed); err != nil {
 		msh.With().Error("failed to persist processed layer",
 			log.FieldNamed("processed_layer", lastProcessed.ID),
-			log.String("processed_layer_hash", lastProcessed.Hash.Hex()),
+			log.String("processed_layer_hash", lastProcessed.Hash.ShortString()),
 			log.Err(err))
 	}
 }
@@ -316,7 +316,7 @@ func (msh *Mesh) persistProcessedLayer(lyr *ProcessedLayer) error {
 	}
 	msh.With().Debug("persisted processed layer",
 		lyr.ID,
-		log.String("layer_hash", lyr.Hash.Hex()))
+		log.String("layer_hash", lyr.Hash.ShortString()))
 	return nil
 }
 
@@ -544,7 +544,7 @@ func (msh *Mesh) calcSimpleLayerHash(layer *types.Layer) types.Hash32 {
 func (msh *Mesh) persistAggregatedLayerHash(layerID types.LayerID, hash types.Hash32) {
 	if err := msh.general.Put(msh.getAggregatedLayerHashKey(layerID), hash.Bytes()); err != nil {
 		msh.With().Error("failed to persist running layer hash", log.Err(err), msh.ProcessedLayer(),
-			log.String("layer_hash", hash.Hex()))
+			log.String("layer_hash", hash.ShortString()))
 	}
 }
 
@@ -562,7 +562,7 @@ func (msh *Mesh) getAggregatedLayerHash(layerID types.LayerID) (types.Hash32, er
 func (msh *Mesh) GetLayerHashBlocks(h types.Hash32) []types.BlockID {
 	layerIDBytes, err := msh.general.Get(h.Bytes())
 	if err != nil {
-		msh.Warning("requested unknown layer hash %v", h.Hex())
+		msh.Warning("requested unknown layer hash %v", h.ShortString())
 		return []types.BlockID{}
 	}
 	l := types.BytesToLayerID(layerIDBytes)

--- a/mesh/mesh.go
+++ b/mesh/mesh.go
@@ -533,12 +533,12 @@ func (msh *Mesh) logStateRoot(layerID types.LayerID) {
 // calcAggregatedLayerHash calculates the aggregated hash up to the specified layer
 func (msh *Mesh) calcAggregatedLayerHash(layer *types.Layer, prevHash types.Hash32) types.Hash32 {
 	validBlocks, _ := msh.BlocksByValidity(layer.Blocks())
-	return types.CalcBlocksHash32(types.BlockIDs(validBlocks), prevHash.Bytes())
+	return types.CalcBlocksHash32(types.SortBlockIDs(types.BlockIDs(validBlocks)), prevHash.Bytes())
 }
 
 func (msh *Mesh) calcSimpleLayerHash(layer *types.Layer) types.Hash32 {
 	validBlocks, _ := msh.BlocksByValidity(layer.Blocks())
-	return types.CalcBlocksHash32(types.BlockIDs(validBlocks), nil)
+	return types.CalcBlocksHash32(types.SortBlockIDs(types.BlockIDs(validBlocks)), nil)
 }
 
 func (msh *Mesh) persistAggregatedLayerHash(layerID types.LayerID, hash types.Hash32) {

--- a/mesh/mesh.go
+++ b/mesh/mesh.go
@@ -376,13 +376,13 @@ func (msh *Mesh) persistLayerHashes(l *types.Layer) {
 	prevHash := types.Hash32{}
 	var err error
 	if l.Index().After(types.GetEffectiveGenesis()) {
-		prevHash, err = msh.getRunningLayerHash(l.Index().Sub(1))
+		prevHash, err = msh.getAggregatedLayerHash(l.Index().Sub(1))
 		if err != nil {
 			msh.With().Error("cannot get running layer hash", l.Index().Sub(1))
 			return
 		}
 	}
-	msh.persistRunningLayerHash(l.Index(), types.CalcAggregateHash32(prevHash, l.Hash().Bytes()))
+	msh.persistAggregatedLayerHash(l.Index(), types.CalcAggregateHash32(prevHash, l.Hash().Bytes()))
 }
 
 func (msh *Mesh) reInsertTxsToPool(validBlocks, invalidBlocks []*types.Block, l types.LayerID) {
@@ -520,15 +520,15 @@ func (msh *Mesh) calcValidLayerHash(layer *types.Layer) types.Hash32 {
 	return types.CalcBlocksHash32(types.BlockIDs(validBlocks), msh.ProcessedLayerHash().Bytes())
 }
 
-func (msh *Mesh) persistRunningLayerHash(layerID types.LayerID, hash types.Hash32) {
-	if err := msh.general.Put(msh.getRunningLayerHashKey(layerID), hash.Bytes()); err != nil {
+func (msh *Mesh) persistAggregatedLayerHash(layerID types.LayerID, hash types.Hash32) {
+	if err := msh.general.Put(msh.getAggregatedLayerHashKey(layerID), hash.Bytes()); err != nil {
 		msh.With().Error("failed to persist running layer hash", log.Err(err), msh.ProcessedLayer(),
 			log.String("layer_hash", hash.Hex()))
 	}
 }
 
-func (msh *Mesh) getRunningLayerHash(layerID types.LayerID) (types.Hash32, error) {
-	bts, err := msh.general.Get(msh.getRunningLayerHashKey(layerID))
+func (msh *Mesh) getAggregatedLayerHash(layerID types.LayerID) (types.Hash32, error) {
+	bts, err := msh.general.Get(msh.getAggregatedLayerHashKey(layerID))
 	if err != nil {
 		return [32]byte{}, err
 	}
@@ -556,7 +556,7 @@ func (msh *Mesh) getLayerBlockHashKey(layerID types.LayerID) []byte {
 	return []byte(fmt.Sprintf("layerBlockHash_%v", layerID.Bytes()))
 }
 
-func (msh *Mesh) getRunningLayerHashKey(layerID types.LayerID) []byte {
+func (msh *Mesh) getAggregatedLayerHashKey(layerID types.LayerID) []byte {
 	return []byte(fmt.Sprintf("rLayerHash_%v", layerID.Bytes()))
 }
 

--- a/mesh/mesh_test.go
+++ b/mesh/mesh_test.go
@@ -204,16 +204,26 @@ func TestMesh_ProcessedLayer(t *testing.T) {
 		expectedHash := types.CalcBlocksHash32([]types.BlockID{}, prevHash.Bytes())
 		assert.Equal(t, lyr.Index(), msh.ProcessedLayer())
 		assert.Equal(t, expectedHash, msh.ProcessedLayerHash())
+		// make sure processed layer is persisted
+		pLyr, err := msh.recoverProcessedLayer()
+		assert.NoError(t, err)
+		assert.Equal(t, lyr.Index(), pLyr.ID)
+		assert.Equal(t, expectedHash, pLyr.Hash)
 		prevHash = expectedHash
 	}
 
-	// effective gensis layer
+	// effective genesis layer
 	lyr, err := msh.GetLayer(gLyr)
 	assert.NoError(t, err)
 	msh.setProcessedLayer(lyr)
 	expectedHash := types.CalcBlocksHash32(types.BlockIDs(lyr.Blocks()), prevHash.Bytes())
 	assert.Equal(t, lyr.Index(), msh.ProcessedLayer())
 	assert.Equal(t, expectedHash, msh.ProcessedLayerHash())
+	// make sure processed layer is persisted
+	pLyr, err := msh.recoverProcessedLayer()
+	assert.NoError(t, err)
+	assert.Equal(t, lyr.Index(), pLyr.ID)
+	assert.Equal(t, expectedHash, pLyr.Hash)
 	prevHash = expectedHash
 
 	gPlus1 := addLayer(r, gLyr.Add(1), 1, msh)
@@ -226,6 +236,11 @@ func TestMesh_ProcessedLayer(t *testing.T) {
 	expectedHash = types.CalcBlocksHash32(types.BlockIDs(gPlus1.Blocks()), prevHash.Bytes())
 	assert.Equal(t, gPlus1.Index(), msh.ProcessedLayer())
 	assert.Equal(t, expectedHash, msh.ProcessedLayerHash())
+	// make sure processed layer is persisted
+	pLyr, err = msh.recoverProcessedLayer()
+	assert.NoError(t, err)
+	assert.Equal(t, gPlus1.Index(), pLyr.ID)
+	assert.Equal(t, expectedHash, pLyr.Hash)
 	prevHash = expectedHash
 
 	// set gPlus3 and gPlus5 out of order
@@ -233,10 +248,18 @@ func TestMesh_ProcessedLayer(t *testing.T) {
 	// processed layer should not advance
 	assert.Equal(t, gPlus1.Index(), msh.ProcessedLayer())
 	assert.Equal(t, prevHash, msh.ProcessedLayerHash())
+	pLyr, err = msh.recoverProcessedLayer()
+	assert.NoError(t, err)
+	assert.Equal(t, gPlus1.Index(), pLyr.ID)
+	assert.Equal(t, expectedHash, pLyr.Hash)
 	msh.setProcessedLayer(gPlus5)
 	// processed layer should not advance
 	assert.Equal(t, gPlus1.Index(), msh.ProcessedLayer())
 	assert.Equal(t, prevHash, msh.ProcessedLayerHash())
+	pLyr, err = msh.recoverProcessedLayer()
+	assert.NoError(t, err)
+	assert.Equal(t, gPlus1.Index(), pLyr.ID)
+	assert.Equal(t, expectedHash, pLyr.Hash)
 
 	// setting gPlus2 will bring the processed layer to gPlus3
 	msh.setProcessedLayer(gPlus2)
@@ -244,6 +267,11 @@ func TestMesh_ProcessedLayer(t *testing.T) {
 	expectedHash = types.CalcBlocksHash32(types.BlockIDs(gPlus3.Blocks()), gPlus2Hash.Bytes())
 	assert.Equal(t, gPlus3.Index(), msh.ProcessedLayer())
 	assert.Equal(t, expectedHash, msh.ProcessedLayerHash())
+	// make sure processed layer is persisted
+	pLyr, err = msh.recoverProcessedLayer()
+	assert.NoError(t, err)
+	assert.Equal(t, gPlus3.Index(), pLyr.ID)
+	assert.Equal(t, expectedHash, pLyr.Hash)
 	prevHash = expectedHash
 
 	// setting gPlus4 will bring the processed layer to gPlus5
@@ -252,12 +280,22 @@ func TestMesh_ProcessedLayer(t *testing.T) {
 	expectedHash = types.CalcBlocksHash32(types.BlockIDs(gPlus5.Blocks()), gPlus4Hash.Bytes())
 	assert.Equal(t, gPlus5.Index(), msh.ProcessedLayer())
 	assert.Equal(t, expectedHash, msh.ProcessedLayerHash())
+	// make sure processed layer is persisted
+	pLyr, err = msh.recoverProcessedLayer()
+	assert.NoError(t, err)
+	assert.Equal(t, gPlus5.Index(), pLyr.ID)
+	assert.Equal(t, expectedHash, pLyr.Hash)
 	prevHash = expectedHash
 
 	// setting it to an older layer should have no effect
 	msh.setProcessedLayer(gPlus2)
 	assert.Equal(t, gPlus5.Index(), msh.ProcessedLayer())
 	assert.Equal(t, prevHash, msh.ProcessedLayerHash())
+	// make sure processed layer is persisted
+	pLyr, err = msh.recoverProcessedLayer()
+	assert.NoError(t, err)
+	assert.Equal(t, gPlus5.Index(), pLyr.ID)
+	assert.Equal(t, expectedHash, pLyr.Hash)
 }
 
 func TestMesh_PersistProcessedLayer(t *testing.T) {

--- a/mesh/mesh_test.go
+++ b/mesh/mesh_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/database"
+	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/log/logtest"
 	"github.com/spacemeshos/go-spacemesh/rand"
 	"github.com/spacemeshos/go-spacemesh/signing"
@@ -142,14 +143,21 @@ func getMesh(tb testing.TB, id string) *Mesh {
 }
 
 func addLayer(r *require.Assertions, id types.LayerID, layerSize int, msh *Mesh) *types.Layer {
-	for i := 0; i < layerSize; i++ {
-		txIDs, _ := addManyTXsToPool(r, msh, 4)
-		block := types.NewExistingBlock(id, []byte(rand.String(8)), txIDs)
-		block.Initialize()
-		err := msh.AddBlockWithTxs(context.TODO(), block)
-		r.NoError(err, "cannot add data to test")
-		msh.contextualValidity.Put(block.ID().Bytes(), []byte{1})
+	if layerSize == 0 {
+		msh.SetZeroBlockLayer(id)
+	} else {
+		for i := 0; i < layerSize; i++ {
+			log.Info("creating block for layer %v", id)
+			txIDs, _ := addManyTXsToPool(r, msh, 4)
+			block := types.NewExistingBlock(id, []byte(rand.String(8)), txIDs)
+			block.Initialize()
+			log.Info("block created for layer %v", block.LayerIndex)
+			err := msh.AddBlockWithTxs(context.TODO(), block)
+			r.NoError(err, "cannot add data to test")
+			msh.contextualValidity.Put(block.ID().Bytes(), []byte{1})
+		}
 	}
+	log.Info("getting layer %v", id)
 	l, err := msh.GetLayer(id)
 	r.NoError(err, "cant get a layer we've just created")
 	return l
@@ -179,18 +187,77 @@ func TestMesh_AddLayerGetLayer(t *testing.T) {
 }
 
 func TestMesh_ProcessedLayer(t *testing.T) {
-	msh := getMesh(t, "t6")
+	r := require.New(t)
+	msh := getMesh(t, "processed layer")
 	defer msh.Close()
-	msh.setProcessedLayer(types.NewLayerID(2), types.Hash32{})
-	assert.Equal(t, types.NewLayerID(2), msh.ProcessedLayer())
-	msh.setProcessedLayer(types.NewLayerID(3), types.Hash32{})
-	assert.Equal(t, types.NewLayerID(3), msh.ProcessedLayer())
-	msh.setProcessedLayer(types.NewLayerID(5), types.Hash32{})
-	assert.Equal(t, types.NewLayerID(3), msh.ProcessedLayer())
-	msh.setProcessedLayer(types.NewLayerID(4), types.Hash32{})
-	assert.Equal(t, types.NewLayerID(4), msh.ProcessedLayer())
-	msh.setProcessedLayer(types.NewLayerID(3), types.Hash32{})
-	assert.Equal(t, types.NewLayerID(4), msh.ProcessedLayer())
+
+	// test genesis layers
+	gLyr := types.GetEffectiveGenesis()
+	var lyrs []*types.Layer
+	for i := types.NewLayerID(1); i.Before(gLyr); i = i.Add(1) {
+		lyr := addLayer(r, i, 0, msh)
+		lyrs = append(lyrs, lyr)
+	}
+	prevHash := types.Hash32{}
+	for _, lyr := range lyrs {
+		msh.setProcessedLayer(lyr)
+		expectedHash := types.CalcBlocksHash32([]types.BlockID{}, prevHash.Bytes())
+		assert.Equal(t, lyr.Index(), msh.ProcessedLayer())
+		assert.Equal(t, expectedHash, msh.ProcessedLayerHash())
+		prevHash = expectedHash
+	}
+
+	// effective gensis layer
+	lyr, err := msh.GetLayer(gLyr)
+	assert.NoError(t, err)
+	msh.setProcessedLayer(lyr)
+	expectedHash := types.CalcBlocksHash32(types.BlockIDs(lyr.Blocks()), prevHash.Bytes())
+	assert.Equal(t, lyr.Index(), msh.ProcessedLayer())
+	assert.Equal(t, expectedHash, msh.ProcessedLayerHash())
+	prevHash = expectedHash
+
+	gPlus1 := addLayer(r, gLyr.Add(1), 1, msh)
+	gPlus2 := addLayer(r, gLyr.Add(2), 2, msh)
+	gPlus3 := addLayer(r, gLyr.Add(3), 3, msh)
+	gPlus4 := addLayer(r, gLyr.Add(4), 4, msh)
+	gPlus5 := addLayer(r, gLyr.Add(5), 5, msh)
+
+	msh.setProcessedLayer(gPlus1)
+	expectedHash = types.CalcBlocksHash32(types.BlockIDs(gPlus1.Blocks()), prevHash.Bytes())
+	assert.Equal(t, gPlus1.Index(), msh.ProcessedLayer())
+	assert.Equal(t, expectedHash, msh.ProcessedLayerHash())
+	prevHash = expectedHash
+
+	// set gPlus3 and gPlus5 out of order
+	msh.setProcessedLayer(gPlus3)
+	// processed layer should not advance
+	assert.Equal(t, gPlus1.Index(), msh.ProcessedLayer())
+	assert.Equal(t, prevHash, msh.ProcessedLayerHash())
+	msh.setProcessedLayer(gPlus5)
+	// processed layer should not advance
+	assert.Equal(t, gPlus1.Index(), msh.ProcessedLayer())
+	assert.Equal(t, prevHash, msh.ProcessedLayerHash())
+
+	// setting gPlus2 will bring the processed layer to gPlus3
+	msh.setProcessedLayer(gPlus2)
+	gPlus2Hash := types.CalcBlocksHash32(types.BlockIDs(gPlus2.Blocks()), prevHash.Bytes())
+	expectedHash = types.CalcBlocksHash32(types.BlockIDs(gPlus3.Blocks()), gPlus2Hash.Bytes())
+	assert.Equal(t, gPlus3.Index(), msh.ProcessedLayer())
+	assert.Equal(t, expectedHash, msh.ProcessedLayerHash())
+	prevHash = expectedHash
+
+	// setting gPlus4 will bring the processed layer to gPlus5
+	msh.setProcessedLayer(gPlus4)
+	gPlus4Hash := types.CalcBlocksHash32(types.BlockIDs(gPlus4.Blocks()), prevHash.Bytes())
+	expectedHash = types.CalcBlocksHash32(types.BlockIDs(gPlus5.Blocks()), gPlus4Hash.Bytes())
+	assert.Equal(t, gPlus5.Index(), msh.ProcessedLayer())
+	assert.Equal(t, expectedHash, msh.ProcessedLayerHash())
+	prevHash = expectedHash
+
+	// setting it to an older layer should have no effect
+	msh.setProcessedLayer(gPlus2)
+	assert.Equal(t, gPlus5.Index(), msh.ProcessedLayer())
+	assert.Equal(t, prevHash, msh.ProcessedLayerHash())
 }
 
 func TestMesh_PersistProcessedLayer(t *testing.T) {
@@ -400,26 +467,26 @@ func TestMesh_ExtractUniqueOrderedTransactions(t *testing.T) {
 	r.ElementsMatch(GetTransactionIds(tx1, tx2, tx3, tx4), GetTransactionIds(validBlocks...))
 }
 
-func TestMesh_persistLayerHashes(t *testing.T) {
-	r := require.New(t)
-	msh := getMesh(t, "persistLayerHashes")
+func randomHash() (hash types.Hash32) {
+	hash.SetBytes([]byte(rand.String(32)))
+	return
+}
+
+func TestMesh_persistLayerHash(t *testing.T) {
+	msh := getMesh(t, "persistLayerHash")
 	defer msh.Close()
 
-	// test first layer hash
-	l := addLayer(r, types.GetEffectiveGenesis(), 5, msh)
-	msh.persistLayerHashes(l)
-	wantedHash := types.CalcAggregateHash32(types.Hash32{}, l.Hash().Bytes())
-	actualHash, err := msh.getAggregatedLayerHash(types.GetEffectiveGenesis())
-	assert.NoError(t, err)
+	// persist once
+	lyr := types.NewLayerID(3)
+	hash := randomHash()
+	msh.persistLayerHash(lyr, hash)
+	assert.Equal(t, hash, msh.GetLayerHash(lyr))
 
-	assert.Equal(t, wantedHash, actualHash)
-
-	l2 := addLayer(r, types.GetEffectiveGenesis().Add(1), 5, msh)
-	msh.persistLayerHashes(l2)
-	secondWantedHash := types.CalcAggregateHash32(wantedHash, l2.Hash().Bytes())
-	actualHash2, err := msh.getAggregatedLayerHash(types.GetEffectiveGenesis().Add(1))
-	assert.NoError(t, err)
-	assert.Equal(t, secondWantedHash, actualHash2)
+	// persist twice
+	newHash := randomHash()
+	assert.NotEqual(t, newHash, hash)
+	msh.persistLayerHash(lyr, newHash)
+	assert.Equal(t, newHash, msh.GetLayerHash(lyr))
 }
 
 func GetTransactionIds(txs ...*types.Transaction) []types.TransactionID {

--- a/mesh/mesh_test.go
+++ b/mesh/mesh_test.go
@@ -216,7 +216,7 @@ func TestMesh_ProcessedLayer(t *testing.T) {
 	lyr, err := msh.GetLayer(gLyr)
 	assert.NoError(t, err)
 	msh.setProcessedLayer(lyr)
-	expectedHash := types.CalcBlocksHash32(types.BlockIDs(lyr.Blocks()), prevHash.Bytes())
+	expectedHash := types.CalcBlocksHash32(types.SortBlockIDs(types.BlockIDs(lyr.Blocks())), prevHash.Bytes())
 	assert.Equal(t, lyr.Index(), msh.ProcessedLayer())
 	assert.Equal(t, expectedHash, msh.ProcessedLayerHash())
 	// make sure processed layer is persisted
@@ -233,7 +233,7 @@ func TestMesh_ProcessedLayer(t *testing.T) {
 	gPlus5 := addLayer(r, gLyr.Add(5), 5, msh)
 
 	msh.setProcessedLayer(gPlus1)
-	expectedHash = types.CalcBlocksHash32(types.BlockIDs(gPlus1.Blocks()), prevHash.Bytes())
+	expectedHash = types.CalcBlocksHash32(types.SortBlockIDs(types.BlockIDs(gPlus1.Blocks())), prevHash.Bytes())
 	assert.Equal(t, gPlus1.Index(), msh.ProcessedLayer())
 	assert.Equal(t, expectedHash, msh.ProcessedLayerHash())
 	// make sure processed layer is persisted
@@ -263,8 +263,8 @@ func TestMesh_ProcessedLayer(t *testing.T) {
 
 	// setting gPlus2 will bring the processed layer to gPlus3
 	msh.setProcessedLayer(gPlus2)
-	gPlus2Hash := types.CalcBlocksHash32(types.BlockIDs(gPlus2.Blocks()), prevHash.Bytes())
-	expectedHash = types.CalcBlocksHash32(types.BlockIDs(gPlus3.Blocks()), gPlus2Hash.Bytes())
+	gPlus2Hash := types.CalcBlocksHash32(types.SortBlockIDs(types.BlockIDs(gPlus2.Blocks())), prevHash.Bytes())
+	expectedHash = types.CalcBlocksHash32(types.SortBlockIDs(types.BlockIDs(gPlus3.Blocks())), gPlus2Hash.Bytes())
 	assert.Equal(t, gPlus3.Index(), msh.ProcessedLayer())
 	assert.Equal(t, expectedHash, msh.ProcessedLayerHash())
 	// make sure processed layer is persisted
@@ -276,8 +276,8 @@ func TestMesh_ProcessedLayer(t *testing.T) {
 
 	// setting gPlus4 will bring the processed layer to gPlus5
 	msh.setProcessedLayer(gPlus4)
-	gPlus4Hash := types.CalcBlocksHash32(types.BlockIDs(gPlus4.Blocks()), prevHash.Bytes())
-	expectedHash = types.CalcBlocksHash32(types.BlockIDs(gPlus5.Blocks()), gPlus4Hash.Bytes())
+	gPlus4Hash := types.CalcBlocksHash32(types.SortBlockIDs(types.BlockIDs(gPlus4.Blocks())), prevHash.Bytes())
+	expectedHash = types.CalcBlocksHash32(types.SortBlockIDs(types.BlockIDs(gPlus5.Blocks())), gPlus4Hash.Bytes())
 	assert.Equal(t, gPlus5.Index(), msh.ProcessedLayer())
 	assert.Equal(t, expectedHash, msh.ProcessedLayerHash())
 	// make sure processed layer is persisted

--- a/mesh/mesh_test.go
+++ b/mesh/mesh_test.go
@@ -409,7 +409,7 @@ func TestMesh_persistLayerHashes(t *testing.T) {
 	l := addLayer(r, types.GetEffectiveGenesis(), 5, msh)
 	msh.persistLayerHashes(l)
 	wantedHash := types.CalcAggregateHash32(types.Hash32{}, l.Hash().Bytes())
-	actualHash, err := msh.getRunningLayerHash(types.GetEffectiveGenesis())
+	actualHash, err := msh.getAggregatedLayerHash(types.GetEffectiveGenesis())
 	assert.NoError(t, err)
 
 	assert.Equal(t, wantedHash, actualHash)
@@ -417,7 +417,7 @@ func TestMesh_persistLayerHashes(t *testing.T) {
 	l2 := addLayer(r, types.GetEffectiveGenesis().Add(1), 5, msh)
 	msh.persistLayerHashes(l2)
 	secondWantedHash := types.CalcAggregateHash32(wantedHash, l2.Hash().Bytes())
-	actualHash2, err := msh.getRunningLayerHash(types.GetEffectiveGenesis().Add(1))
+	actualHash2, err := msh.getAggregatedLayerHash(types.GetEffectiveGenesis().Add(1))
 	assert.NoError(t, err)
 	assert.Equal(t, secondWantedHash, actualHash2)
 }

--- a/mesh/reward_test.go
+++ b/mesh/reward_test.go
@@ -294,7 +294,7 @@ type meshValidatorBatchMock struct {
 }
 
 func (m *meshValidatorBatchMock) ValidateLayer(lyr *types.Layer) {
-	m.mesh.setProcessedLayer(lyr.Index(), types.Hash32{})
+	m.mesh.setProcessedLayer(lyr)
 	layerID := lyr.Index()
 	if layerID.Uint32() == 0 {
 		return


### PR DESCRIPTION
## Motivation
Closes #2574

## Changes
- make sure all aggregated hash is calculated the same way
- make sure aggregated hash is updated in order
- set and persist processed layer together

## Test Plan
unit tests

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
