### PR TITLE
[Merged by Bors] - Exit tortoise beacon cleanly by using taskgroup.Group

### DIFF
--- a/taskgroup/group.go
+++ b/taskgroup/group.go
@@ -6,8 +6,8 @@ import (
 	"sync"
 )
 
-// Terminated returnedif Group was already terminated.
-var Terminated = errors.New("taskgroup: terminated")
+// ErrTerminated returned if Group was already terminated.
+var ErrTerminated = errors.New("taskgroup: terminated")
 
 // Option to modify Group.
 type Option func(g *Group)
@@ -19,7 +19,7 @@ func WithContext(ctx context.Context) Option {
 	}
 }
 
-// WithContext return instance of the Group.
+// New returns instance of the Group.
 func New(opts ...Option) *Group {
 	g := &Group{
 		waitErr: make(chan struct{}),
@@ -50,12 +50,12 @@ type Group struct {
 }
 
 // Go spawns new goroutine that will run f, unless Group was already terminated.
-// In the latter case Terminated error will be returned.
+// In the latter case ErrTerminated error will be returned.
 func (g *Group) Go(f func(ctx context.Context) error) error {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	if g.err != nil {
-		return Terminated
+		return ErrTerminated
 	}
 	g.wg.Add(1)
 	go func() {

--- a/taskgroup/group.go
+++ b/taskgroup/group.go
@@ -1,0 +1,90 @@
+package taskgroup
+
+import (
+	"context"
+	"errors"
+	"sync"
+)
+
+// Terminated returnedif Group was already terminated.
+var Terminated = errors.New("taskgroup: terminated")
+
+// Option to modify Group.
+type Option func(g *Group)
+
+// WithContext passes parent context to use for the Group.
+func WithContext(ctx context.Context) Option {
+	return func(g *Group) {
+		g.ctx = ctx
+	}
+}
+
+// WithContext return instance of the Group.
+func New(opts ...Option) *Group {
+	g := &Group{
+		waitErr: make(chan struct{}),
+	}
+	for _, opt := range opts {
+		opt(g)
+	}
+	if g.ctx == nil {
+		g.ctx = context.Background()
+	}
+	g.ctx, g.cancel = context.WithCancel(g.ctx)
+	return g
+}
+
+// Group manages set of tasks.
+// Unlike errgroup.Group it is safe to call Go after Wait. If Group didn't terminate yet
+// the behavior will be the same as for errgroup.Group, if it did Go will exit immediatly.
+//
+// Zero value is not a valid Group. Must be initialized using New.
+type Group struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	mu      sync.Mutex
+	err     error
+	waitErr chan struct{}
+	wg      sync.WaitGroup
+}
+
+// Go spawns new goroutine that will run f, unless Group was already terminated.
+// In the latter case Terminated error will be returned.
+func (g *Group) Go(f func(ctx context.Context) error) error {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.err != nil {
+		return Terminated
+	}
+	g.wg.Add(1)
+	go func() {
+		err := f(g.ctx)
+		g.wg.Done()
+
+		g.mu.Lock()
+		defer g.mu.Unlock()
+		if err != nil && g.err == nil {
+			g.err = err
+			close(g.waitErr)
+			g.cancel()
+		}
+	}()
+	return nil
+}
+
+// Wait until Group is terminated. First error is returned.
+func (g *Group) Wait() error {
+	g.mu.Lock()
+	if g.err != nil {
+		g.mu.Unlock()
+		return g.err
+	}
+	g.mu.Unlock()
+
+	<-g.waitErr
+	// at this point the error is set to a non-nil value, won't be ever overwritten,
+	// and all Go calls will terminated immediatly, therefore re-locking here is not required.
+	g.wg.Wait()
+	return g.err
+}

--- a/taskgroup/group.go
+++ b/taskgroup/group.go
@@ -59,8 +59,8 @@ func (g *Group) Go(f func(ctx context.Context) error) error {
 	}
 	g.wg.Add(1)
 	go func() {
+		defer g.wg.Done()
 		err := f(g.ctx)
-		g.wg.Done()
 
 		g.mu.Lock()
 		defer g.mu.Unlock()
@@ -84,7 +84,7 @@ func (g *Group) Wait() error {
 
 	<-g.waitErr
 	// at this point the error is set to a non-nil value, won't be ever overwritten,
-	// and all Go calls will terminated immediatly, therefore re-locking here is not required.
+	// and all Go calls will be terminated immediatly, therefore re-locking here is not required.
 	g.wg.Wait()
 	return g.err
 }

--- a/taskgroup/group_test.go
+++ b/taskgroup/group_test.go
@@ -47,7 +47,7 @@ func TestGroupAfterWait(t *testing.T) {
 	require.ErrorIs(t, g.Wait(), testErr)
 	require.ErrorIs(t, g.Go(func(ctx context.Context) error {
 		return nil
-	}), Terminated)
+	}), ErrTerminated)
 }
 
 func TestGroupNested(t *testing.T) {

--- a/taskgroup/group_test.go
+++ b/taskgroup/group_test.go
@@ -1,0 +1,98 @@
+package taskgroup
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGroupTerminate(t *testing.T) {
+	t.Run("OnError", func(t *testing.T) {
+		testErr := errors.New("test")
+		g := New()
+		for i := 0; i < 10; i++ {
+			g.Go(func(ctx context.Context) error {
+				<-ctx.Done()
+				return ctx.Err()
+			})
+		}
+		g.Go(func(ctx context.Context) error {
+			return testErr
+		})
+		require.ErrorIs(t, g.Wait(), testErr)
+	})
+	t.Run("OnCancel", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		g := New(WithContext(ctx))
+		for i := 0; i < 10; i++ {
+			g.Go(func(ctx context.Context) error {
+				<-ctx.Done()
+				return ctx.Err()
+			})
+		}
+		cancel()
+		require.ErrorIs(t, g.Wait(), context.Canceled)
+	})
+}
+
+func TestGroupAfterWait(t *testing.T) {
+	testErr := errors.New("test")
+	g := New()
+	g.Go(func(ctx context.Context) error {
+		return testErr
+	})
+	require.ErrorIs(t, g.Wait(), testErr)
+	require.ErrorIs(t, g.Go(func(ctx context.Context) error {
+		return nil
+	}), Terminated)
+}
+
+func TestGroupNested(t *testing.T) {
+	g := New()
+	testErr := errors.New("test")
+	g.Go(func(ctx context.Context) error {
+		for i := 0; i < 10; i++ {
+			g.Go(func(ctx context.Context) error {
+				<-ctx.Done()
+				return ctx.Err()
+			})
+			g.Go(func(ctx context.Context) error {
+				return testErr
+			})
+		}
+		<-ctx.Done()
+		return ctx.Err()
+	})
+
+	require.ErrorIs(t, g.Wait(), testErr)
+}
+
+func TestGroupDoubleWait(t *testing.T) {
+	var (
+		testErr  = errors.New("test")
+		g        = New()
+		n        = 10
+		waitErrs = make(chan error, n)
+		wg       sync.WaitGroup
+	)
+
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			waitErrs <- g.Wait()
+			wg.Done()
+		}()
+	}
+
+	g.Go(func(ctx context.Context) error {
+		return testErr
+	})
+	wg.Wait()
+	close(waitErrs)
+	for err := range waitErrs {
+		require.ErrorIs(t, err, testErr)
+	}
+}

--- a/tortoisebeacon/handlers.go
+++ b/tortoisebeacon/handlers.go
@@ -71,7 +71,6 @@ func (tb *TortoiseBeacon) HandleSerializedProposalMessage(ctx context.Context, d
 	}
 
 	select {
-	case <-tb.CloseChannel():
 	case <-ctx.Done():
 	case ch <- proposalWithReceipt:
 	}

--- a/tortoisebeacon/tortoise_beacon.go
+++ b/tortoisebeacon/tortoise_beacon.go
@@ -208,6 +208,7 @@ type TortoiseBeacon struct {
 // Start starts listening for layers and outputs.
 func (tb *TortoiseBeacon) Start(ctx context.Context) error {
 	if !atomic.CompareAndSwapUint64(&tb.closed, 0, 1) {
+		tb.Log.Warning("attempt to start tortoise beacon more than once")
 		return nil
 	}
 	tb.Log.Info("Starting %v with the following config: %+v", protoName, tb.config)

--- a/tortoisebeacon/tortoise_beacon.go
+++ b/tortoisebeacon/tortoise_beacon.go
@@ -241,6 +241,7 @@ func (tb *TortoiseBeacon) Close() {
 	tb.clock.Unsubscribe(tb.layerTicker)
 }
 
+// IsClosed returns true if background workers are not running.
 func (tb *TortoiseBeacon) IsClosed() bool {
 	return atomic.LoadUint64(&tb.closed) == 0
 }

--- a/tortoisebeacon/tortoise_beacon.go
+++ b/tortoisebeacon/tortoise_beacon.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/big"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/ALTree/bigfloat"
@@ -15,6 +16,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/p2p/service"
 	"github.com/spacemeshos/go-spacemesh/signing"
+	"github.com/spacemeshos/go-spacemesh/taskgroup"
 	"github.com/spacemeshos/go-spacemesh/timesync"
 	"github.com/spacemeshos/go-spacemesh/tortoisebeacon/weakcoin"
 )
@@ -79,9 +81,76 @@ type (
 	proposalsMap            = map[types.EpochID]hashSet
 )
 
+// a function to verify the message with the signature and its public key.
+type verifierFunc = func(pub, msg, sig []byte) bool
+
+type layerClock interface {
+	Subscribe() timesync.LayerTimer
+	Unsubscribe(timer timesync.LayerTimer)
+	AwaitLayer(layerID types.LayerID) chan struct{}
+	GetCurrentLayer() types.LayerID
+	LayerToTime(id types.LayerID) time.Time
+}
+
+// New returns a new TortoiseBeacon.
+func New(
+	conf Config,
+	minerID types.NodeID,
+	layerDuration time.Duration,
+	net broadcaster,
+	atxDB activationDB,
+	tortoiseBeaconDB tortoiseBeaconDB,
+	edSigner signing.Signer,
+	vrfVerifier signing.Verifier,
+	vrfSigner signing.Signer,
+	weakCoin coin,
+	clock layerClock,
+	logger log.Log,
+) *TortoiseBeacon {
+	q, ok := new(big.Rat).SetString(conf.Q)
+	if !ok {
+		panic("bad q parameter")
+	}
+	return &TortoiseBeacon{
+		Log:                             logger,
+		config:                          conf,
+		minerID:                         minerID,
+		layerDuration:                   layerDuration,
+		net:                             net,
+		atxDB:                           atxDB,
+		tortoiseBeaconDB:                tortoiseBeaconDB,
+		edSigner:                        edSigner,
+		vrfVerifier:                     vrfVerifier,
+		vrfSigner:                       vrfSigner,
+		weakCoin:                        weakCoin,
+		clock:                           clock,
+		q:                               q,
+		gracePeriodDuration:             time.Duration(conf.GracePeriodDurationMs) * time.Millisecond,
+		proposalDuration:                time.Duration(conf.ProposalDurationMs) * time.Millisecond,
+		firstVotingRoundDuration:        time.Duration(conf.FirstVotingRoundDurationMs) * time.Millisecond,
+		votingRoundDuration:             time.Duration(conf.VotingRoundDurationMs) * time.Millisecond,
+		weakCoinRoundDuration:           time.Duration(conf.WeakCoinRoundDurationMs) * time.Millisecond,
+		waitAfterEpochStart:             time.Duration(conf.WaitAfterEpochStart) * time.Millisecond,
+		currentRounds:                   make(map[types.EpochID]types.RoundID),
+		validProposals:                  make(map[types.EpochID]hashSet),
+		potentiallyValidProposals:       make(map[types.EpochID]hashSet),
+		ownVotes:                        make(ownVotes),
+		beacons:                         make(map[types.EpochID]types.Hash32),
+		proposalPhaseFinishedTimestamps: make(map[types.EpochID]time.Time),
+		incomingVotes:                   make(map[epochRoundPair]votesPerPK),
+		firstRoundIncomingVotes:         make(map[types.EpochID]firstRoundVotesPerPK),
+		firstRoundOutcomingVotes:        make(map[types.EpochID]firstRoundVotes),
+		seenEpochs:                      make(map[types.EpochID]struct{}),
+		proposalChans:                   make(map[types.EpochID]chan *proposalMessageWithReceiptData),
+	}
+}
+
 // TortoiseBeacon represents Tortoise Beacon.
 type TortoiseBeacon struct {
-	util.Closer
+	closed uint64
+	tg     *taskgroup.Group
+	cancel context.CancelFunc
+
 	log.Log
 
 	config        Config
@@ -132,111 +201,48 @@ type TortoiseBeacon struct {
 	proposalChansMu sync.Mutex
 	proposalChans   map[types.EpochID]chan *proposalMessageWithReceiptData
 
-	backgroundWG sync.WaitGroup
-
 	layerMu   sync.RWMutex
 	lastLayer types.LayerID
 }
 
-// a function to verify the message with the signature and its public key.
-type verifierFunc = func(pub, msg, sig []byte) bool
-
-type layerClock interface {
-	Subscribe() timesync.LayerTimer
-	Unsubscribe(timer timesync.LayerTimer)
-	AwaitLayer(layerID types.LayerID) chan struct{}
-	GetCurrentLayer() types.LayerID
-	LayerToTime(id types.LayerID) time.Time
-}
-
-// New returns a new TortoiseBeacon.
-func New(
-	conf Config,
-	minerID types.NodeID,
-	layerDuration time.Duration,
-	net broadcaster,
-	atxDB activationDB,
-	tortoiseBeaconDB tortoiseBeaconDB,
-	edSigner signing.Signer,
-	vrfVerifier signing.Verifier,
-	vrfSigner signing.Signer,
-	weakCoin coin,
-	clock layerClock,
-	logger log.Log,
-) *TortoiseBeacon {
-	q, ok := new(big.Rat).SetString(conf.Q)
-	if !ok {
-		panic("bad q parameter")
-	}
-
-	return &TortoiseBeacon{
-		Log:                             logger,
-		Closer:                          util.NewCloser(),
-		config:                          conf,
-		minerID:                         minerID,
-		layerDuration:                   layerDuration,
-		net:                             net,
-		atxDB:                           atxDB,
-		tortoiseBeaconDB:                tortoiseBeaconDB,
-		edSigner:                        edSigner,
-		vrfVerifier:                     vrfVerifier,
-		vrfSigner:                       vrfSigner,
-		weakCoin:                        weakCoin,
-		clock:                           clock,
-		q:                               q,
-		gracePeriodDuration:             time.Duration(conf.GracePeriodDurationMs) * time.Millisecond,
-		proposalDuration:                time.Duration(conf.ProposalDurationMs) * time.Millisecond,
-		firstVotingRoundDuration:        time.Duration(conf.FirstVotingRoundDurationMs) * time.Millisecond,
-		votingRoundDuration:             time.Duration(conf.VotingRoundDurationMs) * time.Millisecond,
-		weakCoinRoundDuration:           time.Duration(conf.WeakCoinRoundDurationMs) * time.Millisecond,
-		waitAfterEpochStart:             time.Duration(conf.WaitAfterEpochStart) * time.Millisecond,
-		currentRounds:                   make(map[types.EpochID]types.RoundID),
-		validProposals:                  make(map[types.EpochID]hashSet),
-		potentiallyValidProposals:       make(map[types.EpochID]hashSet),
-		ownVotes:                        make(ownVotes),
-		beacons:                         make(map[types.EpochID]types.Hash32),
-		proposalPhaseFinishedTimestamps: make(map[types.EpochID]time.Time),
-		incomingVotes:                   make(map[epochRoundPair]votesPerPK),
-		firstRoundIncomingVotes:         make(map[types.EpochID]firstRoundVotesPerPK),
-		firstRoundOutcomingVotes:        make(map[types.EpochID]firstRoundVotes),
-		seenEpochs:                      make(map[types.EpochID]struct{}),
-		proposalChans:                   make(map[types.EpochID]chan *proposalMessageWithReceiptData),
-	}
-}
-
 // Start starts listening for layers and outputs.
 func (tb *TortoiseBeacon) Start(ctx context.Context) error {
+	if !atomic.CompareAndSwapUint64(&tb.closed, 0, 1) {
+		return nil
+	}
 	tb.Log.Info("Starting %v with the following config: %+v", protoName, tb.config)
 
-	tb.initGenesisBeacons()
+	ctx, cancel := context.WithCancel(ctx)
+	tb.tg = taskgroup.New(taskgroup.WithContext(ctx))
+	tb.cancel = cancel
 
+	tb.initGenesisBeacons()
 	tb.layerTicker = tb.clock.Subscribe()
 
-	tb.backgroundWG.Add(1)
-
-	go func() {
-		defer tb.backgroundWG.Done()
-
+	tb.tg.Go(func(ctx context.Context) error {
 		tb.listenLayers(ctx)
-	}()
-
-	tb.backgroundWG.Add(1)
-
-	go func() {
-		defer tb.backgroundWG.Done()
-
-		tb.cleanupLoop()
-	}()
-
+		return ctx.Err()
+	})
+	tb.tg.Go(func(ctx context.Context) error {
+		tb.cleanupLoop(ctx)
+		return ctx.Err()
+	})
 	return nil
 }
 
 // Close closes TortoiseBeacon.
 func (tb *TortoiseBeacon) Close() {
+	if !atomic.CompareAndSwapUint64(&tb.closed, 1, 0) {
+		return
+	}
 	tb.Log.Info("Closing %v", protoName)
-	tb.Closer.Close()
-	tb.backgroundWG.Wait() // Wait until background goroutines finish
+	tb.cancel()
+	tb.tg.Wait()
 	tb.clock.Unsubscribe(tb.layerTicker)
+}
+
+func (tb *TortoiseBeacon) IsClosed() bool {
+	return atomic.LoadUint64(&tb.closed) == 0
 }
 
 // GetBeacon returns a Tortoise Beacon value as []byte for a certain epoch or an error if it doesn't exist.
@@ -277,13 +283,13 @@ func (tb *TortoiseBeacon) GetBeacon(epochID types.EpochID) ([]byte, error) {
 	return beacon.Bytes(), nil
 }
 
-func (tb *TortoiseBeacon) cleanupLoop() {
+func (tb *TortoiseBeacon) cleanupLoop(ctx context.Context) {
 	ticker := time.NewTicker(cleanupInterval)
 	defer ticker.Stop()
 
 	for {
 		select {
-		case <-tb.CloseChannel():
+		case <-ctx.Done():
 			return
 		case <-ticker.C:
 			tb.cleanup()
@@ -333,11 +339,14 @@ func (tb *TortoiseBeacon) listenLayers(ctx context.Context) {
 
 	for {
 		select {
-		case <-tb.CloseChannel():
+		case <-ctx.Done():
 			return
 		case layer := <-tb.layerTicker:
 			tb.Log.With().Info("Received tick", layer)
-			go tb.handleLayer(ctx, layer)
+			tb.tg.Go(func(ctx context.Context) error {
+				tb.handleLayer(ctx, layer)
+				return nil
+			})
 		}
 	}
 }
@@ -389,12 +398,9 @@ func (tb *TortoiseBeacon) handleLayer(ctx context.Context, layer types.LayerID) 
 		log.String("wait_time", tb.waitAfterEpochStart.String()))
 
 	epochStartTimer := time.NewTimer(tb.waitAfterEpochStart)
-
+	defer epochStartTimer.Stop()
 	select {
-	case <-tb.CloseChannel():
-		if !epochStartTimer.Stop() {
-			<-epochStartTimer.C
-		}
+	case <-ctx.Done():
 	case <-epochStartTimer.C:
 		tb.handleEpoch(ctx, epoch)
 	}
@@ -420,7 +426,10 @@ func (tb *TortoiseBeacon) handleEpoch(ctx context.Context, epoch types.EpochID) 
 	ch := tb.getOrCreateProposalChannel(epoch)
 	tb.proposalChansMu.Unlock()
 
-	go tb.readProposalMessagesLoop(ctx, ch)
+	tb.tg.Go(func(ctx context.Context) error {
+		tb.readProposalMessagesLoop(ctx, ch)
+		return nil
+	})
 
 	tb.runProposalPhase(ctx, epoch)
 	coinflip := tb.runConsensusPhase(ctx, epoch)
@@ -440,7 +449,7 @@ func (tb *TortoiseBeacon) handleEpoch(ctx context.Context, epoch types.EpochID) 
 func (tb *TortoiseBeacon) readProposalMessagesLoop(ctx context.Context, ch chan *proposalMessageWithReceiptData) {
 	for {
 		select {
-		case <-tb.CloseChannel():
+		case <-ctx.Done():
 			return
 
 		case em := <-ch:
@@ -490,7 +499,7 @@ func (tb *TortoiseBeacon) runProposalPhase(ctx context.Context, epoch types.Epoc
 	ctx, cancel = context.WithTimeout(ctx, tb.proposalDuration)
 	defer cancel()
 
-	go func() {
+	tb.tg.Go(func(ctx context.Context) error {
 		tb.Log.With().Debug("Starting proposal message sender",
 			log.Uint64("epoch_id", uint64(epoch)))
 
@@ -502,10 +511,10 @@ func (tb *TortoiseBeacon) runProposalPhase(ctx context.Context, epoch types.Epoc
 
 		tb.Log.With().Debug("Proposal message sender finished",
 			log.Uint64("epoch_id", uint64(epoch)))
-	}()
+		return nil
+	})
 
 	select {
-	case <-tb.CloseChannel():
 	case <-ctx.Done():
 		tb.markProposalPhaseFinished(epoch)
 
@@ -612,19 +621,22 @@ func (tb *TortoiseBeacon) runConsensusPhase(ctx context.Context, epoch types.Epo
 	for round := firstRound; round <= tb.lastPossibleRound(); round++ {
 		// always use coinflip from the previous round for current round.
 		// round 1 is running without coinflip (e.g. value is false) intentionally
-		go func(epoch types.EpochID, round types.RoundID, coinflip bool) {
+		round := round
+		tb.tg.Go(func(ctx context.Context) error {
 			if err := tb.sendVotes(ctx, epoch, round, coinflip); err != nil {
 				tb.Log.With().Error("Failed to send voting messages",
 					log.Uint32("epoch_id", uint32(epoch)),
 					log.Uint64("round_id", uint64(round)),
 					log.Err(err))
 			}
-		}(epoch, round, coinflip)
-		go tb.startWeakCoin(ctx, epoch, round)
+			return nil
+		})
+		tb.tg.Go(func(ctx context.Context) error {
+			tb.startWeakCoin(ctx, epoch, round)
+			return nil
+		})
 		select {
 		case <-ticker.C:
-		case <-tb.CloseChannel():
-			return false
 		case <-ctx.Done():
 			return false
 		}
@@ -664,8 +676,6 @@ func (tb *TortoiseBeacon) startWeakCoin(ctx context.Context, epoch types.EpochID
 	select {
 	case <-t.C:
 		break
-	case <-tb.CloseChannel():
-		return
 	case <-ctx.Done():
 		return
 	}


### PR DESCRIPTION
## Motivation

Tortoise beacon creates multiple goroutines during its lifetime, not all of them are guaranteed to exit when Close is called. I need it for my logging refactoring, and it should be default behavior anyway.

closes: https://github.com/spacemeshos/go-spacemesh/issues/2621
depends on change in: https://github.com/spacemeshos/go-spacemesh/pull/2605

## Changes

I added new module called taskgroup, it behaves identically to errgroup, with a difference that it is safe to call Go concurrently with Wait. If the group didn't terminate Wait will ensure that concurrent Go call completes. If it did Go call will exit immediately with Terminated error (this error should be ignored unless callers counts number of goroutine for some reason).

## Test Plan
unit tests

## TODO
<!-- This section should be removed when all items are complete -->
- [ ] Explain motivation or link existing issue(s)
- [ ] Test changes and document test plan
- [ ] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
