### PR TITLE
[Merged by Bors] - Introduce `make go-env` and `make go-env-test`

### DIFF
--- a/.run/Template Go Test.run.xml
+++ b/.run/Template Go Test.run.xml
@@ -1,0 +1,15 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="true" type="GoTestRunConfiguration" factoryName="Go Test">
+    <module name="go-spacemesh" />
+    <working_directory value="$PROJECT_DIR$" />
+    <go_parameters value="-i" />
+    <kind value="DIRECTORY" />
+    <package value="github.com/spacemeshos/go-spacemesh" />
+    <directory value="$PROJECT_DIR$" />
+    <filePath value="$PROJECT_DIR$" />
+    <framework value="gotest" />
+    <method v="2">
+      <option name="RunConfigurationTask" enabled="true" run_configuration_name="go-env-test" run_configuration_type="MAKEFILE_TARGET_RUN_CONFIGURATION" />
+    </method>
+  </configuration>
+</component>

--- a/.run/go-env-test.run.xml
+++ b/.run/go-env-test.run.xml
@@ -1,0 +1,8 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="go-env-test" type="MAKEFILE_TARGET_RUN_CONFIGURATION" factoryName="Makefile">
+    <makefile filename="$PROJECT_DIR$/Makefile.Inc" target="go-env-test" workingDirectory="" arguments="">
+      <envs />
+    </makefile>
+    <method v="2" />
+  </configuration>
+</component>

--- a/Makefile.Inc
+++ b/Makefile.Inc
@@ -36,7 +36,9 @@ else
   endif
 endif
 
-$(info "OS: $(OS), HOST_OS: $(HOST_OS), GOOS: $(GOOS), GOARCH: $(GOARH), BIN_DIR: $(BIN_DIR), platform: $(platform)")
+ifneq ($(VERBOSE),)
+  $(info "OS: $(OS), HOST_OS: $(HOST_OS), GOOS: $(GOOS), GOARCH: $(GOARH), BIN_DIR: $(BIN_DIR), platform: $(platform)")
+endif
 
 GPU_SETUP_REV = 0.1.21
 GPU_SETUP_ZIP = libgpu-setup-$(platform)-$(GPU_SETUP_REV).zip
@@ -60,6 +62,7 @@ $(PROJ_DIR)$(GPU_SETUP_ZIP):
 	curl -L $(GPU_SETUP_URL_ZIP) -o $(PROJ_DIR)$(GPU_SETUP_ZIP)
 
 get-gpu-setup: $(PROJ_DIR)$(GPU_SETUP_ZIP) $(BINDIR_GPU_SETUP_LIBS)
+.PHONY: get-gpu-setup
 
 SUBDIRS_LVL1 := $(foreach X,$(wildcard $(dir $(PROJ_DIR))*/.), $(lastword $(subst /, ,$(dir $(X)))))
 SUBDIRS_ONLY := $(sort \
@@ -92,3 +95,18 @@ print-test-targets:
 	done
 .PHONY: $(SUBDIRS_ALL) $(SUBDIRS_LVL2) $(SUBDIRS_ONLY) print-test-targets
 
+go-env: get-gpu-setup
+	go env -w CGO_LDFLAGS="$(CGO_LDFLAGS)"
+.PHONY: go-env
+
+go-env-test: get-gpu-setup
+	go env -w CGO_LDFLAGS="$(CGO_TEST_LDFLAGS)"
+.PHONY: go-env-test
+
+print-ldflags: get-gpu-setup
+	@echo $(CGO_LDFLAGS)
+.PHONY: print-ldflags
+
+print-test-ldflags: get-gpu-setup
+	@echo $(CGO_TEST_LDFLAGS)
+.PHONY: print-test-ldflags

--- a/README.md
+++ b/README.md
@@ -126,6 +126,19 @@ make darwin | linux | freebsd | windows
 
 Platform-specific binaries are saved to the `/build` directory.
 
+### Using `go build` and `go test` without `make`
+To build code without using `make` the `CGO_LDFLAGS` environment variable must be set
+appropriately. The required value can be obtained by running `make print-ldflags` or
+`make print-test-ldflags`.
+
+This can be done in 3 ways:
+1. Setting the variable in the shell environment (e.g., in bash run `CGO_LDFLAGS=$(make print-ldflags)`).
+2. Prefixing the key and value to the `go` command (e.g., `CGO_LDFLAGS=$(make print-ldflags) go build`).
+3. Using `go env -w CGO_LDFLAGS=$(make print-ldflags)`, which persistently adds this value to Go's
+   environment for any future runs.
+
+There's a handy shortcut for the 3rd method: `make go-env` or `make go-env-test`.
+
 ---
 
 ### Running


### PR DESCRIPTION
## Motivation
Running tests without using `make` is cumbersome. This is relevant for using `go test` from the command line, as well as running tests from GoLand (which most of the team uses). Even more specifically, the `make test-*` commands don't support running a specific test - only all tests in an entire folder.

This PR is an alternative to https://github.com/spacemeshos/go-spacemesh/pull/2600.

## Changes
Introduce `make go-env` and `make go-env-test` which add the appropriate `CGO_LDFLAGS` to the Go environment, using `go env -w`.

We also add a shared GoLand run configuration for the `make go-env-test` command and a shared run configuration template for Go tests.

## Test Plan
No code changes that require testing.

## TODO
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
