### PR TITLE
[Merged by Bors] - fix fetcher excessive log on unknown hash

### DIFF
--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -361,7 +361,10 @@ func (f *Fetch) FetchRequestHandler(ctx context.Context, data []byte) []byte {
 		}
 		res, err := db.Get(r.Hash.Bytes())
 		if err != nil {
-			f.log.WithContext(ctx).Warning("remote peer requested non existing hash %v %v", r.Hash.Hex(), err)
+			f.log.WithContext(ctx).With().Warning("remote peer requested non existing hash",
+				log.String("hash", r.Hash.ShortString()),
+				log.String("hint", string(r.Hint)),
+				log.Err(err))
 			continue
 		} else {
 			f.log.WithContext(ctx).Debug("responded to hash req %v bytes %v", r.Hash.ShortString(), len(res))
@@ -554,12 +557,12 @@ func (f *Fetch) sendBatch(requests []requestMessage) {
 
 // handleHashError is called when an error occurred processing batches of the following hashes
 func (f *Fetch) handleHashError(batchHash types.Hash32, err error) {
-	f.log.Debug("cannot fetch message %v err %v", batchHash.Hex(), err)
+	f.log.Debug("cannot fetch message %v err %v", batchHash.ShortString(), err)
 	f.activeBatchM.RLock()
 	batch, ok := f.activeBatches[batchHash]
 	if !ok {
 		f.activeBatchM.RUnlock()
-		f.log.Error("batch invalidated twice %v", batchHash.Hex())
+		f.log.Error("batch invalidated twice %v", batchHash.ShortString())
 		return
 	}
 	f.activeBatchM.RUnlock()

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -137,12 +137,11 @@ type Config struct {
 // DefaultConfig is the default config for the fetch component
 func DefaultConfig() Config {
 	return Config{
-		BatchTimeout:      50,
-		MaxRetiresForPeer: 2,
-		BatchSize:         20,
-		RequestTimeout:    10,
-		// TODO change it back to 20
-		MaxRetriesForRequest: 2000,
+		BatchTimeout:         50,
+		MaxRetiresForPeer:    2,
+		BatchSize:            20,
+		RequestTimeout:       10,
+		MaxRetriesForRequest: 20,
 	}
 }
 

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -280,7 +280,7 @@ func (f *Fetch) AddDB(hint Hint, db database.Getter) {
 	f.dbLock.Unlock()
 }
 
-// handleNewRequest batches low priority requests and sends a high priority request to peers right away.
+// handleNewRequest batches low priority requests and sends a high priority request to the peers right away.
 // if there are pending requests for the same hash, it will put the new request, regardless of the priority,
 // to the pending list and wait for notification when the earlier request gets response.
 // it returns true if a request is sent immediately, or false otherwise.
@@ -303,10 +303,10 @@ func (f *Fetch) handleNewRequest(req *request) bool {
 	f.activeReqM.Unlock()
 	if sendNow {
 		f.sendBatch([]requestMessage{{req.hint, req.hash}})
-		f.log.Debug("high priority request sent %v", req.hash.ShortString())
+		f.log.With().Debug("high priority request sent", log.String("hash", req.hash.ShortString()))
 		return true
 	}
-	f.log.Debug("request added to queue %v", req.hash.ShortString())
+	f.log.With().Debug("request added to queue", log.String("hash", req.hash.ShortString()))
 	if rLen > batchMaxSize {
 		go f.requestHashBatchFromPeers() // Process the batch.
 		return true
@@ -341,7 +341,7 @@ func (f *Fetch) FetchRequestHandler(ctx context.Context, data []byte) []byte {
 	var requestBatch requestBatch
 	err := types.BytesToInterface(data, &requestBatch)
 	if err != nil {
-		f.log.WithContext(ctx).Error("cannot parse request %v", err)
+		f.log.WithContext(ctx).With().Error("failed to parse request", log.Err(err))
 		return []byte{}
 	}
 	resBatch := responseBatch{
@@ -355,18 +355,20 @@ func (f *Fetch) FetchRequestHandler(ctx context.Context, data []byte) []byte {
 		db, ok := f.dbs[r.Hint]
 		f.dbLock.RUnlock()
 		if !ok {
-			f.log.WithContext(ctx).Warning("db not found %v", r.Hint)
+			f.log.WithContext(ctx).With().Warning("db not found", log.String("hint", string(r.Hint)))
 			continue
 		}
 		res, err := db.Get(r.Hash.Bytes())
 		if err != nil {
-			f.log.WithContext(ctx).With().Warning("remote peer requested non existing hash",
+			f.log.WithContext(ctx).With().Info("remote peer requested non existing hash",
 				log.String("hash", r.Hash.ShortString()),
 				log.String("hint", string(r.Hint)),
 				log.Err(err))
 			continue
 		} else {
-			f.log.WithContext(ctx).Debug("responded to hash req %v bytes %v", r.Hash.ShortString(), len(res))
+			f.log.WithContext(ctx).With().Debug("responded to hash request",
+				log.String("hash", r.Hash.ShortString()),
+				log.Int("dataSize", len(res)))
 		}
 		// add response to batch
 		m := responseMessage{
@@ -378,10 +380,14 @@ func (f *Fetch) FetchRequestHandler(ctx context.Context, data []byte) []byte {
 
 	bts, err := types.InterfaceToBytes(&resBatch)
 	if err != nil {
-		f.log.WithContext(ctx).Error("cannot parse message for batch ID %v", resBatch.ID.Hex())
+		f.log.WithContext(ctx).With().Error("cannot parse message for batch ID",
+			log.String("batchHash", resBatch.ID.ShortString()))
 		return nil
 	}
-	f.log.WithContext(ctx).Debug("returning response batch Id %v responses %v total bytes %v", resBatch.ID.Hex(), len(resBatch.Responses), len(bts))
+	f.log.WithContext(ctx).With().Debug("returning response for batch",
+		log.String("batchHash", resBatch.ID.ShortString()),
+		log.Int("numResponse", len(resBatch.Responses)),
+		log.Int("dataSize", len(bts)))
 	return bts
 }
 
@@ -402,7 +408,7 @@ func (f *Fetch) receiveResponse(data []byte) {
 	batch, has := f.activeBatches[response.ID]
 	f.activeBatchM.RUnlock()
 	if !has {
-		f.log.Warning("unknown batch response received, or already invalidated %v", response.ID.Hex())
+		f.log.With().Warning("unknown batch response received, or already invalidated", log.String("batchHash", response.ID.ShortString()))
 		return
 	}
 
@@ -447,14 +453,17 @@ func (f *Fetch) receiveResponse(data []byte) {
 		if f.stopped() {
 			return
 		}
-		f.log.Warning("%v hash %v was not found in response from peer %v", batchMap[h].Hint, h.ShortString(), batch.peer)
+		f.log.With().Warning("hash not found in response from peer",
+			log.String("hint", string(batchMap[h].Hint)),
+			log.String("hash", h.ShortString()),
+			log.String("peer", batch.peer.String()))
 		f.activeReqM.Lock()
 		reqs := f.pendingRequests[h]
 		invalidatedRequests := 0
 		for _, req := range reqs {
 			req.retries++
 			if req.retries > f.cfg.MaxRetriesForRequest {
-				f.log.Debug("returning error to request %v %v %v %p", req.hash.ShortString(), len(req.returnChan), len(reqs), req)
+				f.log.With().Debug("gave up on hash after max retries", log.String("hash", req.hash.ShortString()))
 				req.returnChan <- HashDataPromiseResult{
 					Err:     ErrExceedMaxRetries,
 					Hash:    req.hash,
@@ -485,7 +494,7 @@ func (f *Fetch) requestHashBatchFromPeers() {
 	f.activeReqM.Lock()
 	// only send one request per hash
 	for hash, reqs := range f.activeRequests {
-		f.log.Debug("batching %v", hash.ShortString())
+		f.log.With().Debug("batching hash request", log.String("hash", hash.ShortString()))
 		requestList = append(requestList, requestMessage{Hash: hash, Hint: reqs[0].hint})
 		// move the processed requests to pending
 		f.pendingRequests[hash] = append(f.pendingRequests[hash], reqs...)
@@ -515,7 +524,7 @@ func (f *Fetch) sendBatch(requests []requestMessage) {
 	f.activeBatchM.Unlock()
 	// timeout function will be called if no response was received for the hashes sent
 	timeoutFunc := func(err error) {
-		f.log.Error("request %v timed out", batch.ID.Hex())
+		f.log.With().Error("request timed out", log.String("batchHash", batch.ID.ShortString()))
 		f.handleHashError(batch.ID, err)
 	}
 
@@ -533,7 +542,10 @@ func (f *Fetch) sendBatch(requests []requestMessage) {
 
 		// get random peer
 		p = GetRandomPeer(f.net.GetPeers())
-		f.log.Debug("sending request batch %v items %v peer %v", batch.ID.Hex(), len(batch.Requests), p)
+		f.log.With().Debug("sending request batch to peer",
+			log.String("batchHash", batch.ID.ShortString()),
+			log.Int("numRequests", len(batch.Requests)),
+			log.String("peer", p.String()))
 		batch.peer = p
 		f.activeBatchM.Lock()
 		f.activeBatches[batch.ID] = batch
@@ -547,7 +559,9 @@ func (f *Fetch) sendBatch(requests []requestMessage) {
 				break
 			}
 			//todo: mark number of fails per peer to make it low priority
-			f.log.Warning("could not send message to peer %v, retrying, retries %v", p, retries)
+			f.log.With().Warning("could not send message to peer",
+				log.String("peer", p.String()),
+				log.Int("retries", retries))
 		} else {
 			break
 		}
@@ -556,19 +570,24 @@ func (f *Fetch) sendBatch(requests []requestMessage) {
 
 // handleHashError is called when an error occurred processing batches of the following hashes
 func (f *Fetch) handleHashError(batchHash types.Hash32, err error) {
-	f.log.Debug("cannot fetch message %v err %v", batchHash.ShortString(), err)
+	f.log.With().Debug("cannot fetch message",
+		log.String("batchHash", batchHash.ShortString()),
+		log.Err(err))
 	f.activeBatchM.RLock()
 	batch, ok := f.activeBatches[batchHash]
 	if !ok {
 		f.activeBatchM.RUnlock()
-		f.log.Error("batch invalidated twice %v", batchHash.ShortString())
+		f.log.With().Error("batch invalidated twice", log.String("batchHash", batchHash.ShortString()))
 		return
 	}
 	f.activeBatchM.RUnlock()
 	f.activeReqM.Lock()
 	for _, h := range batch.Requests {
+		f.log.With().Debug("error for hash requests",
+			log.String("hash", h.Hash.ShortString()),
+			log.Int("numSubscribers", len(f.pendingRequests[h.Hash])),
+			log.Err(err))
 		for _, callback := range f.pendingRequests[h.Hash] {
-			f.log.Debug("hash error to request %v %v %v %p: %v", h.Hash.ShortString(), len(callback.returnChan), len(f.pendingRequests[h.Hash]), callback, err)
 			callback.returnChan <- HashDataPromiseResult{
 				Err:     err,
 				Hash:    h.Hash,
@@ -619,7 +638,7 @@ func (f *Fetch) GetHash(hash types.Hash32, h Hint, validateHash bool) chan HashD
 	db, ok := f.dbs[h]
 	f.dbLock.RUnlock()
 	if !ok {
-		f.log.Panic("tried to fetch Data from DB that doesn't exist locally: %v", h)
+		f.log.With().Panic("tried to fetch Data from DB that doesn't exist locally", log.String("hint", string(h)))
 	}
 
 	if b, err := db.Get(hash.Bytes()); err == nil {

--- a/layerfetcher/layers.go
+++ b/layerfetcher/layers.go
@@ -404,6 +404,15 @@ func (l *Logic) fetchLayerBlocks(ctx context.Context, layerID types.LayerID, blo
 		l.log.WithContext(ctx).With().Debug("error fetching layer blocks", layerID, log.Err(err))
 	}
 
+	if len(blocks.VerifyingVector) > 0 {
+		l.log.WithContext(ctx).With().Debug("saving input vector from peer", layerID)
+		err := l.layerDB.SaveLayerInputVectorByID(ctx, layerID, blocks.VerifyingVector)
+		if err == nil {
+			return
+		}
+		l.log.WithContext(ctx).With().Error("failed to save input vector", layerID, log.Err(err))
+	}
+
 	if err := l.GetInputVector(ctx, layerID); err != nil {
 		l.log.WithContext(ctx).With().Debug("error getting input vector", layerID, log.Err(err))
 	}

--- a/layerfetcher/layers.go
+++ b/layerfetcher/layers.go
@@ -193,18 +193,20 @@ func (l *Logic) AddDBs(blockDB, AtxDB, TxDB, poetDB, IvDB, tbDB database.Getter)
 func (l *Logic) layerHashReqReceiver(ctx context.Context, msg []byte) []byte {
 	lyr := types.NewLayerID(util.BytesToUint32(msg))
 	h := l.layerDB.GetLayerHash(lyr)
-	l.log.WithContext(ctx).Debug("got layer hash request %v, responding with %v", lyr, h.ShortString())
+	l.log.WithContext(ctx).With().Debug("responded layer hash request",
+		lyr,
+		log.String("layerHash", h.ShortString()))
 	return h.Bytes()
 }
 
 // epochATXsReqReceiver returns the ATXs for the specified epoch.
 func (l *Logic) epochATXsReqReceiver(ctx context.Context, msg []byte) []byte {
-	lyr := types.EpochID(util.BytesToUint32(msg))
-	l.log.WithContext(ctx).With().Debug("got epoch atxs request for layer", lyr)
-	atxs := l.atxIds.GetEpochAtxs(lyr)
+	epoch := types.EpochID(util.BytesToUint32(msg))
+	atxs := l.atxIds.GetEpochAtxs(epoch)
+	l.log.WithContext(ctx).With().Debug("responded epoch atxs request", epoch, log.Int("numATXs", len(atxs)))
 	bts, err := types.InterfaceToBytes(atxs)
 	if err != nil {
-		l.log.WithContext(ctx).Warning("cannot find epoch atxs for epoch %v", lyr)
+		l.log.WithContext(ctx).With().Warning("cannot find epoch atxs", epoch, log.Err(err))
 	}
 	return bts
 }
@@ -219,7 +221,7 @@ func (l *Logic) layerHashBlocksReqReceiver(ctx context.Context, msg []byte) []by
 	// best effort with input vector
 	if err != nil {
 		// TODO: We need to diff empty set and no results in sync somehow.
-		l.log.WithContext(ctx).Debug("didn't have input vector for layer ")
+		l.log.WithContext(ctx).With().Debug("didn't have input vector for layer", log.String("layerHash", h.ShortString()))
 	}
 	// latest := l.gossipBlocks.Get() todo: implement this
 	b := layerBlocks{
@@ -230,7 +232,7 @@ func (l *Logic) layerHashBlocksReqReceiver(ctx context.Context, msg []byte) []by
 
 	out, err := types.InterfaceToBytes(b)
 	if err != nil {
-		l.log.WithContext(ctx).Error("cannot serialize response")
+		l.log.WithContext(ctx).With().Error("cannot serialize layer blocks response", log.Err(err))
 	}
 
 	return out
@@ -239,27 +241,27 @@ func (l *Logic) layerHashBlocksReqReceiver(ctx context.Context, msg []byte) []by
 // tortoiseBeaconReqReceiver returns the tortoise beacon for the given layer ID
 func (l *Logic) tortoiseBeaconReqReceiver(ctx context.Context, msg []byte) []byte {
 	epoch := types.EpochID(util.BytesToUint32(msg))
-	l.log.WithContext(ctx).Debug("got tortoise beacon request for epoch %v", epoch)
+	l.log.WithContext(ctx).With().Debug("got tortoise beacon request", epoch)
 
 	beacon, err := l.tbDB.GetTortoiseBeacon(epoch)
 	if errors.Is(err, database.ErrNotFound) {
-		l.log.WithContext(ctx).Warning("tortoise beacon for epoch %v was requested, but wasn't found in the DB", epoch)
+		l.log.WithContext(ctx).With().Warning("tortoise beacon not found in DB", epoch)
 		return []byte{}
 	}
 
 	if err != nil {
-		l.log.WithContext(ctx).Error("cannot get tortoise beacon for epoch %v: %v", epoch, err)
+		l.log.WithContext(ctx).With().Error("failed to get tortoise beacon", epoch, log.Err(err))
 		return []byte{}
 	}
 
-	l.log.WithContext(ctx).Debug("replying to tortoise beacon request for epoch %v: %v", epoch, beacon.String())
+	l.log.WithContext(ctx).With().Debug("replying to tortoise beacon request", epoch, log.String("beacon", beacon.ShortString()))
 	return beacon.Bytes()
 }
 
 // PollLayerHash polls peers on the layer hash. it returns a channel for the caller to be notified when
 // responses are received from all peers.
 func (l *Logic) PollLayerHash(ctx context.Context, layerID types.LayerID) chan LayerHashResult {
-	l.log.WithContext(ctx).Info("polling layer hash for layer %v", layerID)
+	l.log.WithContext(ctx).With().Info("polling layer hash", layerID)
 	resChannel := make(chan LayerHashResult, 1)
 
 	remotePeers := l.net.GetPeers()
@@ -306,16 +308,24 @@ func (l *Logic) receiveLayerHash(ctx context.Context, layerID types.LayerID, pee
 	if err == nil {
 		hash := types.BytesToHash(data)
 		l.layerHashesRes[layerID][peer] = &peerResult{data: data, err: nil}
-		l.log.WithContext(ctx).Debug("received data %v for layer %v from peer %v", hash.ShortString(), layerID, peer.String())
+		l.log.WithContext(ctx).With().Debug("received layer hash from peer",
+			layerID,
+			log.String("layerHash", hash.ShortString()),
+			log.String("peer", peer.String()))
 	} else {
 		l.layerHashesRes[layerID][peer] = &peerResult{data: nil, err: err}
-		l.log.WithContext(ctx).Debug("received error for layer %v from peer %v err: %v", layerID, peer.String(), err)
+		l.log.WithContext(ctx).With().Debug("received layer hash error from peer",
+			layerID,
+			log.String("peer", peer.String()),
+			log.Err(err))
 	}
 
 	// check if we have all responses from peers
 	result := l.layerHashesRes[layerID]
 	if len(result) < numPeers {
-		l.log.WithContext(ctx).Debug("received %v results, not from all numPeers yet (%v)", len(result), numPeers)
+		l.log.WithContext(ctx).With().Debug("not yet received layer hash from all peers",
+			log.Int("received", len(result)),
+			log.Int("expected", numPeers))
 		return
 	}
 
@@ -329,7 +339,7 @@ func (l *Logic) receiveLayerHash(ctx context.Context, layerID types.LayerID, pee
 // if there are too many errors from peers, it reports error instead.
 // it deliberately doesn't hold any lock while notifying channels
 func notifyLayerHashResult(layerID types.LayerID, channels []chan LayerHashResult, peerResult map[peers.Peer]*peerResult, numPeers int, logger log.Log) {
-	logger.Debug("got hashes for layer %v, now aggregating", layerID)
+	logger.With().Debug("got layer hashes. now aggregating", layerID)
 	numErrors := 0
 	// aggregate the peerResult by data
 	hashes := make(map[types.Hash32][]peers.Peer)
@@ -405,7 +415,7 @@ func (l *Logic) fetchLayerBlocks(ctx context.Context, layerID types.LayerID, blo
 	}
 
 	if len(blocks.VerifyingVector) > 0 {
-		l.log.WithContext(ctx).With().Debug("saving input vector from peer", layerID)
+		l.log.WithContext(ctx).With().Debug("saving input vector from peer blocks", layerID)
 		err := l.layerDB.SaveLayerInputVectorByID(ctx, layerID, blocks.VerifyingVector)
 		if err == nil {
 			return
@@ -430,7 +440,7 @@ func (l *Logic) receiveBlockHashes(ctx context.Context, layerID types.LayerID, p
 		var blocks layerBlocks
 		convertErr := types.BytesToInterface(data, &blocks)
 		if convertErr != nil {
-			l.log.WithContext(ctx).Error("error converting bytes to layerBlocks", convertErr)
+			l.log.WithContext(ctx).With().Error("error converting bytes to layerBlocks", log.Err(convertErr))
 			pRes.err = convertErr
 		} else {
 			pRes.data = data
@@ -445,7 +455,9 @@ func (l *Logic) receiveBlockHashes(ctx context.Context, layerID types.LayerID, p
 	// check if we have all responses from peers
 	result := l.layerBlocksRes[layerID]
 	if len(result) < expectedResults {
-		l.log.WithContext(ctx).Debug("received %v results, not from all peers yet (%v)", len(result), expectedResults)
+		l.log.WithContext(ctx).With().Debug("not yet received layer blocks from all peers",
+			log.Int("received", len(result)),
+			log.Int("expected", expectedResults))
 		return
 	}
 
@@ -484,7 +496,7 @@ func notifyLayerBlocksResult(layerID types.LayerID, channels []chan LayerPromise
 			result.Err = firstErr
 		}
 	}
-	logger.Debug("notifying layer blocks result %v", result)
+	logger.With().Debug("notifying layer blocks result", log.String("blocks", fmt.Sprintf("%v", result)))
 	for _, ch := range channels {
 		ch <- *result
 	}
@@ -518,7 +530,7 @@ func (l *Logic) GetEpochATXs(ctx context.Context, id types.EpochID) error {
 	if err != nil {
 		return err
 	}
-	l.log.WithContext(ctx).Debug("waiting for epoch atx response")
+	l.log.WithContext(ctx).With().Debug("waiting for epoch atx response", id)
 	res := <-resCh
 	if res.Error != nil {
 		return res.Error
@@ -528,18 +540,24 @@ func (l *Logic) GetEpochATXs(ctx context.Context, id types.EpochID) error {
 
 // getAtxResults is called when an ATX result is received
 func (l *Logic) getAtxResults(ctx context.Context, hash types.Hash32, data []byte) error {
-	l.log.WithContext(ctx).Info("got response for ATX %v, len: %v", hash.ShortString(), len(data))
+	l.log.WithContext(ctx).With().Info("got response for ATX",
+		log.String("hash", hash.ShortString()),
+		log.Int("dataSize", len(data)))
 	return l.atxs.HandleAtxData(ctx, data, l)
 }
 
 func (l *Logic) getTxResult(ctx context.Context, hash types.Hash32, data []byte) error {
-	l.log.WithContext(ctx).Info("got response for TX %v, len: %v", hash.ShortString(), len(data))
+	l.log.WithContext(ctx).With().Info("got response for TX",
+		log.String("hash", hash.ShortString()),
+		log.Int("dataSize", len(data)))
 	return l.txs.HandleTxSyncData(data)
 }
 
 // getPoetResult is handler function to poet proof fetch result
 func (l *Logic) getPoetResult(ctx context.Context, hash types.Hash32, data []byte) error {
-	l.log.WithContext(ctx).Info("got poet ref %v, size %v", hash.ShortString(), len(data))
+	l.log.WithContext(ctx).Info("got poet ref",
+		log.String("hash", hash.ShortString()),
+		log.Int("dataSize", len(data)))
 	return l.poetProofs.ValidateAndStoreMsg(data)
 }
 
@@ -614,7 +632,9 @@ func (l *Logic) GetAtxs(ctx context.Context, IDs []types.ATXID) error {
 	for hash, resC := range results {
 		res := <-resC
 		if res.Err != nil {
-			l.log.WithContext(ctx).Error("cannot fetch atx %v err %v", hash.ShortString(), res.Err)
+			l.log.WithContext(ctx).With().Error("cannot fetch atx",
+				log.String("hash", hash.ShortString()),
+				log.Err(res.Err))
 			return res.Err
 		}
 		if !res.IsLocal {
@@ -630,7 +650,7 @@ func (l *Logic) GetAtxs(ctx context.Context, IDs []types.ATXID) error {
 // GetBlocks gets the data for given block ids and validates the blocks. returns an error if a single atx failed to be fetched
 // or validated
 func (l *Logic) GetBlocks(ctx context.Context, IDs []types.BlockID) error {
-	l.log.WithContext(ctx).Debug("requesting %v blocks from peer", len(IDs))
+	l.log.WithContext(ctx).With().Debug("requesting blocks from peer", log.Int("numBlocks", len(IDs)))
 	hashes := make([]types.Hash32, 0, len(IDs))
 	for _, blockID := range IDs {
 		hashes = append(hashes, blockID.AsHash32())
@@ -639,11 +659,11 @@ func (l *Logic) GetBlocks(ctx context.Context, IDs []types.BlockID) error {
 	for hash, resC := range results {
 		res, open := <-resC
 		if !open {
-			l.log.WithContext(ctx).Info("res channel for %v is closed", hash.ShortString())
+			l.log.WithContext(ctx).With().Info("block res channel closed", log.String("hash", hash.ShortString()))
 			continue
 		}
 		if res.Err != nil {
-			l.log.WithContext(ctx).Error("cannot find block %v err %v", hash.String(), res.Err)
+			l.log.WithContext(ctx).With().Error("cannot find block", log.String("hash", hash.String()), log.Err(res.Err))
 			continue
 		}
 		if !res.IsLocal {
@@ -666,7 +686,7 @@ func (l *Logic) GetTxs(ctx context.Context, IDs []types.TransactionID) error {
 	for hash, resC := range results {
 		res := <-resC
 		if res.Err != nil {
-			l.log.WithContext(ctx).Error("cannot find tx %v err %v", hash.String(), res.Err)
+			l.log.WithContext(ctx).With().Error("cannot find tx", log.String("hash", hash.String()), log.Err(res.Err))
 			continue
 		}
 		if !res.IsLocal {
@@ -681,7 +701,7 @@ func (l *Logic) GetTxs(ctx context.Context, IDs []types.TransactionID) error {
 
 // GetPoetProof gets poet proof from remote peer
 func (l *Logic) GetPoetProof(ctx context.Context, id types.Hash32) error {
-	l.log.WithContext(ctx).Debug("getting proof %v", id.ShortString())
+	l.log.WithContext(ctx).With().Debug("getting poet proof", log.String("hash", id.ShortString()))
 	res := <-l.fetcher.GetHash(id, fetch.POETDB, false)
 	if res.Err != nil {
 		return res.Err
@@ -701,10 +721,10 @@ func (l *Logic) GetInputVector(ctx context.Context, id types.LayerID) error {
 	}
 	// if result is local we don't need to process it again
 	if !res.IsLocal {
-		l.log.WithContext(ctx).With().Debug("saving input vector", id, res.Hash)
+		l.log.WithContext(ctx).With().Debug("saving input vector from peer", id, res.Hash)
 		var blocks []types.BlockID
 		if err := types.BytesToInterface(res.Data, &blocks); err != nil {
-			l.log.WithContext(ctx).With().Error("got invalid input vector from peer", id)
+			l.log.WithContext(ctx).With().Error("got invalid input vector from peer", id, log.Err(err))
 			return err
 		}
 		return l.layerDB.SaveLayerInputVectorByID(ctx, id, blocks)
@@ -728,27 +748,32 @@ func (l *Logic) GetTortoiseBeacon(ctx context.Context, id types.EpochID) error {
 	makeReceiveFunc := func(peer fmt.Stringer) func([]byte) {
 		return func(data []byte) {
 			if len(data) == 0 {
-				l.log.WithContext(ctx).Info("received empty tortoise beacon (peer does not have it): %v", util.Bytes2Hex(data))
+				l.log.WithContext(ctx).With().Info("empty tortoise beacon response (peer does not have it)",
+					id,
+					log.String("peer", peer.String()))
 				return
 			}
 
 			if len(data) != types.Hash32Length {
-				l.log.WithContext(ctx).Warning("received tortoise beacon response contains either empty or bad data, ignoring: %v", util.Bytes2Hex(data))
+				l.log.WithContext(ctx).With().Warning("tortoise beacon response contains bad data, ignoring",
+					log.String("data", util.Bytes2Hex(data)))
 				return
 			}
 
-			l.log.WithContext(ctx).Info("peer %v responded to tortoise beacon request with beacon %v", peer.String(), util.Bytes2Hex(data))
+			l.log.WithContext(ctx).With().Info("tortoise beacon response from peer",
+				log.String("peer", peer.String()),
+				log.String("beacon", types.BytesToHash(data).ShortString()))
 			resCh <- data
 		}
 	}
 
 	makeErrFunc := func(peer fmt.Stringer) func(error) {
 		return func(err error) {
-			l.log.WithContext(ctx).Warning("peer %v responded to tortoise beacon request with error %v", peer.String(), err)
+			l.log.WithContext(ctx).With().Warning("error in tortoise beacon response", log.String("peer", peer.String()), log.Err(err))
 		}
 	}
 
-	l.log.WithContext(ctx).Info("requesting tortoise beacon from all peers for epoch %v", id)
+	l.log.WithContext(ctx).With().Info("requesting tortoise beacon from all peers", id)
 
 	for _, p := range remotePeers {
 		go func(peer peers.Peer) {
@@ -756,11 +781,10 @@ func (l *Logic) GetTortoiseBeacon(ctx context.Context, id types.EpochID) error {
 			case <-cancelCtx.Done():
 				return
 			default:
-				l.log.WithContext(ctx).Info("requesting tortoise beacon from for epoch %v, peer: %v", id, peer.String())
-
+				l.log.WithContext(ctx).With().Debug("requesting tortoise beacon from peer", id, log.String("peer", peer.String()))
 				err := l.net.SendRequest(cancelCtx, server.TortoiseBeaconMsg, id.ToBytes(), peer, makeReceiveFunc(peer), makeErrFunc(peer))
 				if err != nil {
-					l.log.WithContext(ctx).Warning("failed to send  tortoise beacon request to peer %v: %v", peer.String(), err)
+					l.log.WithContext(ctx).Warning("failed to send tortoise beacon request", log.String("peer", peer.String()), log.Err(err))
 				}
 			}
 		}(p)
@@ -774,17 +798,16 @@ func (l *Logic) GetTortoiseBeacon(ctx context.Context, id types.EpochID) error {
 
 	select {
 	case <-cancelCtx.Done():
-		l.log.WithContext(ctx).Debug("receiving tortoise beacon for epoch canceled", id)
+		l.log.WithContext(ctx).With().Debug("receiving tortoise beacon canceled", id)
 		return nil
 
 	case <-timer.C:
-		l.log.WithContext(ctx).Debug("receiving tortoise beacon for epoch timed out after %v", timeout)
+		l.log.WithContext(ctx).With().Debug("receiving tortoise beacon timed out", id, log.String("timeout", timeout.String()))
 		return nil
 
 	case res := <-resCh:
 		resHash := types.BytesToHash(res)
-		l.log.WithContext(ctx).Info("received tortoise beacon for epoch %v: %v", id, resHash.String())
-
+		l.log.WithContext(ctx).With().Info("received tortoise beacon", id, log.String("beacon", resHash.ShortString()))
 		return l.tbDB.SetTortoiseBeacon(id, resHash)
 	}
 }

--- a/layerfetcher/layers_test.go
+++ b/layerfetcher/layers_test.go
@@ -98,13 +98,8 @@ func (l *layerDBMock) GetLayerInputVector(hash types.Hash32) ([]types.BlockID, e
 	return l.vectors[hash], nil
 }
 
-func (l *layerDBMock) SaveLayerHashInputVector(id types.Hash32, data []byte) error {
-	var blocks []types.BlockID
-	err := types.BytesToInterface(data, blocks)
-	if err != nil {
-		return err
-	}
-	l.vectors[id] = blocks
+func (l *layerDBMock) SaveLayerInputVectorByID(ctx context.Context, id types.LayerID, blocks []types.BlockID) error {
+	l.vectors[types.CalcHash32(id.Bytes())] = blocks
 	return nil
 }
 func (l *layerDBMock) GetLayerHash(ID types.LayerID) types.Hash32           { return l.hashes[ID] }

--- a/mesh/mesh.go
+++ b/mesh/mesh.go
@@ -439,8 +439,8 @@ func (msh *Mesh) HandleValidatedLayer(ctx context.Context, validatedLayer types.
 
 	msh.Log.With().Info("mesh validating layer", lyr.Index().Field(), log.Int("valid_blocks", len(blocks)), log.Int("invalid_blocks", len(invalidBlocks)))
 
-	if err := msh.SaveLayerInputVectorByID(lyr.Index(), types.BlockIDs(blocks)); err != nil {
-		msh.Log.With().Error("Saving layer input vector failed", lyr.Index().Field())
+	if err := msh.SaveLayerInputVectorByID(ctx, lyr.Index(), types.BlockIDs(blocks)); err != nil {
+		msh.Log.With().Error("failed to save input vector", lyr.Index())
 	}
 	msh.ValidateLayer(lyr)
 }

--- a/mesh/meshdb.go
+++ b/mesh/meshdb.go
@@ -101,8 +101,8 @@ func NewPersistentMeshDB(path string, blockCacheSize int, logger log.Log) (*DB, 
 			ll.Log.With().Error("Error inserting genesis block to db", blk.ID(), blk.LayerIndex)
 		}
 	}
-	if err := ll.SaveLayerInputVectorByID(GenesisLayer().Index(), types.BlockIDs(GenesisLayer().Blocks())); err != nil {
-		ll.Log.With().Error("Error inserting genesis input vector to db", GenesisLayer().Index())
+	if err := ll.SaveLayerInputVectorByID(context.Background(), GenesisLayer().Index(), types.BlockIDs(GenesisLayer().Blocks())); err != nil {
+		log.With().Error("Error inserting genesis input vector to db", GenesisLayer().Index())
 	}
 	return ll, err
 }
@@ -138,7 +138,7 @@ func NewMemMeshDB(log log.Log) *DB {
 		ll.AddBlock(blk)
 		ll.SaveContextualValidity(blk.ID(), true)
 	}
-	if err := ll.SaveLayerInputVectorByID(GenesisLayer().Index(), types.BlockIDs(GenesisLayer().Blocks())); err != nil {
+	if err := ll.SaveLayerInputVectorByID(context.Background(), GenesisLayer().Index(), types.BlockIDs(GenesisLayer().Blocks())); err != nil {
 		log.With().Error("Error inserting genesis input vector to db", GenesisLayer().Index())
 	}
 	return ll
@@ -344,16 +344,6 @@ func (m *DB) GetCoinflip(ctx context.Context, layerID types.LayerID) (bool, bool
 	return coin, exists
 }
 
-// SaveLayerInputVector saves the input vote vector for a layer (hare results)
-func (m *DB) SaveLayerInputVector(hash types.Hash32, vector []types.BlockID) error {
-	bytes, err := types.InterfaceToBytes(vector)
-	if err != nil {
-		return err
-	}
-
-	return m.inputVector.Put(hash.Bytes(), bytes)
-}
-
 func (m *DB) defaulGetLayerInputVectorByID(id types.LayerID) ([]types.BlockID, error) {
 	by, err := m.inputVector.Get(types.CalcHash32(id.Bytes()).Bytes())
 	if err != nil {
@@ -384,16 +374,18 @@ func (m *DB) GetLayerInputVectorByID(id types.LayerID) ([]types.BlockID, error) 
 }
 
 // SaveLayerInputVectorByID gets the input vote vector for a layer (hare results)
-func (m *DB) SaveLayerInputVectorByID(id types.LayerID, blks []types.BlockID) error {
+func (m *DB) SaveLayerInputVectorByID(ctx context.Context, id types.LayerID, blks []types.BlockID) error {
 	hash := types.CalcHash32(id.Bytes())
-	m.With().Info("SaveLayerInputVectorByID: Saving input vector", id, hash)
-	return m.SaveLayerInputVector(hash, blks)
-}
+	m.With().Info("saving input vector",
+		id,
+		log.String("iv_hash", hash.ShortString()))
 
-// SaveLayerHashInputVector saves the input vote vector for a layer (hare results) using its hash
-func (m *DB) SaveLayerHashInputVector(h types.Hash32, data []byte) error {
-	m.Info("saved input vector for hash %v", h.ShortString())
-	return m.inputVector.Put(h.Bytes(), data)
+	bytes, err := types.InterfaceToBytes(blks)
+	if err != nil {
+		return err
+	}
+
+	return m.inputVector.Put(hash.Bytes(), bytes)
 }
 
 func (m *DB) writeBlock(bl *types.Block) error {
@@ -467,14 +459,14 @@ func (msh *Mesh) GetLayerHash(layerID types.LayerID) types.Hash32 {
 func (m *DB) persistLayerHash(layerID types.LayerID, hash types.Hash32) {
 	if err := m.general.Put(m.getLayerHashKey(layerID), hash.Bytes()); err != nil {
 		m.With().Error("failed to persist layer hash", log.Err(err), layerID,
-			log.String("layer_hash", hash.Hex()))
+			log.String("layer_hash", hash.ShortString()))
 	}
 
 	// we store a double index here because most of the code uses layer ID as key, currently only sync reads layer by hash
 	// when this changes we can simply point to the layes
 	if err := m.general.Put(hash.Bytes(), layerID.Bytes()); err != nil {
 		m.With().Error("failed to persist layer hash", log.Err(err), layerID,
-			log.String("layer_hash", hash.Hex()))
+			log.String("layer_hash", hash.ShortString()))
 	}
 }
 

--- a/tortoise/verifying_tortoise.go
+++ b/tortoise/verifying_tortoise.go
@@ -16,7 +16,6 @@ type blockDataProvider interface {
 	LayerBlockIds(types.LayerID) (ids []types.BlockID, err error)
 
 	GetLayerInputVectorByID(types.LayerID) ([]types.BlockID, error)
-	SaveLayerInputVectorByID(types.LayerID, []types.BlockID) error
 
 	SaveContextualValidity(id types.BlockID, valid bool) error
 

--- a/tortoise/verifying_tortoise_test.go
+++ b/tortoise/verifying_tortoise_test.go
@@ -246,7 +246,7 @@ func turtleMakeAndProcessLayer(t *testing.T, l types.LayerID, trtl *turtle, bloc
 	blocks, err := hm(l)
 	if err == nil {
 		// save blocks to db for this layer
-		require.NoError(t, msh.SaveLayerInputVectorByID(l, blocks))
+		require.NoError(t, msh.SaveLayerInputVectorByID(context.TODO(), l, blocks))
 	}
 
 	trtl.HandleIncomingLayer(lyr)
@@ -315,7 +315,7 @@ func createTurtleLayer(ctx context.Context, l types.LayerID, msh *mesh.DB, bbp b
 	if err != nil {
 		blocks = nil
 	}
-	if err := msh.SaveLayerInputVectorByID(l.Sub(1), blocks); err != nil {
+	if err := msh.SaveLayerInputVectorByID(context.TODO(), l.Sub(1), blocks); err != nil {
 		panic("can't save layuer input vector")
 	}
 


### PR DESCRIPTION
## Motivation
Closes #2630

## Changes
- add more log information
- restore MaxRetriesForRequest to 20
- only asks for input vector when peer didn't respond in the layer blocks query

## Test Plan
unit test

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
