### PR TITLE
[Merged by Bors] - add aggregated layer hash in layer hash response

### DIFF
--- a/layerfetcher/layers.go
+++ b/layerfetcher/layers.go
@@ -195,20 +195,20 @@ func (l *Logic) layerHashReqReceiver(ctx context.Context, msg []byte) []byte {
 	lyr := types.NewLayerID(util.BytesToUint32(msg))
 	lyrHash := &layerHash{
 		ProcessedLayer: l.layerDB.ProcessedLayer(),
-		SimpleHash:     l.layerDB.GetLayerHash(lyr),
-		AggHash:        l.layerDB.GetAggregatedLayerHash(lyr),
+		Hash:           l.layerDB.GetLayerHash(lyr),
+		AggregatedHash: l.layerDB.GetAggregatedLayerHash(lyr),
 	}
 	out, err := types.InterfaceToBytes(lyrHash)
 	if err != nil {
-		l.log.WithContext(ctx).With().Error("failed to serialize layer hash",
+		l.log.WithContext(ctx).With().Panic("failed to serialize layer hash",
 			lyr,
-			log.String("simpleHash", lyrHash.SimpleHash.ShortString()),
-			log.String("aggHash", lyrHash.AggHash.ShortString()))
+			log.String("hash", lyrHash.Hash.ShortString()),
+			log.String("aggregatedHash", lyrHash.AggregatedHash.ShortString()))
 	} else {
 		l.log.WithContext(ctx).With().Debug("responded layer hash request",
 			lyr,
-			log.String("simpleHash", lyrHash.SimpleHash.ShortString()),
-			log.String("aggHash", lyrHash.AggHash.ShortString()))
+			log.String("hash", lyrHash.Hash.ShortString()),
+			log.String("aggregatedHash", lyrHash.AggregatedHash.ShortString()))
 	}
 	return out
 }
@@ -364,7 +364,7 @@ func notifyLayerHashResult(layerID types.LayerID, channels []chan LayerHashResul
 			var lyrHash layerHash
 			convertErr := types.BytesToInterface(res.data, &lyrHash)
 			if convertErr != nil {
-				logger.Error("received error converting bytes to layerHash", convertErr)
+				logger.With().Debug("received error converting bytes to layerHash", log.Err(convertErr))
 				numErrors++
 			}
 			hashes[lyrHash] = append(hashes[lyrHash], peer)

--- a/layerfetcher/layers.go
+++ b/layerfetcher/layers.go
@@ -517,7 +517,7 @@ func notifyLayerBlocksResult(layerID types.LayerID, channels []chan LayerPromise
 			result.Err = firstErr
 		}
 	}
-	logger.With().Debug("notifying layer blocks result", log.String("blocks", fmt.Sprintf("%v", result)))
+	logger.With().Debug("notifying layer blocks result", layerID, log.String("blocks", fmt.Sprintf("%+v", result)))
 	for _, ch := range channels {
 		ch <- *result
 	}

--- a/layerfetcher/layers_test.go
+++ b/layerfetcher/layers_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/spacemeshos/go-spacemesh/mesh"
+
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/database"
 	"github.com/spacemeshos/go-spacemesh/fetch"
@@ -397,9 +399,9 @@ func TestPollLayerBlocks_OneZeroLayerAmongstErrors(t *testing.T) {
 	layerID := types.NewLayerID(10)
 	// currently first peer for each hash is queried
 	layerHashes := map[types.Hash32][]peers.Peer{
-		emptyHash:    {net.peers[2]},
-		randomHash(): {net.peers[1], net.peers[0]},
-		randomHash(): {net.peers[3]},
+		mesh.EmptyLayerHash: {net.peers[2]},
+		randomHash():        {net.peers[1], net.peers[0]},
+		randomHash():        {net.peers[3]},
 	}
 
 	res := <-l.PollLayerBlocks(context.TODO(), layerID, layerHashes)
@@ -421,7 +423,7 @@ func TestPollLayerBlocks_ZeroLayer(t *testing.T) {
 	layerID := types.NewLayerID(10)
 	// currently first peer for each hash is queried
 	layerHashes := map[types.Hash32][]peers.Peer{
-		emptyHash: {net.peers[2], net.peers[1], net.peers[0], net.peers[3]},
+		mesh.EmptyLayerHash: {net.peers[2], net.peers[1], net.peers[0], net.peers[3]},
 	}
 
 	res := <-l.PollLayerBlocks(context.TODO(), layerID, layerHashes)

--- a/layerfetcher/layers_test.go
+++ b/layerfetcher/layers_test.go
@@ -5,13 +5,12 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/spacemeshos/go-spacemesh/mesh"
-
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/database"
 	"github.com/spacemeshos/go-spacemesh/fetch"
 	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/log/logtest"
+	"github.com/spacemeshos/go-spacemesh/mesh"
 	"github.com/spacemeshos/go-spacemesh/p2p/p2pcrypto"
 	"github.com/spacemeshos/go-spacemesh/p2p/peers"
 	"github.com/spacemeshos/go-spacemesh/p2p/server"
@@ -81,32 +80,36 @@ func (m *mockNet) SendRequest(_ context.Context, msgType server.MessageType, _ [
 func (mockNet) Close() {}
 
 type layerDBMock struct {
-	layers  map[types.Hash32][]types.BlockID
-	vectors map[types.Hash32][]types.BlockID
-	gossip  []types.BlockID
-	hashes  map[types.LayerID]types.Hash32
+	layers    map[types.Hash32][]types.BlockID
+	vectors   map[types.Hash32][]types.BlockID
+	gossip    []types.BlockID
+	hashes    map[types.LayerID]types.Hash32
+	aggHashes map[types.LayerID]types.Hash32
+	processed types.LayerID
 }
 
 func newLayerDBMock() *layerDBMock {
 	return &layerDBMock{
-		layers:  make(map[types.Hash32][]types.BlockID),
-		vectors: make(map[types.Hash32][]types.BlockID),
-		gossip:  []types.BlockID{},
-		hashes:  make(map[types.LayerID]types.Hash32),
+		layers:    make(map[types.Hash32][]types.BlockID),
+		vectors:   make(map[types.Hash32][]types.BlockID),
+		gossip:    []types.BlockID{},
+		hashes:    make(map[types.LayerID]types.Hash32),
+		aggHashes: make(map[types.LayerID]types.Hash32),
+		processed: types.NewLayerID(10),
 	}
 }
-
 func (l *layerDBMock) GetLayerInputVector(hash types.Hash32) ([]types.BlockID, error) {
 	return l.vectors[hash], nil
 }
-
 func (l *layerDBMock) SaveLayerInputVectorByID(ctx context.Context, id types.LayerID, blocks []types.BlockID) error {
 	l.vectors[types.CalcHash32(id.Bytes())] = blocks
 	return nil
 }
+func (l *layerDBMock) ProcessedLayer() types.LayerID                        { return l.processed }
 func (l *layerDBMock) GetLayerHash(ID types.LayerID) types.Hash32           { return l.hashes[ID] }
+func (l *layerDBMock) GetAggregatedLayerHash(ID types.LayerID) types.Hash32 { return l.aggHashes[ID] }
 func (l *layerDBMock) GetLayerHashBlocks(hash types.Hash32) []types.BlockID { return l.layers[hash] }
-func (l layerDBMock) Get() []types.BlockID                                  { return l.gossip }
+func (l *layerDBMock) Get() []types.BlockID                                 { return l.gossip }
 
 type mockFetcher struct{}
 
@@ -158,10 +161,16 @@ func TestLayerHashReqReceiver(t *testing.T) {
 	db := newLayerDBMock()
 	layerID := types.NewLayerID(1)
 	l := NewMockLogic(newMockNet(), db, db, &mockBlocks{}, &mockAtx{}, &mockFetcher{}, logtest.New(t))
-	h := randomHash()
-	db.hashes[layerID] = h
+	simpleHash := randomHash()
+	aggHash := randomHash()
+	db.hashes[layerID] = simpleHash
+	db.aggHashes[layerID] = aggHash
 	out := l.layerHashReqReceiver(context.TODO(), layerID.Bytes())
-	assert.Equal(t, h, types.BytesToHash(out))
+	var lyrHash layerHash
+	assert.NoError(t, types.BytesToInterface(out, &lyrHash))
+	assert.Equal(t, db.processed, lyrHash.ProcessedLayer)
+	assert.Equal(t, simpleHash, lyrHash.SimpleHash)
+	assert.Equal(t, aggHash, lyrHash.AggHash)
 }
 
 func TestLayerHashBlocksReqReceiver(t *testing.T) {
@@ -236,14 +245,16 @@ func TestPollLayerHash_SomeError(t *testing.T) {
 	db := newLayerDBMock()
 	net := newMockNet()
 	numPeers := 4
-	hash := randomHash()
+	lyrHash := layerHash{ProcessedLayer: types.NewLayerID(20), SimpleHash: randomHash(), AggHash: randomHash()}
+	data, err := types.InterfaceToBytes(&lyrHash)
+	assert.NoError(t, err)
 	for i := 0; i < numPeers; i++ {
 		peer := p2pcrypto.NewRandomPubkey()
 		net.peers = append(net.peers, peer)
 		if i%2 == 0 {
 			net.errors[peer] = errors.New("SendRequest error")
 		} else {
-			net.layerHashes[peer] = hash.Bytes()
+			net.layerHashes[peer] = data
 		}
 	}
 	l := NewMockLogic(net, db, db, &mockBlocks{}, &mockAtx{}, &mockFetcher{}, logtest.New(t))
@@ -252,21 +263,23 @@ func TestPollLayerHash_SomeError(t *testing.T) {
 	res := <-l.PollLayerHash(context.TODO(), layerID)
 	assert.Nil(t, res.Err)
 	assert.Equal(t, 1, len(res.Hashes))
-	assert.ElementsMatch(t, []peers.Peer{net.peers[1], net.peers[3]}, res.Hashes[hash])
+	assert.ElementsMatch(t, []peers.Peer{net.peers[1], net.peers[3]}, res.Hashes[lyrHash])
 }
 
 func TestPollLayerHash_SomeTimeout(t *testing.T) {
 	db := newLayerDBMock()
 	net := newMockNet()
 	numPeers := 4
-	hash := randomHash()
+	lyrHash := layerHash{ProcessedLayer: types.NewLayerID(20), SimpleHash: randomHash(), AggHash: randomHash()}
+	data, err := types.InterfaceToBytes(&lyrHash)
+	assert.NoError(t, err)
 	for i := 0; i < numPeers; i++ {
 		peer := p2pcrypto.NewRandomPubkey()
 		net.peers = append(net.peers, peer)
 		if i%2 == 0 {
 			net.timeouts[peer] = struct{}{}
 		} else {
-			net.layerHashes[peer] = hash.Bytes()
+			net.layerHashes[peer] = data
 		}
 	}
 	l := NewMockLogic(net, db, db, &mockBlocks{}, &mockAtx{}, &mockFetcher{}, logtest.New(t))
@@ -275,22 +288,26 @@ func TestPollLayerHash_SomeTimeout(t *testing.T) {
 	res := <-l.PollLayerHash(context.TODO(), layerID)
 	assert.Nil(t, res.Err)
 	assert.Equal(t, 1, len(res.Hashes))
-	assert.ElementsMatch(t, []peers.Peer{net.peers[1], net.peers[3]}, res.Hashes[hash])
+	assert.ElementsMatch(t, []peers.Peer{net.peers[1], net.peers[3]}, res.Hashes[lyrHash])
 }
 
 func TestPollLayerHash_Aggregated(t *testing.T) {
 	db := newLayerDBMock()
 	net := newMockNet()
 	numPeers := 4
-	evenHash := randomHash()
-	oddHash := randomHash()
+	evenHash := layerHash{ProcessedLayer: types.NewLayerID(20), SimpleHash: randomHash(), AggHash: randomHash()}
+	evenData, err := types.InterfaceToBytes(&evenHash)
+	assert.NoError(t, err)
+	oddHash := layerHash{ProcessedLayer: types.NewLayerID(21), SimpleHash: randomHash(), AggHash: randomHash()}
+	oddData, err := types.InterfaceToBytes(&oddHash)
+	assert.NoError(t, err)
 	for i := 0; i < numPeers; i++ {
 		peer := p2pcrypto.NewRandomPubkey()
 		net.peers = append(net.peers, peer)
 		if i%2 == 0 {
-			net.layerHashes[peer] = evenHash.Bytes()
+			net.layerHashes[peer] = evenData
 		} else {
-			net.layerHashes[peer] = oddHash.Bytes()
+			net.layerHashes[peer] = oddData
 		}
 	}
 	l := NewMockLogic(net, db, db, &mockBlocks{}, &mockAtx{}, &mockFetcher{}, logtest.New(t))
@@ -310,7 +327,10 @@ func TestPollLayerHash_AllDifferent(t *testing.T) {
 	for i := 0; i < numPeers; i++ {
 		peer := p2pcrypto.NewRandomPubkey()
 		net.peers = append(net.peers, peer)
-		net.layerHashes[peer] = randomHash().Bytes()
+		lyrHash := layerHash{ProcessedLayer: types.NewLayerID(20 + uint32(i)), SimpleHash: randomHash(), AggHash: randomHash()}
+		data, err := types.InterfaceToBytes(&lyrHash)
+		assert.NoError(t, err)
+		net.layerHashes[peer] = data
 	}
 	l := NewMockLogic(net, db, db, &mockBlocks{}, &mockAtx{}, &mockFetcher{}, logtest.New(t))
 

--- a/layerfetcher/layers_test.go
+++ b/layerfetcher/layers_test.go
@@ -161,16 +161,16 @@ func TestLayerHashReqReceiver(t *testing.T) {
 	db := newLayerDBMock()
 	layerID := types.NewLayerID(1)
 	l := NewMockLogic(newMockNet(), db, db, &mockBlocks{}, &mockAtx{}, &mockFetcher{}, logtest.New(t))
-	simpleHash := randomHash()
+	hash := randomHash()
 	aggHash := randomHash()
-	db.hashes[layerID] = simpleHash
+	db.hashes[layerID] = hash
 	db.aggHashes[layerID] = aggHash
 	out := l.layerHashReqReceiver(context.TODO(), layerID.Bytes())
 	var lyrHash layerHash
 	assert.NoError(t, types.BytesToInterface(out, &lyrHash))
 	assert.Equal(t, db.processed, lyrHash.ProcessedLayer)
-	assert.Equal(t, simpleHash, lyrHash.SimpleHash)
-	assert.Equal(t, aggHash, lyrHash.AggHash)
+	assert.Equal(t, hash, lyrHash.Hash)
+	assert.Equal(t, aggHash, lyrHash.AggregatedHash)
 }
 
 func TestLayerHashBlocksReqReceiver(t *testing.T) {
@@ -245,7 +245,7 @@ func TestPollLayerHash_SomeError(t *testing.T) {
 	db := newLayerDBMock()
 	net := newMockNet()
 	numPeers := 4
-	lyrHash := layerHash{ProcessedLayer: types.NewLayerID(20), SimpleHash: randomHash(), AggHash: randomHash()}
+	lyrHash := layerHash{ProcessedLayer: types.NewLayerID(20), Hash: randomHash(), AggregatedHash: randomHash()}
 	data, err := types.InterfaceToBytes(&lyrHash)
 	assert.NoError(t, err)
 	for i := 0; i < numPeers; i++ {
@@ -270,7 +270,7 @@ func TestPollLayerHash_SomeTimeout(t *testing.T) {
 	db := newLayerDBMock()
 	net := newMockNet()
 	numPeers := 4
-	lyrHash := layerHash{ProcessedLayer: types.NewLayerID(20), SimpleHash: randomHash(), AggHash: randomHash()}
+	lyrHash := layerHash{ProcessedLayer: types.NewLayerID(20), Hash: randomHash(), AggregatedHash: randomHash()}
 	data, err := types.InterfaceToBytes(&lyrHash)
 	assert.NoError(t, err)
 	for i := 0; i < numPeers; i++ {
@@ -295,10 +295,10 @@ func TestPollLayerHash_Aggregated(t *testing.T) {
 	db := newLayerDBMock()
 	net := newMockNet()
 	numPeers := 4
-	evenHash := layerHash{ProcessedLayer: types.NewLayerID(20), SimpleHash: randomHash(), AggHash: randomHash()}
+	evenHash := layerHash{ProcessedLayer: types.NewLayerID(20), Hash: randomHash(), AggregatedHash: randomHash()}
 	evenData, err := types.InterfaceToBytes(&evenHash)
 	assert.NoError(t, err)
-	oddHash := layerHash{ProcessedLayer: types.NewLayerID(21), SimpleHash: randomHash(), AggHash: randomHash()}
+	oddHash := layerHash{ProcessedLayer: types.NewLayerID(21), Hash: randomHash(), AggregatedHash: randomHash()}
 	oddData, err := types.InterfaceToBytes(&oddHash)
 	assert.NoError(t, err)
 	for i := 0; i < numPeers; i++ {
@@ -327,7 +327,7 @@ func TestPollLayerHash_AllDifferent(t *testing.T) {
 	for i := 0; i < numPeers; i++ {
 		peer := p2pcrypto.NewRandomPubkey()
 		net.peers = append(net.peers, peer)
-		lyrHash := layerHash{ProcessedLayer: types.NewLayerID(20 + uint32(i)), SimpleHash: randomHash(), AggHash: randomHash()}
+		lyrHash := layerHash{ProcessedLayer: types.NewLayerID(20 + uint32(i)), Hash: randomHash(), AggregatedHash: randomHash()}
 		data, err := types.InterfaceToBytes(&lyrHash)
 		assert.NoError(t, err)
 		net.layerHashes[peer] = data

--- a/layerfetcher/wire_types.go
+++ b/layerfetcher/wire_types.go
@@ -2,7 +2,17 @@ package layerfetcher
 
 import "github.com/spacemeshos/go-spacemesh/common/types"
 
-// layerBlocks is the response for layer hash
+// layerHash is the response for a given layer
+type layerHash struct {
+	// ProcessedLayer is the latest processed layer from peer
+	ProcessedLayer types.LayerID
+	// SimpleHash is the hash of contextually valid blocks (sorted by block ID) in the given layer
+	SimpleHash types.Hash32
+	// AggHash is the aggregated hash of all layers up to the given layer
+	AggHash types.Hash32
+}
+
+// layerBlocks is the response for a given layer hash
 type layerBlocks struct {
 	Blocks          []types.BlockID
 	LatestBlocks    []types.BlockID // LatestBlocks are the blocks received in the last 30 seconds from gossip

--- a/layerfetcher/wire_types.go
+++ b/layerfetcher/wire_types.go
@@ -2,14 +2,13 @@ package layerfetcher
 
 import "github.com/spacemeshos/go-spacemesh/common/types"
 
-// layerHash is the response for a given layer
 type layerHash struct {
 	// ProcessedLayer is the latest processed layer from peer
 	ProcessedLayer types.LayerID
-	// SimpleHash is the hash of contextually valid blocks (sorted by block ID) in the given layer
-	SimpleHash types.Hash32
-	// AggHash is the aggregated hash of all layers up to the given layer
-	AggHash types.Hash32
+	// Hash is the hash of contextually valid blocks (sorted by block ID) in the given layer
+	Hash types.Hash32
+	// AggregatedHash is the aggregated hash of all layers up to the given layer
+	AggregatedHash types.Hash32
 }
 
 // layerBlocks is the response for a given layer hash

--- a/mesh/mesh.go
+++ b/mesh/mesh.go
@@ -568,6 +568,15 @@ func (msh *Mesh) persistAggregatedLayerHash(layerID types.LayerID, hash types.Ha
 	}
 }
 
+// GetAggregatedLayerHash returns the aggregated layer hash up to the specified layer
+func (msh *Mesh) GetAggregatedLayerHash(layerID types.LayerID) types.Hash32 {
+	h, err := msh.getAggregatedLayerHash(layerID)
+	if err != nil {
+		return EmptyLayerHash
+	}
+	return h
+}
+
 func (msh *Mesh) getAggregatedLayerHash(layerID types.LayerID) (types.Hash32, error) {
 	bts, err := msh.general.Get(msh.getAggregatedLayerHashKey(layerID))
 	if err != nil {

--- a/mesh/mesh.go
+++ b/mesh/mesh.go
@@ -236,6 +236,22 @@ func (msh *Mesh) GetLayer(i types.LayerID) (*types.Layer, error) {
 	return l, nil
 }
 
+// GetLayerHash returns layer hash for received blocks
+func (msh *Mesh) GetLayerHash(layerID types.LayerID) types.Hash32 {
+	h, err := msh.recoverLayerHash(layerID)
+	if err == nil {
+		return h
+	}
+	if err == database.ErrNotFound {
+		// layer hash not persisted. i.e. contextual validity not yet determined
+		lyr, err := msh.GetLayer(layerID)
+		if err == nil {
+			return lyr.Hash()
+		}
+	}
+	return EmptyLayerHash
+}
+
 // ProcessedLayer returns the last processed layer ID
 func (msh *Mesh) ProcessedLayer() types.LayerID {
 	return msh.getProcessedLayer().ID
@@ -260,6 +276,7 @@ func (msh *Mesh) setProcessedLayerFromRecoveredData(pLayer *ProcessedLayer) {
 }
 
 func (msh *Mesh) setProcessedLayer(layer *types.Layer) {
+	msh.persistLayerHash(layer.Index(), msh.calcSimpleLayerHash(layer))
 	msh.mutex.Lock()
 	defer msh.mutex.Unlock()
 	if !layer.Index().After(msh.processedLayer.ID) {
@@ -331,33 +348,6 @@ func (msh *Mesh) setProcessedLayer(layer *types.Layer) {
 			log.String("processed_layer_hash", lastProcessed.Hash.ShortString()),
 			log.Err(err))
 	}
-}
-
-func (msh *Mesh) persistProcessedLayer(lyr *ProcessedLayer) error {
-	data, err := types.InterfaceToBytes(lyr)
-	if err != nil {
-		return err
-	}
-	if err := msh.general.Put(constPROCESSED, data); err != nil {
-		return err
-	}
-	msh.With().Debug("persisted processed layer",
-		lyr.ID,
-		log.String("layer_hash", lyr.Hash.ShortString()))
-	return nil
-}
-
-func (msh *Mesh) recoverProcessedLayer() (*ProcessedLayer, error) {
-	processed, err := msh.general.Get(constPROCESSED)
-	if err != nil {
-		return nil, err
-	}
-	var data ProcessedLayer
-	err = types.BytesToInterface(processed, &data)
-	if err != nil {
-		return nil, err
-	}
-	return &data, nil
 }
 
 // HandleLateBlock process a late (contextually invalid) block.
@@ -564,6 +554,9 @@ func (msh *Mesh) calcAggregatedLayerHash(layer *types.Layer, prevHash types.Hash
 }
 
 func (msh *Mesh) calcSimpleLayerHash(layer *types.Layer) types.Hash32 {
+	if len(layer.Blocks()) == 0 {
+		return EmptyLayerHash
+	}
 	validBlocks, _ := msh.BlocksByValidity(layer.Blocks())
 	return types.CalcBlocksHash32(types.SortBlockIDs(types.BlockIDs(validBlocks)), nil)
 }
@@ -678,6 +671,8 @@ func (msh *Mesh) pushTransactions(l *types.Layer) {
 	)
 }
 
+var errLayerHasBlock = errors.New("layer has block")
+
 // SetZeroBlockLayer tags lyr as a layer without blocks
 func (msh *Mesh) SetZeroBlockLayer(lyr types.LayerID) error {
 	msh.With().Info("tagging zero block layer", lyr)
@@ -694,7 +689,7 @@ func (msh *Mesh) SetZeroBlockLayer(lyr types.LayerID) error {
 			lyr,
 			l,
 			log.Int("num_blocks", len(l.Blocks())))
-		return fmt.Errorf("layer has blocks")
+		return errLayerHasBlock
 	}
 
 	msh.setLatestLayer(lyr)

--- a/mesh/mesh.go
+++ b/mesh/mesh.go
@@ -365,7 +365,7 @@ type validator struct {
 }
 
 func (vl *validator) ValidateLayer(lyr *types.Layer) {
-	vl.With().Info("validate layer", lyr)
+	vl.With().Info("validate layer", lyr.Index())
 	if len(lyr.Blocks()) == 0 {
 		vl.With().Info("skip validation of layer with no blocks", lyr)
 		vl.setProcessedLayer(lyr)
@@ -386,7 +386,7 @@ func (vl *validator) ValidateLayer(lyr *types.Layer) {
 		Layer:  lyr,
 		Status: events.LayerStatusTypeConfirmed,
 	})
-	vl.With().Info("done validating layer", lyr)
+	vl.With().Info("done validating layer", lyr.Index())
 }
 
 func (msh *Mesh) pushLayersToState(oldPbase types.LayerID, newPbase types.LayerID) {

--- a/mesh/meshdb.go
+++ b/mesh/meshdb.go
@@ -381,7 +381,7 @@ func (m *DB) GetLayerInputVectorByID(id types.LayerID) ([]types.BlockID, error) 
 // SaveLayerInputVectorByID gets the input vote vector for a layer (hare results)
 func (m *DB) SaveLayerInputVectorByID(ctx context.Context, id types.LayerID, blks []types.BlockID) error {
 	hash := types.CalcHash32(id.Bytes())
-	m.With().Info("saving input vector",
+	m.WithContext(ctx).With().Info("saving input vector",
 		id,
 		log.String("iv_hash", hash.ShortString()))
 

--- a/mesh/meshdb.go
+++ b/mesh/meshdb.go
@@ -293,6 +293,9 @@ func (m *DB) LayerBlockIds(index types.LayerID) ([]types.BlockID, error) {
 	return blockIds, nil
 }
 
+// EmptyLayerHash is the layer hash for an empty layer
+var EmptyLayerHash = types.Hash32{}
+
 // AddZeroBlockLayer tags lyr as a layer without blocks
 func (m *DB) AddZeroBlockLayer(index types.LayerID) error {
 	blockIds := make([]types.BlockID, 0, 1)
@@ -300,7 +303,11 @@ func (m *DB) AddZeroBlockLayer(index types.LayerID) error {
 	if err != nil {
 		return errors.New("could not encode layer blk ids")
 	}
-	return m.layers.Put(index.Bytes(), w)
+	err = m.layers.Put(index.Bytes(), w)
+	if err == nil {
+		m.persistLayerHash(index, EmptyLayerHash)
+	}
+	return err
 }
 
 func (m *DB) getBlockBytes(id types.BlockID) ([]byte, error) {
@@ -386,6 +393,33 @@ func (m *DB) SaveLayerInputVectorByID(ctx context.Context, id types.LayerID, blk
 	return m.inputVector.Put(hash.Bytes(), bytes)
 }
 
+func (m *DB) persistProcessedLayer(lyr *ProcessedLayer) error {
+	data, err := types.InterfaceToBytes(lyr)
+	if err != nil {
+		return err
+	}
+	if err := m.general.Put(constPROCESSED, data); err != nil {
+		return err
+	}
+	m.With().Debug("persisted processed layer",
+		lyr.ID,
+		log.String("layer_hash", lyr.Hash.ShortString()))
+	return nil
+}
+
+func (m *DB) recoverProcessedLayer() (*ProcessedLayer, error) {
+	processed, err := m.general.Get(constPROCESSED)
+	if err != nil {
+		return nil, err
+	}
+	var data ProcessedLayer
+	err = types.BytesToInterface(processed, &data)
+	if err != nil {
+		return nil, err
+	}
+	return &data, nil
+}
+
 func (m *DB) writeBlock(bl *types.Block) error {
 	block := &types.DBBlock{
 		MiniBlock: bl.MiniBlock,
@@ -433,9 +467,6 @@ func (m *DB) updateLayerWithBlock(blk *types.Block) error {
 	}
 
 	m.layers.Put(blk.LayerIndex.Bytes(), w)
-	hash := types.CalcBlocksHash32(blockIds, nil)
-	m.persistLayerHash(blk.LayerIndex, hash)
-
 	return nil
 }
 
@@ -443,15 +474,14 @@ func (m *DB) getLayerHashKey(layerID types.LayerID) []byte {
 	return []byte(fmt.Sprintf("layerHash_%v", layerID.Bytes()))
 }
 
-// GetLayerHash returns layer hash for received blocks
-func (msh *Mesh) GetLayerHash(layerID types.LayerID) types.Hash32 {
-	h := types.Hash32{}
-	bts, err := msh.general.Get(msh.getLayerHashKey(layerID))
+func (m *DB) recoverLayerHash(layerID types.LayerID) (types.Hash32, error) {
+	h := EmptyLayerHash
+	bts, err := m.general.Get(m.getLayerHashKey(layerID))
 	if err != nil {
-		return types.Hash32{}
+		return EmptyLayerHash, err
 	}
 	h.SetBytes(bts)
-	return h
+	return h, nil
 }
 
 func (m *DB) persistLayerHash(layerID types.LayerID, hash types.Hash32) {

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -369,11 +369,11 @@ func (s *Syncer) getLayerFromPeers(ctx context.Context, layerID types.LayerID) (
 		return nil, fmt.Errorf("PollLayerHash: %w", hashRes.Err)
 	}
 	// TODO: resolve hash with peers
-	simpleHashes := make(map[types.Hash32][]peers.Peer)
+	hashes := make(map[types.Hash32][]peers.Peer)
 	for lyrHash, peers := range hashRes.Hashes {
-		simpleHashes[lyrHash.SimpleHash] = peers
+		hashes[lyrHash.Hash] = peers
 	}
-	bch := s.fetcher.PollLayerBlocks(ctx, layerID, simpleHashes)
+	bch := s.fetcher.PollLayerBlocks(ctx, layerID, hashes)
 	res := <-bch
 	if res.Err != nil {
 		if res.Err == layerfetcher.ErrZeroLayer {

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -369,7 +369,11 @@ func (s *Syncer) getLayerFromPeers(ctx context.Context, layerID types.LayerID) (
 		return nil, fmt.Errorf("PollLayerHash: %w", hashRes.Err)
 	}
 	// TODO: resolve hash with peers
-	bch := s.fetcher.PollLayerBlocks(ctx, layerID, hashRes.Hashes)
+	simpleHashes := make(map[types.Hash32][]peers.Peer)
+	for lyrHash, peers := range hashRes.Hashes {
+		simpleHashes[lyrHash.SimpleHash] = peers
+	}
+	bch := s.fetcher.PollLayerBlocks(ctx, layerID, simpleHashes)
 	res := <-bch
 	if res.Err != nil {
 		if res.Err == layerfetcher.ErrZeroLayer {

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -284,7 +284,7 @@ func (s *Syncer) synchronize(ctx context.Context) bool {
 		var layer *types.Layer
 		var err error
 		if layer, err = s.syncLayer(ctx, layerID); err != nil {
-			logger.With().Error("failed to sync to layer", log.Err(err))
+			logger.With().Error("failed to sync to layer", layerID, log.Err(err))
 			return false
 		}
 


### PR DESCRIPTION
## Motivation
Closes #2524

## Changes
- only persist layer hash after validity is determined
- add aggregated layer hash and processed layer in layer hash response

## Test Plan
unit tests

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
