### PR TITLE
[Merged by Bors] - Use local logger with hooks to listen for errors in TestSpacemeshApp_NodeService

### DIFF
--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -119,7 +119,9 @@ var Cmd = &cobra.Command{
 			WithConfig(conf),
 			// NOTE(dshulyak) this needs to be max level so that child logger can can be current level or below.
 			// otherwise it will fail later when child logger will try to increase level.
-			WithLog(log.NewWithLevel("", zap.NewAtomicLevelAt(zapcore.DebugLevel))),
+			WithLog(log.RegisterHooks(
+				log.NewWithLevel("", zap.NewAtomicLevelAt(zapcore.DebugLevel)),
+				events.EventHook())),
 		)
 		starter := func() error {
 			if err := app.Initialize(); err != nil {
@@ -244,7 +246,6 @@ func New(opts ...Option) *App {
 	for _, opt := range opts {
 		opt(app)
 	}
-	app.log = log.RegisterHooks(app.log, events.EventHook())
 	lvl := zap.NewAtomicLevelAt(zap.InfoLevel)
 	log.SetupGlobal(app.log.SetLevel(&lvl))
 	return app

--- a/cmd/node/node_test.go
+++ b/cmd/node/node_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"io/ioutil"
 	inet "net"
 	"net/http"
@@ -17,6 +16,7 @@ import (
 	"time"
 
 	"github.com/spacemeshos/go-spacemesh/activation"
+	"github.com/spacemeshos/go-spacemesh/cmd"
 	"github.com/spacemeshos/go-spacemesh/eligibility"
 	"github.com/spacemeshos/go-spacemesh/log/logtest"
 	"github.com/spacemeshos/go-spacemesh/p2p/service"
@@ -547,7 +547,9 @@ func TestSpacemeshApp_JsonService(t *testing.T) {
 
 // E2E app test of the stream endpoints in the NodeService
 func TestSpacemeshApp_NodeService(t *testing.T) {
-	logger := logtest.New(t, zap.ErrorLevel)
+	// errlog should be used only for testing.
+	logger := logtest.New(t)
+	errlog := log.RegisterHooks(logtest.New(t, zap.ErrorLevel), events.EventHook())
 	setup()
 
 	// Use a unique port
@@ -593,77 +595,29 @@ func TestSpacemeshApp_NodeService(t *testing.T) {
 		// This makes sure the test doesn't end until this goroutine closes
 		defer wg.Done()
 		str, err := testArgs("--grpc-port", strconv.Itoa(port), "--grpc", "node", "--acquire-port=false", "--tcp-interface", "127.0.0.1", "--grpc-interface", "localhost")
-		require.Empty(t, str)
-		require.NoError(t, err)
+		assert.Empty(t, str)
+		assert.NoError(t, err)
 	}()
-
-	// Wait for the app and services to start
-	// Strictly speaking, this does not indicate that all of the services
-	// have started, we could add separate channels for that.
-	<-app.started
-
-	// Unfortunately sometimes we need to wait even longer
-	time.Sleep(3 * time.Second)
 
 	// Set up a new connection to the server
-	addr := fmt.Sprintf("localhost:%d", port)
-	conn, err := grpc.Dial(addr, grpc.WithInsecure())
-	defer func() {
-		require.NoError(t, conn.Close())
-	}()
+	var (
+		conn *grpc.ClientConn
+	)
+	for start := time.Now(); time.Since(start) <= 10*time.Second; {
+		conn, err = grpc.Dial(fmt.Sprintf("localhost:%d", port), grpc.WithInsecure(), grpc.WithBlock())
+		if err == nil {
+			break
+		}
+	}
+	require.NotNil(t, conn)
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
 	c := pb.NewNodeServiceClient(conn)
-
-	// Use a channel to coordinate ending the test
-	end := make(chan struct{})
-
-	go func() {
-		// Don't close the channel twice
-		defer close(end)
-
-		// Open an error stream and a status stream
-		streamErr, err := c.ErrorStream(context.Background(), &pb.ErrorStreamRequest{})
-		require.NoError(t, err)
-
-		nextError := func() *pb.NodeError {
-			in, err := streamErr.Recv()
-			require.NoError(t, err)
-			return in.Error
-		}
-
-		// We expect a specific series of errors in a specific order!
-		// Check each one
-		expected := []string{
-			"test123",
-			"test456",
-			"Fatal: goroutine panicked.",
-			"testPANIC",
-		}
-		// TODO(dshulyak) multiple modules were using incorrent loggers and notifications weren't made.
-		// this test is very problematic and must be completely rewritten.
-		// - ideally without using global state (logger and event publisher)
-		// - or atleast initialize only what is needed and not everything
-		ignored := map[string]struct{}{
-			"error adding genesis block, block already exists in database":            {},
-			"method IsIdentityActiveOnConsensusView erred while calling actives func": {},
-			"error checking if identity is active":                                    {},
-			"could not notify subscribers":                                            {},
-			"Failed to send proposal message":                                         {},
-		}
-
-		for i := 0; i < len(expected); {
-			current := nextError()
-			if _, ignore := ignored[current.Msg]; ignore {
-				continue
-			}
-			require.Contains(t, current.Msg, expected[i])
-			i++
-		}
-	}()
 
 	wg.Add(1)
 	go func() {
-		// This makes sure the test doesn't end until this goroutine closes
 		defer wg.Done()
 
 		streamStatus, err := c.StatusStream(context.Background(), &pb.StatusStreamRequest{})
@@ -674,53 +628,49 @@ func TestSpacemeshApp_NodeService(t *testing.T) {
 		// app is running, and make sure there are no errors.
 		for {
 			in, err := streamStatus.Recv()
-			if err == io.EOF {
+			if err != nil {
+				code := status.Code(err)
+				if code == codes.Unavailable {
+					return
+				}
+				assert.NoError(t, err)
 				return
 			}
-			errCode := status.Code(err)
-			// We expect this to happen when the server disconnects
-			if errCode == codes.Unavailable {
-				return
-			}
-			require.NoError(t, err)
-
 			// Note that, for some reason, protobuf does not display fields
 			// that still have their default value, so the output here will
 			// only be partial.
-			log.Info("Got status message: %s", in.Status)
-
-			// Check if the test should end
-			select {
-			case <-end:
-				return
-			default:
-				continue
-			}
+			logger.Debug("Got status message: %s", in.Status)
 		}
 	}()
-	time.Sleep(4 * time.Second)
+
+	streamErr, err := c.ErrorStream(context.Background(), &pb.ErrorStreamRequest{})
+	require.NoError(t, err)
 
 	// Report two errors and make sure they're both received
-	log.Error("test123")
-	log.Error("test456")
-	time.Sleep(4 * time.Second)
-
-	// Trap a panic
-	func() {
-		defer func() {
-			if r := recover(); r != nil {
-				log.Info("Recovered", r)
-			}
-		}()
-		log.Panic("testPANIC")
+	go func() {
+		errlog.Error("test123")
+		errlog.Error("test456")
+		assert.Panics(t, func() {
+			errlog.Panic("testPANIC")
+		})
 	}()
 
-	// Wait for messages to be received
-	<-end
+	// We expect a specific series of errors in a specific order!
+	expected := []string{
+		"test123",
+		"test456",
+		"Fatal: goroutine panicked.",
+		"testPANIC",
+	}
+	for _, errmsg := range expected {
+		in, err := streamErr.Recv()
+		require.NoError(t, err)
+		current := in.Error
+		require.Contains(t, current.Msg, errmsg)
+	}
 
 	// This stops the app
-	cmdp.Cancel()
-
+	cmd.Cancel() // stop the app
 	// Wait for everything to stop cleanly before ending test
 	wg.Wait()
 }

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -292,7 +292,7 @@ def wait_genesis(genesis_time, genesis_delta):
 def wait_for_minimal_elk_cluster_ready(namespace, es_ss_name=ES_SS_NAME,
                                                   logstash_ss_name=LOGSTASH_SS_NAME,
                                                   kibana_dep_name=KIBANA_DEP_NAME):
-    es_timeout = 300
+    es_timeout = 600
     try:
         print("waiting for ES to be ready")
         es_sleep_time = statefulset.wait_to_statefulset_to_be_ready(es_ss_name, namespace, time_out=es_timeout)


### PR DESCRIPTION
## Motivation

closes: https://github.com/spacemeshos/go-spacemesh/issues/2638

## Changes

- events hook is now initialized for the app only if the app is started from the command line.
- it allows us to initialize hook for a specific logger and test errors emitted only from that logger

This modification makes it possible to erroneously remove the hook initialization from command line starter and the test will pass. But I think this such dependency is acceptable for unit test.

## Test Plan
unit tests

## TODO
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [ ] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
