### PR TITLE
Fix race condition in peers listener

### DIFF
--- a/cmd/node/app_test.go
+++ b/cmd/node/app_test.go
@@ -635,9 +635,9 @@ func TestShutdown(t *testing.T) {
 	gCount2 := runtime.NumGoroutine()
 
 	if gCount != gCount2 {
-		buf := make([]byte, 4096)
-		runtime.Stack(buf, true)
-		logtest.New(t).Error(string(buf))
+		buf := make([]byte, 1<<16)
+		numbytes := runtime.Stack(buf, true)
+		t.Log(string(buf[:numbytes]))
 	}
 	require.Equal(t, gCount, gCount2)
 }


### PR DESCRIPTION
## Motivation
Closes #2654

## Changes
- Fixes race condition
- Properly prints stack in TestShutdown

## Test Plan
N/A, fixes tests

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
