### PR TITLE
[Merged by Bors] - Bring back different node weights in app test

### DIFF
--- a/cmd/node/multi_node.go
+++ b/cmd/node/multi_node.go
@@ -224,6 +224,8 @@ func InitSingleInstance(lg log.Log, cfg config.Config, i int, genesisTime string
 
 	smApp.Config.SMESHING.CoinbaseAccount = strconv.Itoa(i + 1)
 	smApp.Config.SMESHING.Opts.DataDir, _ = ioutil.TempDir("", "sm-app-test-post-datadir")
+	smApp.Config.POST.MaxNumUnits = smApp.Config.SMESHING.Opts.NumUnits << 5
+	smApp.Config.SMESHING.Opts.NumUnits = smApp.Config.SMESHING.Opts.NumUnits << (i % 5)
 
 	smApp.edSgn = edSgn
 


### PR DESCRIPTION
## Motivation
Nodes in app test used to have exponentially different weights. This was removed in #2149, and all nodes currently have the same weight. The test is more realistic if nodes have very different weights.

## Changes
- add back differing weights

## Test Plan
N/A, existing app tests should pass

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [ ] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
