### PR TITLE
[Merged by Bors] - Fix devnet203 tortoise beacon issues

### DIFF
--- a/activation/activationdb_test.go
+++ b/activation/activationdb_test.go
@@ -63,6 +63,7 @@ func (m *MeshValidatorMock) LatestComplete() types.LayerID {
 func (m *MeshValidatorMock) HandleIncomingLayer(layer *types.Layer) (types.LayerID, types.LayerID) {
 	return layer.Index().Sub(1), layer.Index()
 }
+
 func (m *MeshValidatorMock) HandleLateBlock(bl *types.Block) (types.LayerID, types.LayerID) {
 	return bl.Layer().Sub(1), bl.Layer()
 }
@@ -111,6 +112,7 @@ func (MockState) GetLayerStateRoot(layer types.LayerID) (types.Hash32, error) {
 func (MockState) GetBalance(addr types.Address) uint64 {
 	panic("implement me")
 }
+
 func (MockState) GetNonce(addr types.Address) uint64 {
 	panic("implement me")
 }
@@ -257,9 +259,9 @@ func TestATX_ActiveSetForLayerView(t *testing.T) {
 	assert.NoError(t, err)
 	// TODO: check this test failure
 	_ = actives
-	//assert.Len(t, actives, 2)
-	//assert.Equal(t, uint64(10000), actives[id1.Key], "actives[id1.Key] (%d) != %d", actives[id1.Key], 10000)
-	//assert.Equal(t, uint64(20000), actives[id2.Key], "actives[id2.Key] (%d) != %d", actives[id2.Key], 20000)
+	// assert.Len(t, actives, 2)
+	// assert.Equal(t, uint64(10000), actives[id1.Key], "actives[id1.Key] (%d) != %d", actives[id1.Key], 10000)
+	// assert.Equal(t, uint64(20000), actives[id2.Key], "actives[id2.Key] (%d) != %d", actives[id2.Key], 20000)
 }
 
 func TestMesh_ActiveSetForLayerView2(t *testing.T) {
@@ -736,7 +738,6 @@ func TestActivationDB_ValidateAndInsertSorted(t *testing.T) {
 
 	err = atxdb.StoreAtx(1, atx)
 	assert.NoError(t, err)
-
 }
 
 func TestActivationDb_ProcessAtx(t *testing.T) {
@@ -846,7 +847,7 @@ func BenchmarkNewActivationDb(b *testing.B) {
 			prevAtxs[miner] = atx.ID()
 			storeAtx(r, atxdb, atx, lg.WithName("storeAtx"))
 		}
-		//noinspection GoNilness
+		// noinspection GoNilness
 		posAtx = atx.ID()
 		layer = layer.Add(layersPerEpoch)
 		if epoch%batchSize == batchSize-1 {
@@ -945,7 +946,6 @@ func TestActivationDb_ValidateSignedAtx(t *testing.T) {
 	signedAtx.Sig = []byte("anton")
 	_, err = ExtractPublicKey(signedAtx)
 	r.Error(err)
-
 }
 
 func createAndStoreAtx(atxdb *DB, layer types.LayerID) (*types.ActivationTx, error) {

--- a/activation/activationdb_test.go
+++ b/activation/activationdb_test.go
@@ -63,7 +63,6 @@ func (m *MeshValidatorMock) LatestComplete() types.LayerID {
 func (m *MeshValidatorMock) HandleIncomingLayer(layer *types.Layer) (types.LayerID, types.LayerID) {
 	return layer.Index().Sub(1), layer.Index()
 }
-
 func (m *MeshValidatorMock) HandleLateBlock(bl *types.Block) (types.LayerID, types.LayerID) {
 	return bl.Layer().Sub(1), bl.Layer()
 }
@@ -112,7 +111,6 @@ func (MockState) GetLayerStateRoot(layer types.LayerID) (types.Hash32, error) {
 func (MockState) GetBalance(addr types.Address) uint64 {
 	panic("implement me")
 }
-
 func (MockState) GetNonce(addr types.Address) uint64 {
 	panic("implement me")
 }
@@ -259,9 +257,9 @@ func TestATX_ActiveSetForLayerView(t *testing.T) {
 	assert.NoError(t, err)
 	// TODO: check this test failure
 	_ = actives
-	// assert.Len(t, actives, 2)
-	// assert.Equal(t, uint64(10000), actives[id1.Key], "actives[id1.Key] (%d) != %d", actives[id1.Key], 10000)
-	// assert.Equal(t, uint64(20000), actives[id2.Key], "actives[id2.Key] (%d) != %d", actives[id2.Key], 20000)
+	//assert.Len(t, actives, 2)
+	//assert.Equal(t, uint64(10000), actives[id1.Key], "actives[id1.Key] (%d) != %d", actives[id1.Key], 10000)
+	//assert.Equal(t, uint64(20000), actives[id2.Key], "actives[id2.Key] (%d) != %d", actives[id2.Key], 20000)
 }
 
 func TestMesh_ActiveSetForLayerView2(t *testing.T) {
@@ -301,7 +299,6 @@ func Test_DBSanity(t *testing.T) {
 	id1 := types.NodeID{Key: uuid.New().String()}
 	id2 := types.NodeID{Key: uuid.New().String()}
 	id3 := types.NodeID{Key: uuid.New().String()}
-
 	coinbase1 := types.HexToAddress("aaaa")
 	coinbase2 := types.HexToAddress("bbbb")
 	coinbase3 := types.HexToAddress("cccc")
@@ -317,27 +314,27 @@ func Test_DBSanity(t *testing.T) {
 	err = atxdb.storeAtxUnlocked(atx3)
 	assert.NoError(t, err)
 
-	err = atxdb.addAtxToNodeID(id1.Key, atx1)
+	err = atxdb.addAtxToNodeID(id1, atx1)
 	assert.NoError(t, err)
 	id, err := atxdb.GetNodeLastAtxID(id1)
 	assert.NoError(t, err)
 	assert.Equal(t, atx1.ID(), id)
 	assert.Equal(t, types.EpochID(1), atx1.TargetEpoch())
-	id, err = atxdb.GetNodeAtxIDForEpoch(id1.Key, atx1.PubLayerID.GetEpoch())
+	id, err = atxdb.GetNodeAtxIDForEpoch(id1, atx1.PubLayerID.GetEpoch())
 	assert.NoError(t, err)
 	assert.Equal(t, atx1.ID(), id)
 
-	err = atxdb.addAtxToNodeID(id2.Key, atx2)
+	err = atxdb.addAtxToNodeID(id2, atx2)
 	assert.NoError(t, err)
 
-	err = atxdb.addAtxToNodeID(id1.Key, atx3)
+	err = atxdb.addAtxToNodeID(id1, atx3)
 	assert.NoError(t, err)
 
 	id, err = atxdb.GetNodeLastAtxID(id2)
 	assert.NoError(t, err)
 	assert.Equal(t, atx2.ID(), id)
 	assert.Equal(t, types.EpochID(2), atx2.TargetEpoch())
-	id, err = atxdb.GetNodeAtxIDForEpoch(id2.Key, atx2.PubLayerID.GetEpoch())
+	id, err = atxdb.GetNodeAtxIDForEpoch(id2, atx2.PubLayerID.GetEpoch())
 	assert.NoError(t, err)
 	assert.Equal(t, atx2.ID(), id)
 
@@ -345,7 +342,7 @@ func Test_DBSanity(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, atx3.ID(), id)
 	assert.Equal(t, types.EpochID(3), atx3.TargetEpoch())
-	id, err = atxdb.GetNodeAtxIDForEpoch(id1.Key, atx3.PubLayerID.GetEpoch())
+	id, err = atxdb.GetNodeAtxIDForEpoch(id1, atx3.PubLayerID.GetEpoch())
 	assert.NoError(t, err)
 	assert.Equal(t, atx3.ID(), id)
 
@@ -570,7 +567,7 @@ func TestActivationDB_ValidateAtxErrors(t *testing.T) {
 	err = atxdb.StoreAtx(1, atx)
 	assert.NoError(t, err)
 	atx = newActivationTx(idx1, 1, prevAtx.ID(), posAtx.ID(), types.NewLayerID(12), 0, 100, coinbase, 100, &types.NIPost{})
-	iter := atxdb.atxs.Find(getNodeAtxPrefix(atx.NodeID.Key))
+	iter := atxdb.atxs.Find(getNodeAtxPrefix(atx.NodeID))
 	for iter.Next() {
 		err = atxdb.atxs.Delete(iter.Key())
 		assert.NoError(t, err)
@@ -739,6 +736,7 @@ func TestActivationDB_ValidateAndInsertSorted(t *testing.T) {
 
 	err = atxdb.StoreAtx(1, atx)
 	assert.NoError(t, err)
+
 }
 
 func TestActivationDb_ProcessAtx(t *testing.T) {
@@ -848,7 +846,7 @@ func BenchmarkNewActivationDb(b *testing.B) {
 			prevAtxs[miner] = atx.ID()
 			storeAtx(r, atxdb, atx, lg.WithName("storeAtx"))
 		}
-		// noinspection GoNilness
+		//noinspection GoNilness
 		posAtx = atx.ID()
 		layer = layer.Add(layersPerEpoch)
 		if epoch%batchSize == batchSize-1 {
@@ -947,6 +945,7 @@ func TestActivationDb_ValidateSignedAtx(t *testing.T) {
 	signedAtx.Sig = []byte("anton")
 	_, err = ExtractPublicKey(signedAtx)
 	r.Error(err)
+
 }
 
 func createAndStoreAtx(atxdb *DB, layer types.LayerID) (*types.ActivationTx, error) {

--- a/activation/atxdb.go
+++ b/activation/atxdb.go
@@ -22,12 +22,12 @@ import (
 
 const topAtxKey = "topAtxKey"
 
-func getNodeAtxKey(nodePK string, targetEpoch types.EpochID) []byte {
-	return append(getNodeAtxPrefix(nodePK), util.Uint64ToBytesBigEndian(uint64(targetEpoch))...)
+func getNodeAtxKey(nodeID types.NodeID, targetEpoch types.EpochID) []byte {
+	return append(getNodeAtxPrefix(nodeID), util.Uint64ToBytesBigEndian(uint64(targetEpoch))...)
 }
 
-func getNodeAtxPrefix(nodePK string) []byte {
-	return []byte(fmt.Sprintf("n_%v_", nodePK))
+func getNodeAtxPrefix(nodeID types.NodeID) []byte {
+	return []byte(fmt.Sprintf("n_%v_", nodeID.Key))
 }
 
 func getNodeAtxEpochKey(epoch types.EpochID, nodeID types.NodeID) []byte {
@@ -425,7 +425,7 @@ func (db *DB) StoreAtx(ech types.EpochID, atx *types.ActivationTx) error {
 		return err
 	}
 
-	err = db.addAtxToNodeID(atx.NodeID.Key, atx)
+	err = db.addAtxToNodeID(atx.NodeID, atx)
 	if err != nil {
 		return err
 	}
@@ -534,8 +534,8 @@ func (db *DB) getAtxTimestamp(id types.ATXID) (time.Time, error) {
 }
 
 // addAtxToNodeID inserts activation atx id by node
-func (db *DB) addAtxToNodeID(nodePK string, atx *types.ActivationTx) error {
-	err := db.atxs.Put(getNodeAtxKey(nodePK, atx.PubLayerID.GetEpoch()), atx.ID().Bytes())
+func (db *DB) addAtxToNodeID(nodeID types.NodeID, atx *types.ActivationTx) error {
+	err := db.atxs.Put(getNodeAtxKey(nodeID, atx.PubLayerID.GetEpoch()), atx.ID().Bytes())
 	if err != nil {
 		return fmt.Errorf("failed to store atx ID for node: %v", err)
 	}
@@ -569,7 +569,7 @@ type ErrAtxNotFound error
 
 // GetNodeLastAtxID returns the last atx id that was received for node nodeID
 func (db *DB) GetNodeLastAtxID(nodeID types.NodeID) (types.ATXID, error) {
-	nodeAtxsIterator := db.atxs.Find(getNodeAtxPrefix(nodeID.Key))
+	nodeAtxsIterator := db.atxs.Find(getNodeAtxPrefix(nodeID))
 	// ATX syntactic validation ensures that each ATX is at least one epoch after a referenced previous ATX.
 	// Contextual validation ensures that the previous ATX referenced matches what this method returns, so the next ATX
 	// added will always be the next ATX returned by this method.
@@ -606,11 +606,11 @@ func (db *DB) GetEpochAtxs(epochID types.EpochID) (atxs []types.ATXID) {
 
 // GetNodeAtxIDForEpoch returns an atx published by the provided nodeID for the specified publication epoch. meaning the atx
 // that the requested nodeID has published. it returns an error if no atx was found for provided nodeID
-func (db *DB) GetNodeAtxIDForEpoch(nodePK string, publicationEpoch types.EpochID) (types.ATXID, error) {
-	id, err := db.atxs.Get(getNodeAtxKey(nodePK, publicationEpoch))
+func (db *DB) GetNodeAtxIDForEpoch(nodeID types.NodeID, publicationEpoch types.EpochID) (types.ATXID, error) {
+	id, err := db.atxs.Get(getNodeAtxKey(nodeID, publicationEpoch))
 	if err != nil {
-		return *types.EmptyATXID, fmt.Errorf("atx for node %v with publication epoch %v: %w",
-			util.Bytes2Hex([]byte(nodePK)), publicationEpoch, err)
+		return *types.EmptyATXID, fmt.Errorf("atx for node %v with publication epoch %v: %v",
+			nodeID.ShortString(), publicationEpoch, err)
 	}
 	return types.ATXID(types.BytesToHash(id)), nil
 }

--- a/blocks/blockeligibilityvalidator_test.go
+++ b/blocks/blockeligibilityvalidator_test.go
@@ -25,7 +25,7 @@ func (m mockAtxDB) GetIdentity(edID string) (types.NodeID, error) {
 	return types.NodeID{Key: edID, VRFPublicKey: nodeID.VRFPublicKey}, nil
 }
 
-func (m mockAtxDB) GetNodeAtxIDForEpoch(string, types.EpochID) (types.ATXID, error) {
+func (m mockAtxDB) GetNodeAtxIDForEpoch(types.NodeID, types.EpochID) (types.ATXID, error) {
 	return types.ATXID{}, m.err
 }
 

--- a/blocks/blockoracle.go
+++ b/blocks/blockoracle.go
@@ -13,7 +13,7 @@ import (
 )
 
 type activationDB interface {
-	GetNodeAtxIDForEpoch(nodePK string, targetEpoch types.EpochID) (types.ATXID, error)
+	GetNodeAtxIDForEpoch(nodeID types.NodeID, targetEpoch types.EpochID) (types.ATXID, error)
 	GetAtxHeader(types.ATXID) (*types.ActivationTxHeader, error)
 	GetEpochWeight(types.EpochID) (uint64, []types.ATXID, error)
 }
@@ -222,7 +222,7 @@ func getNumberOfEligibleBlocks(weight, totalWeight uint64, committeeSize uint32,
 }
 
 func (bo *Oracle) getATXIDForEpoch(targetEpoch types.EpochID) (types.ATXID, error) {
-	latestATXID, err := bo.atxDB.GetNodeAtxIDForEpoch(bo.nodeID.Key, targetEpoch)
+	latestATXID, err := bo.atxDB.GetNodeAtxIDForEpoch(bo.nodeID, targetEpoch)
 	if err != nil {
 		bo.log.With().Warning("did not find atx ids for node",
 			log.FieldNamed("atx_node_id", bo.nodeID),

--- a/blocks/blockoracle_test.go
+++ b/blocks/blockoracle_test.go
@@ -13,11 +13,13 @@ import (
 	"github.com/spacemeshos/go-spacemesh/signing"
 )
 
-var atxID = types.ATXID([32]byte{1, 3, 3, 7})
-var nodeID, vrfsgn = generateNodeIDAndSigner()
-var validateVRF = signing.VRFVerify
-var edSigner = signing.NewEdSigner()
-var activeSetAtxs = []types.ATXID{atxID, atxID, atxID, atxID, atxID, atxID, atxID, atxID, atxID, atxID} // 10 ATXs
+var (
+	atxID          = types.ATXID([32]byte{1, 3, 3, 7})
+	nodeID, vrfsgn = generateNodeIDAndSigner()
+	validateVRF    = signing.VRFVerify
+	edSigner       = signing.NewEdSigner()
+	activeSetAtxs  = []types.ATXID{atxID, atxID, atxID, atxID, atxID, atxID, atxID, atxID, atxID, atxID} // 10 ATXs
+)
 
 const defaultAtxWeight = 1024
 
@@ -367,5 +369,4 @@ func TestMinerBlockOracle_GetEligibleLayers(t *testing.T) {
 		}
 	}
 	r.Equal(eligibleLayers, len(blockOracle.GetEligibleLayers()))
-
 }

--- a/blocks/blockoracle_test.go
+++ b/blocks/blockoracle_test.go
@@ -13,13 +13,11 @@ import (
 	"github.com/spacemeshos/go-spacemesh/signing"
 )
 
-var (
-	atxID          = types.ATXID([32]byte{1, 3, 3, 7})
-	nodeID, vrfsgn = generateNodeIDAndSigner()
-	validateVRF    = signing.VRFVerify
-	edSigner       = signing.NewEdSigner()
-	activeSetAtxs  = []types.ATXID{atxID, atxID, atxID, atxID, atxID, atxID, atxID, atxID, atxID, atxID} // 10 ATXs
-)
+var atxID = types.ATXID([32]byte{1, 3, 3, 7})
+var nodeID, vrfsgn = generateNodeIDAndSigner()
+var validateVRF = signing.VRFVerify
+var edSigner = signing.NewEdSigner()
+var activeSetAtxs = []types.ATXID{atxID, atxID, atxID, atxID, atxID, atxID, atxID, atxID, atxID, atxID} // 10 ATXs
 
 const defaultAtxWeight = 1024
 
@@ -52,8 +50,8 @@ func (a mockActivationDB) GetIdentity(edID string) (types.NodeID, error) {
 	return types.NodeID{Key: edID, VRFPublicKey: nodeID.VRFPublicKey}, nil
 }
 
-func (a mockActivationDB) GetNodeAtxIDForEpoch(nodePK string, targetEpoch types.EpochID) (types.ATXID, error) {
-	if nodePK != nodeID.Key || targetEpoch == 0 {
+func (a mockActivationDB) GetNodeAtxIDForEpoch(nID types.NodeID, targetEpoch types.EpochID) (types.ATXID, error) {
+	if nID.Key != nodeID.Key || targetEpoch == 0 {
 		return *types.EmptyATXID, errors.New("not found")
 	}
 	return atxID, nil
@@ -369,4 +367,5 @@ func TestMinerBlockOracle_GetEligibleLayers(t *testing.T) {
 		}
 	}
 	r.Equal(eligibleLayers, len(blockOracle.GetEligibleLayers()))
+
 }

--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -605,8 +605,7 @@ func (app *App) initServices(ctx context.Context,
 	)
 
 	ld := time.Duration(app.Config.LayerDurationSec) * time.Second
-	minerPK := signing.NewPublicKey(util.Hex2Bytes(nodeID.Key))
-	tBeacon := tortoisebeacon.New(app.Config.TortoiseBeacon, ld, minerPK, swarm, atxDB, tBeaconDB, sgn, edVerifier, vrfSigner, vrfVerifier, wc, clock, app.addLogger(TBeaconLogger, lg))
+	tBeacon := tortoisebeacon.New(app.Config.TortoiseBeacon, ld, nodeID, swarm, atxDB, tBeaconDB, sgn, edVerifier, vrfSigner, vrfVerifier, wc, clock, app.addLogger(TBeaconLogger, lg))
 
 	var msh *mesh.Mesh
 	var trtl *tortoise.ThreadSafeVerifyingTortoise

--- a/tortoisebeacon/activation_db.go
+++ b/tortoisebeacon/activation_db.go
@@ -9,7 +9,7 @@ import (
 //go:generate mockery -name activationDB -case underscore -inpkg
 type activationDB interface {
 	GetEpochWeight(epochID types.EpochID) (uint64, []types.ATXID, error)
-	GetNodeAtxIDForEpoch(nodePK string, targetEpoch types.EpochID) (types.ATXID, error)
+	GetNodeAtxIDForEpoch(nodeID types.NodeID, targetEpoch types.EpochID) (types.ATXID, error)
 	GetAtxHeader(id types.ATXID) (*types.ActivationTxHeader, error)
 	GetAtxTimestamp(id types.ATXID) (time.Time, error)
 }

--- a/tortoisebeacon/beacon_calc_test.go
+++ b/tortoisebeacon/beacon_calc_test.go
@@ -18,7 +18,7 @@ func TestTortoiseBeacon_calcBeacon(t *testing.T) {
 
 	mockDB := &mockActivationDB{}
 	mockDB.On("GetEpochWeight", mock.AnythingOfType("types.EpochID")).Return(uint64(1), nil, nil)
-	mockDB.On("GetNodeAtxIDForEpoch", mock.AnythingOfType("*signing.PublicKey"), mock.AnythingOfType("types.EpochID")).Return(types.ATXID{}, nil)
+	mockDB.On("GetNodeAtxIDForEpoch", mock.AnythingOfType("types.NodeID"), mock.AnythingOfType("types.EpochID")).Return(types.ATXID{}, nil)
 	mockATXHeader := types.ActivationTxHeader{
 		NIPostChallenge: types.NIPostChallenge{
 			StartTick: 0,

--- a/tortoisebeacon/handlers.go
+++ b/tortoisebeacon/handlers.go
@@ -320,7 +320,7 @@ func (tb *TortoiseBeacon) verifyFirstVotingMessage(message FirstVotingMessage, c
 	defer tb.consensusMu.Unlock()
 
 	if tb.hasVoted[firstRound] == nil {
-		tb.hasVoted[firstRound] = make(map[nodePK]struct{})
+		tb.hasVoted[firstRound] = make(map[string]struct{})
 	}
 
 	// TODO(nkryuchkov): consider having a separate table for an epoch with one bit in it if atx/miner is voted already
@@ -467,7 +467,7 @@ func (tb *TortoiseBeacon) verifyFollowingVotingMessage(message FollowingVotingMe
 	defer tb.consensusMu.Unlock()
 
 	if tb.hasVoted[message.RoundID-firstRound] == nil {
-		tb.hasVoted[message.RoundID-firstRound] = make(map[nodePK]struct{})
+		tb.hasVoted[message.RoundID-firstRound] = make(map[string]struct{})
 	}
 
 	if _, ok := tb.hasVoted[message.RoundID-firstRound][string(minerPK.Bytes())]; ok {

--- a/tortoisebeacon/handlers.go
+++ b/tortoisebeacon/handlers.go
@@ -441,7 +441,7 @@ func (tb *TortoiseBeacon) verifyFollowingVotingMessage(message FollowingVotingMe
 		return nil, types.ATXID{}, fmt.Errorf("unable to recover ID from signature %x: %w", message.Signature, err)
 	}
 
-	atxID, err := tb.atxDB.GetNodeAtxIDForEpoch(string(minerPK.Bytes()), currentEpoch-1)
+	atxID, err := tb.atxDB.GetNodeAtxIDForEpoch(minerPK.String(), currentEpoch-1)
 	if errors.Is(err, database.ErrNotFound) {
 		tb.Log.With().Warning("Miner has no ATXs in the previous epoch",
 			log.String("miner_id", minerPK.ShortString()))

--- a/tortoisebeacon/handlers.go
+++ b/tortoisebeacon/handlers.go
@@ -295,7 +295,8 @@ func (tb *TortoiseBeacon) verifyFirstVotingMessage(message FirstVotingMessage, c
 
 	// TODO(nkryuchkov): Ensure that epoch is the same.
 
-	atxID, err := tb.atxDB.GetNodeAtxIDForEpoch(types.NodeID{Key: minerPK.String()}, currentEpoch-1)
+	nodeID := types.NodeID{Key: minerPK.String()}
+	atxID, err := tb.atxDB.GetNodeAtxIDForEpoch(nodeID, currentEpoch-1)
 	if errors.Is(err, database.ErrNotFound) {
 		tb.Log.With().Warning("Miner has no ATXs in the previous epoch",
 			log.String("miner_id", minerPK.ShortString()))
@@ -441,7 +442,8 @@ func (tb *TortoiseBeacon) verifyFollowingVotingMessage(message FollowingVotingMe
 		return nil, types.ATXID{}, fmt.Errorf("unable to recover ID from signature %x: %w", message.Signature, err)
 	}
 
-	atxID, err := tb.atxDB.GetNodeAtxIDForEpoch(types.NodeID{Key: minerPK.String()}, currentEpoch-1)
+	nodeID := types.NodeID{Key: minerPK.String()}
+	atxID, err := tb.atxDB.GetNodeAtxIDForEpoch(nodeID, currentEpoch-1)
 	if errors.Is(err, database.ErrNotFound) {
 		tb.Log.With().Warning("Miner has no ATXs in the previous epoch",
 			log.String("miner_id", minerPK.ShortString()))

--- a/tortoisebeacon/handlers.go
+++ b/tortoisebeacon/handlers.go
@@ -162,8 +162,7 @@ func (tb *TortoiseBeacon) verifyProposalMessage(m ProposalMessage, currentEpoch 
 		return types.ATXID{}, fmt.Errorf("calculate proposal: %w", err)
 	}
 
-	edPK := m.NodeID.Key
-	atxID, err := tb.atxDB.GetNodeAtxIDForEpoch(edPK, currentEpoch-1)
+	atxID, err := tb.atxDB.GetNodeAtxIDForEpoch(m.NodeID, currentEpoch-1)
 	if errors.Is(err, database.ErrNotFound) {
 		tb.Log.With().Warning("Miner has no ATXs in the previous epoch",
 			log.String("miner_id", m.NodeID.ShortString()))
@@ -296,7 +295,7 @@ func (tb *TortoiseBeacon) verifyFirstVotingMessage(message FirstVotingMessage, c
 
 	// TODO(nkryuchkov): Ensure that epoch is the same.
 
-	atxID, err := tb.atxDB.GetNodeAtxIDForEpoch(minerPK.String(), currentEpoch-1)
+	atxID, err := tb.atxDB.GetNodeAtxIDForEpoch(types.NodeID{Key: minerPK.String()}, currentEpoch-1)
 	if errors.Is(err, database.ErrNotFound) {
 		tb.Log.With().Warning("Miner has no ATXs in the previous epoch",
 			log.String("miner_id", minerPK.ShortString()))
@@ -442,7 +441,7 @@ func (tb *TortoiseBeacon) verifyFollowingVotingMessage(message FollowingVotingMe
 		return nil, types.ATXID{}, fmt.Errorf("unable to recover ID from signature %x: %w", message.Signature, err)
 	}
 
-	atxID, err := tb.atxDB.GetNodeAtxIDForEpoch(minerPK.String(), currentEpoch-1)
+	atxID, err := tb.atxDB.GetNodeAtxIDForEpoch(types.NodeID{Key: minerPK.String()}, currentEpoch-1)
 	if errors.Is(err, database.ErrNotFound) {
 		tb.Log.With().Warning("Miner has no ATXs in the previous epoch",
 			log.String("miner_id", minerPK.ShortString()))

--- a/tortoisebeacon/handlers.go
+++ b/tortoisebeacon/handlers.go
@@ -319,7 +319,7 @@ func (tb *TortoiseBeacon) verifyFirstVotingMessage(message FirstVotingMessage, c
 	defer tb.consensusMu.Unlock()
 
 	if tb.hasVoted[firstRound] == nil {
-		tb.hasVoted[firstRound] = make(map[nodeID]struct{})
+		tb.hasVoted[firstRound] = make(map[nodePK]struct{})
 	}
 
 	// TODO(nkryuchkov): consider having a separate table for an epoch with one bit in it if atx/miner is voted already
@@ -465,7 +465,7 @@ func (tb *TortoiseBeacon) verifyFollowingVotingMessage(message FollowingVotingMe
 	defer tb.consensusMu.Unlock()
 
 	if tb.hasVoted[message.RoundID-firstRound] == nil {
-		tb.hasVoted[message.RoundID-firstRound] = make(map[nodeID]struct{})
+		tb.hasVoted[message.RoundID-firstRound] = make(map[nodePK]struct{})
 	}
 
 	if _, ok := tb.hasVoted[message.RoundID-firstRound][string(minerPK.Bytes())]; ok {

--- a/tortoisebeacon/handlers_test.go
+++ b/tortoisebeacon/handlers_test.go
@@ -59,6 +59,11 @@ func TestTortoiseBeacon_handleProposalMessage(t *testing.T) {
 	vrfSigner, _, err := signing.NewVRFSigner(edSgn.Sign(edPubkey.Bytes()))
 	r.NoError(err)
 
+	nodeID := types.NodeID{
+		Key:          edPubkey.String(),
+		VRFPublicKey: vrfSigner.PublicKey().Bytes(),
+	}
+
 	tt := []struct {
 		name                     string
 		epoch                    types.EpochID
@@ -73,7 +78,7 @@ func TestTortoiseBeacon_handleProposalMessage(t *testing.T) {
 				epoch: round,
 			},
 			message: ProposalMessage{
-				MinerPK: vrfSigner.PublicKey().Bytes(),
+				NodeID:  nodeID,
 				EpochID: epoch,
 			},
 		},
@@ -87,7 +92,7 @@ func TestTortoiseBeacon_handleProposalMessage(t *testing.T) {
 			tb := TortoiseBeacon{
 				config:      UnitTestConfig(),
 				Log:         logtest.New(t).WithName("TortoiseBeacon"),
-				minerPK:     vrfSigner.PublicKey(),
+				nodeID:      nodeID,
 				atxDB:       mockDB,
 				vrfVerifier: signing.VRFVerifier{},
 				vrfSigner:   vrfSigner,

--- a/tortoisebeacon/handlers_test.go
+++ b/tortoisebeacon/handlers_test.go
@@ -164,7 +164,7 @@ func TestTortoiseBeacon_handleFirstVotingMessage(t *testing.T) {
 		epoch         types.EpochID
 		currentRounds map[types.EpochID]types.RoundID
 		message       FirstVotingMessage
-		expected      map[nodeID]proposals
+		expected      map[nodePK]proposals
 	}{
 		{
 			name:  "Current round and message round equal",
@@ -178,7 +178,7 @@ func TestTortoiseBeacon_handleFirstVotingMessage(t *testing.T) {
 					PotentiallyValidProposals: nil,
 				},
 			},
-			expected: map[nodeID]proposals{
+			expected: map[nodePK]proposals{
 				string(edSgn.PublicKey().Bytes()): {
 					valid: [][]byte{hash.Bytes()},
 				},
@@ -196,7 +196,7 @@ func TestTortoiseBeacon_handleFirstVotingMessage(t *testing.T) {
 					PotentiallyValidProposals: nil,
 				},
 			},
-			expected: map[nodeID]proposals{
+			expected: map[nodePK]proposals{
 				string(edSgn.PublicKey().Bytes()): {
 					valid: [][]byte{hash.Bytes()},
 				},
@@ -217,9 +217,9 @@ func TestTortoiseBeacon_handleFirstVotingMessage(t *testing.T) {
 				edSigner:                edSgn,
 				edVerifier:              signing.NewEDVerifier(),
 				clock:                   clock,
-				firstRoundIncomingVotes: map[nodeID]proposals{},
+				firstRoundIncomingVotes: map[nodePK]proposals{},
 				votesMargin:             map[proposal]*big.Int{},
-				hasVoted:                make([]map[nodeID]struct{}, round+1),
+				hasVoted:                make([]map[nodePK]struct{}, round+1),
 			}
 
 			sig, err := tb.signMessage(tc.message.FirstVotingMessageBody)
@@ -343,14 +343,14 @@ func TestTortoiseBeacon_handleFollowingVotingMessage(t *testing.T) {
 				edSigner:    edSgn,
 				edVerifier:  signing.NewEDVerifier(),
 				clock:       clock,
-				firstRoundIncomingVotes: map[nodeID]proposals{
+				firstRoundIncomingVotes: map[nodePK]proposals{
 					string(edSgn.PublicKey().Bytes()): {
 						valid:            [][]byte{hash1.Bytes(), hash2.Bytes()},
 						potentiallyValid: [][]byte{hash3.Bytes()},
 					},
 				},
 				lastLayer:   types.NewLayerID(epoch),
-				hasVoted:    make([]map[nodeID]struct{}, round+1),
+				hasVoted:    make([]map[nodePK]struct{}, round+1),
 				votesMargin: map[proposal]*big.Int{},
 			}
 

--- a/tortoisebeacon/handlers_test.go
+++ b/tortoisebeacon/handlers_test.go
@@ -169,7 +169,7 @@ func TestTortoiseBeacon_handleFirstVotingMessage(t *testing.T) {
 		epoch         types.EpochID
 		currentRounds map[types.EpochID]types.RoundID
 		message       FirstVotingMessage
-		expected      map[nodePK]proposals
+		expected      map[string]proposals
 	}{
 		{
 			name:  "Current round and message round equal",
@@ -183,7 +183,7 @@ func TestTortoiseBeacon_handleFirstVotingMessage(t *testing.T) {
 					PotentiallyValidProposals: nil,
 				},
 			},
-			expected: map[nodePK]proposals{
+			expected: map[string]proposals{
 				string(edSgn.PublicKey().Bytes()): {
 					valid: [][]byte{hash.Bytes()},
 				},
@@ -201,7 +201,7 @@ func TestTortoiseBeacon_handleFirstVotingMessage(t *testing.T) {
 					PotentiallyValidProposals: nil,
 				},
 			},
-			expected: map[nodePK]proposals{
+			expected: map[string]proposals{
 				string(edSgn.PublicKey().Bytes()): {
 					valid: [][]byte{hash.Bytes()},
 				},
@@ -222,9 +222,9 @@ func TestTortoiseBeacon_handleFirstVotingMessage(t *testing.T) {
 				edSigner:                edSgn,
 				edVerifier:              signing.NewEDVerifier(),
 				clock:                   clock,
-				firstRoundIncomingVotes: map[nodePK]proposals{},
+				firstRoundIncomingVotes: map[string]proposals{},
 				votesMargin:             map[proposal]*big.Int{},
-				hasVoted:                make([]map[nodePK]struct{}, round+1),
+				hasVoted:                make([]map[string]struct{}, round+1),
 			}
 
 			sig, err := tb.signMessage(tc.message.FirstVotingMessageBody)
@@ -348,14 +348,14 @@ func TestTortoiseBeacon_handleFollowingVotingMessage(t *testing.T) {
 				edSigner:    edSgn,
 				edVerifier:  signing.NewEDVerifier(),
 				clock:       clock,
-				firstRoundIncomingVotes: map[nodePK]proposals{
+				firstRoundIncomingVotes: map[string]proposals{
 					string(edSgn.PublicKey().Bytes()): {
 						valid:            [][]byte{hash1.Bytes(), hash2.Bytes()},
 						potentiallyValid: [][]byte{hash3.Bytes()},
 					},
 				},
 				lastLayer:   types.NewLayerID(epoch),
-				hasVoted:    make([]map[nodePK]struct{}, round+1),
+				hasVoted:    make([]map[string]struct{}, round+1),
 				votesMargin: map[proposal]*big.Int{},
 			}
 

--- a/tortoisebeacon/handlers_test.go
+++ b/tortoisebeacon/handlers_test.go
@@ -223,7 +223,7 @@ func TestTortoiseBeacon_handleFirstVotingMessage(t *testing.T) {
 				edVerifier:              signing.NewEDVerifier(),
 				clock:                   clock,
 				firstRoundIncomingVotes: map[string]proposals{},
-				votesMargin:             map[proposal]*big.Int{},
+				votesMargin:             map[string]*big.Int{},
 				hasVoted:                make([]map[string]struct{}, round+1),
 			}
 
@@ -292,7 +292,7 @@ func TestTortoiseBeacon_handleFollowingVotingMessage(t *testing.T) {
 		epoch         types.EpochID
 		currentRounds map[types.EpochID]types.RoundID
 		message       FollowingVotingMessage
-		expected      map[proposal]*big.Int
+		expected      map[string]*big.Int
 	}{
 		{
 			name:  "Current round and message round equal",
@@ -306,7 +306,7 @@ func TestTortoiseBeacon_handleFollowingVotingMessage(t *testing.T) {
 					VotesBitVector: []uint64{0b101},
 				},
 			},
-			expected: map[proposal]*big.Int{
+			expected: map[string]*big.Int{
 				string(hash1.Bytes()): big.NewInt(1),
 				string(hash2.Bytes()): big.NewInt(-1),
 				string(hash3.Bytes()): big.NewInt(1),
@@ -324,7 +324,7 @@ func TestTortoiseBeacon_handleFollowingVotingMessage(t *testing.T) {
 					VotesBitVector: []uint64{0b101},
 				},
 			},
-			expected: map[proposal]*big.Int{
+			expected: map[string]*big.Int{
 				string(hash1.Bytes()): big.NewInt(1),
 				string(hash2.Bytes()): big.NewInt(-1),
 				string(hash3.Bytes()): big.NewInt(1),
@@ -356,7 +356,7 @@ func TestTortoiseBeacon_handleFollowingVotingMessage(t *testing.T) {
 				},
 				lastLayer:   types.NewLayerID(epoch),
 				hasVoted:    make([]map[string]struct{}, round+1),
-				votesMargin: map[proposal]*big.Int{},
+				votesMargin: map[string]*big.Int{},
 			}
 
 			sig, err := tb.signMessage(tc.message.FollowingVotingMessageBody)

--- a/tortoisebeacon/message.go
+++ b/tortoisebeacon/message.go
@@ -11,7 +11,7 @@ import (
 // ProposalMessage is a message type which is used when sending proposals.
 type ProposalMessage struct {
 	EpochID      types.EpochID
-	MinerPK      []byte
+	NodeID       types.NodeID
 	VRFSignature []byte
 }
 

--- a/tortoisebeacon/mock_activation_db.go
+++ b/tortoisebeacon/mock_activation_db.go
@@ -90,12 +90,12 @@ func (_m *mockActivationDB) GetEpochWeight(epochID types.EpochID) (uint64, []typ
 }
 
 // GetNodeAtxIDForEpoch provides a mock function with given fields: nodeID, targetEpoch
-func (_m *mockActivationDB) GetNodeAtxIDForEpoch(nodePK string, targetEpoch types.EpochID) (types.ATXID, error) {
-	ret := _m.Called(nodePK, targetEpoch)
+func (_m *mockActivationDB) GetNodeAtxIDForEpoch(nodeID types.NodeID, targetEpoch types.EpochID) (types.ATXID, error) {
+	ret := _m.Called(nodeID, targetEpoch)
 
 	var r0 types.ATXID
-	if rf, ok := ret.Get(0).(func(string, types.EpochID) types.ATXID); ok {
-		r0 = rf(nodePK, targetEpoch)
+	if rf, ok := ret.Get(0).(func(types.NodeID, types.EpochID) types.ATXID); ok {
+		r0 = rf(nodeID, targetEpoch)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(types.ATXID)
@@ -103,8 +103,8 @@ func (_m *mockActivationDB) GetNodeAtxIDForEpoch(nodePK string, targetEpoch type
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string, types.EpochID) error); ok {
-		r1 = rf(nodePK, targetEpoch)
+	if rf, ok := ret.Get(1).(func(types.NodeID, types.EpochID) error); ok {
+		r1 = rf(nodeID, targetEpoch)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/tortoisebeacon/proposal_list.go
+++ b/tortoisebeacon/proposal_list.go
@@ -9,9 +9,9 @@ import (
 	"github.com/spacemeshos/go-spacemesh/common/types"
 )
 
-type proposalList []proposal
+type proposalList []string
 
-func (hl proposalList) sort() []proposal {
+func (hl proposalList) sort() []string {
 	sort.Slice(hl, func(i, j int) bool {
 		return strings.Compare(hl[i], hl[j]) == -1
 	})

--- a/tortoisebeacon/proposal_set.go
+++ b/tortoisebeacon/proposal_set.go
@@ -1,6 +1,6 @@
 package tortoisebeacon
 
-type proposalSet map[proposal]struct{}
+type proposalSet map[string]struct{}
 
 func (vs proposalSet) list() proposalList {
 	votes := make(proposalList, 0)

--- a/tortoisebeacon/tortoise_beacon.go
+++ b/tortoisebeacon/tortoise_beacon.go
@@ -75,7 +75,7 @@ type layerClock interface {
 func New(
 	conf Config,
 	layerDuration time.Duration,
-	minerPK *signing.PublicKey,
+	nodeID types.NodeID,
 	net broadcaster,
 	atxDB activationDB,
 	tortoiseBeaconDB tortoiseBeaconDB,
@@ -91,7 +91,7 @@ func New(
 		Log:                     logger,
 		config:                  conf,
 		layerDuration:           layerDuration,
-		minerPK:                 minerPK,
+		nodeID:                  nodeID,
 		net:                     net,
 		atxDB:                   atxDB,
 		tortoiseBeaconDB:        tortoiseBeaconDB,
@@ -120,7 +120,7 @@ type TortoiseBeacon struct {
 
 	config        Config
 	layerDuration time.Duration
-	minerPK       *signing.PublicKey
+	nodeID        types.NodeID
 
 	net              broadcaster
 	atxDB            activationDB
@@ -521,7 +521,7 @@ func (tb *TortoiseBeacon) proposalPhaseImpl(ctx context.Context, epoch types.Epo
 	// concat them into a single proposal message
 	m := ProposalMessage{
 		EpochID:      epoch,
-		MinerPK:      tb.minerPK.Bytes(),
+		NodeID:       tb.nodeID,
 		VRFSignature: proposedSignature,
 	}
 

--- a/tortoisebeacon/tortoise_beacon.go
+++ b/tortoisebeacon/tortoise_beacon.go
@@ -57,7 +57,7 @@ type coin interface {
 }
 
 type (
-	nodeID    = string
+	nodePK    = string
 	proposal  = string
 	proposals = struct{ valid, potentiallyValid [][]byte }
 	allVotes  = struct{ valid, invalid proposalSet }
@@ -102,8 +102,8 @@ func New(
 		weakCoin:                weakCoin,
 		clock:                   clock,
 		beacons:                 make(map[types.EpochID]types.Hash32),
-		hasVoted:                make([]map[nodeID]struct{}, conf.RoundsNumber),
-		firstRoundIncomingVotes: make(map[nodeID]proposals),
+		hasVoted:                make([]map[nodePK]struct{}, conf.RoundsNumber),
+		firstRoundIncomingVotes: make(map[nodePK]proposals),
 		seenEpochs:              make(map[types.EpochID]struct{}),
 		proposalChans:           make(map[types.EpochID]chan *proposalMessageWithReceiptData),
 		votesMargin:             map[proposal]*big.Int{},
@@ -143,10 +143,10 @@ type TortoiseBeacon struct {
 	// TODO(nkryuchkov): have a mixed list of all sorted proposals
 	// have one bit vector: valid proposals
 	incomingProposals       proposals
-	firstRoundIncomingVotes map[nodeID]proposals // sorted votes for bit vector decoding
+	firstRoundIncomingVotes map[nodePK]proposals // sorted votes for bit vector decoding
 	// TODO(nkryuchkov): For every round excluding first round consider having a vector of opinions.
 	votesMargin map[proposal]*big.Int
-	hasVoted    []map[nodeID]struct{}
+	hasVoted    []map[nodePK]struct{}
 
 	proposalPhaseFinishedTimeMu sync.RWMutex
 	proposalPhaseFinishedTime   time.Time
@@ -266,9 +266,9 @@ func (tb *TortoiseBeacon) cleanupVotes() {
 	defer tb.consensusMu.Unlock()
 
 	tb.incomingProposals = proposals{}
-	tb.firstRoundIncomingVotes = map[nodeID]proposals{}
+	tb.firstRoundIncomingVotes = map[nodePK]proposals{}
 	tb.votesMargin = map[proposal]*big.Int{}
-	tb.hasVoted = make([]map[nodeID]struct{}, tb.config.RoundsNumber)
+	tb.hasVoted = make([]map[nodePK]struct{}, tb.config.RoundsNumber)
 
 	tb.proposalPhaseFinishedTimeMu.Lock()
 	defer tb.proposalPhaseFinishedTimeMu.Unlock()

--- a/tortoisebeacon/tortoise_beacon.go
+++ b/tortoisebeacon/tortoise_beacon.go
@@ -57,7 +57,6 @@ type coin interface {
 }
 
 type (
-	nodePK    = string
 	proposal  = string
 	proposals = struct{ valid, potentiallyValid [][]byte }
 	allVotes  = struct{ valid, invalid proposalSet }
@@ -102,8 +101,8 @@ func New(
 		weakCoin:                weakCoin,
 		clock:                   clock,
 		beacons:                 make(map[types.EpochID]types.Hash32),
-		hasVoted:                make([]map[nodePK]struct{}, conf.RoundsNumber),
-		firstRoundIncomingVotes: make(map[nodePK]proposals),
+		hasVoted:                make([]map[string]struct{}, conf.RoundsNumber),
+		firstRoundIncomingVotes: make(map[string]proposals),
 		seenEpochs:              make(map[types.EpochID]struct{}),
 		proposalChans:           make(map[types.EpochID]chan *proposalMessageWithReceiptData),
 		votesMargin:             map[proposal]*big.Int{},
@@ -143,10 +142,10 @@ type TortoiseBeacon struct {
 	// TODO(nkryuchkov): have a mixed list of all sorted proposals
 	// have one bit vector: valid proposals
 	incomingProposals       proposals
-	firstRoundIncomingVotes map[nodePK]proposals // sorted votes for bit vector decoding
+	firstRoundIncomingVotes map[string]proposals // sorted votes for bit vector decoding
 	// TODO(nkryuchkov): For every round excluding first round consider having a vector of opinions.
 	votesMargin map[proposal]*big.Int
-	hasVoted    []map[nodePK]struct{}
+	hasVoted    []map[string]struct{}
 
 	proposalPhaseFinishedTimeMu sync.RWMutex
 	proposalPhaseFinishedTime   time.Time
@@ -266,9 +265,9 @@ func (tb *TortoiseBeacon) cleanupVotes() {
 	defer tb.consensusMu.Unlock()
 
 	tb.incomingProposals = proposals{}
-	tb.firstRoundIncomingVotes = map[nodePK]proposals{}
+	tb.firstRoundIncomingVotes = map[string]proposals{}
 	tb.votesMargin = map[proposal]*big.Int{}
-	tb.hasVoted = make([]map[nodePK]struct{}, tb.config.RoundsNumber)
+	tb.hasVoted = make([]map[string]struct{}, tb.config.RoundsNumber)
 
 	tb.proposalPhaseFinishedTimeMu.Lock()
 	defer tb.proposalPhaseFinishedTimeMu.Unlock()

--- a/tortoisebeacon/tortoise_beacon.go
+++ b/tortoisebeacon/tortoise_beacon.go
@@ -57,7 +57,6 @@ type coin interface {
 }
 
 type (
-	proposal  = string
 	proposals = struct{ valid, potentiallyValid [][]byte }
 	allVotes  = struct{ valid, invalid proposalSet }
 )
@@ -105,7 +104,7 @@ func New(
 		firstRoundIncomingVotes: make(map[string]proposals),
 		seenEpochs:              make(map[types.EpochID]struct{}),
 		proposalChans:           make(map[types.EpochID]chan *proposalMessageWithReceiptData),
-		votesMargin:             map[proposal]*big.Int{},
+		votesMargin:             map[string]*big.Int{},
 	}
 }
 
@@ -144,7 +143,7 @@ type TortoiseBeacon struct {
 	incomingProposals       proposals
 	firstRoundIncomingVotes map[string]proposals // sorted votes for bit vector decoding
 	// TODO(nkryuchkov): For every round excluding first round consider having a vector of opinions.
-	votesMargin map[proposal]*big.Int
+	votesMargin map[string]*big.Int
 	hasVoted    []map[string]struct{}
 
 	proposalPhaseFinishedTimeMu sync.RWMutex
@@ -266,7 +265,7 @@ func (tb *TortoiseBeacon) cleanupVotes() {
 
 	tb.incomingProposals = proposals{}
 	tb.firstRoundIncomingVotes = map[string]proposals{}
-	tb.votesMargin = map[proposal]*big.Int{}
+	tb.votesMargin = map[string]*big.Int{}
 	tb.hasVoted = make([]map[string]struct{}, tb.config.RoundsNumber)
 
 	tb.proposalPhaseFinishedTimeMu.Lock()

--- a/tortoisebeacon/tortoise_beacon_test.go
+++ b/tortoisebeacon/tortoise_beacon_test.go
@@ -73,7 +73,7 @@ func TestTortoiseBeacon(t *testing.T) {
 	atxdb := activation.NewDB(database.NewMemDatabase(), idStore, memesh, 3, goldenATXID, &validatorMock{}, lg.WithName("atxDB"))
 	_ = atxdb
 
-	tb := New(conf, ld, signing.NewPublicKey(util.Hex2Bytes(minerID.Key)), n1, mockDB, nil, edSgn, signing.NewEDVerifier(), vrfSigner, signing.VRFVerifier{}, mwc, clock, logger)
+	tb := New(conf, ld, minerID, n1, mockDB, nil, edSgn, signing.NewEDVerifier(), vrfSigner, signing.VRFVerifier{}, mwc, clock, logger)
 	requirer.NotNil(tb)
 
 	err = tb.Start(context.TODO())

--- a/tortoisebeacon/votes_calc_test.go
+++ b/tortoisebeacon/votes_calc_test.go
@@ -58,7 +58,7 @@ func TestTortoiseBeacon_calcVotes(t *testing.T) {
 		epoch         types.EpochID
 		round         types.RoundID
 		votesMargin   map[proposal]*big.Int
-		incomingVotes []map[nodePK]allVotes
+		incomingVotes []map[string]allVotes
 		expected      allVotes
 	}{
 		{

--- a/tortoisebeacon/votes_calc_test.go
+++ b/tortoisebeacon/votes_calc_test.go
@@ -58,7 +58,7 @@ func TestTortoiseBeacon_calcVotes(t *testing.T) {
 		epoch         types.EpochID
 		round         types.RoundID
 		votesMargin   map[proposal]*big.Int
-		incomingVotes []map[nodeID]allVotes
+		incomingVotes []map[nodePK]allVotes
 		expected      allVotes
 	}{
 		{

--- a/tortoisebeacon/votes_calc_test.go
+++ b/tortoisebeacon/votes_calc_test.go
@@ -57,7 +57,7 @@ func TestTortoiseBeacon_calcVotes(t *testing.T) {
 		name          string
 		epoch         types.EpochID
 		round         types.RoundID
-		votesMargin   map[proposal]*big.Int
+		votesMargin   map[string]*big.Int
 		incomingVotes []map[string]allVotes
 		expected      allVotes
 	}{
@@ -65,7 +65,7 @@ func TestTortoiseBeacon_calcVotes(t *testing.T) {
 			name:  "Case 1",
 			epoch: epoch,
 			round: round,
-			votesMargin: map[proposal]*big.Int{
+			votesMargin: map[string]*big.Int{
 				"0x1": big.NewInt(2),
 				"0x2": big.NewInt(0),
 				"0x3": big.NewInt(0),
@@ -135,7 +135,7 @@ func TestTortoiseBeacon_calcOwnCurrentRoundVotes(t *testing.T) {
 		epoch              types.EpochID
 		round              types.RoundID
 		ownFirstRoundVotes allVotes
-		votesCount         map[proposal]*big.Int
+		votesCount         map[string]*big.Int
 		weakCoin           bool
 		result             allVotes
 	}{
@@ -152,7 +152,7 @@ func TestTortoiseBeacon_calcOwnCurrentRoundVotes(t *testing.T) {
 					"0x3": {},
 				},
 			},
-			votesCount: map[proposal]*big.Int{
+			votesCount: map[string]*big.Int{
 				"0x1": big.NewInt(threshold * 2),
 				"0x2": big.NewInt(-threshold * 3),
 				"0x3": big.NewInt(threshold / 2),
@@ -172,7 +172,7 @@ func TestTortoiseBeacon_calcOwnCurrentRoundVotes(t *testing.T) {
 			name:  "Case 2",
 			epoch: 5,
 			round: 5,
-			votesCount: map[proposal]*big.Int{
+			votesCount: map[string]*big.Int{
 				"0x1": big.NewInt(threshold * 2),
 				"0x2": big.NewInt(-threshold * 3),
 				"0x3": big.NewInt(threshold / 2),

--- a/tortoisebeacon/votes_calc_test.go
+++ b/tortoisebeacon/votes_calc_test.go
@@ -40,7 +40,7 @@ func TestTortoiseBeacon_calcVotes(t *testing.T) {
 	mockDB.On("GetEpochWeight",
 		mock.AnythingOfType("types.EpochID")).
 		Return(uint64(1), nil, nil)
-	mockDB.On("GetNodeAtxIDForEpoch", mock.AnythingOfType("string"), mock.AnythingOfType("types.EpochID")).Return(types.ATXID{}, nil)
+	mockDB.On("GetNodeAtxIDForEpoch", mock.AnythingOfType("types.NodeID"), mock.AnythingOfType("types.EpochID")).Return(types.ATXID{}, nil)
 	mockATXHeader := types.ActivationTxHeader{
 		NIPostChallenge: types.NIPostChallenge{
 			StartTick: 0,
@@ -120,7 +120,7 @@ func TestTortoiseBeacon_calcOwnCurrentRoundVotes(t *testing.T) {
 	mockDB.On("GetEpochWeight",
 		mock.AnythingOfType("types.EpochID")).
 		Return(uint64(threshold), nil, nil)
-	mockDB.On("GetNodeAtxIDForEpoch", mock.AnythingOfType("string"), mock.AnythingOfType("types.EpochID")).Return(types.ATXID{}, nil)
+	mockDB.On("GetNodeAtxIDForEpoch", mock.AnythingOfType("types.NodeID"), mock.AnythingOfType("types.EpochID")).Return(types.ATXID{}, nil)
 	mockATXHeader := types.ActivationTxHeader{
 		NIPostChallenge: types.NIPostChallenge{
 			StartTick: 0,


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
Closes #2694 
Closes #2696 
<!-- `Closes #XXXX, closes #XXXX, ...` links mentioned issues to this PR and automatically closes them when this it's merged -->

## Changes
<!-- Please describe in detail the changes made -->
- Revert changing `GetNodeLastAtxID` signature
- Fix incorrect usage of miner PK when passing to `GetNodeLastAtxID`
- Accept `types.NodeID` instead of ED public key in `tortoisebeacon.New`
- Send `types.NodeID` instead of ED public key in `ProposalMessage`

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->
Unit tests

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
