### PR TITLE
[Merged by Bors] - use layer id to query layer content btwn peers

### DIFF
--- a/common/types/block.go
+++ b/common/types/block.go
@@ -43,6 +43,9 @@ var (
 	// effectiveGenesis marks when actual blocks would start being created in the network. It takes into account
 	// the first genesis epoch and the following epoch in which ATXs are published.
 	effectiveGenesis uint32
+
+	// EmptyLayerHash is the layer hash for an empty layer
+	EmptyLayerHash = Hash32{}
 )
 
 // SetLayersPerEpoch sets global parameter of layers per epoch, all conversions from layer to epoch use this param
@@ -420,6 +423,9 @@ func (l *Layer) BlocksIDs() []BlockID {
 // Hash returns the 32-byte sha256 sum of the block IDs of both contextually valid and invalid blocks in this layer,
 // sorted in lexicographic order.
 func (l Layer) Hash() Hash32 {
+	if len(l.blocks) == 0 {
+		return EmptyLayerHash
+	}
 	return CalcBlocksHash32(SortBlockIDs(BlockIDs(l.blocks)), nil)
 }
 

--- a/hare/hare.go
+++ b/hare/hare.go
@@ -302,6 +302,7 @@ func (h *Hare) outputCollectionLoop(ctx context.Context) {
 		case out := <-h.outputChan:
 			layerID := out.ID()
 			coin := out.Coinflip()
+			ctx := log.WithNewSessionID(ctx)
 			logger := h.WithContext(ctx).WithFields(layerID)
 
 			// collect coinflip, regardless of success

--- a/layerfetcher/layers.go
+++ b/layerfetcher/layers.go
@@ -13,7 +13,6 @@ import (
 	"github.com/spacemeshos/go-spacemesh/database"
 	"github.com/spacemeshos/go-spacemesh/fetch"
 	"github.com/spacemeshos/go-spacemesh/log"
-	"github.com/spacemeshos/go-spacemesh/mesh"
 	"github.com/spacemeshos/go-spacemesh/p2p/p2pcrypto"
 	"github.com/spacemeshos/go-spacemesh/p2p/peers"
 	"github.com/spacemeshos/go-spacemesh/p2p/server"
@@ -37,21 +36,16 @@ type TxProcessor interface {
 
 // layerDB is an interface that returns layer data and blocks
 type layerDB interface {
-	GetLayerHash(ID types.LayerID) types.Hash32
-	GetAggregatedLayerHash(ID types.LayerID) types.Hash32
-	GetLayerHashBlocks(hash types.Hash32) []types.BlockID
-	GetLayerInputVector(hash types.Hash32) ([]types.BlockID, error)
+	GetLayerHash(types.LayerID) types.Hash32
+	GetAggregatedLayerHash(types.LayerID) types.Hash32
+	LayerBlockIds(types.LayerID) ([]types.BlockID, error)
+	GetLayerInputVectorByID(id types.LayerID) ([]types.BlockID, error)
 	SaveLayerInputVectorByID(ctx context.Context, id types.LayerID, blks []types.BlockID) error
 	ProcessedLayer() types.LayerID
 }
 
 type atxIDsDB interface {
 	GetEpochAtxs(epochID types.EpochID) (atxs []types.ATXID)
-}
-
-// gossipBlocks returns gossip block received byu this node in the last x time frame
-type gossipBlocks interface {
-	Get() []types.BlockID
 }
 
 // poetDB is an interface to reading and storing poet proofs
@@ -84,16 +78,13 @@ var ErrNoPeers = errors.New("no peers")
 // ErrTooManyPeerErrors is returned when too many (> 1/2) peers return error
 var ErrTooManyPeerErrors = errors.New("too many peers returned error")
 
+// ErrInternal is returned from the peer when the peer encounters an internal error
+var ErrInternal = errors.New("unspecified error returned by peer")
+
 // peerResult captures the response from each peer.
 type peerResult struct {
-	data []byte
+	data *layerBlocks
 	err  error
-}
-
-// LayerHashResult is the result of fetching hashes for each layer from peers.
-type LayerHashResult struct {
-	Hashes map[layerHash][]peers.Peer
-	Err    error
 }
 
 // LayerPromiseResult is the result of trying to fetch data for an entire layer.
@@ -108,8 +99,6 @@ type Logic struct {
 	fetcher        fetch.Fetcher
 	net            network
 	mutex          sync.Mutex
-	layerHashesRes map[types.LayerID]map[peers.Peer]*peerResult
-	layerHashesChs map[types.LayerID][]chan LayerHashResult
 	layerBlocksRes map[types.LayerID]map[peers.Peer]*peerResult
 	layerBlocksChs map[types.LayerID][]chan LayerPromiseResult
 	poetProofs     poetDB
@@ -119,7 +108,6 @@ type Logic struct {
 	layerDB        layerDB
 	atxIds         atxIDsDB
 	tbDB           tortoiseBeaconDB
-	gossipBlocks   gossipBlocks
 	goldenATXID    types.ATXID
 }
 
@@ -141,8 +129,6 @@ func NewLogic(ctx context.Context, cfg Config, blocks blockHandler, atxs atxHand
 		log:            log,
 		fetcher:        fetcher,
 		net:            srv,
-		layerHashesRes: make(map[types.LayerID]map[peers.Peer]*peerResult),
-		layerHashesChs: make(map[types.LayerID][]chan LayerHashResult),
 		layerBlocksRes: make(map[types.LayerID]map[peers.Peer]*peerResult),
 		layerBlocksChs: make(map[types.LayerID][]chan LayerPromiseResult),
 		poetProofs:     poet,
@@ -155,8 +141,7 @@ func NewLogic(ctx context.Context, cfg Config, blocks blockHandler, atxs atxHand
 		goldenATXID:    cfg.GoldenATXID,
 	}
 
-	srv.RegisterBytesMsgHandler(server.LayerHashMsg, l.layerHashReqReceiver)
-	srv.RegisterBytesMsgHandler(server.LayerBlocksMsg, l.layerHashBlocksReqReceiver)
+	srv.RegisterBytesMsgHandler(server.LayerBlocksMsg, l.layerBlocksReqReceiver)
 	srv.RegisterBytesMsgHandler(server.AtxIDsMsg, l.epochATXsReqReceiver)
 	srv.RegisterBytesMsgHandler(server.TortoiseBeaconMsg, l.tortoiseBeaconReqReceiver)
 
@@ -188,28 +173,6 @@ func (l *Logic) AddDBs(blockDB, AtxDB, TxDB, poetDB, IvDB, tbDB database.Getter)
 	l.fetcher.AddDB(fetch.TBDB, tbDB)
 }
 
-// layerHashReqReceiver returns the layer hash for the specified layer.
-func (l *Logic) layerHashReqReceiver(ctx context.Context, msg []byte) ([]byte, error) {
-	lyr := types.NewLayerID(util.BytesToUint32(msg))
-	lyrHash := &layerHash{
-		ProcessedLayer: l.layerDB.ProcessedLayer(),
-		Hash:           l.layerDB.GetLayerHash(lyr),
-		AggregatedHash: l.layerDB.GetAggregatedLayerHash(lyr),
-	}
-	out, err := types.InterfaceToBytes(lyrHash)
-	if err != nil {
-		l.log.WithContext(ctx).With().Panic("failed to serialize layer hash",
-			lyr,
-			log.String("hash", lyrHash.Hash.ShortString()),
-			log.String("aggregatedHash", lyrHash.AggregatedHash.ShortString()))
-	}
-	l.log.WithContext(ctx).With().Debug("responded to layer hash request",
-		lyr,
-		log.String("hash", lyrHash.Hash.ShortString()),
-		log.String("aggregatedHash", lyrHash.AggregatedHash.ShortString()))
-	return out, nil
-}
-
 // epochATXsReqReceiver returns the ATXs for the specified epoch.
 func (l *Logic) epochATXsReqReceiver(ctx context.Context, msg []byte) ([]byte, error) {
 	epoch := types.EpochID(util.BytesToUint32(msg))
@@ -224,24 +187,28 @@ func (l *Logic) epochATXsReqReceiver(ctx context.Context, msg []byte) ([]byte, e
 	return bts, err
 }
 
-// layerHashBlocksReqReceiver returns the block IDs for the specified layer hash,
+// layerBlocksReqReceiver returns the block IDs for the specified layer hash,
 // it also returns the validation vector for this data and the latest blocks received in gossip
-func (l *Logic) layerHashBlocksReqReceiver(ctx context.Context, msg []byte) ([]byte, error) {
-	h := types.BytesToHash(msg)
-
-	blocks := l.layerDB.GetLayerHashBlocks(h)
-	vector, err := l.layerDB.GetLayerInputVector(h)
-	// best effort with input vector
+func (l *Logic) layerBlocksReqReceiver(ctx context.Context, req []byte) ([]byte, error) {
+	lyrID := types.BytesToLayerID(req)
+	blockIDs, err := l.layerDB.LayerBlockIds(lyrID)
 	if err != nil {
-		// TODO: differentiate between empty set and no results in sync
-		l.log.WithContext(ctx).With().Debug("no input vector for layer",
-			log.String("layer_hash", h.ShortString()))
+		l.log.WithContext(ctx).With().Debug("failed to get layer content", lyrID, log.Err(err))
+		return nil, ErrInternal
 	}
-	// latest := l.gossipBlocks.Get() todo: implement this
-	b := layerBlocks{
-		blocks,
-		nil,
-		vector,
+
+	inputVector, err := l.layerDB.GetLayerInputVectorByID(lyrID)
+	if err != nil {
+		// best effort with input vector
+		l.log.WithContext(ctx).With().Debug("failed to get input vector for layer", lyrID, log.Err(err))
+	}
+
+	b := &layerBlocks{
+		Blocks:         blockIDs,
+		InputVector:    inputVector,
+		ProcessedLayer: l.layerDB.ProcessedLayer(),
+		Hash:           l.layerDB.GetLayerHash(lyrID),
+		AggregatedHash: l.layerDB.GetAggregatedLayerHash(lyrID),
 	}
 
 	out, err := types.InterfaceToBytes(b)
@@ -272,130 +239,23 @@ func (l *Logic) tortoiseBeaconReqReceiver(ctx context.Context, data []byte) ([]b
 	return beacon.Bytes(), nil
 }
 
-// PollLayerHash polls peers on the layer hash. it returns a channel for the caller to be notified when
-// responses are received from all peers.
-func (l *Logic) PollLayerHash(ctx context.Context, layerID types.LayerID) chan LayerHashResult {
-	l.log.WithContext(ctx).With().Info("polling for layer hash", layerID)
-	resChannel := make(chan LayerHashResult, 1)
+// PollLayerContent polls peers for the content of a given layer ID.
+// it returns a channel for the caller to be notified when responses are received from all peers.
+func (l *Logic) PollLayerContent(ctx context.Context, layerID types.LayerID) chan LayerPromiseResult {
+	l.log.WithContext(ctx).With().Info("polling layer content", layerID)
+	resChannel := make(chan LayerPromiseResult, 1)
 
 	remotePeers := l.net.GetPeers()
 	numPeers := len(remotePeers)
 	if numPeers == 0 {
-		resChannel <- LayerHashResult{Hashes: nil, Err: ErrNoPeers}
+		resChannel <- LayerPromiseResult{Layer: layerID, Err: ErrNoPeers}
 		return resChannel
 	}
 
-	l.mutex.Lock()
-	l.layerHashesChs[layerID] = append(l.layerHashesChs[layerID], resChannel)
-	if _, ok := l.layerHashesRes[layerID]; ok {
-		// polling hashes of layerID is on-going, just wait for the polling to finish and get notified
-		l.mutex.Unlock()
-		return resChannel
-	}
-	l.layerHashesRes[layerID] = make(map[peers.Peer]*peerResult)
-	l.mutex.Unlock()
-
-	// request layers from all peers since different peers can have different layer hashes
-	for _, p := range remotePeers {
-		// build custom receiver for each peer so that receiver will know which peer the data came from
-		// so that it could request relevant block ids from the same peer
-		peer := p
-		receiveForPeerFunc := func(data []byte) {
-			l.receiveLayerHash(ctx, layerID, peer, numPeers, data, nil)
-		}
-		errFunc := func(err error) {
-			l.receiveLayerHash(ctx, layerID, peer, numPeers, nil, err)
-		}
-		err := l.net.SendRequest(ctx, server.LayerHashMsg, layerID.Bytes(), p, receiveForPeerFunc, errFunc)
-		if err != nil {
-			l.receiveLayerHash(ctx, layerID, peer, numPeers, nil, err)
-		}
-	}
-	return resChannel
-}
-
-// receiveLayerHash is called when a layer hash response is received from a remote peer.
-// if enough responses are received, it notifies the channels waiting for the layer hash result.
-func (l *Logic) receiveLayerHash(ctx context.Context, layerID types.LayerID, peer peers.Peer, numPeers int, data []byte, err error) {
-	l.mutex.Lock()
-	defer l.mutex.Unlock()
-	if err == nil {
-		hash := types.BytesToHash(data)
-		l.layerHashesRes[layerID][peer] = &peerResult{data: data, err: nil}
-		l.log.WithContext(ctx).With().Debug("received layer hash from peer",
-			layerID,
-			log.String("layerHash", hash.ShortString()),
-			log.String("peer", peer.String()))
-	} else {
-		l.layerHashesRes[layerID][peer] = &peerResult{data: nil, err: err}
-		l.log.WithContext(ctx).With().Debug("received layer hash error from peer",
-			layerID,
-			log.String("peer", peer.String()),
-			log.Err(err))
-	}
-
-	// check if we have all responses from peers
-	result := l.layerHashesRes[layerID]
-	if len(result) < numPeers {
-		l.log.WithContext(ctx).With().Debug("not yet received layer hash from all peers",
-			log.Int("received", len(result)),
-			log.Int("expected", numPeers))
-		return
-	}
-
-	// make a copy of data and channels to avoid holding a lock while notifying
-	go notifyLayerHashResult(layerID, l.layerHashesChs[layerID], result, numPeers, l.log.WithContext(ctx))
-	delete(l.layerHashesChs, layerID)
-	delete(l.layerHashesRes, layerID)
-}
-
-// notifyLayerHashResult aggregates all layer hash responses from peers and notify subscribed channels of the result.
-// if there are too many errors from peers, it reports error instead.
-// it deliberately doesn't hold any lock while notifying channels
-func notifyLayerHashResult(layerID types.LayerID, channels []chan LayerHashResult, peerResult map[peers.Peer]*peerResult, numPeers int, logger log.Log) {
-	logger.With().Debug("got layer hashes. now aggregating", layerID)
-	numErrors := 0
-	// aggregate the peerResult by data
-	hashes := make(map[layerHash][]peers.Peer)
-	for peer, res := range peerResult {
-		if res.err != nil {
-			numErrors++
-		} else {
-			var lyrHash layerHash
-			convertErr := types.BytesToInterface(res.data, &lyrHash)
-			if convertErr != nil {
-				logger.With().Debug("received error converting bytes to layerHash", log.Err(convertErr))
-				numErrors++
-			}
-			hashes[lyrHash] = append(hashes[lyrHash], peer)
-		}
-	}
-	result := LayerHashResult{Hashes: hashes, Err: nil}
-
-	// if more than half the peers returned an error, fail the sync of the entire layer
-	// todo: think whether we should panic here
-	if numErrors > numPeers/2 {
-		logger.With().Error("too many errors from peers",
-			layerID,
-			log.Int("numPeers", numPeers),
-			log.Int("numErrors", numErrors))
-		result.Hashes = nil
-		result.Err = ErrTooManyPeerErrors
-	}
-	for _, ch := range channels {
-		ch <- result
-	}
-}
-
-// PollLayerBlocks polls peers on blocks for given layer hashes. for each layer hash, it requests the blocks from a
-// peer that reported the layer hash previously. it returns a channel for the caller to be notified when responses
-// are received from all peers.
-func (l *Logic) PollLayerBlocks(ctx context.Context, layerID types.LayerID, hashes map[types.Hash32][]peers.Peer) chan LayerPromiseResult {
-	resChannel := make(chan LayerPromiseResult, 1)
 	l.mutex.Lock()
 	l.layerBlocksChs[layerID] = append(l.layerBlocksChs[layerID], resChannel)
 	if _, ok := l.layerBlocksRes[layerID]; ok {
-		// polling of block hashes of  is on-going, just wait for the polling to finish and get notified
+		// polling of block IDs of this layerID is ongoing, just wait for the polling to finish and get notified
 		l.mutex.Unlock()
 		return resChannel
 	}
@@ -404,22 +264,17 @@ func (l *Logic) PollLayerBlocks(ctx context.Context, layerID types.LayerID, hash
 
 	// send a request to the first peer of the list to get blocks data.
 	// todo: think if we should aggregate or ask from multiple peers to have some redundancy in requests
-	numHashes := len(hashes)
-	for hash, remotePeers := range hashes {
-		peer := remotePeers[0]
-		if hash == mesh.EmptyLayerHash {
-			l.receiveBlockHashes(ctx, layerID, peer, numHashes, nil, ErrZeroLayer)
-			continue
-		}
+	for _, p := range remotePeers {
+		peer := p
 		receiveForPeerFunc := func(data []byte) {
-			l.receiveBlockHashes(ctx, layerID, peer, numHashes, data, nil)
+			l.receiveLayerContent(ctx, layerID, peer, numPeers, data, nil)
 		}
 		errFunc := func(err error) {
-			l.receiveBlockHashes(ctx, layerID, peer, numHashes, nil, err)
+			l.receiveLayerContent(ctx, layerID, peer, numPeers, nil, err)
 		}
-		err := l.net.SendRequest(ctx, server.LayerBlocksMsg, hash.Bytes(), peer, receiveForPeerFunc, errFunc)
+		err := l.net.SendRequest(ctx, server.LayerBlocksMsg, layerID.Bytes(), peer, receiveForPeerFunc, errFunc)
 		if err != nil {
-			l.receiveBlockHashes(ctx, layerID, peer, numHashes, nil, err)
+			l.receiveLayerContent(ctx, layerID, peer, numPeers, nil, err)
 		}
 	}
 	return resChannel
@@ -427,51 +282,62 @@ func (l *Logic) PollLayerBlocks(ctx context.Context, layerID types.LayerID, hash
 
 // fetchLayerBlocks fetches the content of the block IDs in the specified layerBlocks
 func (l *Logic) fetchLayerBlocks(ctx context.Context, layerID types.LayerID, blocks *layerBlocks) {
+	l.log.WithContext(ctx).With().Debug("fetching layer blocks", layerID, log.Int("numBlocks", len(blocks.Blocks)))
 	if err := l.GetBlocks(ctx, blocks.Blocks); err != nil {
 		// if there is an error this means that the entire layerID cannot be validated and therefore sync should fail
 		// TODO: fail sync?
 		l.log.WithContext(ctx).With().Debug("error fetching layer blocks", layerID, log.Err(err))
 	}
 
-	if len(blocks.VerifyingVector) > 0 {
+	if len(blocks.InputVector) > 0 {
 		l.log.WithContext(ctx).With().Debug("saving input vector from peer blocks", layerID)
-		err := l.layerDB.SaveLayerInputVectorByID(ctx, layerID, blocks.VerifyingVector)
+		err := l.layerDB.SaveLayerInputVectorByID(ctx, layerID, blocks.InputVector)
 		if err == nil {
 			return
 		}
 		l.log.WithContext(ctx).With().Error("failed to save input vector", layerID, log.Err(err))
-	}
-
-	if !layerID.GetEpoch().IsGenesis() {
+	} else if !layerID.GetEpoch().IsGenesis() {
 		if err := l.GetInputVector(ctx, layerID); err != nil {
 			l.log.WithContext(ctx).With().Debug("error getting input vector", layerID, log.Err(err))
 		}
 	}
 }
 
-// receiveBlockHashes is called when response of block IDs for a layer hash is received from remote peer.
-// if enough responses are received, it notifies the channels waiting for the layer blocks result.
-func (l *Logic) receiveBlockHashes(ctx context.Context, layerID types.LayerID, peer peers.Peer, expectedResults int, data []byte, extErr error) {
-	pRes := &peerResult{err: extErr}
-	if extErr != nil {
-		if !errors.Is(extErr, ErrZeroLayer) || !(layerID.GetEpoch()).IsGenesis() {
-			l.log.WithContext(ctx).With().Error("received error from peer for block hashes", log.Err(extErr), layerID, layerID.GetEpoch())
-		}
-	} else if data != nil {
-		var blocks layerBlocks
-		convertErr := types.BytesToInterface(data, &blocks)
-		if convertErr != nil {
-			l.log.WithContext(ctx).With().Error("error converting bytes to layerBlocks", log.Err(convertErr))
-			pRes.err = convertErr
-		} else {
-			pRes.data = data
-			l.fetchLayerBlocks(ctx, layerID, &blocks)
-		}
+func extractPeerResult(logger log.Log, layerID types.LayerID, data []byte, peerErr error) (result peerResult) {
+	result.err = peerErr
+	if peerErr != nil {
+		logger.With().Debug("received peer error for layer content", layerID, log.Err(peerErr))
+		return
 	}
+
+	var blocks layerBlocks
+	if err := types.BytesToInterface(data, &blocks); err != nil {
+		logger.With().Debug("error converting bytes to layerBlocks", log.Err(err))
+		result.err = err
+		return
+	}
+
+	result.data = &blocks
+	if len(blocks.Blocks) == 0 {
+		result.err = ErrZeroLayer
+	}
+	// TODO check layer hash to be consistent with the content. if not, blacklist the peer
+	return
+}
+
+// receiveLayerContent is called when response of block IDs for a layer hash is received from remote peer.
+// if enough responses are received, it notifies the channels waiting for the layer blocks result.
+func (l *Logic) receiveLayerContent(ctx context.Context, layerID types.LayerID, peer peers.Peer, expectedResults int, data []byte, peerErr error) {
+	l.log.WithContext(ctx).With().Debug("received layer content from peer", log.String("peer", peer.String()))
+	peerRes := extractPeerResult(l.log.WithContext(ctx), layerID, data, peerErr)
+	if peerRes.err == nil {
+		l.fetchLayerBlocks(ctx, layerID, peerRes.data)
+	}
+
 	l.mutex.Lock()
 	defer l.mutex.Unlock()
 
-	l.layerBlocksRes[layerID][peer] = pRes
+	l.layerBlocksRes[layerID][peer] = &peerRes
 
 	// check if we have all responses from peers
 	result := l.layerBlocksRes[layerID]
@@ -496,7 +362,7 @@ func notifyLayerBlocksResult(layerID types.LayerID, channels []chan LayerPromise
 	hasZeroBlockHash := false
 	var firstErr error
 	for _, res := range peerResult {
-		if res.data != nil {
+		if res.err == nil && res.data != nil {
 			// at least one layer hash contains blocks. not a zero block layer
 			result = &LayerPromiseResult{Layer: layerID, Err: nil}
 			break
@@ -517,7 +383,7 @@ func notifyLayerBlocksResult(layerID types.LayerID, channels []chan LayerPromise
 			result.Err = firstErr
 		}
 	}
-	logger.With().Debug("notifying layer blocks result", layerID, log.String("blocks", fmt.Sprintf("%+v", result)))
+	logger.With().Debug("notifying layer blocks result", layerID, log.String("blocks", fmt.Sprintf("%+v", *result)))
 	for _, ch := range channels {
 		ch <- *result
 	}
@@ -564,14 +430,14 @@ func (l *Logic) GetEpochATXs(ctx context.Context, id types.EpochID) error {
 
 // getAtxResults is called when an ATX result is received
 func (l *Logic) getAtxResults(ctx context.Context, hash types.Hash32, data []byte) error {
-	l.log.WithContext(ctx).With().Info("got response for ATX",
+	l.log.WithContext(ctx).With().Debug("got response for ATX",
 		log.String("hash", hash.ShortString()),
 		log.Int("dataSize", len(data)))
 	return l.atxs.HandleAtxData(ctx, data, l)
 }
 
 func (l *Logic) getTxResult(ctx context.Context, hash types.Hash32, data []byte) error {
-	l.log.WithContext(ctx).With().Info("got response for TX",
+	l.log.WithContext(ctx).With().Debug("got response for TX",
 		log.String("hash", hash.ShortString()),
 		log.Int("dataSize", len(data)))
 	return l.txs.HandleTxSyncData(data)
@@ -579,7 +445,7 @@ func (l *Logic) getTxResult(ctx context.Context, hash types.Hash32, data []byte)
 
 // getPoetResult is handler function to poet proof fetch result
 func (l *Logic) getPoetResult(ctx context.Context, hash types.Hash32, data []byte) error {
-	l.log.WithContext(ctx).Info("got poet ref",
+	l.log.WithContext(ctx).Debug("got poet ref",
 		log.String("hash", hash.ShortString()),
 		log.Int("dataSize", len(data)))
 	return l.poetProofs.ValidateAndStoreMsg(data)

--- a/layerfetcher/layers_test.go
+++ b/layerfetcher/layers_test.go
@@ -43,7 +43,6 @@ func randomBlockID() types.BlockID {
 
 type mockNet struct {
 	peers       []peers.Peer
-	layerHashes map[peers.Peer][]byte
 	layerBlocks map[peers.Peer][]byte
 	errors      map[peers.Peer]error
 	timeouts    map[peers.Peer]struct{}
@@ -51,7 +50,6 @@ type mockNet struct {
 
 func newMockNet() *mockNet {
 	return &mockNet{
-		layerHashes: make(map[peers.Peer][]byte),
 		layerBlocks: make(map[peers.Peer][]byte),
 		errors:      make(map[peers.Peer]error),
 		timeouts:    make(map[peers.Peer]struct{}),
@@ -66,11 +64,6 @@ func (m *mockNet) SendRequest(_ context.Context, msgType server.MessageType, _ [
 		return nil
 	}
 	switch msgType {
-	case server.LayerHashMsg:
-		if data, ok := m.layerHashes[address]; ok {
-			resHandler(data)
-			return nil
-		}
 	case server.LayerBlocksMsg:
 		if data, ok := m.layerBlocks[address]; ok {
 			resHandler(data)
@@ -82,36 +75,39 @@ func (m *mockNet) SendRequest(_ context.Context, msgType server.MessageType, _ [
 func (mockNet) Close() {}
 
 type layerDBMock struct {
-	layers    map[types.Hash32][]types.BlockID
-	vectors   map[types.Hash32][]types.BlockID
-	gossip    []types.BlockID
-	hashes    map[types.LayerID]types.Hash32
-	aggHashes map[types.LayerID]types.Hash32
-	processed types.LayerID
+	layers     map[types.LayerID][]types.BlockID
+	vectors    map[types.LayerID][]types.BlockID
+	hashes     map[types.LayerID]types.Hash32
+	aggHashes  map[types.LayerID]types.Hash32
+	processed  types.LayerID
+	unknownErr error
 }
 
 func newLayerDBMock() *layerDBMock {
 	return &layerDBMock{
-		layers:    make(map[types.Hash32][]types.BlockID),
-		vectors:   make(map[types.Hash32][]types.BlockID),
-		gossip:    []types.BlockID{},
+		layers:    make(map[types.LayerID][]types.BlockID),
+		vectors:   make(map[types.LayerID][]types.BlockID),
 		hashes:    make(map[types.LayerID]types.Hash32),
 		aggHashes: make(map[types.LayerID]types.Hash32),
 		processed: types.NewLayerID(10),
 	}
 }
-func (l *layerDBMock) GetLayerInputVector(hash types.Hash32) ([]types.BlockID, error) {
-	return l.vectors[hash], nil
+func (l *layerDBMock) GetLayerInputVectorByID(id types.LayerID) ([]types.BlockID, error) {
+	return l.vectors[id], nil
 }
 func (l *layerDBMock) SaveLayerInputVectorByID(ctx context.Context, id types.LayerID, blocks []types.BlockID) error {
-	l.vectors[types.CalcHash32(id.Bytes())] = blocks
+	l.vectors[id] = blocks
 	return nil
 }
 func (l *layerDBMock) ProcessedLayer() types.LayerID                        { return l.processed }
 func (l *layerDBMock) GetLayerHash(ID types.LayerID) types.Hash32           { return l.hashes[ID] }
 func (l *layerDBMock) GetAggregatedLayerHash(ID types.LayerID) types.Hash32 { return l.aggHashes[ID] }
-func (l *layerDBMock) GetLayerHashBlocks(hash types.Hash32) []types.BlockID { return l.layers[hash] }
-func (l *layerDBMock) Get() []types.BlockID                                 { return l.gossip }
+func (l *layerDBMock) LayerBlockIds(ID types.LayerID) ([]types.BlockID, error) {
+	if l.unknownErr != nil {
+		return nil, l.unknownErr
+	}
+	return l.layers[ID], nil
+}
 
 type mockFetcher struct{}
 
@@ -142,211 +138,104 @@ func (m mockAtx) HandleAtxData(_ context.Context, _ []byte, _ service.Fetcher) e
 	panic("implement me")
 }
 
-func NewMockLogic(net *mockNet, layers layerDB, blocksDB gossipBlocks, blocks blockHandler, atxs atxHandler, fetcher fetch.Fetcher, log log.Log) *Logic {
+func NewMockLogic(net *mockNet, layers layerDB, blocks blockHandler, atxs atxHandler, fetcher fetch.Fetcher, log log.Log) *Logic {
 	l := &Logic{
 		log:            log,
 		fetcher:        fetcher,
 		net:            net,
-		layerHashesRes: make(map[types.LayerID]map[peers.Peer]*peerResult),
-		layerHashesChs: make(map[types.LayerID][]chan LayerHashResult),
 		layerBlocksRes: make(map[types.LayerID]map[peers.Peer]*peerResult),
 		layerBlocksChs: make(map[types.LayerID][]chan LayerPromiseResult),
 		atxs:           atxs,
 		blockHandler:   blocks,
 		layerDB:        layers,
-		gossipBlocks:   blocksDB,
 	}
 	return l
 }
 
-func TestLayerHashReqReceiver(t *testing.T) {
-	db := newLayerDBMock()
-	layerID := types.NewLayerID(1)
-	l := NewMockLogic(newMockNet(), db, db, &mockBlocks{}, &mockAtx{}, &mockFetcher{}, logtest.New(t))
-	hash := randomHash()
-	aggHash := randomHash()
-	db.hashes[layerID] = hash
-	db.aggHashes[layerID] = aggHash
-	out, err := l.layerHashReqReceiver(context.TODO(), layerID.Bytes())
-	require.NoError(t, err)
-	var lyrHash layerHash
-	assert.NoError(t, types.BytesToInterface(out, &lyrHash))
-	assert.Equal(t, db.processed, lyrHash.ProcessedLayer)
-	assert.Equal(t, hash, lyrHash.Hash)
-	assert.Equal(t, aggHash, lyrHash.AggregatedHash)
-}
-
 func TestLayerHashBlocksReqReceiver(t *testing.T) {
 	db := newLayerDBMock()
-	l := NewMockLogic(newMockNet(), db, db, &mockBlocks{}, &mockAtx{}, &mockFetcher{}, logtest.New(t))
-	h := randomHash()
-	db.layers[h] = []types.BlockID{randomBlockID(), randomBlockID(), randomBlockID(), randomBlockID()}
-	db.vectors[h] = []types.BlockID{randomBlockID(), randomBlockID(), randomBlockID()}
+	l := NewMockLogic(newMockNet(), db, &mockBlocks{}, &mockAtx{}, &mockFetcher{}, logtest.New(t))
+	lyrID := types.NewLayerID(100)
+	blockIDs := []types.BlockID{randomBlockID(), randomBlockID(), randomBlockID(), randomBlockID()}
+	db.layers[lyrID] = blockIDs
+	db.hashes[lyrID] = types.CalcBlocksHash32(types.SortBlockIDs(blockIDs), nil)
+	db.aggHashes[lyrID] = randomHash()
+	db.vectors[lyrID] = []types.BlockID{randomBlockID(), randomBlockID(), randomBlockID()}
 
-	out, err := l.layerHashBlocksReqReceiver(context.TODO(), h.Bytes())
+	out, err := l.layerBlocksReqReceiver(context.TODO(), lyrID.Bytes())
 	require.NoError(t, err)
-	var act layerBlocks
-	err = types.BytesToInterface(out, &act)
+	var got layerBlocks
+	err = types.BytesToInterface(out, &got)
 	assert.NoError(t, err)
-	assert.Equal(t, act.Blocks, db.layers[h])
-	assert.Equal(t, act.VerifyingVector, db.vectors[h])
-	assert.Nil(t, act.LatestBlocks)
+	assert.Equal(t, db.layers[lyrID], got.Blocks)
+	assert.Equal(t, db.vectors[lyrID], got.InputVector)
+	assert.Equal(t, db.processed, got.ProcessedLayer)
+	assert.Equal(t, db.hashes[lyrID], got.Hash)
+	assert.Equal(t, db.aggHashes[lyrID], got.AggregatedHash)
 }
 
-func TestPollLayerHash_NoPeers(t *testing.T) {
+func TestLayerHashBlocksReqReceiverEmptyLayer(t *testing.T) {
 	db := newLayerDBMock()
-	l := NewMockLogic(newMockNet(), db, db, &mockBlocks{}, &mockAtx{}, &mockFetcher{}, logtest.New(t))
-	layerID := types.NewLayerID(10)
-	res := <-l.PollLayerHash(context.TODO(), layerID)
-	assert.Equal(t, ErrNoPeers, res.Err)
-	assert.Nil(t, res.Hashes)
-}
+	l := NewMockLogic(newMockNet(), db, &mockBlocks{}, &mockAtx{}, &mockFetcher{}, logtest.New(t))
+	lyrID := types.NewLayerID(100)
+	var blockIDs []types.BlockID
+	db.layers[lyrID] = blockIDs
+	db.hashes[lyrID] = mesh.EmptyLayerHash
+	db.aggHashes[lyrID] = randomHash()
 
-func TestPollLayerHash_TooManyErrors(t *testing.T) {
-	db := newLayerDBMock()
-	net := newMockNet()
-	numPeers := 4
-	for i := 0; i < numPeers; i++ {
-		peer := p2pcrypto.NewRandomPubkey()
-		net.peers = append(net.peers, peer)
-		if i == 0 {
-			net.layerHashes[peer] = randomHash().Bytes()
-		} else {
-			net.errors[peer] = errors.New("SendRequest error")
-		}
-	}
-	l := NewMockLogic(net, db, db, &mockBlocks{}, &mockAtx{}, &mockFetcher{}, logtest.New(t))
-
-	layerID := types.NewLayerID(10)
-	res := <-l.PollLayerHash(context.TODO(), layerID)
-	assert.Equal(t, ErrTooManyPeerErrors, res.Err)
-	assert.Nil(t, res.Hashes)
-}
-
-func TestPollLayerHash_TooManyErrors_Timeout(t *testing.T) {
-	db := newLayerDBMock()
-	net := newMockNet()
-	numPeers := 4
-	for i := 0; i < numPeers; i++ {
-		peer := p2pcrypto.NewRandomPubkey()
-		net.peers = append(net.peers, peer)
-		if i == 0 {
-			net.layerHashes[peer] = randomHash().Bytes()
-		} else {
-			net.timeouts[peer] = struct{}{}
-		}
-	}
-	l := NewMockLogic(net, db, db, &mockBlocks{}, &mockAtx{}, &mockFetcher{}, logtest.New(t))
-
-	layerID := types.NewLayerID(10)
-	res := <-l.PollLayerHash(context.TODO(), layerID)
-	assert.Equal(t, ErrTooManyPeerErrors, res.Err)
-	assert.Nil(t, res.Hashes)
-}
-
-func TestPollLayerHash_SomeError(t *testing.T) {
-	db := newLayerDBMock()
-	net := newMockNet()
-	numPeers := 4
-	lyrHash := layerHash{ProcessedLayer: types.NewLayerID(20), Hash: randomHash(), AggregatedHash: randomHash()}
-	data, err := types.InterfaceToBytes(&lyrHash)
+	out, err := l.layerBlocksReqReceiver(context.TODO(), lyrID.Bytes())
+	require.NoError(t, err)
+	var got layerBlocks
+	err = types.BytesToInterface(out, &got)
 	assert.NoError(t, err)
-	for i := 0; i < numPeers; i++ {
-		peer := p2pcrypto.NewRandomPubkey()
-		net.peers = append(net.peers, peer)
-		if i%2 == 0 {
-			net.errors[peer] = errors.New("SendRequest error")
-		} else {
-			net.layerHashes[peer] = data
-		}
-	}
-	l := NewMockLogic(net, db, db, &mockBlocks{}, &mockAtx{}, &mockFetcher{}, logtest.New(t))
-
-	layerID := types.NewLayerID(10)
-	res := <-l.PollLayerHash(context.TODO(), layerID)
-	assert.Nil(t, res.Err)
-	assert.Equal(t, 1, len(res.Hashes))
-	assert.ElementsMatch(t, []peers.Peer{net.peers[1], net.peers[3]}, res.Hashes[lyrHash])
+	assert.Equal(t, db.layers[lyrID], got.Blocks)
+	assert.Nil(t, got.InputVector)
+	assert.Equal(t, db.processed, got.ProcessedLayer)
+	assert.Equal(t, mesh.EmptyLayerHash, got.Hash)
+	assert.Equal(t, db.aggHashes[lyrID], got.AggregatedHash)
 }
 
-func TestPollLayerHash_SomeTimeout(t *testing.T) {
+func TestLayerHashBlocksReqReceiverUnknownError(t *testing.T) {
 	db := newLayerDBMock()
-	net := newMockNet()
-	numPeers := 4
-	lyrHash := layerHash{ProcessedLayer: types.NewLayerID(20), Hash: randomHash(), AggregatedHash: randomHash()}
-	data, err := types.InterfaceToBytes(&lyrHash)
-	assert.NoError(t, err)
-	for i := 0; i < numPeers; i++ {
-		peer := p2pcrypto.NewRandomPubkey()
-		net.peers = append(net.peers, peer)
-		if i%2 == 0 {
-			net.timeouts[peer] = struct{}{}
-		} else {
-			net.layerHashes[peer] = data
-		}
-	}
-	l := NewMockLogic(net, db, db, &mockBlocks{}, &mockAtx{}, &mockFetcher{}, logtest.New(t))
+	l := NewMockLogic(newMockNet(), db, &mockBlocks{}, &mockAtx{}, &mockFetcher{}, logtest.New(t))
+	lyrID := types.NewLayerID(100)
+	db.unknownErr = database.ErrNotFound
 
-	layerID := types.NewLayerID(10)
-	res := <-l.PollLayerHash(context.TODO(), layerID)
-	assert.Nil(t, res.Err)
-	assert.Equal(t, 1, len(res.Hashes))
-	assert.ElementsMatch(t, []peers.Peer{net.peers[1], net.peers[3]}, res.Hashes[lyrHash])
-}
-
-func TestPollLayerHash_Aggregated(t *testing.T) {
-	db := newLayerDBMock()
-	net := newMockNet()
-	numPeers := 4
-	evenHash := layerHash{ProcessedLayer: types.NewLayerID(20), Hash: randomHash(), AggregatedHash: randomHash()}
-	evenData, err := types.InterfaceToBytes(&evenHash)
-	assert.NoError(t, err)
-	oddHash := layerHash{ProcessedLayer: types.NewLayerID(21), Hash: randomHash(), AggregatedHash: randomHash()}
-	oddData, err := types.InterfaceToBytes(&oddHash)
-	assert.NoError(t, err)
-	for i := 0; i < numPeers; i++ {
-		peer := p2pcrypto.NewRandomPubkey()
-		net.peers = append(net.peers, peer)
-		if i%2 == 0 {
-			net.layerHashes[peer] = evenData
-		} else {
-			net.layerHashes[peer] = oddData
-		}
-	}
-	l := NewMockLogic(net, db, db, &mockBlocks{}, &mockAtx{}, &mockFetcher{}, logtest.New(t))
-
-	layerID := types.NewLayerID(10)
-	res := <-l.PollLayerHash(context.TODO(), layerID)
-	assert.Nil(t, res.Err)
-	assert.Equal(t, numPeers/2, len(res.Hashes))
-	assert.ElementsMatch(t, []peers.Peer{net.peers[0], net.peers[2]}, res.Hashes[evenHash])
-	assert.ElementsMatch(t, []peers.Peer{net.peers[1], net.peers[3]}, res.Hashes[oddHash])
-}
-
-func TestPollLayerHash_AllDifferent(t *testing.T) {
-	db := newLayerDBMock()
-	net := newMockNet()
-	numPeers := 4
-	for i := 0; i < numPeers; i++ {
-		peer := p2pcrypto.NewRandomPubkey()
-		net.peers = append(net.peers, peer)
-		lyrHash := layerHash{ProcessedLayer: types.NewLayerID(20 + uint32(i)), Hash: randomHash(), AggregatedHash: randomHash()}
-		data, err := types.InterfaceToBytes(&lyrHash)
-		assert.NoError(t, err)
-		net.layerHashes[peer] = data
-	}
-	l := NewMockLogic(net, db, db, &mockBlocks{}, &mockAtx{}, &mockFetcher{}, logtest.New(t))
-
-	layerID := types.NewLayerID(10)
-	res := <-l.PollLayerHash(context.TODO(), layerID)
-	assert.Nil(t, res.Err)
-	assert.Equal(t, numPeers, len(res.Hashes))
+	out, err := l.layerBlocksReqReceiver(context.TODO(), lyrID.Bytes())
+	assert.Nil(t, out)
+	assert.Equal(t, err, ErrInternal)
 }
 
 func generateLayerBlocks() []byte {
+	return generateLayerBlocksWithHash(true)
+}
+
+func generateLayerBlocksWithHash(consistentHash bool) []byte {
+	blockIDs := []types.BlockID{randomBlockID(), randomBlockID(), randomBlockID(), randomBlockID()}
+	var hash types.Hash32
+	if consistentHash {
+		hash = types.CalcBlocksHash32(types.SortBlockIDs(blockIDs), nil)
+	} else {
+		hash = randomHash()
+	}
 	lb := layerBlocks{
-		Blocks:          []types.BlockID{randomBlockID(), randomBlockID(), randomBlockID(), randomBlockID()},
-		VerifyingVector: []types.BlockID{randomBlockID(), randomBlockID(), randomBlockID()},
+		Blocks:         blockIDs,
+		InputVector:    []types.BlockID{randomBlockID(), randomBlockID(), randomBlockID()},
+		ProcessedLayer: types.NewLayerID(10),
+		Hash:           hash,
+		AggregatedHash: randomHash(),
+	}
+	out, _ := types.InterfaceToBytes(lb)
+	return out
+}
+
+func generateEmptyLayer() []byte {
+	lb := layerBlocks{
+		Blocks:         []types.BlockID{},
+		InputVector:    nil,
+		ProcessedLayer: types.NewLayerID(10),
+		Hash:           mesh.EmptyLayerHash,
+		AggregatedHash: randomHash(),
 	}
 	out, _ := types.InterfaceToBytes(lb)
 	return out
@@ -361,17 +250,10 @@ func TestPollLayerBlocks_AllHaveBlockData(t *testing.T) {
 		net.peers = append(net.peers, peer)
 		net.layerBlocks[peer] = generateLayerBlocks()
 	}
-	l := NewMockLogic(net, db, db, &mockBlocks{}, &mockAtx{}, &mockFetcher{}, logtest.New(t))
+	l := NewMockLogic(net, db, &mockBlocks{}, &mockAtx{}, &mockFetcher{}, logtest.New(t))
 
 	layerID := types.NewLayerID(10)
-	// currently first peer for each hash is queried
-	layerHashes := map[types.Hash32][]peers.Peer{
-		randomHash(): {net.peers[2]},
-		randomHash(): {net.peers[1], net.peers[0]},
-		randomHash(): {net.peers[3]},
-	}
-
-	res := <-l.PollLayerBlocks(context.TODO(), layerID, layerHashes)
+	res := <-l.PollLayerContent(context.TODO(), layerID)
 	assert.Nil(t, res.Err)
 	assert.Equal(t, layerID, res.Layer)
 }
@@ -391,17 +273,10 @@ func TestPollLayerBlocks_OnlyOneHasBlockData(t *testing.T) {
 			net.errors[peer] = errors.New("SendRequest error")
 		}
 	}
-	l := NewMockLogic(net, db, db, &mockBlocks{}, &mockAtx{}, &mockFetcher{}, logtest.New(t))
+	l := NewMockLogic(net, db, &mockBlocks{}, &mockAtx{}, &mockFetcher{}, logtest.New(t))
 
 	layerID := types.NewLayerID(10)
-	// currently first peer for each hash is queried
-	layerHashes := map[types.Hash32][]peers.Peer{
-		randomHash(): {net.peers[2]},
-		randomHash(): {net.peers[1], net.peers[0]},
-		randomHash(): {net.peers[3]},
-	}
-
-	res := <-l.PollLayerBlocks(context.TODO(), layerID, layerHashes)
+	res := <-l.PollLayerContent(context.TODO(), layerID)
 	assert.Nil(t, res.Err)
 	assert.Equal(t, layerID, res.Layer)
 }
@@ -415,19 +290,16 @@ func TestPollLayerBlocks_OneZeroLayerAmongstErrors(t *testing.T) {
 	for i := 0; i < numPeers; i++ {
 		peer := p2pcrypto.NewRandomPubkey()
 		net.peers = append(net.peers, peer)
-		net.errors[peer] = errors.New("SendRequest error")
+		if i == numPeers-1 {
+			net.layerBlocks[peer] = generateEmptyLayer()
+		} else {
+			net.errors[peer] = errors.New("SendRequest error")
+		}
 	}
-	l := NewMockLogic(net, db, db, &mockBlocks{}, &mockAtx{}, &mockFetcher{}, logtest.New(t))
+	l := NewMockLogic(net, db, &mockBlocks{}, &mockAtx{}, &mockFetcher{}, logtest.New(t))
 
 	layerID := types.NewLayerID(10)
-	// currently first peer for each hash is queried
-	layerHashes := map[types.Hash32][]peers.Peer{
-		mesh.EmptyLayerHash: {net.peers[2]},
-		randomHash():        {net.peers[1], net.peers[0]},
-		randomHash():        {net.peers[3]},
-	}
-
-	res := <-l.PollLayerBlocks(context.TODO(), layerID, layerHashes)
+	res := <-l.PollLayerContent(context.TODO(), layerID)
 	assert.Equal(t, ErrZeroLayer, res.Err)
 	assert.Equal(t, layerID, res.Layer)
 }
@@ -439,17 +311,12 @@ func TestPollLayerBlocks_ZeroLayer(t *testing.T) {
 	for i := 0; i < numPeers; i++ {
 		peer := p2pcrypto.NewRandomPubkey()
 		net.peers = append(net.peers, peer)
-		net.errors[peer] = errors.New("SendRequest error")
+		net.layerBlocks[peer] = generateEmptyLayer()
 	}
-	l := NewMockLogic(net, db, db, &mockBlocks{}, &mockAtx{}, &mockFetcher{}, logtest.New(t))
+	l := NewMockLogic(net, db, &mockBlocks{}, &mockAtx{}, &mockFetcher{}, logtest.New(t))
 
 	layerID := types.NewLayerID(10)
-	// currently first peer for each hash is queried
-	layerHashes := map[types.Hash32][]peers.Peer{
-		mesh.EmptyLayerHash: {net.peers[2], net.peers[1], net.peers[0], net.peers[3]},
-	}
-
-	res := <-l.PollLayerBlocks(context.TODO(), layerID, layerHashes)
+	res := <-l.PollLayerContent(context.TODO(), layerID)
 	assert.Equal(t, ErrZeroLayer, res.Err)
 	assert.Equal(t, layerID, res.Layer)
 }

--- a/layerfetcher/wire_types.go
+++ b/layerfetcher/wire_types.go
@@ -2,18 +2,16 @@ package layerfetcher
 
 import "github.com/spacemeshos/go-spacemesh/common/types"
 
-type layerHash struct {
+// layerBlocks is the response for a given layer ID
+type layerBlocks struct {
+	// Blocks are the blocks in a layer
+	Blocks []types.BlockID
+	// InputVector is the input vector for verifying tortoise
+	InputVector []types.BlockID
 	// ProcessedLayer is the latest processed layer from peer
 	ProcessedLayer types.LayerID
 	// Hash is the hash of contextually valid blocks (sorted by block ID) in the given layer
 	Hash types.Hash32
 	// AggregatedHash is the aggregated hash of all layers up to the given layer
 	AggregatedHash types.Hash32
-}
-
-// layerBlocks is the response for a given layer hash
-type layerBlocks struct {
-	Blocks          []types.BlockID
-	LatestBlocks    []types.BlockID // LatestBlocks are the blocks received in the last 30 seconds from gossip
-	VerifyingVector []types.BlockID // VerifyingVector is the input vector for verifying tortoise
 }

--- a/mesh/mesh.go
+++ b/mesh/mesh.go
@@ -241,7 +241,7 @@ func (msh *Mesh) GetLayerHash(layerID types.LayerID) types.Hash32 {
 			return lyr.Hash()
 		}
 	}
-	return EmptyLayerHash
+	return types.EmptyLayerHash
 }
 
 // ProcessedLayer returns the last processed layer ID
@@ -586,7 +586,7 @@ func (msh *Mesh) calcAggregatedLayerHash(layer *types.Layer, prevHash types.Hash
 
 func (msh *Mesh) calcSimpleLayerHash(layer *types.Layer) types.Hash32 {
 	if len(layer.Blocks()) == 0 {
-		return EmptyLayerHash
+		return types.EmptyLayerHash
 	}
 	validBlocks, _ := msh.BlocksByValidity(layer.Blocks())
 	return types.CalcBlocksHash32(types.SortBlockIDs(types.BlockIDs(validBlocks)), nil)
@@ -605,14 +605,14 @@ func (msh *Mesh) persistAggregatedLayerHash(layerID types.LayerID, hash types.Ha
 func (msh *Mesh) GetAggregatedLayerHash(layerID types.LayerID) types.Hash32 {
 	h, err := msh.getAggregatedLayerHash(layerID)
 	if err != nil {
-		return EmptyLayerHash
+		return types.EmptyLayerHash
 	}
 	return h
 }
 
 func (msh *Mesh) getAggregatedLayerHash(layerID types.LayerID) (types.Hash32, error) {
 	if layerID.Before(types.NewLayerID(1)) {
-		return EmptyLayerHash, nil
+		return types.EmptyLayerHash, nil
 	}
 	var hash types.Hash32
 	bts, err := msh.general.Get(getAggregatedLayerHashKey(layerID))

--- a/mesh/mesh.go
+++ b/mesh/mesh.go
@@ -124,6 +124,9 @@ func NewMesh(db *DB, atxDb AtxDB, rewardConfig Config, trtl tortoise, txPool txM
 	}
 
 	msh.Validator = &validator{Mesh: msh}
+	for lyr := types.NewLayerID(1); lyr.Before(types.GetEffectiveGenesis()); lyr = lyr.Add(1) {
+		msh.SetZeroBlockLayer(lyr)
+	}
 	return msh
 }
 
@@ -621,21 +624,6 @@ func (msh *Mesh) getAggregatedLayerHash(layerID types.LayerID) (types.Hash32, er
 		return hash, nil
 	}
 	return hash, err
-}
-
-// GetLayerHashBlocks returns blocks for given hash
-func (msh *Mesh) GetLayerHashBlocks(h types.Hash32) []types.BlockID {
-	layerIDBytes, err := msh.general.Get(h.Bytes())
-	if err != nil {
-		msh.With().Warning("requested unknown layer hash", log.String("hash", h.ShortString()))
-		return []types.BlockID{}
-	}
-	l := types.BytesToLayerID(layerIDBytes)
-	mBlocks, err := msh.LayerBlockIds(l)
-	if err != nil {
-		return []types.BlockID{}
-	}
-	return mBlocks
 }
 
 func (msh *Mesh) extractUniqueOrderedTransactions(l *types.Layer) (validBlockTxs []*types.Transaction) {

--- a/mesh/mesh.go
+++ b/mesh/mesh.go
@@ -124,9 +124,6 @@ func NewMesh(db *DB, atxDb AtxDB, rewardConfig Config, trtl tortoise, txPool txM
 	}
 
 	msh.Validator = &validator{Mesh: msh}
-	for lyr := types.NewLayerID(1); lyr.Before(types.GetEffectiveGenesis()); lyr = lyr.Add(1) {
-		msh.SetZeroBlockLayer(lyr)
-	}
 	return msh
 }
 

--- a/mesh/mesh_test.go
+++ b/mesh/mesh_test.go
@@ -161,6 +161,18 @@ func addLayer(r *require.Assertions, id types.LayerID, layerSize int, msh *Mesh)
 	return l
 }
 
+func TestMesh_GenesisLayersSaved(t *testing.T) {
+	msh := getMesh(t, "genesis layers")
+	t.Cleanup(func() {
+		msh.Close()
+	})
+	for i := types.NewLayerID(1); i.Before(types.GetEffectiveGenesis()); i = i.Add(1) {
+		lyr, err := msh.GetLayer(i)
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(lyr.Blocks()))
+	}
+}
+
 func TestMesh_GetLayerHash(t *testing.T) {
 	r := require.New(t)
 	msh := getMesh(t, "get layer hash")
@@ -168,7 +180,7 @@ func TestMesh_GetLayerHash(t *testing.T) {
 		msh.Close()
 	})
 
-	lyrID := types.NewLayerID(1)
+	lyrID := types.GetEffectiveGenesis().Add(1)
 	lyr, err := msh.GetLayer(lyrID)
 	r.Equal(database.ErrNotFound, err)
 	r.Nil(lyr)
@@ -216,7 +228,7 @@ func TestMesh_SetZeroBlockLayer(t *testing.T) {
 		msh.Close()
 	})
 
-	lyrID := types.NewLayerID(1)
+	lyrID := types.GetEffectiveGenesis().Add(1)
 	lyr, err := msh.GetLayer(lyrID)
 	r.Equal(database.ErrNotFound, err)
 	r.Nil(lyr)
@@ -244,7 +256,7 @@ func TestMesh_AddLayerGetLayer(t *testing.T) {
 		msh.Close()
 	})
 
-	id := types.NewLayerID(1)
+	id := types.GetEffectiveGenesis().Add(1)
 	_, err := msh.GetLayer(id)
 	r.EqualError(err, database.ErrNotFound.Error())
 

--- a/mesh/mesh_test.go
+++ b/mesh/mesh_test.go
@@ -222,7 +222,7 @@ func TestMesh_SetZeroBlockLayer(t *testing.T) {
 	r.Nil(lyr)
 	err = msh.SetZeroBlockLayer(lyrID)
 	assert.NoError(t, err)
-	assert.Equal(t, EmptyLayerHash, msh.GetLayerHash(lyrID))
+	assert.Equal(t, types.EmptyLayerHash, msh.GetLayerHash(lyrID))
 
 	// it's ok to add to an empty layer
 	lyr = addLayer(r, lyrID, 10, msh)
@@ -269,7 +269,7 @@ func TestMesh_GetAggregatedLayerHash(t *testing.T) {
 	})
 
 	gLyr := types.GetEffectiveGenesis()
-	prevHash := EmptyLayerHash
+	prevHash := types.EmptyLayerHash
 	for i := types.NewLayerID(1); i.Before(gLyr); i = i.Add(1) {
 		lyr := addLayer(r, i, 0, msh)
 		msh.ValidateLayer(context.TODO(), lyr)
@@ -312,7 +312,7 @@ func TestMesh_ProcessedLayer(t *testing.T) {
 	}
 	prevHash := types.Hash32{}
 	for _, lyr := range lyrs {
-		assert.Equal(t, EmptyLayerHash, msh.GetLayerHash(lyr.Index()))
+		assert.Equal(t, types.EmptyLayerHash, msh.GetLayerHash(lyr.Index()))
 		msh.setProcessedLayer(lyr)
 		expectedHash := types.CalcBlocksHash32([]types.BlockID{}, prevHash.Bytes())
 		assert.Equal(t, lyr.Index(), msh.ProcessedLayer())

--- a/mesh/mesh_test.go
+++ b/mesh/mesh_test.go
@@ -161,18 +161,6 @@ func addLayer(r *require.Assertions, id types.LayerID, layerSize int, msh *Mesh)
 	return l
 }
 
-func TestMesh_GenesisLayersSaved(t *testing.T) {
-	msh := getMesh(t, "genesis layers")
-	t.Cleanup(func() {
-		msh.Close()
-	})
-	for i := types.NewLayerID(1); i.Before(types.GetEffectiveGenesis()); i = i.Add(1) {
-		lyr, err := msh.GetLayer(i)
-		assert.NoError(t, err)
-		assert.Equal(t, 0, len(lyr.Blocks()))
-	}
-}
-
 func TestMesh_GetLayerHash(t *testing.T) {
 	r := require.New(t)
 	msh := getMesh(t, "get layer hash")

--- a/mesh/meshdb.go
+++ b/mesh/meshdb.go
@@ -303,14 +303,11 @@ func (m *DB) LayerBlockIds(index types.LayerID) ([]types.BlockID, error) {
 	return nil, database.ErrNotFound
 }
 
-// EmptyLayerHash is the layer hash for an empty layer
-var EmptyLayerHash = types.Hash32{}
-
 // AddZeroBlockLayer tags lyr as a layer without blocks
 func (m *DB) AddZeroBlockLayer(index types.LayerID) error {
 	err := m.layers.Put(index.Bytes(), nil)
 	if err == nil {
-		m.persistLayerHash(index, EmptyLayerHash)
+		m.persistLayerHash(index, types.EmptyLayerHash)
 	}
 	return err
 }
@@ -470,10 +467,10 @@ func (m *DB) updateLayerWithBlock(blk *types.Block) error {
 }
 
 func (m *DB) recoverLayerHash(layerID types.LayerID) (types.Hash32, error) {
-	h := EmptyLayerHash
+	h := types.EmptyLayerHash
 	bts, err := m.general.Get(getLayerHashKey(layerID))
 	if err != nil {
-		return EmptyLayerHash, err
+		return types.EmptyLayerHash, err
 	}
 	h.SetBytes(bts)
 	return h, nil

--- a/mesh/meshdb.go
+++ b/mesh/meshdb.go
@@ -376,19 +376,6 @@ func (m *DB) GetCoinflip(_ context.Context, layerID types.LayerID) (bool, bool) 
 	return coin, exists
 }
 
-// GetLayerInputVector gets the input vote vector for a layer (hare results)
-func (m *DB) GetLayerInputVector(hash types.Hash32) ([]types.BlockID, error) {
-	buf, err := m.inputVector.Get(hash.Bytes())
-	if err != nil {
-		return nil, err
-	}
-	var ids []types.BlockID
-	if err := codec.Decode(buf, &ids); err != nil {
-		return nil, err
-	}
-	return ids, nil
-}
-
 // InputVectorBackupFunc specifies a backup function for testing
 type InputVectorBackupFunc func(id types.LayerID) ([]types.BlockID, error)
 
@@ -397,11 +384,15 @@ func (m *DB) GetLayerInputVectorByID(layerID types.LayerID) ([]types.BlockID, er
 	if m.InputVectorBackupFunc != nil {
 		return m.InputVectorBackupFunc(layerID)
 	}
-	// check if this layer was marked invalid
-	if _, ok := m.invalidatedLayers[layerID]; ok {
-		return nil, ErrInvalidLayer
+	buf, err := m.inputVector.Get(layerID.Bytes())
+	if err != nil {
+		return nil, err
 	}
-	return m.GetLayerInputVector(types.CalcHash32(layerID.Bytes()))
+	var ids []types.BlockID
+	if err := codec.Decode(buf, &ids); err != nil {
+		return nil, err
+	}
+	return ids, nil
 }
 
 // SetInputVectorBackupFunc sets the backup function for testing
@@ -416,17 +407,13 @@ func (m *DB) GetInputVectorBackupFunc() InputVectorBackupFunc {
 
 // SaveLayerInputVectorByID gets the input vote vector for a layer (hare results)
 func (m *DB) SaveLayerInputVectorByID(ctx context.Context, id types.LayerID, blks []types.BlockID) error {
-	hash := types.CalcHash32(id.Bytes())
-	m.WithContext(ctx).With().Info("saving input vector",
-		id,
-		log.String("iv_hash", hash.ShortString()))
-
+	m.WithContext(ctx).With().Debug("saving input vector", id)
 	// NOTE(dshulyak) there is an implicit dependency in fetcher
 	buf, err := codec.Encode(blks)
 	if err != nil {
 		return err
 	}
-	return m.inputVector.Put(hash.Bytes(), buf)
+	return m.inputVector.Put(id.Bytes(), buf)
 }
 
 func (m *DB) persistProcessedLayer(lyr *ProcessedLayer) error {
@@ -494,13 +481,6 @@ func (m *DB) recoverLayerHash(layerID types.LayerID) (types.Hash32, error) {
 
 func (m *DB) persistLayerHash(layerID types.LayerID, hash types.Hash32) {
 	if err := m.general.Put(getLayerHashKey(layerID), hash.Bytes()); err != nil {
-		m.With().Error("failed to persist layer hash", log.Err(err), layerID,
-			log.String("layer_hash", hash.ShortString()))
-	}
-
-	// we store a double index here because most of the code uses layer ID as key, currently only sync reads layer by hash
-	// when this changes we can simply point to the layes
-	if err := m.general.Put(hash.Bytes(), layerID.Bytes()); err != nil {
 		m.With().Error("failed to persist layer hash", log.Err(err), layerID,
 			log.String("layer_hash", hash.ShortString()))
 	}

--- a/p2p/server/msgserver.go
+++ b/p2p/server/msgserver.go
@@ -25,8 +25,6 @@ const (
 	PingPong MessageType = iota
 	// GetAddresses is the findnode protocol ID
 	GetAddresses
-	// LayerHashMsg is used to fetch layer hash for a given layer ID
-	LayerHashMsg
 	// LayerBlocksMsg is used to fetch block IDs for a given layer hash
 	LayerBlocksMsg
 	// AtxIDsMsg is used to fetch ATXs for a given epoch

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -349,7 +349,7 @@ func (s *Syncer) syncLayer(ctx context.Context, layerID types.LayerID) (*types.L
 			s.logger.WithContext(ctx).With().Panic("failed to get genesis layer", layerID, log.Err(err))
 		}
 	} else {
-		s.logger.WithContext(ctx).With().Debug("polling layer from peers", layerID)
+		s.logger.WithContext(ctx).With().Info("polling layer content", layerID)
 		if layer, err = s.getLayerFromPeers(ctx, layerID); err != nil {
 			return nil, err
 		}

--- a/syncer/syncer_test.go
+++ b/syncer/syncer_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/log/logtest"
 	"github.com/spacemeshos/go-spacemesh/mesh"
-	"github.com/spacemeshos/go-spacemesh/p2p/peers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -52,39 +51,30 @@ func (mlt *mockLayerTicker) LayerToTime(_ types.LayerID) time.Time {
 }
 
 type mockFetcher struct {
-	mu         sync.Mutex
-	polled     map[types.LayerID]chan struct{}
-	hashResult map[types.LayerID]chan layerfetcher.LayerHashResult
-	result     map[types.LayerID]chan layerfetcher.LayerPromiseResult
-	atxsError  map[types.EpochID]error
-	atxsCalls  uint32
-	tbError    map[types.EpochID]error
-	tbCalls    uint32
+	mu        sync.Mutex
+	polled    map[types.LayerID]chan struct{}
+	result    map[types.LayerID]chan layerfetcher.LayerPromiseResult
+	atxsError map[types.EpochID]error
+	atxsCalls uint32
+	tbError   map[types.EpochID]error
+	tbCalls   uint32
 }
 
 func newMockFetcher() *mockFetcher {
 	numLayers := layersPerEpoch * 5
 	polled := make(map[types.LayerID]chan struct{}, numLayers)
-	hashResult := make(map[types.LayerID]chan layerfetcher.LayerHashResult, numLayers)
 	result := make(map[types.LayerID]chan layerfetcher.LayerPromiseResult, numLayers)
 	for i := uint32(0); i <= uint32(numLayers); i++ {
 		polled[types.NewLayerID(i)] = make(chan struct{}, 10)
-		hashResult[types.NewLayerID(i)] = make(chan layerfetcher.LayerHashResult, 10)
 		result[types.NewLayerID(i)] = make(chan layerfetcher.LayerPromiseResult, 10)
 	}
-	return &mockFetcher{hashResult: hashResult, result: result, polled: polled, atxsError: make(map[types.EpochID]error), tbError: make(map[types.EpochID]error)}
+	return &mockFetcher{result: result, polled: polled, atxsError: make(map[types.EpochID]error), tbError: make(map[types.EpochID]error)}
 }
 
-func (mf *mockFetcher) PollLayerHash(_ context.Context, layerID types.LayerID) chan layerfetcher.LayerHashResult {
+func (mf *mockFetcher) PollLayerContent(_ context.Context, layerID types.LayerID) chan layerfetcher.LayerPromiseResult {
 	mf.mu.Lock()
 	defer mf.mu.Unlock()
 	mf.polled[layerID] <- struct{}{}
-	return mf.hashResult[layerID]
-}
-
-func (mf *mockFetcher) PollLayerBlocks(_ context.Context, layerID types.LayerID, _ map[types.Hash32][]peers.Peer) chan layerfetcher.LayerPromiseResult {
-	mf.mu.Lock()
-	defer mf.mu.Unlock()
 	return mf.result[layerID]
 }
 
@@ -108,12 +98,6 @@ func (mf *mockFetcher) getLayerPollChan(layerID types.LayerID) chan struct{} {
 	return mf.polled[layerID]
 }
 
-func (mf *mockFetcher) getLayerHashResultChan(layerID types.LayerID) chan layerfetcher.LayerHashResult {
-	mf.mu.Lock()
-	defer mf.mu.Unlock()
-	return mf.hashResult[layerID]
-}
-
 func (mf *mockFetcher) getLayerResultChan(layerID types.LayerID) chan layerfetcher.LayerPromiseResult {
 	mf.mu.Lock()
 	defer mf.mu.Unlock()
@@ -126,7 +110,6 @@ func (mf *mockFetcher) feedLayerResult(from, to types.LayerID) {
 		if i == types.GetEffectiveGenesis() {
 			err = nil
 		}
-		mf.getLayerHashResultChan(i) <- layerfetcher.LayerHashResult{}
 		mf.getLayerResultChan(i) <- layerfetcher.LayerPromiseResult{
 			Layer: i,
 			Err:   err,
@@ -272,7 +255,6 @@ func TestSynchronize_getLayerFromPeersFailed(t *testing.T) {
 	}()
 
 	// this will cause getLayerFromPeers to return an error
-	mf.getLayerHashResultChan(types.NewLayerID(1)) <- layerfetcher.LayerHashResult{}
 	mf.getLayerResultChan(types.NewLayerID(1)) <- layerfetcher.LayerPromiseResult{
 		Layer: types.NewLayerID(1),
 		Err:   errors.New("something baaahhhhhhd"),
@@ -419,7 +401,6 @@ func TestSynchronize_SyncZeroBlockFailed(t *testing.T) {
 
 	mf.feedLayerResult(types.NewLayerID(0), gLayer.Sub(1))
 	// genesis block has data. this LayerPromiseResult will cause SetZeroBlockLayer() to fail
-	mf.getLayerHashResultChan(gLayer) <- layerfetcher.LayerHashResult{}
 	mf.getLayerResultChan(gLayer) <- layerfetcher.LayerPromiseResult{
 		Layer: gLayer,
 		Err:   layerfetcher.ErrZeroLayer,


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
Closes #2693
Closes #2704
<!-- `Closes #XXXX, closes #XXXX, ...` links mentioned issues to this PR and automatically closes them when this it's merged -->

## Changes
<!-- Please describe in detail the changes made -->
- remove the step that query layer hashes and directly query layer contents by layer ID

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->
unit tests

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
