### PR TITLE
[Merged by Bors] - only calculate layer aggregated hash after block validity is determined

### DIFF
--- a/mesh/mesh_test.go
+++ b/mesh/mesh_test.go
@@ -47,7 +47,8 @@ func (m *ContextualValidityMock) Close() {
 }
 
 type MeshValidatorMock struct {
-	mdb *DB
+	mdb          *DB
+	lastComplete types.LayerID
 }
 
 func (m *MeshValidatorMock) Persist(context.Context) error {
@@ -161,52 +162,121 @@ func addLayer(r *require.Assertions, id types.LayerID, layerSize int, msh *Mesh)
 	return l
 }
 
-func TestMesh_GetLayerHash(t *testing.T) {
+func TestMesh_LayerHash(t *testing.T) {
 	r := require.New(t)
-	msh := getMesh(t, "get layer hash")
+	msh := getMesh(t, "layerHash")
 	t.Cleanup(func() {
 		msh.Close()
 	})
 
-	lyrID := types.GetEffectiveGenesis().Add(1)
-	lyr, err := msh.GetLayer(lyrID)
-	r.Equal(database.ErrNotFound, err)
-	r.Nil(lyr)
+	gLyr := types.GetEffectiveGenesis()
+	for i := types.NewLayerID(1); i.Before(gLyr); i = i.Add(1) {
+		msh.SetZeroBlockLayer(i)
+	}
+	latestLyr := gLyr.Add(5)
+	for i := gLyr.Add(1); !i.After(latestLyr); i = i.Add(1) {
+		numBlocks := 10 * i.Uint32()
+		lyr := addLayer(r, i, int(numBlocks), msh)
+		// make the first block of each layer invalid
+		msh.SaveContextualValidity(lyr.Blocks()[0].ID(), lyr.Index(), false)
+	}
 
-	numBlocks := 10
-	lyr = addLayer(r, lyrID, numBlocks, msh)
-	r.NoError(msh.SaveContextualValidity(lyr.Blocks()[0].ID(), lyrID, false))
+	for i := types.NewLayerID(1); !i.After(latestLyr); i = i.Add(1) {
+		thisLyr, err := msh.GetLayer(i)
+		r.NoError(err)
+		if !i.After(gLyr) {
+			// nothing is validated by tortoise before genesis layer
+			msh.ValidateLayer(context.TODO(), thisLyr)
+			if i.Before(gLyr) {
+				assert.Equal(t, types.EmptyLayerHash, msh.GetLayerHash(i))
+				assert.Equal(t, types.EmptyLayerHash, thisLyr.Hash())
+			} else {
+				assert.Equal(t, thisLyr.Hash(), msh.GetLayerHash(i))
+			}
+			continue
+		}
 
-	// before a layer is validated, all blocks count towards its hash, valid or not
-	lyr, err = msh.GetLayer(lyrID)
-	r.NoError(err)
-	assert.Equal(t, numBlocks, len(lyr.Blocks()))
-	assert.Equal(t, lyr.Hash(), msh.GetLayerHash(lyrID))
+		// only layers before "lyr" will have their block contextual validity determined
+		prevLyr, err := msh.GetLayer(i.Sub(1))
+		r.NoError(err)
+		assert.Equal(t, prevLyr.Hash(), msh.GetLayerHash(i.Sub(1)))
+		assert.Equal(t, thisLyr.Hash(), msh.GetLayerHash(i))
+		msh.ValidateLayer(context.TODO(), thisLyr)
+		// contextual validity is still not determined for thisLyr, so hash is still calculated from all blocks
+		assert.Equal(t, thisLyr.Hash(), msh.GetLayerHash(i))
+		// but for previous layer hash should already be changed to contain only valid blocks
+		if prevLyr.Index() == gLyr {
+			// genesis blocks are all valid
+			expHash := types.CalcBlocksHash32(types.SortBlockIDs(types.BlockIDs(prevLyr.Blocks())), nil)
+			actHash := msh.GetLayerHash(prevLyr.Index())
+			assert.Equal(t, expHash, actHash)
+			assert.Equal(t, prevLyr.Hash(), actHash)
+		} else {
+			expHash := types.CalcBlocksHash32(types.SortBlockIDs(types.BlockIDs(prevLyr.Blocks()[1:])), nil)
+			actHash := msh.GetLayerHash(prevLyr.Index())
+			assert.Equal(t, expHash, actHash)
+			assert.NotEqual(t, prevLyr.Hash(), actHash)
+		}
+	}
+}
 
-	validBlocks := lyr.Blocks()[1:]
-	msh.ValidateLayer(context.TODO(), lyr)
-	// after a layer is validated, only contextually valid blocks count towards its hash
-	expHash := types.CalcBlocksHash32(types.SortBlockIDs(types.BlockIDs(validBlocks)), nil)
-	assert.Equal(t, expHash, msh.GetLayerHash(lyrID))
-	assert.NotEqual(t, expHash, lyr.Hash())
+func TestMesh_GetAggregatedLayerHash(t *testing.T) {
+	r := require.New(t)
+	msh := getMesh(t, "aggLayerHash")
+	t.Cleanup(func() {
+		msh.Close()
+	})
 
-	// if a late block is received and is considered invalid. hash does not change
-	txIDs, _ := addManyTXsToPool(r, msh, 10)
-	block := types.NewExistingBlock(lyrID, []byte(rand.String(8)), txIDs)
-	block.Initialize()
-	err = msh.AddBlockWithTxs(context.TODO(), block)
-	r.NoError(err)
-	lyr, err = msh.GetLayer(lyrID)
-	r.NoError(err)
-	assert.Equal(t, numBlocks+1, len(lyr.Blocks()))
-	msh.ValidateLayer(context.TODO(), lyr)
-	assert.Equal(t, expHash, msh.GetLayerHash(lyrID))
+	gLyr := types.GetEffectiveGenesis()
+	for i := types.NewLayerID(1); i.Before(gLyr); i = i.Add(1) {
+		msh.SetZeroBlockLayer(i)
+	}
+	latestLyr := gLyr.Add(5)
+	for i := gLyr.Add(1); !i.After(latestLyr); i = i.Add(1) {
+		numBlocks := 10 * i.Uint32()
+		lyr := addLayer(r, i, int(numBlocks), msh)
+		// make the first block of each layer invalid
+		msh.SaveContextualValidity(lyr.Blocks()[0].ID(), lyr.Index(), false)
+	}
 
-	// now if the late block is determined valid, the hash should be updated
-	r.NoError(msh.SaveContextualValidity(block.ID(), lyrID, true))
-	msh.ValidateLayer(context.TODO(), lyr)
-	newExpectedHash := types.CalcBlocksHash32(types.SortBlockIDs(types.BlockIDs(append(validBlocks, block))), nil)
-	assert.Equal(t, newExpectedHash, msh.GetLayerHash(lyrID))
+	prevAggHash := types.EmptyLayerHash
+	for i := types.NewLayerID(1); !i.After(latestLyr); i = i.Add(1) {
+		thisLyr, err := msh.GetLayer(i)
+		r.NoError(err)
+		if i.Before(gLyr) {
+			// nothing is validated by tortoise before genesis layer
+			msh.ValidateLayer(context.TODO(), thisLyr)
+			assert.Equal(t, types.EmptyLayerHash, msh.GetAggregatedLayerHash(i))
+			continue
+		}
+
+		r.Equal(types.EmptyLayerHash, msh.GetAggregatedLayerHash(i.Sub(1)))
+		r.Equal(types.EmptyLayerHash, msh.GetAggregatedLayerHash(i))
+		msh.ValidateLayer(context.TODO(), thisLyr)
+		// contextual validity is still not determined for thisLyr, so aggregated hash is not calculated for this layer
+		r.Equal(types.EmptyLayerHash, msh.GetAggregatedLayerHash(i))
+		// but for previous layer hash should already be changed to contain only valid blocks
+		var expHash types.Hash32
+		if i == gLyr {
+			// aggregated layer hash for genesis layers should be computed now
+			for j := types.NewLayerID(1); j.Before(gLyr); j = j.Add(1) {
+				expHash = types.CalcBlocksHash32([]types.BlockID{}, prevAggHash.Bytes())
+				assert.Equal(t, expHash, msh.GetAggregatedLayerHash(j))
+				prevAggHash = expHash
+			}
+		} else {
+			prevLyr, err := msh.GetLayer(i.Sub(1))
+			r.NoError(err)
+			if prevLyr.Index() == gLyr {
+				// all genesis blocks are valid
+				expHash = types.CalcBlocksHash32(types.SortBlockIDs(types.BlockIDs(prevLyr.Blocks())), prevAggHash.Bytes())
+			} else {
+				expHash = types.CalcBlocksHash32(types.SortBlockIDs(types.BlockIDs(prevLyr.Blocks()[1:])), prevAggHash.Bytes())
+			}
+			assert.Equal(t, expHash, msh.GetAggregatedLayerHash(prevLyr.Index()))
+			prevAggHash = expHash
+		}
+	}
 }
 
 func TestMesh_SetZeroBlockLayer(t *testing.T) {
@@ -261,41 +331,6 @@ func TestMesh_AddLayerGetLayer(t *testing.T) {
 	r.Equal(3, len(lyr.Blocks()))
 }
 
-func TestMesh_GetAggregatedLayerHash(t *testing.T) {
-	r := require.New(t)
-	msh := getMesh(t, "aggregated hash")
-	t.Cleanup(func() {
-		msh.Close()
-	})
-
-	gLyr := types.GetEffectiveGenesis()
-	prevHash := types.EmptyLayerHash
-	for i := types.NewLayerID(1); i.Before(gLyr); i = i.Add(1) {
-		lyr := addLayer(r, i, 0, msh)
-		msh.ValidateLayer(context.TODO(), lyr)
-		aggHash := types.CalcBlocksHash32([]types.BlockID{}, prevHash.Bytes())
-		assert.Equal(t, aggHash, msh.GetAggregatedLayerHash(lyr.Index()))
-		prevHash = aggHash
-	}
-	lyr, err := msh.GetLayer(gLyr)
-	r.NoError(err)
-	assert.Equal(t, 1, len(lyr.Blocks()))
-	msh.ValidateLayer(context.TODO(), lyr)
-	aggHash := types.CalcBlocksHash32(types.SortBlockIDs(types.BlockIDs(lyr.Blocks())), prevHash.Bytes())
-	assert.Equal(t, aggHash, msh.GetAggregatedLayerHash(lyr.Index()))
-	prevHash = aggHash
-
-	// add a layer with some invalid blocks
-	lyrID := gLyr.Add(1)
-	lyr = addLayer(r, lyrID, 5, msh)
-	r.Equal(5, len(lyr.Blocks()))
-	r.NoError(msh.SaveContextualValidity(lyr.Blocks()[0].ID(), lyrID, false))
-	msh.ValidateLayer(context.TODO(), lyr)
-	// aggregated layer hash only includes valid blocks
-	aggHash = types.CalcBlocksHash32(types.SortBlockIDs(types.BlockIDs(lyr.Blocks()[1:])), prevHash.Bytes())
-	assert.Equal(t, aggHash, msh.GetAggregatedLayerHash(lyr.Index()))
-}
-
 func TestMesh_ProcessedLayer(t *testing.T) {
 	r := require.New(t)
 	msh := getMesh(t, "processed layer")
@@ -310,34 +345,17 @@ func TestMesh_ProcessedLayer(t *testing.T) {
 		lyr := addLayer(r, i, 0, msh)
 		lyrs = append(lyrs, lyr)
 	}
-	prevHash := types.Hash32{}
+	lyr, err := msh.GetLayer(gLyr)
+	r.NoError(err)
+	lyrs = append(lyrs, lyr)
 	for _, lyr := range lyrs {
-		assert.Equal(t, types.EmptyLayerHash, msh.GetLayerHash(lyr.Index()))
-		msh.setProcessedLayer(lyr)
-		expectedHash := types.CalcBlocksHash32([]types.BlockID{}, prevHash.Bytes())
+		msh.ValidateLayer(context.TODO(), lyr)
 		assert.Equal(t, lyr.Index(), msh.ProcessedLayer())
 		// make sure processed layer is persisted
 		pLyr, err := msh.recoverProcessedLayer()
 		assert.NoError(t, err)
 		assert.Equal(t, lyr.Index(), pLyr)
-		prevHash = expectedHash
 	}
-
-	// effective genesis layer
-	_, err := msh.recoverLayerHash(gLyr)
-	assert.Equal(t, database.ErrNotFound, err)
-	lyr, err := msh.GetLayer(gLyr)
-	r.NoError(err)
-	msh.setProcessedLayer(lyr)
-	h := types.CalcBlocksHash32(types.SortBlockIDs(types.BlockIDs(lyr.Blocks())), nil)
-	assert.Equal(t, h, msh.GetLayerHash(lyr.Index()))
-	expectedHash := types.CalcBlocksHash32(types.SortBlockIDs(types.BlockIDs(lyr.Blocks())), prevHash.Bytes())
-	assert.Equal(t, lyr.Index(), msh.ProcessedLayer())
-	// make sure processed layer is persisted
-	pLyr, err := msh.recoverProcessedLayer()
-	r.NoError(err)
-	assert.Equal(t, lyr.Index(), pLyr)
-	prevHash = expectedHash
 
 	gPlus1 := addLayer(r, gLyr.Add(1), 1, msh)
 	gPlus2 := addLayer(r, gLyr.Add(2), 2, msh)
@@ -345,36 +363,22 @@ func TestMesh_ProcessedLayer(t *testing.T) {
 	gPlus4 := addLayer(r, gLyr.Add(4), 4, msh)
 	gPlus5 := addLayer(r, gLyr.Add(5), 5, msh)
 
-	_, err = msh.recoverLayerHash(gPlus1.Index())
-	assert.Equal(t, database.ErrNotFound, err)
-	msh.setProcessedLayer(gPlus1)
-	h = types.CalcBlocksHash32(types.SortBlockIDs(types.BlockIDs(gPlus1.Blocks())), nil)
-	assert.Equal(t, h, msh.GetLayerHash(gPlus1.Index()))
-	expectedHash = types.CalcBlocksHash32(types.SortBlockIDs(types.BlockIDs(gPlus1.Blocks())), prevHash.Bytes())
+	msh.ValidateLayer(context.TODO(), gPlus1)
 	assert.Equal(t, gPlus1.Index(), msh.ProcessedLayer())
 	// make sure processed layer is persisted
-	pLyr, err = msh.recoverProcessedLayer()
+	pLyr, err := msh.recoverProcessedLayer()
 	r.NoError(err)
 	assert.Equal(t, gPlus1.Index(), pLyr)
-	prevHash = expectedHash
 
 	// set gPlus3 and gPlus5 out of order
-	_, err = msh.recoverLayerHash(gPlus3.Index())
-	assert.Equal(t, database.ErrNotFound, err)
-	msh.setProcessedLayer(gPlus3)
-	h = types.CalcBlocksHash32(types.SortBlockIDs(types.BlockIDs(gPlus3.Blocks())), nil)
-	assert.Equal(t, h, msh.GetLayerHash(gPlus3.Index()))
+	msh.ValidateLayer(context.TODO(), gPlus3)
 	// processed layer should not advance
 	assert.Equal(t, gPlus1.Index(), msh.ProcessedLayer())
 	pLyr, err = msh.recoverProcessedLayer()
 	r.NoError(err)
 	assert.Equal(t, gPlus1.Index(), pLyr)
 
-	_, err = msh.recoverLayerHash(gPlus5.Index())
-	assert.Equal(t, database.ErrNotFound, err)
-	msh.setProcessedLayer(gPlus5)
-	h = types.CalcBlocksHash32(types.SortBlockIDs(types.BlockIDs(gPlus5.Blocks())), nil)
-	assert.Equal(t, h, msh.GetLayerHash(gPlus5.Index()))
+	msh.ValidateLayer(context.TODO(), gPlus5)
 	// processed layer should not advance
 	assert.Equal(t, gPlus1.Index(), msh.ProcessedLayer())
 	pLyr, err = msh.recoverProcessedLayer()
@@ -382,74 +386,28 @@ func TestMesh_ProcessedLayer(t *testing.T) {
 	assert.Equal(t, gPlus1.Index(), pLyr)
 
 	// setting gPlus2 will bring the processed layer to gPlus3
-	_, err = msh.recoverLayerHash(gPlus2.Index())
-	assert.Equal(t, database.ErrNotFound, err)
-	msh.setProcessedLayer(gPlus2)
-	h = types.CalcBlocksHash32(types.SortBlockIDs(types.BlockIDs(gPlus2.Blocks())), nil)
-	assert.Equal(t, h, msh.GetLayerHash(gPlus2.Index()))
-	gPlus2Hash := types.CalcBlocksHash32(types.SortBlockIDs(types.BlockIDs(gPlus2.Blocks())), prevHash.Bytes())
-	expectedHash = types.CalcBlocksHash32(types.SortBlockIDs(types.BlockIDs(gPlus3.Blocks())), gPlus2Hash.Bytes())
+	msh.ValidateLayer(context.TODO(), gPlus2)
 	assert.Equal(t, gPlus3.Index(), msh.ProcessedLayer())
 	// make sure processed layer is persisted
 	pLyr, err = msh.recoverProcessedLayer()
 	r.NoError(err)
 	assert.Equal(t, gPlus3.Index(), pLyr)
-	prevHash = expectedHash
 
 	// setting gPlus4 will bring the processed layer to gPlus5
-	_, err = msh.recoverLayerHash(gPlus4.Index())
-	assert.Equal(t, database.ErrNotFound, err)
-	msh.setProcessedLayer(gPlus4)
-	h = types.CalcBlocksHash32(types.SortBlockIDs(types.BlockIDs(gPlus4.Blocks())), nil)
-	assert.Equal(t, h, msh.GetLayerHash(gPlus4.Index()))
-	gPlus4Hash := types.CalcBlocksHash32(types.SortBlockIDs(types.BlockIDs(gPlus4.Blocks())), prevHash.Bytes())
-	expectedHash = types.CalcBlocksHash32(types.SortBlockIDs(types.BlockIDs(gPlus5.Blocks())), gPlus4Hash.Bytes())
+	msh.ValidateLayer(context.TODO(), gPlus4)
 	assert.Equal(t, gPlus5.Index(), msh.ProcessedLayer())
 	// make sure processed layer is persisted
 	pLyr, err = msh.recoverProcessedLayer()
 	r.NoError(err)
 	assert.Equal(t, gPlus5.Index(), pLyr)
-	prevHash = expectedHash
 
 	// setting it to an older layer should have no effect
-	h, err = msh.recoverLayerHash(gPlus2.Index())
-	assert.NoError(t, err)
-	msh.setProcessedLayer(gPlus2)
-	assert.Equal(t, h, msh.GetLayerHash(gPlus2.Index()))
+	msh.ValidateLayer(context.TODO(), gPlus2)
 	assert.Equal(t, gPlus5.Index(), msh.ProcessedLayer())
 	// make sure processed layer is persisted
 	pLyr, err = msh.recoverProcessedLayer()
 	r.NoError(err)
 	assert.Equal(t, gPlus5.Index(), pLyr)
-
-	// add a couple more blocks to gPlus3
-	aggHash1, _ := msh.getAggregatedLayerHash(gPlus1.Index())
-	aggHash2, _ := msh.getAggregatedLayerHash(gPlus2.Index())
-	aggHash3, _ := msh.getAggregatedLayerHash(gPlus3.Index())
-	aggHash4, _ := msh.getAggregatedLayerHash(gPlus4.Index())
-	aggHash5, _ := msh.getAggregatedLayerHash(gPlus5.Index())
-	gPlus3 = addLayer(r, gLyr.Add(3), 2, msh)
-	oldHash, err := msh.recoverLayerHash(gPlus2.Index())
-	assert.NoError(t, err)
-	msh.setProcessedLayer(gPlus3)
-	h = types.CalcBlocksHash32(types.SortBlockIDs(types.BlockIDs(gPlus3.Blocks())), nil)
-	assert.Equal(t, h, msh.GetLayerHash(gPlus3.Index()))
-	assert.NotEqual(t, oldHash, msh.GetLayerHash(gPlus3.Index()))
-	assert.Equal(t, gPlus5.Index(), msh.ProcessedLayer())
-	for i, hash := range []types.Hash32{aggHash1, aggHash2, aggHash3, aggHash4, aggHash5} {
-		lyr := gLyr.Add(uint32(i + 1))
-		aggHash, _ := msh.getAggregatedLayerHash(lyr)
-		if i < 2 {
-			assert.Equal(t, hash, aggHash, i)
-		} else {
-			assert.NotEqual(t, hash, aggHash, i)
-			layer, err := msh.GetLayer(lyr)
-			r.NoError(err)
-			expectedHash = types.CalcBlocksHash32(types.SortBlockIDs(types.BlockIDs(layer.Blocks())), prevHash.Bytes())
-			assert.Equal(t, expectedHash, aggHash)
-		}
-		prevHash = aggHash
-	}
 }
 
 func TestMesh_PersistProcessedLayer(t *testing.T) {

--- a/mesh/mesh_test.go
+++ b/mesh/mesh_test.go
@@ -316,12 +316,10 @@ func TestMesh_ProcessedLayer(t *testing.T) {
 		msh.setProcessedLayer(lyr)
 		expectedHash := types.CalcBlocksHash32([]types.BlockID{}, prevHash.Bytes())
 		assert.Equal(t, lyr.Index(), msh.ProcessedLayer())
-		assert.Equal(t, expectedHash, msh.ProcessedLayerHash())
 		// make sure processed layer is persisted
 		pLyr, err := msh.recoverProcessedLayer()
 		assert.NoError(t, err)
-		assert.Equal(t, lyr.Index(), pLyr.ID)
-		assert.Equal(t, expectedHash, pLyr.Hash)
+		assert.Equal(t, lyr.Index(), pLyr)
 		prevHash = expectedHash
 	}
 
@@ -335,12 +333,10 @@ func TestMesh_ProcessedLayer(t *testing.T) {
 	assert.Equal(t, h, msh.GetLayerHash(lyr.Index()))
 	expectedHash := types.CalcBlocksHash32(types.SortBlockIDs(types.BlockIDs(lyr.Blocks())), prevHash.Bytes())
 	assert.Equal(t, lyr.Index(), msh.ProcessedLayer())
-	assert.Equal(t, expectedHash, msh.ProcessedLayerHash())
 	// make sure processed layer is persisted
 	pLyr, err := msh.recoverProcessedLayer()
 	r.NoError(err)
-	assert.Equal(t, lyr.Index(), pLyr.ID)
-	assert.Equal(t, expectedHash, pLyr.Hash)
+	assert.Equal(t, lyr.Index(), pLyr)
 	prevHash = expectedHash
 
 	gPlus1 := addLayer(r, gLyr.Add(1), 1, msh)
@@ -356,12 +352,10 @@ func TestMesh_ProcessedLayer(t *testing.T) {
 	assert.Equal(t, h, msh.GetLayerHash(gPlus1.Index()))
 	expectedHash = types.CalcBlocksHash32(types.SortBlockIDs(types.BlockIDs(gPlus1.Blocks())), prevHash.Bytes())
 	assert.Equal(t, gPlus1.Index(), msh.ProcessedLayer())
-	assert.Equal(t, expectedHash, msh.ProcessedLayerHash())
 	// make sure processed layer is persisted
 	pLyr, err = msh.recoverProcessedLayer()
 	r.NoError(err)
-	assert.Equal(t, gPlus1.Index(), pLyr.ID)
-	assert.Equal(t, expectedHash, pLyr.Hash)
+	assert.Equal(t, gPlus1.Index(), pLyr)
 	prevHash = expectedHash
 
 	// set gPlus3 and gPlus5 out of order
@@ -372,11 +366,9 @@ func TestMesh_ProcessedLayer(t *testing.T) {
 	assert.Equal(t, h, msh.GetLayerHash(gPlus3.Index()))
 	// processed layer should not advance
 	assert.Equal(t, gPlus1.Index(), msh.ProcessedLayer())
-	assert.Equal(t, prevHash, msh.ProcessedLayerHash())
 	pLyr, err = msh.recoverProcessedLayer()
 	r.NoError(err)
-	assert.Equal(t, gPlus1.Index(), pLyr.ID)
-	assert.Equal(t, expectedHash, pLyr.Hash)
+	assert.Equal(t, gPlus1.Index(), pLyr)
 
 	_, err = msh.recoverLayerHash(gPlus5.Index())
 	assert.Equal(t, database.ErrNotFound, err)
@@ -385,11 +377,9 @@ func TestMesh_ProcessedLayer(t *testing.T) {
 	assert.Equal(t, h, msh.GetLayerHash(gPlus5.Index()))
 	// processed layer should not advance
 	assert.Equal(t, gPlus1.Index(), msh.ProcessedLayer())
-	assert.Equal(t, prevHash, msh.ProcessedLayerHash())
 	pLyr, err = msh.recoverProcessedLayer()
 	r.NoError(err)
-	assert.Equal(t, gPlus1.Index(), pLyr.ID)
-	assert.Equal(t, expectedHash, pLyr.Hash)
+	assert.Equal(t, gPlus1.Index(), pLyr)
 
 	// setting gPlus2 will bring the processed layer to gPlus3
 	_, err = msh.recoverLayerHash(gPlus2.Index())
@@ -400,12 +390,10 @@ func TestMesh_ProcessedLayer(t *testing.T) {
 	gPlus2Hash := types.CalcBlocksHash32(types.SortBlockIDs(types.BlockIDs(gPlus2.Blocks())), prevHash.Bytes())
 	expectedHash = types.CalcBlocksHash32(types.SortBlockIDs(types.BlockIDs(gPlus3.Blocks())), gPlus2Hash.Bytes())
 	assert.Equal(t, gPlus3.Index(), msh.ProcessedLayer())
-	assert.Equal(t, expectedHash, msh.ProcessedLayerHash())
 	// make sure processed layer is persisted
 	pLyr, err = msh.recoverProcessedLayer()
 	r.NoError(err)
-	assert.Equal(t, gPlus3.Index(), pLyr.ID)
-	assert.Equal(t, expectedHash, pLyr.Hash)
+	assert.Equal(t, gPlus3.Index(), pLyr)
 	prevHash = expectedHash
 
 	// setting gPlus4 will bring the processed layer to gPlus5
@@ -417,12 +405,10 @@ func TestMesh_ProcessedLayer(t *testing.T) {
 	gPlus4Hash := types.CalcBlocksHash32(types.SortBlockIDs(types.BlockIDs(gPlus4.Blocks())), prevHash.Bytes())
 	expectedHash = types.CalcBlocksHash32(types.SortBlockIDs(types.BlockIDs(gPlus5.Blocks())), gPlus4Hash.Bytes())
 	assert.Equal(t, gPlus5.Index(), msh.ProcessedLayer())
-	assert.Equal(t, expectedHash, msh.ProcessedLayerHash())
 	// make sure processed layer is persisted
 	pLyr, err = msh.recoverProcessedLayer()
 	r.NoError(err)
-	assert.Equal(t, gPlus5.Index(), pLyr.ID)
-	assert.Equal(t, expectedHash, pLyr.Hash)
+	assert.Equal(t, gPlus5.Index(), pLyr)
 	prevHash = expectedHash
 
 	// setting it to an older layer should have no effect
@@ -431,12 +417,10 @@ func TestMesh_ProcessedLayer(t *testing.T) {
 	msh.setProcessedLayer(gPlus2)
 	assert.Equal(t, h, msh.GetLayerHash(gPlus2.Index()))
 	assert.Equal(t, gPlus5.Index(), msh.ProcessedLayer())
-	assert.Equal(t, prevHash, msh.ProcessedLayerHash())
 	// make sure processed layer is persisted
 	pLyr, err = msh.recoverProcessedLayer()
 	r.NoError(err)
-	assert.Equal(t, gPlus5.Index(), pLyr.ID)
-	assert.Equal(t, expectedHash, pLyr.Hash)
+	assert.Equal(t, gPlus5.Index(), pLyr)
 
 	// add a couple more blocks to gPlus3
 	aggHash1, _ := msh.getAggregatedLayerHash(gPlus1.Index())
@@ -464,9 +448,6 @@ func TestMesh_ProcessedLayer(t *testing.T) {
 			expectedHash = types.CalcBlocksHash32(types.SortBlockIDs(types.BlockIDs(layer.Blocks())), prevHash.Bytes())
 			assert.Equal(t, expectedHash, aggHash)
 		}
-		if i == 5 {
-			assert.Equal(t, hash, msh.ProcessedLayerHash())
-		}
 		prevHash = aggHash
 	}
 }
@@ -476,14 +457,11 @@ func TestMesh_PersistProcessedLayer(t *testing.T) {
 	t.Cleanup(func() {
 		msh.Close()
 	})
-	lyr := &ProcessedLayer{
-		ID:   types.NewLayerID(3),
-		Hash: types.CalcHash32([]byte("layer 3 hash")),
-	}
-	assert.NoError(t, msh.persistProcessedLayer(lyr))
+	layerID := types.NewLayerID(3)
+	assert.NoError(t, msh.persistProcessedLayer(layerID))
 	rLyr, err := msh.recoverProcessedLayer()
 	assert.NoError(t, err)
-	assert.Equal(t, lyr, rLyr)
+	assert.Equal(t, layerID, rLyr)
 }
 
 func TestMesh_LatestKnownLayer(t *testing.T) {

--- a/mesh/mesh_test.go
+++ b/mesh/mesh_test.go
@@ -440,11 +440,12 @@ func TestMesh_WakeUp(t *testing.T) {
 		msh.Close()
 	})
 
+	gLyr := types.GetEffectiveGenesis()
 	r := require.New(t)
 	txIDs1, _ := addManyTXsToPool(r, msh, 4)
 	txIDs2, _ := addManyTXsToPool(r, msh, 3)
-	block1 := types.NewExistingBlock(types.NewLayerID(1), []byte("data1"), txIDs1)
-	block2 := types.NewExistingBlock(types.NewLayerID(2), []byte("data2"), txIDs2)
+	block1 := types.NewExistingBlock(gLyr.Add(1), []byte("data1"), txIDs1)
+	block2 := types.NewExistingBlock(gLyr.Add(2), []byte("data2"), txIDs2)
 
 	assert.NoError(t, msh.AddBlockWithTxs(context.TODO(), block1))
 	assert.NoError(t, msh.AddBlockWithTxs(context.TODO(), block2))

--- a/mesh/mesh_test.go
+++ b/mesh/mesh_test.go
@@ -171,6 +171,21 @@ func addLayer(r *require.Assertions, id types.LayerID, layerSize int, msh *Mesh)
 	return l
 }
 
+func TestMesh_LayerBlocksSortedByIDs(t *testing.T) {
+	r := require.New(t)
+	msh := getMesh(t, "blockIDs")
+	t.Cleanup(func() {
+		msh.Close()
+	})
+	lyr := addLayer(r, types.GetEffectiveGenesis().Add(19), 100, msh)
+	blockIDs := types.BlockIDs(lyr.Blocks())
+	outOfSort := blockIDs[1:]
+	outOfSort = append(outOfSort, blockIDs[0])
+	sorted := types.SortBlockIDs(blockIDs)
+	assert.Equal(t, sorted, blockIDs)
+	assert.NotEqual(t, sorted, outOfSort)
+}
+
 func TestMesh_LayerHash(t *testing.T) {
 	r := require.New(t)
 	msh := getMesh(t, "layerHash")

--- a/mesh/meshdb.go
+++ b/mesh/meshdb.go
@@ -406,11 +406,7 @@ func (m *DB) SaveLayerInputVectorByID(ctx context.Context, id types.LayerID, blk
 }
 
 func (m *DB) persistProcessedLayer(layerID types.LayerID) error {
-	if err := m.general.Put(constPROCESSED, layerID.Bytes()); err != nil {
-		return err
-	}
-	m.With().Debug("persisted processed layer", layerID)
-	return nil
+	return m.general.Put(constPROCESSED, layerID.Bytes())
 }
 
 func (m *DB) recoverProcessedLayer() (types.LayerID, error) {
@@ -457,11 +453,12 @@ func (m *DB) recoverLayerHash(layerID types.LayerID) (types.Hash32, error) {
 	return h, nil
 }
 
-func (m *DB) persistLayerHash(layerID types.LayerID, hash types.Hash32) {
-	if err := m.general.Put(getLayerHashKey(layerID), hash.Bytes()); err != nil {
-		m.With().Error("failed to persist layer hash", log.Err(err), layerID,
-			log.String("layer_hash", hash.ShortString()))
-	}
+func (m *DB) persistLayerHash(layerID types.LayerID, hash types.Hash32) error {
+	return m.general.Put(getLayerHashKey(layerID), hash.Bytes())
+}
+
+func (m *DB) persistAggregatedLayerHash(layerID types.LayerID, hash types.Hash32) error {
+	return m.general.Put(getAggregatedLayerHashKey(layerID), hash.Bytes())
 }
 
 func getRewardKey(l types.LayerID, account types.Address, smesherID types.NodeID) []byte {

--- a/mesh/meshdb.go
+++ b/mesh/meshdb.go
@@ -301,11 +301,7 @@ func (m *DB) LayerBlockIds(index types.LayerID) ([]types.BlockID, error) {
 
 // AddZeroBlockLayer tags lyr as a layer without blocks
 func (m *DB) AddZeroBlockLayer(index types.LayerID) error {
-	err := m.layers.Put(index.Bytes(), nil)
-	if err == nil {
-		m.persistLayerHash(index, types.EmptyLayerHash)
-	}
-	return err
+	return m.layers.Put(index.Bytes(), nil)
 }
 
 func (m *DB) getBlockBytes(id types.BlockID) ([]byte, error) {

--- a/mesh/reward_test.go
+++ b/mesh/reward_test.go
@@ -2,17 +2,16 @@ package mesh
 
 import (
 	"context"
-	"github.com/stretchr/testify/require"
 	"math/big"
 	"strconv"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/log/logtest"
 	"github.com/spacemeshos/go-spacemesh/rand"
 	"github.com/spacemeshos/go-spacemesh/signing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var goldenATXID = types.ATXID(types.HexToHash32("77777"))
@@ -153,20 +152,25 @@ func NewTestRewardParams() Config {
 	}
 }
 
-func createLayer(t testing.TB, mesh *Mesh, id types.LayerID, numOfBlocks, maxTransactions int, atxDB *AtxDbMock) (totalRewards int64, blocks []*types.Block) {
-	for i := 0; i < numOfBlocks; i++ {
-		block1 := types.NewExistingBlock(id, []byte(rand.String(8)), nil)
-		nodeID := types.NodeID{Key: strconv.Itoa(i), VRFPublicKey: []byte("bbbbb")}
-		coinbase := types.HexToAddress(nodeID.Key)
-		atx := newActivationTx(nodeID, 0, goldenATXID, types.NewLayerID(1), 0, goldenATXID, coinbase, 10, []types.BlockID{}, &types.NIPost{})
-		atxDB.AddAtx(atx.ID(), atx)
-		block1.ATXID = atx.ID()
+func createBlock(t testing.TB, mesh *Mesh, lyrID types.LayerID, nodeID types.NodeID, maxTransactions int, atxDB *AtxDbMock) (*types.Block, int64) {
+	blk := types.NewExistingBlock(lyrID, []byte(rand.String(8)), nil)
+	coinbase := types.HexToAddress(nodeID.Key)
+	atx := newActivationTx(nodeID, 0, goldenATXID, types.NewLayerID(1), 0, goldenATXID, coinbase, 10, []types.BlockID{}, &types.NIPost{})
+	atxDB.AddAtx(atx.ID(), atx)
+	blk.ATXID = atx.ID()
+	reward := addTransactionsWithFee(t, mesh.DB, blk, rand.Intn(maxTransactions), rand.Int63n(100))
+	blk.Initialize()
+	err := mesh.AddBlock(blk)
+	assert.NoError(t, err)
+	return blk, reward
+}
 
-		totalRewards += addTransactionsWithFee(t, mesh.DB, block1, rand.Intn(maxTransactions), rand.Int63n(100))
-		block1.Initialize()
-		err := mesh.AddBlock(block1)
-		assert.NoError(t, err)
-		blocks = append(blocks, block1)
+func createLayer(t testing.TB, mesh *Mesh, lyrID types.LayerID, numOfBlocks, maxTransactions int, atxDB *AtxDbMock) (totalRewards int64, blocks []*types.Block) {
+	for i := 0; i < numOfBlocks; i++ {
+		nodeID := types.NodeID{Key: strconv.Itoa(i), VRFPublicKey: []byte("bbbbb")}
+		blk, reward := createBlock(t, mesh, lyrID, nodeID, maxTransactions, atxDB)
+		blocks = append(blocks, blk)
+		totalRewards += reward
 	}
 	return totalRewards, blocks
 }
@@ -197,99 +201,190 @@ func TestMesh_integration(t *testing.T) {
 	assert.True(t, totalPayout-s.TotalReward < int64(numOfBlocks), " rewards : %v, total %v blocks %v", totalPayout, s.TotalReward, int64(numOfBlocks))
 }
 
-func TestMesh_updateStateWithLayer(t *testing.T) {
-	// test states are the same when one input is from tortoise and the other from hare
-	// test state is the same if receiving result from tortoise after same result from hare received
-	// test state is the same after late block
-	// test panic after block from hare was not found in mesh
-	// test that state does not advance when layer x+2 is received before layer x+1, and then test that all layers are pushed
-	numOfLayers := 10
+func createMeshFromSyncing(t *testing.T, finalLyr types.LayerID, msh *Mesh, atxDB *AtxDbMock) {
 	numOfBlocks := 10
 	maxTxs := 20
-
-	s := &MockMapState{Rewards: make(map[types.Address]*big.Int)}
-	mesh, atxDB := getMeshWithMapState(t, "t1", s)
-	defer mesh.Close()
-
-	startLayer := types.GetEffectiveGenesis()
-
-	for i := 0; i < numOfLayers; i++ {
-		layerID := startLayer.Add(uint32(i))
-		createLayer(t, mesh, layerID, numOfBlocks, maxTxs, atxDB)
-		l, err := mesh.GetLayer(layerID)
+	gLyr := types.GetEffectiveGenesis()
+	for i := types.NewLayerID(1); !i.After(finalLyr); i = i.Add(1) {
+		if i.After(gLyr) {
+			createLayer(t, msh, i, numOfBlocks, maxTxs, atxDB)
+		}
+		lyr, err := msh.GetLayer(i)
 		require.NoError(t, err)
-		mesh.ValidateLayer(context.TODO(), l)
+		msh.ValidateLayer(context.TODO(), lyr)
 	}
+}
 
+func createMeshFromHareOutput(t *testing.T, finalLyr types.LayerID, msh *Mesh, atxDB *AtxDbMock) {
+	numOfBlocks := 10
+	maxTxs := 20
+	gLyr := types.GetEffectiveGenesis()
+	for i := types.NewLayerID(1); !i.After(finalLyr); i = i.Add(1) {
+		if i.After(gLyr) {
+			createLayer(t, msh, i, numOfBlocks, maxTxs, atxDB)
+		}
+		lyr, err := msh.GetLayer(i)
+		require.NoError(t, err)
+		msh.HandleValidatedLayer(context.TODO(), i, lyr.BlocksIDs())
+	}
+}
+
+// test states are the same when one input is data polled from peers and the other from hare's output
+func TestMesh_updateStateWithLayer_SyncingAndHareReachSameState(t *testing.T) {
+	gLyr := types.GetEffectiveGenesis()
+	finalLyr := gLyr.Add(10)
+
+	// s1 is the state where a node advance its state via syncing with peers
+	s1 := &MockMapState{Rewards: make(map[types.Address]*big.Int)}
+	msh1, atxDB := getMeshWithMapState(t, "t1", s1)
+	t.Cleanup(func() {
+		msh1.Close()
+	})
+	createMeshFromSyncing(t, finalLyr, msh1, atxDB)
+
+	// s2 is the state where the node advances its state via hare output
 	s2 := &MockMapState{Rewards: make(map[types.Address]*big.Int)}
-	mesh2, atxDB2 := getMeshWithMapState(t, "t2", s2)
+	msh2, atxDB2 := getMeshWithMapState(t, "t2", s2)
+	t.Cleanup(func() {
+		msh2.Close()
+	})
 
-	// this should be played until numOfLayers-1 if we want to compare states
-	for i := 0; i < numOfLayers-1; i++ {
-		layerID := startLayer.Add(uint32(i))
-		blockIds := copyLayer(t, mesh, mesh2, atxDB2, layerID)
-		mesh2.HandleValidatedLayer(context.TODO(), layerID, blockIds)
+	// use hare output to advance state to finalLyr
+	for i := gLyr.Add(1); !i.After(finalLyr); i = i.Add(1) {
+		blockIds := copyLayer(t, msh1, msh2, atxDB2, i)
+		msh2.HandleValidatedLayer(context.TODO(), i, blockIds)
 	}
 
-	// test states are the same when one input is from tortoise and the other from hare
-	require.NotEqual(t, s.Txs, s2.Txs)
+	// s1 (sync from peers) and s2 (advance via hare output) should have the same state
+	require.Equal(t, s1.Txs, s2.Txs)
+	require.Greater(t, len(s1.Txs), 0)
+}
 
-	layerIDFinal := startLayer.Add(uint32(numOfLayers - 1))
-	copyLayer(t, mesh, mesh2, atxDB2, layerIDFinal)
-	l, err := mesh.GetLayer(layerIDFinal)
+// test state is the same after same result received from hare
+func TestMesh_updateStateWithLayer_SameInputFromHare(t *testing.T) {
+	gLyr := types.GetEffectiveGenesis()
+	finalLyr := gLyr.Add(10)
+
+	// s is the state where a node advance its state via syncing with peers
+	s := &MockMapState{Rewards: make(map[types.Address]*big.Int)}
+	msh, atxDB := getMeshWithMapState(t, "t2", s)
+	t.Cleanup(func() {
+		msh.Close()
+	})
+	createMeshFromSyncing(t, finalLyr, msh, atxDB)
+	oldTxs := make([]*types.Transaction, len(s.Txs))
+	copy(oldTxs, s.Txs)
+	require.Greater(t, len(oldTxs), 0)
+
+	// then hare outputs the same result
+	lyr, err := msh.GetLayer(finalLyr)
 	require.NoError(t, err)
-	mesh2.ValidateLayer(context.TODO(), l)
+	msh.HandleValidatedLayer(context.TODO(), finalLyr, lyr.BlocksIDs())
 
-	// test states are the same when one input is from tortoise and the other from hare
-	require.Equal(t, s.Txs, s2.Txs)
+	// s2 state should be unchanged
+	require.Equal(t, oldTxs, s.Txs)
+}
 
-	// test state is the same if receiving result from tortoise after same result from hare received
-	assert.ObjectsAreEqualValues(s.Txs, s2.Txs)
+// test state is the same after same result received from syncing with peers
+func TestMesh_updateStateWithLayer_SameInputFromSyncing(t *testing.T) {
+	gLyr := types.GetEffectiveGenesis()
+	finalLyr := gLyr.Add(10)
 
-	// test state is the same after late block
-	layer4, err := mesh.GetLayer(startLayer.Add(4))
+	// s is the state where a node advance its state via syncing with peers
+	s := &MockMapState{Rewards: make(map[types.Address]*big.Int)}
+	msh, atxDB := getMeshWithMapState(t, "t1", s)
+	t.Cleanup(func() {
+		msh.Close()
+	})
+	createMeshFromHareOutput(t, finalLyr, msh, atxDB)
+	oldTxs := make([]*types.Transaction, len(s.Txs))
+	copy(oldTxs, s.Txs)
+	require.Greater(t, len(oldTxs), 0)
+
+	// sync the last layer from peers
+	lyr, err := msh.GetLayer(finalLyr)
+	require.NoError(t, err)
+	msh.ValidateLayer(context.TODO(), lyr)
+
+	// s2 state should be unchanged
+	require.Equal(t, oldTxs, s.Txs)
+}
+
+func TestMesh_updateStateWithLayer_LateBlock(t *testing.T) {
+	gLyr := types.GetEffectiveGenesis()
+	finalLyr := gLyr.Add(10)
+
+	// s is the state where a node advance its state via syncing with peers
+	s := &MockMapState{Rewards: make(map[types.Address]*big.Int)}
+	msh, atxDB := getMeshWithMapState(t, "t1", s)
+	t.Cleanup(func() {
+		msh.Close()
+	})
+	createMeshFromSyncing(t, finalLyr, msh, atxDB)
+	oldTxs := make([]*types.Transaction, len(s.Txs))
+	copy(oldTxs, s.Txs)
+	require.Greater(t, len(oldTxs), 0)
+
+	oldLyr, err := msh.GetLayer(finalLyr.Sub(4))
 	require.NoError(t, err)
 
-	blk := layer4.Blocks()[0]
-	mesh2.HandleLateBlock(context.TODO(), blk)
-	require.Equal(t, s.Txs, s2.Txs)
+	blk := oldLyr.Blocks()[0]
+	msh.HandleLateBlock(context.TODO(), blk)
+	// a seen late block should not change the state
+	require.Equal(t, oldTxs, s.Txs)
 
-	// test that state does not advance when layer x+2 is received before layer x+1,
-	// and then test that all layers are pushed
-	s3 := &MockMapState{Rewards: make(map[types.Address]*big.Int)}
-	mesh3, atxDB3 := getMeshWithMapState(t, "t3", s3)
+	// a not-before-seen late block should not change the state either
+	nodeID := types.NodeID{Key: strconv.Itoa(999), VRFPublicKey: []byte("ccccc")}
+	blk, _ = createBlock(t, msh, oldLyr.Index(), nodeID, 200, atxDB)
+	msh.HandleLateBlock(context.TODO(), blk)
+	// a late block we haven't seen should not the state
+	require.Equal(t, oldTxs, s.Txs)
+}
 
-	// this should be played until numOfLayers-1 if we want to compare states
-	for i := 0; i < numOfLayers-3; i++ {
-		layerID := startLayer.Add(uint32(i))
-		blockIds := copyLayer(t, mesh, mesh3, atxDB3, layerID)
-		mesh3.HandleValidatedLayer(context.TODO(), layerID, blockIds)
+func TestMesh_updateStateWithLayer_AdvanceInOrder(t *testing.T) {
+	gLyr := types.GetEffectiveGenesis()
+	finalLyr := gLyr.Add(10)
+
+	// s1 is the state where a node advance its state via syncing with peers
+	s1 := &MockMapState{Rewards: make(map[types.Address]*big.Int)}
+	msh1, atxDB := getMeshWithMapState(t, "t1", s1)
+	t.Cleanup(func() {
+		msh1.Close()
+	})
+	createMeshFromSyncing(t, finalLyr, msh1, atxDB)
+
+	// s2 is the state where the node advances its state via hare output
+	s2 := &MockMapState{Rewards: make(map[types.Address]*big.Int)}
+	msh2, atxDB2 := getMeshWithMapState(t, "t2", s2)
+	t.Cleanup(func() {
+		msh2.Close()
+	})
+
+	// use hare output to advance state to finalLyr-2
+	for i := gLyr.Add(1); i.Before(finalLyr.Sub(1)); i = i.Add(1) {
+		blockIds := copyLayer(t, msh1, msh2, atxDB2, i)
+		msh2.HandleValidatedLayer(context.TODO(), i, blockIds)
 	}
-	s3Len := len(s3.Txs)
-	blockIds := copyLayer(t, mesh, mesh3, atxDB3, startLayer.Add(uint32(numOfLayers)-2))
-	// layer arrived early, gets queued for state processing (no new txs processed)
-	mesh3.HandleValidatedLayer(context.TODO(), startLayer.Add(uint32(numOfLayers)-2), blockIds)
-	require.Equal(t, s3Len, len(s3.Txs))
+	// s1 is at finalLyr, s2 is at finalLyr-2
+	require.NotEqual(t, s1.Txs, s2.Txs)
 
-	blockIds = copyLayer(t, mesh, mesh3, atxDB3, startLayer.Add(uint32(numOfLayers)-3))
-	// this is the next layer, it's processed along with layer n-2
-	mesh3.HandleValidatedLayer(context.TODO(), startLayer.Add(uint32(numOfLayers)-3), blockIds)
-	require.Greater(t, len(s3.Txs), s3Len)
-	s3Len = len(s3.Txs)
+	finalMinus2Txs := make([]*types.Transaction, len(s2.Txs))
+	copy(finalMinus2Txs, s2.Txs)
+	require.Greater(t, len(finalMinus2Txs), 0)
 
-	// re-validate layer n-2: no change, it should already have been processed
-	mesh3.HandleValidatedLayer(context.TODO(), startLayer.Add(uint32(numOfLayers)-2), blockIds)
-	require.Equal(t, s3Len, len(s3.Txs))
+	finalMinus1BlockIds := copyLayer(t, msh1, msh2, atxDB2, finalLyr.Sub(1))
+	//copyLayer(t, msh1, msh2, atxDB2, finalLyr.Sub(1))
+	finalBlockIds := copyLayer(t, msh1, msh2, atxDB2, finalLyr)
 
-	// validate layer n-1
-	blockIds = copyLayer(t, mesh, mesh3, atxDB3, startLayer.Add(uint32(numOfLayers)-1))
-	mesh3.HandleValidatedLayer(context.TODO(), startLayer.Add(uint32(numOfLayers)-1), blockIds)
-	require.Greater(t, len(s3.Txs), s3Len) // expect txs from layer n-1 to have been applied
+	// now advance s2 to finalLyr
+	msh2.HandleValidatedLayer(context.TODO(), finalLyr, finalBlockIds)
+	// s2 should be unchanged because finalLyr-1 has not been processed
+	require.Equal(t, finalMinus2Txs, s2.Txs)
 
-	// now everything should have been applied
-	blockIds = copyLayer(t, mesh, mesh3, atxDB3, startLayer.Add(uint32(numOfLayers)-2))
-	mesh3.HandleValidatedLayer(context.TODO(), startLayer.Add(uint32(numOfLayers)-2), blockIds)
-	require.Equal(t, s.Txs, s3.Txs)
+	// advancing s2 to finalLyr-1 should bring s2 to finalLyr
+	msh2.HandleValidatedLayer(context.TODO(), finalLyr.Sub(1), finalMinus1BlockIds)
+	// s2 should be the same as s1 (at finalLyr)
+	require.Equal(t, s1.Txs, s2.Txs)
 }
 
 func copyLayer(t *testing.T, srcMesh, dstMesh *Mesh, dstAtxDb *AtxDbMock, id types.LayerID) []types.BlockID {


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
Closes #2695
<!-- `Closes #XXXX, closes #XXXX, ...` links mentioned issues to this PR and automatically closes them when this it's merged -->

## Changes
<!-- Please describe in detail the changes made -->
- remove processed layer hash. this was used to as a cache of aggregated hash for the latest layer. now with GetAggregatedHash(layerID), this field is no longer needed
- calculate layer hash and aggregated hash after tortoise validate a layer

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->
unit tests

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
