### PR TITLE
[Merged by Bors] - simulator: make peers operation blocking again

### DIFF
--- a/p2p/service/sim.go
+++ b/p2p/service/sim.go
@@ -78,28 +78,26 @@ func (s *Simulator) SubscribeToPeerEvents(myid p2pcrypto.Key) (chan p2pcrypto.Pu
 
 func (s *Simulator) publishNewPeer(peer p2pcrypto.PublicKey) {
 	s.subLock.Lock()
+	defer s.subLock.Unlock()
 	for _, ch := range s.newPeersSubs {
 		log.Debug("publish new peer on chan with len %v, cap %v", len(ch), cap(ch))
-		select {
-		case ch <- peer:
-		default:
-			log.Warning("unable to publish new peer event to subscriber")
-		}
+		// NOTE(dshulyak) services are not expected to be ready to receive all peers
+		// all tests that are using Simulator will become very flaky, especially on slow
+		// environments
+		ch <- peer
 	}
-	s.subLock.Unlock()
 }
 
 // nolint
 func (s *Simulator) publishDelPeer(peer p2pcrypto.PublicKey) {
 	s.subLock.Lock()
+	defer s.subLock.Unlock()
 	for _, ch := range s.delPeersSubs {
-		select {
-		case ch <- peer:
-		default:
-			log.Warning("unable to publish delete peer event to subscriber")
-		}
+		// NOTE(dshulyak) services are not expected to be ready to receive all peers
+		// all tests that are using Simulator will become very flaky, especially on slow
+		// environments
+		ch <- peer
 	}
-	s.subLock.Unlock()
 }
 
 func (s *Simulator) createdNode(n *Node) {


### PR DESCRIPTION
## Motivation

Simulator operations are supposed to be blocking. Subscribers, in their current shape, are not expected to have buffer for 
new peers. Removing this leads to very flaky tests in resource restricted environments, as currently on CI.

## Changes
- make send peer and delete peer blocking again

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->

## TODO
<!-- This section should be removed when all items are complete -->
- [ ] Explain motivation or link existing issue(s)
- [ ] Test changes and document test plan
- [ ] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
