### PR TITLE
[Merged by Bors] - fix flaky syncer test by using errgroup

### DIFF
--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -183,9 +183,18 @@ func (s *Syncer) Start(ctx context.Context) {
 
 // ForceSync manually starts a sync process outside the main sync loop. If the node is already running a sync process,
 // ForceSync will be ignored.
-func (s *Syncer) ForceSync(ctx context.Context) {
+func (s *Syncer) ForceSync(ctx context.Context) bool {
 	s.logger.WithContext(ctx).Debug("executing ForceSync")
+	if s.isClosed() {
+		s.logger.WithContext(ctx).Info("shutting down. dropping ForceSync request")
+		return false
+	}
+	if len(s.forceSyncCh) > 0 {
+		s.logger.WithContext(ctx).Info("another ForceSync already in progress. dropping this one")
+		return false
+	}
 	s.forceSyncCh <- struct{}{}
+	return true
 }
 
 func (s *Syncer) isClosed() bool {

--- a/syncer/syncer_test.go
+++ b/syncer/syncer_test.go
@@ -637,6 +637,28 @@ func TestForceSync(t *testing.T) {
 	syncer.Close()
 }
 
+func TestMultipleForceSync(t *testing.T) {
+	lg := logtest.New(t).WithName("syncer")
+	ticker := newMockLayerTicker()
+	mf := newMockFetcher()
+	syncer := newSyncerWithoutSyncTimer(context.TODO(), conf, ticker, newMemMesh(lg), mf, lg)
+	assert.False(t, syncer.ListenToGossip())
+	assert.False(t, syncer.IsSynced(context.TODO()))
+	lyr := types.NewLayerID(1)
+	ticker.advanceToLayer(lyr)
+	syncer.Start(context.TODO())
+
+	assert.True(t, true, syncer.ForceSync(context.TODO()))
+	assert.False(t, false, syncer.ForceSync(context.TODO()))
+
+	// allow synchronize to finish
+	mf.feedLayerResult(lyr, lyr)
+	syncer.Close()
+
+	// node already shutdown
+	assert.False(t, false, syncer.ForceSync(context.TODO()))
+}
+
 func TestShouldValidateLayer(t *testing.T) {
 	lg := logtest.New(t).WithName("syncer")
 	ticker := newMockLayerTicker()

--- a/taskgroup/group.go
+++ b/taskgroup/group.go
@@ -78,7 +78,7 @@ func (g *Group) Go(f func(ctx context.Context) error) error {
 func (g *Group) Wait() error {
 	g.mu.Lock()
 	err := g.err
-	// wait atleast once even if error was already set when we Wait is called for the first time
+	// wait at least once even if error was already set when we Wait is called for the first time
 	// otherwise we can't guarantee that all goroutines are closed when Wait exits
 	once := g.waitOnce
 	if !once {
@@ -91,7 +91,7 @@ func (g *Group) Wait() error {
 
 	<-g.waitErr
 	// at this point the error is set to a non-nil value, won't be ever overwritten,
-	// and all Go calls will be terminated immediatly, therefore re-locking here is not required.
+	// and all Go calls will be terminated immediately, therefore re-locking here is not required.
 	g.wg.Wait()
 	return g.err
 }


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
Closes #2742
<!-- `Closes #XXXX, closes #XXXX, ...` links mentioned issues to this PR and automatically closes them when this it's merged -->

## Changes
- add taskgroup to syncer and make sure all goroutines are finished before ending tests
- stop synctimer to prevent ticked synchronize for testing
 
## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->
go test -race -v ./syncer/ -count 1000

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
