### PR TITLE
[Merged by Bors] - Download gcloud sdk with wget instead of curl

### DIFF
--- a/DockerFileTests
+++ b/DockerFileTests
@@ -9,7 +9,7 @@ RUN chmod +x ./kubectl
 RUN mv ./kubectl /usr/local/bin
 
 # Downloading gcloud package
-RUN curl https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz > /tmp/google-cloud-sdk.tar.gz
+RUN wget https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz -P /tmp/
 
 # Installing the package
 RUN mkdir -p /usr/local/gcloud \

--- a/DockerFileTests
+++ b/DockerFileTests
@@ -9,7 +9,7 @@ RUN chmod +x ./kubectl
 RUN mv ./kubectl /usr/local/bin
 
 # Downloading gcloud package
-RUN wget https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz -P /tmp/
+RUN wget https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz -P /tmp/ --progress=dot
 
 # Installing the package
 RUN mkdir -p /usr/local/gcloud \


### PR DESCRIPTION
## Motivation
We hope this will fix interrupted downloads of the gcloud SDK during CI runs.

## Changes
Switch from `curl` to `wget` for downloading the gcloud SDK.

## Test Plan
bors try

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
