### PR TITLE
[Merged by Bors] - make sure Discovery.Shutdown is called by test cleanup

### DIFF
--- a/p2p/discovery/discovery.go
+++ b/p2p/discovery/discovery.go
@@ -178,6 +178,7 @@ func New(ctx context.Context, ln node.LocalNode, config config.SwarmConfig, serv
 
 // Shutdown stops the discovery service
 func (d *Discovery) Shutdown() {
+	d.disc.Close()
 	d.rt.Stop()
 }
 

--- a/p2p/discovery/discovery_test.go
+++ b/p2p/discovery/discovery_test.go
@@ -41,12 +41,18 @@ func simNodeWithDHT(t *testing.T, sc config.SwarmConfig, sim *service.Simulator)
 func TestDHT_BootstrapAbort(t *testing.T) {
 	// Create a bootstrap node
 	sim := service.NewSimulator()
-	bn, _ := simNodeWithDHT(t, config.DefaultConfig().SwarmConfig, sim)
+	bn, bdht := simNodeWithDHT(t, config.DefaultConfig().SwarmConfig, sim)
+	t.Cleanup(func() {
+		bdht.Shutdown()
+	})
 	// config for other nodes
 	cfg2 := config.DefaultConfig()
 	cfg2.SwarmConfig.RandomConnections = 2
 	cfg2.SwarmConfig.BootstrapNodes = []string{bn.String()}
 	_, dht := simNodeWithDHT(t, cfg2.SwarmConfig, sim)
+	t.Cleanup(func() {
+		dht.Shutdown()
+	})
 	// Create a bootstrap node to abort
 	Ctx, Cancel := context.WithCancel(context.Background())
 	// Abort bootstrap after 500 milliseconds
@@ -65,11 +71,22 @@ func TestKadDHT_VerySmallBootstrap(t *testing.T) {
 	bn, bninfo := node.GenerateTestNode(t)
 	b1 := sim.NewNodeFrom(bninfo)
 	bdht := New(context.TODO(), bn, bncfg.SwarmConfig, b1, "", logtest.New(t).WithName(t.Name()+"_"+bninfo.PublicKey().String()))
+	t.Cleanup(func() {
+		bdht.Shutdown()
+	})
+	t.Cleanup(func() {
+		bdht.Shutdown()
+	})
+
 	bdht.SetLocalAddresses(int(bninfo.ProtocolPort), int(bninfo.DiscoveryPort))
 
 	extra, extrainfo := node.GenerateTestNode(t)
 	extrasvc := sim.NewNodeFrom(extrainfo)
 	edht := New(context.TODO(), extra, bncfg.SwarmConfig, extrasvc, "", logtest.New(t).WithName(t.Name()+"_"+extra.PublicKey().String()))
+	t.Cleanup(func() {
+		edht.Shutdown()
+	})
+
 	edht.SetLocalAddresses(int(bninfo.ProtocolPort), int(bninfo.DiscoveryPort))
 	edht.rt.AddAddress(generateDiscNode(), extrainfo)
 
@@ -85,6 +102,9 @@ func TestKadDHT_VerySmallBootstrap(t *testing.T) {
 	ln, lninfo := node.GenerateTestNode(t)
 	n := sim.NewNodeFrom(lninfo)
 	dht := New(context.TODO(), ln, cfg, n, "", logtest.New(t).WithName(t.Name()+lninfo.PublicKey().String()))
+	t.Cleanup(func() {
+		dht.Shutdown()
+	})
 	dht.SetLocalAddresses(int(lninfo.ProtocolPort), int(lninfo.DiscoveryPort))
 	err := dht.Bootstrap(context.TODO())
 
@@ -111,6 +131,11 @@ func TestKadDHT_BootstrapSingleBoot(t *testing.T) {
 
 	bn, bninfo := node.GenerateTestNode(t)
 	b1 := sim.NewNodeFrom(bninfo)
+	b1Dht := New(context.TODO(), bn, bncfg.SwarmConfig, b1, "", logtest.New(t).WithName(t.Name()+"_"+bninfo.String()))
+	t.Cleanup(func() {
+		b1Dht.Shutdown()
+	})
+
 	_ = New(context.TODO(), bn, bncfg.SwarmConfig, b1, "", logtest.New(t).WithName(t.Name()+"_"+bninfo.String()))
 
 	cfg := config.DefaultConfig().SwarmConfig
@@ -126,6 +151,7 @@ func TestKadDHT_BootstrapSingleBoot(t *testing.T) {
 	for i := 0; i < numPeers; i++ {
 		ln, lninfo := node.GenerateTestNode(t)
 		n := sim.NewNodeFrom(lninfo)
+		//dht := New(context.TODO(), ln, cfg, n, "", logtest.New(t, zapcore.InfoLevel).WithName("dht"+strconv.Itoa(i)))
 		dht := New(context.TODO(), ln, cfg, n, "", logtest.New(t).WithName("dht"+strconv.Itoa(i)))
 		dht.SetLocalAddresses(int(lninfo.ProtocolPort), int(lninfo.DiscoveryPort))
 		nods[i] = lninfo
@@ -136,6 +162,11 @@ func TestKadDHT_BootstrapSingleBoot(t *testing.T) {
 			donech <- struct{}{}
 		}()
 	}
+	t.Cleanup(func() {
+		for _, dht := range dhts {
+			dht.Shutdown()
+		}
+	})
 
 	tm := time.NewTimer(tstBootstrapTimeout)
 
@@ -164,13 +195,20 @@ func TestKadDHT_Bootstrap(t *testing.T) {
 	cfg.Gossip = false
 	cfg.Bootstrap = true
 
+	bDhts := make([]*Discovery, bootnum)
 	for b := 0; b < bootnum; b++ {
 		bn, bninfo := node.GenerateTestNode(t)
 		b1 := sim.NewNodeFrom(bninfo)
 		disc := New(context.TODO(), bn, bncfg.SwarmConfig, b1, "", logtest.New(t).WithName("bn"+strconv.Itoa(b)))
+		bDhts[b] = disc
 		disc.SetLocalAddresses(int(bninfo.ProtocolPort), int(bninfo.DiscoveryPort))
 		cfg.BootstrapNodes = append(cfg.BootstrapNodes, bninfo.String())
 	}
+	t.Cleanup(func() {
+		for _, bDht := range bDhts {
+			bDht.Shutdown()
+		}
+	})
 
 	cfg.RandomConnections = min
 
@@ -190,6 +228,11 @@ func TestKadDHT_Bootstrap(t *testing.T) {
 			donech <- struct{}{}
 		}()
 	}
+	t.Cleanup(func() {
+		for _, dht := range dhts {
+			dht.Shutdown()
+		}
+	})
 
 	tm := time.NewTimer(tstBootstrapTimeout)
 
@@ -230,14 +273,21 @@ func Test_findNodeFailure(t *testing.T) {
 	cfg.RoutingTableBucketSize = 1
 	cfg.BootstrapNodes = []string{bsinfo.String()}
 	_, dht2 := simNodeWithDHT(t, cfg, sim)
+	t.Cleanup(func() {
+		dht2.Shutdown()
+	})
 
+	var dht *Discovery
 	go func() {
 		<-time.After(time.Second)
 		realnode := sim.NewNodeFrom(bsinfo)
-		d := New(context.TODO(), bsnode, config.DefaultConfig().SwarmConfig, realnode, "", logtest.New(t).WithName(t.Name()))
+		dht = New(context.TODO(), bsnode, config.DefaultConfig().SwarmConfig, realnode, "", logtest.New(t).WithName(t.Name()))
+		t.Cleanup(func() {
+			dht.Shutdown()
+		})
 		<-time.After(time.Second)
 		nd, _ := simNodeWithDHT(t, config.DefaultConfig().SwarmConfig, sim)
-		d.rt.AddAddress(nd.Info, bsinfo)
+		dht.rt.AddAddress(nd.Info, bsinfo)
 	}()
 
 	err := dht2.Bootstrap(context.TODO())
@@ -252,6 +302,9 @@ func Test_Refresh(t *testing.T) {
 	serv := sim.NewNodeFrom(bsinfo)
 
 	disc := New(context.TODO(), bsnode, config.DefaultConfig().SwarmConfig, serv, "", logtest.New(t).WithName(""))
+	t.Cleanup(func() {
+		disc.Shutdown()
+	})
 	rt := &mockAddrBook{}
 	rt.NeedNewAddressesFunc = func() bool {
 		return true


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
Closes #2757
<!-- `Closes #XXXX, closes #XXXX, ...` links mentioned issues to this PR and automatically closes them when this it's merged -->

## Changes
<!-- Please describe in detail the changes made -->
- clean up tests by making sure Discovery.Shutdown is called
- change msgserver to use errgroup

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->
$ go test -timeout 0 -v ./p2p/discovery/ -run "^TestKadDHT_Bootstrap$" -count 50

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
