### PR TITLE
[Merged by Bors] - fix p2p flaky unittests

### DIFF
--- a/p2p/gossip/protocol.go
+++ b/p2p/gossip/protocol.go
@@ -88,6 +88,8 @@ func (p *Protocol) Start(ctx context.Context) {
 // Close stops the protocol and waits for background workers to exit.
 func (p *Protocol) Close() {
 	p.cancel()
+	p.pq.Close()
+	p.peers.Close()
 	p.wg.Wait()
 }
 
@@ -249,8 +251,6 @@ func (p *Protocol) propagationEventLoop(ctx context.Context) {
 			metrics.PropagationQueueLen.Set(float64(len(p.propagateQ)))
 
 		case <-p.shutdownCtx.Done():
-			p.pq.Close()
-			p.peers.Close()
 			p.WithContext(ctx).Error("propagate event loop stopped: protocol shutdown")
 			return
 		}

--- a/p2p/gossip/protocol_test.go
+++ b/p2p/gossip/protocol_test.go
@@ -24,7 +24,12 @@ func TestProcessMessage(t *testing.T) {
 	defer ctrl.Finish()
 
 	net := NewMockbaseNetwork(ctrl)
-	protocol := NewProtocol(context.TODO(), config.SwarmConfig{}, net, nil, nil, logtest.New(t))
+	peersManager := NewMockpeersManager(ctrl)
+	protocol := NewProtocol(context.TODO(), config.SwarmConfig{}, net, peersManager, nil, logtest.New(t))
+	t.Cleanup(func() {
+		peersManager.EXPECT().Close()
+		protocol.Close()
+	})
 
 	isSent := false
 	net.EXPECT().
@@ -48,6 +53,10 @@ func TestPropagateMessage(t *testing.T) {
 	net := NewMockbaseNetwork(ctrl)
 	peersManager := NewMockpeersManager(ctrl)
 	protocol := NewProtocol(context.TODO(), config.SwarmConfig{}, net, peersManager, nil, logtest.New(t))
+	t.Cleanup(func() {
+		peersManager.EXPECT().Close()
+		protocol.Close()
+	})
 
 	peers := make([]p2ppeers.Peer, 30)
 	for i := range peers {
@@ -97,7 +106,6 @@ func (mpq mockPriorityQueue) Read() (interface{}, error) {
 
 func (mpq *mockPriorityQueue) Close() {
 	mpq.isClosed = true
-	mpq.called <- struct{}{}
 }
 
 func (mpq *mockPriorityQueue) Length() int {
@@ -105,17 +113,21 @@ func (mpq *mockPriorityQueue) Length() int {
 }
 
 func TestPropagationEventLoop(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	peersManager := NewMockpeersManager(ctrl)
 	peersManager.EXPECT().Close()
-	protocol := NewProtocol(ctx, config.SwarmConfig{}, nil, peersManager, nil, logtest.New(t))
+	protocol := NewProtocol(context.Background(), config.SwarmConfig{}, nil, peersManager, nil, logtest.New(t))
 	called := make(chan struct{})
 	mpq := mockPriorityQueue{called: called, bus: make(chan struct{}, 10)}
 	protocol.pq = &mpq
 
-	go protocol.propagationEventLoop(context.TODO())
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		protocol.propagationEventLoop(context.TODO())
+		wg.Done()
+	}()
 
 	protocol.propagateQ <- service.MessageValidation{}
 	<-called
@@ -123,8 +135,8 @@ func TestPropagationEventLoop(t *testing.T) {
 	assert.Equal(t, false, mpq.isClosed, "listener should not be shut down yet")
 
 	mpq.isWritten = false
-	cancel()
-	<-called
+	protocol.Close()
+	wg.Wait()
 	assert.Equal(t, false, mpq.isWritten, "message should not be written")
 	assert.Equal(t, true, mpq.isClosed, "listener should be shut down")
 

--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -26,6 +26,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/p2p/service"
 	"github.com/spacemeshos/go-spacemesh/priorityq"
 	"github.com/spacemeshos/go-spacemesh/timesync"
+	"golang.org/x/sync/errgroup"
 )
 
 // ConnectingTimeout is the timeout we wait when trying to connect a neighborhood
@@ -102,6 +103,8 @@ type Switch struct {
 
 	// function to release upnp port when shutting down
 	releaseUpnp func()
+
+	eg errgroup.Group
 }
 
 func (s *Switch) waitForBoot() error {
@@ -284,13 +287,13 @@ func (s *Switch) Start(ctx context.Context) error {
 	// TODO : insert new addresses to discovery
 
 	if s.config.SwarmConfig.Bootstrap {
-		go func() {
+		s.eg.Go(func() error {
 			b := time.Now()
 			if err := s.discover.Bootstrap(s.shutdownCtx); err != nil {
 				s.bootErr = err
 				close(s.bootChan)
 				s.Shutdown()
-				return
+				return nil
 			}
 			close(s.bootChan)
 			size := s.discover.Size()
@@ -298,7 +301,8 @@ func (s *Switch) Start(ctx context.Context) error {
 				log.Bool("success", size >= s.config.SwarmConfig.RandomConnections && s.bootErr == nil),
 				log.Int("size", size),
 				log.Duration("time_elapsed", time.Since(b)))
-		}()
+			return nil
+		})
 	}
 
 	// todo: maybe reset peers that connected us while bootstrapping
@@ -306,10 +310,10 @@ func (s *Switch) Start(ctx context.Context) error {
 	if s.config.SwarmConfig.Gossip {
 		// start gossip before starting to collect peers
 		s.gossip.Start(log.WithNewSessionID(ctx))
-		go func() {
+		s.eg.Go(func() error {
 			if s.config.SwarmConfig.Bootstrap {
 				if s.waitForBoot() != nil {
-					return
+					return nil
 				}
 			}
 			//todo:maybe start listening only after we got enough outbound neighbors?
@@ -318,11 +322,16 @@ func (s *Switch) Start(ctx context.Context) error {
 			if s.gossipErr != nil {
 				close(s.gossipC)
 				s.Shutdown()
-				return
+				return nil
 			}
-			<-s.initial
-			close(s.gossipC)
-		}() // todo handle error async
+			select {
+			case <-s.initial:
+				close(s.gossipC)
+			case <-s.shutdownCtx.Done():
+				return nil
+			}
+			return nil
+		}) // todo handle error async
 	}
 
 	return nil
@@ -463,6 +472,9 @@ func (s *Switch) Shutdown() {
 		if s.releaseUpnp != nil {
 			s.releaseUpnp()
 		}
+		s.logger.Info("waiting for switch goroutines to finish")
+		s.eg.Wait()
+		s.logger.Info("switch goroutines finished")
 	})
 }
 
@@ -522,20 +534,21 @@ func (s *Switch) listenToNetworkMessages(ctx context.Context) {
 	netqueues := s.network.IncomingMessages()
 	for nq := range netqueues { // run a separate worker for each queue.
 		ctx := log.WithNewSessionID(ctx)
-		go func(c chan net.IncomingMessageEvent) {
+		ch := netqueues[nq]
+		s.eg.Go(func() error {
 			for {
 				select {
-				case msg := <-c:
+				case msg := <-ch:
 					if s.isShuttingDown() {
-						return
+						return nil
 					}
 					// requestID will be restored from the saved message, no need to generate one here
 					s.processMessage(ctx, msg)
 				case <-s.shutdownCtx.Done():
-					return
+					return nil
 				}
 			}
-		}(netqueues[nq])
+		})
 	}
 }
 
@@ -722,7 +735,10 @@ func (s *Switch) startNeighborhood(ctx context.Context) error {
 	s.logger.WithContext(ctx).Info("neighborhood service started")
 
 	// initial request for peers
-	go s.peersLoop(ctx)
+	s.eg.Go(func() error {
+		s.peersLoop(ctx)
+		return nil
+	})
 	s.morePeersReq <- struct{}{}
 
 	return nil
@@ -851,16 +867,19 @@ func (s *Switch) getMorePeers(ctx context.Context, numpeers int) int {
 		if s.isShuttingDown() {
 			break
 		}
-		go func(nd *node.Info, reportChan chan cnErr) {
+		nd := nds[i]
+		reportChan := res
+		s.eg.Go(func() error {
 			if nd.PublicKey() == s.lNode.PublicKey() {
 				reportChan <- cnErr{nd, errors.New("connection to self")}
-				return
+				return nil
 			}
 			s.discover.Attempt(nd.PublicKey())
 			addr := inet.TCPAddr{IP: inet.ParseIP(nd.IP.String()), Port: int(nd.ProtocolPort)}
 			_, err := s.cPool.GetConnection(ctx, &addr, nd.PublicKey())
 			reportChan <- cnErr{nd, err}
-		}(nds[i], res)
+			return nil
+		})
 	}
 
 	total, bad := 0, 0

--- a/p2p/switch_test.go
+++ b/p2p/switch_test.go
@@ -62,11 +62,12 @@ func (cp *cpoolMock) Shutdown() {
 
 func p2pTestInstance(t testing.TB, config config.Config) *Switch {
 	p := p2pTestNoStart(t, config)
-	err := p.Start(context.TODO())
-	if err != nil {
+	if err := p.Start(context.TODO()); err != nil {
 		t.Fatal(err)
 	}
-
+	t.Cleanup(func() {
+		p.Shutdown()
+	})
 	return p
 }
 


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
Closes #2766
Closes #2767
<!-- `Closes #XXXX, closes #XXXX, ...` links mentioned issues to this PR and automatically closes them when this it's merged -->

## Changes
<!-- Please describe in detail the changes made -->
- move shutdown routine of gossip/protocol.go to `Close()`
- use errgroup to manage goroutines in switch.go
- make sure switch_test.go calls Shutdown() started switch instance

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->
$ CGO_LDFLAGS="-L/home/k/src/go-spacemesh/build/ -Wl,-rpath,/home/k/src/go-spacemesh/build/" TEST_LOG_LEVEL= go test -v -timeout 0 -p 1 -tags exclude_app_test ./p2p -count 50

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
