### PR TITLE
add test to document the expected behavior when hare output layer out of order

### DIFF
--- a/tortoise/verifying_tortoise_test.go
+++ b/tortoise/verifying_tortoise_test.go
@@ -1261,10 +1261,11 @@ func TestCalculateExceptions(t *testing.T) {
 	// now advance the processed layer
 	alg.trtl.Last = l1ID
 
-	// missing layer data
+	// missing layer data:
+	// expect FOR only for l0, and neutral is 0 since there are no blocks in l1 to add an exception for
 	votes, err = alg.trtl.calculateExceptions(context.TODO(), l1ID, Opinion{})
-	r.Equal(database.ErrNotFound, err)
-	r.Nil(votes)
+	r.NoError(err)
+	expectVotes(votes, 0, 1, 0)
 
 	// layer opinion vector is nil (abstains): recent layer, in mesh, no input vector
 	alg.trtl.Last = l0ID


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
add a test case that documents tortoise expected behavior when hare output layers out-of-order

## Changes
add test case when `HandleValidateLayer` is called out of layer order

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->
uint tests

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
