### PR TITLE
[Merged by Bors] - simplify beacon a little

### DIFF
--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -603,10 +603,8 @@ func (app *App) initServices(ctx context.Context,
 		weakcoin.WithMaxRound(app.Config.TortoiseBeacon.RoundsNumber),
 	)
 
-	ld := time.Duration(app.Config.LayerDurationSec) * time.Second
 	tBeacon := tortoisebeacon.New(
 		app.Config.TortoiseBeacon,
-		ld,
 		nodeID,
 		swarm,
 		atxDB,

--- a/tortoisebeacon/beacon_calc.go
+++ b/tortoisebeacon/beacon_calc.go
@@ -26,10 +26,7 @@ func (tb *TortoiseBeacon) calcBeacon(ctx context.Context, epoch types.EpochID, l
 
 	events.ReportCalculatedTortoiseBeacon(epoch, beacon.ShortString())
 
-	tb.mu.Lock()
-	tb.beacons[epoch] = beacon
-	tb.mu.Unlock()
-
+	tb.setBeacon(epoch, beacon)
 	if tb.tortoiseBeaconDB != nil {
 		tb.Log.WithContext(ctx).With().Info("writing beacon to database",
 			log.Uint32("epoch_id", uint32(epoch)),

--- a/tortoisebeacon/beacon_calc.go
+++ b/tortoisebeacon/beacon_calc.go
@@ -26,9 +26,9 @@ func (tb *TortoiseBeacon) calcBeacon(ctx context.Context, epoch types.EpochID, l
 
 	events.ReportCalculatedTortoiseBeacon(epoch, beacon.ShortString())
 
-	tb.beaconsMu.Lock()
+	tb.mu.Lock()
 	tb.beacons[epoch] = beacon
-	tb.beaconsMu.Unlock()
+	tb.mu.Unlock()
 
 	if tb.tortoiseBeaconDB != nil {
 		tb.Log.WithContext(ctx).With().Info("writing beacon to database",

--- a/tortoisebeacon/beacon_calc_test.go
+++ b/tortoisebeacon/beacon_calc_test.go
@@ -72,10 +72,10 @@ func TestTortoiseBeacon_calcBeacon(t *testing.T) {
 					RoundsNumber: rounds,
 					Theta:        big.NewRat(1, 1),
 				},
-				lastLayer: types.NewLayerID(epoch),
-				Log:       logtest.New(t).WithName("TortoiseBeacon"),
-				beacons:   make(map[types.EpochID]types.Hash32),
-				atxDB:     mockDB,
+				epochInProgress: epoch,
+				Log:             logtest.New(t).WithName("TortoiseBeacon"),
+				beacons:         make(map[types.EpochID]types.Hash32),
+				atxDB:           mockDB,
 			}
 
 			tb.initGenesisBeacons()

--- a/tortoisebeacon/handlers.go
+++ b/tortoisebeacon/handlers.go
@@ -61,9 +61,9 @@ func (tb *TortoiseBeacon) HandleSerializedProposalMessage(ctx context.Context, d
 		return
 	}
 
-	tb.proposalChansMu.Lock()
+	tb.mu.Lock()
 	ch := tb.getOrCreateProposalChannel(message.EpochID)
-	tb.proposalChansMu.Unlock()
+	tb.mu.Unlock()
 
 	proposalWithReceipt := &proposalMessageWithReceiptData{
 		message:      message,
@@ -312,8 +312,8 @@ func (tb *TortoiseBeacon) verifyFirstVotingMessage(ctx context.Context, message 
 		return nil, types.ATXID{}, ErrMalformedSignature
 	}
 
-	tb.consensusMu.Lock()
-	defer tb.consensusMu.Unlock()
+	tb.mu.Lock()
+	defer tb.mu.Unlock()
 
 	if tb.hasVoted[firstRound] == nil {
 		tb.hasVoted[firstRound] = make(map[string]struct{})
@@ -341,8 +341,8 @@ func (tb *TortoiseBeacon) verifyFirstVotingMessage(ctx context.Context, message 
 }
 
 func (tb *TortoiseBeacon) storeFirstVotes(message FirstVotingMessage, minerPK *signing.PublicKey, voteWeight *big.Int) {
-	tb.consensusMu.Lock()
-	defer tb.consensusMu.Unlock()
+	tb.mu.Lock()
+	defer tb.mu.Unlock()
 
 	for _, vote := range message.ValidProposals {
 		if _, ok := tb.votesMargin[string(vote)]; !ok {
@@ -460,8 +460,8 @@ func (tb *TortoiseBeacon) verifyFollowingVotingMessage(ctx context.Context, mess
 		return nil, types.ATXID{}, ErrMalformedSignature
 	}
 
-	tb.consensusMu.Lock()
-	defer tb.consensusMu.Unlock()
+	tb.mu.Lock()
+	defer tb.mu.Unlock()
 
 	if tb.hasVoted[message.RoundID-firstRound] == nil {
 		tb.hasVoted[message.RoundID-firstRound] = make(map[string]struct{})
@@ -481,8 +481,8 @@ func (tb *TortoiseBeacon) verifyFollowingVotingMessage(ctx context.Context, mess
 }
 
 func (tb *TortoiseBeacon) storeFollowingVotes(message FollowingVotingMessage, minerPK *signing.PublicKey, voteWeight *big.Int) {
-	tb.consensusMu.Lock()
-	defer tb.consensusMu.Unlock()
+	tb.mu.Lock()
+	defer tb.mu.Unlock()
 
 	thisRoundVotes := tb.decodeVotes(message.VotesBitVector, tb.firstRoundIncomingVotes[string(minerPK.Bytes())])
 
@@ -510,8 +510,8 @@ func (tb *TortoiseBeacon) currentEpoch() types.EpochID {
 }
 
 func (tb *TortoiseBeacon) currentLayer() types.LayerID {
-	tb.layerMu.RLock()
-	defer tb.layerMu.RUnlock()
+	tb.mu.RLock()
+	defer tb.mu.RUnlock()
 
 	return tb.lastLayer
 }

--- a/tortoisebeacon/handlers.go
+++ b/tortoisebeacon/handlers.go
@@ -506,12 +506,7 @@ func (tb *TortoiseBeacon) storeFollowingVotes(message FollowingVotingMessage, mi
 }
 
 func (tb *TortoiseBeacon) currentEpoch() types.EpochID {
-	return tb.currentLayer().GetEpoch()
-}
-
-func (tb *TortoiseBeacon) currentLayer() types.LayerID {
 	tb.mu.RLock()
 	defer tb.mu.RUnlock()
-
-	return tb.lastLayer
+	return tb.epochInProgress
 }

--- a/tortoisebeacon/handlers_test.go
+++ b/tortoisebeacon/handlers_test.go
@@ -87,14 +87,14 @@ func TestTortoiseBeacon_handleProposalMessage(t *testing.T) {
 			t.Parallel()
 
 			tb := TortoiseBeacon{
-				config:      UnitTestConfig(),
-				Log:         logtest.New(t).WithName("TortoiseBeacon"),
-				nodeID:      nodeID,
-				atxDB:       mockDB,
-				vrfVerifier: signing.VRFVerifier{},
-				vrfSigner:   vrfSigner,
-				clock:       clock,
-				lastLayer:   types.NewLayerID(epoch),
+				config:          UnitTestConfig(),
+				Log:             logtest.New(t).WithName("TortoiseBeacon"),
+				nodeID:          nodeID,
+				atxDB:           mockDB,
+				vrfVerifier:     signing.VRFVerifier{},
+				vrfSigner:       vrfSigner,
+				clock:           clock,
+				epochInProgress: epoch,
 			}
 
 			sig, err := tb.getSignedProposal(context.TODO(), epoch)
@@ -341,9 +341,9 @@ func TestTortoiseBeacon_handleFollowingVotingMessage(t *testing.T) {
 						potentiallyValid: [][]byte{hash3.Bytes()},
 					},
 				},
-				lastLayer:   types.NewLayerID(epoch),
-				hasVoted:    make([]map[string]struct{}, round+1),
-				votesMargin: map[string]*big.Int{},
+				epochInProgress: epoch,
+				hasVoted:        make([]map[string]struct{}, round+1),
+				votesMargin:     map[string]*big.Int{},
 			}
 
 			sig, err := tb.signMessage(tc.message.FollowingVotingMessageBody)

--- a/tortoisebeacon/handlers_test.go
+++ b/tortoisebeacon/handlers_test.go
@@ -108,9 +108,9 @@ func TestTortoiseBeacon_handleProposalMessage(t *testing.T) {
 				valid: [][]byte{sig},
 			}
 
-			tb.consensusMu.RLock()
+			tb.mu.RLock()
 			r.EqualValues(expectedProposals, tb.incomingProposals)
-			tb.consensusMu.RUnlock()
+			tb.mu.RUnlock()
 		})
 	}
 }
@@ -226,9 +226,9 @@ func TestTortoiseBeacon_handleFirstVotingMessage(t *testing.T) {
 			err = tb.handleFirstVotingMessage(context.TODO(), tc.message)
 			r.NoError(err)
 
-			tb.consensusMu.RLock()
+			tb.mu.RLock()
 			r.EqualValues(tc.expected, tb.firstRoundIncomingVotes)
-			tb.consensusMu.RUnlock()
+			tb.mu.RUnlock()
 		})
 	}
 }

--- a/tortoisebeacon/mocks/mocks.go
+++ b/tortoisebeacon/mocks/mocks.go
@@ -227,34 +227,6 @@ func (m *MocklayerClock) EXPECT() *MocklayerClockMockRecorder {
 	return m.recorder
 }
 
-// AwaitLayer mocks base method.
-func (m *MocklayerClock) AwaitLayer(arg0 types.LayerID) chan struct{} {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AwaitLayer", arg0)
-	ret0, _ := ret[0].(chan struct{})
-	return ret0
-}
-
-// AwaitLayer indicates an expected call of AwaitLayer.
-func (mr *MocklayerClockMockRecorder) AwaitLayer(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AwaitLayer", reflect.TypeOf((*MocklayerClock)(nil).AwaitLayer), arg0)
-}
-
-// GetCurrentLayer mocks base method.
-func (m *MocklayerClock) GetCurrentLayer() types.LayerID {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCurrentLayer")
-	ret0, _ := ret[0].(types.LayerID)
-	return ret0
-}
-
-// GetCurrentLayer indicates an expected call of GetCurrentLayer.
-func (mr *MocklayerClockMockRecorder) GetCurrentLayer() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCurrentLayer", reflect.TypeOf((*MocklayerClock)(nil).GetCurrentLayer))
-}
-
 // LayerToTime mocks base method.
 func (m *MocklayerClock) LayerToTime(arg0 types.LayerID) time.Time {
 	m.ctrl.T.Helper()

--- a/tortoisebeacon/tortoise_beacon.go
+++ b/tortoisebeacon/tortoise_beacon.go
@@ -75,7 +75,6 @@ type SyncState interface {
 // New returns a new TortoiseBeacon.
 func New(
 	conf Config,
-	layerDuration time.Duration,
 	nodeID types.NodeID,
 	net broadcaster,
 	atxDB activationDB,
@@ -91,7 +90,6 @@ func New(
 	return &TortoiseBeacon{
 		Log:                     logger,
 		config:                  conf,
-		layerDuration:           layerDuration,
 		nodeID:                  nodeID,
 		net:                     net,
 		atxDB:                   atxDB,
@@ -105,7 +103,6 @@ func New(
 		beacons:                 make(map[types.EpochID]types.Hash32),
 		hasVoted:                make([]map[string]struct{}, conf.RoundsNumber),
 		firstRoundIncomingVotes: make(map[string]proposals),
-		seenEpochs:              make(map[types.EpochID]struct{}),
 		proposalChans:           make(map[types.EpochID]chan *proposalMessageWithReceiptData),
 		votesMargin:             map[string]*big.Int{},
 	}
@@ -119,10 +116,8 @@ type TortoiseBeacon struct {
 
 	log.Log
 
-	config        Config
-	layerDuration time.Duration
-	nodeID        types.NodeID
-
+	config           Config
+	nodeID           types.NodeID
 	sync             SyncState
 	net              broadcaster
 	atxDB            activationDB
@@ -136,9 +131,8 @@ type TortoiseBeacon struct {
 	clock       layerClock
 	layerTicker chan types.LayerID
 
-	mu         sync.RWMutex
-	seenEpochs map[types.EpochID]struct{}
-	lastLayer  types.LayerID
+	mu              sync.RWMutex
+	epochInProgress types.EpochID
 	// TODO(nkryuchkov): have a mixed list of all sorted proposals
 	// have one bit vector: valid proposals
 	incomingProposals       proposals
@@ -247,10 +241,13 @@ func (tb *TortoiseBeacon) GetBeacon(epochID types.EpochID) ([]byte, error) {
 	return beacon.Bytes(), nil
 }
 
-func (tb *TortoiseBeacon) initGenesisBeacons() {
-	closedCh := make(chan struct{})
-	close(closedCh)
+func (tb *TortoiseBeacon) setBeacon(epoch types.EpochID, beacon types.Hash32) {
+	tb.mu.Lock()
+	tb.beacons[epoch] = beacon
+	tb.mu.Unlock()
+}
 
+func (tb *TortoiseBeacon) initGenesisBeacons() {
 	for epoch := types.EpochID(0); epoch.IsGenesis(); epoch++ {
 		genesis := types.HexToHash32(genesisBeacon)
 		tb.beacons[epoch] = genesis
@@ -285,7 +282,7 @@ func (tb *TortoiseBeacon) listenLayers(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case layer := <-tb.layerTicker:
-			tb.Log.With().Info("received tick", layer)
+			tb.Log.With().Debug("received tick", layer)
 			err := tb.tg.Go(func(ctx context.Context) error {
 				tb.handleLayer(ctx, layer)
 				return nil
@@ -301,43 +298,24 @@ func (tb *TortoiseBeacon) listenLayers(ctx context.Context) {
 // the logic that happens when a new layer arrives.
 // this function triggers the start of new CPs.
 func (tb *TortoiseBeacon) handleLayer(ctx context.Context, layer types.LayerID) {
-	tb.mu.Lock()
-	if layer.After(tb.lastLayer) {
-		tb.Log.WithContext(ctx).With().Debug("updating layer",
-			log.Uint32("old_value", tb.lastLayer.Uint32()),
-			log.Uint32("new_value", layer.Uint32()))
-		tb.lastLayer = layer
-	}
-
 	epoch := layer.GetEpoch()
+	logger := tb.WithContext(ctx).WithFields(layer, epoch)
 
 	if !layer.FirstInEpoch() {
-		tb.Log.WithContext(ctx).With().Debug("skipping layer because it's not first in this epoch",
-			log.Uint32("epoch_id", uint32(epoch)),
-			log.Uint32("layer_id", layer.Uint32()))
-
+		logger.Debug("not first layer in epoch, skipping")
 		return
 	}
+	logger.Info("first layer in epoch, proceeding")
 
-	tb.Log.WithContext(ctx).With().Info("layer is first in epoch, proceeding",
-		log.Uint32("layer", layer.Uint32()))
-
-	if _, ok := tb.seenEpochs[epoch]; ok {
-		tb.Log.WithContext(ctx).With().Error("already seen this epoch",
-			log.Uint32("epoch_id", uint32(epoch)),
-			log.Uint32("layer_id", layer.Uint32()))
-
+	tb.mu.Lock()
+	if tb.epochInProgress >= epoch {
 		tb.mu.Unlock()
-
-		return
+		logger.Panic("epoch ticked twice")
 	}
-
-	tb.seenEpochs[epoch] = struct{}{}
+	tb.epochInProgress = epoch
 	tb.mu.Unlock()
 
-	tb.Log.WithContext(ctx).With().Debug("tortoise beacon got tick, waiting until other nodes have the same epoch",
-		log.Uint32("layer", layer.Uint32()),
-		log.Uint32("epoch_id", uint32(epoch)),
+	logger.With().Debug("tortoise beacon got tick, waiting until other nodes have the same epoch",
 		log.Duration("wait_time", tb.config.WaitAfterEpochStart))
 
 	epochStartTimer := time.NewTimer(tb.config.WaitAfterEpochStart)
@@ -351,20 +329,18 @@ func (tb *TortoiseBeacon) handleLayer(ctx context.Context, layer types.LayerID) 
 
 func (tb *TortoiseBeacon) handleEpoch(ctx context.Context, epoch types.EpochID) {
 	ctx = log.WithNewSessionID(ctx)
+	logger := tb.WithContext(ctx).WithFields(epoch)
 	// TODO(nkryuchkov): check when epoch started, adjust waiting time for this timestamp
 	if epoch.IsGenesis() {
-		tb.Log.WithContext(ctx).With().Debug("not starting tortoise beacon since we are in genesis epoch",
-			log.Uint32("epoch_id", uint32(epoch)))
-
+		logger.Debug("not starting tortoise beacon since we are in genesis epoch")
 		return
 	}
 	if !tb.sync.IsSynced(ctx) {
-		tb.Log.With().Info("tortoise beacon protocol is skipped while node is not synced", epoch)
+		logger.Info("tortoise beacon protocol is skipped while node is not synced")
 		return
 	}
 
-	tb.Log.WithContext(ctx).With().Info("handling epoch",
-		log.Uint32("epoch_id", uint32(epoch)))
+	logger.Info("handling epoch")
 
 	defer tb.cleanupVotes()
 
@@ -381,28 +357,23 @@ func (tb *TortoiseBeacon) handleEpoch(ctx context.Context, epoch types.EpochID) 
 		return nil
 	})
 	if err != nil {
-		tb.Log.WithContext(ctx).With().Warning("taskgroup: Go returned an error",
-			log.Err(err))
+		logger.With().Warning("taskgroup: Go returned an error", log.Err(err))
 	}
 
 	tb.runProposalPhase(ctx, epoch)
 	lastRoundOwnVotes, err := tb.runConsensusPhase(ctx, epoch)
 	if err != nil {
-		tb.Log.WithContext(ctx).With().Warning("Consensus execution cancelled",
-			log.Err(err))
+		logger.With().Warning("Consensus execution cancelled", log.Err(err))
 		return
 	}
 
 	// K rounds passed
 	// After K rounds had passed, tally up votes for proposals using simple tortoise vote counting
 	if err := tb.calcBeacon(ctx, epoch, lastRoundOwnVotes); err != nil {
-		tb.Log.WithContext(ctx).With().Error("failed to calculate beacon",
-			log.Uint32("epoch_id", uint32(epoch)),
-			log.Err(err))
+		logger.With().Error("failed to calculate beacon", log.Err(err))
 	}
 
-	tb.Log.WithContext(ctx).With().Debug("finished handling epoch",
-		log.Uint32("epoch_id", uint32(epoch)))
+	logger.With().Debug("finished handling epoch")
 }
 
 func (tb *TortoiseBeacon) readProposalMessagesLoop(ctx context.Context, ch chan *proposalMessageWithReceiptData) {
@@ -452,47 +423,41 @@ func (tb *TortoiseBeacon) getOrCreateProposalChannel(epoch types.EpochID) chan *
 }
 
 func (tb *TortoiseBeacon) runProposalPhase(ctx context.Context, epoch types.EpochID) {
-	tb.Log.WithContext(ctx).With().Debug("starting proposal phase",
-		log.Uint32("epoch_id", uint32(epoch)))
+	logger := tb.Log.WithContext(ctx).WithFields(epoch)
+	logger.Debug("starting proposal phase")
 
 	var cancel func()
 	ctx, cancel = context.WithTimeout(ctx, tb.config.ProposalDuration)
 	defer cancel()
 
 	err := tb.tg.Go(func(ctx context.Context) error {
-		tb.Log.WithContext(ctx).With().Debug("starting proposal message sender",
-			log.Uint32("epoch_id", uint32(epoch)))
+		logger.Debug("starting proposal message sender")
 
 		if err := tb.proposalPhaseImpl(ctx, epoch); err != nil {
-			tb.Log.WithContext(ctx).With().Error("failed to send proposal message",
-				log.Uint32("epoch_id", uint32(epoch)),
-				log.Err(err))
+			logger.With().Error("failed to send proposal message", log.Err(err))
 		}
 
-		tb.Log.WithContext(ctx).With().Debug("proposal message sender finished",
-			log.Uint32("epoch_id", uint32(epoch)))
+		logger.Debug("proposal message sender finished")
 		return nil
 	})
 	if err != nil {
-		tb.Log.WithContext(ctx).With().Warning("taskgroup: Go returned an error",
-			log.Err(err))
+		logger.With().Warning("taskgroup: Go returned an error", log.Err(err))
 	}
 
 	<-ctx.Done()
 	tb.markProposalPhaseFinished(epoch)
 
-	tb.Log.WithContext(ctx).With().Debug("proposal phase finished",
-		log.Uint32("epoch_id", uint32(epoch)))
+	logger.Debug("proposal phase finished")
 }
 
 func (tb *TortoiseBeacon) proposalPhaseImpl(ctx context.Context, epoch types.EpochID) error {
+	logger := tb.Log.WithContext(ctx).WithFields(epoch)
 	proposedSignature, err := tb.getSignedProposal(ctx, epoch)
 	if err != nil {
 		return fmt.Errorf("calculate signed proposal: %w", err)
 	}
 
-	tb.Log.WithContext(ctx).With().Debug("calculated proposal signature",
-		log.Uint32("epoch_id", uint32(epoch)),
+	logger.With().Debug("calculated proposal signature",
 		log.String("signature", string(proposedSignature)))
 
 	epochWeight, _, err := tb.atxDB.GetEpochWeight(epoch)
@@ -506,16 +471,14 @@ func (tb *TortoiseBeacon) proposalPhaseImpl(ctx context.Context, epoch types.Epo
 	}
 
 	if !passes {
-		tb.Log.WithContext(ctx).With().Debug("proposal to be sent doesn't pass threshold",
-			log.Uint32("epoch_id", uint32(epoch)),
+		logger.With().Debug("proposal to be sent doesn't pass threshold",
 			log.String("proposal", string(proposedSignature)),
 			log.Uint64("weight", epochWeight))
 		// proposal is not sent
 		return nil
 	}
 
-	tb.Log.WithContext(ctx).With().Debug("Proposal to be sent passes threshold",
-		log.Uint32("epoch_id", uint32(epoch)),
+	logger.With().Debug("Proposal to be sent passes threshold",
 		log.String("proposal", string(proposedSignature)),
 		log.Uint64("weight", epochWeight))
 
@@ -526,17 +489,13 @@ func (tb *TortoiseBeacon) proposalPhaseImpl(ctx context.Context, epoch types.Epo
 		VRFSignature: proposedSignature,
 	}
 
-	tb.Log.WithContext(ctx).With().Debug("going to send proposal",
-		log.Uint32("epoch_id", uint32(epoch)),
-		log.String("message", m.String()))
+	logger.With().Debug("going to send proposal", log.String("message", m.String()))
 
 	if err := tb.sendToGossip(ctx, TBProposalProtocol, m); err != nil {
 		return fmt.Errorf("broadcast proposal message: %w", err)
 	}
 
-	tb.Log.WithContext(ctx).With().Info("sent proposal",
-		log.Uint32("epoch_id", uint32(epoch)),
-		log.String("message", m.String()))
+	logger.With().Info("sent proposal", log.String("message", m.String()))
 
 	tb.mu.Lock()
 	defer tb.mu.Unlock()
@@ -548,8 +507,8 @@ func (tb *TortoiseBeacon) proposalPhaseImpl(ctx context.Context, epoch types.Epo
 
 // runConsensusPhase runs K voting rounds and returns result from last weak coin round.
 func (tb *TortoiseBeacon) runConsensusPhase(ctx context.Context, epoch types.EpochID) (allVotes, error) {
-	tb.Log.WithContext(ctx).With().Debug("starting consensus phase",
-		log.Uint32("epoch_id", uint32(epoch)))
+	logger := tb.Log.WithContext(ctx).WithFields(epoch)
+	logger.Debug("starting consensus phase")
 
 	tb.startWeakCoinEpoch(epoch)
 	defer tb.fininshWeakCoinEpoch()
@@ -575,8 +534,7 @@ func (tb *TortoiseBeacon) runConsensusPhase(ctx context.Context, epoch types.Epo
 		err := tb.tg.Go(func(ctx context.Context) error {
 			if round == firstRound {
 				if err := tb.sendProposalVote(ctx, epoch); err != nil {
-					tb.Log.WithContext(ctx).With().Error("Failed to send proposal vote",
-						log.Uint32("epoch_id", uint32(epoch)),
+					logger.With().Error("Failed to send proposal vote",
 						log.Uint32("round_id", uint32(round)),
 						log.Err(err))
 
@@ -590,8 +548,7 @@ func (tb *TortoiseBeacon) runConsensusPhase(ctx context.Context, epoch types.Epo
 			// construct a message that points to all messages from previous round received by δ
 			ownCurrentRoundVotes, err := tb.calcVotes(epoch, round, previousCoinFlip)
 			if err != nil {
-				tb.Log.WithContext(ctx).With().Error("Failed to calculate votes",
-					log.Uint32("epoch_id", uint32(epoch)),
+				logger.With().Error("Failed to calculate votes",
 					log.Uint32("round_id", uint32(round)),
 					log.Err(err))
 
@@ -605,8 +562,7 @@ func (tb *TortoiseBeacon) runConsensusPhase(ctx context.Context, epoch types.Epo
 			}
 
 			if err := tb.sendFollowingVote(ctx, epoch, round, ownCurrentRoundVotes); err != nil {
-				tb.Log.WithContext(ctx).With().Error("Failed to send following vote",
-					log.Uint32("epoch_id", uint32(epoch)),
+				logger.With().Error("Failed to send following vote",
 					log.Uint32("round_id", uint32(round)),
 					log.Err(err))
 
@@ -616,8 +572,7 @@ func (tb *TortoiseBeacon) runConsensusPhase(ctx context.Context, epoch types.Epo
 			return nil
 		})
 		if err != nil {
-			tb.Log.WithContext(ctx).Warning("taskgroup: Go returned an error",
-				log.Err(err))
+			logger.With().Warning("taskgroup: Go returned an error", log.Err(err))
 		}
 
 		err = tb.tg.Go(func(ctx context.Context) error {
@@ -625,8 +580,7 @@ func (tb *TortoiseBeacon) runConsensusPhase(ctx context.Context, epoch types.Epo
 			return nil
 		})
 		if err != nil {
-			tb.Log.WithContext(ctx).With().Warning("taskgroup: Go returned an error",
-				log.Err(err))
+			logger.With().Warning("taskgroup: Go returned an error", log.Err(err))
 		}
 
 		select {
@@ -641,8 +595,7 @@ func (tb *TortoiseBeacon) runConsensusPhase(ctx context.Context, epoch types.Epo
 		coinFlip = tb.weakCoin.Get(epoch, round)
 	}
 
-	tb.Log.WithContext(ctx).With().Debug("Consensus phase finished",
-		log.Uint32("epoch_id", uint32(epoch)))
+	logger.Debug("Consensus phase finished")
 
 	ownLastRoundVotesMu.RLock()
 	defer ownLastRoundVotesMu.RUnlock()
@@ -711,7 +664,7 @@ func (tb *TortoiseBeacon) startWeakCoinRound(ctx context.Context, epoch types.Ep
 	// should be published only after we should have received them
 	if err := tb.weakCoin.StartRound(ctx, round); err != nil {
 		tb.Log.WithContext(ctx).With().Error("failed to publish weak coin proposal",
-			log.Uint32("epoch_id", uint32(epoch)),
+			epoch,
 			log.Uint32("round_id", uint32(round)),
 			log.Err(err))
 	}
@@ -744,7 +697,7 @@ func (tb *TortoiseBeacon) sendFirstRoundVote(ctx context.Context, epoch types.Ep
 	}
 
 	tb.Log.WithContext(ctx).With().Debug("sending first round vote",
-		log.Uint32("epoch_id", uint32(epoch)),
+		epoch,
 		log.Uint32("round_id", uint32(firstRound)),
 		log.String("message", m.String()))
 
@@ -776,7 +729,7 @@ func (tb *TortoiseBeacon) sendFollowingVote(ctx context.Context, epoch types.Epo
 	}
 
 	tb.Log.WithContext(ctx).With().Debug("sending following round vote",
-		log.Uint32("epoch_id", uint32(epoch)),
+		epoch,
 		log.Uint32("round_id", uint32(round)),
 		log.String("message", m.String()))
 
@@ -858,7 +811,7 @@ func (tb *TortoiseBeacon) getSignedProposal(ctx context.Context, epoch types.Epo
 
 	signature := tb.vrfSigner.Sign(p)
 	tb.Log.WithContext(ctx).With().Debug("calculated signature",
-		log.Uint32("epoch_id", uint32(epoch)),
+		epoch,
 		log.String("proposal", util.Bytes2Hex(p)),
 		log.String("signature", string(signature)))
 

--- a/tortoisebeacon/tortoise_beacon_test.go
+++ b/tortoisebeacon/tortoise_beacon_test.go
@@ -81,7 +81,7 @@ func TestTortoiseBeacon(t *testing.T) {
 	atxdb := activation.NewDB(database.NewMemDatabase(), idStore, memesh, 3, goldenATXID, &validatorMock{}, lg.WithName("atxDB"))
 	_ = atxdb
 
-	tb := New(conf, ld, minerID, n1, mockDB, nil, edSgn, signing.NewEDVerifier(), vrfSigner, signing.VRFVerifier{}, mwc, clock, logger)
+	tb := New(conf, minerID, n1, mockDB, nil, edSgn, signing.NewEDVerifier(), vrfSigner, signing.VRFVerifier{}, mwc, clock, logger)
 	requirer.NotNil(tb)
 	tb.SetSyncState(testSyncState(true))
 

--- a/tortoisebeacon/votes_calc.go
+++ b/tortoisebeacon/votes_calc.go
@@ -9,8 +9,8 @@ import (
 )
 
 func (tb *TortoiseBeacon) calcVotes(epoch types.EpochID, round types.RoundID, coinFlip bool) (allVotes, error) {
-	tb.consensusMu.Lock()
-	defer tb.consensusMu.Unlock()
+	tb.mu.Lock()
+	defer tb.mu.Unlock()
 
 	tb.Log.With().Debug("Calculating votes",
 		log.Uint32("epoch_id", uint32(epoch)),


### PR DESCRIPTION
## Motivation
slight simplification of tortoise beacon code 

## Changes
<!-- Please describe in detail the changes made -->
- use one mutex to synchronize access to struct variables. 
tortoise beacon operations are mostly serial and should not have lock contention. using one mutex keeps code logic less error prone.
- remove some redundant logic for epoch house keeping
- replace taskgroup with errgroup
- reduce calls to log.WithContext()

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->
unit tests

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
