### PR TITLE
[Merged by Bors] - tortoisebeacon: initialize proposal threshold just once per epoch

### DIFF
--- a/common/types/round.go
+++ b/common/types/round.go
@@ -1,4 +1,18 @@
 package types
 
-// RoundID is the round ID. It's 1-based, so the first round equals to 1.
+import (
+	"github.com/spacemeshos/go-spacemesh/log"
+)
+
+// RoundID is the round ID used to run any protocol that requires multiple rounds.
 type RoundID uint32
+
+const (
+	// FirstRound is convenient for initializing the index in a loop
+	FirstRound = RoundID(0)
+)
+
+// Field returns a log field. Implements the LoggableField interface.
+func (r RoundID) Field() log.Field {
+	return log.Uint32("round_id", uint32(r))
+}

--- a/tortoisebeacon/beacon_calc.go
+++ b/tortoisebeacon/beacon_calc.go
@@ -49,5 +49,5 @@ func (tb *TortoiseBeacon) calcBeacon(ctx context.Context, epoch types.EpochID, l
 }
 
 func (tb *TortoiseBeacon) lastRound() types.RoundID {
-	return tb.config.RoundsNumber - 1 + firstRound
+	return tb.config.RoundsNumber - 1
 }

--- a/tortoisebeacon/beacon_calc.go
+++ b/tortoisebeacon/beacon_calc.go
@@ -11,40 +11,30 @@ import (
 )
 
 func (tb *TortoiseBeacon) calcBeacon(ctx context.Context, epoch types.EpochID, lastRoundVotes allVotes) error {
-	tb.Log.WithContext(ctx).With().Info("calculating beacon", log.Uint32("epoch_id", uint32(epoch)))
+	logger := tb.logger.WithContext(ctx).WithFields(epoch)
+	logger.Info("calculating beacon")
 
 	allHashes := lastRoundVotes.valid.sort()
-
-	tb.Log.WithContext(ctx).With().Debug("calculating tortoise beacon from this hash list",
-		log.Uint32("epoch_id", uint32(epoch)),
+	logger.With().Debug("calculating tortoise beacon from this hash list",
 		log.String("hashes", strings.Join(allHashes, ", ")))
 
 	beacon := allHashes.hash()
 
-	tb.Log.WithContext(ctx).With().Info("calculated beacon", log.Uint32("epoch_id", uint32(epoch)),
-		log.String("beacon", beacon.ShortString()))
+	logger = logger.WithFields(log.String("beacon", beacon.ShortString()))
+	logger.With().Info("calculated beacon", log.Int("num_hashes", len(allHashes)))
 
 	events.ReportCalculatedTortoiseBeacon(epoch, beacon.ShortString())
 
 	tb.setBeacon(epoch, beacon)
 	if tb.tortoiseBeaconDB != nil {
-		tb.Log.WithContext(ctx).With().Info("writing beacon to database",
-			log.Uint32("epoch_id", uint32(epoch)),
-			log.String("beacon", beacon.ShortString()))
-
+		logger.Info("writing beacon to database")
 		if err := tb.tortoiseBeaconDB.SetTortoiseBeacon(epoch, beacon); err != nil {
-			tb.Log.WithContext(ctx).With().Error("failed to write tortoise beacon to database",
-				log.Uint32("epoch_id", uint32(epoch)),
-				log.String("beacon", beacon.ShortString()))
-
+			logger.With().Error("failed to write tortoise beacon to database", log.Err(err))
 			return fmt.Errorf("write tortoise beacon to DB: %w", err)
 		}
 	}
 
-	tb.Log.WithContext(ctx).With().Debug("beacon updated for this epoch",
-		log.Uint32("epoch_id", uint32(epoch)),
-		log.String("beacon", beacon.ShortString()))
-
+	logger.Debug("beacon updated for this epoch")
 	return nil
 }
 

--- a/tortoisebeacon/beacon_calc_test.go
+++ b/tortoisebeacon/beacon_calc_test.go
@@ -73,7 +73,7 @@ func TestTortoiseBeacon_calcBeacon(t *testing.T) {
 					Theta:        big.NewRat(1, 1),
 				},
 				epochInProgress: epoch,
-				Log:             logtest.New(t).WithName("TortoiseBeacon"),
+				logger:          logtest.New(t).WithName("TortoiseBeacon"),
 				beacons:         make(map[types.EpochID]types.Hash32),
 				atxDB:           mockDB,
 			}

--- a/tortoisebeacon/handlers_test.go
+++ b/tortoisebeacon/handlers_test.go
@@ -97,8 +97,7 @@ func TestTortoiseBeacon_handleProposalMessage(t *testing.T) {
 				epochInProgress: epoch,
 			}
 
-			sig, err := tb.getSignedProposal(context.TODO(), epoch)
-			r.NoError(err)
+			sig := tb.getSignedProposal(context.TODO(), epoch)
 			tc.message.VRFSignature = sig
 
 			err = tb.handleProposalMessage(context.TODO(), tc.message, time.Now())
@@ -219,8 +218,7 @@ func TestTortoiseBeacon_handleFirstVotingMessage(t *testing.T) {
 				hasVoted:                make([]map[string]struct{}, round+1),
 			}
 
-			sig, err := tb.signMessage(tc.message.FirstVotingMessageBody)
-			r.NoError(err)
+			sig := tb.signMessage(tc.message.FirstVotingMessageBody)
 			tc.message.Signature = sig
 
 			err = tb.handleFirstVotingMessage(context.TODO(), tc.message)
@@ -346,8 +344,7 @@ func TestTortoiseBeacon_handleFollowingVotingMessage(t *testing.T) {
 				votesMargin:     map[string]*big.Int{},
 			}
 
-			sig, err := tb.signMessage(tc.message.FollowingVotingMessageBody)
-			r.NoError(err)
+			sig := tb.signMessage(tc.message.FollowingVotingMessageBody)
 			tc.message.Signature = sig
 
 			err = tb.handleFollowingVotingMessage(context.TODO(), tc.message)

--- a/tortoisebeacon/handlers_test.go
+++ b/tortoisebeacon/handlers_test.go
@@ -88,7 +88,7 @@ func TestTortoiseBeacon_handleProposalMessage(t *testing.T) {
 
 			tb := TortoiseBeacon{
 				config:          UnitTestConfig(),
-				Log:             logtest.New(t).WithName("TortoiseBeacon"),
+				logger:          logtest.New(t).WithName("TortoiseBeacon"),
 				nodeID:          nodeID,
 				atxDB:           mockDB,
 				vrfVerifier:     signing.VRFVerifier{},
@@ -206,7 +206,7 @@ func TestTortoiseBeacon_handleFirstVotingMessage(t *testing.T) {
 			t.Parallel()
 
 			tb := TortoiseBeacon{
-				Log:                     logtest.New(t).WithName("TortoiseBeacon"),
+				logger:                  logtest.New(t).WithName("TortoiseBeacon"),
 				atxDB:                   mockDB,
 				vrfVerifier:             signing.VRFVerifier{},
 				vrfSigner:               vrfSigner,
@@ -326,7 +326,7 @@ func TestTortoiseBeacon_handleFollowingVotingMessage(t *testing.T) {
 				config: Config{
 					RoundsNumber: round + 1,
 				},
-				Log:         logtest.New(t).WithName("TortoiseBeacon"),
+				logger:      logtest.New(t).WithName("TortoiseBeacon"),
 				atxDB:       mockDB,
 				vrfVerifier: signing.VRFVerifier{},
 				vrfSigner:   vrfSigner,

--- a/tortoisebeacon/handlers_test.go
+++ b/tortoisebeacon/handlers_test.go
@@ -2,6 +2,7 @@ package tortoisebeacon
 
 import (
 	"context"
+	"fmt"
 	"math/big"
 	"testing"
 	"time"
@@ -15,44 +16,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func clockNeverNotify(t *testing.T) layerClock {
+	return timesync.NewClock(timesync.RealClock{}, time.Hour, time.Now(), logtest.New(t).WithName("clock"))
+}
+
 func TestTortoiseBeacon_handleProposalMessage(t *testing.T) {
 	t.Parallel()
 
 	r := require.New(t)
-
-	hash := types.HexToHash32("0x12345678")
-
-	genesisTime := time.Now().Add(time.Second * 10)
-	ld := time.Duration(10) * time.Second
-	clock := timesync.NewClock(timesync.RealClock{}, ld, genesisTime, logtest.New(t).WithName("clock"))
-	clock.StartNotifying()
-
-	ctrl := gomock.NewController(t)
-	mockDB := mocks.NewMockactivationDB(ctrl)
-	mockDB.EXPECT().GetEpochWeight(gomock.Any()).Return(uint64(10), nil, nil).AnyTimes()
-	mockDB.EXPECT().GetNodeAtxIDForEpoch(
-		gomock.Any(),
-		gomock.Any()).
-		Return(types.ATXID(hash), nil).AnyTimes()
-	mockDB.EXPECT().GetAtxHeader(gomock.Any()).Return(&types.ActivationTxHeader{
-		NIPostChallenge: types.NIPostChallenge{
-			StartTick: 1,
-			EndTick:   3,
-		},
-		NumUnits: 5,
-	}, nil).AnyTimes()
-	mockDB.EXPECT().GetAtxTimestamp(gomock.Any()).Return(time.Now(), nil)
-
-	const (
-		epoch = 3
-		round = 5
-	)
-
+	const epoch = types.EpochID(3)
 	types.SetLayersPerEpoch(1)
 
 	edSgn := signing.NewEdSigner()
 	edPubkey := edSgn.PublicKey()
-
 	vrfSigner, _, err := signing.NewVRFSigner(edSgn.Sign(edPubkey.Bytes()))
 	r.NoError(err)
 
@@ -61,54 +37,92 @@ func TestTortoiseBeacon_handleProposalMessage(t *testing.T) {
 		VRFPublicKey: vrfSigner.PublicKey().Bytes(),
 	}
 
+	ctrl := gomock.NewController(t)
+	mockChecker := mocks.NewMockeligibilityChecker(ctrl)
+	mockChecker.EXPECT().IsProposalEligible(gomock.Any()).Return(true).Times(1)
+	mockChecker.EXPECT().IsProposalEligible(gomock.Any()).Return(false).Times(1)
+
+	mockDB := mocks.NewMockactivationDB(ctrl)
+	mockDB.EXPECT().GetEpochWeight(epoch).Return(uint64(10), nil, nil).Times(1)
+	mockDB.EXPECT().GetNodeAtxIDForEpoch(
+		nodeID,
+		epoch-1).
+		Return(types.ATXID(types.HexToHash32("0x12345678")), nil).Times(3)
+	mockDB.EXPECT().GetAtxHeader(gomock.Any()).Return(&types.ActivationTxHeader{
+		NIPostChallenge: types.NIPostChallenge{
+			StartTick: 1,
+			EndTick:   3,
+		},
+		NumUnits: 5,
+	}, nil).Times(2)
+	mockDB.EXPECT().GetAtxTimestamp(gomock.Any()).Return(time.Now(), nil).Times(2)
+
+	sig := buildSignedProposal(context.TODO(), vrfSigner, epoch, logtest.New(t))
 	tt := []struct {
-		name                     string
-		epoch                    types.EpochID
-		currentRounds            map[types.EpochID]types.RoundID
-		message                  ProposalMessage
-		expectedIncomingProposal proposals
+		name        string
+		message     ProposalMessage
+		eligible    bool
+		expectedErr error
 	}{
 		{
-			name:  "Case 1",
-			epoch: epoch,
-			currentRounds: map[types.EpochID]types.RoundID{
-				epoch: round,
-			},
+			name: "bad signature",
 			message: ProposalMessage{
-				NodeID:  nodeID,
-				EpochID: epoch,
+				NodeID:       nodeID,
+				EpochID:      epoch,
+				VRFSignature: sig[1:], // missing the first byte
 			},
+			eligible:    false,
+			expectedErr: ErrMalformedProposal,
+		},
+		{
+			name: "proposal eligible",
+			message: ProposalMessage{
+				NodeID:       nodeID,
+				EpochID:      epoch,
+				VRFSignature: sig,
+			},
+			eligible:    true,
+			expectedErr: nil,
+		},
+		{
+			name: "proposal not eligible",
+			message: ProposalMessage{
+				NodeID:       nodeID,
+				EpochID:      epoch,
+				VRFSignature: sig,
+			},
+			eligible:    false,
+			expectedErr: nil,
 		},
 	}
-
-	for _, tc := range tt {
+	for i, tc := range tt {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
+			// don't run these tests in parallel. somehow all cases end up using the same TortoiseBeacon instance
+			// t.Parallel()
 
 			tb := TortoiseBeacon{
 				config:          UnitTestConfig(),
-				logger:          logtest.New(t).WithName("TortoiseBeacon"),
+				logger:          logtest.New(t).WithName(fmt.Sprintf("TortoiseBeacon-%v", i)),
 				nodeID:          nodeID,
 				atxDB:           mockDB,
 				vrfVerifier:     signing.VRFVerifier{},
 				vrfSigner:       vrfSigner,
-				clock:           clock,
+				clock:           clockNeverNotify(t),
 				epochInProgress: epoch,
+				proposalChecker: mockChecker,
 			}
 
-			sig := tb.getSignedProposal(context.TODO(), epoch)
-			tc.message.VRFSignature = sig
-
 			err = tb.handleProposalMessage(context.TODO(), tc.message, time.Now())
-			r.NoError(err)
+			r.Equal(tc.expectedErr, err)
 
-			expectedProposals := proposals{
-				valid: [][]byte{sig},
+			var expectedProposals proposals
+			if tc.eligible {
+				expectedProposals.valid = [][]byte{sig}
 			}
 
 			tb.mu.RLock()
-			r.EqualValues(expectedProposals, tb.incomingProposals)
+			r.EqualValues(expectedProposals, tb.incomingProposals, t.Name())
 			tb.mu.RUnlock()
 		})
 	}
@@ -143,7 +157,6 @@ func TestTortoiseBeacon_handleFirstVotingMessage(t *testing.T) {
 	mockDB.EXPECT().GetAtxTimestamp(gomock.Any()).Return(time.Now(), nil)
 
 	const (
-		epoch = 0
 		round = 0
 	)
 
@@ -155,25 +168,22 @@ func TestTortoiseBeacon_handleFirstVotingMessage(t *testing.T) {
 	vrfSigner, _, err := signing.NewVRFSigner(edSgn.Sign(edPubkey.Bytes()))
 	r.NoError(err)
 
+	msg := FirstVotingMessage{
+		FirstVotingMessageBody: FirstVotingMessageBody{
+			ValidProposals:            [][]byte{hash.Bytes()},
+			PotentiallyValidProposals: nil,
+		},
+	}
+	msg.Signature = signMessage(edSgn, msg.FirstVotingMessageBody, logtest.New(t))
+
 	tt := []struct {
-		name          string
-		epoch         types.EpochID
-		currentRounds map[types.EpochID]types.RoundID
-		message       FirstVotingMessage
-		expected      map[string]proposals
+		name     string
+		message  FirstVotingMessage
+		expected map[string]proposals
 	}{
 		{
-			name:  "Current round and message round equal",
-			epoch: epoch,
-			currentRounds: map[types.EpochID]types.RoundID{
-				epoch: round,
-			},
-			message: FirstVotingMessage{
-				FirstVotingMessageBody: FirstVotingMessageBody{
-					ValidProposals:            [][]byte{hash.Bytes()},
-					PotentiallyValidProposals: nil,
-				},
-			},
+			name:    "Current round and message round equal",
+			message: msg,
 			expected: map[string]proposals{
 				string(edSgn.PublicKey().Bytes()): {
 					valid: [][]byte{hash.Bytes()},
@@ -181,17 +191,8 @@ func TestTortoiseBeacon_handleFirstVotingMessage(t *testing.T) {
 			},
 		},
 		{
-			name:  "Current round and message round differ",
-			epoch: epoch,
-			currentRounds: map[types.EpochID]types.RoundID{
-				epoch: round + 1,
-			},
-			message: FirstVotingMessage{
-				FirstVotingMessageBody: FirstVotingMessageBody{
-					ValidProposals:            [][]byte{hash.Bytes()},
-					PotentiallyValidProposals: nil,
-				},
-			},
+			name:    "Current round and message round differ",
+			message: msg,
 			expected: map[string]proposals{
 				string(edSgn.PublicKey().Bytes()): {
 					valid: [][]byte{hash.Bytes()},
@@ -217,9 +218,6 @@ func TestTortoiseBeacon_handleFirstVotingMessage(t *testing.T) {
 				votesMargin:             map[string]*big.Int{},
 				hasVoted:                make([]map[string]struct{}, round+1),
 			}
-
-			sig := tb.signMessage(tc.message.FirstVotingMessageBody)
-			tc.message.Signature = sig
 
 			err = tb.handleFirstVotingMessage(context.TODO(), tc.message)
 			r.NoError(err)
@@ -272,25 +270,22 @@ func TestTortoiseBeacon_handleFollowingVotingMessage(t *testing.T) {
 	vrfSigner, _, err := signing.NewVRFSigner(edSgn.Sign(edPubkey.Bytes()))
 	r.NoError(err)
 
+	msg := FollowingVotingMessage{
+		FollowingVotingMessageBody: FollowingVotingMessageBody{
+			RoundID:        round,
+			VotesBitVector: []uint64{0b101},
+		},
+	}
+	msg.Signature = signMessage(edSgn, msg.FollowingVotingMessageBody, logtest.New(t))
+
 	tt := []struct {
-		name          string
-		epoch         types.EpochID
-		currentRounds map[types.EpochID]types.RoundID
-		message       FollowingVotingMessage
-		expected      map[string]*big.Int
+		name     string
+		message  FollowingVotingMessage
+		expected map[string]*big.Int
 	}{
 		{
-			name:  "Current round and message round equal",
-			epoch: epoch,
-			currentRounds: map[types.EpochID]types.RoundID{
-				epoch: round,
-			},
-			message: FollowingVotingMessage{
-				FollowingVotingMessageBody: FollowingVotingMessageBody{
-					RoundID:        round,
-					VotesBitVector: []uint64{0b101},
-				},
-			},
+			name:    "Current round and message round equal",
+			message: msg,
 			expected: map[string]*big.Int{
 				string(hash1.Bytes()): big.NewInt(1),
 				string(hash2.Bytes()): big.NewInt(-1),
@@ -298,17 +293,8 @@ func TestTortoiseBeacon_handleFollowingVotingMessage(t *testing.T) {
 			},
 		},
 		{
-			name:  "Current round and message round differ",
-			epoch: epoch,
-			currentRounds: map[types.EpochID]types.RoundID{
-				epoch: round + 1,
-			},
-			message: FollowingVotingMessage{
-				FollowingVotingMessageBody: FollowingVotingMessageBody{
-					RoundID:        round,
-					VotesBitVector: []uint64{0b101},
-				},
-			},
+			name:    "Current round and message round differ",
+			message: msg,
 			expected: map[string]*big.Int{
 				string(hash1.Bytes()): big.NewInt(1),
 				string(hash2.Bytes()): big.NewInt(-1),
@@ -343,9 +329,6 @@ func TestTortoiseBeacon_handleFollowingVotingMessage(t *testing.T) {
 				hasVoted:        make([]map[string]struct{}, round+1),
 				votesMargin:     map[string]*big.Int{},
 			}
-
-			sig := tb.signMessage(tc.message.FollowingVotingMessageBody)
-			tc.message.Signature = sig
 
 			err = tb.handleFollowingVotingMessage(context.TODO(), tc.message)
 			r.NoError(err)

--- a/tortoisebeacon/mocks/mocks.go
+++ b/tortoisebeacon/mocks/mocks.go
@@ -204,6 +204,43 @@ func (mr *MockcoinMockRecorder) StartRound(arg0, arg1 interface{}) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartRound", reflect.TypeOf((*Mockcoin)(nil).StartRound), arg0, arg1)
 }
 
+// MockeligibilityChecker is a mock of eligibilityChecker interface.
+type MockeligibilityChecker struct {
+	ctrl     *gomock.Controller
+	recorder *MockeligibilityCheckerMockRecorder
+}
+
+// MockeligibilityCheckerMockRecorder is the mock recorder for MockeligibilityChecker.
+type MockeligibilityCheckerMockRecorder struct {
+	mock *MockeligibilityChecker
+}
+
+// NewMockeligibilityChecker creates a new mock instance.
+func NewMockeligibilityChecker(ctrl *gomock.Controller) *MockeligibilityChecker {
+	mock := &MockeligibilityChecker{ctrl: ctrl}
+	mock.recorder = &MockeligibilityCheckerMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockeligibilityChecker) EXPECT() *MockeligibilityCheckerMockRecorder {
+	return m.recorder
+}
+
+// IsProposalEligible mocks base method.
+func (m *MockeligibilityChecker) IsProposalEligible(proposal []byte) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsProposalEligible", proposal)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsProposalEligible indicates an expected call of IsProposalEligible.
+func (mr *MockeligibilityCheckerMockRecorder) IsProposalEligible(proposal interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsProposalEligible", reflect.TypeOf((*MockeligibilityChecker)(nil).IsProposalEligible), proposal)
+}
+
 // MocklayerClock is a mock of layerClock interface.
 type MocklayerClock struct {
 	ctrl     *gomock.Controller

--- a/tortoisebeacon/mocks/mocks.go
+++ b/tortoisebeacon/mocks/mocks.go
@@ -129,41 +129,41 @@ func (m *Mockcoin) EXPECT() *MockcoinMockRecorder {
 }
 
 // FinishEpoch mocks base method.
-func (m *Mockcoin) FinishEpoch() {
+func (m *Mockcoin) FinishEpoch(arg0 context.Context, arg1 types.EpochID) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "FinishEpoch")
+	m.ctrl.Call(m, "FinishEpoch", arg0, arg1)
 }
 
 // FinishEpoch indicates an expected call of FinishEpoch.
-func (mr *MockcoinMockRecorder) FinishEpoch() *gomock.Call {
+func (mr *MockcoinMockRecorder) FinishEpoch(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FinishEpoch", reflect.TypeOf((*Mockcoin)(nil).FinishEpoch))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FinishEpoch", reflect.TypeOf((*Mockcoin)(nil).FinishEpoch), arg0, arg1)
 }
 
 // FinishRound mocks base method.
-func (m *Mockcoin) FinishRound() {
+func (m *Mockcoin) FinishRound(arg0 context.Context) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "FinishRound")
+	m.ctrl.Call(m, "FinishRound", arg0)
 }
 
 // FinishRound indicates an expected call of FinishRound.
-func (mr *MockcoinMockRecorder) FinishRound() *gomock.Call {
+func (mr *MockcoinMockRecorder) FinishRound(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FinishRound", reflect.TypeOf((*Mockcoin)(nil).FinishRound))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FinishRound", reflect.TypeOf((*Mockcoin)(nil).FinishRound), arg0)
 }
 
 // Get mocks base method.
-func (m *Mockcoin) Get(arg0 types.EpochID, arg1 types.RoundID) bool {
+func (m *Mockcoin) Get(arg0 context.Context, arg1 types.EpochID, arg2 types.RoundID) bool {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Get", arg0, arg1)
+	ret := m.ctrl.Call(m, "Get", arg0, arg1, arg2)
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
 // Get indicates an expected call of Get.
-func (mr *MockcoinMockRecorder) Get(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockcoinMockRecorder) Get(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*Mockcoin)(nil).Get), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*Mockcoin)(nil).Get), arg0, arg1, arg2)
 }
 
 // HandleSerializedMessage mocks base method.
@@ -179,15 +179,15 @@ func (mr *MockcoinMockRecorder) HandleSerializedMessage(arg0, arg1, arg2 interfa
 }
 
 // StartEpoch mocks base method.
-func (m *Mockcoin) StartEpoch(arg0 types.EpochID, arg1 weakcoin.UnitAllowances) {
+func (m *Mockcoin) StartEpoch(arg0 context.Context, arg1 types.EpochID, arg2 weakcoin.UnitAllowances) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "StartEpoch", arg0, arg1)
+	m.ctrl.Call(m, "StartEpoch", arg0, arg1, arg2)
 }
 
 // StartEpoch indicates an expected call of StartEpoch.
-func (mr *MockcoinMockRecorder) StartEpoch(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockcoinMockRecorder) StartEpoch(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartEpoch", reflect.TypeOf((*Mockcoin)(nil).StartEpoch), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartEpoch", reflect.TypeOf((*Mockcoin)(nil).StartEpoch), arg0, arg1, arg2)
 }
 
 // StartRound mocks base method.

--- a/tortoisebeacon/tortoise_beacon.go
+++ b/tortoisebeacon/tortoise_beacon.go
@@ -348,6 +348,7 @@ func (tb *TortoiseBeacon) handleEpoch(ctx context.Context, epoch types.EpochID) 
 	}
 	if epochWeight == 0 {
 		logger.With().Error("zero weight targeting epoch", log.Err(ErrZeroEpochWeight))
+		return
 	}
 
 	tb.mu.Lock()

--- a/tortoisebeacon/tortoise_beacon_test.go
+++ b/tortoisebeacon/tortoise_beacon_test.go
@@ -391,8 +391,7 @@ func TestTortoiseBeacon_buildProposal(t *testing.T) {
 				Log: logtest.New(t).WithName("TortoiseBeacon"),
 			}
 
-			result, err := tb.buildProposal(tc.epoch)
-			r.NoError(err)
+			result := tb.buildProposal(tc.epoch)
 			r.Equal(tc.result, string(result))
 		})
 	}
@@ -432,8 +431,7 @@ func TestTortoiseBeacon_signMessage(t *testing.T) {
 				edSigner: edSgn,
 			}
 
-			result, err := tb.signMessage(tc.message)
-			r.NoError(err)
+			result := tb.signMessage(tc.message)
 			r.Equal(string(tc.result), string(result))
 		})
 	}
@@ -477,8 +475,7 @@ func TestTortoiseBeacon_getSignedProposal(t *testing.T) {
 				vrfSigner: vrfSigner,
 			}
 
-			result, err := tb.getSignedProposal(context.TODO(), tc.epoch)
-			r.NoError(err)
+			result := tb.getSignedProposal(context.TODO(), tc.epoch)
 			r.Equal(string(tc.result), string(result))
 		})
 	}

--- a/tortoisebeacon/votes_calc.go
+++ b/tortoisebeacon/votes_calc.go
@@ -1,6 +1,7 @@
 package tortoisebeacon
 
 import (
+	"context"
 	"fmt"
 	"math/big"
 
@@ -8,25 +9,21 @@ import (
 	"github.com/spacemeshos/go-spacemesh/log"
 )
 
-func (tb *TortoiseBeacon) calcVotes(epoch types.EpochID, round types.RoundID, coinFlip bool) (allVotes, error) {
+func (tb *TortoiseBeacon) calcVotes(ctx context.Context, epoch types.EpochID, round types.RoundID, coinFlip bool) (allVotes, error) {
+	logger := tb.logger.WithContext(ctx).WithFields(epoch, round, log.Bool("weak_coin", coinFlip))
 	tb.mu.Lock()
 	defer tb.mu.Unlock()
 
-	tb.Log.With().Debug("Calculating votes",
-		log.Uint32("epoch_id", uint32(epoch)),
-		log.Uint32("round_id", uint32(round)),
-		log.String("votesMargin", fmt.Sprint(tb.votesMargin)))
+	logger.With().Debug("calculating votes", log.String("vote_margins", fmt.Sprint(tb.votesMargin)))
 
 	ownCurrentRoundVotes, err := tb.calcOwnCurrentRoundVotes(epoch, coinFlip)
 	if err != nil {
 		return allVotes{}, fmt.Errorf("calc own current round votes: %w", err)
 	}
 
-	tb.Log.With().Debug("Calculated votes for one round",
-		log.Uint32("epoch_id", uint32(epoch)),
-		log.Uint32("round_id", uint32(round)),
-		log.String("for", fmt.Sprint(ownCurrentRoundVotes.valid)),
-		log.String("against", fmt.Sprint(ownCurrentRoundVotes.invalid)))
+	logger.With().Debug("calculated votes for one round",
+		log.String("for_votes", fmt.Sprint(ownCurrentRoundVotes.valid)),
+		log.String("against_votes", fmt.Sprint(ownCurrentRoundVotes.invalid)))
 
 	return ownCurrentRoundVotes, nil
 }

--- a/tortoisebeacon/votes_calc_test.go
+++ b/tortoisebeacon/votes_calc_test.go
@@ -1,6 +1,7 @@
 package tortoisebeacon
 
 import (
+	"context"
 	"math/big"
 	"testing"
 
@@ -8,27 +9,8 @@ import (
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/log/logtest"
 	"github.com/spacemeshos/go-spacemesh/tortoisebeacon/mocks"
-	"github.com/spacemeshos/go-spacemesh/tortoisebeacon/weakcoin"
 	"github.com/stretchr/testify/require"
 )
-
-func coinValueMock(tb testing.TB, value bool) coin {
-	ctrl := gomock.NewController(tb)
-	coinMock := mocks.NewMockcoin(ctrl)
-	coinMock.EXPECT().StartEpoch(
-		gomock.AssignableToTypeOf(types.EpochID(0)),
-		gomock.AssignableToTypeOf(weakcoin.UnitAllowances{}),
-	).AnyTimes()
-	coinMock.EXPECT().FinishEpoch().AnyTimes()
-	coinMock.EXPECT().StartRound(gomock.Any(), gomock.AssignableToTypeOf(types.RoundID(0))).
-		AnyTimes().Return(nil)
-	coinMock.EXPECT().FinishRound().AnyTimes()
-	coinMock.EXPECT().Get(
-		gomock.AssignableToTypeOf(types.EpochID(0)),
-		gomock.AssignableToTypeOf(types.RoundID(0)),
-	).AnyTimes().Return(value)
-	return coinMock
-}
 
 func TestTortoiseBeacon_calcVotes(t *testing.T) {
 	t.Parallel()
@@ -93,12 +75,12 @@ func TestTortoiseBeacon_calcVotes(t *testing.T) {
 				config: Config{
 					Theta: big.NewRat(1, 1),
 				},
-				Log:         logtest.New(t).WithName("TortoiseBeacon"),
+				logger:      logtest.New(t).WithName("TortoiseBeacon"),
 				atxDB:       mockDB,
 				votesMargin: tc.votesMargin,
 			}
 
-			result, err := tb.calcVotes(tc.epoch, tc.round, false)
+			result, err := tb.calcVotes(context.TODO(), tc.epoch, tc.round, false)
 			r.NoError(err)
 			r.EqualValues(tc.expected, result)
 		})
@@ -192,7 +174,7 @@ func TestTortoiseBeacon_calcOwnCurrentRoundVotes(t *testing.T) {
 				config: Config{
 					Theta: big.NewRat(1, 1),
 				},
-				Log:         logtest.New(t).WithName("TortoiseBeacon"),
+				logger:      logtest.New(t).WithName("TortoiseBeacon"),
 				atxDB:       mockDB,
 				votesMargin: tc.votesCount,
 			}

--- a/tortoisebeacon/votes_decoder_test.go
+++ b/tortoisebeacon/votes_decoder_test.go
@@ -62,7 +62,7 @@ func TestTortoiseBeacon_decodeVotes(t *testing.T) {
 				config: Config{
 					VotesLimit: 100,
 				},
-				Log: logtest.New(t).WithName("TortoiseBeacon"),
+				logger: logtest.New(t).WithName("TortoiseBeacon"),
 			}
 
 			result := tb.decodeVotes(tc.bitVector, tc.firstRound)

--- a/tortoisebeacon/votes_encoder_test.go
+++ b/tortoisebeacon/votes_encoder_test.go
@@ -63,7 +63,7 @@ func TestTortoiseBeacon_encodeVotes(t *testing.T) {
 				config: Config{
 					VotesLimit: 100,
 				},
-				Log: logtest.New(t).WithName("TortoiseBeacon"),
+				logger: logtest.New(t).WithName("TortoiseBeacon"),
 			}
 
 			result := tb.encodeVotes(tc.currentRound, tc.proposals)

--- a/tortoisebeacon/weakcoin/handler.go
+++ b/tortoisebeacon/weakcoin/handler.go
@@ -10,31 +10,29 @@ import (
 )
 
 // HandleSerializedMessage defines method to handle Tortoise Beacon Weak Coin Messages from gossip.
-func (wc *WeakCoin) HandleSerializedMessage(ctx context.Context, data service.GossipMessage, sync service.Fetcher) {
-	wc.logger.With().Debug("received weak coin message",
+func (wc *WeakCoin) HandleSerializedMessage(ctx context.Context, data service.GossipMessage, _ service.Fetcher) {
+	logger := wc.logger.WithContext(ctx)
+	logger.With().Debug("received weak coin message",
 		log.String("from", data.Sender().String()),
 		log.Binary("data", data.Bytes()),
 	)
 
 	var message Message
 	if err := types.BytesToInterface(data.Bytes(), &message); err != nil {
-		wc.logger.With().Debug("received invalid weak coin message",
+		logger.With().Warning("received invalid weak coin message",
 			log.Binary("message", data.Bytes()),
 			log.Err(err))
 		return
 	}
 
-	if err := wc.receiveMessage(message); err != nil {
-		wc.logger.With().Debug("received invalid proposal",
-			log.Err(err),
-			log.Uint32("epoch_id", uint32(message.Epoch)),
-			log.Uint32("round_id", uint32(message.Round)))
+	if err := wc.receiveMessage(ctx, message); err != nil {
+		logger.With().Debug("received invalid proposal", message.Epoch, message.Round, log.Err(err))
 		return
 	}
 	data.ReportValidation(ctx, GossipProtocol)
 }
 
-func (wc *WeakCoin) receiveMessage(message Message) error {
+func (wc *WeakCoin) receiveMessage(ctx context.Context, message Message) error {
 	if wc.aboveThreshold(message.Signature) {
 		return fmt.Errorf("proposal %x is above threshold", message.Signature)
 	}
@@ -48,7 +46,7 @@ func (wc *WeakCoin) receiveMessage(message Message) error {
 		}
 		return fmt.Errorf("message for the wrong round %v/%v", message.Epoch, message.Round)
 	}
-	return wc.updateProposal(message)
+	return wc.updateProposal(ctx, message)
 }
 
 func (wc *WeakCoin) isNextRound(epoch types.EpochID, round types.RoundID) bool {

--- a/tortoisebeacon/weakcoin/weak_coin.go
+++ b/tortoisebeacon/weakcoin/weak_coin.go
@@ -230,7 +230,7 @@ func (wc *WeakCoin) prepareProposal(epoch types.EpochID, round types.RoundID) (b
 			}
 			msg, err := types.InterfaceToBytes(message)
 			if err != nil {
-				wc.logger.Panic("can't serialize weak coin message", log.Err(err))
+				wc.logger.Panic("failed to serialize weak coin message", log.Err(err))
 			}
 
 			broadcast = msg

--- a/tortoisebeacon/weakcoin/weak_coin.go
+++ b/tortoisebeacon/weakcoin/weak_coin.go
@@ -131,15 +131,15 @@ type WeakCoin struct {
 
 // Get the result of the coin flip in this round. It is only valid in between StartEpoch/EndEpoch
 // and only after CompleteRound was called.
-func (wc *WeakCoin) Get(epoch types.EpochID, round types.RoundID) bool {
+func (wc *WeakCoin) Get(ctx context.Context, epoch types.EpochID, round types.RoundID) bool {
 	if epoch.IsGenesis() {
-		return false
+		wc.logger.WithContext(ctx).With().Panic("tb weak coin not used during genesis")
 	}
 
 	wc.mu.RLock()
 	defer wc.mu.RUnlock()
 	if wc.epoch != epoch {
-		wc.logger.Panic("requested epoch wasn't started or already completed",
+		wc.logger.WithContext(ctx).With().Panic("requested epoch wasn't started or already completed",
 			log.Uint32("started_epoch", uint32(wc.epoch)),
 			log.Uint32("requested_epoch", uint32(epoch)))
 	}
@@ -148,30 +148,35 @@ func (wc *WeakCoin) Get(epoch types.EpochID, round types.RoundID) bool {
 }
 
 // StartEpoch notifies that epoch is started and we can accept messages for this epoch.
-func (wc *WeakCoin) StartEpoch(epoch types.EpochID, allowances UnitAllowances) {
+func (wc *WeakCoin) StartEpoch(ctx context.Context, epoch types.EpochID, allowances UnitAllowances) {
 	wc.mu.Lock()
 	defer wc.mu.Unlock()
 	wc.epochStarted = true
 	wc.epoch = epoch
 	wc.allowances = allowances
+	wc.logger.WithContext(ctx).With().Info("tb weak coin started epoch", epoch)
 }
 
 // FinishEpoch completes epoch. After it is called Get for this epoch will panic.
-func (wc *WeakCoin) FinishEpoch() {
+func (wc *WeakCoin) FinishEpoch(ctx context.Context, epoch types.EpochID) {
+	logger := wc.logger.WithContext(ctx).WithFields(epoch)
 	wc.mu.Lock()
 	defer wc.mu.Unlock()
+	if epoch != wc.epoch {
+		logger.Panic("attempted to finish tb weak coin for the wrong epoch")
+	}
 	wc.epochStarted = false
 	wc.allowances = nil
 	wc.coins = map[types.RoundID]bool{}
 	wc.round = 0
+	logger.Info("tb weak coin finished epoch")
 }
 
 // StartRound process any buffered messages for this round and broadcast our proposal.
 func (wc *WeakCoin) StartRound(ctx context.Context, round types.RoundID) error {
 	wc.mu.Lock()
-	wc.logger.With().Info("started round",
-		log.Uint32("epoch_id", uint32(wc.epoch)),
-		log.Uint32("round_id", uint32(round)))
+	logger := wc.logger.WithContext(ctx).WithFields(wc.epoch, round)
+	logger.Info("started round")
 	wc.roundStarted = true
 	wc.round = round
 	wc.smallestProposal = nil
@@ -180,11 +185,8 @@ func (wc *WeakCoin) StartRound(ctx context.Context, round types.RoundID) error {
 		if msg.Epoch != wc.epoch || msg.Round != wc.round {
 			continue
 		}
-		if err := wc.updateProposal(msg); err != nil {
-			wc.logger.With().Debug("received invalid proposal",
-				log.Err(err),
-				log.Uint32("epoch_id", uint32(msg.Epoch)),
-				log.Uint32("round_id", uint32(msg.Round)))
+		if err := wc.updateProposal(ctx, msg); err != nil {
+			logger.With().Debug("received invalid proposal", log.Err(err))
 		}
 		wc.nextRoundBuffer[i] = Message{}
 	}
@@ -193,7 +195,7 @@ func (wc *WeakCoin) StartRound(ctx context.Context, round types.RoundID) error {
 	return wc.publishProposal(ctx, epoch, round)
 }
 
-func (wc *WeakCoin) updateProposal(message Message) error {
+func (wc *WeakCoin) updateProposal(ctx context.Context, message Message) error {
 	buf := wc.encodeProposal(message.Epoch, message.Round, message.Unit)
 	if !wc.verifier.Verify(signing.NewPublicKey(message.MinerPK), buf, message.Signature) {
 		return fmt.Errorf("signature is invalid signature %x", message.Signature)
@@ -204,7 +206,7 @@ func (wc *WeakCoin) updateProposal(message Message) error {
 		return fmt.Errorf("miner %x is not allowed to submit proposal for unit %d", message.MinerPK, message.Unit)
 	}
 
-	wc.updateSmallest(message.Signature)
+	wc.updateSmallest(ctx, message.Signature)
 	return nil
 }
 
@@ -230,7 +232,7 @@ func (wc *WeakCoin) prepareProposal(epoch types.EpochID, round types.RoundID) (b
 			}
 			msg, err := types.InterfaceToBytes(message)
 			if err != nil {
-				wc.logger.Panic("failed to serialize weak coin message", log.Err(err))
+				wc.logger.With().Panic("failed to serialize weak coin message", log.Err(err))
 			}
 
 			broadcast = msg
@@ -252,9 +254,9 @@ func (wc *WeakCoin) publishProposal(ctx context.Context, epoch types.EpochID, ro
 		return fmt.Errorf("failed to broadcast weak coin message: %w", err)
 	}
 
-	wc.logger.With().Info("published proposal",
-		log.Uint32("epoch_id", uint32(epoch)),
-		log.Uint32("round_id", uint32(round)),
+	wc.logger.WithContext(ctx).With().Info("published proposal",
+		epoch,
+		round,
 		log.String("proposal", types.BytesToHash(smallest).ShortString()))
 
 	wc.mu.Lock()
@@ -263,21 +265,19 @@ func (wc *WeakCoin) publishProposal(ctx context.Context, epoch types.EpochID, ro
 		// another epoch/round was started concurrently
 		return nil
 	}
-	wc.updateSmallest(smallest)
+	wc.updateSmallest(ctx, smallest)
 	return nil
 }
 
 // FinishRound computes coinflip based on proposals received in this round.
 // After it is called new proposals for this round won't be accepted.
-func (wc *WeakCoin) FinishRound() {
+func (wc *WeakCoin) FinishRound(ctx context.Context) {
 	wc.mu.Lock()
 	defer wc.mu.Unlock()
+	logger := wc.logger.WithContext(ctx).WithFields(wc.epoch, wc.round)
 	wc.roundStarted = false
 	if wc.smallestProposal == nil {
-		wc.logger.With().Warning("completed round without valid proposals",
-			log.Uint32("epoch_id", uint32(wc.epoch)),
-			log.Uint32("round_id", uint32(wc.round)),
-		)
+		logger.Warning("completed round without valid proposals")
 		return
 	}
 	// NOTE(dshulyak) we need to select good bit here. for ed25519 it means select LSB and never MSB.
@@ -290,19 +290,17 @@ func (wc *WeakCoin) FinishRound() {
 	coinflip := wc.smallestProposal[lsbIndex]&1 == 1
 
 	wc.coins[wc.round] = coinflip
-	wc.logger.With().Info("completed round",
-		log.Uint32("epoch_id", uint32(wc.epoch)),
-		log.Uint32("round_id", uint32(wc.round)),
+	logger.With().Info("completed round",
 		log.String("proposal", types.BytesToHash(wc.smallestProposal).ShortString()),
-		log.Bool("coinflip", coinflip))
+		log.Bool("tb_weakcoin", coinflip))
 	wc.smallestProposal = nil
 }
 
-func (wc *WeakCoin) updateSmallest(proposal []byte) {
+func (wc *WeakCoin) updateSmallest(ctx context.Context, proposal []byte) {
 	if len(proposal) > 0 && (bytes.Compare(proposal, wc.smallestProposal) == -1 || wc.smallestProposal == nil) {
-		wc.logger.With().Debug("saving new proposal",
-			log.Uint32("epoch_id", uint32(wc.epoch)),
-			log.Uint64("round_id", uint64(wc.round)),
+		wc.logger.WithContext(ctx).With().Debug("saving new proposal",
+			wc.epoch,
+			wc.round,
 			log.String("proposal", types.BytesToHash(proposal).ShortString()),
 			log.String("previous", types.BytesToHash(wc.smallestProposal).ShortString()),
 		)
@@ -318,17 +316,17 @@ func (wc *WeakCoin) encodeProposal(epoch types.EpochID, round types.RoundID, uni
 	proposal := bytes.Buffer{}
 	proposal.WriteString(wc.config.VRFPrefix)
 	if _, err := proposal.Write(epoch.ToBytes()); err != nil {
-		wc.logger.Panic("can't write epoch to a buffer", log.Err(err))
+		wc.logger.With().Panic("can't write epoch to a buffer", log.Err(err))
 	}
 	roundBuf := make([]byte, 8)
 	binary.LittleEndian.PutUint64(roundBuf, uint64(round))
 	if _, err := proposal.Write(roundBuf); err != nil {
-		wc.logger.Panic("can't write uint64 to a buffer", log.Err(err))
+		wc.logger.With().Panic("can't write uint64 to a buffer", log.Err(err))
 	}
 	buf := make([]byte, 8)
 	binary.LittleEndian.PutUint64(buf, unit)
 	if _, err := proposal.Write(buf); err != nil {
-		wc.logger.Panic("can't write uint64 to a buffer", log.Err(err))
+		wc.logger.With().Panic("can't write uint64 to a buffer", log.Err(err))
 	}
 	return proposal.Bytes()
 }

--- a/tortoisebeacon/weakcoin/weak_coin_test.go
+++ b/tortoisebeacon/weakcoin/weak_coin_test.go
@@ -193,15 +193,15 @@ func TestWeakCoin(t *testing.T) {
 				weakcoin.WithThreshold([]byte{0xfe}),
 			)
 
-			wc.StartEpoch(tc.startedEpoch, tc.allowances)
+			wc.StartEpoch(context.TODO(), tc.startedEpoch, tc.allowances)
 			require.NoError(t, wc.StartRound(context.TODO(), tc.startedRound))
 
 			for _, msg := range tc.messages {
 				wc.HandleSerializedMessage(context.TODO(), broadcastedMessage(t, ctrl, msg), nil)
 			}
-			wc.FinishRound()
+			wc.FinishRound(context.TODO())
 
-			require.Equal(t, tc.coinflip, wc.Get(tc.startedEpoch, tc.startedRound))
+			require.Equal(t, tc.coinflip, wc.Get(context.TODO(), tc.startedEpoch, tc.startedRound))
 		})
 	}
 
@@ -214,15 +214,15 @@ func TestWeakCoin(t *testing.T) {
 				weakcoin.WithThreshold([]byte{0xfe}),
 			)
 
-			wc.StartEpoch(tc.startedEpoch, tc.allowances)
+			wc.StartEpoch(context.TODO(), tc.startedEpoch, tc.allowances)
 
 			for _, msg := range tc.messages {
 				wc.HandleSerializedMessage(context.TODO(), broadcastedMessage(t, ctrl, msg), nil)
 			}
 			require.NoError(t, wc.StartRound(context.TODO(), tc.startedRound))
-			wc.FinishRound()
+			wc.FinishRound(context.TODO())
 
-			require.Equal(t, tc.coinflip, wc.Get(tc.startedEpoch, tc.startedRound))
+			require.Equal(t, tc.coinflip, wc.Get(context.TODO(), tc.startedEpoch, tc.startedRound))
 		})
 	}
 
@@ -235,7 +235,7 @@ func TestWeakCoin(t *testing.T) {
 				weakcoin.WithThreshold([]byte{0xfe}),
 			)
 
-			wc.StartEpoch(tc.startedEpoch, tc.allowances)
+			wc.StartEpoch(context.TODO(), tc.startedEpoch, tc.allowances)
 			require.NoError(t, wc.StartRound(context.TODO(), tc.startedRound))
 
 			for _, msg := range tc.messages {
@@ -244,10 +244,10 @@ func TestWeakCoin(t *testing.T) {
 			}
 
 			require.NoError(t, wc.StartRound(context.TODO(), tc.startedRound+1))
-			wc.FinishRound()
+			wc.FinishRound(context.TODO())
 
-			require.Equal(t, tc.coinflip, wc.Get(tc.startedEpoch, tc.startedRound+1))
-			wc.FinishEpoch()
+			require.Equal(t, tc.coinflip, wc.Get(context.TODO(), tc.startedEpoch, tc.startedRound+1))
+			wc.FinishEpoch(context.TODO(), tc.startedEpoch)
 		})
 	}
 	for _, tc := range tcs {
@@ -259,20 +259,20 @@ func TestWeakCoin(t *testing.T) {
 				weakcoin.WithThreshold([]byte{0xfe}),
 			)
 
-			wc.StartEpoch(tc.startedEpoch, tc.allowances)
-			wc.FinishEpoch()
+			wc.StartEpoch(context.TODO(), tc.startedEpoch, tc.allowances)
+			wc.FinishEpoch(context.TODO(), tc.startedEpoch)
 
-			wc.StartEpoch(tc.startedEpoch+1, tc.allowances)
+			wc.StartEpoch(context.TODO(), tc.startedEpoch+1, tc.allowances)
 			for _, msg := range tc.messages {
 				msg.Epoch++
 				wc.HandleSerializedMessage(context.TODO(), broadcastedMessage(t, ctrl, msg), nil)
 			}
 
 			require.NoError(t, wc.StartRound(context.TODO(), tc.startedRound))
-			wc.FinishRound()
+			wc.FinishRound(context.TODO())
 
-			require.Equal(t, tc.coinflip, wc.Get(tc.startedEpoch+1, tc.startedRound))
-			wc.FinishEpoch()
+			require.Equal(t, tc.coinflip, wc.Get(context.TODO(), tc.startedEpoch+1, tc.startedRound))
+			wc.FinishEpoch(context.TODO(), tc.startedEpoch+1)
 		})
 	}
 }
@@ -289,11 +289,11 @@ func TestWeakCoinGetPanic(t *testing.T) {
 	defer ctrl.Finish()
 
 	require.Panics(t, func() {
-		wc.Get(epoch, round)
+		wc.Get(context.TODO(), epoch, round)
 	})
 
-	wc.StartEpoch(epoch, nil)
-	require.False(t, wc.Get(epoch, round))
+	wc.StartEpoch(context.TODO(), epoch, nil)
+	require.False(t, wc.Get(context.TODO(), epoch, round))
 }
 
 func TestWeakCoinNextRoundBufferOverflow(t *testing.T) {
@@ -316,7 +316,7 @@ func TestWeakCoinNextRoundBufferOverflow(t *testing.T) {
 		weakcoin.WithNextRoundBufferSize(bufSize),
 	)
 
-	wc.StartEpoch(epoch, weakcoin.UnitAllowances{string(oneLSB): 1, string(zeroLSB): 1})
+	wc.StartEpoch(context.TODO(), epoch, weakcoin.UnitAllowances{string(oneLSB): 1, string(zeroLSB): 1})
 	require.NoError(t, wc.StartRound(context.TODO(), round))
 	for i := 0; i < bufSize; i++ {
 		wc.HandleSerializedMessage(context.TODO(), broadcastedMessage(t, ctrl, weakcoin.Message{
@@ -333,10 +333,10 @@ func TestWeakCoinNextRoundBufferOverflow(t *testing.T) {
 		Unit:      1,
 		Signature: zeroLSB,
 	}), nil)
-	wc.FinishRound()
+	wc.FinishRound(context.TODO())
 	require.NoError(t, wc.StartRound(context.TODO(), nextRound))
-	wc.FinishRound()
-	require.True(t, wc.Get(epoch, nextRound))
+	wc.FinishRound(context.TODO())
+	require.True(t, wc.Get(context.TODO(), epoch, nextRound))
 }
 
 func TestWeakCoinEncodingRegression(t *testing.T) {
@@ -363,7 +363,7 @@ func TestWeakCoinEncodingRegression(t *testing.T) {
 
 	allowances := weakcoin.UnitAllowances{string(signer.PublicKey().Bytes()): 1}
 	instance := weakcoin.New(broadcaster, signer, signing.VRFVerifier{}, weakcoin.WithThreshold([]byte{0xff}))
-	instance.StartEpoch(epoch, allowances)
+	instance.StartEpoch(context.TODO(), epoch, allowances)
 	require.NoError(t, instance.StartRound(context.TODO(), round))
 
 	require.Equal(t,
@@ -378,7 +378,7 @@ func TestWeakCoinExchangeProposals(t *testing.T) {
 	var (
 		instances                          = make([]*weakcoin.WeakCoin, 10)
 		verifier                           = signing.VRFVerifier{}
-		epochStart, epochEnd types.EpochID = 0, 4
+		epochStart, epochEnd types.EpochID = 2, 6
 		start, end           types.RoundID = 0, 9
 		allowances                         = weakcoin.UnitAllowances{}
 		r                                  = rand.New(rand.NewSource(999))
@@ -411,22 +411,22 @@ func TestWeakCoinExchangeProposals(t *testing.T) {
 
 	for epoch := epochStart; epoch <= epochEnd; epoch++ {
 		for _, instance := range instances {
-			instance.StartEpoch(epoch, allowances)
+			instance.StartEpoch(context.TODO(), epoch, allowances)
 		}
 		for current := start; current <= end; current++ {
 			for _, instance := range instances {
 				require.NoError(t, instance.StartRound(context.TODO(), current))
 			}
 			for _, instance := range instances {
-				instance.FinishRound()
+				instance.FinishRound(context.TODO())
 			}
-			rst := instances[0].Get(epoch, current)
+			rst := instances[0].Get(context.TODO(), epoch, current)
 			for _, instance := range instances[1:] {
-				require.Equal(t, rst, instance.Get(epoch, current), "round %d", current)
+				require.Equal(t, rst, instance.Get(context.TODO(), epoch, current), "round %d", current)
 			}
 		}
 		for _, instance := range instances {
-			instance.FinishEpoch()
+			instance.FinishEpoch(context.TODO(), epoch)
 		}
 	}
 }


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
Closes #2786
- proposal threshold is calculated once per proposal based on the total weight of previous epoch. this is inefficient.
- the more test the merrier. this is the first PR that add tests to tortoise beacon. more to follow.

## Changes
<!-- Please describe in detail the changes made -->
in commit order
- simplify error handling
- reuse more log.WithContext()
- initialize a proposal eligibility checker and only do the threshold calculation once at the start of epoch
- remove the receiver for some functions to facilitate testing
- add test cases:
  - proposal that doesn't pass eligibility
  - proposal with bad vrf signature

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->
unit tests

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
