### PR TITLE
[Merged by Bors] - Wait for any number of peers not only outbound when sync is started

### DIFF
--- a/cmd/node/multi_node.go
+++ b/cmd/node/multi_node.go
@@ -131,6 +131,8 @@ func getTestDefaultConfig() *config.Config {
 		log.Error("cannot load config from file")
 		return nil
 	}
+	// is set to 0 to make sync start immediatly when node starts
+	cfg.P2P.SwarmConfig.RandomConnections = 0
 
 	cfg.POST = activation.DefaultPostConfig()
 	cfg.POST.LabelsPerUnit = 32

--- a/p2p/peers/peers.go
+++ b/p2p/peers/peers.go
@@ -101,6 +101,9 @@ func (p *Peers) PeerCount() uint64 {
 // WaitPeers returns with atleast N peers or when context is terminated.
 // Nil slice is returned if Peers is closing.
 func (p *Peers) WaitPeers(ctx context.Context, n int) ([]Peer, error) {
+	if n == 0 {
+		return nil, nil
+	}
 	req := waitPeersReq{min: n, ch: make(chan []Peer, 1)}
 	select {
 	case <-ctx.Done():


### PR DESCRIPTION
## Motivation

I had multiple errors due to the slow discovery recently. I also tried other approaches:
1. randcon to 2 resulted in flaky errors due to the problems with message delivery
2. randcon to 5 still got same errors with slow discovery

So i decided to use any peers when sync is started. Note that it uses same parameter (`randcon`) but now we will wait for any peers, not only outbound peers when starting discovery. I didn't want to introduce additional parameter specifically for starting sync.

I will open an issue once this is merged to make sure that we will address the requirement to wait for outbound peers.

Closes https://github.com/spacemeshos/go-spacemesh/issues/2764

## Changes
- wait for both inbound and outbound peers when starting sync  

## Test Plan
app and system tests

## TODO
<!-- This section should be removed when all items are complete -->
- [ ] Explain motivation or link existing issue(s)
- [ ] Test changes and document test plan
- [ ] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
