### PR TITLE
[Merged by Bors] - tortoise beacon: disallow double proposals and add more tests

### DIFF
--- a/tortoisebeacon/handlers.go
+++ b/tortoisebeacon/handlers.go
@@ -196,7 +196,8 @@ func (tb *TortoiseBeacon) verifyProposalMessage(ctx context.Context, m ProposalM
 		// the peer may have different total weight from us so that it passes threshold for the peer
 		// but does not pass here
 		logger.With().Warning("rejected proposal that doesn't pass threshold",
-			log.String("proposal", proposalShortString))
+			log.String("proposal", proposalShortString),
+			log.Uint64("total_weight", tb.epochWeight))
 
 		return types.ATXID{}, ErrProposalDoesntPassThreshold
 	}

--- a/tortoisebeacon/handlers.go
+++ b/tortoisebeacon/handlers.go
@@ -469,6 +469,8 @@ func (tb *TortoiseBeacon) storeFollowingVotes(message FollowingVotingMessage, mi
 		}
 	}
 
+	// TODO(kimmy): keep later rounds votes in a separate buffer so we don't count them prematurely
+	// tho i am not sure whether counting votes for later rounds early is a security concern.
 	for vote := range thisRoundVotes.invalid {
 		if _, ok := tb.votesMargin[vote]; !ok {
 			tb.votesMargin[vote] = new(big.Int).Neg(voteWeight)

--- a/tortoisebeacon/handlers.go
+++ b/tortoisebeacon/handlers.go
@@ -147,17 +147,29 @@ func (tb *TortoiseBeacon) classifyProposalMessage(ctx context.Context, m Proposa
 	switch {
 	case tb.isValidProposalMessage(currentEpoch, atxTimestamp, nextEpochStart, receivedTime):
 		logger.Debug("received valid proposal message")
-		tb.incomingProposals.valid = append(tb.incomingProposals.valid, m.VRFSignature)
+		tb.addValidProposal(m.VRFSignature)
 
 	case tb.isPotentiallyValidProposalMessage(currentEpoch, atxTimestamp, nextEpochStart, receivedTime):
 		logger.Debug("received potentially valid proposal message")
-		tb.incomingProposals.potentiallyValid = append(tb.incomingProposals.potentiallyValid, m.VRFSignature)
+		tb.addPotentiallyValidProposal(m.VRFSignature)
 
 	default:
 		logger.Warning("received invalid proposal message")
 	}
 
 	return nil
+}
+
+func (tb *TortoiseBeacon) addValidProposal(proposal []byte) {
+	tb.mu.Lock()
+	defer tb.mu.Unlock()
+	tb.incomingProposals.valid = append(tb.incomingProposals.valid, proposal)
+}
+
+func (tb *TortoiseBeacon) addPotentiallyValidProposal(proposal []byte) {
+	tb.mu.Lock()
+	defer tb.mu.Unlock()
+	tb.incomingProposals.potentiallyValid = append(tb.incomingProposals.potentiallyValid, proposal)
 }
 
 func (tb *TortoiseBeacon) verifyProposalMessage(ctx context.Context, m ProposalMessage, currentEpoch types.EpochID) (types.ATXID, error) {

--- a/tortoisebeacon/message.go
+++ b/tortoisebeacon/message.go
@@ -33,6 +33,7 @@ type proposalMessageWithReceiptData struct {
 
 // FirstVotingMessageBody is FirstVotingMessage without a signature.
 type FirstVotingMessageBody struct {
+	EpochID                   types.EpochID
 	ValidProposals            [][]byte
 	PotentiallyValidProposals [][]byte
 }
@@ -55,7 +56,7 @@ func (v FirstVotingMessage) String() string {
 
 // FollowingVotingMessageBody is FollowingVotingMessage without a signature.
 type FollowingVotingMessageBody struct {
-	MinerID        types.NodeID
+	EpochID        types.EpochID
 	RoundID        types.RoundID
 	VotesBitVector []uint64
 }

--- a/tortoisebeacon/tortoise_beacon.go
+++ b/tortoisebeacon/tortoise_beacon.go
@@ -104,6 +104,7 @@ func New(
 		weakCoin:                weakCoin,
 		clock:                   clock,
 		beacons:                 make(map[types.EpochID]types.Hash32),
+		hasProposed:             make(map[string]struct{}),
 		hasVoted:                make([]map[string]struct{}, conf.RoundsNumber),
 		firstRoundIncomingVotes: make(map[string]proposals),
 		proposalChans:           make(map[types.EpochID]chan *proposalMessageWithReceiptData),
@@ -143,6 +144,7 @@ type TortoiseBeacon struct {
 	firstRoundIncomingVotes map[string]proposals // sorted votes for bit vector decoding
 	// TODO(nkryuchkov): For every round excluding first round consider having a vector of opinions.
 	votesMargin               map[string]*big.Int
+	hasProposed               map[string]struct{}
 	hasVoted                  []map[string]struct{}
 	proposalPhaseFinishedTime time.Time
 	beacons                   map[types.EpochID]types.Hash32
@@ -282,6 +284,7 @@ func (tb *TortoiseBeacon) cleanupEpoch() {
 	tb.incomingProposals = proposals{}
 	tb.firstRoundIncomingVotes = map[string]proposals{}
 	tb.votesMargin = map[string]*big.Int{}
+	tb.hasProposed = make(map[string]struct{})
 	tb.hasVoted = make([]map[string]struct{}, tb.config.RoundsNumber)
 	tb.proposalPhaseFinishedTime = time.Time{}
 

--- a/tortoisebeacon/tortoise_beacon.go
+++ b/tortoisebeacon/tortoise_beacon.go
@@ -456,12 +456,6 @@ func (tb *TortoiseBeacon) proposalPhaseImpl(ctx context.Context, epoch types.Epo
 	}
 
 	logger.With().Info("sent proposal", log.String("message", m.String()))
-
-	tb.mu.Lock()
-	defer tb.mu.Unlock()
-
-	tb.incomingProposals.valid = append(tb.incomingProposals.valid, proposedSignature)
-
 	return nil
 }
 

--- a/tortoisebeacon/tortoise_beacon.go
+++ b/tortoisebeacon/tortoise_beacon.go
@@ -611,6 +611,7 @@ func (tb *TortoiseBeacon) sendProposalVote(ctx context.Context, epoch types.Epoc
 
 func (tb *TortoiseBeacon) sendFirstRoundVote(ctx context.Context, epoch types.EpochID, proposals proposals) error {
 	mb := FirstVotingMessageBody{
+		EpochID:                   epoch,
 		ValidProposals:            proposals.valid,
 		PotentiallyValidProposals: proposals.potentiallyValid,
 	}
@@ -640,6 +641,7 @@ func (tb *TortoiseBeacon) sendFollowingVote(ctx context.Context, epoch types.Epo
 	tb.mu.RUnlock()
 
 	mb := FollowingVotingMessageBody{
+		EpochID:        epoch,
 		RoundID:        round,
 		VotesBitVector: bitVector,
 	}

--- a/tortoisebeacon/tortoise_beacon.go
+++ b/tortoisebeacon/tortoise_beacon.go
@@ -535,6 +535,9 @@ func (tb *TortoiseBeacon) runConsensusPhase(ctx context.Context, epoch types.Epo
 			return allVotes{}, ctx.Err()
 		}
 
+		// note that votes after this calcVotes() call will _not_ be counted towards our votes
+		// for this round, as the late votes can be cast after the weak coin is revealed. we
+		// count them towards our votes in the next round.
 		ownVotes, undecided, err = tb.calcVotes(ctx, epoch, round)
 		if err != nil {
 			logger.With().Error("failed to calculate votes", log.Err(err))

--- a/tortoisebeacon/tortoise_beacon_test.go
+++ b/tortoisebeacon/tortoise_beacon_test.go
@@ -62,7 +62,8 @@ func setUpTortoiseBeacon(t *testing.T, mockEpochWeight uint64) (*TortoiseBeacon,
 
 	ctrl := gomock.NewController(t)
 	mockDB := mocks.NewMockactivationDB(ctrl)
-	mockDB.EXPECT().GetEpochWeight(gomock.Any()).Return(mockEpochWeight, nil, nil).AnyTimes()
+	// epoch 2, 3, and 4 (since we waited til epoch 3 in each test)
+	mockDB.EXPECT().GetEpochWeight(gomock.Any()).Return(mockEpochWeight, nil, nil).MaxTimes(3)
 	mwc := coinValueMock(t, true)
 
 	types.SetLayersPerEpoch(1)

--- a/tortoisebeacon/votes_calc.go
+++ b/tortoisebeacon/votes_calc.go
@@ -16,7 +16,7 @@ func (tb *TortoiseBeacon) calcVotes(ctx context.Context, epoch types.EpochID, ro
 
 	logger.With().Debug("calculating votes", log.String("vote_margins", fmt.Sprint(tb.votesMargin)))
 
-	ownCurrentRoundVotes, undecided, err := tb.calcOwnCurrentRoundVotes(epoch)
+	ownCurrentRoundVotes, undecided, err := tb.calcOwnCurrentRoundVotes()
 	if err != nil {
 		return allVotes{}, nil, fmt.Errorf("calc own current round votes: %w", err)
 	}
@@ -28,18 +28,13 @@ func (tb *TortoiseBeacon) calcVotes(ctx context.Context, epoch types.EpochID, ro
 	return ownCurrentRoundVotes, undecided, nil
 }
 
-func (tb *TortoiseBeacon) calcOwnCurrentRoundVotes(epoch types.EpochID) (allVotes, []string, error) {
+func (tb *TortoiseBeacon) calcOwnCurrentRoundVotes() (allVotes, []string, error) {
 	ownCurrentRoundVotes := allVotes{
 		valid:   make(proposalSet),
 		invalid: make(proposalSet),
 	}
 
-	epochWeight, _, err := tb.atxDB.GetEpochWeight(epoch)
-	if err != nil {
-		return allVotes{}, nil, fmt.Errorf("get epoch weight: %w", err)
-	}
-
-	positiveVotingThreshold := tb.votingThreshold(epochWeight)
+	positiveVotingThreshold := tb.votingThreshold(tb.epochWeight)
 	negativeThreshold := new(big.Int).Neg(positiveVotingThreshold)
 
 	var undecided []string

--- a/tortoisebeacon/votes_calc_test.go
+++ b/tortoisebeacon/votes_calc_test.go
@@ -18,7 +18,6 @@ func TestTortoiseBeacon_calcVotes(t *testing.T) {
 
 	ctrl := gomock.NewController(t)
 	mockDB := mocks.NewMockactivationDB(ctrl)
-	mockDB.EXPECT().GetEpochWeight(gomock.Any()).Return(uint64(1), nil, nil).AnyTimes()
 	mockDB.EXPECT().GetAtxHeader(gomock.Any()).Return(&types.ActivationTxHeader{
 		NIPostChallenge: types.NIPostChallenge{
 			StartTick: 0,
@@ -76,6 +75,7 @@ func TestTortoiseBeacon_calcVotes(t *testing.T) {
 				logger:      logtest.New(t).WithName("TortoiseBeacon"),
 				atxDB:       mockDB,
 				votesMargin: tc.votesMargin,
+				epochWeight: uint64(1),
 			}
 
 			result, undecided, err := tb.calcVotes(context.TODO(), tc.epoch, tc.round)
@@ -94,7 +94,6 @@ func TestTortoiseBeacon_calcOwnCurrentRoundVotes(t *testing.T) {
 
 	ctrl := gomock.NewController(t)
 	mockDB := mocks.NewMockactivationDB(ctrl)
-	mockDB.EXPECT().GetEpochWeight(gomock.Any()).Return(uint64(threshold), nil, nil).AnyTimes()
 	mockDB.EXPECT().GetAtxHeader(gomock.Any()).Return(&types.ActivationTxHeader{
 		NIPostChallenge: types.NIPostChallenge{
 			StartTick: 0,
@@ -173,9 +172,10 @@ func TestTortoiseBeacon_calcOwnCurrentRoundVotes(t *testing.T) {
 				logger:      logtest.New(t).WithName("TortoiseBeacon"),
 				atxDB:       mockDB,
 				votesMargin: tc.votesCount,
+				epochWeight: uint64(threshold),
 			}
 
-			result, undecided, err := tb.calcOwnCurrentRoundVotes(tc.epoch)
+			result, undecided, err := tb.calcOwnCurrentRoundVotes()
 			require.NoError(t, err)
 			sort.Strings(undecided)
 			require.Equal(t, tc.undecided, undecided)
@@ -183,6 +183,7 @@ func TestTortoiseBeacon_calcOwnCurrentRoundVotes(t *testing.T) {
 		})
 	}
 }
+
 func TestTallyUndecided(t *testing.T) {
 	t.Parallel()
 	for _, tc := range []struct {


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
<!-- `Closes #XXXX, closes #XXXX, ...` links mentioned issues to this PR and automatically closes them when this it's merged -->
Closes #2772 
Closes #2787
Closes #2789

## Changes
<!-- Please describe in detail the changes made -->
- remove initial epoch delay
- use cached epoch weight everywhere
- stop accepting proposals after proposal round ends
- add epoch ID to first and following vote messages
- drop vote messages from gossip for mismatching epoch ID
- count own proposal once 
- make incoming proposals thread-safe
- prevent double proposals
- add tests for gossip handers

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->
unit tests

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
