### PR TITLE
[Merged by Bors] - we do not sync current layer anymore, remove relevant config

### DIFF
--- a/cmd/node/multi_node.go
+++ b/cmd/node/multi_node.go
@@ -162,7 +162,6 @@ func getTestDefaultConfig() *config.Config {
 	cfg.HareEligibility.EpochOffset = 0
 	cfg.SyncRequestTimeout = 500
 	cfg.SyncInterval = 2
-	cfg.SyncValidationDelta = 5
 
 	cfg.FETCH.RequestTimeout = 10
 	cfg.FETCH.MaxRetriesForPeer = 5

--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -682,9 +682,8 @@ func (app *App) initServices(ctx context.Context,
 	layerFetch.AddDBs(mdb.Blocks(), atxdbstore, mdb.Transactions(), poetDbStore, mdb.InputVector(), tBeaconDBStore)
 
 	syncerConf := syncer.Configuration{
-		SyncInterval:    time.Duration(app.Config.SyncInterval) * time.Second,
-		ValidationDelta: time.Duration(app.Config.SyncValidationDelta) * time.Second,
-		AlwaysListen:    app.Config.AlwaysListen,
+		SyncInterval: time.Duration(app.Config.SyncInterval) * time.Second,
+		AlwaysListen: app.Config.AlwaysListen,
 	}
 	newSyncer := syncer.NewSyncer(ctx, syncerConf, clock, msh, layerFetch, app.addLogger(SyncLogger, lg))
 	// TODO(dshulyak) this needs to be improved, but dependency graph is a bit complicated

--- a/cmd/sync/sync.go
+++ b/cmd/sync/sync.go
@@ -165,8 +165,7 @@ func (app *syncApp) start(_ *cobra.Command, _ []string) {
 	layerFetch := createFetcherWithMock(dbs, msh, swarm, app.logger)
 	layerFetch.Start()
 	syncerConf := syncer.Configuration{
-		SyncInterval:    2 * 60 * time.Millisecond,
-		ValidationDelta: 30 * time.Second,
+		SyncInterval: 2 * 60 * time.Millisecond,
 	}
 	app.sync = createSyncer(syncerConf, msh, layerFetch, types.NewLayerID(expectedLayers), app.logger)
 	if err = swarm.Start(cmdp.Ctx); err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -104,8 +104,6 @@ type BaseConfig struct {
 
 	SyncInterval int `mapstructure:"sync-interval"` // sync interval in seconds
 
-	SyncValidationDelta int `mapstructure:"sync-validation-delta"` // sync interval in seconds
-
 	PublishEventsURL string `mapstructure:"events-url"`
 
 	AtxsPerBlock int `mapstructure:"atxs-per-block"`
@@ -213,7 +211,6 @@ func defaultBaseConfig() BaseConfig {
 		BlockCacheSize:        20,
 		SyncRequestTimeout:    2000,
 		SyncInterval:          10,
-		SyncValidationDelta:   300,
 		AtxsPerBlock:          100,
 		TxsPerBlock:           100,
 	}

--- a/syncer/syncer_test.go
+++ b/syncer/syncer_test.go
@@ -150,9 +150,8 @@ func newMemMesh(lg log.Log) *mesh.Mesh {
 }
 
 var conf = Configuration{
-	SyncInterval:    time.Second * 60 * 60 * 24, // long enough that it doesn't kick in during testing
-	ValidationDelta: 30 * time.Millisecond,
-	AlwaysListen:    false,
+	SyncInterval: time.Second * 60 * 60 * 24, // long enough that it doesn't kick in during testing
+	AlwaysListen: false,
 }
 
 func newSyncerWithoutSyncTimer(ctx context.Context, conf Configuration, ticker layerTicker, mesh *mesh.Mesh, fetcher layerFetcher, logger log.Log) *Syncer {
@@ -657,26 +656,6 @@ func TestMultipleForceSync(t *testing.T) {
 
 	// node already shutdown
 	assert.False(t, false, syncer.ForceSync(context.TODO()))
-}
-
-func TestShouldValidateLayer(t *testing.T) {
-	lg := logtest.New(t).WithName("syncer")
-	ticker := newMockLayerTicker()
-	syncer := newSyncerWithoutSyncTimer(context.TODO(), conf, ticker, newMemMesh(lg), newMockFetcher(), lg)
-	syncer.Start(context.TODO())
-	assert.False(t, syncer.shouldValidateLayer(types.NewLayerID(0)))
-
-	ticker.advanceToLayer(types.NewLayerID(3))
-	assert.False(t, syncer.shouldValidateLayer(types.NewLayerID(0)))
-	assert.True(t, syncer.shouldValidateLayer(types.NewLayerID(1)))
-	assert.True(t, syncer.shouldValidateLayer(types.NewLayerID(2)))
-	// current layer
-	ticker.layerStartTime = time.Now()
-	assert.False(t, syncer.shouldValidateLayer(types.NewLayerID(3)))
-	// but if current layer has elapsed ValidationDelta ms, we will validate
-	ticker.layerStartTime = time.Now().Add(-conf.ValidationDelta)
-	assert.True(t, syncer.shouldValidateLayer(types.NewLayerID(3)))
-	syncer.Close()
 }
 
 func TestGetATXsCurrentEpoch(t *testing.T) {


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
code and config clean up.
syncer does not sync current layer anymore. remove relevant code to avoid confusion.

## Changes
remove SyncValidationDelta and related code

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->
unit tests

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
