### PR TITLE
[Merged by Bors] - sync: improve on layer fetch error reporting and fix multiple fetches on the same block ID

### DIFF
--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -679,7 +679,7 @@ func (app *App) initServices(ctx context.Context,
 	remoteFetchService := fetch.NewFetch(ctx, app.Config.FETCH, swarm, app.addLogger(Fetcher, lg))
 
 	layerFetch := layerfetcher.NewLogic(ctx, app.Config.LAYERS, blockListener, atxDB, poetDb, atxDB, processor, swarm, remoteFetchService, msh, tBeaconDB, app.addLogger(LayerFetcher, lg))
-	layerFetch.AddDBs(mdb.Blocks(), atxdbstore, mdb.Transactions(), poetDbStore, mdb.InputVector(), tBeaconDBStore)
+	layerFetch.AddDBs(mdb.Blocks(), atxdbstore, mdb.Transactions(), poetDbStore, tBeaconDBStore)
 
 	syncerConf := syncer.Configuration{
 		SyncInterval: time.Duration(app.Config.SyncInterval) * time.Second,

--- a/cmd/sync/mocks.go
+++ b/cmd/sync/mocks.go
@@ -163,7 +163,7 @@ func createFetcherWithMock(dbs *allDbs, msh *mesh.Mesh, swarm service.Service, l
 
 	lCfg := layerfetcher.Config{RequestTimeout: 20}
 	layerFetch := layerfetcher.NewLogic(context.TODO(), lCfg, blockHandler, dbs.atxdb, dbs.poetDb, dbs.atxdb, mockTxProcessor{}, swarm, fetcher, msh, dbs.tbDB, lg)
-	layerFetch.AddDBs(dbs.mshdb.Blocks(), dbs.atxdbStore, dbs.mshdb.Transactions(), dbs.poetStorage, dbs.mshdb.InputVector(), dbs.tbDBStore)
+	layerFetch.AddDBs(dbs.mshdb.Blocks(), dbs.atxdbStore, dbs.mshdb.Transactions(), dbs.poetStorage, dbs.tbDBStore)
 	return layerFetch
 }
 

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -30,7 +30,6 @@ const (
 	ATXDB   Hint = "ATXDB"
 	TXDB    Hint = "TXDB"
 	POETDB  Hint = "POETDB"
-	IVDB    Hint = "IVDB"
 	TBDB    Hint = "TBDB"
 )
 

--- a/layerfetcher/layers_test.go
+++ b/layerfetcher/layers_test.go
@@ -5,8 +5,6 @@ import (
 	"errors"
 	"testing"
 
-	"go.uber.org/zap/zapcore"
-
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/database"
 	"github.com/spacemeshos/go-spacemesh/fetch"
@@ -283,7 +281,7 @@ func TestPollLayerBlocks_AllHaveBlockData(t *testing.T) {
 		net.peers = append(net.peers, peer)
 		net.layerBlocks[peer] = generateLayerBlocks(i + 1)
 	}
-	l := NewMockLogic(net, db, &mockBlocks{}, &mockAtx{}, &mockFetcher{}, logtest.New(t, zapcore.DebugLevel))
+	l := NewMockLogic(net, db, &mockBlocks{}, &mockAtx{}, &mockFetcher{}, logtest.New(t))
 
 	layerID := types.NewLayerID(10)
 	res := <-l.PollLayerContent(context.TODO(), layerID)
@@ -304,7 +302,7 @@ func TestPollLayerBlocks_FetchBlockError(t *testing.T) {
 		net.peers = append(net.peers, peer)
 		net.layerBlocks[peer] = generateLayerBlocks(i + 1)
 	}
-	l := NewMockLogic(net, newLayerDBMock(), &mockBlocks{}, &mockAtx{}, &mockFetcher{fetchError: ErrInternal}, logtest.New(t, zapcore.DebugLevel))
+	l := NewMockLogic(net, newLayerDBMock(), &mockBlocks{}, &mockAtx{}, &mockFetcher{fetchError: ErrInternal}, logtest.New(t))
 
 	layerID := types.NewLayerID(10)
 	res := <-l.PollLayerContent(context.TODO(), layerID)

--- a/mesh/meshdb.go
+++ b/mesh/meshdb.go
@@ -172,11 +172,6 @@ func (m *DB) Transactions() database.Getter {
 	return m.transactions
 }
 
-// InputVector exports the inputvector DB
-func (m *DB) InputVector() database.Getter {
-	return m.inputVector
-}
-
 // ErrAlreadyExist error returned when adding an existing value to the database
 var ErrAlreadyExist = errors.New("block already exists in database")
 


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
Closes #2796
<!-- `Closes #XXXX, closes #XXXX, ...` links mentioned issues to this PR and automatically closes them when this it's merged -->

## Changes
<!-- Please describe in detail the changes made -->
- fetch one block ID exactly once. the underlying fetcher will retry the same hash 20 times (with random peer)
- with above change, we can directly report error from fetchLayerBlock
- remove unnecessary layer fetch API `GetInputVector`. the input vector is returned along with block IDs in the layer. if no peers return input vector, trying it again with `GetInputVector` is kinda pointless since we will be asking the same peers

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->
unit test

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
