### PR TITLE
[Merged by Bors] - Revert loop variable capturing fixes to fix hanging Test_Gossiping

### DIFF
--- a/p2p/integration_suite.go
+++ b/p2p/integration_suite.go
@@ -169,13 +169,11 @@ func createP2pInstance(t testing.TB, config config.Config, loggerName string) *S
 func (its *IntegrationTestSuite) WaitForGossip(ctx context.Context) error {
 	g, _ := errgroup.WithContext(ctx)
 	for _, b := range its.boot {
-		b := b
 		g.Go(func() error {
 			return b.waitForGossip()
 		})
 	}
 	for _, i := range its.Instances {
-		i := i
 		g.Go(func() error {
 			return i.waitForGossip()
 		})


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->

<!-- `Closes #XXXX, closes #XXXX, ...` links mentioned issues to this PR and automatically closes them when this it's merged -->
After fixing the issue with loop variable capturing, `Test_Gossiping` started to hang. It seems there's an issue either in `Test_Gossiping` implementation or in `WaitForGossip`. To make the test pass, I'm temporarily reverting the fix and will create an issue for fixing the loop variable capturing and hanging Test_Gossiping

## Changes
<!-- Please describe in detail the changes made -->
- Revert loop variable capturing fixes to fix hanging Test_Gossiping

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->
Unit tests

## TODO
<!-- This section should be removed when all items are complete -->
- [ ] Explain motivation or link existing issue(s)
- [ ] Test changes and document test plan
- [ ] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
