### PR TITLE
Separate tortoise config

### DIFF
--- a/cmd/node/app_test.go
+++ b/cmd/node/app_test.go
@@ -723,7 +723,7 @@ func TestShutdown(t *testing.T) {
 	smApp.Config.LayerAvgSize = 5
 	smApp.Config.LayersPerEpoch = 3
 	smApp.Config.TxsPerBlock = 100
-	smApp.Config.Hdist = 5
+	smApp.Config.Tortoise.Hdist = 5
 	smApp.Config.GenesisTime = genesisTime.Format(time.RFC3339)
 	smApp.Config.LayerDurationSec = 20
 	smApp.Config.HareEligibility.ConfidenceParam = 3

--- a/cmd/node/multi_node.go
+++ b/cmd/node/multi_node.go
@@ -154,7 +154,7 @@ func getTestDefaultConfig() *config.Config {
 	cfg.LayerAvgSize = 5
 	cfg.LayersPerEpoch = 3
 	cfg.TxsPerBlock = 100
-	cfg.Hdist = 5
+	cfg.Tortoise.Hdist = 5
 
 	cfg.LayerDurationSec = 20
 	cfg.HareEligibility.ConfidenceParam = 4

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -42,8 +42,8 @@ func AddCommands(cmd *cobra.Command) {
 		config.LayerDurationSec, "Duration between layers in seconds")
 	cmd.PersistentFlags().IntVar(&config.LayerAvgSize, "layer-average-size",
 		config.LayerAvgSize, "Layer Avg size")
-	cmd.PersistentFlags().Uint32Var(&config.Hdist, "hdist",
-		config.Hdist, "hdist")
+	cmd.PersistentFlags().Uint32Var(&config.Tortoise.Hdist, "hdist",
+		config.Tortoise.Hdist, "hdist")
 	cmd.PersistentFlags().BoolVar(&config.PprofHTTPServer, "pprof-server",
 		config.PprofHTTPServer, "enable http pprof server")
 	cmd.PersistentFlags().StringVar(&config.GoldenATXID, "golden-atx",

--- a/cmd/sync/sync.go
+++ b/cmd/sync/sync.go
@@ -95,7 +95,7 @@ func (app *syncApp) start(_ *cobra.Command, _ []string) {
 		log.Int("request_timeout", app.Config.SyncRequestTimeout),
 		log.String("data_version", version),
 		log.Uint32("layers_per_epoch", app.Config.LayersPerEpoch),
-		log.Uint32("hdist", app.Config.Hdist),
+		log.Uint32("hdist", app.Config.Tortoise.Hdist),
 	)
 
 	path := app.Config.DataDir()

--- a/config.toml
+++ b/config.toml
@@ -14,7 +14,6 @@ oracle_server_worldid = 0
 genesis-time = "2019-02-13T17:02:00+00:00"
 layer-duration-sec = "5"
 block-cache-size = "20"
-hdist = "5"
 coinbase = "0x1234"
 golden-atx = "0x5678"
 
@@ -64,6 +63,16 @@ hare-round-duration-sec = "5"
 hare-committee-size = 800
 hare-max-adversaries = 399
 hare-wakeup-delta = 5
+
+# Tortoise Config
+[tortoise]
+hdist = "10"
+zdist = "5"
+confidence-param = "5"
+window-size = "100"
+global-threshold = "60/100"
+local-threshold = "20/100"
+rerun-interval = "20m"
 
 # Tortoise Beacon Config
 [tortoise-beacon]

--- a/config/config.go
+++ b/config/config.go
@@ -3,7 +3,7 @@ package config
 
 import (
 	"fmt"
-	"math/big"
+	"github.com/spacemeshos/go-spacemesh/tortoise"
 	"path/filepath"
 	"time"
 
@@ -43,6 +43,7 @@ type Config struct {
 	API             apiConfig.Config         `mapstructure:"api"`
 	HARE            hareConfig.Config        `mapstructure:"hare"`
 	HareEligibility eligConfig.Config        `mapstructure:"hare-eligibility"`
+	Tortoise        tortoise.Config          `mapstructure:"tortoise"`
 	TortoiseBeacon  tortoisebeacon.Config    `mapstructure:"tortoise-beacon"`
 	TIME            timeConfig.TimeConfig    `mapstructure:"time"`
 	REWARD          mesh.Config              `mapstructure:"reward"`
@@ -79,19 +80,10 @@ type BaseConfig struct {
 	OracleServer        string `mapstructure:"oracle_server"`
 	OracleServerWorldID int    `mapstructure:"oracle_server_worldid"`
 
-	GenesisTime      string   `mapstructure:"genesis-time"`
-	LayerDurationSec int      `mapstructure:"layer-duration-sec"`
-	LayerAvgSize     int      `mapstructure:"layer-average-size"`
-	LayersPerEpoch   uint32   `mapstructure:"layers-per-epoch"`
-	Hdist            uint32   `mapstructure:"hdist"`                     // hare/input vector lookback distance
-	Zdist            uint32   `mapstructure:"zdist"`                     // hare result wait distance
-	ConfidenceParam  uint32   `mapstructure:"tortoise-confidence-param"` // layers to wait for global consensus
-	WindowSize       uint32   `mapstructure:"tortoise-window-size"`      // size of the tortoise sliding window (in layers)
-	GlobalThreshold  *big.Rat `mapstructure:"tortoise-global-threshold"` // threshold for finalizing blocks and layers
-	LocalThreshold   *big.Rat `mapstructure:"tortoise-local-threshold"`  // threshold for choosing when to use weak coin
-
-	// how often we rerun tortoise from scratch, in minutes
-	TortoiseRerunInterval uint32 `mapstructure:"tortoise-rerun-interval"`
+	GenesisTime      string `mapstructure:"genesis-time"`
+	LayerDurationSec int    `mapstructure:"layer-duration-sec"`
+	LayerAvgSize     int    `mapstructure:"layer-average-size"`
+	LayersPerEpoch   uint32 `mapstructure:"layers-per-epoch"`
 
 	PoETServer string `mapstructure:"poet-server"`
 
@@ -165,6 +157,7 @@ func DefaultConfig() Config {
 		HARE:            hareConfig.DefaultConfig(),
 		HareEligibility: eligConfig.DefaultConfig(),
 		TortoiseBeacon:  tortoisebeacon.DefaultConfig(),
+		Tortoise:        tortoise.DefaultConfig(),
 		TIME:            timeConfig.DefaultConfig(),
 		REWARD:          mesh.DefaultMeshConfig(),
 		POST:            activation.DefaultPostConfig(),
@@ -186,34 +179,27 @@ func DefaultTestConfig() Config {
 // DefaultBaseConfig returns a default configuration for spacemesh
 func defaultBaseConfig() BaseConfig {
 	return BaseConfig{
-		DataDirParent:         defaultDataDir,
-		ConfigFile:            defaultConfigFileName,
-		TestMode:              false,
-		CollectMetrics:        false,
-		MetricsPort:           1010,
-		MetricsPush:           "", // "" = doesn't push
-		MetricsPushPeriod:     60,
-		ProfilerURL:           "",
-		ProfilerName:          "gp-spacemesh",
-		OracleServer:          "http://localhost:3030",
-		OracleServerWorldID:   0,
-		GenesisTime:           time.Now().Format(time.RFC3339),
-		LayerDurationSec:      30,
-		LayersPerEpoch:        3,
-		PoETServer:            "127.0.0.1",
-		GoldenATXID:           "0x5678", // TODO: Change the value
-		Hdist:                 10,
-		Zdist:                 5,
-		ConfidenceParam:       5,
-		WindowSize:            100,                 // should be "a few thousand layers" in production
-		GlobalThreshold:       big.NewRat(60, 100), // fraction
-		LocalThreshold:        big.NewRat(20, 100), // fraction
-		TortoiseRerunInterval: 60 * 24,             // in minutes, once per day
-		BlockCacheSize:        20,
-		SyncRequestTimeout:    2000,
-		SyncInterval:          10,
-		AtxsPerBlock:          100,
-		TxsPerBlock:           100,
+		DataDirParent:       defaultDataDir,
+		ConfigFile:          defaultConfigFileName,
+		TestMode:            false,
+		CollectMetrics:      false,
+		MetricsPort:         1010,
+		MetricsPush:         "", // "" = doesn't push
+		MetricsPushPeriod:   60,
+		ProfilerURL:         "",
+		ProfilerName:        "gp-spacemesh",
+		OracleServer:        "http://localhost:3030",
+		OracleServerWorldID: 0,
+		GenesisTime:         time.Now().Format(time.RFC3339),
+		LayerDurationSec:    30,
+		LayersPerEpoch:      3,
+		PoETServer:          "127.0.0.1",
+		GoldenATXID:         "0x5678", // TODO: Change the value
+		BlockCacheSize:      20,
+		SyncRequestTimeout:  2000,
+		SyncInterval:        10,
+		AtxsPerBlock:        100,
+		TxsPerBlock:         100,
 	}
 }
 

--- a/tortoise/config.go
+++ b/tortoise/config.go
@@ -1,0 +1,30 @@
+package tortoise
+
+import (
+	"math/big"
+	"time"
+)
+
+// Config is the configuration of the Tortoise.
+type Config struct {
+	Hdist           uint32        `mapstructure:"hdist"`            // hare/input vector lookback distance
+	Zdist           uint32        `mapstructure:"zdist"`            // hare result wait distance
+	ConfidenceParam uint32        `mapstructure:"confidence-param"` // layers to wait for global consensus
+	WindowSize      uint32        `mapstructure:"window-size"`      // size of the tortoise sliding window (in layers)
+	GlobalThreshold *big.Rat      `mapstructure:"global-threshold"` // threshold for finalizing blocks and layers
+	LocalThreshold  *big.Rat      `mapstructure:"local-threshold"`  // threshold for choosing when to use weak coin
+	RerunInterval   time.Duration `mapstructure:"rerun-interval"`
+}
+
+// DefaultConfig defines the default Tortoise configuration
+func DefaultConfig() Config {
+	return Config{
+		Hdist:           10,
+		Zdist:           5,
+		ConfidenceParam: 5,
+		WindowSize:      100,                 // should be "a few thousand layers" in production
+		GlobalThreshold: big.NewRat(60, 100), // fraction
+		LocalThreshold:  big.NewRat(20, 100), // fraction
+		RerunInterval:   24 * time.Minute,    // in minutes, once per day
+	}
+}

--- a/tortoise/verifying_algorithm.go
+++ b/tortoise/verifying_algorithm.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math/big"
 	"sync"
 	"time"
 
@@ -22,25 +21,19 @@ type ThreadSafeVerifyingTortoise struct {
 	mutex     sync.RWMutex
 }
 
-// Config holds the arguments and dependencies to create a verifying tortoise instance.
-type Config struct {
-	LayerSize       uint32
-	Database        database.Database
-	MeshDatabase    blockDataProvider
-	ATXDB           atxDataProvider
-	Clock           layerClock
-	Hdist           uint32   // hare lookback distance: the distance over which we use the input vector/hare results
-	Zdist           uint32   // hare result wait distance: the distance over which we're willing to wait for hare results
-	ConfidenceParam uint32   // confidence wait distance: how long we wait for global consensus to be established
-	GlobalThreshold *big.Rat // threshold required to finalize blocks and layers
-	LocalThreshold  *big.Rat // threshold that determines whether a node votes based on local or global opinion
-	WindowSize      uint32   // tortoise sliding window: how many layers we store data for
-	Log             log.Log
-	RerunInterval   time.Duration // how often to rerun from genesis
+// Configuration holds the arguments and dependencies to create a verifying tortoise instance.
+type Configuration struct {
+	Config
+	LayerSize    uint32
+	Database     database.Database
+	MeshDatabase blockDataProvider
+	ATXDB        atxDataProvider
+	Clock        layerClock
+	Log          log.Log
 }
 
 // NewVerifyingTortoise creates ThreadSafeVerifyingTortoise instance.
-func NewVerifyingTortoise(ctx context.Context, cfg Config) *ThreadSafeVerifyingTortoise {
+func NewVerifyingTortoise(ctx context.Context, cfg Configuration) *ThreadSafeVerifyingTortoise {
 	if cfg.Hdist < cfg.Zdist {
 		cfg.Log.With().Panic("hdist must be >= zdist", log.Uint32("hdist", cfg.Hdist), log.Uint32("zdist", cfg.Zdist))
 	}

--- a/tortoise/verifying_tortoise_test.go
+++ b/tortoise/verifying_tortoise_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/spacemeshos/go-spacemesh/timesync"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
-	"github.com/spacemeshos/go-spacemesh/config"
 	"github.com/spacemeshos/go-spacemesh/database"
 	"github.com/spacemeshos/go-spacemesh/log/logtest"
 	"github.com/spacemeshos/go-spacemesh/mesh"
@@ -135,12 +134,12 @@ const (
 )
 
 var (
-	defaultTestHdist           = config.DefaultConfig().Hdist
-	defaultTestZdist           = config.DefaultConfig().Zdist
+	defaultTestHdist           = DefaultConfig().Hdist
+	defaultTestZdist           = DefaultConfig().Zdist
 	defaultTestGlobalThreshold = big.NewRat(6, 10)
 	defaultTestLocalThreshold  = big.NewRat(2, 10)
 	defaultTestRerunInterval   = time.Hour
-	defaultTestConfidenceParam = config.DefaultConfig().ConfidenceParam
+	defaultTestConfidenceParam = DefaultConfig().ConfidenceParam
 )
 
 func requireVote(t *testing.T, trtl *turtle, vote vec, blocks ...types.BlockID) {
@@ -1097,21 +1096,15 @@ func TestCloneTurtle(t *testing.T) {
 	r.NotEqual(trtl.Last, trtl2.Last)
 }
 
-func defaultConfig(t *testing.T, mdb *mesh.DB) Config {
-	return Config{
-		LayerSize:       defaultTestLayerSize,
-		Database:        database.NewMemDatabase(),
-		MeshDatabase:    mdb,
-		ATXDB:           getAtxDB(),
-		Clock:           defaultClock(t),
-		Hdist:           defaultTestHdist,
-		Zdist:           defaultTestZdist,
-		ConfidenceParam: defaultTestConfidenceParam,
-		WindowSize:      defaultTestWindowSize,
-		GlobalThreshold: defaultTestGlobalThreshold,
-		LocalThreshold:  defaultTestLocalThreshold,
-		RerunInterval:   defaultTestRerunInterval,
-		Log:             logtest.New(t),
+func defaultConfig(t *testing.T, mdb *mesh.DB) Configuration {
+	return Configuration{
+		Config:       DefaultConfig(),
+		LayerSize:    defaultTestLayerSize,
+		Database:     database.NewMemDatabase(),
+		MeshDatabase: mdb,
+		ATXDB:        getAtxDB(),
+		Clock:        defaultClock(t),
+		Log:          logtest.New(t),
 	}
 }
 


### PR DESCRIPTION
## Motivation
The tortoise should have its own config module

Closes #2707

## Changes
Tortoise config is separated to the own configuration module

## DevOps Notes
It may require to change configuration 
