### PR TITLE
[Merged by Bors] - fix bug where different beacon values are calculated for the same epoch

### DIFF
--- a/blocks/blockoracle.go
+++ b/blocks/blockoracle.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/common/util"
+	"github.com/spacemeshos/go-spacemesh/database"
 	"github.com/spacemeshos/go-spacemesh/log"
 )
 
@@ -25,6 +26,9 @@ type vrfSigner interface {
 // DefaultProofsEpoch is set such that it will never equal the current epoch
 const DefaultProofsEpoch = ^types.EpochID(0)
 
+// ErrMinerHasNoATXInPreviousEpoch is returned when miner has no ATXs in previous epoch.
+var ErrMinerHasNoATXInPreviousEpoch = errors.New("miner has no ATX in previous epoch")
+
 // Oracle is the oracle that provides block eligibility proofs for the miner.
 type Oracle struct {
 	committeeSize  uint32
@@ -37,7 +41,7 @@ type Oracle struct {
 	proofsEpoch       types.EpochID
 	epochAtxs         []types.ATXID
 	eligibilityProofs map[types.LayerID][]types.BlockEligibilityProof
-	atxID             types.ATXID
+	atx               *types.ActivationTxHeader
 	isSynced          func() bool
 	eligibilityMutex  sync.RWMutex
 	log               log.Log
@@ -66,6 +70,15 @@ func (bo *Oracle) BlockEligible(layerID types.LayerID) (types.ATXID, []types.Blo
 	}
 
 	epochNumber := layerID.GetEpoch()
+	atx, err := bo.getValidAtxForEpoch(epochNumber)
+	if err != nil {
+		if errors.Is(err, database.ErrNotFound) {
+			return types.ATXID{}, nil, nil, ErrMinerHasNoATXInPreviousEpoch
+		}
+		return types.ATXID{}, nil, nil, fmt.Errorf("failed to get latest atx for node in epoch %d: %w", epochNumber, err)
+	}
+	bo.atx = atx
+
 	var cachedEpochDescription log.Field
 	if bo.proofsEpoch == DefaultProofsEpoch {
 		cachedEpochDescription = log.Int("cached_epoch_id", -1)
@@ -96,7 +109,7 @@ func (bo *Oracle) BlockEligible(layerID types.LayerID) (types.ATXID, []types.Blo
 		bo.nodeID, layerID, layerID.GetEpoch(),
 		log.Int("num_blocks", len(proofs)))
 
-	return bo.atxID, proofs, bo.epochAtxs, nil
+	return bo.atx.ID(), proofs, bo.epochAtxs, nil
 }
 
 func (bo *Oracle) calcEligibilityProofs(epochNumber types.EpochID) (map[types.LayerID][]types.BlockEligibilityProof, error) {
@@ -114,21 +127,12 @@ func (bo *Oracle) calcEligibilityProofs(epochNumber types.EpochID) (map[types.La
 		log.Uint64("epoch_id", uint64(epochNumber)),
 		log.String("epoch_beacon", beaconDbgStr))
 
-	var weight uint64
 	// get the previous epoch's total weight
 	totalWeight, activeSet, err := bo.atxDB.GetEpochWeight(epochNumber)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get epoch %v weight: %w", epochNumber, err)
 	}
-	atx, err := bo.getValidAtxForEpoch(epochNumber)
-	if err != nil {
-		if !epochNumber.IsGenesis() {
-			return nil, fmt.Errorf("failed to get latest atx for node in epoch %d: %w", epochNumber, err)
-		}
-	} else {
-		weight = atx.GetWeight()
-		bo.atxID = atx.ID()
-	}
+
 	bo.log.With().Info("calculating eligibility",
 		epochNumber,
 		log.Uint64("total_weight", totalWeight))
@@ -136,6 +140,7 @@ func (bo *Oracle) calcEligibilityProofs(epochNumber types.EpochID) (map[types.La
 		epochNumber,
 		log.String("epoch_beacon", beaconDbgStr))
 
+	weight := bo.atx.GetWeight()
 	numberOfEligibleBlocks, err := getNumberOfEligibleBlocks(weight, totalWeight, bo.committeeSize, bo.layersPerEpoch)
 	if err != nil {
 		bo.log.With().Error("failed to get number of eligible blocks", log.Err(err))

--- a/layerfetcher/layers.go
+++ b/layerfetcher/layers.go
@@ -716,7 +716,7 @@ func (l *Logic) GetTortoiseBeacon(ctx context.Context, id types.EpochID) error {
 		resHash := types.BytesToHash(res)
 		l.log.WithContext(ctx).With().Info("received tortoise beacon",
 			id,
-			log.String("beacon", resHash.String()))
+			log.String("beacon", resHash.ShortString()))
 		return l.tbDB.SetTortoiseBeacon(id, resHash)
 	}
 }

--- a/miner/block_builder.go
+++ b/miner/block_builder.go
@@ -306,6 +306,11 @@ func (t *BlockBuilder) createBlockLoop(ctx context.Context) {
 
 			atxID, proofs, atxs, err := t.blockOracle.BlockEligible(layerID)
 			if err != nil {
+				if errors.Is(err, blocks.ErrMinerHasNoATXInPreviousEpoch) {
+					logger.With().Info("node has no ATX in previous epoch and is not eligible for blocks")
+					events.ReportDoneCreatingBlock(true, layerID.Uint32(), "not eligible to produce block")
+					continue
+				}
 				events.ReportDoneCreatingBlock(true, layerID.Uint32(), "failed to check for block eligibility")
 				logger.With().Error("failed to check for block eligibility", layerID, log.Err(err))
 				continue

--- a/tortoisebeacon/beacon_calc.go
+++ b/tortoisebeacon/beacon_calc.go
@@ -19,7 +19,7 @@ func (tb *TortoiseBeacon) calcBeacon(ctx context.Context, epoch types.EpochID, l
 	for i, h := range allHashes {
 		allHashHexes[i] = types.BytesToHash([]byte(h)).ShortString()
 	}
-	logger.With().Info("calculating tortoise beacon from this hash list",
+	logger.With().Debug("calculating tortoise beacon from this hash list",
 		log.String("hashes", strings.Join(allHashHexes, ", ")))
 
 	beacon := allHashes.hash()

--- a/tortoisebeacon/beacon_calc.go
+++ b/tortoisebeacon/beacon_calc.go
@@ -15,8 +15,12 @@ func (tb *TortoiseBeacon) calcBeacon(ctx context.Context, epoch types.EpochID, l
 	logger.Info("calculating beacon")
 
 	allHashes := lastRoundVotes.valid.sort()
-	logger.With().Debug("calculating tortoise beacon from this hash list",
-		log.String("hashes", strings.Join(allHashes, ", ")))
+	allHashHexes := make([]string, len(allHashes))
+	for i, h := range allHashes {
+		allHashHexes[i] = types.BytesToHash([]byte(h)).ShortString()
+	}
+	logger.With().Info("calculating tortoise beacon from this hash list",
+		log.String("hashes", strings.Join(allHashHexes, ", ")))
 
 	beacon := allHashes.hash()
 

--- a/tortoisebeacon/handlers.go
+++ b/tortoisebeacon/handlers.go
@@ -38,11 +38,15 @@ var (
 
 	// errMinerATXNotFound is returned when miner has no ATXs in the previous epoch.
 	errMinerATXNotFound = errors.New("miner ATX not found in previous epoch")
+
+	// errProtocolNotRunning is returned when we are not in the middle of tortoise beacon protocol
+	errProtocolNotRunning = errors.New("tortoise beacon protocol not running")
 )
 
 // HandleSerializedProposalMessage defines method to handle Tortoise Beacon proposal Messages from gossip.
 func (tb *TortoiseBeacon) HandleSerializedProposalMessage(ctx context.Context, data service.GossipMessage, _ service.Fetcher) {
-	if tb.IsClosed() {
+	if tb.isClosed() || !tb.isInProtocol() {
+		tb.logger.WithContext(ctx).Debug("tortoise beacon shutting down or not in protocol, dropping msg")
 		return
 	}
 
@@ -81,7 +85,7 @@ func (tb *TortoiseBeacon) readProposalMessagesLoop(ctx context.Context, ch chan 
 			return
 
 		case em := <-ch:
-			if em == nil || tb.IsClosed() {
+			if em == nil || tb.isClosed() || !tb.isInProtocol() {
 				return
 			}
 
@@ -165,12 +169,22 @@ func (tb *TortoiseBeacon) classifyProposalMessage(ctx context.Context, m Proposa
 }
 
 func (tb *TortoiseBeacon) addValidProposal(proposal []byte) {
+	if !tb.isInProtocol() {
+		tb.logger.Debug("tortoise beacon not in protocol, not adding valid proposals")
+		return
+	}
+
 	tb.mu.Lock()
 	defer tb.mu.Unlock()
 	tb.incomingProposals.valid = append(tb.incomingProposals.valid, proposal)
 }
 
 func (tb *TortoiseBeacon) addPotentiallyValidProposal(proposal []byte) {
+	if !tb.isInProtocol() {
+		tb.logger.Debug("tortoise beacon not in protocol, not adding potentially valid proposals")
+		return
+	}
+
 	tb.mu.Lock()
 	defer tb.mu.Unlock()
 	tb.incomingProposals.potentiallyValid = append(tb.incomingProposals.potentiallyValid, proposal)
@@ -204,15 +218,16 @@ func (tb *TortoiseBeacon) verifyProposalMessage(ctx context.Context, m ProposalM
 	}
 
 	passes := tb.proposalChecker.IsProposalEligible(m.VRFSignature)
+	proposalShortString := types.BytesToHash(m.VRFSignature).ShortString()
 	if !passes {
 		// the peer may have different total weight from us so that it passes threshold for the peer
 		// but does not pass here
-		proposalShortString := types.BytesToHash(m.VRFSignature).ShortString()
 		logger.With().Warning("rejected proposal that doesn't pass threshold",
 			log.String("proposal", proposalShortString),
 			log.Uint64("total_weight", tb.epochWeight))
 		return types.ATXID{}, fmt.Errorf("[proposal] not eligible (miner ID %v): %w", minerID, errProposalDoesntPassThreshold)
 	}
+	logger.Info("accepted proposal from (miner ID %v)", minerID)
 
 	return atxID, nil
 }
@@ -233,7 +248,8 @@ func (tb *TortoiseBeacon) isValidProposalMessage(currentEpoch types.EpochID, atx
 
 // HandleSerializedFirstVotingMessage defines method to handle Tortoise Beacon first voting Messages from gossip.
 func (tb *TortoiseBeacon) HandleSerializedFirstVotingMessage(ctx context.Context, data service.GossipMessage, _ service.Fetcher) {
-	if tb.IsClosed() {
+	if tb.isClosed() || !tb.isInProtocol() {
+		tb.logger.WithContext(ctx).Debug("tortoise beacon shutting down or not in protocol, dropping msg")
 		return
 	}
 
@@ -323,6 +339,11 @@ func (tb *TortoiseBeacon) verifyFirstVotingMessage(ctx context.Context, message 
 }
 
 func (tb *TortoiseBeacon) storeFirstVotes(message FirstVotingMessage, minerPK *signing.PublicKey, voteWeight *big.Int) {
+	if !tb.isInProtocol() {
+		tb.logger.Debug("tortoise beacon not in protocol, not storing first votes")
+		return
+	}
+
 	tb.mu.Lock()
 	defer tb.mu.Unlock()
 
@@ -354,7 +375,8 @@ func (tb *TortoiseBeacon) storeFirstVotes(message FirstVotingMessage, minerPK *s
 
 // HandleSerializedFollowingVotingMessage defines method to handle Tortoise Beacon following voting Messages from gossip.
 func (tb *TortoiseBeacon) HandleSerializedFollowingVotingMessage(ctx context.Context, data service.GossipMessage, _ service.Fetcher) {
-	if tb.IsClosed() {
+	if tb.isClosed() || !tb.isInProtocol() {
+		tb.logger.WithContext(ctx).Debug("tortoise beacon shutting down or not in protocol, dropping msg")
 		return
 	}
 
@@ -446,6 +468,11 @@ func (tb *TortoiseBeacon) verifyFollowingVotingMessage(ctx context.Context, mess
 }
 
 func (tb *TortoiseBeacon) storeFollowingVotes(message FollowingVotingMessage, minerPK *signing.PublicKey, voteWeight *big.Int) {
+	if !tb.isInProtocol() {
+		tb.logger.Debug("tortoise beacon not in protocol, not storing following votes")
+		return
+	}
+
 	tb.mu.Lock()
 	defer tb.mu.Unlock()
 
@@ -477,6 +504,11 @@ func (tb *TortoiseBeacon) currentEpoch() types.EpochID {
 }
 
 func (tb *TortoiseBeacon) registerProposed(minerPK *signing.PublicKey, logger log.Log) error {
+	if !tb.isInProtocol() {
+		tb.logger.Debug("tortoise beacon not in protocol, not registering proposal")
+		return errProtocolNotRunning
+	}
+
 	tb.mu.Lock()
 	defer tb.mu.Unlock()
 
@@ -492,6 +524,11 @@ func (tb *TortoiseBeacon) registerProposed(minerPK *signing.PublicKey, logger lo
 }
 
 func (tb *TortoiseBeacon) registerVoted(minerPK *signing.PublicKey, round types.RoundID, logger log.Log) error {
+	if !tb.isInProtocol() {
+		tb.logger.Debug("tortoise beacon not in protocol, not registering votes")
+		return errProtocolNotRunning
+	}
+
 	tb.mu.Lock()
 	defer tb.mu.Unlock()
 

--- a/tortoisebeacon/handlers.go
+++ b/tortoisebeacon/handlers.go
@@ -218,16 +218,15 @@ func (tb *TortoiseBeacon) verifyProposalMessage(ctx context.Context, m ProposalM
 	}
 
 	passes := tb.proposalChecker.IsProposalEligible(m.VRFSignature)
-	proposalShortString := types.BytesToHash(m.VRFSignature).ShortString()
 	if !passes {
 		// the peer may have different total weight from us so that it passes threshold for the peer
 		// but does not pass here
+		proposalShortString := types.BytesToHash(m.VRFSignature).ShortString()
 		logger.With().Warning("rejected proposal that doesn't pass threshold",
 			log.String("proposal", proposalShortString),
 			log.Uint64("total_weight", tb.epochWeight))
 		return types.ATXID{}, fmt.Errorf("[proposal] not eligible (miner ID %v): %w", minerID, errProposalDoesntPassThreshold)
 	}
-	logger.Info("accepted proposal from (miner ID %v)", minerID)
 
 	return atxID, nil
 }

--- a/tortoisebeacon/tortoise_beacon.go
+++ b/tortoisebeacon/tortoise_beacon.go
@@ -348,6 +348,12 @@ func (tb *TortoiseBeacon) handleEpoch(ctx context.Context, epoch types.EpochID) 
 		return
 	}
 
+	// make sure this node has ATX in the last epoch and is eligible to participate in tortoise beacon
+	if _, err := tb.atxDB.GetNodeAtxIDForEpoch(tb.nodeID, epoch-1); err != nil {
+		logger.Info("node has no ATX in last epoch. not participating in tortoise beacon")
+		return
+	}
+
 	logger.Info("handling epoch")
 	epochWeight, atxs, err := tb.atxDB.GetEpochWeight(epoch)
 	if err != nil {

--- a/tortoisebeacon/tortoise_beacon.go
+++ b/tortoisebeacon/tortoise_beacon.go
@@ -114,9 +114,10 @@ func New(
 
 // TortoiseBeacon represents Tortoise Beacon.
 type TortoiseBeacon struct {
-	running uint64
-	eg      errgroup.Group
-	cancel  context.CancelFunc
+	running    uint64
+	inProtocol uint64
+	eg         errgroup.Group
+	cancel     context.CancelFunc
 
 	logger log.Log
 
@@ -200,8 +201,8 @@ func (tb *TortoiseBeacon) Close() {
 	tb.clock.Unsubscribe(tb.layerTicker)
 }
 
-// IsClosed returns true if background workers are not running.
-func (tb *TortoiseBeacon) IsClosed() bool {
+// isClosed returns true if background workers are not running.
+func (tb *TortoiseBeacon) isClosed() bool {
 	return atomic.LoadUint64(&tb.running) == 0
 }
 
@@ -265,19 +266,37 @@ func (tb *TortoiseBeacon) initGenesisBeacons() {
 	}
 }
 
-func (tb *TortoiseBeacon) setupEpoch(epochWeight uint64, logger log.Log) chan *proposalMessageWithReceiptData {
+func (tb *TortoiseBeacon) setBeginProtocol(ctx context.Context) {
+	if !atomic.CompareAndSwapUint64(&tb.inProtocol, 0, 1) {
+		tb.logger.WithContext(ctx).Warning("attempt to begin tortoise beacon protocol more than once")
+	}
+}
+
+func (tb *TortoiseBeacon) setEndProtocol(ctx context.Context) {
+	if !atomic.CompareAndSwapUint64(&tb.inProtocol, 1, 0) {
+		tb.logger.WithContext(ctx).Warning("attempt to end tortoise beacon protocol more than once")
+	}
+}
+
+func (tb *TortoiseBeacon) isInProtocol() bool {
+	return atomic.LoadUint64(&tb.inProtocol) == 1
+}
+
+func (tb *TortoiseBeacon) setupEpoch(epoch types.EpochID, epochWeight uint64, logger log.Log) chan *proposalMessageWithReceiptData {
+	tb.cleanupEpoch(epoch - 1) // just in case we processed any gossip messages before the protocol started
+
 	tb.mu.Lock()
 	defer tb.mu.Unlock()
 
 	tb.epochWeight = epochWeight
 	tb.proposalChecker = createProposalChecker(tb.config.Kappa, tb.config.Q, epochWeight, logger)
-	ch := tb.getOrCreateProposalChannel(tb.epochInProgress)
+	ch := tb.getOrCreateProposalChannel(epoch)
 	// allow proposals for the next epoch to come in early
-	_ = tb.getOrCreateProposalChannel(tb.epochInProgress + 1)
+	_ = tb.getOrCreateProposalChannel(epoch + 1)
 	return ch
 }
 
-func (tb *TortoiseBeacon) cleanupEpoch() {
+func (tb *TortoiseBeacon) cleanupEpoch(epoch types.EpochID) {
 	tb.mu.Lock()
 	defer tb.mu.Unlock()
 
@@ -288,9 +307,9 @@ func (tb *TortoiseBeacon) cleanupEpoch() {
 	tb.hasVoted = make([]map[string]struct{}, tb.config.RoundsNumber)
 	tb.proposalPhaseFinishedTime = time.Time{}
 
-	if ch, ok := tb.proposalChans[tb.epochInProgress]; ok {
+	if ch, ok := tb.proposalChans[epoch]; ok {
 		close(ch)
-		delete(tb.proposalChans, tb.epochInProgress)
+		delete(tb.proposalChans, epoch)
 	}
 }
 
@@ -365,8 +384,11 @@ func (tb *TortoiseBeacon) handleEpoch(ctx context.Context, epoch types.EpochID) 
 		return
 	}
 
-	ch := tb.setupEpoch(epochWeight, logger)
-	defer tb.cleanupEpoch()
+	tb.setBeginProtocol(ctx)
+	defer tb.setEndProtocol(ctx)
+
+	ch := tb.setupEpoch(epoch, epochWeight, logger)
+	defer tb.cleanupEpoch(epoch)
 
 	tb.eg.Go(func() error {
 		tb.readProposalMessagesLoop(ctx, ch)
@@ -429,7 +451,7 @@ func (tb *TortoiseBeacon) runProposalPhase(ctx context.Context, epoch types.Epoc
 }
 
 func (tb *TortoiseBeacon) proposalPhaseImpl(ctx context.Context, epoch types.EpochID) error {
-	if tb.IsClosed() {
+	if tb.isClosed() {
 		return nil
 	}
 
@@ -696,7 +718,8 @@ func createProposalChecker(kappa uint64, q *big.Rat, epochWeight uint64, logger 
 	}
 
 	threshold := atxThreshold(kappa, q, epochWeight)
-	logger.With().Debug("created proposal checker with ATX threshold",
+	logger.With().Info("created proposal checker with ATX threshold",
+		log.Uint64("epoch_weight", epochWeight),
 		log.String("threshold", threshold.String()))
 	return &proposalChecker{threshold: threshold}
 }


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
Closes #2781
Closes #2837
<!-- `Closes #XXXX, closes #XXXX, ...` links mentioned issues to this PR and automatically closes them when this it's merged -->

## Changes
<!-- Please describe in detail the changes made -->
- check self ATX in previous epoch before participating in tortoise beacon and building blocks
- discard gossip messages when we are not in protocol

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->
unit tests

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
