### PR TITLE
[Merged by Bors] - `cmd/node`: Move `setupGenesis` logic into `svm.SetupGenesis`

### DIFF
--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/spacemeshos/go-spacemesh/svm/state"
 	"io/ioutil"
 	"math/big"
 	"net/http"
@@ -18,6 +17,9 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/spacemeshos/go-spacemesh/svm"
+	"github.com/spacemeshos/go-spacemesh/svm/state"
+
 	"github.com/mitchellh/mapstructure"
 	"github.com/pyroscope-io/pyroscope/pkg/agent/profiler"
 	"github.com/spf13/cobra"
@@ -27,7 +29,6 @@ import (
 
 	"github.com/spacemeshos/go-spacemesh/activation"
 	"github.com/spacemeshos/go-spacemesh/api"
-	apiCfg "github.com/spacemeshos/go-spacemesh/api/config"
 	"github.com/spacemeshos/go-spacemesh/api/grpcserver"
 	"github.com/spacemeshos/go-spacemesh/blocks"
 	cmdp "github.com/spacemeshos/go-spacemesh/cmd"
@@ -98,6 +99,7 @@ const (
 	Fetcher              = "fetcher"
 	LayerFetcher         = "layerFetcher"
 	TimeSyncLogger       = "timesync"
+	SVMLogger            = "SVM"
 )
 
 // Cmd is the cobra wrapper for the node, that allows adding parameters to it
@@ -394,34 +396,6 @@ func (app *App) Cleanup() {
 	log.Info("app cleanup completed")
 }
 
-func (app *App) setupGenesis(state *state.TransactionProcessor, msh *mesh.Mesh) error {
-	if app.Config.Genesis == nil {
-		app.Config.Genesis = apiCfg.DefaultGenesisConfig()
-	}
-	for id, balance := range app.Config.Genesis.Accounts {
-		bytes := util.FromHex(id)
-		if len(bytes) == 0 {
-			return fmt.Errorf("cannot decode entry %s for genesis account", id)
-		}
-		// just make it explicit that we want address and not a public key
-		if len(bytes) != types.AddressLength {
-			return fmt.Errorf("%s must be an address of size %d", id, types.AddressLength)
-		}
-		addr := types.BytesToAddress(bytes)
-		state.CreateAccount(addr)
-		state.AddBalance(addr, balance)
-		app.log.With().Info("genesis account created",
-			log.String("address", addr.Hex()),
-			log.Uint64("balance", balance))
-	}
-
-	_, err := state.Commit()
-	if err != nil {
-		return fmt.Errorf("cannot commit genesis state: %w", err)
-	}
-	return nil
-}
-
 // Wrap the top-level logger to add context info and set the level for a
 // specific module.
 func (app *App) addLogger(name string, logger log.Log) log.Log {
@@ -650,7 +624,9 @@ func (app *App) initServices(ctx context.Context,
 		go msh.CacheWarmUp(app.Config.LayerAvgSize)
 	} else {
 		msh = mesh.NewMesh(mdb, atxDB, app.Config.REWARD, trtl, app.txPool, processor, app.addLogger(MeshLogger, lg))
-		if err := app.setupGenesis(processor, msh); err != nil {
+		svm := svm.New(app.state, app.addLogger(SVMLogger, lg))
+
+		if err := svm.SetupGenesis(app.Config.Genesis); err != nil {
 			return err
 		}
 	}

--- a/svm/api.go
+++ b/svm/api.go
@@ -1,0 +1,48 @@
+package svm
+
+import (
+	"fmt"
+
+	"github.com/spacemeshos/go-spacemesh/api/config"
+	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/common/util"
+	"github.com/spacemeshos/go-spacemesh/log"
+	"github.com/spacemeshos/go-spacemesh/svm/state"
+)
+
+type SVM struct {
+	state *state.TransactionProcessor
+	log   log.Logger
+}
+
+func New(state *state.TransactionProcessor, logger log.Log) *SVM {
+	return &SVM{state, log.NewDefault("svm")}
+}
+
+func (svm *SVM) SetupGenesis(conf *config.GenesisConfig) error {
+	if conf == nil {
+		conf = config.DefaultGenesisConfig()
+	}
+	for id, balance := range conf.Accounts {
+		bytes := util.FromHex(id)
+		if len(bytes) == 0 {
+			return fmt.Errorf("cannot decode entry %s for genesis account", id)
+		}
+		// just make it explicit that we want address and not a public key
+		if len(bytes) != types.AddressLength {
+			return fmt.Errorf("%s must be an address of size %d", id, types.AddressLength)
+		}
+		addr := types.BytesToAddress(bytes)
+		svm.state.CreateAccount(addr)
+		svm.state.AddBalance(addr, balance)
+		svm.log.With().Info("genesis account created",
+			log.String("address", addr.Hex()),
+			log.Uint64("balance", balance))
+	}
+
+	_, err := svm.state.Commit()
+	if err != nil {
+		return fmt.Errorf("cannot commit genesis state: %w", err)
+	}
+	return nil
+}

--- a/svm/api.go
+++ b/svm/api.go
@@ -10,15 +10,18 @@ import (
 	"github.com/spacemeshos/go-spacemesh/svm/state"
 )
 
+// SVM is an entry point for all SVM operations.
 type SVM struct {
 	state *state.TransactionProcessor
 	log   log.Logger
 }
 
+// New creates a new `SVM` instance from the given `state` and `logger`.
 func New(state *state.TransactionProcessor, logger log.Log) *SVM {
 	return &SVM{state, log.NewDefault("svm")}
 }
 
+// SetupGenesis creates new accounts and adds balances as dictated by `conf`.
 func (svm *SVM) SetupGenesis(conf *config.GenesisConfig) error {
 	if conf == nil {
 		conf = config.DefaultGenesisConfig()


### PR DESCRIPTION
Closes #2830. I'm available for iterating based on any feedback you all might have.

## Changes
Moves all genesis setup logic from `cmd/node` into `svm`.

## DevOps Notes
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)

TODO's, for future PRs:
- Hide `state.TransactionProcessor` from `svm.New` public API.