### PR TITLE
[Merged by Bors] - hare: determine good blocks based on beacon value

### DIFF
--- a/cmd/hare/hare.go
+++ b/cmd/hare/hare.go
@@ -50,9 +50,7 @@ func init() {
 	cmdp.AddCommands(Cmd)
 }
 
-type mockBlockProvider struct {
-	allBlocks map[types.BlockID]*types.Block
-}
+type mockBlockProvider struct{}
 
 func (mbp *mockBlockProvider) HandleValidatedLayer(context.Context, types.LayerID, []types.BlockID) {
 }
@@ -63,14 +61,18 @@ func (mbp *mockBlockProvider) InvalidateLayer(context.Context, types.LayerID) {
 func (mbp *mockBlockProvider) RecordCoinflip(context.Context, types.LayerID, bool) {
 }
 
-func (mbp *mockBlockProvider) LayerBlocks(types.LayerID) ([]*types.Block, error) {
-	blockSet, allBlocks := buildSet()
-	mbp.allBlocks = allBlocks
-	return blockSet, nil
+func (mbp *mockBlockProvider) LayerBlocks(lyr types.LayerID) ([]*types.Block, error) {
+	s := make([]*types.Block, 200)
+	for i := uint64(0); i < 200; i++ {
+		blk := types.NewExistingBlock(lyr, util.Uint64ToBytes(i), nil)
+		blk.TortoiseBeacon = lyr.GetEpoch().ToBytes()
+		s[i] = blk
+	}
+	return s, nil
 }
 
-func (mbp *mockBlockProvider) GetBlock(bID types.BlockID) (*types.Block, error) {
-	return mbp.allBlocks[bID], nil
+func (mbp *mockBlockProvider) GetBlock(types.BlockID) (*types.Block, error) {
+	return nil, nil
 }
 
 type mockBeaconGetter struct{}
@@ -105,18 +107,6 @@ func NewHareApp() *HareApp {
 func (app *HareApp) Cleanup() {
 	// TODO: move to array of cleanup functions and execute all here
 	app.oracle.Unregister(true, app.sgn.PublicKey().String())
-}
-
-func buildSet() ([]*types.Block, map[types.BlockID]*types.Block) {
-	s := make([]*types.Block, 200, 200)
-	allBlocks := make(map[types.BlockID]*types.Block, 200)
-	for i := uint64(0); i < 200; i++ {
-		blk := types.NewExistingBlock(types.GetEffectiveGenesis().Add(1), util.Uint64ToBytes(i), nil)
-		s = append(s, blk)
-		allBlocks[blk.ID()] = blk
-	}
-
-	return s, allBlocks
 }
 
 type mockIDProvider struct{}

--- a/cmd/hare/hare.go
+++ b/cmd/hare/hare.go
@@ -50,7 +50,9 @@ func init() {
 	cmdp.AddCommands(Cmd)
 }
 
-type mockBlockProvider struct{}
+type mockBlockProvider struct {
+	allBlocks map[types.BlockID]*types.Block
+}
 
 func (mbp *mockBlockProvider) HandleValidatedLayer(context.Context, types.LayerID, []types.BlockID) {
 }
@@ -61,8 +63,20 @@ func (mbp *mockBlockProvider) InvalidateLayer(context.Context, types.LayerID) {
 func (mbp *mockBlockProvider) RecordCoinflip(context.Context, types.LayerID, bool) {
 }
 
-func (mbp *mockBlockProvider) LayerBlockIds(types.LayerID) ([]types.BlockID, error) {
-	return buildSet(), nil
+func (mbp *mockBlockProvider) LayerBlocks(types.LayerID) ([]*types.Block, error) {
+	blockSet, allBlocks := buildSet()
+	mbp.allBlocks = allBlocks
+	return blockSet, nil
+}
+
+func (mbp *mockBlockProvider) GetBlock(bID types.BlockID) (*types.Block, error) {
+	return mbp.allBlocks[bID], nil
+}
+
+type mockBeaconGetter struct{}
+
+func (mbg *mockBeaconGetter) GetBeacon(id types.EpochID) ([]byte, error) {
+	return id.ToBytes(), nil
 }
 
 // HareApp represents an Hare application.
@@ -93,14 +107,16 @@ func (app *HareApp) Cleanup() {
 	app.oracle.Unregister(true, app.sgn.PublicKey().String())
 }
 
-func buildSet() []types.BlockID {
-	s := make([]types.BlockID, 200, 200)
-
+func buildSet() ([]*types.Block, map[types.BlockID]*types.Block) {
+	s := make([]*types.Block, 200, 200)
+	allBlocks := make(map[types.BlockID]*types.Block, 200)
 	for i := uint64(0); i < 200; i++ {
-		s = append(s, types.NewExistingBlock(types.GetEffectiveGenesis().Add(1), util.Uint64ToBytes(i), nil).ID())
+		blk := types.NewExistingBlock(types.GetEffectiveGenesis().Add(1), util.Uint64ToBytes(i), nil)
+		s = append(s, blk)
+		allBlocks[blk.ID()] = blk
 	}
 
-	return s
+	return s, allBlocks
 }
 
 type mockIDProvider struct{}
@@ -161,7 +177,7 @@ func (app *HareApp) Start(cmd *cobra.Command, args []string) {
 	//app.clock = timesync.NewClock(timesync.RealClock{}, ld, gTime, lg)
 	lt := make(timesync.LayerTimer)
 
-	hareI := hare.New(app.Config.HARE, app.p2p, app.sgn, types.NodeID{Key: app.sgn.PublicKey().String(), VRFPublicKey: []byte{}}, IsSynced, &mockBlockProvider{}, hareOracle, layerpatrol.New(), uint16(app.Config.LayersPerEpoch), &mockIDProvider{}, &mockStateQuerier{}, lt, lg)
+	hareI := hare.New(app.Config.HARE, app.p2p, app.sgn, types.NodeID{Key: app.sgn.PublicKey().String(), VRFPublicKey: []byte{}}, IsSynced, &mockBlockProvider{}, &mockBeaconGetter{}, hareOracle, layerpatrol.New(), uint16(app.Config.LayersPerEpoch), &mockIDProvider{}, &mockStateQuerier{}, lt, lg)
 	log.Info("starting hare service")
 	app.ha = hareI
 	if err = app.ha.Start(cmdp.Ctx); err != nil {

--- a/cmd/hare/oracle.go
+++ b/cmd/hare/oracle.go
@@ -36,7 +36,3 @@ func (bo *hareOracle) CalcEligibility(_ context.Context, layer types.LayerID, ro
 func (bo *hareOracle) Proof(context.Context, types.LayerID, uint32) ([]byte, error) {
 	return []byte{}, nil
 }
-
-func (bo *hareOracle) IsEpochBeaconReady(ctx context.Context, epoch types.EpochID) bool {
-	return true
-}

--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -649,7 +649,7 @@ func (app *App) initServices(ctx context.Context,
 	}
 
 	gossipListener := service.NewListener(swarm, layerFetch, newSyncer.ListenToGossip, app.addLogger(GossipListener, lg))
-	rabbit := app.HareFactory(ctx, mdb, swarm, sgn, nodeID, patrol, newSyncer, msh, hOracle, idStore, clock, lg)
+	rabbit := app.HareFactory(ctx, mdb, swarm, sgn, nodeID, patrol, newSyncer, msh, tBeacon, hOracle, idStore, clock, lg)
 
 	stateAndMeshProjector := pendingtxs.NewStateAndMeshProjector(processor, msh)
 	minerCfg := miner.Config{
@@ -774,6 +774,7 @@ func (app *App) HareFactory(
 	patrol *layerpatrol.LayerPatrol,
 	syncer *syncer.Syncer,
 	msh *mesh.Mesh,
+	beacons blocks.BeaconGetter,
 	hOracle hare.Rolacle,
 	idStore *activation.IdentityStore,
 	clock TickProvider,
@@ -792,6 +793,7 @@ func (app *App) HareFactory(
 		nodeID,
 		syncer.IsSynced,
 		msh,
+		beacons,
 		hOracle,
 		patrol,
 		uint16(app.Config.LayersPerEpoch),

--- a/cmd/node/oracle.go
+++ b/cmd/node/oracle.go
@@ -51,10 +51,6 @@ func (bo *localOracle) Proof(ctx context.Context, layer types.LayerID, round uin
 	return proof, nil
 }
 
-func (bo *localOracle) IsEpochBeaconReady(ctx context.Context, epoch types.EpochID) bool {
-	return true
-}
-
 func newLocalOracle(rolacle *eligibility.FixedRolacle, committeeSize int, nodeID types.NodeID) *localOracle {
 	return &localOracle{
 		committeeSize: committeeSize,

--- a/common/types/activation.go
+++ b/common/types/activation.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"sort"
+	"strconv"
 
 	poetShared "github.com/spacemeshos/poet/shared"
 	postShared "github.com/spacemeshos/post/shared"
@@ -38,6 +39,11 @@ func (l EpochID) FirstLayer() LayerID {
 
 // Field returns a log field. Implements the LoggableField interface.
 func (l EpochID) Field() log.Field { return log.Uint32("epoch_id", uint32(l)) }
+
+// String returns string representation of the epoch id numeric value.
+func (l EpochID) String() string {
+	return strconv.FormatUint(uint64(l), 10)
+}
 
 // ATXID is a 32-bit hash used to identify an activation transaction.
 type ATXID Hash32

--- a/eligibility/fixedoracle.go
+++ b/eligibility/fixedoracle.go
@@ -97,11 +97,6 @@ func (fo *FixedRolacle) Unregister(isHonest bool, client string) {
 	fo.mutex.Unlock()
 }
 
-// IsEpochBeaconReady returns true if the beacon value is known for the specified epoch.
-func (fo *FixedRolacle) IsEpochBeaconReady(context.Context, types.EpochID) bool {
-	return true
-}
-
 func cloneMap(m map[string]struct{}) map[string]struct{} {
 	c := make(map[string]struct{}, len(m))
 	for k, v := range m {

--- a/hare/algorithm.go
+++ b/hare/algorithm.go
@@ -585,21 +585,23 @@ func (proc *consensusProcess) beginCommitRound(ctx context.Context) {
 	// proposedSet may be nil, in such case the tracker will ignore Messages
 	proc.commitTracker = newCommitTracker(proc.cfg.F+1, proc.cfg.N, proposedSet) // track commits for proposed set
 
-	if proposedSet != nil { // has proposal to commit on
-		// check participation
-		if !proc.shouldParticipate(ctx) {
-			return
-		}
-
-		builder, err := proc.initDefaultBuilder(proposedSet)
-		if err != nil {
-			proc.WithContext(ctx).With().Error("init default builder failed", log.Err(err))
-			return
-		}
-		builder = builder.SetType(commit).Sign(proc.signing)
-		commitMsg := builder.Build()
-		proc.sendMessage(ctx, commitMsg)
+	if proposedSet == nil {
+		return
 	}
+
+	// check participation
+	if !proc.shouldParticipate(ctx) {
+		return
+	}
+
+	builder, err := proc.initDefaultBuilder(proposedSet)
+	if err != nil {
+		proc.WithContext(ctx).With().Error("init default builder failed", log.Err(err))
+		return
+	}
+	builder = builder.SetType(commit).Sign(proc.signing)
+	commitMsg := builder.Build()
+	proc.sendMessage(ctx, commitMsg)
 }
 
 func (proc *consensusProcess) beginNotifyRound(ctx context.Context) {

--- a/hare/algorithm.go
+++ b/hare/algorithm.go
@@ -234,7 +234,7 @@ func iterationFromCounter(roundCounter uint32) uint32 {
 // Start the consensus process.
 // It starts the PreRound round and then iterates through the rounds until consensus is reached or the instance is canceled.
 // It is assumed that the inbox is set before the call to Start.
-// It returns an error if Start has been called more than once, the set size is zero (no values) or the inbox is nil.
+// It returns an error if Start has been called more than once or the inbox is nil.
 func (proc *consensusProcess) Start(ctx context.Context) error {
 	logger := proc.WithContext(ctx)
 	if proc.isStarted { // called twice on same instance
@@ -276,7 +276,7 @@ func (proc *consensusProcess) eventLoop(ctx context.Context) {
 		log.Int("hare_n", proc.cfg.N),
 		log.Int("f", proc.cfg.F),
 		log.String("duration", (time.Duration(proc.cfg.RoundDuration)*time.Second).String()),
-		types.LayerID(proc.instanceID),
+		proc.instanceID,
 		log.Int("exp_leaders", proc.cfg.ExpectedLeaders),
 		log.String("current_set", proc.s.String()),
 		log.Int("set_size", proc.s.Size()))
@@ -300,7 +300,7 @@ func (proc *consensusProcess) eventLoop(ctx context.Context) {
 		} else {
 			logger.With().Info("should not participate",
 				log.Uint32("current_k", proc.k),
-				types.LayerID(proc.instanceID))
+				proc.instanceID)
 		}
 	}()
 
@@ -315,23 +315,24 @@ PreRound:
 		case <-proc.CloseChannel():
 			logger.With().Info("terminating during preround: received termination signal",
 				log.Uint32("current_k", proc.k),
-				types.LayerID(proc.instanceID))
+				proc.instanceID)
 			return
 		}
 	}
 	logger.With().Debug("preround ended, filtering preliminary set",
-		types.LayerID(proc.instanceID),
+		proc.instanceID,
 		log.Int("set_size", proc.s.Size()))
 	proc.preRoundTracker.FilterSet(proc.s)
 	logger.With().Debug("preround set size after filtering",
-		types.LayerID(proc.instanceID),
+		proc.instanceID,
 		log.Int("set_size", proc.s.Size()))
 	if proc.s.Size() == 0 {
-		logger.Event().Warning("preround ended with empty set", types.LayerID(proc.instanceID))
+		logger.Event().Warning("preround ended with empty set",
+			proc.instanceID)
 	} else {
 		logger.With().Info("preround ended",
 			log.Int("set_size", proc.s.Size()),
-			types.LayerID(proc.instanceID))
+			proc.instanceID)
 	}
 	proc.advanceToNextRound(ctx) // K was initialized to -1, K should be 0
 
@@ -356,7 +357,7 @@ PreRound:
 				logger.With().Warning("terminating: reached iterations limit",
 					log.Int("limit", proc.cfg.LimitIterations),
 					log.Uint32("current_k", proc.k),
-					types.LayerID(proc.instanceID))
+					proc.instanceID)
 				proc.report(notCompleted)
 				return
 			}
@@ -365,7 +366,7 @@ PreRound:
 		case <-proc.CloseChannel(): // close event
 			logger.With().Info("terminating: received termination signal",
 				log.Uint32("current_k", proc.k),
-				types.LayerID(proc.instanceID))
+				proc.instanceID)
 			proc.report(notCompleted)
 			return
 		}
@@ -408,7 +409,7 @@ func (proc *consensusProcess) handleMessage(ctx context.Context, m *Msg) {
 		log.FieldNamed("sender_id", m.PubKey),
 		log.Uint32("current_k", proc.k),
 		log.Uint32("msg_k", m.InnerMsg.K),
-		types.LayerID(proc.instanceID))
+		proc.instanceID)
 
 	// Try to extract reqID from message and restore it to context
 	if m.RequestID == "" {
@@ -493,7 +494,7 @@ func (proc *consensusProcess) sendMessage(ctx context.Context, msg *Msg) bool {
 
 	// generate a new requestID for this message
 	ctx = log.WithNewRequestID(ctx,
-		types.LayerID(proc.instanceID),
+		proc.instanceID,
 		log.Uint32("msg_k", msg.InnerMsg.K),
 		log.String("msg_type", msg.InnerMsg.Type.String()),
 		log.Int("eligibility_count", int(msg.InnerMsg.EligibilityCount)),
@@ -515,8 +516,7 @@ func (proc *consensusProcess) sendMessage(ctx context.Context, msg *Msg) bool {
 func (proc *consensusProcess) onRoundEnd(ctx context.Context) {
 	logger := proc.WithContext(ctx).WithFields(
 		log.Uint32("current_k", proc.k),
-		types.LayerID(proc.instanceID),
-	)
+		proc.instanceID)
 	logger.Debug("end of round")
 
 	// reset trackers
@@ -544,7 +544,7 @@ func (proc *consensusProcess) advanceToNextRound(ctx context.Context) {
 	if proc.k >= 4 && proc.k%4 == 0 {
 		proc.WithContext(ctx).Event().Warning("starting new iteration",
 			log.Uint32("current_k", proc.k),
-			types.LayerID(proc.instanceID))
+			proc.instanceID)
 	}
 }
 
@@ -612,7 +612,7 @@ func (proc *consensusProcess) beginCommitRound(ctx context.Context) {
 }
 
 func (proc *consensusProcess) beginNotifyRound(ctx context.Context) {
-	logger := proc.WithContext(ctx).WithFields(types.LayerID(proc.instanceID))
+	logger := proc.WithContext(ctx).WithFields(proc.instanceID)
 
 	// release proposal & commit trackers
 	defer func() {
@@ -773,7 +773,7 @@ func (proc *consensusProcess) processNotifyMsg(ctx context.Context, msg *Msg) {
 		proc.WithContext(ctx).With().Debug("not enough notifications for termination",
 			log.String("current_set", proc.s.String()),
 			log.Uint32("current_k", proc.k),
-			types.LayerID(proc.instanceID),
+			proc.instanceID,
 			log.Int("expected", proc.cfg.F+1),
 			log.Int("actual", proc.notifyTracker.NotificationsCount(s)))
 		return
@@ -784,7 +784,7 @@ func (proc *consensusProcess) processNotifyMsg(ctx context.Context, msg *Msg) {
 	proc.WithContext(ctx).Event().Info("consensus process terminated",
 		log.String("current_set", proc.s.String()),
 		log.Uint32("current_k", proc.k),
-		types.LayerID(proc.instanceID),
+		proc.instanceID,
 		log.Int("set_size", proc.s.Size()), log.Uint32("K", proc.k))
 	proc.report(completed)
 	proc.terminating = true
@@ -831,7 +831,7 @@ func (proc *consensusProcess) endOfStatusRound() {
 	proc.statusesTracker.AnalyzeStatuses(vtFunc)
 	proc.Event().Info("status round ended",
 		log.Bool("is_svp_ready", proc.statusesTracker.IsSVPReady()),
-		types.LayerID(proc.instanceID),
+		proc.instanceID,
 		log.Int("set_size", proc.s.Size()),
 		log.String("analyze_duration", time.Since(before).String()))
 }
@@ -839,32 +839,30 @@ func (proc *consensusProcess) endOfStatusRound() {
 // checks if we should participate in the current round
 // returns true if we should participate, false otherwise.
 func (proc *consensusProcess) shouldParticipate(ctx context.Context) bool {
-	logger := proc.WithContext(ctx)
+	logger := proc.WithContext(ctx).WithFields(
+		log.Uint32("current_k", proc.k),
+		proc.instanceID)
 
 	// query if identity is active
-	res, err := proc.oracle.IsIdentityActiveOnConsensusView(ctx, proc.signing.PublicKey().String(), types.LayerID(proc.instanceID))
+	res, err := proc.oracle.IsIdentityActiveOnConsensusView(ctx, proc.signing.PublicKey().String(), proc.instanceID)
 	if err != nil {
-		logger.With().Error("should not participate: error checking our identity for activeness",
-			log.Err(err), types.LayerID(proc.instanceID))
+		logger.With().Error("should not participate: error checking our identity for activeness", log.Err(err))
 		return false
 	}
 
 	if !res {
-		logger.With().Info("should not participate: identity is not active",
-			types.LayerID(proc.instanceID))
+		logger.Info("should not participate: identity is not active")
 		return false
 	}
 
 	currentRole := proc.currentRole(ctx)
 	if currentRole == passive {
-		logger.With().Info("should not participate: passive",
-			log.Uint32("current_k", proc.k), types.LayerID(proc.instanceID))
+		logger.Info("should not participate: passive")
 		return false
 	}
 
 	// should participate
 	logger.With().Info("should participate",
-		log.Uint32("current_k", proc.k), types.LayerID(proc.instanceID),
 		log.Bool("leader", currentRole == leader),
 		log.Uint32("eligibility_count", uint32(proc.eligibilityCount)),
 	)
@@ -873,17 +871,17 @@ func (proc *consensusProcess) shouldParticipate(ctx context.Context) bool {
 
 // Returns the role matching the current round if eligible for this round, false otherwise.
 func (proc *consensusProcess) currentRole(ctx context.Context) role {
-	logger := proc.WithContext(ctx)
-	proof, err := proc.oracle.Proof(ctx, types.LayerID(proc.instanceID), proc.k)
+	logger := proc.WithContext(ctx).WithFields(proc.instanceID)
+	proof, err := proc.oracle.Proof(ctx, proc.instanceID, proc.k)
 	if err != nil {
 		logger.With().Error("could not retrieve eligibility proof from oracle", log.Err(err))
 		return passive
 	}
 
-	eligibilityCount, err := proc.oracle.CalcEligibility(ctx, types.LayerID(proc.instanceID),
+	eligibilityCount, err := proc.oracle.CalcEligibility(ctx, proc.instanceID,
 		proc.k, expectedCommitteeSize(proc.k, proc.cfg.N, proc.cfg.ExpectedLeaders), proc.nid, proof)
 	if err != nil {
-		logger.With().Error("failed to check eligibility", log.Err(err), types.LayerID(proc.instanceID))
+		logger.With().Error("failed to check eligibility", log.Err(err))
 		return passive
 	}
 

--- a/hare/algorithm.go
+++ b/hare/algorithm.go
@@ -29,15 +29,6 @@ const ( // constants of the different roles
 	leader  = role(2)
 )
 
-// Rolacle is the roles oracle provider.
-type Rolacle interface {
-	Validate(ctx context.Context, layer types.LayerID, round uint32, committeeSize int, id types.NodeID, sig []byte, eligibilityCount uint16) (bool, error)
-	CalcEligibility(ctx context.Context, layer types.LayerID, round uint32, committeeSize int, id types.NodeID, sig []byte) (uint16, error)
-	Proof(ctx context.Context, layer types.LayerID, round uint32) ([]byte, error)
-	IsIdentityActiveOnConsensusView(ctx context.Context, edID string, layer types.LayerID) (bool, error)
-	IsEpochBeaconReady(ctx context.Context, epoch types.EpochID) bool
-}
-
 // NetworkService provides the registration and broadcast abilities in the network.
 type NetworkService interface {
 	RegisterGossipProtocol(protocol string, prio priorityq.Priority) chan service.GossipMessage

--- a/hare/algorithm_test.go
+++ b/hare/algorithm_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -13,6 +14,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/common/util"
 	"github.com/spacemeshos/go-spacemesh/eligibility"
 	"github.com/spacemeshos/go-spacemesh/hare/config"
+	"github.com/spacemeshos/go-spacemesh/hare/mocks"
 	"github.com/spacemeshos/go-spacemesh/log/logtest"
 	"github.com/spacemeshos/go-spacemesh/p2p/node"
 	"github.com/spacemeshos/go-spacemesh/p2p/service"
@@ -37,37 +39,6 @@ func (mmv *mockMessageValidator) SyntacticallyValidateMessage(context.Context, *
 func (mmv *mockMessageValidator) ContextuallyValidateMessage(context.Context, *Msg, uint32) error {
 	mmv.countContext++
 	return mmv.contextValid
-}
-
-type mockRolacle struct {
-	isEligible bool
-	err        error
-	MockStateQuerier
-}
-
-func (mr *mockRolacle) Validate(context.Context, types.LayerID, uint32, int, types.NodeID, []byte, uint16) (bool, error) {
-	return mr.isEligible, mr.err
-}
-
-func (mr *mockRolacle) CalcEligibility(context.Context, types.LayerID, uint32, int, types.NodeID, []byte) (uint16, error) {
-	if mr.isEligible {
-		return 1, nil
-	}
-	return 0, mr.err
-}
-
-func (mr *mockRolacle) Proof(context.Context, types.LayerID, uint32) ([]byte, error) {
-	return []byte{}, nil
-}
-
-func (mr *mockRolacle) Register(string) {
-}
-
-func (mr *mockRolacle) Unregister(string) {
-}
-
-func (mr *mockRolacle) IsEpochBeaconReady(context.Context, types.EpochID) bool {
-	return true
 }
 
 type mockP2p struct {
@@ -145,10 +116,6 @@ func (s *mockSyncer) IsSynced(context.Context) bool {
 	return s.isSync
 }
 
-func generateSigning(*testing.T) Signer {
-	return signing.NewEdSigner()
-}
-
 func buildMessage(msg *Message) *Msg {
 	return &Msg{Message: msg, PubKey: nil}
 }
@@ -175,22 +142,12 @@ func (mev *mockEligibilityValidator) Validate(ctx context.Context, msg *Msg) boo
 	return mev.valid
 }
 
-type mockOracle struct{}
-
-func (mo *mockOracle) Eligible(types.LayerID, int32, string, []byte) bool {
-	return true
-}
-
-func buildOracle(oracle Rolacle) Rolacle {
-	return oracle
-}
-
 // test that a InnerMsg to a specific set ObjectID is delivered by the broker.
 func TestConsensusProcess_Start(t *testing.T) {
 	sim := service.NewSimulator()
 	n1 := sim.NewNode()
 	broker := buildBroker(t, n1, t.Name())
-	broker.Start(context.TODO())
+	require.NoError(t, broker.Start(context.TODO()))
 	proc := generateConsensusProcess(t)
 	inbox, _ := broker.Register(context.TODO(), proc.ID())
 	proc.SetInbox(inbox)
@@ -206,20 +163,27 @@ func TestConsensusProcess_TerminationLimit(t *testing.T) {
 	p.SetInbox(make(chan *Msg, 10))
 	p.cfg.LimitIterations = 1
 	p.cfg.RoundDuration = 1
-	p.Start(context.TODO())
+	require.NoError(t, p.Start(context.TODO()))
 	time.Sleep(time.Duration(6*p.cfg.RoundDuration) * time.Second)
 	assert.EqualValues(t, 1, p.k/4)
 }
 
 func TestConsensusProcess_eventLoop(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
 	net := &mockP2p{}
 	broker := buildBroker(t, net, t.Name())
-	broker.Start(context.TODO())
+	require.NoError(t, broker.Start(context.TODO()))
 	proc := generateConsensusProcess(t)
 	proc.network = net
-	oracle := &mockRolacle{MockStateQuerier: MockStateQuerier{true, nil}}
-	oracle.isEligible = true
-	proc.oracle = oracle
+
+	mo := mocks.NewMockRolacle(ctrl)
+	mo.EXPECT().IsIdentityActiveOnConsensusView(gomock.Any(), gomock.Any(), proc.instanceID).Return(true, nil).Times(1)
+	mo.EXPECT().Proof(gomock.Any(), proc.instanceID, proc.k).Return(nil, nil).Times(2)
+	mo.EXPECT().CalcEligibility(gomock.Any(), proc.instanceID, proc.k, gomock.Any(), proc.nid, gomock.Any()).Return(uint16(1), nil).Times(1)
+	proc.oracle = mo
+
 	proc.inbox, _ = broker.Register(context.TODO(), proc.ID())
 	proc.s = NewSetFromValues(value1, value2)
 	proc.cfg.F = 2
@@ -229,19 +193,21 @@ func TestConsensusProcess_eventLoop(t *testing.T) {
 }
 
 func TestConsensusProcess_handleMessage(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
 	r := require.New(t)
 	net := &mockP2p{}
 	broker := buildBroker(t, net, t.Name())
 	r.NoError(broker.Start(context.TODO()))
 	proc := generateConsensusProcess(t)
 	proc.network = net
-	oracle := &mockRolacle{}
-	proc.oracle = oracle
+	mo := mocks.NewMockRolacle(ctrl)
+	proc.oracle = mo
 	mValidator := &mockMessageValidator{}
 	proc.validator = mValidator
 	proc.inbox, _ = broker.Register(context.TODO(), proc.ID())
-	msg := BuildPreRoundMsg(generateSigning(t), NewSetFromValues(value1), []byte{1})
-	oracle.isEligible = true
+	msg := BuildPreRoundMsg(signing.NewEdSigner(), NewSetFromValues(value1), []byte{1})
 	mValidator.syntaxValid = false
 	r.False(proc.preRoundTracker.coinflip, "default coinflip should be false")
 	proc.handleMessage(context.TODO(), msg)
@@ -273,7 +239,7 @@ func TestConsensusProcess_nextRound(t *testing.T) {
 	sim := service.NewSimulator()
 	n1 := sim.NewNode()
 	broker := buildBroker(t, n1, t.Name())
-	broker.Start(context.TODO())
+	require.NoError(t, broker.Start(context.TODO()))
 	proc := generateConsensusProcess(t)
 	proc.inbox, _ = broker.Register(context.TODO(), proc.ID())
 	proc.advanceToNextRound(context.TODO())
@@ -336,20 +302,56 @@ func TestConsensusProcess_InitDefaultBuilder(t *testing.T) {
 	assert.Equal(t, builder.inner.InstanceID, proc.instanceID)
 }
 
-func TestConsensusProcess_isEligible(t *testing.T) {
+func TestConsensusProcess_isEligible_NotEligible(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
 	proc := generateConsensusProcess(t)
-	oracle := &mockRolacle{MockStateQuerier: MockStateQuerier{true, nil}}
-	proc.oracle = oracle
-	oracle.isEligible = false
+	mo := mocks.NewMockRolacle(ctrl)
+	proc.oracle = mo
+
+	mo.EXPECT().Proof(gomock.Any(), proc.instanceID, proc.k).Return(nil, nil).Times(1)
+	mo.EXPECT().IsIdentityActiveOnConsensusView(gomock.Any(), gomock.Any(), proc.instanceID).Return(true, nil).Times(1)
+	mo.EXPECT().CalcEligibility(gomock.Any(), proc.instanceID, proc.k, gomock.Any(), proc.nid, gomock.Any()).Return(uint16(0), nil).Times(1)
 	assert.False(t, proc.shouldParticipate(context.TODO()))
-	oracle.isEligible = true
+}
+
+func TestConsensusProcess_isEligible_Eligible(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	proc := generateConsensusProcess(t)
+	mo := mocks.NewMockRolacle(ctrl)
+	proc.oracle = mo
+
+	mo.EXPECT().Proof(gomock.Any(), proc.instanceID, proc.k).Return(nil, nil).Times(1)
+	mo.EXPECT().IsIdentityActiveOnConsensusView(gomock.Any(), gomock.Any(), proc.instanceID).Return(true, nil).Times(1)
+	mo.EXPECT().CalcEligibility(gomock.Any(), proc.instanceID, proc.k, gomock.Any(), proc.nid, gomock.Any()).Return(uint16(1), nil).Times(1)
 	assert.True(t, proc.shouldParticipate(context.TODO()))
-	oracle.MockStateQuerier = MockStateQuerier{false, errors.New("some err")}
+}
+
+func TestConsensusProcess_isEligible_ActiveSetFailed(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	proc := generateConsensusProcess(t)
+	mo := mocks.NewMockRolacle(ctrl)
+	proc.oracle = mo
+
+	mo.EXPECT().IsIdentityActiveOnConsensusView(gomock.Any(), gomock.Any(), proc.instanceID).Return(false, errors.New("some err")).Times(1)
 	assert.False(t, proc.shouldParticipate(context.TODO()))
-	oracle.MockStateQuerier = MockStateQuerier{false, nil}
+}
+
+func TestConsensusProcess_isEligible_NotActive(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	proc := generateConsensusProcess(t)
+	mo := mocks.NewMockRolacle(ctrl)
+	proc.oracle = mo
+
+	mo.EXPECT().IsIdentityActiveOnConsensusView(gomock.Any(), gomock.Any(), proc.instanceID).Return(false, nil).Times(1)
 	assert.False(t, proc.shouldParticipate(context.TODO()))
-	oracle.MockStateQuerier = MockStateQuerier{true, nil}
-	assert.True(t, proc.shouldParticipate(context.TODO()))
 }
 
 func TestConsensusProcess_sendMessage(t *testing.T) {
@@ -362,7 +364,7 @@ func TestConsensusProcess_sendMessage(t *testing.T) {
 	b := proc.sendMessage(context.TODO(), nil)
 	r.Equal(0, net.count)
 	r.False(b)
-	msg := buildStatusMsg(generateSigning(t), proc.s, 0)
+	msg := buildStatusMsg(signing.NewEdSigner(), proc.s, 0)
 
 	net.err = errors.New("mock network failed error")
 	b = proc.sendMessage(context.TODO(), msg)
@@ -377,7 +379,7 @@ func TestConsensusProcess_sendMessage(t *testing.T) {
 func TestConsensusProcess_procPre(t *testing.T) {
 	proc := generateConsensusProcess(t)
 	s := NewDefaultEmptySet()
-	m := BuildPreRoundMsg(generateSigning(t), s, []byte{1})
+	m := BuildPreRoundMsg(signing.NewEdSigner(), s, []byte{1})
 	require.False(t, proc.preRoundTracker.coinflip)
 	proc.processPreRoundMsg(context.TODO(), m)
 	require.Equal(t, 1, len(proc.preRoundTracker.preRound))
@@ -388,7 +390,7 @@ func TestConsensusProcess_procStatus(t *testing.T) {
 	proc := generateConsensusProcess(t)
 	proc.beginStatusRound(context.TODO())
 	s := NewDefaultEmptySet()
-	m := BuildStatusMsg(generateSigning(t), s)
+	m := BuildStatusMsg(signing.NewEdSigner(), s)
 	proc.processStatusMsg(context.TODO(), m)
 	require.Equal(t, 1, len(proc.statusesTracker.statuses))
 }
@@ -403,7 +405,7 @@ func TestConsensusProcess_procProposal(t *testing.T) {
 	proc.advanceToNextRound(context.TODO())
 	proc.advanceToNextRound(context.TODO())
 	s := NewSetFromValues(value1)
-	m := BuildProposalMsg(generateSigning(t), s)
+	m := BuildProposalMsg(signing.NewEdSigner(), s)
 	mpt := &mockProposalTracker{}
 	proc.proposalTracker = mpt
 	proc.handleMessage(context.TODO(), m)
@@ -419,7 +421,7 @@ func TestConsensusProcess_procCommit(t *testing.T) {
 	proc.advanceToNextRound(context.TODO())
 	s := NewDefaultEmptySet()
 	proc.commitTracker = newCommitTracker(1, 1, s)
-	m := BuildCommitMsg(generateSigning(t), s)
+	m := BuildCommitMsg(signing.NewEdSigner(), s)
 	mct := &mockCommitTracker{}
 	proc.commitTracker = mct
 	proc.processCommitMsg(context.TODO(), m)
@@ -430,10 +432,10 @@ func TestConsensusProcess_procNotify(t *testing.T) {
 	proc := generateConsensusProcess(t)
 	proc.advanceToNextRound(context.TODO())
 	s := NewSetFromValues(value1)
-	m := BuildNotifyMsg(generateSigning(t), s)
+	m := BuildNotifyMsg(signing.NewEdSigner(), s)
 	proc.processNotifyMsg(context.TODO(), m)
 	assert.Equal(t, 1, len(proc.notifyTracker.notifies))
-	m = BuildNotifyMsg(generateSigning(t), s)
+	m = BuildNotifyMsg(signing.NewEdSigner(), s)
 	proc.ki = 0
 	m.InnerMsg.K = proc.ki
 	proc.s.Add(value5)
@@ -448,7 +450,7 @@ func TestConsensusProcess_Termination(t *testing.T) {
 	s := NewSetFromValues(value1)
 
 	for i := 0; i < cfg.F+1; i++ {
-		proc.processNotifyMsg(context.TODO(), BuildNotifyMsg(generateSigning(t), s))
+		proc.processNotifyMsg(context.TODO(), BuildNotifyMsg(signing.NewEdSigner(), s))
 	}
 
 	timer := time.NewTimer(10 * time.Second)
@@ -477,7 +479,7 @@ func TestConsensusProcess_currentRound(t *testing.T) {
 func TestConsensusProcess_onEarlyMessage(t *testing.T) {
 	r := require.New(t)
 	proc := generateConsensusProcess(t)
-	m := BuildPreRoundMsg(generateSigning(t), NewDefaultEmptySet(), nil)
+	m := BuildPreRoundMsg(signing.NewEdSigner(), NewDefaultEmptySet(), nil)
 	proc.advanceToNextRound(context.TODO())
 	proc.onEarlyMessage(context.TODO(), buildMessage(nil))
 	r.Len(proc.pending, 0)
@@ -485,9 +487,9 @@ func TestConsensusProcess_onEarlyMessage(t *testing.T) {
 	r.Len(proc.pending, 1)
 	proc.onEarlyMessage(context.TODO(), m)
 	r.Len(proc.pending, 1)
-	m2 := BuildPreRoundMsg(generateSigning(t), NewDefaultEmptySet(), nil)
+	m2 := BuildPreRoundMsg(signing.NewEdSigner(), NewDefaultEmptySet(), nil)
 	proc.onEarlyMessage(context.TODO(), m2)
-	m3 := BuildPreRoundMsg(generateSigning(t), NewDefaultEmptySet(), nil)
+	m3 := BuildPreRoundMsg(signing.NewEdSigner(), NewDefaultEmptySet(), nil)
 	proc.onEarlyMessage(context.TODO(), m3)
 	r.Len(proc.pending, 3)
 	proc.onRoundBegin(context.TODO())
@@ -514,41 +516,54 @@ func TestIterationFromCounter(t *testing.T) {
 	}
 }
 
-func TestConsensusProcess_beginRound1(t *testing.T) {
+func TestConsensusProcess_beginStatusRound(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
 	proc := generateConsensusProcess(t)
 	proc.advanceToNextRound(context.TODO())
 	proc.onRoundBegin(context.TODO())
 	network := &mockP2p{}
 	proc.network = network
-	oracle := &mockRolacle{MockStateQuerier: MockStateQuerier{true, nil}}
-	proc.oracle = oracle
+
+	mo := mocks.NewMockRolacle(ctrl)
+	mo.EXPECT().IsIdentityActiveOnConsensusView(gomock.Any(), gomock.Any(), proc.instanceID).Return(true, nil).Times(1)
+	mo.EXPECT().Proof(gomock.Any(), proc.instanceID, proc.k).Return(nil, nil).Times(2)
+	mo.EXPECT().CalcEligibility(gomock.Any(), proc.instanceID, proc.k, gomock.Any(), proc.nid, gomock.Any()).Return(uint16(1), nil).Times(1)
+	proc.oracle = mo
+
 	s := NewDefaultEmptySet()
-	m := BuildPreRoundMsg(generateSigning(t), s, nil)
+	m := BuildPreRoundMsg(signing.NewEdSigner(), s, nil)
 	proc.statusesTracker.RecordStatus(context.TODO(), m)
 
 	preStatusTracker := proc.statusesTracker
-	oracle.isEligible = true
 	proc.beginStatusRound(context.TODO())
 	assert.Equal(t, 1, network.count)
 	assert.NotEqual(t, preStatusTracker, proc.statusesTracker)
 }
 
-func TestConsensusProcess_beginRound2(t *testing.T) {
+func TestConsensusProcess_beginProposalRound(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
 	proc := generateConsensusProcess(t)
 	proc.advanceToNextRound(context.TODO())
 	network := &mockP2p{}
 	proc.network = network
-	oracle := &mockRolacle{MockStateQuerier: MockStateQuerier{true, nil}}
-	proc.oracle = oracle
-	oracle.isEligible = true
+	proc.k = 1
+
+	mo := mocks.NewMockRolacle(ctrl)
+	mo.EXPECT().IsIdentityActiveOnConsensusView(gomock.Any(), gomock.Any(), proc.instanceID).Return(true, nil).Times(1)
+	mo.EXPECT().Proof(gomock.Any(), proc.instanceID, proc.k).Return(nil, nil).Times(2)
+	mo.EXPECT().CalcEligibility(gomock.Any(), proc.instanceID, proc.k, gomock.Any(), proc.nid, gomock.Any()).Return(uint16(1), nil).Times(1)
+	proc.oracle = mo
 
 	statusTracker := newStatusTracker(1, 1)
 	s := NewSetFromValues(value1)
-	statusTracker.RecordStatus(context.TODO(), BuildStatusMsg(generateSigning(t), s))
+	statusTracker.RecordStatus(context.TODO(), BuildStatusMsg(signing.NewEdSigner(), s))
 	statusTracker.AnalyzeStatuses(validate)
 	proc.statusesTracker = statusTracker
 
-	proc.k = 1
 	proc.SetInbox(make(chan *Msg, 1))
 	proc.beginProposalRound(context.TODO())
 
@@ -556,24 +571,34 @@ func TestConsensusProcess_beginRound2(t *testing.T) {
 	assert.Nil(t, proc.statusesTracker)
 }
 
-func TestConsensusProcess_beginRound3(t *testing.T) {
+func TestConsensusProcess_beginCommitRound(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
 	proc := generateConsensusProcess(t)
 	network := &mockP2p{}
 	proc.network = network
-	oracle := &mockRolacle{MockStateQuerier: MockStateQuerier{true, nil}}
-	proc.oracle = oracle
+
+	mo := mocks.NewMockRolacle(ctrl)
+	proc.oracle = mo
+
 	mpt := &mockProposalTracker{}
 	proc.proposalTracker = mpt
 	mpt.proposedSet = NewSetFromValues(value1)
 
 	preCommitTracker := proc.commitTracker
+	mo.EXPECT().IsIdentityActiveOnConsensusView(gomock.Any(), gomock.Any(), proc.instanceID).Return(true, nil).Times(1)
+	mo.EXPECT().Proof(gomock.Any(), proc.instanceID, proc.k).Return(nil, nil).Times(1)
+	mo.EXPECT().CalcEligibility(gomock.Any(), proc.instanceID, proc.k, gomock.Any(), proc.nid, gomock.Any()).Return(uint16(0), nil).Times(1)
 	proc.beginCommitRound(context.TODO())
 	assert.NotEqual(t, preCommitTracker, proc.commitTracker)
 
 	mpt.isConflicting = false
 	mpt.proposedSet = NewSetFromValues(value1)
-	oracle.isEligible = true
 	proc.SetInbox(make(chan *Msg, 1))
+	mo.EXPECT().IsIdentityActiveOnConsensusView(gomock.Any(), gomock.Any(), proc.instanceID).Return(true, nil).Times(1)
+	mo.EXPECT().Proof(gomock.Any(), proc.instanceID, proc.k).Return(nil, nil).Times(2)
+	mo.EXPECT().CalcEligibility(gomock.Any(), proc.instanceID, proc.k, gomock.Any(), proc.nid, gomock.Any()).Return(uint16(1), nil).Times(1)
 	proc.beginCommitRound(context.TODO())
 	assert.Equal(t, 1, network.count)
 }
@@ -584,12 +609,12 @@ type mockNet struct {
 	err           error
 }
 
-func (m *mockNet) Broadcast(ctx context.Context, protocol string, payload []byte) error {
+func (m *mockNet) Broadcast(context.Context, string, []byte) error {
 	m.callBroadcast++
 	return m.err
 }
 
-func (m *mockNet) RegisterGossipProtocol(protocol string, prio priorityq.Priority) chan service.GossipMessage {
+func (m *mockNet) RegisterGossipProtocol(string, priorityq.Priority) chan service.GossipMessage {
 	m.callRegister++
 	return nil
 }
@@ -600,7 +625,7 @@ func TestConsensusProcess_handlePending(t *testing.T) {
 	const count = 5
 	pending := make(map[string]*Msg)
 	for i := 0; i < count; i++ {
-		v := generateSigning(t)
+		v := signing.NewEdSigner()
 		m := BuildStatusMsg(v, NewSetFromValues(value1))
 		pending[v.PublicKey().String()] = m
 	}

--- a/hare/algorithm_test.go
+++ b/hare/algorithm_test.go
@@ -3,6 +3,7 @@ package hare
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -187,9 +188,16 @@ func TestConsensusProcess_eventLoop(t *testing.T) {
 	proc.inbox, _ = broker.Register(context.TODO(), proc.ID())
 	proc.s = NewSetFromValues(value1, value2)
 	proc.cfg.F = 2
-	go proc.eventLoop(context.TODO())
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		proc.eventLoop(context.TODO())
+		wg.Done()
+	}()
 	time.Sleep(500 * time.Millisecond)
 	assert.Equal(t, 1, net.count)
+	proc.Close()
+	wg.Wait()
 }
 
 func TestConsensusProcess_handleMessage(t *testing.T) {

--- a/hare/committracker_test.go
+++ b/hare/committracker_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/spacemeshos/go-spacemesh/signing"
 )
 
 func BuildCommitMsg(signing Signer, s *Set) *Msg {
@@ -20,26 +22,26 @@ func TestCommitTracker_OnCommit(t *testing.T) {
 	tracker := newCommitTracker(lowThresh10+1, lowThresh10, s)
 
 	for i := 0; i < lowThresh10; i++ {
-		m := BuildCommitMsg(generateSigning(t), s)
+		m := BuildCommitMsg(signing.NewEdSigner(), s)
 		tracker.OnCommit(m)
 		assert.False(t, tracker.HasEnoughCommits())
 	}
 
-	tracker.OnCommit(BuildCommitMsg(generateSigning(t), s))
+	tracker.OnCommit(BuildCommitMsg(signing.NewEdSigner(), s))
 	assert.True(t, tracker.HasEnoughCommits())
 }
 
 func TestCommitTracker_OnCommitDuplicate(t *testing.T) {
 	s := NewSetFromValues(value1)
 	tracker := newCommitTracker(2, 2, s)
-	verifier := generateSigning(t)
+	verifier := signing.NewEdSigner()
 	assert.Equal(t, 0, len(tracker.seenSenders))
 	tracker.OnCommit(BuildCommitMsg(verifier, s))
 	assert.Equal(t, 1, len(tracker.seenSenders))
 	assert.Equal(t, 1, len(tracker.commits))
 	tracker.OnCommit(BuildCommitMsg(verifier, s))
 	assert.Equal(t, 1, len(tracker.seenSenders))
-	tracker.OnCommit(BuildCommitMsg(generateSigning(t), s))
+	tracker.OnCommit(BuildCommitMsg(signing.NewEdSigner(), s))
 	assert.Equal(t, 2, len(tracker.seenSenders))
 }
 
@@ -47,8 +49,8 @@ func TestCommitTracker_HasEnoughCommits(t *testing.T) {
 	s := NewSetFromValues(value1)
 	tracker := newCommitTracker(2, 2, s)
 	assert.False(t, tracker.HasEnoughCommits())
-	tracker.OnCommit(BuildCommitMsg(generateSigning(t), s))
-	tracker.OnCommit(BuildCommitMsg(generateSigning(t), s))
+	tracker.OnCommit(BuildCommitMsg(signing.NewEdSigner(), s))
+	tracker.OnCommit(BuildCommitMsg(signing.NewEdSigner(), s))
 	assert.True(t, tracker.HasEnoughCommits())
 }
 
@@ -56,8 +58,8 @@ func TestCommitTracker_BuildCertificate(t *testing.T) {
 	s := NewSetFromValues(value1)
 	tracker := newCommitTracker(2, 2, s)
 	assert.Nil(t, tracker.BuildCertificate())
-	tracker.OnCommit(BuildCommitMsg(generateSigning(t), s))
-	tracker.OnCommit(BuildCommitMsg(generateSigning(t), s))
+	tracker.OnCommit(BuildCommitMsg(signing.NewEdSigner(), s))
+	tracker.OnCommit(BuildCommitMsg(signing.NewEdSigner(), s))
 	cert := tracker.BuildCertificate()
 	assert.Equal(t, 2, len(cert.AggMsgs.Messages))
 	assert.Nil(t, cert.AggMsgs.Messages[0].InnerMsg.Values)

--- a/hare/eligibility/oracle.go
+++ b/hare/eligibility/oracle.go
@@ -136,8 +136,8 @@ func New(
 	}
 }
 
-// IsEpochBeaconReady returns true if the beacon value is known for the specified epoch.
-func (o *Oracle) IsEpochBeaconReady(ctx context.Context, epoch types.EpochID) bool {
+// GetEpochBeacon returns the beacon for the specified epoch.
+func (o *Oracle) GetEpochBeacon(ctx context.Context, epoch types.EpochID) bool {
 	_, err := o.beacon.Value(ctx, epoch)
 	return err == nil
 }

--- a/hare/flows_test.go
+++ b/hare/flows_test.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math/rand"
 	"testing"
 	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 
+	bMocks "github.com/spacemeshos/go-spacemesh/blocks/mocks"
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/common/util"
 	"github.com/spacemeshos/go-spacemesh/hare/config"
@@ -161,10 +161,6 @@ func (trueOracle) IsIdentityActiveOnConsensusView(context.Context, string, types
 	return true, nil
 }
 
-func (trueOracle) IsEpochBeaconReady(context.Context, types.EpochID) bool {
-	return true
-}
-
 // Test - runs a single CP for more than one iteration.
 func Test_consensusIterations(t *testing.T) {
 	test := newConsensusTest()
@@ -202,24 +198,9 @@ func (m *mockIdentityP) GetIdentity(string) (types.NodeID, error) {
 	return m.nid, nil
 }
 
-func buildSet() []types.BlockID {
-	rng := rand.New(rand.NewSource(0))
-	s := make([]types.BlockID, 200, 200)
-	for i := uint64(0); i < 200; i++ {
-		s = append(s, newRandBlockID(rng))
-	}
-	return s
+type mockBlockProvider struct {
+	lyrBlocks map[types.LayerID][]*types.Block
 }
-
-func newRandBlockID(rng *rand.Rand) (id types.BlockID) {
-	_, err := rng.Read(id[:])
-	if err != nil {
-		panic(err)
-	}
-	return id
-}
-
-type mockBlockProvider struct{}
 
 func (mbp *mockBlockProvider) HandleValidatedLayer(context.Context, types.LayerID, []types.BlockID) {
 }
@@ -230,11 +211,15 @@ func (mbp *mockBlockProvider) InvalidateLayer(context.Context, types.LayerID) {
 func (mbp *mockBlockProvider) RecordCoinflip(context.Context, types.LayerID, bool) {
 }
 
-func (mbp *mockBlockProvider) LayerBlockIds(types.LayerID) ([]types.BlockID, error) {
-	return buildSet(), nil
+func (mbp *mockBlockProvider) LayerBlocks(lyrID types.LayerID) ([]*types.Block, error) {
+	return mbp.lyrBlocks[lyrID], nil
 }
 
-func createMaatuf(tb testing.TB, tcfg config.Config, layersCh chan types.LayerID, p2p NetworkService, rolacle Rolacle, name string) *Hare {
+func (mbp *mockBlockProvider) GetBlock(bID types.BlockID) (*types.Block, error) {
+	return nil, nil
+}
+
+func createMaatuf(t testing.TB, tcfg config.Config, layersCh chan types.LayerID, p2p NetworkService, rolacle Rolacle, name string, lyrBlocks map[types.LayerID][]*types.Block) *Hare {
 	ed := signing.NewEdSigner()
 	pub := ed.PublicKey()
 	_, vrfPub, err := signing.NewVRFSigner(ed.Sign(pub.Bytes()))
@@ -242,11 +227,16 @@ func createMaatuf(tb testing.TB, tcfg config.Config, layersCh chan types.LayerID
 		panic("failed to create vrf signer")
 	}
 	nodeID := types.NodeID{Key: pub.String(), VRFPublicKey: vrfPub}
-	ctrl := gomock.NewController(tb)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
 	patrol := mocks.NewMocklayerPatrol(ctrl)
 	patrol.EXPECT().SetHareInCharge(gomock.Any()).AnyTimes()
-	hare := New(tcfg, p2p, ed, nodeID, isSynced, &mockBlockProvider{}, rolacle, patrol, 10, &mockIdentityP{nid: nodeID},
-		&MockStateQuerier{true, nil}, layersCh, logtest.New(tb).WithName(name+"_"+ed.PublicKey().ShortString()))
+	mockBeacons := bMocks.NewMockBeaconGetter(ctrl)
+	mockBeacons.EXPECT().GetBeacon(gomock.Any()).Return(nil, nil).AnyTimes()
+
+	hare := New(tcfg, p2p, ed, nodeID, isSynced, &mockBlockProvider{lyrBlocks: lyrBlocks}, mockBeacons, rolacle, patrol, 10, &mockIdentityP{nid: nodeID},
+		&MockStateQuerier{true, nil}, layersCh, logtest.New(t).WithName(name+"_"+ed.PublicKey().ShortString()))
 
 	return hare
 }
@@ -265,11 +255,19 @@ func Test_multipleCPs(t *testing.T) {
 	sim := service.NewSimulator()
 	test.initialSets = make([]*Set, totalNodes)
 	oracle := &trueOracle{}
+
+	lyrBlocks := make(map[types.LayerID][]*types.Block)
+	for j := types.GetEffectiveGenesis().Add(1); !j.After(types.GetEffectiveGenesis().Add(totalCp)); j = j.Add(1) {
+		for i := uint64(0); i < 200; i++ {
+			blk := randomBlock(t, j, nil)
+			lyrBlocks[j] = append(lyrBlocks[j], blk)
+		}
+	}
 	for i := 0; i < totalNodes; i++ {
 		s := sim.NewNode()
 		// p2pm := &p2pManipulator{nd: s, err: errors.New("fake err")}
 		test.lCh = append(test.lCh, make(chan types.LayerID, 1))
-		h := createMaatuf(t, cfg, test.lCh[i], s, oracle, t.Name())
+		h := createMaatuf(t, cfg, test.lCh[i], s, oracle, t.Name(), lyrBlocks)
 		test.hare = append(test.hare, h)
 		e := h.Start(context.TODO())
 		r.NoError(e)
@@ -300,11 +298,19 @@ func Test_multipleCPsAndIterations(t *testing.T) {
 	sim := service.NewSimulator()
 	test.initialSets = make([]*Set, totalNodes)
 	oracle := &trueOracle{}
+
+	lyrBlocks := make(map[types.LayerID][]*types.Block)
+	for j := types.GetEffectiveGenesis().Add(1); !j.After(types.GetEffectiveGenesis().Add(totalCp)); j = j.Add(1) {
+		for i := uint64(0); i < 200; i++ {
+			blk := randomBlock(t, j, nil)
+			lyrBlocks[j] = append(lyrBlocks[j], blk)
+		}
+	}
 	for i := 0; i < totalNodes; i++ {
 		s := sim.NewNode()
 		mp2p := &p2pManipulator{nd: s, stalledLayer: types.NewLayerID(1), err: errors.New("fake err")}
 		test.lCh = append(test.lCh, make(chan types.LayerID, 1))
-		h := createMaatuf(t, cfg, test.lCh[i], mp2p, oracle, t.Name())
+		h := createMaatuf(t, cfg, test.lCh[i], mp2p, oracle, t.Name(), lyrBlocks)
 		test.hare = append(test.hare, h)
 		e := h.Start(context.TODO())
 		r.NoError(e)

--- a/hare/hare.go
+++ b/hare/hare.go
@@ -257,7 +257,7 @@ func (h *Hare) onTick(ctx context.Context, id types.LayerID) (bool, error) {
 	c, err := h.broker.Register(ctx, instID)
 	if err != nil {
 		logger.With().Error("could not register consensus process on broker", log.Err(err))
-		return false, fmt.Errorf("broker registerr: %w", err)
+		return false, fmt.Errorf("broker register: %w", err)
 	}
 	cp := h.factory(h.config, instID, set, h.rolacle, h.sign, h.network, h.outputChan)
 	cp.SetInbox(c)

--- a/hare/hare.go
+++ b/hare/hare.go
@@ -255,14 +255,14 @@ func (h *Hare) onTick(ctx context.Context, id types.LayerID) (bool, error) {
 	c, err := h.broker.Register(ctx, instID)
 	if err != nil {
 		logger.With().Error("could not register consensus process on broker", log.Err(err))
-		return false, err
+		return false, fmt.Errorf("broker registerr: %w", err)
 	}
 	cp := h.factory(h.config, instID, set, h.rolacle, h.sign, h.network, h.outputChan)
 	cp.SetInbox(c)
 	if err = cp.Start(ctx); err != nil {
 		logger.With().Error("could not start consensus process", log.Err(err))
 		h.broker.Unregister(ctx, cp.ID())
-		return false, err
+		return false, fmt.Errorf("start consensus: %w", err)
 	}
 	h.patrol.SetHareInCharge(instID)
 	logger.With().Info("number of consensus processes (after register)",

--- a/hare/hare_rounds_test.go
+++ b/hare/hare_rounds_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 
+	bMocks "github.com/spacemeshos/go-spacemesh/blocks/mocks"
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/hare/config"
 	"github.com/spacemeshos/go-spacemesh/hare/mocks"
@@ -56,7 +57,7 @@ func (w *TestHareWrapper) LayerTicker(interval time.Duration) {
 
 type (
 	funcOracle   func(types.LayerID, uint32, int, types.NodeID, []byte, *testHare) (uint16, error)
-	funcLayers   func(types.LayerID, *testHare) ([]types.BlockID, error)
+	funcLayers   func(types.LayerID, *testHare) ([]*types.Block, error)
 	funcValidate func(types.LayerID, []types.BlockID, *testHare)
 	testHare     struct {
 		*Hare
@@ -73,9 +74,6 @@ func (h *testHare) CalcEligibility(ctx context.Context, layer types.LayerID, rou
 
 func (testHare) Register(bool, string)   {}
 func (testHare) Unregister(bool, string) {}
-func (testHare) IsEpochBeaconReady(context.Context, types.EpochID) bool {
-	return true
-}
 
 func (testHare) Validate(context.Context, types.LayerID, uint32, int, types.NodeID, []byte, uint16) (bool, error) {
 	return true, nil
@@ -93,8 +91,12 @@ func (h *testHare) HandleValidatedLayer(ctx context.Context, layer types.LayerID
 	h.validate(layer, ids, h)
 }
 
-func (h *testHare) LayerBlockIds(layer types.LayerID) ([]types.BlockID, error) {
+func (h *testHare) LayerBlocks(layer types.LayerID) ([]*types.Block, error) {
 	return h.layers(layer, h)
+}
+
+func (h *testHare) GetBlock(id types.BlockID) (*types.Block, error) {
+	return nil, nil
 }
 
 func (h *testHare) InvalidateLayer(ctx context.Context, layerID types.LayerID) {
@@ -106,10 +108,15 @@ func createTestHare(tb testing.TB, tcfg config.Config, layersCh chan types.Layer
 	ed := signing.NewEdSigner()
 	pub := ed.PublicKey()
 	nodeID := types.NodeID{Key: pub.String(), VRFPublicKey: pub.Bytes()}
+
 	ctrl := gomock.NewController(tb)
+	defer ctrl.Finish()
+
+	mockBeacons := bMocks.NewMockBeaconGetter(ctrl)
+	mockBeacons.EXPECT().GetBeacon(gomock.Any()).Return(nil, nil).AnyTimes()
 	patrol := mocks.NewMocklayerPatrol(ctrl)
 	patrol.EXPECT().SetHareInCharge(gomock.Any()).AnyTimes()
-	hare := New(tcfg, p2p, ed, nodeID, isSynced, bp, rolacle, patrol, 10, &mockIdentityP{nid: nodeID},
+	hare := New(tcfg, p2p, ed, nodeID, isSynced, bp, mockBeacons, rolacle, patrol, 10, &mockIdentityP{nid: nodeID},
 		&MockStateQuerier{true, nil}, layersCh, logtest.New(tb).WithName(name+"_"+ed.PublicKey().ShortString()))
 	return hare
 }
@@ -154,8 +161,8 @@ func Test_HarePreRoundEmptySet(t *testing.T) {
 			}
 			return 1, nil
 		},
-		func(layer types.LayerID, hare *testHare) ([]types.BlockID, error) {
-			return []types.BlockID{}, nil
+		func(layer types.LayerID, hare *testHare) ([]*types.Block, error) {
+			return []*types.Block{}, nil
 		},
 		func(layer types.LayerID, blocks []types.BlockID, hare *testHare) {
 			l := layer.Difference(types.GetEffectiveGenesis()) - 1
@@ -191,8 +198,8 @@ func Test_HareNotEnoughStatuses(t *testing.T) {
 			}
 			return 1, nil
 		},
-		func(layer types.LayerID, hare *testHare) ([]types.BlockID, error) {
-			return []types.BlockID{}, nil
+		func(layer types.LayerID, hare *testHare) ([]*types.Block, error) {
+			return []*types.Block{}, nil
 		},
 		func(layer types.LayerID, blocks []types.BlockID, hare *testHare) {
 			l := layer.Difference(types.GetEffectiveGenesis()) - 1
@@ -227,8 +234,8 @@ func Test_HareNotEnoughLeaders(t *testing.T) {
 			}
 			return 1, nil
 		},
-		func(layer types.LayerID, hare *testHare) ([]types.BlockID, error) {
-			return []types.BlockID{}, nil
+		func(layer types.LayerID, hare *testHare) ([]*types.Block, error) {
+			return []*types.Block{}, nil
 		},
 		func(layer types.LayerID, blocks []types.BlockID, hare *testHare) {
 			l := layer.Difference(types.GetEffectiveGenesis()) - 1
@@ -263,8 +270,8 @@ func Test_HareNotEnoughCommits(t *testing.T) {
 			}
 			return 1, nil
 		},
-		func(layer types.LayerID, hare *testHare) ([]types.BlockID, error) {
-			return []types.BlockID{genBlockID(1)}, nil
+		func(layer types.LayerID, hare *testHare) ([]*types.Block, error) {
+			return []*types.Block{randomBlock(t, layer, nil)}, nil
 		},
 		func(layer types.LayerID, blocks []types.BlockID, hare *testHare) {
 			l := layer.Difference(types.GetEffectiveGenesis()) - 1
@@ -299,8 +306,8 @@ func Test_HareNotEnoughNotifications(t *testing.T) {
 			}
 			return 1, nil
 		},
-		func(layer types.LayerID, hare *testHare) ([]types.BlockID, error) {
-			return []types.BlockID{genBlockID(1)}, nil
+		func(layer types.LayerID, hare *testHare) ([]*types.Block, error) {
+			return []*types.Block{randomBlock(t, layer, nil)}, nil
 		},
 		func(layer types.LayerID, blocks []types.BlockID, hare *testHare) {
 			l := layer.Difference(types.GetEffectiveGenesis()) - 1
@@ -332,8 +339,8 @@ func Test_HareComplete(t *testing.T) {
 		func(layer types.LayerID, round uint32, committee int, id types.NodeID, blocks []byte, hare *testHare) (uint16, error) {
 			return 1, nil
 		},
-		func(layer types.LayerID, hare *testHare) ([]types.BlockID, error) {
-			return []types.BlockID{genBlockID(int(layer.Uint32()))}, nil
+		func(layer types.LayerID, hare *testHare) ([]*types.Block, error) {
+			return []*types.Block{randomBlock(t, layer, nil)}, nil
 		},
 		func(layer types.LayerID, blocks []types.BlockID, hare *testHare) {
 			l := layer.Difference(types.GetEffectiveGenesis()) - 1

--- a/hare/hare_test.go
+++ b/hare/hare_test.go
@@ -1,9 +1,8 @@
 package hare
 
 import (
-	"bytes"
 	"context"
-	"sort"
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -12,8 +11,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/spacemeshos/go-spacemesh/blocks"
+	bMocks "github.com/spacemeshos/go-spacemesh/blocks/mocks"
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/common/util"
+	"github.com/spacemeshos/go-spacemesh/crypto"
 	"github.com/spacemeshos/go-spacemesh/eligibility"
 	"github.com/spacemeshos/go-spacemesh/hare/config"
 	"github.com/spacemeshos/go-spacemesh/hare/mocks"
@@ -88,150 +90,116 @@ func newMockConsensusProcess(_ config.Config, instanceID types.LayerID, s *Set, 
 	return mcp
 }
 
-func createHare(t *testing.T, n1 p2p.Service, logger log.Log) *Hare {
+func randomBytes(t *testing.T, size int) []byte {
+	data, err := crypto.GetRandomBytes(size)
+	require.NoError(t, err)
+	return data
+}
+
+func randomBlock(t *testing.T, lyrID types.LayerID, beacon []byte) *types.Block {
+	block := types.NewExistingBlock(lyrID, randomBytes(t, 4), nil)
+	block.TortoiseBeacon = beacon
+	return block
+}
+
+func createHare(t *testing.T, n1 p2p.Service, msh meshProvider, beacons blocks.BeaconGetter, logger log.Log) *Hare {
 	ctrl := gomock.NewController(t)
 	patrol := mocks.NewMocklayerPatrol(ctrl)
 	patrol.EXPECT().SetHareInCharge(gomock.Any()).AnyTimes()
-	return New(cfg, n1, signing2.NewEdSigner(), types.NodeID{}, (&mockSyncer{true}).IsSynced, new(orphanMock), eligibility.New(logger), patrol, 10, &mockIDProvider{}, NewMockStateQuerier(), make(chan types.LayerID), logger)
+	return New(cfg, n1, signing2.NewEdSigner(), types.NodeID{}, (&mockSyncer{true}).IsSynced, msh, beacons, eligibility.New(logger), patrol, 10, &mockIDProvider{}, NewMockStateQuerier(), make(chan types.LayerID), logger)
 }
 
 var _ Consensus = (*mockConsensusProcess)(nil)
 
-func TestNew(t *testing.T) {
+func TestHare_New(t *testing.T) {
 	sim := service.NewSimulator()
 	n1 := sim.NewNode()
 
-	h := createHare(t, n1, logtest.New(t).WithName(t.Name()))
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
 
-	if h == nil {
-		t.Fatal()
-	}
+	logger := logtest.New(t).WithName(t.Name())
+	h := New(cfg, n1, signing2.NewEdSigner(), types.NodeID{}, (&mockSyncer{true}).IsSynced,
+		mocks.NewMockmeshProvider(ctrl), bMocks.NewMockBeaconGetter(ctrl), eligibility.New(logger), mocks.NewMocklayerPatrol(ctrl), 10,
+		&mockIDProvider{}, NewMockStateQuerier(), make(chan types.LayerID), logger)
+	assert.NotNil(t, h)
 }
 
 func TestHare_Start(t *testing.T) {
 	sim := service.NewSimulator()
 	n1 := sim.NewNode()
 
-	h := createHare(t, n1, logtest.New(t).WithName(t.Name()))
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
 
-	require.NoError(t, h.broker.Start(context.TODO())) // todo: fix that hack. this will cause h.Start to return err
+	mockMesh := mocks.NewMockmeshProvider(ctrl)
+	mockBeacons := bMocks.NewMockBeaconGetter(ctrl)
+	h := createHare(t, n1, mockMesh, mockBeacons, logtest.New(t).WithName(t.Name()))
 
-	/*err := h.Start()
-	require.Error(t, err)*/
-
-	h2 := createHare(t, n1, logtest.New(t).WithName(t.Name()))
-	require.NoError(t, h2.Start(context.TODO()))
+	assert.NoError(t, h.Start(context.TODO()))
+	t.Cleanup(func() {
+		h.Close()
+	})
 }
 
-func TestHare_GetResult(t *testing.T) {
-	r := require.New(t)
+func TestHare_collectOutputAndGetResult(t *testing.T) {
 	sim := service.NewSimulator()
 	n1 := sim.NewNode()
 
-	h := createHare(t, n1, logtest.New(t).WithName(t.Name()))
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockMesh := mocks.NewMockmeshProvider(ctrl)
+	mockBeacons := bMocks.NewMockBeaconGetter(ctrl)
+	h := createHare(t, n1, mockMesh, mockBeacons, logtest.New(t).WithName(t.Name()))
 
 	res, err := h.GetResult(types.NewLayerID(0))
-	r.Equal(errNoResult, err)
-	r.Nil(res)
+	assert.Equal(t, errNoResult, err)
+	assert.Nil(t, res)
 
-	mockid := types.NewLayerID(0)
+	lyrID := types.NewLayerID(10)
 	set := NewSetFromValues(value1)
 
-	r.NoError(h.collectOutput(context.TODO(), mockReport{mockid, set, true, false}))
+	mockMesh.EXPECT().HandleValidatedLayer(gomock.Any(), lyrID, gomock.Any()).Times(1)
+	require.NoError(t, h.collectOutput(context.TODO(), mockReport{lyrID, set, true, false}))
 
-	res, err = h.GetResult(types.NewLayerID(0))
-	r.NoError(err)
-	r.Equal(value1.Bytes(), res[0].Bytes())
+	res, err = h.GetResult(lyrID)
+	assert.NoError(t, err)
+	assert.Equal(t, value1.Bytes(), res[0].Bytes())
+
+	res, err = h.GetResult(lyrID.Add(1))
+	assert.Equal(t, errNoResult, err)
+	assert.Empty(t, res)
 }
 
-func TestHare_GetResult2(t *testing.T) {
-	types.SetLayersPerEpoch(1)
-
+func TestHare_collectOutputGetResult_TerminateTooLate(t *testing.T) {
 	sim := service.NewSimulator()
 	n1 := sim.NewNode()
 
-	om := new(orphanMock)
-	om.f = func() []types.BlockID {
-		return []types.BlockID{value1}
-	}
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
 
-	h := createHare(t, n1, logtest.New(t).WithName(t.Name()))
-	h.mesh = om
+	mockMesh := mocks.NewMockmeshProvider(ctrl)
+	mockBeacons := bMocks.NewMockBeaconGetter(ctrl)
+	h := createHare(t, n1, mockMesh, mockBeacons, logtest.New(t).WithName(t.Name()))
 
-	h.networkDelta = 0
+	lyrID := types.NewLayerID(10)
+	res, err := h.GetResult(lyrID)
+	assert.Equal(t, errNoResult, err)
+	assert.Nil(t, res)
 
-	h.factory = func(cfg config.Config, instanceId types.LayerID, s *Set, oracle Rolacle, signing Signer, p2p NetworkService, outputChan chan TerminationOutput) Consensus {
-		return newMockConsensusProcess(cfg, instanceId, s, oracle, signing, p2p, outputChan)
-	}
-
-	_ = h.Start(context.TODO())
-
-	for i := uint32(1); i <= h.bufferSize; i++ {
-		h.beginLayer <- types.NewLayerID(i)
-		time.Sleep(15 * time.Millisecond)
-	}
-	time.Sleep(100 * time.Millisecond)
-
-	_, err := h.GetResult(types.NewLayerID(h.bufferSize))
-	require.NoError(t, err)
-
-	h.beginLayer <- types.NewLayerID(h.bufferSize + 1)
-
-	time.Sleep(100 * time.Millisecond)
-
-	_, err = h.GetResult(types.LayerID{})
-	require.Equal(t, err, errTooOld)
-}
-
-func TestHare_collectOutput(t *testing.T) {
-	sim := service.NewSimulator()
-	n1 := sim.NewNode()
-
-	h := createHare(t, n1, logtest.New(t).WithName(t.Name()))
-
-	mockid := instanceID1
+	h.layerLock.Lock()
+	h.lastLayer = lyrID.Add(h.bufferSize + 1)
+	h.layerLock.Unlock()
 	set := NewSetFromValues(value1)
 
-	require.NoError(t, h.collectOutput(context.TODO(), mockReport{mockid, set, true, false}))
-	output, ok := h.outputs[mockid]
-	require.True(t, ok)
-	require.Equal(t, output[0], value1)
+	mockMesh.EXPECT().HandleValidatedLayer(gomock.Any(), lyrID, gomock.Any()).Times(1)
+	err = h.collectOutput(context.TODO(), mockReport{lyrID, set, true, false})
+	assert.Equal(t, ErrTooLate, err)
 
-	mockid = instanceID2
-
-	output, ok = h.outputs[mockid] // todo: replace with getresult if this yields a race
-	require.False(t, ok)
-	require.Nil(t, output)
-}
-
-func TestHare_collectOutput2(t *testing.T) {
-	sim := service.NewSimulator()
-	n1 := sim.NewNode()
-
-	h := createHare(t, n1, logtest.New(t).WithName(t.Name()))
-	h.bufferSize = 1
-	h.lastLayer = types.NewLayerID(0)
-
-	mockid := instanceID0
-	set := NewSetFromValues(value1)
-
-	require.NoError(t, h.collectOutput(context.TODO(), mockReport{mockid, set, true, false}))
-	output, ok := h.outputs[mockid]
-	require.True(t, ok)
-	require.Equal(t, output[0], value1)
-
-	h.lastLayer = types.NewLayerID(3)
-	newmockid := instanceID1
-	err := h.collectOutput(context.TODO(), mockReport{newmockid, set, true, false})
-	require.Equal(t, err, ErrTooLate)
-
-	newmockid2 := instanceID2
-	err = h.collectOutput(context.TODO(), mockReport{newmockid2, set, true, false})
-	require.NoError(t, err)
-
-	_, ok = h.outputs[types.LayerID{}]
-
-	require.False(t, ok)
+	res, err = h.GetResult(lyrID)
+	assert.Equal(t, err, errTooOld)
+	assert.Empty(t, res)
 }
 
 func TestHare_OutputCollectionLoop(t *testing.T) {
@@ -239,9 +207,18 @@ func TestHare_OutputCollectionLoop(t *testing.T) {
 	sim := service.NewSimulator()
 	n1 := sim.NewNode()
 
-	h := createHare(t, n1, logtest.New(t).WithName(t.Name()))
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockMesh := mocks.NewMockmeshProvider(ctrl)
+	mockBeacons := bMocks.NewMockBeaconGetter(ctrl)
+	h := createHare(t, n1, mockMesh, mockBeacons, logtest.New(t).WithName(t.Name()))
 	require.NoError(t, h.Start(context.TODO()))
-	mo := mockReport{types.NewLayerID(8), NewEmptySet(0), true, false}
+
+	lyrID := types.NewLayerID(8)
+	mo := mockReport{lyrID, NewEmptySet(0), true, false}
+	mockMesh.EXPECT().RecordCoinflip(gomock.Any(), lyrID, false).Times(1)
+	mockMesh.EXPECT().HandleValidatedLayer(gomock.Any(), lyrID, gomock.Any()).Times(1)
 	_, err := h.broker.Register(context.TODO(), mo.ID())
 	require.NoError(t, err)
 	time.Sleep(1 * time.Second)
@@ -251,6 +228,9 @@ func TestHare_OutputCollectionLoop(t *testing.T) {
 }
 
 func TestHare_onTick(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
 	cfg := config.DefaultConfig()
 	types.SetLayersPerEpoch(4)
 
@@ -266,35 +246,40 @@ func TestHare_onTick(t *testing.T) {
 	oracle := newMockHashOracle(numOfClients)
 	signing := signing2.NewEdSigner()
 
-	blockset := []types.BlockID{value1, value2, value3}
-	om := new(orphanMock)
-	om.f = func() []types.BlockID {
-		return blockset
-	}
-
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
+	mockMesh := mocks.NewMockmeshProvider(ctrl)
+	mockBeacons := bMocks.NewMockBeaconGetter(ctrl)
 	patrol := mocks.NewMocklayerPatrol(ctrl)
 	patrol.EXPECT().SetHareInCharge(types.GetEffectiveGenesis().Add(1)).Times(1)
-	h := New(cfg, n1, signing, types.NodeID{}, (&mockSyncer{true}).IsSynced, om, oracle, patrol, 10, &mockIDProvider{}, NewMockStateQuerier(), layerTicker, logtest.New(t).WithName("Hare"))
+	h := New(cfg, n1, signing, types.NodeID{}, (&mockSyncer{true}).IsSynced, mockMesh, mockBeacons, oracle, patrol, 10, &mockIDProvider{}, NewMockStateQuerier(), layerTicker, logtest.New(t).WithName("Hare"))
 	h.networkDelta = 0
 	h.bufferSize = 1
 
 	createdChan := make(chan struct{})
-
 	var nmcp *mockConsensusProcess
 	h.factory = func(cfg config.Config, instanceId types.LayerID, s *Set, oracle Rolacle, signing Signer, p2p NetworkService, outputChan chan TerminationOutput) Consensus {
 		nmcp = newMockConsensusProcess(cfg, instanceId, s, oracle, signing, p2p, outputChan)
 		createdChan <- struct{}{}
 		return nmcp
 	}
+
 	require.NoError(t, h.Start(context.TODO()))
 
-	var wg sync.WaitGroup
+	lyrID := types.GetEffectiveGenesis().Add(1)
+	beacon := randomBytes(t, 32)
+	blockSet := []*types.Block{
+		randomBlock(t, lyrID, beacon),
+		randomBlock(t, lyrID, beacon),
+		randomBlock(t, lyrID, beacon),
+	}
+	mockBeacons.EXPECT().GetBeacon(lyrID.GetEpoch()).Return(beacon, nil).Times(1)
+	mockMesh.EXPECT().RecordCoinflip(gomock.Any(), lyrID, false).Times(1)
+	mockMesh.EXPECT().LayerBlocks(lyrID).Return(blockSet, nil).Times(1)
+	mockMesh.EXPECT().HandleValidatedLayer(gomock.Any(), lyrID, gomock.Any()).Times(1)
 
+	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
-		layerTicker <- types.GetEffectiveGenesis().Add(1)
+		layerTicker <- lyrID
 		<-createdChan
 		<-nmcp.CloseChannel()
 		wg.Done()
@@ -303,16 +288,14 @@ func TestHare_onTick(t *testing.T) {
 	wg.Wait()
 	time.Sleep(100 * time.Millisecond)
 	res1, err := h.GetResult(types.GetEffectiveGenesis().Add(1))
-	require.NoError(t, err)
+	assert.NoError(t, err)
+	assert.Equal(t, types.SortBlockIDs(types.BlockIDs(blockSet)), types.SortBlockIDs(res1))
 
-	SortBlockIDs(res1)
-	SortBlockIDs(blockset)
-
-	require.Equal(t, blockset, res1)
-
+	lyrID = lyrID.Add(1)
+	// consensus process is closed, should not process any tick
 	wg.Add(1)
 	go func() {
-		layerTicker <- types.GetEffectiveGenesis().Add(2)
+		layerTicker <- lyrID
 		h.Close()
 		wg.Done()
 	}()
@@ -320,9 +303,221 @@ func TestHare_onTick(t *testing.T) {
 	// collect output one more time
 	wg.Wait()
 	time.Sleep(100 * time.Millisecond)
-	res2, err := h.GetResult(types.GetEffectiveGenesis().Add(2))
-	require.Equal(t, errNoResult, err)
-	require.Equal(t, []types.BlockID(nil), res2)
+	res2, err := h.GetResult(lyrID)
+	assert.Equal(t, errNoResult, err)
+	assert.Empty(t, res2)
+}
+
+func TestHare_onTick_BeaconFromRefBlocks(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	cfg := config.DefaultConfig()
+	types.SetLayersPerEpoch(4)
+
+	cfg.N = 2
+	cfg.F = 1
+	cfg.RoundDuration = 1
+
+	sim := service.NewSimulator()
+	n1 := sim.NewNode()
+
+	layerTicker := make(chan types.LayerID)
+	lyrID := types.GetEffectiveGenesis().Add(2)
+
+	oracle := newMockHashOracle(numOfClients)
+	signing := signing2.NewEdSigner()
+
+	mockMesh := mocks.NewMockmeshProvider(ctrl)
+	mockBeacons := bMocks.NewMockBeaconGetter(ctrl)
+
+	patrol := mocks.NewMocklayerPatrol(ctrl)
+	patrol.EXPECT().SetHareInCharge(lyrID).Times(1)
+	h := New(cfg, n1, signing, types.NodeID{}, (&mockSyncer{true}).IsSynced, mockMesh, mockBeacons, oracle, patrol, 10, &mockIDProvider{}, NewMockStateQuerier(), layerTicker, logtest.New(t).WithName("Hare"))
+	h.networkDelta = 0
+	h.bufferSize = 1
+
+	createdChan := make(chan struct{})
+	var nmcp *mockConsensusProcess
+	h.factory = func(cfg config.Config, instanceId types.LayerID, s *Set, oracle Rolacle, signing Signer, p2p NetworkService, outputChan chan TerminationOutput) Consensus {
+		nmcp = newMockConsensusProcess(cfg, instanceId, s, oracle, signing, p2p, outputChan)
+		createdChan <- struct{}{}
+		return nmcp
+	}
+
+	require.NoError(t, h.Start(context.TODO()))
+	t.Cleanup(func() {
+		h.Close()
+	})
+
+	epochBeacon := randomBytes(t, 32)
+	blockSet := []*types.Block{
+		randomBlock(t, lyrID, epochBeacon),
+		randomBlock(t, lyrID, nil),
+		randomBlock(t, lyrID, epochBeacon),
+	}
+	refBlock := randomBlock(t, lyrID.Sub(1), epochBeacon)
+	bID := refBlock.ID()
+	blockSet[1].RefBlock = &bID
+	mockBeacons.EXPECT().GetBeacon(lyrID.GetEpoch()).Return(epochBeacon, nil).Times(1)
+	mockMesh.EXPECT().RecordCoinflip(gomock.Any(), lyrID, false).Times(1)
+	mockMesh.EXPECT().LayerBlocks(lyrID).Return(blockSet, nil).Times(1)
+	mockMesh.EXPECT().GetBlock(bID).Return(refBlock, nil).Times(1)
+	mockMesh.EXPECT().HandleValidatedLayer(gomock.Any(), lyrID, gomock.Any()).Times(1)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		layerTicker <- lyrID
+		<-createdChan
+		<-nmcp.CloseChannel()
+		wg.Done()
+	}()
+
+	wg.Wait()
+	time.Sleep(100 * time.Millisecond)
+	res, err := h.GetResult(lyrID)
+	assert.NoError(t, err)
+	assert.Equal(t, types.SortBlockIDs(types.BlockIDs(blockSet)), types.SortBlockIDs(res))
+}
+
+func TestHare_onTick_SomeBadBlocks(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	cfg := config.DefaultConfig()
+	types.SetLayersPerEpoch(4)
+
+	cfg.N = 2
+	cfg.F = 1
+	cfg.RoundDuration = 1
+
+	sim := service.NewSimulator()
+	n1 := sim.NewNode()
+
+	layerTicker := make(chan types.LayerID)
+
+	oracle := newMockHashOracle(numOfClients)
+	signing := signing2.NewEdSigner()
+
+	mockMesh := mocks.NewMockmeshProvider(ctrl)
+	mockBeacons := bMocks.NewMockBeaconGetter(ctrl)
+	patrol := mocks.NewMocklayerPatrol(ctrl)
+	patrol.EXPECT().SetHareInCharge(types.GetEffectiveGenesis().Add(1)).Times(1)
+	h := New(cfg, n1, signing, types.NodeID{}, (&mockSyncer{true}).IsSynced, mockMesh, mockBeacons, oracle, patrol, 10, &mockIDProvider{}, NewMockStateQuerier(), layerTicker, logtest.New(t).WithName("Hare"))
+	h.networkDelta = 0
+	h.bufferSize = 1
+
+	createdChan := make(chan struct{})
+	var nmcp *mockConsensusProcess
+	h.factory = func(cfg config.Config, instanceId types.LayerID, s *Set, oracle Rolacle, signing Signer, p2p NetworkService, outputChan chan TerminationOutput) Consensus {
+		nmcp = newMockConsensusProcess(cfg, instanceId, s, oracle, signing, p2p, outputChan)
+		createdChan <- struct{}{}
+		return nmcp
+	}
+
+	require.NoError(t, h.Start(context.TODO()))
+	t.Cleanup(func() {
+		h.Close()
+	})
+
+	lyrID := types.GetEffectiveGenesis().Add(1)
+	beacon := randomBytes(t, 32)
+	epochBeacon := randomBytes(t, 32)
+	blockSet := []*types.Block{
+		randomBlock(t, lyrID, epochBeacon),
+		randomBlock(t, lyrID, beacon),
+		randomBlock(t, lyrID, epochBeacon),
+	}
+	mockBeacons.EXPECT().GetBeacon(lyrID.GetEpoch()).Return(epochBeacon, nil).Times(1)
+	mockMesh.EXPECT().RecordCoinflip(gomock.Any(), lyrID, false).Times(1)
+	mockMesh.EXPECT().LayerBlocks(lyrID).Return(blockSet, nil).Times(1)
+	mockMesh.EXPECT().HandleValidatedLayer(gomock.Any(), lyrID, gomock.Any()).Times(1)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		layerTicker <- lyrID
+		<-createdChan
+		<-nmcp.CloseChannel()
+		wg.Done()
+	}()
+
+	wg.Wait()
+	time.Sleep(100 * time.Millisecond)
+	res, err := h.GetResult(lyrID)
+	assert.NoError(t, err)
+	goodBlocks := []*types.Block{blockSet[0], blockSet[2]}
+	assert.Equal(t, types.SortBlockIDs(types.BlockIDs(goodBlocks)), types.SortBlockIDs(res))
+}
+
+func TestHare_onTick_NoGoodBlocks(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	cfg := config.DefaultConfig()
+	types.SetLayersPerEpoch(4)
+
+	cfg.N = 2
+	cfg.F = 1
+	cfg.RoundDuration = 1
+
+	sim := service.NewSimulator()
+	n1 := sim.NewNode()
+
+	layerTicker := make(chan types.LayerID)
+
+	oracle := newMockHashOracle(numOfClients)
+	signing := signing2.NewEdSigner()
+
+	mockMesh := mocks.NewMockmeshProvider(ctrl)
+	mockBeacons := bMocks.NewMockBeaconGetter(ctrl)
+	patrol := mocks.NewMocklayerPatrol(ctrl)
+	patrol.EXPECT().SetHareInCharge(types.GetEffectiveGenesis().Add(1)).Times(1)
+	h := New(cfg, n1, signing, types.NodeID{}, (&mockSyncer{true}).IsSynced, mockMesh, mockBeacons, oracle, patrol, 10, &mockIDProvider{}, NewMockStateQuerier(), layerTicker, logtest.New(t).WithName("Hare"))
+	h.networkDelta = 0
+	h.bufferSize = 1
+
+	createdChan := make(chan struct{})
+	var nmcp *mockConsensusProcess
+	h.factory = func(cfg config.Config, instanceId types.LayerID, s *Set, oracle Rolacle, signing Signer, p2p NetworkService, outputChan chan TerminationOutput) Consensus {
+		nmcp = newMockConsensusProcess(cfg, instanceId, s, oracle, signing, p2p, outputChan)
+		createdChan <- struct{}{}
+		return nmcp
+	}
+
+	require.NoError(t, h.Start(context.TODO()))
+	t.Cleanup(func() {
+		h.Close()
+	})
+
+	lyrID := types.GetEffectiveGenesis().Add(1)
+	beacon := randomBytes(t, 32)
+	epochBeacon := randomBytes(t, 32)
+	blockSet := []*types.Block{
+		randomBlock(t, lyrID, beacon),
+		randomBlock(t, lyrID, beacon),
+		randomBlock(t, lyrID, beacon),
+	}
+	mockBeacons.EXPECT().GetBeacon(lyrID.GetEpoch()).Return(epochBeacon, nil).Times(1)
+	mockMesh.EXPECT().RecordCoinflip(gomock.Any(), lyrID, false).Times(1)
+	mockMesh.EXPECT().LayerBlocks(lyrID).Return(blockSet, nil).Times(1)
+	mockMesh.EXPECT().HandleValidatedLayer(gomock.Any(), lyrID, gomock.Any()).Times(1)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		layerTicker <- lyrID
+		<-createdChan
+		<-nmcp.CloseChannel()
+		wg.Done()
+	}()
+
+	wg.Wait()
+	time.Sleep(100 * time.Millisecond)
+	res, err := h.GetResult(lyrID)
+	assert.NoError(t, err)
+	assert.Empty(t, res)
 }
 
 func TestHare_onTick_NoBeacon(t *testing.T) {
@@ -333,16 +528,17 @@ func TestHare_onTick_NoBeacon(t *testing.T) {
 	defer ctrl.Finish()
 
 	moRolacle := mocks.NewMockRolacle(ctrl)
-	moRolacle.EXPECT().IsEpochBeaconReady(gomock.Any(), lyr.GetEpoch()).Return(false).Times(1)
 	moRolacle.EXPECT().IsIdentityActiveOnConsensusView(gomock.Any(), gomock.Any(), lyr).Return(true, nil).MaxTimes(1)
 
-	mp := mocks.NewMockmeshProvider(ctrl)
+	mockMesh := mocks.NewMockmeshProvider(ctrl)
+	mockBeacons := bMocks.NewMockBeaconGetter(ctrl)
+	mockBeacons.EXPECT().GetBeacon(lyr.GetEpoch()).Return(nil, errors.New("whatever")).Times(1)
+
 	layerTicker := make(chan types.LayerID)
 	net := service.NewSimulator().NewNode()
 
 	patrol := mocks.NewMocklayerPatrol(ctrl)
-	patrol.EXPECT().SetHareInCharge(types.GetEffectiveGenesis().Add(1)).Times(1)
-	h := New(cfg, net, nil, types.NodeID{}, (&mockSyncer{false}).IsSynced, mp, moRolacle, patrol, 10, &mockIDProvider{}, NewMockStateQuerier(), layerTicker, logtest.New(t).WithName("Hare"))
+	h := New(cfg, net, nil, types.NodeID{}, (&mockSyncer{false}).IsSynced, mockMesh, mockBeacons, moRolacle, patrol, 10, &mockIDProvider{}, NewMockStateQuerier(), layerTicker, logtest.New(t).WithName("Hare"))
 	h.networkDelta = 0
 	require.NoError(t, h.broker.Start(context.TODO()))
 
@@ -359,16 +555,17 @@ func TestHare_onTick_NotSynced(t *testing.T) {
 	defer ctrl.Finish()
 
 	moRolacle := mocks.NewMockRolacle(ctrl)
-	moRolacle.EXPECT().IsEpochBeaconReady(gomock.Any(), lyr.GetEpoch()).Return(true).Times(1)
 	moRolacle.EXPECT().IsIdentityActiveOnConsensusView(gomock.Any(), gomock.Any(), lyr).Return(true, nil).MaxTimes(1)
 
 	mp := mocks.NewMockmeshProvider(ctrl)
+	mockBeacons := bMocks.NewMockBeaconGetter(ctrl)
+	mockBeacons.EXPECT().GetBeacon(lyr.GetEpoch()).Return(randomBytes(t, 32), nil).Times(1)
+
 	layerTicker := make(chan types.LayerID)
 	net := service.NewSimulator().NewNode()
 
 	patrol := mocks.NewMocklayerPatrol(ctrl)
-	patrol.EXPECT().SetHareInCharge(types.GetEffectiveGenesis().Add(1)).Times(1)
-	h := New(cfg, net, nil, types.NodeID{}, (&mockSyncer{false}).IsSynced, mp, moRolacle, patrol, 10, &mockIDProvider{}, NewMockStateQuerier(), layerTicker, logtest.New(t).WithName("Hare"))
+	h := New(cfg, net, nil, types.NodeID{}, (&mockSyncer{false}).IsSynced, mp, mockBeacons, moRolacle, patrol, 10, &mockIDProvider{}, NewMockStateQuerier(), layerTicker, logtest.New(t).WithName("Hare"))
 	h.networkDelta = 0
 	require.NoError(t, h.broker.Start(context.TODO()))
 
@@ -377,24 +574,17 @@ func TestHare_onTick_NotSynced(t *testing.T) {
 	assert.False(t, started)
 }
 
-type BlockIDSlice []types.BlockID
-
-func (p BlockIDSlice) Len() int           { return len(p) }
-func (p BlockIDSlice) Less(i, j int) bool { return bytes.Compare(p[i].Bytes(), p[j].Bytes()) == -1 }
-func (p BlockIDSlice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
-
-// Sort is a convenience method.
-func (p BlockIDSlice) Sort() { sort.Sort(p) }
-
-func SortBlockIDs(slice []types.BlockID) {
-	sort.Sort(BlockIDSlice(slice))
-}
-
 func TestHare_outputBuffer(t *testing.T) {
 	sim := service.NewSimulator()
 	n1 := sim.NewNode()
 
-	h := createHare(t, n1, logtest.New(t).WithName(t.Name()))
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockMesh := mocks.NewMockmeshProvider(ctrl)
+	mockMesh.EXPECT().HandleValidatedLayer(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+	mockBeacons := bMocks.NewMockBeaconGetter(ctrl)
+	h := createHare(t, n1, mockMesh, mockBeacons, logtest.New(t).WithName(t.Name()))
 	lasti := types.LayerID{}
 
 	for i := lasti; i.Before(types.NewLayerID(h.bufferSize)); i = i.Add(1) {
@@ -423,7 +613,13 @@ func TestHare_IsTooLate(t *testing.T) {
 	sim := service.NewSimulator()
 	n1 := sim.NewNode()
 
-	h := createHare(t, n1, logtest.New(t).WithName(t.Name()))
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockMesh := mocks.NewMockmeshProvider(ctrl)
+	mockMesh.EXPECT().HandleValidatedLayer(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+	mockBeacons := bMocks.NewMockBeaconGetter(ctrl)
+	h := createHare(t, n1, mockMesh, mockBeacons, logtest.New(t).WithName(t.Name()))
 
 	for i := (types.LayerID{}); i.Before(types.NewLayerID(h.bufferSize * 2)); i = i.Add(1) {
 		mockid := i
@@ -447,7 +643,13 @@ func TestHare_oldestInBuffer(t *testing.T) {
 	sim := service.NewSimulator()
 	n1 := sim.NewNode()
 
-	h := createHare(t, n1, logtest.New(t).WithName(t.Name()))
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockMesh := mocks.NewMockmeshProvider(ctrl)
+	mockMesh.EXPECT().HandleValidatedLayer(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+	mockBeacons := bMocks.NewMockBeaconGetter(ctrl)
+	h := createHare(t, n1, mockMesh, mockBeacons, logtest.New(t).WithName(t.Name()))
 	lasti := types.LayerID{}
 
 	for i := lasti; i.Before(types.NewLayerID(h.bufferSize)); i = i.Add(1) {
@@ -505,19 +707,19 @@ func TestHare_WeakCoin(t *testing.T) {
 	layerTicker := make(chan types.LayerID)
 	oracle := newMockHashOracle(numOfClients)
 	signing := signing2.NewEdSigner()
-	om := &orphanMock{recordCoinflipsFn: func(_ context.Context, id types.LayerID, b bool) {
-		r.Equal(layerID, id)
-		r.True(b)
-		done <- struct{}{}
-	}}
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
-	h := New(cfg, n1, signing, types.NodeID{}, (&mockSyncer{true}).IsSynced, om, oracle, mocks.NewMocklayerPatrol(ctrl), 10, &mockIDProvider{}, NewMockStateQuerier(), layerTicker, logtest.New(t).WithName("Hare"))
+
+	mockMesh := mocks.NewMockmeshProvider(ctrl)
+	mockBeacons := bMocks.NewMockBeaconGetter(ctrl)
+	patrol := mocks.NewMocklayerPatrol(ctrl)
+	h := New(cfg, n1, signing, types.NodeID{}, (&mockSyncer{true}).IsSynced, mockMesh, mockBeacons, oracle, patrol, 10, &mockIDProvider{}, NewMockStateQuerier(), layerTicker, logtest.New(t).WithName("Hare"))
 	defer h.Close()
 	h.lastLayer = layerID
 	set := NewSetFromValues(value1)
 
-	_ = h.Start(context.TODO())
+	require.NoError(t, h.Start(context.TODO()))
 	waitForMsg := func() {
 		tmr := time.NewTimer(time.Second)
 		select {
@@ -526,24 +728,40 @@ func TestHare_WeakCoin(t *testing.T) {
 		case <-done:
 		}
 	}
+
+	// complete + coin flip true
+	mockMesh.EXPECT().RecordCoinflip(gomock.Any(), layerID, true).Times(1)
+	mockMesh.EXPECT().HandleValidatedLayer(gomock.Any(), layerID, gomock.Any()).Do(
+		func(context.Context, types.LayerID, []types.BlockID) {
+			done <- struct{}{}
+		}).Times(1)
 	h.outputChan <- mockReport{layerID, set, true, true}
+	waitForMsg()
+
+	// incomplete + coin flip true
+	mockMesh.EXPECT().RecordCoinflip(gomock.Any(), layerID, true).Times(1)
+	mockMesh.EXPECT().InvalidateLayer(gomock.Any(), layerID).Do(
+		func(context.Context, types.LayerID) {
+			done <- struct{}{}
+		}).Times(1)
 	h.outputChan <- mockReport{layerID, set, false, true}
 	waitForMsg()
-	waitForMsg()
-	om.recordCoinflipsFn = func(_ context.Context, id types.LayerID, b bool) {
-		r.Equal(layerID, id)
-		r.False(b)
-		done <- struct{}{}
-	}
+
+	// complete + coin flip false
+	mockMesh.EXPECT().RecordCoinflip(gomock.Any(), layerID, false).Times(1)
+	mockMesh.EXPECT().HandleValidatedLayer(gomock.Any(), layerID, gomock.Any()).Do(
+		func(context.Context, types.LayerID, []types.BlockID) {
+			done <- struct{}{}
+		}).Times(1)
 	h.outputChan <- mockReport{layerID, set, true, false}
+	waitForMsg()
+
+	// incomplete + coin flip false
+	mockMesh.EXPECT().RecordCoinflip(gomock.Any(), layerID, false).Times(1)
+	mockMesh.EXPECT().InvalidateLayer(gomock.Any(), layerID).Do(
+		func(context.Context, types.LayerID) {
+			done <- struct{}{}
+		}).Times(1)
 	h.outputChan <- mockReport{layerID, set, false, false}
-	waitForMsg()
-	waitForMsg()
-	om.recordCoinflipsFn = func(_ context.Context, id types.LayerID, b bool) {
-		r.Equal(layerID.Add(1), id)
-		r.True(b)
-		done <- struct{}{}
-	}
-	h.outputChan <- mockReport{layerID.Add(1), set, true, true}
 	waitForMsg()
 }

--- a/hare/interfaces.go
+++ b/hare/interfaces.go
@@ -18,12 +18,13 @@ type Rolacle interface {
 	CalcEligibility(ctx context.Context, layer types.LayerID, round uint32, committeeSize int, id types.NodeID, sig []byte) (uint16, error)
 	Proof(ctx context.Context, layer types.LayerID, round uint32) ([]byte, error)
 	IsIdentityActiveOnConsensusView(ctx context.Context, edID string, layer types.LayerID) (bool, error)
-	IsEpochBeaconReady(ctx context.Context, epoch types.EpochID) bool
 }
 
 type meshProvider interface {
-	// LayerBlockIds returns the block IDs stored for a layer
-	LayerBlockIds(layerID types.LayerID) ([]types.BlockID, error)
+	// LayerBlocks returns the blocks in a layer
+	LayerBlocks(types.LayerID) ([]*types.Block, error)
+	// GetBlock returns the block with the specified block ID
+	GetBlock(types.BlockID) (*types.Block, error)
 	// HandleValidatedLayer receives Hare output when it succeeds
 	HandleValidatedLayer(ctx context.Context, validatedLayer types.LayerID, layer []types.BlockID)
 	// InvalidateLayer receives the signal that Hare failed for a layer

--- a/hare/interfaces.go
+++ b/hare/interfaces.go
@@ -1,9 +1,33 @@
 package hare
 
-import "github.com/spacemeshos/go-spacemesh/common/types"
+import (
+	"context"
+
+	"github.com/spacemeshos/go-spacemesh/common/types"
+)
 
 //go:generate mockgen -package=mocks -destination=./mocks/mocks.go -source=./interfaces.go
 
 type layerPatrol interface {
 	SetHareInCharge(types.LayerID)
+}
+
+// Rolacle is the roles oracle provider.
+type Rolacle interface {
+	Validate(ctx context.Context, layer types.LayerID, round uint32, committeeSize int, id types.NodeID, sig []byte, eligibilityCount uint16) (bool, error)
+	CalcEligibility(ctx context.Context, layer types.LayerID, round uint32, committeeSize int, id types.NodeID, sig []byte) (uint16, error)
+	Proof(ctx context.Context, layer types.LayerID, round uint32) ([]byte, error)
+	IsIdentityActiveOnConsensusView(ctx context.Context, edID string, layer types.LayerID) (bool, error)
+	IsEpochBeaconReady(ctx context.Context, epoch types.EpochID) bool
+}
+
+type meshProvider interface {
+	// LayerBlockIds returns the block IDs stored for a layer
+	LayerBlockIds(layerID types.LayerID) ([]types.BlockID, error)
+	// HandleValidatedLayer receives Hare output when it succeeds
+	HandleValidatedLayer(ctx context.Context, validatedLayer types.LayerID, layer []types.BlockID)
+	// InvalidateLayer receives the signal that Hare failed for a layer
+	InvalidateLayer(ctx context.Context, layerID types.LayerID)
+	// RecordCoinflip records the weak coinflip result for a layer
+	RecordCoinflip(ctx context.Context, layerID types.LayerID, coinflip bool)
 }

--- a/hare/messagevalidation_test.go
+++ b/hare/messagevalidation_test.go
@@ -5,10 +5,12 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/hare/mocks"
 	"github.com/spacemeshos/go-spacemesh/log/logtest"
 	"github.com/spacemeshos/go-spacemesh/signing"
 )
@@ -29,8 +31,8 @@ func defaultValidator(tb testing.TB) *syntaxContextValidator {
 }
 
 func TestMessageValidator_CommitStatus(t *testing.T) {
-	assert.True(t, validateCommitType(BuildCommitMsg(generateSigning(t), NewEmptySet(lowDefaultSize))))
-	assert.True(t, validateStatusType(BuildStatusMsg(generateSigning(t), NewEmptySet(lowDefaultSize))))
+	assert.True(t, validateCommitType(BuildCommitMsg(signing.NewEdSigner(), NewEmptySet(lowDefaultSize))))
+	assert.True(t, validateStatusType(BuildStatusMsg(signing.NewEdSigner(), NewEmptySet(lowDefaultSize))))
 }
 
 func TestMessageValidator_ValidateCertificate(t *testing.T) {
@@ -51,58 +53,113 @@ func TestMessageValidator_ValidateCertificate(t *testing.T) {
 
 	msgs = make([]*Message, validator.threshold)
 	for i := 0; i < validator.threshold; i++ {
-		msgs[i] = BuildCommitMsg(generateSigning(t), NewDefaultEmptySet()).Message
+		msgs[i] = BuildCommitMsg(signing.NewEdSigner(), NewDefaultEmptySet()).Message
 	}
 	cert.AggMsgs.Messages = msgs
 	assert.True(t, validator.validateCertificate(context.TODO(), cert))
 }
 
-func TestEligibilityValidator_validateRole(t *testing.T) {
-	oracle := &mockRolacle{}
-	types.SetLayersPerEpoch(10)
+func TestEligibilityValidator_validateRole_NoMsg(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
 
-	ev := newEligibilityValidator(oracle, 10, &mockIDProvider{}, 1, 5, logtest.New(t))
-	ev.oracle = oracle
+	types.SetLayersPerEpoch(10)
+	mo := mocks.NewMockRolacle(ctrl)
+	ev := newEligibilityValidator(mo, 10, &mockIDProvider{}, 1, 5, logtest.New(t))
 	res, err := ev.validateRole(context.TODO(), nil)
 	assert.NotNil(t, err)
 	assert.False(t, res)
+}
 
-	m := BuildPreRoundMsg(generateSigning(t), NewDefaultEmptySet(), nil)
+func TestEligibilityValidator_validateRole_NoInnerMsg(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	types.SetLayersPerEpoch(10)
+	mo := mocks.NewMockRolacle(ctrl)
+	ev := newEligibilityValidator(mo, 10, &mockIDProvider{}, 1, 5, logtest.New(t))
+	m := BuildPreRoundMsg(signing.NewEdSigner(), NewDefaultEmptySet(), nil)
 	m.InnerMsg = nil
-	res, err = ev.validateRole(context.TODO(), m)
+	res, err := ev.validateRole(context.TODO(), m)
 	assert.NotNil(t, err)
 	assert.False(t, res)
+}
 
-	m = BuildPreRoundMsg(generateSigning(t), NewDefaultEmptySet(), nil)
-	oracle.isEligible = false
-	/*res*/ _, err = ev.validateRole(context.TODO(), m)
+func TestEligibilityValidator_validateRole_Genesis(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	types.SetLayersPerEpoch(10)
+	mo := mocks.NewMockRolacle(ctrl)
+	ev := newEligibilityValidator(mo, 10, &mockIDProvider{}, 1, 5, logtest.New(t))
+	m := BuildPreRoundMsg(signing.NewEdSigner(), NewDefaultEmptySet(), nil)
+	res, err := ev.validateRole(context.TODO(), m)
 	assert.Nil(t, err)
 	// TODO: remove comment after inceptions problem is addressed
 	// assert.False(t, res)
+	assert.True(t, res)
+}
 
+func TestEligibilityValidator_validateRole_FailedToGetIdentity(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	types.SetLayersPerEpoch(10)
+	mo := mocks.NewMockRolacle(ctrl)
+	ev := newEligibilityValidator(mo, 10, &mockIDProvider{}, 1, 5, logtest.New(t))
+	m := BuildPreRoundMsg(signing.NewEdSigner(), NewDefaultEmptySet(), nil)
 	m.InnerMsg.InstanceID = types.NewLayerID(111)
 	myErr := errors.New("my error")
 	ev.identityProvider = &mockIDProvider{myErr}
-	res, err = ev.validateRole(context.TODO(), m)
+	res, err := ev.validateRole(context.TODO(), m)
 	assert.NotNil(t, err)
 	assert.ErrorIs(t, err, myErr)
 	assert.False(t, res)
+}
 
-	oracle.err = myErr
-	res, err = ev.validateRole(context.TODO(), m)
+func TestEligibilityValidator_validateRole_FailedToValidate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	types.SetLayersPerEpoch(10)
+	mo := mocks.NewMockRolacle(ctrl)
+	ev := newEligibilityValidator(mo, 10, &mockIDProvider{}, 1, 5, logtest.New(t))
+	m := BuildPreRoundMsg(signing.NewEdSigner(), NewDefaultEmptySet(), nil)
+	m.InnerMsg.InstanceID = types.NewLayerID(111)
+	myErr := errors.New("my error")
+	mo.EXPECT().Validate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(false, myErr).Times(1)
+	res, err := ev.validateRole(context.TODO(), m)
 	assert.NotNil(t, err)
 	assert.ErrorIs(t, err, myErr)
 	assert.False(t, res)
+}
 
-	ev.identityProvider = &mockIDProvider{nil}
-	oracle.err = nil
-	res, err = ev.validateRole(context.TODO(), m)
+func TestEligibilityValidator_validateRole_NotEligible(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	types.SetLayersPerEpoch(10)
+	mo := mocks.NewMockRolacle(ctrl)
+	ev := newEligibilityValidator(mo, 10, &mockIDProvider{}, 1, 5, logtest.New(t))
+	m := BuildPreRoundMsg(signing.NewEdSigner(), NewDefaultEmptySet(), nil)
+	m.InnerMsg.InstanceID = types.NewLayerID(111)
+	mo.EXPECT().Validate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil).Times(1)
+	res, err := ev.validateRole(context.TODO(), m)
 	assert.Nil(t, err)
 	assert.False(t, res)
+}
 
-	oracle.isEligible = true
+func TestEligibilityValidator_validateRole_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	types.SetLayersPerEpoch(10)
+	mo := mocks.NewMockRolacle(ctrl)
+	ev := newEligibilityValidator(mo, 10, &mockIDProvider{}, 1, 5, logtest.New(t))
+	m := BuildPreRoundMsg(signing.NewEdSigner(), NewDefaultEmptySet(), nil)
 	m.InnerMsg.InstanceID = types.NewLayerID(111)
-	res, err = ev.validateRole(context.TODO(), m)
+	mo.EXPECT().Validate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).Times(1)
+	res, err := ev.validateRole(context.TODO(), m)
 	assert.Nil(t, err)
 	assert.True(t, res)
 }
@@ -112,7 +169,7 @@ func TestMessageValidator_IsStructureValid(t *testing.T) {
 	assert.False(t, validator.SyntacticallyValidateMessage(context.TODO(), nil))
 	m := &Msg{Message: &Message{}, PubKey: nil}
 	assert.False(t, validator.SyntacticallyValidateMessage(context.TODO(), m))
-	m.PubKey = generateSigning(t).PublicKey()
+	m.PubKey = signing.NewEdSigner().PublicKey()
 	assert.False(t, validator.SyntacticallyValidateMessage(context.TODO(), m))
 
 	// empty set is allowed now
@@ -132,12 +189,12 @@ func (m mockValidator) Validate(context.Context, *Msg) bool {
 	return m.res
 }
 
-func initPg(t *testing.T, validator *syntaxContextValidator) (*pubGetter, []*Message, Signer) {
+func initPg(validator *syntaxContextValidator) (*pubGetter, []*Message, Signer) {
 	pg := newPubGetter()
 	msgs := make([]*Message, validator.threshold)
-	sgn := generateSigning(t)
+	sgn := signing.NewEdSigner()
 	for i := 0; i < validator.threshold; i++ {
-		sgn = generateSigning(t) // hold some sgn
+		sgn = signing.NewEdSigner() // hold some sgn
 		iMsg := BuildStatusMsg(sgn, NewSetFromValues(value1))
 		msgs[i] = iMsg.Message
 		pg.Track(iMsg)
@@ -159,7 +216,7 @@ func TestMessageValidator_Aggregated(t *testing.T) {
 	agg.Messages = makeMessages(validator.threshold - 1)
 	r.Equal(errMsgsCountMismatch, validator.validateAggregatedMessage(context.TODO(), agg, funcs))
 
-	pg, msgs, sgn := initPg(t, validator)
+	pg, msgs, sgn := initPg(validator)
 
 	validator.validMsgsTracker = pg
 	agg.Messages = msgs
@@ -191,9 +248,9 @@ func TestMessageValidator_Aggregated(t *testing.T) {
 	msgs[len(msgs)-1] = m0
 	r.Equal(errDupSender, validator.validateAggregatedMessage(context.TODO(), agg, funcs))
 
-	msgs[0] = BuildStatusMsg(generateSigning(t), NewSetFromValues(value1)).Message
+	msgs[0] = BuildStatusMsg(signing.NewEdSigner(), NewSetFromValues(value1)).Message
 	r.Nil(pg.PublicKey(msgs[0]))
-	validator.validateAggregatedMessage(context.TODO(), agg, funcs)
+	require.NoError(t, validator.validateAggregatedMessage(context.TODO(), agg, funcs))
 	r.NotNil(pg.PublicKey(msgs[0]))
 }
 
@@ -293,9 +350,9 @@ func (pg pubGetter) PublicKey(m *Message) *signing.PublicKey {
 
 func TestMessageValidator_SyntacticallyValidateMessage(t *testing.T) {
 	validator := newSyntaxContextValidator(signing.NewEdSigner(), 1, validate, &MockStateQuerier{true, nil}, 10, truer{}, newPubGetter(), logtest.New(t))
-	m := BuildPreRoundMsg(generateSigning(t), NewDefaultEmptySet(), nil)
+	m := BuildPreRoundMsg(signing.NewEdSigner(), NewDefaultEmptySet(), nil)
 	assert.True(t, validator.SyntacticallyValidateMessage(context.TODO(), m))
-	m = BuildPreRoundMsg(generateSigning(t), NewSetFromValues(value1), nil)
+	m = BuildPreRoundMsg(signing.NewEdSigner(), NewSetFromValues(value1), nil)
 	assert.True(t, validator.SyntacticallyValidateMessage(context.TODO(), m))
 }
 
@@ -361,7 +418,7 @@ func validateMatrix(t *testing.T, mType messageType, msgK uint32, exp []error) {
 	r := require.New(t)
 	rounds := []uint32{preRound, 0, 1, 2, 3, 4, 5, 6, 7}
 	v := defaultValidator(t)
-	sgn := generateSigning(t)
+	sgn := signing.NewEdSigner()
 	set := NewEmptySet(1)
 	var m *Msg
 	switch mType {

--- a/hare/mock_oracle.go
+++ b/hare/mock_oracle.go
@@ -72,10 +72,6 @@ func (mho *mockHashOracle) Unregister(client string) {
 	mho.mutex.Unlock()
 }
 
-func (mho *mockHashOracle) IsEpochBeaconReady(context.Context, types.EpochID) bool {
-	return true
-}
-
 // Calculates the threshold for the given committee size.
 func (mho *mockHashOracle) calcThreshold(committeeSize int) uint32 {
 	mho.mutex.RLock()

--- a/hare/mock_oracle_test.go
+++ b/hare/mock_oracle_test.go
@@ -11,20 +11,21 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/signing"
 )
 
 const numOfClients = 100
 
 func TestMockHashOracle_Register(t *testing.T) {
 	oracle := newMockHashOracle(numOfClients)
-	oracle.Register(generateSigning(t).PublicKey().String())
-	oracle.Register(generateSigning(t).PublicKey().String())
+	oracle.Register(signing.NewEdSigner().PublicKey().String())
+	oracle.Register(signing.NewEdSigner().PublicKey().String())
 	assert.Equal(t, 2, len(oracle.clients))
 }
 
 func TestMockHashOracle_Unregister(t *testing.T) {
 	oracle := newMockHashOracle(numOfClients)
-	pub := generateSigning(t)
+	pub := signing.NewEdSigner()
 	oracle.Register(pub.PublicKey().String())
 	assert.Equal(t, 1, len(oracle.clients))
 	oracle.Unregister(pub.PublicKey().String())
@@ -38,7 +39,7 @@ func TestMockHashOracle_Concurrency(t *testing.T) {
 
 	go func() {
 		for i := 0; i < 500; i++ {
-			pub := generateSigning(t)
+			pub := signing.NewEdSigner()
 			oracle.Register(pub.PublicKey().String())
 			c <- pub
 		}
@@ -70,14 +71,14 @@ func genSig() []byte {
 func TestMockHashOracle_Role(t *testing.T) {
 	oracle := newMockHashOracle(numOfClients)
 	for i := 0; i < numOfClients; i++ {
-		pub := generateSigning(t)
+		pub := signing.NewEdSigner()
 		oracle.Register(pub.PublicKey().String())
 	}
 
 	committeeSize := 20
 	counter := 0
 	for i := 0; i < numOfClients; i++ {
-		res, _ := oracle.eligible(context.TODO(), types.LayerID{}, 1, committeeSize, types.NodeID{Key: generateSigning(t).PublicKey().String()}, []byte(genSig()))
+		res, _ := oracle.eligible(context.TODO(), types.LayerID{}, 1, committeeSize, types.NodeID{Key: signing.NewEdSigner().PublicKey().String()}, []byte(genSig()))
 		if res {
 			counter++
 		}
@@ -91,8 +92,8 @@ func TestMockHashOracle_Role(t *testing.T) {
 
 func TestMockHashOracle_calcThreshold(t *testing.T) {
 	oracle := newMockHashOracle(2)
-	oracle.Register(generateSigning(t).PublicKey().String())
-	oracle.Register(generateSigning(t).PublicKey().String())
+	oracle.Register(signing.NewEdSigner().PublicKey().String())
+	oracle.Register(signing.NewEdSigner().PublicKey().String())
 	assert.Equal(t, uint32(math.MaxUint32/2), oracle.calcThreshold(1))
 	assert.Equal(t, uint32(math.MaxUint32), oracle.calcThreshold(2))
 }

--- a/hare/mocks/mocks.go
+++ b/hare/mocks/mocks.go
@@ -5,6 +5,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -44,4 +45,175 @@ func (m *MocklayerPatrol) SetHareInCharge(arg0 types.LayerID) {
 func (mr *MocklayerPatrolMockRecorder) SetHareInCharge(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetHareInCharge", reflect.TypeOf((*MocklayerPatrol)(nil).SetHareInCharge), arg0)
+}
+
+// MockRolacle is a mock of Rolacle interface.
+type MockRolacle struct {
+	ctrl     *gomock.Controller
+	recorder *MockRolacleMockRecorder
+}
+
+// MockRolacleMockRecorder is the mock recorder for MockRolacle.
+type MockRolacleMockRecorder struct {
+	mock *MockRolacle
+}
+
+// NewMockRolacle creates a new mock instance.
+func NewMockRolacle(ctrl *gomock.Controller) *MockRolacle {
+	mock := &MockRolacle{ctrl: ctrl}
+	mock.recorder = &MockRolacleMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockRolacle) EXPECT() *MockRolacleMockRecorder {
+	return m.recorder
+}
+
+// CalcEligibility mocks base method.
+func (m *MockRolacle) CalcEligibility(ctx context.Context, layer types.LayerID, round uint32, committeeSize int, id types.NodeID, sig []byte) (uint16, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CalcEligibility", ctx, layer, round, committeeSize, id, sig)
+	ret0, _ := ret[0].(uint16)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CalcEligibility indicates an expected call of CalcEligibility.
+func (mr *MockRolacleMockRecorder) CalcEligibility(ctx, layer, round, committeeSize, id, sig interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CalcEligibility", reflect.TypeOf((*MockRolacle)(nil).CalcEligibility), ctx, layer, round, committeeSize, id, sig)
+}
+
+// IsEpochBeaconReady mocks base method.
+func (m *MockRolacle) IsEpochBeaconReady(ctx context.Context, epoch types.EpochID) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsEpochBeaconReady", ctx, epoch)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsEpochBeaconReady indicates an expected call of IsEpochBeaconReady.
+func (mr *MockRolacleMockRecorder) IsEpochBeaconReady(ctx, epoch interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsEpochBeaconReady", reflect.TypeOf((*MockRolacle)(nil).IsEpochBeaconReady), ctx, epoch)
+}
+
+// IsIdentityActiveOnConsensusView mocks base method.
+func (m *MockRolacle) IsIdentityActiveOnConsensusView(ctx context.Context, edID string, layer types.LayerID) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsIdentityActiveOnConsensusView", ctx, edID, layer)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// IsIdentityActiveOnConsensusView indicates an expected call of IsIdentityActiveOnConsensusView.
+func (mr *MockRolacleMockRecorder) IsIdentityActiveOnConsensusView(ctx, edID, layer interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsIdentityActiveOnConsensusView", reflect.TypeOf((*MockRolacle)(nil).IsIdentityActiveOnConsensusView), ctx, edID, layer)
+}
+
+// Proof mocks base method.
+func (m *MockRolacle) Proof(ctx context.Context, layer types.LayerID, round uint32) ([]byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Proof", ctx, layer, round)
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Proof indicates an expected call of Proof.
+func (mr *MockRolacleMockRecorder) Proof(ctx, layer, round interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Proof", reflect.TypeOf((*MockRolacle)(nil).Proof), ctx, layer, round)
+}
+
+// Validate mocks base method.
+func (m *MockRolacle) Validate(ctx context.Context, layer types.LayerID, round uint32, committeeSize int, id types.NodeID, sig []byte, eligibilityCount uint16) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Validate", ctx, layer, round, committeeSize, id, sig, eligibilityCount)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Validate indicates an expected call of Validate.
+func (mr *MockRolacleMockRecorder) Validate(ctx, layer, round, committeeSize, id, sig, eligibilityCount interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Validate", reflect.TypeOf((*MockRolacle)(nil).Validate), ctx, layer, round, committeeSize, id, sig, eligibilityCount)
+}
+
+// MockmeshProvider is a mock of meshProvider interface.
+type MockmeshProvider struct {
+	ctrl     *gomock.Controller
+	recorder *MockmeshProviderMockRecorder
+}
+
+// MockmeshProviderMockRecorder is the mock recorder for MockmeshProvider.
+type MockmeshProviderMockRecorder struct {
+	mock *MockmeshProvider
+}
+
+// NewMockmeshProvider creates a new mock instance.
+func NewMockmeshProvider(ctrl *gomock.Controller) *MockmeshProvider {
+	mock := &MockmeshProvider{ctrl: ctrl}
+	mock.recorder = &MockmeshProviderMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockmeshProvider) EXPECT() *MockmeshProviderMockRecorder {
+	return m.recorder
+}
+
+// HandleValidatedLayer mocks base method.
+func (m *MockmeshProvider) HandleValidatedLayer(ctx context.Context, validatedLayer types.LayerID, layer []types.BlockID) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "HandleValidatedLayer", ctx, validatedLayer, layer)
+}
+
+// HandleValidatedLayer indicates an expected call of HandleValidatedLayer.
+func (mr *MockmeshProviderMockRecorder) HandleValidatedLayer(ctx, validatedLayer, layer interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleValidatedLayer", reflect.TypeOf((*MockmeshProvider)(nil).HandleValidatedLayer), ctx, validatedLayer, layer)
+}
+
+// InvalidateLayer mocks base method.
+func (m *MockmeshProvider) InvalidateLayer(ctx context.Context, layerID types.LayerID) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "InvalidateLayer", ctx, layerID)
+}
+
+// InvalidateLayer indicates an expected call of InvalidateLayer.
+func (mr *MockmeshProviderMockRecorder) InvalidateLayer(ctx, layerID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InvalidateLayer", reflect.TypeOf((*MockmeshProvider)(nil).InvalidateLayer), ctx, layerID)
+}
+
+// LayerBlockIds mocks base method.
+func (m *MockmeshProvider) LayerBlockIds(layerID types.LayerID) ([]types.BlockID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LayerBlockIds", layerID)
+	ret0, _ := ret[0].([]types.BlockID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// LayerBlockIds indicates an expected call of LayerBlockIds.
+func (mr *MockmeshProviderMockRecorder) LayerBlockIds(layerID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LayerBlockIds", reflect.TypeOf((*MockmeshProvider)(nil).LayerBlockIds), layerID)
+}
+
+// RecordCoinflip mocks base method.
+func (m *MockmeshProvider) RecordCoinflip(ctx context.Context, layerID types.LayerID, coinflip bool) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "RecordCoinflip", ctx, layerID, coinflip)
+}
+
+// RecordCoinflip indicates an expected call of RecordCoinflip.
+func (mr *MockmeshProviderMockRecorder) RecordCoinflip(ctx, layerID, coinflip interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecordCoinflip", reflect.TypeOf((*MockmeshProvider)(nil).RecordCoinflip), ctx, layerID, coinflip)
 }

--- a/hare/mocks/mocks.go
+++ b/hare/mocks/mocks.go
@@ -85,20 +85,6 @@ func (mr *MockRolacleMockRecorder) CalcEligibility(ctx, layer, round, committeeS
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CalcEligibility", reflect.TypeOf((*MockRolacle)(nil).CalcEligibility), ctx, layer, round, committeeSize, id, sig)
 }
 
-// IsEpochBeaconReady mocks base method.
-func (m *MockRolacle) IsEpochBeaconReady(ctx context.Context, epoch types.EpochID) bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsEpochBeaconReady", ctx, epoch)
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// IsEpochBeaconReady indicates an expected call of IsEpochBeaconReady.
-func (mr *MockRolacleMockRecorder) IsEpochBeaconReady(ctx, epoch interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsEpochBeaconReady", reflect.TypeOf((*MockRolacle)(nil).IsEpochBeaconReady), ctx, epoch)
-}
-
 // IsIdentityActiveOnConsensusView mocks base method.
 func (m *MockRolacle) IsIdentityActiveOnConsensusView(ctx context.Context, edID string, layer types.LayerID) (bool, error) {
 	m.ctrl.T.Helper()
@@ -167,6 +153,21 @@ func (m *MockmeshProvider) EXPECT() *MockmeshProviderMockRecorder {
 	return m.recorder
 }
 
+// GetBlock mocks base method.
+func (m *MockmeshProvider) GetBlock(arg0 types.BlockID) (*types.Block, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBlock", arg0)
+	ret0, _ := ret[0].(*types.Block)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetBlock indicates an expected call of GetBlock.
+func (mr *MockmeshProviderMockRecorder) GetBlock(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlock", reflect.TypeOf((*MockmeshProvider)(nil).GetBlock), arg0)
+}
+
 // HandleValidatedLayer mocks base method.
 func (m *MockmeshProvider) HandleValidatedLayer(ctx context.Context, validatedLayer types.LayerID, layer []types.BlockID) {
 	m.ctrl.T.Helper()
@@ -191,19 +192,19 @@ func (mr *MockmeshProviderMockRecorder) InvalidateLayer(ctx, layerID interface{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InvalidateLayer", reflect.TypeOf((*MockmeshProvider)(nil).InvalidateLayer), ctx, layerID)
 }
 
-// LayerBlockIds mocks base method.
-func (m *MockmeshProvider) LayerBlockIds(layerID types.LayerID) ([]types.BlockID, error) {
+// LayerBlocks mocks base method.
+func (m *MockmeshProvider) LayerBlocks(arg0 types.LayerID) ([]*types.Block, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LayerBlockIds", layerID)
-	ret0, _ := ret[0].([]types.BlockID)
+	ret := m.ctrl.Call(m, "LayerBlocks", arg0)
+	ret0, _ := ret[0].([]*types.Block)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// LayerBlockIds indicates an expected call of LayerBlockIds.
-func (mr *MockmeshProviderMockRecorder) LayerBlockIds(layerID interface{}) *gomock.Call {
+// LayerBlocks indicates an expected call of LayerBlocks.
+func (mr *MockmeshProviderMockRecorder) LayerBlocks(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LayerBlockIds", reflect.TypeOf((*MockmeshProvider)(nil).LayerBlockIds), layerID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LayerBlocks", reflect.TypeOf((*MockmeshProvider)(nil).LayerBlocks), arg0)
 }
 
 // RecordCoinflip mocks base method.

--- a/hare/notifytracker_test.go
+++ b/hare/notifytracker_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/spacemeshos/go-spacemesh/signing"
 )
 
 func BuildNotifyMsg(signing Signer, s *Set) *Msg {
@@ -24,7 +26,7 @@ func TestNotifyTracker_OnNotify(t *testing.T) {
 	s := NewEmptySet(lowDefaultSize)
 	s.Add(value1)
 	s.Add(value2)
-	verifier := generateSigning(t)
+	verifier := signing.NewEdSigner()
 
 	tracker := newNotifyTracker(lowDefaultSize)
 	exist := tracker.OnNotify(BuildNotifyMsg(verifier, s))
@@ -42,8 +44,8 @@ func TestNotifyTracker_NotificationsCount(t *testing.T) {
 	s := NewEmptySet(lowDefaultSize)
 	s.Add(value1)
 	tracker := newNotifyTracker(lowDefaultSize)
-	tracker.OnNotify(BuildNotifyMsg(generateSigning(t), s))
+	tracker.OnNotify(BuildNotifyMsg(signing.NewEdSigner(), s))
 	assert.Equal(t, 1, tracker.NotificationsCount(s))
-	tracker.OnNotify(BuildNotifyMsg(generateSigning(t), s))
+	tracker.OnNotify(BuildNotifyMsg(signing.NewEdSigner(), s))
 	assert.Equal(t, 2, tracker.NotificationsCount(s))
 }

--- a/hare/proposaltracker_test.go
+++ b/hare/proposaltracker_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/spacemeshos/go-spacemesh/log/logtest"
+	"github.com/spacemeshos/go-spacemesh/signing"
 )
 
 func buildProposalMsg(signing Signer, s *Set, signature []byte) *Msg {
@@ -24,7 +25,7 @@ func BuildProposalMsg(signing Signer, s *Set) *Msg {
 
 func TestProposalTracker_OnProposalConflict(t *testing.T) {
 	s := NewSetFromValues(value1, value2)
-	verifier := generateSigning(t)
+	verifier := signing.NewEdSigner()
 
 	m1 := BuildProposalMsg(verifier, s)
 	tracker := newProposalTracker(logtest.New(t))
@@ -42,14 +43,14 @@ func TestProposalTracker_IsConflicting(t *testing.T) {
 	tracker := newProposalTracker(logtest.New(t))
 
 	for i := 0; i < lowThresh10; i++ {
-		tracker.OnProposal(context.TODO(), BuildProposalMsg(generateSigning(t), s))
+		tracker.OnProposal(context.TODO(), BuildProposalMsg(signing.NewEdSigner(), s))
 		assert.False(t, tracker.IsConflicting())
 	}
 }
 
 func TestProposalTracker_OnLateProposal(t *testing.T) {
 	s := NewSetFromValues(value1, value2)
-	verifier := generateSigning(t)
+	verifier := signing.NewEdSigner()
 	m1 := BuildProposalMsg(verifier, s)
 	tracker := newProposalTracker(logtest.New(t))
 	tracker.OnProposal(context.TODO(), m1)
@@ -65,12 +66,12 @@ func TestProposalTracker_ProposedSet(t *testing.T) {
 	proposedSet := tracker.ProposedSet()
 	assert.Nil(t, proposedSet)
 	s1 := NewSetFromValues(value1, value2)
-	tracker.OnProposal(context.TODO(), buildProposalMsg(generateSigning(t), s1, []byte{1, 2, 3}))
+	tracker.OnProposal(context.TODO(), buildProposalMsg(signing.NewEdSigner(), s1, []byte{1, 2, 3}))
 	proposedSet = tracker.ProposedSet()
 	assert.NotNil(t, proposedSet)
 	assert.True(t, s1.Equals(proposedSet))
 	s2 := NewSetFromValues(value3, value4, value5)
-	pub := generateSigning(t)
+	pub := signing.NewEdSigner()
 	tracker.OnProposal(context.TODO(), buildProposalMsg(pub, s2, []byte{0}))
 	proposedSet = tracker.ProposedSet()
 	assert.True(t, s2.Equals(proposedSet))

--- a/hare/statustracker_test.go
+++ b/hare/statustracker_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/spacemeshos/go-spacemesh/signing"
 )
 
 func buildStatusMsg(signing Signer, s *Set, ki uint32) *Msg {
@@ -33,7 +35,7 @@ func TestStatusTracker_RecordStatus(t *testing.T) {
 	assert.False(t, tracker.IsSVPReady())
 
 	for i := 0; i < lowThresh10; i++ {
-		tracker.RecordStatus(context.TODO(), BuildPreRoundMsg(generateSigning(t), s, nil))
+		tracker.RecordStatus(context.TODO(), BuildPreRoundMsg(signing.NewEdSigner(), s, nil))
 		assert.False(t, tracker.IsSVPReady())
 	}
 
@@ -46,11 +48,11 @@ func TestStatusTracker_BuildUnionSet(t *testing.T) {
 
 	s := NewEmptySet(lowDefaultSize)
 	s.Add(value1)
-	tracker.RecordStatus(context.TODO(), BuildStatusMsg(generateSigning(t), s))
+	tracker.RecordStatus(context.TODO(), BuildStatusMsg(signing.NewEdSigner(), s))
 	s.Add(value2)
-	tracker.RecordStatus(context.TODO(), BuildStatusMsg(generateSigning(t), s))
+	tracker.RecordStatus(context.TODO(), BuildStatusMsg(signing.NewEdSigner(), s))
 	s.Add(value3)
-	tracker.RecordStatus(context.TODO(), BuildStatusMsg(generateSigning(t), s))
+	tracker.RecordStatus(context.TODO(), BuildStatusMsg(signing.NewEdSigner(), s))
 
 	g := tracker.buildUnionSet(defaultSetSize)
 	assert.True(t, s.Equals(g))
@@ -60,7 +62,7 @@ func TestStatusTracker_IsSVPReady(t *testing.T) {
 	tracker := newStatusTracker(1, 1)
 	assert.False(t, tracker.IsSVPReady())
 	s := NewSetFromValues(value1)
-	tracker.RecordStatus(context.TODO(), BuildStatusMsg(generateSigning(t), s))
+	tracker.RecordStatus(context.TODO(), BuildStatusMsg(signing.NewEdSigner(), s))
 	tracker.AnalyzeStatuses(validate)
 	assert.True(t, tracker.IsSVPReady())
 }
@@ -68,8 +70,8 @@ func TestStatusTracker_IsSVPReady(t *testing.T) {
 func TestStatusTracker_BuildSVP(t *testing.T) {
 	tracker := newStatusTracker(2, 1)
 	s := NewSetFromValues(value1)
-	tracker.RecordStatus(context.TODO(), BuildStatusMsg(generateSigning(t), s))
-	tracker.RecordStatus(context.TODO(), BuildStatusMsg(generateSigning(t), s))
+	tracker.RecordStatus(context.TODO(), BuildStatusMsg(signing.NewEdSigner(), s))
+	tracker.RecordStatus(context.TODO(), BuildStatusMsg(signing.NewEdSigner(), s))
 	tracker.AnalyzeStatuses(validate)
 	svp := tracker.BuildSVP()
 	assert.Equal(t, 2, len(svp.Messages))
@@ -79,8 +81,8 @@ func TestStatusTracker_ProposalSetTypeA(t *testing.T) {
 	tracker := newStatusTracker(2, 1)
 	s1 := NewSetFromValues(value1)
 	s2 := NewSetFromValues(value1, value2)
-	tracker.RecordStatus(context.TODO(), buildStatusMsg(generateSigning(t), s1, preRound))
-	tracker.RecordStatus(context.TODO(), buildStatusMsg(generateSigning(t), s2, preRound))
+	tracker.RecordStatus(context.TODO(), buildStatusMsg(signing.NewEdSigner(), s1, preRound))
+	tracker.RecordStatus(context.TODO(), buildStatusMsg(signing.NewEdSigner(), s2, preRound))
 	proposedSet := tracker.ProposalSet(2)
 	assert.NotNil(t, proposedSet)
 	assert.True(t, proposedSet.Equals(s1.Union(s2)))
@@ -90,8 +92,8 @@ func TestStatusTracker_ProposalSetTypeB(t *testing.T) {
 	tracker := newStatusTracker(2, 1)
 	s1 := NewSetFromValues(value1, value3)
 	s2 := NewSetFromValues(value1, value2)
-	tracker.RecordStatus(context.TODO(), buildStatusMsg(generateSigning(t), s1, 0))
-	tracker.RecordStatus(context.TODO(), buildStatusMsg(generateSigning(t), s2, 2))
+	tracker.RecordStatus(context.TODO(), buildStatusMsg(signing.NewEdSigner(), s1, 0))
+	tracker.RecordStatus(context.TODO(), buildStatusMsg(signing.NewEdSigner(), s2, 2))
 	tracker.AnalyzeStatuses(validate)
 	proposedSet := tracker.ProposalSet(2)
 	assert.NotNil(t, proposedSet)
@@ -102,9 +104,9 @@ func TestStatusTracker_AnalyzeStatuses(t *testing.T) {
 	tracker := newStatusTracker(2, 1)
 	s1 := NewSetFromValues(value1, value3)
 	s2 := NewSetFromValues(value1, value2)
-	tracker.RecordStatus(context.TODO(), buildStatusMsg(generateSigning(t), s1, 2))
-	tracker.RecordStatus(context.TODO(), buildStatusMsg(generateSigning(t), s2, 1))
-	tracker.RecordStatus(context.TODO(), buildStatusMsg(generateSigning(t), s2, 2))
+	tracker.RecordStatus(context.TODO(), buildStatusMsg(signing.NewEdSigner(), s1, 2))
+	tracker.RecordStatus(context.TODO(), buildStatusMsg(signing.NewEdSigner(), s2, 1))
+	tracker.RecordStatus(context.TODO(), buildStatusMsg(signing.NewEdSigner(), s2, 2))
 	tracker.AnalyzeStatuses(validate)
 	assert.Equal(t, 3, int(tracker.count))
 }

--- a/tortoisebeacon/beacon_calc.go
+++ b/tortoisebeacon/beacon_calc.go
@@ -7,7 +7,6 @@ import (
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/events"
 	"github.com/spacemeshos/go-spacemesh/log"
-	"github.com/spacemeshos/go-spacemesh/tortoisebeacon/metrics"
 )
 
 func (tb *TortoiseBeacon) calcBeacon(ctx context.Context, epoch types.EpochID, lastRoundVotes allVotes) error {
@@ -29,7 +28,6 @@ func (tb *TortoiseBeacon) calcBeacon(ctx context.Context, epoch types.EpochID, l
 	logger.With().Info("calculated beacon", log.Int("num_hashes", len(allHashes)))
 
 	events.ReportCalculatedTortoiseBeacon(epoch, beaconStr)
-	metrics.CalculatedBeaconCounter.With(metrics.LabelEpoch, epoch.String(), metrics.LabelBeacon, beaconStr).Add(1)
 
 	if err := tb.setBeacon(epoch, beacon); err != nil {
 		return err

--- a/tortoisebeacon/beacon_calc.go
+++ b/tortoisebeacon/beacon_calc.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/events"
 	"github.com/spacemeshos/go-spacemesh/log"
+	"github.com/spacemeshos/go-spacemesh/tortoisebeacon/metrics"
 )
 
 func (tb *TortoiseBeacon) calcBeacon(ctx context.Context, epoch types.EpochID, lastRoundVotes allVotes) error {
@@ -22,11 +23,13 @@ func (tb *TortoiseBeacon) calcBeacon(ctx context.Context, epoch types.EpochID, l
 		log.String("hashes", strings.Join(allHashHexes, ", ")))
 
 	beacon := allHashes.hash()
+	beaconStr := beacon.ShortString()
 
-	logger = logger.WithFields(log.String("beacon", beacon.ShortString()))
+	logger = logger.WithFields(log.String("beacon", beaconStr))
 	logger.With().Info("calculated beacon", log.Int("num_hashes", len(allHashes)))
 
-	events.ReportCalculatedTortoiseBeacon(epoch, beacon.ShortString())
+	events.ReportCalculatedTortoiseBeacon(epoch, beaconStr)
+	metrics.CalculatedBeaconCounter.With(metrics.LabelEpoch, epoch.String(), metrics.LabelBeacon, beaconStr).Add(1)
 
 	if err := tb.setBeacon(epoch, beacon); err != nil {
 		return err

--- a/tortoisebeacon/metrics/prometheus.go
+++ b/tortoisebeacon/metrics/prometheus.go
@@ -1,0 +1,37 @@
+package metrics
+
+import "github.com/spacemeshos/go-spacemesh/metrics"
+
+const (
+	subsystem = "beacons"
+	// LabelEpoch is the metric label for the epoch value.
+	LabelEpoch = "epoch"
+	// LabelBeacon is the metric label for the beacon value.
+	LabelBeacon = "beacon"
+)
+
+var (
+	// ObservedBeaconCounter is the total count of each beacon reported by blocks.
+	ObservedBeaconCounter = metrics.NewCounter(
+		"observed_beacon_count",
+		subsystem,
+		"Weight of each beacon collected from blocks for each epoch and value",
+		[]string{"epoch", "beacon"},
+	)
+
+	// ObservedBeaconWeightCounter is the total weight of each beacon reported by blocks.
+	ObservedBeaconWeightCounter = metrics.NewCounter(
+		"observed_beacon_weight",
+		subsystem,
+		"Weight of each beacon collected from blocks for each epoch and value",
+		[]string{"epoch", "beacon"},
+	)
+
+	// CalculatedBeaconCounter is the weight of the beacon calculated by the node.
+	CalculatedBeaconCounter = metrics.NewCounter(
+		"calculated_beacon_weight",
+		subsystem,
+		"Weight of each beacon calculated by the node for each epoch",
+		[]string{"epoch", "beacon"},
+	)
+)

--- a/tortoisebeacon/metrics/prometheus_test.go
+++ b/tortoisebeacon/metrics/prometheus_test.go
@@ -1,0 +1,55 @@
+package metrics
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/spacemeshos/go-spacemesh/common/types"
+)
+
+func TestBeaconMetrics(t *testing.T) {
+	epoch := types.EpochID(10)
+	observed := []*BeaconStats{
+		{
+			Epoch:  epoch,
+			Beacon: "canadian",
+			Count:  uint64(123),
+			Weight: uint64(32100),
+		},
+		{
+			Epoch:  epoch,
+			Beacon: "rashers",
+			Count:  uint64(321),
+			Weight: uint64(12300),
+		},
+	}
+	calculated := &BeaconStats{
+		Epoch:  epoch,
+		Beacon: "speck",
+		Count:  uint64(1),
+		Weight: uint64(45678),
+	}
+
+	bmc := NewBeaconMetricsCollector(func() ([]*BeaconStats, *BeaconStats) {
+		return observed, calculated
+	}, nil)
+
+	deviceExpected := `
+# HELP spacemesh_beacons_beacon_calculated_weight Weight of the beacon calculated by the node for each epoch
+# TYPE spacemesh_beacons_beacon_calculated_weight counter
+spacemesh_beacons_beacon_calculated_weight{beacon="speck",epoch="11"} 45678
+# HELP spacemesh_beacons_beacon_observed_total Number of beacons collected from blocks for each epoch and value
+# TYPE spacemesh_beacons_beacon_observed_total counter
+spacemesh_beacons_beacon_observed_total{beacon="canadian",epoch="10"} 123
+spacemesh_beacons_beacon_observed_total{beacon="rashers",epoch="10"} 321
+# HELP spacemesh_beacons_beacon_observed_weight Weight of beacons collected from blocks for each epoch and value
+# TYPE spacemesh_beacons_beacon_observed_weight counter
+spacemesh_beacons_beacon_observed_weight{beacon="canadian",epoch="10"} 32100
+spacemesh_beacons_beacon_observed_weight{beacon="rashers",epoch="10"} 12300
+`
+	if err := testutil.CollectAndCompare(bmc, strings.NewReader(deviceExpected)); err != nil {
+		t.Error(err)
+	}
+}

--- a/tortoisebeacon/tortoise_beacon.go
+++ b/tortoisebeacon/tortoise_beacon.go
@@ -19,6 +19,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/p2p/service"
 	"github.com/spacemeshos/go-spacemesh/signing"
 	"github.com/spacemeshos/go-spacemesh/timesync"
+	"github.com/spacemeshos/go-spacemesh/tortoisebeacon/metrics"
 	"github.com/spacemeshos/go-spacemesh/tortoisebeacon/weakcoin"
 )
 
@@ -231,6 +232,10 @@ func (tb *TortoiseBeacon) ReportBeaconFromBlock(epoch types.EpochID, blockID typ
 }
 
 func (tb *TortoiseBeacon) recordBlockBeacon(epochID types.EpochID, blockID types.BlockID, beacon []byte, weight uint64) {
+	beaconStr := types.BytesToHash(beacon).ShortString()
+	metrics.ObservedBeaconCounter.With(metrics.LabelEpoch, epochID.String(), metrics.LabelBeacon, beaconStr).Add(1)
+	metrics.ObservedBeaconWeightCounter.With(metrics.LabelEpoch, epochID.String(), metrics.LabelBeacon, beaconStr).Add(float64(weight))
+
 	tb.mu.Lock()
 	defer tb.mu.Unlock()
 
@@ -247,7 +252,7 @@ func (tb *TortoiseBeacon) recordBlockBeacon(epochID types.EpochID, blockID types
 		tb.logger.With().Debug("added beacon from block",
 			epochID,
 			blockID,
-			log.String("beacon", types.BytesToHash(beacon).ShortString()),
+			log.String("beacon", beaconStr),
 			log.Uint64("weight", weight))
 		return
 	}
@@ -263,7 +268,7 @@ func (tb *TortoiseBeacon) recordBlockBeacon(epochID types.EpochID, blockID types
 	tb.logger.With().Debug("added beacon from block",
 		epochID,
 		blockID,
-		log.String("beacon", types.BytesToHash(beacon).ShortString()),
+		log.String("beacon", beaconStr),
 		log.Uint64("weight", weight))
 }
 

--- a/tortoisebeacon/tortoise_beacon.go
+++ b/tortoisebeacon/tortoise_beacon.go
@@ -985,9 +985,6 @@ func (tb *TortoiseBeacon) sendToGossip(ctx context.Context, channel string, data
 }
 
 func (tb *TortoiseBeacon) getOwnWeight(epoch types.EpochID) uint64 {
-	if epoch == 0 {
-		return 0
-	}
 	atxID, err := tb.atxDB.GetNodeAtxIDForEpoch(tb.nodeID, epoch)
 	if err != nil {
 		tb.logger.With().Error("failed to look up own ATX for epoch", epoch, log.Err(err))
@@ -1019,12 +1016,16 @@ func (tb *TortoiseBeacon) gatherMetricsData() ([]*metrics.BeaconStats, *metrics.
 		}
 	}
 	var calculated *metrics.BeaconStats
+	ownWeight := uint64(0)
+	if !epoch.IsGenesis() {
+		ownWeight = tb.getOwnWeight(epoch - 1)
+	}
 	if beacon, ok := tb.beacons[epoch]; ok {
 		calculated = &metrics.BeaconStats{
 			Epoch:  epoch,
 			Beacon: beacon.ShortString(),
 			Count:  1,
-			Weight: tb.getOwnWeight(epoch - 1),
+			Weight: ownWeight,
 		}
 	}
 

--- a/tortoisebeacon/tortoise_beacon_test.go
+++ b/tortoisebeacon/tortoise_beacon_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -84,16 +85,14 @@ func setUpTortoiseBeacon(t *testing.T, mockEpochWeight uint64, hasATX bool) (*To
 	tb := New(conf, minerID, node, mockDB, edSgn, signing.NewEDVerifier(), vrfSigner, signing.VRFVerifier{}, mwc, database.NewMemDatabase(), clock, logger)
 	require.NotNil(t, tb)
 	tb.SetSyncState(testSyncState(true))
+	tb.setMetricsRegistry(prometheus.NewPedanticRegistry())
 	return tb, clock
 }
 
 func TestTortoiseBeacon(t *testing.T) {
-	t.Parallel()
-
 	tb, clock := setUpTortoiseBeacon(t, uint64(10), true)
 	epoch := types.EpochID(3)
-	err := tb.Start(context.TODO())
-	require.NoError(t, err)
+	require.NoError(t, tb.Start(context.TODO()))
 
 	t.Logf("Awaiting epoch %v", epoch)
 	awaitEpoch(clock, epoch)
@@ -109,12 +108,9 @@ func TestTortoiseBeacon(t *testing.T) {
 }
 
 func TestTortoiseBeaconZeroWeightEpoch(t *testing.T) {
-	t.Parallel()
-
 	tb, clock := setUpTortoiseBeacon(t, uint64(0), true)
 	epoch := types.EpochID(3)
-	err := tb.Start(context.TODO())
-	require.NoError(t, err)
+	require.NoError(t, tb.Start(context.TODO()))
 
 	t.Logf("Awaiting epoch %v", epoch)
 	awaitEpoch(clock, epoch)
@@ -128,12 +124,9 @@ func TestTortoiseBeaconZeroWeightEpoch(t *testing.T) {
 }
 
 func TestTortoiseBeaconNoATXInPreviousEpoch(t *testing.T) {
-	t.Parallel()
-
 	tb, clock := setUpTortoiseBeacon(t, uint64(0), false)
 	epoch := types.EpochID(3)
-	err := tb.Start(context.TODO())
-	require.NoError(t, err)
+	require.NoError(t, tb.Start(context.TODO()))
 
 	t.Logf("Awaiting epoch %v", epoch)
 	awaitEpoch(clock, epoch)
@@ -154,6 +147,131 @@ func awaitEpoch(clock *timesync.TimeClock, epoch types.EpochID) {
 		if layer.GetEpoch() > epoch {
 			return
 		}
+	}
+}
+
+func TestTortoiseBeaconWithMetrics(t *testing.T) {
+	layersPerEpoch := uint32(3)
+	types.SetLayersPerEpoch(layersPerEpoch)
+
+	conf := UnitTestConfig()
+	ctrl := gomock.NewController(t)
+	mockDB := mocks.NewMockactivationDB(ctrl)
+	mockDB.EXPECT().GetNodeAtxIDForEpoch(gomock.Any(), gomock.Any()).Return(types.ATXID{}, nil).AnyTimes()
+	mockDB.EXPECT().GetEpochWeight(gomock.Any()).Return(uint64(10000), nil, nil).AnyTimes()
+	atxHeader := &types.ActivationTxHeader{
+		NIPostChallenge: types.NIPostChallenge{
+			StartTick: 0,
+			EndTick:   1,
+		},
+		NumUnits: 199,
+	}
+	mockDB.EXPECT().GetAtxHeader(gomock.Any()).Return(atxHeader, nil).AnyTimes()
+	mockDB.EXPECT().GetNodeAtxIDForEpoch(gomock.Any(), gomock.Any()).Return(types.ATXID{}, nil).AnyTimes()
+
+	mwc := coinValueMock(t, true)
+
+	logger := logtest.New(t).WithName("TortoiseBeacon")
+	clock := clockNeverNotify(t)
+
+	edSgn := signing.NewEdSigner()
+	edPubkey := edSgn.PublicKey()
+	vrfSigner, vrfPub, err := signing.NewVRFSigner(edSgn.Sign(edPubkey.Bytes()))
+	require.NoError(t, err)
+
+	node := service.NewSimulator().NewNode()
+	minerID := types.NodeID{Key: edPubkey.String(), VRFPublicKey: vrfPub}
+	tb := New(conf, minerID, node, mockDB, edSgn, signing.NewEDVerifier(), vrfSigner, signing.VRFVerifier{}, mwc, database.NewMemDatabase(), clock, logger)
+	require.NotNil(t, tb)
+	tb.SetSyncState(testSyncState(true))
+
+	require.NoError(t, tb.Start(context.TODO()))
+	t.Cleanup(func() {
+		tb.Close()
+	})
+
+	gLayer := types.GetEffectiveGenesis()
+	numCalculatedBeacon := 0
+	for layer := types.NewLayerID(1); !layer.After(gLayer); layer = layer.Add(1) {
+		tb.handleLayer(context.TODO(), layer)
+		thisEpoch := layer.GetEpoch()
+		allMetrics, err := prometheus.DefaultGatherer.Gather()
+		assert.NoError(t, err)
+		for _, m := range allMetrics {
+			switch *m.Name {
+			case "spacemesh_beacons_beacon_calculated_weight":
+				require.Equal(t, 1, len(m.Metric))
+				numCalculatedBeacon++
+				beaconStr := types.HexToHash32(genesisBeacon).ShortString()
+				expected := fmt.Sprintf("label:<name:\"beacon\" value:\"%s\" > label:<name:\"epoch\" value:\"%d\" > counter:<value:%d > ", beaconStr, thisEpoch+1, atxHeader.GetWeight())
+				assert.Equal(t, expected, m.Metric[0].String())
+			case "spacemesh_beacons_beacon_observed_total":
+				t.Errorf("genesis blocks do not have blocks")
+			case "spacemesh_beacons_beacon_observed_weight":
+				t.Errorf("genesis blocks do not have blocks")
+			}
+		}
+	}
+	assert.Equal(t, int(gLayer.Uint32()), numCalculatedBeacon)
+
+	epoch3Beacon := "0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	epoch := types.EpochID(3)
+	finalLayer := types.NewLayerID(layersPerEpoch * uint32(epoch))
+	beacon1 := randomHash()
+	beacon2 := randomHash()
+	for layer := gLayer.Add(1); layer.Before(finalLayer); layer = layer.Add(1) {
+		tb.handleLayer(context.TODO(), layer)
+		thisEpoch := layer.GetEpoch()
+		tb.recordBlockBeacon(thisEpoch, randomBlockID(), beacon1.Bytes(), 100)
+		tb.recordBlockBeacon(thisEpoch, randomBlockID(), beacon2.Bytes(), 200)
+
+		numCalculated := 0
+		numObserved := 0
+		numObservedWeight := 0
+		tb.logger.Info("gathering data from test in epoch %v", thisEpoch)
+		allMetrics, err := prometheus.DefaultGatherer.Gather()
+		assert.NoError(t, err)
+		for _, m := range allMetrics {
+			switch *m.Name {
+			case "spacemesh_beacons_beacon_calculated_weight":
+				require.Equal(t, 1, len(m.Metric))
+				numCalculated++
+				beaconStr := types.HexToHash32(epoch3Beacon).ShortString()
+				expected := fmt.Sprintf("label:<name:\"beacon\" value:\"%s\" > label:<name:\"epoch\" value:\"%d\" > counter:<value:%d > ", beaconStr, thisEpoch+1, atxHeader.GetWeight())
+				assert.Equal(t, expected, m.Metric[0].String())
+			case "spacemesh_beacons_beacon_observed_total":
+				tb.logger.Info(m.String())
+				require.Equal(t, 2, len(m.Metric))
+				numObserved = numObserved + 2
+				count := layer.OrdinalInEpoch() + 1
+				expected := []string{
+					fmt.Sprintf("label:<name:\"beacon\" value:\"%s\" > label:<name:\"epoch\" value:\"%d\" > counter:<value:%d > ", beacon1.ShortString(), thisEpoch, count),
+					fmt.Sprintf("label:<name:\"beacon\" value:\"%s\" > label:<name:\"epoch\" value:\"%d\" > counter:<value:%d > ", beacon2.ShortString(), thisEpoch, count),
+				}
+				for _, subM := range m.Metric {
+					assert.Contains(t, expected, subM.String())
+				}
+			case "spacemesh_beacons_beacon_observed_weight":
+				require.Equal(t, 2, len(m.Metric))
+				numObservedWeight = numObservedWeight + 2
+				weight := (layer.OrdinalInEpoch() + 1) * 100
+				expected := []string{
+					fmt.Sprintf("label:<name:\"beacon\" value:\"%s\" > label:<name:\"epoch\" value:\"%d\" > counter:<value:%d > ", beacon1.ShortString(), thisEpoch, weight),
+					fmt.Sprintf("label:<name:\"beacon\" value:\"%s\" > label:<name:\"epoch\" value:\"%d\" > counter:<value:%d > ", beacon2.ShortString(), thisEpoch, weight*2),
+				}
+				for _, subM := range m.Metric {
+					assert.Contains(t, expected, subM.String())
+				}
+			}
+		}
+		if layer.OrdinalInEpoch() == 2 {
+			// there should be calculated beacon already by the last layer of the epoch
+			assert.Equal(t, 1, numCalculated, layer)
+		} else {
+			assert.LessOrEqual(t, numCalculated, 1, layer)
+		}
+		assert.Equal(t, 2, numObserved, layer)
+		assert.Equal(t, 2, numObservedWeight, layer)
 	}
 }
 

--- a/tortoisebeacon/tortoise_beacon_test.go
+++ b/tortoisebeacon/tortoise_beacon_test.go
@@ -195,6 +195,10 @@ func TestTortoiseBeaconWithMetrics(t *testing.T) {
 	for layer := types.NewLayerID(1); !layer.After(gLayer); layer = layer.Add(1) {
 		tb.handleLayer(context.TODO(), layer)
 		thisEpoch := layer.GetEpoch()
+		ownWeight := atxHeader.GetWeight()
+		if thisEpoch == 1 {
+			ownWeight = 0
+		}
 		allMetrics, err := prometheus.DefaultGatherer.Gather()
 		assert.NoError(t, err)
 		for _, m := range allMetrics {
@@ -203,7 +207,7 @@ func TestTortoiseBeaconWithMetrics(t *testing.T) {
 				require.Equal(t, 1, len(m.Metric))
 				numCalculatedBeacon++
 				beaconStr := types.HexToHash32(genesisBeacon).ShortString()
-				expected := fmt.Sprintf("label:<name:\"beacon\" value:\"%s\" > label:<name:\"epoch\" value:\"%d\" > counter:<value:%d > ", beaconStr, thisEpoch+1, atxHeader.GetWeight())
+				expected := fmt.Sprintf("label:<name:\"beacon\" value:\"%s\" > label:<name:\"epoch\" value:\"%d\" > counter:<value:%d > ", beaconStr, thisEpoch+1, ownWeight)
 				assert.Equal(t, expected, m.Metric[0].String())
 			case "spacemesh_beacons_beacon_observed_total":
 				t.Errorf("genesis blocks do not have blocks")

--- a/tortoisebeacon/tortoise_beacon_test.go
+++ b/tortoisebeacon/tortoise_beacon_test.go
@@ -196,7 +196,7 @@ func TestTortoiseBeaconWithMetrics(t *testing.T) {
 		tb.handleLayer(context.TODO(), layer)
 		thisEpoch := layer.GetEpoch()
 		ownWeight := atxHeader.GetWeight()
-		if thisEpoch == 1 {
+		if thisEpoch.IsGenesis() {
 			ownWeight = 0
 		}
 		allMetrics, err := prometheus.DefaultGatherer.Gather()


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
Closes #2811
also follow up on beacon sync PR https://github.com/spacemeshos/go-spacemesh/pull/2850, add test to hare
<!-- `Closes #XXXX, closes #XXXX, ...` links mentioned issues to this PR and automatically closes them when this it's merged -->


## Changes
<!-- Please describe in detail the changes made -->
- add test to hare.onTick for not synced and beacon unavailable
- use gomock for mockRoracle
- use epoch beacon value to decide good blocks as the hare's proposal set

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->
unit tests

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
