### PR TITLE
[Merged by Bors] - Remove unused scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,6 @@ Before building we need to set up the golang environment. Do this by running:
 ```bash
 make install
 ```
-This will invoke `setup_env.sh` which supports Linux and MacOS. On other platforms it should be straightforward to follow the steps in this script manually.
-
 
 ### Building
 To build `go-spacemesh` for your current system architecture, from the project root directory, use:

--- a/setup_env.bat
+++ b/setup_env.bat
@@ -1,4 +1,0 @@
-@echo off
-PowerShell.exe -NoProfile -ExecutionPolicy Bypass -Command "& './scripts/win/check-go-version.ps1'"
-if %ERRORLEVEL% GTR 0 exit /B 1
-

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-set -e
-./scripts/check-go-version.sh
-
-go mod download
-
-GO111MODULE=off go get golang.org/x/lint/golint # TODO: also install on Windows
-
-echo "setup complete 🎉"


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
Closes #2863
<!-- `Closes #XXXX, closes #XXXX, ...` links mentioned issues to this PR and automatically closes them when this it's merged -->

There're two shell scripts for checking the Go version:
- `setup_env.sh`
- `setup_env.bat`

They don't work now and were superseded by a `scripts/check-go-version.go`. This PR removes them.

## Changes
<!-- Please describe in detail the changes made -->
- Remove `setup_env.sh`
- Remove `setup_env.bat`
- Update `README.md`

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->
No tests needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
