### PR TITLE
[Merged by Bors] - add more debugging info based on devnet 208 monitoring

### DIFF
--- a/mesh/mesh.go
+++ b/mesh/mesh.go
@@ -431,7 +431,10 @@ func (msh *Mesh) getValidBlockIDs(ctx context.Context, layerID types.LayerID) ([
 
 // HandleLateBlock process a late (contextually invalid) block.
 func (msh *Mesh) HandleLateBlock(ctx context.Context, b *types.Block) {
-	msh.WithContext(ctx).With().Info("validate late block", b.ID())
+	msh.WithContext(ctx).With().Info("validate late block",
+		b.ID(),
+		b.ATXID,
+		log.FieldNamed("miner_id", b.MinerID()))
 	// TODO: handle late blocks in batches, see https://github.com/spacemeshos/go-spacemesh/issues/2412
 	oldPbase, newPbase := msh.trtl.HandleLateBlocks(ctx, []*types.Block{b})
 	if err := msh.trtl.Persist(ctx); err != nil {

--- a/p2p/udp.go
+++ b/p2p/udp.go
@@ -110,7 +110,9 @@ func (mux *UDPMux) listenToNetworkMessage() {
 			go func(event inet.IncomingMessageEvent) {
 				err := mux.processUDPMessage(event)
 				if err != nil {
-					mux.logger.Error("Error handing network message err=%v", err)
+					mux.logger.With().Error("Error handing network message",
+						log.String("from_addr", event.Conn.RemoteAddr().String()),
+						log.Err(err))
 					// todo: blacklist ?
 				}
 			}(msg)

--- a/tortoise/verifying_tortoise.go
+++ b/tortoise/verifying_tortoise.go
@@ -271,8 +271,8 @@ func (t *turtle) checkBlockAndGetLocalOpinion(
 	className string,
 	voteVector vec,
 	baseBlockLayer types.LayerID,
+	logger log.Logger,
 ) bool {
-	logger := t.logger.WithContext(ctx)
 	for _, exceptionBlockID := range diffList {
 		exceptionBlock, err := t.bdp.GetBlock(exceptionBlockID)
 		if err != nil {
@@ -743,9 +743,9 @@ func (t *turtle) determineBlockGoodness(ctx context.Context, block *types.Block)
 		logger.With().Error("inconsistent state: base block not found", log.Err(err))
 	} else if true &&
 		// (2) all diffs appear after the base block and are consistent with the current local opinion
-		t.checkBlockAndGetLocalOpinion(ctx, block.ForDiff, "support", support, baseBlock.LayerIndex) &&
-		t.checkBlockAndGetLocalOpinion(ctx, block.AgainstDiff, "against", against, baseBlock.LayerIndex) &&
-		t.checkBlockAndGetLocalOpinion(ctx, block.NeutralDiff, "abstain", abstain, baseBlock.LayerIndex) {
+		t.checkBlockAndGetLocalOpinion(ctx, block.ForDiff, "support", support, baseBlock.LayerIndex, logger) &&
+		t.checkBlockAndGetLocalOpinion(ctx, block.AgainstDiff, "against", against, baseBlock.LayerIndex, logger) &&
+		t.checkBlockAndGetLocalOpinion(ctx, block.NeutralDiff, "abstain", abstain, baseBlock.LayerIndex, logger) {
 		logger.Debug("block is good")
 		return true
 	}

--- a/tortoise/verifying_tortoise_test.go
+++ b/tortoise/verifying_tortoise_test.go
@@ -1187,28 +1187,29 @@ func TestCheckBlockAndGetInputVector(t *testing.T) {
 	l1ID := types.GetEffectiveGenesis().Add(1)
 	blocks := generateBlocks(t, l1ID, 3, alg.BaseBlock, atxdb, 1)
 	diffList := []types.BlockID{blocks[0].ID()}
+	lg := logtest.New(t)
 
 	// missing block
-	r.False(alg.trtl.checkBlockAndGetLocalOpinion(context.TODO(), diffList, "foo", support, l1ID))
+	r.False(alg.trtl.checkBlockAndGetLocalOpinion(context.TODO(), diffList, "foo", support, l1ID, lg))
 
 	// exception block older than base block
 	blocks[0].LayerIndex = mesh.GenesisLayer().Index()
 	r.NoError(mdb.AddBlock(blocks[0]))
-	r.False(alg.trtl.checkBlockAndGetLocalOpinion(context.TODO(), diffList, "foo", support, l1ID))
+	r.False(alg.trtl.checkBlockAndGetLocalOpinion(context.TODO(), diffList, "foo", support, l1ID, lg))
 
 	// missing input vector for layer
 	r.NoError(mdb.AddBlock(blocks[1]))
 	diffList[0] = blocks[1].ID()
-	r.False(alg.trtl.checkBlockAndGetLocalOpinion(context.TODO(), diffList, "foo", support, l1ID))
+	r.False(alg.trtl.checkBlockAndGetLocalOpinion(context.TODO(), diffList, "foo", support, l1ID, lg))
 
 	// good
 	r.NoError(mdb.SaveLayerInputVectorByID(context.TODO(), l1ID, diffList))
-	r.True(alg.trtl.checkBlockAndGetLocalOpinion(context.TODO(), diffList, "foo", support, l1ID))
+	r.True(alg.trtl.checkBlockAndGetLocalOpinion(context.TODO(), diffList, "foo", support, l1ID, lg))
 
 	// vote differs from input vector
 	diffList[0] = blocks[2].ID()
 	r.NoError(mdb.AddBlock(blocks[2]))
-	r.False(alg.trtl.checkBlockAndGetLocalOpinion(context.TODO(), diffList, "foo", support, l1ID))
+	r.False(alg.trtl.checkBlockAndGetLocalOpinion(context.TODO(), diffList, "foo", support, l1ID, lg))
 }
 
 func TestCalculateExceptions(t *testing.T) {


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
<!-- `Closes #XXXX, closes #XXXX, ...` links mentioned issues to this PR and automatically closes them when this it's merged -->
add more debug info for error logs in devnet 208

## Changes
<!-- Please describe in detail the changes made -->
- record remote address for mis-match network ID
- add miner id for late blocks
- add block ID and base block ID for `good block candidate contains exception for block older than its base block`

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->
unit tests

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
