### PR TITLE
[Merged by Bors] - simplify miner block builder and oracle code

### DIFF
--- a/blocks/blockoracle.go
+++ b/blocks/blockoracle.go
@@ -23,9 +23,6 @@ type vrfSigner interface {
 	Sign(msg []byte) []byte
 }
 
-// DefaultProofsEpoch is set such that it will never equal the current epoch.
-const DefaultProofsEpoch = ^types.EpochID(0)
-
 // ErrMinerHasNoATXInPreviousEpoch is returned when miner has no ATXs in previous epoch.
 var ErrMinerHasNoATXInPreviousEpoch = errors.New("miner has no ATX in previous epoch")
 
@@ -37,14 +34,14 @@ type Oracle struct {
 	beaconProvider BeaconGetter
 	vrfSigner      vrfSigner
 	nodeID         types.NodeID
+	isSynced       func() bool
+	log            log.Log
 
+	mu                sync.Mutex
 	proofsEpoch       types.EpochID
 	epochAtxs         []types.ATXID
 	eligibilityProofs map[types.LayerID][]types.BlockEligibilityProof
 	atx               *types.ActivationTxHeader
-	isSynced          func() bool
-	eligibilityMutex  sync.RWMutex
-	log               log.Log
 }
 
 // NewMinerBlockOracle returns a new Oracle.
@@ -56,120 +53,111 @@ func NewMinerBlockOracle(committeeSize uint32, layersPerEpoch uint32, atxDB acti
 		beaconProvider: beaconProvider,
 		vrfSigner:      vrfSigner,
 		nodeID:         nodeID,
-		proofsEpoch:    DefaultProofsEpoch,
 		isSynced:       isSynced,
 		log:            log,
 	}
 }
 
-// BlockEligible returns the ATXID and list of block eligibility proofs for the given layer. It caches proofs for a
-// single epoch and only refreshes the cache if eligibility is queried for a different epoch.
+// BlockEligible returns the ATXID, list of block eligibility proofs for the given layer and the active set of the epoch.
+// It caches proofs for a single epoch and only refreshes the cache if eligibility is queried for a different epoch.
 func (bo *Oracle) BlockEligible(layerID types.LayerID) (types.ATXID, []types.BlockEligibilityProof, []types.ATXID, error) {
-	if !bo.isSynced() {
-		return types.ATXID{}, nil, nil, fmt.Errorf("cannot calc eligibility, not synced yet")
-	}
+	bo.mu.Lock()
+	defer bo.mu.Unlock()
 
-	epochNumber := layerID.GetEpoch()
-	atx, err := bo.getValidAtxForEpoch(epochNumber)
-	if err != nil {
-		if errors.Is(err, database.ErrNotFound) {
-			return types.ATXID{}, nil, nil, ErrMinerHasNoATXInPreviousEpoch
-		}
-		return types.ATXID{}, nil, nil, fmt.Errorf("failed to get latest atx for node in epoch %d: %w", epochNumber, err)
-	}
-	bo.atx = atx
+	epoch := layerID.GetEpoch()
+	logger := bo.log.WithFields(layerID, epoch, bo.proofsEpoch)
 
-	var cachedEpochDescription log.Field
-	if bo.proofsEpoch == DefaultProofsEpoch {
-		cachedEpochDescription = log.Int("cached_epoch_id", -1)
-	} else {
-		cachedEpochDescription = log.FieldNamed("cached_epoch_id", bo.proofsEpoch.Field())
-	}
-	bo.log.With().Info("asked for block eligibility", layerID, epochNumber, cachedEpochDescription)
-	if epochNumber.IsGenesis() {
-		bo.log.With().Error("asked for block eligibility in genesis epoch, cannot create blocks here",
-			layerID, epochNumber, cachedEpochDescription)
+	if epoch.IsGenesis() {
+		logger.Error("asked for block eligibility in genesis epoch, cannot create blocks here",
+			layerID, epoch)
 		return *types.EmptyATXID, nil, nil, nil
 	}
-	var proofs []types.BlockEligibilityProof
-	bo.eligibilityMutex.RLock()
-	if bo.proofsEpoch != epochNumber {
-		bo.eligibilityMutex.RUnlock()
-		newProofs, err := bo.calcEligibilityProofs(epochNumber)
-		proofs = newProofs[layerID]
-		if err != nil {
-			bo.log.With().Error("failed to calculate eligibility proofs", layerID, epochNumber, log.Err(err))
-			return *types.EmptyATXID, nil, nil, err
-		}
-	} else {
-		proofs = bo.eligibilityProofs[layerID]
-		bo.eligibilityMutex.RUnlock()
+
+	if !bo.isSynced() {
+		return *types.EmptyATXID, nil, nil, fmt.Errorf("cannot calc eligibility, not synced yet")
 	}
-	bo.log.With().Info("got eligibility for blocks",
-		bo.nodeID, layerID, layerID.GetEpoch(),
-		log.Int("num_blocks", len(proofs)))
+
+	logger.Info("asked for block eligibility")
+
+	var proofs []types.BlockEligibilityProof
+	if bo.proofsEpoch == epoch { // use the cached value
+		proofs = bo.eligibilityProofs[layerID]
+		logger.With().Info("got cached eligibility for blocks", log.Int("num_blocks", len(proofs)))
+		return bo.atx.ID(), proofs, bo.epochAtxs, nil
+	}
+
+	// calculate the proof
+	atx, err := bo.getValidAtxForEpoch(epoch)
+	if err != nil {
+		if errors.Is(err, database.ErrNotFound) {
+			return *types.EmptyATXID, nil, nil, ErrMinerHasNoATXInPreviousEpoch
+		}
+		return *types.EmptyATXID, nil, nil, fmt.Errorf("failed to get valid atx for node for target epoch %d: %w", epoch, err)
+	}
+
+	newProofs, activeSet, err := bo.calcEligibilityProofs(atx.GetWeight(), epoch)
+	if err != nil {
+		logger.With().Error("failed to calculate eligibility proofs", log.Err(err))
+		return *types.EmptyATXID, nil, nil, err
+	}
+
+	bo.proofsEpoch = epoch
+	bo.atx = atx
+	bo.epochAtxs = activeSet
+	bo.eligibilityProofs = newProofs
+
+	proofs = bo.eligibilityProofs[layerID]
+	logger.With().Info("got eligibility for blocks", log.Int("num_blocks", len(proofs)))
 
 	return bo.atx.ID(), proofs, bo.epochAtxs, nil
 }
 
-func (bo *Oracle) calcEligibilityProofs(epochNumber types.EpochID) (map[types.LayerID][]types.BlockEligibilityProof, error) {
-	epochBeacon, err := bo.beaconProvider.GetBeacon(epochNumber)
-	if err != nil {
-		bo.log.With().Error("Failed to get beacon",
-			log.Uint64("epoch_id", uint64(epochNumber)),
-			log.Err(err))
+// calcEligibilityProofs calculates the eligibility proofs of blocks for the miner in the given epoch
+// and returns the proofs along with the epoch's active set.
+func (bo *Oracle) calcEligibilityProofs(weight uint64, epoch types.EpochID) (map[types.LayerID][]types.BlockEligibilityProof, []types.ATXID, error) {
+	logger := bo.log.WithFields(epoch)
 
-		return nil, fmt.Errorf("get beacon: %w", err)
+	beacon, err := bo.beaconProvider.GetBeacon(epoch)
+	if err != nil {
+		logger.With().Error("Failed to get beacon", log.Err(err))
+		return nil, nil, fmt.Errorf("get beacon: %w", err)
 	}
 
-	beaconDbgStr := types.BytesToHash(epochBeacon).ShortString()
-	bo.log.With().Info("got beacon",
-		log.Uint64("epoch_id", uint64(epochNumber)),
-		log.String("epoch_beacon", beaconDbgStr))
+	beaconDbgStr := types.BytesToHash(beacon).ShortString()
+	logger.With().Info("block oracle got beacon", log.String("beacon", beaconDbgStr))
 
 	// get the previous epoch's total weight
-	totalWeight, activeSet, err := bo.atxDB.GetEpochWeight(epochNumber)
+	totalWeight, activeSet, err := bo.atxDB.GetEpochWeight(epoch)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get epoch %v weight: %w", epochNumber, err)
+		return nil, nil, fmt.Errorf("failed to get epoch %v weight: %w", epoch, err)
 	}
 
-	bo.log.With().Info("calculating eligibility",
-		epochNumber,
-		log.Uint64("total_weight", totalWeight))
-	bo.log.With().Debug("calculating eligibility",
-		epochNumber,
-		log.String("epoch_beacon", beaconDbgStr))
+	logger = logger.WithFields(log.Uint64("weight", weight), log.Uint64("total_weight", totalWeight))
+	logger.Info("calculating eligibility")
 
-	weight := bo.atx.GetWeight()
 	numberOfEligibleBlocks, err := getNumberOfEligibleBlocks(weight, totalWeight, bo.committeeSize, bo.layersPerEpoch)
 	if err != nil {
-		bo.log.With().Error("failed to get number of eligible blocks", log.Err(err))
-		return nil, err
+		logger.With().Error("failed to get number of eligible blocks", log.Err(err))
+		return nil, nil, err
 	}
 
 	eligibilityProofs := map[types.LayerID][]types.BlockEligibilityProof{}
 	for counter := uint32(0); counter < numberOfEligibleBlocks; counter++ {
-		message, err := serializeVRFMessage(epochBeacon, epochNumber, counter)
+		message, err := serializeVRFMessage(beacon, epoch, counter)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		vrfSig := bo.vrfSigner.Sign(message)
 
-		bo.log.Debug("signed vrf message, beacon %v, epoch %v, counter: %v, vrfSig: %v",
-			types.BytesToHash(epochBeacon).ShortString(), epochNumber, counter, types.BytesToHash(vrfSig).ShortString())
+		logger.Debug("signed vrf message, beacon %v, epoch %v, counter: %v, vrfSig: %v",
+			beaconDbgStr, epoch, counter, types.BytesToHash(vrfSig).ShortString())
 
-		eligibleLayer := calcEligibleLayer(epochNumber, bo.layersPerEpoch, vrfSig)
+		eligibleLayer := calcEligibleLayer(epoch, bo.layersPerEpoch, vrfSig)
 		eligibilityProofs[eligibleLayer] = append(eligibilityProofs[eligibleLayer], types.BlockEligibilityProof{
 			J:   counter,
 			Sig: vrfSig,
 		})
 	}
-
-	bo.eligibilityMutex.Lock()
-	bo.epochAtxs = activeSet
-	bo.proofsEpoch = epochNumber
-	bo.eligibilityProofs = eligibilityProofs
-	bo.eligibilityMutex.Unlock()
 
 	// Sort the layer map so we can print the layer data in order
 	keys := make([]types.LayerID, len(eligibilityProofs))
@@ -188,12 +176,11 @@ func (bo *Oracle) calcEligibilityProofs(epochNumber types.EpochID) (map[types.La
 		strs = append(strs, fmt.Sprintf("Layer %s: %d", keys[k].String(), len(eligibilityProofs[keys[k]])))
 	}
 
-	bo.log.With().Info("block eligibility calculated",
-		epochNumber,
+	logger.With().Info("block eligibility calculated",
 		log.Uint32("total_num_blocks", numberOfEligibleBlocks),
 		log.Int("num_layers_eligible", len(eligibilityProofs)),
 		log.String("layers_and_num_blocks", strings.Join(strs, ", ")))
-	return eligibilityProofs, nil
+	return eligibilityProofs, activeSet, nil
 }
 
 func (bo *Oracle) getValidAtxForEpoch(validForEpoch types.EpochID) (*types.ActivationTxHeader, error) {
@@ -257,16 +244,4 @@ func serializeVRFMessage(epochBeacon []byte, epochNumber types.EpochID, counter 
 		return nil, fmt.Errorf("failed to serialize vrf message: %v", err)
 	}
 	return serialized, nil
-}
-
-// GetEligibleLayers returns a list of layers in which the miner is eligible for at least one block. The list is
-// returned in arbitrary order.
-func (bo *Oracle) GetEligibleLayers() []types.LayerID {
-	bo.eligibilityMutex.RLock()
-	layers := make([]types.LayerID, 0, len(bo.eligibilityProofs))
-	for layer := range bo.eligibilityProofs {
-		layers = append(layers, layer)
-	}
-	bo.eligibilityMutex.RUnlock()
-	return layers
 }

--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -625,7 +625,6 @@ func (app *App) initServices(ctx context.Context,
 	stateAndMeshProjector := pendingtxs.NewStateAndMeshProjector(processor, msh)
 	minerCfg := miner.Config{
 		DBPath:         filepath.Join(dbStorepath, "builder"),
-		Hdist:          app.Config.Hdist,
 		MinerID:        nodeID,
 		AtxsPerBlock:   app.Config.AtxsPerBlock,
 		LayersPerEpoch: layersPerEpoch,

--- a/miner/block_builder.go
+++ b/miner/block_builder.go
@@ -11,6 +11,8 @@ import (
 	"sync"
 	"time"
 
+	"golang.org/x/sync/errgroup"
+
 	"github.com/spacemeshos/go-spacemesh/blocks"
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/database"
@@ -62,7 +64,6 @@ type BlockBuilder struct {
 	signer
 	minerID         types.NodeID
 	rnd             *rand.Rand
-	hdist           uint32
 	beginRoundEvent chan types.LayerID
 	stopChan        chan struct{}
 	TransactionPool txPool
@@ -73,7 +74,7 @@ type BlockBuilder struct {
 	blockOracle     blockOracle
 	beaconProvider  blocks.BeaconGetter
 	syncer          syncer
-	wg              sync.WaitGroup
+	eg              errgroup.Group
 	started         bool
 	atxsPerBlock    int // number of atxs to select per block
 	txsPerBlock     int // max number of tx to select per block
@@ -86,7 +87,6 @@ type BlockBuilder struct {
 type Config struct {
 	DBPath         string
 	MinerID        types.NodeID
-	Hdist          uint32
 	AtxsPerBlock   int
 	LayersPerEpoch uint32
 	TxsPerBlock    int
@@ -98,7 +98,7 @@ func NewBlockBuilder(
 	sgn signer,
 	publisher pubsub.Publisher,
 	beginRoundEvent chan types.LayerID,
-	orph meshProvider,
+	msh meshProvider,
 	bbp baseBlockProvider,
 	blockOracle blockOracle,
 	beaconProvider blocks.BeaconGetter,
@@ -123,14 +123,13 @@ func NewBlockBuilder(
 	return &BlockBuilder{
 		minerID:         config.MinerID,
 		signer:          sgn,
-		hdist:           config.Hdist,
 		Log:             logger,
 		rnd:             rand.New(rand.NewSource(int64(seed))),
 		beginRoundEvent: beginRoundEvent,
 		stopChan:        make(chan struct{}),
 		mu:              sync.Mutex{},
 		publisher:       publisher,
-		meshProvider:    orph,
+		meshProvider:    msh,
 		baseBlockP:      bbp,
 		blockOracle:     blockOracle,
 		beaconProvider:  beaconProvider,
@@ -155,11 +154,10 @@ func (t *BlockBuilder) Start(ctx context.Context) error {
 	}
 
 	t.started = true
-	t.wg.Add(1)
-	go func() {
+	t.eg.Go(func() error {
 		t.createBlockLoop(log.WithNewSessionID(ctx))
-		t.wg.Done()
-	}()
+		return nil
+	})
 	return nil
 }
 
@@ -172,7 +170,7 @@ func (t *BlockBuilder) Close() error {
 	}
 	t.started = false
 	close(t.stopChan)
-	t.wg.Wait()
+	t.eg.Wait()
 	t.db.Close()
 	return nil
 }
@@ -312,40 +310,40 @@ func (t *BlockBuilder) createBlockLoop(ctx context.Context) {
 
 			started := time.Now()
 
-			atxID, proofs, atxs, err := t.blockOracle.BlockEligible(layerID)
+			atxID, proofs, activeSet, err := t.blockOracle.BlockEligible(layerID)
 			if err != nil {
 				if errors.Is(err, blocks.ErrMinerHasNoATXInPreviousEpoch) {
-					logger.With().Info("node has no ATX in previous epoch and is not eligible for blocks")
-					events.ReportDoneCreatingBlock(true, layerID.Uint32(), "not eligible to produce block")
+					logger.Info("node has no ATX in previous epoch and is not eligible for blocks")
+					events.ReportDoneCreatingBlock(false, layerID.Uint32(), "not eligible to produce block")
 					continue
 				}
-				events.ReportDoneCreatingBlock(true, layerID.Uint32(), "failed to check for block eligibility")
-				logger.With().Error("failed to check for block eligibility", layerID, log.Err(err))
+				events.ReportDoneCreatingBlock(false, layerID.Uint32(), "failed to check for block eligibility")
+				logger.With().Error("failed to check for block eligibility", log.Err(err))
 				continue
 			}
 			if len(proofs) == 0 {
 				events.ReportDoneCreatingBlock(false, layerID.Uint32(), "")
-				logger.With().Info("not eligible for blocks in layer", layerID, layerID.GetEpoch())
+				logger.Info("not eligible for blocks in layer")
 				continue
 			}
 			// TODO: include multiple proofs in each block and weigh blocks where applicable
 
-			logger.With().Info("eligible for one or more blocks in layer", atxID, log.Int("count", len(proofs)))
+			logger.With().Info("eligible for one or more blocks in layer", atxID, log.Int("num_blocks", len(proofs)))
 			for _, eligibilityProof := range proofs {
 				txList, _, err := t.TransactionPool.GetTxsForBlock(t.txsPerBlock, t.projector.GetProjection)
 				if err != nil {
-					events.ReportDoneCreatingBlock(false, layerID.Uint32(), "failed to get txs for block")
-					logger.With().Error("failed to get txs for block", layerID, log.Err(err))
+					events.ReportDoneCreatingBlock(true, layerID.Uint32(), "failed to get txs for block")
+					logger.With().Error("failed to get txs for block", log.Err(err))
 					continue
 				}
-				blk, err := t.createBlock(ctx, layerID, atxID, eligibilityProof, txList, atxs, beacon)
+				blk, err := t.createBlock(ctx, layerID, atxID, eligibilityProof, txList, activeSet, beacon)
 				if err != nil {
-					events.ReportDoneCreatingBlock(true, layerID.Uint32(), "cannot create new block")
+					events.ReportDoneCreatingBlock(true, layerID.Uint32(), "failed to create new block")
 					logger.With().Error("failed to create new block", log.Err(err))
 					continue
 				}
 
-				t.saveBlockBuildDurationMetric(ctx, started, layerID, blk.ID())
+				t.saveBlockBuildDurationMetric(ctx, started, layerID)
 
 				if t.stopped() {
 					return
@@ -355,12 +353,12 @@ func (t *BlockBuilder) createBlockLoop(ctx context.Context) {
 					logger.With().Error("failed to store block", blk.ID(), log.Err(err))
 					continue
 				}
-				go func() {
+				t.eg.Go(func() error {
 					bytes, err := types.InterfaceToBytes(blk)
 					if err != nil {
 						logger.With().Error("failed to serialize block", log.Err(err))
 						events.ReportDoneCreatingBlock(true, layerID.Uint32(), "cannot serialize block")
-						return
+						return nil
 					}
 
 					// generate a new requestID for the new block message
@@ -369,13 +367,14 @@ func (t *BlockBuilder) createBlockLoop(ctx context.Context) {
 						logger.WithContext(blockCtx).With().Error("failed to send block", log.Err(err))
 					}
 					events.ReportDoneCreatingBlock(true, layerID.Uint32(), "")
-				}()
+					return nil
+				})
 			}
 		}
 	}
 }
 
-func (t *BlockBuilder) saveBlockBuildDurationMetric(ctx context.Context, started time.Time, layerID types.LayerID, blockID types.BlockID) {
+func (t *BlockBuilder) saveBlockBuildDurationMetric(ctx context.Context, started time.Time, layerID types.LayerID) {
 	elapsed := time.Since(started)
 	if elapsed > blockBuildDurationErrorThreshold {
 		t.WithContext(ctx).WithFields(layerID, layerID.GetEpoch()).With().

--- a/miner/builder_test.go
+++ b/miner/builder_test.go
@@ -527,7 +527,6 @@ func mockTortoiseBeacon(t *testing.T) blocks.BeaconGetter {
 func createBlockBuilder(t *testing.T, ID string, publisher pubsub.Publisher, meshBlocks []*types.Block) *BlockBuilder {
 	beginRound := make(chan types.LayerID)
 	cfg := Config{
-		Hdist:          5,
 		MinerID:        types.NodeID{Key: ID},
 		AtxsPerBlock:   selectCount,
 		LayersPerEpoch: 3,


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
<!-- `Closes #XXXX, closes #XXXX, ...` links mentioned issues to this PR and automatically closes them when this it's merged -->
simplify miner block builder and oracle code

## Changes
<!-- Please describe in detail the changes made -->
- hold lock throughout BlockEligible method. this ensure that the epoch cache update in block oracle is serialized
- removed unused GetEligibleLayers API in block oracle
- remove unused hdist in block builder
- use errgroup in block builder


## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->
unit tests

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
