### PR TITLE
[Merged by Bors] - p2p: enable logging for libp2p components

### DIFF
--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -374,7 +374,7 @@ func (app *App) addLogger(name string, logger log.Log) log.Log {
 	lvl := zap.NewAtomicLevel()
 	loggers, err := decodeLoggers(app.Config.LOGGING)
 	if err != nil {
-		panic("unable to decode loggers into map[string]string")
+		app.log.With().Panic("unable to decode loggers into map[string]string", log.Err(err))
 	}
 	level, ok := loggers[name]
 	if ok {

--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -392,12 +392,12 @@ func (app *App) addLogger(name string, logger log.Log) log.Log {
 	return logger.WithName(name).WithFields(log.String("module", name))
 }
 
-func (app *App) getLevel(name string) (log.Level, bool) {
+func (app *App) getLevel(name string) log.Level {
 	alvl, exist := app.loggers[name]
 	if !exist {
-		return 0, false
+		return 0
 	}
-	return alvl.Level(), true
+	return alvl.Level()
 }
 
 // SetLogLevel updates the log level of an existing logger.
@@ -1093,11 +1093,8 @@ func (app *App) Start() error {
 	cfg := app.Config.P2P
 	cfg.DataDir = filepath.Join(app.Config.DataDir(), "p2p")
 	p2plog := app.addLogger(P2PLogger, lg)
-	var exist bool
-	cfg.LogLevel, exist = app.getLevel(P2PLogger)
-	if !exist {
-		lg.Panic("p2p logger level is not set after calling app.addLogger")
-	}
+	// if addLogger won't add a level we will use a default 0 (info).
+	cfg.LogLevel = app.getLevel(P2PLogger)
 	app.host, err = p2p.New(ctx, p2plog, cfg,
 		p2p.WithNodeReporter(events.ReportNodeStatusUpdate),
 	)

--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -29,7 +29,6 @@ import (
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/common/util"
 	"github.com/spacemeshos/go-spacemesh/config"
-	cfg "github.com/spacemeshos/go-spacemesh/config"
 	"github.com/spacemeshos/go-spacemesh/database"
 	"github.com/spacemeshos/go-spacemesh/events"
 	"github.com/spacemeshos/go-spacemesh/fetch"
@@ -199,17 +198,17 @@ type TickProvider interface {
 }
 
 // LoadConfigFromFile tries to load configuration file if the config parameter was specified.
-func LoadConfigFromFile() (*cfg.Config, error) {
+func LoadConfigFromFile() (*config.Config, error) {
 	fileLocation := viper.GetString("config")
 	vip := viper.New()
 	// read in default config if passed as param using viper
-	if err := cfg.LoadConfig(fileLocation, vip); err != nil {
+	if err := config.LoadConfig(fileLocation, vip); err != nil {
 		log.Error(fmt.Sprintf("couldn't load config file at location: %s switching to defaults \n error: %v.",
 			fileLocation, err))
 		// return err
 	}
 
-	conf := cfg.DefaultConfig()
+	conf := config.DefaultConfig()
 
 	hook := mapstructure.ComposeDecodeHookFunc(
 		mapstructure.StringToTimeDurationHookFunc(),
@@ -237,7 +236,7 @@ func WithLog(logger log.Log) Option {
 }
 
 // WithConfig overvwrites default App config.
-func WithConfig(conf *cfg.Config) Option {
+func WithConfig(conf *config.Config) Option {
 	return func(app *App) {
 		app.Config = conf
 	}
@@ -245,7 +244,7 @@ func WithConfig(conf *cfg.Config) Option {
 
 // New creates an instance of the spacemesh app.
 func New(opts ...Option) *App {
-	defaultConfig := cfg.DefaultConfig()
+	defaultConfig := config.DefaultConfig()
 	app := &App{
 		Config:  &defaultConfig,
 		log:     log.NewNop(),
@@ -265,7 +264,7 @@ func New(opts ...Option) *App {
 type App struct {
 	*cobra.Command
 	nodeID         types.NodeID
-	Config         *cfg.Config
+	Config         *config.Config
 	grpcAPIService *grpcserver.Server
 	jsonAPIService *grpcserver.JSONHTTPServer
 	gatewaySvc     *grpcserver.GatewayService

--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -28,6 +28,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/cmd/mapstructureutil"
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/common/util"
+	"github.com/spacemeshos/go-spacemesh/config"
 	cfg "github.com/spacemeshos/go-spacemesh/config"
 	"github.com/spacemeshos/go-spacemesh/database"
 	"github.com/spacemeshos/go-spacemesh/events"
@@ -371,44 +372,18 @@ func (app *App) Cleanup() {
 // specific module.
 func (app *App) addLogger(name string, logger log.Log) log.Log {
 	lvl := zap.NewAtomicLevel()
-	config := app.Config.LOGGING
-	level, ok := map[string]string{
-		AppLogger:            config.AppLoggerLevel,
-		P2PLogger:            config.P2PLoggerLevel,
-		PostLogger:           config.PostLoggerLevel,
-		StateDbLogger:        config.StateDbLoggerLevel,
-		StateLogger:          config.StateLoggerLevel,
-		AtxDbStoreLogger:     config.AtxDbStoreLoggerLevel,
-		TBeaconLogger:        config.TBeaconLoggerLevel,
-		WeakCoinLogger:       config.WeakCoinLoggerLevel,
-		PoetDbStoreLogger:    config.PoetDbStoreLoggerLevel,
-		StoreLogger:          config.StoreLoggerLevel,
-		PoetDbLogger:         config.PoetDbLoggerLevel,
-		MeshDBLogger:         config.MeshDBLoggerLevel,
-		TrtlLogger:           config.TrtlLoggerLevel,
-		AtxDbLogger:          config.AtxDbLoggerLevel,
-		BlkEligibilityLogger: config.BlkEligibilityLoggerLevel,
-		MeshLogger:           config.MeshLoggerLevel,
-		SyncLogger:           config.SyncLoggerLevel,
-		BlockOracle:          config.BlockOracleLevel,
-		HareOracleLogger:     config.HareOracleLoggerLevel,
-		HareBeaconLogger:     config.HareBeaconLoggerLevel,
-		HareLogger:           config.HareLoggerLevel,
-		BlockBuilderLogger:   config.BlockBuilderLoggerLevel,
-		BlockListenerLogger:  config.BlockListenerLoggerLevel,
-		PoetListenerLogger:   config.PoetListenerLoggerLevel,
-		NipostBuilderLogger:  config.NipostBuilderLoggerLevel,
-		AtxBuilderLogger:     config.AtxBuilderLoggerLevel,
-		TimeSyncLogger:       config.TimeSyncLoggerLevel,
-	}[name]
-
+	loggers, err := decodeLoggers(app.Config.LOGGING)
+	if err != nil {
+		panic("unable to decode loggers into map[string]string")
+	}
+	level, ok := loggers[name]
 	if ok {
 		if err := lvl.UnmarshalText([]byte(level)); err != nil {
 			app.log.Error("cannot parse logging for %v error %v", name, err)
-			lvl.SetLevel(log.Level())
+			lvl.SetLevel(log.DefaultLevel())
 		}
 	} else {
-		lvl.SetLevel(log.Level())
+		lvl.SetLevel(log.DefaultLevel())
 	}
 
 	if logger.Check(lvl.Level()) {
@@ -416,6 +391,14 @@ func (app *App) addLogger(name string, logger log.Log) log.Log {
 		logger = logger.SetLevel(&lvl)
 	}
 	return logger.WithName(name).WithFields(log.String("module", name))
+}
+
+func (app *App) getLevel(name string) (log.Level, bool) {
+	alvl, exist := app.loggers[name]
+	if !exist {
+		return 0, false
+	}
+	return alvl.Level(), true
 }
 
 // SetLogLevel updates the log level of an existing logger.
@@ -1110,8 +1093,15 @@ func (app *App) Start() error {
 
 	cfg := app.Config.P2P
 	cfg.DataDir = filepath.Join(app.Config.DataDir(), "p2p")
-	app.host, err = p2p.New(ctx, app.addLogger(P2PLogger, lg), cfg,
-		p2p.WithNodeReporter(events.ReportNodeStatusUpdate))
+	p2plog := app.addLogger(P2PLogger, lg)
+	var exist bool
+	cfg.LogLevel, exist = app.getLevel(P2PLogger)
+	if !exist {
+		lg.Panic("p2p logger level is not set after calling app.addLogger")
+	}
+	app.host, err = p2p.New(ctx, p2plog, cfg,
+		p2p.WithNodeReporter(events.ReportNodeStatusUpdate),
+	)
 	if err != nil {
 		return fmt.Errorf("failed to initialize p2p host: %w", err)
 	}
@@ -1180,4 +1170,12 @@ func (app *App) Start() error {
 
 type layerFetcher struct {
 	system.Fetcher
+}
+
+func decodeLoggers(cfg config.LoggerConfig) (map[string]string, error) {
+	rst := map[string]string{}
+	if err := mapstructure.Decode(cfg, &rst); err != nil {
+		return nil, fmt.Errorf("mapstructure decode: %w", err)
+	}
+	return rst, nil
 }

--- a/log/log.go
+++ b/log/log.go
@@ -23,8 +23,11 @@ var logwriter io.Writer
 // default encoders.
 var defaultEncoder = zap.NewDevelopmentEncoderConfig()
 
-// Level returns the zapcore level of logging.
-func Level() zapcore.Level {
+// Level is an alias to zapcore.Level.
+type Level = zapcore.Level
+
+// DefaultLevel returns the zapcore level of logging.
+func DefaultLevel() Level {
 	return zapcore.InfoLevel
 }
 
@@ -95,7 +98,7 @@ func RegisterHooks(lg Log, hooks ...func(zapcore.Entry) error) Log {
 
 // NewDefault creates a Log with the default log level.
 func NewDefault(module string) Log {
-	return NewWithLevel(module, zap.NewAtomicLevelAt(Level()))
+	return NewWithLevel(module, zap.NewAtomicLevelAt(DefaultLevel()))
 }
 
 // NewFromLog creates a Log from an existing zap-compatible log.

--- a/p2p/host.go
+++ b/p2p/host.go
@@ -37,6 +37,7 @@ func DefaultConfig() Config {
 // Config for all things related to p2p layer.
 type Config struct {
 	DataDir            string
+	LogLevel           log.Level
 	GracePeersShutdown time.Duration
 	BootstrapTimeout   time.Duration
 	MaxMessageSize     int
@@ -58,7 +59,10 @@ func New(ctx context.Context, logger log.Log, cfg Config, opts ...Opt) (*Host, e
 	if err != nil {
 		return nil, err
 	}
+	// what we set in cfg.LogLevel doesn't will not be applied
+	// unless level of the Core is atleast as high
 	lp2plog.SetPrimaryCore(logger.Core())
+	lp2plog.SetAllLoggers(lp2plog.LogLevel(cfg.LogLevel))
 
 	cm := connmgr.NewConnManager(cfg.LowPeers, cfg.HighPeers, cfg.GracePeersShutdown)
 	// TODO(dshulyak) remove this part
@@ -69,7 +73,6 @@ func New(ctx context.Context, logger log.Log, cfg Config, opts ...Opt) (*Host, e
 		}
 		cm.Protect(addr.ID, "bootstrap")
 	}
-
 	streamer := *yamux.DefaultTransport
 	lopts := []libp2p.Option{
 		libp2p.Identity(key),

--- a/p2p/host.go
+++ b/p2p/host.go
@@ -59,7 +59,7 @@ func New(ctx context.Context, logger log.Log, cfg Config, opts ...Opt) (*Host, e
 	if err != nil {
 		return nil, err
 	}
-	// what we set in cfg.LogLevel doesn't will not be applied
+	// what we set in cfg.LogLevel will not be used
 	// unless level of the Core is atleast as high
 	lp2plog.SetPrimaryCore(logger.Core())
 	lp2plog.SetAllLoggers(lp2plog.LogLevel(cfg.LogLevel))


### PR DESCRIPTION
## Motivation

libp2p logging must be enabled.

in test mode libp2p logs will look like:

```
{"L":"DEBUG","T":"2021-10-26T06:43:15.889+0300","N":"basichost","C":"basic/basic_host.go:370","M":"protocol negotiation took 183.635µs","node_id":"1567169fa686ce24fa13d01390d1269d7603078fc2c82b74705dd5ba5435ec7e","module":"p2p"}
{"L":"DEBUG","T":"2021-10-26T06:43:15.889+0300","N":"basichost","C":"basic/basic_host.go:370","M":"protocol negotiation took 140.061754ms","node_id":"1567169fa686ce24fa13d01390d1269d7603078fc2c82b74705dd5ba5435ec7e","module":"p2p"}
{"L":"DEBUG","T":"2021-10-26T06:43:15.889+0300","N":"pubsub","C":"go-libp2p-pubsub@v0.5.4/gossipsub.go:1354","M":"HEARTBEAT: Add mesh link to 12D3KooWAsL38r9L1qc3yL6boyWLAAQka9YyfaoHjVi78tFyPEoW in HARE_PROTOCOL","node_id":"1567169fa686ce24fa13d01390d1269d7603078fc2c82b74705dd5ba5435ec7e","module":"p2p"}
{"L":"DEBUG","T":"2021-10-26T06:43:15.890+0300","N":"pubsub","C":"go-libp2p-pubsub@v0.5.4/gossipsub.go:1354","M":"HEARTBEAT: Add mesh link to 12D3KooWB7oDmnpuXCd1APR4chrkAPkz3BDXyaAtKQmBDdH79FCn in HARE_PROTOCOL","node_id":"1567169fa686ce24fa13d01390d1269d7603078fc2c82b74705dd5ba5435ec7e","module":"p2p"}
{"L":"DEBUG","T":"2021-10-26T06:43:15.890+0300","N":"pubsub","C":"go-libp2p-pubsub@v0.5.4/gossipsub.go:1354","M":"HEARTBEAT: Add mesh link to 12D3KooW9qnhAVbbLqqPmArtJx2erjD8b85JvaSzow1XHwNLLaUw in HARE_PROTOCOL","node_id":"1567169fa686ce24fa13d01390d1269d7603078fc2c82b74705dd5ba5435ec7e","module":"p2p"}
```

## Changes
- set log level when host is initialized
- create loggers map by decoding mapstructure tags

## Test Plan
tested format manually

## TODO
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
