### PR TITLE
[Merged by Bors] - miner: differentiate database.ErrNotFound when lookup ref block

### DIFF
--- a/tortoise/state.go
+++ b/tortoise/state.go
@@ -120,9 +120,7 @@ func (s *state) Recover() error {
 	s.LastEvicted = types.BytesToLayerID(buf)
 
 	it := s.db.Find([]byte(namespaceGood))
-	defer func(iter database.Iterator) {
-		it.Release()
-	}(it)
+	defer it.Release()
 	for it.Next() {
 		s.GoodBlocksIndex[decodeBlock(it.Key()[1:])] = true
 	}
@@ -131,9 +129,7 @@ func (s *state) Recover() error {
 	}
 
 	it = s.db.Find([]byte(namespaceOpinions))
-	defer func(iter database.Iterator) {
-		it.Release()
-	}(it)
+	defer it.Release()
 	for it.Next() {
 		layer := decodeLayerKey(it.Key())
 		offset := 1 + types.LayerIDSize

--- a/tortoise/state_test.go
+++ b/tortoise/state_test.go
@@ -20,7 +20,7 @@ import (
 
 func makeStateGen(tb testing.TB, db database.Database, logger log.Log) func(rng *rand.Rand) *state {
 	return func(rng *rand.Rand) *state {
-		st := &state{db: database.NewMemDatabase(), log: logtest.New(tb)}
+		st := &state{db: db, log: logger}
 		var layers [3]types.LayerID
 		for i := range layers {
 			layer, ok := quick.Value(reflect.TypeOf(types.LayerID{}), rng)


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
make sure we don't create multiple ref blocks on disk error

<!-- `Closes #XXXX, closes #XXXX, ...` links mentioned issues to this PR and automatically closes them when this it's merged -->

## Changes
<!-- Please describe in detail the changes made -->
- block builder: differentiate btwn database.ErrNotFound and other disk errors when looking up refblock
- block builder: make failure saving ref block an error

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->
unit tests

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
