### PR TITLE
[Merged by Bors] - tortoise: optimize processing blocks

### DIFF
--- a/tortoise/state.go
+++ b/tortoise/state.go
@@ -37,6 +37,7 @@ type state struct {
 	GoodBlocksIndex map[types.BlockID]bool
 	// use 2D array to be able to iterate from latest elements easily
 	BlockOpinionsByLayer map[types.LayerID]map[types.BlockID]Opinion
+	HaveOpinions         map[types.BlockID]struct{}
 }
 
 func (s *state) Persist() error {

--- a/tortoise/state.go
+++ b/tortoise/state.go
@@ -37,7 +37,7 @@ type state struct {
 	GoodBlocksIndex map[types.BlockID]bool
 	// use 2D array to be able to iterate from latest elements easily
 	BlockOpinionsByLayer map[types.LayerID]map[types.BlockID]Opinion
-	HaveOpinions         map[types.BlockID]struct{}
+	HaveOpinions         map[types.BlockID]types.LayerID
 }
 
 func (s *state) Persist() error {

--- a/tortoise/state_test.go
+++ b/tortoise/state_test.go
@@ -34,6 +34,7 @@ func makeStateGen(tb testing.TB, db database.Database, logger log.Log) func(rng 
 
 		st.GoodBlocksIndex = map[types.BlockID]bool{}
 		st.BlockOpinionsByLayer = map[types.LayerID]map[types.BlockID]Opinion{}
+		st.BlockLayer = map[types.BlockID]types.LayerID{}
 
 		for i := 0; i < 200; i++ {
 			layerGen, ok := quick.Value(reflect.TypeOf(types.LayerID{}), rng)
@@ -50,6 +51,7 @@ func makeStateGen(tb testing.TB, db database.Database, logger log.Log) func(rng 
 			block1 := block1Gen.Interface().(types.BlockID)
 			if _, exist := st.BlockOpinionsByLayer[layer][block1]; !exist {
 				st.BlockOpinionsByLayer[layer][block1] = Opinion{}
+				st.BlockLayer[block1] = layer
 			}
 			st.GoodBlocksIndex[block1] = false
 			block2 := block2Gen.Interface().(types.BlockID)
@@ -109,6 +111,7 @@ func TestStateEvict(t *testing.T) {
 				continue
 			}
 			for block := range st.BlockOpinionsByLayer[layer] {
+				delete(st.BlockLayer, block)
 				delete(st.GoodBlocksIndex, block)
 			}
 			delete(st.BlockOpinionsByLayer, layer)

--- a/tortoise/verifying_algorithm.go
+++ b/tortoise/verifying_algorithm.go
@@ -185,7 +185,8 @@ func (bdp *bdpWrapper) SaveContextualValidity(bid types.BlockID, lid types.Layer
 func (trtl *ThreadSafeVerifyingTortoise) rerunFromGenesis(ctx context.Context) (reverted bool, revertLayer types.LayerID) {
 	// TODO: should this happen "in the background" in a separate goroutine? Should it hold the mutex?
 	logger := trtl.logger.WithContext(ctx)
-	logger.With().Info("triggering tortoise full rerun from genesis")
+	last := trtl.trtl.Last
+	logger.With().Info("triggering tortoise full rerun from genesis", last)
 
 	// start from scratch with a new tortoise instance for each rerun
 	trtlForRerun := trtl.trtl.cloneTurtleParams()
@@ -203,7 +204,7 @@ func (trtl *ThreadSafeVerifyingTortoise) rerunFromGenesis(ctx context.Context) (
 			return
 		}
 	}
-	logger.With().Info("full rerun completed")
+	logger.With().Info("full rerun completed", last)
 
 	// revert state if necessary
 	// state will be reapplied in mesh after we return, no need to reapply here

--- a/tortoise/verifying_algorithm.go
+++ b/tortoise/verifying_algorithm.go
@@ -125,7 +125,7 @@ func (trtl *ThreadSafeVerifyingTortoise) HandleIncomingLayer(ctx context.Context
 	//   tortoise since we don't want to mess with the state of the main tortoise. We re-stream layer data from genesis
 	//   using the sliding window, simulating a full resync.
 	//   See https://github.com/spacemeshos/go-spacemesh/issues/2551
-	if time.Now().Sub(trtl.lastRerun) > trtl.trtl.RerunInterval {
+	if time.Now().Sub(trtl.lastRerun) > trtl.trtl.RerunInterval || true {
 		var revertLayer types.LayerID
 		if reverted, revertLayer = trtl.rerunFromGenesis(ctx); reverted {
 			// make sure state is reapplied from far enough back if there was a state reversion.
@@ -203,6 +203,7 @@ func (trtl *ThreadSafeVerifyingTortoise) rerunFromGenesis(ctx context.Context) (
 			return
 		}
 	}
+	logger.With().Info("full rerun completed")
 
 	// revert state if necessary
 	// state will be reapplied in mesh after we return, no need to reapply here

--- a/tortoise/verifying_algorithm.go
+++ b/tortoise/verifying_algorithm.go
@@ -125,7 +125,7 @@ func (trtl *ThreadSafeVerifyingTortoise) HandleIncomingLayer(ctx context.Context
 	//   tortoise since we don't want to mess with the state of the main tortoise. We re-stream layer data from genesis
 	//   using the sliding window, simulating a full resync.
 	//   See https://github.com/spacemeshos/go-spacemesh/issues/2551
-	if time.Now().Sub(trtl.lastRerun) > trtl.trtl.RerunInterval || true {
+	if time.Now().Sub(trtl.lastRerun) > trtl.trtl.RerunInterval {
 		var revertLayer types.LayerID
 		if reverted, revertLayer = trtl.rerunFromGenesis(ctx); reverted {
 			// make sure state is reapplied from far enough back if there was a state reversion.

--- a/tortoise/verifying_tortoise.go
+++ b/tortoise/verifying_tortoise.go
@@ -279,8 +279,8 @@ func (t *turtle) checkBlockAndGetLocalOpinion(
 	voteVector vec,
 	baseBlockLayer types.LayerID,
 	logger log.Logger,
+	inputs map[types.LayerID][]types.BlockID,
 ) bool {
-	inputs := map[types.LayerID][]types.BlockID{}
 	for _, exceptionBlockID := range diffList {
 		lid, exist := t.BlockLayer[exceptionBlockID]
 		if !exist {
@@ -633,7 +633,7 @@ func (t *turtle) processBlock(ctx context.Context, block *types.Block) error {
 		opinion[bid] = abstain
 	}
 	for blk, vote := range baseBlockOpinion {
-		// ignore opinions of very old blocks
+		// ignore opinions on very old blocks
 		_, exist := t.BlockLayer[blk]
 		if !exist {
 			continue
@@ -749,15 +749,16 @@ func (t *turtle) determineBlockGoodness(ctx context.Context, block *types.Block)
 		log.FieldNamed("base_block_id", block.BaseBlock))
 	// Go over all blocks, in order. Mark block i "good" if:
 	// (1) the base block is marked as good
+	inputs := map[types.LayerID][]types.BlockID{}
 	if _, good := t.GoodBlocksIndex[block.BaseBlock]; !good {
 		logger.Debug("base block is not good")
 	} else if baselid, exist := t.BlockLayer[block.BaseBlock]; !exist {
 		logger.With().Error("inconsistent state: base block not found")
 	} else if true &&
 		// (2) all diffs appear after the base block and are consistent with the current local opinion
-		t.checkBlockAndGetLocalOpinion(ctx, block.ForDiff, "support", support, baselid, logger) &&
-		t.checkBlockAndGetLocalOpinion(ctx, block.AgainstDiff, "against", against, baselid, logger) &&
-		t.checkBlockAndGetLocalOpinion(ctx, block.NeutralDiff, "abstain", abstain, baselid, logger) {
+		t.checkBlockAndGetLocalOpinion(ctx, block.ForDiff, "support", support, baselid, logger, inputs) &&
+		t.checkBlockAndGetLocalOpinion(ctx, block.AgainstDiff, "against", against, baselid, logger, inputs) &&
+		t.checkBlockAndGetLocalOpinion(ctx, block.NeutralDiff, "abstain", abstain, baselid, logger, inputs) {
 		logger.Debug("block is good")
 		return true
 	}

--- a/tortoise/verifying_tortoise_test.go
+++ b/tortoise/verifying_tortoise_test.go
@@ -1190,26 +1190,26 @@ func TestCheckBlockAndGetInputVector(t *testing.T) {
 	lg := logtest.New(t)
 
 	// missing block
-	r.False(alg.trtl.checkBlockAndGetLocalOpinion(context.TODO(), diffList, "foo", support, l1ID, lg))
+	r.False(alg.trtl.checkBlockAndGetLocalOpinion(context.TODO(), diffList, "foo", support, l1ID, lg, map[types.LayerID][]types.BlockID{}))
 
 	// exception block older than base block
 	blocks[0].LayerIndex = mesh.GenesisLayer().Index()
 	r.NoError(mdb.AddBlock(blocks[0]))
-	r.False(alg.trtl.checkBlockAndGetLocalOpinion(context.TODO(), diffList, "foo", support, l1ID, lg))
+	r.False(alg.trtl.checkBlockAndGetLocalOpinion(context.TODO(), diffList, "foo", support, l1ID, lg, map[types.LayerID][]types.BlockID{}))
 
 	// missing input vector for layer
 	r.NoError(mdb.AddBlock(blocks[1]))
 	diffList[0] = blocks[1].ID()
-	r.False(alg.trtl.checkBlockAndGetLocalOpinion(context.TODO(), diffList, "foo", support, l1ID, lg))
+	r.False(alg.trtl.checkBlockAndGetLocalOpinion(context.TODO(), diffList, "foo", support, l1ID, lg, map[types.LayerID][]types.BlockID{}))
 
 	// good
 	r.NoError(mdb.SaveLayerInputVectorByID(context.TODO(), l1ID, diffList))
-	r.True(alg.trtl.checkBlockAndGetLocalOpinion(context.TODO(), diffList, "foo", support, l1ID, lg))
+	r.True(alg.trtl.checkBlockAndGetLocalOpinion(context.TODO(), diffList, "foo", support, l1ID, lg, map[types.LayerID][]types.BlockID{}))
 
 	// vote differs from input vector
 	diffList[0] = blocks[2].ID()
 	r.NoError(mdb.AddBlock(blocks[2]))
-	r.False(alg.trtl.checkBlockAndGetLocalOpinion(context.TODO(), diffList, "foo", support, l1ID, lg))
+	r.False(alg.trtl.checkBlockAndGetLocalOpinion(context.TODO(), diffList, "foo", support, l1ID, lg, map[types.LayerID][]types.BlockID{}))
 }
 
 func TestCalculateExceptions(t *testing.T) {

--- a/tortoise/verifying_tortoise_test.go
+++ b/tortoise/verifying_tortoise_test.go
@@ -1161,18 +1161,18 @@ func TestGetLocalBlockOpinion(t *testing.T) {
 	blocks := generateBlocks(t, l1ID, 2, alg.BaseBlock, atxdb, 1)
 
 	// no input vector for recent layer: expect abstain vote
-	vec, err := alg.trtl.getLocalBlockOpinion(context.TODO(), l1ID, blocks[0].ID())
+	vec, err := alg.trtl.getLocalBlockOpinion(context.TODO(), l1ID, blocks[0].ID(), map[types.LayerID][]types.BlockID{})
 	r.NoError(err)
 	r.Equal(abstain, vec)
 
 	// block included in input vector
 	r.NoError(mdb.SaveLayerInputVectorByID(context.TODO(), l1ID, []types.BlockID{blocks[0].ID()}))
-	vec, err = alg.trtl.getLocalBlockOpinion(context.TODO(), l1ID, blocks[0].ID())
+	vec, err = alg.trtl.getLocalBlockOpinion(context.TODO(), l1ID, blocks[0].ID(), map[types.LayerID][]types.BlockID{})
 	r.NoError(err)
 	r.Equal(support, vec)
 
 	// block not included in input vector
-	vec, err = alg.trtl.getLocalBlockOpinion(context.TODO(), l1ID, blocks[1].ID())
+	vec, err = alg.trtl.getLocalBlockOpinion(context.TODO(), l1ID, blocks[1].ID(), map[types.LayerID][]types.BlockID{})
 	r.NoError(err)
 	r.Equal(against, vec)
 }


### PR DESCRIPTION
## Motivation

Processing blocks takes too much time because of the excessive reads from database and slow decoding.

With this change, it takes ~20 seconds to re-run mesh with ~2600 layers. The same amount on cloud miners was taking 3-4 hours to rerun.

```
20004:2021-10-28T14:00:43.848+0300	INFO	15671.trtl         	triggering tortoise full rerun from genesis	{"node_id": "1567169fa686ce24fa13d01390d1269d7603078fc2c82b74705dd5ba5435ec7e", "module": "trtl", "sessionId": "acdac760-8913-4c91-adff-0893407e542f", "layer_id": 2654, "name": "trtl"}
38630:2021-10-28T14:01:02.651+0300	INFO	15671.trtl         	full rerun completed	{"node_id": "1567169fa686ce24fa13d01390d1269d7603078fc2c82b74705dd5ba5435ec7e", "module": "trtl", "sessionId": "acdac760-8913-4c91-adff-0893407e542f", "layer_id": 2654, "name": "trtl"}
38842:2021-10-28T14:02:48.210+0300	INFO	15671.trtl         	triggering tortoise full rerun from genesis	{"node_id": "1567169fa686ce24fa13d01390d1269d7603078fc2c82b74705dd5ba5435ec7e", "module": "trtl", "sessionId": "acdac760-8913-4c91-adff-0893407e542f", "layer_id": 2655, "name": "trtl"}
57507:2021-10-28T14:03:07.446+0300	INFO	15671.trtl         	full rerun completed	{"node_id": "1567169fa686ce24fa13d01390d1269d7603078fc2c82b74705dd5ba5435ec7e", "module": "trtl", "sessionId": "acdac760-8913-4c91-adff-0893407e542f", "layer_id": 2655, "name": "trtl"}
57652:2021-10-28T14:04:49.284+0300	INFO	15671.trtl         	triggering tortoise full rerun from genesis	{"node_id": "1567169fa686ce24fa13d01390d1269d7603078fc2c82b74705dd5ba5435ec7e", "module": "trtl", "sessionId": "acdac760-8913-4c91-adff-0893407e542f", "layer_id": 2656, "name": "trtl"}
76341:2021-10-28T14:05:07.825+0300	INFO	15671.trtl         	full rerun completed	{"node_id": "1567169fa686ce24fa13d01390d1269d7603078fc2c82b74705dd5ba5435ec7e", "module": "trtl", "sessionId": "acdac760-8913-4c91-adff-0893407e542f", "layer_id": 2656, "name": "trtl"}
``` 

There are actually not so many bottlenecks left, all of them related to the number of opinions. I think that once we have a unified block we will be able to drop the persistent state for tortoise completely, and recompute tortoise state on node restart.

This change doesn't have new benchmarks, as there are not good utilities to build good benchmarks, i will add that later. If someone wants i can share profiles. 

related: https://github.com/spacemeshos/go-spacemesh/issues/2852

## Changes
- keep a map to a layer id for blocks in sliding window
- allocate opinions map based on the size of exceptions and opinions in base block
- comment out very slow log 

## Test Plan
existing tests and manual tests

## TODO
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
