### PR TITLE
[Merged by Bors] - cleanup hare round clock with cache

### DIFF
--- a/hare/algorithm_test.go
+++ b/hare/algorithm_test.go
@@ -23,9 +23,9 @@ import (
 
 var cfg = config.Config{N: 10, F: 5, RoundDuration: 2, ExpectedLeaders: 5, LimitIterations: 1000, LimitConcurrent: 1000}
 
-func newRoundClockFromCfg(logger log.Log, cfg config.Config) *RoundClockWithCache {
+func newRoundClockFromCfg(logger log.Log, cfg config.Config) *SimpleRoundClock {
 	logger.Info("creating clock at %v wakeup: %v round duration: %v", time.Now(), cfg.WakeupDelta, cfg.RoundDuration)
-	return NewRoundClockWithCache(time.Now(),
+	return NewSimpleRoundClock(time.Now(),
 		time.Duration(cfg.WakeupDelta)*time.Second,
 		time.Duration(cfg.RoundDuration)*time.Second,
 	)

--- a/hare/clock.go
+++ b/hare/clock.go
@@ -2,71 +2,12 @@ package hare
 
 import (
 	"math"
-	"sync"
 	"time"
 )
 
 // Wakeup has a value of -2 because it occurs exactly two round durations before the end of round 0.
 // This accounts for the duration of round zero and the preround.
 const Wakeup = math.MaxUint32 - 1 // -2
-
-// RoundClockWithCache is a Hare-round clock with a cache that allows repeatedly calling AwaitEndOfRound() and getting
-// the same instance of a timer. The cache management and synchronization require some additional resources.
-type RoundClockWithCache struct {
-	LayerTime     time.Time
-	WakeupDelta   time.Duration
-	RoundDuration time.Duration
-	cache         map[uint32]chan struct{}
-	m             sync.RWMutex
-}
-
-// NewRoundClockWithCache returns a new RoundClockWithCache, given the provided configuration.
-func NewRoundClockWithCache(layerTime time.Time, wakeupDelta, roundDuration time.Duration) *RoundClockWithCache {
-	return &RoundClockWithCache{
-		LayerTime:     layerTime,
-		WakeupDelta:   wakeupDelta,
-		RoundDuration: roundDuration,
-		cache:         make(map[uint32]chan struct{}),
-	}
-}
-
-// AwaitWakeup returns a channel that gets closed when the Hare wakeup delay has passed.
-func (c *RoundClockWithCache) AwaitWakeup() <-chan struct{} {
-	return c.AwaitEndOfRound(Wakeup)
-}
-
-// AwaitEndOfRound returns a channel that gets closed when the given round ends. Repeated calls to this method will
-// return the same instance of the channel and use the same underlying timer.
-func (c *RoundClockWithCache) AwaitEndOfRound(round uint32) <-chan struct{} {
-	c.m.RLock()
-	if ch, ok := c.cache[round]; ok {
-		c.m.RUnlock()
-		return ch
-	}
-	c.m.RUnlock()
-
-	c.m.Lock()
-	defer c.m.Unlock()
-	if ch, ok := c.cache[round]; ok {
-		return ch
-	}
-	ch := make(chan struct{})
-	c.cache[round] = ch
-
-	// The pre-round (which has a value of -1) ends one RoundDuration after the WakeupDelta. Rounds, in general, are
-	// zero-based. By adding 2 to the round number and multiplying by the RoundDuration we get the correct number of
-	// RoundDurations to wait.
-	duration := c.WakeupDelta + (c.RoundDuration * time.Duration(round+2))
-	time.AfterFunc(c.LayerTime.Add(duration).Sub(time.Now()), func() {
-		c.m.Lock()
-		defer c.m.Unlock()
-
-		close(ch)
-		delete(c.cache, round)
-	})
-
-	return ch
-}
 
 // SimpleRoundClock is a simple Hare-round clock. Repeated calls to AwaitEndOfRound() will each return a new channel
 // and will be backed by a new timer which will not be garbage collected until it expires. To avoid leaking resources,

--- a/hare/clock_test.go
+++ b/hare/clock_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestClock_AwaitWakeup(t *testing.T) {
-	c := NewRoundClockWithCache(time.Now(), 10*time.Millisecond, 8*time.Millisecond)
+	c := NewSimpleRoundClock(time.Now(), 10*time.Millisecond, 8*time.Millisecond)
 
 	ch := c.AwaitWakeup()
 	select {
@@ -37,7 +37,7 @@ func TestClock_AwaitRound(t *testing.T) {
 		Add(-(wakeupDelta + (5 * roundDuration))).
 		Add(waitTime)
 
-	c := NewRoundClockWithCache(layerTime, wakeupDelta, roundDuration)
+	c := NewSimpleRoundClock(layerTime, wakeupDelta, roundDuration)
 
 	ch := c.AwaitEndOfRound(3)
 


### PR DESCRIPTION
## Motivation
Cleanup an artifact of developing the Hare Round Clock.

## Changes
Remove `RoundClockWithCache` and replace it with `SimpleRoundClock` in the tests in which it's used.

## Test Plan
Existing tests.

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
