### PR TITLE
tortoise: add more cache for getting local input vector

### DIFF
--- a/tortoise/verifying_tortoise.go
+++ b/tortoise/verifying_tortoise.go
@@ -824,13 +824,6 @@ func (t *turtle) verifyLayers(ctx context.Context) error {
 candidateLayerLoop:
 	for candidateLayerID := t.Verified.Add(1); candidateLayerID.Before(t.Last); candidateLayerID = candidateLayerID.Add(1) {
 		logger := logger.WithFields(log.FieldNamed("candidate_layer", candidateLayerID))
-
-		// it's possible that self healing already verified a layer
-		if !t.Verified.Before(candidateLayerID) {
-			logger.Info("self healing already verified this layer")
-			continue
-		}
-
 		logger.Info("attempting to verify candidate layer")
 
 		// note: if the following checks fail, we just return rather than trying to verify later layers.
@@ -941,10 +934,6 @@ candidateLayerLoop:
 			// between this unverified candidate layer and the latest layer is greater than this distance, then we trigger
 			// self healing. But there's no point in trying to heal a layer that's not at least Hdist layers old since
 			// we only consider the local opinion for recent layers.
-			if candidateLayerID.After(t.Last) {
-				logger.With().Panic("candidate layer is higher than last layer received",
-					log.FieldNamed("last_layer", t.Last))
-			}
 			logger.With().Debug("considering attempting to heal layer",
 				log.FieldNamed("layer_cutoff", t.layerCutoff()),
 				log.Uint32("zdist", t.Zdist),

--- a/tortoise/verifying_tortoise_test.go
+++ b/tortoise/verifying_tortoise_test.go
@@ -190,7 +190,7 @@ func requireVote(t *testing.T, trtl *turtle, vote vec, blocks ...types.BlockID) 
 					continue
 				}
 
-				weight, err := trtl.voteWeightByID(context.TODO(), bid, i)
+				weight, err := trtl.voteWeightByID(context.TODO(), bid)
 				require.NoError(t, err)
 				sum = sum.Add(opinionVote.Multiply(weight))
 			}
@@ -1227,26 +1227,31 @@ func TestCalculateExceptions(t *testing.T) {
 		r.Len(votes[2], numNeutral) // neutral
 	}
 
+	localOpinionsCache := map[types.LayerID][]types.BlockID{}
+
 	// genesis layer
 	l0ID := types.GetEffectiveGenesis()
-	votes, err := alg.trtl.calculateExceptions(context.TODO(), l0ID, Opinion{})
+	votes, err := alg.trtl.calculateExceptions(context.TODO(), l0ID, Opinion{}, localOpinionsCache)
 	r.NoError(err)
 	// expect votes in support of all genesis blocks
 	expectVotes(votes, 0, len(mesh.GenesisLayer().Blocks()), 0)
+	r.Equal(1, len(localOpinionsCache))
 
 	// layer greater than last processed: expect support only for genesis
 	l1ID := l0ID.Add(1)
-	votes, err = alg.trtl.calculateExceptions(context.TODO(), l1ID, Opinion{})
+	votes, err = alg.trtl.calculateExceptions(context.TODO(), l1ID, Opinion{}, localOpinionsCache)
 	r.NoError(err)
 	expectVotes(votes, 0, 1, 0)
+	r.Equal(1, len(localOpinionsCache))
 
 	// now advance the processed layer
 	alg.trtl.Last = l1ID
 
 	// missing layer data
-	votes, err = alg.trtl.calculateExceptions(context.TODO(), l1ID, Opinion{})
+	votes, err = alg.trtl.calculateExceptions(context.TODO(), l1ID, Opinion{}, localOpinionsCache)
 	r.ErrorIs(err, database.ErrNotFound)
 	r.Nil(votes)
+	r.Equal(1, len(localOpinionsCache))
 
 	// layer opinion vector is nil (abstains): recent layer, in mesh, no input vector
 	alg.trtl.Last = l0ID
@@ -1254,38 +1259,45 @@ func TestCalculateExceptions(t *testing.T) {
 	r.NoError(addLayerToMesh(mdb, l1))
 	alg.trtl.Last = l1ID
 	mdb.InputVectorBackupFunc = nil
-	votes, err = alg.trtl.calculateExceptions(context.TODO(), l1ID, Opinion{})
+	votes, err = alg.trtl.calculateExceptions(context.TODO(), l1ID, Opinion{}, localOpinionsCache)
 	r.NoError(err)
 	// expect no against, FOR only for l0, and NEUTRAL for l1
 	expectVotes(votes, 0, len(mesh.GenesisLayer().Blocks()), defaultTestLayerSize)
+	r.Equal(2, len(localOpinionsCache))
 
 	// adding diffs for: support all blocks in the layer
+	localOpinionsCache = map[types.LayerID][]types.BlockID{}
 	mdb.InputVectorBackupFunc = mdb.LayerBlockIds
-	votes, err = alg.trtl.calculateExceptions(context.TODO(), l1ID, Opinion{})
+	votes, err = alg.trtl.calculateExceptions(context.TODO(), l1ID, Opinion{}, localOpinionsCache)
 	r.NoError(err)
 	expectVotes(votes, 0, len(mesh.GenesisLayer().Blocks())+defaultTestLayerSize, 0)
+	r.Equal(2, len(localOpinionsCache))
 
 	// adding diffs against: vote against all blocks in the layer
 	mdb.InputVectorBackupFunc = nil
+	localOpinionsCache = map[types.LayerID][]types.BlockID{}
 	// we cannot store an empty vector here (it comes back as nil), so just put another block ID in it
 	r.NoError(mdb.SaveLayerInputVectorByID(context.TODO(), l1ID, []types.BlockID{mesh.GenesisBlock().ID()}))
-	votes, err = alg.trtl.calculateExceptions(context.TODO(), l1ID, Opinion{})
+	votes, err = alg.trtl.calculateExceptions(context.TODO(), l1ID, Opinion{}, localOpinionsCache)
 	r.NoError(err)
 
 	// we don't explicitly vote against blocks in the layer, we implicitly vote against them by not voting for them
 	expectVotes(votes, 0, len(mesh.GenesisLayer().Blocks()), 0)
+	r.Equal(2, len(localOpinionsCache))
 
 	// compare opinions: all agree, no exceptions
 	mdb.InputVectorBackupFunc = mdb.LayerBlockIds
+	localOpinionsCache = map[types.LayerID][]types.BlockID{}
 	opinion := Opinion{
 		mesh.GenesisBlock().ID(): support,
 		l1.Blocks()[0].ID():      support,
 		l1.Blocks()[1].ID():      support,
 		l1.Blocks()[2].ID():      support,
 	}
-	votes, err = alg.trtl.calculateExceptions(context.TODO(), l1ID, opinion)
+	votes, err = alg.trtl.calculateExceptions(context.TODO(), l1ID, opinion, localOpinionsCache)
 	r.NoError(err)
 	expectVotes(votes, 0, 0, 0)
+	r.Equal(2, len(localOpinionsCache))
 
 	// compare opinions: all disagree, adds exceptions
 	opinion = Opinion{
@@ -1294,9 +1306,10 @@ func TestCalculateExceptions(t *testing.T) {
 		l1.Blocks()[1].ID():      against,
 		l1.Blocks()[2].ID():      against,
 	}
-	votes, err = alg.trtl.calculateExceptions(context.TODO(), l1ID, opinion)
+	votes, err = alg.trtl.calculateExceptions(context.TODO(), l1ID, opinion, localOpinionsCache)
 	r.NoError(err)
 	expectVotes(votes, 0, 4, 0)
+	r.Equal(2, len(localOpinionsCache))
 
 	l2ID := l1ID.Add(1)
 	l3ID := l2ID.Add(1)
@@ -1304,6 +1317,7 @@ func TestCalculateExceptions(t *testing.T) {
 
 	// exceeding max exceptions
 	t.Run("exceeding max exceptions", func(t *testing.T) {
+		localOpinionsCache := map[types.LayerID][]types.BlockID{}
 		alg.trtl.MaxExceptions = 10
 		l2 := createTurtleLayer(t, l2ID, mdb, atxdb, alg.BaseBlock, mdb.LayerBlockIds, alg.trtl.MaxExceptions+1)
 		for _, block := range l2.Blocks() {
@@ -1311,16 +1325,18 @@ func TestCalculateExceptions(t *testing.T) {
 		}
 		l3 = createTurtleLayer(t, l3ID, mdb, atxdb, alg.BaseBlock, mdb.LayerBlockIds, defaultTestLayerSize)
 		alg.trtl.Last = l2ID
-		votes, err = alg.trtl.calculateExceptions(context.TODO(), l2ID, Opinion{})
+		votes, err = alg.trtl.calculateExceptions(context.TODO(), l2ID, Opinion{}, localOpinionsCache)
 		r.Error(err)
 		r.Contains(err.Error(), errstrTooManyExceptions, "expected too many exceptions error")
 		r.Nil(votes)
+		r.Equal(3, len(localOpinionsCache))
 	})
 
 	// TODO: test adding base block opinion in support of a block that disagrees with the local opinion, e.g., a block
 	//   that this node has not seen yet. See https://github.com/spacemeshos/go-spacemesh/issues/2424.
 
 	t.Run("advance sliding window", func(t *testing.T) {
+		localOpinionsCache := map[types.LayerID][]types.BlockID{}
 		// advance the evicted layer until the exception layer slides outside the sliding window
 		for _, block := range l3.Blocks() {
 			r.NoError(mdb.AddBlock(block))
@@ -1335,10 +1351,11 @@ func TestCalculateExceptions(t *testing.T) {
 		l5ID := l4ID.Add(1)
 		createTurtleLayer(t, l5ID, mdb, atxdb, alg.BaseBlock, mdb.LayerBlockIds, defaultTestLayerSize)
 		alg.trtl.Last = l4ID
-		votes, err = alg.trtl.calculateExceptions(context.TODO(), l3ID, Opinion{})
+		votes, err = alg.trtl.calculateExceptions(context.TODO(), l3ID, Opinion{}, localOpinionsCache)
 		r.NoError(err)
 		// expect votes FOR the blocks in the two intervening layers between the base block layer and the last layer
 		expectVotes(votes, 0, 2*defaultTestLayerSize, 0)
+		r.Equal(2, len(localOpinionsCache))
 	})
 }
 
@@ -1351,27 +1368,28 @@ func TestDetermineBlockGoodness(t *testing.T) {
 
 	l1ID := types.GetEffectiveGenesis().Add(1)
 	l1Blocks := generateBlocks(t, l1ID, 3, alg.BaseBlock, atxdb, 1)
+	localOpinionsCache := map[types.LayerID][]types.BlockID{}
 
 	// block marked good
-	r.True(alg.trtl.determineBlockGoodness(context.TODO(), l1Blocks[0]))
+	r.True(alg.trtl.determineBlockGoodness(context.TODO(), l1Blocks[0], localOpinionsCache))
 
 	// base block not found
 	randBlockID := randomBlockID()
 	alg.trtl.GoodBlocksIndex[randBlockID] = false
 	l1Blocks[1].BaseBlock = randBlockID
-	r.False(alg.trtl.determineBlockGoodness(context.TODO(), l1Blocks[1]))
+	r.False(alg.trtl.determineBlockGoodness(context.TODO(), l1Blocks[1], localOpinionsCache))
 
 	// base block not good
 	l1Blocks[1].BaseBlock = l1Blocks[2].ID()
-	r.False(alg.trtl.determineBlockGoodness(context.TODO(), l1Blocks[1]))
+	r.False(alg.trtl.determineBlockGoodness(context.TODO(), l1Blocks[1], localOpinionsCache))
 
 	// diff inconsistent with local opinion
 	l1Blocks[2].AgainstDiff = []types.BlockID{mesh.GenesisBlock().ID()}
-	r.False(alg.trtl.determineBlockGoodness(context.TODO(), l1Blocks[2]))
+	r.False(alg.trtl.determineBlockGoodness(context.TODO(), l1Blocks[2], localOpinionsCache))
 
 	// can run again on the same block with no change (idempotency)
-	r.True(alg.trtl.determineBlockGoodness(context.TODO(), l1Blocks[0]))
-	r.False(alg.trtl.determineBlockGoodness(context.TODO(), l1Blocks[2]))
+	r.True(alg.trtl.determineBlockGoodness(context.TODO(), l1Blocks[0], localOpinionsCache))
+	r.False(alg.trtl.determineBlockGoodness(context.TODO(), l1Blocks[2], localOpinionsCache))
 }
 
 func TestScoreBlocks(t *testing.T) {
@@ -1383,26 +1401,27 @@ func TestScoreBlocks(t *testing.T) {
 
 	l1ID := types.GetEffectiveGenesis().Add(1)
 	l1Blocks := generateBlocks(t, l1ID, 3, alg.BaseBlock, atxdb, 1)
+	localOpinionsCache := map[types.LayerID][]types.BlockID{}
 
 	// adds a block not already marked good
 	r.NotContains(alg.trtl.GoodBlocksIndex, l1Blocks[0].ID())
-	alg.trtl.scoreBlocks(context.TODO(), []*types.Block{l1Blocks[0]})
+	alg.trtl.scoreBlocks(context.TODO(), []*types.Block{l1Blocks[0]}, localOpinionsCache)
 	r.Contains(alg.trtl.GoodBlocksIndex, l1Blocks[0].ID())
 
 	// no change if already marked good
-	alg.trtl.scoreBlocks(context.TODO(), []*types.Block{l1Blocks[0]})
+	alg.trtl.scoreBlocks(context.TODO(), []*types.Block{l1Blocks[0]}, localOpinionsCache)
 	r.Contains(alg.trtl.GoodBlocksIndex, l1Blocks[0].ID())
 
 	// removes a block previously marked good
 	// diff inconsistent with local opinion
 	l1Blocks[0].AgainstDiff = []types.BlockID{mesh.GenesisBlock().ID()}
-	alg.trtl.scoreBlocks(context.TODO(), []*types.Block{l1Blocks[0]})
+	alg.trtl.scoreBlocks(context.TODO(), []*types.Block{l1Blocks[0]}, localOpinionsCache)
 	r.NotContains(alg.trtl.GoodBlocksIndex, l1Blocks[0].ID())
 
 	// try a few blocks
 	r.NotContains(alg.trtl.GoodBlocksIndex, l1Blocks[1].ID())
 	r.NotContains(alg.trtl.GoodBlocksIndex, l1Blocks[2].ID())
-	alg.trtl.scoreBlocks(context.TODO(), l1Blocks)
+	alg.trtl.scoreBlocks(context.TODO(), l1Blocks, localOpinionsCache)
 
 	// adds new blocks
 	r.Contains(alg.trtl.GoodBlocksIndex, l1Blocks[1].ID())
@@ -1711,11 +1730,13 @@ func TestVerifyLayers(t *testing.T) {
 	l6ID := l5ID.Add(1)
 	l6Blocks := generateBlocks(t, l6ID, defaultTestLayerSize, alg.BaseBlock, atxdb, 1)
 
+	localOpinionsCache := map[types.LayerID][]types.BlockID{}
 	// layer missing in database
 	alg.trtl.Last = l2ID
-	err := alg.trtl.verifyLayers(context.TODO())
+	err := alg.trtl.verifyLayers(context.TODO(), localOpinionsCache)
 	r.Error(err)
 	r.Contains(err.Error(), errstrCantFindLayer)
+	r.Equal(0, len(localOpinionsCache))
 
 	// empty layer: local opinion vector is nil, abstains on all blocks in layer
 	// no contextual validity data recorded
@@ -1730,9 +1751,10 @@ func TestVerifyLayers(t *testing.T) {
 		},
 	}
 	alg.trtl.bdp = mdbWrapper
-	err = alg.trtl.verifyLayers(context.TODO())
+	err = alg.trtl.verifyLayers(context.TODO(), localOpinionsCache)
 	r.NoError(err)
 	r.Equal(int(l1ID.Uint32()), int(alg.trtl.Verified.Uint32()))
+	r.Equal(1, len(localOpinionsCache))
 
 	for _, block := range l2Blocks {
 		r.NoError(mdb.AddBlock(block))
@@ -1751,8 +1773,9 @@ func TestVerifyLayers(t *testing.T) {
 	alg.trtl.Last = l3ID
 
 	// voting blocks not marked good, both global and local opinion is abstain, verified layer does not advance
-	r.NoError(alg.trtl.verifyLayers(context.TODO()))
+	r.NoError(alg.trtl.verifyLayers(context.TODO(), localOpinionsCache))
 	r.Equal(int(l1ID.Uint32()), int(alg.trtl.Verified.Uint32()))
+	r.Equal(2, len(localOpinionsCache))
 
 	// now mark voting blocks good
 	alg.trtl.GoodBlocksIndex[l3Blocks[0].ID()] = false
@@ -1768,8 +1791,9 @@ func TestVerifyLayers(t *testing.T) {
 
 	// consensus doesn't match: fail to verify candidate layer
 	// global opinion: good, local opinion: abstain
-	r.NoError(alg.trtl.verifyLayers(context.TODO()))
+	r.NoError(alg.trtl.verifyLayers(context.TODO(), localOpinionsCache))
 	r.Equal(int(l1ID.Uint32()), int(alg.trtl.Verified.Uint32()))
+	r.Equal(2, len(localOpinionsCache))
 
 	// mark local opinion of L2 good so verified layer advances
 	// do the reverse for L3: local opinion is good, global opinion is undecided
@@ -1859,9 +1883,11 @@ func TestVerifyLayers(t *testing.T) {
 	// verified layer advances one step, but L3 is not verified because global opinion is undecided, so verification
 	// stops there
 	t.Run("global opinion undecided", func(t *testing.T) {
-		err = alg.trtl.verifyLayers(context.TODO())
+		localOpinionsCache := map[types.LayerID][]types.BlockID{}
+		err = alg.trtl.verifyLayers(context.TODO(), localOpinionsCache)
 		r.NoError(err)
 		r.Equal(int(l2ID.Uint32()), int(alg.trtl.Verified.Uint32()))
+		r.Equal(2, len(localOpinionsCache))
 	})
 
 	l4Votes = Opinion{
@@ -1877,14 +1903,17 @@ func TestVerifyLayers(t *testing.T) {
 
 	// weight not exceeded
 	t.Run("weight not exceeded", func(t *testing.T) {
+		localOpinionsCache := map[types.LayerID][]types.BlockID{}
 		// modify vote so one block votes in support of L3 blocks, two blocks continue to abstain, so threshold not met
 		alg.trtl.BlockOpinionsByLayer[l4ID][l4Blocks[0].ID()] = l4Votes
-		err = alg.trtl.verifyLayers(context.TODO())
+		err = alg.trtl.verifyLayers(context.TODO(), localOpinionsCache)
 		r.NoError(err)
 		r.Equal(int(l2ID.Uint32()), int(alg.trtl.Verified.Uint32()))
+		r.Equal(1, len(localOpinionsCache))
 	})
 
 	t.Run("healing handoff", func(t *testing.T) {
+		localOpinionsCache := map[types.LayerID][]types.BlockID{}
 		// test self-healing: self-healing can verify layers that are stuck for specific reasons, i.e., where local and
 		// global opinion differ (or local opinion is missing).
 		alg.trtl.Hdist = 1
@@ -1946,8 +1975,9 @@ func TestVerifyLayers(t *testing.T) {
 		// previously stuck layer (l3) and the following layer (l4) since it's old enough, then hand control back to the
 		// ordinary verifying tortoise which should continue and verify l5.
 		alg.trtl.Last = l4ID.Add(alg.trtl.Hdist + 1)
-		r.NoError(alg.trtl.verifyLayers(context.TODO()))
+		r.NoError(alg.trtl.verifyLayers(context.TODO(), localOpinionsCache))
 		r.Equal(int(l5ID.Uint32()), int(alg.trtl.Verified.Uint32()))
+		r.Equal(2, len(localOpinionsCache))
 	})
 }
 
@@ -2381,8 +2411,10 @@ func TestHealBalanceAttack(t *testing.T) {
 
 	// now process l5
 	r.NoError(mdb.SaveLayerInputVectorByID(context.TODO(), l5ID, l5blockIDs))
-	r.NoError(alg.trtl.verifyLayers(context.TODO()))
+	localOpinionsCache := map[types.LayerID][]types.BlockID{}
+	r.NoError(alg.trtl.verifyLayers(context.TODO(), localOpinionsCache))
 	checkVerifiedLayer(t, alg.trtl, l0ID.Add(3))
+	r.Equal(1, len(localOpinionsCache))
 
 	// we can trick calculateExceptions into not adding explicit exception votes for or against this block by
 	// making it think we've already evicted its layer
@@ -2406,7 +2438,7 @@ func TestHealBalanceAttack(t *testing.T) {
 			baseBlockID = l5BaseBlock2
 		}
 
-		evm, err := alg.trtl.calculateExceptions(context.TODO(), l5ID, alg.trtl.BlockOpinionsByLayer[l5ID][baseBlockID])
+		evm, err := alg.trtl.calculateExceptions(context.TODO(), l5ID, alg.trtl.BlockOpinionsByLayer[l5ID][baseBlockID], map[types.LayerID][]types.BlockID{})
 		r.NoError(err)
 		return baseBlockID, [][]types.BlockID{
 			blockMapToArray(evm[0]),


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
add more cache for local input vectors for calculating exceptions, and btwn scoring and verifying layers

## Changes
<!-- Please describe in detail the changes made -->
- for miner: add cache for local input vectors across blocks in the same layer
- for tortoise: share cache btwn good blocks determination and verifying blocks

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->
unit tests


## TODO
<!-- This section should be removed when all items are complete -->
- [ ] Explain motivation or link existing issue(s)
- [ ] Test changes and document test plan
- [ ] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
