### PR TITLE
[Merged by Bors] - add test for healing from vote blocks with different beacon

### DIFF
--- a/tortoise/verifying_tortoise.go
+++ b/tortoise/verifying_tortoise.go
@@ -949,6 +949,7 @@ candidateLayerLoop:
 				log.FieldNamed("last_layer_received", t.Last),
 				log.Uint32("confidence_param", t.ConfidenceParam))
 			if candidateLayerID.Before(t.layerCutoff()) && t.Last.Difference(candidateLayerID) > t.Zdist+t.ConfidenceParam {
+				logger.With().Info("start self-healing with verified layer", t.Verified)
 				lastLayer := t.Last
 				// don't attempt to heal layers newer than Hdist
 				if lastLayer.After(t.layerCutoff()) {
@@ -956,6 +957,7 @@ candidateLayerLoop:
 				}
 				lastVerified := t.Verified
 				t.heal(ctx, lastLayer)
+				logger.With().Info("finished self-healing with verified layer", t.Verified)
 
 				// if self healing made progress, short-circuit processing of this layer, but allow verification of
 				// later layers to continue
@@ -1247,7 +1249,6 @@ func (t *turtle) heal(ctx context.Context, targetLayerID types.LayerID) {
 		pbaseNew = candidateLayerID
 		logger.Info("self healing verified candidate layer")
 	}
-
 	return
 }
 


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
follow-up on https://github.com/spacemeshos/go-spacemesh/pull/2916. add test
<!-- `Closes #XXXX, closes #XXXX, ...` links mentioned issues to this PR and automatically closes them when this it's merged -->

## Changes
<!-- Please describe in detail the changes made -->
add test for healing counting votes from bad beacon blocks

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->
unit test

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
