### PR TITLE
[Merged by Bors] - tortoise/organizer: missed a case for out order layer sent twice

### DIFF
--- a/tortoise/organizer/organizer.go
+++ b/tortoise/organizer/organizer.go
@@ -120,19 +120,22 @@ func (o *Organizer) submitPending(f Callback) {
 	}
 }
 
-type layerBuffer []bool
+type layerBuffer []types.LayerID
 
 func (buf layerBuffer) store(lid types.LayerID) {
 	pos := int(lid.Uint32()) % len(buf)
-	if buf[pos] {
+	if buf[pos] == lid {
+		return
+	}
+	if (buf[pos] != types.LayerID{}) {
 		panic(fmt.Sprintf("invalid state. overwriting non-empty layer %s in the buffer with", lid))
 	}
-	buf[pos] = true
+	buf[pos] = lid
 }
 
 func (buf layerBuffer) pop(lid types.LayerID) bool {
 	pos := int(lid.Uint32()) % len(buf)
 	rst := buf[pos]
-	buf[pos] = false
-	return rst
+	buf[pos] = types.LayerID{}
+	return rst != types.LayerID{}
 }

--- a/tortoise/organizer/organizer_test.go
+++ b/tortoise/organizer/organizer_test.go
@@ -103,6 +103,16 @@ func TestOrder(t *testing.T) {
 			},
 			window: 3,
 		},
+		{
+			desc: "RepeatLayerLargerSubmitted",
+			send: []types.LayerID{
+				types.NewLayerID(4), types.NewLayerID(6), types.NewLayerID(6), types.NewLayerID(5),
+			},
+			expect: []types.LayerID{
+				types.NewLayerID(4), types.NewLayerID(5), types.NewLayerID(6),
+			},
+			window: 3,
+		},
 	} {
 		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {


### PR DESCRIPTION
## Motivation

closes: https://github.com/spacemeshos/go-spacemesh/issues/2932

## Changes
- handle same layer that wasn't submitted

## Test Plan
UT

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
