### PR TITLE
[Merged by Bors] - sync: allow sync to resume when validation takes too long

### DIFF
--- a/syncer/syncer_test.go
+++ b/syncer/syncer_test.go
@@ -39,7 +39,8 @@ type mockLayerTicker struct {
 }
 
 func newMockLayerTicker() *mockLayerTicker {
-	return &mockLayerTicker{current: unsafe.Pointer(&types.LayerID{})}
+	firstLayer := types.NewLayerID(1)
+	return &mockLayerTicker{current: unsafe.Pointer(&firstLayer)}
 }
 
 func (mlt *mockLayerTicker) advanceToLayer(layerID types.LayerID) {
@@ -272,6 +273,8 @@ func TestSynchronize_ValidationTakesTooLong(t *testing.T) {
 					arrivedOldCurrent <- struct{}{}
 					<-finishOldCurrent
 				}
+				// cause mesh's processed layer to advance
+				mm.HandleValidatedLayer(ctx, l, []types.BlockID{})
 			}).Times(1)
 	}
 
@@ -493,7 +496,6 @@ func TestSynchronize_getATXsFailedCurrentEpoch(t *testing.T) {
 	syncer.Start(context.TODO())
 
 	// brings the node to synced state
-	ticker.advanceToLayer(types.NewLayerID(1))
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
@@ -543,7 +545,6 @@ func TestSynchronize_StaySyncedUponFailure(t *testing.T) {
 	syncer.Start(context.TODO())
 
 	// brings the node to synced state
-	ticker.advanceToLayer(types.NewLayerID(1))
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
@@ -583,7 +584,6 @@ func TestSynchronize_BecomeNotSyncedUponFailureIfNoGossip(t *testing.T) {
 	syncer.Start(context.TODO())
 
 	// brings the node to synced state
-	ticker.advanceToLayer(types.NewLayerID(1))
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
Closes #2934
<!-- `Closes #XXXX, closes #XXXX, ...` links mentioned issues to this PR and automatically closes them when this it's merged -->

## Changes
<!-- Please describe in detail the changes made -->
allow for the code to resume the sync loop if the current layer has advanced after validation thread exited

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->
unit tests

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
