### PR TITLE
[Merged by Bors] - api: include layer ID in `AccountMeshDataStream`

### DIFF
--- a/api/grpcserver/grpcserver_test.go
+++ b/api/grpcserver/grpcserver_test.go
@@ -494,7 +494,7 @@ func (m *MempoolMock) Put(id types.TransactionID, tx *types.Transaction) {
 	m.poolByTxid[id] = tx
 	m.poolByAddress[tx.Recipient] = id
 	m.poolByAddress[tx.Origin()] = id
-	events.ReportNewTx(tx)
+	events.ReportNewTx(types.LayerID{}, tx)
 }
 
 // Return a mock estimated nonce and balance that's different than the default, mimicking transactions that are
@@ -1978,7 +1978,7 @@ func TestTransactionService(t *testing.T) {
 			events.CloseEventReporter()
 			err := events.InitializeEventReporterWithOptions("", 1, true)
 			require.NoError(t, err)
-			events.ReportNewTx(globalTx)
+			events.ReportNewTx(types.LayerID{}, globalTx)
 			wg.Wait()
 		}},
 		{"TransactionsStateStream_All", func(t *testing.T) {
@@ -2005,7 +2005,7 @@ func TestTransactionService(t *testing.T) {
 			events.CloseEventReporter()
 			err := events.InitializeEventReporterWithOptions("", 1, true)
 			require.NoError(t, err)
-			events.ReportNewTx(globalTx)
+			events.ReportNewTx(types.LayerID{}, globalTx)
 			wg.Wait()
 		}},
 		// Submit a tx, then receive it over the stream
@@ -2226,14 +2226,14 @@ func TestAccountMeshDataStream_comprehensive(t *testing.T) {
 	require.NoError(t, err)
 
 	// publish a tx
-	events.ReportNewTx(globalTx)
+	events.ReportNewTx(types.LayerID{}, globalTx)
 
 	// publish an activation
 	events.ReportNewActivation(globalAtx)
 
 	// test streaming a tx and an atx that are filtered out
 	// these should not be received
-	events.ReportNewTx(globalTx2)
+	events.ReportNewTx(types.LayerID{}, globalTx2)
 	events.ReportNewActivation(globalAtx2)
 
 	// close the stream

--- a/api/grpcserver/mesh_service.go
+++ b/api/grpcserver/mesh_service.go
@@ -459,7 +459,7 @@ func (s MeshService) AccountMeshDataStream(in *pb.AccountMeshDataStreamRequest, 
 
 	// Subscribe to the stream of transactions and activations
 	var (
-		txStream          chan events.TransactionWithValidity
+		txStream          chan events.TransactionWithLayerAndValidity
 		activationsStream chan *types.ActivationTx
 	)
 	if filterTx {
@@ -509,12 +509,14 @@ func (s MeshService) AccountMeshDataStream(in *pb.AccountMeshDataStreamRequest, 
 				return nil
 			}
 			// Apply address filter
-			// TODO(dshulyak) include layerID when streamed too
 			if tx.Valid && (tx.Transaction.Origin() == addr || tx.Transaction.Recipient == addr) {
 				resp := &pb.AccountMeshDataStreamResponse{
 					Datum: &pb.AccountMeshData{
 						Datum: &pb.AccountMeshData_MeshTransaction{
-							MeshTransaction: &pb.MeshTransaction{Transaction: convertTransaction(tx.Transaction)},
+							MeshTransaction: &pb.MeshTransaction{
+								Transaction: convertTransaction(tx.Transaction),
+								LayerId:     &pb.LayerNumber{Number: tx.LayerID.Uint32()},
+							},
 						},
 					},
 				}

--- a/events/event_test.go
+++ b/events/event_test.go
@@ -74,7 +74,7 @@ func MakeTx(nonce uint64, recipient types.Address, signer *signing.EdSigner) *ty
 
 func TestEventReporter(t *testing.T) {
 	// There should be no error reporting an event before initializing the reporter
-	ReportNewTx(globalTx)
+	ReportNewTx(types.LayerID{}, globalTx)
 
 	// Stream is nil before we initialize it
 	txStream := GetNewTxChannel()
@@ -87,7 +87,7 @@ func TestEventReporter(t *testing.T) {
 
 	// This will not be received as no one is listening
 	// This also makes sure that this call is nonblocking.
-	ReportNewTx(globalTx)
+	ReportNewTx(types.LayerID{}, globalTx)
 
 	// listen on the channel
 	wgListening := sync.WaitGroup{}
@@ -104,14 +104,14 @@ func TestEventReporter(t *testing.T) {
 
 	// Wait until goroutine is listening
 	wgListening.Wait()
-	ReportNewTx(globalTx)
+	ReportNewTx(types.LayerID{}, globalTx)
 
 	// Wait for goroutine to finish
 	wgDone.Wait()
 
 	// This should also not cause an error
 	CloseEventReporter()
-	ReportNewTx(globalTx)
+	ReportNewTx(types.LayerID{}, globalTx)
 }
 
 func TestReportError(t *testing.T) {

--- a/events/reporter.go
+++ b/events/reporter.go
@@ -35,7 +35,7 @@ func EventHook() func(entry zapcore.Entry) error {
 }
 
 // ReportNewTx dispatches incoming events to the reporter singleton.
-func ReportNewTx(tx *types.Transaction) {
+func ReportNewTx(layerID types.LayerID, tx *types.Transaction) {
 	Publish(NewTx{
 		ID:          tx.ID().String(),
 		Origin:      tx.Origin().String(),
@@ -43,15 +43,16 @@ func ReportNewTx(tx *types.Transaction) {
 		Amount:      tx.Amount,
 		Fee:         tx.Fee,
 	})
-	ReportTxWithValidity(tx, true)
+	ReportTxWithValidity(layerID, tx, true)
 }
 
 // ReportTxWithValidity reports a tx along with whether it was just invalidated.
-func ReportTxWithValidity(tx *types.Transaction, valid bool) {
+func ReportTxWithValidity(layerID types.LayerID, tx *types.Transaction, valid bool) {
 	mu.RLock()
 	defer mu.RUnlock()
-	txWithValidity := TransactionWithValidity{
+	txWithValidity := TransactionWithLayerAndValidity{
 		Transaction: tx,
+		LayerID:     layerID,
 		Valid:       valid,
 	}
 	if reporter != nil {
@@ -286,7 +287,7 @@ func ReportAccountUpdate(a types.Address) {
 }
 
 // GetNewTxChannel returns a channel of new transactions.
-func GetNewTxChannel() chan TransactionWithValidity {
+func GetNewTxChannel() chan TransactionWithLayerAndValidity {
 	mu.RLock()
 	defer mu.RUnlock()
 
@@ -470,15 +471,16 @@ type Reward struct {
 	Smesher types.NodeID
 }
 
-// TransactionWithValidity wraps a tx with its validity info.
-type TransactionWithValidity struct {
+// TransactionWithLayerAndValidity wraps a tx with its layer ID and validity info.
+type TransactionWithLayerAndValidity struct {
 	Transaction *types.Transaction
+	LayerID     types.LayerID
 	Valid       bool
 }
 
 // EventReporter is the struct that receives incoming events and dispatches them.
 type EventReporter struct {
-	channelTransaction chan TransactionWithValidity
+	channelTransaction chan TransactionWithLayerAndValidity
 	channelActivation  chan *types.ActivationTx
 	channelLayer       chan LayerUpdate
 	channelError       chan NodeError
@@ -492,7 +494,7 @@ type EventReporter struct {
 
 func newEventReporter(bufsize int, blocking bool) *EventReporter {
 	return &EventReporter{
-		channelTransaction: make(chan TransactionWithValidity, bufsize),
+		channelTransaction: make(chan TransactionWithLayerAndValidity, bufsize),
 		channelActivation:  make(chan *types.ActivationTx, bufsize),
 		channelLayer:       make(chan LayerUpdate, bufsize),
 		channelStatus:      make(chan struct{}, bufsize),

--- a/mempool/tx_pool.go
+++ b/mempool/tx_pool.go
@@ -104,7 +104,7 @@ func (t *TxMempool) Put(id types.TransactionID, tx *types.Transaction) {
 	t.addToAddr(tx.Origin(), id)
 	t.addToAddr(tx.Recipient, id)
 	t.mu.Unlock()
-	events.ReportNewTx(tx)
+	events.ReportNewTx(types.LayerID{}, tx)
 }
 
 // Invalidate removes transaction from pool.
@@ -123,7 +123,7 @@ func (t *TxMempool) Invalidate(id types.TransactionID) {
 			// We only report those transactions that are being dropped from the txpool here as
 			// conflicting since they won't be reported anywhere else. There is no need to report
 			// the initial tx here since it'll be reported as part of a new block/layer anyway.
-			events.ReportTxWithValidity(tx, false)
+			events.ReportTxWithValidity(types.LayerID{}, tx, false)
 		}
 		t.removeFromAddr(tx.Origin(), id)
 		t.removeFromAddr(tx.Recipient, id)

--- a/svm/state/processor.go
+++ b/svm/state/processor.go
@@ -238,7 +238,7 @@ func (tp *TransactionProcessor) Process(txs []*types.Transaction, layerID types.
 			remaining = append(remaining, tx)
 		}
 		events.ReportValidTx(tx, err == nil)
-		events.ReportNewTx(tx)
+		events.ReportNewTx(layerID, tx)
 	}
 	return
 }


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
<!-- Closes # -->
<!-- `Closes #XXXX, closes #XXXX, ...` links mentioned issues to this PR and automatically closes them when this it's merged -->
This PR includes layer ID in transaction streamed by `AccountMeshDataStream`

## Changes
<!-- Please describe in detail the changes made -->
- Add layer ID to `AccountMeshDataStream`

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->
UT

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [ ] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
