### PR TITLE
[Merged by Bors] - sync: only validate a layer when the beacon is available

### DIFF
--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -594,7 +594,7 @@ func (app *App) initServices(ctx context.Context,
 		SyncInterval: time.Duration(app.Config.SyncInterval) * time.Second,
 		AlwaysListen: app.Config.AlwaysListen,
 	}
-	newSyncer := syncer.NewSyncer(ctx, syncerConf, clock, msh, layerFetch, patrol, app.addLogger(SyncLogger, lg))
+	newSyncer := syncer.NewSyncer(ctx, syncerConf, clock, tBeacon, msh, layerFetch, patrol, app.addLogger(SyncLogger, lg))
 	// TODO(dshulyak) this needs to be improved, but dependency graph is a bit complicated
 	tBeacon.SetSyncState(newSyncer)
 	blockOracle := blocks.NewMinerBlockOracle(layerSize, layersPerEpoch, atxDB, tBeacon, vrfSigner, nodeID, newSyncer.ListenToGossip, app.addLogger(BlockOracle, lg))

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -531,9 +531,12 @@ func (s *Syncer) startValidating(ctx context.Context, run uint64, attempt int) (
 			if s.isClosed() {
 				return nil
 			}
-			if s.shouldValidate(layer.Index()) {
-				s.validateLayer(ctx, layer)
+			if !s.shouldValidate(layer.Index()) {
+				// layers should be validated in order. once we skip one layer, there is no point
+				// continuing with later layers
+				break
 			}
+			s.validateLayer(ctx, layer)
 		}
 		close(done)
 		logger.Debug("validation done for run #%v attempt #%v", run, attempt)

--- a/syncer/syncer_test.go
+++ b/syncer/syncer_test.go
@@ -426,8 +426,10 @@ func TestSynchronize_BeaconDelay(t *testing.T) {
 	lyr := gLayer.Add(3)
 	for l := types.NewLayerID(1); !l.After(gLayer.Add(2)); l = l.Add(1) {
 		l := l
+		if !l.GetEpoch().IsGenesis() {
+			beacons.EXPECT().GetBeacon(l.GetEpoch()).Return(l.GetEpoch().ToBytes(), nil).Times(1)
+		}
 		patrol.EXPECT().IsHareInCharge(l).Return(false).Times(1)
-		beacons.EXPECT().GetBeacon(l.GetEpoch()).Return(l.GetEpoch().ToBytes(), nil).Times(1)
 		validator.EXPECT().ValidateLayer(gomock.Any(), gomock.Any()).DoAndReturn(
 			func(ctx context.Context, layer *types.Layer) {
 				assert.Equal(t, l, layer.Index())

--- a/syncer/syncer_test.go
+++ b/syncer/syncer_test.go
@@ -485,13 +485,8 @@ func TestSynchronize_HareValidateLayersTooDelayed(t *testing.T) {
 				mm.HandleValidatedLayer(ctx, l, []types.BlockID{})
 			}).Times(1)
 	}
-	for l := gLayer.Add(1); l.Before(latestLyr); l = l.Add(1) {
-		if l == gLayer.Add(1) {
-			patrol.EXPECT().IsHareInCharge(l).Return(true).Times(1)
-		} else {
-			patrol.EXPECT().IsHareInCharge(l).Return(true).Times(maxAttemptWithinRun)
-		}
-	}
+	patrol.EXPECT().IsHareInCharge(gLayer.Add(1)).Return(true).Times(1)
+	patrol.EXPECT().IsHareInCharge(gLayer.Add(2)).Return(true).Times(maxAttemptWithinRun)
 	// the 1st layer after genesis, despite having hare started consensus protocol for it,
 	// is too much delayed.
 	validator.EXPECT().ValidateLayer(gomock.Any(), gomock.Any()).DoAndReturn(

--- a/syncer/syncer_test.go
+++ b/syncer/syncer_test.go
@@ -119,12 +119,6 @@ func (mv *mockValidator) HandleLateBlocks(_ context.Context, blocks []*types.Blo
 	return blocks[0].Layer(), blocks[0].Layer().Sub(1)
 }
 
-func feedLayerResultNTimes(from, to types.LayerID, mf *mockFetcher, msh *mesh.Mesh, n int) {
-	for i := 0; i < n; i++ {
-		feedLayerResult(from, to, mf, msh)
-	}
-}
-
 func feedLayerResult(from, to types.LayerID, mf *mockFetcher, msh *mesh.Mesh) {
 	for i := from; !i.After(to); i = i.Add(1) {
 		msh.SetZeroBlockLayer(i)
@@ -381,7 +375,7 @@ func TestSynchronize_MaxAttemptWithinRun(t *testing.T) {
 	}()
 
 	// allow synchronize to finish
-	feedLayerResultNTimes(current, lastLayer.Sub(1), mf, mm, maxAttemptWithinRun)
+	feedLayerResult(current, lastLayer.Sub(1), mf, mm)
 	wg.Wait()
 
 	assert.False(t, syncer.stateOnTarget())
@@ -454,10 +448,7 @@ func TestSynchronize_BeaconDelay(t *testing.T) {
 	}()
 
 	// allow synchronize to finish
-	// for 1st attempt
 	feedLayerResult(gLayer.Add(1), lyr, mf, mm)
-	// for 2nd/3rd attempt
-	feedLayerResultNTimes(lyr, lyr, mf, mm, 2)
 	wg.Wait()
 
 	assert.False(t, syncer.stateOnTarget())
@@ -508,10 +499,7 @@ func TestSynchronize_OnlyValidateSomeLayers(t *testing.T) {
 	}()
 
 	// allow synchronize to finish
-	// for 1st attempt
 	feedLayerResult(gLayer.Add(1), lyr, mf, mm)
-	// for 2nd/3rd attempt
-	feedLayerResultNTimes(lyr, lyr, mf, mm, 2)
 	wg.Wait()
 
 	assert.False(t, syncer.stateOnTarget())
@@ -579,10 +567,7 @@ func TestSynchronize_HareValidateLayersTooDelayed(t *testing.T) {
 	}()
 
 	// allow synchronize to finish
-	// for 1st attempt
 	feedLayerResult(gLayer.Add(1), latestLyr.Sub(1), mf, mm)
-	// for 2nd/3rd attempt
-	feedLayerResultNTimes(gLayer.Add(2), latestLyr.Sub(1), mf, mm, 2)
 	wg.Wait()
 
 	assert.False(t, syncer.stateOnTarget())

--- a/tortoise/verifying_tortoise.go
+++ b/tortoise/verifying_tortoise.go
@@ -726,7 +726,7 @@ func (t *turtle) blockHasGoodBeacon(block *types.Block, logger log.Log) bool {
 
 	epochBeacon, err := t.beacons.GetBeacon(layerID.GetEpoch())
 	if err != nil {
-		logger.Error("failed to get beacon for epoch", layerID.GetEpoch())
+		logger.With().Error("failed to get beacon for epoch", layerID.GetEpoch(), log.Err(err))
 		return false
 	}
 


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
Closes #2938
<!-- `Closes #XXXX, closes #XXXX, ...` links mentioned issues to this PR and automatically closes them when this it's merged -->

## Changes
<!-- Please describe in detail the changes made -->
syncer wait for beacon for the epoch is available before asking tortoise to verify a layer

follow-up changes:
- make `HandleIncomingLayer` return right away if beacon value is not available
- force beacon determination when the node has seen all blocks in the epoch

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->
in late nodes system test, when i set `tortoise-beacon-sync-num-blocks` to 50:
with this change, verified layer still get stuck until enough blocks are synced to obtain beacon.
the only difference is that `tortoise.HandleIncomingLayer()` will not get called and cause blocks to mark as not-good and potentially cause base-block selection error and inconsistent state within tortoise.

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
