### PR TITLE
[Merged by Bors] - tortoise: add generator for partition and a negative test case

### DIFF
--- a/tortoise/rerun_test.go
+++ b/tortoise/rerun_test.go
@@ -80,7 +80,7 @@ func TestRerunEvictConcurrent(t *testing.T) {
 	s := sim.New(sim.WithLayerSize(size))
 	s.Setup()
 
-	cfg := defaultConfig(t, s.State.MeshDB, s.State.AtxDB)
+	cfg := defaultConfigFromSimState(t, s.State)
 	cfg.LayerSize = size
 	tortoise := NewVerifyingTortoise(ctx, cfg)
 

--- a/tortoise/sim/generator.go
+++ b/tortoise/sim/generator.go
@@ -5,6 +5,7 @@ import (
 	"math/rand"
 
 	"github.com/spacemeshos/go-spacemesh/activation"
+	"github.com/spacemeshos/go-spacemesh/blocks"
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/mesh"
@@ -42,6 +43,24 @@ func WithPath(path string) GenOpt {
 	}
 }
 
+func withRng(rng *rand.Rand) GenOpt {
+	return func(g *Generator) {
+		g.rng = rng
+	}
+}
+
+func withConf(conf config) GenOpt {
+	return func(g *Generator) {
+		g.conf = conf
+	}
+}
+
+func withLayers(layers []*types.Layer) GenOpt {
+	return func(g *Generator) {
+		g.layers = layers
+	}
+}
+
 type config struct {
 	Path           string
 	FirstLayer     types.LayerID
@@ -52,15 +71,15 @@ type config struct {
 func defaults() config {
 	return config{
 		LayerSize:      30,
-		FirstLayer:     types.GetEffectiveGenesis().Add(1),
 		LayersPerEpoch: types.GetLayersPerEpoch(),
 	}
 }
 
 // State is state that can be used by tortoise.
 type State struct {
-	MeshDB *mesh.DB
-	AtxDB  *activation.DB
+	MeshDB  *mesh.DB
+	AtxDB   *activation.DB
+	Beacons blocks.BeaconGetter
 }
 
 // New creates Generator instance.
@@ -77,9 +96,11 @@ func New(opts ...GenOpt) *Generator {
 	mdb := newMeshDB(g.logger, g.conf)
 	atxdb := newAtxDB(g.logger, mdb, g.conf)
 
-	g.State = State{MeshDB: mdb, AtxDB: atxdb}
+	g.beacons = &beaconStore{}
+	g.State = State{MeshDB: mdb, AtxDB: atxdb, Beacons: g.beacons}
 	g.layers = append(g.layers, mesh.GenesisLayer())
-	g.nextLayer = g.conf.FirstLayer
+	last := g.layers[len(g.layers)-1]
+	g.nextLayer = last.Index().Add(1)
 	return g
 }
 
@@ -96,7 +117,9 @@ type Generator struct {
 	reordered   map[types.LayerID]types.LayerID
 	layers      []*types.Layer
 	activations []types.ATXID
-	keys        []*signing.EdSigner
+
+	beacons *beaconStore
+	keys    []*signing.EdSigner
 }
 
 // SetupOpt configures setup.
@@ -116,9 +139,16 @@ func WithSetupUnitsRange(low, high int) SetupOpt {
 	}
 }
 
+func withBeacon(beacon []byte) SetupOpt {
+	return func(conf *setupConf) {
+		conf.Beacon = beacon
+	}
+}
+
 type setupConf struct {
 	Miners [2]int
 	Units  [2]int
+	Beacon []byte
 }
 
 func defaultSetupConf() setupConf {
@@ -133,6 +163,16 @@ func (g *Generator) Setup(opts ...SetupOpt) {
 	conf := defaultSetupConf()
 	for _, opt := range opts {
 		opt(&conf)
+	}
+
+	// TODO(dshulyak) do we need to support more than one beacon per setup?
+	// tortoise is not really about epochs, the only dependency is to
+	// get the correct beacon based on layer's epoch
+	if conf.Beacon != nil {
+		g.beacons.beacon = conf.Beacon
+	} else {
+		g.beacons.beacon = make([]byte, 32)
+		g.rng.Read(g.beacons.beacon)
 	}
 
 	miners := intInRange(g.rng, conf.Miners)

--- a/tortoise/sim/partition.go
+++ b/tortoise/sim/partition.go
@@ -1,0 +1,132 @@
+package sim
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/log"
+)
+
+// Frac is a shortcut for creating Fraction object.
+func Frac(nominator, denominator int) Fraction {
+	return Fraction{Nominator: nominator, Denominator: denominator}
+}
+
+// Fraction of something.
+type Fraction struct {
+	Nominator, Denominator int
+}
+
+func (f Fraction) String() string {
+	return fmt.Sprintf("%d/%d", f.Nominator, f.Denominator)
+}
+
+// SplitOpt is for configuring partition.
+type SplitOpt func(*splitConf)
+
+// WithPartitions configures number of miners in each partition
+// relative to original Generator.
+func WithPartitions(parts ...Fraction) SplitOpt {
+	return func(c *splitConf) {
+		c.Partitions = parts
+	}
+}
+
+func splitConfDefaults() splitConf {
+	return splitConf{
+		Partitions: []Fraction{Frac(1, 2), Frac(1, 2)},
+	}
+}
+
+type splitConf struct {
+	Partitions []Fraction
+	// TODO(dshulyak) support both transient and full partitions
+	// in transient partition miners still have the same atxs and beacons
+	//
+	// transient partitions can be configured without splitting state, in transient partitions
+	// - votes are splitted
+	// - hare will not reach consensus (or will reach only in one of the partition)
+	// all of this can be done by option to Next
+}
+
+// Split generator into multiple partitions.
+// First generator will use original tortoise state (mesh, activations).
+func (g *Generator) Split(opts ...SplitOpt) []*Generator {
+	conf := splitConfDefaults()
+	for _, opt := range opts {
+		opt(&conf)
+	}
+	if len(conf.Partitions) < 2 {
+		panic("should be atlest two parititions")
+	}
+	gens := make([]*Generator, len(conf.Partitions))
+	total := len(g.activations)
+
+	for i := range gens {
+		part := conf.Partitions[i]
+		if part.Denominator == 0 {
+			panic(fmt.Sprintf("denominator in fraction %v is zero", part))
+		}
+		share := total * int(part.Nominator) / int(part.Denominator)
+		if i == 0 {
+			gens[i] = g
+			g.Setup(WithSetupMinerRange(share, share))
+		} else {
+			layers := make([]*types.Layer, len(g.layers))
+			copy(layers, g.layers)
+			gens[i] = New(
+				withRng(g.rng),
+				withConf(g.conf),
+				withLayers(layers),
+				WithLogger(g.logger),
+			)
+			g.Setup(WithSetupMinerRange(share, share))
+		}
+	}
+	return gens
+}
+
+// Merge other Generator state into this Generator state. This is to simulate state exchange after partition.
+func (g *Generator) Merge(other *Generator) {
+	// don't merge beacon, as it is not supposed to be merged.
+
+	g.activations = append(g.activations, other.activations...)
+	for _, key := range other.keys {
+		for _, existing := range g.keys {
+			if key == existing {
+				continue
+			}
+			g.keys = append(g.keys, key)
+		}
+	}
+
+	for _, atxid := range other.activations {
+		for _, existing := range g.activations {
+			if atxid == existing {
+				continue
+			}
+			atx, err := other.State.AtxDB.GetFullAtx(atxid)
+			if err != nil {
+				g.logger.With().Panic("failed to get atx", atxid, log.Err(err))
+			}
+			if err := g.State.AtxDB.StoreAtx(context.Background(), 0, atx); err != nil {
+				g.logger.With().Panic("failed to save atx", atxid, log.Err(err))
+			}
+			g.activations = append(g.activations, atxid)
+		}
+	}
+
+	for i, layer := range other.layers {
+		for _, block := range layer.Blocks() {
+			rst, _ := g.State.MeshDB.GetBlock(block.ID())
+			if rst != nil {
+				continue
+			}
+			if err := g.State.MeshDB.AddBlock(block); err != nil {
+				g.logger.With().Panic("failed to save block", block.ID(), log.Err(err))
+			}
+			g.layers[i].AddBlock(block)
+		}
+	}
+}

--- a/tortoise/sim/partition.go
+++ b/tortoise/sim/partition.go
@@ -65,13 +65,14 @@ func (g *Generator) Split(opts ...SplitOpt) []*Generator {
 	//  things that should remain the same:
 	// - blocks, contextually valid blocks and input vectors before partition
 	// - activations before partition
+	// - beacons before partition
 
 	conf := splitConfDefaults()
 	for _, opt := range opts {
 		opt(&conf)
 	}
 	if len(conf.Partitions) < 2 {
-		panic("should be atlest two parititions")
+		panic("should be at least two parititions")
 	}
 	gens := make([]*Generator, len(conf.Partitions))
 	total := len(g.activations)

--- a/tortoise/sim/utils.go
+++ b/tortoise/sim/utils.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 
 	"github.com/spacemeshos/go-spacemesh/activation"
+	"github.com/spacemeshos/go-spacemesh/blocks"
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/database"
 	"github.com/spacemeshos/go-spacemesh/log"
@@ -50,4 +51,16 @@ func intInRange(rng *rand.Rand, ints [2]int) int {
 		return ints[0]
 	}
 	return rng.Intn(ints[1]-ints[0]) + ints[0]
+}
+
+var _ blocks.BeaconGetter = (*beaconStore)(nil)
+
+// TODO(dshulyak) replaced it with real beacon store so that we can enable persistence
+// for benchmarks.
+type beaconStore struct {
+	beacon []byte
+}
+
+func (b *beaconStore) GetBeacon(types.EpochID) ([]byte, error) {
+	return b.beacon, nil
 }

--- a/tortoise/verifying_tortoise_test.go
+++ b/tortoise/verifying_tortoise_test.go
@@ -422,7 +422,7 @@ func TestLayerPatterns(t *testing.T) {
 		s.Setup()
 
 		ctx := context.Background()
-		cfg := defaultConfig(t, s.State.MeshDB, s.State.AtxDB)
+		cfg := defaultConfigFromSimState(t, s.State)
 		cfg.LayerSize = size
 		tortoise := NewVerifyingTortoise(ctx, cfg)
 
@@ -444,7 +444,7 @@ func TestLayerPatterns(t *testing.T) {
 		s.Setup()
 
 		ctx := context.Background()
-		cfg := defaultConfig(t, s.State.MeshDB, s.State.AtxDB)
+		cfg := defaultConfigFromSimState(t, s.State)
 		cfg.LayerSize = size
 		tortoise := NewVerifyingTortoise(ctx, cfg)
 
@@ -490,7 +490,7 @@ func TestLayerPatterns(t *testing.T) {
 		s.Setup()
 
 		ctx := context.Background()
-		cfg := defaultConfig(t, s.State.MeshDB, s.State.AtxDB)
+		cfg := defaultConfigFromSimState(t, s.State)
 		cfg.LayerSize = size
 		tortoise := NewVerifyingTortoise(ctx, cfg)
 
@@ -680,7 +680,7 @@ func TestEviction(t *testing.T) {
 	s.Setup()
 
 	ctx := context.Background()
-	cfg := defaultConfig(t, s.State.MeshDB, s.State.AtxDB)
+	cfg := defaultConfigFromSimState(t, s.State)
 	cfg.LayerSize = size
 	tortoise := NewVerifyingTortoise(ctx, cfg)
 	trtl := tortoise.trtl
@@ -950,6 +950,12 @@ func defaultConfig(tb testing.TB, mdb *mesh.DB, atxdb atxDataProvider) Config {
 		RerunInterval:            defaultTestRerunInterval,
 		Log:                      logtest.New(tb),
 	}
+}
+
+func defaultConfigFromSimState(tb testing.TB, state sim.State) Config {
+	cfg := defaultConfig(tb, state.MeshDB, state.AtxDB)
+	cfg.Beacons = state.Beacons
+	return cfg
 }
 
 func defaultAlgorithm(t *testing.T, mdb *mesh.DB) *ThreadSafeVerifyingTortoise {
@@ -2723,7 +2729,7 @@ func TestOutOfOrderLayersAreVerified(t *testing.T) {
 	s.Setup()
 
 	ctx := context.Background()
-	cfg := defaultConfig(t, s.State.MeshDB, s.State.AtxDB)
+	cfg := defaultConfigFromSimState(t, s.State)
 	tortoise := NewVerifyingTortoise(ctx, cfg)
 
 	var (
@@ -2963,7 +2969,7 @@ func TestBaseBlockGenesis(t *testing.T) {
 	ctx := context.Background()
 
 	s := sim.New()
-	cfg := defaultConfig(t, s.State.MeshDB, s.State.AtxDB)
+	cfg := defaultConfigFromSimState(t, s.State)
 	tortoise := NewVerifyingTortoise(ctx, cfg)
 
 	base, exceptions, err := tortoise.BaseBlock(ctx)
@@ -2995,7 +3001,7 @@ func TestBaseBlockEvictedBlock(t *testing.T) {
 	s.Setup()
 
 	ctx := context.Background()
-	cfg := defaultConfig(t, s.State.MeshDB, s.State.AtxDB)
+	cfg := defaultConfigFromSimState(t, s.State)
 	cfg.LayerSize = size
 	cfg.WindowSize = 10
 	tortoise := NewVerifyingTortoise(ctx, cfg)
@@ -3075,7 +3081,7 @@ func TestBaseBlockPrioritization(t *testing.T) {
 			s.Setup()
 
 			ctx := context.Background()
-			cfg := defaultConfig(t, s.State.MeshDB, s.State.AtxDB)
+			cfg := defaultConfigFromSimState(t, s.State)
 			cfg.LayerSize = size
 			cfg.WindowSize = tc.window
 			cfg.Log = logtest.New(t)
@@ -3136,7 +3142,7 @@ func TestWeakCoinVoting(t *testing.T) {
 	s.Setup(sim.WithSetupUnitsRange(1, 1))
 
 	ctx := context.Background()
-	cfg := defaultConfig(t, s.State.MeshDB, s.State.AtxDB)
+	cfg := defaultConfigFromSimState(t, s.State)
 	cfg.LayerSize = size
 	cfg.Hdist = hdist
 	cfg.Zdist = hdist
@@ -3197,7 +3203,7 @@ func TestVoteAgainstSupportedByBaseBlock(t *testing.T) {
 	s.Setup()
 
 	ctx := context.Background()
-	cfg := defaultConfig(t, s.State.MeshDB, s.State.AtxDB)
+	cfg := defaultConfigFromSimState(t, s.State)
 	cfg.LayerSize = size
 	cfg.WindowSize = 1
 	cfg.Hdist = 1 // for eviction
@@ -3339,7 +3345,7 @@ func TestComputeLocalOpinion(t *testing.T) {
 			s.Setup(sim.WithSetupUnitsRange(1, 1))
 
 			ctx := context.Background()
-			cfg := defaultConfig(t, s.State.MeshDB, s.State.AtxDB)
+			cfg := defaultConfigFromSimState(t, s.State)
 			cfg.LayerSize = size
 			cfg.Hdist = hdist
 			cfg.Zdist = hdist

--- a/tortoise/verifying_tortoise_test.go
+++ b/tortoise/verifying_tortoise_test.go
@@ -3364,7 +3364,7 @@ func TestComputeLocalOpinion(t *testing.T) {
 	}
 }
 
-func TestRecoverFromFullPartition(t *testing.T) {
+func TestNetworkDoesNotRecoverFromFullPartition(t *testing.T) {
 	const size = 10
 	s1 := sim.New(
 		sim.WithLayerSize(size),
@@ -3426,9 +3426,8 @@ func TestRecoverFromFullPartition(t *testing.T) {
 	_, verified1, _ = tortoise1.HandleIncomingLayer(ctx, last)
 	require.Equal(t, last.Sub(1), verified1)
 
-	// verify that all blocks that were created in s2 during partition are
-	// contextually valid in s1 state.
-	// this is not the case right, this is a negative test case
+	// succesfull test should verify that all blocks that were created in s2
+	// during partition are contextually valid in s1 state.
 	for lid := partitionStart.Add(1); lid.Before(partitionEnd); lid = lid.Add(1) {
 		bids, err := s2.State.MeshDB.LayerBlockIds(lid)
 		require.NoError(t, err)


### PR DESCRIPTION
## Motivation

Partition simulates splitting states as if the network was separated for longer than an epoch. After split - each par will have its own atx's, beacon and share of miners.

Merge consumes state from another partition, as would happen after state sync.

There is a test TestRecoverFromFullPartition, which confirms that we do not recover from such partition by rerun. I found several issues that prevent from healing:
- rerun should not even try to run verifying tortoise for layers that are before hdist. it always counts votes from good blocks, which prematurely confirms the layer
- we are using layer size and not weight for computing threshold - https://github.com/spacemeshos/go-spacemesh/issues/2946 , because threshold didn't change when we received more atx's we are deciding on validity before we can count votes with bad beacon. if weight would have been doubled we will need more votes and it will make votes from blocks with bad beacon count eventually.

## TODO
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
