### PR TITLE
[Merged by Bors] - tortoise: local threshold should be based on expected weight from last layer

### DIFF
--- a/tortoise/tortoise.go
+++ b/tortoise/tortoise.go
@@ -943,7 +943,7 @@ func (t *turtle) computeLocalOpinion(ctx *tcontext, lid types.LayerID) (map[type
 		return opinion, nil
 	}
 
-	weight, err := computeExpectedVoteWeight(t.atxdb, t.epochWeight, lid, t.Last)
+	weight, err := computeExpectedVoteWeight(t.atxdb, t.epochWeight, t.Last.Sub(1), t.Last)
 	if err != nil {
 		return nil, err
 	}

--- a/tortoise/tortoise_test.go
+++ b/tortoise/tortoise_test.go
@@ -2325,10 +2325,6 @@ func TestMultiTortoise(t *testing.T) {
 		for i := 0; i < healingDistance; i++ {
 			layerID = layerID.Add(1)
 
-			// technically only minority (mdb2) will not make progress without weakcoin
-			mdb1.RecordCoinflip(context.TODO(), layerID, true)
-			mdb2.RecordCoinflip(context.TODO(), layerID, true)
-
 			// these blocks will be nearly identical but they will have different base blocks, since the set of blocks
 			// for recent layers has been bifurcated, so we have to generate and store blocks separately to simulate
 			// an ongoing partition.


### PR DESCRIPTION
## Motivation

It fixes local threshold to use weight from single layer, as per protocol. I messed it up slightly when was refactoring threshold weights.

## Changes
- for local threshold count expected weight only from last processed layer

## Test Plan
unit tests, specifically TestMultiTortoise/unequal_partition_and_rejoin doesn't require weak coin

## TODO
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
