### PR TITLE
[Merged by Bors] - logging: add array/object logging for ballot

### DIFF
--- a/common/types/ballot.go
+++ b/common/types/ballot.go
@@ -173,6 +173,34 @@ func (b *Ballot) Fields() []log.LoggableField {
 	}
 }
 
+// MarshalLogObject implements logging encoder for Ballot.
+func (b *Ballot) MarshalLogObject(encoder log.ObjectEncoder) error {
+	var (
+		activeSetSize = 0
+		beacon        []byte
+	)
+
+	if b.EpochData != nil {
+		activeSetSize = len(b.EpochData.ActiveSet)
+		beacon = b.EpochData.Beacon
+	}
+
+	encoder.AddString("id", b.ID().String())
+	encoder.AddUint32("layer", b.LayerIndex.Value)
+	encoder.AddUint32("epoch", uint32(b.LayerIndex.GetEpoch()))
+	encoder.AddString("smesher", b.SmesherID().String())
+	encoder.AddString("base_ballot", b.BaseBallot.String())
+	encoder.AddInt("supports", len(b.ForDiff))
+	encoder.AddInt("againsts", len(b.AgainstDiff))
+	encoder.AddInt("abstains", len(b.NeutralDiff))
+	encoder.AddString("atx", b.AtxID.String())
+	encoder.AddUint32("eligibility_counter", b.EligibilityProof.J)
+	encoder.AddString("ref_ballot", b.RefBallot.String())
+	encoder.AddInt("active_set_size", activeSetSize)
+	encoder.AddString("beacon", BytesToHash(beacon).ShortString())
+	return nil
+}
+
 // String returns a short prefix of the hex representation of the ID.
 func (id BallotID) String() string {
 	return id.AsHash32().ShortString()

--- a/common/types/block.go
+++ b/common/types/block.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
-	"strings"
 	"sync/atomic"
 
 	"github.com/spacemeshos/ed25519"
@@ -437,13 +436,18 @@ func BlockIDs(blocks []*Block) []BlockID {
 	return ids
 }
 
+type blockIds []BlockID
+
+func (ids blockIds) MarshalLogArray(encoder log.ArrayEncoder) error {
+	for i := range ids {
+		encoder.AppendString(ids[i].String())
+	}
+	return nil
+}
+
 // BlockIdsField returns a list of loggable fields for a given list of BlockIDs.
 func BlockIdsField(ids []BlockID) log.Field {
-	var strs []string
-	for _, a := range ids {
-		strs = append(strs, a.String())
-	}
-	return log.String("block_ids", strings.Join(strs, ", "))
+	return log.Array("block_ids", blockIds(ids))
 }
 
 // Layer contains a list of blocks and their corresponding LayerID.

--- a/log/log.go
+++ b/log/log.go
@@ -162,3 +162,16 @@ func Event() FieldLogger {
 func Panic(msg string, args ...interface{}) {
 	GetLogger().Panic(msg, args...)
 }
+
+type (
+	// ObjectMarshaller is an alias to zapcore.ObjectMarshaller.
+	ObjectMarshaller = zapcore.ObjectMarshaler
+	// ObjectEncoder is an alias to zapcore.ObjectEncoder.
+	ObjectEncoder = zapcore.ObjectEncoder
+	// ArrayMarshaler is an alias to zapcore.ArrayMarshaller.
+	ArrayMarshaler = zapcore.ArrayMarshaler
+	// ArrayMarshalerFunc is an alias to zapcore.ArrayMarshallerFunc.
+	ArrayMarshalerFunc = zapcore.ArrayMarshalerFunc
+	// ArrayEncoder is an alias to zapcore.ArrayEncoder.
+	ArrayEncoder = zapcore.ArrayEncoder
+)

--- a/log/zap.go
+++ b/log/zap.go
@@ -133,6 +133,16 @@ func Err(v error) Field {
 	return Field(zap.NamedError("errmsg", v))
 }
 
+// Object for logging struct fields in namespace.
+func Object(namespace string, object ObjectMarshaller) Field {
+	return Field(zap.Object(namespace, object))
+}
+
+// Array for logging array efficiently.
+func Array(name string, array ArrayMarshaler) Field {
+	return Field(zap.Array(name, array))
+}
+
 // LoggableField as an interface to enable every type to be used as a log field.
 type LoggableField interface {
 	Field() Field

--- a/tortoise/tortoise.go
+++ b/tortoise/tortoise.go
@@ -440,7 +440,7 @@ func (t *turtle) processBallot(ctx context.Context, ballot *types.Ballot) error 
 	// When a new ballot arrives, we look up the ballot it points to in our table,
 	// and add the corresponding vector (multiplied by the ballot weight) to our own vote-totals vector.
 	// We then add the vote difference vector and the explicit vote vector to our vote-totals vector.
-	logger.With().Debug("processing ballot", ballot.Fields()...)
+	logger.With().Debug("processing ballot", log.Object("ballot", ballot))
 
 	logger.With().Debug("ballot adds support for",
 		log.Int("count", len(ballot.ForDiff)),


### PR DESCRIPTION
## Motivation

zap provides interface for logging objects and arrays lazily and in general more efficiently

```
logger.go:130: 2021-12-01T07:20:54.920+0200	DEBUG	processing ballot	{"rerun": true, "last-layer-id": 15, "processing_ballot_id": "9c5c877751", "processing_ballot_layer": 23, "ballot": {"id": "9c5c877751", "layer": 23, "epoch": 5, "smesher": "ab5159b7cff1665ee0060a73886b6f4aa4c5a80cdd8b901cdad96e7361be0b6c", "base_ballot": "1f168bb954", "supports": 10, "againsts": 0, "abstains": 0, "atx": "1ac8d6170f", "eligibility_counter": 0, "ref_ballot": "0000000000", "active_set_size": 15, "beacon": "c5d23f6f3f"}, "name": ""}
    logger.go:130: 2021-12-01T07:20:54.920+0200	DEBUG	ballot adds support for	{"rerun": true, "last-layer-id": 15, "processing_ballot_id": "9c5c877751", "processing_ballot_layer": 23, "count": 10, "block_ids": ["60266206d3", "b961036c75", "9371a9aa73", "4d1b1fe580", "9731751652", "284d6180a6", "6c5e2ea7c3", "d81444af73", "1f168bb954", "7b26f873e1"], "name": ""}
```

for example reduction in allocations is significant in this case:

```
benchmark                             old ns/op     new ns/op     delta
BenchmarkTortoiseLayerHandling-16     900988496     836235873     -7.19%

benchmark                             old allocs     new allocs     delta
BenchmarkTortoiseLayerHandling-16     2612684        1656383        -36.60%

benchmark                             old bytes     new bytes     delta
BenchmarkTortoiseLayerHandling-16     507506576     420751108     -17.09%
```

related: https://github.com/spacemeshos/go-spacemesh/issues/2962

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
