### PR TITLE
[Merged by Bors] - Downgrade levels of too often logs

### DIFF
--- a/blocks/blocks.go
+++ b/blocks/blocks.go
@@ -103,7 +103,7 @@ func (bh *BlockHandler) HandleBlock(ctx context.Context, _ peer.ID, msg []byte) 
 // HandleBlockData handles blocks from gossip and sync.
 func (bh *BlockHandler) HandleBlockData(ctx context.Context, data []byte) error {
 	logger := bh.logger.WithContext(ctx)
-	logger.Info("handling data for new block")
+	logger.Debug("handling data for new block")
 	start := time.Now()
 
 	var blk types.Block

--- a/hare/eligibility/oracle.go
+++ b/hare/eligibility/oracle.go
@@ -267,7 +267,7 @@ func (o *Oracle) prepareEligibilityCheck(ctx context.Context, layer types.LayerI
 		return 0, fixed.Fixed{}, fixed.Fixed{}, true, err
 	}
 
-	logger.With().Info("preparing eligibility check",
+	logger.With().Debug("preparing eligibility check",
 		log.Uint64("miner_weight", minerWeight),
 		log.Uint64("total_weight", totalWeight),
 	)

--- a/log/context.go
+++ b/log/context.go
@@ -95,7 +95,7 @@ func ExtractRequestFields(ctx context.Context) (fields []LoggableField) {
 func WithSessionID(ctx context.Context, sessionID string, fields ...LoggableField) context.Context {
 	// Warn if overwriting
 	if curSessionID, ok := ExtractSessionID(ctx); ok && curSessionID != sessionID {
-		GetLogger().WithContext(ctx).With().Debug("overwriting sessionID in context",
+		GetLogger().WithContext(ctx).With().Info("overwriting sessionID in context",
 			String("old_session_id", curSessionID),
 			String("new_session_id", sessionID))
 	}

--- a/log/context.go
+++ b/log/context.go
@@ -95,7 +95,7 @@ func ExtractRequestFields(ctx context.Context) (fields []LoggableField) {
 func WithSessionID(ctx context.Context, sessionID string, fields ...LoggableField) context.Context {
 	// Warn if overwriting
 	if curSessionID, ok := ExtractSessionID(ctx); ok && curSessionID != sessionID {
-		GetLogger().WithContext(ctx).With().Info("overwriting sessionID in context",
+		GetLogger().WithContext(ctx).With().Debug("overwriting sessionID in context",
 			String("old_session_id", curSessionID),
 			String("new_session_id", sessionID))
 	}

--- a/p2p/handshake/handshake.go
+++ b/p2p/handshake/handshake.go
@@ -103,7 +103,7 @@ func (h *Handshake) start(ctx context.Context, sub event.Subscription) {
 				h.eg.Go(func() error {
 					logger.Debug("handshake with peer")
 					if err := h.Request(ctx, id.Peer); err != nil {
-						logger.Warning("failed to complete handshake with peer",
+						logger.With().Warning("failed to complete handshake with peer",
 							log.Err(err),
 						)
 						_ = h.h.Network().ClosePeer(id.Peer)

--- a/svm/state/processor.go
+++ b/svm/state/processor.go
@@ -186,7 +186,7 @@ func (tp *TransactionProcessor) GetLayerStateRoot(layer types.LayerID) (types.Ha
 // ApplyRewards applies reward reward to miners vector for layer.
 func (tp *TransactionProcessor) ApplyRewards(layer types.LayerID, rewards map[types.Address]uint64) {
 	for account, reward := range rewards {
-		tp.Log.With().Info("reward applied",
+		tp.Log.With().Debug("reward applied",
 			log.String("account", account.Short()),
 			log.Uint64("reward", reward),
 			layer,


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
Related: #2633 
<!-- `Closes #XXXX, closes #XXXX, ...` links mentioned issues to this PR and automatically closes them when this it's merged -->
Some logs currently happen too often and fill the whole screen. Example:

![image](https://user-images.githubusercontent.com/24493220/144420335-062915ca-e8b7-40f2-883e-81101a609a56.png)

Here, the whole screen was filled with a repetitive log within ~100ms. This makes logs storage and lookup more complex.

This PR downgrades levels of such logs.

## Changes
<!-- Please describe in detail the changes made -->
- Downgrade levels of too often logs

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [ ] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
