### PR TITLE
[Merged by Bors] - tortoise: restart verifying by force

### DIFF
--- a/tortoise/full_test.go
+++ b/tortoise/full_test.go
@@ -27,7 +27,7 @@ func TestFullBallotFilter(t *testing.T) {
 			desc:             "Good",
 			badBeaconBallots: map[types.BallotID]struct{}{},
 			ballot:           types.BallotID{1},
-			expect:           true,
+			expect:           false,
 		},
 		{
 			desc: "BadFromRecent",
@@ -38,7 +38,7 @@ func TestFullBallotFilter(t *testing.T) {
 			ballotlid: types.NewLayerID(10),
 			last:      types.NewLayerID(11),
 			distance:  2,
-			expect:    false,
+			expect:    true,
 		},
 		{
 			desc: "BadFromOld",
@@ -49,7 +49,7 @@ func TestFullBallotFilter(t *testing.T) {
 			ballotlid: types.NewLayerID(8),
 			last:      types.NewLayerID(11),
 			distance:  2,
-			expect:    true,
+			expect:    false,
 		},
 	} {
 		tc := tc
@@ -63,7 +63,7 @@ func TestFullBallotFilter(t *testing.T) {
 
 			f := newFullTortoise(config, &state)
 
-			require.Equal(t, tc.expect, f.ballotFilter(tc.ballot, tc.ballotlid))
+			require.Equal(t, tc.expect, f.shouldBeDelayed(tc.ballot, tc.ballotlid))
 		})
 	}
 }

--- a/tortoise/threshold.go
+++ b/tortoise/threshold.go
@@ -98,7 +98,7 @@ func computeThresholdForLayers(config Config, epochWeight map[types.EpochID]weig
 	return threshold
 }
 
-func getConfidenceWindow(config Config, state *commonState, tmode mode) types.LayerID {
+func getVerificationWindow(config Config, state *commonState, tmode mode) types.LayerID {
 	target := state.verified.Add(1)
 	window := state.last
 	if tmode.isFull() && state.last.Difference(target) > config.FullModeVerificationWindow {
@@ -116,7 +116,7 @@ func getConfidenceWindow(config Config, state *commonState, tmode mode) types.La
 func updateThresholds(logger log.Log, config Config, state *commonState, tmode mode) {
 	state.localThreshold = computeLocalThreshold(config, state.epochWeight, state.last)
 
-	window := getConfidenceWindow(config, state, tmode)
+	window := getVerificationWindow(config, state, tmode)
 	if window.Before(state.processed) {
 		window = state.processed
 	}

--- a/tortoise/tortoise.go
+++ b/tortoise/tortoise.go
@@ -631,7 +631,7 @@ func (t *turtle) updateLayerState(logger log.Log, lid types.LayerID) error {
 		}
 		logger.With().Info("computed weight for layers in an epoch", epoch, log.Stringer("weight", layerWeight))
 	}
-	window := getConfidenceWindow(t.Config, &t.commonState, t.mode)
+	window := getVerificationWindow(t.Config, &t.commonState, t.mode)
 	if lastUpdated || window.Before(t.processed) || t.globalThreshold.isNil() {
 		updateThresholds(logger, t.Config, &t.commonState, t.mode)
 	}

--- a/tortoise/tortoise.go
+++ b/tortoise/tortoise.go
@@ -546,8 +546,7 @@ func (t *turtle) processLayer(ctx context.Context, logger log.Log, lid types.Lay
 					for lid := target; !lid.After(t.processed); lid = lid.Add(1) {
 						t.verifying.countVotes(logger, lid, t.getTortoiseBallots(lid))
 					}
-					restarted := t.verifying.verify(logger, target)
-					if restarted && t.mode.isFull() {
+					if t.verifying.verify(logger, target) {
 						t.switchModes(logger)
 					}
 				}

--- a/tortoise/tortoise_test.go
+++ b/tortoise/tortoise_test.go
@@ -1768,7 +1768,7 @@ func TestVoteAgainstSupportedByBaseBallot(t *testing.T) {
 
 	// remove good ballots and genesis to make tortoise select one of the later blocks.
 	delete(tortoise.trtl.ballots, genesis)
-	tortoise.trtl.verifying.goodBallots = map[types.BallotID]struct{}{}
+	tortoise.trtl.verifying.goodBallots = map[types.BallotID]goodness{}
 
 	base, exceptions, err := tortoise.BaseBallot(ctx)
 	require.NoError(t, err)
@@ -2083,7 +2083,7 @@ func TestVerifyLayerByWeightNotSize(t *testing.T) {
 	require.Equal(t, last.Sub(2), verified)
 }
 
-func TestSwitchVerifying(t *testing.T) {
+func TestSwitchVerifyingByUsingFullOutput(t *testing.T) {
 	ctx := context.Background()
 	const size = 10
 	s := sim.New(sim.WithLayerSize(size))
@@ -2112,6 +2112,31 @@ func TestSwitchVerifying(t *testing.T) {
 	require.True(t, tortoise.trtl.mode.isFull(), "full mode")
 	for i := 0; i < 10; i++ {
 		last = s.Next(sim.WithVoteGenerator(tortoiseVoting(tortoise)))
+		_, verified, _ = tortoise.HandleIncomingLayer(ctx, last)
+	}
+	require.Equal(t, last.Sub(1), verified)
+	require.True(t, tortoise.trtl.mode.isVerifying(), "verifying mode")
+}
+
+func TestSwitchVerifyingByChangingGoodness(t *testing.T) {
+	ctx := context.Background()
+	const size = 10
+	s := sim.New(sim.WithLayerSize(size))
+	s.Setup()
+
+	cfg := defaultTestConfig()
+	cfg.LayerSize = size
+	cfg.Hdist = 2
+	cfg.Zdist = 2
+	cfg.WindowSize = 10
+
+	tortoise := tortoiseFromSimState(s.GetState(0), WithLogger(logtest.New(t)), WithConfig(cfg))
+	var last, verified types.LayerID
+	// in the test hare is not working from the start, voters
+	for _, last = range sim.GenLayers(s,
+		sim.WithSequence(20, sim.WithEmptyInputVector()),
+		sim.WithSequence(10),
+	) {
 		_, verified, _ = tortoise.HandleIncomingLayer(ctx, last)
 	}
 	require.Equal(t, last.Sub(1), verified)

--- a/tortoise/verifying.go
+++ b/tortoise/verifying.go
@@ -57,15 +57,11 @@ func (v *verifying) resetWeights() {
 }
 
 func (v *verifying) checkIsGood(ballot types.BallotID) bool {
-	return v.checkGoodness(ballot, good)
+	return v.goodBallots[ballot] == good
 }
 
 func (v *verifying) checkCanBeGood(ballot types.BallotID) bool {
-	return v.checkGoodness(ballot, canBeGood)
-}
-
-func (v *verifying) checkGoodness(ballot types.BallotID, val goodness) bool {
-	return v.goodBallots[ballot] == val
+	return v.goodBallots[ballot] != bad
 }
 
 func (v *verifying) markGoodCut(logger log.Log, lid types.LayerID, ballots []tortoiseBallot) bool {

--- a/tortoise/verifying.go
+++ b/tortoise/verifying.go
@@ -75,6 +75,7 @@ func (v *verifying) markGoodCut(logger log.Log, lid types.LayerID, ballots []tor
 			)
 			v.goodBallots[ballot.id] = good
 			v.goodBallots[ballot.base] = good
+			n++
 		}
 	}
 	return n > 0

--- a/tortoise/verifying.go
+++ b/tortoise/verifying.go
@@ -25,7 +25,7 @@ func (g goodness) String() string {
 const (
 	bad goodness = iota
 	good
-	// canBeGood is for ballots that have are voting consistently with local opinion
+	// canBeGood is for ballots that are voting consistently with local opinion
 	// within base ballot layer up to ballot layer.
 	canBeGood
 )

--- a/tortoise/verifying_test.go
+++ b/tortoise/verifying_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/log/logtest"
 )
 
-func TestVerifyingIsGood(t *testing.T) {
+func TestVerifyingDetermineGoodness(t *testing.T) {
 	goodbase := types.BallotID{0}
 	ballots := []types.BallotID{{1}, {2}, {3}}
 	blocks := []types.BlockID{{11}, {22}, {33}}
@@ -127,7 +127,7 @@ func TestVerifyingIsGood(t *testing.T) {
 
 			v := newVerifying(Config{}, &tc.commonState)
 			v.goodBallots[goodbase] = good
-			require.Equal(t, tc.expect, v.isGood(logger, tc.ballot))
+			require.Equal(t, tc.expect, v.determineGoodness(logger, tc.ballot))
 		})
 	}
 }

--- a/tortoise/verifying_test.go
+++ b/tortoise/verifying_test.go
@@ -18,7 +18,7 @@ func TestVerifyingIsGood(t *testing.T) {
 		desc string
 		commonState
 		ballot tortoiseBallot
-		expect bool
+		expect goodness
 	}{
 		{
 			desc: "BadBeaconBallot",
@@ -35,6 +35,7 @@ func TestVerifyingIsGood(t *testing.T) {
 				badBeaconBallots: map[types.BallotID]struct{}{},
 			},
 			ballot: tortoiseBallot{id: ballots[0], base: ballots[1]},
+			expect: canBeGood,
 		},
 		{
 			desc: "ExceptionBeforeBaseBallot",
@@ -100,6 +101,8 @@ func TestVerifyingIsGood(t *testing.T) {
 				},
 				blockLayer: map[types.BlockID]types.LayerID{
 					blocks[0]: types.NewLayerID(10),
+					blocks[1]: types.NewLayerID(10),
+					blocks[2]: types.NewLayerID(10),
 				},
 				hareOutput: votes{
 					blocks[0]: support,
@@ -115,6 +118,7 @@ func TestVerifyingIsGood(t *testing.T) {
 					blocks[2]: against,
 				},
 			},
+			expect: good,
 		},
 	} {
 		tc := tc
@@ -122,7 +126,7 @@ func TestVerifyingIsGood(t *testing.T) {
 			logger := logtest.New(t)
 
 			v := newVerifying(Config{}, &tc.commonState)
-			v.goodBallots[goodbase] = struct{}{}
+			v.goodBallots[goodbase] = good
 			require.Equal(t, tc.expect, v.isGood(logger, tc.ballot))
 		})
 	}
@@ -245,7 +249,7 @@ func TestVerifyingProcessLayer(t *testing.T) {
 
 			state := genCommonState()
 			v := newVerifying(Config{Hdist: 10}, &state)
-			v.goodBallots[goodbase] = struct{}{}
+			v.goodBallots[goodbase] = good
 
 			for i := range tc.ballots {
 				lid := start.Add(uint32(i + 1))


### PR DESCRIPTION
## Motivation

when tortoise sees that some ballots started to vote consistently with local opinion it tries to bootstrap a verifying mode. in order to bootstrap a verifying mode it needs to find a cut of ballots that vote consistently with local opinion

| block/ballot | local opinion | 0xaa | 0xbb | 0xcc | 0xdd | 0xee | 0xff |
| ------------ | ------------- | ---- | ---- | ---- | ---- | ---- | ---- |
| base         | -             | -    | -    | 0xaa | 0xaa | 0xcc | 0xcc |
| layer        | -             | 10   | 10   | 11   | 11   | 12   | 12   |
| 0x11         | 1             | -1   | -1   | 1    | -1   | 1    | 1    |
| 0x22         | 1             | -1   | -1   | 1    | -1   | 1    | 1    |
| 0x33         | -1            | -    | -    | -1   | -1   | -1   | -1   |
| 0x44         | -1            | -    | -    | -1   | -1   | -1   | -1   |
| 0x55         | 1             | -    | -    | -    | -    | 1    | 1    |
| 0x66         | -1            | -    | -    | -    | -    | -1   | -1   |

In this example ballots starting from layer 10 are voting for some old layer (for example 5). Ballots from layer 10 disagree with local opinion and will be marked bad. Ballot 0xcc from layer 10 and ballots 0xee and 0xff will be marked "can be good" because votes from those ballots are consistent with local opinion. 0xee -> 0xcc and 0xff -> 0xcc is sufficient to bootstrap verifying tortoise.

closes: https://github.com/spacemeshos/go-spacemesh/issues/2985
closes: https://github.com/spacemeshos/go-spacemesh/issues/2678

## Changes
- try to bootstrap tortoise into verifying mode even if there are no good in the memory

## Test Plan
uts

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
