### PR TITLE
[Merged by Bors] - mesh: maintain a separate list of ballots and proposals

### DIFF
--- a/mesh/meshdb_test.go
+++ b/mesh/meshdb_test.go
@@ -55,7 +55,7 @@ func TestMeshDB_New_Proposal(t *testing.T) {
 }
 
 func TestMeshDB_AddBallot(t *testing.T) {
-	mdb, err := NewPersistentMeshDB(Path+"/mesh_db/", 1, logtest.New(t))
+	mdb, err := NewPersistentMeshDB(t.TempDir(), 1, logtest.New(t))
 	require.NoError(t, err)
 	defer mdb.Close()
 
@@ -80,6 +80,11 @@ func TestMeshDB_AddBallot(t *testing.T) {
 	gotNew, err := mdb.GetBallot(ballot.ID())
 	require.NoError(t, err)
 	assert.Equal(t, got, gotNew)
+
+	ballots, err := mdb.LayerBallots(gotNew.LayerIndex)
+	require.NoError(t, err)
+	require.Len(t, ballots, 1)
+	require.Equal(t, gotNew, ballots[0])
 }
 
 func TestMeshDB_AddBlockNotCached(t *testing.T) {


### PR DESCRIPTION
## Motivation

HandleBallotData wasn't (and can't) update list of proposals, but we still need to keep database state consistent.

closes: https://github.com/spacemeshos/go-spacemesh/issues/3015

## Changes
- keep a list of ballots that gets updated every time AddBallot is called

## Test Plan
uts

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
