### PR TITLE
[Merged by Bors] - cmd/node, log: fatal logs have fatal level instead of error

### DIFF
--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -97,11 +97,9 @@ var Cmd = &cobra.Command{
 		conf, err := LoadConfigFromFile()
 		if err != nil {
 			log.With().Fatal("can't load config file", log.Err(err))
-			return
 		}
 		if err := cmdp.EnsureCLIFlags(cmd, conf); err != nil {
 			log.With().Fatal("can't ensure that cli flags match config value types", log.Err(err))
-			return
 		}
 
 		if conf.TestMode {

--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -96,11 +96,11 @@ var Cmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		conf, err := LoadConfigFromFile()
 		if err != nil {
-			log.With().Error("can't load config file", log.Err(err))
+			log.With().Fatal("can't load config file", log.Err(err))
 			return
 		}
 		if err := cmdp.EnsureCLIFlags(cmd, conf); err != nil {
-			log.With().Error("can't ensure that cli flags match config value types", log.Err(err))
+			log.With().Fatal("can't ensure that cli flags match config value types", log.Err(err))
 			return
 		}
 
@@ -118,12 +118,10 @@ var Cmd = &cobra.Command{
 		)
 		starter := func() error {
 			if err := app.Initialize(); err != nil {
-				log.With().Error("Failed to initialize node.", log.Err(err))
 				return fmt.Errorf("init node: %w", err)
 			}
 			// This blocks until the context is finished or until an error is produced
 			if err := app.Start(); err != nil {
-				log.With().Error("Failed to start the node. See logs for details.", log.Err(err))
 				return fmt.Errorf("start node: %w", err)
 			}
 
@@ -132,7 +130,7 @@ var Cmd = &cobra.Command{
 		err = starter()
 		app.Cleanup()
 		if err != nil {
-			os.Exit(1)
+			log.With().Fatal("Failed to run the node. See logs for details.", log.Err(err))
 		}
 	},
 }

--- a/log/zap.go
+++ b/log/zap.go
@@ -272,3 +272,8 @@ func (fl FieldLogger) Warning(msg string, fields ...LoggableField) {
 func (fl FieldLogger) Panic(msg string, fields ...LoggableField) {
 	fl.l.Panic(msg, unpack(append(fields, String("name", fl.name)))...)
 }
+
+// Fatal prints message with fields.
+func (fl FieldLogger) Fatal(msg string, fields ...LoggableField) {
+	fl.l.Fatal(msg, unpack(append(fields, String("name", fl.name)))...)
+}


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
Closes #3029
<!-- `Closes #XXXX, closes #XXXX, ...` links mentioned issues to this PR and automatically closes them when this it's merged -->

## Changes
<!-- Please describe in detail the changes made -->
- fatal logs have fatal level instead of error

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->
Manual testing

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [ ] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
