### PR TITLE
tortoise: count abstain votes as consistent with any opinion

### DIFF
--- a/tortoise/verifying.go
+++ b/tortoise/verifying.go
@@ -178,6 +178,11 @@ func (v *verifying) determineGoodness(logger log.Log, ballot tortoiseBallot) goo
 			return bad
 		}
 
+		// by protocol abstain vote is consistent with any opinion
+		if vote == abstain {
+			continue
+		}
+
 		if localVote, reason := getLocalVote(v.commonState, v.Config, blocklid, block); localVote != vote {
 			logger.With().Debug("ballot is not good. vote on a block doesn't match a local vote",
 				log.Stringer("local_vote", localVote),

--- a/tortoise/verifying_test.go
+++ b/tortoise/verifying_test.go
@@ -120,6 +120,34 @@ func TestVerifyingDetermineGoodness(t *testing.T) {
 			},
 			expect: good,
 		},
+		{
+			desc: "BallotWithAbstainVote",
+			commonState: commonState{
+				badBeaconBallots: map[types.BallotID]struct{}{},
+				ballotLayer: map[types.BallotID]types.LayerID{
+					goodbase: types.NewLayerID(10),
+				},
+				blockLayer: map[types.BlockID]types.LayerID{
+					blocks[0]: types.NewLayerID(10),
+					blocks[1]: types.NewLayerID(10),
+					blocks[2]: types.NewLayerID(10),
+				},
+				hareOutput: votes{
+					blocks[0]: support,
+					blocks[1]: against,
+					blocks[2]: against,
+				},
+			},
+			ballot: tortoiseBallot{
+				id: ballots[0], base: goodbase,
+				votes: votes{
+					blocks[0]: abstain,
+					blocks[1]: abstain,
+					blocks[2]: abstain,
+				},
+			},
+			expect: good,
+		},
 	} {
 		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {


### PR DESCRIPTION
The problem is that goodness definition as it is implemented right now is not compatible with abstain votes and zdist. So if tortoise votes for a layer that is not yet terminated - during rerun node will be forced into full mode. It could be also forced into full mode during live-run but it is less critical because full mode is not expensive at that point  

closes: https://github.com/spacemeshos/go-spacemesh/issues/3032

changes:
- abstain vote is consistent with any opinion 

