### PR TITLE
[Merged by Bors] - tortoise: recompute verification window when switching into full mode

### DIFF
--- a/tortoise/full.go
+++ b/tortoise/full.go
@@ -93,7 +93,7 @@ func (f *full) countVotesFromBallots(logger log.Log, ballotlid types.LayerID, ba
 	}
 }
 
-func (f *full) countVotes(logger log.Log) {
+func (f *full) countLayerVotes(logger log.Log, lid types.LayerID) {
 	for front := f.delayedQueue.Front(); front != nil; {
 		delayed := front.Value.(delayedBallots)
 		if f.last.Difference(delayed.lid) <= f.BadBeaconVoteDelayLayers {
@@ -110,8 +110,12 @@ func (f *full) countVotes(logger log.Log) {
 		f.delayedQueue.Remove(front)
 		front = next
 	}
+	f.countVotesFromBallots(logger, lid, f.ballots[lid])
+}
+
+func (f *full) countVotes(logger log.Log) {
 	for lid := f.counted.Add(1); !lid.After(f.processed); lid = lid.Add(1) {
-		f.countVotesFromBallots(logger, lid, f.ballots[lid])
+		f.countLayerVotes(logger, lid)
 	}
 	f.counted = f.processed
 }

--- a/tortoise/full.go
+++ b/tortoise/full.go
@@ -128,7 +128,7 @@ func (f *full) countVotes(logger log.Log) {
 func (f *full) verify(logger log.Log, lid types.LayerID) bool {
 	logger = logger.WithFields(
 		log.String("verifier", fullTortoise),
-		log.Stringer("processed_layer", f.processed),
+		log.Stringer("counted_layer", f.counted),
 		log.Stringer("candidate_layer", lid),
 		log.Stringer("local_threshold", f.localThreshold),
 		log.Stringer("global_threshold", f.globalThreshold),

--- a/tortoise/full.go
+++ b/tortoise/full.go
@@ -94,6 +94,11 @@ func (f *full) countVotesFromBallots(logger log.Log, ballotlid types.LayerID, ba
 }
 
 func (f *full) countLayerVotes(logger log.Log, lid types.LayerID) {
+	if lid.After(f.counted) {
+		f.counted = lid
+	} else {
+		return
+	}
 	for front := f.delayedQueue.Front(); front != nil; {
 		delayed := front.Value.(delayedBallots)
 		if f.last.Difference(delayed.lid) <= f.BadBeaconVoteDelayLayers {

--- a/tortoise/full.go
+++ b/tortoise/full.go
@@ -94,11 +94,11 @@ func (f *full) countVotesFromBallots(logger log.Log, ballotlid types.LayerID, ba
 }
 
 func (f *full) countLayerVotes(logger log.Log, lid types.LayerID) {
-	if lid.After(f.counted) {
-		f.counted = lid
-	} else {
+	if !lid.After(f.counted) {
 		return
 	}
+	f.counted = lid
+
 	for front := f.delayedQueue.Front(); front != nil; {
 		delayed := front.Value.(delayedBallots)
 		if f.last.Difference(delayed.lid) <= f.BadBeaconVoteDelayLayers {

--- a/tortoise/full.go
+++ b/tortoise/full.go
@@ -128,6 +128,7 @@ func (f *full) countVotes(logger log.Log) {
 func (f *full) verify(logger log.Log, lid types.LayerID) bool {
 	logger = logger.WithFields(
 		log.String("verifier", fullTortoise),
+		log.Stringer("processed_layer", f.processed),
 		log.Stringer("candidate_layer", lid),
 		log.Stringer("local_threshold", f.localThreshold),
 		log.Stringer("global_threshold", f.globalThreshold),

--- a/tortoise/rerun_test.go
+++ b/tortoise/rerun_test.go
@@ -52,6 +52,15 @@ func TestRecoverState(t *testing.T) {
 }
 
 func TestRerunDistanceVoteCounting(t *testing.T) {
+	t.Run("FixesMisverified", func(t *testing.T) {
+		testWindowCounting(t, 3, 100, 10, true)
+	})
+	t.Run("ShortWindow", func(t *testing.T) {
+		testWindowCounting(t, 3, 100, 3, false)
+	})
+}
+
+func testWindowCounting(tb testing.TB, maliciousLayers, verifyingWindow, fullWindow int, expectedValidity bool) {
 	genesis := types.GetEffectiveGenesis()
 	ctx := context.Background()
 	const size = 10
@@ -62,44 +71,41 @@ func TestRerunDistanceVoteCounting(t *testing.T) {
 	cfg.LayerSize = size
 	cfg.Hdist = 1
 	cfg.Zdist = 1
+	cfg.FullModeVerificationWindow = uint32(fullWindow)
 
-	tortoise := tortoiseFromSimState(s.GetState(0), WithLogger(logtest.New(t)), WithConfig(cfg))
+	tortoise := tortoiseFromSimState(s.GetState(0), WithLogger(logtest.New(tb)), WithConfig(cfg))
 	var last, verified types.LayerID
 
-	const firstBatch = 5
+	const firstBatch = 2
 	misverified := genesis.Add(firstBatch)
+
 	for _, last = range sim.GenLayers(s,
 		sim.WithSequence(firstBatch, sim.WithEmptyHareOutput()),
-		// in this layer voting is malicious, and it will make that misverified layer will be invalid
-		sim.WithSequence(1, sim.WithVoteGenerator(gapVote)),
-		// in this layer we skip previously malicious voting
-		sim.WithSequence(1, sim.WithVoteGenerator(gapVote)),
-		sim.WithSequence(5),
+		// in this layer voting is malicious. it doesn't support previous layer so there will be no valid blocks in it
+		sim.WithSequence(1, sim.WithVoteGenerator(gapVote), sim.WithEmptyHareOutput()),
+		sim.WithSequence(maliciousLayers-1, sim.WithEmptyHareOutput()),
+		// in this layer we skip previously malicious voting.
+		sim.WithSequence(1, sim.WithVoteGenerator(skipLayers(maliciousLayers)), sim.WithEmptyHareOutput()),
+		sim.WithSequence(10, sim.WithEmptyHareOutput()),
 	) {
 		_, verified, _ = tortoise.HandleIncomingLayer(ctx, last)
 	}
-	require.Equal(t, last.Sub(1), verified)
+	require.Equal(tb, last.Sub(1), verified)
 
 	blocks, err := s.GetState(0).MeshDB.LayerBlockIds(misverified)
-	require.NoError(t, err)
+	require.NoError(tb, err)
 	for _, block := range blocks {
 		validity, err := s.GetState(0).MeshDB.ContextualValidity(block)
-		require.NoError(t, err)
-		require.False(t, validity, "validity for block %s", block)
+		require.NoError(tb, err)
+		require.False(tb, validity, "validity for block %s", block)
 	}
-	require.NoError(t, tortoise.rerun(ctx))
+	require.NoError(tb, tortoise.rerun(ctx))
 
 	for _, block := range blocks {
 		validity, err := s.GetState(0).MeshDB.ContextualValidity(block)
-		require.NoError(t, err)
-		require.True(t, validity, "validity for block %s", block)
+		require.NoError(tb, err)
+		require.Equal(tb, expectedValidity, validity, "validity for block %s", block)
 	}
-
-	last = s.Next()
-	previous, verified, reverted := tortoise.HandleIncomingLayer(ctx, last)
-	require.True(t, reverted, "should be reverted")
-	require.Equal(t, misverified, previous.Add(1))
-	require.Equal(t, last.Sub(1), verified)
 }
 
 func BenchmarkRerun(b *testing.B) {

--- a/tortoise/rerun_test.go
+++ b/tortoise/rerun_test.go
@@ -70,7 +70,7 @@ func TestRerunDistanceVoteCounting(t *testing.T) {
 	misverified := genesis.Add(firstBatch)
 	for _, last = range sim.GenLayers(s,
 		sim.WithSequence(firstBatch, sim.WithEmptyHareOutput()),
-		// in this layer voting is malicious, and it will make that misverified layer will be all invalid
+		// in this layer voting is malicious, and it will make that misverified layer will be invalid
 		sim.WithSequence(1, sim.WithVoteGenerator(gapVote)),
 		// in this layer we skip previously malicious voting
 		sim.WithSequence(1, sim.WithVoteGenerator(gapVote)),

--- a/tortoise/threshold.go
+++ b/tortoise/threshold.go
@@ -116,10 +116,8 @@ func getVerificationWindow(config Config, state *commonState, tmode mode) types.
 func updateThresholds(logger log.Log, config Config, state *commonState, tmode mode) {
 	state.localThreshold = computeLocalThreshold(config, state.epochWeight, state.last)
 
-	window := getVerificationWindow(config, state, tmode)
-	if window.Before(state.processed) {
-		window = state.processed
-	}
+	window := maxLayer(getVerificationWindow(config, state, tmode), state.processed)
+
 	target := state.verified.Add(1)
 	state.globalThreshold = computeThresholdForLayers(config, state.epochWeight, target, window)
 	state.globalThreshold = state.globalThreshold.add(state.localThreshold)

--- a/tortoise/threshold.go
+++ b/tortoise/threshold.go
@@ -107,11 +107,14 @@ func getVerificationWindow(config Config, tmode mode, target, last types.LayerID
 	return last
 }
 
-func computeThresholds(logger log.Log, config Config, tmode mode, target, last, processed types.LayerID, epochWeight map[types.EpochID]weight) (weight, weight) {
+func computeThresholds(logger log.Log, config Config, tmode mode,
+	target, last, processed types.LayerID,
+	epochWeight map[types.EpochID]weight,
+) (local, global weight) {
 	localThreshold := computeLocalThreshold(config, epochWeight, last)
-
-	window := maxLayer(getVerificationWindow(config, tmode, target, last), processed)
-
-	globalThreshold := computeThresholdForLayers(config, epochWeight, target, window)
+	globalThreshold := computeThresholdForLayers(config, epochWeight,
+		target,
+		maxLayer(getVerificationWindow(config, tmode, target, last), processed),
+	)
 	return localThreshold, globalThreshold.add(localThreshold)
 }

--- a/tortoise/threshold_test.go
+++ b/tortoise/threshold_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/log/logtest"
 )
 
-func TestUpdateThresholds(t *testing.T) {
+func TestComputeThreshold(t *testing.T) {
 	genesis := types.GetEffectiveGenesis()
 
 	for _, tc := range []struct {
@@ -75,15 +75,12 @@ func TestUpdateThresholds(t *testing.T) {
 	} {
 		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
-			state := commonState{
-				epochWeight: tc.epochWeight,
-				processed:   tc.processed,
-				last:        tc.last,
-				verified:    tc.verified,
-			}
-			updateThresholds(logtest.New(t), tc.config, &state, tc.mode)
-			require.Equal(t, tc.expectedLocal.String(), state.localThreshold.String())
-			require.Equal(t, tc.expectedGlobal.String(), state.globalThreshold.String())
+			local, global := computeThresholds(
+				logtest.New(t), tc.config, tc.mode,
+				tc.verified.Add(1), tc.last, tc.processed, tc.epochWeight,
+			)
+			require.Equal(t, tc.expectedLocal.String(), local.String())
+			require.Equal(t, tc.expectedGlobal.String(), global.String())
 		})
 	}
 }

--- a/tortoise/tortoise_test.go
+++ b/tortoise/tortoise_test.go
@@ -1374,7 +1374,7 @@ func skipLayers(n int) sim.VotesGenerator {
 	return func(rng *mrand.Rand, layers []*types.Layer, _ int) sim.Voting {
 		position := n + 1
 		if len(layers) < position {
-			panic(fmt.Sprintf("need atleast %d layers", position))
+			panic(fmt.Sprintf("need at least %d layers", position))
 		}
 		baseLayer := layers[len(layers)-position]
 		support := layers[len(layers)-position].BlocksIDs()

--- a/tortoise/tortoise_test.go
+++ b/tortoise/tortoise_test.go
@@ -1366,15 +1366,22 @@ func TestGetBallotBeacon(t *testing.T) {
 }
 
 // gapVote will skip one layer in voting.
-func gapVote(rng *mrand.Rand, layers []*types.Layer, _ int) sim.Voting {
-	if len(layers) < 2 {
-		panic("need atleast 2 layers")
+func gapVote(rng *mrand.Rand, layers []*types.Layer, i int) sim.Voting {
+	return skipLayers(1)(rng, layers, i)
+}
+
+func skipLayers(n int) sim.VotesGenerator {
+	return func(rng *mrand.Rand, layers []*types.Layer, _ int) sim.Voting {
+		position := n + 1
+		if len(layers) < position {
+			panic(fmt.Sprintf("need atleast %d layers", position))
+		}
+		baseLayer := layers[len(layers)-position]
+		support := layers[len(layers)-position].BlocksIDs()
+		ballots := baseLayer.Ballots()
+		base := ballots[rng.Intn(len(ballots))]
+		return sim.Voting{Base: base.ID(), Support: support}
 	}
-	baseLayer := layers[len(layers)-2]
-	support := layers[len(layers)-2].BlocksIDs()
-	ballots := baseLayer.Ballots()
-	base := ballots[rng.Intn(len(ballots))]
-	return sim.Voting{Base: base.ID(), Support: support}
 }
 
 // olderExceptions will vote for block older then base ballot.

--- a/tortoise/util.go
+++ b/tortoise/util.go
@@ -204,3 +204,10 @@ func (m mode) isVerifying() bool {
 func (m mode) isFull() bool {
 	return m[0]
 }
+
+func maxLayer(i, j types.LayerID) types.LayerID {
+	if i.After(j) {
+		return i
+	}
+	return j
+}

--- a/tortoise/verifying_test.go
+++ b/tortoise/verifying_test.go
@@ -365,7 +365,10 @@ func TestVerifyingVerifyLayers(t *testing.T) {
 			state.blocks = tc.blocks
 			state.hareOutput = tc.localOpinion
 
-			updateThresholds(logger, tc.config, &state, mode{})
+			state.localThreshold, state.globalThreshold = computeThresholds(logger, tc.config, mode{},
+				state.verified.Add(1), state.processed, state.processed,
+				state.epochWeight,
+			)
 
 			v := newVerifying(tc.config, &state)
 			v.layerWeights = tc.layersWeight
@@ -375,7 +378,10 @@ func TestVerifyingVerifyLayers(t *testing.T) {
 					return false
 				}
 				state.verified = lid
-				updateThresholds(logger, tc.config, &state, mode{})
+				state.localThreshold, state.globalThreshold = computeThresholds(logger, tc.config, mode{},
+					state.verified.Add(1), state.processed, state.processed,
+					state.epochWeight,
+				)
 				return true
 			})
 			require.Equal(t, tc.expected, state.verified)


### PR DESCRIPTION
## Motivation

verifying has a large verification window (think 1_000_000) and if it failed to verify layer the threshold will be computed according to that window. if we won't reset the threshold full tortoise will have to count votes for 1_000_000 layers before
any layer can be expected to get verified. this is infeasible given current performance of the full tortoise and may take weeks to finish.

closes https://github.com/spacemeshos/go-spacemesh/issues/3009

## Changes
- compute thresholds according to the full tortoise configuration when in full mode

## Test Plan
TestRerunDistanceVoteCounting
