### PR TITLE
[Merged by Bors] - mesh, hare: fallback to sync if we don't have data to process the layer

### DIFF
--- a/hare/flows_test.go
+++ b/hare/flows_test.go
@@ -188,6 +188,7 @@ func createTestHare(t testing.TB, tcfg config.Config, clock *mockClock, pid p2p.
 	ctrl := gomock.NewController(t)
 	patrol := mocks.NewMocklayerPatrol(ctrl)
 	patrol.EXPECT().SetHareInCharge(gomock.Any()).AnyTimes()
+	patrol.EXPECT().CompleteHare(gomock.Any()).AnyTimes()
 	mockBeacons := smocks.NewMockBeaconGetter(ctrl)
 	mockBeacons.EXPECT().GetBeacon(gomock.Any()).Return(types.EmptyBeacon, nil).AnyTimes()
 	mockIDProvider := mocks.NewMockidentityProvider(ctrl)

--- a/hare/hare.go
+++ b/hare/hare.go
@@ -216,6 +216,8 @@ var ErrTooLate = errors.New("consensus process finished too late")
 // records the provided output.
 func (h *Hare) collectOutput(ctx context.Context, output TerminationOutput) error {
 	layerID := output.ID()
+	defer h.patrol.CompleteHare(layerID)
+
 	var pids []types.ProposalID
 	if output.Completed() {
 		h.WithContext(ctx).With().Info("hare terminated with success", layerID, log.Int("num_proposals", output.Set().Size()))

--- a/hare/interfaces.go
+++ b/hare/interfaces.go
@@ -10,6 +10,7 @@ import (
 
 type layerPatrol interface {
 	SetHareInCharge(types.LayerID)
+	CompleteHare(types.LayerID)
 }
 
 // Rolacle is the roles oracle provider.

--- a/hare/mocks/mocks.go
+++ b/hare/mocks/mocks.go
@@ -35,6 +35,18 @@ func (m *MocklayerPatrol) EXPECT() *MocklayerPatrolMockRecorder {
 	return m.recorder
 }
 
+// CompleteHare mocks base method.
+func (m *MocklayerPatrol) CompleteHare(arg0 types.LayerID) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "CompleteHare", arg0)
+}
+
+// CompleteHare indicates an expected call of CompleteHare.
+func (mr *MocklayerPatrolMockRecorder) CompleteHare(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CompleteHare", reflect.TypeOf((*MocklayerPatrol)(nil).CompleteHare), arg0)
+}
+
 // SetHareInCharge mocks base method.
 func (m *MocklayerPatrol) SetHareInCharge(arg0 types.LayerID) {
 	m.ctrl.T.Helper()

--- a/layerpatrol/layer_patrol.go
+++ b/layerpatrol/layer_patrol.go
@@ -42,3 +42,10 @@ func (lp *LayerPatrol) IsHareInCharge(layerID types.LayerID) bool {
 	_, ok := lp.runByHare[layerID]
 	return ok
 }
+
+// CompleteHare is called by hare instance that completed this layer.
+func (lp *LayerPatrol) CompleteHare(layerID types.LayerID) {
+	lp.mu.Lock()
+	defer lp.mu.Unlock()
+	delete(lp.runByHare, layerID)
+}

--- a/layerpatrol/layer_patrol_test.go
+++ b/layerpatrol/layer_patrol_test.go
@@ -19,5 +19,9 @@ func Test_GetAndSetHareInCharge(t *testing.T) {
 	// the original layer should no longer be in the buffer
 	assert.False(t, patrol.IsHareInCharge(lyr))
 	// but the next one is still there
-	assert.True(t, patrol.IsHareInCharge(lyr.Add(1)))
+	exists := lyr.Add(1)
+	assert.True(t, patrol.IsHareInCharge(exists))
+
+	patrol.CompleteHare(exists)
+	assert.False(t, patrol.IsHareInCharge(exists))
 }

--- a/mesh/mesh_test.go
+++ b/mesh/mesh_test.go
@@ -739,6 +739,7 @@ func TestMesh_ReverifyFailed(t *testing.T) {
 	// no calls to svm state, as layer will be failed earlier
 	require.Error(t, tm.ProcessLayer(ctx, last))
 	require.Equal(t, last, tm.ProcessedLayer())
+	require.Equal(t, last, tm.missingLayer)
 	require.Equal(t, last.Sub(1), tm.LatestLayerInState())
 
 	last = last.Add(1)
@@ -752,6 +753,7 @@ func TestMesh_ReverifyFailed(t *testing.T) {
 		tm.ProcessLayer(ctx, lid)
 	}
 
+	require.Empty(t, tm.MissingLayer())
 	require.Equal(t, last, tm.ProcessedLayer())
 	require.Equal(t, last, tm.LatestLayerInState())
 }

--- a/mesh/mesh_test.go
+++ b/mesh/mesh_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/database"
@@ -61,7 +60,7 @@ type testMesh struct {
 func createTestMesh(t *testing.T) *testMesh {
 	t.Helper()
 	types.SetLayersPerEpoch(3)
-	lg := logtest.New(t, zapcore.DebugLevel)
+	lg := logtest.New(t)
 	mmdb := NewMemMeshDB(lg)
 	ctrl := gomock.NewController(t)
 	tm := &testMesh{
@@ -711,4 +710,107 @@ func TestMesh_AddBlockWithTXs(t *testing.T) {
 		txns := getTxns(t, tm.DB, tx.Origin())
 		r.Len(txns, 1)
 	}
+}
+
+func TestMesh_ReverifyFailed(t *testing.T) {
+	tm := createTestMesh(t)
+	defer tm.ctrl.Finish()
+	defer tm.Close()
+
+	ctx := context.TODO()
+	genesis := types.GetEffectiveGenesis()
+	last := genesis.Add(10)
+
+	for lid := genesis.Add(1); !lid.After(last); lid = lid.Add(1) {
+		tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gomock.Any()).
+			Return(lid.Sub(1), lid, false)
+		tm.mockState.EXPECT().GetStateRoot()
+		tm.SetZeroBlockLayer(lid)
+		tm.ProcessLayer(ctx, lid)
+	}
+
+	require.Equal(t, last, tm.ProcessedLayer())
+	require.Equal(t, last, tm.LatestLayerInState())
+
+	last = last.Add(1)
+	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gomock.Any()).
+		Return(last.Sub(1), last, false)
+
+	// no calls to svm state, as layer will be failed earlier
+	require.Error(t, tm.ProcessLayer(ctx, last))
+	require.Equal(t, last, tm.ProcessedLayer())
+	require.Equal(t, last.Sub(1), tm.LatestLayerInState())
+
+	last = last.Add(1)
+	for lid := last.Sub(1); !lid.After(last); lid = lid.Add(1) {
+		tm.SetZeroBlockLayer(lid)
+		tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gomock.Any()).
+			Return(lid, last, false)
+		tm.mockState.EXPECT().GetStateRoot()
+	}
+	for lid := last.Sub(1); !lid.After(last); lid = lid.Add(1) {
+		tm.ProcessLayer(ctx, lid)
+	}
+
+	require.Equal(t, last, tm.ProcessedLayer())
+	require.Equal(t, last, tm.LatestLayerInState())
+}
+
+func TestMesh_MissingTransactionsFailure(t *testing.T) {
+	tm := createTestMesh(t)
+	defer tm.ctrl.Finish()
+	defer tm.Close()
+
+	ctx := context.TODO()
+	genesis := types.GetEffectiveGenesis()
+	last := genesis.Add(1)
+
+	block := types.Block{}
+	block.LayerIndex = last
+	block.TxIDs = []types.TransactionID{{1, 1, 1}}
+	require.NoError(t, tm.AddBlock(&block))
+	require.NoError(t, tm.SaveContextualValidity(block.ID(), last, true))
+
+	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gomock.Any()).
+		Return(genesis, last, false)
+
+	tm.ProcessLayer(ctx, last)
+	require.Equal(t, last, tm.ProcessedLayer())
+	require.Equal(t, genesis, tm.LatestLayerInState())
+}
+
+func TestMesh_ResetAppliedOnRevert(t *testing.T) {
+	tm := createTestMesh(t)
+	defer tm.ctrl.Finish()
+	defer tm.Close()
+
+	ctx := context.TODO()
+	genesis := types.GetEffectiveGenesis()
+	last := genesis.Add(10)
+
+	for lid := genesis.Add(1); lid.Before(last); lid = lid.Add(1) {
+		tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gomock.Any()).
+			Return(lid.Sub(1), lid, false)
+		tm.mockState.EXPECT().GetStateRoot()
+		tm.SetZeroBlockLayer(lid)
+		require.NoError(t, tm.ProcessLayer(ctx, lid))
+	}
+
+	require.Equal(t, last.Sub(1), tm.ProcessedLayer())
+	require.Equal(t, last.Sub(1), tm.LatestLayerInState())
+
+	failed := genesis.Add(2)
+	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gomock.Any()).
+		Return(failed.Sub(1), last, true)
+	tm.mockState.EXPECT().Rewind(failed.Sub(1))
+
+	block := types.Block{}
+	block.LayerIndex = failed
+	block.TxIDs = []types.TransactionID{{1, 1, 1}}
+	require.NoError(t, tm.AddBlock(&block))
+	require.NoError(t, tm.SaveContextualValidity(block.ID(), failed, true))
+	tm.ProcessLayer(ctx, last)
+
+	require.Equal(t, last, tm.ProcessedLayer())
+	require.Equal(t, failed.Sub(1), tm.LatestLayerInState())
 }


### PR DESCRIPTION
## Motivation

when blocks are applied to the state node needs to have all transactions that are referenced by those blocks. blocks are applied to the state only after tortoise validates them. so if at the time of validation we are missing transactions from blocks that are valid according to the tortoise node needs to fall back to sync and loop until it fetches all transactions referenced by valid blocks.

why not to enforce data availability when blocks are received from the network (e.g. in handler)?
--

any node can propose a block and reference non-existing transactions. because of that, we can't loop in sync indefinitely until we download transactions for all blocks that are sent to us from peers. at some point, sync has to give up on fetching transactions from any random block, and if the node misses some transactions it should vote against the block. however if according to the tortoise block is valid then it means that majority of the smeshers have transactions and node should continue trying to download transactions from that block, as it doesn't have any other choice. 

closes: https://github.com/spacemeshos/go-spacemesh/issues/3039

## Changes
- if valid blocks or transactions from valid blocks are missing terminate layer verification
- allow sync to pick up layer immediately without waiting additional time
- add a variable to the mesh called MissingLayer, it is updated if layer is failed to be applied to the state and reset to null if this layer eventually succeeds
- sync watches MissingLayer variable and will try to download it when the layer is not null value
