### PR TITLE
[Merged by Bors] - tortoise: support abstain votes in verifying tortoise

### DIFF
--- a/tortoise/sim/votes.go
+++ b/tortoise/sim/votes.go
@@ -23,3 +23,13 @@ func PerfectVoting(rng *rand.Rand, layers []*types.Layer, _ int) Voting {
 	base := ballots[rng.Intn(len(ballots))]
 	return Voting{Base: base.ID(), Against: against, Support: support}
 }
+
+// VaryingVoting votes using first generator for ballots before mid, and with second generator after mid.
+func VaryingVoting(mid int, first, second VotesGenerator) VotesGenerator {
+	return func(rng *rand.Rand, layers []*types.Layer, i int) Voting {
+		if i < mid {
+			return first(rng, layers, i)
+		}
+		return second(rng, layers, i)
+	}
+}

--- a/tortoise/tortoise.go
+++ b/tortoise/tortoise.go
@@ -149,7 +149,8 @@ func (t *turtle) evict(ctx context.Context) {
 		}
 		delete(t.blocks, lid)
 		delete(t.undecided, lid)
-		delete(t.verifying.layerWeights, lid)
+		delete(t.verifying.goodWeight, lid)
+		delete(t.verifying.abstainedWeight, lid)
 		if lid.GetEpoch() < oldestEpoch {
 			delete(t.refBallotBeacons, lid.GetEpoch())
 			delete(t.epochWeight, lid.GetEpoch())

--- a/tortoise/util.go
+++ b/tortoise/util.go
@@ -67,6 +67,9 @@ func (w weight) add(other weight) weight {
 }
 
 func (w weight) sub(other weight) weight {
+	if other.Rat == nil {
+		return w
+	}
 	w.Rat.Sub(w.Rat, other.Rat)
 	return w
 }

--- a/tortoise/verifying.go
+++ b/tortoise/verifying.go
@@ -109,7 +109,6 @@ func (v *verifying) countVotes(logger log.Log, lid types.LayerID, ballots []tort
 	goodWeight, goodBallotsCount := v.countGoodBallots(logger, ballots)
 
 	v.goodWeight[lid] = goodWeight
-	v.abstainedWeight[lid] = weightFromInt64(0)
 	v.totalGoodWeight = v.totalGoodWeight.add(goodWeight)
 
 	logger.With().Info("counted weight from good ballots",
@@ -189,6 +188,9 @@ func (v *verifying) countGoodBallots(logger log.Log, ballots []tortoiseBallot) (
 		if rst == good || rst == abstained {
 			sum = sum.add(ballot.weight)
 			for lid := range ballot.abstain {
+				if _, exist := v.abstainedWeight[lid]; !exist {
+					v.abstainedWeight[lid] = weightFromFloat64(0)
+				}
 				v.abstainedWeight[lid].add(ballot.weight)
 			}
 			n++
@@ -235,6 +237,7 @@ func (v *verifying) determineGoodness(logger log.Log, ballot tortoiseBallot) goo
 	base := v.goodBallots[ballot.base]
 
 	if len(ballot.abstain) > 0 {
+		logger.With().Debug("ballot has abstained on some layers", log.Stringer("base_goodness", base))
 		switch base {
 		case good:
 			return abstained

--- a/tortoise/verifying.go
+++ b/tortoise/verifying.go
@@ -234,8 +234,13 @@ func (v *verifying) determineGoodness(logger log.Log, ballot tortoiseBallot) goo
 
 	base := v.goodBallots[ballot.base]
 
-	if base == good && len(ballot.abstain) > 0 {
-		return abstained
+	if len(ballot.abstain) > 0 {
+		switch base {
+		case good:
+			return abstained
+		default:
+			return bad
+		}
 	}
 
 	if base != good {

--- a/tortoise/verifying.go
+++ b/tortoise/verifying.go
@@ -31,9 +31,9 @@ const (
 	// but it doesn't count weight for abstained layers.
 	//
 	// for voting tortoise still prioritizes good ballots, ballots that selects base ballot
-	// that abstained will not be marked as a bad ballot. this condition is necessary
+	// that abstained will be marked as a bad ballot. this condition is necessary
 	// to simplify implementation. otherwise verifying tortoise needs to copy abstained
-	// votes from base ballot if they weren't fixed.
+	// votes from base ballot if they tortoise hasn't terminated yet.
 	//
 	// Example:
 	// Block: 0x01 Layer: 9
@@ -144,7 +144,7 @@ func (v *verifying) verify(logger log.Log, lid types.LayerID) bool {
 		log.String("verifier", verifyingTortoise),
 		log.Stringer("candidate_layer", lid),
 		log.Stringer("margin", margin),
-		log.Stringer("asbtained_weight", v.abstainedWeight[lid]),
+		log.Stringer("abstained_weight", v.abstainedWeight[lid]),
 		log.Stringer("local_threshold", v.localThreshold),
 		log.Stringer("global_threshold", v.globalThreshold),
 	)

--- a/tortoise/verifying_test.go
+++ b/tortoise/verifying_test.go
@@ -254,8 +254,8 @@ func TestVerifyingProcessLayer(t *testing.T) {
 			for i := range tc.ballots {
 				lid := start.Add(uint32(i + 1))
 				v.countVotes(logger, lid, tc.ballots[i])
-				require.Equal(t, tc.layerWeights[i], v.layerWeights[lid])
-				require.Equal(t, tc.total[i], v.totalWeight)
+				require.Equal(t, tc.layerWeights[i], v.goodWeight[lid])
+				require.Equal(t, tc.total[i], v.totalGoodWeight)
 			}
 		})
 	}
@@ -371,8 +371,8 @@ func TestVerifyingVerifyLayers(t *testing.T) {
 			)
 
 			v := newVerifying(tc.config, &state)
-			v.layerWeights = tc.layersWeight
-			v.totalWeight = tc.totalWeight
+			v.goodWeight = tc.layersWeight
+			v.totalGoodWeight = tc.totalWeight
 			iterateLayers(tc.verified.Add(1), tc.processed.Sub(1), func(lid types.LayerID) bool {
 				if !v.verify(logger, lid) {
 					return false
@@ -385,7 +385,7 @@ func TestVerifyingVerifyLayers(t *testing.T) {
 				return true
 			})
 			require.Equal(t, tc.expected, state.verified)
-			require.Equal(t, tc.expectedTotalWeight.String(), v.totalWeight.String())
+			require.Equal(t, tc.expectedTotalWeight.String(), v.totalGoodWeight.String())
 		})
 	}
 }


### PR DESCRIPTION
## Motivation

ballots may vote abstain for a layer if the hare instance didn't terminate
for that layer. verifying tortoise counts weight from those ballots
but it doesn't count weight for abstained layers.
	
for voting tortoise still prioritizes good ballots, ballots that selects base ballot
that abstained will be marked as a bad ballot. this condition is necessary
to simplify implementation. otherwise verifying tortoise needs to copy abstained
votes from the base ballot if they weren't fixed.
	
Example:
Block: 0x01 Layer: 9
Ballot: 0xaa Layer: 11 Votes: {Base: 0x01, Support: [0x01], Abstain: [10]}
Assuming that Support is consistent with local opinion, verifying tortoise
will count the weight from this ballot for layer 9, but not for layer 10.

closes: https://github.com/spacemeshos/go-spacemesh/issues/3032

## Changes
- introduce abstained state in verifying tortoise
- reduce margin by abstained weight when layer is being verified

## Test Plan
additional unit tests
