### PR TITLE
[Merged by Bors] - tortoise: load validity for all blocks

### DIFF
--- a/tortoise/tortoise.go
+++ b/tortoise/tortoise.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/database"
 	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/system"
 	"github.com/spacemeshos/go-spacemesh/tortoise/metrics"
@@ -377,7 +378,7 @@ func (t *turtle) encodeVotes(
 // in the current layer.
 func (t *turtle) getFullVote(ctx context.Context, lid types.LayerID, bid types.BlockID) (sign, voteReason, error) {
 	vote, reason := getLocalVote(&t.commonState, t.Config, lid, bid)
-	if !(vote == abstain && reason == reasonValiditiy) {
+	if !(vote == abstain && reason == reasonValidity) {
 		return vote, reason, nil
 	}
 	sum := t.full.weights[bid]
@@ -771,12 +772,19 @@ func (t *turtle) addLocalVotes(ctx context.Context, logger log.Log, lid types.La
 	if !lid.After(t.historicallyVerified) {
 		// this layer has been verified, so we should be able to read the set of contextual blocks
 		logger.Debug("using contextually valid blocks as opinion on old, verified layer")
-		valid, err := t.bdp.LayerContextuallyValidBlocks(ctx, lid)
-		if err != nil {
-			return fmt.Errorf("failed to load contextually balid blocks for layer %s: %w", lid, err)
-		}
-		for bid := range valid {
-			t.validity[bid] = support
+		for _, bid := range t.blocks[lid] {
+			valid, err := t.bdp.ContextualValidity(bid)
+			if errors.Is(err, database.ErrNotFound) {
+				continue
+			}
+			if err != nil {
+				return fmt.Errorf("failed to load contextually validiy for block %s: %w", bid, err)
+			}
+			sign := support
+			if !valid {
+				sign = abstain
+			}
+			t.validity[bid] = sign
 		}
 		return nil
 	}
@@ -809,10 +817,9 @@ func getLocalVote(state *commonState, config Config, lid types.LayerID, block ty
 		}
 		return against, reasonHareOutput
 	}
-
 	vote, exists := state.validity[block]
 	if exists {
-		return vote, reasonValiditiy
+		return vote, reasonValidity
 	}
-	return abstain, reasonValiditiy
+	return abstain, reasonValidity
 }

--- a/tortoise/tortoise.go
+++ b/tortoise/tortoise.go
@@ -782,7 +782,7 @@ func (t *turtle) addLocalVotes(ctx context.Context, logger log.Log, lid types.La
 			}
 			sign := support
 			if !valid {
-				sign = abstain
+				sign = against
 			}
 			t.validity[bid] = sign
 		}

--- a/tortoise/util.go
+++ b/tortoise/util.go
@@ -160,7 +160,7 @@ func (v voteReason) String() string {
 
 const (
 	reasonHareOutput     voteReason = "hare"
-	reasonValiditiy      voteReason = "validity"
+	reasonValidity       voteReason = "validity"
 	reasonLocalThreshold voteReason = "local_threshold"
 	reasonCoinflip       voteReason = "coinflip"
 )


### PR DESCRIPTION
## Motivation

During rerun tortoise should reload contextual validity for all blocks, otherwise tortoise will think that opinion on some old block is abstain, which will prevent verifying tortoise from making progress.

## Changes
- load contextual validity for all blocks

## Test Plan
TestRerunStaysInVerifyingMode and BenchmarkRerun/Verifying/*
