### PR TITLE
[Merged by Bors] - mesh: prefixes in the same space should not overlap

### DIFF
--- a/common/types/block.go
+++ b/common/types/block.go
@@ -21,6 +21,11 @@ type BlockID Hash20
 // EmptyBlockID is a canonical empty BlockID.
 var EmptyBlockID = BlockID{}
 
+// NewExistingBlock creates a block from existing data.
+func NewExistingBlock(id BlockID, inner InnerBlock) *Block {
+	return &Block{blockID: id, InnerBlock: inner}
+}
+
 // Block contains the content of a layer on the mesh history.
 type Block struct {
 	InnerBlock

--- a/mesh/meshdb.go
+++ b/mesh/meshdb.go
@@ -20,8 +20,8 @@ import (
 const (
 	layerSize = 200
 
-	layerBlocks  = "k"
-	layerBallots = "a"
+	layerBlocks  = "b"
+	layerBallots = "bL"
 )
 
 // DB represents a mesh database instance.

--- a/mesh/meshdb.go
+++ b/mesh/meshdb.go
@@ -21,7 +21,7 @@ const (
 	layerSize = 200
 
 	layerBlocks  = "b"
-	layerBallots = "bL"
+	layerBallots = "a"
 )
 
 // DB represents a mesh database instance.

--- a/mesh/meshdb.go
+++ b/mesh/meshdb.go
@@ -22,8 +22,6 @@ const (
 
 	layerBlocks  = "k"
 	layerBallots = "a"
-	// ProposalPrefix is used in proposal module.
-	ProposalPrefix = "p"
 )
 
 // DB represents a mesh database instance.

--- a/mesh/meshdb.go
+++ b/mesh/meshdb.go
@@ -21,7 +21,7 @@ const (
 	layerSize = 200
 
 	layerBlocks  = "b"
-	layerBallots = "a"
+	layerBallots = "l"
 )
 
 // DB represents a mesh database instance.

--- a/mesh/meshdb.go
+++ b/mesh/meshdb.go
@@ -20,8 +20,10 @@ import (
 const (
 	layerSize = 200
 
-	layerBlocks  = "bL"
-	layerBallots = "b"
+	layerBlocks  = "k"
+	layerBallots = "a"
+	// ProposalPrefix is used in proposal module.
+	ProposalPrefix = "p"
 )
 
 // DB represents a mesh database instance.

--- a/mesh/meshdb_test.go
+++ b/mesh/meshdb_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/database"
 	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/log/logtest"
 	"github.com/spacemeshos/go-spacemesh/rand"
@@ -669,13 +670,16 @@ func TestBlocksBallotsOverlap(t *testing.T) {
 	defer mdb.Close()
 
 	lid := []byte{'L', 0, 0, 0}
-	block := types.NewExistingBlock(types.BlockID{0, 2, 3},
+	bid := types.BlockID{1, 2, 3}
+	block := types.NewExistingBlock(bid,
 		types.InnerBlock{LayerIndex: types.NewLayerID(binary.LittleEndian.Uint32(lid))})
 	require.NoError(t, mdb.AddBlock(block))
 
-	ids, err := mdb.LayerBallotIDs(types.NewLayerID(0))
-	require.NoError(t, err)
-	require.Len(t, ids, 1)
+	// bL is consumed as prefix.
+	// layer is will read first by of the block id, hence 0001 in thi example
+	ids, err := mdb.LayerBallotIDs(types.NewLayerID(binary.LittleEndian.Uint32([]byte{bid[0], 0, 0, 0})))
+	require.ErrorIs(t, err, database.ErrNotFound)
+	require.Empty(t, ids)
 }
 
 func BenchmarkGetBlock(b *testing.B) {

--- a/mesh/meshdb_test.go
+++ b/mesh/meshdb_test.go
@@ -3,6 +3,7 @@ package mesh
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"math"
 	"os"
 	"path"
@@ -661,6 +662,20 @@ func TestMesh_FindOnce(t *testing.T) {
 			assert.Len(t, txs, 1)
 		}
 	})
+}
+
+func TestBlocksBallotsOverlap(t *testing.T) {
+	mdb := NewMemMeshDB(logtest.New(t))
+	defer mdb.Close()
+
+	lid := []byte{'L', 0, 0, 0}
+	block := types.NewExistingBlock(types.BlockID{0, 2, 3},
+		types.InnerBlock{LayerIndex: types.NewLayerID(binary.LittleEndian.Uint32(lid))})
+	require.NoError(t, mdb.AddBlock(block))
+
+	ids, err := mdb.LayerBallotIDs(types.NewLayerID(0))
+	require.NoError(t, err)
+	require.Len(t, ids, 1)
 }
 
 func BenchmarkGetBlock(b *testing.B) {

--- a/proposals/proposaldb.go
+++ b/proposals/proposaldb.go
@@ -180,7 +180,7 @@ func (db *DB) Get(hash []byte) ([]byte, error) {
 // LayerProposalIDs retrieves all proposal IDs from the layer specified by layer ID.
 func (db *DB) LayerProposalIDs(lid types.LayerID) ([]types.ProposalID, error) {
 	var ids []types.ProposalID
-	if err := mesh.LayerIDs(db.layers, mesh.ProposalPrefix, lid, func(id []byte) error {
+	if err := mesh.LayerIDs(db.layers, "", lid, func(id []byte) error {
 		var pid types.ProposalID
 		copy(pid[:], id)
 		ids = append(ids, pid)
@@ -195,7 +195,7 @@ func (db *DB) LayerProposalIDs(lid types.LayerID) ([]types.ProposalID, error) {
 // LayerProposals retrieves all proposals from the layer specified by layer ID.
 func (db *DB) LayerProposals(lid types.LayerID) ([]*types.Proposal, error) {
 	var proposals []*types.Proposal
-	if err := mesh.LayerIDs(db.layers, mesh.ProposalPrefix, lid, func(id []byte) error {
+	if err := mesh.LayerIDs(db.layers, "", lid, func(id []byte) error {
 		var pid types.ProposalID
 		copy(pid[:], id)
 		block, err := db.GetProposal(pid)

--- a/proposals/proposaldb.go
+++ b/proposals/proposaldb.go
@@ -180,7 +180,7 @@ func (db *DB) Get(hash []byte) ([]byte, error) {
 // LayerProposalIDs retrieves all proposal IDs from the layer specified by layer ID.
 func (db *DB) LayerProposalIDs(lid types.LayerID) ([]types.ProposalID, error) {
 	var ids []types.ProposalID
-	if err := mesh.LayerIDs(db.layers, "", lid, func(id []byte) error {
+	if err := mesh.LayerIDs(db.layers, mesh.ProposalPrefix, lid, func(id []byte) error {
 		var pid types.ProposalID
 		copy(pid[:], id)
 		ids = append(ids, pid)
@@ -195,7 +195,7 @@ func (db *DB) LayerProposalIDs(lid types.LayerID) ([]types.ProposalID, error) {
 // LayerProposals retrieves all proposals from the layer specified by layer ID.
 func (db *DB) LayerProposals(lid types.LayerID) ([]*types.Proposal, error) {
 	var proposals []*types.Proposal
-	if err := mesh.LayerIDs(db.layers, "", lid, func(id []byte) error {
+	if err := mesh.LayerIDs(db.layers, mesh.ProposalPrefix, lid, func(id []byte) error {
 		var pid types.ProposalID
 		copy(pid[:], id)
 		block, err := db.GetProposal(pid)


### PR DESCRIPTION
## Motivation

prefixes in the same space should not overlap. as it leads to corrupted database state.
for example keys `bl || abc` and `b || lzxd` overlap, so when we query for `bl` we could unexpectedly load object with key zxd.

## Changes
- use nonoverlapping prefixes for blocks and ballots

## Test Plan
i don't know how to add a failing test if prefixes are correct, so i added an example that would fail if prefixes are incorrect in a specific way.
