### PR TITLE
[Merged by Bors] - tortoise: add OnBlock and OnBallot to tortoise interface

### DIFF
--- a/mesh/interface.go
+++ b/mesh/interface.go
@@ -26,5 +26,7 @@ type state interface {
 }
 
 type tortoise interface {
+	OnBallot(*types.Ballot)
+	OnBlock(*types.Block)
 	HandleIncomingLayer(context.Context, types.LayerID) (oldPbase, newPbase types.LayerID, reverted bool)
 }

--- a/mesh/mesh.go
+++ b/mesh/mesh.go
@@ -725,10 +725,18 @@ func (msh *Mesh) AddTXsFromProposal(ctx context.Context, layerID types.LayerID, 
 	return nil
 }
 
+// AddBallot to the mesh.
+func (msh *Mesh) AddBallot(ballot *types.Ballot) error {
+	msh.trtl.OnBallot(ballot)
+	return msh.DB.AddBallot(ballot)
+}
+
 // AddBlockWithTXs adds the block and its TXs in into the database.
 func (msh *Mesh) AddBlockWithTXs(ctx context.Context, block *types.Block) error {
 	logger := msh.WithContext(ctx).WithFields(block.LayerIndex, block.ID(), log.Int("num_txs", len(block.TxIDs)))
 	logger.Debug("adding block txs to mesh")
+
+	msh.trtl.OnBlock(block)
 
 	msh.addTransactionsForBlock(logger, block.LayerIndex, block.ID(), block.TxIDs)
 	return msh.AddBlock(block)

--- a/mesh/mesh_test.go
+++ b/mesh/mesh_test.go
@@ -68,6 +68,8 @@ func createTestMesh(t *testing.T) *testMesh {
 		mockState:    mocks.NewMockstate(ctrl),
 		mockTortoise: mocks.NewMocktortoise(ctrl),
 	}
+	tm.mockTortoise.EXPECT().OnBlock(gomock.Any()).AnyTimes()
+	tm.mockTortoise.EXPECT().OnBallot(gomock.Any()).AnyTimes()
 	tm.Mesh = NewMesh(mmdb, nil, tm.mockTortoise, newMockTxMemPool(), tm.mockState, lg)
 	return tm
 }

--- a/mesh/mocks/mocks.go
+++ b/mesh/mocks/mocks.go
@@ -231,3 +231,27 @@ func (mr *MocktortoiseMockRecorder) HandleIncomingLayer(arg0, arg1 interface{}) 
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleIncomingLayer", reflect.TypeOf((*Mocktortoise)(nil).HandleIncomingLayer), arg0, arg1)
 }
+
+// OnBallot mocks base method.
+func (m *Mocktortoise) OnBallot(arg0 *types.Ballot) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "OnBallot", arg0)
+}
+
+// OnBallot indicates an expected call of OnBallot.
+func (mr *MocktortoiseMockRecorder) OnBallot(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OnBallot", reflect.TypeOf((*Mocktortoise)(nil).OnBallot), arg0)
+}
+
+// OnBlock mocks base method.
+func (m *Mocktortoise) OnBlock(arg0 *types.Block) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "OnBlock", arg0)
+}
+
+// OnBlock indicates an expected call of OnBlock.
+func (mr *MocktortoiseMockRecorder) OnBlock(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OnBlock", reflect.TypeOf((*Mocktortoise)(nil).OnBlock), arg0)
+}

--- a/syncer/syncer_test.go
+++ b/syncer/syncer_test.go
@@ -109,6 +109,10 @@ func (mf *mockFetcher) setATXsErrors(epoch types.EpochID, err error) {
 
 type mockValidator struct{}
 
+func (mv *mockValidator) OnBlock(*types.Block) {}
+
+func (mv *mockValidator) OnBallot(*types.Ballot) {}
+
 func (mv *mockValidator) HandleIncomingLayer(_ context.Context, layerID types.LayerID) (types.LayerID, types.LayerID, bool) {
 	return layerID, layerID.Sub(1), false
 }

--- a/tortoise/algorithm.go
+++ b/tortoise/algorithm.go
@@ -214,7 +214,8 @@ func (t *Tortoise) OnBlock(block *types.Block) {
 	t.trtl.onBlock(block.LayerIndex, block.ID())
 }
 
-// OnBallot should be called every time new ballot is received. ATX must be stored in the database.
+// OnBallot should be called every time new ballot is received.
+// BaseBallot and RefBallot must be always processed first. And ATX must be stored in the database.
 func (t *Tortoise) OnBallot(ballot *types.Ballot) {
 	if err := t.trtl.onBallot(ballot); err != nil {
 		t.logger.Error("failed to save state from ballot", ballot.ID(), log.Err(err))

--- a/tortoise/algorithm.go
+++ b/tortoise/algorithm.go
@@ -211,12 +211,16 @@ func (t *Tortoise) HandleIncomingLayer(ctx context.Context, layerID types.LayerI
 
 // OnBlock should be called every time new block is received.
 func (t *Tortoise) OnBlock(block *types.Block) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
 	t.trtl.onBlock(block.LayerIndex, block.ID())
 }
 
 // OnBallot should be called every time new ballot is received.
 // BaseBallot and RefBallot must be always processed first. And ATX must be stored in the database.
 func (t *Tortoise) OnBallot(ballot *types.Ballot) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
 	if err := t.trtl.onBallot(ballot); err != nil {
 		t.logger.Error("failed to save state from ballot", ballot.ID(), log.Err(err))
 	}

--- a/tortoise/full.go
+++ b/tortoise/full.go
@@ -47,10 +47,14 @@ func (f *full) processBallots(ballots []tortoiseBallot) {
 	}
 }
 
-func (f *full) processBlocks(blocks []types.BlockID) {
-	for _, block := range blocks {
-		f.weights[block] = weightFromUint64(0)
-	}
+func (f *full) onBallot(ballot *tortoiseBallot) {
+	f.base[ballot.id] = ballot.base
+	f.votes[ballot.id] = ballot.votes
+	f.abstain[ballot.id] = ballot.abstain
+}
+
+func (f *full) onBlock(block types.BlockID) {
+	f.weights[block] = weightFromUint64(0)
 }
 
 func (f *full) getVote(logger log.Log, ballot types.BallotID, blocklid types.LayerID, block types.BlockID) sign {

--- a/tortoise/full_test.go
+++ b/tortoise/full_test.go
@@ -325,8 +325,9 @@ func TestFullCountVotes(t *testing.T) {
 					layerBlocks = append(layerBlocks, types.BlockID(p.ID()))
 				}
 
-				consensus.processBlocks(lid, layerBlocks)
-				consensus.full.processBlocks(layerBlocks)
+				for _, block := range layerBlocks {
+					consensus.onBlock(lid, block)
+				}
 				blocks = append(blocks, layerBlocks)
 			}
 
@@ -358,10 +359,9 @@ func TestFullCountVotes(t *testing.T) {
 
 				consensus.processed = lid
 				consensus.last = lid
-				tballots, err := consensus.processBallots(lid, layerBallots)
-				consensus.full.processBallots(tballots)
-				require.NoError(t, err)
-				consensus.full.processBallots(tballots)
+				for _, ballot := range layerBallots {
+					require.NoError(t, consensus.onBallot(ballot))
+				}
 
 				consensus.full.countVotes(logger)
 			}

--- a/tortoise/tortoise.go
+++ b/tortoise/tortoise.go
@@ -672,6 +672,16 @@ func (t *turtle) onBallot(ballot *types.Ballot) error {
 	if _, exist := t.ballotLayer[ballot.ID()]; exist {
 		return nil
 	}
+
+	baselid, exist := t.ballotLayer[ballot.Votes.Base]
+	if !exist {
+		t.logger.With().Warning("base ballot is not in the state",
+			ballot.ID(),
+			log.Stringer("base", ballot.Votes.Base),
+		)
+		return nil
+	}
+
 	ballotWeight, err := computeBallotWeight(t.atxdb, t.bdp, t.ballotWeight, ballot, t.LayerSize, types.GetLayersPerEpoch())
 	if err != nil {
 		return err
@@ -681,8 +691,6 @@ func (t *turtle) onBallot(ballot *types.Ballot) error {
 
 	// TODO(dshulyak) this should not fail without terminating tortoise
 	t.markBeaconWithBadBallot(t.logger, ballot)
-
-	baselid := t.ballotLayer[ballot.Votes.Base]
 
 	abstainVotes := map[types.LayerID]struct{}{}
 	for _, lid := range ballot.Votes.Abstain {

--- a/tortoise/tortoise.go
+++ b/tortoise/tortoise.go
@@ -673,14 +673,7 @@ func (t *turtle) onBallot(ballot *types.Ballot) error {
 		return nil
 	}
 
-	baselid, exist := t.ballotLayer[ballot.Votes.Base]
-	if !exist {
-		t.logger.With().Warning("base ballot is not in the state",
-			ballot.ID(),
-			log.Stringer("base", ballot.Votes.Base),
-		)
-		return nil
-	}
+	baselid := t.ballotLayer[ballot.Votes.Base]
 
 	ballotWeight, err := computeBallotWeight(t.atxdb, t.bdp, t.ballotWeight, ballot, t.LayerSize, types.GetLayersPerEpoch())
 	if err != nil {

--- a/tortoise/tortoise.go
+++ b/tortoise/tortoise.go
@@ -624,6 +624,8 @@ func (t *turtle) updateLayer(logger log.Log, lid types.LayerID) error {
 // expensive long running computation in this method.
 func (t *turtle) updateState(ctx context.Context, logger log.Log, lid types.LayerID) error {
 	// TODO(dshulyak) loading state from db is only needed for rerun.
+	// but in general it won't hurt, so maybe refactor it in future.
+
 	blocks, err := t.bdp.LayerBlockIds(lid)
 	if err != nil {
 		return fmt.Errorf("read blocks for layer %s: %w", lid, err)

--- a/tortoise/tortoise_test.go
+++ b/tortoise/tortoise_test.go
@@ -2178,8 +2178,12 @@ func TestLateBaseBallot(t *testing.T) {
 	cfg.Zdist = cfg.Hdist
 
 	tortoise := tortoiseFromSimState(s.GetState(0), WithLogger(logtest.New(t)), WithConfig(cfg))
-	last := s.Next()
-	_, verified, _ := tortoise.HandleIncomingLayer(ctx, last)
+	var last, verified types.LayerID
+	for _, last = range sim.GenLayers(s,
+		sim.WithSequence(2, sim.WithEmptyHareOutput()),
+	) {
+		_, verified, _ = tortoise.HandleIncomingLayer(ctx, last)
+	}
 
 	ballots, err := s.GetState(0).MeshDB.LayerBallots(last)
 	require.NoError(t, err)

--- a/tortoise/tortoise_test.go
+++ b/tortoise/tortoise_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/spacemeshos/go-spacemesh/codec"
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/log/logtest"
@@ -2149,11 +2150,100 @@ func TestAbstainVotingVerifyingMode(t *testing.T) {
 	require.Equal(t, last.Sub(1), verified)
 }
 
-func TestSupportingUnknownBlock(t *testing.T) {
+func voteWithBaseBallot(base types.BallotID) sim.VotesGenerator {
+	return func(rng *mrand.Rand, layers []*types.Layer, i int) sim.Voting {
+		voting := sim.PerfectVoting(rng, layers, i)
+		voting.Base = base
+		return voting
+	}
+}
+
+func voteForBlock(block types.BlockID) sim.VotesGenerator {
+	return func(rng *mrand.Rand, layers []*types.Layer, i int) sim.Voting {
+		voting := sim.PerfectVoting(rng, layers, i)
+		voting.Support = append(voting.Support, block)
+		return voting
+	}
+}
+
+func TestLateBaseBallot(t *testing.T) {
 	ctx := context.Background()
 	const size = 10
 	s := sim.New(sim.WithLayerSize(size))
 	s.Setup(sim.WithSetupUnitsRange(2, 2))
+
+	cfg := defaultTestConfig()
+	cfg.LayerSize = size
+	cfg.Hdist = 1
+	cfg.Zdist = cfg.Hdist
+
+	tortoise := tortoiseFromSimState(s.GetState(0), WithLogger(logtest.New(t)), WithConfig(cfg))
+	last := s.Next()
+	_, verified, _ := tortoise.HandleIncomingLayer(ctx, last)
+
+	ballots, err := s.GetState(0).MeshDB.LayerBallots(last)
+	require.NoError(t, err)
+	require.NotEmpty(t, ballots)
+
+	buf, err := codec.Encode(ballots[0])
+	require.NoError(t, err)
+	var base types.Ballot
+	require.NoError(t, codec.Decode(buf, &base))
+	base.EligibilityProof.J++
+	base.Initialize()
+	tortoise.OnBallot(&base)
+
+	for _, last = range sim.GenLayers(s,
+		sim.WithSequence(1, sim.WithVoteGenerator(voteWithBaseBallot(base.ID()))),
+		sim.WithSequence(1),
+	) {
+		_, verified, _ = tortoise.HandleIncomingLayer(ctx, last)
+	}
+
+	require.Equal(t, last.Sub(1), verified)
+}
+
+func TestLateBlock(t *testing.T) {
+	ctx := context.Background()
+	const size = 10
+	s := sim.New(sim.WithLayerSize(size))
+	s.Setup(sim.WithSetupUnitsRange(2, 2))
+
+	cfg := defaultTestConfig()
+	cfg.LayerSize = size
+	cfg.Hdist = 1
+	cfg.Zdist = cfg.Hdist
+
+	tortoise := tortoiseFromSimState(s.GetState(0), WithLogger(logtest.New(t)), WithConfig(cfg))
+	last := s.Next()
+	_, verified, _ := tortoise.HandleIncomingLayer(ctx, last)
+
+	blocks, err := s.GetState(0).MeshDB.LayerBlocks(last)
+	require.NoError(t, err)
+	require.NotEmpty(t, blocks)
+
+	buf, err := codec.Encode(blocks[0])
+	require.NoError(t, err)
+	var block types.Block
+	require.NoError(t, codec.Decode(buf, &block))
+	require.True(t, len(block.TxIDs) > 2)
+	block.TxIDs = block.TxIDs[:2]
+	block.Initialize()
+	tortoise.OnBlock(&block)
+	require.NoError(t, s.GetState(0).MeshDB.AddBlock(&block))
+
+	for _, last = range sim.GenLayers(s,
+		sim.WithSequence(1, sim.WithVoteGenerator(voteForBlock(block.ID()))),
+		sim.WithSequence(1),
+	) {
+		_, verified, _ = tortoise.HandleIncomingLayer(ctx, last)
+	}
+
+	require.Equal(t, last.Sub(1), verified)
+
+	valid, err := s.GetState(0).MeshDB.ContextualValidity(block.ID())
+	require.NoError(t, err)
+	require.True(t, valid)
 }
 
 func TestStateManagement(t *testing.T) {

--- a/tortoise/tortoise_test.go
+++ b/tortoise/tortoise_test.go
@@ -2149,6 +2149,13 @@ func TestAbstainVotingVerifyingMode(t *testing.T) {
 	require.Equal(t, last.Sub(1), verified)
 }
 
+func TestSupportingUnknownBlock(t *testing.T) {
+	ctx := context.Background()
+	const size = 10
+	s := sim.New(sim.WithLayerSize(size))
+	s.Setup(sim.WithSetupUnitsRange(2, 2))
+}
+
 func TestStateManagement(t *testing.T) {
 	const (
 		size   = 10


### PR DESCRIPTION
## Motivation

Several bugs can occur because tortoise may miss state that wasn't available at the time when the layer was passed to the tortoise.

A ballot that uses a base ballot that wasn't available when layer was created will not be marked good and will implicitly vote for many blocks in the past. This problem will be fixed during rerun, but we can avoid it.

If block was received after layer was processed we won't count votes for it and can verify layer without deciding on that particular block. This again will be fixed by rerun, but it can be avoided as well.

Besides that OnBallot will be required for work on this issue https://github.com/spacemeshos/go-spacemesh/issues/3054 .

OnBlock will be removed after pruning is integrated, as votes will have all information that we need in tortoise (layer id and block id). 

closes: https://github.com/spacemeshos/go-spacemesh/issues/3004

## Changes
- introduce OnBlock and OnBallot methods for tortoise
- call them from mesh

## Test Plan
unit tests
