### PR TITLE
[Merged by Bors] - p2p, proposals, atx: don't broadcast already known data

### DIFF
--- a/layerfetcher/layers.go
+++ b/layerfetcher/layers.go
@@ -492,7 +492,7 @@ func (l *Logic) getAtxResults(ctx context.Context, hash types.Hash32, data []byt
 		log.Int("dataSize", len(data)))
 
 	if err := l.atxHandler.HandleAtxData(ctx, data); err != nil {
-		return fmt.Errorf("handle ATX data: %w", err)
+		return fmt.Errorf("handle ATX data %s len %d: %w", hash, len(data), err)
 	}
 
 	return nil

--- a/miner/proposal_builder.go
+++ b/miner/proposal_builder.go
@@ -380,12 +380,6 @@ func (pb *ProposalBuilder) handleLayer(ctx context.Context, layerID types.LayerI
 			}
 		}
 
-		if err := pb.proposalDB.AddProposal(ctx, p); err != nil {
-			events.ReportDoneCreatingProposal(true, layerID.Uint32(), "failed to add proposal")
-			logger.With().Error("failed to add proposal", p.ID(), log.Err(err))
-			return fmt.Errorf("builder add proposal: %w", err)
-		}
-
 		data, err := codec.Encode(p)
 		if err != nil {
 			logger.With().Panic("failed to serialize proposal", log.Err(err))

--- a/miner/proposal_builder.go
+++ b/miner/proposal_builder.go
@@ -388,6 +388,8 @@ func (pb *ProposalBuilder) handleLayer(ctx context.Context, layerID types.LayerI
 		pb.eg.Go(func() error {
 			// generate a new requestID for the new block message
 			newCtx := log.WithNewRequestID(ctx, layerID, p.ID())
+			// validation handler, where proposal is persisted, is applied synchronously before
+			// proposal is sent over the network
 			if err = pb.publisher.Publish(newCtx, proposals.NewProposalProtocol, data); err != nil {
 				logger.WithContext(newCtx).With().Error("failed to send proposal", log.Err(err))
 			}

--- a/miner/proposal_builder_test.go
+++ b/miner/proposal_builder_test.go
@@ -140,7 +140,6 @@ func TestBuilder_HandleLayer_MultipleProposals(t *testing.T) {
 	b.mBaseBP.EXPECT().BaseBallot(gomock.Any()).Return(&types.Votes{Base: bb1}, nil).Times(1)
 	b.mRefDB.EXPECT().Get(getEpochKey(epoch)).Return(nil, database.ErrNotFound).Times(1)
 	b.mRefDB.EXPECT().Put(getEpochKey(epoch), gomock.Any()).Return(nil).Times(1)
-	b.mPDB.EXPECT().AddProposal(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 	b.mPubSub.EXPECT().Publish(gomock.Any(), proposals.NewProposalProtocol, gomock.Any()).DoAndReturn(
 		func(_ context.Context, _ string, data []byte) error {
 			var p types.Proposal
@@ -163,7 +162,6 @@ func TestBuilder_HandleLayer_MultipleProposals(t *testing.T) {
 	b.mTxPool.EXPECT().SelectTopNTransactions(gomock.Any(), gomock.Any()).Return([]types.TransactionID{tx2.ID()}, nil, nil).Times(1)
 	b.mBaseBP.EXPECT().BaseBallot(gomock.Any()).Return(&types.Votes{Base: bb2}, nil).Times(1)
 	b.mRefDB.EXPECT().Get(getEpochKey(epoch)).Return(refBid.Bytes(), nil).Times(1)
-	b.mPDB.EXPECT().AddProposal(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 	b.mPubSub.EXPECT().Publish(gomock.Any(), proposals.NewProposalProtocol, gomock.Any()).DoAndReturn(
 		func(_ context.Context, _ string, data []byte) error {
 			var p types.Proposal
@@ -208,7 +206,6 @@ func TestBuilder_HandleLayer_OneProposal(t *testing.T) {
 	b.mBaseBP.EXPECT().BaseBallot(gomock.Any()).Return(&types.Votes{Base: bb}, nil).Times(1)
 	b.mRefDB.EXPECT().Get(getEpochKey(epoch)).Return(nil, database.ErrNotFound).Times(1)
 	b.mRefDB.EXPECT().Put(getEpochKey(epoch), gomock.Any()).Return(nil).Times(1)
-	b.mPDB.EXPECT().AddProposal(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 	b.mPubSub.EXPECT().Publish(gomock.Any(), proposals.NewProposalProtocol, gomock.Any()).DoAndReturn(
 		func(_ context.Context, _ string, data []byte) error {
 			var p types.Proposal
@@ -401,7 +398,6 @@ func TestBuilder_HandleLayer_PublishError(t *testing.T) {
 	b.mBaseBP.EXPECT().BaseBallot(gomock.Any()).Return(&types.Votes{Base: types.RandomBallotID()}, nil).Times(1)
 	b.mRefDB.EXPECT().Get(getEpochKey(epoch)).Return(nil, database.ErrNotFound).Times(1)
 	b.mRefDB.EXPECT().Put(getEpochKey(epoch), gomock.Any()).Return(nil).Times(1)
-	b.mPDB.EXPECT().AddProposal(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 	b.mPubSub.EXPECT().Publish(gomock.Any(), proposals.NewProposalProtocol, gomock.Any()).Return(errors.New("unknown")).Times(1)
 
 	// publish error is ignored

--- a/proposals/handler.go
+++ b/proposals/handler.go
@@ -34,6 +34,7 @@ var (
 	errDuplicateTX           = errors.New("duplicate TxID in proposal")
 	errDuplicateATX          = errors.New("duplicate ATXID in active set")
 	errKnownBallot           = errors.New("known ballot")
+	errKnownProposal         = errors.New("known proposal")
 )
 
 // Handler processes Proposal from gossip and, if deems it valid, propagates it to peers.
@@ -130,7 +131,9 @@ func NewHandler(f system.Fetcher, bc system.BeaconCollector, db atxDB, m meshDB,
 // HandleProposal is the gossip receiver for Proposal.
 func (h *Handler) HandleProposal(ctx context.Context, _ peer.ID, msg []byte) pubsub.ValidationResult {
 	newCtx := log.WithNewRequestID(ctx)
-	if err := h.HandleProposalData(newCtx, msg); err != nil {
+	if err := h.HandleProposalData(newCtx, msg); errors.Is(err, errKnownProposal) {
+		return pubsub.ValidationIgnore
+	} else if err != nil {
 		h.logger.WithContext(newCtx).With().Error("failed to process proposal gossip", log.Err(err))
 		return pubsub.ValidationIgnore
 	}
@@ -189,7 +192,7 @@ func (h *Handler) HandleProposalData(ctx context.Context, data []byte) error {
 
 	if h.proposalDB.HasProposal(p.ID()) {
 		logger.Info("known proposal")
-		return nil
+		return fmt.Errorf("%w proposal %s", errKnownProposal, p.ID())
 	}
 	logger.With().Info("new proposal", log.Inline(&p))
 

--- a/proposals/handler_test.go
+++ b/proposals/handler_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/spacemeshos/go-spacemesh/codec"
 	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/p2p/pubsub"
 	"github.com/spacemeshos/go-spacemesh/proposals/mocks"
 	"github.com/spacemeshos/go-spacemesh/signing"
 	smocks "github.com/spacemeshos/go-spacemesh/system/mocks"
@@ -386,8 +387,9 @@ func TestProposal_KnownProposal(t *testing.T) {
 	defer th.ctrl.Finish()
 	p := createProposal(t)
 	data := encodeProposal(t, p)
-	th.mp.EXPECT().HasProposal(p.ID()).Return(true).Times(1)
-	assert.NoError(t, th.HandleProposalData(context.TODO(), data))
+	th.mp.EXPECT().HasProposal(p.ID()).Return(true).Times(2)
+	assert.ErrorIs(t, th.HandleProposalData(context.TODO(), data), errKnownProposal)
+	assert.Equal(t, pubsub.ValidationIgnore, th.HandleProposal(context.TODO(), "", data))
 }
 
 func TestProposal_DuplicateTXs(t *testing.T) {

--- a/proposals/handler_test.go
+++ b/proposals/handler_test.go
@@ -388,7 +388,7 @@ func TestProposal_KnownProposal(t *testing.T) {
 	p := createProposal(t)
 	data := encodeProposal(t, p)
 	th.mp.EXPECT().HasProposal(p.ID()).Return(true).Times(2)
-	assert.ErrorIs(t, th.HandleProposalData(context.TODO(), data), errKnownProposal)
+	assert.NoError(t, th.HandleProposalData(context.TODO(), data))
 	assert.Equal(t, pubsub.ValidationIgnore, th.HandleProposal(context.TODO(), "", data))
 }
 


### PR DESCRIPTION
## Motivation

p2p layer uses bounded time-restricted cache for seen messages, as long as the message is in the cache it will not re-broadcast it and will not be passed to the handler. if node receives a message after it was evicted from the cache - it will be passed to the handler and broadcasted again. additionally, p2p layer uses lazy push, that periodically sends `ihave` message to peers. and if the peer doesn't have the message advertised in `ihave` - it will ask for it. i suspect that the could be some issues where one peer A evicts message earlier than the other peer B, peer B advertises this message to peer A and the message gets downloaded again. 

logs from testnet23 indicate that some old messages were received over and over again, there is not enough metrics to be sure that it is caused by behavior that i described above, but ignoring old message is safer than what we do now.

## Changes
- ignore previously received proposals and activations 