### PR TITLE
[Merged by Bors] - mesh: error if tortoise reverts layer without notification

### DIFF
--- a/mesh/mesh.go
+++ b/mesh/mesh.go
@@ -434,7 +434,7 @@ func (msh *Mesh) pushLayersToState(ctx context.Context, from, to types.LayerID) 
 	// we never reapply the state of oldVerified. note that state reversions must be handled separately.
 	for layerID := from; !layerID.After(to); layerID = layerID.Add(1) {
 		if !layerID.After(msh.latestLayerInState) {
-			logger.With().Warning("trying to apply layer before currently applied layer",
+			logger.With().Error("trying to apply layer before currently applied layer",
 				log.Stringer("applied_layer", msh.latestLayerInState),
 				layerID,
 			)

--- a/mesh/mesh.go
+++ b/mesh/mesh.go
@@ -317,6 +317,14 @@ func (vl *validator) ProcessLayer(ctx context.Context, layerID types.LayerID) er
 			return err
 		}
 	}
+	if !reverted && newVerified.Before(vl.latestLayerInState) {
+		logger.With().Error("tortoise reverted state without notifying mesh",
+			log.Stringer("applied_layer", vl.latestLayerInState),
+			log.Stringer("verified_layer", newVerified),
+		)
+		newVerified = vl.latestLayerInState
+	}
+
 	// mesh can't skip layer that failed to complete
 	from := minLayer(oldVerified, vl.latestLayerInState).Add(1)
 	to := newVerified


### PR DESCRIPTION
## Motivation

This is a stop-gap to prevent crashing node, so that we can release a network. Will work on a proper fix in the meantime.

related: https://github.com/spacemeshos/go-spacemesh/issues/3060 

## Changes
- error if tortoise reverts layer without notifying mesh
