### PR TITLE
[Merged by Bors] - cmd: add flag for genesis accounts

### DIFF
--- a/cmd/base.go
+++ b/cmd/base.go
@@ -15,6 +15,7 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
+	"github.com/spacemeshos/go-spacemesh/cmd/flags"
 	"github.com/spacemeshos/go-spacemesh/cmd/mapstructureutil"
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	bc "github.com/spacemeshos/go-spacemesh/config"
@@ -187,6 +188,8 @@ func EnsureCLIFlags(cmd *cobra.Command, appCFG *bc.Config) error {
 					val = viper.GetStringSlice(name)
 				case "time.Duration":
 					val = viper.GetDuration(name)
+				case "map[string]uint64":
+					val = flags.CastStringToMapStringUint64(viper.GetString(name))
 				case "*big.Rat":
 					v, ok := new(big.Rat).SetString(viper.GetString(name))
 					if !ok {
@@ -216,6 +219,10 @@ func EnsureCLIFlags(cmd *cobra.Command, appCFG *bc.Config) error {
 
 			ff = reflect.TypeOf(*appCFG)
 			elem = reflect.ValueOf(&appCFG).Elem()
+			assignFields(ff, elem, name)
+
+			ff = reflect.TypeOf(*appCFG.Genesis)
+			elem = reflect.ValueOf(appCFG.Genesis).Elem()
 			assignFields(ff, elem, name)
 
 			ff = reflect.TypeOf(appCFG.API)

--- a/cmd/flags/string_to_uint64.go
+++ b/cmd/flags/string_to_uint64.go
@@ -1,0 +1,68 @@
+package flags
+
+import (
+	"bytes"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// StringToUint64Value is a flag type for string to uint64 values.
+type StringToUint64Value struct {
+	value   *map[string]uint64
+	changed bool
+}
+
+// NewStringToUint64Value creates instance.
+func NewStringToUint64Value(p *map[string]uint64) *StringToUint64Value {
+	return &StringToUint64Value{value: p}
+}
+
+// Set expects value as "smth=101,else=102".
+func (s *StringToUint64Value) Set(val string) error {
+	ss := strings.Split(val, ",")
+	for _, pair := range ss {
+		parts := strings.SplitN(pair, "=", 2)
+		if len(parts) != 2 {
+			return fmt.Errorf("%s must be formatted as key=value", pair)
+		}
+		out, err := strconv.ParseUint(parts[1], 10, 64)
+		if err != nil {
+			return fmt.Errorf("parsing %s: %w", parts[1], err)
+		}
+		key := strings.TrimSpace(parts[0])
+		if _, exists := (*s.value)[key]; exists {
+			return fmt.Errorf("key %s is set multiple times", key)
+		}
+		(*s.value)[key] = out
+	}
+	return nil
+}
+
+// Type returns stringToUint64 type.
+func (s *StringToUint64Value) Type() string {
+	return "string=uint64"
+}
+
+// String marshals value of the StringToUint64Value instance.
+func (s *StringToUint64Value) String() string {
+	var buf bytes.Buffer
+	for k, v := range *s.value {
+		buf.WriteString(k)
+		buf.WriteRune('=')
+		buf.WriteString(strconv.FormatUint(v, 10))
+		buf.WriteRune(',')
+	}
+	if buf.Len() == 0 {
+		return ""
+	}
+	return buf.String()[:buf.Len()-1]
+}
+
+// CastStringToMapStringUint64 casts string with comma separated values to map[string]uint64.
+func CastStringToMapStringUint64(value string) map[string]uint64 {
+	val := map[string]uint64{}
+	parser := NewStringToUint64Value(&val)
+	_ = parser.Set(value)
+	return val
+}

--- a/cmd/flags/string_to_uint64_test.go
+++ b/cmd/flags/string_to_uint64_test.go
@@ -1,0 +1,72 @@
+package flags
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStringToUint64Value(t *testing.T) {
+	for _, tc := range []struct {
+		desc     string
+		input    []string
+		err      string
+		expected map[string]uint64
+	}{
+		{
+			desc:  "Joined",
+			input: []string{"1=1,2=2"},
+			expected: map[string]uint64{
+				"1": 1,
+				"2": 2,
+			},
+		},
+		{
+			desc:  "Separate",
+			input: []string{"1=1", "2=2"},
+			expected: map[string]uint64{
+				"1": 1,
+				"2": 2,
+			},
+		},
+		{
+			desc:  "InvalidSeparator",
+			input: []string{"1->1"},
+			err:   "1->1 must be formatted as key=value",
+		},
+		{
+			desc:  "NoSeparator",
+			input: []string{"1"},
+			err:   "1 must be formatted as key=value",
+		},
+		{
+			desc:  "InvalidInteger",
+			input: []string{"1=abc"},
+			err:   "strconv.ParseUint: parsing \"abc\": invalid syntax",
+		},
+	} {
+		tc := tc
+		t.Run(tc.desc, func(t *testing.T) {
+			value := map[string]uint64{}
+			parser := NewStringToUint64Value(value)
+			full := ""
+			for _, arg := range tc.input {
+				full += arg + ","
+				err := parser.Set(arg)
+				if len(tc.err) > 0 {
+					require.NotNil(t, err)
+					require.Contains(t, err.Error(), tc.err)
+				} else {
+					require.NoError(t, err)
+				}
+			}
+			full = full[:len(full)-1]
+			if len(tc.err) == 0 {
+				require.Equal(t, tc.expected, value)
+				require.Equal(t, tc.expected, CastStringToMapStringUint64(full))
+			} else {
+				require.Nil(t, CastStringToMapStringUint64(full))
+			}
+		})
+	}
+}

--- a/cmd/node/node_test.go
+++ b/cmd/node/node_test.go
@@ -897,11 +897,18 @@ func TestConfig_GenesisAccounts(t *testing.T) {
 		cmd := &cobra.Command{}
 		cmdp.AddCommands(cmd)
 
-		const key = "0x03"
-		require.NoError(t, cmd.ParseFlags([]string{"-a 0x03=100"}))
+		const value = 100
+		keys := []string{"0x03", "0x04"}
+		args := []string{}
+		for _, key := range keys {
+			args = append(args, fmt.Sprintf("-a %s=%d", key, value))
+		}
+		require.NoError(t, cmd.ParseFlags(args))
 
 		conf, err := loadConfig(cmd)
 		require.NoError(t, err)
-		require.EqualValues(t, conf.Genesis.Accounts[key], 100)
+		for _, key := range keys {
+			require.EqualValues(t, conf.Genesis.Accounts[key], value)
+		}
 	})
 }

--- a/cmd/node/node_test.go
+++ b/cmd/node/node_test.go
@@ -891,3 +891,17 @@ func TestConfig_Preset(t *testing.T) {
 		require.Equal(t, preset, *conf)
 	})
 }
+
+func TestConfig_GenesisAccounts(t *testing.T) {
+	t.Run("OverwriteDefaults", func(t *testing.T) {
+		cmd := &cobra.Command{}
+		cmdp.AddCommands(cmd)
+
+		const key = "0x03"
+		require.NoError(t, cmd.ParseFlags([]string{"-a 0x03=100"}))
+
+		conf, err := loadConfig(cmd)
+		require.NoError(t, err)
+		require.EqualValues(t, conf.Genesis.Accounts[key], 100)
+	})
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -66,7 +66,7 @@ func AddCommands(cmd *cobra.Command) {
 	cmd.PersistentFlags().IntVar(&config.TxsPerBlock, "txs-per-block",
 		config.TxsPerBlock, "the number of transactions to select per block on block creation")
 
-	cmd.PersistentFlags().VarP(flags.NewStringToUint64Value(&config.Genesis.Accounts), "accounts", "a",
+	cmd.PersistentFlags().VarP(flags.NewStringToUint64Value(config.Genesis.Accounts), "accounts", "a",
 		"List of prefunded accounts")
 
 	/** ======================== P2P Flags ========================== **/

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
+	"github.com/spacemeshos/go-spacemesh/cmd/flags"
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	cfg "github.com/spacemeshos/go-spacemesh/config"
 	"github.com/spacemeshos/go-spacemesh/config/presets"
@@ -64,6 +65,9 @@ func AddCommands(cmd *cobra.Command) {
 		config.SyncRequestTimeout, "the timeout in ms for direct requests in the sync")
 	cmd.PersistentFlags().IntVar(&config.TxsPerBlock, "txs-per-block",
 		config.TxsPerBlock, "the number of transactions to select per block on block creation")
+
+	cmd.PersistentFlags().VarP(flags.NewStringToUint64Value(&config.Genesis.Accounts), "accounts", "a",
+		"List of prefunded accounts")
 
 	/** ======================== P2P Flags ========================== **/
 

--- a/config/config.go
+++ b/config/config.go
@@ -145,6 +145,7 @@ type SmeshingConfig struct {
 func DefaultConfig() Config {
 	return Config{
 		BaseConfig:      defaultBaseConfig(),
+		Genesis:         apiConfig.DefaultGenesisConfig(),
 		Tortoise:        tortoise.DefaultConfig(),
 		P2P:             p2p.DefaultConfig(),
 		API:             apiConfig.DefaultConfig(),


### PR DESCRIPTION
For system tests, we want to have additional keys with funds in order to create transactions without waiting for rewards to accumulate. It is convenient to create those keys when the cluster is created and pass the addresses using command line.

## Changes
- add -a/-accounts map[string]uint64 flag
