### PR TITLE
[Merged by Bors] - sql/migrations: embed doesn't support backward slash

### DIFF
--- a/sql/migrations.go
+++ b/sql/migrations.go
@@ -5,7 +5,7 @@ import (
 	"bytes"
 	"embed"
 	"fmt"
-	"path/filepath"
+	"path"
 	"sort"
 	"strconv"
 	"strings"
@@ -38,10 +38,10 @@ func embeddedMigrations(db Executor) error {
 		if err != nil {
 			return fmt.Errorf("invalid migration %s: %w", file.Name(), err)
 		}
-		path := filepath.Join("migrations", file.Name())
-		content, err := embedded.ReadFile(path)
+		fpath := path.Join("migrations", file.Name())
+		content, err := embedded.ReadFile(fpath)
 		if err != nil {
-			return fmt.Errorf("readfile %s: %w", path, err)
+			return fmt.Errorf("readfile %s: %w", fpath, err)
 		}
 		scanner := bufio.NewScanner(bytes.NewBuffer(content))
 		scanner.Split(func(data []byte, atEOF bool) (advance int, token []byte, err error) {


### PR DESCRIPTION
users on windows reported the following bug, turns on out embed won't work if path contains backward slash, so using filepath was a mistake. 

```
"2022-01-23T18:35:36.833+0100 FATAL 00000.defaultLogger Failed to run the node. See logs for details. {"errmsg": "start node: cannot start services: create mesh DB: open sqlite db readfile migrations\0001_initial.sql: open migrations\0001_initial.sql: file does not exist", "name": ""}"
``` 

closes: https://github.com/spacemeshos/go-spacemesh/issues/3080

## Changes
- use path module

