### PR TITLE
blocks: rewards for some smeshers are diluted

### DIFF
--- a/blocks/generator.go
+++ b/blocks/generator.go
@@ -110,7 +110,7 @@ func (g *Generator) calculateSmesherRewards(logger log.Log, layerID types.LayerI
 	for _, proposal := range proposals {
 		eligibilities += len(proposal.EligibilityProofs)
 	}
-	rInfo := calculateRewardPerEligibility(layerID, g.cfg, txs, eligibilities)
+	rInfo := calculateRewardPerEligibility(layerID, g.cfg, txs, 50)
 	logger.With().Info("reward calculated", log.Inline(rInfo))
 	rewards := make([]types.AnyReward, 0, len(proposals))
 	for _, p := range proposals {


### PR DESCRIPTION
i was running tests and discovered that after an epoch rewards are not equal for the smeshers.

for example after 12 layers (3 epochs):

```
    sanity_test.go:87: 19: 0xc84ebd157f64b381c24b8d9fa0f4be977f5ec50050383ddfa8efb729a9afa04d => 61060573848895
    sanity_test.go:87: 19: 0x9f10a8dd7338600dcd6b53ef1f64053a9b4f458657030ef46fd9338d1ab9e8fc => 59879646184480
    sanity_test.go:87: 19: 0x441a0b040ddf9bf6596e2ac07376e51459fe0828f6bb64c4f43dba656680fcaa => 60283269371537
    sanity_test.go:87: 19: 0x62cf5866460dff83621458319e95277a615a500e3832efea3e9df1baeca502ab => 60813770739764
    sanity_test.go:87: 19: 0x78eb3230009ad58dbd0f79ecf880d5b8dea28bcc234a527d8b420e517d3148cd => 59781962434891
    sanity_test.go:87: 19: 0xce8c1965943b2c5d60e67ba234731f59d95f5dc645f9428bcb8e67ec263e8031 => 58047608463152

```

it happens because average layer size may fluctuate, and in some layers rewards for some smeshers will get diluted. for example if total number of eligibilities is 70, and your node has only 1 eligibility in that layer, the reward won't be the same if total number of eligiblitites is 30.

with the change that i made the rewards distribution is fair and equal among all nodes:

```
    sanity_test.go:87: 19: 0x24803fdad46fe6b70c8ae161bd7500e9816bab25acd2026f73849bc629d8be53 => 60000000000000
    sanity_test.go:87: 19: 0xa9e8f0ecd99b4e1f4ba5ce749063a8ed43c92685fe05471d22078037f87d9331 => 60000000000000
    sanity_test.go:87: 19: 0x728c2a6d4e9ed1b4b4fcca8662f1dc657257080a998d5bea7c815966f778478f => 60000000000000
    sanity_test.go:87: 19: 0x00cf62725ee4d6299b3c76e9f38d9e8fb310da29b470ac6546753d576d14893d => 60000000000000
    sanity_test.go:87: 19: 0xa103f62bcb86ab19db2098b75311527dfe29d263e1109719d813dff48c022e07 => 60000000000000
    sanity_test.go:87: 19: 0x9d6d52a66b3e5dfc069a5ea0401c4c897ec5d078a83ecef05f9baad0e9de1887 => 60000000000000
    sanity_test.go:87: 19: 0x7e2de0ebb7b2240162895560a0ccd67c5164dd2d4a5bdaab99e7d5e2a7831380 => 60000000000000
```
