### PR TITLE
[Merged by Bors] - testnet: new epoch every 2h with layer duration 2m

### DIFF
--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -190,9 +190,9 @@ func loadConfig(cmd *cobra.Command) (*config.Config, error) {
 // LoadConfigFromFile tries to load configuration file if the config parameter was specified.
 func LoadConfigFromFile() (*config.Config, error) {
 	fileLocation := viper.GetString("config")
-	vip := viper.New()
+
 	// read in default config if passed as param using viper
-	if err := config.LoadConfig(fileLocation, vip); err != nil {
+	if err := config.LoadConfig(fileLocation, viper.GetViper()); err != nil {
 		log.Error(fmt.Sprintf("couldn't load config file at location: %s switching to defaults \n error: %v.",
 			fileLocation, err))
 		// return err
@@ -214,7 +214,7 @@ func LoadConfigFromFile() (*config.Config, error) {
 	)
 
 	// load config if it was loaded to the viper
-	if err := vip.Unmarshal(&conf, viper.DecodeHook(hook)); err != nil {
+	if err := viper.Unmarshal(&conf, viper.DecodeHook(hook)); err != nil {
 		return nil, fmt.Errorf("unmarshal viper: %w", err)
 	}
 	return &conf, nil

--- a/cmd/node/node_test.go
+++ b/cmd/node/node_test.go
@@ -865,25 +865,32 @@ func TestInitialize_BadTortoiseParams(t *testing.T) {
 
 func TestConfig_Preset(t *testing.T) {
 	const name = "testnet"
-	viper.Set("preset", name)
-	preset, err := presets.Get(name)
-	require.NoError(t, err)
 
 	t.Run("PresetApplied", func(t *testing.T) {
+		preset, err := presets.Get(name)
+		require.NoError(t, err)
+
 		cmd := &cobra.Command{}
 		cmdp.AddCommands(cmd)
 
+		viper.Set("preset", name)
+		t.Cleanup(viper.Reset)
 		conf, err := loadConfig(cmd)
 		require.NoError(t, err)
 		require.Equal(t, preset, *conf)
 	})
 
 	t.Run("PresetOverwrittenByFlags", func(t *testing.T) {
+		preset, err := presets.Get(name)
+		require.NoError(t, err)
+
 		cmd := &cobra.Command{}
 		cmdp.AddCommands(cmd)
 		const networkID = 42
 		require.NoError(t, cmd.ParseFlags([]string{"--network-id=" + strconv.Itoa(networkID)}))
 
+		viper.Set("preset", name)
+		t.Cleanup(viper.Reset)
 		conf, err := loadConfig(cmd)
 		require.NoError(t, err)
 		preset.P2P.NetworkID = networkID
@@ -891,6 +898,9 @@ func TestConfig_Preset(t *testing.T) {
 	})
 
 	t.Run("PresetOverWrittenByConfigFile", func(t *testing.T) {
+		preset, err := presets.Get(name)
+		require.NoError(t, err)
+
 		cmd := &cobra.Command{}
 		cmdp.AddCommands(cmd)
 		const networkID = 42
@@ -900,9 +910,30 @@ func TestConfig_Preset(t *testing.T) {
 		require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
 		require.NoError(t, cmd.ParseFlags([]string{"--config=" + path}))
 
+		viper.Set("preset", name)
+		t.Cleanup(viper.Reset)
 		conf, err := loadConfig(cmd)
 		require.NoError(t, err)
 		preset.P2P.NetworkID = networkID
+		preset.ConfigFile = path
+		require.Equal(t, preset, *conf)
+	})
+	t.Run("LoadedFromConfigFile", func(t *testing.T) {
+		preset, err := presets.Get(name)
+		require.NoError(t, err)
+
+		cmd := &cobra.Command{}
+		cmdp.AddCommands(cmd)
+
+		content := fmt.Sprintf(`{"preset": "%s"}`, name)
+		path := filepath.Join(t.TempDir(), "config.json")
+		require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+		require.NoError(t, cmd.ParseFlags([]string{"--config=" + path}))
+
+		t.Cleanup(viper.Reset)
+
+		conf, err := loadConfig(cmd)
+		require.NoError(t, err)
 		preset.ConfigFile = path
 		require.Equal(t, preset, *conf)
 	})

--- a/config/presets/testnet.go
+++ b/config/presets/testnet.go
@@ -27,8 +27,8 @@ func testnet() config.Config {
 	conf.HARE.LimitConcurrent = 5
 	conf.HARE.LimitIterations = 10
 	conf.HARE.F = 399
-	conf.HARE.RoundDuration = 30
-	conf.HARE.WakeupDelta = 30
+	conf.HARE.RoundDuration = 10
+	conf.HARE.WakeupDelta = 10
 
 	conf.P2P.TargetOutbound = 10
 
@@ -43,8 +43,8 @@ func testnet() config.Config {
 	}
 
 	conf.LayerAvgSize = 50
-	conf.LayerDurationSec = 200
-	conf.LayersPerEpoch = 6
+	conf.LayerDurationSec = 120
+	conf.LayersPerEpoch = 60
 	conf.SyncRequestTimeout = 60_000
 
 	conf.POST.BitsPerLabel = 8


### PR DESCRIPTION
the current testnet configuration is too unrealistic. verifying atxs is expensive, we shouldn't create them very often in the public testnets, as it leads to unnecessarily long sync times on resource-restricted machines.

## Changes
- change the layer to 120s. hare round 10s, 2 iterations of 4 rounds + pre round + wakeup + commitment round should fit in
- epoch size is 60 layers, so that atx is generated once in 2h
