### PR TITLE
[Merged by Bors] - beacon: allow early proposals and votes within grace period

### DIFF
--- a/activation/atxdb.go
+++ b/activation/atxdb.go
@@ -9,7 +9,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/spacemeshos/post/shared"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
@@ -17,6 +16,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/database"
 	"github.com/spacemeshos/go-spacemesh/events"
 	"github.com/spacemeshos/go-spacemesh/log"
+	"github.com/spacemeshos/go-spacemesh/p2p"
 	"github.com/spacemeshos/go-spacemesh/p2p/pubsub"
 	"github.com/spacemeshos/go-spacemesh/signing"
 	"github.com/spacemeshos/go-spacemesh/system"
@@ -677,7 +677,7 @@ func (db *DB) ValidateSignedAtx(pubKey signing.PublicKey, signedAtx *types.Activ
 }
 
 // HandleGossipAtx handles the atx gossip data channel.
-func (db *DB) HandleGossipAtx(ctx context.Context, _ peer.ID, msg []byte) pubsub.ValidationResult {
+func (db *DB) HandleGossipAtx(ctx context.Context, _ p2p.Peer, msg []byte) pubsub.ValidationResult {
 	if err := db.handleAtxData(ctx, msg); errors.Is(err, errKnownAtx) {
 		return pubsub.ValidationIgnore
 	} else if err != nil {

--- a/activation/poetlistener.go
+++ b/activation/poetlistener.go
@@ -3,10 +3,9 @@ package activation
 import (
 	"context"
 
-	"github.com/libp2p/go-libp2p-core/peer"
-
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/log"
+	"github.com/spacemeshos/go-spacemesh/p2p"
 	"github.com/spacemeshos/go-spacemesh/p2p/pubsub"
 )
 
@@ -25,7 +24,7 @@ type PoetListener struct {
 }
 
 // HandlePoetProofMessage is a receiver for broadcast messages.
-func (l *PoetListener) HandlePoetProofMessage(ctx context.Context, _ peer.ID, msg []byte) pubsub.ValidationResult {
+func (l *PoetListener) HandlePoetProofMessage(ctx context.Context, _ p2p.Peer, msg []byte) pubsub.ValidationResult {
 	var proofMessage types.PoetProofMessage
 	if err := types.BytesToInterface(msg, &proofMessage); err != nil {
 		l.Log.Error("failed to unmarshal poet membership proof: %v", err)

--- a/beacon/beacon.go
+++ b/beacon/beacon.go
@@ -431,7 +431,7 @@ func (pd *ProtocolDriver) initEpochStateIfNotPresent(logger log.Log, epoch types
 func (pd *ProtocolDriver) setProposalTimeForNextEpoch() {
 	epoch := pd.currentEpoch()
 	nextEpochStart := pd.clock.LayerToTime((epoch + 1).FirstLayer())
-	t := nextEpochStart.Add(-1 * pd.config.GracePeriodDuration)
+	t := nextEpochStart.Add(-pd.config.GracePeriodDuration)
 	pd.logger.With().Debug("earliest proposal time for epoch",
 		epoch+1,
 		log.Time("earliest_time", t))
@@ -509,7 +509,7 @@ func (pd *ProtocolDriver) setRoundInProgress(round types.RoundID) {
 	} else {
 		nextRoundStartTime = now.Add(pd.config.VotingRoundDuration + pd.config.WeakCoinRoundDuration)
 	}
-	earliestVoteTime := nextRoundStartTime.Add(-1 * pd.config.GracePeriodDuration)
+	earliestVoteTime := nextRoundStartTime.Add(-pd.config.GracePeriodDuration)
 	pd.logger.With().Debug("earliest vote time for next round",
 		round,
 		log.Uint32("next_round", uint32(round+1)),

--- a/beacon/beacon.go
+++ b/beacon/beacon.go
@@ -26,14 +26,11 @@ import (
 	"github.com/spacemeshos/go-spacemesh/sql"
 	"github.com/spacemeshos/go-spacemesh/sql/beacons"
 	"github.com/spacemeshos/go-spacemesh/system"
-	"github.com/spacemeshos/go-spacemesh/timesync"
 )
 
 const (
-	proposalPrefix = "BP"
-
-	proposalChanCapacity = 1024
-	numEpochsToKeep      = 10
+	proposalPrefix  = "BP"
+	numEpochsToKeep = 10
 )
 
 var (
@@ -49,12 +46,6 @@ type (
 		ballots map[types.BallotID]struct{}
 	}
 )
-
-type layerClock interface {
-	Subscribe() timesync.LayerTimer
-	Unsubscribe(timesync.LayerTimer)
-	LayerToTime(types.LayerID) time.Time
-}
 
 // Opt for configuring beacon protocol.
 type Opt func(*ProtocolDriver)
@@ -110,6 +101,7 @@ func New(
 		clock:              clock,
 		beacons:            make(map[types.EpochID]types.Beacon),
 		beaconsFromBallots: make(map[types.EpochID]map[types.Beacon]*ballotWeight),
+		states:             make(map[types.EpochID]*state),
 	}
 	for _, opt := range opts {
 		opt(pd)
@@ -123,8 +115,7 @@ func New(
 			weakcoin.WithMaxRound(pd.config.RoundsNumber),
 		)
 	}
-	pd.current = newState(pd.config)
-	pd.next = newState(pd.config)
+
 	pd.metricsCollector = metrics.NewBeaconMetricsCollector(pd.gatherMetricsData, pd.logger.WithName("metrics"))
 	return pd
 }
@@ -154,10 +145,17 @@ type ProtocolDriver struct {
 	layerTicker chan types.LayerID
 	db          *sql.Database
 
-	mu              sync.RWMutex
-	lastTickedEpoch types.EpochID
-	epochInProgress types.EpochID
+	mu sync.RWMutex
+
 	roundInProgress types.RoundID
+	// states for the current epoch and the next epoch. we accept early proposals for the next epoch.
+	// state for an epoch is created on demand:
+	// - when the first proposal of the epoch comes in
+	// - when the protocol starts running for the epoch
+	// whichever happens first.
+	// we start accepting early proposals for the next epoch pd.config.GracePeriodDuration before
+	// the next epoch begins.
+	states map[types.EpochID]*state
 
 	// beacons store calculated beacons as the result of the beacon protocol.
 	// the map key is the target epoch when beacon is used. if a beacon is calculated in epoch N, it will be used
@@ -167,9 +165,6 @@ type ProtocolDriver struct {
 	// the map key is the epoch when the ballot is published. the beacon value is calculated in the
 	// previous epoch and used in the current epoch.
 	beaconsFromBallots map[types.EpochID]map[types.Beacon]*ballotWeight
-
-	// states for the current epoch and the next epoch. we accept early proposals for the next epoch.
-	current, next *state
 
 	// metrics
 	metricsCollector *metrics.BeaconMetricsCollector
@@ -242,7 +237,9 @@ func (pd *ProtocolDriver) ReportBeaconFromBallot(epoch types.EpochID, bid types.
 	}
 
 	if eBeacon := pd.findMostWeightedBeaconForEpoch(epoch); eBeacon != types.EmptyBeacon {
-		pd.setBeacon(epoch, eBeacon)
+		if err := pd.setBeacon(epoch, eBeacon); err != nil {
+			pd.logger.With().Error("beacon sync: failed to set beacon", log.Err(err))
+		}
 	}
 }
 
@@ -356,16 +353,17 @@ func (pd *ProtocolDriver) setBeacon(targetEpoch types.EpochID, beacon types.Beac
 	}
 	pd.mu.Lock()
 	defer pd.mu.Unlock()
-	pd.beacons[targetEpoch] = beacon
+	if _, ok := pd.beacons[targetEpoch]; !ok {
+		pd.beacons[targetEpoch] = beacon
+	}
 	return nil
 }
 
 func (pd *ProtocolDriver) persistBeacon(epoch types.EpochID, beacon types.Beacon) error {
-	if err := beacons.Add(pd.db, epoch, beacon); err != nil {
+	if err := beacons.Add(pd.db, epoch, beacon); err != nil && err != sql.ErrObjectExists {
 		pd.logger.With().Error("failed to persist beacon", epoch, beacon, log.Err(err))
 		return fmt.Errorf("persist beacon: %w", err)
 	}
-
 	return nil
 }
 
@@ -374,7 +372,6 @@ func (pd *ProtocolDriver) getPersistedBeacon(epoch types.EpochID) (types.Beacon,
 	if err != nil {
 		return types.EmptyBeacon, fmt.Errorf("get from DB: %w", err)
 	}
-
 	return data, nil
 }
 
@@ -394,21 +391,51 @@ func (pd *ProtocolDriver) isInProtocol() bool {
 	return atomic.LoadUint64(&pd.inProtocol) == 1
 }
 
-func (pd *ProtocolDriver) setupEpoch(logger log.Log, epochWeight uint64) chan *proposalMessageWithReceiptData {
+func (pd *ProtocolDriver) initEpochStateIfNotPresent(logger log.Log, epoch types.EpochID) (*state, error) {
 	pd.mu.Lock()
 	defer pd.mu.Unlock()
 
-	pd.current.init(epochWeight, createProposalChecker(logger, pd.config.Kappa, pd.config.Q, epochWeight))
-	return pd.current.proposalChan
+	if s, ok := pd.states[epoch]; ok {
+		return s, nil
+	}
+
+	epochWeight, atxs, err := pd.atxDB.GetEpochWeight(epoch)
+	if err != nil {
+		logger.With().Error("failed to get weight targeting epoch", log.Err(err))
+		return nil, fmt.Errorf("get epoch weight: %w", err)
+	}
+	if epochWeight == 0 {
+		logger.With().Error("zero weight targeting epoch", log.Err(errZeroEpochWeight))
+		return nil, errZeroEpochWeight
+	}
+
+	pd.states[epoch] = newState(logger, pd.config, epochWeight, atxs)
+	return pd.states[epoch], nil
+}
+
+func (pd *ProtocolDriver) setupEpoch(logger log.Log, epoch types.EpochID) ([]types.ATXID, uint64, error) {
+	s, err := pd.initEpochStateIfNotPresent(logger, epoch)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	pd.mu.Lock()
+	defer pd.mu.Unlock()
+	pd.roundInProgress = types.FirstRound
+
+	return s.atxs, s.epochWeight, nil
 }
 
 func (pd *ProtocolDriver) cleanupEpoch(epoch types.EpochID) {
 	pd.mu.Lock()
 	defer pd.mu.Unlock()
 
-	pd.roundInProgress = types.FirstRound
-	pd.current = pd.next
-	pd.next = newState(pd.config)
+	for e := range pd.states {
+		if e < epoch {
+			delete(pd.states, e)
+		}
+	}
+	delete(pd.states, epoch)
 
 	if epoch <= numEpochsToKeep {
 		return
@@ -432,24 +459,16 @@ func (pd *ProtocolDriver) listenLayers(ctx context.Context) {
 			return
 		case layer := <-pd.layerTicker:
 			pd.logger.With().Debug("received tick", layer)
-			pd.eg.Go(func() error {
-				pd.handleLayer(ctx, layer)
-				return nil
-			})
+			if layer.FirstInEpoch() {
+				epoch := layer.GetEpoch()
+				pd.logger.With().Info("first layer in epoch", layer, epoch)
+				pd.eg.Go(func() error {
+					pd.onNewEpoch(ctx, epoch)
+					return nil
+				})
+			}
 		}
 	}
-}
-
-func (pd *ProtocolDriver) setTickedEpoch(epoch types.EpochID) {
-	pd.mu.Lock()
-	defer pd.mu.Unlock()
-	pd.lastTickedEpoch = epoch
-}
-
-func (pd *ProtocolDriver) setEpochInProgress(epoch types.EpochID) {
-	pd.mu.Lock()
-	defer pd.mu.Unlock()
-	pd.epochInProgress = epoch
 }
 
 func (pd *ProtocolDriver) setRoundInProgress(round types.RoundID) {
@@ -458,79 +477,58 @@ func (pd *ProtocolDriver) setRoundInProgress(round types.RoundID) {
 	pd.roundInProgress = round
 }
 
-// the logic that happens when a new layer arrives.
-// this function triggers the start of new CPs.
-func (pd *ProtocolDriver) handleLayer(ctx context.Context, layer types.LayerID) {
-	epoch := layer.GetEpoch()
-	logger := pd.logger.WithContext(ctx).WithFields(layer, epoch)
+func (pd *ProtocolDriver) onNewEpoch(ctx context.Context, epoch types.EpochID) {
+	logger := pd.logger.WithContext(ctx).WithFields(epoch)
 
-	pd.setTickedEpoch(epoch)
-	if !layer.FirstInEpoch() {
-		logger.Debug("not first layer in epoch, skipping")
-		return
-	}
-	if pd.isInProtocol() {
-		logger.Error("last beacon protocol is still running, skipping")
-		return
-	}
-	logger.Info("first layer in epoch, proceeding")
-	pd.handleEpoch(ctx, epoch)
-}
-
-func (pd *ProtocolDriver) handleEpoch(ctx context.Context, epoch types.EpochID) {
-	ctx = log.WithNewSessionID(ctx)
-	targetEpoch := epoch + 1
-	logger := pd.logger.WithContext(ctx).WithFields(epoch, log.Uint32("target_epoch", uint32(targetEpoch)))
-	// TODO(nkryuchkov): check when epoch started, adjust waiting time for this timestamp
 	if epoch.IsGenesis() {
-		logger.Debug("not starting beacon protocol since we are in genesis epoch")
+		logger.Info("not running beacon protocol: genesis epochs")
 		return
 	}
 	if !pd.sync.IsSynced(ctx) {
-		logger.Info("beacon protocol is skipped while node is not synced")
+		logger.Info("not running beacon protocol: node not synced")
+		return
+	}
+	if pd.isInProtocol() {
+		logger.Error("not running beacon protocol: last one still running")
 		return
 	}
 
 	// make sure this node has ATX in the last epoch and is eligible to participate in the beacon protocol
 	atxID, err := pd.atxDB.GetNodeAtxIDForEpoch(pd.nodeID, epoch-1)
 	if err != nil {
-		logger.With().Info("node has no ATX in last epoch, not participating in beacon protocol", log.Err(err))
+		logger.With().Info("not running beacon protocol: no own ATX in last epoch", log.Err(err))
 		return
 	}
 
-	logger.With().Info("participating in beacon protocol with ATX", atxID)
-
-	epochWeight, atxs, err := pd.atxDB.GetEpochWeight(epoch)
+	atxs, epochWeight, err := pd.setupEpoch(logger, epoch)
 	if err != nil {
-		logger.With().Error("failed to get weight targeting epoch", log.Err(err))
+		logger.With().Error("epoch not setup correctly", log.Err(err))
 		return
 	}
-	if epochWeight == 0 {
-		logger.With().Error("zero weight targeting epoch", log.Err(errZeroEpochWeight))
-		return
-	}
-
-	pd.setEpochInProgress(epoch)
-	pd.setBeginProtocol(ctx)
-	defer pd.setEndProtocol(ctx)
-
-	ch := pd.setupEpoch(logger, epochWeight)
 	defer pd.cleanupEpoch(epoch)
 
-	pd.eg.Go(func() error {
-		pd.readProposalMessagesLoop(ctx, ch)
-		return nil
-	})
+	logger.With().Info("participating beacon protocol with ATX", atxID, log.Uint64("epoch_weight", epochWeight))
+	pd.runProtocol(ctx, epoch, atxs)
+}
+
+func (pd *ProtocolDriver) runProtocol(ctx context.Context, epoch types.EpochID, atxs []types.ATXID) {
+	ctx = log.WithNewSessionID(ctx)
+	targetEpoch := epoch + 1
+	logger := pd.logger.WithContext(ctx).WithFields(epoch, log.Uint32("target_epoch", uint32(targetEpoch)))
+
+	pd.setBeginProtocol(ctx)
+	defer pd.setEndProtocol(ctx)
 
 	pd.startWeakCoinEpoch(ctx, epoch, atxs)
 	defer pd.weakCoin.FinishEpoch(ctx, epoch)
 
-	pd.runProposalPhase(ctx, epoch)
-	// close the proposal channel
-	close(ch)
+	if err := pd.runProposalPhase(ctx, epoch); err != nil {
+		logger.With().Warning("proposal phase failed", log.Err(err))
+		return
+	}
 	lastRoundOwnVotes, err := pd.runConsensusPhase(ctx, epoch)
 	if err != nil {
-		logger.With().Warning("consensus execution canceled", log.Err(err))
+		logger.With().Warning("consensus phase failed", log.Err(err))
 		return
 	}
 
@@ -566,48 +564,45 @@ func calcBeacon(logger log.Log, lastRoundVotes allVotes) types.Beacon {
 	return beacon
 }
 
-func (pd *ProtocolDriver) runProposalPhase(ctx context.Context, epoch types.EpochID) {
+func (pd *ProtocolDriver) runProposalPhase(ctx context.Context, epoch types.EpochID) error {
 	logger := pd.logger.WithContext(ctx).WithFields(epoch)
-	logger.Debug("starting proposal phase")
+	logger.Info("starting beacon proposal phase")
 
 	var cancel func()
 	ctx, cancel = context.WithTimeout(ctx, pd.config.ProposalDuration)
 	defer cancel()
 
 	pd.eg.Go(func() error {
-		logger.Debug("starting proposal message sender")
-
-		if err := pd.proposalPhaseImpl(ctx, epoch); err != nil {
-			logger.With().Error("failed to send proposal message", log.Err(err))
-		}
-
-		logger.Debug("proposal message sender finished")
+		pd.sendProposal(ctx, epoch)
 		return nil
 	})
 
 	select {
 	case <-ctx.Done():
 	case <-pd.ctx.Done():
-		return
+		return pd.ctx.Err()
 	}
 
-	pd.markProposalPhaseFinished(epoch)
+	if err := pd.markProposalPhaseFinished(epoch, time.Now()); err != nil {
+		return err
+	}
 
-	logger.Debug("proposal phase finished")
+	logger.Debug("beacon proposal phase finished")
+	return nil
 }
 
-func (pd *ProtocolDriver) proposalPhaseImpl(ctx context.Context, epoch types.EpochID) error {
+func (pd *ProtocolDriver) sendProposal(ctx context.Context, epoch types.EpochID) {
 	if pd.isClosed() {
-		return nil
+		return
 	}
 
 	logger := pd.logger.WithContext(ctx).WithFields(epoch)
 	proposedSignature := buildSignedProposal(ctx, pd.vrfSigner, epoch, pd.logger)
-	if !pd.checkProposalEligibility(logger, proposedSignature) {
+	if !pd.checkProposalEligibility(logger, epoch, proposedSignature) {
 		logger.With().Debug("own proposal doesn't pass threshold",
 			log.String("proposal", string(proposedSignature)))
 		// proposal is not sent
-		return nil
+		return
 	}
 
 	logger.With().Debug("own proposal passes threshold",
@@ -620,57 +615,14 @@ func (pd *ProtocolDriver) proposalPhaseImpl(ctx context.Context, epoch types.Epo
 		VRFSignature: proposedSignature,
 	}
 
-	logger.With().Debug("sending proposal", log.String("message", m.String()))
-	if err := pd.sendToGossip(ctx, ProposalProtocol, m); err != nil {
-		return fmt.Errorf("broadcast proposal message: %w", err)
-	}
-
-	logger.With().Info("sent proposal", log.String("message", m.String()))
-	return nil
-}
-
-func (pd *ProtocolDriver) getProposalChannel(ctx context.Context, epoch types.EpochID) chan *proposalMessageWithReceiptData {
-	pd.mu.RLock()
-	defer pd.mu.RUnlock()
-
-	logger := pd.logger.WithContext(ctx).WithFields(
-		log.FieldNamed("current_epoch", pd.epochInProgress),
-		log.FieldNamed("proposal_epoch", epoch))
-	switch {
-	case epoch < pd.epochInProgress:
-		logger.With().Debug("proposal too old, do not accept")
-		return nil
-	case epoch == pd.epochInProgress:
-		ongoing := pd.current.proposalPhaseFinishedTime == time.Time{}
-		if ongoing {
-			return pd.current.proposalChan
-		}
-		logger.With().Debug("proposal phase ended, do not accept")
-		return nil
-	case epoch == pd.epochInProgress+1:
-		// always accept proposals for the next epoch, but not too far in the future
-		logger.Debug("accepting proposal for the next epoch")
-		ch := pd.next.proposalChan
-		if len(ch) == proposalChanCapacity {
-			// the reader loop is not started for the next epoch yet. drop old messages if it's already full
-			// channel receive is not synchronous with length check, use select+default here to prevent potential blocking
-			select {
-			case msg := <-ch:
-				logger.With().Warning("proposal channel for next epoch is full, dropping oldest msg",
-					log.String("message", msg.message.String()))
-			default:
-			}
-		}
-		return ch
-	default:
-		return nil
-	}
+	pd.sendToGossip(ctx, ProposalProtocol, m)
+	logger.With().Info("beacon proposal sent", log.String("message", m.String()))
 }
 
 // runConsensusPhase runs K voting rounds and returns result from last weak coin round.
 func (pd *ProtocolDriver) runConsensusPhase(ctx context.Context, epoch types.EpochID) (allVotes, error) {
 	logger := pd.logger.WithContext(ctx).WithFields(epoch)
-	logger.Debug("starting consensus phase")
+	logger.Info("starting consensus phase")
 
 	// For K rounds: In each round that lasts δ, wait for votes to come in.
 	// For next rounds,
@@ -682,6 +634,7 @@ func (pd *ProtocolDriver) runConsensusPhase(ctx context.Context, epoch types.Epo
 	var (
 		ownVotes  allVotes
 		undecided []string
+		err       error
 	)
 	for round := types.FirstRound; round < pd.config.RoundsNumber; round++ {
 		round := round
@@ -710,7 +663,10 @@ func (pd *ProtocolDriver) runConsensusPhase(ctx context.Context, epoch types.Epo
 		// note that votes after this calcVotes() call will _not_ be counted towards our votes
 		// for this round, as the late votes can be cast after the weak coin is revealed. we
 		// count them towards our votes in the next round.
-		ownVotes, undecided = pd.calcVotesBeforeWeakCoin(rLogger)
+		ownVotes, undecided, err = pd.calcVotesBeforeWeakCoin(rLogger, epoch)
+		if err != nil {
+			return allVotes{}, err
+		}
 		if round != types.FirstRound {
 			timer.Reset(pd.config.WeakCoinRoundDuration)
 
@@ -731,7 +687,7 @@ func (pd *ProtocolDriver) runConsensusPhase(ctx context.Context, epoch types.Epo
 		timer.Reset(pd.config.VotingRoundDuration)
 	}
 
-	logger.Debug("consensus phase finished")
+	logger.Info("consensus phase finished")
 	return ownVotes, nil
 }
 
@@ -749,44 +705,48 @@ func (pd *ProtocolDriver) startWeakCoinEpoch(ctx context.Context, epoch types.Ep
 	pd.weakCoin.StartEpoch(ctx, epoch, ua)
 }
 
-func (pd *ProtocolDriver) markProposalPhaseFinished(epoch types.EpochID) {
-	finishedAt := time.Now()
+func (pd *ProtocolDriver) markProposalPhaseFinished(epoch types.EpochID, finishedAt time.Time) error {
+	pd.logger.With().Debug("proposal phase finished", epoch, log.Time("finished_at", finishedAt))
 	pd.mu.Lock()
-	pd.current.proposalPhaseFinishedTime = finishedAt
-	pd.mu.Unlock()
-	pd.logger.Debug("marked proposal phase for epoch %v finished at %v", epoch, finishedAt.String())
+	defer pd.mu.Unlock()
+	if _, ok := pd.states[epoch]; !ok {
+		return errEpochNotActive
+	}
+	pd.states[epoch].proposalPhaseFinishedTime = finishedAt
+	return nil
 }
 
-func (pd *ProtocolDriver) receivedBeforeProposalPhaseFinished(epoch types.EpochID, receivedAt time.Time) bool {
-	pd.mu.RLock()
-	finishedAt := pd.current.proposalPhaseFinishedTime
-	pd.mu.RUnlock()
-	hasFinished := !finishedAt.IsZero()
-
-	pd.logger.Debug("checking if timestamp %v was received before proposal phase finished in epoch %v, is phase finished: %v, finished at: %v", receivedAt.String(), epoch, hasFinished, finishedAt.String())
-
-	return !hasFinished || receivedAt.Before(finishedAt)
-}
-
-func (pd *ProtocolDriver) calcVotesBeforeWeakCoin(logger log.Log) (allVotes, []string) {
+func (pd *ProtocolDriver) calcVotesBeforeWeakCoin(logger log.Log, epoch types.EpochID) (allVotes, []string, error) {
 	pd.mu.RLock()
 	defer pd.mu.RUnlock()
-	return calcVotes(logger, pd.theta, pd.current)
+	if _, ok := pd.states[epoch]; !ok {
+		return allVotes{}, nil, errEpochNotActive
+	}
+	decided, undecided := calcVotes(logger, pd.theta, pd.states[epoch])
+	return decided, undecided, nil
 }
 
-func (pd *ProtocolDriver) genFirstRoundMsgBody(epoch types.EpochID) FirstVotingMessageBody {
+func (pd *ProtocolDriver) genFirstRoundMsgBody(epoch types.EpochID) (FirstVotingMessageBody, error) {
 	pd.mu.RLock()
 	defer pd.mu.RUnlock()
 
+	if _, ok := pd.states[epoch]; !ok {
+		return FirstVotingMessageBody{}, errEpochNotActive
+	}
+	s := pd.states[epoch]
 	return FirstVotingMessageBody{
 		EpochID:                   epoch,
-		ValidProposals:            pd.current.incomingProposals.valid.sort(),
-		PotentiallyValidProposals: pd.current.incomingProposals.potentiallyValid.sort(),
-	}
+		ValidProposals:            s.incomingProposals.valid.sort(),
+		PotentiallyValidProposals: s.incomingProposals.potentiallyValid.sort(),
+	}, nil
 }
 
 func (pd *ProtocolDriver) sendFirstRoundVote(ctx context.Context, epoch types.EpochID) error {
-	mb := pd.genFirstRoundMsgBody(epoch)
+	mb, err := pd.genFirstRoundMsgBody(epoch)
+	if err != nil {
+		return err
+	}
+
 	sig := signMessage(pd.edSigner, mb, pd.logger)
 	m := FirstVotingMessage{
 		FirstVotingMessageBody: mb,
@@ -798,21 +758,21 @@ func (pd *ProtocolDriver) sendFirstRoundVote(ctx context.Context, epoch types.Ep
 		types.FirstRound,
 		log.String("message", m.String()))
 
-	if err := pd.sendToGossip(ctx, FirstVoteProtocol, m); err != nil {
-		return fmt.Errorf("sendToGossip: %w", err)
-	}
-
+	pd.sendToGossip(ctx, FirstVotesProtocol, m)
 	return nil
 }
 
-func (pd *ProtocolDriver) getFirstRoundVote(minerPK *signing.PublicKey) ([][]byte, error) {
+func (pd *ProtocolDriver) getFirstRoundVote(epoch types.EpochID, minerPK *signing.PublicKey) ([][]byte, error) {
 	pd.mu.RLock()
 	defer pd.mu.RUnlock()
-	return pd.current.getMinerFirstRoundVote(minerPK)
+	if _, ok := pd.states[epoch]; !ok {
+		return nil, errEpochNotActive
+	}
+	return pd.states[epoch].getMinerFirstRoundVote(minerPK)
 }
 
 func (pd *ProtocolDriver) sendFollowingVote(ctx context.Context, epoch types.EpochID, round types.RoundID, ownCurrentRoundVotes allVotes) error {
-	firstRoundVotes, err := pd.getFirstRoundVote(pd.edSigner.PublicKey())
+	firstRoundVotes, err := pd.getFirstRoundVote(epoch, pd.edSigner.PublicKey())
 	if err != nil {
 		return fmt.Errorf("get own first round votes %v: %w", pd.edSigner.PublicKey().String(), err)
 	}
@@ -836,10 +796,7 @@ func (pd *ProtocolDriver) sendFollowingVote(ctx context.Context, epoch types.Epo
 		round,
 		log.String("message", m.String()))
 
-	if err := pd.sendToGossip(ctx, FollowingVotingProtocol, m); err != nil {
-		return fmt.Errorf("broadcast voting message: %w", err)
-	}
-
+	pd.sendToGossip(ctx, FollowingVotesProtocol, m)
 	return nil
 }
 
@@ -949,7 +906,7 @@ func buildProposal(epoch types.EpochID, logger log.Log) []byte {
 	return b
 }
 
-func (pd *ProtocolDriver) sendToGossip(ctx context.Context, protocol string, data interface{}) error {
+func (pd *ProtocolDriver) sendToGossip(ctx context.Context, protocol string, data interface{}) {
 	serialized, err := types.InterfaceToBytes(data)
 	if err != nil {
 		pd.logger.With().Panic("failed to serialize message for gossip", log.Err(err))
@@ -965,7 +922,6 @@ func (pd *ProtocolDriver) sendToGossip(ctx context.Context, protocol string, dat
 		}
 		return nil
 	})
-	return nil
 }
 
 func (pd *ProtocolDriver) getOwnWeight(epoch types.EpochID) uint64 {
@@ -986,10 +942,10 @@ func (pd *ProtocolDriver) gatherMetricsData() ([]*metrics.BeaconStats, *metrics.
 	pd.mu.RLock()
 	defer pd.mu.RUnlock()
 
-	epoch := pd.lastTickedEpoch
+	epoch := pd.clock.GetCurrentLayer().GetEpoch()
 	var observed []*metrics.BeaconStats
-	if beacons, ok := pd.beaconsFromBallots[epoch]; ok {
-		for beacon, stats := range beacons {
+	if epochBeacons, ok := pd.beaconsFromBallots[epoch]; ok {
+		for beacon, stats := range epochBeacons {
 			stat := &metrics.BeaconStats{
 				Epoch:  epoch,
 				Beacon: beacon.ShortString(),

--- a/beacon/beacon_test.go
+++ b/beacon/beacon_test.go
@@ -554,6 +554,18 @@ func TestBeacon_findMostWeightedBeaconForEpoch_NoBeacon(t *testing.T) {
 	assert.Equal(t, types.EmptyBeacon, got)
 }
 
+func TestBeacon_persistBeacon(t *testing.T) {
+	tpd := setUpProtocolDriver(t)
+	epoch := types.EpochID(5)
+	beacon := types.RandomBeacon()
+	require.NoError(t, tpd.setBeacon(epoch, beacon))
+
+	// saving it again won't cause error
+	assert.NoError(t, tpd.persistBeacon(epoch, beacon))
+	// but saving a different one will
+	assert.ErrorIs(t, tpd.persistBeacon(epoch, types.RandomBeacon()), errDifferentBeacon)
+}
+
 func TestBeacon_atxThresholdFraction(t *testing.T) {
 	t.Parallel()
 

--- a/beacon/beacon_test.go
+++ b/beacon/beacon_test.go
@@ -17,14 +17,12 @@ import (
 	"github.com/spacemeshos/go-spacemesh/beacon/weakcoin"
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/common/util"
-	"github.com/spacemeshos/go-spacemesh/database"
 	"github.com/spacemeshos/go-spacemesh/log/logtest"
 	"github.com/spacemeshos/go-spacemesh/p2p/pubsub"
 	pubsubmocks "github.com/spacemeshos/go-spacemesh/p2p/pubsub/mocks"
 	"github.com/spacemeshos/go-spacemesh/signing"
 	"github.com/spacemeshos/go-spacemesh/sql"
 	smocks "github.com/spacemeshos/go-spacemesh/system/mocks"
-	"github.com/spacemeshos/go-spacemesh/timesync"
 )
 
 func coinValueMock(tb testing.TB, value bool) coin {
@@ -49,45 +47,6 @@ func coinValueMock(tb testing.TB, value bool) coin {
 	return coinMock
 }
 
-func setUpProtocolDriver(t *testing.T, mockEpochWeight uint64, hasATX bool) (*ProtocolDriver, *timesync.TimeClock) {
-	conf := UnitTestConfig()
-
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	mockDB := mocks.NewMockactivationDB(ctrl)
-	if hasATX {
-		mockDB.EXPECT().GetNodeAtxIDForEpoch(gomock.Any(), gomock.Any()).Return(types.ATXID{}, nil).MaxTimes(3)
-	} else {
-		mockDB.EXPECT().GetNodeAtxIDForEpoch(gomock.Any(), gomock.Any()).Return(types.ATXID{}, database.ErrNotFound).MaxTimes(3)
-	}
-	// epoch 2, 3, and 4 (since we waited til epoch 3 in each test)
-	mockDB.EXPECT().GetEpochWeight(gomock.Any()).Return(mockEpochWeight, nil, nil).MaxTimes(3)
-	mwc := coinValueMock(t, true)
-
-	types.SetLayersPerEpoch(3)
-	logger := logtest.New(t).WithName("Beacon")
-	genesisTime := time.Now().Add(100 * time.Millisecond)
-	ld := 100 * time.Millisecond
-	clock := timesync.NewClock(timesync.RealClock{}, ld, genesisTime, logtest.New(t).WithName("clock"))
-	clock.StartNotifying()
-
-	edSgn := signing.NewEdSigner()
-	edPubkey := edSgn.PublicKey()
-	vrfSigner, vrfPub, err := signing.NewVRFSigner(edSgn.Sign(edPubkey.Bytes()))
-	require.NoError(t, err)
-
-	publisher := newPublisher(t)
-	minerID := types.NodeID{Key: edPubkey.String(), VRFPublicKey: vrfPub}
-	ms := smocks.NewMockSyncStateProvider(ctrl)
-	ms.EXPECT().IsSynced(gomock.Any()).Return(true).AnyTimes()
-	pd := New(conf, minerID, publisher, mockDB, edSgn, signing.NewEDVerifier(), vrfSigner, signing.VRFVerifier{}, mwc, sql.InMemory(), clock, logger)
-	require.NotNil(t, pd)
-	pd.SetSyncState(ms)
-	pd.setMetricsRegistry(prometheus.NewPedanticRegistry())
-	return pd, clock
-}
-
 func newPublisher(tb testing.TB) pubsub.Publisher {
 	tb.Helper()
 	ctrl := gomock.NewController(tb)
@@ -101,77 +60,149 @@ func newPublisher(tb testing.TB) pubsub.Publisher {
 	return publisher
 }
 
-func TestBeacon(t *testing.T) {
-	pd, clock := setUpProtocolDriver(t, uint64(10), true)
-	epoch := types.EpochID(3)
-	require.NoError(t, pd.Start(context.TODO()))
+type testProtocolDriver struct {
+	*ProtocolDriver
+	ctrl   *gomock.Controller
+	mAtxDB *mocks.MockactivationDB
+	mClock *mocks.MocklayerClock
+	mSync  *smocks.MockSyncStateProvider
+}
 
-	t.Logf("Awaiting epoch %v", epoch)
-	awaitEpoch(clock, epoch)
-
-	v, err := pd.GetBeacon(epoch)
+func setUpProtocolDriver(t *testing.T) *testProtocolDriver {
+	types.SetLayersPerEpoch(3)
+	ctrl := gomock.NewController(t)
+	tpd := &testProtocolDriver{
+		ctrl:   ctrl,
+		mAtxDB: mocks.NewMockactivationDB(ctrl),
+		mClock: mocks.NewMocklayerClock(ctrl),
+		mSync:  smocks.NewMockSyncStateProvider(ctrl),
+	}
+	edSgn := signing.NewEdSigner()
+	edPubkey := edSgn.PublicKey()
+	vrfSigner, vrfPub, err := signing.NewVRFSigner(edSgn.Sign(edPubkey.Bytes()))
 	require.NoError(t, err)
+	minerID := types.NodeID{Key: edPubkey.String(), VRFPublicKey: vrfPub}
+	tpd.ProtocolDriver = New(minerID, newPublisher(t), tpd.mAtxDB, edSgn, vrfSigner, sql.InMemory(), tpd.mClock,
+		WithConfig(UnitTestConfig()),
+		WithLogger(logtest.New(t).WithName("Beacon")),
+		withWeakCoin(coinValueMock(t, true)))
+	tpd.ProtocolDriver.SetSyncState(tpd.mSync)
+	tpd.ProtocolDriver.setMetricsRegistry(prometheus.NewPedanticRegistry())
+	return tpd
+}
 
+func TestBeacon(t *testing.T) {
+	tpd := setUpProtocolDriver(t)
+	tpd.mSync.EXPECT().IsSynced(gomock.Any()).Return(true).AnyTimes()
+
+	tpd.mClock.EXPECT().Subscribe().Times(1)
+	tpd.mClock.EXPECT().GetCurrentLayer().Return(types.NewLayerID(1)).Times(1)
+	tpd.mClock.EXPECT().LayerToTime(types.EpochID(1).FirstLayer()).Return(time.Now()).Times(1)
+	tpd.Start(context.TODO())
+
+	tpd.onNewEpoch(context.TODO(), types.EpochID(0))
+	tpd.onNewEpoch(context.TODO(), types.EpochID(1))
+	tpd.mAtxDB.EXPECT().GetNodeAtxIDForEpoch(gomock.Any(), gomock.Any()).Return(types.ATXID{}, nil).Times(1)
+	tpd.mAtxDB.EXPECT().GetEpochWeight(gomock.Any()).Return(uint64(10), nil, nil).Times(1)
+	tpd.onNewEpoch(context.TODO(), types.EpochID(2))
+
+	got, err := tpd.GetBeacon(types.EpochID(2))
+	require.NoError(t, err)
+	assert.EqualValues(t, got, types.HexToBeacon(types.BootstrapBeacon))
+
+	got, err = tpd.GetBeacon(types.EpochID(3))
+	require.NoError(t, err)
 	expected := types.HexToBeacon("0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
-	assert.EqualValues(t, expected, v)
+	assert.EqualValues(t, expected, got)
 
-	pd.Close()
-	clock.Close()
+	tpd.mClock.EXPECT().Unsubscribe(gomock.Any()).Times(1)
+	tpd.Close()
 }
 
 func TestBeaconZeroWeightEpoch(t *testing.T) {
-	pd, clock := setUpProtocolDriver(t, uint64(0), true)
-	epoch := types.EpochID(3)
-	require.NoError(t, pd.Start(context.TODO()))
+	tpd := setUpProtocolDriver(t)
+	tpd.mSync.EXPECT().IsSynced(gomock.Any()).Return(true).AnyTimes()
 
-	t.Logf("Awaiting epoch %v", epoch)
-	awaitEpoch(clock, epoch)
+	tpd.mClock.EXPECT().Subscribe().Times(1)
+	tpd.mClock.EXPECT().GetCurrentLayer().Return(types.NewLayerID(1)).Times(1)
+	tpd.mClock.EXPECT().LayerToTime(types.EpochID(1).FirstLayer()).Return(time.Now()).Times(1)
+	tpd.Start(context.TODO())
 
-	v, err := pd.GetBeacon(epoch)
+	tpd.onNewEpoch(context.TODO(), types.EpochID(0))
+	tpd.onNewEpoch(context.TODO(), types.EpochID(1))
+	tpd.mAtxDB.EXPECT().GetNodeAtxIDForEpoch(gomock.Any(), gomock.Any()).Return(types.ATXID{}, nil).Times(1)
+	tpd.mAtxDB.EXPECT().GetEpochWeight(gomock.Any()).Return(uint64(0), nil, nil).Times(1)
+	tpd.onNewEpoch(context.TODO(), types.EpochID(2))
+
+	got, err := tpd.GetBeacon(types.EpochID(2))
+	require.NoError(t, err)
+	assert.EqualValues(t, got, types.HexToBeacon(types.BootstrapBeacon))
+
+	got, err = tpd.GetBeacon(types.EpochID(3))
 	assert.Equal(t, errBeaconNotCalculated, err)
-	assert.Equal(t, types.EmptyBeacon, v)
+	assert.Equal(t, types.EmptyBeacon, got)
 
-	pd.Close()
-	clock.Close()
+	tpd.mClock.EXPECT().Unsubscribe(gomock.Any()).Times(1)
+	tpd.Close()
+}
+
+func TestBeaconNotSynced(t *testing.T) {
+	tpd := setUpProtocolDriver(t)
+	tpd.mSync.EXPECT().IsSynced(gomock.Any()).Return(false).AnyTimes()
+
+	tpd.mClock.EXPECT().Subscribe().Times(1)
+	tpd.mClock.EXPECT().GetCurrentLayer().Return(types.NewLayerID(1)).Times(1)
+	tpd.mClock.EXPECT().LayerToTime(types.EpochID(1).FirstLayer()).Return(time.Now()).Times(1)
+	tpd.Start(context.TODO())
+
+	tpd.onNewEpoch(context.TODO(), types.EpochID(0))
+	tpd.onNewEpoch(context.TODO(), types.EpochID(1))
+	tpd.onNewEpoch(context.TODO(), types.EpochID(2))
+
+	got, err := tpd.GetBeacon(types.EpochID(2))
+	require.NoError(t, err)
+	assert.EqualValues(t, got, types.HexToBeacon(types.BootstrapBeacon))
+
+	got, err = tpd.GetBeacon(types.EpochID(3))
+	assert.Equal(t, errBeaconNotCalculated, err)
+	assert.Equal(t, types.EmptyBeacon, got)
+
+	tpd.mClock.EXPECT().Unsubscribe(gomock.Any()).Times(1)
+	tpd.Close()
 }
 
 func TestBeaconNoATXInPreviousEpoch(t *testing.T) {
-	pd, clock := setUpProtocolDriver(t, uint64(0), false)
-	epoch := types.EpochID(3)
-	require.NoError(t, pd.Start(context.TODO()))
+	tpd := setUpProtocolDriver(t)
+	tpd.mSync.EXPECT().IsSynced(gomock.Any()).Return(true).AnyTimes()
 
-	t.Logf("Awaiting epoch %v", epoch)
-	awaitEpoch(clock, epoch)
+	tpd.mClock.EXPECT().Subscribe().Times(1)
+	tpd.mClock.EXPECT().GetCurrentLayer().Return(types.NewLayerID(1)).Times(1)
+	tpd.mClock.EXPECT().LayerToTime(types.EpochID(1).FirstLayer()).Return(time.Now()).Times(1)
+	tpd.Start(context.TODO())
 
-	v, err := pd.GetBeacon(epoch)
+	tpd.onNewEpoch(context.TODO(), types.EpochID(0))
+	tpd.onNewEpoch(context.TODO(), types.EpochID(1))
+	tpd.mAtxDB.EXPECT().GetNodeAtxIDForEpoch(gomock.Any(), gomock.Any()).Return(types.ATXID{}, sql.ErrNotFound).Times(1)
+	tpd.onNewEpoch(context.TODO(), types.EpochID(2))
+
+	got, err := tpd.GetBeacon(types.EpochID(2))
+	require.NoError(t, err)
+	assert.EqualValues(t, got, types.HexToBeacon(types.BootstrapBeacon))
+
+	got, err = tpd.GetBeacon(types.EpochID(3))
 	assert.Equal(t, errBeaconNotCalculated, err)
-	assert.Equal(t, types.EmptyBeacon, v)
+	assert.Equal(t, types.EmptyBeacon, got)
 
-	pd.Close()
-	clock.Close()
-}
-
-func awaitEpoch(clock *timesync.TimeClock, epoch types.EpochID) {
-	layerTicker := clock.Subscribe()
-
-	for layer := range layerTicker {
-		// Wait until required epoch passes.
-		if layer.GetEpoch() > epoch {
-			return
-		}
-	}
+	tpd.mClock.EXPECT().Unsubscribe(gomock.Any()).Times(1)
+	tpd.Close()
 }
 
 func TestBeaconWithMetrics(t *testing.T) {
-	layersPerEpoch := uint32(3)
-	types.SetLayersPerEpoch(layersPerEpoch)
+	tpd := setUpProtocolDriver(t)
+	tpd.mSync.EXPECT().IsSynced(gomock.Any()).Return(true).AnyTimes()
 
-	conf := UnitTestConfig()
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-	mockDB := mocks.NewMockactivationDB(ctrl)
-	mockDB.EXPECT().GetNodeAtxIDForEpoch(gomock.Any(), gomock.Any()).Return(types.ATXID{}, nil).AnyTimes()
-	mockDB.EXPECT().GetEpochWeight(gomock.Any()).Return(uint64(10000), nil, nil).AnyTimes()
+	tpd.mAtxDB.EXPECT().GetNodeAtxIDForEpoch(gomock.Any(), gomock.Any()).Return(types.ATXID{}, nil).AnyTimes()
+	tpd.mAtxDB.EXPECT().GetEpochWeight(gomock.Any()).Return(uint64(10000), nil, nil).AnyTimes()
 	atxHeader := &types.ActivationTxHeader{
 		NIPostChallenge: types.NIPostChallenge{
 			StartTick: 0,
@@ -179,47 +210,32 @@ func TestBeaconWithMetrics(t *testing.T) {
 		},
 		NumUnits: 199,
 	}
-	mockDB.EXPECT().GetAtxHeader(gomock.Any()).Return(atxHeader, nil).AnyTimes()
-	mockDB.EXPECT().GetNodeAtxIDForEpoch(gomock.Any(), gomock.Any()).Return(types.ATXID{}, nil).AnyTimes()
-
-	mwc := coinValueMock(t, true)
-
-	logger := logtest.New(t).WithName("Beacon")
-	clock := clockNeverNotify(t)
-
-	edSgn := signing.NewEdSigner()
-	edPubkey := edSgn.PublicKey()
-	vrfSigner, vrfPub, err := signing.NewVRFSigner(edSgn.Sign(edPubkey.Bytes()))
-	require.NoError(t, err)
-
-	minerID := types.NodeID{Key: edPubkey.String(), VRFPublicKey: vrfPub}
-	ms := smocks.NewMockSyncStateProvider(ctrl)
-	ms.EXPECT().IsSynced(gomock.Any()).Return(true).AnyTimes()
-	pd := New(conf, minerID, newPublisher(t), mockDB, edSgn, signing.NewEDVerifier(), vrfSigner, signing.VRFVerifier{}, mwc, sql.InMemory(), clock, logger)
-	require.NotNil(t, pd)
-	pd.SetSyncState(ms)
-
-	require.NoError(t, pd.Start(context.TODO()))
-	t.Cleanup(func() {
-		pd.Close()
-	})
+	tpd.mAtxDB.EXPECT().GetAtxHeader(gomock.Any()).Return(atxHeader, nil).AnyTimes()
+	tpd.mAtxDB.EXPECT().GetNodeAtxIDForEpoch(gomock.Any(), gomock.Any()).Return(types.ATXID{}, nil).AnyTimes()
 
 	gLayer := types.GetEffectiveGenesis()
+	tpd.mClock.EXPECT().Subscribe().Times(1)
+	tpd.mClock.EXPECT().GetCurrentLayer().Return(gLayer).Times(1)
+	tpd.mClock.EXPECT().LayerToTime((gLayer.GetEpoch() + 1).FirstLayer()).Return(time.Now()).Times(1)
+	tpd.Start(context.TODO())
+
 	epoch3Beacon := types.HexToBeacon("0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
 	epoch := types.EpochID(3)
-	finalLayer := types.NewLayerID(layersPerEpoch * uint32(epoch))
+	finalLayer := types.NewLayerID(types.GetLayersPerEpoch() * uint32(epoch))
 	beacon1 := types.RandomBeacon()
 	beacon2 := types.RandomBeacon()
 	for layer := gLayer.Add(1); layer.Before(finalLayer); layer = layer.Add(1) {
-		pd.handleLayer(context.TODO(), layer)
+		tpd.mClock.EXPECT().GetCurrentLayer().Return(layer).AnyTimes()
+		if layer.FirstInEpoch() {
+			tpd.onNewEpoch(context.TODO(), layer.GetEpoch())
+		}
 		thisEpoch := layer.GetEpoch()
-		pd.recordBeacon(thisEpoch, types.RandomBallotID(), beacon1, 100)
-		pd.recordBeacon(thisEpoch, types.RandomBallotID(), beacon2, 200)
+		tpd.recordBeacon(thisEpoch, types.RandomBallotID(), beacon1, 100)
+		tpd.recordBeacon(thisEpoch, types.RandomBallotID(), beacon2, 200)
 
 		numCalculated := 0
 		numObserved := 0
 		numObservedWeight := 0
-		pd.logger.Info("gathering data from test in epoch %v", thisEpoch)
 		allMetrics, err := prometheus.DefaultGatherer.Gather()
 		assert.NoError(t, err)
 		for _, m := range allMetrics {
@@ -231,7 +247,6 @@ func TestBeaconWithMetrics(t *testing.T) {
 				expected := fmt.Sprintf("label:<name:\"beacon\" value:\"%s\" > label:<name:\"epoch\" value:\"%d\" > counter:<value:%d > ", beaconStr, thisEpoch+1, atxHeader.GetWeight())
 				assert.Equal(t, expected, m.Metric[0].String())
 			case "spacemesh_beacons_beacon_observed_total":
-				pd.logger.Info(m.String())
 				require.Equal(t, 2, len(m.Metric))
 				numObserved = numObserved + 2
 				count := layer.OrdinalInEpoch() + 1
@@ -264,6 +279,9 @@ func TestBeaconWithMetrics(t *testing.T) {
 		assert.Equal(t, 2, numObserved, layer)
 		assert.Equal(t, 2, numObservedWeight, layer)
 	}
+
+	tpd.mClock.EXPECT().Unsubscribe(gomock.Any()).Times(1)
+	tpd.Close()
 }
 
 func TestBeacon_BeaconsWithDatabase(t *testing.T) {
@@ -534,89 +552,6 @@ func TestBeacon_findMostWeightedBeaconForEpoch_NoBeacon(t *testing.T) {
 	epoch := types.EpochID(3)
 	got := pd.findMostWeightedBeaconForEpoch(epoch)
 	assert.Equal(t, types.EmptyBeacon, got)
-}
-
-func TestBeacon_getProposalChannel(t *testing.T) {
-	t.Parallel()
-
-	currentEpoch := types.EpochID(10)
-
-	tt := []struct {
-		name            string
-		epoch           types.EpochID
-		proposalEndTime time.Time
-		makeNextChFull  bool
-		expected        bool
-	}{
-		{
-			name:     "old epoch",
-			epoch:    currentEpoch - 1,
-			expected: false,
-		},
-		{
-			name:     "on time",
-			epoch:    currentEpoch,
-			expected: true,
-		},
-		{
-			name:            "proposal phase ended",
-			epoch:           currentEpoch,
-			proposalEndTime: time.Now(),
-			expected:        false,
-		},
-		{
-			name:     "accept next epoch",
-			epoch:    currentEpoch + 1,
-			expected: true,
-		},
-		{
-			name:           "next epoch full",
-			epoch:          currentEpoch + 1,
-			makeNextChFull: true,
-			expected:       true,
-		},
-		{
-			name:     "no future epoch beyond next",
-			epoch:    currentEpoch + 2,
-			expected: false,
-		},
-	}
-
-	for i, tc := range tt {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			// don't run these tests in parallel. somehow all cases end up using the same ProtocolDriver instance
-			// t.Parallel()
-			pd := ProtocolDriver{
-				logger:          logtest.New(t).WithName(fmt.Sprintf("ProtocolDriver-%v", i)),
-				epochInProgress: currentEpoch,
-				current: &state{
-					proposalChan:              make(chan *proposalMessageWithReceiptData, proposalChanCapacity),
-					proposalPhaseFinishedTime: tc.proposalEndTime,
-				},
-				next: &state{
-					proposalChan: make(chan *proposalMessageWithReceiptData, proposalChanCapacity),
-				},
-			}
-			if tc.makeNextChFull {
-				pd.mu.Lock()
-				nextCh := pd.next.proposalChan
-				for i := 0; i < proposalChanCapacity; i++ {
-					nextCh <- &proposalMessageWithReceiptData{
-						message: ProposalMessage{},
-					}
-				}
-				pd.mu.Unlock()
-			}
-
-			ch := pd.getProposalChannel(context.TODO(), tc.epoch)
-			if tc.expected {
-				assert.NotNil(t, ch)
-			} else {
-				assert.Nil(t, ch)
-			}
-		})
-	}
 }
 
 func TestBeacon_atxThresholdFraction(t *testing.T) {

--- a/beacon/handlers.go
+++ b/beacon/handlers.go
@@ -16,126 +16,100 @@ import (
 	"github.com/spacemeshos/go-spacemesh/signing"
 )
 
+type category uint8
+
 const (
 	// ProposalProtocol is the protocol for sending proposal messages through Gossip.
 	ProposalProtocol = "BeaconProposal"
 
-	// FirstVoteProtocol is the protocol for sending first vote messages through Gossip.
-	FirstVoteProtocol = "BeaconFirstVote"
+	// FirstVotesProtocol is the protocol for sending first vote messages through Gossip.
+	FirstVotesProtocol = "BeaconFirstVotes"
 
-	// FollowingVotingProtocol is the protocol for sending following vote messages through Gossip.
-	FollowingVotingProtocol = "BeaconFollowingVotes"
+	// FollowingVotesProtocol is the protocol for sending following vote messages through Gossip.
+	FollowingVotesProtocol = "BeaconFollowingVotes"
+
+	valid            category = 1
+	potentiallyValid category = 2
+	invalid          category = 3
 )
 
 var (
-	// errVRFNotVerified is returned if proposal message fails VRF verification.
-	errVRFNotVerified = errors.New("proposal failed vrf verification")
-
-	// errProposalDoesntPassThreshold is returned if proposal message doesn't pass threshold.
+	errVRFNotVerified              = errors.New("proposal failed vrf verification")
 	errProposalDoesntPassThreshold = errors.New("proposal doesn't pass threshold")
-
-	// errAlreadyProposed is returned when miner doubly proposed for the same epoch.
-	errAlreadyProposed = errors.New("already proposed")
-
-	// errAlreadyVoted is returned when miner doubly voted for the same epoch/round.
-	errAlreadyVoted = errors.New("already voted")
-
-	// errMinerATXNotFound is returned when miner has no ATXs in the previous epoch.
-	errMinerATXNotFound = errors.New("miner ATX not found in previous epoch")
-
-	// errProtocolNotRunning is returned when we are not in the middle of the beacon protocol.
-	errProtocolNotRunning = errors.New("beacon protocol not running")
+	errAlreadyProposed             = errors.New("already proposed")
+	errAlreadyVoted                = errors.New("already voted")
+	errMinerATXNotFound            = errors.New("miner ATX not found in previous epoch")
+	errProtocolNotRunning          = errors.New("beacon protocol not running")
+	errEpochNotActive              = errors.New("epoch not active")
+	errMalformedMessage            = errors.New("malformed msg")
+	errUntimelyMessage             = errors.New("untimely msg")
 )
 
+// HandleWeakCoinProposal handles weakcoin proposal from gossip.
 func (pd *ProtocolDriver) HandleWeakCoinProposal(ctx context.Context, pid peer.ID, msg []byte) pubsub.ValidationResult {
 	return pd.weakCoin.HandleProposal(ctx, pid, msg)
 }
 
-// HandleSerializedProposalMessage defines method to handle proposal Messages from gossip.
-func (pd *ProtocolDriver) HandleSerializedProposalMessage(ctx context.Context, pid peer.ID, msg []byte) pubsub.ValidationResult {
+// HandleProposal handles beacon proposal from gossip.
+func (pd *ProtocolDriver) HandleProposal(ctx context.Context, pid peer.ID, msg []byte) pubsub.ValidationResult {
 	if pd.isClosed() || !pd.isInProtocol() {
-		pd.logger.WithContext(ctx).Debug("beacon protocol shutting down or not running, dropping msg")
+		pd.logger.WithContext(ctx).Debug("beacon protocol shutting down, dropping msg")
 		return pubsub.ValidationIgnore
 	}
+
 	receivedTime := time.Now()
-	logger := pd.logger.WithContext(ctx)
-
-	logger.With().Debug("new proposal message", log.String("sender", pid.String()))
-
-	var message ProposalMessage
-	if err := types.BytesToInterface(msg, &message); err != nil {
-		logger.With().Warning("received malformed proposal message", log.Err(err))
+	if err := pd.handleProposal(ctx, pid, msg, receivedTime); err != nil {
+		pd.logger.WithContext(ctx).With().Error("failed to handle beacon proposal", log.Err(err))
 		return pubsub.ValidationIgnore
-	}
-
-	ch := pd.getProposalChannel(ctx, message.EpochID)
-	if ch == nil {
-		return pubsub.ValidationIgnore
-	}
-	proposalWithReceipt := &proposalMessageWithReceiptData{
-		message:      message,
-		receivedTime: receivedTime,
-	}
-	// FIXME(dshulyak) buffer messages without channel.
-	// if message.EpochID == currentEpoch + 1 : buffer message in the slice. when epoch starts, check that slice
-	// if message.EpochID == currentEpoch     : validate without passing to the channel
-	select {
-	case <-ctx.Done():
-	case ch <- proposalWithReceipt:
 	}
 	return pubsub.ValidationAccept
 }
 
-func (pd *ProtocolDriver) readProposalMessagesLoop(ctx context.Context, ch chan *proposalMessageWithReceiptData) {
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case em := <-ch:
-			if em == nil || pd.isClosed() || !pd.isInProtocol() {
-				return
-			}
+func (pd *ProtocolDriver) handleProposal(ctx context.Context, pid peer.ID, msg []byte, receivedTime time.Time) error {
+	logger := pd.logger.WithContext(ctx)
 
-			if err := pd.handleProposalMessage(ctx, em.message, em.receivedTime); err != nil {
-				pd.logger.WithContext(ctx).With().Error("failed to handle proposal message",
-					log.String("message", em.message.String()),
-					log.Err(err))
-
-				return
-			}
-		}
+	var m ProposalMessage
+	if err := types.BytesToInterface(msg, &m); err != nil {
+		logger.With().Warning("received malformed beacon proposal", log.String("sender", pid.String()), log.Err(err))
+		return errMalformedMessage
 	}
-}
 
-func (pd *ProtocolDriver) handleProposalMessage(ctx context.Context, m ProposalMessage, receivedTime time.Time) error {
-	currentEpoch := pd.currentEpoch()
+	if !pd.isProposalTimely(&m) {
+		logger.With().Warning("proposal too early", m.EpochID, log.Time("received_at", receivedTime))
+		return errUntimelyMessage
+	}
 
-	atxID, err := pd.verifyProposalMessage(ctx, m, currentEpoch)
+	logger = pd.logger.WithContext(ctx).WithFields(m.EpochID, log.String("miner_id", m.NodeID.ShortString()))
+	logger.Debug("new beacon proposal")
+
+	if _, err := pd.initEpochStateIfNotPresent(logger, m.EpochID); err != nil {
+		return err
+	}
+
+	atxID, err := pd.verifyProposalMessage(logger, m)
 	if err != nil {
 		return err
 	}
 
-	if err = pd.classifyProposalMessage(ctx, m, atxID, currentEpoch, receivedTime); err != nil {
+	cat, err := pd.classifyProposal(logger, m, atxID, receivedTime)
+	if err != nil {
 		return err
 	}
-
-	return nil
+	return pd.addProposal(m, cat)
 }
 
-func (pd *ProtocolDriver) classifyProposalMessage(ctx context.Context, m ProposalMessage, atxID types.ATXID, currentEpoch types.EpochID, receivedTime time.Time) error {
+func (pd *ProtocolDriver) classifyProposal(logger log.Log, m ProposalMessage, atxID types.ATXID, receivedTime time.Time) (category, error) {
 	minerID := m.NodeID.ShortString()
-	logger := pd.logger.WithContext(ctx).WithFields(currentEpoch, log.String("miner_id", minerID))
-
 	atxHeader, err := pd.atxDB.GetAtxHeader(atxID)
 	if err != nil {
 		logger.Error("[proposal] failed to get ATX header", atxID, log.Err(err))
-		return fmt.Errorf("[proposal] failed to get ATX header (miner ID %v, ATX ID %v): %w", minerID, atxID, err)
+		return invalid, fmt.Errorf("[proposal] failed to get ATX header (miner ID %v, ATX ID %v): %w", minerID, atxID, err)
 	}
 
 	atxTimestamp, err := pd.atxDB.GetAtxTimestamp(atxID)
 	if err != nil {
 		logger.Error("[proposal] failed to get ATX timestamp", atxID, log.Err(err))
-		return fmt.Errorf("[proposal] failed to get ATX timestamp (miner ID %v, ATX ID %v): %w", minerID, atxID, err)
+		return invalid, fmt.Errorf("[proposal] failed to get ATX timestamp (miner ID %v, ATX ID %v): %w", minerID, atxID, err)
 	}
 
 	atxEpoch := atxHeader.PubLayerID.GetEpoch()
@@ -158,7 +132,7 @@ func (pd *ProtocolDriver) classifyProposalMessage(ctx context.Context, m Proposa
 
 	var (
 		atxDelay      = atxTimestamp.Sub(nextEpochStart)
-		endTime       = pd.getProposalPhaseFinishedTime()
+		endTime       = pd.getProposalPhaseFinishedTime(m.EpochID)
 		proposalDelay time.Duration
 	)
 	if endTime != (time.Time{}) {
@@ -168,14 +142,14 @@ func (pd *ProtocolDriver) classifyProposalMessage(ctx context.Context, m Proposa
 	switch {
 	case atxDelay <= 0 && proposalDelay <= 0:
 		logger.Debug("received valid proposal: ATX delay %v, proposal delay %v", atxDelay, proposalDelay)
-		pd.addValidProposal(m.VRFSignature)
+		return valid, nil
 	case atxDelay <= pd.config.GracePeriodDuration && proposalDelay <= pd.config.GracePeriodDuration:
 		logger.Debug("received potentially proposal: ATX delay %v, proposal delay %v", atxDelay, proposalDelay)
-		pd.addPotentiallyValidProposal(m.VRFSignature)
+		return potentiallyValid, nil
 	default:
 		logger.Warning("received invalid proposal: ATX delay %v, proposal delay %v", atxDelay, proposalDelay)
 	}
-	return nil
+	return invalid, nil
 }
 
 func cropData(numBytes int, data []byte) []byte {
@@ -186,41 +160,26 @@ func cropData(numBytes int, data []byte) []byte {
 	return shortened
 }
 
-func (pd *ProtocolDriver) addValidProposal(proposal []byte) {
-	if !pd.isInProtocol() {
-		pd.logger.Debug("beacon not in protocol, not adding valid proposals")
-		return
-	}
-
+func (pd *ProtocolDriver) addProposal(m ProposalMessage, cat category) error {
+	p := cropData(types.BeaconSize, m.VRFSignature)
 	pd.mu.Lock()
 	defer pd.mu.Unlock()
-	if pd.current.incomingProposals.valid == nil {
-		pd.current.incomingProposals.valid = make(map[string]struct{})
+	if _, ok := pd.states[m.EpochID]; !ok {
+		return errEpochNotActive
 	}
-	p := cropData(types.BeaconSize, proposal)
-	pd.current.incomingProposals.valid[string(p)] = struct{}{}
+	switch cat {
+	case valid:
+		pd.states[m.EpochID].addValidProposal(p)
+	case potentiallyValid:
+		pd.states[m.EpochID].addPotentiallyValidProposal(p)
+	}
+	return nil
 }
 
-func (pd *ProtocolDriver) addPotentiallyValidProposal(proposal []byte) {
-	if !pd.isInProtocol() {
-		pd.logger.Debug("beacon not in protocol, not adding potentially valid proposals")
-		return
-	}
-
-	pd.mu.Lock()
-	defer pd.mu.Unlock()
-	if pd.current.incomingProposals.potentiallyValid == nil {
-		pd.current.incomingProposals.potentiallyValid = make(map[string]struct{})
-	}
-	p := cropData(types.BeaconSize, proposal)
-	pd.current.incomingProposals.potentiallyValid[string(p)] = struct{}{}
-}
-
-func (pd *ProtocolDriver) verifyProposalMessage(ctx context.Context, m ProposalMessage, currentEpoch types.EpochID) (types.ATXID, error) {
+func (pd *ProtocolDriver) verifyProposalMessage(logger log.Log, m ProposalMessage) (types.ATXID, error) {
 	minerID := m.NodeID.ShortString()
-	logger := pd.logger.WithContext(ctx).WithFields(currentEpoch, log.String("miner_id", minerID))
 
-	atxID, err := pd.atxDB.GetNodeAtxIDForEpoch(m.NodeID, currentEpoch-1)
+	atxID, err := pd.atxDB.GetNodeAtxIDForEpoch(m.NodeID, m.EpochID-1)
 	if errors.Is(err, database.ErrNotFound) {
 		logger.Warning("[proposal] miner has no ATX in previous epoch")
 		return types.ATXID{}, fmt.Errorf("[proposal] miner has no ATX in previous epoch (miner ID %v): %w", minerID, errMinerATXNotFound)
@@ -232,67 +191,73 @@ func (pd *ProtocolDriver) verifyProposalMessage(ctx context.Context, m ProposalM
 	}
 
 	vrfPK := signing.NewPublicKey(m.NodeID.VRFPublicKey)
-	currentEpochProposal := buildProposal(currentEpoch, logger)
+	currentEpochProposal := buildProposal(m.EpochID, logger)
 	if !pd.vrfVerifier.Verify(vrfPK, currentEpochProposal, m.VRFSignature) {
 		// TODO(nkryuchkov): attach telemetry
 		logger.Warning("[proposal] failed to verify VRF signature")
 		return types.ATXID{}, fmt.Errorf("[proposal] failed to verify VRF signature (miner ID %v): %w", minerID, errVRFNotVerified)
 	}
 
-	if err := pd.registerProposed(logger, vrfPK); err != nil {
+	if err := pd.registerProposed(logger, m.EpochID, vrfPK); err != nil {
 		return types.ATXID{}, fmt.Errorf("[proposal] failed to register proposal (miner ID %v): %w", minerID, err)
 	}
 
-	if !pd.checkProposalEligibility(logger, m.VRFSignature) {
+	if !pd.checkProposalEligibility(logger, m.EpochID, m.VRFSignature) {
 		return types.ATXID{}, fmt.Errorf("[proposal] not eligible (miner ID %v): %w", minerID, errProposalDoesntPassThreshold)
 	}
 
 	return atxID, nil
 }
 
-// HandleSerializedFirstVotingMessage defines method to handle first voting messages from gossip.
-func (pd *ProtocolDriver) HandleSerializedFirstVotingMessage(ctx context.Context, pid peer.ID, msg []byte) pubsub.ValidationResult {
+// HandleFirstVotes handles beacon first votes from gossip.
+func (pd *ProtocolDriver) HandleFirstVotes(ctx context.Context, pid peer.ID, msg []byte) pubsub.ValidationResult {
 	if pd.isClosed() || !pd.isInProtocol() {
 		pd.logger.WithContext(ctx).Debug("beacon protocol shutting down or not running, dropping msg")
 		return pubsub.ValidationIgnore
 	}
 
-	logger := pd.logger.WithContext(ctx).WithFields(
-		log.String("sender", pid.String()),
-		log.Binary("message", msg))
-	logger.Debug("new first voting message")
-
-	var m FirstVotingMessage
-	if err := types.BytesToInterface(msg, &m); err != nil {
-		logger.With().Warning("received invalid voting message", log.Err(err))
-		return pubsub.ValidationIgnore
-	}
-
-	currentEpoch := pd.currentEpoch()
-	if m.EpochID != currentEpoch {
-		logger.With().Debug("first voting message from different epoch",
-			log.Uint32("current_epoch", uint32(currentEpoch)),
-			log.Uint32("message_epoch", uint32(m.EpochID)))
-		return pubsub.ValidationIgnore
-	}
-
-	if err := pd.handleFirstVotingMessage(ctx, m); err != nil {
+	logger := pd.logger.WithContext(ctx).WithFields(log.String("sender", pid.String()), log.Binary("message", msg))
+	logger.Debug("new first votes")
+	if err := pd.handleFirstVotes(ctx, pid, msg); err != nil {
 		logger.With().Warning("failed to handle first voting message", log.Err(err))
 		return pubsub.ValidationIgnore
 	}
 	return pubsub.ValidationAccept
 }
 
-func (pd *ProtocolDriver) handleFirstVotingMessage(ctx context.Context, message FirstVotingMessage) error {
-	currentEpoch := pd.currentEpoch()
+func (pd *ProtocolDriver) handleFirstVotes(ctx context.Context, pid peer.ID, msg []byte) error {
+	logger := pd.logger.WithContext(ctx).WithFields(types.FirstRound, log.String("sender", pid.String()))
 
-	minerPK, atxID, err := pd.verifyFirstVotingMessage(ctx, message, currentEpoch)
+	var m FirstVotingMessage
+	if err := types.BytesToInterface(msg, &m); err != nil {
+		logger.With().Warning("received invalid first votes", log.Binary("message", msg), log.Err(err))
+		return errMalformedMessage
+	}
+
+	currentEpoch := pd.currentEpoch()
+	if m.EpochID != currentEpoch {
+		logger.With().Debug("first votes from different epoch",
+			log.Uint32("current_epoch", uint32(currentEpoch)),
+			log.Uint32("message_epoch", uint32(m.EpochID)))
+		return errEpochNotActive
+	}
+
+	// don't accept more first vote after the round ends
+	currentRound := pd.currentRound()
+	if currentRound > types.FirstRound {
+		logger.With().Warning("first votes too late",
+			log.Uint32("current_round", uint32(currentRound)),
+			log.Uint32("message_round", uint32(types.FirstRound)))
+		return errUntimelyMessage
+	}
+
+	minerPK, atxID, err := pd.verifyFirstVotes(ctx, m)
 	if err != nil {
 		return err
 	}
 
 	minerID := types.NodeID{Key: minerPK.String()}.ShortString()
-	logger := pd.logger.WithContext(ctx).WithFields(currentEpoch, types.FirstRound, log.String("miner_id", minerID))
+	logger = pd.logger.WithContext(ctx).WithFields(m.EpochID, types.FirstRound, log.String("miner_id", minerID))
 	atx, err := pd.atxDB.GetAtxHeader(atxID)
 	if err != nil {
 		logger.With().Error("failed to get ATX header", atxID, log.Err(err))
@@ -302,38 +267,30 @@ func (pd *ProtocolDriver) handleFirstVotingMessage(ctx context.Context, message 
 	voteWeight := new(big.Int).SetUint64(atx.GetWeight())
 
 	logger.Debug("received first voting message, storing its votes")
-	pd.storeFirstVotes(message, minerPK, voteWeight)
-
-	return nil
+	return pd.storeFirstVotes(m, minerPK, voteWeight)
 }
 
-func (pd *ProtocolDriver) verifyFirstVotingMessage(ctx context.Context, message FirstVotingMessage, currentEpoch types.EpochID) (*signing.PublicKey, types.ATXID, error) {
-	// don't accept more first vote after the round ends
-	currentRound := pd.currentRound()
-	if currentRound > types.FirstRound {
-		return nil, types.ATXID{}, fmt.Errorf("[round %v] message too late. protocol has advanced to round %v", types.FirstRound, currentRound)
-	}
-
-	logger := pd.logger.WithContext(ctx).WithFields(currentEpoch, types.FirstRound)
-	messageBytes, err := types.InterfaceToBytes(message.FirstVotingMessageBody)
+func (pd *ProtocolDriver) verifyFirstVotes(ctx context.Context, m FirstVotingMessage) (*signing.PublicKey, types.ATXID, error) {
+	logger := pd.logger.WithContext(ctx).WithFields(m.EpochID, types.FirstRound)
+	messageBytes, err := types.InterfaceToBytes(m.FirstVotingMessageBody)
 	if err != nil {
 		logger.With().Panic("failed to serialize first voting message", log.Err(err))
 	}
 
-	minerPK, err := pd.edVerifier.Extract(messageBytes, message.Signature)
+	minerPK, err := pd.edVerifier.Extract(messageBytes, m.Signature)
 	if err != nil {
-		return nil, types.ATXID{}, fmt.Errorf("[round %v] unable to recover ID from signature %x: %w", types.FirstRound, message.Signature, err)
+		return nil, types.ATXID{}, fmt.Errorf("[round %v] unable to recover ID from signature %x: %w", types.FirstRound, m.Signature, err)
 	}
 
 	nodeID := types.NodeID{Key: minerPK.String()}
 	minerID := nodeID.ShortString()
 	logger = logger.WithFields(log.String("miner_id", minerID))
 
-	if err := pd.registerVoted(logger, minerPK, types.FirstRound); err != nil {
+	if err := pd.registerVoted(logger, m.EpochID, minerPK, types.FirstRound); err != nil {
 		return nil, types.ATXID{}, fmt.Errorf("[round %v] failed to register proposal (miner ID %v): %w", types.FirstRound, minerID, err)
 	}
 
-	atxID, err := pd.atxDB.GetNodeAtxIDForEpoch(nodeID, currentEpoch-1)
+	atxID, err := pd.atxDB.GetNodeAtxIDForEpoch(nodeID, m.EpochID-1)
 	if errors.Is(err, database.ErrNotFound) {
 		logger.Warning("miner has no ATX in the previous epoch")
 		return nil, types.ATXID{}, fmt.Errorf("[round %v] miner has no ATX in previous epoch (miner ID %v): %w", types.FirstRound, minerID, errMinerATXNotFound)
@@ -347,87 +304,96 @@ func (pd *ProtocolDriver) verifyFirstVotingMessage(ctx context.Context, message 
 	return minerPK, atxID, nil
 }
 
-func (pd *ProtocolDriver) storeFirstVotes(message FirstVotingMessage, minerPK *signing.PublicKey, voteWeight *big.Int) {
+func (pd *ProtocolDriver) storeFirstVotes(m FirstVotingMessage, minerPK *signing.PublicKey, voteWeight *big.Int) error {
 	if !pd.isInProtocol() {
 		pd.logger.Debug("beacon not in protocol, not storing first votes")
-		return
+		return errProtocolNotRunning
 	}
 
 	pd.mu.Lock()
 	defer pd.mu.Unlock()
 
-	for _, proposal := range message.ValidProposals {
-		pd.current.addVote(string(proposal), up, voteWeight)
+	if _, ok := pd.states[m.EpochID]; !ok {
+		return errEpochNotActive
 	}
 
-	for _, proposal := range message.PotentiallyValidProposals {
-		pd.current.addVote(string(proposal), down, voteWeight)
+	for _, proposal := range m.ValidProposals {
+		pd.states[m.EpochID].addVote(string(proposal), up, voteWeight)
+	}
+
+	for _, proposal := range m.PotentiallyValidProposals {
+		pd.states[m.EpochID].addVote(string(proposal), down, voteWeight)
 	}
 
 	// this is used for bit vector calculation
-	voteList := append(message.ValidProposals, message.PotentiallyValidProposals...)
+	voteList := append(m.ValidProposals, m.PotentiallyValidProposals...)
 	if uint32(len(voteList)) > pd.config.VotesLimit {
 		voteList = voteList[:pd.config.VotesLimit]
 	}
 
-	pd.current.setMinerFirstRoundVote(minerPK, voteList)
+	pd.states[m.EpochID].setMinerFirstRoundVote(minerPK, voteList)
+	return nil
 }
 
-// HandleSerializedFollowingVotingMessage defines method to handle following voting Messages from gossip.
-func (pd *ProtocolDriver) HandleSerializedFollowingVotingMessage(ctx context.Context, pid peer.ID, msg []byte) pubsub.ValidationResult {
+// HandleFollowingVotes handles beacon following votes from gossip.
+func (pd *ProtocolDriver) HandleFollowingVotes(ctx context.Context, pid peer.ID, msg []byte) pubsub.ValidationResult {
+	receivedTime := time.Now()
+
 	if pd.isClosed() || !pd.isInProtocol() {
 		pd.logger.WithContext(ctx).Debug("beacon protocol shutting down or not running, dropping msg")
 		return pubsub.ValidationIgnore
 	}
 
-	logger := pd.logger.WithContext(ctx).WithFields(
-		log.String("sender", pid.String()),
-		log.Binary("message", msg))
-
-	logger.Debug("new voting message")
-
-	var m FollowingVotingMessage
-	if err := types.BytesToInterface(msg, &m); err != nil {
-		logger.With().Warning("received invalid voting message", log.Err(err))
-		return pubsub.ValidationIgnore
-	}
-
-	currentEpoch := pd.currentEpoch()
-	if m.EpochID != currentEpoch {
-		logger.With().Debug("following voting message from different epoch",
-			log.Uint32("current_epoch", uint32(currentEpoch)),
-			log.Uint32("message_epoch", uint32(m.EpochID)))
-		return pubsub.ValidationIgnore
-	}
-
-	if err := pd.handleFollowingVotingMessage(ctx, m); err != nil {
+	logger := pd.logger.WithContext(ctx).WithFields(log.String("sender", pid.String()), log.Binary("message", msg))
+	logger.Debug("new following votes")
+	if err := pd.handleFollowingVotes(ctx, pid, msg, receivedTime); err != nil {
 		logger.With().Warning("failed to handle following voting message", log.Err(err))
 		return pubsub.ValidationIgnore
 	}
 	return pubsub.ValidationAccept
 }
 
-func (pd *ProtocolDriver) handleFollowingVotingMessage(ctx context.Context, message FollowingVotingMessage) error {
-	currentEpoch := pd.currentEpoch()
+func (pd *ProtocolDriver) handleFollowingVotes(ctx context.Context, pid peer.ID, msg []byte, receivedTime time.Time) error {
+	logger := pd.logger.WithContext(ctx).WithFields(log.String("sender", pid.String()))
 
-	minerPK, atxID, err := pd.verifyFollowingVotingMessage(ctx, message, currentEpoch)
+	var m FollowingVotingMessage
+	if err := types.BytesToInterface(msg, &m); err != nil {
+		logger.With().Warning("received malformed following votes", log.Binary("message", msg), log.Err(err))
+		return errMalformedMessage
+	}
+
+	currentEpoch := pd.currentEpoch()
+	if m.EpochID != currentEpoch {
+		logger.With().Debug("following votes from different epoch",
+			log.Uint32("current_epoch", uint32(currentEpoch)),
+			log.Uint32("message_epoch", uint32(m.EpochID)))
+		return errEpochNotActive
+	}
+
+	// don't accept votes from future rounds
+	if !pd.isVoteTimely(&m) {
+		logger.With().Warning("following votes too early", m.RoundID, log.Time("received_at", receivedTime))
+		return errUntimelyMessage
+	}
+
+	minerPK, atxID, err := pd.verifyFollowingVotes(ctx, m)
 	if err != nil {
 		return err
 	}
 
 	minerID := types.NodeID{Key: minerPK.String()}.ShortString()
-	logger := pd.logger.WithContext(ctx).WithFields(currentEpoch, message.RoundID, log.String("miner_id", minerID))
+	logger = pd.logger.WithContext(ctx).WithFields(m.EpochID, m.RoundID, log.String("miner_id", minerID))
 
 	atx, err := pd.atxDB.GetAtxHeader(atxID)
 	if err != nil {
 		logger.With().Error("failed to get ATX header", atxID, log.Err(err))
-		return fmt.Errorf("[round %v] failed to get ATX header (miner ID %v, ATX ID %v): %w", message.RoundID, minerID, atxID, err)
+		return fmt.Errorf("[round %v] failed to get ATX header (miner ID %v, ATX ID %v): %w", m.RoundID, minerID, atxID, err)
 	}
 
 	voteWeight := new(big.Int).SetUint64(atx.GetWeight())
 
 	logger.Debug("received following voting message, counting its votes")
-	if err = pd.storeFollowingVotes(message, minerPK, voteWeight); err != nil {
+	if err = pd.storeFollowingVotes(m, minerPK, voteWeight); err != nil {
 		logger.With().Warning("failed to store following votes", log.Err(err))
 		return err
 	}
@@ -435,34 +401,27 @@ func (pd *ProtocolDriver) handleFollowingVotingMessage(ctx context.Context, mess
 	return nil
 }
 
-func (pd *ProtocolDriver) verifyFollowingVotingMessage(ctx context.Context, message FollowingVotingMessage, currentEpoch types.EpochID) (*signing.PublicKey, types.ATXID, error) {
-	round := message.RoundID
-
-	// don't accept votes from future rounds
-	currentRound := pd.currentRound()
-	if round > currentRound {
-		return nil, types.ATXID{}, fmt.Errorf("[round %v] message too early. protocol is at round %v", round, currentRound)
-	}
-
-	messageBytes, err := types.InterfaceToBytes(message.FollowingVotingMessageBody)
+func (pd *ProtocolDriver) verifyFollowingVotes(ctx context.Context, m FollowingVotingMessage) (*signing.PublicKey, types.ATXID, error) {
+	round := m.RoundID
+	messageBytes, err := types.InterfaceToBytes(m.FollowingVotingMessageBody)
 	if err != nil {
 		pd.logger.With().Panic("failed to serialize voting message", log.Err(err))
 	}
 
-	minerPK, err := pd.edVerifier.Extract(messageBytes, message.Signature)
+	minerPK, err := pd.edVerifier.Extract(messageBytes, m.Signature)
 	if err != nil {
-		return nil, types.ATXID{}, fmt.Errorf("[round %v] unable to recover ID from signature %x: %w", round, message.Signature, err)
+		return nil, types.ATXID{}, fmt.Errorf("[round %v] unable to recover ID from signature %x: %w", round, m.Signature, err)
 	}
 
 	nodeID := types.NodeID{Key: minerPK.String()}
 	minerID := nodeID.ShortString()
-	logger := pd.logger.WithContext(ctx).WithFields(currentEpoch, round, log.String("miner_id", minerID))
+	logger := pd.logger.WithContext(ctx).WithFields(m.EpochID, round, log.String("miner_id", minerID))
 
-	if err := pd.registerVoted(logger, minerPK, message.RoundID); err != nil {
+	if err := pd.registerVoted(logger, m.EpochID, minerPK, m.RoundID); err != nil {
 		return nil, types.ATXID{}, err
 	}
 
-	atxID, err := pd.atxDB.GetNodeAtxIDForEpoch(nodeID, currentEpoch-1)
+	atxID, err := pd.atxDB.GetNodeAtxIDForEpoch(nodeID, m.EpochID-1)
 	if errors.Is(err, database.ErrNotFound) {
 		logger.Warning("miner has no ATX in the previous epoch")
 		return nil, types.ATXID{}, fmt.Errorf("[round %v] miner has no ATX in previous epoch (miner ID %v): %w", round, minerID, errMinerATXNotFound)
@@ -476,45 +435,54 @@ func (pd *ProtocolDriver) verifyFollowingVotingMessage(ctx context.Context, mess
 	return minerPK, atxID, nil
 }
 
-func (pd *ProtocolDriver) storeFollowingVotes(message FollowingVotingMessage, minerPK *signing.PublicKey, voteWeight *big.Int) error {
+func (pd *ProtocolDriver) storeFollowingVotes(m FollowingVotingMessage, minerPK *signing.PublicKey, voteWeight *big.Int) error {
 	if !pd.isInProtocol() {
 		pd.logger.Debug("beacon not in protocol, not storing following votes")
-		return nil
+		return errProtocolNotRunning
 	}
 
-	firstRoundVotes, err := pd.getFirstRoundVote(minerPK)
+	firstRoundVotes, err := pd.getFirstRoundVote(m.EpochID, minerPK)
 	if err != nil {
 		return fmt.Errorf("failed to get miner first round votes %v: %w", minerPK.String(), err)
 	}
 
-	thisRoundVotes := decodeVotes(message.VotesBitVector, firstRoundVotes)
-	pd.addToVoteMargin(thisRoundVotes, voteWeight)
-	return nil
+	thisRoundVotes := decodeVotes(m.VotesBitVector, firstRoundVotes)
+	return pd.addToVoteMargin(m.EpochID, thisRoundVotes, voteWeight)
 }
 
-func (pd *ProtocolDriver) getProposalPhaseFinishedTime() time.Time {
+func (pd *ProtocolDriver) getProposalPhaseFinishedTime(epoch types.EpochID) time.Time {
 	pd.mu.RLock()
 	defer pd.mu.RUnlock()
-	return pd.current.proposalPhaseFinishedTime
+	if s, ok := pd.states[epoch]; ok {
+		return s.proposalPhaseFinishedTime
+	}
+	// if this epoch doesn't exist, it is finished. returns something
+	// always in the past but different from time.Time{}
+	return time.Time{}.Add(time.Second)
 }
 
-func (pd *ProtocolDriver) addToVoteMargin(thisRoundVotes allVotes, voteWeight *big.Int) {
+func (pd *ProtocolDriver) addToVoteMargin(epoch types.EpochID, thisRoundVotes allVotes, voteWeight *big.Int) error {
 	pd.mu.Lock()
 	defer pd.mu.Unlock()
 
+	if _, ok := pd.states[epoch]; !ok {
+		return errEpochNotActive
+	}
 	for proposal := range thisRoundVotes.support {
-		pd.current.addVote(proposal, up, voteWeight)
+		pd.states[epoch].addVote(proposal, up, voteWeight)
 	}
 
 	for proposal := range thisRoundVotes.against {
-		pd.current.addVote(proposal, down, voteWeight)
+		pd.states[epoch].addVote(proposal, down, voteWeight)
 	}
+
+	return nil
 }
 
 func (pd *ProtocolDriver) currentEpoch() types.EpochID {
 	pd.mu.RLock()
 	defer pd.mu.RUnlock()
-	return pd.epochInProgress
+	return pd.clock.GetCurrentLayer().GetEpoch()
 }
 
 func (pd *ProtocolDriver) currentRound() types.RoundID {
@@ -523,39 +491,59 @@ func (pd *ProtocolDriver) currentRound() types.RoundID {
 	return pd.roundInProgress
 }
 
-func (pd *ProtocolDriver) checkProposalEligibility(logger log.Log, vrfSig []byte) bool {
+func (pd *ProtocolDriver) isProposalTimely(p *ProposalMessage) bool {
 	pd.mu.RLock()
 	defer pd.mu.RUnlock()
-	eligible := pd.current.proposalChecker.IsProposalEligible(vrfSig)
+
+	currentEpoch := pd.clock.GetCurrentLayer().GetEpoch()
+	switch p.EpochID {
+	case currentEpoch:
+		return true
+	case currentEpoch + 1:
+		return true
+	}
+	return false
+}
+
+func (pd *ProtocolDriver) isVoteTimely(m *FollowingVotingMessage) bool {
+	pd.mu.RLock()
+	defer pd.mu.RUnlock()
+	return m.RoundID == pd.roundInProgress
+}
+
+func (pd *ProtocolDriver) checkProposalEligibility(logger log.Log, epoch types.EpochID, vrfSig []byte) bool {
+	pd.mu.RLock()
+	defer pd.mu.RUnlock()
+	if _, ok := pd.states[epoch]; !ok {
+		return false
+	}
+
+	eligible := pd.states[epoch].proposalChecker.IsProposalEligible(vrfSig)
 	if !eligible {
 		// the peer may have different total weight from us so that it passes threshold for the peer
 		// but does not pass here
 		proposalShortString := types.BytesToHash(vrfSig).ShortString()
 		logger.With().Warning("proposal doesn't pass threshold",
 			log.String("proposal", proposalShortString),
-			log.Uint64("total_weight", pd.current.epochWeight))
+			log.Uint64("total_weight", pd.states[epoch].epochWeight))
 	}
 	return eligible
 }
 
-func (pd *ProtocolDriver) registerProposed(logger log.Log, minerPK *signing.PublicKey) error {
-	if !pd.isInProtocol() {
-		pd.logger.Debug("beacon not in protocol, not registering proposal")
-		return errProtocolNotRunning
-	}
-
+func (pd *ProtocolDriver) registerProposed(logger log.Log, epoch types.EpochID, minerPK *signing.PublicKey) error {
 	pd.mu.Lock()
 	defer pd.mu.Unlock()
-	return pd.current.registerProposed(logger, minerPK)
+	if _, ok := pd.states[epoch]; !ok {
+		return errEpochNotActive
+	}
+	return pd.states[epoch].registerProposed(logger, minerPK)
 }
 
-func (pd *ProtocolDriver) registerVoted(logger log.Log, minerPK *signing.PublicKey, round types.RoundID) error {
-	if !pd.isInProtocol() {
-		pd.logger.Debug("beacon not in protocol, not registering votes")
-		return errProtocolNotRunning
-	}
-
+func (pd *ProtocolDriver) registerVoted(logger log.Log, epoch types.EpochID, minerPK *signing.PublicKey, round types.RoundID) error {
 	pd.mu.Lock()
 	defer pd.mu.Unlock()
-	return pd.current.registerVoted(logger, minerPK, round)
+	if _, ok := pd.states[epoch]; !ok {
+		return errEpochNotActive
+	}
+	return pd.states[epoch].registerVoted(logger, minerPK, round)
 }

--- a/beacon/handlers_test.go
+++ b/beacon/handlers_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"math/big"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -14,65 +13,82 @@ import (
 
 	"github.com/spacemeshos/go-spacemesh/beacon/mocks"
 	"github.com/spacemeshos/go-spacemesh/common/types"
-	"github.com/spacemeshos/go-spacemesh/database"
 	"github.com/spacemeshos/go-spacemesh/log/logtest"
+	"github.com/spacemeshos/go-spacemesh/p2p/pubsub"
 	"github.com/spacemeshos/go-spacemesh/signing"
-	"github.com/spacemeshos/go-spacemesh/timesync"
+	"github.com/spacemeshos/go-spacemesh/sql"
 )
 
-const peerID = "peer1"
+const (
+	epochWeight = uint64(100)
+)
 
-var errUnknown = errors.New("unknown")
-
-func clockNeverNotify(t *testing.T) layerClock {
-	return timesync.NewClock(timesync.RealClock{}, time.Hour, time.Now(), logtest.New(t).WithName("clock"))
+func createProtocolDriver(t *testing.T, epoch types.EpochID) *testProtocolDriver {
+	t.Helper()
+	tpd := setUpProtocolDriver(t)
+	createEpochState(t, tpd.ProtocolDriver, epoch)
+	tpd.setBeginProtocol(context.TODO())
+	return tpd
 }
 
-func createProtocolDriver(t *testing.T, epoch types.EpochID) (*ProtocolDriver, *mocks.MockactivationDB) {
-	types.SetLayersPerEpoch(3)
-	ctrl := gomock.NewController(t)
-	mockDB := mocks.NewMockactivationDB(ctrl)
-	edSgn := signing.NewEdSigner()
-	cfg := UnitTestConfig()
-	pd := &ProtocolDriver{
-		logger:          logtest.New(t).WithName("Beacon"),
-		clock:           clockNeverNotify(t),
-		config:          cfg,
-		atxDB:           mockDB,
-		edSigner:        edSgn,
-		edVerifier:      signing.NewEDVerifier(),
-		vrfVerifier:     signing.VRFVerifier{},
-		current:         newState(cfg),
-		next:            newState(cfg),
-		epochInProgress: epoch,
-		running:         1,
-		inProtocol:      1,
-	}
-	return pd, mockDB
+func createProtocolDriverWithFirstRoundVotes(t *testing.T, signer signing.Signer, epoch types.EpochID, round types.RoundID) (*testProtocolDriver, proposalList) {
+	tpd := createProtocolDriver(t, epoch)
+	plist := proposalList{types.RandomBytes(types.BeaconSize), types.RandomBytes(types.BeaconSize), types.RandomBytes(types.BeaconSize)}
+	setFirstRoundVotes(t, tpd.ProtocolDriver, epoch, signer.PublicKey(), plist)
+	tpd.setRoundInProgress(round)
+	return tpd, plist
 }
 
-func createProtocolDriverWithFirstRoundVotes(t *testing.T, epoch types.EpochID, signer signing.Signer) (*ProtocolDriver, *mocks.MockactivationDB, []types.Hash32) {
-	pd, mockDB := createProtocolDriver(t, epoch)
-	hash1 := types.HexToHash32("0x12345678")
-	hash2 := types.HexToHash32("0x23456789")
-	hash3 := types.HexToHash32("0x34567890")
+func createEpochState(t *testing.T, pd *ProtocolDriver, epoch types.EpochID) {
+	t.Helper()
 	pd.mu.Lock()
 	defer pd.mu.Unlock()
-	pd.current.setMinerFirstRoundVote(signer.PublicKey(), [][]byte{hash1.Bytes(), hash2.Bytes(), hash3.Bytes()})
-	return pd, mockDB, []types.Hash32{hash1, hash2, hash3}
+	pd.states[epoch] = newState(pd.logger, pd.config, epochWeight, nil)
 }
 
-func setMockAtxDbExpectations(mockDB *mocks.MockactivationDB) {
-	mockDB.EXPECT().GetNodeAtxIDForEpoch(gomock.Any(), gomock.Any()).
-		Return(types.ATXID(types.HexToHash32("0x22345678")), nil).Times(1)
-	mockDB.EXPECT().GetAtxHeader(gomock.Any()).Return(&types.ActivationTxHeader{
+func setFirstRoundVotes(t *testing.T, pd *ProtocolDriver, epoch types.EpochID, minerPK *signing.PublicKey, plist proposalList) {
+	t.Helper()
+	pd.mu.Lock()
+	defer pd.mu.Unlock()
+	pd.states[epoch].setMinerFirstRoundVote(minerPK, plist)
+}
+
+func setMockAtxDbForProposals(mockDB *mocks.MockactivationDB, epoch types.EpochID) {
+	atxID := types.RandomATXID()
+	mockDB.EXPECT().GetNodeAtxIDForEpoch(gomock.Any(), epoch-1).
+		Return(atxID, nil).Times(1)
+	mockDB.EXPECT().GetAtxHeader(atxID).Return(&types.ActivationTxHeader{
+		NIPostChallenge: types.NIPostChallenge{
+			StartTick:  1,
+			EndTick:    3,
+			PubLayerID: epoch.FirstLayer().Sub(1),
+		},
+		NumUnits: 5,
+	}, nil).Times(1)
+	mockDB.EXPECT().GetAtxTimestamp(atxID).Return(time.Now().Add(-1*time.Second), nil).Times(1)
+}
+
+func setMockAtxDbForVotes(mockDB *mocks.MockactivationDB, epoch types.EpochID) {
+	atxID := types.RandomATXID()
+	mockDB.EXPECT().GetNodeAtxIDForEpoch(gomock.Any(), epoch-1).Return(atxID, nil).Times(1)
+	mockDB.EXPECT().GetAtxHeader(atxID).Return(&types.ActivationTxHeader{
 		NIPostChallenge: types.NIPostChallenge{
 			StartTick: 1,
 			EndTick:   3,
 		},
 		NumUnits: 5,
 	}, nil).Times(1)
-	mockDB.EXPECT().GetAtxTimestamp(gomock.Any()).Return(time.Now().Add(-1*time.Second), nil).Times(1)
+}
+
+func mockAlwaysFalseProposalChecker(t *testing.T, pd *ProtocolDriver, epoch types.EpochID) {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	mockChecker := mocks.NewMockeligibilityChecker(ctrl)
+	mockChecker.EXPECT().IsProposalEligible(gomock.Any()).Return(false).Times(1)
+	pd.mu.Lock()
+	defer pd.mu.Unlock()
+	require.NotNil(t, pd.states[epoch])
+	pd.states[epoch].proposalChecker = mockChecker
 }
 
 func createProposal(t *testing.T, signer, vrfSigner signing.Signer, epoch types.EpochID, corruptSignature bool) *ProposalMessage {
@@ -92,29 +108,33 @@ func createProposal(t *testing.T, signer, vrfSigner signing.Signer, epoch types.
 	return msg
 }
 
-func checkProposalQueueSize(t *testing.T, pd *ProtocolDriver, numProposals int) {
-	pd.mu.RLock()
-	defer pd.mu.RUnlock()
-	assert.Equal(t, numProposals, len(pd.current.proposalChan))
+func setEarliestProposalTime(pd *ProtocolDriver, t time.Time) {
+	pd.mu.Lock()
+	defer pd.mu.Unlock()
+	pd.earliestProposalTime = t
 }
 
-func checkFutureProposalQueueSize(t *testing.T, pd *ProtocolDriver, numProposals int) {
+func checkProposed(t *testing.T, pd *ProtocolDriver, epoch types.EpochID, minerPK *signing.PublicKey, expected bool) {
 	pd.mu.RLock()
 	defer pd.mu.RUnlock()
-	assert.Equal(t, numProposals, len(pd.next.proposalChan))
+
+	if _, ok := pd.states[epoch]; ok {
+		_, proposed := pd.states[epoch].hasProposed[string(minerPK.Bytes())]
+		assert.Equal(t, expected, proposed)
+	} else {
+		assert.False(t, expected)
+	}
 }
 
-func checkProposed(t *testing.T, pd *ProtocolDriver, signer signing.Signer, proposed bool) {
+func checkProposals(t *testing.T, pd *ProtocolDriver, epoch types.EpochID, expected proposals) {
 	pd.mu.RLock()
 	defer pd.mu.RUnlock()
-	_, ok := pd.current.hasProposed[string(signer.PublicKey().Bytes())]
-	assert.Equal(t, proposed, ok)
-}
 
-func checkProposals(t *testing.T, pd *ProtocolDriver, expected proposals) {
-	pd.mu.RLock()
-	defer pd.mu.RUnlock()
-	assert.EqualValues(t, expected, pd.current.incomingProposals)
+	if _, ok := pd.states[epoch]; ok {
+		assert.EqualValues(t, expected, pd.states[epoch].incomingProposals)
+	} else {
+		assert.Equal(t, expected, proposals{})
+	}
 }
 
 func createFirstVote(t *testing.T, signer signing.Signer, epoch types.EpochID, valid, pValid [][]byte, corruptSignature bool) *FirstVotingMessage {
@@ -134,17 +154,19 @@ func createFirstVote(t *testing.T, signer signing.Signer, epoch types.EpochID, v
 	return msg
 }
 
-func checkVoted(t *testing.T, pd *ProtocolDriver, signer signing.Signer, round types.RoundID, voted bool) {
+func checkVoted(t *testing.T, pd *ProtocolDriver, epoch types.EpochID, signer signing.Signer, round types.RoundID, voted bool) {
 	pd.mu.RLock()
 	defer pd.mu.RUnlock()
-	_, ok := pd.current.hasVoted[round][string(signer.PublicKey().Bytes())]
+	require.NotNil(t, pd.states[epoch])
+	_, ok := pd.states[epoch].hasVoted[round][string(signer.PublicKey().Bytes())]
 	assert.Equal(t, voted, ok)
 }
 
-func checkFirstIncomingVotes(t *testing.T, pd *ProtocolDriver, expected map[string]proposalList) {
+func checkFirstIncomingVotes(t *testing.T, pd *ProtocolDriver, epoch types.EpochID, expected map[string]proposalList) {
 	pd.mu.RLock()
 	defer pd.mu.RUnlock()
-	assert.EqualValues(t, expected, pd.current.firstRoundIncomingVotes)
+	require.NotNil(t, pd.states[epoch])
+	assert.EqualValues(t, expected, pd.states[epoch].firstRoundIncomingVotes)
 }
 
 func createFollowingVote(t *testing.T, signer signing.Signer, epoch types.EpochID, round types.RoundID, bitVector []byte, corruptSignature bool) *FollowingVotingMessage {
@@ -164,18 +186,67 @@ func createFollowingVote(t *testing.T, signer signing.Signer, epoch types.EpochI
 	return msg
 }
 
-func checkVoteMargins(t *testing.T, pd *ProtocolDriver, expected map[string]*big.Int) {
+func checkVoteMargins(t *testing.T, pd *ProtocolDriver, epoch types.EpochID, expected map[string]*big.Int) {
 	pd.mu.RLock()
 	defer pd.mu.RUnlock()
-	assert.EqualValues(t, expected, pd.current.votesMargin)
+	require.NotNil(t, pd.states[epoch])
+	assert.EqualValues(t, expected, pd.states[epoch].votesMargin)
 }
 
-func Test_HandleSerializedProposalMessage_Success(t *testing.T) {
+func Test_HandleProposal_Success(t *testing.T) {
 	t.Parallel()
 
 	const epoch = types.EpochID(10)
+	tpd := createProtocolDriver(t, epoch)
 
-	pd, _ := createProtocolDriver(t, epoch)
+	signer1 := signing.NewEdSigner()
+	vrfSigner1, _, err := signing.NewVRFSigner(signer1.PublicKey().Bytes())
+	require.NoError(t, err)
+
+	msg1 := createProposal(t, signer1, vrfSigner1, epoch, false)
+	msgBytes1, err := types.InterfaceToBytes(msg1)
+	require.NoError(t, err)
+
+	tpd.mClock.EXPECT().GetCurrentLayer().Return(epoch.FirstLayer()).Times(1)
+	tpd.mClock.EXPECT().LayerToTime(epoch.FirstLayer()).Return(time.Now()).Times(1)
+	setMockAtxDbForProposals(tpd.mAtxDB, epoch)
+	res := tpd.HandleProposal(context.TODO(), "peerID", msgBytes1)
+	assert.Equal(t, pubsub.ValidationAccept, res)
+
+	tpd.markProposalPhaseFinished(epoch, time.Now())
+
+	signer2 := signing.NewEdSigner()
+	vrfSigner2, _, err := signing.NewVRFSigner(signer2.PublicKey().Bytes())
+	require.NoError(t, err)
+
+	msg2 := createProposal(t, signer2, vrfSigner2, epoch, false)
+	msgBytes2, err := types.InterfaceToBytes(msg2)
+	require.NoError(t, err)
+
+	tpd.mClock.EXPECT().GetCurrentLayer().Return(epoch.FirstLayer()).Times(1)
+	tpd.mClock.EXPECT().LayerToTime(epoch.FirstLayer()).Return(time.Now()).Times(1)
+	setMockAtxDbForProposals(tpd.mAtxDB, epoch)
+	res = tpd.HandleProposal(context.TODO(), "peerID", msgBytes2)
+	assert.Equal(t, pubsub.ValidationAccept, res)
+
+	p1 := msg1.VRFSignature[:types.BeaconSize]
+	p2 := msg2.VRFSignature[:types.BeaconSize]
+	checkProposed(t, tpd.ProtocolDriver, epoch, vrfSigner1.PublicKey(), true)
+	expectedProposals := proposals{
+		valid:            proposalSet{string(p1): struct{}{}},
+		potentiallyValid: proposalSet{string(p2): struct{}{}},
+	}
+	checkProposals(t, tpd.ProtocolDriver, epoch, expectedProposals)
+}
+
+func Test_HandleProposal_Shutdown(t *testing.T) {
+	t.Parallel()
+
+	const epoch = types.EpochID(10)
+	tpd := createProtocolDriver(t, epoch)
+	tpd.mClock.EXPECT().Unsubscribe(gomock.Any()).Times(1)
+	tpd.Close()
+
 	signer := signing.NewEdSigner()
 	vrfSigner, _, err := signing.NewVRFSigner(signer.Sign(signer.PublicKey().Bytes()))
 	require.NoError(t, err)
@@ -184,68 +255,71 @@ func Test_HandleSerializedProposalMessage_Success(t *testing.T) {
 	msgBytes, err := types.InterfaceToBytes(msg)
 	require.NoError(t, err)
 
-	pd.HandleSerializedProposalMessage(context.TODO(), peerID, msgBytes)
-	checkProposalQueueSize(t, pd, 1)
+	res := tpd.HandleProposal(context.TODO(), "peerID", msgBytes)
+	assert.Equal(t, pubsub.ValidationIgnore, res)
+
+	checkProposed(t, tpd.ProtocolDriver, epoch, vrfSigner.PublicKey(), false)
+	checkProposals(t, tpd.ProtocolDriver, epoch, proposals{})
 }
 
-func Test_HandleSerializedProposalMessage_Shutdown(t *testing.T) {
+func Test_HandleProposal_NotInProtocolStillWorks(t *testing.T) {
 	t.Parallel()
 
 	const epoch = types.EpochID(10)
-	pd, _ := createProtocolDriver(t, epoch)
+	tpd := createProtocolDriver(t, epoch)
+
 	signer := signing.NewEdSigner()
 	vrfSigner, _, err := signing.NewVRFSigner(signer.Sign(signer.PublicKey().Bytes()))
 	require.NoError(t, err)
 
-	atomic.StoreUint64(&pd.running, 0)
 	msg := createProposal(t, signer, vrfSigner, epoch, false)
 	msgBytes, err := types.InterfaceToBytes(msg)
 	require.NoError(t, err)
 
-	pd.HandleSerializedProposalMessage(context.TODO(), peerID, msgBytes)
-	checkProposalQueueSize(t, pd, 0)
+	tpd.mClock.EXPECT().GetCurrentLayer().Return(epoch.FirstLayer()).Times(1)
+	tpd.mClock.EXPECT().LayerToTime(epoch.FirstLayer()).Return(time.Now()).Times(1)
+	setMockAtxDbForProposals(tpd.mAtxDB, epoch)
+
+	tpd.setEndProtocol(context.TODO())
+	require.False(t, tpd.isInProtocol())
+	res := tpd.HandleProposal(context.TODO(), "peerID", msgBytes)
+	assert.Equal(t, pubsub.ValidationAccept, res)
+
+	p := msg.VRFSignature[:types.BeaconSize]
+	checkProposed(t, tpd.ProtocolDriver, epoch, vrfSigner.PublicKey(), true)
+	expectedProposals := proposals{
+		valid: proposalSet{string(p): struct{}{}},
+	}
+	checkProposals(t, tpd.ProtocolDriver, epoch, expectedProposals)
 }
 
-func Test_HandleSerializedProposalMessage_NotInProtocol(t *testing.T) {
+func Test_handleProposal_Corrupted(t *testing.T) {
 	t.Parallel()
 
 	const epoch = types.EpochID(10)
-	pd, _ := createProtocolDriver(t, epoch)
+	tpd := createProtocolDriver(t, epoch)
+
 	signer := signing.NewEdSigner()
 	vrfSigner, _, err := signing.NewVRFSigner(signer.Sign(signer.PublicKey().Bytes()))
 	require.NoError(t, err)
 
-	atomic.StoreUint64(&pd.inProtocol, 0)
 	msg := createProposal(t, signer, vrfSigner, epoch, false)
 	msgBytes, err := types.InterfaceToBytes(msg)
 	require.NoError(t, err)
 
-	pd.HandleSerializedProposalMessage(context.TODO(), peerID, msgBytes)
-	checkProposalQueueSize(t, pd, 0)
+	got := tpd.handleProposal(context.TODO(), "peerID", msgBytes[1:], time.Now())
+	assert.ErrorIs(t, got, errMalformedMessage)
+
+	checkProposed(t, tpd.ProtocolDriver, epoch, vrfSigner.PublicKey(), false)
+	checkProposals(t, tpd.ProtocolDriver, epoch, proposals{})
 }
 
-func Test_HandleSerializedProposalMessage_Corrupted(t *testing.T) {
+func Test_handleProposal_EpochTooOld(t *testing.T) {
 	t.Parallel()
 
 	const epoch = types.EpochID(10)
-	pd, _ := createProtocolDriver(t, epoch)
-	signer := signing.NewEdSigner()
-	vrfSigner, _, err := signing.NewVRFSigner(signer.Sign(signer.PublicKey().Bytes()))
-	require.NoError(t, err)
+	tpd := createProtocolDriver(t, epoch)
 
-	msg := createProposal(t, signer, vrfSigner, epoch, true)
-	msgBytes, err := types.InterfaceToBytes(msg)
-	require.NoError(t, err)
-
-	pd.HandleSerializedProposalMessage(context.TODO(), peerID, msgBytes[1:])
-	checkProposalQueueSize(t, pd, 0)
-}
-
-func Test_HandleSerializedProposalMessage_EpochTooOld(t *testing.T) {
-	t.Parallel()
-
-	const epoch = types.EpochID(10)
-	pd, _ := createProtocolDriver(t, epoch)
 	signer := signing.NewEdSigner()
 	vrfSigner, _, err := signing.NewVRFSigner(signer.Sign(signer.PublicKey().Bytes()))
 	require.NoError(t, err)
@@ -254,63 +328,86 @@ func Test_HandleSerializedProposalMessage_EpochTooOld(t *testing.T) {
 	msgBytes, err := types.InterfaceToBytes(msg)
 	require.NoError(t, err)
 
-	pd.HandleSerializedProposalMessage(context.TODO(), peerID, msgBytes)
-	checkProposalQueueSize(t, pd, 0)
-	checkFutureProposalQueueSize(t, pd, 0)
+	tpd.mClock.EXPECT().GetCurrentLayer().Return(epoch.FirstLayer()).Times(1)
+	got := tpd.handleProposal(context.TODO(), "peerID", msgBytes, time.Now())
+	assert.ErrorIs(t, got, errUntimelyMessage)
+
+	checkProposed(t, tpd.ProtocolDriver, epoch, vrfSigner.PublicKey(), false)
+	checkProposals(t, tpd.ProtocolDriver, epoch, proposals{})
 }
 
-func Test_HandleSerializedProposalMessage_NextEpoch(t *testing.T) {
+func Test_handleProposal_NextEpoch(t *testing.T) {
 	t.Parallel()
 
 	const epoch = types.EpochID(10)
-	pd, _ := createProtocolDriver(t, epoch)
+	const nextEpoch = epoch + 1
+	tpd := createProtocolDriver(t, epoch)
+	tpd.mAtxDB.EXPECT().GetEpochWeight(nextEpoch).Return(epochWeight, nil, nil).Times(1)
+
 	signer := signing.NewEdSigner()
 	vrfSigner, _, err := signing.NewVRFSigner(signer.Sign(signer.PublicKey().Bytes()))
 	require.NoError(t, err)
 
-	msg := createProposal(t, signer, vrfSigner, epoch+1, false)
+	msg := createProposal(t, signer, vrfSigner, nextEpoch, false)
 	msgBytes, err := types.InterfaceToBytes(msg)
 	require.NoError(t, err)
 
-	pd.HandleSerializedProposalMessage(context.TODO(), peerID, msgBytes)
-	checkProposalQueueSize(t, pd, 0)
-	checkFutureProposalQueueSize(t, pd, 1)
-}
+	setEarliestProposalTime(tpd.ProtocolDriver, time.Now().Add(-1*time.Second))
+	tpd.mClock.EXPECT().GetCurrentLayer().Return(epoch.FirstLayer()).AnyTimes()
+	tpd.mClock.EXPECT().LayerToTime((nextEpoch).FirstLayer()).Return(time.Now()).Times(1)
+	setMockAtxDbForProposals(tpd.mAtxDB, nextEpoch)
+	got := tpd.handleProposal(context.TODO(), "peerID", msgBytes, time.Now())
+	assert.NoError(t, got)
 
-func Test_HandleSerializedProposalMessage_NextEpochFull(t *testing.T) {
-	t.Parallel()
+	// nothing added to the current epoch
+	checkProposed(t, tpd.ProtocolDriver, epoch, vrfSigner.PublicKey(), false)
+	checkProposals(t, tpd.ProtocolDriver, epoch, proposals{})
 
-	const epoch = types.EpochID(10)
-	pd, _ := createProtocolDriver(t, epoch)
-	signer := signing.NewEdSigner()
-	vrfSigner, _, err := signing.NewVRFSigner(signer.Sign(signer.PublicKey().Bytes()))
-	require.NoError(t, err)
-
-	for i := 0; i < proposalChanCapacity; i++ {
-		msg := createProposal(t, signer, vrfSigner, epoch+1, false)
-		msgBytes, err := types.InterfaceToBytes(msg)
-		require.NoError(t, err)
-
-		pd.HandleSerializedProposalMessage(context.TODO(), peerID, msgBytes)
+	// proposal added to the next epoch
+	p := msg.VRFSignature[:types.BeaconSize]
+	checkProposed(t, tpd.ProtocolDriver, nextEpoch, vrfSigner.PublicKey(), true)
+	expectedProposals := proposals{
+		valid: proposalSet{string(p): struct{}{}},
 	}
-	checkProposalQueueSize(t, pd, 0)
-	checkFutureProposalQueueSize(t, pd, proposalChanCapacity)
-
-	// now try to overflow channel for the next epoch
-	msg := createProposal(t, signer, vrfSigner, epoch+1, false)
-	msgBytes, err := types.InterfaceToBytes(msg)
-	require.NoError(t, err)
-
-	pd.HandleSerializedProposalMessage(context.TODO(), peerID, msgBytes)
-	checkProposalQueueSize(t, pd, 0)
-	checkFutureProposalQueueSize(t, pd, proposalChanCapacity)
+	checkProposals(t, tpd.ProtocolDriver, nextEpoch, expectedProposals)
 }
 
-func Test_HandleSerializedProposalMessage_EpochTooFarAhead(t *testing.T) {
+func Test_handleProposal_NextEpochTooEarly(t *testing.T) {
 	t.Parallel()
 
 	const epoch = types.EpochID(10)
-	pd, _ := createProtocolDriver(t, epoch)
+	const nextEpoch = epoch + 1
+	tpd := createProtocolDriver(t, epoch)
+
+	signer := signing.NewEdSigner()
+	vrfSigner, _, err := signing.NewVRFSigner(signer.Sign(signer.PublicKey().Bytes()))
+	require.NoError(t, err)
+
+	msg := createProposal(t, signer, vrfSigner, nextEpoch, false)
+	msgBytes, err := types.InterfaceToBytes(msg)
+	require.NoError(t, err)
+
+	now := time.Now()
+	setEarliestProposalTime(tpd.ProtocolDriver, now.Add(1*time.Second))
+	tpd.mClock.EXPECT().GetCurrentLayer().Return(epoch.FirstLayer()).AnyTimes()
+	got := tpd.handleProposal(context.TODO(), "peerID", msgBytes, now)
+	assert.ErrorIs(t, got, errUntimelyMessage)
+
+	// nothing added to the current epoch
+	checkProposed(t, tpd.ProtocolDriver, epoch, vrfSigner.PublicKey(), false)
+	checkProposals(t, tpd.ProtocolDriver, epoch, proposals{})
+
+	// proposal added to the next epoch
+	checkProposed(t, tpd.ProtocolDriver, nextEpoch, vrfSigner.PublicKey(), false)
+	checkProposals(t, tpd.ProtocolDriver, nextEpoch, proposals{})
+}
+
+func Test_handleProposal_EpochTooFarAhead(t *testing.T) {
+	t.Parallel()
+
+	const epoch = types.EpochID(10)
+	tpd := createProtocolDriver(t, epoch)
+
 	signer := signing.NewEdSigner()
 	vrfSigner, _, err := signing.NewVRFSigner(signer.Sign(signer.PublicKey().Bytes()))
 	require.NoError(t, err)
@@ -319,766 +416,714 @@ func Test_HandleSerializedProposalMessage_EpochTooFarAhead(t *testing.T) {
 	msgBytes, err := types.InterfaceToBytes(msg)
 	require.NoError(t, err)
 
-	pd.HandleSerializedProposalMessage(context.TODO(), peerID, msgBytes)
-	checkProposalQueueSize(t, pd, 0)
-	checkFutureProposalQueueSize(t, pd, 0)
+	tpd.mClock.EXPECT().GetCurrentLayer().Return(epoch.FirstLayer()).Times(1)
+	got := tpd.handleProposal(context.TODO(), "peerID", msgBytes, time.Now())
+	assert.ErrorIs(t, got, errUntimelyMessage)
+
+	checkProposed(t, tpd.ProtocolDriver, epoch, vrfSigner.PublicKey(), false)
+	checkProposals(t, tpd.ProtocolDriver, epoch, proposals{})
 }
 
-func mockProposalChecker(t *testing.T, pd *ProtocolDriver, success bool, calls int) {
-	t.Helper()
-	ctrl := gomock.NewController(t)
-	mockChecker := mocks.NewMockeligibilityChecker(ctrl)
-	mockChecker.EXPECT().IsProposalEligible(gomock.Any()).Return(success).Times(calls)
-	pd.mu.Lock()
-	defer pd.mu.Unlock()
-	pd.current.proposalChecker = mockChecker
-}
-
-func Test_handleProposalMessage_Success(t *testing.T) {
+func Test_handleProposal_BadSignature(t *testing.T) {
 	t.Parallel()
 
 	const epoch = types.EpochID(10)
-	pd, mockDB := createProtocolDriver(t, epoch)
-	setMockAtxDbExpectations(mockDB)
-	signer1 := signing.NewEdSigner()
-	vrfSigner1, _, err := signing.NewVRFSigner(signer1.Sign(signer1.PublicKey().Bytes()))
-	require.NoError(t, err)
-	msg1 := createProposal(t, signer1, vrfSigner1, epoch, false)
-	mockProposalChecker(t, pd, true, 1)
-	err = pd.handleProposalMessage(context.TODO(), *msg1, time.Now())
-	assert.NoError(t, err)
-	checkProposed(t, pd, vrfSigner1, true)
-
-	// make the next proposal late
-	pd.markProposalPhaseFinished(epoch)
-
-	setMockAtxDbExpectations(mockDB)
-	signer2 := signing.NewEdSigner()
-	vrfSigner2, _, err := signing.NewVRFSigner(signer2.Sign(signer2.PublicKey().Bytes()))
-	require.NoError(t, err)
-	msg2 := createProposal(t, signer2, vrfSigner2, epoch, false)
-	mockProposalChecker(t, pd, true, 1)
-	err = pd.handleProposalMessage(context.TODO(), *msg2, time.Now())
-	assert.NoError(t, err)
-	checkProposed(t, pd, vrfSigner2, true)
-
-	p1 := msg1.VRFSignature[:types.BeaconSize]
-	p2 := msg2.VRFSignature[:types.BeaconSize]
-	expectedProposals := proposals{
-		valid:            proposalSet{string(p1): struct{}{}},
-		potentiallyValid: proposalSet{string(p2): struct{}{}},
-	}
-	checkProposals(t, pd, expectedProposals)
-}
-
-func Test_handleProposalMessage_BadSignature(t *testing.T) {
-	t.Parallel()
-
-	const epoch = types.EpochID(10)
-	pd, mockDB := createProtocolDriver(t, epoch)
-	mockDB.EXPECT().GetNodeAtxIDForEpoch(gomock.Any(), gomock.Any()).
-		Return(types.ATXID(types.HexToHash32("0x22345678")), nil).Times(1)
+	tpd := createProtocolDriver(t, epoch)
 
 	signer := signing.NewEdSigner()
 	vrfSigner, _, err := signing.NewVRFSigner(signer.Sign(signer.PublicKey().Bytes()))
 	require.NoError(t, err)
+
 	msg := createProposal(t, signer, vrfSigner, epoch, true)
+	msgBytes, err := types.InterfaceToBytes(msg)
+	require.NoError(t, err)
 
-	err = pd.handleProposalMessage(context.TODO(), *msg, time.Now())
-	assert.ErrorIs(t, err, errVRFNotVerified)
+	tpd.mClock.EXPECT().GetCurrentLayer().Return(epoch.FirstLayer()).Times(1)
+	tpd.mAtxDB.EXPECT().GetNodeAtxIDForEpoch(gomock.Any(), epoch-1).Return(types.ATXID{}, nil).Times(1)
+	got := tpd.handleProposal(context.TODO(), "peerID", msgBytes, time.Now())
+	assert.ErrorIs(t, got, errVRFNotVerified)
 
-	checkProposed(t, pd, vrfSigner, false)
-	checkProposals(t, pd, proposals{})
+	checkProposed(t, tpd.ProtocolDriver, epoch, vrfSigner.PublicKey(), false)
+	checkProposals(t, tpd.ProtocolDriver, epoch, proposals{})
 }
 
-func Test_handleProposalMessage_AlreadyProposed(t *testing.T) {
+func Test_handleProposal_AlreadyProposed(t *testing.T) {
 	t.Parallel()
 
 	const epoch = types.EpochID(10)
-	pd, mockDB := createProtocolDriver(t, epoch)
-	setMockAtxDbExpectations(mockDB)
+	tpd := createProtocolDriver(t, epoch)
+
 	signer := signing.NewEdSigner()
 	vrfSigner, _, err := signing.NewVRFSigner(signer.Sign(signer.PublicKey().Bytes()))
 	require.NoError(t, err)
-	msg := createProposal(t, signer, vrfSigner, epoch, false)
 
-	mockProposalChecker(t, pd, true, 1)
+	msg1 := createProposal(t, signer, vrfSigner, epoch, false)
+	msgBytes1, err := types.InterfaceToBytes(msg1)
+	require.NoError(t, err)
 
-	err = pd.handleProposalMessage(context.TODO(), *msg, time.Now())
-	assert.NoError(t, err)
+	tpd.mClock.EXPECT().GetCurrentLayer().Return(epoch.FirstLayer()).Times(1)
+	tpd.mClock.EXPECT().LayerToTime(epoch.FirstLayer()).Return(time.Now()).Times(1)
+	setMockAtxDbForProposals(tpd.mAtxDB, epoch)
+	got := tpd.handleProposal(context.TODO(), "peerID", msgBytes1, time.Now())
+	require.NoError(t, got)
 
-	checkProposed(t, pd, vrfSigner, true)
-	p := msg.VRFSignature[:types.BeaconSize]
+	checkProposed(t, tpd.ProtocolDriver, epoch, vrfSigner.PublicKey(), true)
+	p := msg1.VRFSignature[:types.BeaconSize]
 	expectedProposals := proposals{
 		valid: proposalSet{string(p): struct{}{}},
 	}
-	checkProposals(t, pd, expectedProposals)
+	checkProposals(t, tpd.ProtocolDriver, epoch, expectedProposals)
 
-	// now make the same proposal again
-	mockDB.EXPECT().GetNodeAtxIDForEpoch(gomock.Any(), gomock.Any()).
-		Return(types.ATXID(types.HexToHash32("0x22345678")), nil).Times(1)
-
-	err = pd.handleProposalMessage(context.TODO(), *msg, time.Now())
-	assert.ErrorIs(t, err, errAlreadyProposed)
-	checkProposed(t, pd, vrfSigner, true)
-	checkProposals(t, pd, expectedProposals)
-}
-
-func Test_handleProposalMessage_ProposalNotEligible(t *testing.T) {
-	t.Parallel()
-
-	const epoch = types.EpochID(10)
-	pd, mockDB := createProtocolDriver(t, epoch)
-	mockDB.EXPECT().GetNodeAtxIDForEpoch(gomock.Any(), gomock.Any()).
-		Return(types.ATXID(types.HexToHash32("0x22345678")), nil).Times(1)
-
-	signer := signing.NewEdSigner()
-	vrfSigner, _, err := signing.NewVRFSigner(signer.Sign(signer.PublicKey().Bytes()))
+	// the same vrf key will not cause double-proposal
+	msg2 := createProposal(t, signing.NewEdSigner(), vrfSigner, epoch, false)
+	msgBytes2, err := types.InterfaceToBytes(msg2)
 	require.NoError(t, err)
-	msg := createProposal(t, signer, vrfSigner, epoch, false)
 
-	mockProposalChecker(t, pd, false, 1)
+	tpd.mClock.EXPECT().GetCurrentLayer().Return(epoch.FirstLayer()).Times(1)
+	tpd.mAtxDB.EXPECT().GetNodeAtxIDForEpoch(gomock.Any(), epoch-1).Return(types.ATXID{}, nil).Times(1)
+	got = tpd.handleProposal(context.TODO(), "peerID", msgBytes2, time.Now())
+	assert.ErrorIs(t, got, errAlreadyProposed)
 
-	err = pd.handleProposalMessage(context.TODO(), *msg, time.Now())
-	assert.ErrorIs(t, err, errProposalDoesntPassThreshold)
-
-	checkProposed(t, pd, vrfSigner, true)
-	checkProposals(t, pd, proposals{})
+	checkProposed(t, tpd.ProtocolDriver, epoch, vrfSigner.PublicKey(), true)
+	checkProposals(t, tpd.ProtocolDriver, epoch, expectedProposals)
 }
 
-func Test_handleProposalMessage_MinerMissingATX(t *testing.T) {
+func Test_handleProposal_ProposalNotEligible(t *testing.T) {
 	t.Parallel()
 
 	const epoch = types.EpochID(10)
-	pd, mockDB := createProtocolDriver(t, epoch)
-	mockDB.EXPECT().GetNodeAtxIDForEpoch(gomock.Any(), gomock.Any()).
-		Return(types.ATXID{}, database.ErrNotFound).Times(1)
-
-	signer := signing.NewEdSigner()
-	vrfSigner, _, err := signing.NewVRFSigner(signer.Sign(signer.PublicKey().Bytes()))
-	require.NoError(t, err)
-	msg := createProposal(t, signer, vrfSigner, epoch, false)
-
-	err = pd.handleProposalMessage(context.TODO(), *msg, time.Now())
-	assert.ErrorIs(t, err, errMinerATXNotFound)
-
-	checkProposed(t, pd, vrfSigner, false)
-	checkProposals(t, pd, proposals{})
-}
-
-func Test_handleProposalMessage_ATXLookupError(t *testing.T) {
-	t.Parallel()
-
-	const epoch = types.EpochID(10)
-	pd, mockDB := createProtocolDriver(t, epoch)
-	mockDB.EXPECT().GetNodeAtxIDForEpoch(gomock.Any(), gomock.Any()).
-		Return(types.ATXID{}, errUnknown).Times(1)
-
-	signer := signing.NewEdSigner()
-	vrfSigner, _, err := signing.NewVRFSigner(signer.Sign(signer.PublicKey().Bytes()))
-	require.NoError(t, err)
-	msg := createProposal(t, signer, vrfSigner, epoch, false)
-
-	err = pd.handleProposalMessage(context.TODO(), *msg, time.Now())
-	assert.ErrorIs(t, err, errUnknown)
-
-	checkProposed(t, pd, vrfSigner, false)
-	checkProposals(t, pd, proposals{})
-}
-
-func Test_handleProposalMessage_ATXHeaderLookupError(t *testing.T) {
-	t.Parallel()
-
-	const epoch = types.EpochID(10)
-	pd, mockDB := createProtocolDriver(t, epoch)
-	mockDB.EXPECT().GetNodeAtxIDForEpoch(gomock.Any(), gomock.Any()).
-		Return(types.ATXID(types.HexToHash32("0x22345678")), nil).Times(1)
-	mockDB.EXPECT().GetAtxHeader(gomock.Any()).Return(nil, errUnknown).Times(1)
-
-	mockProposalChecker(t, pd, true, 1)
+	tpd := createProtocolDriver(t, epoch)
+	mockAlwaysFalseProposalChecker(t, tpd.ProtocolDriver, epoch)
 
 	signer := signing.NewEdSigner()
 	vrfSigner, _, err := signing.NewVRFSigner(signer.Sign(signer.PublicKey().Bytes()))
 	require.NoError(t, err)
 
 	msg := createProposal(t, signer, vrfSigner, epoch, false)
-
-	err = pd.handleProposalMessage(context.TODO(), *msg, time.Now())
-	assert.ErrorIs(t, err, errUnknown)
-
-	checkProposed(t, pd, vrfSigner, true)
-	checkProposals(t, pd, proposals{})
-}
-
-func Test_HandleSerializedFirstVotingMessage_Success(t *testing.T) {
-	t.Parallel()
-
-	const epoch = types.EpochID(10)
-	valid := [][]byte{types.HexToHash32("0x12345678").Bytes(), types.HexToHash32("0x87654321").Bytes()}
-	pValid := [][]byte{types.HexToHash32("0x23456789").Bytes()}
-
-	pd, mockDB := createProtocolDriver(t, epoch)
-	mockDB.EXPECT().GetNodeAtxIDForEpoch(gomock.Any(), gomock.Any()).
-		Return(types.ATXID(types.HexToHash32("0x22345678")), nil).Times(1)
-	mockDB.EXPECT().GetAtxHeader(gomock.Any()).Return(&types.ActivationTxHeader{
-		NIPostChallenge: types.NIPostChallenge{
-			StartTick: 1,
-			EndTick:   3,
-		},
-		NumUnits: 5,
-	}, nil).Times(1)
-
-	signer := signing.NewEdSigner()
-
-	msg := createFirstVote(t, signer, epoch, valid, pValid, false)
 	msgBytes, err := types.InterfaceToBytes(msg)
 	require.NoError(t, err)
 
-	pd.HandleSerializedFirstVotingMessage(context.TODO(), peerID, msgBytes)
-	checkVoted(t, pd, signer, types.FirstRound, true)
+	tpd.mClock.EXPECT().GetCurrentLayer().Return(epoch.FirstLayer()).Times(1)
+	tpd.mAtxDB.EXPECT().GetNodeAtxIDForEpoch(gomock.Any(), epoch-1).Return(types.ATXID{}, nil).Times(1)
+	got := tpd.handleProposal(context.TODO(), "peerID", msgBytes, time.Now())
+	assert.ErrorIs(t, got, errProposalDoesntPassThreshold)
+
+	checkProposed(t, tpd.ProtocolDriver, epoch, vrfSigner.PublicKey(), true)
+	checkProposals(t, tpd.ProtocolDriver, epoch, proposals{})
+}
+
+func Test_handleProposal_MinerMissingATX(t *testing.T) {
+	t.Parallel()
+
+	const epoch = types.EpochID(10)
+	tpd := createProtocolDriver(t, epoch)
+
+	signer := signing.NewEdSigner()
+	vrfSigner, _, err := signing.NewVRFSigner(signer.Sign(signer.PublicKey().Bytes()))
+	require.NoError(t, err)
+
+	msg := createProposal(t, signer, vrfSigner, epoch, false)
+	msgBytes, err := types.InterfaceToBytes(msg)
+	require.NoError(t, err)
+
+	tpd.mClock.EXPECT().GetCurrentLayer().Return(epoch.FirstLayer()).Times(1)
+	tpd.mAtxDB.EXPECT().GetNodeAtxIDForEpoch(gomock.Any(), epoch-1).Return(types.ATXID{}, sql.ErrNotFound).Times(1)
+	got := tpd.handleProposal(context.TODO(), "peerID", msgBytes, time.Now())
+	assert.ErrorIs(t, got, errMinerATXNotFound)
+
+	checkProposed(t, tpd.ProtocolDriver, epoch, vrfSigner.PublicKey(), false)
+	checkProposals(t, tpd.ProtocolDriver, epoch, proposals{})
+}
+
+func Test_handleProposal_ATXLookupError(t *testing.T) {
+	t.Parallel()
+
+	const epoch = types.EpochID(10)
+	tpd := createProtocolDriver(t, epoch)
+
+	signer := signing.NewEdSigner()
+	vrfSigner, _, err := signing.NewVRFSigner(signer.Sign(signer.PublicKey().Bytes()))
+	require.NoError(t, err)
+
+	msg := createProposal(t, signer, vrfSigner, epoch, false)
+	msgBytes, err := types.InterfaceToBytes(msg)
+	require.NoError(t, err)
+
+	tpd.mClock.EXPECT().GetCurrentLayer().Return(epoch.FirstLayer()).Times(1)
+	errUnknown := errors.New("unknown")
+	tpd.mAtxDB.EXPECT().GetNodeAtxIDForEpoch(gomock.Any(), epoch-1).Return(types.ATXID{}, errUnknown).Times(1)
+	got := tpd.handleProposal(context.TODO(), "peerID", msgBytes, time.Now())
+	assert.ErrorIs(t, got, errUnknown)
+
+	checkProposed(t, tpd.ProtocolDriver, epoch, vrfSigner.PublicKey(), false)
+	checkProposals(t, tpd.ProtocolDriver, epoch, proposals{})
+}
+
+func Test_handleProposal_ATXHeaderLookupError(t *testing.T) {
+	t.Parallel()
+
+	const epoch = types.EpochID(10)
+	tpd := createProtocolDriver(t, epoch)
+
+	signer := signing.NewEdSigner()
+	vrfSigner, _, err := signing.NewVRFSigner(signer.Sign(signer.PublicKey().Bytes()))
+	require.NoError(t, err)
+
+	msg := createProposal(t, signer, vrfSigner, epoch, false)
+	msgBytes, err := types.InterfaceToBytes(msg)
+	require.NoError(t, err)
+
+	tpd.mClock.EXPECT().GetCurrentLayer().Return(epoch.FirstLayer()).Times(1)
+	errUnknown := errors.New("unknown")
+	atxID := types.RandomATXID()
+	tpd.mAtxDB.EXPECT().GetNodeAtxIDForEpoch(gomock.Any(), epoch-1).Return(atxID, nil).Times(1)
+	tpd.mAtxDB.EXPECT().GetAtxHeader(atxID).Return(nil, errUnknown).Times(1)
+	got := tpd.handleProposal(context.TODO(), "peerID", msgBytes, time.Now())
+	assert.ErrorIs(t, got, errUnknown)
+
+	checkProposed(t, tpd.ProtocolDriver, epoch, vrfSigner.PublicKey(), true)
+	checkProposals(t, tpd.ProtocolDriver, epoch, proposals{})
+}
+
+func Test_HandleFirstVotes_Success(t *testing.T) {
+	t.Parallel()
+
+	const epoch = types.EpochID(10)
+	tpd := createProtocolDriver(t, epoch)
+
+	validVotes := [][]byte{types.HexToHash32("0x12345678").Bytes(), types.HexToHash32("0x87654321").Bytes()}
+	pValidVotes := [][]byte{types.HexToHash32("0x23456789").Bytes()}
+	signer := signing.NewEdSigner()
+	msg := createFirstVote(t, signer, epoch, validVotes, pValidVotes, false)
+	msgBytes, err := types.InterfaceToBytes(msg)
+	require.NoError(t, err)
+
+	tpd.mClock.EXPECT().GetCurrentLayer().Return(epoch.FirstLayer()).Times(1)
+	setMockAtxDbForVotes(tpd.mAtxDB, epoch)
+	res := tpd.HandleFirstVotes(context.TODO(), "peerID", msgBytes)
+	assert.Equal(t, pubsub.ValidationAccept, res)
+	checkVoted(t, tpd.ProtocolDriver, epoch, signer, types.FirstRound, true)
 	expected := map[string]proposalList{
-		string(signer.PublicKey().Bytes()): append(valid, pValid...),
+		string(signer.PublicKey().Bytes()): append(validVotes, pValidVotes...),
 	}
-	checkFirstIncomingVotes(t, pd, expected)
+	checkFirstIncomingVotes(t, tpd.ProtocolDriver, epoch, expected)
 }
 
-func Test_HandleSerializedFirstVotingMessage_Shutdown(t *testing.T) {
+func Test_HandleFirstVotes_Shutdown(t *testing.T) {
 	t.Parallel()
 
 	const epoch = types.EpochID(10)
-	valid := [][]byte{types.HexToHash32("0x12345678").Bytes(), types.HexToHash32("0x87654321").Bytes()}
-	pValid := [][]byte{types.HexToHash32("0x23456789").Bytes()}
+	tpd := createProtocolDriver(t, epoch)
+	tpd.mClock.EXPECT().Unsubscribe(gomock.Any()).Times(1)
+	tpd.Close()
 
-	pd, _ := createProtocolDriver(t, epoch)
-	atomic.StoreUint64(&pd.running, 0)
-
+	validVotes := [][]byte{types.HexToHash32("0x12345678").Bytes(), types.HexToHash32("0x87654321").Bytes()}
+	pValidVotes := [][]byte{types.HexToHash32("0x23456789").Bytes()}
 	signer := signing.NewEdSigner()
-	msg := createFirstVote(t, signer, epoch, valid, pValid, false)
+	msg := createFirstVote(t, signer, epoch, validVotes, pValidVotes, false)
 	msgBytes, err := types.InterfaceToBytes(msg)
 	require.NoError(t, err)
 
-	pd.HandleSerializedFirstVotingMessage(context.TODO(), peerID, msgBytes)
-	checkVoted(t, pd, signer, types.FirstRound, false)
-	checkFirstIncomingVotes(t, pd, map[string]proposalList{})
+	res := tpd.HandleFirstVotes(context.TODO(), "peerID", msgBytes)
+	assert.Equal(t, pubsub.ValidationIgnore, res)
+	checkVoted(t, tpd.ProtocolDriver, epoch, signer, types.FirstRound, false)
+	checkFirstIncomingVotes(t, tpd.ProtocolDriver, epoch, map[string]proposalList{})
 }
 
-func Test_HandleSerializedFirstVotingMessage_NotInProtocol(t *testing.T) {
+func Test_HandleFirstVotes_NotInProtocol(t *testing.T) {
 	t.Parallel()
 
 	const epoch = types.EpochID(10)
-	valid := proposalList{types.HexToHash32("0x12345678").Bytes(), types.HexToHash32("0x87654321").Bytes()}
-	pValid := proposalList{types.HexToHash32("0x23456789").Bytes()}
+	tpd := createProtocolDriver(t, epoch)
 
-	pd, _ := createProtocolDriver(t, epoch)
-	atomic.StoreUint64(&pd.inProtocol, 0)
-
+	validVotes := [][]byte{types.HexToHash32("0x12345678").Bytes(), types.HexToHash32("0x87654321").Bytes()}
+	pValidVotes := [][]byte{types.HexToHash32("0x23456789").Bytes()}
 	signer := signing.NewEdSigner()
-	msg := createFirstVote(t, signer, epoch, valid, pValid, false)
+	msg := createFirstVote(t, signer, epoch, validVotes, pValidVotes, false)
 	msgBytes, err := types.InterfaceToBytes(msg)
 	require.NoError(t, err)
 
-	pd.HandleSerializedFirstVotingMessage(context.TODO(), peerID, msgBytes)
-	checkVoted(t, pd, signer, types.FirstRound, false)
-	checkFirstIncomingVotes(t, pd, map[string]proposalList{})
+	tpd.setEndProtocol(context.TODO())
+	res := tpd.HandleFirstVotes(context.TODO(), "peerID", msgBytes)
+	assert.Equal(t, pubsub.ValidationIgnore, res)
+	checkVoted(t, tpd.ProtocolDriver, epoch, signer, types.FirstRound, false)
+	checkFirstIncomingVotes(t, tpd.ProtocolDriver, epoch, map[string]proposalList{})
 }
 
-func Test_HandleSerializedFirstVotingMessage_TooLate(t *testing.T) {
+func Test_handleFirstVotes_CorruptMsg(t *testing.T) {
 	t.Parallel()
 
 	const epoch = types.EpochID(10)
-	valid := proposalList{types.HexToHash32("0x12345678").Bytes(), types.HexToHash32("0x87654321").Bytes()}
-	pValid := proposalList{types.HexToHash32("0x23456789").Bytes()}
+	tpd := createProtocolDriver(t, epoch)
 
-	pd, _ := createProtocolDriver(t, epoch)
+	validVotes := [][]byte{types.HexToHash32("0x12345678").Bytes(), types.HexToHash32("0x87654321").Bytes()}
+	pValidVotes := [][]byte{types.HexToHash32("0x23456789").Bytes()}
 	signer := signing.NewEdSigner()
-	msg := createFirstVote(t, signer, epoch, valid, pValid, false)
+	msg := createFirstVote(t, signer, epoch, validVotes, pValidVotes, false)
 	msgBytes, err := types.InterfaceToBytes(msg)
 	require.NoError(t, err)
 
-	pd.setRoundInProgress(types.RoundID(1))
-	pd.HandleSerializedFirstVotingMessage(context.TODO(), peerID, msgBytes)
-	checkVoted(t, pd, signer, types.FirstRound, false)
-	checkFirstIncomingVotes(t, pd, map[string]proposalList{})
+	got := tpd.handleFirstVotes(context.TODO(), "peerID", msgBytes[1:])
+	assert.ErrorIs(t, got, errMalformedMessage)
+	checkVoted(t, tpd.ProtocolDriver, epoch, signer, types.FirstRound, false)
+	checkFirstIncomingVotes(t, tpd.ProtocolDriver, epoch, map[string]proposalList{})
 }
 
-func Test_HandleSerializedFirstVotingMessage_CorruptedGossipMsg(t *testing.T) {
+func Test_handleFirstVotes_WrongEpoch(t *testing.T) {
 	t.Parallel()
 
 	const epoch = types.EpochID(10)
-	valid := proposalList{types.HexToHash32("0x12345678").Bytes(), types.HexToHash32("0x87654321").Bytes()}
-	pValid := proposalList{types.HexToHash32("0x23456789").Bytes()}
+	tpd := createProtocolDriver(t, epoch)
+	createEpochState(t, tpd.ProtocolDriver, epoch-1)
+	createEpochState(t, tpd.ProtocolDriver, epoch+1)
 
-	pd, _ := createProtocolDriver(t, epoch)
+	validVotes := [][]byte{types.HexToHash32("0x12345678").Bytes(), types.HexToHash32("0x87654321").Bytes()}
+	pValidVotes := [][]byte{types.HexToHash32("0x23456789").Bytes()}
 	signer := signing.NewEdSigner()
-	msg := createFirstVote(t, signer, epoch, valid, pValid, true)
+	msg := createFirstVote(t, signer, epoch+1, validVotes, pValidVotes, false)
 	msgBytes, err := types.InterfaceToBytes(msg)
 	require.NoError(t, err)
 
-	pd.HandleSerializedFirstVotingMessage(context.TODO(), peerID, msgBytes)
-	checkVoted(t, pd, signer, types.FirstRound, false)
-	checkFirstIncomingVotes(t, pd, map[string]proposalList{})
+	tpd.mClock.EXPECT().GetCurrentLayer().Return(epoch.FirstLayer()).Times(1)
+	got := tpd.handleFirstVotes(context.TODO(), "peerID", msgBytes)
+	assert.ErrorIs(t, got, errEpochNotActive)
+	checkVoted(t, tpd.ProtocolDriver, epoch, signer, types.FirstRound, false)
+	checkFirstIncomingVotes(t, tpd.ProtocolDriver, epoch, map[string]proposalList{})
+	checkVoted(t, tpd.ProtocolDriver, epoch+1, signer, types.FirstRound, false)
+	checkFirstIncomingVotes(t, tpd.ProtocolDriver, epoch+1, map[string]proposalList{})
+
+	msg = createFirstVote(t, signer, epoch-1, validVotes, pValidVotes, false)
+	msgBytes, err = types.InterfaceToBytes(msg)
+	require.NoError(t, err)
+
+	tpd.mClock.EXPECT().GetCurrentLayer().Return(epoch.FirstLayer()).Times(1)
+	got = tpd.handleFirstVotes(context.TODO(), "peerID", msgBytes)
+	assert.ErrorIs(t, got, errEpochNotActive)
+	checkVoted(t, tpd.ProtocolDriver, epoch, signer, types.FirstRound, false)
+	checkFirstIncomingVotes(t, tpd.ProtocolDriver, epoch, map[string]proposalList{})
+	checkVoted(t, tpd.ProtocolDriver, epoch-1, signer, types.FirstRound, false)
+	checkFirstIncomingVotes(t, tpd.ProtocolDriver, epoch-1, map[string]proposalList{})
 }
 
-func Test_HandleSerializedFirstVotingMessage_WrongEpoch(t *testing.T) {
+func Test_handleFirstVotes_TooLate(t *testing.T) {
 	t.Parallel()
 
 	const epoch = types.EpochID(10)
-	valid := proposalList{types.HexToHash32("0x12345678").Bytes(), types.HexToHash32("0x87654321").Bytes()}
-	pValid := proposalList{types.HexToHash32("0x23456789").Bytes()}
+	tpd := createProtocolDriver(t, epoch)
 
-	pd, _ := createProtocolDriver(t, epoch+1)
+	validVotes := [][]byte{types.HexToHash32("0x12345678").Bytes(), types.HexToHash32("0x87654321").Bytes()}
+	pValidVotes := [][]byte{types.HexToHash32("0x23456789").Bytes()}
 	signer := signing.NewEdSigner()
-	msg := createFirstVote(t, signer, epoch, valid, pValid, false)
+	msg := createFirstVote(t, signer, epoch, validVotes, pValidVotes, false)
 	msgBytes, err := types.InterfaceToBytes(msg)
 	require.NoError(t, err)
 
-	pd.HandleSerializedFirstVotingMessage(context.TODO(), peerID, msgBytes)
-	checkVoted(t, pd, signer, types.FirstRound, false)
-	checkFirstIncomingVotes(t, pd, map[string]proposalList{})
+	tpd.mClock.EXPECT().GetCurrentLayer().Return(epoch.FirstLayer()).Times(1)
+	tpd.setRoundInProgress(types.RoundID(1))
+	got := tpd.handleFirstVotes(context.TODO(), "peerID", msgBytes)
+	assert.ErrorIs(t, got, errUntimelyMessage)
+	checkVoted(t, tpd.ProtocolDriver, epoch, signer, types.FirstRound, false)
+	checkFirstIncomingVotes(t, tpd.ProtocolDriver, epoch, map[string]proposalList{})
 }
 
-func Test_handleFirstVotingMessage_Success(t *testing.T) {
+func Test_HandleFirstVotes_FailedToExtractPK(t *testing.T) {
 	t.Parallel()
 
 	const epoch = types.EpochID(10)
-	valid := proposalList{types.HexToHash32("0x12345678").Bytes(), types.HexToHash32("0x87654321").Bytes()}
-	pValid := proposalList{types.HexToHash32("0x23456789").Bytes()}
+	tpd := createProtocolDriver(t, epoch)
 
-	pd, mockDB := createProtocolDriver(t, epoch)
-	mockDB.EXPECT().GetNodeAtxIDForEpoch(gomock.Any(), gomock.Any()).
-		Return(types.ATXID(types.HexToHash32("0x22345678")), nil).Times(1)
-	mockDB.EXPECT().GetAtxHeader(gomock.Any()).Return(&types.ActivationTxHeader{
-		NIPostChallenge: types.NIPostChallenge{
-			StartTick: 1,
-			EndTick:   3,
-		},
-		NumUnits: 5,
-	}, nil).Times(1)
-
+	validVotes := [][]byte{types.HexToHash32("0x12345678").Bytes(), types.HexToHash32("0x87654321").Bytes()}
+	pValidVotes := [][]byte{types.HexToHash32("0x23456789").Bytes()}
 	signer := signing.NewEdSigner()
-	msg := createFirstVote(t, signer, epoch, valid, pValid, false)
+	msg := createFirstVote(t, signer, epoch, validVotes, pValidVotes, true)
+	msgBytes, err := types.InterfaceToBytes(msg)
+	require.NoError(t, err)
 
-	err := pd.handleFirstVotingMessage(context.TODO(), *msg)
-	assert.NoError(t, err)
+	tpd.mClock.EXPECT().GetCurrentLayer().Return(epoch.FirstLayer()).Times(1)
+	got := tpd.handleFirstVotes(context.TODO(), "peerID", msgBytes)
+	assert.Contains(t, got.Error(), "bad signature format")
+	checkVoted(t, tpd.ProtocolDriver, epoch, signer, types.FirstRound, false)
+	checkFirstIncomingVotes(t, tpd.ProtocolDriver, epoch, map[string]proposalList{})
+}
 
-	checkVoted(t, pd, signer, types.FirstRound, true)
+func Test_HandleFirstVotes_AlreadyVoted(t *testing.T) {
+	t.Parallel()
+
+	const epoch = types.EpochID(10)
+	tpd := createProtocolDriver(t, epoch)
+
+	validVotes := [][]byte{types.HexToHash32("0x12345678").Bytes(), types.HexToHash32("0x87654321").Bytes()}
+	pValidVotes := [][]byte{types.HexToHash32("0x23456789").Bytes()}
+	signer := signing.NewEdSigner()
+	msg := createFirstVote(t, signer, epoch, validVotes, pValidVotes, false)
+	msgBytes, err := types.InterfaceToBytes(msg)
+	require.NoError(t, err)
+
+	tpd.mClock.EXPECT().GetCurrentLayer().Return(epoch.FirstLayer()).Times(1)
+	setMockAtxDbForVotes(tpd.mAtxDB, epoch)
+	got := tpd.handleFirstVotes(context.TODO(), "peerID", msgBytes)
+	assert.NoError(t, got)
+	checkVoted(t, tpd.ProtocolDriver, epoch, signer, types.FirstRound, true)
 	expected := map[string]proposalList{
-		string(signer.PublicKey().Bytes()): append(valid, pValid...),
+		string(signer.PublicKey().Bytes()): append(validVotes, pValidVotes...),
 	}
-	checkFirstIncomingVotes(t, pd, expected)
+	checkFirstIncomingVotes(t, tpd.ProtocolDriver, epoch, expected)
+
+	// the same ed key will not cause double-vote
+	msg2 := createFirstVote(t, signer, epoch, validVotes, proposalList{}, false)
+	msgBytes2, err := types.InterfaceToBytes(msg2)
+	require.NoError(t, err)
+
+	tpd.mClock.EXPECT().GetCurrentLayer().Return(epoch.FirstLayer()).Times(1)
+	got = tpd.handleFirstVotes(context.TODO(), "peerID", msgBytes2)
+	assert.ErrorIs(t, got, errAlreadyVoted)
+	checkVoted(t, tpd.ProtocolDriver, epoch, signer, types.FirstRound, true)
+	checkFirstIncomingVotes(t, tpd.ProtocolDriver, epoch, expected)
 }
 
-func Test_handleFirstVotingMessage_FailedToExtractPK(t *testing.T) {
+func Test_HandleFirstVotes_MinerMissingATX(t *testing.T) {
 	t.Parallel()
 
 	const epoch = types.EpochID(10)
-	valid := proposalList{types.HexToHash32("0x12345678").Bytes(), types.HexToHash32("0x87654321").Bytes()}
-	pValid := proposalList{types.HexToHash32("0x23456789").Bytes()}
+	tpd := createProtocolDriver(t, epoch)
 
-	pd, _ := createProtocolDriver(t, epoch)
+	validVotes := [][]byte{types.HexToHash32("0x12345678").Bytes(), types.HexToHash32("0x87654321").Bytes()}
+	pValidVotes := [][]byte{types.HexToHash32("0x23456789").Bytes()}
 	signer := signing.NewEdSigner()
-	msg := createFirstVote(t, signer, epoch, valid, pValid, true)
+	msg := createFirstVote(t, signer, epoch, validVotes, pValidVotes, false)
+	msgBytes, err := types.InterfaceToBytes(msg)
+	require.NoError(t, err)
 
-	err := pd.handleFirstVotingMessage(context.TODO(), *msg)
-	assert.Contains(t, err.Error(), "bad signature format")
-
-	checkVoted(t, pd, signer, types.FirstRound, false)
-	checkFirstIncomingVotes(t, pd, map[string]proposalList{})
+	tpd.mClock.EXPECT().GetCurrentLayer().Return(epoch.FirstLayer()).Times(1)
+	tpd.mAtxDB.EXPECT().GetNodeAtxIDForEpoch(gomock.Any(), epoch-1).Return(types.ATXID{}, sql.ErrNotFound).Times(1)
+	got := tpd.handleFirstVotes(context.TODO(), "peerID", msgBytes)
+	assert.ErrorIs(t, got, errMinerATXNotFound)
+	checkVoted(t, tpd.ProtocolDriver, epoch, signer, types.FirstRound, true)
+	checkFirstIncomingVotes(t, tpd.ProtocolDriver, epoch, map[string]proposalList{})
 }
 
-func Test_handleFirstVotingMessage_AlreadyVoted(t *testing.T) {
+func Test_HandleFirstVotes_ATXLookupError(t *testing.T) {
 	t.Parallel()
 
 	const epoch = types.EpochID(10)
-	valid := proposalList{types.HexToHash32("0x12345678").Bytes(), types.HexToHash32("0x87654321").Bytes()}
-	pValid := proposalList{types.HexToHash32("0x23456789").Bytes()}
+	tpd := createProtocolDriver(t, epoch)
 
-	pd, mockDB := createProtocolDriver(t, epoch)
-	mockDB.EXPECT().GetNodeAtxIDForEpoch(gomock.Any(), gomock.Any()).
-		Return(types.ATXID(types.HexToHash32("0x22345678")), nil).Times(1)
-	mockDB.EXPECT().GetAtxHeader(gomock.Any()).Return(&types.ActivationTxHeader{
-		NIPostChallenge: types.NIPostChallenge{
-			StartTick: 1,
-			EndTick:   3,
-		},
-		NumUnits: 5,
-	}, nil).Times(1)
-
+	validVotes := [][]byte{types.HexToHash32("0x12345678").Bytes(), types.HexToHash32("0x87654321").Bytes()}
+	pValidVotes := [][]byte{types.HexToHash32("0x23456789").Bytes()}
 	signer := signing.NewEdSigner()
-	msg := createFirstVote(t, signer, epoch, valid, pValid, false)
+	msg := createFirstVote(t, signer, epoch, validVotes, pValidVotes, false)
+	msgBytes, err := types.InterfaceToBytes(msg)
+	require.NoError(t, err)
 
-	err := pd.handleFirstVotingMessage(context.TODO(), *msg)
-	assert.NoError(t, err)
-
-	checkVoted(t, pd, signer, types.FirstRound, true)
-	expected := map[string]proposalList{
-		string(signer.PublicKey().Bytes()): append(valid, pValid...),
-	}
-	checkFirstIncomingVotes(t, pd, expected)
-
-	// now vote again
-	err = pd.handleFirstVotingMessage(context.TODO(), *msg)
-	assert.ErrorIs(t, err, errAlreadyVoted)
-
-	checkVoted(t, pd, signer, types.FirstRound, true)
-	checkFirstIncomingVotes(t, pd, expected)
+	tpd.mClock.EXPECT().GetCurrentLayer().Return(epoch.FirstLayer()).Times(1)
+	errUnknown := errors.New("unknown")
+	tpd.mAtxDB.EXPECT().GetNodeAtxIDForEpoch(gomock.Any(), epoch-1).Return(types.ATXID{}, errUnknown).Times(1)
+	got := tpd.handleFirstVotes(context.TODO(), "peerID", msgBytes)
+	assert.ErrorIs(t, got, errUnknown)
+	checkVoted(t, tpd.ProtocolDriver, epoch, signer, types.FirstRound, true)
+	checkFirstIncomingVotes(t, tpd.ProtocolDriver, epoch, map[string]proposalList{})
 }
 
-func Test_handleFirstVotingMessage_MinerMissingATX(t *testing.T) {
+func Test_HandleFirstVotes_ATXHeaderLookupError(t *testing.T) {
 	t.Parallel()
 
 	const epoch = types.EpochID(10)
-	valid := proposalList{types.HexToHash32("0x12345678").Bytes(), types.HexToHash32("0x87654321").Bytes()}
-	pValid := proposalList{types.HexToHash32("0x23456789").Bytes()}
+	tpd := createProtocolDriver(t, epoch)
 
-	pd, mockDB := createProtocolDriver(t, epoch)
-	mockDB.EXPECT().GetNodeAtxIDForEpoch(gomock.Any(), gomock.Any()).
-		Return(types.ATXID{}, database.ErrNotFound).Times(1)
-
+	validVotes := [][]byte{types.HexToHash32("0x12345678").Bytes(), types.HexToHash32("0x87654321").Bytes()}
+	pValidVotes := [][]byte{types.HexToHash32("0x23456789").Bytes()}
 	signer := signing.NewEdSigner()
-	msg := createFirstVote(t, signer, epoch, valid, pValid, false)
+	msg := createFirstVote(t, signer, epoch, validVotes, pValidVotes, false)
+	msgBytes, err := types.InterfaceToBytes(msg)
+	require.NoError(t, err)
 
-	err := pd.handleFirstVotingMessage(context.TODO(), *msg)
-	assert.ErrorIs(t, err, errMinerATXNotFound)
-
-	checkVoted(t, pd, signer, types.FirstRound, true)
-	checkFirstIncomingVotes(t, pd, map[string]proposalList{})
+	tpd.mClock.EXPECT().GetCurrentLayer().Return(epoch.FirstLayer()).Times(1)
+	atxID := types.RandomATXID()
+	tpd.mAtxDB.EXPECT().GetNodeAtxIDForEpoch(gomock.Any(), epoch-1).Return(atxID, nil).Times(1)
+	errUnknown := errors.New("unknown")
+	tpd.mAtxDB.EXPECT().GetAtxHeader(atxID).Return(nil, errUnknown).Times(1)
+	got := tpd.handleFirstVotes(context.TODO(), "peerID", msgBytes)
+	assert.ErrorIs(t, got, errUnknown)
+	checkVoted(t, tpd.ProtocolDriver, epoch, signer, types.FirstRound, true)
+	checkFirstIncomingVotes(t, tpd.ProtocolDriver, epoch, map[string]proposalList{})
 }
 
-func Test_handleFirstVotingMessage_ATXLookupError(t *testing.T) {
-	t.Parallel()
-
-	const epoch = types.EpochID(10)
-	valid := proposalList{types.HexToHash32("0x12345678").Bytes(), types.HexToHash32("0x87654321").Bytes()}
-	pValid := proposalList{types.HexToHash32("0x23456789").Bytes()}
-
-	pd, mockDB := createProtocolDriver(t, epoch)
-	mockDB.EXPECT().GetNodeAtxIDForEpoch(gomock.Any(), gomock.Any()).
-		Return(types.ATXID{}, errUnknown).Times(1)
-
-	signer := signing.NewEdSigner()
-	msg := createFirstVote(t, signer, epoch, valid, pValid, false)
-
-	err := pd.handleFirstVotingMessage(context.TODO(), *msg)
-	assert.ErrorIs(t, err, errUnknown)
-
-	checkVoted(t, pd, signer, types.FirstRound, true)
-	checkFirstIncomingVotes(t, pd, map[string]proposalList{})
-}
-
-func Test_handleFirstVotingMessage_ATXHeaderLookupError(t *testing.T) {
-	t.Parallel()
-
-	const epoch = types.EpochID(10)
-	valid := proposalList{types.HexToHash32("0x12345678").Bytes(), types.HexToHash32("0x87654321").Bytes()}
-	pValid := proposalList{types.HexToHash32("0x23456789").Bytes()}
-
-	pd, mockDB := createProtocolDriver(t, epoch)
-	mockDB.EXPECT().GetNodeAtxIDForEpoch(gomock.Any(), gomock.Any()).
-		Return(types.ATXID(types.HexToHash32("0x22345678")), nil).Times(1)
-	mockDB.EXPECT().GetAtxHeader(gomock.Any()).Return(nil, errUnknown).Times(1)
-
-	signer := signing.NewEdSigner()
-	msg := createFirstVote(t, signer, epoch, valid, pValid, false)
-
-	err := pd.handleFirstVotingMessage(context.TODO(), *msg)
-	assert.ErrorIs(t, err, errUnknown)
-
-	checkVoted(t, pd, signer, types.FirstRound, true)
-	checkFirstIncomingVotes(t, pd, map[string]proposalList{})
-}
-
-func Test_HandleSerializedFollowingVotingMessage_Success(t *testing.T) {
+func Test_HandleFollowingVotes_Success(t *testing.T) {
 	t.Parallel()
 
 	const epoch = types.EpochID(10)
 	const round = types.RoundID(5)
-
 	signer := signing.NewEdSigner()
-	pd, mockDB, hashes := createProtocolDriverWithFirstRoundVotes(t, epoch, signer)
-	mockDB.EXPECT().GetNodeAtxIDForEpoch(gomock.Any(), gomock.Any()).
-		Return(types.ATXID(types.HexToHash32("0x22345678")), nil).Times(1)
-	mockDB.EXPECT().GetAtxHeader(gomock.Any()).Return(&types.ActivationTxHeader{
-		NIPostChallenge: types.NIPostChallenge{
-			StartTick: 1,
-			EndTick:   3,
-		},
-		NumUnits: 5,
-	}, nil).Times(1)
+	tpd, plist := createProtocolDriverWithFirstRoundVotes(t, signer, epoch, round)
 
 	// this msg will contain a bit vector that set bit 0 and 2
 	msg := createFollowingVote(t, signer, epoch, round, []byte{0b101}, false)
 	msgBytes, err := types.InterfaceToBytes(msg)
 	require.NoError(t, err)
 
-	pd.setRoundInProgress(round)
-	pd.HandleSerializedFollowingVotingMessage(context.TODO(), peerID, msgBytes)
-	checkVoted(t, pd, signer, round, true)
-	expected := make(map[string]*big.Int, len(hashes))
-	for i, hash := range hashes {
+	tpd.mClock.EXPECT().GetCurrentLayer().Return(epoch.FirstLayer()).Times(1)
+	setMockAtxDbForVotes(tpd.mAtxDB, epoch)
+	res := tpd.HandleFollowingVotes(context.TODO(), "peerID", msgBytes)
+	assert.Equal(t, pubsub.ValidationAccept, res)
+	checkVoted(t, tpd.ProtocolDriver, epoch, signer, round, true)
+	expected := make(map[string]*big.Int, len(plist))
+	for i, p := range plist {
 		if i == 0 || i == 2 {
-			expected[string(hash.Bytes())] = big.NewInt(10)
+			expected[string(p)] = big.NewInt(10)
 		} else {
-			expected[string(hash.Bytes())] = big.NewInt(-10)
+			expected[string(p)] = big.NewInt(-10)
 		}
 	}
-	checkVoteMargins(t, pd, expected)
+	checkVoteMargins(t, tpd.ProtocolDriver, epoch, expected)
 }
 
-func Test_HandleSerializedFollowingVotingMessage_Shutdown(t *testing.T) {
+func Test_HandleFollowingVotes_Shutdown(t *testing.T) {
 	t.Parallel()
 
 	const epoch = types.EpochID(10)
 	const round = types.RoundID(5)
-
 	signer := signing.NewEdSigner()
-	pd, _, _ := createProtocolDriverWithFirstRoundVotes(t, epoch, signer)
-	atomic.StoreUint64(&pd.running, 0)
+	tpd, _ := createProtocolDriverWithFirstRoundVotes(t, signer, epoch, round)
+	tpd.mClock.EXPECT().Unsubscribe(gomock.Any())
+	tpd.Close()
 
 	// this msg will contain a bit vector that set bit 0 and 2
 	msg := createFollowingVote(t, signer, epoch, round, []byte{0b101}, false)
 	msgBytes, err := types.InterfaceToBytes(msg)
 	require.NoError(t, err)
 
-	pd.setRoundInProgress(round)
-	pd.HandleSerializedFollowingVotingMessage(context.TODO(), peerID, msgBytes)
-	checkVoted(t, pd, signer, round, false)
-	checkVoteMargins(t, pd, map[string]*big.Int{})
+	res := tpd.HandleFollowingVotes(context.TODO(), "peerID", msgBytes)
+	assert.Equal(t, pubsub.ValidationIgnore, res)
+	checkVoted(t, tpd.ProtocolDriver, epoch, signer, round, false)
+	checkVoteMargins(t, tpd.ProtocolDriver, epoch, map[string]*big.Int{})
 }
 
-func Test_HandleSerializedFollowingVotingMessage_NotInProtocol(t *testing.T) {
+func Test_HandleFollowingVotes_NotInProtocol(t *testing.T) {
 	t.Parallel()
 
 	const epoch = types.EpochID(10)
 	const round = types.RoundID(5)
-
 	signer := signing.NewEdSigner()
-	pd, _, _ := createProtocolDriverWithFirstRoundVotes(t, epoch, signer)
-	atomic.StoreUint64(&pd.inProtocol, 0)
+	tpd, _ := createProtocolDriverWithFirstRoundVotes(t, signer, epoch, round)
+
 	// this msg will contain a bit vector that set bit 0 and 2
 	msg := createFollowingVote(t, signer, epoch, round, []byte{0b101}, false)
 	msgBytes, err := types.InterfaceToBytes(msg)
 	require.NoError(t, err)
 
-	pd.setRoundInProgress(round)
-	pd.HandleSerializedFollowingVotingMessage(context.TODO(), peerID, msgBytes)
-	checkVoted(t, pd, signer, round, false)
-	checkVoteMargins(t, pd, map[string]*big.Int{})
+	tpd.setEndProtocol(context.TODO())
+	res := tpd.HandleFollowingVotes(context.TODO(), "peerID", msgBytes)
+	assert.Equal(t, pubsub.ValidationIgnore, res)
+	checkVoted(t, tpd.ProtocolDriver, epoch, signer, round, false)
+	checkVoteMargins(t, tpd.ProtocolDriver, epoch, map[string]*big.Int{})
 }
 
-func Test_HandleSerializedFollowingVotingMessage_TooEarly(t *testing.T) {
+func Test_handleFollowingVotes_CorruptMsg(t *testing.T) {
 	t.Parallel()
 
 	const epoch = types.EpochID(10)
 	const round = types.RoundID(5)
 	signer := signing.NewEdSigner()
-	pd, _, _ := createProtocolDriverWithFirstRoundVotes(t, epoch, signer)
+	tpd, _ := createProtocolDriverWithFirstRoundVotes(t, signer, epoch, round)
+
 	// this msg will contain a bit vector that set bit 0 and 2
 	msg := createFollowingVote(t, signer, epoch, round, []byte{0b101}, false)
 	msgBytes, err := types.InterfaceToBytes(msg)
 	require.NoError(t, err)
 
-	pd.setRoundInProgress(round - 1)
-	pd.HandleSerializedFollowingVotingMessage(context.TODO(), peerID, msgBytes)
-	checkVoted(t, pd, signer, round, false)
-	checkVoteMargins(t, pd, map[string]*big.Int{})
+	got := tpd.handleFollowingVotes(context.TODO(), "peerID", msgBytes[1:], time.Now())
+	assert.ErrorIs(t, got, errMalformedMessage)
+	checkVoted(t, tpd.ProtocolDriver, epoch, signer, round, false)
+	checkVoteMargins(t, tpd.ProtocolDriver, epoch, map[string]*big.Int{})
 }
 
-func Test_HandleSerializedFollowingVotingMessage_CorruptedGossipMsg(t *testing.T) {
+func Test_handleFollowingVotes_WrongEpoch(t *testing.T) {
 	t.Parallel()
 
 	const epoch = types.EpochID(10)
 	const round = types.RoundID(5)
 	signer := signing.NewEdSigner()
-	pd, _, _ := createProtocolDriverWithFirstRoundVotes(t, epoch, signer)
+	tpd, _ := createProtocolDriverWithFirstRoundVotes(t, signer, epoch, round)
+	createEpochState(t, tpd.ProtocolDriver, epoch+1)
+	createEpochState(t, tpd.ProtocolDriver, epoch-1)
+
+	// this msg will contain a bit vector that set bit 0 and 2
+	msg := createFollowingVote(t, signer, epoch+1, round, []byte{0b101}, false)
+	msgBytes, err := types.InterfaceToBytes(msg)
+	require.NoError(t, err)
+
+	tpd.mClock.EXPECT().GetCurrentLayer().Return(epoch.FirstLayer()).Times(1)
+	got := tpd.handleFollowingVotes(context.TODO(), "peerID", msgBytes, time.Now())
+	assert.ErrorIs(t, got, errEpochNotActive)
+	checkVoted(t, tpd.ProtocolDriver, epoch, signer, round, false)
+	checkVoteMargins(t, tpd.ProtocolDriver, epoch, map[string]*big.Int{})
+	checkVoted(t, tpd.ProtocolDriver, epoch+1, signer, round, false)
+	checkVoteMargins(t, tpd.ProtocolDriver, epoch+1, map[string]*big.Int{})
+
+	msg = createFollowingVote(t, signer, epoch-1, round, []byte{0b101}, false)
+	msgBytes, err = types.InterfaceToBytes(msg)
+	require.NoError(t, err)
+
+	tpd.mClock.EXPECT().GetCurrentLayer().Return(epoch.FirstLayer()).Times(1)
+	got = tpd.handleFollowingVotes(context.TODO(), "peerID", msgBytes, time.Now())
+	assert.ErrorIs(t, got, errEpochNotActive)
+	checkVoted(t, tpd.ProtocolDriver, epoch, signer, round, false)
+	checkVoteMargins(t, tpd.ProtocolDriver, epoch, map[string]*big.Int{})
+	checkVoted(t, tpd.ProtocolDriver, epoch-1, signer, round, false)
+	checkVoteMargins(t, tpd.ProtocolDriver, epoch-1, map[string]*big.Int{})
+}
+
+func Test_handleFollowingVotes_TooEarly(t *testing.T) {
+	t.Parallel()
+
+	const epoch = types.EpochID(10)
+	const round = types.RoundID(5)
+	signer := signing.NewEdSigner()
+	tpd, _ := createProtocolDriverWithFirstRoundVotes(t, signer, epoch, round)
+
+	// this msg will contain a bit vector that set bit 0 and 2
+	msg := createFollowingVote(t, signer, epoch, round, []byte{0b101}, false)
+	msgBytes, err := types.InterfaceToBytes(msg)
+	require.NoError(t, err)
+
+	tpd.setRoundInProgress(round - 1)
+	tpd.mClock.EXPECT().GetCurrentLayer().Return(epoch.FirstLayer()).Times(1)
+	got := tpd.handleFollowingVotes(context.TODO(), "peerID", msgBytes, time.Now())
+	assert.ErrorIs(t, got, errUntimelyMessage)
+	checkVoted(t, tpd.ProtocolDriver, epoch, signer, round, false)
+	checkVoteMargins(t, tpd.ProtocolDriver, epoch, map[string]*big.Int{})
+}
+
+func Test_handleFollowingVotes_FailedToExtractPK(t *testing.T) {
+	t.Parallel()
+
+	const epoch = types.EpochID(10)
+	const round = types.RoundID(5)
+	signer := signing.NewEdSigner()
+	tpd, _ := createProtocolDriverWithFirstRoundVotes(t, signer, epoch, round)
+
 	// this msg will contain a bit vector that set bit 0 and 2
 	msg := createFollowingVote(t, signer, epoch, round, []byte{0b101}, true)
 	msgBytes, err := types.InterfaceToBytes(msg)
 	require.NoError(t, err)
 
-	pd.setRoundInProgress(round)
-	pd.HandleSerializedFollowingVotingMessage(context.TODO(), peerID, msgBytes)
-	checkVoted(t, pd, signer, round, false)
-	checkVoteMargins(t, pd, map[string]*big.Int{})
+	tpd.mClock.EXPECT().GetCurrentLayer().Return(epoch.FirstLayer()).Times(1)
+	got := tpd.handleFollowingVotes(context.TODO(), "peerID", msgBytes, time.Now())
+	assert.Contains(t, got.Error(), "bad signature format")
+	checkVoted(t, tpd.ProtocolDriver, epoch, signer, round, false)
+	checkVoteMargins(t, tpd.ProtocolDriver, epoch, map[string]*big.Int{})
 }
 
-func Test_HandleSerializedFollowingVotingMessage_WrongEpoch(t *testing.T) {
+func Test_handleFollowingVotes_AlreadyVoted(t *testing.T) {
 	t.Parallel()
 
 	const epoch = types.EpochID(10)
 	const round = types.RoundID(5)
 	signer := signing.NewEdSigner()
-	pd, _, _ := createProtocolDriverWithFirstRoundVotes(t, epoch+1, signer)
+	tpd, plist := createProtocolDriverWithFirstRoundVotes(t, signer, epoch, round)
+
 	// this msg will contain a bit vector that set bit 0 and 2
 	msg := createFollowingVote(t, signer, epoch, round, []byte{0b101}, false)
 	msgBytes, err := types.InterfaceToBytes(msg)
 	require.NoError(t, err)
 
-	pd.setRoundInProgress(round)
-	pd.HandleSerializedFollowingVotingMessage(context.TODO(), peerID, msgBytes)
-	checkVoted(t, pd, signer, round, false)
-	checkVoteMargins(t, pd, map[string]*big.Int{})
-}
-
-func Test_handleFollowingVotingMessage_Success(t *testing.T) {
-	t.Parallel()
-
-	const epoch = types.EpochID(10)
-	const round = types.RoundID(5)
-	signer := signing.NewEdSigner()
-	pd, mockDB, hashes := createProtocolDriverWithFirstRoundVotes(t, epoch, signer)
-	mockDB.EXPECT().GetNodeAtxIDForEpoch(gomock.Any(), gomock.Any()).
-		Return(types.ATXID(types.HexToHash32("0x22345678")), nil).Times(1)
-	mockDB.EXPECT().GetAtxHeader(gomock.Any()).Return(&types.ActivationTxHeader{
-		NIPostChallenge: types.NIPostChallenge{
-			StartTick: 1,
-			EndTick:   3,
-		},
-		NumUnits: 5,
-	}, nil).Times(1)
-
-	// this msg will contain a bit vector that set bit 0 and 2
-	msg := createFollowingVote(t, signer, epoch, round, []byte{0b101}, false)
-
-	pd.setRoundInProgress(round)
-	err := pd.handleFollowingVotingMessage(context.TODO(), *msg)
-	assert.NoError(t, err)
-
-	checkVoted(t, pd, signer, round, true)
-	expected := make(map[string]*big.Int, len(hashes))
-	for i, hash := range hashes {
+	tpd.mClock.EXPECT().GetCurrentLayer().Return(epoch.FirstLayer()).Times(1)
+	setMockAtxDbForVotes(tpd.mAtxDB, epoch)
+	got := tpd.handleFollowingVotes(context.TODO(), "peerID", msgBytes, time.Now())
+	assert.NoError(t, got)
+	checkVoted(t, tpd.ProtocolDriver, epoch, signer, round, true)
+	expected := make(map[string]*big.Int, len(plist))
+	for i, p := range plist {
 		if i == 0 || i == 2 {
-			expected[string(hash.Bytes())] = big.NewInt(10)
+			expected[string(p)] = big.NewInt(10)
 		} else {
-			expected[string(hash.Bytes())] = big.NewInt(-10)
+			expected[string(p)] = big.NewInt(-10)
 		}
 	}
-	checkVoteMargins(t, pd, expected)
-}
-
-func Test_handleFollowingVotingMessage_FailedToExtractPK(t *testing.T) {
-	t.Parallel()
-
-	const epoch = types.EpochID(10)
-	const round = types.RoundID(5)
-	signer := signing.NewEdSigner()
-	pd, _, _ := createProtocolDriverWithFirstRoundVotes(t, epoch, signer)
-	// this msg will contain a bit vector that set bit 0 and 2
-	msg := createFollowingVote(t, signer, epoch, round, []byte{0b101}, true)
-
-	pd.setRoundInProgress(round)
-	err := pd.handleFollowingVotingMessage(context.TODO(), *msg)
-	assert.Contains(t, err.Error(), "bad signature format")
-
-	checkVoted(t, pd, signer, round, false)
-	checkVoteMargins(t, pd, map[string]*big.Int{})
-}
-
-func Test_handleFollowingVotingMessage_AlreadyVoted(t *testing.T) {
-	t.Parallel()
-
-	const epoch = types.EpochID(10)
-	const round = types.RoundID(5)
-	signer := signing.NewEdSigner()
-	pd, mockDB, hashes := createProtocolDriverWithFirstRoundVotes(t, epoch, signer)
-	mockDB.EXPECT().GetNodeAtxIDForEpoch(gomock.Any(), gomock.Any()).
-		Return(types.ATXID(types.HexToHash32("0x22345678")), nil).Times(1)
-	mockDB.EXPECT().GetAtxHeader(gomock.Any()).Return(&types.ActivationTxHeader{
-		NIPostChallenge: types.NIPostChallenge{
-			StartTick: 1,
-			EndTick:   3,
-		},
-		NumUnits: 5,
-	}, nil).Times(1)
-
-	// this msg will contain a bit vector that set bit 0 and 2
-	msg := createFollowingVote(t, signer, epoch, round, []byte{0b101}, false)
-
-	pd.setRoundInProgress(round)
-	err := pd.handleFollowingVotingMessage(context.TODO(), *msg)
-	assert.NoError(t, err)
-
-	checkVoted(t, pd, signer, round, true)
-	expected := make(map[string]*big.Int, len(hashes))
-	for i, hash := range hashes {
-		if i == 0 || i == 2 {
-			expected[string(hash.Bytes())] = big.NewInt(10)
-		} else {
-			expected[string(hash.Bytes())] = big.NewInt(-10)
-		}
-	}
-	checkVoteMargins(t, pd, expected)
+	checkVoteMargins(t, tpd.ProtocolDriver, epoch, expected)
 
 	// now vote again
-	err = pd.handleFollowingVotingMessage(context.TODO(), *msg)
-	assert.ErrorIs(t, err, errAlreadyVoted)
+	msg = createFollowingVote(t, signer, epoch, round, []byte{0b111}, false)
+	msgBytes, err = types.InterfaceToBytes(msg)
+	require.NoError(t, err)
 
-	checkVoted(t, pd, signer, round, true)
-	checkVoteMargins(t, pd, expected)
+	tpd.mClock.EXPECT().GetCurrentLayer().Return(epoch.FirstLayer()).Times(1)
+	got = tpd.handleFollowingVotes(context.TODO(), "peerID", msgBytes, time.Now())
+	assert.ErrorIs(t, got, errAlreadyVoted)
+	checkVoted(t, tpd.ProtocolDriver, epoch, signer, round, true)
+	checkVoteMargins(t, tpd.ProtocolDriver, epoch, expected)
 }
 
-func Test_handleFollowingVotingMessage_MinerMissingATX(t *testing.T) {
+func Test_handleFollowingVotes_MinerMissingATX(t *testing.T) {
 	t.Parallel()
 
 	const epoch = types.EpochID(10)
 	const round = types.RoundID(5)
 	signer := signing.NewEdSigner()
-	pd, mockDB, _ := createProtocolDriverWithFirstRoundVotes(t, epoch, signer)
-	mockDB.EXPECT().GetNodeAtxIDForEpoch(gomock.Any(), gomock.Any()).
-		Return(types.ATXID{}, database.ErrNotFound).Times(1)
+	tpd, _ := createProtocolDriverWithFirstRoundVotes(t, signer, epoch, round)
+
 	// this msg will contain a bit vector that set bit 0 and 2
 	msg := createFollowingVote(t, signer, epoch, round, []byte{0b101}, false)
+	msgBytes, err := types.InterfaceToBytes(msg)
+	require.NoError(t, err)
 
-	pd.setRoundInProgress(round)
-	err := pd.handleFollowingVotingMessage(context.TODO(), *msg)
-	assert.ErrorIs(t, err, errMinerATXNotFound)
-
-	checkVoted(t, pd, signer, round, true)
-	checkVoteMargins(t, pd, map[string]*big.Int{})
+	tpd.mClock.EXPECT().GetCurrentLayer().Return(epoch.FirstLayer()).Times(1)
+	tpd.mAtxDB.EXPECT().GetNodeAtxIDForEpoch(gomock.Any(), epoch-1).
+		Return(types.ATXID{}, sql.ErrNotFound).Times(1)
+	got := tpd.handleFollowingVotes(context.TODO(), "peerID", msgBytes, time.Now())
+	assert.ErrorIs(t, got, errMinerATXNotFound)
+	checkVoted(t, tpd.ProtocolDriver, epoch, signer, round, true)
+	checkVoteMargins(t, tpd.ProtocolDriver, epoch, map[string]*big.Int{})
 }
 
-func Test_handleFollowingVotingMessage_ATXLookupError(t *testing.T) {
+func Test_handleFollowingVotes_ATXLookupError(t *testing.T) {
 	t.Parallel()
 
 	const epoch = types.EpochID(10)
 	const round = types.RoundID(5)
 	signer := signing.NewEdSigner()
-	pd, mockDB, _ := createProtocolDriverWithFirstRoundVotes(t, epoch, signer)
-	mockDB.EXPECT().GetNodeAtxIDForEpoch(gomock.Any(), gomock.Any()).
+	tpd, _ := createProtocolDriverWithFirstRoundVotes(t, signer, epoch, round)
+
+	// this msg will contain a bit vector that set bit 0 and 2
+	msg := createFollowingVote(t, signer, epoch, round, []byte{0b101}, false)
+	msgBytes, err := types.InterfaceToBytes(msg)
+	require.NoError(t, err)
+
+	tpd.mClock.EXPECT().GetCurrentLayer().Return(epoch.FirstLayer()).Times(1)
+	errUnknown := errors.New("unknown")
+	tpd.mAtxDB.EXPECT().GetNodeAtxIDForEpoch(gomock.Any(), epoch-1).
 		Return(types.ATXID{}, errUnknown).Times(1)
-	// this msg will contain a bit vector that set bit 0 and 2
-	msg := createFollowingVote(t, signer, epoch, round, []byte{0b101}, false)
-
-	pd.setRoundInProgress(round)
-	err := pd.handleFollowingVotingMessage(context.TODO(), *msg)
-	assert.ErrorIs(t, err, errUnknown)
-
-	checkVoted(t, pd, signer, round, true)
-	checkVoteMargins(t, pd, map[string]*big.Int{})
+	got := tpd.handleFollowingVotes(context.TODO(), "peerID", msgBytes, time.Now())
+	assert.ErrorIs(t, got, errUnknown)
+	checkVoted(t, tpd.ProtocolDriver, epoch, signer, round, true)
+	checkVoteMargins(t, tpd.ProtocolDriver, epoch, map[string]*big.Int{})
 }
 
-func Test_handleFollowingVotingMessage_ATXHeaderLookupError(t *testing.T) {
+func Test_handleFollowingVotes_ATXHeaderLookupError(t *testing.T) {
 	t.Parallel()
 
 	const epoch = types.EpochID(10)
 	const round = types.RoundID(5)
 	signer := signing.NewEdSigner()
-	pd, mockDB, _ := createProtocolDriverWithFirstRoundVotes(t, epoch, signer)
-	mockDB.EXPECT().GetNodeAtxIDForEpoch(gomock.Any(), gomock.Any()).
-		Return(types.ATXID(types.HexToHash32("0x22345678")), nil).Times(1)
-	mockDB.EXPECT().GetAtxHeader(gomock.Any()).Return(nil, errUnknown).Times(1)
+	tpd, _ := createProtocolDriverWithFirstRoundVotes(t, signer, epoch, round)
+
 	// this msg will contain a bit vector that set bit 0 and 2
 	msg := createFollowingVote(t, signer, epoch, round, []byte{0b101}, false)
+	msgBytes, err := types.InterfaceToBytes(msg)
+	require.NoError(t, err)
 
-	pd.setRoundInProgress(round)
-	err := pd.handleFollowingVotingMessage(context.TODO(), *msg)
-	assert.ErrorIs(t, err, errUnknown)
-
-	checkVoted(t, pd, signer, round, true)
-	checkVoteMargins(t, pd, map[string]*big.Int{})
+	tpd.mClock.EXPECT().GetCurrentLayer().Return(epoch.FirstLayer()).Times(1)
+	atxID := types.RandomATXID()
+	tpd.mAtxDB.EXPECT().GetNodeAtxIDForEpoch(gomock.Any(), epoch-1).Return(atxID, nil).Times(1)
+	errUnknown := errors.New("unknown")
+	tpd.mAtxDB.EXPECT().GetAtxHeader(atxID).Return(nil, errUnknown).Times(1)
+	got := tpd.handleFollowingVotes(context.TODO(), "peerID", msgBytes, time.Now())
+	assert.ErrorIs(t, got, errUnknown)
+	checkVoted(t, tpd.ProtocolDriver, epoch, signer, round, true)
+	checkVoteMargins(t, tpd.ProtocolDriver, epoch, map[string]*big.Int{})
 }
 
-func Test_uniqueFollowingVotingMessages(t *testing.T) {
+func Test_UniqueFollowingVotingMessages(t *testing.T) {
 	round := types.RoundID(3)
 	votesBitVector := []byte{0b101}
 	edSgn := signing.NewEdSigner()

--- a/beacon/interface.go
+++ b/beacon/interface.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"time"
 
+	"github.com/libp2p/go-libp2p-core/peer"
+
 	"github.com/spacemeshos/go-spacemesh/beacon/weakcoin"
 	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/p2p/pubsub"
 )
 
 //go:generate mockgen -package=mocks -destination=./mocks/mocks.go -source=./interface.go
@@ -23,6 +26,7 @@ type coin interface {
 	FinishRound(context.Context)
 	Get(context.Context, types.EpochID, types.RoundID) bool
 	FinishEpoch(context.Context, types.EpochID)
+	HandleProposal(context.Context, peer.ID, []byte) pubsub.ValidationResult
 }
 
 type eligibilityChecker interface {

--- a/beacon/interface.go
+++ b/beacon/interface.go
@@ -4,10 +4,9 @@ import (
 	"context"
 	"time"
 
-	"github.com/libp2p/go-libp2p-core/peer"
-
 	"github.com/spacemeshos/go-spacemesh/beacon/weakcoin"
 	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/p2p"
 	"github.com/spacemeshos/go-spacemesh/p2p/pubsub"
 	"github.com/spacemeshos/go-spacemesh/timesync"
 )
@@ -27,7 +26,7 @@ type coin interface {
 	FinishRound(context.Context)
 	Get(context.Context, types.EpochID, types.RoundID) bool
 	FinishEpoch(context.Context, types.EpochID)
-	HandleProposal(context.Context, peer.ID, []byte) pubsub.ValidationResult
+	HandleProposal(context.Context, p2p.Peer, []byte) pubsub.ValidationResult
 }
 
 type eligibilityChecker interface {

--- a/beacon/interface.go
+++ b/beacon/interface.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/beacon/weakcoin"
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/p2p/pubsub"
+	"github.com/spacemeshos/go-spacemesh/timesync"
 )
 
 //go:generate mockgen -package=mocks -destination=./mocks/mocks.go -source=./interface.go
@@ -31,4 +32,11 @@ type coin interface {
 
 type eligibilityChecker interface {
 	IsProposalEligible([]byte) bool
+}
+
+type layerClock interface {
+	Subscribe() timesync.LayerTimer
+	Unsubscribe(timesync.LayerTimer)
+	LayerToTime(types.LayerID) time.Time
+	GetCurrentLayer() types.LayerID
 }

--- a/beacon/message.go
+++ b/beacon/message.go
@@ -2,7 +2,6 @@ package beacon
 
 import (
 	"encoding/json"
-	"time"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
 )
@@ -22,11 +21,6 @@ func (p ProposalMessage) String() string {
 	}
 
 	return string(bytes)
-}
-
-type proposalMessageWithReceiptData struct {
-	message      ProposalMessage
-	receivedTime time.Time
 }
 
 // FirstVotingMessageBody is FirstVotingMessage without a signature.

--- a/beacon/mocks/mocks.go
+++ b/beacon/mocks/mocks.go
@@ -10,8 +10,10 @@ import (
 	time "time"
 
 	gomock "github.com/golang/mock/gomock"
+	peer "github.com/libp2p/go-libp2p-core/peer"
 	weakcoin "github.com/spacemeshos/go-spacemesh/beacon/weakcoin"
 	types "github.com/spacemeshos/go-spacemesh/common/types"
+	pubsub "github.com/spacemeshos/go-spacemesh/p2p/pubsub"
 )
 
 // MockactivationDB is a mock of activationDB interface.
@@ -157,6 +159,20 @@ func (m *Mockcoin) Get(arg0 context.Context, arg1 types.EpochID, arg2 types.Roun
 func (mr *MockcoinMockRecorder) Get(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*Mockcoin)(nil).Get), arg0, arg1, arg2)
+}
+
+// HandleProposal mocks base method.
+func (m *Mockcoin) HandleProposal(arg0 context.Context, arg1 peer.ID, arg2 []byte) pubsub.ValidationResult {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HandleProposal", arg0, arg1, arg2)
+	ret0, _ := ret[0].(pubsub.ValidationResult)
+	return ret0
+}
+
+// HandleProposal indicates an expected call of HandleProposal.
+func (mr *MockcoinMockRecorder) HandleProposal(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleProposal", reflect.TypeOf((*Mockcoin)(nil).HandleProposal), arg0, arg1, arg2)
 }
 
 // StartEpoch mocks base method.

--- a/beacon/mocks/mocks.go
+++ b/beacon/mocks/mocks.go
@@ -14,6 +14,7 @@ import (
 	weakcoin "github.com/spacemeshos/go-spacemesh/beacon/weakcoin"
 	types "github.com/spacemeshos/go-spacemesh/common/types"
 	pubsub "github.com/spacemeshos/go-spacemesh/p2p/pubsub"
+	timesync "github.com/spacemeshos/go-spacemesh/timesync"
 )
 
 // MockactivationDB is a mock of activationDB interface.
@@ -236,4 +237,81 @@ func (m *MockeligibilityChecker) IsProposalEligible(arg0 []byte) bool {
 func (mr *MockeligibilityCheckerMockRecorder) IsProposalEligible(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsProposalEligible", reflect.TypeOf((*MockeligibilityChecker)(nil).IsProposalEligible), arg0)
+}
+
+// MocklayerClock is a mock of layerClock interface.
+type MocklayerClock struct {
+	ctrl     *gomock.Controller
+	recorder *MocklayerClockMockRecorder
+}
+
+// MocklayerClockMockRecorder is the mock recorder for MocklayerClock.
+type MocklayerClockMockRecorder struct {
+	mock *MocklayerClock
+}
+
+// NewMocklayerClock creates a new mock instance.
+func NewMocklayerClock(ctrl *gomock.Controller) *MocklayerClock {
+	mock := &MocklayerClock{ctrl: ctrl}
+	mock.recorder = &MocklayerClockMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MocklayerClock) EXPECT() *MocklayerClockMockRecorder {
+	return m.recorder
+}
+
+// GetCurrentLayer mocks base method.
+func (m *MocklayerClock) GetCurrentLayer() types.LayerID {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCurrentLayer")
+	ret0, _ := ret[0].(types.LayerID)
+	return ret0
+}
+
+// GetCurrentLayer indicates an expected call of GetCurrentLayer.
+func (mr *MocklayerClockMockRecorder) GetCurrentLayer() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCurrentLayer", reflect.TypeOf((*MocklayerClock)(nil).GetCurrentLayer))
+}
+
+// LayerToTime mocks base method.
+func (m *MocklayerClock) LayerToTime(arg0 types.LayerID) time.Time {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LayerToTime", arg0)
+	ret0, _ := ret[0].(time.Time)
+	return ret0
+}
+
+// LayerToTime indicates an expected call of LayerToTime.
+func (mr *MocklayerClockMockRecorder) LayerToTime(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LayerToTime", reflect.TypeOf((*MocklayerClock)(nil).LayerToTime), arg0)
+}
+
+// Subscribe mocks base method.
+func (m *MocklayerClock) Subscribe() timesync.LayerTimer {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Subscribe")
+	ret0, _ := ret[0].(timesync.LayerTimer)
+	return ret0
+}
+
+// Subscribe indicates an expected call of Subscribe.
+func (mr *MocklayerClockMockRecorder) Subscribe() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Subscribe", reflect.TypeOf((*MocklayerClock)(nil).Subscribe))
+}
+
+// Unsubscribe mocks base method.
+func (m *MocklayerClock) Unsubscribe(arg0 timesync.LayerTimer) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Unsubscribe", arg0)
+}
+
+// Unsubscribe indicates an expected call of Unsubscribe.
+func (mr *MocklayerClockMockRecorder) Unsubscribe(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Unsubscribe", reflect.TypeOf((*MocklayerClock)(nil).Unsubscribe), arg0)
 }

--- a/beacon/mocks/mocks.go
+++ b/beacon/mocks/mocks.go
@@ -10,9 +10,9 @@ import (
 	time "time"
 
 	gomock "github.com/golang/mock/gomock"
-	peer "github.com/libp2p/go-libp2p-core/peer"
 	weakcoin "github.com/spacemeshos/go-spacemesh/beacon/weakcoin"
 	types "github.com/spacemeshos/go-spacemesh/common/types"
+	p2p "github.com/spacemeshos/go-spacemesh/p2p"
 	pubsub "github.com/spacemeshos/go-spacemesh/p2p/pubsub"
 	timesync "github.com/spacemeshos/go-spacemesh/timesync"
 )
@@ -163,7 +163,7 @@ func (mr *MockcoinMockRecorder) Get(arg0, arg1, arg2 interface{}) *gomock.Call {
 }
 
 // HandleProposal mocks base method.
-func (m *Mockcoin) HandleProposal(arg0 context.Context, arg1 peer.ID, arg2 []byte) pubsub.ValidationResult {
+func (m *Mockcoin) HandleProposal(arg0 context.Context, arg1 p2p.Peer, arg2 []byte) pubsub.ValidationResult {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HandleProposal", arg0, arg1, arg2)
 	ret0, _ := ret[0].(pubsub.ValidationResult)

--- a/beacon/weakcoin/handler.go
+++ b/beacon/weakcoin/handler.go
@@ -4,18 +4,17 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/libp2p/go-libp2p-core/peer"
-
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/log"
+	"github.com/spacemeshos/go-spacemesh/p2p"
 	"github.com/spacemeshos/go-spacemesh/p2p/pubsub"
 )
 
 // HandleProposal defines method to handle Beacon Weak Coin Messages from gossip.
-func (wc *WeakCoin) HandleProposal(ctx context.Context, pid peer.ID, msg []byte) pubsub.ValidationResult {
+func (wc *WeakCoin) HandleProposal(ctx context.Context, peer p2p.Peer, msg []byte) pubsub.ValidationResult {
 	logger := wc.logger.WithContext(ctx)
 	logger.With().Debug("received weak coin message",
-		log.String("from", pid.String()),
+		log.String("from", peer.String()),
 		log.Binary("data", msg),
 	)
 

--- a/beacon/weakcoin/weak_coin.go
+++ b/beacon/weakcoin/weak_coin.go
@@ -83,23 +83,31 @@ func WithNextRoundBufferSize(size int) Option {
 	}
 }
 
+func withVerifier(v signing.Verifier) Option {
+	return func(wc *WeakCoin) {
+		wc.verifier = v
+	}
+}
+
 // New creates an instance of weak coin protocol.
 func New(
 	publisher pubsub.Publisher,
 	signer signing.Signer,
-	verifier signing.Verifier,
 	opts ...Option,
 ) *WeakCoin {
 	wc := &WeakCoin{
 		logger:    log.NewNop(),
 		config:    defaultConfig(),
 		signer:    signer,
-		verifier:  verifier,
 		publisher: publisher,
 		coins:     make(map[types.RoundID]bool),
 	}
 	for _, opt := range opts {
 		opt(wc)
+	}
+
+	if wc.verifier == nil {
+		wc.verifier = signing.VRFVerifier{}
 	}
 	wc.nextRoundBuffer = make([]Message, 0, wc.config.NextRoundBufferSize)
 	return wc
@@ -128,7 +136,7 @@ type WeakCoin struct {
 // and only after CompleteRound was called.
 func (wc *WeakCoin) Get(ctx context.Context, epoch types.EpochID, round types.RoundID) bool {
 	if epoch.IsGenesis() {
-		wc.logger.WithContext(ctx).With().Panic("tb weak coin not used during genesis")
+		wc.logger.WithContext(ctx).With().Panic("beacon weak coin not used during genesis")
 	}
 
 	wc.mu.RLock()
@@ -149,7 +157,7 @@ func (wc *WeakCoin) StartEpoch(ctx context.Context, epoch types.EpochID, allowan
 	wc.epochStarted = true
 	wc.epoch = epoch
 	wc.allowances = allowances
-	wc.logger.WithContext(ctx).With().Info("tb weak coin started epoch", epoch)
+	wc.logger.WithContext(ctx).With().Info("beacon weak coin started epoch", epoch)
 }
 
 // FinishEpoch completes epoch. After it is called Get for this epoch will panic.
@@ -158,7 +166,7 @@ func (wc *WeakCoin) FinishEpoch(ctx context.Context, epoch types.EpochID) {
 	wc.mu.Lock()
 	defer wc.mu.Unlock()
 	if epoch != wc.epoch {
-		logger.Panic("attempted to finish tb weak coin for the wrong epoch")
+		logger.Panic("attempted to finish beacon weak coin for the wrong epoch")
 	}
 	wc.epochStarted = false
 	wc.allowances = nil

--- a/beacon/weakcoin/weak_coin.go
+++ b/beacon/weakcoin/weak_coin.go
@@ -83,7 +83,8 @@ func WithNextRoundBufferSize(size int) Option {
 	}
 }
 
-func withVerifier(v signing.Verifier) Option {
+// WithVerifier changes the verifier of the weakcoin messages.
+func WithVerifier(v signing.Verifier) Option {
 	return func(wc *WeakCoin) {
 		wc.verifier = v
 	}

--- a/beacon/weakcoin/weak_coin.go
+++ b/beacon/weakcoin/weak_coin.go
@@ -179,7 +179,7 @@ func (wc *WeakCoin) FinishEpoch(ctx context.Context, epoch types.EpochID) {
 func (wc *WeakCoin) StartRound(ctx context.Context, round types.RoundID) error {
 	wc.mu.Lock()
 	logger := wc.logger.WithContext(ctx).WithFields(wc.epoch, round)
-	logger.Info("started round")
+	logger.Info("started beacon weak coin round")
 	wc.roundStarted = true
 	wc.round = round
 	wc.smallestProposal = nil

--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -72,7 +72,6 @@ const (
 	StateDbLogger          = "stateDbStore"
 	AtxDbStoreLogger       = "atxDbStore"
 	BeaconLogger           = "beacon"
-	WeakCoinLogger         = "weakCoin"
 	PoetDbStoreLogger      = "poetDbStore"
 	StoreLogger            = "store"
 	PoetDbLogger           = "poetDb"
@@ -699,11 +698,11 @@ func (app *App) initServices(ctx context.Context,
 
 	app.host.Register(weakcoin.GossipProtocol, pubsub.ChainGossipHandler(syncHandler, beaconProtocol.HandleWeakCoinProposal))
 	app.host.Register(beacon.ProposalProtocol,
-		pubsub.ChainGossipHandler(syncHandler, beaconProtocol.HandleSerializedProposalMessage))
-	app.host.Register(beacon.FirstVoteProtocol,
-		pubsub.ChainGossipHandler(syncHandler, beaconProtocol.HandleSerializedFirstVotingMessage))
-	app.host.Register(beacon.FollowingVotingProtocol,
-		pubsub.ChainGossipHandler(syncHandler, beaconProtocol.HandleSerializedFollowingVotingMessage))
+		pubsub.ChainGossipHandler(syncHandler, beaconProtocol.HandleProposal))
+	app.host.Register(beacon.FirstVotesProtocol,
+		pubsub.ChainGossipHandler(syncHandler, beaconProtocol.HandleFirstVotes))
+	app.host.Register(beacon.FollowingVotesProtocol,
+		pubsub.ChainGossipHandler(syncHandler, beaconProtocol.HandleFollowingVotes))
 	app.host.Register(proposals.NewProposalProtocol, pubsub.ChainGossipHandler(syncHandler, proposalListener.HandleProposal))
 	app.host.Register(activation.AtxProtocol, pubsub.ChainGossipHandler(syncHandler, atxDB.HandleGossipAtx))
 	app.host.Register(svm.IncomingTxProtocol, pubsub.ChainGossipHandler(syncHandler, state.HandleGossipTransaction))

--- a/hare/broker_test.go
+++ b/hare/broker_test.go
@@ -127,7 +127,7 @@ func TestBroker_Priority(t *testing.T) {
 	wg2.Wait()
 
 	// now broadcast one outbound message
-	broker.queueMessage(context.TODO(), broker.pid, serMsgOutbound)
+	broker.queueMessage(context.TODO(), broker.peer, serMsgOutbound)
 
 	// all messages are queued, release the waiting listener (hare event loop)
 	wg.Done()

--- a/hare/hare.go
+++ b/hare/hare.go
@@ -8,13 +8,12 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/libp2p/go-libp2p-core/peer"
-
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/common/util"
 	"github.com/spacemeshos/go-spacemesh/database"
 	"github.com/spacemeshos/go-spacemesh/hare/config"
 	"github.com/spacemeshos/go-spacemesh/log"
+	"github.com/spacemeshos/go-spacemesh/p2p"
 	"github.com/spacemeshos/go-spacemesh/p2p/pubsub"
 	"github.com/spacemeshos/go-spacemesh/system"
 )
@@ -93,7 +92,7 @@ type Hare struct {
 // New returns a new Hare struct.
 func New(
 	conf config.Config,
-	pid peer.ID,
+	peer p2p.Peer,
 	publisher pubsub.PublishSubsciber,
 	sign Signer,
 	nid types.NodeID,
@@ -131,7 +130,7 @@ func New(
 	}
 
 	ev := newEligibilityValidator(rolacle, layersPerEpoch, idProvider, conf.N, conf.ExpectedLeaders, logger)
-	h.broker = newBroker(pid, ev, stateQ, syncState, layersPerEpoch, conf.LimitConcurrent, h.Closer, logger)
+	h.broker = newBroker(peer, ev, stateQ, syncState, layersPerEpoch, conf.LimitConcurrent, h.Closer, logger)
 	publisher.Register(protoName, h.broker.HandleMessage)
 	h.sign = sign
 	h.blockGen = blockGen

--- a/proposals/handler.go
+++ b/proposals/handler.go
@@ -5,12 +5,12 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/spacemeshos/go-spacemesh/codec"
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/log"
+	"github.com/spacemeshos/go-spacemesh/p2p"
 	"github.com/spacemeshos/go-spacemesh/p2p/pubsub"
 	"github.com/spacemeshos/go-spacemesh/proposals/metrics"
 	"github.com/spacemeshos/go-spacemesh/system"
@@ -129,7 +129,7 @@ func NewHandler(f system.Fetcher, bc system.BeaconCollector, db atxDB, m meshDB,
 }
 
 // HandleProposal is the gossip receiver for Proposal.
-func (h *Handler) HandleProposal(ctx context.Context, _ peer.ID, msg []byte) pubsub.ValidationResult {
+func (h *Handler) HandleProposal(ctx context.Context, _ p2p.Peer, msg []byte) pubsub.ValidationResult {
 	newCtx := log.WithNewRequestID(ctx)
 	if err := h.handleProposalData(newCtx, msg); errors.Is(err, errKnownProposal) {
 		return pubsub.ValidationIgnore

--- a/proposals/proposaldb.go
+++ b/proposals/proposaldb.go
@@ -113,7 +113,7 @@ func (db *DB) AddProposal(ctx context.Context, p *types.Proposal) error {
 		return err
 	}
 	events.ReportNewProposal(p)
-	db.logger.Info("added proposal to database", log.Inline(p))
+	db.logger.With().Info("added proposal to database", log.Inline(p))
 	return nil
 }
 


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
while debugging https://github.com/spacemeshos/go-spacemesh/pull/3103, i found that early proposals are rejected due to the `isInProtocol` check. 

early votes are also rejected due to the round number check. as nodes are not perfectly time-synced, some go into the next round earlier than others. 

this is not an issue in the current system tests, but may cause participants seeing different set of proposals in a larger network. we should accept early proposals and votes within grace period, accounting for time sync difference.

## Changes
<!-- Please describe in detail the changes made -->
- use context to decide whether the protocol is shutting down
- don't use channels to buffer proposals. instead, process proposals as they arrive. this simplify the processing logic
- allow proposals that arrive within grace period before its intended epoch begins.
- allow following votes that arrive within grace period before its intended round begins.

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->
unit tests / system tests

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
