### PR TITLE
[Merged by Bors] - sql/blocks: ensure that blocks for layer are returned in order 

### DIFF
--- a/api/grpcserver/grpcserver_test.go
+++ b/api/grpcserver/grpcserver_test.go
@@ -290,7 +290,9 @@ func (t *TxAPIMock) GetLayer(tid types.LayerID) (*types.Layer, error) {
 
 	ballots := []*types.Ballot{ballot1}
 	blocks := []*types.Block{block1, block2, block3}
-	return types.NewExistingLayer(tid, ballots, blocks), nil
+	return types.NewExistingLayer(tid,
+		types.CalcBlocksHash32(types.ToBlockIDs(blocks), nil),
+		ballots, blocks), nil
 }
 
 func (t *TxAPIMock) GetATXs(context.Context, []types.ATXID) (map[types.ATXID]*types.ActivationTx, []types.ATXID) {

--- a/common/types/layer.go
+++ b/common/types/layer.go
@@ -76,7 +76,7 @@ func InitGenesisData() {
 		},
 		blockID: GenesisBlockID,
 	}
-	genesisLayer = NewExistingLayer(GetEffectiveGenesis(), []*Ballot{ballot}, []*Block{block})
+	genesisLayer = NewExistingLayer(GetEffectiveGenesis(), Hash32{}, []*Ballot{ballot}, []*Block{block})
 }
 
 // GetEffectiveGenesis returns when actual proposals would be created.
@@ -247,6 +247,7 @@ func (id NodeID) Field() log.Field { return log.String("node_id", id.Key) }
 // Layer contains a list of proposals and their corresponding LayerID.
 type Layer struct {
 	index   LayerID
+	hash    Hash32
 	ballots []*Ballot
 	blocks  []*Block
 }
@@ -284,10 +285,7 @@ func (l *Layer) BallotIDs() []BallotID {
 
 // Hash returns the 32-byte sha256 sum of the block IDs in this layer, sorted in lexicographic order.
 func (l Layer) Hash() Hash32 {
-	if len(l.blocks) == 0 {
-		return EmptyLayerHash
-	}
-	return CalcBlocksHash32(SortBlockIDs(l.BlocksIDs()), nil)
+	return l.hash
 }
 
 // AddBallot adds a ballot to this layer. Panics if the ballot's index doesn't match the layer.
@@ -317,9 +315,10 @@ func (l *Layer) SetBlocks(blocks []*Block) {
 }
 
 // NewExistingLayer returns a new layer with the given list of blocks without validation.
-func NewExistingLayer(idx LayerID, ballots []*Ballot, blocks []*Block) *Layer {
+func NewExistingLayer(idx LayerID, hash Hash32, ballots []*Ballot, blocks []*Block) *Layer {
 	return &Layer{
 		index:   idx,
+		hash:    hash,
 		ballots: ballots,
 		blocks:  blocks,
 	}

--- a/mesh/mesh.go
+++ b/mesh/mesh.go
@@ -181,16 +181,20 @@ func (msh *Mesh) setLatestLayer(lid types.LayerID) {
 }
 
 // GetLayer returns Layer i from the database.
-func (msh *Mesh) GetLayer(i types.LayerID) (*types.Layer, error) {
-	ballots, err := msh.LayerBallots(i)
+func (msh *Mesh) GetLayer(lid types.LayerID) (*types.Layer, error) {
+	ballots, err := msh.LayerBallots(lid)
 	if err != nil {
 		return nil, fmt.Errorf("layer ballots: %w", err)
 	}
-	blocks, err := msh.LayerBlocks(i)
+	blocks, err := msh.LayerBlocks(lid)
 	if err != nil {
 		return nil, fmt.Errorf("layer blocks: %w", err)
 	}
-	return types.NewExistingLayer(i, ballots, blocks), nil
+	hash, err := layers.GetHash(msh.db, lid)
+	if err != nil {
+		hash = types.CalcBlockHash32Presorted(types.ToBlockIDs(blocks), nil)
+	}
+	return types.NewExistingLayer(lid, hash, ballots, blocks), nil
 }
 
 // GetLayerHash returns layer hash.

--- a/sql/blocks/blocks_test.go
+++ b/sql/blocks/blocks_test.go
@@ -1,6 +1,7 @@
 package blocks
 
 import (
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -88,20 +89,54 @@ func TestLayerFilter(t *testing.T) {
 			types.InnerBlock{LayerIndex: start},
 		),
 		types.NewExistingBlock(
-			types.BlockID{2, 2},
-			types.InnerBlock{LayerIndex: start},
-		),
-		types.NewExistingBlock(
 			types.BlockID{3, 3},
 			types.InnerBlock{LayerIndex: start.Add(1)},
+		),
+		types.NewExistingBlock(
+			types.BlockID{2, 2},
+			types.InnerBlock{LayerIndex: start},
 		),
 	}
 	for _, block := range blocks {
 		require.NoError(t, Add(db, block))
 	}
+	sort.Slice(blocks, func(i, j int) bool {
+		return blocks[i].ID().Compare(blocks[j].ID())
+	})
 	bids, err := IDsInLayer(db, start)
 	require.NoError(t, err)
 	require.Len(t, bids, 2)
+	for i, bid := range bids {
+		require.Equal(t, bid, blocks[i].ID())
+	}
+}
+
+func TestLayerOrdered(t *testing.T) {
+	db := sql.InMemory()
+	start := types.NewLayerID(1)
+	blocks := []*types.Block{
+		types.NewExistingBlock(
+			types.BlockID{1, 1},
+			types.InnerBlock{LayerIndex: start},
+		),
+		types.NewExistingBlock(
+			types.BlockID{3, 3},
+			types.InnerBlock{LayerIndex: start},
+		),
+		types.NewExistingBlock(
+			types.BlockID{2, 2},
+			types.InnerBlock{LayerIndex: start},
+		),
+	}
+	for _, block := range blocks {
+		require.NoError(t, Add(db, block))
+	}
+	sort.Slice(blocks, func(i, j int) bool {
+		return blocks[i].ID().Compare(blocks[j].ID())
+	})
+	bids, err := IDsInLayer(db, start)
+	require.NoError(t, err)
+	require.Len(t, bids, 3)
 	for i, bid := range bids {
 		require.Equal(t, bid, blocks[i].ID())
 	}

--- a/sql/migrations/0001_initial.sql
+++ b/sql/migrations/0001_initial.sql
@@ -5,7 +5,7 @@ CREATE TABLE blocks
     validity SMALL INT,
     block    BLOB
 );
-CREATE INDEX blocks_by_layer ON blocks (layer);
+CREATE INDEX blocks_by_layer ON blocks (layer,id asc);
 
 CREATE TABLE ballots
 (

--- a/tortoise/tortoise_test.go
+++ b/tortoise/tortoise_test.go
@@ -281,7 +281,7 @@ func createTurtleLayer(t *testing.T, l types.LayerID, msh *mesh.DB, atxdb atxDat
 		types.GenLayerBlock(l, types.RandomTXSet(rand.Intn(100))),
 		types.GenLayerBlock(l, types.RandomTXSet(rand.Intn(100))),
 	}
-	return types.NewExistingLayer(l, ballots, blocks)
+	return types.NewExistingLayer(l, types.Hash32{}, ballots, blocks)
 }
 
 func TestLayerCutoff(t *testing.T) {


### PR DESCRIPTION
we expect blocks to be lexicographically sorted when layer hash is computed 
