### PR TITLE
[Merged by Bors] - fail signature extraction deterministically

### DIFF
--- a/txs/handler_test.go
+++ b/txs/handler_test.go
@@ -71,7 +71,7 @@ func Test_handleTransaction_BadSignature(t *testing.T) {
 
 	signer := signing.NewEdSigner()
 	tx := newTx(t, 3, 10, 1, signer)
-	copy(tx.Signature[:], types.RandomBytes(64))
+	tx.Signature[63] = 224
 	msg, err := codec.Encode(tx)
 	require.NoError(t, err)
 
@@ -146,7 +146,7 @@ func Test_HandleSyncTransaction_BadSignature(t *testing.T) {
 
 	signer := signing.NewEdSigner()
 	tx := newTx(t, 3, 10, 1, signer)
-	copy(tx.Signature[:], types.RandomBytes(64))
+	tx.Signature[63] = 224
 	msg, err := codec.Encode(tx)
 	require.NoError(t, err)
 


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
Closes #3126
<!-- `Closes #XXXX, closes #XXXX, ...` links mentioned issues to this PR and automatically closes them when this it's merged -->

## Changes
<!-- Please describe in detail the changes made -->
make ed25519 signature extraction fail

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->
unit test

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
