### PR TITLE
[Merged by Bors] - Add `./bin` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ cmd/tmp
 .DS_Store
 */**/.DS_Store
 /build
+/bin
 libgpu-setup-*
 libsvm-*
 


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
`./bin/golangci-lint` was recently committed because it was not added to `.gitignore`
<!-- `Closes #XXXX, closes #XXXX, ...` links mentioned issues to this PR and automatically closes them when this it's merged -->

## Changes
<!-- Please describe in detail the changes made -->
- Add `./bin` to `.gitignore`
- Delete `./bin/golangci-lint`

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
