### PR TITLE
[Merged by Bors] - TX Selection: optimistically apply a layer after hare terminates

### DIFF
--- a/activation/poetdb.go
+++ b/activation/poetdb.go
@@ -1,7 +1,6 @@
 package activation
 
 import (
-	"errors"
 	"fmt"
 	"sync"
 
@@ -90,7 +89,7 @@ func (db *PoetDb) StoreProof(proofMessage *types.PoetProofMessage) error {
 		return fmt.Errorf("could not marshal proof message: %v", err)
 	}
 
-	if err := poets.Add(db.sqlDB, ref, messageBytes, proofMessage.PoetServiceID, proofMessage.RoundID); err != nil && !errors.Is(err, sql.ErrObjectExists) {
+	if err := poets.Add(db.sqlDB, ref, messageBytes, proofMessage.PoetServiceID, proofMessage.RoundID); err != nil {
 		return fmt.Errorf("failed to store poet proof for poetId %x round %s: %v",
 			proofMessage.PoetServiceID[:5], proofMessage.RoundID, err)
 	}

--- a/activation/poetdb.go
+++ b/activation/poetdb.go
@@ -1,6 +1,7 @@
 package activation
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 
@@ -89,7 +90,7 @@ func (db *PoetDb) StoreProof(proofMessage *types.PoetProofMessage) error {
 		return fmt.Errorf("could not marshal proof message: %v", err)
 	}
 
-	if err := poets.Add(db.sqlDB, ref, messageBytes, proofMessage.PoetServiceID, proofMessage.RoundID); err != nil {
+	if err := poets.Add(db.sqlDB, ref, messageBytes, proofMessage.PoetServiceID, proofMessage.RoundID); err != nil && !errors.Is(err, sql.ErrObjectExists) {
 		return fmt.Errorf("failed to store poet proof for poetId %x round %s: %v",
 			proofMessage.PoetServiceID[:5], proofMessage.RoundID, err)
 	}

--- a/cmd/node/app_test.go
+++ b/cmd/node/app_test.go
@@ -447,7 +447,7 @@ func healingTester(dependencies []int) TestScenario {
 		success := true
 		for i, app := range suite.apps {
 			lyrProcessed := app.mesh.ProcessedLayer()
-			lyrVerified := app.mesh.LatestLayerInState()
+			lyrVerified := app.tortoise.LatestComplete()
 			suite.log.With().Info("node latest layers",
 				log.FieldNamed("old_verified", lastVerifiedLayer),
 				log.Uint32("confidence_interval", confidenceInterval),

--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -70,7 +70,6 @@ const (
 	PostLogger             = "post"
 	StateDbLogger          = "stateDbStore"
 	BeaconLogger           = "beacon"
-	PoetDbStoreLogger      = "poetDbStore"
 	StoreLogger            = "store"
 	PoetDbLogger           = "poetDb"
 	MeshDBLogger           = "meshDb"

--- a/mesh/interface.go
+++ b/mesh/interface.go
@@ -19,5 +19,5 @@ type conservativeState interface {
 type tortoise interface {
 	OnBallot(*types.Ballot)
 	OnBlock(*types.Block)
-	HandleIncomingLayer(context.Context, types.LayerID) (oldPbase, newPbase types.LayerID, reverted bool)
+	HandleIncomingLayer(context.Context, types.LayerID) types.LayerID
 }

--- a/mesh/mesh.go
+++ b/mesh/mesh.go
@@ -152,6 +152,7 @@ func (msh *Mesh) UpdateBlockValidity(bid types.BlockID, lid types.LayerID, newVa
 			}
 			if msh.minUpdatedLayer.CompareAndSwap(minUpdated, lid) {
 				msh.With().Debug("min updated layer set for block", lid, bid)
+				break
 			}
 		}
 	}
@@ -588,7 +589,8 @@ func (msh *Mesh) ProcessLayerPerHareOutput(ctx context.Context, layerID types.La
 
 	logger.Info("saving hare output for layer")
 	if err := msh.SaveHareConsensusOutput(ctx, layerID, blockID); err != nil {
-		logger.With().Error("saving layer hare output failed", log.Err(err))
+		logger.With().Error("failed to save hare output", log.Err(err))
+		return err
 	}
 	return msh.ProcessLayer(ctx, layerID)
 }

--- a/mesh/mesh_test.go
+++ b/mesh/mesh_test.go
@@ -94,86 +94,40 @@ func createLayerBallots(t *testing.T, mesh *Mesh, lyrID types.LayerID) []*types.
 	return ballots
 }
 
-func TestMesh_LayerHash(t *testing.T) {
+func TestMesh_LayerHashes(t *testing.T) {
 	tm := createTestMesh(t)
 	defer tm.Close()
 
 	gLyr := types.GetEffectiveGenesis()
 	numLayers := 5
 	latestLyr := gLyr.Add(uint32(numLayers))
+	lyrBlocks := make(map[types.LayerID]*types.Block)
 	for i := gLyr.Add(1); !i.After(latestLyr); i = i.Add(1) {
 		_, blocks := createLayerBallotsAndBlocks(t, tm.Mesh, i)
-		require.NoError(t, tm.SaveContextualValidity(types.SortBlocks(blocks)[0].ID(), i, false))
-	}
-
-	tm.mockState.EXPECT().GetStateRoot().Return(types.Hash32{}).Times(numLayers - 1)
-	tm.mockState.EXPECT().ReinsertTxsToMemPool(gomock.Any()).Return(nil).AnyTimes()
-	for i := gLyr.Add(1); !i.After(latestLyr); i = i.Add(1) {
-		thisLyr, err := tm.GetLayer(i)
-		require.NoError(t, err)
-		// when tortoise verify a layer N, it can only determine blocks' contextual validity for layer N-1
-		prevLyr, err := tm.GetLayer(i.Sub(1))
-		require.NoError(t, err)
-		assert.Equal(t, thisLyr.Hash(), tm.GetLayerHash(i))
-		assert.Equal(t, prevLyr.Hash(), tm.GetLayerHash(i.Sub(1)))
-
-		if prevLyr.Index().After(gLyr) {
-			tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), i).Return(i.Sub(2), i.Sub(1), false).Times(1)
-			tm.mockState.EXPECT().ApplyLayer(prevLyr.Index(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
-		} else {
-			tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), i).Return(gLyr, gLyr, false).Times(1)
-		}
-		require.NoError(t, tm.ProcessLayer(context.TODO(), thisLyr.Index()))
-		// for this layer, hash is unchanged because the block contextual validity is not determined yet
-		assert.Equal(t, thisLyr.Hash(), tm.GetLayerHash(i))
-		if prevLyr.Index().After(gLyr) {
-			// but for previous layer hash should already be changed to contain only valid proposals
-			prevExpHash := types.CalcBlocksHash32(types.SortBlockIDs(prevLyr.BlocksIDs())[1:], nil)
-			require.Equal(t, prevExpHash, tm.GetLayerHash(i.Sub(1)), "layer %s", i.Sub(1))
-			assert.NotEqual(t, prevLyr.Hash(), tm.GetLayerHash(i.Sub(1)))
-		}
-	}
-}
-
-func TestMesh_GetAggregatedLayerHash(t *testing.T) {
-	r := require.New(t)
-	tm := createTestMesh(t)
-	defer tm.Close()
-
-	gLyr := types.GetEffectiveGenesis()
-	numLayers := 5
-	latestLyr := gLyr.Add(uint32(numLayers))
-	for i := gLyr.Add(1); !i.After(latestLyr); i = i.Add(1) {
-		_, blocks := createLayerBallotsAndBlocks(t, tm.Mesh, i)
-		require.NoError(t, tm.SaveContextualValidity(types.SortBlocks(blocks)[0].ID(), i, false))
+		hareOutput := types.SortBlocks(blocks)[0]
+		lyrBlocks[i] = hareOutput
+		require.NoError(t, tm.SaveHareConsensusOutput(context.TODO(), i, hareOutput.ID()))
 	}
 
 	prevAggHash := tm.GetAggregatedLayerHash(gLyr)
-	tm.mockState.EXPECT().GetStateRoot().Return(types.Hash32{}).Times(numLayers - 1)
-	tm.mockState.EXPECT().ReinsertTxsToMemPool(gomock.Any()).Return(nil).AnyTimes()
 	for i := gLyr.Add(1); !i.After(latestLyr); i = i.Add(1) {
 		thisLyr, err := tm.GetLayer(i)
-		r.NoError(err)
-		prevLyr, err := tm.GetLayer(i.Sub(1))
-		r.NoError(err)
-		if prevLyr.Index() == gLyr {
-			r.Equal(types.EmptyLayerHash, tm.GetAggregatedLayerHash(i))
-			tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), i).Return(gLyr, gLyr, false).Times(1)
-			require.NoError(t, tm.ProcessLayer(context.TODO(), thisLyr.Index()))
-			r.Equal(types.EmptyLayerHash, tm.GetAggregatedLayerHash(i))
-			continue
-		}
-		tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), i).Return(i.Sub(2), i.Sub(1), false).Times(1)
-		tm.mockState.EXPECT().ApplyLayer(prevLyr.Index(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
-		r.Equal(types.EmptyLayerHash, tm.GetAggregatedLayerHash(i.Sub(1)))
-		r.Equal(types.EmptyLayerHash, tm.GetAggregatedLayerHash(i))
+		require.NoError(t, err)
+
+		tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), i).Return(minLayer(gLyr, i.Sub(2)), i.Sub(1), false).Times(1)
+		blk := lyrBlocks[i]
+		tm.mockState.EXPECT().ApplyLayer(i, blk.ID(), blk.TxIDs, gomock.Any()).Return(nil, nil).Times(1)
+		tm.mockState.EXPECT().GetStateRoot().Return(types.Hash32{})
+		tm.mockState.EXPECT().ReinsertTxsToMemPool(gomock.Any()).Return(nil)
+
+		require.Equal(t, types.EmptyLayerHash, tm.GetLayerHash(i))
+		require.Equal(t, types.EmptyLayerHash, tm.GetAggregatedLayerHash(i))
 		require.NoError(t, tm.ProcessLayer(context.TODO(), thisLyr.Index()))
-		// contextual validity is still not determined for thisLyr, so aggregated hash is not calculated for this layer
-		r.Equal(types.EmptyLayerHash, tm.GetAggregatedLayerHash(i))
-		// but for previous layer hash should already be changed to contain only valid proposals
-		expHash := types.CalcBlocksHash32(types.SortBlockIDs(prevLyr.BlocksIDs())[1:], prevAggHash.Bytes())
-		assert.Equal(t, expHash, tm.GetAggregatedLayerHash(prevLyr.Index()))
-		prevAggHash = expHash
+		expectedHash := types.CalcBlocksHash32([]types.BlockID{blk.ID()}, nil)
+		assert.Equal(t, expectedHash, tm.GetLayerHash(i))
+		expectedAggHash := types.CalcBlocksHash32([]types.BlockID{blk.ID()}, prevAggHash.Bytes())
+		assert.Equal(t, expectedAggHash, tm.GetAggregatedLayerHash(i))
+		prevAggHash = expectedAggHash
 	}
 }
 
@@ -212,53 +166,26 @@ func TestMesh_ProcessLayerPerHareOutput(t *testing.T) {
 	_, blocks3 := createLayerBallotsAndBlocks(t, tm.Mesh, gLyr.Add(3))
 	_, blocks4 := createLayerBallotsAndBlocks(t, tm.Mesh, gLyr.Add(4))
 	_, blocks5 := createLayerBallotsAndBlocks(t, tm.Mesh, gLyr.Add(5))
+	layerBlocks := map[types.LayerID]*types.Block{
+		gPlus1: blocks1[0],
+		gPlus2: blocks2[0],
+		gPlus3: blocks3[0],
+		gPlus4: blocks4[0],
+		gPlus5: blocks5[0],
+	}
 
-	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gPlus1).Return(gLyr, gLyr, false).Times(1)
-	require.NoError(t, tm.ProcessLayerPerHareOutput(context.TODO(), gPlus1, blocks1[0].ID()))
-	hareOutput, err := tm.GetHareConsensusOutput(gPlus1)
-	require.NoError(t, err)
-	assert.Equal(t, blocks1[0].ID(), hareOutput)
-	assert.Equal(t, gPlus1, tm.ProcessedLayer())
-
-	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gPlus2).Return(gLyr, gPlus1, false).Times(1)
-	tm.mockState.EXPECT().ApplyLayer(gPlus1, gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
-	tm.mockState.EXPECT().GetStateRoot().Return(types.Hash32{}).Times(1)
-	tm.mockState.EXPECT().ReinsertTxsToMemPool(gomock.Any()).Return(nil).Times(1)
-	require.NoError(t, tm.ProcessLayerPerHareOutput(context.TODO(), gPlus2, blocks2[0].ID()))
-	hareOutput, err = tm.GetHareConsensusOutput(gPlus2)
-	require.NoError(t, err)
-	assert.Equal(t, blocks2[0].ID(), hareOutput)
-	assert.Equal(t, gPlus2, tm.ProcessedLayer())
-
-	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gPlus3).Return(gPlus1, gPlus2, false).Times(1)
-	tm.mockState.EXPECT().ApplyLayer(gPlus2, gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
-	tm.mockState.EXPECT().GetStateRoot().Return(types.Hash32{}).Times(1)
-	tm.mockState.EXPECT().ReinsertTxsToMemPool(gomock.Any()).Return(nil).Times(1)
-	require.NoError(t, tm.ProcessLayerPerHareOutput(context.TODO(), gPlus3, blocks3[0].ID()))
-	hareOutput, err = tm.GetHareConsensusOutput(gPlus3)
-	require.NoError(t, err)
-	assert.Equal(t, blocks3[0].ID(), hareOutput)
-	assert.Equal(t, gPlus3, tm.ProcessedLayer())
-
-	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gPlus4).Return(gPlus2, gPlus3, false).Times(1)
-	tm.mockState.EXPECT().ApplyLayer(gPlus3, gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
-	tm.mockState.EXPECT().GetStateRoot().Return(types.Hash32{}).Times(1)
-	tm.mockState.EXPECT().ReinsertTxsToMemPool(gomock.Any()).Return(nil).Times(1)
-	require.NoError(t, tm.ProcessLayerPerHareOutput(context.TODO(), gPlus4, blocks4[0].ID()))
-	hareOutput, err = tm.GetHareConsensusOutput(gPlus4)
-	require.NoError(t, err)
-	assert.Equal(t, blocks4[0].ID(), hareOutput)
-	assert.Equal(t, gPlus4, tm.ProcessedLayer())
-
-	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gPlus5).Return(gPlus3, gPlus4, false).Times(1)
-	tm.mockState.EXPECT().ApplyLayer(gPlus4, gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
-	tm.mockState.EXPECT().GetStateRoot().Return(types.Hash32{}).Times(1)
-	tm.mockState.EXPECT().ReinsertTxsToMemPool(gomock.Any()).Return(nil).Times(1)
-	require.NoError(t, tm.ProcessLayerPerHareOutput(context.TODO(), gPlus5, blocks5[0].ID()))
-	hareOutput, err = tm.GetHareConsensusOutput(gPlus5)
-	require.NoError(t, err)
-	assert.Equal(t, blocks5[0].ID(), hareOutput)
-	assert.Equal(t, gPlus5, tm.ProcessedLayer())
+	for i := gPlus1; !i.After(gPlus5); i = i.Add(1) {
+		hareOutput := layerBlocks[i]
+		tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), i).Return(minLayer(gLyr, i.Sub(2)), i.Sub(1), false).Times(1)
+		tm.mockState.EXPECT().ApplyLayer(i, hareOutput.ID(), hareOutput.TxIDs, gomock.Any()).Return(nil, nil).Times(1)
+		tm.mockState.EXPECT().GetStateRoot().Return(types.Hash32{}).Times(1)
+		tm.mockState.EXPECT().ReinsertTxsToMemPool(gomock.Any()).Return(nil).Times(1)
+		require.NoError(t, tm.ProcessLayerPerHareOutput(context.TODO(), i, hareOutput.ID()))
+		got, err := tm.GetHareConsensusOutput(i)
+		require.NoError(t, err)
+		assert.Equal(t, hareOutput.ID(), got)
+		assert.Equal(t, i, tm.ProcessedLayer())
+	}
 }
 
 func TestMesh_ProcessLayerPerHareOutput_OutOfOrder(t *testing.T) {
@@ -280,47 +207,66 @@ func TestMesh_ProcessLayerPerHareOutput_OutOfOrder(t *testing.T) {
 	// process order is  : gPlus1, gPlus3, gPlus5, gPlus2, gPlus4
 	// processed layer is: gPlus1, gPlus1, gPlus1, gPlus3, gPlus5
 	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gPlus1).Return(gLyr, gLyr, false).Times(1)
+	tm.mockState.EXPECT().ApplyLayer(gPlus1, blocks1[0].ID(), blocks1[0].TxIDs, gomock.Any()).Return(nil, nil).Times(1)
+	tm.mockState.EXPECT().GetStateRoot().Return(types.Hash32{}).Times(1)
+	tm.mockState.EXPECT().ReinsertTxsToMemPool(gomock.Any()).Return(nil).Times(1)
 	require.NoError(t, tm.ProcessLayerPerHareOutput(context.TODO(), gPlus1, blocks1[0].ID()))
-	hareOutput, err := tm.GetHareConsensusOutput(gPlus1)
+	got, err := tm.GetHareConsensusOutput(gPlus1)
 	require.NoError(t, err)
-	assert.Equal(t, blocks1[0].ID(), hareOutput)
+	assert.Equal(t, blocks1[0].ID(), got)
 	assert.Equal(t, gPlus1, tm.ProcessedLayer())
+	assert.Equal(t, gPlus1, tm.LatestLayerInState())
 
 	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gPlus3).Return(gLyr, gLyr, false).Times(1)
-	require.NoError(t, tm.ProcessLayerPerHareOutput(context.TODO(), gPlus3, blocks3[0].ID()))
-	hareOutput, err = tm.GetHareConsensusOutput(gPlus3)
+	// will try to apply state for gPlus2
+	err = tm.ProcessLayerPerHareOutput(context.TODO(), gPlus3, blocks3[0].ID())
+	assert.ErrorIs(t, err, errMissingHareOutput)
+	got, err = tm.GetHareConsensusOutput(gPlus3)
 	require.NoError(t, err)
-	assert.Equal(t, blocks3[0].ID(), hareOutput)
+	assert.Equal(t, blocks3[0].ID(), got)
 	assert.Equal(t, gPlus1, tm.ProcessedLayer())
+	assert.Equal(t, gPlus1, tm.LatestLayerInState())
 
 	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gPlus5).Return(gLyr, gLyr, false).Times(1)
-	require.NoError(t, tm.ProcessLayerPerHareOutput(context.TODO(), gPlus5, blocks5[0].ID()))
-	hareOutput, err = tm.GetHareConsensusOutput(gPlus5)
+	// will try to apply state for gPlus2
+	err = tm.ProcessLayerPerHareOutput(context.TODO(), gPlus5, blocks5[0].ID())
+	assert.ErrorIs(t, err, errMissingHareOutput)
+	got, err = tm.GetHareConsensusOutput(gPlus5)
 	require.NoError(t, err)
-	assert.Equal(t, blocks5[0].ID(), hareOutput)
+	assert.Equal(t, blocks5[0].ID(), got)
 	assert.Equal(t, gPlus1, tm.ProcessedLayer())
+	assert.Equal(t, gPlus1, tm.LatestLayerInState())
 
 	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gPlus2).Return(gLyr, gPlus2, false).Times(1)
-	tm.mockState.EXPECT().ApplyLayer(gPlus1, gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
-	tm.mockState.EXPECT().ApplyLayer(gPlus2, gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
+	// will try to apply state for gPlus2, gPlus3 and gPlus4
+	// since gPlus2 has been verified, we will apply the lowest order of contextually valid blocks
+	gPlus2Block := types.SortBlocks(blocks2)[0]
+	tm.mockState.EXPECT().ApplyLayer(gPlus2, gPlus2Block.ID(), gPlus2Block.TxIDs, gomock.Any()).Return(nil, nil).Times(1)
+	tm.mockState.EXPECT().ApplyLayer(gPlus3, blocks3[0].ID(), blocks3[0].TxIDs, gomock.Any()).Return(nil, nil).Times(1)
 	tm.mockState.EXPECT().GetStateRoot().Return(types.Hash32{}).Times(2)
 	tm.mockState.EXPECT().ReinsertTxsToMemPool(gomock.Any()).Return(nil).Times(2)
-	require.NoError(t, tm.ProcessLayerPerHareOutput(context.TODO(), gPlus2, blocks2[0].ID()))
-	hareOutput, err = tm.GetHareConsensusOutput(gPlus2)
+	err = tm.ProcessLayerPerHareOutput(context.TODO(), gPlus2, blocks2[0].ID())
+	assert.ErrorIs(t, err, errMissingHareOutput)
+	got, err = tm.GetHareConsensusOutput(gPlus2)
 	require.NoError(t, err)
-	assert.Equal(t, blocks2[0].ID(), hareOutput)
+	assert.Equal(t, blocks2[0].ID(), got)
 	assert.Equal(t, gPlus3, tm.ProcessedLayer())
+	assert.Equal(t, gPlus3, tm.LatestLayerInState())
 
 	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gPlus4).Return(gPlus2, gPlus4, false).Times(1)
-	tm.mockState.EXPECT().ApplyLayer(gPlus3, gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
-	tm.mockState.EXPECT().ApplyLayer(gPlus4, gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
+	// will try to apply state for gPlus4 and gPlus5
+	// since gPlus4 has been verified, we will apply the lowest order of contextually valid blocks
+	gPlus4Block := types.SortBlocks(blocks4)[0]
+	tm.mockState.EXPECT().ApplyLayer(gPlus4, gPlus4Block.ID(), gPlus4Block.TxIDs, gomock.Any()).Return(nil, nil).Times(1)
+	tm.mockState.EXPECT().ApplyLayer(gPlus5, blocks5[0].ID(), blocks5[0].TxIDs, gomock.Any()).Return(nil, nil).Times(1)
 	tm.mockState.EXPECT().GetStateRoot().Return(types.Hash32{}).Times(2)
 	tm.mockState.EXPECT().ReinsertTxsToMemPool(gomock.Any()).Return(nil).Times(2)
 	require.NoError(t, tm.ProcessLayerPerHareOutput(context.TODO(), gPlus4, blocks4[0].ID()))
-	hareOutput, err = tm.GetHareConsensusOutput(gPlus4)
+	got, err = tm.GetHareConsensusOutput(gPlus4)
 	require.NoError(t, err)
-	assert.Equal(t, blocks4[0].ID(), hareOutput)
+	assert.Equal(t, blocks4[0].ID(), got)
 	assert.Equal(t, gPlus5, tm.ProcessedLayer())
+	assert.Equal(t, gPlus5, tm.LatestLayerInState())
 }
 
 func TestMesh_ProcessLayerPerHareOutput_emptyOutput(t *testing.T) {
@@ -331,6 +277,9 @@ func TestMesh_ProcessLayerPerHareOutput_emptyOutput(t *testing.T) {
 	gPlus1 := gLyr.Add(1)
 	_, blocks1 := createLayerBallotsAndBlocks(t, tm.Mesh, gPlus1)
 	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gPlus1).Return(gLyr, gLyr, false).Times(1)
+	tm.mockState.EXPECT().ApplyLayer(gPlus1, blocks1[0].ID(), blocks1[0].TxIDs, gomock.Any()).Return(nil, nil).Times(1)
+	tm.mockState.EXPECT().GetStateRoot().Return(types.Hash32{}).Times(1)
+	tm.mockState.EXPECT().ReinsertTxsToMemPool(gomock.Any()).Return(nil).Times(1)
 	require.NoError(t, tm.ProcessLayerPerHareOutput(context.TODO(), gPlus1, blocks1[0].ID()))
 	hareOutput, err := tm.GetHareConsensusOutput(gPlus1)
 	require.NoError(t, err)
@@ -340,7 +289,6 @@ func TestMesh_ProcessLayerPerHareOutput_emptyOutput(t *testing.T) {
 	gPlus2 := gLyr.Add(2)
 	createLayerBallotsAndBlocks(t, tm.Mesh, gPlus2)
 	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gPlus2).Return(gLyr, gPlus1, false).Times(1)
-	tm.mockState.EXPECT().ApplyLayer(gPlus1, gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
 	tm.mockState.EXPECT().GetStateRoot().Return(types.Hash32{}).Times(1)
 	tm.mockState.EXPECT().ReinsertTxsToMemPool(gomock.Any()).Return(nil).Times(1)
 	require.NoError(t, tm.ProcessLayerPerHareOutput(context.TODO(), gPlus2, types.EmptyBlockID))
@@ -352,6 +300,7 @@ func TestMesh_ProcessLayerPerHareOutput_emptyOutput(t *testing.T) {
 
 	// but processed layer has advanced
 	assert.Equal(t, gPlus2, tm.ProcessedLayer())
+	assert.Equal(t, gPlus2, tm.LatestLayerInState())
 }
 
 func TestMesh_PersistProcessedLayer(t *testing.T) {
@@ -409,7 +358,7 @@ func TestMesh_WakeUp(t *testing.T) {
 	}
 }
 
-func TestMesh_pushLayersToState(t *testing.T) {
+func TestMesh_pushLayersToState_verified(t *testing.T) {
 	tm := createTestMesh(t)
 	defer tm.Close()
 
@@ -424,16 +373,19 @@ func TestMesh_pushLayersToState(t *testing.T) {
 		pendingTXs[id] = struct{}{}
 	}
 	// either block1 or block2 will be applied to the state
-	tm.mockState.EXPECT().StoreTransactionsFromMemPool(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+	tm.mockState.EXPECT().StoreTransactionsFromMemPool(gomock.Any(), gomock.Any(), gomock.Any()).Times(4)
 	block1 := addBlockWithTXsToMesh(t, tm.Mesh, layerID, true, txIDs[:1])
 	block2 := addBlockWithTXsToMesh(t, tm.Mesh, layerID, true, txIDs[1:4])
-	addBlockWithTXsToMesh(t, tm.Mesh, layerID, false, txIDs[3:])
+	block3 := addBlockWithTXsToMesh(t, tm.Mesh, layerID, false, txIDs[3:])
 	addBlockWithTXsToMesh(t, tm.Mesh, layerID, false, txIDs[4:])
+
+	// set block3 to be hare output
+	require.NoError(t, tm.SaveHareConsensusOutput(context.TODO(), layerID, block3.ID()))
 
 	valids := []*types.Block{block1, block2}
 	types.SortBlocks(valids)
-	hareOutput := valids[0]
-	for _, txID := range hareOutput.TxIDs {
+	toApply := valids[0]
+	for _, txID := range toApply.TxIDs {
 		delete(pendingTXs, txID)
 	}
 	var reinsert []types.TransactionID
@@ -442,6 +394,44 @@ func TestMesh_pushLayersToState(t *testing.T) {
 			reinsert = append(reinsert, id)
 		}
 	}
+
+	tm.mockState.EXPECT().ApplyLayer(layerID, toApply.ID(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ types.LayerID, _ types.BlockID, ids []types.TransactionID, _ map[types.Address]uint64) ([]*types.Transaction, error) {
+			assert.ElementsMatch(t, toApply.TxIDs, ids)
+			return nil, nil
+		}).Times(1)
+	tm.mockState.EXPECT().GetStateRoot().Return(types.Hash32{}).Times(1)
+	tm.mockState.EXPECT().ReinsertTxsToMemPool(gomock.Any()).Do(
+		func(got []types.TransactionID) error {
+			assert.ElementsMatch(t, got, reinsert)
+			return nil
+		}).Times(1)
+	require.NoError(t, tm.pushLayersToState(context.TODO(), layerID, layerID, layerID))
+}
+
+func TestMesh_pushLayersToState_notVerified(t *testing.T) {
+	tm := createTestMesh(t)
+	defer tm.Close()
+
+	tm.mockTortoise.EXPECT().OnBlock(gomock.Any()).AnyTimes()
+	tm.mockTortoise.EXPECT().OnBallot(gomock.Any()).AnyTimes()
+	layerID := types.GetEffectiveGenesis().Add(1)
+	createLayerBallots(t, tm.Mesh, layerID)
+
+	txIDs := types.RandomTXSet(5)
+	pendingTXs := map[types.TransactionID]struct{}{}
+	for _, id := range txIDs {
+		pendingTXs[id] = struct{}{}
+	}
+	// either block1 or block2 will be applied to the state
+	tm.mockState.EXPECT().StoreTransactionsFromMemPool(gomock.Any(), gomock.Any(), gomock.Any()).Times(4)
+	addBlockWithTXsToMesh(t, tm.Mesh, layerID, true, txIDs[:1])
+	addBlockWithTXsToMesh(t, tm.Mesh, layerID, true, txIDs[1:4])
+	addBlockWithTXsToMesh(t, tm.Mesh, layerID, true, txIDs[3:])
+	hareOutput := addBlockWithTXsToMesh(t, tm.Mesh, layerID, true, txIDs[4:])
+	reinsert := txIDs[:4]
+
+	require.NoError(t, tm.SaveHareConsensusOutput(context.TODO(), layerID, hareOutput.ID()))
 
 	tm.mockState.EXPECT().ApplyLayer(layerID, hareOutput.ID(), gomock.Any(), gomock.Any()).DoAndReturn(
 		func(_ types.LayerID, _ types.BlockID, ids []types.TransactionID, _ map[types.Address]uint64) ([]*types.Transaction, error) {
@@ -454,12 +444,11 @@ func TestMesh_pushLayersToState(t *testing.T) {
 			assert.ElementsMatch(t, got, reinsert)
 			return nil
 		}).Times(1)
-	require.NoError(t, tm.pushLayersToState(context.TODO(), types.GetEffectiveGenesis().Add(1), types.GetEffectiveGenesis().Add(1)))
+	require.NoError(t, tm.pushLayersToState(context.TODO(), layerID, layerID, layerID.Sub(1)))
 }
 
 func TestMesh_persistLayerHash(t *testing.T) {
 	tm := createTestMesh(t)
-	defer tm.ctrl.Finish()
 	defer tm.Close()
 
 	// persist once
@@ -486,7 +475,6 @@ func addBlockWithTXsToMesh(t *testing.T, msh *Mesh, id types.LayerID, valid bool
 func TestMesh_AddTXsFromProposal(t *testing.T) {
 	r := require.New(t)
 	tm := createTestMesh(t)
-	defer tm.ctrl.Finish()
 	defer tm.Close()
 
 	txIDs := types.RandomTXSet(numTXs)
@@ -513,7 +501,6 @@ func TestMesh_AddBlockWithTXs(t *testing.T) {
 
 func TestMesh_ReverifyFailed(t *testing.T) {
 	tm := createTestMesh(t)
-	defer tm.ctrl.Finish()
 	defer tm.Close()
 
 	ctx := context.TODO()
@@ -521,55 +508,50 @@ func TestMesh_ReverifyFailed(t *testing.T) {
 	last := genesis.Add(10)
 
 	for lid := genesis.Add(1); !lid.After(last); lid = lid.Add(1) {
-		tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gomock.Any()).
+		tm.SaveHareConsensusOutput(ctx, lid, types.EmptyBlockID)
+		tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), lid).
 			Return(maxLayer(lid.Sub(2), genesis), lid.Sub(1), false)
-		if lid.Sub(1).After(genesis) {
-			tm.mockState.EXPECT().GetStateRoot()
-		}
+		tm.mockState.EXPECT().GetStateRoot()
 		tm.ProcessLayer(ctx, lid)
 	}
 
 	require.Equal(t, last, tm.ProcessedLayer())
-	require.Equal(t, last.Sub(1), tm.LatestLayerInState())
+	require.Equal(t, last, tm.LatestLayerInState())
 
 	last = last.Add(1)
-	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gomock.Any()).
-		Return(last.Sub(1), last, false)
+	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), last).
+		Return(last.Sub(2), last.Sub(1), false)
 
 	block := types.Block{}
 	block.LayerIndex = last
 	block.TxIDs = []types.TransactionID{{1, 1, 1}}
 	require.NoError(t, tm.AddBlock(&block))
-	require.NoError(t, tm.SaveContextualValidity(block.ID(), last, true))
+	require.NoError(t, tm.SaveHareConsensusOutput(ctx, last, block.ID()))
 	errTXMissing := errors.New("tx missing")
 	tm.mockState.EXPECT().ApplyLayer(block.LayerIndex, block.ID(), block.TxIDs, gomock.Any()).Return(nil, errTXMissing)
-	tm.mockState.EXPECT().ReinsertTxsToMemPool(gomock.Any())
-	tm.mockState.EXPECT().GetStateRoot()
 	require.Error(t, tm.ProcessLayer(ctx, last))
 	require.Equal(t, last, tm.ProcessedLayer())
 	require.Equal(t, last, tm.MissingLayer())
 	require.Equal(t, last.Sub(1), tm.LatestLayerInState())
 
 	last = last.Add(1)
+	require.NoError(t, tm.SaveContextualValidity(block.ID(), last.Sub(1), true))
+	tm.mockState.EXPECT().ApplyLayer(last.Sub(1), block.ID(), block.TxIDs, gomock.Any()).Return(nil, nil)
+	require.NoError(t, tm.SaveHareConsensusOutput(ctx, last, types.EmptyBlockID))
 	for lid := last.Sub(1); !lid.After(last); lid = lid.Add(1) {
-		require.NoError(t, tm.SaveContextualValidity(block.ID(), last, false))
 		tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gomock.Any()).
 			Return(lid.Sub(1), last.Sub(1), false)
-	}
-
-	tm.mockState.EXPECT().GetStateRoot()
-	for lid := last.Sub(1); !lid.After(last); lid = lid.Add(1) {
+		tm.mockState.EXPECT().GetStateRoot()
 		tm.ProcessLayer(ctx, lid)
 	}
 
 	require.Empty(t, tm.MissingLayer())
 	require.Equal(t, last, tm.ProcessedLayer())
-	require.Equal(t, last.Sub(1), tm.LatestLayerInState())
+	require.Equal(t, last, tm.LatestLayerInState())
 }
 
 func TestMesh_MissingTransactionsFailure(t *testing.T) {
 	tm := createTestMesh(t)
-	defer tm.ctrl.Finish()
 	defer tm.Close()
 
 	ctx := context.TODO()
@@ -594,7 +576,6 @@ func TestMesh_MissingTransactionsFailure(t *testing.T) {
 
 func TestMesh_ResetAppliedOnRevert(t *testing.T) {
 	tm := createTestMesh(t)
-	defer tm.ctrl.Finish()
 	defer tm.Close()
 
 	ctx := context.TODO()
@@ -602,10 +583,10 @@ func TestMesh_ResetAppliedOnRevert(t *testing.T) {
 	last := genesis.Add(10)
 
 	for lid := genesis.Add(1); lid.Before(last); lid = lid.Add(1) {
-		tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gomock.Any()).
-			Return(lid.Sub(1), lid, false)
-		tm.mockState.EXPECT().GetStateRoot()
 		tm.SetZeroBlockLayer(lid)
+		tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gomock.Any()).
+			Return(maxLayer(lid.Sub(1), genesis), lid.Sub(1), false)
+		tm.mockState.EXPECT().GetStateRoot()
 		require.NoError(t, tm.ProcessLayer(ctx, lid))
 	}
 
@@ -614,7 +595,7 @@ func TestMesh_ResetAppliedOnRevert(t *testing.T) {
 
 	failed := genesis.Add(2)
 	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gomock.Any()).
-		Return(failed.Sub(1), last, true)
+		Return(failed.Sub(1), last.Sub(1), true)
 	tm.mockState.EXPECT().Rewind(failed.Sub(1))
 
 	block := types.Block{}
@@ -632,7 +613,6 @@ func TestMesh_ResetAppliedOnRevert(t *testing.T) {
 
 func TestMesh_NoPanicOnIncorrectVerified(t *testing.T) {
 	tm := createTestMesh(t)
-	defer tm.ctrl.Finish()
 	defer tm.Close()
 
 	ctx := context.TODO()
@@ -640,20 +620,22 @@ func TestMesh_NoPanicOnIncorrectVerified(t *testing.T) {
 	const n = 10
 	last := genesis.Add(n)
 
-	tm.mockState.EXPECT().GetStateRoot().Times(n - 1)
 	for lid := genesis.Add(1); !lid.After(last); lid = lid.Add(1) {
-		tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gomock.Any()).
+		tm.SaveHareConsensusOutput(ctx, lid, types.EmptyBlockID)
+		tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), lid).
 			Return(maxLayer(lid.Sub(2), genesis), lid.Sub(1), false)
+		tm.mockState.EXPECT().GetStateRoot()
 		tm.ProcessLayer(ctx, lid)
 	}
-	require.Equal(t, last.Sub(1), tm.LatestLayerInState())
+	require.Equal(t, last, tm.LatestLayerInState())
 
+	tm.SaveHareConsensusOutput(ctx, last.Add(1), types.EmptyBlockID)
 	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gomock.Any()).
 		Return(tm.LatestLayerInState().Sub(2), tm.LatestLayerInState().Sub(1), false)
+	tm.mockState.EXPECT().GetStateRoot()
 	tm.ProcessLayer(ctx, last.Add(1))
-	require.Equal(t, last.Sub(1), tm.LatestLayerInState())
+	require.Equal(t, last.Add(1), tm.LatestLayerInState())
 
-	tm.mockState.EXPECT().GetStateRoot().Times(2) // will apply two layers
 	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gomock.Any()).
 		Return(last, last.Add(1), false)
 	tm.ProcessLayer(ctx, last.Add(2))
@@ -662,7 +644,6 @@ func TestMesh_NoPanicOnIncorrectVerified(t *testing.T) {
 
 func TestMesh_CallOnBlock(t *testing.T) {
 	tm := createTestMesh(t)
-	defer tm.ctrl.Finish()
 	defer tm.Close()
 
 	block := types.Block{}
@@ -676,7 +657,6 @@ func TestMesh_CallOnBlock(t *testing.T) {
 
 func TestMesh_CallOnBallot(t *testing.T) {
 	tm := createTestMesh(t)
-	defer tm.ctrl.Finish()
 	defer tm.Close()
 
 	ballot := types.RandomBallot()

--- a/mesh/mesh_test.go
+++ b/mesh/mesh_test.go
@@ -43,7 +43,7 @@ func createTestMesh(t *testing.T) *testMesh {
 	return tm
 }
 
-func createBlock(t testing.TB, mesh *Mesh, layerID types.LayerID, nodeID types.NodeID) *types.Block {
+func createBlock(t testing.TB, mesh *Mesh, layerID types.LayerID, nodeID types.NodeID, valid bool) *types.Block {
 	t.Helper()
 	coinbase := types.HexToAddress(nodeID.Key)
 	txIDs := types.RandomTXSet(numTXs)
@@ -63,21 +63,21 @@ func createBlock(t testing.TB, mesh *Mesh, layerID types.LayerID, nodeID types.N
 	}
 	b.Initialize()
 	require.NoError(t, mesh.AddBlock(b))
-	require.NoError(t, mesh.SaveContextualValidity(b.ID(), layerID, true))
+	require.NoError(t, mesh.SaveContextualValidity(b.ID(), layerID, valid))
 	return b
 }
 
 func createLayerBallotsAndBlocks(t *testing.T, mesh *Mesh, lyrID types.LayerID) ([]*types.Ballot, []*types.Block) {
 	t.Helper()
-	return createLayerBallots(t, mesh, lyrID), createLayerBlocks(t, mesh, lyrID)
+	return createLayerBallots(t, mesh, lyrID), createLayerBlocks(t, mesh, lyrID, true)
 }
 
-func createLayerBlocks(t *testing.T, mesh *Mesh, lyrID types.LayerID) []*types.Block {
+func createLayerBlocks(t *testing.T, mesh *Mesh, lyrID types.LayerID, valid bool) []*types.Block {
 	t.Helper()
 	blocks := make([]*types.Block, 0, numBlocks)
 	for i := 0; i < numBlocks; i++ {
 		nodeID := types.NodeID{Key: strconv.Itoa(i), VRFPublicKey: []byte("bbbbb")}
-		blk := createBlock(t, mesh, lyrID, nodeID)
+		blk := createBlock(t, mesh, lyrID, nodeID, valid)
 		blocks = append(blocks, blk)
 	}
 	return blocks
@@ -114,7 +114,7 @@ func TestMesh_LayerHashes(t *testing.T) {
 		thisLyr, err := tm.GetLayer(i)
 		require.NoError(t, err)
 
-		tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), i).Return(minLayer(gLyr, i.Sub(2)), i.Sub(1), false).Times(1)
+		tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), i).Return(i.Sub(1)).Times(1)
 		blk := lyrBlocks[i]
 		tm.mockState.EXPECT().ApplyLayer(i, blk.ID(), blk.TxIDs, gomock.Any()).Return(nil, nil).Times(1)
 		tm.mockState.EXPECT().GetStateRoot().Return(types.Hash32{})
@@ -141,7 +141,7 @@ func TestMesh_GetLayer(t *testing.T) {
 	assert.Empty(t, lyr.Blocks())
 	assert.Empty(t, lyr.Ballots())
 
-	blocks := createLayerBlocks(t, tm.Mesh, id)
+	blocks := createLayerBlocks(t, tm.Mesh, id, true)
 	ballots := createLayerBallots(t, tm.Mesh, id)
 	lyr, err = tm.GetLayer(id)
 	require.NoError(t, err)
@@ -176,7 +176,7 @@ func TestMesh_ProcessLayerPerHareOutput(t *testing.T) {
 
 	for i := gPlus1; !i.After(gPlus5); i = i.Add(1) {
 		hareOutput := layerBlocks[i]
-		tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), i).Return(minLayer(gLyr, i.Sub(2)), i.Sub(1), false).Times(1)
+		tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), i).Return(i.Sub(1)).Times(1)
 		tm.mockState.EXPECT().ApplyLayer(i, hareOutput.ID(), hareOutput.TxIDs, gomock.Any()).Return(nil, nil).Times(1)
 		tm.mockState.EXPECT().GetStateRoot().Return(types.Hash32{}).Times(1)
 		tm.mockState.EXPECT().ReinsertTxsToMemPool(gomock.Any()).Return(nil).Times(1)
@@ -206,7 +206,7 @@ func TestMesh_ProcessLayerPerHareOutput_OutOfOrder(t *testing.T) {
 
 	// process order is  : gPlus1, gPlus3, gPlus5, gPlus2, gPlus4
 	// processed layer is: gPlus1, gPlus1, gPlus1, gPlus3, gPlus5
-	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gPlus1).Return(gLyr, gLyr, false).Times(1)
+	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gPlus1).Return(gLyr).Times(1)
 	tm.mockState.EXPECT().ApplyLayer(gPlus1, blocks1[0].ID(), blocks1[0].TxIDs, gomock.Any()).Return(nil, nil).Times(1)
 	tm.mockState.EXPECT().GetStateRoot().Return(types.Hash32{}).Times(1)
 	tm.mockState.EXPECT().ReinsertTxsToMemPool(gomock.Any()).Return(nil).Times(1)
@@ -217,7 +217,7 @@ func TestMesh_ProcessLayerPerHareOutput_OutOfOrder(t *testing.T) {
 	assert.Equal(t, gPlus1, tm.ProcessedLayer())
 	assert.Equal(t, gPlus1, tm.LatestLayerInState())
 
-	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gPlus3).Return(gLyr, gLyr, false).Times(1)
+	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gPlus3).Return(gLyr).Times(1)
 	// will try to apply state for gPlus2
 	err = tm.ProcessLayerPerHareOutput(context.TODO(), gPlus3, blocks3[0].ID())
 	assert.ErrorIs(t, err, errMissingHareOutput)
@@ -227,7 +227,7 @@ func TestMesh_ProcessLayerPerHareOutput_OutOfOrder(t *testing.T) {
 	assert.Equal(t, gPlus1, tm.ProcessedLayer())
 	assert.Equal(t, gPlus1, tm.LatestLayerInState())
 
-	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gPlus5).Return(gLyr, gLyr, false).Times(1)
+	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gPlus5).Return(gLyr).Times(1)
 	// will try to apply state for gPlus2
 	err = tm.ProcessLayerPerHareOutput(context.TODO(), gPlus5, blocks5[0].ID())
 	assert.ErrorIs(t, err, errMissingHareOutput)
@@ -237,7 +237,7 @@ func TestMesh_ProcessLayerPerHareOutput_OutOfOrder(t *testing.T) {
 	assert.Equal(t, gPlus1, tm.ProcessedLayer())
 	assert.Equal(t, gPlus1, tm.LatestLayerInState())
 
-	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gPlus2).Return(gLyr, gPlus2, false).Times(1)
+	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gPlus2).Return(gPlus2).Times(1)
 	// will try to apply state for gPlus2, gPlus3 and gPlus4
 	// since gPlus2 has been verified, we will apply the lowest order of contextually valid blocks
 	gPlus2Block := types.SortBlocks(blocks2)[0]
@@ -253,7 +253,7 @@ func TestMesh_ProcessLayerPerHareOutput_OutOfOrder(t *testing.T) {
 	assert.Equal(t, gPlus3, tm.ProcessedLayer())
 	assert.Equal(t, gPlus3, tm.LatestLayerInState())
 
-	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gPlus4).Return(gPlus2, gPlus4, false).Times(1)
+	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gPlus4).Return(gPlus4).Times(1)
 	// will try to apply state for gPlus4 and gPlus5
 	// since gPlus4 has been verified, we will apply the lowest order of contextually valid blocks
 	gPlus4Block := types.SortBlocks(blocks4)[0]
@@ -276,7 +276,7 @@ func TestMesh_ProcessLayerPerHareOutput_emptyOutput(t *testing.T) {
 	gLyr := types.GetEffectiveGenesis()
 	gPlus1 := gLyr.Add(1)
 	_, blocks1 := createLayerBallotsAndBlocks(t, tm.Mesh, gPlus1)
-	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gPlus1).Return(gLyr, gLyr, false).Times(1)
+	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gPlus1).Return(gLyr).Times(1)
 	tm.mockState.EXPECT().ApplyLayer(gPlus1, blocks1[0].ID(), blocks1[0].TxIDs, gomock.Any()).Return(nil, nil).Times(1)
 	tm.mockState.EXPECT().GetStateRoot().Return(types.Hash32{}).Times(1)
 	tm.mockState.EXPECT().ReinsertTxsToMemPool(gomock.Any()).Return(nil).Times(1)
@@ -288,7 +288,7 @@ func TestMesh_ProcessLayerPerHareOutput_emptyOutput(t *testing.T) {
 
 	gPlus2 := gLyr.Add(2)
 	createLayerBallotsAndBlocks(t, tm.Mesh, gPlus2)
-	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gPlus2).Return(gLyr, gPlus1, false).Times(1)
+	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gPlus2).Return(gPlus1).Times(1)
 	tm.mockState.EXPECT().GetStateRoot().Return(types.Hash32{}).Times(1)
 	tm.mockState.EXPECT().ReinsertTxsToMemPool(gomock.Any()).Return(nil).Times(1)
 	require.NoError(t, tm.ProcessLayerPerHareOutput(context.TODO(), gPlus2, types.EmptyBlockID))
@@ -301,6 +301,75 @@ func TestMesh_ProcessLayerPerHareOutput_emptyOutput(t *testing.T) {
 	// but processed layer has advanced
 	assert.Equal(t, gPlus2, tm.ProcessedLayer())
 	assert.Equal(t, gPlus2, tm.LatestLayerInState())
+}
+
+func TestMesh_Revert(t *testing.T) {
+	tm := createTestMesh(t)
+	defer tm.Close()
+
+	gLyr := types.GetEffectiveGenesis()
+	gPlus1 := gLyr.Add(1)
+	gPlus2 := gLyr.Add(2)
+	gPlus3 := gLyr.Add(3)
+	gPlus4 := gLyr.Add(4)
+	gPlus5 := gLyr.Add(5)
+	blocks1 := createLayerBlocks(t, tm.Mesh, gLyr.Add(1), false)
+	blocks2 := createLayerBlocks(t, tm.Mesh, gLyr.Add(2), false)
+	blocks3 := createLayerBlocks(t, tm.Mesh, gLyr.Add(3), false)
+	blocks4 := createLayerBlocks(t, tm.Mesh, gLyr.Add(4), false)
+	blocks5 := createLayerBlocks(t, tm.Mesh, gLyr.Add(5), false)
+	layerBlocks := map[types.LayerID]*types.Block{
+		gPlus1: blocks1[0],
+		gPlus2: blocks2[0],
+		gPlus3: blocks3[0],
+		gPlus4: blocks4[0],
+		gPlus5: blocks5[0],
+	}
+
+	for i := gPlus1; i.Before(gPlus4); i = i.Add(1) {
+		hareOutput := layerBlocks[i]
+		tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), i).Return(i.Sub(1)).Times(1)
+		tm.mockState.EXPECT().ApplyLayer(i, hareOutput.ID(), hareOutput.TxIDs, gomock.Any()).Return(nil, nil).Times(1)
+		tm.mockState.EXPECT().GetStateRoot().Return(types.Hash32{}).Times(1)
+		tm.mockState.EXPECT().ReinsertTxsToMemPool(gomock.Any()).Return(nil).Times(1)
+		require.NoError(t, tm.ProcessLayerPerHareOutput(context.TODO(), i, hareOutput.ID()))
+	}
+	require.Equal(t, gPlus3, tm.ProcessedLayer())
+	require.Equal(t, gPlus3, tm.LatestLayerInState())
+
+	oldHash := tm.GetAggregatedLayerHash(gPlus2)
+	require.NotEqual(t, types.EmptyLayerHash, oldHash)
+
+	// for layer gPlus2, the valid block turned out to be a different from the one applied
+	layerBlocks[gPlus2] = blocks2[1]
+	for lyr, blk := range layerBlocks {
+		tm.UpdateBlockValidity(blk.ID(), lyr, true)
+	}
+
+	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gPlus4).Return(gPlus3).Times(1)
+	tm.mockState.EXPECT().Rewind(gPlus1).Return(types.Hash32{}, nil)
+	for i := gPlus2; !i.After(gPlus4); i = i.Add(1) {
+		hareOutput := layerBlocks[i]
+		tm.mockState.EXPECT().ApplyLayer(i, hareOutput.ID(), hareOutput.TxIDs, gomock.Any()).Return(nil, nil).Times(1)
+		tm.mockState.EXPECT().GetStateRoot().Return(types.Hash32{}).Times(1)
+		tm.mockState.EXPECT().ReinsertTxsToMemPool(gomock.Any()).Return(nil).Times(1)
+	}
+	require.NoError(t, tm.ProcessLayerPerHareOutput(context.TODO(), gPlus4, blocks4[0].ID()))
+	require.Equal(t, gPlus4, tm.ProcessedLayer())
+	require.Equal(t, gPlus4, tm.LatestLayerInState())
+	newHash := tm.GetAggregatedLayerHash(gPlus2)
+	require.NotEqual(t, types.EmptyLayerHash, newHash)
+	require.NotEqual(t, oldHash, newHash)
+
+	// another new layer won't cause a revert
+	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gPlus5).Return(gPlus4).Times(1)
+	tm.mockState.EXPECT().ApplyLayer(gPlus5, blocks5[0].ID(), blocks5[0].TxIDs, gomock.Any()).Return(nil, nil).Times(1)
+	tm.mockState.EXPECT().GetStateRoot().Return(types.Hash32{}).Times(1)
+	tm.mockState.EXPECT().ReinsertTxsToMemPool(gomock.Any()).Return(nil).Times(1)
+	require.NoError(t, tm.ProcessLayerPerHareOutput(context.TODO(), gPlus5, blocks5[0].ID()))
+	require.Equal(t, gPlus5, tm.ProcessedLayer())
+	require.Equal(t, gPlus5, tm.LatestLayerInState())
+	require.Equal(t, newHash, tm.GetAggregatedLayerHash(gPlus2))
 }
 
 func TestMesh_PersistProcessedLayer(t *testing.T) {
@@ -508,19 +577,17 @@ func TestMesh_ReverifyFailed(t *testing.T) {
 	last := genesis.Add(10)
 
 	for lid := genesis.Add(1); !lid.After(last); lid = lid.Add(1) {
-		tm.SaveHareConsensusOutput(ctx, lid, types.EmptyBlockID)
-		tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), lid).
-			Return(maxLayer(lid.Sub(2), genesis), lid.Sub(1), false)
+		require.NoError(t, tm.SaveHareConsensusOutput(ctx, lid, types.EmptyBlockID))
+		tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), lid).Return(lid.Sub(1))
 		tm.mockState.EXPECT().GetStateRoot()
-		tm.ProcessLayer(ctx, lid)
+		require.NoError(t, tm.ProcessLayer(ctx, lid))
 	}
 
 	require.Equal(t, last, tm.ProcessedLayer())
 	require.Equal(t, last, tm.LatestLayerInState())
 
 	last = last.Add(1)
-	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), last).
-		Return(last.Sub(2), last.Sub(1), false)
+	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), last).Return(last.Sub(1))
 
 	block := types.Block{}
 	block.LayerIndex = last
@@ -539,10 +606,9 @@ func TestMesh_ReverifyFailed(t *testing.T) {
 	tm.mockState.EXPECT().ApplyLayer(last.Sub(1), block.ID(), block.TxIDs, gomock.Any()).Return(nil, nil)
 	require.NoError(t, tm.SaveHareConsensusOutput(ctx, last, types.EmptyBlockID))
 	for lid := last.Sub(1); !lid.After(last); lid = lid.Add(1) {
-		tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gomock.Any()).
-			Return(lid.Sub(1), last.Sub(1), false)
+		tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), lid).Return(last.Sub(1))
 		tm.mockState.EXPECT().GetStateRoot()
-		tm.ProcessLayer(ctx, lid)
+		require.NoError(t, tm.ProcessLayer(ctx, lid))
 	}
 
 	require.Empty(t, tm.MissingLayer())
@@ -562,53 +628,15 @@ func TestMesh_MissingTransactionsFailure(t *testing.T) {
 	block.LayerIndex = last
 	block.TxIDs = []types.TransactionID{{1, 1, 1}}
 	require.NoError(t, tm.AddBlock(&block))
-	require.NoError(t, tm.SaveContextualValidity(block.ID(), last, true))
+	require.NoError(t, tm.SaveHareConsensusOutput(ctx, last, block.ID()))
 
-	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gomock.Any()).
-		Return(genesis, last, false)
+	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), last).Return(last.Sub(1))
 	errTXMissing := errors.New("tx missing")
 	tm.mockState.EXPECT().ApplyLayer(block.LayerIndex, block.ID(), block.TxIDs, gomock.Any()).Return(nil, errTXMissing)
 	require.ErrorIs(t, tm.ProcessLayer(ctx, last), errTXMissing)
 
 	require.Equal(t, last, tm.ProcessedLayer())
 	require.Equal(t, genesis, tm.LatestLayerInState())
-}
-
-func TestMesh_ResetAppliedOnRevert(t *testing.T) {
-	tm := createTestMesh(t)
-	defer tm.Close()
-
-	ctx := context.TODO()
-	genesis := types.GetEffectiveGenesis()
-	last := genesis.Add(10)
-
-	for lid := genesis.Add(1); lid.Before(last); lid = lid.Add(1) {
-		tm.SetZeroBlockLayer(lid)
-		tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gomock.Any()).
-			Return(maxLayer(lid.Sub(1), genesis), lid.Sub(1), false)
-		tm.mockState.EXPECT().GetStateRoot()
-		require.NoError(t, tm.ProcessLayer(ctx, lid))
-	}
-
-	require.Equal(t, last.Sub(1), tm.ProcessedLayer())
-	require.Equal(t, last.Sub(1), tm.LatestLayerInState())
-
-	failed := genesis.Add(2)
-	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gomock.Any()).
-		Return(failed.Sub(1), last.Sub(1), true)
-	tm.mockState.EXPECT().Rewind(failed.Sub(1))
-
-	block := types.Block{}
-	block.LayerIndex = failed
-	block.TxIDs = []types.TransactionID{{1, 1, 1}}
-	require.NoError(t, tm.AddBlock(&block))
-	require.NoError(t, tm.SaveContextualValidity(block.ID(), failed, true))
-	errTXMissing := errors.New("tx missing")
-	tm.mockState.EXPECT().ApplyLayer(block.LayerIndex, block.ID(), block.TxIDs, gomock.Any()).Return(nil, errTXMissing)
-	require.ErrorIs(t, tm.ProcessLayer(ctx, last), errTXMissing)
-
-	require.Equal(t, last, tm.ProcessedLayer())
-	require.Equal(t, failed.Sub(1), tm.LatestLayerInState())
 }
 
 func TestMesh_NoPanicOnIncorrectVerified(t *testing.T) {
@@ -621,24 +649,21 @@ func TestMesh_NoPanicOnIncorrectVerified(t *testing.T) {
 	last := genesis.Add(n)
 
 	for lid := genesis.Add(1); !lid.After(last); lid = lid.Add(1) {
-		tm.SaveHareConsensusOutput(ctx, lid, types.EmptyBlockID)
-		tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), lid).
-			Return(maxLayer(lid.Sub(2), genesis), lid.Sub(1), false)
+		require.NoError(t, tm.SaveHareConsensusOutput(ctx, lid, types.EmptyBlockID))
+		tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), lid).Return(lid.Sub(1))
 		tm.mockState.EXPECT().GetStateRoot()
-		tm.ProcessLayer(ctx, lid)
+		require.NoError(t, tm.ProcessLayer(ctx, lid))
 	}
 	require.Equal(t, last, tm.LatestLayerInState())
 
-	tm.SaveHareConsensusOutput(ctx, last.Add(1), types.EmptyBlockID)
-	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gomock.Any()).
-		Return(tm.LatestLayerInState().Sub(2), tm.LatestLayerInState().Sub(1), false)
+	require.NoError(t, tm.SaveHareConsensusOutput(ctx, last.Add(1), types.EmptyBlockID))
+	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), last.Add(1)).Return(tm.LatestLayerInState().Sub(1))
 	tm.mockState.EXPECT().GetStateRoot()
-	tm.ProcessLayer(ctx, last.Add(1))
+	require.NoError(t, tm.ProcessLayer(ctx, last.Add(1)))
 	require.Equal(t, last.Add(1), tm.LatestLayerInState())
 
-	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gomock.Any()).
-		Return(last, last.Add(1), false)
-	tm.ProcessLayer(ctx, last.Add(2))
+	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), last.Add(2)).Return(last.Add(1))
+	require.ErrorIs(t, tm.ProcessLayer(ctx, last.Add(2)), errMissingHareOutput)
 	require.Equal(t, last.Add(1), tm.LatestLayerInState())
 }
 

--- a/mesh/meshdb.go
+++ b/mesh/meshdb.go
@@ -342,23 +342,6 @@ func (m *DB) GetRewardsBySmesherID(smesherID types.NodeID) ([]types.Reward, erro
 	return rewards.FilterBySmesher(m.db, smesherID.ToBytes())
 }
 
-// BlocksByValidity classifies a slice of blocks by validity.
-func (m *DB) BlocksByValidity(blocks []*types.Block) ([]*types.Block, []*types.Block) {
-	var validBlocks, invalidBlocks []*types.Block
-	for _, b := range blocks {
-		valid, err := m.ContextualValidity(b.ID())
-		if err != nil {
-			m.With().Warning("could not get contextual validity for block in list", b.ID(), log.Err(err))
-		}
-		if valid {
-			validBlocks = append(validBlocks, b)
-		} else {
-			invalidBlocks = append(invalidBlocks, b)
-		}
-	}
-	return validBlocks, invalidBlocks
-}
-
 // LayerContextuallyValidBlocks returns the set of contextually valid block IDs for the provided layer.
 func (m *DB) LayerContextuallyValidBlocks(ctx context.Context, layer types.LayerID) (map[types.BlockID]struct{}, error) {
 	logger := m.WithContext(ctx)

--- a/mesh/mocks/mocks.go
+++ b/mesh/mocks/mocks.go
@@ -131,13 +131,11 @@ func (m *Mocktortoise) EXPECT() *MocktortoiseMockRecorder {
 }
 
 // HandleIncomingLayer mocks base method.
-func (m *Mocktortoise) HandleIncomingLayer(arg0 context.Context, arg1 types.LayerID) (types.LayerID, types.LayerID, bool) {
+func (m *Mocktortoise) HandleIncomingLayer(arg0 context.Context, arg1 types.LayerID) types.LayerID {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HandleIncomingLayer", arg0, arg1)
 	ret0, _ := ret[0].(types.LayerID)
-	ret1, _ := ret[1].(types.LayerID)
-	ret2, _ := ret[2].(bool)
-	return ret0, ret1, ret2
+	return ret0
 }
 
 // HandleIncomingLayer indicates an expected call of HandleIncomingLayer.

--- a/sql/atxs/atxs.go
+++ b/sql/atxs/atxs.go
@@ -80,7 +80,7 @@ func GetLastIDByNodeID(db sql.Executor, nodeID types.NodeID) (id types.ATXID, er
 	if rows, err := db.Exec(`
 		select id from atxs 
 		where smesher = ?1
-		order by epoch desc 
+		order by epoch desc, timestamp desc
 		limit 1;`, enc, dec); err != nil {
 		return types.ATXID{}, fmt.Errorf("exec id %v: %w", id, err)
 	} else if rows == 0 {

--- a/sql/atxs/atxs_test.go
+++ b/sql/atxs/atxs_test.go
@@ -98,8 +98,11 @@ func TestGetLastIDByNodeID(t *testing.T) {
 	atx1 := newAtx(nodeID1, types.NewLayerID(uint32(1*layersPerEpoch)))
 	atx2 := newAtx(nodeID1, types.NewLayerID(uint32(2*layersPerEpoch)))
 	atx3 := newAtx(nodeID2, types.NewLayerID(uint32(3*layersPerEpoch)))
+	atx4 := newAtx(nodeID2, types.NewLayerID(uint32(3*layersPerEpoch)))
+	atx4.Sequence = atx3.Sequence + 1
+	atx4.CalcAndSetID()
 
-	for _, atx := range []*types.ActivationTx{atx1, atx2, atx3} {
+	for _, atx := range []*types.ActivationTx{atx1, atx2, atx3, atx4} {
 		require.NoError(t, Add(db, atx, time.Now()))
 	}
 
@@ -109,7 +112,7 @@ func TestGetLastIDByNodeID(t *testing.T) {
 
 	id2, err := GetLastIDByNodeID(db, nodeID2)
 	require.NoError(t, err)
-	require.EqualValues(t, atx3.ID(), id2)
+	require.EqualValues(t, atx4.ID(), id2)
 
 	_, err = GetLastIDByNodeID(db, nodeID0)
 	require.ErrorIs(t, err, database.ErrNotFound)

--- a/sql/layers/layers_test.go
+++ b/sql/layers/layers_test.go
@@ -33,6 +33,31 @@ func TestHareOutput(t *testing.T) {
 	require.Equal(t, expected, output)
 }
 
+func TestAppliedBlock(t *testing.T) {
+	db := sql.InMemory()
+	lid := types.NewLayerID(10)
+
+	_, err := GetApplied(db, lid)
+	require.ErrorIs(t, err, sql.ErrNotFound)
+
+	// cause layer to be inserted
+	require.NoError(t, SetHareOutput(db, lid, types.BlockID{}))
+
+	_, err = GetApplied(db, lid)
+	require.ErrorIs(t, err, sql.ErrNotFound)
+
+	require.NoError(t, SetApplied(db, lid, types.EmptyBlockID))
+	output, err := GetApplied(db, lid)
+	require.NoError(t, err)
+	require.Equal(t, types.EmptyBlockID, output)
+
+	expected := types.BlockID{1, 1, 1}
+	require.NoError(t, SetApplied(db, lid, expected))
+	output, err = GetApplied(db, lid)
+	require.NoError(t, err)
+	require.Equal(t, expected, output)
+}
+
 func TestStatus(t *testing.T) {
 	db := sql.InMemory()
 	lid := types.NewLayerID(10)

--- a/sql/migrations/0001_initial.sql
+++ b/sql/migrations/0001_initial.sql
@@ -4,7 +4,7 @@ CREATE TABLE blocks
     layer    INT NOT NULL,
     validity SMALL INT,
     block    BLOB
-);
+) WITHOUT ROWID;
 CREATE INDEX blocks_by_layer ON blocks (layer, id asc);
 
 CREATE TABLE ballots
@@ -14,19 +14,20 @@ CREATE TABLE ballots
     signature VARCHAR,
     pubkey    VARCHAR,
     ballot    BLOB
-);
+) WITHOUT ROWID;
 CREATE INDEX ballots_by_layer_by_pubkey ON ballots (layer, pubkey);
 
 CREATE TABLE identities
 (
     pubkey    VARCHAR PRIMARY KEY,
     malicious bool
-);
+) WITHOUT ROWID;
 
 CREATE TABLE layers
 (
     id              INT PRIMARY KEY,
     hare_output     VARCHAR,
+    applied_block   VARCHAR,
     hash            CHAR(32),
     aggregated_hash CHAR(32)
 ) WITHOUT ROWID;
@@ -45,8 +46,7 @@ CREATE TABLE rewards
     total_reward UNSIGNED LONG INT,
     layer_reward UNSIGNED LONG INT,
     PRIMARY KEY (smesher, layer)
-);
-
+) WITHOUT ROWID;
 CREATE INDEX rewards_by_coinbase ON rewards (coinbase, layer);
 
 CREATE TABLE transactions
@@ -58,8 +58,7 @@ CREATE TABLE transactions
     origin      CHAR(20),
     destination CHAR(20),
     status      INT
-);
-
+) WITHOUT ROWID;
 CREATE INDEX transaction_by_origin ON transactions (origin, layer);
 CREATE INDEX transaction_by_destination ON transactions (destination, layer);
 
@@ -77,8 +76,7 @@ CREATE TABLE atxs
     smesher   CHAR(64),
     atx       BLOB,
     timestamp INT NOT NULL
-);
-
+) WITHOUT ROWID;
 CREATE INDEX atxs_by_smesher_by_epoch_desc ON atxs (smesher, epoch desc);
 CREATE INDEX atxs_by_epoch_by_pubkey ON atxs (epoch, smesher);
 
@@ -87,7 +85,7 @@ CREATE TABLE atx_top
     id     INT PRIMARY KEY CHECK (id = 1),
     atx_id CHAR(32),
     layer  INT NOT NULL
-);
+) WITHOUT ROWID;
 
 CREATE TABLE proposals
 (
@@ -96,9 +94,8 @@ CREATE TABLE proposals
     layer     INT NOT NULL,
     tx_ids    BLOB,
     signature VARCHAR,
-    encoded   BLOB
-);
-
+    proposal   BLOB
+) WITHOUT ROWID;
 CREATE INDEX proposals_by_layer ON proposals (layer);
 
 CREATE TABLE poets
@@ -107,6 +104,6 @@ CREATE TABLE poets
     poet       BLOB,
     service_id VARCHAR,
     round_id   VARCHAR
-);
+) WITHOUT ROWID;
 
 CREATE INDEX poets_by_service_id_by_round_id ON poets (service_id, round_id);

--- a/sql/proposals/proposals.go
+++ b/sql/proposals/proposals.go
@@ -112,7 +112,7 @@ func GetByLayer(db sql.Executor, layerID types.LayerID) (proposals []*types.Prop
 
 // GetBlob loads proposal as an encoded blob, ready to be sent over the wire.
 func GetBlob(db sql.Executor, id []byte) (proposal []byte, err error) {
-	if rows, err := db.Exec(`select encoded from proposals where id = ?1;`,
+	if rows, err := db.Exec(`select proposal from proposals where id = ?1;`,
 		func(stmt *sql.Statement) {
 			stmt.BindBytes(1, id)
 		}, func(stmt *sql.Statement) bool {
@@ -150,7 +150,7 @@ func Add(db sql.Executor, proposal *types.Proposal) error {
 	}
 
 	_, err = db.Exec(`
-		insert into proposals (id, ballot_id, layer, tx_ids, signature, encoded) 
+		insert into proposals (id, ballot_id, layer, tx_ids, signature, proposal) 
 		values (?1, ?2, ?3, ?4, ?5, ?6);`, enc, nil)
 	if err != nil {
 		return fmt.Errorf("insert proposal ID %v: %w", proposal.ID(), err)

--- a/tortoise/interfaces.go
+++ b/tortoise/interfaces.go
@@ -16,8 +16,11 @@ type blockDataProvider interface {
 	LayerBlockIds(layerID types.LayerID) ([]types.BlockID, error)
 	GetCoinflip(context.Context, types.LayerID) (bool, bool)
 	GetHareConsensusOutput(types.LayerID) (types.BlockID, error)
-	SaveContextualValidity(types.BlockID, types.LayerID, bool) error
 	ContextualValidity(types.BlockID) (bool, error)
+}
+
+type blockValidityUpdater interface {
+	UpdateBlockValidity(types.BlockID, types.LayerID, bool) error
 }
 
 type atxDataProvider interface {

--- a/tortoise/mocks/mocks.go
+++ b/tortoise/mocks/mocks.go
@@ -155,20 +155,6 @@ func (mr *MockblockDataProviderMockRecorder) LayerContextuallyValidBlocks(arg0, 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LayerContextuallyValidBlocks", reflect.TypeOf((*MockblockDataProvider)(nil).LayerContextuallyValidBlocks), arg0, arg1)
 }
 
-// SaveContextualValidity mocks base method.
-func (m *MockblockDataProvider) SaveContextualValidity(arg0 types.BlockID, arg1 types.LayerID, arg2 bool) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SaveContextualValidity", arg0, arg1, arg2)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// SaveContextualValidity indicates an expected call of SaveContextualValidity.
-func (mr *MockblockDataProviderMockRecorder) SaveContextualValidity(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveContextualValidity", reflect.TypeOf((*MockblockDataProvider)(nil).SaveContextualValidity), arg0, arg1, arg2)
-}
-
 // MockatxDataProvider is a mock of atxDataProvider interface.
 type MockatxDataProvider struct {
 	ctrl     *gomock.Controller

--- a/tortoise/rerun.go
+++ b/tortoise/rerun.go
@@ -2,38 +2,25 @@ package tortoise
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"time"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
-	"github.com/spacemeshos/go-spacemesh/database"
 	"github.com/spacemeshos/go-spacemesh/log"
 )
 
-type rerunResult struct {
-	Consensus *turtle
-	Tracer    *validityTracer
-}
-
 // updateFromRerun must be called while holding appropriate mutex (see struct definition).
-func (t *Tortoise) updateFromRerun(ctx context.Context) (bool, types.LayerID) {
-	var (
-		logger   = t.logger.WithContext(ctx).With()
-		reverted bool
-		observed types.LayerID
-	)
+func (t *Tortoise) updateFromRerun(ctx context.Context) {
+	logger := t.logger.WithContext(ctx).With()
 	if t.update == nil {
-		return reverted, observed
+		return
 	}
 	defer func() {
 		t.update = nil
 	}()
 	var (
-		completed = t.update
-		current   = t.trtl
-		updated   = completed.Consensus
-		err       error
+		current = t.trtl
+		updated = t.update
+		err     error
 	)
 	if current.last.After(updated.last) && err == nil {
 		start := time.Now()
@@ -43,23 +30,18 @@ func (t *Tortoise) updateFromRerun(ctx context.Context) (bool, types.LayerID) {
 
 		err = catchupToCurrent(ctx, current, updated)
 		if err != nil {
-			logger.Error("cathup failed", log.Err(err))
+			logger.Error("catchup failed", log.Err(err))
 		} else {
 			logger.Info("catchup finished", log.Duration("duration", time.Since(start)))
 		}
 	}
 	if err != nil {
-		return reverted, observed
-	}
-	reverted = completed.Tracer.Reverted()
-	if reverted {
-		observed = completed.Tracer.FirstLayer()
+		return
 	}
 	updated.bdp = current.bdp
 	updated.logger = current.logger
 	updated.mode = updated.mode.toggleRerun()
 	t.trtl = updated
-	return reverted, observed
 }
 
 func (t *Tortoise) rerunLoop(ctx context.Context, period time.Duration) {
@@ -91,8 +73,6 @@ func (t *Tortoise) rerun(ctx context.Context) error {
 	consensus := t.trtl.cloneTurtleParams()
 	consensus.logger = logger
 	consensus.init(ctx, types.GenesisLayer())
-	tracer := &validityTracer{blockDataProvider: consensus.bdp}
-	consensus.bdp = tracer
 	consensus.last = last
 	consensus.historicallyVerified = historicallyVerified
 	consensus.mode = consensus.mode.toggleRerun()
@@ -109,52 +89,13 @@ func (t *Tortoise) rerun(ctx context.Context) error {
 			return err
 		}
 	}
-	if !tracer.Reverted() && consensus.verified.Before(consensus.historicallyVerified) {
-		revertFrom := consensus.verified.Add(1)
-		tracer.firstUpdatedLayer = &revertFrom
-	}
-	if tracer.Reverted() {
-		logger = logger.WithFields(log.Stringer("first_reverted_layer", tracer.FirstLayer()))
-	}
 	consensus.historicallyVerified = consensus.verified
 	logger.With().Info("tortoise rerun completed", last, log.Duration("duration", time.Since(start)))
 
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	t.update = &rerunResult{Consensus: consensus, Tracer: tracer}
+	t.update = consensus
 	return nil
-}
-
-// validityTracer monitors the tortoise rerun for database changes that would cause us to need to revert state.
-type validityTracer struct {
-	blockDataProvider
-	firstUpdatedLayer *types.LayerID
-}
-
-// SaveContextualValidity overrides the method in the embedded type to check if we've made changes.
-func (vt *validityTracer) SaveContextualValidity(bid types.BlockID, lid types.LayerID, validityNew bool) error {
-	if vt.firstUpdatedLayer == nil {
-		validityCur, err := vt.ContextualValidity(bid)
-		if err != nil && !errors.Is(err, database.ErrNotFound) {
-			return fmt.Errorf("error reading contextual validity of block %v: %w", bid, err)
-		}
-		if validityCur != validityNew {
-			vt.firstUpdatedLayer = &lid
-		}
-	}
-	if err := vt.blockDataProvider.SaveContextualValidity(bid, lid, validityNew); err != nil {
-		return fmt.Errorf("save contextual validity: %w", err)
-	}
-	return nil
-}
-
-func (vt *validityTracer) Reverted() bool {
-	return vt.firstUpdatedLayer != nil
-}
-
-// FirstLayer should be called only if Reverted returns true.
-func (vt *validityTracer) FirstLayer() types.LayerID {
-	return *vt.firstUpdatedLayer
 }
 
 func catchupToCurrent(ctx context.Context, current, updated *turtle) error {

--- a/tortoise/rerun_test.go
+++ b/tortoise/rerun_test.go
@@ -24,7 +24,7 @@ func TestRecoverState(t *testing.T) {
 	var last, verified types.LayerID
 	for i := 0; i < 50; i++ {
 		last = s.Next()
-		_, verified, _ = tortoise.HandleIncomingLayer(ctx, last)
+		verified = tortoise.HandleIncomingLayer(ctx, last)
 	}
 	require.Equal(t, last.Sub(1), verified)
 
@@ -37,7 +37,7 @@ func TestRecoverState(t *testing.T) {
 		// test that it won't block on multiple attempts
 		require.NoError(t, tortoise2.WaitReady(initctx))
 	}
-	_, verified, _ = tortoise2.HandleIncomingLayer(ctx, last)
+	verified = tortoise2.HandleIncomingLayer(ctx, last)
 	require.Equal(t, last.Sub(1), verified)
 
 	cfg.MeshVerified = last.Sub(1)
@@ -46,8 +46,7 @@ func TestRecoverState(t *testing.T) {
 	initctx, cancel = context.WithTimeout(ctx, time.Second)
 	defer cancel()
 	require.NoError(t, tortoise3.WaitReady(initctx))
-	old, verified, _ := tortoise2.HandleIncomingLayer(ctx, last)
-	require.Equal(t, cfg.MeshVerified, old)
+	verified = tortoise2.HandleIncomingLayer(ctx, last)
 	require.Equal(t, last.Sub(1), verified)
 }
 
@@ -70,12 +69,12 @@ func TestRerunStaysInVerifyingMode(t *testing.T) {
 	var last, verified types.LayerID
 	for i := 0; i < layers; i++ {
 		last = s.Next()
-		_, verified, _ = tortoise.HandleIncomingLayer(ctx, last)
+		verified = tortoise.HandleIncomingLayer(ctx, last)
 	}
 	require.Equal(t, last.Sub(1), verified)
 
 	require.NoError(t, tortoise.rerun(ctx))
-	_, verified, _ = tortoise.HandleIncomingLayer(ctx, s.Next())
+	verified = tortoise.HandleIncomingLayer(ctx, s.Next())
 	require.Equal(t, last, verified)
 
 	require.Equal(t, types.GetEffectiveGenesis(), tortoise.trtl.full.counted)
@@ -99,16 +98,14 @@ func TestRerunRevertNonverifiedLayers(t *testing.T) {
 		sim.WithSequence(good),
 		sim.WithSequence(5, sim.WithVoteGenerator(splitVoting(size))),
 	) {
-		_, verified, _ = tortoise.HandleIncomingLayer(ctx, last)
+		verified = tortoise.HandleIncomingLayer(ctx, last)
 	}
 	expected := types.GetEffectiveGenesis().Add(good - 1)
 	require.Equal(t, expected, verified)
 
 	require.NoError(t, tortoise.rerun(ctx))
-	old, verified, reverted := tortoise.HandleIncomingLayer(ctx, s.Next())
-	require.True(t, reverted)
+	verified = tortoise.HandleIncomingLayer(ctx, s.Next())
 	require.True(t, verified.Before(expected))
-	require.Equal(t, old, verified)
 }
 
 func TestRerunDistanceVoteCounting(t *testing.T) {
@@ -148,7 +145,7 @@ func testWindowCounting(tb testing.TB, maliciousLayers, verifyingWindow, fullWin
 		sim.WithSequence(1, sim.WithVoteGenerator(skipLayers(maliciousLayers)), sim.WithEmptyHareOutput()),
 		sim.WithSequence(10, sim.WithEmptyHareOutput()),
 	) {
-		_, verified, _ = tortoise.HandleIncomingLayer(ctx, last)
+		verified = tortoise.HandleIncomingLayer(ctx, last)
 	}
 	require.Equal(tb, last.Sub(1), verified)
 

--- a/tortoise/tortoise.go
+++ b/tortoise/tortoise.go
@@ -25,6 +25,7 @@ type turtle struct {
 	atxdb   atxDataProvider
 	bdp     blockDataProvider
 	beacons system.BeaconGetter
+	updater blockValidityUpdater
 
 	mode mode
 
@@ -39,6 +40,7 @@ func newTurtle(
 	bdp blockDataProvider,
 	atxdb atxDataProvider,
 	beacons system.BeaconGetter,
+	updater blockValidityUpdater,
 	config Config,
 ) *turtle {
 	t := &turtle{
@@ -48,6 +50,7 @@ func newTurtle(
 		bdp:         bdp,
 		atxdb:       atxdb,
 		beacons:     beacons,
+		updater:     updater,
 	}
 	t.verifying = newVerifying(config, &t.commonState)
 	t.full = newFullTortoise(config, &t.commonState)
@@ -61,6 +64,7 @@ func (t *turtle) cloneTurtleParams() *turtle {
 		t.bdp,
 		t.atxdb,
 		t.beacons,
+		t.updater,
 		t.Config,
 	)
 }
@@ -533,7 +537,7 @@ func (t *turtle) processLayer(ctx context.Context, logger log.Log, lid types.Lay
 		}
 	}
 	if err := persistContextualValidity(logger,
-		t.bdp,
+		t.updater,
 		previous, t.verified,
 		t.blocks,
 		t.validity,

--- a/tortoise/util.go
+++ b/tortoise/util.go
@@ -36,14 +36,6 @@ func (a sign) String() string {
 
 type votes map[types.BlockID]sign
 
-func blockMapToArray(m map[types.BlockID]struct{}) []types.BlockID {
-	arr := make([]types.BlockID, 0, len(m))
-	for b := range m {
-		arr = append(arr, b)
-	}
-	return arr
-}
-
 func weightFromInt64(value int64) weight {
 	return weight{Rat: new(big.Rat).SetInt64(value)}
 }
@@ -132,7 +124,7 @@ type tortoiseBallot struct {
 }
 
 func persistContextualValidity(logger log.Log,
-	bdp blockDataProvider,
+	updater blockValidityUpdater,
 	from, to types.LayerID,
 	blocks map[types.LayerID][]types.BlockID,
 	opinion votes,
@@ -144,7 +136,7 @@ func persistContextualValidity(logger log.Log,
 			if sign == abstain {
 				logger.With().Panic("bug: layer should not be verified if there is an undecided block", lid, bid)
 			}
-			err = bdp.SaveContextualValidity(bid, lid, sign == support)
+			err = updater.UpdateBlockValidity(bid, lid, sign == support)
 			if err != nil {
 				err = fmt.Errorf("saving validity for %s: %w", bid, err)
 				return false


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
1st PR of #3035
<!-- `Closes #XXXX, closes #XXXX, ...` links mentioned issues to this PR and automatically closes them when this it's merged -->

## Changes
<!-- Please describe in detail the changes made -->
- apply a layer as soon as hare terminates
- calculate layer hash/agg. hash with just the applied block, not all contextually valid blocks
- mesh self-determines the layer to revert to based on change on contextual validity of blocks. 
  tortoise simply updates contextual validity and no longer needs to care which layer the state should revert to. this is a cleaner separation between consensus and state.

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->

## TODO
<!-- This section should be removed when all items are complete -->
- [ ] Update tests

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
