### PR TITLE
logging: add `log-filepath` flag, rotate logs if it's set

### DIFF
--- a/cmd/base.go
+++ b/cmd/base.go
@@ -116,6 +116,10 @@ func setupLogging(config *bc.Config) {
 		log.JSONLog(true)
 	}
 
+	if config.LOGGING.Filepath != "" {
+		log.FileLog(config.LOGGING.Filepath)
+	}
+
 	// setup logging early
 	err := filesystem.ExistOrCreate(config.DataDir())
 	if err != nil {

--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -107,6 +107,11 @@ var Cmd = &cobra.Command{
 		if conf.LOGGING.Encoder == config.JSONLogEncoder {
 			log.JSONLog(true)
 		}
+
+		if conf.LOGGING.Filepath != "" {
+			log.FileLog(conf.LOGGING.Filepath)
+		}
+
 		app := New(
 			WithConfig(conf),
 			// NOTE(dshulyak) this needs to be max level so that child logger can can be current level or below.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,6 +26,8 @@ func AddCommands(cmd *cobra.Command) {
 		config.BaseConfig.DataDirParent, "Specify data directory for spacemesh")
 	cmd.PersistentFlags().StringVar(&config.LOGGING.Encoder, "log-encoder",
 		config.LOGGING.Encoder, "Log as JSON instead of plain text")
+	cmd.PersistentFlags().StringVar(&config.LOGGING.Filepath, "log-filepath",
+		config.LOGGING.Filepath, "Log into a file")
 	cmd.PersistentFlags().BoolVar(&config.CollectMetrics, "metrics",
 		config.CollectMetrics, "collect node metrics")
 	cmd.PersistentFlags().IntVar(&config.MetricsPort, "metrics-port",

--- a/config/logging.go
+++ b/config/logging.go
@@ -16,6 +16,7 @@ const (
 // LoggerConfig holds the logging level for each module.
 type LoggerConfig struct {
 	Encoder                   LogEncoder `mapstructure:"log-encoder"`
+	Filepath                  string     `mapstructure:"log-filepath"`
 	AppLoggerLevel            string     `mapstructure:"app"`
 	P2PLoggerLevel            string     `mapstructure:"p2p"`
 	PostLoggerLevel           string     `mapstructure:"post"`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
           "--poet-server", "${SMESH_POET_SERVER:?SMESH_POET_SERVER Must be specified}",
           "--post-space", "${SMESH_POST_SPACE:-1024}",
           "--log-encoder", "${SMESH_LOG_ENCODER:?json}",
+          "--log-filepath", "${SMESH_LOG_FILEPATH}",
           "--start-mining",
           "--randcon",  "${SMESH_RANDCON:-8}",
           "--layer-duration-sec", "${SMESH_LAYER_DURATION:-180}",

--- a/log/log.go
+++ b/log/log.go
@@ -10,6 +10,7 @@ import (
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	"gopkg.in/natefinch/lumberjack.v2"
 )
 
 // mainLoggerName is a name of the global logger.
@@ -91,6 +92,22 @@ func initLogging() {
 // JSONLog turns JSON format on or off.
 func JSONLog(b bool) {
 	jsonLog = b
+
+	// Need to reinitialize
+	initLogging()
+}
+
+// FileLog turns on logging to file
+func FileLog(filepath string) {
+	if filepath == "" {
+		logwriter = os.Stdout
+	} else {
+		fileWriter := &lumberjack.Logger{
+			Filename: filepath,
+		}
+
+		logwriter = io.MultiWriter(fileWriter, os.Stdout)
+	}
 
 	// Need to reinitialize
 	initLogging()


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
Closes https://github.com/spacemeshos/go-spacemesh/issues/3092
<!-- `Closes #XXXX, closes #XXXX, ...` links mentioned issues to this PR and automatically closes them when this it's merged -->

## Changes
<!-- Please describe in detail the changes made -->
- add `log-filepath` flag
- rotate logs if `log-filepath` flag is set

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->
unit and system tests

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
