### PR TITLE
[Merged by Bors] - hare: delay gossip msg till after the node catches up

### DIFF
--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -160,6 +160,7 @@ type Service interface {
 // HareService is basic definition of hare algorithm service, providing consensus results for a layer.
 type HareService interface {
 	Service
+	GetHareMsgHandler() pubsub.GossipHandler
 }
 
 // TickProvider is an interface to a glopbal system clock that releases ticks on each layer.
@@ -675,6 +676,10 @@ func (app *App) initServices(ctx context.Context,
 	app.host.Register(activation.AtxProtocol, pubsub.ChainGossipHandler(syncHandler, atxDB.HandleGossipAtx))
 	app.host.Register(txs.IncomingTxProtocol, pubsub.ChainGossipHandler(syncHandler, txHandler.HandleGossipTransaction))
 	app.host.Register(activation.PoetProofProtocol, poetListener.HandlePoetProofMessage)
+	hareGossipHandler := rabbit.GetHareMsgHandler()
+	if hareGossipHandler != nil {
+		app.host.Register(hare.ProtoName, pubsub.ChainGossipHandler(syncHandler, rabbit.GetHareMsgHandler()))
+	}
 
 	app.proposalBuilder = proposalBuilder
 	app.proposalListener = proposalListener

--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -677,9 +677,10 @@ func (app *App) initServices(ctx context.Context,
 	app.host.Register(txs.IncomingTxProtocol, pubsub.ChainGossipHandler(syncHandler, txHandler.HandleGossipTransaction))
 	app.host.Register(activation.PoetProofProtocol, poetListener.HandlePoetProofMessage)
 	hareGossipHandler := rabbit.GetHareMsgHandler()
-	if hareGossipHandler != nil {
-		app.host.Register(hare.ProtoName, pubsub.ChainGossipHandler(syncHandler, rabbit.GetHareMsgHandler()))
+	if hareGossipHandler == nil {
+		app.log.Panic("hare message handler missing")
 	}
+	app.host.Register(hare.ProtoName, pubsub.ChainGossipHandler(syncHandler, hareGossipHandler))
 
 	app.proposalBuilder = proposalBuilder
 	app.proposalListener = proposalListener

--- a/hare/algorithm.go
+++ b/hare/algorithm.go
@@ -23,7 +23,8 @@ import (
 const (
 	// RoundsPerIteration is the number of rounds per iteration in the hare protocol.
 	RoundsPerIteration = 4
-	protoName          = "HARE_PROTOCOL"
+	// ProtoName is the protocol indicator for hare gossip messages.
+	ProtoName = "HARE_PROTOCOL"
 )
 
 type role byte
@@ -517,7 +518,7 @@ func (proc *consensusProcess) sendMessage(ctx context.Context, msg *Msg) bool {
 	)
 	logger := proc.WithContext(ctx)
 
-	if err := proc.publisher.Publish(ctx, protoName, msg.Bytes()); err != nil {
+	if err := proc.publisher.Publish(ctx, ProtoName, msg.Bytes()); err != nil {
 		logger.With().Error("could not broadcast round message", log.Err(err))
 		return false
 	}

--- a/hare/broker.go
+++ b/hare/broker.go
@@ -223,7 +223,7 @@ func (b *Broker) eventLoop(ctx context.Context) {
 			// create an inner context object to handle this message
 			messageCtx := msg.Ctx
 
-			h := types.CalcMessageHash12(msg.Data, protoName)
+			h := types.CalcMessageHash12(msg.Data, ProtoName)
 			msgLogger := logger.WithContext(messageCtx).WithFields(h)
 			hareMsg, err := MessageFromBuffer(msg.Data)
 			if err != nil {

--- a/hare/consensus_test.go
+++ b/hare/consensus_test.go
@@ -153,7 +153,7 @@ func createConsensusProcess(tb testing.TB, isHonest bool, cfg config.Config, ora
 	broker.mockSyncS.EXPECT().IsSynced(gomock.Any()).Return(true).AnyTimes()
 	broker.mockStateQ.EXPECT().IsIdentityActiveOnConsensusView(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).AnyTimes()
 	broker.Start(context.TODO())
-	network.Register(protoName, broker.HandleMessage)
+	network.Register(ProtoName, broker.HandleMessage)
 	output := make(chan TerminationOutput)
 	certs := make(chan CertificationOutput)
 	signing := signing2.NewEdSigner()

--- a/hare/flows_test.go
+++ b/hare/flows_test.go
@@ -466,7 +466,7 @@ func Test_multipleCPs(t *testing.T) {
 	require.NoError(t, mesh.ConnectAllButSelf())
 	require.Eventually(t, func() bool {
 		for _, ps := range pubsubs {
-			if len(ps.ProtocolPeers(protoName)) != len(mesh.Hosts())-1 {
+			if len(ps.ProtocolPeers(ProtoName)) != len(mesh.Hosts())-1 {
 				return false
 			}
 		}
@@ -561,7 +561,7 @@ func Test_multipleCPsAndIterations(t *testing.T) {
 	require.NoError(t, mesh.ConnectAllButSelf())
 	require.Eventually(t, func() bool {
 		for _, ps := range pubsubs {
-			if len(ps.ProtocolPeers(protoName)) != len(mesh.Hosts())-1 {
+			if len(ps.ProtocolPeers(ProtoName)) != len(mesh.Hosts())-1 {
 				return false
 			}
 		}

--- a/hare/flows_test.go
+++ b/hare/flows_test.go
@@ -206,6 +206,7 @@ func createTestHare(t testing.TB, tcfg config.Config, clock *mockClock, pid p2p.
 
 	hare := New(tcfg, pid, p2p, ed, nodeID, mockBlockGen, mockSyncS, mockMeshDB, mockProposalDB, mockBeacons, mockFetcher, mockRoracle, patrol, 10,
 		mockIDProvider, mockStateQ, clock, logtest.New(t).WithName(name+"_"+ed.PublicKey().ShortString()))
+	p2p.Register(ProtoName, hare.GetHareMsgHandler())
 
 	return &hareWithMocks{
 		Hare:           hare,

--- a/hare/hare.go
+++ b/hare/hare.go
@@ -131,7 +131,6 @@ func New(
 
 	ev := newEligibilityValidator(rolacle, layersPerEpoch, idProvider, conf.N, conf.ExpectedLeaders, logger)
 	h.broker = newBroker(peer, ev, stateQ, syncState, layersPerEpoch, conf.LimitConcurrent, h.Closer, logger)
-	publisher.Register(protoName, h.broker.HandleMessage)
 	h.sign = sign
 	h.blockGen = blockGen
 
@@ -155,6 +154,11 @@ func New(
 	h.nid = nid
 
 	return h
+}
+
+// GetHareMsgHandler returns the gossip handler for hare protocol message.
+func (h *Hare) GetHareMsgHandler() pubsub.GossipHandler {
+	return h.broker.HandleMessage
 }
 
 func (h *Hare) getLastLayer() types.LayerID {
@@ -491,13 +495,13 @@ func (h *Hare) tickLoop(ctx context.Context) {
 
 // Start starts listening for layers and outputs.
 func (h *Hare) Start(ctx context.Context) error {
-	h.WithContext(ctx).With().Info("starting protocol", log.String("protocol", protoName))
+	h.WithContext(ctx).With().Info("starting protocol", log.String("protocol", ProtoName))
 
 	// Create separate contexts for each subprocess. This allows us to better track the flow of messages.
-	ctxBroker := log.WithNewSessionID(ctx, log.String("protocol", protoName+"_broker"))
-	ctxTickLoop := log.WithNewSessionID(ctx, log.String("protocol", protoName+"_tickloop"))
-	ctxOutputLoop := log.WithNewSessionID(ctx, log.String("protocol", protoName+"_outputloop"))
-	ctxCertLoop := log.WithNewSessionID(ctx, log.String("protocol", protoName+"_certloop"))
+	ctxBroker := log.WithNewSessionID(ctx, log.String("protocol", ProtoName+"_broker"))
+	ctxTickLoop := log.WithNewSessionID(ctx, log.String("protocol", ProtoName+"_tickloop"))
+	ctxOutputLoop := log.WithNewSessionID(ctx, log.String("protocol", ProtoName+"_outputloop"))
+	ctxCertLoop := log.WithNewSessionID(ctx, log.String("protocol", ProtoName+"_certloop"))
 
 	if err := h.broker.Start(ctxBroker); err != nil {
 		return fmt.Errorf("start broker: %w", err)

--- a/layerfetcher/layers.go
+++ b/layerfetcher/layers.go
@@ -322,7 +322,7 @@ func (l *Logic) fetchLayerData(ctx context.Context, logger log.Log, layerID type
 	}
 	if lyrResult.hareOutput == types.EmptyBlockID {
 		if blocks.HareOutput != types.EmptyBlockID {
-			logger.Info("adopting hare output", blocks.HareOutput)
+			logger.With().Info("adopting hare output", blocks.HareOutput)
 			lyrResult.hareOutput = blocks.HareOutput
 		}
 	} else if blocks.HareOutput != types.EmptyBlockID && lyrResult.hareOutput != blocks.HareOutput {

--- a/turbohare/hare.go
+++ b/turbohare/hare.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/hare/config"
 	"github.com/spacemeshos/go-spacemesh/log"
+	"github.com/spacemeshos/go-spacemesh/p2p/pubsub"
 )
 
 type meshProvider interface {
@@ -112,4 +113,9 @@ func (h *SuperHare) Start(ctx context.Context) error {
 // Close is a stup to support service API.
 func (h *SuperHare) Close() {
 	close(h.closeChannel)
+}
+
+// GetHareMsgHandler returns the gossip handler for hare protocol message.
+func (h *SuperHare) GetHareMsgHandler() pubsub.GossipHandler {
+	return nil
 }

--- a/turbohare/hare.go
+++ b/turbohare/hare.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/hare/config"
 	"github.com/spacemeshos/go-spacemesh/log"
+	"github.com/spacemeshos/go-spacemesh/p2p"
 	"github.com/spacemeshos/go-spacemesh/p2p/pubsub"
 )
 
@@ -117,5 +118,7 @@ func (h *SuperHare) Close() {
 
 // GetHareMsgHandler returns the gossip handler for hare protocol message.
 func (h *SuperHare) GetHareMsgHandler() pubsub.GossipHandler {
-	return nil
+	return func(context.Context, p2p.Peer, []byte) pubsub.ValidationResult {
+		return pubsub.ValidationAccept
+	}
 }


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
when starting a new node, the log is filled with hare warning message about validation error.
the node is not synced and not participating in the hare protocol. these spam logs just impede debugging.
<!-- `Closes #XXXX, closes #XXXX, ...` links mentioned issues to this PR and automatically closes them when this it's merged -->

## Changes
<!-- Please describe in detail the changes made -->
only start listening to hare message when gossip sync

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->
unit tests, systests

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
