### PR TITLE
fix issue “beacon, sync: ReportBeaconFromBallot should account for a …

### DIFF
--- a/proposals/eligibility_validator.go
+++ b/proposals/eligibility_validator.go
@@ -137,7 +137,8 @@ func (v *Validator) CheckEligibility(ctx context.Context, ballot *types.Ballot) 
 		beacon,
 	)
 
-	v.beacons.ReportBeaconFromBallot(epoch, ballot.ID(), beacon, weight)
+	layerWeight := weight * uint64(len(ballot.EligibilityProofs)) / uint64(numEligibleSlots)
+	v.beacons.ReportBeaconFromBallot(epoch, ballot.ID(), beacon, layerWeight)
 	return true, nil
 }
 

--- a/proposals/eligibility_validator_test.go
+++ b/proposals/eligibility_validator_test.go
@@ -526,7 +526,8 @@ func TestCheckEligibility(t *testing.T) {
 		}
 		h.SetID(&b.AtxID)
 		tv.mdb.EXPECT().GetAtxHeader(b.AtxID).Return(h, nil).Times(1)
-		tv.mbc.EXPECT().ReportBeaconFromBallot(epoch, b.ID(), beacon, h.GetWeight()).Times(1)
+		layerWeight := h.GetWeight() * uint64(len(b.EligibilityProofs)) / uint64(eligibleSlots)
+		tv.mbc.EXPECT().ReportBeaconFromBallot(epoch, b.ID(), beacon, layerWeight).Times(1)
 		eligible, err := tv.CheckEligibility(context.TODO(), b)
 		assert.NoError(t, err)
 		assert.True(t, eligible)


### PR DESCRIPTION
…number of eligibilities in the ballot #3118”

## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
fix issue3118 -“ beacon, sync: ReportBeaconFromBallot should account for a number of eligibilities in the ballot“”
<!-- `Closes #XXXX, closes #XXXX, ...` links mentioned issues to this PR and automatically closes them when this it's merged -->

## Changes
<!-- Please describe in detail the changes made -->
For eligibilities of ballot in the layer is not whole weight of  epcho‘s’atx （it will be distributed between multi layers ），so it‘s weight’ should scale down in proportion 

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->

## TODO
<!-- This section should be removed when all items are complete -->
- [ ] Explain motivation or link existing issue(s)
https://github.com/spacemeshos/go-spacemesh/issues/3118
- [ ] Test changes and document test plan
- [ ] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
