### PR TITLE
[Merged by Bors] - Add CLI tool to generate an identity file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,7 +84,7 @@ COPY . .
 # And compile the project
 RUN make build
 RUN make harness
-RUN make gen_identity
+RUN make gen-p2p-identity
 
 #In this last stage, we start from a fresh Alpine image, to reduce the image size and not ship the Go compiler in our production artifacts.
 FROM linux AS spacemesh
@@ -95,7 +95,7 @@ COPY --from=server_builder /go/src/github.com/spacemeshos/go-spacemesh/build/go-
 COPY --from=server_builder /go/src/github.com/spacemeshos/go-spacemesh/build/libgpu-setup.so /bin/
 # TODO(nkryuchkov): uncomment when go-svm is imported
 #COPY --from=server_builder /go/src/github.com/spacemeshos/go-spacemesh/build/libsvm.so /bin/
-COPY --from=server_builder /go/src/github.com/spacemeshos/go-spacemesh/build/gen_identity /bin/
+COPY --from=server_builder /go/src/github.com/spacemeshos/go-spacemesh/build/gen-p2p-identity /bin/
 
 ENTRYPOINT ["/bin/go-harness"]
 EXPOSE 7513

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,6 +84,7 @@ COPY . .
 # And compile the project
 RUN make build
 RUN make harness
+RUN make gen_identity
 
 #In this last stage, we start from a fresh Alpine image, to reduce the image size and not ship the Go compiler in our production artifacts.
 FROM linux AS spacemesh
@@ -94,6 +95,7 @@ COPY --from=server_builder /go/src/github.com/spacemeshos/go-spacemesh/build/go-
 COPY --from=server_builder /go/src/github.com/spacemeshos/go-spacemesh/build/libgpu-setup.so /bin/
 # TODO(nkryuchkov): uncomment when go-svm is imported
 #COPY --from=server_builder /go/src/github.com/spacemeshos/go-spacemesh/build/libsvm.so /bin/
+COPY --from=server_builder /go/src/github.com/spacemeshos/go-spacemesh/build/gen_identity /bin/
 
 ENTRYPOINT ["/bin/go-harness"]
 EXPOSE 7513

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ build: go-spacemesh
 get-libs: get-gpu-setup #get-svm
 .PHONY: get-libs
 
-gen_identity: p2p
+gen-p2p-identity:
 	cd $@ ; go build -o $(BIN_DIR)$@$(EXE) $(GOTAGS) .
 hare p2p: get-libs
 	cd $@ ; go build -o $(BIN_DIR)go-$@$(EXE) $(GOTAGS) .
@@ -86,7 +86,7 @@ go-spacemesh: get-libs
 	go build -o $(BIN_DIR)$@$(EXE) $(LDFLAGS) $(GOTAGS) .
 harness: get-libs
 	cd cmd/integration ; go build -o $(BIN_DIR)go-$@$(EXE) $(GOTAGS) .
-.PHONY: hare p2p harness go-spacemesh gen_identity
+.PHONY: hare p2p harness go-spacemesh gen-p2p-identity
 
 tidy:
 	go mod tidy

--- a/Makefile
+++ b/Makefile
@@ -78,13 +78,15 @@ build: go-spacemesh
 get-libs: get-gpu-setup #get-svm
 .PHONY: get-libs
 
+gen_identity: p2p
+	cd $@ ; go build -o $(BIN_DIR)$@$(EXE) $(GOTAGS) .
 hare p2p: get-libs
-	cd cmd/$@ ; go build -o $(BIN_DIR)go-$@$(EXE) $(GOTAGS) .
+	cd $@ ; go build -o $(BIN_DIR)go-$@$(EXE) $(GOTAGS) .
 go-spacemesh: get-libs
 	go build -o $(BIN_DIR)$@$(EXE) $(LDFLAGS) $(GOTAGS) .
 harness: get-libs
 	cd cmd/integration ; go build -o $(BIN_DIR)go-$@$(EXE) $(GOTAGS) .
-.PHONY: hare p2p harness go-spacemesh
+.PHONY: hare p2p harness go-spacemesh gen_identity
 
 tidy:
 	go mod tidy

--- a/gen-p2p-identity/gen_identity.go
+++ b/gen-p2p-identity/gen_identity.go
@@ -2,8 +2,9 @@ package main
 
 import (
 	"fmt"
-	"github.com/spacemeshos/go-spacemesh/p2p"
 	"os"
+
+	"github.com/spacemeshos/go-spacemesh/p2p"
 )
 
 func main() {

--- a/gen_identity/gen_identity.go
+++ b/gen_identity/gen_identity.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"fmt"
+	"github.com/spacemeshos/go-spacemesh/p2p"
+	"os"
+)
+
+func main() {
+
+	if len(os.Args) != 2 {
+		fmt.Printf("Usage: %v <path/to/output_dir>\n", os.Args[0])
+		return
+	}
+
+	key, err := p2p.EnsureIdentity(os.Args[1])
+	if err != nil {
+		fmt.Printf("failed generating identity: %v\n", err)
+	}
+
+	fmt.Printf("Private Key: %x\n", key)
+}

--- a/gen_identity/gen_identity.go
+++ b/gen_identity/gen_identity.go
@@ -7,16 +7,24 @@ import (
 )
 
 func main() {
-
 	if len(os.Args) != 2 {
 		fmt.Printf("Usage: %v <path/to/output_dir>\n", os.Args[0])
-		return
+		os.Exit(1)
 	}
 
-	key, err := p2p.EnsureIdentity(os.Args[1])
+	dir := os.Args[1]
+	_, err := p2p.EnsureIdentity(dir)
 	if err != nil {
 		fmt.Printf("failed generating identity: %v\n", err)
+		os.Exit(1)
 	}
 
-	fmt.Printf("Private Key: %x\n", key)
+	identityStr, err := p2p.PrettyIdentityInfoFromDir(dir)
+	if err != nil {
+		fmt.Printf("failed fetching identity from file: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Print ID
+	fmt.Printf("%s\n", identityStr)
 }

--- a/p2p/host.go
+++ b/p2p/host.go
@@ -55,7 +55,7 @@ type Config struct {
 // New initializes libp2p host configured for spacemesh.
 func New(ctx context.Context, logger log.Log, cfg Config, opts ...Opt) (*Host, error) {
 	logger.Info("starting libp2p host with config %+v", cfg)
-	key, err := ensureIdentity(cfg.DataDir)
+	key, err := EnsureIdentity(cfg.DataDir)
 	if err != nil {
 		return nil, err
 	}

--- a/p2p/identity.go
+++ b/p2p/identity.go
@@ -42,7 +42,8 @@ func identityInfoFromDir(dir string) (*identityInfo, error) {
 	return &info, nil
 }
 
-func ensureIdentity(dir string) (crypto.PrivKey, error) {
+// EnsureIdentity generates an identity key file in given directory
+func EnsureIdentity(dir string) (crypto.PrivKey, error) {
 	// TODO add crc check
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return nil, fmt.Errorf("ensure that directory %s exist: %w", dir, err)

--- a/p2p/identity.go
+++ b/p2p/identity.go
@@ -42,13 +42,13 @@ func identityInfoFromDir(dir string) (*identityInfo, error) {
 	return &info, nil
 }
 
-// PrettyIdentityInfoFromDir returns a printable ID from a given identity directory
+// PrettyIdentityInfoFromDir returns a printable ID from a given identity directory.
 func PrettyIdentityInfoFromDir(dir string) (string, error) {
 	identityInfo, err := identityInfoFromDir(dir)
 	return identityInfo.ID.Pretty(), err
 }
 
-// EnsureIdentity generates an identity key file in given directory
+// EnsureIdentity generates an identity key file in given directory.
 func EnsureIdentity(dir string) (crypto.PrivKey, error) {
 	// TODO add crc check
 	if err := os.MkdirAll(dir, 0o755); err != nil {

--- a/p2p/identity.go
+++ b/p2p/identity.go
@@ -42,6 +42,12 @@ func identityInfoFromDir(dir string) (*identityInfo, error) {
 	return &info, nil
 }
 
+// PrettyIdentityInfoFromDir returns a printable ID from a given identity directory
+func PrettyIdentityInfoFromDir(dir string) (string, error) {
+	identityInfo, err := identityInfoFromDir(dir)
+	return identityInfo.ID.Pretty(), err
+}
+
 // EnsureIdentity generates an identity key file in given directory
 func EnsureIdentity(dir string) (crypto.PrivKey, error) {
 	// TODO add crc check

--- a/p2p/idetity_test.go
+++ b/p2p/idetity_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestPersistedIdentity(t *testing.T) {
 	dir := t.TempDir()
-	_, err := ensureIdentity(dir)
+	_, err := EnsureIdentity(dir)
 	require.NoError(t, err)
 
 	info, err := identityInfoFromDir(dir)


### PR DESCRIPTION
## Motivation
Closes #3157 

## Changes
Change the ensureIdentity to public EnsureIdentity,
Add a CLI tool that calls EnsureIdentity

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
