### PR TITLE
Bugfix issue3049-prune proposals from database

### DIFF
--- a/hare/hare.go
+++ b/hare/hare.go
@@ -241,6 +241,9 @@ func (h *Hare) collectOutput(ctx context.Context, output TerminationOutput) erro
 			return fmt.Errorf("hare save block: %w", err)
 		} else {
 			hareOutput = block.ID()
+			if err = h.pdb.DelProposals(pids); err != nil {
+				h.WithContext(ctx).With().Warning("failed to remove proposals from database", log.Err(err))
+			}
 		}
 	}
 	if err := h.mesh.ProcessLayerPerHareOutput(ctx, layerID, hareOutput); err != nil {

--- a/hare/hare_test.go
+++ b/hare/hare_test.go
@@ -155,6 +155,11 @@ func TestHare_collectOutputAndGetResult(t *testing.T) {
 			assert.ElementsMatch(t, proposalIDs, pids)
 			return proposals, nil
 		}).Times(1)
+	h.mockProposalDB.EXPECT().DelProposals(gomock.Any()).DoAndReturn(
+		func(pids []types.ProposalID) error {
+			assert.ElementsMatch(t, proposalIDs, pids)
+			return nil
+		}).Times(1)
 	h.mockBlockGen.EXPECT().GenerateBlock(gomock.Any(), lyrID, proposals).Return(block, nil).Times(1)
 	h.mockMeshDB.EXPECT().AddBlockWithTXs(gomock.Any(), block).Return(nil).Times(1)
 	h.mockMeshDB.EXPECT().ProcessLayerPerHareOutput(gomock.Any(), lyrID, block.ID()).Times(1)
@@ -199,6 +204,11 @@ func TestHare_collectOutputGetResult_TerminateTooLate(t *testing.T) {
 		func(pids []types.ProposalID) ([]*types.Proposal, error) {
 			assert.ElementsMatch(t, proposalIDs, pids)
 			return proposals, nil
+		}).Times(1)
+	h.mockProposalDB.EXPECT().DelProposals(gomock.Any()).DoAndReturn(
+		func(pids []types.ProposalID) error {
+			assert.ElementsMatch(t, proposalIDs, pids)
+			return nil
 		}).Times(1)
 	h.mockBlockGen.EXPECT().GenerateBlock(gomock.Any(), lyrID, proposals).Return(block, nil).Times(1)
 	h.mockMeshDB.EXPECT().AddBlockWithTXs(gomock.Any(), block).Return(nil).Times(1)
@@ -276,6 +286,11 @@ func TestHare_onTick(t *testing.T) {
 		func(pids []types.ProposalID) ([]*types.Proposal, error) {
 			assert.ElementsMatch(t, types.ToProposalIDs(proposals), pids)
 			return proposals, nil
+		}).Times(1)
+	h.mockProposalDB.EXPECT().DelProposals(gomock.Any()).DoAndReturn(
+		func(pids []types.ProposalID) error {
+			assert.ElementsMatch(t, types.ToProposalIDs(proposals), pids)
+			return nil
 		}).Times(1)
 	h.mockBlockGen.EXPECT().GenerateBlock(gomock.Any(), lyrID, proposals).Return(block, nil).Times(1)
 	h.mockMeshDB.EXPECT().AddBlockWithTXs(gomock.Any(), block).Return(nil).Times(1)
@@ -365,6 +380,11 @@ func TestHare_onTick_BeaconFromRefBallot(t *testing.T) {
 			assert.ElementsMatch(t, types.ToProposalIDs(proposals), pids)
 			return proposals, nil
 		}).Times(1)
+	h.mockProposalDB.EXPECT().DelProposals(gomock.Any()).DoAndReturn(
+		func(pids []types.ProposalID) error {
+			assert.ElementsMatch(t, types.ToProposalIDs(proposals), pids)
+			return nil
+		}).Times(1)
 	h.mockBlockGen.EXPECT().GenerateBlock(gomock.Any(), lyrID, proposals).Return(block, nil).Times(1)
 	h.mockMeshDB.EXPECT().AddBlockWithTXs(gomock.Any(), block).Return(nil).Times(1)
 	h.mockMeshDB.EXPECT().ProcessLayerPerHareOutput(gomock.Any(), lyrID, block.ID()).Times(1)
@@ -409,6 +429,7 @@ func TestHare_onTick_SomeBadBallots(t *testing.T) {
 
 	lyrID := types.GetEffectiveGenesis().Add(1)
 	beacon := types.RandomBeacon()
+	time.Sleep(1 * time.Millisecond)
 	epochBeacon := types.RandomBeacon()
 	proposals := []*types.Proposal{
 		randomProposal(lyrID, epochBeacon),
@@ -433,6 +454,11 @@ func TestHare_onTick_SomeBadBallots(t *testing.T) {
 		func(pids []types.ProposalID) ([]*types.Proposal, error) {
 			assert.ElementsMatch(t, types.ToProposalIDs(goodProposals), pids)
 			return goodProposals, nil
+		}).Times(1)
+	h.mockProposalDB.EXPECT().DelProposals(gomock.Any()).DoAndReturn(
+		func(pids []types.ProposalID) error {
+			assert.ElementsMatch(t, types.ToProposalIDs(goodProposals), pids)
+			return nil
 		}).Times(1)
 	h.mockBlockGen.EXPECT().GenerateBlock(gomock.Any(), lyrID, goodProposals).Return(block, nil).Times(1)
 	h.mockMeshDB.EXPECT().AddBlockWithTXs(gomock.Any(), block).Return(nil).Times(1)
@@ -478,6 +504,7 @@ func TestHare_onTick_NoGoodBallots(t *testing.T) {
 
 	lyrID := types.GetEffectiveGenesis().Add(1)
 	beacon := types.RandomBeacon()
+	time.Sleep(1 * time.Millisecond)
 	epochBeacon := types.RandomBeacon()
 	proposals := []*types.Proposal{
 		randomProposal(lyrID, beacon),
@@ -668,6 +695,13 @@ func TestHare_WeakCoin(t *testing.T) {
 			assert.ElementsMatch(t, types.ToProposalIDs(proposals), pids)
 			return proposals, nil
 		}).Times(1)
+
+	h.mockProposalDB.EXPECT().DelProposals(gomock.Any()).DoAndReturn(
+		func(pids []types.ProposalID) error {
+			assert.ElementsMatch(t, types.ToProposalIDs(proposals), pids)
+			return nil
+		}).AnyTimes()
+
 	h.mockBlockGen.EXPECT().GenerateBlock(gomock.Any(), layerID, proposals).Return(block, nil).Times(1)
 	h.mockMeshDB.EXPECT().AddBlockWithTXs(gomock.Any(), block).Return(nil).Times(1)
 	h.mockMeshDB.EXPECT().ProcessLayerPerHareOutput(gomock.Any(), layerID, block.ID()).DoAndReturn(

--- a/hare/interfaces.go
+++ b/hare/interfaces.go
@@ -31,6 +31,7 @@ type meshProvider interface {
 type proposalProvider interface {
 	LayerProposals(types.LayerID) ([]*types.Proposal, error)
 	GetProposals([]types.ProposalID) ([]*types.Proposal, error)
+	DelProposals([]types.ProposalID) error
 }
 
 type blockGenerator interface {

--- a/hare/mocks/mocks.go
+++ b/hare/mocks/mocks.go
@@ -243,6 +243,20 @@ func (m *MockproposalProvider) EXPECT() *MockproposalProviderMockRecorder {
 	return m.recorder
 }
 
+// DelProposals mocks base method.
+func (m *MockproposalProvider) DelProposals(arg0 []types.ProposalID) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DelProposals", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DelProposals indicates an expected call of DelProposals.
+func (mr *MockproposalProviderMockRecorder) DelProposals(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DelProposals", reflect.TypeOf((*MockproposalProvider)(nil).DelProposals), arg0)
+}
+
 // GetProposals mocks base method.
 func (m *MockproposalProvider) GetProposals(arg0 []types.ProposalID) ([]*types.Proposal, error) {
 	m.ctrl.T.Helper()

--- a/proposals/proposaldb.go
+++ b/proposals/proposaldb.go
@@ -58,11 +58,24 @@ func (db *DB) AddProposal(ctx context.Context, p *types.Proposal) error {
 }
 
 // DelProposal dels a proposal from the database
-func (db *DB) DelProposal(ctx context.Context, id types.ProposalID) error {
+func (db *DB) DelProposal(id types.ProposalID) error {
 	if err := proposals.Del(db.sqlDB, id); err != nil {
 		return fmt.Errorf("could not remove Proposal %v from database: %w", id, err)
 	}
-	db.logger.WithContext(ctx).With().Info("removed proposal from database", id)
+
+	return nil
+}
+
+// DelProposals dels give set proposals from the database
+func (db *DB) DelProposals(pids []types.ProposalID) error {
+	var (
+		err error
+	)
+	for _, pid := range pids {
+		if err = db.DelProposal(pid); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/proposals/proposaldb.go
+++ b/proposals/proposaldb.go
@@ -57,6 +57,15 @@ func (db *DB) AddProposal(ctx context.Context, p *types.Proposal) error {
 	return nil
 }
 
+// DelProposal dels a proposal from the database
+func (db *DB) DelProposal(ctx context.Context, id types.ProposalID) error {
+	if err := proposals.Del(db.sqlDB, id); err != nil {
+		return fmt.Errorf("could not remove Proposal %v from database: %w", id, err)
+	}
+	db.logger.WithContext(ctx).With().Info("removed proposal from database", id)
+	return nil
+}
+
 // GetProposal retrieves a proposal from the database.
 func (db *DB) GetProposal(id types.ProposalID) (*types.Proposal, error) {
 	return proposals.Get(db.sqlDB, id)

--- a/proposals/proposaldb_test.go
+++ b/proposals/proposaldb_test.go
@@ -51,6 +51,16 @@ func TestDB_AddProposal(t *testing.T) {
 	require.NoError(t, td.AddProposal(context.TODO(), p))
 }
 
+func TestDB_DelProposal(t *testing.T) {
+	td := createTestDB(t)
+	layerID := types.GetEffectiveGenesis().Add(10)
+	p := createProposalAndSaveBallot(t, td, layerID)
+	require.NoError(t, td.AddProposal(context.TODO(), p))
+	require.True(t, td.HasProposal(p.ID()))
+	require.NoError(t, td.DelProposal(context.TODO(), p.ID()))
+	require.False(t, td.HasProposal(p.ID()))
+}
+
 func TestDB_HasProposal(t *testing.T) {
 	td := createTestDB(t)
 	layerID := types.GetEffectiveGenesis().Add(10)

--- a/proposals/proposaldb_test.go
+++ b/proposals/proposaldb_test.go
@@ -57,8 +57,22 @@ func TestDB_DelProposal(t *testing.T) {
 	p := createProposalAndSaveBallot(t, td, layerID)
 	require.NoError(t, td.AddProposal(context.TODO(), p))
 	require.True(t, td.HasProposal(p.ID()))
-	require.NoError(t, td.DelProposal(context.TODO(), p.ID()))
+	require.NoError(t, td.DelProposal(p.ID()))
 	require.False(t, td.HasProposal(p.ID()))
+}
+
+func TestDB_DelProposals(t *testing.T) {
+	td := createTestDB(t)
+	layerID := types.GetEffectiveGenesis().Add(10)
+	p1 := createProposalAndSaveBallot(t, td, layerID)
+	p2 := createProposalAndSaveBallot(t, td, layerID)
+	require.NoError(t, td.AddProposal(context.TODO(), p1))
+	require.NoError(t, td.AddProposal(context.TODO(), p2))
+	pids := []types.ProposalID{p1.ID(), p2.ID()}
+	require.NoError(t, td.DelProposals(pids))
+	require.False(t, td.HasProposal(p1.ID()))
+	require.False(t, td.HasProposal(p2.ID()))
+
 }
 
 func TestDB_HasProposal(t *testing.T) {

--- a/sql/proposals/proposals.go
+++ b/sql/proposals/proposals.go
@@ -159,6 +159,20 @@ func Add(db sql.Executor, proposal *types.Proposal) error {
 	return nil
 }
 
+// Del removes a proposal for a given ID.
+func Del(db sql.Executor, id types.ProposalID) error {
+	_, err := db.Exec(`
+		delete from proposals where proposals.id = ?1;`,
+		func(stmt *sql.Statement) {
+			stmt.BindBytes(1, id.Bytes())
+		}, nil)
+
+	if err != nil {
+		return fmt.Errorf("delete proposal ID %v: %w", id, err)
+	}
+	return nil
+}
+
 func decodeProposal(stmt *sql.Statement) (*types.Proposal, error) {
 	ballotID := types.BallotID{}
 	stmt.ColumnBytes(5, ballotID[:])

--- a/sql/proposals/proposals_test.go
+++ b/sql/proposals/proposals_test.go
@@ -83,3 +83,34 @@ func TestGet(t *testing.T) {
 	require.NoError(t, err)
 	require.EqualValues(t, proposal, got)
 }
+
+func TestDel(t *testing.T) {
+	db := sql.InMemory()
+	pub := []byte{1, 1}
+	ballot := types.NewExistingBallot(types.BallotID{1}, []byte{1, 1}, pub,
+		types.InnerBallot{})
+
+	require.NoError(t, ballots.Add(db, &ballot))
+	require.NoError(t, identities.SetMalicious(db, pub))
+	proposal := &types.Proposal{
+		InnerProposal: types.InnerProposal{
+			Ballot: ballot,
+			TxIDs:  []types.TransactionID{{3, 4}},
+		},
+		Signature: []byte{5, 6},
+	}
+
+	proposal.SetID(types.ProposalID{7, 8})
+	var (
+		has bool
+		err error
+	)
+	require.NoError(t, Add(db, proposal))
+	has, err = Has(db, proposal.ID())
+	require.NoError(t, err)
+	require.True(t, has)
+	require.NoError(t, Del(db, proposal.ID()))
+	has, err = Has(db, proposal.ID())
+	require.NoError(t, err)
+	require.False(t, has)
+}


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
fix issue 3049 - prune proposals from database
<!-- `Closes #XXXX, closes #XXXX, ...` links mentioned issues to this PR and automatically closes them when this it's merged -->

## Changes
<!-- Please describe in detail the changes made -->
add remove proposals after create unify block 
## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->

