### PR TITLE
Bugfix issue3164

### DIFF
--- a/layerfetcher/layers.go
+++ b/layerfetcher/layers.go
@@ -664,7 +664,7 @@ func (l *Logic) GetTxs(ctx context.Context, IDs []types.TransactionID) error {
 		res := <-resC
 		if res.Err != nil {
 			l.log.WithContext(ctx).With().Error("cannot find tx", log.String("hash", hash.String()), log.Err(res.Err))
-			continue
+			return res.Err
 		}
 		if !res.IsLocal {
 			err := l.getTxResult(ctx, hash, res.Data)


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
try to fix “sync: data sync keeps going while validation stuck #3164”
<!-- `Closes #XXXX, closes #XXXX, ...` links mentioned issues to this PR and automatically closes them when this it's merged -->

## Changes
<!-- Please describe in detail the changes made -->
The main idea of modification is: when beacon delay occurs, to rerun validate process from the layer of delayed beacon! key point is ：rerun check routine is triggered in the synchronization layer loop 

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->

add unit test TestSynchronize_BeaconDelayRerun for the this issue scenario

