### PR TITLE
fix issue "beacon sync: should determine beacon when all blocks from …

### DIFF
--- a/beacon/beacon.go
+++ b/beacon/beacon.go
@@ -309,9 +309,12 @@ func (pd *ProtocolDriver) findMostWeightedBeaconForEpoch(epoch types.EpochID) ty
 		// it should determine the beacon value despite not reaching beacon-sync-num-blocks
 		if l, err := layers.GetByStatus(pd.db, layers.Processed); err == nil {
 			if l.Uint32() < uint32(epoch)*types.GetLayersPerEpoch() {
-				logger.Debug("not enough ballots to determine beacon")
+				logger.Debug("not enough ballots to determine beacon and not synced epoch")
 				return types.EmptyBeacon
 			}
+		} else {
+			logger.Debug("not enough ballots to determine beacon")
+			return types.EmptyBeacon
 		}
 	}
 


### PR DESCRIPTION
…epoch are seen #2952"

## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
fix issue “beacon sync: should determine beacon when all blocks from epoch are seen #2952”
<!-- `Closes #XXXX, closes #XXXX, ...` links mentioned issues to this PR and automatically closes them when this it's merged -->

## Changes
<!-- Please describe in detail the changes made -->
 when the node has seen all blocks from an epoch(i.e all layers in the epoch is data-synced),it should determine the beacon value despite not reaching beacon-sync-num-blocks
noted. modify findMostWeightedBeaconForEpoch to add ablove logic

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->
add unit test TestBeacon_findMostWeightedBeaconForEpoch_NotEnoughBlocks_ButSync

