### PR TITLE
[Merged by Bors] - fix node crash loop after the initial crash

### DIFF
--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -514,8 +514,6 @@ func (app *App) initServices(ctx context.Context,
 		beacon.WithConfig(app.Config.Beacon),
 		beacon.WithLogger(app.addLogger(BeaconLogger, lg)))
 
-	var trtl *tortoise.Tortoise
-
 	processed, err := mdb.GetProcessedLayer()
 	if err != nil && !errors.Is(err, database.ErrNotFound) {
 		return fmt.Errorf("failed to load processed layer: %w", err)
@@ -525,29 +523,28 @@ func (app *App) initServices(ctx context.Context,
 		return fmt.Errorf("failed to load verified layer: %w", err)
 	}
 
+	var verifier blockValidityVerifier
+	var msh *mesh.Mesh
+	if mdb.PersistentData() {
+		msh = mesh.NewRecoveredMesh(mdb, atxDB, &verifier, app.conState, app.addLogger(MeshLogger, lg))
+	} else {
+		msh = mesh.NewMesh(mdb, atxDB, &verifier, app.conState, app.addLogger(MeshLogger, lg))
+		if err := state.SetupGenesis(app.Config.Genesis); err != nil {
+			return fmt.Errorf("setup genesis: %w", err)
+		}
+	}
+
 	trtlCfg := app.Config.Tortoise
 	trtlCfg.LayerSize = layerSize
 	trtlCfg.BadBeaconVoteDelayLayers = app.Config.LayersPerEpoch
 	trtlCfg.MeshProcessed = processed
 	trtlCfg.MeshVerified = verified
-
-	var updater blockValidityUpdater
-	trtl = tortoise.New(mdb, atxDB, beaconProtocol, &updater,
+	trtl := tortoise.New(mdb, atxDB, beaconProtocol, msh,
 		tortoise.WithContext(ctx),
 		tortoise.WithLogger(app.addLogger(TrtlLogger, lg)),
 		tortoise.WithConfig(trtlCfg),
 	)
-
-	var msh *mesh.Mesh
-	if mdb.PersistentData() {
-		msh = mesh.NewRecoveredMesh(mdb, atxDB, trtl, app.conState, app.addLogger(MeshLogger, lg))
-	} else {
-		msh = mesh.NewMesh(mdb, atxDB, trtl, app.conState, app.addLogger(MeshLogger, lg))
-		if err := state.SetupGenesis(app.Config.Genesis); err != nil {
-			return fmt.Errorf("setup genesis: %w", err)
-		}
-	}
-	updater.Mesh = msh
+	verifier.Tortoise = trtl
 
 	proposalDB, err := proposals.NewProposalDB(sqlDB, app.addLogger(ProposalDBLogger, lg))
 	if err != nil {
@@ -1168,8 +1165,8 @@ type layerFetcher struct {
 	system.Fetcher
 }
 
-type blockValidityUpdater struct {
-	*mesh.Mesh
+type blockValidityVerifier struct {
+	*tortoise.Tortoise
 }
 
 func decodeLoggers(cfg config.LoggerConfig) (map[string]string, error) {

--- a/systest/Makefile
+++ b/systest/Makefile
@@ -4,6 +4,7 @@ org ?= spacemeshos
 image_name ?= $(org)/systest:$(version_info)
 smesher_image ?= $(org)/go-spacemesh-dev:$(version_info)
 test_pod_name ?= systest-$(version_info)
+keep ?= false
 clusters ?= 1
 size ?= 10
 level ?= debug
@@ -26,7 +27,7 @@ launch:
 	@kubectl run --image $(image_name) $(test_pod_name) \
 	--restart=Never \
 	--image-pull-policy=IfNotPresent -- \
-	tests -test.v -test.timeout=0 -test.run=$(test_name) -clusters=$(clusters) -size=$(size) -image=$(smesher_image) -level=$(level) -node-selector=$(node_selector) -bootstrap=$(bootstrap)
+	tests -test.v -test.timeout=0 -test.run=$(test_name) -clusters=$(clusters) -size=$(size) -image=$(smesher_image) -level=$(level) -node-selector=$(node_selector) -bootstrap=$(bootstrap) -keep=$(keep)
 
 .PHONY: watch
 watch:


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
Closes #3181 
<!-- `Closes #XXXX, closes #XXXX, ...` links mentioned issues to this PR and automatically closes them when this it's merged -->

## Changes
<!-- Please describe in detail the changes made -->
- reverse the dependency btwn mesh and trtl, initialize mesh first so that tortoise can start its background recovery asap.
- add make option `keep` to keep the namespace around after test exits

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->
unit tests, systest

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
