### PR TITLE
[Merged by Bors] - layerfetcher: syntactically invalid blocks are expected from malicious peers

### DIFF
--- a/layerfetcher/layers.go
+++ b/layerfetcher/layers.go
@@ -338,9 +338,8 @@ func (l *Logic) fetchLayerData(ctx context.Context, logger log.Log, layerID type
 	}
 	logger.With().Debug("fetching new blocks", log.Int("to_fetch", len(blocksToFetch)))
 	if err := l.GetBlocks(ctx, blocksToFetch); err != nil {
-		logger.With().Error("failed fetching new blocks", log.Err(err))
+		logger.With().Warning("failed fetching new blocks", log.Err(err))
 		// syntactically invalid blocks are expected from malicious peers
-		return nil
 	}
 	return nil
 }

--- a/layerfetcher/layers.go
+++ b/layerfetcher/layers.go
@@ -338,8 +338,9 @@ func (l *Logic) fetchLayerData(ctx context.Context, logger log.Log, layerID type
 	}
 	logger.With().Debug("fetching new blocks", log.Int("to_fetch", len(blocksToFetch)))
 	if err := l.GetBlocks(ctx, blocksToFetch); err != nil {
-		// fail sync for the entire layer
-		return err
+		logger.With().Error("failed fetching new blocks", log.Err(err))
+		// syntactically invalid blocks are expected from malicious peers
+		return nil
 	}
 	return nil
 }

--- a/layerfetcher/layers_test.go
+++ b/layerfetcher/layers_test.go
@@ -332,7 +332,7 @@ func TestPollLayerBlocks_FetchLayerBallotsError(t *testing.T) {
 	assert.Equal(t, layerID, res.Layer)
 }
 
-func TestPollLayerBlocks_FetchLayerBlocksError(t *testing.T) {
+func TestPollLayerBlocks_FetchLayerBlocksErrorIgnored(t *testing.T) {
 	net := newMockNet(t)
 	numPeers := 4
 	for i := 0; i < numPeers; i++ {

--- a/layerfetcher/layers_test.go
+++ b/layerfetcher/layers_test.go
@@ -352,9 +352,14 @@ func TestPollLayerBlocks_FetchLayerBlocksError(t *testing.T) {
 			}
 			return map[types.Hash32]chan fetch.HashDataPromiseResult{types.RandomHash(): ch}
 		}).Times(numPeers)
+	tl.mLayerDB.EXPECT().SaveHareConsensusOutput(gomock.Any(), layerID, gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ types.LayerID, blockID types.BlockID) interface{} {
+			assert.NotEqual(t, blockID, types.EmptyBlockID)
+			return nil
+		}).Times(1)
 
 	res := <-tl.PollLayerContent(context.TODO(), layerID)
-	assert.Equal(t, ErrLayerDataNotFetched, res.Err)
+	assert.Nil(t, res.Err)
 	assert.Equal(t, layerID, res.Layer)
 }
 
@@ -466,8 +471,14 @@ func TestPollLayerBlocks_MissingBlocks(t *testing.T) {
 			return nil
 		},
 	).AnyTimes()
+	tl.mLayerDB.EXPECT().SaveHareConsensusOutput(gomock.Any(), requested, gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ types.LayerID, blockID types.BlockID) interface{} {
+			assert.Equal(t, blockID, types.EmptyBlockID)
+			return nil
+		}).Times(1)
+
 	res := <-tl.PollLayerContent(context.TODO(), requested)
-	require.ErrorIs(t, res.Err, ErrLayerDataNotFetched)
+	assert.Nil(t, res.Err)
 }
 
 func TestPollLayerBlocks_DifferentHareOutputIgnored(t *testing.T) {


### PR DESCRIPTION
## Motivation
Closes #2697 

## Changes
Skip returning error for invalid blocks

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
