### PR TITLE
PoET: skip validating PoET proof with empty membership

### DIFF
--- a/activation/poetdb.go
+++ b/activation/poetdb.go
@@ -64,6 +64,10 @@ func (db *PoetDb) Validate(proof types.PoetProof, poetID []byte, roundID string,
 		return types.ProcessingError(fmt.Sprintf("invalid poet id %x", poetID))
 	}
 	root, err := calcRoot(proof.Members)
+	// we shouldn't care about poet proof with empty membership as it's not relevant.
+	if len(proof.Members) == 0 {
+		return nil
+	}
 	if err != nil {
 		return types.ProcessingError(fmt.Sprintf("failed to calculate membership root for poetID %x round %s: %v",
 			poetID[:shortIDlth], roundID, err))

--- a/activation/poetdb_test.go
+++ b/activation/poetdb_test.go
@@ -57,6 +57,29 @@ func TestPoetDbHappyFlow(t *testing.T) {
 	r.False(membership[types.BytesToHash([]byte("5"))])
 }
 
+func TestPoetDbPoetProofNoMembers(t *testing.T) {
+	r := require.New(t)
+
+	poetDb := NewPoetDb(sql.InMemory(), logtest.New(t))
+
+	file, err := os.Open(filepath.Join("test_resources", "poet.proof"))
+	r.NoError(err)
+
+	var poetProof types.PoetProof
+	_, err = codec.DecodeFrom(file, &poetProof)
+	r.NoError(err)
+	r.EqualValues([][]byte{[]byte("1"), []byte("2"), []byte("3")}, poetProof.Members)
+	poetID := []byte("poet_id_123456")
+	roundID := "1337"
+	poetProof.Root = []byte("some other root")
+
+	poetProof.Members = nil
+
+	err = poetDb.Validate(poetProof, poetID, roundID, nil)
+	r.NoError(err)
+	r.False(types.IsProcessingError(err))
+}
+
 func TestPoetDbInvalidPoetProof(t *testing.T) {
 	r := require.New(t)
 


### PR DESCRIPTION
## Motivation
Closes #3153 

## Changes
Skip validating PoET proof with empty membership

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
