### PR TITLE
[Merged by Bors] - fix flaky TransactionService test

### DIFF
--- a/cmd/node/node_test.go
+++ b/cmd/node/node_test.go
@@ -713,8 +713,9 @@ func TestSpacemeshApp_TransactionService(t *testing.T) {
 		// Avoid waiting for new connections.
 		app.Config.P2P.TargetOutbound = 0
 
-		// Speed things up a little
-		app.Config.SyncInterval = 1
+		// syncer will cause the node to go out of sync (and not listen to gossip)
+		// since we are testing single-node transaction service, we don't need the syncer to run
+		app.Config.SyncInterval = 1000000
 		app.Config.LayerDurationSec = 2
 
 		app.Config.GenesisTime = time.Now().Add(20 * time.Second).Format(time.RFC3339)
@@ -813,8 +814,6 @@ func TestSpacemeshApp_TransactionService(t *testing.T) {
 		// Wait for the app to exit
 		wg.Wait()
 	}()
-
-	time.Sleep(4 * time.Second)
 
 	// Submit the txs
 	res1, err := c.SubmitTransaction(context.Background(), &pb.SubmitTransactionRequest{


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
fixed flaky TransactionService test caused by https://github.com/spacemeshos/go-spacemesh/pull/3190
<!-- `Closes #XXXX, closes #XXXX, ...` links mentioned issues to this PR and automatically closes them when this it's merged -->

## Changes
<!-- Please describe in detail the changes made -->
this test becomes flaky after the said PR. the root cause is that once syncer starts syncing 
(pointless since it's a single node test), it will take the node out of sync and stop listening to gossip.

since we are testing TransactionService, there is not point for the syncer to start. set the interval long
enough so it doesn't.

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->
unit tests

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
