### PR TITLE
[Merged by Bors] - conservative cache: fixes bugs observed from devnet

### DIFF
--- a/sql/transactions/transactions.go
+++ b/sql/transactions/transactions.go
@@ -171,13 +171,14 @@ func UndoLayers(db sql.Executor, from types.LayerID) ([]types.TransactionID, err
 
 // DiscardNonceBelow sets the applied field to `stateDiscarded` for transactions with nonce lower than specified.
 func DiscardNonceBelow(db sql.Executor, address types.Address, nonce uint64) error {
-	_, err := db.Exec(`update transactions set applied = ?3, layer = ?4, block = ?5 where origin = ?1 and nonce < ?2`,
+	_, err := db.Exec(`update transactions set applied = ?3, layer = ?4, block = ?5 where origin = ?1 and nonce < ?2 and applied != ?6`,
 		func(stmt *sql.Statement) {
 			stmt.BindBytes(1, address.Bytes())
 			stmt.BindInt64(2, int64(nonce))
 			stmt.BindInt64(3, stateDiscarded)
 			stmt.BindInt64(4, int64(types.LayerID{}.Value))
 			stmt.BindBytes(5, types.EmptyBlockID.Bytes())
+			stmt.BindInt64(6, stateApplied)
 		}, nil)
 	if err != nil {
 		return fmt.Errorf("discard nonce below %s/%d: %w", address, nonce, err)

--- a/txs/cache.go
+++ b/txs/cache.go
@@ -600,7 +600,7 @@ func (c *cache) MoreInDB(addr types.Address) bool {
 
 func (c *cache) cleanupAccounts(accounts map[types.Address]struct{}) {
 	for addr := range accounts {
-		if c.pending[addr].shouldEvict() {
+		if _, ok := c.pending[addr]; ok && c.pending[addr].shouldEvict() {
 			delete(c.pending, addr)
 		}
 	}

--- a/txs/conservative_state_test.go
+++ b/txs/conservative_state_test.go
@@ -38,18 +38,18 @@ func newTxWthRecipient(t *testing.T, dest types.Address, nonce uint64, amount, f
 
 type testConState struct {
 	*ConservativeState
-	db   *sql.Database
-	mSVM *mocks.MocksvmState
+	db  *sql.Database
+	mvm *mocks.MockvmState
 }
 
 func createConservativeState(t *testing.T) *testConState {
 	ctrl := gomock.NewController(t)
-	mockSvm := mocks.NewMocksvmState(ctrl)
+	mvm := mocks.NewMockvmState(ctrl)
 	db := sql.InMemory()
 	return &testConState{
-		ConservativeState: NewConservativeState(mockSvm, db, logtest.New(t)),
+		ConservativeState: NewConservativeState(mvm, db, logtest.New(t)),
 		db:                db,
-		mSVM:              mockSvm,
+		mvm:               mvm,
 	}
 }
 
@@ -60,8 +60,8 @@ func addBatch(t *testing.T, tcs *testConState, numTXs int) ([]types.TransactionI
 	for i := 0; i < numTXs; i++ {
 		signer := signing.NewEdSigner()
 		addr := types.BytesToAddress(signer.PublicKey().Bytes())
-		tcs.mSVM.EXPECT().GetBalance(addr).Return(defaultBalance, nil).Times(1)
-		tcs.mSVM.EXPECT().GetNonce(addr).Return(nonce, nil).Times(1)
+		tcs.mvm.EXPECT().GetBalance(addr).Return(defaultBalance, nil).Times(1)
+		tcs.mvm.EXPECT().GetNonce(addr).Return(nonce, nil).Times(1)
 		tx := newTx(t, nonce, amount, fee, signer)
 		require.NoError(t, tcs.AddToCache(tx, true))
 		ids = append(ids, tx.ID())
@@ -79,8 +79,8 @@ func TestSelectTXsForProposal(t *testing.T) {
 	for i := 0; i < numTXs; i++ {
 		signer := signing.NewEdSigner()
 		addr := types.GenerateAddress(signer.PublicKey().Bytes())
-		tcs.mSVM.EXPECT().GetBalance(addr).Return(defaultBalance, nil).Times(1)
-		tcs.mSVM.EXPECT().GetNonce(addr).Return(uint64(0), nil).Times(1)
+		tcs.mvm.EXPECT().GetBalance(addr).Return(defaultBalance, nil).Times(1)
+		tcs.mvm.EXPECT().GetNonce(addr).Return(uint64(0), nil).Times(1)
 		tx1 := newTx(t, 0, amount, fee, signer)
 		require.NoError(t, tcs.AddToCache(tx1, true))
 		// all the TXs with nonce 0 are pending in database
@@ -103,8 +103,8 @@ func TestSelectTXsForProposal_ExhaustMemPool(t *testing.T) {
 	for i := 0; i < numTXs; i++ {
 		signer := signing.NewEdSigner()
 		addr := types.GenerateAddress(signer.PublicKey().Bytes())
-		tcs.mSVM.EXPECT().GetBalance(addr).Return(defaultBalance, nil).Times(1)
-		tcs.mSVM.EXPECT().GetNonce(addr).Return(uint64(0), nil).Times(1)
+		tcs.mvm.EXPECT().GetBalance(addr).Return(defaultBalance, nil).Times(1)
+		tcs.mvm.EXPECT().GetNonce(addr).Return(uint64(0), nil).Times(1)
 		tx1 := newTx(t, 0, amount, fee, signer)
 		require.NoError(t, tcs.AddToCache(tx1, true))
 		// all the TXs with nonce 0 are pending in database
@@ -126,8 +126,8 @@ func TestSelectTXsForProposal_SamePrincipal(t *testing.T) {
 	numInBlock := numTXsInProposal
 	lid := types.NewLayerID(97)
 	bid := types.BlockID{100}
-	tcs.mSVM.EXPECT().GetBalance(addr).Return(defaultBalance, nil).Times(1)
-	tcs.mSVM.EXPECT().GetNonce(addr).Return(uint64(0), nil).Times(1)
+	tcs.mvm.EXPECT().GetBalance(addr).Return(defaultBalance, nil).Times(1)
+	tcs.mvm.EXPECT().GetNonce(addr).Return(uint64(0), nil).Times(1)
 	for i := 0; i < numInBlock; i++ {
 		tx := newTx(t, uint64(i), amount, fee, signer)
 		require.NoError(t, tcs.AddToCache(tx, true))
@@ -159,10 +159,10 @@ func TestSelectTXsForProposal_TwoPrincipals(t *testing.T) {
 	addr2 := types.GenerateAddress(signer2.PublicKey().Bytes())
 	lid := types.NewLayerID(97)
 	bid := types.BlockID{100}
-	tcs.mSVM.EXPECT().GetBalance(addr1).Return(defaultBalance*100, nil).Times(1)
-	tcs.mSVM.EXPECT().GetNonce(addr1).Return(uint64(0), nil).Times(1)
-	tcs.mSVM.EXPECT().GetBalance(addr2).Return(defaultBalance*100, nil).Times(1)
-	tcs.mSVM.EXPECT().GetNonce(addr2).Return(uint64(0), nil).Times(1)
+	tcs.mvm.EXPECT().GetBalance(addr1).Return(defaultBalance*100, nil).Times(1)
+	tcs.mvm.EXPECT().GetNonce(addr1).Return(uint64(0), nil).Times(1)
+	tcs.mvm.EXPECT().GetBalance(addr2).Return(defaultBalance*100, nil).Times(1)
+	tcs.mvm.EXPECT().GetNonce(addr2).Return(uint64(0), nil).Times(1)
 	allTXs := make(map[types.TransactionID]*types.Transaction)
 	for i := 0; i < numInDBs; i++ {
 		tx := newTx(t, uint64(i), amount, fee, signer1)
@@ -206,8 +206,8 @@ func TestGetProjection(t *testing.T) {
 	tcs := createConservativeState(t)
 	signer := signing.NewEdSigner()
 	addr := types.BytesToAddress(signer.PublicKey().Bytes())
-	tcs.mSVM.EXPECT().GetBalance(addr).Return(defaultBalance, nil).Times(1)
-	tcs.mSVM.EXPECT().GetNonce(addr).Return(nonce, nil).Times(1)
+	tcs.mvm.EXPECT().GetBalance(addr).Return(defaultBalance, nil).Times(1)
+	tcs.mvm.EXPECT().GetNonce(addr).Return(nonce, nil).Times(1)
 	tx1 := newTx(t, nonce, amount, fee, signer)
 	require.NoError(t, tcs.AddToCache(tx1, true))
 	require.NoError(t, tcs.LinkTXsWithBlock(types.NewLayerID(10), types.BlockID{100}, []types.TransactionID{tx1.ID()}))
@@ -223,8 +223,8 @@ func TestAddToCache(t *testing.T) {
 	tcs := createConservativeState(t)
 	signer := signing.NewEdSigner()
 	addr := types.BytesToAddress(signer.PublicKey().Bytes())
-	tcs.mSVM.EXPECT().GetBalance(addr).Return(defaultBalance, nil).Times(1)
-	tcs.mSVM.EXPECT().GetNonce(addr).Return(nonce, nil).Times(1)
+	tcs.mvm.EXPECT().GetBalance(addr).Return(defaultBalance, nil).Times(1)
+	tcs.mvm.EXPECT().GetNonce(addr).Return(nonce, nil).Times(1)
 	tx := newTx(t, nonce, amount, fee, signer)
 	assert.NoError(t, tcs.AddToCache(tx, true))
 	got, err := tcs.HasTx(tx.ID())
@@ -236,8 +236,8 @@ func TestAddToCache_KnownTX(t *testing.T) {
 	tcs := createConservativeState(t)
 	signer := signing.NewEdSigner()
 	addr := types.BytesToAddress(signer.PublicKey().Bytes())
-	tcs.mSVM.EXPECT().GetBalance(addr).Return(defaultBalance, nil).Times(1)
-	tcs.mSVM.EXPECT().GetNonce(addr).Return(nonce, nil).Times(1)
+	tcs.mvm.EXPECT().GetBalance(addr).Return(defaultBalance, nil).Times(1)
+	tcs.mvm.EXPECT().GetNonce(addr).Return(nonce, nil).Times(1)
 	tx := newTx(t, nonce, amount, fee, signer)
 	assert.NoError(t, tcs.AddToCache(tx, false))
 	got, err := tcs.HasTx(tx.ID())
@@ -249,8 +249,8 @@ func TestAddToCache_InsufficientBalance(t *testing.T) {
 	tcs := createConservativeState(t)
 	signer := signing.NewEdSigner()
 	addr := types.BytesToAddress(signer.PublicKey().Bytes())
-	tcs.mSVM.EXPECT().GetBalance(addr).Return(amount, nil).Times(1)
-	tcs.mSVM.EXPECT().GetNonce(addr).Return(nonce, nil).Times(1)
+	tcs.mvm.EXPECT().GetBalance(addr).Return(amount, nil).Times(1)
+	tcs.mvm.EXPECT().GetNonce(addr).Return(nonce, nil).Times(1)
 	tx := newTx(t, nonce, amount, fee, signer)
 	err := tcs.AddToCache(tx, true)
 	assert.ErrorIs(t, err, errInsufficientBalance)
@@ -260,8 +260,8 @@ func TestGetMeshTransaction(t *testing.T) {
 	tcs := createConservativeState(t)
 	signer := signing.NewEdSigner()
 	addr := types.BytesToAddress(signer.PublicKey().Bytes())
-	tcs.mSVM.EXPECT().GetBalance(addr).Return(defaultBalance, nil).Times(1)
-	tcs.mSVM.EXPECT().GetNonce(addr).Return(nonce, nil).Times(1)
+	tcs.mvm.EXPECT().GetBalance(addr).Return(defaultBalance, nil).Times(1)
+	tcs.mvm.EXPECT().GetNonce(addr).Return(nonce, nil).Times(1)
 	tx := newTx(t, nonce, amount, fee, signer)
 	assert.NoError(t, tcs.AddToCache(tx, true))
 	mtx, err := tcs.GetMeshTransaction(tx.ID())
@@ -319,16 +319,16 @@ func TestGetTransactionsByAddress(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, mtxs)
 
-	tcs.mSVM.EXPECT().GetBalance(addr1).Return(defaultBalance, nil).Times(1)
-	tcs.mSVM.EXPECT().GetNonce(addr1).Return(nonce, nil).Times(1)
+	tcs.mvm.EXPECT().GetBalance(addr1).Return(defaultBalance, nil).Times(1)
+	tcs.mvm.EXPECT().GetNonce(addr1).Return(nonce, nil).Times(1)
 	tx0 := newTxWthRecipient(t, addr2, nonce, amount, fee, signer1)
 	assert.NoError(t, tcs.AddToCache(tx0, true))
 	tx1 := newTxWthRecipient(t, addr3, nonce+1, amount, fee, signer1)
 	assert.NoError(t, tcs.AddToCache(tx1, true))
 	require.NoError(t, tcs.LinkTXsWithBlock(types.NewLayerID(5), types.BlockID{11}, []types.TransactionID{tx1.ID()}))
 
-	tcs.mSVM.EXPECT().GetBalance(addr2).Return(defaultBalance, nil).Times(1)
-	tcs.mSVM.EXPECT().GetNonce(addr2).Return(nonce, nil).Times(1)
+	tcs.mvm.EXPECT().GetBalance(addr2).Return(defaultBalance, nil).Times(1)
+	tcs.mvm.EXPECT().GetNonce(addr2).Return(nonce, nil).Times(1)
 	tx2 := newTxWthRecipient(t, addr3, nonce, amount, fee, signer2)
 	assert.NoError(t, tcs.AddToCache(tx2, true))
 	tx3 := newTxWthRecipient(t, addr3, nonce+1, amount, fee, signer2)
@@ -371,12 +371,11 @@ func TestApplyLayer(t *testing.T) {
 			},
 			TxIDs: ids,
 		})
-	rewards := []types.AnyReward{{Address: coinbase, Amount: reward}}
 	for _, tx := range txs {
-		tcs.mSVM.EXPECT().GetBalance(tx.Origin()).Return(defaultBalance-(amount+fee), nil)
-		tcs.mSVM.EXPECT().GetNonce(tx.Origin()).Return(nonce+1, nil)
+		tcs.mvm.EXPECT().GetBalance(tx.Origin()).Return(defaultBalance-(amount+fee), nil)
+		tcs.mvm.EXPECT().GetNonce(tx.Origin()).Return(nonce+1, nil)
 	}
-	tcs.mSVM.EXPECT().ApplyLayer(lid, gomock.Any(), rewards).DoAndReturn(
+	tcs.mvm.EXPECT().ApplyLayer(lid, gomock.Any(), block.Rewards).DoAndReturn(
 		func(_ types.LayerID, got []*types.Transaction, _ []types.AnyReward) ([]*types.Transaction, error) {
 			require.ElementsMatch(t, got, txs)
 			return nil, nil
@@ -414,8 +413,8 @@ func TestApplyLayer_TXsFailedVM(t *testing.T) {
 	ids, txs := addBatch(t, tcs, numTXs)
 	for _, tx := range txs[numFailed:] {
 		principal := tx.Origin()
-		tcs.mSVM.EXPECT().GetBalance(principal).Return(defaultBalance - (tx.Amount + tx.Fee)).Times(1)
-		tcs.mSVM.EXPECT().GetNonce(principal).Return(nonce + 1).Times(1)
+		tcs.mvm.EXPECT().GetBalance(principal).Return(defaultBalance-(tx.Amount+tx.Fee), nil).Times(1)
+		tcs.mvm.EXPECT().GetNonce(principal).Return(nonce+1, nil).Times(1)
 	}
 	coinbase := types.GenerateAddress(types.RandomBytes(20))
 	reward := uint64(200)
@@ -427,9 +426,8 @@ func TestApplyLayer_TXsFailedVM(t *testing.T) {
 			},
 			TxIDs: ids,
 		})
-	rewards := map[types.Address]uint64{coinbase: reward}
-	tcs.mSVM.EXPECT().ApplyLayer(lid, gomock.Any(), rewards).DoAndReturn(
-		func(_ types.LayerID, got []*types.Transaction, _ map[types.Address]uint64) ([]*types.Transaction, error) {
+	tcs.mvm.EXPECT().ApplyLayer(lid, gomock.Any(), block.Rewards).DoAndReturn(
+		func(_ types.LayerID, got []*types.Transaction, _ []types.AnyReward) ([]*types.Transaction, error) {
 			require.ElementsMatch(t, got, txs)
 			return got[:numFailed], nil
 		}).Times(1)
@@ -467,15 +465,14 @@ func TestApplyLayer_VMError(t *testing.T) {
 			},
 			TxIDs: ids,
 		})
-	rewards := []types.AnyReward{{Address: coinbase, Amount: reward}}
-	errSVM := errors.New("svm")
-	tcs.mSVM.EXPECT().ApplyLayer(lid, gomock.Any(), rewards).DoAndReturn(
+	errVM := errors.New("vm error")
+	tcs.mvm.EXPECT().ApplyLayer(lid, gomock.Any(), block.Rewards).DoAndReturn(
 		func(_ types.LayerID, got []*types.Transaction, _ []types.AnyReward) ([]*types.Transaction, error) {
 			require.ElementsMatch(t, got, txs)
-			return got[:numFailed], errSVM
+			return got[:numFailed], errVM
 		}).Times(1)
 	failed, err := tcs.ApplyLayer(block)
-	assert.ErrorIs(t, err, errSVM)
+	assert.ErrorIs(t, err, errVM)
 	assert.Len(t, failed, numFailed)
 
 	for _, id := range ids {

--- a/txs/handler.go
+++ b/txs/handler.go
@@ -19,7 +19,6 @@ var (
 	errDuplicateTX      = errors.New("tx already exists")
 	errAddrNotExtracted = errors.New("address not extracted")
 	errAddrNotFound     = errors.New("address not found")
-	errRejectedByCache  = errors.New("rejected by conservative cache")
 )
 
 // TxHandler handles the transactions received via gossip or sync.
@@ -90,7 +89,6 @@ func (th *TxHandler) handleTransaction(ctx context.Context, msg []byte) error {
 			tx.Origin(),
 			tx.ID(),
 			log.Err(err))
-		return errRejectedByCache
 	}
 
 	return nil
@@ -119,7 +117,6 @@ func (th *TxHandler) HandleSyncTransaction(ctx context.Context, data []byte) err
 	}
 	if err = th.state.AddToCache(&tx, !exists); err != nil {
 		th.logger.WithContext(ctx).With().Warning("failed to add sync tx to conservative cache", tx.ID(), log.Err(err))
-		return errRejectedByCache
 	}
 	return nil
 }

--- a/txs/handler_test.go
+++ b/txs/handler_test.go
@@ -130,7 +130,7 @@ func Test_handleTransaction_AddressNotFound(t *testing.T) {
 	assert.ErrorIs(t, got, errAddrNotFound)
 }
 
-func Test_handleTransaction_FailedMemPool(t *testing.T) {
+func Test_handleTransaction_FailedMemPoolIgnored(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	cstate := mocks.NewMockconservativeState(ctrl)
 	th := NewTxHandler(cstate, logtest.New(t))
@@ -151,8 +151,7 @@ func Test_handleTransaction_FailedMemPool(t *testing.T) {
 	msg, err := codec.Encode(tx)
 	require.NoError(t, err)
 
-	got := th.handleTransaction(context.TODO(), msg)
-	assert.ErrorIs(t, got, errRejectedByCache)
+	require.NoError(t, th.handleTransaction(context.TODO(), msg))
 }
 
 func Test_HandleSyncTransaction_Success(t *testing.T) {
@@ -208,7 +207,7 @@ func Test_HandleSyncTransaction_HasTXError(t *testing.T) {
 	assert.ErrorIs(t, got, errUnknown)
 }
 
-func Test_HandleSyncTransaction_FailedMemPool(t *testing.T) {
+func Test_HandleSyncTransaction_FailedMemPoolIgnored(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	cstate := mocks.NewMockconservativeState(ctrl)
 	th := NewTxHandler(cstate, logtest.New(t))
@@ -227,6 +226,5 @@ func Test_HandleSyncTransaction_FailedMemPool(t *testing.T) {
 	msg, err := codec.Encode(tx)
 	require.NoError(t, err)
 
-	got := th.HandleSyncTransaction(context.TODO(), msg)
-	assert.ErrorIs(t, got, errRejectedByCache)
+	require.NoError(t, th.HandleSyncTransaction(context.TODO(), msg))
 }

--- a/txs/interface.go
+++ b/txs/interface.go
@@ -15,7 +15,7 @@ type conservativeState interface {
 	AddToCache(*types.Transaction, bool) error
 }
 
-type svmState interface {
+type vmState interface {
 	GetStateRoot() (types.Hash32, error)
 	GetLayerStateRoot(types.LayerID) (types.Hash32, error)
 	GetLayerApplied(types.TransactionID) (types.LayerID, error)

--- a/txs/mocks/mocks.go
+++ b/txs/mocks/mocks.go
@@ -80,31 +80,31 @@ func (mr *MockconservativeStateMockRecorder) HasTx(arg0 interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasTx", reflect.TypeOf((*MockconservativeState)(nil).HasTx), arg0)
 }
 
-// MocksvmState is a mock of svmState interface.
-type MocksvmState struct {
+// MockvmState is a mock of vmState interface.
+type MockvmState struct {
 	ctrl     *gomock.Controller
-	recorder *MocksvmStateMockRecorder
+	recorder *MockvmStateMockRecorder
 }
 
-// MocksvmStateMockRecorder is the mock recorder for MocksvmState.
-type MocksvmStateMockRecorder struct {
-	mock *MocksvmState
+// MockvmStateMockRecorder is the mock recorder for MockvmState.
+type MockvmStateMockRecorder struct {
+	mock *MockvmState
 }
 
-// NewMocksvmState creates a new mock instance.
-func NewMocksvmState(ctrl *gomock.Controller) *MocksvmState {
-	mock := &MocksvmState{ctrl: ctrl}
-	mock.recorder = &MocksvmStateMockRecorder{mock}
+// NewMockvmState creates a new mock instance.
+func NewMockvmState(ctrl *gomock.Controller) *MockvmState {
+	mock := &MockvmState{ctrl: ctrl}
+	mock.recorder = &MockvmStateMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MocksvmState) EXPECT() *MocksvmStateMockRecorder {
+func (m *MockvmState) EXPECT() *MockvmStateMockRecorder {
 	return m.recorder
 }
 
 // AddressExists mocks base method.
-func (m *MocksvmState) AddressExists(arg0 types.Address) (bool, error) {
+func (m *MockvmState) AddressExists(arg0 types.Address) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddressExists", arg0)
 	ret0, _ := ret[0].(bool)
@@ -113,13 +113,13 @@ func (m *MocksvmState) AddressExists(arg0 types.Address) (bool, error) {
 }
 
 // AddressExists indicates an expected call of AddressExists.
-func (mr *MocksvmStateMockRecorder) AddressExists(arg0 interface{}) *gomock.Call {
+func (mr *MockvmStateMockRecorder) AddressExists(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddressExists", reflect.TypeOf((*MocksvmState)(nil).AddressExists), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddressExists", reflect.TypeOf((*MockvmState)(nil).AddressExists), arg0)
 }
 
 // ApplyLayer mocks base method.
-func (m *MocksvmState) ApplyLayer(arg0 types.LayerID, arg1 []*types.Transaction, arg2 []types.AnyReward) ([]*types.Transaction, error) {
+func (m *MockvmState) ApplyLayer(arg0 types.LayerID, arg1 []*types.Transaction, arg2 []types.AnyReward) ([]*types.Transaction, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ApplyLayer", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]*types.Transaction)
@@ -128,13 +128,13 @@ func (m *MocksvmState) ApplyLayer(arg0 types.LayerID, arg1 []*types.Transaction,
 }
 
 // ApplyLayer indicates an expected call of ApplyLayer.
-func (mr *MocksvmStateMockRecorder) ApplyLayer(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockvmStateMockRecorder) ApplyLayer(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyLayer", reflect.TypeOf((*MocksvmState)(nil).ApplyLayer), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyLayer", reflect.TypeOf((*MockvmState)(nil).ApplyLayer), arg0, arg1, arg2)
 }
 
 // GetAllAccounts mocks base method.
-func (m *MocksvmState) GetAllAccounts() ([]*types.Account, error) {
+func (m *MockvmState) GetAllAccounts() ([]*types.Account, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAllAccounts")
 	ret0, _ := ret[0].([]*types.Account)
@@ -143,13 +143,13 @@ func (m *MocksvmState) GetAllAccounts() ([]*types.Account, error) {
 }
 
 // GetAllAccounts indicates an expected call of GetAllAccounts.
-func (mr *MocksvmStateMockRecorder) GetAllAccounts() *gomock.Call {
+func (mr *MockvmStateMockRecorder) GetAllAccounts() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllAccounts", reflect.TypeOf((*MocksvmState)(nil).GetAllAccounts))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllAccounts", reflect.TypeOf((*MockvmState)(nil).GetAllAccounts))
 }
 
 // GetBalance mocks base method.
-func (m *MocksvmState) GetBalance(arg0 types.Address) (uint64, error) {
+func (m *MockvmState) GetBalance(arg0 types.Address) (uint64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetBalance", arg0)
 	ret0, _ := ret[0].(uint64)
@@ -158,13 +158,13 @@ func (m *MocksvmState) GetBalance(arg0 types.Address) (uint64, error) {
 }
 
 // GetBalance indicates an expected call of GetBalance.
-func (mr *MocksvmStateMockRecorder) GetBalance(arg0 interface{}) *gomock.Call {
+func (mr *MockvmStateMockRecorder) GetBalance(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBalance", reflect.TypeOf((*MocksvmState)(nil).GetBalance), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBalance", reflect.TypeOf((*MockvmState)(nil).GetBalance), arg0)
 }
 
 // GetLayerApplied mocks base method.
-func (m *MocksvmState) GetLayerApplied(arg0 types.TransactionID) (types.LayerID, error) {
+func (m *MockvmState) GetLayerApplied(arg0 types.TransactionID) (types.LayerID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetLayerApplied", arg0)
 	ret0, _ := ret[0].(types.LayerID)
@@ -173,13 +173,13 @@ func (m *MocksvmState) GetLayerApplied(arg0 types.TransactionID) (types.LayerID,
 }
 
 // GetLayerApplied indicates an expected call of GetLayerApplied.
-func (mr *MocksvmStateMockRecorder) GetLayerApplied(arg0 interface{}) *gomock.Call {
+func (mr *MockvmStateMockRecorder) GetLayerApplied(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLayerApplied", reflect.TypeOf((*MocksvmState)(nil).GetLayerApplied), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLayerApplied", reflect.TypeOf((*MockvmState)(nil).GetLayerApplied), arg0)
 }
 
 // GetLayerStateRoot mocks base method.
-func (m *MocksvmState) GetLayerStateRoot(arg0 types.LayerID) (types.Hash32, error) {
+func (m *MockvmState) GetLayerStateRoot(arg0 types.LayerID) (types.Hash32, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetLayerStateRoot", arg0)
 	ret0, _ := ret[0].(types.Hash32)
@@ -188,13 +188,13 @@ func (m *MocksvmState) GetLayerStateRoot(arg0 types.LayerID) (types.Hash32, erro
 }
 
 // GetLayerStateRoot indicates an expected call of GetLayerStateRoot.
-func (mr *MocksvmStateMockRecorder) GetLayerStateRoot(arg0 interface{}) *gomock.Call {
+func (mr *MockvmStateMockRecorder) GetLayerStateRoot(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLayerStateRoot", reflect.TypeOf((*MocksvmState)(nil).GetLayerStateRoot), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLayerStateRoot", reflect.TypeOf((*MockvmState)(nil).GetLayerStateRoot), arg0)
 }
 
 // GetNonce mocks base method.
-func (m *MocksvmState) GetNonce(arg0 types.Address) (uint64, error) {
+func (m *MockvmState) GetNonce(arg0 types.Address) (uint64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetNonce", arg0)
 	ret0, _ := ret[0].(uint64)
@@ -203,13 +203,13 @@ func (m *MocksvmState) GetNonce(arg0 types.Address) (uint64, error) {
 }
 
 // GetNonce indicates an expected call of GetNonce.
-func (mr *MocksvmStateMockRecorder) GetNonce(arg0 interface{}) *gomock.Call {
+func (mr *MockvmStateMockRecorder) GetNonce(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNonce", reflect.TypeOf((*MocksvmState)(nil).GetNonce), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNonce", reflect.TypeOf((*MockvmState)(nil).GetNonce), arg0)
 }
 
 // GetStateRoot mocks base method.
-func (m *MocksvmState) GetStateRoot() (types.Hash32, error) {
+func (m *MockvmState) GetStateRoot() (types.Hash32, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetStateRoot")
 	ret0, _ := ret[0].(types.Hash32)
@@ -218,13 +218,13 @@ func (m *MocksvmState) GetStateRoot() (types.Hash32, error) {
 }
 
 // GetStateRoot indicates an expected call of GetStateRoot.
-func (mr *MocksvmStateMockRecorder) GetStateRoot() *gomock.Call {
+func (mr *MockvmStateMockRecorder) GetStateRoot() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStateRoot", reflect.TypeOf((*MocksvmState)(nil).GetStateRoot))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStateRoot", reflect.TypeOf((*MockvmState)(nil).GetStateRoot))
 }
 
 // Revert mocks base method.
-func (m *MocksvmState) Revert(arg0 types.LayerID) (types.Hash32, error) {
+func (m *MockvmState) Revert(arg0 types.LayerID) (types.Hash32, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Revert", arg0)
 	ret0, _ := ret[0].(types.Hash32)
@@ -233,9 +233,9 @@ func (m *MocksvmState) Revert(arg0 types.LayerID) (types.Hash32, error) {
 }
 
 // Revert indicates an expected call of Revert.
-func (mr *MocksvmStateMockRecorder) Revert(arg0 interface{}) *gomock.Call {
+func (mr *MockvmStateMockRecorder) Revert(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Revert", reflect.TypeOf((*MocksvmState)(nil).Revert), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Revert", reflect.TypeOf((*MockvmState)(nil).Revert), arg0)
 }
 
 // MockconStateCache is a mock of conStateCache interface.


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
fixes many issues observed from running latest develop with devnet 221 (without conservative cache)
<!-- `Closes #XXXX, closes #XXXX, ...` links mentioned issues to this PR and automatically closes them when this it's merged -->

## Changes
<!-- Please describe in detail the changes made -->
- fixed bug where discarding invalid nonce after applying txs for an account overwriting previously applied TXs
- failures adding txs to conservative cache during gossip should not failed p2p propagation
- failures adding txs to conservative cache during sync should not fail the syncer run
- fixes panic with stack trace
```
github.com/spacemeshos/go-spacemesh/txs.(*accountCache).shouldEvict(...)
	/home/dd/go-spacemesh/txs/cache.go:491
github.com/spacemeshos/go-spacemesh/txs.(*cache).cleanupAccounts(0xc0006b61e0, 0xc0009f72a4?)
	/home/dd/go-spacemesh/txs/cache.go:603 +0xc8
github.com/spacemeshos/go-spacemesh/txs.(*cache).BuildFromScratch(0xc0006b61e0)
	/home/dd/go-spacemesh/txs/cache.go:562 +0x71f
```
- relax failure condition on too many nonce for an account. it's not an error. we just need to get them from DB when there is room (earlier nonce being applied)
- distinguish between warning and failure for `cache.ApplyLayer`
- txs that failed VM previously should not be applied to conservative cache
- fix linter version so it doesn't create sudden surprise

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->
unit tests, systest, manual testing

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
