### PR TITLE
[Merged by Bors] - systest: deflake timeskew test by preventing it from failing beacon

### DIFF
--- a/systest/tests/timeskew_test.go
+++ b/systest/tests/timeskew_test.go
@@ -16,6 +16,9 @@ import (
 func TestShortTimeskew(t *testing.T) {
 	const (
 		enableSkew = 9
+		// the chaos needs to end before the first layer
+		// of the next epoch. otherwise it may cause beacon protocol
+		// to fail. and it will take longer time to recover from that
 		stopSkew   = enableSkew + 2
 		stopTest   = stopSkew + 5
 		skewOffset = "-3s" // hare round is 2s

--- a/systest/tests/timeskew_test.go
+++ b/systest/tests/timeskew_test.go
@@ -15,8 +15,8 @@ import (
 
 func TestShortTimeskew(t *testing.T) {
 	const (
-		enableSkew = 10
-		stopSkew   = enableSkew + 3
+		enableSkew = 9
+		stopSkew   = enableSkew + 2
 		stopTest   = stopSkew + 5
 		skewOffset = "-3s" // hare round is 2s
 	)


### PR DESCRIPTION
closes https://github.com/spacemeshos/go-spacemesh/issues/3188

chaos is stopped in the last layer of the epoch so that it won't affect beacon, recovery from beacon failures take longer and wasn't the goal of this test. 