### PR TITLE
[Merged by Bors] - layerfetcher: fail tx hashes fetch when at least 1 fails

### DIFF
--- a/common/types/activation.go
+++ b/common/types/activation.go
@@ -350,8 +350,26 @@ func IsProcessingError(err error) bool {
 	return ok
 }
 
+// ToATXIDs returns a slice of ATXID corresponding to the given activation tx.
+func ToATXIDs(atxs []*ActivationTx) []ATXID {
+	ids := make([]ATXID, 0, len(atxs))
+	for _, atx := range atxs {
+		ids = append(ids, atx.ID())
+	}
+	return ids
+}
+
 // SortAtxIDs sorts a list of atx IDs in lexicographic order, in-place.
 func SortAtxIDs(ids []ATXID) []ATXID {
 	sort.Slice(ids, func(i, j int) bool { return ids[i].Compare(ids[j]) })
 	return ids
+}
+
+// ATXIDsToHashes turns a list of ATXID into their Hash32 representation.
+func ATXIDsToHashes(ids []ATXID) []Hash32 {
+	hashes := make([]Hash32, 0, len(ids))
+	for _, id := range ids {
+		hashes = append(hashes, id.Hash32())
+	}
+	return hashes
 }

--- a/common/types/transaction.go
+++ b/common/types/transaction.go
@@ -174,6 +174,15 @@ func SortTransactionIDs(ids []TransactionID) []TransactionID {
 	return ids
 }
 
+// TransactionIDsToHashes turns a list of TransactionID into their Hash32 representation.
+func TransactionIDsToHashes(ids []TransactionID) []Hash32 {
+	hashes := make([]Hash32, 0, len(ids))
+	for _, id := range ids {
+		hashes = append(hashes, id.Hash32())
+	}
+	return hashes
+}
+
 // TXState describes the state of a transaction.
 type TXState int
 


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
Closes #3139
<!-- `Closes #XXXX, closes #XXXX, ...` links mentioned issues to this PR and automatically closes them when this it's merged -->

## Changes
<!-- Please describe in detail the changes made -->
- fail tx hashes fetch when any of them fails
- change atx/tx to share the same code with ballot/proposal/ballots in layerfetcher and add tests

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
