### PR TITLE
[Merged by Bors] - tx selection: proposal/block construction

### DIFF
--- a/api/grpcserver/grpcserver_test.go
+++ b/api/grpcserver/grpcserver_test.go
@@ -60,7 +60,7 @@ const (
 	genTimeUnix      = 1000000
 	layerDurationSec = 10
 	layerAvgSize     = 10
-	txsPerBlock      = 99
+	txsPerProposal   = 99
 	layersPerEpoch   = uint32(5)
 	networkID        = 120
 	atxPerLayer      = 2
@@ -1081,7 +1081,7 @@ func TestSmesherService(t *testing.T) {
 
 func TestMeshService(t *testing.T) {
 	logtest.SetupGlobal(t)
-	grpcService := NewMeshService(meshAPI, conStateAPI, &genTime, layersPerEpoch, networkID, layerDurationSec, layerAvgSize, txsPerBlock)
+	grpcService := NewMeshService(meshAPI, conStateAPI, &genTime, layersPerEpoch, networkID, layerDurationSec, layerAvgSize, txsPerProposal)
 	shutDown := launchServer(t, grpcService)
 	defer shutDown()
 
@@ -1135,7 +1135,7 @@ func TestMeshService(t *testing.T) {
 			logtest.SetupGlobal(t)
 			response, err := c.MaxTransactionsPerSecond(context.Background(), &pb.MaxTransactionsPerSecondRequest{})
 			require.NoError(t, err)
-			require.Equal(t, uint64(layerAvgSize*txsPerBlock/layerDurationSec), response.MaxTxsPerSecond.Value)
+			require.Equal(t, uint64(layerAvgSize*txsPerProposal/layerDurationSec), response.MaxTxsPerSecond.Value)
 		}},
 		{"AccountMeshDataQuery", func(t *testing.T) {
 			logtest.SetupGlobal(t)
@@ -2112,7 +2112,7 @@ func checkLayer(t *testing.T, l *pb.Layer) {
 
 func TestAccountMeshDataStream_comprehensive(t *testing.T) {
 	logtest.SetupGlobal(t)
-	grpcService := NewMeshService(meshAPI, conStateAPI, &genTime, layersPerEpoch, networkID, layerDurationSec, layerAvgSize, txsPerBlock)
+	grpcService := NewMeshService(meshAPI, conStateAPI, &genTime, layersPerEpoch, networkID, layerDurationSec, layerAvgSize, txsPerProposal)
 	shutDown := launchServer(t, grpcService)
 	defer shutDown()
 
@@ -2446,7 +2446,7 @@ func TestLayerStream_comprehensive(t *testing.T) {
 	}
 	logtest.SetupGlobal(t)
 
-	grpcService := NewMeshService(meshAPI, conStateAPI, &genTime, layersPerEpoch, networkID, layerDurationSec, layerAvgSize, txsPerBlock)
+	grpcService := NewMeshService(meshAPI, conStateAPI, &genTime, layersPerEpoch, networkID, layerDurationSec, layerAvgSize, txsPerProposal)
 	shutDown := launchServer(t, grpcService)
 	defer shutDown()
 
@@ -2680,7 +2680,7 @@ func TestMultiService(t *testing.T) {
 	logtest.SetupGlobal(t)
 	cfg.GrpcServerPort = 9192
 	svc1 := NewNodeService(&networkMock, meshAPI, &genTime, &SyncerMock{}, &ActivationAPIMock{})
-	svc2 := NewMeshService(meshAPI, conStateAPI, &genTime, layersPerEpoch, networkID, layerDurationSec, layerAvgSize, txsPerBlock)
+	svc2 := NewMeshService(meshAPI, conStateAPI, &genTime, layersPerEpoch, networkID, layerDurationSec, layerAvgSize, txsPerProposal)
 	shutDown := launchServer(t, svc1, svc2)
 	defer shutDown()
 
@@ -2742,7 +2742,7 @@ func TestJsonApi(t *testing.T) {
 
 	// enable services and try again
 	svc1 := NewNodeService(&networkMock, meshAPI, &genTime, &SyncerMock{}, &ActivationAPIMock{})
-	svc2 := NewMeshService(meshAPI, conStateAPI, &genTime, layersPerEpoch, networkID, layerDurationSec, layerAvgSize, txsPerBlock)
+	svc2 := NewMeshService(meshAPI, conStateAPI, &genTime, layersPerEpoch, networkID, layerDurationSec, layerAvgSize, txsPerProposal)
 	cfg.StartNodeService = true
 	cfg.StartMeshService = true
 	shutDown = launchServer(t, svc1, svc2)

--- a/api/grpcserver/grpcserver_test.go
+++ b/api/grpcserver/grpcserver_test.go
@@ -2975,7 +2975,7 @@ func TestEventsReceived(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 	lg := logtest.New(t).WithName("svm")
 	svm := vm.New(lg, sql.InMemory())
-	conState := txs.NewConservativeState(svm, sql.InMemory(), logtest.New(t).WithName("conState"))
+	conState := txs.NewConservativeState(svm, sql.InMemory(), txs.WithLogger(logtest.New(t).WithName("conState")))
 	conState.AddToCache(globalTx, true)
 	time.Sleep(100 * time.Millisecond)
 

--- a/api/grpcserver/mesh_service.go
+++ b/api/grpcserver/mesh_service.go
@@ -23,7 +23,7 @@ type MeshService struct {
 	networkID        uint32
 	layerDurationSec int
 	layerAvgSize     int
-	txsPerBlock      int
+	txsPerProposal   int
 }
 
 // RegisterService registers this service with a grpc server instance.
@@ -35,7 +35,7 @@ func (s MeshService) RegisterService(server *Server) {
 func NewMeshService(
 	msh api.MeshAPI, cstate api.ConservativeState, genTime api.GenesisTimeAPI,
 	layersPerEpoch uint32, networkID uint32, layerDurationSec int,
-	layerAvgSize int, txsPerBlock int,
+	layerAvgSize int, txsPerProposal int,
 ) *MeshService {
 	return &MeshService{
 		mesh:             msh,
@@ -45,7 +45,7 @@ func NewMeshService(
 		networkID:        networkID,
 		layerDurationSec: layerDurationSec,
 		layerAvgSize:     layerAvgSize,
-		txsPerBlock:      txsPerBlock,
+		txsPerProposal:   txsPerProposal,
 	}
 }
 
@@ -102,7 +102,7 @@ func (s MeshService) LayerDuration(context.Context, *pb.LayerDurationRequest) (*
 func (s MeshService) MaxTransactionsPerSecond(context.Context, *pb.MaxTransactionsPerSecondRequest) (*pb.MaxTransactionsPerSecondResponse, error) {
 	log.Info("GRPC MeshService.MaxTransactionsPerSecond")
 	return &pb.MaxTransactionsPerSecondResponse{MaxTxsPerSecond: &pb.SimpleInt{
-		Value: uint64(s.txsPerBlock * s.layerAvgSize / s.layerDurationSec),
+		Value: uint64(s.txsPerProposal * s.layerAvgSize / s.layerDurationSec),
 	}}, nil
 }
 

--- a/blocks/generator_test.go
+++ b/blocks/generator_test.go
@@ -31,35 +31,33 @@ func testConfig() Config {
 
 type testGenerator struct {
 	*Generator
-	ctrl      *gomock.Controller
-	mockMesh  *mocks.MockmeshProvider
-	mockATXDB *mocks.MockatxProvider
-	mockTXs   *mocks.MocktxProvider
+	ctrl       *gomock.Controller
+	mockMesh   *mocks.MockmeshProvider
+	mockATXDB  *mocks.MockatxProvider
+	mockCState *mocks.MockconservativeState
 }
 
 func createTestGenerator(t *testing.T) *testGenerator {
 	ctrl := gomock.NewController(t)
 	tg := &testGenerator{
-		ctrl:      ctrl,
-		mockMesh:  mocks.NewMockmeshProvider(ctrl),
-		mockATXDB: mocks.NewMockatxProvider(ctrl),
-		mockTXs:   mocks.NewMocktxProvider(ctrl),
+		ctrl:       ctrl,
+		mockMesh:   mocks.NewMockmeshProvider(ctrl),
+		mockATXDB:  mocks.NewMockatxProvider(ctrl),
+		mockCState: mocks.NewMockconservativeState(ctrl),
 	}
-	tg.Generator = NewGenerator(tg.mockATXDB, tg.mockMesh, tg.mockTXs, WithGeneratorLogger(logtest.New(t)), WithConfig(testConfig()))
+	tg.Generator = NewGenerator(tg.mockATXDB, tg.mockMesh, tg.mockCState, WithGeneratorLogger(logtest.New(t)), WithConfig(testConfig()))
 	return tg
 }
 
-func createTransactions(t testing.TB, numOfTxs int) ([]types.TransactionID, []*types.MeshTransaction) {
+func createTransactions(t testing.TB, numOfTxs int) []types.TransactionID {
 	t.Helper()
-	txs := make([]*types.MeshTransaction, 0, numOfTxs)
 	txIDs := make([]types.TransactionID, 0, numOfTxs)
 	for i := 0; i < numOfTxs; i++ {
 		tx, err := transaction.GenerateCallTransaction(signing.NewEdSigner(), types.HexToAddress("1"), 1, 10, 100, 3)
 		require.NoError(t, err)
-		txs = append(txs, &types.MeshTransaction{Transaction: *tx})
 		txIDs = append(txIDs, tx.ID())
 	}
-	return txIDs, txs
+	return txIDs
 }
 
 func createATXs(t *testing.T, numATXs int) ([]*signing.EdSigner, []*types.ActivationTx, map[types.ATXID]*types.ActivationTx) {
@@ -127,21 +125,29 @@ func createProposal(t *testing.T, epochData *types.EpochData, lid types.LayerID,
 	return p
 }
 
+func checkRewards(t *testing.T, atxs []*types.ActivationTx, expWeightPer util.Weight, rewards []types.AnyReward) {
+	t.Helper()
+	sort.Slice(atxs, func(i, j int) bool {
+		return bytes.Compare(atxs[i].Coinbase.Bytes(), atxs[j].Coinbase.Bytes()) < 0
+	})
+	for i, r := range rewards {
+		require.Equal(t, atxs[i].Coinbase, r.Coinbase)
+		got := util.WeightFromNumDenom(r.Weight.Num, r.Weight.Denom)
+		require.Equal(t, expWeightPer, got)
+	}
+}
+
 func Test_GenerateBlock(t *testing.T) {
 	tg := createTestGenerator(t)
 	layerID := types.GetEffectiveGenesis().Add(100)
 	// create multiple proposals with overlapping TXs
 	numTXs := 1000
 	numProposals := 10
-	txIDs, txs := createTransactions(t, numTXs)
+	txIDs := createTransactions(t, numTXs)
 	signers, atxs, atxByID := createATXs(t, numProposals)
 	activeSet := types.ToATXIDs(atxs)
 	proposals := createProposals(t, layerID, signers, activeSet, txIDs)
-	tg.mockTXs.EXPECT().GetMeshTransactions(gomock.Any()).DoAndReturn(
-		func(got []types.TransactionID) ([]*types.MeshTransaction, map[types.TransactionID]struct{}) {
-			require.ElementsMatch(t, got, txIDs)
-			return txs, nil
-		}).Times(1)
+	tg.mockCState.EXPECT().SelectBlockTXs(layerID, proposals).Return(txIDs, nil)
 	tg.mockATXDB.EXPECT().GetAtxHeader(gomock.Any()).DoAndReturn(
 		func(id types.ATXID) (*types.ActivationTxHeader, error) {
 			return atxByID[id].ActivationTxHeader, nil
@@ -153,18 +159,43 @@ func Test_GenerateBlock(t *testing.T) {
 	require.Equal(t, layerID, block.LayerIndex)
 	require.Len(t, block.TxIDs, numTXs)
 	require.Len(t, block.Rewards, numProposals)
-	sort.Slice(proposals, func(i, j int) bool {
-		cbi := types.BytesToAddress(proposals[i].SmesherID().Bytes())
-		cbj := types.BytesToAddress(proposals[j].SmesherID().Bytes())
-		return bytes.Compare(cbi.Bytes(), cbj.Bytes()) < 0
-	})
-	for i, r := range block.Rewards {
-		require.Equal(t, types.BytesToAddress(proposals[i].SmesherID().Bytes()), r.Coinbase)
-		got := util.WeightFromNumDenom(r.Weight.Num, r.Weight.Denom)
-		// numUint is the ATX weight. eligible slots per epoch is 3 for each atx, each proposal has 1 eligibility
-		// the expected weight for each eligibility is `numUnit` * 1/3
-		require.Equal(t, util.WeightFromInt64(numUint*1/3), got)
+	// numUint is the ATX weight. eligible slots per epoch is 3 for each atx, each proposal has 1 eligibility
+	// the expected weight for each eligibility is `numUnit` * 1/3
+	expWeight := util.WeightFromInt64(numUint * 1 / 3)
+	checkRewards(t, atxs, expWeight, block.Rewards)
+}
+
+func Test_GenerateBlock_EmptyProposals(t *testing.T) {
+	tg := createTestGenerator(t)
+	numProposals := 10
+	signers, atxs, atxByID := createATXs(t, numProposals)
+	activeSet := types.ToATXIDs(atxs)
+	epochData := &types.EpochData{
+		ActiveSet: activeSet,
+		Beacon:    types.RandomBeacon(),
 	}
+	lid := types.GetEffectiveGenesis().Add(2)
+	proposals := make([]*types.Proposal, 0, numProposals)
+	for i := 0; i < numProposals; i++ {
+		p := createProposal(t, epochData, lid, activeSet[i], signers[i], nil, 1)
+		proposals = append(proposals, p)
+	}
+	tg.mockCState.EXPECT().SelectBlockTXs(lid, proposals).Return(nil, nil)
+	tg.mockATXDB.EXPECT().GetAtxHeader(gomock.Any()).DoAndReturn(
+		func(id types.ATXID) (*types.ActivationTxHeader, error) {
+			return atxByID[id].ActivationTxHeader, nil
+		}).AnyTimes()
+	block, err := tg.GenerateBlock(context.TODO(), lid, proposals)
+	require.NoError(t, err)
+	require.NotEqual(t, types.EmptyBlockID, block.ID())
+
+	require.Equal(t, lid, block.LayerIndex)
+	require.Empty(t, block.TxIDs)
+	require.Len(t, block.Rewards, numProposals)
+	// numUint is the ATX weight. eligible slots per epoch is 3 for each atx, each proposal has 1 eligibility
+	// the expected weight for each eligibility is `numUnit` * 1/3
+	expWeight := util.WeightFromInt64(numUint * 1 / 3)
+	checkRewards(t, atxs, expWeight, block.Rewards)
 }
 
 func Test_GenerateBlockStableBlockID(t *testing.T) {
@@ -173,15 +204,11 @@ func Test_GenerateBlockStableBlockID(t *testing.T) {
 	// create multiple proposals with overlapping TXs
 	numTXs := 1000
 	numProposals := 10
-	txIDs, txs := createTransactions(t, numTXs)
+	txIDs := createTransactions(t, numTXs)
 	signers, atxs, atxByID := createATXs(t, numProposals)
 	activeSet := types.ToATXIDs(atxs)
 	proposals := createProposals(t, layerID, signers, activeSet, txIDs)
-	tg.mockTXs.EXPECT().GetMeshTransactions(gomock.Any()).DoAndReturn(
-		func(got []types.TransactionID) ([]*types.MeshTransaction, map[types.TransactionID]struct{}) {
-			require.ElementsMatch(t, got, txIDs)
-			return txs, nil
-		}).Times(2)
+	tg.mockCState.EXPECT().SelectBlockTXs(layerID, proposals).Return(txIDs, nil)
 	tg.mockATXDB.EXPECT().GetAtxHeader(gomock.Any()).DoAndReturn(
 		func(id types.ATXID) (*types.ActivationTxHeader, error) {
 			return atxByID[id].ActivationTxHeader, nil
@@ -196,6 +223,7 @@ func Test_GenerateBlockStableBlockID(t *testing.T) {
 	ordered := proposals[numProposals/2 : numProposals]
 	ordered = append(ordered, proposals[0:numProposals/2]...)
 	require.NotEqual(t, proposals, ordered)
+	tg.mockCState.EXPECT().SelectBlockTXs(layerID, ordered).Return(txIDs, nil)
 	block2, err := tg.GenerateBlock(context.TODO(), layerID, ordered)
 	require.NoError(t, err)
 	require.Equal(t, block, block2)
@@ -207,7 +235,7 @@ func Test_GenerateBlock_SameCoinbase(t *testing.T) {
 	layerID := types.GetEffectiveGenesis().Add(100)
 	numTXs := 1000
 	numProposals := 10
-	txIDs, txs := createTransactions(t, numTXs)
+	txIDs := createTransactions(t, numTXs)
 	signers, atxs, atxByID := createATXs(t, numProposals)
 	activeSet := types.ToATXIDs(atxs)
 	epochData := &types.EpochData{
@@ -217,30 +245,24 @@ func Test_GenerateBlock_SameCoinbase(t *testing.T) {
 	atxID := activeSet[0]
 	proposal1 := createProposal(t, epochData, layerID, atxID, signers[0], txIDs[0:500], 1)
 	proposal2 := createProposal(t, epochData, layerID, atxID, signers[0], txIDs[400:], 1)
-
-	tg.mockTXs.EXPECT().GetMeshTransactions(gomock.Any()).DoAndReturn(
-		func(got []types.TransactionID) ([]*types.MeshTransaction, map[types.TransactionID]struct{}) {
-			require.ElementsMatch(t, got, txIDs)
-			return txs, nil
-		}).Times(1)
+	proposals := []*types.Proposal{proposal1, proposal2}
+	tg.mockCState.EXPECT().SelectBlockTXs(layerID, proposals).Return(txIDs, nil)
 	tg.mockATXDB.EXPECT().GetAtxHeader(gomock.Any()).DoAndReturn(
 		func(id types.ATXID) (*types.ActivationTxHeader, error) {
 			return atxByID[id].ActivationTxHeader, nil
 		}).AnyTimes()
-	block, err := tg.GenerateBlock(context.TODO(), layerID, []*types.Proposal{proposal1, proposal2})
+	block, err := tg.GenerateBlock(context.TODO(), layerID, proposals)
 	require.NoError(t, err)
 	require.NotEqual(t, types.EmptyBlockID, block.ID())
 
 	require.Equal(t, layerID, block.LayerIndex)
 	require.Len(t, block.TxIDs, numTXs)
-	require.Len(t, block.Rewards, 1)
-	r := block.Rewards[0]
-	require.Equal(t, atxs[0].Coinbase, r.Coinbase)
-	got := util.WeightFromNumDenom(r.Weight.Num, r.Weight.Denom)
+
 	// numUint is the ATX weight. eligible slots per epoch is 3 for each atx, each proposal has 1 eligibility
 	// the expected weight for each eligibility is `numUnit` * 1/3
 	// since there are two proposals for the same coinbase, the final weight is `numUnit` * 1/3 * 2
-	require.Equal(t, util.WeightFromInt64(numUint*1/3*2), got)
+	expWeight := util.WeightFromInt64(numUint * 1 / 3 * 2)
+	checkRewards(t, atxs[0:1], expWeight, block.Rewards)
 }
 
 func Test_GenerateBlock_EmptyATXID(t *testing.T) {
@@ -249,7 +271,7 @@ func Test_GenerateBlock_EmptyATXID(t *testing.T) {
 	// create multiple proposals with overlapping TXs
 	numTXs := 1000
 	numProposals := 10
-	txIDs, txs := createTransactions(t, numTXs)
+	txIDs := createTransactions(t, numTXs)
 	signers, atxs, atxByID := createATXs(t, numProposals)
 	activeSet := types.ToATXIDs(atxs)
 	proposals := createProposals(t, layerID, signers, activeSet, txIDs)
@@ -257,11 +279,7 @@ func Test_GenerateBlock_EmptyATXID(t *testing.T) {
 	types.SortProposals(proposals)
 	proposals[numProposals-1].AtxID = *types.EmptyATXID
 
-	tg.mockTXs.EXPECT().GetMeshTransactions(gomock.Any()).DoAndReturn(
-		func(got []types.TransactionID) ([]*types.MeshTransaction, map[types.TransactionID]struct{}) {
-			require.ElementsMatch(t, got, txIDs)
-			return txs, nil
-		}).Times(1)
+	tg.mockCState.EXPECT().SelectBlockTXs(layerID, proposals).Return(txIDs, nil)
 	tg.mockATXDB.EXPECT().GetAtxHeader(gomock.Any()).DoAndReturn(
 		func(id types.ATXID) (*types.ActivationTxHeader, error) {
 			return atxByID[id].ActivationTxHeader, nil
@@ -277,15 +295,11 @@ func Test_GenerateBlock_ATXNotFound(t *testing.T) {
 	// create multiple proposals with overlapping TXs
 	numTXs := 1000
 	numProposals := 10
-	txIDs, txs := createTransactions(t, numTXs)
+	txIDs := createTransactions(t, numTXs)
 	signers, atxs, atxByID := createATXs(t, numProposals)
 	activeSet := types.ToATXIDs(atxs)
 	proposals := createProposals(t, layerID, signers, activeSet, txIDs)
-	tg.mockTXs.EXPECT().GetMeshTransactions(gomock.Any()).DoAndReturn(
-		func(got []types.TransactionID) ([]*types.MeshTransaction, map[types.TransactionID]struct{}) {
-			require.ElementsMatch(t, got, txIDs)
-			return txs, nil
-		}).Times(1)
+	tg.mockCState.EXPECT().SelectBlockTXs(layerID, proposals).Return(txIDs, nil)
 	errUnknown := errors.New("unknown")
 	tg.mockATXDB.EXPECT().GetAtxHeader(gomock.Any()).DoAndReturn(
 		func(id types.ATXID) (*types.ActivationTxHeader, error) {
@@ -299,30 +313,10 @@ func Test_GenerateBlock_ATXNotFound(t *testing.T) {
 	require.Nil(t, block)
 }
 
-func Test_GenerateBlock_TXNotFound(t *testing.T) {
-	tg := createTestGenerator(t)
-	layerID := types.GetEffectiveGenesis().Add(100)
-	// create multiple proposals with overlapping TXs
-	numTXs := 1000
-	numProposals := 10
-	txIDs, txs := createTransactions(t, numTXs)
-	signers, atxs, _ := createATXs(t, numProposals)
-	activeSet := types.ToATXIDs(atxs)
-	proposals := createProposals(t, layerID, signers, activeSet, txIDs)
-	tg.mockTXs.EXPECT().GetMeshTransactions(gomock.Any()).DoAndReturn(
-		func(got []types.TransactionID) ([]*types.MeshTransaction, map[types.TransactionID]struct{}) {
-			require.ElementsMatch(t, got, txIDs)
-			return txs[1:], map[types.TransactionID]struct{}{txs[0].ID(): {}}
-		}).Times(1)
-	block, err := tg.GenerateBlock(context.TODO(), layerID, proposals)
-	require.ErrorIs(t, err, errTXNotFound)
-	require.Nil(t, block)
-}
-
 func Test_GenerateBlock_MultipleEligibilities(t *testing.T) {
 	tg := createTestGenerator(t)
 	layerID := types.GetEffectiveGenesis().Add(100)
-	ids, txs := createTransactions(t, 1000)
+	ids := createTransactions(t, 1000)
 	signers, atxs, atxByID := createATXs(t, 10)
 	activeSet := types.ToATXIDs(atxs)
 	epochData := &types.EpochData{
@@ -335,7 +329,7 @@ func Test_GenerateBlock_MultipleEligibilities(t *testing.T) {
 		createProposal(t, epochData, layerID, atxs[2].ID(), signers[2], ids, 5),
 	}
 
-	tg.mockTXs.EXPECT().GetMeshTransactions(gomock.Any()).Return(txs, nil).Times(1)
+	tg.mockCState.EXPECT().SelectBlockTXs(layerID, proposals).Return(ids, nil)
 	tg.mockATXDB.EXPECT().GetAtxHeader(gomock.Any()).DoAndReturn(
 		func(id types.ATXID) (*types.ActivationTxHeader, error) {
 			return atxByID[id].ActivationTxHeader, nil

--- a/blocks/handler_test.go
+++ b/blocks/handler_test.go
@@ -52,7 +52,7 @@ func createBlockData(t *testing.T, layerID types.LayerID, txIDs []types.Transact
 func Test_HandleBlockData_MalformedData(t *testing.T) {
 	th := createTestHandler(t)
 	layerID := types.NewLayerID(99)
-	txIDs, _ := createTransactions(t, max(10, rand.Intn(100)))
+	txIDs := createTransactions(t, max(10, rand.Intn(100)))
 
 	_, data := createBlockData(t, layerID, txIDs)
 	assert.ErrorIs(t, th.HandleBlockData(context.TODO(), data[1:]), errMalformedData)
@@ -61,7 +61,7 @@ func Test_HandleBlockData_MalformedData(t *testing.T) {
 func Test_HandleBlockData_AlreadyHasBlock(t *testing.T) {
 	th := createTestHandler(t)
 	layerID := types.NewLayerID(99)
-	txIDs, _ := createTransactions(t, max(10, rand.Intn(100)))
+	txIDs := createTransactions(t, max(10, rand.Intn(100)))
 
 	block, data := createBlockData(t, layerID, txIDs)
 	th.mockMesh.EXPECT().HasBlock(block.ID()).Return(true).Times(1)
@@ -71,7 +71,7 @@ func Test_HandleBlockData_AlreadyHasBlock(t *testing.T) {
 func Test_HandleBlockData_FailedToFetchTXs(t *testing.T) {
 	th := createTestHandler(t)
 	layerID := types.NewLayerID(99)
-	txIDs, _ := createTransactions(t, max(10, rand.Intn(100)))
+	txIDs := createTransactions(t, max(10, rand.Intn(100)))
 
 	block, data := createBlockData(t, layerID, txIDs)
 	th.mockMesh.EXPECT().HasBlock(block.ID()).Return(false).Times(1)
@@ -83,7 +83,7 @@ func Test_HandleBlockData_FailedToFetchTXs(t *testing.T) {
 func Test_HandleBlockData_FailedToAddBlock(t *testing.T) {
 	th := createTestHandler(t)
 	layerID := types.NewLayerID(99)
-	txIDs, _ := createTransactions(t, max(10, rand.Intn(100)))
+	txIDs := createTransactions(t, max(10, rand.Intn(100)))
 
 	block, data := createBlockData(t, layerID, txIDs)
 	th.mockMesh.EXPECT().HasBlock(block.ID()).Return(false).Times(1)
@@ -96,7 +96,7 @@ func Test_HandleBlockData_FailedToAddBlock(t *testing.T) {
 func Test_HandleBlockData(t *testing.T) {
 	th := createTestHandler(t)
 	layerID := types.NewLayerID(99)
-	txIDs, _ := createTransactions(t, max(10, rand.Intn(100)))
+	txIDs := createTransactions(t, max(10, rand.Intn(100)))
 
 	block, data := createBlockData(t, layerID, txIDs)
 	th.mockMesh.EXPECT().HasBlock(block.ID()).Return(false).Times(1)

--- a/blocks/interface.go
+++ b/blocks/interface.go
@@ -18,6 +18,6 @@ type meshProvider interface {
 	GetBallot(types.BallotID) (*types.Ballot, error)
 }
 
-type txProvider interface {
-	GetMeshTransactions([]types.TransactionID) ([]*types.MeshTransaction, map[types.TransactionID]struct{})
+type conservativeState interface {
+	SelectBlockTXs(types.LayerID, []*types.Proposal) ([]types.TransactionID, error)
 }

--- a/blocks/mocks/mocks.go
+++ b/blocks/mocks/mocks.go
@@ -116,40 +116,40 @@ func (mr *MockmeshProviderMockRecorder) HasBlock(arg0 interface{}) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasBlock", reflect.TypeOf((*MockmeshProvider)(nil).HasBlock), arg0)
 }
 
-// MocktxProvider is a mock of txProvider interface.
-type MocktxProvider struct {
+// MockconservativeState is a mock of conservativeState interface.
+type MockconservativeState struct {
 	ctrl     *gomock.Controller
-	recorder *MocktxProviderMockRecorder
+	recorder *MockconservativeStateMockRecorder
 }
 
-// MocktxProviderMockRecorder is the mock recorder for MocktxProvider.
-type MocktxProviderMockRecorder struct {
-	mock *MocktxProvider
+// MockconservativeStateMockRecorder is the mock recorder for MockconservativeState.
+type MockconservativeStateMockRecorder struct {
+	mock *MockconservativeState
 }
 
-// NewMocktxProvider creates a new mock instance.
-func NewMocktxProvider(ctrl *gomock.Controller) *MocktxProvider {
-	mock := &MocktxProvider{ctrl: ctrl}
-	mock.recorder = &MocktxProviderMockRecorder{mock}
+// NewMockconservativeState creates a new mock instance.
+func NewMockconservativeState(ctrl *gomock.Controller) *MockconservativeState {
+	mock := &MockconservativeState{ctrl: ctrl}
+	mock.recorder = &MockconservativeStateMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MocktxProvider) EXPECT() *MocktxProviderMockRecorder {
+func (m *MockconservativeState) EXPECT() *MockconservativeStateMockRecorder {
 	return m.recorder
 }
 
-// GetMeshTransactions mocks base method.
-func (m *MocktxProvider) GetMeshTransactions(arg0 []types.TransactionID) ([]*types.MeshTransaction, map[types.TransactionID]struct{}) {
+// SelectBlockTXs mocks base method.
+func (m *MockconservativeState) SelectBlockTXs(arg0 types.LayerID, arg1 []*types.Proposal) ([]types.TransactionID, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMeshTransactions", arg0)
-	ret0, _ := ret[0].([]*types.MeshTransaction)
-	ret1, _ := ret[1].(map[types.TransactionID]struct{})
+	ret := m.ctrl.Call(m, "SelectBlockTXs", arg0, arg1)
+	ret0, _ := ret[0].([]types.TransactionID)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetMeshTransactions indicates an expected call of GetMeshTransactions.
-func (mr *MocktxProviderMockRecorder) GetMeshTransactions(arg0 interface{}) *gomock.Call {
+// SelectBlockTXs indicates an expected call of SelectBlockTXs.
+func (mr *MockconservativeStateMockRecorder) SelectBlockTXs(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMeshTransactions", reflect.TypeOf((*MocktxProvider)(nil).GetMeshTransactions), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SelectBlockTXs", reflect.TypeOf((*MockconservativeState)(nil).SelectBlockTXs), arg0, arg1)
 }

--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -622,7 +622,7 @@ func (app *App) initServices(ctx context.Context,
 		newSyncer,
 		app.conState,
 		miner.WithMinerID(nodeID),
-		miner.WithTxsPerProposal(app.Config.TxsPerBlock),
+		miner.WithTxsPerProposal(app.Config.TxsPerProposal),
 		miner.WithLayerSize(layerSize),
 		miner.WithLayerPerEpoch(layersPerEpoch),
 		miner.WithLogger(app.addLogger(ProposalBuilderLogger, lg)))
@@ -814,7 +814,7 @@ func (app *App) startAPIServices(ctx context.Context) {
 		registerService(grpcserver.NewGlobalStateService(app.mesh, app.conState))
 	}
 	if apiConf.StartMeshService {
-		registerService(grpcserver.NewMeshService(app.mesh, app.conState, app.clock, app.Config.LayersPerEpoch, app.Config.P2P.NetworkID, layerDuration, app.Config.LayerAvgSize, app.Config.TxsPerBlock))
+		registerService(grpcserver.NewMeshService(app.mesh, app.conState, app.clock, app.Config.LayersPerEpoch, app.Config.P2P.NetworkID, layerDuration, app.Config.LayerAvgSize, app.Config.TxsPerProposal))
 	}
 	if apiConf.StartNodeService {
 		nodeService := grpcserver.NewNodeService(app.host, app.mesh, app.clock, app.syncer, app.atxBuilder)

--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -491,8 +491,9 @@ func (app *App) initServices(ctx context.Context,
 	state := vm.New(app.addLogger(SVMLogger, lg), sqlDB)
 	app.conState = txs.NewConservativeState(state, sqlDB,
 		txs.WithCSConfig(txs.CSConfig{
-			BlockGasLimit:     app.Config.BlockGasLimit,
-			NumTXsPerProposal: app.Config.TxsPerProposal,
+			BlockGasLimit:      app.Config.BlockGasLimit,
+			NumTXsPerProposal:  app.Config.TxsPerProposal,
+			OptFilterThreshold: app.Config.OptFilterThreshold,
 		}),
 		txs.WithLogger(app.addLogger(ConStateLogger, lg)))
 

--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -489,7 +489,12 @@ func (app *App) initServices(ctx context.Context,
 	}
 
 	state := vm.New(app.addLogger(SVMLogger, lg), sqlDB)
-	app.conState = txs.NewConservativeState(state, sqlDB, app.addLogger(ConStateLogger, lg))
+	app.conState = txs.NewConservativeState(state, sqlDB,
+		txs.WithCSConfig(txs.CSConfig{
+			BlockGasLimit:     app.Config.BlockGasLimit,
+			NumTXsPerProposal: app.Config.TxsPerProposal,
+		}),
+		txs.WithLogger(app.addLogger(ConStateLogger, lg)))
 
 	goldenATXID := types.ATXID(types.HexToHash32(app.Config.GoldenATXID))
 	if goldenATXID == *types.EmptyATXID {
@@ -616,6 +621,7 @@ func (app *App) initServices(ctx context.Context,
 		vrfSigner,
 		sqlDB,
 		atxDB,
+		msh,
 		app.host,
 		trtl,
 		beaconProtocol,

--- a/cmd/node/node_test.go
+++ b/cmd/node/node_test.go
@@ -989,7 +989,7 @@ func getTestDefaultConfig() *config.Config {
 	cfg.HARE.SuperHare = true
 	cfg.LayerAvgSize = 5
 	cfg.LayersPerEpoch = 3
-	cfg.TxsPerBlock = 100
+	cfg.TxsPerProposal = 100
 	cfg.Tortoise.Hdist = 5
 	cfg.Tortoise.Zdist = 5
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -61,6 +61,8 @@ func AddCommands(cmd *cobra.Command) {
 		config.SyncRequestTimeout, "the timeout in ms for direct requests in the sync")
 	cmd.PersistentFlags().IntVar(&config.TxsPerProposal, "txs-per-proposal",
 		config.TxsPerProposal, "the number of transactions to select per proposal")
+	cmd.PersistentFlags().Uint64Var(&config.BlockGasLimit, "block-gas-limit",
+		config.BlockGasLimit, "max gas allowed per block")
 
 	cmd.PersistentFlags().VarP(flags.NewStringToUint64Value(config.Genesis.Accounts), "accounts", "a",
 		"List of prefunded accounts")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -63,6 +63,8 @@ func AddCommands(cmd *cobra.Command) {
 		config.TxsPerProposal, "the number of transactions to select per proposal")
 	cmd.PersistentFlags().Uint64Var(&config.BlockGasLimit, "block-gas-limit",
 		config.BlockGasLimit, "max gas allowed per block")
+	cmd.PersistentFlags().IntVar(&config.OptFilterThreshold, "optimistic-filtering-threshold",
+		config.OptFilterThreshold, "threshold for optimistic filtering in percentage")
 
 	cmd.PersistentFlags().VarP(flags.NewStringToUint64Value(config.Genesis.Accounts), "accounts", "a",
 		"List of prefunded accounts")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -59,8 +59,8 @@ func AddCommands(cmd *cobra.Command) {
 
 	cmd.PersistentFlags().IntVar(&config.SyncRequestTimeout, "sync-request-timeout",
 		config.SyncRequestTimeout, "the timeout in ms for direct requests in the sync")
-	cmd.PersistentFlags().IntVar(&config.TxsPerBlock, "txs-per-block",
-		config.TxsPerBlock, "the number of transactions to select per block on block creation")
+	cmd.PersistentFlags().IntVar(&config.TxsPerProposal, "txs-per-proposal",
+		config.TxsPerProposal, "the number of transactions to select per proposal")
 
 	cmd.PersistentFlags().VarP(flags.NewStringToUint64Value(config.Genesis.Accounts), "accounts", "a",
 		"List of prefunded accounts")

--- a/common/types/proposal.go
+++ b/common/types/proposal.go
@@ -45,6 +45,11 @@ type InnerProposal struct {
 	Ballot
 	// smesher's content proposal for a layer
 	TxIDs []TransactionID
+	// aggregated hash up to the layer before this proposal.
+	MeshHash Hash32
+	// state root up to the layer before this proposal.
+	// note: this is needed in addition to mesh hash to detect bug in SVM
+	StateHash Hash32
 }
 
 // Initialize calculates and sets the Proposal's cached proposalID.
@@ -100,6 +105,8 @@ func (p *Proposal) MarshalLogObject(encoder log.ObjectEncoder) error {
 		}
 		return nil
 	}))
+	encoder.AddString("mesh_hash", p.MeshHash.String())
+	encoder.AddString("state_root", p.StateHash.String())
 	p.Ballot.MarshalLogObject(encoder)
 	return nil
 }

--- a/common/types/proposal.go
+++ b/common/types/proposal.go
@@ -47,9 +47,10 @@ type InnerProposal struct {
 	TxIDs []TransactionID
 	// aggregated hash up to the layer before this proposal.
 	MeshHash Hash32
+	// TODO add this when a state commitment mechanism is implemented.
 	// state root up to the layer before this proposal.
 	// note: this is needed in addition to mesh hash to detect bug in SVM
-	StateHash Hash32
+	// StateHash Hash32
 }
 
 // Initialize calculates and sets the Proposal's cached proposalID.
@@ -106,7 +107,6 @@ func (p *Proposal) MarshalLogObject(encoder log.ObjectEncoder) error {
 		return nil
 	}))
 	encoder.AddString("mesh_hash", p.MeshHash.String())
-	encoder.AddString("state_root", p.StateHash.String())
 	p.Ballot.MarshalLogObject(encoder)
 	return nil
 }

--- a/common/types/transaction.go
+++ b/common/types/transaction.go
@@ -132,6 +132,11 @@ func (t *Transaction) GetFee() uint64 {
 	return t.Fee
 }
 
+// MaxGas returns the max gas this transaction can use.
+func (t *Transaction) MaxGas() uint64 {
+	return t.GasLimit
+}
+
 // Spending returns the total amount spent on by this transaction.
 func (t *Transaction) Spending() uint64 {
 	return t.Fee + t.Amount

--- a/config/config.go
+++ b/config/config.go
@@ -97,6 +97,9 @@ type BaseConfig struct {
 
 	TxsPerProposal int    `mapstructure:"txs-per-proposal"`
 	BlockGasLimit  uint64 `mapstructure:"block-gas-limit"`
+	// if the number of proposals with the same mesh state crosses this threshold (in percentage),
+	// then we optimistically filter out infeasible transactions before constructing the block.
+	OptFilterThreshold int `mapstructure:"optimistic-filtering-threshold"`
 }
 
 // SmeshingConfig defines configuration for the node's smeshing (mining).
@@ -157,6 +160,7 @@ func defaultBaseConfig() BaseConfig {
 		SyncInterval:        10,
 		TxsPerProposal:      100,
 		BlockGasLimit:       math.MaxUint64,
+		OptFilterThreshold:  90,
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -3,6 +3,7 @@ package config
 
 import (
 	"fmt"
+	"math"
 	"path/filepath"
 	"time"
 
@@ -94,7 +95,8 @@ type BaseConfig struct {
 
 	PublishEventsURL string `mapstructure:"events-url"`
 
-	TxsPerProposal int `mapstructure:"txs-per-proposal"`
+	TxsPerProposal int    `mapstructure:"txs-per-proposal"`
+	BlockGasLimit  uint64 `mapstructure:"block-gas-limit"`
 }
 
 // SmeshingConfig defines configuration for the node's smeshing (mining).
@@ -154,6 +156,7 @@ func defaultBaseConfig() BaseConfig {
 		SyncRequestTimeout:  2000,
 		SyncInterval:        10,
 		TxsPerProposal:      100,
+		BlockGasLimit:       math.MaxUint64,
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -94,7 +94,7 @@ type BaseConfig struct {
 
 	PublishEventsURL string `mapstructure:"events-url"`
 
-	TxsPerBlock int `mapstructure:"txs-per-block"`
+	TxsPerProposal int `mapstructure:"txs-per-proposal"`
 }
 
 // SmeshingConfig defines configuration for the node's smeshing (mining).
@@ -153,7 +153,7 @@ func defaultBaseConfig() BaseConfig {
 		GoldenATXID:         "0x5678", // TODO: Change the value
 		SyncRequestTimeout:  2000,
 		SyncInterval:        10,
-		TxsPerBlock:         100,
+		TxsPerProposal:      100,
 	}
 }
 

--- a/config/presets/fastnet.go
+++ b/config/presets/fastnet.go
@@ -22,6 +22,8 @@ func fastnet() config.Config {
 		panic(err)
 	}
 
+	conf.BaseConfig.OptFilterThreshold = 100
+
 	conf.HARE.N = 800
 	conf.HARE.ExpectedLeaders = 10
 	conf.HARE.LimitConcurrent = 5

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/prometheus/client_golang v1.11.0
 	github.com/prometheus/common v0.30.0
 	github.com/pyroscope-io/pyroscope v0.0.30
+	github.com/seehuhn/mt19937 v1.0.0
 	github.com/spacemeshos/api/release/go v1.4.1-0.20220208052242-dd7698a0ca84
 	github.com/spacemeshos/ed25519 v0.0.0-20190530014421-e235766d15a1
 	github.com/spacemeshos/fixed v0.0.0-20210321020345-0ef1406dc23f

--- a/go.sum
+++ b/go.sum
@@ -944,6 +944,8 @@ github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
+github.com/seehuhn/mt19937 v1.0.0 h1:r02DuVkQXfohssWZO8L/TeAlYOah7aNNubEHB/7Vtfs=
+github.com/seehuhn/mt19937 v1.0.0/go.mod h1:RikyXajNu+1Gqxm4hOacc3ckyWRd0usF6IkE3gnEcAM=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/shurcooL/component v0.0.0-20170202220835-f88ec8f54cc4/go.mod h1:XhFIlyj5a1fBNx5aJTbKoIq0mNaPvOagO+HjB3EtxrY=
 github.com/shurcooL/events v0.0.0-20181021180414-410e4ca65f48/go.mod h1:5u70Mqkb5O5cxEA8nxTsgrgLehJeAw6Oc4Ab1c/P1HM=

--- a/layerfetcher/mocks/mocks.go
+++ b/layerfetcher/mocks/mocks.go
@@ -224,11 +224,12 @@ func (m *MocklayerDB) EXPECT() *MocklayerDBMockRecorder {
 }
 
 // GetAggregatedLayerHash mocks base method.
-func (m *MocklayerDB) GetAggregatedLayerHash(arg0 types.LayerID) types.Hash32 {
+func (m *MocklayerDB) GetAggregatedLayerHash(arg0 types.LayerID) (types.Hash32, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAggregatedLayerHash", arg0)
 	ret0, _ := ret[0].(types.Hash32)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // GetAggregatedLayerHash indicates an expected call of GetAggregatedLayerHash.
@@ -253,11 +254,12 @@ func (mr *MocklayerDBMockRecorder) GetHareConsensusOutput(arg0 interface{}) *gom
 }
 
 // GetLayerHash mocks base method.
-func (m *MocklayerDB) GetLayerHash(arg0 types.LayerID) types.Hash32 {
+func (m *MocklayerDB) GetLayerHash(arg0 types.LayerID) (types.Hash32, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetLayerHash", arg0)
 	ret0, _ := ret[0].(types.Hash32)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // GetLayerHash indicates an expected call of GetLayerHash.
@@ -397,34 +399,6 @@ func NewMockpoetDB(ctrl *gomock.Controller) *MockpoetDB {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockpoetDB) EXPECT() *MockpoetDBMockRecorder {
 	return m.recorder
-}
-
-// HasProof mocks base method.
-func (m *MockpoetDB) HasProof(proofRef []byte) bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HasProof", proofRef)
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// HasProof indicates an expected call of HasProof.
-func (mr *MockpoetDBMockRecorder) HasProof(proofRef interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasProof", reflect.TypeOf((*MockpoetDB)(nil).HasProof), proofRef)
-}
-
-// ValidateAndStore mocks base method.
-func (m *MockpoetDB) ValidateAndStore(proofMessage *types.PoetProofMessage) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ValidateAndStore", proofMessage)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ValidateAndStore indicates an expected call of ValidateAndStore.
-func (mr *MockpoetDBMockRecorder) ValidateAndStore(proofMessage interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateAndStore", reflect.TypeOf((*MockpoetDB)(nil).ValidateAndStore), proofMessage)
 }
 
 // ValidateAndStoreMsg mocks base method.

--- a/miner/interface.go
+++ b/miner/interface.go
@@ -14,7 +14,8 @@ type proposalOracle interface {
 }
 
 type conservativeState interface {
-	SelectTXsForProposal(int) ([]types.TransactionID, error)
+	GetStateRoot() (types.Hash32, error)
+	SelectProposalTXs(int) []types.TransactionID
 }
 
 type votesEncoder interface {
@@ -25,4 +26,8 @@ type activationDB interface {
 	GetNodeAtxIDForEpoch(nodeID types.NodeID, targetEpoch types.EpochID) (types.ATXID, error)
 	GetAtxHeader(types.ATXID) (*types.ActivationTxHeader, error)
 	GetEpochWeight(types.EpochID) (uint64, []types.ATXID, error)
+}
+
+type meshProvider interface {
+	GetAggregatedLayerHash(types.LayerID) (types.Hash32, error)
 }

--- a/miner/interface.go
+++ b/miner/interface.go
@@ -14,7 +14,6 @@ type proposalOracle interface {
 }
 
 type conservativeState interface {
-	GetStateRoot() (types.Hash32, error)
 	SelectProposalTXs(int) []types.TransactionID
 }
 

--- a/miner/mocks/mocks.go
+++ b/miner/mocks/mocks.go
@@ -76,21 +76,6 @@ func (m *MockconservativeState) EXPECT() *MockconservativeStateMockRecorder {
 	return m.recorder
 }
 
-// GetStateRoot mocks base method.
-func (m *MockconservativeState) GetStateRoot() (types.Hash32, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetStateRoot")
-	ret0, _ := ret[0].(types.Hash32)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetStateRoot indicates an expected call of GetStateRoot.
-func (mr *MockconservativeStateMockRecorder) GetStateRoot() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStateRoot", reflect.TypeOf((*MockconservativeState)(nil).GetStateRoot))
-}
-
 // SelectProposalTXs mocks base method.
 func (m *MockconservativeState) SelectProposalTXs(arg0 int) []types.TransactionID {
 	m.ctrl.T.Helper()

--- a/miner/mocks/mocks.go
+++ b/miner/mocks/mocks.go
@@ -76,19 +76,33 @@ func (m *MockconservativeState) EXPECT() *MockconservativeStateMockRecorder {
 	return m.recorder
 }
 
-// SelectTXsForProposal mocks base method.
-func (m *MockconservativeState) SelectTXsForProposal(arg0 int) ([]types.TransactionID, error) {
+// GetStateRoot mocks base method.
+func (m *MockconservativeState) GetStateRoot() (types.Hash32, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SelectTXsForProposal", arg0)
-	ret0, _ := ret[0].([]types.TransactionID)
+	ret := m.ctrl.Call(m, "GetStateRoot")
+	ret0, _ := ret[0].(types.Hash32)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// SelectTXsForProposal indicates an expected call of SelectTXsForProposal.
-func (mr *MockconservativeStateMockRecorder) SelectTXsForProposal(arg0 interface{}) *gomock.Call {
+// GetStateRoot indicates an expected call of GetStateRoot.
+func (mr *MockconservativeStateMockRecorder) GetStateRoot() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SelectTXsForProposal", reflect.TypeOf((*MockconservativeState)(nil).SelectTXsForProposal), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStateRoot", reflect.TypeOf((*MockconservativeState)(nil).GetStateRoot))
+}
+
+// SelectProposalTXs mocks base method.
+func (m *MockconservativeState) SelectProposalTXs(arg0 int) []types.TransactionID {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SelectProposalTXs", arg0)
+	ret0, _ := ret[0].([]types.TransactionID)
+	return ret0
+}
+
+// SelectProposalTXs indicates an expected call of SelectProposalTXs.
+func (mr *MockconservativeStateMockRecorder) SelectProposalTXs(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SelectProposalTXs", reflect.TypeOf((*MockconservativeState)(nil).SelectProposalTXs), arg0)
 }
 
 // MockvotesEncoder is a mock of votesEncoder interface.
@@ -201,4 +215,42 @@ func (m *MockactivationDB) GetNodeAtxIDForEpoch(nodeID types.NodeID, targetEpoch
 func (mr *MockactivationDBMockRecorder) GetNodeAtxIDForEpoch(nodeID, targetEpoch interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNodeAtxIDForEpoch", reflect.TypeOf((*MockactivationDB)(nil).GetNodeAtxIDForEpoch), nodeID, targetEpoch)
+}
+
+// MockmeshProvider is a mock of meshProvider interface.
+type MockmeshProvider struct {
+	ctrl     *gomock.Controller
+	recorder *MockmeshProviderMockRecorder
+}
+
+// MockmeshProviderMockRecorder is the mock recorder for MockmeshProvider.
+type MockmeshProviderMockRecorder struct {
+	mock *MockmeshProvider
+}
+
+// NewMockmeshProvider creates a new mock instance.
+func NewMockmeshProvider(ctrl *gomock.Controller) *MockmeshProvider {
+	mock := &MockmeshProvider{ctrl: ctrl}
+	mock.recorder = &MockmeshProviderMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockmeshProvider) EXPECT() *MockmeshProviderMockRecorder {
+	return m.recorder
+}
+
+// GetAggregatedLayerHash mocks base method.
+func (m *MockmeshProvider) GetAggregatedLayerHash(arg0 types.LayerID) (types.Hash32, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAggregatedLayerHash", arg0)
+	ret0, _ := ret[0].(types.Hash32)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAggregatedLayerHash indicates an expected call of GetAggregatedLayerHash.
+func (mr *MockmeshProviderMockRecorder) GetAggregatedLayerHash(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAggregatedLayerHash", reflect.TypeOf((*MockmeshProvider)(nil).GetAggregatedLayerHash), arg0)
 }

--- a/miner/proposal_builder.go
+++ b/miner/proposal_builder.go
@@ -241,15 +241,7 @@ func (pb *ProposalBuilder) createProposal(
 		ib.RefBallot = refBallot
 	}
 
-	var (
-		state = types.Hash32{}
-		mesh  = types.Hash32{}
-	)
-	state, err = pb.conState.GetStateRoot()
-	if err != nil {
-		logger.With().Warning("failed to get state root", log.Err(err))
-	}
-	mesh, err = pb.msh.GetAggregatedLayerHash(layerID.Sub(1))
+	mesh, err := pb.msh.GetAggregatedLayerHash(layerID.Sub(1))
 	if err != nil {
 		logger.With().Warning("failed to get mesh hash", log.Err(err))
 	}
@@ -258,9 +250,8 @@ func (pb *ProposalBuilder) createProposal(
 			Ballot: types.Ballot{
 				InnerBallot: *ib,
 			},
-			TxIDs:     txIDs,
-			MeshHash:  mesh,
-			StateHash: state,
+			TxIDs:    txIDs,
+			MeshHash: mesh,
 		},
 	}
 	p.Ballot.Signature = pb.signer.Sign(p.Ballot.Bytes())

--- a/miner/proposal_builder_test.go
+++ b/miner/proposal_builder_test.go
@@ -130,8 +130,6 @@ func TestBuilder_HandleLayer_MultipleProposals(t *testing.T) {
 	b.mCState.EXPECT().SelectProposalTXs(len(proofs)).Return([]types.TransactionID{tx1.ID()}).Times(1)
 	b.mBaseBP.EXPECT().EncodeVotes(gomock.Any(), gomock.Any()).Return(&types.Votes{Base: base}, nil).Times(1)
 	meshHash := types.RandomHash()
-	stateRoot := types.RandomHash()
-	b.mCState.EXPECT().GetStateRoot().Return(stateRoot, nil).Times(1)
 	b.mMsh.EXPECT().GetAggregatedLayerHash(layerID.Sub(1)).Return(meshHash, nil).Times(1)
 	b.mPubSub.EXPECT().Publish(gomock.Any(), proposals.NewProposalProtocol, gomock.Any()).DoAndReturn(
 		func(_ context.Context, _ string, data []byte) error {
@@ -148,7 +146,6 @@ func TestBuilder_HandleLayer_MultipleProposals(t *testing.T) {
 			require.Equal(t, []types.TransactionID{tx1.ID()}, p.TxIDs)
 			require.Equal(t, proofs, p.EligibilityProofs)
 			require.Equal(t, meshHash, p.MeshHash)
-			require.Equal(t, stateRoot, p.StateHash)
 			return nil
 		}).Times(1)
 
@@ -179,8 +176,6 @@ func TestBuilder_HandleLayer_OneProposal(t *testing.T) {
 	b.mCState.EXPECT().SelectProposalTXs(len(proofs)).Return([]types.TransactionID{tx.ID()}).Times(1)
 	b.mBaseBP.EXPECT().EncodeVotes(gomock.Any(), gomock.Any()).Return(&types.Votes{Base: bb}, nil).Times(1)
 	meshHash := types.RandomHash()
-	stateRoot := types.RandomHash()
-	b.mCState.EXPECT().GetStateRoot().Return(stateRoot, nil).Times(1)
 	b.mMsh.EXPECT().GetAggregatedLayerHash(layerID.Sub(1)).Return(meshHash, nil).Times(1)
 	b.mPubSub.EXPECT().Publish(gomock.Any(), proposals.NewProposalProtocol, gomock.Any()).DoAndReturn(
 		func(_ context.Context, _ string, data []byte) error {
@@ -196,7 +191,6 @@ func TestBuilder_HandleLayer_OneProposal(t *testing.T) {
 			require.Equal(t, beacon, p.EpochData.Beacon)
 			require.Equal(t, []types.TransactionID{tx.ID()}, p.TxIDs)
 			require.Equal(t, meshHash, p.MeshHash)
-			require.Equal(t, stateRoot, p.StateHash)
 			return nil
 		}).Times(1)
 
@@ -284,7 +278,6 @@ func TestBuilder_HandleLayer_NoRefBallot(t *testing.T) {
 	b.mOracle.EXPECT().GetProposalEligibility(layerID, beacon).Return(types.RandomATXID(), activeSet, genProofs(t, 1), nil).Times(1)
 	b.mCState.EXPECT().SelectProposalTXs(1).Return([]types.TransactionID{tx.ID()}).Times(1)
 	b.mBaseBP.EXPECT().EncodeVotes(gomock.Any(), gomock.Any()).Return(&types.Votes{Base: types.RandomBallotID()}, nil).Times(1)
-	b.mCState.EXPECT().GetStateRoot().Return(types.RandomHash(), nil).Times(1)
 	b.mMsh.EXPECT().GetAggregatedLayerHash(layerID.Sub(1)).Return(types.RandomHash(), nil).Times(1)
 	b.mPubSub.EXPECT().Publish(gomock.Any(), proposals.NewProposalProtocol, gomock.Any()).DoAndReturn(
 		func(_ context.Context, _ string, data []byte) error {
@@ -314,7 +307,6 @@ func TestBuilder_HandleLayer_RefBallot(t *testing.T) {
 	b.mOracle.EXPECT().GetProposalEligibility(layerID, beacon).Return(types.RandomATXID(), genActiveSet(t), genProofs(t, 1), nil).Times(1)
 	b.mCState.EXPECT().SelectProposalTXs(1).Return([]types.TransactionID{tx.ID()}).Times(1)
 	b.mBaseBP.EXPECT().EncodeVotes(gomock.Any(), gomock.Any()).Return(&types.Votes{Base: types.RandomBallotID()}, nil).Times(1)
-	b.mCState.EXPECT().GetStateRoot().Return(types.RandomHash(), nil).Times(1)
 	b.mMsh.EXPECT().GetAggregatedLayerHash(layerID.Sub(1)).Return(types.RandomHash(), nil).Times(1)
 	b.mPubSub.EXPECT().Publish(gomock.Any(), proposals.NewProposalProtocol, gomock.Any()).DoAndReturn(
 		func(_ context.Context, _ string, data []byte) error {
@@ -343,7 +335,6 @@ func TestBuilder_HandleLayer_CanceledDuringBuilding(t *testing.T) {
 	b.mOracle.EXPECT().GetProposalEligibility(layerID, beacon).Return(types.RandomATXID(), genActiveSet(t), genProofs(t, 1), nil).Times(1)
 	b.mCState.EXPECT().SelectProposalTXs(1).Return([]types.TransactionID{tx.ID()}).Times(1)
 	b.mBaseBP.EXPECT().EncodeVotes(gomock.Any(), gomock.Any()).Return(&types.Votes{Base: types.RandomBallotID()}, nil).Times(1)
-	b.mCState.EXPECT().GetStateRoot().Return(types.RandomHash(), nil).Times(1)
 	b.mMsh.EXPECT().GetAggregatedLayerHash(layerID.Sub(1)).Return(types.RandomHash(), nil).Times(1)
 
 	b.Close()
@@ -364,7 +355,6 @@ func TestBuilder_HandleLayer_PublishError(t *testing.T) {
 	b.mOracle.EXPECT().GetProposalEligibility(layerID, beacon).Return(types.RandomATXID(), genActiveSet(t), genProofs(t, 1), nil).Times(1)
 	b.mCState.EXPECT().SelectProposalTXs(1).Return([]types.TransactionID{tx.ID()}).Times(1)
 	b.mBaseBP.EXPECT().EncodeVotes(gomock.Any(), gomock.Any()).Return(&types.Votes{Base: types.RandomBallotID()}, nil).Times(1)
-	b.mCState.EXPECT().GetStateRoot().Return(types.RandomHash(), nil).Times(1)
 	b.mMsh.EXPECT().GetAggregatedLayerHash(layerID.Sub(1)).Return(types.RandomHash(), nil).Times(1)
 	b.mPubSub.EXPECT().Publish(gomock.Any(), proposals.NewProposalProtocol, gomock.Any()).Return(errors.New("unknown")).Times(1)
 
@@ -387,7 +377,6 @@ func TestBuilder_HandleLayer_StateRootErrorOK(t *testing.T) {
 	b.mOracle.EXPECT().GetProposalEligibility(layerID, beacon).Return(types.RandomATXID(), genActiveSet(t), genProofs(t, 1), nil).Times(1)
 	b.mCState.EXPECT().SelectProposalTXs(1).Return([]types.TransactionID{tx.ID()}).Times(1)
 	b.mBaseBP.EXPECT().EncodeVotes(gomock.Any(), gomock.Any()).Return(&types.Votes{Base: types.RandomBallotID()}, nil).Times(1)
-	b.mCState.EXPECT().GetStateRoot().Return(types.Hash32{}, errors.New("unknown")).Times(1)
 	b.mMsh.EXPECT().GetAggregatedLayerHash(layerID.Sub(1)).Return(types.RandomHash(), nil).Times(1)
 	b.mPubSub.EXPECT().Publish(gomock.Any(), proposals.NewProposalProtocol, gomock.Any()).Return(errors.New("unknown")).Times(1)
 
@@ -409,7 +398,6 @@ func TestBuilder_HandleLayer_MeshHashErrorOK(t *testing.T) {
 	b.mOracle.EXPECT().GetProposalEligibility(layerID, beacon).Return(types.RandomATXID(), genActiveSet(t), genProofs(t, 1), nil).Times(1)
 	b.mCState.EXPECT().SelectProposalTXs(1).Return([]types.TransactionID{tx.ID()}).Times(1)
 	b.mBaseBP.EXPECT().EncodeVotes(gomock.Any(), gomock.Any()).Return(&types.Votes{Base: types.RandomBallotID()}, nil).Times(1)
-	b.mCState.EXPECT().GetStateRoot().Return(types.RandomHash(), nil).Times(1)
 	b.mMsh.EXPECT().GetAggregatedLayerHash(layerID.Sub(1)).Return(types.EmptyLayerHash, errors.New("unknown")).Times(1)
 	b.mPubSub.EXPECT().Publish(gomock.Any(), proposals.NewProposalProtocol, gomock.Any()).Return(errors.New("unknown")).Times(1)
 
@@ -427,14 +415,11 @@ func TestBuilder_UniqueBlockID(t *testing.T) {
 	activeSet := genActiveSet(t)
 	beacon := types.RandomBeacon()
 	meshHash := types.RandomHash()
-	stateRoot := types.RandomHash()
 
-	builder1.mCState.EXPECT().GetStateRoot().Return(stateRoot, nil).Times(1)
 	builder1.mMsh.EXPECT().GetAggregatedLayerHash(layerID.Sub(1)).Return(meshHash, nil).Times(1)
 	b1, err := builder1.createProposal(context.TODO(), layerID, nil, atxID1, activeSet, beacon, nil, types.Votes{})
 	require.NoError(t, err)
 
-	builder2.mCState.EXPECT().GetStateRoot().Return(stateRoot, nil).Times(1)
 	builder2.mMsh.EXPECT().GetAggregatedLayerHash(layerID.Sub(1)).Return(meshHash, nil).Times(1)
 	b2, err := builder2.createProposal(context.TODO(), layerID, nil, atxID2, activeSet, beacon, nil, types.Votes{})
 	require.NoError(t, err)

--- a/sql/migrations/0001_initial.sql
+++ b/sql/migrations/0001_initial.sql
@@ -115,7 +115,6 @@ CREATE TABLE proposals
     layer      INT NOT NULL,
     tx_ids     BLOB,
     mesh_hash  CHAR(32),
-    state_hash CHAR(32),
     signature  VARCHAR,
     proposal   BLOB
 

--- a/sql/migrations/0001_initial.sql
+++ b/sql/migrations/0001_initial.sql
@@ -110,12 +110,15 @@ CREATE TABLE atx_top
 
 CREATE TABLE proposals
 (
-    id        CHAR(20) PRIMARY KEY,
-    ballot_id CHAR(20),
-    layer     INT NOT NULL,
-    tx_ids    BLOB,
-    signature VARCHAR,
+    id         CHAR(20) PRIMARY KEY,
+    ballot_id  CHAR(20),
+    layer      INT NOT NULL,
+    tx_ids     BLOB,
+    mesh_hash  CHAR(32),
+    state_hash CHAR(32),
+    signature  VARCHAR,
     proposal   BLOB
+
 ) WITHOUT ROWID;
 CREATE INDEX proposals_by_layer ON proposals (layer);
 

--- a/sql/proposals/proposals.go
+++ b/sql/proposals/proposals.go
@@ -22,7 +22,6 @@ func Get(db sql.Executor, id types.ProposalID) (proposal *types.Proposal, err er
 			proposals.ballot_id, 
 			proposals.tx_ids, 
 			proposals.mesh_hash,
-			proposals.state_hash,
 			proposals.signature
 		from proposals 
 		left join ballots on proposals.ballot_id = ballots.id 
@@ -88,7 +87,6 @@ func GetByLayer(db sql.Executor, layerID types.LayerID) (proposals []*types.Prop
 			proposals.ballot_id, 
 			proposals.tx_ids, 
 			proposals.mesh_hash,
-			proposals.state_hash,
 			proposals.signature 
 		from proposals 
 		left join ballots on proposals.ballot_id = ballots.id 
@@ -150,14 +148,13 @@ func Add(db sql.Executor, proposal *types.Proposal) error {
 		stmt.BindInt64(3, int64(proposal.LayerIndex.Uint32()))
 		stmt.BindBytes(4, txIDsBytes)
 		stmt.BindBytes(5, proposal.MeshHash.Bytes())
-		stmt.BindBytes(6, proposal.StateHash.Bytes())
-		stmt.BindBytes(7, proposal.Signature)
-		stmt.BindBytes(8, encodedProposal)
+		stmt.BindBytes(6, proposal.Signature)
+		stmt.BindBytes(7, encodedProposal)
 	}
 
 	_, err = db.Exec(`
-		insert into proposals (id, ballot_id, layer, tx_ids, mesh_hash, state_hash, signature, proposal)
-		values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8);`, enc, nil)
+		insert into proposals (id, ballot_id, layer, tx_ids, mesh_hash, signature, proposal)
+		values (?1, ?2, ?3, ?4, ?5, ?6, ?7);`, enc, nil)
 	if err != nil {
 		return fmt.Errorf("insert proposal ID %v: %w", proposal.ID(), err)
 	}
@@ -196,10 +193,8 @@ func decodeProposal(stmt *sql.Statement) (*types.Proposal, error) {
 
 	meshBytes := make([]byte, stmt.ColumnLen(7))
 	stmt.ColumnBytes(7, meshBytes)
-	stateBytes := make([]byte, stmt.ColumnLen(8))
-	stmt.ColumnBytes(8, stateBytes)
-	signature := make([]byte, stmt.ColumnLen(9))
-	stmt.ColumnBytes(9, signature)
+	signature := make([]byte, stmt.ColumnLen(8))
+	stmt.ColumnBytes(8, signature)
 
 	txIDs := make([]types.TransactionID, 0)
 	if err := codec.Decode(txIDsBytes, &txIDs); err != nil {
@@ -209,10 +204,9 @@ func decodeProposal(stmt *sql.Statement) (*types.Proposal, error) {
 	}
 	proposal := &types.Proposal{
 		InnerProposal: types.InnerProposal{
-			Ballot:    ballot,
-			TxIDs:     txIDs,
-			MeshHash:  types.BytesToHash(meshBytes),
-			StateHash: types.BytesToHash(stateBytes),
+			Ballot:   ballot,
+			TxIDs:    txIDs,
+			MeshHash: types.BytesToHash(meshBytes),
 		},
 		Signature: signature,
 	}

--- a/sql/proposals/proposals_test.go
+++ b/sql/proposals/proposals_test.go
@@ -21,10 +21,9 @@ func TestAdd(t *testing.T) {
 	require.NoError(t, identities.SetMalicious(db, pub))
 	proposal := &types.Proposal{
 		InnerProposal: types.InnerProposal{
-			Ballot:    ballot,
-			TxIDs:     []types.TransactionID{{3, 4}},
-			MeshHash:  types.RandomHash(),
-			StateHash: types.RandomHash(),
+			Ballot:   ballot,
+			TxIDs:    []types.TransactionID{{3, 4}},
+			MeshHash: types.RandomHash(),
 		},
 		Signature: []byte{5, 6},
 	}
@@ -44,10 +43,9 @@ func TestHas(t *testing.T) {
 	require.NoError(t, identities.SetMalicious(db, pub))
 	proposal := &types.Proposal{
 		InnerProposal: types.InnerProposal{
-			Ballot:    ballot,
-			TxIDs:     []types.TransactionID{{3, 4}},
-			MeshHash:  types.RandomHash(),
-			StateHash: types.RandomHash(),
+			Ballot:   ballot,
+			TxIDs:    []types.TransactionID{{3, 4}},
+			MeshHash: types.RandomHash(),
 		},
 		Signature: []byte{5, 6},
 	}
@@ -73,10 +71,9 @@ func TestGet(t *testing.T) {
 
 	proposal := &types.Proposal{
 		InnerProposal: types.InnerProposal{
-			Ballot:    ballot,
-			TxIDs:     []types.TransactionID{{3, 4}},
-			MeshHash:  types.RandomHash(),
-			StateHash: types.RandomHash(),
+			Ballot:   ballot,
+			TxIDs:    []types.TransactionID{{3, 4}},
+			MeshHash: types.RandomHash(),
 		},
 		Signature: []byte{5, 6},
 	}

--- a/sql/proposals/proposals_test.go
+++ b/sql/proposals/proposals_test.go
@@ -21,8 +21,10 @@ func TestAdd(t *testing.T) {
 	require.NoError(t, identities.SetMalicious(db, pub))
 	proposal := &types.Proposal{
 		InnerProposal: types.InnerProposal{
-			Ballot: ballot,
-			TxIDs:  []types.TransactionID{{3, 4}},
+			Ballot:    ballot,
+			TxIDs:     []types.TransactionID{{3, 4}},
+			MeshHash:  types.RandomHash(),
+			StateHash: types.RandomHash(),
 		},
 		Signature: []byte{5, 6},
 	}
@@ -42,8 +44,10 @@ func TestHas(t *testing.T) {
 	require.NoError(t, identities.SetMalicious(db, pub))
 	proposal := &types.Proposal{
 		InnerProposal: types.InnerProposal{
-			Ballot: ballot,
-			TxIDs:  []types.TransactionID{{3, 4}},
+			Ballot:    ballot,
+			TxIDs:     []types.TransactionID{{3, 4}},
+			MeshHash:  types.RandomHash(),
+			StateHash: types.RandomHash(),
 		},
 		Signature: []byte{5, 6},
 	}
@@ -69,8 +73,10 @@ func TestGet(t *testing.T) {
 
 	proposal := &types.Proposal{
 		InnerProposal: types.InnerProposal{
-			Ballot: ballot,
-			TxIDs:  []types.TransactionID{{3, 4}},
+			Ballot:    ballot,
+			TxIDs:     []types.TransactionID{{3, 4}},
+			MeshHash:  types.RandomHash(),
+			StateHash: types.RandomHash(),
 		},
 		Signature: []byte{5, 6},
 	}

--- a/txs/conservative_state.go
+++ b/txs/conservative_state.go
@@ -93,8 +93,9 @@ func (cs *ConservativeState) getState(addr types.Address) (uint64, uint64) {
 func (cs *ConservativeState) SelectBlockTXs(lid types.LayerID, proposals []*types.Proposal) ([]types.TransactionID, error) {
 	myHash, err := cs.cache.GetMeshHash(lid.Sub(1))
 	if err != nil {
-		cs.logger.With().Error("failed to get mesh hash", lid, log.Err(err))
-		return nil, fmt.Errorf("get own mesh hash: %w", err)
+		cs.logger.With().Warning("failed to get mesh hash", lid, log.Err(err))
+		// if we don't have hash for that layer, other nodes probably don't either
+		myHash = types.EmptyLayerHash
 	}
 
 	md, err := checkStateConsensus(cs.logger, cs.cfg, lid, proposals, myHash, cs.GetMeshTransaction)

--- a/txs/conservative_state_test.go
+++ b/txs/conservative_state_test.go
@@ -2,6 +2,7 @@ package txs
 
 import (
 	"errors"
+	"math"
 	"math/rand"
 	"testing"
 
@@ -19,10 +20,11 @@ import (
 )
 
 const (
-	numTXsInProposal = 5
+	numTXsInProposal = 17
+	defaultGas       = uint64(100)
 	defaultBalance   = uint64(1000)
-	amount           = uint64(10)
-	fee              = uint64(5)
+	defaultAmount    = uint64(10)
+	defaultFee       = uint64(5)
 )
 
 func newTx(t *testing.T, nonce uint64, amount, fee uint64, signer *signing.EdSigner) *types.Transaction {
@@ -31,7 +33,7 @@ func newTx(t *testing.T, nonce uint64, amount, fee uint64, signer *signing.EdSig
 }
 
 func newTxWthRecipient(t *testing.T, dest types.Address, nonce uint64, amount, fee uint64, signer *signing.EdSigner) *types.Transaction {
-	tx, err := transaction.GenerateCallTransaction(signer, dest, nonce, amount, 100, fee)
+	tx, err := transaction.GenerateCallTransaction(signer, dest, nonce, amount, defaultGas, fee)
 	require.NoError(t, err)
 	return tx
 }
@@ -42,15 +44,26 @@ type testConState struct {
 	mvm *mocks.MockvmState
 }
 
-func createConservativeState(t *testing.T) *testConState {
+func createTestState(t *testing.T, gasLimit uint64) *testConState {
 	ctrl := gomock.NewController(t)
 	mvm := mocks.NewMockvmState(ctrl)
 	db := sql.InMemory()
-	return &testConState{
-		ConservativeState: NewConservativeState(mvm, db, logtest.New(t)),
-		db:                db,
-		mvm:               mvm,
+	cfg := CSConfig{
+		BlockGasLimit:     gasLimit,
+		NumTXsPerProposal: numTXsInProposal,
 	}
+
+	return &testConState{
+		ConservativeState: NewConservativeState(mvm, db,
+			WithCSConfig(cfg),
+			WithLogger(logtest.New(t))),
+		db:  db,
+		mvm: mvm,
+	}
+}
+
+func createConservativeState(t *testing.T) *testConState {
+	return createTestState(t, math.MaxUint64)
 }
 
 func addBatch(t *testing.T, tcs *testConState, numTXs int) ([]types.TransactionID, []*types.Transaction) {
@@ -62,7 +75,7 @@ func addBatch(t *testing.T, tcs *testConState, numTXs int) ([]types.TransactionI
 		addr := types.BytesToAddress(signer.PublicKey().Bytes())
 		tcs.mvm.EXPECT().GetBalance(addr).Return(defaultBalance, nil).Times(1)
 		tcs.mvm.EXPECT().GetNonce(addr).Return(nonce, nil).Times(1)
-		tx := newTx(t, nonce, amount, fee, signer)
+		tx := newTx(t, nonce, defaultAmount, defaultFee, signer)
 		require.NoError(t, tcs.AddToCache(tx, true))
 		ids = append(ids, tx.ID())
 		txs = append(txs, tx)
@@ -70,31 +83,59 @@ func addBatch(t *testing.T, tcs *testConState, numTXs int) ([]types.TransactionI
 	return ids, txs
 }
 
-func TestSelectTXsForProposal(t *testing.T) {
+func TestSelectProposalTXs(t *testing.T) {
 	tcs := createConservativeState(t)
 	numTXs := 2 * numTXsInProposal
 	lid := types.NewLayerID(97)
 	bid := types.BlockID{100}
-	expected := make([]types.TransactionID, 0, numTXs)
 	for i := 0; i < numTXs; i++ {
 		signer := signing.NewEdSigner()
 		addr := types.GenerateAddress(signer.PublicKey().Bytes())
 		tcs.mvm.EXPECT().GetBalance(addr).Return(defaultBalance, nil).Times(1)
 		tcs.mvm.EXPECT().GetNonce(addr).Return(uint64(0), nil).Times(1)
-		tx1 := newTx(t, 0, amount, fee, signer)
+		tx1 := newTx(t, 0, defaultAmount, defaultFee, signer)
 		require.NoError(t, tcs.AddToCache(tx1, true))
 		// all the TXs with nonce 0 are pending in database
 		require.NoError(t, tcs.LinkTXsWithBlock(lid, bid, []types.TransactionID{tx1.ID()}))
-		tx2 := newTx(t, 1, amount, fee, signer)
+		tx2 := newTx(t, 1, defaultAmount, defaultFee, signer)
 		require.NoError(t, tcs.AddToCache(tx2, true))
-		expected = append(expected, tx2.ID())
 	}
-	got, err := tcs.SelectTXsForProposal(numTXsInProposal)
-	require.NoError(t, err)
-	require.ElementsMatch(t, expected[:numTXsInProposal], got)
+
+	got := tcs.SelectProposalTXs(1)
+	require.Len(t, got, numTXsInProposal)
+
+	// the second call should have different result than the first, as the transactions should be
+	// randomly selected
+	got2 := tcs.SelectProposalTXs(1)
+	require.Len(t, got2, numTXsInProposal)
+	require.NotSubset(t, got, got2)
+	require.NotSubset(t, got2, got)
 }
 
-func TestSelectTXsForProposal_ExhaustMemPool(t *testing.T) {
+func TestSelectProposalTXs_ExhaustGas(t *testing.T) {
+	numTXs := 2 * numTXsInProposal
+	lid := types.NewLayerID(97)
+	bid := types.BlockID{100}
+	expSize := numTXsInProposal / 2
+	gasLimit := defaultGas * uint64(expSize)
+	tcs := createTestState(t, gasLimit)
+	for i := 0; i < numTXs; i++ {
+		signer := signing.NewEdSigner()
+		addr := types.GenerateAddress(signer.PublicKey().Bytes())
+		tcs.mvm.EXPECT().GetBalance(addr).Return(defaultBalance, nil).Times(1)
+		tcs.mvm.EXPECT().GetNonce(addr).Return(uint64(0), nil).Times(1)
+		tx1 := newTx(t, 0, defaultAmount, defaultFee, signer)
+		require.NoError(t, tcs.AddToCache(tx1, true))
+		// all the TXs with nonce 0 are pending in database
+		require.NoError(t, tcs.LinkTXsWithBlock(lid, bid, []types.TransactionID{tx1.ID()}))
+		tx2 := newTx(t, 1, defaultAmount, defaultFee, signer)
+		require.NoError(t, tcs.AddToCache(tx2, true))
+	}
+	got := tcs.SelectProposalTXs(1)
+	require.Len(t, got, expSize)
+}
+
+func TestSelectProposalTXs_ExhaustMemPool(t *testing.T) {
 	tcs := createConservativeState(t)
 	numTXs := numTXsInProposal - 1
 	lid := types.NewLayerID(97)
@@ -105,20 +146,24 @@ func TestSelectTXsForProposal_ExhaustMemPool(t *testing.T) {
 		addr := types.GenerateAddress(signer.PublicKey().Bytes())
 		tcs.mvm.EXPECT().GetBalance(addr).Return(defaultBalance, nil).Times(1)
 		tcs.mvm.EXPECT().GetNonce(addr).Return(uint64(0), nil).Times(1)
-		tx1 := newTx(t, 0, amount, fee, signer)
+		tx1 := newTx(t, 0, defaultAmount, defaultFee, signer)
 		require.NoError(t, tcs.AddToCache(tx1, true))
 		// all the TXs with nonce 0 are pending in database
 		require.NoError(t, tcs.LinkTXsWithBlock(lid, bid, []types.TransactionID{tx1.ID()}))
-		tx2 := newTx(t, 1, amount, fee, signer)
+		tx2 := newTx(t, 1, defaultAmount, defaultFee, signer)
 		require.NoError(t, tcs.AddToCache(tx2, true))
 		expected = append(expected, tx2.ID())
 	}
-	got, err := tcs.SelectTXsForProposal(numTXsInProposal)
-	require.NoError(t, err)
-	require.ElementsMatch(t, expected, got)
+	got := tcs.SelectProposalTXs(1)
+	// no reshuffling happens when mempool is exhausted. two list should be exactly the same
+	require.Equal(t, expected, got)
+
+	// the second call should have the same result since both exhaust the mempool
+	got2 := tcs.SelectProposalTXs(1)
+	require.Equal(t, got, got2)
 }
 
-func TestSelectTXsForProposal_SamePrincipal(t *testing.T) {
+func TestSelectProposalTXs_SamePrincipal(t *testing.T) {
 	tcs := createConservativeState(t)
 	signer := signing.NewEdSigner()
 	addr := types.GenerateAddress(signer.PublicKey().Bytes())
@@ -129,24 +174,23 @@ func TestSelectTXsForProposal_SamePrincipal(t *testing.T) {
 	tcs.mvm.EXPECT().GetBalance(addr).Return(defaultBalance, nil).Times(1)
 	tcs.mvm.EXPECT().GetNonce(addr).Return(uint64(0), nil).Times(1)
 	for i := 0; i < numInBlock; i++ {
-		tx := newTx(t, uint64(i), amount, fee, signer)
+		tx := newTx(t, uint64(i), defaultAmount, defaultFee, signer)
 		require.NoError(t, tcs.AddToCache(tx, true))
 		require.NoError(t, tcs.LinkTXsWithBlock(lid, bid, []types.TransactionID{tx.ID()}))
 	}
 	expected := make([]types.TransactionID, 0, numTXsInProposal)
 	for i := 0; i < numTXs; i++ {
-		tx := newTx(t, uint64(numInBlock+i), amount, fee, signer)
+		tx := newTx(t, uint64(numInBlock+i), defaultAmount, defaultFee, signer)
 		require.NoError(t, tcs.AddToCache(tx, true))
 		if i < numTXsInProposal {
 			expected = append(expected, tx.ID())
 		}
 	}
-	got, err := tcs.SelectTXsForProposal(numTXsInProposal)
-	require.NoError(t, err)
-	require.ElementsMatch(t, expected, got)
+	got := tcs.SelectProposalTXs(1)
+	require.Equal(t, expected, got)
 }
 
-func TestSelectTXsForProposal_TwoPrincipals(t *testing.T) {
+func TestSelectProposalTXs_TwoPrincipals(t *testing.T) {
 	const (
 		numInProposal = 30
 		numTXs        = numInProposal * 2
@@ -165,25 +209,24 @@ func TestSelectTXsForProposal_TwoPrincipals(t *testing.T) {
 	tcs.mvm.EXPECT().GetNonce(addr2).Return(uint64(0), nil).Times(1)
 	allTXs := make(map[types.TransactionID]*types.Transaction)
 	for i := 0; i < numInDBs; i++ {
-		tx := newTx(t, uint64(i), amount, fee, signer1)
+		tx := newTx(t, uint64(i), defaultAmount, defaultFee, signer1)
 		require.NoError(t, tcs.AddToCache(tx, true))
 		require.NoError(t, tcs.LinkTXsWithBlock(lid, bid, []types.TransactionID{tx.ID()}))
 		allTXs[tx.ID()] = tx
-		tx = newTx(t, uint64(i), amount, fee, signer2)
+		tx = newTx(t, uint64(i), defaultAmount, defaultFee, signer2)
 		require.NoError(t, tcs.AddToCache(tx, true))
 		require.NoError(t, tcs.LinkTXsWithBlock(lid, bid, []types.TransactionID{tx.ID()}))
 		allTXs[tx.ID()] = tx
 	}
 	for i := 0; i < numTXs; i++ {
-		tx := newTx(t, uint64(numInDBs+i), amount, fee, signer1)
+		tx := newTx(t, uint64(numInDBs+i), defaultAmount, defaultFee, signer1)
 		require.NoError(t, tcs.AddToCache(tx, true))
 		allTXs[tx.ID()] = tx
-		tx = newTx(t, uint64(numInDBs+i), amount, fee, signer2)
+		tx = newTx(t, uint64(numInDBs+i), defaultAmount, defaultFee, signer2)
 		require.NoError(t, tcs.AddToCache(tx, true))
 		allTXs[tx.ID()] = tx
 	}
-	got, err := tcs.SelectTXsForProposal(numInProposal)
-	require.NoError(t, err)
+	got := tcs.SelectProposalTXs(1)
 	// the odds of picking just one principal is 2^30
 	chosen := make(map[types.Address][]*types.Transaction)
 	for _, tid := range got {
@@ -208,15 +251,15 @@ func TestGetProjection(t *testing.T) {
 	addr := types.BytesToAddress(signer.PublicKey().Bytes())
 	tcs.mvm.EXPECT().GetBalance(addr).Return(defaultBalance, nil).Times(1)
 	tcs.mvm.EXPECT().GetNonce(addr).Return(nonce, nil).Times(1)
-	tx1 := newTx(t, nonce, amount, fee, signer)
+	tx1 := newTx(t, nonce, defaultAmount, defaultFee, signer)
 	require.NoError(t, tcs.AddToCache(tx1, true))
 	require.NoError(t, tcs.LinkTXsWithBlock(types.NewLayerID(10), types.BlockID{100}, []types.TransactionID{tx1.ID()}))
-	tx2 := newTx(t, nonce+1, amount, fee, signer)
+	tx2 := newTx(t, nonce+1, defaultAmount, defaultFee, signer)
 	require.NoError(t, tcs.AddToCache(tx2, true))
 
 	got, balance := tcs.GetProjection(addr)
 	require.EqualValues(t, nonce+2, got)
-	require.EqualValues(t, defaultBalance-2*(amount+fee), balance)
+	require.EqualValues(t, defaultBalance-2*(defaultAmount+defaultFee), balance)
 }
 
 func TestAddToCache(t *testing.T) {
@@ -225,7 +268,7 @@ func TestAddToCache(t *testing.T) {
 	addr := types.BytesToAddress(signer.PublicKey().Bytes())
 	tcs.mvm.EXPECT().GetBalance(addr).Return(defaultBalance, nil).Times(1)
 	tcs.mvm.EXPECT().GetNonce(addr).Return(nonce, nil).Times(1)
-	tx := newTx(t, nonce, amount, fee, signer)
+	tx := newTx(t, nonce, defaultAmount, defaultFee, signer)
 	require.NoError(t, tcs.AddToCache(tx, true))
 	got, err := tcs.HasTx(tx.ID())
 	require.NoError(t, err)
@@ -238,7 +281,7 @@ func TestAddToCache_KnownTX(t *testing.T) {
 	addr := types.BytesToAddress(signer.PublicKey().Bytes())
 	tcs.mvm.EXPECT().GetBalance(addr).Return(defaultBalance, nil).Times(1)
 	tcs.mvm.EXPECT().GetNonce(addr).Return(nonce, nil).Times(1)
-	tx := newTx(t, nonce, amount, fee, signer)
+	tx := newTx(t, nonce, defaultAmount, defaultFee, signer)
 	require.NoError(t, tcs.AddToCache(tx, false))
 	got, err := tcs.HasTx(tx.ID())
 	require.NoError(t, err)
@@ -249,9 +292,9 @@ func TestAddToCache_InsufficientBalance(t *testing.T) {
 	tcs := createConservativeState(t)
 	signer := signing.NewEdSigner()
 	addr := types.BytesToAddress(signer.PublicKey().Bytes())
-	tcs.mvm.EXPECT().GetBalance(addr).Return(amount, nil).Times(1)
+	tcs.mvm.EXPECT().GetBalance(addr).Return(defaultAmount, nil).Times(1)
 	tcs.mvm.EXPECT().GetNonce(addr).Return(nonce, nil).Times(1)
-	tx := newTx(t, nonce, amount, fee, signer)
+	tx := newTx(t, nonce, defaultAmount, defaultFee, signer)
 	err := tcs.AddToCache(tx, true)
 	require.ErrorIs(t, err, errInsufficientBalance)
 }
@@ -262,7 +305,7 @@ func TestGetMeshTransaction(t *testing.T) {
 	addr := types.BytesToAddress(signer.PublicKey().Bytes())
 	tcs.mvm.EXPECT().GetBalance(addr).Return(defaultBalance, nil).Times(1)
 	tcs.mvm.EXPECT().GetNonce(addr).Return(nonce, nil).Times(1)
-	tx := newTx(t, nonce, amount, fee, signer)
+	tx := newTx(t, nonce, defaultAmount, defaultFee, signer)
 	require.NoError(t, tcs.AddToCache(tx, true))
 	mtx, err := tcs.GetMeshTransaction(tx.ID())
 	require.NoError(t, err)
@@ -321,17 +364,17 @@ func TestGetTransactionsByAddress(t *testing.T) {
 
 	tcs.mvm.EXPECT().GetBalance(addr1).Return(defaultBalance, nil).Times(1)
 	tcs.mvm.EXPECT().GetNonce(addr1).Return(nonce, nil).Times(1)
-	tx0 := newTxWthRecipient(t, addr2, nonce, amount, fee, signer1)
+	tx0 := newTxWthRecipient(t, addr2, nonce, defaultAmount, defaultFee, signer1)
 	require.NoError(t, tcs.AddToCache(tx0, true))
-	tx1 := newTxWthRecipient(t, addr3, nonce+1, amount, fee, signer1)
+	tx1 := newTxWthRecipient(t, addr3, nonce+1, defaultAmount, defaultFee, signer1)
 	require.NoError(t, tcs.AddToCache(tx1, true))
 	require.NoError(t, tcs.LinkTXsWithBlock(types.NewLayerID(5), types.BlockID{11}, []types.TransactionID{tx1.ID()}))
 
 	tcs.mvm.EXPECT().GetBalance(addr2).Return(defaultBalance, nil).Times(1)
 	tcs.mvm.EXPECT().GetNonce(addr2).Return(nonce, nil).Times(1)
-	tx2 := newTxWthRecipient(t, addr3, nonce, amount, fee, signer2)
+	tx2 := newTxWthRecipient(t, addr3, nonce, defaultAmount, defaultFee, signer2)
 	require.NoError(t, tcs.AddToCache(tx2, true))
-	tx3 := newTxWthRecipient(t, addr3, nonce+1, amount, fee, signer2)
+	tx3 := newTxWthRecipient(t, addr3, nonce+1, defaultAmount, defaultFee, signer2)
 	require.NoError(t, tcs.AddToCache(tx3, true))
 	require.NoError(t, tcs.LinkTXsWithBlock(types.NewLayerID(6), types.BlockID{12}, []types.TransactionID{tx3.ID()}))
 
@@ -372,7 +415,7 @@ func TestApplyLayer(t *testing.T) {
 			TxIDs: ids,
 		})
 	for _, tx := range txs {
-		tcs.mvm.EXPECT().GetBalance(tx.Origin()).Return(defaultBalance-(amount+fee), nil)
+		tcs.mvm.EXPECT().GetBalance(tx.Origin()).Return(defaultBalance-(defaultAmount+defaultFee), nil)
 		tcs.mvm.EXPECT().GetNonce(tx.Origin()).Return(nonce+1, nil)
 	}
 	tcs.mvm.EXPECT().ApplyLayer(lid, gomock.Any(), block.Rewards).DoAndReturn(

--- a/txs/interface.go
+++ b/txs/interface.go
@@ -28,7 +28,7 @@ type vmState interface {
 }
 
 type conStateCache interface {
-	GetMempool() (map[types.Address][]*txtypes.NanoTX, error)
+	GetMempool() map[types.Address][]*txtypes.NanoTX
 }
 
 type txProvider interface {

--- a/txs/interface.go
+++ b/txs/interface.go
@@ -46,4 +46,5 @@ type txProvider interface {
 	GetAllPending() ([]*types.MeshTransaction, error)
 	GetAcctPendingFromNonce(types.Address, uint64) ([]*types.MeshTransaction, error)
 	LastAppliedLayer() (types.LayerID, error)
+	GetMeshHash(types.LayerID) (types.Hash32, error)
 }

--- a/txs/mempool_iterator_test.go
+++ b/txs/mempool_iterator_test.go
@@ -1,7 +1,6 @@
 package txs
 
 import (
-	"errors"
 	"testing"
 	"time"
 
@@ -19,11 +18,12 @@ func makeNanoTX(addr types.Address, fee uint64, received time.Time) *txtypes.Nan
 		Tid:       types.RandomTransactionID(),
 		Principal: addr,
 		Fee:       fee,
+		MaxGas:    1,
 		Received:  received,
 	}
 }
 
-func makeMempool() (map[types.Address][]*txtypes.NanoTX, []types.TransactionID) {
+func makeMempool() (map[types.Address][]*txtypes.NanoTX, []*txtypes.NanoTX) {
 	// acct:   [(fee, received) ....]
 	// acct_0: [(4, 3), (4, 4), (4, 5)]
 	// acct_1: [(2, 0), (2, 3)]
@@ -49,43 +49,57 @@ func makeMempool() (map[types.Address][]*txtypes.NanoTX, []types.TransactionID) 
 			makeNanoTX(addr2, 5, now.Add(time.Second*3)),
 		},
 	}
-	expected := []types.TransactionID{
-		mempool[addr2][0].Tid, // (4, 0)
-		mempool[addr0][0].Tid, // (4, 3)
-		mempool[addr0][1].Tid, // (4, 4)
-		mempool[addr0][2].Tid, // (4, 5)
-		mempool[addr2][1].Tid, // (3, 0)
-		mempool[addr1][0].Tid, // (2, 0)
-		mempool[addr2][2].Tid, // (2, 1)
-		mempool[addr2][3].Tid, // (5, 3)
-		mempool[addr1][1].Tid, // (2, 3)
+	expected := []*txtypes.NanoTX{
+		mempool[addr2][0], // (4, 0)
+		mempool[addr0][0], // (4, 3)
+		mempool[addr0][1], // (4, 4)
+		mempool[addr0][2], // (4, 5)
+		mempool[addr2][1], // (3, 0)
+		mempool[addr1][0], // (2, 0)
+		mempool[addr2][2], // (2, 1)
+		mempool[addr2][3], // (5, 3)
+		mempool[addr1][1], // (2, 3)
 	}
 	return mempool, expected
 }
 
-func TestNewMempoolIterator(t *testing.T) {
-	mempool, _ := makeMempool()
-	ctrl := gomock.NewController(t)
-	mockCache := mocks.NewMockconStateCache(ctrl)
-	mockCache.EXPECT().GetMempool().Return(mempool, nil)
-	_, err := newMempoolIterator(logtest.New(t), mockCache, 100)
-	require.NoError(t, err)
-
-	errUnknown := errors.New("unknown")
-	mockCache.EXPECT().GetMempool().Return(nil, errUnknown)
-	_, err = newMempoolIterator(logtest.New(t), mockCache, 100)
-	require.ErrorIs(t, err, errUnknown)
+func testPopAll(t *testing.T, mi *mempoolIterator, expected []*txtypes.NanoTX) {
+	got, byAddrAndNonce := mi.PopAll()
+	require.Equal(t, expected, got)
+	for _, ntx := range got {
+		ntxs, ok := byAddrAndNonce[ntx.Principal]
+		require.True(t, ok)
+		if len(ntxs) > 1 {
+			byAddrAndNonce[ntx.Principal] = byAddrAndNonce[ntx.Principal][1:]
+		} else {
+			delete(byAddrAndNonce, ntx.Principal)
+		}
+	}
+	require.Empty(t, byAddrAndNonce)
 }
 
 func TestPopAll(t *testing.T) {
 	mempool, expected := makeMempool()
 	ctrl := gomock.NewController(t)
 	mockCache := mocks.NewMockconStateCache(ctrl)
-	mockCache.EXPECT().GetMempool().Return(mempool, nil)
-	numTXs := 3
-	mi, err := newMempoolIterator(logtest.New(t), mockCache, numTXs)
-	require.NoError(t, err)
-	require.Equal(t, expected[0:numTXs], mi.PopAll())
+	mockCache.EXPECT().GetMempool().Return(mempool)
+	gasLimit := uint64(3)
+	mi := newMempoolIterator(logtest.New(t), mockCache, gasLimit)
+	testPopAll(t, mi, expected[:gasLimit])
+	require.NotEmpty(t, mempool)
+}
+
+func TestPopAll_SkipSomeGasTooHigh(t *testing.T) {
+	mempool, orderedByFee := makeMempool()
+	ctrl := gomock.NewController(t)
+	mockCache := mocks.NewMockconStateCache(ctrl)
+	mockCache.EXPECT().GetMempool().Return(mempool)
+	gasLimit := uint64(3)
+	// make the 2nd one too expensive to pick, therefore invalidated all txs from addr0
+	orderedByFee[1].MaxGas = 10
+	expected := []*txtypes.NanoTX{orderedByFee[0], orderedByFee[4], orderedByFee[5]}
+	mi := newMempoolIterator(logtest.New(t), mockCache, gasLimit)
+	testPopAll(t, mi, expected)
 	require.NotEmpty(t, mempool)
 }
 
@@ -93,10 +107,9 @@ func TestPopAll_ExhaustMempool(t *testing.T) {
 	mempool, expected := makeMempool()
 	ctrl := gomock.NewController(t)
 	mockCache := mocks.NewMockconStateCache(ctrl)
-	mockCache.EXPECT().GetMempool().Return(mempool, nil)
-	numTXs := 100
-	mi, err := newMempoolIterator(logtest.New(t), mockCache, numTXs)
-	require.NoError(t, err)
-	require.Equal(t, expected, mi.PopAll())
+	mockCache.EXPECT().GetMempool().Return(mempool)
+	gasLimit := uint64(100)
+	mi := newMempoolIterator(logtest.New(t), mockCache, gasLimit)
+	testPopAll(t, mi, expected)
 	require.Empty(t, mempool)
 }

--- a/txs/mocks/mocks.go
+++ b/txs/mocks/mocks.go
@@ -262,12 +262,11 @@ func (m *MockconStateCache) EXPECT() *MockconStateCacheMockRecorder {
 }
 
 // GetMempool mocks base method.
-func (m *MockconStateCache) GetMempool() (map[types.Address][]*types0.NanoTX, error) {
+func (m *MockconStateCache) GetMempool() map[types.Address][]*types0.NanoTX {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMempool")
 	ret0, _ := ret[0].(map[types.Address][]*types0.NanoTX)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	return ret0
 }
 
 // GetMempool indicates an expected call of GetMempool.
@@ -442,6 +441,21 @@ func (m *MocktxProvider) GetByAddress(arg0, arg1 types.LayerID, arg2 types.Addre
 func (mr *MocktxProviderMockRecorder) GetByAddress(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByAddress", reflect.TypeOf((*MocktxProvider)(nil).GetByAddress), arg0, arg1, arg2)
+}
+
+// GetMeshHash mocks base method.
+func (m *MocktxProvider) GetMeshHash(arg0 types.LayerID) (types.Hash32, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMeshHash", arg0)
+	ret0, _ := ret[0].(types.Hash32)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetMeshHash indicates an expected call of GetMeshHash.
+func (mr *MocktxProviderMockRecorder) GetMeshHash(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMeshHash", reflect.TypeOf((*MocktxProvider)(nil).GetMeshHash), arg0)
 }
 
 // Has mocks base method.

--- a/txs/noop_tx_provider.go
+++ b/txs/noop_tx_provider.go
@@ -1,0 +1,37 @@
+package txs
+
+import (
+	"time"
+
+	"github.com/spacemeshos/go-spacemesh/common/types"
+)
+
+// a no-op txs provider for cache to build the transactions for block.
+type nopTP struct{}
+
+func (ntp *nopTP) Add(*types.Transaction, time.Time) error                 { return nil }
+func (ntp *nopTP) Has(types.TransactionID) (bool, error)                   { return false, nil }
+func (ntp *nopTP) Get(types.TransactionID) (*types.MeshTransaction, error) { return nil, nil }
+func (ntp *nopTP) GetBlob(types.TransactionID) ([]byte, error)             { return nil, nil }
+func (ntp *nopTP) GetByAddress(types.LayerID, types.LayerID, types.Address) ([]*types.MeshTransaction, error) {
+	return nil, nil
+}
+
+func (ntp *nopTP) AddToProposal(types.LayerID, types.ProposalID, []types.TransactionID) error {
+	return nil
+}
+func (ntp *nopTP) AddToBlock(types.LayerID, types.BlockID, []types.TransactionID) error { return nil }
+func (ntp *nopTP) UndoLayers(types.LayerID) error                                       { return nil }
+func (ntp *nopTP) ApplyLayer(types.LayerID, types.BlockID, types.Address, map[uint64]types.TransactionID) error {
+	return nil
+}
+func (ntp *nopTP) DiscardNonceBelow(types.Address, uint64) error { return nil }
+func (ntp *nopTP) SetNextLayerBlock(types.TransactionID, types.LayerID) (types.LayerID, types.BlockID, error) {
+	return types.LayerID{}, types.EmptyBlockID, nil
+}
+func (ntp *nopTP) GetAllPending() ([]*types.MeshTransaction, error) { return nil, nil }
+func (ntp *nopTP) GetAcctPendingFromNonce(types.Address, uint64) ([]*types.MeshTransaction, error) {
+	return nil, nil
+}
+func (ntp *nopTP) LastAppliedLayer() (types.LayerID, error)        { return types.LayerID{}, nil }
+func (ntp *nopTP) GetMeshHash(types.LayerID) (types.Hash32, error) { return types.EmptyLayerHash, nil }

--- a/txs/store.go
+++ b/txs/store.go
@@ -6,15 +6,13 @@ import (
 	"time"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
-	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/sql"
 	"github.com/spacemeshos/go-spacemesh/sql/layers"
 	"github.com/spacemeshos/go-spacemesh/sql/transactions"
 )
 
 type store struct {
-	logger log.Log
-	db     *sql.Database
+	db *sql.Database
 }
 
 func newStore(db *sql.Database) *store {
@@ -28,6 +26,11 @@ func (s *store) LastAppliedLayer() (types.LayerID, error) {
 	// it's not correct to query transactions table for max applied layer because
 	// layer can be empty (contains no transactions).
 	return layers.GetLastApplied(s.db)
+}
+
+// GetMeshHash gets the aggregated layer hash at the specified layer.
+func (s *store) GetMeshHash(lid types.LayerID) (types.Hash32, error) {
+	return layers.GetAggregatedHash(s.db, lid)
 }
 
 // Add adds a transaction to the database.

--- a/txs/store_test.go
+++ b/txs/store_test.go
@@ -23,7 +23,7 @@ func TestStore_AddToProposal(t *testing.T) {
 	txs := make([]*types.Transaction, 0, numTXs)
 	for i := 0; i < numTXs; i++ {
 		signer := signing.NewEdSigner()
-		tx := newTx(t, nonce, amount, fee, signer)
+		tx := newTx(t, nonce, defaultAmount, defaultFee, signer)
 		require.NoError(t, st.Add(tx, time.Now()))
 		txs = append(txs, tx)
 	}
@@ -54,7 +54,7 @@ func TestStore_AddToBlock(t *testing.T) {
 	txs := make([]*types.Transaction, 0, numTXs)
 	for i := 0; i < numTXs; i++ {
 		signer := signing.NewEdSigner()
-		tx := newTx(t, nonce, amount, fee, signer)
+		tx := newTx(t, nonce, defaultAmount, defaultFee, signer)
 		require.NoError(t, st.Add(tx, time.Now()))
 		txs = append(txs, tx)
 	}
@@ -86,7 +86,7 @@ func TestStore_ApplyLayer(t *testing.T) {
 	signer := signing.NewEdSigner()
 	// create a bunch of transactions with competing txs for the same nonce
 	for i := 0; i < numTXs; i++ {
-		tx := newTx(t, nonce, amount, fee, signer)
+		tx := newTx(t, nonce, defaultAmount, defaultFee, signer)
 		require.NoError(t, st.Add(tx, time.Now()))
 		txs = append(txs, tx)
 	}
@@ -94,7 +94,7 @@ func TestStore_ApplyLayer(t *testing.T) {
 	// create a bunch of transactions for different account
 	for i := 0; i < numTXs; i++ {
 		s := signing.NewEdSigner()
-		tx := newTx(t, nonce, amount, fee, s)
+		tx := newTx(t, nonce, defaultAmount, defaultFee, s)
 		require.NoError(t, st.Add(tx, time.Now()))
 		txs = append(txs, tx)
 	}
@@ -134,7 +134,7 @@ func TestStore_UndoLayers_Simple(t *testing.T) {
 		for j := 0; j < numLayers; j++ {
 			lyr := lid.Add(uint32(j))
 			nnc := nonce + uint64(j)
-			tx := newTx(t, nnc, amount, fee, signer)
+			tx := newTx(t, nnc, defaultAmount, defaultFee, signer)
 			require.NoError(t, st.Add(tx, time.Now()))
 			txs = append(txs, tx)
 			require.NoError(t, st.ApplyLayer(lyr, types.RandomBlockID(), principal, map[uint64]types.TransactionID{nnc: tx.ID()}))
@@ -166,11 +166,11 @@ func TestStore_UndoLayers_TXsInMultipleLayers(t *testing.T) {
 	principalA := types.BytesToAddress(signerA.PublicKey().Bytes())
 	signerB := signing.NewEdSigner()
 	principalB := types.BytesToAddress(signerB.PublicKey().Bytes())
-	txA0 := newTx(t, nonce, amount, fee, signerA)
-	txA1 := newTx(t, nonce+1, amount, fee, signerA)
-	txA2 := newTx(t, nonce+2, amount, fee, signerA)
-	txB0 := newTx(t, nonce, amount, fee, signerB)
-	txB1 := newTx(t, nonce+1, amount, fee, signerB)
+	txA0 := newTx(t, nonce, defaultAmount, defaultFee, signerA)
+	txA1 := newTx(t, nonce+1, defaultAmount, defaultFee, signerA)
+	txA2 := newTx(t, nonce+2, defaultAmount, defaultFee, signerA)
+	txB0 := newTx(t, nonce, defaultAmount, defaultFee, signerB)
+	txB1 := newTx(t, nonce+1, defaultAmount, defaultFee, signerB)
 	txs := []*types.Transaction{txA0, txA1, txA2, txB0, txB1}
 	for _, tx := range txs {
 		require.NoError(t, st.Add(tx, time.Now()))

--- a/txs/txs_builder.go
+++ b/txs/txs_builder.go
@@ -1,14 +1,239 @@
 package txs
 
 import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math"
 	"math/rand"
+	"sort"
 	"time"
+
+	"github.com/seehuhn/mt19937"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/common/util"
 	"github.com/spacemeshos/go-spacemesh/log"
 	txtypes "github.com/spacemeshos/go-spacemesh/txs/types"
 )
+
+var (
+	errNodeHasBadMeshHash = errors.New("node has different mesh hash from majority")
+	errMultipleStateRoots = errors.New("multiple state root for the same mesh hash")
+
+	mempoolLayer = types.LayerID{}
+)
+
+type blockMetadata struct {
+	candidates     []*txtypes.NanoTX
+	byAddrAndNonce map[types.Address][]*txtypes.NanoTX
+	byTid          map[types.TransactionID]*txtypes.NanoTX
+}
+
+type meshState struct {
+	hash  types.Hash32
+	roots map[types.Hash32]struct{}
+	count int
+}
+
+type proposalMetadata struct {
+	lid        types.LayerID
+	size       int
+	meshHashes map[string]*meshState
+	mtxs       []*types.MeshTransaction
+	optFilter  bool
+}
+
+func extractProposalMetadata(
+	logger log.Log,
+	cfg CSConfig,
+	lid types.LayerID,
+	proposals []*types.Proposal,
+	getTx func(types.TransactionID) (*types.MeshTransaction, error),
+) (*proposalMetadata, error) {
+	var (
+		seen       = make(map[types.TransactionID]struct{})
+		mtxs       = make([]*types.MeshTransaction, 0, len(proposals)*cfg.NumTXsPerProposal)
+		meshHashes = make(map[string]*meshState)
+	)
+	for _, p := range proposals {
+		key := p.MeshHash.ShortString()
+		if _, ok := meshHashes[key]; !ok {
+			meshHashes[key] = &meshState{
+				hash:  p.MeshHash,
+				count: 1,
+				roots: map[types.Hash32]struct{}{p.StateHash: {}},
+			}
+		} else {
+			meshHashes[key].count++
+			meshHashes[key].roots[p.StateHash] = struct{}{}
+		}
+
+		for _, tid := range p.TxIDs {
+			if _, ok := seen[tid]; ok {
+				continue
+			}
+			mtx, err := getTx(tid)
+			if err != nil {
+				logger.With().Error("failed to find proposal tx", p.LayerIndex, p.ID(), tid, log.Err(err))
+				return nil, fmt.Errorf("get proposal tx: %w", err)
+			}
+			seen[tid] = struct{}{}
+			mtxs = append(mtxs, mtx)
+		}
+	}
+	logger.With().Info("extracted proposals metadata",
+		lid,
+		log.Int("num_mesh_hash", len(meshHashes)),
+		log.Int("num_txs", len(mtxs)))
+	return &proposalMetadata{lid: lid, size: len(proposals), mtxs: mtxs, meshHashes: meshHashes}, nil
+}
+
+func getMajorityState(meshHashes map[string]*meshState, numProposals, threshold int) *meshState {
+	for _, ms := range meshHashes {
+		if ms.count*100 > numProposals*threshold {
+			return ms
+		}
+	}
+	return nil
+}
+
+// returns true if there is a consensus on mesh state across proposals.
+func checkStateConsensus(
+	logger log.Log,
+	cfg CSConfig,
+	lid types.LayerID,
+	proposals []*types.Proposal,
+	ownMeshHash types.Hash32,
+	getTx func(types.TransactionID) (*types.MeshTransaction, error),
+) (*proposalMetadata, error) {
+	md, err := extractProposalMetadata(logger, cfg, lid, proposals, getTx)
+	if err != nil {
+		return nil, err
+	}
+
+	ms := getMajorityState(md.meshHashes, md.size, cfg.OptFilterThreshold)
+	if ms == nil {
+		logger.With().Warning("no consensus on mesh hash. NOT doing optimistic filtering", lid)
+		return md, nil
+	}
+
+	if ownMeshHash != ms.hash {
+		logger.With().Error("node mesh hash differ from majority",
+			lid,
+			log.String("majority_hash", ms.hash.String()),
+			log.String("node_hash", ownMeshHash.String()))
+		return nil, errNodeHasBadMeshHash
+	}
+	if len(ms.roots) != 1 {
+		logger.With().Error("multiple state roots for the same mesh contents",
+			log.Object("mesh_state", log.ObjectMarshallerFunc(func(encoder log.ObjectEncoder) error {
+				encoder.AddInt("num_proposals", ms.count)
+				encoder.AddString("mesh_hash", ms.hash.String())
+				_ = encoder.AddArray("state_roots", log.ArrayMarshalerFunc(func(encoder log.ArrayEncoder) error {
+					rl := make([]types.Hash32, 0, len(ms.roots))
+					for r := range ms.roots {
+						rl = append(rl, r)
+					}
+					sort.Slice(rl, func(i, j int) bool { return bytes.Compare(rl[i].Bytes(), rl[j].Bytes()) < 0 })
+					for _, r := range rl {
+						encoder.AppendString(r.String())
+					}
+					return nil
+				}))
+				return nil
+			})))
+		return nil, errMultipleStateRoots
+	}
+	md.optFilter = true
+	logger.With().Info("consensus on mesh and state. doing optimistic filtering",
+		lid, log.Stringer("mesh_hash", ms.hash))
+	return md, nil
+}
+
+// uses a DB-less cache to organize the transactions into a list of transactions that are in nonce order
+// with respect to its principal.
+// e.g.
+// input:  [(addr-0, nonce-9), (addr-1, nonce-4), (addr-2, nonce-7), (addr-0, nonce-8), (addr-1, nonce-3)]
+// output: [(addr-0, nonce-8), (addr-0, nonce-9), (addr-1, nonce-3), (addr-1, nonce-4), (addr-2, nonce-7)]
+//
+// if optimistic filtering is ON, transactions that fail balance/nonce check will be filtered out, as well
+// as transactions that are already applied.
+func orderTXs(logger log.Log, pmd *proposalMetadata, realState stateFunc, blockSeed []byte) (*blockMetadata, error) {
+	stateF := realState
+	candidates := pmd.mtxs
+	if pmd.optFilter {
+		candidates = make([]*types.MeshTransaction, 0, len(pmd.mtxs))
+		for _, mtx := range pmd.mtxs {
+			if mtx.State != types.APPLIED {
+				mtx.LayerID = mempoolLayer // for dbLessCache.GetMempool
+				candidates = append(candidates, mtx)
+			}
+		}
+	} else {
+		minNonceByAddr := make(map[types.Address]uint64)
+		for _, mtx := range pmd.mtxs {
+			mtx.LayerID = mempoolLayer // for dbLessCache.GetMempool
+			principal := mtx.Origin()
+			if _, ok := minNonceByAddr[principal]; !ok {
+				minNonceByAddr[principal] = mtx.AccountNonce
+			} else if minNonceByAddr[principal] > mtx.AccountNonce {
+				minNonceByAddr[principal] = mtx.AccountNonce
+			}
+		}
+		stateF = func(addr types.Address) (uint64, uint64) {
+			if _, ok := minNonceByAddr[addr]; !ok {
+				logger.With().Fatal("principal not found", addr)
+			}
+			return minNonceByAddr[addr], math.MaxUint64
+		}
+	}
+	// this cache is used for building the set of transactions in a block.
+	// we do not want to access database here, as all transactions are already in memory.
+	dbLessCache := &cache{
+		logger:    logger,
+		tp:        &nopTP{},
+		stateF:    stateF,
+		pending:   make(map[types.Address]*accountCache),
+		cachedTXs: make(map[types.TransactionID]*txtypes.NanoTX),
+	}
+	if err := dbLessCache.BuildFromTXs(candidates, blockSeed); err != nil {
+		return nil, err
+	}
+	byAddrAndNonce := dbLessCache.GetMempool()
+	ntxs := make([]*txtypes.NanoTX, 0, len(pmd.mtxs))
+	byTid := make(map[types.TransactionID]*txtypes.NanoTX)
+	for _, acctTXs := range byAddrAndNonce {
+		ntxs = append(ntxs, acctTXs...)
+		for _, ntx := range acctTXs {
+			byTid[ntx.Tid] = ntx
+		}
+	}
+	return &blockMetadata{candidates: ntxs, byAddrAndNonce: byAddrAndNonce, byTid: byTid}, nil
+}
+
+func getBlockTXs(logger log.Log, pmd *proposalMetadata, getState stateFunc, blockSeed []byte, gasLimit uint64) ([]types.TransactionID, error) {
+	bmd, err := orderTXs(logger, pmd, getState, blockSeed)
+	if err != nil {
+		logger.With().Error("failed to build txs cache for block", log.Err(err))
+		return nil, err
+	}
+	if len(bmd.candidates) == 0 {
+		logger.With().Warning("no feasible txs for block")
+		return nil, nil
+	}
+
+	sort.Slice(bmd.candidates, func(i, j int) bool { return bmd.candidates[i].Tid.Compare(bmd.candidates[j].Tid) })
+	// initialize a Mersenne Twister with the block seed and use it as a source of randomness for
+	// a Fisher-Yates shuffle of the sorted transaction IDs.
+	mt := mt19937.New()
+	mt.SeedFromSlice(toUint64Slice(blockSeed))
+	rng := rand.New(mt)
+	ordered := shuffleWithNonceOrder(logger, rng, len(bmd.candidates), bmd.candidates, bmd.byAddrAndNonce)
+	logger.With().Debug("block txs after shuffle", log.Int("num_txs", len(ordered)))
+	return prune(logger, ordered, bmd.byTid, gasLimit), nil
+}
 
 func getProposalTXs(logger log.Log, numTXs int, predictedBlock []*txtypes.NanoTX, byAddrAndNonce map[types.Address][]*txtypes.NanoTX) []types.TransactionID {
 	if len(predictedBlock) <= numTXs {
@@ -53,4 +278,38 @@ func shuffleWithNonceOrder(
 		}
 	}
 	return result
+}
+
+func prune(logger log.Log, tids []types.TransactionID, byTid map[types.TransactionID]*txtypes.NanoTX, gasLimit uint64) []types.TransactionID {
+	var (
+		gasRemaining = gasLimit
+		idx          int
+		tid          types.TransactionID
+	)
+	for idx, tid = range tids {
+		if gasRemaining < minTXGas {
+			logger.With().Debug("gas exhausted for block",
+				log.Int("num_txs", idx),
+				log.Uint64("gas_left", gasRemaining),
+				log.Uint64("gas_limit", gasLimit))
+			return tids[:idx]
+		}
+		ntx, ok := byTid[tid]
+		if !ok {
+			logger.With().Fatal("tx missing", tid)
+		}
+		gasRemaining -= ntx.MaxGas
+	}
+	logger.With().Debug("block txs after pruning", log.Int("num_txs", len(tids)))
+	return tids
+}
+
+func toUint64Slice(b []byte) []uint64 {
+	const numByte = 8
+	l := len(b)
+	var s []uint64
+	for i := 0; i < l; i += numByte {
+		s = append(s, binary.LittleEndian.Uint64(b[i:util.Min(l, i+numByte)]))
+	}
+	return s
 }

--- a/txs/txs_builder.go
+++ b/txs/txs_builder.go
@@ -1,0 +1,56 @@
+package txs
+
+import (
+	"math/rand"
+	"time"
+
+	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/common/util"
+	"github.com/spacemeshos/go-spacemesh/log"
+	txtypes "github.com/spacemeshos/go-spacemesh/txs/types"
+)
+
+func getProposalTXs(logger log.Log, numTXs int, predictedBlock []*txtypes.NanoTX, byAddrAndNonce map[types.Address][]*txtypes.NanoTX) []types.TransactionID {
+	if len(predictedBlock) <= numTXs {
+		result := make([]types.TransactionID, 0, len(predictedBlock))
+		for _, ntx := range predictedBlock {
+			result = append(result, ntx.Tid)
+		}
+		return result
+	}
+	// randomly select transactions from the predicted block.
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	return shuffleWithNonceOrder(logger, rng, numTXs, predictedBlock, byAddrAndNonce)
+}
+
+// perform a Fisher-Yates shuffle on the transactions. note that after shuffling, the original list of transactions
+// are no longer in nonce order within the same principal. we simply check which principal occupies the spot after
+// the shuffle and retrieve their transactions in nonce order.
+func shuffleWithNonceOrder(
+	logger log.Log,
+	rng *rand.Rand,
+	numTXs int,
+	ntxs []*txtypes.NanoTX,
+	byAddrAndNonce map[types.Address][]*txtypes.NanoTX,
+) []types.TransactionID {
+	rng.Shuffle(len(ntxs), func(i, j int) { ntxs[i], ntxs[j] = ntxs[j], ntxs[i] })
+	total := util.Min(len(ntxs), numTXs)
+	result := make([]types.TransactionID, 0, total)
+	for _, ntx := range ntxs[:total] {
+		// if a spot is taken by a principal, we add its TX for the next eligible nonce
+		p := ntx.Principal
+		if _, ok := byAddrAndNonce[p]; !ok {
+			logger.With().Fatal("principal missing", p)
+		}
+		if len(byAddrAndNonce[p]) == 0 {
+			logger.With().Fatal("txs missing", p)
+		}
+		result = append(result, byAddrAndNonce[p][0].Tid)
+		if len(byAddrAndNonce[p]) == 1 {
+			delete(byAddrAndNonce, p)
+		} else {
+			byAddrAndNonce[p] = byAddrAndNonce[p][1:]
+		}
+	}
+	return result
+}

--- a/txs/txs_builder_test.go
+++ b/txs/txs_builder_test.go
@@ -1,0 +1,176 @@
+package txs
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/log/logtest"
+)
+
+func TestGetBlockTXs_OptimisticFiltering(t *testing.T) {
+	accounts := createState(t, 100)
+	num := 3
+	mtxs := make([]*types.MeshTransaction, 0, num*len(accounts))
+	expected := make([]types.TransactionID, 0, num*len(accounts))
+	now := time.Now()
+	for _, ta := range accounts {
+		nextNonce := ta.nonce
+		balance := ta.balance
+		availPerTx := balance / uint64(num)
+		if availPerTx <= defaultFee {
+			continue
+		}
+		amt := availPerTx - defaultFee
+		for i := 0; i < num; i++ {
+			mtx := newMeshTX(t, nextNonce, ta.signer, amt, now)
+			mtxs = append(mtxs, mtx)
+			expected = append(expected, mtx.ID())
+			nextNonce++
+		}
+	}
+	blockSeed := types.RandomHash().Bytes()
+	got, err := getBlockTXs(logtest.New(t), &proposalMetadata{mtxs: mtxs, optFilter: true}, getStateFunc(accounts), blockSeed, math.MaxUint64)
+	require.NoError(t, err)
+	require.Equal(t, len(expected), len(mtxs))
+	require.ElementsMatch(t, expected, got)
+
+	expSize := len(mtxs) / 2
+	gasLimit := uint64(expSize) * defaultGas
+	got, err = getBlockTXs(logtest.New(t), &proposalMetadata{mtxs: mtxs, optFilter: true}, getStateFunc(accounts), blockSeed, gasLimit)
+	require.NoError(t, err)
+	require.Len(t, got, expSize)
+}
+
+func TestGetBlockTXs_OptimisticFiltering_SomeTXsApplied(t *testing.T) {
+	accounts := createState(t, 100)
+	num := 3
+	mtxs := make([]*types.MeshTransaction, 0, num*len(accounts))
+	expected := make([]types.TransactionID, 0, num*len(accounts))
+	now := time.Now()
+	for _, ta := range accounts {
+		// causing the first tx for every account APPLIED
+		nextNonce := ta.nonce - 1
+		balance := ta.balance
+		availPerTx := balance / uint64(num)
+		if availPerTx <= defaultFee {
+			continue
+		}
+		amt := availPerTx - defaultFee
+		for i := 0; i < num; i++ {
+			mtx := newMeshTX(t, nextNonce, ta.signer, amt, now)
+			if i == 0 {
+				mtx.State = types.APPLIED
+			} else {
+				expected = append(expected, mtx.ID())
+			}
+			mtxs = append(mtxs, mtx)
+			nextNonce++
+		}
+	}
+	blockSeed := types.RandomHash().Bytes()
+	got, err := getBlockTXs(logtest.New(t), &proposalMetadata{mtxs: mtxs, optFilter: true}, getStateFunc(accounts), blockSeed, math.MaxUint64)
+	require.NoError(t, err)
+	require.Less(t, len(expected), len(mtxs))
+	require.ElementsMatch(t, expected, got)
+}
+
+func TestGetBlockTXs_OptimisticFiltering_InsufficientBalance(t *testing.T) {
+	accounts := createState(t, 100)
+	num := 3
+	mtxs := make([]*types.MeshTransaction, 0, num*len(accounts))
+	expected := make([]types.TransactionID, 0, num*len(accounts))
+	now := time.Now()
+	for _, ta := range accounts {
+		nextNonce := ta.nonce
+		balance := ta.balance
+		// cause the last transaction to fail the balance check
+		availPerTx := balance / uint64(num-1)
+		if availPerTx <= defaultFee {
+			continue
+		}
+		amt := availPerTx - defaultFee
+		for i := 0; i < num; i++ {
+			mtx := newMeshTX(t, nextNonce, ta.signer, amt, now)
+			mtxs = append(mtxs, mtx)
+			if i < num-1 {
+				expected = append(expected, mtx.ID())
+			}
+			nextNonce++
+		}
+	}
+	blockSeed := types.RandomHash().Bytes()
+	got, err := getBlockTXs(logtest.New(t), &proposalMetadata{mtxs: mtxs, optFilter: true}, getStateFunc(accounts), blockSeed, math.MaxUint64)
+	require.NoError(t, err)
+	require.Less(t, len(expected), len(mtxs))
+	require.ElementsMatch(t, expected, got)
+}
+
+func TestGetBlockTXs_OptimisticFiltering_BadNonce(t *testing.T) {
+	accounts := createState(t, 100)
+	num := 3
+	mtxs := make([]*types.MeshTransaction, 0, num*len(accounts))
+	expected := make([]types.TransactionID, 0, num*len(accounts))
+	now := time.Now()
+	for _, ta := range accounts {
+		nextNonce := ta.nonce
+		balance := ta.balance
+		availPerTx := balance / uint64(num)
+		if availPerTx <= defaultFee {
+			continue
+		}
+		amt := availPerTx - defaultFee
+		for i := 0; i < num; i++ {
+			mtx := newMeshTX(t, nextNonce, ta.signer, amt, now)
+			mtxs = append(mtxs, mtx)
+			// cause the following transaction to fail the nonce check
+			nextNonce = nextNonce + 2
+			if i == 0 {
+				expected = append(expected, mtx.ID())
+			}
+		}
+	}
+	blockSeed := types.RandomHash().Bytes()
+	got, err := getBlockTXs(logtest.New(t), &proposalMetadata{mtxs: mtxs, optFilter: true}, getStateFunc(accounts), blockSeed, math.MaxUint64)
+	require.NoError(t, err)
+	require.Less(t, len(expected), len(mtxs))
+	require.ElementsMatch(t, expected, got)
+}
+
+func TestGetBlockTXs_NoOptimisticFiltering(t *testing.T) {
+	accounts := createState(t, 100)
+	num := 3
+	mtxs := make([]*types.MeshTransaction, 0, num*len(accounts))
+	expected := make([]types.TransactionID, 0, num*len(accounts))
+	now := time.Now()
+	for _, ta := range accounts {
+		nextNonce := ta.nonce
+		balance := ta.balance
+		// every tx used up the balance
+		for i := 0; i < num; i++ {
+			mtx := newMeshTX(t, nextNonce, ta.signer, balance, now)
+			mtxs = append(mtxs, mtx)
+			expected = append(expected, mtx.ID())
+			nextNonce++
+		}
+	}
+	blockSeed := types.RandomHash().Bytes()
+	got, err := getBlockTXs(logtest.New(t), &proposalMetadata{mtxs: mtxs, optFilter: false}, getStateFunc(accounts), blockSeed, math.MaxUint64)
+	require.NoError(t, err)
+	require.Equal(t, len(expected), len(mtxs))
+	require.ElementsMatch(t, expected, got)
+
+	expSize := len(mtxs) / 2
+	gasLimit := uint64(expSize) * defaultGas
+	got, err = getBlockTXs(logtest.New(t), &proposalMetadata{mtxs: mtxs, optFilter: false}, getStateFunc(accounts), blockSeed, gasLimit)
+	require.NoError(t, err)
+	require.Len(t, got, expSize)
+
+	// no txs will return if optimistic filtering is ON
+	got, err = getBlockTXs(logtest.New(t), &proposalMetadata{mtxs: mtxs, optFilter: true}, getStateFunc(accounts), blockSeed, math.MaxUint64)
+	require.NoError(t, err)
+	require.Empty(t, got)
+}

--- a/txs/types/nano_tx.go
+++ b/txs/types/nano_tx.go
@@ -10,7 +10,8 @@ import (
 type NanoTX struct {
 	Tid       types.TransactionID
 	Principal types.Address
-	Fee       uint64
+	Fee       uint64 // TODO replace with gas price
+	MaxGas    uint64
 	Received  time.Time
 
 	Amount uint64
@@ -25,6 +26,7 @@ func NewNanoTX(mtx *types.MeshTransaction) *NanoTX {
 		Tid:       mtx.ID(),
 		Principal: mtx.Origin(),
 		Fee:       mtx.GetFee(),
+		MaxGas:    mtx.MaxGas(),
 		Amount:    mtx.Amount,
 		Nonce:     mtx.AccountNonce,
 		Received:  mtx.Received,

--- a/txs/types/nano_tx_test.go
+++ b/txs/types/nano_tx_test.go
@@ -1,0 +1,78 @@
+package types
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	ctypes "github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/signing"
+	"github.com/spacemeshos/go-spacemesh/vm/transaction"
+)
+
+func createMeshTX(t *testing.T, signer *signing.EdSigner, lid ctypes.LayerID) *ctypes.MeshTransaction {
+	t.Helper()
+	tx, err := transaction.GenerateCallTransaction(signer, ctypes.Address{1, 2, 3}, 223, uint64(rand.Intn(10000)), 31, 179997)
+	require.NoError(t, err)
+	return &ctypes.MeshTransaction{
+		Transaction: *tx,
+		LayerID:     lid,
+		BlockID:     ctypes.BlockID{1, 3, 5},
+		Received:    time.Now(),
+		State:       ctypes.MEMPOOL,
+	}
+}
+
+func TestNewNanoTX(t *testing.T) {
+	mtx := createMeshTX(t, signing.NewEdSigner(), ctypes.NewLayerID(13))
+	ntx := NewNanoTX(mtx)
+	require.Equal(t, mtx.ID(), ntx.Tid)
+	require.Equal(t, mtx.Origin(), ntx.Principal)
+	require.Equal(t, mtx.Fee, ntx.Fee)
+	require.Equal(t, mtx.MaxGas(), ntx.MaxGas)
+	require.Equal(t, mtx.Received, ntx.Received)
+	require.Equal(t, mtx.Amount, ntx.Amount)
+	require.Equal(t, mtx.AccountNonce, ntx.Nonce)
+	require.Equal(t, mtx.BlockID, ntx.Block)
+	require.Equal(t, mtx.LayerID, ntx.Layer)
+	require.Equal(t, mtx.Amount+mtx.Fee, ntx.MaxSpending())
+}
+
+func TestUpdateMaybe(t *testing.T) {
+	mtx := createMeshTX(t, signing.NewEdSigner(), ctypes.LayerID{})
+	ntx := NewNanoTX(mtx)
+	lid := ctypes.NewLayerID(23)
+	bid := ctypes.RandomBlockID()
+	require.NotEqual(t, lid, ntx.Layer)
+	require.NotEqual(t, bid, ntx.Block)
+	ntx.UpdateLayerMaybe(lid, bid)
+	require.Equal(t, lid, ntx.Layer)
+	require.Equal(t, bid, ntx.Block)
+
+	lid = lid.Sub(1)
+	ntx.UpdateLayerMaybe(lid, ctypes.EmptyBlockID)
+	require.Equal(t, lid, ntx.Layer)
+	require.Equal(t, ctypes.EmptyBlockID, ntx.Block)
+
+	lid = lid.Add(1)
+	bid = ctypes.RandomBlockID()
+	ntx.UpdateLayerMaybe(lid, ctypes.RandomBlockID())
+	require.Equal(t, lid.Sub(1), ntx.Layer)
+	require.Equal(t, ctypes.EmptyBlockID, ntx.Block)
+}
+
+func TestBetter(t *testing.T) {
+	signer := signing.NewEdSigner()
+	ntx0 := NewNanoTX(createMeshTX(t, signer, ctypes.LayerID{}))
+	ntx1 := NewNanoTX(createMeshTX(t, signer, ctypes.LayerID{}))
+	require.Equal(t, ntx0.Principal, ntx1.Principal)
+	require.Equal(t, ntx0.Nonce, ntx1.Nonce)
+	// fees are equal, ntx0 is better due to earlier timestamp
+	require.True(t, ntx0.Better(ntx1))
+
+	// ntx1 now has higher fee, so it's better than ntx0
+	ntx1.Fee = ntx0.Fee + 1
+	require.False(t, ntx0.Better(ntx1))
+}


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
Closes #3035
Closes #3036
<!-- `Closes #XXXX, closes #XXXX, ...` links mentioned issues to this PR and automatically closes them when this it's merged -->

## Changes
<!-- Please describe in detail the changes made -->
see #3035 and #3036 for implementation details.

proposal and block constructions uses the same code (cache.go) to construct the list of transactions. 

key points:
- txs balance check and nonce ordering (conservative cache)
  - proposals construction uses a conservative cache backed by database data for getting more eligible txs
  - block construction uses a conservative cache without a database, since the set of txs are fixed by the proposals  
- txs selection
  - proposal construction uses mempool_iterator to sort the best N txs, constraints by gas limit, for a proposal, and then sort them in nonce order within each account.
  - block construction has to include all txs from proposals, it put these txs in a stable order while keeping nonce order within each account, and pick them in sequence up to gas limit.
- selection stability
  - proposal construction uses local randomness and is not stable
  - block construction uses a Mersenne Twister (seeded by the hare consensus output) as source of randomness and is stable.
- optimistic filtering for block
  - ON: the conservative cache will use the real state for balance/nonce check and drop those that fail the check
  - OFF: the conservative cache will use a fake state that allow all txs to pass the check, hence keeping all txs

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->
unit tests, systests

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
