### PR TITLE
[Merged by Bors] - logging: make eligibility log a list of (layer,slot) pair

### DIFF
--- a/miner/oracle.go
+++ b/miner/oracle.go
@@ -170,7 +170,7 @@ func (o *Oracle) calcEligibilityProofs(weight uint64, epoch types.EpochID, beaco
 	logger.With().Info("proposal eligibility calculated",
 		log.Uint32("total_num_slots", numEligibleSlots),
 		log.Int("num_layers_eligible", len(eligibilityProofs)),
-		log.Object("layers_to_num_proposals", log.ObjectMarshallerFunc(func(encoder log.ObjectEncoder) error {
+		log.Array("layers_to_num_proposals", log.ArrayMarshalerFunc(func(encoder log.ArrayEncoder) error {
 			// Sort the layer map to log the layer data in order
 			keys := make([]types.LayerID, 0, len(eligibilityProofs))
 			for k := range eligibilityProofs {
@@ -180,8 +180,11 @@ func (o *Oracle) calcEligibilityProofs(weight uint64, epoch types.EpochID, beaco
 				return keys[i].Before(keys[j])
 			})
 			for _, lyr := range keys {
-				encoder.AddUint32("layer", lyr.Uint32())
-				encoder.AddInt("slots", len(eligibilityProofs[lyr]))
+				encoder.AppendObject(log.ObjectMarshallerFunc(func(encoder log.ObjectEncoder) error {
+					encoder.AddUint32("layer", lyr.Uint32())
+					encoder.AddInt("slots", len(eligibilityProofs[lyr]))
+					return nil
+				}))
 			}
 			return nil
 		})))


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
Closes #3012
<!-- `Closes #XXXX, closes #XXXX, ...` links mentioned issues to this PR and automatically closes them when this it's merged -->

## Changes
<!-- Please describe in detail the changes made -->
with this PR, the eligibility log looks like below (copied from grafana loki output
```
layers_to_num_proposals | [{"layer":16,"slots":6},{"layer":17,"slots":6},{"layer":18,"slots":4},{"layer":19,"slots":4}]
```

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->
unit test, systest

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
