### PR TITLE
[Merged by Bors] - ballot: detect malicious conflicting votes in a ballot

### DIFF
--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -551,10 +551,13 @@ func (app *App) initServices(ctx context.Context,
 
 	proposalListener := proposals.NewHandler(fetcherWrapped, beaconProtocol, atxDB, msh, proposalDB,
 		proposals.WithLogger(app.addLogger(ProposalListenerLogger, lg)),
-		proposals.WithLayerPerEpoch(layersPerEpoch),
-		proposals.WithLayerSize(layerSize),
-		proposals.WithGoldenATXID(goldenATXID),
-		proposals.WithMaxExceptions(trtlCfg.MaxExceptions))
+		proposals.WithConfig(proposals.Config{
+			LayerSize:      layerSize,
+			LayersPerEpoch: layersPerEpoch,
+			GoldenATXID:    goldenATXID,
+			MaxExceptions:  trtlCfg.MaxExceptions,
+			Hdist:          trtlCfg.Hdist,
+		}))
 
 	blockHandller := blocks.NewHandler(fetcherWrapped, msh,
 		blocks.WithLogger(app.addLogger(BlockHandlerLogger, lg)))

--- a/mesh/meshdb.go
+++ b/mesh/meshdb.go
@@ -111,6 +111,11 @@ func (m *DB) Blocks() database.Getter {
 	return newBlockFetcherDB(m)
 }
 
+// SetIdentityMalicious records an identity to be malicious.
+func (m *DB) SetIdentityMalicious(pubKey *signing.PublicKey) error {
+	return identities.SetMalicious(m.db, pubKey.Bytes())
+}
+
 // AddBallot adds a ballot to the database.
 func (m *DB) AddBallot(b *types.Ballot) error {
 	mal, err := identities.IsMalicious(m.db, b.SmesherID().Bytes())
@@ -196,11 +201,12 @@ func (m *DB) HasBlock(bid types.BlockID) bool {
 
 // GetBlock returns the block specified by the block ID.
 func (m *DB) GetBlock(bid types.BlockID) (*types.Block, error) {
-	b, err := m.getBlock(bid)
-	if err != nil {
-		return nil, err
-	}
-	return b, nil
+	return blocks.Get(m.db, bid)
+}
+
+// GetBlockLayer returns the layer of the block specified by the block ID.
+func (m *DB) GetBlockLayer(bid types.BlockID) (types.LayerID, error) {
+	return blocks.Layer(m.db, bid)
 }
 
 // LayerBlockIds retrieves all block IDs from the layer specified by layer ID.
@@ -223,10 +229,6 @@ func (m *DB) LayerBlocks(lid types.LayerID) ([]*types.Block, error) {
 		rst = append(rst, block)
 	}
 	return rst, nil
-}
-
-func (m *DB) getBlock(id types.BlockID) (*types.Block, error) {
-	return blocks.Get(m.db, id)
 }
 
 // AddZeroBlockLayer tags lyr as a layer without blocks.

--- a/mesh/meshdb_test.go
+++ b/mesh/meshdb_test.go
@@ -147,7 +147,7 @@ func BenchmarkNewPersistentMeshDB(b *testing.B) {
 			lStart = time.Now()
 			for i := 0; i < 100; i++ {
 				for _, blk := range lyr.Blocks() {
-					block, err := mdb.getBlock(blk.ID())
+					block, err := mdb.GetBlock(blk.ID())
 					require.NoError(b, err)
 					require.NotNil(b, block)
 				}

--- a/proposals/handler.go
+++ b/proposals/handler.go
@@ -298,7 +298,10 @@ func (h *Handler) setBallotMalicious(ctx context.Context, b *types.Ballot) error
 
 func (h *Handler) checkVotesConsistency(ctx context.Context, b *types.Ballot) error {
 	exceptions := map[types.BlockID]struct{}{}
-	cutoff := b.LayerIndex.Sub(h.cfg.Hdist)
+	cutoff := types.LayerID{}
+	if b.LayerIndex.After(types.NewLayerID(h.cfg.Hdist)) {
+		cutoff = b.LayerIndex.Sub(h.cfg.Hdist)
+	}
 	layers := make(map[types.LayerID]types.BlockID)
 	// a ballot should not vote for multiple blocks in the same layer within hdist,
 	// since hare only output a single block each layer and miner should vote according

--- a/proposals/handler.go
+++ b/proposals/handler.go
@@ -29,6 +29,7 @@ var (
 	errEmptyActiveSet        = errors.New("ref ballot declares empty active set")
 	errMissingBeacon         = errors.New("beacon is missing in ref ballot")
 	errNotEligible           = errors.New("ballot not eligible")
+	errDoubleVoting          = errors.New("ballot doubly-voted in same layer")
 	errConflictingExceptions = errors.New("conflicting exceptions")
 	errExceptionsOverflow    = errors.New("too many exceptions")
 	errDuplicateTX           = errors.New("duplicate TxID in proposal")
@@ -49,44 +50,22 @@ type Handler struct {
 
 // Config defines configuration for the handler.
 type Config struct {
-	LayerSize            uint32
-	LayersPerEpoch       uint32
-	GoldenATXID          types.ATXID
-	MaxExceptions        int
-	EligibilityValidator eligibilityValidator
+	LayerSize      uint32
+	LayersPerEpoch uint32
+	GoldenATXID    types.ATXID
+	MaxExceptions  int
+	Hdist          uint32
 }
 
 // defaultConfig for BlockHandler.
 func defaultConfig() Config {
 	return Config{
-		MaxExceptions:        1000,
-		EligibilityValidator: nil,
+		MaxExceptions: 1000,
 	}
 }
 
 // Opt for configuring Handler.
 type Opt func(h *Handler)
-
-// WithGoldenATXID defines the golden ATXID.
-func WithGoldenATXID(atx types.ATXID) Opt {
-	return func(h *Handler) {
-		h.cfg.GoldenATXID = atx
-	}
-}
-
-// WithLayerSize defines the average number of proposal per layer.
-func WithLayerSize(size uint32) Opt {
-	return func(h *Handler) {
-		h.cfg.LayerSize = size
-	}
-}
-
-// WithLayerPerEpoch defines the number of layers per epoch.
-func WithLayerPerEpoch(layers uint32) Opt {
-	return func(h *Handler) {
-		h.cfg.LayersPerEpoch = layers
-	}
-}
 
 // withValidator defines eligibility Validator.
 func withValidator(v eligibilityValidator) Opt {
@@ -95,17 +74,17 @@ func withValidator(v eligibilityValidator) Opt {
 	}
 }
 
-// WithMaxExceptions defines max allowed exceptions in a ballot.
-func WithMaxExceptions(max int) Opt {
-	return func(h *Handler) {
-		h.cfg.MaxExceptions = max
-	}
-}
-
 // WithLogger defines logger for Handler.
 func WithLogger(logger log.Log) Opt {
 	return func(h *Handler) {
 		h.logger = logger
+	}
+}
+
+// WithConfig defines protocol parameters.
+func WithConfig(cfg Config) Opt {
+	return func(h *Handler) {
+		h.cfg = cfg
 	}
 }
 
@@ -245,7 +224,7 @@ func (h *Handler) processBallot(ctx context.Context, b *types.Ballot, logger log
 func (h *Handler) checkBallotSyntacticValidity(ctx context.Context, b *types.Ballot) error {
 	h.logger.WithContext(ctx).With().Debug("checking proposal syntactic validity")
 
-	if err := h.checkBallotDataIntegrity(b); err != nil {
+	if err := h.checkBallotDataIntegrity(ctx, b); err != nil {
 		h.logger.WithContext(ctx).With().Warning("ballot integrity check failed", log.Err(err))
 		return err
 	}
@@ -264,7 +243,7 @@ func (h *Handler) checkBallotSyntacticValidity(ctx context.Context, b *types.Bal
 	return nil
 }
 
-func (h *Handler) checkBallotDataIntegrity(b *types.Ballot) error {
+func (h *Handler) checkBallotDataIntegrity(ctx context.Context, b *types.Ballot) error {
 	if b.AtxID == *types.EmptyATXID || b.AtxID == h.cfg.GoldenATXID {
 		return errInvalidATXID
 	}
@@ -298,28 +277,93 @@ func (h *Handler) checkBallotDataIntegrity(b *types.Ballot) error {
 		}
 	}
 
-	if err := checkExceptions(b, h.cfg.MaxExceptions); err != nil {
+	if err := h.checkVotesConsistency(ctx, b); err != nil {
 		return err
 	}
 	return nil
 }
 
-func checkExceptions(ballot *types.Ballot, max int) error {
+func (h *Handler) setBallotMalicious(ctx context.Context, b *types.Ballot) error {
+	if err := h.mesh.SetIdentityMalicious(b.SmesherID()); err != nil {
+		h.logger.WithContext(ctx).With().Error("failed to set smesher malicious",
+			b.ID(),
+			b.LayerIndex,
+			log.Stringer("smesher", b.SmesherID()),
+			log.Err(err))
+		return fmt.Errorf("set smesher malcious: %w", err)
+	}
+	b.SetMalicious()
+	return nil
+}
+
+func (h *Handler) checkVotesConsistency(ctx context.Context, b *types.Ballot) error {
 	exceptions := map[types.BlockID]struct{}{}
-	// TODO maybe validate that explicit votes do not conflict with abstain layers
-	for _, diff := range [][]types.BlockID{ballot.Votes.Support, ballot.Votes.Against} {
-		for _, bid := range diff {
-			_, exist := exceptions[bid]
-			if exist {
-				return fmt.Errorf("%w: block %s is referenced multiple times in exceptions of ballot %s",
-					errConflictingExceptions, bid, ballot.ID())
+	cutoff := b.LayerIndex.Sub(h.cfg.Hdist)
+	layers := make(map[types.LayerID]types.BlockID)
+	// a ballot should not vote for multiple blocks in the same layer within hdist,
+	// since hare only output a single block each layer and miner should vote according
+	// to the hare output within hdist of the current layer when producing a ballot.
+	for _, bid := range b.Votes.Support {
+		exceptions[bid] = struct{}{}
+		lid, err := h.mesh.GetBlockLayer(bid)
+		if err != nil {
+			h.logger.WithContext(ctx).With().Error("failed to get block layer", log.Err(err))
+			return fmt.Errorf("check exception get block layer: %w", err)
+		}
+		if voted, ok := layers[lid]; ok {
+			// already voted for a block in this layer
+			if voted != bid && !lid.Before(cutoff) {
+				h.logger.WithContext(ctx).With().Warning("ballot doubly voted within hdist, set smesher malicious",
+					b.ID(),
+					b.LayerIndex,
+					log.Stringer("smesher", b.SmesherID()),
+					log.Stringer("voted_bid", voted),
+					log.Stringer("voted_bid", bid),
+					log.Uint32("hdist", h.cfg.Hdist))
+				if err = h.setBallotMalicious(ctx, b); err != nil {
+					return err
+				}
+				return errDoubleVoting
 			}
-			exceptions[bid] = struct{}{}
+		} else {
+			layers[lid] = bid
 		}
 	}
-	if len(exceptions) > max {
+	// a ballot should not vote support and against on the same block.
+	for _, bid := range b.Votes.Against {
+		if _, exist := exceptions[bid]; exist {
+			h.logger.WithContext(ctx).With().Warning("conflicting votes on block", bid, b.ID(), b.LayerIndex)
+			return fmt.Errorf("%w: block %s is referenced multiple times in exceptions of ballot %s at layer %v",
+				errConflictingExceptions, bid, b.ID(), b.LayerIndex)
+		}
+		lid, err := h.mesh.GetBlockLayer(bid)
+		if err != nil {
+			h.logger.WithContext(ctx).With().Error("failed to get block layer", log.Err(err))
+			return fmt.Errorf("check exception get block layer: %w", err)
+		}
+		layers[lid] = bid
+	}
+	if len(exceptions) > h.cfg.MaxExceptions {
+		h.logger.WithContext(ctx).With().Warning("exceptions exceed limits",
+			b.ID(),
+			b.LayerIndex,
+			log.Int("len", len(exceptions)),
+			log.Int("max_allowed", h.cfg.MaxExceptions))
 		return fmt.Errorf("%w: %d exceptions with max allowed %d in ballot %s",
-			errExceptionsOverflow, len(exceptions), max, ballot.ID())
+			errExceptionsOverflow, len(exceptions), h.cfg.MaxExceptions, b.ID())
+	}
+	// a ballot should not abstain on a layer that it voted for/against on block in that layer.
+	for _, lid := range b.Votes.Abstain {
+		if _, ok := layers[lid]; ok {
+			h.logger.WithContext(ctx).With().Warning("conflicting votes on layer",
+				b.ID(),
+				b.LayerIndex,
+				log.Stringer("conflict_layer", lid))
+			if err := h.setBallotMalicious(ctx, b); err != nil {
+				return err
+			}
+			return errConflictingExceptions
+		}
 	}
 	return nil
 }

--- a/proposals/handler_test.go
+++ b/proposals/handler_test.go
@@ -238,6 +238,19 @@ func TestBallot_BallotDoubleVotedWithinHdist(t *testing.T) {
 	require.ErrorIs(t, th.HandleBallotData(context.TODO(), data), errDoubleVoting)
 }
 
+func TestBallot_BallotDoubleVotedWithinHdist_LyrBfrHdist(t *testing.T) {
+	th := createTestHandler(t)
+	b := createBallot(t)
+	th.cfg.Hdist = b.LayerIndex.Add(1).Uint32()
+	require.GreaterOrEqual(t, 2, len(b.Votes.Support))
+	data := encodeBallot(t, b)
+	th.mm.EXPECT().HasBallot(b.ID()).Return(false).Times(1)
+	th.mm.EXPECT().GetBlockLayer(b.Votes.Support[0]).Return(b.LayerIndex.Sub(1), nil)
+	th.mm.EXPECT().GetBlockLayer(b.Votes.Support[1]).Return(b.LayerIndex.Sub(1), nil)
+	th.mm.EXPECT().SetIdentityMalicious(b.SmesherID()).Return(nil)
+	require.ErrorIs(t, th.HandleBallotData(context.TODO(), data), errDoubleVoting)
+}
+
 func TestBallot_BallotDoubleVotedWithinHdist_SetMaliciousError(t *testing.T) {
 	th := createTestHandler(t)
 	b := createBallot(t)

--- a/proposals/interface.go
+++ b/proposals/interface.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/signing"
 )
 
 //go:generate mockgen -package=mocks -destination=./mocks/mocks.go -source=./interface.go
@@ -21,6 +22,8 @@ type meshDB interface {
 	HasBallot(types.BallotID) bool
 	AddBallot(*types.Ballot) error
 	GetBallot(types.BallotID) (*types.Ballot, error)
+	GetBlockLayer(types.BlockID) (types.LayerID, error)
+	SetIdentityMalicious(*signing.PublicKey) error
 }
 
 type proposalDB interface {

--- a/proposals/mocks/mocks.go
+++ b/proposals/mocks/mocks.go
@@ -10,6 +10,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	types "github.com/spacemeshos/go-spacemesh/common/types"
+	signing "github.com/spacemeshos/go-spacemesh/signing"
 )
 
 // MockatxDB is a mock of atxDB interface.
@@ -154,6 +155,21 @@ func (mr *MockmeshDBMockRecorder) GetBallot(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBallot", reflect.TypeOf((*MockmeshDB)(nil).GetBallot), arg0)
 }
 
+// GetBlockLayer mocks base method.
+func (m *MockmeshDB) GetBlockLayer(arg0 types.BlockID) (types.LayerID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBlockLayer", arg0)
+	ret0, _ := ret[0].(types.LayerID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetBlockLayer indicates an expected call of GetBlockLayer.
+func (mr *MockmeshDBMockRecorder) GetBlockLayer(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlockLayer", reflect.TypeOf((*MockmeshDB)(nil).GetBlockLayer), arg0)
+}
+
 // HasBallot mocks base method.
 func (m *MockmeshDB) HasBallot(arg0 types.BallotID) bool {
 	m.ctrl.T.Helper()
@@ -166,6 +182,20 @@ func (m *MockmeshDB) HasBallot(arg0 types.BallotID) bool {
 func (mr *MockmeshDBMockRecorder) HasBallot(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasBallot", reflect.TypeOf((*MockmeshDB)(nil).HasBallot), arg0)
+}
+
+// SetIdentityMalicious mocks base method.
+func (m *MockmeshDB) SetIdentityMalicious(arg0 *signing.PublicKey) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetIdentityMalicious", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetIdentityMalicious indicates an expected call of SetIdentityMalicious.
+func (mr *MockmeshDBMockRecorder) SetIdentityMalicious(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetIdentityMalicious", reflect.TypeOf((*MockmeshDB)(nil).SetIdentityMalicious), arg0)
 }
 
 // MockproposalDB is a mock of proposalDB interface.

--- a/sql/blocks/blocks.go
+++ b/sql/blocks/blocks.go
@@ -109,6 +109,22 @@ func IsValid(db sql.Executor, id types.BlockID) (rst bool, err error) {
 	return rst, err
 }
 
+// Layer returns the layer of a block.
+func Layer(db sql.Executor, id types.BlockID) (types.LayerID, error) {
+	var lid types.LayerID
+	if rows, err := db.Exec("select layer from blocks where id = ?1;", func(stmt *sql.Statement) {
+		stmt.BindBytes(1, id.Bytes())
+	}, func(stmt *sql.Statement) bool {
+		lid = types.NewLayerID(uint32(stmt.ColumnInt64(0)))
+		return true
+	}); err != nil {
+		return lid, fmt.Errorf("get block layer %s: %w", id, err)
+	} else if rows == 0 {
+		return lid, fmt.Errorf("%w block %s not in db", sql.ErrNotFound, err)
+	}
+	return lid, nil
+}
+
 // IDsInLayer returns list of block ids in the layer.
 func IDsInLayer(db sql.Executor, lid types.LayerID) ([]types.BlockID, error) {
 	var rst []types.BlockID

--- a/sql/blocks/blocks_test.go
+++ b/sql/blocks/blocks_test.go
@@ -182,3 +182,27 @@ func TestContextualValidity(t *testing.T) {
 		require.True(t, validity.Validity)
 	}
 }
+
+func TestLayer(t *testing.T) {
+	db := sql.InMemory()
+	lid1 := types.NewLayerID(11)
+	block1 := types.NewExistingBlock(
+		types.BlockID{1, 1},
+		types.InnerBlock{LayerIndex: lid1},
+	)
+	lid2 := lid1.Add(1)
+	block2 := types.NewExistingBlock(
+		types.BlockID{2, 2},
+		types.InnerBlock{LayerIndex: lid2},
+	)
+
+	for _, b := range []*types.Block{block1, block2} {
+		require.NoError(t, Add(db, b))
+	}
+
+	for _, b := range []*types.Block{block1, block2} {
+		lid, err := Layer(db, b.ID())
+		require.NoError(t, err)
+		require.Equal(t, b.LayerIndex, lid)
+	}
+}


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
Closes #3048
<!-- `Closes #XXXX, closes #XXXX, ...` links mentioned issues to this PR and automatically closes them when this it's merged -->

## Changes
<!-- Please describe in detail the changes made -->
treat the following vote pattern as malicious and syntactically invalid
- voting more than one blocks for the same layer within hdist of the ballot layer
- abstain on a layer and voted for/against on block in the layer it abstained

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->
unit tests

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
