### PR TITLE
[Merged by Bors] - p2p remove time.Sleep from tests

### DIFF
--- a/p2p/nodechecker_test.go
+++ b/p2p/nodechecker_test.go
@@ -107,18 +107,25 @@ func TestHost_LocalAddressChange(t *testing.T) {
 			discoveryBootstrap(nodeA.host.discovery)
 			discoveryBootstrap(nodeB.host.discovery)
 
-			require.Equal(t, 1, len(nodeB.host.Peerstore().Addrs(nodeA.host.ID())), "nodeB should have 1 address of nodeA")
+			require.Eventually(t, func() bool {
+				return len(nodeB.host.Peerstore().Addrs(nodeA.host.ID())) == 1
+			}, 2*time.Second, 100*time.Millisecond, "nodeB should have 1 address of nodeA")
 
 			// assing new address to nodeA, expect nodeB to be notified.
 			require.NoError(t, nodeA.host.Network().Listen(addrANew), "nodeA should be able to listen on new address")
 
-			time.Sleep(100 * time.Millisecond)
-			for _, addr := range nodeB.host.Peerstore().Addrs(nodeA.host.ID()) {
-				require.Condition(t, func() bool {
-					return addr.String() == addrANew.String() || addr.String() == addrAOld.String()
-				}, "nodeB should have address of nodeA")
-			}
-			require.Equal(t, 2, len(nodeB.host.Peerstore().Addrs(nodeA.host.ID())), "nodeB should have 2 addresses of nodeA")
+			require.Eventually(t, func() bool {
+				for _, addr := range nodeB.host.Peerstore().Addrs(nodeA.host.ID()) {
+					valid := addr.String() == addrANew.String() || addr.String() == addrAOld.String()
+					if !valid {
+						return false
+					}
+				}
+				return true
+			}, 2*time.Second, 100*time.Millisecond) // wait for nodeB to be notified
+			require.Eventually(t, func() bool {
+				return len(nodeB.host.Peerstore().Addrs(nodeA.host.ID())) == 2
+			}, 2*time.Second, 100*time.Millisecond, "nodeB should have 2 addresses of nodeA")
 
 			for _, addr := range testCase.block {
 				switch addr {
@@ -134,10 +141,8 @@ func TestHost_LocalAddressChange(t *testing.T) {
 			}
 			require.NoError(t, nodeA.host.Network().ClosePeer(nodeB.host.ID()), "nodeA should be able to close nodeB")
 			require.NoError(t, nodeB.host.Network().ClosePeer(nodeA.host.ID()), "nodeB should be able to close nodeA")
-			time.Sleep(100 * time.Millisecond)
 
 			nodeB.host.discovery.CheckPeers(context.Background())
-			time.Sleep(100 * time.Millisecond)
 
 			addressBookAddresses := nodeB.host.discovery.GetAddresses()
 			if len(testCase.expected) == 2 {

--- a/p2p/peerexchange/bookchecker_test.go
+++ b/p2p/peerexchange/bookchecker_test.go
@@ -27,8 +27,7 @@ func TestDiscovery_CheckBook(t *testing.T) {
 		totalAddressesBefore := calcTotalAddresses(instances)
 		totalPeerAddressesBefore := calcTotalAddressesPeerStore(instances)
 
-		brokeMesh(t, mesh)
-		time.Sleep(3 * time.Second)
+		brokeMesh(t, mesh, instances)
 		checkBooks(instances)
 
 		totalAddressesAfter := calcTotalAddresses(instances)
@@ -48,8 +47,7 @@ func TestDiscovery_CheckBook(t *testing.T) {
 		require.True(t, totalAddressesBefore > 0, "total addresses before break should be greater than 0")
 		require.True(t, totalPeerAddressesBefore > 0, "total addresses before break should be greater than 0")
 
-		brokeMesh(t, mesh)
-		time.Sleep(3 * time.Second)
+		brokeMesh(t, mesh, instances)
 		checkBooks(instances)
 
 		totalAddressesAfter := calcTotalAddresses(instances)
@@ -78,8 +76,9 @@ func TestDiscovery_GetRandomPeers(t *testing.T) {
 	connectedNodeAddress.SetAddr(addr)
 
 	t.Run("empty peers", func(t *testing.T) {
-		time.Sleep(100 * time.Millisecond)
-		require.Equal(t, 0, d.book.NumAddresses())
+		require.Eventually(t, func() bool {
+			return d.book.NumAddresses() == 0
+		}, 2*time.Second, 100*time.Millisecond)
 		res := d.GetRandomPeers(10)
 		require.Equal(t, 0, len(res), "should return 2 peers")
 	})
@@ -93,46 +92,65 @@ func TestDiscovery_GetRandomPeers(t *testing.T) {
 	d.book.AddAddress(connectedNodeAddress, best)
 
 	t.Run("check all nodes in book", func(t *testing.T) {
-		time.Sleep(3 * time.Second)
-		res := d.GetRandomPeers(10)
-		require.Equal(t, 4, len(res), "should return 4 peers")
+		require.Eventually(t, func() bool {
+			return len(d.GetRandomPeers(10)) == 4
+		}, 4*time.Second, 100*time.Millisecond, "should return 4 peers")
 	})
 
 	wrapDiscovery(instances)
 
 	t.Run("return all except connected node", func(t *testing.T) {
-		time.Sleep(3 * time.Second)
-		require.Equal(t, 4, d.book.NumAddresses())
-		res := d.GetRandomPeers(10)
-		require.Equal(t, 3, len(res), "should return 3 peers")
-		require.NotContains(t, res, connectedNodeAddress, "should not return connected node")
+		require.Eventually(t, func() bool {
+			return d.book.NumAddresses() == 4
+		}, 4*time.Second, 100*time.Millisecond)
+
+		require.Eventually(t, func() bool {
+			return len(d.GetRandomPeers(10)) == 3
+		}, 4*time.Second, 100*time.Millisecond, "should return 3 peers")
+		require.NotContains(t, d.GetRandomPeers(10), connectedNodeAddress, "should not return connected node")
 	})
 
 	t.Run("return all except connected node and bootnode", func(t *testing.T) {
 		d.host.ConnManager().Protect(bootNodeAddress.ID, BootNodeTag)
 		defer d.host.ConnManager().Unprotect(bootNodeAddress.ID, BootNodeTag)
-		time.Sleep(3 * time.Second)
-		require.Equal(t, 4, d.book.NumAddresses())
+		require.Eventually(t, func() bool {
+			return d.book.NumAddresses() == 4
+		}, 4*time.Second, 100*time.Millisecond)
+
+		require.Eventually(t, func() bool {
+			return len(d.GetRandomPeers(10)) == 2
+		}, 4*time.Second, 100*time.Millisecond, "should return 2 peers")
 		res := d.GetRandomPeers(10)
-		require.Equal(t, 2, len(res), "should return 2 peers")
 		require.NotContains(t, res, connectedNodeAddress, "should not return connected node")
 		require.NotContains(t, res, bootNodeAddress, "should not return bootnode")
 	})
 
 	t.Run("check last usage address", func(t *testing.T) {
-		time.Sleep(3 * time.Second)
 		// trigger update last usage date
 		d.book.AddAddress(oldNode, best)
-		require.Equal(t, 4, d.book.NumAddresses())
-		time.Sleep(100 * time.Millisecond)
+		require.Eventually(t, func() bool {
+			return d.book.NumAddresses() == 4
+		}, 4*time.Second, 100*time.Millisecond)
+
+		require.Eventually(t, func() bool {
+			return len(d.GetRandomPeers(10)) == 2
+		}, 4*time.Second, 100*time.Millisecond, "should return 2 peers")
+
 		res := d.GetRandomPeers(10)
-		require.Equal(t, 2, len(res), "should return 3 peers")
 		require.NotContains(t, res, oldNode, "should not return connected node")
 
-		time.Sleep(3 * time.Second)
-		res = d.GetRandomPeers(10)
-		require.Contains(t, res, oldNode, "should not return old node")
-		require.Equal(t, 3, len(res), "should return 3 peers")
+		require.Eventually(t, func() bool {
+			res = d.GetRandomPeers(10)
+			if len(res) != 3 {
+				return false
+			}
+			for _, peer := range res {
+				if peer.ID.String() == oldNode.ID.String() {
+					return true
+				}
+			}
+			return false
+		}, 4*time.Second, 100*time.Millisecond, "should return 3 peers and contain old node")
 	})
 }
 
@@ -203,7 +221,6 @@ func wrapDiscovery(instances []*Discovery) {
 				if err := instance.Bootstrap(ctx); errors.Is(err, context.Canceled) {
 					return
 				}
-				time.Sleep(10 * time.Millisecond)
 			}
 		}(instance)
 	}
@@ -211,7 +228,7 @@ func wrapDiscovery(instances []*Discovery) {
 }
 
 // brokeMesh simulate that all peers are disconnected and the mesh is broken.
-func brokeMesh(t *testing.T, mesh mocknet.Mocknet) {
+func brokeMesh(t *testing.T, mesh mocknet.Mocknet, instances []*Discovery) {
 	for _, h := range mesh.Hosts() {
 		for _, hh := range mesh.Hosts() {
 			if h.ID() == hh.ID() {
@@ -223,6 +240,15 @@ func brokeMesh(t *testing.T, mesh mocknet.Mocknet) {
 			// require.NoError(t, mesh.DisconnectNets(h.Network(), hh.Network()))
 		}
 	}
+	// wait until address ussage will expire and will check again
+	require.Eventually(t, func() bool {
+		for _, instance := range instances {
+			if len(instance.GetRandomPeers(10)) == 0 {
+				return false
+			}
+		}
+		return true
+	}, 4*time.Second, 100*time.Millisecond)
 }
 
 // checkBook trigger book check in all instances.


### PR DESCRIPTION
## Motivation
fix flacky tests in p2p addrBook

## Changes
remove time.Sleep from test


## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
