### PR TITLE
[Merged by Bors] - disable TCP/UDP offload on unittests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,10 @@ jobs:
     # should take around 15-18 mins
     timeout-minutes: 20
     steps:
+        # as we use some request to localhost, sometimes it gives us flaky tests. try to disable tcp offloading for fix it
+        # https://github.com/actions/virtual-environments/issues/1187
+      - name: disable TCP/UDP offload
+        run: sudo ethtool -K eth0 tx off rx off
       - name: checkout
         uses: actions/checkout@v2
       - name: set up go


### PR DESCRIPTION
## Motivation
Closes #3241

As we use some request to localhost, sometimes it gives us flaky tests. Try to disable tcp offloading for fix it
Reffering to https://github.com/actions/virtual-environments/issues/1187

## Changes
Modify ci with additional ubuntu command. 

## Test Plan
unit tests

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
