### PR TITLE
[Merged by Bors] - change protocol versions

### DIFF
--- a/activation/activation.go
+++ b/activation/activation.go
@@ -30,7 +30,7 @@ var (
 )
 
 // AtxProtocol is the protocol id for broadcasting atxs over gossip.
-const AtxProtocol = "AtxGossip"
+const AtxProtocol = "AtxGossip/1"
 
 const defaultPoetRetryInterval = 5 * time.Second
 

--- a/activation/poetlistener.go
+++ b/activation/poetlistener.go
@@ -12,7 +12,7 @@ import (
 )
 
 // PoetProofProtocol is the name of the PoetProof gossip protocol.
-const PoetProofProtocol = "PoetProof"
+const PoetProofProtocol = "PoetProof/1"
 
 // PoetListener handles PoET gossip messages.
 type PoetListener struct {

--- a/beacon/handlers.go
+++ b/beacon/handlers.go
@@ -19,13 +19,13 @@ type category uint8
 
 const (
 	// ProposalProtocol is the protocol for sending proposal messages through Gossip.
-	ProposalProtocol = "BeaconProposal"
+	ProposalProtocol = "BeaconProposal/1"
 
 	// FirstVotesProtocol is the protocol for sending first vote messages through Gossip.
-	FirstVotesProtocol = "BeaconFirstVotes"
+	FirstVotesProtocol = "BeaconFirstVotes/1"
 
 	// FollowingVotesProtocol is the protocol for sending following vote messages through Gossip.
-	FollowingVotesProtocol = "BeaconFollowingVotes"
+	FollowingVotesProtocol = "BeaconFollowingVotes/1"
 
 	valid            category = 1
 	potentiallyValid category = 2

--- a/beacon/weakcoin/weak_coin.go
+++ b/beacon/weakcoin/weak_coin.go
@@ -18,7 +18,7 @@ const (
 	// Prefix defines weak coin proposal prefix.
 	proposalPrefix = "WeakCoin"
 	// GossipProtocol is weak coin Gossip protocol name.
-	GossipProtocol = "WeakCoinGossip"
+	GossipProtocol = "WeakCoinGossip/1"
 
 	// equal to 2^256 / 2.
 	defaultThreshold = "0x8000000000000000000000000000000000000000000000000000000000000000"

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -47,7 +47,7 @@ const (
 )
 
 const (
-	fetchProtocol = "/sync/2.0/"
+	fetchProtocol = "/sync/2"
 	batchMaxSize  = 20
 )
 

--- a/hare/algorithm.go
+++ b/hare/algorithm.go
@@ -24,7 +24,7 @@ const (
 	// RoundsPerIteration is the number of rounds per iteration in the hare protocol.
 	RoundsPerIteration = 4
 	// ProtoName is the protocol indicator for hare gossip messages.
-	ProtoName = "HARE_PROTOCOL"
+	ProtoName = "HARE_PROTOCOL/1"
 )
 
 type role byte

--- a/layerfetcher/layers.go
+++ b/layerfetcher/layers.go
@@ -138,8 +138,8 @@ func DefaultConfig() Config {
 }
 
 const (
-	blockProtocol = "/block/1.0.0"
-	atxProtocol   = "/atx/1.0.0"
+	blockProtocol = "/block/1"
+	atxProtocol   = "/atx/1"
 )
 
 // DataHandlers collects handlers for different data type.

--- a/p2p/handshake/handshake.go
+++ b/p2p/handshake/handshake.go
@@ -34,7 +34,7 @@ func WithLog(logger log.Log) Opt {
 }
 
 const (
-	hsprotocol    = "/handshake/1.0.0"
+	hsprotocol    = "/handshake/1"
 	streamTimeout = 10 * time.Second
 )
 

--- a/proposals/handler.go
+++ b/proposals/handler.go
@@ -17,7 +17,7 @@ import (
 )
 
 // NewProposalProtocol is the protocol indicator for gossip Proposals.
-const NewProposalProtocol = "newProposal"
+const NewProposalProtocol = "newProposal/1"
 
 var (
 	errMalformedData         = errors.New("malformed data")

--- a/txs/handler.go
+++ b/txs/handler.go
@@ -12,7 +12,7 @@ import (
 )
 
 // IncomingTxProtocol is the protocol identifier for tx received by gossip that is used by the p2p.
-const IncomingTxProtocol = "TxGossip"
+const IncomingTxProtocol = "TxGossip/1"
 
 var (
 	errMalformedMsg     = errors.New("malformed tx")


### PR DESCRIPTION
i think we should change relevant protocol versions when related types are changed.

for genesis we will probably reset them to 1, and maintain backward compatibility. but for now it is safer to change versions so that not updated clients won't cause issues for new network.

related https://github.com/spacemeshos/go-spacemesh/issues/3247