### PR TITLE
[Merged by Bors] - p2p time sync validation fix - move to separate pkg

### DIFF
--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -42,7 +42,6 @@ import (
 	"github.com/spacemeshos/go-spacemesh/layerfetcher"
 	"github.com/spacemeshos/go-spacemesh/layerpatrol"
 	"github.com/spacemeshos/go-spacemesh/log"
-	"github.com/spacemeshos/go-spacemesh/log/errcode"
 	"github.com/spacemeshos/go-spacemesh/mesh"
 	"github.com/spacemeshos/go-spacemesh/metrics"
 	"github.com/spacemeshos/go-spacemesh/miner"
@@ -296,34 +295,6 @@ type App struct {
 
 func (app *App) introduction() {
 	log.Info("Welcome to Spacemesh. Spacemesh full node is starting...")
-}
-
-type clockErrorDetails struct {
-	Drift time.Duration
-}
-
-func (c *clockErrorDetails) MarshalLogObject(encoder log.ObjectEncoder) error {
-	encoder.AddDuration("drift", c.Drift)
-	return nil
-}
-
-type clockError struct {
-	err     error
-	details clockErrorDetails
-}
-
-func (c *clockError) MarshalLogObject(encoder log.ObjectEncoder) error {
-	encoder.AddString("code", errcode.ErrClockDrift)
-	encoder.AddString("errmsg", c.err.Error())
-	if err := encoder.AddObject("details", &c.details); err != nil {
-		return fmt.Errorf("add object: %w", err)
-	}
-
-	return nil
-}
-
-func (c *clockError) Error() string {
-	return c.err.Error()
 }
 
 // Initialize sets up an exit signal, logging and checks the clock, returns error if clock is not in sync.

--- a/timesync/peersync/clickerror.go
+++ b/timesync/peersync/clickerror.go
@@ -1,0 +1,37 @@
+package peersync
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/spacemeshos/go-spacemesh/log"
+	"github.com/spacemeshos/go-spacemesh/log/errcode"
+)
+
+type ClockError struct {
+	err     error
+	details clockErrorDetails
+}
+
+func (c *ClockError) MarshalLogObject(encoder log.ObjectEncoder) error {
+	encoder.AddString("code", errcode.ErrClockDrift)
+	encoder.AddString("errmsg", c.err.Error())
+	if err := encoder.AddObject("details", &c.details); err != nil {
+		return fmt.Errorf("add object: %w", err)
+	}
+
+	return nil
+}
+
+func (c *ClockError) Error() string {
+	return c.err.Error()
+}
+
+type clockErrorDetails struct {
+	Drift time.Duration
+}
+
+func (c *clockErrorDetails) MarshalLogObject(encoder log.ObjectEncoder) error {
+	encoder.AddDuration("drift", c.Drift)
+	return nil
+}

--- a/timesync/peersync/clockerror.go
+++ b/timesync/peersync/clockerror.go
@@ -8,12 +8,12 @@ import (
 	"github.com/spacemeshos/go-spacemesh/log/errcode"
 )
 
-type ClockError struct {
+type clockError struct {
 	err     error
 	details clockErrorDetails
 }
 
-func (c *ClockError) MarshalLogObject(encoder log.ObjectEncoder) error {
+func (c clockError) MarshalLogObject(encoder log.ObjectEncoder) error {
 	encoder.AddString("code", errcode.ErrClockDrift)
 	encoder.AddString("errmsg", c.err.Error())
 	if err := encoder.AddObject("details", &c.details); err != nil {
@@ -23,7 +23,7 @@ func (c *ClockError) MarshalLogObject(encoder log.ObjectEncoder) error {
 	return nil
 }
 
-func (c *ClockError) Error() string {
+func (c clockError) Error() string {
 	return c.err.Error()
 }
 
@@ -31,7 +31,7 @@ type clockErrorDetails struct {
 	Drift time.Duration
 }
 
-func (c *clockErrorDetails) MarshalLogObject(encoder log.ObjectEncoder) error {
+func (c clockErrorDetails) MarshalLogObject(encoder log.ObjectEncoder) error {
 	encoder.AddDuration("drift", c.Drift)
 	return nil
 }

--- a/timesync/peersync/sync.go
+++ b/timesync/peersync/sync.go
@@ -209,7 +209,10 @@ func (s *Sync) run() error {
 					log.Duration("max_offset", s.config.MaxClockOffset),
 				)
 				if atomic.AddUint32(&s.errCnt, 1) == uint32(s.config.MaxOffsetErrors) {
-					return ErrPeersNotSynced
+					return clockError{
+						err:     ErrPeersNotSynced,
+						details: clockErrorDetails{Drift: offset},
+					}
 				}
 			} else {
 				s.log.With().Info("peers offset is within max allowed clock difference",

--- a/timesync/peersync/sync_test.go
+++ b/timesync/peersync/sync_test.go
@@ -120,7 +120,7 @@ func TestSyncTerminateOnError(t *testing.T) {
 	}()
 	select {
 	case err := <-errors:
-		require.ErrorIs(t, err, ErrPeersNotSynced)
+		require.ErrorContains(t, err, ErrPeersNotSynced.Error())
 	case <-time.After(100 * time.Millisecond):
 		require.FailNow(t, "timed out waiting for sync to fail")
 	}
@@ -167,7 +167,7 @@ func TestSyncSimulateMultiple(t *testing.T) {
 		}()
 		select {
 		case err := <-wait:
-			require.ErrorIs(t, err, errors[i])
+			require.ErrorContains(t, err, errors[i].Error())
 		case <-time.After(1000 * time.Millisecond):
 			require.FailNowf(t, "timed out waiting for an error", "node %d", i)
 		}


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
Closes #3210
<!-- `Closes #XXXX, closes #XXXX, ...` links mentioned issues to this PR and automatically closes them when this it's merged -->

## Changes
`clockError` moved from node.go to separate package.
As we not sync node over ntp server, synchronization goes from peers. If difference with peers more that alloved - node store error. If amount of such errors more that allowed - node stopping execution.

For allow smapp show error - log this fail more detailed via  `clockError` struct. `clockError` implements `ObjectMarshaler` interface, which enrich log

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
