### PR TITLE
check tx order for block syntactic validity

### DIFF
--- a/blocks/handler.go
+++ b/blocks/handler.go
@@ -10,12 +10,14 @@ import (
 	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/sql"
 	"github.com/spacemeshos/go-spacemesh/sql/blocks"
+	"github.com/spacemeshos/go-spacemesh/sql/transactions"
 	"github.com/spacemeshos/go-spacemesh/system"
 )
 
 var (
 	errMalformedData = errors.New("malformed data")
 	errDuplicateTX   = errors.New("duplicate TxID in proposal")
+	errTXsOutOfOrder = errors.New("txs out of order")
 )
 
 // Handler processes Block fetched from peers during sync.
@@ -99,7 +101,24 @@ func (h *Handler) checkTransactions(ctx context.Context, b *types.Block) error {
 		set[tx] = struct{}{}
 	}
 	if err := h.fetcher.GetTxs(ctx, b.TxIDs); err != nil {
-		return fmt.Errorf("block get TXs: %w", err)
+		return fmt.Errorf("block fetch TXs: %w", err)
+	}
+
+	byAddrAndNonce := make(map[types.Address]uint64)
+	for _, tid := range b.TxIDs {
+		mtx, err := transactions.Get(h.db, tid)
+		if err != nil {
+			return fmt.Errorf("block get tx: %w", err)
+		}
+		if _, ok := byAddrAndNonce[mtx.Origin()]; ok {
+			if mtx.AccountNonce == byAddrAndNonce[mtx.Origin()]+1 {
+				byAddrAndNonce[mtx.Origin()] = mtx.AccountNonce
+			} else {
+				return errTXsOutOfOrder
+			}
+		} else {
+			byAddrAndNonce[mtx.Origin()] = mtx.AccountNonce
+		}
 	}
 	return nil
 }

--- a/blocks/handler_test.go
+++ b/blocks/handler_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"math/rand"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -14,9 +15,12 @@ import (
 	"github.com/spacemeshos/go-spacemesh/codec"
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/log/logtest"
+	"github.com/spacemeshos/go-spacemesh/signing"
 	"github.com/spacemeshos/go-spacemesh/sql"
 	"github.com/spacemeshos/go-spacemesh/sql/blocks"
+	"github.com/spacemeshos/go-spacemesh/sql/transactions"
 	smocks "github.com/spacemeshos/go-spacemesh/system/mocks"
+	"github.com/spacemeshos/go-spacemesh/vm/transaction"
 )
 
 type testHandler struct {
@@ -49,6 +53,18 @@ func createBlockData(t *testing.T, layerID types.LayerID, txIDs []types.Transact
 	return block, data
 }
 
+func createAndSaveTxs(t *testing.T, db *sql.Database, numTXs int) []types.TransactionID {
+	t.Helper()
+	txIDs := make([]types.TransactionID, 0, numTXs)
+	for i := 0; i < numTXs; i++ {
+		tx, err := transaction.GenerateCallTransaction(signing.NewEdSigner(), types.HexToAddress("1"), 1, 10, 100, 3)
+		require.NoError(t, err)
+		require.NoError(t, transactions.Add(db, tx, time.Now()))
+		txIDs = append(txIDs, tx.ID())
+	}
+	return txIDs
+}
+
 func Test_HandleBlockData_MalformedData(t *testing.T) {
 	th := createTestHandler(t)
 	layerID := types.NewLayerID(99)
@@ -79,10 +95,27 @@ func Test_HandleBlockData_FailedToFetchTXs(t *testing.T) {
 	assert.ErrorIs(t, th.HandleBlockData(context.TODO(), data), errUnknown)
 }
 
+func Test_HandleBlockData_TXsOutOfOrder(t *testing.T) {
+	th := createTestHandler(t)
+	layerID := types.NewLayerID(99)
+	signer := signing.NewEdSigner()
+	tx1, err := transaction.GenerateCallTransaction(signer, types.HexToAddress("1"), 1, 10, 100, 3)
+	require.NoError(t, err)
+	require.NoError(t, transactions.Add(th.db, tx1, time.Now()))
+	tx2, err := transaction.GenerateCallTransaction(signer, types.HexToAddress("1"), 2, 10, 100, 3)
+	require.NoError(t, err)
+	require.NoError(t, transactions.Add(th.db, tx2, time.Now()))
+	txIDs := types.ToTransactionIDs([]*types.Transaction{tx2, tx1})
+
+	_, data := createBlockData(t, layerID, txIDs)
+	th.mockFetcher.EXPECT().GetTxs(gomock.Any(), txIDs).Return(nil).Times(1)
+	assert.ErrorIs(t, th.HandleBlockData(context.TODO(), data), errTXsOutOfOrder)
+}
+
 func Test_HandleBlockData_FailedToAddBlock(t *testing.T) {
 	th := createTestHandler(t)
 	layerID := types.NewLayerID(99)
-	txIDs := createTransactions(t, max(10, rand.Intn(100)))
+	txIDs := createAndSaveTxs(t, th.db, max(10, rand.Intn(100)))
 
 	block, data := createBlockData(t, layerID, txIDs)
 	th.mockFetcher.EXPECT().GetTxs(gomock.Any(), txIDs).Return(nil).Times(1)
@@ -94,7 +127,7 @@ func Test_HandleBlockData_FailedToAddBlock(t *testing.T) {
 func Test_HandleBlockData(t *testing.T) {
 	th := createTestHandler(t)
 	layerID := types.NewLayerID(99)
-	txIDs := createTransactions(t, max(10, rand.Intn(100)))
+	txIDs := createAndSaveTxs(t, th.db, max(10, rand.Intn(100)))
 
 	block, data := createBlockData(t, layerID, txIDs)
 	th.mockFetcher.EXPECT().GetTxs(gomock.Any(), txIDs).Return(nil).Times(1)


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
Closes #3234
<!-- `Closes #XXXX, closes #XXXX, ...` links mentioned issues to this PR and automatically closes them when this it's merged -->

## Changes
<!-- Please describe in detail the changes made -->
consider a block syntactic invalid when the txs are not in nonce order within the same account

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->
unit tests

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
