### PR TITLE
[Merged by Bors] - beacon: always cleanup epoch data

### DIFF
--- a/beacon/beacon.go
+++ b/beacon/beacon.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	proposalPrefix  = "BP"
-	numEpochsToKeep = 10
+	numEpochsToKeep = 3
 )
 
 var (

--- a/beacon/beacon.go
+++ b/beacon/beacon.go
@@ -520,6 +520,7 @@ func (pd *ProtocolDriver) setRoundInProgress(round types.RoundID) {
 
 func (pd *ProtocolDriver) onNewEpoch(ctx context.Context, epoch types.EpochID) {
 	logger := pd.logger.WithContext(ctx).WithFields(epoch)
+	defer pd.cleanupEpoch(epoch)
 
 	if epoch.IsGenesis() {
 		logger.Info("not running beacon protocol: genesis epochs")
@@ -546,7 +547,6 @@ func (pd *ProtocolDriver) onNewEpoch(ctx context.Context, epoch types.EpochID) {
 		logger.With().Error("epoch not setup correctly", log.Err(err))
 		return
 	}
-	defer pd.cleanupEpoch(epoch)
 
 	logger.With().Info("participating beacon protocol with ATX", atxID, log.Uint64("epoch_weight", epochWeight))
 	pd.runProtocol(ctx, epoch, atxs)


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
Closes #3302
<!-- `Closes #XXXX, closes #XXXX, ...` links mentioned issues to this PR and automatically closes them when this it's merged -->

## Changes
<!-- Please describe in detail the changes made -->
- change number epoch to keep from 10 to 3
- always cleanup epoch data regardless of whether the node is synced or not
- added a test that failed previously and passed with changed code

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->
unit tests, systest

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
