### PR TITLE
[Merged by Bors] - janitor: push all network requests to fetcher

### DIFF
--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -17,19 +17,27 @@ import (
 	"github.com/spacemeshos/go-spacemesh/p2p/server"
 )
 
-var emptyHash = types.Hash32{}
-
 const (
-	fetchProtocol = "/sync/2"
-	batchMaxSize  = 20
-	cacheSize     = 1000
+	atxProtocol     = "/atx/1"
+	lyrDataProtocol = "/layerdata/1"
+	fetchProtocol   = "/fetch/2"
+
+	batchMaxSize = 20
+	cacheSize    = 1000
 )
 
-// ErrCouldNotSend is a special type of error indicating fetch could not be done because message could not be sent to peers.
-type ErrCouldNotSend error
+var (
+	emptyHash = types.Hash32{}
 
-// ErrExceedMaxRetries is returned when MaxRetriesForRequest attempts has been made to fetch data for a hash and failed.
-var ErrExceedMaxRetries = errors.New("fetch failed after max retries for request")
+	// errNoPeers is returned when node has no peers.
+	errNoPeers = errors.New("no peers")
+
+	// errExceedMaxRetries is returned when MaxRetriesForRequest attempts has been made to fetch data for a hash and failed.
+	errExceedMaxRetries = errors.New("fetch failed after max retries for request")
+
+	// errWrongHash is returned when the data in the peer's response does not hash to the same value as requested.
+	errWrongHash = errors.New("wrong hash from response")
+)
 
 // request contains all relevant Data for a single request for a specified hash.
 type request struct {
@@ -108,21 +116,8 @@ func DefaultConfig() Config {
 	}
 }
 
-type networkInterface interface {
-	PeerCount() uint64
-	GetPeers() []p2p.Peer
-	Request(context.Context, p2p.Peer, []byte, func([]byte), func(error)) error
-	Close() error
-}
-
-// messageNetwork is a network interface that allows fetch to communicate with other nodes with 'fetch servers'.
-type messageNetwork struct {
-	*server.Server
-	*p2p.Host
-}
-
-// GetRandomPeer returns a random peer from current peer list.
-func GetRandomPeer(peers []p2p.Peer) p2p.Peer {
+// randomPeer returns a random peer from current peer list.
+func randomPeer(peers []p2p.Peer) p2p.Peer {
 	if len(peers) == 0 {
 		log.Panic("cannot send fetch: no peers found")
 	}
@@ -131,9 +126,13 @@ func GetRandomPeer(peers []p2p.Peer) p2p.Peer {
 
 // Fetch is the main struct that contains network peers and logic to batch and dispatch hash fetch requests.
 type Fetch struct {
-	cfg Config
-	log log.Log
-	bs  *datastore.BlobStore
+	cfg     Config
+	log     log.Log
+	bs      *datastore.BlobStore
+	host    host
+	atxSrv  server.Requestor
+	lyrSrv  server.Requestor
+	hashSrv server.Requestor
 
 	// activeRequests contains requests that are not processed
 	activeRequests map[types.Hash32][]*request
@@ -141,7 +140,6 @@ type Fetch struct {
 	pendingRequests map[types.Hash32][]*request
 	// activeBatches contains batches of requests in pendingRequests.
 	activeBatches        map[types.Hash32]batchInfo
-	net                  networkInterface
 	requestReceiver      chan request
 	batchRequestReceiver chan []request
 	batchTimeout         *time.Ticker
@@ -154,12 +152,16 @@ type Fetch struct {
 	hashToPeers          *HashPeersCache
 }
 
-// NewFetch creates a new Fetch struct.
-func NewFetch(cfg Config, h *p2p.Host, bs *datastore.BlobStore, logger log.Log) *Fetch {
+// newFetch creates a new Fetch struct.
+func newFetch(cfg Config, h host, bs *datastore.BlobStore, atxS, lyrS, hashS server.Requestor, logger log.Log) *Fetch {
 	f := &Fetch{
 		cfg:             cfg,
 		log:             logger,
 		bs:              bs,
+		host:            h,
+		atxSrv:          atxS,
+		lyrSrv:          lyrS,
+		hashSrv:         hashS,
 		activeRequests:  make(map[types.Hash32][]*request),
 		pendingRequests: make(map[types.Hash32][]*request),
 		requestReceiver: make(chan request),
@@ -168,16 +170,6 @@ func NewFetch(cfg Config, h *p2p.Host, bs *datastore.BlobStore, logger log.Log) 
 		activeBatches:   make(map[types.Hash32]batchInfo),
 		doneChan:        make(chan struct{}),
 		hashToPeers:     NewHashPeersCache(cacheSize),
-	}
-	// TODO(dshulyak) this is done for tests. needs to be mocked properly
-	if h != nil {
-		f.net = &messageNetwork{
-			Server: server.New(h, fetchProtocol, f.FetchRequestHandler,
-				server.WithTimeout(time.Duration(cfg.RequestTimeout)*time.Second),
-				server.WithLog(logger),
-			),
-			Host: h,
-		}
 	}
 	return f
 }
@@ -194,7 +186,7 @@ func (f *Fetch) Stop() {
 	f.log.Info("stopping fetch")
 	f.batchTimeout.Stop()
 	close(f.stop)
-	f.net.Close()
+	f.host.Close()
 	f.activeReqM.Lock()
 	for _, batch := range f.activeRequests {
 		for _, req := range batch {
@@ -263,58 +255,6 @@ func (f *Fetch) loop() {
 	}
 }
 
-// FetchRequestHandler handles requests for sync from peersProvider, and basically reads Data from database and puts it
-// in a response batch.
-func (f *Fetch) FetchRequestHandler(ctx context.Context, data []byte) ([]byte, error) {
-	if f.stopped() {
-		return nil, context.Canceled
-	}
-
-	var requestBatch requestBatch
-	err := types.BytesToInterface(data, &requestBatch)
-	if err != nil {
-		f.log.WithContext(ctx).With().Error("failed to parse request", log.Err(err))
-		return nil, errors.New("bad request")
-	}
-	resBatch := responseBatch{
-		ID:        requestBatch.ID,
-		Responses: make([]responseMessage, 0, len(requestBatch.Requests)),
-	}
-	// this will iterate all requests and populate appropriate Responses, if there are any missing items they will not
-	// be included in the response at all
-	for _, r := range requestBatch.Requests {
-		res, err := f.bs.Get(r.Hint, r.Hash.Bytes())
-		if err != nil {
-			f.log.WithContext(ctx).With().Info("remote peer requested nonexistent hash",
-				log.String("hash", r.Hash.ShortString()),
-				log.String("hint", string(r.Hint)),
-				log.Err(err))
-			continue
-		} else {
-			f.log.WithContext(ctx).With().Debug("responded to hash request",
-				log.String("hash", r.Hash.ShortString()),
-				log.Int("dataSize", len(res)))
-		}
-		// add response to batch
-		m := responseMessage{
-			Hash: r.Hash,
-			Data: res,
-		}
-		resBatch.Responses = append(resBatch.Responses, m)
-	}
-
-	bts, err := types.InterfaceToBytes(&resBatch)
-	if err != nil {
-		f.log.WithContext(ctx).With().Panic("failed to serialize batch id",
-			log.String("batch_hash", resBatch.ID.ShortString()))
-	}
-	f.log.WithContext(ctx).With().Debug("returning response for batch",
-		log.String("batch_hash", resBatch.ID.ShortString()),
-		log.Int("count_responses", len(resBatch.Responses)),
-		log.Int("data_size", len(bts)))
-	return bts, nil
-}
-
 // receive Data from message server and call response handlers accordingly.
 func (f *Fetch) receiveResponse(data []byte) {
 	if f.stopped() {
@@ -352,7 +292,7 @@ func (f *Fetch) receiveResponse(data []byte) {
 					actualHash = types.CalcHash32(data)
 				}
 				if actualHash != resID.Hash {
-					err = fmt.Errorf("hash didnt match expected: %v, actual %v", resID.Hash.ShortString(), actualHash.ShortString())
+					err = fmt.Errorf("%w: %v, actual %v", errWrongHash, resID.Hash.ShortString(), actualHash.ShortString())
 				}
 			}
 			req.returnChan <- ftypes.HashDataPromiseResult{
@@ -390,7 +330,7 @@ func (f *Fetch) receiveResponse(data []byte) {
 				f.log.With().Debug("gave up on hash after max retries",
 					log.String("hash", req.hash.ShortString()))
 				req.returnChan <- ftypes.HashDataPromiseResult{
-					Err:     ErrExceedMaxRetries,
+					Err:     errExceedMaxRetries,
 					Hash:    req.hash,
 					Data:    []byte{},
 					IsLocal: false,
@@ -450,11 +390,12 @@ func (f *Fetch) send(requests []requestMessage) {
 func (f *Fetch) organizeRequests(requests []requestMessage) map[p2p.Peer][][]requestMessage {
 	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
 	peer2requests := make(map[p2p.Peer][]requestMessage)
+	peers := f.host.GetPeers()
 
 	for _, req := range requests {
 		p, exists := f.hashToPeers.GetRandom(req.Hash, rng)
 		if !exists {
-			p = GetRandomPeer(f.net.GetPeers())
+			p = randomPeer(peers)
 		}
 
 		_, ok := peer2requests[p]
@@ -523,14 +464,14 @@ func (f *Fetch) sendBatch(p p2p.Peer, requests []requestMessage) error {
 			log.Int("num_requests", len(batch.Requests)),
 			log.String("peer", p.String()))
 
-		err = f.net.Request(context.TODO(), p, bytes, f.receiveResponse, errorFunc)
+		err = f.hashSrv.Request(context.TODO(), p, bytes, f.receiveResponse, errorFunc)
 		if err == nil {
 			break
 		}
 
 		retries++
 		if retries > f.cfg.MaxRetriesForPeer {
-			f.handleHashError(batch.ID, ErrCouldNotSend(fmt.Errorf("could not send message: %w", err)))
+			f.handleHashError(batch.ID, fmt.Errorf("could not send message: %w", err))
 			break
 		}
 		// todo: mark number of fails per peer to make it low priority
@@ -622,6 +563,46 @@ func (f *Fetch) GetHash(hash types.Hash32, h datastore.Hint, validateHash bool) 
 	f.requestReceiver <- req
 
 	return resChan
+}
+
+// GetLayerData get layer data from peers.
+func (f *Fetch) GetLayerData(ctx context.Context, lid types.LayerID, okCB func([]byte, p2p.Peer, int), errCB func(error, p2p.Peer, int)) error {
+	remotePeers := f.host.GetPeers()
+	numPeers := len(remotePeers)
+	if numPeers == 0 {
+		return errNoPeers
+	}
+
+	for _, p := range remotePeers {
+		peer := p
+		okFunc := func(data []byte) {
+			okCB(data, peer, numPeers)
+		}
+		errFunc := func(err error) {
+			errCB(err, peer, numPeers)
+		}
+		if err := f.lyrSrv.Request(ctx, peer, lid.Bytes(), okFunc, errFunc); err != nil {
+			errFunc(err)
+		}
+	}
+	return nil
+}
+
+// GetEpochATXIDs get all ATXIDs targeted for a specified epoch from peers.
+func (f *Fetch) GetEpochATXIDs(ctx context.Context, eid types.EpochID, okCB func([]byte, p2p.Peer), errFunc func(error)) error {
+	remotePeers := f.host.GetPeers()
+	if len(remotePeers) == 0 {
+		return errNoPeers
+	}
+
+	peer := randomPeer(remotePeers)
+	okFunc := func(data []byte) {
+		okCB(data, peer)
+	}
+	if err := f.atxSrv.Request(ctx, peer, eid.ToBytes(), okFunc, errFunc); err != nil {
+		return err
+	}
+	return nil
 }
 
 // RegisterPeerHashes registers provided peer for a list of hashes.

--- a/fetch/handler.go
+++ b/fetch/handler.go
@@ -1,0 +1,150 @@
+package fetch
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/spacemeshos/go-spacemesh/codec"
+	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/common/util"
+	"github.com/spacemeshos/go-spacemesh/datastore"
+	"github.com/spacemeshos/go-spacemesh/log"
+	"github.com/spacemeshos/go-spacemesh/sql"
+	"github.com/spacemeshos/go-spacemesh/sql/atxs"
+	"github.com/spacemeshos/go-spacemesh/sql/ballots"
+	"github.com/spacemeshos/go-spacemesh/sql/blocks"
+	"github.com/spacemeshos/go-spacemesh/sql/layers"
+)
+
+// errInternal is returned from the peer when the peer encounters an internal error.
+var errInternal = errors.New("unspecified error returned by peer")
+
+type handler struct {
+	logger log.Log
+	db     *sql.Database
+	bs     *datastore.BlobStore
+	msh    meshProvider
+}
+
+func newHandler(db *sql.Database, bs *datastore.BlobStore, msh meshProvider, lg log.Log) *handler {
+	return &handler{
+		logger: lg,
+		db:     db,
+		bs:     bs,
+		msh:    msh,
+	}
+}
+
+// handleEpochATXIDsReq returns the ATXs published in the specified epoch.
+func (h *handler) handleEpochATXIDsReq(ctx context.Context, msg []byte) ([]byte, error) {
+	epoch := types.EpochID(util.BytesToUint32(msg))
+	atxids, err := atxs.GetIDsByEpoch(h.db, epoch)
+	if err != nil {
+		return nil, fmt.Errorf("get epoch ATXs for epoch %v: %w", epoch, err)
+	}
+
+	h.logger.WithContext(ctx).With().Debug("responded to epoch atx request",
+		epoch,
+		log.Int("count", len(atxids)))
+	bts, err := codec.Encode(atxids)
+	if err != nil {
+		h.logger.WithContext(ctx).With().Panic("failed to serialize epoch atx", epoch, log.Err(err))
+		return bts, fmt.Errorf("serialize: %w", err)
+	}
+
+	return bts, nil
+}
+
+// handleLayerDataReq returns the block IDs for the specified layer hash,
+// it also returns the validation vector for this data and the latest blocks received in gossip.
+func (h *handler) handleLayerDataReq(ctx context.Context, req []byte) ([]byte, error) {
+	lyrID := types.BytesToLayerID(req)
+	processed := h.msh.ProcessedLayer()
+	if lyrID.After(processed) {
+		return nil, fmt.Errorf("%w: requested layer %v is higher than processed %v", errLayerNotProcessed, lyrID, processed)
+	}
+	ld := &layerData{ProcessedLayer: processed}
+	var err error
+	ld.Hash, err = layers.GetHash(h.db, lyrID)
+	if err != nil {
+		h.logger.WithContext(ctx).With().Warning("failed to get layer hash", lyrID, log.Err(err))
+		return nil, errInternal
+	}
+	ld.AggregatedHash, err = layers.GetAggregatedHash(h.db, lyrID)
+	if err != nil {
+		h.logger.WithContext(ctx).With().Warning("failed to get aggregated layer hash", lyrID, log.Err(err))
+		return nil, errInternal
+	}
+	ld.Ballots, err = ballots.IDsInLayer(h.db, lyrID)
+	if err != nil {
+		// sqh.ErrNotFound should be considered a programming error since we are only responding for
+		// layers older than processed layer
+		h.logger.WithContext(ctx).With().Warning("failed to get layer ballots", lyrID, log.Err(err))
+		return nil, errInternal
+	}
+	ld.Blocks, err = blocks.IDsInLayer(h.db, lyrID)
+	if err != nil {
+		// sqh.ErrNotFound should be considered a programming error since we are only responding for
+		// layers older than processed layer
+		h.logger.WithContext(ctx).With().Warning("failed to get layer blocks", lyrID, log.Err(err))
+		return nil, errInternal
+	}
+	if ld.HareOutput, err = layers.GetHareOutput(h.db, lyrID); err != nil {
+		h.logger.WithContext(ctx).With().Warning("failed to get hare output for layer", lyrID, log.Err(err))
+		return nil, errInternal
+	}
+
+	out, err := codec.Encode(ld)
+	if err != nil {
+		h.logger.WithContext(ctx).With().Panic("failed to serialize layer blocks response", log.Err(err))
+	}
+
+	return out, nil
+}
+
+func (h *handler) handleHashReq(ctx context.Context, data []byte) ([]byte, error) {
+	var requestBatch requestBatch
+	err := types.BytesToInterface(data, &requestBatch)
+	if err != nil {
+		h.logger.WithContext(ctx).With().Error("failed to parse request", log.Err(err))
+		return nil, errors.New("bad request")
+	}
+	resBatch := responseBatch{
+		ID:        requestBatch.ID,
+		Responses: make([]responseMessage, 0, len(requestBatch.Requests)),
+	}
+	// this will iterate all requests and populate appropriate Responses, if there are any missing items they will not
+	// be included in the response at all
+	for _, r := range requestBatch.Requests {
+		res, err := h.bs.Get(r.Hint, r.Hash.Bytes())
+		if err != nil {
+			h.logger.WithContext(ctx).With().Info("remote peer requested nonexistent hash",
+				log.String("hash", r.Hash.ShortString()),
+				log.String("hint", string(r.Hint)),
+				log.Err(err))
+			continue
+		} else {
+			h.logger.WithContext(ctx).With().Debug("responded to hash request",
+				log.String("hash", r.Hash.ShortString()),
+				log.Int("dataSize", len(res)))
+		}
+		// add response to batch
+		m := responseMessage{
+			Hash: r.Hash,
+			Data: res,
+		}
+		resBatch.Responses = append(resBatch.Responses, m)
+	}
+
+	bts, err := types.InterfaceToBytes(&resBatch)
+	if err != nil {
+		h.logger.WithContext(ctx).With().Panic("failed to serialize batch id",
+			log.String("batch_hash", resBatch.ID.ShortString()))
+	}
+	h.logger.WithContext(ctx).With().Debug("returning response for batch",
+		log.String("batch_hash", resBatch.ID.ShortString()),
+		log.Int("count_responses", len(resBatch.Responses)),
+		log.Int("data_size", len(bts)))
+	return bts, nil
+}

--- a/fetch/handler_test.go
+++ b/fetch/handler_test.go
@@ -1,0 +1,122 @@
+package fetch
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/spacemeshos/go-spacemesh/codec"
+	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/datastore"
+	"github.com/spacemeshos/go-spacemesh/fetch/mocks"
+	"github.com/spacemeshos/go-spacemesh/log/logtest"
+	"github.com/spacemeshos/go-spacemesh/signing"
+	"github.com/spacemeshos/go-spacemesh/sql"
+	"github.com/spacemeshos/go-spacemesh/sql/ballots"
+	"github.com/spacemeshos/go-spacemesh/sql/blocks"
+	"github.com/spacemeshos/go-spacemesh/sql/layers"
+)
+
+type lyrdata struct {
+	hash, aggHash types.Hash32
+	blts          []types.BallotID
+	blks          []types.BlockID
+}
+
+type testHandler struct {
+	*handler
+	mmp *mocks.MockmeshProvider
+}
+
+func createTestHandler(t *testing.T) *testHandler {
+	mmp := mocks.NewMockmeshProvider(gomock.NewController(t))
+	db := sql.InMemory()
+	return &testHandler{
+		handler: newHandler(db, datastore.NewBlobStore(db), mmp, logtest.New(t)),
+		mmp:     mmp,
+	}
+}
+
+func createLayer(t *testing.T, db *sql.Database, lid types.LayerID) *lyrdata {
+	l := &lyrdata{}
+	l.hash = types.RandomHash()
+	require.NoError(t, layers.SetHash(db, lid, l.hash))
+	l.aggHash = types.RandomHash()
+	require.NoError(t, layers.SetAggregatedHash(db, lid, l.aggHash))
+	for i := 0; i < 5; i++ {
+		b := types.RandomBallot()
+		b.LayerIndex = lid
+		b.Signature = signing.NewEdSigner().Sign(b.Bytes())
+		require.NoError(t, b.Initialize())
+		require.NoError(t, ballots.Add(db, b))
+		l.blts = append(l.blts, b.ID())
+
+		bk := types.NewExistingBlock(types.RandomBlockID(), types.InnerBlock{LayerIndex: lid})
+		require.NoError(t, blocks.Add(db, bk))
+		l.blks = append(l.blks, bk.ID())
+	}
+	return l
+}
+
+func TestHandleLayerDataReq(t *testing.T) {
+	tt := []struct {
+		name                 string
+		requested, processed types.LayerID
+		emptyLyr             bool
+		err                  error
+	}{
+		{
+			name:      "success",
+			requested: types.NewLayerID(100),
+			processed: types.NewLayerID(101),
+			emptyLyr:  false,
+		},
+		{
+			name:      "success with empty layer",
+			requested: types.NewLayerID(100),
+			processed: types.NewLayerID(101),
+			emptyLyr:  true,
+		},
+		{
+			name:      "requested layer too high",
+			requested: types.NewLayerID(100),
+			processed: types.NewLayerID(99),
+			err:       errLayerNotProcessed,
+		},
+	}
+
+	for _, tc := range tt {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			th := createTestHandler(t)
+			expected := createLayer(t, th.db, tc.requested)
+			hareOutput := types.EmptyBlockID
+			if !tc.emptyLyr {
+				hareOutput = expected.blks[0]
+			}
+			require.NoError(t, layers.SetHareOutput(th.db, tc.requested, hareOutput))
+			th.mmp.EXPECT().ProcessedLayer().Return(tc.processed)
+
+			out, err := th.handleLayerDataReq(context.TODO(), tc.requested.Bytes())
+			if tc.err != nil {
+				require.ErrorIs(t, err, tc.err)
+			} else {
+				require.NoError(t, err)
+				var got layerData
+				err = codec.Decode(out, &got)
+				require.NoError(t, err)
+				assert.ElementsMatch(t, expected.blts, got.Ballots)
+				assert.ElementsMatch(t, expected.blks, got.Blocks)
+				assert.Equal(t, hareOutput, got.HareOutput)
+				assert.Equal(t, tc.processed, got.ProcessedLayer)
+				assert.Equal(t, expected.hash, got.Hash)
+				assert.Equal(t, expected.aggHash, got.AggregatedHash)
+			}
+		})
+	}
+}

--- a/fetch/interface.go
+++ b/fetch/interface.go
@@ -7,13 +7,13 @@ import (
 	"github.com/spacemeshos/go-spacemesh/datastore"
 	ftypes "github.com/spacemeshos/go-spacemesh/fetch/types"
 	"github.com/spacemeshos/go-spacemesh/p2p"
-	"github.com/spacemeshos/go-spacemesh/p2p/bootstrap"
-	"github.com/spacemeshos/go-spacemesh/p2p/server"
 )
 
 //go:generate mockgen -package=mocks -destination=./mocks/mocks.go -source=./interface.go
 
 type fetcher interface {
+	GetEpochATXIDs(context.Context, types.EpochID, func([]byte, p2p.Peer), func(error)) error
+	GetLayerData(context.Context, types.LayerID, func([]byte, p2p.Peer, int), func(error, p2p.Peer, int)) error
 	GetHash(types.Hash32, datastore.Hint, bool) chan ftypes.HashDataPromiseResult
 	GetHashes([]types.Hash32, datastore.Hint, bool) map[types.Hash32]chan ftypes.HashDataPromiseResult
 	Stop()
@@ -52,7 +52,7 @@ type meshProvider interface {
 	SetZeroBlockLayer(types.LayerID) error
 }
 
-type network interface {
-	bootstrap.Provider
-	server.Host
+type host interface {
+	GetPeers() []p2p.Peer
+	Close() error
 }

--- a/fetch/layers.go
+++ b/fetch/layers.go
@@ -5,29 +5,22 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/spacemeshos/go-spacemesh/codec"
 	"github.com/spacemeshos/go-spacemesh/common/types"
-	"github.com/spacemeshos/go-spacemesh/common/util"
 	"github.com/spacemeshos/go-spacemesh/datastore"
 	ftypes "github.com/spacemeshos/go-spacemesh/fetch/types"
 	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/p2p"
 	"github.com/spacemeshos/go-spacemesh/p2p/server"
 	"github.com/spacemeshos/go-spacemesh/sql"
-	"github.com/spacemeshos/go-spacemesh/sql/atxs"
-	"github.com/spacemeshos/go-spacemesh/sql/ballots"
-	"github.com/spacemeshos/go-spacemesh/sql/blocks"
 	"github.com/spacemeshos/go-spacemesh/sql/layers"
 )
 
 var (
-	// ErrNoPeers is returned when node has no peers.
-	ErrNoPeers = errors.New("no peers")
-	// ErrInternal is returned from the peer when the peer encounters an internal error.
-	ErrInternal = errors.New("unspecified error returned by peer")
-	// ErrLayerDataNotFetched is returned when any layer data is not fetched successfully.
-	ErrLayerDataNotFetched = errors.New("layer data not fetched")
+	// errLayerDataNotFetched is returned when any layer data is not fetched successfully.
+	errLayerDataNotFetched = errors.New("layer data not fetched")
 
 	// errLayerNotProcessed is returned when requested layer was not yet processed.
 	errLayerNotProcessed = errors.New("requested layer is not yet processed")
@@ -56,27 +49,21 @@ type LayerPromiseResult struct {
 
 // Logic is the struct containing components needed to follow layer fetching logic.
 type Logic struct {
-	log              log.Log
-	db               *sql.Database
-	fetcher          fetcher
-	atxsrv, blocksrv server.Requestor
-	host             network
-	mutex            sync.Mutex
-	layerBlocksRes   map[types.LayerID]*layerResult
-	layerBlocksChs   map[types.LayerID][]chan LayerPromiseResult
-	poetHandler      poetHandler
-	atxHandler       atxHandler
-	ballotHandler    ballotHandler
-	blockHandler     blockHandler
-	proposalHandler  proposalHandler
-	txHandler        txHandler
-	msh              meshProvider
-}
+	log     log.Log
+	db      *sql.Database
+	msh     meshProvider
+	fetcher fetcher
 
-const (
-	blockProtocol = "/block/1"
-	atxProtocol   = "/atx/1"
-)
+	mutex           sync.Mutex
+	layerBlocksRes  map[types.LayerID]*layerResult
+	layerBlocksChs  map[types.LayerID][]chan LayerPromiseResult
+	poetHandler     poetHandler
+	atxHandler      atxHandler
+	ballotHandler   ballotHandler
+	blockHandler    blockHandler
+	proposalHandler proposalHandler
+	txHandler       txHandler
+}
 
 // DataHandlers collects handlers for different data type.
 type DataHandlers struct {
@@ -89,28 +76,35 @@ type DataHandlers struct {
 }
 
 // NewLogic creates a new instance of layer fetching logic.
-// TODO clean up the tangle between Logic and Fetch. ideally Logic should only care about layer data and epoch ATX
-// and leave the actual request sending to Fetch. this will improve testing as well.
-func NewLogic(cfg Config, db *sql.Database, msh meshProvider,
-	host *p2p.Host, handlers DataHandlers, log log.Log,
-) *Logic {
+func NewLogic(cfg Config, db *sql.Database, msh meshProvider, host *p2p.Host, handlers DataHandlers, log log.Log) *Logic {
 	l := &Logic{
 		log:             log,
-		fetcher:         NewFetch(cfg, host, datastore.NewBlobStore(db), log.WithName("fetch")),
-		host:            host,
+		msh:             msh,
+		db:              db,
 		layerBlocksRes:  make(map[types.LayerID]*layerResult),
 		layerBlocksChs:  make(map[types.LayerID][]chan LayerPromiseResult),
 		poetHandler:     handlers.Poet,
-		msh:             msh,
-		db:              db,
 		atxHandler:      handlers.ATX,
 		ballotHandler:   handlers.Ballot,
 		blockHandler:    handlers.Block,
 		proposalHandler: handlers.Proposal,
 		txHandler:       handlers.TX,
 	}
-	l.atxsrv = server.New(host, atxProtocol, l.epochATXsReqReceiver, server.WithLog(log))
-	l.blocksrv = server.New(host, blockProtocol, l.layerContentReqReceiver, server.WithLog(log))
+	bs := datastore.NewBlobStore(db)
+	h := newHandler(db, bs, msh, log)
+	atxSrv := server.New(host, atxProtocol, h.handleEpochATXIDsReq,
+		server.WithTimeout(time.Duration(cfg.RequestTimeout)*time.Second),
+		server.WithLog(log),
+	)
+	lyrSrv := server.New(host, lyrDataProtocol, h.handleLayerDataReq,
+		server.WithTimeout(time.Duration(cfg.RequestTimeout)*time.Second),
+		server.WithLog(log),
+	)
+	hashSrv := server.New(host, fetchProtocol, h.handleHashReq,
+		server.WithTimeout(time.Duration(cfg.RequestTimeout)*time.Second),
+		server.WithLog(log),
+	)
+	l.fetcher = newFetch(cfg, host, bs, atxSrv, lyrSrv, hashSrv, log.WithName("fetch"))
 	return l
 }
 
@@ -122,73 +116,6 @@ func (l *Logic) Start() {
 // Close closes all running workers.
 func (l *Logic) Close() {
 	l.fetcher.Stop()
-}
-
-// epochATXsReqReceiver returns the ATXs for the specified epoch.
-func (l *Logic) epochATXsReqReceiver(ctx context.Context, msg []byte) ([]byte, error) {
-	epoch := types.EpochID(util.BytesToUint32(msg))
-	atxids, err := atxs.GetIDsByEpoch(l.db, epoch)
-	if err != nil {
-		return nil, fmt.Errorf("get epoch ATXs for epoch %v: %w", epoch, err)
-	}
-
-	l.log.WithContext(ctx).With().Debug("responded to epoch atx request",
-		epoch,
-		log.Int("count", len(atxids)))
-	bts, err := codec.Encode(atxids)
-	if err != nil {
-		l.log.WithContext(ctx).With().Panic("failed to serialize epoch atx", epoch, log.Err(err))
-		return bts, fmt.Errorf("serialize: %w", err)
-	}
-
-	return bts, nil
-}
-
-// layerContentReqReceiver returns the block IDs for the specified layer hash,
-// it also returns the validation vector for this data and the latest blocks received in gossip.
-func (l *Logic) layerContentReqReceiver(ctx context.Context, req []byte) ([]byte, error) {
-	lyrID := types.BytesToLayerID(req)
-	processed := l.msh.ProcessedLayer()
-	if lyrID.After(processed) {
-		return nil, fmt.Errorf("%w: requested layer %v is higher than processed %v", errLayerNotProcessed, lyrID, processed)
-	}
-	ld := &layerData{ProcessedLayer: processed}
-	var err error
-	ld.Hash, err = layers.GetHash(l.db, lyrID)
-	if err != nil {
-		l.log.WithContext(ctx).With().Warning("failed to get layer hash", lyrID, log.Err(err))
-		return nil, ErrInternal
-	}
-	ld.AggregatedHash, err = layers.GetAggregatedHash(l.db, lyrID)
-	if err != nil {
-		l.log.WithContext(ctx).With().Warning("failed to get aggregated layer hash", lyrID, log.Err(err))
-		return nil, ErrInternal
-	}
-	ld.Ballots, err = ballots.IDsInLayer(l.db, lyrID)
-	if err != nil {
-		// sql.ErrNotFound should be considered a programming error since we are only responding for
-		// layers older than processed layer
-		l.log.WithContext(ctx).With().Warning("failed to get layer ballots", lyrID, log.Err(err))
-		return nil, ErrInternal
-	}
-	ld.Blocks, err = blocks.IDsInLayer(l.db, lyrID)
-	if err != nil {
-		// sql.ErrNotFound should be considered a programming error since we are only responding for
-		// layers older than processed layer
-		l.log.WithContext(ctx).With().Warning("failed to get layer blocks", lyrID, log.Err(err))
-		return nil, ErrInternal
-	}
-	if ld.HareOutput, err = layers.GetHareOutput(l.db, lyrID); err != nil {
-		l.log.WithContext(ctx).With().Warning("failed to get hare output for layer", lyrID, log.Err(err))
-		return nil, ErrInternal
-	}
-
-	out, err := codec.Encode(ld)
-	if err != nil {
-		l.log.WithContext(ctx).With().Panic("failed to serialize layer blocks response", log.Err(err))
-	}
-
-	return out, nil
 }
 
 // initLayerPolling returns false if there is an ongoing polling of the given layer content,
@@ -214,31 +141,18 @@ func (l *Logic) initLayerPolling(layerID types.LayerID, ch chan LayerPromiseResu
 // it returns a channel for the caller to be notified when responses are received from all peers.
 func (l *Logic) PollLayerContent(ctx context.Context, layerID types.LayerID) chan LayerPromiseResult {
 	resChannel := make(chan LayerPromiseResult, 1)
-
-	remotePeers := l.host.GetPeers()
-	numPeers := len(remotePeers)
-	if numPeers == 0 {
-		resChannel <- LayerPromiseResult{Layer: layerID, Err: ErrNoPeers}
-		return resChannel
-	}
-
 	if !l.initLayerPolling(layerID, resChannel) {
 		return resChannel
 	}
 
-	// send a request to the first peer of the list to get blocks data.
-	// todo: think if we should aggregate or ask from multiple peers to have some redundancy in requests
-	for _, p := range remotePeers {
-		peer := p
-		receiveForPeerFunc := func(data []byte) {
-			l.receiveLayerContent(ctx, layerID, peer, numPeers, data, nil)
-		}
-		errFunc := func(err error) {
-			l.receiveLayerContent(ctx, layerID, peer, numPeers, nil, err)
-		}
-		if err := l.blocksrv.Request(ctx, peer, layerID.Bytes(), receiveForPeerFunc, errFunc); err != nil {
-			errFunc(err)
-		}
+	okFunc := func(data []byte, peer p2p.Peer, numPeers int) {
+		l.receiveLayerContent(ctx, layerID, peer, numPeers, data, nil)
+	}
+	errFunc := func(err error, peer p2p.Peer, numPeers int) {
+		l.receiveLayerContent(ctx, layerID, peer, numPeers, nil, err)
+	}
+	if err := l.fetcher.GetLayerData(ctx, layerID, okFunc, errFunc); err != nil {
+		resChannel <- LayerPromiseResult{Layer: layerID, Err: err}
 	}
 	return resChannel
 }
@@ -264,7 +178,6 @@ func (l *Logic) registerLayerHashes(peer p2p.Peer, data *layerData) {
 	}
 
 	l.fetcher.RegisterPeerHashes(peer, layerHashes)
-
 	return
 }
 
@@ -344,7 +257,7 @@ func (l *Logic) receiveLayerContent(ctx context.Context, layerID types.LayerID, 
 
 	if peerRes.err == nil {
 		if err := l.fetchLayerData(ctx, logger, layerID, peerRes.data); err != nil {
-			peerRes.err = ErrLayerDataNotFetched
+			peerRes.err = errLayerDataNotFetched
 		}
 	}
 
@@ -370,7 +283,7 @@ func (l *Logic) receiveLayerContent(ctx context.Context, layerID types.LayerID, 
 // notifyLayerDataResult determines the final result for the layer, and notifies subscribed channels when
 // all blocks are fetched for a given layer.
 // it deliberately doesn't hold any lock while notifying channels.
-func notifyLayerDataResult(db *sql.Database, layerID types.LayerID, layerDB meshProvider, channels []chan LayerPromiseResult, lyrResult *layerResult, logger log.Log) {
+func notifyLayerDataResult(db *sql.Database, layerID types.LayerID, msh meshProvider, channels []chan LayerPromiseResult, lyrResult *layerResult, logger log.Log) {
 	var (
 		missing, success bool
 		err              error
@@ -379,7 +292,7 @@ func notifyLayerDataResult(db *sql.Database, layerID types.LayerID, layerDB mesh
 		if res.err == nil && res.data != nil {
 			success = true
 		}
-		if errors.Is(res.err, ErrLayerDataNotFetched) {
+		if errors.Is(res.err, errLayerDataNotFetched) {
 			// all fetches need to succeed
 			missing = true
 			err = res.err
@@ -404,7 +317,7 @@ func notifyLayerDataResult(db *sql.Database, layerID types.LayerID, layerDB mesh
 			result.Err = err
 		}
 		if len(lyrResult.blocks) == 0 {
-			if err := layerDB.SetZeroBlockLayer(layerID); err != nil {
+			if err := msh.SetZeroBlockLayer(layerID); err != nil {
 				// this can happen when node actually had received blocks for this layer before. ok to ignore
 				logger.With().Warning("failed to set zero-block for layer", layerID, log.Err(err))
 			}
@@ -418,16 +331,17 @@ func notifyLayerDataResult(db *sql.Database, layerID types.LayerID, layerDB mesh
 }
 
 type epochAtxRes struct {
+	Peer  p2p.Peer
 	Error error
 	Atxs  []types.ATXID
 }
 
 // GetEpochATXs fetches all atxs received by peer for given layer.
-func (l *Logic) GetEpochATXs(ctx context.Context, id types.EpochID) error {
+func (l *Logic) GetEpochATXs(ctx context.Context, eid types.EpochID) error {
 	resCh := make(chan epochAtxRes, 1)
 
 	// build receiver function
-	receiveForPeerFunc := func(data []byte) {
+	okFunc := func(data []byte, peer p2p.Peer) {
 		var atxsIDs []types.ATXID
 		err := codec.Decode(data, &atxsIDs)
 		resCh <- epochAtxRes{
@@ -441,14 +355,10 @@ func (l *Logic) GetEpochATXs(ctx context.Context, id types.EpochID) error {
 			Atxs:  nil,
 		}
 	}
-	if l.host.PeerCount() == 0 {
-		return errors.New("no peers")
-	}
-	peer := GetRandomPeer(l.host.GetPeers())
-	if err := l.atxsrv.Request(ctx, peer, id.ToBytes(), receiveForPeerFunc, errFunc); err != nil {
+	if err := l.fetcher.GetEpochATXIDs(ctx, eid, okFunc, errFunc); err != nil {
 		return fmt.Errorf("failed to send request to the peer: %w", err)
 	}
-	l.log.WithContext(ctx).With().Debug("waiting for epoch atx response", id)
+	l.log.WithContext(ctx).With().Debug("waiting for epoch atx response", eid)
 	res := <-resCh
 	if res.Error != nil {
 		return res.Error
@@ -456,9 +366,9 @@ func (l *Logic) GetEpochATXs(ctx context.Context, id types.EpochID) error {
 
 	l.log.WithContext(ctx).With().Debug("tracking peer for atxs",
 		log.Int("to_fetch", len(res.Atxs)),
-		log.String("peer", peer.String()))
+		log.Stringer("peer", res.Peer))
 	atxHashes := types.ATXIDsToHashes(res.Atxs)
-	l.fetcher.RegisterPeerHashes(peer, atxHashes)
+	l.fetcher.RegisterPeerHashes(res.Peer, atxHashes)
 
 	if err := l.GetAtxs(ctx, res.Atxs); err != nil {
 		return fmt.Errorf("get ATXs: %w", err)

--- a/fetch/layers_test.go
+++ b/fetch/layers_test.go
@@ -3,6 +3,7 @@ package fetch
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -17,58 +18,10 @@ import (
 	"github.com/spacemeshos/go-spacemesh/genvm/sdk/wallet"
 	"github.com/spacemeshos/go-spacemesh/log/logtest"
 	"github.com/spacemeshos/go-spacemesh/p2p"
-	"github.com/spacemeshos/go-spacemesh/p2p/server"
-	srvmocks "github.com/spacemeshos/go-spacemesh/p2p/server/mocks"
-	"github.com/spacemeshos/go-spacemesh/rand"
 	"github.com/spacemeshos/go-spacemesh/signing"
 	"github.com/spacemeshos/go-spacemesh/sql"
-	"github.com/spacemeshos/go-spacemesh/sql/ballots"
-	"github.com/spacemeshos/go-spacemesh/sql/blocks"
 	"github.com/spacemeshos/go-spacemesh/sql/layers"
 )
-
-func randPeer(tb testing.TB) p2p.Peer {
-	tb.Helper()
-	buf := make([]byte, 20)
-	_, err := rand.Read(buf)
-	require.NoError(tb, err)
-	return p2p.Peer(buf)
-}
-
-type mockNetwork struct {
-	server.Host
-	peers     []p2p.Peer
-	layerData map[p2p.Peer][]byte
-	errors    map[p2p.Peer]error
-	timeouts  map[p2p.Peer]struct{}
-}
-
-func newMockNet(tb testing.TB) *mockNetwork {
-	ctrl := gomock.NewController(tb)
-	h := srvmocks.NewMockHost(ctrl)
-	h.EXPECT().SetStreamHandler(gomock.Any(), gomock.Any()).AnyTimes()
-	return &mockNetwork{
-		Host:      h,
-		layerData: make(map[p2p.Peer][]byte),
-		errors:    make(map[p2p.Peer]error),
-		timeouts:  make(map[p2p.Peer]struct{}),
-	}
-}
-func (m *mockNetwork) GetPeers() []p2p.Peer { return m.peers }
-func (m *mockNetwork) PeerCount() uint64    { return uint64(len(m.peers)) }
-
-func (m *mockNetwork) Request(_ context.Context, pid p2p.Peer, _ []byte, resHandler func(msg []byte), errorHandler func(err error)) error {
-	if _, ok := m.timeouts[pid]; ok {
-		errorHandler(errors.New("peer timeout"))
-		return nil
-	}
-	if data, ok := m.layerData[pid]; ok {
-		resHandler(data)
-		return nil
-	}
-	return m.errors[pid]
-}
-func (mockNetwork) Close() {}
 
 const (
 	txsForBlock    = iota
@@ -140,95 +93,6 @@ func createTestLogic(t *testing.T) *testLogic {
 	return tl
 }
 
-func createTestLogicWithMocknet(t *testing.T, net *mockNetwork) *testLogic {
-	tl := createTestLogic(t)
-	tl.host = net
-	tl.blocksrv = net
-	tl.atxsrv = net
-	return tl
-}
-
-type lyrdata struct {
-	hash, aggHash types.Hash32
-	blts          []types.BallotID
-	blks          []types.BlockID
-}
-
-func createLayer(t *testing.T, db *sql.Database, lid types.LayerID) *lyrdata {
-	l := &lyrdata{}
-	l.hash = types.RandomHash()
-	require.NoError(t, layers.SetHash(db, lid, l.hash))
-	l.aggHash = types.RandomHash()
-	require.NoError(t, layers.SetAggregatedHash(db, lid, l.aggHash))
-	for i := 0; i < 5; i++ {
-		b := types.RandomBallot()
-		b.LayerIndex = lid
-		b.Signature = signing.NewEdSigner().Sign(b.Bytes())
-		require.NoError(t, b.Initialize())
-		require.NoError(t, ballots.Add(db, b))
-		l.blts = append(l.blts, b.ID())
-
-		bk := types.NewExistingBlock(types.RandomBlockID(), types.InnerBlock{LayerIndex: lid})
-		require.NoError(t, blocks.Add(db, bk))
-		l.blks = append(l.blks, bk.ID())
-	}
-	return l
-}
-
-func TestLayerBlocksReqReceiver_Success(t *testing.T) {
-	tl := createTestLogicWithMocknet(t, newMockNet(t))
-	lyrID := types.NewLayerID(100)
-	expected := createLayer(t, tl.db, lyrID)
-	hareOutput := expected.blks[0]
-	require.NoError(t, layers.SetHareOutput(tl.db, lyrID, hareOutput))
-	processed := lyrID.Add(10)
-	tl.mMesh.EXPECT().ProcessedLayer().Return(processed).Times(1)
-
-	out, err := tl.layerContentReqReceiver(context.TODO(), lyrID.Bytes())
-	require.NoError(t, err)
-	var got layerData
-	err = codec.Decode(out, &got)
-	require.NoError(t, err)
-	assert.ElementsMatch(t, expected.blts, got.Ballots)
-	assert.ElementsMatch(t, expected.blks, got.Blocks)
-	assert.Equal(t, expected.blks[0], got.HareOutput)
-	assert.Equal(t, processed, got.ProcessedLayer)
-	assert.Equal(t, expected.hash, got.Hash)
-	assert.Equal(t, expected.aggHash, got.AggregatedHash)
-}
-
-func TestLayerBlocksReqReceiver_SuccessEmptyLayer(t *testing.T) {
-	tl := createTestLogicWithMocknet(t, newMockNet(t))
-	lyrID := types.NewLayerID(100)
-	expected := createLayer(t, tl.db, lyrID)
-	require.NoError(t, layers.SetHareOutput(tl.db, lyrID, types.EmptyBlockID))
-	processed := lyrID.Add(10)
-	tl.mMesh.EXPECT().ProcessedLayer().Return(processed).Times(1)
-
-	out, err := tl.layerContentReqReceiver(context.TODO(), lyrID.Bytes())
-	require.NoError(t, err)
-	var got layerData
-	err = codec.Decode(out, &got)
-	require.NoError(t, err)
-	assert.ElementsMatch(t, expected.blts, got.Ballots)
-	assert.ElementsMatch(t, expected.blks, got.Blocks)
-	assert.Equal(t, types.EmptyBlockID, got.HareOutput)
-	assert.Equal(t, processed, got.ProcessedLayer)
-	assert.Equal(t, expected.hash, got.Hash)
-	assert.Equal(t, expected.aggHash, got.AggregatedHash)
-}
-
-func TestLayerBlocksReqReceiver_RequestedHigherLayer(t *testing.T) {
-	lyrID := types.NewLayerID(100)
-	processed := lyrID.Add(10)
-	tl := createTestLogicWithMocknet(t, newMockNet(t))
-	tl.mMesh.EXPECT().ProcessedLayer().Return(processed).Times(1)
-
-	out, err := tl.layerContentReqReceiver(context.TODO(), processed.Add(1).Bytes())
-	assert.ErrorIs(t, err, errLayerNotProcessed)
-	assert.Empty(t, out)
-}
-
 const (
 	numBallots = 10
 	numBlocks  = 3
@@ -273,198 +137,179 @@ func generateEmptyLayer() []byte {
 	return out
 }
 
-func TestPollLayerBlocks_AllHaveLayerData(t *testing.T) {
-	net := newMockNet(t)
-	numPeers := 4
-	for i := 0; i < numPeers; i++ {
-		peer := randPeer(t)
-		net.peers = append(net.peers, peer)
-		net.layerData[peer] = generateLayerContent(false)
+func genPeers(num int) []p2p.Peer {
+	peers := make([]p2p.Peer, 0, num)
+	for i := 0; i < num; i++ {
+		peers = append(peers, p2p.Peer(fmt.Sprintf("peer_%d", i)))
 	}
-
-	layerID := types.NewLayerID(10)
-	tl := createTestLogicWithMocknet(t, net)
-	tl.mFetcher.EXPECT().GetHashes(gomock.Any(), datastore.BallotDB, false).Return(nil).Times(numPeers)
-	tl.mFetcher.EXPECT().GetHashes(gomock.Any(), datastore.BlockDB, false).Return(nil).Times(numPeers)
-	for _, peer := range net.peers {
-		tl.mFetcher.EXPECT().RegisterPeerHashes(peer, gomock.Any())
-	}
-
-	res := <-tl.PollLayerContent(context.TODO(), layerID)
-	assert.NoError(t, res.Err)
-	assert.Equal(t, layerID, res.Layer)
-	got, err := layers.GetHareOutput(tl.db, layerID)
-	require.NoError(t, err)
-	require.NotEqual(t, types.EmptyBlockID, got)
+	return peers
 }
 
-func TestPollLayerBlocks_AllHaveLayerData_EmptyHareOutput(t *testing.T) {
-	net := newMockNet(t)
-	numPeers := 4
-	for i := 0; i < numPeers; i++ {
-		peer := randPeer(t)
-		net.peers = append(net.peers, peer)
-		net.layerData[peer] = generateLayerContent(true)
+func TestPollLayerContent(t *testing.T) {
+	tt := []struct {
+		name                       string
+		emptyHareOutput, zeroBlock bool
+		ballotFail, blocksFail     bool
+		err                        error
+	}{
+		{
+			name:            "all peers have layer data",
+			emptyHareOutput: false,
+		},
+		{
+			name:            "empty hare output",
+			emptyHareOutput: true,
+		},
+		{
+			name:      "all peers have zero blocks",
+			zeroBlock: true,
+		},
+		{
+			name:       "ballots error fails layer fetch",
+			ballotFail: true,
+			err:        errLayerDataNotFetched,
+		},
+		{
+			name:       "blocks failure ignored",
+			blocksFail: true,
+		},
 	}
 
-	layerID := types.NewLayerID(10)
-	tl := createTestLogicWithMocknet(t, net)
-	tl.mFetcher.EXPECT().GetHashes(gomock.Any(), datastore.BallotDB, false).Return(nil).Times(numPeers)
-	tl.mFetcher.EXPECT().GetHashes(gomock.Any(), datastore.BlockDB, false).Return(nil).Times(numPeers)
-	for _, peer := range net.peers {
-		tl.mFetcher.EXPECT().RegisterPeerHashes(peer, gomock.Any())
-	}
+	for _, tc := range tt {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	res := <-tl.PollLayerContent(context.TODO(), layerID)
-	assert.NoError(t, res.Err)
-	assert.Equal(t, layerID, res.Layer)
-	got, err := layers.GetHareOutput(tl.db, layerID)
-	require.NoError(t, err)
-	require.Equal(t, types.EmptyBlockID, got)
-}
-
-func TestPollLayerBlocks_FetchLayerBallotsError(t *testing.T) {
-	net := newMockNet(t)
-	numPeers := 4
-	for i := 0; i < numPeers; i++ {
-		peer := randPeer(t)
-		net.peers = append(net.peers, peer)
-		net.layerData[peer] = generateLayerContent(false)
-	}
-
-	layerID := types.NewLayerID(10)
-	tl := createTestLogicWithMocknet(t, net)
-	for _, peer := range net.peers {
-		tl.mFetcher.EXPECT().RegisterPeerHashes(peer, gomock.Any())
-	}
-
-	tl.mFetcher.EXPECT().GetHashes(gomock.Any(), datastore.BallotDB, false).DoAndReturn(
-		func([]types.Hash32, datastore.Hint, bool) map[types.Hash32]chan ftypes.HashDataPromiseResult {
-			ch := make(chan ftypes.HashDataPromiseResult, 1)
-			ch <- ftypes.HashDataPromiseResult{
-				Err: ErrInternal,
+			numPeers := 4
+			peers := genPeers(numPeers)
+			layerID := types.NewLayerID(10)
+			tl := createTestLogic(t)
+			tl.mFetcher.EXPECT().GetLayerData(gomock.Any(), layerID, gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ context.Context, _ types.LayerID, okCB func([]byte, p2p.Peer, int), errCB func(error, p2p.Peer, int)) error {
+					for _, peer := range peers {
+						if tc.zeroBlock {
+							okCB(generateEmptyLayer(), peer, numPeers)
+						} else {
+							tl.mFetcher.EXPECT().RegisterPeerHashes(peer, gomock.Any())
+							okCB(generateLayerContent(tc.emptyHareOutput), peer, numPeers)
+						}
+					}
+					return nil
+				})
+			if tc.ballotFail {
+				tl.mFetcher.EXPECT().GetHashes(gomock.Any(), datastore.BallotDB, false).DoAndReturn(
+					func([]types.Hash32, datastore.Hint, bool) map[types.Hash32]chan ftypes.HashDataPromiseResult {
+						ch := make(chan ftypes.HashDataPromiseResult, 1)
+						ch <- ftypes.HashDataPromiseResult{
+							Err: errInternal,
+						}
+						return map[types.Hash32]chan ftypes.HashDataPromiseResult{types.RandomHash(): ch}
+					}).Times(numPeers)
+			} else if tc.blocksFail {
+				tl.mFetcher.EXPECT().GetHashes(gomock.Any(), datastore.BallotDB, false).Return(nil).Times(numPeers)
+				tl.mFetcher.EXPECT().GetHashes(gomock.Any(), datastore.BlockDB, false).DoAndReturn(
+					func([]types.Hash32, datastore.Hint, bool) map[types.Hash32]chan ftypes.HashDataPromiseResult {
+						ch := make(chan ftypes.HashDataPromiseResult, 1)
+						ch <- ftypes.HashDataPromiseResult{
+							Err: errInternal,
+						}
+						return map[types.Hash32]chan ftypes.HashDataPromiseResult{types.RandomHash(): ch}
+					}).Times(numPeers)
+			} else if !tc.zeroBlock {
+				tl.mFetcher.EXPECT().GetHashes(gomock.Any(), datastore.BallotDB, false).Return(nil).Times(numPeers)
+				tl.mFetcher.EXPECT().GetHashes(gomock.Any(), datastore.BlockDB, false).Return(nil).Times(numPeers)
 			}
-			return map[types.Hash32]chan ftypes.HashDataPromiseResult{types.RandomHash(): ch}
-		}).Times(numPeers)
-
-	res := <-tl.PollLayerContent(context.TODO(), layerID)
-	assert.Equal(t, ErrLayerDataNotFetched, res.Err)
-	assert.Equal(t, layerID, res.Layer)
-}
-
-func TestPollLayerBlocks_FetchLayerBlocksErrorIgnored(t *testing.T) {
-	net := newMockNet(t)
-	numPeers := 4
-	for i := 0; i < numPeers; i++ {
-		peer := randPeer(t)
-		net.peers = append(net.peers, peer)
-		net.layerData[peer] = generateLayerContent(false)
-	}
-
-	layerID := types.NewLayerID(10)
-	tl := createTestLogicWithMocknet(t, net)
-
-	tl.mFetcher.EXPECT().GetHashes(gomock.Any(), datastore.BallotDB, false).Return(nil).Times(numPeers)
-	for _, peer := range net.peers {
-		tl.mFetcher.EXPECT().RegisterPeerHashes(peer, gomock.Any())
-	}
-
-	tl.mFetcher.EXPECT().GetHashes(gomock.Any(), datastore.BlockDB, false).DoAndReturn(
-		func([]types.Hash32, datastore.Hint, bool) map[types.Hash32]chan ftypes.HashDataPromiseResult {
-			ch := make(chan ftypes.HashDataPromiseResult, 1)
-			ch <- ftypes.HashDataPromiseResult{
-				Err: ErrInternal,
+			if tc.zeroBlock {
+				tl.mMesh.EXPECT().SetZeroBlockLayer(layerID)
 			}
-			return map[types.Hash32]chan ftypes.HashDataPromiseResult{types.RandomHash(): ch}
-		}).Times(numPeers)
 
-	res := <-tl.PollLayerContent(context.TODO(), layerID)
-	assert.Nil(t, res.Err)
-	assert.Equal(t, layerID, res.Layer)
-	got, err := layers.GetHareOutput(tl.db, layerID)
-	require.NoError(t, err)
-	require.NotEqual(t, types.EmptyBlockID, got)
+			res := <-tl.PollLayerContent(context.TODO(), layerID)
+			if tc.err != nil {
+				require.ErrorIs(t, res.Err, tc.err)
+			} else {
+				assert.NoError(t, res.Err)
+				assert.Equal(t, layerID, res.Layer)
+				got, err := layers.GetHareOutput(tl.db, layerID)
+				require.NoError(t, err)
+				if tc.emptyHareOutput || tc.zeroBlock {
+					require.Equal(t, types.EmptyBlockID, got)
+				} else {
+					require.NotEqual(t, types.EmptyBlockID, got)
+				}
+			}
+		})
+	}
 }
 
-func TestPollLayerBlocks_OnlyOneHasLayerData(t *testing.T) {
-	net := newMockNet(t)
+func TestPollLayerContent_PeerErrors(t *testing.T) {
 	numPeers := 4
-	var withDataPeer p2p.Peer
-	for i := 0; i < numPeers; i++ {
-		peer := randPeer(t)
-		net.peers = append(net.peers, peer)
-		if i == 2 {
-			withDataPeer = peer
-			net.layerData[peer] = generateLayerContent(false)
-		} else {
-			net.errors[peer] = errors.New("SendRequest error")
-		}
+	peers := genPeers(numPeers)
+	err := errors.New("not available")
+
+	tt := []struct {
+		name                       string
+		errs                       []error
+		responses                  [][]byte
+		emptyHareOutput, zeroBlock bool
+	}{
+		{
+			name: "only one peer has data",
+			errs: []error{err, nil, err, err},
+		},
+		{
+			name:            "only one peer has empty layer",
+			errs:            []error{err, nil, err, err},
+			emptyHareOutput: true,
+			zeroBlock:       true,
+		},
 	}
 
-	layerID := types.NewLayerID(10)
-	tl := createTestLogicWithMocknet(t, net)
-	tl.mFetcher.EXPECT().GetHashes(gomock.Any(), datastore.BallotDB, false).Return(nil).Times(1)
-	tl.mFetcher.EXPECT().GetHashes(gomock.Any(), datastore.BlockDB, false).Return(nil).Times(1)
-	tl.mFetcher.EXPECT().RegisterPeerHashes(withDataPeer, gomock.Any())
+	for _, tc := range tt {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	res := <-tl.PollLayerContent(context.TODO(), layerID)
-	assert.Nil(t, res.Err)
-	assert.Equal(t, layerID, res.Layer)
-	got, err := layers.GetHareOutput(tl.db, layerID)
-	require.NoError(t, err)
-	require.NotEqual(t, types.EmptyBlockID, got)
-}
+			require.Len(t, tc.errs, numPeers)
+			layerID := types.NewLayerID(10)
+			tl := createTestLogic(t)
+			tl.mFetcher.EXPECT().GetLayerData(gomock.Any(), layerID, gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ context.Context, _ types.LayerID, okCB func([]byte, p2p.Peer, int), errCB func(error, p2p.Peer, int)) error {
+					for i, peer := range peers {
+						if tc.errs[i] == nil {
+							if tc.zeroBlock {
+								okCB(generateEmptyLayer(), peer, numPeers)
+							} else {
+								tl.mFetcher.EXPECT().RegisterPeerHashes(peer, gomock.Any())
+								okCB(generateLayerContent(tc.emptyHareOutput), peer, numPeers)
+							}
+						} else {
+							errCB(errors.New("not available"), peer, numPeers)
+						}
+					}
+					return nil
+				})
+			if tc.zeroBlock {
+				tl.mMesh.EXPECT().SetZeroBlockLayer(layerID)
+			} else {
+				tl.mFetcher.EXPECT().GetHashes(gomock.Any(), datastore.BallotDB, false).Return(nil)
+				tl.mFetcher.EXPECT().GetHashes(gomock.Any(), datastore.BlockDB, false).Return(nil)
+			}
 
-func TestPollLayerBlocks_OneZeroLayerAmongstErrors(t *testing.T) {
-	types.SetLayersPerEpoch(5)
-
-	net := newMockNet(t)
-	numPeers := 4
-
-	for i := 0; i < numPeers; i++ {
-		peer := randPeer(t)
-		net.peers = append(net.peers, peer)
-		if i == numPeers-1 {
-			net.layerData[peer] = generateEmptyLayer()
-		} else {
-			net.errors[peer] = errors.New("SendRequest error")
-		}
+			res := <-tl.PollLayerContent(context.TODO(), layerID)
+			assert.Nil(t, res.Err)
+			assert.Equal(t, layerID, res.Layer)
+			got, err := layers.GetHareOutput(tl.db, layerID)
+			require.NoError(t, err)
+			if tc.emptyHareOutput {
+				require.Equal(t, types.EmptyBlockID, got)
+			} else {
+				require.NotEqual(t, types.EmptyBlockID, got)
+			}
+		})
 	}
-
-	layerID := types.NewLayerID(10)
-	tl := createTestLogicWithMocknet(t, net)
-	tl.mMesh.EXPECT().SetZeroBlockLayer(layerID).Return(nil).Times(1)
-
-	res := <-tl.PollLayerContent(context.TODO(), layerID)
-	assert.NoError(t, res.Err)
-	assert.Equal(t, layerID, res.Layer)
-	got, err := layers.GetHareOutput(tl.db, layerID)
-	require.NoError(t, err)
-	require.Equal(t, types.EmptyBlockID, got)
 }
 
-func TestPollLayerBlocks_ZeroLayer(t *testing.T) {
-	net := newMockNet(t)
-	numPeers := 4
-	for i := 0; i < numPeers; i++ {
-		peer := randPeer(t)
-		net.peers = append(net.peers, peer)
-		net.layerData[peer] = generateEmptyLayer()
-	}
-
-	layerID := types.NewLayerID(10)
-	tl := createTestLogicWithMocknet(t, net)
-	tl.mMesh.EXPECT().SetZeroBlockLayer(layerID).Return(nil).Times(1)
-
-	res := <-tl.PollLayerContent(context.TODO(), layerID)
-	assert.NoError(t, res.Err)
-	assert.Equal(t, layerID, res.Layer)
-	got, err := layers.GetHareOutput(tl.db, layerID)
-	require.NoError(t, err)
-	require.Equal(t, types.EmptyBlockID, got)
-}
-
-func TestPollLayerBlocks_MissingBlocks(t *testing.T) {
+func TestPollLayerContent_MissingBlocks(t *testing.T) {
 	requested := types.NewLayerID(20)
 	blks := &layerData{
 		Blocks:         []types.BlockID{{1, 1, 1}, {2, 2, 2}, {3, 3, 3}},
@@ -472,20 +317,19 @@ func TestPollLayerBlocks_MissingBlocks(t *testing.T) {
 	}
 	data, err := codec.Encode(blks)
 	require.NoError(t, err)
-	net := newMockNet(t)
+	tl := createTestLogic(t)
 	numPeers := 2
-	for i := 0; i < numPeers; i++ {
-		peer := randPeer(t)
-		net.peers = append(net.peers, peer)
-		net.layerData[peer] = data
-	}
-
-	tl := createTestLogicWithMocknet(t, net)
+	peers := genPeers(numPeers)
+	tl.mFetcher.EXPECT().GetLayerData(gomock.Any(), requested, gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ types.LayerID, okCB func([]byte, p2p.Peer, int), errCB func(error, p2p.Peer, int)) error {
+			for _, peer := range peers {
+				tl.mFetcher.EXPECT().RegisterPeerHashes(peer, gomock.Any())
+				okCB(data, peer, numPeers)
+			}
+			return nil
+		})
 
 	tl.mFetcher.EXPECT().GetHashes(gomock.Any(), datastore.BallotDB, false).Return(nil).AnyTimes()
-	for _, peer := range net.peers {
-		tl.mFetcher.EXPECT().RegisterPeerHashes(peer, gomock.Any())
-	}
 	tl.mFetcher.EXPECT().GetHashes(gomock.Any(), datastore.BlockDB, false).DoAndReturn(
 		func(hashes []types.Hash32, _ datastore.Hint, _ bool) map[types.Hash32]chan ftypes.HashDataPromiseResult {
 			rst := map[types.Hash32]chan ftypes.HashDataPromiseResult{}
@@ -512,27 +356,26 @@ func TestPollLayerBlocks_MissingBlocks(t *testing.T) {
 	require.Equal(t, types.EmptyBlockID, got)
 }
 
-func TestPollLayerBlocks_DifferentHareOutputIgnored(t *testing.T) {
-	net := newMockNet(t)
-	numPeers := 4
-	for i := 0; i < numPeers; i++ {
-		peer := randPeer(t)
-		net.peers = append(net.peers, peer)
-		content := generateLayerContent(false)
-		if i == 0 {
-			content = generateLayerContent(true)
-		}
-		net.layerData[peer] = content
-	}
-
+func TestPollLayerContent_DifferentHareOutputIgnored(t *testing.T) {
 	layerID := types.NewLayerID(10)
-	tl := createTestLogicWithMocknet(t, net)
+	tl := createTestLogic(t)
+	numPeers := 4
+	peers := genPeers(numPeers)
+	tl.mFetcher.EXPECT().GetLayerData(gomock.Any(), layerID, gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ types.LayerID, okCB func([]byte, p2p.Peer, int), errCB func(error, p2p.Peer, int)) error {
+			for i, peer := range peers {
+				tl.mFetcher.EXPECT().RegisterPeerHashes(peer, gomock.Any())
+				if i == 0 {
+					okCB(generateLayerContent(true), peer, numPeers)
+				} else {
+					okCB(generateLayerContent(false), peer, numPeers)
+				}
+			}
+			return nil
+		})
 
 	tl.mFetcher.EXPECT().GetHashes(gomock.Any(), datastore.BallotDB, false).Return(nil).Times(numPeers)
 	tl.mFetcher.EXPECT().GetHashes(gomock.Any(), datastore.BlockDB, false).Return(nil).Times(numPeers)
-	for _, peer := range net.peers {
-		tl.mFetcher.EXPECT().RegisterPeerHashes(peer, gomock.Any())
-	}
 
 	res := <-tl.PollLayerContent(context.TODO(), layerID)
 	assert.NoError(t, res.Err)
@@ -542,17 +385,18 @@ func TestPollLayerBlocks_DifferentHareOutputIgnored(t *testing.T) {
 	require.NotEqual(t, types.EmptyBlockID, got)
 }
 
-func TestPollLayerBlocks_FailureToSaveZeroBlockLayerIgnored(t *testing.T) {
-	net := newMockNet(t)
-	numPeers := 4
-	for i := 0; i < numPeers; i++ {
-		peer := randPeer(t)
-		net.peers = append(net.peers, peer)
-		net.layerData[peer] = generateEmptyLayer()
-	}
-
+func TestPollLayerContent_FailureToSaveZeroBlockLayerIgnored(t *testing.T) {
 	layerID := types.NewLayerID(10)
-	tl := createTestLogicWithMocknet(t, net)
+	tl := createTestLogic(t)
+	numPeers := 4
+	peers := genPeers(numPeers)
+	tl.mFetcher.EXPECT().GetLayerData(gomock.Any(), layerID, gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ types.LayerID, okCB func([]byte, p2p.Peer, int), errCB func(error, p2p.Peer, int)) error {
+			for _, peer := range peers {
+				okCB(generateEmptyLayer(), peer, numPeers)
+			}
+			return nil
+		})
 	tl.mMesh.EXPECT().SetZeroBlockLayer(layerID).Return(errors.New("whatever")).Times(1)
 
 	res := <-tl.PollLayerContent(context.TODO(), layerID)
@@ -563,338 +407,208 @@ func TestPollLayerBlocks_FailureToSaveZeroBlockLayerIgnored(t *testing.T) {
 	require.Equal(t, types.EmptyBlockID, got)
 }
 
-func TestPollLayerBlocks_FailureToSaveZeroBallotLayerIgnored(t *testing.T) {
-	net := newMockNet(t)
-	numPeers := 4
-	for i := 0; i < numPeers; i++ {
-		peer := randPeer(t)
-		net.peers = append(net.peers, peer)
-		net.layerData[peer] = generateEmptyLayer()
-	}
-
-	layerID := types.NewLayerID(10)
-	tl := createTestLogicWithMocknet(t, net)
-	tl.mMesh.EXPECT().SetZeroBlockLayer(layerID).Return(nil).Times(1)
-
-	res := <-tl.PollLayerContent(context.TODO(), layerID)
-	assert.NoError(t, res.Err)
-	assert.Equal(t, layerID, res.Layer)
-
-	got, err := layers.GetHareOutput(tl.db, layerID)
-	require.NoError(t, err)
-	require.Equal(t, types.EmptyBlockID, got)
-}
-
-func TestGetBlocks_FetchAllError(t *testing.T) {
-	l := createTestLogic(t)
-	blks := []*types.Block{
-		types.GenLayerBlock(types.NewLayerID(10), types.RandomTXSet(10)),
-		types.GenLayerBlock(types.NewLayerID(20), types.RandomTXSet(10)),
-	}
-	blockIDs := types.ToBlockIDs(blks)
-	hashes := types.BlockIDsToHashes(blockIDs)
-
-	errUnknown := errors.New("unknown")
-	results := make(map[types.Hash32]chan ftypes.HashDataPromiseResult, len(hashes))
-	for _, h := range hashes {
-		ch := make(chan ftypes.HashDataPromiseResult, 1)
-		ch <- ftypes.HashDataPromiseResult{
-			Hash: h,
-			Err:  errUnknown,
-		}
-		results[h] = ch
-	}
-
-	l.mFetcher.EXPECT().GetHashes(hashes, datastore.BlockDB, false).Return(results).Times(1)
-	assert.ErrorIs(t, l.GetBlocks(context.TODO(), blockIDs), errUnknown)
-}
-
-func TestGetBlocks_FetchSomeError(t *testing.T) {
-	l := createTestLogic(t)
-	blks := []*types.Block{
-		types.GenLayerBlock(types.NewLayerID(10), types.RandomTXSet(10)),
-		types.GenLayerBlock(types.NewLayerID(20), types.RandomTXSet(10)),
-	}
-	blockIDs := types.ToBlockIDs(blks)
-	hashes := types.BlockIDsToHashes(blockIDs)
-
-	errUnknown := errors.New("unknown")
-	results := make(map[types.Hash32]chan ftypes.HashDataPromiseResult, len(hashes))
-	for i, h := range hashes {
-		ch := make(chan ftypes.HashDataPromiseResult, 1)
-		if i == 0 {
-			ch <- ftypes.HashDataPromiseResult{
-				Hash: h,
-				Err:  errUnknown,
-			}
-		} else {
-			data, err := codec.Encode(blks[i])
-			require.NoError(t, err)
-			ch <- ftypes.HashDataPromiseResult{
-				Hash: h,
-				Data: data,
-			}
-			l.mBlocksH.EXPECT().HandleBlockData(gomock.Any(), data).Return(nil).Times(1)
-		}
-
-		results[h] = ch
-	}
-
-	l.mFetcher.EXPECT().GetHashes(hashes, datastore.BlockDB, false).Return(results).Times(1)
-	assert.ErrorIs(t, l.GetBlocks(context.TODO(), blockIDs), errUnknown)
-}
-
-func TestGetBlocks_HandlerError(t *testing.T) {
-	l := createTestLogic(t)
-	blks := []*types.Block{
-		types.GenLayerBlock(types.NewLayerID(10), types.RandomTXSet(10)),
-		types.GenLayerBlock(types.NewLayerID(20), types.RandomTXSet(10)),
-	}
-	blockIDs := types.ToBlockIDs(blks)
-	hashes := types.BlockIDsToHashes(blockIDs)
-
-	errUnknown := errors.New("unknown")
-	results := make(map[types.Hash32]chan ftypes.HashDataPromiseResult, len(hashes))
-	for i, h := range hashes {
-		ch := make(chan ftypes.HashDataPromiseResult, 1)
-		data, err := codec.Encode(blks[i])
-		require.NoError(t, err)
-		ch <- ftypes.HashDataPromiseResult{
-			Hash: h,
-			Data: data,
-		}
-		results[h] = ch
-		l.mBlocksH.EXPECT().HandleBlockData(gomock.Any(), data).Return(errUnknown).Times(1)
-	}
-
-	l.mFetcher.EXPECT().GetHashes(hashes, datastore.BlockDB, false).Return(results).Times(1)
-	assert.ErrorIs(t, l.GetBlocks(context.TODO(), blockIDs), errUnknown)
-}
-
 func TestGetBlocks(t *testing.T) {
-	l := createTestLogic(t)
 	blks := []*types.Block{
 		types.GenLayerBlock(types.NewLayerID(10), types.RandomTXSet(10)),
 		types.GenLayerBlock(types.NewLayerID(20), types.RandomTXSet(10)),
 	}
 	blockIDs := types.ToBlockIDs(blks)
 	hashes := types.BlockIDsToHashes(blockIDs)
-
-	results := make(map[types.Hash32]chan ftypes.HashDataPromiseResult, len(hashes))
-	for i, h := range hashes {
-		ch := make(chan ftypes.HashDataPromiseResult, 1)
-		data, err := codec.Encode(blks[i])
-		require.NoError(t, err)
-		ch <- ftypes.HashDataPromiseResult{
-			Hash: h,
-			Data: data,
-		}
-		results[h] = ch
-		l.mBlocksH.EXPECT().HandleBlockData(gomock.Any(), data).Return(nil).Times(1)
-	}
-
-	l.mFetcher.EXPECT().GetHashes(hashes, datastore.BlockDB, false).Return(results).Times(1)
-	assert.NoError(t, l.GetBlocks(context.TODO(), blockIDs))
-}
-
-func TestGetBallots_FetchAllError(t *testing.T) {
-	l := createTestLogic(t)
-	blts := []*types.Ballot{
-		types.GenLayerBallot(types.NewLayerID(10)),
-		types.GenLayerBallot(types.NewLayerID(20)),
-	}
-	ballotIDs := types.ToBallotIDs(blts)
-	hashes := types.BallotIDsToHashes(ballotIDs)
-
 	errUnknown := errors.New("unknown")
-	results := make(map[types.Hash32]chan ftypes.HashDataPromiseResult, len(hashes))
-	for _, h := range hashes {
-		ch := make(chan ftypes.HashDataPromiseResult, 1)
-		ch <- ftypes.HashDataPromiseResult{
-			Hash: h,
-			Err:  errUnknown,
-		}
-		results[h] = ch
+	tt := []struct {
+		name         string
+		fetchErrs    []error
+		hdlrErr, err error
+	}{
+		{
+			name:      "all hashes fetched",
+			fetchErrs: []error{nil, nil},
+		},
+		{
+			name:      "all hashes failed",
+			fetchErrs: []error{errUnknown, errUnknown},
+			err:       errUnknown,
+		},
+		{
+			name:      "some hashes failed",
+			fetchErrs: []error{nil, errUnknown},
+			err:       errUnknown,
+		},
+		{
+			name:      "handler failed",
+			fetchErrs: []error{nil, nil},
+			hdlrErr:   errUnknown,
+			err:       errUnknown,
+		},
 	}
 
-	l.mFetcher.EXPECT().GetHashes(hashes, datastore.BallotDB, false).Return(results).Times(1)
-	assert.ErrorIs(t, l.GetBallots(context.TODO(), ballotIDs), errUnknown)
-}
+	for _, tc := range tt {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-func TestGetBallots_FetchSomeError(t *testing.T) {
-	l := createTestLogic(t)
-	blts := []*types.Ballot{
-		types.GenLayerBallot(types.NewLayerID(10)),
-		types.GenLayerBallot(types.NewLayerID(20)),
-	}
-	ballotIDs := types.ToBallotIDs(blts)
-	hashes := types.BallotIDsToHashes(ballotIDs)
-
-	errUnknown := errors.New("unknown")
-	results := make(map[types.Hash32]chan ftypes.HashDataPromiseResult, len(hashes))
-	for i, h := range hashes {
-		ch := make(chan ftypes.HashDataPromiseResult, 1)
-		if i == 0 {
-			ch <- ftypes.HashDataPromiseResult{
-				Hash: h,
-				Err:  errUnknown,
+			require.Len(t, tc.fetchErrs, len(hashes))
+			l := createTestLogic(t)
+			results := make(map[types.Hash32]chan ftypes.HashDataPromiseResult, len(hashes))
+			for i, h := range hashes {
+				ch := make(chan ftypes.HashDataPromiseResult, 1)
+				if tc.fetchErrs[i] == nil {
+					data, err := codec.Encode(blks[i])
+					require.NoError(t, err)
+					ch <- ftypes.HashDataPromiseResult{
+						Hash: h,
+						Data: data,
+					}
+					l.mBlocksH.EXPECT().HandleBlockData(gomock.Any(), data).Return(tc.hdlrErr)
+				} else {
+					ch <- ftypes.HashDataPromiseResult{
+						Hash: h,
+						Err:  tc.fetchErrs[i],
+					}
+				}
+				results[h] = ch
 			}
-		} else {
-			data, err := codec.Encode(blts[i])
-			require.NoError(t, err)
-			ch <- ftypes.HashDataPromiseResult{
-				Hash: h,
-				Data: data,
-			}
-			l.mBallotH.EXPECT().HandleBallotData(gomock.Any(), data).Return(nil).Times(1)
-		}
 
-		results[h] = ch
+			l.mFetcher.EXPECT().GetHashes(hashes, datastore.BlockDB, false).Return(results)
+			require.ErrorIs(t, l.GetBlocks(context.TODO(), blockIDs), tc.err)
+		})
 	}
-
-	l.mFetcher.EXPECT().GetHashes(hashes, datastore.BallotDB, false).Return(results).Times(1)
-	assert.ErrorIs(t, l.GetBallots(context.TODO(), ballotIDs), errUnknown)
-}
-
-func TestGetBallots_HandlerError(t *testing.T) {
-	l := createTestLogic(t)
-	blts := []*types.Ballot{
-		types.GenLayerBallot(types.NewLayerID(10)),
-		types.GenLayerBallot(types.NewLayerID(20)),
-	}
-	ballotIDs := types.ToBallotIDs(blts)
-	hashes := types.BallotIDsToHashes(ballotIDs)
-
-	errUnknown := errors.New("unknown")
-	results := make(map[types.Hash32]chan ftypes.HashDataPromiseResult, len(hashes))
-	for i, h := range hashes {
-		ch := make(chan ftypes.HashDataPromiseResult, 1)
-		data, err := codec.Encode(blts[i])
-		require.NoError(t, err)
-		ch <- ftypes.HashDataPromiseResult{
-			Hash: h,
-			Data: data,
-		}
-		results[h] = ch
-		l.mBallotH.EXPECT().HandleBallotData(gomock.Any(), data).Return(errUnknown).Times(1)
-	}
-
-	l.mFetcher.EXPECT().GetHashes(hashes, datastore.BallotDB, false).Return(results).Times(1)
-	assert.ErrorIs(t, l.GetBallots(context.TODO(), ballotIDs), errUnknown)
 }
 
 func TestGetBallots(t *testing.T) {
-	l := createTestLogic(t)
 	blts := []*types.Ballot{
 		types.GenLayerBallot(types.NewLayerID(10)),
 		types.GenLayerBallot(types.NewLayerID(20)),
 	}
 	ballotIDs := types.ToBallotIDs(blts)
 	hashes := types.BallotIDsToHashes(ballotIDs)
-
-	results := make(map[types.Hash32]chan ftypes.HashDataPromiseResult, len(hashes))
-	for i, h := range hashes {
-		ch := make(chan ftypes.HashDataPromiseResult, 1)
-		data, err := codec.Encode(blts[i])
-		require.NoError(t, err)
-		ch <- ftypes.HashDataPromiseResult{
-			Hash: h,
-			Data: data,
-		}
-		results[h] = ch
-		l.mBallotH.EXPECT().HandleBallotData(gomock.Any(), data).Return(nil).Times(1)
-	}
-
-	l.mFetcher.EXPECT().GetHashes(hashes, datastore.BallotDB, false).Return(results).Times(1)
-	assert.NoError(t, l.GetBallots(context.TODO(), ballotIDs))
-}
-
-func TestGetProposals_FetchSomeError(t *testing.T) {
-	l := createTestLogic(t)
-	proposals := []*types.Proposal{
-		types.GenLayerProposal(types.NewLayerID(10), nil),
-		types.GenLayerProposal(types.NewLayerID(20), nil),
-	}
-	proposalIDs := types.ToProposalIDs(proposals)
-	hashes := types.ProposalIDsToHashes(proposalIDs)
-
 	errUnknown := errors.New("unknown")
-	results := make(map[types.Hash32]chan ftypes.HashDataPromiseResult, len(hashes))
-	for i, h := range hashes {
-		ch := make(chan ftypes.HashDataPromiseResult, 1)
-		if i == 0 {
-			ch <- ftypes.HashDataPromiseResult{
-				Hash: h,
-				Err:  errUnknown,
+	tt := []struct {
+		name         string
+		fetchErrs    []error
+		hdlrErr, err error
+	}{
+		{
+			name:      "all hashes fetched",
+			fetchErrs: []error{nil, nil},
+		},
+		{
+			name:      "all hashes failed",
+			fetchErrs: []error{errUnknown, errUnknown},
+			err:       errUnknown,
+		},
+		{
+			name:      "some hashes failed",
+			fetchErrs: []error{nil, errUnknown},
+			err:       errUnknown,
+		},
+		{
+			name:      "handler failed",
+			fetchErrs: []error{nil, nil},
+			hdlrErr:   errUnknown,
+			err:       errUnknown,
+		},
+	}
+
+	for _, tc := range tt {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Len(t, tc.fetchErrs, len(hashes))
+			l := createTestLogic(t)
+			results := make(map[types.Hash32]chan ftypes.HashDataPromiseResult, len(hashes))
+			for i, h := range hashes {
+				ch := make(chan ftypes.HashDataPromiseResult, 1)
+				if tc.fetchErrs[i] == nil {
+					data, err := codec.Encode(blts[i])
+					require.NoError(t, err)
+					ch <- ftypes.HashDataPromiseResult{
+						Hash: h,
+						Data: data,
+					}
+					l.mBallotH.EXPECT().HandleBallotData(gomock.Any(), data).Return(tc.hdlrErr)
+				} else {
+					ch <- ftypes.HashDataPromiseResult{
+						Hash: h,
+						Err:  tc.fetchErrs[i],
+					}
+				}
+				results[h] = ch
 			}
-		} else {
-			data, err := codec.Encode(proposals[i])
-			require.NoError(t, err)
-			ch <- ftypes.HashDataPromiseResult{
-				Hash: h,
-				Data: data,
-			}
-			l.mProposalH.EXPECT().HandleProposalData(gomock.Any(), data).Return(nil).Times(1)
-		}
 
-		results[h] = ch
+			l.mFetcher.EXPECT().GetHashes(hashes, datastore.BallotDB, false).Return(results)
+			require.ErrorIs(t, l.GetBallots(context.TODO(), ballotIDs), tc.err)
+		})
 	}
-
-	l.mFetcher.EXPECT().GetHashes(hashes, datastore.ProposalDB, false).Return(results).Times(1)
-	assert.ErrorIs(t, l.GetProposals(context.TODO(), proposalIDs), errUnknown)
-}
-
-func TestGetProposals_HandlerError(t *testing.T) {
-	l := createTestLogic(t)
-	proposals := []*types.Proposal{
-		types.GenLayerProposal(types.NewLayerID(10), nil),
-		types.GenLayerProposal(types.NewLayerID(20), nil),
-	}
-	proposalIDs := types.ToProposalIDs(proposals)
-	hashes := types.ProposalIDsToHashes(proposalIDs)
-
-	errUnknown := errors.New("unknown")
-	results := make(map[types.Hash32]chan ftypes.HashDataPromiseResult, len(hashes))
-	for i, h := range hashes {
-		ch := make(chan ftypes.HashDataPromiseResult, 1)
-		data, err := codec.Encode(proposals[i])
-		require.NoError(t, err)
-		ch <- ftypes.HashDataPromiseResult{
-			Hash: h,
-			Data: data,
-		}
-		results[h] = ch
-		l.mProposalH.EXPECT().HandleProposalData(gomock.Any(), data).Return(errUnknown).Times(1)
-	}
-
-	l.mFetcher.EXPECT().GetHashes(hashes, datastore.ProposalDB, false).Return(results).Times(1)
-	assert.ErrorIs(t, l.GetProposals(context.TODO(), proposalIDs), errUnknown)
 }
 
 func TestGetProposals(t *testing.T) {
-	l := createTestLogic(t)
 	proposals := []*types.Proposal{
 		types.GenLayerProposal(types.NewLayerID(10), nil),
 		types.GenLayerProposal(types.NewLayerID(20), nil),
 	}
 	proposalIDs := types.ToProposalIDs(proposals)
 	hashes := types.ProposalIDsToHashes(proposalIDs)
-
-	results := make(map[types.Hash32]chan ftypes.HashDataPromiseResult, len(hashes))
-	for i, h := range hashes {
-		ch := make(chan ftypes.HashDataPromiseResult, 1)
-		data, err := codec.Encode(proposals[i])
-		require.NoError(t, err)
-		ch <- ftypes.HashDataPromiseResult{
-			Hash: h,
-			Data: data,
-		}
-		results[h] = ch
-		l.mProposalH.EXPECT().HandleProposalData(gomock.Any(), data).Return(nil).Times(1)
+	errUnknown := errors.New("unknown")
+	tt := []struct {
+		name         string
+		fetchErrs    []error
+		hdlrErr, err error
+	}{
+		{
+			name:      "all hashes fetched",
+			fetchErrs: []error{nil, nil},
+		},
+		{
+			name:      "all hashes failed",
+			fetchErrs: []error{errUnknown, errUnknown},
+			err:       errUnknown,
+		},
+		{
+			name:      "some hashes failed",
+			fetchErrs: []error{nil, errUnknown},
+			err:       errUnknown,
+		},
+		{
+			name:      "handler failed",
+			fetchErrs: []error{nil, nil},
+			hdlrErr:   errUnknown,
+			err:       errUnknown,
+		},
 	}
 
-	l.mFetcher.EXPECT().GetHashes(hashes, datastore.ProposalDB, false).Return(results).Times(1)
-	assert.NoError(t, l.GetProposals(context.TODO(), proposalIDs))
+	for _, tc := range tt {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Len(t, tc.fetchErrs, len(hashes))
+			l := createTestLogic(t)
+			results := make(map[types.Hash32]chan ftypes.HashDataPromiseResult, len(hashes))
+			for i, h := range hashes {
+				ch := make(chan ftypes.HashDataPromiseResult, 1)
+				if tc.fetchErrs[i] == nil {
+					data, err := codec.Encode(proposals[i])
+					require.NoError(t, err)
+					ch <- ftypes.HashDataPromiseResult{
+						Hash: h,
+						Data: data,
+					}
+					l.mProposalH.EXPECT().HandleProposalData(gomock.Any(), data).Return(tc.hdlrErr)
+				} else {
+					ch <- ftypes.HashDataPromiseResult{
+						Hash: h,
+						Err:  tc.fetchErrs[i],
+					}
+				}
+				results[h] = ch
+			}
+
+			l.mFetcher.EXPECT().GetHashes(hashes, datastore.ProposalDB, false).Return(results)
+			require.ErrorIs(t, l.GetProposals(context.TODO(), proposalIDs), tc.err)
+		})
+	}
 }
 
 func genTx(t *testing.T, signer *signing.EdSigner, dest types.Address, amount, nonce, price uint64) types.Transaction {
@@ -1028,82 +742,69 @@ func genATXs(t *testing.T, num int) []*types.ActivationTx {
 	return atxs
 }
 
-func TestGetAtxs_FetchSomeError(t *testing.T) {
-	l := createTestLogic(t)
-	atxs := genATXs(t, 19)
+func TestGetATXs(t *testing.T) {
+	atxs := genATXs(t, 2)
 	atxIDs := types.ToATXIDs(atxs)
 	hashes := types.ATXIDsToHashes(atxIDs)
-
 	errUnknown := errors.New("unknown")
-	results := make(map[types.Hash32]chan ftypes.HashDataPromiseResult, len(hashes))
-	for i, h := range hashes {
-		ch := make(chan ftypes.HashDataPromiseResult, 1)
-		if i == 0 {
-			ch <- ftypes.HashDataPromiseResult{
-				Hash: h,
-				Err:  errUnknown,
+	tt := []struct {
+		name         string
+		fetchErrs    []error
+		hdlrErr, err error
+	}{
+		{
+			name:      "all hashes fetched",
+			fetchErrs: []error{nil, nil},
+		},
+		{
+			name:      "all hashes failed",
+			fetchErrs: []error{errUnknown, errUnknown},
+			err:       errUnknown,
+		},
+		{
+			name:      "some hashes failed",
+			fetchErrs: []error{nil, errUnknown},
+			err:       errUnknown,
+		},
+		{
+			name:      "handler failed",
+			fetchErrs: []error{nil, nil},
+			hdlrErr:   errUnknown,
+			err:       errUnknown,
+		},
+	}
+
+	for _, tc := range tt {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Len(t, tc.fetchErrs, len(hashes))
+			l := createTestLogic(t)
+			results := make(map[types.Hash32]chan ftypes.HashDataPromiseResult, len(hashes))
+			for i, h := range hashes {
+				ch := make(chan ftypes.HashDataPromiseResult, 1)
+				if tc.fetchErrs[i] == nil {
+					data, err := codec.Encode(atxs[i])
+					require.NoError(t, err)
+					ch <- ftypes.HashDataPromiseResult{
+						Hash: h,
+						Data: data,
+					}
+					l.mAtxH.EXPECT().HandleAtxData(gomock.Any(), data).Return(tc.hdlrErr)
+				} else {
+					ch <- ftypes.HashDataPromiseResult{
+						Hash: h,
+						Err:  tc.fetchErrs[i],
+					}
+				}
+				results[h] = ch
 			}
-		} else {
-			data, err := codec.Encode(atxIDs[i])
-			require.NoError(t, err)
-			ch <- ftypes.HashDataPromiseResult{
-				Hash: h,
-				Data: data,
-			}
-			l.mAtxH.EXPECT().HandleAtxData(gomock.Any(), data).Return(nil).Times(1)
-		}
-		results[h] = ch
+
+			l.mFetcher.EXPECT().GetHashes(hashes, datastore.ATXDB, false).Return(results)
+			require.ErrorIs(t, l.GetAtxs(context.TODO(), atxIDs), tc.err)
+		})
 	}
-
-	l.mFetcher.EXPECT().GetHashes(hashes, datastore.ATXDB, false).Return(results).Times(1)
-	assert.ErrorIs(t, l.GetAtxs(context.TODO(), atxIDs), errUnknown)
-}
-
-func TestGetAtxs_HandlerError(t *testing.T) {
-	l := createTestLogic(t)
-	atxs := genATXs(t, 19)
-	atxIDs := types.ToATXIDs(atxs)
-	hashes := types.ATXIDsToHashes(atxIDs)
-
-	errUnknown := errors.New("unknown")
-	results := make(map[types.Hash32]chan ftypes.HashDataPromiseResult, len(hashes))
-	for i, h := range hashes {
-		ch := make(chan ftypes.HashDataPromiseResult, 1)
-		data, err := codec.Encode(atxs[i])
-		require.NoError(t, err)
-		ch <- ftypes.HashDataPromiseResult{
-			Hash: h,
-			Data: data,
-		}
-		results[h] = ch
-		l.mAtxH.EXPECT().HandleAtxData(gomock.Any(), data).Return(errUnknown).Times(1)
-	}
-
-	l.mFetcher.EXPECT().GetHashes(hashes, datastore.ATXDB, false).Return(results).Times(1)
-	assert.ErrorIs(t, l.GetAtxs(context.TODO(), atxIDs), errUnknown)
-}
-
-func TestGetAtxs(t *testing.T) {
-	l := createTestLogic(t)
-	atxs := genATXs(t, 19)
-	atxIDs := types.ToATXIDs(atxs)
-	hashes := types.ATXIDsToHashes(atxIDs)
-
-	results := make(map[types.Hash32]chan ftypes.HashDataPromiseResult, len(hashes))
-	for i, h := range hashes {
-		ch := make(chan ftypes.HashDataPromiseResult, 1)
-		data, err := codec.Encode(atxIDs[i])
-		require.NoError(t, err)
-		ch <- ftypes.HashDataPromiseResult{
-			Hash: h,
-			Data: data,
-		}
-		results[h] = ch
-		l.mAtxH.EXPECT().HandleAtxData(gomock.Any(), data).Return(nil).Times(1)
-	}
-
-	l.mFetcher.EXPECT().GetHashes(hashes, datastore.ATXDB, false).Return(results).Times(1)
-	assert.NoError(t, l.GetAtxs(context.TODO(), atxIDs))
 }
 
 func TestGetPoetProof(t *testing.T) {

--- a/fetch/mocks/mocks.go
+++ b/fetch/mocks/mocks.go
@@ -9,9 +9,6 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	network "github.com/libp2p/go-libp2p-core/network"
-	peer "github.com/libp2p/go-libp2p-core/peer"
-	protocol "github.com/libp2p/go-libp2p-core/protocol"
 	types "github.com/spacemeshos/go-spacemesh/common/types"
 	datastore "github.com/spacemeshos/go-spacemesh/datastore"
 	types0 "github.com/spacemeshos/go-spacemesh/fetch/types"
@@ -53,6 +50,20 @@ func (mr *MockfetcherMockRecorder) AddPeersFromHash(arg0, arg1 interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddPeersFromHash", reflect.TypeOf((*Mockfetcher)(nil).AddPeersFromHash), arg0, arg1)
 }
 
+// GetEpochATXIDs mocks base method.
+func (m *Mockfetcher) GetEpochATXIDs(arg0 context.Context, arg1 types.EpochID, arg2 func([]byte, p2p.Peer), arg3 func(error)) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetEpochATXIDs", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// GetEpochATXIDs indicates an expected call of GetEpochATXIDs.
+func (mr *MockfetcherMockRecorder) GetEpochATXIDs(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEpochATXIDs", reflect.TypeOf((*Mockfetcher)(nil).GetEpochATXIDs), arg0, arg1, arg2, arg3)
+}
+
 // GetHash mocks base method.
 func (m *Mockfetcher) GetHash(arg0 types.Hash32, arg1 datastore.Hint, arg2 bool) chan types0.HashDataPromiseResult {
 	m.ctrl.T.Helper()
@@ -79,6 +90,20 @@ func (m *Mockfetcher) GetHashes(arg0 []types.Hash32, arg1 datastore.Hint, arg2 b
 func (mr *MockfetcherMockRecorder) GetHashes(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHashes", reflect.TypeOf((*Mockfetcher)(nil).GetHashes), arg0, arg1, arg2)
+}
+
+// GetLayerData mocks base method.
+func (m *Mockfetcher) GetLayerData(arg0 context.Context, arg1 types.LayerID, arg2 func([]byte, p2p.Peer, int), arg3 func(error, p2p.Peer, int)) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetLayerData", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// GetLayerData indicates an expected call of GetLayerData.
+func (mr *MockfetcherMockRecorder) GetLayerData(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLayerData", reflect.TypeOf((*Mockfetcher)(nil).GetLayerData), arg0, arg1, arg2, arg3)
 }
 
 // RegisterPeerHashes mocks base method.
@@ -404,99 +429,53 @@ func (mr *MockmeshProviderMockRecorder) SetZeroBlockLayer(arg0 interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetZeroBlockLayer", reflect.TypeOf((*MockmeshProvider)(nil).SetZeroBlockLayer), arg0)
 }
 
-// Mocknetwork is a mock of network interface.
-type Mocknetwork struct {
+// Mockhost is a mock of host interface.
+type Mockhost struct {
 	ctrl     *gomock.Controller
-	recorder *MocknetworkMockRecorder
+	recorder *MockhostMockRecorder
 }
 
-// MocknetworkMockRecorder is the mock recorder for Mocknetwork.
-type MocknetworkMockRecorder struct {
-	mock *Mocknetwork
+// MockhostMockRecorder is the mock recorder for Mockhost.
+type MockhostMockRecorder struct {
+	mock *Mockhost
 }
 
-// NewMocknetwork creates a new mock instance.
-func NewMocknetwork(ctrl *gomock.Controller) *Mocknetwork {
-	mock := &Mocknetwork{ctrl: ctrl}
-	mock.recorder = &MocknetworkMockRecorder{mock}
+// NewMockhost creates a new mock instance.
+func NewMockhost(ctrl *gomock.Controller) *Mockhost {
+	mock := &Mockhost{ctrl: ctrl}
+	mock.recorder = &MockhostMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *Mocknetwork) EXPECT() *MocknetworkMockRecorder {
+func (m *Mockhost) EXPECT() *MockhostMockRecorder {
 	return m.recorder
 }
 
+// Close mocks base method.
+func (m *Mockhost) Close() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Close")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Close indicates an expected call of Close.
+func (mr *MockhostMockRecorder) Close() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*Mockhost)(nil).Close))
+}
+
 // GetPeers mocks base method.
-func (m *Mocknetwork) GetPeers() []peer.ID {
+func (m *Mockhost) GetPeers() []p2p.Peer {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPeers")
-	ret0, _ := ret[0].([]peer.ID)
+	ret0, _ := ret[0].([]p2p.Peer)
 	return ret0
 }
 
 // GetPeers indicates an expected call of GetPeers.
-func (mr *MocknetworkMockRecorder) GetPeers() *gomock.Call {
+func (mr *MockhostMockRecorder) GetPeers() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPeers", reflect.TypeOf((*Mocknetwork)(nil).GetPeers))
-}
-
-// Network mocks base method.
-func (m *Mocknetwork) Network() network.Network {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Network")
-	ret0, _ := ret[0].(network.Network)
-	return ret0
-}
-
-// Network indicates an expected call of Network.
-func (mr *MocknetworkMockRecorder) Network() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Network", reflect.TypeOf((*Mocknetwork)(nil).Network))
-}
-
-// NewStream mocks base method.
-func (m *Mocknetwork) NewStream(arg0 context.Context, arg1 peer.ID, arg2 ...protocol.ID) (network.Stream, error) {
-	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1}
-	for _, a := range arg2 {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "NewStream", varargs...)
-	ret0, _ := ret[0].(network.Stream)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// NewStream indicates an expected call of NewStream.
-func (mr *MocknetworkMockRecorder) NewStream(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewStream", reflect.TypeOf((*Mocknetwork)(nil).NewStream), varargs...)
-}
-
-// PeerCount mocks base method.
-func (m *Mocknetwork) PeerCount() uint64 {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PeerCount")
-	ret0, _ := ret[0].(uint64)
-	return ret0
-}
-
-// PeerCount indicates an expected call of PeerCount.
-func (mr *MocknetworkMockRecorder) PeerCount() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PeerCount", reflect.TypeOf((*Mocknetwork)(nil).PeerCount))
-}
-
-// SetStreamHandler mocks base method.
-func (m *Mocknetwork) SetStreamHandler(arg0 protocol.ID, arg1 network.StreamHandler) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetStreamHandler", arg0, arg1)
-}
-
-// SetStreamHandler indicates an expected call of SetStreamHandler.
-func (mr *MocknetworkMockRecorder) SetStreamHandler(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetStreamHandler", reflect.TypeOf((*Mocknetwork)(nil).SetStreamHandler), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPeers", reflect.TypeOf((*Mockhost)(nil).GetPeers))
 }

--- a/p2p/bootstrap/mocks/peers.go
+++ b/p2p/bootstrap/mocks/peers.go
@@ -12,57 +12,6 @@ import (
 	peer "github.com/libp2p/go-libp2p-core/peer"
 )
 
-// MockProvider is a mock of Provider interface.
-type MockProvider struct {
-	ctrl     *gomock.Controller
-	recorder *MockProviderMockRecorder
-}
-
-// MockProviderMockRecorder is the mock recorder for MockProvider.
-type MockProviderMockRecorder struct {
-	mock *MockProvider
-}
-
-// NewMockProvider creates a new mock instance.
-func NewMockProvider(ctrl *gomock.Controller) *MockProvider {
-	mock := &MockProvider{ctrl: ctrl}
-	mock.recorder = &MockProviderMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockProvider) EXPECT() *MockProviderMockRecorder {
-	return m.recorder
-}
-
-// GetPeers mocks base method.
-func (m *MockProvider) GetPeers() []peer.ID {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPeers")
-	ret0, _ := ret[0].([]peer.ID)
-	return ret0
-}
-
-// GetPeers indicates an expected call of GetPeers.
-func (mr *MockProviderMockRecorder) GetPeers() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPeers", reflect.TypeOf((*MockProvider)(nil).GetPeers))
-}
-
-// PeerCount mocks base method.
-func (m *MockProvider) PeerCount() uint64 {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PeerCount")
-	ret0, _ := ret[0].(uint64)
-	return ret0
-}
-
-// PeerCount indicates an expected call of PeerCount.
-func (mr *MockProviderMockRecorder) PeerCount() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PeerCount", reflect.TypeOf((*MockProvider)(nil).PeerCount))
-}
-
 // MockWaiter is a mock of Waiter interface.
 type MockWaiter struct {
 	ctrl     *gomock.Controller

--- a/p2p/bootstrap/peers.go
+++ b/p2p/bootstrap/peers.go
@@ -52,12 +52,6 @@ func StartPeers(h host.Host, opts ...Opt) *Peers {
 
 //go:generate mockgen -package=mocks -destination=./mocks/peers.go -source=./peers.go
 
-// Provider is an interface that provides peers.
-type Provider interface {
-	PeerCount() uint64
-	GetPeers() []peer.ID
-}
-
 // Waiter is an interface to wait for peers.
 type Waiter interface {
 	WaitPeers(context.Context, int) ([]peer.ID, error)

--- a/system/fetcher.go
+++ b/system/fetcher.go
@@ -28,7 +28,6 @@ type BlockFetcher interface {
 // AtxFetcher defines an interface for fetching ATXs from remote peers.
 type AtxFetcher interface {
 	GetAtxs(context.Context, []types.ATXID) error
-	FetchAtx(context.Context, types.ATXID) error
 }
 
 // TxFetcher defines an interface for fetching transactions from remote peers.

--- a/system/mocks/fetcher.go
+++ b/system/mocks/fetcher.go
@@ -48,20 +48,6 @@ func (mr *MockFetcherMockRecorder) AddPeersFromHash(arg0, arg1 interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddPeersFromHash", reflect.TypeOf((*MockFetcher)(nil).AddPeersFromHash), arg0, arg1)
 }
 
-// FetchAtx mocks base method.
-func (m *MockFetcher) FetchAtx(arg0 context.Context, arg1 types.ATXID) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FetchAtx", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// FetchAtx indicates an expected call of FetchAtx.
-func (mr *MockFetcherMockRecorder) FetchAtx(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchAtx", reflect.TypeOf((*MockFetcher)(nil).FetchAtx), arg0, arg1)
-}
-
 // GetAtxs mocks base method.
 func (m *MockFetcher) GetAtxs(arg0 context.Context, arg1 []types.ATXID) error {
 	m.ctrl.T.Helper()
@@ -230,20 +216,6 @@ func NewMockAtxFetcher(ctrl *gomock.Controller) *MockAtxFetcher {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockAtxFetcher) EXPECT() *MockAtxFetcherMockRecorder {
 	return m.recorder
-}
-
-// FetchAtx mocks base method.
-func (m *MockAtxFetcher) FetchAtx(arg0 context.Context, arg1 types.ATXID) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FetchAtx", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// FetchAtx indicates an expected call of FetchAtx.
-func (mr *MockAtxFetcherMockRecorder) FetchAtx(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchAtx", reflect.TypeOf((*MockAtxFetcher)(nil).FetchAtx), arg0, arg1)
 }
 
 // GetAtxs mocks base method.


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
refactor the fetch package to achieve separation of concerns:
- layer.go handle the per epoch/layer data
- handler.go handle peer requests
- fetch.go does all the actually peer requests

## Changes
<!-- Please describe in detail the changes made -->
- create a handler.go to decouple the circular dependency of Logic and Fetcher and allows mocking out network/peers
- move the actual peer requests to Fetcher. Logic will handle the sync logic by epoch/layer

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->
unit test, systest

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
