### PR TITLE
[Merged by Bors] - node: check genesis accounts before creating

### DIFF
--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -464,16 +464,15 @@ func (app *App) initServices(ctx context.Context,
 	}
 
 	genesisAccts := app.Config.Genesis.ToAccounts()
-	if len(genesisAccts) == 0 {
-		return fmt.Errorf("missing genesis accounts in config")
-	}
-	_, err = state.GetBalance(genesisAccts[0].Address)
-	if errors.Is(err, sql.ErrNotFound) {
-		if err = state.ApplyGenesis(app.Config.Genesis.ToAccounts()); err != nil {
-			return fmt.Errorf("setup genesis: %w", err)
+	if len(genesisAccts) > 0 {
+		_, err = state.GetBalance(genesisAccts[0].Address)
+		if errors.Is(err, sql.ErrNotFound) {
+			if err = state.ApplyGenesis(app.Config.Genesis.ToAccounts()); err != nil {
+				return fmt.Errorf("setup genesis: %w", err)
+			}
+		} else if err != nil {
+			return fmt.Errorf("failed to check genesis accounts %v: %w", genesisAccts[0].Address, err)
 		}
-	} else if err != nil {
-		return fmt.Errorf("failed to check genesis accounts %v: %w", genesisAccts[0].Address, err)
 	}
 
 	goldenATXID := types.ATXID(types.HexToHash32(app.Config.GoldenATXID))

--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -465,13 +465,14 @@ func (app *App) initServices(ctx context.Context,
 
 	genesisAccts := app.Config.Genesis.ToAccounts()
 	if len(genesisAccts) > 0 {
-		_, err = state.GetBalance(genesisAccts[0].Address)
-		if errors.Is(err, sql.ErrNotFound) {
-			if err = state.ApplyGenesis(app.Config.Genesis.ToAccounts()); err != nil {
+		exists, err := state.AccountExists(genesisAccts[0].Address)
+		if err != nil {
+			return fmt.Errorf("failed to check genesis account %v: %w", genesisAccts[0].Address, err)
+		}
+		if !exists {
+			if err = state.ApplyGenesis(genesisAccts); err != nil {
 				return fmt.Errorf("setup genesis: %w", err)
 			}
-		} else if err != nil {
-			return fmt.Errorf("failed to check genesis accounts %v: %w", genesisAccts[0].Address, err)
 		}
 	}
 

--- a/genvm/vm.go
+++ b/genvm/vm.go
@@ -112,6 +112,11 @@ func (v *VM) Revert(lid types.LayerID) (types.Hash32, error) {
 	return v.GetStateRoot()
 }
 
+// AccountExists returns true if the address exists, spawned or not.
+func (v *VM) AccountExists(address core.Address) (bool, error) {
+	return accounts.Has(v.db, address)
+}
+
 // GetNonce returns expected next nonce for the address.
 func (v *VM) GetNonce(address core.Address) (core.Nonce, error) {
 	account, err := accounts.Latest(v.db, address)

--- a/mesh/mesh_test.go
+++ b/mesh/mesh_test.go
@@ -41,9 +41,8 @@ func createTestMesh(t *testing.T) *testMesh {
 		mockState:    mocks.NewMockconservativeState(ctrl),
 		mockTortoise: mocks.NewMocktortoise(ctrl),
 	}
-	msh, recovered, err := NewMesh(datastore.NewCachedDB(sql.InMemory(), lg), tm.mockTortoise, tm.mockState, lg)
+	msh, err := NewMesh(datastore.NewCachedDB(sql.InMemory(), lg), tm.mockTortoise, tm.mockState, lg)
 	require.NoError(t, err)
-	require.False(t, recovered)
 	tm.Mesh = msh
 	checkLastApplied(t, tm.Mesh, types.GetEffectiveGenesis())
 	return tm
@@ -103,9 +102,8 @@ func checkLastApplied(t *testing.T, mesh *Mesh, expected types.LayerID) {
 
 func TestMesh_FromGenesis(t *testing.T) {
 	tm := createTestMesh(t)
-	msh, recovered, err := NewMesh(tm.cdb, tm.mockTortoise, tm.mockState, logtest.New(t))
+	msh, err := NewMesh(tm.cdb, tm.mockTortoise, tm.mockState, logtest.New(t))
 	require.NoError(t, err)
-	require.False(t, recovered)
 	gotP, err := msh.GetProcessedLayer()
 	require.NoError(t, err)
 	require.Equal(t, types.GetEffectiveGenesis(), gotP)
@@ -148,9 +146,8 @@ func TestMesh_WakeUp(t *testing.T) {
 	require.NoError(t, layers.SetStatus(tm.cdb, latestState, layers.Applied))
 
 	tm.mockState.EXPECT().RevertState(latestState).Return(types.RandomHash(), nil)
-	msh, recovered, err := NewMesh(tm.cdb, tm.mockTortoise, tm.mockState, logtest.New(t))
+	msh, err := NewMesh(tm.cdb, tm.mockTortoise, tm.mockState, logtest.New(t))
 	require.NoError(t, err)
-	require.True(t, recovered)
 	gotP, err := msh.GetProcessedLayer()
 	require.NoError(t, err)
 	require.Equal(t, latest, gotP)

--- a/sql/accounts/accounts.go
+++ b/sql/accounts/accounts.go
@@ -29,6 +29,19 @@ func load(db sql.Executor, address types.Address, query string, enc sql.Encoder)
 	return account, nil
 }
 
+// Has the account in the database.
+func Has(db sql.Executor, address types.Address) (bool, error) {
+	rows, err := db.Exec("select 1 from accounts where address = ?1;",
+		func(stmt *sql.Statement) {
+			stmt.BindBytes(1, address.Bytes())
+		}, nil,
+	)
+	if err != nil {
+		return false, fmt.Errorf("has address %v: %w", address, err)
+	}
+	return rows > 0, nil
+}
+
 // Latest latest account data for an address.
 func Latest(db sql.Executor, address types.Address) (types.Account, error) {
 	account, err := load(db, address, "select balance, initialized, nonce, layer_updated, template, state from accounts where address = ?1;", func(stmt *sql.Statement) {

--- a/sql/accounts/accounts_test.go
+++ b/sql/accounts/accounts_test.go
@@ -30,6 +30,21 @@ func TestUpdate(t *testing.T) {
 	require.Equal(t, seq[len(seq)-1], &latest)
 }
 
+func TestHas(t *testing.T) {
+	address := types.Address{1, 2, 3}
+	db := sql.InMemory()
+	has, err := Has(db, address)
+	require.NoError(t, err)
+	require.False(t, has)
+	seq := genSeq(address, 2)
+	for _, update := range seq {
+		require.NoError(t, Update(db, update))
+	}
+	has, err = Has(db, address)
+	require.NoError(t, err)
+	require.True(t, has)
+}
+
 func TestRevert(t *testing.T) {
 	address := types.Address{1, 1}
 	seq := genSeq(address, 10)

--- a/syncer/syncer_test.go
+++ b/syncer/syncer_test.go
@@ -59,7 +59,7 @@ func newMesh(t *testing.T, lg log.Log, cdb *datastore.CachedDB, allMocked bool) 
 				return lid.Sub(1)
 			}).AnyTimes()
 	}
-	msh, _, err := mesh.NewMesh(cdb, mt, mcs, lg)
+	msh, err := mesh.NewMesh(cdb, mt, mcs, lg)
 	require.NoError(t, err)
 	return msh, mcs, mt
 }

--- a/tortoise/algorithm.go
+++ b/tortoise/algorithm.go
@@ -137,7 +137,7 @@ func New(cdb *datastore.CachedDB, beacons system.BeaconGetter, updater blockVali
 		t.trtl.verified = t.cfg.MeshVerified
 		t.trtl.historicallyVerified = t.cfg.MeshVerified
 
-		t.logger.Info("loading state from disk. make sure to wait until tortoise is ready",
+		t.logger.With().Info("loading state from disk. make sure to wait until tortoise is ready",
 			log.Stringer("last_layer", t.cfg.MeshProcessed),
 			log.Stringer("historically_verified", t.cfg.MeshVerified),
 		)


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
Closes #3303 and some minor fixes in mesh
<!-- `Closes #XXXX, closes #XXXX, ...` links mentioned issues to this PR and automatically closes them when this it's merged -->

## Changes
<!-- Please describe in detail the changes made -->
- check whether the first genesis account exists (has balance). only try to create the genesis accounts when it's missing
- simplify mesh initialization
- remove one extra SetApplied call in mesh.go

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->
unit test, systest, manual testing with node+devnet

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
