### PR TITLE
[Merged by Bors] - fix bug in GetAllPending query

### DIFF
--- a/sql/transactions/transactions.go
+++ b/sql/transactions/transactions.go
@@ -392,7 +392,7 @@ func GetByAddress(db sql.Executor, from, to types.LayerID, address types.Address
 // GetAllPending get all transactions that are not yet applied.
 func GetAllPending(db sql.Executor) ([]*types.MeshTransaction, error) {
 	return queryPending(db, `
-		select tx, header, layer, block, principal, timestamp, id from transactions
+		select tx, header, layer, block, timestamp, id from transactions
 		where applied = ?1 order by timestamp asc`,
 		func(stmt *sql.Statement) {
 			stmt.BindInt64(1, statePending)

--- a/sql/transactions/transactions_test.go
+++ b/sql/transactions/transactions_test.go
@@ -587,13 +587,18 @@ func TestGetAllPending(t *testing.T) {
 	got, err := GetAllPending(db)
 	require.NoError(t, err)
 	require.Len(t, got, numTXs*numAccts-totalApplied)
+	inB := 0
+	inM := 0
 	for _, mtx := range got {
 		if _, ok := inBlock[mtx.ID]; ok {
 			require.Equal(t, types.BLOCK, mtx.State)
+			inB++
 		} else if _, ok = inMempool[mtx.ID]; ok {
 			require.Equal(t, types.MEMPOOL, mtx.State)
+			inM++
 		}
 	}
+	require.Equal(t, len(got), inB+inM)
 }
 
 func TestGetAcctPendingFromNonce(t *testing.T) {


### PR DESCRIPTION
## Motivation
transaction.ID was not parsed correctly as its taking data from the wrong column.

## Changes
<!-- Please describe in detail the changes made -->
- add test that failed the original code
- remove princial from the query string and test passed

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->
unittest, systest

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
