### PR TITLE
[Merged by Bors] - block construction: allow optimistic filtering at threshold

### DIFF
--- a/txs/txs_builder.go
+++ b/txs/txs_builder.go
@@ -85,9 +85,13 @@ func extractProposalMetadata(
 	return &proposalMetadata{lid: lid, size: len(proposals), mtxs: mtxs, meshHashes: meshHashes}, nil
 }
 
-func getMajorityState(meshHashes map[string]*meshState, numProposals, threshold int) *meshState {
+func getMajorityState(logger log.Log, meshHashes map[string]*meshState, numProposals, threshold int) *meshState {
 	for _, ms := range meshHashes {
-		if ms.count*100 > numProposals*threshold {
+		logger.With().Debug("mesh hash", ms.hash,
+			log.Int("count", ms.count),
+			log.Int("threshold", threshold),
+			log.Int("num_proposals", numProposals))
+		if ms.count*100 >= numProposals*threshold {
 			return ms
 		}
 	}
@@ -108,7 +112,7 @@ func checkStateConsensus(
 		return nil, err
 	}
 
-	ms := getMajorityState(md.meshHashes, md.size, cfg.OptFilterThreshold)
+	ms := getMajorityState(logger, md.meshHashes, md.size, cfg.OptFilterThreshold)
 	if ms == nil {
 		logger.With().Warning("no consensus on mesh hash. NOT doing optimistic filtering", lid)
 		return md, nil

--- a/txs/txs_builder_test.go
+++ b/txs/txs_builder_test.go
@@ -178,3 +178,81 @@ func TestGetBlockTXs_NoOptimisticFiltering(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, got)
 }
+
+func Test_checkStateConsensus(t *testing.T) {
+	cfg := CSConfig{OptFilterThreshold: 100}
+	lid := types.NewLayerID(11)
+	meshHash := types.RandomHash()
+	numProps := 10
+	props := make([]*types.Proposal, 0, numProps)
+	for i := 0; i < 10; i++ {
+		p := &types.Proposal{
+			InnerProposal: types.InnerProposal{
+				MeshHash: meshHash,
+			},
+		}
+		props = append(props, p)
+	}
+	md, err := checkStateConsensus(logtest.New(t), cfg, lid, props, meshHash, nil)
+	require.NoError(t, err)
+	require.Equal(t, proposalMetadata{
+		lid:  lid,
+		size: numProps,
+		meshHashes: map[string]*meshState{
+			meshHash.ShortString(): {hash: meshHash, count: numProps},
+		},
+		mtxs:      []*types.MeshTransaction{},
+		optFilter: true,
+	}, *md)
+}
+
+func Test_checkStateConsensus_ownMeshDiffer(t *testing.T) {
+	cfg := CSConfig{OptFilterThreshold: 100}
+	lid := types.NewLayerID(11)
+	meshHash := types.RandomHash()
+	numProps := 10
+	props := make([]*types.Proposal, 0, numProps)
+	for i := 0; i < 10; i++ {
+		p := &types.Proposal{
+			InnerProposal: types.InnerProposal{
+				MeshHash: meshHash,
+			},
+		}
+		props = append(props, p)
+	}
+	_, err := checkStateConsensus(logtest.New(t), cfg, lid, props, types.RandomHash(), nil)
+	require.ErrorIs(t, err, errNodeHasBadMeshHash)
+}
+
+func Test_checkStateConsensus_NoConsensus(t *testing.T) {
+	cfg := CSConfig{OptFilterThreshold: 100}
+	lid := types.NewLayerID(11)
+	meshHash0 := types.RandomHash()
+	meshHash1 := types.RandomHash()
+	numProps := 10
+	props := make([]*types.Proposal, 0, numProps)
+	for i := 0; i < 10; i++ {
+		h := meshHash0
+		if i%2 == 0 {
+			h = meshHash1
+		}
+		p := &types.Proposal{
+			InnerProposal: types.InnerProposal{
+				MeshHash: h,
+			},
+		}
+		props = append(props, p)
+	}
+	md, err := checkStateConsensus(logtest.New(t), cfg, lid, props, meshHash1, nil)
+	require.NoError(t, err)
+	require.Equal(t, proposalMetadata{
+		lid:  lid,
+		size: numProps,
+		meshHashes: map[string]*meshState{
+			meshHash0.ShortString(): {hash: meshHash0, count: numProps / 2},
+			meshHash1.ShortString(): {hash: meshHash1, count: numProps / 2},
+		},
+		mtxs:      []*types.MeshTransaction{},
+		optFilter: false,
+	}, *md)
+}


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
a quick bug fix without filing an issue.

when perfect consensus is reached (100%), it should enable optimistic filtering with threshold at 100%.

## Changes
<!-- Please describe in detail the changes made -->
change the criteria from `count < threshold` to `count <= threshold`

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->
unit test / systests

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
