### PR TITLE
[Merged by Bors] - syncer/fetcher: fix flaky tests

### DIFF
--- a/syncer/syncer_test.go
+++ b/syncer/syncer_test.go
@@ -161,31 +161,31 @@ func TestSynchronize_OnlyOneSynchronize(t *testing.T) {
 	gLayer := types.GetEffectiveGenesis()
 
 	ch := make(chan fetch.LayerPromiseResult)
+	started := make(chan struct{}, 1)
 	for lid := gLayer.Add(1); lid.Before(current); lid = lid.Add(1) {
-		ts.mLyrFetcher.EXPECT().PollLayerContent(gomock.Any(), lid).Return(ch)
+		if lid == gLayer.Add(1) {
+			ts.mLyrFetcher.EXPECT().PollLayerContent(gomock.Any(), lid).DoAndReturn(
+				func(context.Context, types.LayerID) chan fetch.LayerPromiseResult {
+					close(started)
+					return ch
+				},
+			)
+		} else {
+			ts.mLyrFetcher.EXPECT().PollLayerContent(gomock.Any(), lid).Return(ch)
+		}
 	}
 	var wg sync.WaitGroup
-	wg.Add(2)
-	first, second := true, true
-	started := make(chan struct{}, 2)
+	wg.Add(1)
 	go func() {
-		started <- struct{}{}
-		first = ts.syncer.synchronize(context.TODO())
+		require.True(t, ts.syncer.synchronize(context.TODO()))
 		wg.Done()
 	}()
 	<-started
-	go func() {
-		started <- struct{}{}
-		second = ts.syncer.synchronize(context.TODO())
-		wg.Done()
-	}()
-	<-started
+	require.False(t, ts.syncer.synchronize(context.TODO()))
 	// allow synchronize to finish
 	close(ch)
 	wg.Wait()
 
-	// one of the synchronize calls should fail
-	require.False(t, first && second)
 	require.Equal(t, uint64(1), ts.syncer.run)
 	ts.syncer.Close()
 }


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
flaky TestSynchronize_OnlyOneSynchronize:
see https://github.com/spacemeshos/go-spacemesh/runs/7260295921?check_suite_focus=true

flaky TestFetch_GetLayerData/some_peers_errors
see https://github.com/spacemeshos/go-spacemesh/runs/7260893762?check_suite_focus=true

## Changes
<!-- Please describe in detail the changes made -->
ran with 
`go clean -testcache && go test -v ./syncer/ -run TestSynchronize_OnlyOneSynchronize -count 2000` 
(-count 1000 cannot reproduce reliably)
and
`go test -v ./fetch/ -run TestFetch_GetLayerData/some_peers_errors -count 1000`


## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->
unit test

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
