### PR TITLE
[Merged by Bors] - systest: parametrize storage

### DIFF
--- a/systest/Makefile
+++ b/systest/Makefile
@@ -10,6 +10,7 @@ clusters ?= 1
 size ?= 10
 level ?= debug
 bootstrap ?= 5m
+storage ?= standard=1Gi
 node_selector ?=
 namespace ?=
 label ?=
@@ -30,7 +31,7 @@ run:
 	--restart=Never \
 	--labels="testid=$(test_id)" \
     --image-pull-policy=IfNotPresent -- \
-    tests -test.v -test.timeout=0 -test.run=$(test_name) -namespace=$(namespace) -clusters=$(clusters) -size=$(size) -image=$(smesher_image) -level=$(level) -node-selector=$(node_selector) -bootstrap=$(bootstrap) -keep=$(keep) -testid=$(test_id) -labels=$(label)
+    tests -test.v -test.timeout=0 -test.run=$(test_name) -namespace=$(namespace) -clusters=$(clusters) -storage=$(storage) -size=$(size) -image=$(smesher_image) -level=$(level) -node-selector=$(node_selector) -bootstrap=$(bootstrap) -keep=$(keep) -testid=$(test_id) -labels=$(label)
 	-@kubectl wait --timeout=5s --for=condition=ready pod/$(test_pod_name)
 	@kubectl logs $(test_pod_name) -f
 

--- a/systest/README.md
+++ b/systest/README.md
@@ -191,3 +191,19 @@ It launches a test that will execute subtests to create transactions, add nodes,
 export namespace=qqq
 make run test_name=TestScheduleBasic size=10 bootstrap=1m keep=true
 ```
+
+### Storage for longevity tests
+
+See available storage classes using:
+
+```bash
+kubectl get sc
+```
+
+For longevity tests standard storage class is not sufficiently fast, and has low amount of allocated resources (iops and throughput). Allocated resource also depend on the disk size.
+
+On gke for the network with a moderate load `premium-rwo` storage class with 10Gi disk size can be used. It will provision ssd disks.
+
+```bash
+export storage=premium-rwo=10Gi
+```

--- a/systest/cluster/nodes.go
+++ b/systest/cluster/nodes.go
@@ -275,9 +275,9 @@ func deployNode(ctx *testcontext.Context, name string, applabels map[string]stri
 				corev1.PersistentVolumeClaim(persistentVolumeName, ctx.Namespace).
 					WithSpec(corev1.PersistentVolumeClaimSpec().
 						WithAccessModes(v1.ReadWriteOnce).
-						WithStorageClassName("standard").
+						WithStorageClassName(ctx.Storage.Class).
 						WithResources(corev1.ResourceRequirements().
-							WithRequests(v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Gi")}))),
+							WithRequests(v1.ResourceList{v1.ResourceStorage: resource.MustParse(ctx.Storage.Size)}))),
 			).
 			WithSelector(metav1.LabelSelector().WithMatchLabels(labels)).
 			WithTemplate(corev1.PodTemplateSpec().

--- a/systest/testcontext/context.go
+++ b/systest/testcontext/context.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
+	"strings"
 	"sync"
 	"syscall"
 	"testing"
@@ -40,6 +41,7 @@ var (
 	testTimeout  = flag.Duration("test-timeout", 60*time.Minute, "timeout for a single test")
 	keep         = flag.Bool("keep", false, "if true cluster will not be removed after test is finished")
 	clusters     = flag.Int("clusters", 1, "controls how many clusters are deployed on k8s")
+	storage      = flag.String("storage", "standard=1Gi", "<class>=<size> for the storage")
 	nodeSelector = stringToString{}
 	labels       = stringSet{}
 	tokens       chan struct{}
@@ -78,8 +80,12 @@ type Context struct {
 	Namespace         string
 	Image             string
 	PoetImage         string
-	NodeSelector      map[string]string
-	Log               *zap.SugaredLogger
+	Storage           struct {
+		Size  string
+		Class string
+	}
+	NodeSelector map[string]string
+	Log          *zap.SugaredLogger
 }
 
 func cleanup(tb testing.TB, f func()) {
@@ -112,6 +118,14 @@ func deployNamespace(ctx *Context) error {
 		return fmt.Errorf("create namespace %s: %w", ctx.Namespace, err)
 	}
 	return nil
+}
+
+func getStorage() (string, string, error) {
+	parts := strings.Split(*storage, "=")
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("malformed storage %s. see default value for example", *storage)
+	}
+	return parts[0], parts[1], nil
 }
 
 func updateContext(ctx *Context) error {
@@ -182,6 +196,8 @@ func New(t *testing.T, opts ...Opt) *Context {
 	initTokens.Do(func() {
 		tokens = make(chan struct{}, *clusters)
 	})
+	class, size, err := getStorage()
+	require.NoError(t, err)
 
 	c := newCfg()
 	for _, opt := range opts {
@@ -228,6 +244,8 @@ func New(t *testing.T, opts ...Opt) *Context {
 		NodeSelector:      nodeSelector,
 		Log:               zaptest.NewLogger(t, zaptest.Level(logLevel)).Sugar(),
 	}
+	cctx.Storage.Class = class
+	cctx.Storage.Size = size
 	err = updateContext(cctx)
 	require.NoError(t, err)
 	if !cctx.Keep {


### PR DESCRIPTION
closes: https://github.com/spacemeshos/go-spacemesh/issues/3330

parametrize storage so that network can be used with a higher load
