### PR TITLE
[Merged by Bors] - p2p gossipsub: turn on peer scoring

### DIFF
--- a/activation/activation.go
+++ b/activation/activation.go
@@ -31,9 +31,6 @@ var (
 	ErrPoetServiceUnstable = errors.New("builder: poet service is unstable")
 )
 
-// AtxProtocol is the protocol id for broadcasting atxs over gossip.
-const AtxProtocol = "AtxGossip/1"
-
 const defaultPoetRetryInterval = 5 * time.Second
 
 type poetNumberOfTickProvider struct{}
@@ -597,7 +594,7 @@ func (b *Builder) signAndBroadcast(ctx context.Context, atx *types.ActivationTx)
 	if err != nil {
 		return 0, fmt.Errorf("failed to serialize ATX: %v", err)
 	}
-	if err := b.publisher.Publish(ctx, AtxProtocol, buf); err != nil {
+	if err := b.publisher.Publish(ctx, pubsub.AtxProtocol, buf); err != nil {
 		return 0, fmt.Errorf("failed to broadcast ATX: %v", err)
 	}
 	return len(buf), nil

--- a/activation/poetlistener.go
+++ b/activation/poetlistener.go
@@ -11,9 +11,6 @@ import (
 	"github.com/spacemeshos/go-spacemesh/sql"
 )
 
-// PoetProofProtocol is the name of the PoetProof gossip protocol.
-const PoetProofProtocol = "PoetProof/1"
-
 // PoetListener handles PoET gossip messages.
 type PoetListener struct {
 	log    log.Log
@@ -25,7 +22,7 @@ func (l *PoetListener) HandlePoetProofMessage(ctx context.Context, _ p2p.Peer, m
 	var proofMessage types.PoetProofMessage
 	if err := types.BytesToInterface(msg, &proofMessage); err != nil {
 		l.log.WithContext(ctx).With().Error("failed to unmarshal poet membership proof", log.Err(err))
-		return pubsub.ValidationIgnore
+		return pubsub.ValidationReject
 	}
 
 	ref, err := proofMessage.Ref()

--- a/api/grpcserver/gateway_service.go
+++ b/api/grpcserver/gateway_service.go
@@ -9,9 +9,9 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/spacemeshos/go-spacemesh/activation"
 	"github.com/spacemeshos/go-spacemesh/api"
 	"github.com/spacemeshos/go-spacemesh/log"
+	"github.com/spacemeshos/go-spacemesh/p2p/pubsub"
 )
 
 // GatewayService exposes transaction data, and a submit tx endpoint.
@@ -40,7 +40,7 @@ func (s GatewayService) BroadcastPoet(ctx context.Context, in *pb.BroadcastPoetR
 	}
 
 	// Note that we broadcast a poet message regardless of whether or not we are currently in sync
-	if err := s.publisher.Publish(ctx, activation.PoetProofProtocol, in.Data); err != nil {
+	if err := s.publisher.Publish(ctx, pubsub.PoetProofProtocol, in.Data); err != nil {
 		log.Error("failed to broadcast poet message: %s", err)
 		return nil, status.Errorf(codes.Internal, "failed to broadcast message")
 	}

--- a/api/grpcserver/transaction_service.go
+++ b/api/grpcserver/transaction_service.go
@@ -18,9 +18,9 @@ import (
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/events"
 	"github.com/spacemeshos/go-spacemesh/log"
+	"github.com/spacemeshos/go-spacemesh/p2p/pubsub"
 	"github.com/spacemeshos/go-spacemesh/sql"
 	"github.com/spacemeshos/go-spacemesh/sql/transactions"
-	"github.com/spacemeshos/go-spacemesh/txs"
 )
 
 // TransactionService exposes transaction data, and a submit tx endpoint.
@@ -67,7 +67,7 @@ func (s TransactionService) SubmitTransaction(ctx context.Context, in *pb.Submit
 			"Cannot submit transaction, node is not in sync yet, try again later")
 	}
 
-	if err := s.publisher.Publish(ctx, txs.IncomingTxProtocol, in.Transaction); err != nil {
+	if err := s.publisher.Publish(ctx, pubsub.TxProtocol, in.Transaction); err != nil {
 		log.Error("error broadcasting incoming tx: %v", err)
 		return nil, status.Error(codes.Internal, "Failed to publish transaction")
 	}

--- a/beacon/beacon.go
+++ b/beacon/beacon.go
@@ -655,7 +655,7 @@ func (pd *ProtocolDriver) sendProposal(ctx context.Context, epoch types.EpochID)
 		VRFSignature: proposedSignature,
 	}
 
-	pd.sendToGossip(ctx, ProposalProtocol, m)
+	pd.sendToGossip(ctx, pubsub.BeaconProposalProtocol, m)
 	logger.With().Info("beacon proposal sent", log.String("message", m.String()))
 }
 
@@ -798,7 +798,7 @@ func (pd *ProtocolDriver) sendFirstRoundVote(ctx context.Context, epoch types.Ep
 		types.FirstRound,
 		log.String("message", m.String()))
 
-	pd.sendToGossip(ctx, FirstVotesProtocol, m)
+	pd.sendToGossip(ctx, pubsub.BeaconFirstVotesProtocol, m)
 	return nil
 }
 
@@ -836,7 +836,7 @@ func (pd *ProtocolDriver) sendFollowingVote(ctx context.Context, epoch types.Epo
 		round,
 		log.String("message", m.String()))
 
-	pd.sendToGossip(ctx, FollowingVotesProtocol, m)
+	pd.sendToGossip(ctx, pubsub.BeaconFollowingVotesProtocol, m)
 	return nil
 }
 

--- a/beacon/handlers.go
+++ b/beacon/handlers.go
@@ -19,15 +19,6 @@ import (
 type category uint8
 
 const (
-	// ProposalProtocol is the protocol for sending proposal messages through Gossip.
-	ProposalProtocol = "BeaconProposal/1"
-
-	// FirstVotesProtocol is the protocol for sending first vote messages through Gossip.
-	FirstVotesProtocol = "BeaconFirstVotes/1"
-
-	// FollowingVotesProtocol is the protocol for sending following vote messages through Gossip.
-	FollowingVotesProtocol = "BeaconFollowingVotes/1"
-
 	valid            category = 1
 	potentiallyValid category = 2
 	invalid          category = 3

--- a/beacon/weakcoin/weak_coin.go
+++ b/beacon/weakcoin/weak_coin.go
@@ -17,9 +17,6 @@ import (
 const (
 	// Prefix defines weak coin proposal prefix.
 	proposalPrefix = "WeakCoin"
-	// GossipProtocol is weak coin Gossip protocol name.
-	GossipProtocol = "WeakCoinGossip/1"
-
 	// equal to 2^256 / 2.
 	defaultThreshold = "0x8000000000000000000000000000000000000000000000000000000000000000"
 )
@@ -257,7 +254,7 @@ func (wc *WeakCoin) publishProposal(ctx context.Context, epoch types.EpochID, ro
 		return nil
 	}
 
-	if err := wc.publisher.Publish(ctx, GossipProtocol, msg); err != nil {
+	if err := wc.publisher.Publish(ctx, pubsub.BeaconWeakCoinProtocol, msg); err != nil {
 		return fmt.Errorf("failed to broadcast weak coin message: %w", err)
 	}
 

--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -27,7 +27,6 @@ import (
 	"github.com/spacemeshos/go-spacemesh/activation"
 	"github.com/spacemeshos/go-spacemesh/api/grpcserver"
 	"github.com/spacemeshos/go-spacemesh/beacon"
-	"github.com/spacemeshos/go-spacemesh/beacon/weakcoin"
 	"github.com/spacemeshos/go-spacemesh/blocks"
 	cmdp "github.com/spacemeshos/go-spacemesh/cmd"
 	"github.com/spacemeshos/go-spacemesh/cmd/mapstructureutil"
@@ -621,15 +620,15 @@ func (app *App) initServices(ctx context.Context,
 		return pubsub.ValidationIgnore
 	}
 
-	app.host.Register(weakcoin.GossipProtocol, pubsub.ChainGossipHandler(syncHandler, beaconProtocol.HandleWeakCoinProposal))
-	app.host.Register(beacon.ProposalProtocol,
+	app.host.Register(pubsub.BeaconWeakCoinProtocol, pubsub.ChainGossipHandler(syncHandler, beaconProtocol.HandleWeakCoinProposal))
+	app.host.Register(pubsub.ProposalProtocol,
 		pubsub.ChainGossipHandler(syncHandler, beaconProtocol.HandleProposal))
-	app.host.Register(beacon.FirstVotesProtocol,
+	app.host.Register(pubsub.BeaconFirstVotesProtocol,
 		pubsub.ChainGossipHandler(syncHandler, beaconProtocol.HandleFirstVotes))
-	app.host.Register(beacon.FollowingVotesProtocol,
+	app.host.Register(pubsub.BeaconFollowingVotesProtocol,
 		pubsub.ChainGossipHandler(syncHandler, beaconProtocol.HandleFollowingVotes))
-	app.host.Register(proposals.NewProposalProtocol, pubsub.ChainGossipHandler(syncHandler, proposalListener.HandleProposal))
-	app.host.Register(activation.AtxProtocol, pubsub.ChainGossipHandler(
+	app.host.Register(pubsub.ProposalProtocol, pubsub.ChainGossipHandler(syncHandler, proposalListener.HandleProposal))
+	app.host.Register(pubsub.AtxProtocol, pubsub.ChainGossipHandler(
 		func(_ context.Context, _ p2p.Peer, _ []byte) pubsub.ValidationResult {
 			if newSyncer.ListenToATXGossip() {
 				return pubsub.ValidationAccept
@@ -637,13 +636,13 @@ func (app *App) initServices(ctx context.Context,
 			return pubsub.ValidationIgnore
 		},
 		atxHandler.HandleGossipAtx))
-	app.host.Register(txs.IncomingTxProtocol, pubsub.ChainGossipHandler(syncHandler, txHandler.HandleGossipTransaction))
-	app.host.Register(activation.PoetProofProtocol, poetListener.HandlePoetProofMessage)
+	app.host.Register(pubsub.TxProtocol, pubsub.ChainGossipHandler(syncHandler, txHandler.HandleGossipTransaction))
+	app.host.Register(pubsub.PoetProofProtocol, poetListener.HandlePoetProofMessage)
 	hareGossipHandler := rabbit.GetHareMsgHandler()
 	if hareGossipHandler == nil {
 		app.log.Panic("hare message handler missing")
 	}
-	app.host.Register(hare.ProtoName, pubsub.ChainGossipHandler(syncHandler, hareGossipHandler))
+	app.host.Register(pubsub.HareProtocol, pubsub.ChainGossipHandler(syncHandler, hareGossipHandler))
 
 	app.proposalBuilder = proposalBuilder
 	app.proposalListener = proposalListener

--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -621,7 +621,7 @@ func (app *App) initServices(ctx context.Context,
 	}
 
 	app.host.Register(pubsub.BeaconWeakCoinProtocol, pubsub.ChainGossipHandler(syncHandler, beaconProtocol.HandleWeakCoinProposal))
-	app.host.Register(pubsub.ProposalProtocol,
+	app.host.Register(pubsub.BeaconProposalProtocol,
 		pubsub.ChainGossipHandler(syncHandler, beaconProtocol.HandleProposal))
 	app.host.Register(pubsub.BeaconFirstVotesProtocol,
 		pubsub.ChainGossipHandler(syncHandler, beaconProtocol.HandleFirstVotes))

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/ipfs/go-log/v2 v2.5.1
 	github.com/libp2p/go-eventbus v0.2.1
 	github.com/libp2p/go-libp2p v0.20.3
-	github.com/libp2p/go-libp2p-connmgr v0.2.4
 	github.com/libp2p/go-libp2p-core v0.16.1
 	github.com/libp2p/go-libp2p-netutil v0.1.0
 	github.com/libp2p/go-libp2p-peerstore v0.6.0

--- a/hare/algorithm.go
+++ b/hare/algorithm.go
@@ -23,8 +23,8 @@ import (
 const (
 	// RoundsPerIteration is the number of rounds per iteration in the hare protocol.
 	RoundsPerIteration = 4
-	// ProtoName is the protocol indicator for hare gossip messages.
-	ProtoName = "HARE_PROTOCOL/1"
+	// HareProtocol is the protocol indicator for hare gossip messages.
+
 )
 
 type role byte
@@ -496,7 +496,7 @@ func (proc *consensusProcess) sendMessage(ctx context.Context, msg *Msg) bool {
 	)
 	logger := proc.WithContext(ctx)
 
-	if err := proc.publisher.Publish(ctx, ProtoName, msg.Bytes()); err != nil {
+	if err := proc.publisher.Publish(ctx, pubsub.HareProtocol, msg.Bytes()); err != nil {
 		logger.With().Error("could not broadcast round message", log.Err(err))
 		return false
 	}

--- a/hare/algorithm.go
+++ b/hare/algorithm.go
@@ -23,8 +23,6 @@ import (
 const (
 	// RoundsPerIteration is the number of rounds per iteration in the hare protocol.
 	RoundsPerIteration = 4
-	// HareProtocol is the protocol indicator for hare gossip messages.
-
 )
 
 type role byte

--- a/hare/broker.go
+++ b/hare/broker.go
@@ -223,7 +223,7 @@ func (b *Broker) eventLoop(ctx context.Context) {
 			// create an inner context object to handle this message
 			messageCtx := msg.Ctx
 
-			h := types.CalcMessageHash12(msg.Data, ProtoName)
+			h := types.CalcMessageHash12(msg.Data, pubsub.HareProtocol)
 			msgLogger := logger.WithContext(messageCtx).WithFields(h)
 			hareMsg, err := MessageFromBuffer(msg.Data)
 			if err != nil {

--- a/hare/consensus_test.go
+++ b/hare/consensus_test.go
@@ -153,7 +153,7 @@ func createConsensusProcess(tb testing.TB, isHonest bool, cfg config.Config, ora
 	broker.mockSyncS.EXPECT().IsSynced(gomock.Any()).Return(true).AnyTimes()
 	broker.mockStateQ.EXPECT().IsIdentityActiveOnConsensusView(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).AnyTimes()
 	broker.Start(context.TODO())
-	network.Register(ProtoName, broker.HandleMessage)
+	network.Register(pubsub.HareProtocol, broker.HandleMessage)
 	output := make(chan TerminationOutput, 1)
 	signing := signing2.NewEdSigner()
 	nid := types.BytesToNodeID(signing.PublicKey().Bytes())

--- a/hare/flows_test.go
+++ b/hare/flows_test.go
@@ -201,7 +201,7 @@ func createTestHare(t testing.TB, db *sql.Database, tcfg config.Config, clock *m
 
 	hare := New(db, tcfg, pid, p2p, ed, nodeID, mockBlockGen, mockSyncS, mockMeshDB, mockBeacons, mockFetcher, mockRoracle, patrol, 10,
 		mockStateQ, clock, logtest.New(t).WithName(name+"_"+ed.PublicKey().ShortString()))
-	p2p.Register(ProtoName, hare.GetHareMsgHandler())
+	p2p.Register(pubsub.HareProtocol, hare.GetHareMsgHandler())
 
 	return &hareWithMocks{
 		Hare:         hare,
@@ -453,7 +453,7 @@ func Test_multipleCPs(t *testing.T) {
 	require.NoError(t, mesh.ConnectAllButSelf())
 	require.Eventually(t, func() bool {
 		for _, ps := range pubsubs {
-			if len(ps.ProtocolPeers(ProtoName)) != len(mesh.Hosts())-1 {
+			if len(ps.ProtocolPeers(pubsub.HareProtocol)) != len(mesh.Hosts())-1 {
 				return false
 			}
 		}
@@ -541,7 +541,7 @@ func Test_multipleCPsAndIterations(t *testing.T) {
 	require.NoError(t, mesh.ConnectAllButSelf())
 	require.Eventually(t, func() bool {
 		for _, ps := range pubsubs {
-			if len(ps.ProtocolPeers(ProtoName)) != len(mesh.Hosts())-1 {
+			if len(ps.ProtocolPeers(pubsub.HareProtocol)) != len(mesh.Hosts())-1 {
 				return false
 			}
 		}

--- a/hare/hare.go
+++ b/hare/hare.go
@@ -483,12 +483,12 @@ func (h *Hare) tickLoop(ctx context.Context) {
 
 // Start starts listening for layers and outputs.
 func (h *Hare) Start(ctx context.Context) error {
-	h.WithContext(ctx).With().Info("starting protocol", log.String("protocol", ProtoName))
+	h.WithContext(ctx).With().Info("starting protocol", log.String("protocol", pubsub.HareProtocol))
 
 	// Create separate contexts for each subprocess. This allows us to better track the flow of messages.
-	ctxBroker := log.WithNewSessionID(ctx, log.String("protocol", ProtoName+"_broker"))
-	ctxTickLoop := log.WithNewSessionID(ctx, log.String("protocol", ProtoName+"_tickloop"))
-	ctxOutputLoop := log.WithNewSessionID(ctx, log.String("protocol", ProtoName+"_outputloop"))
+	ctxBroker := log.WithNewSessionID(ctx, log.String("protocol", pubsub.HareProtocol+"_broker"))
+	ctxTickLoop := log.WithNewSessionID(ctx, log.String("protocol", pubsub.HareProtocol+"_tickloop"))
+	ctxOutputLoop := log.WithNewSessionID(ctx, log.String("protocol", pubsub.HareProtocol+"_outputloop"))
 
 	if err := h.broker.Start(ctxBroker); err != nil {
 		return fmt.Errorf("start broker: %w", err)

--- a/miner/proposal_builder.go
+++ b/miner/proposal_builder.go
@@ -17,7 +17,6 @@ import (
 	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/miner/metrics"
 	"github.com/spacemeshos/go-spacemesh/p2p/pubsub"
-	"github.com/spacemeshos/go-spacemesh/proposals"
 	"github.com/spacemeshos/go-spacemesh/signing"
 	"github.com/spacemeshos/go-spacemesh/sql"
 	"github.com/spacemeshos/go-spacemesh/sql/ballots"
@@ -319,7 +318,7 @@ func (pb *ProposalBuilder) handleLayer(ctx context.Context, layerID types.LayerI
 		if err != nil {
 			logger.With().Panic("failed to serialize proposal", log.Err(err))
 		}
-		if err = pb.publisher.Publish(newCtx, proposals.NewProposalProtocol, data); err != nil {
+		if err = pb.publisher.Publish(newCtx, pubsub.ProposalProtocol, data); err != nil {
 			logger.WithContext(newCtx).With().Error("failed to send proposal", log.Err(err))
 		}
 		events.ReportProposal(events.ProposalCreated, p)

--- a/p2p/host.go
+++ b/p2p/host.go
@@ -7,10 +7,10 @@ import (
 
 	lp2plog "github.com/ipfs/go-log/v2"
 	"github.com/libp2p/go-libp2p"
-	connmgr "github.com/libp2p/go-libp2p-connmgr"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-peerstore/pstoremem"
 	"github.com/libp2p/go-libp2p/p2p/muxer/yamux"
+	"github.com/libp2p/go-libp2p/p2p/net/connmgr"
 	"github.com/libp2p/go-libp2p/p2p/security/noise"
 	"github.com/libp2p/go-libp2p/p2p/transport/tcp"
 
@@ -73,7 +73,10 @@ func New(_ context.Context, logger log.Log, cfg Config, opts ...Opt) (*Host, err
 	lp2plog.SetPrimaryCore(logger.Core())
 	lp2plog.SetAllLoggers(lp2plog.LogLevel(cfg.LogLevel))
 
-	cm := connmgr.NewConnManager(cfg.LowPeers, cfg.HighPeers, cfg.GracePeersShutdown)
+	cm, err := connmgr.NewConnManager(cfg.LowPeers, cfg.HighPeers, connmgr.WithGracePeriod(cfg.GracePeersShutdown))
+	if err != nil {
+		return nil, fmt.Errorf("p2p create conn mgr: %w", err)
+	}
 	// TODO(dshulyak) remove this part
 	for _, p := range cfg.Bootnodes {
 		addr, err := peer.AddrInfoFromString(p)

--- a/p2p/peerexchange/bookchecker_test.go
+++ b/p2p/peerexchange/bookchecker_test.go
@@ -11,10 +11,10 @@ import (
 	"time"
 
 	"github.com/libp2p/go-libp2p"
-	connmgr "github.com/libp2p/go-libp2p-connmgr"
 	"github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/libp2p/go-libp2p/p2p/net/connmgr"
 	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
 	ma "github.com/multiformats/go-multiaddr"
 	"github.com/pkg/errors"
@@ -213,7 +213,8 @@ func TestHost_ReceiveAddressesOnCheck(t *testing.T) {
 func setupOverNodes(t *testing.T, nodesCount int) ([]host.Host, []*Discovery) {
 	hosts := make([]host.Host, 0, nodesCount)
 	for i := 0; i < nodesCount; i++ {
-		cm := connmgr.NewConnManager(40, 100, 30*time.Second)
+		cm, err := connmgr.NewConnManager(40, 100, connmgr.WithGracePeriod(30*time.Second))
+		require.NoError(t, err)
 		h, err := libp2p.New(libp2p.ConnectionManager(cm))
 		require.NoError(t, err)
 		t.Cleanup(func() {

--- a/p2p/peerexchange/bookchecker_test.go
+++ b/p2p/peerexchange/bookchecker_test.go
@@ -88,7 +88,7 @@ func TestDiscovery_GetRandomPeers(t *testing.T) {
 		require.Equal(t, 0, len(d.GetRandomPeers(10)), "should return zero peers")
 	})
 
-	best, err := BestHostAddress(d.host)
+	best, err := bestHostAddress(d.host)
 	require.NoError(t, err)
 	// populate address book with some addresses.
 	d.book.AddAddress(bootNodeAddress, best)
@@ -191,7 +191,7 @@ func TestHost_ReceiveAddressesOnCheck(t *testing.T) {
 		ids = append(ids, tmpAddr.ID)
 	}
 
-	best, err := BestHostAddress(nodeA.host)
+	best, err := bestHostAddress(nodeA.host)
 	require.NoError(t, err)
 	nodeA.book.AddAddresses(addrs, best)
 
@@ -247,7 +247,7 @@ func setup(t *testing.T, hosts []host.Host) []*Discovery {
 			CheckPeersNumber:     10,
 		}
 
-		best, err := BestHostAddress(h)
+		best, err := bestHostAddress(h)
 		require.NoError(t, err)
 		if bootnode == nil {
 			bootnode = best

--- a/p2p/peerexchange/bookchecker_test.go
+++ b/p2p/peerexchange/bookchecker_test.go
@@ -255,8 +255,9 @@ func setup(t *testing.T, hosts []host.Host) []*Discovery {
 			cfg.Bootnodes = append(cfg.Bootnodes, bootnode.RawAddr)
 		}
 
-		instance, err := New(logger, h, cfg)
+		instance, isBoot, err := New(logger, h, cfg)
 		require.NoError(t, err)
+		require.False(t, isBoot)
 		t.Cleanup(instance.Stop)
 		instances = append(instances, instance)
 	}

--- a/p2p/peerexchange/bookchecker_test.go
+++ b/p2p/peerexchange/bookchecker_test.go
@@ -88,7 +88,7 @@ func TestDiscovery_GetRandomPeers(t *testing.T) {
 		require.Equal(t, 0, len(d.GetRandomPeers(10)), "should return zero peers")
 	})
 
-	best, err := bestHostAddress(d.host)
+	best, err := BestHostAddress(d.host)
 	require.NoError(t, err)
 	// populate address book with some addresses.
 	d.book.AddAddress(bootNodeAddress, best)
@@ -191,7 +191,7 @@ func TestHost_ReceiveAddressesOnCheck(t *testing.T) {
 		ids = append(ids, tmpAddr.ID)
 	}
 
-	best, err := bestHostAddress(nodeA.host)
+	best, err := BestHostAddress(nodeA.host)
 	require.NoError(t, err)
 	nodeA.book.AddAddresses(addrs, best)
 
@@ -247,7 +247,7 @@ func setup(t *testing.T, hosts []host.Host) []*Discovery {
 			CheckPeersNumber:     10,
 		}
 
-		best, err := bestHostAddress(h)
+		best, err := BestHostAddress(h)
 		require.NoError(t, err)
 		if bootnode == nil {
 			bootnode = best
@@ -255,9 +255,8 @@ func setup(t *testing.T, hosts []host.Host) []*Discovery {
 			cfg.Bootnodes = append(cfg.Bootnodes, bootnode.RawAddr)
 		}
 
-		instance, isBoot, err := New(logger, h, cfg)
+		instance, err := New(logger, h, cfg)
 		require.NoError(t, err)
-		require.False(t, isBoot)
 		t.Cleanup(instance.Stop)
 		instances = append(instances, instance)
 	}

--- a/p2p/peerexchange/discovery.go
+++ b/p2p/peerexchange/discovery.go
@@ -74,7 +74,7 @@ func New(logger log.Log, h host.Host, config Config) (*Discovery, error) {
 		}
 		bootnodes = append(bootnodes, info)
 	}
-	best, err := BestHostAddress(h)
+	best, err := bestHostAddress(h)
 	if err != nil {
 		return nil, err
 	}
@@ -125,8 +125,8 @@ func (d *Discovery) ExternalPort() uint16 {
 
 var errNotFound = errors.New("not found")
 
-// BestHostAddress returns routable address if exists, otherwise it returns first available address.
-func BestHostAddress(h host.Host) (*addressbook.AddrInfo, error) {
+// bestHostAddress returns routable address if exists, otherwise it returns first available address.
+func bestHostAddress(h host.Host) (*addressbook.AddrInfo, error) {
 	best, err := bestNetAddress(h)
 	if err == nil {
 		ip, err := manet.ToIP(best)

--- a/p2p/peerexchange/discovery_test.go
+++ b/p2p/peerexchange/discovery_test.go
@@ -33,18 +33,15 @@ func TestDiscovery_CrawlMesh(t *testing.T) {
 	for _, h := range mesh.Hosts() {
 		logger := logtest.New(t).Named(h.ID().Pretty())
 		cfg := Config{}
-		isBootnode := false
 
-		best, err := bestHostAddress(h)
+		best, err := BestHostAddress(h)
 		require.NoError(t, err)
 		if bootnode == nil {
 			bootnode = best
-			isBootnode = true
 		}
 		cfg.Bootnodes = append(cfg.Bootnodes, bootnode.RawAddr)
-		instance, isBoot, err := New(logger, h, cfg)
+		instance, err := New(logger, h, cfg)
 		require.NoError(t, err)
-		require.Equal(t, isBootnode, isBoot)
 		t.Cleanup(instance.Stop)
 		instances = append(instances, instance)
 	}
@@ -122,9 +119,8 @@ func TestDiscovery_PrefereRoutablePort(t *testing.T) {
 	addrmock.EXPECT().Addrs().DoAndReturn(func() []ma.Multiaddr {
 		return returned
 	}).AnyTimes()
-	discovery, isBoot, err := New(logtest.New(t), ph, Config{})
+	discovery, err := New(logtest.New(t), ph, Config{})
 	require.NoError(t, err)
-	require.False(t, isBoot)
 	t.Cleanup(discovery.Stop)
 
 	external := uint16(1010)

--- a/p2p/peerexchange/discovery_test.go
+++ b/p2p/peerexchange/discovery_test.go
@@ -34,7 +34,7 @@ func TestDiscovery_CrawlMesh(t *testing.T) {
 		logger := logtest.New(t).Named(h.ID().Pretty())
 		cfg := Config{}
 
-		best, err := BestHostAddress(h)
+		best, err := bestHostAddress(h)
 		require.NoError(t, err)
 		if bootnode == nil {
 			bootnode = best

--- a/p2p/peerexchange/protocol_test.go
+++ b/p2p/peerexchange/protocol_test.go
@@ -36,7 +36,7 @@ func TestDiscovery_LearnAddress(t *testing.T) {
 		require.NoError(t, err)
 		book := addressbook.NewAddrBook(addressbook.DefaultAddressBookConfigWithDataDir(""), logger)
 
-		best, err := bestHostAddress(h)
+		best, err := BestHostAddress(h)
 		require.NoError(t, err)
 		book.AddAddress(info, best)
 
@@ -51,7 +51,7 @@ func TestDiscovery_LearnAddress(t *testing.T) {
 			}
 			_, err := proto.Request(context.TODO(), proto2.h.ID())
 			require.NoError(t, err)
-			best, err := bestHostAddress(proto.h)
+			best, err := BestHostAddress(proto.h)
 			require.NoError(t, err)
 			found := proto2.book.Lookup(proto.h.ID())
 			require.Equal(t, best, found)

--- a/p2p/peerexchange/protocol_test.go
+++ b/p2p/peerexchange/protocol_test.go
@@ -36,7 +36,7 @@ func TestDiscovery_LearnAddress(t *testing.T) {
 		require.NoError(t, err)
 		book := addressbook.NewAddrBook(addressbook.DefaultAddressBookConfigWithDataDir(""), logger)
 
-		best, err := BestHostAddress(h)
+		best, err := bestHostAddress(h)
 		require.NoError(t, err)
 		book.AddAddress(info, best)
 
@@ -51,7 +51,7 @@ func TestDiscovery_LearnAddress(t *testing.T) {
 			}
 			_, err := proto.Request(context.TODO(), proto2.h.ID())
 			require.NoError(t, err)
-			best, err := BestHostAddress(proto.h)
+			best, err := bestHostAddress(proto.h)
 			require.NoError(t, err)
 			found := proto2.book.Lookup(proto.h.ID())
 			require.Equal(t, best, found)

--- a/p2p/pubsub/pubsub.go
+++ b/p2p/pubsub/pubsub.go
@@ -3,6 +3,7 @@ package pubsub
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/libp2p/go-libp2p-core/peer"
@@ -14,6 +15,28 @@ import (
 	p2pmetrics "github.com/spacemeshos/go-spacemesh/p2p/metrics"
 )
 
+func init() {
+	// configure larger overlay parameters
+	pubsub.GossipSubD = 8
+	pubsub.GossipSubDscore = 6
+	pubsub.GossipSubDout = 3
+	pubsub.GossipSubDlo = 6
+	pubsub.GossipSubDhi = 12
+	pubsub.GossipSubDlazy = 12
+	pubsub.GossipSubDirectConnectInitialDelay = 30 * time.Second
+	pubsub.GossipSubIWantFollowupTime = 5 * time.Second
+	pubsub.GossipSubHistoryLength = 10
+	pubsub.GossipSubGossipFactor = 0.1
+}
+
+const (
+	GossipScoreThreshold             = -500
+	PublishScoreThreshold            = -1000
+	GraylistScoreThreshold           = -2500
+	AcceptPXScoreThreshold           = 1000
+	OpportunisticGraftScoreThreshold = 3.5
+)
+
 // DefaultConfig for PubSub.
 func DefaultConfig() Config {
 	return Config{Flood: true}
@@ -23,24 +46,14 @@ func DefaultConfig() Config {
 type Config struct {
 	// TODO(dshulyak) change it to NoFlood
 	Flood          bool
+	IsBootnode     bool
 	MaxMessageSize int
 }
 
 // New creates PubSub instance.
 func New(ctx context.Context, logger log.Log, h host.Host, cfg Config) (*PubSub, error) {
 	// TODO(dshulyak) refactor code to accept options
-	opts := []pubsub.Option{
-		pubsub.WithFloodPublish(cfg.Flood),
-		pubsub.WithMessageIdFn(msgID),
-		pubsub.WithNoAuthor(),
-		pubsub.WithMessageSignaturePolicy(pubsub.StrictNoSign),
-		pubsub.WithPeerOutboundQueueSize(8192),
-		pubsub.WithValidateQueueSize(8192),
-		pubsub.WithRawTracer(p2pmetrics.NewGoSIPCollector()),
-	}
-	if cfg.MaxMessageSize != 0 {
-		opts = append(opts, pubsub.WithMaxMessageSize(cfg.MaxMessageSize))
-	}
+	opts := getOptions(cfg)
 	ps, err := pubsub.NewGossipSub(ctx, h, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize gossipsub instance: %w", err)
@@ -106,4 +119,70 @@ func msgID(msg *pb.Message) string {
 	}
 	hasher.Write(msg.Data)
 	return string(hasher.Sum(nil))
+}
+
+func getOptions(cfg Config) []pubsub.Option {
+	options := []pubsub.Option{
+		// Gossipsubv1.1 configuration
+		pubsub.WithFloodPublish(cfg.Flood),
+		pubsub.WithMessageIdFn(msgID),
+		pubsub.WithNoAuthor(),
+		pubsub.WithMessageSignaturePolicy(pubsub.StrictNoSign),
+		pubsub.WithPeerOutboundQueueSize(8192),
+		pubsub.WithValidateQueueSize(8192),
+		pubsub.WithRawTracer(p2pmetrics.NewGoSIPCollector()),
+		pubsub.WithPeerScore(
+			&pubsub.PeerScoreParams{
+				AppSpecificScore: func(p peer.ID) float64 {
+					// TODO: add application specific score to provide feedback to the pubsub system
+					//       based on observed behaviour
+					return 0
+				},
+				AppSpecificWeight: 1,
+
+				// TODO: consider setting IP co-location threshold before applying penalties
+
+				// P7: behavioural penalties, decay after 1hr
+				BehaviourPenaltyThreshold: 6,
+				BehaviourPenaltyWeight:    -10,
+				BehaviourPenaltyDecay:     pubsub.ScoreParameterDecay(time.Hour),
+
+				DecayInterval: pubsub.DefaultDecayInterval,
+				DecayToZero:   pubsub.DefaultDecayToZero,
+
+				// this retains non-positive scores for 6 hours
+				RetainScore: 6 * time.Hour,
+
+				// TODO: add TopicScoreParams
+			},
+			&pubsub.PeerScoreThresholds{
+				GossipThreshold:             GossipScoreThreshold,
+				PublishThreshold:            PublishScoreThreshold,
+				GraylistThreshold:           GraylistScoreThreshold,
+				AcceptPXThreshold:           AcceptPXScoreThreshold,
+				OpportunisticGraftThreshold: OpportunisticGraftScoreThreshold,
+			},
+		),
+		// TODO: add peer scoring debugging with WithPeerScoreInspect
+	}
+
+	if cfg.MaxMessageSize != 0 {
+		options = append(options, pubsub.WithMaxMessageSize(cfg.MaxMessageSize))
+	}
+
+	// enable Peer eXchange on bootstrappers
+	if cfg.IsBootnode {
+		// turn off the mesh for bootnodes -- only do gossip and PX
+		pubsub.GossipSubD = 0
+		pubsub.GossipSubDscore = 0
+		pubsub.GossipSubDlo = 0
+		pubsub.GossipSubDhi = 0
+		pubsub.GossipSubDout = 0
+		pubsub.GossipSubDlazy = 64
+		pubsub.GossipSubGossipFactor = 0.25
+		pubsub.GossipSubPruneBackoff = 5 * time.Minute
+		// turn on PX
+		options = append(options, pubsub.WithPeerExchange(true))
+	}
+	return options
 }

--- a/p2p/pubsub/pubsub.go
+++ b/p2p/pubsub/pubsub.go
@@ -17,6 +17,8 @@ import (
 
 func init() {
 	// configure larger overlay parameters
+	// these params are copied from FIL https://github.com/filecoin-project/lotus
+	// TODO: reevaluate these params for spacemesh network
 	pubsub.GossipSubD = 8
 	pubsub.GossipSubDscore = 6
 	pubsub.GossipSubDout = 3
@@ -65,9 +67,9 @@ const (
 	// BeaconProposalProtocol is the protocol id for beacon proposals.
 	BeaconProposalProtocol = "/sm/beaconpr/1"
 	// BeaconFirstVotesProtocol is the protocol id for beacon first vote.
-	BeaconFirstVotesProtocol = "/sm/beaconfv/1"
+	BeaconFirstVotesProtocol = "/sm/beaconfi/1"
 	// BeaconFollowingVotesProtocol is the protocol id for beacon following votes.
-	BeaconFollowingVotesProtocol = "/sm/beaconfv/1"
+	BeaconFollowingVotesProtocol = "/sm/beaconfo/1"
 )
 
 // DefaultConfig for PubSub.
@@ -234,9 +236,10 @@ func defaultTopicParam() *pubsub.TopicScoreParams {
 		TimeInMeshQuantum: time.Second,
 		TimeInMeshCap:     1,
 
-		// deliveries decay after 1 hour, cap at 100 blocks
+		// deliveries decay after 1 hour, cap at 1000
 		FirstMessageDeliveriesWeight: 5, // max value is 500
 		FirstMessageDeliveriesDecay:  pubsub.ScoreParameterDecay(time.Hour),
+		FirstMessageDeliveriesCap:    100,
 
 		// TODO: consider mesh delivery failure when the network grows and traffic becomes significant
 

--- a/p2p/pubsub/pubsub.go
+++ b/p2p/pubsub/pubsub.go
@@ -51,25 +51,25 @@ const (
 	OpportunisticGraftScoreThreshold = 3.5
 
 	// AtxProtocol is the protocol id for ATXs.
-	AtxProtocol = "/sm/atx/1"
+	AtxProtocol = "/sm/ax/1"
 	// PoetProofProtocol is the protocol id for PoetProof.
-	PoetProofProtocol = "/sm/poet/1"
+	PoetProofProtocol = "/sm/pt/1"
 	// ProposalProtocol is the protocol id for block proposals.
-	ProposalProtocol = "/sm/prop/1"
+	ProposalProtocol = "/sm/pp/1"
 	// TxProtocol iis the protocol id for transactions.
 	TxProtocol = "/sm/tx/1"
 
 	// HareProtocol is the protocol id for hare messages.
-	HareProtocol = "/sm/hare/1"
+	HareProtocol = "/sm/hr/1"
 
 	// BeaconWeakCoinProtocol is the protocol id for beacon weak coin.
-	BeaconWeakCoinProtocol = "/sm/beaconwk/1"
+	BeaconWeakCoinProtocol = "/sm/bw/1"
 	// BeaconProposalProtocol is the protocol id for beacon proposals.
-	BeaconProposalProtocol = "/sm/beaconpr/1"
+	BeaconProposalProtocol = "/sm/bp/1"
 	// BeaconFirstVotesProtocol is the protocol id for beacon first vote.
-	BeaconFirstVotesProtocol = "/sm/beaconfi/1"
+	BeaconFirstVotesProtocol = "/sm/bf/1"
 	// BeaconFollowingVotesProtocol is the protocol id for beacon following votes.
-	BeaconFollowingVotesProtocol = "/sm/beaconfo/1"
+	BeaconFollowingVotesProtocol = "/sm/bo/1"
 )
 
 // DefaultConfig for PubSub.

--- a/p2p/pubsub/pubsub_test.go
+++ b/p2p/pubsub/pubsub_test.go
@@ -2,7 +2,6 @@ package pubsub
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -24,7 +23,6 @@ func TestGossip(t *testing.T) {
 	count := n * n
 	received := make(chan []byte, count)
 
-	fmt.Printf("num in mesh %d\n", len(mesh.Hosts()))
 	for _, h := range mesh.Hosts() {
 		h := h
 		ps, err := New(ctx, logtest.New(t), h, Config{Flood: true, IsBootnode: true})

--- a/p2p/upgrade.go
+++ b/p2p/upgrade.go
@@ -65,16 +65,12 @@ type Host struct {
 }
 
 func isBootnode(h host.Host, bootnodes []string) (bool, error) {
-	best, err := peerexchange.BestHostAddress(h)
-	if err != nil {
-		return false, err
-	}
 	for _, raw := range bootnodes {
 		info, err := addressbook.ParseAddrInfo(raw)
 		if err != nil {
 			return false, fmt.Errorf("failed to parse bootstrap node: %w", err)
 		}
-		if best.ID == info.ID {
+		if h.ID() == info.ID {
 			return true, nil
 		}
 	}

--- a/p2p/upgrade.go
+++ b/p2p/upgrade.go
@@ -7,6 +7,7 @@ import (
 	"github.com/libp2p/go-libp2p-core/host"
 
 	"github.com/spacemeshos/go-spacemesh/log"
+	"github.com/spacemeshos/go-spacemesh/p2p/addressbook"
 	"github.com/spacemeshos/go-spacemesh/p2p/bootstrap"
 	"github.com/spacemeshos/go-spacemesh/p2p/handshake"
 	"github.com/spacemeshos/go-spacemesh/p2p/peerexchange"
@@ -63,6 +64,23 @@ type Host struct {
 	bootstrap *bootstrap.Bootstrap
 }
 
+func isBootnode(h host.Host, bootnodes []string) (bool, error) {
+	best, err := peerexchange.BestHostAddress(h)
+	if err != nil {
+		return false, err
+	}
+	for _, raw := range bootnodes {
+		info, err := addressbook.ParseAddrInfo(raw)
+		if err != nil {
+			return false, fmt.Errorf("failed to parse bootstrap node: %w", err)
+		}
+		if best.ID == info.ID {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 // Upgrade creates Host instance from host.Host.
 func Upgrade(h host.Host, opts ...Opt) (*Host, error) {
 	fh := &Host{
@@ -75,16 +93,23 @@ func Upgrade(h host.Host, opts ...Opt) (*Host, error) {
 		opt(fh)
 	}
 	cfg := fh.cfg
+	bootnode, err := isBootnode(h, cfg.Bootnodes)
+	if err != nil {
+		return nil, fmt.Errorf("check node as bootnode: %w", err)
+	}
+	if fh.PubSub, err = pubsub.New(fh.ctx, fh.logger, h, pubsub.Config{
+		Flood:          cfg.Flood,
+		IsBootnode:     bootnode,
+		MaxMessageSize: cfg.MaxMessageSize,
+	}); err != nil {
+		return nil, fmt.Errorf("failed to initialize pubsub: %w", err)
+	}
 	fh.Peers = bootstrap.StartPeers(h,
 		bootstrap.WithLog(fh.logger),
 		bootstrap.WithContext(fh.ctx),
 		bootstrap.WithNodeReporter(fh.nodeReporter),
 	)
-	var (
-		err        error
-		isBootnode bool
-	)
-	if fh.discovery, isBootnode, err = peerexchange.New(fh.logger, h, peerexchange.Config{
+	if fh.discovery, err = peerexchange.New(fh.logger, h, peerexchange.Config{
 		DataDir:              cfg.DataDir,
 		Bootnodes:            cfg.Bootnodes,
 		CheckPeersNumber:     cfg.CheckPeersNumber,
@@ -93,13 +118,6 @@ func Upgrade(h host.Host, opts ...Opt) (*Host, error) {
 		CheckPeersUsedBefore: cfg.CheckPeersUsedBefore,
 	}); err != nil {
 		return nil, fmt.Errorf("failed to initialize peerexchange discovery: %w", err)
-	}
-	if fh.PubSub, err = pubsub.New(fh.ctx, fh.logger, h, pubsub.Config{
-		Flood:          cfg.Flood,
-		IsBootnode:     isBootnode,
-		MaxMessageSize: cfg.MaxMessageSize,
-	}); err != nil {
-		return nil, fmt.Errorf("failed to initialize pubsub: %w", err)
 	}
 	if fh.bootstrap, err = bootstrap.NewBootstrap(fh.logger, bootstrap.Config{
 		TargetOutbound: cfg.TargetOutbound,

--- a/p2p/upgrade_test.go
+++ b/p2p/upgrade_test.go
@@ -6,12 +6,13 @@ import (
 	"time"
 
 	"github.com/libp2p/go-libp2p"
-	connmgr "github.com/libp2p/go-libp2p-connmgr"
+	"github.com/libp2p/go-libp2p/p2p/net/connmgr"
 	"github.com/stretchr/testify/require"
 )
 
 func TestIsBootnode(t *testing.T) {
-	cm := connmgr.NewConnManager(40, 100, 30*time.Second)
+	cm, err := connmgr.NewConnManager(40, 100, connmgr.WithGracePeriod(30*time.Second))
+	require.NoError(t, err)
 	h, err := libp2p.New(libp2p.ConnectionManager(cm))
 	require.NoError(t, err)
 	bootnodes := []string{

--- a/p2p/upgrade_test.go
+++ b/p2p/upgrade_test.go
@@ -1,0 +1,47 @@
+package p2p
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/libp2p/go-libp2p"
+	connmgr "github.com/libp2p/go-libp2p-connmgr"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsBootnode(t *testing.T) {
+	cm := connmgr.NewConnManager(40, 100, 30*time.Second)
+	h, err := libp2p.New(libp2p.ConnectionManager(cm))
+	require.NoError(t, err)
+	bootnodes := []string{
+		"/dns4/sample.spacemesh.io/tcp/5004/p2p/12D3KooWDS4mbE2Cqysjf6GBMtWnhcaoBYC6M3FNkTeZqCNFCNkf",
+		"/dns4/sample.spacemesh.io/tcp/5005/p2p/12D3KooWRN5Jv6U2CbNZRFCHbGrfQ2m8tZkN8nxpBDNPu4cHRvJw",
+		"/dns4/sample.spacemesh.io/tcp/5006/p2p/12D3KooWJEBZqrws8VSKSChtNMH4aYpiRxZ3D2mRaJWCUFPJCf3v",
+	}
+
+	tcs := []struct {
+		desc      string
+		bootnodes []string
+		isBoot    bool
+	}{
+		{
+			desc:      "bootnode",
+			bootnodes: append(bootnodes, fmt.Sprintf("/dns4/sample.spacemesh.io/tcp/5007/p2p/%s", h.ID())),
+			isBoot:    true,
+		},
+		{
+			desc:      "not_bootnode",
+			bootnodes: bootnodes,
+			isBoot:    false,
+		},
+	}
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.desc, func(t *testing.T) {
+			got, err := isBootnode(h, tc.bootnodes)
+			require.NoError(t, err)
+			require.Equal(t, tc.isBoot, got)
+		})
+	}
+}

--- a/txs/handler.go
+++ b/txs/handler.go
@@ -12,15 +12,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/sql"
 )
 
-// IncomingTxProtocol is the protocol identifier for tx received by gossip that is used by the p2p.
-const IncomingTxProtocol = "TxGossip/1"
-
-var (
-	errMalformedMsg     = errors.New("malformed tx")
-	errDuplicateTX      = errors.New("tx already exists")
-	errAddrNotExtracted = errors.New("address not extracted")
-	errAddrNotFound     = errors.New("address not found")
-)
+var errDuplicateTX = errors.New("tx already exists")
 
 // TxHandler handles the transactions received via gossip or sync.
 type TxHandler struct {


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
part of #2507
Closes #3247

## Changes
<!-- Please describe in detail the changes made -->
- turn on gossipsub peer scoring. params are copied from FIL (https://github.com/filecoin-project/lotus)
- shorten protocol names and moved them to p2p/pubsub pkg
- gossip validation return `ValidationReject` on malformed msgs for atx/poetproof/block proposals 

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->
unit test, systests
