### PR TITLE
[Merged by Bors] - conservative cache: reset an account when its txs failed in VM

### DIFF
--- a/sql/transactions/transactions.go
+++ b/sql/transactions/transactions.go
@@ -55,7 +55,9 @@ func Add(db sql.Executor, tx *types.Transaction, received time.Time) error {
 
 // AddToProposal associates a transaction with a proposal.
 func AddToProposal(db sql.Executor, tid types.TransactionID, lid types.LayerID, pid types.ProposalID) error {
-	if _, err := db.Exec(`insert into proposal_transactions (pid, tid, layer) values (?1, ?2, ?3)`,
+	if _, err := db.Exec(`
+		insert into proposal_transactions (pid, tid, layer) values (?1, ?2, ?3) 
+		on conflict(tid, pid) do nothing;`,
 		func(stmt *sql.Statement) {
 			stmt.BindBytes(1, pid.Bytes())
 			stmt.BindBytes(2, tid.Bytes())
@@ -81,7 +83,9 @@ func HasProposalTX(db sql.Executor, pid types.ProposalID, tid types.TransactionI
 
 // AddToBlock associates a transaction with a block.
 func AddToBlock(db sql.Executor, tid types.TransactionID, lid types.LayerID, bid types.BlockID) error {
-	if _, err := db.Exec(`insert into block_transactions (bid, tid, layer) values (?1, ?2, ?3)`,
+	if _, err := db.Exec(`
+		insert into block_transactions (bid, tid, layer) values (?1, ?2, ?3)
+		on conflict(tid, bid) do nothing;`,
 		func(stmt *sql.Statement) {
 			stmt.BindBytes(1, bid.Bytes())
 			stmt.BindBytes(2, tid.Bytes())

--- a/sql/transactions/transactions_test.go
+++ b/sql/transactions/transactions_test.go
@@ -169,6 +169,8 @@ func TestAddToProposal(t *testing.T) {
 	lid := types.NewLayerID(10)
 	pid := types.ProposalID{1, 1}
 	require.NoError(t, AddToProposal(db, tx.ID, lid, pid))
+	// do it again
+	require.NoError(t, AddToProposal(db, tx.ID, lid, pid))
 
 	has, err := HasProposalTX(db, pid, tx.ID)
 	require.NoError(t, err)
@@ -189,6 +191,8 @@ func TestAddToBlock(t *testing.T) {
 
 	lid := types.NewLayerID(10)
 	bid := types.BlockID{1, 1}
+	require.NoError(t, AddToBlock(db, tx.ID, lid, bid))
+	// do it again
 	require.NoError(t, AddToBlock(db, tx.ID, lid, bid))
 
 	has, err := HasBlockTX(db, bid, tx.ID)

--- a/systest/tests/steps_test.go
+++ b/systest/tests/steps_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/genvm/sdk/wallet"
+	"github.com/spacemeshos/go-spacemesh/hash"
 	"github.com/spacemeshos/go-spacemesh/systest/chaos"
 	"github.com/spacemeshos/go-spacemesh/systest/cluster"
 	"github.com/spacemeshos/go-spacemesh/systest/testcontext"
@@ -119,14 +120,17 @@ func TestStepTransactions(t *testing.T) {
 			for i := 0; i < n; i++ {
 				receiver := types.Address{}
 				rng.Read(receiver[:])
-				_, err := client.submit(tctx, wallet.Spend(
+				raw := wallet.Spend(
 					client.account.PrivateKey,
 					types.Address(receiver),
 					rng.Uint64()%amountLimit,
 					types.Nonce{Counter: nonce},
-				))
+				)
+				_, err := client.submit(tctx, raw)
 				if err != nil {
-					return err
+					return fmt.Errorf("failed to submit 0x%x from %s with nonce %d: %w",
+						hash.Sum(raw), client.account, nonce, err,
+					)
 				}
 				nonce++
 			}

--- a/txs/conservative_state.go
+++ b/txs/conservative_state.go
@@ -177,7 +177,7 @@ func (cs *ConservativeState) ApplyLayer(toApply *types.Block) ([]types.Transacti
 	logger.With().Info("applying layer to cache",
 		log.Int("num_txs_failed", len(skipped)),
 		log.Int("num_txs_final", len(rsts)))
-	if _, errs := cs.cache.ApplyLayer(cs.db, toApply.LayerIndex, toApply.ID(), rsts); len(errs) > 0 {
+	if _, errs := cs.cache.ApplyLayer(cs.db, toApply.LayerIndex, toApply.ID(), rsts, skipped); len(errs) > 0 {
 		return nil, errs[0]
 	}
 	return skipped, nil

--- a/txs/conservative_state.go
+++ b/txs/conservative_state.go
@@ -133,13 +133,15 @@ func (cs *ConservativeState) Validation(raw types.RawTx) system.ValidationReques
 // AddToCache adds the provided transaction to the conservative cache.
 func (cs *ConservativeState) AddToCache(tx *types.Transaction) error {
 	received := time.Now()
+	if err := cs.cache.Add(cs.db, tx, received, nil); err != nil {
+		return err
+	}
 	if err := transactions.Add(cs.db, tx, received); err != nil {
 		return err
 	}
 	events.ReportNewTx(types.LayerID{}, tx)
 	events.ReportAccountUpdate(tx.Principal)
-
-	return cs.cache.Add(cs.db, tx, received, nil)
+	return nil
 }
 
 // RevertState reverts the VM state and database to the given layer.

--- a/txs/conservative_state.go
+++ b/txs/conservative_state.go
@@ -215,6 +215,8 @@ func (cs *ConservativeState) getTXsToApply(logger log.Log, toApply *types.Block)
 			}
 			// restore cache consistency (e.g nonce/balance) so that gossiped
 			// transactions can be added successfully
+
+			// TODO(dshulyak) this should overwrite cache state without possibility of the validation failure
 			if err = cs.cache.Add(cs.db, &mtx.Transaction, mtx.Received, nil); err != nil {
 				return nil, err
 			}

--- a/txs/conservative_state_test.go
+++ b/txs/conservative_state_test.go
@@ -570,7 +570,7 @@ func TestApplyLayer_TXsFailedVM(t *testing.T) {
 	tcs := createConservativeState(t)
 	lid := types.NewLayerID(1)
 	ids, txs := addBatch(t, tcs, numTXs)
-	for _, tx := range txs[numFailed:] {
+	for _, tx := range txs {
 		principal := tx.Principal
 		tcs.mvm.EXPECT().GetBalance(principal).Return(defaultBalance-(tx.Spending()), nil).Times(1)
 		tcs.mvm.EXPECT().GetNonce(principal).Return(types.Nonce{Counter: nonce + 1}, nil).Times(1)

--- a/txs/handler.go
+++ b/txs/handler.go
@@ -76,6 +76,7 @@ func (th *TxHandler) handleTransaction(ctx context.Context, msg []byte) error {
 		th.logger.WithContext(ctx).With().Warning("failed to add tx to conservative cache",
 			raw.ID,
 			log.Err(err))
+		return err
 	}
 	return nil
 }

--- a/txs/handler_test.go
+++ b/txs/handler_test.go
@@ -143,7 +143,7 @@ func Test_HandleGossip(t *testing.T) {
 			desc:   "AddFailed",
 			verify: true,
 			addErr: errors.New("test"),
-			expect: pubsub.ValidationAccept,
+			expect: pubsub.ValidationIgnore,
 		},
 	} {
 		tc := tc
@@ -200,6 +200,7 @@ func Test_HandleProposal(t *testing.T) {
 			desc:   "AddFailed",
 			verify: true,
 			addErr: errors.New("test"),
+			fail:   true,
 		},
 	} {
 		tc := tc


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
Closes #3356
Closes #3357
<!-- `Closes #XXXX, closes #XXXX, ...` links mentioned issues to this PR and automatically closes them when this it's merged -->

## Changes
<!-- Please describe in detail the changes made -->
- reset cache for account when its txs failed to apply in VM
- syncer checks for both latest applied layer and processed layer
- allow duplicate calls to AddToBlock/AddToProposal as syncer can cause one goroutine to fetch a ballot (and causing blocks to be fetched) and another goroutine is fetching layer blocks directly from peers 

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->
unit tests
