### PR TITLE
[Merged by Bors] - conservative cache: allow nonce-too-big and insufficient-balance txs

### DIFF
--- a/api/grpcserver/grpcserver_test.go
+++ b/api/grpcserver/grpcserver_test.go
@@ -55,8 +55,6 @@ const (
 	labelsPerUnit    = 2048
 	bitsPerLabel     = 8
 	numUnits         = 2
-	defaultGasLimit  = 10
-	defaultFee       = 1
 	genTimeUnix      = 1000000
 	layerDurationSec = 10
 	layerAvgSize     = 10
@@ -2871,7 +2869,7 @@ func TestEventsReceived(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 	svm := vm.New(sql.InMemory(), vm.WithLogger(logtest.New(t)))
 	conState := txs.NewConservativeState(svm, sql.InMemory(), txs.WithLogger(logtest.New(t).WithName("conState")))
-	conState.AddToCache(globalTx)
+	conState.AddToCache(context.TODO(), globalTx)
 
 	weight := util.WeightFromFloat64(18.7)
 	require.NoError(t, err)

--- a/mesh/interface.go
+++ b/mesh/interface.go
@@ -9,7 +9,7 @@ import (
 //go:generate mockgen -package=mocks -destination=./mocks/mocks.go -source=./interface.go
 
 type conservativeState interface {
-	ApplyLayer(*types.Block) ([]types.TransactionID, error)
+	ApplyLayer(context.Context, *types.Block) ([]types.TransactionID, error)
 	GetStateRoot() (types.Hash32, error)
 	RevertState(types.LayerID) (types.Hash32, error)
 	LinkTXsWithProposal(types.LayerID, types.ProposalID, []types.TransactionID) error

--- a/mesh/mesh.go
+++ b/mesh/mesh.go
@@ -530,7 +530,7 @@ func (msh *Mesh) pushLayer(ctx context.Context, lid, verified types.LayerID) err
 	if err != nil {
 		return err
 	}
-	if err = msh.applyState(logger, lid, valids); err != nil {
+	if err = msh.applyState(ctx, logger, lid, valids); err != nil {
 		return err
 	}
 	msh.setLatestLayerInState(lid)
@@ -546,12 +546,12 @@ func (msh *Mesh) pushLayer(ctx context.Context, lid, verified types.LayerID) err
 // applyState applies the block to the conservative state / vm and updates mesh's internal state.
 // ideally everything happens here should be atomic.
 // see https://github.com/spacemeshos/go-spacemesh/issues/3333
-func (msh *Mesh) applyState(logger log.Log, lid types.LayerID, valids []*types.Block) error {
+func (msh *Mesh) applyState(ctx context.Context, logger log.Log, lid types.LayerID, valids []*types.Block) error {
 	applied := types.EmptyBlockID
 	block := msh.getBlockToApply(valids)
 	if block != nil {
 		applied = block.ID()
-		failedTxs, err := msh.conState.ApplyLayer(block)
+		failedTxs, err := msh.conState.ApplyLayer(ctx, block)
 		if err != nil {
 			logger.With().Error("failed to apply transactions",
 				log.Int("num_failed_txs", len(failedTxs)),

--- a/mesh/mesh_test.go
+++ b/mesh/mesh_test.go
@@ -209,7 +209,7 @@ func TestMesh_LayerHashes(t *testing.T) {
 
 		tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), i).Return(i.Sub(1)).Times(1)
 		blk := lyrBlocks[i]
-		tm.mockState.EXPECT().ApplyLayer(blk).Return(nil, nil).Times(1)
+		tm.mockState.EXPECT().ApplyLayer(context.TODO(), blk).Return(nil, nil).Times(1)
 		tm.mockState.EXPECT().GetStateRoot().Return(types.Hash32{}, nil)
 
 		h, err := layers.GetHash(tm.cdb, i)
@@ -273,7 +273,7 @@ func TestMesh_ProcessLayerPerHareOutput(t *testing.T) {
 	for i := gPlus1; !i.After(gPlus5); i = i.Add(1) {
 		toApply := layerBlocks[i]
 		tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), i).Return(i.Sub(1)).Times(1)
-		tm.mockState.EXPECT().ApplyLayer(toApply).Return(nil, nil).Times(1)
+		tm.mockState.EXPECT().ApplyLayer(context.TODO(), toApply).Return(nil, nil).Times(1)
 		tm.mockState.EXPECT().GetStateRoot().Return(types.Hash32{}, nil).Times(1)
 		require.NoError(t, tm.ProcessLayerPerHareOutput(context.TODO(), i, toApply.ID()))
 		got, err := layers.GetHareOutput(tm.cdb, i)
@@ -301,7 +301,7 @@ func TestMesh_ProcessLayerPerHareOutput_OutOfOrder(t *testing.T) {
 	// process order is  : gPlus1, gPlus3, gPlus5, gPlus2, gPlus4
 	// processed layer is: gPlus1, gPlus1, gPlus1, gPlus3, gPlus5
 	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gPlus1).Return(gLyr).Times(1)
-	tm.mockState.EXPECT().ApplyLayer(blocks1[0]).Return(nil, nil).Times(1)
+	tm.mockState.EXPECT().ApplyLayer(context.TODO(), blocks1[0]).Return(nil, nil).Times(1)
 	tm.mockState.EXPECT().GetStateRoot().Return(types.Hash32{}, nil).Times(1)
 	require.NoError(t, tm.ProcessLayerPerHareOutput(context.TODO(), gPlus1, blocks1[0].ID()))
 	got, err := layers.GetHareOutput(tm.cdb, gPlus1)
@@ -337,8 +337,8 @@ func TestMesh_ProcessLayerPerHareOutput_OutOfOrder(t *testing.T) {
 	// will try to apply state for gPlus2, gPlus3 and gPlus4
 	// since gPlus2 has been verified, we will apply the lowest order of contextually valid blocks
 	gPlus2Block := types.SortBlocks(blocks2)[0]
-	tm.mockState.EXPECT().ApplyLayer(gPlus2Block).Return(nil, nil).Times(1)
-	tm.mockState.EXPECT().ApplyLayer(blocks3[0]).Return(nil, nil).Times(1)
+	tm.mockState.EXPECT().ApplyLayer(context.TODO(), gPlus2Block).Return(nil, nil).Times(1)
+	tm.mockState.EXPECT().ApplyLayer(context.TODO(), blocks3[0]).Return(nil, nil).Times(1)
 	tm.mockState.EXPECT().GetStateRoot().Return(types.Hash32{}, nil).Times(2)
 	err = tm.ProcessLayerPerHareOutput(context.TODO(), gPlus2, blocks2[0].ID())
 	assert.ErrorIs(t, err, errMissingHareOutput)
@@ -353,8 +353,8 @@ func TestMesh_ProcessLayerPerHareOutput_OutOfOrder(t *testing.T) {
 	// will try to apply state for gPlus4 and gPlus5
 	// since gPlus4 has been verified, we will apply the lowest order of contextually valid blocks
 	gPlus4Block := types.SortBlocks(blocks4)[0]
-	tm.mockState.EXPECT().ApplyLayer(gPlus4Block).Return(nil, nil).Times(1)
-	tm.mockState.EXPECT().ApplyLayer(blocks5[0]).Return(nil, nil).Times(1)
+	tm.mockState.EXPECT().ApplyLayer(context.TODO(), gPlus4Block).Return(nil, nil).Times(1)
+	tm.mockState.EXPECT().ApplyLayer(context.TODO(), blocks5[0]).Return(nil, nil).Times(1)
 	tm.mockState.EXPECT().GetStateRoot().Return(types.Hash32{}, nil).Times(2)
 	require.NoError(t, tm.ProcessLayerPerHareOutput(context.TODO(), gPlus4, blocks4[0].ID()))
 	got, err = layers.GetHareOutput(tm.cdb, gPlus4)
@@ -371,7 +371,7 @@ func TestMesh_ProcessLayerPerHareOutput_emptyOutput(t *testing.T) {
 	gPlus1 := gLyr.Add(1)
 	blocks1 := createLayerBlocks(t, tm.Mesh, gPlus1, false)
 	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gPlus1).Return(gLyr).Times(1)
-	tm.mockState.EXPECT().ApplyLayer(blocks1[0]).Return(nil, nil).Times(1)
+	tm.mockState.EXPECT().ApplyLayer(context.TODO(), blocks1[0]).Return(nil, nil).Times(1)
 	tm.mockState.EXPECT().GetStateRoot().Return(types.Hash32{}, nil).Times(1)
 	require.NoError(t, tm.ProcessLayerPerHareOutput(context.TODO(), gPlus1, blocks1[0].ID()))
 	hareOutput, err := layers.GetHareOutput(tm.cdb, gPlus1)
@@ -421,7 +421,7 @@ func TestMesh_Revert(t *testing.T) {
 	for i := gPlus1; i.Before(gPlus4); i = i.Add(1) {
 		hareOutput := layerBlocks[i]
 		tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), i).Return(i.Sub(1)).Times(1)
-		tm.mockState.EXPECT().ApplyLayer(hareOutput).Return(nil, nil).Times(1)
+		tm.mockState.EXPECT().ApplyLayer(context.TODO(), hareOutput).Return(nil, nil).Times(1)
 		tm.mockState.EXPECT().GetStateRoot().Return(types.Hash32{}, nil).Times(1)
 		require.NoError(t, tm.ProcessLayerPerHareOutput(context.TODO(), i, hareOutput.ID()))
 	}
@@ -446,7 +446,7 @@ func TestMesh_Revert(t *testing.T) {
 	tm.mockState.EXPECT().RevertState(gPlus1).Return(types.Hash32{}, nil)
 	for i := gPlus2; !i.After(gPlus4); i = i.Add(1) {
 		hareOutput := layerBlocks[i]
-		tm.mockState.EXPECT().ApplyLayer(hareOutput).Return(nil, nil).Times(1)
+		tm.mockState.EXPECT().ApplyLayer(context.TODO(), hareOutput).Return(nil, nil).Times(1)
 		tm.mockState.EXPECT().GetStateRoot().Return(types.Hash32{}, nil).Times(1)
 	}
 	require.NoError(t, tm.ProcessLayerPerHareOutput(context.TODO(), gPlus4, blocks4[0].ID()))
@@ -466,7 +466,7 @@ func TestMesh_Revert(t *testing.T) {
 
 	// another new layer won't cause a revert
 	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gPlus5).Return(gPlus4).Times(1)
-	tm.mockState.EXPECT().ApplyLayer(blocks5[0]).Return(nil, nil).Times(1)
+	tm.mockState.EXPECT().ApplyLayer(context.TODO(), blocks5[0]).Return(nil, nil).Times(1)
 	tm.mockState.EXPECT().GetStateRoot().Return(types.Hash32{}, nil).Times(1)
 	require.NoError(t, tm.ProcessLayerPerHareOutput(context.TODO(), gPlus5, blocks5[0].ID()))
 	require.Equal(t, gPlus5, tm.ProcessedLayer())
@@ -506,7 +506,7 @@ func TestMesh_pushLayersToState_verified(t *testing.T) {
 	valids := []*types.Block{block1, block2}
 	types.SortBlocks(valids)
 	toApply := valids[0]
-	tm.mockState.EXPECT().ApplyLayer(toApply).Return(nil, nil).Times(1)
+	tm.mockState.EXPECT().ApplyLayer(context.TODO(), toApply).Return(nil, nil).Times(1)
 	tm.mockState.EXPECT().GetStateRoot().Return(types.Hash32{}, nil).Times(1)
 	require.NoError(t, tm.pushLayersToState(context.TODO(), layerID, layerID, layerID))
 	checkLastAppliedInDB(t, tm.Mesh, layerID)
@@ -527,7 +527,7 @@ func TestMesh_pushLayersToState_notVerified(t *testing.T) {
 	hareOutput := addBlockWithTXsToMesh(t, tm, layerID, true, txIDs[4:])
 	require.NoError(t, layers.SetHareOutput(tm.cdb, layerID, hareOutput.ID()))
 
-	tm.mockState.EXPECT().ApplyLayer(hareOutput).Return(nil, nil).Times(1)
+	tm.mockState.EXPECT().ApplyLayer(context.TODO(), hareOutput).Return(nil, nil).Times(1)
 	tm.mockState.EXPECT().GetStateRoot().Return(types.Hash32{}, nil).Times(1)
 	require.NoError(t, tm.pushLayersToState(context.TODO(), layerID, layerID, layerID.Sub(1)))
 	checkLastAppliedInDB(t, tm.Mesh, layerID)
@@ -590,7 +590,7 @@ func TestMesh_ReverifyFailed(t *testing.T) {
 	require.NoError(t, blocks.Add(tm.cdb, block))
 	require.NoError(t, layers.SetHareOutput(tm.cdb, last, block.ID()))
 	errTXMissing := errors.New("tx missing")
-	tm.mockState.EXPECT().ApplyLayer(block).Return(nil, errTXMissing)
+	tm.mockState.EXPECT().ApplyLayer(context.TODO(), block).Return(nil, errTXMissing)
 	require.Error(t, tm.ProcessLayer(ctx, last))
 	require.Equal(t, last, tm.ProcessedLayer())
 	require.Equal(t, last, tm.MissingLayer())
@@ -599,7 +599,7 @@ func TestMesh_ReverifyFailed(t *testing.T) {
 
 	last = last.Add(1)
 	require.NoError(t, tm.saveContextualValidity(block.ID(), last.Sub(1), true))
-	tm.mockState.EXPECT().ApplyLayer(block).Return(nil, nil)
+	tm.mockState.EXPECT().ApplyLayer(context.TODO(), block).Return(nil, nil)
 	require.NoError(t, layers.SetHareOutput(tm.cdb, last, types.EmptyBlockID))
 	for lid := last.Sub(1); !lid.After(last); lid = lid.Add(1) {
 		tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), lid).Return(last.Sub(1))
@@ -626,7 +626,7 @@ func TestMesh_MissingTransactionsFailure(t *testing.T) {
 
 	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), last).Return(last.Sub(1))
 	errTXMissing := errors.New("tx missing")
-	tm.mockState.EXPECT().ApplyLayer(block).Return(nil, errTXMissing)
+	tm.mockState.EXPECT().ApplyLayer(context.TODO(), block).Return(nil, errTXMissing)
 	require.ErrorIs(t, tm.ProcessLayer(ctx, last), errTXMissing)
 
 	require.Equal(t, last, tm.ProcessedLayer())

--- a/mesh/mocks/mocks.go
+++ b/mesh/mocks/mocks.go
@@ -36,18 +36,18 @@ func (m *MockconservativeState) EXPECT() *MockconservativeStateMockRecorder {
 }
 
 // ApplyLayer mocks base method.
-func (m *MockconservativeState) ApplyLayer(arg0 *types.Block) ([]types.TransactionID, error) {
+func (m *MockconservativeState) ApplyLayer(arg0 context.Context, arg1 *types.Block) ([]types.TransactionID, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ApplyLayer", arg0)
+	ret := m.ctrl.Call(m, "ApplyLayer", arg0, arg1)
 	ret0, _ := ret[0].([]types.TransactionID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ApplyLayer indicates an expected call of ApplyLayer.
-func (mr *MockconservativeStateMockRecorder) ApplyLayer(arg0 interface{}) *gomock.Call {
+func (mr *MockconservativeStateMockRecorder) ApplyLayer(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyLayer", reflect.TypeOf((*MockconservativeState)(nil).ApplyLayer), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyLayer", reflect.TypeOf((*MockconservativeState)(nil).ApplyLayer), arg0, arg1)
 }
 
 // GetStateRoot mocks base method.

--- a/miner/interface.go
+++ b/miner/interface.go
@@ -14,7 +14,7 @@ type proposalOracle interface {
 }
 
 type conservativeState interface {
-	SelectProposalTXs(int) []types.TransactionID
+	SelectProposalTXs(types.LayerID, int) []types.TransactionID
 }
 
 type votesEncoder interface {

--- a/miner/mocks/mocks.go
+++ b/miner/mocks/mocks.go
@@ -77,17 +77,17 @@ func (m *MockconservativeState) EXPECT() *MockconservativeStateMockRecorder {
 }
 
 // SelectProposalTXs mocks base method.
-func (m *MockconservativeState) SelectProposalTXs(arg0 int) []types.TransactionID {
+func (m *MockconservativeState) SelectProposalTXs(arg0 types.LayerID, arg1 int) []types.TransactionID {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SelectProposalTXs", arg0)
+	ret := m.ctrl.Call(m, "SelectProposalTXs", arg0, arg1)
 	ret0, _ := ret[0].([]types.TransactionID)
 	return ret0
 }
 
 // SelectProposalTXs indicates an expected call of SelectProposalTXs.
-func (mr *MockconservativeStateMockRecorder) SelectProposalTXs(arg0 interface{}) *gomock.Call {
+func (mr *MockconservativeStateMockRecorder) SelectProposalTXs(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SelectProposalTXs", reflect.TypeOf((*MockconservativeState)(nil).SelectProposalTXs), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SelectProposalTXs", reflect.TypeOf((*MockconservativeState)(nil).SelectProposalTXs), arg0, arg1)
 }
 
 // MockvotesEncoder is a mock of votesEncoder interface.

--- a/miner/proposal_builder.go
+++ b/miner/proposal_builder.go
@@ -296,7 +296,7 @@ func (pb *ProposalBuilder) handleLayer(ctx context.Context, layerID types.LayerI
 
 	logger.With().Info("eligible for one or more proposals in layer", atxID, log.Int("num_proposals", len(proofs)))
 
-	txList := pb.conState.SelectProposalTXs(len(proofs))
+	txList := pb.conState.SelectProposalTXs(layerID, len(proofs))
 	p, err := pb.createProposal(ctx, layerID, proofs, atxID, activeSet, beacon, txList, *votes)
 	if err != nil {
 		logger.With().Error("failed to create new proposal", log.Err(err))

--- a/miner/proposal_builder_test.go
+++ b/miner/proposal_builder_test.go
@@ -136,7 +136,7 @@ func TestBuilder_HandleLayer_MultipleProposals(t *testing.T) {
 	b.mOracle.EXPECT().GetProposalEligibility(layerID, beacon).Return(atxID, activeSet, proofs, nil).Times(1)
 
 	// for 1st proposal, containing the ref ballot of this epoch
-	b.mCState.EXPECT().SelectProposalTXs(len(proofs)).Return([]types.TransactionID{tx1.ID}).Times(1)
+	b.mCState.EXPECT().SelectProposalTXs(layerID, len(proofs)).Return([]types.TransactionID{tx1.ID}).Times(1)
 	b.mBaseBP.EXPECT().EncodeVotes(gomock.Any(), gomock.Any()).Return(&types.Votes{Base: base}, nil).Times(1)
 	meshHash := types.RandomHash()
 	require.NoError(t, layers.SetHashes(b.cdb, layerID.Sub(1), types.RandomHash(), meshHash))
@@ -182,7 +182,7 @@ func TestBuilder_HandleLayer_OneProposal(t *testing.T) {
 	b.mOracle.EXPECT().GetProposalEligibility(layerID, beacon).Return(atxID, activeSet, proofs, nil).Times(1)
 
 	// for 1st proposal, containing the ref ballot of this epoch
-	b.mCState.EXPECT().SelectProposalTXs(len(proofs)).Return([]types.TransactionID{tx.ID}).Times(1)
+	b.mCState.EXPECT().SelectProposalTXs(layerID, len(proofs)).Return([]types.TransactionID{tx.ID}).Times(1)
 	b.mBaseBP.EXPECT().EncodeVotes(gomock.Any(), gomock.Any()).Return(&types.Votes{Base: bb}, nil).Times(1)
 	meshHash := types.RandomHash()
 	require.NoError(t, layers.SetHashes(b.cdb, layerID.Sub(1), types.RandomHash(), meshHash))
@@ -285,7 +285,7 @@ func TestBuilder_HandleLayer_NoRefBallot(t *testing.T) {
 	b.mSync.EXPECT().IsSynced(gomock.Any()).Return(true).Times(1)
 	b.mBeacon.EXPECT().GetBeacon(gomock.Any()).Return(beacon, nil).Times(1)
 	b.mOracle.EXPECT().GetProposalEligibility(layerID, beacon).Return(types.RandomATXID(), activeSet, genProofs(t, 1), nil).Times(1)
-	b.mCState.EXPECT().SelectProposalTXs(1).Return([]types.TransactionID{tx.ID}).Times(1)
+	b.mCState.EXPECT().SelectProposalTXs(layerID, 1).Return([]types.TransactionID{tx.ID}).Times(1)
 	b.mBaseBP.EXPECT().EncodeVotes(gomock.Any(), gomock.Any()).Return(&types.Votes{Base: types.RandomBallotID()}, nil).Times(1)
 	require.NoError(t, layers.SetHashes(b.cdb, layerID.Sub(1), types.RandomHash(), types.RandomHash()))
 	b.mPubSub.EXPECT().Publish(gomock.Any(), pubsub.ProposalProtocol, gomock.Any()).DoAndReturn(
@@ -314,7 +314,7 @@ func TestBuilder_HandleLayer_RefBallot(t *testing.T) {
 	b.mSync.EXPECT().IsSynced(gomock.Any()).Return(true).Times(1)
 	b.mBeacon.EXPECT().GetBeacon(gomock.Any()).Return(beacon, nil).Times(1)
 	b.mOracle.EXPECT().GetProposalEligibility(layerID, beacon).Return(types.RandomATXID(), genActiveSet(t), genProofs(t, 1), nil).Times(1)
-	b.mCState.EXPECT().SelectProposalTXs(1).Return([]types.TransactionID{tx.ID}).Times(1)
+	b.mCState.EXPECT().SelectProposalTXs(layerID, 1).Return([]types.TransactionID{tx.ID}).Times(1)
 	b.mBaseBP.EXPECT().EncodeVotes(gomock.Any(), gomock.Any()).Return(&types.Votes{Base: types.RandomBallotID()}, nil).Times(1)
 	require.NoError(t, layers.SetHashes(b.cdb, layerID.Sub(1), types.RandomHash(), types.RandomHash()))
 	b.mPubSub.EXPECT().Publish(gomock.Any(), pubsub.ProposalProtocol, gomock.Any()).DoAndReturn(
@@ -342,7 +342,7 @@ func TestBuilder_HandleLayer_CanceledDuringBuilding(t *testing.T) {
 	b.mSync.EXPECT().IsSynced(gomock.Any()).Return(true).Times(1)
 	b.mBeacon.EXPECT().GetBeacon(gomock.Any()).Return(beacon, nil).Times(1)
 	b.mOracle.EXPECT().GetProposalEligibility(layerID, beacon).Return(types.RandomATXID(), genActiveSet(t), genProofs(t, 1), nil).Times(1)
-	b.mCState.EXPECT().SelectProposalTXs(1).Return([]types.TransactionID{tx.ID}).Times(1)
+	b.mCState.EXPECT().SelectProposalTXs(layerID, 1).Return([]types.TransactionID{tx.ID}).Times(1)
 	b.mBaseBP.EXPECT().EncodeVotes(gomock.Any(), gomock.Any()).Return(&types.Votes{Base: types.RandomBallotID()}, nil).Times(1)
 	require.NoError(t, layers.SetHashes(b.cdb, layerID.Sub(1), types.RandomHash(), types.RandomHash()))
 
@@ -362,7 +362,7 @@ func TestBuilder_HandleLayer_PublishError(t *testing.T) {
 	b.mSync.EXPECT().IsSynced(gomock.Any()).Return(true).Times(1)
 	b.mBeacon.EXPECT().GetBeacon(gomock.Any()).Return(beacon, nil).Times(1)
 	b.mOracle.EXPECT().GetProposalEligibility(layerID, beacon).Return(types.RandomATXID(), genActiveSet(t), genProofs(t, 1), nil).Times(1)
-	b.mCState.EXPECT().SelectProposalTXs(1).Return([]types.TransactionID{tx.ID}).Times(1)
+	b.mCState.EXPECT().SelectProposalTXs(layerID, 1).Return([]types.TransactionID{tx.ID}).Times(1)
 	b.mBaseBP.EXPECT().EncodeVotes(gomock.Any(), gomock.Any()).Return(&types.Votes{Base: types.RandomBallotID()}, nil).Times(1)
 	require.NoError(t, layers.SetHashes(b.cdb, layerID.Sub(1), types.RandomHash(), types.RandomHash()))
 	b.mPubSub.EXPECT().Publish(gomock.Any(), pubsub.ProposalProtocol, gomock.Any()).Return(errors.New("unknown")).Times(1)
@@ -384,7 +384,7 @@ func TestBuilder_HandleLayer_StateRootErrorOK(t *testing.T) {
 	b.mSync.EXPECT().IsSynced(gomock.Any()).Return(true).Times(1)
 	b.mBeacon.EXPECT().GetBeacon(gomock.Any()).Return(beacon, nil).Times(1)
 	b.mOracle.EXPECT().GetProposalEligibility(layerID, beacon).Return(types.RandomATXID(), genActiveSet(t), genProofs(t, 1), nil).Times(1)
-	b.mCState.EXPECT().SelectProposalTXs(1).Return([]types.TransactionID{tx.ID}).Times(1)
+	b.mCState.EXPECT().SelectProposalTXs(layerID, 1).Return([]types.TransactionID{tx.ID}).Times(1)
 	b.mBaseBP.EXPECT().EncodeVotes(gomock.Any(), gomock.Any()).Return(&types.Votes{Base: types.RandomBallotID()}, nil).Times(1)
 	require.NoError(t, layers.SetHashes(b.cdb, layerID.Sub(1), types.RandomHash(), types.RandomHash()))
 	b.mPubSub.EXPECT().Publish(gomock.Any(), pubsub.ProposalProtocol, gomock.Any()).Return(errors.New("unknown")).Times(1)
@@ -405,7 +405,7 @@ func TestBuilder_HandleLayer_MeshHashErrorOK(t *testing.T) {
 	b.mSync.EXPECT().IsSynced(gomock.Any()).Return(true).Times(1)
 	b.mBeacon.EXPECT().GetBeacon(gomock.Any()).Return(beacon, nil).Times(1)
 	b.mOracle.EXPECT().GetProposalEligibility(layerID, beacon).Return(types.RandomATXID(), genActiveSet(t), genProofs(t, 1), nil).Times(1)
-	b.mCState.EXPECT().SelectProposalTXs(1).Return([]types.TransactionID{tx.ID}).Times(1)
+	b.mCState.EXPECT().SelectProposalTXs(layerID, 1).Return([]types.TransactionID{tx.ID}).Times(1)
 	b.mBaseBP.EXPECT().EncodeVotes(gomock.Any(), gomock.Any()).Return(&types.Votes{Base: types.RandomBallotID()}, nil).Times(1)
 	b.mPubSub.EXPECT().Publish(gomock.Any(), pubsub.ProposalProtocol, gomock.Any()).Return(errors.New("unknown")).Times(1)
 

--- a/syncer/syncer_test.go
+++ b/syncer/syncer_test.go
@@ -533,8 +533,8 @@ func TestSyncMissingLayer(t *testing.T) {
 		if lid == failed {
 			ts.mTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), lid).Return(lid.Sub(1))
 			errMissingTXs := errors.New("missing TXs")
-			ts.mConState.EXPECT().ApplyLayer(block).DoAndReturn(
-				func(got *types.Block) ([]*types.Transaction, error) {
+			ts.mConState.EXPECT().ApplyLayer(context.TODO(), block).DoAndReturn(
+				func(_ context.Context, got *types.Block) ([]*types.Transaction, error) {
 					require.Equal(t, block.ID(), got.ID())
 					return nil, errMissingTXs
 				})
@@ -554,8 +554,8 @@ func TestSyncMissingLayer(t *testing.T) {
 	for lid := failed; lid.Before(last); lid = lid.Add(1) {
 		ts.mTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), lid).Return(lid.Sub(1))
 		if lid == failed {
-			ts.mConState.EXPECT().ApplyLayer(block).DoAndReturn(
-				func(got *types.Block) ([]*types.Transaction, []*types.Reward, error) {
+			ts.mConState.EXPECT().ApplyLayer(context.TODO(), block).DoAndReturn(
+				func(_ context.Context, got *types.Block) ([]*types.Transaction, []*types.Reward, error) {
 					require.Equal(t, block.ID(), got.ID())
 					return nil, nil, nil
 				})

--- a/txs/cache.go
+++ b/txs/cache.go
@@ -800,13 +800,13 @@ func (c *cache) GetProjection(addr types.Address) (uint64, uint64) {
 }
 
 // GetMempool returns all the transactions that eligible for a proposal/block.
-func (c *cache) GetMempool() map[types.Address][]*txtypes.NanoTX {
+func (c *cache) GetMempool(logger log.Log) map[types.Address][]*txtypes.NanoTX {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	all := make(map[types.Address][]*txtypes.NanoTX)
 	for addr, accCache := range c.pending {
-		txs := accCache.getMempool(c.logger.WithFields(addr))
+		txs := accCache.getMempool(logger.WithFields(addr))
 		if len(txs) > 0 {
 			all[addr] = txs
 		}

--- a/txs/cache_test.go
+++ b/txs/cache_test.go
@@ -111,7 +111,7 @@ func checkNoTX(t *testing.T, c *cache, tid types.TransactionID) {
 
 func checkMempool(t *testing.T, c *cache, expected map[types.Address][]*txtypes.NanoTX) {
 	t.Helper()
-	mempool := c.GetMempool()
+	mempool := c.GetMempool(c.logger)
 	require.Len(t, mempool, len(expected))
 	for addr := range mempool {
 		var exp, got txtypes.NanoTX
@@ -1001,7 +1001,7 @@ func buildSmallCache(t *testing.T, tc *testCache, accounts map[types.Address]*te
 
 func checkMempoolSize(t *testing.T, c *cache, expected int) {
 	t.Helper()
-	mempool := c.GetMempool()
+	mempool := c.GetMempool(c.logger)
 	numTXs := 0
 	for _, ntxs := range mempool {
 		numTXs += len(ntxs)

--- a/txs/handler.go
+++ b/txs/handler.go
@@ -64,7 +64,7 @@ func (th *TxHandler) handleTransaction(ctx context.Context, msg []byte) error {
 	if !req.Verify() {
 		return fmt.Errorf("failed to verify %s", raw.ID)
 	}
-	if err := th.state.AddToCache(&types.Transaction{RawTx: raw, TxHeader: header}); err != nil {
+	if err := th.state.AddToCache(ctx, &types.Transaction{RawTx: raw, TxHeader: header}); err != nil {
 		th.logger.WithContext(ctx).With().Warning("failed to add tx to conservative cache",
 			raw.ID,
 			log.Err(err))

--- a/txs/handler_test.go
+++ b/txs/handler_test.go
@@ -88,8 +88,8 @@ func gossipExpectations(t *testing.T, hasErr, parseErr, addErr error, has, verif
 		if parseErr == nil {
 			req.EXPECT().Verify().Times(1).Return(verify)
 			if verify {
-				cstate.EXPECT().AddToCache(gomock.Any()).DoAndReturn(
-					func(got *types.Transaction) error {
+				cstate.EXPECT().AddToCache(gomock.Any(), gomock.Any()).DoAndReturn(
+					func(_ context.Context, got *types.Transaction) error {
 						assert.Equal(t, tx.ID, got.ID) // causing ID to be calculated
 						assert.Equal(t, tx, got)
 						return addErr

--- a/txs/interface.go
+++ b/txs/interface.go
@@ -1,6 +1,8 @@
 package txs
 
 import (
+	"context"
+
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	vm "github.com/spacemeshos/go-spacemesh/genvm"
 	"github.com/spacemeshos/go-spacemesh/system"
@@ -12,7 +14,7 @@ import (
 type conservativeState interface {
 	HasTx(types.TransactionID) (bool, error)
 	Validation(types.RawTx) system.ValidationRequest
-	AddToCache(*types.Transaction) error
+	AddToCache(context.Context, *types.Transaction) error
 	AddToDB(*types.Transaction) error
 	GetMeshTransaction(types.TransactionID) (*types.MeshTransaction, error)
 }

--- a/txs/interface.go
+++ b/txs/interface.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	vm "github.com/spacemeshos/go-spacemesh/genvm"
+	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/system"
 	txtypes "github.com/spacemeshos/go-spacemesh/txs/types"
 )
@@ -32,5 +33,5 @@ type vmState interface {
 }
 
 type conStateCache interface {
-	GetMempool() map[types.Address][]*txtypes.NanoTX
+	GetMempool(log.Log) map[types.Address][]*txtypes.NanoTX
 }

--- a/txs/mempool_iterator.go
+++ b/txs/mempool_iterator.go
@@ -73,7 +73,7 @@ type mempoolIterator struct {
 
 // newMempoolIterator builds and returns a mempoolIterator.
 func newMempoolIterator(logger log.Log, cs conStateCache, gasLimit uint64) *mempoolIterator {
-	txs := cs.GetMempool()
+	txs := cs.GetMempool(logger)
 	mi := &mempoolIterator{
 		logger:       logger,
 		gasRemaining: gasLimit,

--- a/txs/mempool_iterator_test.go
+++ b/txs/mempool_iterator_test.go
@@ -84,7 +84,7 @@ func TestPopAll(t *testing.T) {
 	mempool, expected := makeMempool()
 	ctrl := gomock.NewController(t)
 	mockCache := mocks.NewMockconStateCache(ctrl)
-	mockCache.EXPECT().GetMempool().Return(mempool)
+	mockCache.EXPECT().GetMempool(gomock.Any()).Return(mempool)
 	gasLimit := uint64(3)
 	mi := newMempoolIterator(logtest.New(t), mockCache, gasLimit)
 	testPopAll(t, mi, expected[:gasLimit])
@@ -95,7 +95,7 @@ func TestPopAll_SkipSomeGasTooHigh(t *testing.T) {
 	mempool, orderedByFee := makeMempool()
 	ctrl := gomock.NewController(t)
 	mockCache := mocks.NewMockconStateCache(ctrl)
-	mockCache.EXPECT().GetMempool().Return(mempool)
+	mockCache.EXPECT().GetMempool(gomock.Any()).Return(mempool)
 	gasLimit := uint64(3)
 	// make the 2nd one too expensive to pick, therefore invalidated all txs from addr0
 	orderedByFee[1].MaxGas = 10
@@ -109,7 +109,7 @@ func TestPopAll_ExhaustMempool(t *testing.T) {
 	mempool, expected := makeMempool()
 	ctrl := gomock.NewController(t)
 	mockCache := mocks.NewMockconStateCache(ctrl)
-	mockCache.EXPECT().GetMempool().Return(mempool)
+	mockCache.EXPECT().GetMempool(gomock.Any()).Return(mempool)
 	gasLimit := uint64(100)
 	mi := newMempoolIterator(logtest.New(t), mockCache, gasLimit)
 	testPopAll(t, mi, expected)

--- a/txs/mocks/mocks.go
+++ b/txs/mocks/mocks.go
@@ -11,6 +11,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	types "github.com/spacemeshos/go-spacemesh/common/types"
 	vm "github.com/spacemeshos/go-spacemesh/genvm"
+	log "github.com/spacemeshos/go-spacemesh/log"
 	system "github.com/spacemeshos/go-spacemesh/system"
 	types0 "github.com/spacemeshos/go-spacemesh/txs/types"
 )
@@ -292,15 +293,15 @@ func (m *MockconStateCache) EXPECT() *MockconStateCacheMockRecorder {
 }
 
 // GetMempool mocks base method.
-func (m *MockconStateCache) GetMempool() map[types.Address][]*types0.NanoTX {
+func (m *MockconStateCache) GetMempool(arg0 log.Log) map[types.Address][]*types0.NanoTX {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMempool")
+	ret := m.ctrl.Call(m, "GetMempool", arg0)
 	ret0, _ := ret[0].(map[types.Address][]*types0.NanoTX)
 	return ret0
 }
 
 // GetMempool indicates an expected call of GetMempool.
-func (mr *MockconStateCacheMockRecorder) GetMempool() *gomock.Call {
+func (mr *MockconStateCacheMockRecorder) GetMempool(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMempool", reflect.TypeOf((*MockconStateCache)(nil).GetMempool))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMempool", reflect.TypeOf((*MockconStateCache)(nil).GetMempool), arg0)
 }

--- a/txs/mocks/mocks.go
+++ b/txs/mocks/mocks.go
@@ -5,8 +5,8 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
-	time "time"
 
 	gomock "github.com/golang/mock/gomock"
 	types "github.com/spacemeshos/go-spacemesh/common/types"
@@ -39,17 +39,17 @@ func (m *MockconservativeState) EXPECT() *MockconservativeStateMockRecorder {
 }
 
 // AddToCache mocks base method.
-func (m *MockconservativeState) AddToCache(arg0 *types.Transaction) error {
+func (m *MockconservativeState) AddToCache(arg0 context.Context, arg1 *types.Transaction) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddToCache", arg0)
+	ret := m.ctrl.Call(m, "AddToCache", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // AddToCache indicates an expected call of AddToCache.
-func (mr *MockconservativeStateMockRecorder) AddToCache(arg0 interface{}) *gomock.Call {
+func (mr *MockconservativeStateMockRecorder) AddToCache(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddToCache", reflect.TypeOf((*MockconservativeState)(nil).AddToCache), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddToCache", reflect.TypeOf((*MockconservativeState)(nil).AddToCache), arg0, arg1)
 }
 
 // AddToDB mocks base method.
@@ -64,20 +64,6 @@ func (m *MockconservativeState) AddToDB(arg0 *types.Transaction) error {
 func (mr *MockconservativeStateMockRecorder) AddToDB(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddToDB", reflect.TypeOf((*MockconservativeState)(nil).AddToDB), arg0)
-}
-
-// AddWithHeader mocks base method.
-func (m *MockconservativeState) AddWithHeader(arg0 *types.Transaction, arg1 time.Time) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddWithHeader", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// AddWithHeader indicates an expected call of AddWithHeader.
-func (mr *MockconservativeStateMockRecorder) AddWithHeader(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddWithHeader", reflect.TypeOf((*MockconservativeState)(nil).AddWithHeader), arg0, arg1)
 }
 
 // GetMeshTransaction mocks base method.

--- a/txs/txs_builder.go
+++ b/txs/txs_builder.go
@@ -259,7 +259,7 @@ func shuffleWithNonceOrder(
 			byAddrAndNonce[p] = byAddrAndNonce[p][1:]
 		}
 	}
-	logger.With().Info("packed txs", log.Array("ranges", log.ArrayMarshalerFunc(func(encoder log.ArrayEncoder) error {
+	logger.With().Debug("packed txs", log.Array("ranges", log.ArrayMarshalerFunc(func(encoder log.ArrayEncoder) error {
 		for addr, nonces := range packed {
 			encoder.AppendObject(log.ObjectMarshallerFunc(func(encoder log.ObjectEncoder) error {
 				encoder.AddString("addr", addr.String())

--- a/txs/txs_builder.go
+++ b/txs/txs_builder.go
@@ -207,7 +207,6 @@ func getBlockTXs(logger log.Log, pmd *proposalMetadata, getState stateFunc, bloc
 	mt.SeedFromSlice(toUint64Slice(blockSeed))
 	rng := rand.New(mt)
 	ordered := shuffleWithNonceOrder(logger, rng, len(bmd.candidates), bmd.candidates, bmd.byAddrAndNonce)
-	logger.With().Debug("block txs after shuffle", log.Int("num_txs", len(ordered)))
 	return prune(logger, ordered, bmd.byTid, gasLimit), nil
 }
 
@@ -237,6 +236,7 @@ func shuffleWithNonceOrder(
 	rng.Shuffle(len(ntxs), func(i, j int) { ntxs[i], ntxs[j] = ntxs[j], ntxs[i] })
 	total := util.Min(len(ntxs), numTXs)
 	result := make([]types.TransactionID, 0, total)
+	packed := make(map[types.Address][]uint64)
 	for _, ntx := range ntxs[:total] {
 		// if a spot is taken by a principal, we add its TX for the next eligible nonce
 		p := ntx.Principal
@@ -246,12 +246,21 @@ func shuffleWithNonceOrder(
 		if len(byAddrAndNonce[p]) == 0 {
 			logger.With().Fatal("txs missing", p)
 		}
-		result = append(result, byAddrAndNonce[p][0].ID)
+		toAdd := byAddrAndNonce[p][0]
+		result = append(result, toAdd.ID)
+		if _, ok := packed[p]; !ok {
+			packed[p] = []uint64{toAdd.Nonce.Counter, toAdd.Nonce.Counter}
+		} else {
+			packed[p][1] = toAdd.Nonce.Counter
+		}
 		if len(byAddrAndNonce[p]) == 1 {
 			delete(byAddrAndNonce, p)
 		} else {
 			byAddrAndNonce[p] = byAddrAndNonce[p][1:]
 		}
+	}
+	for addr, nonces := range packed {
+		logger.With().Debug("packed txs", addr, log.Uint64("from", nonces[0]), log.Uint64("to", nonces[1]))
 	}
 	return result
 }
@@ -264,7 +273,7 @@ func prune(logger log.Log, tids []types.TransactionID, byTid map[types.Transacti
 	)
 	for idx, tid = range tids {
 		if gasRemaining < minTXGas {
-			logger.With().Debug("gas exhausted for block",
+			logger.With().Info("gas exhausted for block",
 				log.Int("num_txs", idx),
 				log.Uint64("gas_left", gasRemaining),
 				log.Uint64("gas_limit", gasLimit))


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
Closes #3362 
<!-- `Closes #XXXX, closes #XXXX, ...` links mentioned issues to this PR and automatically closes them when this it's merged -->

## Changes
<!-- Please describe in detail the changes made -->
- move saving tx into DB inside cache.Add()
- allow nonce-too-big and insufficient balance txs to be saved to db
- check for address existence in cache before doing cleanup
- add tests for update tx header, nonce-to-high and insufficient balance txs
- add context for debugging

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->

unit tests, systests