### PR TITLE
[Merged by Bors] - block construction: enable optimistic filtering in systests

### DIFF
--- a/config/presets/fastnet.go
+++ b/config/presets/fastnet.go
@@ -22,7 +22,7 @@ func fastnet() config.Config {
 		panic(err)
 	}
 
-	conf.BaseConfig.OptFilterThreshold = 100
+	conf.BaseConfig.OptFilterThreshold = 90
 
 	conf.HARE.N = 800
 	conf.HARE.ExpectedLeaders = 10

--- a/txs/txs_builder_test.go
+++ b/txs/txs_builder_test.go
@@ -178,3 +178,108 @@ func TestGetBlockTXs_NoOptimisticFiltering(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, got)
 }
+
+func Test_checkStateConsensus(t *testing.T) {
+	cfg := CSConfig{OptFilterThreshold: 100}
+	lid := types.NewLayerID(11)
+	meshHash := types.RandomHash()
+	numProps := 10
+	props := make([]*types.Proposal, 0, numProps)
+	for i := 0; i < 10; i++ {
+		p := &types.Proposal{
+			InnerProposal: types.InnerProposal{
+				MeshHash: meshHash,
+			},
+		}
+		props = append(props, p)
+	}
+	md, err := checkStateConsensus(logtest.New(t), cfg, lid, props, meshHash, nil)
+	require.NoError(t, err)
+	require.Equal(t, proposalMetadata{
+		lid:  lid,
+		size: numProps,
+		meshHashes: map[types.Hash32]*meshState{
+			meshHash: {hash: meshHash, count: numProps},
+		},
+		mtxs:      []*types.MeshTransaction{},
+		optFilter: true,
+	}, *md)
+}
+
+func Test_checkStateConsensus_allEmpty(t *testing.T) {
+	cfg := CSConfig{OptFilterThreshold: 100}
+	lid := types.NewLayerID(11)
+	meshHash := types.EmptyLayerHash
+	numProps := 10
+	props := make([]*types.Proposal, 0, numProps)
+	for i := 0; i < 10; i++ {
+		p := &types.Proposal{
+			InnerProposal: types.InnerProposal{
+				MeshHash: meshHash,
+			},
+		}
+		props = append(props, p)
+	}
+	md, err := checkStateConsensus(logtest.New(t), cfg, lid, props, meshHash, nil)
+	require.NoError(t, err)
+	require.Equal(t, proposalMetadata{
+		lid:  lid,
+		size: numProps,
+		meshHashes: map[types.Hash32]*meshState{
+			meshHash: {hash: meshHash, count: numProps},
+		},
+		mtxs:      []*types.MeshTransaction{},
+		optFilter: false,
+	}, *md)
+}
+
+func Test_checkStateConsensus_ownMeshDiffer(t *testing.T) {
+	cfg := CSConfig{OptFilterThreshold: 100}
+	lid := types.NewLayerID(11)
+	meshHash := types.RandomHash()
+	numProps := 10
+	props := make([]*types.Proposal, 0, numProps)
+	for i := 0; i < 10; i++ {
+		p := &types.Proposal{
+			InnerProposal: types.InnerProposal{
+				MeshHash: meshHash,
+			},
+		}
+		props = append(props, p)
+	}
+	_, err := checkStateConsensus(logtest.New(t), cfg, lid, props, types.RandomHash(), nil)
+	require.ErrorIs(t, err, errNodeHasBadMeshHash)
+}
+
+func Test_checkStateConsensus_NoConsensus(t *testing.T) {
+	cfg := CSConfig{OptFilterThreshold: 100}
+	lid := types.NewLayerID(11)
+	meshHash0 := types.RandomHash()
+	meshHash1 := types.RandomHash()
+	numProps := 10
+	props := make([]*types.Proposal, 0, numProps)
+	for i := 0; i < 10; i++ {
+		h := meshHash0
+		if i%2 == 0 {
+			h = meshHash1
+		}
+		p := &types.Proposal{
+			InnerProposal: types.InnerProposal{
+				MeshHash: h,
+			},
+		}
+		props = append(props, p)
+	}
+	md, err := checkStateConsensus(logtest.New(t), cfg, lid, props, meshHash1, nil)
+	require.NoError(t, err)
+	require.Equal(t, proposalMetadata{
+		lid:  lid,
+		size: numProps,
+		meshHashes: map[types.Hash32]*meshState{
+			meshHash0: {hash: meshHash0, count: numProps / 2},
+			meshHash1: {hash: meshHash1, count: numProps / 2},
+		},
+		mtxs:      []*types.MeshTransaction{},
+		optFilter: false,
+	}, *md)
+}


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
Closes #3346

## Changes
<!-- Please describe in detail the changes made -->
- allow 100% agreement, replacing > with >=
- make sure consensus on empty layer hash is not consensus.
- add unit tests
- reduce consensus threshold to 90% in systests

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->
unittest, systests, longevity
