### PR TITLE
sync data from layers with emptly hare output

### DIFF
--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -545,10 +545,10 @@ func (app *App) initServices(ctx context.Context,
 	fetcherWrapped.Fetcher = layerFetch
 
 	patrol := layerpatrol.New()
-	syncerConf := syncer.Configuration{
+	syncerConf := syncer.Config{
 		SyncInterval: time.Duration(app.Config.SyncInterval) * time.Second,
 	}
-	newSyncer := syncer.NewSyncer(ctx, syncerConf, clock, beaconProtocol, msh, layerFetch, patrol, app.addLogger(SyncLogger, lg))
+	newSyncer := syncer.NewSyncer(ctx, app.addLogger(SyncLogger, lg), sqlDB, syncerConf, clock, beaconProtocol, msh, layerFetch, patrol)
 	// TODO(dshulyak) this needs to be improved, but dependency graph is a bit complicated
 	beaconProtocol.SetSyncState(newSyncer)
 


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
Closes #3371
<!-- `Closes #XXXX, closes #XXXX, ...` links mentioned issues to this PR and automatically closes them when this it's merged -->

## Changes
<!-- Please describe in detail the changes made -->
syncer double check for layers with empty hare output btwn (lastSyncedLayer, processedLayer]

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->
unittests, systests
