### PR TITLE
[Merged by Bors] - sync: ignore malicious ballots during sync

### DIFF
--- a/fetch/layers_test.go
+++ b/fetch/layers_test.go
@@ -165,9 +165,8 @@ func TestPollLayerContent(t *testing.T) {
 			zeroBlock: true,
 		},
 		{
-			name:       "ballots error fails layer fetch",
+			name:       "ballots failure ignored",
 			ballotFail: true,
-			err:        errLayerDataNotFetched,
 		},
 		{
 			name:       "blocks failure ignored",
@@ -205,6 +204,7 @@ func TestPollLayerContent(t *testing.T) {
 						}
 						return map[types.Hash32]chan ftypes.HashDataPromiseResult{types.RandomHash(): ch}
 					}).Times(numPeers)
+				tl.mFetcher.EXPECT().GetHashes(gomock.Any(), datastore.BlockDB, false).Return(nil).Times(numPeers)
 			} else if tc.blocksFail {
 				tl.mFetcher.EXPECT().GetHashes(gomock.Any(), datastore.BallotDB, false).Return(nil).Times(numPeers)
 				tl.mFetcher.EXPECT().GetHashes(gomock.Any(), datastore.BlockDB, false).DoAndReturn(


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
Closes #2697 
<!-- `Closes #XXXX, closes #XXXX, ...` links mentioned issues to this PR and automatically closes them when this it's merged -->

## Changes
<!-- Please describe in detail the changes made -->
the block part is done in https://github.com/spacemeshos/go-spacemesh/pull/3189
same should be done for ballots.
