### PR TITLE
[Merged by Bors] - Publish releases as not drafts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,5 +107,5 @@ jobs:
             - Windows: https://storage.googleapis.com/${{ secrets.GCP_BUCKET }}/${{ steps.version.outputs.content }}/Windows.zip
             - macOS: https://storage.googleapis.com/${{ secrets.GCP_BUCKET }}/${{ steps.version.outputs.content }}/macOS.zip
             - Linux: https://storage.googleapis.com/${{ secrets.GCP_BUCKET }}/${{ steps.version.outputs.content }}/Linux.zip
-          draft: true
+          draft: false
           prerelease: true


### PR DESCRIPTION
Releases shouldn't be marked as drafts.

Draft releases are visible only in the organization. Therefore I think we should "undraft" them :)