### PR TITLE
[Merged by Bors] - sync: advance the network when it stalls

### DIFF
--- a/fetch/interface.go
+++ b/fetch/interface.go
@@ -49,7 +49,7 @@ type poetHandler interface {
 
 type meshProvider interface {
 	ProcessedLayer() types.LayerID
-	SetZeroBlockLayer(types.LayerID) error
+	SetZeroBlockLayer(context.Context, types.LayerID) error
 }
 
 type host interface {

--- a/fetch/layers_test.go
+++ b/fetch/layers_test.go
@@ -220,7 +220,7 @@ func TestPollLayerContent(t *testing.T) {
 				tl.mFetcher.EXPECT().GetHashes(gomock.Any(), datastore.BlockDB, false).Return(nil).Times(numPeers)
 			}
 			if tc.zeroBlock {
-				tl.mMesh.EXPECT().SetZeroBlockLayer(layerID)
+				tl.mMesh.EXPECT().SetZeroBlockLayer(gomock.Any(), layerID)
 			}
 
 			res := <-tl.PollLayerContent(context.TODO(), layerID)
@@ -289,7 +289,7 @@ func TestPollLayerContent_PeerErrors(t *testing.T) {
 					return nil
 				})
 			if tc.zeroBlock {
-				tl.mMesh.EXPECT().SetZeroBlockLayer(layerID)
+				tl.mMesh.EXPECT().SetZeroBlockLayer(gomock.Any(), layerID)
 			} else {
 				tl.mFetcher.EXPECT().GetHashes(gomock.Any(), datastore.BallotDB, false).Return(nil)
 				tl.mFetcher.EXPECT().GetHashes(gomock.Any(), datastore.BlockDB, false).Return(nil)
@@ -397,7 +397,7 @@ func TestPollLayerContent_FailureToSaveZeroBlockLayerIgnored(t *testing.T) {
 			}
 			return nil
 		})
-	tl.mMesh.EXPECT().SetZeroBlockLayer(layerID).Return(errors.New("whatever")).Times(1)
+	tl.mMesh.EXPECT().SetZeroBlockLayer(gomock.Any(), layerID).Return(errors.New("whatever")).Times(1)
 
 	res := <-tl.PollLayerContent(context.TODO(), layerID)
 	assert.NoError(t, res.Err)

--- a/fetch/mocks/mocks.go
+++ b/fetch/mocks/mocks.go
@@ -416,17 +416,17 @@ func (mr *MockmeshProviderMockRecorder) ProcessedLayer() *gomock.Call {
 }
 
 // SetZeroBlockLayer mocks base method.
-func (m *MockmeshProvider) SetZeroBlockLayer(arg0 types.LayerID) error {
+func (m *MockmeshProvider) SetZeroBlockLayer(arg0 context.Context, arg1 types.LayerID) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetZeroBlockLayer", arg0)
+	ret := m.ctrl.Call(m, "SetZeroBlockLayer", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetZeroBlockLayer indicates an expected call of SetZeroBlockLayer.
-func (mr *MockmeshProviderMockRecorder) SetZeroBlockLayer(arg0 interface{}) *gomock.Call {
+func (mr *MockmeshProviderMockRecorder) SetZeroBlockLayer(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetZeroBlockLayer", reflect.TypeOf((*MockmeshProvider)(nil).SetZeroBlockLayer), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetZeroBlockLayer", reflect.TypeOf((*MockmeshProvider)(nil).SetZeroBlockLayer), arg0, arg1)
 }
 
 // Mockhost is a mock of host interface.

--- a/mesh/interface.go
+++ b/mesh/interface.go
@@ -20,4 +20,5 @@ type tortoise interface {
 	OnBallot(*types.Ballot)
 	OnBlock(*types.Block)
 	HandleIncomingLayer(context.Context, types.LayerID) types.LayerID
+	LatestComplete() types.LayerID
 }

--- a/mesh/mesh_test.go
+++ b/mesh/mesh_test.go
@@ -478,11 +478,12 @@ func TestMesh_Revert(t *testing.T) {
 
 func TestMesh_LatestKnownLayer(t *testing.T) {
 	tm := createTestMesh(t)
-	tm.setLatestLayer(types.NewLayerID(3))
-	tm.setLatestLayer(types.NewLayerID(7))
-	tm.setLatestLayer(types.NewLayerID(10))
-	tm.setLatestLayer(types.NewLayerID(1))
-	tm.setLatestLayer(types.NewLayerID(2))
+	lg := logtest.New(t)
+	tm.setLatestLayer(lg, types.NewLayerID(3))
+	tm.setLatestLayer(lg, types.NewLayerID(7))
+	tm.setLatestLayer(lg, types.NewLayerID(10))
+	tm.setLatestLayer(lg, types.NewLayerID(1))
+	tm.setLatestLayer(lg, types.NewLayerID(2))
 	assert.Equal(t, types.NewLayerID(10), tm.LatestLayer(), "wrong layer")
 }
 

--- a/mesh/mesh_test.go
+++ b/mesh/mesh_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
@@ -18,6 +17,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/sql/ballots"
 	"github.com/spacemeshos/go-spacemesh/sql/blocks"
 	"github.com/spacemeshos/go-spacemesh/sql/layers"
+	smocks "github.com/spacemeshos/go-spacemesh/system/mocks"
 )
 
 const (
@@ -30,6 +30,7 @@ type testMesh struct {
 	*Mesh
 	mockState    *mocks.MockconservativeState
 	mockTortoise *mocks.Mocktortoise
+	mockBeacon   *smocks.MockBeaconGetter
 }
 
 func createTestMesh(t *testing.T) *testMesh {
@@ -40,8 +41,9 @@ func createTestMesh(t *testing.T) *testMesh {
 	tm := &testMesh{
 		mockState:    mocks.NewMockconservativeState(ctrl),
 		mockTortoise: mocks.NewMocktortoise(ctrl),
+		mockBeacon:   smocks.NewMockBeaconGetter(ctrl),
 	}
-	msh, err := NewMesh(datastore.NewCachedDB(sql.InMemory(), lg), tm.mockTortoise, tm.mockState, lg)
+	msh, err := NewMesh(datastore.NewCachedDB(sql.InMemory(), lg), tm.mockBeacon, tm.mockTortoise, tm.mockState, lg)
 	require.NoError(t, err)
 	gLid := types.GetEffectiveGenesis()
 	checkLastAppliedInDB(t, msh, gLid)
@@ -153,7 +155,7 @@ func TestMesh_FromGenesis(t *testing.T) {
 
 func TestMesh_WakeUpWhileGenesis(t *testing.T) {
 	tm := createTestMesh(t)
-	msh, err := NewMesh(tm.cdb, tm.mockTortoise, tm.mockState, logtest.New(t))
+	msh, err := NewMesh(tm.cdb, tm.mockBeacon, tm.mockTortoise, tm.mockState, logtest.New(t))
 	require.NoError(t, err)
 	gLid := types.GetEffectiveGenesis()
 	checkLatestInDB(t, msh, gLid)
@@ -177,7 +179,7 @@ func TestMesh_WakeUp(t *testing.T) {
 	require.NoError(t, layers.SetApplied(tm.cdb, latestState, types.RandomBlockID()))
 
 	tm.mockState.EXPECT().RevertState(latestState).Return(types.RandomHash(), nil)
-	msh, err := NewMesh(tm.cdb, tm.mockTortoise, tm.mockState, logtest.New(t))
+	msh, err := NewMesh(tm.cdb, tm.mockBeacon, tm.mockTortoise, tm.mockState, logtest.New(t))
 	require.NoError(t, err)
 	gotL := msh.LatestLayer()
 	require.Equal(t, latest, gotL)
@@ -206,9 +208,10 @@ func TestMesh_LayerHashes(t *testing.T) {
 		thisLyr, err := tm.GetLayer(i)
 		require.NoError(t, err)
 
-		tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), i).Return(i.Sub(1)).Times(1)
+		tm.mockBeacon.EXPECT().GetBeacon(i.GetEpoch()).Return(types.RandomBeacon(), nil)
+		tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), i).Return(i.Sub(1))
 		blk := lyrBlocks[i]
-		tm.mockState.EXPECT().ApplyLayer(context.TODO(), blk).Return(nil).Times(1)
+		tm.mockState.EXPECT().ApplyLayer(context.TODO(), blk).Return(nil)
 		tm.mockState.EXPECT().GetStateRoot().Return(types.Hash32{}, nil)
 
 		h, err := layers.GetHash(tm.cdb, i)
@@ -221,11 +224,11 @@ func TestMesh_LayerHashes(t *testing.T) {
 		expectedHash := types.CalcBlocksHash32([]types.BlockID{blk.ID()}, nil)
 		h, err = layers.GetHash(tm.cdb, i)
 		require.NoError(t, err)
-		assert.Equal(t, expectedHash, h)
+		require.Equal(t, expectedHash, h)
 		expectedAggHash := types.CalcBlocksHash32([]types.BlockID{blk.ID()}, prevAggHash.Bytes())
 		ah, err = layers.GetAggregatedHash(tm.cdb, i)
 		require.NoError(t, err)
-		assert.Equal(t, expectedAggHash, ah)
+		require.Equal(t, expectedAggHash, ah)
 		prevAggHash = expectedAggHash
 	}
 }
@@ -235,8 +238,8 @@ func TestMesh_GetLayer(t *testing.T) {
 	id := types.GetEffectiveGenesis().Add(1)
 	lyr, err := tm.GetLayer(id)
 	require.NoError(t, err)
-	assert.Empty(t, lyr.Blocks())
-	assert.Empty(t, lyr.Ballots())
+	require.Empty(t, lyr.Blocks())
+	require.Empty(t, lyr.Ballots())
 
 	blks := createLayerBlocks(t, tm.Mesh, id, true)
 	blts := createLayerBallots(t, tm.Mesh, id)
@@ -244,8 +247,8 @@ func TestMesh_GetLayer(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, id, lyr.Index())
 	require.Len(t, lyr.Ballots(), len(blts))
-	assert.ElementsMatch(t, blts, lyr.Ballots())
-	assert.ElementsMatch(t, blks, lyr.Blocks())
+	require.ElementsMatch(t, blts, lyr.Ballots())
+	require.ElementsMatch(t, blks, lyr.Blocks())
 }
 
 func TestMesh_ProcessLayerPerHareOutput(t *testing.T) {
@@ -271,14 +274,15 @@ func TestMesh_ProcessLayerPerHareOutput(t *testing.T) {
 
 	for i := gPlus1; !i.After(gPlus5); i = i.Add(1) {
 		toApply := layerBlocks[i]
-		tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), i).Return(i.Sub(1)).Times(1)
-		tm.mockState.EXPECT().ApplyLayer(context.TODO(), toApply).Return(nil).Times(1)
-		tm.mockState.EXPECT().GetStateRoot().Return(types.Hash32{}, nil).Times(1)
+		tm.mockBeacon.EXPECT().GetBeacon(i.GetEpoch()).Return(types.RandomBeacon(), nil)
+		tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), i).Return(i.Sub(1))
+		tm.mockState.EXPECT().ApplyLayer(context.TODO(), toApply).Return(nil)
+		tm.mockState.EXPECT().GetStateRoot().Return(types.Hash32{}, nil)
 		require.NoError(t, tm.ProcessLayerPerHareOutput(context.TODO(), i, toApply.ID()))
 		got, err := layers.GetHareOutput(tm.cdb, i)
 		require.NoError(t, err)
-		assert.Equal(t, toApply.ID(), got)
-		assert.Equal(t, i, tm.ProcessedLayer())
+		require.Equal(t, toApply.ID(), got)
+		require.Equal(t, i, tm.ProcessedLayer())
 	}
 	checkLastAppliedInDB(t, tm.Mesh, gPlus5)
 }
@@ -299,68 +303,73 @@ func TestMesh_ProcessLayerPerHareOutput_OutOfOrder(t *testing.T) {
 
 	// process order is  : gPlus1, gPlus3, gPlus5, gPlus2, gPlus4
 	// processed layer is: gPlus1, gPlus1, gPlus1, gPlus3, gPlus5
-	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gPlus1).Return(gLyr).Times(1)
-	tm.mockState.EXPECT().ApplyLayer(context.TODO(), blocks1[0]).Return(nil).Times(1)
-	tm.mockState.EXPECT().GetStateRoot().Return(types.Hash32{}, nil).Times(1)
+	tm.mockBeacon.EXPECT().GetBeacon(gPlus1.GetEpoch()).Return(types.RandomBeacon(), nil)
+	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gPlus1).Return(gLyr)
+	tm.mockState.EXPECT().ApplyLayer(context.TODO(), blocks1[0]).Return(nil)
+	tm.mockState.EXPECT().GetStateRoot().Return(types.Hash32{}, nil)
 	require.NoError(t, tm.ProcessLayerPerHareOutput(context.TODO(), gPlus1, blocks1[0].ID()))
 	got, err := layers.GetHareOutput(tm.cdb, gPlus1)
 	require.NoError(t, err)
-	assert.Equal(t, blocks1[0].ID(), got)
-	assert.Equal(t, gPlus1, tm.ProcessedLayer())
-	assert.Equal(t, gPlus1, tm.LatestLayerInState())
+	require.Equal(t, blocks1[0].ID(), got)
+	require.Equal(t, gPlus1, tm.ProcessedLayer())
+	require.Equal(t, gPlus1, tm.LatestLayerInState())
 	checkLastAppliedInDB(t, tm.Mesh, gPlus1)
 
-	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gPlus3).Return(gLyr).Times(1)
+	tm.mockBeacon.EXPECT().GetBeacon(gPlus3.GetEpoch()).Return(types.RandomBeacon(), nil)
+	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gPlus3).Return(gLyr)
 	// will try to apply state for gPlus2
 	err = tm.ProcessLayerPerHareOutput(context.TODO(), gPlus3, blocks3[0].ID())
-	assert.ErrorIs(t, err, errMissingHareOutput)
+	require.ErrorIs(t, err, errMissingHareOutput)
 	got, err = layers.GetHareOutput(tm.cdb, gPlus3)
 	require.NoError(t, err)
-	assert.Equal(t, blocks3[0].ID(), got)
-	assert.Equal(t, gPlus1, tm.ProcessedLayer())
-	assert.Equal(t, gPlus1, tm.LatestLayerInState())
+	require.Equal(t, blocks3[0].ID(), got)
+	require.Equal(t, gPlus1, tm.ProcessedLayer())
+	require.Equal(t, gPlus1, tm.LatestLayerInState())
 	checkLastAppliedInDB(t, tm.Mesh, gPlus1)
 
-	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gPlus5).Return(gLyr).Times(1)
+	tm.mockBeacon.EXPECT().GetBeacon(gPlus5.GetEpoch()).Return(types.RandomBeacon(), nil)
+	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gPlus5).Return(gLyr)
 	// will try to apply state for gPlus2
 	err = tm.ProcessLayerPerHareOutput(context.TODO(), gPlus5, blocks5[0].ID())
-	assert.ErrorIs(t, err, errMissingHareOutput)
+	require.ErrorIs(t, err, errMissingHareOutput)
 	got, err = layers.GetHareOutput(tm.cdb, gPlus5)
 	require.NoError(t, err)
-	assert.Equal(t, blocks5[0].ID(), got)
-	assert.Equal(t, gPlus1, tm.ProcessedLayer())
-	assert.Equal(t, gPlus1, tm.LatestLayerInState())
+	require.Equal(t, blocks5[0].ID(), got)
+	require.Equal(t, gPlus1, tm.ProcessedLayer())
+	require.Equal(t, gPlus1, tm.LatestLayerInState())
 	checkLastAppliedInDB(t, tm.Mesh, gPlus1)
 
-	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gPlus2).Return(gPlus2).Times(1)
+	tm.mockBeacon.EXPECT().GetBeacon(gPlus2.GetEpoch()).Return(types.RandomBeacon(), nil)
+	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gPlus2).Return(gPlus2)
 	// will try to apply state for gPlus2, gPlus3 and gPlus4
 	// since gPlus2 has been verified, we will apply the lowest order of contextually valid blocks
 	gPlus2Block := sortBlocks(blocks2)[0]
-	tm.mockState.EXPECT().ApplyLayer(context.TODO(), gPlus2Block).Return(nil).Times(1)
-	tm.mockState.EXPECT().ApplyLayer(context.TODO(), blocks3[0]).Return(nil).Times(1)
+	tm.mockState.EXPECT().ApplyLayer(context.TODO(), gPlus2Block).Return(nil)
+	tm.mockState.EXPECT().ApplyLayer(context.TODO(), blocks3[0]).Return(nil)
 	tm.mockState.EXPECT().GetStateRoot().Return(types.Hash32{}, nil).Times(2)
 	err = tm.ProcessLayerPerHareOutput(context.TODO(), gPlus2, blocks2[0].ID())
-	assert.ErrorIs(t, err, errMissingHareOutput)
+	require.ErrorIs(t, err, errMissingHareOutput)
 	got, err = layers.GetHareOutput(tm.cdb, gPlus2)
 	require.NoError(t, err)
-	assert.Equal(t, blocks2[0].ID(), got)
-	assert.Equal(t, gPlus3, tm.ProcessedLayer())
-	assert.Equal(t, gPlus3, tm.LatestLayerInState())
+	require.Equal(t, blocks2[0].ID(), got)
+	require.Equal(t, gPlus3, tm.ProcessedLayer())
+	require.Equal(t, gPlus3, tm.LatestLayerInState())
 	checkLastAppliedInDB(t, tm.Mesh, gPlus3)
 
-	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gPlus4).Return(gPlus4).Times(1)
+	tm.mockBeacon.EXPECT().GetBeacon(gPlus4.GetEpoch()).Return(types.RandomBeacon(), nil)
+	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gPlus4).Return(gPlus4)
 	// will try to apply state for gPlus4 and gPlus5
 	// since gPlus4 has been verified, we will apply the lowest order of contextually valid blocks
 	gPlus4Block := sortBlocks(blocks4)[0]
-	tm.mockState.EXPECT().ApplyLayer(context.TODO(), gPlus4Block).Return(nil).Times(1)
-	tm.mockState.EXPECT().ApplyLayer(context.TODO(), blocks5[0]).Return(nil).Times(1)
+	tm.mockState.EXPECT().ApplyLayer(context.TODO(), gPlus4Block).Return(nil)
+	tm.mockState.EXPECT().ApplyLayer(context.TODO(), blocks5[0]).Return(nil)
 	tm.mockState.EXPECT().GetStateRoot().Return(types.Hash32{}, nil).Times(2)
 	require.NoError(t, tm.ProcessLayerPerHareOutput(context.TODO(), gPlus4, blocks4[0].ID()))
 	got, err = layers.GetHareOutput(tm.cdb, gPlus4)
 	require.NoError(t, err)
-	assert.Equal(t, blocks4[0].ID(), got)
-	assert.Equal(t, gPlus5, tm.ProcessedLayer())
-	assert.Equal(t, gPlus5, tm.LatestLayerInState())
+	require.Equal(t, blocks4[0].ID(), got)
+	require.Equal(t, gPlus5, tm.ProcessedLayer())
+	require.Equal(t, gPlus5, tm.LatestLayerInState())
 	checkLastAppliedInDB(t, tm.Mesh, gPlus5)
 }
 
@@ -369,9 +378,10 @@ func TestMesh_ProcessLayerPerHareOutput_emptyOutput(t *testing.T) {
 	gLyr := types.GetEffectiveGenesis()
 	gPlus1 := gLyr.Add(1)
 	blocks1 := createLayerBlocks(t, tm.Mesh, gPlus1, false)
-	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gPlus1).Return(gLyr).Times(1)
-	tm.mockState.EXPECT().ApplyLayer(context.TODO(), blocks1[0]).Return(nil).Times(1)
-	tm.mockState.EXPECT().GetStateRoot().Return(types.Hash32{}, nil).Times(1)
+	tm.mockBeacon.EXPECT().GetBeacon(gPlus1.GetEpoch()).Return(types.RandomBeacon(), nil)
+	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gPlus1).Return(gLyr)
+	tm.mockState.EXPECT().ApplyLayer(context.TODO(), blocks1[0]).Return(nil)
+	tm.mockState.EXPECT().GetStateRoot().Return(types.Hash32{}, nil)
 	require.NoError(t, tm.ProcessLayerPerHareOutput(context.TODO(), gPlus1, blocks1[0].ID()))
 	hareOutput, err := layers.GetHareOutput(tm.cdb, gPlus1)
 	require.NoError(t, err)
@@ -381,19 +391,36 @@ func TestMesh_ProcessLayerPerHareOutput_emptyOutput(t *testing.T) {
 
 	gPlus2 := gLyr.Add(2)
 	createLayerBlocks(t, tm.Mesh, gPlus2, false)
-	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gPlus2).Return(gPlus1).Times(1)
-	tm.mockState.EXPECT().GetStateRoot().Return(types.Hash32{}, nil).Times(1)
+	tm.mockBeacon.EXPECT().GetBeacon(gPlus2.GetEpoch()).Return(types.RandomBeacon(), nil)
+	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gPlus2).Return(gPlus1)
+	tm.mockState.EXPECT().GetStateRoot().Return(types.Hash32{}, nil)
 	require.NoError(t, tm.ProcessLayerPerHareOutput(context.TODO(), gPlus2, types.EmptyBlockID))
 
 	// hare output saved
 	hareOutput, err = layers.GetHareOutput(tm.cdb, gPlus2)
 	require.NoError(t, err)
-	assert.Equal(t, types.EmptyBlockID, hareOutput)
+	require.Equal(t, types.EmptyBlockID, hareOutput)
 
 	// but processed layer has advanced
-	assert.Equal(t, gPlus2, tm.ProcessedLayer())
-	assert.Equal(t, gPlus2, tm.LatestLayerInState())
+	require.Equal(t, gPlus2, tm.ProcessedLayer())
+	require.Equal(t, gPlus2, tm.LatestLayerInState())
 	checkLastAppliedInDB(t, tm.Mesh, gPlus2)
+}
+
+func TestMesh_ProcessLayer_NoBeacon(t *testing.T) {
+	tm := createTestMesh(t)
+	gLyr := types.GetEffectiveGenesis()
+	lyr := gLyr.Add(1)
+	errUnknown := errors.New("unknown")
+	tm.mockBeacon.EXPECT().GetBeacon(lyr.GetEpoch()).Return(types.EmptyBeacon, errUnknown)
+	tm.mockTortoise.EXPECT().LatestComplete().Return(gLyr)
+	tm.mockState.EXPECT().GetStateRoot().Return(types.Hash32{}, nil)
+	require.NoError(t, tm.ProcessLayerPerHareOutput(context.TODO(), lyr, types.EmptyBlockID))
+	got, err := layers.GetHareOutput(tm.cdb, lyr)
+	require.NoError(t, err)
+	require.Equal(t, types.EmptyBlockID, got)
+	require.Equal(t, lyr, tm.ProcessedLayer())
+	checkLastAppliedInDB(t, tm.Mesh, lyr)
 }
 
 func TestMesh_Revert(t *testing.T) {
@@ -419,9 +446,10 @@ func TestMesh_Revert(t *testing.T) {
 
 	for i := gPlus1; i.Before(gPlus4); i = i.Add(1) {
 		hareOutput := layerBlocks[i]
-		tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), i).Return(i.Sub(1)).Times(1)
-		tm.mockState.EXPECT().ApplyLayer(context.TODO(), hareOutput).Return(nil).Times(1)
-		tm.mockState.EXPECT().GetStateRoot().Return(types.Hash32{}, nil).Times(1)
+		tm.mockBeacon.EXPECT().GetBeacon(i.GetEpoch()).Return(types.RandomBeacon(), nil)
+		tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), i).Return(i.Sub(1))
+		tm.mockState.EXPECT().ApplyLayer(context.TODO(), hareOutput).Return(nil)
+		tm.mockState.EXPECT().GetStateRoot().Return(types.Hash32{}, nil)
 		require.NoError(t, tm.ProcessLayerPerHareOutput(context.TODO(), i, hareOutput.ID()))
 	}
 	require.Equal(t, gPlus3, tm.ProcessedLayer())
@@ -441,12 +469,13 @@ func TestMesh_Revert(t *testing.T) {
 		require.NoError(t, tm.UpdateBlockValidity(blk.ID(), lyr, true))
 	}
 
-	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gPlus4).Return(gPlus3).Times(1)
+	tm.mockBeacon.EXPECT().GetBeacon(gPlus4.GetEpoch()).Return(types.RandomBeacon(), nil)
+	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gPlus4).Return(gPlus3)
 	tm.mockState.EXPECT().RevertState(gPlus1).Return(types.Hash32{}, nil)
 	for i := gPlus2; !i.After(gPlus4); i = i.Add(1) {
 		hareOutput := layerBlocks[i]
-		tm.mockState.EXPECT().ApplyLayer(context.TODO(), hareOutput).Return(nil).Times(1)
-		tm.mockState.EXPECT().GetStateRoot().Return(types.Hash32{}, nil).Times(1)
+		tm.mockState.EXPECT().ApplyLayer(context.TODO(), hareOutput).Return(nil)
+		tm.mockState.EXPECT().GetStateRoot().Return(types.Hash32{}, nil)
 	}
 	require.NoError(t, tm.ProcessLayerPerHareOutput(context.TODO(), gPlus4, blocks4[0].ID()))
 	require.Equal(t, gPlus4, tm.ProcessedLayer())
@@ -464,9 +493,10 @@ func TestMesh_Revert(t *testing.T) {
 	require.Equal(t, types.CalcBlocksHash32(types.ToBlockIDs(sortBlocks(blocks2[1:])), nil), h)
 
 	// another new layer won't cause a revert
-	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gPlus5).Return(gPlus4).Times(1)
-	tm.mockState.EXPECT().ApplyLayer(context.TODO(), blocks5[0]).Return(nil).Times(1)
-	tm.mockState.EXPECT().GetStateRoot().Return(types.Hash32{}, nil).Times(1)
+	tm.mockBeacon.EXPECT().GetBeacon(gPlus5.GetEpoch()).Return(types.RandomBeacon(), nil)
+	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), gPlus5).Return(gPlus4)
+	tm.mockState.EXPECT().ApplyLayer(context.TODO(), blocks5[0]).Return(nil)
+	tm.mockState.EXPECT().GetStateRoot().Return(types.Hash32{}, nil)
 	require.NoError(t, tm.ProcessLayerPerHareOutput(context.TODO(), gPlus5, blocks5[0].ID()))
 	require.Equal(t, gPlus5, tm.ProcessedLayer())
 	require.Equal(t, gPlus5, tm.LatestLayerInState())
@@ -484,7 +514,7 @@ func TestMesh_LatestKnownLayer(t *testing.T) {
 	tm.setLatestLayer(lg, types.NewLayerID(10))
 	tm.setLatestLayer(lg, types.NewLayerID(1))
 	tm.setLatestLayer(lg, types.NewLayerID(2))
-	assert.Equal(t, types.NewLayerID(10), tm.LatestLayer(), "wrong layer")
+	require.Equal(t, types.NewLayerID(10), tm.LatestLayer(), "wrong layer")
 }
 
 func TestMesh_pushLayersToState_verified(t *testing.T) {
@@ -506,8 +536,8 @@ func TestMesh_pushLayersToState_verified(t *testing.T) {
 	valids := []*types.Block{block1, block2}
 	sortBlocks(valids)
 	toApply := valids[0]
-	tm.mockState.EXPECT().ApplyLayer(context.TODO(), toApply).Return(nil).Times(1)
-	tm.mockState.EXPECT().GetStateRoot().Return(types.Hash32{}, nil).Times(1)
+	tm.mockState.EXPECT().ApplyLayer(context.TODO(), toApply).Return(nil)
+	tm.mockState.EXPECT().GetStateRoot().Return(types.Hash32{}, nil)
 	require.NoError(t, tm.pushLayersToState(context.TODO(), layerID, layerID, layerID))
 	checkLastAppliedInDB(t, tm.Mesh, layerID)
 }
@@ -569,8 +599,8 @@ func TestMesh_pushLayersToState_notVerified(t *testing.T) {
 	hareOutput := addBlockWithTXsToMesh(t, tm, layerID, true, txIDs[4:])
 	require.NoError(t, layers.SetHareOutput(tm.cdb, layerID, hareOutput.ID()))
 
-	tm.mockState.EXPECT().ApplyLayer(context.TODO(), hareOutput).Return(nil).Times(1)
-	tm.mockState.EXPECT().GetStateRoot().Return(types.Hash32{}, nil).Times(1)
+	tm.mockState.EXPECT().ApplyLayer(context.TODO(), hareOutput).Return(nil)
+	tm.mockState.EXPECT().GetStateRoot().Return(types.Hash32{}, nil)
 	require.NoError(t, tm.pushLayersToState(context.TODO(), layerID, layerID, layerID.Sub(1)))
 	checkLastAppliedInDB(t, tm.Mesh, layerID)
 }
@@ -578,7 +608,7 @@ func TestMesh_pushLayersToState_notVerified(t *testing.T) {
 func addBlockWithTXsToMesh(t *testing.T, tm *testMesh, id types.LayerID, valid bool, txIDs []types.TransactionID) *types.Block {
 	t.Helper()
 	b := types.GenLayerBlock(id, txIDs)
-	tm.mockState.EXPECT().LinkTXsWithBlock(id, b.ID(), b.TxIDs).Times(1)
+	tm.mockState.EXPECT().LinkTXsWithBlock(id, b.ID(), b.TxIDs)
 	require.NoError(t, tm.Mesh.AddBlockWithTXs(context.TODO(), b))
 	require.NoError(t, tm.Mesh.saveContextualValidity(b.ID(), id, valid))
 	return b
@@ -590,7 +620,7 @@ func TestMesh_AddTXsFromProposal(t *testing.T) {
 	layerID := types.GetEffectiveGenesis().Add(1)
 	pid := types.RandomProposalID()
 	txIDs := types.RandomTXSet(numTXs)
-	tm.mockState.EXPECT().LinkTXsWithProposal(layerID, pid, txIDs).Return(nil).Times(1)
+	tm.mockState.EXPECT().LinkTXsWithProposal(layerID, pid, txIDs).Return(nil)
 	r.NoError(tm.AddTXsFromProposal(context.TODO(), layerID, pid, txIDs))
 }
 
@@ -603,7 +633,7 @@ func TestMesh_AddBlockWithTXs(t *testing.T) {
 	txIDs := types.RandomTXSet(numTXs)
 	layerID := types.GetEffectiveGenesis().Add(1)
 	block := types.GenLayerBlock(layerID, txIDs)
-	tm.mockState.EXPECT().LinkTXsWithBlock(layerID, block.ID(), txIDs).Return(nil).Times(1)
+	tm.mockState.EXPECT().LinkTXsWithBlock(layerID, block.ID(), txIDs).Return(nil)
 	r.NoError(tm.AddBlockWithTXs(context.TODO(), block))
 }
 
@@ -615,6 +645,7 @@ func TestMesh_ReverifyFailed(t *testing.T) {
 
 	for lid := genesis.Add(1); !lid.After(last); lid = lid.Add(1) {
 		require.NoError(t, layers.SetHareOutput(tm.cdb, lid, types.EmptyBlockID))
+		tm.mockBeacon.EXPECT().GetBeacon(lid.GetEpoch()).Return(types.RandomBeacon(), nil)
 		tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), lid).Return(lid.Sub(1))
 		tm.mockState.EXPECT().GetStateRoot()
 		require.NoError(t, tm.ProcessLayer(ctx, lid))
@@ -625,6 +656,7 @@ func TestMesh_ReverifyFailed(t *testing.T) {
 	checkLastAppliedInDB(t, tm.Mesh, last)
 
 	last = last.Add(1)
+	tm.mockBeacon.EXPECT().GetBeacon(last.GetEpoch()).Return(types.RandomBeacon(), nil)
 	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), last).Return(last.Sub(1))
 
 	block := types.NewExistingBlock(types.BlockID{1},
@@ -644,6 +676,7 @@ func TestMesh_ReverifyFailed(t *testing.T) {
 	tm.mockState.EXPECT().ApplyLayer(context.TODO(), block).Return(nil)
 	require.NoError(t, layers.SetHareOutput(tm.cdb, last, types.EmptyBlockID))
 	for lid := last.Sub(1); !lid.After(last); lid = lid.Add(1) {
+		tm.mockBeacon.EXPECT().GetBeacon(lid.GetEpoch()).Return(types.RandomBeacon(), nil)
 		tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), lid).Return(last.Sub(1))
 		tm.mockState.EXPECT().GetStateRoot()
 		require.NoError(t, tm.ProcessLayer(ctx, lid))
@@ -666,6 +699,7 @@ func TestMesh_MissingTransactionsFailure(t *testing.T) {
 	require.NoError(t, blocks.Add(tm.cdb, block))
 	require.NoError(t, layers.SetHareOutput(tm.cdb, last, block.ID()))
 
+	tm.mockBeacon.EXPECT().GetBeacon(last.GetEpoch()).Return(types.RandomBeacon(), nil)
 	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), last).Return(last.Sub(1))
 	errTXMissing := errors.New("tx missing")
 	tm.mockState.EXPECT().ApplyLayer(context.TODO(), block).Return(errTXMissing)
@@ -685,6 +719,7 @@ func TestMesh_NoPanicOnIncorrectVerified(t *testing.T) {
 
 	for lid := genesis.Add(1); !lid.After(last); lid = lid.Add(1) {
 		require.NoError(t, layers.SetHareOutput(tm.cdb, lid, types.EmptyBlockID))
+		tm.mockBeacon.EXPECT().GetBeacon(lid.GetEpoch()).Return(types.RandomBeacon(), nil)
 		tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), lid).Return(lid.Sub(1))
 		tm.mockState.EXPECT().GetStateRoot()
 		require.NoError(t, tm.ProcessLayer(ctx, lid))
@@ -692,11 +727,13 @@ func TestMesh_NoPanicOnIncorrectVerified(t *testing.T) {
 	require.Equal(t, last, tm.LatestLayerInState())
 
 	require.NoError(t, layers.SetHareOutput(tm.cdb, last.Add(1), types.EmptyBlockID))
+	tm.mockBeacon.EXPECT().GetBeacon(last.Add(1).GetEpoch()).Return(types.RandomBeacon(), nil)
 	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), last.Add(1)).Return(tm.LatestLayerInState().Sub(1))
 	tm.mockState.EXPECT().GetStateRoot()
 	require.NoError(t, tm.ProcessLayer(ctx, last.Add(1)))
 	require.Equal(t, last.Add(1), tm.LatestLayerInState())
 
+	tm.mockBeacon.EXPECT().GetBeacon(last.Add(2).GetEpoch()).Return(types.RandomBeacon(), nil)
 	tm.mockTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), last.Add(2)).Return(last.Add(1))
 	require.ErrorIs(t, tm.ProcessLayer(ctx, last.Add(2)), errMissingHareOutput)
 	require.Equal(t, last.Add(1), tm.LatestLayerInState())
@@ -709,7 +746,7 @@ func TestMesh_CallOnBlock(t *testing.T) {
 	block.Initialize()
 
 	tm.mockTortoise.EXPECT().OnBlock(&block)
-	tm.mockState.EXPECT().LinkTXsWithBlock(block.LayerIndex, block.ID(), block.TxIDs).Times(1)
+	tm.mockState.EXPECT().LinkTXsWithBlock(block.LayerIndex, block.ID(), block.TxIDs)
 	require.NoError(t, tm.AddBlockWithTXs(context.TODO(), &block))
 }
 

--- a/mesh/mocks/mocks.go
+++ b/mesh/mocks/mocks.go
@@ -144,6 +144,20 @@ func (mr *MocktortoiseMockRecorder) HandleIncomingLayer(arg0, arg1 interface{}) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleIncomingLayer", reflect.TypeOf((*Mocktortoise)(nil).HandleIncomingLayer), arg0, arg1)
 }
 
+// LatestComplete mocks base method.
+func (m *Mocktortoise) LatestComplete() types.LayerID {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LatestComplete")
+	ret0, _ := ret[0].(types.LayerID)
+	return ret0
+}
+
+// LatestComplete indicates an expected call of LatestComplete.
+func (mr *MocktortoiseMockRecorder) LatestComplete() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LatestComplete", reflect.TypeOf((*Mocktortoise)(nil).LatestComplete))
+}
+
 // OnBallot mocks base method.
 func (m *Mocktortoise) OnBallot(arg0 *types.Ballot) {
 	m.ctrl.T.Helper()

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -327,7 +327,7 @@ func (s *Syncer) synchronize(ctx context.Context) bool {
 			for epoch := s.getLastSyncedATXs() + 1; epoch <= s.ticker.GetCurrentLayer().GetEpoch(); epoch++ {
 				logger.With().Info("syncing atxs for epoch", epoch)
 				if err := s.fetcher.GetEpochATXs(ctx, epoch); err != nil {
-					s.logger.WithContext(ctx).With().Error("failed to fetch epoch atxs", epoch, log.Err(err))
+					logger.With().Error("failed to fetch epoch atxs", epoch, log.Err(err))
 					return false
 				}
 				s.setLastSyncedATXs(epoch)
@@ -342,11 +342,6 @@ func (s *Syncer) synchronize(ctx context.Context) bool {
 				logger.With().Warning("failed to fetch missing layer", missing, log.Err(err))
 				return false
 			}
-		}
-		// no need to sync a layer that's already processed (advanced by the hare)
-		processed := s.mesh.ProcessedLayer()
-		if s.getLastSyncedLayer().Before(processed) {
-			s.setLastSyncedLayer(processed)
 		}
 		// always sync to currentLayer-1 to reduce race with gossip and hare/tortoise
 		for layerID := s.getLastSyncedLayer().Add(1); layerID.Before(s.ticker.GetCurrentLayer()); layerID = layerID.Add(1) {

--- a/syncer/syncer_test.go
+++ b/syncer/syncer_test.go
@@ -466,43 +466,6 @@ func waitOutGossipSync(t *testing.T, current types.LayerID, ts *testSyncer) {
 	require.True(t, ts.syncer.IsSynced(context.TODO()))
 }
 
-func TestForceSync(t *testing.T) {
-	ts := newSyncerWithoutSyncTimer(t)
-	syncedCh := make(chan struct{})
-	ts.syncer.RegisterChForSynced(context.TODO(), syncedCh)
-	require.False(t, ts.syncer.ListenToATXGossip())
-	require.False(t, ts.syncer.ListenToGossip())
-	require.False(t, ts.syncer.IsSynced(context.TODO()))
-	ts.syncer.Start(context.TODO())
-	t.Cleanup(func() {
-		ts.syncer.Close()
-	})
-	ts.syncer.ForceSync(context.TODO())
-	<-syncedCh
-	require.True(t, ts.syncer.dataSynced())
-	require.True(t, ts.syncer.ListenToATXGossip())
-	require.True(t, ts.syncer.ListenToGossip())
-	require.True(t, ts.syncer.IsSynced(context.TODO()))
-}
-
-func TestMultipleForceSync(t *testing.T) {
-	ts := newSyncerWithoutSyncTimer(t)
-	require.False(t, ts.syncer.ListenToGossip())
-	require.False(t, ts.syncer.IsSynced(context.TODO()))
-	lyr := types.NewLayerID(1)
-	ts.mTicker.advanceToLayer(lyr)
-	ts.syncer.Start(context.TODO())
-
-	require.True(t, true, ts.syncer.ForceSync(context.TODO()))
-	require.False(t, false, ts.syncer.ForceSync(context.TODO()))
-
-	// allow synchronize to finish
-	ts.syncer.Close()
-
-	// node already shutdown
-	require.False(t, false, ts.syncer.ForceSync(context.TODO()))
-}
-
 func TestSyncMissingLayer(t *testing.T) {
 	ts := newTestSyncer(context.TODO(), t, never, false)
 	genesis := types.GetEffectiveGenesis()


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
Closes #3440
<!-- `Closes #XXXX, closes #XXXX, ...` links mentioned issues to this PR and automatically closes them when this it's merged -->

## Changes
<!-- Please describe in detail the changes made -->
- as a true backup mechanism, syncer should sync every layer from peers even when there is hare output
- remove fetching restrictions on layers higher than processed layer so that the network can make progress when there are no proposals/ballots/blocks in the network
- move the beacon check from syncer to mesh so that processed layer can advance
- removed some unused code

this is tested by 
- bringing up a cluster in GCP
- delete poet pod
- observe the network still advance with processed layer and apply empty layer when there are no data in the network. only tortoise verified layer and vm applied layer are stuck.