### PR TITLE
[Merged by Bors] - give more time for smesher to submit a challenge

### DIFF
--- a/systest/cluster/cluster.go
+++ b/systest/cluster/cluster.go
@@ -102,8 +102,8 @@ func New(cctx *testcontext.Context, opts ...Opt) *Cluster {
 	// NOTE(dshulyak) epoch duration needs to be in sync with go-spacemesh
 	// configuration. consider to move epoch configuration from preset to systest
 	cluster.addPoetFlag(EpochDuration(60 * time.Second))
-	cluster.addPoetFlag(CycleGap(2 * time.Second))
-	cluster.addPoetFlag(PhaseShift(2 * time.Second))
+	cluster.addPoetFlag(CycleGap(10 * time.Second))
+	cluster.addPoetFlag(PhaseShift(20 * time.Second))
 
 	for _, opt := range opts {
 		opt(cluster)


### PR DESCRIPTION
turns out 2s is not enough for smeshers to submit challenge on the ci.

in one of the failures (namespace="test-pbsy")

on time smesher-42-0:
```json
{"L":"INFO","T":"2022-08-18T07:38:06.153-0400","N":"e9ba7.nipostBuilder","M":"challenge submitted to poet proving service (poet id: 96c1b31bd2e32116ef0cff902974f51ca6436ca6ea2718322cc870d0ce869eae, round id: 3, challenge: 5bcda3179900fedcbb2a259ef9dedfdee8339f5f8e473a46b83a34f0dfc1492c)","node_id":"e9ba702543f80f2038c922ebd0f1a7153292cfccd436406383b9ff1509f10f53","module":"nipostBuilder"}
```

too late on time smesher-43-0::
```json
{"L":"INFO","T":"2022-08-18T07:38:08.601-0400","N":"a652d.nipostBuilder","M":"challenge submitted to poet proving service (poet id: 96c1b31bd2e32116ef0cff902974f51ca6436ca6ea2718322cc870d0ce869eae, round id: 4, challenge: 35b5983dc4b710023ba20b00b08dc177fff878274f0446aaabc35bcd2f20b2e9)","node_id":"a652d085a3e127e417c60ae9f9f8696f8dfc647b180a9a96d2948063daae28e1","module":"nipostBuilder"}
```
