### PR TITLE
[Merged by Bors] - Added wait to systests cleaning process

### DIFF
--- a/systest/Makefile
+++ b/systest/Makefile
@@ -41,10 +41,13 @@ run:
 clean:
 	@echo "deleting test pods with testid=$(test_id)"
 	@kubectl delete pod --selector=testid=$(test_id)
+	@kubectl wait --for delete pod --selector=testid=$(test_id)
 	@echo "deleting ephemeral namespaces with testid=$(test_id)"
 	@kubectl delete ns --selector=testid=$(test_id),keep=false
+	@kubectl wait --timeout=60s --for delete namespace --selector=testid=$(test_id),keep=false
 
 .PHONY: cleanall
 cleanall: clean
 	@echo "deleting all namespaces with testid=$(test_id)"
 	@kubectl delete ns --selector=testid=$(test_id)
+	@kubectl wait --timeout=60s --for delete namespace --selector=testid=$(test_id)


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
<!-- `Closes #XXXX, closes #XXXX, ...` links mentioned issues to this PR and automatically closes them when this it's merged -->

It was reported today that sometimes we have flaky systests because of resource intensive items that are not yet cleaned.

That should address that issue.

## Changes
<!-- Please describe in detail the changes made -->

Added kubectl wait after ns and pod deletions.

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
