### PR TITLE
[Merged by Bors] - tortoise: ensure that blocks and ballots are processed after ref height was computed

### DIFF
--- a/tortoise/full.go
+++ b/tortoise/full.go
@@ -171,7 +171,8 @@ func (f *full) verify(logger log.Log, lid types.LayerID) bool {
 		return false
 	}
 	isEmpty := empty.Cmp(f.globalThreshold) > 0
-	if len(f.blocks) == 0 {
+	blocks := f.blocks[lid]
+	if len(blocks) == 0 {
 		if isEmpty {
 			logger.With().Info("candidate layer is empty")
 		}
@@ -179,7 +180,7 @@ func (f *full) verify(logger log.Log, lid types.LayerID) bool {
 	}
 	return verifyLayer(
 		logger,
-		f.blocks[lid],
+		blocks,
 		f.validity,
 		func(block blockInfo) sign {
 			decision := sign(block.weight.Cmp(f.globalThreshold))

--- a/tortoise/sim/votes.go
+++ b/tortoise/sim/votes.go
@@ -27,6 +27,19 @@ func PerfectVoting(rng *rand.Rand, layers []*types.Layer, _ int) Voting {
 	return votes
 }
 
+// ConsistentVoting selects same base ballot for ballot at a specific index.
+func ConsistentVoting(rng *rand.Rand, layers []*types.Layer, i int) Voting {
+	baseLayer := layers[len(layers)-1]
+	ballots := baseLayer.Ballots()
+	base := ballots[i%len(ballots)]
+	votes := Voting{Base: base.ID()}
+	if len(layers[len(layers)-1].BlocksIDs()) > 0 {
+		votes.Support = layers[len(layers)-1].BlocksIDs()[0:1]
+		votes.Against = layers[len(layers)-1].BlocksIDs()[1:]
+	}
+	return votes
+}
+
 // VaryingVoting votes using first generator for ballots before mid, and with second generator after mid.
 func VaryingVoting(mid int, first, second VotesGenerator) VotesGenerator {
 	return func(rng *rand.Rand, layers []*types.Layer, i int) Voting {

--- a/tortoise/tortoise.go
+++ b/tortoise/tortoise.go
@@ -757,6 +757,10 @@ func (t *turtle) onBallot(ballot *types.Ballot) error {
 	if !ballot.LayerIndex.After(t.evicted) {
 		return nil
 	}
+	if _, exist := t.referenceHeight[ballot.LayerIndex.GetEpoch()]; !exist {
+		t.logger.With().Info("ballot was submitted before computing reference height", ballot.ID(), ballot.LayerIndex)
+		return nil
+	}
 	if _, exist := t.ballotLayer[ballot.ID()]; exist {
 		return nil
 	}

--- a/tortoise/tortoise.go
+++ b/tortoise/tortoise.go
@@ -484,10 +484,10 @@ func (t *turtle) onLayerTerminated(ctx context.Context, lid types.LayerID) error
 	if err := t.updateLayer(t.logger, lid); err != nil {
 		return err
 	}
-	if err := t.loadConsensusData(lid); err != nil {
-		return err
-	}
 	for process := t.minprocessed.Add(1); !process.After(t.processed); process = process.Add(1) {
+		if err := t.loadBlocksData(process); err != nil {
+			return err
+		}
 		if isUndecided(t.Config, t.decided, process, t.last) {
 			t.logger.With().Info("gap in the layers received by tortoise", log.Stringer("undecided", process))
 			return nil
@@ -515,6 +515,7 @@ func (t *turtle) processLayer(logger log.Log, lid types.LayerID) error {
 	logger = logger.WithFields(
 		log.Stringer("last_layer", t.last),
 	)
+	logger.With().Debug("processing layer", lid)
 	if err := t.loadBallots(logger, lid); err != nil {
 		return err
 	}
@@ -621,7 +622,8 @@ func (t *turtle) getTortoiseBallots(lid types.LayerID) []tortoiseBallot {
 	return tballots
 }
 
-func (t *turtle) loadConsensusData(lid types.LayerID) error {
+// loadBlocksData loads blocks, hare output and contextual validity
+func (t *turtle) loadBlocksData(lid types.LayerID) error {
 	blocks, err := blocks.Layer(t.cdb, lid)
 	if err != nil {
 		return fmt.Errorf("read blocks for layer %s: %w", lid, err)
@@ -721,6 +723,7 @@ func (t *turtle) onBlock(lid types.LayerID, block *types.Block) {
 	if !lid.After(t.evicted) {
 		return
 	}
+	t.logger.With().Debug("on block", log.Inline(block))
 	if _, exist := t.referenceHeight[lid.GetEpoch()]; !exist {
 		// TODO(dshulyak) reference height is computed when first layer in the epoch
 		// is sent to the onLayerTerminated. after that we will load blocks from that layer.
@@ -746,6 +749,7 @@ func (t *turtle) onHareOutput(lid types.LayerID, bid types.BlockID) {
 	if !lid.After(t.evicted) {
 		return
 	}
+	t.logger.With().Debug("on hare output", lid, bid, log.Bool("empty", bid == types.EmptyBlockID))
 	t.decided[lid] = struct{}{}
 	if bid != types.EmptyBlockID {
 		t.hareOutput[bid] = support

--- a/tortoise/tortoise.go
+++ b/tortoise/tortoise.go
@@ -622,7 +622,7 @@ func (t *turtle) getTortoiseBallots(lid types.LayerID) []tortoiseBallot {
 	return tballots
 }
 
-// loadBlocksData loads blocks, hare output and contextual validity
+// loadBlocksData loads blocks, hare output and contextual validity.
 func (t *turtle) loadBlocksData(lid types.LayerID) error {
 	blocks, err := blocks.Layer(t.cdb, lid)
 	if err != nil {

--- a/tortoise/tortoise.go
+++ b/tortoise/tortoise.go
@@ -725,7 +725,7 @@ func (t *turtle) onBlock(lid types.LayerID, block *types.Block) {
 		// TODO(dshulyak) reference height is computed when first layer in the epoch
 		// is sent to the onLayerTerminated. after that we will load blocks from that layer.
 		// this warning is expected if block was sent to onBlock before the first event
-		t.logger.With().Info("block was submitted before computing reference height", block.ID(), lid)
+		t.logger.With().Debug("block was submitted before computing reference height", block.ID(), lid)
 		return
 	}
 	if _, exist := t.blockLayer[block.ID()]; exist {
@@ -758,7 +758,7 @@ func (t *turtle) onBallot(ballot *types.Ballot) error {
 		return nil
 	}
 	if _, exist := t.referenceHeight[ballot.LayerIndex.GetEpoch()]; !exist {
-		t.logger.With().Info("ballot was submitted before computing reference height", ballot.ID(), ballot.LayerIndex)
+		t.logger.With().Debug("ballot was submitted before computing reference height", ballot.ID(), ballot.LayerIndex)
 		return nil
 	}
 	if _, exist := t.ballotLayer[ballot.ID()]; exist {

--- a/tortoise/tortoise_test.go
+++ b/tortoise/tortoise_test.go
@@ -438,8 +438,9 @@ func TestEncodeAbstainVotesDelayedHare(t *testing.T) {
 		verified types.LayerID
 	)
 	for _, lid := range sim.GenLayers(s,
-		sim.WithSequence(1),
-		sim.WithSequence(1, sim.WithNextReorder(1)),
+		sim.WithSequence(1, sim.WithNumBlocks(1)),
+		sim.WithSequence(1, sim.WithNumBlocks(1), sim.WithoutHareOutput()),
+		sim.WithSequence(1, sim.WithNumBlocks(1)),
 	) {
 		last = lid
 		verified = tortoise.HandleIncomingLayer(ctx, lid)

--- a/tortoise/tortoise_test.go
+++ b/tortoise/tortoise_test.go
@@ -2776,7 +2776,7 @@ func TestFutureHeight(t *testing.T) {
 		)
 		var last, verified types.LayerID
 		for i := 0; i < int(cfg.Hdist); i++ {
-			last = s.Next(sim.WithNumBlocks(1), sim.WithBlockTickHeights(slow+1))
+			last = s.Next(sim.WithNumBlocks(1), sim.WithBlockTickHeights(slow+1), sim.WithVoteGenerator(sim.ConsistentVoting))
 			verified = tortoise.HandleIncomingLayer(context.Background(), last)
 		}
 		require.Equal(t, last.Sub(2), verified)


### PR DESCRIPTION
reference height is computed when the first layer of the epoch is terminated
before that all ballots and blocks that are passed to OnBlock/OnBallot should be ignored, 
processing them will lead to inconsistent state. namely ballots wont have votes for all blocks in the previous layers 

if there a gap in the layer that were sent to tortoise (due to the failed hare), tortoise waits only for zdist until moving on.
once it decided to move on it will download all relevant data (blocks and ballots) after ref height was computed.