### PR TITLE
[Merged by Bors] - certifier: accept early certify message

### DIFF
--- a/blocks/certifier_test.go
+++ b/blocks/certifier_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/sql"
 	"github.com/spacemeshos/go-spacemesh/sql/blocks"
 	"github.com/spacemeshos/go-spacemesh/sql/layers"
+	smocks "github.com/spacemeshos/go-spacemesh/system/mocks"
 )
 
 const defaultCnt = uint16(2)
@@ -33,10 +34,12 @@ type testCertifier struct {
 	mOracle *hmocks.MockRolacle
 	mPub    *pubsubmock.MockPublisher
 	mClk    *mocks.MocklayerClock
+	mb      *smocks.MockBeaconGetter
 }
 
 func newTestCertifier(t *testing.T) *testCertifier {
 	t.Helper()
+	types.SetLayersPerEpoch(3)
 	db := sql.InMemory()
 	signer := signing.NewEdSigner()
 	nid := types.BytesToNodeID(signer.PublicKey().Bytes())
@@ -44,7 +47,8 @@ func newTestCertifier(t *testing.T) *testCertifier {
 	mo := hmocks.NewMockRolacle(ctrl)
 	mp := pubsubmock.NewMockPublisher(ctrl)
 	mc := mocks.NewMocklayerClock(ctrl)
-	c := NewCertifier(db, mo, nid, signer, mp, mc, WithCertifierLogger(logtest.New(t)))
+	mb := smocks.NewMockBeaconGetter(ctrl)
+	c := NewCertifier(db, mo, nid, signer, mp, mc, mb, WithCertifierLogger(logtest.New(t)))
 	return &testCertifier{
 		Certifier: c,
 		db:        db,
@@ -52,6 +56,7 @@ func newTestCertifier(t *testing.T) *testCertifier {
 		mOracle:   mo,
 		mPub:      mp,
 		mClk:      mc,
+		mb:        mb,
 	}
 }
 
@@ -112,34 +117,151 @@ func TestStartStop(t *testing.T) {
 	tc.Stop()
 }
 
+func Test_HandleSyncedCertificate(t *testing.T) {
+	tc := newTestCertifier(t)
+	numMsgs := tc.cfg.CertifyThreshold / int(defaultCnt)
+	b := generateBlock(t, tc.db)
+	require.NoError(t, tc.RegisterDeadline(context.TODO(), b.LayerIndex, b.ID(), time.Now()))
+	sigs := make([]types.CertifyMessage, numMsgs)
+	for i := 0; i < numMsgs; i++ {
+		nid, msg, _ := genEncodedMsg(t, b.LayerIndex, b.ID())
+		tc.mOracle.EXPECT().Validate(gomock.Any(), b.LayerIndex, eligibility.CertifyRound, tc.cfg.CommitteeSize, nid, msg.Proof, defaultCnt).
+			Return(true, nil)
+		sigs[i] = *msg
+	}
+	cert := &types.Certificate{
+		BlockID:    b.ID(),
+		Signatures: sigs,
+	}
+	require.NoError(t, tc.HandleSyncedCertificate(context.TODO(), b.LayerIndex, cert))
+	verifiedSaved(t, tc.db, b.LayerIndex, b.ID(), numMsgs)
+}
+
+func Test_HandleSyncedCertificate_NotEnoughEligibility(t *testing.T) {
+	tc := newTestCertifier(t)
+	numMsgs := tc.cfg.CertifyThreshold/int(defaultCnt) - 1
+	b := generateBlock(t, tc.db)
+	require.NoError(t, tc.RegisterDeadline(context.TODO(), b.LayerIndex, b.ID(), time.Now()))
+	sigs := make([]types.CertifyMessage, numMsgs)
+	for i := 0; i < numMsgs; i++ {
+		nid, msg, _ := genEncodedMsg(t, b.LayerIndex, b.ID())
+		tc.mOracle.EXPECT().Validate(gomock.Any(), b.LayerIndex, eligibility.CertifyRound, tc.cfg.CommitteeSize, nid, msg.Proof, defaultCnt).
+			Return(true, nil)
+		sigs[i] = *msg
+	}
+	cert := &types.Certificate{
+		BlockID:    b.ID(),
+		Signatures: sigs,
+	}
+	require.ErrorIs(t, tc.HandleSyncedCertificate(context.TODO(), b.LayerIndex, cert), errInvalidCert)
+}
+
 func Test_HandleCertifyMessage(t *testing.T) {
 	tc := newTestCertifier(t)
 	b := generateBlock(t, tc.db)
 	nid, msg, encoded := genEncodedMsg(t, b.LayerIndex, b.ID())
 
-	tc.RegisterDeadline(b.LayerIndex, b.ID(), time.Now())
+	require.NoError(t, tc.RegisterDeadline(context.TODO(), b.LayerIndex, b.ID(), time.Now()))
+	tc.mb.EXPECT().GetBeacon(b.LayerIndex.GetEpoch()).Return(types.RandomBeacon(), nil)
 	tc.mOracle.EXPECT().Validate(gomock.Any(), b.LayerIndex, eligibility.CertifyRound, tc.cfg.CommitteeSize, nid, msg.Proof, defaultCnt).
 		Return(true, nil)
 	res := tc.HandleCertifyMessage(context.TODO(), "peer", encoded)
 	require.Equal(t, pubsub.ValidationAccept, res)
 }
 
+func waitTillCertified(t *testing.T, tc *testCertifier, current types.LayerID, b *types.Block, numMsgs int) {
+	ch := make(chan struct{}, 1)
+	started := make(chan struct{}, 1)
+	tc.mClk.EXPECT().GetCurrentLayer().Return(current).AnyTimes()
+	tc.mClk.EXPECT().AwaitLayer(gomock.Any()).DoAndReturn(
+		func(got types.LayerID) chan struct{} {
+			if got == current {
+				close(started)
+			}
+			return ch
+		}).AnyTimes()
+	tc.Start()
+	<-started
+	close(ch)
+	var cert *types.Certificate
+	require.Eventually(t, func() bool {
+		cert, _ = layers.GetCert(tc.db, b.LayerIndex)
+		return cert != nil
+	}, 1*time.Second, 1*time.Millisecond)
+	tc.Stop()
+	require.Equal(t, b.ID(), cert.BlockID)
+	require.Len(t, cert.Signatures, numMsgs)
+}
+
 func Test_HandleCertifyMessage_Certified(t *testing.T) {
 	tc := newTestCertifier(t)
-	numMsgs := tc.cfg.CommitteeSize
-	cutoff := tc.cfg.CertifyThreshold / int(defaultCnt)
+	numMsgs := tc.cfg.CertifyThreshold/int(defaultCnt) + 2
 	b := generateBlock(t, tc.db)
-	tc.RegisterDeadline(b.LayerIndex, b.ID(), time.Now())
+	require.NoError(t, tc.RegisterDeadline(context.TODO(), b.LayerIndex, b.ID(), time.Time{}))
 	for i := 0; i < numMsgs; i++ {
 		nid, msg, encoded := genEncodedMsg(t, b.LayerIndex, b.ID())
-		if i < cutoff {
+		tc.mb.EXPECT().GetBeacon(b.LayerIndex.GetEpoch()).Return(types.RandomBeacon(), nil)
+		tc.mOracle.EXPECT().Validate(gomock.Any(), b.LayerIndex, eligibility.CertifyRound, tc.cfg.CommitteeSize, nid, msg.Proof, defaultCnt).
+			Return(true, nil)
+		res := tc.HandleCertifyMessage(context.TODO(), "peer", encoded)
+		require.Equal(t, pubsub.ValidationAccept, res)
+	}
+	waitTillCertified(t, tc, b.LayerIndex, b, numMsgs)
+}
+
+func Test_HandleCertifyMessage_CertifiedWithEarlyMsgs(t *testing.T) {
+	tc := newTestCertifier(t)
+	numMsgs := tc.cfg.CertifyThreshold/int(defaultCnt) + 2
+	b := generateBlock(t, tc.db)
+	current := b.LayerIndex.Sub(1)
+	tc.mClk.EXPECT().GetCurrentLayer().Return(current).AnyTimes()
+	for i := 0; i < numMsgs; i++ {
+		nid, msg, encoded := genEncodedMsg(t, b.LayerIndex, b.ID())
+		tc.mb.EXPECT().GetBeacon(b.LayerIndex.GetEpoch()).Return(types.RandomBeacon(), nil)
+		tc.mOracle.EXPECT().Validate(gomock.Any(), b.LayerIndex, eligibility.CertifyRound, tc.cfg.CommitteeSize, nid, msg.Proof, defaultCnt).
+			Return(true, nil)
+		res := tc.HandleCertifyMessage(context.TODO(), "peer", encoded)
+		require.Equal(t, pubsub.ValidationAccept, res)
+	}
+	require.NoError(t, tc.RegisterDeadline(context.TODO(), b.LayerIndex, b.ID(), time.Time{}))
+	waitTillCertified(t, tc, current, b, numMsgs)
+}
+
+func Test_HandleCertifyMessage_TooManyEarlyMsgs(t *testing.T) {
+	tc := newTestCertifier(t)
+	numMsgs := tc.cfg.CommitteeSize + 1
+	b := generateBlock(t, tc.db)
+	current := b.LayerIndex.Sub(1)
+	tc.mClk.EXPECT().GetCurrentLayer().Return(current).AnyTimes()
+	for i := 0; i < numMsgs; i++ {
+		nid, msg, encoded := genEncodedMsg(t, b.LayerIndex, b.ID())
+		tc.mb.EXPECT().GetBeacon(b.LayerIndex.GetEpoch()).Return(types.RandomBeacon(), nil)
+		if i < tc.cfg.CommitteeSize {
 			tc.mOracle.EXPECT().Validate(gomock.Any(), b.LayerIndex, eligibility.CertifyRound, tc.cfg.CommitteeSize, nid, msg.Proof, defaultCnt).
 				Return(true, nil)
 		}
 		res := tc.HandleCertifyMessage(context.TODO(), "peer", encoded)
-		require.Equal(t, pubsub.ValidationAccept, res)
+		if i < tc.cfg.CommitteeSize {
+			require.Equal(t, pubsub.ValidationAccept, res)
+		} else {
+			// one too many
+			require.Equal(t, pubsub.ValidationIgnore, res)
+		}
 	}
-	verifiedSaved(t, tc.db, b.LayerIndex, b.ID(), cutoff)
+}
+
+func Test_HandleCertifyMessage_MsgsTooEarly(t *testing.T) {
+	tc := newTestCertifier(t)
+	numMsgs := tc.cfg.CommitteeSize
+	b := generateBlock(t, tc.db)
+	current := b.LayerIndex.Sub(tc.cfg.NumLayersToKeep)
+	tc.mClk.EXPECT().GetCurrentLayer().Return(current).AnyTimes()
+	for i := 0; i < numMsgs; i++ {
+		_, _, encoded := genEncodedMsg(t, b.LayerIndex, b.ID())
+		tc.mb.EXPECT().GetBeacon(b.LayerIndex.GetEpoch()).Return(types.RandomBeacon(), nil)
+		res := tc.HandleCertifyMessage(context.TODO(), "peer", encoded)
+		require.Equal(t, pubsub.ValidationIgnore, res)
+	}
 }
 
 func Test_HandleCertifyMessage_Stopped(t *testing.T) {
@@ -165,6 +287,8 @@ func Test_HandleCertifyMessage_LayerNotRegistered(t *testing.T) {
 	b := generateBlock(t, tc.db)
 	_, _, encoded := genEncodedMsg(t, b.LayerIndex, b.ID())
 
+	tc.mb.EXPECT().GetBeacon(b.LayerIndex.GetEpoch()).Return(types.RandomBeacon(), nil)
+	tc.mClk.EXPECT().GetCurrentLayer().Return(b.LayerIndex.Add(1)).AnyTimes()
 	res := tc.HandleCertifyMessage(context.TODO(), "peer", encoded)
 	require.Equal(t, pubsub.ValidationIgnore, res)
 }
@@ -174,17 +298,19 @@ func Test_HandleCertifyMessage_BlockNotRegistered(t *testing.T) {
 	b := generateBlock(t, tc.db)
 	_, msg, encoded := genEncodedMsg(t, b.LayerIndex, b.ID())
 
-	tc.RegisterDeadline(msg.LayerID, types.RandomBlockID(), time.Now())
+	require.NoError(t, tc.RegisterDeadline(context.TODO(), msg.LayerID, types.RandomBlockID(), time.Now()))
+	tc.mb.EXPECT().GetBeacon(b.LayerIndex.GetEpoch()).Return(types.RandomBeacon(), nil)
 	res := tc.HandleCertifyMessage(context.TODO(), "peer", encoded)
 	require.Equal(t, pubsub.ValidationIgnore, res)
 }
 
-func Test_HandleCertifyMessage_TooLate(t *testing.T) {
+func Test_HandleCertifyMessage_BeaconNotAvailable(t *testing.T) {
 	tc := newTestCertifier(t)
 	b := generateBlock(t, tc.db)
-	_, _, encoded := genEncodedMsg(t, b.LayerIndex, b.ID())
+	_, msg, encoded := genEncodedMsg(t, b.LayerIndex, b.ID())
 
-	tc.RegisterDeadline(b.LayerIndex, b.ID(), time.Time{})
+	require.NoError(t, tc.RegisterDeadline(context.TODO(), msg.LayerID, types.RandomBlockID(), time.Now()))
+	tc.mb.EXPECT().GetBeacon(b.LayerIndex.GetEpoch()).Return(types.EmptyBeacon, errors.New("meh"))
 	res := tc.HandleCertifyMessage(context.TODO(), "peer", encoded)
 	require.Equal(t, pubsub.ValidationIgnore, res)
 }
@@ -193,8 +319,8 @@ func Test_OldLayersPruned(t *testing.T) {
 	tc := newTestCertifier(t)
 	lid := types.NewLayerID(11)
 
-	tc.RegisterDeadline(lid, types.RandomBlockID(), time.Now())
-	tc.RegisterDeadline(lid.Add(1), types.RandomBlockID(), time.Now())
+	require.NoError(t, tc.RegisterDeadline(context.TODO(), lid, types.RandomBlockID(), time.Now()))
+	require.NoError(t, tc.RegisterDeadline(context.TODO(), lid.Add(1), types.RandomBlockID(), time.Now()))
 	require.Equal(t, 2, tc.NumCached())
 
 	current := lid.Add(tc.cfg.NumLayersToKeep + 1)
@@ -219,6 +345,7 @@ func Test_OldLayersPruned(t *testing.T) {
 func Test_CertifyIfEligible(t *testing.T) {
 	tc := newTestCertifier(t)
 	b := generateBlock(t, tc.db)
+	tc.mb.EXPECT().GetBeacon(b.LayerIndex.GetEpoch()).Return(types.RandomBeacon(), nil)
 	proof := []byte("not a fraud")
 	tc.mOracle.EXPECT().Proof(gomock.Any(), b.LayerIndex, eligibility.CertifyRound).Return(proof, nil)
 	tc.mOracle.EXPECT().CalcEligibility(gomock.Any(), b.LayerIndex, eligibility.CertifyRound, tc.cfg.CommitteeSize, tc.nodeID, proof).Return(defaultCnt, nil)
@@ -241,6 +368,7 @@ func Test_CertifyIfEligible(t *testing.T) {
 func Test_CertifyIfEligible_NotEligible(t *testing.T) {
 	tc := newTestCertifier(t)
 	b := generateBlock(t, tc.db)
+	tc.mb.EXPECT().GetBeacon(b.LayerIndex.GetEpoch()).Return(types.RandomBeacon(), nil)
 	proof := []byte("not a fraud")
 	tc.mOracle.EXPECT().Proof(gomock.Any(), b.LayerIndex, eligibility.CertifyRound).Return(proof, nil)
 	tc.mOracle.EXPECT().CalcEligibility(gomock.Any(), b.LayerIndex, eligibility.CertifyRound, tc.cfg.CommitteeSize, tc.nodeID, proof).Return(uint16(0), nil)
@@ -250,6 +378,7 @@ func Test_CertifyIfEligible_NotEligible(t *testing.T) {
 func Test_CertifyIfEligible_EligibilityErr(t *testing.T) {
 	tc := newTestCertifier(t)
 	b := generateBlock(t, tc.db)
+	tc.mb.EXPECT().GetBeacon(b.LayerIndex.GetEpoch()).Return(types.RandomBeacon(), nil)
 	errUnknown := errors.New("unknown")
 	proof := []byte("not a fraud")
 	tc.mOracle.EXPECT().Proof(gomock.Any(), b.LayerIndex, eligibility.CertifyRound).Return(proof, nil)
@@ -260,7 +389,15 @@ func Test_CertifyIfEligible_EligibilityErr(t *testing.T) {
 func Test_CertifyIfEligible_ProofErr(t *testing.T) {
 	tc := newTestCertifier(t)
 	b := generateBlock(t, tc.db)
+	tc.mb.EXPECT().GetBeacon(b.LayerIndex.GetEpoch()).Return(types.RandomBeacon(), nil)
 	errUnknown := errors.New("unknown")
 	tc.mOracle.EXPECT().Proof(gomock.Any(), b.LayerIndex, eligibility.CertifyRound).Return(nil, errUnknown)
 	require.ErrorIs(t, tc.CertifyIfEligible(context.TODO(), tc.logger, b.LayerIndex, b.ID()), errUnknown)
+}
+
+func Test_CertifyIfEligible_BeaconNotAvailable(t *testing.T) {
+	tc := newTestCertifier(t)
+	b := generateBlock(t, tc.db)
+	tc.mb.EXPECT().GetBeacon(b.LayerIndex.GetEpoch()).Return(types.EmptyBeacon, errors.New("meh"))
+	require.ErrorIs(t, tc.CertifyIfEligible(context.TODO(), tc.logger, b.LayerIndex, b.ID()), errBeaconNotAvailable)
 }

--- a/blocks/generator.go
+++ b/blocks/generator.go
@@ -190,7 +190,10 @@ func (g *Generator) processHareOutput(out hare.LayerOutput) error {
 		emptyOutputCnt.Inc()
 	}
 
-	g.cert.RegisterDeadline(out.Layer, hareOutput, time.Now())
+	if err := g.cert.RegisterDeadline(ctx, out.Layer, hareOutput, time.Now()); err != nil {
+		logger.With().Warning("failed to register hare output for certifying", log.Err(err))
+	}
+
 	if err := g.cert.CertifyIfEligible(ctx, logger.WithFields(hareOutput), out.Layer, hareOutput); err != nil {
 		logger.With().Warning("failed to certify block", hareOutput, log.Err(err))
 	}

--- a/blocks/generator.go
+++ b/blocks/generator.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"sort"
 	"sync"
-	"time"
 
 	"golang.org/x/sync/errgroup"
 
@@ -190,7 +189,7 @@ func (g *Generator) processHareOutput(out hare.LayerOutput) error {
 		emptyOutputCnt.Inc()
 	}
 
-	if err := g.cert.RegisterDeadline(ctx, out.Layer, hareOutput, time.Now()); err != nil {
+	if err := g.cert.RegisterForCert(ctx, out.Layer, hareOutput); err != nil {
 		logger.With().Warning("failed to register hare output for certifying", log.Err(err))
 	}
 

--- a/blocks/generator_test.go
+++ b/blocks/generator_test.go
@@ -208,8 +208,8 @@ func Test_processHareOutput(t *testing.T) {
 			checkRewards(t, atxes, expWeight, block.Rewards)
 			return nil
 		})
-	tg.mockCert.EXPECT().RegisterDeadline(gomock.Any(), layerID, gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, _ types.LayerID, got types.BlockID, _ time.Time) error {
+	tg.mockCert.EXPECT().RegisterForCert(gomock.Any(), layerID, gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ types.LayerID, got types.BlockID) error {
 			require.Equal(t, block.ID(), got)
 			return nil
 		})
@@ -229,7 +229,7 @@ func Test_processHareOutput(t *testing.T) {
 func Test_processHareOutput_EmptyOutput(t *testing.T) {
 	tg := createTestGenerator(t)
 	layerID := types.GetEffectiveGenesis().Add(100)
-	tg.mockCert.EXPECT().RegisterDeadline(gomock.Any(), layerID, types.EmptyBlockID, gomock.Any()).Return(nil)
+	tg.mockCert.EXPECT().RegisterForCert(gomock.Any(), layerID, types.EmptyBlockID).Return(nil)
 	tg.mockCert.EXPECT().CertifyIfEligible(gomock.Any(), gomock.Any(), layerID, types.EmptyBlockID).Return(nil)
 	tg.mockMesh.EXPECT().ProcessLayerPerHareOutput(gomock.Any(), layerID, types.EmptyBlockID).Return(nil)
 	require.NoError(t, tg.processHareOutput(hare.LayerOutput{Ctx: context.TODO(), Layer: layerID}))
@@ -262,8 +262,8 @@ func Test_processHareOutput_ProcessFailed(t *testing.T) {
 			checkRewards(t, atxes, expWeight, block.Rewards)
 			return nil
 		})
-	tg.mockCert.EXPECT().RegisterDeadline(gomock.Any(), layerID, gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, _ types.LayerID, got types.BlockID, _ time.Time) error {
+	tg.mockCert.EXPECT().RegisterForCert(gomock.Any(), layerID, gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ types.LayerID, got types.BlockID) error {
 			require.Equal(t, block.ID(), got)
 			return nil
 		})

--- a/blocks/generator_test.go
+++ b/blocks/generator_test.go
@@ -208,11 +208,12 @@ func Test_processHareOutput(t *testing.T) {
 			checkRewards(t, atxes, expWeight, block.Rewards)
 			return nil
 		})
-	tg.mockCert.EXPECT().RegisterDeadline(layerID, gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ types.LayerID, got types.BlockID, _ time.Time) {
+	tg.mockCert.EXPECT().RegisterDeadline(gomock.Any(), layerID, gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ types.LayerID, got types.BlockID, _ time.Time) error {
 			require.Equal(t, block.ID(), got)
+			return nil
 		})
-	tg.mockCert.EXPECT().CertifyMaybe(gomock.Any(), gomock.Any(), layerID, gomock.Any()).DoAndReturn(
+	tg.mockCert.EXPECT().CertifyIfEligible(gomock.Any(), gomock.Any(), layerID, gomock.Any()).DoAndReturn(
 		func(_ context.Context, _ log.Log, _ types.LayerID, got types.BlockID) error {
 			require.Equal(t, block.ID(), got)
 			return nil
@@ -228,8 +229,8 @@ func Test_processHareOutput(t *testing.T) {
 func Test_processHareOutput_EmptyOutput(t *testing.T) {
 	tg := createTestGenerator(t)
 	layerID := types.GetEffectiveGenesis().Add(100)
-	tg.mockCert.EXPECT().RegisterDeadline(layerID, types.EmptyBlockID, gomock.Any())
-	tg.mockCert.EXPECT().CertifyMaybe(gomock.Any(), gomock.Any(), layerID, types.EmptyBlockID).Return(nil)
+	tg.mockCert.EXPECT().RegisterDeadline(gomock.Any(), layerID, types.EmptyBlockID, gomock.Any()).Return(nil)
+	tg.mockCert.EXPECT().CertifyIfEligible(gomock.Any(), gomock.Any(), layerID, types.EmptyBlockID).Return(nil)
 	tg.mockMesh.EXPECT().ProcessLayerPerHareOutput(gomock.Any(), layerID, types.EmptyBlockID).Return(nil)
 	require.NoError(t, tg.processHareOutput(hare.LayerOutput{Ctx: context.TODO(), Layer: layerID}))
 }
@@ -261,11 +262,12 @@ func Test_processHareOutput_ProcessFailed(t *testing.T) {
 			checkRewards(t, atxes, expWeight, block.Rewards)
 			return nil
 		})
-	tg.mockCert.EXPECT().RegisterDeadline(layerID, gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ types.LayerID, got types.BlockID, _ time.Time) {
+	tg.mockCert.EXPECT().RegisterDeadline(gomock.Any(), layerID, gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ types.LayerID, got types.BlockID, _ time.Time) error {
 			require.Equal(t, block.ID(), got)
+			return nil
 		})
-	tg.mockCert.EXPECT().CertifyMaybe(gomock.Any(), gomock.Any(), layerID, gomock.Any()).DoAndReturn(
+	tg.mockCert.EXPECT().CertifyIfEligible(gomock.Any(), gomock.Any(), layerID, gomock.Any()).DoAndReturn(
 		func(_ context.Context, _ log.Log, _ types.LayerID, got types.BlockID) error {
 			require.Equal(t, block.ID(), got)
 			return nil

--- a/blocks/interface.go
+++ b/blocks/interface.go
@@ -2,7 +2,6 @@ package blocks
 
 import (
 	"context"
-	"time"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/log"
@@ -25,6 +24,6 @@ type layerClock interface {
 }
 
 type certifier interface {
-	RegisterDeadline(context.Context, types.LayerID, types.BlockID, time.Time) error
+	RegisterForCert(context.Context, types.LayerID, types.BlockID) error
 	CertifyIfEligible(context.Context, log.Log, types.LayerID, types.BlockID) error
 }

--- a/blocks/interface.go
+++ b/blocks/interface.go
@@ -25,6 +25,6 @@ type layerClock interface {
 }
 
 type certifier interface {
-	RegisterDeadline(types.LayerID, types.BlockID, time.Time)
+	RegisterDeadline(context.Context, types.LayerID, types.BlockID, time.Time) error
 	CertifyIfEligible(context.Context, log.Log, types.LayerID, types.BlockID) error
 }

--- a/blocks/mocks/mocks.go
+++ b/blocks/mocks/mocks.go
@@ -177,7 +177,7 @@ func (m *Mockcertifier) EXPECT() *MockcertifierMockRecorder {
 	return m.recorder
 }
 
-// CertifyMaybe mocks base method.
+// CertifyIfEligible mocks base method.
 func (m *Mockcertifier) CertifyIfEligible(arg0 context.Context, arg1 log.Log, arg2 types.LayerID, arg3 types.BlockID) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CertifyIfEligible", arg0, arg1, arg2, arg3)
@@ -185,20 +185,22 @@ func (m *Mockcertifier) CertifyIfEligible(arg0 context.Context, arg1 log.Log, ar
 	return ret0
 }
 
-// CertifyMaybe indicates an expected call of CertifyMaybe.
-func (mr *MockcertifierMockRecorder) CertifyMaybe(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+// CertifyIfEligible indicates an expected call of CertifyIfEligible.
+func (mr *MockcertifierMockRecorder) CertifyIfEligible(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CertifyIfEligible", reflect.TypeOf((*Mockcertifier)(nil).CertifyIfEligible), arg0, arg1, arg2, arg3)
 }
 
 // RegisterDeadline mocks base method.
-func (m *Mockcertifier) RegisterDeadline(arg0 types.LayerID, arg1 types.BlockID, arg2 time.Time) {
+func (m *Mockcertifier) RegisterDeadline(arg0 context.Context, arg1 types.LayerID, arg2 types.BlockID, arg3 time.Time) error {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "RegisterDeadline", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "RegisterDeadline", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // RegisterDeadline indicates an expected call of RegisterDeadline.
-func (mr *MockcertifierMockRecorder) RegisterDeadline(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockcertifierMockRecorder) RegisterDeadline(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterDeadline", reflect.TypeOf((*Mockcertifier)(nil).RegisterDeadline), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterDeadline", reflect.TypeOf((*Mockcertifier)(nil).RegisterDeadline), arg0, arg1, arg2, arg3)
 }

--- a/blocks/mocks/mocks.go
+++ b/blocks/mocks/mocks.go
@@ -7,7 +7,6 @@ package mocks
 import (
 	context "context"
 	reflect "reflect"
-	time "time"
 
 	gomock "github.com/golang/mock/gomock"
 	types "github.com/spacemeshos/go-spacemesh/common/types"
@@ -191,16 +190,16 @@ func (mr *MockcertifierMockRecorder) CertifyIfEligible(arg0, arg1, arg2, arg3 in
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CertifyIfEligible", reflect.TypeOf((*Mockcertifier)(nil).CertifyIfEligible), arg0, arg1, arg2, arg3)
 }
 
-// RegisterDeadline mocks base method.
-func (m *Mockcertifier) RegisterDeadline(arg0 context.Context, arg1 types.LayerID, arg2 types.BlockID, arg3 time.Time) error {
+// RegisterForCert mocks base method.
+func (m *Mockcertifier) RegisterForCert(arg0 context.Context, arg1 types.LayerID, arg2 types.BlockID) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RegisterDeadline", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "RegisterForCert", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// RegisterDeadline indicates an expected call of RegisterDeadline.
-func (mr *MockcertifierMockRecorder) RegisterDeadline(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+// RegisterForCert indicates an expected call of RegisterForCert.
+func (mr *MockcertifierMockRecorder) RegisterForCert(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterDeadline", reflect.TypeOf((*Mockcertifier)(nil).RegisterDeadline), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterForCert", reflect.TypeOf((*Mockcertifier)(nil).RegisterForCert), arg0, arg1, arg2)
 }

--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -489,10 +489,9 @@ func (app *App) initServices(ctx context.Context,
 	app.certifier = blocks.NewCertifier(sqlDB, hOracle, nodeID, sgn, app.host, clock, beaconProtocol,
 		blocks.WithCertContext(ctx),
 		blocks.WithCertConfig(blocks.CertConfig{
-			CommitteeSize:         app.Config.HARE.N,
-			CertifyThreshold:      app.Config.HARE.F + 1,
-			SignatureWaitDuration: time.Second * time.Duration(app.Config.HARE.WakeupDelta),
-			NumLayersToKeep:       app.Config.Tortoise.Zdist,
+			CommitteeSize:    app.Config.HARE.N,
+			CertifyThreshold: app.Config.HARE.F + 1,
+			NumLayersToKeep:  app.Config.Tortoise.Zdist,
 		}),
 		blocks.WithCertifierLogger(app.addLogger(BlockCertLogger, lg)))
 

--- a/config/presets/fastnet.go
+++ b/config/presets/fastnet.go
@@ -32,7 +32,7 @@ func fastnet() config.Config {
 	conf.HARE.F = 399
 	conf.HARE.LimitIterations = 4
 	conf.HARE.RoundDuration = 2
-	conf.HARE.WakeupDelta = 2
+	conf.HARE.WakeupDelta = 3
 
 	conf.P2P.TargetOutbound = 10
 

--- a/fetch/fetch_test.go
+++ b/fetch/fetch_test.go
@@ -26,6 +26,7 @@ type testFetch struct {
 	mh     *mocks.Mockhost
 	mAtxS  *smocks.MockRequestor
 	mLyrS  *smocks.MockRequestor
+	mOpnS  *smocks.MockRequestor
 	mHashS *smocks.MockRequestor
 }
 
@@ -34,6 +35,7 @@ func createFetch(tb testing.TB) *testFetch {
 	mh := mocks.NewMockhost(ctrl)
 	msAtx := smocks.NewMockRequestor(ctrl)
 	msLyr := smocks.NewMockRequestor(ctrl)
+	msOpn := smocks.NewMockRequestor(ctrl)
 	msHash := smocks.NewMockRequestor(ctrl)
 	cfg := Config{
 		2000, // make sure we never hit the batch timeout
@@ -43,10 +45,11 @@ func createFetch(tb testing.TB) *testFetch {
 		3,
 	}
 	return &testFetch{
-		Fetch:  newFetch(cfg, mh, datastore.NewBlobStore(sql.InMemory()), msAtx, msLyr, msHash, logtest.New(tb)),
+		Fetch:  newFetch(cfg, mh, datastore.NewBlobStore(sql.InMemory()), msAtx, msLyr, msOpn, msHash, logtest.New(tb)),
 		mh:     mh,
 		mAtxS:  msAtx,
 		mLyrS:  msLyr,
+		mOpnS:  msOpn,
 		mHashS: msHash,
 	}
 }
@@ -225,7 +228,6 @@ func TestFetch_GetRandomPeer(t *testing.T) {
 }
 
 func TestFetch_GetLayerData(t *testing.T) {
-	processed := types.NewLayerID(10)
 	peers := []p2p.Peer{"p0", "p1", "p3", "p4"}
 	errUnknown := errors.New("unknown")
 	tt := []struct {
@@ -250,33 +252,32 @@ func TestFetch_GetLayerData(t *testing.T) {
 			require.Equal(t, len(peers), len(tc.errs))
 			f := createFetch(t)
 			f.mh.EXPECT().GetPeers().Return(peers)
-			var mu sync.Mutex
-			resPeers := make([]p2p.Peer, 0, len(peers))
-			resErrs := make([]error, 0, len(peers))
+			oks := make(chan struct{}, len(peers))
+			errs := make(chan struct{}, len(peers))
 			var wg sync.WaitGroup
 			wg.Add(len(peers))
 			okFunc := func(data []byte, peer p2p.Peer, numPeers int) {
 				require.Equal(t, len(peers), numPeers)
-				mu.Lock()
-				defer mu.Unlock()
-				resPeers = append(resPeers, peer)
-				resErrs = append(resErrs, nil)
+				oks <- struct{}{}
 				wg.Done()
 			}
 			errFunc := func(err error, peer p2p.Peer, numPeers int) {
 				require.Equal(t, len(peers), numPeers)
-				mu.Lock()
-				defer mu.Unlock()
-				resPeers = append(resPeers, peer)
-				resErrs = append(resErrs, err)
+				errs <- struct{}{}
 				wg.Done()
 			}
+			var expOk, expErr int
 			for i, p := range peers {
+				if tc.errs[i] == nil {
+					expOk++
+				} else {
+					expErr++
+				}
 				idx := i
 				f.mLyrS.EXPECT().Request(gomock.Any(), p, gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
 					func(_ context.Context, _ p2p.Peer, _ []byte, okFunc func([]byte), errFunc func(error)) error {
 						if tc.errs[idx] == nil {
-							go okFunc(generateLayerContent(t, processed))
+							go okFunc(generateLayerContent(t))
 						} else {
 							go errFunc(tc.errs[idx])
 						}
@@ -285,8 +286,73 @@ func TestFetch_GetLayerData(t *testing.T) {
 			}
 			require.NoError(t, f.GetLayerData(context.TODO(), types.NewLayerID(111), okFunc, errFunc))
 			wg.Wait()
-			require.ElementsMatch(t, resPeers, peers)
-			require.ElementsMatch(t, resErrs, tc.errs)
+			require.Len(t, oks, expOk)
+			require.Len(t, errs, expErr)
+		})
+	}
+}
+
+func TestFetch_GetLayerOpinions(t *testing.T) {
+	peers := []p2p.Peer{"p0", "p1", "p3", "p4"}
+	errUnknown := errors.New("unknown")
+	tt := []struct {
+		name string
+		errs []error
+	}{
+		{
+			name: "all peers returns",
+			errs: []error{nil, nil, nil, nil},
+		},
+		{
+			name: "some peers errors",
+			errs: []error{nil, errUnknown, nil, errUnknown},
+		},
+	}
+
+	for _, tc := range tt {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, len(peers), len(tc.errs))
+			f := createFetch(t)
+			f.mh.EXPECT().GetPeers().Return(peers)
+			oks := make(chan struct{}, len(peers))
+			errs := make(chan struct{}, len(peers))
+			var wg sync.WaitGroup
+			wg.Add(len(peers))
+			okFunc := func(data []byte, peer p2p.Peer, numPeers int) {
+				require.Equal(t, len(peers), numPeers)
+				oks <- struct{}{}
+				wg.Done()
+			}
+			errFunc := func(err error, peer p2p.Peer, numPeers int) {
+				require.Equal(t, len(peers), numPeers)
+				errs <- struct{}{}
+				wg.Done()
+			}
+			var expOk, expErr int
+			for i, p := range peers {
+				if tc.errs[i] == nil {
+					expOk++
+				} else {
+					expErr++
+				}
+				idx := i
+				f.mOpnS.EXPECT().Request(gomock.Any(), p, gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+					func(_ context.Context, _ p2p.Peer, _ []byte, okFunc func([]byte), errFunc func(error)) error {
+						if tc.errs[idx] == nil {
+							go okFunc([]byte("data"))
+						} else {
+							go errFunc(tc.errs[idx])
+						}
+						return nil
+					})
+			}
+			require.NoError(t, f.GetLayerOpinions(context.TODO(), types.NewLayerID(111), okFunc, errFunc))
+			wg.Wait()
+			require.Len(t, oks, expOk)
+			require.Len(t, errs, expErr)
 		})
 	}
 }

--- a/fetch/handler.go
+++ b/fetch/handler.go
@@ -90,11 +90,10 @@ func (h *handler) handleLayerDataReq(ctx context.Context, req []byte) ([]byte, e
 	}
 
 	ld.HareOutput, err = layers.GetCert(h.db, lyrID)
-	if err != nil {
+	if err != nil && !errors.Is(err, sql.ErrNotFound) {
 		h.logger.WithContext(ctx).With().Warning("failed to get hare output for layer", lyrID, log.Err(err))
 		return nil, errInternal
 	}
-
 	out, err := codec.Encode(&ld)
 	if err != nil {
 		h.logger.WithContext(ctx).With().Panic("failed to serialize layer blocks response", log.Err(err))

--- a/fetch/handler_test.go
+++ b/fetch/handler_test.go
@@ -4,14 +4,12 @@ import (
 	"context"
 	"testing"
 
-	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/spacemeshos/go-spacemesh/codec"
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/datastore"
-	"github.com/spacemeshos/go-spacemesh/fetch/mocks"
 	"github.com/spacemeshos/go-spacemesh/log/logtest"
 	"github.com/spacemeshos/go-spacemesh/signing"
 	"github.com/spacemeshos/go-spacemesh/sql"
@@ -28,15 +26,12 @@ type lyrdata struct {
 
 type testHandler struct {
 	*handler
-	mmp *mocks.MockmeshProvider
 }
 
 func createTestHandler(t *testing.T) *testHandler {
-	mmp := mocks.NewMockmeshProvider(gomock.NewController(t))
 	db := sql.InMemory()
 	return &testHandler{
-		handler: newHandler(db, datastore.NewBlobStore(db), mmp, logtest.New(t)),
-		mmp:     mmp,
+		handler: newHandler(db, datastore.NewBlobStore(db), logtest.New(t)),
 	}
 }
 
@@ -62,24 +57,15 @@ func createLayer(t *testing.T, db *sql.Database, lid types.LayerID) *lyrdata {
 
 func TestHandleLayerDataReq(t *testing.T) {
 	tt := []struct {
-		name                    string
-		requested               types.LayerID
-		emptyLyr, hareHasOutput bool
+		name     string
+		emptyLyr bool
 	}{
 		{
-			name:          "success",
-			requested:     types.NewLayerID(100),
-			hareHasOutput: true,
+			name: "success",
 		},
 		{
-			name:          "empty hare output",
-			requested:     types.NewLayerID(100),
-			hareHasOutput: false,
-		},
-		{
-			name:      "empty layer",
-			requested: types.NewLayerID(100),
-			emptyLyr:  true,
+			name:     "empty layer",
+			emptyLyr: true,
 		},
 	}
 
@@ -88,31 +74,54 @@ func TestHandleLayerDataReq(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			if tc.hareHasOutput {
-				require.False(t, tc.emptyLyr)
-			}
+			lid := types.NewLayerID(111)
 			th := createTestHandler(t)
-			expected := createLayer(t, th.db, tc.requested)
-			bid := types.EmptyBlockID
-			if !tc.emptyLyr {
-				bid = expected.blks[0]
-			}
-			hareOutput := &types.Certificate{
-				BlockID: bid,
-			}
-			require.NoError(t, layers.SetHareOutputWithCert(th.db, tc.requested, hareOutput))
-			th.mmp.EXPECT().ProcessedLayer().Return(tc.requested)
+			expected := createLayer(t, th.db, lid)
 
-			out, err := th.handleLayerDataReq(context.TODO(), tc.requested.Bytes())
+			out, err := th.handleLayerDataReq(context.TODO(), lid.Bytes())
 			require.NoError(t, err)
 			var got LayerData
 			err = codec.Decode(out, &got)
 			require.NoError(t, err)
 			assert.ElementsMatch(t, expected.blts, got.Ballots)
 			assert.ElementsMatch(t, expected.blks, got.Blocks)
-			assert.Equal(t, hareOutput, got.HareOutput)
 			assert.Equal(t, expected.hash, got.Hash)
 			assert.Equal(t, expected.aggHash, got.AggregatedHash)
+		})
+	}
+}
+
+func TestHandleLayerOpinionsReq(t *testing.T) {
+	tt := []struct {
+		name string
+		cert *types.Certificate
+	}{
+		{
+			name: "has cert",
+			cert: &types.Certificate{BlockID: types.BlockID{1, 2, 3}},
+		},
+		{
+			name: "no cert",
+		},
+	}
+
+	for _, tc := range tt {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			th := createTestHandler(t)
+			lid := types.NewLayerID(111)
+			if tc.cert != nil {
+				require.NoError(t, layers.SetHareOutputWithCert(th.db, lid, tc.cert))
+			}
+
+			out, err := th.handleLayerOpinionsReq(context.TODO(), lid.Bytes())
+			require.NoError(t, err)
+			var got LayerOpinions
+			err = codec.Decode(out, &got)
+			require.NoError(t, err)
+			assert.Equal(t, tc.cert, got.Cert)
 		})
 	}
 }

--- a/fetch/interface.go
+++ b/fetch/interface.go
@@ -30,10 +30,6 @@ type blockHandler interface {
 	HandleSyncedBlock(context.Context, []byte) error
 }
 
-type certHandler interface {
-	HandleSyncedCertificate(context.Context, types.LayerID, *types.Certificate) error
-}
-
 type ballotHandler interface {
 	HandleSyncedBallot(context.Context, []byte) error
 }

--- a/fetch/interface.go
+++ b/fetch/interface.go
@@ -14,6 +14,7 @@ import (
 type fetcher interface {
 	GetEpochATXIDs(context.Context, types.EpochID, func([]byte, p2p.Peer), func(error)) error
 	GetLayerData(context.Context, types.LayerID, func([]byte, p2p.Peer, int), func(error, p2p.Peer, int)) error
+	GetLayerOpinions(context.Context, types.LayerID, func([]byte, p2p.Peer, int), func(error, p2p.Peer, int)) error
 	GetHash(types.Hash32, datastore.Hint, bool) chan ftypes.HashDataPromiseResult
 	GetHashes([]types.Hash32, datastore.Hint, bool) map[types.Hash32]chan ftypes.HashDataPromiseResult
 	Stop()
@@ -28,6 +29,10 @@ type atxHandler interface {
 
 type blockHandler interface {
 	HandleSyncedBlock(context.Context, []byte) error
+}
+
+type certHandler interface {
+	HandleSyncedCertificate(context.Context, types.LayerID, *types.Certificate) error
 }
 
 type ballotHandler interface {

--- a/fetch/mocks/mocks.go
+++ b/fetch/mocks/mocks.go
@@ -216,43 +216,6 @@ func (mr *MockblockHandlerMockRecorder) HandleSyncedBlock(arg0, arg1 interface{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleSyncedBlock", reflect.TypeOf((*MockblockHandler)(nil).HandleSyncedBlock), arg0, arg1)
 }
 
-// MockcertHandler is a mock of certHandler interface.
-type MockcertHandler struct {
-	ctrl     *gomock.Controller
-	recorder *MockcertHandlerMockRecorder
-}
-
-// MockcertHandlerMockRecorder is the mock recorder for MockcertHandler.
-type MockcertHandlerMockRecorder struct {
-	mock *MockcertHandler
-}
-
-// NewMockcertHandler creates a new mock instance.
-func NewMockcertHandler(ctrl *gomock.Controller) *MockcertHandler {
-	mock := &MockcertHandler{ctrl: ctrl}
-	mock.recorder = &MockcertHandlerMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockcertHandler) EXPECT() *MockcertHandlerMockRecorder {
-	return m.recorder
-}
-
-// HandleSyncedCertificate mocks base method.
-func (m *MockcertHandler) HandleSyncedCertificate(arg0 context.Context, arg1 types.LayerID, arg2 *types.Certificate) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HandleSyncedCertificate", arg0, arg1, arg2)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// HandleSyncedCertificate indicates an expected call of HandleSyncedCertificate.
-func (mr *MockcertHandlerMockRecorder) HandleSyncedCertificate(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleSyncedCertificate", reflect.TypeOf((*MockcertHandler)(nil).HandleSyncedCertificate), arg0, arg1, arg2)
-}
-
 // MockballotHandler is a mock of ballotHandler interface.
 type MockballotHandler struct {
 	ctrl     *gomock.Controller

--- a/fetch/mocks/mocks.go
+++ b/fetch/mocks/mocks.go
@@ -106,6 +106,20 @@ func (mr *MockfetcherMockRecorder) GetLayerData(arg0, arg1, arg2, arg3 interface
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLayerData", reflect.TypeOf((*Mockfetcher)(nil).GetLayerData), arg0, arg1, arg2, arg3)
 }
 
+// GetLayerOpinions mocks base method.
+func (m *Mockfetcher) GetLayerOpinions(arg0 context.Context, arg1 types.LayerID, arg2 func([]byte, p2p.Peer, int), arg3 func(error, p2p.Peer, int)) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetLayerOpinions", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// GetLayerOpinions indicates an expected call of GetLayerOpinions.
+func (mr *MockfetcherMockRecorder) GetLayerOpinions(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLayerOpinions", reflect.TypeOf((*Mockfetcher)(nil).GetLayerOpinions), arg0, arg1, arg2, arg3)
+}
+
 // RegisterPeerHashes mocks base method.
 func (m *Mockfetcher) RegisterPeerHashes(arg0 p2p.Peer, arg1 []types.Hash32) {
 	m.ctrl.T.Helper()
@@ -214,6 +228,43 @@ func (m *MockblockHandler) HandleSyncedBlock(arg0 context.Context, arg1 []byte) 
 func (mr *MockblockHandlerMockRecorder) HandleSyncedBlock(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleSyncedBlock", reflect.TypeOf((*MockblockHandler)(nil).HandleSyncedBlock), arg0, arg1)
+}
+
+// MockcertHandler is a mock of certHandler interface.
+type MockcertHandler struct {
+	ctrl     *gomock.Controller
+	recorder *MockcertHandlerMockRecorder
+}
+
+// MockcertHandlerMockRecorder is the mock recorder for MockcertHandler.
+type MockcertHandlerMockRecorder struct {
+	mock *MockcertHandler
+}
+
+// NewMockcertHandler creates a new mock instance.
+func NewMockcertHandler(ctrl *gomock.Controller) *MockcertHandler {
+	mock := &MockcertHandler{ctrl: ctrl}
+	mock.recorder = &MockcertHandlerMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockcertHandler) EXPECT() *MockcertHandlerMockRecorder {
+	return m.recorder
+}
+
+// HandleSyncedCertificate mocks base method.
+func (m *MockcertHandler) HandleSyncedCertificate(arg0 context.Context, arg1 types.LayerID, arg2 *types.Certificate) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HandleSyncedCertificate", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// HandleSyncedCertificate indicates an expected call of HandleSyncedCertificate.
+func (mr *MockcertHandlerMockRecorder) HandleSyncedCertificate(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleSyncedCertificate", reflect.TypeOf((*MockcertHandler)(nil).HandleSyncedCertificate), arg0, arg1, arg2)
 }
 
 // MockballotHandler is a mock of ballotHandler interface.

--- a/fetch/wire_types.go
+++ b/fetch/wire_types.go
@@ -6,18 +6,20 @@ import (
 
 //go:generate scalegen
 
-// LayerData is the response for a given layer ID.
+// LayerData is the data response for a given layer ID.
 type LayerData struct {
 	// Ballots are the ballots in layer
 	Ballots []types.BallotID
 	// Blocks are the blocks in a layer
 	Blocks []types.BlockID
-	// HareOutput is the output of hare consensus and input for verifying tortoise
-	HareOutput *types.Certificate
-	// ProcessedLayer is the latest processed layer from peer
-	ProcessedLayer types.LayerID
 	// Hash is the hash of contextually valid blocks (sorted by block ID) in the given layer
 	Hash types.Hash32
 	// AggregatedHash is the aggregated hash of all layers up to the given layer
 	AggregatedHash types.Hash32
+}
+
+// LayerOpinions is the response for opinions for a given layer.
+type LayerOpinions struct {
+	// Cert is the certificate for the layer.
+	Cert *types.Certificate
 }

--- a/fetch/wire_types_scale.go
+++ b/fetch/wire_types_scale.go
@@ -24,20 +24,6 @@ func (t *LayerData) EncodeScale(enc *scale.Encoder) (total int, err error) {
 		total += n
 	}
 	{
-		n, err := scale.EncodeOption(enc, t.HareOutput)
-		if err != nil {
-			return total, err
-		}
-		total += n
-	}
-	{
-		n, err := t.ProcessedLayer.EncodeScale(enc)
-		if err != nil {
-			return total, err
-		}
-		total += n
-	}
-	{
 		n, err := scale.EncodeByteArray(enc, t.Hash[:])
 		if err != nil {
 			return total, err
@@ -72,21 +58,6 @@ func (t *LayerData) DecodeScale(dec *scale.Decoder) (total int, err error) {
 		t.Blocks = field
 	}
 	{
-		field, n, err := scale.DecodeOption[types.Certificate](dec)
-		if err != nil {
-			return total, err
-		}
-		total += n
-		t.HareOutput = field
-	}
-	{
-		n, err := t.ProcessedLayer.DecodeScale(dec)
-		if err != nil {
-			return total, err
-		}
-		total += n
-	}
-	{
 		n, err := scale.DecodeByteArray(dec, t.Hash[:])
 		if err != nil {
 			return total, err
@@ -99,6 +70,29 @@ func (t *LayerData) DecodeScale(dec *scale.Decoder) (total int, err error) {
 			return total, err
 		}
 		total += n
+	}
+	return total, nil
+}
+
+func (t *LayerOpinions) EncodeScale(enc *scale.Encoder) (total int, err error) {
+	{
+		n, err := scale.EncodeOption(enc, t.Cert)
+		if err != nil {
+			return total, err
+		}
+		total += n
+	}
+	return total, nil
+}
+
+func (t *LayerOpinions) DecodeScale(dec *scale.Decoder) (total int, err error) {
+	{
+		field, n, err := scale.DecodeOption[types.Certificate](dec)
+		if err != nil {
+			return total, err
+		}
+		total += n
+		t.Cert = field
 	}
 	return total, nil
 }

--- a/genvm/vm.go
+++ b/genvm/vm.go
@@ -88,7 +88,11 @@ func (v *VM) GetLayerApplied(tid types.TransactionID) (types.LayerID, error) {
 
 // GetStateRoot gets the current state root hash.
 func (v *VM) GetStateRoot() (types.Hash32, error) {
-	return layers.GetLatestStateHash(v.db)
+	root, err := layers.GetLatestStateHash(v.db)
+	if errors.Is(err, sql.ErrNotFound) {
+		return types.Hash32{}, nil
+	}
+	return root, err
 }
 
 // GetAllAccounts returns a dump of all accounts in global state.

--- a/genvm/vm.go
+++ b/genvm/vm.go
@@ -89,6 +89,9 @@ func (v *VM) GetLayerApplied(tid types.TransactionID) (types.LayerID, error) {
 // GetStateRoot gets the current state root hash.
 func (v *VM) GetStateRoot() (types.Hash32, error) {
 	root, err := layers.GetLatestStateHash(v.db)
+	// TODO: reconsider this.
+	// instead of skipping vm on empty layers, maybe pass empty layer to vm
+	// and let it persist empty (or previous if we will use cumulative) hash.
 	if errors.Is(err, sql.ErrNotFound) {
 		return types.Hash32{}, nil
 	}

--- a/genvm/vm_test.go
+++ b/genvm/vm_test.go
@@ -1036,6 +1036,10 @@ func BenchmarkValidation(b *testing.B) {
 func TestStateHashFromUpdatedAccounts(t *testing.T) {
 	tt := newTester(t).addSingleSig(10).applyGenesis()
 
+	root, err := tt.GetStateRoot()
+	require.NoError(t, err)
+	require.Equal(t, types.Hash32{}, root)
+
 	lid := types.NewLayerID(1)
 	skipped, _, err := tt.Apply(testContext(lid), notVerified(
 		tt.selfSpawn(0),
@@ -1059,6 +1063,10 @@ func TestStateHashFromUpdatedAccounts(t *testing.T) {
 	statehash, err := layers.GetStateHash(tt.db, lid)
 	require.NoError(t, err)
 	require.Equal(t, expected, statehash)
+
+	root, err = tt.GetStateRoot()
+	require.NoError(t, err)
+	require.Equal(t, expected, root)
 }
 
 func BenchmarkWallet(b *testing.B) {

--- a/hare/hare.go
+++ b/hare/hare.go
@@ -221,15 +221,14 @@ func (h *Hare) collectOutput(ctx context.Context, output TerminationOutput) erro
 		postNumProposals.Add(float64(set.len()))
 		pids = make([]types.ProposalID, 0, set.len())
 		pids = append(pids, set.elements()...)
+		h.blockGenCh <- LayerOutput{
+			Ctx:       ctx,
+			Layer:     layerID,
+			Proposals: pids,
+		}
 	} else {
 		consensusFailCnt.Inc()
 		h.WithContext(ctx).With().Warning("hare terminated with failure", layerID)
-	}
-
-	h.blockGenCh <- LayerOutput{
-		Ctx:       ctx,
-		Layer:     layerID,
-		Proposals: pids,
 	}
 
 	if h.outOfBufferRange(layerID) {

--- a/hare/hare_test.go
+++ b/hare/hare_test.go
@@ -570,12 +570,13 @@ func TestHare_WeakCoin(t *testing.T) {
 
 	require.NoError(t, h.Start(context.TODO()))
 	defer h.Close()
-	waitForMsg := func() {
+	waitForMsg := func() error {
 		tmr := time.NewTimer(time.Second)
 		select {
 		case <-tmr.C:
-			require.Fail(t, "timed out waiting for message")
+			return errors.New("timeout")
 		case <-h.blockGenCh:
+			return nil
 		}
 	}
 
@@ -592,29 +593,28 @@ func TestHare_WeakCoin(t *testing.T) {
 
 	// complete + coin flip true
 	h.outputChan <- mockReport{layerID, set, true, true}
-	waitForMsg()
+	require.NoError(t, waitForMsg())
 	wc, err := layers.GetWeakCoin(h.db, layerID)
 	require.NoError(t, err)
 	require.True(t, wc)
 
 	// incomplete + coin flip true
 	h.outputChan <- mockReport{layerID, set, false, true}
-	waitForMsg()
+	require.Error(t, waitForMsg())
 	wc, err = layers.GetWeakCoin(h.db, layerID)
 	require.NoError(t, err)
 	require.True(t, wc)
 
 	// complete + coin flip false
 	h.outputChan <- mockReport{layerID, set, true, false}
-	waitForMsg()
+	require.NoError(t, waitForMsg())
 	wc, err = layers.GetWeakCoin(h.db, layerID)
 	require.NoError(t, err)
 	require.False(t, wc)
 
 	// incomplete + coin flip false
 	h.outputChan <- mockReport{layerID, set, false, true}
-	waitForMsg()
-
+	require.Error(t, waitForMsg())
 	wc, err = layers.GetWeakCoin(h.db, layerID)
 	require.NoError(t, err)
 	require.True(t, wc)

--- a/mesh/interface.go
+++ b/mesh/interface.go
@@ -22,3 +22,7 @@ type tortoise interface {
 	HandleIncomingLayer(context.Context, types.LayerID) types.LayerID
 	LatestComplete() types.LayerID
 }
+
+type certHandler interface {
+	HandleSyncedCertificate(context.Context, types.LayerID, *types.Certificate) error
+}

--- a/mesh/interface.go
+++ b/mesh/interface.go
@@ -20,9 +20,4 @@ type tortoise interface {
 	OnBallot(*types.Ballot)
 	OnBlock(*types.Block)
 	HandleIncomingLayer(context.Context, types.LayerID) types.LayerID
-	LatestComplete() types.LayerID
-}
-
-type certHandler interface {
-	HandleSyncedCertificate(context.Context, types.LayerID, *types.Certificate) error
 }

--- a/mesh/mesh.go
+++ b/mesh/mesh.go
@@ -55,10 +55,17 @@ type Mesh struct {
 	// if contextual validity changed for blocks in that layer, we need to
 	// double-check whether we have applied the correct block for that layer.
 	minUpdatedLayer atomic.Value
+
+	// used for caching hare certificate when the node sync data from peers.
+	// a synced certificate cannot be verified before the node learns the beacon value
+	// of the epoch. any certificate passed on by the syncer will stay here until
+	// beacon is available.
+	certCache    map[types.LayerID][]*types.Certificate
+	certVerifier certHandler
 }
 
 // NewMesh creates a new instant of a mesh.
-func NewMesh(cdb *datastore.CachedDB, bcn system.BeaconGetter, trtl tortoise, state conservativeState, logger log.Log) (*Mesh, error) {
+func NewMesh(cdb *datastore.CachedDB, bcn system.BeaconGetter, trtl tortoise, state conservativeState, c certHandler, logger log.Log) (*Mesh, error) {
 	msh := &Mesh{
 		logger:              logger,
 		cdb:                 cdb,
@@ -66,6 +73,8 @@ func NewMesh(cdb *datastore.CachedDB, bcn system.BeaconGetter, trtl tortoise, st
 		trtl:                trtl,
 		conState:            state,
 		nextProcessedLayers: make(map[types.LayerID]struct{}),
+		certCache:           make(map[types.LayerID][]*types.Certificate),
+		certVerifier:        c,
 	}
 	msh.latestLayer.Store(types.LayerID{})
 	msh.latestLayerInState.Store(types.LayerID{})
@@ -367,12 +376,51 @@ func (msh *Mesh) revertMaybe(ctx context.Context, logger log.Log, newVerified ty
 	return nil
 }
 
+// TODO: detect multiple hare certificate in the same network
+// https://github.com/spacemeshos/go-spacemesh/issues/3467
+func (msh *Mesh) verifyCertificates(ctx context.Context, lid types.LayerID, certs []*types.Certificate) {
+	if _, err := layers.GetCert(msh.cdb, lid); err == nil {
+		return
+	}
+	for _, cert := range certs {
+		if err := msh.certVerifier.HandleSyncedCertificate(ctx, lid, cert); err == nil {
+			// we only need one valid certificate per layer
+			return
+		}
+	}
+}
+
+// ProcessCertificates verify the hare certificate if beacon is available. if not, put them in the cache.
+// they will be verified when tortoise is triggered.
+func (msh *Mesh) ProcessCertificates(ctx context.Context, lid types.LayerID, certs []*types.Certificate) {
+	if !msh.trtl.LatestComplete().Before(lid) {
+		return
+	}
+
+	epoch := lid.GetEpoch()
+	if _, err := msh.beacon.GetBeacon(epoch); err != nil {
+		msh.logger.WithContext(ctx).With().Info("beacon not available. cache certs for now", lid, epoch)
+		msh.mu.Lock()
+		defer msh.mu.Unlock()
+		msh.certCache[lid] = certs
+		return
+	}
+
+	msh.verifyCertificates(ctx, lid, certs)
+}
+
 func (msh *Mesh) triggerTortoise(ctx context.Context, logger log.Log, lid types.LayerID) types.LayerID {
 	epoch := lid.GetEpoch()
 	if _, err := msh.beacon.GetBeacon(epoch); err != nil {
 		logger.With().Warning("not triggering tortoise: beacon not available", lid, epoch)
 		return msh.trtl.LatestComplete()
 	}
+
+	if _, ok := msh.certCache[lid]; ok {
+		msh.verifyCertificates(ctx, lid, msh.certCache[lid])
+		delete(msh.certCache, lid)
+	}
+
 	newVerified := msh.trtl.HandleIncomingLayer(ctx, lid)
 	logger.With().Debug("tortoise results", log.FieldNamed("verified", newVerified))
 	return newVerified
@@ -498,7 +546,7 @@ func layerValidBlocks(logger log.Log, cdb *datastore.CachedDB, layerID, latestVe
 		// tortoise has not verified this layer yet, simply apply the block that hare certified
 		bid, err := layers.GetHareOutput(cdb, layerID)
 		if err != nil {
-			logger.With().Error("failed to get hare output", layerID, log.Err(err))
+			logger.With().Warning("failed to get hare output", layerID, log.Err(err))
 			return nil, fmt.Errorf("%w: get hare output %v", errMissingHareOutput, err.Error())
 		}
 		// hare output an empty layer

--- a/mesh/mesh.go
+++ b/mesh/mesh.go
@@ -376,7 +376,7 @@ func (msh *Mesh) ProcessLayer(ctx context.Context, layerID types.LayerID) error 
 
 	// pass the layer to tortoise for processing
 	newVerified := msh.trtl.HandleIncomingLayer(ctx, layerID)
-	logger.With().Debug("tortoise results", log.FieldNamed("verified", newVerified))
+	logger.With().Debug("tortoise results", log.Stringer("verified", newVerified))
 
 	// set processed layer even if later code will fail, as that failure is not related
 	// to the layer that is being processed
@@ -397,7 +397,7 @@ func (msh *Mesh) ProcessLayer(ctx context.Context, layerID types.LayerID) error 
 
 	if !to.Before(from) {
 		if err := msh.pushLayersToState(ctx, from, to, newVerified); err != nil {
-			logger.With().Warning("failed to push layers to state", log.Err(err))
+			logger.With().Error("failed to push layers to state", log.Err(err))
 			return err
 		}
 	}

--- a/mesh/mocks/mocks.go
+++ b/mesh/mocks/mocks.go
@@ -181,3 +181,40 @@ func (mr *MocktortoiseMockRecorder) OnBlock(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OnBlock", reflect.TypeOf((*Mocktortoise)(nil).OnBlock), arg0)
 }
+
+// MockcertHandler is a mock of certHandler interface.
+type MockcertHandler struct {
+	ctrl     *gomock.Controller
+	recorder *MockcertHandlerMockRecorder
+}
+
+// MockcertHandlerMockRecorder is the mock recorder for MockcertHandler.
+type MockcertHandlerMockRecorder struct {
+	mock *MockcertHandler
+}
+
+// NewMockcertHandler creates a new mock instance.
+func NewMockcertHandler(ctrl *gomock.Controller) *MockcertHandler {
+	mock := &MockcertHandler{ctrl: ctrl}
+	mock.recorder = &MockcertHandlerMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockcertHandler) EXPECT() *MockcertHandlerMockRecorder {
+	return m.recorder
+}
+
+// HandleSyncedCertificate mocks base method.
+func (m *MockcertHandler) HandleSyncedCertificate(arg0 context.Context, arg1 types.LayerID, arg2 *types.Certificate) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HandleSyncedCertificate", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// HandleSyncedCertificate indicates an expected call of HandleSyncedCertificate.
+func (mr *MockcertHandlerMockRecorder) HandleSyncedCertificate(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleSyncedCertificate", reflect.TypeOf((*MockcertHandler)(nil).HandleSyncedCertificate), arg0, arg1, arg2)
+}

--- a/mesh/mocks/mocks.go
+++ b/mesh/mocks/mocks.go
@@ -144,20 +144,6 @@ func (mr *MocktortoiseMockRecorder) HandleIncomingLayer(arg0, arg1 interface{}) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleIncomingLayer", reflect.TypeOf((*Mocktortoise)(nil).HandleIncomingLayer), arg0, arg1)
 }
 
-// LatestComplete mocks base method.
-func (m *Mocktortoise) LatestComplete() types.LayerID {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LatestComplete")
-	ret0, _ := ret[0].(types.LayerID)
-	return ret0
-}
-
-// LatestComplete indicates an expected call of LatestComplete.
-func (mr *MocktortoiseMockRecorder) LatestComplete() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LatestComplete", reflect.TypeOf((*Mocktortoise)(nil).LatestComplete))
-}
-
 // OnBallot mocks base method.
 func (m *Mocktortoise) OnBallot(arg0 *types.Ballot) {
 	m.ctrl.T.Helper()
@@ -180,41 +166,4 @@ func (m *Mocktortoise) OnBlock(arg0 *types.Block) {
 func (mr *MocktortoiseMockRecorder) OnBlock(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OnBlock", reflect.TypeOf((*Mocktortoise)(nil).OnBlock), arg0)
-}
-
-// MockcertHandler is a mock of certHandler interface.
-type MockcertHandler struct {
-	ctrl     *gomock.Controller
-	recorder *MockcertHandlerMockRecorder
-}
-
-// MockcertHandlerMockRecorder is the mock recorder for MockcertHandler.
-type MockcertHandlerMockRecorder struct {
-	mock *MockcertHandler
-}
-
-// NewMockcertHandler creates a new mock instance.
-func NewMockcertHandler(ctrl *gomock.Controller) *MockcertHandler {
-	mock := &MockcertHandler{ctrl: ctrl}
-	mock.recorder = &MockcertHandlerMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockcertHandler) EXPECT() *MockcertHandlerMockRecorder {
-	return m.recorder
-}
-
-// HandleSyncedCertificate mocks base method.
-func (m *MockcertHandler) HandleSyncedCertificate(arg0 context.Context, arg1 types.LayerID, arg2 *types.Certificate) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HandleSyncedCertificate", arg0, arg1, arg2)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// HandleSyncedCertificate indicates an expected call of HandleSyncedCertificate.
-func (mr *MockcertHandlerMockRecorder) HandleSyncedCertificate(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleSyncedCertificate", reflect.TypeOf((*MockcertHandler)(nil).HandleSyncedCertificate), arg0, arg1, arg2)
 }

--- a/sql/layers/layers_test.go
+++ b/sql/layers/layers_test.go
@@ -53,37 +53,42 @@ func TestHareOutput(t *testing.T) {
 
 	// but setting the same layer with a certificate works
 	bid1 := types.BlockID{1, 1, 1}
-	cert := makeCert(lid1, bid1)
-	require.NoError(t, SetHareOutputWithCert(db, lid1, cert))
+	cert1 := makeCert(lid1, bid1)
+	require.NoError(t, SetHareOutputWithCert(db, lid1, cert1))
 
 	output, err = GetHareOutput(db, lid1)
 	require.NoError(t, err)
 	require.Equal(t, bid1, output)
 	gotC, err := GetCert(db, lid1)
 	require.NoError(t, err)
-	require.Equal(t, cert, gotC)
+	require.Equal(t, cert1, gotC)
 
 	bid2 := types.BlockID{2, 2, 2}
 	lid2 := lid1.Add(1)
-	cert = makeCert(lid2, bid2)
-	require.NoError(t, SetHareOutputWithCert(db, lid2, cert))
+	cert2 := makeCert(lid2, bid2)
+	require.NoError(t, SetHareOutputWithCert(db, lid2, cert2))
 	output, err = GetHareOutput(db, lid2)
 	require.NoError(t, err)
 	require.Equal(t, bid2, output)
 	gotC, err = GetCert(db, lid2)
 	require.NoError(t, err)
-	require.Equal(t, cert, gotC)
+	require.Equal(t, cert2, gotC)
 
 	bid3 := types.BlockID{3, 3, 3}
-	cert = makeCert(lid2, bid3)
-	// this will overwrite the previous certificate
-	require.NoError(t, SetHareOutputWithCert(db, lid2, cert))
+	cert3 := makeCert(lid2, bid3)
+	// will not overwrite the previous certificate
+	require.NoError(t, SetHareOutput(db, lid2, bid3))
+	require.NoError(t, SetHareOutputWithCert(db, lid2, cert3))
 	output, err = GetHareOutput(db, lid2)
 	require.NoError(t, err)
-	require.Equal(t, bid3, output)
+	require.Equal(t, bid2, output)
 	gotC, err = GetCert(db, lid2)
 	require.NoError(t, err)
-	require.Equal(t, cert, gotC)
+	require.Equal(t, cert2, gotC)
+
+	got, err := GetCert(db, lid2.Add(1))
+	require.ErrorIs(t, err, sql.ErrNotFound)
+	require.Nil(t, got)
 }
 
 func TestWeakCoin(t *testing.T) {

--- a/syncer/interface.go
+++ b/syncer/interface.go
@@ -24,4 +24,5 @@ type layerPatrol interface {
 
 type layerProcessor interface {
 	ProcessLayer(context.Context, types.LayerID) error
+	ProcessCertificates(context.Context, types.LayerID, []*types.Certificate)
 }

--- a/syncer/interface.go
+++ b/syncer/interface.go
@@ -14,7 +14,8 @@ type layerTicker interface {
 }
 
 type layerFetcher interface {
-	PollLayerContent(context.Context, types.LayerID) chan fetch.LayerPromiseResult
+	PollLayerData(context.Context, types.LayerID) chan fetch.LayerPromiseResult
+	PollLayerOpinions(context.Context, types.LayerID) chan fetch.LayerPromiseResult
 	GetEpochATXs(context.Context, types.EpochID) error
 }
 
@@ -24,5 +25,4 @@ type layerPatrol interface {
 
 type layerProcessor interface {
 	ProcessLayer(context.Context, types.LayerID) error
-	ProcessCertificates(context.Context, types.LayerID, []*types.Certificate)
 }

--- a/syncer/mocks/mocks.go
+++ b/syncer/mocks/mocks.go
@@ -87,18 +87,32 @@ func (mr *MocklayerFetcherMockRecorder) GetEpochATXs(arg0, arg1 interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEpochATXs", reflect.TypeOf((*MocklayerFetcher)(nil).GetEpochATXs), arg0, arg1)
 }
 
-// PollLayerContent mocks base method.
-func (m *MocklayerFetcher) PollLayerContent(arg0 context.Context, arg1 types.LayerID) chan fetch.LayerPromiseResult {
+// PollLayerData mocks base method.
+func (m *MocklayerFetcher) PollLayerData(arg0 context.Context, arg1 types.LayerID) chan fetch.LayerPromiseResult {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PollLayerContent", arg0, arg1)
+	ret := m.ctrl.Call(m, "PollLayerData", arg0, arg1)
 	ret0, _ := ret[0].(chan fetch.LayerPromiseResult)
 	return ret0
 }
 
-// PollLayerContent indicates an expected call of PollLayerContent.
-func (mr *MocklayerFetcherMockRecorder) PollLayerContent(arg0, arg1 interface{}) *gomock.Call {
+// PollLayerData indicates an expected call of PollLayerData.
+func (mr *MocklayerFetcherMockRecorder) PollLayerData(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PollLayerContent", reflect.TypeOf((*MocklayerFetcher)(nil).PollLayerContent), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PollLayerData", reflect.TypeOf((*MocklayerFetcher)(nil).PollLayerData), arg0, arg1)
+}
+
+// PollLayerOpinions mocks base method.
+func (m *MocklayerFetcher) PollLayerOpinions(arg0 context.Context, arg1 types.LayerID) chan fetch.LayerPromiseResult {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PollLayerOpinions", arg0, arg1)
+	ret0, _ := ret[0].(chan fetch.LayerPromiseResult)
+	return ret0
+}
+
+// PollLayerOpinions indicates an expected call of PollLayerOpinions.
+func (mr *MocklayerFetcherMockRecorder) PollLayerOpinions(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PollLayerOpinions", reflect.TypeOf((*MocklayerFetcher)(nil).PollLayerOpinions), arg0, arg1)
 }
 
 // MocklayerPatrol is a mock of layerPatrol interface.
@@ -159,18 +173,6 @@ func NewMocklayerProcessor(ctrl *gomock.Controller) *MocklayerProcessor {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MocklayerProcessor) EXPECT() *MocklayerProcessorMockRecorder {
 	return m.recorder
-}
-
-// ProcessCertificates mocks base method.
-func (m *MocklayerProcessor) ProcessCertificates(arg0 context.Context, arg1 types.LayerID, arg2 []*types.Certificate) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "ProcessCertificates", arg0, arg1, arg2)
-}
-
-// ProcessCertificates indicates an expected call of ProcessCertificates.
-func (mr *MocklayerProcessorMockRecorder) ProcessCertificates(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessCertificates", reflect.TypeOf((*MocklayerProcessor)(nil).ProcessCertificates), arg0, arg1, arg2)
 }
 
 // ProcessLayer mocks base method.

--- a/syncer/mocks/mocks.go
+++ b/syncer/mocks/mocks.go
@@ -161,6 +161,18 @@ func (m *MocklayerProcessor) EXPECT() *MocklayerProcessorMockRecorder {
 	return m.recorder
 }
 
+// ProcessCertificates mocks base method.
+func (m *MocklayerProcessor) ProcessCertificates(arg0 context.Context, arg1 types.LayerID, arg2 []*types.Certificate) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "ProcessCertificates", arg0, arg1, arg2)
+}
+
+// ProcessCertificates indicates an expected call of ProcessCertificates.
+func (mr *MocklayerProcessorMockRecorder) ProcessCertificates(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessCertificates", reflect.TypeOf((*MocklayerProcessor)(nil).ProcessCertificates), arg0, arg1, arg2)
+}
+
 // ProcessLayer mocks base method.
 func (m *MocklayerProcessor) ProcessLayer(arg0 context.Context, arg1 types.LayerID) error {
 	m.ctrl.T.Helper()

--- a/systest/cluster/cluster.go
+++ b/systest/cluster/cluster.go
@@ -311,10 +311,10 @@ func (c *Cluster) AddSmeshers(cctx *testcontext.Context, n int) error {
 	bootnodes := c.clients[:c.bootnodes]
 	smeshers := c.clients[c.bootnodes:]
 	c.clients = nil
-	smeshers = append(smeshers, clients...)
 	c.clients = append(c.clients, bootnodes...)
 	c.clients = append(c.clients, smeshers...)
-	c.smeshers = len(smeshers)
+	c.clients = append(c.clients, clients...)
+	c.smeshers += len(clients)
 	return nil
 }
 

--- a/systest/cluster/cluster.go
+++ b/systest/cluster/cluster.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	"sort"
 	"time"
 
 	"github.com/spacemeshos/ed25519"
@@ -313,9 +312,6 @@ func (c *Cluster) AddSmeshers(cctx *testcontext.Context, n int) error {
 	smeshers := c.clients[c.bootnodes:]
 	c.clients = nil
 	smeshers = append(smeshers, clients...)
-	sort.Slice(smeshers, func(i, j int) bool {
-		return decodeOrdinal(smeshers[i].Name) < decodeOrdinal(smeshers[j].Name)
-	})
 	c.clients = append(c.clients, bootnodes...)
 	c.clients = append(c.clients, smeshers...)
 	c.smeshers = len(smeshers)

--- a/systest/cluster/cluster.go
+++ b/systest/cluster/cluster.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"sort"
 	"time"
 
 	"github.com/spacemeshos/ed25519"
@@ -309,10 +310,15 @@ func (c *Cluster) AddSmeshers(cctx *testcontext.Context, n int) error {
 		return err
 	}
 	bootnodes := c.clients[:c.bootnodes]
+	smeshers := c.clients[c.bootnodes:]
 	c.clients = nil
+	smeshers = append(smeshers, clients...)
+	sort.Slice(smeshers, func(i, j int) bool {
+		return decodeOrdinal(smeshers[i].Name) < decodeOrdinal(smeshers[j].Name)
+	})
 	c.clients = append(c.clients, bootnodes...)
-	c.clients = append(c.clients, clients...)
-	c.smeshers = len(clients)
+	c.clients = append(c.clients, smeshers...)
+	c.smeshers = len(smeshers)
 	return nil
 }
 

--- a/systest/cluster/nodes.go
+++ b/systest/cluster/nodes.go
@@ -3,6 +3,7 @@ package cluster
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -213,6 +214,9 @@ func deployNodes(ctx *testcontext.Context, name string, from, to int, flags []De
 	for node := range clients {
 		rst = append(rst, node)
 	}
+	sort.Slice(rst, func(i, j int) bool {
+		return decodeOrdinal(rst[i].Name) < decodeOrdinal(rst[j].Name)
+	})
 	return rst, nil
 }
 

--- a/systest/tests/nodes_test.go
+++ b/systest/tests/nodes_test.go
@@ -23,6 +23,7 @@ func init() {
 }
 
 func TestAddNodes(t *testing.T) {
+	t.Skip()
 	t.Parallel()
 
 	tctx := testcontext.New(t, testcontext.Labels("sanity"))

--- a/systest/tests/nodes_test.go
+++ b/systest/tests/nodes_test.go
@@ -173,8 +173,8 @@ func TestFailedNodes(t *testing.T) {
 		}
 		return reference, result
 	}
-	// the reason we try more than once that we apply a block eagerly before tortoise verify
-	// it's contextual validity. for hashes collected from the earlier layers, they may have
+	// the reason the test tries more than once is that the node applies a block eagerly before tortoise
+	// verifies its contextual validity. for hashes collected from the earlier layers, they may have
 	// been changed when tortoise verify those layers.
 	for try := 0; try < attempts; try++ {
 		ref, diffs := run()
@@ -187,6 +187,5 @@ func TestFailedNodes(t *testing.T) {
 			}
 		}
 	}
-
 	require.NoError(t, waitAll(tctx, cl))
 }

--- a/systest/tests/timeskew_test.go
+++ b/systest/tests/timeskew_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestShortTimeskew(t *testing.T) {
+	t.Skip()
 	t.Parallel()
 
 	tctx := testcontext.New(t, testcontext.Labels("sanity"))

--- a/tortoise/util.go
+++ b/tortoise/util.go
@@ -158,8 +158,8 @@ func verifyLayer(logger log.Log, blocks []blockInfo, validity map[types.BlockID]
 	for _, block := range blocks {
 		decision := getDecision(block)
 		logger.With().Debug("decision for a block",
+			block.id,
 			log.Stringer("decision", decision),
-			log.Stringer("id", block.id),
 			log.Stringer("weight", block.weight),
 			log.Uint64("height", block.height),
 		)


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
Closes #3475

<!-- `Closes #XXXX, closes #XXXX, ...` links mentioned issues to this PR and automatically closes them when this it's merged -->

## Changes
<!-- Please describe in detail the changes made -->
- block certifier accept early CertifyMessage
- syncer: 
  - separate fetching layer data and layer opinions (only certificate for now)
  - only fetch certificates from peers within hdist layers of processed layer. processed layer is tortoise's last layer
- fix sql bug where certificate is retrieved correctly and not overwritten once set
- systest
  - fixed systests TestAddNode so that the test fails with the certificate sync failures
  - make systests TestFailedNodes to reassess layer hashes from nodes. because blocks are applied optimistically, the applied block can be changed after tortoise verify a layer

