### PR TITLE
[Merged by Bors] - replace remaining fnv with repo's default hash

### DIFF
--- a/eligibility/fixedoracle.go
+++ b/eligibility/fixedoracle.go
@@ -175,7 +175,7 @@ func hashLayerAndRound(logger log.Log, instanceID types.LayerID, round uint32) u
 			log.FieldNamed("err1", log.Err(err)),
 			log.FieldNamed("err2", log.Err(err2)))
 	}
-	sum := h.Sum(make([]byte, h.Size()))
+	sum := h.Sum([]byte{})
 	return binary.LittleEndian.Uint32(sum)
 }
 
@@ -231,7 +231,7 @@ func (fo *FixedRolacle) Proof(ctx context.Context, layer types.LayerID, round ui
 		fo.logger.WithContext(ctx).With().Error("error writing hash", log.Err(err))
 	}
 
-	sum := h.Sum(make([]byte, h.Size()))
+	sum := h.Sum([]byte{})
 
 	return sum, nil
 }

--- a/eligibility/fixedoracle_test.go
+++ b/eligibility/fixedoracle_test.go
@@ -186,7 +186,7 @@ func TestFixedRolacle_Export(t *testing.T) {
 
 	// when requesting a bigger committee size everyone should be eligible
 
-	m := oracle.Export(0, numOfClients)
+	m := oracle.Export(types.RandomHash(), numOfClients)
 
 	for _, s := range ids {
 		_, ok := m[s]

--- a/hare/haretypes.go
+++ b/hare/haretypes.go
@@ -2,7 +2,6 @@ package hare
 
 import (
 	"bytes"
-	"encoding/binary"
 	"fmt"
 	"sort"
 	"sync"
@@ -55,7 +54,7 @@ func (mType MessageType) String() string {
 type Set struct {
 	valuesMu  sync.RWMutex
 	values    map[types.ProposalID]struct{}
-	id        uint32
+	id        types.Hash32
 	isIDValid bool
 }
 
@@ -68,7 +67,7 @@ func NewDefaultEmptySet() *Set {
 func NewEmptySet(size int) *Set {
 	s := &Set{}
 	s.initWithSize(size)
-	s.id = 0
+	s.id = types.Hash32{}
 	s.isIDValid = false
 
 	return s
@@ -82,7 +81,7 @@ func NewSetFromValues(values ...types.ProposalID) *Set {
 	for _, v := range values {
 		s.Add(v)
 	}
-	s.id = 0
+	s.id = types.Hash32{}
 	s.isIDValid = false
 
 	return s
@@ -210,12 +209,12 @@ func (s *Set) updateID() {
 	}
 
 	// update
-	s.id = binary.LittleEndian.Uint32(h.Sum([]byte{}))
+	s.id = types.BytesToHash(h.Sum([]byte{}))
 	s.isIDValid = true
 }
 
 // ID returns the ObjectID of the set.
-func (s *Set) ID() uint32 {
+func (s *Set) ID() types.Hash32 {
 	if !s.isIDValid {
 		s.updateID()
 	}

--- a/hare/haretypes.go
+++ b/hare/haretypes.go
@@ -210,8 +210,7 @@ func (s *Set) updateID() {
 	}
 
 	// update
-	idBuf := make([]byte, h.Size())
-	s.id = binary.LittleEndian.Uint32(h.Sum(idBuf))
+	s.id = binary.LittleEndian.Uint32(h.Sum([]byte{}))
 	s.isIDValid = true
 }
 

--- a/hare/haretypes.go
+++ b/hare/haretypes.go
@@ -2,13 +2,14 @@ package hare
 
 import (
 	"bytes"
+	"encoding/binary"
 	"fmt"
-	"hash/fnv"
 	"sort"
 	"sync"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/hare/eligibility"
+	"github.com/spacemeshos/go-spacemesh/hash"
 )
 
 // MessageType is a message type.
@@ -203,13 +204,14 @@ func (s *Set) updateID() {
 	sort.Slice(keys, func(i, j int) bool { return bytes.Compare(keys[i].Bytes(), keys[j].Bytes()) == -1 })
 
 	// calc
-	h := fnv.New32()
+	h := hash.New()
 	for i := 0; i < len(keys); i++ {
 		h.Write(keys[i].Bytes())
 	}
 
 	// update
-	s.id = h.Sum32()
+	idBuf := make([]byte, h.Size())
+	s.id = binary.LittleEndian.Uint32(h.Sum(idBuf))
 	s.isIDValid = true
 }
 

--- a/hare/mock_oracle.go
+++ b/hare/mock_oracle.go
@@ -30,7 +30,7 @@ func (h *hasherU32) Hash(values ...[]byte) uint32 {
 	for _, b := range values {
 		hsh.Write(b)
 	}
-	return binary.LittleEndian.Uint32(hsh.Sum(make([]byte, 0)))
+	return binary.LittleEndian.Uint32(hsh.Sum([]byte{}))
 }
 
 func (h *hasherU32) MaxValue() uint32 {

--- a/hare/mock_oracle.go
+++ b/hare/mock_oracle.go
@@ -2,12 +2,13 @@ package hare
 
 import (
 	"context"
+	"encoding/binary"
 	"errors"
-	"hash/fnv"
 	"math"
 	"sync"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/hash"
 	"github.com/spacemeshos/go-spacemesh/log"
 )
 
@@ -25,11 +26,11 @@ func newHasherU32() *hasherU32 {
 }
 
 func (h *hasherU32) Hash(values ...[]byte) uint32 {
-	fnv := fnv.New32()
+	hsh := hash.New()
 	for _, b := range values {
-		fnv.Write(b)
+		hsh.Write(b)
 	}
-	return fnv.Sum32()
+	return binary.LittleEndian.Uint32(hsh.Sum(make([]byte, 0)))
 }
 
 func (h *hasherU32) MaxValue() uint32 {

--- a/hare/notifytracker.go
+++ b/hare/notifytracker.go
@@ -2,7 +2,8 @@ package hare
 
 import (
 	"encoding/binary"
-	"hash/fnv"
+
+	"github.com/spacemeshos/go-spacemesh/hash"
 )
 
 // notifyTracker tracks notify messages.
@@ -49,20 +50,20 @@ func (nt *notifyTracker) NotificationsCount(s *Set) int {
 
 // calculates a unique id for the provided k and set.
 func calcID(k uint32, set *Set) uint32 {
-	hash := fnv.New32()
+	h := hash.New()
 
 	// write K
 	buff := make([]byte, 4)
 	binary.LittleEndian.PutUint32(buff, k) // K>=0 because this not pre-round
-	hash.Write(buff)
+	h.Write(buff)
 
 	// TODO: is this hash enough for this usage?
 	// write set ObjectID
 	buff = make([]byte, 4)
 	binary.LittleEndian.PutUint32(buff, set.ID())
-	hash.Write(buff)
+	h.Write(buff)
 
-	return hash.Sum32()
+	return binary.LittleEndian.Uint32(h.Sum(make([]byte, h.Size())))
 }
 
 // tracks certificates.

--- a/hare/notifytracker.go
+++ b/hare/notifytracker.go
@@ -63,7 +63,7 @@ func calcID(k uint32, set *Set) uint32 {
 	binary.LittleEndian.PutUint32(buff, set.ID())
 	h.Write(buff)
 
-	return binary.LittleEndian.Uint32(h.Sum(make([]byte, h.Size())))
+	return binary.LittleEndian.Uint32(h.Sum([]byte{}))
 }
 
 // tracks certificates.


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
Closes #1508
<!-- `Closes #XXXX, closes #XXXX, ...` links mentioned issues to this PR and automatically closes them when this it's merged -->

The last remnants of FNV were in the hare package.

## Changes
<!-- Please describe in detail the changes made -->

Replaced usage of FNV with truncated SHA256 (what's used everywhere else)

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->

No extra tests. Existing tests must continue to pass.

