### PR TITLE
Remove sequence number from NIPostChallenge

### DIFF
--- a/activation/activation.go
+++ b/activation/activation.go
@@ -442,7 +442,6 @@ func (b *Builder) buildNIPostChallenge(ctx context.Context) error {
 		challenge.InitialPostIndices = b.initialPost.Indices
 	} else {
 		challenge.PrevATXID = prevAtx.ID()
-		challenge.Sequence = prevAtx.Sequence + 1
 	}
 	b.challenge = challenge
 	if err := b.storeChallenge(b.challenge); err != nil {

--- a/activation/activation_test.go
+++ b/activation/activation_test.go
@@ -326,8 +326,8 @@ func TestBuilder_waitForFirstATX(t *testing.T) {
 	b.initialPost = initialPost
 
 	layerStart := time.Now().Add(-1 * time.Millisecond)
-	poetWindwow := poetCfg.PhaseShift - poetCfg.CycleGap + poetCfg.GracePeriod
-	expectedWait := poetWindwow - time.Millisecond
+	poetWindow := poetCfg.PhaseShift - poetCfg.CycleGap + poetCfg.GracePeriod
+	expectedWait := poetWindow - time.Millisecond
 	ch := make(chan struct{}, 1)
 	close(ch)
 	current := types.NewLayerID(layersPerEpoch * 2)

--- a/activation/activation_test.go
+++ b/activation/activation_test.go
@@ -167,7 +167,6 @@ func newAtxHandler(tb testing.TB, cdb *datastore.CachedDB) *Handler {
 
 func newChallenge(sequence uint64, prevAtxID, posAtxID types.ATXID, pubLayerID types.LayerID) types.NIPostChallenge {
 	return types.NIPostChallenge{
-		Sequence:       sequence,
 		PrevATXID:      prevAtxID,
 		PubLayerID:     pubLayerID,
 		PositioningATX: posAtxID,
@@ -255,12 +254,10 @@ func assertLastAtx(r *require.Assertions, posAtx, prevAtx *types.ActivationTxHea
 	atx := sigAtx
 	r.Equal(sig.NodeID(), atx.NodeID())
 	if prevAtx != nil {
-		r.Equal(prevAtx.Sequence+1, atx.Sequence)
 		r.Equal(prevAtx.ID(), atx.PrevATXID)
 		r.Nil(atx.InitialPost)
 		r.Nil(atx.InitialPostIndices)
 	} else {
-		r.Zero(atx.Sequence)
 		r.Equal(*types.EmptyATXID, atx.PrevATXID)
 		r.NotNil(atx.InitialPost)
 		r.NotNil(atx.InitialPostIndices)
@@ -804,7 +801,6 @@ func TestBuilder_NIPostPublishRecovery(t *testing.T) {
 	assert.NoError(t, err)
 
 	challenge := types.NIPostChallenge{
-		Sequence:       2,
 		PrevATXID:      atx.ID(),
 		PubLayerID:     atx.PubLayerID.Add(b.layersPerEpoch),
 		PositioningATX: atx.ID(),

--- a/activation/handler.go
+++ b/activation/handler.go
@@ -138,12 +138,9 @@ func (h *Handler) ProcessAtx(ctx context.Context, atx *types.ActivationTx) error
 
 // SyntacticallyValidateAtx ensures the following conditions apply, otherwise it returns an error.
 //
-//   - If the sequence number is non-zero: PrevATX points to a syntactically valid ATX whose sequence number is one less
-//     than the current ATX's sequence number.
-//   - If the sequence number is zero: PrevATX is empty.
 //   - Positioning ATX points to a syntactically valid ATX.
 //   - NIPost challenge is a hash of the serialization of the following fields:
-//     NodeID, SequenceNumber, PrevATXID, LayerID, StartTick, PositioningATX.
+//     NodeID, PrevATXID, LayerID, StartTick, PositioningATX.
 //   - The NIPost is valid.
 //   - ATX LayerID is NIPostLayerTime or less after the PositioningATX LayerID.
 //   - The ATX view of the previous epoch contains ActiveSetSize activations.
@@ -173,10 +170,6 @@ func (h *Handler) SyntacticallyValidateAtx(ctx context.Context, atx *types.Activ
 				prevEp, prevATX.PubLayerID, curEp, atx.PubLayerID)
 		}
 
-		if prevATX.Sequence+1 != atx.Sequence {
-			return fmt.Errorf("sequence number is not one more than prev sequence number")
-		}
-
 		if atx.InitialPost != nil {
 			return fmt.Errorf("prevATX declared, but initial Post is included")
 		}
@@ -185,10 +178,6 @@ func (h *Handler) SyntacticallyValidateAtx(ctx context.Context, atx *types.Activ
 			return fmt.Errorf("prevATX declared, but initial Post indices is included in challenge")
 		}
 	} else {
-		if atx.Sequence != 0 {
-			return fmt.Errorf("no prevATX declared, but sequence number not zero")
-		}
-
 		if atx.InitialPost == nil {
 			return fmt.Errorf("no prevATX declared, but initial Post is not included")
 		}

--- a/activation/handler_test.go
+++ b/activation/handler_test.go
@@ -204,15 +204,8 @@ func TestHandler_ValidateAtxErrors(t *testing.T) {
 	err = atxHdlr.StoreAtx(context.TODO(), 1, posAtx)
 	assert.NoError(t, err)
 
-	// Wrong sequence.
-	atx := newActivationTx(sig, 0, prevAtx.ID(), posAtx.ID(), types.NewLayerID(1012), 0, 100, coinbase, 100, &types.NIPost{})
-	err = SignAtx(sig, atx)
-	assert.NoError(t, err)
-	err = atxHdlr.SyntacticallyValidateAtx(context.TODO(), atx)
-	assert.EqualError(t, err, "sequence number is not one more than prev sequence number")
-
 	// Wrong positioning atx.
-	atx = newActivationTx(sig, 1, prevAtx.ID(), atxList[0].ID(), types.NewLayerID(1012), 0, 100, coinbase, 100, &types.NIPost{})
+	atx := newActivationTx(sig, 1, prevAtx.ID(), atxList[0].ID(), types.NewLayerID(1012), 0, 100, coinbase, 100, &types.NIPost{})
 	err = SignAtx(sig, atx)
 	assert.NoError(t, err)
 	err = atxHdlr.SyntacticallyValidateAtx(context.TODO(), atx)
@@ -358,9 +351,6 @@ func TestHandler_ValidateAndInsertSorted(t *testing.T) {
 	atx = newActivationTx(sig, 4, prevAtx.ID(), prevAtx.ID(), types.NewLayerID(1012), 0, 100, coinbase, 100, &types.NIPost{})
 	err = SignAtx(sig, atx)
 	assert.NoError(t, err)
-
-	err = atxHdlr.SyntacticallyValidateAtx(context.TODO(), atx)
-	assert.EqualError(t, err, "sequence number is not one more than prev sequence number")
 
 	err = atxHdlr.StoreAtx(context.TODO(), 1, atx)
 	assert.NoError(t, err)
@@ -767,7 +757,6 @@ func TestHandler_AtxWeight(t *testing.T) {
 		InnerActivationTx: types.InnerActivationTx{
 			ActivationTxHeader: types.ActivationTxHeader{
 				NIPostChallenge: types.NIPostChallenge{
-					Sequence:       1,
 					PositioningATX: atx1.ID(),
 					PrevATXID:      atx1.ID(),
 					PubLayerID:     types.NewLayerID(1).Add(2 * layersPerEpoch),

--- a/activation/handler_test.go
+++ b/activation/handler_test.go
@@ -60,11 +60,11 @@ func TestHandler_GetNodeLastAtxId(t *testing.T) {
 	atxHdlr := getATXHandler(t, cdb)
 	coinbase1 := types.GenerateAddress([]byte("aaaa"))
 	epoch1 := types.EpochID(1)
-	atx1 := newAtx(newChallenge(0, *types.EmptyATXID, goldenATXID, epoch1.FirstLayer()), sig, &types.NIPost{}, 0, coinbase1)
+	atx1 := newAtx(newChallenge(*types.EmptyATXID, goldenATXID, epoch1.FirstLayer()), sig, &types.NIPost{}, 0, coinbase1)
 	r.NoError(atxHdlr.StoreAtx(context.TODO(), epoch1, atx1))
 
 	epoch2 := types.EpochID(2)
-	atx2 := newAtx(newChallenge(1, atx1.ID(), atx1.ID(), epoch2.FirstLayer()), sig, &types.NIPost{}, 0, coinbase1)
+	atx2 := newAtx(newChallenge(atx1.ID(), atx1.ID(), epoch2.FirstLayer()), sig, &types.NIPost{}, 0, coinbase1)
 	r.NoError(atxHdlr.StoreAtx(context.TODO(), epoch2, atx2))
 
 	atxid, err := atxs.GetLastIDByNodeID(cdb, sig.NodeID())
@@ -88,13 +88,13 @@ func TestMesh_processBlockATXs(t *testing.T) {
 	chlng := types.HexToHash32("0x3333")
 	poetRef := []byte{0x76, 0x45}
 	npst := newNIPostWithChallenge(&chlng, poetRef)
-	posATX := newActivationTx(sig, 0, *types.EmptyATXID, *types.EmptyATXID, types.NewLayerID(1000), 0, 100, coinbase1, 100, npst)
+	posATX := newActivationTx(sig, *types.EmptyATXID, *types.EmptyATXID, types.NewLayerID(1000), 0, 100, coinbase1, 100, npst)
 	err := atxHdlr.StoreAtx(context.TODO(), 0, posATX)
 	assert.NoError(t, err)
 	atxList := []*types.ActivationTx{
-		newActivationTx(sig, 0, *types.EmptyATXID, posATX.ID(), types.NewLayerID(1012), 0, 100, coinbase1, 100, &types.NIPost{}),
-		newActivationTx(sig, 0, *types.EmptyATXID, posATX.ID(), types.NewLayerID(1300), 0, 100, coinbase2, 100, &types.NIPost{}),
-		newActivationTx(sig, 0, *types.EmptyATXID, posATX.ID(), types.NewLayerID(1435), 0, 100, coinbase3, 100, &types.NIPost{}),
+		newActivationTx(sig, *types.EmptyATXID, posATX.ID(), types.NewLayerID(1012), 0, 100, coinbase1, 100, &types.NIPost{}),
+		newActivationTx(sig, *types.EmptyATXID, posATX.ID(), types.NewLayerID(1300), 0, 100, coinbase2, 100, &types.NIPost{}),
+		newActivationTx(sig, *types.EmptyATXID, posATX.ID(), types.NewLayerID(1435), 0, 100, coinbase3, 100, &types.NIPost{}),
 	}
 	for _, atx := range atxList {
 		hash, err := atx.NIPostChallenge.Hash()
@@ -107,9 +107,9 @@ func TestMesh_processBlockATXs(t *testing.T) {
 
 	// check that further atxList don't affect current epoch count
 	atxList2 := []*types.ActivationTx{
-		newActivationTx(sig, 1, atxList[0].ID(), atxList[0].ID(), types.NewLayerID(2012), 0, 100, coinbase1, 100, &types.NIPost{}),
-		newActivationTx(sig, 1, atxList[1].ID(), atxList[1].ID(), types.NewLayerID(2300), 0, 100, coinbase2, 100, &types.NIPost{}),
-		newActivationTx(sig, 1, atxList[2].ID(), atxList[2].ID(), types.NewLayerID(2435), 0, 100, coinbase3, 100, &types.NIPost{}),
+		newActivationTx(sig, atxList[0].ID(), atxList[0].ID(), types.NewLayerID(2012), 0, 100, coinbase1, 100, &types.NIPost{}),
+		newActivationTx(sig, atxList[1].ID(), atxList[1].ID(), types.NewLayerID(2300), 0, 100, coinbase2, 100, &types.NIPost{}),
+		newActivationTx(sig, atxList[2].ID(), atxList[2].ID(), types.NewLayerID(2435), 0, 100, coinbase3, 100, &types.NIPost{}),
 	}
 	for _, atx := range atxList2 {
 		hash, err := atx.NIPostChallenge.Hash()
@@ -140,9 +140,9 @@ func TestHandler_ValidateAtx(t *testing.T) {
 	coinbase2 := types.GenerateAddress([]byte("bbbb"))
 	coinbase3 := types.GenerateAddress([]byte("cccc"))
 	atxs := []*types.ActivationTx{
-		newActivationTx(sig1, 0, *types.EmptyATXID, *types.EmptyATXID, types.NewLayerID(1), 0, 100, coinbase1, 100, &types.NIPost{}),
-		newActivationTx(sig2, 0, *types.EmptyATXID, *types.EmptyATXID, types.NewLayerID(1), 0, 100, coinbase2, 100, &types.NIPost{}),
-		newActivationTx(sig3, 0, *types.EmptyATXID, *types.EmptyATXID, types.NewLayerID(1), 0, 100, coinbase3, 100, &types.NIPost{}),
+		newActivationTx(sig1, *types.EmptyATXID, *types.EmptyATXID, types.NewLayerID(1), 0, 100, coinbase1, 100, &types.NIPost{}),
+		newActivationTx(sig2, *types.EmptyATXID, *types.EmptyATXID, types.NewLayerID(1), 0, 100, coinbase2, 100, &types.NIPost{}),
+		newActivationTx(sig3, *types.EmptyATXID, *types.EmptyATXID, types.NewLayerID(1), 0, 100, coinbase3, 100, &types.NIPost{}),
 	}
 	poetRef := []byte{0x12, 0x21}
 	for _, atx := range atxs {
@@ -151,12 +151,12 @@ func TestHandler_ValidateAtx(t *testing.T) {
 		atx.NIPost = newNIPostWithChallenge(hash, poetRef)
 	}
 
-	prevAtx := newActivationTx(sig, 0, *types.EmptyATXID, *types.EmptyATXID, types.NewLayerID(100), 0, 100, coinbase1, 100, &types.NIPost{})
+	prevAtx := newActivationTx(sig, *types.EmptyATXID, *types.EmptyATXID, types.NewLayerID(100), 0, 100, coinbase1, 100, &types.NIPost{})
 	hash, err := prevAtx.NIPostChallenge.Hash()
 	assert.NoError(t, err)
 	prevAtx.NIPost = newNIPostWithChallenge(hash, poetRef)
 
-	atx := newActivationTx(sig, 1, prevAtx.ID(), prevAtx.ID(), types.NewLayerID(1012), 0, 100, coinbase1, 100, &types.NIPost{})
+	atx := newActivationTx(sig, prevAtx.ID(), prevAtx.ID(), types.NewLayerID(1012), 0, 100, coinbase1, 100, &types.NIPost{})
 	hash, err = atx.NIPostChallenge.Hash()
 	assert.NoError(t, err)
 	atx.NIPost = newNIPostWithChallenge(hash, poetRef)
@@ -188,38 +188,38 @@ func TestHandler_ValidateAtxErrors(t *testing.T) {
 	sig2 := NewMockSigner()
 	sig3 := NewMockSigner()
 	atxList := []*types.ActivationTx{
-		newActivationTx(sig1, 0, *types.EmptyATXID, *types.EmptyATXID, types.NewLayerID(1), 0, 100, coinbase, 100, &types.NIPost{}),
-		newActivationTx(sig2, 0, *types.EmptyATXID, *types.EmptyATXID, types.NewLayerID(1), 0, 100, coinbase, 100, &types.NIPost{}),
-		newActivationTx(sig3, 0, *types.EmptyATXID, *types.EmptyATXID, types.NewLayerID(1), 0, 100, coinbase, 100, &types.NIPost{}),
+		newActivationTx(sig1, *types.EmptyATXID, *types.EmptyATXID, types.NewLayerID(1), 0, 100, coinbase, 100, &types.NIPost{}),
+		newActivationTx(sig2, *types.EmptyATXID, *types.EmptyATXID, types.NewLayerID(1), 0, 100, coinbase, 100, &types.NIPost{}),
+		newActivationTx(sig3, *types.EmptyATXID, *types.EmptyATXID, types.NewLayerID(1), 0, 100, coinbase, 100, &types.NIPost{}),
 	}
 	require.NoError(t, processAtxs(atxHdlr, atxList))
 
 	chlng := types.HexToHash32("0x3333")
 	poetRef := []byte{0xba, 0xbe}
 	npst := newNIPostWithChallenge(&chlng, poetRef)
-	prevAtx := newActivationTx(sig, 0, *types.EmptyATXID, *types.EmptyATXID, types.NewLayerID(100), 0, 100, coinbase, 100, npst)
-	posAtx := newActivationTx(otherSig, 0, *types.EmptyATXID, *types.EmptyATXID, types.NewLayerID(100), 0, 100, coinbase, 100, npst)
+	prevAtx := newActivationTx(sig, *types.EmptyATXID, *types.EmptyATXID, types.NewLayerID(100), 0, 100, coinbase, 100, npst)
+	posAtx := newActivationTx(otherSig, *types.EmptyATXID, *types.EmptyATXID, types.NewLayerID(100), 0, 100, coinbase, 100, npst)
 	err := atxHdlr.StoreAtx(context.TODO(), 1, prevAtx)
 	assert.NoError(t, err)
 	err = atxHdlr.StoreAtx(context.TODO(), 1, posAtx)
 	assert.NoError(t, err)
 
 	// Wrong positioning atx.
-	atx := newActivationTx(sig, 1, prevAtx.ID(), atxList[0].ID(), types.NewLayerID(1012), 0, 100, coinbase, 100, &types.NIPost{})
+	atx := newActivationTx(sig, prevAtx.ID(), atxList[0].ID(), types.NewLayerID(1012), 0, 100, coinbase, 100, &types.NIPost{})
 	err = SignAtx(sig, atx)
 	assert.NoError(t, err)
 	err = atxHdlr.SyntacticallyValidateAtx(context.TODO(), atx)
 	assert.EqualError(t, err, "expected distance of one epoch (1000 layers) from pos atx but found 1011")
 
 	// Empty positioning atx.
-	atx = newActivationTx(sig, 1, prevAtx.ID(), *types.EmptyATXID, types.NewLayerID(2000), 0, 1, coinbase, 3, &types.NIPost{})
+	atx = newActivationTx(sig, prevAtx.ID(), *types.EmptyATXID, types.NewLayerID(2000), 0, 1, coinbase, 3, &types.NIPost{})
 	err = SignAtx(sig, atx)
 	assert.NoError(t, err)
 	err = atxHdlr.SyntacticallyValidateAtx(context.TODO(), atx)
 	assert.EqualError(t, err, "empty positioning atx")
 
 	// Using Golden ATX in epochs other than 1 is not allowed. Testing epoch 0.
-	atx = newActivationTx(sig, 0, *types.EmptyATXID, goldenATXID, types.NewLayerID(0), 0, 1, coinbase, 3, &types.NIPost{PostMetadata: &types.PostMetadata{}})
+	atx = newActivationTx(sig, *types.EmptyATXID, goldenATXID, types.NewLayerID(0), 0, 1, coinbase, 3, &types.NIPost{PostMetadata: &types.PostMetadata{}})
 	atx.InitialPost = initialPost
 	atx.InitialPostIndices = initialPost.Indices
 	err = SignAtx(sig, atx)
@@ -228,26 +228,26 @@ func TestHandler_ValidateAtxErrors(t *testing.T) {
 	assert.EqualError(t, err, "golden atx used for atx in epoch 0, but is only valid in epoch 1")
 
 	// Using Golden ATX in epochs other than 1 is not allowed. Testing epoch 2.
-	atx = newActivationTx(sig, 1, prevAtx.ID(), goldenATXID, types.NewLayerID(2000), 0, 1, coinbase, 3, &types.NIPost{})
+	atx = newActivationTx(sig, prevAtx.ID(), goldenATXID, types.NewLayerID(2000), 0, 1, coinbase, 3, &types.NIPost{})
 	err = SignAtx(sig, atx)
 	assert.NoError(t, err)
 	err = atxHdlr.SyntacticallyValidateAtx(context.TODO(), atx)
 	assert.EqualError(t, err, "golden atx used for atx in epoch 2, but is only valid in epoch 1")
 
 	// Wrong prevATx.
-	atx = newActivationTx(sig, 1, atxList[0].ID(), posAtx.ID(), types.NewLayerID(1012), 0, 100, coinbase, 100, &types.NIPost{})
+	atx = newActivationTx(sig, atxList[0].ID(), posAtx.ID(), types.NewLayerID(1012), 0, 100, coinbase, 100, &types.NIPost{})
 	err = SignAtx(sig, atx)
 	assert.NoError(t, err)
 	err = atxHdlr.SyntacticallyValidateAtx(context.TODO(), atx)
 	assert.EqualError(t, err, fmt.Sprintf("previous atx belongs to different miner. atx.ID: %v, atx.NodeID: %v, prevAtx.NodeID: %v", atx.ShortString(), atx.NodeID(), atxList[0].NodeID()))
 
 	// Wrong layerId.
-	posAtx2 := newActivationTx(otherSig, 0, *types.EmptyATXID, *types.EmptyATXID, types.NewLayerID(1020), 0, 100, coinbase, 100, npst)
+	posAtx2 := newActivationTx(otherSig, *types.EmptyATXID, *types.EmptyATXID, types.NewLayerID(1020), 0, 100, coinbase, 100, npst)
 	err = SignAtx(sig, atx)
 	assert.NoError(t, err)
 	err = atxHdlr.StoreAtx(context.TODO(), 1, posAtx2)
 	assert.NoError(t, err)
-	atx = newActivationTx(sig, 1, prevAtx.ID(), posAtx2.ID(), types.NewLayerID(1012), 0, 100, coinbase, 100, npst)
+	atx = newActivationTx(sig, prevAtx.ID(), posAtx2.ID(), types.NewLayerID(1012), 0, 100, coinbase, 100, npst)
 	err = SignAtx(sig, atx)
 	assert.NoError(t, err)
 	err = atxHdlr.SyntacticallyValidateAtx(context.TODO(), atx)
@@ -256,14 +256,14 @@ func TestHandler_ValidateAtxErrors(t *testing.T) {
 	// Atx already exists.
 	err = atxHdlr.StoreAtx(context.TODO(), 1, atx)
 	assert.NoError(t, err)
-	atx = newActivationTx(sig, 1, prevAtx.ID(), posAtx.ID(), types.NewLayerID(12), 0, 100, coinbase, 100, &types.NIPost{})
+	atx = newActivationTx(sig, prevAtx.ID(), posAtx.ID(), types.NewLayerID(12), 0, 100, coinbase, 100, &types.NIPost{})
 	err = atxHdlr.ContextuallyValidateAtx(&atx.ActivationTxHeader)
 	assert.EqualError(t, err, "last atx is not the one referenced")
 
 	// Prev atx declared but not found.
 	err = atxHdlr.StoreAtx(context.TODO(), 1, atx)
 	assert.NoError(t, err)
-	atx = newActivationTx(sig, 1, prevAtx.ID(), posAtx.ID(), types.NewLayerID(12), 0, 100, coinbase, 100, &types.NIPost{})
+	atx = newActivationTx(sig, prevAtx.ID(), posAtx.ID(), types.NewLayerID(12), 0, 100, coinbase, 100, &types.NIPost{})
 	require.NoError(t, atxs.DeleteATXsByNodeID(cdb, atx.NodeID()))
 
 	err = SignAtx(sig, atx)
@@ -272,14 +272,14 @@ func TestHandler_ValidateAtxErrors(t *testing.T) {
 	assert.ErrorIs(t, err, sql.ErrNotFound)
 
 	// Prev atx not declared but initial Post not included.
-	atx = newActivationTx(sig, 0, *types.EmptyATXID, posAtx.ID(), types.NewLayerID(1012), 0, 100, coinbase, 100, &types.NIPost{})
+	atx = newActivationTx(sig, *types.EmptyATXID, posAtx.ID(), types.NewLayerID(1012), 0, 100, coinbase, 100, &types.NIPost{})
 	err = SignAtx(sig, atx)
 	assert.NoError(t, err)
 	err = atxHdlr.SyntacticallyValidateAtx(context.TODO(), atx)
 	assert.EqualError(t, err, "no prevATX declared, but initial Post is not included")
 
 	// Prev atx not declared but initial Post indices not included.
-	atx = newActivationTx(sig, 0, *types.EmptyATXID, posAtx.ID(), types.NewLayerID(1012), 0, 100, coinbase, 100, &types.NIPost{})
+	atx = newActivationTx(sig, *types.EmptyATXID, posAtx.ID(), types.NewLayerID(1012), 0, 100, coinbase, 100, &types.NIPost{})
 	atx.InitialPost = initialPost
 	err = SignAtx(sig, atx)
 	assert.NoError(t, err)
@@ -287,7 +287,7 @@ func TestHandler_ValidateAtxErrors(t *testing.T) {
 	assert.EqualError(t, err, "no prevATX declared, but initial Post indices is not included in challenge")
 
 	// Challenge and initial Post indices mismatch.
-	atx = newActivationTx(sig, 0, *types.EmptyATXID, posAtx.ID(), types.NewLayerID(1012), 0, 100, coinbase, 100, &types.NIPost{})
+	atx = newActivationTx(sig, *types.EmptyATXID, posAtx.ID(), types.NewLayerID(1012), 0, 100, coinbase, 100, &types.NIPost{})
 	atx.InitialPost = initialPost
 	atx.InitialPostIndices = append([]byte{}, initialPost.Indices...)
 	atx.InitialPostIndices[0]++
@@ -297,7 +297,7 @@ func TestHandler_ValidateAtxErrors(t *testing.T) {
 	assert.EqualError(t, err, "initial Post indices included in challenge does not equal to the initial Post indices included in the atx")
 
 	// Prev atx declared but initial Post is included.
-	atx = newActivationTx(sig, 1, prevAtx.ID(), posAtx.ID(), types.NewLayerID(1012), 0, 100, coinbase, 100, &types.NIPost{})
+	atx = newActivationTx(sig, prevAtx.ID(), posAtx.ID(), types.NewLayerID(1012), 0, 100, coinbase, 100, &types.NIPost{})
 	atx.InitialPost = initialPost
 	err = SignAtx(sig, atx)
 	assert.NoError(t, err)
@@ -305,7 +305,7 @@ func TestHandler_ValidateAtxErrors(t *testing.T) {
 	assert.EqualError(t, err, "prevATX declared, but initial Post is included")
 
 	// Prev atx declared but initial Post indices is included.
-	atx = newActivationTx(sig, 1, prevAtx.ID(), posAtx.ID(), types.NewLayerID(1012), 0, 100, coinbase, 100, &types.NIPost{})
+	atx = newActivationTx(sig, prevAtx.ID(), posAtx.ID(), types.NewLayerID(1012), 0, 100, coinbase, 100, &types.NIPost{})
 	atx.InitialPostIndices = initialPost.Indices
 	err = SignAtx(sig, atx)
 	assert.NoError(t, err)
@@ -313,7 +313,7 @@ func TestHandler_ValidateAtxErrors(t *testing.T) {
 	assert.EqualError(t, err, "prevATX declared, but initial Post indices is included in challenge")
 
 	// Prev atx has publication layer in the same epoch as the atx.
-	atx = newActivationTx(sig, 1, prevAtx.ID(), posAtx.ID(), types.NewLayerID(100), 0, 100, coinbase, 100, &types.NIPost{})
+	atx = newActivationTx(sig, prevAtx.ID(), posAtx.ID(), types.NewLayerID(100), 0, 100, coinbase, 100, &types.NIPost{})
 	err = SignAtx(sig, atx)
 	assert.NoError(t, err)
 	err = atxHdlr.SyntacticallyValidateAtx(context.TODO(), atx)
@@ -330,41 +330,37 @@ func TestHandler_ValidateAndInsertSorted(t *testing.T) {
 	chlng := types.HexToHash32("0x3333")
 	poetRef := []byte{0x56, 0xbe}
 	npst := newNIPostWithChallenge(&chlng, poetRef)
-	prevAtx := newActivationTx(sig, 0, *types.EmptyATXID, *types.EmptyATXID, types.NewLayerID(100), 0, 100, coinbase, 100, npst)
+	prevAtx := newActivationTx(sig, *types.EmptyATXID, *types.EmptyATXID, types.NewLayerID(100), 0, 100, coinbase, 100, npst)
 
 	err := atxHdlr.StoreAtx(context.TODO(), 1, prevAtx)
 	assert.NoError(t, err)
 
 	// wrong sequence
-	atx := newActivationTx(sig, 1, prevAtx.ID(), prevAtx.ID(), types.NewLayerID(1012), 0, 100, coinbase, 100, &types.NIPost{})
+	atx := newActivationTx(sig, prevAtx.ID(), prevAtx.ID(), types.NewLayerID(1012), 0, 100, coinbase, 100, &types.NIPost{})
 	err = atxHdlr.StoreAtx(context.TODO(), 1, atx)
 	assert.NoError(t, err)
 
-	atx = newActivationTx(sig, 2, atx.ID(), atx.ID(), types.NewLayerID(1012), 0, 100, coinbase, 100, &types.NIPost{})
-	assert.NoError(t, err)
+	atx = newActivationTx(sig, atx.ID(), atx.ID(), types.NewLayerID(1012), 0, 100, coinbase, 100, &types.NIPost{})
 	err = SignAtx(sig, atx)
 	assert.NoError(t, err)
 	err = atxHdlr.StoreAtx(context.TODO(), 1, atx)
 	assert.NoError(t, err)
 	atx2id := atx.ID()
 
-	atx = newActivationTx(sig, 4, prevAtx.ID(), prevAtx.ID(), types.NewLayerID(1012), 0, 100, coinbase, 100, &types.NIPost{})
+	atx = newActivationTx(sig, atx.ID(), atx.ID(), types.NewLayerID(1012), 0, 100, coinbase, 100, &types.NIPost{})
 	err = SignAtx(sig, atx)
 	assert.NoError(t, err)
-
 	err = atxHdlr.StoreAtx(context.TODO(), 1, atx)
 	assert.NoError(t, err)
+	atx4id := atx.ID()
 
-	atx = newActivationTx(sig, 3, atx2id, prevAtx.ID(), types.NewLayerID(1012+layersPerEpoch), 0, 100, coinbase, 100, &types.NIPost{})
+	atx = newActivationTx(sig, atx2id, prevAtx.ID(), types.NewLayerID(1012+layersPerEpoch), 0, 100, coinbase, 100, &types.NIPost{})
 	err = atxHdlr.ContextuallyValidateAtx(&atx.ActivationTxHeader)
 	assert.EqualError(t, err, "last atx is not the one referenced")
 
-	err = atxHdlr.StoreAtx(context.TODO(), 1, atx)
-	assert.NoError(t, err)
-
 	id, err := atxs.GetLastIDByNodeID(cdb, sig.NodeID())
 	assert.NoError(t, err)
-	assert.Equal(t, atx.ID(), id)
+	assert.Equal(t, atx4id, id)
 
 	_, err = atxHdlr.cdb.GetAtxHeader(id)
 	assert.NoError(t, err)
@@ -375,19 +371,19 @@ func TestHandler_ValidateAndInsertSorted(t *testing.T) {
 	// test same sequence
 	otherSig := NewMockSigner()
 
-	prevAtx = newActivationTx(otherSig, 0, *types.EmptyATXID, *types.EmptyATXID, types.NewLayerID(100), 0, 100, coinbase, 100, npst)
+	prevAtx = newActivationTx(otherSig, *types.EmptyATXID, *types.EmptyATXID, types.NewLayerID(100), 0, 100, coinbase, 100, npst)
 	err = atxHdlr.StoreAtx(context.TODO(), 1, prevAtx)
 	assert.NoError(t, err)
-	atx = newActivationTx(otherSig, 1, prevAtx.ID(), prevAtx.ID(), types.NewLayerID(1012), 0, 100, coinbase, 100, &types.NIPost{})
+	atx = newActivationTx(otherSig, prevAtx.ID(), prevAtx.ID(), types.NewLayerID(1012), 0, 100, coinbase, 100, &types.NIPost{})
 	err = atxHdlr.StoreAtx(context.TODO(), 1, atx)
 	assert.NoError(t, err)
 	atxID := atx.ID()
 
-	atx = newActivationTx(otherSig, 2, atxID, atx.ID(), types.NewLayerID(1012+layersPerEpoch), 0, 100, coinbase, 100, &types.NIPost{})
+	atx = newActivationTx(otherSig, atxID, atx.ID(), types.NewLayerID(1012+layersPerEpoch), 0, 100, coinbase, 100, &types.NIPost{})
 	err = atxHdlr.StoreAtx(context.TODO(), 1, atx)
 	assert.NoError(t, err)
 
-	atx = newActivationTx(otherSig, 2, atxID, atx.ID(), types.NewLayerID(1012+2*layersPerEpoch), 0, 100, coinbase, 100, &types.NIPost{})
+	atx = newActivationTx(otherSig, atxID, atx.ID(), types.NewLayerID(1012+2*layersPerEpoch), 0, 100, coinbase, 100, &types.NIPost{})
 	err = atxHdlr.ContextuallyValidateAtx(&atx.ActivationTxHeader)
 	assert.EqualError(t, err, "last atx is not the one referenced")
 
@@ -400,7 +396,7 @@ func TestHandler_ProcessAtx(t *testing.T) {
 
 	atxHdlr := getATXHandler(t, newCachedDB(t))
 	coinbase := types.GenerateAddress([]byte("aaaa"))
-	atx := newActivationTx(sig, 0, *types.EmptyATXID, *types.EmptyATXID, types.NewLayerID(100), 0, 100, coinbase, 100, &types.NIPost{})
+	atx := newActivationTx(sig, *types.EmptyATXID, *types.EmptyATXID, types.NewLayerID(100), 0, 100, coinbase, 100, &types.NIPost{})
 
 	err := atxHdlr.ProcessAtx(context.TODO(), atx)
 	r.NoError(err)
@@ -418,7 +414,7 @@ func BenchmarkActivationDb_SyntacticallyValidateAtx(b *testing.B) {
 	coinbase := types.GenerateAddress([]byte("c012ba5e"))
 	var atxList []*types.ActivationTx
 	for i := 0; i < activesetSize; i++ {
-		atxList = append(atxList, newActivationTx(sig, 0, *types.EmptyATXID, *types.EmptyATXID, types.NewLayerID(1), 0, 100, coinbase, 100, &types.NIPost{}))
+		atxList = append(atxList, newActivationTx(sig, *types.EmptyATXID, *types.EmptyATXID, types.NewLayerID(1), 0, 100, coinbase, 100, &types.NIPost{}))
 	}
 
 	poetRef := []byte{0x12, 0x21}
@@ -428,12 +424,12 @@ func BenchmarkActivationDb_SyntacticallyValidateAtx(b *testing.B) {
 		atx.NIPost = newNIPostWithChallenge(hash, poetRef)
 	}
 
-	challenge := newChallenge(0, *types.EmptyATXID, goldenATXID, types.LayerID{}.Add(numberOfLayers+1))
+	challenge := newChallenge(*types.EmptyATXID, goldenATXID, types.LayerID{}.Add(numberOfLayers+1))
 	hash, err := challenge.Hash()
 	r.NoError(err)
 	prevAtx := newAtx(challenge, sig, newNIPostWithChallenge(hash, poetRef), 2, coinbase)
 
-	atx := newActivationTx(sig, 1, prevAtx.ID(), prevAtx.ID(), types.LayerID{}.Add(numberOfLayers+1+layersPerEpochBig), 0, 100, coinbase, 100, &types.NIPost{})
+	atx := newActivationTx(sig, prevAtx.ID(), prevAtx.ID(), types.LayerID{}.Add(numberOfLayers+1+layersPerEpochBig), 0, 100, coinbase, 100, &types.NIPost{})
 	hash, err = atx.NIPostChallenge.Hash()
 	r.NoError(err)
 	atx.NIPost = newNIPostWithChallenge(hash, poetRef)
@@ -479,7 +475,7 @@ func BenchmarkNewActivationDb(b *testing.B) {
 	eStart := time.Now()
 	for epoch := postGenesisEpoch; epoch < postGenesisEpoch+numOfEpochs; epoch++ {
 		for miner := 0; miner < numOfMiners; miner++ {
-			challenge := newChallenge(1, prevAtxs[miner], posAtx, layer)
+			challenge := newChallenge(prevAtxs[miner], posAtx, layer)
 			h, err := challenge.Hash()
 			r.NoError(err)
 			atx = newAtx(challenge, sig, newNIPostWithChallenge(h, poetBytes), 2, coinbase)
@@ -541,7 +537,7 @@ func TestHandler_TopAtx(t *testing.T) {
 }
 
 func createAndStoreAtx(atxHdlr *Handler, layer types.LayerID) (*types.ActivationTx, error) {
-	atx := newActivationTx(sig, 0, *types.EmptyATXID, *types.EmptyATXID, layer, 0, 100, coinbase, 100, &types.NIPost{})
+	atx := newActivationTx(sig, *types.EmptyATXID, *types.EmptyATXID, layer, 0, 100, coinbase, 100, &types.NIPost{})
 	err := atxHdlr.StoreAtx(context.TODO(), atx.TargetEpoch(), atx)
 	if err != nil {
 		return nil, err
@@ -554,7 +550,7 @@ func TestHandler_AwaitAtx(t *testing.T) {
 
 	lg := logtest.New(t).WithName("sigValidation")
 	atxHdlr := NewHandler(datastore.NewCachedDB(sql.InMemory(), lg), nil, layersPerEpochBig, testTickSize, goldenATXID, &ValidatorMock{}, lg.WithName("atxHandler"))
-	atx := newActivationTx(sig, 0, *types.EmptyATXID, *types.EmptyATXID, types.NewLayerID(1), 0, 100, coinbase, 100, &types.NIPost{})
+	atx := newActivationTx(sig, *types.EmptyATXID, *types.EmptyATXID, types.NewLayerID(1), 0, 100, coinbase, 100, &types.NIPost{})
 
 	ch := atxHdlr.AwaitAtx(atx.ID())
 	r.Len(atxHdlr.atxChannels, 1) // channel was created
@@ -593,19 +589,19 @@ func TestHandler_ContextuallyValidateAtx(t *testing.T) {
 	lg := logtest.New(t).WithName("sigValidation")
 	atxHdlr := NewHandler(datastore.NewCachedDB(sql.InMemory(), lg), nil, layersPerEpochBig, testTickSize, goldenATXID, &ValidatorMock{}, lg.WithName("atxHandler"))
 
-	validAtx := newAtx(newChallenge(0, *types.EmptyATXID, goldenATXID, types.LayerID{}), sig, nil, 0, types.Address{})
+	validAtx := newAtx(newChallenge(*types.EmptyATXID, goldenATXID, types.LayerID{}), sig, nil, 0, types.Address{})
 	err := atxHdlr.ContextuallyValidateAtx(&validAtx.ActivationTxHeader)
 	r.NoError(err)
 
 	arbitraryAtxID := types.ATXID(types.HexToHash32("11111"))
-	malformedAtx := newAtx(newChallenge(0, arbitraryAtxID, goldenATXID, types.LayerID{}), sig, nil, 0, types.Address{})
+	malformedAtx := newAtx(newChallenge(arbitraryAtxID, goldenATXID, types.LayerID{}), sig, nil, 0, types.Address{})
 	err = atxHdlr.ContextuallyValidateAtx(&malformedAtx.ActivationTxHeader)
 	r.ErrorIs(err, sql.ErrNotFound)
 }
 
 func TestHandler_HandleAtxNilNipst(t *testing.T) {
 	atxHdlr := getATXHandler(t, newCachedDB(t))
-	atx := newActivationTx(sig, 0, *types.EmptyATXID, *types.EmptyATXID, types.LayerID{}, 0, 0, coinbase, 0, nil)
+	atx := newActivationTx(sig, *types.EmptyATXID, *types.EmptyATXID, types.LayerID{}, 0, 0, coinbase, 0, nil)
 	buf, err := codec.Encode(atx)
 	require.NoError(t, err)
 	require.Error(t, atxHdlr.HandleAtxData(context.TODO(), buf))
@@ -613,7 +609,7 @@ func TestHandler_HandleAtxNilNipst(t *testing.T) {
 
 func TestHandler_KnownATX(t *testing.T) {
 	atxHdlr := getATXHandler(t, newCachedDB(t))
-	atx := newActivationTx(sig, 0, *types.EmptyATXID, *types.EmptyATXID, types.LayerID{}, 0, 0, coinbase, 0, nil)
+	atx := newActivationTx(sig, *types.EmptyATXID, *types.EmptyATXID, types.LayerID{}, 0, 0, coinbase, 0, nil)
 	require.NoError(t, atxHdlr.ProcessAtx(context.TODO(), atx))
 	require.NoError(t, SignAtx(sig, atx))
 	buf, err := codec.Encode(atx)
@@ -636,8 +632,8 @@ func BenchmarkGetAtxHeaderWithConcurrentStoreAtx(b *testing.B) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			for i := 0; ; i++ {
-				atx := types.NewActivationTx(newChallenge(uint64(i), *types.EmptyATXID, goldenATXID, types.NewLayerID(0)), types.Address{}, nil, 0, nil)
+			for {
+				atx := types.NewActivationTx(newChallenge(*types.EmptyATXID, goldenATXID, types.NewLayerID(0)), types.Address{}, nil, 0, nil)
 				if !assert.NoError(b, atxHdlr.StoreAtx(context.TODO(), types.EpochID(1), atx)) {
 					return
 				}
@@ -663,7 +659,7 @@ func TestHandler_FetchAtxReferences(t *testing.T) {
 	mockFetch := mocks.NewMockFetcher(gomock.NewController(t))
 	atxHdlr := NewHandler(newCachedDB(t), mockFetch, layersPerEpoch, testTickSize,
 		goldenATXID, &ValidatorMock{}, logtest.New(t).WithName("atxHandler"))
-	challenge := newChallenge(1, prevAtxID, prevAtxID, postGenesisEpochLayer)
+	challenge := newChallenge(prevAtxID, prevAtxID, postGenesisEpochLayer)
 
 	atx1 := newAtx(challenge, sig, nipost, 2, coinbase)
 	atx1.PositioningATX = types.ATXID{1, 2, 3} // should be fetched

--- a/api/grpcserver/grpcserver_test.go
+++ b/api/grpcserver/grpcserver_test.go
@@ -317,7 +317,6 @@ func NewTx(nonce uint64, recipient types.Address, signer *signing.EdSigner) *typ
 
 func newChallenge(sequence uint64, prevAtxID, posAtxID types.ATXID, pubLayerID types.LayerID) types.NIPostChallenge {
 	return types.NIPostChallenge{
-		Sequence:       sequence,
 		PrevATXID:      prevAtxID,
 		PubLayerID:     pubLayerID,
 		PositioningATX: posAtxID,

--- a/common/types/activation.go
+++ b/common/types/activation.go
@@ -188,11 +188,10 @@ func (atxh *ActivationTxHeader) Verify(baseTickHeight, tickCount uint64) {
 }
 
 // NIPostChallenge is the set of fields that's serialized, hashed and submitted to the PoET service to be included in the
-// PoET membership proof. It includes ATX sequence number, the previous ATX's ID (for all but the first in the sequence),
-// the intended publication layer ID, the PoET's start and end ticks, the positioning ATX's ID and for
-// the first ATX in the sequence also the commitment Merkle root.
+// PoET membership proof. It includes the previous ATX's ID (for all but the first in the sequence), the intended publication
+// layer ID, the PoET's start and end ticks, the positioning ATX's ID and for the first ATX in the sequence also the
+// commitment Merkle root.
 type NIPostChallenge struct {
-	Sequence           uint64
 	PrevATXID          ATXID
 	PubLayerID         LayerID
 	PositioningATX     ATXID
@@ -212,8 +211,7 @@ func (challenge *NIPostChallenge) Hash() (*Hash32, error) {
 // String returns a string representation of the NIPostChallenge, for logging purposes.
 // It implements the Stringer interface.
 func (challenge *NIPostChallenge) String() string {
-	return fmt.Sprintf("<seq: %v, prevATX: %v, PubLayer: %v, posATX: %s>",
-		challenge.Sequence,
+	return fmt.Sprintf("<prevATX: %v, PubLayer: %v, posATX: %s>",
 		challenge.PrevATXID.ShortString(),
 		challenge.PubLayerID,
 		challenge.PositioningATX.ShortString())
@@ -273,7 +271,6 @@ func (atx *ActivationTx) MarshalLogObject(encoder log.ObjectEncoder) error {
 	encoder.AddUint32("pub_layer_id", atx.PubLayerID.Value)
 	encoder.AddUint32("epoch", uint32(atx.PubLayerID.GetEpoch()))
 	encoder.AddUint64("num_units", uint64(atx.NumUnits))
-	encoder.AddUint64("sequence_number", atx.Sequence)
 	if atx.verified {
 		encoder.AddUint64("base_tick_height", atx.baseTickHeight)
 		encoder.AddUint64("tick_count", atx.tickCount)

--- a/common/types/activation_scale.go
+++ b/common/types/activation_scale.go
@@ -60,13 +60,6 @@ func (t *ActivationTxHeader) DecodeScale(dec *scale.Decoder) (total int, err err
 
 func (t *NIPostChallenge) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	{
-		n, err := scale.EncodeCompact64(enc, uint64(t.Sequence))
-		if err != nil {
-			return total, err
-		}
-		total += n
-	}
-	{
 		n, err := scale.EncodeByteArray(enc, t.PrevATXID[:])
 		if err != nil {
 			return total, err
@@ -98,14 +91,6 @@ func (t *NIPostChallenge) EncodeScale(enc *scale.Encoder) (total int, err error)
 }
 
 func (t *NIPostChallenge) DecodeScale(dec *scale.Decoder) (total int, err error) {
-	{
-		field, n, err := scale.DecodeCompact64(dec)
-		if err != nil {
-			return total, err
-		}
-		total += n
-		t.Sequence = uint64(field)
-	}
 	{
 		n, err := scale.DecodeByteArray(dec, t.PrevATXID[:])
 		if err != nil {

--- a/sql/atxs/atxs_test.go
+++ b/sql/atxs/atxs_test.go
@@ -96,7 +96,6 @@ func TestGetLastIDByNodeID(t *testing.T) {
 	atx2 := newAtx(sig1, types.NewLayerID(uint32(2*layersPerEpoch)))
 	atx3 := newAtx(sig2, types.NewLayerID(uint32(3*layersPerEpoch)))
 	atx4 := newAtx(sig2, types.NewLayerID(uint32(3*layersPerEpoch)))
-	atx4.Sequence = atx3.Sequence + 1
 	atx4.CalcAndSetID()
 
 	for _, atx := range []*types.ActivationTx{atx1, atx2, atx3, atx4} {


### PR DESCRIPTION
## Motivation
Sequence number isn't used any more.

## Changes
Remove field from NIPostChallenge and remove validation for it

## Test Plan
Existing Tests

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
