### PR TITLE
[Merged by Bors] - fix flaky tests against time

### DIFF
--- a/timesync/clock.go
+++ b/timesync/clock.go
@@ -58,7 +58,7 @@ func NewClock(c Clock, tickInterval time.Duration, genesisTime time.Time, logger
 func (t *TimeClock) startClock() error {
 	t.log.Info("starting global clock now=%v genesis=%v %p", t.clock.Now(), t.genesis, t)
 
-	tmr := time.NewTimer(0)
+	tmr := time.NewTimer(time.Hour)
 	defer tmr.Stop()
 	for {
 		currLayer := t.Ticker.TimeToLayer(t.clock.Now()) // get current layer

--- a/timesync/clock.go
+++ b/timesync/clock.go
@@ -58,8 +58,6 @@ func NewClock(c Clock, tickInterval time.Duration, genesisTime time.Time, logger
 func (t *TimeClock) startClock() error {
 	t.log.Info("starting global clock now=%v genesis=%v %p", t.clock.Now(), t.genesis, t)
 
-	tmr := time.NewTimer(time.Hour)
-	defer tmr.Stop()
 	for {
 		currLayer := t.Ticker.TimeToLayer(t.clock.Now()) // get current layer
 		nextLayer := currLayer.Add(1)
@@ -68,13 +66,14 @@ func (t *TimeClock) startClock() error {
 		}
 		nextTickTime := t.Ticker.LayerToTime(nextLayer) // get next tick time for the next layer
 		diff := nextTickTime.Sub(t.clock.Now())
-		tmr.Reset(diff)
 		t.log.With().Info("global clock going to sleep before next layer",
 			log.String("diff", diff.String()),
 			log.FieldNamed("curr_layer", currLayer),
 			log.FieldNamed("next_layer", nextLayer))
+		tmr := time.NewTimer(diff)
 		select {
 		case <-tmr.C:
+			tmr.Stop()
 			t.mu.Lock()
 			subscriberCount := len(t.subscribers)
 			t.mu.Unlock()
@@ -90,6 +89,7 @@ func (t *TimeClock) startClock() error {
 					log.Int("missed", missed))
 			}
 		case <-t.stop:
+			tmr.Stop()
 			t.log.Info("stopping global clock %p", t)
 			return nil
 		}


### PR DESCRIPTION
## Motivation
fix flaky tests

tested with 
```
go clean -testcache && go test ./activation/ -v -run "^TestBuilder_waitForFirstATX" -count 2000
go clean -testcache && go test ./timesync/ -v -run "^TestClock_" -count 1000
```
