### PR TITLE
[Merged by Bors] - syncer do not set hare output for empty layer

### DIFF
--- a/api/grpcserver/mesh_service.go
+++ b/api/grpcserver/mesh_service.go
@@ -573,6 +573,8 @@ func convertLayerStatus(in int) pb.Layer_LayerStatus {
 		return pb.Layer_LAYER_STATUS_APPROVED
 	case events.LayerStatusTypeConfirmed:
 		return pb.Layer_LAYER_STATUS_CONFIRMED
+	case events.LayerStatusTypeApplied:
+		return pb.Layer_LAYER_STATUS_APPLIED
 	default:
 		return pb.Layer_LAYER_STATUS_UNSPECIFIED
 	}

--- a/events/reporter.go
+++ b/events/reporter.go
@@ -331,6 +331,7 @@ const (
 	LayerStatusTypeUnknown   = iota
 	LayerStatusTypeApproved  // approved by Hare
 	LayerStatusTypeConfirmed // confirmed by Tortoise
+	LayerStatusTypeApplied   // applied to state
 )
 
 // LayerUpdate packages up a layer with its status (which a layer does not ordinarily contain).

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/prometheus/common v0.37.0
 	github.com/pyroscope-io/pyroscope v0.27.0
 	github.com/seehuhn/mt19937 v1.0.0
-	github.com/spacemeshos/api/release/go v1.4.1-0.20220808081923-57864fb8ea2e
+	github.com/spacemeshos/api/release/go v1.4.1-0.20220905145225-2baea06a0206
 	github.com/spacemeshos/ed25519 v0.0.0-20220819111725-6f9b8412778f
 	github.com/spacemeshos/fixed v0.0.0-20210523192743-8d17e03c169a
 	github.com/spacemeshos/go-scale v0.0.0-20220825075539-b6b3deb9834c
@@ -159,7 +159,6 @@ require (
 	github.com/pyroscope-io/dotnetdiag v1.2.1 // indirect
 	github.com/raulk/go-watchdog v1.3.0 // indirect
 	github.com/robfig/cron/v3 v3.0.1 // indirect
-	github.com/rogpeppe/go-internal v1.8.1 // indirect
 	github.com/shirou/gopsutil v3.21.4+incompatible // indirect
 	github.com/spacemeshos/bitstream v0.0.0-20210407173523-8168e84f83b0 // indirect
 	github.com/spacemeshos/sha256-simd v0.0.0-20190111104731-8575aafc88c9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -289,7 +289,6 @@ github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:Fecb
 github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 h1:+9834+KizmvFV7pXQGSXQTsaWhq2GjuNUt0aUU0YBYw=
 github.com/grpc-ecosystem/go-grpc-middleware v1.3.0/go.mod h1:z0ButlSOZa5vEBq9m2m2hlwIgKw+rp3sdCBRoJY+30Y=
 github.com/grpc-ecosystem/grpc-gateway v1.5.0/go.mod h1:RSKVYQBd5MCa4OVpNdGskqpgL2+G+NZTnrVHpWWfpdw=
-github.com/grpc-ecosystem/grpc-gateway v1.14.6/go.mod h1:zdiPV4Yse/1gnckTHtghG4GkDEdKCRJduHpTxT3/jcw=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0 h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4M0+kPpLofRdBo=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.11.3 h1:lLT7ZLSzGLI08vc9cpd+tYmNWjdKDqyr/2L+f6U12Fk=
@@ -528,7 +527,6 @@ github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3v
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pelletier/go-toml/v2 v2.0.1 h1:8e3L2cCQzLFi2CR4g7vGFuFxX7Jl1kKX8gW+iV0GUKU=
 github.com/pelletier/go-toml/v2 v2.0.1/go.mod h1:r9LEWfGN8R5k0VXJ+0BkIe7MYkRdwZOjgMj2KwnJFUo=
-github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -575,7 +573,6 @@ github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzG
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.8.1 h1:geMPLpDpQOgVyCg5z5GoRwLHepNdb71NXb67XFkP+Eg=
-github.com/rogpeppe/go-internal v1.8.1/go.mod h1:JeRgkft04UBgHMgCIwADu4Pn6Mtm5d4nPKWu0nJ5d+o=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -614,8 +611,8 @@ github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d/go.mod h1:UdhH50NIW0fCiwBSr0co2m7BnFLdv4fQTgdqdJTHFeE=
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
-github.com/spacemeshos/api/release/go v1.4.1-0.20220808081923-57864fb8ea2e h1:52WP6W7E5JkOF2B78J0sdmN+iORp+UZUOH6mWO34ToY=
-github.com/spacemeshos/api/release/go v1.4.1-0.20220808081923-57864fb8ea2e/go.mod h1:kNY4cuAimIxpUbMLPZSgU8jl7Zbv5ohQrLn87ybl0QI=
+github.com/spacemeshos/api/release/go v1.4.1-0.20220905145225-2baea06a0206 h1:x5ldxg+NiUip+lLrHH39bKCAJrHdNa+rxOEg/yVAraM=
+github.com/spacemeshos/api/release/go v1.4.1-0.20220905145225-2baea06a0206/go.mod h1:rn6ND0nWI/EKtiwBiEiYC4lOHvInamNlvR4YMsm+hy8=
 github.com/spacemeshos/bitstream v0.0.0-20210407173523-8168e84f83b0 h1:f5AVMlh6x7rVJ+SoYvqkOl284OpdPw7tH5aBliIt0gc=
 github.com/spacemeshos/bitstream v0.0.0-20210407173523-8168e84f83b0/go.mod h1:wnp+444ieV6+UUjPYJ8id/kuQbk4jZ6NWp5Nw6O091E=
 github.com/spacemeshos/ed25519 v0.0.0-20220819111725-6f9b8412778f h1:x87xdFatVFfWYPycpjS94zyauvzK0GaVVjy07VeoRL0=
@@ -786,7 +783,6 @@ golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190628185345-da137c7871d7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190724013045-ca1201d0de80/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20191002035440-2ec189313ef0/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -893,7 +889,6 @@ golang.org/x/sys v0.0.0-20200523222454-059865788121/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200602225109-6fdc65e7d980/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200727154430-2d971f7391a4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200814200057-3d37ad5750ed/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200905004654-be1d3432aa8f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -1073,7 +1068,6 @@ google.golang.org/genproto v0.0.0-20200513103714-09dca8ec2884/go.mod h1:55QSHmfG
 google.golang.org/genproto v0.0.0-20200515170657-fc4c6c6a6587/go.mod h1:YsZOwe1myG/8QRHRsmBRE1LrgQY60beZKjly0O1fX9U=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
 google.golang.org/genproto v0.0.0-20200618031413-b414f8b61790/go.mod h1:jDfRM7FcilCzHH/e9qn6dsT145K34l5v+OpcnNgKAAA=
-google.golang.org/genproto v0.0.0-20200726014623-da3ae01ef02d/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200729003335-053ba62fc06f/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200804131852-c06518451d9c/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200825200019-8632dd797987/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=

--- a/mesh/mesh.go
+++ b/mesh/mesh.go
@@ -418,6 +418,10 @@ func persistLayerHashes(logger log.Log, dbtx *sql.Tx, lid types.LayerID, bids []
 		logger.With().Error("failed to set layer hashes", lid, log.Err(err))
 		return err
 	}
+	events.ReportLayerUpdate(events.LayerUpdate{
+		LayerID: lid,
+		Status:  events.LayerStatusTypeApplied,
+	})
 	logger.With().Info("layer hashes updated",
 		lid,
 		log.String("hash", hash.ShortString()),

--- a/mesh/mesh.go
+++ b/mesh/mesh.go
@@ -23,10 +23,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/sql/rewards"
 )
 
-var (
-	errMissingHareOutput = errors.New("missing hare output")
-	errLayerHasBlock     = errors.New("layer has block")
-)
+var errMissingHareOutput = errors.New("missing hare output")
 
 // Mesh is the logic layer above our mesh.DB database.
 type Mesh struct {
@@ -82,11 +79,6 @@ func NewMesh(cdb *datastore.CachedDB, trtl tortoise, state conservativeState, lo
 	gLid := types.GetEffectiveGenesis()
 	if err = cdb.WithTx(context.Background(), func(dbtx *sql.Tx) error {
 		for i := types.NewLayerID(1); !i.After(gLid); i = i.Add(1) {
-			if i.Before(gLid) {
-				if err = setZeroBlockLayer(msh.logger, dbtx, i); err != nil {
-					return err
-				}
-			}
 			if err = layers.SetProcessed(dbtx, i); err != nil {
 				return fmt.Errorf("mesh init: %w", err)
 			}
@@ -621,36 +613,11 @@ func (msh *Mesh) setLatestLayerInState(lyr types.LayerID) {
 	msh.latestLayerInState.Store(lyr)
 }
 
-// SetZeroBlockLayer tags lyr as a layer without blocks.
+// SetZeroBlockLayer advances the latest layer in the network with a layer
+// that truly has no data.
 func (msh *Mesh) SetZeroBlockLayer(ctx context.Context, lid types.LayerID) error {
-	logger := msh.logger.WithContext(ctx)
-	if err := setZeroBlockLayer(logger, msh.cdb, lid); err != nil {
-		return err
-	}
-	msh.setLatestLayer(logger, lid)
+	msh.setLatestLayer(msh.logger.WithContext(ctx), lid)
 	return nil
-}
-
-func setZeroBlockLayer(logger log.Log, db sql.Executor, lyr types.LayerID) error {
-	logger.With().Info("tagging zero block layer", lyr)
-	// check database for layer
-	if l, err := getLayer(db, lyr); err != nil {
-		// database error
-		if !errors.Is(err, sql.ErrNotFound) {
-			logger.With().Error("error trying to fetch layer from database", lyr, log.Err(err))
-			return err
-		}
-	} else if len(l.Blocks()) != 0 {
-		// layer exists
-		logger.With().Error("layer has blocks, cannot tag as zero block layer",
-			lyr,
-			l,
-			log.Int("num_blocks", len(l.Blocks())))
-		return errLayerHasBlock
-	}
-
-	// layer doesn't exist, need to insert new layer
-	return layers.SetHareOutput(db, lyr, types.EmptyBlockID)
 }
 
 // AddTXsFromProposal adds the TXs in a Proposal into the database.

--- a/syncer/syncer_test.go
+++ b/syncer/syncer_test.go
@@ -492,6 +492,11 @@ func TestSyncMissingLayer(t *testing.T) {
 	})
 	require.NoError(t, blocks.Add(ts.cdb, block))
 	require.NoError(t, layers.SetHareOutput(ts.cdb, failed, block.ID()))
+	for lid := genesis.Add(1); lid.Before(last); lid = lid.Add(1) {
+		if lid != failed {
+			require.NoError(t, layers.SetHareOutput(ts.cdb, lid, types.EmptyBlockID))
+		}
+	}
 
 	for lid := genesis.Add(1); lid.Before(last); lid = lid.Add(1) {
 		ts.mLyrFetcher.EXPECT().PollLayerData(gomock.Any(), lid).Return(okCh())

--- a/systest/tests/nodes_test.go
+++ b/systest/tests/nodes_test.go
@@ -141,8 +141,8 @@ func TestFailedNodes(t *testing.T) {
 		i := i
 		client := cl.Client(i)
 		watchLayers(ctx, eg, client, func(layer *spacemeshv1.LayerStreamResponse) (bool, error) {
-			if layer.Layer.Status == spacemeshv1.Layer_LAYER_STATUS_CONFIRMED {
-				tctx.Log.Debugw("confirmed layer",
+			if layer.Layer.Status == spacemeshv1.Layer_LAYER_STATUS_APPLIED {
+				tctx.Log.Debugw("layer applied",
 					"client", client.Name,
 					"layer", layer.Layer.Number.Number,
 					"hash", prettyHex(layer.Layer.Hash),

--- a/systest/tests/timeskew_test.go
+++ b/systest/tests/timeskew_test.go
@@ -14,7 +14,6 @@ import (
 )
 
 func TestShortTimeskew(t *testing.T) {
-	t.Skip()
 	t.Parallel()
 
 	tctx := testcontext.New(t, testcontext.Labels("sanity"))

--- a/systest/tests/timeskew_test.go
+++ b/systest/tests/timeskew_test.go
@@ -58,8 +58,8 @@ func TestShortTimeskew(t *testing.T) {
 		if layer.Layer.Number.Number == stopTest {
 			return false, nil
 		}
-		if layer.Layer.Status == spacemeshv1.Layer_LAYER_STATUS_CONFIRMED {
-			tctx.Log.Debugw("confirmed layer",
+		if layer.Layer.Status == spacemeshv1.Layer_LAYER_STATUS_APPLIED {
+			tctx.Log.Debugw("layer applied",
 				"layer", layer.Layer.Number.Number,
 				"hash", prettyHex(layer.Layer.Hash),
 			)


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
Closes #3522 
<!-- `Closes #XXXX, closes #XXXX, ...` links mentioned issues to this PR and automatically closes them when this it's merged -->

## Changes
<!-- Please describe in detail the changes made -->
- when syncing, remove call to SetHareOutput on empty block ID when layer is empty. it should wait for a certificate instead.
- undo retry stream in TestFailedNodes.
- emit event Layer_LAYER_STATUS_APPLIED when a block is applied and use that for systest