### PR TITLE
[Merged by Bors] - consistent active set for hare and tortoise in the network

### DIFF
--- a/config/presets/fastnet.go
+++ b/config/presets/fastnet.go
@@ -43,6 +43,9 @@ func fastnet() config.Config {
 	conf.LayerDurationSec = 15
 	conf.LayersPerEpoch = 4
 
+	conf.HareEligibility.ConfidenceParam = 2 // half epoch
+	conf.HareEligibility.EpochOffset = 0
+
 	conf.POST.BitsPerLabel = 8
 	conf.POST.K1 = 2000
 	conf.POST.K2 = 4

--- a/hare/eligibility/config/config.go
+++ b/hare/eligibility/config/config.go
@@ -8,5 +8,5 @@ type Config struct {
 
 // DefaultConfig returns the default configuration for the oracle package.
 func DefaultConfig() Config {
-	return Config{25, 0}
+	return Config{ConfidenceParam: 25, EpochOffset: 0}
 }

--- a/hare/eligibility/oracle.go
+++ b/hare/eligibility/oracle.go
@@ -549,7 +549,6 @@ func (o *Oracle) actives(ctx context.Context, targetLayer types.LayerID) (map[ty
 	}
 
 	// if we failed to get a Hare active set, we fall back on reading the Tortoise active set targeting this epoch
-	// TODO: do we want to cache tortoise active set too?
 	if safeLayerStart.GetEpoch().IsGenesis() {
 		logger.With().Debug("no hare active set for genesis layer range, reading tortoise set for epoch instead",
 			targetLayer.GetEpoch())
@@ -575,9 +574,6 @@ func (o *Oracle) actives(ctx context.Context, targetLayer types.LayerID) (map[ty
 		activeMap[atxHeader.NodeID()] = atxHeader.GetWeight()
 	}
 	logger.With().Debug("got tortoise active set", log.Int("count", len(activeMap)))
-
-	// update cache and return
-	o.activesCache.Add(targetLayer.GetEpoch(), activeMap)
 	return activeMap, nil
 }
 


### PR DESCRIPTION
## Motivation
in the hare active set calculation. we calculate a safe layer range for each target layer.
in the system test, there are 4 layers per epoch. here is the mapping btwn target layers and their safe layer range (test only ran to layer 41)
```
target layer -> safe layer range
8-32        ->      [7,7]
33-36       ->      [8,8]
37-40       ->      [12,12]
41          ->      [16,16]
```

during systest, each miner has different total weight when calculating the active set for a layer.
hare oracle only starts using hare active set (activeset from ref ballots in safe layer range) from layer 33.
i.e. for the first 9 epochs, it's using tortoise active set (i.e. all ATX in database)

this PR include changes 3 changes
- syncer fetch ATXs from peers at the beginning of every epoch so that nodes have consistent tortoise active set
- remove caching tortoise active set so that it does not pollute the hare active set in future epoch.
- adjusted hare eligibility config for fastnet/systests