### PR TITLE
[Merged by Bors] - add back missing call to mesh.AddBallot() when receiving proposal/ballot

### DIFF
--- a/proposals/handler.go
+++ b/proposals/handler.go
@@ -275,7 +275,7 @@ func (h *Handler) processBallot(ctx context.Context, logger log.Log, b *types.Ba
 	}
 
 	t1 := time.Now()
-	if err := ballots.Add(h.cdb, b); err != nil {
+	if err := h.mesh.AddBallot(b); err != nil {
 		if errors.Is(err, sql.ErrObjectExists) {
 			return fmt.Errorf("%w: ballot %s", errKnownBallot, b.ID())
 		}

--- a/proposals/interface.go
+++ b/proposals/interface.go
@@ -9,6 +9,7 @@ import (
 //go:generate mockgen -package=mocks -destination=./mocks/mocks.go -source=./interface.go
 
 type meshProvider interface {
+	AddBallot(*types.Ballot) error
 	AddTXsFromProposal(context.Context, types.LayerID, types.ProposalID, []types.TransactionID) error
 }
 

--- a/proposals/mocks/mocks.go
+++ b/proposals/mocks/mocks.go
@@ -35,6 +35,20 @@ func (m *MockmeshProvider) EXPECT() *MockmeshProviderMockRecorder {
 	return m.recorder
 }
 
+// AddBallot mocks base method.
+func (m *MockmeshProvider) AddBallot(arg0 *types.Ballot) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddBallot", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AddBallot indicates an expected call of AddBallot.
+func (mr *MockmeshProviderMockRecorder) AddBallot(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddBallot", reflect.TypeOf((*MockmeshProvider)(nil).AddBallot), arg0)
+}
+
 // AddTXsFromProposal mocks base method.
 func (m *MockmeshProvider) AddTXsFromProposal(arg0 context.Context, arg1 types.LayerID, arg2 types.ProposalID, arg3 []types.TransactionID) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
## Motivation
the call was removed by mistake from https://github.com/spacemeshos/go-spacemesh/pull/3265 :-(
