### PR TITLE
[Merged by Bors] - Fixed length of `pid` and `bid` in SQL tables.

### DIFF
--- a/sql/migrations/0001_initial.sql
+++ b/sql/migrations/0001_initial.sql
@@ -76,7 +76,7 @@ CREATE INDEX transactions_results_addresses_by_address ON transactions_results_a
 CREATE TABLE proposal_transactions
 (
     tid     CHAR(32),
-    pid     CHAR(32),
+    pid     CHAR(20),
     layer   INT NOT NULL,
     PRIMARY KEY (tid, pid)
 ) WITHOUT ROWID;
@@ -84,7 +84,7 @@ CREATE TABLE proposal_transactions
 CREATE TABLE block_transactions
 (
     tid     CHAR(32),
-    bid     CHAR(32),
+    bid     CHAR(20),
     layer   INT NOT NULL,
     PRIMARY KEY (tid, bid)
 ) WITHOUT ROWID;


### PR DESCRIPTION
## Motivation
Both `id`s in `blocks` and `proposals` SQL tables have a length of 20B. However, they were referenced with 32B long fields in the relation tables `proposal_transactions` and `block_transactions` (fields `pid` and `bid` respectively).

## Test Plan
unit tests, systests

## DevOps Notes
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
