### PR TITLE
[Merged by Bors] - ATX: add API to differentiate publish and target epoch

### DIFF
--- a/activation/activation_test.go
+++ b/activation/activation_test.go
@@ -90,7 +90,7 @@ func (n *NetMock) hookToAtxPool(transmission []byte) {
 				if err != nil {
 					panic(err)
 				}
-				if err := atxDb.StoreAtx(context.TODO(), atx.PubLayerID.GetEpoch(), vAtx); err != nil {
+				if err := atxDb.StoreAtx(context.TODO(), vAtx); err != nil {
 					panic(err)
 				}
 			}
@@ -282,9 +282,7 @@ func assertLastAtx(r *require.Assertions, posAtx, prevAtx *types.VerifiedActivat
 }
 
 func storeAtx(r *require.Assertions, atxHdlr *Handler, atx *types.VerifiedActivationTx, lg log.Log) {
-	epoch := atx.PubLayerID.GetEpoch()
-	lg.Info("stored ATX in epoch %v", epoch)
-	err := atxHdlr.StoreAtx(context.TODO(), epoch, atx)
+	err := atxHdlr.StoreAtx(context.TODO(), atx)
 	r.NoError(err)
 }
 
@@ -813,7 +811,7 @@ func TestBuilder_NIPostPublishRecovery(t *testing.T) {
 
 	atx := newActivationTx(t, sig, 1, prevAtx, prevAtx, types.NewLayerID(15), 1, 100, coinbase, 100, npst)
 
-	err := atxHdlr.StoreAtx(context.TODO(), atx.PubLayerID.GetEpoch(), atx)
+	err := atxHdlr.StoreAtx(context.TODO(), atx)
 	assert.NoError(t, err)
 
 	challenge := types.NIPostChallenge{

--- a/activation/activation_test.go
+++ b/activation/activation_test.go
@@ -299,8 +299,6 @@ func publishAtx(b *Builder, clockEpoch types.EpochID, buildNIPostLayerDuration u
 	return net.lastTransmission != nil, builtNIPost, err
 }
 
-// ========== Tests ==========
-
 func addPrevAtx(t *testing.T, db sql.Executor, epoch types.EpochID) {
 	prevAtx := &types.ActivationTx{
 		InnerActivationTx: types.InnerActivationTx{
@@ -314,6 +312,8 @@ func addPrevAtx(t *testing.T, db sql.Executor, epoch types.EpochID) {
 	require.NoError(t, err)
 	require.NoError(t, atxs.Add(db, vAtx, time.Now()))
 }
+
+// ========== Tests ==========
 
 func TestBuilder_waitForFirstATX(t *testing.T) {
 	cdb := newCachedDB(t)

--- a/activation/activation_test.go
+++ b/activation/activation_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/spacemeshos/go-spacemesh/codec"
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/datastore"
-	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/log/logtest"
 	"github.com/spacemeshos/go-spacemesh/signing"
 	"github.com/spacemeshos/go-spacemesh/sql"
@@ -281,11 +280,6 @@ func assertLastAtx(r *require.Assertions, posAtx, prevAtx *types.VerifiedActivat
 	r.Equal(poetRef, atx.GetPoetProofRef())
 }
 
-func storeAtx(r *require.Assertions, atxHdlr *Handler, atx *types.VerifiedActivationTx, lg log.Log) {
-	err := atxHdlr.StoreAtx(context.TODO(), atx)
-	r.NoError(err)
-}
-
 func publishAtx(b *Builder, clockEpoch types.EpochID, buildNIPostLayerDuration uint32) (published, builtNIPost bool, err error) {
 	net.lastTransmission = nil
 	nipostBuilderMock.buildNIPostFunc = func(challenge *types.Hash32) (*types.NIPost, error) {
@@ -450,7 +444,7 @@ func TestBuilder_PublishActivationTx_HappyFlow(t *testing.T) {
 	prevAtx := newAtx(t, challenge, sig, nipost, 2, coinbase)
 	vPrevAtx, err := prevAtx.Verify(0, 1)
 	r.NoError(err)
-	storeAtx(r, atxHdlr, vPrevAtx, logtest.New(t).WithName("storeAtx"))
+	require.NoError(t, atxHdlr.StoreAtx(context.TODO(), vPrevAtx))
 
 	// create and publish ATX
 	published, _, err := publishAtx(b, postGenesisEpoch, layersPerEpoch)
@@ -480,7 +474,7 @@ func TestBuilder_PublishActivationTx_FaultyNet(t *testing.T) {
 	prevAtx := newAtx(t, challenge, sig, nipost, 2, coinbase)
 	vAtx, err := prevAtx.Verify(0, 1)
 	r.NoError(err)
-	storeAtx(r, atxHdlr, vAtx, logtest.New(t).WithName("storeAtx"))
+	require.NoError(t, atxHdlr.StoreAtx(context.TODO(), vAtx))
 
 	cfg := Config{
 		CoinbaseAccount: coinbase,
@@ -510,7 +504,7 @@ func TestBuilder_PublishActivationTx_FaultyNet(t *testing.T) {
 	posAtx := newAtx(t, challenge, sig, nipost, 2, coinbase)
 	vPosAtx, err := posAtx.Verify(0, 1)
 	r.NoError(err)
-	storeAtx(r, atxHdlr, vPosAtx, logtest.New(t).WithName("storeAtx"))
+	require.NoError(t, atxHdlr.StoreAtx(context.TODO(), vPosAtx))
 	published, builtNipost, err = publishAtx(b, postGenesisEpoch+1, layersPerEpoch)
 	r.NoError(err)
 	r.True(published)
@@ -527,7 +521,7 @@ func TestBuilder_PublishActivationTx_RebuildNIPostWhenTargetEpochPassed(t *testi
 	prevAtx := newAtx(t, challenge, sig, nipost, 2, coinbase)
 	vAtx, err := prevAtx.Verify(0, 1)
 	r.NoError(err)
-	storeAtx(r, atxHdlr, vAtx, logtest.New(t).WithName("storeAtx"))
+	require.NoError(t, atxHdlr.StoreAtx(context.TODO(), vAtx))
 
 	cfg := Config{
 		CoinbaseAccount: coinbase,
@@ -554,7 +548,7 @@ func TestBuilder_PublishActivationTx_RebuildNIPostWhenTargetEpochPassed(t *testi
 	posAtx := newAtx(t, challenge, sig, nipost, 2, coinbase)
 	vPosAtx, err := posAtx.Verify(0, 1)
 	r.NoError(err)
-	storeAtx(r, atxHdlr, vPosAtx, logtest.New(t).WithName("storeAtx"))
+	require.NoError(t, atxHdlr.StoreAtx(context.TODO(), vPosAtx))
 	published, builtNIPost, err = publishAtx(b, postGenesisEpoch+3, layersPerEpoch)
 	r.NoError(err)
 	r.True(published)
@@ -573,7 +567,7 @@ func TestBuilder_PublishActivationTx_NoPrevATX(t *testing.T) {
 	posAtx := newAtx(t, challenge, otherSig, nipost, 2, coinbase)
 	vPosAtx, err := posAtx.Verify(0, 1)
 	r.NoError(err)
-	storeAtx(r, atxHdlr, vPosAtx, logtest.New(t).WithName("storeAtx"))
+	require.NoError(t, atxHdlr.StoreAtx(context.TODO(), vPosAtx))
 
 	// create and publish ATX
 	published, _, err := publishAtx(b, postGenesisEpoch, layersPerEpoch)
@@ -594,7 +588,7 @@ func TestBuilder_PublishActivationTx_PrevATXWithoutPrevATX(t *testing.T) {
 	posAtx := newAtx(t, challenge, otherSig, nipost, 2, coinbase)
 	vPosAtx, err := posAtx.Verify(0, 1)
 	r.NoError(err)
-	storeAtx(r, atxHdlr, vPosAtx, logtest.New(t).WithName("storeAtx"))
+	require.NoError(t, atxHdlr.StoreAtx(context.TODO(), vPosAtx))
 
 	challenge = newChallenge(0, *types.EmptyATXID, posAtx.ID(), lid)
 	challenge.InitialPostIndices = initialPost.Indices
@@ -602,7 +596,7 @@ func TestBuilder_PublishActivationTx_PrevATXWithoutPrevATX(t *testing.T) {
 	prevAtx.InitialPost = initialPost
 	vPrevAtx, err := prevAtx.Verify(0, 1)
 	r.NoError(err)
-	storeAtx(r, atxHdlr, vPrevAtx, logtest.New(t).WithName("storeAtx"))
+	require.NoError(t, atxHdlr.StoreAtx(context.TODO(), vPrevAtx))
 
 	// create and publish ATX
 	published, _, err := publishAtx(b, postGenesisEpoch, layersPerEpoch)
@@ -623,7 +617,7 @@ func TestBuilder_PublishActivationTx_TargetsEpochBasedOnPosAtx(t *testing.T) {
 	posAtx := newAtx(t, challenge, otherSig, nipost, 2, coinbase)
 	vPosAtx, err := posAtx.Verify(0, 1)
 	r.NoError(err)
-	storeAtx(r, atxHdlr, vPosAtx, logtest.New(t).WithName("storeAtx"))
+	require.NoError(t, atxHdlr.StoreAtx(context.TODO(), vPosAtx))
 
 	// create and publish ATX based on the best available posAtx, as long as the node is synced
 	published, _, err := publishAtx(b, postGenesisEpoch, layersPerEpoch)
@@ -644,7 +638,7 @@ func TestBuilder_PublishActivationTx_DoesNotPublish2AtxsInSameEpoch(t *testing.T
 	prevAtx := newAtx(t, challenge, sig, nipost, 2, coinbase)
 	vPrevAtx, err := prevAtx.Verify(0, 1)
 	r.NoError(err)
-	storeAtx(r, atxHdlr, vPrevAtx, logtest.New(t).WithName("storeAtx"))
+	require.NoError(t, atxHdlr.StoreAtx(context.TODO(), vPrevAtx))
 
 	// create and publish ATX
 	published, _, err := publishAtx(b, postGenesisEpoch, layersPerEpoch)
@@ -688,7 +682,7 @@ func TestBuilder_PublishActivationTx_FailsWhenNIPostBuilderFails(t *testing.T) {
 	posAtx := newAtx(t, challenge, otherSig, nipost, 2, coinbase)
 	vPosAtx, err := posAtx.Verify(0, 1)
 	r.NoError(err)
-	storeAtx(r, atxHdlr, vPosAtx, logtest.New(t).WithName("storeAtx"))
+	require.NoError(t, atxHdlr.StoreAtx(context.TODO(), vPosAtx))
 
 	published, _, err := publishAtx(b, postGenesisEpoch, layersPerEpoch)
 	r.EqualError(err, "create ATX: failed to build NIPost: NIPost builder error")
@@ -696,13 +690,11 @@ func TestBuilder_PublishActivationTx_FailsWhenNIPostBuilderFails(t *testing.T) {
 }
 
 func TestBuilder_PublishActivationTx_Serialize(t *testing.T) {
-	r := require.New(t)
-
 	cdb := newCachedDB(t)
 	atxHdlr := newAtxHandler(t, cdb)
 
 	atx := newActivationTx(t, sig, 1, prevAtxID, prevAtxID, types.NewLayerID(5), 1, 100, coinbase, 100, nipost)
-	storeAtx(r, atxHdlr, atx, logtest.New(t).WithName("storeAtx"))
+	require.NoError(t, atxHdlr.StoreAtx(context.TODO(), atx))
 
 	act := newActivationTx(t, sig, 2, atx.ID(), atx.ID(), atx.PubLayerID.Add(10), 0, 100, coinbase, 100, nipost)
 
@@ -725,20 +717,19 @@ func TestBuilder_PublishActivationTx_PosAtxOnSameLayerAsPrevAtx(t *testing.T) {
 	atxHdlr := newAtxHandler(t, cdb)
 	b := newBuilder(t, cdb, atxHdlr)
 
-	lg := logtest.New(t).WithName("storeAtx")
 	for i := postGenesisEpochLayer; i.Before(postGenesisEpochLayer.Add(3)); i = i.Add(1) {
 		challenge := newChallenge(1, prevAtxID, prevAtxID, i.Mul(layersPerEpoch))
 		atx := newAtx(t, challenge, sig, nipost, 2, coinbase)
 		vAtx, err := atx.Verify(0, 1)
 		r.NoError(err)
-		storeAtx(r, atxHdlr, vAtx, lg)
+		require.NoError(t, atxHdlr.StoreAtx(context.TODO(), vAtx))
 	}
 
 	challenge := newChallenge(1, prevAtxID, prevAtxID, postGenesisEpochLayer.Add(3).Mul(layersPerEpoch))
 	prevAtx := newAtx(t, challenge, sig, nipost, 2, coinbase)
 	vPrevAtx, err := prevAtx.Verify(0, 1)
 	r.NoError(err)
-	storeAtx(r, atxHdlr, vPrevAtx, lg)
+	require.NoError(t, atxHdlr.StoreAtx(context.TODO(), vPrevAtx))
 
 	published, _, err := publishAtx(b, postGenesisEpoch, layersPerEpoch)
 	r.NoError(err)
@@ -884,7 +875,7 @@ func TestBuilder_RetryPublishActivationTx(t *testing.T) {
 	posAtx := newAtx(t, challenge, otherSig, nipost, 2, coinbase)
 	vPosAtx, err := posAtx.Verify(0, 1)
 	r.NoError(err)
-	storeAtx(r, atxHdlr, vPosAtx, logtest.New(t).WithName("storeAtx"))
+	require.NoError(t, atxHdlr.StoreAtx(context.TODO(), vPosAtx))
 
 	net.lastTransmission = nil
 	tries := 0
@@ -941,7 +932,7 @@ func TestBuilder_InitialProofGeneratedOnce(t *testing.T) {
 	prevAtx := newAtx(t, challenge, sig, nipost, 2, coinbase)
 	vPrevAtx, err := prevAtx.Verify(0, 1)
 	r.NoError(err)
-	storeAtx(r, atxHdlr, vPrevAtx, logtest.New(t).WithName("storeAtx"))
+	require.NoError(t, atxHdlr.StoreAtx(context.TODO(), vPrevAtx))
 
 	published, _, err := publishAtx(b, postGenesisEpoch, layersPerEpoch)
 	r.NoError(err)

--- a/activation/handler.go
+++ b/activation/handler.go
@@ -130,7 +130,7 @@ func (h *Handler) ProcessAtx(ctx context.Context, atx *types.VerifiedActivationT
 	} else {
 		h.log.WithContext(ctx).With().Info("atx is valid", atx.ID())
 	}
-	if err := h.StoreAtx(ctx, epoch, atx); err != nil {
+	if err := h.StoreAtx(ctx, atx); err != nil {
 		return fmt.Errorf("cannot store atx %s: %w", atx.ShortString(), err)
 	}
 	return nil
@@ -278,10 +278,8 @@ func (h *Handler) ContextuallyValidateAtx(atx *types.VerifiedActivationTx) error
 	return nil
 }
 
-// StoreAtx stores an atx for epoch ech, it stores atx for the current epoch and adds the atx for the nodeID that
-// created it in a sorted manner by the sequence id. This function does not validate the atx and assumes all data is
-// correct and that all associated atx exist in the db. Will return error if writing to db failed.
-func (h *Handler) StoreAtx(ctx context.Context, ech types.EpochID, atx *types.VerifiedActivationTx) error {
+// StoreAtx stores an ATX and notifies subscribers of the ATXID.
+func (h *Handler) StoreAtx(ctx context.Context, atx *types.VerifiedActivationTx) error {
 	h.Lock()
 	defer h.Unlock()
 
@@ -299,7 +297,7 @@ func (h *Handler) StoreAtx(ctx context.Context, ech types.EpochID, atx *types.Ve
 		delete(h.atxChannels, atx.ID())
 	}
 
-	h.log.WithContext(ctx).With().Info("finished storing atx in epoch", atx.ID(), ech)
+	h.log.WithContext(ctx).With().Info("finished storing atx in epoch", atx.ID(), atx.PubLayerID.GetEpoch())
 	return nil
 }
 

--- a/activation/handler.go
+++ b/activation/handler.go
@@ -116,7 +116,7 @@ func (h *Handler) ProcessAtx(ctx context.Context, atx *types.VerifiedActivationT
 	if existingATX != nil { // Already processed
 		return nil
 	}
-	epoch := atx.PubLayerID.GetEpoch()
+	epoch := atx.PublishEpoch()
 	h.log.WithContext(ctx).With().Info("processing atx",
 		atx.ID(),
 		epoch,
@@ -165,8 +165,8 @@ func (h *Handler) SyntacticallyValidateAtx(ctx context.Context, atx *types.Activ
 			)
 		}
 
-		prevEp := prevATX.PubLayerID.GetEpoch()
-		curEp := atx.PubLayerID.GetEpoch()
+		prevEp := prevATX.PublishEpoch()
+		curEp := atx.PublishEpoch()
 		if prevEp >= curEp {
 			return nil, fmt.Errorf(
 				"prevAtx epoch (%v, layer %v) isn't older than current atx epoch (%v, layer %v)",
@@ -224,7 +224,7 @@ func (h *Handler) SyntacticallyValidateAtx(ctx context.Context, atx *types.Activ
 		}
 		baseTickHeight = posAtx.TickHeight()
 	} else {
-		publicationEpoch := atx.PubLayerID.GetEpoch()
+		publicationEpoch := atx.PublishEpoch()
 		if !publicationEpoch.NeedsGoldenPositioningATX() {
 			return nil, fmt.Errorf("golden atx used for atx in epoch %d, but is only valid in epoch 1", publicationEpoch)
 		}
@@ -297,7 +297,7 @@ func (h *Handler) StoreAtx(ctx context.Context, atx *types.VerifiedActivationTx)
 		delete(h.atxChannels, atx.ID())
 	}
 
-	h.log.WithContext(ctx).With().Info("finished storing atx in epoch", atx.ID(), atx.PubLayerID.GetEpoch())
+	h.log.WithContext(ctx).With().Info("finished storing atx in epoch", atx.ID(), atx.PublishEpoch())
 	return nil
 }
 

--- a/activation/handler_test.go
+++ b/activation/handler_test.go
@@ -489,7 +489,7 @@ func BenchmarkNewActivationDb(b *testing.B) {
 			prevAtxs[miner] = atx.ID()
 			vAtx, err := atx.Verify(0, 1)
 			r.NoError(err)
-			storeAtx(r, atxHdlr, vAtx, lg.WithName("storeAtx"))
+			require.NoError(b, atxHdlr.StoreAtx(context.TODO(), vAtx))
 		}
 		// noinspection GoNilness
 		posAtx = atx.ID()

--- a/activation/handler_test.go
+++ b/activation/handler_test.go
@@ -61,11 +61,11 @@ func TestHandler_GetNodeLastAtxId(t *testing.T) {
 	coinbase1 := types.GenerateAddress([]byte("aaaa"))
 	epoch1 := types.EpochID(1)
 	atx1 := newActivationTx(t, sig, 0, *types.EmptyATXID, goldenATXID, epoch1.FirstLayer(), 0, 100, coinbase1, 0, &types.NIPost{})
-	r.NoError(atxHdlr.StoreAtx(context.TODO(), epoch1, atx1))
+	r.NoError(atxHdlr.StoreAtx(context.TODO(), atx1))
 
 	epoch2 := types.EpochID(2)
 	atx2 := newActivationTx(t, sig, 1, atx1.ID(), atx1.ID(), epoch2.FirstLayer(), 0, 100, coinbase1, 0, &types.NIPost{})
-	r.NoError(atxHdlr.StoreAtx(context.TODO(), epoch2, atx2))
+	r.NoError(atxHdlr.StoreAtx(context.TODO(), atx2))
 
 	atxid, err := atxs.GetLastIDByNodeID(cdb, sig.NodeID())
 	r.NoError(err)
@@ -89,7 +89,7 @@ func TestMesh_processBlockATXs(t *testing.T) {
 	poetRef := []byte{0x76, 0x45}
 	npst := newNIPostWithChallenge(&chlng, poetRef)
 	posATX := newActivationTx(t, sig, 0, *types.EmptyATXID, *types.EmptyATXID, types.NewLayerID(1000), 0, 100, coinbase1, 100, npst)
-	err := atxHdlr.StoreAtx(context.TODO(), 0, posATX)
+	err := atxHdlr.StoreAtx(context.TODO(), posATX)
 	assert.NoError(t, err)
 	atxList := []*types.VerifiedActivationTx{
 		newActivationTx(t, sig, 0, *types.EmptyATXID, posATX.ID(), types.NewLayerID(1012), 0, 100, coinbase1, 100, &types.NIPost{}),
@@ -163,7 +163,7 @@ func TestHandler_ValidateAtx(t *testing.T) {
 	atx.NIPost = newNIPostWithChallenge(hash, poetRef)
 	err = SignAtx(sig, atx)
 	assert.NoError(t, err)
-	err = atxHdlr.StoreAtx(context.TODO(), 1, prevAtx)
+	err = atxHdlr.StoreAtx(context.TODO(), prevAtx)
 	assert.NoError(t, err)
 
 	vAtx, err := atxHdlr.SyntacticallyValidateAtx(context.TODO(), atx)
@@ -200,9 +200,9 @@ func TestHandler_ValidateAtxErrors(t *testing.T) {
 	npst := newNIPostWithChallenge(&chlng, poetRef)
 	prevAtx := newActivationTx(t, sig, 0, *types.EmptyATXID, *types.EmptyATXID, types.NewLayerID(100), 0, 100, coinbase, 100, npst)
 	posAtx := newActivationTx(t, otherSig, 0, *types.EmptyATXID, *types.EmptyATXID, types.NewLayerID(100), 0, 100, coinbase, 100, npst)
-	err := atxHdlr.StoreAtx(context.TODO(), 1, prevAtx)
+	err := atxHdlr.StoreAtx(context.TODO(), prevAtx)
 	assert.NoError(t, err)
-	err = atxHdlr.StoreAtx(context.TODO(), 1, posAtx)
+	err = atxHdlr.StoreAtx(context.TODO(), posAtx)
 	assert.NoError(t, err)
 
 	// Wrong sequence.
@@ -247,7 +247,7 @@ func TestHandler_ValidateAtxErrors(t *testing.T) {
 	posAtx2 := newActivationTx(t, otherSig, 0, *types.EmptyATXID, *types.EmptyATXID, types.NewLayerID(1020), 0, 100, coinbase, 100, npst)
 	err = SignAtx(sig, atx)
 	assert.NoError(t, err)
-	err = atxHdlr.StoreAtx(context.TODO(), 1, posAtx2)
+	err = atxHdlr.StoreAtx(context.TODO(), posAtx2)
 	assert.NoError(t, err)
 	challenge = newChallenge(1, prevAtx.ID(), posAtx2.ID(), types.NewLayerID(1012))
 	atx = newAtx(t, challenge, sig, npst, 100, coinbase)
@@ -257,7 +257,7 @@ func TestHandler_ValidateAtxErrors(t *testing.T) {
 	// Atx already exists.
 	vAtx, err := atx.Verify(0, 1)
 	require.NoError(t, err)
-	err = atxHdlr.StoreAtx(context.TODO(), 1, vAtx)
+	err = atxHdlr.StoreAtx(context.TODO(), vAtx)
 	assert.NoError(t, err)
 	challenge = newChallenge(1, prevAtx.ID(), posAtx.ID(), types.NewLayerID(12))
 	atx = newAtx(t, challenge, sig, &types.NIPost{}, 100, coinbase)
@@ -269,7 +269,7 @@ func TestHandler_ValidateAtxErrors(t *testing.T) {
 	// Prev atx declared but not found.
 	vAtx, err = atx.Verify(0, 1)
 	assert.NoError(t, err)
-	err = atxHdlr.StoreAtx(context.TODO(), 1, vAtx)
+	err = atxHdlr.StoreAtx(context.TODO(), vAtx)
 	assert.NoError(t, err)
 	challenge = newChallenge(1, prevAtx.ID(), posAtx.ID(), types.NewLayerID(12))
 	vAtx, err = newAtx(t, challenge, sig, &types.NIPost{}, 100, coinbase).Verify(0, 1)
@@ -332,17 +332,17 @@ func TestHandler_ValidateAndInsertSorted(t *testing.T) {
 	npst := newNIPostWithChallenge(&chlng, poetRef)
 	prevAtx := newActivationTx(t, sig, 0, *types.EmptyATXID, *types.EmptyATXID, types.NewLayerID(100), 0, 100, coinbase, 100, npst)
 
-	err := atxHdlr.StoreAtx(context.TODO(), 1, prevAtx)
+	err := atxHdlr.StoreAtx(context.TODO(), prevAtx)
 	assert.NoError(t, err)
 
 	// wrong sequence
 	vAtx := newActivationTx(t, sig, 1, prevAtx.ID(), prevAtx.ID(), types.NewLayerID(1012), 0, 100, coinbase, 100, &types.NIPost{})
-	err = atxHdlr.StoreAtx(context.TODO(), 1, vAtx)
+	err = atxHdlr.StoreAtx(context.TODO(), vAtx)
 	assert.NoError(t, err)
 
 	vAtx = newActivationTx(t, sig, 2, vAtx.ID(), vAtx.ID(), types.NewLayerID(1012), 0, 100, coinbase, 100, &types.NIPost{})
 	assert.NoError(t, err)
-	err = atxHdlr.StoreAtx(context.TODO(), 1, vAtx)
+	err = atxHdlr.StoreAtx(context.TODO(), vAtx)
 	assert.NoError(t, err)
 	atx2id := vAtx.ID()
 
@@ -353,14 +353,14 @@ func TestHandler_ValidateAndInsertSorted(t *testing.T) {
 
 	vAtx, err = atx.Verify(0, 100)
 	assert.NoError(t, err)
-	err = atxHdlr.StoreAtx(context.TODO(), 1, vAtx)
+	err = atxHdlr.StoreAtx(context.TODO(), vAtx)
 	assert.NoError(t, err)
 
 	vAtx = newActivationTx(t, sig, 3, atx2id, prevAtx.ID(), types.NewLayerID(1012+layersPerEpoch), 0, 100, coinbase, 100, &types.NIPost{})
 	err = atxHdlr.ContextuallyValidateAtx(vAtx)
 	assert.EqualError(t, err, "last atx is not the one referenced")
 
-	err = atxHdlr.StoreAtx(context.TODO(), 1, vAtx)
+	err = atxHdlr.StoreAtx(context.TODO(), vAtx)
 	assert.NoError(t, err)
 
 	id, err := atxs.GetLastIDByNodeID(cdb, sig.NodeID())
@@ -377,22 +377,22 @@ func TestHandler_ValidateAndInsertSorted(t *testing.T) {
 	otherSig := NewMockSigner()
 
 	prevAtx = newActivationTx(t, otherSig, 0, *types.EmptyATXID, *types.EmptyATXID, types.NewLayerID(100), 0, 100, coinbase, 100, npst)
-	err = atxHdlr.StoreAtx(context.TODO(), 1, prevAtx)
+	err = atxHdlr.StoreAtx(context.TODO(), prevAtx)
 	assert.NoError(t, err)
 	vAtx = newActivationTx(t, otherSig, 1, prevAtx.ID(), prevAtx.ID(), types.NewLayerID(1012), 0, 100, coinbase, 100, &types.NIPost{})
-	err = atxHdlr.StoreAtx(context.TODO(), 1, vAtx)
+	err = atxHdlr.StoreAtx(context.TODO(), vAtx)
 	assert.NoError(t, err)
 	atxID := atx.ID()
 
 	vAtx = newActivationTx(t, otherSig, 2, atxID, atx.ID(), types.NewLayerID(1012+layersPerEpoch), 0, 100, coinbase, 100, &types.NIPost{})
-	err = atxHdlr.StoreAtx(context.TODO(), 1, vAtx)
+	err = atxHdlr.StoreAtx(context.TODO(), vAtx)
 	assert.NoError(t, err)
 
 	vAtx = newActivationTx(t, otherSig, 2, atxID, atx.ID(), types.NewLayerID(1012+2*layersPerEpoch), 0, 100, coinbase, 100, &types.NIPost{})
 	err = atxHdlr.ContextuallyValidateAtx(vAtx)
 	assert.EqualError(t, err, "last atx is not the one referenced")
 
-	err = atxHdlr.StoreAtx(context.TODO(), 1, vAtx)
+	err = atxHdlr.StoreAtx(context.TODO(), vAtx)
 	assert.NoError(t, err)
 }
 
@@ -441,7 +441,7 @@ func BenchmarkActivationDb_SyntacticallyValidateAtx(b *testing.B) {
 	atx.NIPost = newNIPostWithChallenge(hash, poetRef)
 	vPrevAtx, err := prevAtx.Verify(0, 1)
 	r.NoError(err)
-	r.NoError(atxHdlr.StoreAtx(context.TODO(), 1, vPrevAtx))
+	r.NoError(atxHdlr.StoreAtx(context.TODO(), vPrevAtx))
 
 	start := time.Now()
 	_, err = atxHdlr.SyntacticallyValidateAtx(context.TODO(), atx)
@@ -547,7 +547,7 @@ func TestHandler_TopAtx(t *testing.T) {
 
 func createAndStoreAtx(t *testing.T, atxHdlr *Handler, layer types.LayerID) (*types.VerifiedActivationTx, error) {
 	atx := newActivationTx(t, sig, 0, *types.EmptyATXID, *types.EmptyATXID, layer, 0, 100, coinbase, 100, &types.NIPost{})
-	err := atxHdlr.StoreAtx(context.TODO(), atx.TargetEpoch(), atx)
+	err := atxHdlr.StoreAtx(context.TODO(), atx)
 	if err != nil {
 		return nil, err
 	}
@@ -570,7 +570,7 @@ func TestHandler_AwaitAtx(t *testing.T) {
 	default:
 	}
 
-	err := atxHdlr.StoreAtx(context.TODO(), atx.TargetEpoch(), atx)
+	err := atxHdlr.StoreAtx(context.TODO(), atx)
 	r.NoError(err)
 	r.Len(atxHdlr.atxChannels, 0) // after notifying subscribers, channel is cleared
 
@@ -647,7 +647,7 @@ func BenchmarkGetAtxHeaderWithConcurrentStoreAtx(b *testing.B) {
 				if !assert.NoError(b, err) {
 					return
 				}
-				if !assert.NoError(b, atxHdlr.StoreAtx(context.TODO(), types.EpochID(1), vAtx)) {
+				if !assert.NoError(b, atxHdlr.StoreAtx(context.TODO(), vAtx)) {
 					return
 				}
 				if atomic.LoadUint64(&stop) == 1 {

--- a/beacon/handlers.go
+++ b/beacon/handlers.go
@@ -104,7 +104,7 @@ func (pd *ProtocolDriver) classifyProposal(logger log.Log, m ProposalMessage, at
 		return invalid, fmt.Errorf("[proposal] failed to get ATX timestamp (miner ID %v, ATX ID %v): %w", minerID, atxID, err)
 	}
 
-	atxEpoch := atxHeader.PubLayerID.GetEpoch()
+	atxEpoch := atxHeader.PublishEpoch()
 	nextEpochStart := pd.clock.LayerToTime((atxEpoch + 1).FirstLayer())
 
 	logger = logger.WithFields(

--- a/common/types/activation.go
+++ b/common/types/activation.go
@@ -133,6 +133,17 @@ func (challenge *NIPostChallenge) String() string {
 		challenge.PositioningATX.ShortString())
 }
 
+// TargetEpoch returns the target epoch of the NIPostChallenge. This is the epoch in which the miner is eligible
+// to participate thanks to the ATX.
+func (challenge *NIPostChallenge) TargetEpoch() EpochID {
+	return challenge.PubLayerID.GetEpoch() + 1
+}
+
+// PublishEpoch returns the publishing epoch of the NIPostChallenge.
+func (challenge *NIPostChallenge) PublishEpoch() EpochID {
+	return challenge.PubLayerID.GetEpoch()
+}
+
 // InnerActivationTx is a set of all of an ATX's fields, except the signature. To generate the ATX signature, this
 // structure is serialized and signed. It includes the header fields, as well as the larger fields that are only used
 // for validation: the NIPost and the initial Post.
@@ -192,7 +203,7 @@ func (atx *ActivationTx) MarshalLogObject(encoder log.ObjectEncoder) error {
 	encoder.AddString("pos_atx_id", atx.PositioningATX.String())
 	encoder.AddString("coinbase", atx.Coinbase.String())
 	encoder.AddUint32("pub_layer_id", atx.PubLayerID.Value)
-	encoder.AddUint32("epoch", uint32(atx.PubLayerID.GetEpoch()))
+	encoder.AddUint32("epoch", uint32(atx.PublishEpoch()))
 	encoder.AddUint64("num_units", uint64(atx.NumUnits))
 	encoder.AddUint64("sequence_number", atx.Sequence)
 	return nil
@@ -253,12 +264,6 @@ func (atx *ActivationTx) NodeID() NodeID {
 		panic("nodeID field must be set")
 	}
 	return *atx.nodeID
-}
-
-// TargetEpoch returns the target epoch of the activation transaction. This is the epoch in which the miner is eligible
-// to participate thanks to the ATX.
-func (atx *ActivationTx) TargetEpoch() EpochID {
-	return atx.PubLayerID.GetEpoch() + 1
 }
 
 // SetID sets the ATXID in this ATX's cache.

--- a/common/types/activation_tx_header.go
+++ b/common/types/activation_tx_header.go
@@ -20,12 +20,6 @@ type ActivationTxHeader struct {
 	TickCount uint64
 }
 
-// TargetEpoch returns the target epoch of the activation transaction. This is the epoch in which the miner is eligible
-// to participate thanks to the ATX.
-func (atxh *ActivationTxHeader) TargetEpoch() EpochID {
-	return atxh.PubLayerID.GetEpoch() + 1
-}
-
 // GetWeight of the ATX. The total weight of the epoch is expected to fit in a uint64 and is
 // sum(atx.NumUnits * atx.TickCount for each ATX in a given epoch).
 // Space Units sizes are chosen such that NumUnits for all ATXs in an epoch is expected to be < 10^9.

--- a/common/types/verified_activation.go
+++ b/common/types/verified_activation.go
@@ -49,7 +49,7 @@ func (vatx *VerifiedActivationTx) MarshalLogObject(encoder log.ObjectEncoder) er
 	encoder.AddString("pos_atx_id", vatx.PositioningATX.String())
 	encoder.AddString("coinbase", vatx.Coinbase.String())
 	encoder.AddUint32("pub_layer_id", vatx.PubLayerID.Value)
-	encoder.AddUint32("epoch", uint32(vatx.PubLayerID.GetEpoch()))
+	encoder.AddUint32("epoch", uint32(vatx.PublishEpoch()))
 	encoder.AddUint64("num_units", uint64(vatx.NumUnits))
 	encoder.AddUint64("sequence_number", vatx.Sequence)
 	encoder.AddUint64("base_tick_height", vatx.baseTickHeight)

--- a/proposals/eligibility_validator.go
+++ b/proposals/eligibility_validator.go
@@ -154,7 +154,7 @@ func (v *Validator) getBallotATX(ctx context.Context, ballot *types.Ballot) (*ty
 	if err != nil {
 		return nil, fmt.Errorf("get ballot ATX %v epoch %v: %w", ballot.AtxID.ShortString(), epoch, err)
 	}
-	if targetEpoch := atx.PubLayerID.GetEpoch() + 1; targetEpoch != epoch {
+	if targetEpoch := atx.TargetEpoch(); targetEpoch != epoch {
 		return nil, fmt.Errorf("%w: ATX target epoch (%v), ballot publication epoch (%v)",
 			errTargetEpochMismatch, targetEpoch, epoch)
 	}

--- a/sql/atxs/atxs.go
+++ b/sql/atxs/atxs.go
@@ -169,7 +169,7 @@ func Add(db sql.Executor, atx *types.VerifiedActivationTx, timestamp time.Time) 
 	enc := func(stmt *sql.Statement) {
 		stmt.BindBytes(1, atx.ID().Bytes())
 		stmt.BindInt64(2, int64(atx.PubLayerID.Uint32()))
-		stmt.BindInt64(3, int64(atx.PubLayerID.GetEpoch()))
+		stmt.BindInt64(3, int64(atx.PublishEpoch()))
 		stmt.BindBytes(4, atx.NodeID().ToBytes())
 		stmt.BindBytes(5, buf)
 		stmt.BindInt64(6, timestamp.UnixNano())


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
for code clarity, explicitly use PublishEpoch() vs TargetEpoch()

## Changes
<!-- Please describe in detail the changes made -->
- move TargetEpoch to challenge struct and add PublishEpoch API
- simplify StoreAtx API