### PR TITLE
[Merged by Bors] - block certificate: allow certify msg from up to zdist+1 layers ago

### DIFF
--- a/blocks/certifier.go
+++ b/blocks/certifier.go
@@ -306,8 +306,12 @@ func (c *Certifier) certified(lid types.LayerID, bid types.BlockID) bool {
 
 func expectedLayer(clock layerClock, lid types.LayerID, waitLayers uint32) bool {
 	current := clock.GetCurrentLayer()
+	start := types.GetEffectiveGenesis()
+	if current.Uint32() > waitLayers+1 {
+		start = current.Sub(waitLayers + 1)
+	}
 	// only accept early msgs within a range and with limited size to prevent DOS
-	return !lid.Before(current.Sub(waitLayers+1)) && !lid.After(current.Add(numEarlyLayers))
+	return !lid.Before(start) && !lid.After(current.Add(numEarlyLayers))
 }
 
 func (c *Certifier) handleRawCertifyMsg(ctx context.Context, data []byte) error {

--- a/blocks/certifier.go
+++ b/blocks/certifier.go
@@ -36,6 +36,7 @@ var (
 type CertConfig struct {
 	CommitteeSize    int
 	CertifyThreshold int
+	WaitSigLayers    uint32
 	NumLayersToKeep  uint32
 }
 
@@ -43,6 +44,7 @@ func defaultCertConfig() CertConfig {
 	return CertConfig{
 		CommitteeSize:    10,
 		CertifyThreshold: 6,
+		WaitSigLayers:    5,
 		NumLayersToKeep:  5,
 	}
 }
@@ -302,10 +304,10 @@ func (c *Certifier) certified(lid types.LayerID, bid types.BlockID) bool {
 	return false
 }
 
-func expectedLayer(clock layerClock, lid types.LayerID) bool {
+func expectedLayer(clock layerClock, lid types.LayerID, waitLayers uint32) bool {
 	current := clock.GetCurrentLayer()
 	// only accept early msgs within a range and with limited size to prevent DOS
-	return !lid.Before(current) && !lid.After(current.Add(numEarlyLayers))
+	return !lid.Before(current.Sub(waitLayers+1)) && !lid.After(current.Add(numEarlyLayers))
 }
 
 func (c *Certifier) handleRawCertifyMsg(ctx context.Context, data []byte) error {
@@ -323,7 +325,7 @@ func (c *Certifier) handleRawCertifyMsg(ctx context.Context, data []byte) error 
 		return errBeaconNotAvailable
 	}
 
-	if !expectedLayer(c.layerClock, lid) {
+	if !expectedLayer(c.layerClock, lid, c.cfg.WaitSigLayers) {
 		logger.Debug("received message for unexpected layer")
 		return errUnexpectedMsg
 	}

--- a/blocks/certifier_test.go
+++ b/blocks/certifier_test.go
@@ -174,6 +174,11 @@ func Test_HandleCertifyMessage(t *testing.T) {
 			expected: pubsub.ValidationAccept,
 		},
 		{
+			name:     "genesis",
+			expected: pubsub.ValidationIgnore,
+			diff:     -10,
+		},
+		{
 			name:     "boundary - early",
 			expected: pubsub.ValidationAccept,
 			diff:     -1 * int(numEarlyLayers),

--- a/blocks/certifier_test.go
+++ b/blocks/certifier_test.go
@@ -163,17 +163,62 @@ func Test_HandleSyncedCertificate_NotEnoughEligibility(t *testing.T) {
 }
 
 func Test_HandleCertifyMessage(t *testing.T) {
-	tc := newTestCertifier(t)
-	b := generateBlock(t, tc.db)
-	nid, msg, encoded := genEncodedMsg(t, b.LayerIndex, b.ID())
+	cfg := defaultCertConfig()
+	tt := []struct {
+		name     string
+		diff     int
+		expected pubsub.ValidationResult
+	}{
+		{
+			name:     "on time",
+			expected: pubsub.ValidationAccept,
+		},
+		{
+			name:     "boundary - early",
+			expected: pubsub.ValidationAccept,
+			diff:     -1 * int(numEarlyLayers),
+		},
+		{
+			name:     "boundary - late",
+			expected: pubsub.ValidationAccept,
+			diff:     int(cfg.WaitSigLayers + 1),
+		},
+		{
+			name:     "too early",
+			expected: pubsub.ValidationIgnore,
+			diff:     -1 * int(numEarlyLayers+1),
+		},
+		{
+			name:     "too late",
+			expected: pubsub.ValidationIgnore,
+			diff:     int(cfg.WaitSigLayers + 2),
+		},
+	}
 
-	tc.mClk.EXPECT().GetCurrentLayer().Return(b.LayerIndex).AnyTimes()
-	require.NoError(t, tc.RegisterForCert(context.TODO(), b.LayerIndex, b.ID()))
-	tc.mb.EXPECT().GetBeacon(b.LayerIndex.GetEpoch()).Return(types.RandomBeacon(), nil)
-	tc.mOracle.EXPECT().Validate(gomock.Any(), b.LayerIndex, eligibility.CertifyRound, tc.cfg.CommitteeSize, nid, msg.Proof, defaultCnt).
-		Return(true, nil)
-	res := tc.HandleCertifyMessage(context.TODO(), "peer", encoded)
-	require.Equal(t, pubsub.ValidationAccept, res)
+	for _, tc := range tt {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			testCert := newTestCertifier(t)
+			b := generateBlock(t, testCert.db)
+			nid, msg, encoded := genEncodedMsg(t, b.LayerIndex, b.ID())
+
+			current := b.LayerIndex
+			if tc.diff > 0 {
+				current = current.Add(uint32(tc.diff))
+			} else {
+				current = current.Sub(uint32(-1 * tc.diff))
+			}
+			testCert.mClk.EXPECT().GetCurrentLayer().Return(current).AnyTimes()
+			testCert.mb.EXPECT().GetBeacon(b.LayerIndex.GetEpoch()).Return(types.RandomBeacon(), nil)
+			require.NoError(t, testCert.RegisterForCert(context.TODO(), b.LayerIndex, b.ID()))
+			if tc.expected == pubsub.ValidationAccept {
+				testCert.mOracle.EXPECT().Validate(gomock.Any(), b.LayerIndex, eligibility.CertifyRound, testCert.cfg.CommitteeSize, nid, msg.Proof, defaultCnt).
+					Return(true, nil)
+			}
+			res := testCert.HandleCertifyMessage(context.TODO(), "peer", encoded)
+			require.Equal(t, tc.expected, res)
+		})
+	}
 }
 
 func Test_HandleCertifyMessage_Certified(t *testing.T) {
@@ -211,46 +256,6 @@ func Test_HandleCertifyMessage_NotRegistered(t *testing.T) {
 		require.Equal(t, pubsub.ValidationAccept, res)
 	}
 	verifyNotSaved(t, tc.db, b.LayerIndex)
-}
-
-func Test_HandleCertifyMessage_CertifiedWithEarlyMsgs(t *testing.T) {
-	tc := newTestCertifier(t)
-	numMsgs := tc.cfg.CommitteeSize
-	b := generateBlock(t, tc.db)
-	tc.mClk.EXPECT().GetCurrentLayer().Return(b.LayerIndex).AnyTimes()
-	tc.mb.EXPECT().GetBeacon(b.LayerIndex.GetEpoch()).Return(types.RandomBeacon(), nil).AnyTimes()
-	for i := 0; i < numMsgs; i++ {
-		nid, msg, encoded := genEncodedMsg(t, b.LayerIndex, b.ID())
-		tc.mOracle.EXPECT().Validate(gomock.Any(), b.LayerIndex, eligibility.CertifyRound, tc.cfg.CommitteeSize, nid, msg.Proof, defaultCnt).
-			Return(true, nil)
-		res := tc.HandleCertifyMessage(context.TODO(), "peer", encoded)
-		require.Equal(t, pubsub.ValidationAccept, res)
-	}
-	verifyNotSaved(t, tc.db, b.LayerIndex)
-	require.NoError(t, tc.RegisterForCert(context.TODO(), b.LayerIndex, b.ID()))
-	verifySaved(t, tc.db, b.LayerIndex, b.ID(), numMsgs)
-}
-
-func Test_HandleCertifyMessage_TooLate(t *testing.T) {
-	tc := newTestCertifier(t)
-	b := generateBlock(t, tc.db)
-	current := b.LayerIndex.Sub(1)
-	tc.mClk.EXPECT().GetCurrentLayer().Return(current.Sub(1)).AnyTimes()
-	tc.mb.EXPECT().GetBeacon(b.LayerIndex.GetEpoch()).Return(types.RandomBeacon(), nil)
-	_, _, encoded := genEncodedMsg(t, b.LayerIndex, b.ID())
-	res := tc.HandleCertifyMessage(context.TODO(), "peer", encoded)
-	require.Equal(t, pubsub.ValidationIgnore, res)
-}
-
-func Test_HandleCertifyMessage_TooEarly(t *testing.T) {
-	tc := newTestCertifier(t)
-	b := generateBlock(t, tc.db)
-	current := b.LayerIndex.Add(numEarlyLayers + 1)
-	tc.mClk.EXPECT().GetCurrentLayer().Return(current.Sub(1)).AnyTimes()
-	tc.mb.EXPECT().GetBeacon(b.LayerIndex.GetEpoch()).Return(types.RandomBeacon(), nil)
-	_, _, encoded := genEncodedMsg(t, b.LayerIndex, b.ID())
-	res := tc.HandleCertifyMessage(context.TODO(), "peer", encoded)
-	require.Equal(t, pubsub.ValidationIgnore, res)
 }
 
 func Test_HandleCertifyMessage_Stopped(t *testing.T) {

--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -543,6 +543,7 @@ func (app *App) initServices(ctx context.Context,
 		blocks.WithCertConfig(blocks.CertConfig{
 			CommitteeSize:    app.Config.HARE.N,
 			CertifyThreshold: app.Config.HARE.F + 1,
+			WaitSigLayers:    app.Config.Tortoise.Zdist,
 			NumLayersToKeep:  app.Config.Tortoise.Zdist,
 		}),
 		blocks.WithCertifierLogger(app.addLogger(BlockCertLogger, lg)))


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
Closes #3548
<!-- `Closes #XXXX, closes #XXXX, ...` links mentioned issues to this PR and automatically closes them when this it's merged -->

## Changes
<!-- Please describe in detail the changes made -->
accept CertifyMessage btwn the range [current - zdist - 1, current + 1]