### PR TITLE
[Merged by Bors] - tortoise: revisit thresholds and margin computation 

### DIFF
--- a/tortoise/algorithm.go
+++ b/tortoise/algorithm.go
@@ -2,7 +2,6 @@ package tortoise
 
 import (
 	"context"
-	"math/big"
 	"sync"
 
 	"golang.org/x/sync/errgroup"
@@ -18,10 +17,8 @@ type Config struct {
 	Hdist uint32 `mapstructure:"tortoise-hdist"` // hare output lookback distance
 	Zdist uint32 `mapstructure:"tortoise-zdist"` // hare result wait distance
 	// how long we are waiting for a switch from verifying to full. relevant during rerun.
-	WindowSize      uint32   `mapstructure:"tortoise-window-size"`      // size of the tortoise sliding window (in layers)
-	GlobalThreshold *big.Rat `mapstructure:"tortoise-global-threshold"` // threshold for finalizing blocks and layers
-	LocalThreshold  *big.Rat `mapstructure:"tortoise-local-threshold"`  // threshold for choosing when to use weak coin
-	MaxExceptions   int      `mapstructure:"tortoise-max-exceptions"`   // if candidate for base block has more than max exceptions it will be ignored
+	WindowSize    uint32 `mapstructure:"tortoise-window-size"`    // size of the tortoise sliding window (in layers)
+	MaxExceptions int    `mapstructure:"tortoise-max-exceptions"` // if candidate for base block has more than max exceptions it will be ignored
 
 	LayerSize                uint32
 	BadBeaconVoteDelayLayers uint32 // number of layers to delay votes for blocks with bad beacon values during self-healing
@@ -35,8 +32,6 @@ func DefaultConfig() Config {
 		Hdist:                    10,
 		Zdist:                    8,
 		WindowSize:               1000,
-		GlobalThreshold:          big.NewRat(60, 100),
-		LocalThreshold:           big.NewRat(20, 100),
 		BadBeaconVoteDelayLayers: 6,
 		MaxExceptions:            30 * 100, // 100 layers of average size
 	}

--- a/tortoise/full_test.go
+++ b/tortoise/full_test.go
@@ -1,7 +1,6 @@
 package tortoise
 
 import (
-	"math/big"
 	mrand "math/rand"
 	"testing"
 	"time"
@@ -419,7 +418,6 @@ func TestFullVerify(t *testing.T) {
 	epoch := types.EpochID(1)
 	target := epoch.FirstLayer().Sub(1)
 	last := target.Add(types.GetLayersPerEpoch())
-	cfg := Config{GlobalThreshold: big.NewRat(60, 100)}
 	epochs := map[types.EpochID]*epochInfo{
 		1: {weight: 10},
 	}
@@ -527,7 +525,7 @@ func TestFullVerify(t *testing.T) {
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			full := newFullTortoise(cfg, newState())
+			full := newFullTortoise(Config{}, newState())
 			full.epochs = epochs
 			full.last = last
 			full.processed = last

--- a/tortoise/state.go
+++ b/tortoise/state.go
@@ -92,6 +92,10 @@ func (s *state) globalThreshold(cfg Config, target types.LayerID) weight {
 	return computeGlobalThreshold(cfg, s.localThreshold, s.epochs, target, s.processed, s.last)
 }
 
+func (s *state) expectedWeight(cfg Config, target types.LayerID) weight {
+	return computeExpectedWeightInWindow(cfg, s.epochs, target, s.processed, s.last)
+}
+
 func (s *state) layer(lid types.LayerID) *layerInfo {
 	layer, exist := s.layers[lid]
 	if !exist {

--- a/tortoise/state.go
+++ b/tortoise/state.go
@@ -81,10 +81,11 @@ type (
 
 func newState() *state {
 	return &state{
-		epochs:     map[types.EpochID]*epochInfo{},
-		layers:     map[types.LayerID]*layerInfo{},
-		ballotRefs: map[types.BallotID]*ballotInfo{},
-		blockRefs:  map[types.BlockID]*blockInfo{},
+		localThreshold: util.WeightFromUint64(0),
+		epochs:         map[types.EpochID]*epochInfo{},
+		layers:         map[types.LayerID]*layerInfo{},
+		ballotRefs:     map[types.BallotID]*ballotInfo{},
+		blockRefs:      map[types.BlockID]*blockInfo{},
 	}
 }
 

--- a/tortoise/threshold_test.go
+++ b/tortoise/threshold_test.go
@@ -1,7 +1,6 @@
 package tortoise
 
 import (
-	"math/big"
 	"testing"
 	"time"
 
@@ -29,36 +28,27 @@ func TestComputeThreshold(t *testing.T) {
 		expectedGlobal util.Weight
 	}{
 		{
-			desc: "sanity",
-			config: Config{
-				GlobalThreshold: big.NewRat(1, 2),
-			},
+			desc:      "sanity",
 			processed: genesis.Add(length),
 			last:      genesis.Add(length),
 			target:    genesis,
 			epochs: map[types.EpochID]*epochInfo{
-				2: {weight: 40},
+				2: {weight: 45},
 			},
-			expectedGlobal: util.WeightFromUint64(20),
+			expectedGlobal: util.WeightFromUint64(15),
 		},
 		{
-			desc: "shorter than epoch",
-			config: Config{
-				GlobalThreshold: big.NewRat(1, 2),
-			},
+			desc:      "shorter than epoch",
 			processed: genesis.Add(length / 2),
 			last:      genesis.Add(length / 2),
 			target:    genesis,
 			epochs: map[types.EpochID]*epochInfo{
-				2: {weight: 40},
+				2: {weight: 45},
 			},
-			expectedGlobal: util.WeightFromUint64(10),
+			expectedGlobal: util.WeightFromFloat64(7.5),
 		},
 		{
-			desc: "multi epoch",
-			config: Config{
-				GlobalThreshold: big.NewRat(1, 2),
-			},
+			desc:      "multi epoch",
 			processed: genesis.Add(length * 3),
 			last:      genesis.Add(length * 3),
 			target:    genesis,
@@ -67,61 +57,53 @@ func TestComputeThreshold(t *testing.T) {
 				3: {weight: 40},
 				4: {weight: 40},
 			},
-			expectedGlobal: util.WeightFromUint64(60),
+			expectedGlobal: util.WeightFromUint64(40),
 		},
 		{
-			desc: "not full epoch",
-			config: Config{
-				GlobalThreshold: big.NewRat(1, 2),
-			},
+			desc:      "not full epoch",
 			processed: genesis.Add(length - 1),
 			last:      genesis.Add(length - 1),
 			target:    genesis,
 			epochs: map[types.EpochID]*epochInfo{
 				2: {weight: 40},
 			},
-			expectedGlobal: util.WeightFromUint64(15),
+			expectedGlobal: util.WeightFromUint64(10),
 		},
 		{
-			desc: "multiple not full epochs",
-			config: Config{
-				GlobalThreshold: big.NewRat(1, 2),
-			},
+			desc:      "multiple not full epochs",
 			processed: genesis.Add(length*2 - 2),
 			last:      genesis.Add(length*2 - 2),
 			target:    genesis.Add(1),
 			epochs: map[types.EpochID]*epochInfo{
-				2: {weight: 40},
-				3: {weight: 40},
+				2: {weight: 60},
+				3: {weight: 60},
 			},
 			expectedGlobal: util.WeightFromUint64(25),
 		},
 		{
 			desc: "window size",
 			config: Config{
-				GlobalThreshold: big.NewRat(1, 2),
-				WindowSize:      2,
+				WindowSize: 2,
 			},
 			last:   genesis.Add(length),
 			target: genesis,
 			epochs: map[types.EpochID]*epochInfo{
-				2: {weight: 40},
+				2: {weight: 45},
 			},
-			expectedGlobal: util.WeightFromUint64(10),
+			expectedGlobal: util.WeightFromFloat64(7.5),
 		},
 		{
 			desc: "window size is ignored if processed is past window",
 			config: Config{
-				GlobalThreshold: big.NewRat(1, 2),
-				WindowSize:      2,
+				WindowSize: 2,
 			},
 			last:      genesis.Add(length),
 			processed: genesis.Add(length - 1),
 			target:    genesis,
 			epochs: map[types.EpochID]*epochInfo{
-				2: {weight: 40},
+				2: {weight: 45},
 			},
-			expectedGlobal: util.WeightFromUint64(15),
+			expectedGlobal: util.WeightFromFloat64(11.25),
 		},
 	} {
 		tc := tc

--- a/tortoise/tortoise.go
+++ b/tortoise/tortoise.go
@@ -88,6 +88,7 @@ func (t *turtle) init(ctx context.Context, genesisLayer *types.Layer) {
 			layer:    genesis,
 			hare:     support,
 			validity: support,
+			margin:   util.WeightFromUint64(0),
 		}
 		t.layers[genesis].blocks = append(t.layers[genesis].blocks, blinfo)
 		t.blockRefs[blinfo.id] = blinfo

--- a/tortoise/tortoise.go
+++ b/tortoise/tortoise.go
@@ -631,7 +631,7 @@ func (t *turtle) onAtx(atx *types.ActivationTxHeader) {
 	}
 	if atx.TargetEpoch() == t.last.GetEpoch() {
 		t.localThreshold = util.WeightFromUint64(epoch.weight).
-			Fraction(t.LocalThreshold).
+			Fraction(localThresholdFraction).
 			Div(util.WeightFromUint64(uint64(types.GetLayersPerEpoch())))
 	}
 }

--- a/tortoise/verifying_test.go
+++ b/tortoise/verifying_test.go
@@ -1,7 +1,6 @@
 package tortoise
 
 import (
-	"math/big"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -167,11 +166,9 @@ func TestVerifying_Verify(t *testing.T) {
 	}
 
 	config := Config{
-		LocalThreshold:  big.NewRat(1, 10),
-		GlobalThreshold: big.NewRat(7, 10),
-		WindowSize:      10,
-		Hdist:           10,
-		Zdist:           1,
+		WindowSize: 10,
+		Hdist:      10,
+		Zdist:      1,
 	}
 
 	for _, tc := range []struct {
@@ -240,8 +237,8 @@ func TestVerifying_Verify(t *testing.T) {
 				},
 				start.Add(3): {
 					verifying: verifyingInfo{
-						goodUncounted: util.WeightFromUint64(22),
-						abstained:     util.WeightFromUint64(5),
+						goodUncounted: util.WeightFromUint64(25),
+						abstained:     util.WeightFromUint64(6),
 					},
 					blocks: []*blockInfo{
 						{id: types.BlockID{3}, hare: support, layer: start.Add(3)},
@@ -581,17 +578,17 @@ func TestVerifying_Verify(t *testing.T) {
 			layers: map[types.LayerID]*layerInfo{
 				start.Add(1): {
 					verifying: verifyingInfo{
-						goodUncounted: util.WeightFromUint64(10),
+						goodUncounted: util.WeightFromUint64(13),
 					},
 				},
 				start.Add(2): {
 					verifying: verifyingInfo{
-						goodUncounted: util.WeightFromUint64(20),
+						goodUncounted: util.WeightFromUint64(26),
 					},
 				},
 				start.Add(3): {
 					verifying: verifyingInfo{
-						goodUncounted: util.WeightFromUint64(24),
+						goodUncounted: util.WeightFromUint64(28),
 					},
 				},
 				start.Add(4): {


### PR DESCRIPTION
closes: https://github.com/spacemeshos/go-spacemesh/issues/3119

see https://community.spacemesh.io/t/requirements-for-local-and-global-thresholds/235 and https://community.spacemesh.io/t/uncounted-weight-and-the-global-threshold/228 

local threshold is selected in a way so that two honest nodes can't be on a different side of the local threshold if they receive inconsistent votes from adversary (e.g. one receives support for the block, and another received votes that are against the block). 1/3 is a safe upper bound for this parameter. 

global threshold is selected so that if honest node crossed global threshold and adversary cancels weight (by assumption 1/3 of total weight) the honest node will still cross the local threshold.

full tortoise verifies layer when votes margin crosses global threshold

verifying tortoise uses conservative margin, we assume that all weight that wasn't counted by a verifying tortoise votes against local opinion. verifying tortoise counts only weight from ballots that vote consistently with local opinion.

other changes:
- some tests were refactored as layers are verified faster