### PR TITLE
[Merged by Bors] - vm, blocks: integrate rewards from updated economics

### DIFF
--- a/api/grpcserver/grpcserver_test.go
+++ b/api/grpcserver/grpcserver_test.go
@@ -2892,7 +2892,7 @@ func TestEventsReceived(t *testing.T) {
 	weight := util.WeightFromFloat64(18.7)
 	require.NoError(t, err)
 	rewards := []types.AnyReward{{Coinbase: addr2, Weight: types.RatNum{Num: weight.Num().Uint64(), Denom: weight.Denom().Uint64()}}}
-	svm.Apply(vm.ApplyContext{Layer: layerFirst},
+	svm.Apply(vm.ApplyContext{Layer: types.GetEffectiveGenesis()},
 		[]types.Transaction{*globalTx}, rewards)
 
 	select {

--- a/blocks/handler.go
+++ b/blocks/handler.go
@@ -15,8 +15,9 @@ import (
 )
 
 var (
-	errMalformedData = errors.New("malformed data")
-	errDuplicateTX   = errors.New("duplicate TxID in proposal")
+	errMalformedData  = errors.New("malformed data")
+	errInvalidRewards = errors.New("invalid rewards")
+	errDuplicateTX    = errors.New("duplicate TxID in proposal")
 )
 
 // Handler processes Block fetched from peers during sync.
@@ -65,7 +66,7 @@ func (h *Handler) HandleSyncedBlock(ctx context.Context, data []byte) error {
 	b.Initialize()
 
 	if err := vm.ValidateRewards(b.Rewards); err != nil {
-		return err
+		return fmt.Errorf("%w: %s", errInvalidRewards, err.Error())
 	}
 
 	logger = logger.WithFields(b.ID())

--- a/blocks/handler.go
+++ b/blocks/handler.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spacemeshos/go-spacemesh/codec"
 	"github.com/spacemeshos/go-spacemesh/common/types"
+	vm "github.com/spacemeshos/go-spacemesh/genvm"
 	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/sql"
 	"github.com/spacemeshos/go-spacemesh/sql/blocks"
@@ -60,9 +61,13 @@ func (h *Handler) HandleSyncedBlock(ctx context.Context, data []byte) error {
 		logger.With().Error("malformed block", log.Err(err))
 		return errMalformedData
 	}
-
 	// set the block ID when received
 	b.Initialize()
+
+	if err := vm.ValidateRewards(b.Rewards); err != nil {
+		return err
+	}
+
 	logger = logger.WithFields(b.ID())
 
 	if exists, err := blocks.Has(h.db, b.ID()); err != nil {

--- a/blocks/handler_test.go
+++ b/blocks/handler_test.go
@@ -61,7 +61,7 @@ func Test_HandleBlockData_InvalidRewards(t *testing.T) {
 	th := createTestHandler(t)
 	buf, err := codec.Encode(&types.Block{})
 	require.NoError(t, err)
-	require.Error(t, th.HandleSyncedBlock(context.TODO(), buf))
+	require.ErrorIs(t, th.HandleSyncedBlock(context.TODO(), buf), errInvalidRewards)
 }
 
 func Test_HandleBlockData_AlreadyHasBlock(t *testing.T) {

--- a/common/types/block.go
+++ b/common/types/block.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"bytes"
+	"fmt"
 	"sort"
 
 	"github.com/spacemeshos/go-scale"
@@ -61,6 +62,11 @@ type InnerBlock struct {
 // for doing math around weight inside go-spacemesh codebase, use util.Weight.
 type RatNum struct {
 	Num, Denom uint64
+}
+
+// String implements fmt.Stringer interface for RatNum.
+func (r *RatNum) String() string {
+	return fmt.Sprintf("%d/%d", r.Num, r.Denom)
 }
 
 // AnyReward contains the reward information.

--- a/genvm/metrics.go
+++ b/genvm/metrics.go
@@ -113,13 +113,25 @@ var (
 	feesCount = metrics.NewCounter(
 		"fees",
 		namespace,
-		"Fees in coins",
+		"Transaction fees",
+		[]string{},
+	).WithLabelValues()
+	subsidyCount = metrics.NewCounter(
+		"subsidy",
+		namespace,
+		"Estimated subsidy",
 		[]string{},
 	).WithLabelValues()
 	rewardsCount = metrics.NewCounter(
 		"rewards",
 		namespace,
 		"Total rewards including issuence and fees",
+		[]string{},
+	).WithLabelValues()
+	burntCount = metrics.NewCounter(
+		"rewards_burn",
+		namespace,
+		"Burnt amount of issuence and fees",
 		[]string{},
 	).WithLabelValues()
 )

--- a/genvm/rewards.go
+++ b/genvm/rewards.go
@@ -2,79 +2,112 @@ package vm
 
 import (
 	"fmt"
-	"math"
+	"math/big"
+
+	erewards "github.com/spacemeshos/economics/rewards"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
-	"github.com/spacemeshos/go-spacemesh/common/util"
+	"github.com/spacemeshos/go-spacemesh/genvm/core"
 	"github.com/spacemeshos/go-spacemesh/log"
+	"github.com/spacemeshos/go-spacemesh/sql"
+	"github.com/spacemeshos/go-spacemesh/sql/rewards"
 )
 
-// Config defines the configuration options for Spacemesh rewards.
-type Config struct {
-	GasLimit          uint64
-	StorageCostFactor uint64 `mapstructure:"vm-storage-cost-factor"`
-	BaseReward        uint64 `mapstructure:"base-reward"`
-}
-
-// DefaultConfig returns the default RewardConfig.
-func DefaultConfig() Config {
-	return Config{
-		GasLimit:          100_000_000,
-		StorageCostFactor: 2,
-		BaseReward:        50 * uint64(math.Pow10(12)),
+// ValidateRewards syntactically validates rewards.
+func ValidateRewards(rewards []types.AnyReward) error {
+	if len(rewards) == 0 {
+		return fmt.Errorf("empty rewards")
 	}
-}
-
-func calculateLayerReward(cfg Config) uint64 {
-	// todo: add inflation rules here
-	return cfg.BaseReward
-}
-
-// calculateRewards splits layer rewards and total fees fairly between coinbases recorded in rewards.
-func calculateRewards(logger log.Log, cfg Config, lid types.LayerID, totalFees uint64, rewards []types.AnyReward) ([]*types.Reward, error) {
-	logger = logger.WithFields(lid)
-	totalWeight := util.WeightFromUint64(0)
-	byCoinbase := make(map[types.Address]util.Weight)
+	unique := map[core.Address]struct{}{}
+	base := rewards[0].Weight.Denom
+	total := uint64(0)
 	for _, reward := range rewards {
-		weight := util.WeightFromNumDenom(reward.Weight.Num, reward.Weight.Denom)
-		logger.With().Debug("coinbase weight", reward.Coinbase, log.Stringer("weight", weight))
-		totalWeight.Add(weight)
-		if _, ok := byCoinbase[reward.Coinbase]; ok {
-			byCoinbase[reward.Coinbase].Add(weight)
-		} else {
-			byCoinbase[reward.Coinbase] = weight
+		if reward.Weight.Num == 0 || reward.Weight.Denom == 0 {
+			return fmt.Errorf("reward with invalid (zeroed) weight (%d/%d) included into the block for %v", reward.Weight.Num, reward.Weight.Denom, reward.Coinbase)
 		}
+		if base != reward.Weight.Denom {
+			return fmt.Errorf("all rewards must have the same base %d != %d", base, reward.Weight.Denom)
+		}
+		if _, exists := unique[reward.Coinbase]; exists {
+			return fmt.Errorf("multiple rewards for the same coinbase %v", reward.Coinbase)
+		}
+		unique[reward.Coinbase] = struct{}{}
+		total += reward.Weight.Num
 	}
-	if totalWeight.Cmp(util.WeightFromUint64(0)) == 0 {
-		logger.Error("zero total weight in block rewards")
-		return nil, fmt.Errorf("zero total weight")
+	if total != base {
+		return fmt.Errorf("total %d is inconsistent with a base %d", total, base)
 	}
-	finalRewards := make([]*types.Reward, 0, len(rewards))
-	layerRewards := calculateLayerReward(cfg)
-	totalRewards := layerRewards + totalFees
-	logger.With().Debug("rewards info for layer",
-		log.Uint64("layer_rewards", layerRewards),
-		log.Uint64("fee", totalFees))
-	rewardPer := util.WeightFromUint64(totalRewards).Div(totalWeight)
-	lyrRewardPer := util.WeightFromUint64(layerRewards).Div(totalWeight)
-	seen := make(map[types.Address]struct{})
-	for _, reward := range rewards {
-		if _, ok := seen[reward.Coinbase]; ok {
-			continue
+	return nil
+}
+
+func (v *VM) addRewards(lctx ApplyContext, ss *core.StagedCache, tx *sql.Tx, fees uint64, blockRewards []types.AnyReward) error {
+	var (
+		layersAfterEffectiveGenesis = lctx.Layer.Difference(types.GetEffectiveGenesis())
+		subsidy                     = erewards.TotalSubsidyAtLayer(layersAfterEffectiveGenesis)
+		total                       = subsidy + fees
+		transferred                 uint64
+	)
+	for _, blockReward := range blockRewards {
+		fraction := new(big.Int).SetUint64(blockReward.Weight.Num)
+		base := new(big.Int).SetUint64(blockReward.Weight.Denom)
+
+		totalReward := new(big.Int).SetUint64(total)
+		totalReward.
+			Mul(totalReward, fraction).
+			Quo(totalReward, base)
+		if !totalReward.IsUint64() {
+			return fmt.Errorf("%w: total reward %v for %v overflows uint64",
+				core.ErrInternal, totalReward, blockReward.Coinbase)
 		}
 
-		seen[reward.Coinbase] = struct{}{}
-		weight := byCoinbase[reward.Coinbase]
+		subsidyReward := new(big.Int).SetUint64(subsidy)
+		subsidyReward.
+			Mul(subsidyReward, fraction).
+			Quo(subsidyReward, base)
+		if !subsidyReward.IsUint64() {
+			return fmt.Errorf("%w: subsidy reward %v for %v overflows uint64",
+				core.ErrInternal, subsidyReward, blockReward.Coinbase)
+		}
 
-		fTotal, _ := rewardPer.Copy().Mul(weight).Float64()
-		totalReward := uint64(fTotal)
-		fLyr, _ := lyrRewardPer.Copy().Mul(weight).Float64()
-		finalRewards = append(finalRewards, &types.Reward{
-			Layer:       lid,
-			Coinbase:    reward.Coinbase,
-			TotalReward: totalReward,
-			LayerReward: uint64(fLyr),
-		})
+		v.logger.With().Debug("rewards for coinbase",
+			lctx.Layer,
+			blockReward.Coinbase,
+			log.Stringer("relative weight", &blockReward.Weight),
+			log.Uint64("subsidy", subsidyReward.Uint64()),
+			log.Uint64("total", totalReward.Uint64()),
+		)
+
+		reward := &types.Reward{
+			Layer:       lctx.Layer,
+			Coinbase:    blockReward.Coinbase,
+			TotalReward: totalReward.Uint64(),
+			LayerReward: subsidyReward.Uint64(),
+		}
+		if err := rewards.Add(tx, reward); err != nil {
+			return fmt.Errorf("%w: %s", core.ErrInternal, err.Error())
+		}
+		account, err := ss.Get(blockReward.Coinbase)
+		if err != nil {
+			return fmt.Errorf("%w: %s", core.ErrInternal, err.Error())
+		}
+		account.Balance += reward.TotalReward
+		if err := ss.Update(account); err != nil {
+			return fmt.Errorf("%w: %s", core.ErrInternal, err.Error())
+		}
+		transferred += totalReward.Uint64()
 	}
-	return finalRewards, nil
+	v.logger.With().Debug("rewards for layer",
+		lctx.Layer,
+		log.Uint32("after genesis", layersAfterEffectiveGenesis),
+		log.Uint64("subsidy estimated", subsidy),
+		log.Uint64("fee", fees),
+		log.Uint64("total estimated", total),
+		log.Uint64("total transffered", transferred),
+		log.Uint64("total burnt", total-transferred),
+	)
+	feesCount.Add(float64(fees))
+	subsidyCount.Add(float64(subsidy))
+	rewardsCount.Add(float64(transferred))
+	burntCount.Add(float64(total - transferred))
+	return nil
 }

--- a/genvm/rewards_test.go
+++ b/genvm/rewards_test.go
@@ -1,0 +1,256 @@
+package vm
+
+import (
+	"testing"
+
+	erewards "github.com/spacemeshos/economics/rewards"
+	"github.com/stretchr/testify/require"
+
+	"github.com/spacemeshos/go-spacemesh/common/types"
+)
+
+func TestValidateRewards(t *testing.T) {
+	for _, tc := range []struct {
+		desc    string
+		rewards []types.AnyReward
+		err     bool
+	}{
+		{
+			desc: "sanity",
+			rewards: []types.AnyReward{
+				{
+					Coinbase: types.Address{1},
+					Weight:   types.RatNum{Num: 1, Denom: 3},
+				},
+				{
+					Coinbase: types.Address{2},
+					Weight:   types.RatNum{Num: 1, Denom: 3},
+				},
+				{
+					Coinbase: types.Address{3},
+					Weight:   types.RatNum{Num: 1, Denom: 3},
+				},
+			},
+		},
+		{
+			desc:    "empty",
+			rewards: []types.AnyReward{},
+			err:     true,
+		},
+		{
+			desc: "nil",
+			err:  true,
+		},
+		{
+			desc: "zero num",
+			rewards: []types.AnyReward{
+				{
+					Coinbase: types.Address{1},
+					Weight:   types.RatNum{Num: 1, Denom: 3},
+				},
+				{
+					Coinbase: types.Address{3},
+					Weight:   types.RatNum{Num: 0, Denom: 3},
+				},
+			},
+			err: true,
+		},
+		{
+			desc: "zero denom",
+			rewards: []types.AnyReward{
+				{
+					Coinbase: types.Address{1},
+					Weight:   types.RatNum{Num: 1, Denom: 3},
+				},
+				{
+					Coinbase: types.Address{3},
+					Weight:   types.RatNum{Num: 1, Denom: 0},
+				},
+			},
+			err: true,
+		},
+		{
+			desc: "inconsistent base",
+			rewards: []types.AnyReward{
+				{
+					Coinbase: types.Address{1},
+					Weight:   types.RatNum{Num: 2, Denom: 4},
+				},
+				{
+					Coinbase: types.Address{3},
+					Weight:   types.RatNum{Num: 1, Denom: 2},
+				},
+			},
+			err: true,
+		},
+		{
+			desc: "total overflow",
+			rewards: []types.AnyReward{
+				{
+					Coinbase: types.Address{1},
+					Weight:   types.RatNum{Num: 2, Denom: 3},
+				},
+				{
+					Coinbase: types.Address{3},
+					Weight:   types.RatNum{Num: 2, Denom: 3},
+				},
+			},
+			err: true,
+		},
+		{
+			desc: "total underflow",
+			rewards: []types.AnyReward{
+				{
+					Coinbase: types.Address{1},
+					Weight:   types.RatNum{Num: 1, Denom: 3},
+				},
+				{
+					Coinbase: types.Address{3},
+					Weight:   types.RatNum{Num: 1, Denom: 3},
+				},
+			},
+			err: true,
+		},
+		{
+			desc: "multiple per coinbase",
+			rewards: []types.AnyReward{
+				{
+					Coinbase: types.Address{1},
+					Weight:   types.RatNum{Num: 1, Denom: 3},
+				},
+				{
+					Coinbase: types.Address{3},
+					Weight:   types.RatNum{Num: 1, Denom: 3},
+				},
+				{
+					Coinbase: types.Address{1},
+					Weight:   types.RatNum{Num: 1, Denom: 3},
+				},
+			},
+			err: true,
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			err := ValidateRewards(tc.rewards)
+			if tc.err {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestRewards(t *testing.T) {
+	genTester := func(t *testing.T) *tester {
+		return newTester(t).
+			addSingleSig(10).
+			applyGenesis()
+	}
+	ref := genTester(t)
+	const spawnFee = 398
+	require.Equal(t, int(spawnFee), ref.estimateSpawnGas(0))
+	// this is hardcoded so that you can see which number is divided without reminder
+	// and pick correct fractions for tests
+	expected := []int{
+		477618397593,
+		477618296206,
+		477618194821,
+		477618093434,
+		477617992047,
+	}
+	for i := 0; i < 5; i++ {
+		require.Equal(t, expected[i], int(erewards.TotalSubsidyAtLayer(uint32(i))))
+	}
+	tcs := []templateTestCase{
+		{
+			desc: "sanity",
+			layers: []layertc{
+				{
+					rewards: []reward{{address: 1, share: 1}},
+					expected: map[int]change{
+						1: earned{amount: expected[0]},
+					},
+				},
+				{
+					rewards: []reward{{address: 2, share: 1}},
+					expected: map[int]change{
+						2: earned{amount: expected[1]},
+					},
+				},
+				{
+					rewards: []reward{{address: 3, share: 1}},
+					expected: map[int]change{
+						3: earned{amount: expected[2]},
+					},
+				},
+			},
+		},
+		{
+			desc: "empty layer",
+			layers: []layertc{
+				{
+					rewards: []reward{{address: 1, share: 1}},
+					expected: map[int]change{
+						1: earned{amount: expected[0]},
+					},
+				},
+				{},
+				{
+					rewards: []reward{{address: 3, share: 1}},
+					expected: map[int]change{
+						3: earned{amount: expected[2]},
+					},
+				},
+				{},
+				{
+					rewards: []reward{{address: 5, share: 1}},
+					expected: map[int]change{
+						5: earned{amount: expected[4]},
+					},
+				},
+			},
+		},
+		{
+			desc: "subsidy rounded down",
+			layers: []layertc{
+				{
+					rewards: []reward{{address: 1, share: 0.5}, {address: 2, share: 0.5}},
+					expected: map[int]change{
+						1: earned{amount: (expected[0] - 1) / 2},
+						2: earned{amount: (expected[0] - 1) / 2},
+					},
+				},
+				{
+					rewards: []reward{{address: 1, share: 0.9}, {address: 2, share: 0.1}},
+					expected: map[int]change{
+						1: earned{amount: expected[1] * 9 / 10},
+						2: earned{amount: expected[1] / 10},
+					},
+				},
+			},
+		},
+		{
+			desc: "fees and subsidy rounded down together",
+			layers: []layertc{
+				{
+					txs:     []testTx{&selfSpawnTx{8}},
+					rewards: []reward{{address: 1, share: 0.5}, {address: 2, share: 0.5}},
+					expected: map[int]change{
+						1: earned{amount: (expected[0] - 1 + spawnFee) / 2},
+						2: earned{amount: (expected[0] - 1 + spawnFee) / 2},
+					},
+				},
+				{
+					txs:     []testTx{&selfSpawnTx{9}},
+					rewards: []reward{{address: 1, share: 0.9}, {address: 2, share: 0.1}},
+					expected: map[int]change{
+						1: earned{amount: (expected[1] + spawnFee) * 9 / 10},
+						2: earned{amount: (expected[1] + spawnFee) / 10},
+					},
+				},
+			},
+		},
+	}
+	runTestCases(t, tcs, genTester)
+}

--- a/genvm/rewards_test.go
+++ b/genvm/rewards_test.go
@@ -70,48 +70,6 @@ func TestValidateRewards(t *testing.T) {
 			err: true,
 		},
 		{
-			desc: "inconsistent base",
-			rewards: []types.AnyReward{
-				{
-					Coinbase: types.Address{1},
-					Weight:   types.RatNum{Num: 2, Denom: 4},
-				},
-				{
-					Coinbase: types.Address{3},
-					Weight:   types.RatNum{Num: 1, Denom: 2},
-				},
-			},
-			err: true,
-		},
-		{
-			desc: "total overflow",
-			rewards: []types.AnyReward{
-				{
-					Coinbase: types.Address{1},
-					Weight:   types.RatNum{Num: 2, Denom: 3},
-				},
-				{
-					Coinbase: types.Address{3},
-					Weight:   types.RatNum{Num: 2, Denom: 3},
-				},
-			},
-			err: true,
-		},
-		{
-			desc: "total underflow",
-			rewards: []types.AnyReward{
-				{
-					Coinbase: types.Address{1},
-					Weight:   types.RatNum{Num: 1, Denom: 3},
-				},
-				{
-					Coinbase: types.Address{3},
-					Weight:   types.RatNum{Num: 1, Denom: 3},
-				},
-			},
-			err: true,
-		},
-		{
 			desc: "multiple per coinbase",
 			rewards: []types.AnyReward{
 				{

--- a/genvm/templates/vault/vault.go
+++ b/genvm/templates/vault/vault.go
@@ -41,7 +41,7 @@ func (v *Vault) Available(lid core.LayerID) uint64 {
 	}
 	incremental := new(big.Int).SetUint64(v.TotalAmount - v.InitialUnlockAmount)
 	incremental.Mul(incremental, new(big.Int).SetUint64(uint64(lid.Difference(v.VestingStart))))
-	incremental.Div(incremental, new(big.Int).SetUint64(uint64(v.VestingEnd.Difference(v.VestingStart))))
+	incremental.Quo(incremental, new(big.Int).SetUint64(uint64(v.VestingEnd.Difference(v.VestingStart))))
 	return v.InitialUnlockAmount + incremental.Uint64()
 }
 

--- a/genvm/vm.go
+++ b/genvm/vm.go
@@ -37,7 +37,7 @@ func WithLogger(logger log.Log) Opt {
 	}
 }
 
-// Config defines the configuration options for Spacemesh rewards.
+// Config defines the configuration options for vm.
 type Config struct {
 	GasLimit          uint64
 	StorageCostFactor uint64 `mapstructure:"vm-storage-cost-factor"`

--- a/genvm/vm.go
+++ b/genvm/vm.go
@@ -37,6 +37,20 @@ func WithLogger(logger log.Log) Opt {
 	}
 }
 
+// Config defines the configuration options for Spacemesh rewards.
+type Config struct {
+	GasLimit          uint64
+	StorageCostFactor uint64 `mapstructure:"vm-storage-cost-factor"`
+}
+
+// DefaultConfig returns the default RewardConfig.
+func DefaultConfig() Config {
+	return Config{
+		GasLimit:          100_000_000,
+		StorageCostFactor: 2,
+	}
+}
+
 // WithConfig updates config on the vm.
 func WithConfig(cfg Config) Opt {
 	return func(vm *VM) {
@@ -175,6 +189,11 @@ func (v *VM) ApplyGenesis(genesis []types.Account) error {
 
 // Apply transactions.
 func (v *VM) Apply(lctx ApplyContext, txs []types.Transaction, blockRewards []types.AnyReward) ([]types.Transaction, []types.TransactionWithResult, error) {
+	if lctx.Layer.Before(types.GetEffectiveGenesis()) {
+		return nil, nil, fmt.Errorf("%w: applying layer %s before effective genesis %s",
+			core.ErrInternal, lctx.Layer, types.GetEffectiveGenesis(),
+		)
+	}
 	t1 := time.Now()
 	tx, err := v.db.TxImmediate(context.Background())
 	if err != nil {
@@ -192,12 +211,10 @@ func (v *VM) Apply(lctx ApplyContext, txs []types.Transaction, blockRewards []ty
 	t3 := time.Now()
 	blockDurationTxs.Observe(float64(time.Since(t2)))
 
-	// TODO(dshulyak) why it fails if there are no rewards?
-	if len(blockRewards) > 0 {
-		if err := v.addRewards(lctx, ss, tx, fees, blockRewards); err != nil {
-			return nil, nil, err
-		}
+	if err := v.addRewards(lctx, ss, tx, fees, blockRewards); err != nil {
+		return nil, nil, err
 	}
+
 	t4 := time.Now()
 	blockDurationRewards.Observe(float64(time.Since(t3)))
 
@@ -242,29 +259,6 @@ func (v *VM) Apply(lctx ApplyContext, txs []types.Transaction, blockRewards []ty
 		log.Stringer("state_hash", hash),
 	)
 	return skipped, results, nil
-}
-
-func (v *VM) addRewards(lctx ApplyContext, ss *core.StagedCache, tx *sql.Tx, fees uint64, blockRewards []types.AnyReward) error {
-	finalRewards, err := calculateRewards(v.logger, v.cfg, lctx.Layer, fees, blockRewards)
-	if err != nil {
-		return fmt.Errorf("%w: %s", core.ErrInternal, err.Error())
-	}
-	for _, reward := range finalRewards {
-		if err := rewards.Add(tx, reward); err != nil {
-			return fmt.Errorf("%w: %s", core.ErrInternal, err.Error())
-		}
-		account, err := ss.Get(reward.Coinbase)
-		if err != nil {
-			return fmt.Errorf("%w: %s", core.ErrInternal, err.Error())
-		}
-		account.Balance += reward.TotalReward
-		if err := ss.Update(account); err != nil {
-			return fmt.Errorf("%w: %s", core.ErrInternal, err.Error())
-		}
-		rewardsCount.Add(float64(reward.TotalReward))
-	}
-	feesCount.Add(float64(fees))
-	return nil
 }
 
 func (v *VM) execute(lctx ApplyContext, ss *core.StagedCache, txs []types.Transaction) ([]types.TransactionWithResult, []types.Transaction, uint64, error) {

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/pyroscope-io/pyroscope v0.29.0
 	github.com/seehuhn/mt19937 v1.0.0
 	github.com/spacemeshos/api/release/go v1.4.1-0.20220905145225-2baea06a0206
+	github.com/spacemeshos/economics v0.0.0-20220810190316-045462b489e8
 	github.com/spacemeshos/ed25519 v0.0.0-20220825090204-1f103b5756da
 	github.com/spacemeshos/fixed v0.0.0-20210523192743-8d17e03c169a
 	github.com/spacemeshos/go-scale v0.0.0-20220825075539-b6b3deb9834c
@@ -70,6 +71,7 @@ require (
 	github.com/docker/go-units v0.4.0 // indirect
 	github.com/elastic/gosigar v0.14.2 // indirect
 	github.com/emicklei/go-restful/v3 v3.8.0 // indirect
+	github.com/ericlagergren/decimal v0.0.0-20211103172832-aca2edc11f73 // indirect
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
 	github.com/flynn/noise v1.0.0 // indirect
 	github.com/francoispqt/gojay v1.2.13 // indirect

--- a/go.sum
+++ b/go.sum
@@ -70,6 +70,7 @@ github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 h1:s6gZFSlWYmbqAu
 github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137/go.mod h1:OMCwj8VM1Kc9e19TLln2VL61YJF0x1XFtfdL4JdbSyE=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
+github.com/apmckinlay/gsuneido v0.0.0-20190404155041-0b6cd442a18f/go.mod h1:JU2DOj5Fc6rol0yaT79Csr47QR0vONGwJtBNGRD7jmc=
 github.com/aquasecurity/libbpfgo v0.3.0-libbpf-0.8.0 h1:NQEf484vQOshZwZOLTE7kzo62TvYrM906gUjlVg4D2k=
 github.com/aquasecurity/libbpfgo v0.3.0-libbpf-0.8.0/go.mod h1:qu0TVGRvtNMFkuKLscJkY1FwmageNBLqeImAFslqPPc=
 github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d h1:Byv0BzEl3/e6D5CLfI0j/7hiIEtvGVFPCZ7Ei2oq8iQ=
@@ -107,6 +108,7 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
+github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMeY4+DwBQ=
 github.com/containerd/cgroups v0.0.0-20201119153540-4cbc285b3327/go.mod h1:ZJeTFisyysqgcCdecO57Dj79RfL0LNeGiFUqLYQRYLE=
 github.com/containerd/cgroups v1.0.4 h1:jN/mbWBEaz+T1pi5OFtnkQ+8qnmEbAr1Oo1FRm5B0dA=
 github.com/containerd/cgroups v1.0.4/go.mod h1:nLNQtsF7Sl2HxNebu77i1R0oDlhiTG+kO4JTrUzo6IA=
@@ -144,6 +146,8 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5ynNVH9qI8YYLbd1fK2po=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/ericlagergren/decimal v0.0.0-20211103172832-aca2edc11f73 h1:odNUt+pGupjtZyfaNIGLT/PUxT7r3fZ0Kf+QH9reIoM=
+github.com/ericlagergren/decimal v0.0.0-20211103172832-aca2edc11f73/go.mod h1:5sruVSMrZCk0U4hwRaGD0D8wIMFVsBWQqG74jQDFg4k=
 github.com/evanphx/json-patch v0.5.2/go.mod h1:ZWS5hhDbVDyob71nXKNL0+PWn6ToqBHMikGIFbs31qQ=
 github.com/evanphx/json-patch v4.12.0+incompatible h1:4onqiflcdA9EOZ4RxV643DvftH5pOlLGNtQ5lPWQu84=
 github.com/evanphx/json-patch/v5 v5.6.0 h1:b91NhWfaz02IuVxO9faSllyAtNXHMPkC5J8sJCLunww=
@@ -372,6 +376,7 @@ github.com/kr/pty v1.1.3/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/libp2p/go-buffer-pool v0.1.0 h1:oK4mSFcQz7cTQIfqbe4MIj9gLW+mnanjyFtc6cdF0Y8=
 github.com/libp2p/go-buffer-pool v0.1.0/go.mod h1:N+vh8gMqimBzdKkSMVuydVDq+UV5QTWy5HSiZacSbPg=
 github.com/libp2p/go-cidranger v1.1.0 h1:ewPN8EZ0dd1LSnrtuwd4709PXVcITVeuwbag38yPW7c=
@@ -580,6 +585,7 @@ github.com/seehuhn/mt19937 v1.0.0/go.mod h1:RikyXajNu+1Gqxm4hOacc3ckyWRd0usF6IkE
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/shirou/gopsutil v3.21.4+incompatible h1:fuHcTm5mX+wzo542cmYcV9RTGQLbnHLI5SyQ5ryTVck=
 github.com/shirou/gopsutil v3.21.4+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
+github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24/go.mod h1:M+9NzErvs504Cn4c5DxATwIqPbtswREoFCre64PpcG4=
 github.com/shurcooL/component v0.0.0-20170202220835-f88ec8f54cc4/go.mod h1:XhFIlyj5a1fBNx5aJTbKoIq0mNaPvOagO+HjB3EtxrY=
 github.com/shurcooL/events v0.0.0-20181021180414-410e4ca65f48/go.mod h1:5u70Mqkb5O5cxEA8nxTsgrgLehJeAw6Oc4Ab1c/P1HM=
 github.com/shurcooL/github_flavored_markdown v0.0.0-20181002035957-2122de532470/go.mod h1:2dOwnU2uBioM+SGy2aZoq1f/Sd1l9OkAeAUvjSyvgU0=
@@ -614,6 +620,8 @@ github.com/spacemeshos/api/release/go v1.4.1-0.20220905145225-2baea06a0206 h1:x5
 github.com/spacemeshos/api/release/go v1.4.1-0.20220905145225-2baea06a0206/go.mod h1:rn6ND0nWI/EKtiwBiEiYC4lOHvInamNlvR4YMsm+hy8=
 github.com/spacemeshos/bitstream v0.0.0-20210407173523-8168e84f83b0 h1:f5AVMlh6x7rVJ+SoYvqkOl284OpdPw7tH5aBliIt0gc=
 github.com/spacemeshos/bitstream v0.0.0-20210407173523-8168e84f83b0/go.mod h1:wnp+444ieV6+UUjPYJ8id/kuQbk4jZ6NWp5Nw6O091E=
+github.com/spacemeshos/economics v0.0.0-20220810190316-045462b489e8 h1:z0XwruM9Vl2YIUxHjTh/3ijhe8ZI7XK3O127Trz5LEk=
+github.com/spacemeshos/economics v0.0.0-20220810190316-045462b489e8/go.mod h1:bMv7iXffBCPAHFivV6XM2l2SWXIfDoXkw4ND9yhgyfI=
 github.com/spacemeshos/ed25519 v0.0.0-20220825090204-1f103b5756da h1:A4t7zL04bZMJZDbgRNCqzMKilAZn1mbi+X2CzhSoHGE=
 github.com/spacemeshos/ed25519 v0.0.0-20220825090204-1f103b5756da/go.mod h1:T58UnqgFOh3CvVotk5SD53hY+3BhX81pH4Qc1qtP8Sk=
 github.com/spacemeshos/fixed v0.0.0-20210523192743-8d17e03c169a h1:p/BRpvEHGqd4oYBp+B/vG3Z3RWdb7vAZCz8xsecS92M=


### PR DESCRIPTION
closes: https://github.com/spacemeshos/pm/issues/151
closes: https://github.com/spacemeshos/go-spacemesh/issues/3408
closes: https://github.com/spacemeshos/go-spacemesh/issues/3251

this change enforces next rules for block syntactic validity:
- every block must have at least one reward (empty layers are an obvious exception)
- to make block more compact there should be at most one reward per coinbase (smeshers are not recorded in rewards) - this is already like that in the code that generates block, i am adding a validation for it
- weight is recorded as fractional int using two uint64 (num/denom), if any of those is 0 - block is syntactically invalid

total rewards is a sum of fees and subsidy (subsidy is computed using github.com/spacemeshos/economics). total rewards are splited between coinbases recorded in the block. each coinbase share is a relative to the total weight recorded in the block. share is computed using big.Rat from stdlib on integer values.

absolute value is computed by multiplying total reward by big.Rat numerator and divides by denominator using big.Int from stdlib (no floating operations).  