### PR TITLE
[Merged by Bors] - Removed extra log added just to satisfy tests.

### DIFF
--- a/p2p/bootstrap/bootstrap.go
+++ b/p2p/bootstrap/bootstrap.go
@@ -102,11 +102,10 @@ func (b *Bootstrap) run(ctx context.Context, sub event.Subscription, emitter eve
 	defer b.host.Network().StopNotify(notifier)
 
 	var (
-		outbound           int
-		discoveryBootstrap bool
-		peers              = map[peer.ID]network.Direction{}
-		limit              = make(chan struct{}, 1)
-		ticker             = time.NewTicker(b.cfg.Timeout)
+		outbound int
+		peers    = map[peer.ID]network.Direction{}
+		limit    = make(chan struct{}, 1)
+		ticker   = time.NewTicker(b.cfg.Timeout)
 	)
 	defer ticker.Stop()
 
@@ -147,12 +146,6 @@ func (b *Bootstrap) run(ctx context.Context, sub event.Subscription, emitter eve
 				Direction:     hs.Direction,
 				Connectedness: network.Connected,
 			})
-			if len(peers) >= b.cfg.TargetOutbound && !discoveryBootstrap {
-				// NOTE(dshulyak) this is a hack to support logic in tests that expects a message
-				// to be printed once
-				discoveryBootstrap = true
-				b.logger.Event().Info("discovery_bootstrap", log.Int("peers", len(peers)))
-			}
 		case pid := <-disconnected:
 			_, exist := peers[pid]
 			if exist && b.host.Network().Connectedness(pid) == network.NotConnected {


### PR DESCRIPTION
Reasoning: No test depends on this log.

## Motivation
There is a hack meant to satisfy tests by emitting a log message. But no test seems to use this log.
## Changes
Removed the hack

## Test Plan
unit tests, systests

## DevOps Notes
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
