### PR TITLE
[Merged by Bors] - sync: get block validity from peers

### DIFF
--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -547,13 +547,12 @@ func (app *App) initServices(ctx context.Context,
 	dataHanders := fetch.DataHandlers{
 		ATX:      atxHandler,
 		Block:    blockHandller,
-		Cert:     app.certifier,
 		Ballot:   proposalListener,
 		Proposal: proposalListener,
 		TX:       txHandler,
 		Poet:     poetDb,
 	}
-	layerFetch := fetch.NewLogic(app.Config.FETCH, sqlDB, msh, app.host, dataHanders, app.addLogger(LayerFetcher, lg))
+	layerFetch := fetch.NewLogic(app.Config.FETCH, cdb, msh, app.host, dataHanders, app.addLogger(LayerFetcher, lg))
 	fetcherWrapped.Fetcher = layerFetch
 
 	patrol := layerpatrol.New()
@@ -562,7 +561,7 @@ func (app *App) initServices(ctx context.Context,
 		HareDelayLayers:  app.Config.Tortoise.Zdist,
 		SyncCertDistance: app.Config.Tortoise.Hdist,
 	}
-	newSyncer := syncer.NewSyncer(ctx, syncerConf, clock, beaconProtocol, msh, layerFetch, patrol, app.addLogger(SyncLogger, lg))
+	newSyncer := syncer.NewSyncer(ctx, syncerConf, sqlDB, clock, beaconProtocol, msh, layerFetch, patrol, app.certifier, app.addLogger(SyncLogger, lg))
 	// TODO(dshulyak) this needs to be improved, but dependency graph is a bit complicated
 	beaconProtocol.SetSyncState(newSyncer)
 

--- a/fetch/handler.go
+++ b/fetch/handler.go
@@ -96,9 +96,9 @@ func (h *handler) handleLayerOpinionsReq(ctx context.Context, req []byte) ([]byt
 		h.logger.WithContext(ctx).With().Warning("failed to get epoch weight", lid, lid.GetEpoch(), log.Err(err))
 		return nil, errInternal
 	}
-	lo.AggregatedHash, err = layers.GetAggregatedHash(h.cdb, lid)
+	lo.PrevAggHash, err = layers.GetAggregatedHash(h.cdb, lid.Sub(1))
 	if err != nil && !errors.Is(err, sql.ErrNotFound) {
-		h.logger.WithContext(ctx).With().Warning("failed to get aggregated layer hash", lid, log.Err(err))
+		h.logger.WithContext(ctx).With().Warning("failed to get prev agg hash", lid, log.Err(err))
 		return nil, errInternal
 	}
 	lo.Verified = h.msh.LastVerified()

--- a/fetch/handler_test.go
+++ b/fetch/handler_test.go
@@ -146,7 +146,7 @@ func TestHandleLayerOpinionsReq(t *testing.T) {
 			err = codec.Decode(out, &got)
 			require.NoError(t, err)
 			require.Equal(t, uint64(0), got.EpochWeight)
-			require.Equal(t, aggHash, got.AggregatedHash)
+			require.Equal(t, aggHash, got.PrevAggHash)
 			require.Equal(t, tc.verified, got.Verified)
 			if tc.missingCert {
 				require.Nil(t, got.Cert)

--- a/fetch/handler_test.go
+++ b/fetch/handler_test.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/spacemeshos/go-spacemesh/codec"
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/datastore"
+	"github.com/spacemeshos/go-spacemesh/fetch/mocks"
 	"github.com/spacemeshos/go-spacemesh/log/logtest"
 	"github.com/spacemeshos/go-spacemesh/signing"
 	"github.com/spacemeshos/go-spacemesh/sql"
@@ -18,41 +19,57 @@ import (
 	"github.com/spacemeshos/go-spacemesh/sql/layers"
 )
 
-type lyrdata struct {
-	hash, aggHash types.Hash32
-	blts          []types.BallotID
-	blks          []types.BlockID
-}
-
 type testHandler struct {
 	*handler
+	cdb *datastore.CachedDB
+	mm  *mocks.MockmeshProvider
 }
 
 func createTestHandler(t *testing.T) *testHandler {
-	db := sql.InMemory()
+	lg := logtest.New(t)
+	cdb := datastore.NewCachedDB(sql.InMemory(), lg)
+	mm := mocks.NewMockmeshProvider(gomock.NewController(t))
 	return &testHandler{
-		handler: newHandler(db, datastore.NewBlobStore(db), logtest.New(t)),
+		handler: newHandler(cdb, datastore.NewBlobStore(cdb.Database), mm, lg),
+		cdb:     cdb,
+		mm:      mm,
 	}
 }
 
-func createLayer(t *testing.T, db *sql.Database, lid types.LayerID) *lyrdata {
-	l := &lyrdata{}
-	l.hash = types.RandomHash()
-	l.aggHash = types.RandomHash()
-	require.NoError(t, layers.SetHashes(db, lid, l.hash, l.aggHash))
-	for i := 0; i < 5; i++ {
+func createLayer(t *testing.T, db *datastore.CachedDB, lid types.LayerID) ([]types.BallotID, []types.BlockID) {
+	num := 5
+	blts := make([]types.BallotID, 0, num)
+	blks := make([]types.BlockID, 0, num)
+	for i := 0; i < num; i++ {
 		b := types.RandomBallot()
 		b.LayerIndex = lid
 		b.Signature = signing.NewEdSigner().Sign(b.Bytes())
 		require.NoError(t, b.Initialize())
 		require.NoError(t, ballots.Add(db, b))
-		l.blts = append(l.blts, b.ID())
+		blts = append(blts, b.ID())
 
 		bk := types.NewExistingBlock(types.RandomBlockID(), types.InnerBlock{LayerIndex: lid})
 		require.NoError(t, blocks.Add(db, bk))
-		l.blks = append(l.blks, bk.ID())
+		blks = append(blks, bk.ID())
 	}
-	return l
+	return blts, blks
+}
+
+func createOpinions(t *testing.T, db *datastore.CachedDB, lid types.LayerID, genCert bool) ([]types.BlockID, types.Hash32) {
+	_, blks := createLayer(t, db, lid)
+	if genCert {
+		require.NoError(t, layers.SetHareOutputWithCert(db, lid, &types.Certificate{BlockID: blks[0]}))
+	}
+	for i, bid := range blks {
+		if i == 0 {
+			require.NoError(t, blocks.SetValid(db, bid))
+		} else {
+			require.NoError(t, blocks.SetInvalid(db, bid))
+		}
+	}
+	aggHash := types.RandomHash()
+	require.NoError(t, layers.SetHashes(db, lid, types.RandomHash(), aggHash))
+	return blks, aggHash
 }
 
 func TestHandleLayerDataReq(t *testing.T) {
@@ -76,32 +93,40 @@ func TestHandleLayerDataReq(t *testing.T) {
 
 			lid := types.NewLayerID(111)
 			th := createTestHandler(t)
-			expected := createLayer(t, th.db, lid)
+			blts, blks := createLayer(t, th.cdb, lid)
 
 			out, err := th.handleLayerDataReq(context.TODO(), lid.Bytes())
 			require.NoError(t, err)
 			var got LayerData
 			err = codec.Decode(out, &got)
 			require.NoError(t, err)
-			assert.ElementsMatch(t, expected.blts, got.Ballots)
-			assert.ElementsMatch(t, expected.blks, got.Blocks)
-			assert.Equal(t, expected.hash, got.Hash)
-			assert.Equal(t, expected.aggHash, got.AggregatedHash)
+			require.ElementsMatch(t, blts, got.Ballots)
+			require.ElementsMatch(t, blks, got.Blocks)
 		})
 	}
 }
 
 func TestHandleLayerOpinionsReq(t *testing.T) {
 	tt := []struct {
-		name string
-		cert *types.Certificate
+		name                string
+		verified, requested types.LayerID
+		missingCert         bool
 	}{
 		{
-			name: "has cert",
-			cert: &types.Certificate{BlockID: types.BlockID{1, 2, 3}},
+			name:      "all good",
+			verified:  types.NewLayerID(111),
+			requested: types.NewLayerID(111),
 		},
 		{
-			name: "no cert",
+			name:      "not verified",
+			verified:  types.NewLayerID(100),
+			requested: types.NewLayerID(111),
+		},
+		{
+			name:        "cert missing",
+			verified:    types.NewLayerID(111),
+			requested:   types.NewLayerID(111),
+			missingCert: true,
 		},
 	}
 
@@ -111,17 +136,31 @@ func TestHandleLayerOpinionsReq(t *testing.T) {
 			t.Parallel()
 
 			th := createTestHandler(t)
-			lid := types.NewLayerID(111)
-			if tc.cert != nil {
-				require.NoError(t, layers.SetHareOutputWithCert(th.db, lid, tc.cert))
-			}
+			blks, aggHash := createOpinions(t, th.cdb, tc.requested, !tc.missingCert)
 
-			out, err := th.handleLayerOpinionsReq(context.TODO(), lid.Bytes())
+			th.mm.EXPECT().LastVerified().Return(tc.verified)
+			out, err := th.handleLayerOpinionsReq(context.TODO(), tc.requested.Bytes())
 			require.NoError(t, err)
-			var got LayerOpinions
+
+			var got LayerOpinion
 			err = codec.Decode(out, &got)
 			require.NoError(t, err)
-			assert.Equal(t, tc.cert, got.Cert)
+			require.Equal(t, uint64(0), got.EpochWeight)
+			require.Equal(t, aggHash, got.AggregatedHash)
+			require.Equal(t, tc.verified, got.Verified)
+			if tc.missingCert {
+				require.Nil(t, got.Cert)
+			} else {
+				require.NotNil(t, got.Cert)
+				require.Equal(t, blks[0], got.Cert.BlockID)
+			}
+			if !tc.verified.Before(tc.requested) {
+				require.ElementsMatch(t, blks[0:1], got.Valid)
+				require.ElementsMatch(t, blks[1:], got.Invalid)
+			} else {
+				require.Empty(t, got.Valid)
+				require.Empty(t, got.Invalid)
+			}
 		})
 	}
 }

--- a/fetch/handler_test.go
+++ b/fetch/handler_test.go
@@ -68,7 +68,7 @@ func createOpinions(t *testing.T, db *datastore.CachedDB, lid types.LayerID, gen
 		}
 	}
 	aggHash := types.RandomHash()
-	require.NoError(t, layers.SetHashes(db, lid, types.RandomHash(), aggHash))
+	require.NoError(t, layers.SetHashes(db, lid.Sub(1), types.RandomHash(), aggHash))
 	return blks, aggHash
 }
 

--- a/fetch/interface.go
+++ b/fetch/interface.go
@@ -31,10 +31,6 @@ type blockHandler interface {
 	HandleSyncedBlock(context.Context, []byte) error
 }
 
-type certHandler interface {
-	HandleSyncedCertificate(context.Context, types.LayerID, *types.Certificate) error
-}
-
 type ballotHandler interface {
 	HandleSyncedBallot(context.Context, []byte) error
 }
@@ -55,6 +51,7 @@ type poetHandler interface {
 type meshProvider interface {
 	ProcessedLayer() types.LayerID
 	SetZeroBlockLayer(context.Context, types.LayerID) error
+	LastVerified() types.LayerID
 }
 
 type host interface {

--- a/fetch/mocks/mocks.go
+++ b/fetch/mocks/mocks.go
@@ -230,43 +230,6 @@ func (mr *MockblockHandlerMockRecorder) HandleSyncedBlock(arg0, arg1 interface{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleSyncedBlock", reflect.TypeOf((*MockblockHandler)(nil).HandleSyncedBlock), arg0, arg1)
 }
 
-// MockcertHandler is a mock of certHandler interface.
-type MockcertHandler struct {
-	ctrl     *gomock.Controller
-	recorder *MockcertHandlerMockRecorder
-}
-
-// MockcertHandlerMockRecorder is the mock recorder for MockcertHandler.
-type MockcertHandlerMockRecorder struct {
-	mock *MockcertHandler
-}
-
-// NewMockcertHandler creates a new mock instance.
-func NewMockcertHandler(ctrl *gomock.Controller) *MockcertHandler {
-	mock := &MockcertHandler{ctrl: ctrl}
-	mock.recorder = &MockcertHandlerMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockcertHandler) EXPECT() *MockcertHandlerMockRecorder {
-	return m.recorder
-}
-
-// HandleSyncedCertificate mocks base method.
-func (m *MockcertHandler) HandleSyncedCertificate(arg0 context.Context, arg1 types.LayerID, arg2 *types.Certificate) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HandleSyncedCertificate", arg0, arg1, arg2)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// HandleSyncedCertificate indicates an expected call of HandleSyncedCertificate.
-func (mr *MockcertHandlerMockRecorder) HandleSyncedCertificate(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleSyncedCertificate", reflect.TypeOf((*MockcertHandler)(nil).HandleSyncedCertificate), arg0, arg1, arg2)
-}
-
 // MockballotHandler is a mock of ballotHandler interface.
 type MockballotHandler struct {
 	ctrl     *gomock.Controller
@@ -450,6 +413,20 @@ func NewMockmeshProvider(ctrl *gomock.Controller) *MockmeshProvider {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockmeshProvider) EXPECT() *MockmeshProviderMockRecorder {
 	return m.recorder
+}
+
+// LastVerified mocks base method.
+func (m *MockmeshProvider) LastVerified() types.LayerID {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LastVerified")
+	ret0, _ := ret[0].(types.LayerID)
+	return ret0
+}
+
+// LastVerified indicates an expected call of LastVerified.
+func (mr *MockmeshProviderMockRecorder) LastVerified() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LastVerified", reflect.TypeOf((*MockmeshProvider)(nil).LastVerified))
 }
 
 // ProcessedLayer mocks base method.

--- a/fetch/wire_types.go
+++ b/fetch/wire_types.go
@@ -2,24 +2,58 @@ package fetch
 
 import (
 	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/log"
+	"github.com/spacemeshos/go-spacemesh/p2p"
 )
 
 //go:generate scalegen
 
 // LayerData is the data response for a given layer ID.
 type LayerData struct {
-	// Ballots are the ballots in layer
 	Ballots []types.BallotID
-	// Blocks are the blocks in a layer
-	Blocks []types.BlockID
-	// Hash is the hash of contextually valid blocks (sorted by block ID) in the given layer
-	Hash types.Hash32
-	// AggregatedHash is the aggregated hash of all layers up to the given layer
-	AggregatedHash types.Hash32
+	Blocks  []types.BlockID
 }
 
-// LayerOpinions is the response for opinions for a given layer.
-type LayerOpinions struct {
-	// Cert is the certificate for the layer.
-	Cert *types.Certificate
+// LayerOpinion is the response for opinion for a given layer.
+type LayerOpinion struct {
+	EpochWeight    uint64
+	AggregatedHash types.Hash32
+	Verified       types.LayerID
+	Valid, Invalid []types.BlockID
+	Cert           *types.Certificate
+
+	peer p2p.Peer
+}
+
+// SetPeer ...
+func (lo *LayerOpinion) SetPeer(p p2p.Peer) {
+	lo.peer = p
+}
+
+// Peer ...
+func (lo *LayerOpinion) Peer() p2p.Peer {
+	return lo.peer
+}
+
+// MarshalLogObject implements logging encoder for LayerOpinion.
+func (lo *LayerOpinion) MarshalLogObject(encoder log.ObjectEncoder) error {
+	encoder.AddString("peer", lo.peer.String())
+	encoder.AddUint64("epoch_weight", lo.EpochWeight)
+	encoder.AddUint32("verified", lo.Verified.Uint32())
+	if lo.Cert != nil {
+		encoder.AddString("cert_block_id", lo.Cert.BlockID.String())
+	}
+	encoder.AddArray("valid", log.ArrayMarshalerFunc(func(encoder log.ArrayEncoder) error {
+		for _, bid := range lo.Valid {
+			encoder.AppendString(bid.String())
+		}
+		return nil
+	}))
+	encoder.AddArray("invalid", log.ArrayMarshalerFunc(func(encoder log.ArrayEncoder) error {
+		for _, bid := range lo.Invalid {
+			encoder.AppendString(bid.String())
+		}
+		return nil
+	}))
+	return nil
 }

--- a/fetch/wire_types.go
+++ b/fetch/wire_types.go
@@ -17,7 +17,7 @@ type LayerData struct {
 // LayerOpinion is the response for opinion for a given layer.
 type LayerOpinion struct {
 	EpochWeight    uint64
-	AggregatedHash types.Hash32
+	PrevAggHash    types.Hash32
 	Verified       types.LayerID
 	Valid, Invalid []types.BlockID
 	Cert           *types.Certificate
@@ -40,6 +40,7 @@ func (lo *LayerOpinion) MarshalLogObject(encoder log.ObjectEncoder) error {
 	encoder.AddString("peer", lo.peer.String())
 	encoder.AddUint64("epoch_weight", lo.EpochWeight)
 	encoder.AddUint32("verified", lo.Verified.Uint32())
+	encoder.AddString("prev_hash", lo.PrevAggHash.String())
 	if lo.Cert != nil {
 		encoder.AddString("cert_block_id", lo.Cert.BlockID.String())
 	}

--- a/fetch/wire_types_scale.go
+++ b/fetch/wire_types_scale.go
@@ -55,7 +55,7 @@ func (t *LayerOpinion) EncodeScale(enc *scale.Encoder) (total int, err error) {
 		total += n
 	}
 	{
-		n, err := scale.EncodeByteArray(enc, t.AggregatedHash[:])
+		n, err := scale.EncodeByteArray(enc, t.PrevAggHash[:])
 		if err != nil {
 			return total, err
 		}
@@ -102,7 +102,7 @@ func (t *LayerOpinion) DecodeScale(dec *scale.Decoder) (total int, err error) {
 		t.EpochWeight = uint64(field)
 	}
 	{
-		n, err := scale.DecodeByteArray(dec, t.AggregatedHash[:])
+		n, err := scale.DecodeByteArray(dec, t.PrevAggHash[:])
 		if err != nil {
 			return total, err
 		}

--- a/fetch/wire_types_scale.go
+++ b/fetch/wire_types_scale.go
@@ -23,20 +23,6 @@ func (t *LayerData) EncodeScale(enc *scale.Encoder) (total int, err error) {
 		}
 		total += n
 	}
-	{
-		n, err := scale.EncodeByteArray(enc, t.Hash[:])
-		if err != nil {
-			return total, err
-		}
-		total += n
-	}
-	{
-		n, err := scale.EncodeByteArray(enc, t.AggregatedHash[:])
-		if err != nil {
-			return total, err
-		}
-		total += n
-	}
 	return total, nil
 }
 
@@ -57,24 +43,45 @@ func (t *LayerData) DecodeScale(dec *scale.Decoder) (total int, err error) {
 		total += n
 		t.Blocks = field
 	}
-	{
-		n, err := scale.DecodeByteArray(dec, t.Hash[:])
-		if err != nil {
-			return total, err
-		}
-		total += n
-	}
-	{
-		n, err := scale.DecodeByteArray(dec, t.AggregatedHash[:])
-		if err != nil {
-			return total, err
-		}
-		total += n
-	}
 	return total, nil
 }
 
-func (t *LayerOpinions) EncodeScale(enc *scale.Encoder) (total int, err error) {
+func (t *LayerOpinion) EncodeScale(enc *scale.Encoder) (total int, err error) {
+	{
+		n, err := scale.EncodeCompact64(enc, uint64(t.EpochWeight))
+		if err != nil {
+			return total, err
+		}
+		total += n
+	}
+	{
+		n, err := scale.EncodeByteArray(enc, t.AggregatedHash[:])
+		if err != nil {
+			return total, err
+		}
+		total += n
+	}
+	{
+		n, err := t.Verified.EncodeScale(enc)
+		if err != nil {
+			return total, err
+		}
+		total += n
+	}
+	{
+		n, err := scale.EncodeStructSlice(enc, t.Valid)
+		if err != nil {
+			return total, err
+		}
+		total += n
+	}
+	{
+		n, err := scale.EncodeStructSlice(enc, t.Invalid)
+		if err != nil {
+			return total, err
+		}
+		total += n
+	}
 	{
 		n, err := scale.EncodeOption(enc, t.Cert)
 		if err != nil {
@@ -85,7 +92,45 @@ func (t *LayerOpinions) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	return total, nil
 }
 
-func (t *LayerOpinions) DecodeScale(dec *scale.Decoder) (total int, err error) {
+func (t *LayerOpinion) DecodeScale(dec *scale.Decoder) (total int, err error) {
+	{
+		field, n, err := scale.DecodeCompact64(dec)
+		if err != nil {
+			return total, err
+		}
+		total += n
+		t.EpochWeight = uint64(field)
+	}
+	{
+		n, err := scale.DecodeByteArray(dec, t.AggregatedHash[:])
+		if err != nil {
+			return total, err
+		}
+		total += n
+	}
+	{
+		n, err := t.Verified.DecodeScale(dec)
+		if err != nil {
+			return total, err
+		}
+		total += n
+	}
+	{
+		field, n, err := scale.DecodeStructSlice[types.BlockID](dec)
+		if err != nil {
+			return total, err
+		}
+		total += n
+		t.Valid = field
+	}
+	{
+		field, n, err := scale.DecodeStructSlice[types.BlockID](dec)
+		if err != nil {
+			return total, err
+		}
+		total += n
+		t.Invalid = field
+	}
 	{
 		field, n, err := scale.DecodeOption[types.Certificate](dec)
 		if err != nil {

--- a/mesh/mesh.go
+++ b/mesh/mesh.go
@@ -729,3 +729,8 @@ func sortBlocks(blks []*types.Block) []*types.Block {
 	})
 	return blks
 }
+
+// LastVerified returns the latest layer verified by tortoise.
+func (msh *Mesh) LastVerified() types.LayerID {
+	return msh.trtl.LatestComplete()
+}

--- a/sql/blocks/blocks.go
+++ b/sql/blocks/blocks.go
@@ -178,3 +178,19 @@ func ContextualValidity(db sql.Executor, lid types.LayerID) ([]types.BlockContex
 	}
 	return rst, nil
 }
+
+// CountContextualValidity counts the number of blocks with contextual validity set in the layer.
+func CountContextualValidity(db sql.Executor, lid types.LayerID) (int, error) {
+	var count int
+	if _, err := db.Exec("select count(id) from blocks where layer = ?1 and validity in (?2, ?3);", func(stmt *sql.Statement) {
+		stmt.BindInt64(1, int64(lid.Uint32()))
+		stmt.BindInt64(2, valid)
+		stmt.BindInt64(3, invalid)
+	}, func(stmt *sql.Statement) bool {
+		count = stmt.ColumnInt(0)
+		return true
+	}); err != nil {
+		return 0, fmt.Errorf("count contextual validity in layer %s: %w", lid, err)
+	}
+	return count, nil
+}

--- a/sql/blocks/blocks_test.go
+++ b/sql/blocks/blocks_test.go
@@ -171,21 +171,33 @@ func TestContextualValidity(t *testing.T) {
 	for _, block := range blocks {
 		require.NoError(t, Add(db, block))
 	}
+	cnt, err := CountContextualValidity(db, lid)
+	require.NoError(t, err)
+	require.Zero(t, cnt)
+
 	validities, err := ContextualValidity(db, lid)
 	require.NoError(t, err)
 	require.Len(t, validities, 3)
+
 	for i, validity := range validities {
 		require.Equal(t, blocks[i].ID(), validity.ID)
 		require.False(t, validity.Validity)
 		require.NoError(t, SetValid(db, validity.ID))
 	}
+	cnt, err = CountContextualValidity(db, lid)
+	require.NoError(t, err)
+	require.Equal(t, 3, cnt)
 
 	validities, err = ContextualValidity(db, lid)
 	require.NoError(t, err)
 	require.Len(t, validities, 3)
 	for _, validity := range validities {
 		require.True(t, validity.Validity)
+		require.NoError(t, SetInvalid(db, validity.ID))
 	}
+	cnt, err = CountContextualValidity(db, lid)
+	require.NoError(t, err)
+	require.Equal(t, 3, cnt)
 }
 
 func TestGetLayer(t *testing.T) {

--- a/syncer/interface.go
+++ b/syncer/interface.go
@@ -14,15 +14,16 @@ type layerTicker interface {
 }
 
 type layerFetcher interface {
-	PollLayerData(context.Context, types.LayerID) chan fetch.LayerPromiseResult
-	PollLayerOpinions(context.Context, types.LayerID) chan fetch.LayerPromiseResult
+	PollLayerData(context.Context, types.LayerID) chan fetch.LayerPromiseData
+	PollLayerOpinions(context.Context, types.LayerID) chan fetch.LayerPromiseOpinions
 	GetEpochATXs(context.Context, types.EpochID) error
+	GetBlocks(context.Context, []types.BlockID) error
 }
 
 type layerPatrol interface {
 	IsHareInCharge(types.LayerID) bool
 }
 
-type layerProcessor interface {
-	ProcessLayer(context.Context, types.LayerID) error
+type certHandler interface {
+	HandleSyncedCertificate(context.Context, types.LayerID, *types.Certificate) error
 }

--- a/syncer/mocks/mocks.go
+++ b/syncer/mocks/mocks.go
@@ -73,6 +73,20 @@ func (m *MocklayerFetcher) EXPECT() *MocklayerFetcherMockRecorder {
 	return m.recorder
 }
 
+// GetBlocks mocks base method.
+func (m *MocklayerFetcher) GetBlocks(arg0 context.Context, arg1 []types.BlockID) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBlocks", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// GetBlocks indicates an expected call of GetBlocks.
+func (mr *MocklayerFetcherMockRecorder) GetBlocks(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlocks", reflect.TypeOf((*MocklayerFetcher)(nil).GetBlocks), arg0, arg1)
+}
+
 // GetEpochATXs mocks base method.
 func (m *MocklayerFetcher) GetEpochATXs(arg0 context.Context, arg1 types.EpochID) error {
 	m.ctrl.T.Helper()
@@ -88,10 +102,10 @@ func (mr *MocklayerFetcherMockRecorder) GetEpochATXs(arg0, arg1 interface{}) *go
 }
 
 // PollLayerData mocks base method.
-func (m *MocklayerFetcher) PollLayerData(arg0 context.Context, arg1 types.LayerID) chan fetch.LayerPromiseResult {
+func (m *MocklayerFetcher) PollLayerData(arg0 context.Context, arg1 types.LayerID) chan fetch.LayerPromiseData {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PollLayerData", arg0, arg1)
-	ret0, _ := ret[0].(chan fetch.LayerPromiseResult)
+	ret0, _ := ret[0].(chan fetch.LayerPromiseData)
 	return ret0
 }
 
@@ -102,10 +116,10 @@ func (mr *MocklayerFetcherMockRecorder) PollLayerData(arg0, arg1 interface{}) *g
 }
 
 // PollLayerOpinions mocks base method.
-func (m *MocklayerFetcher) PollLayerOpinions(arg0 context.Context, arg1 types.LayerID) chan fetch.LayerPromiseResult {
+func (m *MocklayerFetcher) PollLayerOpinions(arg0 context.Context, arg1 types.LayerID) chan fetch.LayerPromiseOpinions {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PollLayerOpinions", arg0, arg1)
-	ret0, _ := ret[0].(chan fetch.LayerPromiseResult)
+	ret0, _ := ret[0].(chan fetch.LayerPromiseOpinions)
 	return ret0
 }
 
@@ -152,39 +166,39 @@ func (mr *MocklayerPatrolMockRecorder) IsHareInCharge(arg0 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsHareInCharge", reflect.TypeOf((*MocklayerPatrol)(nil).IsHareInCharge), arg0)
 }
 
-// MocklayerProcessor is a mock of layerProcessor interface.
-type MocklayerProcessor struct {
+// MockcertHandler is a mock of certHandler interface.
+type MockcertHandler struct {
 	ctrl     *gomock.Controller
-	recorder *MocklayerProcessorMockRecorder
+	recorder *MockcertHandlerMockRecorder
 }
 
-// MocklayerProcessorMockRecorder is the mock recorder for MocklayerProcessor.
-type MocklayerProcessorMockRecorder struct {
-	mock *MocklayerProcessor
+// MockcertHandlerMockRecorder is the mock recorder for MockcertHandler.
+type MockcertHandlerMockRecorder struct {
+	mock *MockcertHandler
 }
 
-// NewMocklayerProcessor creates a new mock instance.
-func NewMocklayerProcessor(ctrl *gomock.Controller) *MocklayerProcessor {
-	mock := &MocklayerProcessor{ctrl: ctrl}
-	mock.recorder = &MocklayerProcessorMockRecorder{mock}
+// NewMockcertHandler creates a new mock instance.
+func NewMockcertHandler(ctrl *gomock.Controller) *MockcertHandler {
+	mock := &MockcertHandler{ctrl: ctrl}
+	mock.recorder = &MockcertHandlerMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MocklayerProcessor) EXPECT() *MocklayerProcessorMockRecorder {
+func (m *MockcertHandler) EXPECT() *MockcertHandlerMockRecorder {
 	return m.recorder
 }
 
-// ProcessLayer mocks base method.
-func (m *MocklayerProcessor) ProcessLayer(arg0 context.Context, arg1 types.LayerID) error {
+// HandleSyncedCertificate mocks base method.
+func (m *MockcertHandler) HandleSyncedCertificate(arg0 context.Context, arg1 types.LayerID, arg2 *types.Certificate) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ProcessLayer", arg0, arg1)
+	ret := m.ctrl.Call(m, "HandleSyncedCertificate", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// ProcessLayer indicates an expected call of ProcessLayer.
-func (mr *MocklayerProcessorMockRecorder) ProcessLayer(arg0, arg1 interface{}) *gomock.Call {
+// HandleSyncedCertificate indicates an expected call of HandleSyncedCertificate.
+func (mr *MockcertHandlerMockRecorder) HandleSyncedCertificate(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessLayer", reflect.TypeOf((*MocklayerProcessor)(nil).ProcessLayer), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleSyncedCertificate", reflect.TypeOf((*MockcertHandler)(nil).HandleSyncedCertificate), arg0, arg1, arg2)
 }

--- a/syncer/state_syncer.go
+++ b/syncer/state_syncer.go
@@ -141,13 +141,14 @@ func (s *Syncer) fetchLayerOpinions(ctx context.Context, lid types.LayerID) erro
 			return fmt.Errorf("PollLayerOpinions: %w", res.Err)
 		}
 		if len(res.Opinions) == 0 {
-			logger.Debug("no opinions available from peers")
+			logger.Warning("no opinions available from peers")
 			return errNoOpinionsAvailable
 		}
 
 		// TODO: check if the node agree with peers' aggregated hashes
 
 		if err := s.adopt(ctx, lid, res.Opinions); err != nil {
+			logger.With().Info("opinions not fully adopted", log.Err(err))
 			return err
 		}
 	case <-ctx.Done():

--- a/syncer/state_syncer.go
+++ b/syncer/state_syncer.go
@@ -1,0 +1,262 @@
+package syncer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/fetch"
+	"github.com/spacemeshos/go-spacemesh/log"
+	"github.com/spacemeshos/go-spacemesh/sql"
+	"github.com/spacemeshos/go-spacemesh/sql/blocks"
+	"github.com/spacemeshos/go-spacemesh/sql/layers"
+)
+
+var (
+	errNoOpinionsAvailable = errors.New("no layer opinions available from peers")
+	errNoOpinionsAdopted   = errors.New("no opinions are adopted from peers")
+	errCertificateMissing  = errors.New("certificates missing from all peers")
+)
+
+func minLayer(a, b types.LayerID) types.LayerID {
+	if a.Before(b) {
+		return a
+	}
+	return b
+}
+
+func (s *Syncer) stateSynced() bool {
+	current := s.ticker.GetCurrentLayer()
+	return current.Uint32() <= 1 || !s.mesh.ProcessedLayer().Before(current.Sub(1))
+}
+
+func (s *Syncer) processLayers(ctx context.Context) error {
+	ctx = log.WithNewSessionID(ctx)
+	if !s.ListenToATXGossip() {
+		return errATXsNotSynced
+	}
+
+	s.logger.WithContext(ctx).With().Info("processing synced layers",
+		log.Stringer("processed", s.mesh.ProcessedLayer()),
+		log.Stringer("in_state", s.mesh.LatestLayerInState()),
+		log.Stringer("last_synced", s.getLastSyncedLayer()))
+
+	start := minLayer(s.mesh.LatestLayerInState(), s.mesh.ProcessedLayer())
+	if !start.Before(s.getLastSyncedLayer()) {
+		return nil
+	}
+
+	for lid := start.Add(1); !lid.After(s.getLastSyncedLayer()); lid = lid.Add(1) {
+		if s.isClosed() {
+			return errShuttingDown
+		}
+
+		// layers should be processed in order. once we skip one layer, there is no point
+		// continuing with later layers. return on error
+		if _, err := s.beacon.GetBeacon(lid.GetEpoch()); err != nil {
+			s.logger.WithContext(ctx).With().Debug("beacon not available", lid)
+			return errBeaconNotAvailable
+		}
+
+		if s.patrol.IsHareInCharge(lid) {
+			lag := types.NewLayerID(0)
+			current := s.ticker.GetCurrentLayer()
+			if current.After(lid) {
+				lag = current.Sub(lid.Uint32())
+			}
+			if lag.Value < s.conf.HareDelayLayers {
+				s.logger.WithContext(ctx).With().Info("skip validating layer: hare still working", lid)
+				return errHareInCharge
+			}
+		}
+
+		_ = s.fetchLayerOpinions(ctx, lid)
+		// even if it fails to fetch opinions, we still go ahead to ProcessLayer so that the tortoise
+		// has a chance to count ballots and form its own opinions
+
+		if err := s.mesh.ProcessLayer(ctx, lid); err != nil {
+			s.logger.WithContext(ctx).With().Warning("mesh failed to process layer from sync", lid, log.Err(err))
+		}
+	}
+	s.logger.WithContext(ctx).With().Info("end of state sync",
+		log.Bool("state_synced", s.stateSynced()),
+		log.Stringer("last_synced", s.getLastSyncedLayer()),
+		log.Stringer("processed", s.mesh.ProcessedLayer()))
+	return nil
+}
+
+func sortOpinions(opinions []*fetch.LayerOpinion) {
+	sort.Slice(opinions, func(i, j int) bool {
+		io := opinions[i]
+		jo := opinions[j]
+		if io.EpochWeight != jo.EpochWeight {
+			return io.EpochWeight > jo.EpochWeight
+		}
+		if io.Verified != jo.Verified {
+			return io.Verified.After(jo.Verified)
+		}
+		if io.Cert != nil && jo.Cert != nil {
+			// TODO: maybe uses peer's p2p scores to break tie
+			return strings.Compare(io.Peer().String(), jo.Peer().String()) < 0
+		}
+		return io.Cert != nil
+	})
+}
+
+func (s *Syncer) needCert(logger log.Log, lid types.LayerID) (bool, error) {
+	cutoff := s.certCutoffLayer()
+	if lid.Before(cutoff) {
+		return false, nil
+	}
+	cert, err := layers.GetCert(s.db, lid)
+	if err != nil && !errors.Is(err, sql.ErrNotFound) {
+		logger.With().Error("state sync failed to get cert", log.Err(err))
+		return false, err
+	}
+	return cert == nil, nil
+}
+
+func (s *Syncer) needValidity(logger log.Log, lid types.LayerID) (bool, error) {
+	count, err := blocks.CountContextualValidity(s.db, lid)
+	if err != nil {
+		logger.With().Error("state sync failed to get validity", log.Err(err))
+		return false, err
+	}
+	return count == 0, nil
+}
+
+func (s *Syncer) fetchLayerOpinions(ctx context.Context, lid types.LayerID) error {
+	logger := s.logger.WithContext(ctx).WithFields(lid)
+	logger.Info("polling layer opinions")
+	ch := s.fetcher.PollLayerOpinions(ctx, lid)
+	select {
+	case res := <-ch:
+		if res.Err != nil {
+			return fmt.Errorf("PollLayerOpinions: %w", res.Err)
+		}
+		if len(res.Opinions) == 0 {
+			logger.Debug("no opinions available from peers")
+			return errNoOpinionsAvailable
+		}
+
+		// TODO: check if the node agree with peers' aggregated hashes
+
+		if err := s.adopt(ctx, lid, res.Opinions); err != nil {
+			return err
+		}
+	case <-ctx.Done():
+	}
+	return nil
+}
+
+func (s *Syncer) adopt(ctx context.Context, lid types.LayerID, opinions []*fetch.LayerOpinion) error {
+	logger := s.logger.WithContext(ctx).WithFields(lid)
+	latestVerified := s.mesh.LastVerified()
+	if !latestVerified.Before(lid) {
+		logger.With().Debug("opinions older than own verified layer")
+		return nil
+	}
+
+	sortOpinions(opinions)
+
+	needCert, err := s.needCert(logger, lid)
+	if err != nil {
+		return err
+	}
+	needValidity, err := s.needValidity(logger, lid)
+	if err != nil {
+		return err
+	}
+	if !needCert && !needValidity {
+		logger.With().Debug("node already has local opinions")
+		return nil
+	}
+
+	numCert := 0
+	for _, opn := range opinions {
+		if !opn.Verified.After(latestVerified) {
+			logger.With().Debug("node has same/higher verified layer than peers",
+				log.Stringer("verified", latestVerified),
+				log.Stringer("peers_verified", opn.Verified))
+			continue
+		}
+
+		if opn.Cert != nil {
+			numCert++
+		}
+
+		// TODO: detect multiple hare certificate in the same network
+		// https://github.com/spacemeshos/go-spacemesh/issues/3467
+		if needCert {
+			if opn.Cert == nil {
+				logger.With().Debug("peer has no cert", log.Inline(opn))
+			} else if err := s.adoptCert(ctx, lid, opn); err != nil {
+				logger.With().Warning("failed to adopt cert", log.Inline(opn), log.Err(err))
+			} else {
+				logger.With().Info("adopted cert from peer", log.Inline(opn))
+				needCert = false
+			}
+		}
+		if needValidity {
+			if len(opn.Valid) == 0 && len(opn.Invalid) == 0 {
+				logger.With().Debug("peer has no block validity", log.Inline(opn))
+			} else if err := s.adoptValidity(ctx, opn); err != nil {
+				logger.With().Warning("failed to adopt block validity", log.Inline(opn), log.Err(err))
+			} else {
+				logger.With().Info("adopted validity from peer", log.Inline(opn))
+				needValidity = false
+			}
+		}
+		if !needCert && !needValidity {
+			return nil
+		}
+	}
+	if needCert && numCert == 0 {
+		return errCertificateMissing
+	}
+	return errNoOpinionsAdopted
+}
+
+func (s *Syncer) certCutoffLayer() types.LayerID {
+	cutoff := types.GetEffectiveGenesis()
+	// TODO: change this to current layer after https://github.com/spacemeshos/go-spacemesh/issues/2921 is done
+	last := s.mesh.ProcessedLayer()
+	if last.Uint32() > s.conf.SyncCertDistance {
+		limit := last.Sub(s.conf.SyncCertDistance)
+		if limit.After(cutoff) {
+			cutoff = limit
+		}
+	}
+	return cutoff
+}
+
+func (s *Syncer) adoptCert(ctx context.Context, lid types.LayerID, opinion *fetch.LayerOpinion) error {
+	if err := s.certHandler.HandleSyncedCertificate(ctx, lid, opinion.Cert); err != nil {
+		return fmt.Errorf("state sync adopt cert: %w", err)
+	}
+	return nil
+}
+
+func (s *Syncer) adoptValidity(ctx context.Context, opinion *fetch.LayerOpinion) error {
+	all := opinion.Valid
+	all = append(all, opinion.Invalid...)
+	if len(all) > 0 {
+		if err := s.fetcher.GetBlocks(ctx, all); err != nil {
+			return fmt.Errorf("opinions get blocks: %w", err)
+		}
+	}
+	for _, bid := range opinion.Valid {
+		if err := blocks.SetValid(s.db, bid); err != nil {
+			return fmt.Errorf("opinions set valid: %w", err)
+		}
+	}
+	for _, bid := range opinion.Invalid {
+		if err := blocks.SetInvalid(s.db, bid); err != nil {
+			return fmt.Errorf("opinions set invalid: %w", err)
+		}
+	}
+	return nil
+}

--- a/syncer/state_syncer_test.go
+++ b/syncer/state_syncer_test.go
@@ -10,41 +10,50 @@ import (
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/fetch"
+	"github.com/spacemeshos/go-spacemesh/log/logtest"
 	"github.com/spacemeshos/go-spacemesh/sql"
 	"github.com/spacemeshos/go-spacemesh/sql/blocks"
 	"github.com/spacemeshos/go-spacemesh/sql/layers"
 )
 
-func opinions() []*fetch.LayerOpinion {
+func opinions(prevHash types.Hash32) []*fetch.LayerOpinion {
 	return []*fetch.LayerOpinion{
 		{
 			EpochWeight: 100,
 			Verified:    types.NewLayerID(17),
+			PrevAggHash: prevHash,
 			Cert: &types.Certificate{
 				BlockID: types.RandomBlockID(),
 			},
-			Valid: []types.BlockID{types.RandomBlockID()},
+			Valid:   []types.BlockID{types.RandomBlockID(), types.RandomBlockID()},
+			Invalid: []types.BlockID{types.RandomBlockID(), types.RandomBlockID()},
 		},
 		{
 			EpochWeight: 120,
 			Verified:    types.NewLayerID(16),
+			PrevAggHash: prevHash,
 			Cert: &types.Certificate{
 				BlockID: types.RandomBlockID(),
 			},
-			Valid: []types.BlockID{types.RandomBlockID()},
+			Valid:   []types.BlockID{types.RandomBlockID(), types.RandomBlockID()},
+			Invalid: []types.BlockID{types.RandomBlockID(), types.RandomBlockID()},
 		},
 		{
 			EpochWeight: 100,
 			Verified:    types.NewLayerID(18),
-			Valid:       []types.BlockID{types.RandomBlockID()},
+			PrevAggHash: prevHash,
+			Valid:       []types.BlockID{types.RandomBlockID(), types.RandomBlockID()},
+			Invalid:     []types.BlockID{types.RandomBlockID(), types.RandomBlockID()},
 		},
 		{
 			EpochWeight: 100,
 			Verified:    types.NewLayerID(18),
+			PrevAggHash: prevHash,
 			Cert: &types.Certificate{
 				BlockID: types.RandomBlockID(),
 			},
-			Valid: []types.BlockID{types.RandomBlockID()},
+			Valid:   []types.BlockID{types.RandomBlockID(), types.RandomBlockID()},
+			Invalid: []types.BlockID{types.RandomBlockID(), types.RandomBlockID()},
 		},
 	}
 }
@@ -74,99 +83,114 @@ func checkHasBlockValidity(t *testing.T, db sql.Executor, lid types.LayerID) {
 	require.Greater(t, cnt, 0)
 }
 
-func TestProcessLayers_AllGood(t *testing.T) {
-	ts := newSyncerWithoutSyncTimer(t)
-	ts.syncer.setATXSynced()
-	glayer := types.GetEffectiveGenesis()
-	current := glayer.Add(10)
-	ts.syncer.setLastSyncedLayer(current.Sub(1))
-	ts.mTicker.advanceToLayer(current)
-	layerOpns := make(map[types.LayerID][]*fetch.LayerOpinion)
-	for lid := glayer.Add(1); lid.Before(current); lid = lid.Add(1) {
-		lid := lid
-		layerOpns[lid] = opinions()
-		cert := layerOpns[lid][1].Cert
-		ts.mBeacon.EXPECT().GetBeacon(gomock.Any()).Return(types.RandomBeacon(), nil)
-		ts.mLyrPatrol.EXPECT().IsHareInCharge(lid).Return(false)
-		ts.mLyrFetcher.EXPECT().PollLayerOpinions(gomock.Any(), lid).Return(okOpnCh(lid, layerOpns[lid]))
-		ts.mTortoise.EXPECT().LatestComplete().Return(lid.Sub(1))
-		ts.mCertHdr.EXPECT().HandleSyncedCertificate(gomock.Any(), lid, cert).DoAndReturn(
-			func(_ context.Context, gotL types.LayerID, gotC *types.Certificate) error {
-				require.NoError(t, blocks.Add(ts.cdb, types.NewExistingBlock(gotC.BlockID, types.InnerBlock{LayerIndex: lid})))
-				require.NoError(t, layers.SetHareOutputWithCert(ts.cdb, gotL, gotC))
-				return nil
-			})
-		ts.mLyrFetcher.EXPECT().GetBlocks(gomock.Any(), layerOpns[lid][1].Valid).DoAndReturn(
-			func(_ context.Context, bids []types.BlockID) error {
-				for _, bid := range bids {
-					require.NoError(t, blocks.Add(ts.cdb, types.NewExistingBlock(bid, types.InnerBlock{LayerIndex: lid})))
-				}
-				return nil
-			})
-		ts.mTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), lid).Return(lid.Sub(1))
-		ts.mConState.EXPECT().ApplyLayer(gomock.Any(), gomock.Any()).DoAndReturn(
-			func(_ context.Context, got *types.Block) error {
-				require.Equal(t, cert.BlockID, got.ID())
-				return nil
-			})
-		ts.mConState.EXPECT().GetStateRoot().Return(types.Hash32{}, nil)
-	}
-	require.False(t, ts.syncer.stateSynced())
-	require.NoError(t, ts.syncer.processLayers(context.TODO()))
-	require.True(t, ts.syncer.stateSynced())
-	for lid := glayer.Add(1); lid.Before(current); lid = lid.Add(1) {
-		checkHasBlockValidity(t, ts.cdb, lid)
-	}
-}
-
-func TestProcessLayers_DespiteMissingCert(t *testing.T) {
-	ts := newSyncerWithoutSyncTimer(t)
-	ts.syncer.setATXSynced()
-	glayer := types.GetEffectiveGenesis()
-	current := glayer.Add(10)
-	ts.syncer.setLastSyncedLayer(current.Sub(1))
-	ts.mTicker.advanceToLayer(current)
-	layerOpns := make(map[types.LayerID][]*fetch.LayerOpinion)
-	for lid := glayer.Add(1); lid.Before(current); lid = lid.Add(1) {
-		lid := lid
-		layerOpns[lid] = []*fetch.LayerOpinion{
-			{
-				EpochWeight: 100,
-				Verified:    types.NewLayerID(19),
-				Valid:       []types.BlockID{types.RandomBlockID()},
-			},
-		}
-		ts.mBeacon.EXPECT().GetBeacon(gomock.Any()).Return(types.RandomBeacon(), nil)
-		ts.mLyrPatrol.EXPECT().IsHareInCharge(lid).Return(false)
-		ts.mLyrFetcher.EXPECT().PollLayerOpinions(gomock.Any(), lid).Return(okOpnCh(lid, layerOpns[lid]))
-		ts.mTortoise.EXPECT().LatestComplete().Return(lid.Sub(1))
-		ts.mLyrFetcher.EXPECT().GetBlocks(gomock.Any(), layerOpns[lid][0].Valid).DoAndReturn(
-			func(_ context.Context, bids []types.BlockID) error {
-				for _, bid := range bids {
-					require.NoError(t, blocks.Add(ts.cdb, types.NewExistingBlock(bid, types.InnerBlock{LayerIndex: lid})))
-				}
-				return nil
-			})
-		ts.mTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), lid).Return(glayer)
-	}
-	require.False(t, ts.syncer.stateSynced())
-	require.NoError(t, ts.syncer.processLayers(context.TODO()))
-	require.True(t, ts.syncer.stateSynced())
-	for lid := glayer.Add(1); lid.Before(current); lid = lid.Add(1) {
-		checkHasBlockValidity(t, ts.cdb, lid)
-	}
-}
-
-func TestProcessLayers_OpinionsNotNeeded(t *testing.T) {
+func TestProcessLayers_MultiLayers(t *testing.T) {
 	gLid := types.GetEffectiveGenesis()
 	tt := []struct {
 		name                             string
 		requested, verified, opnVerified types.LayerID
-		hasOpns                          bool
+		hasCert                          bool
+	}{
+		{
+			name:    "all good",
+			hasCert: true,
+		},
+		{
+			name: "cert missing",
+		},
+	}
+	for _, tc := range tt {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ts := newSyncerWithoutSyncTimer(t)
+			ts.syncer.setATXSynced()
+			current := gLid.Add(10)
+			ts.syncer.setLastSyncedLayer(current.Sub(1))
+			ts.mTicker.advanceToLayer(current)
+			layerOpns := make(map[types.LayerID][]*fetch.LayerOpinion)
+			adopted := make(map[types.LayerID]*fetch.LayerOpinion)
+			for lid := gLid.Add(1); lid.Before(current); lid = lid.Add(1) {
+				prevHash := types.RandomHash()
+				if lid.Sub(1) == gLid {
+					h, err := layers.GetAggregatedHash(ts.cdb, lid.Sub(1))
+					require.NoError(t, err)
+					prevHash = h
+				}
+				opns := opinions(prevHash)
+				if !tc.hasCert {
+					for _, opn := range opns {
+						opn.Cert = nil
+					}
+				}
+				layerOpns[lid] = opns
+				adopted[lid] = opns[1]
+			}
+			for lid := gLid.Add(1); lid.Before(current); lid = lid.Add(1) {
+				lid := lid
+				cert := layerOpns[lid][1].Cert
+				ts.mBeacon.EXPECT().GetBeacon(gomock.Any()).Return(types.RandomBeacon(), nil)
+				ts.mLyrPatrol.EXPECT().IsHareInCharge(lid).Return(false)
+				ts.mLyrFetcher.EXPECT().PollLayerOpinions(gomock.Any(), lid).DoAndReturn(
+					func(_ context.Context, lid types.LayerID) chan fetch.LayerPromiseOpinions {
+						// fake the prev agg hash from opinions
+						prevLid := lid.Sub(1)
+						if prevLid.After(gLid) {
+							require.NoError(t, layers.SetHashes(ts.cdb, prevLid, types.RandomHash(), adopted[lid].PrevAggHash))
+						}
+						return okOpnCh(lid, layerOpns[lid])
+					})
+				ts.mTortoise.EXPECT().LatestComplete().Return(lid.Sub(1))
+				if tc.hasCert {
+					ts.mCertHdr.EXPECT().HandleSyncedCertificate(gomock.Any(), lid, cert).DoAndReturn(
+						func(_ context.Context, gotL types.LayerID, gotC *types.Certificate) error {
+							require.NoError(t, blocks.Add(ts.cdb, types.NewExistingBlock(gotC.BlockID, types.InnerBlock{LayerIndex: lid})))
+							require.NoError(t, layers.SetHareOutputWithCert(ts.cdb, gotL, gotC))
+							return nil
+						})
+				}
+				ts.mLyrFetcher.EXPECT().GetBlocks(gomock.Any(), gomock.Any()).DoAndReturn(
+					func(_ context.Context, got []types.BlockID) error {
+						require.ElementsMatch(t, append(adopted[lid].Valid, adopted[lid].Invalid...), got)
+						for _, bid := range got {
+							require.NoError(t, blocks.Add(ts.cdb, types.NewExistingBlock(bid, types.InnerBlock{LayerIndex: lid})))
+						}
+						return nil
+					})
+				ts.mTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), lid).Return(lid.Sub(1))
+				if tc.hasCert || lid != current.Sub(1) {
+					ts.mConState.EXPECT().ApplyLayer(gomock.Any(), gomock.Any()).DoAndReturn(
+						func(_ context.Context, got *types.Block) error {
+							if tc.hasCert {
+								require.Equal(t, cert.BlockID, got.ID())
+							} else {
+								types.SortBlockIDs(adopted[lid].Valid)
+								require.Equal(t, adopted[lid].Valid[0], got.ID())
+							}
+							return nil
+						})
+					ts.mConState.EXPECT().GetStateRoot().Return(types.Hash32{}, nil)
+				}
+			}
+			require.False(t, ts.syncer.stateSynced())
+			require.NoError(t, ts.syncer.processLayers(context.TODO()))
+			require.True(t, ts.syncer.stateSynced())
+			for lid := gLid.Add(1); lid.Before(current); lid = lid.Add(1) {
+				checkHasBlockValidity(t, ts.cdb, lid)
+			}
+		})
+	}
+}
+
+func TestProcessLayers_OpinionsNotAdopted(t *testing.T) {
+	gLid := types.GetEffectiveGenesis()
+	tt := []struct {
+		name                             string
+		requested, verified, opnVerified types.LayerID
+		localOpn                         types.BlockID
 	}{
 		{
 			name:        "node already has opinions",
-			hasOpns:     true,
+			localOpn:    types.RandomBlockID(),
 			requested:   gLid.Add(1),
 			verified:    gLid,
 			opnVerified: gLid.Add(10),
@@ -183,6 +207,12 @@ func TestProcessLayers_OpinionsNotNeeded(t *testing.T) {
 			verified:    gLid.Add(1),
 			opnVerified: gLid.Add(10),
 		},
+		{
+			name:        "different prev hash",
+			requested:   gLid.Add(1),
+			verified:    gLid,
+			opnVerified: gLid.Add(10),
+		},
 	}
 	for _, tc := range tt {
 		tc := tc
@@ -195,23 +225,23 @@ func TestProcessLayers_OpinionsNotNeeded(t *testing.T) {
 			ts.mTicker.advanceToLayer(current)
 
 			// saves opinions
-			if tc.hasOpns {
-				bid := types.RandomBlockID()
-				require.NoError(t, blocks.Add(ts.cdb, types.NewExistingBlock(bid, types.InnerBlock{LayerIndex: tc.requested})))
-				require.NoError(t, layers.SetHareOutputWithCert(ts.cdb, tc.requested, &types.Certificate{BlockID: bid}))
-				require.NoError(t, blocks.SetValid(ts.cdb, bid))
+			if tc.localOpn != types.EmptyBlockID {
+				require.NoError(t, blocks.Add(ts.cdb, types.NewExistingBlock(tc.localOpn, types.InnerBlock{LayerIndex: tc.requested})))
+				require.NoError(t, layers.SetHareOutputWithCert(ts.cdb, tc.requested, &types.Certificate{BlockID: tc.localOpn}))
+				require.NoError(t, blocks.SetValid(ts.cdb, tc.localOpn))
 				ts.mConState.EXPECT().ApplyLayer(gomock.Any(), gomock.Any()).DoAndReturn(
 					func(_ context.Context, got *types.Block) error {
-						require.Equal(t, bid, got.ID())
+						require.Equal(t, tc.localOpn, got.ID())
 						return nil
 					})
 				ts.mConState.EXPECT().GetStateRoot().Return(types.Hash32{}, nil)
 			}
 			ts.mBeacon.EXPECT().GetBeacon(gomock.Any()).Return(types.RandomBeacon(), nil)
 			ts.mLyrPatrol.EXPECT().IsHareInCharge(tc.requested).Return(false)
-			opns := opinions()
+			opns := opinions(types.Hash32{})
 			for _, opn := range opns {
 				opn.Verified = tc.opnVerified
+				opn.Cert = nil
 			}
 			ts.mLyrFetcher.EXPECT().PollLayerOpinions(gomock.Any(), tc.requested).Return(okOpnCh(tc.requested, opns))
 			ts.mTortoise.EXPECT().LatestComplete().Return(tc.verified)
@@ -220,6 +250,20 @@ func TestProcessLayers_OpinionsNotNeeded(t *testing.T) {
 			require.False(t, ts.syncer.stateSynced())
 			require.NoError(t, ts.syncer.processLayers(context.TODO()))
 			require.True(t, ts.syncer.stateSynced())
+			if tc.localOpn == types.EmptyBlockID {
+				need, err := ts.syncer.needCert(logtest.New(t), tc.requested)
+				require.NoError(t, err)
+				require.True(t, need)
+				need, err = ts.syncer.needValidity(logtest.New(t), tc.requested)
+				require.NoError(t, err)
+				require.True(t, need)
+			} else {
+				bv, err := blocks.ContextualValidity(ts.cdb, tc.requested)
+				require.NoError(t, err)
+				require.Len(t, bv, 1)
+				require.Equal(t, tc.localOpn, bv[0].ID)
+				require.True(t, bv[0].Validity)
+			}
 		})
 	}
 }
@@ -321,7 +365,7 @@ func TestProcessLayers_OpinionsOptional(t *testing.T) {
 }
 
 func TestSortOpinions(t *testing.T) {
-	sorted := opinions()
+	sorted := opinions(types.Hash32{})
 	unsorted := make([]*fetch.LayerOpinion, len(sorted))
 	copy(unsorted, sorted)
 	sortOpinions(sorted)
@@ -329,4 +373,123 @@ func TestSortOpinions(t *testing.T) {
 	require.Equal(t, unsorted[3], sorted[1])
 	require.Equal(t, unsorted[2], sorted[2])
 	require.Equal(t, unsorted[0], sorted[3])
+}
+
+func TestAdopt(t *testing.T) {
+	gLid := types.GetEffectiveGenesis()
+	prevHash := types.RandomHash()
+	tt := []struct {
+		name                   string
+		opns                   []*fetch.LayerOpinion
+		exp                    int
+		err, certErr, fetchErr error
+	}{
+		{
+			name: "all good",
+			exp:  1,
+			opns: opinions(prevHash),
+		},
+		{
+			name: "no better opinions",
+			err:  errNoBetterOpinions,
+			opns: []*fetch.LayerOpinion{
+				{Verified: gLid},
+				{Verified: gLid},
+				{Verified: gLid},
+			},
+		},
+		{
+			name: "cert missing from all",
+			err:  errMissingCertificate,
+			opns: []*fetch.LayerOpinion{
+				{Verified: types.NewLayerID(11)},
+				{Verified: types.NewLayerID(11)},
+				{Verified: types.NewLayerID(11)},
+			},
+		},
+		{
+			name: "cert not adopted",
+			opns: []*fetch.LayerOpinion{
+				{Verified: types.NewLayerID(11), Cert: &types.Certificate{BlockID: types.RandomBlockID()}},
+				{Verified: types.NewLayerID(11)},
+				{Verified: types.NewLayerID(11)},
+			},
+			certErr: errors.New("meh"),
+			err:     errNoCertAdopted,
+		},
+		{
+			name: "validity missing from all",
+			opns: []*fetch.LayerOpinion{
+				{Verified: types.NewLayerID(11), Cert: &types.Certificate{BlockID: types.RandomBlockID()}},
+				{Verified: types.NewLayerID(11), Cert: &types.Certificate{BlockID: types.RandomBlockID()}},
+				{Verified: types.NewLayerID(11), Cert: &types.Certificate{BlockID: types.RandomBlockID()}},
+			},
+			err: errMissingValidity,
+		},
+		{
+			name:     "blocks missing",
+			exp:      1,
+			opns:     opinions(prevHash),
+			fetchErr: errors.New("meh"),
+			err:      errNoValidityAdopted,
+		},
+		{
+			name: "no matching prev hash",
+			exp:  1,
+			opns: opinions(types.RandomHash()),
+			err:  errNoValidityAdopted,
+		},
+	}
+	for _, tc := range tt {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ts := newSyncerWithoutSyncTimer(t)
+
+			require.NoError(t, layers.SetHashes(ts.cdb, gLid, types.RandomHash(), prevHash))
+			lid := gLid.Add(1)
+			cnt, err := blocks.CountContextualValidity(ts.cdb, lid)
+			require.NoError(t, err)
+			require.Zero(t, cnt)
+
+			ts.mTortoise.EXPECT().LatestComplete().Return(gLid)
+			adopted := tc.opns[tc.exp]
+			ts.mCertHdr.EXPECT().HandleSyncedCertificate(gomock.Any(), lid, adopted.Cert).Return(tc.certErr).MaxTimes(1)
+			if tc.err == nil {
+				ts.mLyrFetcher.EXPECT().GetBlocks(gomock.Any(), gomock.Any()).DoAndReturn(
+					func(_ context.Context, got []types.BlockID) error {
+						require.ElementsMatch(t, append(adopted.Valid, adopted.Invalid...), got)
+						for _, bid := range got {
+							require.NoError(t, blocks.Add(ts.cdb, types.NewExistingBlock(bid, types.InnerBlock{LayerIndex: lid})))
+						}
+						return nil
+					})
+			} else if tc.fetchErr != nil {
+				ts.mLyrFetcher.EXPECT().GetBlocks(gomock.Any(), gomock.Any()).Return(tc.fetchErr).Times(len(tc.opns))
+			}
+			require.ErrorIs(t, ts.syncer.adopt(context.TODO(), lid, tc.opns), tc.err)
+			if tc.err != nil {
+				need, err := ts.syncer.needCert(logtest.New(t), lid)
+				require.NoError(t, err)
+				require.True(t, need)
+				need, err = ts.syncer.needValidity(logtest.New(t), lid)
+				require.NoError(t, err)
+				require.True(t, need)
+			} else {
+				exp := make(map[types.BlockID]bool)
+				for _, bid := range adopted.Valid {
+					exp[bid] = true
+				}
+				for _, bid := range adopted.Invalid {
+					exp[bid] = false
+				}
+				bvs, err := blocks.ContextualValidity(ts.cdb, lid)
+				require.NoError(t, err)
+				require.Len(t, bvs, len(adopted.Valid)+len(adopted.Invalid))
+				for _, bv := range bvs {
+					require.Equal(t, exp[bv.ID], bv.Validity)
+				}
+			}
+		})
+	}
 }

--- a/syncer/state_syncer_test.go
+++ b/syncer/state_syncer_test.go
@@ -1,0 +1,332 @@
+package syncer
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/fetch"
+	"github.com/spacemeshos/go-spacemesh/sql"
+	"github.com/spacemeshos/go-spacemesh/sql/blocks"
+	"github.com/spacemeshos/go-spacemesh/sql/layers"
+)
+
+func opinions() []*fetch.LayerOpinion {
+	return []*fetch.LayerOpinion{
+		{
+			EpochWeight: 100,
+			Verified:    types.NewLayerID(17),
+			Cert: &types.Certificate{
+				BlockID: types.RandomBlockID(),
+			},
+			Valid: []types.BlockID{types.RandomBlockID()},
+		},
+		{
+			EpochWeight: 120,
+			Verified:    types.NewLayerID(16),
+			Cert: &types.Certificate{
+				BlockID: types.RandomBlockID(),
+			},
+			Valid: []types.BlockID{types.RandomBlockID()},
+		},
+		{
+			EpochWeight: 100,
+			Verified:    types.NewLayerID(18),
+			Valid:       []types.BlockID{types.RandomBlockID()},
+		},
+		{
+			EpochWeight: 100,
+			Verified:    types.NewLayerID(18),
+			Cert: &types.Certificate{
+				BlockID: types.RandomBlockID(),
+			},
+			Valid: []types.BlockID{types.RandomBlockID()},
+		},
+	}
+}
+
+func okOpnCh(lid types.LayerID, opinions []*fetch.LayerOpinion) chan fetch.LayerPromiseOpinions {
+	ch := make(chan fetch.LayerPromiseOpinions, 1)
+	ch <- fetch.LayerPromiseOpinions{
+		Layer:    lid,
+		Opinions: opinions,
+	}
+	close(ch)
+	return ch
+}
+
+func failedOpnCh() chan fetch.LayerPromiseOpinions {
+	ch := make(chan fetch.LayerPromiseOpinions, 1)
+	ch <- fetch.LayerPromiseOpinions{
+		Err: errors.New("something baaahhhhhhd"),
+	}
+	close(ch)
+	return ch
+}
+
+func checkHasBlockValidity(t *testing.T, db sql.Executor, lid types.LayerID) {
+	cnt, err := blocks.CountContextualValidity(db, lid)
+	require.NoError(t, err)
+	require.Greater(t, cnt, 0)
+}
+
+func TestProcessLayers_AllGood(t *testing.T) {
+	ts := newSyncerWithoutSyncTimer(t)
+	ts.syncer.setATXSynced()
+	glayer := types.GetEffectiveGenesis()
+	current := glayer.Add(10)
+	ts.syncer.setLastSyncedLayer(current.Sub(1))
+	ts.mTicker.advanceToLayer(current)
+	layerOpns := make(map[types.LayerID][]*fetch.LayerOpinion)
+	for lid := glayer.Add(1); lid.Before(current); lid = lid.Add(1) {
+		lid := lid
+		layerOpns[lid] = opinions()
+		cert := layerOpns[lid][1].Cert
+		ts.mBeacon.EXPECT().GetBeacon(gomock.Any()).Return(types.RandomBeacon(), nil)
+		ts.mLyrPatrol.EXPECT().IsHareInCharge(lid).Return(false)
+		ts.mLyrFetcher.EXPECT().PollLayerOpinions(gomock.Any(), lid).Return(okOpnCh(lid, layerOpns[lid]))
+		ts.mTortoise.EXPECT().LatestComplete().Return(lid.Sub(1))
+		ts.mCertHdr.EXPECT().HandleSyncedCertificate(gomock.Any(), lid, cert).DoAndReturn(
+			func(_ context.Context, gotL types.LayerID, gotC *types.Certificate) error {
+				require.NoError(t, blocks.Add(ts.cdb, types.NewExistingBlock(gotC.BlockID, types.InnerBlock{LayerIndex: lid})))
+				require.NoError(t, layers.SetHareOutputWithCert(ts.cdb, gotL, gotC))
+				return nil
+			})
+		ts.mLyrFetcher.EXPECT().GetBlocks(gomock.Any(), layerOpns[lid][1].Valid).DoAndReturn(
+			func(_ context.Context, bids []types.BlockID) error {
+				for _, bid := range bids {
+					require.NoError(t, blocks.Add(ts.cdb, types.NewExistingBlock(bid, types.InnerBlock{LayerIndex: lid})))
+				}
+				return nil
+			})
+		ts.mTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), lid).Return(lid.Sub(1))
+		ts.mConState.EXPECT().ApplyLayer(gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, got *types.Block) error {
+				require.Equal(t, cert.BlockID, got.ID())
+				return nil
+			})
+		ts.mConState.EXPECT().GetStateRoot().Return(types.Hash32{}, nil)
+	}
+	require.False(t, ts.syncer.stateSynced())
+	require.NoError(t, ts.syncer.processLayers(context.TODO()))
+	require.True(t, ts.syncer.stateSynced())
+	for lid := glayer.Add(1); lid.Before(current); lid = lid.Add(1) {
+		checkHasBlockValidity(t, ts.cdb, lid)
+	}
+}
+
+func TestProcessLayers_DespiteMissingCert(t *testing.T) {
+	ts := newSyncerWithoutSyncTimer(t)
+	ts.syncer.setATXSynced()
+	glayer := types.GetEffectiveGenesis()
+	current := glayer.Add(10)
+	ts.syncer.setLastSyncedLayer(current.Sub(1))
+	ts.mTicker.advanceToLayer(current)
+	layerOpns := make(map[types.LayerID][]*fetch.LayerOpinion)
+	for lid := glayer.Add(1); lid.Before(current); lid = lid.Add(1) {
+		lid := lid
+		layerOpns[lid] = []*fetch.LayerOpinion{
+			{
+				EpochWeight: 100,
+				Verified:    types.NewLayerID(19),
+				Valid:       []types.BlockID{types.RandomBlockID()},
+			},
+		}
+		ts.mBeacon.EXPECT().GetBeacon(gomock.Any()).Return(types.RandomBeacon(), nil)
+		ts.mLyrPatrol.EXPECT().IsHareInCharge(lid).Return(false)
+		ts.mLyrFetcher.EXPECT().PollLayerOpinions(gomock.Any(), lid).Return(okOpnCh(lid, layerOpns[lid]))
+		ts.mTortoise.EXPECT().LatestComplete().Return(lid.Sub(1))
+		ts.mLyrFetcher.EXPECT().GetBlocks(gomock.Any(), layerOpns[lid][0].Valid).DoAndReturn(
+			func(_ context.Context, bids []types.BlockID) error {
+				for _, bid := range bids {
+					require.NoError(t, blocks.Add(ts.cdb, types.NewExistingBlock(bid, types.InnerBlock{LayerIndex: lid})))
+				}
+				return nil
+			})
+		ts.mTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), lid).Return(glayer)
+	}
+	require.False(t, ts.syncer.stateSynced())
+	require.NoError(t, ts.syncer.processLayers(context.TODO()))
+	require.True(t, ts.syncer.stateSynced())
+	for lid := glayer.Add(1); lid.Before(current); lid = lid.Add(1) {
+		checkHasBlockValidity(t, ts.cdb, lid)
+	}
+}
+
+func TestProcessLayers_OpinionsNotNeeded(t *testing.T) {
+	gLid := types.GetEffectiveGenesis()
+	tt := []struct {
+		name                             string
+		requested, verified, opnVerified types.LayerID
+		hasOpns                          bool
+	}{
+		{
+			name:        "node already has opinions",
+			hasOpns:     true,
+			requested:   gLid.Add(1),
+			verified:    gLid,
+			opnVerified: gLid.Add(10),
+		},
+		{
+			name:        "no higher verified from peers",
+			requested:   gLid.Add(1),
+			verified:    gLid,
+			opnVerified: gLid,
+		},
+		{
+			name:        "node already verified",
+			requested:   gLid.Add(1),
+			verified:    gLid.Add(1),
+			opnVerified: gLid.Add(10),
+		},
+	}
+	for _, tc := range tt {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ts := newSyncerWithoutSyncTimer(t)
+			ts.syncer.setATXSynced()
+			current := tc.requested.Add(1)
+			ts.syncer.setLastSyncedLayer(current.Sub(1))
+			ts.mTicker.advanceToLayer(current)
+
+			// saves opinions
+			if tc.hasOpns {
+				bid := types.RandomBlockID()
+				require.NoError(t, blocks.Add(ts.cdb, types.NewExistingBlock(bid, types.InnerBlock{LayerIndex: tc.requested})))
+				require.NoError(t, layers.SetHareOutputWithCert(ts.cdb, tc.requested, &types.Certificate{BlockID: bid}))
+				require.NoError(t, blocks.SetValid(ts.cdb, bid))
+				ts.mConState.EXPECT().ApplyLayer(gomock.Any(), gomock.Any()).DoAndReturn(
+					func(_ context.Context, got *types.Block) error {
+						require.Equal(t, bid, got.ID())
+						return nil
+					})
+				ts.mConState.EXPECT().GetStateRoot().Return(types.Hash32{}, nil)
+			}
+			ts.mBeacon.EXPECT().GetBeacon(gomock.Any()).Return(types.RandomBeacon(), nil)
+			ts.mLyrPatrol.EXPECT().IsHareInCharge(tc.requested).Return(false)
+			opns := opinions()
+			for _, opn := range opns {
+				opn.Verified = tc.opnVerified
+			}
+			ts.mLyrFetcher.EXPECT().PollLayerOpinions(gomock.Any(), tc.requested).Return(okOpnCh(tc.requested, opns))
+			ts.mTortoise.EXPECT().LatestComplete().Return(tc.verified)
+			ts.mTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), tc.requested).Return(tc.requested.Sub(1))
+
+			require.False(t, ts.syncer.stateSynced())
+			require.NoError(t, ts.syncer.processLayers(context.TODO()))
+			require.True(t, ts.syncer.stateSynced())
+		})
+	}
+}
+
+func TestProcessLayers_BeaconNotAvailable(t *testing.T) {
+	ts := newSyncerWithoutSyncTimer(t)
+	ts.syncer.setATXSynced()
+	lastSynced := types.GetEffectiveGenesis().Add(1)
+	ts.syncer.setLastSyncedLayer(lastSynced)
+	ts.mTicker.advanceToLayer(lastSynced.Add(1))
+	ts.mBeacon.EXPECT().GetBeacon(gomock.Any()).Return(types.EmptyBeacon, errBeaconNotAvailable)
+	require.False(t, ts.syncer.stateSynced())
+	require.ErrorIs(t, ts.syncer.processLayers(context.TODO()), errBeaconNotAvailable)
+	require.False(t, ts.syncer.stateSynced())
+}
+
+func TestProcessLayers_ATXsNotSynced(t *testing.T) {
+	ts := newSyncerWithoutSyncTimer(t)
+	glayer := types.GetEffectiveGenesis()
+	current := glayer.Add(10)
+	ts.syncer.setLastSyncedLayer(current.Sub(1))
+	ts.mTicker.advanceToLayer(current)
+	require.False(t, ts.syncer.stateSynced())
+	require.ErrorIs(t, ts.syncer.processLayers(context.TODO()), errATXsNotSynced)
+	require.False(t, ts.syncer.stateSynced())
+}
+
+func TestProcessLayers_Shutdown(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.TODO())
+	ts := newTestSyncer(ctx, t, never)
+	ts.syncer.setATXSynced()
+
+	lastSynced := types.GetEffectiveGenesis().Add(1)
+	ts.syncer.setLastSyncedLayer(lastSynced)
+	ts.mTicker.advanceToLayer(lastSynced.Add(1))
+
+	cancel()
+	require.ErrorIs(t, ts.syncer.processLayers(context.TODO()), errShuttingDown)
+	require.False(t, ts.syncer.stateSynced())
+}
+
+func TestProcessLayers_HareIsStillWorking(t *testing.T) {
+	ts := newSyncerWithoutSyncTimer(t)
+	ts.syncer.setATXSynced()
+	lastSynced := types.GetEffectiveGenesis().Add(1)
+	ts.syncer.setLastSyncedLayer(lastSynced)
+	ts.mTicker.advanceToLayer(lastSynced.Add(1))
+
+	require.False(t, ts.syncer.stateSynced())
+	ts.mBeacon.EXPECT().GetBeacon(gomock.Any()).Return(types.RandomBeacon(), nil)
+	ts.mLyrPatrol.EXPECT().IsHareInCharge(lastSynced).Return(true)
+	require.ErrorIs(t, ts.syncer.processLayers(context.TODO()), errHareInCharge)
+	require.False(t, ts.syncer.stateSynced())
+
+	ts.mBeacon.EXPECT().GetBeacon(gomock.Any()).Return(types.RandomBeacon(), nil)
+	ts.mLyrPatrol.EXPECT().IsHareInCharge(lastSynced).Return(false)
+	ts.mLyrFetcher.EXPECT().PollLayerOpinions(gomock.Any(), lastSynced).Return(okOpnCh(lastSynced, nil))
+	ts.mTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), lastSynced).Return(lastSynced)
+	ts.mConState.EXPECT().GetStateRoot().Return(types.Hash32{}, nil)
+	require.NoError(t, ts.syncer.processLayers(context.TODO()))
+	require.True(t, ts.syncer.stateSynced())
+}
+
+func TestProcessLayers_HareTakesTooLong(t *testing.T) {
+	ts := newSyncerWithoutSyncTimer(t)
+	ts.syncer.setATXSynced()
+	glayer := types.GetEffectiveGenesis()
+	lastSynced := glayer.Add(ts.syncer.conf.HareDelayLayers)
+	ts.syncer.setLastSyncedLayer(lastSynced)
+	current := lastSynced.Add(1)
+	ts.mTicker.advanceToLayer(current)
+	for lid := glayer.Add(1); lid.Before(current); lid = lid.Add(1) {
+		ts.mBeacon.EXPECT().GetBeacon(gomock.Any()).Return(types.RandomBeacon(), nil)
+		if lid == glayer.Add(1) {
+			ts.mLyrPatrol.EXPECT().IsHareInCharge(lid).Return(true)
+		} else {
+			ts.mLyrPatrol.EXPECT().IsHareInCharge(lid).Return(false)
+		}
+		ts.mLyrFetcher.EXPECT().PollLayerOpinions(gomock.Any(), lid).Return(okOpnCh(lid, nil))
+		ts.mTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), lid).Return(glayer)
+	}
+	require.NoError(t, ts.syncer.processLayers(context.TODO()))
+	require.True(t, ts.syncer.stateSynced())
+}
+
+func TestProcessLayers_OpinionsOptional(t *testing.T) {
+	ts := newSyncerWithoutSyncTimer(t)
+	ts.syncer.setATXSynced()
+	lastSynced := types.GetEffectiveGenesis().Add(1)
+	ts.syncer.setLastSyncedLayer(lastSynced)
+	ts.mTicker.advanceToLayer(lastSynced.Add(1))
+	ts.mBeacon.EXPECT().GetBeacon(gomock.Any()).Return(types.RandomBeacon(), nil)
+	ts.mLyrPatrol.EXPECT().IsHareInCharge(lastSynced).Return(false)
+	ts.mLyrFetcher.EXPECT().PollLayerOpinions(gomock.Any(), lastSynced).Return(failedOpnCh())
+	ts.mTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), lastSynced).Return(types.GetEffectiveGenesis())
+	require.False(t, ts.syncer.stateSynced())
+	require.NoError(t, ts.syncer.processLayers(context.TODO()))
+	require.True(t, ts.syncer.stateSynced())
+}
+
+func TestSortOpinions(t *testing.T) {
+	sorted := opinions()
+	unsorted := make([]*fetch.LayerOpinion, len(sorted))
+	copy(unsorted, sorted)
+	sortOpinions(sorted)
+	require.Equal(t, unsorted[1], sorted[0])
+	require.Equal(t, unsorted[3], sorted[1])
+	require.Equal(t, unsorted[2], sorted[2])
+	require.Equal(t, unsorted[0], sorted[3])
+}

--- a/syncer/syncer_test.go
+++ b/syncer/syncer_test.go
@@ -3,6 +3,7 @@ package syncer
 import (
 	"context"
 	"errors"
+	"os"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -29,6 +30,13 @@ const (
 	never          = time.Second * 60 * 24
 )
 
+func TestMain(m *testing.M) {
+	types.SetLayersPerEpoch(layersPerEpoch)
+
+	res := m.Run()
+	os.Exit(res)
+}
+
 type mockLayerTicker struct {
 	current atomic.Value
 }
@@ -53,66 +61,57 @@ type testSyncer struct {
 	msh     *mesh.Mesh
 	mTicker *mockLayerTicker
 
-	mLyrFetcher   *mocks.MocklayerFetcher
-	mBeacon       *smocks.MockBeaconGetter
-	mLyrPatrol    *mocks.MocklayerPatrol
-	mLyrProcessor *mocks.MocklayerProcessor
-	mConState     *mmocks.MockconservativeState
-	mTortoise     *smocks.MockTortoise
+	mLyrFetcher *mocks.MocklayerFetcher
+	mBeacon     *smocks.MockBeaconGetter
+	mLyrPatrol  *mocks.MocklayerPatrol
+	mConState   *mmocks.MockconservativeState
+	mTortoise   *smocks.MockTortoise
+	mCertHdr    *mocks.MockcertHandler
 }
 
-func newTestSyncer(ctx context.Context, t *testing.T, interval time.Duration, defaultMocked bool) *testSyncer {
-	types.SetLayersPerEpoch(layersPerEpoch)
+func newTestSyncer(ctx context.Context, t *testing.T, interval time.Duration) *testSyncer {
 	lg := logtest.New(t)
 
 	mt := newMockLayerTicker()
-	cdb := datastore.NewCachedDB(sql.InMemory(), lg)
-
 	ctrl := gomock.NewController(t)
 	mcs := mmocks.NewMockconservativeState(ctrl)
 	mtrt := smocks.NewMockTortoise(ctrl)
 	mb := smocks.NewMockBeaconGetter(ctrl)
-	if defaultMocked {
-		mcs.EXPECT().GetStateRoot().AnyTimes()
-		mtrt.EXPECT().HandleIncomingLayer(gomock.Any(), gomock.Any()).DoAndReturn(
-			func(_ context.Context, lid types.LayerID) types.LayerID {
-				return lid.Sub(1)
-			}).AnyTimes()
-	}
+	cdb := datastore.NewCachedDB(sql.InMemory(), lg)
 	mm, err := mesh.NewMesh(cdb, mtrt, mcs, lg)
 	require.NoError(t, err)
 
 	mp := mocks.NewMocklayerPatrol(ctrl)
 	mf := mocks.NewMocklayerFetcher(ctrl)
-	mlp := mocks.NewMocklayerProcessor(ctrl)
 	cfg := Configuration{
 		SyncInterval:     interval,
 		SyncCertDistance: 4,
 		HareDelayLayers:  5,
 	}
+	mc := mocks.NewMockcertHandler(ctrl)
 	return &testSyncer{
-		syncer:        NewSyncer(ctx, cfg, mt, mb, mm, mf, mp, lg.WithName("test_sync")),
-		cdb:           cdb,
-		msh:           mm,
-		mTicker:       mt,
-		mLyrFetcher:   mf,
-		mBeacon:       mb,
-		mLyrPatrol:    mp,
-		mLyrProcessor: mlp,
-		mConState:     mcs,
-		mTortoise:     mtrt,
+		syncer:      NewSyncer(ctx, cfg, cdb.Database, mt, mb, mm, mf, mp, mc, lg.WithName("test_sync")),
+		cdb:         cdb,
+		msh:         mm,
+		mTicker:     mt,
+		mLyrFetcher: mf,
+		mBeacon:     mb,
+		mLyrPatrol:  mp,
+		mConState:   mcs,
+		mTortoise:   mtrt,
+		mCertHdr:    mc,
 	}
 }
 
-func okCh() chan fetch.LayerPromiseResult {
-	ch := make(chan fetch.LayerPromiseResult, 1)
+func okCh() chan fetch.LayerPromiseData {
+	ch := make(chan fetch.LayerPromiseData, 1)
 	close(ch)
 	return ch
 }
 
-func failedCh() chan fetch.LayerPromiseResult {
-	ch := make(chan fetch.LayerPromiseResult, 1)
-	ch <- fetch.LayerPromiseResult{
+func failedCh() chan fetch.LayerPromiseData {
+	ch := make(chan fetch.LayerPromiseData, 1)
+	ch <- fetch.LayerPromiseData{
 		Err: errors.New("something baaahhhhhhd"),
 	}
 	close(ch)
@@ -121,7 +120,7 @@ func failedCh() chan fetch.LayerPromiseResult {
 
 func newSyncerWithoutSyncTimer(t *testing.T) *testSyncer {
 	ctx := context.TODO()
-	ts := newTestSyncer(ctx, t, never, true)
+	ts := newTestSyncer(ctx, t, never)
 	ts.syncer.syncTimer.Stop()
 	ts.syncer.validateTimer.Stop()
 	return ts
@@ -129,7 +128,7 @@ func newSyncerWithoutSyncTimer(t *testing.T) *testSyncer {
 
 func TestStartAndShutdown(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.TODO())
-	ts := newTestSyncer(ctx, t, time.Millisecond*5, true)
+	ts := newTestSyncer(ctx, t, time.Millisecond*5)
 
 	syncedCh := make(chan struct{})
 	ts.syncer.RegisterChForSynced(context.TODO(), syncedCh)
@@ -158,15 +157,14 @@ func TestSynchronize_OnlyOneSynchronize(t *testing.T) {
 	ts.syncer.Start(context.TODO())
 
 	ts.mLyrFetcher.EXPECT().GetEpochATXs(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
-	ts.mLyrFetcher.EXPECT().PollLayerOpinions(gomock.Any(), gomock.Any()).Return(failedCh()).AnyTimes()
 	gLayer := types.GetEffectiveGenesis()
 
-	ch := make(chan fetch.LayerPromiseResult)
+	ch := make(chan fetch.LayerPromiseData)
 	started := make(chan struct{}, 1)
 	for lid := gLayer.Add(1); lid.Before(current); lid = lid.Add(1) {
 		if lid == gLayer.Add(1) {
 			ts.mLyrFetcher.EXPECT().PollLayerData(gomock.Any(), lid).DoAndReturn(
-				func(context.Context, types.LayerID) chan fetch.LayerPromiseResult {
+				func(context.Context, types.LayerID) chan fetch.LayerPromiseData {
 					close(started)
 					return ch
 				},
@@ -196,7 +194,6 @@ func TestSynchronize_AllGood(t *testing.T) {
 	gLayer := types.GetEffectiveGenesis()
 	current := gLayer.Add(10)
 	ts.mTicker.advanceToLayer(current)
-	ts.mLyrFetcher.EXPECT().PollLayerOpinions(gomock.Any(), gomock.Any()).Return(failedCh()).AnyTimes()
 	for epoch := gLayer.GetEpoch(); epoch <= current.GetEpoch(); epoch++ {
 		ts.mLyrFetcher.EXPECT().GetEpochATXs(gomock.Any(), epoch).Return(nil)
 	}
@@ -218,7 +215,6 @@ func TestSynchronize_FetchLayerDataFailed(t *testing.T) {
 	gLayer := types.GetEffectiveGenesis()
 	current := gLayer.Add(2)
 	ts.mTicker.advanceToLayer(current)
-	ts.mLyrFetcher.EXPECT().PollLayerOpinions(gomock.Any(), gomock.Any()).Return(failedCh()).AnyTimes()
 	lyr := current.Sub(1)
 	ts.mLyrFetcher.EXPECT().GetEpochATXs(gomock.Any(), gLayer.GetEpoch()).Return(nil)
 	ts.mLyrFetcher.EXPECT().GetEpochATXs(gomock.Any(), current.GetEpoch()).Return(nil)
@@ -258,7 +254,6 @@ func startWithSyncedState(t *testing.T, ts *testSyncer) types.LayerID {
 	gLayer := types.GetEffectiveGenesis()
 	ts.mTicker.advanceToLayer(gLayer)
 	ts.mLyrFetcher.EXPECT().GetEpochATXs(gomock.Any(), gLayer.GetEpoch()).Return(nil)
-	ts.mLyrFetcher.EXPECT().PollLayerOpinions(gomock.Any(), gomock.Any()).Return(failedCh()).AnyTimes()
 	require.True(t, ts.syncer.synchronize(context.TODO()))
 	require.True(t, ts.syncer.ListenToATXGossip())
 	require.True(t, ts.syncer.ListenToGossip())
@@ -268,7 +263,7 @@ func startWithSyncedState(t *testing.T, ts *testSyncer) types.LayerID {
 	ts.mTicker.advanceToLayer(current)
 	lyr := current.Sub(1)
 	ts.mLyrFetcher.EXPECT().PollLayerData(gomock.Any(), lyr).DoAndReturn(
-		func(_ context.Context, got types.LayerID) chan fetch.LayerPromiseResult {
+		func(_ context.Context, got types.LayerID) chan fetch.LayerPromiseData {
 			require.NoError(t, ts.msh.SetZeroBlockLayer(context.TODO(), got))
 			return okCh()
 		})
@@ -328,7 +323,6 @@ func TestFromNotSyncedToSynced(t *testing.T) {
 	lyr := types.GetEffectiveGenesis().Add(1)
 	current := lyr.Add(5)
 	ts.mTicker.advanceToLayer(current)
-	ts.mLyrFetcher.EXPECT().PollLayerOpinions(gomock.Any(), gomock.Any()).Return(failedCh()).AnyTimes()
 	ts.mLyrFetcher.EXPECT().PollLayerData(gomock.Any(), lyr).Return(failedCh())
 
 	require.False(t, ts.syncer.synchronize(context.TODO()))
@@ -339,7 +333,7 @@ func TestFromNotSyncedToSynced(t *testing.T) {
 
 	for lid := lyr; lid.Before(current); lid = lid.Add(1) {
 		ts.mLyrFetcher.EXPECT().PollLayerData(gomock.Any(), lid).DoAndReturn(
-			func(_ context.Context, got types.LayerID) chan fetch.LayerPromiseResult {
+			func(_ context.Context, got types.LayerID) chan fetch.LayerPromiseData {
 				require.NoError(t, ts.msh.SetZeroBlockLayer(context.TODO(), got))
 				return okCh()
 			})
@@ -362,9 +356,8 @@ func TestFromGossipSyncToNotSynced(t *testing.T) {
 	lyr := types.GetEffectiveGenesis().Add(1)
 	current := lyr.Add(1)
 	ts.mTicker.advanceToLayer(current)
-	ts.mLyrFetcher.EXPECT().PollLayerOpinions(gomock.Any(), gomock.Any()).Return(failedCh()).AnyTimes()
 	ts.mLyrFetcher.EXPECT().PollLayerData(gomock.Any(), lyr).DoAndReturn(
-		func(_ context.Context, got types.LayerID) chan fetch.LayerPromiseResult {
+		func(_ context.Context, got types.LayerID) chan fetch.LayerPromiseData {
 			require.NoError(t, ts.msh.SetZeroBlockLayer(context.TODO(), got))
 			return okCh()
 		})
@@ -388,7 +381,7 @@ func TestFromGossipSyncToNotSynced(t *testing.T) {
 
 	for lid := lyr; lid.Before(current); lid = lid.Add(1) {
 		ts.mLyrFetcher.EXPECT().PollLayerData(gomock.Any(), lid).DoAndReturn(
-			func(_ context.Context, got types.LayerID) chan fetch.LayerPromiseResult {
+			func(_ context.Context, got types.LayerID) chan fetch.LayerPromiseData {
 				require.NoError(t, ts.msh.SetZeroBlockLayer(context.TODO(), got))
 				return okCh()
 			})
@@ -408,7 +401,6 @@ func TestFromGossipSyncToNotSynced(t *testing.T) {
 func TestFromSyncedToNotSynced(t *testing.T) {
 	ts := newSyncerWithoutSyncTimer(t)
 	ts.mLyrFetcher.EXPECT().GetEpochATXs(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
-	ts.mLyrFetcher.EXPECT().PollLayerOpinions(gomock.Any(), gomock.Any()).Return(failedCh()).AnyTimes()
 	syncedCh := make(chan struct{})
 	ts.syncer.RegisterChForSynced(context.TODO(), syncedCh)
 
@@ -430,7 +422,7 @@ func TestFromSyncedToNotSynced(t *testing.T) {
 
 	for lid := lyr; lid.Before(current); lid = lid.Add(1) {
 		ts.mLyrFetcher.EXPECT().PollLayerData(gomock.Any(), lid).DoAndReturn(
-			func(_ context.Context, got types.LayerID) chan fetch.LayerPromiseResult {
+			func(_ context.Context, got types.LayerID) chan fetch.LayerPromiseData {
 				require.NoError(t, ts.msh.SetZeroBlockLayer(context.TODO(), got))
 				return okCh()
 			})
@@ -458,7 +450,7 @@ func waitOutGossipSync(t *testing.T, current types.LayerID, ts *testSyncer) {
 	current = current.Add(1)
 	ts.mTicker.advanceToLayer(current)
 	ts.mLyrFetcher.EXPECT().PollLayerData(gomock.Any(), lyr).DoAndReturn(
-		func(_ context.Context, got types.LayerID) chan fetch.LayerPromiseResult {
+		func(_ context.Context, got types.LayerID) chan fetch.LayerPromiseData {
 			require.NoError(t, ts.msh.SetZeroBlockLayer(context.TODO(), got))
 			return okCh()
 		})
@@ -474,7 +466,7 @@ func waitOutGossipSync(t *testing.T, current types.LayerID, ts *testSyncer) {
 	current = current.Add(1)
 	ts.mTicker.advanceToLayer(current)
 	ts.mLyrFetcher.EXPECT().PollLayerData(gomock.Any(), lyr).DoAndReturn(
-		func(_ context.Context, got types.LayerID) chan fetch.LayerPromiseResult {
+		func(_ context.Context, got types.LayerID) chan fetch.LayerPromiseData {
 			require.NoError(t, ts.msh.SetZeroBlockLayer(context.TODO(), got))
 			return okCh()
 		})
@@ -487,14 +479,13 @@ func waitOutGossipSync(t *testing.T, current types.LayerID, ts *testSyncer) {
 }
 
 func TestSyncMissingLayer(t *testing.T) {
-	ts := newTestSyncer(context.TODO(), t, never, false)
+	ts := newTestSyncer(context.TODO(), t, never)
 	genesis := types.GetEffectiveGenesis()
 	failed := genesis.Add(2)
 	last := genesis.Add(4)
 	ts.mTicker.advanceToLayer(last)
 
 	ts.mLyrFetcher.EXPECT().GetEpochATXs(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
-	ts.mLyrFetcher.EXPECT().PollLayerOpinions(gomock.Any(), gomock.Any()).Return(okCh()).AnyTimes()
 	ts.mConState.EXPECT().GetStateRoot().AnyTimes()
 	ts.mLyrPatrol.EXPECT().IsHareInCharge(gomock.Any()).Return(false).AnyTimes()
 	ts.mBeacon.EXPECT().GetBeacon(gomock.Any()).Return(types.RandomBeacon(), nil).AnyTimes()
@@ -513,6 +504,7 @@ func TestSyncMissingLayer(t *testing.T) {
 
 	for lid := genesis.Add(1); lid.Before(last); lid = lid.Add(1) {
 		ts.mLyrFetcher.EXPECT().PollLayerData(gomock.Any(), lid).Return(okCh())
+		ts.mLyrFetcher.EXPECT().PollLayerOpinions(gomock.Any(), lid).Return(okOpnCh(lid, nil))
 		ts.mTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), lid).Return(lid.Sub(1))
 		if lid.Before(failed) {
 			require.NoError(t, ts.msh.SetZeroBlockLayer(context.TODO(), lid))
@@ -539,6 +531,7 @@ func TestSyncMissingLayer(t *testing.T) {
 	require.True(t, ts.syncer.synchronize(context.TODO()))
 
 	for lid := failed; lid.Before(last); lid = lid.Add(1) {
+		ts.mLyrFetcher.EXPECT().PollLayerOpinions(gomock.Any(), lid).Return(okOpnCh(lid, nil))
 		ts.mTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), lid).Return(lid.Sub(1))
 		if lid == failed {
 			ts.mConState.EXPECT().ApplyLayer(gomock.Any(), block).DoAndReturn(
@@ -559,12 +552,13 @@ func TestSyncMissingLayer(t *testing.T) {
 func TestSync_AlsoSyncProcessedLayer(t *testing.T) {
 	ts := newSyncerWithoutSyncTimer(t)
 	ts.mLyrFetcher.EXPECT().GetEpochATXs(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
-	ts.mLyrFetcher.EXPECT().PollLayerOpinions(gomock.Any(), gomock.Any()).Return(okCh()).AnyTimes()
 	lyr := types.GetEffectiveGenesis().Add(1)
 	current := lyr.Add(1)
 	ts.mTicker.advanceToLayer(current)
 
 	// simulate hare advancing the mesh forward
+	ts.mTortoise.EXPECT().HandleIncomingLayer(gomock.Any(), lyr).Return(lyr.Sub(1))
+	ts.mConState.EXPECT().GetStateRoot().Return(types.Hash32{}, nil)
 	ts.mTortoise.EXPECT().OnHareOutput(lyr, types.EmptyBlockID)
 	require.NoError(t, ts.msh.ProcessLayerPerHareOutput(context.TODO(), lyr, types.EmptyBlockID))
 	require.Equal(t, lyr, ts.msh.ProcessedLayer())
@@ -575,134 +569,4 @@ func TestSync_AlsoSyncProcessedLayer(t *testing.T) {
 	require.True(t, ts.syncer.synchronize(context.TODO()))
 	// but last synced is updated
 	require.Equal(t, lyr, ts.syncer.getLastSyncedLayer())
-}
-
-func TestProcessLayers_AllGood(t *testing.T) {
-	ts := newSyncerWithoutSyncTimer(t)
-	ts.syncer.setATXSynced()
-	glayer := types.GetEffectiveGenesis()
-	current := glayer.Add(10)
-	ts.syncer.setLastSyncedLayer(current.Sub(1))
-	ts.mTicker.advanceToLayer(current)
-	for lid := glayer.Add(1); lid.Before(current); lid = lid.Add(1) {
-		require.NoError(t, ts.msh.SetZeroBlockLayer(context.TODO(), lid))
-		ts.mBeacon.EXPECT().GetBeacon(gomock.Any()).Return(types.RandomBeacon(), nil)
-		ts.mLyrPatrol.EXPECT().IsHareInCharge(lid).Return(false)
-		ts.mLyrFetcher.EXPECT().PollLayerOpinions(gomock.Any(), lid).Return(okCh())
-	}
-	require.False(t, ts.syncer.stateSynced())
-	require.NoError(t, ts.syncer.processLayers(context.TODO()))
-	require.True(t, ts.syncer.stateSynced())
-}
-
-func TestProcessLayers_DespiteMissingCert(t *testing.T) {
-	ts := newSyncerWithoutSyncTimer(t)
-	ts.syncer.setATXSynced()
-	glayer := types.GetEffectiveGenesis()
-	current := glayer.Add(10)
-	ts.syncer.setLastSyncedLayer(current.Sub(1))
-	ts.mTicker.advanceToLayer(current)
-	for lid := glayer.Add(1); lid.Before(current); lid = lid.Add(1) {
-		// not calling SetZeroBlockLayer() on this layer will cause mesh.ProcessLayer() to fail
-		ts.mBeacon.EXPECT().GetBeacon(gomock.Any()).Return(types.RandomBeacon(), nil)
-		ts.mLyrPatrol.EXPECT().IsHareInCharge(lid).Return(false)
-		ts.mLyrFetcher.EXPECT().PollLayerOpinions(gomock.Any(), lid).Return(okCh())
-	}
-	require.False(t, ts.syncer.stateSynced())
-	require.NoError(t, ts.syncer.processLayers(context.TODO()))
-	require.True(t, ts.syncer.stateSynced())
-}
-
-func TestProcessLayers_BeaconNotAvailable(t *testing.T) {
-	ts := newSyncerWithoutSyncTimer(t)
-	ts.syncer.setATXSynced()
-	lastSynced := types.GetEffectiveGenesis().Add(1)
-	ts.syncer.setLastSyncedLayer(lastSynced)
-	ts.mTicker.advanceToLayer(lastSynced.Add(1))
-	ts.mBeacon.EXPECT().GetBeacon(gomock.Any()).Return(types.EmptyBeacon, errBeaconNotAvailable)
-	require.False(t, ts.syncer.stateSynced())
-	require.ErrorIs(t, ts.syncer.processLayers(context.TODO()), errBeaconNotAvailable)
-	require.False(t, ts.syncer.stateSynced())
-}
-
-func TestProcessLayers_ATXsNotSynced(t *testing.T) {
-	ts := newSyncerWithoutSyncTimer(t)
-	glayer := types.GetEffectiveGenesis()
-	current := glayer.Add(10)
-	ts.syncer.setLastSyncedLayer(current.Sub(1))
-	ts.mTicker.advanceToLayer(current)
-	require.False(t, ts.syncer.stateSynced())
-	require.ErrorIs(t, ts.syncer.processLayers(context.TODO()), errATXsNotSynced)
-	require.False(t, ts.syncer.stateSynced())
-}
-
-func TestProcessLayers_Shutdown(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.TODO())
-	ts := newTestSyncer(ctx, t, never, true)
-	ts.syncer.setATXSynced()
-
-	lastSynced := types.GetEffectiveGenesis().Add(1)
-	ts.syncer.setLastSyncedLayer(lastSynced)
-	ts.mTicker.advanceToLayer(lastSynced.Add(1))
-
-	cancel()
-	require.ErrorIs(t, ts.syncer.processLayers(context.TODO()), errShuttingDown)
-	require.False(t, ts.syncer.stateSynced())
-}
-
-func TestProcessLayers_HareIsStillWorking(t *testing.T) {
-	ts := newSyncerWithoutSyncTimer(t)
-	ts.syncer.setATXSynced()
-	lastSynced := types.GetEffectiveGenesis().Add(1)
-	ts.syncer.setLastSyncedLayer(lastSynced)
-	ts.mTicker.advanceToLayer(lastSynced.Add(1))
-
-	require.False(t, ts.syncer.stateSynced())
-	ts.mBeacon.EXPECT().GetBeacon(gomock.Any()).Return(types.RandomBeacon(), nil)
-	ts.mLyrPatrol.EXPECT().IsHareInCharge(lastSynced).Return(true)
-	require.ErrorIs(t, ts.syncer.processLayers(context.TODO()), errHareInCharge)
-	require.False(t, ts.syncer.stateSynced())
-
-	require.NoError(t, ts.msh.SetZeroBlockLayer(context.TODO(), lastSynced))
-	ts.mBeacon.EXPECT().GetBeacon(gomock.Any()).Return(types.RandomBeacon(), nil)
-	ts.mLyrPatrol.EXPECT().IsHareInCharge(lastSynced).Return(false)
-	ts.mLyrFetcher.EXPECT().PollLayerOpinions(gomock.Any(), lastSynced).Return(okCh())
-	require.NoError(t, ts.syncer.processLayers(context.TODO()))
-	require.True(t, ts.syncer.stateSynced())
-}
-
-func TestProcessLayers_HareTakesTooLong(t *testing.T) {
-	ts := newSyncerWithoutSyncTimer(t)
-	ts.syncer.setATXSynced()
-	glayer := types.GetEffectiveGenesis()
-	lastSynced := glayer.Add(ts.syncer.conf.HareDelayLayers)
-	ts.syncer.setLastSyncedLayer(lastSynced)
-	current := lastSynced.Add(1)
-	ts.mTicker.advanceToLayer(current)
-	for lid := glayer.Add(1); lid.Before(current); lid = lid.Add(1) {
-		require.NoError(t, ts.msh.SetZeroBlockLayer(context.TODO(), lid))
-		ts.mBeacon.EXPECT().GetBeacon(gomock.Any()).Return(types.RandomBeacon(), nil)
-		if lid == glayer.Add(1) {
-			ts.mLyrPatrol.EXPECT().IsHareInCharge(lid).Return(true)
-		} else {
-			ts.mLyrPatrol.EXPECT().IsHareInCharge(lid).Return(false)
-		}
-		ts.mLyrFetcher.EXPECT().PollLayerOpinions(gomock.Any(), lid).Return(okCh())
-	}
-	require.NoError(t, ts.syncer.processLayers(context.TODO()))
-	require.True(t, ts.syncer.stateSynced())
-}
-
-func TestProcessLayers_OpinionsOptional(t *testing.T) {
-	ts := newSyncerWithoutSyncTimer(t)
-	ts.syncer.setATXSynced()
-	lastSynced := types.GetEffectiveGenesis().Add(1)
-	ts.syncer.setLastSyncedLayer(lastSynced)
-	ts.mTicker.advanceToLayer(lastSynced.Add(1))
-	ts.mBeacon.EXPECT().GetBeacon(gomock.Any()).Return(types.RandomBeacon(), nil)
-	ts.mLyrPatrol.EXPECT().IsHareInCharge(lastSynced).Return(false)
-	ts.mLyrFetcher.EXPECT().PollLayerOpinions(gomock.Any(), lastSynced).Return(failedCh())
-	require.False(t, ts.syncer.stateSynced())
-	require.NoError(t, ts.syncer.processLayers(context.TODO()))
-	require.True(t, ts.syncer.stateSynced())
 }

--- a/system/mocks/tortoise.go
+++ b/system/mocks/tortoise.go
@@ -49,6 +49,20 @@ func (mr *MockTortoiseMockRecorder) HandleIncomingLayer(arg0, arg1 interface{}) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleIncomingLayer", reflect.TypeOf((*MockTortoise)(nil).HandleIncomingLayer), arg0, arg1)
 }
 
+// LatestComplete mocks base method.
+func (m *MockTortoise) LatestComplete() types.LayerID {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LatestComplete")
+	ret0, _ := ret[0].(types.LayerID)
+	return ret0
+}
+
+// LatestComplete indicates an expected call of LatestComplete.
+func (mr *MockTortoiseMockRecorder) LatestComplete() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LatestComplete", reflect.TypeOf((*MockTortoise)(nil).LatestComplete))
+}
+
 // OnBallot mocks base method.
 func (m *MockTortoise) OnBallot(arg0 *types.Ballot) {
 	m.ctrl.T.Helper()

--- a/system/tortoise.go
+++ b/system/tortoise.go
@@ -14,4 +14,5 @@ type Tortoise interface {
 	OnBlock(*types.Block)
 	OnHareOutput(types.LayerID, types.BlockID)
 	HandleIncomingLayer(context.Context, types.LayerID) types.LayerID
+	LatestComplete() types.LayerID
 }

--- a/systest/tests/smeshing_test.go
+++ b/systest/tests/smeshing_test.go
@@ -130,7 +130,7 @@ func requireEqualEligibilities(tb testing.TB, proposals map[uint32][]*spacemeshv
 		if referenceEligibilities < 0 {
 			referenceEligibilities = eligibilities
 		} else {
-			require.Equal(tb, referenceEligibilities, eligibilities, smesher)
+			require.Equal(tb, referenceEligibilities, eligibilities, prettyHex([]byte(smesher)))
 		}
 	}
 }

--- a/tortoise/tortoise.go
+++ b/tortoise/tortoise.go
@@ -665,7 +665,7 @@ func (t *turtle) loadHare(lid types.LayerID) error {
 
 func (t *turtle) loadContextualValidity(lid types.LayerID) error {
 	// validities will be available only during rerun or
-	// if they are synced from peers, which we don't do currently
+	// if they are synced from peers
 	validities, err := blocks.ContextualValidity(t.cdb, lid)
 	if err != nil {
 		return fmt.Errorf("contextual validity %s: %w", lid, err)


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
Closes #3003
<!-- `Closes #XXXX, closes #XXXX, ...` links mentioned issues to this PR and automatically closes them when this it's merged -->

## Changes
<!-- Please describe in detail the changes made -->
- syncer: move state sync code to a separate file
- moves opinion processing from fetcher to syncer pkg
- add the following data to opinions response
  - epoch weight
  - latest verified layer
  - aggregated hash
  - block validity 

opinions amongst peers are sorted in the following order
1. highest epoch weight
2. highest verified layer
3. existence of certificate

- only adopts block validity from peers whose aggregated layer hash is the same as node from the previous layer.
- block validity is saved directly to database for tortoise to consume.