### PR TITLE
WIP. Hare `Set` data structure thread safety

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,41 @@ jobs:
         if: always() # always run even if the previous step fails
         with:
           report_paths: '**/unit-tests.xml'
+
+  # Run unit tests with race detector enabled
+  # It takes significantly longer to run tests hence
+  # it is not currently required to finish for `ci-stage1`.
+  race-detection-unittests:
+    runs-on: ubuntu-latest
+    needs: filter-changes
+    if: ${{ needs.filter-changes.outputs.nondocchanges == 'true' }}
+    # should take around 45 mins
+    timeout-minutes: 60
+    steps:
+        # as we use some request to localhost, sometimes it gives us flaky tests. try to disable tcp offloading for fix it
+        # https://github.com/actions/virtual-environments/issues/1187
+      - name: disable TCP/UDP offload
+        run: sudo ethtool -K eth0 tx off rx off
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: set up go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.go-version }}
+      - name: setup env
+        run: make
+      - name: unit tests
+        env:
+          GOFLAGS: -race
+          GOTESTSUM_FORMAT: standard-verbose
+          GOTESTSUM_JUNITFILE: unit-tests.xml
+        run: make test
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v3
+        if: always()
+        with:
+          report_paths: '**/unit-tests.xml'
+
   # checkpoint and print a single, clean status message to slack
   ci-stage1:
     # run regardless of status of previous jobs but skip if the required secret is not accessible

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ include Makefile-gpu.Inc
 DOCKER_HUB ?= spacemeshos
 TEST_LOG_LEVEL ?=
 
+# Extra flags passed to `go test|build|run`
+GOFLAGS ?=
+
 COMMIT = $(shell git rev-parse HEAD)
 SHA = $(shell git rev-parse --short HEAD)
 BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
@@ -84,13 +87,13 @@ get-libs: get-gpu-setup #get-svm
 .PHONY: get-libs
 
 gen-p2p-identity:
-	cd $@ ; go build -o $(BIN_DIR)$@$(EXE) $(GOTAGS) .
+	cd $@ ; go build -o $(BIN_DIR)$@$(EXE) $(GOTAGS) $(GOFLAGS) .
 hare p2p: get-libs
-	cd $@ ; go build -o $(BIN_DIR)go-$@$(EXE) $(GOTAGS) .
+	cd $@ ; go build -o $(BIN_DIR)go-$@$(EXE) $(GOTAGS) $(GOFLAGS).
 go-spacemesh: get-libs
-	go build -o $(BIN_DIR)$@$(EXE) $(LDFLAGS) $(GOTAGS) .
+	go build -o $(BIN_DIR)$@$(EXE) $(LDFLAGS) $(GOTAGS) $(GOFLAGS).
 harness: get-libs
-	cd cmd/integration ; go build -o $(BIN_DIR)go-$@$(EXE) $(GOTAGS) .
+	cd cmd/integration ; go build -o $(BIN_DIR)go-$@$(EXE) $(GOTAGS) $(GOFLAGS) .
 .PHONY: hare p2p harness go-spacemesh gen-p2p-identity
 
 tidy:
@@ -124,7 +127,7 @@ endif
 test: UNIT_TESTS = $(shell go list ./...  | grep -v systest)
 
 test: get-libs
-	$(ULIMIT) CGO_LDFLAGS="$(CGO_TEST_LDFLAGS)" TEST_LOG_LEVEL=$(TEST_LOG_LEVEL) gotestsum -- -timeout 0 -p 1 $(UNIT_TESTS)
+	$(ULIMIT) CGO_LDFLAGS="$(CGO_TEST_LDFLAGS)" TEST_LOG_LEVEL=$(TEST_LOG_LEVEL) gotestsum -- -timeout 0 -p 1 $(GOFLAGS) $(UNIT_TESTS)
 .PHONY: test
 
 generate: get-libs
@@ -173,7 +176,7 @@ cover:
 	@echo "mode: count" > cover-all.out
 	@export CGO_LDFLAGS="$(CGO_TEST_LDFLAGS)";\
 	  $(foreach pkg,$(PKGS),\
-		go test -coverprofile=cover.out -covermode=count $(pkg);\
+		go test -coverprofile=cover.out -covermode=count $(GOFLAGS) $(pkg);\
 		tail -n +2 cover.out >> cover-all.out;)
 	go tool cover -html=cover-all.out
 .PHONY: cover


### PR DESCRIPTION
# WIP

## Motivation
It's related to bug #3583.

Fix thread safety of https://github.com/spacemeshos/go-spacemesh/blob/572b2f125ff401850a85965c987a6428bf7dbac0/hare/haretypes.go#L54-L59

## Changes
<!-- Please describe in detail the changes made -->

## Test Plan
- write more unit tests stressing concurrent access to `Set`
- all unit tests with race-detector should pass

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
