### PR TITLE
[Merged by Bors] - Enable caching Go mod and build files in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,6 @@ jobs:
           key: cache-go-${{ env.go-version }}-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             cache-go-${{ env.go-version }}-
-            cache-
       - name: fmt, tidy, lint
         run: |
           make
@@ -96,7 +95,6 @@ jobs:
           key: cache-go-${{ env.go-version }}-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             cache-go-${{ env.go-version }}-
-            cache-
       - name: setup env
         run: make
       - name: golangci-lint
@@ -128,7 +126,6 @@ jobs:
           restore-keys: |
             cache-go-${{ env.go-version }}-unittests-
             cache-go-${{ env.go-version }}-
-            cache-
       - name: setup env
         run: make
       - name: Clear test cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,8 @@ jobs:
             cache-
       - name: setup env
         run: make
+      - name: Clear test cache
+        run: make clear-test-cache
       - name: unit tests
         env:
           GOTESTSUM_FORMAT: testname

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,15 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: ${{ env.go-version }}
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: cache-go-${{ env.go-version }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            cache-go-${{ env.go-version }}-
+            cache-
       - name: fmt, tidy, lint
         run: |
           make
@@ -79,6 +88,15 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: ${{ env.go-version }}
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: cache-go-${{ env.go-version }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            cache-go-${{ env.go-version }}-
+            cache-
       - name: setup env
         run: make
       - name: golangci-lint
@@ -101,6 +119,15 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: ${{ env.go-version }}
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: cache-go-${{ env.go-version }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            cache-go-${{ env.go-version }}-
+            cache-
       - name: setup env
         run: make
       - name: unit tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,8 +124,9 @@ jobs:
           path: |
             ~/go/pkg/mod
             ~/.cache/go-build
-          key: cache-go-${{ env.go-version }}-${{ hashFiles('**/go.sum') }}
+          key: cache-go-${{ env.go-version }}-unittests-${{ hashFiles('**/go.sum') }}
           restore-keys: |
+            cache-go-${{ env.go-version }}-unittests-
             cache-go-${{ env.go-version }}-
             cache-
       - name: setup env

--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,10 @@ docker-local-build: go-spacemesh hare p2p harness
 .PHONY: docker-local-build
 endif
 
+# Clear tests cache
+clear-test-cache:
+	go clean -testcache
+
 test: UNIT_TESTS = $(shell go list ./...  | grep -v systest)
 
 test: get-libs


### PR DESCRIPTION
## Motivation
Caching Go's package and build files should speed up CI

## Changes
Added steps to cache Go's module directory and build cache to ci.yml

## DevOps Notes
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
