### PR TITLE
[Merged by Bors] - Add create cover profile to makefile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,7 @@ jobs:
           filters: |
             nondoc:
               - '!**/*.md'
-
-  ## stage 1: run unit tests and app tests as a preqrequisite
+  ## stage 1: run unit tests and app tests as a prerequisite
   ## these run on all pushes to all pull requests, all branches
   ## note that secrets may not be accessible in this phase
   quicktests:
@@ -109,8 +108,8 @@ jobs:
     # should take around 15-18 mins
     timeout-minutes: 20
     steps:
-        # as we use some request to localhost, sometimes it gives us flaky tests. try to disable tcp offloading for fix it
-        # https://github.com/actions/virtual-environments/issues/1187
+      # as we use some request to localhost, sometimes it gives us flaky tests. try to disable tcp offloading for fix it
+      # https://github.com/actions/virtual-environments/issues/1187
       - name: disable TCP/UDP offload
         run: sudo ethtool -K eth0 tx off rx off
       - name: checkout
@@ -170,7 +169,6 @@ jobs:
         if: env.status != 'success'
         run: exit 1
 
-
   ## workflow for regular pull requests ends here
   ## everything below here only runs in a push when bors is invoked
   ## so we can safely assume that all secrets are accessible here below
@@ -203,70 +201,70 @@ jobs:
     timeout-minutes: 60
     concurrency: cloud-limits
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-    - id: 'auth'
-      uses: 'google-github-actions/auth@v0'
-      with:
-        # GCP_CREDENTIALS is minified JSON of service account
-        credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
+      - id: 'auth'
+        uses: 'google-github-actions/auth@v0'
+        with:
+          # GCP_CREDENTIALS is minified JSON of service account
+          credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
 
-    - name: Configure gcloud
-      uses: 'google-github-actions/setup-gcloud@v0'
+      - name: Configure gcloud
+        uses: 'google-github-actions/setup-gcloud@v0'
 
-    - name: Configure kubectl
-      run: gcloud container clusters get-credentials ${{ secrets.CI_CLUSTER_NAME }} --zone ${{ secrets.CI_ZONE_NAME }} --project ${{ secrets.GCP_PROJECT_ID }}
+      - name: Configure kubectl
+        run: gcloud container clusters get-credentials ${{ secrets.CI_CLUSTER_NAME }} --zone ${{ secrets.CI_ZONE_NAME }} --project ${{ secrets.GCP_PROJECT_ID }}
 
-    - name: Login to Docker Hub
-      uses: docker/login-action@v2
-      with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
-    - name: Push go-spacemesh build to dockerhub
-      run: make dockerpush
+      - name: Push go-spacemesh build to dockerhub
+        run: make dockerpush
 
-    - name: Get branch and commit hash
-      id: vars
-      shell: bash
-      run: |
-        echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-        echo "::set-output name=branch_name::$(git rev-parse --abbrev-ref HEAD)"
-        echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-        echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+      - name: Get branch and commit hash
+        id: vars
+        shell: bash
+        run: |
+          echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+          echo "::set-output name=branch_name::$(git rev-parse --abbrev-ref HEAD)"
+          echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+          echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
 
-    - name: Build tests docker image
-      run: cd systest && make docker
+      - name: Build tests docker image
+        run: cd systest && make docker
 
-    - name: Push tests docker images
-      run: cd systest && make push
+      - name: Push tests docker images
+        run: cd systest && make push
 
-    - name: Run tests
-      timeout-minutes: 50
-      run: cd systest && make run test_name=. size=50 bootstrap=10m level=info clusters=2 node_selector=cloud.google.com/gke-nodepool=gha label=sanity storage=premium-rwo=10Gi
+      - name: Run tests
+        timeout-minutes: 50
+        run: cd systest && make run test_name=. size=50 bootstrap=10m level=info clusters=2 node_selector=cloud.google.com/gke-nodepool=gha label=sanity storage=premium-rwo=10Gi
 
-    - name: Systemtest result
-      run: |
-        SUCCESS=$(kubectl get pod --selector testid=systest-${{ steps.vars.outputs.sha_short }} -o json | jq .items[].status.containerStatuses[].state.terminated.exitCode)
-        SUCCESS="${SUCCESS//'%'/'%25'}"
-        SUCCESS="${SUCCESS//$'\n'/'%0A'}"
-        SUCCESS="${SUCCESS//$'\r'/'%0D'}"
-        echo "::set-output name=content::$SUCCESS"
-      id: tests_logs
+      - name: Systemtest result
+        run: |
+          SUCCESS=$(kubectl get pod --selector testid=systest-${{ steps.vars.outputs.sha_short }} -o json | jq .items[].status.containerStatuses[].state.terminated.exitCode)
+          SUCCESS="${SUCCESS//'%'/'%25'}"
+          SUCCESS="${SUCCESS//$'\n'/'%0A'}"
+          SUCCESS="${SUCCESS//$'\r'/'%0D'}"
+          echo "::set-output name=content::$SUCCESS"
+        id: tests_logs
 
-    - name: Delete pod
-      if: always()
-      run: cd systest && make clean
+      - name: Delete pod
+        if: always()
+        run: cd systest && make clean
 
-    - name: Tests Passed or Failed
-      run: |
-        SUCCESS='${{ steps.tests_logs.outputs.content }}'
-        ISTRUE='0'
-        if [[ "$SUCCESS" == "$ISTRUE" ]]; then
-          exit 0
-        else
-          exit 1
-        fi
+      - name: Tests Passed or Failed
+        run: |
+          SUCCESS='${{ steps.tests_logs.outputs.content }}'
+          ISTRUE='0'
+          if [[ "$SUCCESS" == "$ISTRUE" ]]; then
+            exit 0
+          else
+            exit 1
+          fi
   # this summary job is a shortcut that obviates the need to list every individual job in bors.toml
   # all tests that are required to pass before a bors merge must be listed here!
   ci-stage2:

--- a/Makefile
+++ b/Makefile
@@ -7,17 +7,14 @@ include Makefile-gpu.Inc
 #include Makefile-svm.Inc
 
 DOCKER_HUB ?= spacemeshos
-TEST_LOG_LEVEL ?=
+UNIT_TESTS ?= $(shell go list ./...  | grep -v systest)
 
 COMMIT = $(shell git rev-parse HEAD)
 SHA = $(shell git rev-parse --short HEAD)
 BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
 
-export GO111MODULE := on
 export CGO_ENABLED := 1
 export CGO_CFLAGS := "-DSQLITE_ENABLE_DBSTAT_VTAB=1"
-
-PKGS = $(shell go list ./...)
 
 # These commands cause problems on Windows
 ifeq ($(OS),Windows_NT)
@@ -64,7 +61,6 @@ DOCKER_IMAGE = $(DOCKER_IMAGE_REPO):$(BRANCH)
 ifeq ($(BRANCH),$(filter $(BRANCH),staging trying))
   DOCKER_IMAGE = $(DOCKER_IMAGE_REPO):$(SHA)
 endif
-
 
 install:
 	go run scripts/check-go-version.go --major 1 --minor 18
@@ -125,19 +121,18 @@ endif
 # Clear tests cache
 clear-test-cache:
 	go clean -testcache
-
-test: UNIT_TESTS = $(shell go list ./...  | grep -v systest)
+.PHONY: clear-test-cache
 
 test: get-libs
-	$(ULIMIT) CGO_LDFLAGS="$(CGO_TEST_LDFLAGS)" TEST_LOG_LEVEL=$(TEST_LOG_LEVEL) gotestsum -- -timeout 0 -p 1 $(UNIT_TESTS)
+	@$(ULIMIT) CGO_LDFLAGS="$(CGO_TEST_LDFLAGS)" gotestsum -- -timeout 0 -p 1 $(UNIT_TESTS)
 .PHONY: test
 
 generate: get-libs
-	$(ULIMIT) CGO_LDFLAGS="$(CGO_TEST_LDFLAGS)" go generate ./...
+	@$(ULIMIT) CGO_LDFLAGS="$(CGO_TEST_LDFLAGS)" go generate ./...
 .PHONY: generate
 
 staticcheck: get-libs
-	$(ULIMIT) CGO_LDFLAGS="$(CGO_TEST_LDFLAGS)" staticcheck ./...
+	@$(ULIMIT) CGO_LDFLAGS="$(CGO_TEST_LDFLAGS)" staticcheck ./...
 .PHONY: staticcheck
 
 test-tidy:
@@ -177,11 +172,15 @@ golangci-lint-github-action:
 cover:
 	@echo "mode: count" > cover-all.out
 	@export CGO_LDFLAGS="$(CGO_TEST_LDFLAGS)";\
-	  $(foreach pkg,$(PKGS),\
+	  $(foreach pkg,$(UNIT_TESTS),\
 		go test -coverprofile=cover.out -covermode=count $(pkg);\
 		tail -n +2 cover.out >> cover-all.out;)
 	go tool cover -html=cover-all.out
 .PHONY: cover
+
+cover-profile:
+	@$(ULIMIT) CGO_LDFLAGS="$(CGO_TEST_LDFLAGS)" go test -coverprofile=cover.out -timeout 0 -p 1 $(UNIT_TESTS)
+.PHONY: cover-profile
 
 tag-and-build:
 	git diff --quiet || (echo "\033[0;31mWorking directory not clean!\033[0m" && git --no-pager diff && exit 1)

--- a/Makefile
+++ b/Makefile
@@ -170,17 +170,8 @@ golangci-lint-github-action:
 .PHONY: golangci-lint-github-action
 
 cover:
-	@echo "mode: count" > cover-all.out
-	@export CGO_LDFLAGS="$(CGO_TEST_LDFLAGS)";\
-	  $(foreach pkg,$(UNIT_TESTS),\
-		go test -coverprofile=cover.out -covermode=count $(pkg);\
-		tail -n +2 cover.out >> cover-all.out;)
-	go tool cover -html=cover-all.out
-.PHONY: cover
-
-cover-profile:
 	@$(ULIMIT) CGO_LDFLAGS="$(CGO_TEST_LDFLAGS)" go test -coverprofile=cover.out -timeout 0 -p 1 $(UNIT_TESTS)
-.PHONY: cover-profile
+.PHONY: cover
 
 tag-and-build:
 	git diff --quiet || (echo "\033[0;31mWorking directory not clean!\033[0m" && git --no-pager diff && exit 1)

--- a/README.md
+++ b/README.md
@@ -193,14 +193,27 @@ You specify these parameters by providing go-spacemesh with a json config file. 
 *NOTE*: if tests are hanging try running `ulimit -n 400`. some tests require that to work.
 
 ```bash
-make test
+TEST_LOG_LEVEL="" make test
 ```
 
-or
+The optional `TEST_LOG_LEVEL` environment variable can be set to change the log level during test execution.
+If not set, tests won't print any logs. Valid values are the error levels of [zapcore](https://pkg.go.dev/go.uber.org/zap/zapcore#Level)
+
+For code coverage you can run:
 
 ```bash
 make cover
 ```
+
+This will start a local web service and open your browser to render a coverage report. If you just want to
+generate a cover profile you can run:
+
+```bash
+make cover-profile
+```
+
+The generated file will be saved to `./cover.out`. It can be loaded into your editor or IDE to view which code paths
+are covered by tests and which not.
 
 ### Continuous Integration
 


### PR DESCRIPTION
## Motivation
This adds a target to the `Makefile` that creates a cover profile. This file can be used to visualize which parts of the code are covered by tests and which not.

## Changes
New target in Makefile

## Test Plan
n/a

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
