### PR TITLE
[Merged by Bors] - Remove unused golint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,7 +76,6 @@ COPY scripts/* scripts/
 # does not required yet
 # RUN go run scripts/check-go-version.go --major 1 --minor 15
 RUN go mod download
-RUN GO111MODULE=off go get golang.org/x/lint/golint
 
 # This image builds the go-spacemesh server
 FROM build_base AS server_builder

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,6 @@ endif
 install:
 	go run scripts/check-go-version.go --major 1 --minor 18
 	go mod download
-	GO111MODULE=off go get golang.org/x/lint/golint
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.48.0
 	go install github.com/spacemeshos/go-scale/scalegen
 	go install github.com/golang/mock/mockgen
@@ -156,8 +155,6 @@ test-fmt:
 .PHONY: test-fmt
 
 lint: golangci-lint
-	# Golint is deprecated and frozen. Using golangci-lint instead.
-	# golint --set_exit_status ./...
 	go vet ./...
 .PHONY: lint
 


### PR DESCRIPTION
## Motivation
Removes golint from Dockerfile and Makefile since it has been superseded by golangci-lint and isn't used any more.

## Changes
Remove code that installs golint

## Test Plan
Existing tests still pass

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
