### PR TITLE
[Merged by Bors] - Use a dedicated type for PoET proof ref

### DIFF
--- a/activation/interface.go
+++ b/activation/interface.go
@@ -10,9 +10,9 @@ import (
 //go:generate mockgen -package=mocks -destination=./mocks/mocks.go -source=./interface.go
 
 type poetValidatorPersistor interface {
-	HasProof([]byte) bool
+	HasProof(types.PoetProofRef) bool
 	Validate(types.PoetProof, []byte, string, []byte) error
-	StoreProof([]byte, *types.PoetProofMessage) error
+	StoreProof(types.PoetProofRef, *types.PoetProofMessage) error
 }
 
 type nipostValidator interface {

--- a/activation/mocks/mocks.go
+++ b/activation/mocks/mocks.go
@@ -37,7 +37,7 @@ func (m *MockpoetValidatorPersistor) EXPECT() *MockpoetValidatorPersistorMockRec
 }
 
 // HasProof mocks base method.
-func (m *MockpoetValidatorPersistor) HasProof(arg0 []byte) bool {
+func (m *MockpoetValidatorPersistor) HasProof(arg0 types.PoetProofRef) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HasProof", arg0)
 	ret0, _ := ret[0].(bool)
@@ -51,7 +51,7 @@ func (mr *MockpoetValidatorPersistorMockRecorder) HasProof(arg0 interface{}) *go
 }
 
 // StoreProof mocks base method.
-func (m *MockpoetValidatorPersistor) StoreProof(arg0 []byte, arg1 *types.PoetProofMessage) error {
+func (m *MockpoetValidatorPersistor) StoreProof(arg0 types.PoetProofRef, arg1 *types.PoetProofMessage) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StoreProof", arg0, arg1)
 	ret0, _ := ret[0].(error)

--- a/activation/nipost.go
+++ b/activation/nipost.go
@@ -87,9 +87,9 @@ type NIPostBuilder struct {
 }
 
 type poetDbAPI interface {
-	SubscribeToProofRef(poetID []byte, roundID string) chan []byte
-	GetMembershipMap(proofRef []byte) (map[types.Hash32]bool, error)
-	GetProof([]byte) (*types.PoetProof, error)
+	SubscribeToProofRef(poetID []byte, roundID string) chan types.PoetProofRef
+	GetMembershipMap(proofRef types.PoetProofRef) (map[types.Hash32]bool, error)
+	GetProof(types.PoetProofRef) (*types.PoetProof, error)
 	UnsubscribeFromProofRef(poetID []byte, roundID string)
 }
 

--- a/activation/nipost_test.go
+++ b/activation/nipost_test.go
@@ -113,8 +113,8 @@ type poetDbMock struct {
 // A compile time check to ensure that poetDbMock fully implements poetDbAPI.
 var _ poetDbAPI = (*poetDbMock)(nil)
 
-func (*poetDbMock) SubscribeToProofRef(poetID []byte, roundID string) chan []byte {
-	ch := make(chan []byte)
+func (*poetDbMock) SubscribeToProofRef(poetID []byte, roundID string) chan types.PoetProofRef {
+	ch := make(chan types.PoetProofRef)
 	go func() {
 		ch <- []byte("hello there")
 	}()
@@ -123,7 +123,7 @@ func (*poetDbMock) SubscribeToProofRef(poetID []byte, roundID string) chan []byt
 
 func (p *poetDbMock) UnsubscribeFromProofRef(poetID []byte, roundID string) { p.unsubscribed = true }
 
-func (p *poetDbMock) GetMembershipMap(poetRoot []byte) (map[types.Hash32]bool, error) {
+func (p *poetDbMock) GetMembershipMap(poetRoot types.PoetProofRef) (map[types.Hash32]bool, error) {
 	if p.errOn {
 		return map[types.Hash32]bool{}, nil
 	}
@@ -132,7 +132,7 @@ func (p *poetDbMock) GetMembershipMap(poetRoot []byte) (map[types.Hash32]bool, e
 	return map[types.Hash32]bool{hash: true, hash2: true}, nil
 }
 
-func (p *poetDbMock) GetProof(poetRef []byte) (*types.PoetProof, error) {
+func (p *poetDbMock) GetProof(poetRef types.PoetProofRef) (*types.PoetProof, error) {
 	hash := types.BytesToHash([]byte("anton"))
 	hash2 := types.BytesToHash([]byte("anton1"))
 	return &types.PoetProof{Members: [][]byte{hash.Bytes(), hash2.Bytes()}}, nil

--- a/activation/poet_client_mock_test.go
+++ b/activation/poet_client_mock_test.go
@@ -89,7 +89,7 @@ func (m *MockpoetDbAPI) EXPECT() *MockpoetDbAPIMockRecorder {
 }
 
 // GetMembershipMap mocks base method.
-func (m *MockpoetDbAPI) GetMembershipMap(proofRef []byte) (map[types.Hash32]bool, error) {
+func (m *MockpoetDbAPI) GetMembershipMap(proofRef types.PoetProofRef) (map[types.Hash32]bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMembershipMap", proofRef)
 	ret0, _ := ret[0].(map[types.Hash32]bool)
@@ -104,7 +104,7 @@ func (mr *MockpoetDbAPIMockRecorder) GetMembershipMap(proofRef interface{}) *gom
 }
 
 // GetProof mocks base method.
-func (m *MockpoetDbAPI) GetProof(arg0 []byte) (*types.PoetProof, error) {
+func (m *MockpoetDbAPI) GetProof(arg0 types.PoetProofRef) (*types.PoetProof, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetProof", arg0)
 	ret0, _ := ret[0].(*types.PoetProof)
@@ -119,10 +119,10 @@ func (mr *MockpoetDbAPIMockRecorder) GetProof(arg0 interface{}) *gomock.Call {
 }
 
 // SubscribeToProofRef mocks base method.
-func (m *MockpoetDbAPI) SubscribeToProofRef(poetID []byte, roundID string) chan []byte {
+func (m *MockpoetDbAPI) SubscribeToProofRef(poetID []byte, roundID string) chan types.PoetProofRef {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SubscribeToProofRef", poetID, roundID)
-	ret0, _ := ret[0].(chan []byte)
+	ret0, _ := ret[0].(chan types.PoetProofRef)
 	return ret0
 }
 

--- a/activation/poetdb.go
+++ b/activation/poetdb.go
@@ -22,18 +22,21 @@ type poetProofKey [hash.Size]byte
 // PoetDb is a database for PoET proofs.
 type PoetDb struct {
 	sqlDB                     *sql.Database
-	poetProofRefSubscriptions map[poetProofKey][]chan []byte
+	poetProofRefSubscriptions map[poetProofKey][]chan types.PoetProofRef
 	log                       log.Log
 	mu                        sync.Mutex
 }
 
+// A compile time check to ensure that PoetDb fully implements poetDbAPI.
+var _ poetDbAPI = (*PoetDb)(nil)
+
 // NewPoetDb returns a new PoET handler.
 func NewPoetDb(db *sql.Database, log log.Log) *PoetDb {
-	return &PoetDb{sqlDB: db, poetProofRefSubscriptions: make(map[poetProofKey][]chan []byte), log: log}
+	return &PoetDb{sqlDB: db, poetProofRefSubscriptions: make(map[poetProofKey][]chan types.PoetProofRef), log: log}
 }
 
 // HasProof returns true if the database contains a proof with the given reference, or false otherwise.
-func (db *PoetDb) HasProof(proofRef []byte) bool {
+func (db *PoetDb) HasProof(proofRef types.PoetProofRef) bool {
 	has, err := poets.Has(db.sqlDB, proofRef)
 	return err == nil && has
 }
@@ -91,7 +94,7 @@ func (db *PoetDb) Validate(proof types.PoetProof, poetID []byte, roundID string,
 }
 
 // StoreProof saves the poet proof in local db.
-func (db *PoetDb) StoreProof(ref []byte, proofMessage *types.PoetProofMessage) error {
+func (db *PoetDb) StoreProof(ref types.PoetProofRef, proofMessage *types.PoetProofMessage) error {
 	messageBytes, err := codec.Encode(proofMessage)
 	if err != nil {
 		return fmt.Errorf("could not marshal proof message: %w", err)
@@ -116,9 +119,9 @@ func (db *PoetDb) StoreProof(ref []byte, proofMessage *types.PoetProofMessage) e
 
 // SubscribeToProofRef returns a channel that PoET proof ref for the requested PoET ID and round ID will be sent. If the
 // proof is already available it will be sent immediately, otherwise it will be sent when available.
-func (db *PoetDb) SubscribeToProofRef(poetID []byte, roundID string) chan []byte {
+func (db *PoetDb) SubscribeToProofRef(poetID []byte, roundID string) chan types.PoetProofRef {
 	key := makeKey(poetID, roundID)
-	ch := make(chan []byte, 1)
+	ch := make(chan types.PoetProofRef, 1)
 	db.addSubscription(key, ch)
 
 	if poetProofRef, err := db.getProofRef(poetID, roundID); err == nil {
@@ -128,7 +131,7 @@ func (db *PoetDb) SubscribeToProofRef(poetID []byte, roundID string) chan []byte
 	return ch
 }
 
-func (db *PoetDb) addSubscription(key poetProofKey, ch chan []byte) {
+func (db *PoetDb) addSubscription(key poetProofKey, ch chan types.PoetProofRef) {
 	db.mu.Lock()
 	defer db.mu.Unlock()
 	db.poetProofRefSubscriptions[key] = append(db.poetProofRefSubscriptions[key], ch)
@@ -143,7 +146,7 @@ func (db *PoetDb) UnsubscribeFromProofRef(poetID []byte, roundID string) {
 	delete(db.poetProofRefSubscriptions, makeKey(poetID, roundID))
 }
 
-func (db *PoetDb) getProofRef(poetID []byte, roundID string) ([]byte, error) {
+func (db *PoetDb) getProofRef(poetID []byte, roundID string) (types.PoetProofRef, error) {
 	proofRef, err := poets.GetRef(db.sqlDB, poetID, roundID)
 	if err != nil {
 		return nil, fmt.Errorf("could not fetch poet proof for poet ID %x in round %v: %w", poetID[:5], roundID, err)
@@ -151,7 +154,7 @@ func (db *PoetDb) getProofRef(poetID []byte, roundID string) ([]byte, error) {
 	return proofRef, nil
 }
 
-func (db *PoetDb) publishProofRef(key poetProofKey, poetProofRef []byte) {
+func (db *PoetDb) publishProofRef(key poetProofKey, poetProofRef types.PoetProofRef) {
 	db.mu.Lock()
 	defer db.mu.Unlock()
 	for _, ch := range db.poetProofRefSubscriptions[key] {
@@ -162,7 +165,7 @@ func (db *PoetDb) publishProofRef(key poetProofKey, poetProofRef []byte) {
 }
 
 // GetProofMessage returns the originally received PoET proof message.
-func (db *PoetDb) GetProofMessage(proofRef []byte) ([]byte, error) {
+func (db *PoetDb) GetProofMessage(proofRef types.PoetProofRef) ([]byte, error) {
 	proof, err := poets.Get(db.sqlDB, proofRef)
 	if err != nil {
 		return proof, fmt.Errorf("get proof from store: %w", err)
@@ -172,7 +175,7 @@ func (db *PoetDb) GetProofMessage(proofRef []byte) ([]byte, error) {
 }
 
 // GetMembershipMap returns the map of memberships in the requested PoET proof.
-func (db *PoetDb) GetMembershipMap(proofRef []byte) (map[types.Hash32]bool, error) {
+func (db *PoetDb) GetMembershipMap(proofRef types.PoetProofRef) (map[types.Hash32]bool, error) {
 	proofMessageBytes, err := db.GetProofMessage(proofRef)
 	if err != nil {
 		return nil, fmt.Errorf("could not fetch poet proof for ref %x: %w", proofRef[:5], err)
@@ -185,7 +188,7 @@ func (db *PoetDb) GetMembershipMap(proofRef []byte) (map[types.Hash32]bool, erro
 }
 
 // GetProof returns full proof.
-func (db *PoetDb) GetProof(proofRef []byte) (*types.PoetProof, error) {
+func (db *PoetDb) GetProof(proofRef types.PoetProofRef) (*types.PoetProof, error) {
 	proofMessageBytes, err := db.GetProofMessage(proofRef)
 	if err != nil {
 		return nil, fmt.Errorf("could not fetch poet proof for ref %x: %w", proofRef[:5], err)

--- a/activation/poetdb_test.go
+++ b/activation/poetdb_test.go
@@ -46,7 +46,7 @@ func TestPoetDbHappyFlow(t *testing.T) {
 	proofBytes, err := codec.Encode(&msg.PoetProof)
 	require.NoError(t, err)
 	expectedRef := hash.Sum(proofBytes)
-	require.Equal(t, types.CalcHash32(expectedRef[:]).Bytes(), ref)
+	require.Equal(t, types.PoetProofRef(types.CalcHash32(expectedRef[:]).Bytes()), ref)
 
 	require.NoError(t, poetDb.StoreProof(ref, msg))
 	got, err := poetDb.getProofRef(msg.PoetServiceID, msg.RoundID)

--- a/common/types/activation.go
+++ b/common/types/activation.go
@@ -297,6 +297,8 @@ func (atx *ActivationTx) Verify(baseTickHeight, tickCount uint64) (*VerifiedActi
 	return vAtx, nil
 }
 
+type PoetProofRef []byte
+
 // PoetProof is the full PoET service proof of elapsed time. It includes the list of members, a leaf count declaration
 // and the actual PoET Merkle proof.
 type PoetProof struct {
@@ -314,7 +316,7 @@ type PoetProofMessage struct {
 }
 
 // Ref returns the reference to the PoET proof message. It's the sha256 sum of the entire proof message.
-func (proofMessage PoetProofMessage) Ref() ([]byte, error) {
+func (proofMessage PoetProofMessage) Ref() (PoetProofRef, error) {
 	poetProofBytes, err := codec.Encode(&proofMessage.PoetProof)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal poet proof for poetId %x round %v: %v",


### PR DESCRIPTION
## Motivation
This PR presents a practical use of leveraging a type system to increase code readability, the expressiveness of APIs and to prevent API misusage.

The idea is to use a dedicated "new" type instead of a generic primitive (for example use `type PoetProofRef []byte` instead of `[]byte`). Some of the benefits are:

- It is clear what a variable "is for" - this information is embedded in its type. For example, it is immediately clear what a `PoetProofRef` is for, in contrast to `[]byte`. Consider an example interface: https://github.com/spacemeshos/go-spacemesh/blob/develop/activation/interface.go#L12-L16. It's hard to tell what is expected to be passed as an argument exactly.
- It limits the usage of a given type of variable throughout the program. It is easier to understand where it comes from and what can be done with it (IDE's features like _find all references_ begin to be helpful).
- ~It prevents mistakes of passing a wrong thing to some API **at compile time**. It takes the burden of questioning "Am I passing the right thing to this function?" from the developer and moves it to the compiler.~

Some cons:
- it might require adding some "glue" casts here and there where APIs are not fully compatible (not 100% ported to use the new type), this especially manifests in tests. On the other hand, having to do an explicit cast should trigger thinking if one is doing the correct thing, to begin with.
- When used too much and without thinking, it might actually reduce the readability of the code.

**Edit:** I realized that Go actually allows for implicit conversions so the 3rd point is invalid :(

## Changes
Replaces usage of `[]byte` with a new type `type PoetProofRef []byte` where applicable.

## Test Plan
unit tests

## DevOps Notes
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
