### PR TITLE
[Merged by Bors] - implement signer and verifier that prefixes message

### DIFF
--- a/activation/activation_test.go
+++ b/activation/activation_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
-	"github.com/spacemeshos/ed25519"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -768,7 +767,7 @@ func TestBuilder_SignAtx(t *testing.T) {
 	err = b.SignAtx(atx)
 	assert.NoError(t, err)
 
-	pubkey, err := ed25519.ExtractPublicKey(atxBytes, atx.Sig)
+	pubkey, err := signing.ExtractPublicKey(atxBytes, atx.Sig)
 	assert.NoError(t, err)
 	assert.Equal(t, sig.NodeID().ToBytes(), []byte(pubkey))
 

--- a/activation/activation_test.go
+++ b/activation/activation_test.go
@@ -770,9 +770,6 @@ func TestBuilder_SignAtx(t *testing.T) {
 	pubkey, err := signing.ExtractPublicKey(atxBytes, atx.Sig)
 	assert.NoError(t, err)
 	assert.Equal(t, sig.NodeID().ToBytes(), []byte(pubkey))
-
-	ok := signing.Verify(signing.NewPublicKey(atx.NodeID().ToBytes()), atxBytes, atx.Sig)
-	assert.True(t, ok)
 }
 
 func TestBuilder_NIPostPublishRecovery(t *testing.T) {

--- a/beacon/beacon.go
+++ b/beacon/beacon.go
@@ -135,7 +135,6 @@ type ProtocolDriver struct {
 	publisher   pubsub.Publisher
 	edSigner    *signing.EdSigner
 	vrfSigner   *signing.VRFSigner
-	edVerifier  signing.EDVerifier
 	vrfVerifier signing.VRFVerifier
 	weakCoin    coin
 	theta       *big.Float

--- a/beacon/beacon_test.go
+++ b/beacon/beacon_test.go
@@ -780,10 +780,7 @@ func TestBeacon_signAndExtractED(t *testing.T) {
 	extractedPK, err := verifier.Extract(message, signature)
 	r.NoError(err)
 
-	ok := verifier.Verify(extractedPK, message, signature)
-
 	r.Equal(signer.PublicKey().String(), extractedPK.String())
-	r.True(ok)
 }
 
 func TestBeacon_signAndVerifyVRF(t *testing.T) {

--- a/beacon/handlers.go
+++ b/beacon/handlers.go
@@ -269,7 +269,7 @@ func (pd *ProtocolDriver) verifyFirstVotes(ctx context.Context, m FirstVotingMes
 		logger.With().Panic("failed to serialize first voting message", log.Err(err))
 	}
 
-	minerPK, err := pd.edVerifier.Extract(messageBytes, m.Signature)
+	minerPK, err := signing.DefaultVerifier.Extract(messageBytes, m.Signature)
 	if err != nil {
 		return nil, types.ATXID{}, fmt.Errorf("[round %v] unable to recover ID from signature %x: %w", types.FirstRound, m.Signature, err)
 	}
@@ -400,7 +400,7 @@ func (pd *ProtocolDriver) verifyFollowingVotes(ctx context.Context, m FollowingV
 		pd.logger.With().Panic("failed to serialize voting message", log.Err(err))
 	}
 
-	minerPK, err := pd.edVerifier.Extract(messageBytes, m.Signature)
+	minerPK, err := signing.DefaultVerifier.Extract(messageBytes, m.Signature)
 	if err != nil {
 		return nil, types.ATXID{}, fmt.Errorf("[round %v] unable to recover ID from signature %x: %w", round, m.Signature, err)
 	}

--- a/blocks/certifier.go
+++ b/blocks/certifier.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/spacemeshos/ed25519"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/spacemeshos/go-spacemesh/codec"
@@ -353,7 +352,7 @@ func (c *Certifier) handleRawCertifyMsg(ctx context.Context, data []byte) error 
 
 func validate(ctx context.Context, logger log.Log, oracle hare.Rolacle, committeeSize int, msg types.CertifyMessage) error {
 	// extract public key from signature
-	pubkey, err := ed25519.ExtractPublicKey(msg.Bytes(), msg.Signature)
+	pubkey, err := signing.ExtractPublicKey(msg.Bytes(), msg.Signature)
 	if err != nil {
 		return fmt.Errorf("%w: cert msg extract key: %v", errMalformedData, err.Error())
 	}

--- a/blocks/certifier_test.go
+++ b/blocks/certifier_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	"github.com/spacemeshos/ed25519"
 	"github.com/stretchr/testify/require"
 
 	"github.com/spacemeshos/go-spacemesh/blocks/mocks"
@@ -362,7 +361,7 @@ func Test_CertifyIfEligible(t *testing.T) {
 		func(_ context.Context, _ string, got []byte) error {
 			var msg types.CertifyMessage
 			require.NoError(t, codec.Decode(got, &msg))
-			pubkey, err := ed25519.ExtractPublicKey(msg.Bytes(), msg.Signature)
+			pubkey, err := signing.ExtractPublicKey(msg.Bytes(), msg.Signature)
 			require.NoError(t, err)
 			require.Equal(t, tc.nodeID, types.BytesToNodeID(pubkey))
 			require.Equal(t, b.LayerIndex, msg.LayerID)

--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -323,6 +323,8 @@ func (app *App) Initialize() (err error) {
 			return fmt.Errorf("genesis config was updated after initializing a node, if you know that update is required delete config at %s.\ndiff:\n%s", gpath, diff)
 		}
 	}
+	signing.DefaultVerifier = signing.NewEDVerifier(
+		signing.WithVerifierPrefix(app.Config.Genesis.GenesisID().Bytes()))
 
 	// tortoise wait zdist layers for hare to timeout for a layer. once hare timeout, tortoise will
 	// vote against all blocks in that layer. so it's important to make sure zdist takes longer than
@@ -950,7 +952,7 @@ func (app *App) LoadOrCreateEdSigner() (*signing.EdSigner, error) {
 
 		log.Info("Identity file not found. Creating new identity...")
 
-		edSgn := signing.NewEdSigner()
+		edSgn := signing.NewEdSigner(signing.WithSignerPrefix(app.Config.Genesis.GenesisID().Bytes()))
 		err := os.MkdirAll(filepath.Dir(filename), filesystem.OwnerReadWriteExec)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create directory for identity file: %w", err)
@@ -963,7 +965,7 @@ func (app *App) LoadOrCreateEdSigner() (*signing.EdSigner, error) {
 		log.With().Info("created new identity", edSgn.PublicKey())
 		return edSgn, nil
 	}
-	edSgn, err := signing.NewEdSignerFromBuffer(data)
+	edSgn, err := signing.NewEdSignerFromBuffer(data, signing.WithSignerPrefix(app.Config.Genesis.GenesisID().Bytes()))
 	if err != nil {
 		return nil, fmt.Errorf("failed to construct identity from data file: %w", err)
 	}

--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -941,12 +941,11 @@ func (app *App) LoadOrCreateEdSigner() (*signing.EdSigner, error) {
 		log.With().Info("created new identity", edSgn.PublicKey())
 		return edSgn, nil
 	}
-	genesis := []byte("genesis placeholder")
-	edSgn, err := signing.NewEdSignerFromBuffer(data, signing.WithSignerPrefix(genesis))
+	edSgn, err := signing.NewEdSignerFromBuffer(data)
 	if err != nil {
 		return nil, fmt.Errorf("failed to construct identity from data file: %w", err)
 	}
-	signing.DefaultVerifier = signing.NewEDVerifier(signing.WithVerifierPrefix(genesis))
+
 	log.Info("Loaded existing identity; public key: %v", edSgn.PublicKey())
 
 	return edSgn, nil

--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -941,12 +941,12 @@ func (app *App) LoadOrCreateEdSigner() (*signing.EdSigner, error) {
 		log.With().Info("created new identity", edSgn.PublicKey())
 		return edSgn, nil
 	}
-
-	edSgn, err := signing.NewEdSignerFromBuffer(data)
+	genesis := []byte("genesis placeholder")
+	edSgn, err := signing.NewEdSignerFromBuffer(data, signing.WithSignerPrefix(genesis))
 	if err != nil {
 		return nil, fmt.Errorf("failed to construct identity from data file: %w", err)
 	}
-
+	signing.DefaultVerifier = signing.NewEDVerifier(signing.WithVerifierPrefix(genesis))
 	log.Info("Loaded existing identity; public key: %v", edSgn.PublicKey())
 
 	return edSgn, nil

--- a/common/types/activation.go
+++ b/common/types/activation.go
@@ -7,7 +7,6 @@ import (
 	"sort"
 	"strconv"
 
-	"github.com/spacemeshos/ed25519"
 	"github.com/spacemeshos/go-scale"
 	poetShared "github.com/spacemeshos/poet/shared"
 	postShared "github.com/spacemeshos/post/shared"
@@ -16,6 +15,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/common/util"
 	"github.com/spacemeshos/go-spacemesh/hash"
 	"github.com/spacemeshos/go-spacemesh/log"
+	"github.com/spacemeshos/go-spacemesh/signing"
 )
 
 //go:generate scalegen
@@ -225,7 +225,7 @@ func (atx *ActivationTx) CalcAndSetNodeID() error {
 	if err != nil {
 		return fmt.Errorf("failed to derive NodeID: %w", err)
 	}
-	pub, err := ed25519.ExtractPublicKey(b, atx.Sig)
+	pub, err := signing.ExtractPublicKey(b, atx.Sig)
 	if err != nil {
 		return fmt.Errorf("failed to derive NodeID: %w", err)
 	}

--- a/common/types/ballot.go
+++ b/common/types/ballot.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/spacemeshos/ed25519"
 	"github.com/spacemeshos/go-scale"
 
 	"github.com/spacemeshos/go-spacemesh/codec"
@@ -188,7 +187,7 @@ func (b *Ballot) Initialize() error {
 	b.ballotID = BallotID(CalcObjectHash32(b).ToHash20())
 
 	data := b.Bytes()
-	pubkey, err := ed25519.ExtractPublicKey(data, b.Signature)
+	pubkey, err := signing.ExtractPublicKey(data, b.Signature)
 	if err != nil {
 		return fmt.Errorf("ballot extract key: %w", err)
 	}

--- a/common/types/block_test.go
+++ b/common/types/block_test.go
@@ -3,7 +3,6 @@ package types
 import (
 	"testing"
 
-	"github.com/spacemeshos/ed25519"
 	"github.com/spacemeshos/go-scale/tester"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -35,7 +34,7 @@ func Test_CertifyMessage(t *testing.T) {
 	var decoded CertifyMessage
 	require.NoError(t, codec.Decode(data, &decoded))
 	require.Equal(t, msg, decoded)
-	pubKey, err := ed25519.ExtractPublicKey(decoded.Bytes(), decoded.Signature)
+	pubKey, err := signing.ExtractPublicKey(decoded.Bytes(), decoded.Signature)
 	require.NoError(t, err)
 	require.Equal(t, signer.PublicKey().Bytes(), []byte(pubKey))
 }

--- a/common/types/proposal.go
+++ b/common/types/proposal.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/spacemeshos/ed25519"
 	"github.com/spacemeshos/go-scale"
 
 	"github.com/spacemeshos/go-spacemesh/codec"
@@ -78,7 +77,7 @@ func (p *Proposal) Initialize() error {
 	}
 
 	// check proposal signature consistent with ballot's
-	pubkey, err := ed25519.ExtractPublicKey(p.Bytes(), p.Signature)
+	pubkey, err := signing.ExtractPublicKey(p.Bytes(), p.Signature)
 	if err != nil {
 		return fmt.Errorf("proposal extract key: %w", err)
 	}

--- a/hare/algorithm.go
+++ b/hare/algorithm.go
@@ -9,8 +9,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/spacemeshos/ed25519"
-
 	"github.com/spacemeshos/go-spacemesh/codec"
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/common/util"
@@ -111,7 +109,7 @@ func newMsg(ctx context.Context, logger log.Log, hareMsg Message, querier stateQ
 	logger = logger.WithContext(ctx)
 
 	// extract pub key
-	pubKey, err := ed25519.ExtractPublicKey(hareMsg.InnerMsg.Bytes(), hareMsg.Sig)
+	pubKey, err := signing.ExtractPublicKey(hareMsg.InnerMsg.Bytes(), hareMsg.Sig)
 	if err != nil {
 		logger.With().Error("newmsg construction failed: could not extract public key",
 			log.Err(err),

--- a/signing/interfaces.go
+++ b/signing/interfaces.go
@@ -16,6 +16,5 @@ type Verifier interface {
 
 // VerifyExtractor is a common interface for signature verification with support of public key extraction.
 type VerifyExtractor interface {
-	Verifier
 	Extract(msg, sig []byte) (*PublicKey, error)
 }

--- a/signing/mocks/mocks.go
+++ b/signing/mocks/mocks.go
@@ -150,17 +150,3 @@ func (mr *MockVerifyExtractorMockRecorder) Extract(msg, sig interface{}) *gomock
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Extract", reflect.TypeOf((*MockVerifyExtractor)(nil).Extract), msg, sig)
 }
-
-// Verify mocks base method.
-func (m *MockVerifyExtractor) Verify(pub *signing.PublicKey, msg, sig []byte) bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Verify", pub, msg, sig)
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// Verify indicates an expected call of Verify.
-func (mr *MockVerifyExtractorMockRecorder) Verify(pub, msg, sig interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Verify", reflect.TypeOf((*MockVerifyExtractor)(nil).Verify), pub, msg, sig)
-}

--- a/signing/signer.go
+++ b/signing/signer.go
@@ -72,13 +72,23 @@ var _ Signer = (*EdSigner)(nil)
 type EdSigner struct {
 	privKey ed25519.PrivateKey // the pub & private key
 	pubKey  ed25519.PublicKey  // only the pub key part
+
+	prefix []byte
 }
 
 // PrivateKeySize size of the private key in bytes.
 const PrivateKeySize = ed25519.PrivateKeySize
 
+type SignerOpt func(*EdSigner)
+
+func WithSignerPrefix(prefix []byte) SignerOpt {
+	return func(signer *EdSigner) {
+		signer.prefix = prefix
+	}
+}
+
 // NewEdSignerFromBuffer builds a signer from a private key as byte buffer.
-func NewEdSignerFromBuffer(buff []byte) (*EdSigner, error) {
+func NewEdSignerFromBuffer(buff []byte, opts ...SignerOpt) (*EdSigner, error) {
 	if len(buff) != ed25519.PrivateKeySize {
 		log.Error("Could not create EdSigner from the provided buffer: buffer too small")
 		return nil, errors.New("buffer too small")
@@ -90,7 +100,9 @@ func NewEdSignerFromBuffer(buff []byte) (*EdSigner, error) {
 		log.Error("Public key and private key does not match")
 		return nil, errors.New("private and public does not match")
 	}
-
+	for _, opt := range opts {
+		opt(sgn)
+	}
 	return sgn, nil
 }
 
@@ -104,17 +116,23 @@ func NewEdSignerFromRand(rand io.Reader) *EdSigner {
 }
 
 // NewEdSigner returns an auto-generated ed signer.
-func NewEdSigner() *EdSigner {
+func NewEdSigner(opts ...SignerOpt) *EdSigner {
 	pub, priv, err := ed25519.GenerateKey(nil)
 	if err != nil {
 		log.Panic("Could not generate key pair err=%v", err)
 	}
-
-	return &EdSigner{privKey: priv, pubKey: pub}
+	signer := &EdSigner{privKey: priv, pubKey: pub}
+	for _, opt := range opts {
+		opt(signer)
+	}
+	return signer
 }
 
 // Sign signs the provided message.
 func (es *EdSigner) Sign(m []byte) []byte {
+	if es.prefix != nil {
+		m = append(es.prefix, m...)
+	}
 	return ed25519.Sign2(es.privKey, m)
 }
 
@@ -151,26 +169,60 @@ func (es *EdSigner) ToBuffer() []byte {
 
 // Verify verifies the provided message.
 func Verify(pubkey *PublicKey, message []byte, sign []byte) bool {
-	return ed25519.Verify2(pubkey.Bytes(), message, sign)
+	return DefaultVerifier.Verify(pubkey, message, sign)
+}
+
+// VerifierOpt to modify verifier.
+type VerifierOpt func(*EDVerifier)
+
+// WithVerifierPrefix ...
+func WithVerifierPrefix(prefix []byte) VerifierOpt {
+	return func(verifier *EDVerifier) {
+		verifier.prefix = prefix
+	}
+}
+
+// DefaultVerifier used by ExtractPublicKey and Verify.
+var DefaultVerifier = EDVerifier{}
+
+// ExtractPublicKey using DefaultVerifier Extract method.
+func ExtractPublicKey(msg, sig []byte) (ed25519.PublicKey, error) {
+	pub, err := DefaultVerifier.Extract(msg, sig)
+	if err != nil {
+		return nil, err
+	}
+	return pub.Bytes(), nil
 }
 
 // EDVerifier is a verifier for ED purposes.
-type EDVerifier struct{}
+type EDVerifier struct {
+	prefix []byte
+}
 
 // NewEDVerifier returns a new EDVerifier.
-func NewEDVerifier() EDVerifier {
-	return EDVerifier{}
+func NewEDVerifier(opts ...VerifierOpt) EDVerifier {
+	verifier := EDVerifier{}
+	for _, opt := range opts {
+		opt(&verifier)
+	}
+	return verifier
 }
 
 var _ VerifyExtractor = EDVerifier{}
 
 // Verify that signature matches public key.
-func (EDVerifier) Verify(pub *PublicKey, msg, sig []byte) bool {
-	return Verify(pub, msg, sig)
+func (e EDVerifier) Verify(pub *PublicKey, msg, sig []byte) bool {
+	if e.prefix != nil {
+		msg = append(e.prefix, msg...)
+	}
+	return ed25519.Verify2(pub.Bytes(), msg, sig)
 }
 
 // Extract public key from signature.
-func (EDVerifier) Extract(msg, sig []byte) (*PublicKey, error) {
+func (e EDVerifier) Extract(msg, sig []byte) (*PublicKey, error) {
+	if e.prefix != nil {
+		msg = append(e.prefix, msg...)
+	}
 	pub, err := ed25519.ExtractPublicKey(msg, sig)
 	if err != nil {
 		return nil, fmt.Errorf("extract ed25519 pubkey: %w", err)

--- a/signing/signer.go
+++ b/signing/signer.go
@@ -78,8 +78,10 @@ type EdSigner struct {
 // PrivateKeySize size of the private key in bytes.
 const PrivateKeySize = ed25519.PrivateKeySize
 
+// SignerOpt modifies EdSigner.
 type SignerOpt func(*EdSigner)
 
+// WithSignerPrefix sets used by EdSigner.
 func WithSignerPrefix(prefix []byte) SignerOpt {
 	return func(signer *EdSigner) {
 		signer.prefix = prefix
@@ -166,11 +168,6 @@ func (es *EdSigner) ToBuffer() []byte {
 	return buff
 }
 
-// Verify verifies the provided message.
-func Verify(pubkey *PublicKey, message []byte, sign []byte) bool {
-	return DefaultVerifier.Verify(pubkey, message, sign)
-}
-
 // VerifierOpt to modify verifier.
 type VerifierOpt func(*EDVerifier)
 
@@ -181,7 +178,7 @@ func WithVerifierPrefix(prefix []byte) VerifierOpt {
 	}
 }
 
-// DefaultVerifier used by ExtractPublicKey and Verify.
+// DefaultVerifier used by ExtractPublicKey.
 var DefaultVerifier = EDVerifier{}
 
 // ExtractPublicKey using DefaultVerifier Extract method.
@@ -208,14 +205,6 @@ func NewEDVerifier(opts ...VerifierOpt) EDVerifier {
 }
 
 var _ VerifyExtractor = EDVerifier{}
-
-// Verify that signature matches public key.
-func (e EDVerifier) Verify(pub *PublicKey, msg, sig []byte) bool {
-	if e.prefix != nil {
-		msg = append(e.prefix, msg...)
-	}
-	return ed25519.Verify2(pub.Bytes(), msg, sig)
-}
 
 // Extract public key from signature.
 func (e EDVerifier) Extract(msg, sig []byte) (*PublicKey, error) {

--- a/signing/signer.go
+++ b/signing/signer.go
@@ -3,7 +3,6 @@ package signing
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"io"
 
 	"github.com/spacemeshos/ed25519"
@@ -225,7 +224,7 @@ func (e EDVerifier) Extract(msg, sig []byte) (*PublicKey, error) {
 	}
 	pub, err := ed25519.ExtractPublicKey(msg, sig)
 	if err != nil {
-		return nil, fmt.Errorf("extract ed25519 pubkey: %w", err)
+		return nil, err
 	}
 	return &PublicKey{pub: pub}, nil
 }

--- a/signing/signer_test.go
+++ b/signing/signer_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/spacemeshos/ed25519"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/spacemeshos/go-spacemesh/rand"
 )
@@ -49,4 +50,27 @@ func TestPublicKey_ShortString(t *testing.T) {
 
 	pub = NewPublicKey([]byte{1, 2})
 	assert.Equal(t, pub.String(), pub.ShortString())
+}
+
+func TestPrefix(t *testing.T) {
+	t.Run("signer mismatch", func(t *testing.T) {
+		signer := NewEdSigner(WithSignerPrefix([]byte("one")))
+		verifier := NewEDVerifier(WithVerifierPrefix([]byte("two")))
+		msg := []byte("test")
+		sig := signer.Sign(msg)
+
+		pub, err := verifier.Extract(msg, sig)
+		require.NoError(t, err)
+		require.NotEqual(t, pub.Bytes(), signer.PublicKey().Bytes())
+	})
+	t.Run("no mismatch", func(t *testing.T) {
+		signer := NewEdSigner(WithSignerPrefix([]byte("one")))
+		verifier := NewEDVerifier(WithVerifierPrefix([]byte("one")))
+		msg := []byte("test")
+		sig := signer.Sign(msg)
+
+		pub, err := verifier.Extract(msg, sig)
+		require.NoError(t, err)
+		require.Equal(t, pub.Bytes(), signer.PublicKey().Bytes())
+	})
 }


### PR DESCRIPTION
closes: https://github.com/spacemeshos/go-spacemesh/issues/3503

- added option to prefix message before signing and verifying
- signing.ExtractPublicKey replaced ed25519.ExtractPublicKey, so that we can use prefixed verifier

more efficient version won't allocate new buffer when message is being prefixed, but that requires changes in spacemesh/ed25519 library  