### PR TITLE
[Merged by Bors] - block certifier: fix certifier concurrent map access

### DIFF
--- a/blocks/certifier.go
+++ b/blocks/certifier.go
@@ -298,6 +298,8 @@ func (c *Certifier) HandleSyncedCertificate(ctx context.Context, lid types.Layer
 }
 
 func (c *Certifier) certified(lid types.LayerID, bid types.BlockID) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	if _, ok := c.certifyMsgs[lid]; ok {
 		if _, ok := c.certifyMsgs[lid][bid]; ok {
 			return c.certifyMsgs[lid][bid].done

--- a/blocks/certifier_test.go
+++ b/blocks/certifier_test.go
@@ -235,15 +235,12 @@ func Test_HandleCertifyMessage_Certified(t *testing.T) {
 	tt := []struct {
 		name       string
 		concurrent bool
-		expected   pubsub.ValidationResult
 	}{
 		{
-			name:     "sequential",
-			expected: pubsub.ValidationAccept,
+			name: "sequential",
 		},
 		{
 			name:       "concurrent",
-			expected:   pubsub.ValidationAccept,
 			concurrent: true,
 		},
 	}
@@ -259,7 +256,7 @@ func Test_HandleCertifyMessage_Certified(t *testing.T) {
 			require.NoError(t, tcc.RegisterForCert(context.TODO(), b.LayerIndex, b.ID()))
 			if tc.concurrent {
 				tcc.mOracle.EXPECT().Validate(gomock.Any(), b.LayerIndex, eligibility.CertifyRound, tcc.cfg.CommitteeSize, gomock.Any(), gomock.Any(), defaultCnt).
-					Return(true, nil).MaxTimes(numMsgs)
+					Return(true, nil).MinTimes(cutoff).MaxTimes(numMsgs)
 			}
 			tcc.mtortoise.EXPECT().OnHareOutput(b.LayerIndex, b.ID())
 			var wg sync.WaitGroup


### PR DESCRIPTION
## Motivation

race condition, added test that failed with -race -count 5 and pass after the fix