### PR TITLE
[Merged by Bors] - Use temp DataDirParent in node test

### DIFF
--- a/cmd/node/node_test.go
+++ b/cmd/node/node_test.go
@@ -677,11 +677,9 @@ func TestSpacemeshApp_TransactionService(t *testing.T) {
 	// Use a unique port
 	port := 1236
 
-	// Use a unique dir for data so we don't read existing state
-	path := t.TempDir()
-
 	app := New(WithLog(logtest.New(t)))
 	cfg := config.DefaultTestConfig()
+	cfg.DataDirParent = t.TempDir()
 	app.Config = &cfg
 
 	signer := signing.NewEdSigner()
@@ -690,8 +688,6 @@ func TestSpacemeshApp_TransactionService(t *testing.T) {
 	Cmd.Run = func(cmd *cobra.Command, args []string) {
 		defer app.Cleanup()
 		r.NoError(app.Initialize())
-
-		app.Config.DataDirParent = path
 
 		// GRPC configuration
 		app.Config.API.GrpcServerPort = port


### PR DESCRIPTION
## Motivation
A test should use a temporary directory instead of the default one.

## Changes
Fixed overwriting default value to happen before using it for the first time.

## DevOps Notes
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
