### PR TITLE
[Merged by Bors] - Add method to be able to await ATX sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,6 @@ jobs:
       - name: disable TCP/UDP offload
         if: ${{ matrix.os == 'windows-latest' }}
         run: |
-          netsh interface ip set global taskoffload=disabled
           netsh interface tcp set global rss=disabled
 
           netsh interface show interface

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,8 +140,8 @@ jobs:
           netsh interface tcp set global autotuninglevel=disabled
           netsh interface tcp set global rss=disabled
           netsh interface show interface
-          netsh interface set interface name="Ethernet0" admin=disabled
-          netsh interface set interface name="Ethernet0" admin=enabled
+          netsh interface set interface name="Ethernet 3" admin=disabled
+          netsh interface set interface name="Ethernet 3" admin=enabled
       - name: checkout
         uses: actions/checkout@v3
       - name: set up go

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     needs: filter-changes
     if: ${{ needs.filter-changes.outputs.nondocchanges == 'true' }}
-    timeout-minutes: 30
     strategy:
       fail-fast: true
       matrix:
@@ -162,6 +161,7 @@ jobs:
       - name: Clear test cache
         run: make clear-test-cache
       - name: unit tests
+        timeout-minutes: 25
         env:
           GOTESTSUM_FORMAT: standard-verbose
           GOTESTSUM_JUNITFILE: unit-tests.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,14 +134,14 @@ jobs:
         run: |
           sudo sysctl -w net.link.generic.system.hwcksum_tx=0
           sudo sysctl -w net.link.generic.system.hwcksum_rx=0
-      - name: disable TCP/UDP offload
-        if: ${{ matrix.os == 'windows-latest' }}
-        run: |
-          netsh interface tcp set global rss=disabled
-
-          netsh interface show interface
-          netsh interface set interface name="Ethernet 3" admin=disabled
-          netsh interface set interface name="Ethernet 3" admin=enabled
+      # TODO(mafa): these settings don't seem to improve network performance on windows - disabled for now
+      # - name: disable TCP/UDP offload
+      #   if: ${{ matrix.os == 'windows-latest' }}
+      #   run: |
+      #     netsh interface tcp set global rss=disabled
+      #     netsh interface show interface
+      #     netsh interface set interface name="Ethernet 3" admin=disabled
+      #     netsh interface set interface name="Ethernet 3" admin=enabled
       - name: checkout
         uses: actions/checkout@v3
       - name: set up go

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,9 @@ jobs:
         run: |
           netsh interface tcp set global autotuninglevel=disabled
           netsh interface tcp set global rss=disabled
-          netsh interface tcp set global chimney=disabled
+          netsh interface show interface
+          netsh interface set interface name="Ethernet0" admin=disabled
+          netsh interface set interface name="Ethernet0" admin=enabled
       - name: checkout
         uses: actions/checkout@v3
       - name: set up go

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,8 +137,9 @@ jobs:
       - name: disable TCP/UDP offload
         if: ${{ matrix.os == 'windows-latest' }}
         run: |
-          netsh interface tcp set global autotuninglevel=disabled
+          netsh interface ip set global taskoffload=disabled
           netsh interface tcp set global rss=disabled
+
           netsh interface show interface
           netsh interface set interface name="Ethernet 3" admin=disabled
           netsh interface set interface name="Ethernet 3" admin=enabled

--- a/activation/activation.go
+++ b/activation/activation.go
@@ -62,7 +62,7 @@ type signer interface {
 }
 
 type syncer interface {
-	RegisterForSynced(context.Context) chan struct{}
+	RegisterForATXSynced() chan struct{}
 }
 
 // SmeshingProvider defines the functionality required for the node's Smesher API.
@@ -424,11 +424,10 @@ func (b *Builder) loop(ctx context.Context) {
 }
 
 func (b *Builder) buildNIPostChallenge(ctx context.Context) error {
-	syncedCh := b.syncer.RegisterForSynced(ctx)
 	select {
 	case <-ctx.Done():
 		return ErrStopRequested
-	case <-syncedCh:
+	case <-b.syncer.RegisterForATXSynced():
 	}
 	challenge := &types.NIPostChallenge{}
 	atxID, pubLayerID, err := b.GetPositioningAtxInfo()
@@ -569,11 +568,10 @@ func (b *Builder) PublishActivationTx(ctx context.Context) error {
 	case <-atxReceived:
 		logger.With().Info(fmt.Sprintf("received atx in db %v", atx.ID().ShortString()), atx.ID())
 	case <-b.layerClock.AwaitLayer((atx.TargetEpoch() + 1).FirstLayer()):
-		syncedCh := b.syncer.RegisterForSynced(ctx)
 		select {
 		case <-atxReceived:
 			logger.With().Info(fmt.Sprintf("received atx in db %v (in the last moment)", atx.ID().ShortString()), atx.ID())
-		case <-syncedCh: // ensure we've seen all blocks before concluding that the ATX was lost
+		case <-b.syncer.RegisterForATXSynced(): // ensure we've seen all ATXs before concluding that the ATX was lost
 			b.discardChallenge()
 			return fmt.Errorf("%w: target epoch has passed", ErrATXChallengeExpired)
 		case <-ctx.Done():
@@ -625,9 +623,10 @@ func (b *Builder) createAtx(ctx context.Context) (*types.ActivationTx, error) {
 	// we need to provide number of atx seen in the epoch of the positioning atx.
 
 	// ensure we are synced before generating the ATX's view
-	syncedCh := b.syncer.RegisterForSynced(ctx)
-	if err := b.waitOrStop(ctx, syncedCh); err != nil {
-		return nil, err
+	select {
+	case <-ctx.Done():
+		return nil, ErrStopRequested
+	case <-b.syncer.RegisterForATXSynced():
 	}
 
 	var initialPost *types.Post

--- a/activation/activation_test.go
+++ b/activation/activation_test.go
@@ -233,8 +233,8 @@ func (l *LayerClockMock) AwaitLayer(types.LayerID) chan struct{} {
 // TODO(mafa): replace this mock a generated one
 type mockSyncer struct{}
 
-func (m *mockSyncer) RegisterForSynced(_ context.Context) chan struct{} {
-	ch := make(chan struct{}, 0)
+func (m *mockSyncer) RegisterForATXSynced() chan struct{} {
+	ch := make(chan struct{})
 	close(ch)
 	return ch
 }

--- a/activation/activation_test.go
+++ b/activation/activation_test.go
@@ -230,7 +230,7 @@ func (l *LayerClockMock) AwaitLayer(types.LayerID) chan struct{} {
 	return ch
 }
 
-// TODO(mafa): replace this mock a generated one
+// TODO(mafa): replace this mock a generated one.
 type mockSyncer struct{}
 
 func (m *mockSyncer) RegisterForATXSynced() chan struct{} {

--- a/activation/activation_test.go
+++ b/activation/activation_test.go
@@ -230,10 +230,13 @@ func (l *LayerClockMock) AwaitLayer(types.LayerID) chan struct{} {
 	return ch
 }
 
+// TODO(mafa): replace this mock a generated one
 type mockSyncer struct{}
 
-func (m *mockSyncer) RegisterChForSynced(_ context.Context, ch chan struct{}) {
+func (m *mockSyncer) RegisterForSynced(_ context.Context) chan struct{} {
+	ch := make(chan struct{}, 0)
 	close(ch)
+	return ch
 }
 
 func newBuilder(tb testing.TB, cdb *datastore.CachedDB, hdlr atxHandler) *Builder {

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -88,13 +88,13 @@ type Syncer struct {
 	lastLayerSynced   atomic.Value
 	lastATXsSynced    atomic.Value
 
-	mu sync.Mutex
-
 	// awaitSyncedCh is the list of subscribers' channels to notify when this node enters synced state
 	awaitSyncedCh []chan struct{}
+	muSyncedCh    sync.Mutex // protects the slice above from concurrent access
 
 	// awaitATXSyncedCh is the list of subscribers' channels to notify when this node enters ATX synced state
 	awaitATXSyncedCh []chan struct{}
+	muATXSyncedCh    sync.Mutex // protects the slice above from concurrent access
 
 	shutdownCtx context.Context
 	cancelFunc  context.CancelFunc
@@ -161,8 +161,8 @@ func (s *Syncer) RegisterForSynced(ctx context.Context) chan struct{} {
 		close(ch)
 		return ch
 	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.muSyncedCh.Lock()
+	defer s.muSyncedCh.Unlock()
 	s.awaitSyncedCh = append(s.awaitSyncedCh, ch)
 	return ch
 }
@@ -174,8 +174,8 @@ func (s *Syncer) RegisterForATXSynced() chan struct{} {
 		close(ch)
 		return ch
 	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.muATXSyncedCh.Lock()
+	defer s.muATXSyncedCh.Unlock()
 	s.awaitATXSyncedCh = append(s.awaitATXSyncedCh, ch)
 	return ch
 }
@@ -248,8 +248,8 @@ func (s *Syncer) isClosed() bool {
 func (s *Syncer) setATXSynced() {
 	s.atxSyncState.Store(synced)
 
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.muATXSyncedCh.Lock()
+	defer s.muATXSyncedCh.Unlock()
 	for _, ch := range s.awaitATXSyncedCh {
 		close(ch)
 	}
@@ -278,8 +278,8 @@ func (s *Syncer) setSyncState(ctx context.Context, newState syncState) {
 			return
 		}
 		// notify subscribes
-		s.mu.Lock()
-		defer s.mu.Unlock()
+		s.muSyncedCh.Lock()
+		defer s.muSyncedCh.Unlock()
 		for _, ch := range s.awaitSyncedCh {
 			close(ch)
 		}

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -89,8 +89,12 @@ type Syncer struct {
 	lastATXsSynced    atomic.Value
 
 	mu sync.Mutex
+
 	// awaitSyncedCh is the list of subscribers' channels to notify when this node enters synced state
 	awaitSyncedCh []chan struct{}
+
+	// awaitATXSyncedCh is the list of subscribers' channels to notify when this node enters ATX synced state
+	awaitATXSyncedCh []chan struct{}
 
 	shutdownCtx context.Context
 	cancelFunc  context.CancelFunc
@@ -115,20 +119,21 @@ func NewSyncer(
 ) *Syncer {
 	shutdownCtx, cancel := context.WithCancel(ctx)
 	s := &Syncer{
-		logger:        logger,
-		conf:          conf,
-		db:            db,
-		ticker:        ticker,
-		beacon:        beacon,
-		mesh:          mesh,
-		certHandler:   ch,
-		fetcher:       fetcher,
-		patrol:        patrol,
-		syncTimer:     time.NewTicker(conf.SyncInterval),
-		validateTimer: time.NewTicker(conf.SyncInterval * 3),
-		awaitSyncedCh: make([]chan struct{}, 0),
-		shutdownCtx:   shutdownCtx,
-		cancelFunc:    cancel,
+		logger:           logger,
+		conf:             conf,
+		db:               db,
+		ticker:           ticker,
+		beacon:           beacon,
+		mesh:             mesh,
+		certHandler:      ch,
+		fetcher:          fetcher,
+		patrol:           patrol,
+		syncTimer:        time.NewTicker(conf.SyncInterval),
+		validateTimer:    time.NewTicker(conf.SyncInterval * 3),
+		awaitSyncedCh:    make([]chan struct{}, 0),
+		awaitATXSyncedCh: make([]chan struct{}, 0),
+		shutdownCtx:      shutdownCtx,
+		cancelFunc:       cancel,
 	}
 	s.syncState.Store(notSynced)
 	s.atxSyncState.Store(notSynced)
@@ -149,15 +154,30 @@ func (s *Syncer) Close() {
 	s.logger.With().Info("all syncer goroutines finished", log.Err(err))
 }
 
-// RegisterChForSynced registers ch for notification when the node enters synced state.
-func (s *Syncer) RegisterChForSynced(ctx context.Context, ch chan struct{}) {
+// RegisterForSynced returns a channel for notification when the node enters synced state.
+func (s *Syncer) RegisterForSynced(ctx context.Context) chan struct{} {
+	ch := make(chan struct{})
 	if s.IsSynced(ctx) {
 		close(ch)
-		return
+		return ch
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.awaitSyncedCh = append(s.awaitSyncedCh, ch)
+	return ch
+}
+
+// RegisterForATXSynced returns a channel for notification when the node enters ATX synced state.
+func (s *Syncer) RegisterForATXSynced() chan struct{} {
+	ch := make(chan struct{})
+	if s.ListenToATXGossip() {
+		close(ch)
+		return ch
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.awaitATXSyncedCh = append(s.awaitATXSyncedCh, ch)
+	return ch
 }
 
 // ListenToGossip returns true if the node is listening to gossip for blocks/TXs data.
@@ -173,7 +193,7 @@ func (s *Syncer) ListenToATXGossip() bool {
 // IsSynced returns true if the node is in synced state.
 func (s *Syncer) IsSynced(ctx context.Context) bool {
 	res := s.getSyncState() == synced
-	// TODO: downgrade log after syncer stablized.
+	// TODO(kimmy): downgrade log after syncer stablized.
 	s.logger.WithContext(ctx).With().Info("node sync state",
 		log.Bool("synced", res),
 		log.Stringer("current", s.ticker.GetCurrentLayer()),
@@ -227,6 +247,13 @@ func (s *Syncer) isClosed() bool {
 
 func (s *Syncer) setATXSynced() {
 	s.atxSyncState.Store(synced)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, ch := range s.awaitATXSyncedCh {
+		close(ch)
+	}
+	s.awaitATXSyncedCh = make([]chan struct{}, 0)
 }
 
 func (s *Syncer) getATXSyncState() syncState {


### PR DESCRIPTION
## Motivation
Pull out some of the changes from https://github.com/spacemeshos/go-spacemesh/pull/3567 for easier review.

## Changes
The `syncer` that allows components of go-spacemesh to register for callbacks when sync states are reached is extended to allow to register for the ATX synced state.

Additionally the activation package is updated to listen for the new ATX synced state instead of waiting for full sync.

## Test Plan
Existing tests pass, new tests for new functionality.

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
