### PR TITLE
tortoise: use max base tick height to determine votable blocks

### DIFF
--- a/tortoise/full_test.go
+++ b/tortoise/full_test.go
@@ -357,7 +357,7 @@ func TestFullCountVotes(t *testing.T) {
 					b.Initialize()
 					layerBlocks = append(layerBlocks, b)
 				}
-				consensus.referenceHeight[lid.GetEpoch()] = localHeight
+				consensus.maxBaseTickHeight[lid.GetEpoch()] = localHeight
 				for _, block := range layerBlocks {
 					consensus.onBlock(lid, &block)
 				}

--- a/tortoise/threshold_test.go
+++ b/tortoise/threshold_test.go
@@ -92,7 +92,7 @@ func TestComputeThreshold(t *testing.T) {
 	}
 }
 
-func TestReferenceHeight(t *testing.T) {
+func TestMaxBaseHeight(t *testing.T) {
 	for _, tc := range []struct {
 		desc     string
 		epoch    int
@@ -113,19 +113,13 @@ func TestReferenceHeight(t *testing.T) {
 			desc:     "two",
 			epoch:    2,
 			heights:  []int{10, 20},
-			expected: 15,
+			expected: 20,
 		},
 		{
 			desc:     "median odd",
 			epoch:    3,
 			heights:  []int{30, 10, 20},
-			expected: 20,
-		},
-		{
-			desc:     "median even",
-			epoch:    4,
-			heights:  []int{30, 20, 10, 40},
-			expected: 25,
+			expected: 30,
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
@@ -138,7 +132,7 @@ func TestReferenceHeight(t *testing.T) {
 				}}
 				atx.SetID(&types.ATXID{byte(i + 1)})
 				require.NoError(t, activation.SignAtx(signing.NewEdSigner(), atx))
-				vAtx, err := atx.Verify(0, uint64(height))
+				vAtx, err := atx.Verify(uint64(height), 10)
 				require.NoError(t, err)
 				require.NoError(t, atxs.Add(cdb, vAtx, time.Time{}))
 			}

--- a/tortoise/verifying_test.go
+++ b/tortoise/verifying_test.go
@@ -612,7 +612,7 @@ func TestVerifying_Verify(t *testing.T) {
 
 			state := newState()
 			state.epochWeight = epochWeight
-			state.referenceHeight = referenceHeight
+			state.maxBaseTickHeight = referenceHeight
 			state.verified = verified
 			state.processed = processed
 			state.last = processed
@@ -620,7 +620,6 @@ func TestVerifying_Verify(t *testing.T) {
 			for _, layer := range state.layers {
 				for _, block := range layer.blocks {
 					state.blockRefs[block.id] = block
-					state.updateRefHeight(layer, block)
 				}
 			}
 


### PR DESCRIPTION
extracted from https://github.com/spacemeshos/go-spacemesh/issues/3573

blocks are generated using max base tick height from the atxs that are referenced by the proposals. ballots that vote for this block are expected to have higher tick height by one epoch, if such condition doesn't hold votes from this ballots are ineffective.

using max base tick height assumes that no smesher is faster by a whole epoch. if such smesher exists verifying tortoise will stop working. but the actual difference between current and previous solution is minimal, in previous solution verifying tortoise will stop working as soon as superfast smesher participated in building a block, and in current version we assume that it always participates in building a block.