### PR TITLE
[Merged by Bors] - tortoise: refactor layerVote to store only supported blocks

### DIFF
--- a/tortoise/full.go
+++ b/tortoise/full.go
@@ -47,16 +47,16 @@ func (f *full) countVotesFromBallots(logger log.Log, ballots []*ballotInfo) {
 				continue
 			}
 			empty := true
-			for _, bvote := range lvote.blocks {
-				if bvote.height > ballot.height {
+			for _, block := range lvote.blocks {
+				if block.height > ballot.height {
 					continue
 				}
-				switch bvote.vote {
+				switch lvote.getVote(block.id) {
 				case support:
 					empty = false
-					bvote.margin = bvote.margin.Add(ballot.weight)
+					block.margin = block.margin.Add(ballot.weight)
 				case against:
-					bvote.margin = bvote.margin.Sub(ballot.weight)
+					block.margin = block.margin.Sub(ballot.weight)
 				}
 			}
 			if empty {

--- a/tortoise/state.go
+++ b/tortoise/state.go
@@ -124,11 +124,6 @@ func (s *state) updateRefHeight(layer *layerInfo, block *blockInfo) {
 }
 
 type (
-	blockVote struct {
-		*blockInfo
-		vote sign
-	}
-
 	baseInfo struct {
 		id    types.BallotID
 		layer types.LayerID
@@ -204,11 +199,12 @@ func (v *votes) cutBefore(lid types.LayerID) {
 func (v *votes) find(lid types.LayerID, bid types.BlockID) sign {
 	for current := v.tail; current != nil; current = current.prev {
 		if current.lid == lid {
-			for _, block := range current.blocks {
+			for _, block := range current.supported {
 				if block.id == bid {
-					return block.vote
+					return support
 				}
 			}
+			return against
 		}
 	}
 	return abstain
@@ -216,17 +212,26 @@ func (v *votes) find(lid types.LayerID, bid types.BlockID) sign {
 
 type layerVote struct {
 	*layerInfo
-	vote   sign
-	blocks []blockVote
+	vote      sign
+	supported []*blockInfo
 
 	prev *layerVote
+}
+
+func (l *layerVote) getVote(bid types.BlockID) sign {
+	for _, block := range l.supported {
+		if block.id == bid {
+			return support
+		}
+	}
+	return against
 }
 
 func (l *layerVote) copy() *layerVote {
 	return &layerVote{
 		layerInfo: l.layerInfo,
 		vote:      l.vote,
-		blocks:    l.blocks,
+		supported: l.supported,
 		prev:      l.prev,
 	}
 }
@@ -248,15 +253,17 @@ func (l *layerVote) update(from types.LayerID, diff map[types.LayerID]map[types.
 	if exist && len(layerdiff) == 0 {
 		copied.vote = abstain
 	} else if exist && len(layerdiff) > 0 {
-		blocks := make([]blockVote, len(copied.blocks))
-		copy(blocks, copied.blocks)
-		copied.blocks = blocks
-		for i := range copied.blocks {
-			vote, exist := layerdiff[copied.blocks[i].id]
-			if exist {
-				copied.blocks[i].vote = vote
+		var supported []*blockInfo
+		for _, block := range copied.blocks {
+			vote, exist := layerdiff[block.id]
+			if exist && vote == against {
+				continue
+			}
+			if (exist && vote == support) || l.getVote(block.id) == support {
+				supported = append(supported, block)
 			}
 		}
+		copied.supported = supported
 	}
 	return copied
 }

--- a/tortoise/state_test.go
+++ b/tortoise/state_test.go
@@ -69,29 +69,23 @@ func TestVotesUpdate(t *testing.T) {
 		update := map[types.LayerID]map[types.BlockID]sign{}
 		for i := 0; i < last; i++ {
 			original.append(&layerVote{
-				vote: against,
-				blocks: []blockVote{
-					{
-						vote: support,
-						blockInfo: &blockInfo{
-							id: types.BlockID{byte(i)},
-						},
-					},
-				},
-				layerInfo: &layerInfo{lid: types.NewLayerID(uint32(i))},
+				layerInfo: &layerInfo{
+					lid: types.NewLayerID(uint32(i)),
+					blocks: []*blockInfo{{
+						id: types.BlockID{byte(i)},
+					}}},
 			})
 			update[types.NewLayerID(uint32(i))] = map[types.BlockID]sign{
-				{byte(i)}: against,
+				{byte(i)}: support,
 			}
 		}
 		cp := original.update(types.NewLayerID(0), update)
 		for c := original.tail; c != nil; c = c.prev {
-			require.Len(t, c.blocks, 1)
-			require.Equal(t, support, c.blocks[0].vote)
+			require.Len(t, c.supported, 0)
 		}
 		for c := cp.tail; c != nil; c = c.prev {
-			require.Len(t, c.blocks, 1)
-			require.Equal(t, against, c.blocks[0].vote)
+			require.Len(t, c.supported, 1)
+			require.Equal(t, support, c.getVote(c.supported[0].id))
 		}
 	})
 }

--- a/tortoise/state_test.go
+++ b/tortoise/state_test.go
@@ -73,7 +73,8 @@ func TestVotesUpdate(t *testing.T) {
 					lid: types.NewLayerID(uint32(i)),
 					blocks: []*blockInfo{{
 						id: types.BlockID{byte(i)},
-					}}},
+					}},
+				},
 			})
 			update[types.NewLayerID(uint32(i))] = map[types.BlockID]sign{
 				{byte(i)}: support,

--- a/tortoise/tortoise.go
+++ b/tortoise/tortoise.go
@@ -898,8 +898,7 @@ func validateConsistency(state *state, config Config, ballot *ballotInfo) bool {
 		if lvote.vote == abstain {
 			continue
 		}
-		for j := range lvote.blocks {
-			block := lvote.blocks[j]
+		for _, block := range lvote.blocks {
 			local, _ := getLocalVote(state, config, block)
 			if lvote.getVote(block.id) != local {
 				return false

--- a/tortoise/tortoise.go
+++ b/tortoise/tortoise.go
@@ -284,19 +284,19 @@ func (t *turtle) firstDisagreement(ctx context.Context, last types.LayerID, ball
 			)
 			return types.LayerID{}, nil
 		}
-		for _, bvote := range lvote.blocks {
-			vote, _, err := t.getFullVote(ctx, bvote.blockInfo)
+		for _, block := range lvote.blocks {
+			vote, _, err := t.getFullVote(ctx, block)
 			if err != nil {
 				return types.LayerID{}, err
 			}
-			if vote != bvote.vote {
+			if bvote := lvote.getVote(block.id); vote != bvote {
 				t.logger.With().Debug("found disagreement on a block",
 					ballot.id,
-					bvote.id,
+					block.id,
 					log.Stringer("block_layer", lvote.lid),
 					log.Stringer("ballot_layer", ballot.layer),
 					log.Stringer("local_vote", vote),
-					log.Stringer("vote", bvote.vote),
+					log.Stringer("vote", bvote),
 				)
 				return lvote.lid, nil
 			}
@@ -327,25 +327,26 @@ func (t *turtle) encodeVotes(
 		if lvote.vote == abstain && lvote.hareTerminated {
 			return nil, fmt.Errorf("ballot %s can't be used as a base ballot", base.id)
 		}
-		for _, bvote := range lvote.blocks {
-			vote, _, err := t.getFullVote(ctx, bvote.blockInfo)
+		for _, block := range lvote.blocks {
+			vote, _, err := t.getFullVote(ctx, block)
 			if err != nil {
 				return nil, err
 			}
 			// ballot vote is consistent with local opinion, exception is not necessary
-			if vote == bvote.vote {
+			bvote := lvote.getVote(block.id)
+			if vote == bvote {
 				continue
 			}
 			switch vote {
 			case support:
-				logger.With().Debug("support before base ballot", bvote.id, bvote.layer)
-				votes.Support = append(votes.Support, bvote.id)
+				logger.With().Debug("support before base ballot", block.id, block.layer)
+				votes.Support = append(votes.Support, block.id)
 			case against:
-				logger.With().Debug("explicit against overwrites base ballot opinion", bvote.id, bvote.layer)
-				votes.Against = append(votes.Against, bvote.id)
+				logger.With().Debug("explicit against overwrites base ballot opinion", block.id, block.layer)
+				votes.Against = append(votes.Against, block.id)
 			case abstain:
 				logger.With().Error("layers that are not terminated should have been encoded earlier",
-					bvote.id, bvote.layer,
+					block.id, block.layer,
 				)
 			}
 		}
@@ -877,19 +878,13 @@ func (t *turtle) decodeExceptions(base, ballot *ballotInfo, exceptions types.Vot
 		layerdiff, exist := diff[lid]
 		if exist && len(layerdiff) == 0 {
 			lvote.vote = abstain
-		}
-		for _, block := range layer.blocks {
-			bvote := blockVote{
-				blockInfo: block,
-				vote:      against,
-			}
-			if len(layerdiff) > 0 {
+		} else if exist && len(layerdiff) > 0 {
+			for _, block := range layer.blocks {
 				vote, exist := layerdiff[block.id]
-				if exist {
-					bvote.vote = vote
+				if exist && vote == support {
+					lvote.supported = append(lvote.supported, block)
 				}
 			}
-			lvote.blocks = append(lvote.blocks, bvote)
 		}
 		ballot.votes.append(&lvote)
 	}
@@ -904,9 +899,9 @@ func validateConsistency(state *state, config Config, ballot *ballotInfo) bool {
 			continue
 		}
 		for j := range lvote.blocks {
-			local, _ := getLocalVote(state, config, lvote.blocks[j].blockInfo)
-			vote := lvote.blocks[j].vote
-			if vote != local {
+			block := lvote.blocks[j]
+			local, _ := getLocalVote(state, config, block)
+			if lvote.getVote(block.id) != local {
 				return false
 			}
 		}


### PR DESCRIPTION
extracted from https://github.com/spacemeshos/go-spacemesh/issues/3573

this refactoring makes it unnecessary to modify layer votes for each ballot after late block is received. 
for example late block can be received after recovering from partition.