### PR TITLE
[Merged by Bors] - Don't build in `setup env` CI step in every job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
             ${{ runner.os }}-cache-go-${{ env.go-version }}-
       - name: fmt, tidy, lint
         run: |
-          make
+          make install
           make tidy
           make test-fmt
       - name: staticcheck
@@ -98,7 +98,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cache-go-${{ env.go-version }}-
       - name: setup env
-        run: make
+        run: make install
       - name: golangci-lint
         run: make golangci-lint-github-action
 
@@ -157,7 +157,7 @@ jobs:
             ${{ runner.os }}-cache-go-${{ env.go-version }}-unittests-
             ${{ runner.os }}-cache-go-${{ env.go-version }}-
       - name: setup env
-        run: make
+        run: make install
       - name: Clear test cache
         run: make clear-test-cache
       - name: unit tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cache-go-${{ env.go-version }}-
       - name: setup env
-        run: make install get-libs
+        run: make install
       - name: golangci-lint
         run: make golangci-lint-github-action
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cache-go-${{ env.go-version }}-
       - name: setup env
-        run: make install
+        run: make install get-libs
       - name: golangci-lint
         run: make golangci-lint-github-action
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,36 @@ jobs:
       - name: golangci-lint
         run: make golangci-lint-github-action
 
+  build:
+    runs-on: ${{ matrix.os }}
+    needs: filter-changes
+    if: ${{ needs.filter-changes.outputs.nondocchanges == 'true' }}
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: set up go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.go-version }}
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-cache-go-${{ env.go-version }}-build-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-cache-go-${{ env.go-version }}-build-
+            ${{ runner.os }}-cache-go-${{ env.go-version }}-
+      - name: setup env
+        run: make install
+      - name: build
+        timeout-minutes: 5
+        run: make build
+
   unittests:
     runs-on: ${{ matrix.os }}
     needs: filter-changes

--- a/Makefile
+++ b/Makefile
@@ -153,20 +153,20 @@ lint: golangci-lint
 	go vet ./...
 .PHONY: lint
 
-golangci-lint:
+golangci-lint: get-libs
 	golangci-lint run --config .golangci.yml
 .PHONY: golangci-lint
 
 # Auto-fixes golangci-lint issues where possible.
-golangci-lint-fix:
+golangci-lint-fix: get-libs
 	golangci-lint run --config .golangci.yml --fix
 .PHONY: golangci-lint-fix
 
-golangci-lint-github-action:
+golangci-lint-github-action: get-libs
 	./bin/golangci-lint run --config .golangci.yml --out-format=github-actions
 .PHONY: golangci-lint-github-action
 
-cover:
+cover: get-libs
 	@$(ULIMIT) CGO_LDFLAGS="$(CGO_TEST_LDFLAGS)" go test -coverprofile=cover.out -timeout 0 -p 1 $(UNIT_TESTS)
 .PHONY: cover
 


### PR DESCRIPTION
## Motivation
The default target installs deps and builds. The building part is not required to set up the environment in CI.

## Changes
Call `make install` instead of `make` in setup env step in CI.

## Test Plan
CI passes

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
