### PR TITLE
Refactor `AwaitLayer` to use contexts

### DIFF
--- a/activation/activation.go
+++ b/activation/activation.go
@@ -276,15 +276,6 @@ func (b *Builder) SignAtx(atx *types.ActivationTx) error {
 	return nil
 }
 
-func (b *Builder) waitOrStop(ctx context.Context, ch chan struct{}) error {
-	select {
-	case <-ch:
-		return nil
-	case <-ctx.Done():
-		return ErrStopRequested
-	}
-}
-
 func (b *Builder) run(ctx context.Context) {
 	if err := b.generateProof(); err != nil {
 		b.log.Error("Failed to generate proof: %v", err)

--- a/activation/interface.go
+++ b/activation/interface.go
@@ -1,6 +1,7 @@
 package activation
 
 import (
+	"context"
 	"time"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
@@ -21,7 +22,7 @@ type nipostValidator interface {
 }
 
 type layerClock interface {
-	AwaitLayer(layerID types.LayerID) chan struct{}
+	AwaitLayer(ctx context.Context, layerID types.LayerID) context.Context
 	GetCurrentLayer() types.LayerID
 	LayerToTime(types.LayerID) time.Time
 }

--- a/activation/mocks/interface.go
+++ b/activation/mocks/interface.go
@@ -5,6 +5,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 	time "time"
 
@@ -154,17 +155,17 @@ func (m *MocklayerClock) EXPECT() *MocklayerClockMockRecorder {
 }
 
 // AwaitLayer mocks base method.
-func (m *MocklayerClock) AwaitLayer(layerID types.LayerID) chan struct{} {
+func (m *MocklayerClock) AwaitLayer(ctx context.Context, layerID types.LayerID) context.Context {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AwaitLayer", layerID)
-	ret0, _ := ret[0].(chan struct{})
+	ret := m.ctrl.Call(m, "AwaitLayer", ctx, layerID)
+	ret0, _ := ret[0].(context.Context)
 	return ret0
 }
 
 // AwaitLayer indicates an expected call of AwaitLayer.
-func (mr *MocklayerClockMockRecorder) AwaitLayer(layerID interface{}) *gomock.Call {
+func (mr *MocklayerClockMockRecorder) AwaitLayer(ctx, layerID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AwaitLayer", reflect.TypeOf((*MocklayerClock)(nil).AwaitLayer), layerID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AwaitLayer", reflect.TypeOf((*MocklayerClock)(nil).AwaitLayer), ctx, layerID)
 }
 
 // GetCurrentLayer mocks base method.

--- a/blocks/certifier.go
+++ b/blocks/certifier.go
@@ -156,7 +156,7 @@ func (c *Certifier) isShuttingDown() bool {
 func (c *Certifier) run() error {
 	for layer := c.layerClock.GetCurrentLayer(); ; layer = layer.Add(1) {
 		select {
-		case <-c.layerClock.AwaitLayer(layer):
+		case <-c.layerClock.AwaitLayer(c.ctx, layer).Done():
 			c.prune()
 		case <-c.ctx.Done():
 			return fmt.Errorf("context done: %w", c.ctx.Err())

--- a/blocks/certifier.go
+++ b/blocks/certifier.go
@@ -155,12 +155,13 @@ func (c *Certifier) isShuttingDown() bool {
 
 func (c *Certifier) run() error {
 	for layer := c.layerClock.GetCurrentLayer(); ; layer = layer.Add(1) {
+		<-c.layerClock.AwaitLayer(c.ctx, layer).Done()
 		select {
-		case <-c.layerClock.AwaitLayer(c.ctx, layer).Done():
-			c.prune()
 		case <-c.ctx.Done():
 			return fmt.Errorf("context done: %w", c.ctx.Err())
+		default:
 		}
+		c.prune()
 	}
 }
 

--- a/blocks/interface.go
+++ b/blocks/interface.go
@@ -19,7 +19,7 @@ type conservativeState interface {
 }
 
 type layerClock interface {
-	AwaitLayer(layerID types.LayerID) chan struct{}
+	AwaitLayer(ctx context.Context, layerID types.LayerID) context.Context
 	GetCurrentLayer() types.LayerID
 }
 

--- a/blocks/mocks/mocks.go
+++ b/blocks/mocks/mocks.go
@@ -126,17 +126,17 @@ func (m *MocklayerClock) EXPECT() *MocklayerClockMockRecorder {
 }
 
 // AwaitLayer mocks base method.
-func (m *MocklayerClock) AwaitLayer(layerID types.LayerID) chan struct{} {
+func (m *MocklayerClock) AwaitLayer(ctx context.Context, layerID types.LayerID) context.Context {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AwaitLayer", layerID)
-	ret0, _ := ret[0].(chan struct{})
+	ret := m.ctrl.Call(m, "AwaitLayer", ctx, layerID)
+	ret0, _ := ret[0].(context.Context)
 	return ret0
 }
 
 // AwaitLayer indicates an expected call of AwaitLayer.
-func (mr *MocklayerClockMockRecorder) AwaitLayer(layerID interface{}) *gomock.Call {
+func (mr *MocklayerClockMockRecorder) AwaitLayer(ctx, layerID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AwaitLayer", reflect.TypeOf((*MocklayerClock)(nil).AwaitLayer), layerID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AwaitLayer", reflect.TypeOf((*MocklayerClock)(nil).AwaitLayer), ctx, layerID)
 }
 
 // GetCurrentLayer mocks base method.

--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -173,7 +173,7 @@ type TickProvider interface {
 	GetGenesisTime() time.Time
 	LayerToTime(types.LayerID) time.Time
 	Close()
-	AwaitLayer(types.LayerID) chan struct{}
+	AwaitLayer(context.Context, types.LayerID) context.Context
 }
 
 func loadConfig(cmd *cobra.Command) (*config.Config, error) {

--- a/hare/flows_test.go
+++ b/hare/flows_test.go
@@ -227,9 +227,7 @@ func (m *mockClock) AwaitLayer(ctx context.Context, layer types.LayerID) context
 		cancel()
 		return ctx
 	}
-	cancels := m.layersSubscriptions[layer]
-	cancels = append(cancels, cancel)
-	m.layersSubscriptions[layer] = cancels
+	m.layersSubscriptions[layer] = append(m.layersSubscriptions[layer], cancel)
 	return ctx
 }
 

--- a/hare/hare.go
+++ b/hare/hare.go
@@ -53,7 +53,7 @@ type RoundClock interface {
 // layer number to a clock time.
 type LayerClock interface {
 	LayerToTime(id types.LayerID) time.Time
-	AwaitLayer(layerID types.LayerID) chan struct{}
+	AwaitLayer(ctx context.Context, layerID types.LayerID) context.Context
 	GetCurrentLayer() types.LayerID
 }
 
@@ -436,7 +436,7 @@ func (h *Hare) tickLoop(ctx context.Context) {
 
 	for layer := h.layerClock.GetCurrentLayer(); ; layer = layer.Add(1) {
 		select {
-		case <-h.layerClock.AwaitLayer(layer):
+		case <-h.layerClock.AwaitLayer(ctx, layer).Done():
 			if time.Since(h.layerClock.LayerToTime(layer)) > (time.Duration(h.config.WakeupDelta) * time.Second) {
 				h.With().Warning("missed hare window, skipping layer", layer)
 				continue

--- a/timesync/ticker.go
+++ b/timesync/ticker.go
@@ -182,8 +182,8 @@ func init() {
 	close(closedChan)
 }
 
-// AwaitLayer returns a channel that will be signaled when layer id layerID was ticked by the clock, or if this layer has passed
-// while sleeping. it does so by closing the returned channel.
+// AwaitLayer returns a context that will be canceled when layer with given id is ticked by the clock,
+// or if this layer has passed while sleeping.
 func (t *Ticker) AwaitLayer(ctx context.Context, layerID types.LayerID) context.Context {
 	t.mu.Lock()
 	defer t.mu.Unlock()

--- a/timesync/ticker.go
+++ b/timesync/ticker.go
@@ -197,13 +197,7 @@ func (t *Ticker) AwaitLayer(ctx context.Context, layerID types.LayerID) context.
 		return layerCtx
 	}
 
-	cancels := t.layersSubscriptions[layerID]
-	if cancels == nil {
-		cancels = make([]context.CancelFunc, 0, 1)
-	}
-
-	cancels = append(cancels, cancel)
-	t.layersSubscriptions[layerID] = cancels
+	t.layersSubscriptions[layerID] = append(t.layersSubscriptions[layerID], cancel)
 
 	return layerCtx
 }


### PR DESCRIPTION
## Changes
Refactored `AwaitLayer` to base on Go's contexts instead of channels.

The context returned from `AwaitLayer` is cancelled when it is time for the given layer.

## Test Plan
unit tests

## DevOps Notes
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
