### PR TITLE
[Merged by Bors] - Fix tests sharing state

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ endif
 install:
 	go run scripts/check-go-version.go --major 1 --minor 18
 	go mod download
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.50.0
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.48.0
 	go install github.com/spacemeshos/go-scale/scalegen
 	go install github.com/golang/mock/mockgen
 	go install gotest.tools/gotestsum@v1.8.2
@@ -151,12 +151,12 @@ test-fmt:
 
 lint: get-libs
 	go vet ./...
-	./bin/golangci-lint run --config .golangci.yml
+	golangci-lint run --config .golangci.yml
 .PHONY: lint
 
 # Auto-fixes golangci-lint issues where possible.
 lint-fix: get-libs
-	./bin/golangci-lint run --config .golangci.yml --fix
+	golangci-lint run --config .golangci.yml --fix
 .PHONY: lint-fix
 
 lint-github-action: get-libs

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ endif
 install:
 	go run scripts/check-go-version.go --major 1 --minor 18
 	go mod download
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.48.0
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.50.0
 	go install github.com/spacemeshos/go-scale/scalegen
 	go install github.com/golang/mock/mockgen
 	go install gotest.tools/gotestsum@v1.8.2
@@ -151,12 +151,12 @@ test-fmt:
 
 lint: get-libs
 	go vet ./...
-	golangci-lint run --config .golangci.yml
+	./bin/golangci-lint run --config .golangci.yml
 .PHONY: lint
 
 # Auto-fixes golangci-lint issues where possible.
 lint-fix: get-libs
-	golangci-lint run --config .golangci.yml --fix
+	./bin/golangci-lint run --config .golangci.yml --fix
 .PHONY: lint-fix
 
 lint-github-action: get-libs

--- a/filesystem/dirs_test.go
+++ b/filesystem/dirs_test.go
@@ -14,21 +14,19 @@ import (
 var RootFolder = "/"
 
 func TestPathExists(t *testing.T) {
-	tempFile := filepath.Join(os.TempDir(), "testdir"+uuid.New().String()+"_"+t.Name())
+	tempFile := filepath.Join(t.TempDir(), uuid.New().String()+"_"+t.Name())
 	_, err := os.Create(tempFile)
 	require.NoError(t, err, "couldn't create temp path")
 	assert.True(t, PathExists(tempFile), "expecting existence of path")
-	os.RemoveAll(tempFile)
 }
 
 func TestGetFullDirectoryPath(t *testing.T) {
-	tempFile := filepath.Join(os.TempDir(), "testdir"+uuid.New().String()+"_"+t.Name())
+	tempFile := filepath.Join(t.TempDir(), "testdir"+uuid.New().String()+"_"+t.Name())
 	err := os.MkdirAll(tempFile, os.ModeDir)
 	assert.NoError(t, err, "creating temp dir failed")
 	aPath, err := GetFullDirectoryPath(tempFile)
 	assert.Equal(t, tempFile, aPath, "Path is different")
 	assert.NoError(t, err)
-	os.RemoveAll(tempFile)
 }
 
 func TestGetUserHomeDirectory(t *testing.T) {


### PR DESCRIPTION
## Motivation
Fix some tests to not share state: specifically tests related to PoST used to share the same directory for their session, leaking data from one test to the next.

## Changes
The change here makes sure that all tests use their own directory and properly cleanup afterwards. `t.TempDir()` creates a unique test directory upon each call that is automatically deleted when a test ends - successful or not.

## Test Plan
Updated tests still pass.

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
