### PR TITLE
[Merged by Bors] - Target go 1.19 with go-spacemesh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 
 env:
-  go-version: "1.18"
+  go-version: "1.19"
   GCLOUD_KEY: ${{ secrets.GCLOUD_KEY }}
   PROJECT_NAME: ${{ secrets.PROJECT_NAME }}
   CLUSTER_NAME: ${{ secrets.CLUSTER_NAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.18.2'
+          go-version: '1.19'
       
       - if: matrix.os == 'windows-latest'
         name: Install dependencies in windows

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -57,7 +57,7 @@ output:
 linters-settings:
   staticcheck:
     # Select the Go version to target. The default is '1.13'.
-    go: "1.18"
+    go: "1.19"
     # https://staticcheck.io/docs/options#checks
     checks: ["all"]
 
@@ -170,7 +170,7 @@ linters-settings:
     capital: false
   gofumpt:
     # Select the Go version to target. The default is `1.15`.
-    lang-version: "1.18"
+    lang-version: "1.19"
     # Choose whether or not to use the extra rules that are disabled
     # by default
     extra-rules: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,24 +8,24 @@ ARG TZ=US/Eastern
 ENV TZ $TZ
 USER root
 RUN bash -c "for i in {1..9}; do mkdir -p /usr/share/man/man\$i; done" \
- && echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90noninteractive \
- && echo 'DPkg::Options "--force-confnew";' >> /etc/apt/apt.conf.d/90noninteractive \
- && apt-get update --fix-missing \
- && apt-get install -qy --no-install-recommends \
-    ca-certificates \
-    tzdata \
-    locales \
-    procps \
-    net-tools \
-    apt-transport-https \
-    file \
-    # -- it allows to start with nvidia-docker runtime --
-    #libnvidia-compute-390 \
- && apt-get clean \
- && rm -rf /var/lib/apt/lists/* \
- && locale-gen en_US.UTF-8 \
- && update-locale LANG=en_US.UTF-8 \
- && echo "$TZ" > /etc/timezone
+   && echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90noninteractive \
+   && echo 'DPkg::Options "--force-confnew";' >> /etc/apt/apt.conf.d/90noninteractive \
+   && apt-get update --fix-missing \
+   && apt-get install -qy --no-install-recommends \
+   ca-certificates \
+   tzdata \
+   locales \
+   procps \
+   net-tools \
+   apt-transport-https \
+   file \
+   # -- it allows to start with nvidia-docker runtime --
+   #libnvidia-compute-390 \
+   && apt-get clean \
+   && rm -rf /var/lib/apt/lists/* \
+   && locale-gen en_US.UTF-8 \
+   && update-locale LANG=en_US.UTF-8 \
+   && echo "$TZ" > /etc/timezone
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8
 ENV LC_ALL en_US.UTF-8
@@ -34,39 +34,8 @@ ENV NVIDIA_VISIBLE_DEVICES all
 ENV NVIDIA_DRIVER_CAPABILITIES compute,utility,display
 LABEL com.nvidia.volumes.needed="nvidia_driver"
 
-FROM linux as golang
-ARG TARGETPLATFORM
-ENV GOLANG_MAJOR_VERSION 1
-ENV GOLANG_MINOR_VERSION 18
-ENV GOLANG_PATCH_VERSION 1
-ENV GOLANG_VERSION $GOLANG_MAJOR_VERSION.$GOLANG_MINOR_VERSION.$GOLANG_PATCH_VERSION
-ENV GOPATH /go
-ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
-RUN set -ex \
- && apt-get update --fix-missing \
- && apt-get install -qy --no-install-recommends \
-    gcc \
-	libc6-dev \
-    git \
-    bash \
-    sudo \
-    unzip \
-    make \
-    curl \
- && apt-get clean \
- && rm -rf /var/lib/apt/lists/* \
- && if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then export ARCHITECTURE=arm64; else export ARCHITECTURE=amd64; fi \
- && curl -L https://golang.org/dl/go${GOLANG_VERSION}.linux-${ARCHITECTURE}.tar.gz | tar zx -C /usr/local \
- && go version \
- && mkdir -p "$GOPATH/src" "$GOPATH/bin" \
- && chmod -R 777 "$GOPATH"
-
-FROM golang as build_base
+FROM golang:1.19 as builder
 WORKDIR /go/src/github.com/spacemeshos/go-spacemesh
-
-# Force the go compiler to use modules
-ENV GO111MODULE=on
-ENV GOPROXY=https://proxy.golang.org
 
 # We want to populate the module cache based on the go.{mod,sum} files.
 COPY go.mod .
@@ -77,8 +46,6 @@ COPY scripts/* scripts/
 # RUN go run scripts/check-go-version.go --major 1 --minor 15
 RUN go mod download
 
-# This image builds the go-spacemesh server
-FROM build_base AS server_builder
 # Here we copy the rest of the source code
 COPY . .
 
@@ -91,12 +58,12 @@ RUN make gen-p2p-identity
 FROM linux AS spacemesh
 
 # Finally we copy the statically compiled Go binary.
-COPY --from=server_builder /go/src/github.com/spacemeshos/go-spacemesh/build/go-spacemesh /bin/
-COPY --from=server_builder /go/src/github.com/spacemeshos/go-spacemesh/build/go-harness /bin/
-COPY --from=server_builder /go/src/github.com/spacemeshos/go-spacemesh/build/libgpu-setup.so /bin/
+COPY --from=builder /go/src/github.com/spacemeshos/go-spacemesh/build/go-spacemesh /bin/
+COPY --from=builder /go/src/github.com/spacemeshos/go-spacemesh/build/go-harness /bin/
+COPY --from=builder /go/src/github.com/spacemeshos/go-spacemesh/build/libgpu-setup.so /bin/
 # TODO(nkryuchkov): uncomment when go-svm is imported
-#COPY --from=server_builder /go/src/github.com/spacemeshos/go-spacemesh/build/libsvm.so /bin/
-COPY --from=server_builder /go/src/github.com/spacemeshos/go-spacemesh/build/gen-p2p-identity /bin/
+#COPY --from=builder /go/src/github.com/spacemeshos/go-spacemesh/build/libsvm.so /bin/
+COPY --from=builder /go/src/github.com/spacemeshos/go-spacemesh/build/gen-p2p-identity /bin/
 
 ENTRYPOINT ["/bin/go-harness"]
 EXPOSE 7513

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ ifeq ($(BRANCH),$(filter $(BRANCH),staging trying))
 endif
 
 install:
-	go run scripts/check-go-version.go --major 1 --minor 18
+	go run scripts/check-go-version.go --major 1 --minor 19
 	go mod download
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.50.0
 	go install github.com/spacemeshos/go-scale/scalegen

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Since the project uses Go Modules it is best to place the code **outside** your 
 
 Building is supported on OS X, Linux, FreeBSD, and Windows.
 
-Install [Go 1.18 or later](https://golang.org/dl/) for your platform, if you haven't already.
+Install [Go 1.19 or later](https://golang.org/dl/) for your platform, if you haven't already.
 
 On Windows you need to install `make` via [msys2](https://www.msys2.org/), [MingGW-w64](http://mingw-w64.org/doku.php) or [mingw](https://chocolatey.org/packages/mingw)
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ clone_folder: c:\gopath\src\github.com\spacemeshos\go-spacemesh\
 environment:
   GOPATH: c:\gopath
 
-stack: go 1.18
+stack: go 1.19
 
 before_build:
   - choco install make

--- a/config/genesis.go
+++ b/config/genesis.go
@@ -3,7 +3,7 @@ package config
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
@@ -50,7 +50,7 @@ func (g *GenesisConfig) Diff(other *GenesisConfig) string {
 
 // LoadFromFile loads config from file.
 func (g *GenesisConfig) LoadFromFile(filename string) error {
-	buf, err := ioutil.ReadFile(filename)
+	buf, err := os.ReadFile(filename)
 	if err != nil {
 		return err
 	}
@@ -63,7 +63,7 @@ func (g *GenesisConfig) WriteToFile(filename string) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(filename, buf, 0o644)
+	return os.WriteFile(filename, buf, 0o644)
 }
 
 // ToAccounts creates list of types.Account instance from config.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/spacemeshos/go-spacemesh
 
-go 1.18
+go 1.19
 
 require (
 	crawshaw.io/sqlite v0.3.3-0.20211227050848-2cdb5c1a86a1

--- a/systest/Dockerfile
+++ b/systest/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:alpine3.15 as build
+FROM golang:1.19-alpine as build
 RUN apk add libc6-compat gcc musl-dev
 WORKDIR /build/
 COPY . .


### PR DESCRIPTION
## Motivation
With Go 1.19 now being > 2 months old and 1.20 being released in ~ 4 months go-spacemesh could be updated to target the most recent go version.

## Changes
 I updated the github actions, go.mod file and REAMDE.md

## Test Plan
Existing tests pass.

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
