### PR TITLE
[Merged by Bors] - Fix race condition in Builder::StartSmeshing

### DIFF
--- a/activation/activation.go
+++ b/activation/activation.go
@@ -194,11 +194,6 @@ func (b *Builder) Smeshing() bool {
 	return b.started.Load()
 }
 
-// Finished returns true iff atx builder is not smeshing.
-func (b *Builder) Finished() bool {
-	return !b.Smeshing()
-}
-
 // StartSmeshing is the main entry point of the atx builder.
 // It runs the main loop of the builder and shouldn't be called more than once.
 // If the post data is incomplete or missing, data creation

--- a/activation/activation_test.go
+++ b/activation/activation_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/spacemeshos/go-spacemesh/activation/mocks"
 	atypes "github.com/spacemeshos/go-spacemesh/activation/types"
@@ -453,28 +454,32 @@ func TestBuilder_StartSmeshingAfterError(t *testing.T) {
 }
 
 func TestBuilder_RestartSmeshing(t *testing.T) {
-	cdb := newCachedDB(t)
-	atxHdlr := newAtxHandler(t, cdb)
-	net.atxHdlr = atxHdlr
-	cfg := Config{
-		CoinbaseAccount: coinbase,
-		GoldenATXID:     goldenATXID,
-		LayersPerEpoch:  layersPerEpoch,
+	getBuilder := func(t *testing.T) *Builder {
+		cdb := newCachedDB(t)
+		atxHdlr := newAtxHandler(t, cdb)
+		net.atxHdlr = atxHdlr
+		cfg := Config{
+			CoinbaseAccount: coinbase,
+			GoldenATXID:     goldenATXID,
+			LayersPerEpoch:  layersPerEpoch,
+		}
+		sessionChan := make(chan struct{})
+		close(sessionChan)
+		builder := NewBuilder(cfg, sig.NodeID(), sig, cdb, atxHdlr, net, nipostBuilderMock,
+			&postSetupProviderMock{sessionChan: sessionChan},
+			layerClockMock, &mockSyncer{}, logtest.New(t).WithName("atxBuilder"))
+		builder.initialPost = initialPost
+		return builder
 	}
-	sessionChan := make(chan struct{})
-	close(sessionChan)
-	builder := NewBuilder(cfg, sig.NodeID(), sig, cdb, atxHdlr, net, nipostBuilderMock,
-		&postSetupProviderMock{sessionChan: sessionChan},
-		layerClockMock, &mockSyncer{}, logtest.New(t).WithName("atxBuilder"))
-	builder.initialPost = initialPost
 
 	t.Run("Single threaded", func(t *testing.T) {
+		builder := getBuilder(t)
 		for i := 0; i < 100; i++ {
 			require.NoError(t, builder.StartSmeshing(types.Address{}, atypes.PostSetupOpts{}))
-			require.Never(t, builder.Finished, 400*time.Microsecond, 50*time.Microsecond, "failed on execution %d", i)
+			require.Never(t, func() bool { return !builder.Smeshing() }, 400*time.Microsecond, 50*time.Microsecond, "failed on execution %d", i)
 			require.Truef(t, builder.Smeshing(), "failed on execution %d", i)
 			require.NoError(t, builder.StopSmeshing(true))
-			require.Eventually(t, builder.Finished, 10*time.Millisecond, time.Millisecond, "failed on execution %d", i)
+			require.Eventually(t, func() bool { return !builder.Smeshing() }, 10*time.Millisecond, time.Millisecond, "failed on execution %d", i)
 		}
 	})
 
@@ -482,14 +487,18 @@ func TestBuilder_RestartSmeshing(t *testing.T) {
 		// Meant to be run with -race to detect races.
 		// It cannot check `builder.Smeshing()` as Start/Stop is happening from many goroutines simultaneously.
 		// Both Start and Stop can fail as it is not known if builder is smeshing or not.
+		builder := getBuilder(t)
+		eg, _ := errgroup.WithContext(context.Background())
 		for worker := 0; worker < 10; worker += 1 {
-			go func() {
+			eg.Go(func() error {
 				for i := 0; i < 100; i++ {
 					builder.StartSmeshing(types.Address{}, atypes.PostSetupOpts{})
 					builder.StopSmeshing(true)
 				}
-			}()
+				return nil
+			})
 		}
+		eg.Wait()
 	})
 }
 


### PR DESCRIPTION
## Motivation
There is a race condition in `StartSmeshing()` happening when it is called repeatedly with `StopSmeshing()` (not even concurrently). The race is on the atomic boolean `started`. It is set to false in the spawned goroutine (which is fine) and also in `StopSmeshing()` (which is not fine because it no longer serves as a signalling mechanism that Builder stopped smeshing).

Consider the following:

1. `StartSmeshing()`
   1. `started` is set to true
   2. goroutine is spawned
2. `StopSmeshing()`
   1. `started` is set to false. At this point, one can already restart smeshing
   2. b.stop() - cancel context, the goroutine starts to shutdown
3. `StartSmeshing()`
   1. `started` is set to true
   2. goroutine finishes. It sets `started` back to false. Builder state is broken now. It is smeshing, but `Smeshing()` returns false.

Closes #3066 

## Changes
Removed setting `started = false` in `StopSmeshing()`. Added more tests and fixed existing ones

## Test Plan
Unit tests. Tests now pass with `-race` flag.

## DevOps Notes
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
