### PR TITLE
[Merged by Bors] - Increase timeout in TestBuilder_RestartSmeshing

### DIFF
--- a/activation/activation_test.go
+++ b/activation/activation_test.go
@@ -480,7 +480,7 @@ func TestBuilder_RestartSmeshing(t *testing.T) {
 			require.Never(t, func() bool { return !builder.Smeshing() }, 400*time.Microsecond, 50*time.Microsecond, "failed on execution %d", i)
 			require.Truef(t, builder.Smeshing(), "failed on execution %d", i)
 			require.NoError(t, builder.StopSmeshing(true))
-			require.Eventually(t, func() bool { return !builder.Smeshing() }, 10*time.Millisecond, time.Millisecond, "failed on execution %d", i)
+			require.Eventually(t, func() bool { return !builder.Smeshing() }, 100*time.Millisecond, time.Millisecond, "failed on execution %d", i)
 		}
 	})
 


### PR DESCRIPTION
Closes #3660 

## Changes
Increased timeout in `Eventually(...)` from 10ms to 100ms. With 10ms I observed 1/100 fails. With 100ms - 500/500 passes. (tested locally).

## DevOps Notes
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
