### PR TITLE
[Merged by Bors] - use opinion hash for verifying tortoise

### DIFF
--- a/tortoise/algorithm.go
+++ b/tortoise/algorithm.go
@@ -176,7 +176,7 @@ func (t *Tortoise) TallyVotes(ctx context.Context, lid types.LayerID) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	if err := t.trtl.onLayer(ctx, lid); err != nil {
-		t.logger.Error("failed on layer", lid, log.Err(err))
+		t.logger.With().Error("failed on layer", lid, log.Err(err))
 	}
 }
 

--- a/tortoise/state.go
+++ b/tortoise/state.go
@@ -60,9 +60,7 @@ type (
 		evicted types.LayerID
 
 		changedOpinion struct {
-			// sector of layers on which opinion is different from hdist
-			// once max falls out of hdist distance - opinion must
-			// be recomputed starting from min layer
+			// sector of layers where opinion is different from previously computed opinion
 			min, max types.LayerID
 		}
 

--- a/tortoise/state.go
+++ b/tortoise/state.go
@@ -40,8 +40,8 @@ type (
 		margin weight
 
 		validity sign
-		// if validity requires persisting it to the disk
-		dirty bool
+		// persisted validity
+		persisted sign
 	}
 
 	state struct {

--- a/tortoise/state.go
+++ b/tortoise/state.go
@@ -61,8 +61,8 @@ type (
 
 		changedOpinion struct {
 			// sector of layers on which opinion is different from hdist
-			// once max fall out of hdist distance - opinion needs
-			// can be recomputed starting from min layer
+			// once max falls out of hdist distance - opinion must
+			// be recomputed starting from min layer
 			min, max types.LayerID
 		}
 

--- a/tortoise/tortoise.go
+++ b/tortoise/tortoise.go
@@ -485,7 +485,7 @@ func (t *turtle) verifyLayers() error {
 				}
 			}
 			if block.validity == abstain {
-				logger.With().Panic("bug: layer should not be verified if there is an undecided block", target, block.id)
+				logger.With().Fatal("bug: layer should not be verified if there is an undecided block", target, block.id)
 			}
 			err := t.updater.UpdateBlockValidity(block.id, target, block.validity == support)
 			if err != nil {

--- a/tortoise/tortoise.go
+++ b/tortoise/tortoise.go
@@ -75,10 +75,6 @@ func (t *turtle) init(ctx context.Context, genesisLayer *types.Layer) {
 			id:     ballot.ID(),
 			layer:  ballot.LayerIndex,
 			weight: util.WeightFromUint64(0),
-			conditions: conditions{
-				baseGood:   true,
-				consistent: true,
-			},
 		}
 		t.addBallot(binfo)
 	}
@@ -93,6 +89,8 @@ func (t *turtle) init(ctx context.Context, genesisLayer *types.Layer) {
 		t.layers[genesis].blocks = append(t.layers[genesis].blocks, blinfo)
 		t.blockRefs[blinfo.id] = blinfo
 	}
+	t.layer(genesis).computeOpinion(t.Hdist, genesis)
+
 	t.last = genesis
 	t.processed = genesis
 	t.verified = genesis
@@ -340,7 +338,7 @@ func (t *turtle) encodeVotes(
 // outside of hdist. if opinion is undecided according to the votes it will use coinflip recorded
 // in the current layer.
 func (t *turtle) getFullVote(verified, current types.LayerID, block *blockInfo) (sign, voteReason, error) {
-	vote, reason := getLocalVote(verified, current, t.Config, block)
+	vote, reason := getLocalVote(t.Config, verified, current, block)
 	if !(vote == abstain && reason == reasonValidity) {
 		return vote, reason, nil
 	}
@@ -377,7 +375,8 @@ func (t *turtle) onLayer(ctx context.Context, last types.LayerID) error {
 				return err
 			}
 		}
-		layer.verifying.goodUncounted = layer.verifying.goodUncounted.Add(t.layer(process.Sub(1)).verifying.goodUncounted)
+		prev := t.layer(process.Sub(1))
+		layer.verifying.goodUncounted = layer.verifying.goodUncounted.Add(prev.verifying.goodUncounted)
 		for _, ballot := range t.layer(process).ballots {
 			t.countBallot(t.logger, ballot)
 		}
@@ -393,15 +392,19 @@ func (t *turtle) onLayer(ctx context.Context, last types.LayerID) error {
 		if err := t.loadBallots(process); err != nil {
 			return err
 		}
+		layer.prevOpinion = &prev.opinion
+		layer.computeOpinion(t.Hdist, t.last)
+		t.logger.With().Debug("initial local opinion",
+			layer.lid,
+			log.Stringer("local opinion", layer.opinion))
 
 		// terminate layer that falls out of the zdist window and wasn't terminated
 		// by any other component
-		if !process.After(types.NewLayerID(t.Zdist)) {
-			continue
-		}
-		terminated := process.Sub(t.Zdist)
-		if terminated.After(t.evicted) && !t.layer(terminated).hareTerminated {
-			t.onHareOutput(terminated, types.EmptyBlockID)
+		if process.After(types.NewLayerID(t.Zdist)) {
+			terminated := process.Sub(t.Zdist)
+			if terminated.After(t.evicted) && !t.layer(terminated).hareTerminated {
+				t.onHareOutput(terminated, types.EmptyBlockID)
+			}
 		}
 	}
 	return t.verifyLayers()
@@ -409,7 +412,7 @@ func (t *turtle) onLayer(ctx context.Context, last types.LayerID) error {
 
 func (t *turtle) switchModes(logger log.Log) {
 	t.isFull = !t.isFull
-	logger.With().Info("switching tortoise mode",
+	logger.With().Debug("switching tortoise mode",
 		log.Uint32("hdist", t.Hdist),
 		log.Stringer("processed_layer", t.processed),
 		log.Stringer("verified_layer", t.verified),
@@ -431,14 +434,24 @@ func (t *turtle) countBallot(logger log.Log, ballot *ballotInfo) error {
 }
 
 func (t *turtle) verifyLayers() error {
-	logger := t.logger.WithFields(
-		log.Stringer("last layer", t.last),
+	var (
+		logger = t.logger.WithFields(
+			log.Stringer("last layer", t.last),
+		)
+		verified = maxLayer(t.evicted, types.GetEffectiveGenesis())
 	)
-	verified := t.verified
+
+	if t.changedOpinion.min.Value != 0 && !withinDistance(t.Hdist, t.changedOpinion.max, t.last) {
+		logger.With().Debug("changed opinion outside hdist", log.Stringer("from", t.changedOpinion.min), log.Stringer("to", t.changedOpinion.max))
+		t.onOpinionChange(t.changedOpinion.min)
+		t.changedOpinion.min = types.LayerID{}
+		t.changedOpinion.max = types.LayerID{}
+	}
+
 	for target := t.evicted.Add(1); target.Before(t.processed); target = target.Add(1) {
-		var success bool
-		if !t.isFull {
-			success = t.verifying.verify(logger, target)
+		success := t.verifying.verify(logger, target)
+		if success && t.isFull {
+			t.switchModes(logger)
 		}
 		if !success && (t.isFull || !withinDistance(t.Hdist, target, t.last)) {
 			if !t.isFull {
@@ -457,11 +470,32 @@ func (t *turtle) verifyLayers() error {
 			break
 		}
 		verified = target
+		for _, block := range t.layers[target].blocks {
+			if !block.dirty {
+				continue
+			}
+			// record range of layers where opinion has changed.
+			// once those layers fall out of hdist window - opinion can be recomputed
+			if block.validity != block.hare {
+				if target.After(t.changedOpinion.max) {
+					t.changedOpinion.max = target
+				}
+				if t.changedOpinion.min.Value == 0 || target.Before(t.changedOpinion.min) {
+					t.changedOpinion.min = target
+				}
+			}
+			if block.validity == abstain {
+				logger.With().Panic("bug: layer should not be verified if there is an undecided block", target, block.id)
+			}
+			err := t.updater.UpdateBlockValidity(block.id, target, block.validity == support)
+			if err != nil {
+				return fmt.Errorf("saving validity for %s: %w", block.id, err)
+			}
+			block.dirty = false
+		}
 	}
 	t.verified = verified
-	return persistContextualValidity(
-		logger, t.updater, t.evicted.Add(1), t.verified, t.layers,
-	)
+	return nil
 }
 
 // loadBlocksData loads blocks, hare output and contextual validity.
@@ -607,11 +641,21 @@ func (t *turtle) onHareOutput(lid types.LayerID, bid types.BlockID) {
 			log.Stringer("previous", previous),
 			log.Stringer("new", bid),
 		)
+		t.onOpinionChange(lid)
+	}
+}
 
-		t.verifying.resetWeights(lid)
-		for target := lid.Add(1); !target.After(t.processed); target = target.Add(1) {
-			t.verifying.countVotes(t.logger, t.layer(target).ballots)
-		}
+func (t *turtle) onOpinionChange(lid types.LayerID) {
+	for recompute := lid; !recompute.After(t.processed); recompute = recompute.Add(1) {
+		layer := t.layer(recompute)
+		layer.computeOpinion(t.Hdist, t.last)
+		t.logger.With().Debug("computed local opinion",
+			layer.lid,
+			log.Stringer("local opinion", layer.opinion))
+	}
+	t.verifying.resetWeights(lid)
+	for target := lid.Add(1); !target.After(t.processed); target = target.Add(1) {
+		t.verifying.countVotes(t.logger, t.layer(target).ballots)
 	}
 }
 
@@ -750,11 +794,9 @@ func (t *turtle) decodeExceptions(base, ballot *ballotInfo, exceptions types.Vot
 		for _, bid := range bids {
 			block, exist := t.blockRefs[bid]
 			if !exist {
-				ballot.conditions.votesBeforeBase = true
 				continue
 			}
 			if block.layer.Before(from) {
-				ballot.conditions.votesBeforeBase = true
 				from = block.layer
 			}
 			layerdiff, exist := diff[block.layer]
@@ -767,7 +809,6 @@ func (t *turtle) decodeExceptions(base, ballot *ballotInfo, exceptions types.Vot
 	}
 	for _, lid := range exceptions.Abstain {
 		if lid.Before(from) {
-			ballot.conditions.votesBeforeBase = true
 			from = lid
 		}
 		_, exist := diff[lid]
@@ -800,29 +841,6 @@ func (t *turtle) decodeExceptions(base, ballot *ballotInfo, exceptions types.Vot
 	}
 }
 
-func validateConsistency(state *state, config Config, ballot *ballotInfo) bool {
-	for lvote := ballot.votes.tail; lvote != nil; lvote = lvote.prev {
-		if lvote.lid.Before(ballot.base.layer) {
-			return true
-		}
-		// local opinion is undecided yet. tortoise will revisit consistency
-		// after hare is terminated or zdist passes.
-		if !lvote.hareTerminated {
-			return false
-		}
-		if lvote.vote == abstain {
-			continue
-		}
-		for _, block := range lvote.blocks {
-			local, _ := getLocalVote(state.verified, state.last, config, block)
-			if lvote.getVote(block.id) != local {
-				return false
-			}
-		}
-	}
-	return true
-}
-
 func withinDistance(dist uint32, lid, last types.LayerID) bool {
 	genesis := types.GetEffectiveGenesis()
 	limit := types.GetEffectiveGenesis()
@@ -832,7 +850,7 @@ func withinDistance(dist uint32, lid, last types.LayerID) bool {
 	return !lid.Before(limit)
 }
 
-func getLocalVote(verified, last types.LayerID, config Config, block *blockInfo) (sign, voteReason) {
+func getLocalVote(config Config, verified, last types.LayerID, block *blockInfo) (sign, voteReason) {
 	if withinDistance(config.Hdist, block.layer, last) {
 		return block.hare, reasonHareOutput
 	}

--- a/tortoise/tortoise.go
+++ b/tortoise/tortoise.go
@@ -535,10 +535,14 @@ func (t *turtle) loadContextualValidity(lid types.LayerID) error {
 			if !errors.Is(err, sql.ErrNotFound) {
 				return err
 			}
-		} else if valid {
-			block.validity = support
-		} else if !valid {
-			block.validity = against
+		} else {
+			// see TestSwitchMode/loaded_validity
+			block.dirty = true
+			if valid {
+				block.validity = support
+			} else if !valid {
+				block.validity = against
+			}
 		}
 	}
 	return nil

--- a/tortoise/tortoise_test.go
+++ b/tortoise/tortoise_test.go
@@ -2201,6 +2201,42 @@ func TestSwitchMode(t *testing.T) {
 		tortoise.TallyVotes(ctx, last)
 		require.False(t, tortoise.trtl.isFull)
 	})
+	t.Run("loaded validity", func(t *testing.T) {
+		const size = 4
+
+		ctx := context.Background()
+
+		cfg := defaultTestConfig()
+		cfg.LayerSize = size
+		cfg.Zdist = 2
+		cfg.Hdist = 2
+
+		s := sim.New(
+			sim.WithLayerSize(cfg.LayerSize),
+		)
+		s.Setup(
+			sim.WithSetupMinerRange(size, size),
+		)
+		tortoise := tortoiseFromSimState(
+			s.GetState(0), WithConfig(cfg), WithLogger(logtest.New(t)),
+		)
+		var last types.LayerID
+		for i := 0; i <= int(cfg.Hdist); i++ {
+			last = s.Next(sim.WithNumBlocks(1), sim.WithEmptyHareOutput())
+		}
+		tortoise.TallyVotes(ctx, last)
+		require.True(t, tortoise.trtl.isFull)
+
+		tortoise1 := tortoiseFromSimState(
+			s.GetState(0), WithConfig(cfg), WithLogger(logtest.New(t)),
+		)
+		for i := 0; i <= int(cfg.Hdist); i++ {
+			last = s.Next(sim.WithNumBlocks(1))
+			tortoise1.TallyVotes(ctx, last)
+		}
+		tortoise1.TallyVotes(ctx, last)
+		require.False(t, tortoise1.trtl.isFull)
+	})
 }
 
 func TestOnBallotComputeOpinion(t *testing.T) {

--- a/tortoise/tortoise_test.go
+++ b/tortoise/tortoise_test.go
@@ -2265,8 +2265,8 @@ func TestSwitchMode(t *testing.T) {
 			s.GetState(0), WithConfig(cfg), WithLogger(logtest.New(t)),
 		)
 		var last types.LayerID
-		last = s.Next(sim.WithNumBlocks(1))
-		last = s.Next(sim.WithNumBlocks(1), sim.WithVoteGenerator(gapVote))
+		s.Next(sim.WithNumBlocks(1))
+		s.Next(sim.WithNumBlocks(1), sim.WithVoteGenerator(gapVote))
 		for i := 0; i < int(cfg.Hdist)-1; i++ {
 			last = s.Next(sim.WithNumBlocks(1))
 		}

--- a/tortoise/tortoise_test.go
+++ b/tortoise/tortoise_test.go
@@ -2264,7 +2264,8 @@ func TestSwitchMode(t *testing.T) {
 		tortoise := tortoiseFromSimState(
 			s.GetState(0), WithConfig(cfg), WithLogger(logtest.New(t)),
 		)
-		last := s.Next(sim.WithNumBlocks(1))
+		var last types.LayerID
+		last = s.Next(sim.WithNumBlocks(1))
 		last = s.Next(sim.WithNumBlocks(1), sim.WithVoteGenerator(gapVote))
 		for i := 0; i < int(cfg.Hdist)-1; i++ {
 			last = s.Next(sim.WithNumBlocks(1))

--- a/tortoise/util.go
+++ b/tortoise/util.go
@@ -1,7 +1,6 @@
 package tortoise
 
 import (
-	"fmt"
 	"sort"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
@@ -29,32 +28,6 @@ func (a sign) String() string {
 	default:
 		panic("sign should be 0/-1/1")
 	}
-}
-
-func persistContextualValidity(logger log.Log,
-	updater blockValidityUpdater,
-	from, to types.LayerID,
-	layers map[types.LayerID]*layerInfo,
-) error {
-	var err error
-	iterateLayers(from.Add(1), to, func(lid types.LayerID) bool {
-		for _, block := range layers[lid].blocks {
-			if !block.dirty {
-				continue
-			}
-			if block.validity == abstain {
-				logger.With().Panic("bug: layer should not be verified if there is an undecided block", lid, block.id)
-			}
-			err = updater.UpdateBlockValidity(block.id, lid, block.validity == support)
-			if err != nil {
-				err = fmt.Errorf("saving validity for %s: %w", block.id, err)
-				return false
-			}
-			block.dirty = false
-		}
-		return true
-	})
-	return err
 }
 
 func iterateLayers(from, to types.LayerID, callback func(types.LayerID) bool) {

--- a/tortoise/util.go
+++ b/tortoise/util.go
@@ -98,7 +98,6 @@ func verifyLayer(logger log.Log, blocks []*blockInfo, getDecision func(*blockInf
 	for i, decision := range decisions {
 		if blocks[i].validity != decision {
 			changes = true
-			blocks[i].dirty = true
 		}
 		blocks[i].validity = decision
 	}


### PR DESCRIPTION
closes: https://github.com/spacemeshos/go-spacemesh/issues/3637

verifying tortoise counts ballots that vote consistently with local opinion. this pr changes previous approach to a simpler version, that compares local opinion hash with ballot opinion hash, if hashes match each other - ballot will be counted.

local opinion hash is recomputed under the following conditions:
- hare output changes within hdist, including terminating a layer because it falls out of zdist distance
- layer outside hdist terminated with result that doesn't match hare output

every time when local opinion is recomputed tortoise will also re-scan ballots in verifying mode to re-enable it if it wasn't working. 