### PR TITLE
[Merged by Bors] - within hdist should not include layer on a lower boundary

### DIFF
--- a/proposals/handler.go
+++ b/proposals/handler.go
@@ -385,10 +385,6 @@ func (h *Handler) setBallotMalicious(ctx context.Context, b *types.Ballot) error
 
 func (h *Handler) checkVotesConsistency(ctx context.Context, b *types.Ballot) error {
 	exceptions := map[types.BlockID]struct{}{}
-	cutoff := types.LayerID{}
-	if b.LayerIndex.After(types.NewLayerID(h.cfg.Hdist)) {
-		cutoff = b.LayerIndex.Sub(h.cfg.Hdist)
-	}
 	layers := make(map[types.LayerID]types.BlockID)
 	// a ballot should not vote for multiple blocks in the same layer within hdist,
 	// since hare only output a single block each layer and miner should vote according
@@ -402,7 +398,7 @@ func (h *Handler) checkVotesConsistency(ctx context.Context, b *types.Ballot) er
 		}
 		if voted, ok := layers[lid]; ok {
 			// already voted for a block in this layer
-			if voted != bid && !lid.Before(cutoff) {
+			if voted != bid && lid.Add(h.cfg.Hdist).After(b.LayerIndex) {
 				h.logger.WithContext(ctx).With().Warning("ballot doubly voted within hdist, set smesher malicious",
 					b.ID(),
 					b.LayerIndex,

--- a/syncer/state_syncer.go
+++ b/syncer/state_syncer.go
@@ -111,7 +111,7 @@ func sortOpinions(opinions []*fetch.LayerOpinion) {
 
 func (s *Syncer) needCert(logger log.Log, lid types.LayerID) (bool, error) {
 	cutoff := s.certCutoffLayer()
-	if lid.Before(cutoff) {
+	if !lid.After(cutoff) {
 		return false, nil
 	}
 	cert, err := layers.GetCert(s.db, lid)

--- a/tortoise/rerun_test.go
+++ b/tortoise/rerun_test.go
@@ -62,6 +62,7 @@ func TestRerunRevertNonverifiedLayers(t *testing.T) {
 	s.Setup(sim.WithSetupUnitsRange(2, 2))
 
 	cfg := defaultTestConfig()
+	cfg.Hdist = good + 1
 	cfg.LayerSize = size
 
 	tortoise := tortoiseFromSimState(s.GetState(0), WithLogger(logtest.New(t)), WithConfig(cfg))

--- a/tortoise/tortoise.go
+++ b/tortoise/tortoise.go
@@ -847,12 +847,8 @@ func (t *turtle) decodeExceptions(blid types.LayerID, base *ballotInfo, cond *co
 }
 
 func withinDistance(dist uint32, lid, last types.LayerID) bool {
-	genesis := types.GetEffectiveGenesis()
-	limit := types.GetEffectiveGenesis()
-	if last.After(genesis.Add(dist)) {
-		limit = last.Sub(dist)
-	}
-	return !lid.Before(limit)
+	// layer + distance > last
+	return lid.Add(dist).After(last)
 }
 
 func getLocalVote(config Config, verified, last types.LayerID, block *blockInfo) (sign, voteReason) {

--- a/tortoise/tortoise_test.go
+++ b/tortoise/tortoise_test.go
@@ -558,7 +558,7 @@ func TestLongTermination(t *testing.T) {
 			zdist = 2
 			hdist = zdist + 3
 			skip  = 1 // skipping layer generated at this position
-			limit = hdist
+			limit = hdist - 1
 		)
 		s := sim.New(sim.WithLayerSize(size))
 		s.Setup(sim.WithSetupMinerRange(4, 4))
@@ -1123,7 +1123,7 @@ func TestWeakCoinVoting(t *testing.T) {
 
 	for _, lid := range sim.GenLayers(s,
 		sim.WithSequence(1, sim.WithNumBlocks(2), sim.WithEmptyHareOutput()),
-		sim.WithSequence(hdist+1,
+		sim.WithSequence(hdist,
 			sim.WithNumBlocks(2),
 			sim.WithEmptyHareOutput(),
 			sim.WithVoteGenerator(splitVoting(size)),
@@ -1850,7 +1850,7 @@ func TestFutureHeight(t *testing.T) {
 		)
 		tortoise.TallyVotes(context.Background(),
 			s.Next(sim.WithNumBlocks(1), sim.WithBlockTickHeights(100_000)))
-		for i := 0; i < int(cfg.Hdist); i++ {
+		for i := 0; i < int(cfg.Hdist)-1; i++ {
 			tortoise.TallyVotes(context.Background(), s.Next())
 		}
 		require.Equal(t, types.GetEffectiveGenesis(), tortoise.LatestComplete())
@@ -2361,7 +2361,7 @@ func TestNonTerminatedLayers(t *testing.T) {
 	tortoise := tortoiseFromSimState(
 		s.GetState(0), WithConfig(cfg), WithLogger(logtest.New(t)),
 	)
-	for i := 0; i <= int(cfg.Zdist); i++ {
+	for i := 0; i < int(cfg.Zdist); i++ {
 		tortoise.TallyVotes(ctx, s.Next(
 			sim.WithNumBlocks(0), sim.WithoutHareOutput()))
 	}


### PR DESCRIPTION
closes: https://github.com/spacemeshos/go-spacemesh/issues/3646

in this change hdist window is equal to (current-hdist, current].
for example if hdist 10, current 100 then hdist window will include exactly 10 layers, 91...100.
same was fixed for zdist