### PR TITLE
[Merged by Bors] - vm: emit account update even after tx commit

### DIFF
--- a/api/grpcserver/globalstate_service.go
+++ b/api/grpcserver/globalstate_service.go
@@ -6,6 +6,7 @@ import (
 
 	pb "github.com/spacemeshos/api/release/go/spacemesh/v1"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
 	"github.com/spacemeshos/go-spacemesh/api"
@@ -234,6 +235,9 @@ func (s GlobalStateService) AccountDataStream(in *pb.AccountDataStreamRequest, s
 		if rewardsSubscription := events.SubscribeRewards(); rewardsSubscription != nil {
 			rewardsCh, rewardsBufFull = consumeEvents(stream.Context(), rewardsSubscription)
 		}
+	}
+	if err := stream.SendHeader(metadata.MD{}); err != nil {
+		return err
 	}
 
 	for {

--- a/genvm/vm.go
+++ b/genvm/vm.go
@@ -231,7 +231,6 @@ func (v *VM) Apply(lctx ApplyContext, txs []types.Transaction, blockRewards []ty
 			return false
 		}
 		account.EncodeScale(encoder)
-		events.ReportAccountUpdate(account.Address)
 		return true
 	})
 	if err != nil {
@@ -247,6 +246,10 @@ func (v *VM) Apply(lctx ApplyContext, txs []types.Transaction, blockRewards []ty
 	if err := tx.Commit(); err != nil {
 		return nil, nil, fmt.Errorf("%w: %s", core.ErrInternal, err.Error())
 	}
+	ss.IterateChanged(func(account *core.Account) bool {
+		events.ReportAccountUpdate(account.Address)
+		return true
+	})
 	blockDurationPersist.Observe(float64(time.Since(t4)))
 	blockDuration.Observe(float64(time.Since(t1)))
 	transactionsPerBlock.Observe(float64(len(txs)))


### PR DESCRIPTION
closes: https://github.com/spacemeshos/go-spacemesh/issues/3687

added test that would fail previously if executed many times:
`go test ./api/grpcserver/ -run=TestVMAccountUpdates -v -count=1000 -cpu=1