### PR TITLE
[Merged by Bors] - Use updated Initializer API from PoST

### DIFF
--- a/activation/mocks/post.go
+++ b/activation/mocks/post.go
@@ -151,20 +151,6 @@ func (mr *MockPostSetupProviderMockRecorder) Status() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Status", reflect.TypeOf((*MockPostSetupProvider)(nil).Status))
 }
 
-// StatusChan mocks base method.
-func (m *MockPostSetupProvider) StatusChan() <-chan *types.PostSetupStatus {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StatusChan")
-	ret0, _ := ret[0].(<-chan *types.PostSetupStatus)
-	return ret0
-}
-
-// StatusChan indicates an expected call of StatusChan.
-func (mr *MockPostSetupProviderMockRecorder) StatusChan() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StatusChan", reflect.TypeOf((*MockPostSetupProvider)(nil).StatusChan))
-}
-
 // StopSession mocks base method.
 func (m *MockPostSetupProvider) StopSession(deleteFiles bool) error {
 	m.ctrl.T.Helper()

--- a/activation/post.go
+++ b/activation/post.go
@@ -225,7 +225,7 @@ func (mgr *PostSetupManager) StartSession(opts atypes.PostSetupOpts, commitmentA
 			defer mgr.mu.Unlock()
 
 			if errors.Is(err, context.Canceled) {
-				mgr.logger.Info("post setup session stopped")
+				mgr.logger.Info("post setup session was stopped")
 				mgr.state = atypes.PostSetupStateNotStarted
 			} else {
 				mgr.state = atypes.PostSetupStateError

--- a/activation/post_test.go
+++ b/activation/post_test.go
@@ -50,7 +50,7 @@ func TestPostSetupManager(t *testing.T) {
 				return nil
 			case <-timer.C:
 				status := mgr.Status()
-				req.True(status.NumLabelsWritten >= lastStatus.NumLabelsWritten)
+				req.GreaterOrEqual(status.NumLabelsWritten, lastStatus.NumLabelsWritten)
 				req.Equal(opts, *status.LastOpts)
 				req.Nil(status.LastError)
 

--- a/activation/post_test.go
+++ b/activation/post_test.go
@@ -1,12 +1,13 @@
 package activation
 
 import (
-	"sync"
+	"context"
 	"testing"
 	"time"
 
 	"github.com/spacemeshos/post/initialization"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
 
 	atypes "github.com/spacemeshos/go-spacemesh/activation/types"
 	"github.com/spacemeshos/go-spacemesh/common/types"
@@ -34,32 +35,42 @@ func TestPostSetupManager(t *testing.T) {
 	mgr, err := NewPostSetupManager(id, cfg, logtest.New(t), cdb, goldenATXID)
 	req.NoError(err)
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var eg errgroup.Group
 	lastStatus := &atypes.PostSetupStatus{}
-	go func() {
-		for status := range mgr.StatusChan() {
-			req.True(status.NumLabelsWritten >= lastStatus.NumLabelsWritten)
-			req.Equal(opts, *status.LastOpts)
-			req.Nil(status.LastError)
+	eg.Go(func() error {
+		timer := time.NewTicker(50 * time.Millisecond)
+		defer timer.Stop()
 
-			if status.NumLabelsWritten == uint64(opts.NumUnits)*cfg.LabelsPerUnit {
-				// TODO(moshababo): fix the following failure. `status.State` changes to `postSetupStateComplete` only after the channel event was triggered.
-				// req.Equal(postSetupStateComplete, status.State)
-			} else {
-				req.Equal(atypes.PostSetupStateInProgress, status.State)
+		for {
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-timer.C:
+				status := mgr.Status()
+				req.True(status.NumLabelsWritten >= lastStatus.NumLabelsWritten)
+				req.Equal(opts, *status.LastOpts)
+				req.Nil(status.LastError)
+
+				if status.NumLabelsWritten < uint64(opts.NumUnits)*cfg.LabelsPerUnit {
+					req.Equal(atypes.PostSetupStateInProgress, status.State)
+				}
 			}
-
-			lastStatus = status
 		}
-	}()
+	})
 
 	// Create data.
 	doneChan, err := mgr.StartSession(opts, goldenATXID)
 	req.NoError(err)
 	<-doneChan
+	cancel()
+	eg.Wait()
+
 	req.Equal(opts, *mgr.LastOpts())
 	req.NoError(mgr.LastError())
-	// TODO(moshababo): fix the following failure. `status.State` changes to `postSetupStateComplete` only after the channel event was triggered.
-	// req.Equal(lastStatus, mgr.Status())
+	req.Equal(atypes.PostSetupStateComplete, mgr.Status().State)
 
 	// Create data (same opts).
 	doneChan, err = mgr.StartSession(opts, goldenATXID)
@@ -69,8 +80,7 @@ func TestPostSetupManager(t *testing.T) {
 	req.NoError(mgr.LastError())
 
 	// Cleanup.
-	err = mgr.StopSession(true)
-	req.NoError(err)
+	req.NoError(mgr.StopSession(true))
 
 	// Create data (same opts, after deletion).
 	doneChan, err = mgr.StartSession(opts, goldenATXID)
@@ -78,8 +88,7 @@ func TestPostSetupManager(t *testing.T) {
 	<-doneChan
 	req.Equal(opts, *mgr.LastOpts())
 	req.NoError(mgr.LastError())
-	// TODO(moshababo): fix the following failure. `status.State` changes to `postSetupStateComplete` only after the channel event was triggered.
-	// req.Equal(lastStatus, mgr.Status())
+	req.Equal(atypes.PostSetupStateComplete, mgr.Status().State)
 }
 
 func TestPostSetupManager_InitialStatus(t *testing.T) {
@@ -101,10 +110,7 @@ func TestPostSetupManager_InitialStatus(t *testing.T) {
 	doneChan, err := mgr.StartSession(opts, goldenATXID)
 	req.NoError(err)
 	<-doneChan
-
-	// Compare the last status update to the status queried directly.
-	// TODO(moshababo): fix the following failure. `status.State` changes to `postSetupStateComplete` only after the channel event was triggered.
-	// req.Equal(lastStatus, mgr.Status())
+	req.Equal(atypes.PostSetupStateComplete, mgr.Status().State)
 
 	// Re-instantiate `PostSetupManager`.
 	mgr, err = NewPostSetupManager(id, cfg, logtest.New(t), cdb, goldenATXID)
@@ -149,94 +155,6 @@ func TestPostSetupManager_GenerateProof(t *testing.T) {
 	req.ErrorIs(err, errNotComplete)
 }
 
-func TestPostSetupManager_StatusChan_BeforeSessionStarted(t *testing.T) {
-	req := require.New(t)
-
-	cdb := newCachedDB(t)
-	cfg, opts := getTestConfig(t)
-	mgr, err := NewPostSetupManager(id, cfg, logtest.New(t), cdb, goldenATXID)
-	req.NoError(err)
-
-	// Verify that the status stream works properly when called *before* session started.
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		ch := mgr.StatusChan()
-		var prevStatus *atypes.PostSetupStatus
-		for {
-			status, more := <-ch
-			if more {
-				if prevStatus == nil {
-					// Verify initial status.
-					req.Equal(uint64(0), status.NumLabelsWritten)
-				}
-				prevStatus = status
-			} else {
-				// Verify last status.
-				req.Equal(uint64(opts.NumUnits)*cfg.LabelsPerUnit, prevStatus.NumLabelsWritten)
-				break
-			}
-		}
-	}()
-
-	// Create data.
-	time.Sleep(1 * time.Second) // Short delay.
-	doneChan, err := mgr.StartSession(opts, goldenATXID)
-	req.NoError(err)
-	<-doneChan
-	wg.Wait()
-
-	// Cleanup.
-	err = mgr.StopSession(true)
-	req.NoError(err)
-}
-
-func TestPostSetupManager_StatusChan_AfterSessionStarted(t *testing.T) {
-	req := require.New(t)
-
-	cdb := newCachedDB(t)
-	cfg, opts := getTestConfig(t)
-	opts.NumUnits *= 10
-	mgr, err := NewPostSetupManager(id, cfg, logtest.New(t), cdb, goldenATXID)
-	req.NoError(err)
-
-	// Verify that the status stream works properly when called *after* session started (yet before it ended).
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		time.Sleep(100 * time.Millisecond) // Short delay.
-
-		ch := mgr.StatusChan()
-		var prevStatus *atypes.PostSetupStatus
-		for {
-			status, more := <-ch
-			if more {
-				if prevStatus == nil {
-					// Verify initial status.
-					req.Equal(uint64(0), status.NumLabelsWritten)
-				}
-				prevStatus = status
-			} else {
-				// Verify last status.
-				req.Equal(uint64(opts.NumUnits)*cfg.LabelsPerUnit, prevStatus.NumLabelsWritten)
-				break
-			}
-		}
-		wg.Done()
-	}()
-
-	// Create data.
-	doneChan, err := mgr.StartSession(opts, goldenATXID)
-	req.NoError(err)
-	<-doneChan
-	wg.Wait()
-
-	// Cleanup.
-	err = mgr.StopSession(true)
-	req.NoError(err)
-}
-
 func TestPostSetupManager_Stop(t *testing.T) {
 	req := require.New(t)
 
@@ -248,6 +166,8 @@ func TestPostSetupManager_Stop(t *testing.T) {
 	// Verify state.
 	status := mgr.Status()
 	req.Equal(atypes.PostSetupStateNotStarted, status.State)
+	req.Zero(status.NumLabelsWritten)
+	req.Nil(status.LastOpts)
 
 	// Create data.
 	doneChan, err := mgr.StartSession(opts, goldenATXID)
@@ -255,24 +175,19 @@ func TestPostSetupManager_Stop(t *testing.T) {
 	<-doneChan
 
 	// Verify state.
-	status = mgr.Status()
-	req.Equal(atypes.PostSetupStateComplete, status.State)
+	req.Equal(atypes.PostSetupStateComplete, mgr.Status().State)
 
 	// Stop without file deletion.
-	err = mgr.StopSession(false)
-	req.NoError(err)
+	req.NoError(mgr.StopSession(false))
 
 	// Verify state.
-	status = mgr.Status()
-	req.Equal(atypes.PostSetupStateComplete, status.State)
+	req.Equal(atypes.PostSetupStateComplete, mgr.Status().State)
 
 	// Stop with file deletion.
-	err = mgr.StopSession(true)
-	req.NoError(err)
+	req.NoError(mgr.StopSession(true))
 
 	// Verify state.
-	status = mgr.Status()
-	req.Equal(atypes.PostSetupStateNotStarted, status.State)
+	req.Equal(atypes.PostSetupStateNotStarted, mgr.Status().State)
 
 	// Create data again.
 	doneChan, err = mgr.StartSession(opts, goldenATXID)
@@ -280,8 +195,7 @@ func TestPostSetupManager_Stop(t *testing.T) {
 	<-doneChan
 
 	// Verify state.
-	status = mgr.Status()
-	req.Equal(atypes.PostSetupStateComplete, status.State)
+	req.Equal(atypes.PostSetupStateComplete, mgr.Status().State)
 }
 
 func TestPostSetupManager_Stop_WhileInProgress(t *testing.T) {
@@ -306,8 +220,7 @@ func TestPostSetupManager_Stop_WhileInProgress(t *testing.T) {
 	req.Equal(atypes.PostSetupStateInProgress, status.State)
 
 	// Stop without files deletion.
-	err = mgr.StopSession(false)
-	req.NoError(err)
+	req.NoError(mgr.StopSession(false))
 
 	select {
 	case <-doneChan:

--- a/api/config/config.go
+++ b/api/config/config.go
@@ -4,6 +4,7 @@ package config
 import (
 	"errors"
 	"fmt"
+	"time"
 )
 
 const (
@@ -18,6 +19,8 @@ const (
 	defaultStartNodeService        = false
 	defaultStartSmesherService     = false
 	defaultStartTransactionService = false
+
+	defaultSmesherStreamInterval = 1 * time.Second
 )
 
 // Config defines the api config params.
@@ -35,6 +38,8 @@ type Config struct {
 	StartNodeService        bool
 	StartSmesherService     bool
 	StartTransactionService bool
+
+	SmesherStreamInterval time.Duration
 }
 
 func init() {
@@ -57,6 +62,8 @@ func DefaultConfig() Config {
 		StartNodeService:        defaultStartNodeService,
 		StartSmesherService:     defaultStartSmesherService,
 		StartTransactionService: defaultStartTransactionService,
+
+		SmesherStreamInterval: defaultSmesherStreamInterval,
 	}
 }
 

--- a/api/grpcserver/grpcserver_test.go
+++ b/api/grpcserver/grpcserver_test.go
@@ -978,7 +978,7 @@ func TestGlobalStateService(t *testing.T) {
 
 func TestSmesherService(t *testing.T) {
 	logtest.SetupGlobal(t)
-	svc := NewSmesherService(&PostAPIMock{}, &SmeshingAPIMock{})
+	svc := NewSmesherService(&PostAPIMock{}, &SmeshingAPIMock{}, 10*time.Millisecond)
 	shutDown := launchServer(t, svc)
 	defer shutDown()
 

--- a/api/grpcserver/grpcserver_test.go
+++ b/api/grpcserver/grpcserver_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"log"
 	"math"
@@ -988,112 +987,118 @@ func TestSmesherService(t *testing.T) {
 	conn := dialGrpc(ctx, t, cfg)
 	c := pb.NewSmesherServiceClient(conn)
 
-	// Construct an array of test cases to test each endpoint in turn
-	testCases := []struct {
-		name string
-		run  func(*testing.T)
-	}{
-		{"IsSmeshing", func(t *testing.T) {
-			logtest.SetupGlobal(t)
-			res, err := c.IsSmeshing(context.Background(), &empty.Empty{})
-			require.NoError(t, err)
-			require.False(t, res.IsSmeshing, "expected IsSmeshing to be false")
-		}},
-		{"StartSmeshingMissingArgs", func(t *testing.T) {
-			logtest.SetupGlobal(t)
-			_, err := c.StartSmeshing(context.Background(), &pb.StartSmeshingRequest{})
-			require.Equal(t, codes.InvalidArgument, status.Code(err))
-		}},
-		{"StartSmeshing", func(t *testing.T) {
-			logtest.SetupGlobal(t)
-			opts := &pb.PostSetupOpts{}
-			opts.DataDir = t.TempDir()
-			opts.NumUnits = 1
-			opts.NumFiles = 1
+	t.Run("IsSmeshing", func(t *testing.T) {
+		logtest.SetupGlobal(t)
+		res, err := c.IsSmeshing(context.Background(), &empty.Empty{})
+		require.NoError(t, err)
+		require.False(t, res.IsSmeshing, "expected IsSmeshing to be false")
+	})
 
-			coinbase := &pb.AccountId{Address: addr1.String()}
+	t.Run("StartSmeshingMissingArgs", func(t *testing.T) {
+		logtest.SetupGlobal(t)
+		_, err := c.StartSmeshing(context.Background(), &pb.StartSmeshingRequest{})
+		require.Equal(t, codes.InvalidArgument, status.Code(err))
+	})
 
-			res, err := c.StartSmeshing(context.Background(), &pb.StartSmeshingRequest{
-				Opts:     opts,
-				Coinbase: coinbase,
-			})
-			require.NoError(t, err)
-			require.Equal(t, int32(code.Code_OK), res.Status.Code)
-		}},
-		{"StopSmeshing", func(t *testing.T) {
-			logtest.SetupGlobal(t)
-			res, err := c.StopSmeshing(context.Background(), &pb.StopSmeshingRequest{})
-			require.NoError(t, err)
-			require.Equal(t, int32(code.Code_OK), res.Status.Code)
-		}},
-		{"SmesherID", func(t *testing.T) {
-			logtest.SetupGlobal(t)
-			res, err := c.SmesherID(context.Background(), &empty.Empty{})
-			require.NoError(t, err)
-			nodeAddr := types.GenerateAddress(signer.NodeID().ToBytes())
-			resAddr, err := types.StringToAddress(res.AccountId.Address)
-			require.NoError(t, err)
-			require.Equal(t, nodeAddr.String(), resAddr.String())
-		}},
-		{"SetCoinbaseMissingArgs", func(t *testing.T) {
-			logtest.SetupGlobal(t)
-			_, err := c.SetCoinbase(context.Background(), &pb.SetCoinbaseRequest{})
-			require.Error(t, err)
-			statusCode := status.Code(err)
-			require.Equal(t, codes.InvalidArgument, statusCode)
-		}},
-		{"SetCoinbase", func(t *testing.T) {
-			logtest.SetupGlobal(t)
-			res, err := c.SetCoinbase(context.Background(), &pb.SetCoinbaseRequest{
-				Id: &pb.AccountId{Address: addr1.String()},
-			})
-			require.NoError(t, err)
-			require.Equal(t, int32(code.Code_OK), res.Status.Code)
-		}},
-		{"Coinbase", func(t *testing.T) {
-			logtest.SetupGlobal(t)
-			res, err := c.Coinbase(context.Background(), &empty.Empty{})
-			require.NoError(t, err)
-			addr, err := types.StringToAddress(res.AccountId.Address)
-			require.NoError(t, err)
-			require.Equal(t, addr1.Bytes(), addr.Bytes())
-		}},
-		{"MinGas", func(t *testing.T) {
-			logtest.SetupGlobal(t)
-			_, err := c.MinGas(context.Background(), &empty.Empty{})
-			require.Error(t, err)
-			statusCode := status.Code(err)
-			require.Equal(t, codes.Unimplemented, statusCode)
-		}},
-		{"SetMinGas", func(t *testing.T) {
-			logtest.SetupGlobal(t)
-			_, err := c.SetMinGas(context.Background(), &pb.SetMinGasRequest{})
-			require.Error(t, err)
-			statusCode := status.Code(err)
-			require.Equal(t, codes.Unimplemented, statusCode)
-		}},
-		{"PostSetupComputeProviders", func(t *testing.T) {
-			logtest.SetupGlobal(t)
-			_, err := c.PostSetupComputeProviders(context.Background(), &pb.PostSetupComputeProvidersRequest{Benchmark: false})
-			require.NoError(t, err)
-		}},
-		{"PostSetupStatusStream", func(t *testing.T) {
-			logtest.SetupGlobal(t)
-			stream, err := c.PostSetupStatusStream(context.Background(), &empty.Empty{})
+	t.Run("StartSmeshing", func(t *testing.T) {
+		logtest.SetupGlobal(t)
+		opts := &pb.PostSetupOpts{}
+		opts.DataDir = t.TempDir()
+		opts.NumUnits = 1
+		opts.NumFiles = 1
 
-			// Expecting the stream to return a single update before closing.
-			require.NoError(t, err)
+		coinbase := &pb.AccountId{Address: addr1.String()}
+
+		res, err := c.StartSmeshing(context.Background(), &pb.StartSmeshingRequest{
+			Opts:     opts,
+			Coinbase: coinbase,
+		})
+		require.NoError(t, err)
+		require.Equal(t, int32(code.Code_OK), res.Status.Code)
+	})
+
+	t.Run("StopSmeshing", func(t *testing.T) {
+		logtest.SetupGlobal(t)
+		res, err := c.StopSmeshing(context.Background(), &pb.StopSmeshingRequest{})
+		require.NoError(t, err)
+		require.Equal(t, int32(code.Code_OK), res.Status.Code)
+	})
+
+	t.Run("SmesherID", func(t *testing.T) {
+		logtest.SetupGlobal(t)
+		res, err := c.SmesherID(context.Background(), &empty.Empty{})
+		require.NoError(t, err)
+		nodeAddr := types.GenerateAddress(signer.NodeID().ToBytes())
+		resAddr, err := types.StringToAddress(res.AccountId.Address)
+		require.NoError(t, err)
+		require.Equal(t, nodeAddr.String(), resAddr.String())
+	})
+
+	t.Run("SetCoinbaseMissingArgs", func(t *testing.T) {
+		logtest.SetupGlobal(t)
+		_, err := c.SetCoinbase(context.Background(), &pb.SetCoinbaseRequest{})
+		require.Error(t, err)
+		statusCode := status.Code(err)
+		require.Equal(t, codes.InvalidArgument, statusCode)
+	})
+
+	t.Run("SetCoinbase", func(t *testing.T) {
+		logtest.SetupGlobal(t)
+		res, err := c.SetCoinbase(context.Background(), &pb.SetCoinbaseRequest{
+			Id: &pb.AccountId{Address: addr1.String()},
+		})
+		require.NoError(t, err)
+		require.Equal(t, int32(code.Code_OK), res.Status.Code)
+	})
+
+	t.Run("Coinbase", func(t *testing.T) {
+		logtest.SetupGlobal(t)
+		res, err := c.Coinbase(context.Background(), &empty.Empty{})
+		require.NoError(t, err)
+		addr, err := types.StringToAddress(res.AccountId.Address)
+		require.NoError(t, err)
+		require.Equal(t, addr1.Bytes(), addr.Bytes())
+	})
+
+	t.Run("MinGas", func(t *testing.T) {
+		logtest.SetupGlobal(t)
+		_, err := c.MinGas(context.Background(), &empty.Empty{})
+		require.Error(t, err)
+		statusCode := status.Code(err)
+		require.Equal(t, codes.Unimplemented, statusCode)
+	})
+
+	t.Run("SetMinGas", func(t *testing.T) {
+		logtest.SetupGlobal(t)
+		_, err := c.SetMinGas(context.Background(), &pb.SetMinGasRequest{})
+		require.Error(t, err)
+		statusCode := status.Code(err)
+		require.Equal(t, codes.Unimplemented, statusCode)
+	})
+
+	t.Run("PostSetupComputeProviders", func(t *testing.T) {
+		logtest.SetupGlobal(t)
+		_, err := c.PostSetupComputeProviders(context.Background(), &pb.PostSetupComputeProvidersRequest{Benchmark: false})
+		require.NoError(t, err)
+	})
+
+	t.Run("PostSetupStatusStream", func(t *testing.T) {
+		logtest.SetupGlobal(t)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		stream, err := c.PostSetupStatusStream(ctx, &empty.Empty{})
+		require.NoError(t, err)
+
+		// Expecting the stream to return updates before closing.
+		for i := 0; i < 3; i++ {
 			_, err = stream.Recv()
 			require.NoError(t, err)
-			_, err = stream.Recv()
-			require.EqualError(t, err, io.EOF.Error())
-		}},
-	}
+		}
 
-	// Run subtests
-	for _, tc := range testCases {
-		t.Run(tc.name, tc.run)
-	}
+		cancel()
+		_, err = stream.Recv()
+		require.ErrorContains(t, err, context.Canceled.Error())
+	})
 }
 
 func TestMeshService(t *testing.T) {

--- a/api/grpcserver/smesher_service.go
+++ b/api/grpcserver/smesher_service.go
@@ -29,6 +29,8 @@ type PostSetupProvider interface {
 type SmesherService struct {
 	postSetupProvider PostSetupProvider
 	smeshingProvider  api.SmeshingAPI
+
+	streamInterval time.Duration
 }
 
 // RegisterService registers this service with a grpc server instance.
@@ -37,8 +39,8 @@ func (s SmesherService) RegisterService(server *Server) {
 }
 
 // NewSmesherService creates a new grpc service using config data.
-func NewSmesherService(post PostSetupProvider, smeshing api.SmeshingAPI) *SmesherService {
-	return &SmesherService{post, smeshing}
+func NewSmesherService(post PostSetupProvider, smeshing api.SmeshingAPI, streamInterval time.Duration) *SmesherService {
+	return &SmesherService{post, smeshing, streamInterval}
 }
 
 // IsSmeshing reports whether the node is smeshing.
@@ -183,7 +185,7 @@ func (s SmesherService) PostSetupStatus(context.Context, *empty.Empty) (*pb.Post
 func (s SmesherService) PostSetupStatusStream(_ *empty.Empty, stream pb.SmesherService_PostSetupStatusStreamServer) error {
 	log.Info("GRPC SmesherService.PostSetupStatusStream")
 
-	timer := time.NewTicker(time.Second)
+	timer := time.NewTicker(s.streamInterval)
 	defer timer.Stop()
 
 	for {

--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -831,7 +831,7 @@ func (app *App) startAPIServices(ctx context.Context) {
 		app.closers = append(app.closers, nodeService)
 	}
 	if apiConf.StartSmesherService {
-		registerService(grpcserver.NewSmesherService(app.postSetupMgr, app.atxBuilder))
+		registerService(grpcserver.NewSmesherService(app.postSetupMgr, app.atxBuilder, apiConf.SmesherStreamInterval))
 	}
 	if apiConf.StartTransactionService {
 		registerService(grpcserver.NewTransactionService(app.db, app.host, app.mesh, app.conState, app.syncer))

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/spacemeshos/go-scale v1.1.0
 	github.com/spacemeshos/merkle-tree v0.1.0
 	github.com/spacemeshos/poet v0.2.1
-	github.com/spacemeshos/post v0.1.3-0.20221109131305-a7e19fdb3cb7
+	github.com/spacemeshos/post v0.2.0
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.13.0

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/spacemeshos/go-scale v1.1.0
 	github.com/spacemeshos/merkle-tree v0.1.0
 	github.com/spacemeshos/poet v0.2.1
-	github.com/spacemeshos/post v0.1.2
+	github.com/spacemeshos/post v0.1.3-0.20221108110315-6118fdc5f80e
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.13.0

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/spacemeshos/go-scale v1.1.0
 	github.com/spacemeshos/merkle-tree v0.1.0
 	github.com/spacemeshos/poet v0.2.1
-	github.com/spacemeshos/post v0.1.3-0.20221108110315-6118fdc5f80e
+	github.com/spacemeshos/post v0.1.3-0.20221109131305-a7e19fdb3cb7
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.13.0

--- a/go.sum
+++ b/go.sum
@@ -620,8 +620,8 @@ github.com/spacemeshos/merkle-tree v0.1.0 h1:3oGOfJab60BPy0qn05gHYQpqvpA/Szr7Cge
 github.com/spacemeshos/merkle-tree v0.1.0/go.mod h1:uGtTEKksCgRdSMyeDdHM1W2d/rI7CxYlzNnKP1GU5Mw=
 github.com/spacemeshos/poet v0.2.1 h1:m//vgqV5e6UrIv1xfYQbk0OLhVlr5037oa9RO2VQzic=
 github.com/spacemeshos/poet v0.2.1/go.mod h1:7EJZ+I19+UL39FxXG65SsBQtFoRdkZGBwZhqkcUsC/g=
-github.com/spacemeshos/post v0.1.3-0.20221108110315-6118fdc5f80e h1:KwCLcNkovgKb7ew9osKtqeU4s0Hq9ABfZ2OU0gh1cpE=
-github.com/spacemeshos/post v0.1.3-0.20221108110315-6118fdc5f80e/go.mod h1:9KZB+Wd/WeNkB8wU522BsG0a8IVBavb7BbiKMPUHQPI=
+github.com/spacemeshos/post v0.1.3-0.20221109131305-a7e19fdb3cb7 h1:ji8HdKTXgjhar/0MHjtGO0UAnM7Rv1O7BvFTz91p8CY=
+github.com/spacemeshos/post v0.1.3-0.20221109131305-a7e19fdb3cb7/go.mod h1:9KZB+Wd/WeNkB8wU522BsG0a8IVBavb7BbiKMPUHQPI=
 github.com/spacemeshos/smutil v0.0.0-20220819180433-6aaadca3eb1d h1:09R53k+V+cPCwTH3AnvOJO2OmCb4dJlG6hfgqQlTm6w=
 github.com/spacemeshos/smutil v0.0.0-20220819180433-6aaadca3eb1d/go.mod h1:ZCb6K2K6Dz51qrYp04sZtf4kJex9lCwGBH5Npok9uy8=
 github.com/spacemonkeygo/spacelog v0.0.0-20180420211403-2296661a0572 h1:RC6RW7j+1+HkWaX/Yh71Ee5ZHaHYt7ZP4sQgUrm6cDU=

--- a/go.sum
+++ b/go.sum
@@ -620,8 +620,8 @@ github.com/spacemeshos/merkle-tree v0.1.0 h1:3oGOfJab60BPy0qn05gHYQpqvpA/Szr7Cge
 github.com/spacemeshos/merkle-tree v0.1.0/go.mod h1:uGtTEKksCgRdSMyeDdHM1W2d/rI7CxYlzNnKP1GU5Mw=
 github.com/spacemeshos/poet v0.2.1 h1:m//vgqV5e6UrIv1xfYQbk0OLhVlr5037oa9RO2VQzic=
 github.com/spacemeshos/poet v0.2.1/go.mod h1:7EJZ+I19+UL39FxXG65SsBQtFoRdkZGBwZhqkcUsC/g=
-github.com/spacemeshos/post v0.1.3-0.20221109131305-a7e19fdb3cb7 h1:ji8HdKTXgjhar/0MHjtGO0UAnM7Rv1O7BvFTz91p8CY=
-github.com/spacemeshos/post v0.1.3-0.20221109131305-a7e19fdb3cb7/go.mod h1:9KZB+Wd/WeNkB8wU522BsG0a8IVBavb7BbiKMPUHQPI=
+github.com/spacemeshos/post v0.2.0 h1:O4JeCDbqXyskRVlnmE8m1HMypeglgE0YvBtYQeKn4M4=
+github.com/spacemeshos/post v0.2.0/go.mod h1:9KZB+Wd/WeNkB8wU522BsG0a8IVBavb7BbiKMPUHQPI=
 github.com/spacemeshos/smutil v0.0.0-20220819180433-6aaadca3eb1d h1:09R53k+V+cPCwTH3AnvOJO2OmCb4dJlG6hfgqQlTm6w=
 github.com/spacemeshos/smutil v0.0.0-20220819180433-6aaadca3eb1d/go.mod h1:ZCb6K2K6Dz51qrYp04sZtf4kJex9lCwGBH5Npok9uy8=
 github.com/spacemonkeygo/spacelog v0.0.0-20180420211403-2296661a0572 h1:RC6RW7j+1+HkWaX/Yh71Ee5ZHaHYt7ZP4sQgUrm6cDU=

--- a/go.sum
+++ b/go.sum
@@ -619,8 +619,8 @@ github.com/spacemeshos/merkle-tree v0.1.0 h1:3oGOfJab60BPy0qn05gHYQpqvpA/Szr7Cge
 github.com/spacemeshos/merkle-tree v0.1.0/go.mod h1:uGtTEKksCgRdSMyeDdHM1W2d/rI7CxYlzNnKP1GU5Mw=
 github.com/spacemeshos/poet v0.2.1 h1:m//vgqV5e6UrIv1xfYQbk0OLhVlr5037oa9RO2VQzic=
 github.com/spacemeshos/poet v0.2.1/go.mod h1:7EJZ+I19+UL39FxXG65SsBQtFoRdkZGBwZhqkcUsC/g=
-github.com/spacemeshos/post v0.1.2 h1:XZTCxyuDwUudsdczzDcOBzFflOU3snWo/mQ6mXi0XGs=
-github.com/spacemeshos/post v0.1.2/go.mod h1:9KZB+Wd/WeNkB8wU522BsG0a8IVBavb7BbiKMPUHQPI=
+github.com/spacemeshos/post v0.1.3-0.20221108110315-6118fdc5f80e h1:KwCLcNkovgKb7ew9osKtqeU4s0Hq9ABfZ2OU0gh1cpE=
+github.com/spacemeshos/post v0.1.3-0.20221108110315-6118fdc5f80e/go.mod h1:9KZB+Wd/WeNkB8wU522BsG0a8IVBavb7BbiKMPUHQPI=
 github.com/spacemeshos/smutil v0.0.0-20220819180433-6aaadca3eb1d h1:09R53k+V+cPCwTH3AnvOJO2OmCb4dJlG6hfgqQlTm6w=
 github.com/spacemeshos/smutil v0.0.0-20220819180433-6aaadca3eb1d/go.mod h1:ZCb6K2K6Dz51qrYp04sZtf4kJex9lCwGBH5Npok9uy8=
 github.com/spacemonkeygo/spacelog v0.0.0-20180420211403-2296661a0572 h1:RC6RW7j+1+HkWaX/Yh71Ee5ZHaHYt7ZP4sQgUrm6cDU=


### PR DESCRIPTION
## Motivation
Integrates changes of https://github.com/spacemeshos/post/issues/78 into go-spacemesh, only merge after the former has been merged.

## Changes
The asynchronous `Initializer::SessionNumLabelsWrittenChan()` is removed in favor of the synchronous `Initializer::SessionNumLabelsWritten()` with the changes in https://github.com/spacemeshos/post/pull/84/

This updates go-spacemesh to not use the removed method any more.

The GRPC server now sends PoST status updates to a client in 1 second intervals instead of relying on PoST to report its status in (possibly) irregular intervals. This also means that a client now has to cancel a request or it will receive status updates about PoST indefinitely.

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
