### PR TITLE
[Merged by Bors] - Re-add go-env targets to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ SHA = $(shell git rev-parse --short HEAD)
 BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
 
 export CGO_ENABLED := 1
-export CGO_CFLAGS := "-DSQLITE_ENABLE_DBSTAT_VTAB=1"
+export CGO_CFLAGS := $(CGO_CFLAGS) -DSQLITE_ENABLE_DBSTAT_VTAB=1
 
 # These commands cause problems on Windows
 ifeq ($(OS),Windows_NT)

--- a/Makefile-gpu.Inc
+++ b/Makefile-gpu.Inc
@@ -2,7 +2,7 @@ PROJ_DIR := $(dir $(realpath $(firstword $(MAKEFILE_LIST))))
 BIN_DIR ?= $(PROJ_DIR)build/
 
 export CGO_LDFLAGS := -L$(BIN_DIR)
-export CPATH := $(PROJ_DIR)build/
+export CGO_CFLAGS := -I$(PROJ_DIR)build/
 export GOOS
 export GOARCH
 export GOARM
@@ -106,3 +106,23 @@ print-test-targets:
 	do echo $$i; \
 	done
 .PHONY: $(SUBDIRS_ALL) $(SUBDIRS_LVL2) $(SUBDIRS_ONLY) print-test-targets
+
+go-env: get-gpu-setup
+	go env -w CGO_CFLAGS="$(CGO_CFLAGS)"
+	go env -w CGO_LDFLAGS="$(CGO_LDFLAGS)"
+.PHONY: go-env
+
+go-env-test: get-gpu-setup
+	go env -w CGO_CFLAGS="$(CGO_CFLAGS)"
+	go env -w CGO_LDFLAGS="$(CGO_TEST_LDFLAGS)"
+.PHONY: go-env-test
+
+print-env: get-gpu-setup
+	@echo CGO_CFLAGS="$(CGO_CFLAGS)"
+	@echo CGO_LDFLAGS="$(CGO_LDFLAGS)"
+.PHONY: print-env
+
+print-test-env: get-gpu-setup
+	@echo CGO_CFLAGS="$(CGO_CFLAGS)"
+	@echo CGO_TEST_LDFLAGS="$(CGO_TEST_LDFLAGS)"
+.PHONY: print-test-env


### PR DESCRIPTION
## Motivation
Resolves https://github.com/spacemeshos/go-spacemesh/pull/3710#pullrequestreview-1171129123

## Changes
Puts back go-env targets into the makefile

## Test Plan
Existing tests pass

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [X] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
