### PR TITLE
[Merged by Bors] - don't cancel identity because of syntactically invalid ballots

### DIFF
--- a/proposals/handler_test.go
+++ b/proposals/handler_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/spacemeshos/go-spacemesh/sql"
 	"github.com/spacemeshos/go-spacemesh/sql/ballots"
 	"github.com/spacemeshos/go-spacemesh/sql/blocks"
-	"github.com/spacemeshos/go-spacemesh/sql/identities"
 	"github.com/spacemeshos/go-spacemesh/sql/proposals"
 	smocks "github.com/spacemeshos/go-spacemesh/system/mocks"
 	"github.com/spacemeshos/go-spacemesh/tortoise"
@@ -217,13 +216,6 @@ func checkProposal(t *testing.T, cdb *datastore.CachedDB, p *types.Proposal, exi
 	}
 }
 
-func checkIdentity(t *testing.T, cdb *datastore.CachedDB, b *types.Ballot, malicious bool) {
-	t.Helper()
-	gotM, err := identities.IsMalicious(cdb, b.SmesherID().Bytes())
-	require.NoError(t, err)
-	require.Equal(t, malicious, gotM)
-}
-
 func TestBallot_MalformedData(t *testing.T) {
 	th := createTestHandlerNoopDecoder(t)
 	b := createBallot(t)
@@ -340,7 +332,6 @@ func TestBallot_BallotDoubleVotedWithinHdist(t *testing.T) {
 	th.mf.EXPECT().GetAtxs(gomock.Any(), types.ATXIDList{b.AtxID}).Return(nil).Times(1)
 	th.mf.EXPECT().GetBlocks(gomock.Any(), types.ToBlockIDs(supported)).Return(nil).Times(1)
 	require.ErrorIs(t, th.HandleSyncedBallot(context.TODO(), data), errDoubleVoting)
-	checkIdentity(t, th.cdb, b, true)
 }
 
 func TestBallot_BallotDoubleVotedWithinHdist_LyrBfrHdist(t *testing.T) {
@@ -365,7 +356,7 @@ func TestBallot_BallotDoubleVotedWithinHdist_LyrBfrHdist(t *testing.T) {
 	th.mf.EXPECT().GetAtxs(gomock.Any(), types.ATXIDList{b.AtxID}).Return(nil).Times(1)
 	th.mf.EXPECT().GetBlocks(gomock.Any(), types.ToBlockIDs(supported)).Return(nil).Times(1)
 	require.ErrorIs(t, th.HandleSyncedBallot(context.TODO(), data), errDoubleVoting)
-	checkIdentity(t, th.cdb, b, true)
+
 }
 
 func TestBallot_BallotDoubleVotedOutsideHdist(t *testing.T) {
@@ -396,7 +387,6 @@ func TestBallot_BallotDoubleVotedOutsideHdist(t *testing.T) {
 		})
 	th.mm.EXPECT().AddBallot(b).Return(nil)
 	require.NoError(t, th.HandleSyncedBallot(context.TODO(), data))
-	checkIdentity(t, th.cdb, b, false)
 }
 
 func TestBallot_ConflictingForAndAgainst(t *testing.T) {
@@ -420,7 +410,7 @@ func TestBallot_ConflictingForAndAgainst(t *testing.T) {
 	th.mf.EXPECT().GetAtxs(gomock.Any(), types.ATXIDList{b.AtxID}).Return(nil).Times(1)
 	th.mf.EXPECT().GetBlocks(gomock.Any(), types.ToBlockIDs(append(supported, supported...))).Return(nil).Times(1)
 	require.ErrorIs(t, th.HandleSyncedBallot(context.TODO(), data), errConflictingExceptions)
-	checkIdentity(t, th.cdb, b, true)
+
 }
 
 func TestBallot_ConflictingForAndAbstain(t *testing.T) {
@@ -444,7 +434,7 @@ func TestBallot_ConflictingForAndAbstain(t *testing.T) {
 	th.mf.EXPECT().GetAtxs(gomock.Any(), types.ATXIDList{b.AtxID}).Return(nil).Times(1)
 	th.mf.EXPECT().GetBlocks(gomock.Any(), types.ToBlockIDs(supported)).Return(nil).Times(1)
 	require.ErrorIs(t, th.HandleSyncedBallot(context.TODO(), data), errConflictingExceptions)
-	checkIdentity(t, th.cdb, b, true)
+
 }
 
 func TestBallot_ConflictingAgainstAndAbstain(t *testing.T) {
@@ -469,7 +459,7 @@ func TestBallot_ConflictingAgainstAndAbstain(t *testing.T) {
 	th.mf.EXPECT().GetAtxs(gomock.Any(), types.ATXIDList{b.AtxID}).Return(nil).Times(1)
 	th.mf.EXPECT().GetBlocks(gomock.Any(), types.ToBlockIDs(against)).Return(nil).Times(1)
 	require.ErrorIs(t, th.HandleSyncedBallot(context.TODO(), data), errConflictingExceptions)
-	checkIdentity(t, th.cdb, b, true)
+
 }
 
 func TestBallot_ExceedMaxExceptions(t *testing.T) {
@@ -494,7 +484,6 @@ func TestBallot_ExceedMaxExceptions(t *testing.T) {
 	th.mf.EXPECT().GetAtxs(gomock.Any(), types.ATXIDList{b.AtxID}).Return(nil).Times(1)
 	th.mf.EXPECT().GetBlocks(gomock.Any(), types.ToBlockIDs(supported)).Return(nil).Times(1)
 	require.ErrorIs(t, th.HandleSyncedBallot(context.TODO(), data), errExceptionsOverflow)
-	checkIdentity(t, th.cdb, b, false)
 }
 
 func TestBallot_BallotsNotAvailable(t *testing.T) {
@@ -506,7 +495,6 @@ func TestBallot_BallotsNotAvailable(t *testing.T) {
 	th.mf.EXPECT().AddPeersFromHash(b.ID().AsHash32(), collectHashes(*b))
 	th.mf.EXPECT().GetBallots(gomock.Any(), []types.BallotID{b.Votes.Base, b.RefBallot}).Return(errUnknown).Times(1)
 	require.ErrorIs(t, th.HandleSyncedBallot(context.TODO(), data), errUnknown)
-	checkIdentity(t, th.cdb, b, false)
 }
 
 func TestBallot_ATXsNotAvailable(t *testing.T) {
@@ -518,7 +506,6 @@ func TestBallot_ATXsNotAvailable(t *testing.T) {
 	errUnknown := errors.New("unknown")
 	th.mf.EXPECT().GetAtxs(gomock.Any(), types.ATXIDList{b.AtxID}).Return(errUnknown).Times(1)
 	require.ErrorIs(t, th.HandleSyncedBallot(context.TODO(), data), errUnknown)
-	checkIdentity(t, th.cdb, b, false)
 }
 
 func TestBallot_BlocksNotAvailable(t *testing.T) {
@@ -541,7 +528,6 @@ func TestBallot_BlocksNotAvailable(t *testing.T) {
 	errUnknown := errors.New("unknown")
 	th.mf.EXPECT().GetBlocks(gomock.Any(), types.ToBlockIDs(supported)).Return(errUnknown).Times(1)
 	require.ErrorIs(t, th.HandleSyncedBallot(context.TODO(), data), errUnknown)
-	checkIdentity(t, th.cdb, b, false)
 }
 
 func TestBallot_ErrorCheckingEligible(t *testing.T) {
@@ -569,7 +555,6 @@ func TestBallot_ErrorCheckingEligible(t *testing.T) {
 			return false, errors.New("unknown")
 		})
 	require.ErrorIs(t, th.HandleSyncedBallot(context.TODO(), data), errNotEligible)
-	checkIdentity(t, th.cdb, b, false)
 }
 
 func TestBallot_NotEligible(t *testing.T) {
@@ -597,7 +582,6 @@ func TestBallot_NotEligible(t *testing.T) {
 			return false, nil
 		})
 	require.ErrorIs(t, th.HandleSyncedBallot(context.TODO(), data), errNotEligible)
-	checkIdentity(t, th.cdb, b, false)
 }
 
 func TestBallot_InvalidVote(t *testing.T) {
@@ -674,7 +658,6 @@ func TestBallot_Success(t *testing.T) {
 	th.md.EXPECT().DecodeBallot(b).Return(decoded, nil)
 	th.md.EXPECT().StoreBallot(decoded).Return(nil)
 	require.NoError(t, th.HandleSyncedBallot(context.TODO(), data))
-	checkIdentity(t, th.cdb, b, false)
 }
 
 func TestBallot_RefBallot(t *testing.T) {
@@ -706,7 +689,6 @@ func TestBallot_RefBallot(t *testing.T) {
 		})
 	th.mm.EXPECT().AddBallot(b).Return(nil)
 	require.NoError(t, th.HandleSyncedBallot(context.TODO(), data))
-	checkIdentity(t, th.cdb, b, false)
 }
 
 func TestBallot_DecodeBeforeVotesConsistency(t *testing.T) {
@@ -998,7 +980,6 @@ func TestProposal_ProposalGossip_Fetched(t *testing.T) {
 				require.Equal(t, pubsub.ValidationAccept, th.HandleProposal(context.TODO(), p2p.NoPeer, data))
 			}
 			checkProposal(t, th.cdb, p, true)
-			checkIdentity(t, th.cdb, &p.Ballot, false)
 		})
 	}
 }

--- a/proposals/handler_test.go
+++ b/proposals/handler_test.go
@@ -456,7 +456,6 @@ func TestBallot_ConflictingAgainstAndAbstain(t *testing.T) {
 	th.mf.EXPECT().GetAtxs(gomock.Any(), types.ATXIDList{b.AtxID}).Return(nil).Times(1)
 	th.mf.EXPECT().GetBlocks(gomock.Any(), types.ToBlockIDs(against)).Return(nil).Times(1)
 	require.ErrorIs(t, th.HandleSyncedBallot(context.TODO(), data), errConflictingExceptions)
-
 }
 
 func TestBallot_ExceedMaxExceptions(t *testing.T) {

--- a/proposals/handler_test.go
+++ b/proposals/handler_test.go
@@ -356,7 +356,6 @@ func TestBallot_BallotDoubleVotedWithinHdist_LyrBfrHdist(t *testing.T) {
 	th.mf.EXPECT().GetAtxs(gomock.Any(), types.ATXIDList{b.AtxID}).Return(nil).Times(1)
 	th.mf.EXPECT().GetBlocks(gomock.Any(), types.ToBlockIDs(supported)).Return(nil).Times(1)
 	require.ErrorIs(t, th.HandleSyncedBallot(context.TODO(), data), errDoubleVoting)
-
 }
 
 func TestBallot_BallotDoubleVotedOutsideHdist(t *testing.T) {
@@ -410,7 +409,6 @@ func TestBallot_ConflictingForAndAgainst(t *testing.T) {
 	th.mf.EXPECT().GetAtxs(gomock.Any(), types.ATXIDList{b.AtxID}).Return(nil).Times(1)
 	th.mf.EXPECT().GetBlocks(gomock.Any(), types.ToBlockIDs(append(supported, supported...))).Return(nil).Times(1)
 	require.ErrorIs(t, th.HandleSyncedBallot(context.TODO(), data), errConflictingExceptions)
-
 }
 
 func TestBallot_ConflictingForAndAbstain(t *testing.T) {
@@ -434,7 +432,6 @@ func TestBallot_ConflictingForAndAbstain(t *testing.T) {
 	th.mf.EXPECT().GetAtxs(gomock.Any(), types.ATXIDList{b.AtxID}).Return(nil).Times(1)
 	th.mf.EXPECT().GetBlocks(gomock.Any(), types.ToBlockIDs(supported)).Return(nil).Times(1)
 	require.ErrorIs(t, th.HandleSyncedBallot(context.TODO(), data), errConflictingExceptions)
-
 }
 
 func TestBallot_ConflictingAgainstAndAbstain(t *testing.T) {


### PR DESCRIPTION
identity should not be cancelled if the data is not kept on mesh and can't be provided to other peers, to ensure that they see things the same way. syntactically invalid data is simply discarded, therefore should not be able to cancel identity.