### PR TITLE
[Merged by Bors] - use base ballot from the layer before current

### DIFF
--- a/tortoise/tortoise.go
+++ b/tortoise/tortoise.go
@@ -141,7 +141,7 @@ func (t *turtle) EncodeVotes(ctx context.Context, conf *encodeConf) (*types.Opin
 		current = *conf.current
 	}
 
-	for lid := t.evicted.Add(1); !lid.After(t.processed); lid = lid.Add(1) {
+	for lid := t.evicted.Add(1); lid.Before(current); lid = lid.Add(1) {
 		for _, ballot := range t.layer(lid).ballots {
 			if ballot.weight.IsNil() {
 				continue

--- a/tortoise/tortoise.go
+++ b/tortoise/tortoise.go
@@ -705,6 +705,10 @@ func (t *turtle) decodeBallot(ballot *types.Ballot) (*ballotInfo, error) {
 			return nil, nil
 		}
 	}
+	if !base.layer.Before(ballot.LayerIndex) {
+		return nil, fmt.Errorf("votes for ballot (%s/%s) should be encoded with base ballot (%s/%s) from previous layers",
+			ballot.LayerIndex, ballot.ID(), base.layer, base.id)
+	}
 
 	if ballot.EpochData != nil {
 		beacon := ballot.EpochData.Beacon

--- a/tortoise/tortoise_test.go
+++ b/tortoise/tortoise_test.go
@@ -2613,6 +2613,51 @@ func TestEncodeVotes(t *testing.T) {
 	})
 }
 
+func TestBaseBallotBeforeCurrentLayer(t *testing.T) {
+	t.Run("encode", func(t *testing.T) {
+		ctx := context.Background()
+		cfg := defaultTestConfig()
+		s := sim.New(sim.WithLayerSize(cfg.LayerSize))
+		s.Setup()
+		tortoise := tortoiseFromSimState(
+			s.GetState(0),
+			WithConfig(cfg),
+			WithLogger(logtest.New(t)),
+		)
+		var last types.LayerID
+		for i := 0; i < 4; i++ {
+			last = s.Next()
+		}
+		tortoise.TallyVotes(ctx, last)
+		encoded, err := tortoise.EncodeVotes(ctx, EncodeVotesWithCurrent(last))
+		require.NoError(t, err)
+		ballot, err := ballots.Get(s.GetState(0).DB, encoded.Base)
+		require.NotEqual(t, last, ballot.LayerIndex)
+	})
+	t.Run("decode", func(t *testing.T) {
+		ctx := context.Background()
+		cfg := defaultTestConfig()
+		s := sim.New(sim.WithLayerSize(cfg.LayerSize))
+		s.Setup()
+		tortoise := tortoiseFromSimState(
+			s.GetState(0),
+			WithConfig(cfg),
+			WithLogger(logtest.New(t)),
+		)
+		var last types.LayerID
+		for i := 0; i < 4; i++ {
+			last = s.Next()
+		}
+		tortoise.TallyVotes(ctx, last)
+		ballots, err := ballots.Layer(s.GetState(0).DB, last)
+		require.NoError(t, err)
+		ballot := types.NewExistingBallot(types.BallotID{1}, nil, nil, ballots[0].InnerBallot)
+		ballot.Votes.Base = ballots[1].ID()
+		_, err = tortoise.DecodeBallot(&ballot)
+		require.ErrorContains(t, err, "votes for ballot")
+	})
+}
+
 func BenchmarkOnBallot(b *testing.B) {
 	const (
 		layerSize = 50

--- a/tortoise/tortoise_test.go
+++ b/tortoise/tortoise_test.go
@@ -2632,6 +2632,7 @@ func TestBaseBallotBeforeCurrentLayer(t *testing.T) {
 		encoded, err := tortoise.EncodeVotes(ctx, EncodeVotesWithCurrent(last))
 		require.NoError(t, err)
 		ballot, err := ballots.Get(s.GetState(0).DB, encoded.Base)
+		require.NoError(t, err)
 		require.NotEqual(t, last, ballot.LayerIndex)
 	})
 	t.Run("decode", func(t *testing.T) {


### PR DESCRIPTION
closes: https://github.com/spacemeshos/go-spacemesh/issues/3717

added syntactic validation to tortoise that checks that the base ballot is from the layer before current ballot
additionally opened issue https://github.com/spacemeshos/go-spacemesh/issues/3753 to move the rest of the validation to the tortoise