### PR TITLE
[Merged by Bors] - prevent double close panic

### DIFF
--- a/common/util/closer.go
+++ b/common/util/closer.go
@@ -8,12 +8,12 @@ type Closer struct {
 }
 
 // NewCloser creates a new (not closed) closer.
+// DEPRECATED: use context.WithCancel.
 func NewCloser() Closer {
 	return Closer{make(chan struct{})}
 }
 
 // Close signals all listening instances to close.
-// Note: should be called only once.
 func (closer *Closer) Close() {
 	select {
 	case <-closer.channel:

--- a/common/util/closer.go
+++ b/common/util/closer.go
@@ -15,7 +15,11 @@ func NewCloser() Closer {
 // Close signals all listening instances to close.
 // Note: should be called only once.
 func (closer *Closer) Close() {
-	close(closer.channel)
+	select {
+	case <-closer.channel:
+	default:
+		close(closer.channel)
+	}
 }
 
 // CloseChannel returns the channel to wait on for close signal.

--- a/common/util/closer_test.go
+++ b/common/util/closer_test.go
@@ -1,0 +1,9 @@
+package util
+
+import "testing"
+
+func TestCloserDoubleClose(t *testing.T) {
+	closer := NewCloser()
+	closer.Close()
+	closer.Close()
+}


### PR DESCRIPTION
closes: https://github.com/spacemeshos/go-spacemesh/issues/3735

this closer should be dropped from the codebase, but i want a quick fix to prevent panics