### PR TITLE
[Merged by Bors] - vm: don't hold write lock until it is time to write accounts updates

### DIFF
--- a/genvm/core/staged_cache_test.go
+++ b/genvm/core/staged_cache_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestCacheGetCopies(t *testing.T) {
 	db := sql.InMemory()
-	ss := core.NewStagedCache(db)
+	ss := core.NewStagedCache(core.DBLoader{db})
 	address := core.Address{1}
 	account, err := ss.Get(address)
 	require.NoError(t, err)
@@ -24,7 +24,7 @@ func TestCacheGetCopies(t *testing.T) {
 
 func TestCacheUpdatePreserveOrder(t *testing.T) {
 	db := sql.InMemory()
-	ss := core.NewStagedCache(db)
+	ss := core.NewStagedCache(core.DBLoader{db})
 	order := []core.Address{{3}, {1}, {2}}
 	for _, address := range order {
 		require.NoError(t, ss.Update(core.Account{Address: address}))

--- a/genvm/vm.go
+++ b/genvm/vm.go
@@ -89,7 +89,7 @@ type VM struct {
 func (v *VM) Validation(raw types.RawTx) system.ValidationRequest {
 	return &Request{
 		vm:      v,
-		cache:   core.NewStagedCache(v.db),
+		cache:   core.NewStagedCache(core.DBLoader{Executor: v.db}),
 		decoder: scale.NewDecoder(bytes.NewReader(raw.Raw)),
 		raw:     raw,
 	}
@@ -201,7 +201,7 @@ func (v *VM) Apply(lctx ApplyContext, txs []types.Transaction, blockRewards []ty
 	t2 := time.Now()
 	blockDurationWait.Observe(float64(time.Since(t1)))
 
-	ss := core.NewStagedCache(v.db)
+	ss := core.NewStagedCache(core.DBLoader{Executor: v.db})
 	results, skipped, fees, err := v.execute(lctx, ss, txs)
 	if err != nil {
 		return nil, nil, err

--- a/genvm/vm.go
+++ b/genvm/vm.go
@@ -209,13 +209,8 @@ func (v *VM) Apply(lctx ApplyContext, txs []types.Transaction, blockRewards []ty
 	t3 := time.Now()
 	blockDurationTxs.Observe(float64(time.Since(t2)))
 
-	tx, err := v.db.TxImmediate(context.Background())
+	rewardsResult, err := v.addRewards(lctx, ss, fees, blockRewards)
 	if err != nil {
-		return nil, nil, err
-	}
-	defer tx.Release()
-
-	if err := v.addRewards(lctx, ss, tx, fees, blockRewards); err != nil {
 		return nil, nil, err
 	}
 
@@ -225,6 +220,18 @@ func (v *VM) Apply(lctx ApplyContext, txs []types.Transaction, blockRewards []ty
 	hasher := hash.New()
 	encoder := scale.NewEncoder(hasher)
 	total := 0
+
+	tx, err := v.db.TxImmediate(context.Background())
+	if err != nil {
+		return nil, nil, err
+	}
+	defer tx.Release()
+
+	for _, reward := range rewardsResult {
+		if err := rewards.Add(tx, &reward); err != nil {
+			return nil, nil, fmt.Errorf("%w: %s", core.ErrInternal, err.Error())
+		}
+	}
 
 	ss.IterateChanged(func(account *core.Account) bool {
 		total++


### PR DESCRIPTION
vm will take non-negligible cpu time to execute with increasing tx load. we are using sqlite that has a single write lock, so every other writer will have to wait.

it contributes to performance issues on the network