### PR TITLE
[Merged by Bors] - raise max message size to 2 mb

### DIFF
--- a/p2p/host.go
+++ b/p2p/host.go
@@ -29,7 +29,7 @@ func DefaultConfig() Config {
 		HighPeers:            100,
 		GracePeersShutdown:   30 * time.Second,
 		BootstrapTimeout:     10 * time.Second,
-		MaxMessageSize:       200 << 10,
+		MaxMessageSize:       2 << 20,
 		CheckInterval:        3 * time.Minute,
 		CheckTimeout:         30 * time.Second,
 		CheckPeersNumber:     10,


### PR DESCRIPTION
turns out some hare messages are larger than 200kb 
i don't know if 2mb is enough for 800 cluster, but 200kb is definetely not enough for 200 cluster
