### PR TITLE
[Merged by Bors] - Use kubectl 1.23 for compatibility with gcloud

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,7 +272,7 @@ jobs:
         id: install
         uses: azure/setup-kubectl@v3
         with:
-          version: "v1.23.0"
+          version: "v1.23.15"
 
       - name: Setup gcloud authentication
         id: "auth"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,7 +272,7 @@ jobs:
         id: install
         uses: azure/setup-kubectl@v3
         with:
-          version: "1.23.15"
+          version: "v1.23.0"
 
       - name: Setup gcloud authentication
         id: "auth"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,7 +268,14 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - id: "auth"
+      - name: Setup kubectl
+        id: install
+        uses: azure/setup-kubectl@v3
+        with:
+          version: "1.23.15"
+
+      - name: Setup gcloud authentication
+        id: "auth"
         uses: "google-github-actions/auth@v1"
         with:
           # GCP_CREDENTIALS is minified JSON of service account


### PR DESCRIPTION
## Motivation
This fixes warnings / errors in our CI due to incompatibility between kubectl and our systest kubernetes cluster like:

```
Waiting for job/systest-0c27e78-1671028821 to complete or fail
W1214 14:45:50.214703   20068 gcp.go:119] WARNING: the gcp auth plugin is deprecated in v1.22+, unavailable in v1.26+; use gcloud instead.
To learn more, consult https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke
W1214 14:45:50.225181   20066 gcp.go:119] WARNING: the gcp auth plugin is deprecated in v1.22+, unavailable in v1.26+; use gcloud instead.
To learn more, consult https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke
```

## Changes
Install kubectl 1.23.5

## Test Plan
n/a

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
