### PR TITLE
[Merged by Bors] - p2p: set address that will be advertised to peers

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -87,6 +87,8 @@ func AddCommands(cmd *cobra.Command) {
 		cfg.P2P.TargetOutbound, "target outbound connections")
 	cmd.PersistentFlags().StringSliceVar(&cfg.P2P.Bootnodes, "bootnodes",
 		cfg.P2P.Bootnodes, "entrypoints into the network")
+	cmd.PersistentFlags().StringVar(&cfg.P2P.AdvertiseAddress, "advertise-address",
+		cfg.P2P.AdvertiseAddress, "libp2p address with identity (example: /dns4/bootnode.spacemesh.io/tcp/5003)")
 
 	/** ======================== TIME Flags ========================== **/
 

--- a/p2p/host.go
+++ b/p2p/host.go
@@ -46,13 +46,14 @@ type Config struct {
 	BootstrapTimeout   time.Duration
 	MaxMessageSize     int
 
-	DisableNatPort bool     `mapstructure:"disable-natport"`
-	Flood          bool     `mapstructure:"flood"`
-	Listen         string   `mapstructure:"listen"`
-	Bootnodes      []string `mapstructure:"bootnodes"`
-	TargetOutbound int      `mapstructure:"target-outbound"`
-	LowPeers       int      `mapstructure:"low-peers"`
-	HighPeers      int      `mapstructure:"high-peers"`
+	DisableNatPort   bool     `mapstructure:"disable-natport"`
+	Flood            bool     `mapstructure:"flood"`
+	Listen           string   `mapstructure:"listen"`
+	Bootnodes        []string `mapstructure:"bootnodes"`
+	TargetOutbound   int      `mapstructure:"target-outbound"`
+	LowPeers         int      `mapstructure:"low-peers"`
+	HighPeers        int      `mapstructure:"high-peers"`
+	AdvertiseAddress string   `mapstructure:"advertise-address"`
 
 	// Discovery book check section.
 	CheckInterval        time.Duration

--- a/p2p/peerexchange/discovery_test.go
+++ b/p2p/peerexchange/discovery_test.go
@@ -123,13 +123,14 @@ func TestDiscovery_PrefereRoutablePort(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(discovery.Stop)
 
-	external := uint16(1010)
+	port := uint16(1010)
+	advertised := ma.StringCast(fmt.Sprintf("/tcp/%d", port))
 	returned = append(returned, multiaddrFromString(
-		t, fmt.Sprintf("/ip4/110.0.0.0/tcp/%d", external),
+		t, fmt.Sprintf("/ip4/110.0.0.0/tcp/%d", port),
 	))
 
 	emitter.Emit(event.EvtLocalAddressesUpdated{})
 	require.Eventually(t, func() bool {
-		return discovery.ExternalPort() == external
+		return discovery.AdvertisedAddress().Equal(advertised)
 	}, 100*time.Millisecond, 10*time.Millisecond)
 }

--- a/p2p/upgrade.go
+++ b/p2p/upgrade.go
@@ -113,6 +113,7 @@ func Upgrade(h host.Host, genesisID types.Hash20, opts ...Opt) (*Host, error) {
 		CheckTimeout:         cfg.CheckTimeout,
 		CheckInterval:        cfg.CheckInterval,
 		CheckPeersUsedBefore: cfg.CheckPeersUsedBefore,
+		AdvertiseAddress:     cfg.AdvertiseAddress,
 		PeerExchange:         cfg.peerExchange,
 	}); err != nil {
 		return nil, fmt.Errorf("failed to initialize peerexchange discovery: %w", err)


### PR DESCRIPTION
close: https://github.com/spacemeshos/go-spacemesh/issues/3610

added option to set advertise-address. it can be set to any valid libp2p address, that doesn't include p2p identity,
such as /dns4/bootnode.spacemesh.io/tcp/5003. peer will receive this address and add identity that will be known from handshake.

existing discovery behavior is kept backward compatible. if advertise-address is not provided node will try to pick either locally listened port or the port that was mapped by nat device. and advertise it as single-component multiaddr - /tcp/9090. and receiver will add ip address from the peer socket if it receives only port.

can be configured using command line flag:
```
--advertise-address=/dns4/bootnode.spacemesh.io/tcp/5003
```
or config option:
```json
{
    "p2p": {"advertise-address": "/dns4/bootnode.spacemesh.io/tcp/5003"}
}
```