### PR TITLE
[Merged by Bors] - systest: fail fast tests to avoid timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,7 +325,7 @@ jobs:
           node_selector: cloud.google.com/gke-nodepool=gha
           size: 50
           bootstrap: 10m
-          level: debug
+          level: info
           clusters: 2
         run: make -C systest run test_name=.
 
@@ -338,7 +338,7 @@ jobs:
           node_selector: cloud.google.com/gke-nodepool=gha
           size: 30
           bootstrap: 10m
-          level: debug
+          level: info
           clusters: 2
         run: make -C systest run test_name=.
 

--- a/systest/Dockerfile
+++ b/systest/Dockerfile
@@ -7,7 +7,7 @@ COPY go.sum .
 RUN go mod download
 
 COPY . .
-RUN --mount=type=cache,target=/root/.cache/go-build go test -v -c -o /build/tests.test ./systest/tests/
+RUN --mount=type=cache,target=/root/.cache/go-build go test -failfast -v -c -o /build/tests.test ./systest/tests/
 
 FROM alpine
 COPY --from=build /build/tests.test /bin/tests


### PR DESCRIPTION
## Motivation
- attempt to differentiate test failures vs test timeout
- make systest I log at info level