### PR TITLE
[Merged by Bors] - Changed concurrency group for ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,7 +268,7 @@ jobs:
       - filter-changes
       - dockerpush
     timeout-minutes: 90
-    concurrency: cloud-limits
+    concurrency: ${{ github.workflow }}-${{ github.ref }}
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
This concurrency change should now limit to one per PR instead of one per repo.