### PR TITLE
[Merged by Bors] - Wait for layer 0 before building the first ATX

### DIFF
--- a/activation/activation.go
+++ b/activation/activation.go
@@ -274,11 +274,10 @@ func (b *Builder) run(ctx context.Context) {
 		return
 	}
 
-	// ensure layer 1 has arrived
 	select {
 	case <-ctx.Done():
 		return
-	case <-b.layerClock.AwaitLayer(types.NewLayerID(1)):
+	case <-b.layerClock.AwaitLayer(types.NewLayerID(0)):
 	}
 
 	b.waitForFirstATX(ctx)


### PR DESCRIPTION
## Motivation
The ATX Builder currently waits for layer 1 before it starts its loop that builds ATXes. In systest a layer is 15s long and a poet phase shift is 20 s. It leaves only 5 seconds to submit a challenge at the Poet service. It is too short when there are many nodes submitting a challenge at the same time. As a result, sometimes some nodes miss round 0 and systests fail.

It turns out that layers used to start from number 1. I believe it should actually wait for the first layer (0).

Closes #3908 as node doesn't fail to select the best proof, but it fails to submit a challenge on time and this should be fixed in this PR.

## Changes
Wait for layer 0 before starting the ATX-building loop.

## Test Plan
- unit tests,
- systests,