### PR TITLE
[Merged by Bors] - Fix grpc logger

### DIFF
--- a/cmd/node/node_test.go
+++ b/cmd/node/node_test.go
@@ -116,7 +116,7 @@ func TestSpacemeshApp_SetLoggers(t *testing.T) {
 	app.log = app.addLogger(mylogger, myLog)
 	msg1 := "hi there"
 	app.log.Info(msg1)
-	r.Equal(fmt.Sprintf("INFO\t%-13s\t%s\t{\"module\": \"%s\"}\n", mylogger, msg1, mylogger), buf1.String())
+	r.Equal(fmt.Sprintf("INFO\t%s\t%s\t{\"module\": \"%s\"}\n", mylogger, msg1, mylogger), buf1.String())
 	r.NoError(app.SetLogLevel(mylogger, "warn"))
 	r.Equal("warn", app.loggers[mylogger].String())
 	buf1.Reset()
@@ -129,7 +129,7 @@ func TestSpacemeshApp_SetLoggers(t *testing.T) {
 	app.log.Info(msg2)
 	// This one should be printed
 	app.log.Warning(msg3)
-	r.Equal(fmt.Sprintf("WARN\t%-13s\t%s\t{\"module\": \"%s\"}\n", mylogger, msg3, mylogger), buf1.String())
+	r.Equal(fmt.Sprintf("WARN\t%s\t%s\t{\"module\": \"%s\"}\n", mylogger, msg3, mylogger), buf1.String())
 	r.Equal(fmt.Sprintf("INFO\t%s\n", msg1), buf2.String())
 	buf1.Reset()
 
@@ -138,7 +138,7 @@ func TestSpacemeshApp_SetLoggers(t *testing.T) {
 	msg4 := "nihao"
 	app.log.Info(msg4)
 	r.Equal("info", app.loggers[mylogger].String())
-	r.Equal(fmt.Sprintf("INFO\t%-13s\t%s\t{\"module\": \"%s\"}\n", mylogger, msg4, mylogger), buf1.String())
+	r.Equal(fmt.Sprintf("INFO\t%s\t%s\t{\"module\": \"%s\"}\n", mylogger, msg4, mylogger), buf1.String())
 
 	// test bad logger name
 	r.Error(app.SetLogLevel("anton3", "warn"))
@@ -160,7 +160,7 @@ func TestSpacemeshApp_AddLogger(t *testing.T) {
 	subLogger.Debug("should not get printed")
 	teststr := "should get printed"
 	subLogger.Info(teststr)
-	r.Equal(fmt.Sprintf("INFO\t%-13s\t%s\t{\"module\": \"%s\"}\n", mylogger, teststr, mylogger), buf.String())
+	r.Equal(fmt.Sprintf("INFO\t%s\t%s\t{\"module\": \"%s\"}\n", mylogger, teststr, mylogger), buf.String())
 }
 
 func testArgs(ctx context.Context, root *cobra.Command, args ...string) (string, error) {

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -52,7 +52,7 @@ func TestLogLevel(t *testing.T) {
 	r.NoError(lvl.UnmarshalText([]byte("INFO")))
 	svcName := "mysvc"
 	subLogger := logger.SetLevel(&lvl).WithName(svcName)
-	prefix := fmt.Sprintf("%s.%-13s", loggerName, svcName)
+	prefix := fmt.Sprintf("%s.%s", loggerName, svcName)
 
 	// Test the default app logger
 	// This is NOT hooked

--- a/log/zap.go
+++ b/log/zap.go
@@ -209,7 +209,7 @@ func (l Log) Core() zapcore.Core {
 
 // WithName appends a name to a current name.
 func (l Log) WithName(prefix string) Log {
-	lgr := l.logger.Named(fmt.Sprintf("%-13s", prefix))
+	lgr := l.logger.Named(prefix)
 	var name string
 	if l.name == "" {
 		name = prefix


### PR DESCRIPTION
## Motivation
GRPC logs are missing. It's a regression introduced by #2930.

## Changes
Fixed configuring logging middleware for GRPC.

Additionally, removed the artificial extension of a logger name prefix to 13 characters. It resulted in awkward logger names like:
```
"5678c.app          .grpc         "
```