### PR TITLE
ATX builder should discard challenge if target epoch is current epoch

### DIFF
--- a/activation/activation.go
+++ b/activation/activation.go
@@ -302,6 +302,8 @@ func (b *Builder) generateProof(ctx context.Context) error {
 	return nil
 }
 
+// waitForFirstATX waits until the first ATX can be published. The return value indicates
+// if the function waited or not (for testing).
 func (b *Builder) waitForFirstATX(ctx context.Context) bool {
 	currentLayer := b.layerClock.GetCurrentLayer()
 	currEpoch := currentLayer.GetEpoch()
@@ -349,8 +351,9 @@ func (b *Builder) waitForFirstATX(ctx context.Context) bool {
 
 	waitTime := time.Until(expectedAtxArrivalTime)
 	timer := time.NewTimer(waitTime)
-	b.log.WithContext(ctx).With().Info("waiting for the first ATX", log.Duration("wait", waitTime))
 	defer timer.Stop()
+
+	b.log.WithContext(ctx).With().Info("waiting for the first ATX", log.Duration("wait", waitTime))
 	select {
 	case <-ctx.Done():
 		return false
@@ -368,13 +371,8 @@ func (b *Builder) receivePendingPoetClients() *[]PoetProvingServiceClient {
 
 // loop is the main loop that tries to create an atx per tick received from the global clock.
 func (b *Builder) loop(ctx context.Context) {
-	var poetRetryTimer *time.Timer
-	defer func() {
-		if poetRetryTimer != nil {
-			poetRetryTimer.Stop()
-		}
-	}()
-	defer b.log.Info("atx builder is stopped")
+	defer b.log.Info("atx builder stopped")
+
 	for {
 		if poetClients := b.receivePendingPoetClients(); poetClients != nil {
 			b.nipostBuilder.UpdatePoETProvers(*poetClients)
@@ -382,32 +380,30 @@ func (b *Builder) loop(ctx context.Context) {
 
 		ctx := log.WithNewSessionID(ctx)
 		if err := b.PublishActivationTx(ctx); err != nil {
-			b.log.WithContext(ctx).With().Error("error attempting to publish atx",
-				b.layerClock.GetCurrentLayer(),
-				b.currentEpoch(),
-				log.Err(err))
 			if errors.Is(err, context.Canceled) {
 				return
 			}
+
+			b.log.WithContext(ctx).With().Error("error attempting to publish atx",
+				log.Stringer("current_layer", b.layerClock.GetCurrentLayer()),
+				log.Stringer("current_epoch", b.currentEpoch()),
+				log.Err(err),
+			)
+
 			switch {
 			case errors.Is(err, ErrATXChallengeExpired):
-				b.log.WithContext(ctx).Debug("Discarding challenge")
+				b.log.WithContext(ctx).Debug("discarding challenge")
 				b.discardChallenge()
 				// can be retried immediately with a new challenge
 			case errors.Is(err, ErrPoetServiceUnstable):
-				b.log.WithContext(ctx).Debug("Setting up poet retry timer")
-				if poetRetryTimer == nil {
-					poetRetryTimer = time.NewTimer(b.poetRetryInterval)
-				} else {
-					poetRetryTimer.Reset(b.poetRetryInterval)
-				}
+				b.log.WithContext(ctx).Debug("retrying after poet retry interval")
 				select {
 				case <-ctx.Done():
 					return
-				case <-poetRetryTimer.C:
+				case <-time.After(b.poetRetryInterval):
 				}
 			default:
-				b.log.WithContext(ctx).Warning("Unknown error")
+				b.log.WithContext(ctx).Warning("unknown error")
 				// other failures are related to in-process software. we may as well panic here
 				currentLayer := b.layerClock.GetCurrentLayer()
 				select {
@@ -426,13 +422,15 @@ func (b *Builder) buildNIPostChallenge(ctx context.Context) error {
 		return ctx.Err()
 	case <-b.syncer.RegisterForATXSynced():
 	}
-	challenge := &types.NIPostChallenge{}
+
 	atxID, pubLayerID, err := b.GetPositioningAtxInfo()
 	if err != nil {
 		return fmt.Errorf("failed to get positioning ATX: %w", err)
 	}
-	challenge.PositioningATX = atxID
-	challenge.PubLayerID = pubLayerID.Add(b.layersPerEpoch)
+	challenge := &types.NIPostChallenge{
+		PositioningATX: atxID,
+		PubLayerID:     pubLayerID.Add(b.layersPerEpoch),
+	}
 	if prevAtx, err := b.cdb.GetPrevAtx(b.nodeID); err != nil {
 		commitmentAtx, err := b.getCommitmentAtx(ctx)
 		if err != nil {
@@ -555,19 +553,18 @@ func (b *Builder) PublishActivationTx(ctx context.Context) error {
 	b.discardChallengeIfStale()
 	logger := b.log.WithContext(ctx)
 
-	if b.challenge != nil {
-		logger.With().Info("using existing atx challenge", log.Stringer("current_epoch", b.currentEpoch()))
-	} else {
+	if b.challenge == nil {
 		logger.With().Info("building new atx challenge", log.Stringer("current_epoch", b.currentEpoch()))
 		if err := b.buildNIPostChallenge(ctx); err != nil {
 			return fmt.Errorf("build new atx challenge: %w", err)
 		}
 	}
 
-	logger.With().Info("new atx challenge is ready",
+	logger.With().Info("atx challenge is ready",
 		log.Stringer("current_epoch", b.currentEpoch()),
 		log.Stringer("publish_epoch", b.challenge.PublishEpoch()),
-		log.Stringer("target_epoch", b.challenge.TargetEpoch()))
+		log.Stringer("target_epoch", b.challenge.TargetEpoch()),
+	)
 
 	if b.pendingATX == nil {
 		var err error
@@ -650,9 +647,7 @@ func (b *Builder) createAtx(ctx context.Context) (*types.ActivationTx, error) {
 		challenge.InitialPost = b.initialPost
 		challenge.InitialPostMetadata = b.initialPostMeta
 	}
-	buildingNipostCtx, cancel := context.WithDeadline(ctx, nextPoetRoundStart)
-	defer cancel()
-	nipost, postDuration, err := b.nipostBuilder.BuildNIPost(buildingNipostCtx, &challenge, poetProofDeadline)
+	nipost, postDuration, err := b.nipostBuilder.BuildNIPost(ctx, &challenge, poetProofDeadline)
 	if err != nil {
 		return nil, fmt.Errorf("build NIPost: %w", err)
 	}
@@ -750,7 +745,7 @@ func (b *Builder) GetPositioningAtxInfo() (types.ATXID, types.LayerID, error) {
 }
 
 func (b *Builder) discardChallengeIfStale() bool {
-	if b.challenge != nil && b.challenge.TargetEpoch() < b.currentEpoch() {
+	if b.challenge != nil && b.challenge.TargetEpoch() <= b.currentEpoch() {
 		b.log.With().Info("atx target epoch has already passed -- starting over",
 			log.FieldNamed("target_epoch", b.challenge.TargetEpoch()),
 			log.FieldNamed("current_epoch", b.currentEpoch()),

--- a/activation/activation_test.go
+++ b/activation/activation_test.go
@@ -266,7 +266,7 @@ func TestBuilder_waitForFirstATX(t *testing.T) {
 		}
 		tab := newTestBuilder(t, WithPoetConfig(poetCfg))
 		current := types.NewLayerID(layersPerEpoch * 2) // first layer of epoch 2
-		next := types.NewLayerID(current.Value + layersPerEpoch)
+		next := current.Add(layersPerEpoch)
 		addPrevAtx(t, tab.cdb, current.GetEpoch()-1, tab.sig, &tab.nodeID)
 		tab.mclock.EXPECT().GetCurrentLayer().Return(current)
 		tab.mclock.EXPECT().LayerToTime(current).Return(time.Now().Add(-5 * time.Millisecond))


### PR DESCRIPTION
## Motivation
See also https://github.com/spacemeshos/go-spacemesh/issues/3936#issuecomment-1377219636

Prevents possible double publication of an ATX in the same epoch by the same smesher

## Changes
Instead of discarding the challenge when the target epoch is before the current epoch it should discard it if is before or the same as the current epoch.

## Test Plan
Existing tests pass, new tests added

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
