### PR TITLE
[Merged by Bors] - Make events.consumeEvents generic over the type of event

### DIFF
--- a/api/grpcserver/debug_service.go
+++ b/api/grpcserver/debug_service.go
@@ -75,7 +75,7 @@ func (d DebugService) ProposalsStream(_ *emptypb.Empty, stream pb.DebugService_P
 	if sub == nil {
 		return status.Errorf(codes.FailedPrecondition, "event reporting is not enabled")
 	}
-	eventch, fullch := consumeEvents(stream.Context(), sub)
+	eventch, fullch := consumeEvents[events.EventProposal](stream.Context(), sub)
 	// send empty header after subscribing to the channel.
 	// this is optional but allows subscriber to wait until stream is fully initialized.
 	if err := stream.SendHeader(metadata.MD{}); err != nil {
@@ -88,8 +88,7 @@ func (d DebugService) ProposalsStream(_ *emptypb.Empty, stream pb.DebugService_P
 		case <-fullch:
 			return status.Errorf(codes.Canceled, "buffer is full")
 		case ev := <-eventch:
-			pev := ev.(events.EventProposal)
-			if err := stream.Send(castEventProposal(&pev)); err != nil {
+			if err := stream.Send(castEventProposal(&ev)); err != nil {
 				return fmt.Errorf("send to stream: %w", err)
 			}
 		}

--- a/api/grpcserver/globalstate_service.go
+++ b/api/grpcserver/globalstate_service.go
@@ -220,20 +220,20 @@ func (s GlobalStateService) AccountDataStream(in *pb.AccountDataStreamRequest, s
 
 	// Subscribe to the various streams
 	var (
-		accountCh      <-chan any
-		rewardsCh      <-chan any
+		accountCh      <-chan events.Account
+		rewardsCh      <-chan events.Reward
 		receiptsCh     <-chan any
 		accountBufFull <-chan struct{}
 		rewardsBufFull <-chan struct{}
 	)
 	if filterAccount {
 		if accountSubscription := events.SubscribeAccount(); accountSubscription != nil {
-			accountCh, accountBufFull = consumeEvents(stream.Context(), accountSubscription)
+			accountCh, accountBufFull = consumeEvents[events.Account](stream.Context(), accountSubscription)
 		}
 	}
 	if filterReward {
 		if rewardsSubscription := events.SubscribeRewards(); rewardsSubscription != nil {
-			rewardsCh, rewardsBufFull = consumeEvents(stream.Context(), rewardsSubscription)
+			rewardsCh, rewardsBufFull = consumeEvents[events.Reward](stream.Context(), rewardsSubscription)
 		}
 	}
 	if err := stream.SendHeader(metadata.MD{}); err != nil {
@@ -249,9 +249,8 @@ func (s GlobalStateService) AccountDataStream(in *pb.AccountDataStreamRequest, s
 			log.Info("rewards buffer is full, shutting down")
 			return status.Error(codes.Canceled, errRewardsBufferFull)
 		case updatedAccountEvent := <-accountCh:
-			updatedAccount := updatedAccountEvent.(events.Account).Address
 			// Apply address filter
-			if updatedAccount == addr {
+			if updatedAccountEvent.Address == addr {
 				// The Reporter service just sends us the account address. We are responsible
 				// for looking up the other required data here. Get the account balance and
 				// nonce.
@@ -268,8 +267,7 @@ func (s GlobalStateService) AccountDataStream(in *pb.AccountDataStreamRequest, s
 				}
 			}
 
-		case rewardEvent := <-rewardsCh:
-			reward := rewardEvent.(events.Reward)
+		case reward := <-rewardsCh:
 			// Apply address filter
 			if reward.Coinbase == addr {
 				resp := &pb.AccountDataStreamResponse{Datum: &pb.AccountData{Datum: &pb.AccountData_Reward{
@@ -348,21 +346,21 @@ func (s GlobalStateService) GlobalStateStream(in *pb.GlobalStateStreamRequest, s
 
 	// Subscribe to the various streams
 	var (
-		accountCh      <-chan any
-		rewardsCh      <-chan any
-		layersCh       <-chan any
+		accountCh      <-chan events.Account
+		rewardsCh      <-chan events.Reward
+		layersCh       <-chan events.LayerUpdate
 		accountBufFull <-chan struct{}
 		rewardsBufFull <-chan struct{}
 		layersBufFull  <-chan struct{}
 	)
 	if filterAccount {
 		if accountSubscription := events.SubscribeAccount(); accountSubscription != nil {
-			accountCh, accountBufFull = consumeEvents(stream.Context(), accountSubscription)
+			accountCh, accountBufFull = consumeEvents[events.Account](stream.Context(), accountSubscription)
 		}
 	}
 	if filterReward {
 		if rewardsSubscription := events.SubscribeRewards(); rewardsSubscription != nil {
-			rewardsCh, rewardsBufFull = consumeEvents(stream.Context(), rewardsSubscription)
+			rewardsCh, rewardsBufFull = consumeEvents[events.Reward](stream.Context(), rewardsSubscription)
 		}
 	}
 
@@ -370,7 +368,7 @@ func (s GlobalStateService) GlobalStateStream(in *pb.GlobalStateStreamRequest, s
 		// Whenever new state is applied to the mesh, a new layer is reported.
 		// There is no separate reporting specifically for new state.
 		if layersSubscription := events.SubscribeLayers(); layersSubscription != nil {
-			layersCh, layersBufFull = consumeEvents(stream.Context(), layersSubscription)
+			layersCh, layersBufFull = consumeEvents[events.LayerUpdate](stream.Context(), layersSubscription)
 		}
 	}
 
@@ -385,12 +383,11 @@ func (s GlobalStateService) GlobalStateStream(in *pb.GlobalStateStreamRequest, s
 		case <-layersBufFull:
 			log.Info("layers buffer is full, shutting down")
 			return status.Error(codes.Canceled, errLayerBufferFull)
-		case updatedAccountEvent := <-accountCh:
-			updatedAccount := updatedAccountEvent.(events.Account).Address
+		case updatedAccount := <-accountCh:
 			// The Reporter service just sends us the account address. We are responsible
 			// for looking up the other required data here. Get the account balance and
 			// nonce.
-			acct, err := s.getAccount(updatedAccount)
+			acct, err := s.getAccount(updatedAccount.Address)
 			if err != nil {
 				log.With().Error("unable to fetch projected account state", log.Err(err))
 				return status.Errorf(codes.Internal, "error fetching projected account data")
@@ -401,9 +398,7 @@ func (s GlobalStateService) GlobalStateStream(in *pb.GlobalStateStreamRequest, s
 			if err := stream.Send(resp); err != nil {
 				return fmt.Errorf("send to stream: %w", err)
 			}
-		case rewardEvent := <-rewardsCh:
-			reward := rewardEvent.(events.Reward)
-
+		case reward := <-rewardsCh:
 			resp := &pb.GlobalStateStreamResponse{Datum: &pb.GlobalStateData{Datum: &pb.GlobalStateData_Reward{
 				Reward: &pb.Reward{
 					Layer:       &pb.LayerNumber{Number: reward.Layer.Uint32()},
@@ -418,8 +413,7 @@ func (s GlobalStateService) GlobalStateStream(in *pb.GlobalStateStreamRequest, s
 			if err := stream.Send(resp); err != nil {
 				return fmt.Errorf("send to stream: %w", err)
 			}
-		case layerEvent := <-layersCh:
-			layer := layerEvent.(events.LayerUpdate)
+		case layer := <-layersCh:
 			if layer.Status != events.LayerStatusTypeApplied {
 				continue
 			}

--- a/api/grpcserver/node_service.go
+++ b/api/grpcserver/node_service.go
@@ -144,12 +144,12 @@ func (s NodeService) StatusStream(_ *pb.StatusStreamRequest, stream pb.NodeServi
 	log.Info("GRPC NodeService.StatusStream")
 
 	var (
-		statusCh      <-chan any
+		statusCh      <-chan events.Status
 		statusBufFull <-chan struct{}
 	)
 
 	if statusSubscription := events.SubscribeStatus(); statusSubscription != nil {
-		statusCh, statusBufFull = consumeEvents(stream.Context(), statusSubscription)
+		statusCh, statusBufFull = consumeEvents[events.Status](stream.Context(), statusSubscription)
 	}
 
 	for {
@@ -193,12 +193,12 @@ func (s NodeService) ErrorStream(_ *pb.ErrorStreamRequest, stream pb.NodeService
 	log.Info("GRPC NodeService.ErrorStream")
 
 	var (
-		errorsCh      <-chan any
+		errorsCh      <-chan events.NodeError
 		errorsBufFull <-chan struct{}
 	)
 
 	if errorsSubscription := events.SubscribeErrors(); errorsSubscription != nil {
-		errorsCh, errorsBufFull = consumeEvents(stream.Context(), errorsSubscription)
+		errorsCh, errorsBufFull = consumeEvents[events.NodeError](stream.Context(), errorsSubscription)
 	}
 	if err := stream.SendHeader(metadata.MD{}); err != nil {
 		return status.Errorf(codes.Unavailable, "can't send header")
@@ -209,13 +209,11 @@ func (s NodeService) ErrorStream(_ *pb.ErrorStreamRequest, stream pb.NodeService
 		case <-errorsBufFull:
 			log.Info("errors buffer is full, shutting down")
 			return status.Error(codes.Canceled, errErrorsBufferFull)
-		case nodeErrorEvent, ok := <-errorsCh:
+		case nodeError, ok := <-errorsCh:
 			if !ok {
 				log.Info("ErrorStream closed, shutting down")
 				return nil
 			}
-
-			nodeError := nodeErrorEvent.(events.NodeError)
 
 			resp := &pb.ErrorStreamResponse{Error: &pb.NodeError{
 				Level:      convertErrorLevel(nodeError.Level),


### PR DESCRIPTION
## Motivation
Currently, `events.consumeEvents` returns a channel of `any`. Because of this, `any` spreads thru the code harming readability and type safety. This could be improved by returning a channel of type `T`.

## Changes
make `events.consumeEvents` generic over event type `T`.
