### PR TITLE
[Merged by Bors] - hare: more simplification

### DIFF
--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -637,9 +637,12 @@ func (app *App) initServices(ctx context.Context,
 		}),
 		blocks.WithHareOutputChan(hareOutputCh),
 		blocks.WithGeneratorLogger(app.addLogger(BlockGenLogger, lg)))
+
+	hareCfg := app.Config.HARE
+	hareCfg.Hdist = app.Config.Tortoise.Hdist
 	app.hare = hare.New(
 		sqlDB,
-		app.Config.HARE,
+		hareCfg,
 		app.host,
 		sgn,
 		nodeID,

--- a/hare/algorithm_test.go
+++ b/hare/algorithm_test.go
@@ -22,8 +22,6 @@ import (
 	smocks "github.com/spacemeshos/go-spacemesh/system/mocks"
 )
 
-var cfg = config.Config{N: 10, F: 5, RoundDuration: 2, ExpectedLeaders: 5, LimitIterations: 1000, LimitConcurrent: 1000}
-
 func newRoundClockFromCfg(logger log.Log, cfg config.Config) *SimpleRoundClock {
 	return NewSimpleRoundClock(time.Now(),
 		time.Duration(cfg.WakeupDelta)*time.Second,
@@ -150,6 +148,7 @@ type testBroker struct {
 }
 
 func buildBroker(tb testing.TB, testName string) *testBroker {
+	cfg := config.Config{N: 10, F: 5, RoundDuration: 2, ExpectedLeaders: 5, LimitIterations: 1000, LimitConcurrent: 1000, Hdist: 20}
 	return buildBrokerWithLimit(tb, testName, cfg.LimitIterations)
 }
 
@@ -197,7 +196,7 @@ func TestConsensusProcess_Start(t *testing.T) {
 }
 
 func TestConsensusProcess_TerminationLimit(t *testing.T) {
-	c := cfg
+	c := config.Config{N: 10, F: 5, RoundDuration: 2, ExpectedLeaders: 5, LimitIterations: 1000, LimitConcurrent: 1000, Hdist: 20}
 	c.LimitConcurrent = 1
 	c.RoundDuration = 1
 	p := generateConsensusProcessWithConfig(t, c)
@@ -218,7 +217,7 @@ func TestConsensusProcess_eventLoop(t *testing.T) {
 	broker.mockSyncS.EXPECT().IsSynced(gomock.Any()).Return(true).AnyTimes()
 	broker.mockSyncS.EXPECT().IsBeaconSynced(gomock.Any()).Return(true).AnyTimes()
 	require.NoError(t, broker.Start(context.Background()))
-	c := cfg
+	c := config.Config{N: 10, F: 5, RoundDuration: 2, ExpectedLeaders: 5, LimitIterations: 1000, LimitConcurrent: 1000, Hdist: 20}
 	c.F = 2
 	proc := generateConsensusProcessWithConfig(t, c)
 	proc.publisher = net
@@ -305,6 +304,7 @@ func TestConsensusProcess_nextRound(t *testing.T) {
 }
 
 func generateConsensusProcess(t *testing.T) *consensusProcess {
+	cfg := config.Config{N: 10, F: 5, RoundDuration: 2, ExpectedLeaders: 5, LimitIterations: 1000, LimitConcurrent: 1000, Hdist: 20}
 	return generateConsensusProcessWithConfig(t, cfg)
 }
 
@@ -524,6 +524,7 @@ func TestConsensusProcess_Termination(t *testing.T) {
 	proc.advanceToNextRound(context.Background())
 	s := NewSetFromValues(value1)
 
+	cfg := config.Config{N: 10, F: 5, RoundDuration: 2, ExpectedLeaders: 5, LimitIterations: 1000, LimitConcurrent: 1000, Hdist: 20}
 	for i := 0; i < cfg.F+1; i++ {
 		signer, err := signing.NewEdSigner()
 		require.NoError(t, err)

--- a/hare/algorithm_test.go
+++ b/hare/algorithm_test.go
@@ -182,7 +182,7 @@ func TestConsensusProcess_Start(t *testing.T) {
 	broker.mockSyncS.EXPECT().IsSynced(gomock.Any()).Return(true).AnyTimes()
 	broker.mockSyncS.EXPECT().IsBeaconSynced(gomock.Any()).Return(true).AnyTimes()
 	broker.Start(context.Background())
-	defer broker.Close()
+	t.Cleanup(broker.Close)
 	proc := generateConsensusProcess(t)
 	inbox, err := broker.Register(context.Background(), proc.ID())
 	require.NoError(t, err)
@@ -220,7 +220,7 @@ func TestConsensusProcess_eventLoop(t *testing.T) {
 	broker.mockSyncS.EXPECT().IsSynced(gomock.Any()).Return(true).AnyTimes()
 	broker.mockSyncS.EXPECT().IsBeaconSynced(gomock.Any()).Return(true).AnyTimes()
 	broker.Start(context.Background())
-	defer broker.Close()
+	t.Cleanup(broker.Close)
 	c := config.Config{N: 10, F: 5, RoundDuration: 2, ExpectedLeaders: 5, LimitIterations: 1000, LimitConcurrent: 1000, Hdist: 20}
 	c.F = 2
 	proc := generateConsensusProcessWithConfig(t, c)

--- a/hare/broker.go
+++ b/hare/broker.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"sync"
 
-	"golang.org/x/sync/errgroup"
-
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/p2p"
@@ -31,15 +29,12 @@ type Broker struct {
 	nodeSyncState system.SyncStateProvider // provider function to check if the node is currently synced
 	outbox        map[uint32]chan *Msg
 	pending       map[uint32][]*Msg // the buffer of pending early messages for the next layer
-	tasks         chan func()       // a channel to synchronize tasks (register/unregister) with incoming messages handling
-	latestLayerMu sync.RWMutex
-	latestLayer   types.LayerID // the latest layer to attempt register (successfully or unsuccessfully)
-	isStarted     bool
+	latestLayer   types.LayerID     // the latest layer to attempt register (successfully or unsuccessfully)
 	minDeleted    types.LayerID
 	limit         int // max number of simultaneous consensus processes
 	ctx           context.Context
 	cancel        context.CancelFunc
-	eg            errgroup.Group
+	once          sync.Once
 }
 
 func newBroker(eValidator validator, stateQuerier stateQuerier, syncState system.SyncStateProvider, limit int, log log.Log) *Broker {
@@ -50,7 +45,6 @@ func newBroker(eValidator validator, stateQuerier stateQuerier, syncState system
 		nodeSyncState: syncState,
 		outbox:        make(map[uint32]chan *Msg),
 		pending:       make(map[uint32][]*Msg),
-		tasks:         make(chan func()),
 		latestLayer:   types.GetEffectiveGenesis(),
 		limit:         limit,
 		minDeleted:    types.GetEffectiveGenesis(),
@@ -60,27 +54,15 @@ func newBroker(eValidator validator, stateQuerier stateQuerier, syncState system
 }
 
 // Start listening to Hare messages (non-blocking).
-func (b *Broker) Start(ctx context.Context) error {
-	if b.isStarted { // Start has been called at least twice
-		b.WithContext(ctx).Error("could not start instance")
-		return errors.New("hare broker already started")
-	}
-	b.isStarted = true
-	{
+func (b *Broker) Start(ctx context.Context) {
+	b.once.Do(func() {
 		b.mu.Lock()
 		defer b.mu.Unlock()
 		if b.cancel != nil {
 			b.cancel()
 		}
 		b.ctx, b.cancel = context.WithCancel(ctx)
-	}
-
-	b.eg.Go(func() error {
-		b.eventLoop(ctx)
-		return nil
 	})
-
-	return nil
 }
 
 var (
@@ -95,17 +77,11 @@ var (
 // validate the message is contextually valid and that the node is synced for processing the message.
 func (b *Broker) validate(ctx context.Context, m *Message) error {
 	msgInstID := m.Layer
-
-	b.mu.RLock()
-	_, exist := b.outbox[msgInstID.Uint32()]
-	b.mu.RUnlock()
-
-	if exist {
+	if b.getInbox(msgInstID) != nil {
 		b.Log.WithContext(ctx).With().Debug("instance exists", msgInstID)
 		return nil
 	}
 
-	// prev layer, must be unregistered
 	latestLayer := b.getLatestLayer()
 
 	if msgInstID.Before(latestLayer) {
@@ -193,30 +169,12 @@ func (b *Broker) handleMessage(ctx context.Context, msg []byte) error {
 	logger.With().Debug("broker reported hare message as valid")
 
 	if isEarly {
-		b.mu.Lock()
-		defer b.mu.Unlock()
-		if _, exist := b.pending[msgLayer.Uint32()]; !exist { // create buffer if first msg
-			b.pending[msgLayer.Uint32()] = make([]*Msg, 0)
-		}
-
-		// we want to write all buffered messages to a chan with InboxCapacity len
-		// hence, we limit the buffer for pending messages
-		chCount := len(b.pending[msgLayer.Uint32()])
-		if chCount == inboxCapacity {
-			logger.With().Error("too many pending messages, ignoring message",
-				log.Int("inbox_capacity", inboxCapacity),
-				log.String("sender_id", iMsg.PubKey.ShortString()))
-			return nil
-		}
-		b.pending[msgLayer.Uint32()] = append(b.pending[msgLayer.Uint32()], iMsg)
-		return nil
+		return b.handleEarlyMessage(logger, iMsg)
 	}
 
 	// has instance, just send
-	b.mu.RLock()
-	out, exist := b.outbox[msgLayer.Uint32()]
-	b.mu.RUnlock()
-	if !exist {
+	out := b.getInbox(msgLayer)
+	if out == nil {
 		logger.With().Debug("missing broker instance for layer", msgLayer)
 		return errTooOld
 	}
@@ -232,32 +190,42 @@ func (b *Broker) handleMessage(ctx context.Context, msg []byte) error {
 	return nil
 }
 
-// listens to incoming messages and incoming tasks.
-func (b *Broker) eventLoop(ctx context.Context) {
-	for {
-		b.WithContext(ctx).With().Debug("broker queue sizes",
-			log.Int("task_queue_size", len(b.tasks)))
-
-		select {
-		case <-b.ctx.Done():
-			return
-		case task := <-b.tasks:
-			latestLayer := b.getLatestLayer()
-
-			b.WithContext(ctx).With().Debug("broker received task, executing",
-				log.Stringer("latest_layer", latestLayer))
-			task()
-			b.WithContext(ctx).With().Debug("broker finished executing task",
-				log.Stringer("latest_layer", latestLayer))
-		}
+func (b *Broker) getInbox(id types.LayerID) chan *Msg {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	out, exist := b.outbox[id.Uint32()]
+	if !exist {
+		return nil
 	}
+	return out
+}
+
+func (b *Broker) handleEarlyMessage(logger log.Log, msg *Msg) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	layerNum := msg.Layer.Uint32()
+	if _, exist := b.pending[layerNum]; !exist { // create buffer if first msg
+		b.pending[layerNum] = make([]*Msg, 0)
+	}
+
+	// we want to write all buffered messages to a chan with InboxCapacity len
+	// hence, we limit the buffer for pending messages
+	chCount := len(b.pending[layerNum])
+	if chCount == inboxCapacity {
+		logger.With().Warning("too many pending messages, ignoring message",
+			log.Int("inbox_capacity", inboxCapacity),
+			log.String("sender_id", msg.PubKey.ShortString()))
+		return nil
+	}
+	b.pending[layerNum] = append(b.pending[layerNum], msg)
+	return nil
 }
 
 func (b *Broker) cleanOldLayers() {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	for i := b.minDeleted.Add(1); i.Before(b.getLatestLayer()); i = i.Add(1) {
+	for i := b.minDeleted.Add(1); i.Before(b.latestLayer); i = i.Add(1) {
 		_, exist := b.outbox[i.Uint32()]
 
 		if !exist { // unregistered
@@ -271,96 +239,47 @@ func (b *Broker) cleanOldLayers() {
 // Register a layer to receive messages
 // Note: the registering instance is assumed to be started and accepting messages.
 func (b *Broker) Register(ctx context.Context, id types.LayerID) (chan *Msg, error) {
-	resErr := make(chan error, 1)
-	resCh := make(chan chan *Msg, 1)
-	regRequest := func() {
-		ctx := log.WithNewSessionID(ctx)
-		b.setLatestLayer(ctx, id)
+	b.setLatestLayer(ctx, id)
 
-		// check to see if the node is still synced
-		if b.Synced(ctx, id) {
-			// This section of code does not need to be protected against possible race conditions
-			// because this function will be added to a queue of tasks that will all be
-			// executed sequentially and synchronously. There is still the concern that two or more
-			// calls to Register will be executed out of order, but Register is only called
-			// on a new layer tick, and anyway updateLatestLayer would panic in this case.
-			b.mu.RLock()
-			outboxLen := len(b.outbox)
-			b.mu.RUnlock()
-			if outboxLen >= b.limit {
-				// unregister the earliest layer to make space for the new layer
-				// cannot call unregister here because unregister blocks and this would cause a deadlock
-				b.mu.RLock()
-				instance := b.minDeleted.Add(1)
-				b.mu.RUnlock()
-				b.cleanState(instance)
-				b.With().Info("unregistered layer due to maximum concurrent processes", instance)
-			}
-
-			outboxCh := make(chan *Msg, inboxCapacity)
-
-			b.mu.Lock()
-			b.outbox[id.Uint32()] = outboxCh
-			pendingForInstance := b.pending[id.Uint32()]
-			b.mu.Unlock()
-
-			if pendingForInstance != nil {
-				for _, mOut := range pendingForInstance {
-					outboxCh <- mOut
-				}
-				b.mu.Lock()
-				delete(b.pending, id.Uint32())
-				b.mu.Unlock()
-			}
-
-			resErr <- nil
-			resCh <- outboxCh
-
-			return
-		}
-
-		// if we are not synced, we return an InstanceNotSynced error
-		resErr <- errInstanceNotSynced
-		resCh <- nil
+	// check to see if the node is still synced
+	if !b.Synced(ctx, id) {
+		return nil, errInstanceNotSynced
 	}
-
-	b.WithContext(ctx).With().Debug("queueing register task", id)
-	b.tasks <- regRequest // send synced task
-
-	// wait for result
-	err := <-resErr
-	result := <-resCh
-	b.WithContext(ctx).With().Debug("register task result received", id, log.Err(err))
-	if err != nil { // reg failed
-		return nil, err
-	}
-
-	return result, nil // reg ok
+	return b.createNewInbox(id), nil
 }
 
-func (b *Broker) cleanState(id types.LayerID) {
+func (b *Broker) createNewInbox(id types.LayerID) chan *Msg {
 	b.mu.Lock()
-	delete(b.outbox, id.Uint32())
-	b.mu.Unlock()
+	defer b.mu.Unlock()
 
-	b.cleanOldLayers()
+	if len(b.outbox) >= b.limit {
+		// unregister the earliest layer to make space for the new layer
+		// cannot call unregister here because unregister blocks and this would cause a deadlock
+		instance := b.minDeleted.Add(1)
+		delete(b.outbox, instance.Uint32())
+		b.minDeleted = instance
+		b.With().Info("unregistered layer due to maximum concurrent processes", instance)
+	}
+	outboxCh := make(chan *Msg, inboxCapacity)
+	b.outbox[id.Uint32()] = outboxCh
+	for _, mOut := range b.pending[id.Uint32()] {
+		outboxCh <- mOut
+	}
+	delete(b.pending, id.Uint32())
+	return outboxCh
+}
+
+func (b *Broker) cleanupInstance(id types.LayerID) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	delete(b.outbox, id.Uint32())
 }
 
 // Unregister a layer from receiving messages.
 func (b *Broker) Unregister(ctx context.Context, id types.LayerID) {
-	wg := sync.WaitGroup{}
-
-	wg.Add(1)
-	f := func() {
-		b.cleanState(id)
-		b.WithContext(ctx).With().Debug("hare broker unregistered layer", id)
-		wg.Done()
-	}
-	select {
-	case b.tasks <- f:
-		wg.Wait()
-	case <-b.ctx.Done():
-	}
+	b.cleanupInstance(id)
+	b.cleanOldLayers()
+	b.WithContext(ctx).With().Debug("hare broker unregistered layer", id)
 }
 
 // Synced returns true if the given layer is synced, false otherwise.
@@ -371,19 +290,18 @@ func (b *Broker) Synced(ctx context.Context, id types.LayerID) bool {
 // Close closes broker.
 func (b *Broker) Close() {
 	b.cancel()
-	_ = b.eg.Wait()
 }
 
 func (b *Broker) getLatestLayer() types.LayerID {
-	b.latestLayerMu.RLock()
-	defer b.latestLayerMu.RUnlock()
+	b.mu.RLock()
+	defer b.mu.RUnlock()
 
 	return b.latestLayer
 }
 
 func (b *Broker) setLatestLayer(ctx context.Context, layer types.LayerID) {
-	b.latestLayerMu.Lock()
-	defer b.latestLayerMu.Unlock()
+	b.mu.Lock()
+	defer b.mu.Unlock()
 
 	if !layer.After(b.latestLayer) { // should expect to update only newer layers
 		b.WithContext(ctx).With().Error("tried to update a previous layer",

--- a/hare/broker_test.go
+++ b/hare/broker_test.go
@@ -57,7 +57,7 @@ func TestBroker_Received(t *testing.T) {
 	broker.mockSyncS.EXPECT().IsBeaconSynced(gomock.Any()).Return(true).AnyTimes()
 	broker.mockStateQ.EXPECT().IsIdentityActiveOnConsensusView(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).AnyTimes()
 	broker.Start(context.Background())
-	defer broker.Close()
+	t.Cleanup(broker.Close)
 
 	inbox, err := broker.Register(context.Background(), instanceID1)
 	assert.Nil(t, err)
@@ -75,7 +75,7 @@ func TestBroker_MaxConcurrentProcesses(t *testing.T) {
 	broker.mockSyncS.EXPECT().IsBeaconSynced(gomock.Any()).Return(true).AnyTimes()
 	broker.mockStateQ.EXPECT().IsIdentityActiveOnConsensusView(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).AnyTimes()
 	broker.Start(context.Background())
-	defer broker.Close()
+	t.Cleanup(broker.Close)
 
 	broker.Register(context.Background(), instanceID1)
 	broker.Register(context.Background(), instanceID2)
@@ -167,7 +167,7 @@ func TestBroker_MultipleInstanceIds(t *testing.T) {
 	broker.mockSyncS.EXPECT().IsBeaconSynced(gomock.Any()).Return(true).AnyTimes()
 	broker.mockStateQ.EXPECT().IsIdentityActiveOnConsensusView(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).AnyTimes()
 	broker.Start(context.Background())
-	defer broker.Close()
+	t.Cleanup(broker.Close)
 
 	inbox1, err := broker.Register(context.Background(), instanceID1)
 	require.NoError(t, err)
@@ -209,7 +209,7 @@ func TestBroker_RegisterUnregister(t *testing.T) {
 	broker.mockSyncS.EXPECT().IsSynced(gomock.Any()).Return(true).AnyTimes()
 	broker.mockSyncS.EXPECT().IsBeaconSynced(gomock.Any()).Return(true).AnyTimes()
 	broker.Start(context.Background())
-	defer broker.Close()
+	t.Cleanup(broker.Close)
 
 	broker.Register(context.Background(), instanceID1)
 
@@ -236,7 +236,7 @@ func TestBroker_Send(t *testing.T) {
 	broker.mockSyncS.EXPECT().IsBeaconSynced(gomock.Any()).Return(true).AnyTimes()
 	broker.mockStateQ.EXPECT().IsIdentityActiveOnConsensusView(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).AnyTimes()
 	broker.Start(ctx)
-	defer broker.Close()
+	t.Cleanup(broker.Close)
 
 	require.Equal(t, pubsub.ValidationIgnore, broker.HandleMessage(ctx, "", nil))
 
@@ -259,7 +259,7 @@ func TestBroker_Register(t *testing.T) {
 	broker.mockSyncS.EXPECT().IsSynced(gomock.Any()).Return(true).AnyTimes()
 	broker.mockSyncS.EXPECT().IsBeaconSynced(gomock.Any()).Return(true).AnyTimes()
 	broker.Start(context.Background())
-	defer broker.Close()
+	t.Cleanup(broker.Close)
 
 	signer, err := signing.NewEdSigner()
 	require.NoError(t, err)
@@ -283,7 +283,7 @@ func TestBroker_Register2(t *testing.T) {
 	broker.mockSyncS.EXPECT().IsBeaconSynced(gomock.Any()).Return(true).AnyTimes()
 	broker.mockStateQ.EXPECT().IsIdentityActiveOnConsensusView(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).AnyTimes()
 	broker.Start(context.Background())
-	defer broker.Close()
+	t.Cleanup(broker.Close)
 	broker.Register(context.Background(), instanceID1)
 
 	signer, err := signing.NewEdSigner()
@@ -305,7 +305,7 @@ func TestBroker_Register3(t *testing.T) {
 	broker.mockSyncS.EXPECT().IsBeaconSynced(gomock.Any()).Return(true).AnyTimes()
 	broker.mockStateQ.EXPECT().IsIdentityActiveOnConsensusView(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).AnyTimes()
 	broker.Start(context.Background())
-	defer broker.Close()
+	t.Cleanup(broker.Close)
 
 	signer, err := signing.NewEdSigner()
 	require.NoError(t, err)
@@ -333,7 +333,7 @@ func TestBroker_PubkeyExtraction(t *testing.T) {
 	broker.mockSyncS.EXPECT().IsBeaconSynced(gomock.Any()).Return(true).AnyTimes()
 	broker.mockStateQ.EXPECT().IsIdentityActiveOnConsensusView(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).AnyTimes()
 	broker.Start(context.Background())
-	defer broker.Close()
+	t.Cleanup(broker.Close)
 	inbox, _ := broker.Register(context.Background(), instanceID1)
 
 	signer, err := signing.NewEdSigner()
@@ -405,7 +405,7 @@ func TestBroker_Register4(t *testing.T) {
 	b.mockSyncS.EXPECT().IsSynced(gomock.Any()).Return(true)
 	b.mockSyncS.EXPECT().IsBeaconSynced(gomock.Any()).Return(true)
 	b.Start(context.Background())
-	defer b.Close()
+	t.Cleanup(b.Close)
 
 	c, e := b.Register(context.Background(), instanceID1)
 	r.NoError(e)
@@ -424,7 +424,7 @@ func TestBroker_eventLoop(t *testing.T) {
 	b := buildBroker(t, t.Name())
 	b.mockStateQ.EXPECT().IsIdentityActiveOnConsensusView(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).AnyTimes()
 	b.Start(context.Background())
-	defer b.Close()
+	t.Cleanup(b.Close)
 
 	signer, err := signing.NewEdSigner()
 	require.NoError(t, err)
@@ -520,7 +520,7 @@ func TestBroker_Flow(t *testing.T) {
 	b.mockSyncS.EXPECT().IsSynced(gomock.Any()).Return(true).AnyTimes()
 	b.mockSyncS.EXPECT().IsBeaconSynced(gomock.Any()).Return(true).AnyTimes()
 	b.Start(context.Background())
-	defer b.Close()
+	t.Cleanup(b.Close)
 
 	signer1, err := signing.NewEdSigner()
 	require.NoError(t, err)

--- a/hare/config/config.go
+++ b/hare/config/config.go
@@ -9,6 +9,8 @@ type Config struct {
 	ExpectedLeaders int `mapstructure:"hare-exp-leaders"`        // the expected number of leaders
 	LimitIterations int `mapstructure:"hare-limit-iterations"`   // limit on number of iterations
 	LimitConcurrent int `mapstructure:"hare-limit-concurrent"`   // limit number of concurrent CPs
+
+	Hdist uint32
 }
 
 // DefaultConfig returns the default configuration for the hare.
@@ -21,5 +23,6 @@ func DefaultConfig() Config {
 		ExpectedLeaders: 5,
 		LimitIterations: 5,
 		LimitConcurrent: 5,
+		Hdist:           20,
 	}
 }

--- a/hare/consensus_test.go
+++ b/hare/consensus_test.go
@@ -175,7 +175,7 @@ func createConsensusProcess(tb testing.TB, ctx context.Context, sig *signing.EdS
 
 func TestConsensusFixedOracle(t *testing.T) {
 	test := newConsensusTest()
-	cfg := config.Config{N: 16, F: 8, RoundDuration: 2, ExpectedLeaders: 5, LimitIterations: 1000}
+	cfg := config.Config{N: 16, F: 8, RoundDuration: 2, ExpectedLeaders: 5, LimitIterations: 1000, Hdist: 20}
 
 	totalNodes := 20
 	ctx, cancel := context.WithCancel(context.Background())
@@ -209,7 +209,7 @@ func TestSingleValueForHonestSet(t *testing.T) {
 	test := newConsensusTest()
 
 	// Larger values may trigger race detector failures because of 8128 goroutines limit.
-	cfg := config.Config{N: 10, F: 5, RoundDuration: 2, ExpectedLeaders: 5, LimitIterations: 1000}
+	cfg := config.Config{N: 10, F: 5, RoundDuration: 2, ExpectedLeaders: 5, LimitIterations: 1000, Hdist: 20}
 	totalNodes := 10
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -242,7 +242,7 @@ func TestSingleValueForHonestSet(t *testing.T) {
 func TestAllDifferentSet(t *testing.T) {
 	test := newConsensusTest()
 
-	cfg := config.Config{N: 10, F: 5, RoundDuration: 2, ExpectedLeaders: 5, LimitIterations: 1000}
+	cfg := config.Config{N: 10, F: 5, RoundDuration: 2, ExpectedLeaders: 5, LimitIterations: 1000, Hdist: 20}
 	totalNodes := 10
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -288,7 +288,7 @@ func TestSndDelayedDishonest(t *testing.T) {
 
 	test := newConsensusTest()
 
-	cfg := config.Config{N: 16, F: 8, RoundDuration: 2, ExpectedLeaders: 5, LimitIterations: 1000}
+	cfg := config.Config{N: 16, F: 8, RoundDuration: 2, ExpectedLeaders: 5, LimitIterations: 1000, Hdist: 20}
 	totalNodes := 20
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -346,7 +346,7 @@ func TestRecvDelayedDishonest(t *testing.T) {
 
 	test := newConsensusTest()
 
-	cfg := config.Config{N: 16, F: 8, RoundDuration: 2, ExpectedLeaders: 5, LimitIterations: 1000}
+	cfg := config.Config{N: 16, F: 8, RoundDuration: 2, ExpectedLeaders: 5, LimitIterations: 1000, Hdist: 20}
 	totalNodes := 20
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -441,7 +441,7 @@ func TestEquivocation(t *testing.T) {
 
 	test := newConsensusTest()
 
-	cfg := config.Config{N: 16, F: 8, RoundDuration: 2, ExpectedLeaders: 5, LimitIterations: 1000}
+	cfg := config.Config{N: 16, F: 8, RoundDuration: 2, ExpectedLeaders: 5, LimitIterations: 1000, Hdist: 20}
 	totalNodes := 20
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/hare/consensus_test.go
+++ b/hare/consensus_test.go
@@ -112,7 +112,7 @@ func (his *HareSuite) checkResult(t *testing.T) {
 	}
 
 	// check that the output has no intersection with the complement of the union of honest
-	for _, v := range his.outputs[0].elements() {
+	for _, v := range his.outputs[0].ToSlice() {
 		if union.Complement(u).Contains(v) {
 			t.Error("Validity 2 failed: unexpected value encountered: ", v)
 		}

--- a/hare/flows_test.go
+++ b/hare/flows_test.go
@@ -131,7 +131,7 @@ func Test_consensusIterations(t *testing.T) {
 	test := newConsensusTest()
 
 	totalNodes := 15
-	cfg := config.Config{N: totalNodes, F: totalNodes/2 - 1, WakeupDelta: 1, RoundDuration: 1, ExpectedLeaders: 5, LimitIterations: 1000, LimitConcurrent: 100}
+	cfg := config.Config{N: totalNodes, F: totalNodes/2 - 1, WakeupDelta: 1, RoundDuration: 1, ExpectedLeaders: 5, LimitIterations: 1000, LimitConcurrent: 100, Hdist: 20}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -375,7 +375,7 @@ func Test_multipleCPs(t *testing.T) {
 	finalLyr := types.GetEffectiveGenesis().Add(totalCp)
 	test := newHareWrapper(totalCp)
 	totalNodes := 10
-	cfg := config.Config{N: totalNodes, F: totalNodes/2 - 1, WakeupDelta: 1, RoundDuration: 5, ExpectedLeaders: 5, LimitIterations: 1000, LimitConcurrent: 100}
+	cfg := config.Config{N: totalNodes, F: totalNodes/2 - 1, WakeupDelta: 1, RoundDuration: 5, ExpectedLeaders: 5, LimitIterations: 1000, LimitConcurrent: 100, Hdist: 20}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -470,7 +470,7 @@ func Test_multipleCPsAndIterations(t *testing.T) {
 	finalLyr := types.GetEffectiveGenesis().Add(totalCp)
 	test := newHareWrapper(totalCp)
 	totalNodes := 10
-	cfg := config.Config{N: totalNodes, F: totalNodes/2 - 1, WakeupDelta: 1, RoundDuration: 3, ExpectedLeaders: 5, LimitIterations: 1000, LimitConcurrent: 100}
+	cfg := config.Config{N: totalNodes, F: totalNodes/2 - 1, WakeupDelta: 1, RoundDuration: 5, ExpectedLeaders: 5, LimitIterations: 1000, LimitConcurrent: 100, Hdist: 20}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/hare/hare.go
+++ b/hare/hare.go
@@ -506,9 +506,7 @@ func (h *Hare) Start(ctx context.Context) error {
 	ctxOutputLoop := log.WithNewSessionID(ctx, log.String("protocol", pubsub.HareProtocol+"_outputloop"))
 	ctxMalfLoop := log.WithNewSessionID(ctx, log.String("protocol", pubsub.HareProtocol+"_malfloop"))
 
-	if err := h.broker.Start(ctxBroker); err != nil {
-		return fmt.Errorf("start broker: %w", err)
-	}
+	h.broker.Start(ctxBroker)
 
 	h.eg.Go(func() error {
 		h.tickLoop(ctxTickLoop)

--- a/hare/hare.go
+++ b/hare/hare.go
@@ -222,9 +222,8 @@ func (h *Hare) collectOutput(ctx context.Context, output TerminationOutput) erro
 		consensusOkCnt.Inc()
 		h.WithContext(ctx).With().Info("hare terminated with success", layerID, log.Int("num_proposals", output.Set().Size()))
 		set := output.Set()
-		postNumProposals.Add(float64(set.len()))
-		pids = make([]types.ProposalID, 0, set.len())
-		pids = append(pids, set.elements()...)
+		postNumProposals.Add(float64(set.Size()))
+		pids = set.ToSlice()
 		select {
 		case h.blockGenCh <- LayerOutput{
 			Ctx:       ctx,

--- a/hare/hare.go
+++ b/hare/hare.go
@@ -23,9 +23,6 @@ import (
 	"github.com/spacemeshos/go-spacemesh/system"
 )
 
-// LayerBuffer is the number of layer results we keep at a given time.
-const LayerBuffer = 20
-
 type consensusFactory func(context.Context, config.Config, types.LayerID, *Set, Rolacle, Signer, pubsub.Publisher, RoundClock, chan TerminationOutput, chan types.MalfeasanceGossip) Consensus
 
 // Consensus represents an item that acts like a consensus process.
@@ -84,8 +81,6 @@ type Hare struct {
 
 	layerLock sync.RWMutex
 	lastLayer types.LayerID
-
-	bufferSize uint32
 
 	outputChan chan TerminationOutput
 	mu         sync.RWMutex
@@ -147,10 +142,8 @@ func New(
 	h.patrol = patrol
 
 	h.networkDelta = time.Duration(conf.WakeupDelta) * time.Second
-	// todo: this should be loaded from global config
-	h.bufferSize = LayerBuffer // XXX: must be at least the size of `hdist`
-	h.outputChan = make(chan TerminationOutput, h.bufferSize)
-	h.outputs = make(map[types.LayerID][]types.ProposalID, h.bufferSize) // we keep results about LayerBuffer past layers
+	h.outputChan = make(chan TerminationOutput, h.config.Hdist)
+	h.outputs = make(map[types.LayerID][]types.ProposalID, h.config.Hdist) // we keep results about LayerBuffer past layers
 	h.factory = func(ctx context.Context, conf config.Config, instanceId types.LayerID, s *Set, oracle Rolacle, signing Signer, p2p pubsub.Publisher, clock RoundClock, terminationReport chan TerminationOutput, malCh chan types.MalfeasanceGossip) Consensus {
 		return newConsensusProcess(ctx, conf, instanceId, s, oracle, stateQ, signing, nid, p2p, terminationReport, ev, clock, malCh, logger)
 	}
@@ -188,10 +181,10 @@ func (h *Hare) setLastLayer(layerID types.LayerID) {
 // checks if the provided id is too late/old to be requested.
 func (h *Hare) outOfBufferRange(id types.LayerID) bool {
 	last := h.getLastLayer()
-	if !last.After(types.NewLayerID(h.bufferSize)) {
+	if !last.After(types.NewLayerID(h.config.Hdist)) {
 		return false
 	}
-	if id.Before(last.Sub(h.bufferSize)) { // bufferSize>=0
+	if id.Before(last.Sub(h.config.Hdist)) { // bufferSize>=0
 		return true
 	}
 	return false
@@ -243,7 +236,7 @@ func (h *Hare) collectOutput(ctx context.Context, output TerminationOutput) erro
 
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	if uint32(len(h.outputs)) >= h.bufferSize {
+	if uint32(len(h.outputs)) >= h.config.Hdist {
 		delete(h.outputs, h.oldestResultInBuffer())
 	}
 	h.outputs[layerID] = pids

--- a/hare/hare_rounds_test.go
+++ b/hare/hare_rounds_test.go
@@ -71,6 +71,7 @@ func runNodesFor(t *testing.T, ctx context.Context, nodes, leaders, maxLayers, l
 		ExpectedLeaders: leaders,
 		LimitIterations: limitIterations,
 		LimitConcurrent: maxLayers,
+		Hdist:           20,
 	}
 
 	mesh, err := mocknet.FullMeshLinked(nodes)

--- a/hare/hare_test.go
+++ b/hare/hare_test.go
@@ -537,7 +537,8 @@ func TestHare_onTick_NoBeacon(t *testing.T) {
 	mockBeacons := smocks.NewMockBeaconGetter(gomock.NewController(t))
 	h.beacons = mockBeacons
 	mockBeacons.EXPECT().GetBeacon(lyr.GetEpoch()).Return(types.EmptyBeacon, errors.New("whatever")).Times(1)
-	require.NoError(t, h.broker.Start(context.Background()))
+	h.broker.Start(context.Background())
+	defer h.broker.Close()
 
 	started, err := h.onTick(context.Background(), lyr)
 	assert.NoError(t, err)
@@ -551,7 +552,8 @@ func TestHare_onTick_NotSynced(t *testing.T) {
 	h.mockRoracle.EXPECT().IsIdentityActiveOnConsensusView(gomock.Any(), gomock.Any(), lyr).Return(true, nil).AnyTimes()
 	mockSyncS := smocks.NewMockSyncStateProvider(gomock.NewController(t))
 	h.broker.nodeSyncState = mockSyncS
-	require.NoError(t, h.broker.Start(context.Background()))
+	h.broker.Start(context.Background())
+	defer h.broker.Close()
 
 	mockSyncS.EXPECT().IsSynced(gomock.Any()).Return(false)
 	started, err := h.onTick(context.Background(), lyr)

--- a/hare/hare_test.go
+++ b/hare/hare_test.go
@@ -132,6 +132,7 @@ func TestHare_New(t *testing.T) {
 	require.NoError(t, err)
 
 	logger := logtest.New(t).WithName(t.Name())
+	cfg := config.Config{N: 10, F: 5, RoundDuration: 2, ExpectedLeaders: 5, LimitIterations: 1000, LimitConcurrent: 1000, Hdist: 20}
 	h := New(sql.InMemory(), cfg, noopPubSub(t), signer, types.NodeID{}, make(chan LayerOutput, 1),
 		smocks.NewMockSyncStateProvider(ctrl), smocks.NewMockBeaconGetter(ctrl),
 		eligibility.New(logger), mocks.NewMocklayerPatrol(ctrl), mocks.NewMockstateQuerier(ctrl), newMockClock(), logger)
@@ -177,7 +178,7 @@ func TestHare_collectOutputGetResult_TerminateTooLate(t *testing.T) {
 	assert.Nil(t, res)
 
 	h.layerLock.Lock()
-	h.lastLayer = lyrID.Add(h.bufferSize + 1)
+	h.lastLayer = lyrID.Add(h.config.Hdist + 1)
 	h.layerLock.Unlock()
 
 	pids := []types.ProposalID{types.RandomProposalID(), types.RandomProposalID(), types.RandomProposalID()}
@@ -291,11 +292,11 @@ func TestHare_onTick(t *testing.T) {
 	cfg.N = 2
 	cfg.F = 1
 	cfg.RoundDuration = 1
+	cfg.Hdist = 1
 	clock := newMockClock()
 	h := createTestHare(t, sql.InMemory(), cfg, clock, noopPubSub(t), t.Name())
 
 	h.networkDelta = 0
-	h.bufferSize = 1
 	createdChan := make(chan struct{}, 1)
 	startedChan := make(chan struct{}, 1)
 	var nmcp *mockConsensusProcess
@@ -361,11 +362,11 @@ func TestHare_onTick_BeaconFromRefBallot(t *testing.T) {
 	cfg.N = 2
 	cfg.F = 1
 	cfg.RoundDuration = 1
+	cfg.Hdist = 1
 	clock := newMockClock()
 	h := createTestHare(t, sql.InMemory(), cfg, clock, noopPubSub(t), t.Name())
 
 	h.networkDelta = 0
-	h.bufferSize = 1
 	createdChan := make(chan struct{}, 1)
 	startedChan := make(chan struct{}, 1)
 	var nmcp *mockConsensusProcess
@@ -421,11 +422,11 @@ func TestHare_onTick_SomeBadBallots(t *testing.T) {
 	cfg.N = 2
 	cfg.F = 1
 	cfg.RoundDuration = 1
+	cfg.Hdist = 1
 	clock := newMockClock()
 	h := createTestHare(t, sql.InMemory(), cfg, clock, noopPubSub(t), t.Name())
 
 	h.networkDelta = 0
-	h.bufferSize = 1
 	createdChan := make(chan struct{}, 1)
 	startedChan := make(chan struct{}, 1)
 	var nmcp *mockConsensusProcess
@@ -478,11 +479,11 @@ func TestHare_onTick_NoGoodBallots(t *testing.T) {
 	cfg.N = 2
 	cfg.F = 1
 	cfg.RoundDuration = 1
+	cfg.Hdist = 1
 	clock := newMockClock()
 	h := createTestHare(t, sql.InMemory(), cfg, clock, noopPubSub(t), t.Name())
 
 	h.networkDelta = 0
-	h.bufferSize = 1
 	createdChan := make(chan struct{}, 1)
 	startedChan := make(chan struct{}, 1)
 	var nmcp *mockConsensusProcess
@@ -567,7 +568,7 @@ func TestHare_onTick_NotSynced(t *testing.T) {
 func TestHare_outputBuffer(t *testing.T) {
 	h := createTestHare(t, sql.InMemory(), config.DefaultConfig(), newMockClock(), noopPubSub(t), t.Name())
 	var lyr types.LayerID
-	for i := uint32(1); i <= h.bufferSize; i++ {
+	for i := uint32(1); i <= h.config.Hdist; i++ {
 		lyr = types.GetEffectiveGenesis().Add(i)
 		h.setLastLayer(lyr)
 		require.NoError(t, h.collectOutput(context.Background(), mockReport{lyr, NewEmptySet(0), true, false}))
@@ -576,7 +577,7 @@ func TestHare_outputBuffer(t *testing.T) {
 		require.EqualValues(t, i, len(h.outputs))
 	}
 
-	require.EqualValues(t, h.bufferSize, len(h.outputs))
+	require.EqualValues(t, h.config.Hdist, len(h.outputs))
 
 	// add another output
 	lyr = lyr.Add(1)
@@ -584,30 +585,30 @@ func TestHare_outputBuffer(t *testing.T) {
 	require.NoError(t, h.collectOutput(context.Background(), mockReport{lyr, NewEmptySet(0), true, false}))
 	_, ok := h.outputs[lyr]
 	require.True(t, ok)
-	require.EqualValues(t, h.bufferSize, len(h.outputs))
+	require.EqualValues(t, h.config.Hdist, len(h.outputs))
 
 	// make sure the oldest layer is no longer there
-	_, ok = h.outputs[lyr.Sub(h.bufferSize)]
+	_, ok = h.outputs[lyr.Sub(h.config.Hdist)]
 	assert.False(t, ok)
 }
 
 func TestHare_IsTooLate(t *testing.T) {
 	h := createTestHare(t, sql.InMemory(), config.DefaultConfig(), newMockClock(), noopPubSub(t), t.Name())
 	var lyr types.LayerID
-	for i := uint32(1); i <= h.bufferSize*2; i++ {
+	for i := uint32(1); i <= h.config.Hdist*2; i++ {
 		lyr = types.GetEffectiveGenesis().Add(i)
 		h.setLastLayer(lyr)
 		_ = h.collectOutput(context.Background(), mockReport{lyr, NewEmptySet(0), true, false})
 		_, ok := h.outputs[lyr]
 		assert.True(t, ok)
-		if i < h.bufferSize {
+		if i < h.config.Hdist {
 			assert.EqualValues(t, i, len(h.outputs))
 		} else {
-			assert.EqualValues(t, h.bufferSize, len(h.outputs))
+			assert.EqualValues(t, h.config.Hdist, len(h.outputs))
 		}
 	}
 
-	for i := uint32(1); i <= h.bufferSize; i++ {
+	for i := uint32(1); i <= h.config.Hdist; i++ {
 		lyr = types.GetEffectiveGenesis().Add(i)
 		require.True(t, h.outOfBufferRange(types.GetEffectiveGenesis().Add(1)))
 	}
@@ -617,7 +618,7 @@ func TestHare_IsTooLate(t *testing.T) {
 func TestHare_oldestInBuffer(t *testing.T) {
 	h := createTestHare(t, sql.InMemory(), config.DefaultConfig(), newMockClock(), noopPubSub(t), t.Name())
 	var lyr types.LayerID
-	for i := uint32(1); i <= h.bufferSize; i++ {
+	for i := uint32(1); i <= h.config.Hdist; i++ {
 		lyr = types.GetEffectiveGenesis().Add(i)
 		h.setLastLayer(lyr)
 		require.NoError(t, h.collectOutput(context.Background(), mockReport{lyr, NewEmptySet(0), true, false}))
@@ -633,7 +634,7 @@ func TestHare_oldestInBuffer(t *testing.T) {
 	require.NoError(t, h.collectOutput(context.Background(), mockReport{lyr, NewEmptySet(0), true, false}))
 	_, ok := h.outputs[lyr]
 	require.True(t, ok)
-	require.EqualValues(t, h.bufferSize, len(h.outputs))
+	require.EqualValues(t, h.config.Hdist, len(h.outputs))
 
 	require.Equal(t, types.GetEffectiveGenesis().Add(2), h.oldestResultInBuffer())
 
@@ -642,7 +643,7 @@ func TestHare_oldestInBuffer(t *testing.T) {
 	require.NoError(t, h.collectOutput(context.Background(), mockReport{lyr, NewEmptySet(0), true, false}))
 	_, ok = h.outputs[lyr]
 	require.True(t, ok)
-	require.EqualValues(t, h.bufferSize, len(h.outputs))
+	require.EqualValues(t, h.config.Hdist, len(h.outputs))
 
 	require.Equal(t, types.GetEffectiveGenesis().Add(3), h.oldestResultInBuffer())
 }

--- a/hare/haretypes.go
+++ b/hare/haretypes.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"sync"
 
+	"golang.org/x/exp/maps"
+
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/hare/eligibility"
 	"github.com/spacemeshos/go-spacemesh/hash"
@@ -191,12 +193,7 @@ func (s *Set) ID() types.Hash32 {
 }
 
 func (s *Set) sortedLocked() []types.ProposalID {
-	result := make([]types.ProposalID, 0, len(s.values))
-
-	for id := range s.values {
-		result = append(result, id)
-	}
-
+	result := maps.Keys(s.values)
 	sort.Slice(result, func(i, j int) bool { return bytes.Compare(result[i].Bytes(), result[j].Bytes()) == -1 })
 
 	return result

--- a/hare/haretypes.go
+++ b/hare/haretypes.go
@@ -2,8 +2,8 @@ package hare
 
 import (
 	"bytes"
-	"fmt"
 	"sort"
+	"strings"
 	"sync"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
@@ -52,10 +52,9 @@ func (mType MessageType) String() string {
 
 // Set represents a unique set of values.
 type Set struct {
-	valuesMu  sync.RWMutex
-	values    map[types.ProposalID]struct{}
-	id        types.Hash32
-	isIDValid bool
+	mu     sync.RWMutex
+	values map[types.ProposalID]struct{}
+	sid    types.Hash32
 }
 
 // NewDefaultEmptySet creates an empty set with the default size.
@@ -65,53 +64,37 @@ func NewDefaultEmptySet() *Set {
 
 // NewEmptySet creates an empty set with the provided size.
 func NewEmptySet(size int) *Set {
-	s := &Set{}
-	s.initWithSize(size)
-	s.id = types.Hash32{}
-	s.isIDValid = false
-
-	return s
+	return &Set{values: make(map[types.ProposalID]struct{}, size)}
 }
 
 // NewSetFromValues creates a set of the provided values.
 // Note: duplicated values are ignored.
 func NewSetFromValues(values ...types.ProposalID) *Set {
-	s := &Set{}
-	s.initWithSize(len(values))
+	s := &Set{values: make(map[types.ProposalID]struct{}, len(values))}
 	for _, v := range values {
-		s.Add(v)
+		s.values[v] = struct{}{}
 	}
-	s.id = types.Hash32{}
-	s.isIDValid = false
-
 	return s
 }
 
 // NewSet creates a set from the provided array of values.
 // Note: duplicated values are ignored.
 func NewSet(data []types.ProposalID) *Set {
-	s := &Set{}
-	s.isIDValid = false
-
-	s.initWithSize(len(data))
-
-	// SAFETY: It's safe not to lock here as `s` was just
-	// created and nobody else has access to it yet.
-	for _, bid := range data {
-		s.values[bid] = struct{}{}
+	s := &Set{values: make(map[types.ProposalID]struct{}, len(data))}
+	for _, v := range data {
+		s.values[v] = struct{}{}
 	}
-
 	return s
 }
 
 // Clone creates a copy of the set.
 func (s *Set) Clone() *Set {
-	s.valuesMu.RLock()
-	defer s.valuesMu.RUnlock()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 
 	clone := NewEmptySet(len(s.values))
-	for bid := range s.values {
-		clone.Add(bid)
+	for v := range s.values {
+		clone.values[v] = struct{}{}
 	}
 
 	return clone
@@ -119,51 +102,55 @@ func (s *Set) Clone() *Set {
 
 // Contains returns true if the provided value is contained in the set, false otherwise.
 func (s *Set) Contains(id types.ProposalID) bool {
-	return s.contains(id)
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	_, ok := s.values[id]
+	return ok
 }
 
 // Add a value to the set.
 // It has no effect if the value already exists in the set.
 func (s *Set) Add(id types.ProposalID) {
-	s.valuesMu.Lock()
-	defer s.valuesMu.Unlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	if _, exist := s.values[id]; exist {
 		return
 	}
 
-	s.isIDValid = false
+	s.sid = types.Hash32{}
 	s.values[id] = struct{}{}
 }
 
 // Remove a value from the set.
 // It has no effect if the value doesn't exist in the set.
 func (s *Set) Remove(id types.ProposalID) {
-	s.valuesMu.Lock()
-	defer s.valuesMu.Unlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	if _, exist := s.values[id]; !exist {
 		return
 	}
 
-	s.isIDValid = false
+	s.sid = types.Hash32{}
 	delete(s.values, id)
 }
 
 // Equals returns true if the provided set represents this set, false otherwise.
 func (s *Set) Equals(g *Set) bool {
-	s.valuesMu.RLock()
-	defer s.valuesMu.RUnlock()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 
-	g.valuesMu.RLock()
-	defer g.valuesMu.RUnlock()
+	g.mu.RLock()
+	defer g.mu.RUnlock()
 
 	if len(s.values) != len(g.values) {
 		return false
 	}
 
-	for bid := range s.values {
-		if _, exist := g.values[bid]; !exist {
+	for v := range s.values {
+		if _, exist := g.values[v]; !exist {
 			return false
 		}
 	}
@@ -173,37 +160,24 @@ func (s *Set) Equals(g *Set) bool {
 
 // ToSlice returns the array representation of the set.
 func (s *Set) ToSlice() []types.ProposalID {
-	s.valuesMu.RLock()
-	defer s.valuesMu.RUnlock()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 
 	// order keys
-	keys := make([]types.ProposalID, len(s.values))
-	i := 0
-	for k := range s.values {
-		keys[i] = k
-		i++
-	}
-	sort.Slice(keys, func(i, j int) bool { return bytes.Compare(keys[i].Bytes(), keys[j].Bytes()) == -1 })
-
-	l := make([]types.ProposalID, 0, len(s.values))
-	for i := range keys {
-		l = append(l, keys[i])
-	}
-	return l
+	return s.sortedLocked()
 }
 
-func (s *Set) updateID() {
-	s.valuesMu.RLock()
-	defer s.valuesMu.RUnlock()
+// ID returns the ObjectID of the set.
+func (s *Set) ID() types.Hash32 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.sid != (types.Hash32{}) {
+		return s.sid
+	}
 
 	// order keys
-	keys := make([]types.ProposalID, len(s.values))
-	i := 0
-	for k := range s.values {
-		keys[i] = k
-		i++
-	}
-	sort.Slice(keys, func(i, j int) bool { return bytes.Compare(keys[i].Bytes(), keys[j].Bytes()) == -1 })
+	keys := s.sortedLocked()
 
 	// calc
 	h := hash.New()
@@ -212,38 +186,43 @@ func (s *Set) updateID() {
 	}
 
 	// update
-	s.id = types.BytesToHash(h.Sum([]byte{}))
-	s.isIDValid = true
+	s.sid = types.BytesToHash(h.Sum([]byte{}))
+	return s.sid
 }
 
-// ID returns the ObjectID of the set.
-func (s *Set) ID() types.Hash32 {
-	if !s.isIDValid {
-		s.updateID()
+func (s *Set) sortedLocked() []types.ProposalID {
+	result := make([]types.ProposalID, 0, len(s.values))
+
+	for id := range s.values {
+		result = append(result, id)
 	}
 
-	return s.id
+	sort.Slice(result, func(i, j int) bool { return bytes.Compare(result[i].Bytes(), result[j].Bytes()) == -1 })
+
+	return result
 }
 
 func (s *Set) String() string {
-	s.valuesMu.RLock()
-	defer s.valuesMu.RUnlock()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 
-	// TODO: should improve
+	var sb strings.Builder
+	idx := len(s.values) - 1
 	b := new(bytes.Buffer)
 	for v := range s.values {
-		fmt.Fprintf(b, "%v,", v.String())
-	}
-	if b.Len() >= 1 {
-		return b.String()[:b.Len()-1]
+		idx--
+		sb.WriteString(v.String())
+		if idx > 0 {
+			sb.WriteString(",")
+		}
 	}
 	return b.String()
 }
 
 // IsSubSetOf returns true if s is a subset of g, false otherwise.
 func (s *Set) IsSubSetOf(g *Set) bool {
-	s.valuesMu.RLock()
-	defer s.valuesMu.RUnlock()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 
 	for v := range s.values {
 		if !g.Contains(v) {
@@ -256,8 +235,8 @@ func (s *Set) IsSubSetOf(g *Set) bool {
 
 // Intersection returns the intersection a new set which represents the intersection of s and g.
 func (s *Set) Intersection(g *Set) *Set {
-	s.valuesMu.RLock()
-	defer s.valuesMu.RUnlock()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 
 	both := NewEmptySet(len(s.values))
 	for v := range s.values {
@@ -271,20 +250,20 @@ func (s *Set) Intersection(g *Set) *Set {
 
 // Union returns a new set which represents the union set of s and g.
 func (s *Set) Union(g *Set) *Set {
-	s.valuesMu.RLock()
-	defer s.valuesMu.RUnlock()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 
-	g.valuesMu.RLock()
-	defer g.valuesMu.RUnlock()
+	g.mu.RLock()
+	defer g.mu.RUnlock()
 
 	union := NewEmptySet(len(s.values) + len(g.values))
 
 	for v := range s.values {
-		union.Add(v)
+		union.values[v] = struct{}{}
 	}
 
 	for v := range g.values {
-		union.Add(v)
+		union.values[v] = struct{}{}
 	}
 
 	return union
@@ -292,13 +271,13 @@ func (s *Set) Union(g *Set) *Set {
 
 // Complement returns a new set that represents the complement of s relatively to the world u.
 func (s *Set) Complement(u *Set) *Set {
-	s.valuesMu.RLock()
-	defer s.valuesMu.RUnlock()
+	u.mu.RLock()
+	defer u.mu.RUnlock()
 
 	comp := NewEmptySet(len(u.values))
 	for v := range u.values {
 		if !s.Contains(v) {
-			comp.Add(v)
+			comp.values[v] = struct{}{}
 		}
 	}
 
@@ -307,50 +286,18 @@ func (s *Set) Complement(u *Set) *Set {
 
 // Subtract g from s.
 func (s *Set) Subtract(g *Set) {
-	g.valuesMu.RLock()
-	defer g.valuesMu.RUnlock()
+	g.mu.RLock()
+	defer g.mu.RUnlock()
 
 	for v := range g.values {
 		s.Remove(v)
 	}
 }
 
-// Size returns the number of elements in the set.
+// Size returns the number of SortedElements in the set.
 func (s *Set) Size() int {
-	return s.len()
-}
-
-func (s *Set) initWithSize(size int) {
-	s.valuesMu.Lock()
-	defer s.valuesMu.Unlock()
-
-	s.values = make(map[types.ProposalID]struct{}, size)
-}
-
-func (s *Set) len() int {
-	s.valuesMu.RLock()
-	defer s.valuesMu.RUnlock()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 
 	return len(s.values)
-}
-
-func (s *Set) contains(id types.ProposalID) bool {
-	s.valuesMu.RLock()
-	defer s.valuesMu.RUnlock()
-
-	_, ok := s.values[id]
-	return ok
-}
-
-func (s *Set) elements() []types.ProposalID {
-	s.valuesMu.RLock()
-	defer s.valuesMu.RUnlock()
-
-	result := make([]types.ProposalID, 0, len(s.values))
-
-	for id := range s.values {
-		result = append(result, id)
-	}
-
-	return result
 }

--- a/hare/messagevalidation.go
+++ b/hare/messagevalidation.go
@@ -450,8 +450,8 @@ func (v *syntaxContextValidator) validateSVPTypeA(ctx context.Context, m *Msg) b
 	for _, status := range m.InnerMsg.Svp.Messages {
 		statusSet := NewSet(status.InnerMsg.Values)
 		// build union
-		for _, bid := range statusSet.elements() {
-			unionSet.Add(bid) // assuming add is unique
+		for _, pid := range statusSet.ToSlice() {
+			unionSet.Add(pid) // assuming add is unique
 		}
 	}
 

--- a/hare/messagevalidation_test.go
+++ b/hare/messagevalidation_test.go
@@ -183,7 +183,7 @@ func TestMessageValidator_IsStructureValid(t *testing.T) {
 	assert.True(t, validator.SyntacticallyValidateMessage(context.Background(), m))
 	m.InnerMsg.Values = nil
 	assert.True(t, validator.SyntacticallyValidateMessage(context.Background(), m))
-	m.InnerMsg.Values = NewDefaultEmptySet().ToSlice()
+	m.InnerMsg.Values = []types.ProposalID{}
 	assert.True(t, validator.SyntacticallyValidateMessage(context.Background(), m))
 }
 
@@ -396,8 +396,7 @@ func TestMessageValidator_validateSVPTypeB(t *testing.T) {
 	m := buildProposalMsg(signer, NewSetFromValues(value1, value2, value3), []byte{})
 	s1 := NewSetFromValues(value1)
 	m.InnerMsg.Svp = buildSVP(preRound, s1)
-	s := NewSetFromValues(value1)
-	m.InnerMsg.Values = s.ToSlice()
+	m.InnerMsg.Values = NewSetFromValues(value1).ToSlice()
 	v := defaultValidator(t)
 	assert.False(t, v.validateSVPTypeB(context.Background(), m, NewSetFromValues(value5)))
 	assert.True(t, v.validateSVPTypeB(context.Background(), m, NewSetFromValues(value1)))

--- a/hare/preroundtracker.go
+++ b/hare/preroundtracker.go
@@ -92,7 +92,7 @@ func (pre *preRoundTracker) OnPreRound(ctx context.Context, msg *Msg) {
 	}
 
 	// record Values
-	for _, v := range sToTrack.elements() {
+	for _, v := range sToTrack.ToSlice() {
 		pre.tracker.Track(v, eligibilityCount)
 	}
 
@@ -120,7 +120,7 @@ func (pre *preRoundTracker) CanProveValue(value types.ProposalID) bool {
 // a set is said to be provable if all his values are provable.
 func (pre *preRoundTracker) CanProveSet(set *Set) bool {
 	// a set is provable iff all its Values are provable
-	for _, bid := range set.elements() {
+	for _, bid := range set.ToSlice() {
 		if !pre.CanProveValue(bid) {
 			return false
 		}
@@ -131,9 +131,9 @@ func (pre *preRoundTracker) CanProveSet(set *Set) bool {
 
 // FilterSet filters out non-provable values from the given set.
 func (pre *preRoundTracker) FilterSet(set *Set) {
-	for _, bid := range set.elements() {
-		if !pre.CanProveValue(bid) { // not enough witnesses
-			set.Remove(bid)
+	for _, v := range set.ToSlice() {
+		if !pre.CanProveValue(v) { // not enough witnesses
+			set.Remove(v)
 		}
 	}
 }

--- a/hare/statustracker.go
+++ b/hare/statustracker.go
@@ -78,7 +78,7 @@ func (st *statusTracker) AnalyzeStatuses(isValid func(m *Msg) bool) {
 	st.analyzed = true
 }
 
-// IsSVPReady returns true if theere are enough statuses to build an SVP, false otherwise.
+// IsSVPReady returns true if there are enough statuses to build an SVP, false otherwise.
 func (st *statusTracker) IsSVPReady() bool {
 	return st.analyzed && st.count >= st.threshold
 }
@@ -100,8 +100,8 @@ func (st *statusTracker) ProposalSet(expectedSize int) *Set {
 func (st *statusTracker) buildUnionSet(expectedSize int) *Set {
 	unionSet := NewEmptySet(expectedSize)
 	for _, m := range st.statuses {
-		for _, bid := range NewSet(m.InnerMsg.Values).elements() {
-			unionSet.Add(bid) // assuming add is unique
+		for _, v := range NewSet(m.InnerMsg.Values).ToSlice() {
+			unionSet.Add(v) // assuming add is unique
 		}
 	}
 


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
part of #3921 

## Changes
<!-- Please describe in detail the changes made -->
- simplify broker locking scheme
broker has complexity in both actor-pattern (where locking should be none or minimal) and mutex world. 
choose the mutex, as the broker handles incoming gossip messages and concurrency is important.
this allows for the removal of event loop and goroutine management 
- simplify consensus process (algorithm.go) locking scheme
- use sync.Once for Start() on broker and consensus 
- simplify hare set implementation