### PR TITLE
[Merged by Bors] - Decrease likelihood that VRFNonce tests fail

### DIFF
--- a/activation/validation_test.go
+++ b/activation/validation_test.go
@@ -21,6 +21,7 @@ func Test_Validation_VRFNonce(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	poetDbAPI := NewMockpoetDbAPI(ctrl)
 	postCfg := DefaultPostConfig()
+	postCfg.LabelsPerUnit = 1 << 15
 	meta := &types.PostMetadata{
 		BitsPerLabel:  postCfg.BitsPerLabel,
 		LabelsPerUnit: postCfg.LabelsPerUnit,


### PR DESCRIPTION
## Motivation
Closes #3884 and #3944

## Changes
There is some inherent randomness to the two subtests of `Test_ValidateVRFNonce` mentioned in the ticket. Before the probability of any of these two tests to fail was 1 in 256, with the increased difficulty the probability is now 1 in 8192.

We can make it even less likely (but that increases test duration - which is already ~ 6 seconds) or use hardcoded values instead, which I'm unsure about. Opinions welcome!

## Test Plan
n/a

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
