### PR TITLE
[Merged by Bors] - use cache for identity check to reduce db reads

### DIFF
--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -291,7 +291,7 @@ type App struct {
 	proposalListener *proposals.Handler
 	proposalBuilder  *miner.ProposalBuilder
 	mesh             *mesh.Mesh
-	atxDB            datastore.CachedDB
+	cachedDB         *datastore.CachedDB
 	clock            TickProvider
 	hare             *hare.Hare
 	blockGen         *blocks.Generator
@@ -300,7 +300,6 @@ type App struct {
 	atxBuilder       *activation.Builder
 	atxHandler       *activation.Handler
 	validator        *activation.Validator
-	edSgn            *signing.EdSigner
 	keyExtractor     *signing.PubKeyExtractor
 	beaconProtocol   *beacon.ProtocolDriver
 	log              log.Log
@@ -459,48 +458,29 @@ func (app *App) SetLogLevel(name, loglevel string) error {
 	return nil
 }
 
-func (app *App) initServices(ctx context.Context,
-	nodeID types.NodeID,
-	dbStorepath string,
+func (app *App) initServices(
+	ctx context.Context,
 	sgn *signing.EdSigner,
-	layerSize uint32,
 	poetClients []activation.PoetProvingServiceClient,
 	vrfSigner *signing.VRFSigner,
-	layersPerEpoch uint32, clock TickProvider,
+	clock TickProvider,
 ) error {
-	app.nodeID = nodeID
-
+	nodeID := sgn.NodeID()
+	layerSize := uint32(app.Config.LayerAvgSize)
+	layersPerEpoch := types.GetLayersPerEpoch()
 	lg := app.log.Named(nodeID.ShortString()).WithFields(nodeID)
-	types.SetLayersPerEpoch(app.Config.LayersPerEpoch)
 
-	app.log = app.addLogger(AppLogger, lg)
-
-	sqlDB, err := sql.Open("file:" + filepath.Join(dbStorepath, "state.sql"))
-	if err != nil {
-		return fmt.Errorf("open sqlite db %w", err)
-	}
-	app.db = sqlDB
-	if app.Config.CollectMetrics {
-		app.dbMetrics = dbmetrics.NewDBMetricsCollector(ctx, sqlDB, app.addLogger(StateDbLogger, lg), 5*time.Minute)
-	}
-
-	cdb := datastore.NewCachedDB(sqlDB, app.addLogger(CachedDBLogger, lg))
-	app.atxDB = *cdb
-	poetDb := activation.NewPoetDb(sqlDB, app.addLogger(PoetDbLogger, lg))
+	poetDb := activation.NewPoetDb(app.db, app.addLogger(PoetDbLogger, lg))
 	validator := activation.NewValidator(poetDb, app.Config.POST)
 	app.validator = validator
-
-	if err := os.MkdirAll(dbStorepath, os.ModePerm); err != nil {
-		return fmt.Errorf("failed to create %s: %w", dbStorepath, err)
-	}
 
 	cfg := vm.DefaultConfig()
 	cfg.GasLimit = app.Config.BlockGasLimit
 	cfg.GenesisID = app.Config.Genesis.GenesisID()
-	state := vm.New(sqlDB,
+	state := vm.New(app.db,
 		vm.WithConfig(cfg),
 		vm.WithLogger(app.addLogger(VMLogger, lg)))
-	app.conState = txs.NewConservativeState(state, sqlDB,
+	app.conState = txs.NewConservativeState(state, app.db,
 		txs.WithCSConfig(txs.CSConfig{
 			BlockGasLimit:     app.Config.BlockGasLimit,
 			NumTXsPerProposal: app.Config.TxsPerProposal,
@@ -525,6 +505,7 @@ func (app *App) initServices(ctx context.Context,
 		return errors.New("invalid golden atx id")
 	}
 
+	var err error
 	app.keyExtractor, err = signing.NewPubKeyExtractor(
 		signing.WithExtractorPrefix(app.Config.Genesis.GenesisID().Bytes()),
 	)
@@ -534,12 +515,12 @@ func (app *App) initServices(ctx context.Context,
 
 	types.ExtractNodeIDFromSig = app.keyExtractor.ExtractNodeID
 
-	vrfVerifier, err := signing.NewVRFVerifier(signing.WithNonceFromDB(cdb))
+	vrfVerifier, err := signing.NewVRFVerifier(signing.WithNonceFromDB(app.cachedDB))
 	if err != nil {
 		return fmt.Errorf("failed to create vrf verifier: %w", err)
 	}
 
-	beaconProtocol := beacon.New(nodeID, app.host, sgn, app.keyExtractor, vrfSigner, vrfVerifier, cdb, clock,
+	beaconProtocol := beacon.New(nodeID, app.host, sgn, app.keyExtractor, vrfSigner, vrfVerifier, app.cachedDB, clock,
 		beacon.WithContext(ctx),
 		beacon.WithConfig(app.Config.Beacon),
 		beacon.WithLogger(app.addLogger(BeaconLogger, lg)))
@@ -547,20 +528,20 @@ func (app *App) initServices(ctx context.Context,
 	trtlCfg := app.Config.Tortoise
 	trtlCfg.LayerSize = layerSize
 	trtlCfg.BadBeaconVoteDelayLayers = app.Config.LayersPerEpoch
-	trtl := tortoise.New(cdb, beaconProtocol,
+	trtl := tortoise.New(app.cachedDB, beaconProtocol,
 		tortoise.WithContext(ctx),
 		tortoise.WithLogger(app.addLogger(TrtlLogger, lg)),
 		tortoise.WithConfig(trtlCfg),
 	)
 
-	executor := mesh.NewExecutor(sqlDB, state, app.conState, app.addLogger(Executor, lg))
-	msh, err := mesh.NewMesh(cdb, clock, trtl, executor, app.conState, app.addLogger(MeshLogger, lg))
+	executor := mesh.NewExecutor(app.db, state, app.conState, app.addLogger(Executor, lg))
+	msh, err := mesh.NewMesh(app.cachedDB, clock, trtl, executor, app.conState, app.addLogger(MeshLogger, lg))
 	if err != nil {
 		return fmt.Errorf("failed to create mesh: %w", err)
 	}
 
 	fetcherWrapped := &layerFetcher{}
-	atxHandler := activation.NewHandler(cdb, clock, app.host, fetcherWrapped, layersPerEpoch, app.Config.TickSize, goldenATXID, validator, trtl, app.addLogger(ATXHandlerLogger, lg))
+	atxHandler := activation.NewHandler(app.cachedDB, clock, app.host, fetcherWrapped, layersPerEpoch, app.Config.TickSize, goldenATXID, validator, trtl, app.addLogger(ATXHandlerLogger, lg))
 
 	// we can't have an epoch offset which is greater/equal than the number of layers in an epoch
 
@@ -569,7 +550,7 @@ func (app *App) initServices(ctx context.Context,
 			app.Config.HareEligibility.EpochOffset, app.Config.BaseConfig.LayersPerEpoch)
 	}
 
-	proposalListener := proposals.NewHandler(cdb, app.host, fetcherWrapped, beaconProtocol, msh, trtl,
+	proposalListener := proposals.NewHandler(app.cachedDB, app.host, fetcherWrapped, beaconProtocol, msh, trtl,
 		proposals.WithLogger(app.addLogger(ProposalListenerLogger, lg)),
 		proposals.WithConfig(proposals.Config{
 			LayerSize:      layerSize,
@@ -579,15 +560,15 @@ func (app *App) initServices(ctx context.Context,
 			Hdist:          trtlCfg.Hdist,
 		}))
 
-	blockHandler := blocks.NewHandler(fetcherWrapped, sqlDB, msh,
+	blockHandler := blocks.NewHandler(fetcherWrapped, app.db, msh,
 		blocks.WithLogger(app.addLogger(BlockHandlerLogger, lg)))
 
 	txHandler := txs.NewTxHandler(app.conState, app.addLogger(TxHandlerLogger, lg))
 
-	hOracle := eligibility.New(beaconProtocol, cdb, vrfVerifier, vrfSigner, app.Config.LayersPerEpoch, app.Config.HareEligibility, app.addLogger(HareOracleLogger, lg))
+	hOracle := eligibility.New(beaconProtocol, app.cachedDB, vrfVerifier, vrfSigner, app.Config.LayersPerEpoch, app.Config.HareEligibility, app.addLogger(HareOracleLogger, lg))
 	// TODO: genesisMinerWeight is set to app.Config.SpaceToCommit, because PoET ticks are currently hardcoded to 1
 
-	app.certifier = blocks.NewCertifier(sqlDB, hOracle, nodeID, sgn, app.host, clock, beaconProtocol, trtl,
+	app.certifier = blocks.NewCertifier(app.db, hOracle, nodeID, sgn, app.host, clock, beaconProtocol, trtl,
 		blocks.WithCertContext(ctx),
 		blocks.WithCertConfig(blocks.CertConfig{
 			CommitteeSize:    app.Config.HARE.N,
@@ -597,7 +578,7 @@ func (app *App) initServices(ctx context.Context,
 		}),
 		blocks.WithCertifierLogger(app.addLogger(BlockCertLogger, lg)))
 
-	fetcher := fetch.NewFetch(cdb, msh, beaconProtocol, app.host,
+	fetcher := fetch.NewFetch(app.cachedDB, msh, beaconProtocol, app.host,
 		fetch.WithContext(ctx),
 		fetch.WithConfig(app.Config.FETCH),
 		fetch.WithLogger(app.addLogger(Fetcher, lg)),
@@ -618,7 +599,7 @@ func (app *App) initServices(ctx context.Context,
 		MaxHashesInReq:   100,
 		MaxStaleDuration: time.Hour,
 	}
-	newSyncer := syncer.NewSyncer(cdb, clock, beaconProtocol, msh, fetcher, patrol, app.certifier,
+	newSyncer := syncer.NewSyncer(app.cachedDB, clock, beaconProtocol, msh, fetcher, patrol, app.certifier,
 		syncer.WithContext(ctx),
 		syncer.WithConfig(syncerConf),
 		syncer.WithLogger(app.addLogger(SyncLogger, lg)))
@@ -626,7 +607,7 @@ func (app *App) initServices(ctx context.Context,
 	beaconProtocol.SetSyncState(newSyncer)
 
 	hareOutputCh := make(chan hare.LayerOutput, app.Config.HARE.LimitConcurrent)
-	app.blockGen = blocks.NewGenerator(cdb, executor, msh, fetcherWrapped, app.certifier,
+	app.blockGen = blocks.NewGenerator(app.cachedDB, executor, msh, fetcherWrapped, app.certifier,
 		blocks.WithContext(ctx),
 		blocks.WithConfig(blocks.Config{
 			LayerSize:          layerSize,
@@ -641,7 +622,7 @@ func (app *App) initServices(ctx context.Context,
 	hareCfg := app.Config.HARE
 	hareCfg.Hdist = app.Config.Tortoise.Hdist
 	app.hare = hare.New(
-		sqlDB,
+		app.cachedDB,
 		hareCfg,
 		app.host,
 		sgn,
@@ -660,7 +641,7 @@ func (app *App) initServices(ctx context.Context,
 		clock.Subscribe(),
 		sgn,
 		vrfSigner,
-		cdb,
+		app.cachedDB,
 		app.host,
 		trtl,
 		beaconProtocol,
@@ -672,12 +653,12 @@ func (app *App) initServices(ctx context.Context,
 		miner.WithHdist(app.Config.Tortoise.Hdist),
 		miner.WithLogger(app.addLogger(ProposalBuilderLogger, lg)))
 
-	postSetupMgr, err := activation.NewPostSetupManager(nodeID, app.Config.POST, app.addLogger(PostLogger, lg), cdb, goldenATXID)
+	postSetupMgr, err := activation.NewPostSetupManager(nodeID, app.Config.POST, app.addLogger(PostLogger, lg), app.cachedDB, goldenATXID)
 	if err != nil {
 		app.log.Panic("failed to create post setup manager: %v", err)
 	}
 
-	nipostBuilder := activation.NewNIPostBuilder(nodeID, postSetupMgr, poetClients, poetDb, sqlDB, app.addLogger(NipostBuilderLogger, lg), sgn)
+	nipostBuilder := activation.NewNIPostBuilder(nodeID, postSetupMgr, poetClients, poetDb, app.db, app.addLogger(NipostBuilderLogger, lg), sgn)
 
 	var coinbaseAddr types.Address
 	if app.Config.SMESHING.Start {
@@ -695,7 +676,7 @@ func (app *App) initServices(ctx context.Context,
 		GoldenATXID:     goldenATXID,
 		LayersPerEpoch:  layersPerEpoch,
 	}
-	atxBuilder := activation.NewBuilder(builderConfig, nodeID, sgn, cdb, atxHandler, app.host, nipostBuilder,
+	atxBuilder := activation.NewBuilder(builderConfig, nodeID, sgn, app.cachedDB, atxHandler, app.host, nipostBuilder,
 		postSetupMgr, clock, newSyncer, app.addLogger("atxBuilder", lg),
 		activation.WithContext(ctx),
 		activation.WithPoetConfig(activation.PoetConfig{
@@ -704,7 +685,7 @@ func (app *App) initServices(ctx context.Context,
 			GracePeriod: app.Config.POET.GracePeriod,
 		}))
 
-	malfeasanceHandler := malfeasance.NewHandler(sqlDB, app.addLogger(Malfeasance, lg), app.host.ID())
+	malfeasanceHandler := malfeasance.NewHandler(app.cachedDB, app.addLogger(Malfeasance, lg), app.host.ID())
 
 	syncHandler := func(_ context.Context, _ p2p.Peer, _ []byte) pubsub.ValidationResult {
 		if newSyncer.ListenToGossip() {
@@ -825,7 +806,7 @@ func (app *App) startAPIServices(ctx context.Context) {
 		registerService(grpcserver.NewDebugService(app.conState, app.host))
 	}
 	if apiConf.StartGatewayService {
-		verifier := activation.NewChallengeVerifier(&app.atxDB, app.keyExtractor, app.validator, app.Config.POST, types.ATXID(app.Config.Genesis.GenesisID().ToHash32()), app.Config.LayersPerEpoch)
+		verifier := activation.NewChallengeVerifier(app.cachedDB, app.keyExtractor, app.validator, app.Config.POST, types.ATXID(app.Config.Genesis.GenesisID().ToHash32()), app.Config.LayersPerEpoch)
 		registerService(grpcserver.NewGatewayService(verifier))
 	}
 	if apiConf.StartGlobalStateService {
@@ -845,7 +826,7 @@ func (app *App) startAPIServices(ctx context.Context) {
 		registerService(grpcserver.NewTransactionService(app.db, app.host, app.mesh, app.conState, app.syncer))
 	}
 	if apiConf.StartActivationService {
-		registerService(grpcserver.NewActivationService(&app.atxDB))
+		registerService(grpcserver.NewActivationService(app.cachedDB))
 	}
 
 	// Now that the services are registered, start the server.
@@ -1007,6 +988,24 @@ func (app *App) startSyncer(ctx context.Context) {
 	app.syncer.Start(ctx)
 }
 
+func (app *App) setupDBs(ctx context.Context, lg log.Log, dbPath string) error {
+	if err := os.MkdirAll(dbPath, os.ModePerm); err != nil {
+		return fmt.Errorf("failed to create %s: %w", dbPath, err)
+	}
+
+	sqlDB, err := sql.Open("file:" + filepath.Join(dbPath, "state.sql"))
+	if err != nil {
+		return fmt.Errorf("open sqlite db %w", err)
+	}
+	app.db = sqlDB
+
+	if app.Config.CollectMetrics {
+		app.dbMetrics = dbmetrics.NewDBMetricsCollector(ctx, sqlDB, app.addLogger(StateDbLogger, lg), 5*time.Minute)
+	}
+	app.cachedDB = datastore.NewCachedDB(sqlDB, app.addLogger(CachedDBLogger, lg))
+	return nil
+}
+
 // Start starts the Spacemesh node and initializes all relevant services according to command line arguments provided.
 func (app *App) Start(ctx context.Context) error {
 	// Create a contextual logger for local usage (lower-level modules will create their own contextual loggers
@@ -1056,7 +1055,7 @@ func (app *App) Start(ctx context.Context) error {
 
 	/* Create or load miner identity */
 
-	app.edSgn, err = app.LoadOrCreateEdSigner()
+	edSgn, err := app.LoadOrCreateEdSigner()
 	if err != nil {
 		return fmt.Errorf("could not retrieve identity: %w", err)
 	}
@@ -1066,19 +1065,13 @@ func (app *App) Start(ctx context.Context) error {
 		poetClients = append(poetClients, activation.NewHTTPPoetClient(address))
 	}
 
-	edPubkey := app.edSgn.PublicKey()
-	vrfSigner, err := app.edSgn.VRFSigner(signing.WithNonceFromDB(&app.atxDB))
-	if err != nil {
-		return fmt.Errorf("could not create vrf signer: %w", err)
-	}
+	edPubkey := edSgn.PublicKey()
+	app.nodeID = types.BytesToNodeID(edPubkey.Bytes())
 
-	nodeID := types.BytesToNodeID(edPubkey.Bytes())
-
-	lg := logger.Named(nodeID.ShortString()).WithFields(nodeID)
+	lg := logger.Named(app.nodeID.ShortString()).WithFields(app.nodeID)
 
 	/* Initialize all protocol services */
 
-	dbStorepath := app.Config.DataDir()
 	gTime, err := time.Parse(time.RFC3339, app.Config.Genesis.GenesisTime)
 	if err != nil {
 		return fmt.Errorf("cannot parse genesis time %s: %d", app.Config.Genesis.GenesisTime, err)
@@ -1100,14 +1093,22 @@ func (app *App) Start(ctx context.Context) error {
 		return fmt.Errorf("failed to initialize p2p host: %w", err)
 	}
 
+	dbStorepath := app.Config.DataDir()
+	if err = app.setupDBs(ctx, lg, dbStorepath); err != nil {
+		return err
+	}
+	// need db to initialize the vrf signer
+	vrfSigner, err := edSgn.VRFSigner(signing.WithNonceFromDB(app.cachedDB))
+	if err != nil {
+		return fmt.Errorf("could not create vrf signer: %w", err)
+	}
+
+	app.log = app.addLogger(AppLogger, lg)
+	types.SetLayersPerEpoch(app.Config.LayersPerEpoch)
 	if err = app.initServices(ctx,
-		nodeID,
-		dbStorepath,
-		app.edSgn,
-		uint32(app.Config.LayerAvgSize),
+		edSgn,
 		poetClients,
 		vrfSigner,
-		app.Config.LayersPerEpoch,
 		clock); err != nil {
 		return fmt.Errorf("cannot start services: %w", err)
 	}

--- a/datastore/store.go
+++ b/datastore/store.go
@@ -3,6 +3,7 @@ package datastore
 import (
 	"errors"
 	"fmt"
+	"sync"
 
 	"github.com/spacemeshos/go-spacemesh/codec"
 	"github.com/spacemeshos/go-spacemesh/common/types"
@@ -11,29 +12,114 @@ import (
 	"github.com/spacemeshos/go-spacemesh/sql/atxs"
 	"github.com/spacemeshos/go-spacemesh/sql/ballots"
 	"github.com/spacemeshos/go-spacemesh/sql/blocks"
+	"github.com/spacemeshos/go-spacemesh/sql/identities"
 	"github.com/spacemeshos/go-spacemesh/sql/poets"
 	"github.com/spacemeshos/go-spacemesh/sql/proposals"
 	"github.com/spacemeshos/go-spacemesh/sql/transactions"
 )
 
 const (
-	atxHdrCacheSize = 600
+	atxHdrCacheSize      = 600
+	malfeasanceCacheSize = 1000
 )
 
 // CachedDB is simply a database injected with cache.
 type CachedDB struct {
 	*sql.Database
 	logger      log.Log
-	atxHdrCache AtxCache
+	atxHdrCache *Cache[types.ATXID, types.ActivationTxHeader]
+
+	// used to coordinate db update and cache
+	mu               sync.Mutex
+	malfeasanceCache *Cache[types.NodeID, types.MalfeasanceProof]
 }
 
 // NewCachedDB create an instance of a CachedDB.
 func NewCachedDB(db *sql.Database, lg log.Log) *CachedDB {
 	return &CachedDB{
-		Database:    db,
-		logger:      lg,
-		atxHdrCache: NewAtxCache(atxHdrCacheSize),
+		Database:         db,
+		logger:           lg,
+		atxHdrCache:      NewAtxCache(atxHdrCacheSize),
+		malfeasanceCache: NewMalfeasanceCache(malfeasanceCacheSize),
 	}
+}
+
+func (db *CachedDB) MalfeasanceCacheSize() int {
+	return db.malfeasanceCache.lru.Len()
+}
+
+// IsMalicious returns true if the NodeID is malicious.
+func (db *CachedDB) IsMalicious(id types.NodeID) (bool, error) {
+	if id == types.EmptyNodeID {
+		return false, errors.New("cache db: get empty node id")
+	}
+
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	if proof, ok := db.malfeasanceCache.Get(id); ok {
+		if proof == nil {
+			return false, nil
+		} else {
+			return true, nil
+		}
+	}
+
+	bad, err := identities.IsMalicious(db, id)
+	if err != nil {
+		return false, err
+	}
+	if !bad {
+		db.malfeasanceCache.Add(id, nil)
+	}
+	return bad, nil
+}
+
+// GetMalfeasanceProof gets the malfeasance proof associated with the NodeID.
+func (db *CachedDB) GetMalfeasanceProof(id types.NodeID) (*types.MalfeasanceProof, error) {
+	if id == types.EmptyNodeID {
+		return nil, errors.New("cache db: get empty node id")
+	}
+
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	if proof, ok := db.malfeasanceCache.Get(id); ok {
+		if proof == nil {
+			return nil, sql.ErrNotFound
+		}
+		return proof, nil
+	}
+
+	proof, err := identities.GetMalfeasanceProof(db.Database, id)
+	if err != nil && err != sql.ErrNotFound {
+		return nil, err
+	}
+	db.malfeasanceCache.Add(id, proof)
+	return proof, err
+}
+
+func (db *CachedDB) AddMalfeasanceProof(id types.NodeID, proof *types.MalfeasanceProof, dbtx *sql.Tx) error {
+	if id == types.EmptyNodeID {
+		return errors.New("cache db: add empty node id")
+	}
+
+	encoded, err := codec.Encode(proof)
+	if err != nil {
+		db.logger.Fatal("failed to encode MalfeasanceProof")
+	}
+
+	var exec sql.Executor = db
+	if dbtx != nil {
+		exec = dbtx
+	}
+
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	if err = identities.SetMalicious(exec, id, encoded); err != nil {
+		return err
+	}
+
+	db.malfeasanceCache.Add(id, proof)
+	return nil
 }
 
 // GetAtxHeader returns the ATX header by the given ID. This function is thread safe and will return an error if the ID

--- a/hare/flows_test.go
+++ b/hare/flows_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/datastore"
 	"github.com/spacemeshos/go-spacemesh/eligibility"
 	"github.com/spacemeshos/go-spacemesh/hare/config"
 	"github.com/spacemeshos/go-spacemesh/hare/mocks"
@@ -187,7 +188,7 @@ func createTestHare(tb testing.TB, db *sql.Database, tcfg config.Config, clock *
 
 	mockRoracle := mocks.NewMockRolacle(ctrl)
 
-	hare := New(db, tcfg, p2p, signer, nodeID, make(chan LayerOutput, 100), mockSyncS, mockBeacons, mockRoracle, patrol,
+	hare := New(datastore.NewCachedDB(db, logtest.New(tb)), tcfg, p2p, signer, nodeID, make(chan LayerOutput, 100), mockSyncS, mockBeacons, mockRoracle, patrol,
 		mockStateQ, clock, logtest.New(tb).WithName(name+"_"+signer.PublicKey().ShortString()))
 	p2p.Register(pubsub.HareProtocol, hare.GetHareMsgHandler())
 

--- a/malfeasance/handler_test.go
+++ b/malfeasance/handler_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spacemeshos/go-spacemesh/codec"
 	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/datastore"
 	"github.com/spacemeshos/go-spacemesh/log/logtest"
 	"github.com/spacemeshos/go-spacemesh/malfeasance"
 	"github.com/spacemeshos/go-spacemesh/p2p/pubsub"
@@ -18,7 +19,8 @@ import (
 
 func TestHandler_handleProof_multipleATXs(t *testing.T) {
 	db := sql.InMemory()
-	h := malfeasance.NewHandler(db, logtest.New(t), "self")
+	lg := logtest.New(t)
+	h := malfeasance.NewHandler(datastore.NewCachedDB(db, lg), lg, "self")
 	sig, err := signing.NewEdSigner()
 	require.NoError(t, err)
 	lid := types.NewLayerID(11)
@@ -219,7 +221,8 @@ func TestHandler_handleProof_multipleATXs(t *testing.T) {
 
 func TestHandler_handleProof_multipleBallots(t *testing.T) {
 	db := sql.InMemory()
-	h := malfeasance.NewHandler(db, logtest.New(t), "self")
+	lg := logtest.New(t)
+	h := malfeasance.NewHandler(datastore.NewCachedDB(db, lg), lg, "self")
 	sig, err := signing.NewEdSigner()
 	require.NoError(t, err)
 	lid := types.NewLayerID(11)
@@ -419,7 +422,8 @@ func TestHandler_handleProof_multipleBallots(t *testing.T) {
 
 func TestHandler_handleProof_hareEquivocation(t *testing.T) {
 	db := sql.InMemory()
-	h := malfeasance.NewHandler(db, logtest.New(t), "self")
+	lg := logtest.New(t)
+	h := malfeasance.NewHandler(datastore.NewCachedDB(db, lg), lg, "self")
 	sig, err := signing.NewEdSigner()
 	require.NoError(t, err)
 	lid := types.NewLayerID(11)


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
part of  #3921
<!-- `Closes #XXXX, closes #XXXX, ...` links mentioned issues to this PR and automatically closes them when this it's merged -->

## Changes
<!-- Please describe in detail the changes made -->
use CacheDB to cache both ATXs and malicious proof.

for each atx, proposal, and hare gossip message, we now query if an identity is known malicious.
atx and proposals are less time sensitive than hare. 

for each hare consensus instance, a different committee of N (800) is selected for each round (1preround+4 rounds per iteration). 

