### PR TITLE
[Merged by Bors] - Fix & simplify syncer startup and lifetime

### DIFF
--- a/api/grpcserver/node_service.go
+++ b/api/grpcserver/node_service.go
@@ -25,6 +25,7 @@ import (
 // data such as node status, software version, errors, etc. It can also be used to start
 // the sync process, or to shut down the node.
 type NodeService struct {
+	appCtx      context.Context
 	mesh        api.MeshAPI
 	genTime     api.GenesisTimeAPI
 	peerCounter api.PeerCounter
@@ -39,9 +40,10 @@ func (s NodeService) RegisterService(server *Server) {
 
 // NewNodeService creates a new grpc service using config data.
 func NewNodeService(
-	peers api.PeerCounter, msh api.MeshAPI, genTime api.GenesisTimeAPI, syncer api.Syncer, atxapi api.ActivationAPI,
+	appCtx context.Context, peers api.PeerCounter, msh api.MeshAPI, genTime api.GenesisTimeAPI, syncer api.Syncer, atxapi api.ActivationAPI,
 ) *NodeService {
 	return &NodeService{
+		appCtx:      appCtx,
 		mesh:        msh,
 		genTime:     genTime,
 		peerCounter: peers,
@@ -108,9 +110,9 @@ func (s NodeService) getLayers() (curLayer, latestLayer, verifiedLayer uint32) {
 }
 
 // SyncStart requests that the node start syncing the mesh (if it isn't already syncing).
-func (s NodeService) SyncStart(ctx context.Context, _ *pb.SyncStartRequest) (*pb.SyncStartResponse, error) {
+func (s NodeService) SyncStart(context.Context, *pb.SyncStartRequest) (*pb.SyncStartResponse, error) {
 	log.Info("GRPC NodeService.SyncStart")
-	s.syncer.Start(ctx)
+	s.syncer.Start(s.appCtx)
 	return &pb.SyncStartResponse{
 		Status: &rpcstatus.Status{Code: int32(code.Code_OK)},
 	}, nil

--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -619,7 +619,6 @@ func (app *App) initServices(ctx context.Context,
 		MaxStaleDuration: time.Hour,
 	}
 	newSyncer := syncer.NewSyncer(cdb, clock, beaconProtocol, msh, fetcher, patrol, app.certifier,
-		syncer.WithContext(ctx),
 		syncer.WithConfig(syncerConf),
 		syncer.WithLogger(app.addLogger(SyncLogger, lg)))
 	// TODO(dshulyak) this needs to be improved, but dependency graph is a bit complicated
@@ -835,7 +834,7 @@ func (app *App) startAPIServices(ctx context.Context) {
 		registerService(grpcserver.NewMeshService(app.mesh, app.conState, app.clock, app.Config.LayersPerEpoch, app.Config.Genesis.GenesisID(), layerDuration, app.Config.LayerAvgSize, app.Config.TxsPerProposal))
 	}
 	if apiConf.StartNodeService {
-		nodeService := grpcserver.NewNodeService(app.host, app.mesh, app.clock, app.syncer, app.atxBuilder)
+		nodeService := grpcserver.NewNodeService(ctx, app.host, app.mesh, app.clock, app.syncer, app.atxBuilder)
 		registerService(nodeService)
 	}
 	if apiConf.StartSmesherService {

--- a/syncer/state_syncer.go
+++ b/syncer/state_syncer.go
@@ -52,8 +52,10 @@ func (s *Syncer) processLayers(ctx context.Context) error {
 	// used to make sure we only resync from the same peer once during each run.
 	resyncPeers := make(map[p2p.Peer]struct{})
 	for lid := start; !lid.After(s.getLastSyncedLayer()); lid = lid.Add(1) {
-		if s.isClosed() {
-			return errShuttingDown
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
 		}
 
 		logger := s.logger.WithContext(ctx).WithFields(lid, lid.GetEpoch())

--- a/syncer/state_syncer_test.go
+++ b/syncer/state_syncer_test.go
@@ -206,7 +206,7 @@ func TestProcessLayers_Shutdown(t *testing.T) {
 	ts.mTicker.advanceToLayer(lastSynced.Add(1))
 
 	cancel()
-	require.ErrorIs(t, ts.syncer.processLayers(context.Background()), errShuttingDown)
+	require.ErrorIs(t, ts.syncer.processLayers(ctx), context.Canceled)
 	require.False(t, ts.syncer.stateSynced())
 }
 

--- a/syncer/syncer_test.go
+++ b/syncer/syncer_test.go
@@ -101,7 +101,6 @@ func newTestSyncer(ctx context.Context, t *testing.T, interval time.Duration) *t
 		HareDelayLayers:  5,
 	}
 	ts.syncer = NewSyncer(ts.cdb, mt, ts.mBeacon, ts.msh, nil, ts.mLyrPatrol, ts.mCertHdr,
-		WithContext(ctx),
 		WithConfig(cfg),
 		WithLogger(lg),
 		withDataFetcher(ts.mDataFetcher),
@@ -121,22 +120,21 @@ func TestStartAndShutdown(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	ts := newTestSyncer(ctx, t, time.Millisecond*5)
 
-	require.False(t, ts.syncer.IsSynced(context.Background()))
+	require.False(t, ts.syncer.IsSynced(ctx))
 	require.False(t, ts.syncer.ListenToATXGossip())
 	require.False(t, ts.syncer.ListenToGossip())
 
 	// the node is synced when current layer is <= 1
-	ts.syncer.Start(context.Background())
+	ts.syncer.Start(ctx)
 
 	ts.mForkFinder.EXPECT().Purge(false).AnyTimes()
 	ts.mDataFetcher.EXPECT().PollLayerOpinions(gomock.Any(), gomock.Any()).AnyTimes()
 	require.Eventually(t, func() bool {
-		return ts.syncer.ListenToATXGossip() && ts.syncer.ListenToGossip() && ts.syncer.IsSynced(context.Background())
+		return ts.syncer.ListenToATXGossip() && ts.syncer.ListenToGossip() && ts.syncer.IsSynced(ctx)
 	}, time.Second, 10*time.Millisecond)
 
 	cancel()
-	require.True(t, ts.syncer.isClosed())
-	require.False(t, ts.syncer.synchronize(context.Background()))
+	require.False(t, ts.syncer.synchronize(ctx))
 	ts.syncer.Close()
 }
 
@@ -144,7 +142,8 @@ func TestSynchronize_OnlyOneSynchronize(t *testing.T) {
 	ts := newSyncerWithoutSyncTimer(t)
 	current := types.NewLayerID(10)
 	ts.mTicker.advanceToLayer(current)
-	ts.syncer.Start(context.Background())
+	ctx, cancel := context.WithCancel(context.Background())
+	ts.syncer.Start(ctx)
 
 	ts.mDataFetcher.EXPECT().GetEpochATXs(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	gLayer := types.GetEffectiveGenesis()
@@ -164,16 +163,17 @@ func TestSynchronize_OnlyOneSynchronize(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
-		require.True(t, ts.syncer.synchronize(context.Background()))
+		require.True(t, ts.syncer.synchronize(ctx))
 		wg.Done()
 	}()
 	<-started
-	require.False(t, ts.syncer.synchronize(context.Background()))
+	require.False(t, ts.syncer.synchronize(ctx))
 	// allow synchronize to finish
 	close(done)
 	wg.Wait()
 
 	require.Equal(t, uint64(1), ts.syncer.run)
+	cancel()
 	ts.syncer.Close()
 }
 

--- a/syncer/syncer_test.go
+++ b/syncer/syncer_test.go
@@ -118,6 +118,7 @@ func newSyncerWithoutSyncTimer(t *testing.T) *testSyncer {
 
 func TestStartAndShutdown(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	ts := newTestSyncer(ctx, t, time.Millisecond*5)
 
 	require.False(t, ts.syncer.IsSynced(ctx))
@@ -143,6 +144,7 @@ func TestSynchronize_OnlyOneSynchronize(t *testing.T) {
 	current := types.NewLayerID(10)
 	ts.mTicker.advanceToLayer(current)
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	ts.syncer.Start(ctx)
 
 	ts.mDataFetcher.EXPECT().GetEpochATXs(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()


### PR DESCRIPTION
Closes #3941

## Changes
- fixed `syncer` start and lifetime when started from a GRPC call. It was started on the GRPC `Context` which is canceled when the GRPC call ends.
- removed `shutdownCtx` from `Syncer struct`. The lifetime of syncing is now controller solely by the context passed to `Syncer::Start()`
