### PR TITLE
[Merged by Bors] - Request 1Gi of memory for poet in systests

### DIFF
--- a/systest/cluster/nodes.go
+++ b/systest/cluster/nodes.go
@@ -132,12 +132,12 @@ func deployPoetPod(ctx *testcontext.Context, id string, flags ...DeploymentFlag)
 					WithResources(corev1.ResourceRequirements().WithRequests(
 						apiv1.ResourceList{
 							apiv1.ResourceCPU:    resource.MustParse("1"),
-							apiv1.ResourceMemory: resource.MustParse("16Gi"),
+							apiv1.ResourceMemory: resource.MustParse("1Gi"),
 						},
 					).WithLimits(
 						apiv1.ResourceList{
 							apiv1.ResourceCPU:    resource.MustParse("2"),
-							apiv1.ResourceMemory: resource.MustParse("16Gi"),
+							apiv1.ResourceMemory: resource.MustParse("1Gi"),
 						},
 					)),
 				),


### PR DESCRIPTION
## Motivation
16Gi is excessive for "normal" systests where the epoch is 1 minute. It is problematic when running a local minikube cluster.

## Changes
Request 1Gi for poet in systests