### PR TITLE
[Merged by Bors] - Skip TestNIPostBuilderWithClients until fixed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,14 +173,10 @@ jobs:
         run: |
           sudo sysctl -w net.link.generic.system.hwcksum_tx=0
           sudo sysctl -w net.link.generic.system.hwcksum_rx=0
-      # TODO(mafa): these settings don't seem to improve network performance on windows - disabled for now
-      # - name: disable TCP/UDP offload
-      #   if: ${{ matrix.os == 'windows-latest' }}
-      #   run: |
-      #     netsh interface tcp set global rss=disabled
-      #     netsh interface show interface
-      #     netsh interface set interface name="Ethernet 3" admin=disabled
-      #     netsh interface set interface name="Ethernet 3" admin=enabled
+      - name: disable TCP/UDP offload
+        if: ${{ matrix.os == 'windows-latest' }}
+        run: |
+          Disable-NetAdapterChecksumOffload -Name * -TcpIPv4 -UdpIPv4 -TcpIPv6 -UdpIPv6
       - name: checkout
         uses: actions/checkout@v3
       - name: set up go

--- a/activation/nipost_test.go
+++ b/activation/nipost_test.go
@@ -167,7 +167,7 @@ func TestPostSetup(t *testing.T) {
 }
 
 func TestNIPostBuilderWithClients(t *testing.T) {
-	t.Skip("skipping test that is flaky, see https://github.com/spacemeshos/go-spacemesh/issues/2614")
+	t.Skip("skipping flaky test, see https://github.com/spacemeshos/go-spacemesh/issues/2614")
 
 	logtest.SetupGlobal(t)
 	r := require.New(t)

--- a/activation/nipost_test.go
+++ b/activation/nipost_test.go
@@ -167,9 +167,8 @@ func TestPostSetup(t *testing.T) {
 }
 
 func TestNIPostBuilderWithClients(t *testing.T) {
-	if testing.Short() {
-		t.Skip()
-	}
+	t.Skip("skipping test that is flaky, see https://github.com/spacemeshos/go-spacemesh/issues/2614")
+
 	logtest.SetupGlobal(t)
 	r := require.New(t)
 


### PR DESCRIPTION
## Motivation
`TestNIPostBuilderWithClients` has been flaky for a while now: https://github.com/spacemeshos/go-spacemesh/issues/2614, disabling the test until it is fixed.

## Changes
Flaky test skipped for now

## Test Plan
n/a

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
