### PR TITLE
[Merged by Bors] - Fix typo to scalegen ProposalVrfMessage

### DIFF
--- a/beacon/beacon.go
+++ b/beacon/beacon.go
@@ -986,7 +986,7 @@ func buildSignedProposal(ctx context.Context, signer vrfSigner, epoch types.Epoc
 	return signature
 }
 
-//go:generate scalegen -types BuildProposalMessage
+//go:generate scalegen -types ProposalVrfMessage
 
 // ProposalVrfMessage is a message for buildProposal below.
 type ProposalVrfMessage struct {


### PR DESCRIPTION
A typo in scalegen generation comment causes `make generate` fail.