### PR TITLE
[Merged by Bors] - Fix flaky nipost unit tests

### DIFF
--- a/activation/nipost_test.go
+++ b/activation/nipost_test.go
@@ -625,6 +625,9 @@ func TestNIPostBuilder_Close(t *testing.T) {
 
 	postProvider := &postSetupProviderMock{}
 	poetProver := defaultPoetServiceMock(t, []byte("poet"))
+	poetProver.EXPECT().GetProof(gomock.Any(), "").AnyTimes().DoAndReturn(func(ctx context.Context, _ string) (*types.PoetProofMessage, error) {
+		return nil, ctx.Err()
+	})
 	poetDb := NewMockpoetDbAPI(gomock.NewController(t))
 	challenge := types.PoetChallenge{NIPostChallenge: &types.NIPostChallenge{
 		PubLayerID: (postGenesisEpoch + 2).FirstLayer(),

--- a/cmd/node/node_test.go
+++ b/cmd/node/node_test.go
@@ -527,14 +527,9 @@ func TestSpacemeshApp_NodeService(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
-	poetHarness, err := activation.NewHTTPPoetHarness(ctx)
+	poetHarness, err := activation.NewHTTPPoetHarness(ctx, t.TempDir())
 	require.NoError(t, err)
-	t.Cleanup(func() {
-		err := poetHarness.Teardown(true)
-		if assert.NoError(t, err, "failed to tear down harness") {
-			t.Log("harness torn down")
-		}
-	})
+
 	edSgn, err := signing.NewEdSigner()
 	require.NoError(t, err)
 	h, err := p2p.Upgrade(mesh.Hosts()[0], cfg.Genesis.GenesisID())

--- a/go.mod
+++ b/go.mod
@@ -184,6 +184,7 @@ require (
 	google.golang.org/appengine v1.6.7 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
+	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.25.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -50,6 +50,7 @@ git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999/go.mod h1:fPE2ZNJGy
 github.com/ALTree/bigfloat v0.0.0-20220102081255-38c8b72a9924 h1:DG4UyTVIujioxwJc8Zj8Nabz1L1wTgQ/xNBSQDfdP3I=
 github.com/ALTree/bigfloat v0.0.0-20220102081255-38c8b72a9924/go.mod h1:+NaH2gLeY6RPBPPQf4aRotPPStg+eXc8f9ZaE4vRfD4=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/BurntSushi/toml v1.2.1 h1:9F2/+DoOYIOksmaJFPw1tGFy1eDnIJXg+UHjuD8lTak=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/Microsoft/go-winio v0.5.0/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Microsoft/go-winio v0.5.1 h1:aPJp2QD7OOrhO5tQXqQoGSJc+DjDtWTGLOmNyAm6FgY=
@@ -1042,6 +1043,7 @@ gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=
 gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/natefinch/lumberjack.v2 v2.0.0 h1:1Lc07Kr7qY4U2YPouBjpCLxpiyxIVoxqXgkXLknAOE8=
+gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
## Motivation
The test `TestNIPostBuilder_Close` is flaky. The code sometimes takes a different route through a `select` statement and doesn't return the proper error.

Also tests using the Poet integration harness sometimes fail w/o a clear explanation of why. The tests with harness are generally difficult to debug as the poet runs in a separate process and its output is not propagated correctly.

## Changes
- fixed error propagation from an error group in nipost builder,
- brought the removed ctx.Err() check after challenges are submitted back,
- removed uses of poet integration harnesses. Now the Poet is spawned in the same process as the test using its public API

Not using the harness is the first step to parallelizing tests using poet. The next one is to use a dynamically allocated port (port 9), but this requires a change on the poet side.