### PR TITLE
[Merged by Bors] - Use AwaitLayer instead of subscription for proposalbuilder

### DIFF
--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -638,7 +638,7 @@ func (app *App) initServices(
 
 	proposalBuilder := miner.NewProposalBuilder(
 		ctx,
-		clock.Subscribe(),
+		clock,
 		sgn,
 		vrfSigner,
 		app.cachedDB,

--- a/miner/interface.go
+++ b/miner/interface.go
@@ -2,6 +2,7 @@ package miner
 
 import (
 	"context"
+	"time"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/tortoise"
@@ -25,4 +26,10 @@ type votesEncoder interface {
 
 type nonceFetcher interface {
 	VRFNonce(types.NodeID, types.EpochID) (types.VRFPostIndex, error)
+}
+
+type layerClock interface {
+	AwaitLayer(layerID types.LayerID) chan struct{}
+	GetCurrentLayer() types.LayerID
+	LayerToTime(types.LayerID) time.Time
 }

--- a/miner/mocks.go
+++ b/miner/mocks.go
@@ -7,6 +7,7 @@ package miner
 import (
 	context "context"
 	reflect "reflect"
+	time "time"
 
 	gomock "github.com/golang/mock/gomock"
 	types "github.com/spacemeshos/go-spacemesh/common/types"
@@ -195,4 +196,69 @@ func (m *MocknonceFetcher) VRFNonce(arg0 types.NodeID, arg1 types.EpochID) (type
 func (mr *MocknonceFetcherMockRecorder) VRFNonce(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VRFNonce", reflect.TypeOf((*MocknonceFetcher)(nil).VRFNonce), arg0, arg1)
+}
+
+// MocklayerClock is a mock of layerClock interface.
+type MocklayerClock struct {
+	ctrl     *gomock.Controller
+	recorder *MocklayerClockMockRecorder
+}
+
+// MocklayerClockMockRecorder is the mock recorder for MocklayerClock.
+type MocklayerClockMockRecorder struct {
+	mock *MocklayerClock
+}
+
+// NewMocklayerClock creates a new mock instance.
+func NewMocklayerClock(ctrl *gomock.Controller) *MocklayerClock {
+	mock := &MocklayerClock{ctrl: ctrl}
+	mock.recorder = &MocklayerClockMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MocklayerClock) EXPECT() *MocklayerClockMockRecorder {
+	return m.recorder
+}
+
+// AwaitLayer mocks base method.
+func (m *MocklayerClock) AwaitLayer(layerID types.LayerID) chan struct{} {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AwaitLayer", layerID)
+	ret0, _ := ret[0].(chan struct{})
+	return ret0
+}
+
+// AwaitLayer indicates an expected call of AwaitLayer.
+func (mr *MocklayerClockMockRecorder) AwaitLayer(layerID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AwaitLayer", reflect.TypeOf((*MocklayerClock)(nil).AwaitLayer), layerID)
+}
+
+// GetCurrentLayer mocks base method.
+func (m *MocklayerClock) GetCurrentLayer() types.LayerID {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCurrentLayer")
+	ret0, _ := ret[0].(types.LayerID)
+	return ret0
+}
+
+// GetCurrentLayer indicates an expected call of GetCurrentLayer.
+func (mr *MocklayerClockMockRecorder) GetCurrentLayer() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCurrentLayer", reflect.TypeOf((*MocklayerClock)(nil).GetCurrentLayer))
+}
+
+// LayerToTime mocks base method.
+func (m *MocklayerClock) LayerToTime(arg0 types.LayerID) time.Time {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LayerToTime", arg0)
+	ret0, _ := ret[0].(time.Time)
+	return ret0
+}
+
+// LayerToTime indicates an expected call of LayerToTime.
+func (mr *MocklayerClockMockRecorder) LayerToTime(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LayerToTime", reflect.TypeOf((*MocklayerClock)(nil).LayerToTime), arg0)
 }

--- a/miner/proposal_builder.go
+++ b/miner/proposal_builder.go
@@ -412,7 +412,7 @@ func (pb *ProposalBuilder) createProposalLoop(ctx context.Context) {
 		case <-pb.clock.AwaitLayer(next):
 			current = pb.clock.GetCurrentLayer()
 			if current.Before(next) {
-				pb.logger.Info("proposal creation triggered early for layer %v, wait again", next)
+				pb.logger.Info("time sync detected, realigning ProposalBuilder")
 				continue
 			}
 			next = current.Add(1)

--- a/miner/proposal_builder.go
+++ b/miner/proposal_builder.go
@@ -24,7 +24,6 @@ import (
 	"github.com/spacemeshos/go-spacemesh/sql/certificates"
 	"github.com/spacemeshos/go-spacemesh/sql/layers"
 	"github.com/spacemeshos/go-spacemesh/system"
-	"github.com/spacemeshos/go-spacemesh/timesync"
 	"github.com/spacemeshos/go-spacemesh/tortoise"
 )
 
@@ -45,12 +44,12 @@ type ProposalBuilder struct {
 	cfg    config
 	cdb    *datastore.CachedDB
 
-	startOnce  sync.Once
-	ctx        context.Context
-	cancel     context.CancelFunc
-	eg         errgroup.Group
-	layerTimer chan types.LayerID
+	startOnce sync.Once
+	ctx       context.Context
+	cancel    context.CancelFunc
+	eg        errgroup.Group
 
+	clock          layerClock
 	publisher      pubsub.Publisher
 	signer         *signing.EdSigner
 	nonceFetcher   nonceFetcher
@@ -129,7 +128,7 @@ func withNonceFetcher(nf nonceFetcher) Opt {
 // NewProposalBuilder creates a struct of block builder type.
 func NewProposalBuilder(
 	ctx context.Context,
-	layerTimer timesync.LayerTimer,
+	clock layerClock,
 	signer *signing.EdSigner,
 	vrfSigner *signing.VRFSigner,
 	cdb *datastore.CachedDB,
@@ -146,7 +145,7 @@ func NewProposalBuilder(
 		ctx:            sctx,
 		cancel:         cancel,
 		signer:         signer,
-		layerTimer:     layerTimer,
+		clock:          clock,
 		cdb:            cdb,
 		publisher:      publisher,
 		tortoise:       trtl,
@@ -405,13 +404,13 @@ func (pb *ProposalBuilder) handleLayer(ctx context.Context, layerID types.LayerI
 
 func (pb *ProposalBuilder) createProposalLoop(ctx context.Context) {
 	for {
+		next := pb.clock.GetCurrentLayer().Add(1)
 		select {
 		case <-pb.ctx.Done():
 			return
-
-		case layerID := <-pb.layerTimer:
+		case <-pb.clock.AwaitLayer(next):
 			lyrCtx := log.WithNewSessionID(ctx)
-			_ = pb.handleLayer(lyrCtx, layerID)
+			_ = pb.handleLayer(lyrCtx, next)
 		}
 	}
 }

--- a/miner/proposal_builder_test.go
+++ b/miner/proposal_builder_test.go
@@ -125,11 +125,12 @@ func TestBuilder_StartAndClose(t *testing.T) {
 		return ch
 	})
 
+	b.mSync.EXPECT().IsSynced(gomock.Any()).Return(false)
+
 	require.NoError(t, b.Start(context.Background()))
 	// calling Start the second time should have no effect
 	require.NoError(t, b.Start(context.Background()))
 
-	b.mSync.EXPECT().IsSynced(gomock.Any()).Return(false)
 	time.Sleep(100 * time.Millisecond)
 
 	b.Close()

--- a/miner/proposal_builder_test.go
+++ b/miner/proposal_builder_test.go
@@ -121,8 +121,7 @@ func TestBuilder_StartAndClose(t *testing.T) {
 
 	b.mClock.EXPECT().GetCurrentLayer().Return(current.Add(1))
 	b.mClock.EXPECT().AwaitLayer(current.Add(2)).DoAndReturn(func(types.LayerID) chan struct{} {
-		ch := make(chan struct{})
-		return ch
+		return make(chan struct{})
 	})
 
 	b.mSync.EXPECT().IsSynced(gomock.Any()).Return(false)
@@ -131,8 +130,7 @@ func TestBuilder_StartAndClose(t *testing.T) {
 	// calling Start the second time should have no effect
 	require.NoError(t, b.Start(context.Background()))
 
-	time.Sleep(100 * time.Millisecond)
-
+	time.Sleep(10 * time.Millisecond)
 	b.Close()
 }
 
@@ -156,8 +154,7 @@ func TestBuilder_HandleLayer_MultipleProposals(t *testing.T) {
 
 	b.mClock.EXPECT().GetCurrentLayer().Return(layerID)
 	b.mClock.EXPECT().AwaitLayer(layerID.Add(1)).DoAndReturn(func(types.LayerID) chan struct{} {
-		ch := make(chan struct{})
-		return ch
+		return make(chan struct{})
 	})
 	b.mSync.EXPECT().IsSynced(gomock.Any()).Return(true)
 	b.mBeacon.EXPECT().GetBeacon(gomock.Any()).Return(beacon, nil)
@@ -217,8 +214,7 @@ func TestBuilder_HandleLayer_OneProposal(t *testing.T) {
 
 	b.mClock.EXPECT().GetCurrentLayer().Return(layerID)
 	b.mClock.EXPECT().AwaitLayer(layerID.Add(1)).DoAndReturn(func(types.LayerID) chan struct{} {
-		ch := make(chan struct{})
-		return ch
+		return make(chan struct{})
 	})
 	b.mSync.EXPECT().IsSynced(gomock.Any()).Return(true)
 	b.mBeacon.EXPECT().GetBeacon(gomock.Any()).Return(beacon, nil)
@@ -415,8 +411,7 @@ func TestBuilder_HandleLayer_CanceledDuringBuilding(t *testing.T) {
 
 	b.mClock.EXPECT().GetCurrentLayer().Return(layerID)
 	b.mClock.EXPECT().AwaitLayer(layerID.Add(1)).DoAndReturn(func(types.LayerID) chan struct{} {
-		ch := make(chan struct{})
-		return ch
+		return make(chan struct{})
 	})
 	b.mSync.EXPECT().IsSynced(gomock.Any()).Return(true)
 	b.mBeacon.EXPECT().GetBeacon(gomock.Any()).Return(beacon, nil)
@@ -446,8 +441,7 @@ func TestBuilder_HandleLayer_PublishError(t *testing.T) {
 
 	b.mClock.EXPECT().GetCurrentLayer().Return(layerID)
 	b.mClock.EXPECT().AwaitLayer(layerID.Add(1)).DoAndReturn(func(types.LayerID) chan struct{} {
-		ch := make(chan struct{})
-		return ch
+		return make(chan struct{})
 	})
 	b.mSync.EXPECT().IsSynced(gomock.Any()).Return(true)
 	b.mBeacon.EXPECT().GetBeacon(gomock.Any()).Return(beacon, nil)
@@ -479,8 +473,7 @@ func TestBuilder_HandleLayer_NotVerified(t *testing.T) {
 
 	b.mClock.EXPECT().GetCurrentLayer().Return(layerID)
 	b.mClock.EXPECT().AwaitLayer(layerID.Add(1)).DoAndReturn(func(types.LayerID) chan struct{} {
-		ch := make(chan struct{})
-		return ch
+		return make(chan struct{})
 	})
 	b.mSync.EXPECT().IsSynced(gomock.Any()).Return(true)
 	b.mBeacon.EXPECT().GetBeacon(gomock.Any()).Return(beacon, nil)
@@ -520,8 +513,7 @@ func TestBuilder_HandleLayer_NoHareOutput(t *testing.T) {
 
 	b.mClock.EXPECT().GetCurrentLayer().Return(layerID)
 	b.mClock.EXPECT().AwaitLayer(layerID.Add(1)).DoAndReturn(func(types.LayerID) chan struct{} {
-		ch := make(chan struct{})
-		return ch
+		return make(chan struct{})
 	})
 	b.mSync.EXPECT().IsSynced(gomock.Any()).Return(true)
 	b.mBeacon.EXPECT().GetBeacon(gomock.Any()).Return(beacon, nil)
@@ -561,8 +553,7 @@ func TestBuilder_HandleLayer_MeshHashErrorOK(t *testing.T) {
 
 	b.mClock.EXPECT().GetCurrentLayer().Return(layerID)
 	b.mClock.EXPECT().AwaitLayer(layerID.Add(1)).DoAndReturn(func(types.LayerID) chan struct{} {
-		ch := make(chan struct{})
-		return ch
+		return make(chan struct{})
 	})
 	b.mSync.EXPECT().IsSynced(gomock.Any()).Return(true)
 	b.mBeacon.EXPECT().GetBeacon(gomock.Any()).Return(beacon, nil)


### PR DESCRIPTION
## Motivation
Part of #4010. Refactor code to not subscribe to layer changes but rather await new layers.

## Changes
Use `AwaitLayer` in `ProposalBuilder` instead of a layer timer and make sure that the correct layer is processed by `ProposalBuilder`:
- `AwaitLayer` might return late (e.g. if the node was hibernating while it was waiting for the next layer) in this case `ProposalBuilder` will continue with the current layer rather than the one it was awaiting
- `GetCurrentLayer` might return a layer lower than the one awaited (if a time sync happens right between awaiting and getting the current layer). In this case wait a little longer.

## Test Plan
n/a

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
