### PR TITLE
[Merged by Bors] - Use a single channel to signal if ATXs are synced

### DIFF
--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -132,8 +132,8 @@ type Syncer struct {
 	lastATXsSynced    atomic.Value
 
 	// awaitATXSyncedCh is the list of subscribers' channels to notify when this node enters ATX synced state
-	awaitATXSyncedCh []chan struct{}
-	muATXSyncedCh    sync.Mutex // protects the slice above from concurrent access
+	awaitATXSyncedCh chan struct{}
+	muATXSyncedCh    sync.RWMutex // protects the slice above from concurrent access
 
 	eg errgroup.Group
 
@@ -161,7 +161,7 @@ func NewSyncer(
 		mesh:             mesh,
 		certHandler:      ch,
 		patrol:           patrol,
-		awaitATXSyncedCh: make([]chan struct{}, 0),
+		awaitATXSyncedCh: make(chan struct{}),
 	}
 	for _, opt := range opts {
 		opt(s)
@@ -195,15 +195,17 @@ func (s *Syncer) Close() {
 
 // RegisterForATXSynced returns a channel for notification when the node enters ATX synced state.
 func (s *Syncer) RegisterForATXSynced() chan struct{} {
-	ch := make(chan struct{})
+	s.muATXSyncedCh.RLock()
+	defer s.muATXSyncedCh.RUnlock()
+
 	if s.ListenToATXGossip() {
-		close(ch)
-		return ch
+		select {
+		case <-s.awaitATXSyncedCh:
+		default:
+			close(s.awaitATXSyncedCh)
+		}
 	}
-	s.muATXSyncedCh.Lock()
-	defer s.muATXSyncedCh.Unlock()
-	s.awaitATXSyncedCh = append(s.awaitATXSyncedCh, ch)
-	return ch
+	return s.awaitATXSyncedCh
 }
 
 // ListenToGossip returns true if the node is listening to gossip for blocks/TXs data.
@@ -272,10 +274,9 @@ func (s *Syncer) setATXSynced() {
 
 	s.muATXSyncedCh.Lock()
 	defer s.muATXSyncedCh.Unlock()
-	for _, ch := range s.awaitATXSyncedCh {
-		close(ch)
-	}
-	s.awaitATXSyncedCh = make([]chan struct{}, 0)
+
+	close(s.awaitATXSyncedCh)
+	s.awaitATXSyncedCh = make(chan struct{})
 }
 
 func (s *Syncer) getATXSyncState() syncState {


### PR DESCRIPTION
## Motivation
The current implementation of `RegisterForATXSynced` uses one channel per listener.

The code can be simplified to only use one channel for all listeners.

## Changes
- Instead of one channel per listener use a single channel
- Remove unneeded mutex

## Test Plan
N/A

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
