### PR TITLE
[Merged by Bors] - Add automatic retries in Poet's HTTP client

### DIFF
--- a/activation/activation.go
+++ b/activation/activation.go
@@ -112,7 +112,7 @@ func WithPoetRetryInterval(interval time.Duration) BuilderOption {
 }
 
 // PoETClientInitializer interfaces for creating PoetProvingServiceClient.
-type PoETClientInitializer func(string) PoetProvingServiceClient
+type PoETClientInitializer func(string, PoetConfig) PoetProvingServiceClient
 
 // WithPoETClientInitializer modifies initialization logic for PoET client. Used during client update.
 func WithPoETClientInitializer(initializer PoETClientInitializer) BuilderOption {
@@ -456,7 +456,7 @@ func (b *Builder) UpdatePoETServers(ctx context.Context, endpoints []string) err
 
 	clients := make([]PoetProvingServiceClient, 0, len(endpoints))
 	for _, endpoint := range endpoints {
-		client := b.poetClientInitializer(endpoint)
+		client := b.poetClientInitializer(endpoint, b.poetCfg)
 		// TODO(dshulyak) not enough information to verify that PoetServiceID matches with an expected one.
 		// Maybe it should be provided during update.
 		ctx, cancel := context.WithTimeout(ctx, time.Second*10)

--- a/activation/activation_test.go
+++ b/activation/activation_test.go
@@ -1115,7 +1115,7 @@ func TestBuilder_InitialProofGeneratedOnce(t *testing.T) {
 func TestBuilder_UpdatePoets(t *testing.T) {
 	r := require.New(t)
 
-	tab := newTestBuilder(t, WithPoETClientInitializer(func(string) PoetProvingServiceClient {
+	tab := newTestBuilder(t, WithPoETClientInitializer(func(string, PoetConfig) PoetProvingServiceClient {
 		poet := NewMockPoetProvingServiceClient(gomock.NewController(t))
 		poet.EXPECT().PoetServiceID(gomock.Any()).AnyTimes().Return([]byte("poetid"), nil)
 		return poet
@@ -1135,7 +1135,7 @@ func TestBuilder_UpdatePoets(t *testing.T) {
 func TestBuilder_UpdatePoetsUnstable(t *testing.T) {
 	r := require.New(t)
 
-	tab := newTestBuilder(t, WithPoETClientInitializer(func(string) PoetProvingServiceClient {
+	tab := newTestBuilder(t, WithPoETClientInitializer(func(string, PoetConfig) PoetProvingServiceClient {
 		poet := NewMockPoetProvingServiceClient(gomock.NewController(t))
 		poet.EXPECT().PoetServiceID(gomock.Any()).AnyTimes().Return([]byte("poetid"), errors.New("ERROR"))
 		return poet

--- a/activation/poet.go
+++ b/activation/poet.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/hashicorp/go-retryablehttp"
 	"github.com/spacemeshos/poet/config"
 	rpcapi "github.com/spacemeshos/poet/release/proto/go/rpc/api/v1"
 	"github.com/spacemeshos/poet/server"
@@ -52,6 +53,18 @@ func WithEpochDuration(epoch time.Duration) HTTPPoetOpt {
 	}
 }
 
+func WithPhaseShift(phase time.Duration) HTTPPoetOpt {
+	return func(cfg *config.Config) {
+		cfg.Service.PhaseShift = phase
+	}
+}
+
+func WithCycleGap(gap time.Duration) HTTPPoetOpt {
+	return func(cfg *config.Config) {
+		cfg.Service.CycleGap = gap
+	}
+}
+
 // NewHTTPPoetHarness returns a new instance of HTTPPoetHarness.
 func NewHTTPPoetHarness(ctx context.Context, poetdir string, opts ...HTTPPoetOpt) (*HTTPPoetHarness, error) {
 	cfg := config.DefaultConfig()
@@ -83,6 +96,7 @@ func NewHTTPPoetHarness(ctx context.Context, poetdir string, opts ...HTTPPoetOpt
 type HTTPPoetClient struct {
 	baseURL       string
 	poetServiceID *types.PoetServiceID
+	client        *retryablehttp.Client
 }
 
 func defaultPoetClientFunc(target string) PoetProvingServiceClient {
@@ -91,7 +105,29 @@ func defaultPoetClientFunc(target string) PoetProvingServiceClient {
 
 // NewHTTPPoetClient returns new instance of HTTPPoetClient for the specified target.
 func NewHTTPPoetClient(target string) *HTTPPoetClient {
-	return &HTTPPoetClient{baseURL: fmt.Sprintf("http://%s/v1", target)}
+	client := retryablehttp.NewClient()
+	client.RetryMax = 10
+	client.RetryWaitMin = time.Second
+	client.RetryWaitMax = time.Second * 2
+	client.Backoff = retryablehttp.LinearJitterBackoff
+
+	// Retry on 404 in addition to the default retry policy.
+	// Reasoning: The proof or round data might not be available YET.
+	client.CheckRetry = func(ctx context.Context, resp *http.Response, err error) (bool, error) {
+		if retry, err := retryablehttp.DefaultRetryPolicy(ctx, resp, err); retry || err != nil {
+			return retry, err
+		}
+
+		if resp.StatusCode == http.StatusNotFound {
+			return true, nil
+		}
+		return false, nil
+	}
+
+	return &HTTPPoetClient{
+		baseURL: fmt.Sprintf("http://%s/v1", target),
+		client:  client,
+	}
 }
 
 // Start is an administrative endpoint of the proving service that tells it to start. This is mostly done in tests,
@@ -99,7 +135,7 @@ func NewHTTPPoetClient(target string) *HTTPPoetClient {
 func (c *HTTPPoetClient) Start(ctx context.Context, gatewayAddresses []string) error {
 	reqBody := rpcapi.StartRequest{GatewayAddresses: gatewayAddresses}
 	if err := c.req(ctx, "POST", "/start", &reqBody, nil); err != nil {
-		return fmt.Errorf("request: %w", err)
+		return fmt.Errorf("starting poet: %w", err)
 	}
 
 	return nil
@@ -113,7 +149,7 @@ func (c *HTTPPoetClient) Submit(ctx context.Context, challenge []byte, signature
 	}
 	resBody := rpcapi.SubmitResponse{}
 	if err := c.req(ctx, "POST", "/submit", &request, &resBody); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("submitting challenge: %w", err)
 	}
 	roundEnd := time.Time{}
 	if resBody.RoundEnd != nil {
@@ -135,7 +171,7 @@ func (c *HTTPPoetClient) PoetServiceID(ctx context.Context) (types.PoetServiceID
 	resBody := rpcapi.GetInfoResponse{}
 
 	if err := c.req(ctx, "GET", "/info", nil, &resBody); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("getting poet ID: %w", err)
 	}
 
 	id := types.PoetServiceID(resBody.ServicePubkey)
@@ -148,7 +184,7 @@ func (c *HTTPPoetClient) GetProof(ctx context.Context, roundID string) (*types.P
 	resBody := rpcapi.GetProofResponse{}
 
 	if err := c.req(ctx, "GET", fmt.Sprintf("/proofs/%s", roundID), nil, &resBody); err != nil {
-		return nil, fmt.Errorf("get proof: %w", err)
+		return nil, fmt.Errorf("getting proof: %w", err)
 	}
 
 	proof := types.PoetProofMessage{
@@ -174,27 +210,25 @@ func (c *HTTPPoetClient) GetProof(ctx context.Context, roundID string) (*types.P
 func (c *HTTPPoetClient) req(ctx context.Context, method string, endURL string, reqBody proto.Message, resBody proto.Message) error {
 	jsonReqBody, err := protojson.Marshal(reqBody)
 	if err != nil {
-		return fmt.Errorf("request json marshal failure: %v", err)
+		return fmt.Errorf("marshaling request body: %w", err)
 	}
 
 	url := fmt.Sprintf("%s%s", c.baseURL, endURL)
-	req, err := http.NewRequest(method, url, bytes.NewBuffer(jsonReqBody))
+	req, err := retryablehttp.NewRequestWithContext(ctx, method, url, bytes.NewBuffer(jsonReqBody))
 	if err != nil {
-		return fmt.Errorf("create request: %w", err)
+		return fmt.Errorf("creating HTTP request: %w", err)
 	}
-
 	req.Header.Set("Content-Type", "application/json")
-	req = req.WithContext(ctx)
 
-	res, err := http.DefaultClient.Do(req)
+	res, err := c.client.Do(req)
 	if err != nil {
-		return fmt.Errorf("perform request: %w", err)
+		return fmt.Errorf("doing request: %w", err)
 	}
 	defer res.Body.Close()
 
 	data, err := io.ReadAll(res.Body)
 	if err != nil {
-		return fmt.Errorf("failed to read response body (%w)", err)
+		return fmt.Errorf("reading response body (%w)", err)
 	}
 
 	log.GetLogger().WithContext(ctx).With().Debug("response from poet", log.String("status", res.Status), log.String("body", string(data)))
@@ -205,11 +239,13 @@ func (c *HTTPPoetClient) req(ctx context.Context, method string, endURL string, 
 		return fmt.Errorf("%w: response status code: %s, body: %s", ErrNotFound, res.Status, string(data))
 	case http.StatusServiceUnavailable:
 		return fmt.Errorf("%w: response status code: %s, body: %s", ErrUnavailable, res.Status, string(data))
+	default:
+		return fmt.Errorf("unrecognized error: status code: %s, body: %s", res.Status, string(data))
 	}
 
 	if resBody != nil {
 		if err := protojson.Unmarshal(data, resBody); err != nil {
-			return fmt.Errorf("response json decode failure: %v", err)
+			return fmt.Errorf("decoding response body to proto: %w", err)
 		}
 	}
 

--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -1071,7 +1071,7 @@ func (app *App) Start(ctx context.Context) error {
 
 	poetClients := make([]activation.PoetProvingServiceClient, 0, len(app.Config.PoETServers))
 	for _, address := range app.Config.PoETServers {
-		poetClients = append(poetClients, activation.NewHTTPPoetClient(address))
+		poetClients = append(poetClients, activation.NewHTTPPoetClient(address, app.Config.POET))
 	}
 
 	edPubkey := edSgn.PublicKey()

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.0
 	github.com/hashicorp/go-multierror v1.1.1
+	github.com/hashicorp/go-retryablehttp v0.7.2
 	github.com/hashicorp/golang-lru v0.6.0
 	github.com/libp2p/go-libp2p v0.24.2
 	github.com/libp2p/go-libp2p-pubsub v0.8.3
@@ -91,6 +92,7 @@ require (
 	github.com/google/pprof v0.0.0-20221203041831-ce31453925ec // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/huin/goupnp v1.0.3 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -129,6 +129,7 @@ github.com/evanphx/json-patch v0.5.2/go.mod h1:ZWS5hhDbVDyob71nXKNL0+PWn6ToqBHMi
 github.com/evanphx/json-patch v4.12.0+incompatible h1:4onqiflcdA9EOZ4RxV643DvftH5pOlLGNtQ5lPWQu84=
 github.com/evanphx/json-patch/v5 v5.6.0 h1:b91NhWfaz02IuVxO9faSllyAtNXHMPkC5J8sJCLunww=
 github.com/evanphx/json-patch/v5 v5.6.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2VvlbKOFpnXhI9Bw4=
+github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/felixge/fgprof v0.9.1 h1:E6FUJ2Mlv043ipLOCFqo8+cHo9MhQ203E2cdEK/isEs=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/flynn/noise v1.0.0 h1:DlTHqmzmvcEiKj+4RYo/imoswx/4r6iBlCMfVtrMXpQ=
@@ -270,8 +271,14 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.0 h1:1JYBfzqrWPcCclBwxFCPAou9n+q
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.0/go.mod h1:YDZoGHuwE+ov0c8smSH49WLF3F2LaWnYYuDVd+EWrc0=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
+github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
+github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
+github.com/hashicorp/go-hclog v1.2.0 h1:La19f8d7WIlm4ogzNHB0JGqs5AUDAZ2UfCY4sJXcJdM=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
+github.com/hashicorp/go-retryablehttp v0.7.2 h1:AcYqCvkpalPnPF2pn0KamgwamS42TqUDDYFRKq/RAd0=
+github.com/hashicorp/go-retryablehttp v0.7.2/go.mod h1:Jy/gPYAdjqffZ/yFGCFV2doI5wjtH1ewM9u8iYVjtX8=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.6.0 h1:uL2shRDx7RTrOrTCUZEGP/wJUFiUI8QT6E7z5o8jga4=
@@ -388,6 +395,7 @@ github.com/marten-seemann/qtls-go1-19 v0.1.1/go.mod h1:5HTDWtVudo/WFsHKRNuOhWlbd
 github.com/marten-seemann/tcp v0.0.0-20210406111302-dfbc87cc63fd h1:br0buuQ854V8u83wA0rVZ8ttrq5CpaPZdvrK0LP2lOk=
 github.com/marten-seemann/tcp v0.0.0-20210406111302-dfbc87cc63fd/go.mod h1:QuCEs1Nt24+FYQEqAAncTDPJIuGs+LxK1MCiFL25pMU=
 github.com/marten-seemann/webtransport-go v0.4.3 h1:vkt5o/Ci+luknRteWdYGYH1KcB7ziup+J+1PzZJIvmg=
+github.com/mattn/go-colorable v0.1.12 h1:jF+Du6AlPIjs2BiUiQlKOX0rt3SujHxPnksPKZbaA40=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-isatty v0.0.16 h1:bq3VjFmv/sOjHtdEhmkEV4x1AJtvUvOJ2PFAZ5+peKQ=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=


### PR DESCRIPTION
## Motivation
HTTP requests are fallible but communication node -> poet is critical. Node should retry talking with poet in case of:
- ephemeral errors (5xx, 429 - too many requests)
- 404 - not found. A Poet returns 404 if a node queries for proof too early (the proof is not yet ready - hence "not found").

## Changes
- use https://github.com/hashicorp/go-retryablehttp for automatic retries with a custom policy to retry on 404,
- use linear backoff with small jitter (within 1 second) to prevent spamming poet with retries at the same time from all nodes.

Closes #2614 
