### PR TITLE
[Merged by Bors] - prevents syncer races with block generation

### DIFF
--- a/blocks/interface.go
+++ b/blocks/interface.go
@@ -9,6 +9,10 @@ import (
 
 //go:generate mockgen -package=mocks -destination=./mocks/mocks.go -source=./interface.go
 
+type layerPatrol interface {
+	CompleteHare(types.LayerID)
+}
+
 type meshProvider interface {
 	AddBlockWithTXs(context.Context, *types.Block) error
 	ProcessLayerPerHareOutput(context.Context, types.LayerID, types.BlockID, bool) error

--- a/blocks/mocks/mocks.go
+++ b/blocks/mocks/mocks.go
@@ -13,6 +13,41 @@ import (
 	log "github.com/spacemeshos/go-spacemesh/log"
 )
 
+// MocklayerPatrol is a mock of layerPatrol interface.
+type MocklayerPatrol struct {
+	ctrl     *gomock.Controller
+	recorder *MocklayerPatrolMockRecorder
+}
+
+// MocklayerPatrolMockRecorder is the mock recorder for MocklayerPatrol.
+type MocklayerPatrolMockRecorder struct {
+	mock *MocklayerPatrol
+}
+
+// NewMocklayerPatrol creates a new mock instance.
+func NewMocklayerPatrol(ctrl *gomock.Controller) *MocklayerPatrol {
+	mock := &MocklayerPatrol{ctrl: ctrl}
+	mock.recorder = &MocklayerPatrolMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MocklayerPatrol) EXPECT() *MocklayerPatrolMockRecorder {
+	return m.recorder
+}
+
+// CompleteHare mocks base method.
+func (m *MocklayerPatrol) CompleteHare(arg0 types.LayerID) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "CompleteHare", arg0)
+}
+
+// CompleteHare indicates an expected call of CompleteHare.
+func (mr *MocklayerPatrolMockRecorder) CompleteHare(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CompleteHare", reflect.TypeOf((*MocklayerPatrol)(nil).CompleteHare), arg0)
+}
+
 // MockmeshProvider is a mock of meshProvider interface.
 type MockmeshProvider struct {
 	ctrl     *gomock.Controller

--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -605,7 +605,7 @@ func (app *App) initServices(
 	beaconProtocol.SetSyncState(newSyncer)
 
 	hareOutputCh := make(chan hare.LayerOutput, app.Config.HARE.LimitConcurrent)
-	app.blockGen = blocks.NewGenerator(app.cachedDB, executor, msh, fetcherWrapped, app.certifier,
+	app.blockGen = blocks.NewGenerator(app.cachedDB, executor, msh, fetcherWrapped, app.certifier, patrol,
 		blocks.WithContext(ctx),
 		blocks.WithConfig(blocks.Config{
 			LayerSize:          layerSize,

--- a/hare/flows_test.go
+++ b/hare/flows_test.go
@@ -180,7 +180,6 @@ func createTestHare(tb testing.TB, db *sql.Database, tcfg config.Config, clock *
 	ctrl := gomock.NewController(tb)
 	patrol := mocks.NewMocklayerPatrol(ctrl)
 	patrol.EXPECT().SetHareInCharge(gomock.Any()).AnyTimes()
-	patrol.EXPECT().CompleteHare(gomock.Any()).AnyTimes()
 	mockBeacons := smocks.NewMockBeaconGetter(ctrl)
 	mockBeacons.EXPECT().GetBeacon(gomock.Any()).Return(types.EmptyBeacon, nil).AnyTimes()
 	mockStateQ := mocks.NewMockstateQuerier(ctrl)

--- a/hare/hare.go
+++ b/hare/hare.go
@@ -261,7 +261,6 @@ var ErrTooLate = errors.New("consensus process finished too late")
 // records the provided output.
 func (h *Hare) collectOutput(ctx context.Context, output TerminationOutput) error {
 	layerID := output.ID()
-	defer h.patrol.CompleteHare(layerID)
 
 	var pids []types.ProposalID
 	if output.Completed() {

--- a/hare/interfaces.go
+++ b/hare/interfaces.go
@@ -10,7 +10,6 @@ import (
 
 type layerPatrol interface {
 	SetHareInCharge(types.LayerID)
-	CompleteHare(types.LayerID)
 }
 
 // Rolacle is the roles oracle provider.

--- a/hare/mocks/mocks.go
+++ b/hare/mocks/mocks.go
@@ -35,18 +35,6 @@ func (m *MocklayerPatrol) EXPECT() *MocklayerPatrolMockRecorder {
 	return m.recorder
 }
 
-// CompleteHare mocks base method.
-func (m *MocklayerPatrol) CompleteHare(arg0 types.LayerID) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "CompleteHare", arg0)
-}
-
-// CompleteHare indicates an expected call of CompleteHare.
-func (mr *MocklayerPatrolMockRecorder) CompleteHare(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CompleteHare", reflect.TypeOf((*MocklayerPatrol)(nil).CompleteHare), arg0)
-}
-
 // SetHareInCharge mocks base method.
 func (m *MocklayerPatrol) SetHareInCharge(arg0 types.LayerID) {
 	m.ctrl.T.Helper()

--- a/mesh/mesh.go
+++ b/mesh/mesh.go
@@ -591,9 +591,14 @@ func (msh *Mesh) saveHareOutput(ctx context.Context, logger log.Log, lid types.L
 	}); err != nil {
 		return err
 	}
-	if len(certs) == 0 {
+	switch len(certs) {
+	case 0:
 		msh.trtl.OnHareOutput(lid, bid)
-	} else if len(certs) > 1 {
+	case 1:
+		logger.With().Info("already synced certificate",
+			log.Stringer("cert_block_id", certs[0].Block),
+			log.Bool("cert_valid", certs[0].Valid))
+	default: // more than 1 cert
 		logger.With().Warning("multiple valid certs found in network",
 			log.Object("certificates", log.ObjectMarshallerFunc(func(encoder zapcore.ObjectEncoder) error {
 				for _, cert := range certs {
@@ -602,10 +607,6 @@ func (msh *Mesh) saveHareOutput(ctx context.Context, logger log.Log, lid types.L
 				}
 				return nil
 			})))
-	} else {
-		logger.With().Info("already synced certificate",
-			log.Stringer("cert_block_id", certs[0].Block),
-			log.Bool("cert_valid", certs[0].Valid))
 	}
 	return nil
 }

--- a/mesh/mesh.go
+++ b/mesh/mesh.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	"go.uber.org/atomic"
+	"go.uber.org/zap/zapcore"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/datastore"
@@ -550,6 +551,65 @@ func (msh *Mesh) revertState(ctx context.Context, logger log.Log, revertTo types
 	return nil
 }
 
+func (msh *Mesh) saveHareOutput(ctx context.Context, logger log.Log, lid types.LayerID, bid types.BlockID) error {
+	logger.Info("saving hare output for layer")
+	var (
+		certs []certificates.CertValidity
+		err   error
+	)
+	if err = msh.cdb.WithTx(ctx, func(tx *sql.Tx) error {
+		// check if a certificate has been sync'ed.
+		// hare outputs are processed in layer order. i.e. when hare fails for a previous layer N,
+		// a later layer N+x has to wait for syncer to fetch block certificate for the mesh to make
+		// progress. therefore, by the time layer N+x is processed, syncer may already have sync'ed
+		// the certificate for this layer. in this case, hare output no longer matters.
+		certs, err = certificates.Get(tx, lid)
+		if err != nil && !errors.Is(err, sql.ErrNotFound) {
+			return fmt.Errorf("mesh get cert %v: %w", lid, err)
+		}
+		saved := false
+		for _, c := range certs {
+			if c.Block == bid {
+				saved = true
+				break
+			} else if c.Valid {
+				err = certificates.SetHareOutputInvalid(tx, lid, bid)
+				if err != nil {
+					return fmt.Errorf("save invalid hare output %v/%v: %w", lid, bid, err)
+				}
+				saved = true
+				break
+			}
+		}
+		if !saved {
+			err = certificates.SetHareOutput(tx, lid, bid)
+			if err != nil {
+				return fmt.Errorf("save valid hare output %v/%v: %w", lid, bid, err)
+			}
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+	if len(certs) == 0 {
+		msh.trtl.OnHareOutput(lid, bid)
+	} else if len(certs) > 1 {
+		logger.With().Warning("multiple valid certs found in network",
+			log.Object("certificates", log.ObjectMarshallerFunc(func(encoder zapcore.ObjectEncoder) error {
+				for _, cert := range certs {
+					encoder.AddString("block_id", cert.Block.String())
+					encoder.AddBool("valid", cert.Valid)
+				}
+				return nil
+			})))
+	} else {
+		logger.With().Info("already synced certificate",
+			log.Stringer("cert_block_id", certs[0].Block),
+			log.Bool("cert_valid", certs[0].Valid))
+	}
+	return nil
+}
+
 // ProcessLayerPerHareOutput receives hare output once it finishes running for a given layer.
 func (msh *Mesh) ProcessLayerPerHareOutput(ctx context.Context, layerID types.LayerID, blockID types.BlockID, executed bool) error {
 	logger := msh.logger.WithContext(ctx).WithFields(layerID, blockID)
@@ -572,11 +632,10 @@ func (msh *Mesh) ProcessLayerPerHareOutput(ctx context.Context, layerID types.La
 		Status:  events.LayerStatusTypeApproved,
 	})
 
-	logger.Info("saving hare output for layer")
-	if err = certificates.SetHareOutput(msh.cdb, layerID, blockID); err != nil {
-		return fmt.Errorf("save hare output %v: %w", blockID, err)
+	if err = msh.saveHareOutput(ctx, logger, layerID, blockID); err != nil {
+		return err
 	}
-	msh.trtl.OnHareOutput(layerID, blockID)
+
 	if executed {
 		if err = msh.persistState(ctx, logger, layerID, block.ID(), []*types.Block{block}); err != nil {
 			return err

--- a/sql/certificates/certs.go
+++ b/sql/certificates/certs.go
@@ -9,11 +9,20 @@ import (
 )
 
 func SetHareOutput(db sql.Executor, lid types.LayerID, bid types.BlockID) error {
-	if _, err := db.Exec(`insert into certificates (layer, block, valid) values (?1, ?2, 1)
+	return setHareOutput(db, lid, bid, true)
+}
+
+func SetHareOutputInvalid(db sql.Executor, lid types.LayerID, bid types.BlockID) error {
+	return setHareOutput(db, lid, bid, false)
+}
+
+func setHareOutput(db sql.Executor, lid types.LayerID, bid types.BlockID, valid bool) error {
+	if _, err := db.Exec(`insert into certificates (layer, block, valid) values (?1, ?2, ?3)
 		on conflict do nothing;`,
 		func(stmt *sql.Statement) {
 			stmt.BindInt64(1, int64(lid.Value))
 			stmt.BindBytes(2, bid[:])
+			stmt.BindBool(3, valid)
 		}, nil); err != nil {
 		return fmt.Errorf("add wo cert %s: %w", lid, err)
 	}

--- a/sql/certificates/certs_test.go
+++ b/sql/certificates/certs_test.go
@@ -71,7 +71,7 @@ func TestCertificates(t *testing.T) {
 	require.True(t, got[0].Valid)
 
 	bid2 := types.BlockID{2, 2, 2}
-	require.NoError(t, SetHareOutput(db, lid, bid2))
+	require.NoError(t, SetHareOutputInvalid(db, lid, bid2))
 	got, err = Get(db, lid)
 	require.NoError(t, err)
 	require.Len(t, got, 2)
@@ -80,7 +80,7 @@ func TestCertificates(t *testing.T) {
 	require.True(t, got[0].Valid)
 	require.Equal(t, bid2, got[1].Block)
 	require.Nil(t, got[1].Cert)
-	require.True(t, got[1].Valid)
+	require.False(t, got[1].Valid)
 }
 
 func TestHareOutput(t *testing.T) {


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
layer patrol was in place to prevent races between syncer and hare to advance the mesh.
but since https://github.com/spacemeshos/go-spacemesh/issues/3297 is implemented, 
the race period extended to block generation, as blocks are now generated serially in layer order.

this is one of the reasons why systest is flaky, as when the layer N is processed in the mesh, syncer
already saved the certificate sync'ed from peers for that layer, causing the node to think there were
multiple certificates for the same layer, which then apply empty block for that layer.

## Changes
<!-- Please describe in detail the changes made -->
- move layer patrol to block generator so it can properly semaphore btwn syncer and block generation
- in case processing layer was delayed by more than patrol's wait limit, make sure mesh doesn't trump the certificate that's already saved
