### PR TITLE
[Merged by Bors] - hare: restore passive hare participation

### DIFF
--- a/hare/algorithm_test.go
+++ b/hare/algorithm_test.go
@@ -181,22 +181,23 @@ func (mev *mockEligibilityValidator) ValidateEligibilityGossip(context.Context, 
 }
 
 func TestConsensusProcess_TerminationLimit(t *testing.T) {
-	c := config.Config{N: 10, F: 5, RoundDuration: time.Second, ExpectedLeaders: 5, LimitIterations: 1, LimitConcurrent: 1, Hdist: 20}
+	c := config.Config{N: 10, F: 5, RoundDuration: 200 * time.Millisecond, ExpectedLeaders: 5, LimitIterations: 1, LimitConcurrent: 1, Hdist: 20}
 	p := generateConsensusProcessWithConfig(t, c, make(chan any, 10))
 	p.Start()
-	time.Sleep(6 * p.cfg.RoundDuration)
 
-	require.EqualValues(t, 1, p.getRound()/4)
+	require.Eventually(t, func() bool {
+		return p.getRound()/4 == 1
+	}, 2*time.Second, 200*time.Millisecond)
 }
 
 func TestConsensusProcess_PassiveParticipant(t *testing.T) {
-	c := config.Config{N: 10, F: 5, RoundDuration: time.Second, ExpectedLeaders: 5, LimitIterations: 1, LimitConcurrent: 1, Hdist: 20}
+	c := config.Config{N: 10, F: 5, RoundDuration: 200 * time.Millisecond, ExpectedLeaders: 5, LimitIterations: 1, LimitConcurrent: 1, Hdist: 20}
 	p := generateConsensusProcessWithConfig(t, c, make(chan any, 10))
 	p.nonce = nil
 	p.Start()
-	time.Sleep(6 * p.cfg.RoundDuration)
-
-	require.EqualValues(t, 1, p.getRound()/4)
+	require.Eventually(t, func() bool {
+		return p.getRound()/4 == uint32(1)
+	}, 2*time.Second, 200*time.Millisecond)
 }
 
 func TestConsensusProcess_eventLoop(t *testing.T) {

--- a/hare/algorithm_test.go
+++ b/hare/algorithm_test.go
@@ -189,6 +189,16 @@ func TestConsensusProcess_TerminationLimit(t *testing.T) {
 	require.EqualValues(t, 1, p.getRound()/4)
 }
 
+func TestConsensusProcess_PassiveParticipant(t *testing.T) {
+	c := config.Config{N: 10, F: 5, RoundDuration: time.Second, ExpectedLeaders: 5, LimitIterations: 1, LimitConcurrent: 1, Hdist: 20}
+	p := generateConsensusProcessWithConfig(t, c, make(chan any, 10))
+	p.nonce = nil
+	p.Start()
+	time.Sleep(6 * p.cfg.RoundDuration)
+
+	require.EqualValues(t, 1, p.getRound()/4)
+}
+
 func TestConsensusProcess_eventLoop(t *testing.T) {
 	net := &mockP2p{}
 	c := config.Config{N: 10, F: 5, RoundDuration: 2 * time.Second, ExpectedLeaders: 5, LimitIterations: 1000, LimitConcurrent: 1000, Hdist: 20}
@@ -198,7 +208,7 @@ func TestConsensusProcess_eventLoop(t *testing.T) {
 	mo := mocks.NewMockRolacle(gomock.NewController(t))
 	mo.EXPECT().IsIdentityActiveOnConsensusView(gomock.Any(), gomock.Any(), proc.layer).Return(true, nil).Times(1)
 	mo.EXPECT().Proof(gomock.Any(), gomock.Any(), proc.layer, proc.getRound()).Return(nil, nil).Times(2)
-	mo.EXPECT().CalcEligibility(gomock.Any(), proc.layer, proc.getRound(), gomock.Any(), proc.nid, proc.nonce, gomock.Any()).Return(uint16(1), nil).Times(1)
+	mo.EXPECT().CalcEligibility(gomock.Any(), proc.layer, proc.getRound(), gomock.Any(), proc.nid, *proc.nonce, gomock.Any()).Return(uint16(1), nil).Times(1)
 	proc.oracle = mo
 	proc.value = NewSetFromValues(types.ProposalID{1}, types.ProposalID{2})
 
@@ -223,7 +233,7 @@ func TestConsensusProcess_StartAndStop(t *testing.T) {
 	mo := mocks.NewMockRolacle(gomock.NewController(t))
 	mo.EXPECT().IsIdentityActiveOnConsensusView(gomock.Any(), gomock.Any(), proc.layer).Return(true, nil).AnyTimes()
 	mo.EXPECT().Proof(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
-	mo.EXPECT().CalcEligibility(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), proc.nid, proc.nonce, gomock.Any()).Return(uint16(1), nil).AnyTimes()
+	mo.EXPECT().CalcEligibility(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), proc.nid, *proc.nonce, gomock.Any()).Return(uint16(1), nil).AnyTimes()
 	proc.oracle = mo
 
 	proc.value = NewSetFromValues(types.ProposalID{1}, types.ProposalID{2})
@@ -309,6 +319,7 @@ func generateConsensusProcessWithConfig(tb testing.TB, cfg config.Config, inbox 
 	nid := types.BytesToNodeID(edPubkey.Bytes())
 	oracle.Register(true, nid)
 	output := make(chan TerminationOutput, 1)
+	nonce := types.VRFPostIndex(rand.Uint64())
 
 	sq := mocks.NewMockstateQuerier(gomock.NewController(tb))
 	sq.EXPECT().IsIdentityActiveOnConsensusView(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).AnyTimes()
@@ -327,7 +338,7 @@ func generateConsensusProcessWithConfig(tb testing.TB, cfg config.Config, inbox 
 		edSigner,
 		pke,
 		types.BytesToNodeID(edPubkey.Bytes()),
-		types.VRFPostIndex(rand.Uint64()),
+		&nonce,
 		noopPubSub(tb),
 		comm,
 		truer{},
@@ -370,9 +381,9 @@ func TestConsensusProcess_isEligible_NotEligible(t *testing.T) {
 	mo := mocks.NewMockRolacle(ctrl)
 	proc.oracle = mo
 
-	mo.EXPECT().Proof(gomock.Any(), proc.nonce, proc.layer, proc.getRound()).Return(nil, nil).Times(1)
+	mo.EXPECT().Proof(gomock.Any(), *proc.nonce, proc.layer, proc.getRound()).Return(nil, nil).Times(1)
 	mo.EXPECT().IsIdentityActiveOnConsensusView(gomock.Any(), gomock.Any(), proc.layer).Return(true, nil).Times(1)
-	mo.EXPECT().CalcEligibility(gomock.Any(), proc.layer, proc.getRound(), gomock.Any(), proc.nid, proc.nonce, gomock.Any()).Return(uint16(0), nil).Times(1)
+	mo.EXPECT().CalcEligibility(gomock.Any(), proc.layer, proc.getRound(), gomock.Any(), proc.nid, *proc.nonce, gomock.Any()).Return(uint16(0), nil).Times(1)
 	require.False(t, proc.shouldParticipate(context.Background()))
 }
 
@@ -383,9 +394,9 @@ func TestConsensusProcess_isEligible_Eligible(t *testing.T) {
 	mo := mocks.NewMockRolacle(ctrl)
 	proc.oracle = mo
 
-	mo.EXPECT().Proof(gomock.Any(), proc.nonce, proc.layer, proc.getRound()).Return(nil, nil).Times(1)
+	mo.EXPECT().Proof(gomock.Any(), *proc.nonce, proc.layer, proc.getRound()).Return(nil, nil).Times(1)
 	mo.EXPECT().IsIdentityActiveOnConsensusView(gomock.Any(), gomock.Any(), proc.layer).Return(true, nil).Times(1)
-	mo.EXPECT().CalcEligibility(gomock.Any(), proc.layer, proc.getRound(), gomock.Any(), proc.nid, proc.nonce, gomock.Any()).Return(uint16(1), nil).Times(1)
+	mo.EXPECT().CalcEligibility(gomock.Any(), proc.layer, proc.getRound(), gomock.Any(), proc.nid, *proc.nonce, gomock.Any()).Return(uint16(1), nil).Times(1)
 	require.True(t, proc.shouldParticipate(context.Background()))
 }
 
@@ -601,8 +612,8 @@ func TestConsensusProcess_beginStatusRound(t *testing.T) {
 
 	mo := mocks.NewMockRolacle(ctrl)
 	mo.EXPECT().IsIdentityActiveOnConsensusView(gomock.Any(), gomock.Any(), proc.layer).Return(true, nil).Times(1)
-	mo.EXPECT().Proof(gomock.Any(), proc.nonce, proc.layer, proc.getRound()).Return(nil, nil).Times(2)
-	mo.EXPECT().CalcEligibility(gomock.Any(), proc.layer, proc.getRound(), gomock.Any(), proc.nid, proc.nonce, gomock.Any()).Return(uint16(1), nil).Times(1)
+	mo.EXPECT().Proof(gomock.Any(), *proc.nonce, proc.layer, proc.getRound()).Return(nil, nil).Times(2)
+	mo.EXPECT().CalcEligibility(gomock.Any(), proc.layer, proc.getRound(), gomock.Any(), proc.nid, *proc.nonce, gomock.Any()).Return(uint16(1), nil).Times(1)
 	proc.oracle = mo
 
 	s := NewDefaultEmptySet()
@@ -628,8 +639,8 @@ func TestConsensusProcess_beginProposalRound(t *testing.T) {
 
 	mo := mocks.NewMockRolacle(ctrl)
 	mo.EXPECT().IsIdentityActiveOnConsensusView(gomock.Any(), gomock.Any(), proc.layer).Return(true, nil).Times(1)
-	mo.EXPECT().Proof(gomock.Any(), proc.nonce, proc.layer, proc.getRound()).Return(nil, nil).Times(2)
-	mo.EXPECT().CalcEligibility(gomock.Any(), proc.layer, proc.getRound(), gomock.Any(), proc.nid, proc.nonce, gomock.Any()).Return(uint16(1), nil).Times(1)
+	mo.EXPECT().Proof(gomock.Any(), *proc.nonce, proc.layer, proc.getRound()).Return(nil, nil).Times(2)
+	mo.EXPECT().CalcEligibility(gomock.Any(), proc.layer, proc.getRound(), gomock.Any(), proc.nid, *proc.nonce, gomock.Any()).Return(uint16(1), nil).Times(1)
 	proc.oracle = mo
 
 	statusTracker := newStatusTracker(logtest.New(t), statusRound, make(chan *types.MalfeasanceGossip), proc.eTracker, 1, 1)
@@ -664,16 +675,16 @@ func TestConsensusProcess_beginCommitRound(t *testing.T) {
 
 	preCommitTracker := proc.commitTracker
 	mo.EXPECT().IsIdentityActiveOnConsensusView(gomock.Any(), gomock.Any(), proc.layer).Return(true, nil).Times(1)
-	mo.EXPECT().Proof(gomock.Any(), proc.nonce, proc.layer, proc.getRound()).Return(nil, nil).Times(1)
-	mo.EXPECT().CalcEligibility(gomock.Any(), proc.layer, proc.getRound(), gomock.Any(), proc.nid, proc.nonce, gomock.Any()).Return(uint16(0), nil).Times(1)
+	mo.EXPECT().Proof(gomock.Any(), *proc.nonce, proc.layer, proc.getRound()).Return(nil, nil).Times(1)
+	mo.EXPECT().CalcEligibility(gomock.Any(), proc.layer, proc.getRound(), gomock.Any(), proc.nid, *proc.nonce, gomock.Any()).Return(uint16(0), nil).Times(1)
 	proc.beginCommitRound(context.Background())
 	require.NotEqual(t, preCommitTracker, proc.commitTracker)
 
 	mpt.isConflicting = false
 	mpt.proposedSet = NewSetFromValues(types.ProposalID{1})
 	mo.EXPECT().IsIdentityActiveOnConsensusView(gomock.Any(), gomock.Any(), proc.layer).Return(true, nil).Times(1)
-	mo.EXPECT().Proof(gomock.Any(), proc.nonce, proc.layer, proc.getRound()).Return(nil, nil).Times(2)
-	mo.EXPECT().CalcEligibility(gomock.Any(), proc.layer, proc.getRound(), gomock.Any(), proc.nid, proc.nonce, gomock.Any()).Return(uint16(1), nil).Times(1)
+	mo.EXPECT().Proof(gomock.Any(), *proc.nonce, proc.layer, proc.getRound()).Return(nil, nil).Times(2)
+	mo.EXPECT().CalcEligibility(gomock.Any(), proc.layer, proc.getRound(), gomock.Any(), proc.nid, *proc.nonce, gomock.Any()).Return(uint16(1), nil).Times(1)
 	proc.beginCommitRound(context.Background())
 	require.Equal(t, 1, network.getCount())
 }

--- a/hare/consensus_test.go
+++ b/hare/consensus_test.go
@@ -186,6 +186,7 @@ func createConsensusProcess(
 	require.NoError(tb, err)
 	c, err := broker.Register(ctx, layer)
 	require.NoError(tb, err)
+	nonce := types.VRFPostIndex(1)
 	mch := make(chan *types.MalfeasanceGossip, cfg.N)
 	comm := communication{
 		inbox:  c,
@@ -202,7 +203,7 @@ func createConsensusProcess(
 		sig,
 		pke,
 		sig.NodeID(),
-		types.VRFPostIndex(1),
+		&nonce,
 		network,
 		comm,
 		truer{},

--- a/hare/hare.go
+++ b/hare/hare.go
@@ -29,9 +29,10 @@ type consensusFactory func(
 	context.Context,
 	config.Config,
 	types.LayerID,
-	*Set, Rolacle,
+	*Set,
+	Rolacle,
 	Signer,
-	types.VRFPostIndex,
+	*types.VRFPostIndex,
 	pubsub.Publisher,
 	communication,
 	RoundClock,
@@ -178,7 +179,7 @@ func New(
 	h.outputChan = make(chan TerminationOutput, h.config.Hdist)
 	h.outputs = make(map[types.LayerID][]types.ProposalID, h.config.Hdist) // we keep results about LayerBuffer past layers
 	h.cps = make(map[types.LayerID]Consensus, h.config.LimitConcurrent)
-	h.factory = func(ctx context.Context, conf config.Config, instanceId types.LayerID, s *Set, oracle Rolacle, signing Signer, nonce types.VRFPostIndex, p2p pubsub.Publisher, comm communication, clock RoundClock) Consensus {
+	h.factory = func(ctx context.Context, conf config.Config, instanceId types.LayerID, s *Set, oracle Rolacle, signing Signer, nonce *types.VRFPostIndex, p2p pubsub.Publisher, comm communication, clock RoundClock) Consensus {
 		return newConsensusProcess(ctx, conf, instanceId, s, oracle, stateQ, signing, pke, nid, nonce, p2p, comm, ev, clock, logger)
 	}
 
@@ -327,14 +328,6 @@ func (h *Hare) onTick(ctx context.Context, lid types.LayerID) (bool, error) {
 		return false, nil
 	}
 
-	defer func() {
-		// it must not return without starting consensus process or mark result as fail
-		// except if it's genesis layer
-		if err != nil {
-			h.outputChan <- procReport{lid, &Set{}, false, notCompleted}
-		}
-	}()
-
 	// call to start the calculation of active set size beforehand
 	h.eg.Go(func() error {
 		// this is called only for its side effects, but at least print the error if it returns one
@@ -361,14 +354,18 @@ func (h *Hare) onTick(ctx context.Context, lid types.LayerID) (bool, error) {
 		return false, nil
 	}
 
-	props := h.getGoodProposal(lid, beacon, logger)
-	logger.With().Info("starting hare", log.Int("num_proposals", len(props)))
-	preNumProposals.Add(float64(len(props)))
-	set := NewSet(props)
+	var nonce *types.VRFPostIndex
+	nnc, err := h.nonceFetcher.VRFNonce(h.nid, h.lastLayer.GetEpoch())
+	if err != nil && !errors.Is(err, sql.ErrNotFound) {
+		logger.With().Error("failed to get vrf nonce", log.Err(err))
+		return false, fmt.Errorf("vrf nonce: %w", err)
+	} else if err == nil {
+		nonce = &nnc
+	}
 
 	ch, err := h.broker.Register(ctx, lid)
 	if err != nil {
-		logger.With().Error("could not register consensus process on broker", log.Err(err))
+		logger.With().Error("failed to register with broker", log.Err(err))
 		return false, fmt.Errorf("broker register: %w", err)
 	}
 	comm := communication{
@@ -376,12 +373,12 @@ func (h *Hare) onTick(ctx context.Context, lid types.LayerID) (bool, error) {
 		mchOut: h.mchMalfeasance,
 		report: h.outputChan,
 	}
-	nonce, err := h.nonceFetcher.VRFNonce(h.nid, h.lastLayer.GetEpoch())
-	if err != nil {
-		logger.With().Error("could not get vrf nonce", log.Err(err))
-		return false, fmt.Errorf("vrf nonce: %w", err)
-	}
+	props := h.getGoodProposal(lid, beacon, logger)
+	preNumProposals.Add(float64(len(props)))
+	set := NewSet(props)
 	cp := h.factory(h.ctx, h.config, lid, set, h.rolacle, h.sign, nonce, h.publisher, comm, clock)
+
+	logger.With().Info("starting hare", log.Int("num_proposals", len(props)))
 	cp.Start()
 	h.addCP(logger, cp)
 	h.patrol.SetHareInCharge(lid)

--- a/hare/hare_test.go
+++ b/hare/hare_test.go
@@ -315,7 +315,7 @@ func TestHare_onTick(t *testing.T) {
 	createdChan := make(chan struct{}, 1)
 	startedChan := make(chan struct{}, 1)
 	var nmcp *mockConsensusProcess
-	h.factory = func(ctx context.Context, cfg config.Config, instanceId types.LayerID, s *Set, oracle Rolacle, signing Signer, nonce types.VRFPostIndex, p2p pubsub.Publisher, comm communication, clock RoundClock) Consensus {
+	h.factory = func(ctx context.Context, cfg config.Config, instanceId types.LayerID, s *Set, oracle Rolacle, signing Signer, _ *types.VRFPostIndex, p2p pubsub.Publisher, comm communication, clock RoundClock) Consensus {
 		nmcp = newMockConsensusProcess(cfg, instanceId, s, oracle, signing, p2p, comm.report, startedChan)
 		close(createdChan)
 		return nmcp
@@ -385,7 +385,7 @@ func TestHare_onTick_BeaconFromRefBallot(t *testing.T) {
 	createdChan := make(chan struct{}, 1)
 	startedChan := make(chan struct{}, 1)
 	var nmcp *mockConsensusProcess
-	h.factory = func(ctx context.Context, cfg config.Config, instanceId types.LayerID, s *Set, oracle Rolacle, signing Signer, nonce types.VRFPostIndex, p2p pubsub.Publisher, comm communication, clock RoundClock) Consensus {
+	h.factory = func(ctx context.Context, cfg config.Config, instanceId types.LayerID, s *Set, oracle Rolacle, signing Signer, _ *types.VRFPostIndex, p2p pubsub.Publisher, comm communication, clock RoundClock) Consensus {
 		nmcp = newMockConsensusProcess(cfg, instanceId, s, oracle, signing, p2p, comm.report, startedChan)
 		close(createdChan)
 		return nmcp
@@ -445,7 +445,7 @@ func TestHare_onTick_SomeBadBallots(t *testing.T) {
 	createdChan := make(chan struct{}, 1)
 	startedChan := make(chan struct{}, 1)
 	var nmcp *mockConsensusProcess
-	h.factory = func(ctx context.Context, cfg config.Config, instanceId types.LayerID, s *Set, oracle Rolacle, signing Signer, nonce types.VRFPostIndex, p2p pubsub.Publisher, comm communication, clock RoundClock) Consensus {
+	h.factory = func(ctx context.Context, cfg config.Config, instanceId types.LayerID, s *Set, oracle Rolacle, signing Signer, _ *types.VRFPostIndex, p2p pubsub.Publisher, comm communication, clock RoundClock) Consensus {
 		nmcp = newMockConsensusProcess(cfg, instanceId, s, oracle, signing, p2p, comm.report, startedChan)
 		close(createdChan)
 		return nmcp
@@ -502,7 +502,7 @@ func TestHare_onTick_NoGoodBallots(t *testing.T) {
 	createdChan := make(chan struct{}, 1)
 	startedChan := make(chan struct{}, 1)
 	var nmcp *mockConsensusProcess
-	h.factory = func(ctx context.Context, cfg config.Config, instanceId types.LayerID, s *Set, oracle Rolacle, signing Signer, nonce types.VRFPostIndex, p2p pubsub.Publisher, comm communication, clock RoundClock) Consensus {
+	h.factory = func(ctx context.Context, cfg config.Config, instanceId types.LayerID, s *Set, oracle Rolacle, signing Signer, _ *types.VRFPostIndex, p2p pubsub.Publisher, comm communication, clock RoundClock) Consensus {
 		nmcp = newMockConsensusProcess(cfg, instanceId, s, oracle, signing, p2p, comm.report, startedChan)
 		close(createdChan)
 		return nmcp


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
in #3971 codepath for passive hare participants is inadvertently disabled when vrf is not available (a non-smeshing node).

## Changes
<!-- Please describe in detail the changes made -->
continue with hare protocol even if vrf nonce is not present