### PR TITLE
[Merged by Bors] - beacon: consider zero proposals a failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ install:
 	go install github.com/spacemeshos/go-scale/scalegen@v1.1.1
 	go install github.com/golang/mock/mockgen
 	go install gotest.tools/gotestsum@v1.8.2
-	go install honnef.co/go/tools/cmd/staticcheck@latest
+	go install honnef.co/go/tools/cmd/staticcheck@v0.3.3
 .PHONY: install
 
 build: go-spacemesh

--- a/activation/activation.go
+++ b/activation/activation.go
@@ -282,7 +282,7 @@ func (b *Builder) run(ctx context.Context) {
 
 func (b *Builder) generateProof(ctx context.Context) error {
 	// don't generate the commitment every time smeshing is starting, but once only.
-	if _, err := b.cdb.GetPrevAtx(b.nodeID); err != nil {
+	if _, err := b.cdb.GetLastAtx(b.nodeID); err != nil {
 		// Once initialized, run the execution phase with zero-challenge,
 		// to create the initial proof (the commitment).
 		startTime := time.Now()
@@ -304,7 +304,7 @@ func (b *Builder) waitForFirstATX(ctx context.Context) bool {
 	if currEpoch == 0 { // genesis miner
 		return false
 	}
-	if prev, err := b.cdb.GetPrevAtx(b.nodeID); err == nil {
+	if prev, err := b.cdb.GetLastAtx(b.nodeID); err == nil {
 		if prev.PublishEpoch() == currEpoch {
 			// miner has published in the current epoch
 			return false
@@ -425,7 +425,7 @@ func (b *Builder) buildNIPostChallenge(ctx context.Context) (*types.NIPostChalle
 		PositioningATX: atxID,
 		PubLayerID:     pubLayerID.Add(b.layersPerEpoch),
 	}
-	if prevAtx, err := b.cdb.GetPrevAtx(b.nodeID); err != nil {
+	if prevAtx, err := b.cdb.GetLastAtx(b.nodeID); err != nil {
 		commitmentAtx, err := b.getCommitmentAtx(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get commitment ATX: %w", err)

--- a/beacon/beacon.go
+++ b/beacon/beacon.go
@@ -48,9 +48,9 @@ type (
 	proposals    = struct{ valid, potentiallyValid proposalSet }
 	allVotes     = struct{ support, against proposalSet }
 	beaconWeight = struct {
-		ballots     map[types.BallotID]struct{}
-		totalWeight fixed.Fixed
-		weightUnits int
+		ballots        map[types.BallotID]struct{}
+		totalWeight    fixed.Fixed
+		numEligibility int
 	}
 )
 
@@ -207,7 +207,7 @@ type ProtocolDriver struct {
 // SetSyncState updates sync state provider. Must be executed only once.
 func (pd *ProtocolDriver) SetSyncState(sync system.SyncStateProvider) {
 	if pd.sync != nil {
-		pd.logger.Panic("sync state provider can be updated only once")
+		pd.logger.Fatal("sync state provider can be updated only once")
 	}
 	pd.sync = sync
 }
@@ -224,7 +224,7 @@ func (pd *ProtocolDriver) Start(ctx context.Context) {
 	pd.startOnce.Do(func() {
 		pd.logger.With().Info("starting beacon protocol", log.String("config", fmt.Sprintf("%+v", pd.config)))
 		if pd.sync == nil {
-			pd.logger.Panic("update sync state provider can't be nil")
+			pd.logger.Fatal("update sync state provider can't be nil")
 		}
 
 		pd.metricsCollector.Start(nil)
@@ -282,24 +282,24 @@ func (pd *ProtocolDriver) recordBeacon(epochID types.EpochID, ballot *types.Ball
 	// using ballot weight here because we're sampling miners for the beacon value recorded
 	// in the ballots. we can't just take the entire ATX weight because otherwise, a "whale"
 	// ATX would dominate the voting.
-	ballotWeight := weightPer.Mul(fixed.New(len(ballot.EligibilityProofs)))
-	weightUnit := len(ballot.EligibilityProofs)
+	numEligibility := len(ballot.EligibilityProofs)
+	ballotWeight := weightPer.Mul(fixed.New(numEligibility))
 	if _, ok := pd.ballotsBeacons[epochID]; !ok {
 		pd.ballotsBeacons[epochID] = make(map[types.Beacon]*beaconWeight)
 	}
 	entry, ok := pd.ballotsBeacons[epochID][beacon]
 	if !ok {
 		pd.ballotsBeacons[epochID][beacon] = &beaconWeight{
-			ballots:     map[types.BallotID]struct{}{ballot.ID(): {}},
-			totalWeight: ballotWeight,
-			weightUnits: weightUnit,
+			ballots:        map[types.BallotID]struct{}{ballot.ID(): {}},
+			totalWeight:    ballotWeight,
+			numEligibility: numEligibility,
 		}
 		pd.logger.With().Debug("added beacon from ballot",
 			epochID,
 			ballot.ID(),
 			beacon,
 			log.Stringer("weight_per", weightPer),
-			log.Int("weight_units", weightUnit),
+			log.Int("num_eligibility", numEligibility),
 			log.Stringer("weight", ballotWeight))
 		return
 	}
@@ -312,13 +312,13 @@ func (pd *ProtocolDriver) recordBeacon(epochID types.EpochID, ballot *types.Ball
 
 	entry.ballots[ballot.ID()] = struct{}{}
 	entry.totalWeight = entry.totalWeight.Add(ballotWeight)
-	entry.weightUnits += weightUnit
+	entry.numEligibility += numEligibility
 	pd.logger.With().Debug("added beacon from ballot",
 		epochID,
 		ballot.ID(),
 		beacon,
 		log.Stringer("weight_per", weightPer),
-		log.Int("weight_units", weightUnit),
+		log.Int("num_eligibility", numEligibility),
 		log.Stringer("weight", ballotWeight))
 }
 
@@ -330,14 +330,14 @@ func (pd *ProtocolDriver) findMajorityBeacon(epoch types.EpochID) types.Beacon {
 		return types.EmptyBeacon
 	}
 	totalWeight := fixed.New64(0)
-	totalWeightUnits := 0
+	totalEligibility := 0
 	for _, bw := range epochBeacons {
-		totalWeightUnits += bw.weightUnits
+		totalEligibility += bw.numEligibility
 		totalWeight = totalWeight.Add(bw.totalWeight)
 	}
 
-	logger := pd.logger.WithFields(epoch, log.Int("total_weight_units", totalWeightUnits))
-	if totalWeightUnits < pd.config.BeaconSyncWeightUnits {
+	logger := pd.logger.WithFields(epoch, log.Int("total_weight_units", totalEligibility))
+	if totalEligibility < pd.config.BeaconSyncWeightUnits {
 		logger.Debug("not enough weight units to determine beacon")
 		return types.EmptyBeacon
 	}
@@ -349,7 +349,7 @@ func (pd *ProtocolDriver) findMajorityBeacon(epoch types.EpochID) types.Beacon {
 		if bw.totalWeight.GreaterThan(majorityWeight) {
 			logger.With().Info("beacon determined for epoch",
 				beacon,
-				log.Int("total_weight_unit", totalWeightUnits),
+				log.Int("total_weight_unit", totalEligibility),
 				log.Stringer("total_weight", totalWeight),
 				log.Stringer("beacon_weight", bw.totalWeight))
 			return beacon
@@ -361,7 +361,7 @@ func (pd *ProtocolDriver) findMajorityBeacon(epoch types.EpochID) types.Beacon {
 	}
 	logger.With().Warning("beacon determined for epoch by plurality, not majority",
 		bPlurality,
-		log.Int("total_weight_unit", totalWeightUnits),
+		log.Int("total_weight_unit", totalEligibility),
 		log.Stringer("total_weight", totalWeight),
 		log.Stringer("beacon_weight", maxWeight))
 	return bPlurality
@@ -428,7 +428,7 @@ func (pd *ProtocolDriver) persistBeacon(epoch types.EpochID, beacon types.Beacon
 			pd.logger.With().Error("trying to persist different beacon", epoch, beacon, log.String("saved_beacon", savedBeacon.ShortString()))
 			return errDifferentBeacon
 		}
-		pd.logger.With().Warning("beacon already exists for epoch", epoch, beacon)
+		pd.logger.With().Debug("beacon already exists for epoch", epoch, beacon)
 	}
 	return nil
 }
@@ -622,7 +622,7 @@ func (pd *ProtocolDriver) onNewEpoch(ctx context.Context, epoch types.EpochID) e
 
 	s, err := pd.setupEpoch(logger, epoch)
 	if err != nil {
-		logger.With().Error("epoch not setup correctly", log.Err(err))
+		logger.With().Error("failed to set up epoch", log.Err(err))
 		return err
 	}
 
@@ -660,7 +660,7 @@ func (pd *ProtocolDriver) runProtocol(ctx context.Context, epoch types.EpochID, 
 	// After K rounds had passed, tally up votes for proposals using simple tortoise vote counting
 	beacon := calcBeacon(logger, lastRoundOwnVotes.support)
 
-	if err := pd.setBeacon(targetEpoch, beacon); err != nil {
+	if err = pd.setBeacon(targetEpoch, beacon); err != nil {
 		logger.With().Error("failed to set beacon", log.Err(err))
 		return
 	}
@@ -671,18 +671,18 @@ func (pd *ProtocolDriver) runProtocol(ctx context.Context, epoch types.EpochID, 
 func calcBeacon(logger log.Log, set proposalSet) types.Beacon {
 	logger.Info("calculating beacon")
 
-	allHashes := set.sort()
-	allHashHexes := make([]string, len(allHashes))
-	for i, h := range allHashes {
-		allHashHexes[i] = hex.EncodeToString(h)
+	allProposals := set.sort()
+	allHexes := make([]string, len(allProposals))
+	for i, h := range allProposals {
+		allHexes[i] = hex.EncodeToString(h)
 	}
-	logger.With().Debug("calculating beacon from this hash list",
-		log.String("hashes", strings.Join(allHashHexes, ", ")))
+	logger.With().Debug("calculating beacon",
+		log.String("proposals", strings.Join(allHexes, ", ")))
 
 	// Beacon should appear to have the same entropy as the initial proposals, hence cropping it
 	// to the same size as the proposal
-	beacon := types.BytesToBeacon(allHashes.hash().Bytes())
-	logger.With().Info("calculated beacon", beacon, log.Int("num_hashes", len(allHashes)))
+	beacon := types.BytesToBeacon(allProposals.hash().Bytes())
+	logger.With().Info("calculated beacon", beacon, log.Int("num_hashes", len(allProposals)))
 
 	return beacon
 }
@@ -710,7 +710,7 @@ func (pd *ProtocolDriver) runProposalPhase(ctx context.Context, epoch types.Epoc
 		return err
 	}
 
-	logger.Debug("beacon proposal phase finished")
+	logger.Info("beacon proposal phase finished")
 	return nil
 }
 
@@ -720,33 +720,35 @@ func (pd *ProtocolDriver) sendProposal(ctx context.Context, epoch types.EpochID,
 	}
 
 	logger := pd.logger.WithContext(ctx).WithFields(epoch)
-	proposedSignature := buildSignedProposal(ctx, pd.logger, pd.vrfSigner, epoch, nonce)
-	if !pd.checkProposalEligibility(logger, epoch, proposedSignature) {
+	vrfSig := buildSignedProposal(ctx, pd.logger, pd.vrfSigner, epoch, nonce)
+	proposal := hex.EncodeToString(cropData(vrfSig))
+
+	if !pd.proposalEligible(logger, epoch, vrfSig) {
 		logger.With().Debug("own proposal doesn't pass threshold",
-			log.String("proposal", string(proposedSignature)),
+			log.String("proposal", proposal),
 		)
 		// proposal is not sent
 		return
 	}
 
 	logger.With().Debug("own proposal passes threshold",
-		log.String("proposal", string(proposedSignature)),
+		log.String("proposal", proposal),
 	)
 
 	// concat them into a single proposal message
 	m := ProposalMessage{
 		EpochID:      epoch,
 		NodeID:       pd.nodeID,
-		VRFSignature: proposedSignature,
+		VRFSignature: vrfSig,
 	}
 
 	serialized, err := codec.Encode(&m)
 	if err != nil {
-		logger.With().Panic("failed to serialize message for gossip", log.Err(err))
+		logger.With().Fatal("failed to encode beacon proposal", log.Err(err))
 	}
 
 	pd.sendToGossip(ctx, pubsub.BeaconProposalProtocol, serialized)
-	logger.With().Info("beacon proposal sent", log.String("message", m.String()))
+	logger.With().Info("beacon proposal sent", log.String("proposal", proposal))
 }
 
 // runConsensusPhase runs K voting rounds and returns result from last weak coin round.
@@ -865,7 +867,7 @@ func (pd *ProtocolDriver) sendFirstRoundVote(ctx context.Context, epoch types.Ep
 
 	encoded, err := codec.Encode(&mb)
 	if err != nil {
-		pd.logger.With().Panic("failed to serialize message for signing", log.Err(err))
+		pd.logger.With().Fatal("failed to serialize message for signing", log.Err(err))
 	}
 	sig := pd.edSigner.Sign(encoded)
 
@@ -874,14 +876,10 @@ func (pd *ProtocolDriver) sendFirstRoundVote(ctx context.Context, epoch types.Ep
 		Signature:              sig,
 	}
 
-	pd.logger.WithContext(ctx).With().Debug("sending first round vote",
-		epoch,
-		types.FirstRound,
-		log.String("message", m.String()))
-
+	pd.logger.WithContext(ctx).With().Debug("sending first round vote", epoch, types.FirstRound)
 	serialized, err := codec.Encode(&m)
 	if err != nil {
-		pd.logger.With().Panic("failed to serialize message for gossip", log.Err(err))
+		pd.logger.With().Fatal("failed to serialize message for gossip", log.Err(err))
 	}
 
 	pd.sendToGossip(ctx, pubsub.BeaconFirstVotesProtocol, serialized)
@@ -912,7 +910,7 @@ func (pd *ProtocolDriver) sendFollowingVote(ctx context.Context, epoch types.Epo
 
 	encoded, err := codec.Encode(&mb)
 	if err != nil {
-		pd.logger.With().Panic("failed to serialize message for signing", log.Err(err))
+		pd.logger.With().Fatal("failed to serialize message for signing", log.Err(err))
 	}
 	sig := pd.edSigner.Sign(encoded)
 
@@ -921,14 +919,11 @@ func (pd *ProtocolDriver) sendFollowingVote(ctx context.Context, epoch types.Epo
 		Signature:                  sig,
 	}
 
-	pd.logger.WithContext(ctx).With().Debug("sending following round vote",
-		epoch,
-		round,
-		log.String("message", m.String()))
+	pd.logger.WithContext(ctx).With().Debug("sending following round vote", epoch, round)
 
 	serialized, err := codec.Encode(&m)
 	if err != nil {
-		pd.logger.With().Panic("failed to serialize message for gossip", log.Err(err))
+		pd.logger.With().Fatal("failed to serialize message for gossip", log.Err(err))
 	}
 
 	pd.sendToGossip(ctx, pubsub.BeaconFollowingVotesProtocol, serialized)
@@ -1012,15 +1007,13 @@ func atxThreshold(kappa int, q *big.Rat, numATXs int) *big.Int {
 
 func buildSignedProposal(ctx context.Context, logger log.Log, signer vrfSigner, epoch types.EpochID, nonce types.VRFPostIndex) []byte {
 	p := buildProposal(logger, epoch, nonce)
-	signature := signer.Sign(p)
-	logger.WithContext(ctx).With().Debug("calculated signature",
+	vrfSig := signer.Sign(p)
+	logger.WithContext(ctx).With().Debug("calculated beacon proposal",
 		epoch,
 		nonce,
-		log.String("proposal", hex.EncodeToString(p)),
-		log.String("signature", hex.EncodeToString(signature)),
+		log.String("proposal", hex.EncodeToString(cropData(vrfSig))),
 	)
-
-	return signature
+	return vrfSig
 }
 
 //go:generate scalegen -types ProposalVrfMessage
@@ -1071,7 +1064,7 @@ func (pd *ProtocolDriver) gatherMetricsData() ([]*metrics.BeaconStats, *metrics.
 				Epoch:      epoch,
 				Beacon:     beacon.ShortString(),
 				Weight:     stats.totalWeight,
-				WeightUnit: stats.weightUnits,
+				WeightUnit: stats.numEligibility,
 			}
 			observed = append(observed, stat)
 		}

--- a/beacon/beacon.go
+++ b/beacon/beacon.go
@@ -465,6 +465,20 @@ func (pd *ProtocolDriver) initEpochStateIfNotPresent(logger log.Log, epoch types
 		return s, nil
 	}
 
+	var (
+		weight uint64
+		ids    []types.ATXID
+		miners = map[string]uint64{}
+	)
+	if err := pd.cdb.IterateEpochATXHeaders(epoch, func(header *types.ActivationTxHeader) bool {
+		weight += header.GetWeight()
+		ids = append(ids, header.ID)
+		miners[string(header.NodeID.Bytes())] += uint64(header.NumUnits)
+		return true
+	}); err != nil {
+		return nil, err
+	}
+
 	epochWeight, atxids, err := pd.cdb.GetEpochWeight(epoch)
 	if err != nil {
 		logger.With().Error("failed to get weight targeting epoch", log.Err(err))
@@ -480,7 +494,7 @@ func (pd *ProtocolDriver) initEpochStateIfNotPresent(logger log.Log, epoch types
 		logger.With().Error("get own VRF nonce", log.Err(err))
 		return nil, fmt.Errorf("get own VRF nonce: %w", err)
 	}
-	pd.states[epoch] = newState(logger, pd.config, epochWeight, nonce, atxids)
+	pd.states[epoch] = newState(logger, pd.config, nonce, epochWeight, atxids, miners)
 	return pd.states[epoch], nil
 }
 
@@ -497,10 +511,10 @@ func (pd *ProtocolDriver) setProposalTimeForNextEpoch() {
 	pd.earliestProposalTime = t
 }
 
-func (pd *ProtocolDriver) setupEpoch(logger log.Log, epoch types.EpochID) ([]types.ATXID, types.VRFPostIndex, error) {
+func (pd *ProtocolDriver) setupEpoch(logger log.Log, epoch types.EpochID) (*state, error) {
 	s, err := pd.initEpochStateIfNotPresent(logger, epoch)
 	if err != nil {
-		return nil, 0, err
+		return nil, err
 	}
 
 	pd.mu.Lock()
@@ -508,7 +522,7 @@ func (pd *ProtocolDriver) setupEpoch(logger log.Log, epoch types.EpochID) ([]typ
 	pd.roundInProgress = types.FirstRound
 	pd.earliestVoteTime = time.Time{}
 
-	return s.atxs, s.nonce, nil
+	return s, nil
 }
 
 func (pd *ProtocolDriver) cleanupEpoch(epoch types.EpochID) {
@@ -606,18 +620,18 @@ func (pd *ProtocolDriver) onNewEpoch(ctx context.Context, epoch types.EpochID) e
 		return err
 	}
 
-	atxids, nonce, err := pd.setupEpoch(logger, epoch)
+	s, err := pd.setupEpoch(logger, epoch)
 	if err != nil {
 		logger.With().Error("epoch not setup correctly", log.Err(err))
 		return err
 	}
 
 	logger.With().Info("participating beacon protocol with ATX", atxID)
-	pd.runProtocol(ctx, epoch, nonce, atxids)
+	pd.runProtocol(ctx, epoch, s)
 	return nil
 }
 
-func (pd *ProtocolDriver) runProtocol(ctx context.Context, epoch types.EpochID, nonce types.VRFPostIndex, atxs []types.ATXID) {
+func (pd *ProtocolDriver) runProtocol(ctx context.Context, epoch types.EpochID, st *state) {
 	ctx = log.WithNewSessionID(ctx)
 	targetEpoch := epoch + 1
 	logger := pd.logger.WithContext(ctx).WithFields(epoch, log.Uint32("target_epoch", uint32(targetEpoch)))
@@ -625,10 +639,10 @@ func (pd *ProtocolDriver) runProtocol(ctx context.Context, epoch types.EpochID, 
 	pd.setBeginProtocol(ctx)
 	defer pd.setEndProtocol(ctx)
 
-	pd.startWeakCoinEpoch(ctx, epoch, nonce, atxs)
+	pd.weakCoin.StartEpoch(ctx, epoch, st.nonce, st.unitAllowance)
 	defer pd.weakCoin.FinishEpoch(ctx, epoch)
 
-	if err := pd.runProposalPhase(ctx, epoch, nonce); err != nil {
+	if err := pd.runProposalPhase(ctx, epoch, st.nonce); err != nil {
 		logger.With().Warning("proposal phase failed", log.Err(err))
 		return
 	}
@@ -805,20 +819,6 @@ func (pd *ProtocolDriver) runConsensusPhase(ctx context.Context, epoch types.Epo
 
 	logger.Info("consensus phase finished")
 	return ownVotes, nil
-}
-
-func (pd *ProtocolDriver) startWeakCoinEpoch(ctx context.Context, epoch types.EpochID, nonce types.VRFPostIndex, atxs []types.ATXID) {
-	// we need to pass a map with spacetime unit allowances before any round is started
-	ua := weakcoin.UnitAllowances{}
-	for _, id := range atxs {
-		header, err := pd.cdb.GetAtxHeader(id)
-		if err != nil {
-			pd.logger.WithContext(ctx).With().Panic("unable to load atx header", log.Err(err))
-		}
-		ua[string(header.NodeID.Bytes())] += uint64(header.EffectiveNumUnits)
-	}
-
-	pd.weakCoin.StartEpoch(ctx, epoch, nonce, ua)
 }
 
 func (pd *ProtocolDriver) markProposalPhaseFinished(epoch types.EpochID, finishedAt time.Time) error {

--- a/beacon/beacon.go
+++ b/beacon/beacon.go
@@ -466,24 +466,19 @@ func (pd *ProtocolDriver) initEpochStateIfNotPresent(logger log.Log, epoch types
 	}
 
 	var (
-		weight uint64
-		ids    []types.ATXID
-		miners = map[string]uint64{}
+		epochWeight uint64
+		atxids      []types.ATXID
+		miners      = map[string]uint64{}
 	)
 	if err := pd.cdb.IterateEpochATXHeaders(epoch, func(header *types.ActivationTxHeader) bool {
-		weight += header.GetWeight()
-		ids = append(ids, header.ID)
+		epochWeight += header.GetWeight()
+		atxids = append(atxids, header.ID)
 		miners[string(header.NodeID.Bytes())] += uint64(header.NumUnits)
 		return true
 	}); err != nil {
 		return nil, err
 	}
 
-	epochWeight, atxids, err := pd.cdb.GetEpochWeight(epoch)
-	if err != nil {
-		logger.With().Error("failed to get weight targeting epoch", log.Err(err))
-		return nil, fmt.Errorf("get epoch weight: %w", err)
-	}
 	if epochWeight == 0 {
 		logger.With().Error("zero weight targeting epoch", log.Err(errZeroEpochWeight))
 		return nil, errZeroEpochWeight

--- a/beacon/beacon_test.go
+++ b/beacon/beacon_test.go
@@ -676,19 +676,19 @@ func TestBeacon_findMajorityBeacon(t *testing.T) {
 
 	beaconFromBallots := map[types.Beacon]*beaconWeight{
 		beacon1: {
-			ballots:     map[types.BallotID]struct{}{types.RandomBallotID(): {}, types.RandomBallotID(): {}},
-			totalWeight: fixed.New64(1),
-			weightUnits: 2,
+			ballots:        map[types.BallotID]struct{}{types.RandomBallotID(): {}, types.RandomBallotID(): {}},
+			totalWeight:    fixed.New64(1),
+			numEligibility: 2,
 		},
 		beacon2: {
-			ballots:     map[types.BallotID]struct{}{types.RandomBallotID(): {}},
-			totalWeight: fixed.New64(3),
-			weightUnits: 1,
+			ballots:        map[types.BallotID]struct{}{types.RandomBallotID(): {}},
+			totalWeight:    fixed.New64(3),
+			numEligibility: 1,
 		},
 		beacon3: {
-			ballots:     map[types.BallotID]struct{}{types.RandomBallotID(): {}},
-			totalWeight: fixed.New64(1),
-			weightUnits: 1,
+			ballots:        map[types.BallotID]struct{}{types.RandomBallotID(): {}},
+			totalWeight:    fixed.New64(1),
+			numEligibility: 1,
 		},
 	}
 	epoch := types.EpochID(3)
@@ -712,19 +712,19 @@ func TestBeacon_findMajorityBeacon_plurality(t *testing.T) {
 
 	beaconFromBallots := map[types.Beacon]*beaconWeight{
 		beacon1: {
-			ballots:     map[types.BallotID]struct{}{types.RandomBallotID(): {}, types.RandomBallotID(): {}},
-			totalWeight: fixed.New64(1),
-			weightUnits: 2,
+			ballots:        map[types.BallotID]struct{}{types.RandomBallotID(): {}, types.RandomBallotID(): {}},
+			totalWeight:    fixed.New64(1),
+			numEligibility: 2,
 		},
 		beacon2: {
-			ballots:     map[types.BallotID]struct{}{types.RandomBallotID(): {}},
-			totalWeight: fixed.DivUint64(11, 10),
-			weightUnits: 1,
+			ballots:        map[types.BallotID]struct{}{types.RandomBallotID(): {}},
+			totalWeight:    fixed.DivUint64(11, 10),
+			numEligibility: 1,
 		},
 		beacon3: {
-			ballots:     map[types.BallotID]struct{}{types.RandomBallotID(): {}},
-			totalWeight: fixed.New64(1),
-			weightUnits: 1,
+			ballots:        map[types.BallotID]struct{}{types.RandomBallotID(): {}},
+			totalWeight:    fixed.New64(1),
+			numEligibility: 1,
 		},
 	}
 	epoch := types.EpochID(3)
@@ -748,19 +748,19 @@ func TestBeacon_findMajorityBeacon_NotEnoughBallots(t *testing.T) {
 
 	beaconFromBallots := map[types.Beacon]*beaconWeight{
 		beacon1: {
-			ballots:     map[types.BallotID]struct{}{types.RandomBallotID(): {}, types.RandomBallotID(): {}},
-			totalWeight: fixed.New64(1),
-			weightUnits: 2,
+			ballots:        map[types.BallotID]struct{}{types.RandomBallotID(): {}, types.RandomBallotID(): {}},
+			totalWeight:    fixed.New64(1),
+			numEligibility: 2,
 		},
 		beacon2: {
-			ballots:     map[types.BallotID]struct{}{types.RandomBallotID(): {}},
-			totalWeight: fixed.New64(3),
-			weightUnits: 1,
+			ballots:        map[types.BallotID]struct{}{types.RandomBallotID(): {}},
+			totalWeight:    fixed.New64(3),
+			numEligibility: 1,
 		},
 		beacon3: {
-			ballots:     map[types.BallotID]struct{}{types.RandomBallotID(): {}},
-			totalWeight: fixed.New64(1),
-			weightUnits: 1,
+			ballots:        map[types.BallotID]struct{}{types.RandomBallotID(): {}},
+			totalWeight:    fixed.New64(1),
+			numEligibility: 1,
 		},
 	}
 	epoch := types.EpochID(3)

--- a/beacon/beacon_test.go
+++ b/beacon/beacon_test.go
@@ -215,6 +215,55 @@ func TestBeacon_MultipleNodes(t *testing.T) {
 	require.Len(t, beacons, 1)
 }
 
+func TestBeacon_NoProposals(t *testing.T) {
+	numNodes := 5
+	testNodes := make([]*testProtocolDriver, 0, numNodes)
+	publisher := pubsubmocks.NewMockPublisher(gomock.NewController(t))
+	publisher.EXPECT().Publish(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+
+	atxPublishLid := types.NewLayerID(types.GetLayersPerEpoch()*2 - 1)
+	current := atxPublishLid.Add(1)
+	dbs := make([]*datastore.CachedDB, 0, numNodes)
+	cfg := NodeSimUnitTestConfig()
+	now := time.Now()
+	for i := 0; i < numNodes; i++ {
+		node := newTestDriver(t, cfg, publisher)
+		node.mSync.EXPECT().IsSynced(gomock.Any()).Return(true).AnyTimes()
+		node.mClock.EXPECT().GetCurrentLayer().Return(current).AnyTimes()
+		node.mClock.EXPECT().LayerToTime(current).Return(now).AnyTimes()
+		testNodes = append(testNodes, node)
+		dbs = append(dbs, node.cdb)
+
+		require.ErrorIs(t, node.onNewEpoch(context.Background(), types.EpochID(0)), errGenesis)
+		require.ErrorIs(t, node.onNewEpoch(context.Background(), types.EpochID(1)), errGenesis)
+		got, err := node.GetBeacon(types.EpochID(1))
+		require.NoError(t, err)
+		require.EqualValues(t, got, types.HexToBeacon(types.BootstrapBeacon))
+		got, err = node.GetBeacon(types.EpochID(2))
+		require.NoError(t, err)
+		require.EqualValues(t, got, types.HexToBeacon(types.BootstrapBeacon))
+	}
+	for _, node := range testNodes {
+		for _, db := range dbs {
+			createATX(t, db, atxPublishLid, node.edSigner, 1)
+		}
+	}
+	var wg sync.WaitGroup
+	for _, node := range testNodes {
+		wg.Add(1)
+		go func(testNode *testProtocolDriver) {
+			require.NoError(t, testNode.onNewEpoch(context.Background(), types.EpochID(2)))
+			wg.Done()
+		}(node)
+	}
+	wg.Wait()
+	for _, node := range testNodes {
+		got, err := node.GetBeacon(types.EpochID(3))
+		require.Error(t, err)
+		require.Equal(t, types.EmptyBeacon, got)
+	}
+}
+
 func TestBeaconNotSynced(t *testing.T) {
 	tpd := setUpProtocolDriver(t)
 	tpd.mSync.EXPECT().IsSynced(gomock.Any()).Return(false).AnyTimes()
@@ -339,12 +388,7 @@ func TestBeaconWithMetrics(t *testing.T) {
 				}
 			}
 		}
-		if layer.OrdinalInEpoch() == 2 {
-			// there should be calculated beacon already by the last layer of the epoch
-			require.Equal(t, 1, numCalculated, layer)
-		} else {
-			require.LessOrEqual(t, numCalculated, 1, layer)
-		}
+		require.Equal(t, 0, numCalculated, layer)
 		require.Equal(t, 2, numObserved, layer)
 		require.Equal(t, 2, numObservedWeight, layer)
 	}
@@ -962,19 +1006,14 @@ func TestBeacon_signAndExtractED(t *testing.T) {
 }
 
 func TestBeacon_calcBeacon(t *testing.T) {
-	votes := allVotes{
-		support: proposalSet{
-			"0x1": {},
-			"0x2": {},
-			"0x4": {},
-			"0x5": {},
-		},
-		against: proposalSet{
-			"0x3": {},
-			"0x6": {},
-		},
+	set := proposalSet{
+		"0x1": {},
+		"0x2": {},
+		"0x4": {},
+		"0x5": {},
 	}
-	beacon := calcBeacon(logtest.New(t), votes)
+
+	beacon := calcBeacon(logtest.New(t), set)
 	expected := types.HexToBeacon("0x98f88210")
 	require.EqualValues(t, expected, beacon)
 }

--- a/beacon/handlers_test.go
+++ b/beacon/handlers_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/spacemeshos/go-spacemesh/beacon/weakcoin"
 	"github.com/spacemeshos/go-spacemesh/codec"
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/common/util"
@@ -44,7 +45,7 @@ func createEpochState(tb testing.TB, pd *ProtocolDriver, epoch types.EpochID) {
 	tb.Helper()
 	pd.mu.Lock()
 	defer pd.mu.Unlock()
-	pd.states[epoch] = newState(pd.logger, pd.config, epochWeight, types.VRFPostIndex(rand.Uint64()), types.RandomActiveSet(1))
+	pd.states[epoch] = newState(pd.logger, pd.config, types.VRFPostIndex(rand.Uint64()), epochWeight, types.RandomActiveSet(1), weakcoin.UnitAllowances{})
 }
 
 func setOwnFirstRoundVotes(t *testing.T, pd *ProtocolDriver, epoch types.EpochID, ownFirstRound proposalList) {

--- a/beacon/message.go
+++ b/beacon/message.go
@@ -1,11 +1,7 @@
 package beacon
 
 import (
-	"encoding/json"
-
-	"github.com/spacemeshos/go-spacemesh/codec"
 	"github.com/spacemeshos/go-spacemesh/common/types"
-	"github.com/spacemeshos/go-spacemesh/log"
 )
 
 //go:generate scalegen
@@ -15,16 +11,6 @@ type ProposalMessage struct {
 	EpochID      types.EpochID
 	NodeID       types.NodeID
 	VRFSignature []byte
-}
-
-// String returns a string form of ProposalMessage.
-func (p ProposalMessage) String() string {
-	bytes, err := codec.Encode(&p)
-	if err != nil {
-		log.With().Fatal("failed to encode ProposalMessage", log.Err(err))
-	}
-
-	return string(bytes)
 }
 
 // FirstVotingMessageBody is FirstVotingMessage without a signature.
@@ -40,16 +26,6 @@ type FirstVotingMessage struct {
 	Signature []byte
 }
 
-// String returns a string form of FirstVotingMessage.
-func (v FirstVotingMessage) String() string {
-	bytes, err := json.Marshal(v)
-	if err != nil {
-		panic(err)
-	}
-
-	return string(bytes)
-}
-
 // FollowingVotingMessageBody is FollowingVotingMessage without a signature.
 type FollowingVotingMessageBody struct {
 	EpochID        types.EpochID
@@ -61,14 +37,4 @@ type FollowingVotingMessageBody struct {
 type FollowingVotingMessage struct {
 	FollowingVotingMessageBody
 	Signature []byte
-}
-
-// String returns a string form of FollowingVotingMessage.
-func (v FollowingVotingMessage) String() string {
-	bytes, err := json.Marshal(v)
-	if err != nil {
-		panic(err)
-	}
-
-	return string(bytes)
 }

--- a/beacon/state.go
+++ b/beacon/state.go
@@ -1,6 +1,7 @@
 package beacon
 
 import (
+	"encoding/hex"
 	"fmt"
 	"math/big"
 	"time"
@@ -51,18 +52,16 @@ func (s *state) addValidProposal(proposal []byte) {
 	if s.incomingProposals.valid == nil {
 		s.incomingProposals.valid = make(map[string]struct{})
 	}
-	p := string(proposal)
-	s.incomingProposals.valid[p] = struct{}{}
-	s.votesMargin[p] = new(big.Int)
+	s.incomingProposals.valid[string(proposal)] = struct{}{}
+	s.votesMargin[string(proposal)] = new(big.Int)
 }
 
 func (s *state) addPotentiallyValidProposal(proposal []byte) {
 	if s.incomingProposals.potentiallyValid == nil {
 		s.incomingProposals.potentiallyValid = make(map[string]struct{})
 	}
-	p := string(proposal)
-	s.incomingProposals.potentiallyValid[p] = struct{}{}
-	s.votesMargin[p] = new(big.Int)
+	s.incomingProposals.potentiallyValid[string(proposal)] = struct{}{}
+	s.votesMargin[string(proposal)] = new(big.Int)
 }
 
 func (s *state) setMinerFirstRoundVote(minerPK *signing.PublicKey, voteList [][]byte) {
@@ -72,7 +71,7 @@ func (s *state) setMinerFirstRoundVote(minerPK *signing.PublicKey, voteList [][]
 func (s *state) getMinerFirstRoundVote(minerPK *signing.PublicKey) (proposalList, error) {
 	p, ok := s.firstRoundIncomingVotes[string(minerPK.Bytes())]
 	if !ok {
-		return nil, fmt.Errorf("no first round votes for miner %v", minerPK.String())
+		return nil, fmt.Errorf("no first round votes for miner")
 	}
 	return p, nil
 }
@@ -81,7 +80,8 @@ func (s *state) addVote(proposal string, vote uint, voteWeight *big.Int) {
 	if _, ok := s.votesMargin[proposal]; !ok {
 		// voteMargin is updated during the proposal phase.
 		// ignore votes on proposals not in the original proposals.
-		s.logger.With().Warning("ignoring vote for unknown proposal", log.Binary("proposal", []byte(proposal)))
+		s.logger.With().Warning("ignoring vote for unknown proposal",
+			log.String("proposal", hex.EncodeToString([]byte(proposal))))
 		return
 	}
 	if vote == up {

--- a/beacon/state.go
+++ b/beacon/state.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 	"time"
 
+	"github.com/spacemeshos/go-spacemesh/beacon/weakcoin"
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/signing"
@@ -28,13 +29,15 @@ type state struct {
 	hasVoted                  []map[string]struct{}
 	proposalPhaseFinishedTime time.Time
 	proposalChecker           eligibilityChecker
+	unitAllowance             weakcoin.UnitAllowances
 }
 
-func newState(logger log.Log, cfg Config, epochWeight uint64, nonce types.VRFPostIndex, atxids []types.ATXID) *state {
+func newState(logger log.Log, cfg Config, nonce types.VRFPostIndex, epochWeight uint64, atxids []types.ATXID, ua weakcoin.UnitAllowances) *state {
 	return &state{
 		logger:                  logger,
 		epochWeight:             epochWeight,
 		nonce:                   nonce,
+		unitAllowance:           ua,
 		atxs:                    atxids,
 		firstRoundIncomingVotes: make(map[string]proposalList),
 		votesMargin:             map[string]*big.Int{},

--- a/beacon/weakcoin/weak_coin_scale.go
+++ b/beacon/weakcoin/weak_coin_scale.go
@@ -38,7 +38,7 @@ func (t *Message) EncodeScale(enc *scale.Encoder) (total int, err error) {
 		total += n
 	}
 	{
-		n, err := scale.EncodeByteSlice(enc, t.Signature)
+		n, err := scale.EncodeByteSlice(enc, t.VrfSignature)
 		if err != nil {
 			return total, err
 		}
@@ -86,12 +86,12 @@ func (t *Message) DecodeScale(dec *scale.Decoder) (total int, err error) {
 			return total, err
 		}
 		total += n
-		t.Signature = field
+		t.VrfSignature = field
 	}
 	return total, nil
 }
 
-func (t *WeakCoinVrfMessage) EncodeScale(enc *scale.Encoder) (total int, err error) {
+func (t *VrfMessage) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	{
 		n, err := scale.EncodeString(enc, string(t.Prefix))
 		if err != nil {
@@ -130,7 +130,7 @@ func (t *WeakCoinVrfMessage) EncodeScale(enc *scale.Encoder) (total int, err err
 	return total, nil
 }
 
-func (t *WeakCoinVrfMessage) DecodeScale(dec *scale.Decoder) (total int, err error) {
+func (t *VrfMessage) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	{
 		field, n, err := scale.DecodeString(dec)
 		if err != nil {

--- a/beacon/weakcoin/weak_coin_test.go
+++ b/beacon/weakcoin/weak_coin_test.go
@@ -84,11 +84,11 @@ func TestWeakCoin(t *testing.T) {
 			startedEpoch: epoch,
 			startedRound: round,
 			messages: []weakcoin.Message{{
-				Epoch:     epoch,
-				Round:     round,
-				Unit:      1,
-				MinerPK:   oneLSB,
-				Signature: oneLSB,
+				Epoch:        epoch,
+				Round:        round,
+				Unit:         1,
+				MinerPK:      oneLSB,
+				VrfSignature: oneLSB,
 			}},
 			coinflip: true,
 		},
@@ -106,11 +106,11 @@ func TestWeakCoin(t *testing.T) {
 			startedEpoch: epoch,
 			startedRound: round,
 			messages: []weakcoin.Message{{
-				Epoch:     epoch,
-				Round:     round,
-				Unit:      2,
-				MinerPK:   oneLSB,
-				Signature: oneLSB,
+				Epoch:        epoch,
+				Round:        round,
+				Unit:         2,
+				MinerPK:      oneLSB,
+				VrfSignature: oneLSB,
 			}},
 		},
 		{
@@ -120,11 +120,11 @@ func TestWeakCoin(t *testing.T) {
 			startedEpoch: epoch,
 			startedRound: round,
 			messages: []weakcoin.Message{{
-				Epoch:     epoch,
-				Round:     round,
-				Unit:      1,
-				MinerPK:   higherThreshold,
-				Signature: higherThreshold,
+				Epoch:        epoch,
+				Round:        round,
+				Unit:         1,
+				MinerPK:      higherThreshold,
+				VrfSignature: higherThreshold,
 			}},
 		},
 		{
@@ -134,11 +134,11 @@ func TestWeakCoin(t *testing.T) {
 			startedEpoch: epoch,
 			startedRound: round,
 			messages: []weakcoin.Message{{
-				Epoch:     epoch,
-				Round:     round,
-				Unit:      1,
-				MinerPK:   zeroLSB,
-				Signature: zeroLSB,
+				Epoch:        epoch,
+				Round:        round,
+				Unit:         1,
+				MinerPK:      zeroLSB,
+				VrfSignature: zeroLSB,
 			}},
 		},
 		{
@@ -148,11 +148,11 @@ func TestWeakCoin(t *testing.T) {
 			startedEpoch: epoch,
 			startedRound: round,
 			messages: []weakcoin.Message{{
-				Epoch:     epoch,
-				Round:     round,
-				Unit:      1,
-				MinerPK:   zeroLSB,
-				Signature: zeroLSB,
+				Epoch:        epoch,
+				Round:        round,
+				Unit:         1,
+				MinerPK:      zeroLSB,
+				VrfSignature: zeroLSB,
 			}},
 		},
 		{
@@ -162,11 +162,11 @@ func TestWeakCoin(t *testing.T) {
 			startedEpoch: epoch,
 			startedRound: round,
 			messages: []weakcoin.Message{{
-				Epoch:     epoch - 1,
-				Round:     round,
-				Unit:      1,
-				MinerPK:   zeroLSB,
-				Signature: oneLSB,
+				Epoch:        epoch - 1,
+				Round:        round,
+				Unit:         1,
+				MinerPK:      zeroLSB,
+				VrfSignature: oneLSB,
 			}},
 		},
 		{
@@ -176,11 +176,11 @@ func TestWeakCoin(t *testing.T) {
 			startedEpoch: epoch,
 			startedRound: round,
 			messages: []weakcoin.Message{{
-				Epoch:     epoch,
-				Round:     round - 1,
-				Unit:      1,
-				MinerPK:   zeroLSB,
-				Signature: oneLSB,
+				Epoch:        epoch,
+				Round:        round - 1,
+				Unit:         1,
+				MinerPK:      zeroLSB,
+				VrfSignature: oneLSB,
 			}},
 		},
 	}
@@ -331,18 +331,18 @@ func TestWeakCoinNextRoundBufferOverflow(t *testing.T) {
 	require.NoError(t, wc.StartRound(context.Background(), round))
 	for i := 0; i < bufSize; i++ {
 		wc.HandleProposal(context.Background(), "", broadcastedMessage(t, weakcoin.Message{
-			Epoch:     epoch,
-			Round:     nextRound,
-			Unit:      1,
-			MinerPK:   oneLSB,
-			Signature: oneLSB,
+			Epoch:        epoch,
+			Round:        nextRound,
+			Unit:         1,
+			MinerPK:      oneLSB,
+			VrfSignature: oneLSB,
 		}))
 	}
 	wc.HandleProposal(context.Background(), "", broadcastedMessage(t, weakcoin.Message{
-		Epoch:     epoch,
-		Round:     nextRound,
-		Unit:      1,
-		Signature: zeroLSB,
+		Epoch:        epoch,
+		Round:        nextRound,
+		Unit:         1,
+		VrfSignature: zeroLSB,
 	}))
 	wc.FinishRound(context.Background())
 	require.NoError(t, wc.StartRound(context.Background(), nextRound))
@@ -362,7 +362,7 @@ func TestWeakCoinEncodingRegression(t *testing.T) {
 	broadcaster.EXPECT().Publish(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().DoAndReturn(func(_ context.Context, _ string, data []byte) error {
 		var msg weakcoin.Message
 		require.NoError(t, codec.Decode(data, &msg))
-		sig = msg.Signature
+		sig = msg.VrfSignature
 		return nil
 	}).AnyTimes()
 

--- a/datastore/store_test.go
+++ b/datastore/store_test.go
@@ -176,6 +176,46 @@ func TestIdentityExists(t *testing.T) {
 	require.True(t, exists)
 }
 
+func TestStore_GetAtxByNodeID(t *testing.T) {
+	cdb := datastore.NewCachedDB(sql.InMemory(), logtest.New(t))
+
+	atx3 := &types.ActivationTx{
+		InnerActivationTx: types.InnerActivationTx{
+			NIPostChallenge: types.NIPostChallenge{
+				PubLayerID: types.EpochID(3).FirstLayer(),
+				Sequence:   11,
+			},
+			NumUnits: 11,
+		},
+	}
+	atx4 := &types.ActivationTx{
+		InnerActivationTx: types.InnerActivationTx{
+			NIPostChallenge: types.NIPostChallenge{
+				PubLayerID: types.EpochID(4).FirstLayer(),
+				Sequence:   12,
+			},
+			NumUnits: 11,
+		},
+	}
+	signer, err := signing.NewEdSigner()
+	require.NoError(t, err)
+	for _, atx := range []*types.ActivationTx{atx3, atx4} {
+		require.NoError(t, activation.SignAndFinalizeAtx(signer, atx))
+		atx.SetEffectiveNumUnits(atx.NumUnits)
+		vAtx, err := atx.Verify(0, 1)
+		require.NoError(t, err)
+		require.NoError(t, atxs.Add(cdb, vAtx, time.Now()))
+	}
+
+	got, err := cdb.GetEpochAtx(types.EpochID(3), signer.NodeID())
+	require.NoError(t, err)
+	require.Equal(t, atx3.ID(), got.ID)
+
+	got, err = cdb.GetLastAtx(signer.NodeID())
+	require.NoError(t, err)
+	require.Equal(t, atx4.ID(), got.ID)
+}
+
 func TestBlobStore_GetATXBlob(t *testing.T) {
 	db := sql.InMemory()
 	bs := datastore.NewBlobStore(db)


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
part of #3903
<!-- `Closes #XXXX, closes #XXXX, ...` links mentioned issues to this PR and automatically closes them when this it's merged -->

## Changes
<!-- Please describe in detail the changes made -->
- if the protocol finishes with zero proposals, the beacon protocol failed
- when beacon starts epoch, iterate all atxs just once (instead of twice, one for total weight/active set and one for weak coin unit allowance)
- retrieves atx header in one db read in handlers.go instead of getting atx ID (1 read) and getting atx header (max 1 read)
- tune some logging level and shorten messages. specifically 
  - using hex to log beacon proposals
  - drop log.binary()
