### PR TITLE
[Merged by Bors] - Build go-spacemesh binaries for arm64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,21 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        include:
+          - os: macos-latest
+          - os: ubuntu-latest
+          - os: windows-latest
+          - os: [self-hosted, macos, arm64]
+          - os: [self-hosted, linux, arm64]
     steps:
+      - shell: bash
+        run: |
+          if [[ ${{ runner.arch }} == "ARM64" ]]; then
+            echo "OUTNAME=${{ runner.os }}_${{ runner.arch }}" >> $GITHUB_ENV
+          else
+            echo "OUTNAME=${{ runner.os }}" >> $GITHUB_ENV
+          fi
+
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
@@ -54,6 +67,8 @@ jobs:
       - name: Get gpu-post release
         shell: bash
         run: |
+          echo "OUTNAME = ${{ env.OUTNAME }} \n"
+
           mkdir build_${{ runner.os }}
           unzip libgpu-setup-*.zip -d build_${{ runner.os }}
 
@@ -63,11 +78,11 @@ jobs:
           
           rm -f build_${{ runner.os }}/api.h
           rm -f ${{ runner.os }}.zip
-          mv build_${{ runner.os }} ${{ runner.os }}
+          mv build_${{ runner.os }} $OUTNAME
 
-          mv ./build/* ${{ runner.os }}
+          mv ./build/* $OUTNAME
 
-          zip -r ${{ runner.os }}.zip ${{ runner.os }}
+          zip -r $OUTNAME.zip $OUTNAME
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v0
         with:
@@ -78,7 +93,7 @@ jobs:
       - name: Upload zip
         uses: google-github-actions/upload-cloud-storage@v0
         with:
-          path: ${{ runner.os }}.zip
+          path: ${{ env.OUTNAME }}.zip
           destination: ${{ secrets.GCP_BUCKET }}/${{ steps.version.outputs.content }}/
   
   release:
@@ -106,6 +121,8 @@ jobs:
             ## Zip Files
             - Windows: https://storage.googleapis.com/${{ secrets.GCP_BUCKET }}/${{ steps.version.outputs.content }}/Windows.zip
             - macOS: https://storage.googleapis.com/${{ secrets.GCP_BUCKET }}/${{ steps.version.outputs.content }}/macOS.zip
+            - macOS: https://storage.googleapis.com/${{ secrets.GCP_BUCKET }}/${{ steps.version.outputs.content }}/macOS_ARM64.zip
             - Linux: https://storage.googleapis.com/${{ secrets.GCP_BUCKET }}/${{ steps.version.outputs.content }}/Linux.zip
+            - Linux: https://storage.googleapis.com/${{ secrets.GCP_BUCKET }}/${{ steps.version.outputs.content }}/Linux_ARM64.zip
           draft: false
           prerelease: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,13 +71,8 @@ jobs:
 
           mkdir build_${{ runner.os }}
           unzip libgpu-setup-*.zip -d build_${{ runner.os }}
-
-          #Download latest smrepl release
-          wget https://github.com/spacemeshos/smrepl/releases/download/v0.1.32/${{ runner.os }}.zip
-          unzip ${{ runner.os }}.zip -d build_${{ runner.os }}
           
           rm -f build_${{ runner.os }}/api.h
-          rm -f ${{ runner.os }}.zip
           mv build_${{ runner.os }} $OUTNAME
 
           mv ./build/* $OUTNAME
@@ -121,8 +116,8 @@ jobs:
             ## Zip Files
             - Windows: https://storage.googleapis.com/${{ secrets.GCP_BUCKET }}/${{ steps.version.outputs.content }}/Windows.zip
             - macOS: https://storage.googleapis.com/${{ secrets.GCP_BUCKET }}/${{ steps.version.outputs.content }}/macOS.zip
-            - macOS: https://storage.googleapis.com/${{ secrets.GCP_BUCKET }}/${{ steps.version.outputs.content }}/macOS_ARM64.zip
+            - macOS arm64: https://storage.googleapis.com/${{ secrets.GCP_BUCKET }}/${{ steps.version.outputs.content }}/macOS_ARM64.zip
             - Linux: https://storage.googleapis.com/${{ secrets.GCP_BUCKET }}/${{ steps.version.outputs.content }}/Linux.zip
-            - Linux: https://storage.googleapis.com/${{ secrets.GCP_BUCKET }}/${{ steps.version.outputs.content }}/Linux_ARM64.zip
+            - Linux arm64: https://storage.googleapis.com/${{ secrets.GCP_BUCKET }}/${{ steps.version.outputs.content }}/Linux_ARM64.zip
           draft: false
           prerelease: true

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-v0.0.0-unreleased
+v0.0.0-test-arm64


### PR DESCRIPTION
## Motivation
It closes #4035 

## Changes
Added two more build targets and tweaked GHA workflow a bit.

## How to test
For testing purposes I've pushed tag [`v0.0.0-test-arm64`](https://github.com/spacemeshos/go-spacemesh/releases/tag/v0.0.0-test-arm64) — there are links to archives.
1. Download the archive corresponding to your os and arch
2. Unzip it
3. Go to extracted dir
4. Set chmod (on Linux & macOS): `chmod 755 ./*`
5. On MacOS turn off quarantine: `sudo xattr -rd com.apple.quarantine ./*`
6. Run go-spacemesh as usually (aka `./go-spacemesh -d ~/node-data -c ~/config.json`)
7. Ensure it has a full list of PoS providers. Call:
    ```
    grpcurl -d "{\"benchmark\": true}" -plaintext localhost:9092 spacemesh.v1.SmesherService.PostSetupComputeProviders
    ```
    The list depends on your OS, but hopefully, you'll see some GPU beside the CPU. :)