### PR TITLE
[Merged by Bors] - systests: make bootnodes non-smeshing

### DIFF
--- a/activation/poetdb.go
+++ b/activation/poetdb.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/codec"
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/log"
+	"github.com/spacemeshos/go-spacemesh/p2p"
 	"github.com/spacemeshos/go-spacemesh/sql"
 	"github.com/spacemeshos/go-spacemesh/sql/poets"
 )
@@ -55,7 +56,7 @@ func (db *PoetDb) ValidateAndStore(ctx context.Context, proofMessage *types.Poet
 }
 
 // ValidateAndStoreMsg validates and stores a new PoET proof.
-func (db *PoetDb) ValidateAndStoreMsg(ctx context.Context, data []byte) error {
+func (db *PoetDb) ValidateAndStoreMsg(ctx context.Context, _ p2p.Peer, data []byte) error {
 	var proofMessage types.PoetProofMessage
 	if err := codec.Decode(data, &proofMessage); err != nil {
 		return fmt.Errorf("parse message: %w", err)

--- a/beacon/beacon.go
+++ b/beacon/beacon.go
@@ -25,7 +25,6 @@ import (
 	"github.com/spacemeshos/go-spacemesh/p2p/pubsub"
 	"github.com/spacemeshos/go-spacemesh/signing"
 	"github.com/spacemeshos/go-spacemesh/sql"
-	"github.com/spacemeshos/go-spacemesh/sql/atxs"
 	"github.com/spacemeshos/go-spacemesh/sql/beacons"
 	"github.com/spacemeshos/go-spacemesh/system"
 )
@@ -458,25 +457,24 @@ func (pd *ProtocolDriver) initEpochStateIfNotPresent(logger log.Log, epoch types
 		return s, nil
 	}
 
-	// make sure this node has ATX in the last epoch and is eligible to participate in the beacon protocol
-	_, err := atxs.GetIDByEpochAndNodeID(pd.cdb, epoch-1, pd.nodeID)
-	if errors.Is(err, sql.ErrNotFound) {
-		pd.states[epoch] = nil
-		return nil, nil
-	} else if err != nil {
-		logger.With().Error("failed to get last epoch atx", log.Err(err))
-		return nil, fmt.Errorf("get last epoch atx: %w", err)
-	}
-
 	var (
 		epochWeight uint64
-		atxids      []types.ATXID
 		miners      = map[string]uint64{}
+		active      bool
+		nonce       *types.VRFPostIndex
 	)
 	if err := pd.cdb.IterateEpochATXHeaders(epoch, func(header *types.ActivationTxHeader) bool {
 		epochWeight += header.GetWeight()
-		atxids = append(atxids, header.ID)
-		miners[string(header.NodeID.Bytes())] += uint64(header.NumUnits)
+		if _, ok := miners[string(header.NodeID.Bytes())]; !ok {
+			miners[string(header.NodeID.Bytes())] = uint64(header.NumUnits)
+		} else {
+			pd.logger.With().Warning("ignore malicious atx from miner",
+				header.ID,
+				log.Stringer("miner_id", header.NodeID))
+		}
+		if header.NodeID == pd.nodeID {
+			active = true
+		}
 		return true
 	}); err != nil {
 		return nil, err
@@ -487,12 +485,15 @@ func (pd *ProtocolDriver) initEpochStateIfNotPresent(logger log.Log, epoch types
 		return nil, errZeroEpochWeight
 	}
 
-	nonce, err := pd.nonceFetcher.VRFNonce(pd.nodeID, epoch)
-	if err != nil {
-		logger.With().Error("get own VRF nonce", log.Err(err))
-		return nil, fmt.Errorf("get own VRF nonce: %w", err)
+	if active {
+		nnc, err := pd.nonceFetcher.VRFNonce(pd.nodeID, epoch)
+		if err != nil {
+			logger.With().Error("failed to get own VRF nonce", log.Err(err))
+			return nil, fmt.Errorf("get own VRF nonce: %w", err)
+		}
+		nonce = &nnc
 	}
-	pd.states[epoch] = newState(logger, pd.config, nonce, epochWeight, atxids, miners)
+	pd.states[epoch] = newState(logger, pd.config, nonce, epochWeight, miners)
 	return pd.states[epoch], nil
 }
 
@@ -511,8 +512,8 @@ func (pd *ProtocolDriver) setProposalTimeForNextEpoch() {
 
 func (pd *ProtocolDriver) setupEpoch(logger log.Log, epoch types.EpochID) (*state, error) {
 	s, err := pd.initEpochStateIfNotPresent(logger, epoch)
-	if s == nil || err != nil {
-		return s, err
+	if err != nil {
+		return nil, err
 	}
 
 	pd.mu.Lock()
@@ -616,10 +617,6 @@ func (pd *ProtocolDriver) onNewEpoch(ctx context.Context, epoch types.EpochID) e
 		logger.With().Error("failed to set up epoch", log.Err(err))
 		return err
 	}
-	if s == nil {
-		logger.With().Info("not eligible to run beacon protocol")
-		return nil
-	}
 	logger.With().Info("participating in beacon protocol")
 	pd.runProtocol(ctx, epoch, s)
 	return nil
@@ -633,14 +630,14 @@ func (pd *ProtocolDriver) runProtocol(ctx context.Context, epoch types.EpochID, 
 	pd.setBeginProtocol(ctx)
 	defer pd.setEndProtocol(ctx)
 
-	pd.weakCoin.StartEpoch(ctx, epoch, st.nonce, st.unitAllowance)
+	pd.weakCoin.StartEpoch(ctx, epoch, st.unitAllowance)
 	defer pd.weakCoin.FinishEpoch(ctx, epoch)
 
 	if err := pd.runProposalPhase(ctx, epoch, st.nonce); err != nil {
 		logger.With().Warning("proposal phase failed", log.Err(err))
 		return
 	}
-	lastRoundOwnVotes, err := pd.runConsensusPhase(ctx, epoch)
+	lastRoundOwnVotes, err := pd.runConsensusPhase(ctx, epoch, st.nonce)
 	if err != nil {
 		logger.With().Warning("consensus phase failed", log.Err(err))
 		return
@@ -663,14 +660,12 @@ func (pd *ProtocolDriver) runProtocol(ctx context.Context, epoch types.EpochID, 
 }
 
 func calcBeacon(logger log.Log, set proposalSet) types.Beacon {
-	logger.Info("calculating beacon")
-
 	allProposals := set.sort()
 	allHexes := make([]string, len(allProposals))
 	for i, h := range allProposals {
 		allHexes[i] = hex.EncodeToString(h)
 	}
-	logger.With().Debug("calculating beacon",
+	logger.With().Info("calculating beacon",
 		log.String("proposals", strings.Join(allHexes, ", ")))
 
 	// Beacon should appear to have the same entropy as the initial proposals, hence cropping it
@@ -681,7 +676,7 @@ func calcBeacon(logger log.Log, set proposalSet) types.Beacon {
 	return beacon
 }
 
-func (pd *ProtocolDriver) runProposalPhase(ctx context.Context, epoch types.EpochID, nonce types.VRFPostIndex) error {
+func (pd *ProtocolDriver) runProposalPhase(ctx context.Context, epoch types.EpochID, nonce *types.VRFPostIndex) error {
 	logger := pd.logger.WithContext(ctx).WithFields(epoch)
 	logger.Info("starting beacon proposal phase")
 
@@ -689,10 +684,12 @@ func (pd *ProtocolDriver) runProposalPhase(ctx context.Context, epoch types.Epoc
 	ctx, cancel = context.WithTimeout(ctx, pd.config.ProposalDuration)
 	defer cancel()
 
-	pd.eg.Go(func() error {
-		pd.sendProposal(ctx, epoch, nonce)
-		return nil
-	})
+	if nonce != nil {
+		pd.eg.Go(func() error {
+			pd.sendProposal(ctx, epoch, *nonce)
+			return nil
+		})
+	}
 
 	select {
 	case <-ctx.Done():
@@ -746,7 +743,7 @@ func (pd *ProtocolDriver) sendProposal(ctx context.Context, epoch types.EpochID,
 }
 
 // runConsensusPhase runs K voting rounds and returns result from last weak coin round.
-func (pd *ProtocolDriver) runConsensusPhase(ctx context.Context, epoch types.EpochID) (allVotes, error) {
+func (pd *ProtocolDriver) runConsensusPhase(ctx context.Context, epoch types.EpochID, nonce *types.VRFPostIndex) (allVotes, error) {
 	logger := pd.logger.WithContext(ctx).WithFields(epoch)
 	logger.Info("starting consensus phase")
 
@@ -767,18 +764,20 @@ func (pd *ProtocolDriver) runConsensusPhase(ctx context.Context, epoch types.Epo
 		pd.setRoundInProgress(round)
 		rLogger := logger.WithFields(round)
 		votes := ownVotes
-		pd.eg.Go(func() error {
-			if round == types.FirstRound {
-				if err := pd.sendFirstRoundVote(ctx, epoch); err != nil {
-					rLogger.With().Error("failed to send proposal vote", log.Err(err))
+		if nonce != nil {
+			pd.eg.Go(func() error {
+				if round == types.FirstRound {
+					if err := pd.sendFirstRoundVote(ctx, epoch); err != nil {
+						rLogger.With().Error("failed to send proposal vote", log.Err(err))
+					}
+				} else {
+					if err := pd.sendFollowingVote(ctx, epoch, round, votes); err != nil {
+						rLogger.With().Error("failed to send following vote", log.Err(err))
+					}
 				}
-			} else {
-				if err := pd.sendFollowingVote(ctx, epoch, round, votes); err != nil {
-					rLogger.With().Error("failed to send following vote", log.Err(err))
-				}
-			}
-			return nil
-		})
+				return nil
+			})
+		}
 
 		select {
 		case <-timer.C:
@@ -797,8 +796,8 @@ func (pd *ProtocolDriver) runConsensusPhase(ctx context.Context, epoch types.Epo
 			timer.Reset(pd.config.WeakCoinRoundDuration)
 
 			pd.eg.Go(func() error {
-				if err := pd.weakCoin.StartRound(ctx, round); err != nil {
-					rLogger.With().Error("failed to publish weak coin proposal", log.Err(err))
+				if err := pd.weakCoin.StartRound(ctx, round, nonce); err != nil {
+					rLogger.With().Error("failed to start weak coin proposal", log.Err(err))
 				}
 				return nil
 			})

--- a/beacon/beacon_test.go
+++ b/beacon/beacon_test.go
@@ -39,12 +39,14 @@ func coinValueMock(tb testing.TB, value bool) coin {
 	coinMock.EXPECT().StartEpoch(
 		gomock.Any(),
 		gomock.AssignableToTypeOf(types.EpochID(0)),
-		gomock.AssignableToTypeOf(types.VRFPostIndex(0)),
 		gomock.AssignableToTypeOf(weakcoin.UnitAllowances{}),
 	).AnyTimes()
 	coinMock.EXPECT().FinishEpoch(gomock.Any(), gomock.AssignableToTypeOf(types.EpochID(0))).AnyTimes()
-	coinMock.EXPECT().StartRound(gomock.Any(), gomock.AssignableToTypeOf(types.RoundID(0))).
-		AnyTimes().Return(nil)
+	nonce := types.VRFPostIndex(0)
+	coinMock.EXPECT().StartRound(gomock.Any(),
+		gomock.AssignableToTypeOf(types.RoundID(0)),
+		gomock.AssignableToTypeOf(&nonce),
+	).AnyTimes().Return(nil)
 	coinMock.EXPECT().FinishRound(gomock.Any()).AnyTimes()
 	coinMock.EXPECT().Get(
 		gomock.Any(),
@@ -192,7 +194,11 @@ func TestBeacon_MultipleNodes(t *testing.T) {
 		require.NoError(t, err)
 		require.EqualValues(t, got, types.HexToBeacon(types.BootstrapBeacon))
 	}
-	for _, node := range testNodes {
+	for i, node := range testNodes {
+		if i == 0 {
+			// make the first node non-smeshing node
+			continue
+		}
 		for _, db := range dbs {
 			createATX(t, db, atxPublishLid, node.edSigner, 1)
 		}

--- a/beacon/beacon_test.go
+++ b/beacon/beacon_test.go
@@ -305,7 +305,7 @@ func TestBeaconNoATXInPreviousEpoch(t *testing.T) {
 	require.ErrorIs(t, tpd.onNewEpoch(context.Background(), types.EpochID(1)), errGenesis)
 	lid := types.NewLayerID(types.GetLayersPerEpoch()*2 - 1)
 	createRandomATXs(t, tpd.cdb, lid, numATXs)
-	require.ErrorIs(t, tpd.onNewEpoch(context.Background(), types.EpochID(2)), sql.ErrNotFound)
+	require.NoError(t, tpd.onNewEpoch(context.Background(), types.EpochID(2)))
 
 	got, err := tpd.GetBeacon(types.EpochID(2))
 	require.NoError(t, err)
@@ -790,7 +790,7 @@ func TestBeacon_findMajorityBeacon_NoBeacon(t *testing.T) {
 	require.Equal(t, types.EmptyBeacon, got)
 }
 
-func TestBeacon_persistBeacon(t *testing.T) {
+func TestBeacon_setBeacon(t *testing.T) {
 	t.Parallel()
 
 	tpd := setUpProtocolDriver(t)
@@ -799,9 +799,9 @@ func TestBeacon_persistBeacon(t *testing.T) {
 	require.NoError(t, tpd.setBeacon(epoch, beacon))
 
 	// saving it again won't cause error
-	require.NoError(t, tpd.persistBeacon(epoch, beacon))
+	require.NoError(t, tpd.setBeacon(epoch, beacon))
 	// but saving a different one will
-	require.ErrorIs(t, tpd.persistBeacon(epoch, types.RandomBeacon()), errDifferentBeacon)
+	require.ErrorIs(t, tpd.setBeacon(epoch, types.RandomBeacon()), errDifferentBeacon)
 }
 
 func TestBeacon_atxThresholdFraction(t *testing.T) {

--- a/beacon/handlers.go
+++ b/beacon/handlers.go
@@ -81,11 +81,8 @@ func (pd *ProtocolDriver) handleProposal(ctx context.Context, peer p2p.Peer, msg
 	logger = pd.logger.WithContext(ctx).WithFields(m.EpochID, log.String("miner_id", m.NodeID.ShortString()))
 	logger.With().Debug("new beacon proposal", log.String("proposal", hex.EncodeToString(cropData(m.VRFSignature))))
 
-	if s, err := pd.initEpochStateIfNotPresent(logger, m.EpochID); err != nil {
+	if _, err := pd.initEpochStateIfNotPresent(logger, m.EpochID); err != nil {
 		return err
-	} else if s == nil {
-		logger.With().Debug("not participating in beacon protocol")
-		return errProtocolNotRunning
 	}
 
 	atxHeader, err := pd.verifyProposalMessage(logger, m)

--- a/beacon/handlers_test.go
+++ b/beacon/handlers_test.go
@@ -45,7 +45,7 @@ func createEpochState(tb testing.TB, pd *ProtocolDriver, epoch types.EpochID) {
 	tb.Helper()
 	pd.mu.Lock()
 	defer pd.mu.Unlock()
-	pd.states[epoch] = newState(pd.logger, pd.config, types.VRFPostIndex(rand.Uint64()), epochWeight, types.RandomActiveSet(1), weakcoin.UnitAllowances{})
+	pd.states[epoch] = newState(pd.logger, pd.config, nil, epochWeight, weakcoin.UnitAllowances{"nodeID": 111})
 }
 
 func setOwnFirstRoundVotes(t *testing.T, pd *ProtocolDriver, epoch types.EpochID, ownFirstRound proposalList) {
@@ -357,7 +357,6 @@ func Test_handleProposal_NextEpoch(t *testing.T) {
 	msgBytes, err := codec.Encode(msg)
 	require.NoError(t, err)
 
-	createATX(t, tpd.cdb, nextEpoch.FirstLayer().Sub(1), tpd.edSigner, 10)
 	setEarliestProposalTime(tpd.ProtocolDriver, time.Now().Add(-1*time.Second))
 	tpd.mClock.EXPECT().CurrentLayer().Return(epoch.FirstLayer()).AnyTimes()
 	tpd.mClock.EXPECT().LayerToTime((nextEpoch).FirstLayer()).Return(time.Now()).Times(1)

--- a/beacon/handlers_test.go
+++ b/beacon/handlers_test.go
@@ -357,6 +357,7 @@ func Test_handleProposal_NextEpoch(t *testing.T) {
 	msgBytes, err := codec.Encode(msg)
 	require.NoError(t, err)
 
+	createATX(t, tpd.cdb, nextEpoch.FirstLayer().Sub(1), tpd.edSigner, 10)
 	setEarliestProposalTime(tpd.ProtocolDriver, time.Now().Add(-1*time.Second))
 	tpd.mClock.EXPECT().CurrentLayer().Return(epoch.FirstLayer()).AnyTimes()
 	tpd.mClock.EXPECT().LayerToTime((nextEpoch).FirstLayer()).Return(time.Now()).Times(1)

--- a/beacon/interface.go
+++ b/beacon/interface.go
@@ -14,8 +14,8 @@ import (
 //go:generate mockgen -package=beacon -destination=./mocks.go -source=./interface.go
 
 type coin interface {
-	StartEpoch(context.Context, types.EpochID, types.VRFPostIndex, weakcoin.UnitAllowances)
-	StartRound(context.Context, types.RoundID) error
+	StartEpoch(context.Context, types.EpochID, weakcoin.UnitAllowances)
+	StartRound(context.Context, types.RoundID, *types.VRFPostIndex) error
 	FinishRound(context.Context)
 	Get(context.Context, types.EpochID, types.RoundID) bool
 	FinishEpoch(context.Context, types.EpochID)

--- a/beacon/mocks.go
+++ b/beacon/mocks.go
@@ -93,29 +93,29 @@ func (mr *MockcoinMockRecorder) HandleProposal(arg0, arg1, arg2 interface{}) *go
 }
 
 // StartEpoch mocks base method.
-func (m *Mockcoin) StartEpoch(arg0 context.Context, arg1 types.EpochID, arg2 types.VRFPostIndex, arg3 weakcoin.UnitAllowances) {
+func (m *Mockcoin) StartEpoch(arg0 context.Context, arg1 types.EpochID, arg2 weakcoin.UnitAllowances) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "StartEpoch", arg0, arg1, arg2, arg3)
+	m.ctrl.Call(m, "StartEpoch", arg0, arg1, arg2)
 }
 
 // StartEpoch indicates an expected call of StartEpoch.
-func (mr *MockcoinMockRecorder) StartEpoch(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockcoinMockRecorder) StartEpoch(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartEpoch", reflect.TypeOf((*Mockcoin)(nil).StartEpoch), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartEpoch", reflect.TypeOf((*Mockcoin)(nil).StartEpoch), arg0, arg1, arg2)
 }
 
 // StartRound mocks base method.
-func (m *Mockcoin) StartRound(arg0 context.Context, arg1 types.RoundID) error {
+func (m *Mockcoin) StartRound(arg0 context.Context, arg1 types.RoundID, arg2 *types.VRFPostIndex) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StartRound", arg0, arg1)
+	ret := m.ctrl.Call(m, "StartRound", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // StartRound indicates an expected call of StartRound.
-func (mr *MockcoinMockRecorder) StartRound(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockcoinMockRecorder) StartRound(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartRound", reflect.TypeOf((*Mockcoin)(nil).StartRound), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartRound", reflect.TypeOf((*Mockcoin)(nil).StartRound), arg0, arg1, arg2)
 }
 
 // MockeligibilityChecker is a mock of eligibilityChecker interface.

--- a/beacon/state.go
+++ b/beacon/state.go
@@ -16,9 +16,8 @@ import (
 // not thread-safe. it relies on ProtocolDriver's thread-safety mechanism.
 type state struct {
 	logger      log.Log
-	nonce       types.VRFPostIndex
+	nonce       *types.VRFPostIndex
 	epochWeight uint64
-	atxs        []types.ATXID
 	// the original proposals as received, bucketed by validity.
 	incomingProposals proposals
 	// minerPublicKey -> list of proposal.
@@ -33,18 +32,17 @@ type state struct {
 	unitAllowance             weakcoin.UnitAllowances
 }
 
-func newState(logger log.Log, cfg Config, nonce types.VRFPostIndex, epochWeight uint64, atxids []types.ATXID, ua weakcoin.UnitAllowances) *state {
+func newState(logger log.Log, cfg Config, nonce *types.VRFPostIndex, epochWeight uint64, ua weakcoin.UnitAllowances) *state {
 	return &state{
 		logger:                  logger,
 		epochWeight:             epochWeight,
 		nonce:                   nonce,
 		unitAllowance:           ua,
-		atxs:                    atxids,
 		firstRoundIncomingVotes: make(map[string]proposalList),
 		votesMargin:             map[string]*big.Int{},
 		hasProposed:             make(map[string]struct{}),
 		hasVoted:                make([]map[string]struct{}, cfg.RoundsNumber),
-		proposalChecker:         createProposalChecker(logger, cfg, len(atxids)),
+		proposalChecker:         createProposalChecker(logger, cfg, len(ua)),
 	}
 }
 

--- a/blocks/certifier.go
+++ b/blocks/certifier.go
@@ -243,7 +243,10 @@ func (c *Certifier) CertifyIfEligible(ctx context.Context, logger log.Log, lid t
 		return errBeaconNotAvailable
 	}
 	nonce, err := c.nonceFetcher.VRFNonce(c.nodeID, lid.GetEpoch())
-	if err != nil {
+	if err != nil { // never submitted an atx, not eligible
+		if errors.Is(err, sql.ErrNotFound) {
+			return nil
+		}
 		return fmt.Errorf("failed to get own vrf nonce: %w", err)
 	}
 

--- a/blocks/handler.go
+++ b/blocks/handler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	vm "github.com/spacemeshos/go-spacemesh/genvm"
 	"github.com/spacemeshos/go-spacemesh/log"
+	"github.com/spacemeshos/go-spacemesh/p2p"
 	"github.com/spacemeshos/go-spacemesh/sql"
 	"github.com/spacemeshos/go-spacemesh/sql/blocks"
 	"github.com/spacemeshos/go-spacemesh/system"
@@ -54,7 +55,7 @@ func NewHandler(f system.Fetcher, db *sql.Database, m meshProvider, opts ...Opt)
 }
 
 // HandleSyncedBlock handles Block data from sync.
-func (h *Handler) HandleSyncedBlock(ctx context.Context, data []byte) error {
+func (h *Handler) HandleSyncedBlock(ctx context.Context, peer p2p.Peer, data []byte) error {
 	logger := h.logger.WithContext(ctx)
 
 	var b types.Block
@@ -79,7 +80,7 @@ func (h *Handler) HandleSyncedBlock(ctx context.Context, data []byte) error {
 	}
 	logger.With().Info("new block")
 
-	h.fetcher.AddPeersFromHash(b.ID().AsHash32(), types.TransactionIDsToHashes(b.TxIDs))
+	h.fetcher.RegisterPeerHashes(peer, types.TransactionIDsToHashes(b.TxIDs))
 	if err := h.checkTransactions(ctx, &b); err != nil {
 		logger.With().Warning("failed to fetch block TXs", log.Err(err))
 		return err

--- a/blocks/handler_test.go
+++ b/blocks/handler_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/codec"
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/log/logtest"
+	"github.com/spacemeshos/go-spacemesh/p2p"
 	"github.com/spacemeshos/go-spacemesh/sql"
 	"github.com/spacemeshos/go-spacemesh/sql/blocks"
 	smocks "github.com/spacemeshos/go-spacemesh/system/mocks"
@@ -54,14 +55,14 @@ func createBlockData(t *testing.T, layerID types.LayerID, txIDs []types.Transact
 
 func Test_HandleBlockData_MalformedData(t *testing.T) {
 	th := createTestHandler(t)
-	assert.ErrorIs(t, th.HandleSyncedBlock(context.TODO(), []byte("malformed")), errMalformedData)
+	assert.ErrorIs(t, th.HandleSyncedBlock(context.TODO(), p2p.NoPeer, []byte("malformed")), errMalformedData)
 }
 
 func Test_HandleBlockData_InvalidRewards(t *testing.T) {
 	th := createTestHandler(t)
 	buf, err := codec.Encode(&types.Block{})
 	require.NoError(t, err)
-	require.ErrorIs(t, th.HandleSyncedBlock(context.TODO(), buf), errInvalidRewards)
+	require.ErrorIs(t, th.HandleSyncedBlock(context.TODO(), p2p.NoPeer, buf), errInvalidRewards)
 }
 
 func Test_HandleBlockData_AlreadyHasBlock(t *testing.T) {
@@ -71,7 +72,7 @@ func Test_HandleBlockData_AlreadyHasBlock(t *testing.T) {
 
 	block, data := createBlockData(t, layerID, txIDs)
 	require.NoError(t, blocks.Add(th.db, block))
-	assert.NoError(t, th.HandleSyncedBlock(context.TODO(), data))
+	assert.NoError(t, th.HandleSyncedBlock(context.TODO(), p2p.NoPeer, data))
 }
 
 func Test_HandleBlockData_FailedToFetchTXs(t *testing.T) {
@@ -82,8 +83,9 @@ func Test_HandleBlockData_FailedToFetchTXs(t *testing.T) {
 	block, data := createBlockData(t, layerID, txIDs)
 	errUnknown := errors.New("unknown")
 	th.mockFetcher.EXPECT().GetBlockTxs(gomock.Any(), txIDs).Return(errUnknown).Times(1)
-	th.mockFetcher.EXPECT().AddPeersFromHash(block.ID().AsHash32(), types.TransactionIDsToHashes(block.TxIDs))
-	assert.ErrorIs(t, th.HandleSyncedBlock(context.TODO(), data), errUnknown)
+	peer := p2p.Peer("buddy")
+	th.mockFetcher.EXPECT().RegisterPeerHashes(peer, types.TransactionIDsToHashes(block.TxIDs))
+	assert.ErrorIs(t, th.HandleSyncedBlock(context.TODO(), peer, data), errUnknown)
 }
 
 func Test_HandleBlockData_FailedToAddBlock(t *testing.T) {
@@ -95,8 +97,9 @@ func Test_HandleBlockData_FailedToAddBlock(t *testing.T) {
 	th.mockFetcher.EXPECT().GetBlockTxs(gomock.Any(), txIDs).Return(nil).Times(1)
 	errUnknown := errors.New("unknown")
 	th.mockMesh.EXPECT().AddBlockWithTXs(gomock.Any(), block).Return(errUnknown).Times(1)
-	th.mockFetcher.EXPECT().AddPeersFromHash(block.ID().AsHash32(), types.TransactionIDsToHashes(block.TxIDs))
-	assert.ErrorIs(t, th.HandleSyncedBlock(context.TODO(), data), errUnknown)
+	peer := p2p.Peer("buddy")
+	th.mockFetcher.EXPECT().RegisterPeerHashes(peer, types.TransactionIDsToHashes(block.TxIDs))
+	assert.ErrorIs(t, th.HandleSyncedBlock(context.TODO(), peer, data), errUnknown)
 }
 
 func Test_HandleBlockData(t *testing.T) {
@@ -107,8 +110,9 @@ func Test_HandleBlockData(t *testing.T) {
 	block, data := createBlockData(t, layerID, txIDs)
 	th.mockFetcher.EXPECT().GetBlockTxs(gomock.Any(), txIDs).Return(nil).Times(1)
 	th.mockMesh.EXPECT().AddBlockWithTXs(gomock.Any(), block).Return(nil).Times(1)
-	th.mockFetcher.EXPECT().AddPeersFromHash(block.ID().AsHash32(), types.TransactionIDsToHashes(block.TxIDs))
-	assert.NoError(t, th.HandleSyncedBlock(context.TODO(), data))
+	peer := p2p.Peer("buddy")
+	th.mockFetcher.EXPECT().RegisterPeerHashes(peer, types.TransactionIDsToHashes(block.TxIDs))
+	assert.NoError(t, th.HandleSyncedBlock(context.TODO(), peer, data))
 }
 
 func max(i, j int) int {

--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -686,6 +686,7 @@ func (app *App) initServices(
 		postSetupMgr, clock, newSyncer, app.addLogger("atxBuilder", lg),
 		activation.WithContext(ctx),
 		activation.WithPoetConfig(poetCfg),
+		activation.WithPoetRetryInterval(app.Config.HARE.WakeupDelta),
 	)
 
 	malfeasanceHandler := malfeasance.NewHandler(

--- a/config/presets/fastnet.go
+++ b/config/presets/fastnet.go
@@ -72,7 +72,7 @@ func fastnet() config.Config {
 	conf.Beacon.VotingRoundDuration = 2 * time.Second
 	conf.Beacon.WeakCoinRoundDuration = 2 * time.Second
 	conf.Beacon.RoundsNumber = 4
-	conf.Beacon.BeaconSyncWeightUnits = 20
+	conf.Beacon.BeaconSyncWeightUnits = 10
 	conf.Beacon.VotesLimit = 100
 
 	return conf

--- a/fetch/cache.go
+++ b/fetch/cache.go
@@ -103,19 +103,3 @@ func (hpc *HashPeersCache) RegisterPeerHashes(peer p2p.Peer, hashes []types.Hash
 		hpc.Add(hash, peer)
 	}
 }
-
-// AddPeersFromHash adds peers from one hash to others.
-func (hpc *HashPeersCache) AddPeersFromHash(fromHash types.Hash32, toHashes []types.Hash32) {
-	hpc.mu.Lock()
-	defer hpc.mu.Unlock()
-
-	peers, exists := hpc.get(fromHash)
-	if !exists {
-		return
-	}
-	for peer := range peers {
-		for _, hash := range toHashes {
-			hpc.add(hash, peer)
-		}
-	}
-}

--- a/fetch/cache_test.go
+++ b/fetch/cache_test.go
@@ -124,31 +124,6 @@ func TestGetRandom(t *testing.T) {
 	})
 }
 
-func TestAddPeersFromHash(t *testing.T) {
-	t.Parallel()
-	t.Run("2Hash2Peers", func(t *testing.T) {
-		cache := NewHashPeersCache(10)
-		hash1 := types.RandomHash()
-		hash2 := types.RandomHash()
-		peer1 := p2p.Peer("test_peer_1")
-		peer2 := p2p.Peer("test_peer_2")
-		var wg sync.WaitGroup
-		wg.Add(2)
-		go func() {
-			defer wg.Done()
-			cache.Add(hash1, peer1)
-		}()
-		go func() {
-			defer wg.Done()
-			cache.Add(hash1, peer2)
-		}()
-		wg.Wait()
-		cache.AddPeersFromHash(hash1, []types.Hash32{hash2})
-		hash2Peers, _ := getCachedEntry(cache, hash2)
-		require.Equal(t, 2, len(hash2Peers))
-	})
-}
-
 func TestRegisterPeerHashes(t *testing.T) {
 	t.Parallel()
 	t.Run("1Hash2Peers", func(t *testing.T) {
@@ -168,66 +143,28 @@ func TestRegisterPeerHashes(t *testing.T) {
 }
 
 func TestRace(t *testing.T) {
-	t.Parallel()
-	t.Run("AddAndGetRandom", func(t *testing.T) {
-		cache := NewHashPeersCache(10)
-		hash := types.RandomHash()
-		peer1 := p2p.Peer("test_peer_1")
-		peer2 := p2p.Peer("test_peer_2")
-		rng := rand.New(rand.NewSource(time.Now().UnixNano()))
-		var wg sync.WaitGroup
-		wg.Add(4)
-		go func() {
-			defer wg.Done()
-			cache.Add(hash, peer1)
-		}()
-		go func() {
-			defer wg.Done()
-			cache.GetRandom(hash, datastore.TXDB, rng)
-		}()
-		go func() {
-			defer wg.Done()
-			cache.Add(hash, peer2)
-		}()
-		go func() {
-			defer wg.Done()
-			cache.GetRandom(hash, datastore.TXDB, rng)
-		}()
-		wg.Wait()
-	})
-	t.Run("AddPeersFromHashAndGetRandom", func(t *testing.T) {
-		cache := NewHashPeersCache(10)
-		hash1 := types.RandomHash()
-		hash2 := types.RandomHash()
-		peer1 := p2p.Peer("test_peer_1")
-		peer2 := p2p.Peer("test_peer_2")
-		peer3 := p2p.Peer("test_peer_3")
-		peer4 := p2p.Peer("test_peer_4")
-		cache.Add(hash1, peer1)
-		cache.Add(hash1, peer2)
-		rng := rand.New(rand.NewSource(time.Now().UnixNano()))
-		var wg sync.WaitGroup
-		wg.Add(5)
-		go func() {
-			defer wg.Done()
-			cache.AddPeersFromHash(hash1, []types.Hash32{hash2})
-		}()
-		go func() {
-			defer wg.Done()
-			cache.GetRandom(hash1, datastore.TXDB, rng)
-		}()
-		go func() {
-			defer wg.Done()
-			cache.Add(hash2, peer3)
-		}()
-		go func() {
-			defer wg.Done()
-			cache.GetRandom(hash2, datastore.TXDB, rng)
-		}()
-		go func() {
-			defer wg.Done()
-			cache.Add(hash2, peer4)
-		}()
-		wg.Wait()
-	})
+	cache := NewHashPeersCache(10)
+	hash := types.RandomHash()
+	peer1 := p2p.Peer("test_peer_1")
+	peer2 := p2p.Peer("test_peer_2")
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	var wg sync.WaitGroup
+	wg.Add(4)
+	go func() {
+		defer wg.Done()
+		cache.Add(hash, peer1)
+	}()
+	go func() {
+		defer wg.Done()
+		cache.GetRandom(hash, datastore.TXDB, rng)
+	}()
+	go func() {
+		defer wg.Done()
+		cache.Add(hash, peer2)
+	}()
+	go func() {
+		defer wg.Done()
+		cache.GetRandom(hash, datastore.TXDB, rng)
+	}()
+	wg.Wait()
 }

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -354,7 +354,7 @@ func (f *Fetch) receiveResponse(data []byte) {
 		rsp := resp
 		f.eg.Go(func() error {
 			// validation fetch data recursively. offload to another goroutine
-			f.hashValidationDone(rsp.Hash, req.validator(req.ctx, rsp.Data))
+			f.hashValidationDone(rsp.Hash, req.validator(req.ctx, batch.peer, rsp.Data))
 			return nil
 		})
 		delete(batchMap, resp.Hash)

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -631,11 +631,6 @@ func (f *Fetch) RegisterPeerHashes(peer p2p.Peer, hashes []types.Hash32) {
 	f.hashToPeers.RegisterPeerHashes(peer, hashes)
 }
 
-// AddPeersFromHash adds peers from one hash to others.
-func (f *Fetch) AddPeersFromHash(fromHash types.Hash32, toHashes []types.Hash32) {
-	f.hashToPeers.AddPeersFromHash(fromHash, toHashes)
-}
-
 func (f *Fetch) GetPeers() []p2p.Peer {
 	return f.host.GetPeers()
 }

--- a/fetch/fetch_test.go
+++ b/fetch/fetch_test.go
@@ -91,11 +91,11 @@ func createFetch(tb testing.TB) *testFetch {
 	return tf
 }
 
-func goodReceiver(context.Context, []byte) error {
+func goodReceiver(context.Context, p2p.Peer, []byte) error {
 	return nil
 }
 
-func badReceiver(context.Context, []byte) error {
+func badReceiver(context.Context, p2p.Peer, []byte) error {
 	return errors.New("bad receiver")
 }
 

--- a/fetch/interface.go
+++ b/fetch/interface.go
@@ -14,32 +14,32 @@ type requester interface {
 }
 
 type malfeasanceHandler interface {
-	HandleSyncedMalfeasanceProof(context.Context, []byte) error
+	HandleSyncedMalfeasanceProof(context.Context, p2p.Peer, []byte) error
 }
 
 type atxHandler interface {
-	HandleAtxData(context.Context, []byte) error
+	HandleAtxData(context.Context, p2p.Peer, []byte) error
 }
 
 type blockHandler interface {
-	HandleSyncedBlock(context.Context, []byte) error
+	HandleSyncedBlock(context.Context, p2p.Peer, []byte) error
 }
 
 type ballotHandler interface {
-	HandleSyncedBallot(context.Context, []byte) error
+	HandleSyncedBallot(context.Context, p2p.Peer, []byte) error
 }
 
 type proposalHandler interface {
-	HandleSyncedProposal(context.Context, []byte) error
+	HandleSyncedProposal(context.Context, p2p.Peer, []byte) error
 }
 
 type txHandler interface {
-	HandleBlockTransaction(context.Context, []byte) error
-	HandleProposalTransaction(context.Context, []byte) error
+	HandleBlockTransaction(context.Context, p2p.Peer, []byte) error
+	HandleProposalTransaction(context.Context, p2p.Peer, []byte) error
 }
 
 type poetHandler interface {
-	ValidateAndStoreMsg(context.Context, []byte) error
+	ValidateAndStoreMsg(context.Context, p2p.Peer, []byte) error
 }
 
 type meshProvider interface {

--- a/fetch/mesh_data.go
+++ b/fetch/mesh_data.go
@@ -27,7 +27,7 @@ func (f *Fetch) GetAtxs(ctx context.Context, ids []types.ATXID) error {
 	return f.getHashes(ctx, hashes, datastore.ATXDB, f.atxHandler.HandleAtxData)
 }
 
-type dataReceiver func(context.Context, []byte) error
+type dataReceiver func(context.Context, p2p.Peer, []byte) error
 
 func (f *Fetch) getHashes(ctx context.Context, hashes []types.Hash32, hint datastore.Hint, receiver dataReceiver) error {
 	var eg multierror.Group

--- a/fetch/mocks/mocks.go
+++ b/fetch/mocks/mocks.go
@@ -74,17 +74,17 @@ func (m *MockmalfeasanceHandler) EXPECT() *MockmalfeasanceHandlerMockRecorder {
 }
 
 // HandleSyncedMalfeasanceProof mocks base method.
-func (m *MockmalfeasanceHandler) HandleSyncedMalfeasanceProof(arg0 context.Context, arg1 []byte) error {
+func (m *MockmalfeasanceHandler) HandleSyncedMalfeasanceProof(arg0 context.Context, arg1 p2p.Peer, arg2 []byte) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HandleSyncedMalfeasanceProof", arg0, arg1)
+	ret := m.ctrl.Call(m, "HandleSyncedMalfeasanceProof", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // HandleSyncedMalfeasanceProof indicates an expected call of HandleSyncedMalfeasanceProof.
-func (mr *MockmalfeasanceHandlerMockRecorder) HandleSyncedMalfeasanceProof(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockmalfeasanceHandlerMockRecorder) HandleSyncedMalfeasanceProof(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleSyncedMalfeasanceProof", reflect.TypeOf((*MockmalfeasanceHandler)(nil).HandleSyncedMalfeasanceProof), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleSyncedMalfeasanceProof", reflect.TypeOf((*MockmalfeasanceHandler)(nil).HandleSyncedMalfeasanceProof), arg0, arg1, arg2)
 }
 
 // MockatxHandler is a mock of atxHandler interface.
@@ -111,17 +111,17 @@ func (m *MockatxHandler) EXPECT() *MockatxHandlerMockRecorder {
 }
 
 // HandleAtxData mocks base method.
-func (m *MockatxHandler) HandleAtxData(arg0 context.Context, arg1 []byte) error {
+func (m *MockatxHandler) HandleAtxData(arg0 context.Context, arg1 p2p.Peer, arg2 []byte) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HandleAtxData", arg0, arg1)
+	ret := m.ctrl.Call(m, "HandleAtxData", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // HandleAtxData indicates an expected call of HandleAtxData.
-func (mr *MockatxHandlerMockRecorder) HandleAtxData(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockatxHandlerMockRecorder) HandleAtxData(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleAtxData", reflect.TypeOf((*MockatxHandler)(nil).HandleAtxData), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleAtxData", reflect.TypeOf((*MockatxHandler)(nil).HandleAtxData), arg0, arg1, arg2)
 }
 
 // MockblockHandler is a mock of blockHandler interface.
@@ -148,17 +148,17 @@ func (m *MockblockHandler) EXPECT() *MockblockHandlerMockRecorder {
 }
 
 // HandleSyncedBlock mocks base method.
-func (m *MockblockHandler) HandleSyncedBlock(arg0 context.Context, arg1 []byte) error {
+func (m *MockblockHandler) HandleSyncedBlock(arg0 context.Context, arg1 p2p.Peer, arg2 []byte) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HandleSyncedBlock", arg0, arg1)
+	ret := m.ctrl.Call(m, "HandleSyncedBlock", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // HandleSyncedBlock indicates an expected call of HandleSyncedBlock.
-func (mr *MockblockHandlerMockRecorder) HandleSyncedBlock(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockblockHandlerMockRecorder) HandleSyncedBlock(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleSyncedBlock", reflect.TypeOf((*MockblockHandler)(nil).HandleSyncedBlock), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleSyncedBlock", reflect.TypeOf((*MockblockHandler)(nil).HandleSyncedBlock), arg0, arg1, arg2)
 }
 
 // MockballotHandler is a mock of ballotHandler interface.
@@ -185,17 +185,17 @@ func (m *MockballotHandler) EXPECT() *MockballotHandlerMockRecorder {
 }
 
 // HandleSyncedBallot mocks base method.
-func (m *MockballotHandler) HandleSyncedBallot(arg0 context.Context, arg1 []byte) error {
+func (m *MockballotHandler) HandleSyncedBallot(arg0 context.Context, arg1 p2p.Peer, arg2 []byte) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HandleSyncedBallot", arg0, arg1)
+	ret := m.ctrl.Call(m, "HandleSyncedBallot", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // HandleSyncedBallot indicates an expected call of HandleSyncedBallot.
-func (mr *MockballotHandlerMockRecorder) HandleSyncedBallot(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockballotHandlerMockRecorder) HandleSyncedBallot(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleSyncedBallot", reflect.TypeOf((*MockballotHandler)(nil).HandleSyncedBallot), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleSyncedBallot", reflect.TypeOf((*MockballotHandler)(nil).HandleSyncedBallot), arg0, arg1, arg2)
 }
 
 // MockproposalHandler is a mock of proposalHandler interface.
@@ -222,17 +222,17 @@ func (m *MockproposalHandler) EXPECT() *MockproposalHandlerMockRecorder {
 }
 
 // HandleSyncedProposal mocks base method.
-func (m *MockproposalHandler) HandleSyncedProposal(arg0 context.Context, arg1 []byte) error {
+func (m *MockproposalHandler) HandleSyncedProposal(arg0 context.Context, arg1 p2p.Peer, arg2 []byte) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HandleSyncedProposal", arg0, arg1)
+	ret := m.ctrl.Call(m, "HandleSyncedProposal", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // HandleSyncedProposal indicates an expected call of HandleSyncedProposal.
-func (mr *MockproposalHandlerMockRecorder) HandleSyncedProposal(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockproposalHandlerMockRecorder) HandleSyncedProposal(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleSyncedProposal", reflect.TypeOf((*MockproposalHandler)(nil).HandleSyncedProposal), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleSyncedProposal", reflect.TypeOf((*MockproposalHandler)(nil).HandleSyncedProposal), arg0, arg1, arg2)
 }
 
 // MocktxHandler is a mock of txHandler interface.
@@ -259,31 +259,31 @@ func (m *MocktxHandler) EXPECT() *MocktxHandlerMockRecorder {
 }
 
 // HandleBlockTransaction mocks base method.
-func (m *MocktxHandler) HandleBlockTransaction(arg0 context.Context, arg1 []byte) error {
+func (m *MocktxHandler) HandleBlockTransaction(arg0 context.Context, arg1 p2p.Peer, arg2 []byte) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HandleBlockTransaction", arg0, arg1)
+	ret := m.ctrl.Call(m, "HandleBlockTransaction", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // HandleBlockTransaction indicates an expected call of HandleBlockTransaction.
-func (mr *MocktxHandlerMockRecorder) HandleBlockTransaction(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MocktxHandlerMockRecorder) HandleBlockTransaction(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleBlockTransaction", reflect.TypeOf((*MocktxHandler)(nil).HandleBlockTransaction), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleBlockTransaction", reflect.TypeOf((*MocktxHandler)(nil).HandleBlockTransaction), arg0, arg1, arg2)
 }
 
 // HandleProposalTransaction mocks base method.
-func (m *MocktxHandler) HandleProposalTransaction(arg0 context.Context, arg1 []byte) error {
+func (m *MocktxHandler) HandleProposalTransaction(arg0 context.Context, arg1 p2p.Peer, arg2 []byte) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HandleProposalTransaction", arg0, arg1)
+	ret := m.ctrl.Call(m, "HandleProposalTransaction", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // HandleProposalTransaction indicates an expected call of HandleProposalTransaction.
-func (mr *MocktxHandlerMockRecorder) HandleProposalTransaction(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MocktxHandlerMockRecorder) HandleProposalTransaction(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleProposalTransaction", reflect.TypeOf((*MocktxHandler)(nil).HandleProposalTransaction), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleProposalTransaction", reflect.TypeOf((*MocktxHandler)(nil).HandleProposalTransaction), arg0, arg1, arg2)
 }
 
 // MockpoetHandler is a mock of poetHandler interface.
@@ -310,17 +310,17 @@ func (m *MockpoetHandler) EXPECT() *MockpoetHandlerMockRecorder {
 }
 
 // ValidateAndStoreMsg mocks base method.
-func (m *MockpoetHandler) ValidateAndStoreMsg(arg0 context.Context, arg1 []byte) error {
+func (m *MockpoetHandler) ValidateAndStoreMsg(arg0 context.Context, arg1 p2p.Peer, arg2 []byte) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ValidateAndStoreMsg", arg0, arg1)
+	ret := m.ctrl.Call(m, "ValidateAndStoreMsg", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ValidateAndStoreMsg indicates an expected call of ValidateAndStoreMsg.
-func (mr *MockpoetHandlerMockRecorder) ValidateAndStoreMsg(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockpoetHandlerMockRecorder) ValidateAndStoreMsg(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateAndStoreMsg", reflect.TypeOf((*MockpoetHandler)(nil).ValidateAndStoreMsg), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateAndStoreMsg", reflect.TypeOf((*MockpoetHandler)(nil).ValidateAndStoreMsg), arg0, arg1, arg2)
 }
 
 // MockmeshProvider is a mock of meshProvider interface.

--- a/hare/hare.go
+++ b/hare/hare.go
@@ -324,13 +324,6 @@ func (h *Hare) onTick(ctx context.Context, lid types.LayerID) (bool, error) {
 		return false, nil
 	}
 
-	var err error
-	beacon, err := h.beacons.GetBeacon(lid.GetEpoch())
-	if err != nil {
-		logger.Info("not starting hare: beacon not retrieved")
-		return false, nil
-	}
-
 	// call to start the calculation of active set size beforehand
 	h.eg.Go(func() error {
 		// this is called only for its side effects, but at least print the error if it returns one
@@ -354,6 +347,13 @@ func (h *Hare) onTick(ctx context.Context, lid types.LayerID) (bool, error) {
 	if !h.broker.Synced(ctx, lid) {
 		// if not currently synced don't start consensus process
 		logger.Info("not starting hare: node not synced at this layer")
+		return false, nil
+	}
+
+	var err error
+	beacon, err := h.beacons.GetBeacon(lid.GetEpoch())
+	if err != nil {
+		logger.Info("not starting hare: beacon not retrieved")
 		return false, nil
 	}
 

--- a/hare/hare_test.go
+++ b/hare/hare_test.go
@@ -549,6 +549,7 @@ func TestHare_onTick_NoBeacon(t *testing.T) {
 	lyr := types.NewLayerID(199)
 
 	h := createTestHare(t, sql.InMemory(), config.DefaultConfig(), newMockClock(), noopPubSub(t), t.Name())
+	h.mockRoracle.EXPECT().IsIdentityActiveOnConsensusView(gomock.Any(), gomock.Any(), lyr).Return(true, nil).Times(1)
 	mockBeacons := smocks.NewMockBeaconGetter(gomock.NewController(t))
 	h.beacons = mockBeacons
 	mockBeacons.EXPECT().GetBeacon(lyr.GetEpoch()).Return(types.EmptyBeacon, errors.New("whatever")).Times(1)

--- a/hare/hare_test.go
+++ b/hare/hare_test.go
@@ -549,7 +549,7 @@ func TestHare_onTick_NoBeacon(t *testing.T) {
 	lyr := types.NewLayerID(199)
 
 	h := createTestHare(t, sql.InMemory(), config.DefaultConfig(), newMockClock(), noopPubSub(t), t.Name())
-	h.mockRoracle.EXPECT().IsIdentityActiveOnConsensusView(gomock.Any(), gomock.Any(), lyr).Return(true, nil).Times(1)
+	h.mockRoracle.EXPECT().IsIdentityActiveOnConsensusView(gomock.Any(), gomock.Any(), lyr).Return(true, nil).MaxTimes(1)
 	mockBeacons := smocks.NewMockBeaconGetter(gomock.NewController(t))
 	h.beacons = mockBeacons
 	mockBeacons.EXPECT().GetBeacon(lyr.GetEpoch()).Return(types.EmptyBeacon, errors.New("whatever")).Times(1)

--- a/hare/haretypes.go
+++ b/hare/haretypes.go
@@ -204,7 +204,7 @@ func (s *Set) String() string {
 	defer s.mu.RUnlock()
 
 	var sb strings.Builder
-	idx := len(s.values) - 1
+	idx := len(s.values)
 	for v := range s.values {
 		idx--
 		sb.WriteString(v.String())

--- a/malfeasance/handler.go
+++ b/malfeasance/handler.go
@@ -54,8 +54,8 @@ func (h *Handler) HandleMalfeasanceProof(ctx context.Context, peer p2p.Peer, msg
 	}
 }
 
-func (h *Handler) HandleSyncedMalfeasanceProof(ctx context.Context, msg []byte) error {
-	return h.handleProof(ctx, "", msg)
+func (h *Handler) HandleSyncedMalfeasanceProof(ctx context.Context, peer p2p.Peer, msg []byte) error {
+	return h.handleProof(ctx, peer, msg)
 }
 
 func (h *Handler) handleProof(ctx context.Context, peer p2p.Peer, data []byte) error {

--- a/syncer/state_syncer.go
+++ b/syncer/state_syncer.go
@@ -34,6 +34,9 @@ func (s *Syncer) stateSynced() bool {
 
 func (s *Syncer) processLayers(ctx context.Context) error {
 	ctx = log.WithNewSessionID(ctx)
+	if !s.ticker.GetCurrentLayer().After(types.GetEffectiveGenesis()) {
+		return nil
+	}
 	if !s.ListenToATXGossip() {
 		return errATXsNotSynced
 	}

--- a/syncer/state_syncer.go
+++ b/syncer/state_syncer.go
@@ -34,7 +34,7 @@ func (s *Syncer) stateSynced() bool {
 
 func (s *Syncer) processLayers(ctx context.Context) error {
 	ctx = log.WithNewSessionID(ctx)
-	if !s.ticker.GetCurrentLayer().After(types.GetEffectiveGenesis()) {
+	if !s.ticker.CurrentLayer().After(types.GetEffectiveGenesis()) {
 		return nil
 	}
 	if !s.ListenToATXGossip() {

--- a/system/fetcher.go
+++ b/system/fetcher.go
@@ -54,5 +54,4 @@ type ProposalFetcher interface {
 // PeerTracker defines an interface to track peer hashes.
 type PeerTracker interface {
 	RegisterPeerHashes(peer p2p.Peer, hashes []types.Hash32)
-	AddPeersFromHash(types.Hash32, []types.Hash32)
 }

--- a/system/mocks/fetcher.go
+++ b/system/mocks/fetcher.go
@@ -36,18 +36,6 @@ func (m *MockFetcher) EXPECT() *MockFetcherMockRecorder {
 	return m.recorder
 }
 
-// AddPeersFromHash mocks base method.
-func (m *MockFetcher) AddPeersFromHash(arg0 types.Hash32, arg1 []types.Hash32) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "AddPeersFromHash", arg0, arg1)
-}
-
-// AddPeersFromHash indicates an expected call of AddPeersFromHash.
-func (mr *MockFetcherMockRecorder) AddPeersFromHash(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddPeersFromHash", reflect.TypeOf((*MockFetcher)(nil).AddPeersFromHash), arg0, arg1)
-}
-
 // GetAtxs mocks base method.
 func (m *MockFetcher) GetAtxs(arg0 context.Context, arg1 []types.ATXID) error {
 	m.ctrl.T.Helper()
@@ -415,18 +403,6 @@ func NewMockPeerTracker(ctrl *gomock.Controller) *MockPeerTracker {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockPeerTracker) EXPECT() *MockPeerTrackerMockRecorder {
 	return m.recorder
-}
-
-// AddPeersFromHash mocks base method.
-func (m *MockPeerTracker) AddPeersFromHash(arg0 types.Hash32, arg1 []types.Hash32) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "AddPeersFromHash", arg0, arg1)
-}
-
-// AddPeersFromHash indicates an expected call of AddPeersFromHash.
-func (mr *MockPeerTrackerMockRecorder) AddPeersFromHash(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddPeersFromHash", reflect.TypeOf((*MockPeerTracker)(nil).AddPeersFromHash), arg0, arg1)
 }
 
 // RegisterPeerHashes mocks base method.

--- a/systest/cluster/cluster.go
+++ b/systest/cluster/cluster.go
@@ -338,6 +338,7 @@ func (c *Cluster) AddBootnodes(cctx *testcontext.Context, n int) error {
 	for _, flag := range c.smesherFlags {
 		flags = append(flags, flag)
 	}
+	flags = append(flags, StartSmeshing(false))
 	clients, err := deployNodes(cctx, bootnodesPrefix, c.bootnodes, c.bootnodes+n, flags)
 	if err != nil {
 		return err
@@ -367,6 +368,7 @@ func (c *Cluster) AddSmeshers(tctx *testcontext.Context, n int) error {
 		return fmt.Errorf("extracing p2p endpoints %w", err)
 	}
 	flags = append(flags, Bootnodes(endpoints...))
+	flags = append(flags, StartSmeshing(true))
 	clients, err := deployNodes(tctx, smesherPrefix, c.nextSmesher(), c.nextSmesher()+n, flags)
 	if err != nil {
 		return err

--- a/systest/cluster/nodes.go
+++ b/systest/cluster/nodes.go
@@ -390,7 +390,6 @@ func deployNode(ctx *testcontext.Context, name string, labels map[string]string,
 		"/bin/go-spacemesh",
 		"-c=" + configDir + attachedSmesherConfig,
 		"--pprof-server",
-		"--smeshing-start=true",
 		"--smeshing-opts-datadir=/data/post",
 		"-d=/data/state",
 		"--log-encoder=json",
@@ -602,4 +601,8 @@ func DurationFlag(flag string, d time.Duration) DeploymentFlag {
 // PoetRestListen socket pair with http api.
 func PoetRestListen(port int) DeploymentFlag {
 	return DeploymentFlag{Name: "--restlisten", Value: fmt.Sprintf("0.0.0.0:%d", port)}
+}
+
+func StartSmeshing(start bool) DeploymentFlag {
+	return DeploymentFlag{Name: "--smeshing-start", Value: fmt.Sprintf("%v", start)}
 }

--- a/systest/tests/common.go
+++ b/systest/tests/common.go
@@ -37,7 +37,7 @@ func sendTransactions(ctx context.Context, eg *errgroup.Group, logger *zap.Sugar
 			if layer.Layer.Number.Number == stop {
 				return false, nil
 			}
-			if layer.Layer.Status != pb.Layer_LAYER_STATUS_APPLIED ||
+			if layer.Layer.Status != pb.Layer_LAYER_STATUS_APPROVED ||
 				layer.Layer.Number.Number < first {
 				return true, nil
 			}

--- a/systest/tests/common.go
+++ b/systest/tests/common.go
@@ -28,12 +28,8 @@ const (
 	layersPerEpoch = 4
 )
 
-func sendTransactions(ctx context.Context, eg *errgroup.Group, logger *zap.SugaredLogger, cl *cluster.Cluster, first, stop uint32) {
-	var (
-		receiver = types.GenerateAddress([]byte{11, 1, 1})
-		amount   = 100
-		batch    = 10
-	)
+func sendTransactions(ctx context.Context, eg *errgroup.Group, logger *zap.SugaredLogger, cl *cluster.Cluster, first, stop uint32, batch, amount int) {
+	receiver := types.GenerateAddress([]byte{11, 1, 1})
 	for i := 0; i < cl.Accounts(); i++ {
 		i := i
 		client := cl.Client(i % cl.Total())
@@ -41,7 +37,7 @@ func sendTransactions(ctx context.Context, eg *errgroup.Group, logger *zap.Sugar
 			if layer.Layer.Number.Number == stop {
 				return false, nil
 			}
-			if layer.Layer.Status != pb.Layer_LAYER_STATUS_APPROVED ||
+			if layer.Layer.Status != pb.Layer_LAYER_STATUS_APPLIED ||
 				layer.Layer.Number.Number < first {
 				return true, nil
 			}

--- a/systest/tests/nodes_test.go
+++ b/systest/tests/nodes_test.go
@@ -89,8 +89,9 @@ func TestAddNodes(t *testing.T) {
 			unique[proposal.Epoch.Value][prettyHex(proposal.Smesher.Id)] = struct{}{}
 		}
 	}
+	smeshers := cl.Total() - cl.Bootnodes()
 	for epoch := uint64(4); epoch <= epochBeforeJoin; epoch++ {
-		require.GreaterOrEqual(t, len(unique[epoch]), cl.Total()-addedLater, "epoch=%d", epoch)
+		require.GreaterOrEqual(t, len(unique[epoch]), smeshers-addedLater, "epoch=%d", epoch)
 	}
 	// condition is so that test waits until the first epoch where all smeshers participated.
 	// and if it finds such epoch, starting from that epoch all smeshers should consistently
@@ -98,11 +99,11 @@ func TestAddNodes(t *testing.T) {
 	// test should fail if such epoch wasn't found.
 	var joined uint64
 	for epoch := uint64(epochBeforeJoin) + 1; epoch <= lastEpoch; epoch++ {
-		if len(unique[epoch]) == cl.Total() {
+		if len(unique[epoch]) == smeshers {
 			joined = epoch
 		}
 		if joined != 0 && epoch >= joined {
-			require.Len(t, unique[epoch], cl.Total(), "epoch=%d", epoch)
+			require.Len(t, unique[epoch], smeshers, "epoch=%d", epoch)
 		}
 	}
 	require.NotEmpty(t, joined, "nodes weren't able to join the cluster")

--- a/systest/tests/partition_test.go
+++ b/systest/tests/partition_test.go
@@ -56,7 +56,7 @@ func testPartition(t *testing.T, tctx *testcontext.Context, cl *cluster.Cluster,
 	// start sending transactions
 	tctx.Log.Debug("sending transactions...")
 	eg2, ctx2 := errgroup.WithContext(tctx)
-	sendTransactions(ctx2, eg2, nil, cl, first, stop)
+	sendTransactions(ctx2, eg2, nil, cl, first, stop, 10, 100)
 
 	type stateUpdate struct {
 		layer  uint32

--- a/systest/tests/poets_test.go
+++ b/systest/tests/poets_test.go
@@ -77,9 +77,7 @@ func testPoetDies(t *testing.T, tctx *testcontext.Context, cl *cluster.Cluster) 
 			tctx.Log.Debug("Poet killer is done")
 			return false, nil
 		}
-		if layer.Layer.GetStatus() != pb.Layer_LAYER_STATUS_APPLIED {
-			return true, nil
-		}
+
 		// don't kill a poet if this is not ~middle of epoch
 		if ((layer.Layer.GetNumber().GetNumber() + layersPerEpoch/2) % layersPerEpoch) != 0 {
 			return true, nil
@@ -193,7 +191,7 @@ func TestNodesUsingDifferentPoets(t *testing.T) {
 	}
 
 	firstEpochWithEligibility := uint32(math.Max(2.0, float64(first/layersPerEpoch)))
-	epochsInTest := (last/layersPerEpoch - firstEpochWithEligibility + 1)
+	epochsInTest := last/layersPerEpoch - firstEpochWithEligibility + 1
 	for id, eligibleEpochs := range smeshers {
 		assert.EqualValues(t, epochsInTest, len(eligibleEpochs), fmt.Sprintf("smesher ID: %v, its epochs: %v", hex.EncodeToString([]byte(id)), eligibleEpochs))
 	}

--- a/systest/tests/poets_test.go
+++ b/systest/tests/poets_test.go
@@ -77,7 +77,9 @@ func testPoetDies(t *testing.T, tctx *testcontext.Context, cl *cluster.Cluster) 
 			tctx.Log.Debug("Poet killer is done")
 			return false, nil
 		}
-
+		if layer.Layer.GetStatus() != pb.Layer_LAYER_STATUS_APPLIED {
+			return true, nil
+		}
 		// don't kill a poet if this is not ~middle of epoch
 		if ((layer.Layer.GetNumber().GetNumber() + layersPerEpoch/2) % layersPerEpoch) != 0 {
 			return true, nil

--- a/systest/tests/smeshing_test.go
+++ b/systest/tests/smeshing_test.go
@@ -93,7 +93,7 @@ func testSmeshing(t *testing.T, tctx *testcontext.Context, cl *cluster.Cluster) 
 		}
 	}
 	requireEqualEligibilities(tctx, t, created)
-	requireEqualProposals(t, created, includedAll, cl.Bootnodes())
+	requireEqualProposals(t, created, includedAll)
 	for epoch := range beacons {
 		require.Len(t, beacons[epoch], 1, "epoch=%d", epoch)
 	}
@@ -101,7 +101,7 @@ func testSmeshing(t *testing.T, tctx *testcontext.Context, cl *cluster.Cluster) 
 	require.Len(t, beaconSet, len(beacons), "beacons=%v", beaconSet)
 }
 
-func requireEqualProposals(tb testing.TB, reference map[uint32][]*pb.Proposal, received []map[uint32][]*pb.Proposal, numBootnodes int) {
+func requireEqualProposals(tb testing.TB, reference map[uint32][]*pb.Proposal, received []map[uint32][]*pb.Proposal) {
 	tb.Helper()
 	for layer := range reference {
 		sort.Slice(reference[layer], func(i, j int) bool {
@@ -115,14 +115,9 @@ func requireEqualProposals(tb testing.TB, reference map[uint32][]*pb.Proposal, r
 			})
 		}
 		for layer, proposals := range reference {
-			if i < numBootnodes && layer%layersPerEpoch == 0 {
-				// bootnodes don't mine and rely on beacon sync. they don't participate in hare in the first layer of each epoch
-				require.LessOrEqual(tb, len(included[layer]), len(proposals), "client=%d layer=%d", i, layer)
-			} else {
-				require.Len(tb, included[layer], len(proposals), "client=%d layer=%d", i, layer)
-				for j := range proposals {
-					assert.Equal(tb, proposals[j].Id, included[layer][j].Id, "client=%d layer=%d", i, layer)
-				}
+			require.Len(tb, included[layer], len(proposals), "client=%d layer=%d", i, layer)
+			for j := range proposals {
+				assert.Equal(tb, proposals[j].Id, included[layer][j].Id, "client=%d layer=%d", i, layer)
 			}
 		}
 	}

--- a/systest/tests/transactions_test.go
+++ b/systest/tests/transactions_test.go
@@ -40,7 +40,7 @@ func testTransactions(t *testing.T, tctx *testcontext.Context, cl *cluster.Clust
 	before := response.AccountWrapper.StateCurrent.Balance
 
 	eg, ctx := errgroup.WithContext(tctx)
-	sendTransactions(ctx, eg, tctx.Log, cl, first, stopSending)
+	sendTransactions(ctx, eg, tctx.Log, cl, first, stopSending, batch, amount)
 	txs := make([][]*pb.Transaction, cl.Total())
 
 	for i := 0; i < cl.Total(); i++ {

--- a/txs/conservative_state_test.go
+++ b/txs/conservative_state_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/genvm/sdk/wallet"
 	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/log/logtest"
+	"github.com/spacemeshos/go-spacemesh/p2p"
 	"github.com/spacemeshos/go-spacemesh/p2p/pubsub"
 	"github.com/spacemeshos/go-spacemesh/signing"
 	"github.com/spacemeshos/go-spacemesh/sql"
@@ -555,7 +556,7 @@ func TestConsistentHandling(t *testing.T) {
 			instances[1].mvm.EXPECT().Validation(txs[i].RawTx).Times(1).Return(failed)
 
 			require.Equal(t, pubsub.ValidationAccept, instances[0].handler().HandleGossipTransaction(context.Background(), "", txs[i].Raw))
-			require.NoError(t, instances[1].handler().HandleBlockTransaction(context.Background(), txs[i].Raw))
+			require.NoError(t, instances[1].handler().HandleBlockTransaction(context.Background(), p2p.NoPeer, txs[i].Raw))
 		}
 		block := types.NewExistingBlock(types.BlockID{byte(lid)},
 			types.InnerBlock{

--- a/txs/handler.go
+++ b/txs/handler.go
@@ -63,7 +63,7 @@ func (th *TxHandler) HandleGossipTransaction(ctx context.Context, _ p2p.Peer, ms
 }
 
 // HandleProposalTransaction handles data received on the transactions synced as a part of proposal.
-func (th *TxHandler) HandleProposalTransaction(ctx context.Context, msg []byte) error {
+func (th *TxHandler) HandleProposalTransaction(ctx context.Context, _ p2p.Peer, msg []byte) error {
 	err := th.handleTransaction(ctx, msg)
 	defer updateMetrics(err, proposalTxCount)
 	if err == nil || errors.Is(err, errDuplicateTX) {
@@ -103,7 +103,7 @@ func (th *TxHandler) handleTransaction(ctx context.Context, msg []byte) error {
 }
 
 // HandleBlockTransaction handles transactions received as a reference to a block.
-func (th *TxHandler) HandleBlockTransaction(ctx context.Context, data []byte) error {
+func (th *TxHandler) HandleBlockTransaction(_ context.Context, _ p2p.Peer, data []byte) error {
 	raw := types.NewRawTx(data)
 	exists, err := th.state.HasTx(raw.ID)
 	if err != nil {

--- a/txs/handler_test.go
+++ b/txs/handler_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/log/logtest"
+	"github.com/spacemeshos/go-spacemesh/p2p"
 	"github.com/spacemeshos/go-spacemesh/p2p/pubsub"
 	"github.com/spacemeshos/go-spacemesh/signing"
 	smocks "github.com/spacemeshos/go-spacemesh/system/mocks"
@@ -75,7 +76,7 @@ func Test_HandleBlock(t *testing.T) {
 					cstate.EXPECT().AddToDB(&types.Transaction{RawTx: tx.RawTx}).Return(tc.addErr)
 				}
 			}
-			err = th.HandleBlockTransaction(context.Background(), tx.Raw)
+			err = th.HandleBlockTransaction(context.Background(), p2p.NoPeer, tx.Raw)
 			if tc.failed {
 				require.Error(t, err)
 			} else {
@@ -254,7 +255,7 @@ func Test_HandleProposal(t *testing.T) {
 				tc.hasErr, tc.parseErr, tc.addErr,
 				tc.has, tc.verify, tc.noheader,
 			)
-			err := th.HandleProposalTransaction(context.Background(), tx.Raw)
+			err := th.HandleProposalTransaction(context.Background(), p2p.NoPeer, tx.Raw)
 			if tc.fail {
 				require.Error(t, err)
 			} else {


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
Closes #4042 
<!-- `Closes #XXXX, closes #XXXX, ...` links mentioned issues to this PR and automatically closes them when this it's merged -->

## Changes
<!-- Please describe in detail the changes made -->
- beacon
  - allow non-smeshers to be passive participants in the beacon protocol
- tune some logs for non-smeshing nodes (error->info/no log)
- activation
  - after atx is published, wait for network propagation delta before building the next challenge.
- hare
  - add session id for the same consensus process for debugging
  - terminate hare right away when iteration limit is reached
  - check beacon after waking up from delta to improve chance of participating in hare
- fetch
  - register poet proof hash with the peer that gossiped the atx
- systests
  - set smeshing-start to false for boot nodes

debugging note:
partition tests became flaky with the change because now that bootnodes are not smeshing, they are not directly getting proof from poet servers and instead rely on peer fetching mechanism when the proof is referenced in the atx.
however, poet proof fetching was not optimized to fetch from source of the referencing atx. instead, it's fetching from the other sides of the partition (randomly) and failed. this happens in the first layer of the epoch after the partition starts.

