### PR TITLE
[Merged by Bors] - merge two stages of systests into one

### DIFF
--- a/.github/workflows/systest.yml
+++ b/.github/workflows/systest.yml
@@ -46,7 +46,7 @@ jobs:
     if: ${{ needs.filter-changes.outputs.nondocchanges == 'true' }}
     needs:
       - filter-changes
-    timeout-minutes: 90
+    timeout-minutes: 70
     concurrency:
       group: ${{ github.base_ref == 'staging' && format('{0}-staging', github.workflow) || format('{0}-{1}', github.workflow, github.ref) }}
       cancel-in-progress: ${{ github.base_ref == 'staging' && false || true }}
@@ -101,7 +101,7 @@ jobs:
           go-version: ${{ env.go-version }}
 
       - name: Run tests
-        timeout-minutes: 85
+        timeout-minutes: 60
         env:
           test_id: systest-${{ steps.vars.outputs.sha_short }}
           label: sanity

--- a/.github/workflows/systest.yml
+++ b/.github/workflows/systest.yml
@@ -108,7 +108,7 @@ jobs:
           storage: premium-rwo=10Gi
           node_selector: cloud.google.com/gke-nodepool=gha
           size: 50
-          bootstrap: 10m
+          bootstrap: 5m
           level: info
           clusters: 4
         run: make -C systest run test_name=.

--- a/.github/workflows/systest.yml
+++ b/.github/workflows/systest.yml
@@ -100,27 +100,14 @@ jobs:
         with:
           go-version: ${{ env.go-version }}
 
-      - name: Run tests I
-        timeout-minutes: 55
+      - name: Run tests
+        timeout-minutes: 80
         env:
           test_id: systest-${{ steps.vars.outputs.sha_short }}
           label: sanity
           storage: premium-rwo=10Gi
           node_selector: cloud.google.com/gke-nodepool=gha
           size: 50
-          bootstrap: 10m
-          level: info
-          clusters: 4
-        run: make -C systest run test_name=.
-
-      - name: Run tests II
-        timeout-minutes: 30
-        env:
-          test_id: systest-${{ steps.vars.outputs.sha_short }}
-          label: destructive
-          storage: premium-rwo=10Gi
-          node_selector: cloud.google.com/gke-nodepool=gha
-          size: 30
           bootstrap: 10m
           level: info
           clusters: 4

--- a/.github/workflows/systest.yml
+++ b/.github/workflows/systest.yml
@@ -101,14 +101,14 @@ jobs:
           go-version: ${{ env.go-version }}
 
       - name: Run tests
-        timeout-minutes: 80
+        timeout-minutes: 85
         env:
           test_id: systest-${{ steps.vars.outputs.sha_short }}
           label: sanity
           storage: premium-rwo=10Gi
           node_selector: cloud.google.com/gke-nodepool=gha
           size: 50
-          bootstrap: 5m
+          bootstrap: 10m
           level: info
           clusters: 4
         run: make -C systest run test_name=.

--- a/systest/tests/partition_test.go
+++ b/systest/tests/partition_test.go
@@ -167,7 +167,7 @@ func testPartition(t *testing.T, tctx *testcontext.Context, cl *cluster.Cluster,
 func TestPartition_30_70(t *testing.T) {
 	t.Parallel()
 
-	tctx := testcontext.New(t, testcontext.Labels("destructive"))
+	tctx := testcontext.New(t, testcontext.Labels("sanity"))
 	cl, err := cluster.Reuse(tctx, cluster.WithKeys(10))
 	require.NoError(t, err)
 	// TODO: re-assess the number of epoch required for healing.
@@ -177,7 +177,7 @@ func TestPartition_30_70(t *testing.T) {
 func TestPartition_50_50(t *testing.T) {
 	t.Parallel()
 
-	tctx := testcontext.New(t, testcontext.Labels("destructive"))
+	tctx := testcontext.New(t, testcontext.Labels("sanity"))
 	cl, err := cluster.Reuse(tctx, cluster.WithKeys(10))
 	require.NoError(t, err)
 	// TODO: re-assess the number of epoch required for healing.

--- a/systest/tests/partition_test.go
+++ b/systest/tests/partition_test.go
@@ -168,6 +168,10 @@ func TestPartition_30_70(t *testing.T) {
 	t.Parallel()
 
 	tctx := testcontext.New(t, testcontext.Labels("sanity"))
+	if tctx.ClusterSize > 30 {
+		tctx.Log.Info("cluster size changed to 30")
+		tctx.ClusterSize = 30
+	}
 	cl, err := cluster.Reuse(tctx, cluster.WithKeys(10))
 	require.NoError(t, err)
 	// TODO: re-assess the number of epoch required for healing.
@@ -178,6 +182,10 @@ func TestPartition_50_50(t *testing.T) {
 	t.Parallel()
 
 	tctx := testcontext.New(t, testcontext.Labels("sanity"))
+	if tctx.ClusterSize > 30 {
+		tctx.Log.Info("cluster size changed to 30")
+		tctx.ClusterSize = 30
+	}
 	cl, err := cluster.Reuse(tctx, cluster.WithKeys(10))
 	require.NoError(t, err)
 	// TODO: re-assess the number of epoch required for healing.

--- a/systest/tests/poets_test.go
+++ b/systest/tests/poets_test.go
@@ -121,6 +121,7 @@ func testPoetDies(t *testing.T, tctx *testcontext.Context, cl *cluster.Cluster) 
 }
 
 func TestNodesUsingDifferentPoets(t *testing.T) {
+	t.Parallel()
 	tctx := testcontext.New(t, testcontext.Labels("sanity"))
 	if tctx.PoetSize < 2 {
 		t.Skip("Skipping test for using different poets - test configured with less then 2 poets")


### PR DESCRIPTION
## Motivation
speed up CI

- make TestNodesUsingDifferentPoets parallel
- merge CI systest I and II 
- change systest timeout from 85 min combined to 60 min (avg run time finishes under 50 min)