### PR TITLE
[Merged by Bors] - Revert back version.txt to `v0.0.0-unreleased`

### DIFF
--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-v0.0.0-test-arm64
+v0.0.0-unreleased


### PR DESCRIPTION
Accidentally merged `v0.0.0-test-arm64` into develop: https://github.com/spacemeshos/go-spacemesh/pull/4036 😢 