### PR TITLE
[Merged by Bors] - README: Fix instructions to run go outside of make

### DIFF
--- a/Makefile-gpu.Inc
+++ b/Makefile-gpu.Inc
@@ -107,22 +107,10 @@ print-test-targets:
 	done
 .PHONY: $(SUBDIRS_ALL) $(SUBDIRS_LVL2) $(SUBDIRS_ONLY) print-test-targets
 
-go-env: get-gpu-setup
-	go env -w CGO_CFLAGS="$(CGO_CFLAGS)"
-	go env -w CGO_LDFLAGS="$(CGO_LDFLAGS)"
-.PHONY: go-env
-
-go-env-test: get-gpu-setup
-	go env -w CGO_CFLAGS="$(CGO_CFLAGS)"
-	go env -w CGO_LDFLAGS="$(CGO_TEST_LDFLAGS)"
-.PHONY: go-env-test
-
 print-env: get-gpu-setup
-	@echo CGO_CFLAGS="$(CGO_CFLAGS)"
-	@echo CGO_LDFLAGS="$(CGO_LDFLAGS)"
+	@echo CGO_CFLAGS="\"$(CGO_CFLAGS)\"" CGO_LDFLAGS="\"$(CGO_LDFLAGS)\""
 .PHONY: print-env
 
 print-test-env: get-gpu-setup
-	@echo CGO_CFLAGS="$(CGO_CFLAGS)"
-	@echo CGO_TEST_LDFLAGS="$(CGO_TEST_LDFLAGS)"
+	@echo CGO_CFLAGS="\"$(CGO_CFLAGS)\"" CGO_LDFLAGS="\"$(CGO_TEST_LDFLAGS)\""
 .PHONY: print-test-env

--- a/README.md
+++ b/README.md
@@ -121,18 +121,21 @@ the `build/*target*` directory.
 
 ### Using `go build` and `go test` without `make`
 
-To build code without using `make` the `CGO_LDFLAGS` environment variable must be set
-appropriately. The required value can be obtained by running `make print-ldflags` or
-`make print-test-ldflags`.
+To build or test code without using `make` some golang environment variables
+must be set appropriately.
 
-This can be done in 3 ways:
+The environment variables can be printed by running either `make print-env` or
+`make print-test-env`.
 
-1. Setting the variable in the shell environment (e.g., in bash run `CGO_LDFLAGS=$(make print-ldflags)`).
-2. Prefixing the key and value to the `go` command (e.g., `CGO_LDFLAGS=$(make print-ldflags) go build`).
-3. Using `go env -w CGO_LDFLAGS=$(make print-ldflags)`, which persistently adds this value to Go's
-   environment for any future runs.
+They can be set in 3 ways:
 
-There's a handy shortcut for the 3rd method: `make go-env` or `make go-env-test`.
+_Note: we need to use eval to interpret the commands since there are spaces in
+the values of the variables so the shell can't correctly split them as
+arguments._
+
+1. Setting the variables on the same line as the `go` command (e.g., `eval $(make print-env) go build`). This affects the environment for that command invocation only.
+2. Exporting the variables in the shell's environment (e.g., `eval export $(make print-env)`). The variables will persist for the duration of that shell (and will be passed to subshells).
+3. Setting the variables in the go environment (e.g., `eval go env -w $(make print-env)`). Persistently adds these values to Go's environment for any future runs.
 
 ---
 


### PR DESCRIPTION
## Motivation
The readme instructions were broken

## Changes
Readme instructions updated to be inline with the Makefile. Changed `print-env` and `print-test-env` to print the variable assignments on one line, this allows them to be easily incorporated into shell commands.

Since the print output could now easily be passed to `go env`, removed the `go-env` and `go-test-env` targets to reduce duplication.

I'm unsure whether i should make the same changes to `Makefile-svm.Inc`, since it already seemed to be somewhat out of sync with `Makefile-gpu.Inc`?

## Test Plan
Manually checked that the instructions in the readme work for building and testing.

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [ ] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
  - This changes the output format of some make commands and removes some make commands, so it could impact infrastructure config.
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
