### PR TITLE
[Merged by Bors] - fix malfeasance proof metrics and add logging

### DIFF
--- a/Makefile-gpu.Inc
+++ b/Makefile-gpu.Inc
@@ -73,6 +73,10 @@ $(BINDIR_GPU_SETUP_LIBS): $(PROJ_DIR)$(GPU_SETUP_ZIP)
 $(PROJ_DIR)$(GPU_SETUP_ZIP):
 	curl -L $(GPU_SETUP_URL_ZIP) -o $(PROJ_DIR)$(GPU_SETUP_ZIP)
 
+go-env-test: get-gpu-setup
+	go env -w CGO_LDFLAGS="$(CGO_TEST_LDFLAGS)"
+.PHONY: go-env-test
+
 get-gpu-setup: $(PROJ_DIR)$(GPU_SETUP_ZIP) $(BINDIR_GPU_SETUP_LIBS)
 .PHONY: get-gpu-setup
 

--- a/Makefile-svm.Inc
+++ b/Makefile-svm.Inc
@@ -62,10 +62,6 @@ go-env: get-gpu-setup
 	go env -w CGO_LDFLAGS="$(CGO_LDFLAGS)"
 .PHONY: go-env
 
-go-env-test: get-gpu-setup
-	go env -w CGO_LDFLAGS="$(CGO_TEST_LDFLAGS)"
-.PHONY: go-env-test
-
 print-ldflags: get-gpu-setup
 	@echo $(CGO_LDFLAGS)
 .PHONY: print-ldflags

--- a/activation/handler.go
+++ b/activation/handler.go
@@ -135,13 +135,13 @@ func (h *Handler) ProcessAtx(ctx context.Context, atx *types.VerifiedActivationT
 	h.log.WithContext(ctx).With().Info("processing atx",
 		atx.ID(),
 		atx.PublishEpoch(),
-		log.FieldNamed("atx_node_id", atx.NodeID()),
+		log.FieldNamed("smesher", atx.NodeID()),
 		atx.PubLayerID,
 	)
 	if err := h.ContextuallyValidateAtx(atx); err != nil {
 		h.log.WithContext(ctx).With().Warning("atx failed contextual validation",
 			atx.ID(),
-			log.FieldNamed("atx_node_id", atx.NodeID()),
+			log.FieldNamed("smesher", atx.NodeID()),
 			log.Err(err),
 		)
 	} else {
@@ -253,7 +253,7 @@ func (h *Handler) validateNonInitialAtx(ctx context.Context, atx *types.Activati
 	if atx.NumUnits > prevAtx.NumUnits && nonce == nil {
 		h.log.WithContext(ctx).With().Info("PoST size increased without new VRF Nonce, re-validating current nonce",
 			atx.ID(),
-			log.FieldNamed("atx_node_id", atx.NodeID()),
+			log.FieldNamed("smesher", atx.NodeID()),
 		)
 
 		current, err := h.cdb.VRFNonce(atx.NodeID(), atx.TargetEpoch())
@@ -326,7 +326,7 @@ func (h *Handler) ContextuallyValidateAtx(atx *types.VerifiedActivationTx) error
 		// no previous atx found but previous atx referenced
 		h.log.With().Error("could not fetch node last atx",
 			atx.ID(),
-			log.FieldNamed("atx_node_id", atx.NodeID()),
+			log.FieldNamed("smesher", atx.NodeID()),
 			log.Err(err),
 		)
 		return fmt.Errorf("could not fetch node last atx: %w", err)

--- a/activation/handler.go
+++ b/activation/handler.go
@@ -307,7 +307,7 @@ func (h *Handler) ContextuallyValidateAtx(atx *types.VerifiedActivationTx) error
 
 	if err == nil && atx.PrevATXID == *types.EmptyATXID {
 		// no previous atx declared, but already seen at least one atx from node
-		return fmt.Errorf("no prevATX reported, but other atx with same nodeID (%v) found: %v", atx.NodeID().ShortString(), lastAtx.ShortString())
+		return fmt.Errorf("no prevATX reported, but other atx with same nodeID (%v) found: %v", atx.NodeID(), lastAtx.ShortString())
 	}
 
 	if err == nil && atx.PrevATXID != lastAtx {

--- a/activation/handler.go
+++ b/activation/handler.go
@@ -517,7 +517,7 @@ func (h *Handler) handleAtxData(ctx context.Context, peer p2p.Peer, data []byte)
 		r.OnAtx(header)
 	}
 	events.ReportNewActivation(vAtx)
-	logger.With().Info("new atx", log.Inline(atx), log.Int("size", len(data)))
+	logger.With().Info("new atx", log.Inline(vAtx), log.Int("size", len(data)))
 	return nil
 }
 

--- a/beacon/beacon.go
+++ b/beacon/beacon.go
@@ -268,7 +268,7 @@ func (pd *ProtocolDriver) OnAtx(atx *types.ActivationTxHeader) {
 	}
 	if id, ok := s.minerAtxs[string(atx.NodeID.Bytes())]; ok && id != atx.ID {
 		pd.logger.With().Warning("ignoring malicious atx",
-			log.Stringer("miner_id", atx.NodeID),
+			log.Stringer("smesher", atx.NodeID),
 			log.Stringer("previous_atx", id),
 			log.Stringer("new_atx", atx.ID),
 		)
@@ -290,7 +290,7 @@ func (pd *ProtocolDriver) minerAtxHdr(epoch types.EpochID, minerPK []byte) (*typ
 	if !ok {
 		pd.logger.With().Debug("miner does not have atx in previous epoch",
 			epoch-1,
-			log.Stringer("miner_id", types.BytesToNodeID(minerPK)))
+			log.Stringer("smesher", types.BytesToNodeID(minerPK)))
 		return nil, errMinerNotActive
 	}
 	return pd.cdb.GetAtxHeader(id)
@@ -526,7 +526,7 @@ func (pd *ProtocolDriver) initEpochStateIfNotPresent(logger log.Log, epoch types
 		} else {
 			pd.logger.With().Warning("ignoring malicious atx from miner",
 				header.ID,
-				log.Stringer("miner_id", header.NodeID))
+				log.Stringer("smesher", header.NodeID))
 		}
 		if header.NodeID == pd.nodeID {
 			active = true

--- a/beacon/handlers.go
+++ b/beacon/handlers.go
@@ -76,7 +76,7 @@ func (pd *ProtocolDriver) handleProposal(ctx context.Context, peer p2p.Peer, msg
 		return errUntimelyMessage
 	}
 
-	logger = pd.logger.WithContext(ctx).WithFields(m.EpochID, log.String("miner_id", m.NodeID.ShortString()))
+	logger = pd.logger.WithContext(ctx).WithFields(m.EpochID, log.String("smesher", m.NodeID.ShortString()))
 	logger.With().Debug("new beacon proposal", log.String("proposal", hex.EncodeToString(cropData(m.VRFSignature))))
 
 	st, err := pd.initEpochStateIfNotPresent(logger, m.EpochID)
@@ -292,7 +292,7 @@ func (pd *ProtocolDriver) verifyFirstVotes(ctx context.Context, m FirstVotingMes
 
 	nodeID := types.BytesToNodeID(minerPK.Bytes())
 	minerID := nodeID.ShortString()
-	logger = logger.WithFields(log.String("miner_id", minerID))
+	logger = logger.WithFields(log.String("smesher", minerID))
 
 	if err = pd.registerVoted(logger, m.EpochID, minerPK, types.FirstRound); err != nil {
 		return nil, fmt.Errorf("[round %v] register proposal (miner ID %v): %w", types.FirstRound, minerID, err)
@@ -410,7 +410,7 @@ func (pd *ProtocolDriver) verifyFollowingVotes(ctx context.Context, m FollowingV
 
 	nodeID := types.BytesToNodeID(minerPK.Bytes())
 	minerID := nodeID.ShortString()
-	logger := pd.logger.WithContext(ctx).WithFields(m.EpochID, round, log.String("miner_id", minerID))
+	logger := pd.logger.WithContext(ctx).WithFields(m.EpochID, round, log.String("smesher", minerID))
 
 	if err := pd.registerVoted(logger, m.EpochID, minerPK, m.RoundID); err != nil {
 		return nil, err

--- a/beacon/handlers.go
+++ b/beacon/handlers.go
@@ -76,7 +76,7 @@ func (pd *ProtocolDriver) handleProposal(ctx context.Context, peer p2p.Peer, msg
 		return errUntimelyMessage
 	}
 
-	logger = pd.logger.WithContext(ctx).WithFields(m.EpochID, log.String("smesher", m.NodeID.ShortString()))
+	logger = pd.logger.WithContext(ctx).WithFields(m.EpochID, log.Stringer("smesher", m.NodeID))
 	logger.With().Debug("new beacon proposal", log.String("proposal", hex.EncodeToString(cropData(m.VRFSignature))))
 
 	st, err := pd.initEpochStateIfNotPresent(logger, m.EpochID)
@@ -200,7 +200,7 @@ func (pd *ProtocolDriver) addProposal(m ProposalMessage, cat category) error {
 }
 
 func (pd *ProtocolDriver) verifyProposalMessage(logger log.Log, m ProposalMessage) error {
-	minerID := m.NodeID.ShortString()
+	minerID := m.NodeID.String()
 
 	nonce, err := pd.nonceFetcher.VRFNonce(m.NodeID, m.EpochID)
 	if err != nil {
@@ -291,8 +291,8 @@ func (pd *ProtocolDriver) verifyFirstVotes(ctx context.Context, m FirstVotingMes
 	}
 
 	nodeID := types.BytesToNodeID(minerPK.Bytes())
-	minerID := nodeID.ShortString()
-	logger = logger.WithFields(log.String("smesher", minerID))
+	minerID := nodeID.String()
+	logger = logger.WithFields(log.Stringer("smesher", nodeID))
 
 	if err = pd.registerVoted(logger, m.EpochID, minerPK, types.FirstRound); err != nil {
 		return nil, fmt.Errorf("[round %v] register proposal (miner ID %v): %w", types.FirstRound, minerID, err)
@@ -409,8 +409,7 @@ func (pd *ProtocolDriver) verifyFollowingVotes(ctx context.Context, m FollowingV
 	}
 
 	nodeID := types.BytesToNodeID(minerPK.Bytes())
-	minerID := nodeID.ShortString()
-	logger := pd.logger.WithContext(ctx).WithFields(m.EpochID, round, log.String("smesher", minerID))
+	logger := pd.logger.WithContext(ctx).WithFields(m.EpochID, round, log.Stringer("smesher", nodeID))
 
 	if err := pd.registerVoted(logger, m.EpochID, minerPK, m.RoundID); err != nil {
 		return nil, err

--- a/common/types/activation.go
+++ b/common/types/activation.go
@@ -290,7 +290,7 @@ func (atx *ActivationTx) MarshalLogObject(encoder log.ObjectEncoder) error {
 	}
 	encoder.AddString("challenge", atx.NIPostChallenge.Hash().String())
 	encoder.AddString("id", atx.id.String())
-	encoder.AddString("sender_id", atx.nodeID.String())
+	encoder.AddString("smesher", atx.nodeID.String())
 	encoder.AddString("prev_atx_id", atx.PrevATXID.String())
 	encoder.AddString("pos_atx_id", atx.PositioningATX.String())
 	if atx.CommitmentATX != nil {

--- a/common/types/activation.go
+++ b/common/types/activation.go
@@ -215,6 +215,12 @@ type ATXMetadata struct {
 	MsgHash Hash32
 }
 
+func (m *ATXMetadata) MarshalLogObject(encoder log.ObjectEncoder) error {
+	encoder.AddUint32("epoch", uint32(m.Target))
+	encoder.AddString("msgHash", m.MsgHash.String())
+	return nil
+}
+
 // ActivationTx is a full, signed activation transaction. It includes (or references) everything a miner needs to prove
 // they are eligible to actively participate in the Spacemesh protocol in the next epoch.
 type ActivationTx struct {

--- a/common/types/ballot.go
+++ b/common/types/ballot.go
@@ -64,6 +64,12 @@ type BallotMetadata struct {
 	MsgHash Hash32
 }
 
+func (m *BallotMetadata) MarshalLogObject(encoder log.ObjectEncoder) error {
+	encoder.AddUint32("layer", m.Layer.Value)
+	encoder.AddString("msgHash", m.MsgHash.String())
+	return nil
+}
+
 // InnerBallot contains all info about a smesher's votes on the mesh history. this structure is
 // serialized and signed to produce the signature in Ballot.
 type InnerBallot struct {

--- a/common/types/ballot.go
+++ b/common/types/ballot.go
@@ -310,12 +310,6 @@ func (b *Ballot) MarshalLogObject(encoder log.ObjectEncoder) error {
 	encoder.AddInt("against", len(b.Votes.Against))
 	encoder.AddInt("abstain", len(b.Votes.Abstain))
 	encoder.AddString("atx_id", b.AtxID.String())
-	encoder.AddArray("eligibilities", log.ArrayMarshalerFunc(func(encoder log.ArrayEncoder) error {
-		for _, proof := range b.EligibilityProofs {
-			encoder.AppendObject(&proof)
-		}
-		return nil
-	}))
 	encoder.AddString("ref_ballot", b.RefBallot.String())
 	encoder.AddInt("active_set_size", activeSetSize)
 	encoder.AddString("beacon", beacon.ShortString())

--- a/common/types/eligibility.go
+++ b/common/types/eligibility.go
@@ -23,6 +23,15 @@ type HareEligibilityGossip struct {
 	Eligibility HareEligibility
 }
 
+func (hg *HareEligibilityGossip) MarshalLogObject(encoder log.ObjectEncoder) error {
+	encoder.AddUint32("layer", hg.Layer.Value)
+	encoder.AddUint32("round", hg.Round)
+	encoder.AddString("smesher", BytesToNodeID(hg.PubKey).String())
+	encoder.AddUint16("count", hg.Eligibility.Count)
+	encoder.AddString("proof", hex.EncodeToString(hg.Eligibility.Proof))
+	return nil
+}
+
 // HareEligibility includes the required values that, along with the smesher's VRF public key,
 // allow non-interactive eligibility validation for hare round participation.
 type HareEligibility struct {

--- a/common/types/malfeasance.go
+++ b/common/types/malfeasance.go
@@ -23,6 +23,40 @@ type MalfeasanceProof struct {
 	Proof Proof
 }
 
+func (mp *MalfeasanceProof) MarshalLogObject(encoder log.ObjectEncoder) error {
+	encoder.AddUint32("generated_layer", mp.Layer.Value)
+	switch mp.Proof.Type {
+	case MultipleATXs:
+		encoder.AddString("type", "multiple atxs")
+		p, ok := mp.Proof.Data.(*AtxProof)
+		if !ok {
+			encoder.AddString("msgs", "n/a")
+		} else {
+			encoder.AddObject("msgs", p)
+		}
+	case MultipleBallots:
+		encoder.AddString("type", "multiple ballots")
+		p, ok := mp.Proof.Data.(*BallotProof)
+		if !ok {
+			encoder.AddString("msgs", "n/a")
+		} else {
+			encoder.AddObject("msgs", p)
+		}
+	case HareEquivocation:
+		encoder.AddString("type", "hare equivocation")
+		p, ok := mp.Proof.Data.(*HareProof)
+		if !ok {
+			encoder.AddString("msgs", "n/a")
+		} else {
+			encoder.AddObject("msgs", p)
+		}
+	default:
+		encoder.AddString("type", "unknown")
+	}
+
+	return nil
+}
+
 type Proof struct {
 	// MultipleATXs | MultipleBallots | HareEquivocation
 	Type uint8
@@ -96,16 +130,42 @@ type MalfeasanceGossip struct {
 	Eligibility *HareEligibilityGossip // optional, only useful in live hare rounds
 }
 
+func (mg *MalfeasanceGossip) MarshalLogObject(encoder log.ObjectEncoder) error {
+	encoder.AddObject("proof", &mg.MalfeasanceProof)
+	if mg.Eligibility != nil {
+		encoder.AddObject("hare eligibility", mg.Eligibility)
+	}
+	return nil
+}
+
 type AtxProof struct {
 	Messages [2]AtxProofMsg
+}
+
+func (ap *AtxProof) MarshalLogObject(encoder log.ObjectEncoder) error {
+	encoder.AddObject("first", &ap.Messages[0].InnerMsg)
+	encoder.AddObject("second", &ap.Messages[1].InnerMsg)
+	return nil
 }
 
 type BallotProof struct {
 	Messages [2]BallotProofMsg
 }
 
+func (bp *BallotProof) MarshalLogObject(encoder log.ObjectEncoder) error {
+	encoder.AddObject("first", &bp.Messages[0].InnerMsg)
+	encoder.AddObject("second", &bp.Messages[1].InnerMsg)
+	return nil
+}
+
 type HareProof struct {
 	Messages [2]HareProofMsg
+}
+
+func (hp *HareProof) MarshalLogObject(encoder log.ObjectEncoder) error {
+	encoder.AddObject("first", &hp.Messages[0].InnerMsg)
+	encoder.AddObject("second", &hp.Messages[1].InnerMsg)
+	return nil
 }
 
 type AtxProofMsg struct {

--- a/common/types/malfeasance.go
+++ b/common/types/malfeasance.go
@@ -144,6 +144,13 @@ type HareMetadata struct {
 	MsgHash Hash32
 }
 
+func (hm *HareMetadata) MarshalLogObject(encoder log.ObjectEncoder) error {
+	encoder.AddUint32("layer", hm.Layer.Value)
+	encoder.AddUint32("round", hm.Round)
+	encoder.AddString("msgHash", hm.MsgHash.String())
+	return nil
+}
+
 type HareProofMsg struct {
 	InnerMsg  HareMetadata
 	Signature []byte

--- a/common/types/verified_activation.go
+++ b/common/types/verified_activation.go
@@ -41,7 +41,7 @@ func (vatx *VerifiedActivationTx) MarshalLogObject(encoder log.ObjectEncoder) er
 	}
 	encoder.AddString("challenge", vatx.NIPostChallenge.Hash().String())
 	encoder.AddString("id", vatx.id.String())
-	encoder.AddString("sender_id", vatx.nodeID.String())
+	encoder.AddString("smesher", vatx.nodeID.String())
 	encoder.AddString("prev_atx_id", vatx.PrevATXID.String())
 	encoder.AddString("pos_atx_id", vatx.PositioningATX.String())
 	if vatx.CommitmentATX != nil {

--- a/hare/algorithm.go
+++ b/hare/algorithm.go
@@ -108,7 +108,7 @@ func newMsg(ctx context.Context, logger log.Log, nodeId types.NodeID, hareMsg Me
 	res, err := querier.IsIdentityActiveOnConsensusView(ctx, nodeId, hareMsg.Layer)
 	if err != nil {
 		logger.With().Error("failed to check if identity is active",
-			log.String("sender_id", nodeId.ShortString()),
+			log.Stringer("smesher", nodeId),
 			log.Err(err),
 			hareMsg.Layer,
 			log.String("msg_type", hareMsg.InnerMsg.Type.String()))
@@ -118,7 +118,7 @@ func newMsg(ctx context.Context, logger log.Log, nodeId types.NodeID, hareMsg Me
 	// check query result
 	if !res {
 		logger.With().Warning("identity is not active",
-			log.String("sender_id", nodeId.ShortString()),
+			log.Stringer("smesher", nodeId),
 			hareMsg.Layer,
 			log.String("msg_type", hareMsg.InnerMsg.Type.String()))
 		return nil, errors.New("inactive identity")
@@ -439,7 +439,8 @@ func (proc *consensusProcess) onEarlyMessage(ctx context.Context, m *Msg) {
 	pub := m.PubKey
 	if _, exist := proc.pending[pub.String()]; exist { // ignore, already received
 		logger.With().Warning("already received message from sender",
-			log.String("sender_id", pub.ShortString()))
+			log.Stringer("smesher", types.BytesToNodeID(m.PubKey.Bytes())),
+		)
 		return
 	}
 
@@ -450,7 +451,7 @@ func (proc *consensusProcess) onEarlyMessage(ctx context.Context, m *Msg) {
 func (proc *consensusProcess) handleMessage(ctx context.Context, m *Msg) {
 	logger := proc.WithContext(ctx).WithFields(
 		log.String("msg_type", m.InnerMsg.Type.String()),
-		log.String("sender_id", m.PubKey.ShortString()),
+		log.Stringer("smesher", types.BytesToNodeID(m.PubKey.Bytes())),
 		log.Uint32("current_round", proc.getRound()),
 		log.Uint32("msg_round", m.Round),
 		proc.layer)
@@ -518,7 +519,8 @@ func (proc *consensusProcess) processMsg(ctx context.Context, m *Msg) {
 		proc.WithContext(ctx).With().Warning("unknown message type",
 			proc.layer,
 			log.String("msg_type", m.InnerMsg.Type.String()),
-			log.String("sender_id", m.PubKey.ShortString()))
+			log.Stringer("smesher", types.BytesToNodeID(m.PubKey.Bytes())),
+		)
 	}
 }
 
@@ -826,7 +828,8 @@ func (proc *consensusProcess) processNotifyMsg(ctx context.Context, msg *Msg) {
 
 	if ignored := proc.notifyTracker.OnNotify(ctx, msg); ignored {
 		proc.WithContext(ctx).With().Warning("ignoring notification",
-			log.String("sender_id", msg.PubKey.ShortString()))
+			log.Stringer("smesher", types.BytesToNodeID(msg.PubKey.Bytes())),
+		)
 		return
 	}
 

--- a/hare/committracker.go
+++ b/hare/committracker.go
@@ -64,8 +64,11 @@ func (ct *commitTracker) OnCommit(ctx context.Context, msg *Msg) {
 			prev.InnerMsg.Round == msg.Round &&
 			prev.InnerMsg.MsgHash != msg.MsgHash {
 			nodeID := types.BytesToNodeID(msg.PubKey.Bytes())
-			ct.logger.WithContext(ctx).With().Warning("equivocation detected at commit round",
-				log.String("sender_id", nodeID.ShortString()))
+			ct.logger.WithContext(ctx).With().Warning("equivocation detected in commit round",
+				log.Stringer("smesher", nodeID),
+				log.Object("prev", &prev.InnerMsg),
+				log.Object("curr", &msg.HareMetadata),
+			)
 			ct.eTracker.Track(msg.PubKey.Bytes(), msg.Round, msg.Eligibility.Count, false)
 			this := &types.HareProofMsg{
 				InnerMsg:  msg.HareMetadata,
@@ -73,7 +76,7 @@ func (ct *commitTracker) OnCommit(ctx context.Context, msg *Msg) {
 			}
 			if err := reportEquivocation(ctx, msg.PubKey.Bytes(), prev, this, &msg.Eligibility, ct.malCh); err != nil {
 				ct.logger.WithContext(ctx).With().Warning("failed to report equivocation in commit round",
-					log.String("sender_id", nodeID.ShortString()),
+					log.Stringer("smesher", nodeID),
 					log.Err(err))
 				return
 			}

--- a/hare/eligibility/oracle.go
+++ b/hare/eligibility/oracle.go
@@ -218,7 +218,7 @@ func calcVrfFrac(vrfSig []byte) fixed.Fixed {
 func (o *Oracle) prepareEligibilityCheck(ctx context.Context, layer types.LayerID, round uint32, committeeSize int, id types.NodeID, nonce types.VRFPostIndex, vrfSig []byte) (n int, p, vrfFrac fixed.Fixed, done bool, err error) {
 	logger := o.WithContext(ctx).WithFields(
 		layer,
-		log.Stringer("sender_id", id),
+		log.Stringer("smesher", id),
 		log.Uint32("round", round),
 		log.Int("committee_size", committeeSize),
 	)
@@ -298,7 +298,7 @@ func (o *Oracle) Validate(ctx context.Context, layer types.LayerID, round uint32
 	nonce, err := o.nonceFetcher.VRFNonce(id, layer.GetEpoch())
 	if err != nil {
 		o.Log.WithContext(ctx).With().Warning("failed to find nonce for node",
-			log.String("sender_id", id.ShortString()),
+			log.Stringer("smesher", id),
 			log.Err(err),
 		)
 		return false, fmt.Errorf("nonce not found for node %s: %w", id, err)

--- a/hare/messagevalidation.go
+++ b/hare/messagevalidation.go
@@ -37,7 +37,7 @@ func (ev *eligibilityValidator) ValidateEligibilityGossip(ctx context.Context, e
 		ev.WithContext(ctx).With().Error("failed to validate role",
 			em.Layer,
 			log.Uint32("round", em.Round),
-			log.String("sender_id", types.BytesToNodeID(em.PubKey).ShortString()),
+			log.Stringer("smesher", types.BytesToNodeID(em.PubKey)),
 		)
 		return false
 	}
@@ -55,7 +55,7 @@ func (ev *eligibilityValidator) Validate(ctx context.Context, m *Msg) bool {
 	if err != nil {
 		ev.WithContext(ctx).With().Error("failed to validate role",
 			log.Err(err),
-			log.String("sender_id", m.PubKey.ShortString()),
+			log.Stringer("smesher", types.BytesToNodeID(m.PubKey.Bytes())),
 			m.Layer,
 			log.String("msg_type", m.InnerMsg.Type.String()))
 		return false
@@ -63,7 +63,7 @@ func (ev *eligibilityValidator) Validate(ctx context.Context, m *Msg) bool {
 
 	if !res {
 		ev.WithContext(ctx).With().Warning("validate message failed: role is invalid",
-			log.String("sender_id", m.PubKey.ShortString()),
+			log.Stringer("smesher", types.BytesToNodeID(m.PubKey.Bytes())),
 			m.Layer,
 			log.String("msg_type", m.InnerMsg.Type.String()))
 		return false
@@ -244,7 +244,7 @@ func (v *syntaxContextValidator) SyntacticallyValidateMessage(ctx context.Contex
 
 	if m.InnerMsg == nil {
 		logger.With().Warning("syntax validation failed: inner message is nil",
-			log.String("sender_id", m.PubKey.ShortString()))
+			log.Stringer("smesher", types.BytesToNodeID(m.PubKey.Bytes())))
 		return false
 	}
 
@@ -387,7 +387,7 @@ func (v *syntaxContextValidator) validateSVP(ctx context.Context, msg *Msg) bool
 		statusIter := inferIteration(m.Round)
 		if proposalIter != statusIter { // not same iteration
 			logger.With().Warning("proposal validation failed: not same iteration",
-				log.String("sender_id", m.PubKey.ShortString()),
+				log.Stringer("smesher", types.BytesToNodeID(m.PubKey.Bytes())),
 				m.Layer,
 				log.Uint32("expected", proposalIter),
 				log.Uint32("actual", statusIter))
@@ -396,7 +396,7 @@ func (v *syntaxContextValidator) validateSVP(ctx context.Context, msg *Msg) bool
 
 		return true
 	}
-	logger = logger.WithFields(log.String("sender_id", msg.PubKey.ShortString()), msg.Layer)
+	logger = logger.WithFields(log.Stringer("smesher", types.BytesToNodeID(msg.PubKey.Bytes())), msg.Layer)
 	validators := []func(m *Msg) bool{validateStatusType, validateSameIteration, v.statusValidator}
 	if err := v.validateAggregatedMessage(ctx, msg.InnerMsg.Svp, validators); err != nil {
 		logger.With().Warning("invalid proposal", log.Err(err))

--- a/hare/notifytracker.go
+++ b/hare/notifytracker.go
@@ -47,8 +47,11 @@ func (nt *notifyTracker) OnNotify(ctx context.Context, msg *Msg) bool {
 		if prev.InnerMsg.Layer == msg.Layer &&
 			prev.InnerMsg.Round == msg.Round &&
 			prev.InnerMsg.MsgHash != msg.MsgHash {
-			nt.logger.WithContext(ctx).With().Warning("equivocation detected at notify round",
-				log.String("sender_id", nodeID.ShortString()))
+			nt.logger.WithContext(ctx).With().Warning("equivocation detected in notify round",
+				log.Stringer("smesher", nodeID),
+				log.Object("prev", &prev.InnerMsg),
+				log.Object("curr", &msg.HareMetadata),
+			)
 			nt.eTracker.Track(msg.PubKey.Bytes(), msg.Round, msg.Eligibility.Count, false)
 			this := &types.HareProofMsg{
 				InnerMsg:  msg.HareMetadata,
@@ -56,7 +59,7 @@ func (nt *notifyTracker) OnNotify(ctx context.Context, msg *Msg) bool {
 			}
 			if err := reportEquivocation(ctx, msg.PubKey.Bytes(), prev, this, &msg.Eligibility, nt.malCh); err != nil {
 				nt.logger.WithContext(ctx).With().Warning("failed to report equivocation in notify round",
-					log.String("sender_id", nodeID.ShortString()),
+					log.Stringer("smesher", nodeID),
 					log.Err(err))
 			}
 		}

--- a/hare/preroundtracker.go
+++ b/hare/preroundtracker.go
@@ -53,7 +53,7 @@ func (pre *preRoundTracker) OnPreRound(ctx context.Context, msg *Msg) {
 	vrfHashVal := binary.LittleEndian.Uint32(vrfHash[:4])
 	logger.With().Debug("received preround message",
 		nodeID,
-		log.String("sender_id", nodeID.ShortString()),
+		log.Stringer("smesher", nodeID),
 		log.Int("num_values", len(msg.InnerMsg.Values)),
 		log.Uint32("vrf_value", vrfHashVal))
 	if vrfHashVal < pre.bestVRF {
@@ -61,7 +61,7 @@ func (pre *preRoundTracker) OnPreRound(ctx context.Context, msg *Msg) {
 		// store lowest-order bit as coin toss value
 		pre.coinflip = vrfHash[0]&byte(1) == byte(1)
 		pre.logger.With().Debug("got new best vrf value",
-			log.String("sender_id", nodeID.ShortString()),
+			log.Stringer("smesher", nodeID),
 			log.String("vrf_value", fmt.Sprintf("%x", vrfHashVal)),
 			log.Bool("weak_coin", pre.coinflip))
 	}
@@ -85,12 +85,12 @@ func (pre *preRoundTracker) OnPreRound(ctx context.Context, msg *Msg) {
 			}
 			if err := reportEquivocation(ctx, msg.PubKey.Bytes(), prev.HareProofMsg, this, &msg.Eligibility, pre.malCh); err != nil {
 				pre.logger.WithContext(ctx).With().Warning("failed to report equivocation in preround",
-					nodeID,
+					log.Stringer("smesher", nodeID),
 					log.Err(err))
 				return
 			}
 		}
-		logger.With().Debug("duplicate preround msg sender", log.String("sender_id", nodeID.ShortString()))
+		logger.With().Debug("duplicate preround msg sender", log.Stringer("smesher", nodeID))
 		alreadyTracked = prev.Set         // update already tracked Values
 		sToTrack.Subtract(alreadyTracked) // subtract the already tracked Values
 	} else {

--- a/hare/preroundtracker.go
+++ b/hare/preroundtracker.go
@@ -73,7 +73,11 @@ func (pre *preRoundTracker) OnPreRound(ctx context.Context, msg *Msg) {
 		if prev.InnerMsg.Layer == msg.Layer &&
 			prev.InnerMsg.Round == msg.Round &&
 			prev.InnerMsg.MsgHash != msg.MsgHash {
-			pre.logger.WithContext(ctx).With().Warning("equivocation detected at preround", nodeID)
+			pre.logger.WithContext(ctx).With().Warning("equivocation detected in preround",
+				log.Stringer("smesher", nodeID),
+				log.Object("prev", &prev.InnerMsg),
+				log.Object("curr", &msg.HareMetadata),
+			)
 			pre.eTracker.Track(msg.PubKey.Bytes(), msg.Round, msg.Eligibility.Count, false)
 			this := &types.HareProofMsg{
 				InnerMsg:  msg.HareMetadata,

--- a/hare/proposaltracker.go
+++ b/hare/proposaltracker.go
@@ -45,10 +45,10 @@ func (pt *proposalTracker) OnProposal(ctx context.Context, msg *Msg) {
 		s := NewSet(msg.InnerMsg.Values)
 		g := NewSet(pt.proposal.InnerMsg.Values)
 		if !s.Equals(g) { // equivocation detected
-			pt.logger.WithContext(ctx).With().Warning("equivocation detected on proposal round",
-				log.Stringer("id_malicious", types.BytesToNodeID(msg.PubKey.Bytes())),
-				log.Stringer("current_set", g),
-				log.Stringer("conflicting_set", s))
+			pt.logger.WithContext(ctx).With().Warning("equivocation detected in proposal round",
+				log.Stringer("smesher", types.BytesToNodeID(msg.PubKey.Bytes())),
+				log.Stringer("prev", g),
+				log.Stringer("curr", s))
 			pt.eTracker.Track(msg.PubKey.Bytes(), msg.Round, msg.Eligibility.Count, false)
 			pt.isConflicting = true
 			prev := &types.HareProofMsg{
@@ -60,8 +60,8 @@ func (pt *proposalTracker) OnProposal(ctx context.Context, msg *Msg) {
 				Signature: msg.Signature,
 			}
 			if err := reportEquivocation(ctx, msg.PubKey.Bytes(), prev, this, &msg.Eligibility, pt.malCh); err != nil {
-				pt.logger.WithContext(ctx).With().Warning("failed to report equivocation in commit round",
-					types.BytesToNodeID(msg.Bytes()),
+				pt.logger.WithContext(ctx).With().Warning("failed to report equivocation in proposal round",
+					log.Stringer("smesher", types.BytesToNodeID(msg.PubKey.Bytes())),
 					log.Err(err))
 			}
 		}
@@ -90,10 +90,10 @@ func (pt *proposalTracker) OnLateProposal(ctx context.Context, msg *Msg) {
 		s := NewSet(msg.InnerMsg.Values)
 		g := NewSet(pt.proposal.InnerMsg.Values)
 		if !s.Equals(g) { // equivocation detected
-			pt.logger.WithContext(ctx).With().Warning("equivocation detected on proposal round - late",
-				log.Stringer("id_malicious", types.BytesToNodeID(msg.PubKey.Bytes())),
-				log.Stringer("current_set", g),
-				log.Stringer("conflicting_set", s))
+			pt.logger.WithContext(ctx).With().Warning("equivocation detected in proposal round - late",
+				log.Stringer("smesher", types.BytesToNodeID(msg.PubKey.Bytes())),
+				log.Stringer("prev", g),
+				log.Stringer("curr", s))
 			pt.eTracker.Track(msg.PubKey.Bytes(), msg.Round, msg.Eligibility.Count, false)
 			pt.isConflicting = true
 			prev := &types.HareProofMsg{
@@ -105,8 +105,8 @@ func (pt *proposalTracker) OnLateProposal(ctx context.Context, msg *Msg) {
 				Signature: msg.Signature,
 			}
 			if err := reportEquivocation(ctx, msg.PubKey.Bytes(), prev, this, &msg.Eligibility, pt.malCh); err != nil {
-				pt.logger.WithContext(ctx).With().Warning("failed to report equivocation in proposal round",
-					types.BytesToNodeID(msg.Bytes()),
+				pt.logger.WithContext(ctx).With().Warning("failed to report equivocation in proposal round - late",
+					log.Stringer("smesher", types.BytesToNodeID(msg.PubKey.Bytes())),
 					log.Err(err))
 			}
 			pt.isConflicting = true

--- a/hare/statustracker.go
+++ b/hare/statustracker.go
@@ -41,8 +41,11 @@ func (st *statusTracker) RecordStatus(ctx context.Context, msg *Msg) {
 		if prev.Layer == msg.Layer &&
 			prev.Round == msg.Round &&
 			prev.MsgHash != msg.MsgHash {
-			st.logger.WithContext(ctx).With().Warning("equivocation detected at status round",
-				log.String("sender_id", nodeID.ShortString()))
+			st.logger.WithContext(ctx).With().Warning("equivocation detected in status round",
+				log.Stringer("smesher", nodeID),
+				log.Object("prev", prev),
+				log.Object("curr", &msg.HareMetadata),
+			)
 			st.eTracker.Track(msg.PubKey.Bytes(), msg.Round, msg.Eligibility.Count, false)
 			old := &types.HareProofMsg{
 				InnerMsg:  prev.HareMetadata,
@@ -54,7 +57,7 @@ func (st *statusTracker) RecordStatus(ctx context.Context, msg *Msg) {
 			}
 			if err := reportEquivocation(ctx, msg.PubKey.Bytes(), old, this, &msg.Eligibility, st.malCh); err != nil {
 				st.logger.WithContext(ctx).With().Warning("failed to report equivocation in status round",
-					log.String("sender_id", nodeID.ShortString()),
+					log.Stringer("smesher", nodeID),
 					log.Err(err))
 				return
 			}

--- a/hare/statustracker.go
+++ b/hare/statustracker.go
@@ -63,7 +63,7 @@ func (st *statusTracker) RecordStatus(ctx context.Context, msg *Msg) {
 			}
 		}
 		st.logger.WithContext(ctx).With().Warning("duplicate status message detected",
-			log.String("sender_id", nodeID.ShortString()))
+			log.Stringer("smesher", nodeID))
 		return
 	}
 

--- a/malfeasance/handler.go
+++ b/malfeasance/handler.go
@@ -93,6 +93,7 @@ func (h *Handler) handleProof(ctx context.Context, peer p2p.Peer, data []byte) e
 	if p.Eligibility != nil {
 		if err = h.validateHareEligibility(ctx, logger, nodeID, &p); err != nil {
 			h.logger.WithContext(ctx).With().Warning("failed to validate hare eligibility",
+				log.Stringer("smesher", nodeID),
 				log.Inline(&p),
 				log.Err(err),
 			)
@@ -108,18 +109,24 @@ func (h *Handler) handleProof(ctx context.Context, peer p2p.Peer, data []byte) e
 			updateMetrics(p.Proof)
 			return nil
 		}
-		logger.With().Debug("known malicious identity", nodeID)
+		logger.With().Debug("known malicious identity",
+			log.Stringer("smesher", nodeID),
+		)
 		return errors.New("known proof")
 	}
 	if err = h.cdb.AddMalfeasanceProof(nodeID, &p.MalfeasanceProof, nil); err != nil {
 		h.logger.WithContext(ctx).With().Error("failed to save MalfeasanceProof",
+			log.Stringer("smesher", nodeID),
 			log.Inline(&p),
 			log.Err(err),
 		)
 		return fmt.Errorf("add malfeasance proof: %w", err)
 	}
 	updateMetrics(p.Proof)
-	h.logger.WithContext(ctx).With().Info("new malfeasance proof", log.Inline(&p))
+	h.logger.WithContext(ctx).With().Info("new malfeasance proof",
+		log.Stringer("smesher", nodeID),
+		log.Inline(&p),
+	)
 	return nil
 }
 
@@ -194,14 +201,11 @@ func (h *Handler) validateHareEquivocation(logger log.Log, proof *types.Malfeasa
 		}
 	}
 	logger.With().Warning("received invalid hare malfeasance proof",
-		log.Stringer("nodeID_1", firstNid),
-		log.Stringer("nodeID_2", nid),
-		log.Stringer("layer_1", firstMsg.InnerMsg.Layer),
-		log.Stringer("layer_2", msg.InnerMsg.Layer),
-		log.Uint32("round_1", firstMsg.InnerMsg.Round),
-		log.Uint32("round_2", msg.InnerMsg.Round),
-		log.Stringer("msg_hash_1", firstMsg.InnerMsg.MsgHash),
-		log.Stringer("msg_hash_2", msg.InnerMsg.MsgHash))
+		log.Stringer("smesher", firstNid),
+		log.Stringer("smesher", nid),
+		log.Object("first", &firstMsg.InnerMsg),
+		log.Object("second", &msg.InnerMsg),
+	)
 	numInvalidProofsHare.Inc()
 	return types.NodeID{}, errors.New("invalid hare malfeasance proof")
 }
@@ -238,12 +242,11 @@ func (h *Handler) validateMultipleATXs(logger log.Log, proof *types.MalfeasanceP
 		}
 	}
 	logger.With().Warning("received invalid atx malfeasance proof",
-		log.Stringer("nodeID_1", firstNid),
-		log.Stringer("nodeID_2", nid),
-		log.Stringer("epoch_1", firstMsg.InnerMsg.Target),
-		log.Stringer("epoch_2", msg.InnerMsg.Target),
-		log.Stringer("msg_hash_1", firstMsg.InnerMsg.MsgHash),
-		log.Stringer("msg_hash_2", msg.InnerMsg.MsgHash))
+		log.Stringer("smesher", firstNid),
+		log.Stringer("smesher", nid),
+		log.Object("first", &firstMsg.InnerMsg),
+		log.Object("second", &msg.InnerMsg),
+	)
 	numInvalidProofsATX.Inc()
 	return types.NodeID{}, errors.New("invalid atx malfeasance proof")
 }
@@ -280,12 +283,11 @@ func (h *Handler) validateMultipleBallots(logger log.Log, proof *types.Malfeasan
 		}
 	}
 	logger.With().Warning("received invalid ballot malfeasance proof",
-		log.Stringer("nodeID_1", firstNid),
-		log.Stringer("nodeID_2", nid),
-		log.Stringer("layer_1", firstMsg.InnerMsg.Layer),
-		log.Stringer("layer_2", msg.InnerMsg.Layer),
-		log.Stringer("msg_hash_1", firstMsg.InnerMsg.MsgHash),
-		log.Stringer("msg_hash_2", msg.InnerMsg.MsgHash))
+		log.Stringer("smesher", firstNid),
+		log.Stringer("smesher", nid),
+		log.Object("first", &firstMsg.InnerMsg),
+		log.Object("second", &msg.InnerMsg),
+	)
 	numInvalidProofsBallot.Inc()
 	return types.NodeID{}, errors.New("invalid ballot malfeasance proof")
 }

--- a/mesh/mesh.go
+++ b/mesh/mesh.go
@@ -719,7 +719,8 @@ func (msh *Mesh) AddBallot(ctx context.Context, ballot *types.Ballot) (*types.Ma
 				ballot.SetMalicious()
 				msh.logger.With().Warning("smesher produced more than one ballot in the same layer",
 					log.Stringer("smesher", ballot.SmesherID()),
-					log.Inline(ballot),
+					log.Object("prev", prev),
+					log.Object("curr", ballot),
 				)
 			}
 		}

--- a/miner/oracle.go
+++ b/miner/oracle.go
@@ -111,7 +111,7 @@ func (o *Oracle) getOwnEpochATX(targetEpoch types.EpochID) (*types.ActivationTxH
 	if err != nil {
 		o.log.With().Warning("failed to find ATX ID for node",
 			log.Named("publish_epoch", publishEpoch),
-			log.Named("atx_node_id", o.nodeID),
+			log.Named("smesher", o.nodeID),
 			log.Err(err))
 		return nil, fmt.Errorf("get ATX ID: %w", err)
 	}
@@ -120,7 +120,7 @@ func (o *Oracle) getOwnEpochATX(targetEpoch types.EpochID) (*types.ActivationTxH
 	if err != nil {
 		o.log.With().Error("failed to get ATX header",
 			log.Named("publish_epoch", publishEpoch),
-			log.Named("atx_node_id", o.nodeID),
+			log.Named("smesher", o.nodeID),
 			log.Err(err))
 		return nil, fmt.Errorf("get ATX header: %w", err)
 	}

--- a/syncer/data_fetch.go
+++ b/syncer/data_fetch.go
@@ -272,7 +272,7 @@ func fetchMalfeasanceProof(ctx context.Context, logger log.Log, ids idProvider, 
 			logger.With().Warning("failed fetching malfeasance proofs",
 				log.Array("malicious_ids", log.ArrayMarshalerFunc(func(encoder log.ArrayEncoder) error {
 					for _, nodeID := range idsToFetch {
-						encoder.AppendString(nodeID.ShortString())
+						encoder.AppendString(nodeID.String())
 					}
 					return nil
 				})),


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
part of #4067
<!-- `Closes #XXXX, closes #XXXX, ...` links mentioned issues to this PR and automatically closes them when this it's merged -->

## Changes
<!-- Please describe in detail the changes made -->
- malfeasance proof: only update metrics when save is successful
- add more logging to malfeasance proof upon generation and reception
- make atx handler uses just 1 mutex, not 2
- rename all miner_id, atx_node_id, sender_Id logging field to just smesher
- fix benchmark tests in atx handler