### PR TITLE
[Merged by Bors] - provide data validator for malfeasance proof

### DIFF
--- a/activation/handler.go
+++ b/activation/handler.go
@@ -365,7 +365,7 @@ func (h *Handler) storeAtx(ctx context.Context, atx *types.VerifiedActivationTx)
 				if err = h.cdb.AddMalfeasanceProof(atx.NodeID(), proof, dbtx); err != nil {
 					return fmt.Errorf("adding malfeasense proof: %w", err)
 				}
-				h.log.With().Warning("smesher produced more than one atx in the same epoch",
+				h.log.WithContext(ctx).With().Warning("smesher produced more than one atx in the same epoch",
 					log.Stringer("smesher", atx.NodeID()),
 					log.Object("prev", prev),
 					log.Object("curr", atx),

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -31,8 +31,12 @@ const (
 	cacheSize = 1000
 )
 
-// errExceedMaxRetries is returned when MaxRetriesForRequest attempts has been made to fetch data for a hash and failed.
-var errExceedMaxRetries = errors.New("fetch failed after max retries for request")
+var (
+	// errExceedMaxRetries is returned when MaxRetriesForRequest attempts has been made to fetch data for a hash and failed.
+	errExceedMaxRetries = errors.New("fetch failed after max retries for request")
+
+	errValidatorsNotSet = errors.New("validators not set")
+)
 
 // request contains all relevant Data for a single request for a specified hash.
 type request struct {
@@ -95,7 +99,7 @@ func DefaultConfig() Config {
 // randomPeer returns a random peer from current peer list.
 func randomPeer(peers []p2p.Peer) p2p.Peer {
 	if len(peers) == 0 {
-		log.Panic("cannot send fetch: no peers found")
+		log.Fatal("cannot send fetch: no peers found")
 	}
 	return peers[rand.Intn(len(peers))]
 }
@@ -124,55 +128,6 @@ func WithLogger(log log.Log) Option {
 	}
 }
 
-// WithMalfeasanceHandler configures the malfeasance handler of the fetcher.
-func WithMalfeasanceHandler(h malfeasanceHandler) Option {
-	return func(f *Fetch) {
-		f.malHandler = h
-	}
-}
-
-// WithATXHandler configures the ATX handler of the fetcher.
-func WithATXHandler(h atxHandler) Option {
-	return func(f *Fetch) {
-		f.atxHandler = h
-	}
-}
-
-// WithBallotHandler configures the Ballot handler of the fetcher.
-func WithBallotHandler(h ballotHandler) Option {
-	return func(f *Fetch) {
-		f.ballotHandler = h
-	}
-}
-
-// WithBlockHandler configures the Block handler of the fetcher.
-func WithBlockHandler(h blockHandler) Option {
-	return func(f *Fetch) {
-		f.blockHandler = h
-	}
-}
-
-// WithProposalHandler configures the Proposal handler of the fetcher.
-func WithProposalHandler(h proposalHandler) Option {
-	return func(f *Fetch) {
-		f.proposalHandler = h
-	}
-}
-
-// WithTXHandler configures the TX handler of the fetcher.
-func WithTXHandler(h txHandler) Option {
-	return func(f *Fetch) {
-		f.txHandler = h
-	}
-}
-
-// WithPoetHandler configures the PoET handler of the fetcher.
-func WithPoetHandler(h poetHandler) Option {
-	return func(f *Fetch) {
-		f.poetHandler = h
-	}
-}
-
 func withServers(s map[string]requester) Option {
 	return func(f *Fetch) {
 		f.servers = s
@@ -192,14 +147,8 @@ type Fetch struct {
 	bs     *datastore.BlobStore
 	host   host
 
-	servers         map[string]requester
-	poetHandler     poetHandler
-	malHandler      malfeasanceHandler
-	atxHandler      atxHandler
-	ballotHandler   ballotHandler
-	blockHandler    blockHandler
-	proposalHandler proposalHandler
-	txHandler       txHandler
+	servers    map[string]requester
+	validators *dataValidators
 
 	// unprocessed contains requests that are not processed
 	unprocessed map[types.Hash32]*request
@@ -252,14 +201,49 @@ func NewFetch(cdb *datastore.CachedDB, msh meshProvider, b system.BeaconGetter, 
 	return f
 }
 
+type dataValidators struct {
+	atx         AtxValidator
+	poet        PoetValidator
+	ballot      BallotValidator
+	block       BlockValidator
+	proposal    ProposalValidator
+	tx          TxValidator
+	malfeasance MalfeasanceValidator
+}
+
+// SetValidators sets the handlers to validate various mesh data fetched from peers.
+func (f *Fetch) SetValidators(
+	atx AtxValidator,
+	poet PoetValidator,
+	ballot BallotValidator,
+	block BlockValidator,
+	prop ProposalValidator,
+	tx TxValidator,
+	mal MalfeasanceValidator,
+) {
+	f.validators = &dataValidators{
+		atx:         atx,
+		poet:        poet,
+		ballot:      ballot,
+		block:       block,
+		proposal:    prop,
+		tx:          tx,
+		malfeasance: mal,
+	}
+}
+
 // Start starts handling fetch requests.
-func (f *Fetch) Start() {
+func (f *Fetch) Start() error {
+	if f.validators == nil {
+		return errValidatorsNotSet
+	}
 	f.onlyOnce.Do(func() {
 		f.eg.Go(func() error {
 			f.loop()
 			return nil
 		})
 	})
+	return nil
 }
 
 // Stop stops handling fetch requests.

--- a/fetch/interface.go
+++ b/fetch/interface.go
@@ -13,32 +13,32 @@ type requester interface {
 	Request(context.Context, p2p.Peer, []byte, func([]byte), func(error)) error
 }
 
-type malfeasanceHandler interface {
+type MalfeasanceValidator interface {
 	HandleSyncedMalfeasanceProof(context.Context, p2p.Peer, []byte) error
 }
 
-type atxHandler interface {
+type AtxValidator interface {
 	HandleAtxData(context.Context, p2p.Peer, []byte) error
 }
 
-type blockHandler interface {
+type BlockValidator interface {
 	HandleSyncedBlock(context.Context, p2p.Peer, []byte) error
 }
 
-type ballotHandler interface {
+type BallotValidator interface {
 	HandleSyncedBallot(context.Context, p2p.Peer, []byte) error
 }
 
-type proposalHandler interface {
+type ProposalValidator interface {
 	HandleSyncedProposal(context.Context, p2p.Peer, []byte) error
 }
 
-type txHandler interface {
+type TxValidator interface {
 	HandleBlockTransaction(context.Context, p2p.Peer, []byte) error
 	HandleProposalTransaction(context.Context, p2p.Peer, []byte) error
 }
 
-type poetHandler interface {
+type PoetValidator interface {
 	ValidateAndStoreMsg(context.Context, p2p.Peer, []byte) error
 }
 

--- a/fetch/mesh_data.go
+++ b/fetch/mesh_data.go
@@ -24,7 +24,7 @@ func (f *Fetch) GetAtxs(ctx context.Context, ids []types.ATXID) error {
 	}
 	f.logger.WithContext(ctx).With().Debug("requesting atxs from peer", log.Int("num_atxs", len(ids)))
 	hashes := types.ATXIDsToHashes(ids)
-	return f.getHashes(ctx, hashes, datastore.ATXDB, f.atxHandler.HandleAtxData)
+	return f.getHashes(ctx, hashes, datastore.ATXDB, f.validators.atx.HandleAtxData)
 }
 
 type dataReceiver func(context.Context, p2p.Peer, []byte) error
@@ -69,7 +69,7 @@ func (f *Fetch) GetMalfeasanceProofs(ctx context.Context, ids []types.NodeID) er
 	}
 	f.logger.WithContext(ctx).With().Debug("requesting malfeasance proofs from peer", log.Int("num_proofs", len(ids)))
 	hashes := types.NodeIDsToHashes(ids)
-	return f.getHashes(ctx, hashes, datastore.Malfeasance, f.malHandler.HandleSyncedMalfeasanceProof)
+	return f.getHashes(ctx, hashes, datastore.Malfeasance, f.validators.malfeasance.HandleSyncedMalfeasanceProof)
 }
 
 // GetBallots gets data for the specified BallotIDs and validates them.
@@ -79,7 +79,7 @@ func (f *Fetch) GetBallots(ctx context.Context, ids []types.BallotID) error {
 	}
 	f.logger.WithContext(ctx).With().Debug("requesting ballots from peer", log.Int("num_ballots", len(ids)))
 	hashes := types.BallotIDsToHashes(ids)
-	return f.getHashes(ctx, hashes, datastore.BallotDB, f.ballotHandler.HandleSyncedBallot)
+	return f.getHashes(ctx, hashes, datastore.BallotDB, f.validators.ballot.HandleSyncedBallot)
 }
 
 // GetProposals gets the data for given proposal IDs from peers.
@@ -89,7 +89,7 @@ func (f *Fetch) GetProposals(ctx context.Context, ids []types.ProposalID) error 
 	}
 	f.logger.WithContext(ctx).With().Debug("requesting proposals from peer", log.Int("num_proposals", len(ids)))
 	hashes := types.ProposalIDsToHashes(ids)
-	return f.getHashes(ctx, hashes, datastore.ProposalDB, f.proposalHandler.HandleSyncedProposal)
+	return f.getHashes(ctx, hashes, datastore.ProposalDB, f.validators.proposal.HandleSyncedProposal)
 }
 
 // GetBlocks gets the data for given block IDs from peers.
@@ -99,18 +99,18 @@ func (f *Fetch) GetBlocks(ctx context.Context, ids []types.BlockID) error {
 	}
 	f.logger.WithContext(ctx).With().Debug("requesting blocks from peer", log.Int("num_blocks", len(ids)))
 	hashes := types.BlockIDsToHashes(ids)
-	return f.getHashes(ctx, hashes, datastore.BlockDB, f.blockHandler.HandleSyncedBlock)
+	return f.getHashes(ctx, hashes, datastore.BlockDB, f.validators.block.HandleSyncedBlock)
 }
 
 // GetProposalTxs fetches the txs provided as IDs and validates them, returns an error if one TX failed to be fetched.
 func (f *Fetch) GetProposalTxs(ctx context.Context, ids []types.TransactionID) error {
-	return f.getTxs(ctx, ids, f.txHandler.HandleProposalTransaction)
+	return f.getTxs(ctx, ids, f.validators.tx.HandleProposalTransaction)
 }
 
 // GetBlockTxs fetches the txs provided as IDs and saves them, they will be validated
 // before block is applied.
 func (f *Fetch) GetBlockTxs(ctx context.Context, ids []types.TransactionID) error {
-	return f.getTxs(ctx, ids, f.txHandler.HandleBlockTransaction)
+	return f.getTxs(ctx, ids, f.validators.tx.HandleBlockTransaction)
 }
 
 func (f *Fetch) getTxs(ctx context.Context, ids []types.TransactionID, receiver dataReceiver) error {
@@ -125,7 +125,7 @@ func (f *Fetch) getTxs(ctx context.Context, ids []types.TransactionID, receiver 
 // GetPoetProof gets poet proof from remote peer.
 func (f *Fetch) GetPoetProof(ctx context.Context, id types.Hash32) error {
 	f.logger.WithContext(ctx).With().Debug("getting poet proof", log.Stringer("hash", id))
-	pm, err := f.getHash(ctx, id, datastore.POETDB, f.poetHandler.ValidateAndStoreMsg)
+	pm, err := f.getHash(ctx, id, datastore.POETDB, f.validators.poet.ValidateAndStoreMsg)
 	if err != nil {
 		return err
 	}

--- a/fetch/mesh_data_test.go
+++ b/fetch/mesh_data_test.go
@@ -188,7 +188,7 @@ func TestFetch_getHashes(t *testing.T) {
 					return nil
 				}).Times(len(peers))
 
-			got := f.getHashes(context.TODO(), hashes, datastore.BlockDB, f.blockHandler.HandleSyncedBlock)
+			got := f.getHashes(context.TODO(), hashes, datastore.BlockDB, f.validators.block.HandleSyncedBlock)
 			if len(tc.fetchErrs) > 0 || tc.hdlrErr != nil {
 				require.NotEmpty(t, got)
 			} else {

--- a/fetch/mocks/mocks.go
+++ b/fetch/mocks/mocks.go
@@ -50,31 +50,31 @@ func (mr *MockrequesterMockRecorder) Request(arg0, arg1, arg2, arg3, arg4 interf
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Request", reflect.TypeOf((*Mockrequester)(nil).Request), arg0, arg1, arg2, arg3, arg4)
 }
 
-// MockmalfeasanceHandler is a mock of malfeasanceHandler interface.
-type MockmalfeasanceHandler struct {
+// MockMalfeasanceValidator is a mock of MalfeasanceValidator interface.
+type MockMalfeasanceValidator struct {
 	ctrl     *gomock.Controller
-	recorder *MockmalfeasanceHandlerMockRecorder
+	recorder *MockMalfeasanceValidatorMockRecorder
 }
 
-// MockmalfeasanceHandlerMockRecorder is the mock recorder for MockmalfeasanceHandler.
-type MockmalfeasanceHandlerMockRecorder struct {
-	mock *MockmalfeasanceHandler
+// MockMalfeasanceValidatorMockRecorder is the mock recorder for MockMalfeasanceValidator.
+type MockMalfeasanceValidatorMockRecorder struct {
+	mock *MockMalfeasanceValidator
 }
 
-// NewMockmalfeasanceHandler creates a new mock instance.
-func NewMockmalfeasanceHandler(ctrl *gomock.Controller) *MockmalfeasanceHandler {
-	mock := &MockmalfeasanceHandler{ctrl: ctrl}
-	mock.recorder = &MockmalfeasanceHandlerMockRecorder{mock}
+// NewMockMalfeasanceValidator creates a new mock instance.
+func NewMockMalfeasanceValidator(ctrl *gomock.Controller) *MockMalfeasanceValidator {
+	mock := &MockMalfeasanceValidator{ctrl: ctrl}
+	mock.recorder = &MockMalfeasanceValidatorMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockmalfeasanceHandler) EXPECT() *MockmalfeasanceHandlerMockRecorder {
+func (m *MockMalfeasanceValidator) EXPECT() *MockMalfeasanceValidatorMockRecorder {
 	return m.recorder
 }
 
 // HandleSyncedMalfeasanceProof mocks base method.
-func (m *MockmalfeasanceHandler) HandleSyncedMalfeasanceProof(arg0 context.Context, arg1 p2p.Peer, arg2 []byte) error {
+func (m *MockMalfeasanceValidator) HandleSyncedMalfeasanceProof(arg0 context.Context, arg1 p2p.Peer, arg2 []byte) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HandleSyncedMalfeasanceProof", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -82,36 +82,36 @@ func (m *MockmalfeasanceHandler) HandleSyncedMalfeasanceProof(arg0 context.Conte
 }
 
 // HandleSyncedMalfeasanceProof indicates an expected call of HandleSyncedMalfeasanceProof.
-func (mr *MockmalfeasanceHandlerMockRecorder) HandleSyncedMalfeasanceProof(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockMalfeasanceValidatorMockRecorder) HandleSyncedMalfeasanceProof(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleSyncedMalfeasanceProof", reflect.TypeOf((*MockmalfeasanceHandler)(nil).HandleSyncedMalfeasanceProof), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleSyncedMalfeasanceProof", reflect.TypeOf((*MockMalfeasanceValidator)(nil).HandleSyncedMalfeasanceProof), arg0, arg1, arg2)
 }
 
-// MockatxHandler is a mock of atxHandler interface.
-type MockatxHandler struct {
+// MockAtxValidator is a mock of AtxValidator interface.
+type MockAtxValidator struct {
 	ctrl     *gomock.Controller
-	recorder *MockatxHandlerMockRecorder
+	recorder *MockAtxValidatorMockRecorder
 }
 
-// MockatxHandlerMockRecorder is the mock recorder for MockatxHandler.
-type MockatxHandlerMockRecorder struct {
-	mock *MockatxHandler
+// MockAtxValidatorMockRecorder is the mock recorder for MockAtxValidator.
+type MockAtxValidatorMockRecorder struct {
+	mock *MockAtxValidator
 }
 
-// NewMockatxHandler creates a new mock instance.
-func NewMockatxHandler(ctrl *gomock.Controller) *MockatxHandler {
-	mock := &MockatxHandler{ctrl: ctrl}
-	mock.recorder = &MockatxHandlerMockRecorder{mock}
+// NewMockAtxValidator creates a new mock instance.
+func NewMockAtxValidator(ctrl *gomock.Controller) *MockAtxValidator {
+	mock := &MockAtxValidator{ctrl: ctrl}
+	mock.recorder = &MockAtxValidatorMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockatxHandler) EXPECT() *MockatxHandlerMockRecorder {
+func (m *MockAtxValidator) EXPECT() *MockAtxValidatorMockRecorder {
 	return m.recorder
 }
 
 // HandleAtxData mocks base method.
-func (m *MockatxHandler) HandleAtxData(arg0 context.Context, arg1 p2p.Peer, arg2 []byte) error {
+func (m *MockAtxValidator) HandleAtxData(arg0 context.Context, arg1 p2p.Peer, arg2 []byte) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HandleAtxData", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -119,36 +119,36 @@ func (m *MockatxHandler) HandleAtxData(arg0 context.Context, arg1 p2p.Peer, arg2
 }
 
 // HandleAtxData indicates an expected call of HandleAtxData.
-func (mr *MockatxHandlerMockRecorder) HandleAtxData(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockAtxValidatorMockRecorder) HandleAtxData(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleAtxData", reflect.TypeOf((*MockatxHandler)(nil).HandleAtxData), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleAtxData", reflect.TypeOf((*MockAtxValidator)(nil).HandleAtxData), arg0, arg1, arg2)
 }
 
-// MockblockHandler is a mock of blockHandler interface.
-type MockblockHandler struct {
+// MockBlockValidator is a mock of BlockValidator interface.
+type MockBlockValidator struct {
 	ctrl     *gomock.Controller
-	recorder *MockblockHandlerMockRecorder
+	recorder *MockBlockValidatorMockRecorder
 }
 
-// MockblockHandlerMockRecorder is the mock recorder for MockblockHandler.
-type MockblockHandlerMockRecorder struct {
-	mock *MockblockHandler
+// MockBlockValidatorMockRecorder is the mock recorder for MockBlockValidator.
+type MockBlockValidatorMockRecorder struct {
+	mock *MockBlockValidator
 }
 
-// NewMockblockHandler creates a new mock instance.
-func NewMockblockHandler(ctrl *gomock.Controller) *MockblockHandler {
-	mock := &MockblockHandler{ctrl: ctrl}
-	mock.recorder = &MockblockHandlerMockRecorder{mock}
+// NewMockBlockValidator creates a new mock instance.
+func NewMockBlockValidator(ctrl *gomock.Controller) *MockBlockValidator {
+	mock := &MockBlockValidator{ctrl: ctrl}
+	mock.recorder = &MockBlockValidatorMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockblockHandler) EXPECT() *MockblockHandlerMockRecorder {
+func (m *MockBlockValidator) EXPECT() *MockBlockValidatorMockRecorder {
 	return m.recorder
 }
 
 // HandleSyncedBlock mocks base method.
-func (m *MockblockHandler) HandleSyncedBlock(arg0 context.Context, arg1 p2p.Peer, arg2 []byte) error {
+func (m *MockBlockValidator) HandleSyncedBlock(arg0 context.Context, arg1 p2p.Peer, arg2 []byte) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HandleSyncedBlock", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -156,36 +156,36 @@ func (m *MockblockHandler) HandleSyncedBlock(arg0 context.Context, arg1 p2p.Peer
 }
 
 // HandleSyncedBlock indicates an expected call of HandleSyncedBlock.
-func (mr *MockblockHandlerMockRecorder) HandleSyncedBlock(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockBlockValidatorMockRecorder) HandleSyncedBlock(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleSyncedBlock", reflect.TypeOf((*MockblockHandler)(nil).HandleSyncedBlock), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleSyncedBlock", reflect.TypeOf((*MockBlockValidator)(nil).HandleSyncedBlock), arg0, arg1, arg2)
 }
 
-// MockballotHandler is a mock of ballotHandler interface.
-type MockballotHandler struct {
+// MockBallotValidator is a mock of BallotValidator interface.
+type MockBallotValidator struct {
 	ctrl     *gomock.Controller
-	recorder *MockballotHandlerMockRecorder
+	recorder *MockBallotValidatorMockRecorder
 }
 
-// MockballotHandlerMockRecorder is the mock recorder for MockballotHandler.
-type MockballotHandlerMockRecorder struct {
-	mock *MockballotHandler
+// MockBallotValidatorMockRecorder is the mock recorder for MockBallotValidator.
+type MockBallotValidatorMockRecorder struct {
+	mock *MockBallotValidator
 }
 
-// NewMockballotHandler creates a new mock instance.
-func NewMockballotHandler(ctrl *gomock.Controller) *MockballotHandler {
-	mock := &MockballotHandler{ctrl: ctrl}
-	mock.recorder = &MockballotHandlerMockRecorder{mock}
+// NewMockBallotValidator creates a new mock instance.
+func NewMockBallotValidator(ctrl *gomock.Controller) *MockBallotValidator {
+	mock := &MockBallotValidator{ctrl: ctrl}
+	mock.recorder = &MockBallotValidatorMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockballotHandler) EXPECT() *MockballotHandlerMockRecorder {
+func (m *MockBallotValidator) EXPECT() *MockBallotValidatorMockRecorder {
 	return m.recorder
 }
 
 // HandleSyncedBallot mocks base method.
-func (m *MockballotHandler) HandleSyncedBallot(arg0 context.Context, arg1 p2p.Peer, arg2 []byte) error {
+func (m *MockBallotValidator) HandleSyncedBallot(arg0 context.Context, arg1 p2p.Peer, arg2 []byte) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HandleSyncedBallot", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -193,36 +193,36 @@ func (m *MockballotHandler) HandleSyncedBallot(arg0 context.Context, arg1 p2p.Pe
 }
 
 // HandleSyncedBallot indicates an expected call of HandleSyncedBallot.
-func (mr *MockballotHandlerMockRecorder) HandleSyncedBallot(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockBallotValidatorMockRecorder) HandleSyncedBallot(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleSyncedBallot", reflect.TypeOf((*MockballotHandler)(nil).HandleSyncedBallot), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleSyncedBallot", reflect.TypeOf((*MockBallotValidator)(nil).HandleSyncedBallot), arg0, arg1, arg2)
 }
 
-// MockproposalHandler is a mock of proposalHandler interface.
-type MockproposalHandler struct {
+// MockProposalValidator is a mock of ProposalValidator interface.
+type MockProposalValidator struct {
 	ctrl     *gomock.Controller
-	recorder *MockproposalHandlerMockRecorder
+	recorder *MockProposalValidatorMockRecorder
 }
 
-// MockproposalHandlerMockRecorder is the mock recorder for MockproposalHandler.
-type MockproposalHandlerMockRecorder struct {
-	mock *MockproposalHandler
+// MockProposalValidatorMockRecorder is the mock recorder for MockProposalValidator.
+type MockProposalValidatorMockRecorder struct {
+	mock *MockProposalValidator
 }
 
-// NewMockproposalHandler creates a new mock instance.
-func NewMockproposalHandler(ctrl *gomock.Controller) *MockproposalHandler {
-	mock := &MockproposalHandler{ctrl: ctrl}
-	mock.recorder = &MockproposalHandlerMockRecorder{mock}
+// NewMockProposalValidator creates a new mock instance.
+func NewMockProposalValidator(ctrl *gomock.Controller) *MockProposalValidator {
+	mock := &MockProposalValidator{ctrl: ctrl}
+	mock.recorder = &MockProposalValidatorMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockproposalHandler) EXPECT() *MockproposalHandlerMockRecorder {
+func (m *MockProposalValidator) EXPECT() *MockProposalValidatorMockRecorder {
 	return m.recorder
 }
 
 // HandleSyncedProposal mocks base method.
-func (m *MockproposalHandler) HandleSyncedProposal(arg0 context.Context, arg1 p2p.Peer, arg2 []byte) error {
+func (m *MockProposalValidator) HandleSyncedProposal(arg0 context.Context, arg1 p2p.Peer, arg2 []byte) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HandleSyncedProposal", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -230,36 +230,36 @@ func (m *MockproposalHandler) HandleSyncedProposal(arg0 context.Context, arg1 p2
 }
 
 // HandleSyncedProposal indicates an expected call of HandleSyncedProposal.
-func (mr *MockproposalHandlerMockRecorder) HandleSyncedProposal(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockProposalValidatorMockRecorder) HandleSyncedProposal(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleSyncedProposal", reflect.TypeOf((*MockproposalHandler)(nil).HandleSyncedProposal), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleSyncedProposal", reflect.TypeOf((*MockProposalValidator)(nil).HandleSyncedProposal), arg0, arg1, arg2)
 }
 
-// MocktxHandler is a mock of txHandler interface.
-type MocktxHandler struct {
+// MockTxValidator is a mock of TxValidator interface.
+type MockTxValidator struct {
 	ctrl     *gomock.Controller
-	recorder *MocktxHandlerMockRecorder
+	recorder *MockTxValidatorMockRecorder
 }
 
-// MocktxHandlerMockRecorder is the mock recorder for MocktxHandler.
-type MocktxHandlerMockRecorder struct {
-	mock *MocktxHandler
+// MockTxValidatorMockRecorder is the mock recorder for MockTxValidator.
+type MockTxValidatorMockRecorder struct {
+	mock *MockTxValidator
 }
 
-// NewMocktxHandler creates a new mock instance.
-func NewMocktxHandler(ctrl *gomock.Controller) *MocktxHandler {
-	mock := &MocktxHandler{ctrl: ctrl}
-	mock.recorder = &MocktxHandlerMockRecorder{mock}
+// NewMockTxValidator creates a new mock instance.
+func NewMockTxValidator(ctrl *gomock.Controller) *MockTxValidator {
+	mock := &MockTxValidator{ctrl: ctrl}
+	mock.recorder = &MockTxValidatorMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MocktxHandler) EXPECT() *MocktxHandlerMockRecorder {
+func (m *MockTxValidator) EXPECT() *MockTxValidatorMockRecorder {
 	return m.recorder
 }
 
 // HandleBlockTransaction mocks base method.
-func (m *MocktxHandler) HandleBlockTransaction(arg0 context.Context, arg1 p2p.Peer, arg2 []byte) error {
+func (m *MockTxValidator) HandleBlockTransaction(arg0 context.Context, arg1 p2p.Peer, arg2 []byte) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HandleBlockTransaction", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -267,13 +267,13 @@ func (m *MocktxHandler) HandleBlockTransaction(arg0 context.Context, arg1 p2p.Pe
 }
 
 // HandleBlockTransaction indicates an expected call of HandleBlockTransaction.
-func (mr *MocktxHandlerMockRecorder) HandleBlockTransaction(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockTxValidatorMockRecorder) HandleBlockTransaction(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleBlockTransaction", reflect.TypeOf((*MocktxHandler)(nil).HandleBlockTransaction), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleBlockTransaction", reflect.TypeOf((*MockTxValidator)(nil).HandleBlockTransaction), arg0, arg1, arg2)
 }
 
 // HandleProposalTransaction mocks base method.
-func (m *MocktxHandler) HandleProposalTransaction(arg0 context.Context, arg1 p2p.Peer, arg2 []byte) error {
+func (m *MockTxValidator) HandleProposalTransaction(arg0 context.Context, arg1 p2p.Peer, arg2 []byte) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HandleProposalTransaction", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -281,36 +281,36 @@ func (m *MocktxHandler) HandleProposalTransaction(arg0 context.Context, arg1 p2p
 }
 
 // HandleProposalTransaction indicates an expected call of HandleProposalTransaction.
-func (mr *MocktxHandlerMockRecorder) HandleProposalTransaction(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockTxValidatorMockRecorder) HandleProposalTransaction(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleProposalTransaction", reflect.TypeOf((*MocktxHandler)(nil).HandleProposalTransaction), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleProposalTransaction", reflect.TypeOf((*MockTxValidator)(nil).HandleProposalTransaction), arg0, arg1, arg2)
 }
 
-// MockpoetHandler is a mock of poetHandler interface.
-type MockpoetHandler struct {
+// MockPoetValidator is a mock of PoetValidator interface.
+type MockPoetValidator struct {
 	ctrl     *gomock.Controller
-	recorder *MockpoetHandlerMockRecorder
+	recorder *MockPoetValidatorMockRecorder
 }
 
-// MockpoetHandlerMockRecorder is the mock recorder for MockpoetHandler.
-type MockpoetHandlerMockRecorder struct {
-	mock *MockpoetHandler
+// MockPoetValidatorMockRecorder is the mock recorder for MockPoetValidator.
+type MockPoetValidatorMockRecorder struct {
+	mock *MockPoetValidator
 }
 
-// NewMockpoetHandler creates a new mock instance.
-func NewMockpoetHandler(ctrl *gomock.Controller) *MockpoetHandler {
-	mock := &MockpoetHandler{ctrl: ctrl}
-	mock.recorder = &MockpoetHandlerMockRecorder{mock}
+// NewMockPoetValidator creates a new mock instance.
+func NewMockPoetValidator(ctrl *gomock.Controller) *MockPoetValidator {
+	mock := &MockPoetValidator{ctrl: ctrl}
+	mock.recorder = &MockPoetValidatorMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockpoetHandler) EXPECT() *MockpoetHandlerMockRecorder {
+func (m *MockPoetValidator) EXPECT() *MockPoetValidatorMockRecorder {
 	return m.recorder
 }
 
 // ValidateAndStoreMsg mocks base method.
-func (m *MockpoetHandler) ValidateAndStoreMsg(arg0 context.Context, arg1 p2p.Peer, arg2 []byte) error {
+func (m *MockPoetValidator) ValidateAndStoreMsg(arg0 context.Context, arg1 p2p.Peer, arg2 []byte) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ValidateAndStoreMsg", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -318,9 +318,9 @@ func (m *MockpoetHandler) ValidateAndStoreMsg(arg0 context.Context, arg1 p2p.Pee
 }
 
 // ValidateAndStoreMsg indicates an expected call of ValidateAndStoreMsg.
-func (mr *MockpoetHandlerMockRecorder) ValidateAndStoreMsg(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockPoetValidatorMockRecorder) ValidateAndStoreMsg(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateAndStoreMsg", reflect.TypeOf((*MockpoetHandler)(nil).ValidateAndStoreMsg), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateAndStoreMsg", reflect.TypeOf((*MockPoetValidator)(nil).ValidateAndStoreMsg), arg0, arg1, arg2)
 }
 
 // MockmeshProvider is a mock of meshProvider interface.

--- a/syncer/data_fetch.go
+++ b/syncer/data_fetch.go
@@ -267,7 +267,7 @@ func fetchMalfeasanceProof(ctx context.Context, logger log.Log, ids idProvider, 
 		}
 	}
 	if len(idsToFetch) > 0 {
-		logger.With().Debug("fetching malfeasance proofs", log.Int("to_fetch", len(idsToFetch)))
+		logger.With().Info("fetching malfeasance proofs", log.Int("to_fetch", len(idsToFetch)))
 		if err := fetcher.GetMalfeasanceProofs(ctx, idsToFetch); err != nil {
 			logger.With().Warning("failed fetching malfeasance proofs",
 				log.Array("malicious_ids", log.ArrayMarshalerFunc(func(encoder log.ArrayEncoder) error {


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
fixing user report https://github.com/spacemeshos/smapp/issues/1168

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x0 addr=0x0 pc=0x7ff6b92b40e2]

goroutine 328 [running]:
github.com/spacemeshos/go-spacemesh/fetch.(*Fetch).GetMalfeasanceProofs(0xc002206000, {0x7ff6ba040f18, 0xc003a88ab0}, {0xc0031ca100, 0x1, 0xc00058f168?})
	D:/a/go-spacemesh/go-spacemesh/fetch/mesh_data.go:72 +0x302
github.com/spacemeshos/go-spacemesh/syncer.fetchMalfeasanceProof({0x7ff6ba040f18, 0xc003a88ab0}, {0xc0022b4a80?, {0x7ff6b9b92e2f?, 0x0?}}, {0x7ff6ba030880?, 0xc0017aea40?}, {0x7ff6ba04c2b0, 0xc002206000}, 0xc003eb43c0, ...)
	D:/a/go-spacemesh/go-spacemesh/syncer/data_fetch.go:271 +0x222
github.com/spacemeshos/go-spacemesh/syncer.(*DataFetch).PollMaliciousProofs(0xc0017a5770, {0x7ff6ba040f18?, 0xc003a88ab0})
	D:/a/go-spacemesh/go-spacemesh/syncer/data_fetch.go:106 +0x53e
github.com/spacemeshos/go-spacemesh/syncer.(*Syncer).syncMalfeasance(0xc0038dec40?, {0x7ff6ba040f18?, 0xc003a88ab0?})
	D:/a/go-spacemesh/go-spacemesh/syncer/syncer.go:497 +0x32
github.com/spacemeshos/go-spacemesh/syncer.(*Syncer).synchronize.func1()
	D:/a/go-spacemesh/go-spacemesh/syncer/syncer.go:384 +0x329
github.com/spacemeshos/go-spacemesh/syncer.(*Syncer).synchronize(0xc002206180, {0x7ff6ba0425d8?, 0xc001628140?})
	D:/a/go-spacemesh/go-spacemesh/syncer/syncer.go:422 +0xa13
github.com/spacemeshos/go-spacemesh/syncer.(*Syncer).Start.func1.1()
	D:/a/go-spacemesh/go-spacemesh/syncer/syncer.go:242 +0x107
golang.org/x/sync/errgroup.(*Group).Go.func1()
	C:/Users/runneradmin/go/pkg/mod/golang.org/x/sync@v0.1.0/errgroup/errgroup.go:75 +0x64
created by golang.org/x/sync/errgroup.(*Group).Go
	C:/Users/runneradmin/go/pkg/mod/golang.org/x/sync@v0.1.0/errgroup/errgroup.go:72 +0xa5
```

## Changes
- initialize data validator for malfeasance proof in fetcher
- due to dependency mess in node.go, data validators can only be added when all handlers are initialized. as a result, a check for validators is added in `fetcher.Start()`

see https://github.com/spacemeshos/go-spacemesh/issues/4091 for adding tests.