### PR TITLE
[Merged by Bors] - Bump poet to v0.6.4

### DIFF
--- a/activation/nipost_test.go
+++ b/activation/nipost_test.go
@@ -184,6 +184,7 @@ func TestPostSetup(t *testing.T) {
 }
 
 func TestNIPostBuilderWithClients(t *testing.T) {
+	t.Parallel()
 	logtest.SetupGlobal(t)
 	r := require.New(t)
 
@@ -289,6 +290,7 @@ func TestNewNIPostBuilderNotInitialized(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
+	t.Parallel()
 
 	r := require.New(t)
 
@@ -558,6 +560,7 @@ func TestNIPostBuilder_ManyPoETs_AllFinished(t *testing.T) {
 }
 
 func TestNIPostBuilder_Close(t *testing.T) {
+	t.Parallel()
 	r := require.New(t)
 
 	postProvider := &postSetupProviderMock{}

--- a/activation/poet.go
+++ b/activation/poet.go
@@ -70,6 +70,7 @@ func NewHTTPPoetHarness(ctx context.Context, poetdir string, opts ...HTTPPoetOpt
 	cfg := config.DefaultConfig()
 	cfg.PoetDir = poetdir
 	cfg.RawRESTListener = "localhost:0"
+	cfg.RawRPCListener = "localhost:0"
 
 	for _, opt := range opts {
 		opt(cfg)

--- a/activation/poet.go
+++ b/activation/poet.go
@@ -69,6 +69,7 @@ func WithCycleGap(gap time.Duration) HTTPPoetOpt {
 func NewHTTPPoetHarness(ctx context.Context, poetdir string, opts ...HTTPPoetOpt) (*HTTPPoetHarness, error) {
 	cfg := config.DefaultConfig()
 	cfg.PoetDir = poetdir
+	cfg.RawRESTListener = "localhost:0"
 
 	for _, opt := range opts {
 		opt(cfg)
@@ -84,10 +85,8 @@ func NewHTTPPoetHarness(ctx context.Context, poetdir string, opts ...HTTPPoetOpt
 		return nil, err
 	}
 
-	// TODO: query for the REST address to allow dynamic port allocation.
-	// It needs changes in poet.
 	return &HTTPPoetHarness{
-		HTTPPoetClient: NewHTTPPoetClient(cfg.RawRESTListener, PoetConfig{
+		HTTPPoetClient: NewHTTPPoetClient(poet.GrpcRestProxyAddr().String(), PoetConfig{
 			PhaseShift: cfg.Service.PhaseShift,
 			CycleGap:   cfg.Service.CycleGap,
 		}),

--- a/activation/poet_test.go
+++ b/activation/poet_test.go
@@ -34,6 +34,7 @@ func TestHTTPPoet(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
+	t.Parallel()
 	r := require.New(t)
 
 	gtw := util.NewMockGrpcServer(t)

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/spacemeshos/fixed v0.0.0-20210523192743-8d17e03c169a
 	github.com/spacemeshos/go-scale v1.1.4
 	github.com/spacemeshos/merkle-tree v0.2.1
-	github.com/spacemeshos/poet v0.6.3
+	github.com/spacemeshos/poet v0.6.4
 	github.com/spacemeshos/post v0.4.0
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -569,8 +569,8 @@ github.com/spacemeshos/go-scale v1.1.4 h1:lvUUTX5ujFSkJ1If9CYCBegQI3q/qAZGPb+lYI
 github.com/spacemeshos/go-scale v1.1.4/go.mod h1:bZscMRJOaT9TpwaqU+ca/8GmMw71KC1CIfcSPSihiT0=
 github.com/spacemeshos/merkle-tree v0.2.1 h1:BSs/zt1n3ceZcpWdcqNFRvTeAWDlc0W+bql0XQH/Gz4=
 github.com/spacemeshos/merkle-tree v0.2.1/go.mod h1:IsrdlW6AHZ4HSi89H7G94ravFCMFZLGnm6To0tQ0SPY=
-github.com/spacemeshos/poet v0.6.3 h1:Kai9bFBlCJ9eWuVUtUzO5G8Slde8ZPWzKXH/z5ay410=
-github.com/spacemeshos/poet v0.6.3/go.mod h1:2RNuFVnvLaSwP6UlJepfAAC0tkMNVOoINVKgHObSzVg=
+github.com/spacemeshos/poet v0.6.4 h1:GV9m2HI465oEGoJgv0Q8oIiwJ2d6++fLMk4u8DiZ3X4=
+github.com/spacemeshos/poet v0.6.4/go.mod h1:9V1UQ2mHYg2sOHLVM2J80Ky+SMe3Qg+l9rvttGTg4so=
 github.com/spacemeshos/post v0.4.0 h1:qw50yYk1T1A0zU2D3pHsuXGXCBauILL+0c3/PFZnDjI=
 github.com/spacemeshos/post v0.4.0/go.mod h1:FqqFg8pfJ584ET4PFhZL0mNhYIeKcuSy56Nc74i30AA=
 github.com/spacemeshos/sha256-simd v0.1.0 h1:G7Mfu5RYdQiuE+wu4ZyJ7I0TI74uqLhFnKblEnSpjYI=


### PR DESCRIPTION
## Changes
- bumped poet to v0.6.4,
- use dynamic (random) port allocation for Poet's GRPC REST proxy to allow running tests with the poet in parallel.

