### PR TITLE
[Merged by Bors] - Update README running instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,17 @@ arguments._
 
 ### Running
 
+_Note: go-spacemesh relies on a gpu setup dynamic library in order to run.
+`make install` puts this file in the build folder, so if you are running
+spacemesh from the build folder you don't need to take any extra action.
+However if you have built the binary using `go build` or moved the binary from
+the build folder you need to ensure that you have the gpu setup dynamic library
+(the exact name will vary based on your OS) accessible by the go-spacemesh
+binary. The simplest way to do this is just copy the library file to be in the
+same directory as the go-spacemesh binary. Alternatively you can modify your
+system's library search paths (e.g. LD_LIBRARY_PATH) to ensure that the
+library is found._
+
 go-spacemesh is p2p software which is designed to form a decentralized network by connecting to other instances of go-spacemesh running on remote computers.
 
 To run go-spacemesh you need to specify the parameters shared between all instances on a specific network.


### PR DESCRIPTION
## Motivation
The readme instructions for running were missing any information regarding
go-spacemesh's dependency on the gpu setup dynamic library.

## Changes
Updated the readme to include instructions regarding handling the gpu setup library.

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
