### PR TITLE
TEST ONLY: add public key to hare messages

### DIFF
--- a/hare/algorithm.go
+++ b/hare/algorithm.go
@@ -549,6 +549,15 @@ func (proc *consensusProcess) sendMessage(ctx context.Context, msg *Msg) bool {
 		return false
 	}
 
+	pubKeyBytes := 32
+	if msg.InnerMsg.Svp != nil {
+		pubKeyBytes += 32 * len(msg.InnerMsg.Svp.Messages)
+	}
+	if msg.InnerMsg.Cert != nil && msg.InnerMsg.Cert.AggMsgs != nil {
+		pubKeyBytes += 32 * len(msg.InnerMsg.Cert.AggMsgs.Messages)
+	}
+	totalPubKeyOut.WithLabelValues().Add(float64(pubKeyBytes))
+
 	logger.Debug("should participate: message sent")
 	return true
 }

--- a/hare/broker.go
+++ b/hare/broker.go
@@ -153,6 +153,14 @@ func (b *Broker) handleMessage(ctx context.Context, msg []byte) error {
 	}
 
 	logger.Debug("broker received hare message")
+	pubKeyBytes := 32
+	if hareMsg.InnerMsg.Svp != nil {
+		pubKeyBytes += 32 * len(hareMsg.InnerMsg.Svp.Messages)
+	}
+	if hareMsg.InnerMsg.Cert != nil && hareMsg.InnerMsg.Cert.AggMsgs != nil {
+		pubKeyBytes += 32 * len(hareMsg.InnerMsg.Cert.AggMsgs.Messages)
+	}
+	totalPubKeyIn.WithLabelValues().Add(float64(pubKeyBytes))
 
 	msgLayer := hareMsg.Layer
 	if !b.Synced(ctx, msgLayer) {

--- a/hare/builder.go
+++ b/hare/builder.go
@@ -19,7 +19,7 @@ type Message struct {
 	Signature   []byte
 	InnerMsg    *InnerMessage
 	Eligibility types.HareEligibility
-	PublicKey   []byte
+	PublicKey   [32]byte
 }
 
 // MessageFromBuffer builds an Hare message from the provided bytes buffer.
@@ -133,7 +133,7 @@ func (mb *messageBuilder) SetCertificate(certificate *Certificate) *messageBuild
 // Sign calls the provided signer to calculate the signature and then set it accordingly.
 func (mb *messageBuilder) Sign(signing Signer) *messageBuilder {
 	mb.msg.Signature = signing.Sign(mb.msg.SignedBytes())
-	mb.msg.PublicKey = signing.PublicKey().PublicKey
+	copy(mb.msg.PublicKey[:], signing.PublicKey().PublicKey)
 	return mb
 }
 

--- a/hare/builder.go
+++ b/hare/builder.go
@@ -19,6 +19,7 @@ type Message struct {
 	Signature   []byte
 	InnerMsg    *InnerMessage
 	Eligibility types.HareEligibility
+	PublicKey   []byte
 }
 
 // MessageFromBuffer builds an Hare message from the provided bytes buffer.
@@ -132,6 +133,7 @@ func (mb *messageBuilder) SetCertificate(certificate *Certificate) *messageBuild
 // Sign calls the provided signer to calculate the signature and then set it accordingly.
 func (mb *messageBuilder) Sign(signing Signer) *messageBuilder {
 	mb.msg.Signature = signing.Sign(mb.msg.SignedBytes())
+	mb.msg.PublicKey = signing.PublicKey().PublicKey
 	return mb
 }
 

--- a/hare/builder_scale.go
+++ b/hare/builder_scale.go
@@ -38,7 +38,7 @@ func (t *Message) EncodeScale(enc *scale.Encoder) (total int, err error) {
 		total += n
 	}
 	{
-		n, err := scale.EncodeByteSlice(enc, t.PublicKey)
+		n, err := scale.EncodeByteArray(enc, t.PublicKey[:])
 		if err != nil {
 			return total, err
 		}
@@ -79,12 +79,11 @@ func (t *Message) DecodeScale(dec *scale.Decoder) (total int, err error) {
 		total += n
 	}
 	{
-		field, n, err := scale.DecodeByteSlice(dec)
+		n, err := scale.DecodeByteArray(dec, t.PublicKey[:])
 		if err != nil {
 			return total, err
 		}
 		total += n
-		t.PublicKey = field
 	}
 	return total, nil
 }

--- a/hare/builder_scale.go
+++ b/hare/builder_scale.go
@@ -37,6 +37,13 @@ func (t *Message) EncodeScale(enc *scale.Encoder) (total int, err error) {
 		}
 		total += n
 	}
+	{
+		n, err := scale.EncodeByteSlice(enc, t.PublicKey)
+		if err != nil {
+			return total, err
+		}
+		total += n
+	}
 	return total, nil
 }
 
@@ -70,6 +77,14 @@ func (t *Message) DecodeScale(dec *scale.Decoder) (total int, err error) {
 			return total, err
 		}
 		total += n
+	}
+	{
+		field, n, err := scale.DecodeByteSlice(dec)
+		if err != nil {
+			return total, err
+		}
+		total += n
+		t.PublicKey = field
 	}
 	return total, nil
 }

--- a/hare/metrics.go
+++ b/hare/metrics.go
@@ -15,6 +15,9 @@ const (
 )
 
 var (
+	totalPubKeyIn  = metrics.NewCounter("total_pubkey_send", namespace, "Total pubkey bytes sent", nil)
+	totalPubKeyOut = metrics.NewCounter("total_pubkey_recv", namespace, "Total pubkey bytes received", nil)
+
 	preNumProposals = metrics.NewCounter(
 		"in_proposals",
 		namespace,


### PR DESCRIPTION
## Motivation

- add public key to hare message to measure the effect of not using public key extraction
- add specific metrics to track the public key size