### PR TITLE
[Merged by Bors] - add max size for public keys in multisig spawn tx according to storage limits

### DIFF
--- a/genvm/templates/multisig/handler_test.go
+++ b/genvm/templates/multisig/handler_test.go
@@ -1,9 +1,11 @@
 package multisig
 
 import (
+	"bytes"
 	"strconv"
 	"testing"
 
+	"github.com/spacemeshos/go-scale"
 	"github.com/stretchr/testify/require"
 
 	"github.com/spacemeshos/go-spacemesh/genvm/core"
@@ -31,4 +33,17 @@ func TestKeysLimits(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDecodeMaxKeys(t *testing.T) {
+	keys := make([]core.PublicKey, 11)
+	buf := bytes.NewBuffer(nil)
+	enc := scale.NewEncoder(buf)
+	_, err := scale.EncodeStructSlice(enc, keys)
+	require.NoError(t, err)
+
+	args := SpawnArguments{}
+	dec := scale.NewDecoder(buf)
+	_, err = args.DecodeScale(dec)
+	require.ErrorContains(t, err, "11 > 10")
 }

--- a/genvm/templates/multisig/multisig.go
+++ b/genvm/templates/multisig/multisig.go
@@ -14,7 +14,7 @@ import (
 // MultiSig K/N template.
 type MultiSig struct {
 	k          uint8
-	PublicKeys []core.PublicKey
+	PublicKeys []core.PublicKey `scale:"max=10"`
 }
 
 // MaxSpend returns amount specified in the SpendArguments.

--- a/genvm/templates/multisig/multisig_scale.go
+++ b/genvm/templates/multisig/multisig_scale.go
@@ -10,7 +10,7 @@ import (
 
 func (t *MultiSig) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	{
-		n, err := scale.EncodeStructSlice(enc, t.PublicKeys)
+		n, err := scale.EncodeStructSliceWithLimit(enc, t.PublicKeys, 10)
 		if err != nil {
 			return total, err
 		}
@@ -21,7 +21,7 @@ func (t *MultiSig) EncodeScale(enc *scale.Encoder) (total int, err error) {
 
 func (t *MultiSig) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	{
-		field, n, err := scale.DecodeStructSlice[types.Hash32](dec)
+		field, n, err := scale.DecodeStructSliceWithLimit[types.Hash32](dec, 10)
 		if err != nil {
 			return total, err
 		}

--- a/genvm/templates/multisig/types.go
+++ b/genvm/templates/multisig/types.go
@@ -9,7 +9,7 @@ import (
 
 // SpawnArguments contains a collection with PublicKeys.
 type SpawnArguments struct {
-	PublicKeys []core.PublicKey
+	PublicKeys []core.PublicKey `scale:"max=10"` // update StorageLimit if it changes.
 }
 
 // Signatures is a collections of parts that must satisfy multisig

--- a/genvm/templates/multisig/types_scale.go
+++ b/genvm/templates/multisig/types_scale.go
@@ -10,7 +10,7 @@ import (
 
 func (t *SpawnArguments) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	{
-		n, err := scale.EncodeStructSlice(enc, t.PublicKeys)
+		n, err := scale.EncodeStructSliceWithLimit(enc, t.PublicKeys, 10)
 		if err != nil {
 			return total, err
 		}
@@ -21,7 +21,7 @@ func (t *SpawnArguments) EncodeScale(enc *scale.Encoder) (total int, err error) 
 
 func (t *SpawnArguments) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	{
-		field, n, err := scale.DecodeStructSlice[types.Hash32](dec)
+		field, n, err := scale.DecodeStructSliceWithLimit[types.Hash32](dec, 10)
 		if err != nil {
 			return total, err
 		}


### PR DESCRIPTION
related: https://github.com/spacemeshos/go-spacemesh/issues/4095

the only place in vm that requires dyn sized collection, more than 10 keys are not going to be supported.