### PR TITLE
[Merged by Bors] - systest: reduce ballot delay in systest for diff beacon

### DIFF
--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -525,7 +525,6 @@ func (app *App) initServices(
 
 	trtlCfg := app.Config.Tortoise
 	trtlCfg.LayerSize = layerSize
-	trtlCfg.BadBeaconVoteDelayLayers = app.Config.LayersPerEpoch
 	trtl := tortoise.New(app.cachedDB, beaconProtocol,
 		tortoise.WithContext(ctx),
 		tortoise.WithLogger(app.addLogger(TrtlLogger, lg)),

--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -525,6 +525,9 @@ func (app *App) initServices(
 
 	trtlCfg := app.Config.Tortoise
 	trtlCfg.LayerSize = layerSize
+	if trtlCfg.BadBeaconVoteDelayLayers == 0 {
+		trtlCfg.BadBeaconVoteDelayLayers = app.Config.LayersPerEpoch
+	}
 	trtl := tortoise.New(app.cachedDB, beaconProtocol,
 		tortoise.WithContext(ctx),
 		tortoise.WithLogger(app.addLogger(TrtlLogger, lg)),

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -178,7 +178,15 @@ func AddCommands(cmd *cobra.Command) {
 
 	/**======================== Tortoise Flags ========================== **/
 	cmd.PersistentFlags().Uint32Var(&cfg.Tortoise.Hdist, "tortoise-hdist",
-		cfg.Tortoise.Hdist, "hdist")
+		cfg.Tortoise.Hdist, "the distance for tortoise to vote according to hare output")
+	cmd.PersistentFlags().Uint32Var(&cfg.Tortoise.Zdist, "tortoise-zdist",
+		cfg.Tortoise.Zdist, "the distance for tortoise to wait for hare output")
+	cmd.PersistentFlags().Uint32Var(&cfg.Tortoise.WindowSize, "tortoise-window-size",
+		cfg.Tortoise.WindowSize, "size of the tortoise sliding window in layers")
+	cmd.PersistentFlags().IntVar(&cfg.Tortoise.MaxExceptions, "tortoise-max-exceptions",
+		cfg.Tortoise.MaxExceptions, "number of exceptions tolerated for a base ballot")
+	cmd.PersistentFlags().Uint32Var(&cfg.Tortoise.BadBeaconVoteDelayLayers, "tortoise-delay-layers",
+		cfg.Tortoise.BadBeaconVoteDelayLayers, "number of layers to ignore a ballot with a different beacon")
 
 	// TODO(moshababo): add usage desc
 

--- a/config/presets/fastnet.go
+++ b/config/presets/fastnet.go
@@ -46,6 +46,7 @@ func fastnet() config.Config {
 
 	conf.Tortoise.Hdist = 4
 	conf.Tortoise.Zdist = 2
+	conf.Tortoise.BadBeaconVoteDelayLayers = 2
 
 	conf.HareEligibility.ConfidenceParam = 2 // half epoch
 	conf.HareEligibility.EpochOffset = 0

--- a/config/presets/testnet.go
+++ b/config/presets/testnet.go
@@ -48,6 +48,10 @@ func testnet() config.Config {
 	conf.LayersPerEpoch = 60
 	conf.SyncRequestTimeout = 60_000
 
+	conf.Tortoise.Hdist = 60
+	conf.Tortoise.Zdist = 10
+	conf.Tortoise.BadBeaconVoteDelayLayers = 30
+
 	conf.POST.BitsPerLabel = 8
 	conf.POST.K1 = 200
 	conf.POST.K2 = 212

--- a/systest/tests/partition_test.go
+++ b/systest/tests/partition_test.go
@@ -22,7 +22,7 @@ func testPartition(t *testing.T, tctx *testcontext.Context, cl *cluster.Cluster,
 	var (
 		first      = uint32(layersPerEpoch * 2)
 		startSplit = uint32(4*layersPerEpoch) - 1
-		rejoin     = startSplit + 2*layersPerEpoch
+		rejoin     = startSplit + layersPerEpoch
 		last       = rejoin + (wait-1)*layersPerEpoch
 		stop       = rejoin + wait*layersPerEpoch
 	)

--- a/tortoise/algorithm.go
+++ b/tortoise/algorithm.go
@@ -21,10 +21,11 @@ type Config struct {
 	Zdist uint32 `mapstructure:"tortoise-zdist"` // hare result wait distance
 	// how long we are waiting for a switch from verifying to full. relevant during rerun.
 	WindowSize    uint32 `mapstructure:"tortoise-window-size"`    // size of the tortoise sliding window (in layers)
-	MaxExceptions int    `mapstructure:"tortoise-max-exceptions"` // if candidate for base block has more than max exceptions it will be ignored
+	MaxExceptions int    `mapstructure:"tortoise-max-exceptions"` // if candidate for base ballot has more than max exceptions it will be ignored
+	// number of layers to delay votes for blocks with bad beacon values during self-healing. ideally a full epoch.
+	BadBeaconVoteDelayLayers uint32 `mapstructure:"tortoise-delay-layers"`
 
-	LayerSize                uint32
-	BadBeaconVoteDelayLayers uint32 // number of layers to delay votes for blocks with bad beacon values during self-healing
+	LayerSize uint32
 }
 
 // DefaultConfig for Tortoise.

--- a/tortoise/algorithm.go
+++ b/tortoise/algorithm.go
@@ -35,7 +35,7 @@ func DefaultConfig() Config {
 		Hdist:                    10,
 		Zdist:                    8,
 		WindowSize:               1000,
-		BadBeaconVoteDelayLayers: 6,
+		BadBeaconVoteDelayLayers: 0,
 		MaxExceptions:            30 * 100, // 100 layers of average size
 	}
 }


### PR DESCRIPTION
## Motivation

related to #4112

speed up systest partition test recovery

- make the delay configurable with default value of 1 epoch if not set
- set value in the preset configs
- reduce the partition duration from 2 to 1 epoch in test