### PR TITLE
[Merged by Bors] - TestForkFinder: make constant layer hash for a given layer

### DIFF
--- a/syncer/find_fork.go
+++ b/syncer/find_fork.go
@@ -36,9 +36,9 @@ type boundary struct {
 
 func (b *boundary) MarshalLogObject(encoder log.ObjectEncoder) error {
 	encoder.AddUint32("from", b.from.layer.Uint32())
-	encoder.AddString("from_hash", b.from.hash.ShortString())
+	encoder.AddString("from_hash", b.from.hash.String())
 	encoder.AddUint32("to", b.to.layer.Uint32())
-	encoder.AddString("to_hash", b.to.hash.ShortString())
+	encoder.AddString("to_hash", b.to.hash.String())
 	return nil
 }
 

--- a/syncer/find_fork_test.go
+++ b/syncer/find_fork_test.go
@@ -2,6 +2,7 @@ package syncer_test
 
 import (
 	"context"
+	"encoding/binary"
 	"fmt"
 	"math/rand"
 	"strconv"
@@ -75,10 +76,16 @@ func TestForkFinder_Purge(t *testing.T) {
 }
 
 func layerHash(layer int, good bool) types.Hash32 {
+	var h2 types.Hash32
+	h := h2[:0]
 	if good {
-		return types.BytesToHash([]byte(strconv.Itoa(layer)))
+		h = append(h, "good/"...)
+		binary.LittleEndian.AppendUint32(h, uint32(layer))
+	} else {
+		h = append(h, "bad/"...)
+		binary.LittleEndian.AppendUint32(h, uint32(layer))
 	}
-	return types.BytesToHash([]byte(strconv.Itoa(2 * layer)))
+	return h2
 }
 
 func storeNodeHashes(t *testing.T, db *sql.Database, diverge, max int) {


### PR DESCRIPTION
## Motivation
attempt for #3781

## Changes
make each layer hash constant:
- peer hashes are Hash32 of "good/"+layerNum
- node hashes are Hash32 of "good/"+layerNum before the diverging layer, and Hash of "bad/"+layerNum at and after the diverging layer 