### PR TITLE
[Merged by Bors] - remove API to start syncing

### DIFF
--- a/api/grpcserver/grpcserver_test.go
+++ b/api/grpcserver/grpcserver_test.go
@@ -695,9 +695,8 @@ func TestNodeService(t *testing.T) {
 			require.Equal(t, false, syncer.startCalled, "Start() not yet called on syncer")
 			req := &pb.SyncStartRequest{}
 			res, err := c.SyncStart(context.Background(), req)
-			require.NoError(t, err)
-			require.Equal(t, int32(code.Code_OK), res.Status.Code)
-			require.Equal(t, true, syncer.startCalled, "Start() was called on syncer")
+			require.Nil(t, res)
+			require.ErrorIs(t, err, status.Errorf(codes.Unimplemented, "UNIMPLEMENTED"))
 		}},
 		{"Shutdown", func(t *testing.T) {
 			logtest.SetupGlobal(t)

--- a/api/grpcserver/node_service.go
+++ b/api/grpcserver/node_service.go
@@ -111,13 +111,11 @@ func (s NodeService) getLayers() (curLayer, latestLayer, verifiedLayer uint32) {
 
 // SyncStart requests that the node start syncing the mesh (if it isn't already syncing).
 func (s NodeService) SyncStart(context.Context, *pb.SyncStartRequest) (*pb.SyncStartResponse, error) {
-	log.Info("UNIMPLEMENTED GRPC NodeService.SyncStart")
 	return nil, status.Errorf(codes.Unimplemented, "UNIMPLEMENTED")
 }
 
 // Shutdown requests a graceful shutdown.
 func (s NodeService) Shutdown(context.Context, *pb.ShutdownRequest) (*pb.ShutdownResponse, error) {
-	log.Info("UNIMPLEMENTED GRPC NodeService.Shutdown")
 	return nil, status.Errorf(codes.Unimplemented, "UNIMPLEMENTED")
 }
 

--- a/api/grpcserver/node_service.go
+++ b/api/grpcserver/node_service.go
@@ -111,11 +111,8 @@ func (s NodeService) getLayers() (curLayer, latestLayer, verifiedLayer uint32) {
 
 // SyncStart requests that the node start syncing the mesh (if it isn't already syncing).
 func (s NodeService) SyncStart(context.Context, *pb.SyncStartRequest) (*pb.SyncStartResponse, error) {
-	log.Info("GRPC NodeService.SyncStart")
-	s.syncer.Start(s.appCtx)
-	return &pb.SyncStartResponse{
-		Status: &rpcstatus.Status{Code: int32(code.Code_OK)},
-	}, nil
+	log.Info("UNIMPLEMENTED GRPC NodeService.SyncStart")
+	return nil, status.Errorf(codes.Unimplemented, "UNIMPLEMENTED")
 }
 
 // Shutdown requests a graceful shutdown.


### PR DESCRIPTION
## Motivation
part of #4140

## Changes
don't allow API to start syncing when the node is not ready (state not loaded...etc)