### PR TITLE
[Merged by Bors] - Mitigate Test_multipleCPs.. timeout

### DIFF
--- a/hare/flows_test.go
+++ b/hare/flows_test.go
@@ -241,7 +241,7 @@ func Test_multipleCPs(t *testing.T) {
 	finalLyr := types.GetEffectiveGenesis().Add(totalCp)
 	test := newHareWrapper(totalCp)
 	totalNodes := 10
-	networkDelay := time.Second
+	networkDelay := time.Second * 4
 	cfg := config.Config{N: totalNodes, WakeupDelta: networkDelay, RoundDuration: networkDelay, ExpectedLeaders: 5, LimitIterations: 1000, LimitConcurrent: 100, Hdist: 20}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -350,7 +350,7 @@ func Test_multipleCPsAndIterations(t *testing.T) {
 	finalLyr := types.GetEffectiveGenesis().Add(totalCp)
 	test := newHareWrapper(totalCp)
 	totalNodes := 10
-	networkDelay := time.Second
+	networkDelay := time.Second * 4
 	cfg := config.Config{N: totalNodes, WakeupDelta: networkDelay, RoundDuration: networkDelay, ExpectedLeaders: 5, LimitIterations: 1000, LimitConcurrent: 100, Hdist: 20}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/hare/flows_test.go
+++ b/hare/flows_test.go
@@ -323,7 +323,7 @@ func Test_multipleCPs(t *testing.T) {
 		}
 	}()
 
-	// There are 5 rounds per layer and totoalCPs layers and we double for good measure.
+	// There are 5 rounds per layer and totalCPs layers and we double for good measure.
 	test.WaitForTimedTermination(t, 2*networkDelay*5*time.Duration(totalCp))
 	for _, h := range test.hare {
 		close(h.blockGenCh)
@@ -435,8 +435,10 @@ func Test_multipleCPsAndIterations(t *testing.T) {
 		}
 	}()
 
-	// There are 5 rounds per layer and totoalCPs layers and we double for good measure.
-	test.WaitForTimedTermination(t, 2*networkDelay*5*time.Duration(totalCp))
+	// There are 5 rounds per layer and totalCPs layers and we double to allow
+	// for the for good measure. Also one layer in this test will run 2
+	// iterations so we increase the layer count by 1.
+	test.WaitForTimedTermination(t, 2*networkDelay*5*time.Duration(totalCp+1))
 	for _, h := range test.hare {
 		close(h.blockGenCh)
 	}

--- a/hare/flows_test.go
+++ b/hare/flows_test.go
@@ -323,7 +323,8 @@ func Test_multipleCPs(t *testing.T) {
 		}
 	}()
 
-	test.WaitForTimedTermination(t, 80*time.Second)
+	// There are 5 rounds per layer and totoalCPs layers and we double for good measure.
+	test.WaitForTimedTermination(t, 2*networkDelay*5*time.Duration(totalCp))
 	for _, h := range test.hare {
 		close(h.blockGenCh)
 	}
@@ -434,7 +435,8 @@ func Test_multipleCPsAndIterations(t *testing.T) {
 		}
 	}()
 
-	test.WaitForTimedTermination(t, 100*time.Second)
+	// There are 5 rounds per layer and totoalCPs layers and we double for good measure.
+	test.WaitForTimedTermination(t, 2*networkDelay*5*time.Duration(totalCp))
 	for _, h := range test.hare {
 		close(h.blockGenCh)
 	}


### PR DESCRIPTION
## Motivation
The `Test_multipleCPs..` tests seem to be timing out on develop, I believe this is as a result of removing the `SharedRoundClock` in #4121.

## Changes
Increased the timeouts for these tests.

## Test Plan
See that CI passes

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
