### PR TITLE
hare activeset: employ ATX grading scheme

### DIFF
--- a/activation/handler.go
+++ b/activation/handler.go
@@ -392,7 +392,7 @@ func (h *Handler) storeAtx(ctx context.Context, atx *types.VerifiedActivationTx)
 				if err != nil {
 					h.log.With().Panic("failed to encode MalfeasanceProof", log.Err(err))
 				}
-				if err := identities.SetMalicious(dbtx, atx.SmesherID, encoded); err != nil {
+				if err := identities.SetMalicious(dbtx, atx.SmesherID, encoded, time.Now()); err != nil {
 					return fmt.Errorf("add malfeasance proof: %w", err)
 				}
 

--- a/activation/handler_test.go
+++ b/activation/handler_test.go
@@ -722,6 +722,8 @@ func TestHandler_ProcessAtx(t *testing.T) {
 	require.ErrorIs(t, atxHdlr.ProcessAtx(context.Background(), atx2), errMaliciousATX)
 	proof, err = identities.GetMalfeasanceProof(atxHdlr.cdb, sig.NodeID())
 	require.NoError(t, err)
+	require.NotNil(t, proof.Received())
+	proof.SetReceived(time.Time{})
 	require.Equal(t, got.MalfeasanceProof, *proof)
 	require.Equal(t, atx2.PublishEpoch.FirstLayer(), got.MalfeasanceProof.Layer)
 }

--- a/beacon/beacon.go
+++ b/beacon/beacon.go
@@ -546,7 +546,7 @@ func (pd *ProtocolDriver) initEpochStateIfNotPresent(logger log.Log, epoch types
 		ontime = pd.clock.LayerToTime(epoch.FirstLayer())
 		early  = ontime.Add(-1 * pd.config.GracePeriodDuration)
 	)
-	if err := pd.cdb.IterateEpochATXHeaders(epoch, func(header *types.ActivationTxHeader) bool {
+	if err := pd.cdb.IterateEpochATXHeaders(epoch, func(header *types.ActivationTxHeader) error {
 		epochWeight += header.GetWeight()
 		if _, ok := miners[header.NodeID]; !ok {
 			miners[header.NodeID] = header.ID
@@ -563,7 +563,7 @@ func (pd *ProtocolDriver) initEpochStateIfNotPresent(logger log.Log, epoch types
 		if header.NodeID == pd.nodeID {
 			active = true
 		}
-		return true
+		return nil
 	}); err != nil {
 		return nil, err
 	}

--- a/common/types/malfeasance.go
+++ b/common/types/malfeasance.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"errors"
+	"time"
 
 	"github.com/spacemeshos/go-scale"
 
@@ -21,6 +22,16 @@ type MalfeasanceProof struct {
 	// for network upgrade
 	Layer LayerID
 	Proof Proof
+
+	received time.Time
+}
+
+func (mp *MalfeasanceProof) Received() time.Time {
+	return mp.received
+}
+
+func (mp *MalfeasanceProof) SetReceived(received time.Time) {
+	mp.received = received
 }
 
 func (mp *MalfeasanceProof) MarshalLogObject(encoder log.ObjectEncoder) error {
@@ -53,7 +64,7 @@ func (mp *MalfeasanceProof) MarshalLogObject(encoder log.ObjectEncoder) error {
 	default:
 		encoder.AddString("type", "unknown")
 	}
-
+	encoder.AddTime("received", mp.received)
 	return nil
 }
 

--- a/datastore/interface.go
+++ b/datastore/interface.go
@@ -1,6 +1,0 @@
-package datastore
-
-// Getter wraps the database read operation.
-type Getter interface {
-	Get(Hint, []byte) ([]byte, error)
-}

--- a/datastore/store.go
+++ b/datastore/store.go
@@ -124,7 +124,7 @@ func (db *CachedDB) GetMalfeasanceProof(id types.NodeID) (*types.MalfeasanceProo
 
 func (db *CachedDB) CacheMalfeasanceProof(id types.NodeID, proof *types.MalfeasanceProof) {
 	if id == types.EmptyNodeID {
-		log.Fatal("invalid argument to AddMalfeasanceProof")
+		log.Fatal("invalid argument to CacheMalfeasanceProof")
 	}
 
 	db.mu.Lock()

--- a/datastore/store.go
+++ b/datastore/store.go
@@ -200,10 +200,10 @@ func (db *CachedDB) GetEpochWeight(epoch types.EpochID) (uint64, []types.ATXID, 
 		weight uint64
 		ids    []types.ATXID
 	)
-	if err := db.IterateEpochATXHeaders(epoch, func(header *types.ActivationTxHeader) bool {
+	if err := db.IterateEpochATXHeaders(epoch, func(header *types.ActivationTxHeader) error {
 		weight += header.GetWeight()
 		ids = append(ids, header.ID)
-		return true
+		return nil
 	}); err != nil {
 		return 0, nil, err
 	}
@@ -211,7 +211,7 @@ func (db *CachedDB) GetEpochWeight(epoch types.EpochID) (uint64, []types.ATXID, 
 }
 
 // IterateEpochATXHeaders iterates over ActivationTxs that target an epoch.
-func (db *CachedDB) IterateEpochATXHeaders(epoch types.EpochID, iter func(*types.ActivationTxHeader) bool) error {
+func (db *CachedDB) IterateEpochATXHeaders(epoch types.EpochID, iter func(*types.ActivationTxHeader) error) error {
 	ids, err := atxs.GetIDsByEpoch(db, epoch-1)
 	if err != nil {
 		return err
@@ -221,8 +221,8 @@ func (db *CachedDB) IterateEpochATXHeaders(epoch types.EpochID, iter func(*types
 		if err != nil {
 			return err
 		}
-		if !iter(header) {
-			return nil
+		if err := iter(header); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/datastore/store.go
+++ b/datastore/store.go
@@ -239,7 +239,7 @@ func (db *CachedDB) GetLastAtx(nodeID types.NodeID) (*types.ActivationTxHeader, 
 	}
 }
 
-// GetEpochAtx gets the atx header of specified node ID in the specified epoch.
+// GetEpochAtx gets the atx header of specified node ID published in the specified epoch.
 func (db *CachedDB) GetEpochAtx(epoch types.EpochID, nodeID types.NodeID) (*types.ActivationTxHeader, error) {
 	vatx, err := atxs.GetByEpochAndNodeID(db, epoch, nodeID)
 	if err != nil {

--- a/datastore/store_test.go
+++ b/datastore/store_test.go
@@ -43,7 +43,7 @@ func TestMalfeasanceProof_Honest(t *testing.T) {
 	require.Equal(t, 1, cdb.MalfeasanceCacheSize())
 
 	// secretly save the proof to database
-	require.NoError(t, identities.SetMalicious(db, nodeID1, []byte("bad")))
+	require.NoError(t, identities.SetMalicious(db, nodeID1, []byte("bad"), time.Now()))
 	bad, err := identities.IsMalicious(db, nodeID1)
 	require.NoError(t, err)
 	require.True(t, bad)
@@ -66,7 +66,7 @@ func TestMalfeasanceProof_Honest(t *testing.T) {
 	require.Equal(t, 2, cdb.MalfeasanceCacheSize())
 
 	// secretly save the proof to database
-	require.NoError(t, identities.SetMalicious(db, nodeID2, []byte("bad")))
+	require.NoError(t, identities.SetMalicious(db, nodeID2, []byte("bad"), time.Now()))
 	bad, err = identities.IsMalicious(db, nodeID2)
 	require.NoError(t, err)
 	require.True(t, bad)
@@ -374,7 +374,7 @@ func TestBlobStore_GetMalfeasanceBlob(t *testing.T) {
 
 	_, err = bs.Get(datastore.Malfeasance, nodeID.Bytes())
 	require.ErrorIs(t, err, sql.ErrNotFound)
-	require.NoError(t, identities.SetMalicious(db, nodeID, encoded))
+	require.NoError(t, identities.SetMalicious(db, nodeID, encoded, time.Now()))
 	got, err := bs.Get(datastore.Malfeasance, nodeID.Bytes())
 	require.NoError(t, err)
 	require.Equal(t, encoded, got)

--- a/fetch/handler_test.go
+++ b/fetch/handler_test.go
@@ -324,7 +324,7 @@ func TestHandleMaliciousIDsReq(t *testing.T) {
 			for i := 0; i < tc.numBad; i++ {
 				nid := types.NodeID{byte(i + 1)}
 				bad = append(bad, nid)
-				require.NoError(t, identities.SetMalicious(th.cdb, nid, types.RandomBytes(11)))
+				require.NoError(t, identities.SetMalicious(th.cdb, nid, types.RandomBytes(11), time.Now()))
 			}
 
 			out, err := th.handleMaliciousIDsReq(context.TODO(), []byte{})

--- a/hare/flows_test.go
+++ b/hare/flows_test.go
@@ -258,10 +258,7 @@ func Test_multipleCPs(t *testing.T) {
 	pList := make(map[types.LayerID][]*types.Proposal)
 	for j := types.GetEffectiveGenesis().Add(1); !j.After(finalLyr); j = j.Add(1) {
 		for i := uint64(0); i < 20; i++ {
-			p := genLayerProposal(j, []types.TransactionID{})
-			p.EpochData = &types.EpochData{
-				Beacon: types.EmptyBeacon,
-			}
+			p := randomProposal(j, types.EmptyBeacon)
 			pList[j] = append(pList[j], p)
 		}
 	}
@@ -378,10 +375,7 @@ func Test_multipleCPsAndIterations(t *testing.T) {
 	pList := make(map[types.LayerID][]*types.Proposal)
 	for j := types.GetEffectiveGenesis().Add(1); !j.After(finalLyr); j = j.Add(1) {
 		for i := uint64(0); i < 20; i++ {
-			p := genLayerProposal(j, []types.TransactionID{})
-			p.EpochData = &types.EpochData{
-				Beacon: types.EmptyBeacon,
-			}
+			p := randomProposal(j, types.EmptyBeacon)
 			pList[j] = append(pList[j], p)
 		}
 	}

--- a/hare/hare.go
+++ b/hare/hare.go
@@ -628,7 +628,7 @@ func (h *Hare) malfeasanceLoop(ctx context.Context) {
 			if err != nil {
 				h.WithContext(ctx).With().Panic("failed to encode MalfeasanceProof", log.Err(err))
 			}
-			if err := identities.SetMalicious(h.msh.Cache(), gossip.Eligibility.NodeID, encoded); err != nil {
+			if err := identities.SetMalicious(h.msh.Cache(), gossip.Eligibility.NodeID, encoded, time.Now()); err != nil {
 				h.With().Error("failed to save MalfeasanceProof",
 					log.Context(ctx),
 					gossip.Eligibility.NodeID,

--- a/hare/hare_rounds_test.go
+++ b/hare/hare_rounds_test.go
@@ -78,10 +78,11 @@ func runNodesFor(t *testing.T, ctx context.Context, nodes, leaders, maxLayers, l
 	mockMesh := mocks.NewMockmesh(gomock.NewController(t))
 	if createProposal {
 		for lid := types.GetEffectiveGenesis().Add(1); !lid.After(types.GetEffectiveGenesis().Add(uint32(maxLayers))); lid = lid.Add(1) {
-			p := genLayerProposal(lid, []types.TransactionID{})
+			p := randomProposal(lid, types.RandomBeacon())
 			mockMesh.EXPECT().Ballot(p.Ballot.ID()).Return(&p.Ballot, nil).AnyTimes()
 			mockMesh.EXPECT().Proposals(lid).Return([]*types.Proposal{p}, nil).AnyTimes()
-			mockMesh.EXPECT().GetAtxHeader(p.AtxID).Return(&types.ActivationTxHeader{BaseTickHeight: 11, TickCount: 1}, nil).AnyTimes()
+			mockMesh.EXPECT().GetAtxHeader(p.AtxID).Return(&types.ActivationTxHeader{BaseTickHeight: 11, TickCount: 1, NodeID: p.SmesherID}, nil).AnyTimes()
+			mockMesh.EXPECT().GetMalfeasanceProof(p.SmesherID)
 		}
 	} else {
 		mockMesh.EXPECT().Proposals(gomock.Any()).Return([]*types.Proposal{}, nil).AnyTimes()

--- a/hare/hare_test.go
+++ b/hare/hare_test.go
@@ -81,10 +81,20 @@ func newMockMesh(tb testing.TB) *mocks.Mockmesh {
 }
 
 func randomProposal(lyrID types.LayerID, beacon types.Beacon) *types.Proposal {
-	p := genLayerProposal(lyrID, nil)
-	p.Ballot.RefBallot = types.EmptyBallotID
-	p.Ballot.EpochData = &types.EpochData{
-		Beacon: beacon,
+	p := &types.Proposal{
+		InnerProposal: types.InnerProposal{
+			Ballot: types.Ballot{
+				InnerBallot: types.InnerBallot{
+					Layer: lyrID,
+					AtxID: types.RandomATXID(),
+					EpochData: &types.EpochData{
+						ActiveSetHash: types.RandomHash(),
+						Beacon:        beacon,
+					},
+				},
+				ActiveSet: types.RandomActiveSet(10),
+			},
+		},
 	}
 	signer, _ := signing.NewEdSigner()
 	p.Ballot.Signature = signer.Sign(signing.BALLOT, p.Ballot.SignedBytes())
@@ -324,7 +334,12 @@ func TestHare_onTick(t *testing.T) {
 		randomProposal(lyrID, beacon),
 	}
 	for _, p := range pList {
-		mockMesh.EXPECT().GetAtxHeader(p.AtxID).Return(&types.ActivationTxHeader{BaseTickHeight: 11, TickCount: 1}, nil)
+		mockMesh.EXPECT().GetAtxHeader(p.AtxID).Return(&types.ActivationTxHeader{BaseTickHeight: 11, TickCount: 1, NodeID: p.SmesherID}, nil)
+		for _, id := range p.ActiveSet {
+			nodeID := types.RandomNodeID()
+			mockMesh.EXPECT().GetAtxHeader(id).Return(&types.ActivationTxHeader{BaseTickHeight: 11, TickCount: 1, NodeID: nodeID}, nil)
+			mockMesh.EXPECT().GetMalfeasanceProof(nodeID)
+		}
 	}
 	mockMesh.EXPECT().GetEpochAtx(lyrID.GetEpoch(), h.nodeID).Return(&types.ActivationTxHeader{BaseTickHeight: 11, TickCount: 1}, nil)
 	mockMesh.EXPECT().Proposals(lyrID).Return(pList, nil)
@@ -403,6 +418,13 @@ func TestHare_onTick_notMining(t *testing.T) {
 		randomProposal(lyrID, beacon),
 		randomProposal(lyrID, beacon),
 	}
+	for _, p := range pList {
+		for _, id := range p.ActiveSet {
+			nodeID := types.RandomNodeID()
+			mockMesh.EXPECT().GetAtxHeader(id).Return(&types.ActivationTxHeader{BaseTickHeight: 11, TickCount: 1, NodeID: nodeID}, nil)
+			mockMesh.EXPECT().GetMalfeasanceProof(nodeID)
+		}
+	}
 	mockMesh.EXPECT().GetEpochAtx(lyrID.GetEpoch(), h.nodeID).Return(nil, sql.ErrNotFound)
 	mockMesh.EXPECT().Proposals(lyrID).Return(pList, nil)
 	h.mockCoin.EXPECT().Set(lyrID, gomock.Any()).DoAndReturn(
@@ -473,7 +495,7 @@ func TestHare_onTick_NotSynced(t *testing.T) {
 	h.Close()
 }
 
-func TestHare_goodProposal(t *testing.T) {
+func TestHare_goodProposals(t *testing.T) {
 	beacon := types.RandomBeacon()
 	nodeBeacon := types.RandomBeacon()
 	nodeBaseHeight := uint64(11)
@@ -550,6 +572,19 @@ func TestHare_goodProposal(t *testing.T) {
 				randomProposal(lyrID, tc.beacons[1]),
 				randomProposal(lyrID, tc.beacons[2]),
 			}
+			if len(tc.refBallot) > 0 {
+				for _, i := range tc.refBallot {
+					refBallot := &randomProposal(lyrID.Sub(1), tc.beacons[i]).Ballot
+					pList[i].EpochData = nil
+					pList[i].RefBallot = refBallot.ID()
+					mockMesh.EXPECT().Ballot(pList[1].RefBallot).Return(refBallot, nil)
+					for _, id := range refBallot.ActiveSet {
+						nodeID := types.RandomNodeID()
+						mockMesh.EXPECT().GetAtxHeader(id).Return(&types.ActivationTxHeader{BaseTickHeight: 11, TickCount: 1, NodeID: nodeID}, nil).AnyTimes()
+						mockMesh.EXPECT().GetMalfeasanceProof(nodeID).AnyTimes()
+					}
+				}
+			}
 			for i, p := range pList {
 				if tc.malicious[i] {
 					p.SetMalicious()
@@ -558,27 +593,104 @@ func TestHare_goodProposal(t *testing.T) {
 				} else {
 					mockMesh.EXPECT().GetAtxHeader(p.AtxID).Return(&types.ActivationTxHeader{BaseTickHeight: tc.baseHeights[i], TickCount: 1}, nil)
 				}
+				if p.EpochData != nil {
+					for _, id := range p.ActiveSet {
+						nodeID := types.RandomNodeID()
+						mockMesh.EXPECT().GetAtxHeader(id).Return(&types.ActivationTxHeader{BaseTickHeight: 11, TickCount: 1, NodeID: nodeID}, nil).AnyTimes()
+						mockMesh.EXPECT().GetMalfeasanceProof(nodeID).AnyTimes()
+					}
+				}
 			}
 			nodeID := types.NodeID{1, 2, 3}
 			mockMesh.EXPECT().GetEpochAtx(lyrID.GetEpoch(), nodeID).Return(&types.ActivationTxHeader{BaseTickHeight: nodeBaseHeight, TickCount: 1}, nil)
 			mockMesh.EXPECT().Proposals(lyrID).Return(pList, nil)
-			if len(tc.refBallot) > 0 {
-				for _, i := range tc.refBallot {
-					refBallot := &randomProposal(lyrID.Sub(1), tc.beacons[i]).Ballot
-					pList[i].EpochData = nil
-					pList[i].RefBallot = refBallot.ID()
-					mockMesh.EXPECT().Ballot(pList[1].RefBallot).Return(refBallot, nil)
-				}
-			}
 
 			expected := make([]types.ProposalID, 0, len(tc.expected))
 			for _, i := range tc.expected {
 				expected = append(expected, pList[i].ID())
 			}
-			got := goodProposals(context.Background(), logtest.New(t), mockMesh, nodeID, lyrID, nodeBeacon)
+			got := goodProposals(context.Background(), logtest.New(t), mockMesh, nodeID, lyrID, nodeBeacon, time.Now(), time.Second)
 			require.ElementsMatch(t, expected, got)
 		})
 	}
+}
+
+func TestHare_goodProposals_gradedAtxs(t *testing.T) {
+	beacon := types.RandomBeacon()
+	tickHeight := uint64(11)
+	lyrID := types.GetEffectiveGenesis().Add(1)
+	epochStart := time.Now()
+	mockMesh := newMockMesh(t)
+	activeSet := types.RandomActiveSet(10)
+	pList := []*types.Proposal{
+		randomProposal(lyrID, beacon),
+		randomProposal(lyrID, beacon),
+		randomProposal(lyrID, beacon),
+		randomProposal(lyrID, beacon),
+		randomProposal(lyrID, beacon),
+		randomProposal(lyrID, beacon),
+		randomProposal(lyrID, beacon),
+	}
+	for _, p := range pList {
+		mockMesh.EXPECT().GetAtxHeader(p.AtxID).Return(&types.ActivationTxHeader{BaseTickHeight: 11, TickCount: 1, NodeID: p.SmesherID}, nil)
+	}
+
+	delay := time.Second
+	goodTime := epochStart.Add(-4*delay - time.Nanosecond)
+	acceptableTime := epochStart.Add(-3*delay - time.Nanosecond)
+	evilTime := epochStart.Add(-3 * delay)
+
+	for i := 0; i < 4; i++ {
+		good := &types.ActivationTxHeader{BaseTickHeight: tickHeight, TickCount: 1, Received: goodTime, NodeID: types.NodeID{byte(i + 1)}}
+		mockMesh.EXPECT().GetAtxHeader(activeSet[i]).Return(good, nil).AnyTimes()
+		mockMesh.EXPECT().GetMalfeasanceProof(good.NodeID).Return(nil, nil).AnyTimes()
+	}
+
+	earlyAtxLateMalicious := &types.ActivationTxHeader{BaseTickHeight: tickHeight, TickCount: 1, Received: goodTime, NodeID: types.NodeID{5}}
+	mockMesh.EXPECT().GetAtxHeader(activeSet[4]).Return(earlyAtxLateMalicious, nil).AnyTimes()
+	proof1 := &types.MalfeasanceProof{}
+	proof1.SetReceived(epochStart)
+	mockMesh.EXPECT().GetMalfeasanceProof(earlyAtxLateMalicious.NodeID).Return(proof1, nil).AnyTimes()
+
+	earlyAtxMalicious := &types.ActivationTxHeader{BaseTickHeight: tickHeight, TickCount: 1, Received: goodTime, NodeID: types.NodeID{6}}
+	mockMesh.EXPECT().GetAtxHeader(activeSet[5]).Return(earlyAtxMalicious, nil).AnyTimes()
+	proof2 := &types.MalfeasanceProof{}
+	proof2.SetReceived(epochStart.Add(-delay))
+	mockMesh.EXPECT().GetMalfeasanceProof(earlyAtxMalicious.NodeID).Return(proof2, nil).AnyTimes()
+
+	acceptable := &types.ActivationTxHeader{BaseTickHeight: tickHeight, TickCount: 1, Received: acceptableTime, NodeID: types.NodeID{7}}
+	mockMesh.EXPECT().GetAtxHeader(activeSet[6]).Return(acceptable, nil).AnyTimes()
+	mockMesh.EXPECT().GetMalfeasanceProof(acceptable.NodeID).Return(nil, nil).AnyTimes()
+
+	acceptableMalicious := &types.ActivationTxHeader{BaseTickHeight: tickHeight, TickCount: 1, Received: acceptableTime, NodeID: types.NodeID{8}}
+	mockMesh.EXPECT().GetAtxHeader(activeSet[7]).Return(acceptableMalicious, nil).AnyTimes()
+	proof3 := &types.MalfeasanceProof{}
+	proof3.SetReceived(epochStart.Add(-delay))
+	mockMesh.EXPECT().GetMalfeasanceProof(acceptableMalicious.NodeID).Return(proof3, nil).AnyTimes()
+
+	malicious := &types.ActivationTxHeader{BaseTickHeight: tickHeight, TickCount: 1, Received: goodTime, NodeID: types.NodeID{9}}
+	mockMesh.EXPECT().GetAtxHeader(activeSet[8]).Return(malicious, nil).AnyTimes()
+	proof4 := &types.MalfeasanceProof{}
+	proof4.SetReceived(epochStart.Add(-delay - time.Nanosecond))
+	mockMesh.EXPECT().GetMalfeasanceProof(malicious.NodeID).Return(proof4, nil).AnyTimes()
+
+	evil := &types.ActivationTxHeader{BaseTickHeight: tickHeight, TickCount: 1, Received: evilTime, NodeID: types.NodeID{10}}
+	mockMesh.EXPECT().GetAtxHeader(activeSet[9]).Return(evil, nil).AnyTimes()
+	mockMesh.EXPECT().GetMalfeasanceProof(evil.NodeID).Return(nil, nil).AnyTimes()
+
+	pList[0].ActiveSet = activeSet[:4]
+	pList[1].ActiveSet = activeSet[:5]
+	pList[2].ActiveSet = activeSet[:6]
+	pList[3].ActiveSet = activeSet[:7]
+	pList[4].ActiveSet = activeSet[:8]
+	pList[5].ActiveSet = activeSet[:9]
+	pList[6].ActiveSet = activeSet
+
+	nodeID := types.NodeID{1, 2, 3}
+	mockMesh.EXPECT().GetEpochAtx(lyrID.GetEpoch(), nodeID).Return(&types.ActivationTxHeader{BaseTickHeight: tickHeight, TickCount: 1}, nil)
+	mockMesh.EXPECT().Proposals(lyrID).Return(pList, nil)
+	got := goodProposals(context.Background(), logtest.New(t), mockMesh, nodeID, lyrID, beacon, epochStart, delay)
+	require.ElementsMatch(t, types.ToProposalIDs(pList[:5]), got)
 }
 
 func TestHare_outputBuffer(t *testing.T) {

--- a/hare/interfaces.go
+++ b/hare/interfaces.go
@@ -33,7 +33,7 @@ type mesh interface {
 	GetAtxHeader(types.ATXID) (*types.ActivationTxHeader, error)
 	Proposals(types.LayerID) ([]*types.Proposal, error)
 	Ballot(types.BallotID) (*types.Ballot, error)
-	GetMalfeasanceProof(nodeID types.NodeID) (*types.MalfeasanceProof, error)
+	GetMalfeasanceProof(types.NodeID) (*types.MalfeasanceProof, error)
 	Cache() *datastore.CachedDB
 }
 

--- a/hare/mocks/mocks.go
+++ b/hare/mocks/mocks.go
@@ -252,18 +252,18 @@ func (mr *MockmeshMockRecorder) GetEpochAtx(arg0, arg1 interface{}) *gomock.Call
 }
 
 // GetMalfeasanceProof mocks base method.
-func (m *Mockmesh) GetMalfeasanceProof(nodeID types.NodeID) (*types.MalfeasanceProof, error) {
+func (m *Mockmesh) GetMalfeasanceProof(arg0 types.NodeID) (*types.MalfeasanceProof, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMalfeasanceProof", nodeID)
+	ret := m.ctrl.Call(m, "GetMalfeasanceProof", arg0)
 	ret0, _ := ret[0].(*types.MalfeasanceProof)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetMalfeasanceProof indicates an expected call of GetMalfeasanceProof.
-func (mr *MockmeshMockRecorder) GetMalfeasanceProof(nodeID interface{}) *gomock.Call {
+func (mr *MockmeshMockRecorder) GetMalfeasanceProof(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMalfeasanceProof", reflect.TypeOf((*Mockmesh)(nil).GetMalfeasanceProof), nodeID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMalfeasanceProof", reflect.TypeOf((*Mockmesh)(nil).GetMalfeasanceProof), arg0)
 }
 
 // Proposals mocks base method.

--- a/hare/preroundtracker_test.go
+++ b/hare/preroundtracker_test.go
@@ -12,33 +12,10 @@ import (
 )
 
 const (
-	k              = 1
 	ki             = preRound
 	lowThresh10    = 10
 	lowDefaultSize = 100
 )
-
-func genLayerProposal(layerID types.LayerID, txs []types.TransactionID) *types.Proposal {
-	p := &types.Proposal{
-		InnerProposal: types.InnerProposal{
-			Ballot: types.Ballot{
-				InnerBallot: types.InnerBallot{
-					Layer: layerID,
-					AtxID: types.RandomATXID(),
-					EpochData: &types.EpochData{
-						Beacon: types.RandomBeacon(),
-					},
-				},
-			},
-			TxIDs: txs,
-		},
-	}
-	signer, _ := signing.NewEdSigner()
-	p.Ballot.Signature = signer.Sign(signing.BALLOT, p.Ballot.SignedBytes())
-	p.Signature = signer.Sign(signing.BALLOT, p.SignedBytes())
-	p.Initialize()
-	return p
-}
 
 func BuildPreRoundMsg(sig *signing.EdSigner, s *Set, roleProof types.VrfSignature) *Message {
 	builder := newMessageBuilder()

--- a/malfeasance/handler.go
+++ b/malfeasance/handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/spacemeshos/go-spacemesh/codec"
 	"github.com/spacemeshos/go-spacemesh/common/types"
@@ -108,7 +109,7 @@ func validateAndSave(
 		if err != nil {
 			logger.With().Panic("failed to encode MalfeasanceProof", log.Err(err))
 		}
-		if err := identities.SetMalicious(dbtx, nodeID, encoded); err != nil {
+		if err := identities.SetMalicious(dbtx, nodeID, encoded, time.Now()); err != nil {
 			return fmt.Errorf("add malfeasance proof: %w", err)
 		}
 		return nil

--- a/malfeasance/handler_test.go
+++ b/malfeasance/handler_test.go
@@ -215,6 +215,8 @@ func TestHandler_HandleMalfeasanceProof_multipleATXs(t *testing.T) {
 
 		malProof, err := identities.GetMalfeasanceProof(db, sig.NodeID())
 		require.NoError(t, err)
+		require.NotNil(t, malProof.Received())
+		malProof.SetReceived(time.Time{})
 		require.Equal(t, gossip.MalfeasanceProof, *malProof)
 	})
 
@@ -429,6 +431,8 @@ func TestHandler_HandleMalfeasanceProof_multipleBallots(t *testing.T) {
 
 		malProof, err := identities.GetMalfeasanceProof(db, sig.NodeID())
 		require.NoError(t, err)
+		require.NotNil(t, malProof.Received())
+		malProof.SetReceived(time.Time{})
 		require.Equal(t, gossip.MalfeasanceProof, *malProof)
 	})
 
@@ -657,6 +661,8 @@ func TestHandler_HandleMalfeasanceProof_hareEquivocation(t *testing.T) {
 
 		malProof, err := identities.GetMalfeasanceProof(db, sig.NodeID())
 		require.NoError(t, err)
+		require.NotNil(t, malProof.Received())
+		malProof.SetReceived(time.Time{})
 		require.Equal(t, gossip.MalfeasanceProof, *malProof)
 	})
 

--- a/mesh/mesh.go
+++ b/mesh/mesh.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	"go.uber.org/atomic"
 	"go.uber.org/zap/zapcore"
@@ -556,7 +557,7 @@ func (msh *Mesh) AddBallot(ctx context.Context, ballot *types.Ballot) (*types.Ma
 				if err != nil {
 					msh.logger.With().Panic("failed to encode MalfeasanceProof", log.Err(err))
 				}
-				if err := identities.SetMalicious(dbtx, ballot.SmesherID, encoded); err != nil {
+				if err := identities.SetMalicious(dbtx, ballot.SmesherID, encoded, time.Now()); err != nil {
 					return fmt.Errorf("add malfeasance proof: %w", err)
 				}
 				ballot.SetMalicious()

--- a/mesh/mesh_test.go
+++ b/mesh/mesh_test.go
@@ -346,6 +346,8 @@ func TestMesh_MaliciousBallots(t *testing.T) {
 	require.True(t, mal)
 	saved, err = identities.GetMalfeasanceProof(tm.cdb, sig.NodeID())
 	require.NoError(t, err)
+	require.NotNil(t, saved.Received())
+	saved.SetReceived(time.Time{})
 	require.EqualValues(t, malProof, saved)
 	expected := malProof
 
@@ -359,6 +361,8 @@ func TestMesh_MaliciousBallots(t *testing.T) {
 	require.True(t, mal)
 	saved, err = identities.GetMalfeasanceProof(tm.cdb, sig.NodeID())
 	require.NoError(t, err)
+	require.NotNil(t, saved.Received())
+	saved.SetReceived(time.Time{})
 	require.EqualValues(t, expected, saved)
 }
 

--- a/miner/atx_grader.go
+++ b/miner/atx_grader.go
@@ -1,0 +1,38 @@
+package miner
+
+import (
+	"errors"
+	"time"
+
+	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/sql"
+)
+
+// AtxGrade describes the grade of an ATX as described in
+// https://community.spacemesh.io/t/grading-atxs-for-the-active-set/335
+//
+// let s be the start of the epoch, and δ the network propagation time.
+// grade 0: ATX was received at time t >= s-3δ, or an equivocation proof was received by time s-δ.
+// grade 1: ATX was received at time t < s-3δ before the start of the epoch, and no equivocation proof was received by time s-δ.
+// grade 2: ATX was received at time t < s-4δ, and no equivocation proof was received for that id until time s.
+type AtxGrade int
+
+const (
+	Evil AtxGrade = iota
+	Acceptable
+	Good
+)
+
+func GradeAtx(msh mesh, nodeID types.NodeID, atxReceived, epochStart time.Time, delta time.Duration) (AtxGrade, error) {
+	proof, err := msh.GetMalfeasanceProof(nodeID)
+	if err != nil && !errors.Is(err, sql.ErrNotFound) {
+		return Good, err
+	}
+	if atxReceived.Before(epochStart.Add(-4*delta)) && (proof == nil || !proof.Received().Before(epochStart)) {
+		return Good, nil
+	}
+	if atxReceived.Before(epochStart.Add(-3*delta)) && (proof == nil || !proof.Received().Before(epochStart.Add(-delta))) {
+		return Acceptable, nil
+	}
+	return Evil, nil
+}

--- a/miner/atx_grader_test.go
+++ b/miner/atx_grader_test.go
@@ -1,0 +1,109 @@
+package miner_test
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/hare/mocks"
+	"github.com/spacemeshos/go-spacemesh/miner"
+	"github.com/spacemeshos/go-spacemesh/sql"
+)
+
+const layersPerEpoch = 3
+
+func TestMain(m *testing.M) {
+	types.SetLayersPerEpoch(layersPerEpoch)
+
+	res := m.Run()
+	os.Exit(res)
+}
+
+func TestGradeAtx(t *testing.T) {
+	const delta = 10
+	for _, tc := range []struct {
+		desc      string
+		malicious bool
+		// distance in second from the epoch start time
+		atxReceived, malReceived int
+		result                   miner.AtxGrade
+	}{
+		{
+			desc:        "very early atx",
+			atxReceived: -41,
+			result:      miner.Good,
+		},
+		{
+			desc:        "very early atx, late malfeasance",
+			atxReceived: -41,
+			malicious:   true,
+			malReceived: 0,
+			result:      miner.Good,
+		},
+		{
+			desc:        "very early atx, malicious",
+			atxReceived: -41,
+			malicious:   true,
+			malReceived: -10,
+			result:      miner.Acceptable,
+		},
+		{
+			desc:        "very early atx, early malicious",
+			atxReceived: -41,
+			malicious:   true,
+			malReceived: -11,
+			result:      miner.Evil,
+		},
+		{
+			desc:        "early atx",
+			atxReceived: -31,
+			result:      miner.Acceptable,
+		},
+		{
+			desc:        "early atx, late malicious",
+			atxReceived: -31,
+			malicious:   true,
+			malReceived: -10,
+			result:      miner.Acceptable,
+		},
+		{
+			desc:        "early atx, early malicious",
+			atxReceived: -31,
+			malicious:   true,
+			malReceived: -11,
+			result:      miner.Evil,
+		},
+		{
+			desc:        "late atx",
+			atxReceived: -30,
+			result:      miner.Evil,
+		},
+		{
+			desc:        "very late atx",
+			atxReceived: 0,
+			result:      miner.Evil,
+		},
+	} {
+		tc := tc
+		t.Run(tc.desc, func(t *testing.T) {
+			mockMsh := mocks.NewMockmesh(gomock.NewController(t))
+			epochStart := time.Now()
+			nodeID := types.RandomNodeID()
+			if tc.malicious {
+				proof := &types.MalfeasanceProof{}
+				proof.SetReceived(epochStart.Add(time.Duration(tc.malReceived) * time.Second))
+				mockMsh.EXPECT().GetMalfeasanceProof(nodeID).Return(proof, nil)
+			} else {
+				mockMsh.EXPECT().GetMalfeasanceProof(nodeID).Return(nil, sql.ErrNotFound)
+			}
+			atxReceived := epochStart.Add(time.Duration(tc.atxReceived) * time.Second)
+			got, err := miner.GradeAtx(mockMsh, nodeID, atxReceived, epochStart, delta*time.Second)
+			require.NoError(t, err)
+			require.Equal(t, tc.result, got)
+		})
+	}
+}

--- a/miner/interface.go
+++ b/miner/interface.go
@@ -11,7 +11,7 @@ import (
 //go:generate mockgen -package=miner -destination=./mocks.go -source=./interface.go
 
 type proposalOracle interface {
-	GetProposalEligibility(types.LayerID, types.Beacon, types.VRFPostIndex) (*EpochEligibility, error)
+	ProposalEligibility(types.LayerID, types.Beacon, types.VRFPostIndex) (*EpochEligibility, error)
 }
 
 type conservativeState interface {
@@ -26,6 +26,10 @@ type votesEncoder interface {
 
 type nonceFetcher interface {
 	VRFNonce(types.NodeID, types.EpochID) (types.VRFPostIndex, error)
+}
+
+type mesh interface {
+	GetMalfeasanceProof(nodeID types.NodeID) (*types.MalfeasanceProof, error)
 }
 
 type layerClock interface {

--- a/miner/mocks.go
+++ b/miner/mocks.go
@@ -37,19 +37,19 @@ func (m *MockproposalOracle) EXPECT() *MockproposalOracleMockRecorder {
 	return m.recorder
 }
 
-// GetProposalEligibility mocks base method.
-func (m *MockproposalOracle) GetProposalEligibility(arg0 types.LayerID, arg1 types.Beacon, arg2 types.VRFPostIndex) (*EpochEligibility, error) {
+// ProposalEligibility mocks base method.
+func (m *MockproposalOracle) ProposalEligibility(arg0 types.LayerID, arg1 types.Beacon, arg2 types.VRFPostIndex) (*EpochEligibility, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetProposalEligibility", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "ProposalEligibility", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*EpochEligibility)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetProposalEligibility indicates an expected call of GetProposalEligibility.
-func (mr *MockproposalOracleMockRecorder) GetProposalEligibility(arg0, arg1, arg2 interface{}) *gomock.Call {
+// ProposalEligibility indicates an expected call of ProposalEligibility.
+func (mr *MockproposalOracleMockRecorder) ProposalEligibility(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProposalEligibility", reflect.TypeOf((*MockproposalOracle)(nil).GetProposalEligibility), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProposalEligibility", reflect.TypeOf((*MockproposalOracle)(nil).ProposalEligibility), arg0, arg1, arg2)
 }
 
 // MockconservativeState is a mock of conservativeState interface.
@@ -194,6 +194,44 @@ func (m *MocknonceFetcher) VRFNonce(arg0 types.NodeID, arg1 types.EpochID) (type
 func (mr *MocknonceFetcherMockRecorder) VRFNonce(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VRFNonce", reflect.TypeOf((*MocknonceFetcher)(nil).VRFNonce), arg0, arg1)
+}
+
+// Mockmesh is a mock of mesh interface.
+type Mockmesh struct {
+	ctrl     *gomock.Controller
+	recorder *MockmeshMockRecorder
+}
+
+// MockmeshMockRecorder is the mock recorder for Mockmesh.
+type MockmeshMockRecorder struct {
+	mock *Mockmesh
+}
+
+// NewMockmesh creates a new mock instance.
+func NewMockmesh(ctrl *gomock.Controller) *Mockmesh {
+	mock := &Mockmesh{ctrl: ctrl}
+	mock.recorder = &MockmeshMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *Mockmesh) EXPECT() *MockmeshMockRecorder {
+	return m.recorder
+}
+
+// GetMalfeasanceProof mocks base method.
+func (m *Mockmesh) GetMalfeasanceProof(nodeID types.NodeID) (*types.MalfeasanceProof, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMalfeasanceProof", nodeID)
+	ret0, _ := ret[0].(*types.MalfeasanceProof)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetMalfeasanceProof indicates an expected call of GetMalfeasanceProof.
+func (mr *MockmeshMockRecorder) GetMalfeasanceProof(nodeID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMalfeasanceProof", reflect.TypeOf((*Mockmesh)(nil).GetMalfeasanceProof), nodeID)
 }
 
 // MocklayerClock is a mock of layerClock interface.

--- a/miner/oracle.go
+++ b/miner/oracle.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/proposals"
 	"github.com/spacemeshos/go-spacemesh/signing"
+	"github.com/spacemeshos/go-spacemesh/system"
 )
 
 var (
@@ -35,18 +36,20 @@ type Oracle struct {
 	clock     layerClock
 	cdb       *datastore.CachedDB
 	vrfSigner *signing.VRFSigner
+	syncState system.SyncStateProvider
 	log       log.Log
 
 	mu    sync.Mutex
 	cache *EpochEligibility
 }
 
-func newMinerOracle(cfg config, c layerClock, cdb *datastore.CachedDB, vrfSigner *signing.VRFSigner, log log.Log) *Oracle {
+func newMinerOracle(cfg config, c layerClock, cdb *datastore.CachedDB, vrfSigner *signing.VRFSigner, ss system.SyncStateProvider, log log.Log) *Oracle {
 	return &Oracle{
 		cfg:       cfg,
 		clock:     c,
 		cdb:       cdb,
 		vrfSigner: vrfSigner,
+		syncState: ss,
 		log:       log,
 		cache:     &EpochEligibility{},
 	}
@@ -88,7 +91,41 @@ func (o *Oracle) ProposalEligibility(lid types.LayerID, beacon types.Beacon, non
 	return ee, nil
 }
 
+func (o *Oracle) activesFromFirstBlock(targetEpoch types.EpochID) (uint64, uint64, []types.ATXID, error) {
+	activeSet, err := ActiveSetFromBlock(o.cdb, targetEpoch)
+	if err != nil {
+		return 0, 0, nil, err
+	}
+	own, err := o.cdb.GetEpochAtx(targetEpoch-1, o.cfg.nodeID)
+	if err != nil {
+		return 0, 0, nil, err
+	}
+	activeSet = append(activeSet, own.ID)
+	var total uint64
+	for _, id := range activeSet {
+		hdr, err := o.cdb.GetAtxHeader(id)
+		if err != nil {
+			return 0, 0, nil, err
+		}
+		total += hdr.GetWeight()
+	}
+	o.log.With().Info("active set selected for proposal",
+		log.Stringer("epoch", targetEpoch),
+		log.Int("num_atx", len(activeSet)),
+	)
+	return own.GetWeight(), total, activeSet, nil
+}
+
 func (o *Oracle) activeSet(targetEpoch types.EpochID) (uint64, uint64, []types.ATXID, error) {
+	if !o.syncState.SyncedBefore(targetEpoch - 1) {
+		// if the node is not synced prior to `targetEpoch-1`, it doesn't have the correct receipt timestamp
+		// for all the atx and malfeasance proof, and cannot use atx grading for active set.
+		o.log.With().Info("node not synced before prior epoch, getting active set from first block",
+			log.Stringer("epoch", targetEpoch),
+		)
+		return o.activesFromFirstBlock(targetEpoch)
+	}
+
 	var (
 		minerWeight, totalWeight uint64
 		minerID                  types.ATXID

--- a/miner/oracle.go
+++ b/miner/oracle.go
@@ -13,8 +13,6 @@ import (
 	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/proposals"
 	"github.com/spacemeshos/go-spacemesh/signing"
-	"github.com/spacemeshos/go-spacemesh/sql"
-	"github.com/spacemeshos/go-spacemesh/sql/atxs"
 )
 
 var (
@@ -33,35 +31,30 @@ type EpochEligibility struct {
 
 // Oracle provides proposal eligibility proofs for the miner.
 type Oracle struct {
-	avgLayerSize       uint32
-	layersPerEpoch     uint32
-	minActiveSetWeight uint64
-	cdb                *datastore.CachedDB
-
+	cfg       config
+	clock     layerClock
+	cdb       *datastore.CachedDB
 	vrfSigner *signing.VRFSigner
-	nodeID    types.NodeID
 	log       log.Log
 
 	mu    sync.Mutex
 	cache *EpochEligibility
 }
 
-func newMinerOracle(layerSize, layersPerEpoch uint32, minActiveSetWeight uint64, cdb *datastore.CachedDB, vrfSigner *signing.VRFSigner, nodeID types.NodeID, log log.Log) *Oracle {
+func newMinerOracle(cfg config, c layerClock, cdb *datastore.CachedDB, vrfSigner *signing.VRFSigner, log log.Log) *Oracle {
 	return &Oracle{
-		avgLayerSize:       layerSize,
-		layersPerEpoch:     layersPerEpoch,
-		minActiveSetWeight: minActiveSetWeight,
-		cdb:                cdb,
-		vrfSigner:          vrfSigner,
-		nodeID:             nodeID,
-		log:                log,
-		cache:              &EpochEligibility{},
+		cfg:       cfg,
+		clock:     c,
+		cdb:       cdb,
+		vrfSigner: vrfSigner,
+		log:       log,
+		cache:     &EpochEligibility{},
 	}
 }
 
-// GetProposalEligibility returns the miner's ATXID and the active set for the layer's epoch, along with the list of eligibility
+// ProposalEligibility returns the miner's ATXID and the active set for the layer's epoch, along with the list of eligibility
 // proofs for that layer.
-func (o *Oracle) GetProposalEligibility(lid types.LayerID, beacon types.Beacon, nonce types.VRFPostIndex) (*EpochEligibility, error) {
+func (o *Oracle) ProposalEligibility(lid types.LayerID, beacon types.Beacon, nonce types.VRFPostIndex) (*EpochEligibility, error) {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 
@@ -86,16 +79,7 @@ func (o *Oracle) GetProposalEligibility(lid types.LayerID, beacon types.Beacon, 
 		return o.cache, nil
 	}
 
-	// calculate the proof
-	atx, err := o.getOwnEpochATX(epoch)
-	if err != nil {
-		if errors.Is(err, sql.ErrNotFound) {
-			return nil, errMinerHasNoATXInPreviousEpoch
-		}
-		return nil, fmt.Errorf("failed to get valid atx for node for target epoch %d: %w", epoch, err)
-	}
-
-	ee, err := o.calcEligibilityProofs(atx, epoch, beacon, nonce)
+	ee, err := o.calcEligibilityProofs(epoch, beacon, nonce)
 	if err != nil {
 		return nil, err
 	}
@@ -104,29 +88,63 @@ func (o *Oracle) GetProposalEligibility(lid types.LayerID, beacon types.Beacon, 
 	return ee, nil
 }
 
-func (o *Oracle) getOwnEpochATX(targetEpoch types.EpochID) (*types.ActivationTxHeader, error) {
-	publishEpoch := targetEpoch - 1
-	atxID, err := atxs.GetIDByEpochAndNodeID(o.cdb, publishEpoch, o.nodeID)
-	if err != nil {
-		return nil, fmt.Errorf("get ATX ID: %w", err)
-	}
+func (o *Oracle) activeSet(targetEpoch types.EpochID) (uint64, uint64, []types.ATXID, error) {
+	var (
+		minerWeight, totalWeight uint64
+		minerID                  types.ATXID
+		atxids                   []types.ATXID
+	)
 
-	atx, err := o.cdb.GetAtxHeader(atxID)
-	if err != nil {
-		return nil, fmt.Errorf("get ATX header: %w", err)
+	epochStart := o.clock.LayerToTime(targetEpoch.FirstLayer())
+	numOmitted := 0
+	if err := o.cdb.IterateEpochATXHeaders(targetEpoch, func(header *types.ActivationTxHeader) error {
+		grade, err := GradeAtx(o.cdb, header.NodeID, header.Received, epochStart, o.cfg.networkDelay)
+		if err != nil {
+			return err
+		}
+		if grade != Good {
+			o.log.With().Info("atx omitted from active set",
+				header.ID,
+				log.Int("grade", int(grade)),
+				log.Stringer("smesher", header.NodeID),
+				log.Time("received", header.Received),
+				log.Time("epoch_start", epochStart),
+			)
+			numOmitted++
+			return nil
+		}
+		totalWeight += header.GetWeight()
+		if header.NodeID == o.cfg.nodeID {
+			minerWeight = header.GetWeight()
+			minerID = header.ID
+		} else {
+			atxids = append(atxids, header.ID)
+		}
+		return nil
+	}); err != nil {
+		return 0, 0, nil, err
 	}
-	return atx, nil
+	// put miner's own ATXID last
+	if minerID != types.EmptyATXID {
+		atxids = append(atxids, minerID)
+	}
+	o.log.With().Info("active set selected for proposal",
+		log.Int("num_atx", len(atxids)),
+		log.Int("num_omitted", numOmitted),
+	)
+	return minerWeight, totalWeight, atxids, nil
 }
 
 // calcEligibilityProofs calculates the eligibility proofs of proposals for the miner in the given epoch
 // and returns the proofs along with the epoch's active set.
-func (o *Oracle) calcEligibilityProofs(atx *types.ActivationTxHeader, epoch types.EpochID, beacon types.Beacon, nonce types.VRFPostIndex) (*EpochEligibility, error) {
-	weight := atx.GetWeight()
-
+func (o *Oracle) calcEligibilityProofs(epoch types.EpochID, beacon types.Beacon, nonce types.VRFPostIndex) (*EpochEligibility, error) {
 	// get the previous epoch's total weight
-	totalWeight, activeSet, err := o.cdb.GetEpochWeight(epoch)
+	minerWeight, totalWeight, activeSet, err := o.activeSet(epoch)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get epoch %v weight: %w", epoch, err)
+	}
+	if minerWeight == 0 {
+		return nil, errMinerHasNoATXInPreviousEpoch
 	}
 	if totalWeight == 0 {
 		return nil, errZeroEpochWeight
@@ -134,15 +152,15 @@ func (o *Oracle) calcEligibilityProofs(atx *types.ActivationTxHeader, epoch type
 	if len(activeSet) == 0 {
 		return nil, errEmptyActiveSet
 	}
-
+	ownAtx := activeSet[len(activeSet)-1]
 	o.log.With().Debug("calculating eligibility",
 		epoch,
 		beacon,
-		log.Uint64("weight", weight),
+		log.Uint64("weight", minerWeight),
 		log.Uint64("total weight", totalWeight),
 	)
 
-	numEligibleSlots, err := proposals.GetNumEligibleSlots(weight, o.minActiveSetWeight, totalWeight, o.avgLayerSize, o.layersPerEpoch)
+	numEligibleSlots, err := proposals.GetNumEligibleSlots(minerWeight, o.cfg.minActiveSetWeight, totalWeight, o.cfg.layerSize, o.cfg.layersPerEpoch)
 	if err != nil {
 		return nil, fmt.Errorf("oracle get num slots: %w", err)
 	}
@@ -154,7 +172,7 @@ func (o *Oracle) calcEligibilityProofs(atx *types.ActivationTxHeader, epoch type
 			o.log.With().Fatal("failed to serialize VRF msg", log.Err(err))
 		}
 		vrfSig := o.vrfSigner.Sign(message)
-		eligibleLayer := proposals.CalcEligibleLayer(epoch, o.layersPerEpoch, vrfSig)
+		eligibleLayer := proposals.CalcEligibleLayer(epoch, o.cfg.layersPerEpoch, vrfSig)
 		eligibilityProofs[eligibleLayer] = append(eligibilityProofs[eligibleLayer], types.VotingEligibility{
 			J:   counter,
 			Sig: vrfSig,
@@ -165,8 +183,8 @@ func (o *Oracle) calcEligibilityProofs(atx *types.ActivationTxHeader, epoch type
 	o.log.With().Info("proposal eligibility for an epoch",
 		epoch,
 		beacon,
-		log.Uint64("weight", weight),
-		log.Uint64("min activeset weight", o.minActiveSetWeight),
+		log.Uint64("weight", minerWeight),
+		log.Uint64("min activeset weight", o.cfg.minActiveSetWeight),
 		log.Uint64("total weight", totalWeight),
 		log.Uint32("total num slots", numEligibleSlots),
 		log.Int("num layers eligible", len(eligibilityProofs)),
@@ -193,7 +211,7 @@ func (o *Oracle) calcEligibilityProofs(atx *types.ActivationTxHeader, epoch type
 	})
 	return &EpochEligibility{
 		Epoch:     epoch,
-		Atx:       atx.ID,
+		Atx:       ownAtx,
 		ActiveSet: activeSet,
 		Proofs:    eligibilityProofs,
 		Slots:     numEligibleSlots,

--- a/miner/proposal_builder.go
+++ b/miner/proposal_builder.go
@@ -174,7 +174,7 @@ func NewProposalBuilder(
 		opt(pb)
 	}
 	if pb.proposalOracle == nil {
-		pb.proposalOracle = newMinerOracle(pb.cfg, clock, cdb, vrfSigner, pb.logger)
+		pb.proposalOracle = newMinerOracle(pb.cfg, clock, cdb, vrfSigner, syncer, pb.logger)
 	}
 	if pb.nonceFetcher == nil {
 		pb.nonceFetcher = defaultFetcher{pb.cdb}

--- a/miner/util.go
+++ b/miner/util.go
@@ -1,0 +1,38 @@
+package miner
+
+import (
+	"fmt"
+
+	"golang.org/x/exp/maps"
+
+	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/sql"
+	"github.com/spacemeshos/go-spacemesh/sql/ballots"
+	"github.com/spacemeshos/go-spacemesh/sql/blocks"
+	"github.com/spacemeshos/go-spacemesh/sql/certificates"
+)
+
+func ActiveSetFromBlock(db sql.Executor, epoch types.EpochID) ([]types.ATXID, error) {
+	bid, err := certificates.FirstInEpoch(db, epoch)
+	if err != nil {
+		return nil, err
+	}
+
+	block, err := blocks.Get(db, bid)
+	if err != nil {
+		return nil, fmt.Errorf("actives get block: %w", err)
+	}
+	activeMap := make(map[types.ATXID]struct{})
+	// the active set is the union of all active sets recorded in rewarded miners' ref ballot
+	for _, r := range block.Rewards {
+		activeMap[r.AtxID] = struct{}{}
+		ballot, err := ballots.FirstInEpoch(db, r.AtxID, block.LayerIndex.GetEpoch())
+		if err != nil {
+			return nil, fmt.Errorf("actives get ballot: %w", err)
+		}
+		for _, id := range ballot.ActiveSet {
+			activeMap[id] = struct{}{}
+		}
+	}
+	return maps.Keys(activeMap), nil
+}

--- a/node/node.go
+++ b/node/node.go
@@ -774,6 +774,7 @@ func (app *App) initServices(ctx context.Context, poetClients []activation.PoetP
 		miner.WithLayerPerEpoch(layersPerEpoch),
 		miner.WithMinimalActiveSetWeight(app.Config.Tortoise.MinimalActiveSetWeight),
 		miner.WithHdist(app.Config.Tortoise.Hdist),
+		miner.WithNetworkDelay(app.Config.HARE.WakeupDelta),
 		miner.WithLogger(app.addLogger(ProposalBuilderLogger, lg)),
 	)
 

--- a/sql/atxs/atxs.go
+++ b/sql/atxs/atxs.go
@@ -70,7 +70,7 @@ func Get(db sql.Executor, id types.ATXID) (*types.VerifiedActivationTx, error) {
 	return v, nil
 }
 
-// GetByEpochAndNodeID gets any ATX by the specified NodeID in the given epoch.
+// GetByEpochAndNodeID gets any ATX by the specified NodeID published in the given epoch.
 func GetByEpochAndNodeID(db sql.Executor, epoch types.EpochID, nodeID types.NodeID) (*types.VerifiedActivationTx, error) {
 	enc := func(stmt *sql.Statement) {
 		stmt.BindInt64(1, int64(epoch))

--- a/sql/atxs/atxs_test.go
+++ b/sql/atxs/atxs_test.go
@@ -586,7 +586,7 @@ func createIdentities(tb testing.TB, db sql.Executor, n int, midxs ...int) []*si
 		sigs = append(sigs, sig)
 	}
 	for _, idx := range midxs {
-		require.NoError(tb, identities.SetMalicious(db, sigs[idx].NodeID(), []byte("bad")))
+		require.NoError(tb, identities.SetMalicious(db, sigs[idx].NodeID(), []byte("bad"), time.Now()))
 	}
 	return sigs
 }

--- a/sql/ballots/ballots_test.go
+++ b/sql/ballots/ballots_test.go
@@ -46,7 +46,7 @@ func TestLayer(t *testing.T) {
 		require.Equal(t, &ballots[i], ballot)
 	}
 
-	require.NoError(t, identities.SetMalicious(db, pub, []byte("proof")))
+	require.NoError(t, identities.SetMalicious(db, pub, []byte("proof"), time.Now()))
 	rst, err = Layer(db, start)
 	require.NoError(t, err)
 	require.Len(t, rst, len(ballots))
@@ -69,7 +69,7 @@ func TestAdd(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, &ballot, stored)
 
-	require.NoError(t, identities.SetMalicious(db, nodeID, []byte("proof")))
+	require.NoError(t, identities.SetMalicious(db, nodeID, []byte("proof"), time.Now()))
 	stored, err = Get(db, ballot.ID())
 	require.NoError(t, err)
 	require.True(t, stored.IsMalicious())

--- a/sql/identities/identities_test.go
+++ b/sql/identities/identities_test.go
@@ -2,6 +2,7 @@ package identities
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -36,9 +37,10 @@ func TestMalicious(t *testing.T) {
 			Data: &ballotProof,
 		},
 	}
+	proof.SetReceived(time.Now().Local())
 	data, err := codec.Encode(proof)
 	require.NoError(t, err)
-	require.NoError(t, SetMalicious(db, nodeID, data))
+	require.NoError(t, SetMalicious(db, nodeID, data, proof.Received()))
 
 	mal, err = IsMalicious(db, nodeID)
 	require.NoError(t, err)
@@ -60,7 +62,7 @@ func Test_GetMalicious(t *testing.T) {
 	for i := 0; i < numBad; i++ {
 		nid := types.NodeID{byte(i + 1)}
 		bad = append(bad, nid)
-		require.NoError(t, SetMalicious(db, nid, types.RandomBytes(11)))
+		require.NoError(t, SetMalicious(db, nid, types.RandomBytes(11), time.Now().Local()))
 	}
 	got, err = GetMalicious(db)
 	require.NoError(t, err)

--- a/sql/migrations/0001_initial.sql
+++ b/sql/migrations/0001_initial.sql
@@ -8,7 +8,7 @@ CREATE TABLE blocks
 (
     id       CHAR(20) PRIMARY KEY,
     layer    INT NOT NULL,
-    validity SMALL INT,
+    validity SMALLINT,
     block    BLOB
 ) WITHOUT ROWID;
 CREATE INDEX blocks_by_layer ON blocks (layer, id asc);
@@ -25,15 +25,17 @@ CREATE INDEX ballots_by_layer_by_pubkey ON ballots (layer asc, pubkey);
 
 CREATE TABLE identities
 (
-    pubkey VARCHAR PRIMARY KEY,
-    proof  BLOB
+    pubkey   VARCHAR PRIMARY KEY,
+    proof    BLOB,
+    received INT NOT NULL
+
 ) WITHOUT ROWID;
 
 CREATE TABLE layers
 (
     id              INT PRIMARY KEY DESC,
-    weak_coin       SMALL INT,
-    processed       SMALL INT,
+    weak_coin       SMALLINT,
+    processed       SMALLINT,
     applied_block   VARCHAR,
     state_hash      CHAR(32),
     aggregated_hash CHAR(32)

--- a/sql/proposals/proposals_test.go
+++ b/sql/proposals/proposals_test.go
@@ -2,6 +2,7 @@ package proposals
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -17,7 +18,7 @@ func TestAdd(t *testing.T) {
 	ballot := types.NewExistingBallot(types.BallotID{1}, types.RandomEdSignature(), nodeID, types.LayerID(0))
 
 	require.NoError(t, ballots.Add(db, &ballot))
-	require.NoError(t, identities.SetMalicious(db, nodeID, []byte("proof")))
+	require.NoError(t, identities.SetMalicious(db, nodeID, []byte("proof"), time.Now()))
 	proposal := &types.Proposal{
 		InnerProposal: types.InnerProposal{
 			Ballot:   ballot,
@@ -38,7 +39,7 @@ func TestHas(t *testing.T) {
 	ballot := types.NewExistingBallot(types.BallotID{1}, types.RandomEdSignature(), nodeID, types.LayerID(0))
 
 	require.NoError(t, ballots.Add(db, &ballot))
-	require.NoError(t, identities.SetMalicious(db, nodeID, []byte("proof")))
+	require.NoError(t, identities.SetMalicious(db, nodeID, []byte("proof"), time.Now()))
 	proposal := &types.Proposal{
 		InnerProposal: types.InnerProposal{
 			Ballot:   ballot,
@@ -63,7 +64,7 @@ func TestGet(t *testing.T) {
 	ballot := types.NewExistingBallot(types.BallotID{1}, types.RandomEdSignature(), nodeID, types.LayerID(0))
 
 	require.NoError(t, ballots.Add(db, &ballot))
-	require.NoError(t, identities.SetMalicious(db, nodeID, []byte("proof")))
+	require.NoError(t, identities.SetMalicious(db, nodeID, []byte("proof"), time.Now()))
 	ballot.SetMalicious()
 
 	proposal := &types.Proposal{

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -212,6 +212,11 @@ func (s *Syncer) IsSynced(ctx context.Context) bool {
 	return s.getSyncState() == synced
 }
 
+// SyncedBefore returns true if the node became synced before `epoch` starts.
+func (s *Syncer) SyncedBefore(epoch types.EpochID) bool {
+	return s.getSyncState() == synced && s.getTargetSyncedLayer() < epoch.FirstLayer()
+}
+
 func (s *Syncer) IsBeaconSynced(epoch types.EpochID) bool {
 	_, err := s.beacon.GetBeacon(epoch)
 	return err == nil

--- a/system/mocks/sync.go
+++ b/system/mocks/sync.go
@@ -62,3 +62,17 @@ func (mr *MockSyncStateProviderMockRecorder) IsSynced(arg0 interface{}) *gomock.
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsSynced", reflect.TypeOf((*MockSyncStateProvider)(nil).IsSynced), arg0)
 }
+
+// SyncedBefore mocks base method.
+func (m *MockSyncStateProvider) SyncedBefore(arg0 types.EpochID) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SyncedBefore", arg0)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// SyncedBefore indicates an expected call of SyncedBefore.
+func (mr *MockSyncStateProviderMockRecorder) SyncedBefore(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncedBefore", reflect.TypeOf((*MockSyncStateProvider)(nil).SyncedBefore), arg0)
+}

--- a/system/sync.go
+++ b/system/sync.go
@@ -12,4 +12,5 @@ import (
 type SyncStateProvider interface {
 	IsSynced(context.Context) bool
 	IsBeaconSynced(types.EpochID) bool
+	SyncedBefore(types.EpochID) bool
 }

--- a/tortoise/recover.go
+++ b/tortoise/recover.go
@@ -65,9 +65,9 @@ func Recover(db *datastore.CachedDB, beacon system.BeaconGetter, opts ...Opt) (*
 }
 
 func recoverEpoch(epoch types.EpochID, trtl *Tortoise, db *datastore.CachedDB, beacondb system.BeaconGetter) error {
-	if err := db.IterateEpochATXHeaders(epoch, func(header *types.ActivationTxHeader) bool {
+	if err := db.IterateEpochATXHeaders(epoch, func(header *types.ActivationTxHeader) error {
 		trtl.OnAtx(header.ToData())
-		return true
+		return nil
 	}); err != nil {
 		return err
 	}

--- a/tortoise/tortoise_test.go
+++ b/tortoise/tortoise_test.go
@@ -1892,7 +1892,7 @@ func TestMaliciousBallotsAreIgnored(t *testing.T) {
 	blts, err := ballots.Layer(s.GetState(0).DB, last)
 	require.NoError(t, err)
 	for _, ballot := range blts {
-		require.NoError(t, identities.SetMalicious(s.GetState(0).DB, ballot.SmesherID, []byte("proof")))
+		require.NoError(t, identities.SetMalicious(s.GetState(0).DB, ballot.SmesherID, []byte("proof"), time.Now()))
 	}
 
 	tortoise.TallyVotes(ctx, s.Next())

--- a/tortoise/tortoise_test.go
+++ b/tortoise/tortoise_test.go
@@ -479,10 +479,10 @@ func extractAtxsData(cdb *datastore.CachedDB, epoch types.EpochID) (uint64, uint
 		weight  uint64
 		heights []uint64
 	)
-	if err := cdb.IterateEpochATXHeaders(epoch, func(header *types.ActivationTxHeader) bool {
+	if err := cdb.IterateEpochATXHeaders(epoch, func(header *types.ActivationTxHeader) error {
 		weight += header.GetWeight()
 		heights = append(heights, header.TickHeight())
-		return true
+		return nil
 	}); err != nil {
 		return 0, 0, fmt.Errorf("computing epoch data for %d: %w", epoch, err)
 	}
@@ -1626,10 +1626,10 @@ func TestNetworkRecoversFromFullPartition(t *testing.T) {
 	partitionEnd := last
 	s1.Merge(s2)
 	require.NoError(t, s1.GetState(0).DB.IterateEpochATXHeaders(
-		partitionEnd.GetEpoch(), func(header *types.ActivationTxHeader) bool {
+		partitionEnd.GetEpoch(), func(header *types.ActivationTxHeader) error {
 			tortoise1.OnAtx(header.ToData())
 			tortoise2.OnAtx(header.ToData())
-			return true
+			return nil
 		}))
 	for lid := partitionStart; !lid.After(partitionEnd); lid = lid.Add(1) {
 		mergedBlocks, err := blocks.Layer(s1.GetState(0).DB, lid)


### PR DESCRIPTION
## Motivation
part of #4089

## Changes
- grade atxs as described in https://community.spacemesh.io/t/grading-atxs-for-the-active-set/335, let s be the start of the epoch, and δ the network propagation time.
  - grade 0/evil: ATX was received at time t >= s-3δ, or an equivocation proof was received by time s-δ.
  - grade 1/acceptable: ATX was received at time t < s-3δ before the start of the epoch, and no equivocation proof was received by time s-δ.
  - grade 2/good: ATX was received at time t < s-4δ, and no equivocation proof was received for that id until time s.
 
- miner only include grade 2/good ATXs in its active set for its first ballot of the epoch
- hare only vote for proposals with grade 1/acceptable and 2/good atxs in the activeset
- newly sync'ed node uses the first block of epoch for active set in ref ballot, since it doesn't have accurate received timestamp for atxs or malfeasance proof