### PR TITLE
[Merged by Bors] - atx: remove commitment check

### DIFF
--- a/activation/validation.go
+++ b/activation/validation.go
@@ -184,11 +184,6 @@ func (*Validator) InitialNIPostChallenge(challenge *types.NIPostChallenge, atxs 
 			return fmt.Errorf("challenge publayer (%v) must be after commitment atx publayer (%v)", challenge.PubLayerID, commitmentAtx.PubLayerID)
 		}
 	}
-
-	if *challenge.CommitmentATX == goldenATXID && !challenge.PublishEpoch().IsGenesis() {
-		return fmt.Errorf("golden atx used for commitment atx in epoch %d, but is only valid in epoch 1", challenge.PublishEpoch())
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
this condition can be relaxed without any security concerns. for genesis we can assume that honest nodes are incentivized to pick higher commitment as it will prevent non-honest nodes from influencing beacon. long term - protocol will be extended with material incentive for selecting higher commitment atx. 