### PR TITLE
[Merged by Bors] - Run test coverage in CI and upload to codecov.io

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -12,3 +12,5 @@ coverage:
 
 ignore:
   - "cmd"
+  - "*_scale.go"
+  - "*mock*.go"

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,14 @@
+# ref: https://docs.codecov.com/docs/codecovyml-reference
+coverage:
+  range: 80..100
+  round: down
+  precision: 1
+  status:
+    # ref: https://docs.codecov.com/docs/commit-status
+    project:
+      default:
+        # Avoid false negatives
+        threshold: 1%
+
+ignore:
+  - "cmd"

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -12,5 +12,5 @@ coverage:
 
 ignore:
   - "cmd"
-  - "*_scale.go"
-  - "*mock*.go"
+  - "**/*_scale.go"
+  - "**/*mock*.go"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,6 +209,29 @@ jobs:
           annotate_only: true
           fail_on_failure: ${{ matrix.allow-failure == 'false' }}
 
+  coverage:
+    runs-on: ubuntu-latest
+    needs: filter-changes
+    if: ${{ needs.filter-changes.outputs.nondocchanges == 'true' }}
+    steps:
+      - name: disable TCP/UDP offload
+        run: |
+          sudo ethtool -K eth0 tx off
+          sudo ethtool -K eth0 rx off
+      - uses: actions/checkout@v3
+      - name: set up go
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.go-version }}
+      - name: setup env
+        run: make install
+      - name: test coverage
+        run: make cover
+      - name: Upload to codecov.io
+        uses: codecov/codecov-action@v3
+        with:
+          fail_ci_if_error: true
+
   ci-status:
     # run regardless of status of previous jobs but skip if the required secret is not accessible
     if: always()


### PR DESCRIPTION
## Motivation
We should track code coverage

## Changes
- added `coverage` job in CI
- uploading coverage to codecov.io. Check out https://app.codecov.io/github/spacemeshos/go-spacemesh