### PR TITLE
[Merged by Bors] - Increase timeout for quicktests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,8 +55,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: filter-changes
     if: ${{ needs.filter-changes.outputs.nondocchanges == 'true' }}
-    # should not take more than 2-3 mins
-    timeout-minutes: 5
+    # should not take more than 4-5 mins
+    timeout-minutes: 7
     steps:
       - name: checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
## Motivation
Lately quicktests have been failing due to timeouts more often. In most runs they take ~4 minutes to complete but sometimes they take a bit longer. 7 minutes should be enough in these cases

## Changes
Increased timeout for quicktests from 5 to 7 minutes.

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
