### PR TITLE
[Merged by Bors] - p2p/book: do not overwrite protected address

### DIFF
--- a/p2p/book/book.go
+++ b/p2p/book/book.go
@@ -176,7 +176,7 @@ func (b *Book) Add(src, id ID, raw Address) {
 		b.shareable = append(b.shareable, addr)
 		b.queue.PushBack(addr)
 		b.known[id] = addr
-	} else if addr.Raw.Address != raw {
+	} else if addr.Raw.Address != raw && !addr.protected {
 		addr.Raw.Address = raw
 		addr.bucket = bucket
 	}

--- a/p2p/book/book_test.go
+++ b/p2p/book/book_test.go
@@ -192,6 +192,15 @@ func TestBook(t *testing.T) {
 			),
 			share("2", 3, "1"),
 		}},
+		{"do not overwrite protected", []step{
+			add("1", "/dns4/protect/tcp/1111"),
+			update("1", book.Protect),
+			add("1", "/ip4/0.0.0.0/tcp/1111"),
+			persist(`
+{"id":"1","raw":"/dns4/protect/tcp/1111","class":3,"connected":false}
+4878977086878651846			
+`),
+		}},
 		{"share protected even if it got stale", []step{
 			add("1", "/ip4/0.0.0.0/tcp/6666"),
 			drain(1, "1"),


### PR DESCRIPTION
preserves address of the bootnode, even if you got another seemingly valid address for it. 

there are two concerns:
- ip address may change, so we want to use dns for protected addresses
- it can be abused to feed invalid addresses