### PR TITLE
Remove k1 and k2 from metadata

### DIFF
--- a/activation/challenge_verifier_test.go
+++ b/activation/challenge_verifier_test.go
@@ -220,7 +220,7 @@ func Test_ChallengeValidation_Initial(t *testing.T) {
 	t.Run("invalid post metadata", func(t *testing.T) {
 		t.Parallel()
 		invalidPostMeta := *validPostMeta
-		invalidPostMeta.K1 += 1
+		invalidPostMeta.Challenge[0] ^= 0xFF
 		challenge := createInitialChallenge(*validPost, invalidPostMeta, postConfig.MinNumUnits)
 		challengeBytes, err := codec.Encode(&challenge)
 		req.NoError(err)

--- a/activation/challenge_verifier_test.go
+++ b/activation/challenge_verifier_test.go
@@ -220,7 +220,7 @@ func Test_ChallengeValidation_Initial(t *testing.T) {
 	t.Run("invalid post metadata", func(t *testing.T) {
 		t.Parallel()
 		invalidPostMeta := *validPostMeta
-		invalidPostMeta.Challenge[0] ^= 0xFF
+		invalidPostMeta.LabelsPerUnit = 0
 		challenge := createInitialChallenge(*validPost, invalidPostMeta, postConfig.MinNumUnits)
 		challengeBytes, err := codec.Encode(&challenge)
 		req.NoError(err)

--- a/activation/post.go
+++ b/activation/post.go
@@ -340,8 +340,6 @@ func (mgr *PostSetupManager) GenerateProof(ctx context.Context, challenge []byte
 	m := &types.PostMetadata{
 		Challenge:     proofMetadata.Challenge,
 		LabelsPerUnit: proofMetadata.LabelsPerUnit,
-		K1:            proofMetadata.K1,
-		K2:            proofMetadata.K2,
 	}
 	return p, m, nil
 }

--- a/activation/post_test.go
+++ b/activation/post_test.go
@@ -118,10 +118,9 @@ func TestPostSetupManager_GenerateProof(t *testing.T) {
 		Challenge:       ch,
 		NumUnits:        mgr.opts.NumUnits,
 		LabelsPerUnit:   m.LabelsPerUnit,
-		K1:              m.K1,
-		K2:              m.K2,
 	},
-		config.DefaultConfig())
+		config.DefaultConfig(),
+	)
 	req.NoError(err)
 
 	// Re-instantiate `PostSetupManager`.

--- a/activation/validation.go
+++ b/activation/validation.go
@@ -96,8 +96,6 @@ func (v *Validator) Post(nodeId types.NodeID, commitmentAtxId types.ATXID, PoST 
 		NumUnits:        numUnits,
 		Challenge:       PostMetadata.Challenge,
 		LabelsPerUnit:   PostMetadata.LabelsPerUnit,
-		K1:              PostMetadata.K1,
-		K2:              PostMetadata.K2,
 	}
 
 	if err := verifying.Verify(p, m, (config.Config)(v.cfg)); err != nil {
@@ -121,14 +119,6 @@ func (*Validator) NumUnits(cfg *PostConfig, numUnits uint32) error {
 func (*Validator) PostMetadata(cfg *PostConfig, metadata *types.PostMetadata) error {
 	if metadata.LabelsPerUnit < uint64(cfg.LabelsPerUnit) {
 		return fmt.Errorf("invalid `LabelsPerUnit`; expected: >=%d, given: %d", cfg.LabelsPerUnit, metadata.LabelsPerUnit)
-	}
-
-	if metadata.K1 > cfg.K1 {
-		return fmt.Errorf("invalid `K1`; expected: <=%d, given: %d", cfg.K1, metadata.K1)
-	}
-
-	if metadata.K2 < cfg.K2 {
-		return fmt.Errorf("invalid `K2`; expected: >=%d, given: %d", cfg.K2, metadata.K2)
 	}
 	return nil
 }

--- a/activation/validation_test.go
+++ b/activation/validation_test.go
@@ -549,8 +549,6 @@ func Test_Validate_PostMetadata(t *testing.T) {
 
 		meta := &types.PostMetadata{
 			LabelsPerUnit: postCfg.LabelsPerUnit,
-			K1:            postCfg.K1,
-			K2:            postCfg.K2,
 		}
 
 		err := v.PostMetadata(&postCfg, meta)
@@ -562,38 +560,10 @@ func Test_Validate_PostMetadata(t *testing.T) {
 
 		meta := &types.PostMetadata{
 			LabelsPerUnit: postCfg.LabelsPerUnit - 1,
-			K1:            postCfg.K1,
-			K2:            postCfg.K2,
 		}
 
 		err := v.PostMetadata(&postCfg, meta)
 		require.EqualError(t, err, fmt.Sprintf("invalid `LabelsPerUnit`; expected: >=%d, given: %d", postCfg.LabelsPerUnit, postCfg.LabelsPerUnit-1))
-	})
-
-	t.Run("wrong k1", func(t *testing.T) {
-		t.Parallel()
-
-		meta := &types.PostMetadata{
-			LabelsPerUnit: postCfg.LabelsPerUnit,
-			K1:            postCfg.K1 + 1,
-			K2:            postCfg.K2,
-		}
-
-		err := v.PostMetadata(&postCfg, meta)
-		require.EqualError(t, err, fmt.Sprintf("invalid `K1`; expected: <=%d, given: %d", postCfg.K1, postCfg.K1+1))
-	})
-
-	t.Run("wrong k2", func(t *testing.T) {
-		t.Parallel()
-
-		meta := &types.PostMetadata{
-			LabelsPerUnit: postCfg.LabelsPerUnit,
-			K1:            postCfg.K1,
-			K2:            postCfg.K2 - 1,
-		}
-
-		err := v.PostMetadata(&postCfg, meta)
-		require.EqualError(t, err, fmt.Sprintf("invalid `K2`; expected: >=%d, given: %d", postCfg.K2, postCfg.K2-1))
 	})
 }
 
@@ -637,16 +607,6 @@ func TestValidator_Validate(t *testing.T) {
 	newPostCfg.LabelsPerUnit = nipost.PostMetadata.LabelsPerUnit + 1
 	err = validateNIPost(postProvider.id, postProvider.commitmentAtxId, nipost, challengeHash, poetDb, newPostCfg, postProvider.opts.NumUnits)
 	r.EqualError(err, fmt.Sprintf("invalid `LabelsPerUnit`; expected: >=%d, given: %d", newPostCfg.LabelsPerUnit, nipost.PostMetadata.LabelsPerUnit))
-
-	newPostCfg = postProvider.cfg
-	newPostCfg.K1 = nipost.PostMetadata.K1 - 1
-	err = validateNIPost(postProvider.id, postProvider.commitmentAtxId, nipost, challengeHash, poetDb, newPostCfg, postProvider.opts.NumUnits)
-	r.EqualError(err, fmt.Sprintf("invalid `K1`; expected: <=%d, given: %d", newPostCfg.K1, nipost.PostMetadata.K1))
-
-	newPostCfg = postProvider.cfg
-	newPostCfg.K2 = nipost.PostMetadata.K2 + 1
-	err = validateNIPost(postProvider.id, postProvider.commitmentAtxId, nipost, challengeHash, poetDb, newPostCfg, postProvider.opts.NumUnits)
-	r.EqualError(err, fmt.Sprintf("invalid `K2`; expected: >=%d, given: %d", newPostCfg.K2, nipost.PostMetadata.K2))
 }
 
 func validateNIPost(minerID types.NodeID, commitmentAtx types.ATXID, nipost *types.NIPost, challenge types.Hash32, poetDb poetDbAPI, postCfg PostConfig, numUnits uint32) error {

--- a/common/types/activation.go
+++ b/common/types/activation.go
@@ -643,9 +643,6 @@ func (p *Post) String() string {
 type PostMetadata struct {
 	Challenge     []byte
 	LabelsPerUnit uint64
-
-	K1 uint32
-	K2 uint32
 }
 
 func (m *PostMetadata) MarshalLogObject(encoder log.ObjectEncoder) error {
@@ -654,8 +651,6 @@ func (m *PostMetadata) MarshalLogObject(encoder log.ObjectEncoder) error {
 	}
 	encoder.AddString("Challenge", hex.EncodeToString(m.Challenge))
 	encoder.AddUint64("LabelsPerUnit", m.LabelsPerUnit)
-	encoder.AddUint32("K1", m.K1)
-	encoder.AddUint32("K2", m.K2)
 	return nil
 }
 

--- a/common/types/activation_scale.go
+++ b/common/types/activation_scale.go
@@ -592,20 +592,6 @@ func (t *PostMetadata) EncodeScale(enc *scale.Encoder) (total int, err error) {
 		}
 		total += n
 	}
-	{
-		n, err := scale.EncodeCompact32(enc, uint32(t.K1))
-		if err != nil {
-			return total, err
-		}
-		total += n
-	}
-	{
-		n, err := scale.EncodeCompact32(enc, uint32(t.K2))
-		if err != nil {
-			return total, err
-		}
-		total += n
-	}
 	return total, nil
 }
 
@@ -625,22 +611,6 @@ func (t *PostMetadata) DecodeScale(dec *scale.Decoder) (total int, err error) {
 		}
 		total += n
 		t.LabelsPerUnit = uint64(field)
-	}
-	{
-		field, n, err := scale.DecodeCompact32(dec)
-		if err != nil {
-			return total, err
-		}
-		total += n
-		t.K1 = uint32(field)
-	}
-	{
-		field, n, err := scale.DecodeCompact32(dec)
-		if err != nil {
-			return total, err
-		}
-		total += n
-		t.K2 = uint32(field)
 	}
 	return total, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/spacemeshos/go-scale v1.1.4
 	github.com/spacemeshos/merkle-tree v0.2.1
 	github.com/spacemeshos/poet v0.6.4
-	github.com/spacemeshos/post v0.5.1-0.20230321145139-91e4ec956445
+	github.com/spacemeshos/post v0.5.1-0.20230322144050-66a83af81382
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.15.0

--- a/go.sum
+++ b/go.sum
@@ -588,8 +588,8 @@ github.com/spacemeshos/merkle-tree v0.2.1 h1:BSs/zt1n3ceZcpWdcqNFRvTeAWDlc0W+bql
 github.com/spacemeshos/merkle-tree v0.2.1/go.mod h1:IsrdlW6AHZ4HSi89H7G94ravFCMFZLGnm6To0tQ0SPY=
 github.com/spacemeshos/poet v0.6.4 h1:GV9m2HI465oEGoJgv0Q8oIiwJ2d6++fLMk4u8DiZ3X4=
 github.com/spacemeshos/poet v0.6.4/go.mod h1:9V1UQ2mHYg2sOHLVM2J80Ky+SMe3Qg+l9rvttGTg4so=
-github.com/spacemeshos/post v0.5.1-0.20230321145139-91e4ec956445 h1:01MbpHeCO6TGI9j7SnlsqBCFcd/YR7nKQXM8q7kPaTs=
-github.com/spacemeshos/post v0.5.1-0.20230321145139-91e4ec956445/go.mod h1:d60yAfGkl0DF+Le9oRNeRNkcZDE+caq7aV1t7JDjAlw=
+github.com/spacemeshos/post v0.5.1-0.20230322144050-66a83af81382 h1:3z04XmHhYZWFP2S7jTjfwUvanv6yVBHum0QzJoUntpg=
+github.com/spacemeshos/post v0.5.1-0.20230322144050-66a83af81382/go.mod h1:d60yAfGkl0DF+Le9oRNeRNkcZDE+caq7aV1t7JDjAlw=
 github.com/spacemeshos/sha256-simd v0.1.0 h1:G7Mfu5RYdQiuE+wu4ZyJ7I0TI74uqLhFnKblEnSpjYI=
 github.com/spacemeshos/sha256-simd v0.1.0/go.mod h1:O8CClVIilId7RtuCMV2+YzMj6qjVn75JsxOxaE8vcfM=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=


### PR DESCRIPTION
## Motivation
Removes k1 and k2 from Post Metadata

## Changes
<!-- Please describe in detail the changes made -->

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
