### PR TITLE
[Merged by Bors] - hare: cache tortoise active set

### DIFF
--- a/datastore/store.go
+++ b/datastore/store.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	atxHdrCacheSize      = 600
+	atxHdrCacheSize      = 2000
 	malfeasanceCacheSize = 1000
 )
 

--- a/hare/eligibility/oracle.go
+++ b/hare/eligibility/oracle.go
@@ -59,9 +59,8 @@ type Oracle struct {
 	vrfVerifier    vrfVerifier
 	nonceFetcher   nonceFetcher
 	layersPerEpoch uint32
-	// map from cacheKey to map[types.NodeID]uint64
-	activesCache cache
-	cfg          config.Config
+	activesCache   cache
+	cfg            config.Config
 	log.Log
 }
 

--- a/hare/eligibility/oracle.go
+++ b/hare/eligibility/oracle.go
@@ -59,8 +59,9 @@ type Oracle struct {
 	vrfVerifier    vrfVerifier
 	nonceFetcher   nonceFetcher
 	layersPerEpoch uint32
-	activesCache   cache
-	cfg            config.Config
+	// map from cacheKey to map[types.NodeID]uint64
+	activesCache cache
+	cfg          config.Config
 	log.Log
 }
 
@@ -394,11 +395,8 @@ func (o *Oracle) actives(ctx context.Context, targetLayer types.LayerID) (map[ty
 	)
 	logger.Debug("hare oracle getting active set")
 
-	// lock until any return
-	// note: no need to lock per safeEp - we do not expect many concurrent requests per safeEp (max two)
 	o.lock.Lock()
 	defer o.lock.Unlock()
-
 	// we first try to get the hare active set for a range of safe layers
 	safeLayerStart, safeLayerEnd := safeLayerRange(
 		targetLayer, o.cfg.ConfidenceParam, o.layersPerEpoch, o.cfg.EpochOffset)
@@ -412,19 +410,23 @@ func (o *Oracle) actives(ctx context.Context, targetLayer types.LayerID) (map[ty
 		log.Uint64("layers_per_epoch", uint64(o.layersPerEpoch)),
 		log.FieldNamed("effective_genesis", types.GetEffectiveGenesis()))
 
+	if value, exists := o.activesCache.Get(safeLayerStart.GetEpoch()); exists {
+		return value.(map[types.NodeID]uint64), nil
+	}
+	activeSet, err := o.computeActiveSet(logger, targetLayer, safeLayerStart, safeLayerEnd)
+	if err != nil {
+		return nil, err
+	}
+	o.activesCache.Add(safeLayerStart.GetEpoch(), activeSet)
+	return activeSet, nil
+}
+
+func (o *Oracle) computeActiveSet(logger log.Log, targetLayer, safeLayerStart, safeLayerEnd types.LayerID) (map[types.NodeID]uint64, error) {
 	// check cache first
 	// as long as epochOffset < layersPerEpoch, we expect safeLayerStart and safeLayerEnd to be in the same epoch.
 	// if not, don't attempt to cache on the basis of a single epoch since the safe layer range will span multiple
 	// epochs.
 	if safeLayerStart.GetEpoch() == safeLayerEnd.GetEpoch() {
-		if val, exist := o.activesCache.Get(safeLayerStart.GetEpoch()); exist {
-			activeMap := val.(map[types.NodeID]uint64)
-			logger.With().Debug("found value in cache for safe layer start epoch",
-				log.FieldNamed("safe_layer_start", safeLayerStart),
-				log.FieldNamed("safe_layer_start_epoch", safeLayerStart.GetEpoch()),
-				log.Int("count", len(activeMap)))
-			return activeMap, nil
-		}
 		logger.With().Debug("no value in cache for safe layer start epoch",
 			log.FieldNamed("safe_layer_start", safeLayerStart),
 			log.FieldNamed("safe_layer_start_epoch", safeLayerStart.GetEpoch()))
@@ -518,7 +520,6 @@ func (o *Oracle) actives(ctx context.Context, targetLayer types.LayerID) (map[ty
 		logger.With().Info("successfully got hare active set for layer range",
 			log.Uint32("layer_range_epoch", uint32(safeLayerStart.GetEpoch())),
 			log.Int("count", len(hareActiveSet)))
-		o.activesCache.Add(safeLayerStart.GetEpoch(), hareActiveSet)
 		return hareActiveSet, nil
 	}
 

--- a/hare/eligibility/oracle_test.go
+++ b/hare/eligibility/oracle_test.go
@@ -232,8 +232,7 @@ func TestCalcEligibility_EligibleFromTortoiseActiveSet(t *testing.T) {
 
 	numMiners := 5
 	o.mBeacon.EXPECT().GetBeacon(layer.GetEpoch()).Return(beacon, nil).Times(numMiners)
-	// there is no cache for tortoise active set. so each signature will cause 2 calls to GetBeacon()
-	o.mBeacon.EXPECT().GetBeacon(start.GetEpoch()).Return(beacon, nil).Times(2 * numMiners)
+	o.mBeacon.EXPECT().GetBeacon(start.GetEpoch()).Return(beacon, nil).Times(1)
 	activeSet := types.RandomActiveSet(numMiners)
 	// there is no cache for tortoise active set. so each signature will cause 2 calls to GetEpochAtxs() and 2*numMiners calls to GetAtxHeader()
 	prevEpoch := layer.GetEpoch() - 1
@@ -783,7 +782,7 @@ func TestActives_TortoiseActiveSet(t *testing.T) {
 	o := defaultOracle(t)
 	layer := types.NewLayerID(40)
 	start, _ := safeLayerRange(layer, confidenceParam, defLayersPerEpoch, epochOffset)
-	o.mBeacon.EXPECT().GetBeacon(start.GetEpoch()).Return(types.RandomBeacon(), nil).Times(2)
+	o.mBeacon.EXPECT().GetBeacon(start.GetEpoch()).Return(types.RandomBeacon(), nil).Times(1)
 
 	numMiners := 5
 	activeSet := types.RandomActiveSet(numMiners)
@@ -808,7 +807,7 @@ func TestActives_TortoiseActiveSet(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, createMapWithSize(numMiners), oldActiveSet)
 
-	// tortoise active set is not cached. same layer may yield different answer
+	// tortoise active set is cached. it will have to be bootstrapped to guarantee consensus.
 	activeSet = types.RandomActiveSet(numMiners)
 	for i, id := range activeSet {
 		nodeID := types.BytesToNodeID([]byte(strconv.Itoa(numMiners + i)))
@@ -828,8 +827,7 @@ func TestActives_TortoiseActiveSet(t *testing.T) {
 	}
 	newActiveSet, err := o.actives(context.Background(), layer)
 	require.NoError(t, err)
-	require.Equal(t, createMapWithSize(numMiners*2), newActiveSet)
-	require.NotEqual(t, oldActiveSet, newActiveSet)
+	require.Equal(t, oldActiveSet, newActiveSet)
 }
 
 func TestActives_ConcurrentCalls(t *testing.T) {


### PR DESCRIPTION
related: https://github.com/spacemeshos/go-spacemesh/issues/4164

without cache hare doesn't work with large number of activations, as it takes too long if eligibility verification triggers load of 1000s of activations for every single message