### PR TITLE
[Merged by Bors] - Ignore systest for coverage and use -coverpkg for better accuracy

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -14,3 +14,4 @@ ignore:
   - "cmd"
   - "**/*_scale.go"
   - "**/*mock*.go"
+  - systest

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -31,4 +31,4 @@ jobs:
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v3
         with:
-          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -153,11 +153,8 @@ lint-github-action: get-libs
 	./bin/golangci-lint run --config .golangci.yml --out-format=github-actions
 .PHONY: lint-github-action
 
-, := ,
-UNIT_TESTS_COMMA_SEP:=$(subst $() $(),$(,),$(UNIT_TESTS))
-
 cover: get-libs
-	@$(ULIMIT) CGO_LDFLAGS="$(CGO_TEST_LDFLAGS)" go test -coverprofile=cover.out -timeout 0 -p 1 -coverpkg=$(UNIT_TESTS_COMMA_SEP) $(UNIT_TESTS)
+	@$(ULIMIT) CGO_LDFLAGS="$(CGO_TEST_LDFLAGS)" go test -coverprofile=cover.out -timeout 0 -p 1 -coverpkg=./... $(UNIT_TESTS)
 .PHONY: cover
 
 tag-and-build:

--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,7 @@ lint-github-action: get-libs
 .PHONY: lint-github-action
 
 cover: get-libs
-	@$(ULIMIT) CGO_LDFLAGS="$(CGO_TEST_LDFLAGS)" go test -coverprofile=cover.out -timeout 0 -p 1 $(UNIT_TESTS)
+	@$(ULIMIT) CGO_LDFLAGS="$(CGO_TEST_LDFLAGS)" go test -coverprofile=cover.out -timeout 0 -p 1 -coverpkg=$(UNIT_TESTS) $(UNIT_TESTS)
 .PHONY: cover
 
 tag-and-build:

--- a/Makefile
+++ b/Makefile
@@ -153,8 +153,11 @@ lint-github-action: get-libs
 	./bin/golangci-lint run --config .golangci.yml --out-format=github-actions
 .PHONY: lint-github-action
 
+, := ,
+UNIT_TESTS_COMMA_SEP:=$(subst $() $(),$(,),$(UNIT_TESTS))
+
 cover: get-libs
-	@$(ULIMIT) CGO_LDFLAGS="$(CGO_TEST_LDFLAGS)" go test -coverprofile=cover.out -timeout 0 -p 1 -coverpkg=$(UNIT_TESTS) $(UNIT_TESTS)
+	@$(ULIMIT) CGO_LDFLAGS="$(CGO_TEST_LDFLAGS)" go test -coverprofile=cover.out -timeout 0 -p 1 -coverpkg=$(UNIT_TESTS_COMMA_SEP) $(UNIT_TESTS)
 .PHONY: cover
 
 tag-and-build:


### PR DESCRIPTION
## Motivation
The `systest` directory contains tests so we don't want to include it in test coverage report (otherwise we will be checking if test utilities are tested too).

With the `-coverpkg` flag, go will also include packages without _any_ tests and include coverage _across packages_ (for example, if test for package `X` executes some code from package `Y` - then w/o this flag it would not count as covering code in `Y`).
