### PR TITLE
[Merged by Bors] - systest: improvements after tests on larger scale

### DIFF
--- a/systest/README.md
+++ b/systest/README.md
@@ -22,10 +22,11 @@ This testing setup can run on top of any k8s installation. The instructions belo
 
 3. Install chaos-mesh
 
+
     chaos-mesh is used for some tests. See <https://chaos-mesh.org/docs/quick-start/> for more up-to-date instructions.
 
     ```bash
-    curl -sSL https://mirrors.chaos-mesh.org/v2.3.0/install.sh | bash
+    curl -sSL https://mirrors.chaos-mesh.org/v2.5.1/install.sh | bash
     ```
 
 4. Install `loki` to use grafana dashboard.

--- a/systest/cluster/discover.go
+++ b/systest/cluster/discover.go
@@ -12,21 +12,21 @@ import (
 	"github.com/spacemeshos/go-spacemesh/systest/testcontext"
 )
 
-func discoverNodes(ctx *testcontext.Context, kind string, pt PodType) ([]*NodeClient, error) {
-	pods, err := ctx.Client.CoreV1().Pods(ctx.Namespace).List(ctx,
+func discoverNodes(ctx *testcontext.Context, kind string) ([]*NodeClient, error) {
+	deployments, err := ctx.Client.AppsV1().Deployments(ctx.Namespace).List(ctx,
 		apimetav1.ListOptions{LabelSelector: fmt.Sprintf("app=%s", kind)})
 	if err != nil {
 		return nil, fmt.Errorf("failed to list pods app=%s: %w", kind, err)
 	}
 	var (
 		eg      errgroup.Group
-		clients = make(chan *NodeClient, len(pods.Items))
+		clients = make(chan *NodeClient, len(deployments.Items))
 		rst     []*NodeClient
 	)
-	for _, pod := range pods.Items {
-		pod := pod
+	for _, deployment := range deployments.Items {
+		deployment := deployment
 		eg.Go(func() error {
-			client, err := waitNode(ctx, pod.Name, pt)
+			client, err := waitNode(ctx, deployment.Name)
 			if err != nil {
 				return err
 			}

--- a/systest/cluster/nodes.go
+++ b/systest/cluster/nodes.go
@@ -150,7 +150,9 @@ func deployPoetD(ctx *testcontext.Context, id string, flags ...DeploymentFlag) (
 						WithName("poet").
 						WithImage(ctx.PoetImage).
 						WithArgs(args...).
-						WithPorts(corev1.ContainerPort().WithName("rest").WithProtocol("TCP").WithContainerPort(poetPort)).
+						WithPorts(
+							corev1.ContainerPort().WithName("rest").WithProtocol("TCP").WithContainerPort(poetPort),
+						).
 						WithVolumeMounts(
 							corev1.VolumeMount().WithName("config").WithMountPath(configDir),
 						).
@@ -342,7 +344,6 @@ func deployNodes(ctx *testcontext.Context, kind string, from, to int, flags []De
 			}
 			clients <- node
 			return nil
-
 		})
 	}
 	if err := eg.Wait(); err != nil {

--- a/systest/cluster/nodes.go
+++ b/systest/cluster/nodes.go
@@ -3,7 +3,6 @@ package cluster
 import (
 	"encoding/json"
 	"fmt"
-	"math/rand"
 	"sort"
 	"strconv"
 	"strings"
@@ -12,7 +11,6 @@ import (
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
-	apiappsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	apimetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -94,10 +92,6 @@ const (
 	buckets = 10
 )
 
-func persistentVolumeClaim(podname string) string {
-	return fmt.Sprintf("%s-%s", persistentVolumeName, podname)
-}
-
 const (
 	prometheusScrapePort = 9216
 	phlareScrapePort     = 6060
@@ -109,10 +103,6 @@ type Node struct {
 	IP        string
 	P2P, GRPC uint16
 
-	// Identifier let's uniquely select the k8s resource
-	Identifier string
-
-	Created   time.Time
 	Restarted time.Time
 }
 
@@ -132,7 +122,7 @@ type NodeClient struct {
 	*grpc.ClientConn
 }
 
-func deployPoetPod(ctx *testcontext.Context, id string, flags ...DeploymentFlag) (*NodeClient, error) {
+func deployPoetD(ctx *testcontext.Context, id string, flags ...DeploymentFlag) (*NodeClient, error) {
 	args := []string{
 		"-c=" + configDir + attachedPoetConfig,
 	}
@@ -142,45 +132,67 @@ func deployPoetPod(ctx *testcontext.Context, id string, flags ...DeploymentFlag)
 
 	ctx.Log.Debugw("deploying poet pod", "id", id, "args", args, "image", ctx.PoetImage)
 
-	labels := nodeLabels("poet", id)
-	pod := corev1.Pod(fmt.Sprintf("poet-%d", rand.Int()), ctx.Namespace).
+	labels := nodeLabels(poetApp, id)
+	deployment := appsv1.Deployment(id, ctx.Namespace).
 		WithLabels(labels).
-		WithSpec(
-			corev1.PodSpec().
-				WithNodeSelector(ctx.NodeSelector).
-				WithVolumes(corev1.Volume().
-					WithName("config").
-					WithConfigMap(corev1.ConfigMapVolumeSource().WithName(poetConfigMapName)),
-				).
-				WithContainers(corev1.Container().
-					WithName("poet").
-					WithImage(ctx.PoetImage).
-					WithArgs(args...).
-					WithPorts(corev1.ContainerPort().WithName("rest").WithProtocol("TCP").WithContainerPort(poetPort)).
-					WithVolumeMounts(
-						corev1.VolumeMount().WithName("config").WithMountPath(configDir),
+		WithSpec(appsv1.DeploymentSpec().
+			WithSelector(metav1.LabelSelector().WithMatchLabels(labels)).
+			WithReplicas(1).
+			WithTemplate(corev1.PodTemplateSpec().
+				WithLabels(labels).
+				WithSpec(corev1.PodSpec().
+					WithNodeSelector(ctx.NodeSelector).
+					WithVolumes(corev1.Volume().
+						WithName("config").
+						WithConfigMap(corev1.ConfigMapVolumeSource().WithName(poetConfigMapName)),
 					).
-					WithResources(corev1.ResourceRequirements().
-						WithRequests(poetResources.Get(ctx.Parameters).Requests).
-						WithLimits(poetResources.Get(ctx.Parameters).Limits),
+					WithContainers(corev1.Container().
+						WithName("poet").
+						WithImage(ctx.PoetImage).
+						WithArgs(args...).
+						WithPorts(corev1.ContainerPort().WithName("rest").WithProtocol("TCP").WithContainerPort(poetPort)).
+						WithVolumeMounts(
+							corev1.VolumeMount().WithName("config").WithMountPath(configDir),
+						).
+						WithResources(corev1.ResourceRequirements().
+							WithRequests(poetResources.Get(ctx.Parameters).Requests).
+							WithLimits(poetResources.Get(ctx.Parameters).Limits),
+						),
 					),
-				),
-		)
+				)))
 
-	_, err := ctx.Client.CoreV1().Pods(ctx.Namespace).Apply(ctx, pod, apimetav1.ApplyOptions{FieldManager: "test"})
+	_, err := ctx.Client.AppsV1().Deployments(ctx.Namespace).Apply(ctx, deployment, apimetav1.ApplyOptions{FieldManager: "test"})
 	if err != nil {
 		return nil, fmt.Errorf("create poet: %w", err)
 	}
-	ppod, err := waitNode(ctx, *pod.Name, Poet)
+	ppod, err := waitNode(ctx, id)
 	if err != nil {
 		return nil, err
 	}
 	return ppod, nil
 }
 
+func deployBootnodeSvc(ctx *testcontext.Context, id string) error {
+	labels := nodeLabels(bootnodeApp, id)
+	svc := corev1.Service(id, ctx.Namespace).
+		WithLabels(labels).
+		WithSpec(corev1.ServiceSpec().
+			WithSelector(labels).
+			WithPorts(
+				corev1.ServicePort().WithName("grpc").WithPort(9092).WithProtocol("TCP"),
+			).
+			WithClusterIP("None"),
+		)
+	_, err := ctx.Client.CoreV1().Services(ctx.Namespace).Apply(ctx, svc, apimetav1.ApplyOptions{FieldManager: "test"})
+	if err != nil {
+		return fmt.Errorf("apply headless service: %w", err)
+	}
+	return nil
+}
+
 func deployPoetSvc(ctx *testcontext.Context, id string) (*apiv1.Service, error) {
 	ctx.Log.Debugw("deploying poet service", "id", id)
-	labels := nodeLabels("poet", id)
+	labels := nodeLabels(poetApp, id)
 	svc := corev1.Service(id, ctx.Namespace).
 		WithLabels(labels).
 		WithSpec(corev1.ServiceSpec().
@@ -194,7 +206,7 @@ func deployPoetSvc(ctx *testcontext.Context, id string) (*apiv1.Service, error) 
 }
 
 func createPoetIdentifier(id int) string {
-	return fmt.Sprintf("%s-%d", poetSvc, id)
+	return fmt.Sprintf("%s-%d", poetApp, id)
 }
 
 func decodePoetIdentifier(id string) int {
@@ -216,7 +228,7 @@ func deployPoet(ctx *testcontext.Context, id string, flags ...DeploymentFlag) (*
 		return nil, fmt.Errorf("apply poet service: %w", err)
 	}
 
-	node, err := deployPoetPod(ctx, id, flags...)
+	node, err := deployPoetD(ctx, id, flags...)
 	if err != nil {
 		return nil, err
 	}
@@ -226,7 +238,7 @@ func deployPoet(ctx *testcontext.Context, id string, flags ...DeploymentFlag) (*
 
 func deletePoet(ctx *testcontext.Context, id string) error {
 	errCfg := ctx.Client.CoreV1().ConfigMaps(ctx.Namespace).Delete(ctx, id, apimetav1.DeleteOptions{})
-	errPod := ctx.Client.CoreV1().Pods(ctx.Namespace).DeleteCollection(ctx, apimetav1.DeleteOptions{}, apimetav1.ListOptions{LabelSelector: labelSelector(id)})
+	errPod := ctx.Client.AppsV1().Deployments(ctx.Namespace).DeleteCollection(ctx, apimetav1.DeleteOptions{}, apimetav1.ListOptions{LabelSelector: labelSelector(id)})
 	var errSvc error
 	if svcs, err := ctx.Client.CoreV1().Services(ctx.Namespace).List(ctx, apimetav1.ListOptions{LabelSelector: labelSelector(id)}); err == nil {
 		for _, svc := range svcs.Items {
@@ -245,14 +257,6 @@ func deletePoet(ctx *testcontext.Context, id string) error {
 	return errSvc
 }
 
-func getStatefulSet(ctx *testcontext.Context, name string) (*apiappsv1.StatefulSet, error) {
-	set, err := ctx.Client.AppsV1().StatefulSets(ctx.Namespace).Get(ctx, name, apimetav1.GetOptions{})
-	if err != nil {
-		return nil, err
-	}
-	return set, nil
-}
-
 // areContainersReady checks if all containers are ready in pod.
 func areContainersReady(pod *apiv1.Pod) bool {
 	for _, c := range pod.Status.ContainerStatuses {
@@ -263,9 +267,9 @@ func areContainersReady(pod *apiv1.Pod) bool {
 	return true
 }
 
-func waitPod(ctx *testcontext.Context, name string) (*apiv1.Pod, error) {
+func waitPod(ctx *testcontext.Context, id string) (*apiv1.Pod, error) {
 	watcher, err := ctx.Client.CoreV1().Pods(ctx.Namespace).Watch(ctx, apimetav1.ListOptions{
-		FieldSelector: fmt.Sprintf("metadata.name=%s", name),
+		LabelSelector: labelSelector(id),
 	})
 	if err != nil {
 		return nil, err
@@ -278,7 +282,7 @@ func waitPod(ctx *testcontext.Context, name string) (*apiv1.Pod, error) {
 			return nil, ctx.Err()
 		case ev, open := <-watcher.ResultChan():
 			if !open {
-				return nil, fmt.Errorf("watcher is terminated while waiting for pod %v", name)
+				return nil, fmt.Errorf("watcher is terminated while waiting for pod with id %v", id)
 			}
 			if ev.Type == watch.Deleted {
 				return nil, nil
@@ -287,7 +291,7 @@ func waitPod(ctx *testcontext.Context, name string) (*apiv1.Pod, error) {
 		}
 		switch pod.Status.Phase {
 		case apiv1.PodFailed:
-			return nil, fmt.Errorf("pod failed %s", name)
+			return nil, fmt.Errorf("pod with id failed %s", id)
 		case apiv1.PodRunning:
 			if areContainersReady(pod) {
 				return pod, nil
@@ -310,7 +314,7 @@ func labelSelector(id string) string {
 	return fmt.Sprintf("id=%s", id)
 }
 
-func deployNodes(ctx *testcontext.Context, name string, from, to int, flags []DeploymentFlag) ([]*NodeClient, error) {
+func deployNodes(ctx *testcontext.Context, kind string, from, to int, flags []DeploymentFlag) ([]*NodeClient, error) {
 	var (
 		eg      errgroup.Group
 		clients = make(chan *NodeClient, to-from)
@@ -322,21 +326,23 @@ func deployNodes(ctx *testcontext.Context, name string, from, to int, flags []De
 		for idx := 0; idx < ctx.PoetSize; idx++ {
 			finalFlags = append(finalFlags, PoetEndpoint(MakePoetEndpoint(idx)))
 		}
-
 		eg.Go(func() error {
-			setname := fmt.Sprintf("%s-%d", name, i)
-			podname := fmt.Sprintf("%s-0", setname)
-			labels := nodeLabels(name, podname)
+			id := fmt.Sprintf("%s-%d", kind, i)
+			labels := nodeLabels(kind, id)
 			labels["bucket"] = strconv.Itoa(i % buckets)
-			if err := deployNode(ctx, setname, labels, finalFlags); err != nil {
+			if err := deployNode(ctx, id, labels, finalFlags); err != nil {
 				return err
 			}
-			node, err := waitNode(ctx, podname, Smesher)
+			node, err := waitNode(ctx, id)
 			if err != nil {
 				return err
 			}
+			if node == nil {
+				return fmt.Errorf("pod was deleted %s", id)
+			}
 			clients <- node
 			return nil
+
 		})
 	}
 	if err := eg.Wait(); err != nil {
@@ -353,39 +359,18 @@ func deployNodes(ctx *testcontext.Context, name string, from, to int, flags []De
 	return rst, nil
 }
 
-func deleteNode(ctx *testcontext.Context, podname string) error {
-	setname := setName(podname)
-	if err := ctx.Client.CoreV1().ConfigMaps(ctx.Namespace).Delete(ctx, setname, apimetav1.DeleteOptions{}); err != nil {
-		return fmt.Errorf("deleting configmap %s/%s: %w", ctx.Namespace, setname, err)
+func deleteNode(ctx *testcontext.Context, id string) error {
+	if err := ctx.Client.CoreV1().ConfigMaps(ctx.Namespace).Delete(ctx, id, apimetav1.DeleteOptions{}); err != nil {
+		return fmt.Errorf("deleting configmap %s/%s: %w", ctx.Namespace, id, err)
 	}
-	if err := ctx.Client.AppsV1().StatefulSets(ctx.Namespace).
-		Delete(ctx, setname, apimetav1.DeleteOptions{}); err != nil {
+	if err := ctx.Client.AppsV1().Deployments(ctx.Namespace).
+		Delete(ctx, id, apimetav1.DeleteOptions{}); err != nil {
 		return err
-	}
-	pvcname := persistentVolumeClaim(podname)
-	if err := ctx.Client.CoreV1().PersistentVolumeClaims(ctx.Namespace).Delete(ctx,
-		pvcname, apimetav1.DeleteOptions{}); err != nil {
-		return fmt.Errorf("failed deleting pvc %s: %w", pvcname, err)
 	}
 	return nil
 }
 
-func deployNode(ctx *testcontext.Context, name string, labels map[string]string, flags []DeploymentFlag) error {
-	svc := corev1.Service(headlessSvc(name), ctx.Namespace).
-		WithLabels(labels).
-		WithSpec(corev1.ServiceSpec().
-			WithSelector(labels).
-			WithPorts(
-				corev1.ServicePort().WithName("grpc").WithPort(9092).WithProtocol("TCP"),
-			).
-			WithClusterIP("None"),
-		)
-
-	_, err := ctx.Client.CoreV1().Services(ctx.Namespace).Apply(ctx, svc, apimetav1.ApplyOptions{FieldManager: "test"})
-	if err != nil {
-		return fmt.Errorf("apply headless service: %w", err)
-	}
-
+func deployNode(ctx *testcontext.Context, id string, labels map[string]string, flags []DeploymentFlag) error {
 	cmd := []string{
 		"/bin/go-spacemesh",
 		"-c=" + configDir + attachedSmesherConfig,
@@ -399,36 +384,27 @@ func deployNode(ctx *testcontext.Context, name string, labels map[string]string,
 	for _, flag := range flags {
 		cmd = append(cmd, flag.Flag())
 	}
-	sset := appsv1.StatefulSet(name, ctx.Namespace).
-		WithSpec(appsv1.StatefulSetSpec().
-			WithUpdateStrategy(appsv1.StatefulSetUpdateStrategy().WithType(apiappsv1.OnDeleteStatefulSetStrategyType)).
-			WithPodManagementPolicy(apiappsv1.ParallelPodManagement).
-			WithReplicas(1).
-			WithServiceName(*svc.Name).
-			WithVolumeClaimTemplates(
-				corev1.PersistentVolumeClaim(persistentVolumeName, ctx.Namespace).
-					WithSpec(corev1.PersistentVolumeClaimSpec().
-						WithAccessModes(apiv1.ReadWriteOnce).
-						WithStorageClassName(ctx.Storage.Class).
-						WithResources(corev1.ResourceRequirements().
-							WithRequests(apiv1.ResourceList{apiv1.ResourceStorage: resource.MustParse(ctx.Storage.Size)}))),
-			).
+	deployment := appsv1.Deployment(id, ctx.Namespace).
+		WithLabels(labels).
+		WithSpec(appsv1.DeploymentSpec().
 			WithSelector(metav1.LabelSelector().WithMatchLabels(labels)).
+			WithReplicas(1).
 			WithTemplate(corev1.PodTemplateSpec().
+				WithLabels(labels).
 				WithAnnotations(
 					map[string]string{
-						"prometheus.io/port":        strconv.Itoa(prometheusScrapePort),
-						"prometheus.io/scrape":      "true",
-						"phlare.grafana.com/port":   strconv.Itoa(phlareScrapePort),
-						"phlare.grafana.com/scrape": "true",
+						"prometheus.io/port":   strconv.Itoa(prometheusScrapePort),
+						"prometheus.io/scrape": "true",
 					},
 				).
-				WithLabels(labels).
 				WithSpec(corev1.PodSpec().
 					WithNodeSelector(ctx.NodeSelector).
-					WithVolumes(corev1.Volume().
-						WithName("config").
-						WithConfigMap(corev1.ConfigMapVolumeSource().WithName(spacemeshConfigMapName)),
+					WithVolumes(
+						corev1.Volume().WithName("config").
+							WithConfigMap(corev1.ConfigMapVolumeSource().WithName(spacemeshConfigMapName)),
+						corev1.Volume().WithName("data").
+							WithEmptyDir(corev1.EmptyDirVolumeSource().
+								WithSizeLimit(resource.MustParse(ctx.Storage.Size))),
 					).
 					WithContainers(corev1.Container().
 						WithName("smesher").
@@ -457,57 +433,41 @@ func deployNode(ctx *testcontext.Context, name string, labels map[string]string,
 							corev1.EnvVar().WithName("GOMAXPROCS").WithValue("4"),
 						).
 						WithCommand(cmd...),
-					)),
-			),
-		)
-
-	_, err = ctx.Client.AppsV1().StatefulSets(ctx.Namespace).
-		Apply(ctx, sset, apimetav1.ApplyOptions{FieldManager: "test"})
+					),
+				)))
+	_, err := ctx.Client.AppsV1().Deployments(ctx.Namespace).
+		Apply(ctx, deployment, apimetav1.ApplyOptions{FieldManager: "test"})
 	if err != nil {
-		return fmt.Errorf("apply statefulset: %w", err)
+		return fmt.Errorf("apply pod %s: %w", id, err)
+	}
+	if strings.Contains(id, bootnodeApp) {
+		return deployBootnodeSvc(ctx, id)
 	}
 	return nil
 }
 
-// PodType indicates the type of pod.
-type PodType int
-
-const (
-	// Smesher ...
-	Smesher PodType = iota
-	// Poet ...
-	Poet
-)
-
-func waitNode(tctx *testcontext.Context, podname string, pt PodType) (*NodeClient, error) {
+func waitNode(tctx *testcontext.Context, id string) (*NodeClient, error) {
 	attempt := func() (*NodeClient, error) {
-		pod, err := waitPod(tctx, podname)
+		pod, err := waitPod(tctx, id)
 		if err != nil {
 			return nil, err
 		}
 		if pod == nil {
 			return nil, nil
 		}
-		if pt == Poet {
+		if strings.Contains(id, poetApp) {
 			return &NodeClient{
 				Node: Node{
-					Name:       podname,
-					Identifier: pod.Labels["id"],
+					Name: id,
 				},
 			}, nil
 		}
-		set, err := getStatefulSet(tctx, setName(podname))
-		if err != nil {
-			return nil, err
-		}
 		node := Node{
-			Name:       podname,
-			Identifier: pod.Labels["id"],
-			IP:         pod.Status.PodIP,
-			P2P:        7513,
-			GRPC:       9092,
-			Created:    set.CreationTimestamp.Time,
-			Restarted:  pod.CreationTimestamp.Time,
+			Name:      id,
+			IP:        pod.Status.PodIP,
+			P2P:       7513,
+			GRPC:      9092,
+			Restarted: pod.CreationTimestamp.Time,
 		}
 		// don't block connection, it is expected that some nodes are unavailable during test
 		conn, err := grpc.DialContext(tctx, node.GRPCEndpoint(),

--- a/systest/parameters/bignet/poet.conf
+++ b/systest/parameters/bignet/poet.conf
@@ -1,0 +1,3 @@
+epoch-duration="250m"
+phase-shift="100m"
+cycle-gap="15m"

--- a/systest/parameters/bignet/resources.env
+++ b/systest/parameters/bignet/resources.env
@@ -1,0 +1,2 @@
+poet_resources={"requests": {"cpu": "1", "memory": "8Gi"}, "limits": {"cpu": "2", "memory": "8Gi"}}
+smesher_resources={"requests": {"cpu": "0.2", "memory": "800Mi"}, "limits": {"cpu": "2", "memory": "2Gi"}}

--- a/systest/parameters/bignet/smesher.json
+++ b/systest/parameters/bignet/smesher.json
@@ -1,0 +1,33 @@
+{
+    "preset": "fastnet",
+    "main": {
+        "layers-per-epoch": 50,
+        "layer-duration": "5m"
+    },
+    "poet": {
+        "phase-shift": "100m",
+        "cycle-gap": "15m",
+        "grace-period": "1m"
+    },
+    "tortoise": {
+        "tortoise-zdist": 4,
+        "tortoise-hdist": 10
+    },
+    "hare": {
+        "hare-wakeup-delta": "30s",
+        "hare-round-duration": "30s",
+        "hare-limit-iterations": 4,
+        "hare-committee-size": 200
+    },
+    "hare-eligibility": {
+        "eligibility-confidence-param": 10
+    },
+    "beacon": {
+        "beacon-grace-period-duration": "1m",
+        "beacon-proposal-duration": "1m",
+        "beacon-first-voting-round-duration": "10m",
+        "beacon-rounds-number": 100,
+        "beacon-voting-round-duration": "1m",
+        "beacon-weak-coin-round-duration": "1m"
+    }
+}

--- a/systest/parameters/chaos/delay.yaml
+++ b/systest/parameters/chaos/delay.yaml
@@ -1,7 +1,7 @@
 apiVersion: chaos-mesh.org/v1alpha1
 kind: NetworkChaos
 metadata:
-  name: delay-smesher
+  name: delay-smesher-200
 spec:
   action: delay
   mode: all
@@ -12,6 +12,6 @@ spec:
         values: ["boot", "smesher"]
   direction: to
   delay:
-    latency: "50ms"
+    latency: "200ms"
     correlation: "0"
-    jitter: "50ms"
+    jitter: "10ms"

--- a/systest/tests/steps_test.go
+++ b/systest/tests/steps_test.go
@@ -298,12 +298,8 @@ func TestStepVerifySynced(t *testing.T) {
 			if time.Since(node.Restarted) < 30*time.Minute {
 				continue
 			}
-			if time.Since(node.Created) < 120*time.Minute {
-				continue
-			}
 			cctx.Log.Warnw("node is not synced",
 				"node", node.Name,
-				"created", node.Created,
 				"restarted", node.Restarted,
 			)
 			return false


### PR DESCRIPTION
changes:
- use deployment with 1 replica to manage apps. we absolutely have to redeploy apps (poet, spacemesh) if spot vm is deleted. pod will not reschedule by itself, so it is not a good fit
- deploy services only for poet and bootnode. i run into limits for number of services
- use local storage instead of pvc. local storage is significantly faster, also provisioning time is significantly faster. state won't recover if vm get deleted, but thats acceptable for testing
- scale number of bootnodes. 2 bootnodes for every 1000 of smeshers
- new configuration in systest/parameters/bignet