### PR TITLE
[Merged by Bors] - Moved local opinion changed message to debug

### DIFF
--- a/tortoise/tortoise.go
+++ b/tortoise/tortoise.go
@@ -621,7 +621,7 @@ func (t *turtle) onHareOutput(lid types.LayerID, bid types.BlockID) {
 		return
 	}
 	if !lid.After(t.processed) && withinDistance(t.Config.Hdist, lid, t.last) {
-		t.logger.With().Info("local opinion changed within hdist",
+		t.logger.With().Debug("local opinion changed within hdist",
 			lid,
 			log.Stringer("verified", t.verified),
 			log.Stringer("previous", previous),


### PR DESCRIPTION
That message prints many lines during startup for a node that had a lot of local state but was restarted.

Alternative would be something like:
```
diff --git a/tortoise/tortoise.go b/tortoise/tortoise.go
index 02d01f79..549471d1 100644
--- a/tortoise/tortoise.go
+++ b/tortoise/tortoise.go
@@ -621,12 +621,14 @@ func (t *turtle) onHareOutput(lid types.LayerID, bid types.BlockID) {
                return
        }
        if !lid.After(t.processed) && withinDistance(t.Config.Hdist, lid, t.last) {
-               t.logger.With().Info("local opinion changed within hdist",
-                       lid,
-                       log.Stringer("verified", t.verified),
-                       log.Stringer("previous", previous),
-                       log.Stringer("new", bid),
-               )
+               if previous != types.EmptyBlockID {
+                       t.logger.With().Info("local opinion changed within hdist",
+                               lid,
+                               log.Stringer("verified", t.verified),
+                               log.Stringer("previous", previous),
+                               log.Stringer("new", bid),
+                       )
+               }
                t.onOpinionChange(lid)
```