### PR TITLE
[Merged by Bors] - datastore: use tuple instead of fmt.Sprintf

### DIFF
--- a/datastore/cache.go
+++ b/datastore/cache.go
@@ -17,9 +17,14 @@ func NewMalfeasanceCache(size int) *Cache[types.NodeID, types.MalfeasanceProof] 
 	return NewCache[types.NodeID, types.MalfeasanceProof](size)
 }
 
+type VrfNonceKey struct {
+	ID    types.NodeID
+	Epoch types.EpochID
+}
+
 // NewVRFCache creates a new cache for VRF nonces.
-func NewVRFNonceCache(size int) *Cache[string, types.VRFPostIndex] {
-	return NewCache[string, types.VRFPostIndex](size)
+func NewVRFNonceCache(size int) *Cache[VrfNonceKey, types.VRFPostIndex] {
+	return NewCache[VrfNonceKey, types.VRFPostIndex](size)
 }
 
 // Cache holds a lru cache of recent T instances.

--- a/datastore/store.go
+++ b/datastore/store.go
@@ -29,7 +29,7 @@ type CachedDB struct {
 	logger log.Log
 
 	atxHdrCache   *Cache[types.ATXID, types.ActivationTxHeader]
-	vrfNonceCache *Cache[string, types.VRFPostIndex]
+	vrfNonceCache *Cache[VrfNonceKey, types.VRFPostIndex]
 
 	// used to coordinate db update and cache
 	mu               sync.Mutex
@@ -128,7 +128,7 @@ func (db *CachedDB) AddMalfeasanceProof(id types.NodeID, proof *types.Malfeasanc
 // VRFNonce returns the VRF nonce of for the given node in the given epoch. This function is thread safe and will return an error if the
 // nonce is not found in the ATX DB.
 func (db *CachedDB) VRFNonce(id types.NodeID, epoch types.EpochID) (types.VRFPostIndex, error) {
-	key := fmt.Sprintf("%s-%s", id, epoch)
+	key := VrfNonceKey{id, epoch}
 	if nonce, ok := db.vrfNonceCache.Get(key); ok {
 		return *nonce, nil
 	}


### PR DESCRIPTION
i was looking at profiles from scale test, and noticed that this gets on heap very often.
i think tuple is a cleaner approach, also nodeID.String encodes to hex 