### PR TITLE
[Merged by Bors] - Made the max msg sizes in grpc adjustable

### DIFF
--- a/api/config/config.go
+++ b/api/config/config.go
@@ -20,6 +20,8 @@ const (
 	defaultStartSmesherService     = false
 	defaultStartTransactionService = false
 	defaultStartActivationService  = false
+	defaultGrpcSendBufferSize      = 1024 * 1024 * 10
+	defaultGrpcRecvBufferSize      = 1024 * 1024 * 10
 
 	defaultSmesherStreamInterval = 1 * time.Second
 )
@@ -29,8 +31,12 @@ type Config struct {
 	StartGrpcServices   []string `mapstructure:"grpc"`
 	GrpcServerPort      int      `mapstructure:"grpc-port"`
 	GrpcServerInterface string   `mapstructure:"grpc-interface"`
-	StartJSONServer     bool     `mapstructure:"json-server"`
-	JSONServerPort      int      `mapstructure:"json-port"`
+	// GRPC send and receive buffer size
+	GrpcSendBufferSize int `mapstructure:"grpc-send-buffer-size"`
+	GrpcRecvBufferSize int `mapstructure:"grpc-recv-buffer-size"`
+
+	StartJSONServer bool `mapstructure:"json-server"`
+	JSONServerPort  int  `mapstructure:"json-port"`
 	// no direct command line flags for these
 	StartDebugService       bool
 	StartGatewayService     bool
@@ -65,6 +71,8 @@ func DefaultConfig() Config {
 		StartSmesherService:     defaultStartSmesherService,
 		StartTransactionService: defaultStartTransactionService,
 		StartActivationService:  defaultStartActivationService,
+		GrpcSendBufferSize:      defaultGrpcSendBufferSize,
+		GrpcRecvBufferSize:      defaultGrpcRecvBufferSize,
 
 		SmesherStreamInterval: defaultSmesherStreamInterval,
 	}

--- a/api/config/config.go
+++ b/api/config/config.go
@@ -20,8 +20,8 @@ const (
 	defaultStartSmesherService     = false
 	defaultStartTransactionService = false
 	defaultStartActivationService  = false
-	defaultGrpcSendBufferSize      = 1024 * 1024 * 10
-	defaultGrpcRecvBufferSize      = 1024 * 1024 * 10
+	defaultGrpcSendMsgSize         = 1024 * 1024 * 10
+	defaultGrpcRecvMsgSize         = 1024 * 1024 * 10
 
 	defaultSmesherStreamInterval = 1 * time.Second
 )
@@ -32,8 +32,8 @@ type Config struct {
 	GrpcServerPort      int      `mapstructure:"grpc-port"`
 	GrpcServerInterface string   `mapstructure:"grpc-interface"`
 	// GRPC send and receive buffer size
-	GrpcSendBufferSize int `mapstructure:"grpc-send-buffer-size"`
-	GrpcRecvBufferSize int `mapstructure:"grpc-recv-buffer-size"`
+	GrpcSendMsgSize int `mapstructure:"grpc-send-msg-size"`
+	GrpcRecvMsgSize int `mapstructure:"grpc-recv-msg-size"`
 
 	StartJSONServer bool `mapstructure:"json-server"`
 	JSONServerPort  int  `mapstructure:"json-port"`
@@ -71,8 +71,8 @@ func DefaultConfig() Config {
 		StartSmesherService:     defaultStartSmesherService,
 		StartTransactionService: defaultStartTransactionService,
 		StartActivationService:  defaultStartActivationService,
-		GrpcSendBufferSize:      defaultGrpcSendBufferSize,
-		GrpcRecvBufferSize:      defaultGrpcRecvBufferSize,
+		GrpcSendMsgSize:         defaultGrpcSendMsgSize,
+		GrpcRecvMsgSize:         defaultGrpcRecvMsgSize,
 
 		SmesherStreamInterval: defaultSmesherStreamInterval,
 	}

--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -806,6 +806,7 @@ func (app *App) startAPIServices(ctx context.Context) {
 			app.grpcAPIService = grpcserver.NewServerWithInterface(apiConf.GrpcServerPort, apiConf.GrpcServerInterface,
 				grpc.ChainStreamInterceptor(grpctags.StreamServerInterceptor(), grpczap.StreamServerInterceptor(logger)),
 				grpc.ChainUnaryInterceptor(grpctags.UnaryServerInterceptor(), grpczap.UnaryServerInterceptor(logger)),
+				grpc.MaxSendMsgSize(50*1024*1024), // 50MB
 			)
 		}
 		services = append(services, svc)

--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -806,7 +806,8 @@ func (app *App) startAPIServices(ctx context.Context) {
 			app.grpcAPIService = grpcserver.NewServerWithInterface(apiConf.GrpcServerPort, apiConf.GrpcServerInterface,
 				grpc.ChainStreamInterceptor(grpctags.StreamServerInterceptor(), grpczap.StreamServerInterceptor(logger)),
 				grpc.ChainUnaryInterceptor(grpctags.UnaryServerInterceptor(), grpczap.UnaryServerInterceptor(logger)),
-				grpc.MaxSendMsgSize(50*1024*1024), // 50MB
+				grpc.MaxSendMsgSize(apiConf.GrpcSendBufferSize),
+				grpc.MaxRecvMsgSize(apiConf.GrpcRecvBufferSize),
 			)
 		}
 		services = append(services, svc)

--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -806,8 +806,8 @@ func (app *App) startAPIServices(ctx context.Context) {
 			app.grpcAPIService = grpcserver.NewServerWithInterface(apiConf.GrpcServerPort, apiConf.GrpcServerInterface,
 				grpc.ChainStreamInterceptor(grpctags.StreamServerInterceptor(), grpczap.StreamServerInterceptor(logger)),
 				grpc.ChainUnaryInterceptor(grpctags.UnaryServerInterceptor(), grpczap.UnaryServerInterceptor(logger)),
-				grpc.MaxSendMsgSize(apiConf.GrpcSendBufferSize),
-				grpc.MaxRecvMsgSize(apiConf.GrpcRecvBufferSize),
+				grpc.MaxSendMsgSize(apiConf.GrpcSendMsgSize),
+				grpc.MaxRecvMsgSize(apiConf.GrpcRecvMsgSize),
 			)
 		}
 		services = append(services, svc)


### PR DESCRIPTION
We are already observing errors in Explorer that say:
``` received message larger than max (14117712 vs. 4194304)```

Basically, if there is a lot of happening the default size is not enough for sending layers over GRPC correctly.