### PR TITLE
[Merged by Bors] - db: parametrize number of connections and latency metering

### DIFF
--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -991,7 +991,10 @@ func (app *App) setupDBs(ctx context.Context, lg log.Log, dbPath string) error {
 		return fmt.Errorf("failed to create %s: %w", dbPath, err)
 	}
 
-	sqlDB, err := sql.Open("file:" + filepath.Join(dbPath, "state.sql"))
+	sqlDB, err := sql.Open("file:"+filepath.Join(dbPath, "state.sql"),
+		sql.WithConnections(app.Config.DatabaseConnections),
+		sql.WithLatencyMetering(app.Config.DatabaseLatencyMetering),
+	)
 	if err != nil {
 		return fmt.Errorf("open sqlite db %w", err)
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -55,8 +55,6 @@ func AddCommands(cmd *cobra.Command) {
 	cmd.PersistentFlags().BoolVar(&cfg.PprofHTTPServer, "pprof-server",
 		cfg.PprofHTTPServer, "enable http pprof server")
 	cmd.PersistentFlags().Uint64Var(&cfg.TickSize, "tick-size", cfg.TickSize, "number of poet leaves in a single tick")
-	cmd.PersistentFlags().StringVar(&cfg.PublishEventsURL, "events-url",
-		cfg.PublishEventsURL, "publish events to this url; if no url specified no events will be published")
 	cmd.PersistentFlags().StringVar(&cfg.ProfilerURL, "profiler-url",
 		cfg.ProfilerURL, "send profiler data to certain url, if no url no profiling will be sent, format: http://<IP>:<PORT>")
 	cmd.PersistentFlags().StringVar(&cfg.ProfilerName, "profiler-name",
@@ -74,6 +72,10 @@ func AddCommands(cmd *cobra.Command) {
 	cmd.PersistentFlags().VarP(flags.NewStringToUint64Value(cfg.Genesis.Accounts), "accounts", "a",
 		"List of prefunded accounts")
 
+	cmd.PersistentFlags().IntVar(&cfg.DatabaseConnections, "db-connections",
+		cfg.DatabaseConnections, "configure number of active connections to enable parallel read requests")
+	cmd.PersistentFlags().BoolVar(&cfg.P2P.Flood, "db-latency-metering",
+		cfg.DatabaseLatencyMetering, "if enabled collect latency histogram for every database query")
 	/** ======================== P2P Flags ========================== **/
 
 	cmd.PersistentFlags().StringVar(&cfg.P2P.Listen, "listen",

--- a/config/config.go
+++ b/config/config.go
@@ -102,6 +102,9 @@ type BaseConfig struct {
 	// then we optimistically filter out infeasible transactions before constructing the block.
 	OptFilterThreshold int    `mapstructure:"optimistic-filtering-threshold"`
 	TickSize           uint64 `mapstructure:"tick-size"`
+
+	DatabaseConnections     int  `mapstructure:"db-connections"`
+	DatabaseLatencyMetering bool `mapstructure:"db-latency-metering"`
 }
 
 // SmeshingConfig defines configuration for the node's smeshing (mining).
@@ -164,6 +167,7 @@ func defaultBaseConfig() BaseConfig {
 		BlockGasLimit:       math.MaxUint64,
 		OptFilterThreshold:  90,
 		TickSize:            100,
+		DatabaseConnections: 16,
 	}
 }
 

--- a/sql/database_test.go
+++ b/sql/database_test.go
@@ -18,7 +18,11 @@ func testTables(db Executor) error {
 }
 
 func TestTransactionIsolation(t *testing.T) {
-	db := InMemory(WithMigrations(testTables))
+	db := InMemory(
+		WithMigrations(testTables),
+		WithConnections(10),
+		WithLatencyMetering(true),
+	)
 
 	tx, err := db.Tx(context.TODO())
 	require.NoError(t, err)

--- a/sql/metrics.go
+++ b/sql/metrics.go
@@ -8,11 +8,12 @@ import (
 
 const namespace = "database"
 
-// QueryDuration in nanoseconds.
-var queryDuration = metrics.NewHistogramWithBuckets(
-	"query_duration",
-	namespace,
-	"Duration of the query in nanoseconds",
-	[]string{"query"},
-	prometheus.ExponentialBuckets(100_000, 2, 20),
-)
+func newQueryLatency() *prometheus.HistogramVec {
+	return metrics.NewHistogramWithBuckets(
+		"query_latency_ns",
+		namespace,
+		"Latency of the query in nanoseconds",
+		[]string{"query"},
+		prometheus.ExponentialBuckets(100_000, 2, 20),
+	)
+}


### PR DESCRIPTION
latency metering consumes a lot of data if enabled on every node. however it is useful to quickly identify database misuse. additionally, it will be useful to configure higher number of connections for doing read requests in parallel (e.g for api).