### PR TITLE
[Merged by Bors] - beacon: use types.NodeID over string and []byte

### DIFF
--- a/beacon/beacon.go
+++ b/beacon/beacon.go
@@ -266,7 +266,7 @@ func (pd *ProtocolDriver) OnAtx(atx *types.ActivationTxHeader) {
 	if !ok {
 		return
 	}
-	if id, ok := s.minerAtxs[string(atx.NodeID.Bytes())]; ok && id != atx.ID {
+	if id, ok := s.minerAtxs[atx.NodeID]; ok && id != atx.ID {
 		pd.logger.With().Warning("ignoring malicious atx",
 			log.Stringer("smesher", atx.NodeID),
 			log.Stringer("previous_atx", id),
@@ -274,10 +274,10 @@ func (pd *ProtocolDriver) OnAtx(atx *types.ActivationTxHeader) {
 		)
 		return
 	}
-	s.minerAtxs[string(atx.NodeID.Bytes())] = atx.ID
+	s.minerAtxs[atx.NodeID] = atx.ID
 }
 
-func (pd *ProtocolDriver) minerAtxHdr(epoch types.EpochID, minerPK []byte) (*types.ActivationTxHeader, error) {
+func (pd *ProtocolDriver) minerAtxHdr(epoch types.EpochID, minerID types.NodeID) (*types.ActivationTxHeader, error) {
 	pd.mu.RLock()
 	defer pd.mu.RUnlock()
 
@@ -286,18 +286,19 @@ func (pd *ProtocolDriver) minerAtxHdr(epoch types.EpochID, minerPK []byte) (*typ
 		return nil, errEpochNotActive
 	}
 
-	id, ok := st.minerAtxs[string(minerPK)]
+	id, ok := st.minerAtxs[minerID]
 	if !ok {
 		pd.logger.With().Debug("miner does not have atx in previous epoch",
 			epoch-1,
-			log.Stringer("smesher", types.BytesToNodeID(minerPK)))
+			log.Stringer("smesher", minerID),
+		)
 		return nil, errMinerNotActive
 	}
 	return pd.cdb.GetAtxHeader(id)
 }
 
-func (pd *ProtocolDriver) MinerAllowance(epoch types.EpochID, minerPK []byte) uint32 {
-	atx, err := pd.minerAtxHdr(epoch, minerPK)
+func (pd *ProtocolDriver) MinerAllowance(epoch types.EpochID, minerID types.NodeID) uint32 {
+	atx, err := pd.minerAtxHdr(epoch, minerID)
 	if err != nil {
 		return 0
 	}
@@ -505,7 +506,7 @@ func (pd *ProtocolDriver) initEpochStateIfNotPresent(logger log.Log, epoch types
 
 	var (
 		epochWeight uint64
-		miners      = make(map[string]types.ATXID)
+		miners      = make(map[types.NodeID]types.ATXID)
 		active      bool
 		nonce       *types.VRFPostIndex
 		// w1 is the weight units at δ before the end of the previous epoch, used to calculate `thresholdStrict`
@@ -516,8 +517,8 @@ func (pd *ProtocolDriver) initEpochStateIfNotPresent(logger log.Log, epoch types
 	)
 	if err := pd.cdb.IterateEpochATXHeaders(epoch, func(header *types.ActivationTxHeader) bool {
 		epochWeight += header.GetWeight()
-		if _, ok := miners[string(header.NodeID.Bytes())]; !ok {
-			miners[string(header.NodeID.Bytes())] = header.ID
+		if _, ok := miners[header.NodeID]; !ok {
+			miners[header.NodeID] = header.ID
 			if header.Received.Before(early) {
 				w1++
 			} else if header.Received.Before(ontime) {
@@ -767,7 +768,7 @@ func (pd *ProtocolDriver) sendProposal(ctx context.Context, epoch types.EpochID,
 		return
 	}
 
-	atx, err := pd.minerAtxHdr(epoch, pd.edSigner.PublicKey().Bytes())
+	atx, err := pd.minerAtxHdr(epoch, pd.edSigner.NodeID())
 	if err != nil {
 		return
 	}
@@ -941,7 +942,7 @@ func (pd *ProtocolDriver) sendFirstRoundVote(ctx context.Context, epoch types.Ep
 	return nil
 }
 
-func (pd *ProtocolDriver) getFirstRoundVote(epoch types.EpochID, minerPK *signing.PublicKey) (proposalList, error) {
+func (pd *ProtocolDriver) getFirstRoundVote(epoch types.EpochID, minerID types.NodeID) (proposalList, error) {
 	pd.mu.RLock()
 	defer pd.mu.RUnlock()
 
@@ -950,13 +951,13 @@ func (pd *ProtocolDriver) getFirstRoundVote(epoch types.EpochID, minerPK *signin
 		return nil, errEpochNotActive
 	}
 
-	return st.getMinerFirstRoundVote(minerPK)
+	return st.getMinerFirstRoundVote(minerID)
 }
 
 func (pd *ProtocolDriver) sendFollowingVote(ctx context.Context, epoch types.EpochID, round types.RoundID, ownCurrentRoundVotes allVotes) error {
-	firstRoundVotes, err := pd.getFirstRoundVote(epoch, pd.edSigner.PublicKey())
+	firstRoundVotes, err := pd.getFirstRoundVote(epoch, pd.edSigner.NodeID())
 	if err != nil {
-		return fmt.Errorf("get own first round votes %v: %w", pd.edSigner.PublicKey().String(), err)
+		return fmt.Errorf("get own first round votes %v: %w", pd.edSigner.NodeID().String(), err)
 	}
 
 	bitVector := encodeVotes(ownCurrentRoundVotes, firstRoundVotes)

--- a/beacon/handlers.go
+++ b/beacon/handlers.go
@@ -85,7 +85,7 @@ func (pd *ProtocolDriver) handleProposal(ctx context.Context, peer p2p.Peer, msg
 		return err
 	}
 
-	atx, err := pd.minerAtxHdr(m.EpochID, m.NodeID.Bytes())
+	atx, err := pd.minerAtxHdr(m.EpochID, m.NodeID)
 	if err != nil {
 		return err
 	}
@@ -278,35 +278,32 @@ func (pd *ProtocolDriver) handleFirstVotes(ctx context.Context, peer p2p.Peer, m
 	return pd.storeFirstVotes(m, minerPK)
 }
 
-func (pd *ProtocolDriver) verifyFirstVotes(ctx context.Context, m FirstVotingMessage) (*signing.PublicKey, error) {
+func (pd *ProtocolDriver) verifyFirstVotes(ctx context.Context, m FirstVotingMessage) (types.NodeID, error) {
 	logger := pd.logger.WithContext(ctx).WithFields(m.EpochID, types.FirstRound)
 	messageBytes, err := codec.Encode(&m.FirstVotingMessageBody)
 	if err != nil {
 		logger.With().Fatal("failed to serialize first voting message", log.Err(err))
 	}
 
-	minerPK, err := pd.pubKeyExtractor.Extract(signing.BEACON, messageBytes, m.Signature)
+	minerID, err := pd.pubKeyExtractor.ExtractNodeID(signing.BEACON, messageBytes, m.Signature)
 	if err != nil {
-		return nil, fmt.Errorf("[round %v] recover ID %x: %w", types.FirstRound, m.Signature, err)
+		return types.EmptyNodeID, fmt.Errorf("[round %v] recover ID %x: %w", types.FirstRound, m.Signature, err)
 	}
 
-	nodeID := types.BytesToNodeID(minerPK.Bytes())
-	minerID := nodeID.String()
-	logger = logger.WithFields(log.Stringer("smesher", nodeID))
-
-	if err = pd.registerVoted(logger, m.EpochID, minerPK, types.FirstRound); err != nil {
-		return nil, fmt.Errorf("[round %v] register proposal (miner ID %v): %w", types.FirstRound, minerID, err)
+	logger = logger.WithFields(log.Stringer("smesher", minerID))
+	if err = pd.registerVoted(logger, m.EpochID, minerID, types.FirstRound); err != nil {
+		return types.EmptyNodeID, fmt.Errorf("[round %v] register proposal (miner ID %v): %w", types.FirstRound, minerID.ShortString(), err)
 	}
-	return minerPK, nil
+	return minerID, nil
 }
 
-func (pd *ProtocolDriver) storeFirstVotes(m FirstVotingMessage, minerPK *signing.PublicKey) error {
+func (pd *ProtocolDriver) storeFirstVotes(m FirstVotingMessage, minerID types.NodeID) error {
 	if !pd.isInProtocol() {
 		pd.logger.Debug("beacon not in protocol, not storing first votes")
 		return errProtocolNotRunning
 	}
 
-	atx, err := pd.minerAtxHdr(m.EpochID, minerPK.Bytes())
+	atx, err := pd.minerAtxHdr(m.EpochID, minerID)
 	if err != nil {
 		return err
 	}
@@ -333,7 +330,7 @@ func (pd *ProtocolDriver) storeFirstVotes(m FirstVotingMessage, minerPK *signing
 		voteList = voteList[:pd.config.VotesLimit]
 	}
 
-	pd.states[m.EpochID].setMinerFirstRoundVote(minerPK, voteList)
+	pd.states[m.EpochID].setMinerFirstRoundVote(minerID, voteList)
 	return nil
 }
 
@@ -382,13 +379,13 @@ func (pd *ProtocolDriver) handleFollowingVotes(ctx context.Context, peer p2p.Pee
 		return errUntimelyMessage
 	}
 
-	minerPK, err := pd.verifyFollowingVotes(ctx, m)
+	minerID, err := pd.verifyFollowingVotes(ctx, m)
 	if err != nil {
 		return err
 	}
 
 	logger.Debug("received following voting message, counting its votes")
-	if err = pd.storeFollowingVotes(m, minerPK); err != nil {
+	if err = pd.storeFollowingVotes(m, minerID); err != nil {
 		logger.With().Warning("failed to store following votes", log.Err(err))
 		return err
 	}
@@ -396,43 +393,43 @@ func (pd *ProtocolDriver) handleFollowingVotes(ctx context.Context, peer p2p.Pee
 	return nil
 }
 
-func (pd *ProtocolDriver) verifyFollowingVotes(ctx context.Context, m FollowingVotingMessage) (*signing.PublicKey, error) {
+func (pd *ProtocolDriver) verifyFollowingVotes(ctx context.Context, m FollowingVotingMessage) (types.NodeID, error) {
 	round := m.RoundID
 	messageBytes, err := codec.Encode(&m.FollowingVotingMessageBody)
 	if err != nil {
 		pd.logger.With().Fatal("failed to serialize voting message", log.Err(err))
 	}
 
-	minerPK, err := pd.pubKeyExtractor.Extract(signing.BEACON, messageBytes, m.Signature)
+	minerID, err := pd.pubKeyExtractor.ExtractNodeID(signing.BEACON, messageBytes, m.Signature)
 	if err != nil {
-		return nil, fmt.Errorf("[round %v] recover ID from signature %x: %w", round, m.Signature, err)
+		return types.EmptyNodeID, fmt.Errorf("[round %v] recover ID from signature %x: %w", round, m.Signature, err)
 	}
 
-	nodeID := types.BytesToNodeID(minerPK.Bytes())
+	nodeID := types.BytesToNodeID(minerID.Bytes())
 	logger := pd.logger.WithContext(ctx).WithFields(m.EpochID, round, log.Stringer("smesher", nodeID))
 
-	if err := pd.registerVoted(logger, m.EpochID, minerPK, m.RoundID); err != nil {
-		return nil, err
+	if err := pd.registerVoted(logger, m.EpochID, minerID, m.RoundID); err != nil {
+		return types.EmptyNodeID, err
 	}
 
-	return minerPK, nil
+	return minerID, nil
 }
 
-func (pd *ProtocolDriver) storeFollowingVotes(m FollowingVotingMessage, minerPK *signing.PublicKey) error {
+func (pd *ProtocolDriver) storeFollowingVotes(m FollowingVotingMessage, minerID types.NodeID) error {
 	if !pd.isInProtocol() {
 		pd.logger.Debug("beacon not in protocol, not storing following votes")
 		return errProtocolNotRunning
 	}
 
-	atx, err := pd.minerAtxHdr(m.EpochID, minerPK.Bytes())
+	atx, err := pd.minerAtxHdr(m.EpochID, minerID)
 	if err != nil {
 		return err
 	}
 	voteWeight := new(big.Int).SetUint64(atx.GetWeight())
 
-	firstRoundVotes, err := pd.getFirstRoundVote(m.EpochID, minerPK)
+	firstRoundVotes, err := pd.getFirstRoundVote(m.EpochID, minerID)
 	if err != nil {
-		return fmt.Errorf("get miner first round votes %v: %w", minerPK.String(), err)
+		return fmt.Errorf("get miner first round votes %v: %w", minerID.ShortString(), err)
 	}
 
 	thisRoundVotes := decodeVotes(m.VotesBitVector, firstRoundVotes)
@@ -515,11 +512,11 @@ func (pd *ProtocolDriver) registerProposed(logger log.Log, epoch types.EpochID, 
 	return pd.states[epoch].registerProposed(logger, minerPK)
 }
 
-func (pd *ProtocolDriver) registerVoted(logger log.Log, epoch types.EpochID, minerPK *signing.PublicKey, round types.RoundID) error {
+func (pd *ProtocolDriver) registerVoted(logger log.Log, epoch types.EpochID, minerID types.NodeID, round types.RoundID) error {
 	pd.mu.Lock()
 	defer pd.mu.Unlock()
 	if _, ok := pd.states[epoch]; !ok {
 		return errEpochNotActive
 	}
-	return pd.states[epoch].registerVoted(logger, minerPK, round)
+	return pd.states[epoch].registerVoted(logger, minerID, round)
 }

--- a/beacon/interface.go
+++ b/beacon/interface.go
@@ -7,7 +7,6 @@ import (
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/p2p"
 	"github.com/spacemeshos/go-spacemesh/p2p/pubsub"
-	"github.com/spacemeshos/go-spacemesh/signing"
 )
 
 //go:generate mockgen -package=beacon -destination=./mocks.go -source=./interface.go
@@ -34,7 +33,7 @@ type layerClock interface {
 
 type vrfSigner interface {
 	Sign(msg []byte) []byte
-	PublicKey() *signing.PublicKey
+	NodeID() types.NodeID
 	LittleEndian() bool
 }
 

--- a/beacon/mocks.go
+++ b/beacon/mocks.go
@@ -13,7 +13,6 @@ import (
 	types "github.com/spacemeshos/go-spacemesh/common/types"
 	p2p "github.com/spacemeshos/go-spacemesh/p2p"
 	pubsub "github.com/spacemeshos/go-spacemesh/p2p/pubsub"
-	signing "github.com/spacemeshos/go-spacemesh/signing"
 )
 
 // Mockcoin is a mock of coin interface.
@@ -269,18 +268,18 @@ func (mr *MockvrfSignerMockRecorder) LittleEndian() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LittleEndian", reflect.TypeOf((*MockvrfSigner)(nil).LittleEndian))
 }
 
-// PublicKey mocks base method.
-func (m *MockvrfSigner) PublicKey() *signing.PublicKey {
+// NodeID mocks base method.
+func (m *MockvrfSigner) NodeID() types.NodeID {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PublicKey")
-	ret0, _ := ret[0].(*signing.PublicKey)
+	ret := m.ctrl.Call(m, "NodeID")
+	ret0, _ := ret[0].(types.NodeID)
 	return ret0
 }
 
-// PublicKey indicates an expected call of PublicKey.
-func (mr *MockvrfSignerMockRecorder) PublicKey() *gomock.Call {
+// NodeID indicates an expected call of NodeID.
+func (mr *MockvrfSignerMockRecorder) NodeID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PublicKey", reflect.TypeOf((*MockvrfSigner)(nil).PublicKey))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NodeID", reflect.TypeOf((*MockvrfSigner)(nil).NodeID))
 }
 
 // Sign mocks base method.

--- a/beacon/weakcoin/interface.go
+++ b/beacon/weakcoin/interface.go
@@ -2,14 +2,13 @@ package weakcoin
 
 import (
 	"github.com/spacemeshos/go-spacemesh/common/types"
-	"github.com/spacemeshos/go-spacemesh/signing"
 )
 
 //go:generate mockgen -package=weakcoin -destination=./mocks.go -source=./interface.go
 
 type vrfSigner interface {
 	Sign(msg []byte) []byte
-	PublicKey() *signing.PublicKey
+	NodeID() types.NodeID
 	LittleEndian() bool
 }
 
@@ -22,5 +21,5 @@ type nonceFetcher interface {
 }
 
 type allowance interface {
-	MinerAllowance(types.EpochID, []byte) uint32
+	MinerAllowance(types.EpochID, types.NodeID) uint32
 }

--- a/beacon/weakcoin/mocks.go
+++ b/beacon/weakcoin/mocks.go
@@ -9,7 +9,6 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	types "github.com/spacemeshos/go-spacemesh/common/types"
-	signing "github.com/spacemeshos/go-spacemesh/signing"
 )
 
 // MockvrfSigner is a mock of vrfSigner interface.
@@ -49,18 +48,18 @@ func (mr *MockvrfSignerMockRecorder) LittleEndian() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LittleEndian", reflect.TypeOf((*MockvrfSigner)(nil).LittleEndian))
 }
 
-// PublicKey mocks base method.
-func (m *MockvrfSigner) PublicKey() *signing.PublicKey {
+// NodeID mocks base method.
+func (m *MockvrfSigner) NodeID() types.NodeID {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PublicKey")
-	ret0, _ := ret[0].(*signing.PublicKey)
+	ret := m.ctrl.Call(m, "NodeID")
+	ret0, _ := ret[0].(types.NodeID)
 	return ret0
 }
 
-// PublicKey indicates an expected call of PublicKey.
-func (mr *MockvrfSignerMockRecorder) PublicKey() *gomock.Call {
+// NodeID indicates an expected call of NodeID.
+func (mr *MockvrfSignerMockRecorder) NodeID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PublicKey", reflect.TypeOf((*MockvrfSigner)(nil).PublicKey))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NodeID", reflect.TypeOf((*MockvrfSigner)(nil).NodeID))
 }
 
 // Sign mocks base method.
@@ -176,7 +175,7 @@ func (m *Mockallowance) EXPECT() *MockallowanceMockRecorder {
 }
 
 // MinerAllowance mocks base method.
-func (m *Mockallowance) MinerAllowance(arg0 types.EpochID, arg1 []byte) uint32 {
+func (m *Mockallowance) MinerAllowance(arg0 types.EpochID, arg1 types.NodeID) uint32 {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MinerAllowance", arg0, arg1)
 	ret0, _ := ret[0].(uint32)

--- a/beacon/weakcoin/weak_coin.go
+++ b/beacon/weakcoin/weak_coin.go
@@ -41,7 +41,7 @@ type Message struct {
 	Epoch        types.EpochID
 	Round        types.RoundID
 	Unit         uint32
-	MinerPK      []byte `scale:"max=32"`
+	MinerID      types.NodeID
 	VrfSignature []byte `scale:"max=80"`
 }
 
@@ -205,27 +205,26 @@ func (wc *WeakCoin) StartRound(ctx context.Context, round types.RoundID, nonce *
 }
 
 func (wc *WeakCoin) updateProposal(ctx context.Context, message Message) error {
-	nodeID := types.BytesToNodeID(message.MinerPK)
-	nonce, err := wc.nonceFetcher.VRFNonce(nodeID, message.Epoch)
+	nonce, err := wc.nonceFetcher.VRFNonce(message.MinerID, message.Epoch)
 	if err != nil {
 		wc.logger.With().Error("failed to get vrf nonce", log.Err(err))
-		return fmt.Errorf("failed to get vrf nonce for node %s: %w", nodeID, err)
+		return fmt.Errorf("failed to get vrf nonce for node %s: %w", message.MinerID, err)
 	}
 	buf := wc.encodeProposal(message.Epoch, nonce, message.Round, message.Unit)
-	if !wc.verifier.Verify(types.BytesToNodeID(message.MinerPK), buf, message.VrfSignature) {
+	if !wc.verifier.Verify(message.MinerID, buf, message.VrfSignature) {
 		return fmt.Errorf("signature is invalid signature %x", message.VrfSignature)
 	}
 
-	allowance := wc.allowance.MinerAllowance(wc.epoch, message.MinerPK)
+	allowance := wc.allowance.MinerAllowance(wc.epoch, message.MinerID)
 	if allowance < message.Unit {
-		return fmt.Errorf("miner %x is not allowed to submit proposal for unit %d (allowed %d)", message.MinerPK, message.Unit, allowance)
+		return fmt.Errorf("miner %x is not allowed to submit proposal for unit %d (allowed %d)", message.MinerID, message.Unit, allowance)
 	}
 
 	return wc.updateSmallest(ctx, message.VrfSignature)
 }
 
 func (wc *WeakCoin) prepareProposal(epoch types.EpochID, nonce types.VRFPostIndex, round types.RoundID) ([]byte, []byte) {
-	minerAllowance := wc.allowance.MinerAllowance(wc.epoch, wc.signer.PublicKey().Bytes())
+	minerAllowance := wc.allowance.MinerAllowance(wc.epoch, wc.signer.NodeID())
 	if minerAllowance == 0 {
 		return nil, nil
 	}
@@ -242,7 +241,7 @@ func (wc *WeakCoin) prepareProposal(epoch types.EpochID, nonce types.VRFPostInde
 				Epoch:        epoch,
 				Round:        round,
 				Unit:         unit,
-				MinerPK:      wc.signer.PublicKey().Bytes(),
+				MinerID:      wc.signer.NodeID(),
 				VrfSignature: signature,
 			}
 			msg, err := codec.Encode(&message)

--- a/beacon/weakcoin/weak_coin_scale.go
+++ b/beacon/weakcoin/weak_coin_scale.go
@@ -31,7 +31,7 @@ func (t *Message) EncodeScale(enc *scale.Encoder) (total int, err error) {
 		total += n
 	}
 	{
-		n, err := scale.EncodeByteSliceWithLimit(enc, t.MinerPK, 32)
+		n, err := scale.EncodeByteArray(enc, t.MinerID[:])
 		if err != nil {
 			return total, err
 		}
@@ -73,12 +73,11 @@ func (t *Message) DecodeScale(dec *scale.Decoder) (total int, err error) {
 		t.Unit = uint32(field)
 	}
 	{
-		field, n, err := scale.DecodeByteSliceWithLimit(dec, 32)
+		n, err := scale.DecodeByteArray(dec, t.MinerID[:])
 		if err != nil {
 			return total, err
 		}
 		total += n
-		t.MinerPK = field
 	}
 	{
 		field, n, err := scale.DecodeByteSliceWithLimit(dec, 80)


### PR DESCRIPTION
## Motivation
Part of #4139

## Changes
Instead of `[]byte` and `string` track NodeIDs using the NodeID type.

## Test Plan
existing tests pass

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
