### PR TITLE
[Merged by Bors] - Use domain in tests instead of manually serialising payloads

### DIFF
--- a/activation/validation_test.go
+++ b/activation/validation_test.go
@@ -31,7 +31,7 @@ func Test_Validation_VRFNonce(t *testing.T) {
 	initOpts.ComputeProviderID = int(initialization.CPUProviderID())
 
 	nodeId := types.BytesToNodeID(make([]byte, 32))
-	commitmentAtxId := types.RandomATXID()
+	commitmentAtxId := *types.EmptyATXID
 
 	init, err := initialization.NewInitializer(
 		initialization.WithNodeId(nodeId.Bytes()),


### PR DESCRIPTION
## Motivation
Part of #4139 

## Changes
Use domain signer in tests instead of manually serializing payloads

## Test Plan
update existing tests

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
