### PR TITLE
[Merged by Bors] - Add fuzzing tests for types with custom EncodeScale and DecodeScale methods

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,5 +192,5 @@ docker-local-push: docker-local-build dockerpush-only
 .PHONY: docker-local-push
 
 fuzz:
-	./scripts/fuzz.sh $(FUZZTIME)
+	@$(ULIMIT) CGO_LDFLAGS="$(CGO_TEST_LDFLAGS)" ./scripts/fuzz.sh $(FUZZTIME)
 .PHONY: fuzz

--- a/api/grpcserver/activation_service_test.go
+++ b/api/grpcserver/activation_service_test.go
@@ -75,7 +75,7 @@ func TestGet_HappyPath(t *testing.T) {
 		},
 	}
 	atx.SetID(&id)
-	nodeId := types.BytesToNodeID(types.RandomBytes(32))
+	nodeId := types.RandomNodeID()
 	atx.SetNodeID(&nodeId)
 	atxProvider.EXPECT().GetFullAtx(id).Return(&atx, nil)
 

--- a/beacon/message_test.go
+++ b/beacon/message_test.go
@@ -1,0 +1,15 @@
+package beacon
+
+import (
+	"testing"
+
+	"github.com/spacemeshos/go-scale/tester"
+)
+
+func FuzzProposalConsistency(f *testing.F) {
+	tester.FuzzConsistency[Proposal](f)
+}
+
+func FuzzProposalSafety(f *testing.F) {
+	tester.FuzzSafety[Proposal](f)
+}

--- a/common/types/activation.go
+++ b/common/types/activation.go
@@ -508,6 +508,10 @@ func (proofMessage *PoetProofMessage) Ref() (PoetProofRef, error) {
 
 type RoundEnd time.Time
 
+func (re RoundEnd) Equal(other RoundEnd) bool {
+	return (time.Time)(re).Equal((time.Time)(other))
+}
+
 func (re *RoundEnd) IntoTime() time.Time {
 	return (time.Time)(*re)
 }

--- a/common/types/activation_test.go
+++ b/common/types/activation_test.go
@@ -12,10 +12,6 @@ import (
 	"github.com/spacemeshos/go-spacemesh/common/types"
 )
 
-func FuzzActivationConsistency(f *testing.F) {
-	tester.FuzzConsistency[types.ActivationTx](f)
-}
-
 func TestRoundEndSerialization(t *testing.T) {
 	end := types.RoundEnd(time.Now())
 	var data bytes.Buffer
@@ -27,10 +23,6 @@ func TestRoundEndSerialization(t *testing.T) {
 	require.NoError(t, err)
 
 	require.EqualValues(t, end.IntoTime().Unix(), deserialized.IntoTime().Unix())
-}
-
-func FuzzActivationTxStateSafety(f *testing.F) {
-	tester.FuzzSafety[types.ActivationTx](f)
 }
 
 func TestActivationEncoding(t *testing.T) {
@@ -45,4 +37,52 @@ func TestActivation_BadMsgHash(t *testing.T) {
 	atx.Signature = types.RandomBytes(64)
 	atx.MsgHash = types.RandomHash()
 	require.Error(t, atx.CalcAndSetID())
+}
+
+func FuzzEpochIDConsistency(f *testing.F) {
+	tester.FuzzConsistency[types.EpochID](f)
+}
+
+func FuzzEpochIDStateSafety(f *testing.F) {
+	tester.FuzzSafety[types.EpochID](f)
+}
+
+func FuzzATXIDConsistency(f *testing.F) {
+	tester.FuzzConsistency[types.ATXID](f)
+}
+
+func FuzzATXIDStateSafety(f *testing.F) {
+	tester.FuzzSafety[types.ATXID](f)
+}
+
+func FuzzMemberConsistency(f *testing.F) {
+	tester.FuzzConsistency[types.Member](f)
+}
+
+func FuzzMemberStateSafety(f *testing.F) {
+	tester.FuzzSafety[types.Member](f)
+}
+
+func FuzzRoundEndConsistency(f *testing.F) {
+	tester.FuzzConsistency[types.RoundEnd](f)
+}
+
+func FuzzRoundEndStateSafety(f *testing.F) {
+	tester.FuzzSafety[types.RoundEnd](f)
+}
+
+func FuzzVRFPostIndexConsistency(f *testing.F) {
+	tester.FuzzConsistency[types.VRFPostIndex](f)
+}
+
+func FuzzVRFPostIndexTxStateSafety(f *testing.F) {
+	tester.FuzzSafety[types.VRFPostIndex](f)
+}
+
+func FuzzPostConsistency(f *testing.F) {
+	tester.FuzzConsistency[types.Post](f)
+}
+
+func FuzzPostStateSafety(f *testing.F) {
+	tester.FuzzSafety[types.Post](f)
 }

--- a/common/types/address_test.go
+++ b/common/types/address_test.go
@@ -5,9 +5,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spacemeshos/go-scale/tester"
 	"github.com/stretchr/testify/require"
 
-	"github.com/spacemeshos/go-scale/tester"
 	"github.com/spacemeshos/go-spacemesh/common/types"
 )
 

--- a/common/types/address_test.go
+++ b/common/types/address_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/spacemeshos/go-scale/tester"
 	"github.com/spacemeshos/go-spacemesh/common/types"
 )
 
@@ -138,4 +139,12 @@ func RandomBytes(size int) []byte {
 		return nil
 	}
 	return b
+}
+
+func FuzzAddressConsistency(f *testing.F) {
+	tester.FuzzConsistency[types.Address](f)
+}
+
+func FuzzAddressStateSafety(f *testing.F) {
+	tester.FuzzSafety[types.Address](f)
 }

--- a/common/types/ballot.go
+++ b/common/types/ballot.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"fmt"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/spacemeshos/go-scale"
 
 	"github.com/spacemeshos/go-spacemesh/codec"
@@ -54,6 +56,25 @@ type Ballot struct {
 	smesherID NodeID
 	// malicious is set to true if smesher that produced this ballot is known to be malicious.
 	malicious bool
+}
+
+func (b Ballot) Equal(other Ballot) bool {
+	if !cmp.Equal(other.BallotMetadata, b.BallotMetadata) {
+		return false
+	}
+	if !cmp.Equal(other.InnerBallot, b.InnerBallot, cmpopts.EquateEmpty()) {
+		return false
+	}
+	if !bytes.Equal(other.Signature, b.Signature) {
+		return false
+	}
+	if !cmp.Equal(other.Votes, b.Votes) {
+		return false
+	}
+	if !cmp.Equal(other.EligibilityProofs, b.EligibilityProofs) {
+		return false
+	}
+	return true
 }
 
 // BallotMetadata is the signed part of Ballot.

--- a/common/types/ballot_test.go
+++ b/common/types/ballot_test.go
@@ -65,6 +65,14 @@ func TestBallot_Initialize_BadMsgHash(t *testing.T) {
 	require.EqualError(t, err, "bad message hash")
 }
 
+func FuzzBallotIDConsistency(f *testing.F) {
+	tester.FuzzConsistency[types.BallotID](f)
+}
+
+func FuzzBallotIDSafety(f *testing.F) {
+	tester.FuzzSafety[types.BallotID](f)
+}
+
 func FuzzBallotConsistency(f *testing.F) {
 	tester.FuzzConsistency[types.Ballot](f)
 }

--- a/common/types/block.go
+++ b/common/types/block.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 	"sort"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/spacemeshos/go-scale"
 
 	"github.com/spacemeshos/go-spacemesh/codec"
@@ -47,6 +48,10 @@ type Block struct {
 	InnerBlock
 	// the following fields are kept private and from being serialized
 	blockID BlockID
+}
+
+func (b Block) Equal(other Block) bool {
+	return cmp.Equal(b.InnerBlock, other.InnerBlock)
 }
 
 // InnerBlock contains the transactions and rewards of a block.

--- a/common/types/hashes.go
+++ b/common/types/hashes.go
@@ -108,11 +108,6 @@ func CalcHash12(data []byte) (h Hash12) {
 	return
 }
 
-// DecodeScale implements scale codec interface.
-func (h *Hash20) DecodeScale(d *scale.Decoder) (int, error) {
-	return scale.DecodeByteArray(d, h[:])
-}
-
 // CalcProposalsHash32 returns the 32-byte blake3 sum of the IDs, sorted in lexicographic order. The pre-image is
 // prefixed with additionalBytes.
 func CalcProposalsHash32(view []ProposalID, additionalBytes []byte) Hash32 {

--- a/common/types/hashes_test.go
+++ b/common/types/hashes_test.go
@@ -3,6 +3,7 @@ package types
 import (
 	"testing"
 
+	"github.com/spacemeshos/go-scale/tester"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -23,4 +24,12 @@ func TestConvert32_20Hash(t *testing.T) {
 	cHash32 := hash20.ToHash32()
 	hash20b := cHash32.ToHash20()
 	assert.Equal(t, hash20b, hash20)
+}
+
+func FuzzHash32Consistency(f *testing.F) {
+	tester.FuzzConsistency[Hash32](f)
+}
+
+func FuzzHash32Safety(f *testing.F) {
+	tester.FuzzSafety[Hash32](f)
 }

--- a/common/types/malfeasance_test.go
+++ b/common/types/malfeasance_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"testing"
 
+	fuzz "github.com/google/gofuzz"
+	"github.com/spacemeshos/go-scale/tester"
 	"github.com/stretchr/testify/require"
 
 	"github.com/spacemeshos/go-spacemesh/codec"
@@ -152,4 +154,30 @@ func TestCodec_MalfeasanceGossip(t *testing.T) {
 
 	require.NoError(t, codec.Decode(encoded, &decoded))
 	require.Equal(t, *gossip, decoded)
+}
+
+func FuzzProofConsistency(f *testing.F) {
+	tester.FuzzConsistency[types.Proof](f, func(p *types.Proof, c fuzz.Continue) {
+		switch c.Intn(3) {
+		case 0:
+			p.Type = types.MultipleATXs
+			data := types.AtxProof{}
+			c.Fuzz(&data)
+			p.Data = &data
+		case 1:
+			p.Type = types.MultipleBallots
+			data := types.BallotProof{}
+			c.Fuzz(&data)
+			p.Data = &data
+		case 2:
+			p.Type = types.HareEquivocation
+			data := types.HareProof{}
+			c.Fuzz(&data)
+			p.Data = &data
+		}
+	})
+}
+
+func FuzzProofSafety(f *testing.F) {
+	tester.FuzzSafety[types.Proof](f)
 }

--- a/common/types/nodeid_test.go
+++ b/common/types/nodeid_test.go
@@ -1,0 +1,15 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/spacemeshos/go-scale/tester"
+)
+
+func FuzzNodeIDConsistency(f *testing.F) {
+	tester.FuzzConsistency[NodeID](f)
+}
+
+func FuzzNodeIDSafety(f *testing.F) {
+	tester.FuzzSafety[NodeID](f)
+}

--- a/common/types/proposal.go
+++ b/common/types/proposal.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/spacemeshos/go-scale"
 
 	"github.com/spacemeshos/go-spacemesh/codec"
@@ -47,6 +48,10 @@ type Proposal struct {
 
 	// the following fields are kept private and from being serialized
 	proposalID ProposalID
+}
+
+func (p Proposal) Equal(other Proposal) bool {
+	return cmp.Equal(p.InnerProposal, other.InnerProposal) && bytes.Equal(p.Signature, other.Signature)
 }
 
 // InnerProposal contains a smesher's content proposal for layer and its votes on the mesh history.

--- a/common/types/proposal_test.go
+++ b/common/types/proposal_test.go
@@ -33,6 +33,14 @@ func TestProposal_Initialize(t *testing.T) {
 	require.EqualError(t, err, "proposal already initialized")
 }
 
+func FuzzProposalIDConsistency(f *testing.F) {
+	tester.FuzzConsistency[types.ProposalID](f)
+}
+
+func FuzzProposalIDSafety(f *testing.F) {
+	tester.FuzzSafety[types.ProposalID](f)
+}
+
 func FuzzProposalConsistency(f *testing.F) {
 	tester.FuzzConsistency[types.Proposal](f)
 }

--- a/common/types/transaction_result.go
+++ b/common/types/transaction_result.go
@@ -1,8 +1,6 @@
 package types
 
 import (
-	"github.com/spacemeshos/go-scale"
-
 	"github.com/spacemeshos/go-spacemesh/log"
 )
 
@@ -29,16 +27,6 @@ func (t TransactionStatus) String() string {
 		return "failure"
 	}
 	panic("unknown status")
-}
-
-// EncodeScale implements scale codec interface.
-func (t TransactionStatus) EncodeScale(e *scale.Encoder) (int, error) {
-	return scale.EncodeCompact8(e, uint8(t))
-}
-
-// DecodeScale implements scale codec interface.
-func (t TransactionStatus) DecodeScale(d *scale.Decoder) (uint8, int, error) {
-	return scale.DecodeCompact8(d)
 }
 
 // TransactionResult is created after consuming transaction.

--- a/common/types/transaction_test.go
+++ b/common/types/transaction_test.go
@@ -6,6 +6,14 @@ import (
 	"github.com/spacemeshos/go-scale/tester"
 )
 
+func FuzzTransactionIDConsistency(f *testing.F) {
+	tester.FuzzConsistency[TransactionID](f)
+}
+
+func FuzzTransactionIDSafety(f *testing.F) {
+	tester.FuzzSafety[TransactionID](f)
+}
+
 func FuzzTransactionConsistency(f *testing.F) {
 	tester.FuzzConsistency[Transaction](f)
 }

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/spacemeshos/economics v0.0.0-20220930194415-799d50b0431d
 	github.com/spacemeshos/ed25519-recovery v0.1.0
 	github.com/spacemeshos/fixed v0.0.0-20210523192743-8d17e03c169a
-	github.com/spacemeshos/go-scale v1.1.6
+	github.com/spacemeshos/go-scale v1.1.7-0.20230327195913-9c8296d2702f
 	github.com/spacemeshos/merkle-tree v0.2.1
 	github.com/spacemeshos/poet v0.6.6
 	github.com/spacemeshos/post v0.5.2

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/spacemeshos/economics v0.0.0-20220930194415-799d50b0431d
 	github.com/spacemeshos/ed25519-recovery v0.1.0
 	github.com/spacemeshos/fixed v0.0.0-20210523192743-8d17e03c169a
-	github.com/spacemeshos/go-scale v1.1.7-0.20230327195913-9c8296d2702f
+	github.com/spacemeshos/go-scale v1.1.7
 	github.com/spacemeshos/merkle-tree v0.2.1
 	github.com/spacemeshos/poet v0.6.6
 	github.com/spacemeshos/post v0.5.2

--- a/go.sum
+++ b/go.sum
@@ -582,8 +582,8 @@ github.com/spacemeshos/ed25519-recovery v0.1.0 h1:ITp0ANR5MiJda51G5R0dV1K0oVcZYu
 github.com/spacemeshos/ed25519-recovery v0.1.0/go.mod h1:3U2H/u9WginYc6AmIoVWPR0A085I+w1RNnr3rWMCgCQ=
 github.com/spacemeshos/fixed v0.0.0-20210523192743-8d17e03c169a h1:p/BRpvEHGqd4oYBp+B/vG3Z3RWdb7vAZCz8xsecS92M=
 github.com/spacemeshos/fixed v0.0.0-20210523192743-8d17e03c169a/go.mod h1:3SkkvXHU4Vm7yjpfgPu97PcZVvWweBmx0FOLRW7ek+g=
-github.com/spacemeshos/go-scale v1.1.6 h1:gieW5CvgoBbJTlqk5vGAu9t4NdHQcgfEL8qtJFo6BQ0=
-github.com/spacemeshos/go-scale v1.1.6/go.mod h1:AxKr+yCe5qn7EsM5ZAygGdulxVVfU+Fe2bc4PsnNakM=
+github.com/spacemeshos/go-scale v1.1.7-0.20230327195913-9c8296d2702f h1:TSma2vQ9gVKyPxfEeHHwgKl3+FXCtdUAb5WGa0ZBOYQ=
+github.com/spacemeshos/go-scale v1.1.7-0.20230327195913-9c8296d2702f/go.mod h1:AxKr+yCe5qn7EsM5ZAygGdulxVVfU+Fe2bc4PsnNakM=
 github.com/spacemeshos/merkle-tree v0.2.1 h1:BSs/zt1n3ceZcpWdcqNFRvTeAWDlc0W+bql0XQH/Gz4=
 github.com/spacemeshos/merkle-tree v0.2.1/go.mod h1:IsrdlW6AHZ4HSi89H7G94ravFCMFZLGnm6To0tQ0SPY=
 github.com/spacemeshos/poet v0.6.6 h1:cZVpX/JWnlllyaQRitOCMJy1o6I9VwFVnr+bMUXxp+E=

--- a/go.sum
+++ b/go.sum
@@ -582,8 +582,8 @@ github.com/spacemeshos/ed25519-recovery v0.1.0 h1:ITp0ANR5MiJda51G5R0dV1K0oVcZYu
 github.com/spacemeshos/ed25519-recovery v0.1.0/go.mod h1:3U2H/u9WginYc6AmIoVWPR0A085I+w1RNnr3rWMCgCQ=
 github.com/spacemeshos/fixed v0.0.0-20210523192743-8d17e03c169a h1:p/BRpvEHGqd4oYBp+B/vG3Z3RWdb7vAZCz8xsecS92M=
 github.com/spacemeshos/fixed v0.0.0-20210523192743-8d17e03c169a/go.mod h1:3SkkvXHU4Vm7yjpfgPu97PcZVvWweBmx0FOLRW7ek+g=
-github.com/spacemeshos/go-scale v1.1.7-0.20230327195913-9c8296d2702f h1:TSma2vQ9gVKyPxfEeHHwgKl3+FXCtdUAb5WGa0ZBOYQ=
-github.com/spacemeshos/go-scale v1.1.7-0.20230327195913-9c8296d2702f/go.mod h1:AxKr+yCe5qn7EsM5ZAygGdulxVVfU+Fe2bc4PsnNakM=
+github.com/spacemeshos/go-scale v1.1.7 h1:nxoNju55EesKjhyXuus3cMM2OZSePYXyn5hY/5rDIwo=
+github.com/spacemeshos/go-scale v1.1.7/go.mod h1:AxKr+yCe5qn7EsM5ZAygGdulxVVfU+Fe2bc4PsnNakM=
 github.com/spacemeshos/merkle-tree v0.2.1 h1:BSs/zt1n3ceZcpWdcqNFRvTeAWDlc0W+bql0XQH/Gz4=
 github.com/spacemeshos/merkle-tree v0.2.1/go.mod h1:IsrdlW6AHZ4HSi89H7G94ravFCMFZLGnm6To0tQ0SPY=
 github.com/spacemeshos/poet v0.6.6 h1:cZVpX/JWnlllyaQRitOCMJy1o6I9VwFVnr+bMUXxp+E=

--- a/scripts/fuzz.sh
+++ b/scripts/fuzz.sh
@@ -14,7 +14,7 @@ do
     for func in ${funcs}
     do
         parentDir=$(dirname $file)
-        command="go test $parentDir -run=$func -fuzz=$func -fuzztime=${fuzzTime}"
+        command="go test $parentDir -run=$func -fuzz=^$func\$ -fuzztime=${fuzzTime}"
         echo $command
         eval $command
     done


### PR DESCRIPTION
## Motivation
We should have fuzzing tests for all types with handwritten `EncodeScale` and `DecodeScale` methods. This will protect us from changes to any type that doesn't have generated methods and might lead to bugs that wouldn't otherwise be detected.

Do not merge before: https://github.com/spacemeshos/go-scale/pull/53

## Changes
Add fuzzing tests for all types with handwritten `EncodeScale` and `DecodeScale` methods.

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
