### PR TITLE
[Merged by Bors] - fetcher: codec error in handleEpochInfoReq

### DIFF
--- a/fetch/handler.go
+++ b/fetch/handler.go
@@ -57,7 +57,9 @@ func (h *handler) handleMaliciousIDsReq(ctx context.Context, _ []byte) ([]byte, 
 // handleEpochInfoReq returns the ATXs published in the specified epoch.
 func (h *handler) handleEpochInfoReq(ctx context.Context, msg []byte) ([]byte, error) {
 	var epoch types.EpochID
-	codec.Decode(msg, &epoch)
+	if err := codec.Decode(msg, &epoch); err != nil {
+		return nil, err
+	}
 	atxids, err := atxs.GetIDsByEpoch(h.cdb, epoch)
 	if err != nil {
 		h.logger.WithContext(ctx).With().Warning("failed to get epoch atx IDs", epoch, log.Err(err))


### PR DESCRIPTION
close: https://github.com/spacemeshos/go-spacemesh/issues/4181

turns out original problem was already fixed by @fasmat , i just noticed that we don't bubble up the error