### PR TITLE
[Merged by Bors] - Fix flaky tests using random signatures

### DIFF
--- a/activation/challenge_verifier_test.go
+++ b/activation/challenge_verifier_test.go
@@ -80,8 +80,11 @@ func Test_SignatureVerification(t *testing.T) {
 	challengeBytes, err := codec.Encode(&challenge)
 	req.NoError(err)
 
+	var sig types.EdSignature
+	sig[types.EdSignatureSize-1] = 0xff
+
 	verifier := activation.NewChallengeVerifier(atxProvider, extractor, validator, activation.DefaultPostConfig(), goldenATXID, layersPerEpoch)
-	_, err = verifier.Verify(context.Background(), challengeBytes, types.RandomEdSignature())
+	_, err = verifier.Verify(context.Background(), challengeBytes, sig)
 	req.ErrorIs(err, activation.ErrSignatureInvalid)
 }
 

--- a/common/types/testutil.go
+++ b/common/types/testutil.go
@@ -116,7 +116,7 @@ func RandomBallot() *Ballot {
 	}
 }
 
-// RandomEdSignature generates a random EdSignature for testing.
+// RandomEdSignature generates a random (not necessarily valid) EdSignature for testing.
 func RandomEdSignature() EdSignature {
 	var b [EdSignatureSize]byte
 	_, err := rand.Read(b[:])

--- a/hare/messagevalidation_test.go
+++ b/hare/messagevalidation_test.go
@@ -211,7 +211,7 @@ func TestMessageValidator_Aggregated(t *testing.T) {
 
 	sv.validMsgsTracker = newPubGetter()
 	tmp := msgs[0].Signature
-	msgs[0].Signature = types.RandomEdSignature()
+	msgs[0].Signature[types.EdSignatureSize-1] = 0xff
 	r.Error(sv.validateAggregatedMessage(context.Background(), agg, funcs))
 
 	msgs[0].Signature = tmp

--- a/proposals/handler_test.go
+++ b/proposals/handler_test.go
@@ -252,7 +252,7 @@ func TestBallot_MalformedData(t *testing.T) {
 func TestBallot_BadSignature(t *testing.T) {
 	th := createTestHandlerNoopDecoder(t)
 	b := createBallot(t)
-	b.Signature = types.RandomEdSignature()
+	b.Signature[types.EdSignatureSize-1] = 0xff
 	data := encodeBallot(t, b)
 	got := th.HandleSyncedBallot(context.Background(), p2p.NoPeer, data)
 	require.ErrorContains(t, got, "bad signature format")

--- a/proposals/handler_test.go
+++ b/proposals/handler_test.go
@@ -841,10 +841,10 @@ func TestProposal_MalformedData(t *testing.T) {
 func TestProposal_BadSignature(t *testing.T) {
 	th := createTestHandlerNoopDecoder(t)
 	p := createProposal(t)
-	p.Signature = types.RandomEdSignature()
+	p.Signature = types.EmptyEdSignature
 	data := encodeProposal(t, p)
 	got := th.HandleSyncedProposal(context.Background(), p2p.NoPeer, data)
-	require.ErrorContains(t, got, "bad signature format")
+	require.ErrorContains(t, got, "inconsistent smesher in proposal")
 
 	require.Equal(t, pubsub.ValidationIgnore, th.HandleProposal(context.Background(), "", data))
 	checkProposal(t, th.cdb, p, false)


### PR DESCRIPTION
## Motivation
Closes #4215 and #4216

## Changes
Instead of a random signature that can be invalid use a fixed signature that is valid, but not from the expected Node.

## Test Plan
fix existing test

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
