### PR TITLE
[Merged by Bors] - Fix module level logging

### DIFF
--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -69,7 +69,6 @@ const (
 
 // Logger names.
 const (
-	AppLogger              = "app"
 	ClockLogger            = "clock"
 	P2PLogger              = "p2p"
 	PostLogger             = "post"
@@ -1115,7 +1114,6 @@ func (app *App) Start(ctx context.Context) error {
 		return fmt.Errorf("could not create vrf signer: %w", err)
 	}
 
-	app.log = app.addLogger(AppLogger, lg)
 	types.SetLayersPerEpoch(app.Config.LayersPerEpoch)
 	err = app.initServices(
 		ctx,


### PR DESCRIPTION
## Motivation
Setting module log levels was not working properly.

The app log was erroneously being re-assigned using `app.addLogger`, which if no specific level was provided for the given module would default to info. So in this case the app log was being set to an info level log, even though it was hardcoded to debug at construction time.

The result was that no module level log could set levels lower than info.

Relates to #4174

## Changes
This change simply deletes the re-assignment, and deletes the now unused `AppLogger` constant.

## Test Plan
Manually tested

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
