### PR TITLE
[Merged by Bors] - Bump golangci-lint and gotestsum versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,10 +60,10 @@ all: install build
 install:
 	go run scripts/check-go-version.go --major 1 --minor 19
 	go mod download
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.50.0
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.52.0
 	go install github.com/spacemeshos/go-scale/scalegen@v1.1.6
 	go install github.com/golang/mock/mockgen
-	go install gotest.tools/gotestsum@v1.8.2
+	go install gotest.tools/gotestsum@v1.9.0
 	go install honnef.co/go/tools/cmd/staticcheck@v0.3.3
 .PHONY: install
 


### PR DESCRIPTION
## Motivation
The current versions don't work with go1.20:
```
❯ make lint
golangci-lint run --config .golangci.yml
make: *** [Makefile:134: lint] Killed
```