### PR TITLE
[Merged by Bors] - atxs: drop posiotining restriction requirement

### DIFF
--- a/activation/activation.go
+++ b/activation/activation.go
@@ -275,7 +275,7 @@ func (b *Builder) waitForFirstATX(ctx context.Context) bool {
 		return false
 	}
 	if prev, err := b.cdb.GetLastAtx(b.nodeID); err == nil {
-		if prev.PublishEpoch() == currEpoch {
+		if prev.PublishEpoch == currEpoch {
 			// miner has published in the current epoch
 			return false
 		}
@@ -404,13 +404,13 @@ func (b *Builder) buildNIPostChallenge(ctx context.Context) (*types.NIPostChalle
 	case <-b.syncer.RegisterForATXSynced():
 	}
 
-	atxID, pubLayerID, err := b.GetPositioningAtxInfo()
+	atxID, pubEpoch, err := b.GetPositioningAtxInfo()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get positioning ATX: %w", err)
 	}
 	challenge := &types.NIPostChallenge{
+		PublishEpoch:   pubEpoch + 1,
 		PositioningATX: atxID,
-		PubLayerID:     pubLayerID.Add(b.layersPerEpoch),
 	}
 	if challenge.TargetEpoch() < b.currentEpoch() {
 		b.discardChallenge()
@@ -491,7 +491,7 @@ func (b *Builder) loadChallenge() (*types.NIPostChallenge, error) {
 	if nipost.TargetEpoch() < b.currentEpoch() {
 		b.log.With().Info("atx nipost challenge is stale - discarding it",
 			log.FieldNamed("target_epoch", nipost.TargetEpoch()),
-			log.FieldNamed("publish_epoch", nipost.PublishEpoch()),
+			log.FieldNamed("publish_epoch", nipost.PublishEpoch),
 			log.FieldNamed("current_epoch", b.currentEpoch()),
 		)
 		b.discardChallenge()
@@ -516,7 +516,7 @@ func (b *Builder) PublishActivationTx(ctx context.Context) error {
 
 	logger.With().Info("atx challenge is ready",
 		log.FieldNamed("current_epoch", b.currentEpoch()),
-		log.FieldNamed("publish_epoch", challenge.PublishEpoch()),
+		log.FieldNamed("publish_epoch", challenge.PublishEpoch),
 		log.FieldNamed("target_epoch", challenge.TargetEpoch()),
 	)
 
@@ -552,7 +552,7 @@ func (b *Builder) PublishActivationTx(ctx context.Context) error {
 }
 
 func (b *Builder) createAtx(ctx context.Context, challenge *types.NIPostChallenge) (*types.ActivationTx, error) {
-	pubEpoch := challenge.PublishEpoch()
+	pubEpoch := challenge.PublishEpoch
 	poetRoundStart := b.layerClock.LayerToTime((pubEpoch - 1).FirstLayer()).Add(b.poetCfg.PhaseShift)
 	nextPoetRoundStart := b.layerClock.LayerToTime(pubEpoch.FirstLayer()).Add(b.poetCfg.PhaseShift)
 
@@ -649,12 +649,12 @@ func (b *Builder) broadcast(ctx context.Context, atx *types.ActivationTx) (int, 
 }
 
 // GetPositioningAtxInfo returns id and publication layer from the best observed atx.
-func (b *Builder) GetPositioningAtxInfo() (types.ATXID, types.LayerID, error) {
+func (b *Builder) GetPositioningAtxInfo() (types.ATXID, types.EpochID, error) {
 	id, err := b.atxHandler.GetPosAtxID()
 	if err != nil {
 		if errors.Is(err, sql.ErrNotFound) {
 			b.log.With().Info("using golden atx as positioning atx", b.goldenATXID)
-			return b.goldenATXID, types.LayerID(0), nil
+			return b.goldenATXID, 0, nil
 		}
 		return types.ATXID{}, 0, fmt.Errorf("cannot find pos atx: %w", err)
 	}
@@ -662,7 +662,7 @@ func (b *Builder) GetPositioningAtxInfo() (types.ATXID, types.LayerID, error) {
 	if err != nil {
 		return types.ATXID{}, 0, fmt.Errorf("inconsistent state: failed to get atx header: %w", err)
 	}
-	return id, atx.PubLayerID, nil
+	return id, atx.PublishEpoch, nil
 }
 
 // SignAndFinalizeAtx signs the atx with specified signer and calculates the ID of the ATX.

--- a/activation/activation_test.go
+++ b/activation/activation_test.go
@@ -42,11 +42,11 @@ func TestMain(m *testing.M) {
 
 // ========== Helper functions ==========
 
-func newChallenge(sequence uint64, prevAtxID, posAtxID types.ATXID, pubLayerID types.LayerID, cATX *types.ATXID) types.NIPostChallenge {
+func newChallenge(sequence uint64, prevAtxID, posAtxID types.ATXID, PublishEpoch types.EpochID, cATX *types.ATXID) types.NIPostChallenge {
 	return types.NIPostChallenge{
 		Sequence:       sequence,
 		PrevATXID:      prevAtxID,
-		PubLayerID:     pubLayerID,
+		PublishEpoch:   PublishEpoch,
 		PositioningATX: posAtxID,
 		CommitmentATX:  cATX,
 	}
@@ -66,13 +66,13 @@ func newActivationTx(
 	prevATX types.ATXID,
 	positioningATX types.ATXID,
 	cATX *types.ATXID,
-	pubLayerID types.LayerID,
+	PublishEpoch types.EpochID,
 	startTick, numTicks uint64,
 	coinbase types.Address,
 	numUnits uint32,
 	nipost *types.NIPost,
 ) *types.VerifiedActivationTx {
-	challenge := newChallenge(sequence, prevATX, positioningATX, pubLayerID, cATX)
+	challenge := newChallenge(sequence, prevATX, positioningATX, PublishEpoch, cATX)
 	atx := newAtx(t, sig, challenge, nipost, numUnits, coinbase)
 	if sequence == 0 {
 		nodeID := sig.NodeID()
@@ -162,7 +162,7 @@ func assertLastAtx(r *require.Assertions, nodeID types.NodeID, poetRef types.Has
 		r.NotNil(atx.VRFNonce)
 	}
 	r.Equal(posAtx.ID(), atx.PositioningATX)
-	r.Equal(posAtx.PubLayerID.Add(layersPerEpoch), atx.PubLayerID)
+	r.Equal(posAtx.PublishEpoch+1, atx.PublishEpoch)
 	r.Equal(poetRef, atx.GetPoetProofRef())
 }
 
@@ -170,13 +170,13 @@ func publishAtx(
 	t *testing.T,
 	tab *testAtxBuilder,
 	posAtxId types.ATXID,
-	posAtxLayer types.LayerID,
+	posEpoch types.EpochID,
 	currLayer *types.LayerID, // pointer to keep current layer consistent across calls
 	buildNIPostLayerDuration uint32,
 ) (*types.ActivationTx, error) {
 	t.Helper()
 
-	publishEpoch := posAtxLayer.GetEpoch() + 1
+	publishEpoch := posEpoch + 1
 	tab.mclock.EXPECT().CurrentLayer().Return(*currLayer).AnyTimes()
 	tab.mhdlr.EXPECT().GetPosAtxID().Return(posAtxId, nil)
 	tab.mclock.EXPECT().LayerToTime(gomock.Any()).DoAndReturn(
@@ -230,7 +230,7 @@ func publishAtx(
 
 func addPrevAtx(t *testing.T, db sql.Executor, epoch types.EpochID, sig *signing.EdSigner) *types.VerifiedActivationTx {
 	challenge := types.NIPostChallenge{
-		PubLayerID: epoch.FirstLayer(),
+		PublishEpoch: epoch,
 	}
 	atx := types.NewActivationTx(challenge, types.Address{}, nil, 2, nil, nil)
 	atx.SetEffectiveNumUnits(2)
@@ -378,9 +378,9 @@ func TestBuilder_StopSmeshing_OnPoSTError(t *testing.T) {
 
 func TestBuilder_PublishActivationTx_HappyFlow(t *testing.T) {
 	tab := newTestBuilder(t, WithPoetConfig(PoetConfig{PhaseShift: layerDuration * 4}))
-	posAtxLayer := postGenesisEpoch.FirstLayer()
-	currLayer := posAtxLayer
-	challenge := newChallenge(1, types.ATXID{1, 2, 3}, types.ATXID{1, 2, 3}, posAtxLayer, nil)
+	posEpoch := postGenesisEpoch
+	currLayer := posEpoch.FirstLayer()
+	challenge := newChallenge(1, types.ATXID{1, 2, 3}, types.ATXID{1, 2, 3}, posEpoch, nil)
 	nipost := newNIPostWithChallenge(types.HexToHash32("55555"), []byte("66666"))
 	prevAtx := newAtx(t, tab.sig, challenge, nipost, 2, types.Address{})
 	SignAndFinalizeAtx(tab.sig, prevAtx)
@@ -389,13 +389,13 @@ func TestBuilder_PublishActivationTx_HappyFlow(t *testing.T) {
 	require.NoError(t, atxs.Add(tab.cdb, vPrevAtx))
 
 	// create and publish ATX
-	atx1, err := publishAtx(t, tab, prevAtx.ID(), posAtxLayer, &currLayer, layersPerEpoch)
+	atx1, err := publishAtx(t, tab, prevAtx.ID(), posEpoch, &currLayer, layersPerEpoch)
 	require.NoError(t, err)
 	require.NotNil(t, atx1)
 
 	// create and publish another ATX
-	currLayer = (posAtxLayer.GetEpoch() + 1).FirstLayer()
-	atx2, err := publishAtx(t, tab, atx1.ID(), atx1.PubLayerID, &currLayer, layersPerEpoch)
+	currLayer = (posEpoch + 1).FirstLayer()
+	atx2, err := publishAtx(t, tab, atx1.ID(), atx1.PublishEpoch, &currLayer, layersPerEpoch)
 	require.NoError(t, err)
 	require.NotEqual(t, atx1, atx2)
 	require.Equal(t, atx1.TargetEpoch()+1, atx2.TargetEpoch())
@@ -407,10 +407,10 @@ func TestBuilder_PublishActivationTx_HappyFlow(t *testing.T) {
 func TestBuilder_PublishActivationTx_StaleChallenge(t *testing.T) {
 	// Arrange
 	tab := newTestBuilder(t, WithPoetConfig(PoetConfig{PhaseShift: layerDuration * 4}))
-	posAtxLayer := postGenesisEpoch.FirstLayer()
+	posEpoch := postGenesisEpoch
 	// current layer is too late to be able to build a nipost on time
 	currLayer := (postGenesisEpoch + 1).FirstLayer()
-	challenge := newChallenge(1, types.ATXID{1, 2, 3}, types.ATXID{1, 2, 3}, posAtxLayer, nil)
+	challenge := newChallenge(1, types.ATXID{1, 2, 3}, types.ATXID{1, 2, 3}, posEpoch, nil)
 	nipost := newNIPostWithChallenge(types.HexToHash32("55555"), []byte("66666"))
 	prevAtx := newAtx(t, tab.sig, challenge, nipost, 2, types.Address{})
 	SignAndFinalizeAtx(tab.sig, prevAtx)
@@ -438,10 +438,9 @@ func TestBuilder_PublishActivationTx_StaleChallenge(t *testing.T) {
 func TestBuilder_Loop_WaitsOnStaleChallenge(t *testing.T) {
 	// Arrange
 	tab := newTestBuilder(t, WithPoetConfig(PoetConfig{PhaseShift: layerDuration * 4}))
-	posAtxLayer := postGenesisEpoch.FirstLayer()
 	// current layer is too late to be able to build a nipost on time
 	currLayer := (postGenesisEpoch + 1).FirstLayer()
-	challenge := newChallenge(1, types.ATXID{1, 2, 3}, types.ATXID{1, 2, 3}, posAtxLayer, nil)
+	challenge := newChallenge(1, types.ATXID{1, 2, 3}, types.ATXID{1, 2, 3}, postGenesisEpoch, nil)
 	nipost := newNIPostWithChallenge(types.HexToHash32("55555"), []byte("66666"))
 	prevAtx := newAtx(t, tab.sig, challenge, nipost, 2, types.Address{})
 	SignAndFinalizeAtx(tab.sig, prevAtx)
@@ -474,9 +473,9 @@ func TestBuilder_Loop_WaitsOnStaleChallenge(t *testing.T) {
 
 func TestBuilder_PublishActivationTx_FaultyNet(t *testing.T) {
 	tab := newTestBuilder(t, WithPoetConfig(PoetConfig{PhaseShift: layerDuration * 4}))
-	posAtxLayer := postGenesisEpoch.FirstLayer()
-	currLayer := posAtxLayer
-	challenge := newChallenge(1, types.ATXID{1, 2, 3}, types.ATXID{1, 2, 3}, posAtxLayer, nil)
+	posEpoch := postGenesisEpoch
+	currLayer := postGenesisEpoch.FirstLayer()
+	challenge := newChallenge(1, types.ATXID{1, 2, 3}, types.ATXID{1, 2, 3}, postGenesisEpoch, nil)
 	nipost := newNIPostWithChallenge(types.HexToHash32("55555"), []byte("66666"))
 	prevAtx := newAtx(t, tab.sig, challenge, nipost, 2, types.Address{})
 	SignAndFinalizeAtx(tab.sig, prevAtx)
@@ -484,7 +483,7 @@ func TestBuilder_PublishActivationTx_FaultyNet(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, atxs.Add(tab.cdb, vPrevAtx))
 
-	publishEpoch := posAtxLayer.GetEpoch() + 1
+	publishEpoch := posEpoch + 1
 	tab.mclock.EXPECT().CurrentLayer().DoAndReturn(func() types.LayerID { return currLayer }).AnyTimes()
 	tab.mhdlr.EXPECT().GetPosAtxID().Return(prevAtx.ID(), nil)
 	tab.mclock.EXPECT().LayerToTime(gomock.Any()).DoAndReturn(
@@ -550,14 +549,14 @@ func TestBuilder_PublishActivationTx_FaultyNet(t *testing.T) {
 	require.ErrorIs(t, tab.PublishActivationTx(context.Background()), ErrATXChallengeExpired)
 
 	// if the network works and we try to publish a new ATX, the timeout should result in a clean state (so a NIPost should be built)
-	posAtxLayer = posAtxLayer.Add(layersPerEpoch + 1)
-	challenge = newChallenge(1, types.ATXID{1, 2, 3}, types.ATXID{1, 2, 3}, posAtxLayer, nil)
+	posEpoch = posEpoch + 1
+	challenge = newChallenge(1, types.ATXID{1, 2, 3}, types.ATXID{1, 2, 3}, posEpoch, nil)
 	posAtx := newAtx(t, tab.sig, challenge, nipost, 2, types.Address{})
 	SignAndFinalizeAtx(tab.sig, posAtx)
 	vPosAtx, err := posAtx.Verify(0, 1)
 	require.NoError(t, err)
 	require.NoError(t, atxs.Add(tab.cdb, vPosAtx))
-	built2, err := publishAtx(t, tab, posAtx.ID(), posAtxLayer, &currLayer, layersPerEpoch)
+	built2, err := publishAtx(t, tab, posAtx.ID(), posEpoch, &currLayer, layersPerEpoch)
 	require.NoError(t, err)
 	require.NotNil(t, built2)
 	require.NotEqual(t, built.NIPost, built2.NIPost)
@@ -566,9 +565,9 @@ func TestBuilder_PublishActivationTx_FaultyNet(t *testing.T) {
 
 func TestBuilder_PublishActivationTx_RebuildNIPostWhenTargetEpochPassed(t *testing.T) {
 	tab := newTestBuilder(t, WithPoetConfig(PoetConfig{PhaseShift: layerDuration * 4}))
-	posAtxLayer := types.EpochID(2).FirstLayer()
-	currLayer := posAtxLayer
-	challenge := newChallenge(1, types.ATXID{1, 2, 3}, types.ATXID{1, 2, 3}, posAtxLayer, nil)
+	posEpoch := types.EpochID(2)
+	currLayer := posEpoch.FirstLayer()
+	challenge := newChallenge(1, types.ATXID{1, 2, 3}, types.ATXID{1, 2, 3}, posEpoch, nil)
 	nipost := newNIPostWithChallenge(types.HexToHash32("55555"), []byte("66666"))
 	prevAtx := newAtx(t, tab.sig, challenge, nipost, 2, types.Address{})
 	SignAndFinalizeAtx(tab.sig, prevAtx)
@@ -576,7 +575,7 @@ func TestBuilder_PublishActivationTx_RebuildNIPostWhenTargetEpochPassed(t *testi
 	require.NoError(t, err)
 	require.NoError(t, atxs.Add(tab.cdb, vPrevAtx))
 
-	publishEpoch := posAtxLayer.GetEpoch() + 1
+	publishEpoch := posEpoch + 1
 	tab.mclock.EXPECT().CurrentLayer().DoAndReturn(
 		func() types.LayerID {
 			return currLayer
@@ -627,15 +626,15 @@ func TestBuilder_PublishActivationTx_RebuildNIPostWhenTargetEpochPassed(t *testi
 	// We started building the NIPost in epoch 2, the publication epoch should have been 3. We should abort the ATX and
 	// start over if the target epoch (4) has passed, so we'll start the ATX builder in epoch 5 and ensure it discards
 	// a stale challenge and builds a new NIPost.
-	posAtxLayer = types.EpochID(5).FirstLayer()
-	currLayer = posAtxLayer
-	challenge = newChallenge(1, types.ATXID{1, 2, 3}, types.ATXID{1, 2, 3}, posAtxLayer, nil)
+	posEpoch = types.EpochID(5)
+	currLayer = posEpoch.FirstLayer()
+	challenge = newChallenge(1, types.ATXID{1, 2, 3}, types.ATXID{1, 2, 3}, posEpoch, nil)
 	posAtx := newAtx(t, tab.sig, challenge, nipost, 2, types.Address{})
 	SignAndFinalizeAtx(tab.sig, posAtx)
 	vPosAtx, err := posAtx.Verify(0, 1)
 	require.NoError(t, err)
 	require.NoError(t, atxs.Add(tab.cdb, vPosAtx))
-	built2, err := publishAtx(t, tab, posAtx.ID(), posAtxLayer, &currLayer, layersPerEpoch)
+	built2, err := publishAtx(t, tab, posAtx.ID(), posEpoch, &currLayer, layersPerEpoch)
 	require.NoError(t, err)
 	require.NotNil(t, built2)
 	require.NotEqual(t, built.NIPost, built2.NIPost)
@@ -644,9 +643,9 @@ func TestBuilder_PublishActivationTx_RebuildNIPostWhenTargetEpochPassed(t *testi
 
 func TestBuilder_PublishActivationTx_NoPrevATX(t *testing.T) {
 	tab := newTestBuilder(t, WithPoetConfig(PoetConfig{PhaseShift: layerDuration * 4}))
-	posAtxLayer := postGenesisEpoch.FirstLayer()
-	currLayer := posAtxLayer
-	challenge := newChallenge(1, types.ATXID{1, 2, 3}, types.ATXID{1, 2, 3}, posAtxLayer, nil)
+	posEpoch := postGenesisEpoch
+	currLayer := posEpoch.FirstLayer()
+	challenge := newChallenge(1, types.ATXID{1, 2, 3}, types.ATXID{1, 2, 3}, posEpoch, nil)
 	nipost := newNIPostWithChallenge(types.HexToHash32("55555"), []byte("66666"))
 	otherSigner, err := signing.NewEdSigner()
 	require.NoError(t, err)
@@ -660,7 +659,7 @@ func TestBuilder_PublishActivationTx_NoPrevATX(t *testing.T) {
 	vrfNonce := types.VRFPostIndex(123)
 	tab.mpost.EXPECT().VRFNonce().Return(&vrfNonce, nil)
 	tab.mpost.EXPECT().CommitmentAtx().Return(types.RandomATXID(), nil)
-	atx, err := publishAtx(t, tab, posAtx.ID(), posAtxLayer, &currLayer, layersPerEpoch)
+	atx, err := publishAtx(t, tab, posAtx.ID(), posEpoch, &currLayer, layersPerEpoch)
 	require.NoError(t, err)
 	require.NotNil(t, atx)
 }
@@ -679,10 +678,10 @@ func TestBuilder_PublishActivationTx_PrevATXWithoutPrevATX(t *testing.T) {
 	}
 
 	currentLayer := postGenesisEpoch.FirstLayer().Add(3)
-	prevAtxPubLayer := postGenesisEpoch.FirstLayer()
-	posAtxPubLayer := postGenesisEpoch.FirstLayer()
+	prevAtxPostEpoch := postGenesisEpoch
+	postAtxPubEpoch := postGenesisEpoch
 
-	challenge := newChallenge(1, types.ATXID{1, 2, 3}, types.ATXID{1, 2, 3}, posAtxPubLayer, nil)
+	challenge := newChallenge(1, types.ATXID{1, 2, 3}, types.ATXID{1, 2, 3}, postAtxPubEpoch, nil)
 	poetBytes := []byte("66666")
 	nipost := newNIPostWithChallenge(types.HexToHash32("55555"), poetBytes)
 	posAtx := newAtx(t, otherSigner, challenge, nipost, 2, types.Address{})
@@ -691,7 +690,7 @@ func TestBuilder_PublishActivationTx_PrevATXWithoutPrevATX(t *testing.T) {
 	r.NoError(err)
 	r.NoError(atxs.Add(tab.cdb, vPosAtx))
 
-	challenge = newChallenge(0, types.EmptyATXID, posAtx.ID(), prevAtxPubLayer, nil)
+	challenge = newChallenge(0, types.EmptyATXID, posAtx.ID(), prevAtxPostEpoch, nil)
 	challenge.InitialPostIndices = initialPost.Indices
 	prevAtx := newAtx(t, tab.sig, challenge, nipost, 2, types.Address{})
 	prevAtx.InitialPost = initialPost
@@ -714,13 +713,13 @@ func TestBuilder_PublishActivationTx_PrevATXWithoutPrevATX(t *testing.T) {
 			genesis := time.Now().Add(-time.Duration(currentLayer) * layerDuration)
 			return genesis.Add(layerDuration * time.Duration(layer))
 		}).AnyTimes()
-	tab.mclock.EXPECT().AwaitLayer(vPosAtx.PublishEpoch().FirstLayer().Add(layersPerEpoch)).DoAndReturn(func(layer types.LayerID) chan struct{} {
+	tab.mclock.EXPECT().AwaitLayer(vPosAtx.PublishEpoch.FirstLayer().Add(layersPerEpoch)).DoAndReturn(func(layer types.LayerID) chan struct{} {
 		ch := make(chan struct{})
 		close(ch)
 		return ch
 	}).Times(1)
 
-	tab.mclock.EXPECT().AwaitLayer(gomock.Not(vPosAtx.PublishEpoch().FirstLayer().Add(layersPerEpoch))).DoAndReturn(func(types.LayerID) chan struct{} {
+	tab.mclock.EXPECT().AwaitLayer(gomock.Not(vPosAtx.PublishEpoch.FirstLayer().Add(layersPerEpoch))).DoAndReturn(func(types.LayerID) chan struct{} {
 		ch := make(chan struct{})
 		return ch
 	}).Times(1)
@@ -757,7 +756,7 @@ func TestBuilder_PublishActivationTx_PrevATXWithoutPrevATX(t *testing.T) {
 		r.Nil(atx.InitialPostIndices)
 
 		r.Equal(posAtx.ID(), atx.PositioningATX)
-		r.Equal(posAtxPubLayer.Add(layersPerEpoch), atx.PubLayerID)
+		r.Equal(postAtxPubEpoch+1, atx.PublishEpoch)
 		r.Equal(types.BytesToHash(poetBytes), atx.GetPoetProofRef())
 
 		close(atxChan)
@@ -776,8 +775,8 @@ func TestBuilder_PublishActivationTx_TargetsEpochBasedOnPosAtx(t *testing.T) {
 	r.NoError(err)
 
 	currentLayer := postGenesisEpoch.FirstLayer().Add(3)
-	posAtxLayer := postGenesisEpoch.FirstLayer()
-	challenge := newChallenge(1, types.ATXID{1, 2, 3}, types.ATXID{1, 2, 3}, posAtxLayer, nil)
+	posEpoch := postGenesisEpoch
+	challenge := newChallenge(1, types.ATXID{1, 2, 3}, types.ATXID{1, 2, 3}, posEpoch, nil)
 	poetBytes := []byte("66666")
 	nipost := newNIPostWithChallenge(types.HexToHash32("55555"), poetBytes)
 	posAtx := newAtx(t, otherSigner, challenge, nipost, 2, types.Address{})
@@ -800,13 +799,13 @@ func TestBuilder_PublishActivationTx_TargetsEpochBasedOnPosAtx(t *testing.T) {
 			genesis := time.Now().Add(-time.Duration(currentLayer) * layerDuration)
 			return genesis.Add(layerDuration * time.Duration(layer))
 		}).AnyTimes()
-	tab.mclock.EXPECT().AwaitLayer(vPosAtx.PublishEpoch().FirstLayer().Add(layersPerEpoch)).DoAndReturn(func(types.LayerID) chan struct{} {
+	tab.mclock.EXPECT().AwaitLayer(vPosAtx.PublishEpoch.FirstLayer().Add(layersPerEpoch)).DoAndReturn(func(types.LayerID) chan struct{} {
 		ch := make(chan struct{})
 		close(ch)
 		return ch
 	}).Times(1)
 
-	tab.mclock.EXPECT().AwaitLayer(gomock.Not(vPosAtx.PublishEpoch().FirstLayer().Add(layersPerEpoch))).DoAndReturn(func(types.LayerID) chan struct{} {
+	tab.mclock.EXPECT().AwaitLayer(gomock.Not(vPosAtx.PublishEpoch.FirstLayer().Add(layersPerEpoch))).DoAndReturn(func(types.LayerID) chan struct{} {
 		ch := make(chan struct{})
 		return ch
 	}).Times(1)
@@ -846,7 +845,7 @@ func TestBuilder_PublishActivationTx_TargetsEpochBasedOnPosAtx(t *testing.T) {
 		r.NotNil(atx.InitialPostIndices)
 
 		r.Equal(posAtx.ID(), atx.PositioningATX)
-		r.Equal(posAtxLayer.Add(layersPerEpoch), atx.PubLayerID)
+		r.Equal(posEpoch+1, atx.PublishEpoch)
 		r.Equal(types.BytesToHash(poetBytes), atx.GetPoetProofRef())
 
 		close(atxChan)
@@ -858,9 +857,9 @@ func TestBuilder_PublishActivationTx_TargetsEpochBasedOnPosAtx(t *testing.T) {
 
 func TestBuilder_PublishActivationTx_FailsWhenNIPostBuilderFails(t *testing.T) {
 	tab := newTestBuilder(t, WithPoetConfig(PoetConfig{PhaseShift: layerDuration * 4}))
-	posAtxLayer := postGenesisEpoch.FirstLayer()
-	currLayer := posAtxLayer
-	challenge := newChallenge(1, types.ATXID{1, 2, 3}, types.ATXID{1, 2, 3}, posAtxLayer, nil)
+	posEpoch := postGenesisEpoch
+	currLayer := posEpoch.FirstLayer()
+	challenge := newChallenge(1, types.ATXID{1, 2, 3}, types.ATXID{1, 2, 3}, posEpoch, nil)
 	nipost := newNIPostWithChallenge(types.HexToHash32("55555"), []byte("66666"))
 	posAtx := newAtx(t, tab.sig, challenge, nipost, 2, types.Address{})
 	SignAndFinalizeAtx(tab.sig, posAtx)
@@ -868,7 +867,7 @@ func TestBuilder_PublishActivationTx_FailsWhenNIPostBuilderFails(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, atxs.Add(tab.cdb, vPosAtx))
 
-	tab.mclock.EXPECT().CurrentLayer().Return(posAtxLayer).AnyTimes()
+	tab.mclock.EXPECT().CurrentLayer().Return(posEpoch.FirstLayer()).AnyTimes()
 	tab.mhdlr.EXPECT().GetPosAtxID().Return(vPosAtx.ID(), nil)
 	tab.mclock.EXPECT().LayerToTime(gomock.Any()).DoAndReturn(
 		func(got types.LayerID) time.Time {
@@ -890,10 +889,10 @@ func TestBuilder_PublishActivationTx_Serialize(t *testing.T) {
 
 	nipost := newNIPostWithChallenge(types.HexToHash32("55555"), []byte("66666"))
 	coinbase := types.Address{4, 5, 6}
-	atx := newActivationTx(t, sig, 1, types.ATXID{1, 2, 3}, types.ATXID{1, 2, 3}, nil, types.LayerID(5), 1, 100, coinbase, 100, nipost)
+	atx := newActivationTx(t, sig, 1, types.ATXID{1, 2, 3}, types.ATXID{1, 2, 3}, nil, types.EpochID(5), 1, 100, coinbase, 100, nipost)
 	require.NoError(t, atxs.Add(cdb, atx))
 
-	act := newActivationTx(t, sig, 2, atx.ID(), atx.ID(), nil, atx.PubLayerID.Add(10), 0, 100, coinbase, 100, nipost)
+	act := newActivationTx(t, sig, 2, atx.ID(), atx.ID(), nil, atx.PublishEpoch.Add(10), 0, 100, coinbase, 100, nipost)
 
 	bt, err := codec.Encode(act)
 	require.NoError(t, err)
@@ -911,7 +910,7 @@ func TestBuilder_PublishActivationTx_Serialize(t *testing.T) {
 func TestBuilder_SignAtx(t *testing.T) {
 	tab := newTestBuilder(t)
 	prevAtx := types.ATXID(types.HexToHash32("0x111"))
-	challenge := newChallenge(1, prevAtx, prevAtx, types.LayerID(15), nil)
+	challenge := newChallenge(1, prevAtx, prevAtx, types.EpochID(15), nil)
 	nipost := newNIPostWithChallenge(types.HexToHash32("55555"), []byte("66666"))
 	atx := newAtx(t, tab.sig, challenge, nipost, 100, types.Address{})
 	atx.SetMetadata()
@@ -930,9 +929,9 @@ func TestBuilder_SignAtx(t *testing.T) {
 
 func TestBuilder_NIPostPublishRecovery(t *testing.T) {
 	tab := newTestBuilder(t, WithPoetConfig(PoetConfig{PhaseShift: layerDuration * 4}))
-	posAtxLayer := postGenesisEpoch.FirstLayer()
-	currLayer := posAtxLayer
-	challenge := newChallenge(1, types.ATXID{1, 2, 3}, types.ATXID{1, 2, 3}, posAtxLayer, nil)
+	posEpoch := postGenesisEpoch
+	currLayer := posEpoch.FirstLayer()
+	challenge := newChallenge(1, types.ATXID{1, 2, 3}, types.ATXID{1, 2, 3}, posEpoch, nil)
 	nipost := newNIPostWithChallenge(types.HexToHash32("55555"), []byte("66666"))
 	prevAtx := newAtx(t, tab.sig, challenge, nipost, 2, types.Address{})
 	SignAndFinalizeAtx(tab.sig, prevAtx)
@@ -940,7 +939,7 @@ func TestBuilder_NIPostPublishRecovery(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, atxs.Add(tab.cdb, vPrevAtx))
 
-	publishEpoch := posAtxLayer.GetEpoch() + 1
+	publishEpoch := posEpoch + 1
 	tab.mclock.EXPECT().CurrentLayer().DoAndReturn(func() types.LayerID { return currLayer }).AnyTimes()
 	tab.mhdlr.EXPECT().GetPosAtxID().Return(prevAtx.ID(), nil)
 	tab.mclock.EXPECT().LayerToTime(gomock.Any()).DoAndReturn(
@@ -1014,14 +1013,14 @@ func TestBuilder_NIPostPublishRecovery(t *testing.T) {
 	require.ErrorIs(t, err, sql.ErrNotFound)
 	require.Empty(t, got)
 
-	posAtxLayer = posAtxLayer.Add(layersPerEpoch + 1)
-	challenge = newChallenge(1, types.ATXID{1, 2, 3}, types.ATXID{1, 2, 3}, posAtxLayer, nil)
+	posEpoch = posEpoch + 1
+	challenge = newChallenge(1, types.ATXID{1, 2, 3}, types.ATXID{1, 2, 3}, posEpoch, nil)
 	posAtx := newAtx(t, tab.sig, challenge, nipost, 2, types.Address{})
 	SignAndFinalizeAtx(tab.sig, posAtx)
 	vPosAtx, err := posAtx.Verify(0, 1)
 	require.NoError(t, err)
 	require.NoError(t, atxs.Add(tab.cdb, vPosAtx))
-	built2, err := publishAtx(t, tab, posAtx.ID(), posAtxLayer, &currLayer, layersPerEpoch)
+	built2, err := publishAtx(t, tab, posAtx.ID(), posEpoch, &currLayer, layersPerEpoch)
 	require.NoError(t, err)
 	require.NotNil(t, built2)
 	require.NotEqual(t, built.NIPost, built2.NIPost)
@@ -1035,8 +1034,8 @@ func TestBuilder_NIPostPublishRecovery(t *testing.T) {
 func TestBuilder_RetryPublishActivationTx(t *testing.T) {
 	retryInterval := 10 * time.Microsecond
 	tab := newTestBuilder(t, WithPoetConfig(PoetConfig{PhaseShift: layerDuration * 4}), WithPoetRetryInterval(retryInterval))
-	posAtxLayer := (postGenesisEpoch + 1).FirstLayer()
-	challenge := newChallenge(1, types.ATXID{1, 2, 3}, types.ATXID{1, 2, 3}, posAtxLayer, nil)
+	posEpoch := postGenesisEpoch + 1
+	challenge := newChallenge(1, types.ATXID{1, 2, 3}, types.ATXID{1, 2, 3}, posEpoch, nil)
 	poetBytes := []byte("66666")
 	nipost := newNIPostWithChallenge(types.HexToHash32("55555"), poetBytes)
 	prevAtx := newAtx(t, tab.sig, challenge, nipost, 2, types.Address{})
@@ -1045,7 +1044,7 @@ func TestBuilder_RetryPublishActivationTx(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, atxs.Add(tab.cdb, vPrevAtx))
 
-	currLayer := posAtxLayer.Add(1)
+	currLayer := posEpoch.FirstLayer().Add(1)
 	tab.mclock.EXPECT().CurrentLayer().Return(currLayer).AnyTimes()
 	tab.mhdlr.EXPECT().GetPosAtxID().Return(prevAtx.ID(), nil).AnyTimes()
 	tab.mclock.EXPECT().LayerToTime(gomock.Any()).DoAndReturn(
@@ -1096,8 +1095,8 @@ func TestBuilder_InitialProofGeneratedOnce(t *testing.T) {
 	tab.mpost.EXPECT().GenerateProof(gomock.Any(), gomock.Any())
 	require.NoError(t, tab.generateProof(context.Background()))
 
-	posAtxLayer := (postGenesisEpoch + 1).FirstLayer()
-	challenge := newChallenge(1, types.ATXID{1, 2, 3}, types.ATXID{1, 2, 3}, posAtxLayer, nil)
+	posEpoch := postGenesisEpoch + 1
+	challenge := newChallenge(1, types.ATXID{1, 2, 3}, types.ATXID{1, 2, 3}, posEpoch, nil)
 	poetByte := []byte("66666")
 	nipost := newNIPostWithChallenge(types.HexToHash32("55555"), poetByte)
 	prevAtx := newAtx(t, tab.sig, challenge, nipost, 2, types.Address{})
@@ -1106,8 +1105,8 @@ func TestBuilder_InitialProofGeneratedOnce(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, atxs.Add(tab.cdb, vPrevAtx))
 
-	currLayer := posAtxLayer.Add(1)
-	atx, err := publishAtx(t, tab, prevAtx.ID(), posAtxLayer, &currLayer, layersPerEpoch)
+	currLayer := posEpoch.FirstLayer().Add(1)
+	atx, err := publishAtx(t, tab, prevAtx.ID(), posEpoch, &currLayer, layersPerEpoch)
 	require.NoError(t, err)
 	require.NotNil(t, atx)
 	assertLastAtx(require.New(t), tab.nodeID, types.BytesToHash(poetByte), atx, vPrevAtx, vPrevAtx, layersPerEpoch)

--- a/activation/handler.go
+++ b/activation/handler.go
@@ -141,9 +141,9 @@ func (h *Handler) ProcessAtx(ctx context.Context, atx *types.VerifiedActivationT
 	}
 	h.log.WithContext(ctx).With().Info("processing atx",
 		atx.ID(),
-		atx.PublishEpoch(),
+		atx.PublishEpoch,
 		log.FieldNamed("smesher", atx.SmesherID),
-		atx.PubLayerID,
+		atx.PublishEpoch,
 	)
 	if err := h.ContextuallyValidateAtx(atx); err != nil {
 		h.log.WithContext(ctx).With().Warning("atx failed contextual validation",
@@ -195,7 +195,7 @@ func (h *Handler) SyntacticallyValidateAtx(ctx context.Context, atx *types.Activ
 		}
 	}
 
-	if err := h.nipostValidator.PositioningAtx(&atx.PositioningATX, h.cdb, h.goldenATXID, atx.PubLayerID, h.layersPerEpoch); err != nil {
+	if err := h.nipostValidator.PositioningAtx(&atx.PositioningATX, h.cdb, h.goldenATXID, atx.PublishEpoch, h.layersPerEpoch); err != nil {
 		return nil, err
 	}
 
@@ -359,7 +359,7 @@ func (h *Handler) storeAtx(ctx context.Context, atx *types.VerifiedActivationTx)
 	var proof *types.MalfeasanceProof
 	if err = h.cdb.WithTx(ctx, func(dbtx *sql.Tx) error {
 		if !malicious {
-			prev, err := atxs.GetByEpochAndNodeID(dbtx, atx.PublishEpoch(), atx.SmesherID)
+			prev, err := atxs.GetByEpochAndNodeID(dbtx, atx.PublishEpoch, atx.SmesherID)
 			if err != nil && !errors.Is(err, sql.ErrNotFound) {
 				return err
 			}
@@ -404,7 +404,7 @@ func (h *Handler) storeAtx(ctx context.Context, atx *types.VerifiedActivationTx)
 		delete(h.atxChannels, atx.ID())
 	}
 
-	h.log.WithContext(ctx).With().Info("finished storing atx in epoch", atx.ID(), atx.PublishEpoch())
+	h.log.WithContext(ctx).With().Info("finished storing atx in epoch", atx.ID(), atx.PublishEpoch)
 
 	// broadcast malfeasance proof last as the verification of the proof will take place
 	// in the same goroutine
@@ -489,7 +489,7 @@ func (h *Handler) handleAtxData(ctx context.Context, peer p2p.Peer, data []byte)
 		return errMalformedData
 	}
 
-	epochStart := h.clock.LayerToTime(atx.PublishEpoch().FirstLayer())
+	epochStart := h.clock.LayerToTime(atx.PublishEpoch.FirstLayer())
 	poetRoundEnd := epochStart.Add(h.poetCfg.PhaseShift - h.poetCfg.CycleGap)
 	latency := receivedTime.Sub(poetRoundEnd)
 	metrics.ReportMessageLatency(pubsub.AtxProtocol, pubsub.AtxProtocol, latency)

--- a/activation/handler_test.go
+++ b/activation/handler_test.go
@@ -80,14 +80,14 @@ func TestHandler_processBlockATXs(t *testing.T) {
 	numUnits := uint32(100)
 
 	npst := newNIPostWithChallenge(chlng, poetRef)
-	posATX := newActivationTx(t, sig, 0, types.EmptyATXID, types.EmptyATXID, nil, types.LayerID(1000), 0, numTicks, coinbase1, numUnits, npst)
+	posATX := newActivationTx(t, sig, 0, types.EmptyATXID, types.EmptyATXID, nil, types.LayerID(1000).GetEpoch(), 0, numTicks, coinbase1, numUnits, npst)
 	r.NoError(atxs.Add(cdb, posATX))
 
 	// Act
 	atxList := []*types.VerifiedActivationTx{
-		newActivationTx(t, sig1, 0, types.EmptyATXID, posATX.ID(), nil, types.LayerID(1012), 0, numTicks, coinbase1, numUnits, &types.NIPost{}),
-		newActivationTx(t, sig2, 0, types.EmptyATXID, posATX.ID(), nil, types.LayerID(1300), 0, numTicks, coinbase2, numUnits, &types.NIPost{}),
-		newActivationTx(t, sig3, 0, types.EmptyATXID, posATX.ID(), nil, types.LayerID(1435), 0, numTicks, coinbase3, numUnits, &types.NIPost{}),
+		newActivationTx(t, sig1, 0, types.EmptyATXID, posATX.ID(), nil, types.LayerID(1012).GetEpoch(), 0, numTicks, coinbase1, numUnits, &types.NIPost{}),
+		newActivationTx(t, sig2, 0, types.EmptyATXID, posATX.ID(), nil, types.LayerID(1300).GetEpoch(), 0, numTicks, coinbase2, numUnits, &types.NIPost{}),
+		newActivationTx(t, sig3, 0, types.EmptyATXID, posATX.ID(), nil, types.LayerID(1435).GetEpoch(), 0, numTicks, coinbase3, numUnits, &types.NIPost{}),
 	}
 	for _, atx := range atxList {
 		atx.NIPost = newNIPostWithChallenge(atx.NIPostChallenge.Hash(), poetRef)
@@ -97,9 +97,9 @@ func TestHandler_processBlockATXs(t *testing.T) {
 
 	// check that further atxList don't affect current epoch count
 	atxList2 := []*types.VerifiedActivationTx{
-		newActivationTx(t, sig1, 1, atxList[0].ID(), atxList[0].ID(), nil, types.LayerID(2012), 0, numTicks, coinbase1, numUnits, &types.NIPost{}),
-		newActivationTx(t, sig2, 1, atxList[1].ID(), atxList[1].ID(), nil, types.LayerID(2300), 0, numTicks, coinbase2, numUnits, &types.NIPost{}),
-		newActivationTx(t, sig3, 1, atxList[2].ID(), atxList[2].ID(), nil, types.LayerID(2435), 0, numTicks, coinbase3, numUnits, &types.NIPost{}),
+		newActivationTx(t, sig1, 1, atxList[0].ID(), atxList[0].ID(), nil, types.LayerID(2012).GetEpoch(), 0, numTicks, coinbase1, numUnits, &types.NIPost{}),
+		newActivationTx(t, sig2, 1, atxList[1].ID(), atxList[1].ID(), nil, types.LayerID(2300).GetEpoch(), 0, numTicks, coinbase2, numUnits, &types.NIPost{}),
+		newActivationTx(t, sig3, 1, atxList[2].ID(), atxList[2].ID(), nil, types.LayerID(2435).GetEpoch(), 0, numTicks, coinbase3, numUnits, &types.NIPost{}),
 	}
 	for _, atx := range atxList2 {
 		atx.NIPost = newNIPostWithChallenge(atx.NIPostChallenge.Hash(), poetRef)
@@ -149,9 +149,9 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 	sig3, err := signing.NewEdSigner()
 	require.NoError(t, err)
 	atxList := []*types.VerifiedActivationTx{
-		newActivationTx(t, sig1, 0, types.EmptyATXID, types.EmptyATXID, &goldenATXID, types.LayerID(1), 0, 100, coinbase, 100, &types.NIPost{}),
-		newActivationTx(t, sig2, 0, types.EmptyATXID, types.EmptyATXID, &goldenATXID, types.LayerID(1), 0, 100, coinbase, 100, &types.NIPost{}),
-		newActivationTx(t, sig3, 0, types.EmptyATXID, types.EmptyATXID, &goldenATXID, types.LayerID(1), 0, 100, coinbase, 100, &types.NIPost{}),
+		newActivationTx(t, sig1, 0, types.EmptyATXID, types.EmptyATXID, &goldenATXID, types.LayerID(1).GetEpoch(), 0, 100, coinbase, 100, &types.NIPost{}),
+		newActivationTx(t, sig2, 0, types.EmptyATXID, types.EmptyATXID, &goldenATXID, types.LayerID(1).GetEpoch(), 0, 100, coinbase, 100, &types.NIPost{}),
+		newActivationTx(t, sig3, 0, types.EmptyATXID, types.EmptyATXID, &goldenATXID, types.LayerID(1).GetEpoch(), 0, 100, coinbase, 100, &types.NIPost{}),
 	}
 	for _, atx := range atxList {
 		require.NoError(t, atxHdlr.ProcessAtx(context.Background(), atx))
@@ -160,17 +160,17 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 	chlng := types.HexToHash32("0x3333")
 	poetRef := []byte{0xba, 0xbe}
 	npst := newNIPostWithChallenge(chlng, poetRef)
-	prevAtx := newActivationTx(t, sig, 0, types.EmptyATXID, types.EmptyATXID, &goldenATXID, types.LayerID(100), 0, 100, coinbase, 100, npst)
+	prevAtx := newActivationTx(t, sig, 0, types.EmptyATXID, types.EmptyATXID, &goldenATXID, types.LayerID(100).GetEpoch(), 0, 100, coinbase, 100, npst)
 	nonce := types.VRFPostIndex(1)
 	prevAtx.VRFNonce = &nonce
-	posAtx := newActivationTx(t, otherSig, 0, types.EmptyATXID, types.EmptyATXID, &goldenATXID, types.LayerID(100), 0, 100, coinbase, 100, npst)
+	posAtx := newActivationTx(t, otherSig, 0, types.EmptyATXID, types.EmptyATXID, &goldenATXID, types.LayerID(100).GetEpoch(), 0, 100, coinbase, 100, npst)
 	require.NoError(t, atxs.Add(cdb, prevAtx))
 	require.NoError(t, atxs.Add(cdb, posAtx))
 
 	// Act & Assert
 
 	t.Run("valid atx", func(t *testing.T) {
-		challenge := newChallenge(1, prevAtx.ID(), prevAtx.ID(), types.LayerID(1012), nil)
+		challenge := newChallenge(1, prevAtx.ID(), prevAtx.ID(), types.LayerID(1012).GetEpoch(), nil)
 		atx := newAtx(t, sig, challenge, &types.NIPost{}, 100, coinbase)
 		atx.NIPost = newNIPostWithChallenge(atx.NIPostChallenge.Hash(), poetRef)
 		require.NoError(t, SignAndFinalizeAtx(sig, atx))
@@ -184,7 +184,7 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 	})
 
 	t.Run("valid atx with new VRF nonce", func(t *testing.T) {
-		challenge := newChallenge(1, prevAtx.ID(), prevAtx.ID(), types.LayerID(1012), nil)
+		challenge := newChallenge(1, prevAtx.ID(), prevAtx.ID(), types.LayerID(1012).GetEpoch(), nil)
 		nonce := types.VRFPostIndex(999)
 		atx := newAtx(t, sig, challenge, &types.NIPost{}, 100, coinbase)
 		atx.NIPost = newNIPostWithChallenge(atx.NIPostChallenge.Hash(), poetRef)
@@ -201,7 +201,7 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 	})
 
 	t.Run("valid atx with decreasing num units", func(t *testing.T) {
-		challenge := newChallenge(1, prevAtx.ID(), prevAtx.ID(), types.LayerID(1012), nil)
+		challenge := newChallenge(1, prevAtx.ID(), prevAtx.ID(), types.LayerID(1012).GetEpoch(), nil)
 		atx := newAtx(t, sig, challenge, &types.NIPost{}, 90, coinbase) // numunits decreased from 100 to 90 between atx and prevAtx
 		atx.NIPost = newNIPostWithChallenge(atx.NIPostChallenge.Hash(), poetRef)
 		require.NoError(t, SignAndFinalizeAtx(sig, atx))
@@ -217,7 +217,7 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 	})
 
 	t.Run("atx with increasing num units, no new VRF, old valid", func(t *testing.T) {
-		challenge := newChallenge(1, prevAtx.ID(), prevAtx.ID(), types.LayerID(1012), nil)
+		challenge := newChallenge(1, prevAtx.ID(), prevAtx.ID(), types.LayerID(1012).GetEpoch(), nil)
 		atx := newAtx(t, sig, challenge, &types.NIPost{}, 110, coinbase) // numunits increased from 100 to 110 between atx and prevAtx
 		atx.NIPost = newNIPostWithChallenge(atx.NIPostChallenge.Hash(), poetRef)
 		require.NoError(t, SignAndFinalizeAtx(sig, atx))
@@ -234,7 +234,7 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 	})
 
 	t.Run("atx with increasing num units, no new VRF, old invalid for new size", func(t *testing.T) {
-		challenge := newChallenge(1, prevAtx.ID(), prevAtx.ID(), types.LayerID(1012), nil)
+		challenge := newChallenge(1, prevAtx.ID(), prevAtx.ID(), types.LayerID(1012).GetEpoch(), nil)
 		atx := newAtx(t, sig, challenge, &types.NIPost{}, 110, coinbase) // numunits increased from 100 to 110 between atx and prevAtx
 		atx.NIPost = newNIPostWithChallenge(atx.NIPostChallenge.Hash(), poetRef)
 		require.NoError(t, SignAndFinalizeAtx(sig, atx))
@@ -253,7 +253,7 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 
 	t.Run("valid initial atx", func(t *testing.T) {
 		ctxID := prevAtx.ID()
-		challenge := newChallenge(0, types.EmptyATXID, prevAtx.ID(), types.LayerID(1012), &ctxID)
+		challenge := newChallenge(0, types.EmptyATXID, prevAtx.ID(), types.LayerID(1012).GetEpoch(), &ctxID)
 		atx := newAtx(t, sig, challenge, &types.NIPost{}, 100, coinbase)
 		atx.InitialPost = initialPost
 		atx.InitialPostIndices = initialPost.Indices
@@ -275,7 +275,7 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 	})
 
 	t.Run("failing nipost challenge validation", func(t *testing.T) {
-		challenge := newChallenge(0, prevAtx.ID(), posAtx.ID(), types.LayerID(1012), nil)
+		challenge := newChallenge(0, prevAtx.ID(), posAtx.ID(), types.LayerID(1012).GetEpoch(), nil)
 		atx := newAtx(t, sig, challenge, &types.NIPost{}, 100, coinbase)
 		require.NoError(t, SignAndFinalizeAtx(sig, atx))
 
@@ -286,7 +286,7 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 	})
 
 	t.Run("failing positioning atx validation", func(t *testing.T) {
-		challenge := newChallenge(0, prevAtx.ID(), posAtx.ID(), types.LayerID(1012), nil)
+		challenge := newChallenge(0, prevAtx.ID(), posAtx.ID(), types.LayerID(1012).GetEpoch(), nil)
 		atx := newAtx(t, sig, challenge, &types.NIPost{}, 100, coinbase)
 		require.NoError(t, SignAndFinalizeAtx(sig, atx))
 
@@ -298,11 +298,11 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 	})
 
 	t.Run("bad initial nipost challenge", func(t *testing.T) {
-		commitmentAtx := newActivationTx(t, otherSig, 0, types.EmptyATXID, types.EmptyATXID, nil, types.LayerID(1020), 0, 100, coinbase, 100, npst)
+		commitmentAtx := newActivationTx(t, otherSig, 0, types.EmptyATXID, types.EmptyATXID, nil, types.LayerID(1020).GetEpoch(), 0, 100, coinbase, 100, npst)
 		require.NoError(t, atxs.Add(cdb, commitmentAtx))
 
 		cATX := commitmentAtx.ID()
-		challenge := newChallenge(0, types.EmptyATXID, posAtx.ID(), types.LayerID(1012), &cATX)
+		challenge := newChallenge(0, types.EmptyATXID, posAtx.ID(), types.LayerID(1012).GetEpoch(), &cATX)
 		atx := newAtx(t, sig, challenge, npst, 100, coinbase)
 		atx.InitialPost = initialPost
 		atx.InitialPostIndices = initialPost.Indices
@@ -317,7 +317,7 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 
 	t.Run("missing NodeID in initial atx", func(t *testing.T) {
 		ctxID := prevAtx.ID()
-		challenge := newChallenge(0, types.EmptyATXID, posAtx.ID(), types.LayerID(1012), &ctxID)
+		challenge := newChallenge(0, types.EmptyATXID, posAtx.ID(), types.LayerID(1012).GetEpoch(), &ctxID)
 		atx := newAtx(t, sig, challenge, &types.NIPost{}, 100, coinbase)
 		atx.InitialPost = initialPost
 		atx.InitialPostIndices = initialPost.Indices
@@ -328,7 +328,7 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 
 	t.Run("missing VRF nonce in initial atx", func(t *testing.T) {
 		ctxID := prevAtx.ID()
-		challenge := newChallenge(0, types.EmptyATXID, posAtx.ID(), types.LayerID(1012), &ctxID)
+		challenge := newChallenge(0, types.EmptyATXID, posAtx.ID(), types.LayerID(1012).GetEpoch(), &ctxID)
 		atx := newAtx(t, sig, challenge, &types.NIPost{}, 100, coinbase)
 		atx.InitialPost = initialPost
 		atx.InitialPostIndices = initialPost.Indices
@@ -346,7 +346,7 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 
 	t.Run("invalid VRF nonce in initial atx", func(t *testing.T) {
 		ctxID := prevAtx.ID()
-		challenge := newChallenge(0, types.EmptyATXID, posAtx.ID(), types.LayerID(1012), &ctxID)
+		challenge := newChallenge(0, types.EmptyATXID, posAtx.ID(), types.LayerID(1012).GetEpoch(), &ctxID)
 		atx := newAtx(t, sig, challenge, &types.NIPost{}, 100, coinbase)
 		atx.InitialPost = initialPost
 		atx.InitialPostIndices = initialPost.Indices
@@ -366,7 +366,7 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 	})
 
 	t.Run("prevAtx not declared but initial Post not included", func(t *testing.T) {
-		challenge := newChallenge(0, types.EmptyATXID, posAtx.ID(), types.LayerID(1012), nil)
+		challenge := newChallenge(0, types.EmptyATXID, posAtx.ID(), types.LayerID(1012).GetEpoch(), nil)
 		atx := newAtx(t, sig, challenge, &types.NIPost{}, 100, coinbase)
 		atx.InitialPostIndices = []byte{}
 		atx.CommitmentATX = &goldenATXID
@@ -377,7 +377,7 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 
 	t.Run("prevAtx not declared but validation of initial post fails", func(t *testing.T) {
 		cATX := prevAtx.ID()
-		challenge := newChallenge(0, types.EmptyATXID, posAtx.ID(), types.LayerID(1012), &cATX)
+		challenge := newChallenge(0, types.EmptyATXID, posAtx.ID(), types.LayerID(1012).GetEpoch(), &cATX)
 		atx := newAtx(t, sig, challenge, npst, 100, coinbase)
 		atx.InitialPost = initialPost
 		atx.InitialPostIndices = initialPost.Indices
@@ -394,7 +394,7 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 	})
 
 	t.Run("prevAtx declared but initial Post is included", func(t *testing.T) {
-		challenge := newChallenge(1, prevAtx.ID(), posAtx.ID(), types.LayerID(1012), nil)
+		challenge := newChallenge(1, prevAtx.ID(), posAtx.ID(), types.LayerID(1012).GetEpoch(), nil)
 		atx := newAtx(t, sig, challenge, &types.NIPost{}, 100, coinbase)
 		atx.InitialPost = initialPost
 		require.NoError(t, SignAndFinalizeAtx(sig, atx))
@@ -406,7 +406,7 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 	})
 
 	t.Run("prevAtx declared but NodeID is included", func(t *testing.T) {
-		challenge := newChallenge(1, prevAtx.ID(), prevAtx.ID(), types.LayerID(1012), nil)
+		challenge := newChallenge(1, prevAtx.ID(), prevAtx.ID(), types.LayerID(1012).GetEpoch(), nil)
 		atx := newAtx(t, sig, challenge, &types.NIPost{}, 100, coinbase)
 		atx.NIPost = newNIPostWithChallenge(atx.NIPostChallenge.Hash(), poetRef)
 		atx.InnerActivationTx.NodeID = new(types.NodeID)
@@ -442,7 +442,7 @@ func TestHandler_ContextuallyValidateAtx(t *testing.T) {
 	chlng := types.HexToHash32("0x3333")
 	poetRef := []byte{0x56, 0xbe}
 	npst := newNIPostWithChallenge(chlng, poetRef)
-	prevAtx := newActivationTx(t, sig, 0, types.EmptyATXID, types.EmptyATXID, nil, types.LayerID(100), 0, 100, coinbase, 100, npst)
+	prevAtx := newActivationTx(t, sig, 0, types.EmptyATXID, types.EmptyATXID, nil, types.LayerID(100).GetEpoch(), 0, 100, coinbase, 100, npst)
 	require.NoError(t, atxs.Add(cdb, prevAtx))
 
 	// Act & Assert
@@ -459,14 +459,14 @@ func TestHandler_ContextuallyValidateAtx(t *testing.T) {
 	})
 
 	t.Run("atx already exists", func(t *testing.T) {
-		challenge := newChallenge(1, types.EmptyATXID, goldenATXID, types.LayerID(layersPerEpochBig), nil)
+		challenge := newChallenge(1, types.EmptyATXID, goldenATXID, types.LayerID(layersPerEpochBig).GetEpoch(), nil)
 		atx := newAtx(t, sig, challenge, &types.NIPost{}, 100, coinbase)
 		require.NoError(t, SignAndFinalizeAtx(sig, atx))
 		vAtx, err := atx.Verify(0, 1)
 		require.NoError(t, err)
 		require.NoError(t, atxs.Add(cdb, vAtx))
 
-		challenge = newChallenge(1, prevAtx.ID(), goldenATXID, types.LayerID(12), nil)
+		challenge = newChallenge(1, prevAtx.ID(), goldenATXID, types.LayerID(12).GetEpoch(), nil)
 		atx = newAtx(t, sig, challenge, &types.NIPost{}, 100, coinbase)
 		require.NoError(t, SignAndFinalizeAtx(sig, atx))
 		vAtx, err = atx.Verify(0, 1)
@@ -493,13 +493,13 @@ func TestHandler_ContextuallyValidateAtx(t *testing.T) {
 		sig1, err := signing.NewEdSigner()
 		require.NoError(t, err)
 
-		vAtx := newActivationTx(t, sig1, 1, prevAtx.ID(), prevAtx.ID(), nil, types.LayerID(1012), 0, 100, coinbase, 100, &types.NIPost{})
+		vAtx := newActivationTx(t, sig1, 1, prevAtx.ID(), prevAtx.ID(), nil, types.LayerID(1012).GetEpoch(), 0, 100, coinbase, 100, &types.NIPost{})
 		require.NoError(t, atxs.Add(cdb, vAtx))
 
-		vAtx2 := newActivationTx(t, sig1, 2, vAtx.ID(), vAtx.ID(), nil, types.LayerID(1012+layersPerEpochBig), 0, 100, coinbase, 100, &types.NIPost{})
+		vAtx2 := newActivationTx(t, sig1, 2, vAtx.ID(), vAtx.ID(), nil, types.LayerID(1012+layersPerEpochBig).GetEpoch(), 0, 100, coinbase, 100, &types.NIPost{})
 		require.NoError(t, atxs.Add(cdb, vAtx2))
 
-		vAtx3 := newActivationTx(t, sig1, 3, vAtx.ID(), vAtx.ID(), nil, types.LayerID(1012+layersPerEpochBig*3), 0, 100, coinbase, 100, &types.NIPost{})
+		vAtx3 := newActivationTx(t, sig1, 3, vAtx.ID(), vAtx.ID(), nil, types.LayerID(1012+layersPerEpochBig*3).GetEpoch(), 0, 100, coinbase, 100, &types.NIPost{})
 		require.EqualError(t, atxHdlr.ContextuallyValidateAtx(vAtx3), "last atx is not the one referenced")
 
 		id, err := atxs.GetLastIDByNodeID(cdb, sig1.NodeID())
@@ -516,16 +516,16 @@ func TestHandler_ContextuallyValidateAtx(t *testing.T) {
 		otherSig, err := signing.NewEdSigner()
 		require.NoError(t, err)
 
-		vAtx := newActivationTx(t, sig1, 2, prevAtx.ID(), prevAtx.ID(), nil, types.LayerID(1012), 0, 100, coinbase, 100, &types.NIPost{})
+		vAtx := newActivationTx(t, sig1, 2, prevAtx.ID(), prevAtx.ID(), nil, types.LayerID(1012).GetEpoch(), 0, 100, coinbase, 100, &types.NIPost{})
 		require.NoError(t, atxs.Add(cdb, vAtx))
 
-		prevAtx := newActivationTx(t, otherSig, 0, types.EmptyATXID, types.EmptyATXID, nil, types.LayerID(100), 0, 100, coinbase, 100, npst)
+		prevAtx := newActivationTx(t, otherSig, 0, types.EmptyATXID, types.EmptyATXID, nil, types.LayerID(100).GetEpoch(), 0, 100, coinbase, 100, npst)
 		require.NoError(t, atxs.Add(cdb, prevAtx))
 
-		vAtx1 := newActivationTx(t, otherSig, 1, prevAtx.ID(), prevAtx.ID(), nil, types.LayerID(1012), 0, 100, coinbase, 100, &types.NIPost{})
+		vAtx1 := newActivationTx(t, otherSig, 1, prevAtx.ID(), prevAtx.ID(), nil, types.LayerID(1012).GetEpoch(), 0, 100, coinbase, 100, &types.NIPost{})
 		require.NoError(t, atxs.Add(cdb, vAtx1))
 
-		vAtx2 := newActivationTx(t, otherSig, 2, vAtx.ID(), vAtx.ID(), nil, types.LayerID(1012+layersPerEpochBig), 0, 100, coinbase, 100, &types.NIPost{})
+		vAtx2 := newActivationTx(t, otherSig, 2, vAtx.ID(), vAtx.ID(), nil, types.LayerID(1012+layersPerEpochBig).GetEpoch(), 0, 100, coinbase, 100, &types.NIPost{})
 		require.EqualError(t, atxHdlr.ContextuallyValidateAtx(vAtx2), "last atx is not the one referenced")
 
 		id, err := atxs.GetLastIDByNodeID(cdb, otherSig.NodeID())
@@ -558,7 +558,7 @@ func TestHandler_ProcessAtx(t *testing.T) {
 	coinbase := types.GenerateAddress([]byte("aaaa"))
 
 	// Act & Assert
-	atx1 := newActivationTx(t, sig, 0, types.EmptyATXID, types.EmptyATXID, nil, types.LayerID(layersPerEpoch), 0, 100, coinbase, 100, &types.NIPost{})
+	atx1 := newActivationTx(t, sig, 0, types.EmptyATXID, types.EmptyATXID, nil, types.LayerID(layersPerEpoch).GetEpoch(), 0, 100, coinbase, 100, &types.NIPost{})
 	require.NoError(t, atxHdlr.ProcessAtx(context.Background(), atx1))
 
 	// processing an already stored ATX returns no error
@@ -568,8 +568,8 @@ func TestHandler_ProcessAtx(t *testing.T) {
 	require.Nil(t, proof)
 
 	// another atx for the same epoch is considered malicious
-	atx2 := newActivationTx(t, sig, 1, atx1.ID(), atx1.ID(), nil, types.LayerID(layersPerEpoch+1), 0, 100, coinbase, 100, &types.NIPost{})
-	mclock.EXPECT().CurrentLayer().Return(atx2.PubLayerID)
+	atx2 := newActivationTx(t, sig, 1, atx1.ID(), atx1.ID(), nil, types.LayerID(layersPerEpoch+1).GetEpoch(), 0, 100, coinbase, 100, &types.NIPost{})
+	mclock.EXPECT().CurrentLayer().Return(atx2.PublishEpoch.FirstLayer())
 	var got types.MalfeasanceGossip
 	mpub.EXPECT().Publish(gomock.Any(), pubsub.MalfeasanceProof, gomock.Any()).DoAndReturn(
 		func(_ context.Context, _ string, data []byte) error {
@@ -604,7 +604,7 @@ func TestHandler_ProcessAtxStoresNewVRFNonce(t *testing.T) {
 	coinbase := types.GenerateAddress([]byte("aaaa"))
 
 	// Act & Assert
-	atx1 := newActivationTx(t, sig, 0, types.EmptyATXID, types.EmptyATXID, nil, types.LayerID(layersPerEpoch), 0, 100, coinbase, 100, &types.NIPost{})
+	atx1 := newActivationTx(t, sig, 0, types.EmptyATXID, types.EmptyATXID, nil, types.LayerID(layersPerEpoch).GetEpoch(), 0, 100, coinbase, 100, &types.NIPost{})
 	nonce1 := types.VRFPostIndex(123)
 	atx1.VRFNonce = &nonce1
 	require.NoError(t, atxHdlr.ProcessAtx(context.Background(), atx1))
@@ -614,7 +614,7 @@ func TestHandler_ProcessAtxStoresNewVRFNonce(t *testing.T) {
 	require.Equal(t, nonce1, got)
 
 	// another atx for the same epoch is considered malicious
-	atx2 := newActivationTx(t, sig, 1, atx1.ID(), atx1.ID(), nil, types.LayerID(2*layersPerEpoch), 0, 100, coinbase, 100, &types.NIPost{})
+	atx2 := newActivationTx(t, sig, 1, atx1.ID(), atx1.ID(), nil, types.LayerID(2*layersPerEpoch).GetEpoch(), 0, 100, coinbase, 100, &types.NIPost{})
 	nonce2 := types.VRFPostIndex(456)
 	atx2.VRFNonce = &nonce2
 	require.NoError(t, atxHdlr.ProcessAtx(context.Background(), atx2))
@@ -652,7 +652,7 @@ func BenchmarkActivationDb_SyntacticallyValidateAtx(b *testing.B) {
 	coinbase := types.GenerateAddress([]byte("c012ba5e"))
 	var atxList []*types.VerifiedActivationTx
 	for i := 0; i < activesetSize; i++ {
-		atxList = append(atxList, newActivationTx(b, sig, 0, types.EmptyATXID, types.EmptyATXID, &goldenATXID, types.LayerID(1), 0, 100, coinbase, 100, &types.NIPost{}))
+		atxList = append(atxList, newActivationTx(b, sig, 0, types.EmptyATXID, types.EmptyATXID, &goldenATXID, types.LayerID(1).GetEpoch(), 0, 100, coinbase, 100, &types.NIPost{}))
 	}
 
 	poetRef := []byte{0x12, 0x21}
@@ -660,11 +660,11 @@ func BenchmarkActivationDb_SyntacticallyValidateAtx(b *testing.B) {
 		atx.NIPost = newNIPostWithChallenge(atx.NIPostChallenge.Hash(), poetRef)
 	}
 
-	challenge := newChallenge(0, types.EmptyATXID, goldenATXID, types.LayerID(numberOfLayers+1), &goldenATXID)
+	challenge := newChallenge(0, types.EmptyATXID, goldenATXID, types.LayerID(numberOfLayers+1).GetEpoch(), &goldenATXID)
 	npst := newNIPostWithChallenge(challenge.Hash(), poetRef)
 	prevAtx := newAtx(b, sig, challenge, npst, 2, coinbase)
 
-	challenge = newChallenge(1, prevAtx.ID(), prevAtx.ID(), types.LayerID(numberOfLayers+1+layersPerEpochBig), nil)
+	challenge = newChallenge(1, prevAtx.ID(), prevAtx.ID(), types.LayerID(numberOfLayers+1+layersPerEpochBig).GetEpoch(), nil)
 	atx := newAtx(b, sig, challenge, &types.NIPost{}, 100, coinbase)
 	nonce := types.VRFPostIndex(1)
 	atx.VRFNonce = &nonce
@@ -726,7 +726,7 @@ func BenchmarkNewActivationDb(b *testing.B) {
 	eStart := time.Now()
 	for epoch := postGenesisEpoch; epoch < postGenesisEpoch+numOfEpochs; epoch++ {
 		for i := 0; i < numOfMiners; i++ {
-			challenge := newChallenge(1, prevAtxs[i], posAtx, layer, nil)
+			challenge := newChallenge(1, prevAtxs[i], posAtx, epoch, nil)
 			npst := newNIPostWithChallenge(challenge.Hash(), poetBytes)
 			atx = newAtx(b, sigs[i], challenge, npst, 2, coinbase)
 			prevAtxs[i] = atx.ID()
@@ -780,7 +780,7 @@ func TestHandler_GetPosAtx(t *testing.T) {
 	// Act & Assert
 
 	// ATX stored should become top ATX
-	atx1 := newActivationTx(t, sig, 0, types.EmptyATXID, types.EmptyATXID, nil, types.LayerID(1), 0, 100, coinbase, 100, &types.NIPost{})
+	atx1 := newActivationTx(t, sig, 0, types.EmptyATXID, types.EmptyATXID, nil, types.LayerID(1).GetEpoch(), 0, 100, coinbase, 100, &types.NIPost{})
 	r.NoError(atxs.Add(cdb, atx1))
 
 	id, err := atxHdlr.GetPosAtxID()
@@ -788,7 +788,7 @@ func TestHandler_GetPosAtx(t *testing.T) {
 	r.Equal(atx1.ID(), id)
 
 	// higher-layer ATX stored should become new top ATX
-	atx2 := newActivationTx(t, otherSig, 0, types.EmptyATXID, types.EmptyATXID, nil, types.LayerID(2*layersPerEpochBig), 0, 100, coinbase, 100, &types.NIPost{})
+	atx2 := newActivationTx(t, otherSig, 0, types.EmptyATXID, types.EmptyATXID, nil, types.LayerID(2*layersPerEpochBig).GetEpoch(), 0, 100, coinbase, 100, &types.NIPost{})
 	r.NoError(atxs.Add(cdb, atx2))
 
 	id, err = atxHdlr.GetPosAtxID()
@@ -796,7 +796,7 @@ func TestHandler_GetPosAtx(t *testing.T) {
 	r.Equal(atx2.ID(), id)
 
 	// lower-layer ATX stored should NOT become new top ATX
-	atx3 := newActivationTx(t, sig, 0, types.EmptyATXID, types.EmptyATXID, nil, types.LayerID(layersPerEpochBig), 0, 100, coinbase, 100, &types.NIPost{})
+	atx3 := newActivationTx(t, sig, 0, types.EmptyATXID, types.EmptyATXID, nil, types.LayerID(layersPerEpochBig).GetEpoch(), 0, 100, coinbase, 100, &types.NIPost{})
 	r.NoError(atxs.Add(cdb, atx3))
 
 	id, err = atxHdlr.GetPosAtxID()
@@ -825,7 +825,7 @@ func TestHandler_AwaitAtx(t *testing.T) {
 	atxHdlr := NewHandler(cdb, verifier, mclock, mpub, nil, layersPerEpochBig, testTickSize, goldenATXID, validator, []AtxReceiver{receiver}, lg, PoetConfig{})
 	// Act & Assert
 
-	atx := newActivationTx(t, sig, 0, types.EmptyATXID, types.EmptyATXID, nil, types.LayerID(1), 0, 100, coinbase, 100, &types.NIPost{})
+	atx := newActivationTx(t, sig, 0, types.EmptyATXID, types.EmptyATXID, nil, types.LayerID(1).GetEpoch(), 0, 100, coinbase, 100, &types.NIPost{})
 	ch := atxHdlr.AwaitAtx(atx.ID())
 	r.Len(atxHdlr.atxChannels, 1) // channel was created
 
@@ -936,7 +936,7 @@ func BenchmarkGetAtxHeaderWithConcurrentProcessAtx(b *testing.B) {
 		go func() {
 			defer wg.Done()
 			for i := 0; ; i++ {
-				challenge := newChallenge(uint64(i), types.EmptyATXID, goldenATXID, types.LayerID(0), nil)
+				challenge := newChallenge(uint64(i), types.EmptyATXID, goldenATXID, 0, nil)
 				sig, err := signing.NewEdSigner()
 				require.NoError(b, err)
 				atx := newAtx(b, sig, challenge, nil, 1, types.Address{})
@@ -981,7 +981,7 @@ func TestHandler_FetchAtxReferences(t *testing.T) {
 	verifier, err := signing.NewEdVerifier()
 	require.NoError(t, err)
 	atxHdlr := NewHandler(cdb, verifier, mclock, mpub, mockFetch, layersPerEpochBig, testTickSize, goldenATXID, validator, []AtxReceiver{receiver}, lg, PoetConfig{})
-	challenge := newChallenge(1, types.ATXID{1, 2, 3}, types.ATXID{1, 2, 3}, types.LayerID(22), nil)
+	challenge := newChallenge(1, types.ATXID{1, 2, 3}, types.ATXID{1, 2, 3}, types.LayerID(22).GetEpoch(), nil)
 	nipost := newNIPostWithChallenge(types.HexToHash32("55555"), []byte("66666"))
 	atx1 := newAtx(t, sig, challenge, nipost, 2, coinbase)
 	atx1.PositioningATX = types.ATXID{1, 2, 3} // should be fetched
@@ -1052,7 +1052,7 @@ func TestHandler_AtxWeight(t *testing.T) {
 			NIPostChallenge: types.NIPostChallenge{
 				PositioningATX:     goldenATXID,
 				InitialPostIndices: []byte{1},
-				PubLayerID:         types.LayerID(1).Add(layersPerEpoch),
+				PublishEpoch:       types.LayerID(1).GetEpoch().Add(layersPerEpoch),
 
 				CommitmentATX: &goldenATXID,
 			},
@@ -1097,7 +1097,7 @@ func TestHandler_AtxWeight(t *testing.T) {
 				Sequence:       1,
 				PositioningATX: atx1.ID(),
 				PrevATXID:      atx1.ID(),
-				PubLayerID:     types.LayerID(1).Add(2 * layersPerEpoch),
+				PublishEpoch:   types.LayerID(1).GetEpoch().Add(2 * layersPerEpoch),
 			},
 			NumUnits: units,
 			NIPost: &types.NIPost{

--- a/activation/interface.go
+++ b/activation/interface.go
@@ -25,7 +25,7 @@ type nipostValidator interface {
 	PostMetadata(cfg *PostConfig, metadata *types.PostMetadata) error
 
 	VRFNonce(nodeId types.NodeID, commitmentAtxId types.ATXID, vrfNonce *types.VRFPostIndex, PostMetadata *types.PostMetadata, numUnits uint32) error
-	PositioningAtx(id *types.ATXID, atxs atxProvider, goldenATXID types.ATXID, publayer types.LayerID, layersPerEpoch uint32) error
+	PositioningAtx(id *types.ATXID, atxs atxProvider, goldenATXID types.ATXID, pubepoch types.EpochID, layersPerEpoch uint32) error
 }
 
 type layerClock interface {

--- a/activation/mocks.go
+++ b/activation/mocks.go
@@ -135,17 +135,17 @@ func (mr *MocknipostValidatorMockRecorder) NumUnits(cfg, numUnits interface{}) *
 }
 
 // PositioningAtx mocks base method.
-func (m *MocknipostValidator) PositioningAtx(id *types.ATXID, atxs atxProvider, goldenATXID types.ATXID, publayer types.LayerID, layersPerEpoch uint32) error {
+func (m *MocknipostValidator) PositioningAtx(id *types.ATXID, atxs atxProvider, goldenATXID types.ATXID, pubepoch types.EpochID, layersPerEpoch uint32) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PositioningAtx", id, atxs, goldenATXID, publayer, layersPerEpoch)
+	ret := m.ctrl.Call(m, "PositioningAtx", id, atxs, goldenATXID, pubepoch, layersPerEpoch)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // PositioningAtx indicates an expected call of PositioningAtx.
-func (mr *MocknipostValidatorMockRecorder) PositioningAtx(id, atxs, goldenATXID, publayer, layersPerEpoch interface{}) *gomock.Call {
+func (mr *MocknipostValidatorMockRecorder) PositioningAtx(id, atxs, goldenATXID, pubepoch, layersPerEpoch interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PositioningAtx", reflect.TypeOf((*MocknipostValidator)(nil).PositioningAtx), id, atxs, goldenATXID, publayer, layersPerEpoch)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PositioningAtx", reflect.TypeOf((*MocknipostValidator)(nil).PositioningAtx), id, atxs, goldenATXID, pubepoch, layersPerEpoch)
 }
 
 // Post mocks base method.

--- a/activation/nipost.go
+++ b/activation/nipost.go
@@ -132,7 +132,7 @@ func (nb *NIPostBuilder) BuildNIPost(ctx context.Context, challenge *types.NIPos
 	//                           WAITING FOR POET        DEADLINE
 	//                               PROOFS
 
-	pubEpoch := challenge.PublishEpoch()
+	pubEpoch := challenge.PublishEpoch
 	poetRoundStart := nb.layerClock.LayerToTime((pubEpoch - 1).FirstLayer()).Add(nb.poetCfg.PhaseShift)
 	nextPoetRoundStart := nb.layerClock.LayerToTime(pubEpoch.FirstLayer()).Add(nb.poetCfg.PhaseShift)
 	poetRoundEnd := nextPoetRoundStart.Add(-nb.poetCfg.CycleGap)

--- a/activation/nipost_test.go
+++ b/activation/nipost_test.go
@@ -45,7 +45,7 @@ func TestNIPostBuilderWithMocks(t *testing.T) {
 	t.Parallel()
 
 	challenge := types.NIPostChallenge{
-		PubLayerID: (postGenesisEpoch + 2).FirstLayer(),
+		PublishEpoch: postGenesisEpoch + 2,
 	}
 
 	ctrl := gomock.NewController(t)
@@ -86,7 +86,7 @@ func TestPostSetup(t *testing.T) {
 	postProvider := newTestPostManager(t)
 
 	challenge := types.NIPostChallenge{
-		PubLayerID: (postGenesisEpoch + 2).FirstLayer(),
+		PublishEpoch: postGenesisEpoch + 2,
 	}
 
 	poetProvider := defaultPoetServiceMock(t, []byte("poet"))
@@ -123,7 +123,7 @@ func TestNIPostBuilderWithClients(t *testing.T) {
 	r := require.New(t)
 
 	challenge := types.NIPostChallenge{
-		PubLayerID: (postGenesisEpoch + 2).FirstLayer(),
+		PublishEpoch: postGenesisEpoch + 2,
 	}
 
 	poetDb := NewMockpoetDbAPI(gomock.NewController(t))
@@ -207,7 +207,7 @@ func TestNewNIPostBuilderNotInitialized(t *testing.T) {
 	r := require.New(t)
 
 	challenge := types.NIPostChallenge{
-		PubLayerID: (postGenesisEpoch + 2).FirstLayer(),
+		PublishEpoch: postGenesisEpoch + 2,
 	}
 
 	postProvider := newTestPostManager(t)
@@ -260,11 +260,11 @@ func TestNIPostBuilder_BuildNIPost(t *testing.T) {
 	postProvider.EXPECT().Status().Return(&PostSetupStatus{State: PostSetupStateComplete}).AnyTimes()
 
 	challenge := types.NIPostChallenge{
-		PubLayerID: (postGenesisEpoch + 2).FirstLayer(),
+		PublishEpoch: postGenesisEpoch + 2,
 	}
 	challenge2 := types.NIPostChallenge{
-		PubLayerID: (postGenesisEpoch + 2).FirstLayer(),
-		Sequence:   1,
+		PublishEpoch: postGenesisEpoch + 2,
+		Sequence:     1,
 	}
 
 	poetProver := defaultPoetServiceMock(t, []byte("poet"))
@@ -337,7 +337,7 @@ func TestNIPostBuilder_ManyPoETs_SubmittingChallenge_DeadlineReached(t *testing.
 	// Arrange
 	req := require.New(t)
 	challenge := types.NIPostChallenge{
-		PubLayerID: (postGenesisEpoch + 1).FirstLayer(),
+		PublishEpoch: postGenesisEpoch + 1,
 	}
 
 	proof := &types.PoetProofMessage{
@@ -404,7 +404,7 @@ func TestNIPostBuilder_ManyPoETs_WaitingForProof_DeadlineReached(t *testing.T) {
 	// Arrange
 	req := require.New(t)
 	challenge := types.NIPostChallenge{
-		PubLayerID: (postGenesisEpoch + 1).FirstLayer(),
+		PublishEpoch: postGenesisEpoch + 1,
 	}
 
 	proof := &types.PoetProofMessage{
@@ -469,7 +469,7 @@ func TestNIPostBuilder_ManyPoETs_AllFinished(t *testing.T) {
 	req := require.New(t)
 
 	challenge := types.NIPostChallenge{
-		PubLayerID: (postGenesisEpoch + 2).FirstLayer(),
+		PublishEpoch: postGenesisEpoch + 2,
 	}
 
 	proofWorse := &types.PoetProofMessage{
@@ -537,7 +537,7 @@ func TestNIPostBuilder_Close(t *testing.T) {
 	poetProver := spawnPoet(t, WithGenesis(time.Now()), WithEpochDuration(time.Second))
 	poetDb := NewMockpoetDbAPI(ctrl)
 	challenge := types.NIPostChallenge{
-		PubLayerID: (postGenesisEpoch + 2).FirstLayer(),
+		PublishEpoch: postGenesisEpoch + 2,
 	}
 	mclock := defaultLayerClockMock(t)
 
@@ -556,7 +556,7 @@ func TestNIPostBuilder_Close(t *testing.T) {
 func TestNIPSTBuilder_PoetUnstable(t *testing.T) {
 	t.Parallel()
 	challenge := types.NIPostChallenge{
-		PubLayerID: (postGenesisEpoch + 1).FirstLayer(),
+		PublishEpoch: postGenesisEpoch + 1,
 	}
 	poetCfg := PoetConfig{PhaseShift: layerDuration}
 

--- a/activation/validation.go
+++ b/activation/validation.go
@@ -210,14 +210,16 @@ func (*Validator) NIPostChallenge(challenge *types.NIPostChallenge, atxs atxProv
 func (*Validator) PositioningAtx(id *types.ATXID, atxs atxProvider, goldenATXID types.ATXID, pubepoch types.EpochID, layersPerEpoch uint32) error {
 	if *id == types.EmptyATXID {
 		return fmt.Errorf("empty positioning atx")
-	} else if *id != goldenATXID {
-		posAtx, err := atxs.GetAtxHeader(*id)
-		if err != nil {
-			return &ErrAtxNotFound{Id: *id, source: err}
-		}
-		if posAtx.PublishEpoch >= pubepoch {
-			return fmt.Errorf("positioning atx epoch (%v) must be before %v", posAtx.PublishEpoch, pubepoch)
-		}
+	}
+	if *id == goldenATXID {
+		return nil
+	}
+	posAtx, err := atxs.GetAtxHeader(*id)
+	if err != nil {
+		return &ErrAtxNotFound{Id: *id, source: err}
+	}
+	if posAtx.PublishEpoch >= pubepoch {
+		return fmt.Errorf("positioning atx epoch (%v) must be before %v", posAtx.PublishEpoch, pubepoch)
 	}
 	return nil
 }

--- a/activation/validation_test.go
+++ b/activation/validation_test.go
@@ -100,13 +100,13 @@ func Test_Validation_InitialNIPostChallenge(t *testing.T) {
 			Indices: make([]byte, 10),
 		}
 
-		challenge := newChallenge(0, types.EmptyATXID, posAtxId, types.LayerID(1012), &commitmentAtxId)
+		challenge := newChallenge(0, types.EmptyATXID, posAtxId, 2, &commitmentAtxId)
 		challenge.InitialPostIndices = initialPost.Indices
 
 		atxProvider := NewMockatxProvider(ctrl)
 		atxProvider.EXPECT().GetAtxHeader(commitmentAtxId).Return(&types.ActivationTxHeader{
 			NIPostChallenge: types.NIPostChallenge{
-				PubLayerID: types.LayerID(888),
+				PublishEpoch: 1,
 			},
 		}, nil)
 
@@ -123,7 +123,7 @@ func Test_Validation_InitialNIPostChallenge(t *testing.T) {
 			Indices: make([]byte, 10),
 		}
 
-		challenge := newChallenge(0, types.EmptyATXID, posAtxId, types.LayerID(2), &goldenATXID)
+		challenge := newChallenge(0, types.EmptyATXID, posAtxId, types.LayerID(2).GetEpoch(), &goldenATXID)
 		challenge.InitialPostIndices = initialPost.Indices
 
 		atxProvider := NewMockatxProvider(ctrl)
@@ -146,7 +146,7 @@ func Test_Validation_InitialNIPostChallenge(t *testing.T) {
 		t.Parallel()
 		posAtxId := types.ATXID{1, 2, 3}
 
-		challenge := newChallenge(0, types.EmptyATXID, posAtxId, types.LayerID(2), &goldenATXID)
+		challenge := newChallenge(0, types.EmptyATXID, posAtxId, types.LayerID(2).GetEpoch(), &goldenATXID)
 
 		err := v.InitialNIPostChallenge(&challenge, nil, goldenATXID, nil)
 		require.EqualError(t, err, "no prevATX declared, but initial Post indices is not included in challenge")
@@ -161,7 +161,7 @@ func Test_Validation_InitialNIPostChallenge(t *testing.T) {
 			Indices: make([]byte, 10),
 		}
 
-		challenge := newChallenge(0, types.EmptyATXID, posAtxId, types.LayerID(2), &goldenATXID)
+		challenge := newChallenge(0, types.EmptyATXID, posAtxId, types.LayerID(2).GetEpoch(), &goldenATXID)
 		challenge.InitialPostIndices = make([]byte, 10)
 		challenge.InitialPostIndices[0] = 1
 
@@ -178,7 +178,7 @@ func Test_Validation_InitialNIPostChallenge(t *testing.T) {
 			Indices: make([]byte, 10),
 		}
 
-		challenge := newChallenge(0, types.EmptyATXID, posAtxId, types.LayerID(2), nil)
+		challenge := newChallenge(0, types.EmptyATXID, posAtxId, types.LayerID(2).GetEpoch(), nil)
 		challenge.InitialPostIndices = initialPost.Indices
 
 		err := v.InitialNIPostChallenge(&challenge, nil, goldenATXID, initialPost.Indices)
@@ -195,18 +195,18 @@ func Test_Validation_InitialNIPostChallenge(t *testing.T) {
 			Indices: make([]byte, 10),
 		}
 
-		challenge := newChallenge(0, types.EmptyATXID, posAtxId, types.LayerID(1012), &commitmentAtxId)
+		challenge := newChallenge(0, types.EmptyATXID, posAtxId, 1, &commitmentAtxId)
 		challenge.InitialPostIndices = initialPost.Indices
 
 		atxProvider := NewMockatxProvider(ctrl)
 		atxProvider.EXPECT().GetAtxHeader(commitmentAtxId).Return(&types.ActivationTxHeader{
 			NIPostChallenge: types.NIPostChallenge{
-				PubLayerID: types.LayerID(1200),
+				PublishEpoch: 2,
 			},
 		}, nil)
 
 		err := v.InitialNIPostChallenge(&challenge, atxProvider, goldenATXID, initialPost.Indices)
-		require.EqualError(t, err, "challenge publayer (1012) must be after commitment atx publayer (1200)")
+		require.EqualError(t, err, "challenge pubepoch (1) must be after commitment atx pubepoch (2)")
 	})
 }
 
@@ -231,13 +231,13 @@ func Test_Validation_NIPostChallenge(t *testing.T) {
 		prevAtxId := types.ATXID{3, 2, 1}
 		posAtxId := types.ATXID{1, 2, 3}
 
-		challenge := newChallenge(10, prevAtxId, posAtxId, types.LayerID(1012), nil)
+		challenge := newChallenge(10, prevAtxId, posAtxId, 2, nil)
 
 		atxProvider := NewMockatxProvider(ctrl)
 		atxProvider.EXPECT().GetAtxHeader(prevAtxId).Return(&types.ActivationTxHeader{
 			NIPostChallenge: types.NIPostChallenge{
-				PubLayerID: types.LayerID(888),
-				Sequence:   9,
+				PublishEpoch: 1,
+				Sequence:     9,
 			},
 			NodeID: nodeId,
 		}, nil)
@@ -254,7 +254,7 @@ func Test_Validation_NIPostChallenge(t *testing.T) {
 		prevAtxId := types.ATXID{3, 2, 1}
 		posAtxId := types.ATXID{1, 2, 3}
 
-		challenge := newChallenge(10, prevAtxId, posAtxId, types.LayerID(1012), nil)
+		challenge := newChallenge(10, prevAtxId, posAtxId, types.LayerID(1012).GetEpoch(), nil)
 
 		atxProvider := NewMockatxProvider(ctrl)
 		atxProvider.EXPECT().GetAtxHeader(prevAtxId).Return(nil, errors.New("not found"))
@@ -273,13 +273,13 @@ func Test_Validation_NIPostChallenge(t *testing.T) {
 		prevAtxId := types.ATXID{3, 2, 1}
 		posAtxId := types.ATXID{1, 2, 3}
 
-		challenge := newChallenge(10, prevAtxId, posAtxId, types.LayerID(1012), nil)
+		challenge := newChallenge(10, prevAtxId, posAtxId, types.LayerID(1012).GetEpoch(), nil)
 
 		atxProvider := NewMockatxProvider(ctrl)
 		atxProvider.EXPECT().GetAtxHeader(prevAtxId).Return(&types.ActivationTxHeader{
 			NIPostChallenge: types.NIPostChallenge{
-				PubLayerID: types.LayerID(888),
-				Sequence:   9,
+				PublishEpoch: types.EpochID(888),
+				Sequence:     9,
 			},
 			NodeID: otherNodeId,
 		}, nil)
@@ -288,7 +288,7 @@ func Test_Validation_NIPostChallenge(t *testing.T) {
 		require.ErrorContains(t, err, "previous atx belongs to different miner")
 	})
 
-	t.Run("prev atx from wrong publication layer", func(t *testing.T) {
+	t.Run("prev atx from wrong publication epoch", func(t *testing.T) {
 		t.Parallel()
 
 		nodeId := types.RandomNodeID()
@@ -296,19 +296,19 @@ func Test_Validation_NIPostChallenge(t *testing.T) {
 		prevAtxId := types.ATXID{3, 2, 1}
 		posAtxId := types.ATXID{1, 2, 3}
 
-		challenge := newChallenge(10, prevAtxId, posAtxId, types.LayerID(1012), nil)
+		challenge := newChallenge(10, prevAtxId, posAtxId, 2, nil)
 
 		atxProvider := NewMockatxProvider(ctrl)
 		atxProvider.EXPECT().GetAtxHeader(prevAtxId).Return(&types.ActivationTxHeader{
 			NIPostChallenge: types.NIPostChallenge{
-				PubLayerID: types.LayerID(1200),
-				Sequence:   9,
+				PublishEpoch: 3,
+				Sequence:     9,
 			},
 			NodeID: nodeId,
 		}, nil)
 
 		err := v.NIPostChallenge(&challenge, atxProvider, nodeId)
-		require.EqualError(t, err, "prevAtx epoch (1, layer 1200) isn't older than current atx epoch (1, layer 1012)")
+		require.EqualError(t, err, "prevAtx epoch (3) isn't older than current atx epoch (2)")
 	})
 
 	t.Run("prev atx sequence not lower than current", func(t *testing.T) {
@@ -319,13 +319,13 @@ func Test_Validation_NIPostChallenge(t *testing.T) {
 		prevAtxId := types.ATXID{3, 2, 1}
 		posAtxId := types.ATXID{1, 2, 3}
 
-		challenge := newChallenge(10, prevAtxId, posAtxId, types.LayerID(1012), nil)
+		challenge := newChallenge(10, prevAtxId, posAtxId, 2, nil)
 
 		atxProvider := NewMockatxProvider(ctrl)
 		atxProvider.EXPECT().GetAtxHeader(prevAtxId).Return(&types.ActivationTxHeader{
 			NIPostChallenge: types.NIPostChallenge{
-				PubLayerID: types.LayerID(888),
-				Sequence:   10,
+				PublishEpoch: 1,
+				Sequence:     10,
 			},
 			NodeID: nodeId,
 		}, nil)
@@ -342,14 +342,14 @@ func Test_Validation_NIPostChallenge(t *testing.T) {
 		prevAtxId := types.ATXID{3, 2, 1}
 		posAtxId := types.ATXID{1, 2, 3}
 
-		challenge := newChallenge(10, prevAtxId, posAtxId, types.LayerID(1012), nil)
+		challenge := newChallenge(10, prevAtxId, posAtxId, 2, nil)
 		challenge.InitialPostIndices = make([]byte, 10)
 
 		atxProvider := NewMockatxProvider(ctrl)
 		atxProvider.EXPECT().GetAtxHeader(prevAtxId).Return(&types.ActivationTxHeader{
 			NIPostChallenge: types.NIPostChallenge{
-				PubLayerID: types.LayerID(888),
-				Sequence:   9,
+				PublishEpoch: 1,
+				Sequence:     9,
 			},
 			NodeID: nodeId,
 		}, nil)
@@ -366,14 +366,14 @@ func Test_Validation_NIPostChallenge(t *testing.T) {
 		prevAtxId := types.ATXID{3, 2, 1}
 		posAtxId := types.ATXID{1, 2, 3}
 
-		challenge := newChallenge(10, prevAtxId, posAtxId, types.LayerID(1012), nil)
+		challenge := newChallenge(10, prevAtxId, posAtxId, 2, nil)
 		challenge.CommitmentATX = &types.ATXID{9, 9, 9}
 
 		atxProvider := NewMockatxProvider(ctrl)
 		atxProvider.EXPECT().GetAtxHeader(prevAtxId).Return(&types.ActivationTxHeader{
 			NIPostChallenge: types.NIPostChallenge{
-				PubLayerID: types.LayerID(888),
-				Sequence:   9,
+				PublishEpoch: 1,
+				Sequence:     9,
 			},
 			NodeID: nodeId,
 		}, nil)
@@ -405,12 +405,12 @@ func Test_Validation_PositioningAtx(t *testing.T) {
 		atxProvider := NewMockatxProvider(ctrl)
 		atxProvider.EXPECT().GetAtxHeader(posAtxId).Return(&types.ActivationTxHeader{
 			NIPostChallenge: types.NIPostChallenge{
-				PubLayerID: types.LayerID(888),
-				Sequence:   9,
+				PublishEpoch: 1,
+				Sequence:     9,
 			},
 		}, nil)
 
-		err := v.PositioningAtx(&posAtxId, atxProvider, goldenAtxId, types.LayerID(1012), layersPerEpochBig)
+		err := v.PositioningAtx(&posAtxId, atxProvider, goldenAtxId, 2, layersPerEpochBig)
 		require.NoError(t, err)
 	})
 
@@ -421,19 +421,19 @@ func Test_Validation_PositioningAtx(t *testing.T) {
 
 		atxProvider := NewMockatxProvider(ctrl)
 
-		err := v.PositioningAtx(&goldenAtxId, atxProvider, goldenAtxId, types.LayerID(1012), layersPerEpochBig)
+		err := v.PositioningAtx(&goldenAtxId, atxProvider, goldenAtxId, types.LayerID(1012).GetEpoch(), layersPerEpochBig)
 		require.NoError(t, err)
 	})
 
-	t.Run("golden ATX is not allowed as positioning atx in non-genesis epoch", func(t *testing.T) {
+	t.Run("golden ATX is allowed as positioning atx in non-genesis epoch", func(t *testing.T) {
 		t.Parallel()
 
 		goldenAtxId := types.ATXID{9, 9, 9}
 
 		atxProvider := NewMockatxProvider(ctrl)
 
-		err := v.PositioningAtx(&goldenAtxId, atxProvider, goldenAtxId, types.LayerID(2012), layersPerEpochBig)
-		require.EqualError(t, err, "golden atx used for positioning atx in epoch 2, but is only valid in epoch 1")
+		err := v.PositioningAtx(&goldenAtxId, atxProvider, goldenAtxId, 5, layersPerEpochBig)
+		require.NoError(t, err)
 	})
 
 	t.Run("fail at empty positioning atx", func(t *testing.T) {
@@ -443,7 +443,7 @@ func Test_Validation_PositioningAtx(t *testing.T) {
 
 		atxProvider := NewMockatxProvider(ctrl)
 
-		err := v.PositioningAtx(&types.EmptyATXID, atxProvider, goldenAtxId, types.LayerID(1012), layersPerEpochBig)
+		err := v.PositioningAtx(&types.EmptyATXID, atxProvider, goldenAtxId, types.LayerID(1012).GetEpoch(), layersPerEpochBig)
 		require.EqualError(t, err, "empty positioning atx")
 	})
 
@@ -456,12 +456,12 @@ func Test_Validation_PositioningAtx(t *testing.T) {
 		atxProvider := NewMockatxProvider(ctrl)
 		atxProvider.EXPECT().GetAtxHeader(posAtxId).Return(nil, errors.New("db error"))
 
-		err := v.PositioningAtx(&posAtxId, atxProvider, goldenAtxId, types.LayerID(1012), layersPerEpochBig)
+		err := v.PositioningAtx(&posAtxId, atxProvider, goldenAtxId, types.LayerID(1012).GetEpoch(), layersPerEpochBig)
 		require.ErrorIs(t, err, &ErrAtxNotFound{Id: posAtxId})
 		require.ErrorContains(t, err, "db error")
 	})
 
-	t.Run("positioning atx published in higher layer than expected", func(t *testing.T) {
+	t.Run("positioning atx published in higher epoch than expected", func(t *testing.T) {
 		t.Parallel()
 
 		posAtxId := types.ATXID{1, 2, 3}
@@ -470,16 +470,16 @@ func Test_Validation_PositioningAtx(t *testing.T) {
 		atxProvider := NewMockatxProvider(ctrl)
 		atxProvider.EXPECT().GetAtxHeader(posAtxId).Return(&types.ActivationTxHeader{
 			NIPostChallenge: types.NIPostChallenge{
-				PubLayerID: types.LayerID(2000),
-				Sequence:   9,
+				PublishEpoch: 5,
+				Sequence:     9,
 			},
 		}, nil)
 
-		err := v.PositioningAtx(&posAtxId, atxProvider, goldenAtxId, types.LayerID(1012), layersPerEpochBig)
-		require.EqualError(t, err, "positioning atx layer (2000) must be before 1012")
+		err := v.PositioningAtx(&posAtxId, atxProvider, goldenAtxId, 3, layersPerEpochBig)
+		require.EqualError(t, err, "positioning atx epoch (5) must be before 3")
 	})
 
-	t.Run("positioning atx with larger distance than expected", func(t *testing.T) {
+	t.Run("any distance to positioning atx is valid", func(t *testing.T) {
 		t.Parallel()
 
 		posAtxId := types.ATXID{1, 2, 3}
@@ -488,13 +488,13 @@ func Test_Validation_PositioningAtx(t *testing.T) {
 		atxProvider := NewMockatxProvider(ctrl)
 		atxProvider.EXPECT().GetAtxHeader(posAtxId).Return(&types.ActivationTxHeader{
 			NIPostChallenge: types.NIPostChallenge{
-				PubLayerID: types.LayerID(888),
-				Sequence:   9,
+				PublishEpoch: 1,
+				Sequence:     9,
 			},
 		}, nil)
 
-		err := v.PositioningAtx(&posAtxId, atxProvider, goldenAtxId, types.LayerID(2000), layersPerEpochBig)
-		require.EqualError(t, err, "expected distance of one epoch (1000 layers) from positioning atx but found 1112")
+		err := v.PositioningAtx(&posAtxId, atxProvider, goldenAtxId, 10, layersPerEpochBig)
+		require.NoError(t, err)
 	})
 }
 
@@ -573,7 +573,7 @@ func TestValidator_Validate(t *testing.T) {
 	r := require.New(t)
 
 	challenge := types.NIPostChallenge{
-		PubLayerID: (postGenesisEpoch + 2).FirstLayer(),
+		PublishEpoch: postGenesisEpoch + 2,
 	}
 	challengeHash := challenge.Hash()
 	poetDb := NewMockpoetDbAPI(gomock.NewController(t))

--- a/api/grpcserver/activation_service_test.go
+++ b/api/grpcserver/activation_service_test.go
@@ -65,7 +65,7 @@ func TestGet_HappyPath(t *testing.T) {
 				NIPostChallenge: types.NIPostChallenge{
 					Sequence:           rand.Uint64(),
 					PrevATXID:          types.RandomATXID(),
-					PubLayerID:         0,
+					PublishEpoch:       0,
 					PositioningATX:     types.RandomATXID(),
 					InitialPostIndices: types.RandomBytes(7),
 				},
@@ -81,7 +81,7 @@ func TestGet_HappyPath(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, atx.ID().Bytes(), response.Atx.Id.Id)
-	require.Equal(t, atx.PubLayerID.Uint32(), response.Atx.Layer.Number)
+	require.Equal(t, atx.PublishEpoch.Uint32(), response.Atx.Layer.Number)
 	require.Equal(t, atx.SmesherID.Bytes(), response.Atx.SmesherId.Id)
 	require.Equal(t, atx.Coinbase.String(), response.Atx.Coinbase.Address)
 	require.Equal(t, atx.PrevATXID.Bytes(), response.Atx.PrevAtx.Id)

--- a/api/grpcserver/grpcserver_test.go
+++ b/api/grpcserver/grpcserver_test.go
@@ -71,13 +71,13 @@ const (
 )
 
 var (
-	txReturnLayer         = types.LayerID(1)
-	layerFirst            = types.LayerID(0)
-	layerVerified         = types.LayerID(8)
-	layerLatest           = types.LayerID(10)
-	layerCurrent          = types.LayerID(12)
-	postGenesisEpochLayer = types.LayerID(22)
-	genesisID             = types.Hash20{}
+	txReturnLayer    = types.LayerID(1)
+	layerFirst       = types.LayerID(0)
+	layerVerified    = types.LayerID(8)
+	layerLatest      = types.LayerID(10)
+	layerCurrent     = types.LayerID(12)
+	postGenesisEpoch = types.EpochID(2)
+	genesisID        = types.Hash20{}
 
 	networkMock = NetworkMock{}
 	genTime     = GenesisTimeMock{time.Unix(genTimeUnix, 0)}
@@ -87,7 +87,7 @@ var (
 	chlng       = types.HexToHash32("55555")
 	poetRef     = []byte("66666")
 	nipost      = newNIPostWithChallenge(&chlng, poetRef)
-	challenge   = newChallenge(1, prevAtxID, prevAtxID, postGenesisEpochLayer)
+	challenge   = newChallenge(1, prevAtxID, prevAtxID, postGenesisEpoch)
 	globalAtx   *types.VerifiedActivationTx
 	globalAtx2  *types.VerifiedActivationTx
 	signer      *signing.EdSigner
@@ -421,11 +421,11 @@ func NewTx(nonce uint64, recipient types.Address, signer *signing.EdSigner) *typ
 	return &tx
 }
 
-func newChallenge(sequence uint64, prevAtxID, posAtxID types.ATXID, lid types.LayerID) types.NIPostChallenge {
+func newChallenge(sequence uint64, prevAtxID, posAtxID types.ATXID, epoch types.EpochID) types.NIPostChallenge {
 	return types.NIPostChallenge{
 		Sequence:       sequence,
 		PrevATXID:      prevAtxID,
-		PublishEpoch:   lid.GetEpoch(),
+		PublishEpoch:   epoch,
 		PositioningATX: posAtxID,
 	}
 }

--- a/api/grpcserver/grpcserver_test.go
+++ b/api/grpcserver/grpcserver_test.go
@@ -421,11 +421,11 @@ func NewTx(nonce uint64, recipient types.Address, signer *signing.EdSigner) *typ
 	return &tx
 }
 
-func newChallenge(sequence uint64, prevAtxID, posAtxID types.ATXID, pubLayerID types.LayerID) types.NIPostChallenge {
+func newChallenge(sequence uint64, prevAtxID, posAtxID types.ATXID, lid types.LayerID) types.NIPostChallenge {
 	return types.NIPostChallenge{
 		Sequence:       sequence,
 		PrevATXID:      prevAtxID,
-		PubLayerID:     pubLayerID,
+		PublishEpoch:   lid.GetEpoch(),
 		PositioningATX: posAtxID,
 	}
 }
@@ -2047,7 +2047,7 @@ func checkLayer(t *testing.T, l *pb.Layer) {
 	require.Condition(t, func() bool {
 		for _, a := range l.Activations {
 			// Compare the two element by element
-			if a.Layer.Number != globalAtx.PubLayerID.Uint32() {
+			if a.Layer.Number != globalAtx.PublishEpoch.Uint32() {
 				continue
 			}
 			if !bytes.Equal(a.Id.Id, globalAtx.ID().Bytes()) {
@@ -2345,7 +2345,7 @@ func checkAccountMeshDataItemActivation(t *testing.T, dataItem any) {
 	require.IsType(t, &pb.AccountMeshData_Activation{}, dataItem)
 	x := dataItem.(*pb.AccountMeshData_Activation)
 	require.Equal(t, globalAtx.ID().Bytes(), x.Activation.Id.Id)
-	require.Equal(t, globalAtx.PubLayerID.Uint32(), x.Activation.Layer.Number)
+	require.Equal(t, globalAtx.PublishEpoch.Uint32(), x.Activation.Layer.Number)
 	require.Equal(t, globalAtx.SmesherID.Bytes(), x.Activation.SmesherId.Id)
 	require.Equal(t, globalAtx.Coinbase.String(), x.Activation.Coinbase.Address)
 	require.Equal(t, globalAtx.PrevATXID.Bytes(), x.Activation.PrevAtx.Id)

--- a/api/grpcserver/mesh_service.go
+++ b/api/grpcserver/mesh_service.go
@@ -277,7 +277,7 @@ func convertTransaction(t *types.Transaction) *pb.Transaction {
 func convertActivation(a *types.VerifiedActivationTx) *pb.Activation {
 	return &pb.Activation{
 		Id:        &pb.ActivationId{Id: a.ID().Bytes()},
-		Layer:     &pb.LayerNumber{Number: a.PubLayerID.Uint32()},
+		Layer:     &pb.LayerNumber{Number: a.PublishEpoch.Uint32()},
 		SmesherId: &pb.SmesherId{Id: a.SmesherID.Bytes()},
 		Coinbase:  &pb.AccountId{Address: a.Coinbase.String()},
 		PrevAtx:   &pb.ActivationId{Id: a.PrevATXID.Bytes()},

--- a/beacon/beacon_test.go
+++ b/beacon/beacon_test.go
@@ -116,7 +116,7 @@ func newTestDriver(tb testing.TB, cfg Config, p pubsub.Publisher) *testProtocolD
 func createATX(tb testing.TB, db *datastore.CachedDB, lid types.LayerID, sig *signing.EdSigner, numUnits uint32, received time.Time) types.ATXID {
 	nonce := types.VRFPostIndex(1)
 	atx := types.NewActivationTx(
-		types.NIPostChallenge{PubLayerID: lid},
+		types.NIPostChallenge{PublishEpoch: lid.GetEpoch()},
 		types.Address{},
 		nil,
 		numUnits,

--- a/blocks/generator_test.go
+++ b/blocks/generator_test.go
@@ -128,7 +128,7 @@ func createModifiedATXs(tb testing.TB, cdb *datastore.CachedDB, lid types.LayerI
 		signers = append(signers, signer)
 		address := types.GenerateAddress(signer.PublicKey().Bytes())
 		atx := types.NewActivationTx(
-			types.NIPostChallenge{PubLayerID: lid},
+			types.NIPostChallenge{PublishEpoch: lid.GetEpoch()},
 			address,
 			nil,
 			numUnit,

--- a/common/types/activation.go
+++ b/common/types/activation.go
@@ -64,7 +64,7 @@ var EmptyATXID = ATXID{}
 // the intended publication layer ID, the PoET's start and end ticks, the positioning ATX's ID and for
 // the first ATX in the sequence also the commitment Merkle root.
 type NIPostChallenge struct {
-	PubLayerID LayerID
+	PublishEpoch EpochID
 	// Sequence number counts the number of ancestors of the ATX. It sequentially increases for each ATX in the chain.
 	// Two ATXs with the same sequence number from the same miner can be used as the proof of malfeasance against that miner.
 	Sequence       uint64
@@ -80,10 +80,10 @@ func (c *NIPostChallenge) MarshalLogObject(encoder log.ObjectEncoder) error {
 	if c == nil {
 		return nil
 	}
-	encoder.AddUint32("PubLayerID", c.PubLayerID.Uint32())
+	encoder.AddUint32("PublishEpoch", c.PublishEpoch.Uint32())
 	encoder.AddUint64("Sequence", c.Sequence)
 	encoder.AddString("PrevATXID", c.PrevATXID.String())
-	encoder.AddUint32("PubLayerID", c.PubLayerID.Uint32())
+	encoder.AddUint32("PublishEpoch", c.PublishEpoch.Uint32())
 	encoder.AddString("PositioningATX", c.PositioningATX.String())
 	if c.CommitmentATX != nil {
 		encoder.AddString("CommitmentATX", c.CommitmentATX.String())
@@ -104,10 +104,10 @@ func (challenge *NIPostChallenge) Hash() Hash32 {
 // String returns a string representation of the NIPostChallenge, for logging purposes.
 // It implements the Stringer interface.
 func (challenge *NIPostChallenge) String() string {
-	return fmt.Sprintf("<seq: %v, prevATX: %v, PubLayer: %v, posATX: %s>",
+	return fmt.Sprintf("<seq: %v, prevATX: %v, publish epoch: %v, posATX: %s>",
 		challenge.Sequence,
 		challenge.PrevATXID.ShortString(),
-		challenge.PubLayerID,
+		challenge.PublishEpoch,
 		challenge.PositioningATX.ShortString(),
 	)
 }
@@ -115,12 +115,7 @@ func (challenge *NIPostChallenge) String() string {
 // TargetEpoch returns the target epoch of the NIPostChallenge. This is the epoch in which the miner is eligible
 // to participate thanks to the ATX.
 func (challenge *NIPostChallenge) TargetEpoch() EpochID {
-	return challenge.PubLayerID.GetEpoch() + 1
-}
-
-// PublishEpoch returns the publishing epoch of the NIPostChallenge.
-func (challenge *NIPostChallenge) PublishEpoch() EpochID {
-	return challenge.PubLayerID.GetEpoch()
+	return challenge.PublishEpoch + 1
 }
 
 // InnerActivationTx is a set of all of an ATX's fields, except the signature. To generate the ATX signature, this
@@ -228,8 +223,7 @@ func (atx *ActivationTx) MarshalLogObject(encoder log.ObjectEncoder) error {
 		encoder.AddUint64("vrf_nonce", uint64(*atx.VRFNonce))
 	}
 	encoder.AddString("coinbase", atx.Coinbase.String())
-	encoder.AddUint32("pub_layer_id", atx.PubLayerID.Uint32())
-	encoder.AddUint32("epoch", uint32(atx.PublishEpoch()))
+	encoder.AddUint32("epoch", uint32(atx.PublishEpoch))
 	encoder.AddUint64("num_units", uint64(atx.NumUnits))
 	if atx.effectiveNumUnits != 0 {
 		encoder.AddUint64("effective_num_units", uint64(atx.effectiveNumUnits))

--- a/common/types/activation.go
+++ b/common/types/activation.go
@@ -223,7 +223,7 @@ func (atx *ActivationTx) MarshalLogObject(encoder log.ObjectEncoder) error {
 		encoder.AddUint64("vrf_nonce", uint64(*atx.VRFNonce))
 	}
 	encoder.AddString("coinbase", atx.Coinbase.String())
-	encoder.AddUint32("epoch", uint32(atx.PublishEpoch))
+	encoder.AddUint32("epoch", atx.PublishEpoch.Uint32())
 	encoder.AddUint64("num_units", uint64(atx.NumUnits))
 	if atx.effectiveNumUnits != 0 {
 		encoder.AddUint64("effective_num_units", uint64(atx.effectiveNumUnits))

--- a/common/types/activation_scale.go
+++ b/common/types/activation_scale.go
@@ -9,7 +9,7 @@ import (
 
 func (t *NIPostChallenge) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	{
-		n, err := scale.EncodeCompact32(enc, uint32(t.PubLayerID))
+		n, err := scale.EncodeCompact32(enc, uint32(t.PublishEpoch))
 		if err != nil {
 			return total, err
 		}
@@ -60,7 +60,7 @@ func (t *NIPostChallenge) DecodeScale(dec *scale.Decoder) (total int, err error)
 			return total, err
 		}
 		total += n
-		t.PubLayerID = LayerID(field)
+		t.PublishEpoch = EpochID(field)
 	}
 	{
 		field, n, err := scale.DecodeCompact64(dec)

--- a/common/types/activation_test.go
+++ b/common/types/activation_test.go
@@ -2,7 +2,6 @@ package types_test
 
 import (
 	"bytes"
-	"math/rand"
 	"testing"
 	"time"
 
@@ -38,7 +37,7 @@ func TestActivationEncoding(t *testing.T) {
 	_, err := object.EncodeScale(enc)
 	require.NoError(t, err)
 
-	epoch := types.EpochID(rand.Uint32())
+	var epoch types.EpochID
 	require.NoError(t, codec.Decode(buf.Bytes(), &epoch))
 	require.Equal(t, object.PublishEpoch, epoch)
 }

--- a/common/types/epoch.go
+++ b/common/types/epoch.go
@@ -11,9 +11,13 @@ import (
 // EpochID is the running epoch number. It's zero-based, so the genesis epoch has EpochID == 0.
 type EpochID uint32
 
+func (e EpochID) Uint32() uint32 {
+	return uint32(e)
+}
+
 // EncodeScale implements scale codec interface.
-func (l EpochID) EncodeScale(e *scale.Encoder) (int, error) {
-	n, err := scale.EncodeCompact32(e, uint32(l))
+func (e EpochID) EncodeScale(enc *scale.Encoder) (int, error) {
+	n, err := scale.EncodeCompact32(enc, uint32(e))
 	if err != nil {
 		return 0, err
 	}
@@ -21,39 +25,39 @@ func (l EpochID) EncodeScale(e *scale.Encoder) (int, error) {
 }
 
 // DecodeScale implements scale codec interface.
-func (l *EpochID) DecodeScale(d *scale.Decoder) (int, error) {
-	value, n, err := scale.DecodeCompact32(d)
+func (e *EpochID) DecodeScale(dec *scale.Decoder) (int, error) {
+	value, n, err := scale.DecodeCompact32(dec)
 	if err != nil {
 		return 0, err
 	}
-	*l = EpochID(value)
+	*e = EpochID(value)
 	return n, nil
 }
 
 // IsGenesis returns true if this epoch is in genesis. The first two epochs are considered genesis epochs.
-func (l EpochID) IsGenesis() bool {
-	return l < 2
+func (e EpochID) IsGenesis() bool {
+	return e < 2
 }
 
 // FirstLayer returns the layer ID of the first layer in the epoch.
-func (l EpochID) FirstLayer() LayerID {
-	return LayerID(uint32(l)).Mul(GetLayersPerEpoch())
+func (e EpochID) FirstLayer() LayerID {
+	return LayerID(uint32(e)).Mul(GetLayersPerEpoch())
 }
 
 // Add Epochs to the EpochID. Panics on wraparound.
-func (l EpochID) Add(epochs uint32) EpochID {
-	nl := uint32(l) + epochs
-	if nl < uint32(l) {
+func (e EpochID) Add(epochs uint32) EpochID {
+	nl := uint32(e) + epochs
+	if nl < uint32(e) {
 		panic("epoch_id wraparound")
 	}
-	l = EpochID(nl)
-	return l
+	e = EpochID(nl)
+	return e
 }
 
 // Field returns a log field. Implements the LoggableField interface.
-func (l EpochID) Field() log.Field { return log.Uint32("epoch_id", uint32(l)) }
+func (e EpochID) Field() log.Field { return log.Uint32("epoch_id", uint32(e)) }
 
 // String returns string representation of the epoch id numeric value.
-func (l EpochID) String() string {
-	return strconv.FormatUint(uint64(l), 10)
+func (e EpochID) String() string {
+	return strconv.FormatUint(uint64(e), 10)
 }

--- a/common/types/epoch.go
+++ b/common/types/epoch.go
@@ -17,18 +17,14 @@ func (e EpochID) Uint32() uint32 {
 
 // EncodeScale implements scale codec interface.
 func (e EpochID) EncodeScale(enc *scale.Encoder) (int, error) {
-	n, err := scale.EncodeCompact32(enc, uint32(e))
-	if err != nil {
-		return 0, err
-	}
-	return n, nil
+	return scale.EncodeCompact32(enc, e.Uint32())
 }
 
 // DecodeScale implements scale codec interface.
 func (e *EpochID) DecodeScale(dec *scale.Decoder) (int, error) {
 	value, n, err := scale.DecodeCompact32(dec)
 	if err != nil {
-		return 0, err
+		return n, err
 	}
 	*e = EpochID(value)
 	return n, nil

--- a/common/types/malfeasance_test.go
+++ b/common/types/malfeasance_test.go
@@ -20,10 +20,10 @@ func TestMain(m *testing.M) {
 }
 
 func TestCodec_MultipleATXs(t *testing.T) {
-	lid := types.LayerID(11)
+	epoch := types.EpochID(11)
 
-	a1 := types.NewActivationTx(types.NIPostChallenge{PubLayerID: lid}, types.Address{1, 2, 3}, nil, 10, nil, nil)
-	a2 := types.NewActivationTx(types.NIPostChallenge{PubLayerID: lid}, types.Address{3, 2, 1}, nil, 11, nil, nil)
+	a1 := types.NewActivationTx(types.NIPostChallenge{PublishEpoch: epoch}, types.Address{1, 2, 3}, nil, 10, nil, nil)
+	a2 := types.NewActivationTx(types.NIPostChallenge{PublishEpoch: epoch}, types.Address{3, 2, 1}, nil, 11, nil, nil)
 
 	var atxProof types.AtxProof
 	for i, a := range []*types.ActivationTx{a1, a2} {
@@ -37,7 +37,7 @@ func TestCodec_MultipleATXs(t *testing.T) {
 		}
 	}
 	proof := &types.MalfeasanceProof{
-		Layer: lid,
+		Layer: epoch.FirstLayer(),
 		Proof: types.Proof{
 			Type: types.MultipleATXs,
 			Data: &atxProof,

--- a/common/types/verified_activation.go
+++ b/common/types/verified_activation.go
@@ -48,8 +48,7 @@ func (vatx *VerifiedActivationTx) MarshalLogObject(encoder log.ObjectEncoder) er
 		encoder.AddUint64("vrf_nonce", uint64(*vatx.VRFNonce))
 	}
 	encoder.AddString("coinbase", vatx.Coinbase.String())
-	encoder.AddUint32("pub_layer_id", vatx.PublishEpoch.Uint32())
-	encoder.AddUint32("epoch", uint32(vatx.PublishEpoch))
+	encoder.AddUint32("epoch", vatx.PublishEpoch.Uint32())
 	encoder.AddUint64("num_units", uint64(vatx.NumUnits))
 	if vatx.effectiveNumUnits != 0 {
 		encoder.AddUint64("effective_num_units", uint64(vatx.effectiveNumUnits))

--- a/common/types/verified_activation.go
+++ b/common/types/verified_activation.go
@@ -48,8 +48,8 @@ func (vatx *VerifiedActivationTx) MarshalLogObject(encoder log.ObjectEncoder) er
 		encoder.AddUint64("vrf_nonce", uint64(*vatx.VRFNonce))
 	}
 	encoder.AddString("coinbase", vatx.Coinbase.String())
-	encoder.AddUint32("pub_layer_id", vatx.PubLayerID.Uint32())
-	encoder.AddUint32("epoch", uint32(vatx.PublishEpoch()))
+	encoder.AddUint32("pub_layer_id", vatx.PublishEpoch.Uint32())
+	encoder.AddUint32("epoch", uint32(vatx.PublishEpoch))
 	encoder.AddUint64("num_units", uint64(vatx.NumUnits))
 	if vatx.effectiveNumUnits != 0 {
 		encoder.AddUint64("effective_num_units", uint64(vatx.effectiveNumUnits))

--- a/datastore/store_test.go
+++ b/datastore/store_test.go
@@ -159,8 +159,8 @@ func TestIdentityExists(t *testing.T) {
 	atx := &types.ActivationTx{
 		InnerActivationTx: types.InnerActivationTx{
 			NIPostChallenge: types.NIPostChallenge{
-				PubLayerID: types.LayerID(22),
-				Sequence:   11,
+				PublishEpoch: types.EpochID(22),
+				Sequence:     11,
 			},
 			NumUnits: 11,
 		},
@@ -183,8 +183,8 @@ func TestStore_GetAtxByNodeID(t *testing.T) {
 	atx3 := &types.ActivationTx{
 		InnerActivationTx: types.InnerActivationTx{
 			NIPostChallenge: types.NIPostChallenge{
-				PubLayerID: types.EpochID(3).FirstLayer(),
-				Sequence:   11,
+				PublishEpoch: types.EpochID(3),
+				Sequence:     11,
 			},
 			NumUnits: 11,
 		},
@@ -192,8 +192,8 @@ func TestStore_GetAtxByNodeID(t *testing.T) {
 	atx4 := &types.ActivationTx{
 		InnerActivationTx: types.InnerActivationTx{
 			NIPostChallenge: types.NIPostChallenge{
-				PubLayerID: types.EpochID(4).FirstLayer(),
-				Sequence:   12,
+				PublishEpoch: types.EpochID(4),
+				Sequence:     12,
 			},
 			NumUnits: 11,
 		},
@@ -225,8 +225,8 @@ func TestBlobStore_GetATXBlob(t *testing.T) {
 	atx := &types.ActivationTx{
 		InnerActivationTx: types.InnerActivationTx{
 			NIPostChallenge: types.NIPostChallenge{
-				PubLayerID: types.LayerID(22),
-				Sequence:   11,
+				PublishEpoch: types.EpochID(22),
+				Sequence:     11,
 			},
 			NumUnits: 11,
 		},

--- a/events/reporter.go
+++ b/events/reporter.go
@@ -83,7 +83,7 @@ func ReportNewActivation(activation *types.VerifiedActivationTx) {
 	if reporter != nil {
 		if err := reporter.activationEmitter.Emit(activationTxEvent); err != nil {
 			// TODO(nkryuchkov): consider returning an error and log outside the function
-			log.With().Error("Failed to emit activation", activation.ID(), activation.PubLayerID, log.Err(err))
+			log.With().Error("Failed to emit activation", activation.ID(), activation.PublishEpoch, log.Err(err))
 		}
 	}
 }

--- a/fetch/handler_test.go
+++ b/fetch/handler_test.go
@@ -242,8 +242,8 @@ func newAtx(t *testing.T, published types.EpochID) *types.VerifiedActivationTx {
 	atx := &types.ActivationTx{
 		InnerActivationTx: types.InnerActivationTx{
 			NIPostChallenge: types.NIPostChallenge{
-				PubLayerID: published.FirstLayer(),
-				PrevATXID:  types.RandomATXID(),
+				PublishEpoch: published,
+				PrevATXID:    types.RandomATXID(),
 			},
 			NumUnits: 2,
 		},

--- a/hare/eligibility/oracle_test.go
+++ b/hare/eligibility/oracle_test.go
@@ -92,7 +92,7 @@ func createActiveSet(tb testing.TB, cdb *datastore.CachedDB, lid types.LayerID, 
 	for i, id := range activeSet {
 		atx := &types.ActivationTx{InnerActivationTx: types.InnerActivationTx{
 			NIPostChallenge: types.NIPostChallenge{
-				PubLayerID: lid,
+				PublishEpoch: lid.GetEpoch(),
 			},
 			NumUnits: uint32(i + 1),
 		}}
@@ -418,7 +418,7 @@ func Test_VrfSignVerify(t *testing.T) {
 
 	atx1 := &types.ActivationTx{InnerActivationTx: types.InnerActivationTx{
 		NIPostChallenge: types.NIPostChallenge{
-			PubLayerID: prevEpoch.FirstLayer(),
+			PublishEpoch: prevEpoch,
 		},
 		NumUnits: 1 * 1024,
 	}}
@@ -435,7 +435,7 @@ func Test_VrfSignVerify(t *testing.T) {
 
 	atx2 := &types.ActivationTx{InnerActivationTx: types.InnerActivationTx{
 		NIPostChallenge: types.NIPostChallenge{
-			PubLayerID: prevEpoch.FirstLayer(),
+			PublishEpoch: prevEpoch,
 		},
 		NumUnits: 9 * 1024,
 	}}
@@ -525,7 +525,7 @@ func TestOracle_IsIdentityActive(t *testing.T) {
 	require.NoError(t, err)
 	atx1 := &types.ActivationTx{InnerActivationTx: types.InnerActivationTx{
 		NIPostChallenge: types.NIPostChallenge{
-			PubLayerID: prevEpoch.FirstLayer(),
+			PublishEpoch: prevEpoch,
 		},
 		NumUnits: 1 * 1024,
 	}}
@@ -541,7 +541,7 @@ func TestOracle_IsIdentityActive(t *testing.T) {
 	require.NoError(t, err)
 	atx2 := &types.ActivationTx{InnerActivationTx: types.InnerActivationTx{
 		NIPostChallenge: types.NIPostChallenge{
-			PubLayerID: prevEpoch.FirstLayer(),
+			PublishEpoch: prevEpoch,
 		},
 		NumUnits: 9 * 1024,
 	}}
@@ -808,7 +808,7 @@ func TestActives_TortoiseActiveSet(t *testing.T) {
 	for i, id := range activeSet {
 		atx := &types.ActivationTx{InnerActivationTx: types.InnerActivationTx{
 			NIPostChallenge: types.NIPostChallenge{
-				PubLayerID: prevEpoch.FirstLayer(),
+				PublishEpoch: prevEpoch,
 			},
 			NumUnits: uint32(i + 1),
 		}}
@@ -829,7 +829,7 @@ func TestActives_TortoiseActiveSet(t *testing.T) {
 	for i, id := range activeSet {
 		atx := &types.ActivationTx{InnerActivationTx: types.InnerActivationTx{
 			NIPostChallenge: types.NIPostChallenge{
-				PubLayerID: prevEpoch.FirstLayer(),
+				PublishEpoch: prevEpoch,
 			},
 			NumUnits: uint32(numMiners + i + 1),
 		}}

--- a/malfeasance/handler_test.go
+++ b/malfeasance/handler_test.go
@@ -32,7 +32,7 @@ func TestMain(m *testing.M) {
 
 func createIdentity(t *testing.T, db *sql.Database, sig *signing.EdSigner) {
 	challenge := types.NIPostChallenge{
-		PubLayerID: types.LayerID(1),
+		PublishEpoch: types.EpochID(1),
 	}
 	atx := types.NewActivationTx(challenge, types.Address{}, nil, 1, nil, nil)
 	require.NoError(t, activation.SignAndFinalizeAtx(sig, atx))

--- a/mesh/executor_test.go
+++ b/mesh/executor_test.go
@@ -68,7 +68,7 @@ func createATX(t testing.TB, db sql.Executor, cb types.Address) types.ATXID {
 	require.NoError(t, err)
 	nonce := types.VRFPostIndex(1)
 	atx := types.NewActivationTx(
-		types.NIPostChallenge{PubLayerID: types.LayerID(11)},
+		types.NIPostChallenge{PublishEpoch: types.EpochID(11)},
 		cb,
 		nil,
 		11,

--- a/miner/oracle_test.go
+++ b/miner/oracle_test.go
@@ -48,7 +48,7 @@ func generateNodeIDAndSigner(tb testing.TB) (types.NodeID, *signing.EdSigner, *s
 func genMinerATX(tb testing.TB, cdb *datastore.CachedDB, id types.ATXID, publishLayer types.LayerID, signer *signing.EdSigner) *types.VerifiedActivationTx {
 	atx := &types.ActivationTx{InnerActivationTx: types.InnerActivationTx{
 		NIPostChallenge: types.NIPostChallenge{
-			PubLayerID: publishLayer,
+			PublishEpoch: publishLayer.GetEpoch(),
 		},
 		NumUnits: defaultAtxWeight,
 	}}

--- a/proposals/eligibility_validator_test.go
+++ b/proposals/eligibility_validator_test.go
@@ -41,7 +41,7 @@ func genActiveSetAndSave(t *testing.T, cdb *datastore.CachedDB, signer *signing.
 	nonce := types.VRFPostIndex(1)
 	atx := &types.ActivationTx{InnerActivationTx: types.InnerActivationTx{
 		NIPostChallenge: types.NIPostChallenge{
-			PubLayerID: epoch.FirstLayer().Sub(layersPerEpoch),
+			PublishEpoch: epoch - 1,
 		},
 		NumUnits: testedATXUnit,
 		VRFNonce: &nonce,
@@ -57,7 +57,7 @@ func genActiveSetAndSave(t *testing.T, cdb *datastore.CachedDB, signer *signing.
 	for _, id := range activeset[1:] {
 		atx := &types.ActivationTx{InnerActivationTx: types.InnerActivationTx{
 			NIPostChallenge: types.NIPostChallenge{
-				PubLayerID: epoch.FirstLayer().Sub(layersPerEpoch),
+				PublishEpoch: epoch - 1,
 			},
 			NumUnits: defaultATXUnit,
 		}}
@@ -253,7 +253,7 @@ func TestCheckEligibility_TargetEpochMismatch(t *testing.T) {
 
 	atx := &types.ActivationTx{InnerActivationTx: types.InnerActivationTx{
 		NIPostChallenge: types.NIPostChallenge{
-			PubLayerID: epoch.FirstLayer(),
+			PublishEpoch: epoch,
 		},
 		NumUnits: testedATXUnit,
 	}}
@@ -267,7 +267,7 @@ func TestCheckEligibility_TargetEpochMismatch(t *testing.T) {
 	for _, id := range rb.ActiveSet[1:] {
 		atx := &types.ActivationTx{InnerActivationTx: types.InnerActivationTx{
 			NIPostChallenge: types.NIPostChallenge{
-				PubLayerID: epoch.FirstLayer().Sub(layersPerEpoch),
+				PublishEpoch: epoch - 1,
 			},
 			NumUnits: defaultATXUnit,
 		}}

--- a/proposals/util_test.go
+++ b/proposals/util_test.go
@@ -33,7 +33,7 @@ func TestComputeWeightPerEligibility(t *testing.T) {
 	for _, id := range rb.ActiveSet {
 		atx := &types.ActivationTx{InnerActivationTx: types.InnerActivationTx{
 			NIPostChallenge: types.NIPostChallenge{
-				PubLayerID: epoch.FirstLayer().Sub(layersPerEpoch),
+				PublishEpoch: epoch - 1,
 			},
 			NumUnits: defaultATXUnit,
 		}}

--- a/sql/atxs/atxs.go
+++ b/sql/atxs/atxs.go
@@ -243,22 +243,21 @@ func Add(db sql.Executor, atx *types.VerifiedActivationTx) error {
 
 	enc := func(stmt *sql.Statement) {
 		stmt.BindBytes(1, atx.ID().Bytes())
-		stmt.BindInt64(2, int64(atx.PubLayerID.Uint32()))
-		stmt.BindInt64(3, int64(atx.PublishEpoch()))
-		stmt.BindInt64(4, int64(atx.EffectiveNumUnits()))
+		stmt.BindInt64(2, int64(atx.PublishEpoch))
+		stmt.BindInt64(3, int64(atx.EffectiveNumUnits()))
 		if atx.VRFNonce != nil {
-			stmt.BindInt64(5, int64(*atx.VRFNonce))
+			stmt.BindInt64(4, int64(*atx.VRFNonce))
 		}
-		stmt.BindBytes(6, atx.SmesherID.Bytes())
-		stmt.BindBytes(7, buf)
-		stmt.BindInt64(8, atx.Received().UnixNano())
-		stmt.BindInt64(9, int64(atx.BaseTickHeight()))
-		stmt.BindInt64(10, int64(atx.TickCount()))
+		stmt.BindBytes(5, atx.SmesherID.Bytes())
+		stmt.BindBytes(6, buf)
+		stmt.BindInt64(7, atx.Received().UnixNano())
+		stmt.BindInt64(8, int64(atx.BaseTickHeight()))
+		stmt.BindInt64(9, int64(atx.TickCount()))
 	}
 
 	_, err = db.Exec(`
-		insert into atxs (id, layer, epoch, effective_num_units, nonce, smesher, atx, received, base_tick_height, tick_count) 
-		values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10);`, enc, nil)
+		insert into atxs (id, epoch, effective_num_units, nonce, smesher, atx, received, base_tick_height, tick_count) 
+		values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9);`, enc, nil)
 	if err != nil {
 		return fmt.Errorf("insert ATX ID %v: %w", atx.ID(), err)
 	}

--- a/sql/atxs/atxs_test.go
+++ b/sql/atxs/atxs_test.go
@@ -382,8 +382,8 @@ func newAtx(signer *signing.EdSigner, layerID types.LayerID) (*types.VerifiedAct
 	atx := &types.ActivationTx{
 		InnerActivationTx: types.InnerActivationTx{
 			NIPostChallenge: types.NIPostChallenge{
-				PubLayerID: layerID,
-				PrevATXID:  types.RandomATXID(),
+				PublishEpoch: layerID.GetEpoch(),
+				PrevATXID:    types.RandomATXID(),
 			},
 			NumUnits: 2,
 		},
@@ -433,7 +433,7 @@ func TestPositioningID(t *testing.T) {
 				full := &types.ActivationTx{
 					InnerActivationTx: types.InnerActivationTx{
 						NIPostChallenge: types.NIPostChallenge{
-							PubLayerID: atx.epoch.FirstLayer(),
+							PublishEpoch: atx.epoch,
 						},
 						Coinbase: atx.coinbase,
 						NumUnits: 2,

--- a/sql/migrations/0001_initial.sql
+++ b/sql/migrations/0001_initial.sql
@@ -101,7 +101,6 @@ CREATE TABLE beacons
 CREATE TABLE atxs
 (
     id                  CHAR(32) PRIMARY KEY,
-    layer               INT NOT NULL,
     epoch               INT NOT NULL,
     effective_num_units INT NOT NULL,
     nonce               UNSIGNED LONG INT,

--- a/tortoise/model/core.go
+++ b/tortoise/model/core.go
@@ -142,7 +142,7 @@ func (c *core) OnMessage(m Messenger, event Message) {
 		}
 
 		nipost := types.NIPostChallenge{
-			PubLayerID: ev.LayerID,
+			PublishEpoch: ev.LayerID.GetEpoch(),
 		}
 		addr := types.GenerateAddress(c.signer.PublicKey().Bytes())
 		atx := types.NewActivationTx(nipost, addr, nil, c.units, nil, nil)

--- a/tortoise/sim/generator.go
+++ b/tortoise/sim/generator.go
@@ -228,7 +228,7 @@ func (g *Generator) generateAtxs() {
 		address := types.GenerateAddress(sig.PublicKey().Bytes())
 
 		nipost := types.NIPostChallenge{
-			PubLayerID: g.nextLayer.Sub(1),
+			PublishEpoch: g.nextLayer.Sub(1).GetEpoch(),
 		}
 		atx := types.NewActivationTx(nipost, address, nil, units, nil, nil)
 		var ticks uint64

--- a/tortoise/threshold_test.go
+++ b/tortoise/threshold_test.go
@@ -156,7 +156,7 @@ func TestReferenceHeight(t *testing.T) {
 			for i, height := range tc.heights {
 				atx := &types.ActivationTx{InnerActivationTx: types.InnerActivationTx{
 					NIPostChallenge: types.NIPostChallenge{
-						PubLayerID: (types.EpochID(tc.epoch) - 1).FirstLayer(),
+						PublishEpoch: types.EpochID(tc.epoch) - 1,
 					},
 					NumUnits: 2,
 				}}

--- a/tortoise/tortoise_test.go
+++ b/tortoise/tortoise_test.go
@@ -476,7 +476,7 @@ func TestComputeExpectedWeight(t *testing.T) {
 				eid := first + types.EpochID(i)
 				atx := &types.ActivationTx{InnerActivationTx: types.InnerActivationTx{
 					NIPostChallenge: types.NIPostChallenge{
-						PubLayerID: (eid - 1).FirstLayer(),
+						PublishEpoch: eid - 1,
 					},
 					NumUnits: uint32(weight),
 				}}
@@ -1518,12 +1518,11 @@ func TestComputeBallotWeight(t *testing.T) {
 			trtl, err := New(cdb, nil, WithLogger(logtest.New(t)), WithConfig(cfg))
 			require.NoError(t, err)
 			lid := types.LayerID(111)
-			atxLid := lid.GetEpoch().FirstLayer().Sub(1)
 			for _, weight := range tc.atxs {
 				atx := &types.ActivationTx{InnerActivationTx: types.InnerActivationTx{
 					NumUnits: uint32(weight),
 				}}
-				atx.PubLayerID = atxLid
+				atx.PublishEpoch = lid.GetEpoch() - 1
 				atxID := types.RandomATXID()
 				atx.SetID(atxID)
 				atx.SetEffectiveNumUnits(atx.NumUnits)
@@ -2280,7 +2279,7 @@ func TestSwitchMode(t *testing.T) {
 
 		// add an atx to increase optimistic threshold in verifying tortoise to trigger a switch
 		header := &types.ActivationTxHeader{ID: types.ATXID{1}, EffectiveNumUnits: 1, TickCount: 200}
-		header.PubLayerID = types.EpochID(1).FirstLayer()
+		header.PublishEpoch = types.EpochID(1)
 		tortoise.OnAtx(header)
 		// feed ballots that vote against previously validated layer
 		// without the fix they would be ignored
@@ -2877,7 +2876,7 @@ func TestMissingActiveSet(t *testing.T) {
 	for _, atxid := range aset[:2] {
 		atx := &types.ActivationTxHeader{}
 		atx.ID = atxid
-		atx.PubLayerID = (epoch - 1).FirstLayer()
+		atx.PublishEpoch = epoch - 1
 		tortoise.OnAtx(atx)
 	}
 	t.Run("empty", func(t *testing.T) {


### PR DESCRIPTION
related https://github.com/spacemeshos/go-spacemesh/issues/3774

with this change any positioning atx is considered to be valid. additionally PubLayerId was changed to PublishEpoch. the rest are changes in tests.

i will submit part that picks publish epoch based on the current clock in a separate pr. 