### PR TITLE
[Merged by Bors] - vm: drop additional blake3 hash before signing

### DIFF
--- a/genvm/core/hash.go
+++ b/genvm/core/hash.go
@@ -7,8 +7,12 @@ import (
 	"github.com/spacemeshos/go-spacemesh/hash"
 )
 
-// Hash bytes into blake3 hash.
-var Hash = hash.Sum
+func SigningBody(genesis, tx []byte) []byte {
+	full := make([]byte, 0, len(genesis)+len(tx))
+	full = append(full, genesis...)
+	full = append(full, tx...)
+	return full
+}
 
 // ComputePrincipal address as the last 20 bytes from blake3(scale(template || args)).
 func ComputePrincipal(template Address, args scale.Encodable) Address {

--- a/genvm/sdk/multisig/tx.go
+++ b/genvm/sdk/multisig/tx.go
@@ -11,7 +11,6 @@ import (
 	"github.com/spacemeshos/go-spacemesh/genvm/core"
 	"github.com/spacemeshos/go-spacemesh/genvm/sdk"
 	"github.com/spacemeshos/go-spacemesh/genvm/templates/multisig"
-	"github.com/spacemeshos/go-spacemesh/hash"
 )
 
 func encode(fields ...scale.Encodable) []byte {
@@ -93,8 +92,7 @@ func Spawn(ref uint8, pk ed25519.PrivateKey, principal, template types.Address, 
 	payload.GasPrice = options.GasPrice
 
 	tx := encode(&sdk.TxVersion, &principal, &sdk.MethodSpawn, &template, &payload, args)
-	hh := hash.Sum(options.GenesisID[:], tx)
-	sig := ed25519.Sign(ed25519.PrivateKey(pk), hh[:])
+	sig := ed25519.Sign(ed25519.PrivateKey(pk), core.SigningBody(options.GenesisID[:], tx))
 	aggregator := &Aggregator{unsigned: tx, parts: map[uint8]multisig.Part{}}
 	part := multisig.Part{Ref: ref}
 	copy(part.Sig[:], sig)
@@ -118,8 +116,7 @@ func Spend(ref uint8, pk ed25519.PrivateKey, principal, to types.Address, amount
 	args.Amount = amount
 
 	tx := encode(&sdk.TxVersion, &principal, &sdk.MethodSpend, &payload, &args)
-	hh := hash.Sum(options.GenesisID[:], tx)
-	sig := ed25519.Sign(ed25519.PrivateKey(pk), hh[:])
+	sig := ed25519.Sign(ed25519.PrivateKey(pk), core.SigningBody(options.GenesisID[:], tx))
 	aggregator := &Aggregator{unsigned: tx, parts: map[uint8]multisig.Part{}}
 	part := multisig.Part{Ref: ref}
 	copy(part.Sig[:], sig)

--- a/genvm/sdk/vesting/tx.go
+++ b/genvm/sdk/vesting/tx.go
@@ -9,7 +9,6 @@ import (
 	"github.com/spacemeshos/go-spacemesh/genvm/sdk"
 	"github.com/spacemeshos/go-spacemesh/genvm/sdk/multisig"
 	"github.com/spacemeshos/go-spacemesh/genvm/templates/vesting"
-	"github.com/spacemeshos/go-spacemesh/hash"
 )
 
 type Aggregator = multisig.Aggregator
@@ -41,8 +40,7 @@ func DrainVault(ref uint8, pk ed25519.PrivateKey, principal, vault, receiver typ
 
 	method := scale.U8(vesting.MethodDrainVault)
 	tx := sdk.Encode(&sdk.TxVersion, &principal, &method, &payload, &args)
-	hh := hash.Sum(options.GenesisID[:], tx)
-	sig := ed25519.Sign(ed25519.PrivateKey(pk), hh[:])
+	sig := ed25519.Sign(ed25519.PrivateKey(pk), core.SigningBody(options.GenesisID[:], tx))
 	aggregator := NewAggregator(tx)
 	part := vesting.Part{Ref: ref}
 	copy(part.Sig[:], sig)

--- a/genvm/sdk/wallet/tx.go
+++ b/genvm/sdk/wallet/tx.go
@@ -10,7 +10,6 @@ import (
 	"github.com/spacemeshos/go-spacemesh/genvm/core"
 	"github.com/spacemeshos/go-spacemesh/genvm/sdk"
 	"github.com/spacemeshos/go-spacemesh/genvm/templates/wallet"
-	"github.com/spacemeshos/go-spacemesh/hash"
 	"github.com/spacemeshos/go-spacemesh/signing"
 )
 
@@ -50,8 +49,7 @@ func Spawn(pk signing.PrivateKey, template core.Address, args scale.Encodable, n
 	principal := core.ComputePrincipal(wallet.TemplateAddress, public)
 
 	tx := encode(&sdk.TxVersion, &principal, &sdk.MethodSpawn, &template, &payload, args)
-	hh := hash.Sum(options.GenesisID[:], tx)
-	sig := ed25519.Sign(ed25519.PrivateKey(pk), hh[:])
+	sig := ed25519.Sign(ed25519.PrivateKey(pk), core.SigningBody(options.GenesisID[:], tx))
 	return append(tx, sig...)
 }
 
@@ -75,7 +73,6 @@ func Spend(pk signing.PrivateKey, to types.Address, amount uint64, nonce types.N
 	args.Amount = amount
 
 	tx := encode(&sdk.TxVersion, &principal, &sdk.MethodSpend, &payload, &args)
-	hh := hash.Sum(options.GenesisID[:], tx)
-	sig := ed25519.Sign(ed25519.PrivateKey(pk), hh[:])
+	sig := ed25519.Sign(ed25519.PrivateKey(pk), core.SigningBody(options.GenesisID[:], tx))
 	return append(tx, sig...)
 }

--- a/genvm/templates/multisig/multisig.go
+++ b/genvm/templates/multisig/multisig.go
@@ -36,7 +36,7 @@ func (ms *MultiSig) Verify(host core.Host, raw []byte, dec *scale.Decoder) bool 
 	if err != nil {
 		return false
 	}
-	hash := core.Hash(host.GetGenesisID().Bytes(), raw[:len(raw)-n])
+	body := core.SigningBody(host.GetGenesisID().Bytes(), raw[:len(raw)-n])
 	batch := ed25519.NewBatchVerifierWithCapacity(int(ms.k))
 	last := uint8(0)
 	for i, part := range sig {
@@ -47,7 +47,7 @@ func (ms *MultiSig) Verify(host core.Host, raw []byte, dec *scale.Decoder) bool 
 			return false
 		}
 		last = part.Ref
-		batch.Add(ms.PublicKeys[part.Ref][:], hash[:], part.Sig[:])
+		batch.Add(ms.PublicKeys[part.Ref][:], body, part.Sig[:])
 	}
 	verified, _ := batch.Verify(nil)
 	return verified

--- a/genvm/templates/multisig/multisig_test.go
+++ b/genvm/templates/multisig/multisig_test.go
@@ -178,10 +178,9 @@ func pullWithDups(k int) (rst []int) {
 func prepSigFromKeys(tb testing.TB, message []byte, privates []ed25519.PrivateKey, refs ...int) []byte {
 	tb.Helper()
 	sigs := Signatures{}
-	hash := core.Hash(message)
 	for _, ref := range refs {
 		sig := core.Signature{}
-		copy(sig[:], ed25519.Sign(privates[ref], hash[:]))
+		copy(sig[:], ed25519.Sign(privates[ref], message))
 		sigs = append(sigs, Part{Ref: uint8(ref), Sig: sig})
 	}
 	buf := bytes.NewBuffer(nil)

--- a/genvm/templates/wallet/wallet.go
+++ b/genvm/templates/wallet/wallet.go
@@ -40,8 +40,11 @@ func (s *Wallet) Verify(host core.Host, raw []byte, dec *scale.Decoder) bool {
 	if err != nil {
 		return false
 	}
-	hash := core.Hash(host.GetGenesisID().Bytes(), raw[:len(raw)-n])
-	return ed25519.Verify(ed25519.PublicKey(s.PublicKey[:]), hash[:], sig[:])
+	return ed25519.Verify(
+		ed25519.PublicKey(s.PublicKey[:]),
+		core.SigningBody(host.GetGenesisID().Bytes(), raw[:len(raw)-n]),
+		sig[:],
+	)
 }
 
 // Spend transfers an amount to the address specified in SpendArguments.

--- a/genvm/templates/wallet/wallet_test.go
+++ b/genvm/templates/wallet/wallet_test.go
@@ -52,8 +52,8 @@ func TestVerify(t *testing.T) {
 	t.Run("Valid", func(t *testing.T) {
 		msg := []byte{1, 2, 3}
 		empty := types.Hash20{}
-		hash := core.Hash(empty[:], msg)
-		sig := ed25519.Sign(pk, hash[:])
+		body := core.SigningBody(empty[:], msg)
+		sig := ed25519.Sign(pk, body[:])
 		require.True(t, wallet.Verify(&core.Context{GenesisID: empty}, append(msg, sig...), scale.NewDecoder(bytes.NewReader(sig))))
 	})
 }


### PR DESCRIPTION
closes: https://github.com/spacemeshos/go-spacemesh/issues/4234

from ledger docs (references in the gh issue)

> The length of the data part is 255 bytes and the whole message sent in a single APDU is 260 bytes with the blocks cla, ins, p1, p2 and one extra byte that encodes the length of the data that follows.

> Receive: the transaction is sent through one or more APDUs. If this transaction is too large to be sent at once, it is copied chunk by chunk into a global buffer.