### PR TITLE
[Merged by Bors] - Migrate ed signature for Beacon domain

### DIFF
--- a/beacon/beacon.go
+++ b/beacon/beacon.go
@@ -106,7 +106,7 @@ func New(
 	nodeID types.NodeID,
 	publisher pubsub.Publisher,
 	edSigner *signing.EdSigner,
-	pubKeyExtractor *signing.PubKeyExtractor,
+	edVerifier *signing.EdVerifier,
 	vrfSigner vrfSigner,
 	vrfVerifier vrfVerifier,
 	cdb *datastore.CachedDB,
@@ -114,20 +114,20 @@ func New(
 	opts ...Opt,
 ) *ProtocolDriver {
 	pd := &ProtocolDriver{
-		ctx:             context.Background(),
-		logger:          log.NewNop(),
-		config:          DefaultConfig(),
-		nodeID:          nodeID,
-		publisher:       publisher,
-		edSigner:        edSigner,
-		pubKeyExtractor: pubKeyExtractor,
-		vrfSigner:       vrfSigner,
-		vrfVerifier:     vrfVerifier,
-		cdb:             cdb,
-		clock:           clock,
-		beacons:         make(map[types.EpochID]types.Beacon),
-		ballotsBeacons:  make(map[types.EpochID]map[types.Beacon]*beaconWeight),
-		states:          make(map[types.EpochID]*state),
+		ctx:            context.Background(),
+		logger:         log.NewNop(),
+		config:         DefaultConfig(),
+		nodeID:         nodeID,
+		publisher:      publisher,
+		edSigner:       edSigner,
+		edVerifier:     edVerifier,
+		vrfSigner:      vrfSigner,
+		vrfVerifier:    vrfVerifier,
+		cdb:            cdb,
+		clock:          clock,
+		beacons:        make(map[types.EpochID]types.Beacon),
+		ballotsBeacons: make(map[types.EpochID]map[types.Beacon]*beaconWeight),
+		states:         make(map[types.EpochID]*state),
 	}
 	for _, opt := range opts {
 		opt(pd)
@@ -164,17 +164,17 @@ type ProtocolDriver struct {
 	cancel     context.CancelFunc
 	startOnce  sync.Once
 
-	config          Config
-	nodeID          types.NodeID
-	sync            system.SyncStateProvider
-	publisher       pubsub.Publisher
-	edSigner        *signing.EdSigner
-	pubKeyExtractor *signing.PubKeyExtractor
-	vrfSigner       vrfSigner
-	vrfVerifier     vrfVerifier
-	nonceFetcher    nonceFetcher
-	weakCoin        coin
-	theta           *big.Float
+	config       Config
+	nodeID       types.NodeID
+	sync         system.SyncStateProvider
+	publisher    pubsub.Publisher
+	edSigner     *signing.EdSigner
+	edVerifier   *signing.EdVerifier
+	vrfSigner    vrfSigner
+	vrfVerifier  vrfVerifier
+	nonceFetcher nonceFetcher
+	weakCoin     coin
+	theta        *big.Float
 
 	clock    layerClock
 	msgTimes *messageTimes
@@ -935,6 +935,7 @@ func (pd *ProtocolDriver) sendFirstRoundVote(ctx context.Context, epoch types.Ep
 
 	m := FirstVotingMessage{
 		FirstVotingMessageBody: mb,
+		SmesherID:              pd.edSigner.NodeID(),
 		Signature:              sig,
 	}
 
@@ -981,6 +982,7 @@ func (pd *ProtocolDriver) sendFollowingVote(ctx context.Context, epoch types.Epo
 
 	m := FollowingVotingMessage{
 		FollowingVotingMessageBody: mb,
+		SmesherID:                  pd.edSigner.NodeID(),
 		Signature:                  sig,
 	}
 

--- a/beacon/beacon_test.go
+++ b/beacon/beacon_test.go
@@ -92,7 +92,7 @@ func newTestDriver(tb testing.TB, cfg Config, p pubsub.Publisher) *testProtocolD
 	}
 	edSgn, err := signing.NewEdSigner()
 	require.NoError(tb, err)
-	extractor, err := signing.NewPubKeyExtractor()
+	edVerify, err := signing.NewEdVerifier()
 	require.NoError(tb, err)
 	minerID := edSgn.NodeID()
 	lg := logtest.New(tb).WithName(minerID.ShortString())
@@ -102,7 +102,7 @@ func newTestDriver(tb testing.TB, cfg Config, p pubsub.Publisher) *testProtocolD
 	tpd.mNonceFetcher.EXPECT().VRFNonce(gomock.Any(), gomock.Any()).AnyTimes().Return(types.VRFPostIndex(1), nil)
 
 	tpd.cdb = datastore.NewCachedDB(sql.InMemory(), lg)
-	tpd.ProtocolDriver = New(minerID, p, edSgn, extractor, tpd.mSigner, tpd.mVerifier, tpd.cdb, tpd.mClock,
+	tpd.ProtocolDriver = New(minerID, p, edSgn, edVerify, tpd.mSigner, tpd.mVerifier, tpd.cdb, tpd.mClock,
 		WithConfig(cfg),
 		WithLogger(lg),
 		withWeakCoin(coinValueMock(tb, true)),
@@ -998,23 +998,6 @@ func TestBeacon_getSignedProposal(t *testing.T) {
 			require.Equal(t, tc.result, result)
 		})
 	}
-}
-
-func TestBeacon_signAndExtractED(t *testing.T) {
-	r := require.New(t)
-
-	signer, err := signing.NewEdSigner()
-	r.NoError(err)
-	extractor, err := signing.NewPubKeyExtractor()
-	r.NoError(err)
-
-	message := []byte{1, 2, 3, 4}
-
-	signature := signer.Sign(signing.BEACON, message)
-	extractedID, err := extractor.ExtractNodeID(signing.BEACON, message, signature)
-	r.NoError(err)
-
-	r.Equal(signer.NodeID(), extractedID)
 }
 
 func TestBeacon_calcBeacon(t *testing.T) {

--- a/beacon/handlers.go
+++ b/beacon/handlers.go
@@ -285,7 +285,7 @@ func (pd *ProtocolDriver) verifyFirstVotes(ctx context.Context, m FirstVotingMes
 	}
 
 	if !pd.edVerifier.Verify(signing.BEACON, m.SmesherID, messageBytes, m.Signature) {
-		return types.EmptyNodeID, fmt.Errorf("[round %v] verify signature %x: failed", types.FirstRound, m.Signature)
+		return types.EmptyNodeID, fmt.Errorf("[round %v] verify signature %s: failed", types.FirstRound, m.Signature)
 	}
 
 	logger = logger.WithFields(log.Stringer("smesher", m.SmesherID))
@@ -402,7 +402,7 @@ func (pd *ProtocolDriver) verifyFollowingVotes(ctx context.Context, m FollowingV
 	}
 
 	if !pd.edVerifier.Verify(signing.BEACON, m.SmesherID, messageBytes, m.Signature) {
-		return types.EmptyNodeID, fmt.Errorf("[round %v] verify signature %x: failed", types.FirstRound, m.Signature)
+		return types.EmptyNodeID, fmt.Errorf("[round %v] verify signature %s: failed", types.FirstRound, m.Signature)
 	}
 
 	logger := pd.logger.WithContext(ctx).WithFields(m.EpochID, round, log.Stringer("smesher", m.SmesherID))

--- a/beacon/handlers.go
+++ b/beacon/handlers.go
@@ -284,16 +284,15 @@ func (pd *ProtocolDriver) verifyFirstVotes(ctx context.Context, m FirstVotingMes
 		logger.With().Fatal("failed to serialize first voting message", log.Err(err))
 	}
 
-	nodeID, err := pd.pubKeyExtractor.ExtractNodeID(signing.BEACON, messageBytes, m.Signature)
-	if err != nil {
-		return types.EmptyNodeID, fmt.Errorf("[round %v] recover ID %x: %w", types.FirstRound, m.Signature, err)
+	if !pd.edVerifier.Verify(signing.BEACON, m.SmesherID, messageBytes, m.Signature) {
+		return types.EmptyNodeID, fmt.Errorf("[round %v] verify signature %x: failed", types.FirstRound, m.Signature)
 	}
 
-	logger = logger.WithFields(log.Stringer("smesher", nodeID))
-	if err = pd.registerVoted(logger, m.EpochID, nodeID, types.FirstRound); err != nil {
-		return types.EmptyNodeID, fmt.Errorf("[round %v] register proposal (miner ID %v): %w", types.FirstRound, nodeID.ShortString(), err)
+	logger = logger.WithFields(log.Stringer("smesher", m.SmesherID))
+	if err = pd.registerVoted(logger, m.EpochID, m.SmesherID, types.FirstRound); err != nil {
+		return types.EmptyNodeID, fmt.Errorf("[round %v] register proposal (miner ID %v): %w", types.FirstRound, m.SmesherID.ShortString(), err)
 	}
-	return nodeID, nil
+	return m.SmesherID, nil
 }
 
 func (pd *ProtocolDriver) storeFirstVotes(m FirstVotingMessage, nodeID types.NodeID) error {
@@ -402,17 +401,16 @@ func (pd *ProtocolDriver) verifyFollowingVotes(ctx context.Context, m FollowingV
 		pd.logger.With().Fatal("failed to serialize voting message", log.Err(err))
 	}
 
-	nodeID, err := pd.pubKeyExtractor.ExtractNodeID(signing.BEACON, messageBytes, m.Signature)
-	if err != nil {
-		return types.EmptyNodeID, fmt.Errorf("[round %v] recover ID from signature %x: %w", round, m.Signature, err)
+	if !pd.edVerifier.Verify(signing.BEACON, m.SmesherID, messageBytes, m.Signature) {
+		return types.EmptyNodeID, fmt.Errorf("[round %v] verify signature %x: failed", types.FirstRound, m.Signature)
 	}
 
-	logger := pd.logger.WithContext(ctx).WithFields(m.EpochID, round, log.Stringer("smesher", nodeID))
-	if err := pd.registerVoted(logger, m.EpochID, nodeID, m.RoundID); err != nil {
+	logger := pd.logger.WithContext(ctx).WithFields(m.EpochID, round, log.Stringer("smesher", m.SmesherID))
+	if err := pd.registerVoted(logger, m.EpochID, m.SmesherID, m.RoundID); err != nil {
 		return types.EmptyNodeID, err
 	}
 
-	return nodeID, nil
+	return m.SmesherID, nil
 }
 
 func (pd *ProtocolDriver) storeFollowingVotes(m FollowingVotingMessage, nodeID types.NodeID) error {

--- a/beacon/message.go
+++ b/beacon/message.go
@@ -50,6 +50,8 @@ type FirstVotingMessageBody struct {
 // FirstVotingMessage is a message type which is used when sending first voting messages.
 type FirstVotingMessage struct {
 	FirstVotingMessageBody
+
+	SmesherID types.NodeID
 	Signature types.EdSignature
 }
 
@@ -63,5 +65,6 @@ type FollowingVotingMessageBody struct {
 // FollowingVotingMessage is a message type which is used when sending following voting messages.
 type FollowingVotingMessage struct {
 	FollowingVotingMessageBody
+	SmesherID types.NodeID
 	Signature types.EdSignature
 }

--- a/beacon/message.go
+++ b/beacon/message.go
@@ -65,6 +65,7 @@ type FollowingVotingMessageBody struct {
 // FollowingVotingMessage is a message type which is used when sending following voting messages.
 type FollowingVotingMessage struct {
 	FollowingVotingMessageBody
+
 	SmesherID types.NodeID
 	Signature types.EdSignature
 }

--- a/beacon/message_scale.go
+++ b/beacon/message_scale.go
@@ -174,6 +174,13 @@ func (t *FirstVotingMessage) EncodeScale(enc *scale.Encoder) (total int, err err
 		total += n
 	}
 	{
+		n, err := scale.EncodeByteArray(enc, t.SmesherID[:])
+		if err != nil {
+			return total, err
+		}
+		total += n
+	}
+	{
 		n, err := scale.EncodeByteArray(enc, t.Signature[:])
 		if err != nil {
 			return total, err
@@ -186,6 +193,13 @@ func (t *FirstVotingMessage) EncodeScale(enc *scale.Encoder) (total int, err err
 func (t *FirstVotingMessage) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	{
 		n, err := t.FirstVotingMessageBody.DecodeScale(dec)
+		if err != nil {
+			return total, err
+		}
+		total += n
+	}
+	{
+		n, err := scale.DecodeByteArray(dec, t.SmesherID[:])
 		if err != nil {
 			return total, err
 		}
@@ -263,6 +277,13 @@ func (t *FollowingVotingMessage) EncodeScale(enc *scale.Encoder) (total int, err
 		total += n
 	}
 	{
+		n, err := scale.EncodeByteArray(enc, t.SmesherID[:])
+		if err != nil {
+			return total, err
+		}
+		total += n
+	}
+	{
 		n, err := scale.EncodeByteArray(enc, t.Signature[:])
 		if err != nil {
 			return total, err
@@ -275,6 +296,13 @@ func (t *FollowingVotingMessage) EncodeScale(enc *scale.Encoder) (total int, err
 func (t *FollowingVotingMessage) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	{
 		n, err := t.FollowingVotingMessageBody.DecodeScale(dec)
+		if err != nil {
+			return total, err
+		}
+		total += n
+	}
+	{
+		n, err := scale.DecodeByteArray(dec, t.SmesherID[:])
 		if err != nil {
 			return total, err
 		}

--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -502,7 +502,7 @@ func (app *App) initServices(
 	}
 
 	vrfVerifier := signing.NewVRFVerifier()
-	beaconProtocol := beacon.New(nodeID, app.host, sgn, app.keyExtractor, vrfSigner, vrfVerifier, app.cachedDB, clock,
+	beaconProtocol := beacon.New(nodeID, app.host, sgn, app.edVerifier, vrfSigner, vrfVerifier, app.cachedDB, clock,
 		beacon.WithContext(ctx),
 		beacon.WithConfig(app.Config.Beacon),
 		beacon.WithLogger(app.addLogger(BeaconLogger, lg)),

--- a/signing/signer.go
+++ b/signing/signer.go
@@ -128,7 +128,7 @@ func (es *EdSigner) Sign(d domain, m []byte) types.EdSignature {
 	msg = append(msg, m...)
 
 	switch d {
-	case ATX:
+	case ATX, BEACON:
 		return *(*[types.EdSignatureSize]byte)(ed25519.Sign(es.priv, msg))
 	default:
 		return *(*[types.EdSignatureSize]byte)(sm_ed25519.Sign(es.priv, msg))

--- a/signing/verifier.go
+++ b/signing/verifier.go
@@ -42,7 +42,7 @@ func NewEdVerifier(opts ...VerifierOptionFunc) (*EdVerifier, error) {
 // Verify verifies that a signature matches public key and message.
 func (es *EdVerifier) Verify(d domain, nodeID types.NodeID, m []byte, sig types.EdSignature) bool {
 	switch d {
-	case ATX:
+	case ATX, BEACON:
 	// all good
 	default:
 		panic("verify not supported for domain " + d.String())


### PR DESCRIPTION
## Motivation
Part of #4139, merge after https://github.com/spacemeshos/go-spacemesh/pull/4230.

This changes the signatures for the beacon domain to be canonical ed25519.

## Changes
- Add `SmesherID` to messages signed for the `BEACON` domain and verify those signatures instead of extracting the PublicKey from the signature

## Test Plan
- existing tests pass

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
