### PR TITLE
[Merged by Bors] - Avoid double hashing in Ballot initialization

### DIFF
--- a/common/types/ballot.go
+++ b/common/types/ballot.go
@@ -238,13 +238,11 @@ func (b *Ballot) Initialize() error {
 	}
 
 	h := hash.New()
-	_, err := codec.EncodeTo(h, &b.InnerBallot)
-	if err != nil {
-		return fmt.Errorf("failed to encode inner ballot for hashing")
+	if _, err := h.Write(b.MsgHash[:]); err != nil {
+		return fmt.Errorf("failed to write to hash")
 	}
-	_, err = scale.EncodeByteSlice(scale.NewEncoder(h), b.Signature[:])
-	if err != nil {
-		return fmt.Errorf("failed to encode byte slice")
+	if _, err := scale.EncodeByteSlice(scale.NewEncoder(h), b.Signature[:]); err != nil {
+		return fmt.Errorf("failed to encode signature")
 	}
 	b.ballotID = BallotID(BytesToHash(h.Sum(nil)).ToHash20())
 	return nil


### PR DESCRIPTION
## Motivation
`Ballot::Initialize` encodes and hashes the message twice when not needed. This removes the second encoding and hash.

## Changes
see above

## Test Plan
n/a

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
