### PR TITLE
[Merged by Bors] - set eligibility integer on reference ballot

### DIFF
--- a/common/types/ballot.go
+++ b/common/types/ballot.go
@@ -105,9 +105,6 @@ type InnerBallot struct {
 	// can be verified before decoding votes.
 	OpinionHash Hash32
 
-	// total number of ballots the smesher is eligible in this epoch.
-	EligibilityCount uint32
-
 	// the first Ballot the smesher cast in the epoch. this Ballot is a special Ballot that contains information
 	// that cannot be changed mid-epoch.
 	RefBallot BallotID
@@ -227,6 +224,8 @@ type EpochData struct {
 	ActiveSetHash Hash32
 	// the beacon value the smesher recorded for this epoch
 	Beacon Beacon
+	// total number of ballots the smesher is eligible in this epoch.
+	EligibilityCount uint32
 }
 
 // Initialize calculates and sets the Ballot's cached ballotID and smesherID.

--- a/common/types/ballot_scale.go
+++ b/common/types/ballot_scale.go
@@ -154,13 +154,6 @@ func (t *InnerBallot) EncodeScale(enc *scale.Encoder) (total int, err error) {
 		total += n
 	}
 	{
-		n, err := scale.EncodeCompact32(enc, uint32(t.EligibilityCount))
-		if err != nil {
-			return total, err
-		}
-		total += n
-	}
-	{
 		n, err := scale.EncodeByteArray(enc, t.RefBallot[:])
 		if err != nil {
 			return total, err
@@ -191,14 +184,6 @@ func (t *InnerBallot) DecodeScale(dec *scale.Decoder) (total int, err error) {
 			return total, err
 		}
 		total += n
-	}
-	{
-		field, n, err := scale.DecodeCompact32(dec)
-		if err != nil {
-			return total, err
-		}
-		total += n
-		t.EligibilityCount = uint32(field)
 	}
 	{
 		n, err := scale.DecodeByteArray(dec, t.RefBallot[:])
@@ -388,6 +373,13 @@ func (t *EpochData) EncodeScale(enc *scale.Encoder) (total int, err error) {
 		}
 		total += n
 	}
+	{
+		n, err := scale.EncodeCompact32(enc, uint32(t.EligibilityCount))
+		if err != nil {
+			return total, err
+		}
+		total += n
+	}
 	return total, nil
 }
 
@@ -405,6 +397,14 @@ func (t *EpochData) DecodeScale(dec *scale.Decoder) (total int, err error) {
 			return total, err
 		}
 		total += n
+	}
+	{
+		field, n, err := scale.DecodeCompact32(dec)
+		if err != nil {
+			return total, err
+		}
+		total += n
+		t.EligibilityCount = uint32(field)
 	}
 	return total, nil
 }

--- a/common/types/testutil.go
+++ b/common/types/testutil.go
@@ -106,9 +106,8 @@ func RandomBallot() *Ballot {
 			Layer: LayerID(10),
 		},
 		InnerBallot: InnerBallot{
-			AtxID:            RandomATXID(),
-			RefBallot:        RandomBallotID(),
-			EligibilityCount: 3,
+			AtxID:     RandomATXID(),
+			RefBallot: RandomBallotID(),
 		},
 		Votes: Votes{
 			Base:    RandomBallotID(),

--- a/miner/oracle_test.go
+++ b/miner/oracle_test.go
@@ -77,10 +77,10 @@ func genBallotWithEligibility(
 		InnerBallot: types.InnerBallot{
 			AtxID: ee.Atx,
 			EpochData: &types.EpochData{
-				ActiveSetHash: ee.ActiveSet.Hash(),
-				Beacon:        beacon,
+				ActiveSetHash:    ee.ActiveSet.Hash(),
+				Beacon:           beacon,
+				EligibilityCount: ee.Slots,
 			},
-			EligibilityCount: ee.Slots,
 		},
 		ActiveSet:         ee.ActiveSet,
 		EligibilityProofs: ee.Proofs[lid],

--- a/miner/proposal_builder.go
+++ b/miner/proposal_builder.go
@@ -214,9 +214,8 @@ func (pb *ProposalBuilder) createProposal(
 	}
 
 	ib := &types.InnerBallot{
-		AtxID:            epochEligibility.Atx,
-		OpinionHash:      opinion.Hash,
-		EligibilityCount: epochEligibility.Slots,
+		AtxID:       epochEligibility.Atx,
+		OpinionHash: opinion.Hash,
 	}
 
 	epoch := layerID.GetEpoch()
@@ -231,8 +230,9 @@ func (pb *ProposalBuilder) createProposal(
 			log.Int("active_set_size", len(epochEligibility.ActiveSet)))
 		ib.RefBallot = types.EmptyBallotID
 		ib.EpochData = &types.EpochData{
-			ActiveSetHash: epochEligibility.ActiveSet.Hash(),
-			Beacon:        beacon,
+			ActiveSetHash:    epochEligibility.ActiveSet.Hash(),
+			Beacon:           beacon,
+			EligibilityCount: epochEligibility.Slots,
 		}
 	} else {
 		logger.With().Debug("creating ballot with reference ballot (no active set)",

--- a/miner/proposal_builder_test.go
+++ b/miner/proposal_builder_test.go
@@ -195,7 +195,7 @@ func TestBuilder_HandleLayer_MultipleProposals(t *testing.T) {
 			require.NotNil(t, p.EpochData)
 			require.Equal(t, activeSet, types.ATXIDList(p.ActiveSet))
 			require.Equal(t, beacon, p.EpochData.Beacon)
-			require.Equal(t, ee.Slots, p.EligibilityCount)
+			require.Equal(t, ee.Slots, p.EpochData.EligibilityCount)
 			require.Equal(t, []types.TransactionID{tx1.ID}, p.TxIDs)
 			require.Equal(t, proofs, p.EligibilityProofs)
 			require.Equal(t, meshHash, p.MeshHash)
@@ -261,7 +261,7 @@ func TestBuilder_HandleLayer_OneProposal(t *testing.T) {
 			require.Equal(t, atxID, p.AtxID)
 			require.Equal(t, p.Layer, layerID)
 			require.NotNil(t, p.EpochData)
-			require.Equal(t, ee.Slots, p.EligibilityCount)
+			require.Equal(t, ee.Slots, p.EpochData.EligibilityCount)
 			require.Equal(t, activeSet, types.ATXIDList(p.ActiveSet))
 			require.Equal(t, beacon, p.EpochData.Beacon)
 			require.Equal(t, []types.TransactionID{tx.ID}, p.TxIDs)
@@ -388,9 +388,9 @@ func TestBuilder_HandleLayer_NoRefBallot(t *testing.T) {
 			var got types.Proposal
 			require.NoError(t, codec.Decode(data, &got))
 			require.Equal(t, types.EmptyBallotID, got.RefBallot)
-			require.Equal(t, types.EpochData{ActiveSetHash: activeSet.Hash(), Beacon: beacon}, *got.EpochData)
+			require.Equal(t, types.EpochData{ActiveSetHash: activeSet.Hash(), Beacon: beacon, EligibilityCount: ee.Slots}, *got.EpochData)
 			require.Equal(t, activeSet, types.ATXIDList(got.ActiveSet))
-			require.Equal(t, ee.Slots, got.EligibilityCount)
+			require.Equal(t, ee.Slots, got.EpochData.EligibilityCount)
 			return nil
 		})
 
@@ -431,7 +431,6 @@ func TestBuilder_HandleLayer_RefBallot(t *testing.T) {
 			require.NoError(t, codec.Decode(data, &got))
 			require.Equal(t, refBallot.ID(), got.RefBallot)
 			require.Nil(t, got.EpochData)
-			require.Equal(t, ee.Slots, got.EligibilityCount)
 			return nil
 		})
 

--- a/proposals/eligibility_validator.go
+++ b/proposals/eligibility_validator.go
@@ -115,6 +115,7 @@ func (v *Validator) CheckEligibility(ctx context.Context, ballot *types.Ballot) 
 	if len(activeSets) == 0 {
 		return false, fmt.Errorf("%w: ref ballot %v", errEmptyActiveSet, refBallot.ID())
 	}
+	advertisedCount := refBallot.EpochData.EligibilityCount
 
 	// todo: optimize by using reference to active set size and cache active set size to not load all atxsIDs from db
 	var owned *types.ActivationTxHeader
@@ -145,8 +146,8 @@ func (v *Validator) CheckEligibility(ctx context.Context, ballot *types.Ballot) 
 	if err != nil {
 		return false, err
 	}
-	if ballot.EligibilityCount != numEligibleSlots {
-		return false, fmt.Errorf("%w: expected %v, got: %v", errIncorrectEligCount, numEligibleSlots, ballot.EligibilityCount)
+	if advertisedCount != numEligibleSlots {
+		return false, fmt.Errorf("%w: expected %v, got: %v", errIncorrectEligCount, numEligibleSlots, advertisedCount)
 	}
 
 	var (

--- a/proposals/eligibility_validator.go
+++ b/proposals/eligibility_validator.go
@@ -115,7 +115,6 @@ func (v *Validator) CheckEligibility(ctx context.Context, ballot *types.Ballot) 
 	if len(activeSets) == 0 {
 		return false, fmt.Errorf("%w: ref ballot %v", errEmptyActiveSet, refBallot.ID())
 	}
-	advertisedCount := refBallot.EpochData.EligibilityCount
 
 	// todo: optimize by using reference to active set size and cache active set size to not load all atxsIDs from db
 	var owned *types.ActivationTxHeader
@@ -146,8 +145,8 @@ func (v *Validator) CheckEligibility(ctx context.Context, ballot *types.Ballot) 
 	if err != nil {
 		return false, err
 	}
-	if advertisedCount != numEligibleSlots {
-		return false, fmt.Errorf("%w: expected %v, got: %v", errIncorrectEligCount, numEligibleSlots, advertisedCount)
+	if ballot.EpochData != nil && ballot.EpochData.EligibilityCount != numEligibleSlots {
+		return false, fmt.Errorf("%w: expected %v, got: %v", errIncorrectEligCount, numEligibleSlots, ballot.EpochData.EligibilityCount)
 	}
 
 	var (

--- a/proposals/eligibility_validator_test.go
+++ b/proposals/eligibility_validator_test.go
@@ -125,15 +125,15 @@ func createBallots(tb testing.TB, signer *signing.EdSigner, activeSet types.ATXI
 		if isRef {
 			b.RefBallot = types.EmptyBallotID
 			b.EpochData = &types.EpochData{
-				ActiveSetHash: activeSet.Hash(),
-				Beacon:        beacon,
+				ActiveSetHash:    activeSet.Hash(),
+				Beacon:           beacon,
+				EligibilityCount: eligibleSlots,
 			}
 			b.ActiveSet = activeSet
 		} else {
 			b.RefBallot = blts[0].ID()
 		}
 		b.EligibilityProofs = proofs
-		b.EligibilityCount = eligibleSlots
 		b.Signature = signer.Sign(signing.BALLOT, b.SignedBytes())
 		b.SetSmesherID(signer.NodeID())
 		require.NoError(tb, b.Initialize())
@@ -313,11 +313,9 @@ func TestCheckEligibility_IncorrectEligibilityCount(t *testing.T) {
 	activeset := genActiveSetAndSave(t, tv.cdb, signer)
 	blts := createBallots(t, signer, activeset, types.Beacon{1, 1, 1})
 	rb := blts[0]
-	require.NoError(t, ballots.Add(tv.cdb, rb))
-	b := blts[1]
-	b.EligibilityCount = eligibleSlots - 1
+	rb.EpochData.EligibilityCount = eligibleSlots - 1
 
-	got, err := tv.CheckEligibility(context.Background(), b)
+	got, err := tv.CheckEligibility(context.Background(), rb)
 	require.ErrorIs(t, err, errIncorrectEligCount)
 	require.False(t, got)
 }

--- a/proposals/handler.go
+++ b/proposals/handler.go
@@ -30,7 +30,6 @@ var (
 	errMalformedData         = errors.New("malformed data")
 	errInitialize            = errors.New("failed to initialize")
 	errInvalidATXID          = errors.New("ballot has invalid ATXID")
-	errMissingCount          = errors.New("missing eligibility count")
 	errMissingEpochData      = errors.New("epoch data is missing in ref ballot")
 	errUnexpectedEpochData   = errors.New("non-ref ballot declares epoch data")
 	errEmptyActiveSet        = errors.New("ref ballot declares empty active set")
@@ -410,10 +409,6 @@ func (h *Handler) checkBallotSyntacticValidity(ctx context.Context, logger log.L
 func (h *Handler) checkBallotDataIntegrity(b *types.Ballot) error {
 	if b.AtxID == types.EmptyATXID || b.AtxID == h.cfg.GoldenATXID {
 		return errInvalidATXID
-	}
-
-	if b.EligibilityCount == 0 {
-		return errMissingCount
 	}
 
 	if b.RefBallot == types.EmptyBallotID {

--- a/proposals/handler_test.go
+++ b/proposals/handler_test.go
@@ -299,17 +299,6 @@ func TestBallot_GoldenATXID(t *testing.T) {
 	require.ErrorIs(t, th.HandleSyncedBallot(context.Background(), peer, data), errInvalidATXID)
 }
 
-func TestBallot_MissingEligibilityCount(t *testing.T) {
-	th := createTestHandlerNoopDecoder(t)
-	b := types.RandomBallot()
-	b.EligibilityCount = 0
-	b = signAndInit(t, b)
-	data := encodeBallot(t, b)
-	peer := p2p.Peer("buddy")
-	th.mf.EXPECT().RegisterPeerHashes(peer, collectHashes(*b))
-	require.ErrorIs(t, th.HandleSyncedBallot(context.Background(), peer, data), errMissingCount)
-}
-
 func TestBallot_RefBallotMissingEpochData(t *testing.T) {
 	th := createTestHandlerNoopDecoder(t)
 	b := createRefBallot(t)


### PR DESCRIPTION
i didn't notice that it wasn't part of the epoch data. integers can't overwrite eligibility count in the same epoch, so it should be specified once