### PR TITLE
[Merged by Bors] - Bump post to 0.5.4

### DIFF
--- a/Makefile-libs.Inc
+++ b/Makefile-libs.Inc
@@ -52,7 +52,7 @@ ifneq ($(VERBOSE),)
   $(info "OS: $(OS), HOST_OS: $(HOST_OS), GOOS: $(GOOS), GOARCH: $(GOARCH), BIN_DIR: $(BIN_DIR), platform: $(platform)")
 endif
 
-GPU_SETUP_REV = 0.1.28
+GPU_SETUP_REV = 0.1.29
 GPU_SETUP_ZIP = libgpu-setup-$(platform)-$(GPU_SETUP_REV).zip
 GPU_SETUP_URL_ZIP = https://github.com/spacemeshos/gpu-post/releases/download/v$(GPU_SETUP_REV)/$(GPU_SETUP_ZIP)
 ifeq ($(platform), windows)

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/spacemeshos/go-scale v1.1.7
 	github.com/spacemeshos/merkle-tree v0.2.1
 	github.com/spacemeshos/poet v0.8.0
-	github.com/spacemeshos/post v0.5.3
+	github.com/spacemeshos/post v0.5.4
 	github.com/spf13/afero v1.9.5
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -592,8 +592,7 @@ github.com/spacemeshos/merkle-tree v0.2.1 h1:BSs/zt1n3ceZcpWdcqNFRvTeAWDlc0W+bql
 github.com/spacemeshos/merkle-tree v0.2.1/go.mod h1:IsrdlW6AHZ4HSi89H7G94ravFCMFZLGnm6To0tQ0SPY=
 github.com/spacemeshos/poet v0.8.0 h1:OLsmNchKmZhU0R5Dpu9L8jAoW0xyd7SmTt5Un09FrEU=
 github.com/spacemeshos/poet v0.8.0/go.mod h1:tIm/BNgojkYx1A2DUNDLSpsEXGxs/4IcSKE9lf7z4rs=
-github.com/spacemeshos/post v0.5.3 h1:VpdKTRDgVExDCdKncZS/pt2v05OHvBwpm0X2pK1hrrQ=
-github.com/spacemeshos/post v0.5.3/go.mod h1:MPjn9h2FdgKkYUZrFWAcHyRqRrbRfMFR52+YFA+EMSk=
+github.com/spacemeshos/post v0.5.4 h1:jtg+nPAUSwaVwHMXNmr67EokGzVKofnSbVTS7EoqIyE=
 github.com/spacemeshos/post v0.5.4/go.mod h1:MPjn9h2FdgKkYUZrFWAcHyRqRrbRfMFR52+YFA+EMSk=
 github.com/spacemeshos/sha256-simd v0.1.0 h1:G7Mfu5RYdQiuE+wu4ZyJ7I0TI74uqLhFnKblEnSpjYI=
 github.com/spacemeshos/sha256-simd v0.1.0/go.mod h1:O8CClVIilId7RtuCMV2+YzMj6qjVn75JsxOxaE8vcfM=

--- a/go.sum
+++ b/go.sum
@@ -594,6 +594,7 @@ github.com/spacemeshos/poet v0.8.0 h1:OLsmNchKmZhU0R5Dpu9L8jAoW0xyd7SmTt5Un09FrE
 github.com/spacemeshos/poet v0.8.0/go.mod h1:tIm/BNgojkYx1A2DUNDLSpsEXGxs/4IcSKE9lf7z4rs=
 github.com/spacemeshos/post v0.5.3 h1:VpdKTRDgVExDCdKncZS/pt2v05OHvBwpm0X2pK1hrrQ=
 github.com/spacemeshos/post v0.5.3/go.mod h1:MPjn9h2FdgKkYUZrFWAcHyRqRrbRfMFR52+YFA+EMSk=
+github.com/spacemeshos/post v0.5.4/go.mod h1:MPjn9h2FdgKkYUZrFWAcHyRqRrbRfMFR52+YFA+EMSk=
 github.com/spacemeshos/sha256-simd v0.1.0 h1:G7Mfu5RYdQiuE+wu4ZyJ7I0TI74uqLhFnKblEnSpjYI=
 github.com/spacemeshos/sha256-simd v0.1.0/go.mod h1:O8CClVIilId7RtuCMV2+YzMj6qjVn75JsxOxaE8vcfM=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e7adebf</samp>

Updated `post` dependency to version 0.5.4 to fix bugs and improve PoST performance. This was part of a pull request to enhance the node's stability and efficiency.