### PR TITLE
[Merged by Bors] - cmd/node: write smesher file in a hex

### DIFF
--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -3,6 +3,7 @@ package node
 
 import (
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"net/http"
@@ -952,7 +953,8 @@ func (app *App) LoadOrCreateEdSigner() (*signing.EdSigner, error) {
 		if err := os.MkdirAll(filepath.Dir(filename), 0o700); err != nil {
 			return nil, fmt.Errorf("failed to create directory for identity file: %w", err)
 		}
-		err = os.WriteFile(filename, edSgn.PrivateKey(), 0o600)
+
+		err = os.WriteFile(filename, []byte(hex.EncodeToString(edSgn.PrivateKey())), 0o600)
 		if err != nil {
 			return nil, fmt.Errorf("failed to write identity file: %w", err)
 		}
@@ -960,8 +962,16 @@ func (app *App) LoadOrCreateEdSigner() (*signing.EdSigner, error) {
 		log.With().Info("created new identity", edSgn.PublicKey())
 		return edSgn, nil
 	}
+	dst := make([]byte, signing.PrivateKeySize)
+	n, err := hex.Decode(dst, data)
+	if err != nil {
+		return nil, fmt.Errorf("bad hex: %w", err)
+	}
+	if n != signing.PrivateKeySize {
+		return nil, fmt.Errorf("invalid key size %d/%d", n, signing.PrivateKeySize)
+	}
 	edSgn, err := signing.NewEdSigner(
-		signing.WithPrivateKey(data),
+		signing.WithPrivateKey(dst),
 		signing.WithPrefix(app.Config.Genesis.GenesisID().Bytes()),
 	)
 	if err != nil {

--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -965,7 +965,7 @@ func (app *App) LoadOrCreateEdSigner() (*signing.EdSigner, error) {
 	dst := make([]byte, signing.PrivateKeySize)
 	n, err := hex.Decode(dst, data)
 	if err != nil {
-		return nil, fmt.Errorf("bad hex: %w", err)
+		return nil, fmt.Errorf("decoding private key: %w", err)
 	}
 	if n != signing.PrivateKeySize {
 		return nil, fmt.Errorf("invalid key size %d/%d", n, signing.PrivateKeySize)

--- a/cmd/node/node_test.go
+++ b/cmd/node/node_test.go
@@ -102,7 +102,7 @@ func TestSpacemeshApp_getEdIdentity(t *testing.T) {
 	t.Run("bad hex", func(t *testing.T) {
 		testLoadOrCreateEdSigner(t,
 			bytes.Repeat([]byte("CV"), signing.PrivateKeySize),
-			"bad hex: encoding/hex: invalid byte",
+			"decoding private key: encoding/hex: invalid byte",
 		)
 	})
 	t.Run("good key", func(t *testing.T) {


### PR DESCRIPTION
it was written in binary, which is not very convenient to work with