### PR TITLE
[Merged by Bors] - Eligibility oracle: Fix incorrect checks for overflows

### DIFF
--- a/blocks/certifier.go
+++ b/blocks/certifier.go
@@ -346,7 +346,8 @@ func (c *Certifier) validateCert(ctx context.Context, logger log.Log, cert *type
 		logger.With().Warning("certificate not meeting threshold",
 			log.Int("num_msgs", len(cert.Signatures)),
 			log.Int("threshold", c.cfg.CertifyThreshold),
-			log.Uint16("eligibility_count", eligibilityCnt))
+			log.Uint16("eligibility_count", eligibilityCnt),
+		)
 		return errInvalidCert
 	}
 	return nil
@@ -436,7 +437,8 @@ func (c *Certifier) saveMessage(ctx context.Context, logger log.Log, msg types.C
 	c.certifyMsgs[lid][bid].totalEligibility += msg.EligibilityCnt
 	logger.With().Debug("saved certify msg",
 		log.Uint16("eligibility_count", c.certifyMsgs[lid][bid].totalEligibility),
-		log.Int("num_msg", len(c.certifyMsgs[lid][bid].signatures)))
+		log.Int("num_msg", len(c.certifyMsgs[lid][bid].signatures)),
+	)
 
 	if c.certifyMsgs[lid][bid].registered {
 		return c.tryGenCert(ctx, logger, lid, bid)
@@ -465,7 +467,8 @@ func (c *Certifier) tryGenCert(ctx context.Context, logger log.Log, lid types.La
 
 	logger.With().Info("generating certificate",
 		log.Uint16("eligibility_count", c.certifyMsgs[lid][bid].totalEligibility),
-		log.Int("num_msg", len(c.certifyMsgs[lid][bid].signatures)))
+		log.Int("num_msg", len(c.certifyMsgs[lid][bid].signatures)),
+	)
 	cert := &types.Certificate{
 		BlockID:    bid,
 		Signatures: c.certifyMsgs[lid][bid].signatures,

--- a/eligibility/fixedoracle.go
+++ b/eligibility/fixedoracle.go
@@ -206,7 +206,8 @@ func (fo *FixedRolacle) eligible(ctx context.Context, layer types.LayerID, round
 	if committeeSize > total {
 		fo.logger.WithContext(ctx).With().Warning("committee size bigger than the number of clients",
 			log.Int("committee_size", committeeSize),
-			log.Int("num_clients", total))
+			log.Int("num_clients", total),
+		)
 		size = total
 	}
 

--- a/hare/eligibility/oracle.go
+++ b/hare/eligibility/oracle.go
@@ -351,12 +351,13 @@ func (o *Oracle) CalcEligibility(
 
 	for x := 0; x < n; x++ {
 		if fixed.BinCDF(n, p, x).GreaterThan(vrfFrac) {
-			// even with large N and large P x will be << 2^16, so this cast is safe
+			// even with large N and large P, x will be << 2^16, so this cast is safe
 			return uint16(x), nil
 		}
 	}
 
-	// since BinCDF(n, p, n) is 1 for any p this code is only reached if n << 2^16
+	// BinCDF(n, p, n) is 1 for any p, this code can only be reached if n much smaller
+	// than 2^16 (so that BinCDF(n, p, n-1) is still lower than vrfFrac)
 	return uint16(n), nil
 }
 

--- a/hare/eligibility/oracle.go
+++ b/hare/eligibility/oracle.go
@@ -43,8 +43,8 @@ const (
 )
 
 const (
-	activesCacheSize = 5                 // we don't expect to handle more than two layers concurrently
-	maxSupportedN    = math.MaxInt32 / 2 // higher values result in an overflow
+	activesCacheSize = 5                       // we don't expect to handle more than two layers concurrently
+	maxSupportedN    = (math.MaxInt32 / 2) + 1 // higher values result in an overflow when calculating CDF
 )
 
 var (

--- a/hare/eligibility/oracle.go
+++ b/hare/eligibility/oracle.go
@@ -299,7 +299,7 @@ func (o *Oracle) Validate(ctx context.Context, layer types.LayerID, round uint32
 		log.Uint32("round", round),
 		log.Int("committee_size", committeeSize),
 		id,
-		log.Uint64("eligibility_count", uint64(eligibilityCount)),
+		log.Uint16("eligibility_count", eligibilityCount),
 		log.Int("n", n),
 		log.String("p", p.String()),
 		log.String("vrf_frac", vrfFrac.String()),
@@ -351,9 +351,12 @@ func (o *Oracle) CalcEligibility(
 
 	for x := 0; x < n; x++ {
 		if fixed.BinCDF(n, p, x).GreaterThan(vrfFrac) {
+			// even with large N and large P x will be << 2^16, so this cast is safe
 			return uint16(x), nil
 		}
 	}
+
+	// since BinCDF(n, p, n) is 1 for any p this code is only reached if n << 2^16
 	return uint16(n), nil
 }
 

--- a/hare/eligibility/oracle.go
+++ b/hare/eligibility/oracle.go
@@ -356,7 +356,7 @@ func (o *Oracle) CalcEligibility(
 		}
 	}
 
-	// BinCDF(n, p, n) is 1 for any p, this code can only be reached if n much smaller
+	// since BinCDF(n, p, n) is 1 for any p, this code can only be reached if n is much smaller
 	// than 2^16 (so that BinCDF(n, p, n-1) is still lower than vrfFrac)
 	return uint16(n), nil
 }

--- a/hare/eligibility/oracle.go
+++ b/hare/eligibility/oracle.go
@@ -43,8 +43,8 @@ const (
 )
 
 const (
-	activesCacheSize = 5                       // we don't expect to handle more than two layers concurrently
-	maxSupportedN    = (math.MaxInt32 + 1) / 2 // higher values result in an overflow
+	activesCacheSize = 5                 // we don't expect to handle more than two layers concurrently
+	maxSupportedN    = math.MaxInt32 / 2 // higher values result in an overflow
 )
 
 var (
@@ -243,11 +243,7 @@ func (o *Oracle) prepareEligibilityCheck(ctx context.Context, layer types.LayerI
 		log.Uint64("total_weight", totalWeight),
 	)
 
-	// ensure miner weight fits in int
 	n := minerWeight
-	if n > maxSupportedN {
-		logger.Fatal(fmt.Sprintf("minerWeight overflows int (%d)", minerWeight))
-	}
 
 	// calc p
 	if uint64(committeeSize) > totalWeight {


### PR DESCRIPTION
## Motivation
Some casts in the hare eligibility oracle don't properly check for overflows.

## Changes
- `minerWeight` larger than `maxSupportedN`: instead of casting to check for an overflow, check first if the value is already too big
- `committeeSize > int(totalWeight)` this might overflow, if `totalWeight` is larger than `math.MaxInt32`. Instead cast `committeeSize` to `uint64`.
- Check for overflows before doing the next calculation, to abort earlier if necessary.

## Test Plan
n/a

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
