### PR TITLE
addressgen util

### DIFF
--- a/genvm/cmd/addressgen/main.go
+++ b/genvm/cmd/addressgen/main.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	hrp = flag.String("hrp", "smtest", "network human readable prefix")
+	hrp = flag.String("hrp", "stest", "network human readable prefix")
 )
 
 func main() {

--- a/genvm/cmd/addressgen/main.go
+++ b/genvm/cmd/addressgen/main.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"encoding/hex"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/genvm/core"
+	"github.com/spacemeshos/go-spacemesh/genvm/templates/wallet"
+)
+
+var (
+	hrp = flag.String("hrp", "smtest", "network human readable prefix")
+)
+
+func main() {
+	flag.Usage = func() {
+		fmt.Println("usage: addressgen <public key> -hrp=smtest")
+	}
+	flag.Parse()
+	public := flag.Arg(0)
+	if len(public) == 0 {
+		fmt.Printf("second argument must be a hexary encoded public key: %s, %v", public, flag.Args())
+		os.Exit(1)
+	}
+	bytes, err := hex.DecodeString(public)
+	if err != nil {
+		fmt.Println("not a hex", err)
+		os.Exit(1)
+	}
+	args := wallet.SpawnArguments{}
+	if n := copy(args.PublicKey[:], bytes); n != 32 {
+		fmt.Println("decoded key must be 32 bytes")
+		os.Exit(1)
+	}
+	types.DefaultAddressConfig().NetworkHRP = *hrp
+	coinbase := core.ComputePrincipal(wallet.TemplateAddress, &args)
+	fmt.Printf("wallet: %s\npublic key: %s\ncoinbase: %s\n",
+		wallet.TemplateAddress.String(),
+		args.PublicKey.String(),
+		coinbase.String(),
+	)
+}


### PR DESCRIPTION
input is a public key encoded in hexary (without 0x prefix). the only option is -hrp, which is set to smtest by default.

```
go run ./genvm/cmd/addressgen/ 16a4c4050362db7ed31203364900c86bdc181e7ee25c1ed4aa64e3e32a1e0699
```

wallet: smtest1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqgu79e6d
public key: 0x16a4c4050362db7ed31203364900c86bdc181e7ee25c1ed4aa64e3e32a1e0699
coinbase: smtest1qqqqqqrg6p3vfj9fq7dv8lhej37fgpqxz676hagtlzwz2