### PR TITLE
[Merged by Bors] - Check if all bytes have been consumed during scale decode

### DIFF
--- a/codec/codec.go
+++ b/codec/codec.go
@@ -71,7 +71,7 @@ func Decode(buf []byte, value Decodable) error {
 	return nil
 }
 
-// Decode value from a byte buffer.
+// DecodeSome value from a byte buffer without checking for full consumption.
 func DecodeSome(buf []byte, value Decodable) error {
 	if _, err := DecodeFrom(bytes.NewBuffer(buf), value); err != nil {
 		return fmt.Errorf("decode from buffer: %w", err)

--- a/codec/codec.go
+++ b/codec/codec.go
@@ -61,6 +61,18 @@ func Encode(value Encodable) ([]byte, error) {
 
 // Decode value from a byte buffer.
 func Decode(buf []byte, value Decodable) error {
+	n, err := DecodeFrom(bytes.NewBuffer(buf), value)
+	if err != nil {
+		return fmt.Errorf("decode from buffer: %w", err)
+	}
+	if n != len(buf) {
+		return fmt.Errorf("decode from buffer: not all bytes were consumed")
+	}
+	return nil
+}
+
+// Decode value from a byte buffer.
+func DecodeSome(buf []byte, value Decodable) error {
 	if _, err := DecodeFrom(bytes.NewBuffer(buf), value); err != nil {
 		return fmt.Errorf("decode from buffer: %w", err)
 	}

--- a/codec/codec.go
+++ b/codec/codec.go
@@ -2,12 +2,15 @@ package codec
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"sync"
 
 	"github.com/spacemeshos/go-scale"
 )
+
+var ErrShortRead = errors.New("decode from buffer: not all bytes were consumed")
 
 // Encodable is an interface that must be implemented by a struct to be encoded.
 type Encodable = scale.Encodable
@@ -66,17 +69,8 @@ func Decode(buf []byte, value Decodable) error {
 		return fmt.Errorf("decode from buffer: %w", err)
 	}
 	if n != len(buf) {
-		return fmt.Errorf("decode from buffer: not all bytes were consumed")
+		return ErrShortRead
 	}
-	return nil
-}
-
-// DecodeSome value from a byte buffer without checking for full consumption.
-func DecodeSome(buf []byte, value Decodable) error {
-	if _, err := DecodeFrom(bytes.NewBuffer(buf), value); err != nil {
-		return fmt.Errorf("decode from buffer: %w", err)
-	}
-
 	return nil
 }
 

--- a/common/types/activation_test.go
+++ b/common/types/activation_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/spacemeshos/go-scale/tester"
 	"github.com/stretchr/testify/require"
 
-	"github.com/spacemeshos/go-spacemesh/codec"
 	"github.com/spacemeshos/go-spacemesh/common/types"
 )
 
@@ -38,7 +37,8 @@ func TestActivationEncoding(t *testing.T) {
 	require.NoError(t, err)
 
 	var epoch types.EpochID
-	require.NoError(t, codec.DecodeSome(buf.Bytes(), &epoch))
+	_, err = epoch.DecodeScale(scale.NewDecoder(buf))
+	require.NoError(t, err)
 	require.Equal(t, object.PublishEpoch, epoch)
 }
 

--- a/common/types/activation_test.go
+++ b/common/types/activation_test.go
@@ -38,7 +38,7 @@ func TestActivationEncoding(t *testing.T) {
 	require.NoError(t, err)
 
 	var epoch types.EpochID
-	require.NoError(t, codec.Decode(buf.Bytes(), &epoch))
+	require.NoError(t, codec.DecodeSome(buf.Bytes(), &epoch))
 	require.Equal(t, object.PublishEpoch, epoch)
 }
 

--- a/common/types/layer_test.go
+++ b/common/types/layer_test.go
@@ -25,7 +25,7 @@ func CheckLayerFirstEncoding[T any, H scale.TypePtr[T]](t *testing.T, getLayerID
 		require.NoError(t, err)
 
 		lid := LayerID(rand.Uint32())
-		require.NoError(t, codec.Decode(buf.Bytes(), &lid))
+		require.NoError(t, codec.DecodeSome(buf.Bytes(), &lid))
 		require.Equal(t, getLayerID(object), lid)
 	})
 }

--- a/common/types/layer_test.go
+++ b/common/types/layer_test.go
@@ -3,7 +3,6 @@ package types
 import (
 	"bytes"
 	"math"
-	"math/rand"
 	"testing"
 
 	fuzz "github.com/google/gofuzz"
@@ -24,8 +23,9 @@ func CheckLayerFirstEncoding[T any, H scale.TypePtr[T]](t *testing.T, getLayerID
 		_, err := H(&object).EncodeScale(enc)
 		require.NoError(t, err)
 
-		lid := LayerID(rand.Uint32())
-		require.NoError(t, codec.DecodeSome(buf.Bytes(), &lid))
+		var lid LayerID
+		_, err = lid.DecodeScale(scale.NewDecoder(buf))
+		require.NoError(t, err)
 		require.Equal(t, getLayerID(object), lid)
 	})
 }

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/spacemeshos/api/release/go v1.8.1-0.20230417051650-d4cb54e6c592
 	github.com/spacemeshos/economics v0.0.0-20220930194415-799d50b0431d
 	github.com/spacemeshos/fixed v0.0.0-20210523192743-8d17e03c169a
-	github.com/spacemeshos/go-scale v1.1.8-0.20230414162212-bc708740c191
+	github.com/spacemeshos/go-scale v1.1.8
 	github.com/spacemeshos/merkle-tree v0.2.1
 	github.com/spacemeshos/poet v0.8.1
 	github.com/spacemeshos/post v0.5.4

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/spacemeshos/api/release/go v1.8.1-0.20230417051650-d4cb54e6c592
 	github.com/spacemeshos/economics v0.0.0-20220930194415-799d50b0431d
 	github.com/spacemeshos/fixed v0.0.0-20210523192743-8d17e03c169a
-	github.com/spacemeshos/go-scale v1.1.7
+	github.com/spacemeshos/go-scale v1.1.8-0.20230414162212-bc708740c191
 	github.com/spacemeshos/merkle-tree v0.2.1
 	github.com/spacemeshos/poet v0.8.1
 	github.com/spacemeshos/post v0.5.4

--- a/go.sum
+++ b/go.sum
@@ -596,8 +596,8 @@ github.com/spacemeshos/economics v0.0.0-20220930194415-799d50b0431d h1:ivLphqrvV
 github.com/spacemeshos/economics v0.0.0-20220930194415-799d50b0431d/go.mod h1:bMv7iXffBCPAHFivV6XM2l2SWXIfDoXkw4ND9yhgyfI=
 github.com/spacemeshos/fixed v0.0.0-20210523192743-8d17e03c169a h1:p/BRpvEHGqd4oYBp+B/vG3Z3RWdb7vAZCz8xsecS92M=
 github.com/spacemeshos/fixed v0.0.0-20210523192743-8d17e03c169a/go.mod h1:3SkkvXHU4Vm7yjpfgPu97PcZVvWweBmx0FOLRW7ek+g=
-github.com/spacemeshos/go-scale v1.1.8-0.20230414162212-bc708740c191 h1:BGRaSNFwCeWqldqIVdZDDAdCm6C16n6SSeNU8yl1aiM=
-github.com/spacemeshos/go-scale v1.1.8-0.20230414162212-bc708740c191/go.mod h1:CunTO4G/s76W4WSYZYNHqP+Wd883o30ZAHYgpt3VlBU=
+github.com/spacemeshos/go-scale v1.1.8 h1:qfqNIAkF40U7rdZTn+2N/nDN9TtAMUkad9LnhtjpOd8=
+github.com/spacemeshos/go-scale v1.1.8/go.mod h1:CunTO4G/s76W4WSYZYNHqP+Wd883o30ZAHYgpt3VlBU=
 github.com/spacemeshos/merkle-tree v0.2.1 h1:BSs/zt1n3ceZcpWdcqNFRvTeAWDlc0W+bql0XQH/Gz4=
 github.com/spacemeshos/merkle-tree v0.2.1/go.mod h1:IsrdlW6AHZ4HSi89H7G94ravFCMFZLGnm6To0tQ0SPY=
 github.com/spacemeshos/poet v0.8.1 h1:4Su831DQUrU7qE7MI1V84w5XcwCbNTl0nof6ahrsu5s=

--- a/go.sum
+++ b/go.sum
@@ -596,8 +596,8 @@ github.com/spacemeshos/economics v0.0.0-20220930194415-799d50b0431d h1:ivLphqrvV
 github.com/spacemeshos/economics v0.0.0-20220930194415-799d50b0431d/go.mod h1:bMv7iXffBCPAHFivV6XM2l2SWXIfDoXkw4ND9yhgyfI=
 github.com/spacemeshos/fixed v0.0.0-20210523192743-8d17e03c169a h1:p/BRpvEHGqd4oYBp+B/vG3Z3RWdb7vAZCz8xsecS92M=
 github.com/spacemeshos/fixed v0.0.0-20210523192743-8d17e03c169a/go.mod h1:3SkkvXHU4Vm7yjpfgPu97PcZVvWweBmx0FOLRW7ek+g=
-github.com/spacemeshos/go-scale v1.1.7 h1:nxoNju55EesKjhyXuus3cMM2OZSePYXyn5hY/5rDIwo=
-github.com/spacemeshos/go-scale v1.1.7/go.mod h1:AxKr+yCe5qn7EsM5ZAygGdulxVVfU+Fe2bc4PsnNakM=
+github.com/spacemeshos/go-scale v1.1.8-0.20230414162212-bc708740c191 h1:BGRaSNFwCeWqldqIVdZDDAdCm6C16n6SSeNU8yl1aiM=
+github.com/spacemeshos/go-scale v1.1.8-0.20230414162212-bc708740c191/go.mod h1:CunTO4G/s76W4WSYZYNHqP+Wd883o30ZAHYgpt3VlBU=
 github.com/spacemeshos/merkle-tree v0.2.1 h1:BSs/zt1n3ceZcpWdcqNFRvTeAWDlc0W+bql0XQH/Gz4=
 github.com/spacemeshos/merkle-tree v0.2.1/go.mod h1:IsrdlW6AHZ4HSi89H7G94ravFCMFZLGnm6To0tQ0SPY=
 github.com/spacemeshos/poet v0.8.1 h1:4Su831DQUrU7qE7MI1V84w5XcwCbNTl0nof6ahrsu5s=


### PR DESCRIPTION
## Motivation
Closes #4133

## Changes
- `codec.Decode` was changed to check if all bytes that were provided for decoding were consumed in the process.
  - if not the function now returns a named error: `ErrShortRead`
- In tests checking that layerID / epochID is first value in encoded bytes decoding was updated to not fail on `ErrShortRead`

## Test Plan
- All existing tests pass

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
