### PR TITLE
[Merged by Bors] - Cherry-pick pr "bring back p2p logger" to 0.3 branch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-retryablehttp v0.7.2
 	github.com/hashicorp/golang-lru v0.6.0
+	github.com/ipfs/go-log/v2 v2.5.1
 	github.com/libp2p/go-libp2p v0.26.0
 	github.com/libp2p/go-libp2p-pubsub v0.9.3
 	github.com/mitchellh/mapstructure v1.5.0
@@ -108,7 +109,6 @@ require (
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/ipfs/go-cid v0.3.2 // indirect
-	github.com/ipfs/go-log/v2 v2.5.1 // indirect
 	github.com/jackpal/go-nat-pmp v1.0.2 // indirect
 	github.com/jbenet/go-temp-err-catcher v0.1.0 // indirect
 	github.com/jessevdk/go-flags v1.5.0 // indirect

--- a/p2p/host.go
+++ b/p2p/host.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	lp2plog "github.com/ipfs/go-log/v2"
 	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p/p2p/host/peerstore/pstoremem"
 	"github.com/libp2p/go-libp2p/p2p/muxer/yamux"
@@ -54,7 +55,8 @@ func New(_ context.Context, logger log.Log, cfg Config, genesisID types.Hash20, 
 	if err != nil {
 		return nil, err
 	}
-
+	lp2plog.SetPrimaryCore(logger.Core())
+	lp2plog.SetAllLoggers(lp2plog.LogLevel(cfg.LogLevel))
 	cm, err := connmgr.NewConnManager(cfg.LowPeers, cfg.HighPeers, connmgr.WithGracePeriod(cfg.GracePeersShutdown))
 	if err != nil {
 		return nil, fmt.Errorf("p2p create conn mgr: %w", err)


### PR DESCRIPTION
https://github.com/spacemeshos/go-spacemesh/pull/4285 should be in 0.3 also.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b7db9c9</samp>

This pull request updates and enhances the logging functionality for the `p2p` package. It uses a newer version of the `go-log` library and adds the `lp2plog` package for better integration with the libp2p host.