### PR TITLE
tests: speed up unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ clear-test-cache:
 .PHONY: clear-test-cache
 
 test: get-libs
-	@$(ULIMIT) CGO_LDFLAGS="$(CGO_TEST_LDFLAGS)" gotestsum -- -race -timeout 5m -p 1 $(UNIT_TESTS)
+	@$(ULIMIT) CGO_LDFLAGS="$(CGO_TEST_LDFLAGS)" gotestsum -- -race -timeout 5m $(UNIT_TESTS)
 .PHONY: test
 
 generate: get-libs

--- a/beacon/beacon_test.go
+++ b/beacon/beacon_test.go
@@ -151,6 +151,8 @@ func TestMain(m *testing.M) {
 }
 
 func TestBeacon_MultipleNodes(t *testing.T) {
+	t.Parallel()
+
 	numNodes := 5
 	testNodes := make([]*testProtocolDriver, 0, numNodes)
 	publisher := pubsubmocks.NewMockPublisher(gomock.NewController(t))
@@ -220,6 +222,8 @@ func TestBeacon_MultipleNodes(t *testing.T) {
 }
 
 func TestBeacon_NoProposals(t *testing.T) {
+	t.Parallel()
+
 	numNodes := 5
 	testNodes := make([]*testProtocolDriver, 0, numNodes)
 	publisher := pubsubmocks.NewMockPublisher(gomock.NewController(t))
@@ -866,6 +870,8 @@ func TestBeacon_atxThreshold(t *testing.T) {
 }
 
 func TestBeacon_proposalPassesEligibilityThreshold(t *testing.T) {
+	t.Parallel()
+
 	cfg := Config{Kappa: 40, Q: big.NewRat(1, 3)}
 	tt := []struct {
 		name            string

--- a/genvm/vm_test.go
+++ b/genvm/vm_test.go
@@ -1372,7 +1372,9 @@ func singleWalletTestCases(defaultGasPrice int, template core.Address, ref *test
 
 func runTestCases(t *testing.T, tcs []templateTestCase, genTester func(t *testing.T) *tester) {
 	for _, tc := range tcs {
+		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
 			tt := genTester(t)
 			next := types.GetEffectiveGenesis()
 			for i, layer := range tc.layers {

--- a/hare/consensus_test.go
+++ b/hare/consensus_test.go
@@ -126,7 +126,9 @@ type ConsensusTest struct {
 	*HareSuite
 }
 
-func newConsensusTest() *ConsensusTest {
+func newConsensusTest(t *testing.T) *ConsensusTest {
+	t.Parallel()
+
 	ct := new(ConsensusTest)
 	ct.HareSuite = newHareSuite()
 
@@ -214,7 +216,7 @@ func createConsensusProcess(
 
 // Test - runs a single CP for more than one iteration.
 func TestConsensus_MultipleIterations(t *testing.T) {
-	test := newConsensusTest()
+	test := newConsensusTest(t)
 
 	totalNodes := 15
 	cfg := config.Config{N: totalNodes, WakeupDelta: time.Second, RoundDuration: time.Second, ExpectedLeaders: 5, LimitIterations: 1000, LimitConcurrent: 100, Hdist: 20}
@@ -249,7 +251,7 @@ func TestConsensus_MultipleIterations(t *testing.T) {
 }
 
 func TestConsensusFixedOracle(t *testing.T) {
-	test := newConsensusTest()
+	test := newConsensusTest(t)
 	cfg := config.Config{N: 16, RoundDuration: 2 * time.Second, ExpectedLeaders: 5, LimitIterations: 1000, Hdist: 20}
 
 	totalNodes := 20
@@ -281,7 +283,7 @@ func TestConsensusFixedOracle(t *testing.T) {
 }
 
 func TestSingleValueForHonestSet(t *testing.T) {
-	test := newConsensusTest()
+	test := newConsensusTest(t)
 
 	// Larger values may trigger race detector failures because of 8128 goroutines limit.
 	cfg := config.Config{N: 10, RoundDuration: 2 * time.Second, ExpectedLeaders: 5, LimitIterations: 1000, Hdist: 20}
@@ -315,7 +317,7 @@ func TestSingleValueForHonestSet(t *testing.T) {
 }
 
 func TestAllDifferentSet(t *testing.T) {
-	test := newConsensusTest()
+	test := newConsensusTest(t)
 
 	cfg := config.Config{N: 10, RoundDuration: 2 * time.Second, ExpectedLeaders: 5, LimitIterations: 1000, Hdist: 20}
 	totalNodes := 10
@@ -361,7 +363,7 @@ func TestSndDelayedDishonest(t *testing.T) {
 		t.Skip()
 	}
 
-	test := newConsensusTest()
+	test := newConsensusTest(t)
 
 	cfg := config.Config{N: 16, RoundDuration: 2 * time.Second, ExpectedLeaders: 5, LimitIterations: 1000, Hdist: 20}
 	totalNodes := 20
@@ -419,7 +421,7 @@ func TestRecvDelayedDishonest(t *testing.T) {
 		t.Skip()
 	}
 
-	test := newConsensusTest()
+	test := newConsensusTest(t)
 
 	cfg := config.Config{N: 16, RoundDuration: 2 * time.Second, ExpectedLeaders: 5, LimitIterations: 1000, Hdist: 20}
 	totalNodes := 20
@@ -514,7 +516,7 @@ func TestEquivocation(t *testing.T) {
 		t.Skip()
 	}
 
-	test := newConsensusTest()
+	test := newConsensusTest(t)
 
 	cfg := config.Config{N: 16, RoundDuration: 2 * time.Second, ExpectedLeaders: 5, LimitIterations: 1000, Hdist: 20}
 	totalNodes := 20

--- a/hare/hare_rounds_test.go
+++ b/hare/hare_rounds_test.go
@@ -120,6 +120,8 @@ func runNodesFor(t *testing.T, ctx context.Context, nodes, leaders, maxLayers, l
 }
 
 func Test_HarePreRoundEmptySet(t *testing.T) {
+	t.Parallel()
+
 	const nodes = 5
 	const layers = 2
 

--- a/hare/hare_test.go
+++ b/hare/hare_test.go
@@ -299,6 +299,8 @@ func TestHare_malfeasanceLoop(t *testing.T) {
 }
 
 func TestHare_onTick(t *testing.T) {
+	t.Parallel()
+
 	cfg := config.DefaultConfig()
 	cfg.N = 2
 	cfg.RoundDuration = 1
@@ -370,6 +372,8 @@ func TestHare_onTick(t *testing.T) {
 }
 
 func TestHare_onTick_notMining(t *testing.T) {
+	t.Parallel()
+
 	cfg := config.DefaultConfig()
 	cfg.N = 2
 	cfg.RoundDuration = 1


### PR DESCRIPTION
- remove `-p` limit so that tests from different modules can run in parallel
- and parallelized some of the tests

the bottleneck seems to be tests in activation module, but they don't want to work in parallel so leaving it for future