### PR TITLE
[Merged by Bors] - cherry pick - Ensure ComputeBatchSize set when starting smeshing (#4293)

### DIFF
--- a/api/grpcserver/grpcserver_test.go
+++ b/api/grpcserver/grpcserver_test.go
@@ -1016,7 +1016,7 @@ func TestGlobalStateService(t *testing.T) {
 
 func TestSmesherService(t *testing.T) {
 	logtest.SetupGlobal(t)
-	svc := NewSmesherService(&PostAPIMock{}, &SmeshingAPIMock{}, 10*time.Millisecond)
+	svc := NewSmesherService(&PostAPIMock{}, &SmeshingAPIMock{}, 10*time.Millisecond, activation.DefaultPostSetupOpts())
 	shutDown := launchServer(t, svc)
 	defer shutDown()
 

--- a/api/grpcserver/smesher_service.go
+++ b/api/grpcserver/smesher_service.go
@@ -25,6 +25,7 @@ type SmesherService struct {
 	smeshingProvider  api.SmeshingAPI
 
 	streamInterval time.Duration
+	postOpts       activation.PostSetupOpts
 }
 
 // RegisterService registers this service with a grpc server instance.
@@ -33,8 +34,8 @@ func (s SmesherService) RegisterService(server *Server) {
 }
 
 // NewSmesherService creates a new grpc service using config data.
-func NewSmesherService(post api.PostSetupProvider, smeshing api.SmeshingAPI, streamInterval time.Duration) *SmesherService {
-	return &SmesherService{post, smeshing, streamInterval}
+func NewSmesherService(post api.PostSetupProvider, smeshing api.SmeshingAPI, streamInterval time.Duration, postOpts activation.PostSetupOpts) *SmesherService {
+	return &SmesherService{post, smeshing, streamInterval, postOpts}
 }
 
 // IsSmeshing reports whether the node is smeshing.
@@ -67,14 +68,14 @@ func (s SmesherService) StartSmeshing(ctx context.Context, in *pb.StartSmeshingR
 		return nil, status.Error(codes.InvalidArgument, "`Opts.MaxFileSize` must be provided")
 	}
 
-	opts := activation.PostSetupOpts{
-		DataDir:           in.Opts.DataDir,
-		NumUnits:          in.Opts.NumUnits,
-		MaxFileSize:       in.Opts.MaxFileSize,
-		ComputeProviderID: int(in.Opts.ComputeProviderId),
-		Throttle:          in.Opts.Throttle,
-		Scrypt:            config.DefaultLabelParams(),
-	}
+	// Copy provided post opts
+	opts := s.postOpts
+	// Overlay api provided opts
+	opts.DataDir = in.Opts.DataDir
+	opts.NumUnits = in.Opts.NumUnits
+	opts.MaxFileSize = in.Opts.MaxFileSize
+	opts.ComputeProviderID = int(in.Opts.ComputeProviderId)
+	opts.Throttle = in.Opts.Throttle
 
 	coinbaseAddr, err := types.StringToAddress(in.Coinbase.Address)
 	if err != nil {

--- a/api/grpcserver/smesher_service_test.go
+++ b/api/grpcserver/smesher_service_test.go
@@ -21,7 +21,7 @@ func TestPostConfig(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	postSetupProvider := activation.NewMockpostSetupProvider(ctrl)
 	smeshingProvider := activation.NewMockSmeshingProvider(ctrl)
-	svc := grpcserver.NewSmesherService(postSetupProvider, smeshingProvider, time.Second)
+	svc := grpcserver.NewSmesherService(postSetupProvider, smeshingProvider, time.Second, activation.DefaultPostSetupOpts())
 
 	postConfig := activation.PostConfig{
 		MinNumUnits:   rand.Uint32(),
@@ -46,7 +46,7 @@ func TestStartSmeshingPassesCorrectSmeshingOpts(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	postSetupProvider := activation.NewMockpostSetupProvider(ctrl)
 	smeshingProvider := activation.NewMockSmeshingProvider(ctrl)
-	svc := grpcserver.NewSmesherService(postSetupProvider, smeshingProvider, time.Second)
+	svc := grpcserver.NewSmesherService(postSetupProvider, smeshingProvider, time.Second, activation.DefaultPostSetupOpts())
 
 	addr, err := types.StringToAddress("stest1qqqqqqrs60l66w5uksxzmaznwq6xnhqfv56c28qlkm4a5")
 	require.NoError(t, err)
@@ -57,6 +57,7 @@ func TestStartSmeshingPassesCorrectSmeshingOpts(t *testing.T) {
 		ComputeProviderID: 7,
 		Throttle:          true,
 		Scrypt:            config.DefaultLabelParams(),
+		ComputeBatchSize:  config.DefaultComputeBatchSize,
 	}).Return(nil)
 
 	_, err = svc.StartSmeshing(context.Background(), &pb.StartSmeshingRequest{

--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -864,7 +864,7 @@ func (app *App) startAPIServices(ctx context.Context) {
 		registerService(nodeService)
 	}
 	if apiConf.StartSmesherService {
-		registerService(grpcserver.NewSmesherService(app.postSetupMgr, app.atxBuilder, apiConf.SmesherStreamInterval))
+		registerService(grpcserver.NewSmesherService(app.postSetupMgr, app.atxBuilder, apiConf.SmesherStreamInterval, app.Config.SMESHING.Opts))
 	}
 	if apiConf.StartTransactionService {
 		registerService(grpcserver.NewTransactionService(app.db, app.host, app.mesh, app.conState, app.syncer))


### PR DESCRIPTION
Closes #4287

Sets the ComputeBatchSize option to the default value when starting smeshing.

Tested locally with the following process to verify that the crash no longer occurs after setting this option. Using config:
```json
{
  "api": {
    "grpc": [
      "debug",
      "node",
      "mesh",
      "globalstate",
      "transaction",
      "smesher"
    ]
  },
  "preset": "testnet",
  "p2p": {
    "bootnodes": [
      "/dns4/testnet-03-bootnode-0.spacemesh.network/tcp/5000/p2p/12D3KooWQMAAL9nkgXJgTM2psJLMbWRgZLjAxJozx7dNkKYczs2V",
      "/dns4/testnet-03-bootnode-1.spacemesh.network/tcp/5000/p2p/12D3KooWF2bhnqsnu2UjxJGZs8KCbzvd91vnud29KaG9rzTNFH78",
      "/dns4/testnet-03-bootnode-2.spacemesh.network/tcp/5000/p2p/12D3KooWQKosE9LZraMfFPg9QRYyKwxT4ipsar37oT6wRy8WqWos",
      "/dns4/testnet-03-bootnode-3.spacemesh.network/tcp/5000/p2p/12D3KooWKMQ5j15x2gzfXfX7uisss7uwkPnqJyoHcfyiYfHgSo3F",
      "/dns4/testnet-03-bootnode-4.spacemesh.network/tcp/5000/p2p/12D3KooWE1YEa3roqamhPt3CNiVRBzS7Lbv8HRbByE7fpSyLAZis",
      "/dns4/testnet-03-bootnode-5.spacemesh.network/tcp/5000/p2p/12D3KooWFCqyEner8hSnBmyQCkcxkuHjwY5BhHTaRYmGuNC1SQET",
      "/dns4/testnet-03-bootnode-6.spacemesh.network/tcp/5000/p2p/12D3KooWA96fvi2pQaQHpS2cpahDJCyQSsBW6A4KwHCPXsDVuiEJ",
      "/dns4/testnet-03-bootnode-7.spacemesh.network/tcp/5000/p2p/12D3KooWRvAVZrK3EURQBh1wdMPRDgjtowU84div3YxWYKuGDaFU",
      "/dns4/testnet-03-bootnode-8.spacemesh.network/tcp/5000/p2p/12D3KooWL3VGmZ4xgT1J5KnVJz7b6wxAUUFAVqNNRURKFfWNXLE4",
      "/dns4/testnet-03-bootnode-9.spacemesh.network/tcp/5000/p2p/12D3KooWCfadA8PUva7eRn1GzdLhnfELRLu81s1na6JbdYivwBgs"
    ]
  },
  "smeshing": {},
  "main": {
    "layer-duration": "300s",
    "layers-per-epoch": 864,
    "tick-size": 9266400,
    "block-gas-limit": 1000000,
    "poet-server": [
      "https://testnet-03-poet-0.spacemesh.network",
      "https://testnet-03-poet-1.spacemesh.network",
      "https://testnet-03-poet-2.spacemesh.network",
      "https://poet-10.spacemesh.network"
    ]
  },
  "genesis": {
    "genesis-time": "2023-04-11T18:00:00.498Z",
    "genesis-extra-data": "testnet-03"
  },
  "poet": {
    "phase-shift": "36h",
    "cycle-gap": "6h",
    "grace-period": "1m"
  },
  "post": {
      "post-labels-per-unit": 536870912,
      "post-max-numunits": 1000,
      "post-min-numunits": 4,
      "post-k1": 279,
      "post-k2": 300,
      "post-k3": 65,
      "post-k2pow-difficulty": 469112881707866048,
      "post-k3pow-difficulty": 29244622850649904
  },
   "hare": {
    "hare-wakeup-delta": "25s",
    "hare-round-duration": "25s",
    "hare-limit-iterations": 4,
    "hare-committee-size": 200
  },
  "tortoise": {
    "tortoise-zdist": 2,
    "tortoise-hdist": 40,
    "tortoise-window-size": 2000,
    "tortoise-delay-layers": 100
  },
  "beacon": {
    "beacon-grace-period-duration": "10m",
    "beacon-proposal-duration": "2m",
    "beacon-first-voting-round-duration": "30m",
    "beacon-rounds-number": 200,
    "beacon-voting-round-duration": "2m",
    "beacon-weak-coin-round-duration": "2m"
  }
}
```

1. `rm -rf testnet_03 ~/post`
1. `make build && LD_LIBRARY_PATH=./build ./build/go-spacemesh --config config_testnet_03.json --data-folder testnet_03 --json-server`
1. In another terminal:
```
grpc_cli call --json_input localhost:9092 spacemesh.v1.SmesherService.StartSmeshing '  {
    "coinbase": {
        "address": "stest1qqqqqqp8r9d6yzz8kqc3e9t0rgtlu8jwhlhyc4gm2xaut"
    },
    "opts": {
        "data_dir": "~/post",
        "num_units": 4,
        "max_file_size": 2147483648,
        "compute_provider_id": 1,
        "throttle": false
    }
}'
```
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)

## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
Closes #
<!-- `Closes #XXXX, closes #XXXX, ...` links mentioned issues to this PR and automatically closes them when this it's merged -->

## Changes
<!-- Please describe in detail the changes made -->

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->

## TODO
<!-- This section should be removed when all items are complete -->
- [ ] Explain motivation or link existing issue(s)
- [ ] Test changes and document test plan
- [ ] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
