### PR TITLE
[Merged by Bors] - Expose num of threads and nonces used for post proof gen in smehsing opts

### DIFF
--- a/activation/post.go
+++ b/activation/post.go
@@ -46,6 +46,21 @@ type PostSetupOpts struct {
 	ComputeBatchSize  uint64              `mapstructure:"smeshing-opts-compute-batch-size"`
 }
 
+// PostProvingOpts are the options controlling POST proving process.
+type PostProvingOpts struct {
+	// Number of threads used in POST proving process.
+	Threads uint `mapstructure:"smeshing-opts-proving-threads"`
+	// Number of nonces tried in parallel in POST proving process.
+	Nonces uint `mapstructure:"smeshing-opts-proving-nonces"`
+}
+
+func DefaultPostProvingOpts() PostProvingOpts {
+	return PostProvingOpts{
+		Threads: 1,
+		Nonces:  20,
+	}
+}
+
 // PostSetupStatus represents a status snapshot of the Post setup.
 type PostSetupStatus struct {
 	State            PostSetupState
@@ -88,14 +103,15 @@ type PostSetupManager struct {
 	db          *datastore.CachedDB
 	goldenATXID types.ATXID
 
-	mu       sync.Mutex                  // mu protects setting the values below.
-	lastOpts *PostSetupOpts              // the last options used to initiate a Post setup session.
-	state    PostSetupState              // state is the current state of the Post setup.
-	init     *initialization.Initializer // init is the current initializer instance.
+	mu          sync.Mutex                  // mu protects setting the values below.
+	lastOpts    *PostSetupOpts              // the last options used to initiate a Post setup session.
+	state       PostSetupState              // state is the current state of the Post setup.
+	init        *initialization.Initializer // init is the current initializer instance.
+	provingOpts PostProvingOpts
 }
 
 // NewPostSetupManager creates a new instance of PostSetupManager.
-func NewPostSetupManager(id types.NodeID, cfg PostConfig, logger log.Log, db *datastore.CachedDB, goldenATXID types.ATXID) (*PostSetupManager, error) {
+func NewPostSetupManager(id types.NodeID, cfg PostConfig, logger log.Log, db *datastore.CachedDB, goldenATXID types.ATXID, provingOpts PostProvingOpts) (*PostSetupManager, error) {
 	mgr := &PostSetupManager{
 		id:          id,
 		cfg:         cfg,
@@ -103,6 +119,7 @@ func NewPostSetupManager(id types.NodeID, cfg PostConfig, logger log.Log, db *da
 		db:          db,
 		goldenATXID: goldenATXID,
 		state:       PostSetupStateNotStarted,
+		provingOpts: provingOpts,
 	}
 
 	return mgr, nil
@@ -332,6 +349,8 @@ func (mgr *PostSetupManager) GenerateProof(ctx context.Context, challenge []byte
 
 	proof, proofMetadata, err := proving.Generate(ctx, challenge, config.Config(mgr.cfg), mgr.logger,
 		proving.WithDataSource(config.Config(mgr.cfg), mgr.id.Bytes(), mgr.commitmentAtxId.Bytes(), mgr.lastOpts.DataDir),
+		proving.WithNonces(mgr.provingOpts.Nonces),
+		proving.WithThreads(mgr.provingOpts.Threads),
 	)
 	if err != nil {
 		return nil, nil, fmt.Errorf("generate proof: %w", err)

--- a/activation/post_test.go
+++ b/activation/post_test.go
@@ -307,7 +307,7 @@ func newTestPostManager(tb testing.TB) *testPostManager {
 	goldenATXID := types.ATXID{2, 3, 4}
 
 	cdb := datastore.NewCachedDB(sql.InMemory(), logtest.New(tb))
-	mgr, err := NewPostSetupManager(id, cfg, logtest.New(tb), cdb, goldenATXID)
+	mgr, err := NewPostSetupManager(id, cfg, logtest.New(tb), cdb, goldenATXID, DefaultPostProvingOpts())
 	require.NoError(tb, err)
 
 	return &testPostManager{

--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -677,7 +677,13 @@ func (app *App) initServices(
 		miner.WithLogger(app.addLogger(ProposalBuilderLogger, lg)),
 	)
 
-	postSetupMgr, err := activation.NewPostSetupManager(nodeID, app.Config.POST, app.addLogger(PostLogger, lg), app.cachedDB, goldenATXID)
+	postSetupMgr, err := activation.NewPostSetupManager(
+		nodeID,
+		app.Config.POST,
+		app.addLogger(PostLogger, lg),
+		app.cachedDB, goldenATXID,
+		app.Config.SMESHING.ProvingOpts,
+	)
 	if err != nil {
 		app.log.Panic("failed to create post setup manager: %v", err)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -111,9 +111,10 @@ type BaseConfig struct {
 
 // SmeshingConfig defines configuration for the node's smeshing (mining).
 type SmeshingConfig struct {
-	Start           bool                     `mapstructure:"smeshing-start"`
-	CoinbaseAccount string                   `mapstructure:"smeshing-coinbase"`
-	Opts            activation.PostSetupOpts `mapstructure:"smeshing-opts"`
+	Start           bool                       `mapstructure:"smeshing-start"`
+	CoinbaseAccount string                     `mapstructure:"smeshing-coinbase"`
+	Opts            activation.PostSetupOpts   `mapstructure:"smeshing-opts"`
+	ProvingOpts     activation.PostProvingOpts `mapstructure:"smeshing-proving-opts"`
 }
 
 // DefaultConfig returns the default configuration for a spacemesh node.
@@ -180,6 +181,7 @@ func DefaultSmeshingConfig() SmeshingConfig {
 		Start:           false,
 		CoinbaseAccount: "",
 		Opts:            activation.DefaultPostSetupOpts(),
+		ProvingOpts:     activation.DefaultPostProvingOpts(),
 	}
 }
 

--- a/config/presets/presets_test.go
+++ b/config/presets/presets_test.go
@@ -25,7 +25,13 @@ func TestCanGeneratePOST(t *testing.T) {
 			opts := params.SMESHING.Opts
 			opts.DataDir = t.TempDir()
 
-			mgr, err := activation.NewPostSetupManager(types.EmptyNodeID, params.POST, logtest.New(t), cdb, goldenATXID)
+			mgr, err := activation.NewPostSetupManager(
+				types.EmptyNodeID,
+				params.POST,
+				logtest.New(t),
+				cdb, goldenATXID,
+				activation.DefaultPostProvingOpts(),
+			)
 			req.NoError(err)
 			req.NoError(mgr.StartSession(context.Background(), opts))
 


### PR DESCRIPTION
## Motivation
Closes #4314

## Changes
Expose:
- number of threads,
- number of nonces used in parallel in a single data-pass,

for fine-tuning post proving.
