### PR TITLE
Ensure that start smeshing cannot fail silently

### DIFF
--- a/activation/activation.go
+++ b/activation/activation.go
@@ -181,7 +181,7 @@ func (b *Builder) StartSmeshing(coinbase types.Address, opts PostSetupOpts) erro
 	ctx, stop := context.WithCancel(b.parentCtx)
 	b.stop = stop
 
-	cfg, err := b.postSetupProvider.PrepareInitializer(b.parentCtx, opts)
+	cfg, err := b.postSetupProvider.InitializerConfig(b.parentCtx, opts)
 	if err != nil {
 		return fmt.Errorf("failed to prepare post initializer: %w", err)
 	}

--- a/activation/activation.go
+++ b/activation/activation.go
@@ -177,14 +177,14 @@ func (b *Builder) StartSmeshing(coinbase types.Address, opts PostSetupOpts) erro
 		return errors.New("already started")
 	}
 
+	b.coinbaseAccount = coinbase
+	ctx, stop := context.WithCancel(b.parentCtx)
+	b.stop = stop
+
 	err := b.postSetupProvider.PrepareInitializer(b.parentCtx, opts)
 	if err != nil {
 		return fmt.Errorf("failed to prepare post initializer: %w", err)
 	}
-
-	b.coinbaseAccount = coinbase
-	ctx, stop := context.WithCancel(b.parentCtx)
-	b.stop = stop
 
 	b.eg.Go(func() error {
 		defer b.started.Store(false)

--- a/activation/activation.go
+++ b/activation/activation.go
@@ -181,7 +181,7 @@ func (b *Builder) StartSmeshing(coinbase types.Address, opts PostSetupOpts) erro
 	ctx, stop := context.WithCancel(b.parentCtx)
 	b.stop = stop
 
-	err := b.postSetupProvider.PrepareInitializer(b.parentCtx, opts)
+	cfg, err := b.postSetupProvider.PrepareInitializer(b.parentCtx, opts)
 	if err != nil {
 		return fmt.Errorf("failed to prepare post initializer: %w", err)
 	}
@@ -198,7 +198,7 @@ func (b *Builder) StartSmeshing(coinbase types.Address, opts PostSetupOpts) erro
 
 		// If start session returns any error other than context.Canceled
 		// (which is how we signal it to stop) then we panic.
-		if err := b.postSetupProvider.StartSession(ctx, opts); err != nil && !errors.Is(err, context.Canceled) {
+		if err := b.postSetupProvider.StartSession(ctx, cfg); err != nil && !errors.Is(err, context.Canceled) {
 			panic(fmt.Sprintf("initialization failed: %v", err))
 		}
 

--- a/activation/activation_test.go
+++ b/activation/activation_test.go
@@ -254,7 +254,7 @@ func TestBuilder_StartSmeshingCoinbase(t *testing.T) {
 	postSetupOpts := PostSetupOpts{}
 	cfg := &SessionConfig{}
 
-	tab.mpost.EXPECT().PrepareInitializer(gomock.Any(), gomock.Any()).Return(cfg, nil).AnyTimes()
+	tab.mpost.EXPECT().InitializerConfig(gomock.Any(), gomock.Any()).Return(cfg, nil).AnyTimes()
 	tab.mpost.EXPECT().StartSession(gomock.Any(), cfg).AnyTimes()
 	tab.mpost.EXPECT().GenerateProof(gomock.Any(), gomock.Any()).AnyTimes()
 	tab.mclock.EXPECT().AwaitLayer(gomock.Any()).Return(make(chan struct{})).AnyTimes()
@@ -272,7 +272,7 @@ func TestBuilder_RestartSmeshing(t *testing.T) {
 	now := time.Now()
 	getBuilder := func(t *testing.T) *Builder {
 		tab := newTestBuilder(t)
-		tab.mpost.EXPECT().PrepareInitializer(gomock.Any(), gomock.Any()).AnyTimes()
+		tab.mpost.EXPECT().InitializerConfig(gomock.Any(), gomock.Any()).AnyTimes()
 		tab.mpost.EXPECT().StartSession(gomock.Any(), gomock.Any()).AnyTimes()
 		tab.mpost.EXPECT().GenerateProof(gomock.Any(), gomock.Any()).AnyTimes()
 		tab.mpost.EXPECT().Reset().AnyTimes()
@@ -321,7 +321,7 @@ func TestBuilder_StopSmeshing_failsWhenNotStarted(t *testing.T) {
 
 func TestBuilder_StopSmeshing_OnPoSTError(t *testing.T) {
 	tab := newTestBuilder(t)
-	tab.mpost.EXPECT().PrepareInitializer(gomock.Any(), gomock.Any()).AnyTimes()
+	tab.mpost.EXPECT().InitializerConfig(gomock.Any(), gomock.Any()).AnyTimes()
 	tab.mpost.EXPECT().StartSession(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	tab.mpost.EXPECT().GenerateProof(gomock.Any(), gomock.Any()).Return(nil, nil, nil).AnyTimes()
 	ch := make(chan struct{})

--- a/activation/activation_test.go
+++ b/activation/activation_test.go
@@ -253,6 +253,7 @@ func TestBuilder_StartSmeshingCoinbase(t *testing.T) {
 	coinbase := types.Address{1, 1, 1}
 	postSetupOpts := PostSetupOpts{}
 
+	tab.mpost.EXPECT().PrepareInitializer(gomock.Any(), gomock.Any()).AnyTimes()
 	tab.mpost.EXPECT().StartSession(gomock.Any(), postSetupOpts).AnyTimes()
 	tab.mpost.EXPECT().GenerateProof(gomock.Any(), gomock.Any()).AnyTimes()
 	tab.mclock.EXPECT().AwaitLayer(gomock.Any()).Return(make(chan struct{})).AnyTimes()
@@ -270,6 +271,7 @@ func TestBuilder_RestartSmeshing(t *testing.T) {
 	now := time.Now()
 	getBuilder := func(t *testing.T) *Builder {
 		tab := newTestBuilder(t)
+		tab.mpost.EXPECT().PrepareInitializer(gomock.Any(), gomock.Any()).AnyTimes()
 		tab.mpost.EXPECT().StartSession(gomock.Any(), gomock.Any()).AnyTimes()
 		tab.mpost.EXPECT().GenerateProof(gomock.Any(), gomock.Any()).AnyTimes()
 		tab.mpost.EXPECT().Reset().AnyTimes()
@@ -318,6 +320,7 @@ func TestBuilder_StopSmeshing_failsWhenNotStarted(t *testing.T) {
 
 func TestBuilder_StopSmeshing_OnPoSTError(t *testing.T) {
 	tab := newTestBuilder(t)
+	tab.mpost.EXPECT().PrepareInitializer(gomock.Any(), gomock.Any()).AnyTimes()
 	tab.mpost.EXPECT().StartSession(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	tab.mpost.EXPECT().GenerateProof(gomock.Any(), gomock.Any()).Return(nil, nil, nil).AnyTimes()
 	ch := make(chan struct{})
@@ -1014,7 +1017,7 @@ func TestBuilder_RetryPublishActivationTx(t *testing.T) {
 
 	select {
 	case <-builderConfirmation:
-	case <-time.After(time.Second):
+	case <-time.After(time.Second * 5):
 		require.FailNow(t, "failed waiting for required number of tries to occur")
 	}
 }

--- a/activation/activation_test.go
+++ b/activation/activation_test.go
@@ -252,9 +252,10 @@ func TestBuilder_StartSmeshingCoinbase(t *testing.T) {
 	tab := newTestBuilder(t)
 	coinbase := types.Address{1, 1, 1}
 	postSetupOpts := PostSetupOpts{}
+	cfg := &SessionConfig{}
 
-	tab.mpost.EXPECT().PrepareInitializer(gomock.Any(), gomock.Any()).AnyTimes()
-	tab.mpost.EXPECT().StartSession(gomock.Any(), postSetupOpts).AnyTimes()
+	tab.mpost.EXPECT().PrepareInitializer(gomock.Any(), gomock.Any()).Return(cfg, nil).AnyTimes()
+	tab.mpost.EXPECT().StartSession(gomock.Any(), cfg).AnyTimes()
 	tab.mpost.EXPECT().GenerateProof(gomock.Any(), gomock.Any()).AnyTimes()
 	tab.mclock.EXPECT().AwaitLayer(gomock.Any()).Return(make(chan struct{})).AnyTimes()
 	require.NoError(t, tab.StartSmeshing(coinbase, postSetupOpts))

--- a/activation/activation_test.go
+++ b/activation/activation_test.go
@@ -252,7 +252,7 @@ func TestBuilder_StartSmeshingCoinbase(t *testing.T) {
 	tab := newTestBuilder(t)
 	coinbase := types.Address{1, 1, 1}
 	postSetupOpts := PostSetupOpts{}
-	cfg := &SessionConfig{}
+	cfg := &InitializationConfig{}
 
 	tab.mpost.EXPECT().InitializerConfig(gomock.Any(), gomock.Any()).Return(cfg, nil).AnyTimes()
 	tab.mpost.EXPECT().StartSession(gomock.Any(), cfg).AnyTimes()

--- a/activation/interface.go
+++ b/activation/interface.go
@@ -58,6 +58,12 @@ type postSetupProvider interface {
 	Status() *PostSetupStatus
 	ComputeProviders() []PostSetupComputeProvider
 	Benchmark(p PostSetupComputeProvider) (int, error)
+	// PrepareInitializer can be called before StartSession to verify if the
+	// given opts are valid. It is not necessary since StartSession also calls
+	// PrepareInitializer, but it provides a means to understand if the post
+	// configuration is valid before kicking off a very long running task
+	// (StartSession can take hours to complete)
+	PrepareInitializer(ctx context.Context, opts PostSetupOpts) error
 	StartSession(context context.Context, opts PostSetupOpts) error
 	Reset() error
 	GenerateProof(ctx context.Context, challenge []byte) (*types.Post, *types.PostMetadata, error)

--- a/activation/interface.go
+++ b/activation/interface.go
@@ -58,12 +58,11 @@ type postSetupProvider interface {
 	Status() *PostSetupStatus
 	ComputeProviders() []PostSetupComputeProvider
 	Benchmark(p PostSetupComputeProvider) (int, error)
-	// PrepareInitializer can be called before StartSession to verify if the
-	// given opts are valid. It is not necessary since StartSession also calls
-	// PrepareInitializer, but it provides a means to understand if the post
-	// configuration is valid before kicking off a very long running task
-	// (StartSession can take hours to complete)
-	PrepareInitializer(ctx context.Context, opts PostSetupOpts) (*SessionConfig, error)
+	// InitializerConfig builds the config to be used by initialization in calls to
+	// StartSession. Having this function be separate from StartSession provides a
+	// means to understand if the post configuration is valid before kicking off a
+	// very long running task (StartSession can take hours to complete).
+	InitializerConfig(ctx context.Context, opts PostSetupOpts) (*SessionConfig, error)
 	StartSession(context context.Context, cfg *SessionConfig) error
 	Reset() error
 	GenerateProof(ctx context.Context, challenge []byte) (*types.Post, *types.PostMetadata, error)

--- a/activation/interface.go
+++ b/activation/interface.go
@@ -62,8 +62,8 @@ type postSetupProvider interface {
 	// StartSession. Having this function be separate from StartSession provides a
 	// means to understand if the post configuration is valid before kicking off a
 	// very long running task (StartSession can take hours to complete).
-	InitializerConfig(ctx context.Context, opts PostSetupOpts) (*SessionConfig, error)
-	StartSession(context context.Context, cfg *SessionConfig) error
+	InitializerConfig(ctx context.Context, opts PostSetupOpts) (*InitializationConfig, error)
+	StartSession(context context.Context, cfg *InitializationConfig) error
 	Reset() error
 	GenerateProof(ctx context.Context, challenge []byte) (*types.Post, *types.PostMetadata, error)
 	CommitmentAtx() (types.ATXID, error)

--- a/activation/interface.go
+++ b/activation/interface.go
@@ -63,8 +63,8 @@ type postSetupProvider interface {
 	// PrepareInitializer, but it provides a means to understand if the post
 	// configuration is valid before kicking off a very long running task
 	// (StartSession can take hours to complete)
-	PrepareInitializer(ctx context.Context, opts PostSetupOpts) error
-	StartSession(context context.Context, opts PostSetupOpts) error
+	PrepareInitializer(ctx context.Context, opts PostSetupOpts) (*SessionConfig, error)
+	StartSession(context context.Context, cfg *SessionConfig) error
 	Reset() error
 	GenerateProof(ctx context.Context, challenge []byte) (*types.Post, *types.PostMetadata, error)
 	CommitmentAtx() (types.ATXID, error)

--- a/activation/mocks.go
+++ b/activation/mocks.go
@@ -561,6 +561,20 @@ func (mr *MockpostSetupProviderMockRecorder) LastOpts() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LastOpts", reflect.TypeOf((*MockpostSetupProvider)(nil).LastOpts))
 }
 
+// PrepareInitializer mocks base method.
+func (m *MockpostSetupProvider) PrepareInitializer(ctx context.Context, opts PostSetupOpts) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PrepareInitializer", ctx, opts)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PrepareInitializer indicates an expected call of PrepareInitializer.
+func (mr *MockpostSetupProviderMockRecorder) PrepareInitializer(ctx, opts interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareInitializer", reflect.TypeOf((*MockpostSetupProvider)(nil).PrepareInitializer), ctx, opts)
+}
+
 // Reset mocks base method.
 func (m *MockpostSetupProvider) Reset() error {
 	m.ctrl.T.Helper()

--- a/activation/mocks.go
+++ b/activation/mocks.go
@@ -562,11 +562,12 @@ func (mr *MockpostSetupProviderMockRecorder) LastOpts() *gomock.Call {
 }
 
 // PrepareInitializer mocks base method.
-func (m *MockpostSetupProvider) PrepareInitializer(ctx context.Context, opts PostSetupOpts) error {
+func (m *MockpostSetupProvider) PrepareInitializer(ctx context.Context, opts PostSetupOpts) (*SessionConfig, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PrepareInitializer", ctx, opts)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(*SessionConfig)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // PrepareInitializer indicates an expected call of PrepareInitializer.
@@ -590,17 +591,17 @@ func (mr *MockpostSetupProviderMockRecorder) Reset() *gomock.Call {
 }
 
 // StartSession mocks base method.
-func (m *MockpostSetupProvider) StartSession(context context.Context, opts PostSetupOpts) error {
+func (m *MockpostSetupProvider) StartSession(context context.Context, cfg *SessionConfig) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StartSession", context, opts)
+	ret := m.ctrl.Call(m, "StartSession", context, cfg)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // StartSession indicates an expected call of StartSession.
-func (mr *MockpostSetupProviderMockRecorder) StartSession(context, opts interface{}) *gomock.Call {
+func (mr *MockpostSetupProviderMockRecorder) StartSession(context, cfg interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartSession", reflect.TypeOf((*MockpostSetupProvider)(nil).StartSession), context, opts)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartSession", reflect.TypeOf((*MockpostSetupProvider)(nil).StartSession), context, cfg)
 }
 
 // Status mocks base method.

--- a/activation/mocks.go
+++ b/activation/mocks.go
@@ -547,6 +547,21 @@ func (mr *MockpostSetupProviderMockRecorder) GenerateProof(ctx, challenge interf
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateProof", reflect.TypeOf((*MockpostSetupProvider)(nil).GenerateProof), ctx, challenge)
 }
 
+// InitializerConfig mocks base method.
+func (m *MockpostSetupProvider) InitializerConfig(ctx context.Context, opts PostSetupOpts) (*SessionConfig, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InitializerConfig", ctx, opts)
+	ret0, _ := ret[0].(*SessionConfig)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// InitializerConfig indicates an expected call of InitializerConfig.
+func (mr *MockpostSetupProviderMockRecorder) InitializerConfig(ctx, opts interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitializerConfig", reflect.TypeOf((*MockpostSetupProvider)(nil).InitializerConfig), ctx, opts)
+}
+
 // LastOpts mocks base method.
 func (m *MockpostSetupProvider) LastOpts() *PostSetupOpts {
 	m.ctrl.T.Helper()
@@ -559,21 +574,6 @@ func (m *MockpostSetupProvider) LastOpts() *PostSetupOpts {
 func (mr *MockpostSetupProviderMockRecorder) LastOpts() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LastOpts", reflect.TypeOf((*MockpostSetupProvider)(nil).LastOpts))
-}
-
-// PrepareInitializer mocks base method.
-func (m *MockpostSetupProvider) PrepareInitializer(ctx context.Context, opts PostSetupOpts) (*SessionConfig, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PrepareInitializer", ctx, opts)
-	ret0, _ := ret[0].(*SessionConfig)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// PrepareInitializer indicates an expected call of PrepareInitializer.
-func (mr *MockpostSetupProviderMockRecorder) PrepareInitializer(ctx, opts interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareInitializer", reflect.TypeOf((*MockpostSetupProvider)(nil).PrepareInitializer), ctx, opts)
 }
 
 // Reset mocks base method.

--- a/activation/mocks.go
+++ b/activation/mocks.go
@@ -548,10 +548,10 @@ func (mr *MockpostSetupProviderMockRecorder) GenerateProof(ctx, challenge interf
 }
 
 // InitializerConfig mocks base method.
-func (m *MockpostSetupProvider) InitializerConfig(ctx context.Context, opts PostSetupOpts) (*SessionConfig, error) {
+func (m *MockpostSetupProvider) InitializerConfig(ctx context.Context, opts PostSetupOpts) (*InitializationConfig, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InitializerConfig", ctx, opts)
-	ret0, _ := ret[0].(*SessionConfig)
+	ret0, _ := ret[0].(*InitializationConfig)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -591,7 +591,7 @@ func (mr *MockpostSetupProviderMockRecorder) Reset() *gomock.Call {
 }
 
 // StartSession mocks base method.
-func (m *MockpostSetupProvider) StartSession(context context.Context, cfg *SessionConfig) error {
+func (m *MockpostSetupProvider) StartSession(context context.Context, cfg *InitializationConfig) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StartSession", context, cfg)
 	ret0, _ := ret[0].(error)

--- a/activation/nipost_test.go
+++ b/activation/nipost_test.go
@@ -97,6 +97,7 @@ func TestPostSetup(t *testing.T) {
 	nb := NewNIPostBuilder(postProvider.id, postProvider, []PoetProvingServiceClient{poetProvider},
 		poetDb, sql.InMemory(), logtest.New(t), postProvider.signer, PoetConfig{}, mclock)
 
+	r.NoError(postProvider.PrepareInitializer(context.Background(), postProvider.opts))
 	r.NoError(postProvider.StartSession(context.Background(), postProvider.opts))
 	t.Cleanup(func() { assert.NoError(t, postProvider.Reset()) })
 
@@ -161,6 +162,7 @@ func spawnPoet(tb testing.TB, opts ...HTTPPoetOpt) *HTTPPoetClient {
 }
 
 func buildNIPost(tb testing.TB, postProvider *testPostManager, postCfg PostConfig, nipostChallenge types.NIPostChallenge, poetDb poetDbAPI) *types.NIPost {
+	require.NoError(tb, postProvider.PrepareInitializer(context.Background(), postProvider.opts))
 	require.NoError(tb, postProvider.StartSession(context.Background(), postProvider.opts))
 	mclock := defaultLayerClockMock(tb)
 
@@ -214,6 +216,7 @@ func TestNewNIPostBuilderNotInitialized(t *testing.T) {
 	r.EqualError(err, "post setup not complete")
 	r.Nil(nipost)
 
+	r.NoError(postProvider.PrepareInitializer(context.Background(), postProvider.opts))
 	r.NoError(postProvider.StartSession(context.Background(), postProvider.opts))
 
 	nipost, _, err = nb.BuildNIPost(context.Background(), &challenge)

--- a/activation/nipost_test.go
+++ b/activation/nipost_test.go
@@ -97,8 +97,9 @@ func TestPostSetup(t *testing.T) {
 	nb := NewNIPostBuilder(postProvider.id, postProvider, []PoetProvingServiceClient{poetProvider},
 		poetDb, sql.InMemory(), logtest.New(t), postProvider.signer, PoetConfig{}, mclock)
 
-	r.NoError(postProvider.PrepareInitializer(context.Background(), postProvider.opts))
-	r.NoError(postProvider.StartSession(context.Background(), postProvider.opts))
+	cfg, err := postProvider.PrepareInitializer(context.Background(), postProvider.opts)
+	r.NoError(err)
+	r.NoError(postProvider.StartSession(context.Background(), cfg))
 	t.Cleanup(func() { assert.NoError(t, postProvider.Reset()) })
 
 	nipost, _, err := nb.BuildNIPost(context.Background(), &challenge)
@@ -162,8 +163,9 @@ func spawnPoet(tb testing.TB, opts ...HTTPPoetOpt) *HTTPPoetClient {
 }
 
 func buildNIPost(tb testing.TB, postProvider *testPostManager, postCfg PostConfig, nipostChallenge types.NIPostChallenge, poetDb poetDbAPI) *types.NIPost {
-	require.NoError(tb, postProvider.PrepareInitializer(context.Background(), postProvider.opts))
-	require.NoError(tb, postProvider.StartSession(context.Background(), postProvider.opts))
+	cfg, err := postProvider.PrepareInitializer(context.Background(), postProvider.opts)
+	require.NoError(tb, err)
+	require.NoError(tb, postProvider.StartSession(context.Background(), cfg))
 	mclock := defaultLayerClockMock(tb)
 
 	epoch := layersPerEpoch * layerDuration
@@ -216,8 +218,9 @@ func TestNewNIPostBuilderNotInitialized(t *testing.T) {
 	r.EqualError(err, "post setup not complete")
 	r.Nil(nipost)
 
-	r.NoError(postProvider.PrepareInitializer(context.Background(), postProvider.opts))
-	r.NoError(postProvider.StartSession(context.Background(), postProvider.opts))
+	cfg, err := postProvider.PrepareInitializer(context.Background(), postProvider.opts)
+	r.NoError(err)
+	r.NoError(postProvider.StartSession(context.Background(), cfg))
 
 	nipost, _, err = nb.BuildNIPost(context.Background(), &challenge)
 	r.NoError(err)

--- a/activation/nipost_test.go
+++ b/activation/nipost_test.go
@@ -97,7 +97,7 @@ func TestPostSetup(t *testing.T) {
 	nb := NewNIPostBuilder(postProvider.id, postProvider, []PoetProvingServiceClient{poetProvider},
 		poetDb, sql.InMemory(), logtest.New(t), postProvider.signer, PoetConfig{}, mclock)
 
-	cfg, err := postProvider.PrepareInitializer(context.Background(), postProvider.opts)
+	cfg, err := postProvider.InitializerConfig(context.Background(), postProvider.opts)
 	r.NoError(err)
 	r.NoError(postProvider.StartSession(context.Background(), cfg))
 	t.Cleanup(func() { assert.NoError(t, postProvider.Reset()) })
@@ -163,7 +163,7 @@ func spawnPoet(tb testing.TB, opts ...HTTPPoetOpt) *HTTPPoetClient {
 }
 
 func buildNIPost(tb testing.TB, postProvider *testPostManager, postCfg PostConfig, nipostChallenge types.NIPostChallenge, poetDb poetDbAPI) *types.NIPost {
-	cfg, err := postProvider.PrepareInitializer(context.Background(), postProvider.opts)
+	cfg, err := postProvider.InitializerConfig(context.Background(), postProvider.opts)
 	require.NoError(tb, err)
 	require.NoError(tb, postProvider.StartSession(context.Background(), cfg))
 	mclock := defaultLayerClockMock(tb)
@@ -218,7 +218,7 @@ func TestNewNIPostBuilderNotInitialized(t *testing.T) {
 	r.EqualError(err, "post setup not complete")
 	r.Nil(nipost)
 
-	cfg, err := postProvider.PrepareInitializer(context.Background(), postProvider.opts)
+	cfg, err := postProvider.InitializerConfig(context.Background(), postProvider.opts)
 	r.NoError(err)
 	r.NoError(postProvider.StartSession(context.Background(), cfg))
 

--- a/activation/post.go
+++ b/activation/post.go
@@ -46,9 +46,10 @@ type PostSetupOpts struct {
 	ComputeBatchSize  uint64              `mapstructure:"smeshing-opts-compute-batch-size"`
 }
 
-// SessionOpts serves as a holder for config generated in PrepareInitializer to
-// be passed to StartSession. It is not intended to be user configurable.
-type SessionConfig struct {
+// InitializationConfig serves as a holder for config generated in
+// InitializerConfig to be passed to StartSession. It is not intended to be
+// user configurable.
+type InitializationConfig struct {
 	init            *initialization.Initializer
 	opts            PostSetupOpts
 	commitmentAtxId types.ATXID
@@ -201,7 +202,7 @@ func (mgr *PostSetupManager) Benchmark(p PostSetupComputeProvider) (int, error) 
 // StartSession in order to retrieve the SessionConfig.
 //
 // Insure that before calling this method, the node is ATX synced.
-func (mgr *PostSetupManager) StartSession(ctx context.Context, cfg *SessionConfig) error {
+func (mgr *PostSetupManager) StartSession(ctx context.Context, cfg *InitializationConfig) error {
 	err := func() error {
 		mgr.mu.Lock()
 		defer mgr.mu.Unlock()
@@ -258,10 +259,10 @@ func (mgr *PostSetupManager) StartSession(ctx context.Context, cfg *SessionConfi
 // StartSession. Having this function be separate from StartSession provides a
 // means to understand if the post configuration is valid before kicking off a
 // very long running task (StartSession can take hours to complete).
-func (mgr *PostSetupManager) InitializerConfig(ctx context.Context, opts PostSetupOpts) (*SessionConfig, error) {
+func (mgr *PostSetupManager) InitializerConfig(ctx context.Context, opts PostSetupOpts) (*InitializationConfig, error) {
 	mgr.mu.Lock()
 	defer mgr.mu.Unlock()
-	cfg := &SessionConfig{}
+	cfg := &InitializationConfig{}
 	cfg.opts = opts
 
 	if cfg.opts.ComputeProviderID == config.BestProviderID {

--- a/activation/post.go
+++ b/activation/post.go
@@ -175,7 +175,11 @@ func (mgr *PostSetupManager) Benchmark(p PostSetupComputeProvider) (int, error) 
 //
 // Ensure that before calling this method, the node is ATX synced.
 func (mgr *PostSetupManager) StartSession(ctx context.Context, opts PostSetupOpts) error {
-	if err := mgr.prepareInitializer(ctx, opts); err != nil {
+	if err := mgr.PrepareInitializer(ctx, opts); err != nil {
+		return err
+	}
+
+	if err := mgr.checkAndSetInProgress(); err != nil {
 		return err
 	}
 
@@ -215,13 +219,19 @@ func (mgr *PostSetupManager) StartSession(ctx context.Context, opts PostSetupOpt
 	return nil
 }
 
-func (mgr *PostSetupManager) prepareInitializer(ctx context.Context, opts PostSetupOpts) error {
+func (mgr *PostSetupManager) checkAndSetInProgress() error {
 	mgr.mu.Lock()
 	defer mgr.mu.Unlock()
-
 	if mgr.state == PostSetupStateInProgress {
 		return fmt.Errorf("post setup session in progress")
 	}
+	mgr.state = PostSetupStateInProgress
+	return nil
+}
+
+func (mgr *PostSetupManager) PrepareInitializer(ctx context.Context, opts PostSetupOpts) error {
+	mgr.mu.Lock()
+	defer mgr.mu.Unlock()
 
 	if opts.ComputeProviderID == config.BestProviderID {
 		p, err := mgr.BestProvider()
@@ -251,7 +261,6 @@ func (mgr *PostSetupManager) prepareInitializer(ctx context.Context, opts PostSe
 		return fmt.Errorf("new initializer: %w", err)
 	}
 
-	mgr.state = PostSetupStateInProgress
 	mgr.init = newInit
 	mgr.lastOpts = &opts
 	return nil

--- a/activation/post.go
+++ b/activation/post.go
@@ -198,8 +198,8 @@ func (mgr *PostSetupManager) Benchmark(p PostSetupComputeProvider) (int, error) 
 
 // StartSession starts (or continues) a PoST session. It supports resuming a
 // previously started session, and will return an error if a session is already
-// in progress. PrepareInitializer should be called prior to calling
-// StartSession in order to retrieve the SessionConfig.
+// in progress. InitializerConfig should be called prior to calling
+// StartSession in order to retrieve the InitializationConfig.
 //
 // Ensure that before calling this method, the node is ATX synced.
 func (mgr *PostSetupManager) StartSession(ctx context.Context, cfg *InitializationConfig) error {

--- a/activation/post.go
+++ b/activation/post.go
@@ -237,9 +237,11 @@ func (mgr *PostSetupManager) StartSession(ctx context.Context, cfg *SessionConfi
 	return nil
 }
 
-// PrepareInitializer constructs the config required to start a session with
-// the given opts, it doesn't modify the state of the PostSetupManager.
-func (mgr *PostSetupManager) PrepareInitializer(ctx context.Context, opts PostSetupOpts) (*SessionConfig, error) {
+// InitializerConfig builds the config to be used by initialization in calls to
+// StartSession. Having this function be separate from StartSession provides a
+// means to understand if the post configuration is valid before kicking off a
+// very long running task (StartSession can take hours to complete).
+func (mgr *PostSetupManager) InitializerConfig(ctx context.Context, opts PostSetupOpts) (*SessionConfig, error) {
 	mgr.mu.Lock()
 	defer mgr.mu.Unlock()
 	cfg := &SessionConfig{}

--- a/activation/post.go
+++ b/activation/post.go
@@ -201,7 +201,7 @@ func (mgr *PostSetupManager) Benchmark(p PostSetupComputeProvider) (int, error) 
 // in progress. PrepareInitializer should be called prior to calling
 // StartSession in order to retrieve the SessionConfig.
 //
-// Insure that before calling this method, the node is ATX synced.
+// Ensure that before calling this method, the node is ATX synced.
 func (mgr *PostSetupManager) StartSession(ctx context.Context, cfg *InitializationConfig) error {
 	err := func() error {
 		mgr.mu.Lock()

--- a/activation/post_test.go
+++ b/activation/post_test.go
@@ -49,6 +49,7 @@ func TestPostSetupManager(t *testing.T) {
 	})
 
 	// Create data.
+	req.NoError(mgr.PrepareInitializer(context.Background(), mgr.opts))
 	req.NoError(mgr.StartSession(context.Background(), mgr.opts))
 	cancel()
 	_ = eg.Wait()
@@ -107,7 +108,7 @@ func TestPostSetupManager_StateError(t *testing.T) {
 
 	mgr := newTestPostManager(t)
 	mgr.opts.NumUnits = 0
-	req.Error(mgr.StartSession(context.Background(), mgr.opts))
+	req.Error(mgr.PrepareInitializer(context.Background(), mgr.opts))
 	// Verify Status returns StateError
 	req.Equal(PostSetupStateError, mgr.Status().State)
 }
@@ -123,6 +124,7 @@ func TestPostSetupManager_InitialStatus(t *testing.T) {
 	req.Zero(status.NumLabelsWritten)
 
 	// Create data.
+	req.NoError(mgr.PrepareInitializer(context.Background(), mgr.opts))
 	req.NoError(mgr.StartSession(context.Background(), mgr.opts))
 	req.Equal(PostSetupStateComplete, mgr.Status().State)
 
@@ -146,6 +148,7 @@ func TestPostSetupManager_GenerateProof(t *testing.T) {
 	req.EqualError(err, errNotComplete.Error())
 
 	// Create data.
+	req.NoError(mgr.PrepareInitializer(context.Background(), mgr.opts))
 	req.NoError(mgr.StartSession(context.Background(), mgr.opts))
 
 	// Generate proof.
@@ -188,6 +191,7 @@ func TestPostSetupManager_VRFNonce(t *testing.T) {
 	req.ErrorIs(err, errNotComplete)
 
 	// Create data.
+	req.NoError(mgr.PrepareInitializer(context.Background(), mgr.opts))
 	req.NoError(mgr.StartSession(context.Background(), mgr.opts))
 
 	// Get nonce.
@@ -214,6 +218,7 @@ func TestPostSetupManager_Stop(t *testing.T) {
 	req.Zero(status.NumLabelsWritten)
 
 	// Create data.
+	req.NoError(mgr.PrepareInitializer(context.Background(), mgr.opts))
 	req.NoError(mgr.StartSession(context.Background(), mgr.opts))
 
 	// Verify state.
@@ -226,6 +231,7 @@ func TestPostSetupManager_Stop(t *testing.T) {
 	req.Equal(PostSetupStateNotStarted, mgr.Status().State)
 
 	// Create data again.
+	req.NoError(mgr.PrepareInitializer(context.Background(), mgr.opts))
 	req.NoError(mgr.StartSession(context.Background(), mgr.opts))
 
 	// Verify state.
@@ -239,6 +245,7 @@ func TestPostSetupManager_Stop_WhileInProgress(t *testing.T) {
 	mgr.opts.MaxFileSize = 4096
 
 	// Create data.
+	req.NoError(mgr.PrepareInitializer(context.Background(), mgr.opts))
 	ctx, cancel := context.WithCancel(context.Background())
 	var eg errgroup.Group
 	eg.Go(func() error {
@@ -261,6 +268,7 @@ func TestPostSetupManager_Stop_WhileInProgress(t *testing.T) {
 	req.LessOrEqual(status.NumLabelsWritten, uint64(mgr.opts.NumUnits)*mgr.cfg.LabelsPerUnit)
 
 	// Continue to create data.
+	req.NoError(mgr.PrepareInitializer(context.Background(), mgr.opts))
 	req.NoError(mgr.StartSession(context.Background(), mgr.opts))
 
 	// Verify status.

--- a/activation/post_test.go
+++ b/activation/post_test.go
@@ -49,7 +49,7 @@ func TestPostSetupManager(t *testing.T) {
 	})
 
 	// Create data.
-	cfg, err := mgr.PrepareInitializer(context.Background(), mgr.opts)
+	cfg, err := mgr.InitializerConfig(context.Background(), mgr.opts)
 	req.NoError(err)
 	req.NoError(mgr.StartSession(context.Background(), cfg))
 	cancel()
@@ -68,10 +68,10 @@ func TestPostSetupManager(t *testing.T) {
 	req.Equal(PostSetupStateComplete, mgr.Status().State)
 }
 
-// Checks that PrepareInitializer returns an error when invalid opts are given.
+// Checks that InitializerConfig returns an error when invalid opts are given.
 // It's not exhaustive since this validation occurs in the post repo codebase
 // and should be fully tested there.
-func TestPostSetupManager_PrepareInitializer(t *testing.T) {
+func TestPostSetupManager_InitializerConfig(t *testing.T) {
 	req := require.New(t)
 
 	mgr := newTestPostManager(t)
@@ -80,7 +80,7 @@ func TestPostSetupManager_PrepareInitializer(t *testing.T) {
 	defer cancel()
 
 	// check no error with good options.
-	_, err := mgr.PrepareInitializer(ctx, mgr.opts)
+	_, err := mgr.InitializerConfig(ctx, mgr.opts)
 	req.NoError(err)
 
 	cfg := config.DefaultConfig()
@@ -88,7 +88,7 @@ func TestPostSetupManager_PrepareInitializer(t *testing.T) {
 	// Check that invalid options return errors
 	opts := mgr.opts
 	opts.NumUnits = cfg.MaxNumUnits + 1
-	_, err = mgr.PrepareInitializer(ctx, opts)
+	_, err = mgr.InitializerConfig(ctx, opts)
 	req.Error(err)
 }
 
@@ -103,7 +103,7 @@ func TestPostSetupManager_InitialStatus(t *testing.T) {
 	req.Zero(status.NumLabelsWritten)
 
 	// Create data.
-	cfg, err := mgr.PrepareInitializer(context.Background(), mgr.opts)
+	cfg, err := mgr.InitializerConfig(context.Background(), mgr.opts)
 	req.NoError(err)
 	req.NoError(mgr.StartSession(context.Background(), cfg))
 	req.Equal(PostSetupStateComplete, mgr.Status().State)
@@ -128,7 +128,7 @@ func TestPostSetupManager_GenerateProof(t *testing.T) {
 	req.EqualError(err, errNotComplete.Error())
 
 	// Create data.
-	cfg, err := mgr.PrepareInitializer(context.Background(), mgr.opts)
+	cfg, err := mgr.InitializerConfig(context.Background(), mgr.opts)
 	req.NoError(err)
 	req.NoError(mgr.StartSession(context.Background(), cfg))
 
@@ -172,7 +172,7 @@ func TestPostSetupManager_VRFNonce(t *testing.T) {
 	req.ErrorIs(err, errNotComplete)
 
 	// Create data.
-	cfg, err := mgr.PrepareInitializer(context.Background(), mgr.opts)
+	cfg, err := mgr.InitializerConfig(context.Background(), mgr.opts)
 	req.NoError(err)
 	req.NoError(mgr.StartSession(context.Background(), cfg))
 
@@ -200,7 +200,7 @@ func TestPostSetupManager_Stop(t *testing.T) {
 	req.Zero(status.NumLabelsWritten)
 
 	// Create data.
-	cfg, err := mgr.PrepareInitializer(context.Background(), mgr.opts)
+	cfg, err := mgr.InitializerConfig(context.Background(), mgr.opts)
 	req.NoError(err)
 	req.NoError(mgr.StartSession(context.Background(), cfg))
 
@@ -226,7 +226,7 @@ func TestPostSetupManager_Stop_WhileInProgress(t *testing.T) {
 	mgr := newTestPostManager(t)
 	mgr.opts.MaxFileSize = 4096
 
-	cfg, err := mgr.PrepareInitializer(context.Background(), mgr.opts)
+	cfg, err := mgr.InitializerConfig(context.Background(), mgr.opts)
 	req.NoError(err)
 	// Create data.
 	ctx, cancel := context.WithCancel(context.Background())

--- a/config/presets/presets_test.go
+++ b/config/presets/presets_test.go
@@ -34,7 +34,7 @@ func TestCanGeneratePOST(t *testing.T) {
 			)
 			req.NoError(err)
 
-			cfg, err := mgr.InitializerConfig(context.Background(), activation.DefaultPostSetupOpts())
+			cfg, err := mgr.InitializerConfig(context.Background(), opts)
 			req.NoError(err)
 			req.NoError(mgr.StartSession(context.Background(), cfg))
 

--- a/config/presets/presets_test.go
+++ b/config/presets/presets_test.go
@@ -28,7 +28,7 @@ func TestCanGeneratePOST(t *testing.T) {
 			mgr, err := activation.NewPostSetupManager(types.EmptyNodeID, params.POST, logtest.New(t), cdb, goldenATXID)
 			req.NoError(err)
 
-			cfg, err := mgr.PrepareInitializer(context.Background(), activation.DefaultPostSetupOpts())
+			cfg, err := mgr.InitializerConfig(context.Background(), activation.DefaultPostSetupOpts())
 			req.NoError(err)
 			req.NoError(mgr.StartSession(context.Background(), cfg))
 

--- a/config/presets/presets_test.go
+++ b/config/presets/presets_test.go
@@ -27,7 +27,10 @@ func TestCanGeneratePOST(t *testing.T) {
 
 			mgr, err := activation.NewPostSetupManager(types.EmptyNodeID, params.POST, logtest.New(t), cdb, goldenATXID)
 			req.NoError(err)
-			req.NoError(mgr.StartSession(context.Background(), opts))
+
+			cfg, err := mgr.PrepareInitializer(context.Background(), activation.DefaultPostSetupOpts())
+			req.NoError(err)
+			req.NoError(mgr.StartSession(context.Background(), cfg))
 
 			_, _, err = mgr.GenerateProof(context.Background(), ch)
 			req.NoError(err)


### PR DESCRIPTION
## Motivation

Closes https://github.com/spacemeshos/go-spacemesh/issues/4292

## Changes
This change removes the `prepareInitializer` method of the `PostSetupManager` and instead adds `InitializerConfig` which  when called generates, validates and returns the config to be used for POS initialization. `StartSession` has been modified to accept the `InitializationConfig` generated by `InitializerConfig`. Having this separate step allows for up front validation of post params before kicking off the long running task of initialisation, which allows the start smeshing api call to directly return an error to the caller if there is a problem with the smeshing options. Note `InitializerConfig` doesn't modify any state in the `PostSetupManager`, which makes it safe to call concurrently while initialization is occurring.


Also this change updates `Builder.StartSmeshing` to panic if the smeshing operation fails, this ensures that the node will crash if there is any problem with the smeshing background task.

## Test Plan
Updated existing tests and added a test to check that `InitializerConfig` returns an error if given invalid config.

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
