### PR TITLE
[Merged by Bors] - activation: reasonable retries for communication with poet

### DIFF
--- a/activation/poet.go
+++ b/activation/poet.go
@@ -69,8 +69,8 @@ func withCustomHttpClient(client *http.Client) PoetClientOpts {
 func NewHTTPPoetClient(baseUrl string, cfg PoetConfig, opts ...PoetClientOpts) (*HTTPPoetClient, error) {
 	client := &retryablehttp.Client{
 		RetryMax:     10,
-		RetryWaitMin: cfg.CycleGap / 100,
-		RetryWaitMax: cfg.CycleGap / 10,
+		RetryWaitMin: cfg.GracePeriod / 100,
+		RetryWaitMax: cfg.GracePeriod / 10,
 		Backoff:      retryablehttp.LinearJitterBackoff,
 		CheckRetry:   checkRetry,
 	}

--- a/activation/poet_test_harness.go
+++ b/activation/poet_test_harness.go
@@ -70,8 +70,9 @@ func NewHTTPPoetTestHarness(ctx context.Context, poetdir string, opts ...HTTPPoe
 	}
 
 	client, err := NewHTTPPoetClient(url.String(), PoetConfig{
-		PhaseShift: cfg.Service.PhaseShift,
-		CycleGap:   cfg.Service.CycleGap,
+		PhaseShift:  cfg.Service.PhaseShift,
+		CycleGap:    cfg.Service.CycleGap,
+		GracePeriod: cfg.Service.CycleGap / 2,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
cycle gap wasn't meant to be spent on requests to poet, it has somewhat different considerations when configured.
automatic retries are still useful, but we can set them to smaller values to tolerate common http problems. if they are not sufficient, we will retry using outer atx builder loop