### PR TITLE
[Merged by Bors] - Ensure start smeshing cannot fail silently (take 2)

### DIFF
--- a/activation/activation.go
+++ b/activation/activation.go
@@ -163,17 +163,23 @@ func (b *Builder) Smeshing() bool {
 	return b.started.Load()
 }
 
-// StartSmeshing is the main entry point of the atx builder.
-// It runs the main loop of the builder and shouldn't be called more than once.
-// If the post data is incomplete or missing, data creation
-// session will be preceded. Changing of the post potions (e.g., number of labels),
-// after initial setup, is supported.
+// StartSmeshing is the main entry point of the atx builder. It runs the main
+// loop of the builder in a new go-routine and shouldn't be called more than
+// once without calling StopSmeshing in between. If the post data is incomplete
+// or missing, data creation session will be preceded. Changing of the post
+// options (e.g., number of labels), after initial setup, is supported. If data
+// creation fails for any reason then the go-routine will panic.
 func (b *Builder) StartSmeshing(coinbase types.Address, opts PostSetupOpts) error {
 	b.smeshingMutex.Lock()
 	defer b.smeshingMutex.Unlock()
 
 	if !b.started.CompareAndSwap(false, true) {
 		return errors.New("already started")
+	}
+
+	err := b.postSetupProvider.PrepareInitializer(b.parentCtx, opts)
+	if err != nil {
+		return fmt.Errorf("failed to prepare post initializer: %w", err)
 	}
 
 	b.coinbaseAccount = coinbase
@@ -190,8 +196,10 @@ func (b *Builder) StartSmeshing(coinbase types.Address, opts PostSetupOpts) erro
 			// ensure we are ATX synced before starting the PoST Session
 		}
 
-		if err := b.postSetupProvider.StartSession(ctx, opts); err != nil {
-			return err
+		// If start session returns any error other than context.Canceled
+		// (which is how we signal it to stop) then we panic.
+		if err := b.postSetupProvider.StartSession(ctx, opts); err != nil && !errors.Is(err, context.Canceled) {
+			panic(fmt.Sprintf("initialization failed: %v", err))
 		}
 
 		b.run(ctx)

--- a/activation/activation.go
+++ b/activation/activation.go
@@ -198,7 +198,7 @@ func (b *Builder) StartSmeshing(coinbase types.Address, opts PostSetupOpts) erro
 
 		// If start session returns any error other than context.Canceled
 		// (which is how we signal it to stop) then we panic.
-		if err := b.postSetupProvider.StartSession(ctx, opts); err != nil && !errors.Is(err, context.Canceled) {
+		if err := b.postSetupProvider.StartSession(ctx); err != nil && !errors.Is(err, context.Canceled) {
 			panic(fmt.Sprintf("initialization failed: %v", err))
 		}
 

--- a/activation/activation.go
+++ b/activation/activation.go
@@ -177,14 +177,14 @@ func (b *Builder) StartSmeshing(coinbase types.Address, opts PostSetupOpts) erro
 		return errors.New("already started")
 	}
 
+	b.coinbaseAccount = coinbase
+	ctx, stop := context.WithCancel(b.parentCtx)
+	b.stop = stop
+
 	err := b.postSetupProvider.PrepareInitializer(b.parentCtx, opts)
 	if err != nil {
 		return fmt.Errorf("failed to prepare post initializer: %w", err)
 	}
-
-	b.coinbaseAccount = coinbase
-	ctx, stop := context.WithCancel(b.parentCtx)
-	b.stop = stop
 
 	b.eg.Go(func() error {
 		defer b.started.Store(false)

--- a/activation/activation.go
+++ b/activation/activation.go
@@ -199,7 +199,7 @@ func (b *Builder) StartSmeshing(coinbase types.Address, opts PostSetupOpts) erro
 		// If start session returns any error other than context.Canceled
 		// (which is how we signal it to stop) then we panic.
 		if err := b.postSetupProvider.StartSession(ctx); err != nil && !errors.Is(err, context.Canceled) {
-			panic(fmt.Sprintf("initialization failed: %v", err))
+			b.log.Panic(fmt.Sprintf("initialization failed: %v", err))
 		}
 
 		b.run(ctx)

--- a/activation/activation_test.go
+++ b/activation/activation_test.go
@@ -253,6 +253,7 @@ func TestBuilder_StartSmeshingCoinbase(t *testing.T) {
 	coinbase := types.Address{1, 1, 1}
 	postSetupOpts := PostSetupOpts{}
 
+	tab.mpost.EXPECT().PrepareInitializer(gomock.Any(), gomock.Any()).AnyTimes()
 	tab.mpost.EXPECT().StartSession(gomock.Any(), postSetupOpts).AnyTimes()
 	tab.mpost.EXPECT().GenerateProof(gomock.Any(), gomock.Any()).AnyTimes()
 	tab.mclock.EXPECT().AwaitLayer(gomock.Any()).Return(make(chan struct{})).AnyTimes()
@@ -270,6 +271,7 @@ func TestBuilder_RestartSmeshing(t *testing.T) {
 	now := time.Now()
 	getBuilder := func(t *testing.T) *Builder {
 		tab := newTestBuilder(t)
+		tab.mpost.EXPECT().PrepareInitializer(gomock.Any(), gomock.Any()).AnyTimes()
 		tab.mpost.EXPECT().StartSession(gomock.Any(), gomock.Any()).AnyTimes()
 		tab.mpost.EXPECT().GenerateProof(gomock.Any(), gomock.Any()).AnyTimes()
 		tab.mpost.EXPECT().Reset().AnyTimes()
@@ -318,6 +320,7 @@ func TestBuilder_StopSmeshing_failsWhenNotStarted(t *testing.T) {
 
 func TestBuilder_StopSmeshing_OnPoSTError(t *testing.T) {
 	tab := newTestBuilder(t)
+	tab.mpost.EXPECT().PrepareInitializer(gomock.Any(), gomock.Any()).AnyTimes()
 	tab.mpost.EXPECT().StartSession(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	tab.mpost.EXPECT().GenerateProof(gomock.Any(), gomock.Any()).Return(nil, nil, nil).AnyTimes()
 	ch := make(chan struct{})
@@ -1014,7 +1017,7 @@ func TestBuilder_RetryPublishActivationTx(t *testing.T) {
 
 	select {
 	case <-builderConfirmation:
-	case <-time.After(time.Second):
+	case <-time.After(time.Second * 5):
 		require.FailNow(t, "failed waiting for required number of tries to occur")
 	}
 }

--- a/activation/activation_test.go
+++ b/activation/activation_test.go
@@ -254,7 +254,7 @@ func TestBuilder_StartSmeshingCoinbase(t *testing.T) {
 	postSetupOpts := PostSetupOpts{}
 
 	tab.mpost.EXPECT().PrepareInitializer(gomock.Any(), gomock.Any()).AnyTimes()
-	tab.mpost.EXPECT().StartSession(gomock.Any(), postSetupOpts).AnyTimes()
+	tab.mpost.EXPECT().StartSession(gomock.Any()).AnyTimes()
 	tab.mpost.EXPECT().GenerateProof(gomock.Any(), gomock.Any()).AnyTimes()
 	tab.mclock.EXPECT().AwaitLayer(gomock.Any()).Return(make(chan struct{})).AnyTimes()
 	require.NoError(t, tab.StartSmeshing(coinbase, postSetupOpts))
@@ -272,7 +272,7 @@ func TestBuilder_RestartSmeshing(t *testing.T) {
 	getBuilder := func(t *testing.T) *Builder {
 		tab := newTestBuilder(t)
 		tab.mpost.EXPECT().PrepareInitializer(gomock.Any(), gomock.Any()).AnyTimes()
-		tab.mpost.EXPECT().StartSession(gomock.Any(), gomock.Any()).AnyTimes()
+		tab.mpost.EXPECT().StartSession(gomock.Any()).AnyTimes()
 		tab.mpost.EXPECT().GenerateProof(gomock.Any(), gomock.Any()).AnyTimes()
 		tab.mpost.EXPECT().Reset().AnyTimes()
 		ch := make(chan struct{})
@@ -321,7 +321,7 @@ func TestBuilder_StopSmeshing_failsWhenNotStarted(t *testing.T) {
 func TestBuilder_StopSmeshing_OnPoSTError(t *testing.T) {
 	tab := newTestBuilder(t)
 	tab.mpost.EXPECT().PrepareInitializer(gomock.Any(), gomock.Any()).AnyTimes()
-	tab.mpost.EXPECT().StartSession(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	tab.mpost.EXPECT().StartSession(gomock.Any()).Return(nil).AnyTimes()
 	tab.mpost.EXPECT().GenerateProof(gomock.Any(), gomock.Any()).Return(nil, nil, nil).AnyTimes()
 	ch := make(chan struct{})
 	close(ch)

--- a/activation/interface.go
+++ b/activation/interface.go
@@ -58,6 +58,12 @@ type postSetupProvider interface {
 	Status() *PostSetupStatus
 	ComputeProviders() []PostSetupComputeProvider
 	Benchmark(p PostSetupComputeProvider) (int, error)
+	// PrepareInitializer can be called before StartSession to verify if the
+	// given opts are valid. It is not necessary since StartSession also calls
+	// PrepareInitializer, but it provides a means to understand if the post
+	// configuration is valid before kicking off a very long running task
+	// (StartSession can take hours to complete)
+	PrepareInitializer(ctx context.Context, opts PostSetupOpts) error
 	StartSession(context context.Context, opts PostSetupOpts) error
 	Reset() error
 	GenerateProof(ctx context.Context, challenge []byte) (*types.Post, *types.PostMetadata, error)

--- a/activation/interface.go
+++ b/activation/interface.go
@@ -58,13 +58,8 @@ type postSetupProvider interface {
 	Status() *PostSetupStatus
 	ComputeProviders() []PostSetupComputeProvider
 	Benchmark(p PostSetupComputeProvider) (int, error)
-	// PrepareInitializer can be called before StartSession to verify if the
-	// given opts are valid. It is not necessary since StartSession also calls
-	// PrepareInitializer, but it provides a means to understand if the post
-	// configuration is valid before kicking off a very long running task
-	// (StartSession can take hours to complete)
 	PrepareInitializer(ctx context.Context, opts PostSetupOpts) error
-	StartSession(context context.Context, opts PostSetupOpts) error
+	StartSession(context context.Context) error
 	Reset() error
 	GenerateProof(ctx context.Context, challenge []byte) (*types.Post, *types.PostMetadata, error)
 	CommitmentAtx() (types.ATXID, error)

--- a/activation/mocks.go
+++ b/activation/mocks.go
@@ -561,6 +561,20 @@ func (mr *MockpostSetupProviderMockRecorder) LastOpts() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LastOpts", reflect.TypeOf((*MockpostSetupProvider)(nil).LastOpts))
 }
 
+// PrepareInitializer mocks base method.
+func (m *MockpostSetupProvider) PrepareInitializer(ctx context.Context, opts PostSetupOpts) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PrepareInitializer", ctx, opts)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PrepareInitializer indicates an expected call of PrepareInitializer.
+func (mr *MockpostSetupProviderMockRecorder) PrepareInitializer(ctx, opts interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareInitializer", reflect.TypeOf((*MockpostSetupProvider)(nil).PrepareInitializer), ctx, opts)
+}
+
 // Reset mocks base method.
 func (m *MockpostSetupProvider) Reset() error {
 	m.ctrl.T.Helper()

--- a/activation/mocks.go
+++ b/activation/mocks.go
@@ -590,17 +590,17 @@ func (mr *MockpostSetupProviderMockRecorder) Reset() *gomock.Call {
 }
 
 // StartSession mocks base method.
-func (m *MockpostSetupProvider) StartSession(context context.Context, opts PostSetupOpts) error {
+func (m *MockpostSetupProvider) StartSession(context context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StartSession", context, opts)
+	ret := m.ctrl.Call(m, "StartSession", context)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // StartSession indicates an expected call of StartSession.
-func (mr *MockpostSetupProviderMockRecorder) StartSession(context, opts interface{}) *gomock.Call {
+func (mr *MockpostSetupProviderMockRecorder) StartSession(context interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartSession", reflect.TypeOf((*MockpostSetupProvider)(nil).StartSession), context, opts)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartSession", reflect.TypeOf((*MockpostSetupProvider)(nil).StartSession), context)
 }
 
 // Status mocks base method.

--- a/activation/nipost_test.go
+++ b/activation/nipost_test.go
@@ -98,6 +98,7 @@ func TestPostSetup(t *testing.T) {
 	nb := NewNIPostBuilder(postProvider.id, postProvider, []PoetProvingServiceClient{poetProvider},
 		poetDb, sql.InMemory(), logtest.New(t), postProvider.signer, PoetConfig{}, mclock)
 
+	r.NoError(postProvider.PrepareInitializer(context.Background(), postProvider.opts))
 	r.NoError(postProvider.StartSession(context.Background(), postProvider.opts))
 	t.Cleanup(func() { assert.NoError(t, postProvider.Reset()) })
 
@@ -162,6 +163,7 @@ func spawnPoet(tb testing.TB, opts ...HTTPPoetOpt) *HTTPPoetClient {
 }
 
 func buildNIPost(tb testing.TB, postProvider *testPostManager, postCfg PostConfig, nipostChallenge types.NIPostChallenge, poetDb poetDbAPI) *types.NIPost {
+	require.NoError(tb, postProvider.PrepareInitializer(context.Background(), postProvider.opts))
 	require.NoError(tb, postProvider.StartSession(context.Background(), postProvider.opts))
 	mclock := defaultLayerClockMock(tb)
 
@@ -215,6 +217,7 @@ func TestNewNIPostBuilderNotInitialized(t *testing.T) {
 	r.EqualError(err, "post setup not complete")
 	r.Nil(nipost)
 
+	r.NoError(postProvider.PrepareInitializer(context.Background(), postProvider.opts))
 	r.NoError(postProvider.StartSession(context.Background(), postProvider.opts))
 
 	nipost, _, err = nb.BuildNIPost(context.Background(), &challenge)

--- a/activation/nipost_test.go
+++ b/activation/nipost_test.go
@@ -99,7 +99,7 @@ func TestPostSetup(t *testing.T) {
 		poetDb, sql.InMemory(), logtest.New(t), postProvider.signer, PoetConfig{}, mclock)
 
 	r.NoError(postProvider.PrepareInitializer(context.Background(), postProvider.opts))
-	r.NoError(postProvider.StartSession(context.Background(), postProvider.opts))
+	r.NoError(postProvider.StartSession(context.Background()))
 	t.Cleanup(func() { assert.NoError(t, postProvider.Reset()) })
 
 	nipost, _, err := nb.BuildNIPost(context.Background(), &challenge)
@@ -164,7 +164,7 @@ func spawnPoet(tb testing.TB, opts ...HTTPPoetOpt) *HTTPPoetClient {
 
 func buildNIPost(tb testing.TB, postProvider *testPostManager, postCfg PostConfig, nipostChallenge types.NIPostChallenge, poetDb poetDbAPI) *types.NIPost {
 	require.NoError(tb, postProvider.PrepareInitializer(context.Background(), postProvider.opts))
-	require.NoError(tb, postProvider.StartSession(context.Background(), postProvider.opts))
+	require.NoError(tb, postProvider.StartSession(context.Background()))
 	mclock := defaultLayerClockMock(tb)
 
 	epoch := layersPerEpoch * layerDuration
@@ -218,7 +218,7 @@ func TestNewNIPostBuilderNotInitialized(t *testing.T) {
 	r.Nil(nipost)
 
 	r.NoError(postProvider.PrepareInitializer(context.Background(), postProvider.opts))
-	r.NoError(postProvider.StartSession(context.Background(), postProvider.opts))
+	r.NoError(postProvider.StartSession(context.Background()))
 
 	nipost, _, err = nb.BuildNIPost(context.Background(), &challenge)
 	r.NoError(err)

--- a/activation/post.go
+++ b/activation/post.go
@@ -192,7 +192,7 @@ func (mgr *PostSetupManager) Benchmark(p PostSetupComputeProvider) (int, error) 
 // previously started session, and will return an error if a session is already
 // in progress. It must be ensured that PrepareInitializer is called once
 // before each call to StartSession and that the node is ATX synced.
-func (mgr *PostSetupManager) StartSession(ctx context.Context, opts PostSetupOpts) error {
+func (mgr *PostSetupManager) StartSession(ctx context.Context) error {
 	// Ensure only one goroutine can execute initialization at a time.
 	err := func() error {
 		mgr.mu.Lock()
@@ -209,10 +209,10 @@ func (mgr *PostSetupManager) StartSession(ctx context.Context, opts PostSetupOpt
 	mgr.logger.With().Info("post setup session starting",
 		log.String("node_id", mgr.id.String()),
 		log.String("commitment_atx", mgr.commitmentAtxId.String()),
-		log.String("data_dir", opts.DataDir),
-		log.String("num_units", fmt.Sprintf("%d", opts.NumUnits)),
+		log.String("data_dir", mgr.lastOpts.DataDir),
+		log.String("num_units", fmt.Sprintf("%d", mgr.lastOpts.NumUnits)),
 		log.String("labels_per_unit", fmt.Sprintf("%d", mgr.cfg.LabelsPerUnit)),
-		log.String("provider", fmt.Sprintf("%d", opts.ComputeProviderID)),
+		log.String("provider", fmt.Sprintf("%d", mgr.lastOpts.ComputeProviderID)),
 	)
 
 	err = mgr.init.Initialize(ctx)
@@ -233,10 +233,10 @@ func (mgr *PostSetupManager) StartSession(ctx context.Context, opts PostSetupOpt
 	mgr.logger.With().Info("post setup completed",
 		log.String("node_id", mgr.id.String()),
 		log.String("commitment_atx", mgr.commitmentAtxId.String()),
-		log.String("data_dir", opts.DataDir),
-		log.String("num_units", fmt.Sprintf("%d", opts.NumUnits)),
+		log.String("data_dir", mgr.lastOpts.DataDir),
+		log.String("num_units", fmt.Sprintf("%d", mgr.lastOpts.NumUnits)),
 		log.String("labels_per_unit", fmt.Sprintf("%d", mgr.cfg.LabelsPerUnit)),
-		log.String("provider", fmt.Sprintf("%d", opts.ComputeProviderID)),
+		log.String("provider", fmt.Sprintf("%d", mgr.lastOpts.ComputeProviderID)),
 	)
 	mgr.state = PostSetupStateComplete
 	return nil

--- a/activation/post_test.go
+++ b/activation/post_test.go
@@ -49,6 +49,7 @@ func TestPostSetupManager(t *testing.T) {
 	})
 
 	// Create data.
+	req.NoError(mgr.PrepareInitializer(context.Background(), mgr.opts))
 	req.NoError(mgr.StartSession(context.Background(), mgr.opts))
 	cancel()
 	_ = eg.Wait()
@@ -56,12 +57,14 @@ func TestPostSetupManager(t *testing.T) {
 	req.Equal(PostSetupStateComplete, mgr.Status().State)
 
 	// Create data (same opts).
+	req.NoError(mgr.PrepareInitializer(context.Background(), mgr.opts))
 	req.NoError(mgr.StartSession(context.Background(), mgr.opts))
 
 	// Cleanup.
 	req.NoError(mgr.Reset())
 
 	// Create data (same opts, after deletion).
+	req.NoError(mgr.PrepareInitializer(context.Background(), mgr.opts))
 	req.NoError(mgr.StartSession(context.Background(), mgr.opts))
 	req.Equal(PostSetupStateComplete, mgr.Status().State)
 }
@@ -107,7 +110,7 @@ func TestPostSetupManager_StateError(t *testing.T) {
 
 	mgr := newTestPostManager(t)
 	mgr.opts.NumUnits = 0
-	req.Error(mgr.StartSession(context.Background(), mgr.opts))
+	req.Error(mgr.PrepareInitializer(context.Background(), mgr.opts))
 	// Verify Status returns StateError
 	req.Equal(PostSetupStateError, mgr.Status().State)
 }
@@ -123,6 +126,7 @@ func TestPostSetupManager_InitialStatus(t *testing.T) {
 	req.Zero(status.NumLabelsWritten)
 
 	// Create data.
+	req.NoError(mgr.PrepareInitializer(context.Background(), mgr.opts))
 	req.NoError(mgr.StartSession(context.Background(), mgr.opts))
 	req.Equal(PostSetupStateComplete, mgr.Status().State)
 
@@ -146,6 +150,7 @@ func TestPostSetupManager_GenerateProof(t *testing.T) {
 	req.EqualError(err, errNotComplete.Error())
 
 	// Create data.
+	req.NoError(mgr.PrepareInitializer(context.Background(), mgr.opts))
 	req.NoError(mgr.StartSession(context.Background(), mgr.opts))
 
 	// Generate proof.
@@ -188,6 +193,7 @@ func TestPostSetupManager_VRFNonce(t *testing.T) {
 	req.ErrorIs(err, errNotComplete)
 
 	// Create data.
+	req.NoError(mgr.PrepareInitializer(context.Background(), mgr.opts))
 	req.NoError(mgr.StartSession(context.Background(), mgr.opts))
 
 	// Get nonce.
@@ -214,6 +220,7 @@ func TestPostSetupManager_Stop(t *testing.T) {
 	req.Zero(status.NumLabelsWritten)
 
 	// Create data.
+	req.NoError(mgr.PrepareInitializer(context.Background(), mgr.opts))
 	req.NoError(mgr.StartSession(context.Background(), mgr.opts))
 
 	// Verify state.
@@ -226,6 +233,7 @@ func TestPostSetupManager_Stop(t *testing.T) {
 	req.Equal(PostSetupStateNotStarted, mgr.Status().State)
 
 	// Create data again.
+	req.NoError(mgr.PrepareInitializer(context.Background(), mgr.opts))
 	req.NoError(mgr.StartSession(context.Background(), mgr.opts))
 
 	// Verify state.
@@ -239,6 +247,7 @@ func TestPostSetupManager_Stop_WhileInProgress(t *testing.T) {
 	mgr.opts.MaxFileSize = 4096
 
 	// Create data.
+	req.NoError(mgr.PrepareInitializer(context.Background(), mgr.opts))
 	ctx, cancel := context.WithCancel(context.Background())
 	var eg errgroup.Group
 	eg.Go(func() error {
@@ -261,6 +270,7 @@ func TestPostSetupManager_Stop_WhileInProgress(t *testing.T) {
 	req.LessOrEqual(status.NumLabelsWritten, uint64(mgr.opts.NumUnits)*mgr.cfg.LabelsPerUnit)
 
 	// Continue to create data.
+	req.NoError(mgr.PrepareInitializer(context.Background(), mgr.opts))
 	req.NoError(mgr.StartSession(context.Background(), mgr.opts))
 
 	// Verify status.

--- a/activation/post_test.go
+++ b/activation/post_test.go
@@ -50,7 +50,7 @@ func TestPostSetupManager(t *testing.T) {
 
 	// Create data.
 	req.NoError(mgr.PrepareInitializer(context.Background(), mgr.opts))
-	req.NoError(mgr.StartSession(context.Background(), mgr.opts))
+	req.NoError(mgr.StartSession(context.Background()))
 	cancel()
 	_ = eg.Wait()
 
@@ -58,14 +58,14 @@ func TestPostSetupManager(t *testing.T) {
 
 	// Create data (same opts).
 	req.NoError(mgr.PrepareInitializer(context.Background(), mgr.opts))
-	req.NoError(mgr.StartSession(context.Background(), mgr.opts))
+	req.NoError(mgr.StartSession(context.Background()))
 
 	// Cleanup.
 	req.NoError(mgr.Reset())
 
 	// Create data (same opts, after deletion).
 	req.NoError(mgr.PrepareInitializer(context.Background(), mgr.opts))
-	req.NoError(mgr.StartSession(context.Background(), mgr.opts))
+	req.NoError(mgr.StartSession(context.Background()))
 	req.Equal(PostSetupStateComplete, mgr.Status().State)
 }
 
@@ -127,7 +127,7 @@ func TestPostSetupManager_InitialStatus(t *testing.T) {
 
 	// Create data.
 	req.NoError(mgr.PrepareInitializer(context.Background(), mgr.opts))
-	req.NoError(mgr.StartSession(context.Background(), mgr.opts))
+	req.NoError(mgr.StartSession(context.Background()))
 	req.Equal(PostSetupStateComplete, mgr.Status().State)
 
 	// Re-instantiate `PostSetupManager`.
@@ -151,7 +151,7 @@ func TestPostSetupManager_GenerateProof(t *testing.T) {
 
 	// Create data.
 	req.NoError(mgr.PrepareInitializer(context.Background(), mgr.opts))
-	req.NoError(mgr.StartSession(context.Background(), mgr.opts))
+	req.NoError(mgr.StartSession(context.Background()))
 
 	// Generate proof.
 	p, m, err := mgr.GenerateProof(context.Background(), ch)
@@ -194,7 +194,7 @@ func TestPostSetupManager_VRFNonce(t *testing.T) {
 
 	// Create data.
 	req.NoError(mgr.PrepareInitializer(context.Background(), mgr.opts))
-	req.NoError(mgr.StartSession(context.Background(), mgr.opts))
+	req.NoError(mgr.StartSession(context.Background()))
 
 	// Get nonce.
 	nonce, err := mgr.VRFNonce()
@@ -221,7 +221,7 @@ func TestPostSetupManager_Stop(t *testing.T) {
 
 	// Create data.
 	req.NoError(mgr.PrepareInitializer(context.Background(), mgr.opts))
-	req.NoError(mgr.StartSession(context.Background(), mgr.opts))
+	req.NoError(mgr.StartSession(context.Background()))
 
 	// Verify state.
 	req.Equal(PostSetupStateComplete, mgr.Status().State)
@@ -234,7 +234,7 @@ func TestPostSetupManager_Stop(t *testing.T) {
 
 	// Create data again.
 	req.NoError(mgr.PrepareInitializer(context.Background(), mgr.opts))
-	req.NoError(mgr.StartSession(context.Background(), mgr.opts))
+	req.NoError(mgr.StartSession(context.Background()))
 
 	// Verify state.
 	req.Equal(PostSetupStateComplete, mgr.Status().State)
@@ -251,7 +251,7 @@ func TestPostSetupManager_Stop_WhileInProgress(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	var eg errgroup.Group
 	eg.Go(func() error {
-		return mgr.StartSession(ctx, mgr.opts)
+		return mgr.StartSession(ctx)
 	})
 
 	// Verify the intermediate status.
@@ -271,7 +271,7 @@ func TestPostSetupManager_Stop_WhileInProgress(t *testing.T) {
 
 	// Continue to create data.
 	req.NoError(mgr.PrepareInitializer(context.Background(), mgr.opts))
-	req.NoError(mgr.StartSession(context.Background(), mgr.opts))
+	req.NoError(mgr.StartSession(context.Background()))
 
 	// Verify status.
 	status = mgr.Status()

--- a/config/presets/presets_test.go
+++ b/config/presets/presets_test.go
@@ -33,6 +33,7 @@ func TestCanGeneratePOST(t *testing.T) {
 				activation.DefaultPostProvingOpts(),
 			)
 			req.NoError(err)
+			req.NoError(mgr.PrepareInitializer(context.Background(), opts))
 			req.NoError(mgr.StartSession(context.Background()))
 
 			_, _, err = mgr.GenerateProof(context.Background(), ch)

--- a/config/presets/presets_test.go
+++ b/config/presets/presets_test.go
@@ -33,7 +33,7 @@ func TestCanGeneratePOST(t *testing.T) {
 				activation.DefaultPostProvingOpts(),
 			)
 			req.NoError(err)
-			req.NoError(mgr.StartSession(context.Background(), opts))
+			req.NoError(mgr.StartSession(context.Background()))
 
 			_, _, err = mgr.GenerateProof(context.Background(), ch)
 			req.NoError(err)


### PR DESCRIPTION
## Motivation

Closes https://github.com/spacemeshos/go-spacemesh/issues/4292

## Changes

This change moves the  `prepareInitializer` method of `PostSetupManager.StartSession` and exports it, putting in place the requirement to call `PrepareInitializer` before calling `StartSession`. This provides a means for POST opts to be validated synchronously before starting the long running task of `StartSession` which allows the start smeshing api call to directly return an error to the caller if there is a problem with the smeshing options.

Also this change updates `Builder.StartSmeshing` to panic if the smeshing operation fails, this ensures that the node will crash if there is any problem with the smeshing background task. While not optimal in terms of user experience this at least means that users will now be aware of problems with the smeshing process.

Note: This replaces #4319 which suffered from the problem that a call to `StartSmeshing`, while initialization was active would crash the node. Now `PrepareInitializer` acts as a gate and will instead return an error if the node is initializing, which prevents calls to `StartSession` while the node is initializing.

## Test Plan
Updated existing tests and added a test to check that `PrepreInitializer` returns an error if given invalid config and a test to check that `PrepareInitialzer` and `StartSession` return errors if not called in sequence.

I have manually verified that if `StartSession` returns an error the `activation.Builder` will panic, but I can't write an automated test for it since the go routine that calls `StartSession` is initiated by the `activation.Builder` and there's not a way to neatly insert a recover statement there just for tests.

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
