### PR TITLE
fetcher: dont ask for blocks

### DIFF
--- a/fetch/handler.go
+++ b/fetch/handler.go
@@ -11,7 +11,6 @@ import (
 	"github.com/spacemeshos/go-spacemesh/sql"
 	"github.com/spacemeshos/go-spacemesh/sql/atxs"
 	"github.com/spacemeshos/go-spacemesh/sql/ballots"
-	"github.com/spacemeshos/go-spacemesh/sql/blocks"
 	"github.com/spacemeshos/go-spacemesh/sql/certificates"
 	"github.com/spacemeshos/go-spacemesh/sql/identities"
 	"github.com/spacemeshos/go-spacemesh/sql/layers"
@@ -91,11 +90,6 @@ func (h *handler) handleLayerDataReq(ctx context.Context, req []byte) ([]byte, e
 	ld.Ballots, err = ballots.IDsInLayer(h.cdb, lid)
 	if err != nil && !errors.Is(err, sql.ErrNotFound) {
 		h.logger.WithContext(ctx).With().Warning("failed to get layer ballots", lid, log.Err(err))
-		return nil, err
-	}
-	ld.Blocks, err = blocks.IDsInLayer(h.cdb, lid)
-	if err != nil && !errors.Is(err, sql.ErrNotFound) {
-		h.logger.WithContext(ctx).With().Warning("failed to get layer blocks", lid, log.Err(err))
 		return nil, err
 	}
 

--- a/fetch/handler_test.go
+++ b/fetch/handler_test.go
@@ -102,7 +102,7 @@ func TestHandleLayerDataReq(t *testing.T) {
 
 			lid := types.LayerID(111)
 			th := createTestHandler(t)
-			blts, blks := createLayer(t, th.cdb, lid)
+			blts, _ := createLayer(t, th.cdb, lid)
 
 			lidBytes, err := codec.Encode(&lid)
 			require.NoError(t, err)
@@ -113,7 +113,6 @@ func TestHandleLayerDataReq(t *testing.T) {
 			err = codec.Decode(out, &got)
 			require.NoError(t, err)
 			require.ElementsMatch(t, blts, got.Ballots)
-			require.ElementsMatch(t, blks, got.Blocks)
 		})
 	}
 }

--- a/fetch/mesh_data_test.go
+++ b/fetch/mesh_data_test.go
@@ -100,13 +100,8 @@ func generateLayerContent(t *testing.T) []byte {
 	for i := 0; i < numBallots; i++ {
 		ballotIDs = append(ballotIDs, types.RandomBallotID())
 	}
-	blockIDs := make([]types.BlockID, 0, numBlocks)
-	for i := 0; i < numBlocks; i++ {
-		blockIDs = append(blockIDs, types.RandomBlockID())
-	}
 	lb := LayerData{
 		Ballots: ballotIDs,
-		Blocks:  blockIDs,
 	}
 	out, _ := codec.Encode(&lb)
 	return out

--- a/fetch/wire_types.go
+++ b/fetch/wire_types.go
@@ -63,7 +63,6 @@ type EpochData struct {
 // LayerData is the data response for a given layer ID.
 type LayerData struct {
 	Ballots []types.BallotID `scale:"max=500"` // expected are 50 proposals per layer + safety margin
-	Blocks  []types.BlockID  `scale:"max=100"` // only expected to have 1 block per layer, 100 is a safe upper bound
 }
 
 // LayerOpinion is the response for opinion for a given layer.

--- a/fetch/wire_types_scale.go
+++ b/fetch/wire_types_scale.go
@@ -317,13 +317,6 @@ func (t *LayerData) EncodeScale(enc *scale.Encoder) (total int, err error) {
 		}
 		total += n
 	}
-	{
-		n, err := scale.EncodeStructSliceWithLimit(enc, t.Blocks, 100)
-		if err != nil {
-			return total, err
-		}
-		total += n
-	}
 	return total, nil
 }
 
@@ -335,14 +328,6 @@ func (t *LayerData) DecodeScale(dec *scale.Decoder) (total int, err error) {
 		}
 		total += n
 		t.Ballots = field
-	}
-	{
-		field, n, err := scale.DecodeStructSliceWithLimit[types.BlockID](dec, 100)
-		if err != nil {
-			return total, err
-		}
-		total += n
-		t.Blocks = field
 	}
 	return total, nil
 }

--- a/mesh/mesh.go
+++ b/mesh/mesh.go
@@ -665,7 +665,7 @@ func (msh *Mesh) setLatestLayerInState(lyr types.LayerID) {
 }
 
 // SetZeroBlockLayer advances the latest layer in the network with a layer
-// that truly has no data.
+// that has no data.
 func (msh *Mesh) SetZeroBlockLayer(ctx context.Context, lid types.LayerID) {
 	msh.setLatestLayer(msh.logger.WithContext(ctx), lid)
 }

--- a/syncer/data_fetch_test.go
+++ b/syncer/data_fetch_test.go
@@ -71,13 +71,8 @@ func generateLayerContent(t *testing.T) []byte {
 	for i := 0; i < numBallots; i++ {
 		ballotIDs = append(ballotIDs, types.RandomBallotID())
 	}
-	blockIDs := make([]types.BlockID, 0, numBlocks)
-	for i := 0; i < numBlocks; i++ {
-		blockIDs = append(blockIDs, types.RandomBlockID())
-	}
 	lb := fetch.LayerData{
 		Ballots: ballotIDs,
-		Blocks:  blockIDs,
 	}
 	out, err := codec.Encode(&lb)
 	require.NoError(t, err)
@@ -87,7 +82,6 @@ func generateLayerContent(t *testing.T) []byte {
 func generateEmptyLayer(t *testing.T) []byte {
 	lb := fetch.LayerData{
 		Ballots: []types.BallotID{},
-		Blocks:  []types.BlockID{},
 	}
 	out, err := codec.Encode(&lb)
 	require.NoError(t, err)
@@ -147,20 +141,6 @@ func TestDataFetch_PollLayerData(t *testing.T) {
 	peers := GenPeers(numPeers)
 	layerID := types.LayerID(10)
 	errUnknown := errors.New("unknown")
-	t.Run("all peers have zero blocks", func(t *testing.T) {
-		t.Parallel()
-		td := newTestDataFetch(t)
-		td.mFetcher.EXPECT().GetPeers().Return(peers)
-		td.mFetcher.EXPECT().GetLayerData(gomock.Any(), peers, layerID, gomock.Any(), gomock.Any()).DoAndReturn(
-			func(_ context.Context, _ []p2p.Peer, _ types.LayerID, okCB func([]byte, p2p.Peer), errCB func(error, p2p.Peer)) error {
-				for _, peer := range peers {
-					okCB(generateEmptyLayer(t), peer)
-				}
-				return nil
-			})
-		td.mMesh.EXPECT().SetZeroBlockLayer(gomock.Any(), layerID)
-		require.NoError(t, td.PollLayerData(context.TODO(), layerID))
-	})
 	newTestDataFetchWithMocks := func(*testing.T) *testDataFetch {
 		td := newTestDataFetch(t)
 		td.mFetcher.EXPECT().GetPeers().Return(peers)
@@ -178,7 +158,6 @@ func TestDataFetch_PollLayerData(t *testing.T) {
 		t.Parallel()
 		td := newTestDataFetchWithMocks(t)
 		td.mFetcher.EXPECT().GetBallots(gomock.Any(), gomock.Any()).Return(nil).MaxTimes(numPeers)
-		td.mFetcher.EXPECT().GetBlocks(gomock.Any(), gomock.Any()).Return(nil).MaxTimes(numPeers)
 		require.NoError(t, td.PollLayerData(context.TODO(), layerID))
 	})
 	t.Run("ballots failure ignored", func(t *testing.T) {
@@ -186,15 +165,12 @@ func TestDataFetch_PollLayerData(t *testing.T) {
 		td := newTestDataFetchWithMocks(t)
 		td.mFetcher.EXPECT().GetBallots(gomock.Any(), gomock.Any()).Return(errUnknown)
 		td.mFetcher.EXPECT().GetBallots(gomock.Any(), gomock.Any()).Return(nil).MaxTimes(numPeers - 1)
-		td.mFetcher.EXPECT().GetBlocks(gomock.Any(), gomock.Any()).Return(nil).MaxTimes(numPeers)
 		require.NoError(t, td.PollLayerData(context.TODO(), layerID))
 	})
 	t.Run("blocks failure ignored", func(t *testing.T) {
 		t.Parallel()
 		td := newTestDataFetchWithMocks(t)
 		td.mFetcher.EXPECT().GetBallots(gomock.Any(), gomock.Any()).Return(nil).MaxTimes(numPeers)
-		td.mFetcher.EXPECT().GetBlocks(gomock.Any(), gomock.Any()).Return(errUnknown)
-		td.mFetcher.EXPECT().GetBlocks(gomock.Any(), gomock.Any()).Return(nil).MaxTimes(numPeers - 1)
 		require.NoError(t, td.PollLayerData(context.TODO(), layerID))
 	})
 }
@@ -232,7 +208,6 @@ func TestDataFetch_PollLayerData_PeerErrors(t *testing.T) {
 				}
 				return nil
 			})
-		td.mMesh.EXPECT().SetZeroBlockLayer(gomock.Any(), layerID)
 		require.NoError(t, td.PollLayerData(context.TODO(), layerID))
 	})
 }


### PR DESCRIPTION
related to: https://github.com/spacemeshos/go-spacemesh/issues/3609

there is no reason to ask for known blocks, as we are not supposed too query simply based on advertisement.
there is code that queries for a block after downloading certificate, and additionally code will have to query when mesh wants to apply block, but misses data.