### PR TITLE
[Merged by Bors] - bootstrapper: allow to bootstrap a specific epoch

### DIFF
--- a/bootstrap/schema.json
+++ b/bootstrap/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://spacemesh.io/checkpoint.schema.json.1.0",
+  "$id": "https://spacemesh.io/bootstrap.schema.json.1.0",
   "title": "epoch data",
   "description": "epoch data for bootstrapping and fallback",
   "type": "object",

--- a/cmd/bootstrapper/server_test.go
+++ b/cmd/bootstrapper/server_test.go
@@ -39,11 +39,16 @@ func TestServer(t *testing.T) {
 		WithFilesystem(fs),
 	)
 
-	srv := NewServer(fs, g, false, port, logtest.New(t))
+	epoch := types.EpochID(4)
+	srv := NewServer(g, false, port,
+		WithSrvFilesystem(fs),
+		WithSrvLogger(logtest.New(t)),
+		WithBootstrapEpoch(epoch),
+	)
 	np := &NetworkParam{
 		Genesis:      time.Now(),
 		LyrsPerEpoch: 2,
-		LyrDuration:  time.Second,
+		LyrDuration:  100 * time.Millisecond,
 		Offset:       1,
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -58,8 +63,7 @@ func TestServer(t *testing.T) {
 	require.Empty(t, ch)
 
 	data := query(t, ctx)
-	epoch := types.EpochID(2)
-	verifyUpdate(t, data, epoch, hex.EncodeToString(epochBeacon(epoch).Bytes()), activeSetSize*3/4)
+	verifyUpdate(t, data, epoch, hex.EncodeToString(epochBeacon(epoch).Bytes()), activeSetSize)
 	cancel()
 	srv.Stop(ctx)
 }

--- a/systest/cluster/nodes.go
+++ b/systest/cluster/nodes.go
@@ -527,12 +527,12 @@ func deployNode(ctx *testcontext.Context, id string, labels map[string]string, f
 	return nil
 }
 
-func deployBootstrapper(ctx *testcontext.Context, id string, flags ...DeploymentFlag) (*NodeClient, error) {
+func deployBootstrapper(ctx *testcontext.Context, id string, bsEpoch uint32, flags ...DeploymentFlag) (*NodeClient, error) {
 	if _, err := deployBootstrapperSvc(ctx, id); err != nil {
 		return nil, fmt.Errorf("apply poet service: %w", err)
 	}
 
-	node, err := deployBootstrapperD(ctx, id, flags...)
+	node, err := deployBootstrapperD(ctx, id, bsEpoch, flags...)
 	if err != nil {
 		return nil, err
 	}
@@ -555,9 +555,10 @@ func deployBootstrapperSvc(ctx *testcontext.Context, id string) (*apiv1.Service,
 	return ctx.Client.CoreV1().Services(ctx.Namespace).Apply(ctx, svc, apimetav1.ApplyOptions{FieldManager: "test"})
 }
 
-func deployBootstrapperD(ctx *testcontext.Context, id string, flags ...DeploymentFlag) (*NodeClient, error) {
+func deployBootstrapperD(ctx *testcontext.Context, id string, bsEpoch uint32, flags ...DeploymentFlag) (*NodeClient, error) {
 	cmd := []string{
 		"/bin/go-bootstrapper",
+		strconv.Itoa(int(bsEpoch)),
 		"--serve-update",
 		"--data-dir=/data/bootstrapper",
 		"--epoch-offset=1",

--- a/systest/tests/fallback_test.go
+++ b/systest/tests/fallback_test.go
@@ -83,7 +83,10 @@ func TestFallback(t *testing.T) {
 	lastEpoch := last / layersPerEpoch
 	for epoch := uint32(2); epoch <= lastEpoch; epoch++ {
 		refActives, err := queryEpochAtxs(tctx, cl.Client(0), epoch)
-		cutoff := len(refActives) * 3 / 4 // bootstrapper only sets 3/4 of the epoch atx to be the fallback active set
+		cutoff := len(refActives)
+		if epoch > 2 {
+			cutoff = len(refActives) * 3 / 4 // bootstrapper only sets 3/4 of the epoch atx to be the fallback active set
+		}
 		require.NoError(t, err, "query atxs from client", cl.Client(0).Name)
 		tctx.Log.Debugw("got atx ids from client", "epoch", epoch, "client", cl.Client(0).Name, "size", len(refActives))
 		for i := 0; i < cl.Total(); i++ {


### PR DESCRIPTION
## Motivation
part of #4090

## Changes
for systest
- allow the server binary to bootstrap any epoch (not just epoch 2)
  in the checkpoint recovery case, we will checkpoint/recover in the middle of epoch 5, we then need to bootstrap 
  - the remainder of epoch 5: so hare can start working immediately at the restore layer
  - epoch 6: the result of beacon protocol in epoch 5 is not persisted across restart, if generated.
 
- change bootstrap active set to be the complete active set (instead of partial 3/4)
- add retry to query network parameters