### PR TITLE
[Merged by Bors] - activation: reduce variance and make poet retries shorter

### DIFF
--- a/activation/activation.go
+++ b/activation/activation.go
@@ -27,13 +27,18 @@ import (
 
 // PoetConfig is the configuration to interact with the poet server.
 type PoetConfig struct {
-	PhaseShift  time.Duration `mapstructure:"phase-shift"`
-	CycleGap    time.Duration `mapstructure:"cycle-gap"`
-	GracePeriod time.Duration `mapstructure:"grace-period"`
+	PhaseShift        time.Duration `mapstructure:"phase-shift"`
+	CycleGap          time.Duration `mapstructure:"cycle-gap"`
+	GracePeriod       time.Duration `mapstructure:"grace-period"`
+	RequestRetryDelay time.Duration `mapstructure:"retry-delay"`
+	MaxRequestRetries int           `mapstructure:"retry-max"`
 }
 
 func DefaultPoetConfig() PoetConfig {
-	return PoetConfig{}
+	return PoetConfig{
+		RequestRetryDelay: 400 * time.Millisecond,
+		MaxRequestRetries: 10,
+	}
 }
 
 const defaultPoetRetryInterval = 5 * time.Second

--- a/activation/poet.go
+++ b/activation/poet.go
@@ -68,9 +68,9 @@ func withCustomHttpClient(client *http.Client) PoetClientOpts {
 // NewHTTPPoetClient returns new instance of HTTPPoetClient connecting to the specified url.
 func NewHTTPPoetClient(baseUrl string, cfg PoetConfig, opts ...PoetClientOpts) (*HTTPPoetClient, error) {
 	client := &retryablehttp.Client{
-		RetryMax:     10,
-		RetryWaitMin: cfg.GracePeriod / 100,
-		RetryWaitMax: cfg.GracePeriod / 10,
+		RetryMax:     cfg.MaxRequestRetries,
+		RetryWaitMin: cfg.RequestRetryDelay,
+		RetryWaitMax: 2 * cfg.RequestRetryDelay,
 		Backoff:      retryablehttp.LinearJitterBackoff,
 		CheckRetry:   checkRetry,
 	}

--- a/activation/poet_test_harness.go
+++ b/activation/poet_test_harness.go
@@ -69,11 +69,7 @@ func NewHTTPPoetTestHarness(ctx context.Context, poetdir string, opts ...HTTPPoe
 		Host:   poet.GrpcRestProxyAddr().String(),
 	}
 
-	client, err := NewHTTPPoetClient(url.String(), PoetConfig{
-		PhaseShift:  cfg.Service.PhaseShift,
-		CycleGap:    cfg.Service.CycleGap,
-		GracePeriod: cfg.Service.CycleGap / 2,
-	})
+	client, err := NewHTTPPoetClient(url.String(), DefaultPoetConfig())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
we are using LinearJitterBackoff from retryablehttp. it selects delay in a following way:

```
jitter := rand.Float64() * float64(max-min)
jitterMin := int64(jitter) + int64(min)
return time.Duration(jitterMin * int64(attemptNum))
```

i think the idea to use GracePeriod / 100 as a min and GracePeriod / 10 wasn't the best. as it makes delay greatly variable.
practically the minimum is ~0 (GracePeriod / 100) so the delay is a random fraction of GracePeriod / 10 multiplied by number of the attempts.

for example if grace period is 10s, the worst case delays for consecutive attempts are 1s, 2s, 3s and so on. related to https://github.com/spacemeshos/go-spacemesh/issues/4367 
10m, - 1m, 2m, 3m.. this makes it very likely to wait very long after several failures. this is very likely why we see something like that https://github.com/spacemeshos/go-spacemesh/issues/4363 

closes: https://github.com/spacemeshos/go-spacemesh/issues/4367 
closes: https://github.com/spacemeshos/go-spacemesh/issues/4363 