### PR TITLE
[Merged by Bors] - cmd/node: use shared filelock by default

### DIFF
--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -324,6 +324,10 @@ func (app *App) introduction() {
 
 // Initialize sets up an exit signal, logging and checks the clock, returns error if clock is not in sync.
 func (app *App) Initialize() (err error) {
+	// ensure all data folders exist
+	if err := os.MkdirAll(app.Config.DataDir(), 0o700); err != nil {
+		return fmt.Errorf("ensure folders exist: %w", err)
+	}
 	fl := flock.New(app.Config.FileLock)
 	locked, err := fl.TryLock()
 	if err != nil {

--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -68,7 +68,6 @@ import (
 const (
 	edKeyFileName   = "key.bin"
 	genesisFileName = "genesis.json"
-	lockFile        = "LOCK"
 )
 
 // Logger names.
@@ -325,15 +324,10 @@ func (app *App) introduction() {
 
 // Initialize sets up an exit signal, logging and checks the clock, returns error if clock is not in sync.
 func (app *App) Initialize() (err error) {
-	// ensure all data folders exist
-	if err := os.MkdirAll(app.Config.DataDir(), 0o700); err != nil {
-		return fmt.Errorf("ensure folders exist: %w", err)
-	}
-	lockName := filepath.Join(app.Config.DataDir(), lockFile)
-	fl := flock.New(lockName)
+	fl := flock.New(app.Config.FileLock)
 	locked, err := fl.TryLock()
 	if err != nil {
-		return fmt.Errorf("flock %s: %w", lockName, err)
+		return fmt.Errorf("flock %s: %w", app.Config.FileLock, err)
 	} else if !locked {
 		return fmt.Errorf("only one spacemesh instance should be running (locking file %s)", fl.Path())
 	}

--- a/cmd/node/node_test.go
+++ b/cmd/node/node_test.go
@@ -425,7 +425,7 @@ func TestSpacemeshApp_NodeService(t *testing.T) {
 	require.NoError(t, err)
 	mesh, err := mocknet.WithNPeers(1)
 	require.NoError(t, err)
-	cfg := getTestDefaultConfig()
+	cfg := getTestDefaultConfig(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
@@ -672,16 +672,18 @@ func TestSpacemeshApp_TransactionService(t *testing.T) {
 func TestInitialize_BadTortoiseParams(t *testing.T) {
 	conf := config.DefaultConfig()
 	conf.DataDirParent = t.TempDir()
+	conf.FileLock = filepath.Join(t.TempDir(), "LOCK")
 	app := New(WithLog(logtest.New(t)), WithConfig(&conf))
 	require.NoError(t, app.Initialize())
 
 	conf = config.DefaultTestConfig()
 	conf.DataDirParent = t.TempDir()
+	conf.FileLock = filepath.Join(t.TempDir(), "LOCK")
 	app = New(WithLog(logtest.New(t)), WithConfig(&conf))
 	require.NoError(t, app.Initialize())
 	app.Cleanup(context.Background())
 
-	tconf := getTestDefaultConfig()
+	tconf := getTestDefaultConfig(t)
 	tconf.DataDirParent = t.TempDir()
 	app = New(WithLog(logtest.New(t)), WithConfig(tconf))
 	require.NoError(t, app.Initialize())
@@ -826,7 +828,7 @@ func TestConfig_GenesisAccounts(t *testing.T) {
 func TestGenesisConfig(t *testing.T) {
 	t.Run("config is written to a file", func(t *testing.T) {
 		app := New()
-		app.Config = getTestDefaultConfig()
+		app.Config = getTestDefaultConfig(t)
 		app.Config.DataDirParent = t.TempDir()
 
 		require.NoError(t, app.Initialize())
@@ -836,7 +838,7 @@ func TestGenesisConfig(t *testing.T) {
 	})
 	t.Run("no error if no diff", func(t *testing.T) {
 		app := New()
-		app.Config = getTestDefaultConfig()
+		app.Config = getTestDefaultConfig(t)
 		app.Config.DataDirParent = t.TempDir()
 
 		require.NoError(t, app.Initialize())
@@ -845,7 +847,7 @@ func TestGenesisConfig(t *testing.T) {
 	})
 	t.Run("fatal error on a diff", func(t *testing.T) {
 		app := New()
-		app.Config = getTestDefaultConfig()
+		app.Config = getTestDefaultConfig(t)
 		app.Config.DataDirParent = t.TempDir()
 
 		require.NoError(t, app.Initialize())
@@ -856,7 +858,7 @@ func TestGenesisConfig(t *testing.T) {
 	})
 	t.Run("not valid time", func(t *testing.T) {
 		app := New()
-		app.Config = getTestDefaultConfig()
+		app.Config = getTestDefaultConfig(t)
 		app.Config.DataDirParent = t.TempDir()
 		app.Config.Genesis.GenesisTime = time.Now().Format(time.RFC1123)
 
@@ -864,7 +866,7 @@ func TestGenesisConfig(t *testing.T) {
 	})
 	t.Run("long extra data", func(t *testing.T) {
 		app := New()
-		app.Config = getTestDefaultConfig()
+		app.Config = getTestDefaultConfig(t)
 		app.Config.DataDirParent = t.TempDir()
 		app.Config.Genesis.ExtraData = string(make([]byte, 256))
 
@@ -874,19 +876,18 @@ func TestGenesisConfig(t *testing.T) {
 
 func TestFlock(t *testing.T) {
 	app := New()
-	app.Config = getTestDefaultConfig()
-	app.Config.DataDirParent = t.TempDir()
+	app.Config = getTestDefaultConfig(t)
 
 	require.NoError(t, app.Initialize())
 	app1 := *app
 	require.ErrorContains(t, app1.Initialize(), "only one spacemesh instance")
 	app.Cleanup(context.Background())
 	require.NoError(t, app.Initialize())
-	require.NoError(t, os.Remove(filepath.Join(app.Config.DataDir(), lockFile)))
+	require.NoError(t, os.Remove(filepath.Join(app.Config.FileLock)))
 	require.NoError(t, app.Initialize())
 }
 
-func getTestDefaultConfig() *config.Config {
+func getTestDefaultConfig(tb testing.TB) *config.Config {
 	cfg, err := LoadConfigFromFile()
 	if err != nil {
 		log.Error("cannot load config from file")
@@ -921,6 +922,9 @@ func getTestDefaultConfig() *config.Config {
 	cfg.HareEligibility.ConfidenceParam = 1
 	cfg.SyncRequestTimeout = 500
 	cfg.SyncInterval = 2
+	tmp := tb.TempDir()
+	cfg.DataDirParent = tmp
+	cfg.FileLock = filepath.Join(tmp, "LOCK")
 
 	cfg.FETCH.RequestTimeout = 10
 	cfg.FETCH.MaxRetriesForPeer = 5

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,6 +28,8 @@ func AddCommands(cmd *cobra.Command) {
 		"config", "c", cfg.BaseConfig.ConfigFile, "Set Load configuration from file")
 	cmd.PersistentFlags().StringVarP(&cfg.BaseConfig.DataDirParent, "data-folder", "d",
 		cfg.BaseConfig.DataDirParent, "Specify data directory for spacemesh")
+	cmd.PersistentFlags().StringVar(&cfg.BaseConfig.FileLock,
+		"filelock", cfg.BaseConfig.FileLock, "Filesystem lock to prevent running more than one instance.")
 	cmd.PersistentFlags().StringVar(&cfg.LOGGING.Encoder, "log-encoder",
 		cfg.LOGGING.Encoder, "Log as JSON instead of plain text")
 	cmd.PersistentFlags().BoolVar(&cfg.CollectMetrics, "metrics",

--- a/config/config.go
+++ b/config/config.go
@@ -69,6 +69,7 @@ func (cfg *Config) DataDir() string {
 // BaseConfig defines the default configuration options for spacemesh app.
 type BaseConfig struct {
 	DataDirParent string `mapstructure:"data-folder"`
+	FileLock      string `mapstructure:"filelock"`
 
 	ConfigFile string `mapstructure:"config"`
 
@@ -154,6 +155,7 @@ func DefaultTestConfig() Config {
 func defaultBaseConfig() BaseConfig {
 	return BaseConfig{
 		DataDirParent:       defaultDataDir,
+		FileLock:            "/tmp/spacemesh.lock",
 		CollectMetrics:      false,
 		MetricsPort:         1010,
 		MetricsPush:         "", // "" = doesn't push

--- a/config/config.go
+++ b/config/config.go
@@ -155,7 +155,7 @@ func DefaultTestConfig() Config {
 func defaultBaseConfig() BaseConfig {
 	return BaseConfig{
 		DataDirParent:       defaultDataDir,
-		FileLock:            "/tmp/spacemesh.lock",
+		FileLock:            filepath.Join(os.TempDir(), "spacemesh.lock"),
 		CollectMetrics:      false,
 		MetricsPort:         1010,
 		MetricsPush:         "", // "" = doesn't push


### PR DESCRIPTION
originally i added file lock for a specific data directory, as it seemed nicer that we can run multiple instances of go-spacemesh. however there are ongoing reports that people somehow run more than one, and submit different atxs, etc.

it would be very stupid if we will have malfeasence proofs because of that. so i would rather request people to configure separate file locks if they wish to run many instances on same computer, to do so there is an option `--filelock`, that defaults to `/tmp/spacemesh.lock`