### PR TITLE
[Merged by Bors] - tortoise: assign hare and opinion fields

### DIFF
--- a/tortoise/algorithm.go
+++ b/tortoise/algorithm.go
@@ -326,12 +326,14 @@ func (t *Tortoise) Results(from, to types.LayerID) ([]result.Layer, error) {
 			blocks = append(blocks, result.Block{
 				Header: block.header(),
 				Data:   block.data,
+				Hare:   block.hare == support,
 				Valid:  block.validity == support,
 			})
 		}
 		rst = append(rst, result.Layer{
-			Layer:  lid,
-			Blocks: blocks,
+			Layer:   lid,
+			Blocks:  blocks,
+			Opinion: layer.opinion,
 		})
 	}
 	return rst, nil


### PR DESCRIPTION
this doesn't fix any bugs, i just messed up with cherry picks a bit and left those fields unassigned. they are logged in mesh with "consensus results" message and may confuse people, when they see them empty
