### PR TITLE
[Merged by Bors] - fetcher: vulnerability in fetcher meshHashReq

### DIFF
--- a/fetch/handler_test.go
+++ b/fetch/handler_test.go
@@ -32,7 +32,7 @@ type testHandler struct {
 	mb  *smocks.MockBeaconGetter
 }
 
-func createTestHandler(t *testing.T) *testHandler {
+func createTestHandler(t testing.TB) *testHandler {
 	lg := logtest.New(t)
 	cdb := datastore.NewCachedDB(sql.InMemory(), lg)
 	ctrl := gomock.NewController(t)

--- a/fetch/mesh_data.go
+++ b/fetch/mesh_data.go
@@ -239,7 +239,11 @@ func iterateLayers(req *MeshHashRequest) ([]types.LayerID, error) {
 	lids := make([]types.LayerID, req.Steps+1)
 	lids[0] = req.From
 	for i := uint32(1); i <= req.Steps; i++ {
-		lids[i] = lids[i-1].Add(req.Delta)
+		next := lids[i-1] + types.LayerID(req.Delta)
+		if next < lids[i-1] {
+			return nil, fmt.Errorf("request causes layer overflow in %d. delta %d", lids[i-1], req.Delta)
+		}
+		lids[i] = next
 	}
 	if lids[req.Steps].After(req.To) {
 		lids[req.Steps] = req.To

--- a/fetch/mesh_data_test.go
+++ b/fetch/mesh_data_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	fuzz "github.com/google/gofuzz"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 
@@ -17,10 +16,8 @@ import (
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/datastore"
 	"github.com/spacemeshos/go-spacemesh/genvm/sdk/wallet"
-	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/p2p"
 	"github.com/spacemeshos/go-spacemesh/signing"
-	"github.com/spacemeshos/go-spacemesh/sql"
 )
 
 const (
@@ -726,16 +723,22 @@ func TestFetch_GetMeshHashes(t *testing.T) {
 }
 
 func FuzzMeshHashRequest(f *testing.F) {
-	h := newHandler(datastore.NewCachedDB(sql.InMemory(), log.NewNop()), nil, nil, nil, log.NewNop())
+	h := createTestHandler(f)
 	f.Fuzz(func(t *testing.T, data []byte) {
-		fuzzer := fuzz.NewFromGoFuzz(data)
-		var object MeshHashRequest
-		fuzzer.Fuzz(&object)
-		buf, err := codec.Encode(&object)
-		if err != nil {
-			// object may fail to encode due to limts, it is ok to skip it
-			return
-		}
-		h.handleMeshHashReq(context.TODO(), buf)
+		h.handleMeshHashReq(context.TODO(), data)
+	})
+}
+
+func FuzzLayerInfo(f *testing.F) {
+	h := createTestHandler(f)
+	f.Fuzz(func(t *testing.T, data []byte) {
+		h.handleEpochInfoReq(context.TODO(), data)
+	})
+}
+
+func FuzzHashReq(f *testing.F) {
+	h := createTestHandler(f)
+	f.Fuzz(func(t *testing.T, data []byte) {
+		h.handleHashReq(context.TODO(), data)
 	})
 }

--- a/fetch/testdata/fuzz/FuzzMeshHashRequest/c59f081af3f0b2ce7b146ce4963c04fe870e4d8a50b0c611fa1629f4d7cf89c6
+++ b/fetch/testdata/fuzz/FuzzMeshHashRequest/c59f081af3f0b2ce7b146ce4963c04fe870e4d8a50b0c611fa1629f4d7cf89c6
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("0200\xe220z}}0")

--- a/fetch/testdata/fuzz/FuzzMeshHashRequest/c59f081af3f0b2ce7b146ce4963c04fe870e4d8a50b0c611fa1629f4d7cf89c6
+++ b/fetch/testdata/fuzz/FuzzMeshHashRequest/c59f081af3f0b2ce7b146ce4963c04fe870e4d8a50b0c611fa1629f4d7cf89c6
@@ -1,2 +1,0 @@
-go test fuzz v1
-[]byte("0200\xe220z}}0")


### PR DESCRIPTION
```
=== FUZZ  FuzzMeshHash
warning: starting with empty corpus
fuzz: elapsed: 0s, execs: 0 (0/sec), new interesting: 0 (total: 0)
fuzz: minimizing 101-byte failing input file
fuzz: elapsed: 3s, minimizing
--- FAIL: FuzzMeshHash (2.53s)
    --- FAIL: FuzzMeshHash (0.12s)
        testing.go:1356: panic: layer_id wraparound
```