### PR TITLE
[Merged by Bors] - Revert "tortoise: use rlock for read-only methods and meter store"

### DIFF
--- a/tortoise/metrics.go
+++ b/tortoise/metrics.go
@@ -78,7 +78,6 @@ var (
 	)
 	waitBallotDuration   = onBallotHist.WithLabelValues("wait")
 	decodeBallotDuration = onBallotHist.WithLabelValues("decode")
-	storeBallotDuration  = onBallotHist.WithLabelValues("store")
 	fcountBallotDuration = onBallotHist.WithLabelValues("full_count")
 	vcountBallotDuration = onBallotHist.WithLabelValues("verifying_count")
 )


### PR DESCRIPTION
This reverts commit 9552e34ad00e80afdd8ed3cc2e6ea54a725c8221.

mistakes were made. i forgot that even on read path i added some functions like that, to prevent accidental crashes:

```
func (s *state) epoch(eid types.EpochID) *epochInfo {
	epoch, exist := s.epochs[eid]
	if !exist {
		epochsNumber.Inc()
		epoch = &epochInfo{atxs: map[types.ATXID]atxInfo{}}
		s.epochs[eid] = epoch
	}
	return epoch
}
```
