### PR TITLE
[Merged by Bors] - p2p/server: limit request size alloc to 10kb

### DIFF
--- a/p2p/server/server.go
+++ b/p2p/server/server.go
@@ -150,6 +150,9 @@ func (s *Server) streamHandler(stream network.Stream) {
 // Request sends a binary request to the peer. Request is executed in the background, one of the callbacks
 // is guaranteed to be called on success/error.
 func (s *Server) Request(ctx context.Context, pid peer.ID, req []byte, resp func([]byte), failure func(error)) error {
+	if len(req) < s.requestLimit {
+		return fmt.Errorf("request length (%d) is longer than limit %d", len(req), s.requestLimit)
+	}
 	if s.h.Network().Connectedness(pid) != network.Connected {
 		return fmt.Errorf("%w: %s", ErrNotConnected, pid)
 	}

--- a/p2p/server/server.go
+++ b/p2p/server/server.go
@@ -150,7 +150,7 @@ func (s *Server) streamHandler(stream network.Stream) {
 // Request sends a binary request to the peer. Request is executed in the background, one of the callbacks
 // is guaranteed to be called on success/error.
 func (s *Server) Request(ctx context.Context, pid peer.ID, req []byte, resp func([]byte), failure func(error)) error {
-	if len(req) < s.requestLimit {
+	if len(req) > s.requestLimit {
 		return fmt.Errorf("request length (%d) is longer than limit %d", len(req), s.requestLimit)
 	}
 	if s.h.Network().Connectedness(pid) != network.Connected {

--- a/p2p/server/server.go
+++ b/p2p/server/server.go
@@ -45,6 +45,12 @@ func WithContext(ctx context.Context) Opt {
 	}
 }
 
+func WithRequestSizeLimit(limit int) Opt {
+	return func(s *Server) {
+		s.requestLimit = limit
+	}
+}
+
 // Handler is the handler to be defined by the application.
 type Handler func(context.Context, []byte) ([]byte, error)
 
@@ -67,10 +73,11 @@ type Host interface {
 
 // Server for the Handler.
 type Server struct {
-	logger   log.Log
-	protocol string
-	handler  Handler
-	timeout  time.Duration
+	logger       log.Log
+	protocol     string
+	handler      Handler
+	timeout      time.Duration
+	requestLimit int
 
 	h Host
 
@@ -80,12 +87,13 @@ type Server struct {
 // New server for the handler.
 func New(h Host, proto string, handler Handler, opts ...Opt) *Server {
 	srv := &Server{
-		ctx:      context.Background(),
-		logger:   log.NewNop(),
-		protocol: proto,
-		handler:  handler,
-		h:        h,
-		timeout:  10 * time.Second,
+		ctx:          context.Background(),
+		logger:       log.NewNop(),
+		protocol:     proto,
+		handler:      handler,
+		h:            h,
+		timeout:      10 * time.Second,
+		requestLimit: 10240,
 	}
 	for _, opt := range opts {
 		opt(srv)
@@ -101,6 +109,14 @@ func (s *Server) streamHandler(stream network.Stream) {
 	rd := bufio.NewReader(stream)
 	size, err := varint.ReadUvarint(rd)
 	if err != nil {
+		return
+	}
+	if size > uint64(s.requestLimit) {
+		s.logger.Warning("request limit overflow",
+			log.Int("limit", s.requestLimit),
+			log.Uint64("request", size),
+		)
+		stream.Conn().Close()
 		return
 	}
 	buf := make([]byte, size)

--- a/p2p/server/server_test.go
+++ b/p2p/server/server_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestServer(t *testing.T) {
+	const limit = 1024
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
@@ -32,6 +33,7 @@ func TestServer(t *testing.T) {
 	opts := []Opt{
 		WithTimeout(100 * time.Millisecond),
 		WithContext(ctx),
+		WithRequestSizeLimit(limit),
 	}
 	client := New(mesh.Hosts()[0], proto, handler, opts...)
 	_ = New(mesh.Hosts()[1], proto, handler, opts...)
@@ -56,6 +58,7 @@ func TestServer(t *testing.T) {
 			require.FailNow(t, "timed out while waiting for message response")
 		case response := <-respch:
 			require.Equal(t, request, response)
+			require.NotEmpty(t, mesh.Hosts()[2].Network().ConnsToPeer(mesh.Hosts()[0].ID()))
 		}
 	})
 	t.Run("ReceiveError", func(t *testing.T) {
@@ -78,6 +81,15 @@ func TestServer(t *testing.T) {
 	})
 	t.Run("NotConnected", func(t *testing.T) {
 		require.ErrorIs(t, client.Request(ctx, "unknown", request, respHandler, respErrHandler), ErrNotConnected)
+	})
+	t.Run("limit overflow", func(t *testing.T) {
+		require.NoError(t, client.Request(ctx, mesh.Hosts()[2].ID(), make([]byte, limit+1), respHandler, respErrHandler))
+		select {
+		case <-time.After(time.Second):
+			require.FailNow(t, "timed out while waiting for error response")
+		case err := <-errch:
+			require.Error(t, err)
+		}
 	})
 }
 

--- a/p2p/server/server_test.go
+++ b/p2p/server/server_test.go
@@ -33,11 +33,10 @@ func TestServer(t *testing.T) {
 	opts := []Opt{
 		WithTimeout(100 * time.Millisecond),
 		WithContext(ctx),
-		WithRequestSizeLimit(limit),
 	}
-	client := New(mesh.Hosts()[0], proto, handler, opts...)
-	_ = New(mesh.Hosts()[1], proto, handler, opts...)
-	_ = New(mesh.Hosts()[2], proto, errhandler, opts...)
+	client := New(mesh.Hosts()[0], proto, handler, append(opts, WithRequestSizeLimit(2*limit))...)
+	_ = New(mesh.Hosts()[1], proto, handler, append(opts, WithRequestSizeLimit(limit))...)
+	_ = New(mesh.Hosts()[2], proto, errhandler, append(opts, WithRequestSizeLimit(limit))...)
 
 	respHandler := func(msg []byte) {
 		select {


### PR DESCRIPTION
lack of limit before alloc can be trivially abused for oom

closes: https://github.com/spacemeshos/go-spacemesh/issues/3970