### PR TITLE
[Merged by Bors] - codec: dont copy bytes from previous encoding

### DIFF
--- a/codec/codec.go
+++ b/codec/codec.go
@@ -53,11 +53,11 @@ func putEncoderBuffer(b *bytes.Buffer) {
 func Encode(value Encodable) ([]byte, error) {
 	b := getEncoderBuffer()
 	defer putEncoderBuffer(b)
-	_, err := EncodeTo(b, value)
+	n, err := EncodeTo(b, value)
 	if err != nil {
 		return nil, err
 	}
-	buf := make([]byte, len(b.Bytes()))
+	buf := make([]byte, n)
 	copy(buf, b.Bytes())
 	return buf, nil
 }


### PR DESCRIPTION
previous code could copy bytes from previously encoded value