### PR TITLE
[Merged by Bors] - tolerate dns resolve failures in system tests better

### DIFF
--- a/config/logging.go
+++ b/config/logging.go
@@ -39,8 +39,8 @@ type LoggerConfig struct {
 	BlockBuilderLoggerLevel   string     `mapstructure:"block-builder"`
 	BlockListenerLoggerLevel  string     `mapstructure:"block-listener"`
 	PoetListenerLoggerLevel   string     `mapstructure:"poet"`
-	NipostBuilderLoggerLevel  string     `mapstructure:"nipost"`
-	AtxBuilderLoggerLevel     string     `mapstructure:"atx-builder"`
+	NipostBuilderLoggerLevel  string     `mapstructure:"nipostBuilder"`
+	AtxBuilderLoggerLevel     string     `mapstructure:"atxBuilder"`
 	HareBeaconLoggerLevel     string     `mapstructure:"hare-beacon"`
 	TimeSyncLoggerLevel       string     `mapstructure:"timesync"`
 	VMLogLevel                string     `mapstructure:"vm"`

--- a/systest/cluster/nodes.go
+++ b/systest/cluster/nodes.go
@@ -488,7 +488,8 @@ func deployNode(ctx *testcontext.Context, id string, labels map[string]string, f
 								WithSizeLimit(resource.MustParse(ctx.Storage.Size))),
 					).
 					WithDNSConfig(corev1.PodDNSConfig().WithOptions(
-						corev1.PodDNSConfigOption().WithName("timeout").WithValue("2"),
+						corev1.PodDNSConfigOption().WithName("timeout").WithValue("1"),
+						corev1.PodDNSConfigOption().WithName("attempts").WithValue("5"),
 					)).
 					WithContainers(corev1.Container().
 						WithName("smesher").

--- a/systest/cluster/nodes.go
+++ b/systest/cluster/nodes.go
@@ -515,7 +515,6 @@ func deployNode(ctx *testcontext.Context, id string, labels map[string]string, f
 						).
 						WithEnv(
 							corev1.EnvVar().WithName("GOMAXPROCS").WithValue("4"),
-							corev1.EnvVar().WithName("GODEBUG").WithValue("http2debug=1"),
 						).
 						WithCommand(cmd...),
 					),

--- a/systest/cluster/nodes.go
+++ b/systest/cluster/nodes.go
@@ -487,6 +487,9 @@ func deployNode(ctx *testcontext.Context, id string, labels map[string]string, f
 							WithEmptyDir(corev1.EmptyDirVolumeSource().
 								WithSizeLimit(resource.MustParse(ctx.Storage.Size))),
 					).
+					WithDNSConfig(corev1.PodDNSConfig().WithOptions(
+						corev1.PodDNSConfigOption().WithName("timeout").WithValue("2"),
+					)).
 					WithContainers(corev1.Container().
 						WithName("smesher").
 						WithImage(ctx.Image).
@@ -512,6 +515,7 @@ func deployNode(ctx *testcontext.Context, id string, labels map[string]string, f
 						).
 						WithEnv(
 							corev1.EnvVar().WithName("GOMAXPROCS").WithValue("4"),
+							corev1.EnvVar().WithName("GODEBUG").WithValue("http2debug=1"),
 						).
 						WithCommand(cmd...),
 					),

--- a/systest/tests/partition_test.go
+++ b/systest/tests/partition_test.go
@@ -166,10 +166,9 @@ func testPartition(t *testing.T, tctx *testcontext.Context, cl *cluster.Cluster,
 }
 
 func TestPartition_30_70(t *testing.T) {
-	t.Skip()
 	t.Parallel()
 
-	tctx := testcontext.New(t, testcontext.Labels("sanity"))
+	tctx := testcontext.New(t, testcontext.Labels("partition"))
 	if tctx.ClusterSize > 30 {
 		tctx.Log.Info("cluster size changed to 30")
 		tctx.ClusterSize = 30
@@ -184,7 +183,7 @@ func TestPartition_50_50(t *testing.T) {
 	t.Skip()
 	t.Parallel()
 
-	tctx := testcontext.New(t, testcontext.Labels("sanity"))
+	tctx := testcontext.New(t, testcontext.Labels("partition"))
 	if tctx.ClusterSize > 30 {
 		tctx.Log.Info("cluster size changed to 30")
 		tctx.ClusterSize = 30

--- a/systest/tests/partition_test.go
+++ b/systest/tests/partition_test.go
@@ -166,6 +166,7 @@ func testPartition(t *testing.T, tctx *testcontext.Context, cl *cluster.Cluster,
 }
 
 func TestPartition_30_70(t *testing.T) {
+	t.Skip()
 	t.Parallel()
 
 	tctx := testcontext.New(t, testcontext.Labels("sanity"))
@@ -180,6 +181,7 @@ func TestPartition_30_70(t *testing.T) {
 }
 
 func TestPartition_50_50(t *testing.T) {
+	t.Skip()
 	t.Parallel()
 
 	tctx := testcontext.New(t, testcontext.Labels("sanity"))


### PR DESCRIPTION
pr changes timeout from default 5s (default in resolv.conf, and golang resolver that follows resolv.conf defaults) to 1s. therefore increases number of retries that can be made during cycle gap in system tests. previously if client had to make 2 retries, it will be automatically timed out, as grace period is 10s.

i don't know actual reasons why k8s dns server may fail to respond, but it succeeds finally, so i assume it can be expected.

also, fixed logger configuration for nipostBuilder and atxBuilder, as there was a mismatch.

closes: https://github.com/spacemeshos/go-spacemesh/issues/4367