### PR TITLE
[Merged by Bors] - PoST: Remove K3 Pow

### DIFF
--- a/Makefile-libs.Inc
+++ b/Makefile-libs.Inc
@@ -49,7 +49,7 @@ else
 	endif
 endif
 
-POSTRS_SETUP_REV = 0.1.12
+POSTRS_SETUP_REV = 0.1.13
 POSTRS_SETUP_ZIP = libpost-$(platform)-v$(POSTRS_SETUP_REV).zip
 POSTRS_SETUP_URL_ZIP ?= https://github.com/spacemeshos/post-rs/releases/download/v$(POSTRS_SETUP_REV)/$(POSTRS_SETUP_ZIP)
 ifeq ($(platform), windows)

--- a/activation/post.go
+++ b/activation/post.go
@@ -22,12 +22,12 @@ type PostSetupProvider initialization.Provider
 
 // PostConfig is the configuration of the Post protocol, used for data creation, proofs generation and validation.
 type PostConfig struct {
-	MinNumUnits   uint32 `mapstructure:"post-min-numunits"`
-	MaxNumUnits   uint32 `mapstructure:"post-max-numunits"`
-	LabelsPerUnit uint64 `mapstructure:"post-labels-per-unit"`
-	K1            uint32 `mapstructure:"post-k1"`
-	K2            uint32 `mapstructure:"post-k2"`
-	K3            uint32 `mapstructure:"post-k3"`
+	MinNumUnits     uint32 `mapstructure:"post-min-numunits"`
+	MaxNumUnits     uint32 `mapstructure:"post-max-numunits"`
+	LabelsPerUnit   uint64 `mapstructure:"post-labels-per-unit"`
+	K1              uint32 `mapstructure:"post-k1"`
+	K2              uint32 `mapstructure:"post-k2"`
+	K3              uint32 `mapstructure:"post-k3"`
 	K2PowDifficulty uint64 `mapstructure:"post-k2pow-difficulty"`
 }
 

--- a/activation/post.go
+++ b/activation/post.go
@@ -28,9 +28,7 @@ type PostConfig struct {
 	K1            uint32 `mapstructure:"post-k1"`
 	K2            uint32 `mapstructure:"post-k2"`
 	K3            uint32 `mapstructure:"post-k3"`
-	// Difficulties for K2 and K3 Proofs of Work
 	K2PowDifficulty uint64 `mapstructure:"post-k2pow-difficulty"`
-	K3PowDifficulty uint64 `mapstructure:"post-k3pow-difficulty"`
 }
 
 // PostSetupOpts are the options used to initiate a Post setup data creation session,

--- a/activation/post_test.go
+++ b/activation/post_test.go
@@ -199,7 +199,6 @@ func TestPostSetupManager_GenerateProof(t *testing.T) {
 		Nonce:   p.Nonce,
 		Indices: p.Indices,
 		K2Pow:   p.K2Pow,
-		K3Pow:   p.K3Pow,
 	}, &shared.ProofMetadata{
 		NodeId:          mgr.id.Bytes(),
 		CommitmentAtxId: mgr.goldenATXID.Bytes(),

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -202,8 +202,6 @@ func AddCommands(cmd *cobra.Command) {
 		cfg.POST.K3, "subset of labels to verify in a proof")
 	cmd.PersistentFlags().Uint64Var(&cfg.POST.K2PowDifficulty, "post-k2pow-difficulty",
 		cfg.POST.K2PowDifficulty, "difficulty of K2 proof of work")
-	cmd.PersistentFlags().Uint64Var(&cfg.POST.K3PowDifficulty, "post-k3pow-difficulty",
-		cfg.POST.K3PowDifficulty, "difficulty of K3 proof of work")
 
 	/**======================== Smeshing Flags ========================== **/
 

--- a/common/types/activation.go
+++ b/common/types/activation.go
@@ -385,13 +385,6 @@ func (p *Post) EncodeScale(enc *scale.Encoder) (total int, err error) {
 		}
 		total += n
 	}
-	{
-		n, err := scale.EncodeCompact64(enc, p.K3Pow)
-		if err != nil {
-			return total, err
-		}
-		total += n
-	}
 	return total, nil
 }
 
@@ -420,14 +413,6 @@ func (p *Post) DecodeScale(dec *scale.Decoder) (total int, err error) {
 		}
 		total += n
 		p.K2Pow = field
-	}
-	{
-		field, n, err := scale.DecodeCompact64(dec)
-		if err != nil {
-			return total, err
-		}
-		total += n
-		p.K3Pow = field
 	}
 	return total, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/spacemeshos/go-scale v1.1.9
 	github.com/spacemeshos/merkle-tree v0.2.1
 	github.com/spacemeshos/poet v0.8.4
-	github.com/spacemeshos/post v0.6.3
+	github.com/spacemeshos/post v0.6.4
 	github.com/spf13/afero v1.9.5
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -603,8 +603,8 @@ github.com/spacemeshos/merkle-tree v0.2.1 h1:BSs/zt1n3ceZcpWdcqNFRvTeAWDlc0W+bql
 github.com/spacemeshos/merkle-tree v0.2.1/go.mod h1:IsrdlW6AHZ4HSi89H7G94ravFCMFZLGnm6To0tQ0SPY=
 github.com/spacemeshos/poet v0.8.4 h1:SH4s0tUacSRE0Pfo/MrF6ds4i3a40Y69Lcm6Ar++YlE=
 github.com/spacemeshos/poet v0.8.4/go.mod h1:tw/WGXBejkTJ1DljanwkzrR0h+dgUlrzasm650LEd0Q=
-github.com/spacemeshos/post v0.6.3 h1:fpb7GzEU2O1K9VBmZYHfbJI/5L9+V9BOqGzlO95UP7U=
-github.com/spacemeshos/post v0.6.3/go.mod h1:MxEMzoCuKfAByJcFlYhgLuGgbGrnEwI0V4jkGZj5C8g=
+github.com/spacemeshos/post v0.6.4 h1:0Wa23871em9BguWwHLivlz7e16ppHyjhqSYs/7HZKKI=
+github.com/spacemeshos/post v0.6.4/go.mod h1:MxEMzoCuKfAByJcFlYhgLuGgbGrnEwI0V4jkGZj5C8g=
 github.com/spacemeshos/sha256-simd v0.1.0 h1:G7Mfu5RYdQiuE+wu4ZyJ7I0TI74uqLhFnKblEnSpjYI=
 github.com/spacemeshos/sha256-simd v0.1.0/go.mod h1:O8CClVIilId7RtuCMV2+YzMj6qjVn75JsxOxaE8vcfM=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=

--- a/systest/parameters/bignet/smesher.json
+++ b/systest/parameters/bignet/smesher.json
@@ -37,7 +37,6 @@
         "post-k1": 273,
         "post-k2": 300,
         "post-k3": 100,
-        "post-k2pow-difficulty": 469112881707866048,
-        "post-k3pow-difficulty": 29244622850649904
+        "post-k2pow-difficulty": 469112881707866048
     }
 }


### PR DESCRIPTION
## Motivation
This removes K3 Pow from the Post Proof

## Changes
This integrates https://github.com/spacemeshos/post/pull/145

Merge after
- [x] https://github.com/spacemeshos/go-spacemesh/pull/4394
- [x] https://github.com/spacemeshos/post/pull/145

have been merged

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->

## TODO
<!-- This section should be removed when all items are complete -->
- [ ] Explain motivation or link existing issue(s)
- [ ] Test changes and document test plan
- [ ] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
