### PR TITLE
[Merged by Bors] - recover 2of3: adjust to new effective genesis after recovery

### DIFF
--- a/api/grpcserver/node_service.go
+++ b/api/grpcserver/node_service.go
@@ -11,6 +11,7 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
+	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/events"
 	"github.com/spacemeshos/go-spacemesh/log"
 )
@@ -101,7 +102,7 @@ func (s NodeService) getLayers() (curLayer, latestLayer, verifiedLayer uint32) {
 	// epochs, so just return the current layer instead
 	curLayerObj := s.genTime.CurrentLayer()
 	curLayer = curLayerObj.Uint32()
-	if curLayerObj.GetEpoch().IsGenesis() {
+	if curLayerObj <= types.GetEffectiveGenesis() {
 		latestLayer = s.mesh.LatestLayer().Uint32()
 		verifiedLayer = latestLayer
 	} else {

--- a/beacon/beacon.go
+++ b/beacon/beacon.go
@@ -688,7 +688,7 @@ func (pd *ProtocolDriver) onNewEpoch(ctx context.Context, epoch types.EpochID) e
 	logger := pd.logger.WithContext(ctx).WithFields(epoch)
 	defer pd.cleanupEpoch(epoch)
 
-	if epoch.IsGenesis() {
+	if epoch.FirstLayer() <= types.GetEffectiveGenesis() {
 		logger.Info("not running beacon protocol: genesis epochs")
 		return errGenesis
 	}

--- a/beacon/weakcoin/weak_coin.go
+++ b/beacon/weakcoin/weak_coin.go
@@ -156,7 +156,7 @@ type WeakCoin struct {
 // Get the result of the coin flip in this round. It is only valid in between StartEpoch/EndEpoch
 // and only after CompleteRound was called.
 func (wc *WeakCoin) Get(ctx context.Context, epoch types.EpochID, round types.RoundID) (bool, error) {
-	if epoch.IsGenesis() {
+	if epoch.FirstLayer() <= types.GetEffectiveGenesis() {
 		wc.logger.WithContext(ctx).With().Fatal("beacon weak coin not used during genesis")
 	}
 

--- a/beacon/weakcoin/weak_coin_test.go
+++ b/beacon/weakcoin/weak_coin_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
+	"os"
 	"testing"
 	"time"
 
@@ -20,6 +21,13 @@ import (
 	"github.com/spacemeshos/go-spacemesh/p2p/pubsub/mocks"
 	"github.com/spacemeshos/go-spacemesh/signing"
 )
+
+func TestMain(m *testing.M) {
+	types.SetLayersPerEpoch(3)
+
+	res := m.Run()
+	os.Exit(res)
+}
 
 func noopBroadcaster(tb testing.TB, ctrl *gomock.Controller) *mocks.MockPublisher {
 	tb.Helper()

--- a/blocks/handler.go
+++ b/blocks/handler.go
@@ -65,6 +65,9 @@ func (h *Handler) HandleSyncedBlock(ctx context.Context, peer p2p.Peer, data []b
 	}
 	// set the block ID when received
 	b.Initialize()
+	if b.LayerIndex <= types.GetEffectiveGenesis() {
+		return fmt.Errorf("block before effective genesis: layer %v", b.LayerIndex)
+	}
 
 	if err := ValidateRewards(b.Rewards); err != nil {
 		return fmt.Errorf("%w: %s", errInvalidRewards, err.Error())

--- a/blocks/handler_test.go
+++ b/blocks/handler_test.go
@@ -60,7 +60,7 @@ func Test_HandleBlockData_MalformedData(t *testing.T) {
 
 func Test_HandleBlockData_InvalidRewards(t *testing.T) {
 	th := createTestHandler(t)
-	buf, err := codec.Encode(&types.Block{})
+	buf, err := codec.Encode(&types.Block{InnerBlock: types.InnerBlock{LayerIndex: 11}})
 	require.NoError(t, err)
 	require.ErrorIs(t, th.HandleSyncedBlock(context.TODO(), p2p.NoPeer, buf), errInvalidRewards)
 }

--- a/common/types/epoch.go
+++ b/common/types/epoch.go
@@ -30,11 +30,6 @@ func (e *EpochID) DecodeScale(dec *scale.Decoder) (int, error) {
 	return n, nil
 }
 
-// IsGenesis returns true if this epoch is in genesis. The first two epochs are considered genesis epochs.
-func (e EpochID) IsGenesis() bool {
-	return e <= GetEffectiveGenesis().GetEpoch()
-}
-
 // FirstLayer returns the layer ID of the first layer in the epoch.
 func (e EpochID) FirstLayer() LayerID {
 	return LayerID(e).Mul(GetLayersPerEpoch())

--- a/common/types/epoch.go
+++ b/common/types/epoch.go
@@ -32,12 +32,12 @@ func (e *EpochID) DecodeScale(dec *scale.Decoder) (int, error) {
 
 // IsGenesis returns true if this epoch is in genesis. The first two epochs are considered genesis epochs.
 func (e EpochID) IsGenesis() bool {
-	return e < 2
+	return e <= GetEffectiveGenesis().GetEpoch()
 }
 
 // FirstLayer returns the layer ID of the first layer in the epoch.
 func (e EpochID) FirstLayer() LayerID {
-	return LayerID(uint32(e)).Mul(GetLayersPerEpoch())
+	return LayerID(e).Mul(GetLayersPerEpoch())
 }
 
 // Add Epochs to the EpochID. Panics on wraparound.

--- a/genvm/rewards.go
+++ b/genvm/rewards.go
@@ -13,7 +13,7 @@ import (
 
 func (v *VM) addRewards(lctx ApplyContext, ss *core.StagedCache, fees uint64, blockRewards []types.CoinbaseReward) ([]types.Reward, error) {
 	var (
-		layersAfterEffectiveGenesis = lctx.Layer.Difference(types.GetEffectiveGenesis())
+		layersAfterEffectiveGenesis = lctx.Layer.Difference(types.FirstEffectiveGenesis())
 		subsidy                     = rewards.TotalSubsidyAtLayer(layersAfterEffectiveGenesis)
 		total                       = subsidy + fees
 		transferred                 uint64

--- a/hare/eligibility/oracle.go
+++ b/hare/eligibility/oracle.go
@@ -377,23 +377,24 @@ func (o *Oracle) actives(ctx context.Context, targetLayer types.LayerID) (*cache
 	}
 	targetEpoch := targetLayer.GetEpoch()
 	// the first bootstrap data targets first epoch after genesis (epoch 2)
-	if targetEpoch != (types.GetEffectiveGenesis().GetEpoch()+1) &&
+	// and the epoch where checkpoint recovery happens
+	if targetEpoch != 2 &&
+		targetEpoch > types.GetEffectiveGenesis().GetEpoch() &&
 		targetLayer.Difference(targetEpoch.FirstLayer()) < o.cfg.ConfidenceParam {
 		targetEpoch -= 1
 	}
-	logger := o.WithContext(ctx).WithFields(
-		log.FieldNamed("target_layer", targetLayer),
-		log.FieldNamed("target_layer_epoch", targetLayer.GetEpoch()),
-		log.FieldNamed("target_epoch", targetEpoch),
+	o.WithContext(ctx).With().Debug("hare oracle getting active set",
+		log.Stringer("target_layer", targetLayer),
+		log.Stringer("target_layer_epoch", targetLayer.GetEpoch()),
+		log.Stringer("target_epoch", targetEpoch),
 	)
-	logger.Debug("hare oracle getting active set")
 
 	o.lock.Lock()
 	defer o.lock.Unlock()
 	if value, exists := o.activesCache.Get(targetEpoch); exists {
 		return value.(*cachedActiveSet), nil
 	}
-	activeSet, err := o.computeActiveSet(logger, targetEpoch)
+	activeSet, err := o.computeActiveSet(ctx, targetEpoch)
 	if err != nil {
 		return nil, err
 	}
@@ -409,7 +410,7 @@ func (o *Oracle) actives(ctx context.Context, targetLayer types.LayerID) (*cache
 	for _, weight := range activeWeights {
 		aset.total += weight
 	}
-	logger.With().Info("got hare active set", log.Int("count", len(activeWeights)))
+	o.WithContext(ctx).With().Info("got hare active set", log.Int("count", len(activeWeights)))
 	o.activesCache.Add(targetEpoch, aset)
 	return aset, nil
 }
@@ -430,10 +431,13 @@ func (o *Oracle) ActiveSet(ctx context.Context, targetEpoch types.EpochID) ([]ty
 	return activeSet, nil
 }
 
-func (o *Oracle) computeActiveSet(logger log.Log, targetEpoch types.EpochID) ([]types.ATXID, error) {
+func (o *Oracle) computeActiveSet(ctx context.Context, targetEpoch types.EpochID) ([]types.ATXID, error) {
 	activeSet, ok := o.fallback[targetEpoch]
 	if ok {
-		logger.With().Info("using fallback active set", log.Int("size", len(activeSet)))
+		o.WithContext(ctx).With().Info("using fallback active set",
+			targetEpoch,
+			log.Int("size", len(activeSet)),
+		)
 		return activeSet, nil
 	}
 	bid, err := certificates.FirstInEpoch(o.cdb, targetEpoch)

--- a/hare/hare.go
+++ b/hare/hare.go
@@ -314,16 +314,15 @@ func (h *Hare) isClosed() bool {
 // the logic that happens when a new layer arrives.
 // this function triggers the start of new consensus processes.
 func (h *Hare) onTick(ctx context.Context, lid types.LayerID) (bool, error) {
-	logger := h.WithContext(ctx).WithFields(lid)
 	if h.isClosed() {
-		logger.Info("hare exiting")
+		h.With().Debug("hare exiting", log.Context(ctx), lid)
 		return false, nil
 	}
 
 	h.setLastLayer(lid)
 
 	if lid <= types.GetEffectiveGenesis() {
-		logger.Info("not starting hare: genesis")
+		h.With().Debug("not starting hare: genesis", log.Context(ctx), lid)
 		return false, nil
 	}
 
@@ -331,14 +330,21 @@ func (h *Hare) onTick(ctx context.Context, lid types.LayerID) (bool, error) {
 	h.eg.Go(func() error {
 		// this is called only for its side effects, but at least print the error if it returns one
 		if isActive, err := h.rolacle.IsIdentityActiveOnConsensusView(ctx, h.nodeID, lid); err != nil {
-			logger.With().Warning("error checking if identity is active",
-				log.Bool("isActive", isActive), log.Err(err),
+			h.With().Warning("error checking if identity is active",
+				log.Context(ctx),
+				lid,
+				log.Bool("isActive", isActive),
+				log.Err(err),
 			)
 		}
 		return nil
 	})
 
-	logger.With().Debug("hare got tick, sleeping", log.String("delta", fmt.Sprint(h.networkDelta)))
+	h.With().Debug("hare got tick, sleeping",
+		log.Context(ctx),
+		lid,
+		log.String("delta", fmt.Sprint(h.networkDelta)),
+	)
 
 	clock := h.newRoundClock(lid)
 	select {
@@ -350,21 +356,27 @@ func (h *Hare) onTick(ctx context.Context, lid types.LayerID) (bool, error) {
 
 	if !h.broker.Synced(ctx, lid) {
 		// if not currently synced don't start consensus process
-		logger.Info("not starting hare: node not synced at this layer")
+		h.With().Info("not starting hare: node not synced at this layer",
+			log.Context(ctx),
+			lid,
+		)
 		return false, nil
 	}
 
 	var err error
 	beacon, err := h.beacons.GetBeacon(lid.GetEpoch())
 	if err != nil {
-		logger.Info("not starting hare: beacon not retrieved")
+		h.With().Info("not starting hare: beacon not retrieved",
+			log.Context(ctx),
+			lid,
+		)
 		return false, nil
 	}
 
 	var nonce *types.VRFPostIndex
 	nnc, err := h.msh.VRFNonce(h.nodeID, h.lastLayer.GetEpoch())
 	if err != nil && !errors.Is(err, sql.ErrNotFound) {
-		logger.With().Error("failed to get vrf nonce", log.Err(err))
+		h.With().Error("failed to get vrf nonce", log.Err(err))
 		return false, fmt.Errorf("vrf nonce: %w", err)
 	} else if err == nil {
 		nonce = &nnc
@@ -372,7 +384,6 @@ func (h *Hare) onTick(ctx context.Context, lid types.LayerID) (bool, error) {
 
 	ch, err := h.broker.Register(ctx, lid)
 	if err != nil {
-		logger.With().Error("failed to register with broker", log.Err(err))
 		return false, fmt.Errorf("broker register: %w", err)
 	}
 	comm := communication{
@@ -380,24 +391,30 @@ func (h *Hare) onTick(ctx context.Context, lid types.LayerID) (bool, error) {
 		mchOut: h.mchMalfeasance,
 		report: h.outputChan,
 	}
-	props := goodProposals(logger, h.msh, h.nodeID, lid, beacon)
+	props := goodProposals(h.Log, h.msh, h.nodeID, lid, beacon)
 	preNumProposals.Add(float64(len(props)))
 	set := NewSet(props)
 	cp := h.factory(ctx, h.config, lid, set, h.rolacle, h.sign, nonce, h.publisher, comm, clock)
 
-	logger.With().Debug("starting hare", log.Int("num_proposals", len(props)))
+	h.With().Debug("starting hare",
+		log.Context(ctx),
+		lid,
+		log.Int("num proposals", len(props)),
+	)
 	cp.Start()
-	h.addCP(logger, cp)
+	h.addCP(ctx, cp)
 	h.patrol.SetHareInCharge(lid)
 	return true, nil
 }
 
-func (h *Hare) addCP(logger log.Log, cp Consensus) {
+func (h *Hare) addCP(ctx context.Context, cp Consensus) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	h.cps[cp.ID()] = cp
-	logger.With().Debug("number of consensus processes (after register)",
-		log.Int("count", len(h.cps)))
+	h.With().Debug("number of consensus processes (after register)",
+		log.Context(ctx),
+		log.Int("count", len(h.cps)),
+	)
 	processesGauge.Set(float64(len(h.cps)))
 }
 
@@ -407,10 +424,10 @@ func (h *Hare) getCP(lid types.LayerID) Consensus {
 	return h.cps[lid]
 }
 
-func (h *Hare) removeCP(logger log.Log, lid types.LayerID) {
+func (h *Hare) removeCP(ctx context.Context, lid types.LayerID) {
 	cp := h.getCP(lid)
 	if cp == nil {
-		logger.With().Error("failed to find consensus process", lid)
+		h.With().Error("failed to find consensus process", log.Context(ctx), lid)
 		return
 	}
 	// do not hold lock while waiting for consensus process to terminate
@@ -419,7 +436,9 @@ func (h *Hare) removeCP(logger log.Log, lid types.LayerID) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	delete(h.cps, cp.ID())
-	logger.With().Debug("number of consensus processes (after deregister)",
+	h.With().Debug("number of consensus processes (after deregister)",
+		log.Context(ctx),
+		lid,
 		log.Int("count", len(h.cps)))
 	processesGauge.Set(float64(len(h.cps)))
 }
@@ -526,19 +545,28 @@ func (h *Hare) outputCollectionLoop(ctx context.Context) {
 			layerID := out.ID()
 			coin := out.Coinflip()
 			ctx := log.WithNewSessionID(ctx)
-			logger := h.WithContext(ctx).WithFields(layerID)
 
 			// collect coinflip, regardless of success
-			logger.With().Debug("recording weak coin result for layer",
+			h.With().Debug("recording weak coin result for layer",
+				log.Context(ctx),
+				layerID,
 				log.Bool("weak_coin", coin))
 			if err := h.weakCoin.Set(layerID, coin); err != nil {
-				logger.With().Error("failed to set weak coin for layer", log.Err(err))
+				h.With().Error("failed to set weak coin for layer",
+					log.Context(ctx),
+					layerID,
+					log.Err(err),
+				)
 			}
 			if err := h.collectOutput(ctx, out); err != nil {
-				logger.With().Warning("error collecting output from hare", log.Err(err))
+				h.With().Warning("error collecting output from hare",
+					log.Context(ctx),
+					layerID,
+					log.Err(err),
+				)
 			}
 			h.broker.Unregister(ctx, out.ID())
-			h.removeCP(logger, out.ID())
+			h.removeCP(ctx, out.ID())
 		case <-h.ctx.Done():
 			return
 		}
@@ -555,7 +583,14 @@ func (h *Hare) tickLoop(ctx context.Context) {
 				h.WithContext(ctx).With().Warning("missed hare window, skipping layer", layer)
 				continue
 			}
-			_, _ = h.onTick(ctx, layer)
+			_, err := h.onTick(ctx, layer)
+			if err != nil {
+				h.With().Warning("hare failed",
+					log.Context(ctx),
+					layer,
+					log.Err(err),
+				)
+			}
 		case <-h.ctx.Done():
 			return
 		}
@@ -575,24 +610,42 @@ func (h *Hare) malfeasanceLoop(ctx context.Context) {
 			if gossip.Eligibility == nil {
 				h.WithContext(ctx).Fatal("missing hare eligibility")
 			}
-			logger := h.WithContext(ctx).WithFields(gossip.Eligibility.NodeID)
 			if malicious, err := h.msh.IsMalicious(gossip.Eligibility.NodeID); err != nil {
-				logger.With().Error("failed to check identity", log.Err(err))
+				h.With().Error("failed to check identity",
+					log.Context(ctx),
+					gossip.Eligibility.NodeID,
+					log.Err(err),
+				)
 				continue
 			} else if malicious {
-				logger.Debug("known malicious identity")
+				h.With().Debug("known malicious identity",
+					log.Context(ctx),
+					gossip.Eligibility.NodeID,
+				)
 				continue
 			}
 			if err := h.msh.AddMalfeasanceProof(gossip.Eligibility.NodeID, &gossip.MalfeasanceProof, nil); err != nil {
-				logger.With().Error("failed to save MalfeasanceProof", log.Err(err))
+				h.With().Error("failed to save MalfeasanceProof",
+					log.Context(ctx),
+					gossip.Eligibility.NodeID,
+					log.Err(err),
+				)
 				continue
 			}
 			gossipBytes, err := codec.Encode(gossip)
 			if err != nil {
-				logger.With().Fatal("failed to encode MalfeasanceGossip", log.Err(err))
+				h.With().Fatal("failed to encode MalfeasanceGossip",
+					log.Context(ctx),
+					gossip.Eligibility.NodeID,
+					log.Err(err),
+				)
 			}
 			if err = h.publisher.Publish(ctx, pubsub.MalfeasanceProof, gossipBytes); err != nil {
-				logger.With().Error("failed to broadcast MalfeasanceProof")
+				h.With().Error("failed to broadcast MalfeasanceProof",
+					log.Context(ctx),
+					gossip.Eligibility.NodeID,
+					log.Err(err),
+				)
 			}
 		case <-ctx.Done():
 			return

--- a/hare/hare_test.go
+++ b/hare/hare_test.go
@@ -535,7 +535,7 @@ func TestHare_goodProposal(t *testing.T) {
 			for _, i := range tc.expected {
 				expected = append(expected, pList[i].ID())
 			}
-			got := goodProposals(logtest.New(t), mockMesh, nodeID, lyrID, nodeBeacon)
+			got := goodProposals(context.Background(), logtest.New(t), mockMesh, nodeID, lyrID, nodeBeacon)
 			require.ElementsMatch(t, expected, got)
 		})
 	}

--- a/mesh/mesh.go
+++ b/mesh/mesh.go
@@ -79,16 +79,14 @@ func NewMesh(cdb *datastore.CachedDB, c layerClock, trtl system.Tortoise, exec *
 
 	genesis := types.GetEffectiveGenesis()
 	if err = cdb.WithTx(context.Background(), func(dbtx *sql.Tx) error {
-		for i := types.LayerID(1); !i.After(genesis); i = i.Add(1) {
-			if err = layers.SetProcessed(dbtx, i); err != nil {
-				return fmt.Errorf("mesh init: %w", err)
-			}
-			if err = layers.SetApplied(dbtx, i, types.EmptyBlockID); err != nil {
-				return fmt.Errorf("mesh init: %w", err)
-			}
-			if err := layers.SetMeshHash(dbtx, i, hash.Sum(nil)); err != nil {
-				return err
-			}
+		if err = layers.SetProcessed(dbtx, genesis); err != nil {
+			return fmt.Errorf("mesh init: %w", err)
+		}
+		if err = layers.SetApplied(dbtx, genesis, types.EmptyBlockID); err != nil {
+			return fmt.Errorf("mesh init: %w", err)
+		}
+		if err := layers.SetMeshHash(dbtx, genesis, hash.Sum(nil)); err != nil {
+			return err
 		}
 		return nil
 	}); err != nil {

--- a/miner/oracle.go
+++ b/miner/oracle.go
@@ -63,20 +63,23 @@ func (o *Oracle) GetProposalEligibility(lid types.LayerID, beacon types.Beacon, 
 	defer o.mu.Unlock()
 
 	epoch := lid.GetEpoch()
-	logger := o.log.WithFields(lid,
-		log.Named("requested_epoch", epoch),
-		log.Named("cached_epoch", o.cache.Epoch))
-
-	if epoch.IsGenesis() {
-		logger.With().Panic("eligibility should not be queried during genesis", lid, epoch)
+	if lid <= types.GetEffectiveGenesis() {
+		o.log.With().Panic("eligibility should not be queried during genesis", lid, epoch)
 	}
 
-	logger.Debug("asked for proposal eligibility")
+	o.log.With().Debug("asked for proposal eligibility",
+		log.Stringer("requested epoch", epoch),
+		log.Stringer("cached epoch", o.cache.Epoch),
+	)
 
 	var layerProofs []types.VotingEligibility
 	if o.cache.Epoch == epoch { // use the cached value
 		layerProofs = o.cache.Proofs[lid]
-		logger.With().Debug("got cached eligibility", log.Int("num_proposals", len(layerProofs)))
+		o.log.With().Debug("got cached eligibility",
+			log.Stringer("requested epoch", epoch),
+			log.Stringer("cached epoch", o.cache.Epoch),
+			log.Int("num proposals", len(layerProofs)),
+		)
 		return o.cache, nil
 	}
 
@@ -115,7 +118,6 @@ func (o *Oracle) getOwnEpochATX(targetEpoch types.EpochID) (*types.ActivationTxH
 // and returns the proofs along with the epoch's active set.
 func (o *Oracle) calcEligibilityProofs(atx *types.ActivationTxHeader, epoch types.EpochID, beacon types.Beacon, nonce types.VRFPostIndex) (*EpochEligibility, error) {
 	weight := atx.GetWeight()
-	logger := o.log.WithFields(epoch, beacon, log.Uint64("weight", weight))
 
 	// get the previous epoch's total weight
 	totalWeight, activeSet, err := o.cdb.GetEpochWeight(epoch)
@@ -129,8 +131,12 @@ func (o *Oracle) calcEligibilityProofs(atx *types.ActivationTxHeader, epoch type
 		return nil, errEmptyActiveSet
 	}
 
-	logger = logger.WithFields(log.Uint64("total_weight", totalWeight))
-	logger.Debug("calculating eligibility")
+	o.log.With().Debug("calculating eligibility",
+		epoch,
+		beacon,
+		log.Uint64("weight", weight),
+		log.Uint64("total weight", totalWeight),
+	)
 
 	numEligibleSlots, err := proposals.GetNumEligibleSlots(weight, totalWeight, o.avgLayerSize, o.layersPerEpoch)
 	if err != nil {
@@ -141,7 +147,7 @@ func (o *Oracle) calcEligibilityProofs(atx *types.ActivationTxHeader, epoch type
 	for counter := uint32(0); counter < numEligibleSlots; counter++ {
 		message, err := proposals.SerializeVRFMessage(beacon, epoch, nonce, counter)
 		if err != nil {
-			logger.With().Fatal("failed to serialize VRF msg", log.Err(err))
+			o.log.With().Fatal("failed to serialize VRF msg", log.Err(err))
 		}
 		vrfSig := o.vrfSigner.Sign(message)
 		eligibleLayer := proposals.CalcEligibleLayer(epoch, o.layersPerEpoch, vrfSig)
@@ -149,15 +155,17 @@ func (o *Oracle) calcEligibilityProofs(atx *types.ActivationTxHeader, epoch type
 			J:   counter,
 			Sig: vrfSig,
 		})
-		logger.Debug("signed vrf message, counter: %v, vrfSig: %s, layer: %v",
-			counter, vrfSig, eligibleLayer,
-		)
+		o.log.Debug(fmt.Sprintf("signed vrf message, counter: %v, vrfSig: %s, layer: %v", counter, vrfSig, eligibleLayer))
 	}
 
-	logger.With().Info("proposal eligibility for an epoch",
-		log.Uint32("total_num_slots", numEligibleSlots),
-		log.Int("num_layers_eligible", len(eligibilityProofs)),
-		log.Array("layers_to_num_proposals", log.ArrayMarshalerFunc(func(encoder log.ArrayEncoder) error {
+	o.log.With().Info("proposal eligibility for an epoch",
+		epoch,
+		beacon,
+		log.Uint64("weight", weight),
+		log.Uint64("total weight", totalWeight),
+		log.Uint32("total num slots", numEligibleSlots),
+		log.Int("num layers eligible", len(eligibilityProofs)),
+		log.Array("layers to num proposals", log.ArrayMarshalerFunc(func(encoder log.ArrayEncoder) error {
 			// Sort the layer map to log the layer data in order
 			keys := make([]types.LayerID, 0, len(eligibilityProofs))
 			for k := range eligibilityProofs {

--- a/miner/proposal_builder.go
+++ b/miner/proposal_builder.go
@@ -207,10 +207,11 @@ func (pb *ProposalBuilder) createProposal(
 	txIDs []types.TransactionID,
 	opinion types.Opinion,
 ) (*types.Proposal, error) {
-	logger := pb.logger.WithContext(ctx).WithFields(layerID, layerID.GetEpoch())
-
 	if !layerID.After(types.GetEffectiveGenesis()) {
-		logger.With().Fatal("attempt to create proposal during genesis", layerID)
+		pb.logger.With().Fatal("attempt to create proposal during genesis",
+			log.Context(ctx),
+			layerID,
+		)
 	}
 
 	ib := &types.InnerBallot{
@@ -223,12 +224,14 @@ func (pb *ProposalBuilder) createProposal(
 	refBallot, err := ballots.GetRefBallot(pb.cdb, epoch, pb.signer.NodeID())
 	if err != nil {
 		if !errors.Is(err, sql.ErrNotFound) {
-			logger.With().Error("failed to get ref ballot", log.Err(err))
 			return nil, fmt.Errorf("get ref ballot: %w", err)
 		}
 
-		logger.With().Debug("creating ballot with active set (reference ballot in epoch)",
-			log.Int("active_set_size", len(epochEligibility.ActiveSet)))
+		pb.logger.With().Debug("creating ballot with active set (reference ballot in epoch)",
+			log.Context(ctx),
+			layerID,
+			log.Int("active_set_size", len(epochEligibility.ActiveSet)),
+		)
 		ib.RefBallot = types.EmptyBallotID
 		ib.EpochData = &types.EpochData{
 			ActiveSetHash:    epochEligibility.ActiveSet.Hash(),
@@ -236,8 +239,11 @@ func (pb *ProposalBuilder) createProposal(
 			EligibilityCount: epochEligibility.Slots,
 		}
 	} else {
-		logger.With().Debug("creating ballot with reference ballot (no active set)",
-			log.Named("ref_ballot", refBallot))
+		pb.logger.With().Debug("creating ballot with reference ballot (no active set)",
+			log.Context(ctx),
+			layerID,
+			log.Named("ref_ballot", refBallot),
+		)
 		ib.RefBallot = refBallot
 	}
 
@@ -249,7 +255,7 @@ func (pb *ProposalBuilder) createProposal(
 				EligibilityProofs: epochEligibility.Proofs[layerID],
 			},
 			TxIDs:    txIDs,
-			MeshHash: pb.decideMeshHash(logger, layerID),
+			MeshHash: pb.decideMeshHash(ctx, layerID),
 		},
 	}
 	if p.EpochData != nil {
@@ -259,9 +265,18 @@ func (pb *ProposalBuilder) createProposal(
 	p.SmesherID = pb.signer.NodeID()
 	p.Signature = pb.signer.Sign(signing.BALLOT, p.SignedBytes())
 	if err := p.Initialize(); err != nil {
-		logger.With().Fatal("proposal failed to initialize", log.Err(err))
+		pb.logger.With().Fatal("proposal failed to initialize",
+			log.Context(ctx),
+			layerID,
+			log.Err(err),
+		)
 	}
-	logger.Event().Info("proposal created", p.ID(), log.Int("num_txs", len(p.TxIDs)))
+	pb.logger.Event().Info("proposal created",
+		log.Context(ctx),
+		layerID,
+		p.ID(),
+		log.Int("num txs", len(p.TxIDs)),
+	)
 	return p, nil
 }
 
@@ -270,7 +285,7 @@ func (pb *ProposalBuilder) createProposal(
 // - the node has hare output for every layer i such that N-hdist <= i <= N.
 // this is done such that when the node is generating the block based on hare output,
 // it can do optimistic filtering if the majority of the proposals agreed on the mesh hash.
-func (pb *ProposalBuilder) decideMeshHash(logger log.Log, current types.LayerID) types.Hash32 {
+func (pb *ProposalBuilder) decideMeshHash(ctx context.Context, current types.LayerID) types.Hash32 {
 	var minVerified types.LayerID
 	if current.Uint32() > pb.cfg.hdist+1 {
 		minVerified = current.Sub(pb.cfg.hdist + 1)
@@ -281,31 +296,46 @@ func (pb *ProposalBuilder) decideMeshHash(logger log.Log, current types.LayerID)
 	}
 	verified := pb.tortoise.LatestComplete()
 	if minVerified.After(verified) {
-		logger.With().Warning("layers outside hdist not verified",
-			log.Stringer("min_verified", minVerified),
-			log.Stringer("latest_verified", verified))
+		pb.logger.With().Warning("layers outside hdist not verified",
+			log.Context(ctx),
+			current,
+			log.Stringer("min verified", minVerified),
+			log.Stringer("latest verified", verified))
 		return types.EmptyLayerHash
 	}
-	logger.With().Debug("verified layer meets optimistic filtering threshold",
-		log.Stringer("min_verified", minVerified),
-		log.Stringer("latest_verified", verified))
+	pb.logger.With().Debug("verified layer meets optimistic filtering threshold",
+		log.Context(ctx),
+		current,
+		log.Stringer("min verified", minVerified),
+		log.Stringer("latest verified", verified),
+	)
 
 	for lid := minVerified.Add(1); lid.Before(current); lid = lid.Add(1) {
 		_, err := certificates.GetHareOutput(pb.cdb, lid)
 		if err != nil {
-			logger.With().Warning("missing hare output for layer within hdist",
+			pb.logger.With().Warning("missing hare output for layer within hdist",
+				log.Context(ctx),
+				current,
 				log.Stringer("missing_layer", lid),
-				log.Err(err))
+				log.Err(err),
+			)
 			return types.EmptyLayerHash
 		}
 	}
-	logger.With().Debug("hare outputs meet optimistic filtering threshold",
+	pb.logger.With().Debug("hare outputs meet optimistic filtering threshold",
+		log.Context(ctx),
+		current,
 		log.Stringer("from", minVerified.Add(1)),
-		log.Stringer("to", current.Sub(1)))
+		log.Stringer("to", current.Sub(1)),
+	)
 
 	mesh, err := layers.GetAggregatedHash(pb.cdb, current.Sub(1))
 	if err != nil {
-		logger.With().Warning("failed to get mesh hash", log.Err(err))
+		pb.logger.With().Warning("failed to get mesh hash",
+			log.Context(ctx),
+			current,
+			log.Err(err),
+		)
 		return types.EmptyLayerHash
 	}
 	return mesh
@@ -316,19 +346,15 @@ func (pb *ProposalBuilder) handleLayer(ctx context.Context, layerID types.LayerI
 		beacon types.Beacon
 		err    error
 		epoch  = layerID.GetEpoch()
-		logger = pb.logger.WithContext(ctx).WithFields(layerID, epoch)
 	)
 
-	if layerID.GetEpoch().IsGenesis() {
-		logger.Info("not building proposal: genesis")
+	if layerID <= types.GetEffectiveGenesis() {
 		return errGenesis
 	}
 	if !pb.syncer.IsSynced(ctx) {
-		logger.Info("not building proposal: not synced")
 		return errNotSynced
 	}
 	if beacon, err = pb.beaconProvider.GetBeacon(epoch); err != nil {
-		logger.With().Warning("beacon not available for epoch", log.Err(err))
 		return errNoBeacon
 	}
 
@@ -336,42 +362,35 @@ func (pb *ProposalBuilder) handleLayer(ctx context.Context, layerID types.LayerI
 
 	count, err := ballots.CountByPubkeyLayer(pb.cdb, layerID, pb.signer.NodeID())
 	if err != nil {
-		logger.With().Error("count ballots in a layer for public key", log.Err(err))
 		return err
 	} else if count != 0 {
-		logger.With().Error("smesher already created a proposal in this layer",
-			log.Int("count", count),
-		)
 		return errDuplicateLayer
 	}
 
 	nonce, err := pb.nonceFetcher.VRFNonce(pb.signer.NodeID(), layerID.GetEpoch())
 	if err != nil {
 		if errors.Is(err, sql.ErrNotFound) {
-			logger.With().Info("miner has no valid vrf nonce, not building proposal")
+			pb.logger.WithContext(ctx).With().Info("miner has no valid vrf nonce, not building proposal", layerID)
 			return nil
-		} else {
-			logger.With().Error("failed to get VRF nonce", log.Err(err))
 		}
 		return err
 	}
 	epochEligibility, err := pb.proposalOracle.GetProposalEligibility(layerID, beacon, nonce)
 	if err != nil {
 		if errors.Is(err, errMinerHasNoATXInPreviousEpoch) {
-			logger.Info("miner has no ATX in previous epoch")
 			return fmt.Errorf("miner no ATX: %w", err)
 		}
-		logger.With().Error("failed to check for proposal eligibility", log.Err(err))
 		return fmt.Errorf("proposal eligibility: %w", err)
 	}
 	proofs := epochEligibility.Proofs[layerID]
 	if len(proofs) == 0 {
-		logger.Debug("not eligible for proposal in layer")
+		pb.logger.WithContext(ctx).With().Debug("not eligible for proposal in layer", layerID)
 		return nil
 	}
-	logger.With().Debug("eligible for proposals in layer",
+	pb.logger.WithContext(ctx).With().Debug("eligible for proposals in layer",
+		layerID,
 		epochEligibility.Atx,
-		log.Int("num_proposals", len(proofs)),
+		log.Int("num proposals", len(proofs)),
 	)
 
 	pb.tortoise.TallyVotes(ctx, layerID)
@@ -379,14 +398,16 @@ func (pb *ProposalBuilder) handleLayer(ctx context.Context, layerID types.LayerI
 	// there are some dependencies in the tests
 	opinion, err := pb.tortoise.EncodeVotes(ctx, tortoise.EncodeVotesWithCurrent(layerID))
 	if err != nil {
-		logger.With().Error("failed to encode votes", log.Err(err))
-		return fmt.Errorf("get base ballot: %w", err)
+		pb.logger.WithContext(ctx).With().Error("failed to encode votes",
+			layerID,
+			log.Err(err),
+		)
+		return fmt.Errorf("encode votes: %w", err)
 	}
 
 	txList := pb.conState.SelectProposalTXs(layerID, len(proofs))
 	p, err := pb.createProposal(ctx, layerID, epochEligibility, beacon, txList, *opinion)
 	if err != nil {
-		logger.With().Error("failed to create new proposal", log.Err(err))
 		return err
 	}
 
@@ -403,10 +424,10 @@ func (pb *ProposalBuilder) handleLayer(ctx context.Context, layerID types.LayerI
 		// proposal is sent over the network
 		data, err := codec.Encode(p)
 		if err != nil {
-			logger.With().Panic("failed to serialize proposal", log.Err(err))
+			pb.logger.WithContext(newCtx).With().Fatal("failed to serialize proposal", log.Err(err))
 		}
 		if err = pb.publisher.Publish(newCtx, pubsub.ProposalProtocol, data); err != nil {
-			logger.WithContext(newCtx).With().Error("failed to send proposal", log.Err(err))
+			pb.logger.WithContext(newCtx).With().Error("failed to send proposal", log.Err(err))
 		}
 		events.ReportProposal(events.ProposalCreated, p)
 		return nil
@@ -428,7 +449,9 @@ func (pb *ProposalBuilder) createProposalLoop(ctx context.Context) {
 			}
 			next = current.Add(1)
 			lyrCtx := log.WithNewSessionID(ctx)
-			_ = pb.handleLayer(lyrCtx, current)
+			if err := pb.handleLayer(lyrCtx, current); err != nil {
+				pb.logger.WithContext(lyrCtx).With().Warning("failed to build proposal", current, log.Err(err))
+			}
 		}
 	}
 }

--- a/proposals/handler.go
+++ b/proposals/handler.go
@@ -144,6 +144,9 @@ func (h *Handler) HandleSyncedBallot(ctx context.Context, peer p2p.Peer, data []
 		logger.With().Error("malformed ballot", log.Err(err))
 		return errMalformedData
 	}
+	if b.Layer <= types.GetEffectiveGenesis() {
+		return fmt.Errorf("ballot before effective genesis: layer %v", b.Layer)
+	}
 
 	if !h.edVerifier.Verify(signing.BALLOT, b.SmesherID, b.SignedBytes(), b.Signature) {
 		return fmt.Errorf("failed to verify ballot signature")
@@ -227,6 +230,9 @@ func (h *Handler) handleProposal(ctx context.Context, peer p2p.Peer, data []byte
 	if err := codec.Decode(data, &p); err != nil {
 		logger.With().Error("malformed proposal", log.Err(err))
 		return errMalformedData
+	}
+	if p.Layer <= types.GetEffectiveGenesis() {
+		return fmt.Errorf("proposal before effective genesis: layer %v", p.Layer)
 	}
 
 	latency := receivedTime.Sub(h.clock.LayerToTime(p.Layer))

--- a/syncer/find_fork_test.go
+++ b/syncer/find_fork_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/fetch"
@@ -135,7 +134,7 @@ func TestForkFinder_FindFork_Permutation(t *testing.T) {
 	expected := diverge - 1
 	for maxHashes := uint32(30); maxHashes >= 5; maxHashes -= 3 {
 		for lid := max; lid > expected; lid-- {
-			tf := newTestForkFinderWithDuration(t, maxHashes, time.Hour, logtest.New(t, zapcore.DebugLevel))
+			tf := newTestForkFinderWithDuration(t, maxHashes, time.Hour, logtest.New(t))
 			storeNodeHashes(t, tf.db, diverge, max)
 			tf.mFetcher.EXPECT().PeerMeshHashes(gomock.Any(), peer, gomock.Any()).DoAndReturn(
 				func(_ context.Context, _ p2p.Peer, req *fetch.MeshHashRequest) (*fetch.MeshHashes, error) {

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -179,7 +179,7 @@ func NewSyncer(
 	s.isBusy.Store(0)
 	s.targetSyncedLayer.Store(types.LayerID(0))
 	s.lastLayerSynced.Store(s.mesh.ProcessedLayer())
-	s.lastEpochSynced.Store(types.EpochID(0))
+	s.lastEpochSynced.Store(types.GetEffectiveGenesis().GetEpoch() - 1)
 	return s
 }
 
@@ -222,7 +222,7 @@ func (s *Syncer) Start(ctx context.Context) {
 	s.syncOnce.Do(func() {
 		s.logger.WithContext(ctx).Info("starting syncer loop")
 		s.eg.Go(func() error {
-			if s.ticker.CurrentLayer().Uint32() <= 1 {
+			if s.ticker.CurrentLayer() <= types.GetEffectiveGenesis() {
 				s.setATXSynced()
 				s.setSyncState(ctx, synced)
 			}
@@ -422,7 +422,8 @@ func (s *Syncer) synchronize(ctx context.Context) bool {
 		log.Stringer("current", s.ticker.CurrentLayer()),
 		log.Stringer("latest", s.mesh.LatestLayer()),
 		log.Stringer("last_synced", s.getLastSyncedLayer()),
-		log.Stringer("processed", s.mesh.ProcessedLayer()))
+		log.Stringer("processed", s.mesh.ProcessedLayer()),
+	)
 	return success
 }
 
@@ -446,6 +447,17 @@ func (s *Syncer) syncAtx(ctx context.Context) error {
 		}
 		s.setATXSynced()
 		return nil
+	}
+
+	// after recovering from a checkpoint, we want to be aggressive syncing atx from peers
+	// as a form of regossip for atxs that didn't make it into the checkpoint data.
+	if types.FirstEffectiveGenesis() != types.GetEffectiveGenesis() &&
+		(s.ticker.CurrentLayer() < types.GetEffectiveGenesis() ||
+			s.ticker.CurrentLayer().GetEpoch() == types.GetEffectiveGenesis().GetEpoch()) {
+		// sync atxs for the first recovery epoch
+		if err := s.fetchATXsForEpoch(ctx, types.GetEffectiveGenesis().GetEpoch()+1); err != nil {
+			return err
+		}
 	}
 
 	// steady state atx syncing

--- a/syncer/syncer_test.go
+++ b/syncer/syncer_test.go
@@ -97,7 +97,7 @@ func newTestSyncer(t *testing.T, interval time.Duration) *testSyncer {
 		SyncCertDistance: 4,
 		HareDelayLayers:  5,
 	}
-	ts.syncer = NewSyncer(ts.cdb, mt, ts.mBeacon, ts.msh, nil, nil, ts.mLyrPatrol, ts.mCertHdr,
+	ts.syncer = NewSyncer(ts.cdb, ts.mTicker, ts.mBeacon, ts.msh, nil, nil, ts.mLyrPatrol, ts.mCertHdr,
 		WithConfig(cfg),
 		WithLogger(lg),
 		withDataFetcher(ts.mDataFetcher),
@@ -607,4 +607,22 @@ func TestSyncer_IsBeaconSynced(t *testing.T) {
 	require.False(t, ts.syncer.IsBeaconSynced(epoch))
 	ts.mBeacon.EXPECT().GetBeacon(epoch).Return(types.RandomBeacon(), nil)
 	require.True(t, ts.syncer.IsBeaconSynced(epoch))
+}
+
+func TestSynchronize_RecoverFromCheckpoint(t *testing.T) {
+	ts := newSyncerWithoutSyncTimer(t)
+	current := types.GetEffectiveGenesis().Add(types.GetLayersPerEpoch() * 5)
+	// recover from a checkpoint
+	types.SetEffectiveGenesis(current.Uint32())
+	ts.mTicker.advanceToLayer(current)
+	ts.syncer = NewSyncer(ts.cdb, ts.mTicker, ts.mBeacon, ts.msh, nil, nil, ts.mLyrPatrol, ts.mCertHdr,
+		WithConfig(ts.syncer.cfg),
+		WithLogger(ts.syncer.logger),
+		withDataFetcher(ts.mDataFetcher),
+		withForkFinder(ts.mForkFinder))
+	// should not sync any atxs before current epoch
+	ts.mDataFetcher.EXPECT().GetEpochATXs(gomock.Any(), current.GetEpoch())
+	require.True(t, ts.syncer.synchronize(context.Background()))
+	require.Equal(t, current.GetEpoch(), ts.syncer.lastAtxEpoch())
+	types.SetEffectiveGenesis(types.FirstEffectiveGenesis().Uint32())
 }

--- a/tortoise/algorithm.go
+++ b/tortoise/algorithm.go
@@ -119,14 +119,13 @@ func (t *Tortoise) OnWeakCoin(lid types.LayerID, coin bool) {
 func (t *Tortoise) OnBeacon(eid types.EpochID, beacon types.Beacon) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	evicted := t.trtl.evicted.GetEpoch()
+	firstInWindow := t.trtl.evicted.Add(1).GetEpoch()
 	t.logger.With().Debug("on beacon",
-		log.Uint32("epoch_id", eid.Uint32()),
-		log.Uint32("evicted", evicted.Uint32()),
+		log.Uint32("epoch id", eid.Uint32()),
+		log.Uint32("first epoch", firstInWindow.Uint32()),
 		log.Stringer("beacon", beacon),
 	)
-	// when the node recover from checkpoint, the new effective genesis can be the same as the beacon's target epoch.
-	if eid <= evicted && eid != types.GetEffectiveGenesis().GetEpoch() {
+	if eid < firstInWindow {
 		return
 	}
 	epoch := t.trtl.epoch(eid)

--- a/tortoise/algorithm.go
+++ b/tortoise/algorithm.go
@@ -125,7 +125,8 @@ func (t *Tortoise) OnBeacon(eid types.EpochID, beacon types.Beacon) {
 		log.Uint32("evicted", evicted.Uint32()),
 		log.Stringer("beacon", beacon),
 	)
-	if eid <= evicted {
+	// when the node recover from checkpoint, the new effective genesis can be the same as the beacon's target epoch.
+	if eid <= evicted && eid != types.GetEffectiveGenesis().GetEpoch() {
 		return
 	}
 	epoch := t.trtl.epoch(eid)

--- a/tortoise/recover.go
+++ b/tortoise/recover.go
@@ -26,6 +26,14 @@ func Recover(db *datastore.CachedDB, beacon system.BeaconGetter, opts ...Opt) (*
 	if err != nil {
 		return nil, fmt.Errorf("failed to load latest known layer: %w", err)
 	}
+
+	if types.GetEffectiveGenesis() != types.FirstEffectiveGenesis() {
+		// need to load the golden atxs after a checkpoint recovery
+		if err := recoverEpoch(types.GetEffectiveGenesis().Add(1).GetEpoch(), trtl, db, beacon); err != nil {
+			return nil, err
+		}
+	}
+
 	epoch, err := atxs.LatestEpoch(db)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load latest epoch: %w", err)
@@ -38,6 +46,7 @@ func Recover(db *datastore.CachedDB, beacon system.BeaconGetter, opts ...Opt) (*
 			}
 		}
 	}
+
 	for lid := types.GetEffectiveGenesis().Add(1); !lid.After(layer); lid = lid.Add(1) {
 		if err := RecoverLayer(context.Background(), trtl, db, beacon, lid); err != nil {
 			return nil, fmt.Errorf("failed to load tortoise state at layer %d: %w", lid, err)

--- a/tortoise/recover.go
+++ b/tortoise/recover.go
@@ -46,7 +46,6 @@ func Recover(db *datastore.CachedDB, beacon system.BeaconGetter, opts ...Opt) (*
 			}
 		}
 	}
-
 	for lid := types.GetEffectiveGenesis().Add(1); !lid.After(layer); lid = lid.Add(1) {
 		if err := RecoverLayer(context.Background(), trtl, db, beacon, lid); err != nil {
 			return nil, fmt.Errorf("failed to load tortoise state at layer %d: %w", lid, err)

--- a/tortoise/tortoise.go
+++ b/tortoise/tortoise.go
@@ -77,7 +77,7 @@ func (t *turtle) lookbackWindowStart() (types.LayerID, bool) {
 	return t.verified.Sub(t.WindowSize), true
 }
 
-// evict makes sure we only keep a window of the last t.WindowSize layers.
+// evict makes sure we only keep a window of the last hdist layers.
 func (t *turtle) evict(ctx context.Context) {
 	// Don't evict before we've verified at least hdist layers
 	if !t.verified.After(types.GetEffectiveGenesis().Add(t.Hdist)) {

--- a/tortoise/tortoise.go
+++ b/tortoise/tortoise.go
@@ -77,7 +77,7 @@ func (t *turtle) lookbackWindowStart() (types.LayerID, bool) {
 	return t.verified.Sub(t.WindowSize), true
 }
 
-// evict makes sure we only keep a window of the last hdist layers.
+// evict makes sure we only keep a window of the last t.WindowSize layers.
 func (t *turtle) evict(ctx context.Context) {
 	// Don't evict before we've verified at least hdist layers
 	if !t.verified.After(types.GetEffectiveGenesis().Add(t.Hdist)) {

--- a/tortoise/tortoise_test.go
+++ b/tortoise/tortoise_test.go
@@ -985,6 +985,30 @@ func tortoiseVotingWithCurrent(tortoise voter) sim.VotesGenerator {
 	}
 }
 
+func TestOnBeacon(t *testing.T) {
+	cfg := defaultTestConfig()
+	tortoise, err := New(WithConfig(cfg), WithLogger(logtest.New(t)))
+	require.NoError(t, err)
+
+	genesis := types.GetEffectiveGenesis()
+	tortoise.OnBeacon(genesis.GetEpoch()-1, types.Beacon{1})
+	require.Nil(t, tortoise.trtl.epoch(genesis.GetEpoch()-1).beacon)
+	tortoise.OnBeacon(genesis.GetEpoch(), types.Beacon{1})
+	require.Equal(t, types.Beacon{1}, *tortoise.trtl.epoch(genesis.GetEpoch()).beacon)
+
+	newGenesis := genesis.Add(types.GetLayersPerEpoch()*10 + types.GetLayersPerEpoch()/2)
+	types.SetEffectiveGenesis(newGenesis.Uint32())
+	defer func() {
+		types.SetEffectiveGenesis(genesis.Uint32())
+	}()
+	tortoise, err = New(WithConfig(cfg), WithLogger(logtest.New(t)))
+	require.NoError(t, err)
+	tortoise.OnBeacon(newGenesis.GetEpoch()-1, types.Beacon{2})
+	require.Nil(t, tortoise.trtl.epoch(newGenesis.GetEpoch()-1).beacon)
+	tortoise.OnBeacon(newGenesis.GetEpoch(), types.Beacon{2})
+	require.Equal(t, types.Beacon{2}, *tortoise.trtl.epoch(newGenesis.GetEpoch()).beacon)
+}
+
 func TestBaseBallotGenesis(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
## Motivation
part of https://github.com/spacemeshos/go-spacemesh/issues/4090
PR 2 of 3 to break down large PR https://github.com/spacemeshos/go-spacemesh/pull/4387
loosely dependent on PR 1 of 3 https://github.com/spacemeshos/go-spacemesh/pull/4404

## Changes
- ATXs re-gossip
when ATXs are not included in the checkpoint file, the network will re-gossip these ATXs by syncing them from peers as soon as a node recovers the checkpoint data. this is achieved by syncer requesting current epoch ATXs immediately after recovery

- gossip handlers
reject data (proposal/ballot/blocks) that are before the restore layer
