### PR TITLE
[Merged by Bors] - recover 3of3: add checkpoint systest

### DIFF
--- a/bootstrap/updater.go
+++ b/bootstrap/updater.go
@@ -271,7 +271,6 @@ func query(ctx context.Context, client *http.Client, resource *url.URL, etag str
 	if err != nil {
 		return "", nil, fmt.Errorf("create http request: %w", err)
 	}
-	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("If-None-Match", etag)
 	resp, err := client.Do(req)
 	if err != nil {

--- a/cmd/bootstrapper/server.go
+++ b/cmd/bootstrapper/server.go
@@ -222,7 +222,6 @@ func (s *Server) handleCheckpoint(w http.ResponseWriter, _ *http.Request) {
 }
 
 func (s *Server) servefile(f string, w http.ResponseWriter) {
-	w.Header().Set("Content-Type", "application/json")
 	data, err := afero.ReadFile(s.fs, f)
 	if err != nil && errors.Is(err, afero.ErrFileNotFound) {
 		return

--- a/cmd/bootstrapper/server_test.go
+++ b/cmd/bootstrapper/server_test.go
@@ -1,11 +1,14 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/hex"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -16,8 +19,60 @@ import (
 	"github.com/spacemeshos/go-spacemesh/log/logtest"
 )
 
+const checkpointdata = `{
+"version":"https://spacemesh.io/checkpoint.schema.json.1.0",
+"data":{
+  "id":"snapshot-15-restore-18",
+  "restore":18,
+  "atxs":[{
+    "id":"d1ef13c8deb8970c19af780f6ce8bbdabfad368afe219ed052fde6766e121cbb",
+    "epoch":3,
+    "commitmentAtx":"c146f83c2b0f670c7e34e30699536a60b6d5eb13d8f0b63adb6084872c4f3b8d",
+    "vrfNonce":144,
+    "numUnits":2,
+    "baseTickHeight":12401,
+    "tickCount":6183,
+    "publicKey":"0655283aa44b67e7dcbde46be857334033f5b9af79ec269f45e8e57e7913ed21",
+    "sequence":2,
+    "coinbase":"000000003100000000000000000000000000000000000000"
+  },{
+    "id":"fcaac088afd1872cf2b4ab8f1e4c1702b3f184c4c85ead0911f6917222324cf6",
+    "epoch":2,
+    "commitmentAtx":"c146f83c2b0f670c7e34e30699536a60b6d5eb13d8f0b63adb6084872c4f3b8d",
+    "vrfNonce":144,
+    "numUnits":2,
+    "baseTickHeight":6202,
+    "tickCount":6199,
+    "publicKey":"0655283aa44b67e7dcbde46be857334033f5b9af79ec269f45e8e57e7913ed21",
+    "sequence":1,
+    "coinbase":"000000003100000000000000000000000000000000000000"
+  }],
+  "accounts":[{
+    "address":"00000000073af7bec018e8d2e379fa47df6a9fa07a6a8344",
+    "balance":100000000000000000,
+    "nonce":0,
+    "template":"",
+    "state":""
+  },{
+    "address":"000000000dc43c7311d28e000130edbcffd6dc230fd1542e",
+    "balance":99999999999863378,
+    "nonce":2,
+    "template":"000000000000000000000000000000000000000000000001",
+    "state":""
+  }]}
+}
+`
+
 func query(t *testing.T, ctx context.Context) []byte {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("http://localhost:%d", port), nil)
+	return queryUrl(t, ctx, fmt.Sprintf("http://localhost:%d", port))
+}
+
+func queryCheckpoint(t *testing.T, ctx context.Context) []byte {
+	return queryUrl(t, ctx, fmt.Sprintf("http://localhost:%d/checkpoint", port))
+}
+
+func queryUrl(t *testing.T, ctx context.Context, url string) []byte {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	require.NoError(t, err)
 	resp, err := (&http.Client{}).Do(req)
 	require.NoError(t, err)
@@ -25,6 +80,17 @@ func query(t *testing.T, ctx context.Context) []byte {
 	got, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 	return got
+}
+
+func updateCheckpoint(t *testing.T, ctx context.Context, data []byte) {
+	endpoint := fmt.Sprintf("http://localhost:%d/updateCheckpoint", port)
+	formData := url.Values{"checkpoint": []string{string(data)}}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(formData.Encode()))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := (&http.Client{}).Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
 }
 
 func TestServer(t *testing.T) {
@@ -38,11 +104,11 @@ func TestServer(t *testing.T) {
 		WithFilesystem(fs),
 	)
 
-	epoch := types.EpochID(4)
+	epochs := []types.EpochID{types.EpochID(4), types.EpochID(5)}
 	srv := NewServer(g, false, port,
 		WithSrvFilesystem(fs),
 		WithSrvLogger(logtest.New(t)),
-		WithBootstrapEpoch(epoch),
+		WithBootstrapEpochs(epochs),
 	)
 	np := &NetworkParam{
 		Genesis:      time.Now(),
@@ -55,14 +121,27 @@ func TestServer(t *testing.T) {
 	ch := make(chan error, 1)
 	srv.Start(ctx, ch, np)
 
-	require.Eventually(t, func() bool {
-		_, err := fs.Stat(PersistedFilename())
-		return err == nil
-	}, 5*time.Second, 100*time.Millisecond)
-	require.Empty(t, ch)
+	for _, epoch := range epochs {
+		fname := PersistedFilename()
+		require.Eventually(t, func() bool {
+			_, err := fs.Stat(fname)
+			return err == nil
+		}, 5*time.Second, 100*time.Millisecond)
+		require.Empty(t, ch)
 
-	data := query(t, ctx)
-	verifyUpdate(t, data, epoch, hex.EncodeToString(epochBeacon(epoch).Bytes()), activeSetSize)
+		data := query(t, ctx)
+		verifyUpdate(t, data, epoch, hex.EncodeToString(epochBeacon(epoch).Bytes()), activeSetSize)
+		require.NoError(t, fs.Remove(fname))
+	}
+
+	got := queryCheckpoint(t, ctx)
+	require.Empty(t, got)
+
+	chdata := []byte(checkpointdata)
+	updateCheckpoint(t, ctx, chdata)
+	got = queryCheckpoint(t, ctx)
+	require.True(t, bytes.Equal(chdata, got))
+
 	cancel()
 	srv.Stop(ctx)
 }

--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -141,7 +141,9 @@ func GetCommand() *cobra.Command {
 					return fmt.Errorf("could not retrieve identity: %w", err)
 				}
 
-				// TODO(kimmy): invoke app.LoadCheckpoint() here
+				if err = app.LoadCheckpoint(ctx); err != nil {
+					return err
+				}
 
 				if err = app.Initialize(); err != nil {
 					return err

--- a/config/presets/fastnet.go
+++ b/config/presets/fastnet.go
@@ -68,5 +68,6 @@ func fastnet() config.Config {
 	conf.Beacon.BeaconSyncWeightUnits = 10
 	conf.Beacon.VotesLimit = 100
 
+	conf.Recovery.RecoverFromDefaultDir = true
 	return conf
 }

--- a/config/presets/fastnet.go
+++ b/config/presets/fastnet.go
@@ -35,6 +35,7 @@ func fastnet() config.Config {
 
 	conf.LayerAvgSize = 50
 	conf.LayerDuration = 15 * time.Second
+	conf.Sync.Interval = 5 * time.Second
 	conf.LayersPerEpoch = 4
 
 	conf.Tortoise.Hdist = 4

--- a/config/presets/testnet.go
+++ b/config/presets/testnet.go
@@ -67,5 +67,6 @@ func testnet() config.Config {
 	conf.Beacon.VotingRoundDuration = 50 * time.Second
 	conf.Beacon.WeakCoinRoundDuration = 10 * time.Second
 
+	conf.Recovery.RecoverFromDefaultDir = false
 	return conf
 }

--- a/systest/cluster/cluster.go
+++ b/systest/cluster/cluster.go
@@ -28,6 +28,7 @@ import (
 var errNotInitialized = errors.New("cluster: not initialized")
 
 const (
+	initBalance      = 100000000000000000
 	defaultExtraData = "systest"
 	poetApp          = "poet"
 	bootnodeApp      = "boot"
@@ -81,6 +82,12 @@ func WithBootstrapperFlag(flag DeploymentFlag) Opt {
 	}
 }
 
+func WithBootstrapEpochs(epochs []int) Opt {
+	return func(c *Cluster) {
+		c.bootstrapEpochs = epochs
+	}
+}
+
 // Reuse will try to recover cluster from the given namespace, if not found
 // it will create a new one.
 func Reuse(cctx *testcontext.Context, opts ...Opt) (*Cluster, error) {
@@ -111,7 +118,7 @@ func ReuseWait(cctx *testcontext.Context, opts ...Opt) (*Cluster, error) {
 	return cl, nil
 }
 
-// Default deployes bootnodes, one poet and the smeshers according to the cluster size.
+// Default deploys bootnodes, one poet and the smeshers according to the cluster size.
 func Default(cctx *testcontext.Context, opts ...Opt) (*Cluster, error) {
 	cl := New(cctx, opts...)
 	bsize := defaultBootnodes(cctx.ClusterSize)
@@ -136,7 +143,7 @@ func New(cctx *testcontext.Context, opts ...Opt) *Cluster {
 		smesherFlags:      map[string]DeploymentFlag{},
 		poetFlags:         map[string]DeploymentFlag{},
 		bootstrapperFlags: map[string]DeploymentFlag{},
-		bootstrapEpoch:    2,
+		bootstrapEpochs:   []int{2},
 	}
 	genesis := GenesisTime(time.Now().Add(cctx.BootstrapDuration))
 	cluster.addFlag(genesis)
@@ -171,7 +178,7 @@ type Cluster struct {
 	poets         []*NodeClient
 	bootstrappers []*NodeClient
 
-	bootstrapEpoch uint32
+	bootstrapEpochs []int
 }
 
 // GenesisID computes id from the configuration.
@@ -423,7 +430,7 @@ func (c *Cluster) AddBootnodes(cctx *testcontext.Context, n int) error {
 }
 
 // AddSmeshers ...
-func (c *Cluster) AddSmeshers(tctx *testcontext.Context, n int) error {
+func (c *Cluster) AddSmeshers(tctx *testcontext.Context, n int, extras ...DeploymentFlag) error {
 	if err := c.resourceControl(tctx, n); err != nil {
 		return err
 	}
@@ -437,6 +444,7 @@ func (c *Cluster) AddSmeshers(tctx *testcontext.Context, n int) error {
 	}
 	flags = append(flags, Bootnodes(endpoints...))
 	flags = append(flags, StartSmeshing(true))
+	flags = append(flags, extras...)
 	clients, err := deployNodes(tctx, smesherApp, c.nextSmesher(), c.nextSmesher()+n, flags)
 	if err != nil {
 		return err
@@ -463,11 +471,20 @@ func (c *Cluster) AddBootstrapper(cctx *testcontext.Context, i int) error {
 		Name:  "--spacemesh-endpoint",
 		Value: fmt.Sprintf("dns:///%s:9092", c.clients[0].Name),
 	})
-	bs, err := deployBootstrapper(cctx, fmt.Sprintf("%s-%d", bootstrapperApp, i), c.bootstrapEpoch, flags...)
+	bs, err := deployBootstrapper(cctx, fmt.Sprintf("%s-%d", bootstrapperApp, i), c.bootstrapEpochs, flags...)
 	if err != nil {
 		return err
 	}
 	c.bootstrappers = append(c.bootstrappers, bs)
+	return nil
+}
+
+func (c *Cluster) DeleteBootstrappers(cctx *testcontext.Context) error {
+	for _, client := range c.bootstrappers {
+		if err := deleteServiceAndPod(cctx, client.Name); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -488,7 +505,7 @@ func (c *Cluster) DeletePoet(cctx *testcontext.Context, i int) error {
 	if poet == nil {
 		return nil
 	}
-	if err := deletePoet(cctx, poet.Name); err != nil {
+	if err := deleteServiceAndPod(cctx, poet.Name); err != nil {
 		return err
 	}
 	c.poets = append(c.poets[0:i], c.poets[i+1:]...)
@@ -538,6 +555,10 @@ func (c *Cluster) Poet(i int) *NodeClient {
 // Client returns client for i-th node, either bootnode or smesher.
 func (c *Cluster) Client(i int) *NodeClient {
 	return c.clients[i]
+}
+
+func (c *Cluster) Bootstrapper(i int) *NodeClient {
+	return c.bootstrappers[i]
 }
 
 // Wait for i-th client to be up.
@@ -655,7 +676,7 @@ func (a *accounts) Recover(ctx *testcontext.Context) error {
 func genGenesis(signers []*signer) (rst map[string]uint64) {
 	rst = map[string]uint64{}
 	for _, sig := range signers {
-		rst[sig.Address().String()] = 100000000000000000
+		rst[sig.Address().String()] = initBalance
 	}
 	return
 }

--- a/systest/tests/checkpoint_test.go
+++ b/systest/tests/checkpoint_test.go
@@ -1,0 +1,284 @@
+package tests
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	pb "github.com/spacemeshos/api/release/go/spacemesh/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/systest/cluster"
+	"github.com/spacemeshos/go-spacemesh/systest/testcontext"
+)
+
+func reuseCluster(tctx *testcontext.Context) (*cluster.Cluster, error) {
+	return cluster.ReuseWait(tctx,
+		cluster.WithKeys(10),
+		cluster.WithSmesherFlag(cluster.DeploymentFlag{Name: "--recover-from-default-dir", Value: "true"}),
+		cluster.WithBootstrapEpochs([]int{2, 4, 5}),
+	)
+}
+
+func TestCheckpoint(t *testing.T) {
+	t.Parallel()
+
+	tctx := testcontext.New(t, testcontext.Labels("sanity"))
+	addedLater := 2
+	size := min(tctx.ClusterSize, 30)
+	oldSize := size - addedLater
+	if tctx.ClusterSize > oldSize {
+		tctx.Log.Info("cluster size changed to ", oldSize)
+		tctx.ClusterSize = oldSize
+	}
+
+	// at the last layer of epoch 3, in the beginning of poet round 2.
+	// it is important to avoid check-pointing in the middle of cycle gap
+	// otherwise nodes' proof generation will be interrupted and miss
+	// the start of the next poet round
+	snapshotLayer := uint32(15)
+	restoreLayer := uint32(18)
+	checkpointEpoch := uint32(4)
+	lastEpoch := uint32(8)
+
+	// need to bootstrap the checkpoint epoch and the next epoch as the beacon protocol was interrupted in the last epoch
+	cl, err := reuseCluster(tctx)
+	require.NoError(t, err)
+
+	layersPerEpoch := uint32(testcontext.LayersPerEpoch.Get(tctx.Parameters))
+	require.EqualValues(t, 4, layersPerEpoch, "checkpoint layer require tuning as layersPerEpoch is changed")
+	layerDuration := testcontext.LayerDuration.Get(tctx.Parameters)
+
+	eg, ctx := errgroup.WithContext(tctx)
+	first := layersPerEpoch * 2
+	stop := first + 2
+	receiver := types.GenerateAddress([]byte{11, 1, 1})
+	tctx.Log.Infow("sending transactions", "from", first, "to", stop-1)
+	sendTransactions(ctx, eg, tctx.Log, cl, first, stop, receiver, 1, 100)
+	require.NoError(t, eg.Wait())
+
+	require.NoError(t, waitLayer(tctx, cl.Client(0), snapshotLayer))
+
+	tctx.Log.Debugw("getting account balances")
+	before, err := getBalance(tctx, cl, snapshotLayer)
+	require.NoError(t, err)
+	for addr, state := range before {
+		tctx.Log.Infow("account received",
+			"address", addr.String(),
+			"nonce", state.nonce,
+			"balance", state.balance,
+		)
+	}
+
+	tctx.Log.Infow("checkpoint cluster", "snapshot", snapshotLayer, "restart", restoreLayer)
+	// query checkpoint files. they all should be the same
+	var checkpoints [][]byte
+	for i := 0; i < cl.Total(); i++ {
+		client := cl.Client(i)
+		data, err := checkpointAndRecover(tctx, client, snapshotLayer, restoreLayer)
+		require.NoError(t, err)
+		checkpoints = append(checkpoints, data)
+	}
+
+	var diffs []string
+	for i := 1; i < len(checkpoints); i++ {
+		if !bytes.Equal(checkpoints[0], checkpoints[i]) {
+			diffs = append(diffs, cl.Client(i).Name)
+			tctx.Log.Errorw("diff checkpoint data",
+				fmt.Sprintf("reference %v", cl.Client(0).Name), string(checkpoints[0]),
+				fmt.Sprintf("client %v", cl.Client(i).Name), string(checkpoints[i]))
+		}
+	}
+	require.Empty(t, diffs)
+
+	tctx.Log.Infow("wait for cluster to recover", "wait", layerDuration)
+	select {
+	case <-time.After(layerDuration):
+	case <-tctx.Done():
+		t.Fail()
+	}
+
+	tctx.Log.Infow("rediscovering cluster")
+	cl, err = reuseCluster(tctx)
+	require.NoError(t, err)
+
+	tctx.Log.Infow("checking account balances")
+	// check if the account balance is correct
+	after, err := getBalance(tctx, cl, restoreLayer)
+	require.NoError(t, err)
+	for addr, state := range before {
+		st, ok := after[addr]
+		if !ok {
+			assert.Failf(t, "account missing after restore", addr.String())
+		} else if st != state {
+			assert.Failf(t, "account incorrect after restore",
+				"addr %v before %+v , after %+v", addr.String(), state, st)
+		}
+	}
+
+	tctx.Log.Infow("waiting for all miners to be smeshing", "last epoch", checkpointEpoch+2)
+	ensureSmeshing(t, tctx, cl, cl.Total()-cl.Bootnodes(), checkpointEpoch+2)
+
+	ip, err := cl.Bootstrapper(0).Resolve(tctx)
+	require.NoError(t, err)
+	tctx.Log.Debugw("resolved bootstrapper", "ip", ip)
+
+	endpoint := fmt.Sprintf("http://%s:%d", ip, 80)
+	updateUrl := fmt.Sprintf("%s/updateCheckpoint", endpoint)
+	tctx.Log.Infow("submit checkpoint data", "update url", updateUrl)
+	require.NoError(t, updateCheckpointServer(tctx, updateUrl, checkpoints[0]))
+
+	queryUrl := fmt.Sprintf("%s/checkpoint", endpoint)
+	tctx.Log.Debugw("query checkpoint data", "query url", queryUrl)
+	data, err := query(tctx, queryUrl)
+	require.NoError(t, err)
+	require.True(t, bytes.Equal(checkpoints[0], data))
+
+	// increase the cluster size to the original test size
+	tctx.Log.Info("cluster size changed to ", size)
+	tctx.ClusterSize = size
+
+	tctx.Log.Infow("adding smesher with checkpoint url",
+		"checkpoint url", queryUrl, "restore layer", restoreLayer)
+	require.NoError(t, cl.AddSmeshers(tctx, addedLater,
+		cluster.DeploymentFlag{Name: "--checkpoint-file", Value: queryUrl},
+		cluster.DeploymentFlag{Name: "--restore-layer", Value: strconv.Itoa(int(restoreLayer))},
+	))
+
+	tctx.Log.Infow("waiting for all miners to be smeshing", "last epoch", lastEpoch)
+	ensureSmeshing(t, tctx, cl, cl.Total()-cl.Bootnodes(), lastEpoch)
+}
+
+func ensureSmeshing(t *testing.T, tctx *testcontext.Context, cl *cluster.Cluster, numSmeshers int, stop uint32) {
+	uniqueSmeshers := map[types.NodeID]struct{}{}
+	eg, _ := errgroup.WithContext(tctx)
+	for i := cl.Bootnodes(); i < cl.Total(); i++ {
+		i := i
+		client := cl.Client(i)
+		watchProposals(tctx, eg, client, func(proposal *pb.Proposal) (bool, error) {
+			if proposal.Epoch.Number > stop {
+				return false, nil
+			}
+			if proposal.Status == pb.Proposal_Created {
+				tctx.Log.Debugw("received proposal event",
+					"client", client.Name,
+					"layer", proposal.Layer.Number,
+					"epoch", proposal.Epoch.Number,
+					"smesher", prettyHex(proposal.Smesher.Id),
+					"eligibilities", len(proposal.Eligibilities),
+					"status", pb.Proposal_Status_name[int32(proposal.Status)],
+				)
+				uniqueSmeshers[types.BytesToNodeID(proposal.Smesher.Id)] = struct{}{}
+				return false, nil
+			}
+			return true, nil
+		})
+	}
+	require.NoError(t, eg.Wait())
+	require.Lenf(t, uniqueSmeshers, numSmeshers, "not all miners are smeshing, expected %d, got %d", numSmeshers, len(uniqueSmeshers))
+}
+
+func query(ctx context.Context, endpoint string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := (&http.Client{}).Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+func updateCheckpointServer(ctx *testcontext.Context, endpoint string, chdata []byte) error {
+	formData := url.Values{"checkpoint": []string{string(chdata)}}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(formData.Encode()))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := (&http.Client{}).Do(req)
+	if err != nil {
+		return err
+	}
+	return resp.Body.Close()
+}
+
+func checkpointAndRecover(ctx *testcontext.Context, client *cluster.NodeClient, snapshot, restore uint32) ([]byte, error) {
+	smshr := pb.NewAdminServiceClient(client)
+	stream, err := smshr.CheckpointStream(ctx, &pb.CheckpointStreamRequest{SnapshotLayer: snapshot})
+	if err != nil {
+		return nil, fmt.Errorf("stream checkpoiont %v: %w", client.Name, err)
+	}
+	var (
+		result bytes.Buffer
+		msg    *pb.CheckpointStreamResponse
+	)
+	for {
+		msg, err = stream.Recv()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, fmt.Errorf("receive stream %v, %w", client.Name, err)
+		}
+		if _, err = result.Write(msg.Data); err != nil {
+			return nil, fmt.Errorf("write data to buffer: %w", err)
+		}
+	}
+	// recover
+	_, err = smshr.Recover(ctx, &pb.RecoverRequest{
+		Uri:          filepath.Join("file:///data/state/checkpoint", fmt.Sprintf("snapshot-%d", snapshot)),
+		RestoreLayer: restore,
+	})
+	if err == nil {
+		return nil, errors.New("recover should return error but did not")
+	}
+	ctx.Log.Debugw("checkpoint file received", "client", client.Name, "size", len(result.Bytes()))
+	return result.Bytes(), nil
+}
+
+type acctState struct {
+	nonce   uint64
+	balance uint64
+}
+
+func getBalance(tctx *testcontext.Context, cl *cluster.Cluster, layer uint32) (map[types.Address]acctState, error) {
+	dbg := pb.NewDebugServiceClient(cl.Client(0))
+	response, err := dbg.Accounts(tctx, &pb.AccountsRequest{Layer: layer})
+	if err != nil {
+		return nil, err
+	}
+	expectedBalances := map[types.Address]acctState{}
+	for _, acct := range response.GetAccountWrapper() {
+		addr, err := types.StringToAddress(acct.AccountId.GetAddress())
+		if err != nil {
+			return nil, err
+		}
+		expectedBalances[addr] = acctState{
+			nonce:   acct.GetStateCurrent().GetCounter(),
+			balance: acct.GetStateCurrent().GetBalance().GetValue(),
+		}
+	}
+	return expectedBalances, nil
+}

--- a/systest/tests/checkpoint_test.go
+++ b/systest/tests/checkpoint_test.go
@@ -27,7 +27,6 @@ import (
 func reuseCluster(tctx *testcontext.Context) (*cluster.Cluster, error) {
 	return cluster.ReuseWait(tctx,
 		cluster.WithKeys(10),
-		cluster.WithSmesherFlag(cluster.DeploymentFlag{Name: "--recover-from-default-dir", Value: "true"}),
 		cluster.WithBootstrapEpochs([]int{2, 4, 5}),
 	)
 }
@@ -153,8 +152,8 @@ func TestCheckpoint(t *testing.T) {
 	tctx.Log.Infow("adding smesher with checkpoint url",
 		"checkpoint url", queryUrl, "restore layer", restoreLayer)
 	require.NoError(t, cl.AddSmeshers(tctx, addedLater,
-		cluster.DeploymentFlag{Name: "--checkpoint-file", Value: queryUrl},
-		cluster.DeploymentFlag{Name: "--restore-layer", Value: strconv.Itoa(int(restoreLayer))},
+		cluster.DeploymentFlag{Name: "--recovery-uri", Value: queryUrl},
+		cluster.DeploymentFlag{Name: "--recovery-layer", Value: strconv.Itoa(int(restoreLayer))},
 	))
 
 	tctx.Log.Infow("waiting for all miners to be smeshing", "last epoch", lastEpoch)

--- a/systest/tests/checkpoint_test.go
+++ b/systest/tests/checkpoint_test.go
@@ -115,7 +115,7 @@ func TestCheckpoint(t *testing.T) {
 
 	tctx.Log.Infow("checking account balances")
 	// check if the account balance is correct
-	after, err := getBalance(tctx, cl, restoreLayer)
+	after, err := getBalance(tctx, cl, restoreLayer-1)
 	require.NoError(t, err)
 	for addr, state := range before {
 		st, ok := after[addr]

--- a/systest/tests/checkpoint_test.go
+++ b/systest/tests/checkpoint_test.go
@@ -194,7 +194,6 @@ func query(ctx context.Context, endpoint string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("Content-Type", "application/json")
 	resp, err := (&http.Client{}).Do(req)
 	if err != nil {
 		return nil, err

--- a/systest/tests/common.go
+++ b/systest/tests/common.go
@@ -27,8 +27,7 @@ const (
 	attempts = 3
 )
 
-func sendTransactions(ctx context.Context, eg *errgroup.Group, logger *zap.SugaredLogger, cl *cluster.Cluster, first, stop uint32, batch, amount int) {
-	receiver := types.GenerateAddress([]byte{11, 1, 1})
+func sendTransactions(ctx context.Context, eg *errgroup.Group, logger *zap.SugaredLogger, cl *cluster.Cluster, first, stop uint32, receiver types.Address, batch, amount int) {
 	for i := 0; i < cl.Accounts(); i++ {
 		i := i
 		client := cl.Client(i % cl.Total())
@@ -183,6 +182,27 @@ func waitGenesis(ctx *testcontext.Context, node *cluster.NodeClient) error {
 	case <-ctx.Done():
 		return ctx.Err()
 	case <-time.After(genesis.Sub(now)):
+		return nil
+	}
+}
+
+func waitLayer(ctx *testcontext.Context, node *cluster.NodeClient, lid uint32) error {
+	svc := pb.NewMeshServiceClient(node)
+	resp, err := svc.GenesisTime(ctx, &pb.GenesisTimeRequest{})
+	if err != nil {
+		return err
+	}
+	lyrTime := time.Unix(int64(resp.Unixtime.Value), 0).Add(time.Duration(lid) * testcontext.LayerDuration.Get(ctx.Parameters))
+
+	now := time.Now()
+	if !lyrTime.After(now) {
+		return nil
+	}
+	ctx.Log.Debugw("waiting for layer", "now", now, "layer time", lyrTime, "layer", lid)
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(lyrTime.Sub(now)):
 		return nil
 	}
 }

--- a/systest/tests/partition_test.go
+++ b/systest/tests/partition_test.go
@@ -57,7 +57,8 @@ func testPartition(t *testing.T, tctx *testcontext.Context, cl *cluster.Cluster,
 	// start sending transactions
 	tctx.Log.Debug("sending transactions...")
 	eg2, ctx2 := errgroup.WithContext(tctx)
-	sendTransactions(ctx2, eg2, nil, cl, first, stop, 10, 100)
+	receiver := types.GenerateAddress([]byte{11, 1, 1})
+	sendTransactions(ctx2, eg2, nil, cl, first, stop, receiver, 10, 100)
 
 	type stateUpdate struct {
 		layer  uint32

--- a/systest/tests/smeshing_test.go
+++ b/systest/tests/smeshing_test.go
@@ -29,7 +29,7 @@ func TestSmeshing(t *testing.T) {
 	})
 	t.Run("Transactions", func(t *testing.T) {
 		t.Parallel()
-		testTransactions(t, tctx, cl)
+		testTransactions(t, tctx, cl, 8)
 	})
 }
 
@@ -115,9 +115,9 @@ func requireEqualProposals(tb testing.TB, reference map[uint32][]*pb.Proposal, r
 			})
 		}
 		for layer, proposals := range reference {
-			require.Len(tb, included[layer], len(proposals), "client=%d layer=%d", i, layer)
+			require.Lenf(tb, included[layer], len(proposals), "client=%d layer=%d", i, layer)
 			for j := range proposals {
-				assert.Equal(tb, proposals[j].Id, included[layer][j].Id, "client=%d layer=%d", i, layer)
+				assert.Equalf(tb, proposals[j].Id, included[layer][j].Id, "client=%d layer=%d", i, layer)
 			}
 		}
 	}

--- a/systest/tests/transactions_test.go
+++ b/systest/tests/transactions_test.go
@@ -13,15 +13,13 @@ import (
 	"github.com/spacemeshos/go-spacemesh/systest/testcontext"
 )
 
-func testTransactions(t *testing.T, tctx *testcontext.Context, cl *cluster.Cluster) {
+func testTransactions(t *testing.T, tctx *testcontext.Context, cl *cluster.Cluster, sendFor uint32) {
 	var (
 		// start sending transactions after two layers or after genesis
-		first              = maxLayer(currentLayer(tctx, t, cl.Client(0))+2, 8)
-		sendFor     uint32 = 8
-		stopSending        = first + sendFor
-		stopWaiting        = stopSending + 4
-		batch              = 10
-		amount             = 100
+		first       = maxLayer(currentLayer(tctx, t, cl.Client(0))+2, 8)
+		stopSending = first + sendFor
+		batch       = 10
+		amount      = 100
 
 		// each account creates spawn transaction in the first layer
 		// plus batch number of spend transactions in every layer after that
@@ -30,7 +28,6 @@ func testTransactions(t *testing.T, tctx *testcontext.Context, cl *cluster.Clust
 	tctx.Log.Debugw("running transactions test",
 		"from", first,
 		"stop sending", stopSending,
-		"stop waiting", stopWaiting,
 		"expected transactions", expectedCount,
 	)
 	receiver := types.GenerateAddress([]byte{11, 1, 1})
@@ -40,7 +37,7 @@ func testTransactions(t *testing.T, tctx *testcontext.Context, cl *cluster.Clust
 	before := response.AccountWrapper.StateCurrent.Balance
 
 	eg, ctx := errgroup.WithContext(tctx)
-	sendTransactions(ctx, eg, tctx.Log, cl, first, stopSending, batch, amount)
+	sendTransactions(ctx, eg, tctx.Log, cl, first, stopSending, receiver, batch, amount)
 	txs := make([][]*pb.Transaction, cl.Total())
 
 	for i := 0; i < cl.Total(); i++ {


### PR DESCRIPTION
## Motivation
part of https://github.com/spacemeshos/go-spacemesh/issues/4090
PR 3 of 3 to break down large PR https://github.com/spacemeshos/go-spacemesh/pull/4387
loosely dependent on PR 1 of 3 https://github.com/spacemeshos/go-spacemesh/pull/4404

## Changes
- change boostrapper to serve checkpoint file

- checkpoint systest does the following:
  - submit transactions to spawn account and transfer coins
  - get accounts nonce/balance
  - issue checkpoint RPC to every node
  - check all the returned checkpoint data are the same
  - issue recovery RPC to every node (node will copy the local checkpoint file to $dataDir/recovery/) and restart
  - check that all accounts have the same nonce/balance as before the checkpoint
  - check all miners start smeshing
  - make boostrapper serve the checkpoint data
  - add two new nodes with --checkpoint_file=[http://bootstrapper-0:80/checkpoint](http://bootstrapper-0/checkpoint) and --restore-layer
  - check all miners are smeshing