### PR TITLE
[Merged by Bors] - Offload PoST verification to pool of verifying workers

### DIFF
--- a/activation/handler.go
+++ b/activation/handler.go
@@ -208,7 +208,7 @@ func (h *Handler) SyntacticallyValidateAtx(ctx context.Context, atx *types.Activ
 	expectedChallengeHash := atx.NIPostChallenge.Hash()
 	h.log.WithContext(ctx).With().Info("validating nipost", log.String("expected_challenge_hash", expectedChallengeHash.String()), atx.ID())
 
-	leaves, err := h.nipostValidator.NIPost(atx.SmesherID, *commitmentATX, atx.NIPost, expectedChallengeHash, atx.NumUnits)
+	leaves, err := h.nipostValidator.NIPost(ctx, atx.SmesherID, *commitmentATX, atx.NIPost, expectedChallengeHash, atx.NumUnits)
 	if err != nil {
 		return nil, fmt.Errorf("invalid nipost: %w", err)
 	}
@@ -216,7 +216,7 @@ func (h *Handler) SyntacticallyValidateAtx(ctx context.Context, atx *types.Activ
 	return atx.Verify(baseTickHeight, leaves/h.tickSize)
 }
 
-func (h *Handler) validateInitialAtx(_ context.Context, atx *types.ActivationTx) error {
+func (h *Handler) validateInitialAtx(ctx context.Context, atx *types.ActivationTx) error {
 	if atx.InitialPost == nil {
 		return fmt.Errorf("no prevATX declared, but initial Post is not included")
 	}
@@ -234,7 +234,7 @@ func (h *Handler) validateInitialAtx(_ context.Context, atx *types.ActivationTx)
 	initialPostMetadata := *atx.NIPost.PostMetadata
 	initialPostMetadata.Challenge = shared.ZeroChallenge
 
-	if err := h.nipostValidator.Post(atx.SmesherID, *atx.CommitmentATX, atx.InitialPost, &initialPostMetadata, atx.NumUnits); err != nil {
+	if err := h.nipostValidator.Post(ctx, atx.SmesherID, *atx.CommitmentATX, atx.InitialPost, &initialPostMetadata, atx.NumUnits); err != nil {
 		return fmt.Errorf("invalid initial Post: %w", err)
 	}
 

--- a/activation/handler_test.go
+++ b/activation/handler_test.go
@@ -205,7 +205,7 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 		atx.NIPost = newNIPostWithChallenge(t, atx.NIPostChallenge.Hash(), poetRef)
 		require.NoError(t, SignAndFinalizeAtx(sig, atx))
 
-		validator.EXPECT().NIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(uint64(1), nil).Times(1)
+		validator.EXPECT().NIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(uint64(1), nil).Times(1)
 		validator.EXPECT().NIPostChallenge(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		validator.EXPECT().PositioningAtx(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 
@@ -221,7 +221,7 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 		atx.VRFNonce = &nonce
 		require.NoError(t, SignAndFinalizeAtx(sig, atx))
 
-		validator.EXPECT().NIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(uint64(1), nil).Times(1)
+		validator.EXPECT().NIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(uint64(1), nil).Times(1)
 		validator.EXPECT().NIPostChallenge(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		validator.EXPECT().PositioningAtx(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		validator.EXPECT().VRFNonce(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
@@ -236,7 +236,7 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 		atx.NIPost = newNIPostWithChallenge(t, atx.NIPostChallenge.Hash(), poetRef)
 		require.NoError(t, SignAndFinalizeAtx(sig, atx))
 
-		validator.EXPECT().NIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(uint64(1), nil).Times(1)
+		validator.EXPECT().NIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(uint64(1), nil).Times(1)
 		validator.EXPECT().NIPostChallenge(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		validator.EXPECT().PositioningAtx(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 
@@ -252,7 +252,7 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 		atx.NIPost = newNIPostWithChallenge(t, atx.NIPostChallenge.Hash(), poetRef)
 		require.NoError(t, SignAndFinalizeAtx(sig, atx))
 
-		validator.EXPECT().NIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(uint64(1), nil).Times(1)
+		validator.EXPECT().NIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(uint64(1), nil).Times(1)
 		validator.EXPECT().NIPostChallenge(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		validator.EXPECT().PositioningAtx(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		validator.EXPECT().VRFNonce(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
@@ -296,8 +296,8 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 
 		validator.EXPECT().InitialNIPostChallenge(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		validator.EXPECT().VRFNonce(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
-		validator.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
-		validator.EXPECT().NIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(uint64(1), nil).Times(1)
+		validator.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+		validator.EXPECT().NIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(uint64(1), nil).Times(1)
 		validator.EXPECT().PositioningAtx(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 
 		_, err = atxHdlr.SyntacticallyValidateAtx(context.Background(), atx)
@@ -368,7 +368,7 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 		require.NoError(t, SignAndFinalizeAtx(sig, atx))
 
 		validator.EXPECT().InitialNIPostChallenge(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
-		validator.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+		validator.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 
 		_, err = atxHdlr.SyntacticallyValidateAtx(context.Background(), atx)
 		require.ErrorContains(t, err, "VRFNonce is missing")
@@ -389,7 +389,7 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 
 		validator.EXPECT().InitialNIPostChallenge(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		validator.EXPECT().VRFNonce(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(errors.New("invalid VRF nonce"))
-		validator.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+		validator.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 
 		_, err = atxHdlr.SyntacticallyValidateAtx(context.Background(), atx)
 		require.ErrorContains(t, err, "invalid VRF nonce")
@@ -417,7 +417,7 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 		*atx.InnerActivationTx.NodeID = sig.NodeID()
 
 		validator.EXPECT().InitialNIPostChallenge(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
-		validator.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("failed post validation")).Times(1)
+		validator.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("failed post validation")).Times(1)
 
 		_, err := atxHdlr.SyntacticallyValidateAtx(context.Background(), atx)
 		require.ErrorContains(t, err, "failed post validation")
@@ -660,7 +660,7 @@ func BenchmarkActivationDb_SyntacticallyValidateAtx(b *testing.B) {
 	cdb := datastore.NewCachedDB(sql.InMemory(), lg)
 	ctrl := gomock.NewController(b)
 	validator := NewMocknipostValidator(ctrl)
-	validator.EXPECT().NIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(uint64(1), nil).AnyTimes()
+	validator.EXPECT().NIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(uint64(1), nil).AnyTimes()
 	validator.EXPECT().NIPostChallenge(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 	validator.EXPECT().VRFNonce(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 	validator.EXPECT().PositioningAtx(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
@@ -1106,8 +1106,8 @@ func TestHandler_AtxWeight(t *testing.T) {
 	mfetch.EXPECT().RegisterPeerHashes(peer, []types.Hash32{proofRef})
 	mfetch.EXPECT().GetPoetProof(gomock.Any(), proofRef).Times(1)
 	mvalidator.EXPECT().VRFNonce(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
-	mvalidator.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
-	mvalidator.EXPECT().NIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(leaves, nil).Times(1)
+	mvalidator.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+	mvalidator.EXPECT().NIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(leaves, nil).Times(1)
 	mvalidator.EXPECT().InitialNIPostChallenge(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 	mvalidator.EXPECT().PositioningAtx(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 	receiver1.EXPECT().OnAtx(gomock.Any()).Times(1)
@@ -1148,7 +1148,7 @@ func TestHandler_AtxWeight(t *testing.T) {
 		})
 	mfetch.EXPECT().GetPoetProof(gomock.Any(), proofRef).Times(1)
 	mfetch.EXPECT().GetAtxs(gomock.Any(), gomock.Any()).Times(1)
-	mvalidator.EXPECT().NIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(leaves, nil).Times(1)
+	mvalidator.EXPECT().NIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(leaves, nil).Times(1)
 	mvalidator.EXPECT().NIPostChallenge(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 	mvalidator.EXPECT().PositioningAtx(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 	receiver1.EXPECT().OnAtx(gomock.Any()).Times(1)

--- a/activation/interface.go
+++ b/activation/interface.go
@@ -17,7 +17,7 @@ type AtxReceiver interface {
 }
 
 type PostVerifier interface {
-	Verify(p *shared.Proof, m *shared.ProofMetadata, opts ...verifying.OptionFunc) error
+	Verify(ctx context.Context, p *shared.Proof, m *shared.ProofMetadata, opts ...verifying.OptionFunc) error
 }
 type nipostValidator interface {
 	InitialNIPostChallenge(challenge *types.NIPostChallenge, atxs atxProvider, goldenATXID types.ATXID, expectedPostIndices []byte) error

--- a/activation/interface.go
+++ b/activation/interface.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/spacemeshos/post/shared"
 	"github.com/spacemeshos/post/verifying"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
@@ -15,6 +16,9 @@ type AtxReceiver interface {
 	OnAtx(*types.ActivationTxHeader)
 }
 
+type PostVerifier interface {
+	Verify(p *shared.Proof, m *shared.ProofMetadata, opts ...verifying.OptionFunc) error
+}
 type nipostValidator interface {
 	InitialNIPostChallenge(challenge *types.NIPostChallenge, atxs atxProvider, goldenATXID types.ATXID, expectedPostIndices []byte) error
 	NIPostChallenge(challenge *types.NIPostChallenge, atxs atxProvider, nodeID types.NodeID) error

--- a/activation/interface.go
+++ b/activation/interface.go
@@ -22,10 +22,10 @@ type PostVerifier interface {
 type nipostValidator interface {
 	InitialNIPostChallenge(challenge *types.NIPostChallenge, atxs atxProvider, goldenATXID types.ATXID, expectedPostIndices []byte) error
 	NIPostChallenge(challenge *types.NIPostChallenge, atxs atxProvider, nodeID types.NodeID) error
-	NIPost(nodeId types.NodeID, atxId types.ATXID, NIPost *types.NIPost, expectedChallenge types.Hash32, numUnits uint32, opts ...verifying.OptionFunc) (uint64, error)
+	NIPost(ctx context.Context, nodeId types.NodeID, atxId types.ATXID, NIPost *types.NIPost, expectedChallenge types.Hash32, numUnits uint32, opts ...verifying.OptionFunc) (uint64, error)
 
 	NumUnits(cfg *PostConfig, numUnits uint32) error
-	Post(nodeId types.NodeID, atxId types.ATXID, Post *types.Post, PostMetadata *types.PostMetadata, numUnits uint32, opts ...verifying.OptionFunc) error
+	Post(ctx context.Context, nodeId types.NodeID, atxId types.ATXID, Post *types.Post, PostMetadata *types.PostMetadata, numUnits uint32, opts ...verifying.OptionFunc) error
 	PostMetadata(cfg *PostConfig, metadata *types.PostMetadata) error
 
 	VRFNonce(nodeId types.NodeID, commitmentAtxId types.ATXID, vrfNonce *types.VRFPostIndex, PostMetadata *types.PostMetadata, numUnits uint32) error

--- a/activation/mocks.go
+++ b/activation/mocks.go
@@ -130,9 +130,9 @@ func (mr *MocknipostValidatorMockRecorder) InitialNIPostChallenge(challenge, atx
 }
 
 // NIPost mocks base method.
-func (m *MocknipostValidator) NIPost(nodeId types.NodeID, atxId types.ATXID, NIPost *types.NIPost, expectedChallenge types.Hash32, numUnits uint32, opts ...verifying.OptionFunc) (uint64, error) {
+func (m *MocknipostValidator) NIPost(ctx context.Context, nodeId types.NodeID, atxId types.ATXID, NIPost *types.NIPost, expectedChallenge types.Hash32, numUnits uint32, opts ...verifying.OptionFunc) (uint64, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{nodeId, atxId, NIPost, expectedChallenge, numUnits}
+	varargs := []interface{}{ctx, nodeId, atxId, NIPost, expectedChallenge, numUnits}
 	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
@@ -143,9 +143,9 @@ func (m *MocknipostValidator) NIPost(nodeId types.NodeID, atxId types.ATXID, NIP
 }
 
 // NIPost indicates an expected call of NIPost.
-func (mr *MocknipostValidatorMockRecorder) NIPost(nodeId, atxId, NIPost, expectedChallenge, numUnits interface{}, opts ...interface{}) *gomock.Call {
+func (mr *MocknipostValidatorMockRecorder) NIPost(ctx, nodeId, atxId, NIPost, expectedChallenge, numUnits interface{}, opts ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{nodeId, atxId, NIPost, expectedChallenge, numUnits}, opts...)
+	varargs := append([]interface{}{ctx, nodeId, atxId, NIPost, expectedChallenge, numUnits}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NIPost", reflect.TypeOf((*MocknipostValidator)(nil).NIPost), varargs...)
 }
 
@@ -192,9 +192,9 @@ func (mr *MocknipostValidatorMockRecorder) PositioningAtx(id, atxs, goldenATXID,
 }
 
 // Post mocks base method.
-func (m *MocknipostValidator) Post(nodeId types.NodeID, atxId types.ATXID, Post *types.Post, PostMetadata *types.PostMetadata, numUnits uint32, opts ...verifying.OptionFunc) error {
+func (m *MocknipostValidator) Post(ctx context.Context, nodeId types.NodeID, atxId types.ATXID, Post *types.Post, PostMetadata *types.PostMetadata, numUnits uint32, opts ...verifying.OptionFunc) error {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{nodeId, atxId, Post, PostMetadata, numUnits}
+	varargs := []interface{}{ctx, nodeId, atxId, Post, PostMetadata, numUnits}
 	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
@@ -204,9 +204,9 @@ func (m *MocknipostValidator) Post(nodeId types.NodeID, atxId types.ATXID, Post 
 }
 
 // Post indicates an expected call of Post.
-func (mr *MocknipostValidatorMockRecorder) Post(nodeId, atxId, Post, PostMetadata, numUnits interface{}, opts ...interface{}) *gomock.Call {
+func (mr *MocknipostValidatorMockRecorder) Post(ctx, nodeId, atxId, Post, PostMetadata, numUnits interface{}, opts ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{nodeId, atxId, Post, PostMetadata, numUnits}, opts...)
+	varargs := append([]interface{}{ctx, nodeId, atxId, Post, PostMetadata, numUnits}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Post", reflect.TypeOf((*MocknipostValidator)(nil).Post), varargs...)
 }
 

--- a/activation/mocks.go
+++ b/activation/mocks.go
@@ -74,9 +74,9 @@ func (m *MockPostVerifier) EXPECT() *MockPostVerifierMockRecorder {
 }
 
 // Verify mocks base method.
-func (m_2 *MockPostVerifier) Verify(p *shared.Proof, m *shared.ProofMetadata, opts ...verifying.OptionFunc) error {
+func (m_2 *MockPostVerifier) Verify(ctx context.Context, p *shared.Proof, m *shared.ProofMetadata, opts ...verifying.OptionFunc) error {
 	m_2.ctrl.T.Helper()
-	varargs := []interface{}{p, m}
+	varargs := []interface{}{ctx, p, m}
 	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
@@ -86,9 +86,9 @@ func (m_2 *MockPostVerifier) Verify(p *shared.Proof, m *shared.ProofMetadata, op
 }
 
 // Verify indicates an expected call of Verify.
-func (mr *MockPostVerifierMockRecorder) Verify(p, m interface{}, opts ...interface{}) *gomock.Call {
+func (mr *MockPostVerifierMockRecorder) Verify(ctx, p, m interface{}, opts ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{p, m}, opts...)
+	varargs := append([]interface{}{ctx, p, m}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Verify", reflect.TypeOf((*MockPostVerifier)(nil).Verify), varargs...)
 }
 

--- a/activation/mocks.go
+++ b/activation/mocks.go
@@ -11,6 +11,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	types "github.com/spacemeshos/go-spacemesh/common/types"
+	shared "github.com/spacemeshos/post/shared"
 	verifying "github.com/spacemeshos/post/verifying"
 )
 
@@ -47,6 +48,48 @@ func (m *MockAtxReceiver) OnAtx(arg0 *types.ActivationTxHeader) {
 func (mr *MockAtxReceiverMockRecorder) OnAtx(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OnAtx", reflect.TypeOf((*MockAtxReceiver)(nil).OnAtx), arg0)
+}
+
+// MockPostVerifier is a mock of PostVerifier interface.
+type MockPostVerifier struct {
+	ctrl     *gomock.Controller
+	recorder *MockPostVerifierMockRecorder
+}
+
+// MockPostVerifierMockRecorder is the mock recorder for MockPostVerifier.
+type MockPostVerifierMockRecorder struct {
+	mock *MockPostVerifier
+}
+
+// NewMockPostVerifier creates a new mock instance.
+func NewMockPostVerifier(ctrl *gomock.Controller) *MockPostVerifier {
+	mock := &MockPostVerifier{ctrl: ctrl}
+	mock.recorder = &MockPostVerifierMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockPostVerifier) EXPECT() *MockPostVerifierMockRecorder {
+	return m.recorder
+}
+
+// Verify mocks base method.
+func (m_2 *MockPostVerifier) Verify(p *shared.Proof, m *shared.ProofMetadata, opts ...verifying.OptionFunc) error {
+	m_2.ctrl.T.Helper()
+	varargs := []interface{}{p, m}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m_2.ctrl.Call(m_2, "Verify", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Verify indicates an expected call of Verify.
+func (mr *MockPostVerifierMockRecorder) Verify(p, m interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{p, m}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Verify", reflect.TypeOf((*MockPostVerifier)(nil).Verify), varargs...)
 }
 
 // MocknipostValidator is a mock of nipostValidator interface.

--- a/activation/nipost_test.go
+++ b/activation/nipost_test.go
@@ -129,6 +129,7 @@ func TestNIPostBuilderWithClients(t *testing.T) {
 		NewPostVerifier(postCfg, logger),
 	)
 	_, err := v.NIPost(
+		context.Background(),
 		postProvider.id,
 		postProvider.commitmentAtxId,
 		nipost,
@@ -224,6 +225,7 @@ func TestNewNIPostBuilderNotInitialized(t *testing.T) {
 	logger := logtest.New(t).WithName("validator")
 	v := NewValidator(poetDb, postProvider.cfg, logger, NewPostVerifier(postProvider.cfg, logger))
 	_, err = v.NIPost(
+		context.Background(),
 		postProvider.id,
 		postProvider.goldenATXID,
 		nipost,

--- a/activation/post.go
+++ b/activation/post.go
@@ -66,8 +66,12 @@ type PostProofVerifyingOpts struct {
 }
 
 func DefaultPostVerifyingOpts() PostProofVerifyingOpts {
+	workers := runtime.NumCPU() * 3 / 4
+	if workers < 1 {
+		workers = 1
+	}
 	return PostProofVerifyingOpts{
-		Workers: runtime.NumCPU() * 3 / 4,
+		Workers: workers,
 	}
 }
 

--- a/activation/post.go
+++ b/activation/post.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"runtime"
 	"sync"
 
 	"github.com/spacemeshos/post/config"
@@ -55,6 +56,18 @@ func DefaultPostProvingOpts() PostProvingOpts {
 	return PostProvingOpts{
 		Threads: 1,
 		Nonces:  16,
+	}
+}
+
+// PostProvingOpts are the options controlling POST proving process.
+type PostProofVerifyingOpts struct {
+	// Number of workers spawned to verify proofs.
+	Workers int `mapstructure:"smeshing-opts-verifying-workers"`
+}
+
+func DefaultPostVerifyingOpts() PostProofVerifyingOpts {
+	return PostProofVerifyingOpts{
+		Workers: runtime.NumCPU() * 3 / 4,
 	}
 }
 

--- a/activation/post_verifier.go
+++ b/activation/post_verifier.go
@@ -1,0 +1,106 @@
+package activation
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spacemeshos/post/config"
+	"github.com/spacemeshos/post/shared"
+	"github.com/spacemeshos/post/verifying"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/log"
+)
+
+type verifyPostJob struct {
+	proof    *shared.Proof
+	metadata *shared.ProofMetadata
+	opts     []verifying.OptionFunc
+	result   chan error
+}
+
+type OffloadingPostVerifier struct {
+	eg      errgroup.Group
+	log     log.Log
+	workers []*postVerifierWorker
+	channel chan<- *verifyPostJob
+}
+
+type postVerifierWorker struct {
+	verifier PostVerifier
+	log      log.Log
+	channel  <-chan *verifyPostJob
+}
+
+type verifierFunc func(*shared.Proof, *shared.ProofMetadata, ...verifying.OptionFunc) error
+
+func (f verifierFunc) Verify(p *shared.Proof, m *shared.ProofMetadata, opts ...verifying.OptionFunc) error {
+	return f(p, m, opts...)
+}
+
+// NewPostVerifier creates a new post verifier.
+func NewPostVerifier(cfg PostConfig, logger log.Log) PostVerifier {
+	c := config.Config(cfg)
+	verify := func(p *shared.Proof, m *shared.ProofMetadata, opts ...verifying.OptionFunc) error {
+		logger.With().Debug("verifying post", log.FieldNamed("proof_node_id", types.BytesToNodeID(m.NodeId)))
+		return verifying.Verify(p, m, c, logger.Zap(), opts...)
+	}
+	return verifierFunc(verify)
+}
+
+// NewOffloadingPostVerifier creates a new post proof verifier with the given number of workers.
+// The verifier will distribute incoming proofs between the workers.
+// It will block if all workers are busy.
+func NewOffloadingPostVerifier(verifiers []PostVerifier, logger log.Log) *OffloadingPostVerifier {
+	numWorkers := len(verifiers)
+	channel := make(chan *verifyPostJob, numWorkers)
+	workers := make([]*postVerifierWorker, 0, numWorkers)
+
+	for i, verifier := range verifiers {
+		workers = append(workers, &postVerifierWorker{
+			verifier: verifier,
+			log:      logger.Named(fmt.Sprintf("worker-%d", i)),
+			channel:  channel,
+		})
+	}
+	logger.With().Info("created post verifier", log.Int("num_workers", numWorkers))
+
+	return &OffloadingPostVerifier{
+		log:     logger,
+		workers: workers,
+		channel: channel,
+	}
+}
+
+func (v *OffloadingPostVerifier) Start(ctx context.Context) {
+	v.log.Info("starting post verifier")
+	for _, worker := range v.workers {
+		worker := worker
+		v.eg.Go(func() error { worker.start(); return nil })
+	}
+	<-ctx.Done()
+	v.log.Info("stopping post verifier")
+	close(v.channel)
+	v.eg.Wait()
+	v.log.Info("stopped post verifier")
+}
+
+func (v *OffloadingPostVerifier) Verify(p *shared.Proof, m *shared.ProofMetadata, opts ...verifying.OptionFunc) error {
+	job := &verifyPostJob{
+		proof:    p,
+		metadata: m,
+		opts:     opts,
+		result:   make(chan error),
+	}
+	v.channel <- job
+	return <-job.result
+}
+
+func (w *postVerifierWorker) start() {
+	w.log.Info("starting post proof verifier worker")
+	for job := range w.channel {
+		job.result <- w.verifier.Verify(job.proof, job.metadata, job.opts...)
+	}
+	w.log.Info("stopped post proof verifier worker")
+}

--- a/activation/post_verifier_test.go
+++ b/activation/post_verifier_test.go
@@ -34,13 +34,13 @@ func TestOffloadingPostVerifier(t *testing.T) {
 	})
 
 	{
-		verifier.EXPECT().Verify(&proof, &metadata, gomock.Any()).Return(nil)
-		err := offloadingVerifier.Verify(&proof, &metadata)
+		verifier.EXPECT().Verify(ctx, &proof, &metadata, gomock.Any()).Return(nil)
+		err := offloadingVerifier.Verify(ctx, &proof, &metadata)
 		require.NoError(t, err)
 	}
 	{
-		verifier.EXPECT().Verify(&proof, &metadata, gomock.Any()).Return(errors.New("invalid proof!"))
-		err := offloadingVerifier.Verify(&proof, &metadata)
+		verifier.EXPECT().Verify(ctx, &proof, &metadata, gomock.Any()).Return(errors.New("invalid proof!"))
+		err := offloadingVerifier.Verify(ctx, &proof, &metadata)
 		require.ErrorContains(t, err, "invalid proof!")
 	}
 
@@ -50,5 +50,40 @@ func TestOffloadingPostVerifier(t *testing.T) {
 
 func TestPostVerfierDetectsInvalidProof(t *testing.T) {
 	verifier := activation.NewPostVerifier(activation.PostConfig{}, log.NewDefault(t.Name()))
-	require.Error(t, verifier.Verify(&shared.Proof{}, &shared.ProofMetadata{}))
+	require.Error(t, verifier.Verify(context.Background(), &shared.Proof{}, &shared.ProofMetadata{}))
+}
+
+func TestPostVerifierVerifyAfterStop(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	proof := shared.Proof{}
+	metadata := shared.ProofMetadata{}
+
+	verifier := activation.NewMockPostVerifier(gomock.NewController(t))
+	offloadingVerifier := activation.NewOffloadingPostVerifier(
+		[]activation.PostVerifier{verifier},
+		log.NewDefault(t.Name()),
+	)
+
+	var eg errgroup.Group
+	eg.Go(func() error {
+		offloadingVerifier.Start(ctx)
+		return nil
+	})
+
+	{
+		verifier.EXPECT().Verify(ctx, &proof, &metadata, gomock.Any()).Return(nil)
+		err := offloadingVerifier.Verify(ctx, &proof, &metadata)
+		require.NoError(t, err)
+	}
+	// Stop the verifier
+	cancel()
+	require.NoError(t, eg.Wait())
+
+	{
+		err := offloadingVerifier.Verify(ctx, &proof, &metadata)
+		require.ErrorIs(t, err, context.Canceled)
+	}
+
 }

--- a/activation/post_verifier_test.go
+++ b/activation/post_verifier_test.go
@@ -85,5 +85,4 @@ func TestPostVerifierVerifyAfterStop(t *testing.T) {
 		err := offloadingVerifier.Verify(ctx, &proof, &metadata)
 		require.ErrorIs(t, err, context.Canceled)
 	}
-
 }

--- a/activation/post_verifier_test.go
+++ b/activation/post_verifier_test.go
@@ -1,0 +1,54 @@
+package activation_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/spacemeshos/post/shared"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/spacemeshos/go-spacemesh/activation"
+	"github.com/spacemeshos/go-spacemesh/log"
+)
+
+func TestOffloadingPostVerifier(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	proof := shared.Proof{}
+	metadata := shared.ProofMetadata{}
+
+	verifier := activation.NewMockPostVerifier(gomock.NewController(t))
+	offloadingVerifier := activation.NewOffloadingPostVerifier(
+		[]activation.PostVerifier{verifier},
+		log.NewDefault(t.Name()),
+	)
+
+	var eg errgroup.Group
+	eg.Go(func() error {
+		offloadingVerifier.Start(ctx)
+		return nil
+	})
+
+	{
+		verifier.EXPECT().Verify(&proof, &metadata, gomock.Any()).Return(nil)
+		err := offloadingVerifier.Verify(&proof, &metadata)
+		require.NoError(t, err)
+	}
+	{
+		verifier.EXPECT().Verify(&proof, &metadata, gomock.Any()).Return(errors.New("invalid proof!"))
+		err := offloadingVerifier.Verify(&proof, &metadata)
+		require.ErrorContains(t, err, "invalid proof!")
+	}
+
+	cancel()
+	require.NoError(t, eg.Wait())
+}
+
+func TestPostVerfierDetectsInvalidProof(t *testing.T) {
+	verifier := activation.NewPostVerifier(activation.PostConfig{}, log.NewDefault(t.Name()))
+	require.Error(t, verifier.Verify(&shared.Proof{}, &shared.ProofMetadata{}))
+}

--- a/activation/validation.go
+++ b/activation/validation.go
@@ -2,6 +2,7 @@ package activation
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"time"
@@ -125,7 +126,7 @@ func (v *Validator) Post(nodeId types.NodeID, commitmentAtxId types.ATXID, PoST 
 	}
 
 	start := time.Now()
-	if err := v.postVerifier.Verify(p, m, opts...); err != nil {
+	if err := v.postVerifier.Verify(context.TODO(), p, m, opts...); err != nil {
 		return fmt.Errorf("verify PoST: %w", err)
 	}
 	metrics.PostVerificationLatency.Observe(time.Since(start).Seconds())

--- a/activation/validation_test.go
+++ b/activation/validation_test.go
@@ -588,33 +588,33 @@ func TestValidator_Validate(t *testing.T) {
 
 	logger := logtest.New(t).WithName("validator")
 	v := NewValidator(poetDb, postProvider.cfg, logger, NewPostVerifier(postProvider.cfg, logger))
-	_, err := v.NIPost(postProvider.id, postProvider.commitmentAtxId, nipost, challengeHash, postProvider.opts.NumUnits, opts...)
+	_, err := v.NIPost(context.Background(), postProvider.id, postProvider.commitmentAtxId, nipost, challengeHash, postProvider.opts.NumUnits, opts...)
 	r.NoError(err)
 
-	_, err = v.NIPost(postProvider.id, postProvider.commitmentAtxId, nipost, types.BytesToHash([]byte("lerner")), postProvider.opts.NumUnits, opts...)
+	_, err = v.NIPost(context.Background(), postProvider.id, postProvider.commitmentAtxId, nipost, types.BytesToHash([]byte("lerner")), postProvider.opts.NumUnits, opts...)
 	r.Contains(err.Error(), "invalid membership proof")
 
 	newNIPost := *nipost
 	newNIPost.Post = &types.Post{}
-	_, err = v.NIPost(postProvider.id, postProvider.commitmentAtxId, &newNIPost, challengeHash, postProvider.opts.NumUnits, opts...)
+	_, err = v.NIPost(context.Background(), postProvider.id, postProvider.commitmentAtxId, &newNIPost, challengeHash, postProvider.opts.NumUnits, opts...)
 	r.Contains(err.Error(), "invalid Post")
 
 	newPostCfg := postProvider.cfg
 	newPostCfg.MinNumUnits = postProvider.opts.NumUnits + 1
 	v = NewValidator(poetDb, newPostCfg, logtest.New(t).WithName("validator"), nil)
-	_, err = v.NIPost(postProvider.id, postProvider.commitmentAtxId, nipost, challengeHash, postProvider.opts.NumUnits, opts...)
+	_, err = v.NIPost(context.Background(), postProvider.id, postProvider.commitmentAtxId, nipost, challengeHash, postProvider.opts.NumUnits, opts...)
 	r.EqualError(err, fmt.Sprintf("invalid `numUnits`; expected: >=%d, given: %d", newPostCfg.MinNumUnits, postProvider.opts.NumUnits))
 
 	newPostCfg = postProvider.cfg
 	newPostCfg.MaxNumUnits = postProvider.opts.NumUnits - 1
 	v = NewValidator(poetDb, newPostCfg, logtest.New(t).WithName("validator"), nil)
-	_, err = v.NIPost(postProvider.id, postProvider.commitmentAtxId, nipost, challengeHash, postProvider.opts.NumUnits, opts...)
+	_, err = v.NIPost(context.Background(), postProvider.id, postProvider.commitmentAtxId, nipost, challengeHash, postProvider.opts.NumUnits, opts...)
 	r.EqualError(err, fmt.Sprintf("invalid `numUnits`; expected: <=%d, given: %d", newPostCfg.MaxNumUnits, postProvider.opts.NumUnits))
 
 	newPostCfg = postProvider.cfg
 	newPostCfg.LabelsPerUnit = nipost.PostMetadata.LabelsPerUnit + 1
 	v = NewValidator(poetDb, newPostCfg, logtest.New(t).WithName("validator"), nil)
-	_, err = v.NIPost(postProvider.id, postProvider.commitmentAtxId, nipost, challengeHash, postProvider.opts.NumUnits, opts...)
+	_, err = v.NIPost(context.Background(), postProvider.id, postProvider.commitmentAtxId, nipost, challengeHash, postProvider.opts.NumUnits, opts...)
 	r.EqualError(err, fmt.Sprintf("invalid `LabelsPerUnit`; expected: >=%d, given: %d", newPostCfg.LabelsPerUnit, nipost.PostMetadata.LabelsPerUnit))
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -110,10 +110,11 @@ type BaseConfig struct {
 
 // SmeshingConfig defines configuration for the node's smeshing (mining).
 type SmeshingConfig struct {
-	Start           bool                       `mapstructure:"smeshing-start"`
-	CoinbaseAccount string                     `mapstructure:"smeshing-coinbase"`
-	Opts            activation.PostSetupOpts   `mapstructure:"smeshing-opts"`
-	ProvingOpts     activation.PostProvingOpts `mapstructure:"smeshing-proving-opts"`
+	Start           bool                              `mapstructure:"smeshing-start"`
+	CoinbaseAccount string                            `mapstructure:"smeshing-coinbase"`
+	Opts            activation.PostSetupOpts          `mapstructure:"smeshing-opts"`
+	ProvingOpts     activation.PostProvingOpts        `mapstructure:"smeshing-proving-opts"`
+	VerifyingOpts   activation.PostProofVerifyingOpts `mapstructure:"smeshing-verifying-opts"`
 }
 
 // DefaultConfig returns the default configuration for a spacemesh node.
@@ -181,6 +182,7 @@ func DefaultSmeshingConfig() SmeshingConfig {
 		CoinbaseAccount: "",
 		Opts:            activation.DefaultPostSetupOpts(),
 		ProvingOpts:     activation.DefaultPostProvingOpts(),
+		VerifyingOpts:   activation.DefaultPostVerifyingOpts(),
 	}
 }
 


### PR DESCRIPTION
## Motivation
Closes #4388 

## Changes
Created a layer between nipostValidator and verifying code in https://github.com/spacemeshos/post that offloads verifying PoST onto a pool of workers. A free worker picks up proof, verifies it, and sends back the result via a provided channel.

## Test Plan
- [x] Existing tests should pass
- [ ] Survive the big 1k nodes network