### PR TITLE
add genesis id and first layer as p2p protocol prefix 

### DIFF
--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -191,12 +191,12 @@ func NewFetch(cdb *datastore.CachedDB, msh meshProvider, b system.BeaconGetter, 
 	}
 	if len(f.servers) == 0 {
 		h := newHandler(cdb, bs, msh, b, f.logger)
-		f.servers[atxProtocol] = server.New(host, atxProtocol, h.handleEpochInfoReq, srvOpts...)
-		f.servers[lyrDataProtocol] = server.New(host, lyrDataProtocol, h.handleLayerDataReq, srvOpts...)
-		f.servers[lyrOpnsProtocol] = server.New(host, lyrOpnsProtocol, h.handleLayerOpinionsReq, srvOpts...)
-		f.servers[hashProtocol] = server.New(host, hashProtocol, h.handleHashReq, srvOpts...)
-		f.servers[meshHashProtocol] = server.New(host, meshHashProtocol, h.handleMeshHashReq, srvOpts...)
-		f.servers[malProtocol] = server.New(host, malProtocol, h.handleMaliciousIDsReq, srvOpts...)
+		f.servers[atxProtocol] = server.New(host, makeProtocol(host.Prefix(), atxProtocol), h.handleEpochInfoReq, srvOpts...)
+		f.servers[lyrDataProtocol] = server.New(host, makeProtocol(host.Prefix(), lyrDataProtocol), h.handleLayerDataReq, srvOpts...)
+		f.servers[lyrOpnsProtocol] = server.New(host, makeProtocol(host.Prefix(), lyrOpnsProtocol), h.handleLayerOpinionsReq, srvOpts...)
+		f.servers[hashProtocol] = server.New(host, makeProtocol(host.Prefix(), hashProtocol), h.handleHashReq, srvOpts...)
+		f.servers[meshHashProtocol] = server.New(host, makeProtocol(host.Prefix(), meshHashProtocol), h.handleMeshHashReq, srvOpts...)
+		f.servers[malProtocol] = server.New(host, makeProtocol(host.Prefix(), malProtocol), h.handleMaliciousIDsReq, srvOpts...)
 	}
 	return f
 }
@@ -210,6 +210,10 @@ type dataValidators struct {
 	txBlock     SyncValidator
 	txProposal  SyncValidator
 	malfeasance SyncValidator
+}
+
+func makeProtocol(prefix, protocol string) string {
+	return fmt.Sprintf("%s/%s", prefix, protocol)
 }
 
 // SetValidators sets the handlers to validate various mesh data fetched from peers.

--- a/fetch/fetch_test.go
+++ b/fetch/fetch_test.go
@@ -324,16 +324,17 @@ func TestFetch_PeerDroppedWhenMessageResultsInValidationReject(t *testing.T) {
 	p2pconf := p2p.DefaultConfig()
 	p2pconf.Listen = "/ip4/127.0.0.1/tcp/0"
 	p2pconf.DataDir = t.TempDir()
+	prefix := "/prefix"
 
 	// Good host
 	genesisID := types.Hash20{}
-	h, err := p2p.New(ctx, lg, p2pconf, genesisID)
+	h, err := p2p.New(ctx, lg, p2pconf, genesisID, prefix)
 	require.NoError(t, err)
 	t.Cleanup(func() { h.Close() })
 
 	// Bad host, will send a message that results in validation reject
 	p2pconf.DataDir = t.TempDir()
-	badPeerHost, err := p2p.New(ctx, lg, p2pconf, genesisID)
+	badPeerHost, err := p2p.New(ctx, lg, p2pconf, genesisID, prefix)
 	require.NoError(t, err)
 	t.Cleanup(func() { badPeerHost.Close() })
 
@@ -361,7 +362,7 @@ func TestFetch_PeerDroppedWhenMessageResultsInValidationReject(t *testing.T) {
 		}
 		return result, nil
 	}
-	server.New(badPeerHost, hashProtocol, badPeerHandler)
+	server.New(badPeerHost, makeProtocol(prefix, hashProtocol), badPeerHandler)
 
 	fetcher := NewFetch(datastore.NewCachedDB(sql.InMemory(), lg), nil, nil, h,
 		WithContext(ctx),

--- a/fetch/interface.go
+++ b/fetch/interface.go
@@ -40,6 +40,7 @@ type meshProvider interface {
 
 type host interface {
 	ID() p2p.Peer
+	Prefix() string
 	GetPeers() []p2p.Peer
 	Close() error
 }

--- a/fetch/mocks/mocks.go
+++ b/fetch/mocks/mocks.go
@@ -225,3 +225,17 @@ func (mr *MockhostMockRecorder) ID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ID", reflect.TypeOf((*Mockhost)(nil).ID))
 }
+
+// Prefix mocks base method.
+func (m *Mockhost) Prefix() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Prefix")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Prefix indicates an expected call of Prefix.
+func (mr *MockhostMockRecorder) Prefix() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Prefix", reflect.TypeOf((*Mockhost)(nil).Prefix))
+}

--- a/hare/consensus_test.go
+++ b/hare/consensus_test.go
@@ -232,7 +232,7 @@ func TestConsensus_MultipleIterations(t *testing.T) {
 	i := 0
 	creationFunc := func() {
 		host := mesh.Hosts()[i]
-		ps, err := pubsub.New(ctx, logtest.New(t), host, pubsub.DefaultConfig())
+		ps, err := pubsub.New(ctx, logtest.New(t), host, "", pubsub.DefaultConfig())
 		require.NoError(t, err)
 		p2pm := &p2pManipulator{nd: ps, stalledLayer: instanceID1, err: errors.New("fake err")}
 		sig, err := signing.NewEdSigner()
@@ -265,7 +265,7 @@ func TestConsensusFixedOracle(t *testing.T) {
 	oracle := eligibility.New(logtest.New(t))
 	i := 0
 	creationFunc := func() {
-		ps, err := pubsub.New(ctx, logtest.New(t), mesh.Hosts()[i], pubsub.DefaultConfig())
+		ps, err := pubsub.New(ctx, logtest.New(t), mesh.Hosts()[i], "", pubsub.DefaultConfig())
 		require.NoError(t, err)
 		sig, err := signing.NewEdSigner()
 		require.NoError(t, err)
@@ -299,7 +299,7 @@ func TestSingleValueForHonestSet(t *testing.T) {
 	oracle := eligibility.New(logtest.New(t))
 	i := 0
 	creationFunc := func() {
-		ps, err := pubsub.New(ctx, logtest.New(t), mesh.Hosts()[i], pubsub.DefaultConfig())
+		ps, err := pubsub.New(ctx, logtest.New(t), mesh.Hosts()[i], "", pubsub.DefaultConfig())
 		require.NoError(t, err)
 		sig, err := signing.NewEdSigner()
 		require.NoError(t, err)
@@ -341,7 +341,7 @@ func TestAllDifferentSet(t *testing.T) {
 	oracle := eligibility.New(logtest.New(t))
 	i := 0
 	creationFunc := func() {
-		ps, err := pubsub.New(ctx, logtest.New(t), mesh.Hosts()[i], pubsub.DefaultConfig())
+		ps, err := pubsub.New(ctx, logtest.New(t), mesh.Hosts()[i], "", pubsub.DefaultConfig())
 		require.NoError(t, err)
 		sig, err := signing.NewEdSigner()
 		require.NoError(t, err)
@@ -382,7 +382,7 @@ func TestSndDelayedDishonest(t *testing.T) {
 	oracle := eligibility.New(logtest.New(t))
 	i := 0
 	honestFunc := func() {
-		ps, err := pubsub.New(ctx, logtest.New(t), mesh.Hosts()[i], pubsub.DefaultConfig())
+		ps, err := pubsub.New(ctx, logtest.New(t), mesh.Hosts()[i], "", pubsub.DefaultConfig())
 		require.NoError(t, err)
 		sig, err := signing.NewEdSigner()
 		require.NoError(t, err)
@@ -397,7 +397,7 @@ func TestSndDelayedDishonest(t *testing.T) {
 
 	// create dishonest
 	dishonestFunc := func() {
-		ps, err := pubsub.New(ctx, logtest.New(t), mesh.Hosts()[i], pubsub.DefaultConfig())
+		ps, err := pubsub.New(ctx, logtest.New(t), mesh.Hosts()[i], "", pubsub.DefaultConfig())
 		require.NoError(t, err)
 		sig, err := signing.NewEdSigner()
 		require.NoError(t, err)
@@ -440,7 +440,7 @@ func TestRecvDelayedDishonest(t *testing.T) {
 	oracle := eligibility.New(logtest.New(t))
 	i := 0
 	honestFunc := func() {
-		ps, err := pubsub.New(ctx, logtest.New(t), mesh.Hosts()[i], pubsub.DefaultConfig())
+		ps, err := pubsub.New(ctx, logtest.New(t), mesh.Hosts()[i], "", pubsub.DefaultConfig())
 		require.NoError(t, err)
 		sig, err := signing.NewEdSigner()
 		require.NoError(t, err)
@@ -455,7 +455,7 @@ func TestRecvDelayedDishonest(t *testing.T) {
 
 	// create dishonest
 	dishonestFunc := func() {
-		ps, err := pubsub.New(ctx, logtest.New(t), mesh.Hosts()[i], pubsub.DefaultConfig())
+		ps, err := pubsub.New(ctx, logtest.New(t), mesh.Hosts()[i], "", pubsub.DefaultConfig())
 		require.NoError(t, err)
 		sig, err := signing.NewEdSigner()
 		require.NoError(t, err)
@@ -534,7 +534,7 @@ func TestEquivocation(t *testing.T) {
 	require.NoError(t, err)
 	mchs := make([]chan *types.MalfeasanceGossip, 0, totalNodes)
 	dishonestFunc := func() {
-		ps, err := pubsub.New(ctx, logtest.New(t), mesh.Hosts()[i], pubsub.DefaultConfig())
+		ps, err := pubsub.New(ctx, logtest.New(t), mesh.Hosts()[i], "", pubsub.DefaultConfig())
 		require.NoError(t, err)
 		tcp := createConsensusProcess(t, ctx, badGuy, false, cfg, oracle,
 			&equivocatePubSub{ps: ps, sig: badGuy},
@@ -548,7 +548,7 @@ func TestEquivocation(t *testing.T) {
 	test.Create(1, dishonestFunc)
 
 	honestFunc := func() {
-		ps, err := pubsub.New(ctx, logtest.New(t), mesh.Hosts()[i], pubsub.DefaultConfig())
+		ps, err := pubsub.New(ctx, logtest.New(t), mesh.Hosts()[i], "", pubsub.DefaultConfig())
 		require.NoError(t, err)
 		sig, err := signing.NewEdSigner()
 		require.NoError(t, err)

--- a/hare/flows_test.go
+++ b/hare/flows_test.go
@@ -288,7 +288,7 @@ func Test_multipleCPs(t *testing.T) {
 	var outputsWaitGroup sync.WaitGroup
 	for i := 0; i < totalNodes; i++ {
 		host := mesh.Hosts()[i]
-		ps, err := pubsub.New(ctx, logtest.New(t), host, pubsub.DefaultConfig())
+		ps, err := pubsub.New(ctx, logtest.New(t), host, "", pubsub.DefaultConfig())
 		require.NoError(t, err)
 		pubsubs = append(pubsubs, ps)
 		h := createTestHare(t, meshes[i], cfg, test.clock, ps, t.Name())
@@ -410,7 +410,7 @@ func Test_multipleCPsAndIterations(t *testing.T) {
 	var outputsWaitGroup sync.WaitGroup
 	for i := 0; i < totalNodes; i++ {
 		host := mesh.Hosts()[i]
-		ps, err := pubsub.New(ctx, logtest.New(t), host, pubsub.DefaultConfig())
+		ps, err := pubsub.New(ctx, logtest.New(t), host, "", pubsub.DefaultConfig())
 		require.NoError(t, err)
 		pubsubs = append(pubsubs, ps)
 		mp2p := &p2pManipulator{nd: ps, stalledLayer: types.GetEffectiveGenesis().Add(1), err: errors.New("fake err")}

--- a/hare/hare_rounds_test.go
+++ b/hare/hare_rounds_test.go
@@ -92,7 +92,7 @@ func runNodesFor(t *testing.T, ctx context.Context, nodes, leaders, maxLayers, l
 
 	for i := 0; i < nodes; i++ {
 		host := mesh.Hosts()[i]
-		ps, err := pubsub.New(ctx, logtest.New(t), host, pubsub.DefaultConfig())
+		ps, err := pubsub.New(ctx, logtest.New(t), host, "", pubsub.DefaultConfig())
 		require.NoError(t, err)
 		mp2p := &p2pManipulator{nd: ps, stalledLayer: types.LayerID(1), err: errors.New("fake err")}
 

--- a/node/node.go
+++ b/node/node.go
@@ -879,6 +879,7 @@ func (app *App) initServices(ctx context.Context, poetClients []activation.PoetP
 		app.ptimesync = peersync.New(
 			app.host,
 			app.host,
+			app.host.Prefix(),
 			peersync.WithLog(app.addLogger(TimeSyncLogger, lg)),
 			peersync.WithConfig(app.Config.TIME.Peersync),
 		)
@@ -1269,7 +1270,8 @@ func (app *App) Start(ctx context.Context) error {
 	p2plog := app.addLogger(P2PLogger, lg)
 	// if addLogger won't add a level we will use a default 0 (info).
 	cfg.LogLevel = app.getLevel(P2PLogger)
-	app.host, err = p2p.New(ctx, p2plog, cfg, app.Config.Genesis.GenesisID(),
+	p2pPrefix := fmt.Sprintf("/%s/%d", hex.EncodeToString(app.Config.Genesis.GenesisID().Bytes())[:5], types.GetEffectiveGenesis()+1)
+	app.host, err = p2p.New(ctx, p2plog, cfg, app.Config.Genesis.GenesisID(), p2pPrefix,
 		p2p.WithNodeReporter(events.ReportNodeStatusUpdate),
 	)
 	if err != nil {

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -433,7 +433,7 @@ func TestSpacemeshApp_NodeService(t *testing.T) {
 
 	edSgn, err := signing.NewEdSigner()
 	require.NoError(t, err)
-	h, err := p2p.Upgrade(mesh.Hosts()[0], cfg.Genesis.GenesisID())
+	h, err := p2p.Upgrade(mesh.Hosts()[0], cfg.Genesis.GenesisID(), "prefix")
 	require.NoError(t, err)
 	app, err := initSingleInstance(logger, *cfg, 0, cfg.Genesis.GenesisTime,
 		path, poetHarness.HTTPPoetClient, clock, h, edSgn,

--- a/p2p/handshake/handshake_test.go
+++ b/p2p/handshake/handshake_test.go
@@ -12,18 +12,22 @@ import (
 )
 
 func TestHandshake(t *testing.T) {
-	mesh, err := mocknet.FullMeshConnected(3)
+	mesh, err := mocknet.FullMeshConnected(4)
 	require.NoError(t, err)
 	genesisID := types.Hash20{1}
-	hs1 := New(mesh.Hosts()[0], genesisID)
+	prefix := "prefix"
+	hs1 := New(mesh.Hosts()[0], genesisID, prefix)
 	t.Cleanup(hs1.Stop)
-	hs2 := New(mesh.Hosts()[1], genesisID)
+	hs2 := New(mesh.Hosts()[1], genesisID, prefix)
 	t.Cleanup(hs2.Stop)
-	hs3 := New(mesh.Hosts()[2], types.Hash20{2})
+	hs3 := New(mesh.Hosts()[2], types.Hash20{2}, prefix)
+	t.Cleanup(hs3.Stop)
+	hs4 := New(mesh.Hosts()[3], genesisID, "")
 	t.Cleanup(hs3.Stop)
 
 	require.NoError(t, hs1.Request(context.TODO(), hs2.h.ID()))
 	require.Error(t, hs1.Request(context.TODO(), hs3.h.ID()))
+	require.Error(t, hs1.Request(context.TODO(), hs4.h.ID()))
 }
 
 func FuzzHandshakeAckConsistency(f *testing.F) {

--- a/p2p/host.go
+++ b/p2p/host.go
@@ -49,7 +49,7 @@ type Config struct {
 }
 
 // New initializes libp2p host configured for spacemesh.
-func New(_ context.Context, logger log.Log, cfg Config, genesisID types.Hash20, opts ...Opt) (*Host, error) {
+func New(_ context.Context, logger log.Log, cfg Config, genesisID types.Hash20, prefix string, opts ...Opt) (*Host, error) {
 	logger.Info("starting libp2p host with config %+v", cfg)
 	key, err := EnsureIdentity(cfg.DataDir)
 	if err != nil {
@@ -95,5 +95,5 @@ func New(_ context.Context, logger log.Log, cfg Config, genesisID types.Hash20, 
 	// TODO(dshulyak) this is small mess. refactor to avoid this patching
 	// both New and Upgrade should use options.
 	opts = append(opts, WithConfig(cfg), WithLog(logger))
-	return Upgrade(h, genesisID, opts...)
+	return Upgrade(h, genesisID, prefix, opts...)
 }

--- a/p2p/pubsub/pubsub.go
+++ b/p2p/pubsub/pubsub.go
@@ -91,7 +91,7 @@ type Config struct {
 }
 
 // New creates PubSub instance.
-func New(ctx context.Context, logger log.Log, h host.Host, cfg Config) (*PubSub, error) {
+func New(ctx context.Context, logger log.Log, h host.Host, prefix string, cfg Config) (*PubSub, error) {
 	// TODO(dshulyak) refactor code to accept options
 	opts := getOptions(cfg)
 	ps, err := pubsub.NewGossipSub(ctx, h, opts...)
@@ -99,10 +99,11 @@ func New(ctx context.Context, logger log.Log, h host.Host, cfg Config) (*PubSub,
 		return nil, fmt.Errorf("failed to initialize gossipsub instance: %w", err)
 	}
 	return &PubSub{
-		logger: logger,
-		pubsub: ps,
-		topics: map[string]*pubsub.Topic{},
-		host:   h,
+		logger:      logger,
+		pubsub:      ps,
+		topics:      map[string]*pubsub.Topic{},
+		host:        h,
+		topicPrefix: prefix,
 	}, nil
 }
 
@@ -145,7 +146,7 @@ func ChainGossipHandler(handlers ...GossipHandler) GossipHandler {
 	}
 }
 
-// DropPeerValidationReject wraps a gossip handler to provide a handler that drops a
+// DropPeerOnValidationReject wraps a gossip handler to provide a handler that drops a
 // peer if the wrapped handler returns ErrValidationReject.
 func DropPeerOnValidationReject(handler GossipHandler, h host.Host, logger log.Log) GossipHandler {
 	return func(ctx context.Context, peer peer.ID, data []byte) error {

--- a/p2p/pubsub/pubsub_test.go
+++ b/p2p/pubsub/pubsub_test.go
@@ -25,7 +25,7 @@ func TestGossip(t *testing.T) {
 
 	for _, h := range mesh.Hosts() {
 		h := h
-		ps, err := New(ctx, logtest.New(t), h, Config{Flood: true, IsBootnode: true})
+		ps, err := New(ctx, logtest.New(t), h, "prefix", Config{Flood: true, IsBootnode: true})
 		require.NoError(t, err)
 		pubsubs = append(pubsubs, ps)
 		ps.Register(topic, func(ctx context.Context, pid peer.ID, msg []byte) error {

--- a/p2p/upgrade_test.go
+++ b/p2p/upgrade_test.go
@@ -59,7 +59,7 @@ func TestConnectionsNotifier(t *testing.T) {
 	// we count events - not peers
 	for i, host := range mesh.Hosts() {
 		i := i
-		_, err := Upgrade(host, types.Hash20{}, WithNodeReporter(func() { counter[i].Add(1) }))
+		_, err := Upgrade(host, types.Hash20{}, "prefix", WithNodeReporter(func() { counter[i].Add(1) }))
 		require.NoError(t, err)
 	}
 


### PR DESCRIPTION
## Motivation
part of #4090 

## Changes
- p2p handshake: add mesh first layer to handshake message
- gossip: add genesis id and mesh first layer into the gossip topic
- fetch: add mesh first layer into protocol