### PR TITLE
[Merged by Bors] - tortoise: dont skip genesis data

### DIFF
--- a/tortoise/recover.go
+++ b/tortoise/recover.go
@@ -25,8 +25,10 @@ func Recover(db *datastore.CachedDB, beacon system.BeaconGetter, opts ...Opt) (*
 	if err != nil {
 		return nil, fmt.Errorf("failed to load latest known layer: %v", err)
 	}
-	if latest <= types.GetEffectiveGenesis() {
-		return trtl, nil
+	if latest == 0 {
+		if err := recoverEpoch(types.GetEffectiveGenesis().Add(1).GetEpoch(), trtl, db, beacon); err != nil {
+			return nil, err
+		}
 	}
 	for lid := types.GetEffectiveGenesis().Add(1); !lid.After(latest); lid = lid.Add(1) {
 		if err := RecoverLayer(context.Background(), trtl, db, beacon, lid); err != nil {
@@ -36,20 +38,24 @@ func Recover(db *datastore.CachedDB, beacon system.BeaconGetter, opts ...Opt) (*
 	return trtl, nil
 }
 
+func recoverEpoch(epoch types.EpochID, trtl *Tortoise, db *datastore.CachedDB, beacondb system.BeaconGetter) error {
+	if err := db.IterateEpochATXHeaders(epoch, func(header *types.ActivationTxHeader) bool {
+		trtl.OnAtx(header)
+		return true
+	}); err != nil {
+		return err
+	}
+	beacon, err := beacondb.GetBeacon(epoch)
+	if err == nil {
+		trtl.OnBeacon(epoch, beacon)
+	}
+	return nil
+}
+
 func RecoverLayer(ctx context.Context, trtl *Tortoise, db *datastore.CachedDB, beacon system.BeaconGetter, lid types.LayerID) error {
 	if lid.FirstInEpoch() {
-		if err := db.IterateEpochATXHeaders(lid.GetEpoch(), func(header *types.ActivationTxHeader) bool {
-			trtl.OnAtx(header)
-			return true
-		}); err != nil {
+		if err := recoverEpoch(lid.GetEpoch(), trtl, db, beacon); err != nil {
 			return err
-		}
-		beacon, err := beacon.GetBeacon(lid.GetEpoch())
-		if err != nil && !errors.Is(err, sql.ErrNotFound) {
-			return err
-		}
-		if err == nil {
-			trtl.OnBeacon(lid.GetEpoch(), beacon)
 		}
 	}
 	blocksrst, err := blocks.Layer(db, lid)

--- a/tortoise/rerun_test.go
+++ b/tortoise/rerun_test.go
@@ -30,8 +30,8 @@ func TestRecoverState(t *testing.T) {
 	}
 	require.Equal(t, last.Sub(1), verified)
 
-	tortoise2 := tortoiseFromSimState(t, s.GetState(0), WithLogger(logtest.New(t)), WithConfig(cfg))
-	tortoise2.TallyVotes(ctx, last)
+	tortoise2, err := Recover(s.GetState(0).DB, s.GetState(0).Beacons, WithLogger(logtest.New(t)), WithConfig(cfg))
+	require.NoError(t, err)
 	verified = tortoise2.LatestComplete()
 	require.Equal(t, last.Sub(1), verified)
 	tortoiseFromSimState(t, s.GetState(0), WithLogger(logtest.New(t)), WithConfig(cfg))
@@ -70,6 +70,18 @@ func TestWindowSizeVoteCounting(t *testing.T) {
 	t.Run("FixesMisverified", func(t *testing.T) {
 		testWindowCounting(t, 3, 10, true)
 	})
+}
+
+func TestRecoverEmpty(t *testing.T) {
+	const size = 10
+	s := sim.New(sim.WithLayerSize(size))
+	s.Setup()
+
+	cfg := defaultTestConfig()
+	cfg.LayerSize = size
+	tortoise, err := Recover(s.GetState(0).DB, s.GetState(0).Beacons, WithLogger(logtest.New(t)), WithConfig(cfg))
+	require.NoError(t, err)
+	require.NotNil(t, tortoise)
 }
 
 func testWindowCounting(tb testing.TB, maliciousLayers, windowSize int, expectedValidity bool) {


### PR DESCRIPTION
there was a codepath that didn't load any data if node was restarted before the first ballot was sent into the network