### PR TITLE
[Merged by Bors] - fetch: fix out of memory issue in handleMeshHashReq

### DIFF
--- a/sql/layers/layers.go
+++ b/sql/layers/layers.go
@@ -197,10 +197,7 @@ func SetMeshHash(db sql.Executor, lid types.LayerID, aggHash types.Hash32) error
 
 // GetAggregatedHash for layer.
 func GetAggregatedHash(db sql.Executor, lid types.LayerID) (types.Hash32, error) {
-	var (
-		rst types.Hash32
-		err error
-	)
+	var rst types.Hash32
 	if rows, err := db.Exec("select aggregated_hash from layers where id = ?1",
 		func(stmt *sql.Statement) {
 			stmt.BindInt64(1, int64(lid.Uint32()))
@@ -213,7 +210,7 @@ func GetAggregatedHash(db sql.Executor, lid types.LayerID) (types.Hash32, error)
 	} else if rows == 0 {
 		return rst, fmt.Errorf("%w layer %s", sql.ErrNotFound, lid)
 	}
-	return rst, err
+	return rst, nil
 }
 
 func makeInClause(num int) string {


### PR DESCRIPTION
## Motivation
Closes #4427

## Changes
- Prevent requests for more than 1000 layers at a time
- Earlier / quicker check for `uint32` overflow

The overflow error could be mitigated by changing the request to only contain `From`, `To` and `Delta`/`By`, since `Steps` can be derived from the other 3. Then only the following checks would suffice to prevent overflows:

- `From` < `To`
- `Delta` <= `To` - `From`

I didn't include this change because because I'm not sure if non-backwards compatible changes are still OK?

## Test Plan
- `FuzzMeshHashRequest` would crash or panic within 15 - 20 seconds before (on my machine) now it doesn't find any issues even after 60 seconds
- Memory consumption during testing doesn't increase above 6 GB any more (before it would rise to > 16 GB before it crashes)

## TODO
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
