### PR TITLE
[Merged by Bors] - Revert "p2p: automatically prefix p2p protocol id with genesis id and layer (#4412)"

### DIFF
--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -1214,8 +1214,7 @@ func (app *App) Start(ctx context.Context) error {
 	p2plog := app.addLogger(P2PLogger, lg)
 	// if addLogger won't add a level we will use a default 0 (info).
 	cfg.LogLevel = app.getLevel(P2PLogger)
-	p2pPrefix := fmt.Sprintf("/%s/%d", hex.EncodeToString(app.Config.Genesis.GenesisID().Bytes())[:5], types.GetEffectiveGenesis()+1)
-	app.host, err = p2p.New(ctx, p2plog, cfg, app.Config.Genesis.GenesisID(), p2pPrefix,
+	app.host, err = p2p.New(ctx, p2plog, cfg, app.Config.Genesis.GenesisID(),
 		p2p.WithNodeReporter(events.ReportNodeStatusUpdate),
 	)
 	if err != nil {

--- a/cmd/node/node_test.go
+++ b/cmd/node/node_test.go
@@ -434,7 +434,7 @@ func TestSpacemeshApp_NodeService(t *testing.T) {
 
 	edSgn, err := signing.NewEdSigner()
 	require.NoError(t, err)
-	h, err := p2p.Upgrade(mesh.Hosts()[0], cfg.Genesis.GenesisID(), "/protocol/prefix")
+	h, err := p2p.Upgrade(mesh.Hosts()[0], cfg.Genesis.GenesisID())
 	require.NoError(t, err)
 	app, err := initSingleInstance(logger, *cfg, 0, cfg.Genesis.GenesisTime,
 		path, eligibility.New(logtest.New(t)),

--- a/p2p/handshake/handshake.go
+++ b/p2p/handshake/handshake.go
@@ -35,7 +35,7 @@ func WithLog(logger log.Log) Opt {
 }
 
 const (
-	hsprotocol    = "handshake/1"
+	hsprotocol    = "/handshake/1"
 	streamTimeout = 10 * time.Second
 )
 
@@ -63,7 +63,7 @@ func New(h host.Host, genesisID types.Hash20, opts ...Opt) *Handshake {
 	for _, opt := range opts {
 		opt(hs)
 	}
-	h.SetStreamHandler(hsprotocol, hs.handler)
+	h.SetStreamHandler(protocol.ID(hsprotocol), hs.handler)
 	emitter, err := h.EventBus().Emitter(new(EventHandshakeComplete))
 	if err != nil {
 		hs.logger.With().Panic("failed to initialize emitter for handshake", log.Err(err))

--- a/p2p/host.go
+++ b/p2p/host.go
@@ -49,7 +49,7 @@ type Config struct {
 }
 
 // New initializes libp2p host configured for spacemesh.
-func New(_ context.Context, logger log.Log, cfg Config, genesisID types.Hash20, prefix string, opts ...Opt) (*Host, error) {
+func New(_ context.Context, logger log.Log, cfg Config, genesisID types.Hash20, opts ...Opt) (*Host, error) {
 	logger.Info("starting libp2p host with config %+v", cfg)
 	key, err := EnsureIdentity(cfg.DataDir)
 	if err != nil {
@@ -95,5 +95,5 @@ func New(_ context.Context, logger log.Log, cfg Config, genesisID types.Hash20, 
 	// TODO(dshulyak) this is small mess. refactor to avoid this patching
 	// both New and Upgrade should use options.
 	opts = append(opts, WithConfig(cfg), WithLog(logger))
-	return Upgrade(h, genesisID, prefix, opts...)
+	return Upgrade(h, genesisID, opts...)
 }

--- a/p2p/peerexchange/protocol.go
+++ b/p2p/peerexchange/protocol.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	protocolName = "peerexchange/v1.0.0"
+	protocolName = "/peerexchange/v1.0.0"
 	// messageTimeout is the timeout for the whole stream lifetime.
 	messageTimeout = 10 * time.Second
 	sharedPeers    = 10
@@ -34,7 +34,7 @@ type peerExchange struct {
 	logger log.Log
 }
 
-// newPeerExchange is a constructor for a protocol provider.
+// newPeerExchange is a constructor for a protocol protocol provider.
 func newPeerExchange(h host.Host, rt *book.Book, advertise ma.Multiaddr, log log.Log) *peerExchange {
 	pe := &peerExchange{
 		h:      h,

--- a/p2p/upgrade.go
+++ b/p2p/upgrade.go
@@ -8,7 +8,6 @@ import (
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
-	"github.com/libp2p/go-libp2p/core/protocol"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/log"
@@ -56,8 +55,6 @@ type Host struct {
 	cfg    Config
 	logger log.Log
 
-	protocolPrefix string
-
 	host.Host
 	*pubsub.PubSub
 
@@ -82,13 +79,12 @@ func isBootnode(h host.Host, bootnodes []string) (bool, error) {
 }
 
 // Upgrade creates Host instance from host.Host.
-func Upgrade(h host.Host, genesisID types.Hash20, prefix string, opts ...Opt) (*Host, error) {
+func Upgrade(h host.Host, genesisID types.Hash20, opts ...Opt) (*Host, error) {
 	fh := &Host{
-		ctx:            context.Background(),
-		cfg:            DefaultConfig(),
-		logger:         log.NewNop(),
-		protocolPrefix: prefix,
-		Host:           h,
+		ctx:    context.Background(),
+		cfg:    DefaultConfig(),
+		logger: log.NewNop(),
+		Host:   h,
 	}
 	for _, opt := range opts {
 		opt(fh)
@@ -98,14 +94,14 @@ func Upgrade(h host.Host, genesisID types.Hash20, prefix string, opts ...Opt) (*
 	if err != nil {
 		return nil, fmt.Errorf("check node as bootnode: %w", err)
 	}
-	if fh.PubSub, err = pubsub.New(fh.ctx, fh.logger, fh, pubsub.Config{
+	if fh.PubSub, err = pubsub.New(fh.ctx, fh.logger, h, pubsub.Config{
 		Flood:          cfg.Flood,
 		IsBootnode:     bootnode,
 		MaxMessageSize: cfg.MaxMessageSize,
 	}); err != nil {
 		return nil, fmt.Errorf("failed to initialize pubsub: %w", err)
 	}
-	if fh.discovery, err = peerexchange.New(fh.logger, fh, peerexchange.Config{
+	if fh.discovery, err = peerexchange.New(fh.logger, h, peerexchange.Config{
 		DataDir:          cfg.DataDir,
 		Bootnodes:        cfg.Bootnodes,
 		AdvertiseAddress: cfg.AdvertiseAddress,
@@ -147,23 +143,4 @@ func (fh *Host) Stop() error {
 		return fmt.Errorf("failed to close libp2p host: %w", err)
 	}
 	return nil
-}
-
-// PrefixedProtocol prepends network specific params to protocol.
-func (fh *Host) PrefixedProtocol(protocol protocol.ID) string {
-	return fmt.Sprintf("%s/%s", fh.protocolPrefix, protocol)
-}
-
-// SetStreamHandler implements host.Host with overwritten protocol ID.
-func (fh *Host) SetStreamHandler(pid protocol.ID, handler network.StreamHandler) {
-	fh.Host.SetStreamHandler(protocol.ID(fh.PrefixedProtocol(pid)), handler)
-}
-
-// NewStream implements host.Host with overwritten protocol ID.
-func (fh *Host) NewStream(ctx context.Context, p peer.ID, pids ...protocol.ID) (network.Stream, error) {
-	var prefixed []protocol.ID
-	for _, pid := range pids {
-		prefixed = append(prefixed, protocol.ID(fh.PrefixedProtocol(pid)))
-	}
-	return fh.Host.NewStream(ctx, p, prefixed...)
 }

--- a/p2p/upgrade_test.go
+++ b/p2p/upgrade_test.go
@@ -1,15 +1,12 @@
 package p2p
 
 import (
-	"context"
 	"fmt"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/libp2p/go-libp2p"
-	"github.com/libp2p/go-libp2p/core/network"
-	"github.com/libp2p/go-libp2p/core/protocol"
 	"github.com/libp2p/go-libp2p/p2p/net/connmgr"
 	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
 	"github.com/stretchr/testify/require"
@@ -60,12 +57,10 @@ func TestConnectionsNotifier(t *testing.T) {
 	require.NoError(t, err)
 	counter := [n]atomic.Uint32{}
 	// we count events - not peers
-	var hosts []*Host
 	for i, host := range mesh.Hosts() {
 		i := i
-		h, err := Upgrade(host, types.Hash20{2, 4, 5}, "/prefix", WithNodeReporter(func() { counter[i].Add(1) }))
+		_, err := Upgrade(host, types.Hash20{}, WithNodeReporter(func() { counter[i].Add(1) }))
 		require.NoError(t, err)
-		hosts = append(hosts, h)
 	}
 
 	mesh.ConnectPeers(mesh.Hosts()[0].ID(), mesh.Hosts()[1].ID())
@@ -73,12 +68,6 @@ func TestConnectionsNotifier(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return counter[0].Load() >= 2 && counter[1].Load() >= 1 && counter[2].Load() >= 1
 	}, time.Second, 10*time.Millisecond)
-
-	prtcl := protocol.ID("test")
-	hosts[1].SetStreamHandler(prtcl, func(stream network.Stream) {})
-	stm, err := hosts[0].NewStream(context.Background(), hosts[1].ID(), prtcl)
-	require.NoError(t, err)
-	require.Equal(t, protocol.ID("/prefix/test"), stm.Protocol())
 
 	mesh.DisconnectPeers(mesh.Hosts()[0].ID(), mesh.Hosts()[1].ID())
 	require.Eventually(t, func() bool {

--- a/timesync/peersync/sync_test.go
+++ b/timesync/peersync/sync_test.go
@@ -138,7 +138,7 @@ func TestSyncSimulateMultiple(t *testing.T) {
 	require.NoError(t, err)
 	hosts := []*p2p.Host{}
 	for _, h := range mesh.Hosts() {
-		fh, err := p2p.Upgrade(h, genesisID, "/protocol/prefix")
+		fh, err := p2p.Upgrade(h, genesisID)
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = fh.Stop() })
 		hosts = append(hosts, fh)


### PR DESCRIPTION
closes: https://github.com/spacemeshos/go-spacemesh/issues/4433

either fmt or append allocates too much, see linked issue. the change needs to be profiled, or we should revisit approach