### PR TITLE
[Merged by Bors] - Bump chaos mesh to v2.6.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	crawshaw.io/sqlite v0.3.3-0.20211227050848-2cdb5c1a86a1
 	github.com/ALTree/bigfloat v0.0.0-20220102081255-38c8b72a9924
 	github.com/benbjohnson/clock v1.3.5
-	github.com/chaos-mesh/chaos-mesh/api v0.0.0-20230209235359-64dc83baed9b
+	github.com/chaos-mesh/chaos-mesh/api v0.0.0-20230531032220-a757362a12e1
 	github.com/cosmos/btcutil v1.0.5
 	github.com/gofrs/flock v0.8.1
 	github.com/golang/mock v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -86,8 +86,8 @@ github.com/c0mm4nd/go-ripemd v0.0.0-20200326052756-bd1759ad7d10/go.mod h1:mYPR+a
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/chaos-mesh/chaos-mesh/api v0.0.0-20230209235359-64dc83baed9b h1:am6IJSVZb/JIMffv4bOJ+BwPbrnwUovCTVP/gY38F1Q=
-github.com/chaos-mesh/chaos-mesh/api v0.0.0-20230209235359-64dc83baed9b/go.mod h1:tMUOEjRuThuozqrIDKhyViTZXaEZhIVV18/cSiGC3NQ=
+github.com/chaos-mesh/chaos-mesh/api v0.0.0-20230531032220-a757362a12e1 h1:yN5yGt1TwiTJhBPpYLW5FOnCYpF086dxdzBisrLhliE=
+github.com/chaos-mesh/chaos-mesh/api v0.0.0-20230531032220-a757362a12e1/go.mod h1:5qllHIhMkPEWjIimDum42JtMj0P1Tn9x91XUceuPNjY=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=


### PR DESCRIPTION
## Motivation
Chaos mesh has released version v2.6.0: https://github.com/chaos-mesh/chaos-mesh/discussions/4069

Since the API module in the repository isn't tagged explicitly we need to manually update the dependency, as it isn't picked up by dependabot automatically.

## Changes
- Update chaos-mesh dependency to v2.6.0

## Test Plan
n/a

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
