### PR TITLE
[Merged by Bors] - mesh: prevent incorrect latest layer updates on error and unexpected inputs

### DIFF
--- a/mesh/mesh.go
+++ b/mesh/mesh.go
@@ -393,7 +393,15 @@ func (msh *Mesh) applyResults(ctx context.Context, results []result.Layer) error
 			log.Context(ctx),
 			log.Stringer("applied", target),
 		)
-		msh.setLatestLayerInState(layer.Layer)
+		if latest := msh.LatestLayerInState(); latest > layer.Layer {
+			msh.logger.With().Warning("reverted layer without reverting state",
+				log.Context(ctx),
+				log.Uint32("latest", latest.Uint32()),
+				log.Uint32("update", layer.Layer.Uint32()),
+			)
+		} else {
+			msh.setLatestLayerInState(layer.Layer)
+		}
 	}
 	return nil
 }

--- a/mesh/mesh.go
+++ b/mesh/mesh.go
@@ -394,7 +394,7 @@ func (msh *Mesh) applyResults(ctx context.Context, results []result.Layer) error
 			log.Stringer("applied", target),
 		)
 		if latest := msh.LatestLayerInState(); latest > layer.Layer {
-			msh.logger.With().Warning("reverted layer without reverting state",
+			msh.logger.With().Debug("reverted layer without reverting state",
 				log.Context(ctx),
 				log.Uint32("latest", latest.Uint32()),
 				log.Uint32("update", layer.Layer.Uint32()),

--- a/mesh/mesh.go
+++ b/mesh/mesh.go
@@ -219,15 +219,12 @@ func (msh *Mesh) setProcessedLayer(layerID types.LayerID) error {
 // the block in consensus, and reverts state before that layer
 // if such layer is found.
 func (msh *Mesh) ensureStateConsistent(ctx context.Context, results []result.Layer) error {
-	var (
-		changed types.LayerID
-		inState = msh.LatestLayerInState()
-	)
+	var changed types.LayerID
 	for _, layer := range results {
-		if layer.Layer > inState {
+		applied, err := layers.GetApplied(msh.cdb, layer.Layer)
+		if err != nil && errors.Is(err, sql.ErrNotFound) {
 			continue
 		}
-		applied, err := layers.GetApplied(msh.cdb, layer.Layer)
 		if err != nil {
 			return fmt.Errorf("get applied %v: %w", layer.Layer, err)
 		}
@@ -393,13 +390,7 @@ func (msh *Mesh) applyResults(ctx context.Context, results []result.Layer) error
 			log.Context(ctx),
 			log.Stringer("applied", target),
 		)
-		if latest := msh.LatestLayerInState(); latest > layer.Layer {
-			msh.logger.With().Debug("reverted layer without reverting state",
-				log.Context(ctx),
-				log.Uint32("latest", latest.Uint32()),
-				log.Uint32("update", layer.Layer.Uint32()),
-			)
-		} else {
+		if layer.Layer > msh.LatestLayerInState() {
 			msh.setLatestLayerInState(layer.Layer)
 		}
 	}

--- a/mesh/mesh_test.go
+++ b/mesh/mesh_test.go
@@ -610,6 +610,39 @@ func TestProcessLayer(t *testing.T) {
 				},
 			},
 		},
+		{
+			"silent revert",
+			[]call{
+				{
+					updates: rlayers(
+						rlayer(start,
+							rblock(fixture.IDGen("1"), fixture.Invalid(), fixture.Data()),
+						),
+						rlayer(start.Add(1),
+							rblock(fixture.IDGen("2"), fixture.Invalid(), fixture.Data()),
+						),
+					),
+					executed: []types.BlockID{{}, {}},
+					applied:  []types.BlockID{{}, {}},
+				},
+				{
+					updates: rlayers(
+						rlayer(start,
+							rblock(fixture.IDGen("1"), fixture.Invalid(), fixture.Data()),
+						)),
+					applied: []types.BlockID{{}, {}},
+				},
+				{
+					updates: rlayers(
+						rlayer(start.Add(1),
+							rblock(fixture.IDGen("2"), fixture.Valid(), fixture.Data()),
+						),
+					),
+					executed: []types.BlockID{idg("2")},
+					applied:  []types.BlockID{{}, idg("2")},
+				},
+			},
+		},
 	} {
 		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {

--- a/systest/tests/partition_test.go
+++ b/systest/tests/partition_test.go
@@ -169,7 +169,7 @@ func testPartition(t *testing.T, tctx *testcontext.Context, cl *cluster.Cluster,
 func TestPartition_30_70(t *testing.T) {
 	t.Parallel()
 
-	tctx := testcontext.New(t, testcontext.Labels("partition"))
+	tctx := testcontext.New(t, testcontext.Labels("sanity"))
 	if tctx.ClusterSize > 30 {
 		tctx.Log.Info("cluster size changed to 30")
 		tctx.ClusterSize = 30
@@ -181,10 +181,9 @@ func TestPartition_30_70(t *testing.T) {
 }
 
 func TestPartition_50_50(t *testing.T) {
-	t.Skip()
 	t.Parallel()
 
-	tctx := testcontext.New(t, testcontext.Labels("partition"))
+	tctx := testcontext.New(t, testcontext.Labels("sanity"))
 	if tctx.ClusterSize > 30 {
 		tctx.Log.Info("cluster size changed to 30")
 		tctx.ClusterSize = 30

--- a/systest/tests/partition_test.go
+++ b/systest/tests/partition_test.go
@@ -169,7 +169,7 @@ func testPartition(t *testing.T, tctx *testcontext.Context, cl *cluster.Cluster,
 func TestPartition_30_70(t *testing.T) {
 	t.Parallel()
 
-	tctx := testcontext.New(t, testcontext.Labels("sanity"))
+	tctx := testcontext.New(t, testcontext.Labels("partition"))
 	if tctx.ClusterSize > 30 {
 		tctx.Log.Info("cluster size changed to 30")
 		tctx.ClusterSize = 30
@@ -181,9 +181,10 @@ func TestPartition_30_70(t *testing.T) {
 }
 
 func TestPartition_50_50(t *testing.T) {
+	t.Skip()
 	t.Parallel()
 
-	tctx := testcontext.New(t, testcontext.Labels("sanity"))
+	tctx := testcontext.New(t, testcontext.Labels("partition"))
 	if tctx.ClusterSize > 30 {
 		tctx.Log.Info("cluster size changed to 30")
 		tctx.ClusterSize = 30


### PR DESCRIPTION
revert didn't work correctly if applied layer was set to a lower layer.

this is still not enough to re-enable partition tests, there seems to be another flake