### PR TITLE
[Merged by Bors] - beacon: add domain to VRF signatures to distinguish between beacon messages

### DIFF
--- a/beacon/beacon.go
+++ b/beacon/beacon.go
@@ -956,7 +956,7 @@ func (pd *ProtocolDriver) sendFirstRoundVote(ctx context.Context, epoch types.Ep
 	if err != nil {
 		pd.logger.With().Fatal("failed to serialize message for signing", log.Err(err))
 	}
-	sig := pd.edSigner.Sign(signing.BEACON, encoded)
+	sig := pd.edSigner.Sign(signing.BEACON_FIRST_MSG, encoded)
 
 	m := FirstVotingMessage{
 		FirstVotingMessageBody: mb,
@@ -1003,7 +1003,7 @@ func (pd *ProtocolDriver) sendFollowingVote(ctx context.Context, epoch types.Epo
 	if err != nil {
 		pd.logger.With().Fatal("failed to serialize message for signing", log.Err(err))
 	}
-	sig := pd.edSigner.Sign(signing.BEACON, encoded)
+	sig := pd.edSigner.Sign(signing.BEACON_FOLLOWUP_MSG, encoded)
 
 	m := FollowingVotingMessage{
 		FollowingVotingMessageBody: mb,
@@ -1108,7 +1108,7 @@ func atxThreshold(kappa int, q *big.Rat, numATXs int) *big.Int {
 
 func buildSignedProposal(ctx context.Context, logger log.Log, signer vrfSigner, epoch types.EpochID, nonce types.VRFPostIndex) types.VrfSignature {
 	p := buildProposal(logger, epoch, nonce)
-	vrfSig := signer.Sign(p)
+	vrfSig := signer.Sign(signing.BEACON_PROPOSAL, p)
 	proposal := ProposalFromVrf(vrfSig)
 	logger.WithContext(ctx).With().Debug("calculated beacon proposal",
 		epoch,

--- a/beacon/beacon_test.go
+++ b/beacon/beacon_test.go
@@ -100,8 +100,8 @@ func newTestDriver(tb testing.TB, cfg Config, p pubsub.Publisher) *testProtocolD
 	minerID := edSgn.NodeID()
 	lg := logtest.New(tb).WithName(minerID.ShortString())
 
-	tpd.mSigner.EXPECT().Sign(gomock.Any()).AnyTimes().Return(types.EmptyVrfSignature)
-	tpd.mVerifier.EXPECT().Verify(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(true)
+	tpd.mSigner.EXPECT().Sign(signing.BEACON_PROPOSAL, gomock.Any()).AnyTimes().Return(types.EmptyVrfSignature)
+	tpd.mVerifier.EXPECT().Verify(signing.BEACON_PROPOSAL, gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(true)
 	tpd.mNonceFetcher.EXPECT().VRFNonce(gomock.Any(), gomock.Any()).AnyTimes().Return(types.VRFPostIndex(1), nil)
 
 	tpd.cdb = datastore.NewCachedDB(sql.InMemory(), lg)
@@ -961,12 +961,12 @@ func TestBeacon_getSignedProposal(t *testing.T) {
 		{
 			name:   "Case 1",
 			epoch:  1,
-			result: vrfSigner.Sign([]byte{0x04, 0x04, 0x04}),
+			result: vrfSigner.Sign(signing.BEACON_PROPOSAL, []byte{0x04, 0x04, 0x04}),
 		},
 		{
 			name:   "Case 2",
 			epoch:  2,
-			result: vrfSigner.Sign([]byte{0x04, 0x04, 0x08}),
+			result: vrfSigner.Sign(signing.BEACON_PROPOSAL, []byte{0x04, 0x04, 0x08}),
 		},
 	}
 

--- a/beacon/handlers.go
+++ b/beacon/handlers.go
@@ -194,7 +194,7 @@ func (pd *ProtocolDriver) verifyProposalMessage(logger log.Log, m ProposalMessag
 		return fmt.Errorf("[proposal] get VRF nonce (miner ID %s): %w", m.NodeID, err)
 	}
 	currentEpochProposal := buildProposal(logger, m.EpochID, nonce)
-	if !pd.vrfVerifier.Verify(m.NodeID, currentEpochProposal, m.VRFSignature) {
+	if !pd.vrfVerifier.Verify(signing.BEACON_PROPOSAL, m.NodeID, currentEpochProposal, m.VRFSignature) {
 		// TODO(nkryuchkov): attach telemetry
 		logger.With().Warning("[proposal] failed to verify VRF signature")
 		return fmt.Errorf("[proposal] verify VRF (miner ID %s): %w", m.NodeID, errVRFNotVerified)
@@ -260,7 +260,7 @@ func (pd *ProtocolDriver) verifyFirstVotes(ctx context.Context, m FirstVotingMes
 	if err != nil {
 		pd.logger.WithContext(ctx).WithFields(m.EpochID, types.FirstRound).With().Fatal("failed to serialize first voting message", log.Err(err))
 	}
-	if !pd.edVerifier.Verify(signing.BEACON, m.SmesherID, messageBytes, m.Signature) {
+	if !pd.edVerifier.Verify(signing.BEACON_FIRST_MSG, m.SmesherID, messageBytes, m.Signature) {
 		return types.EmptyNodeID, fmt.Errorf("[round %v] verify signature %s: failed", types.FirstRound, m.Signature)
 	}
 	if err = pd.registerVoted(m.EpochID, m.SmesherID, types.FirstRound); err != nil {
@@ -360,7 +360,7 @@ func (pd *ProtocolDriver) verifyFollowingVotes(ctx context.Context, m FollowingV
 	if err != nil {
 		pd.logger.With().Fatal("failed to serialize voting message", log.Err(err))
 	}
-	if !pd.edVerifier.Verify(signing.BEACON, m.SmesherID, messageBytes, m.Signature) {
+	if !pd.edVerifier.Verify(signing.BEACON_FOLLOWUP_MSG, m.SmesherID, messageBytes, m.Signature) {
 		return types.EmptyNodeID, fmt.Errorf("[round %v] verify signature %s: failed", types.FirstRound, m.Signature)
 	}
 	if err := pd.registerVoted(m.EpochID, m.SmesherID, m.RoundID); err != nil {

--- a/beacon/handlers_test.go
+++ b/beacon/handlers_test.go
@@ -73,7 +73,7 @@ func createProposal(t *testing.T, vrfSigner *signing.VRFSigner, epoch types.Epoc
 		VRFSignature: sig,
 	}
 	if corruptSignature {
-		msg.VRFSignature = vrfSigner.Sign(types.RandomBytes(32))
+		msg.VRFSignature = vrfSigner.Sign(signing.BEACON_PROPOSAL, types.RandomBytes(32))
 	}
 	return msg
 }
@@ -120,9 +120,9 @@ func createFirstVote(t *testing.T, signer *signing.EdSigner, epoch types.EpochID
 	if err != nil {
 		logger.With().Panic("failed to serialize message for signing", log.Err(err))
 	}
-	msg.Signature = signer.Sign(signing.BEACON, encoded)
+	msg.Signature = signer.Sign(signing.BEACON_FIRST_MSG, encoded)
 	if corruptSignature {
-		msg.Signature = signer.Sign(signing.BEACON, encoded[1:])
+		msg.Signature = signer.Sign(signing.BEACON_FIRST_MSG, encoded[1:])
 	}
 	msg.SmesherID = signer.NodeID()
 	return msg
@@ -160,9 +160,9 @@ func createFollowingVote(t *testing.T, signer *signing.EdSigner, epoch types.Epo
 	if err != nil {
 		logger.With().Panic("failed to serialize message for signing", log.Err(err))
 	}
-	msg.Signature = signer.Sign(signing.BEACON, encoded)
+	msg.Signature = signer.Sign(signing.BEACON_FOLLOWUP_MSG, encoded)
 	if corruptSignature {
-		msg.Signature = signer.Sign(signing.BEACON, encoded[1:])
+		msg.Signature = signer.Sign(signing.BEACON_FOLLOWUP_MSG, encoded[1:])
 	}
 	msg.SmesherID = signer.NodeID()
 	return msg
@@ -500,7 +500,7 @@ func Test_handleProposal_BadVrfSignature(t *testing.T) {
 	require.NoError(t, err)
 
 	mVerifier := NewMockvrfVerifier(tpd.ctrl)
-	mVerifier.EXPECT().Verify(gomock.Any(), gomock.Any(), gomock.Any()).Return(false)
+	mVerifier.EXPECT().Verify(signing.BEACON_PROPOSAL, gomock.Any(), gomock.Any(), gomock.Any()).Return(false)
 	tpd.vrfVerifier = mVerifier
 
 	tpd.mClock.EXPECT().CurrentLayer().Return(epoch.FirstLayer())
@@ -1336,7 +1336,7 @@ func Test_UniqueFollowingVotingMessages(t *testing.T) {
 	if err != nil {
 		logger.With().Panic("failed to serialize msg1.FollowingVotingMessageBody for signing", log.Err(err))
 	}
-	msg1.Signature = signer.Sign(signing.BEACON, encodedMsg1FollowingVotingMessageBody)
+	msg1.Signature = signer.Sign(signing.BEACON_FOLLOWUP_MSG, encodedMsg1FollowingVotingMessageBody)
 
 	data1, err := codec.Encode(&msg1)
 	require.NoError(t, err)
@@ -1351,7 +1351,7 @@ func Test_UniqueFollowingVotingMessages(t *testing.T) {
 	if err != nil {
 		logger.With().Panic("failed to serialize msg2.FollowingVotingMessageBody for signing", log.Err(err))
 	}
-	msg2.Signature = signer.Sign(signing.BEACON, encodedMsg2FollowingVotingMessageBody)
+	msg2.Signature = signer.Sign(signing.BEACON_FOLLOWUP_MSG, encodedMsg2FollowingVotingMessageBody)
 
 	data2, err := codec.Encode(&msg2)
 	require.NoError(t, err)
@@ -1364,7 +1364,7 @@ func Test_UniqueFollowingVotingMessages(t *testing.T) {
 	if err != nil {
 		logger.With().Panic("failed to serialize msg1.FollowingVotingMessageBody for signing", log.Err(err))
 	}
-	msg1.Signature = signer.Sign(signing.BEACON, encodedMsg1FollowingVotingMessageBody)
+	msg1.Signature = signer.Sign(signing.BEACON_FOLLOWUP_MSG, encodedMsg1FollowingVotingMessageBody)
 	data1, err = codec.Encode(&msg1)
 	require.NoError(t, err)
 
@@ -1373,7 +1373,7 @@ func Test_UniqueFollowingVotingMessages(t *testing.T) {
 	if err != nil {
 		logger.With().Panic("failed to serialize msg2.FollowingVotingMessageBody for signing", log.Err(err))
 	}
-	msg2.Signature = signer.Sign(signing.BEACON, encodedMsg2FollowingVotingMessageBody)
+	msg2.Signature = signer.Sign(signing.BEACON_FOLLOWUP_MSG, encodedMsg2FollowingVotingMessageBody)
 
 	data2, err = codec.Encode(&msg2)
 	require.NoError(t, err)

--- a/beacon/interface.go
+++ b/beacon/interface.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/p2p"
+	"github.com/spacemeshos/go-spacemesh/signing"
 )
 
 //go:generate mockgen -package=beacon -destination=./mocks.go -source=./interface.go
@@ -31,13 +32,13 @@ type layerClock interface {
 }
 
 type vrfSigner interface {
-	Sign(msg []byte) types.VrfSignature
+	Sign(d signing.Domain, msg []byte) types.VrfSignature
 	NodeID() types.NodeID
 	LittleEndian() bool
 }
 
 type vrfVerifier interface {
-	Verify(nodeID types.NodeID, msg []byte, sig types.VrfSignature) bool
+	Verify(d signing.Domain, nodeID types.NodeID, msg []byte, sig types.VrfSignature) bool
 }
 
 type nonceFetcher interface {

--- a/beacon/mocks.go
+++ b/beacon/mocks.go
@@ -12,6 +12,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	types "github.com/spacemeshos/go-spacemesh/common/types"
 	p2p "github.com/spacemeshos/go-spacemesh/p2p"
+	signing "github.com/spacemeshos/go-spacemesh/signing"
 )
 
 // Mockcoin is a mock of coin interface.
@@ -282,17 +283,17 @@ func (mr *MockvrfSignerMockRecorder) NodeID() *gomock.Call {
 }
 
 // Sign mocks base method.
-func (m *MockvrfSigner) Sign(msg []byte) types.VrfSignature {
+func (m *MockvrfSigner) Sign(d signing.Domain, msg []byte) types.VrfSignature {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Sign", msg)
+	ret := m.ctrl.Call(m, "Sign", d, msg)
 	ret0, _ := ret[0].(types.VrfSignature)
 	return ret0
 }
 
 // Sign indicates an expected call of Sign.
-func (mr *MockvrfSignerMockRecorder) Sign(msg interface{}) *gomock.Call {
+func (mr *MockvrfSignerMockRecorder) Sign(d, msg interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sign", reflect.TypeOf((*MockvrfSigner)(nil).Sign), msg)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sign", reflect.TypeOf((*MockvrfSigner)(nil).Sign), d, msg)
 }
 
 // MockvrfVerifier is a mock of vrfVerifier interface.
@@ -319,17 +320,17 @@ func (m *MockvrfVerifier) EXPECT() *MockvrfVerifierMockRecorder {
 }
 
 // Verify mocks base method.
-func (m *MockvrfVerifier) Verify(nodeID types.NodeID, msg []byte, sig types.VrfSignature) bool {
+func (m *MockvrfVerifier) Verify(d signing.Domain, nodeID types.NodeID, msg []byte, sig types.VrfSignature) bool {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Verify", nodeID, msg, sig)
+	ret := m.ctrl.Call(m, "Verify", d, nodeID, msg, sig)
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
 // Verify indicates an expected call of Verify.
-func (mr *MockvrfVerifierMockRecorder) Verify(nodeID, msg, sig interface{}) *gomock.Call {
+func (mr *MockvrfVerifierMockRecorder) Verify(d, nodeID, msg, sig interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Verify", reflect.TypeOf((*MockvrfVerifier)(nil).Verify), nodeID, msg, sig)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Verify", reflect.TypeOf((*MockvrfVerifier)(nil).Verify), d, nodeID, msg, sig)
 }
 
 // MocknonceFetcher is a mock of nonceFetcher interface.

--- a/beacon/weakcoin/handler.go
+++ b/beacon/weakcoin/handler.go
@@ -43,8 +43,8 @@ func (wc *WeakCoin) HandleProposal(ctx context.Context, peer p2p.Peer, msg []byt
 }
 
 func (wc *WeakCoin) receiveMessage(ctx context.Context, message Message) error {
-	if wc.aboveThreshold(message.VrfSignature) {
-		return fmt.Errorf("proposal %s is above threshold", message.VrfSignature)
+	if wc.aboveThreshold(message.VRFSignature) {
+		return fmt.Errorf("proposal %s is above threshold", message.VRFSignature)
 	}
 
 	wc.mu.Lock()

--- a/beacon/weakcoin/interface.go
+++ b/beacon/weakcoin/interface.go
@@ -2,18 +2,19 @@ package weakcoin
 
 import (
 	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/signing"
 )
 
 //go:generate mockgen -package=weakcoin -destination=./mocks.go -source=./interface.go
 
 type vrfSigner interface {
-	Sign(msg []byte) types.VrfSignature
+	Sign(d signing.Domain, msg []byte) types.VrfSignature
 	NodeID() types.NodeID
 	LittleEndian() bool
 }
 
 type vrfVerifier interface {
-	Verify(nodeID types.NodeID, msg []byte, sig types.VrfSignature) bool
+	Verify(domain signing.Domain, nodeID types.NodeID, msg []byte, sig types.VrfSignature) bool
 }
 
 type nonceFetcher interface {

--- a/beacon/weakcoin/mocks.go
+++ b/beacon/weakcoin/mocks.go
@@ -9,6 +9,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	types "github.com/spacemeshos/go-spacemesh/common/types"
+	signing "github.com/spacemeshos/go-spacemesh/signing"
 )
 
 // MockvrfSigner is a mock of vrfSigner interface.
@@ -63,17 +64,17 @@ func (mr *MockvrfSignerMockRecorder) NodeID() *gomock.Call {
 }
 
 // Sign mocks base method.
-func (m *MockvrfSigner) Sign(msg []byte) types.VrfSignature {
+func (m *MockvrfSigner) Sign(d signing.Domain, msg []byte) types.VrfSignature {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Sign", msg)
+	ret := m.ctrl.Call(m, "Sign", d, msg)
 	ret0, _ := ret[0].(types.VrfSignature)
 	return ret0
 }
 
 // Sign indicates an expected call of Sign.
-func (mr *MockvrfSignerMockRecorder) Sign(msg interface{}) *gomock.Call {
+func (mr *MockvrfSignerMockRecorder) Sign(d, msg interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sign", reflect.TypeOf((*MockvrfSigner)(nil).Sign), msg)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sign", reflect.TypeOf((*MockvrfSigner)(nil).Sign), d, msg)
 }
 
 // MockvrfVerifier is a mock of vrfVerifier interface.
@@ -100,17 +101,17 @@ func (m *MockvrfVerifier) EXPECT() *MockvrfVerifierMockRecorder {
 }
 
 // Verify mocks base method.
-func (m *MockvrfVerifier) Verify(nodeID types.NodeID, msg []byte, sig types.VrfSignature) bool {
+func (m *MockvrfVerifier) Verify(domain signing.Domain, nodeID types.NodeID, msg []byte, sig types.VrfSignature) bool {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Verify", nodeID, msg, sig)
+	ret := m.ctrl.Call(m, "Verify", domain, nodeID, msg, sig)
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
 // Verify indicates an expected call of Verify.
-func (mr *MockvrfVerifierMockRecorder) Verify(nodeID, msg, sig interface{}) *gomock.Call {
+func (mr *MockvrfVerifierMockRecorder) Verify(domain, nodeID, msg, sig interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Verify", reflect.TypeOf((*MockvrfVerifier)(nil).Verify), nodeID, msg, sig)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Verify", reflect.TypeOf((*MockvrfVerifier)(nil).Verify), domain, nodeID, msg, sig)
 }
 
 // MocknonceFetcher is a mock of nonceFetcher interface.

--- a/beacon/weakcoin/weak_coin_scale.go
+++ b/beacon/weakcoin/weak_coin_scale.go
@@ -38,7 +38,7 @@ func (t *Message) EncodeScale(enc *scale.Encoder) (total int, err error) {
 		total += n
 	}
 	{
-		n, err := scale.EncodeByteArray(enc, t.VrfSignature[:])
+		n, err := scale.EncodeByteArray(enc, t.VRFSignature[:])
 		if err != nil {
 			return total, err
 		}
@@ -80,7 +80,7 @@ func (t *Message) DecodeScale(dec *scale.Decoder) (total int, err error) {
 		total += n
 	}
 	{
-		n, err := scale.DecodeByteArray(dec, t.VrfSignature[:])
+		n, err := scale.DecodeByteArray(dec, t.VRFSignature[:])
 		if err != nil {
 			return total, err
 		}

--- a/beacon/weakcoin/weak_coin_test.go
+++ b/beacon/weakcoin/weak_coin_test.go
@@ -46,7 +46,7 @@ func encoded(tb testing.TB, msg weakcoin.Message) []byte {
 func staticSigner(tb testing.TB, ctrl *gomock.Controller, nodeId types.NodeID, sig types.VrfSignature) *weakcoin.MockvrfSigner {
 	tb.Helper()
 	signer := weakcoin.NewMockvrfSigner(ctrl)
-	signer.EXPECT().Sign(gomock.Any()).Return(sig).AnyTimes()
+	signer.EXPECT().Sign(signing.BEACON_PROPOSAL, gomock.Any()).Return(sig).AnyTimes()
 	signer.EXPECT().NodeID().Return(nodeId).AnyTimes()
 	signer.EXPECT().LittleEndian().Return(true).AnyTimes()
 	return signer
@@ -55,7 +55,7 @@ func staticSigner(tb testing.TB, ctrl *gomock.Controller, nodeId types.NodeID, s
 func sigVerifier(tb testing.TB, ctrl *gomock.Controller) *weakcoin.MockvrfVerifier {
 	tb.Helper()
 	verifier := weakcoin.NewMockvrfVerifier(ctrl)
-	verifier.EXPECT().Verify(gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
+	verifier.EXPECT().Verify(signing.BEACON_PROPOSAL, gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 	return verifier
 }
 
@@ -105,7 +105,7 @@ func TestWeakCoin(t *testing.T) {
 				Round:        round,
 				Unit:         1,
 				NodeID:       zeroLSBMiner,
-				VrfSignature: zeroLSBSig,
+				VRFSignature: zeroLSBSig,
 			}),
 			result: nilErr,
 		},
@@ -119,7 +119,7 @@ func TestWeakCoin(t *testing.T) {
 				Round:        round,
 				Unit:         1,
 				NodeID:       zeroLSBMiner,
-				VrfSignature: zeroLSBSig,
+				VRFSignature: zeroLSBSig,
 			}),
 			result: isErr,
 		},
@@ -133,7 +133,7 @@ func TestWeakCoin(t *testing.T) {
 				Round:        round,
 				Unit:         1,
 				NodeID:       zeroLSBMiner,
-				VrfSignature: zeroLSBSig,
+				VRFSignature: zeroLSBSig,
 			}),
 			result: nilErr,
 		},
@@ -228,7 +228,7 @@ func TestWeakCoin_HandleProposal(t *testing.T) {
 				Round:        round,
 				Unit:         allowance,
 				NodeID:       oneLSBMiner,
-				VrfSignature: oneLSBSig,
+				VRFSignature: oneLSBSig,
 			}),
 			expected: nilErr,
 		},
@@ -248,7 +248,7 @@ func TestWeakCoin_HandleProposal(t *testing.T) {
 				Round:        round,
 				Unit:         allowance + 1,
 				NodeID:       oneLSBMiner,
-				VrfSignature: oneLSBSig,
+				VRFSignature: oneLSBSig,
 			}),
 			expected: isErr,
 		},
@@ -261,7 +261,7 @@ func TestWeakCoin_HandleProposal(t *testing.T) {
 				Round:        round,
 				Unit:         allowance,
 				NodeID:       highLSBMiner,
-				VrfSignature: higherThreshold,
+				VRFSignature: higherThreshold,
 			}),
 			expected: isErr,
 		},
@@ -274,7 +274,7 @@ func TestWeakCoin_HandleProposal(t *testing.T) {
 				Round:        round,
 				Unit:         allowance,
 				NodeID:       oneLSBMiner,
-				VrfSignature: oneLSBSig,
+				VRFSignature: oneLSBSig,
 			}),
 			expected: isErr,
 		},
@@ -287,7 +287,7 @@ func TestWeakCoin_HandleProposal(t *testing.T) {
 				Round:        round,
 				Unit:         allowance,
 				NodeID:       oneLSBMiner,
-				VrfSignature: oneLSBSig,
+				VRFSignature: oneLSBSig,
 			}),
 			expected: isErr,
 		},
@@ -300,7 +300,7 @@ func TestWeakCoin_HandleProposal(t *testing.T) {
 				Round:        round - 1,
 				Unit:         allowance,
 				NodeID:       oneLSBMiner,
-				VrfSignature: oneLSBSig,
+				VRFSignature: oneLSBSig,
 			}),
 			expected: isErr,
 		},
@@ -313,7 +313,7 @@ func TestWeakCoin_HandleProposal(t *testing.T) {
 				Round:        round + 1,
 				Unit:         allowance,
 				NodeID:       oneLSBMiner,
-				VrfSignature: oneLSBSig,
+				VRFSignature: oneLSBSig,
 			}),
 			expected: nilErr,
 		},
@@ -379,14 +379,14 @@ func TestWeakCoinNextRoundBufferOverflow(t *testing.T) {
 			Round:        nextRound,
 			Unit:         1,
 			NodeID:       oneLSBMiner,
-			VrfSignature: oneLSBSig,
+			VRFSignature: oneLSBSig,
 		}))
 	}
 	wc.HandleProposal(context.Background(), "", encoded(t, weakcoin.Message{
 		Epoch:        epoch,
 		Round:        nextRound,
 		Unit:         1,
-		VrfSignature: zeroLSBSig,
+		VRFSignature: zeroLSBSig,
 	}))
 	wc.FinishRound(context.Background())
 	wc.StartRound(context.Background(), nextRound, nil)
@@ -408,7 +408,7 @@ func TestWeakCoinEncodingRegression(t *testing.T) {
 	broadcaster.EXPECT().Publish(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().DoAndReturn(func(_ context.Context, _ string, data []byte) error {
 		var msg weakcoin.Message
 		require.NoError(t, codec.Decode(data, &msg))
-		sig = msg.VrfSignature
+		sig = msg.VRFSignature
 		return nil
 	}).AnyTimes()
 

--- a/beacon/weakcoin/weak_coin_test.go
+++ b/beacon/weakcoin/weak_coin_test.go
@@ -442,7 +442,7 @@ func TestWeakCoinEncodingRegression(t *testing.T) {
 	instance.StartRound(context.Background(), round, &nonce)
 
 	require.Equal(t,
-		"78f523319fd2cdf3812a3bc3905561acb2f7f1b7e47de71f92811d7bb82460e5999a048051cefa2d1b6f3f16656de83c2756b7539b33fa563a3e8fea5130235e66e8dce914d69bd40f13174f3914ad07",
+		"94494c2c55a388acd03acd64b21912c4cb6e8dca56da5979bbab9b23be790ed948eda672dc28b8e379ec041aa46511b2dd4f9143ed8d512bf6386454d43f3b4ed9f7748b09ee92730975d094dc8c3501",
 		sig.String(),
 	)
 }

--- a/hare/eligibility/interface.go
+++ b/hare/eligibility/interface.go
@@ -1,6 +1,9 @@
 package eligibility
 
-import "github.com/spacemeshos/go-spacemesh/common/types"
+import (
+	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/signing"
+)
 
 //go:generate mockgen -package=eligibility -destination=./mocks.go -source=./interface.go
 
@@ -10,7 +13,7 @@ type cache interface {
 }
 
 type vrfVerifier interface {
-	Verify(nodeID types.NodeID, msg []byte, sig types.VrfSignature) bool
+	Verify(d signing.Domain, nodeID types.NodeID, msg []byte, sig types.VrfSignature) bool
 }
 
 type nonceFetcher interface {

--- a/hare/eligibility/mocks.go
+++ b/hare/eligibility/mocks.go
@@ -9,6 +9,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	types "github.com/spacemeshos/go-spacemesh/common/types"
+	signing "github.com/spacemeshos/go-spacemesh/signing"
 )
 
 // Mockcache is a mock of cache interface.
@@ -87,17 +88,17 @@ func (m *MockvrfVerifier) EXPECT() *MockvrfVerifierMockRecorder {
 }
 
 // Verify mocks base method.
-func (m *MockvrfVerifier) Verify(nodeID types.NodeID, msg []byte, sig types.VrfSignature) bool {
+func (m *MockvrfVerifier) Verify(d signing.Domain, nodeID types.NodeID, msg []byte, sig types.VrfSignature) bool {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Verify", nodeID, msg, sig)
+	ret := m.ctrl.Call(m, "Verify", d, nodeID, msg, sig)
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
 // Verify indicates an expected call of Verify.
-func (mr *MockvrfVerifierMockRecorder) Verify(nodeID, msg, sig interface{}) *gomock.Call {
+func (mr *MockvrfVerifierMockRecorder) Verify(d, nodeID, msg, sig interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Verify", reflect.TypeOf((*MockvrfVerifier)(nil).Verify), nodeID, msg, sig)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Verify", reflect.TypeOf((*MockvrfVerifier)(nil).Verify), d, nodeID, msg, sig)
 }
 
 // MocknonceFetcher is a mock of nonceFetcher interface.

--- a/hare/eligibility/oracle.go
+++ b/hare/eligibility/oracle.go
@@ -217,7 +217,7 @@ func (o *Oracle) prepareEligibilityCheck(ctx context.Context, layer types.LayerI
 	}
 
 	// validate message
-	if !o.vrfVerifier.Verify(id, msg, vrfSig) {
+	if !o.vrfVerifier.Verify(signing.HARE, id, msg, vrfSig) {
 		logger.With().Debug("eligibility: a node did not pass vrf signature verification",
 			log.FieldNamed("sender_vrf_nonce", nonce),
 		)
@@ -366,7 +366,7 @@ func (o *Oracle) Proof(ctx context.Context, nonce types.VRFPostIndex, layer type
 	if err != nil {
 		return types.EmptyVrfSignature, err
 	}
-	return o.vrfSigner.Sign(msg), nil
+	return o.vrfSigner.Sign(signing.HARE, msg), nil
 }
 
 // Returns a map of all active node IDs in the specified layer id.

--- a/hare/eligibility/oracle_test.go
+++ b/hare/eligibility/oracle_test.go
@@ -192,7 +192,7 @@ func TestCalcEligibility(t *testing.T) {
 		layer := types.EpochID(5).FirstLayer()
 		miners := createLayerData(t, o.cdb, layer.Sub(defLayersPerEpoch), 5)
 		o.mBeacon.EXPECT().GetBeacon(layer.GetEpoch()).Return(types.RandomBeacon(), nil).Times(1)
-		o.mVerifier.EXPECT().Verify(signing.BEACON_PROPOSAL, gomock.Any(), gomock.Any(), gomock.Any()).Return(false).Times(1)
+		o.mVerifier.EXPECT().Verify(signing.HARE, gomock.Any(), gomock.Any(), gomock.Any()).Return(false).Times(1)
 
 		res, err := o.CalcEligibility(context.Background(), layer, 0, 1, miners[0], nonce, types.EmptyVrfSignature)
 		require.NoError(t, err)
@@ -211,7 +211,7 @@ func TestCalcEligibility(t *testing.T) {
 		miners := createActiveSet(t, o.cdb, types.EpochID(4).FirstLayer(), activeSet)
 		o.UpdateActiveSet(5, activeSet)
 		o.mBeacon.EXPECT().GetBeacon(lid.GetEpoch()).Return(types.RandomBeacon(), nil)
-		o.mVerifier.EXPECT().Verify(signing.BEACON_PROPOSAL, gomock.Any(), gomock.Any(), gomock.Any()).Return(true)
+		o.mVerifier.EXPECT().Verify(signing.HARE, gomock.Any(), gomock.Any(), gomock.Any()).Return(true)
 		_, err = o.CalcEligibility(context.Background(), lid, 1, 1, miners[0], nonce, types.EmptyVrfSignature)
 		require.NoError(t, err)
 	})
@@ -237,7 +237,7 @@ func TestCalcEligibility(t *testing.T) {
 
 			nonce := types.VRFPostIndex(1)
 			o.mBeacon.EXPECT().GetBeacon(lid.GetEpoch()).Return(beacon, nil).Times(1)
-			o.mVerifier.EXPECT().Verify(signing.BEACON_PROPOSAL, gomock.Any(), gomock.Any(), gomock.Any()).Return(true).Times(1)
+			o.mVerifier.EXPECT().Verify(signing.HARE, gomock.Any(), gomock.Any(), gomock.Any()).Return(true).Times(1)
 			res, err := o.CalcEligibility(context.Background(), lid, 1, 10, miners[0], nonce, vrfSig)
 			require.NoError(t, err, vrf)
 			require.Equal(t, exp, res, vrf)
@@ -264,7 +264,7 @@ func TestCalcEligibilityWithSpaceUnit(t *testing.T) {
 		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
 			o := defaultOracle(t)
-			o.mVerifier.EXPECT().Verify(signing.BEACON_PROPOSAL, gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
+			o.mVerifier.EXPECT().Verify(signing.HARE, gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 
 			lid := types.EpochID(5).FirstLayer()
 			beacon := types.Beacon{1, 0, 0, 0}
@@ -334,7 +334,7 @@ func BenchmarkOracle_CalcEligibility(b *testing.B) {
 
 func Test_VrfSignVerify(t *testing.T) {
 	// eligibility of the proof depends on the identity
-	rng := rand.New(rand.NewSource(5))
+	rng := rand.New(rand.NewSource(1000))
 
 	signer, err := signing.NewEdSigner(signing.WithKeyFromRand(rng))
 	require.NoError(t, err)

--- a/hare/eligibility/oracle_test.go
+++ b/hare/eligibility/oracle_test.go
@@ -192,7 +192,7 @@ func TestCalcEligibility(t *testing.T) {
 		layer := types.EpochID(5).FirstLayer()
 		miners := createLayerData(t, o.cdb, layer.Sub(defLayersPerEpoch), 5)
 		o.mBeacon.EXPECT().GetBeacon(layer.GetEpoch()).Return(types.RandomBeacon(), nil).Times(1)
-		o.mVerifier.EXPECT().Verify(gomock.Any(), gomock.Any(), gomock.Any()).Return(false).Times(1)
+		o.mVerifier.EXPECT().Verify(signing.BEACON_PROPOSAL, gomock.Any(), gomock.Any(), gomock.Any()).Return(false).Times(1)
 
 		res, err := o.CalcEligibility(context.Background(), layer, 0, 1, miners[0], nonce, types.EmptyVrfSignature)
 		require.NoError(t, err)
@@ -211,7 +211,7 @@ func TestCalcEligibility(t *testing.T) {
 		miners := createActiveSet(t, o.cdb, types.EpochID(4).FirstLayer(), activeSet)
 		o.UpdateActiveSet(5, activeSet)
 		o.mBeacon.EXPECT().GetBeacon(lid.GetEpoch()).Return(types.RandomBeacon(), nil)
-		o.mVerifier.EXPECT().Verify(gomock.Any(), gomock.Any(), gomock.Any()).Return(true)
+		o.mVerifier.EXPECT().Verify(signing.BEACON_PROPOSAL, gomock.Any(), gomock.Any(), gomock.Any()).Return(true)
 		_, err = o.CalcEligibility(context.Background(), lid, 1, 1, miners[0], nonce, types.EmptyVrfSignature)
 		require.NoError(t, err)
 	})
@@ -237,7 +237,7 @@ func TestCalcEligibility(t *testing.T) {
 
 			nonce := types.VRFPostIndex(1)
 			o.mBeacon.EXPECT().GetBeacon(lid.GetEpoch()).Return(beacon, nil).Times(1)
-			o.mVerifier.EXPECT().Verify(gomock.Any(), gomock.Any(), gomock.Any()).Return(true).Times(1)
+			o.mVerifier.EXPECT().Verify(signing.BEACON_PROPOSAL, gomock.Any(), gomock.Any(), gomock.Any()).Return(true).Times(1)
 			res, err := o.CalcEligibility(context.Background(), lid, 1, 10, miners[0], nonce, vrfSig)
 			require.NoError(t, err, vrf)
 			require.Equal(t, exp, res, vrf)
@@ -264,7 +264,7 @@ func TestCalcEligibilityWithSpaceUnit(t *testing.T) {
 		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
 			o := defaultOracle(t)
-			o.mVerifier.EXPECT().Verify(gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
+			o.mVerifier.EXPECT().Verify(signing.BEACON_PROPOSAL, gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 
 			lid := types.EpochID(5).FirstLayer()
 			beacon := types.Beacon{1, 0, 0, 0}
@@ -304,7 +304,7 @@ func BenchmarkOracle_CalcEligibility(b *testing.B) {
 
 	o := defaultOracle(b)
 	o.mBeacon.EXPECT().GetBeacon(gomock.Any()).Return(types.RandomBeacon(), nil).AnyTimes()
-	o.mVerifier.EXPECT().Verify(gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
+	o.mVerifier.EXPECT().Verify(signing.BEACON_PROPOSAL, gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 	o.mNonceFetcher.EXPECT().VRFNonce(gomock.Any(), gomock.Any()).Return(types.VRFPostIndex(1), nil).AnyTimes()
 	numOfMiners := 2000
 	committeeSize := 800

--- a/miner/oracle.go
+++ b/miner/oracle.go
@@ -149,7 +149,7 @@ func (o *Oracle) calcEligibilityProofs(atx *types.ActivationTxHeader, epoch type
 		if err != nil {
 			o.log.With().Fatal("failed to serialize VRF msg", log.Err(err))
 		}
-		vrfSig := o.vrfSigner.Sign(message)
+		vrfSig := o.vrfSigner.Sign(signing.HARE, message)
 		eligibleLayer := proposals.CalcEligibleLayer(epoch, o.layersPerEpoch, vrfSig)
 		eligibilityProofs[eligibleLayer] = append(eligibilityProofs[eligibleLayer], types.VotingEligibility{
 			J:   counter,

--- a/miner/oracle_test.go
+++ b/miner/oracle_test.go
@@ -148,7 +148,7 @@ func testMinerOracleAndProposalValidator(t *testing.T, layerSize uint32, layersP
 	ctrl := gomock.NewController(t)
 	mbc := mocks.NewMockBeaconCollector(ctrl)
 	vrfVerifier := proposals.NewMockvrfVerifier(ctrl)
-	vrfVerifier.EXPECT().Verify(gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
+	vrfVerifier.EXPECT().Verify(signing.BEACON_PROPOSAL, gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 
 	nonceFetcher := proposals.NewMocknonceFetcher(ctrl)
 	nonce := types.VRFPostIndex(rand.Uint64())

--- a/miner/oracle_test.go
+++ b/miner/oracle_test.go
@@ -148,7 +148,7 @@ func testMinerOracleAndProposalValidator(t *testing.T, layerSize uint32, layersP
 	ctrl := gomock.NewController(t)
 	mbc := mocks.NewMockBeaconCollector(ctrl)
 	vrfVerifier := proposals.NewMockvrfVerifier(ctrl)
-	vrfVerifier.EXPECT().Verify(signing.BEACON_PROPOSAL, gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
+	vrfVerifier.EXPECT().Verify(signing.HARE, gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 
 	nonceFetcher := proposals.NewMocknonceFetcher(ctrl)
 	nonce := types.VRFPostIndex(rand.Uint64())

--- a/proposals/eligibility_validator.go
+++ b/proposals/eligibility_validator.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/datastore"
 	"github.com/spacemeshos/go-spacemesh/log"
+	"github.com/spacemeshos/go-spacemesh/signing"
 	"github.com/spacemeshos/go-spacemesh/sql/ballots"
 	"github.com/spacemeshos/go-spacemesh/system"
 )
@@ -178,7 +179,7 @@ func (v *Validator) CheckEligibility(ctx context.Context, ballot *types.Ballot) 
 		vrfSig := proof.Sig
 
 		beaconStr := beacon.ShortString()
-		if !v.vrfVerifier.Verify(owned.NodeID, message, vrfSig) {
+		if !v.vrfVerifier.Verify(signing.HARE, owned.NodeID, message, vrfSig) {
 			return false, fmt.Errorf("%w: beacon: %v, epoch: %v, counter: %v, vrfSig: %s",
 				errIncorrectVRFSig, beaconStr, epoch, counter, vrfSig,
 			)

--- a/proposals/eligibility_validator_test.go
+++ b/proposals/eligibility_validator_test.go
@@ -343,7 +343,7 @@ func TestCheckEligibility_BadCounter(t *testing.T) {
 func TestCheckEligibility_InvalidOrder(t *testing.T) {
 	tv := createTestValidator(t)
 	signer, err := signing.NewEdSigner(
-		signing.WithKeyFromRand(rand.New(rand.NewSource(1128))),
+		signing.WithKeyFromRand(rand.New(rand.NewSource(1003))),
 	)
 	require.NoError(t, err)
 
@@ -353,7 +353,7 @@ func TestCheckEligibility_InvalidOrder(t *testing.T) {
 	require.Len(t, rb.EligibilityProofs, 2)
 	rb.EligibilityProofs[0], rb.EligibilityProofs[1] = rb.EligibilityProofs[1], rb.EligibilityProofs[0]
 
-	tv.mvrf.EXPECT().Verify(signing.BEACON_PROPOSAL, gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
+	tv.mvrf.EXPECT().Verify(signing.HARE, gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 	tv.mNonce.EXPECT().VRFNonce(gomock.Any(), gomock.Any()).Return(types.VRFPostIndex(1), nil).Times(1)
 
 	eligible, err := tv.CheckEligibility(context.Background(), rb)
@@ -385,7 +385,7 @@ func TestCheckEligibility_BadVRFSignature(t *testing.T) {
 
 	b := blts[1]
 	b.EligibilityProofs[0].Sig = types.RandomVrfSignature()
-	tv.mvrf.EXPECT().Verify(signing.BEACON_PROPOSAL, gomock.Any(), gomock.Any(), b.EligibilityProofs[0].Sig).Return(false)
+	tv.mvrf.EXPECT().Verify(signing.HARE, gomock.Any(), gomock.Any(), b.EligibilityProofs[0].Sig).Return(false)
 	tv.mNonce.EXPECT().VRFNonce(gomock.Any(), gomock.Any()).Return(types.VRFPostIndex(1), nil).Times(1)
 
 	eligible, err := tv.CheckEligibility(context.Background(), b)
@@ -407,7 +407,7 @@ func TestCheckEligibility_IncorrectLayerIndex(t *testing.T) {
 
 	b := blts[1]
 	b.EligibilityProofs[0].Sig = types.RandomVrfSignature()
-	tv.mvrf.EXPECT().Verify(signing.BEACON_PROPOSAL, gomock.Any(), gomock.Any(), b.EligibilityProofs[0].Sig).Return(false)
+	tv.mvrf.EXPECT().Verify(signing.HARE, gomock.Any(), gomock.Any(), b.EligibilityProofs[0].Sig).Return(false)
 	tv.mNonce.EXPECT().VRFNonce(gomock.Any(), gomock.Any()).Return(types.VRFPostIndex(1), nil).Times(1)
 
 	eligible, err := tv.CheckEligibility(context.Background(), b)
@@ -439,7 +439,7 @@ func TestCheckEligibility(t *testing.T) {
 		require.NoError(t, err)
 		weightPer := fixed.DivUint64(hdr.GetWeight(), uint64(eligibleSlots))
 		tv.mbc.EXPECT().ReportBeaconFromBallot(epoch, b, beacon, weightPer).Times(1)
-		tv.mvrf.EXPECT().Verify(signing.BEACON_PROPOSAL, gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
+		tv.mvrf.EXPECT().Verify(signing.HARE, gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 		tv.mNonce.EXPECT().VRFNonce(gomock.Any(), gomock.Any()).Return(types.VRFPostIndex(1), nil).Times(1)
 		got, err := tv.CheckEligibility(context.Background(), b)
 		require.NoError(t, err)

--- a/proposals/interface.go
+++ b/proposals/interface.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/signing"
 	"github.com/spacemeshos/go-spacemesh/tortoise"
 )
 
@@ -25,7 +26,7 @@ type ballotDecoder interface {
 }
 
 type vrfVerifier interface {
-	Verify(types.NodeID, []byte, types.VrfSignature) bool
+	Verify(signing.Domain, types.NodeID, []byte, types.VrfSignature) bool
 }
 
 type nonceFetcher interface {

--- a/proposals/mocks.go
+++ b/proposals/mocks.go
@@ -10,6 +10,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	types "github.com/spacemeshos/go-spacemesh/common/types"
+	signing "github.com/spacemeshos/go-spacemesh/signing"
 	tortoise "github.com/spacemeshos/go-spacemesh/tortoise"
 )
 
@@ -193,17 +194,17 @@ func (m *MockvrfVerifier) EXPECT() *MockvrfVerifierMockRecorder {
 }
 
 // Verify mocks base method.
-func (m *MockvrfVerifier) Verify(arg0 types.NodeID, arg1 []byte, arg2 types.VrfSignature) bool {
+func (m *MockvrfVerifier) Verify(arg0 signing.Domain, arg1 types.NodeID, arg2 []byte, arg3 types.VrfSignature) bool {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Verify", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "Verify", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
 // Verify indicates an expected call of Verify.
-func (mr *MockvrfVerifierMockRecorder) Verify(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockvrfVerifierMockRecorder) Verify(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Verify", reflect.TypeOf((*MockvrfVerifier)(nil).Verify), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Verify", reflect.TypeOf((*MockvrfVerifier)(nil).Verify), arg0, arg1, arg2, arg3)
 }
 
 // MocknonceFetcher is a mock of nonceFetcher interface.

--- a/proposals/util_test.go
+++ b/proposals/util_test.go
@@ -59,7 +59,7 @@ func TestComputeWeightPerEligibility(t *testing.T) {
 func TestComputeWeightPerEligibility_EmptyRefBallotID(t *testing.T) {
 	types.SetLayersPerEpoch(layersPerEpoch)
 	signer, err := signing.NewEdSigner(
-		signing.WithKeyFromRand(rand.New(rand.NewSource(1001))),
+		signing.WithKeyFromRand(rand.New(rand.NewSource(1000))),
 	)
 	require.NoError(t, err)
 	beacon := types.Beacon{1, 1, 1}
@@ -76,7 +76,7 @@ func TestComputeWeightPerEligibility_EmptyRefBallotID(t *testing.T) {
 func TestComputeWeightPerEligibility_FailToGetRefBallot(t *testing.T) {
 	types.SetLayersPerEpoch(layersPerEpoch)
 	signer, err := signing.NewEdSigner(
-		signing.WithKeyFromRand(rand.New(rand.NewSource(1001))),
+		signing.WithKeyFromRand(rand.New(rand.NewSource(1000))),
 	)
 	require.NoError(t, err)
 	beacon := types.Beacon{1, 1, 1}

--- a/signing/signer.go
+++ b/signing/signer.go
@@ -13,23 +13,27 @@ import (
 	"github.com/spacemeshos/go-spacemesh/log"
 )
 
-type domain byte
+type Domain byte
 
 const (
-	ATX domain = iota
-	BEACON
+	ATX Domain = iota
+	BEACON_FIRST_MSG
+	BEACON_FOLLOWUP_MSG
+	BEACON_PROPOSAL
 	BALLOT
 	HARE
 	POET
 )
 
 // String returns the string representation of a domain.
-func (d domain) String() string {
+func (d Domain) String() string {
 	switch d {
 	case ATX:
 		return "ATX"
-	case BEACON:
-		return "BEACON"
+	case BEACON_FIRST_MSG:
+		return "BEACON_FIRST_MSG"
+	case BEACON_FOLLOWUP_MSG:
+		return "BEACON_FOLLOWUP_MSG"
 	case BALLOT:
 		return "BALLOT"
 	case HARE:
@@ -120,7 +124,7 @@ func NewEdSigner(opts ...EdSignerOptionFunc) (*EdSigner, error) {
 }
 
 // Sign signs the provided message.
-func (es *EdSigner) Sign(d domain, m []byte) types.EdSignature {
+func (es *EdSigner) Sign(d Domain, m []byte) types.EdSignature {
 	msg := make([]byte, 0, len(es.prefix)+1+len(m))
 	msg = append(msg, es.prefix...)
 	msg = append(msg, byte(d))

--- a/signing/signer.go
+++ b/signing/signer.go
@@ -34,6 +34,8 @@ func (d Domain) String() string {
 		return "BEACON_FIRST_MSG"
 	case BEACON_FOLLOWUP_MSG:
 		return "BEACON_FOLLOWUP_MSG"
+	case BEACON_PROPOSAL:
+		return "BEACON_PROPOSAL"
 	case BALLOT:
 		return "BALLOT"
 	case HARE:

--- a/signing/verifier.go
+++ b/signing/verifier.go
@@ -40,7 +40,7 @@ func NewEdVerifier(opts ...VerifierOptionFunc) (*EdVerifier, error) {
 }
 
 // Verify verifies that a signature matches public key and message.
-func (es *EdVerifier) Verify(d domain, nodeID types.NodeID, m []byte, sig types.EdSignature) bool {
+func (es *EdVerifier) Verify(d Domain, nodeID types.NodeID, m []byte, sig types.EdSignature) bool {
 	msg := make([]byte, 0, len(es.prefix)+1+len(m))
 	msg = append(msg, es.prefix...)
 	msg = append(msg, byte(d))

--- a/signing/vrf_test.go
+++ b/signing/vrf_test.go
@@ -17,10 +17,10 @@ func Fuzz_VRFSignAndVerify(f *testing.F) {
 		vrfSig, err := edSig.VRFSigner()
 		require.NoError(t, err, "failed to create VRF signer")
 
-		signature := vrfSig.Sign(message)
+		signature := vrfSig.Sign(HARE, message)
 		require.NoError(t, err, "failed to sign message")
 
-		ok := VRFVerify(edSig.NodeID(), message, signature)
+		ok := VRFVerify(HARE, edSig.NodeID(), message, signature)
 		require.True(t, ok, "failed to verify VRF signature")
 	})
 }
@@ -39,10 +39,10 @@ func Test_VRFSignAndVerify(t *testing.T) {
 	require.NoError(t, err, "failed to create VRF signer")
 
 	message := []byte("hello world")
-	signature := vrfSig.Sign(message)
+	signature := vrfSig.Sign(HARE, message)
 
 	vrfVerify := NewVRFVerifier()
-	ok := vrfVerify.Verify(signer.NodeID(), message, signature)
+	ok := vrfVerify.Verify(HARE, signer.NodeID(), message, signature)
 	require.True(t, ok, "failed to verify VRF signature")
 }
 
@@ -69,18 +69,21 @@ func Test_VRFVerifier(t *testing.T) {
 	require.NoError(t, err, "failed to create VRF signer")
 
 	// Act & Assert
-	sig := vrfSig.Sign([]byte("hello world"))
+	sig := vrfSig.Sign(HARE, []byte("hello world"))
 
-	ok := VRFVerify(signer.NodeID(), []byte("hello world"), sig)
+	ok := VRFVerify(HARE, signer.NodeID(), []byte("hello world"), sig)
 	require.True(t, ok, "failed to verify VRF signature")
 
-	ok = VRFVerify(signer.NodeID(), []byte("different message"), sig)
+	ok = VRFVerify(HARE, signer.NodeID(), []byte("different message"), sig)
+	require.False(t, ok, "VRF signature should not be verified")
+
+	ok = VRFVerify(ATX, signer.NodeID(), []byte("hello world"), sig)
 	require.False(t, ok, "VRF signature should not be verified")
 
 	var sig2 types.VrfSignature
 	copy(sig2[:], sig[:])
 	sig2[0] = ^sig2[0] // flip all bits of first byte in the signature
-	ok = VRFVerify(signer.NodeID(), []byte("hello world"), sig2)
+	ok = VRFVerify(HARE, signer.NodeID(), []byte("hello world"), sig2)
 	require.False(t, ok, "VRF signature should not be verified")
 }
 
@@ -100,7 +103,7 @@ func Test_VRF_LSB_evenly_distributed(t *testing.T) {
 		_, err := rand.Read(msg)
 		require.NoError(t, err, "failed to read random bytes")
 
-		sig := vrfSig.Sign(msg)
+		sig := vrfSig.Sign(HARE, msg)
 		lsb[sig.LSB()&1]++
 	}
 


### PR DESCRIPTION
## Motivation
Closes https://github.com/spacemeshos/go-spacemesh/issues/4274

## Changes
- Signatures of different messages can now not be verified any more if the message is decoded for the wrong domain
- This should prevent messages like `FirstVotingMessage` accidentally be parsed and validated as `FollowupVotingMessage`

## Test Plan
- Added tests for new domains
- Updated existing tests to check if the correct domain is used

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
