### PR TITLE
[Merged by Bors] - syncer sync genesis epoch during genesis 

### DIFF
--- a/hare/eligibility/oracle.go
+++ b/hare/eligibility/oracle.go
@@ -377,8 +377,7 @@ func (o *Oracle) actives(ctx context.Context, targetLayer types.LayerID) (*cache
 	targetEpoch := targetLayer.GetEpoch()
 	// the first bootstrap data targets first epoch after genesis (epoch 2)
 	// and the epoch where checkpoint recovery happens
-	if targetEpoch != 2 &&
-		targetEpoch > types.GetEffectiveGenesis().GetEpoch() &&
+	if targetEpoch > types.GetEffectiveGenesis().Add(1).GetEpoch() &&
 		targetLayer.Difference(targetEpoch.FirstLayer()) < o.cfg.ConfidenceParam {
 		targetEpoch -= 1
 	}

--- a/hare/hare_test.go
+++ b/hare/hare_test.go
@@ -203,11 +203,14 @@ func TestHare_OutputCollectionLoop(t *testing.T) {
 	time.Sleep(1 * time.Second)
 
 	h.mockCoin.EXPECT().Set(lyrID, false)
-	h.outputChan <- report{id: lyrID, set: NewEmptySet(0), completed: true}
 	h.wcChan <- wcReport{id: lyrID, coinflip: false}
+	h.outputChan <- report{id: lyrID, set: NewEmptySet(0), completed: true}
 	lo := <-h.blockGenCh
 	require.Equal(t, lyrID, lo.Layer)
 	require.Empty(t, lo.Proposals)
+	require.Eventually(t, func() bool {
+		return len(h.wcChan) == 0
+	}, time.Second, 100*time.Millisecond)
 }
 
 func TestHare_malfeasanceLoop(t *testing.T) {

--- a/node/bad_peer_test.go
+++ b/node/bad_peer_test.go
@@ -81,6 +81,9 @@ func TestPeerDisconnectForMessageResultValidationReject(t *testing.T) {
 
 	s := getStream(conns[0], pubsub.GossipSubID_v11, network.DirOutbound)
 
+	require.True(t, app1.syncer.IsSynced(ctx))
+	require.True(t, app2.syncer.IsSynced(ctx))
+
 	protocol := ps.ProposalProtocol
 	// Send a message that doesn't result in ValidationReject.
 	p := types.Proposal{}

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -54,6 +54,15 @@ import (
 	"github.com/spacemeshos/go-spacemesh/timesync"
 )
 
+const layersPerEpoch = 3
+
+func TestMain(m *testing.M) {
+	types.SetLayersPerEpoch(layersPerEpoch)
+
+	res := m.Run()
+	os.Exit(res)
+}
+
 func TestSpacemeshApp_getEdIdentity(t *testing.T) {
 	r := require.New(t)
 
@@ -611,6 +620,7 @@ func TestSpacemeshApp_TransactionService(t *testing.T) {
 	}()
 
 	<-app.Started()
+	require.True(t, app.syncer.IsSynced(ctx))
 	conn, err := grpc.Dial(
 		listener,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -223,7 +223,6 @@ func (s *Syncer) Start(ctx context.Context) {
 		s.logger.WithContext(ctx).Info("starting syncer loop")
 		s.eg.Go(func() error {
 			if s.ticker.CurrentLayer() <= types.GetEffectiveGenesis() {
-				s.setATXSynced()
 				s.setSyncState(ctx, synced)
 			}
 			for {
@@ -485,9 +484,11 @@ func isTooFarBehind(ctx context.Context, logger log.Log, current, lastSynced typ
 
 func (s *Syncer) setStateBeforeSync(ctx context.Context) {
 	current := s.ticker.CurrentLayer()
-	if current.Uint32() <= 1 {
-		s.setATXSynced()
+	if s.ticker.CurrentLayer() <= types.GetEffectiveGenesis() {
 		s.setSyncState(ctx, synced)
+		if current.GetEpoch() == 0 {
+			s.setATXSynced()
+		}
 		return
 	}
 	if isTooFarBehind(ctx, s.logger, current, s.getLastSyncedLayer()) {


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
Closes #4469 

## Changes
- make syncer sync genesis epoch during genesis
- make hare use bootstrap active set when recover layer is the first of epoch. it would previously use last epoch's active set