### PR TITLE
[Merged by Bors] - beacon: use big.Int to track if smesher voted in a round

### DIFF
--- a/beacon/handlers.go
+++ b/beacon/handlers.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"math/bits"
 	"time"
 
 	"github.com/spacemeshos/go-spacemesh/codec"
@@ -475,39 +474,20 @@ func (pd *ProtocolDriver) registerVoted(epoch types.EpochID, nodeID types.NodeID
 	return pd.states[epoch].registerVoted(nodeID, round)
 }
 
-const wordSize = 64
-
-func newVotesTracker(limit uint32) *votesTracker {
-	b := bits.Len32(limit)
-	words := b / wordSize
-	if b%wordSize != 0 {
-		words += 1
-	}
-	return &votesTracker{words: make([]uint64, words)}
+func newVotesTracker() *votesTracker {
+	return &votesTracker{votes: new(big.Int)}
 }
 
 type votesTracker struct {
-	words []uint64
+	votes *big.Int
 }
 
 func (v *votesTracker) register(round types.RoundID) bool {
-	word := uint64(round) / wordSize
-	if word >= uint64(len(v.words)) {
-		return false
-	}
-	position := uint64(1) << (uint64(round) % wordSize)
-	if v.words[word]&position > 0 {
-		return false
-	}
-	v.words[word] |= position
-	return true
+	rst := !v.voted(round)
+	v.votes.SetBit(v.votes, int(round), 1)
+	return rst
 }
 
 func (v *votesTracker) voted(round types.RoundID) bool {
-	word := uint64(round) / wordSize
-	if word >= uint64(len(v.words)) {
-		return false
-	}
-	position := uint64(1) << (uint64(round) % wordSize)
-	return v.words[word]&position > 0
+	return v.votes.Bit(int(round)) > 0
 }

--- a/beacon/handlers_test.go
+++ b/beacon/handlers_test.go
@@ -1382,3 +1382,13 @@ func Test_UniqueFollowingVotingMessages(t *testing.T) {
 	// not be considered duplicate gossip messages.
 	require.NotEqual(t, data1, data2)
 }
+
+func TestTracker(t *testing.T) {
+	track := newVotesTracker()
+	for i := 0; i < 1000; i++ {
+		require.True(t, track.register(types.RoundID(i)), i)
+	}
+	for i := 0; i < 1000; i++ {
+		require.False(t, track.register(types.RoundID(i)), i)
+	}
+}

--- a/beacon/state.go
+++ b/beacon/state.go
@@ -111,7 +111,7 @@ func (s *state) registerProposed(logger log.Log, nodeID types.NodeID) error {
 func (s *state) registerVoted(nodeID types.NodeID, round types.RoundID) error {
 	tracker, exists := s.hasVoted[nodeID]
 	if !exists {
-		tracker = newVotesTracker(uint32(s.cfg.RoundsNumber))
+		tracker = newVotesTracker()
 		s.hasVoted[nodeID] = tracker
 	}
 	if !tracker.register(round) {


### PR DESCRIPTION
the mistake was that `limit` parameter is already a number of bits. there was no need to check how much bits were needed to represent limit. 