### PR TITLE
Hare 2 sketch

### DIFF
--- a/hare2/algorithm.go
+++ b/hare2/algorithm.go
@@ -23,19 +23,20 @@ package hare2
 // 	Gossip([]byte) (action Action, output []byte)
 // }
 
+//--------------------------------------------------
 // Take 2 below
 
-type NetworkGossiper interface {
-	NetworkGossip([]byte)
-}
+// type NetworkGossiper interface {
+// 	NetworkGossip([]byte)
+// }
 
-type ByzantineGossiper interface {
-	Gossip([]byte) (output []byte)
-}
+// type ByzantineGossiper interface {
+// 	Gossip([]byte) (output []byte)
+// }
 
-type ThresholdGossiper interface {
-	Gossip([]byte) (output []byte)
-}
+// type ThresholdGossiper interface {
+// 	Gossip([]byte) (output []byte)
+// }
 
 // messages have iteration round
 
@@ -45,3 +46,14 @@ type ThresholdGossiper interface {
 //     ByzantineReceiver -> GradecastSender -> ProtocolReceiver
 //     ProtocolSender -> ThresholdSender -> ByzantineSender
 //     ProtocolSender -> GradecastSender -> ByzantineSender
+
+//--------------------------------------------------
+
+// Take 3 below
+
+// so actually rather than the above approach I am now leaning towards not
+// nesting the protocols and simply connecting them up to provide the output of
+// one to the next. This keeps things nice and flat and very isolated.
+
+// I'm going to remove signature verification from these protocols to keep them
+// simple, we assume signature verification is done up front.

--- a/hare2/algorithm.go
+++ b/hare2/algorithm.go
@@ -195,7 +195,7 @@ func (h *Handler) HandleMsg(vk []byte, values []Hash20, round int8) bool {
 }
 
 type Protocol struct {
-	// round encodes both interation and current iteration round in a single value.
+	// round encodes both iteration and round in a single value.
 	round AbsRound
 	// Each index "i" holds an indication of whether iteration "i" is hard locked
 	hardLocked []bool

--- a/hare2/algorithm.go
+++ b/hare2/algorithm.go
@@ -1,0 +1,47 @@
+package hare2
+
+// Don't really want this to be part of the impl because it introduces errors
+// that we don't want or really need.
+//
+// Although actually if we look at how hare handles sending message errors it
+// just logs them, so we could do the same and not expose the error, which
+// probably makes more sense than trying to propagate up an action (send or
+// drop with possibly a message ) from the algorithm to pass to some network
+// component
+// type NetworkGossiper interface {
+// 	NetworkGossip([]byte) error
+// }
+
+// type Action uint32
+
+// const (
+// 	send Action = iota
+// 	drop
+// )
+
+// type ByzantineGossip interface {
+// 	Gossip([]byte) (action Action, output []byte)
+// }
+
+// Take 2 below
+
+type NetworkGossiper interface {
+	NetworkGossip([]byte)
+}
+
+type ByzantineGossiper interface {
+	Gossip([]byte) (output []byte)
+}
+
+type ThresholdGossiper interface {
+	Gossip([]byte) (output []byte)
+}
+
+// messages have iteration round
+
+// Hmm can i have three receive interfaces and three send internfaces and then hook them up in differing order
+// Seems I need to have 2 flows to account for the threshold and gradecast systems.
+// E.G ByzantineReceiver -> ThresholdReceiver -> ProtocolReceiver
+//     ByzantineReceiver -> GradecastSender -> ProtocolReceiver
+//     ProtocolSender -> ThresholdSender -> ByzantineSender
+//     ProtocolSender -> GradecastSender -> ByzantineSender

--- a/hare2/algorithm.go
+++ b/hare2/algorithm.go
@@ -43,14 +43,6 @@ import (
 	"golang.org/x/exp/slices"
 )
 
-// I'm going to remove signature verification from these protocols to keep them
-// simple, we assume signature verification is done up front.
-
-// Also I'm trying to ensure that any processing that could result in an error
-// is also removed from the protocols.
-
-// not sure exactly what to put here, but the output should be the grade of key
-
 type (
 	MsgType            uint8
 	GradedGossipResult uint8

--- a/hare2/algorithm.go
+++ b/hare2/algorithm.go
@@ -60,7 +60,7 @@ const (
 	DropMessage
 
 	// d is the degree parameter of both the graded gossip and threshold gossip
-	// pprotocols, it is the number of different grades that can be assigned.
+	// pprotocols, it is highest grade that can be assigned, grades start at 0.
 	d = 5
 )
 
@@ -118,19 +118,14 @@ type LeaderChecker interface {
 	IsLeader(vk Hash20, round AbsRound) bool
 }
 
+// gradeKey3 returns a grade from 0-3.
 func gradeKey3(key []byte) uint8 {
 	return 0
 }
 
+// gradeKey5 returns a grade from 0-5.
 func gradeKey5(key []byte) uint8 {
 	return 0
-}
-
-type Message struct {
-	ID     Hash20
-	Values []Hash20
-	Round  uint8
-	Grade  uint8
 }
 
 // Handler performs message handling, there is a handler per instance of each

--- a/hare2/algorithm.go
+++ b/hare2/algorithm.go
@@ -1,4 +1,4 @@
-package hare3
+package hare2
 
 import (
 	"github.com/spacemeshos/go-scale"

--- a/hare2/runner/runner.go
+++ b/hare2/runner/runner.go
@@ -3,13 +3,11 @@ package runner
 import (
 	"time"
 
-	"github.com/spacemeshos/go-scale"
-	"github.com/spacemeshos/go-spacemesh/codec"
 	"github.com/spacemeshos/go-spacemesh/hare2"
 )
 
 type ProtocolRunner struct {
-	messages  chan []byte
+	messages  chan MultiMsg
 	handler   hare2.Handler
 	protocol  hare2.Protocol
 	roundTime time.Duration
@@ -34,16 +32,14 @@ func (r *ProtocolRunner) Run() []hare2.Hash20 {
 			if output != nil {
 				return output
 			}
-		case msg := <-r.messages:
-			id, values, round, grade, err := getHandlerInputs(msg)
-			if err != nil {
-				// We drop the message in case of error
-				logerr(err)
-				continue
-			}
-			if r.handler.HandleMsg(id, values, round, grade) {
-				// Send message to peers
-				err := r.gossiper.Gossip(msg)
+		case multiMsg := <-r.messages:
+			// It is assumed that messages received here have had their
+			// signature verified by the broker and that the broker made use of
+			// the message sid to route the message to this instance.
+			m := multiMsg.Message
+			if r.handler.HandleMsg(m.key, m.values, m.round) {
+				// Send raw message to peers
+				err := r.gossiper.Gossip(multiMsg.RawMessage)
 				if err != nil {
 					logerr(err)
 				}
@@ -52,46 +48,9 @@ func (r *ProtocolRunner) Run() []hare2.Hash20 {
 	}
 }
 
-func getHandlerInputs(msg []byte) (id hare2.Hash20, values []hare2.Hash20, round hare2.AbsRound, grade uint8, err error) {
-	w := &Wrapper{}
-
-	err = codec.Decode(msg, w)
-	if err != nil {
-		return hare2.Hash20{}, nil, 0, 0, err
-	}
-	err = verify(w.sig, w.msg)
-	if err != nil {
-		return hare2.Hash20{}, nil, 0, 0, err
-	}
-	m := &Msg{}
-	err = codec.Decode(msg, m)
-	if err != nil {
-		return hare2.Hash20{}, nil, 0, 0, err
-	}
-
-	round = hare2.AbsRound(m.round)
-	switch round.Type() {
-	case hare2.Propose:
-		grade, err = gradeKey3(m.key)
-		if err != nil {
-			return hare2.Hash20{}, nil, 0, 0, err
-		}
-	default:
-		grade, err = gradeKey5(m.key)
-		if err != nil {
-			return hare2.Hash20{}, nil, 0, 0, err
-		}
-	}
-	id = hashBytes(m.key)
-	return id, values, round, grade, nil
-}
-
-type Wrapper struct {
-	msg, sig []byte
-}
-
-func (m *Wrapper) DecodeScale(d *scale.Decoder) (int, error) {
-	return 0, nil
+type MultiMsg struct {
+	RawMessage []byte
+	Message    Msg
 }
 
 type Msg struct {
@@ -100,32 +59,12 @@ type Msg struct {
 	round    int8
 }
 
-func (m *Msg) DecodeScale(d *scale.Decoder) (int, error) {
-	return 0, nil
-}
-
 type NetworkGossiper interface {
 	Gossip(msg []byte) error
 }
 
 func buildEncodedOutputMessgae(m *hare2.OutputMessage) ([]byte, error) {
 	return nil, nil
-}
-
-func hashBytes(v []byte) hare2.Hash20 {
-	return hare2.Hash20{}
-}
-
-func verify(sig, data []byte) error {
-	return nil
-}
-
-func gradeKey3(key []byte) (uint8, error) {
-	return 0, nil
-}
-
-func gradeKey5(key []byte) (uint8, error) {
-	return 0, nil
 }
 
 func logerr(err error) {

--- a/hare2/runner/runner.go
+++ b/hare2/runner/runner.go
@@ -1,0 +1,132 @@
+package runner
+
+import (
+	"time"
+
+	"github.com/spacemeshos/go-scale"
+	"github.com/spacemeshos/go-spacemesh/codec"
+	"github.com/spacemeshos/go-spacemesh/hare2"
+)
+
+type ProtocolRunner struct {
+	messages  chan []byte
+	handler   hare2.Handler
+	protocol  hare2.Protocol
+	roundTime time.Duration
+	gossiper  NetworkGossiper
+}
+
+func (r *ProtocolRunner) Run() []hare2.Hash20 {
+	t := time.NewTicker(r.roundTime)
+	defer t.Stop()
+	for {
+		select {
+		case <-t.C:
+			toSend, output := r.protocol.NextRound()
+			if toSend != nil {
+				msg, err := buildEncodedOutputMessgae(toSend)
+				if err != nil {
+					// This should never happen
+					panic(err)
+				}
+				r.gossiper.Gossip(msg)
+			}
+			if output != nil {
+				return output
+			}
+		case msg := <-r.messages:
+			id, values, round, grade, err := getHandlerInputs(msg)
+			if err != nil {
+				// We drop the message in case of error
+				logerr(err)
+				continue
+			}
+			if r.handler.HandleMsg(id, values, round, grade) {
+				// Send message to peers
+				err := r.gossiper.Gossip(msg)
+				if err != nil {
+					logerr(err)
+				}
+			}
+		}
+	}
+}
+
+func getHandlerInputs(msg []byte) (id hare2.Hash20, values []hare2.Hash20, round hare2.AbsRound, grade uint8, err error) {
+	w := &Wrapper{}
+
+	err = codec.Decode(msg, w)
+	if err != nil {
+		return hare2.Hash20{}, nil, 0, 0, err
+	}
+	err = verify(w.sig, w.msg)
+	if err != nil {
+		return hare2.Hash20{}, nil, 0, 0, err
+	}
+	m := &Msg{}
+	err = codec.Decode(msg, m)
+	if err != nil {
+		return hare2.Hash20{}, nil, 0, 0, err
+	}
+
+	round = hare2.AbsRound(m.round)
+	switch round.Type() {
+	case hare2.Propose:
+		grade, err = gradeKey3(m.key)
+		if err != nil {
+			return hare2.Hash20{}, nil, 0, 0, err
+		}
+	default:
+		grade, err = gradeKey5(m.key)
+		if err != nil {
+			return hare2.Hash20{}, nil, 0, 0, err
+		}
+	}
+	id = hashBytes(m.key)
+	return id, values, round, grade, nil
+}
+
+type Wrapper struct {
+	msg, sig []byte
+}
+
+func (m *Wrapper) DecodeScale(d *scale.Decoder) (int, error) {
+	return 0, nil
+}
+
+type Msg struct {
+	sid, key []byte
+	values   []hare2.Hash20
+	round    int8
+}
+
+func (m *Msg) DecodeScale(d *scale.Decoder) (int, error) {
+	return 0, nil
+}
+
+type NetworkGossiper interface {
+	Gossip(msg []byte) error
+}
+
+func buildEncodedOutputMessgae(m *hare2.OutputMessage) ([]byte, error) {
+	return nil, nil
+}
+
+func hashBytes(v []byte) hare2.Hash20 {
+	return hare2.Hash20{}
+}
+
+func verify(sig, data []byte) error {
+	return nil
+}
+
+func gradeKey3(key []byte) (uint8, error) {
+	return 0, nil
+}
+
+func gradeKey5(key []byte) (uint8, error) {
+	return 0, nil
+}
+
+func logerr(err error) {
+}

--- a/hare3/algorithm.go
+++ b/hare3/algorithm.go
@@ -541,32 +541,6 @@ func (p *Protocol) NextRound() *miniMsg {
 	return nil
 }
 
-// Preround returns a set of values to send in the preround.
-func (p *Protocol) DoPreround() *miniMsg {
-	return &miniMsg{-1, p.values}
-}
-
-func (p *Protocol) DoHardLock() *miniMsg {
-	return nil
-}
-
-func (p *Protocol) DoSoftlock() *miniMsg {
-	return nil
-}
-
-// propose and commit both return iteration and value that can be used to send a message of the appropriate type.
-func (p *Protocol) DoPropose() *miniMsg {
-	return nil
-}
-
-func (p *Protocol) DoCommit() *miniMsg {
-	return nil
-}
-
-func (p *Protocol) DoNotify() *miniMsg {
-	return nil
-}
-
 type miniMsg struct {
 	round  AbsRound
 	values []Hash20

--- a/hare3/algorithm.go
+++ b/hare3/algorithm.go
@@ -1,4 +1,4 @@
-package hare2
+package hare3
 
 // Don't really want this to be part of the impl because it introduces errors
 // that we don't want or really need.

--- a/hare3/algorithm.go
+++ b/hare3/algorithm.go
@@ -1,5 +1,7 @@
 package hare3
 
+// Hare 2 below --------------------------------------------------
+
 // Don't really want this to be part of the impl because it introduces errors
 // that we don't want or really need.
 //
@@ -57,3 +59,35 @@ package hare3
 
 // I'm going to remove signature verification from these protocols to keep them
 // simple, we assume signature verification is done up front.
+
+// Hare 3 below --------------------------------------------------
+
+// Hare 3 is pretty similare just with an underlying PKI grading protocol.
+
+// type GradedGossiper interface {
+// 	// Gossip takes the given sid (session id) value and verification key (key)
+// 	Gossip(sid, value, key, sig []byte) (s, v, k []byte, grade uint8)
+// }
+
+// But we want to take signatures out so that we don't deal with errors
+
+type KeyGrader any
+
+// not sure exactly what to put here, but the output should be the grade of key
+
+type GradedGossiper interface {
+	// GradedGossip takes the given sid (session id) value, key (verification
+	// key) and grade and processes them. If a non nil v is returned the
+	// originally received input message should be forwarded to all neighbors
+	// and (sid, value, key, grade) is considered to have been output.
+	GradedGossip(sid, value, key []byte, grade uint8) (v []byte)
+}
+
+type TrhesholdGradedGossiper interface {
+	// Threshold graded gossip takes outputs from graded gossip, which are in
+	// fact sets of values not single values, and returns sets of values that
+	// have reached the required threshold, along with the grade for that set.
+	ThresholdGradedGossip(sid, round uint32, value [][]byte, key []byte, grade uint8) (v [][]byte, g uint8) // (sid, r, v, d + 1 − s)
+	// Increment round increments the current round
+	IncRound()
+}

--- a/hare3/algorithm.go
+++ b/hare3/algorithm.go
@@ -420,7 +420,7 @@ func (p *Protocol) NextRound() (toSend *miniMsg, output []Hash20) {
 		var mm *miniMsg
 		var result []Hash20
 		values := p.tgg.RetrieveThresholdMessages(NewAbsRound(j-1, 6), 5)
-	OUTER6:
+	OUTER:
 		// Case 1
 		for _, v := range values {
 			for i := 0; i <= int(j); i++ {
@@ -431,7 +431,7 @@ func (p *Protocol) NextRound() (toSend *miniMsg, output []Hash20) {
 						round:  NewAbsRound(j, 6),
 						values: []Hash20{v},
 					}
-					break OUTER6
+					break OUTER
 				}
 			}
 		}


### PR DESCRIPTION
## Motivation
Relates to #4456 

Note that fort he purposes of having more understandable versioning we are will assign the resulting implementation a version number of 2, even though the implementation is derived from the 3rd conceptual version of hare.

This is a high level sketch of how the hare3 protocol could fit together. There are many parts that are not implemented and there are likely many missing elements, but this is intended to give an idea of what the structure of the protocol as a whole will look like when completed.

Since the hare protocol is a fairly critical part of the system the structure has been designed in such a way as to minimise the complexity of the protocol by pushing all parts that are not part of the conceptual state machine defined by the hare 3.0 paper out of the protocol. E.G message encoding/decoding, signature verification and generally any code that could result in an error. Below is a diagram showing a very high level view of the design.

It probably makes more sense to look at `hare2/runner/runner.go` first since that shows how the protocol would be used at a high level and then look at `hare2/algorithm.go` which contains the detail.

![hare_2_high_level_design](https://github.com/spacemeshos/go-spacemesh/assets/5087847/61bb9d2b-b05e-46a0-ac10-a9ec732086b5)



