### PR TITLE
[Merged by Bors] - Revert VRF signature domain

### DIFF
--- a/beacon/beacon.go
+++ b/beacon/beacon.go
@@ -1108,7 +1108,7 @@ func atxThreshold(kappa int, q *big.Rat, numATXs int) *big.Int {
 
 func buildSignedProposal(ctx context.Context, logger log.Log, signer vrfSigner, epoch types.EpochID, nonce types.VRFPostIndex) types.VrfSignature {
 	p := buildProposal(logger, epoch, nonce)
-	vrfSig := signer.Sign(signing.BEACON_PROPOSAL, p)
+	vrfSig := signer.Sign(p)
 	proposal := ProposalFromVrf(vrfSig)
 	logger.WithContext(ctx).With().Debug("calculated beacon proposal",
 		epoch,

--- a/beacon/beacon_test.go
+++ b/beacon/beacon_test.go
@@ -100,8 +100,8 @@ func newTestDriver(tb testing.TB, cfg Config, p pubsub.Publisher) *testProtocolD
 	minerID := edSgn.NodeID()
 	lg := logtest.New(tb).WithName(minerID.ShortString())
 
-	tpd.mSigner.EXPECT().Sign(signing.BEACON_PROPOSAL, gomock.Any()).AnyTimes().Return(types.EmptyVrfSignature)
-	tpd.mVerifier.EXPECT().Verify(signing.BEACON_PROPOSAL, gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(true)
+	tpd.mSigner.EXPECT().Sign(gomock.Any()).AnyTimes().Return(types.EmptyVrfSignature)
+	tpd.mVerifier.EXPECT().Verify(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(true)
 	tpd.mNonceFetcher.EXPECT().VRFNonce(gomock.Any(), gomock.Any()).AnyTimes().Return(types.VRFPostIndex(1), nil)
 
 	tpd.cdb = datastore.NewCachedDB(sql.InMemory(), lg)
@@ -961,12 +961,12 @@ func TestBeacon_getSignedProposal(t *testing.T) {
 		{
 			name:   "Case 1",
 			epoch:  1,
-			result: vrfSigner.Sign(signing.BEACON_PROPOSAL, []byte{0x04, 0x04, 0x04}),
+			result: vrfSigner.Sign([]byte{0x04, 0x04, 0x04}),
 		},
 		{
 			name:   "Case 2",
 			epoch:  2,
-			result: vrfSigner.Sign(signing.BEACON_PROPOSAL, []byte{0x04, 0x04, 0x08}),
+			result: vrfSigner.Sign([]byte{0x04, 0x04, 0x08}),
 		},
 	}
 

--- a/beacon/handlers.go
+++ b/beacon/handlers.go
@@ -193,7 +193,7 @@ func (pd *ProtocolDriver) verifyProposalMessage(logger log.Log, m ProposalMessag
 		return fmt.Errorf("[proposal] get VRF nonce (miner ID %s): %w", m.NodeID, err)
 	}
 	currentEpochProposal := buildProposal(logger, m.EpochID, nonce)
-	if !pd.vrfVerifier.Verify(signing.BEACON_PROPOSAL, m.NodeID, currentEpochProposal, m.VRFSignature) {
+	if !pd.vrfVerifier.Verify(m.NodeID, currentEpochProposal, m.VRFSignature) {
 		// TODO(nkryuchkov): attach telemetry
 		logger.With().Warning("[proposal] failed to verify VRF signature")
 		return fmt.Errorf("[proposal] verify VRF (miner ID %s): %w", m.NodeID, errVRFNotVerified)

--- a/beacon/handlers_test.go
+++ b/beacon/handlers_test.go
@@ -73,7 +73,7 @@ func createProposal(t *testing.T, vrfSigner *signing.VRFSigner, epoch types.Epoc
 		VRFSignature: sig,
 	}
 	if corruptSignature {
-		msg.VRFSignature = vrfSigner.Sign(signing.BEACON_PROPOSAL, types.RandomBytes(32))
+		msg.VRFSignature = vrfSigner.Sign(types.RandomBytes(32))
 	}
 	return msg
 }
@@ -500,7 +500,7 @@ func Test_handleProposal_BadVrfSignature(t *testing.T) {
 	require.NoError(t, err)
 
 	mVerifier := NewMockvrfVerifier(tpd.ctrl)
-	mVerifier.EXPECT().Verify(signing.BEACON_PROPOSAL, gomock.Any(), gomock.Any(), gomock.Any()).Return(false)
+	mVerifier.EXPECT().Verify(gomock.Any(), gomock.Any(), gomock.Any()).Return(false)
 	tpd.vrfVerifier = mVerifier
 
 	tpd.mClock.EXPECT().CurrentLayer().Return(epoch.FirstLayer())

--- a/beacon/interface.go
+++ b/beacon/interface.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/p2p"
-	"github.com/spacemeshos/go-spacemesh/signing"
 )
 
 //go:generate mockgen -package=beacon -destination=./mocks.go -source=./interface.go
@@ -32,13 +31,13 @@ type layerClock interface {
 }
 
 type vrfSigner interface {
-	Sign(d signing.Domain, msg []byte) types.VrfSignature
+	Sign(msg []byte) types.VrfSignature
 	NodeID() types.NodeID
 	LittleEndian() bool
 }
 
 type vrfVerifier interface {
-	Verify(d signing.Domain, nodeID types.NodeID, msg []byte, sig types.VrfSignature) bool
+	Verify(nodeID types.NodeID, msg []byte, sig types.VrfSignature) bool
 }
 
 type nonceFetcher interface {

--- a/beacon/message.go
+++ b/beacon/message.go
@@ -8,9 +8,9 @@ import (
 
 //go:generate scalegen
 
-// ProposalVrfMessage is a message for buildProposal below.
+// ProposalVrfMessage is the payload for the VRF Signature in `ProposalMessage`.
 type ProposalVrfMessage struct {
-	Type  types.EligibilityType
+	Type  types.EligibilityType // always types.EligibilityBeacon
 	Nonce types.VRFPostIndex
 	Epoch types.EpochID
 }

--- a/beacon/mocks.go
+++ b/beacon/mocks.go
@@ -12,7 +12,6 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	types "github.com/spacemeshos/go-spacemesh/common/types"
 	p2p "github.com/spacemeshos/go-spacemesh/p2p"
-	signing "github.com/spacemeshos/go-spacemesh/signing"
 )
 
 // Mockcoin is a mock of coin interface.
@@ -283,17 +282,17 @@ func (mr *MockvrfSignerMockRecorder) NodeID() *gomock.Call {
 }
 
 // Sign mocks base method.
-func (m *MockvrfSigner) Sign(d signing.Domain, msg []byte) types.VrfSignature {
+func (m *MockvrfSigner) Sign(msg []byte) types.VrfSignature {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Sign", d, msg)
+	ret := m.ctrl.Call(m, "Sign", msg)
 	ret0, _ := ret[0].(types.VrfSignature)
 	return ret0
 }
 
 // Sign indicates an expected call of Sign.
-func (mr *MockvrfSignerMockRecorder) Sign(d, msg interface{}) *gomock.Call {
+func (mr *MockvrfSignerMockRecorder) Sign(msg interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sign", reflect.TypeOf((*MockvrfSigner)(nil).Sign), d, msg)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sign", reflect.TypeOf((*MockvrfSigner)(nil).Sign), msg)
 }
 
 // MockvrfVerifier is a mock of vrfVerifier interface.
@@ -320,17 +319,17 @@ func (m *MockvrfVerifier) EXPECT() *MockvrfVerifierMockRecorder {
 }
 
 // Verify mocks base method.
-func (m *MockvrfVerifier) Verify(d signing.Domain, nodeID types.NodeID, msg []byte, sig types.VrfSignature) bool {
+func (m *MockvrfVerifier) Verify(nodeID types.NodeID, msg []byte, sig types.VrfSignature) bool {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Verify", d, nodeID, msg, sig)
+	ret := m.ctrl.Call(m, "Verify", nodeID, msg, sig)
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
 // Verify indicates an expected call of Verify.
-func (mr *MockvrfVerifierMockRecorder) Verify(d, nodeID, msg, sig interface{}) *gomock.Call {
+func (mr *MockvrfVerifierMockRecorder) Verify(nodeID, msg, sig interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Verify", reflect.TypeOf((*MockvrfVerifier)(nil).Verify), d, nodeID, msg, sig)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Verify", reflect.TypeOf((*MockvrfVerifier)(nil).Verify), nodeID, msg, sig)
 }
 
 // MocknonceFetcher is a mock of nonceFetcher interface.

--- a/beacon/weakcoin/interface.go
+++ b/beacon/weakcoin/interface.go
@@ -2,19 +2,18 @@ package weakcoin
 
 import (
 	"github.com/spacemeshos/go-spacemesh/common/types"
-	"github.com/spacemeshos/go-spacemesh/signing"
 )
 
 //go:generate mockgen -package=weakcoin -destination=./mocks.go -source=./interface.go
 
 type vrfSigner interface {
-	Sign(d signing.Domain, msg []byte) types.VrfSignature
+	Sign(msg []byte) types.VrfSignature
 	NodeID() types.NodeID
 	LittleEndian() bool
 }
 
 type vrfVerifier interface {
-	Verify(domain signing.Domain, nodeID types.NodeID, msg []byte, sig types.VrfSignature) bool
+	Verify(nodeID types.NodeID, msg []byte, sig types.VrfSignature) bool
 }
 
 type nonceFetcher interface {

--- a/beacon/weakcoin/mocks.go
+++ b/beacon/weakcoin/mocks.go
@@ -9,7 +9,6 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	types "github.com/spacemeshos/go-spacemesh/common/types"
-	signing "github.com/spacemeshos/go-spacemesh/signing"
 )
 
 // MockvrfSigner is a mock of vrfSigner interface.
@@ -64,17 +63,17 @@ func (mr *MockvrfSignerMockRecorder) NodeID() *gomock.Call {
 }
 
 // Sign mocks base method.
-func (m *MockvrfSigner) Sign(d signing.Domain, msg []byte) types.VrfSignature {
+func (m *MockvrfSigner) Sign(msg []byte) types.VrfSignature {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Sign", d, msg)
+	ret := m.ctrl.Call(m, "Sign", msg)
 	ret0, _ := ret[0].(types.VrfSignature)
 	return ret0
 }
 
 // Sign indicates an expected call of Sign.
-func (mr *MockvrfSignerMockRecorder) Sign(d, msg interface{}) *gomock.Call {
+func (mr *MockvrfSignerMockRecorder) Sign(msg interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sign", reflect.TypeOf((*MockvrfSigner)(nil).Sign), d, msg)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sign", reflect.TypeOf((*MockvrfSigner)(nil).Sign), msg)
 }
 
 // MockvrfVerifier is a mock of vrfVerifier interface.
@@ -101,17 +100,17 @@ func (m *MockvrfVerifier) EXPECT() *MockvrfVerifierMockRecorder {
 }
 
 // Verify mocks base method.
-func (m *MockvrfVerifier) Verify(domain signing.Domain, nodeID types.NodeID, msg []byte, sig types.VrfSignature) bool {
+func (m *MockvrfVerifier) Verify(nodeID types.NodeID, msg []byte, sig types.VrfSignature) bool {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Verify", domain, nodeID, msg, sig)
+	ret := m.ctrl.Call(m, "Verify", nodeID, msg, sig)
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
 // Verify indicates an expected call of Verify.
-func (mr *MockvrfVerifierMockRecorder) Verify(domain, nodeID, msg, sig interface{}) *gomock.Call {
+func (mr *MockvrfVerifierMockRecorder) Verify(nodeID, msg, sig interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Verify", reflect.TypeOf((*MockvrfVerifier)(nil).Verify), domain, nodeID, msg, sig)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Verify", reflect.TypeOf((*MockvrfVerifier)(nil).Verify), nodeID, msg, sig)
 }
 
 // MocknonceFetcher is a mock of nonceFetcher interface.

--- a/beacon/weakcoin/weak_coin.go
+++ b/beacon/weakcoin/weak_coin.go
@@ -55,8 +55,9 @@ type Message struct {
 	VRFSignature types.VrfSignature
 }
 
+// VrfMessage is the payload for the signature of `Message`.
 type VrfMessage struct {
-	Type  types.EligibilityType
+	Type  types.EligibilityType // always types.EligibilityBeaconWC
 	Nonce types.VRFPostIndex
 	Epoch types.EpochID
 	Round types.RoundID

--- a/beacon/weakcoin/weak_coin.go
+++ b/beacon/weakcoin/weak_coin.go
@@ -11,7 +11,6 @@ import (
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/p2p/pubsub"
-	"github.com/spacemeshos/go-spacemesh/signing"
 )
 
 var (
@@ -233,7 +232,7 @@ func (wc *WeakCoin) updateProposal(ctx context.Context, message Message) error {
 		return fmt.Errorf("failed to get vrf nonce for node %s: %w", message.NodeID, err)
 	}
 	buf := wc.encodeProposal(message.Epoch, nonce, message.Round, message.Unit)
-	if !wc.verifier.Verify(signing.BEACON_PROPOSAL, message.NodeID, buf, message.VRFSignature) {
+	if !wc.verifier.Verify(message.NodeID, buf, message.VRFSignature) {
 		return fmt.Errorf("signature is invalid signature %x", message.VRFSignature)
 	}
 
@@ -254,7 +253,7 @@ func (wc *WeakCoin) prepareProposal(epoch types.EpochID, nonce types.VRFPostInde
 	var smallest *types.VrfSignature
 	for unit := uint32(0); unit < minerAllowance; unit++ {
 		proposal := wc.encodeProposal(epoch, nonce, round, unit)
-		signature := wc.signer.Sign(signing.BEACON_PROPOSAL, proposal)
+		signature := wc.signer.Sign(proposal)
 		if wc.aboveThreshold(signature) {
 			continue
 		}

--- a/beacon/weakcoin/weak_coin_test.go
+++ b/beacon/weakcoin/weak_coin_test.go
@@ -46,7 +46,7 @@ func encoded(tb testing.TB, msg weakcoin.Message) []byte {
 func staticSigner(tb testing.TB, ctrl *gomock.Controller, nodeId types.NodeID, sig types.VrfSignature) *weakcoin.MockvrfSigner {
 	tb.Helper()
 	signer := weakcoin.NewMockvrfSigner(ctrl)
-	signer.EXPECT().Sign(signing.BEACON_PROPOSAL, gomock.Any()).Return(sig).AnyTimes()
+	signer.EXPECT().Sign(gomock.Any()).Return(sig).AnyTimes()
 	signer.EXPECT().NodeID().Return(nodeId).AnyTimes()
 	signer.EXPECT().LittleEndian().Return(true).AnyTimes()
 	return signer
@@ -55,7 +55,7 @@ func staticSigner(tb testing.TB, ctrl *gomock.Controller, nodeId types.NodeID, s
 func sigVerifier(tb testing.TB, ctrl *gomock.Controller) *weakcoin.MockvrfVerifier {
 	tb.Helper()
 	verifier := weakcoin.NewMockvrfVerifier(ctrl)
-	verifier.EXPECT().Verify(signing.BEACON_PROPOSAL, gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
+	verifier.EXPECT().Verify(gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 	return verifier
 }
 

--- a/beacon/weakcoin/weak_coin_test.go
+++ b/beacon/weakcoin/weak_coin_test.go
@@ -442,7 +442,7 @@ func TestWeakCoinEncodingRegression(t *testing.T) {
 	instance.StartRound(context.Background(), round, &nonce)
 
 	require.Equal(t,
-		"94494c2c55a388acd03acd64b21912c4cb6e8dca56da5979bbab9b23be790ed948eda672dc28b8e379ec041aa46511b2dd4f9143ed8d512bf6386454d43f3b4ed9f7748b09ee92730975d094dc8c3501",
+		"78f523319fd2cdf3812a3bc3905561acb2f7f1b7e47de71f92811d7bb82460e5999a048051cefa2d1b6f3f16656de83c2756b7539b33fa563a3e8fea5130235e66e8dce914d69bd40f13174f3914ad07",
 		sig.String(),
 	)
 }

--- a/hare/eligibility/interface.go
+++ b/hare/eligibility/interface.go
@@ -2,7 +2,6 @@ package eligibility
 
 import (
 	"github.com/spacemeshos/go-spacemesh/common/types"
-	"github.com/spacemeshos/go-spacemesh/signing"
 )
 
 //go:generate mockgen -package=eligibility -destination=./mocks.go -source=./interface.go
@@ -13,7 +12,7 @@ type activeSetCache interface {
 }
 
 type vrfVerifier interface {
-	Verify(d signing.Domain, nodeID types.NodeID, msg []byte, sig types.VrfSignature) bool
+	Verify(nodeID types.NodeID, msg []byte, sig types.VrfSignature) bool
 }
 
 type nonceFetcher interface {

--- a/hare/eligibility/mocks.go
+++ b/hare/eligibility/mocks.go
@@ -9,7 +9,6 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	types "github.com/spacemeshos/go-spacemesh/common/types"
-	signing "github.com/spacemeshos/go-spacemesh/signing"
 )
 
 // MockactiveSetCache is a mock of activeSetCache interface.
@@ -88,17 +87,17 @@ func (m *MockvrfVerifier) EXPECT() *MockvrfVerifierMockRecorder {
 }
 
 // Verify mocks base method.
-func (m *MockvrfVerifier) Verify(d signing.Domain, nodeID types.NodeID, msg []byte, sig types.VrfSignature) bool {
+func (m *MockvrfVerifier) Verify(nodeID types.NodeID, msg []byte, sig types.VrfSignature) bool {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Verify", d, nodeID, msg, sig)
+	ret := m.ctrl.Call(m, "Verify", nodeID, msg, sig)
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
 // Verify indicates an expected call of Verify.
-func (mr *MockvrfVerifierMockRecorder) Verify(d, nodeID, msg, sig interface{}) *gomock.Call {
+func (mr *MockvrfVerifierMockRecorder) Verify(nodeID, msg, sig interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Verify", reflect.TypeOf((*MockvrfVerifier)(nil).Verify), d, nodeID, msg, sig)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Verify", reflect.TypeOf((*MockvrfVerifier)(nil).Verify), nodeID, msg, sig)
 }
 
 // MocknonceFetcher is a mock of nonceFetcher interface.

--- a/hare/eligibility/oracle.go
+++ b/hare/eligibility/oracle.go
@@ -217,7 +217,7 @@ func (o *Oracle) prepareEligibilityCheck(ctx context.Context, layer types.LayerI
 	}
 
 	// validate message
-	if !o.vrfVerifier.Verify(signing.HARE, id, msg, vrfSig) {
+	if !o.vrfVerifier.Verify(id, msg, vrfSig) {
 		logger.With().Debug("eligibility: a node did not pass vrf signature verification",
 			log.FieldNamed("sender_vrf_nonce", nonce),
 		)
@@ -366,7 +366,7 @@ func (o *Oracle) Proof(ctx context.Context, nonce types.VRFPostIndex, layer type
 	if err != nil {
 		return types.EmptyVrfSignature, err
 	}
-	return o.vrfSigner.Sign(signing.HARE, msg), nil
+	return o.vrfSigner.Sign(msg), nil
 }
 
 // Returns a map of all active node IDs in the specified layer id.

--- a/hare/eligibility/oracle.go
+++ b/hare/eligibility/oracle.go
@@ -135,9 +135,9 @@ func New(
 
 //go:generate scalegen -types VrfMessage
 
-// VrfMessage is a verification message.
+// VrfMessage is a verification message. It is also the payload for the signature in `types.HareEligibility`.
 type VrfMessage struct {
-	Type   types.EligibilityType
+	Type   types.EligibilityType // always types.EligibilityHare
 	Nonce  types.VRFPostIndex
 	Beacon types.Beacon
 	Round  uint32

--- a/hare/eligibility/oracle_test.go
+++ b/hare/eligibility/oracle_test.go
@@ -192,7 +192,7 @@ func TestCalcEligibility(t *testing.T) {
 		layer := types.EpochID(5).FirstLayer()
 		miners := createLayerData(t, o.cdb, layer.Sub(defLayersPerEpoch), 5)
 		o.mBeacon.EXPECT().GetBeacon(layer.GetEpoch()).Return(types.RandomBeacon(), nil).Times(1)
-		o.mVerifier.EXPECT().Verify(signing.HARE, gomock.Any(), gomock.Any(), gomock.Any()).Return(false).Times(1)
+		o.mVerifier.EXPECT().Verify(gomock.Any(), gomock.Any(), gomock.Any()).Return(false).Times(1)
 
 		res, err := o.CalcEligibility(context.Background(), layer, 0, 1, miners[0], nonce, types.EmptyVrfSignature)
 		require.NoError(t, err)
@@ -211,7 +211,7 @@ func TestCalcEligibility(t *testing.T) {
 		miners := createActiveSet(t, o.cdb, types.EpochID(4).FirstLayer(), activeSet)
 		o.UpdateActiveSet(5, activeSet)
 		o.mBeacon.EXPECT().GetBeacon(lid.GetEpoch()).Return(types.RandomBeacon(), nil)
-		o.mVerifier.EXPECT().Verify(signing.HARE, gomock.Any(), gomock.Any(), gomock.Any()).Return(true)
+		o.mVerifier.EXPECT().Verify(gomock.Any(), gomock.Any(), gomock.Any()).Return(true)
 		_, err = o.CalcEligibility(context.Background(), lid, 1, 1, miners[0], nonce, types.EmptyVrfSignature)
 		require.NoError(t, err)
 	})
@@ -237,7 +237,7 @@ func TestCalcEligibility(t *testing.T) {
 
 			nonce := types.VRFPostIndex(1)
 			o.mBeacon.EXPECT().GetBeacon(lid.GetEpoch()).Return(beacon, nil).Times(1)
-			o.mVerifier.EXPECT().Verify(signing.HARE, gomock.Any(), gomock.Any(), gomock.Any()).Return(true).Times(1)
+			o.mVerifier.EXPECT().Verify(gomock.Any(), gomock.Any(), gomock.Any()).Return(true).Times(1)
 			res, err := o.CalcEligibility(context.Background(), lid, 1, 10, miners[0], nonce, vrfSig)
 			require.NoError(t, err, vrf)
 			require.Equal(t, exp, res, vrf)
@@ -264,7 +264,7 @@ func TestCalcEligibilityWithSpaceUnit(t *testing.T) {
 		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
 			o := defaultOracle(t)
-			o.mVerifier.EXPECT().Verify(signing.HARE, gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
+			o.mVerifier.EXPECT().Verify(gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 
 			lid := types.EpochID(5).FirstLayer()
 			beacon := types.Beacon{1, 0, 0, 0}
@@ -304,7 +304,7 @@ func BenchmarkOracle_CalcEligibility(b *testing.B) {
 
 	o := defaultOracle(b)
 	o.mBeacon.EXPECT().GetBeacon(gomock.Any()).Return(types.RandomBeacon(), nil).AnyTimes()
-	o.mVerifier.EXPECT().Verify(signing.BEACON_PROPOSAL, gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
+	o.mVerifier.EXPECT().Verify(gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 	o.mNonceFetcher.EXPECT().VRFNonce(gomock.Any(), gomock.Any()).Return(types.VRFPostIndex(1), nil).AnyTimes()
 	numOfMiners := 2000
 	committeeSize := 800

--- a/hare/eligibility/oracle_test.go
+++ b/hare/eligibility/oracle_test.go
@@ -334,7 +334,7 @@ func BenchmarkOracle_CalcEligibility(b *testing.B) {
 
 func Test_VrfSignVerify(t *testing.T) {
 	// eligibility of the proof depends on the identity
-	rng := rand.New(rand.NewSource(1000))
+	rng := rand.New(rand.NewSource(5))
 
 	signer, err := signing.NewEdSigner(signing.WithKeyFromRand(rng))
 	require.NoError(t, err)

--- a/miner/oracle.go
+++ b/miner/oracle.go
@@ -149,7 +149,7 @@ func (o *Oracle) calcEligibilityProofs(atx *types.ActivationTxHeader, epoch type
 		if err != nil {
 			o.log.With().Fatal("failed to serialize VRF msg", log.Err(err))
 		}
-		vrfSig := o.vrfSigner.Sign(signing.HARE, message)
+		vrfSig := o.vrfSigner.Sign(message)
 		eligibleLayer := proposals.CalcEligibleLayer(epoch, o.layersPerEpoch, vrfSig)
 		eligibilityProofs[eligibleLayer] = append(eligibilityProofs[eligibleLayer], types.VotingEligibility{
 			J:   counter,

--- a/miner/oracle_test.go
+++ b/miner/oracle_test.go
@@ -148,7 +148,7 @@ func testMinerOracleAndProposalValidator(t *testing.T, layerSize uint32, layersP
 	ctrl := gomock.NewController(t)
 	mbc := mocks.NewMockBeaconCollector(ctrl)
 	vrfVerifier := proposals.NewMockvrfVerifier(ctrl)
-	vrfVerifier.EXPECT().Verify(signing.HARE, gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
+	vrfVerifier.EXPECT().Verify(gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 
 	nonceFetcher := proposals.NewMocknonceFetcher(ctrl)
 	nonce := types.VRFPostIndex(rand.Uint64())

--- a/proposals/eligibility_validator.go
+++ b/proposals/eligibility_validator.go
@@ -10,7 +10,6 @@ import (
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/datastore"
 	"github.com/spacemeshos/go-spacemesh/log"
-	"github.com/spacemeshos/go-spacemesh/signing"
 	"github.com/spacemeshos/go-spacemesh/sql/ballots"
 	"github.com/spacemeshos/go-spacemesh/system"
 )
@@ -179,7 +178,7 @@ func (v *Validator) CheckEligibility(ctx context.Context, ballot *types.Ballot) 
 		vrfSig := proof.Sig
 
 		beaconStr := beacon.ShortString()
-		if !v.vrfVerifier.Verify(signing.HARE, owned.NodeID, message, vrfSig) {
+		if !v.vrfVerifier.Verify(owned.NodeID, message, vrfSig) {
 			return false, fmt.Errorf("%w: beacon: %v, epoch: %v, counter: %v, vrfSig: %s",
 				errIncorrectVRFSig, beaconStr, epoch, counter, vrfSig,
 			)

--- a/proposals/eligibility_validator_test.go
+++ b/proposals/eligibility_validator_test.go
@@ -104,7 +104,7 @@ func createBallots(tb testing.TB, signer *signing.EdSigner, activeSet types.ATXI
 	for counter := uint32(0); counter < eligibleSlots; counter++ {
 		message, err := SerializeVRFMessage(beacon, epoch, nonce, counter)
 		require.NoError(tb, err)
-		vrfSig := vrfSigner.Sign(signing.HARE, message)
+		vrfSig := vrfSigner.Sign(message)
 		eligibleLayer := CalcEligibleLayer(epoch, layersPerEpoch, vrfSig)
 		if _, exist := eligibilityProofs[eligibleLayer]; !exist {
 			order = append(order, eligibleLayer)
@@ -353,7 +353,7 @@ func TestCheckEligibility_InvalidOrder(t *testing.T) {
 	require.Len(t, rb.EligibilityProofs, 2)
 	rb.EligibilityProofs[0], rb.EligibilityProofs[1] = rb.EligibilityProofs[1], rb.EligibilityProofs[0]
 
-	tv.mvrf.EXPECT().Verify(signing.HARE, gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
+	tv.mvrf.EXPECT().Verify(gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 	tv.mNonce.EXPECT().VRFNonce(gomock.Any(), gomock.Any()).Return(types.VRFPostIndex(1), nil).Times(1)
 
 	eligible, err := tv.CheckEligibility(context.Background(), rb)
@@ -363,7 +363,7 @@ func TestCheckEligibility_InvalidOrder(t *testing.T) {
 	rb.EligibilityProofs[0], rb.EligibilityProofs[1] = rb.EligibilityProofs[1], rb.EligibilityProofs[0]
 	rb.EligibilityProofs = append(rb.EligibilityProofs, types.VotingEligibility{J: 2})
 
-	tv.mvrf.EXPECT().Verify(signing.BEACON_PROPOSAL, gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
+	tv.mvrf.EXPECT().Verify(gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 	tv.mNonce.EXPECT().VRFNonce(gomock.Any(), gomock.Any()).Return(types.VRFPostIndex(1), nil).Times(1)
 
 	eligible, err = tv.CheckEligibility(context.Background(), rb)
@@ -385,7 +385,7 @@ func TestCheckEligibility_BadVRFSignature(t *testing.T) {
 
 	b := blts[1]
 	b.EligibilityProofs[0].Sig = types.RandomVrfSignature()
-	tv.mvrf.EXPECT().Verify(signing.HARE, gomock.Any(), gomock.Any(), b.EligibilityProofs[0].Sig).Return(false)
+	tv.mvrf.EXPECT().Verify(gomock.Any(), gomock.Any(), b.EligibilityProofs[0].Sig).Return(false)
 	tv.mNonce.EXPECT().VRFNonce(gomock.Any(), gomock.Any()).Return(types.VRFPostIndex(1), nil).Times(1)
 
 	eligible, err := tv.CheckEligibility(context.Background(), b)
@@ -407,7 +407,7 @@ func TestCheckEligibility_IncorrectLayerIndex(t *testing.T) {
 
 	b := blts[1]
 	b.EligibilityProofs[0].Sig = types.RandomVrfSignature()
-	tv.mvrf.EXPECT().Verify(signing.HARE, gomock.Any(), gomock.Any(), b.EligibilityProofs[0].Sig).Return(false)
+	tv.mvrf.EXPECT().Verify(gomock.Any(), gomock.Any(), b.EligibilityProofs[0].Sig).Return(false)
 	tv.mNonce.EXPECT().VRFNonce(gomock.Any(), gomock.Any()).Return(types.VRFPostIndex(1), nil).Times(1)
 
 	eligible, err := tv.CheckEligibility(context.Background(), b)
@@ -439,7 +439,7 @@ func TestCheckEligibility(t *testing.T) {
 		require.NoError(t, err)
 		weightPer := fixed.DivUint64(hdr.GetWeight(), uint64(eligibleSlots))
 		tv.mbc.EXPECT().ReportBeaconFromBallot(epoch, b, beacon, weightPer).Times(1)
-		tv.mvrf.EXPECT().Verify(signing.HARE, gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
+		tv.mvrf.EXPECT().Verify(gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 		tv.mNonce.EXPECT().VRFNonce(gomock.Any(), gomock.Any()).Return(types.VRFPostIndex(1), nil).Times(1)
 		got, err := tv.CheckEligibility(context.Background(), b)
 		require.NoError(t, err)

--- a/proposals/interface.go
+++ b/proposals/interface.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
-	"github.com/spacemeshos/go-spacemesh/signing"
 	"github.com/spacemeshos/go-spacemesh/tortoise"
 )
 
@@ -26,7 +25,7 @@ type ballotDecoder interface {
 }
 
 type vrfVerifier interface {
-	Verify(signing.Domain, types.NodeID, []byte, types.VrfSignature) bool
+	Verify(types.NodeID, []byte, types.VrfSignature) bool
 }
 
 type nonceFetcher interface {

--- a/proposals/mocks.go
+++ b/proposals/mocks.go
@@ -10,7 +10,6 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	types "github.com/spacemeshos/go-spacemesh/common/types"
-	signing "github.com/spacemeshos/go-spacemesh/signing"
 	tortoise "github.com/spacemeshos/go-spacemesh/tortoise"
 )
 
@@ -194,17 +193,17 @@ func (m *MockvrfVerifier) EXPECT() *MockvrfVerifierMockRecorder {
 }
 
 // Verify mocks base method.
-func (m *MockvrfVerifier) Verify(arg0 signing.Domain, arg1 types.NodeID, arg2 []byte, arg3 types.VrfSignature) bool {
+func (m *MockvrfVerifier) Verify(arg0 types.NodeID, arg1 []byte, arg2 types.VrfSignature) bool {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Verify", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "Verify", arg0, arg1, arg2)
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
 // Verify indicates an expected call of Verify.
-func (mr *MockvrfVerifierMockRecorder) Verify(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockvrfVerifierMockRecorder) Verify(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Verify", reflect.TypeOf((*MockvrfVerifier)(nil).Verify), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Verify", reflect.TypeOf((*MockvrfVerifier)(nil).Verify), arg0, arg1, arg2)
 }
 
 // MocknonceFetcher is a mock of nonceFetcher interface.

--- a/proposals/util.go
+++ b/proposals/util.go
@@ -17,9 +17,9 @@ var (
 
 //go:generate scalegen -types VrfMessage
 
-// VrfMessage is a verification message.
+// VrfMessage is a verification message. It is the payload for the signature in `VotingEligibility`.
 type VrfMessage struct {
-	Type    types.EligibilityType
+	Type    types.EligibilityType // always types.EligibilityVoting
 	Beacon  types.Beacon
 	Epoch   types.EpochID
 	Nonce   types.VRFPostIndex

--- a/proposals/util_test.go
+++ b/proposals/util_test.go
@@ -59,7 +59,7 @@ func TestComputeWeightPerEligibility(t *testing.T) {
 func TestComputeWeightPerEligibility_EmptyRefBallotID(t *testing.T) {
 	types.SetLayersPerEpoch(layersPerEpoch)
 	signer, err := signing.NewEdSigner(
-		signing.WithKeyFromRand(rand.New(rand.NewSource(1000))),
+		signing.WithKeyFromRand(rand.New(rand.NewSource(1001))),
 	)
 	require.NoError(t, err)
 	beacon := types.Beacon{1, 1, 1}
@@ -76,7 +76,7 @@ func TestComputeWeightPerEligibility_EmptyRefBallotID(t *testing.T) {
 func TestComputeWeightPerEligibility_FailToGetRefBallot(t *testing.T) {
 	types.SetLayersPerEpoch(layersPerEpoch)
 	signer, err := signing.NewEdSigner(
-		signing.WithKeyFromRand(rand.New(rand.NewSource(1000))),
+		signing.WithKeyFromRand(rand.New(rand.NewSource(1001))),
 	)
 	require.NoError(t, err)
 	beacon := types.Beacon{1, 1, 1}

--- a/signing/signer.go
+++ b/signing/signer.go
@@ -19,7 +19,6 @@ const (
 	ATX Domain = iota
 	BEACON_FIRST_MSG
 	BEACON_FOLLOWUP_MSG
-	BEACON_PROPOSAL
 	BALLOT
 	HARE
 	POET
@@ -34,8 +33,6 @@ func (d Domain) String() string {
 		return "BEACON_FIRST_MSG"
 	case BEACON_FOLLOWUP_MSG:
 		return "BEACON_FOLLOWUP_MSG"
-	case BEACON_PROPOSAL:
-		return "BEACON_PROPOSAL"
 	case BALLOT:
 		return "BALLOT"
 	case HARE:

--- a/signing/signer.go
+++ b/signing/signer.go
@@ -16,12 +16,14 @@ import (
 type Domain byte
 
 const (
-	ATX Domain = iota
-	BEACON_FIRST_MSG
-	BEACON_FOLLOWUP_MSG
-	BALLOT
-	HARE
-	POET
+	ATX Domain = 0
+
+	BALLOT = 2
+	HARE   = 3
+	POET   = 4
+
+	BEACON_FIRST_MSG    = 10
+	BEACON_FOLLOWUP_MSG = 11
 )
 
 // String returns the string representation of a domain.
@@ -29,16 +31,16 @@ func (d Domain) String() string {
 	switch d {
 	case ATX:
 		return "ATX"
-	case BEACON_FIRST_MSG:
-		return "BEACON_FIRST_MSG"
-	case BEACON_FOLLOWUP_MSG:
-		return "BEACON_FOLLOWUP_MSG"
 	case BALLOT:
 		return "BALLOT"
 	case HARE:
 		return "HARE"
 	case POET:
 		return "POET"
+	case BEACON_FIRST_MSG:
+		return "BEACON_FIRST_MSG"
+	case BEACON_FOLLOWUP_MSG:
+		return "BEACON_FOLLOWUP_MSG"
 	default:
 		return "UNKNOWN"
 	}

--- a/signing/vrf.go
+++ b/signing/vrf.go
@@ -14,10 +14,7 @@ type VRFSigner struct {
 }
 
 // Sign signs a message for VRF purposes.
-func (s VRFSigner) Sign(d Domain, m []byte) types.VrfSignature {
-	msg := make([]byte, 0, 1+len(m))
-	msg = append(msg, byte(d))
-	msg = append(msg, m...)
+func (s VRFSigner) Sign(msg []byte) types.VrfSignature {
 	return *(*[types.VrfSignatureSize]byte)(ecvrf.Prove(s.privateKey, msg))
 }
 
@@ -36,22 +33,19 @@ func (s VRFSigner) LittleEndian() bool {
 	return true
 }
 
-type VRFVerifier func(Domain, types.NodeID, []byte, types.VrfSignature) bool
+type VRFVerifier func(types.NodeID, []byte, types.VrfSignature) bool
 
 func NewVRFVerifier() VRFVerifier {
 	return VRFVerify
 }
 
 // Verify verifies that a signature matches public key and message.
-func (v VRFVerifier) Verify(d Domain, nodeID types.NodeID, msg []byte, sig types.VrfSignature) bool {
-	return v(d, nodeID, msg, sig)
+func (v VRFVerifier) Verify(nodeID types.NodeID, msg []byte, sig types.VrfSignature) bool {
+	return v(nodeID, msg, sig)
 }
 
 // VRFVerify verifies that a signature matches public key and message.
-func VRFVerify(d Domain, nodeID types.NodeID, m []byte, sig types.VrfSignature) bool {
-	msg := make([]byte, 0, 1+len(m))
-	msg = append(msg, byte(d))
-	msg = append(msg, m...)
+func VRFVerify(nodeID types.NodeID, msg []byte, sig types.VrfSignature) bool {
 	valid, _ := ecvrf.Verify(nodeID.Bytes(), sig[:], msg)
 	return valid
 }

--- a/signing/vrf_test.go
+++ b/signing/vrf_test.go
@@ -17,10 +17,10 @@ func Fuzz_VRFSignAndVerify(f *testing.F) {
 		vrfSig, err := edSig.VRFSigner()
 		require.NoError(t, err, "failed to create VRF signer")
 
-		signature := vrfSig.Sign(HARE, message)
+		signature := vrfSig.Sign(message)
 		require.NoError(t, err, "failed to sign message")
 
-		ok := VRFVerify(HARE, edSig.NodeID(), message, signature)
+		ok := VRFVerify(edSig.NodeID(), message, signature)
 		require.True(t, ok, "failed to verify VRF signature")
 	})
 }
@@ -39,10 +39,10 @@ func Test_VRFSignAndVerify(t *testing.T) {
 	require.NoError(t, err, "failed to create VRF signer")
 
 	message := []byte("hello world")
-	signature := vrfSig.Sign(HARE, message)
+	signature := vrfSig.Sign(message)
 
 	vrfVerify := NewVRFVerifier()
-	ok := vrfVerify.Verify(HARE, signer.NodeID(), message, signature)
+	ok := vrfVerify.Verify(signer.NodeID(), message, signature)
 	require.True(t, ok, "failed to verify VRF signature")
 }
 
@@ -69,21 +69,18 @@ func Test_VRFVerifier(t *testing.T) {
 	require.NoError(t, err, "failed to create VRF signer")
 
 	// Act & Assert
-	sig := vrfSig.Sign(HARE, []byte("hello world"))
+	sig := vrfSig.Sign([]byte("hello world"))
 
-	ok := VRFVerify(HARE, signer.NodeID(), []byte("hello world"), sig)
+	ok := VRFVerify(signer.NodeID(), []byte("hello world"), sig)
 	require.True(t, ok, "failed to verify VRF signature")
 
-	ok = VRFVerify(HARE, signer.NodeID(), []byte("different message"), sig)
-	require.False(t, ok, "VRF signature should not be verified")
-
-	ok = VRFVerify(ATX, signer.NodeID(), []byte("hello world"), sig)
+	ok = VRFVerify(signer.NodeID(), []byte("different message"), sig)
 	require.False(t, ok, "VRF signature should not be verified")
 
 	var sig2 types.VrfSignature
 	copy(sig2[:], sig[:])
 	sig2[0] = ^sig2[0] // flip all bits of first byte in the signature
-	ok = VRFVerify(HARE, signer.NodeID(), []byte("hello world"), sig2)
+	ok = VRFVerify(signer.NodeID(), []byte("hello world"), sig2)
 	require.False(t, ok, "VRF signature should not be verified")
 }
 
@@ -103,7 +100,7 @@ func Test_VRF_LSB_evenly_distributed(t *testing.T) {
 		_, err := rand.Read(msg)
 		require.NoError(t, err, "failed to read random bytes")
 
-		sig := vrfSig.Sign(HARE, msg)
+		sig := vrfSig.Sign(msg)
 		lsb[sig.LSB()&1]++
 	}
 


### PR DESCRIPTION
## Motivation
Closes #4274 

## Changes
- Reverts the addition of a domain byte to VRFSignatures.
- Ensure that VRFSignatures in `beacon` contain a unique enum value so they can uniquely be decoded and verified

## Test Plan
- Revert tests that were changed before.

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
