### PR TITLE
[Merged by Bors] - Fix release workflow: move git checkout before reading go.mod

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,9 @@ jobs:
             echo "OUTNAME=${{ runner.os }}" >> $GITHUB_ENV
           fi
 
+      - name: Check out Git repository
+        uses: actions/checkout@v3
+
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
@@ -49,9 +52,6 @@ jobs:
         shell: bash
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
-
-      - name: Check out Git repository
-        uses: actions/checkout@v3
 
       - name: Read version.txt
         id: version


### PR DESCRIPTION
## Motivation
No issue. The bug was introduced in #4451 

## Changes
Just moving `actions/checkout` step before installing go ;)

## Proofs that it works
- before the fix: https://github.com/spacemeshos/go-spacemesh/actions/runs/5184781196
- after the fix: https://github.com/spacemeshos/go-spacemesh/actions/runs/5187132323
