### PR TITLE
[Merged by Bors] - p2p: set prologue to a unique genesis id and latest set genesis

### DIFF
--- a/fetch/fetch_test.go
+++ b/fetch/fetch_test.go
@@ -327,13 +327,13 @@ func TestFetch_PeerDroppedWhenMessageResultsInValidationReject(t *testing.T) {
 
 	// Good host
 	genesisID := types.Hash20{}
-	h, err := p2p.New(ctx, lg, p2pconf, genesisID)
+	h, err := p2p.New(ctx, lg, p2pconf, genesisID, []byte{})
 	require.NoError(t, err)
 	t.Cleanup(func() { h.Close() })
 
 	// Bad host, will send a message that results in validation reject
 	p2pconf.DataDir = t.TempDir()
-	badPeerHost, err := p2p.New(ctx, lg, p2pconf, genesisID)
+	badPeerHost, err := p2p.New(ctx, lg, p2pconf, genesisID, []byte{})
 	require.NoError(t, err)
 	t.Cleanup(func() { badPeerHost.Close() })
 

--- a/node/node.go
+++ b/node/node.go
@@ -1274,7 +1274,12 @@ func (app *App) Start(ctx context.Context) error {
 	p2plog := app.addLogger(P2PLogger, lg)
 	// if addLogger won't add a level we will use a default 0 (info).
 	cfg.LogLevel = app.getLevel(P2PLogger)
+	prologue := fmt.Sprintf("%x-%v",
+		app.Config.Genesis.GenesisID(),
+		types.GetEffectiveGenesis(),
+	)
 	app.host, err = p2p.New(ctx, p2plog, cfg, app.Config.Genesis.GenesisID(),
+		[]byte(prologue),
 		p2p.WithNodeReporter(events.ReportNodeStatusUpdate),
 	)
 	if err != nil {

--- a/p2p/host.go
+++ b/p2p/host.go
@@ -7,9 +7,12 @@ import (
 
 	lp2plog "github.com/ipfs/go-log/v2"
 	"github.com/libp2p/go-libp2p"
+	"github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/libp2p/go-libp2p/core/protocol"
 	"github.com/libp2p/go-libp2p/p2p/host/peerstore/pstoremem"
 	"github.com/libp2p/go-libp2p/p2p/muxer/yamux"
 	"github.com/libp2p/go-libp2p/p2p/net/connmgr"
+	tptu "github.com/libp2p/go-libp2p/p2p/net/upgrader"
 	"github.com/libp2p/go-libp2p/p2p/security/noise"
 	"github.com/libp2p/go-libp2p/p2p/transport/tcp"
 
@@ -73,7 +76,13 @@ func New(_ context.Context, logger log.Log, cfg Config, genesisID types.Hash20, 
 		libp2p.DisableRelay(),
 
 		libp2p.Transport(tcp.NewTCPTransport),
-		libp2p.Security(noise.ID, noise.New),
+		libp2p.Security(noise.ID, func(id protocol.ID, privkey crypto.PrivKey, muxers []tptu.StreamMuxer) (*noise.SessionTransport, error) {
+			tp, err := noise.New(id, privkey, muxers)
+			if err != nil {
+				return nil, err
+			}
+			return tp.WithSessionOptions(noise.Prologue(genesisID[:]))
+		}),
 		libp2p.Muxer("/yamux/1.0.0", &streamer),
 
 		libp2p.ConnectionManager(cm),

--- a/p2p/host.go
+++ b/p2p/host.go
@@ -52,7 +52,7 @@ type Config struct {
 }
 
 // New initializes libp2p host configured for spacemesh.
-func New(_ context.Context, logger log.Log, cfg Config, genesisID types.Hash20, opts ...Opt) (*Host, error) {
+func New(_ context.Context, logger log.Log, cfg Config, genesisID types.Hash20, prologue []byte, opts ...Opt) (*Host, error) {
 	logger.Info("starting libp2p host with config %+v", cfg)
 	key, err := EnsureIdentity(cfg.DataDir)
 	if err != nil {
@@ -81,7 +81,7 @@ func New(_ context.Context, logger log.Log, cfg Config, genesisID types.Hash20, 
 			if err != nil {
 				return nil, err
 			}
-			return tp.WithSessionOptions(noise.Prologue(genesisID[:]))
+			return tp.WithSessionOptions(noise.Prologue(prologue))
 		}),
 		libp2p.Muxer("/yamux/1.0.0", &streamer),
 

--- a/p2p/host_test.go
+++ b/p2p/host_test.go
@@ -1,0 +1,31 @@
+package p2p
+
+import (
+	"context"
+	"testing"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/stretchr/testify/require"
+
+	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/log/logtest"
+)
+
+func TestPrologue(t *testing.T) {
+	cfg1 := DefaultConfig()
+	cfg1.DataDir = t.TempDir()
+	cfg1.Listen = "/ip4/127.0.0.1/tcp/0"
+	cfg2 := DefaultConfig()
+	cfg2.DataDir = t.TempDir()
+	cfg2.Listen = "/ip4/127.0.0.1/tcp/0"
+
+	h1, err := New(context.Background(), logtest.New(t), cfg1, types.Hash20{1}, []byte("red"))
+	require.NoError(t, err)
+	h2, err := New(context.Background(), logtest.New(t), cfg2, types.Hash20{1}, []byte("blue"))
+	require.NoError(t, err)
+	err = h1.Connect(context.Background(), peer.AddrInfo{
+		ID:    h2.ID(),
+		Addrs: h2.Addrs(),
+	})
+	require.ErrorContains(t, err, "failed to negotiate security protocol")
+}


### PR DESCRIPTION
in noise protocol there is an option to set [prologue](https://noiseprotocol.org/noise.html#prologue).

> Noise protocols have a prologue input which allows arbitrary data to be hashed into the h variable. If both parties do not provide identical prologue data, the handshake will fail due to a decryption error. This is useful when the parties engaged in negotiation prior to the handshake and want to ensure they share identical views of that negotiation.

this is not exactly our use case, but we don't want to establish secure connection if peers don't need to speak to each other.