### PR TITLE
[Merged by Bors] - node: standalone one node network

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,17 @@ Before building we need to set up the golang environment. Do this by running:
 make install
 ```
 
+### How to run standalone node?
+
+After you got a binary standalone fully functional network can be launched
+with a simple command:
+
+> ./build/go-spacemesh --preset=standalone --genesis-time=2023-06-08T5:30:00.000Z
+
+Network will use short epochs (1 minute), and 10 layers within the epoch (each 6s). Poet is launched in the same process in this mode. So expect that it will periodically hog 1 core. Minimal smeshig is enabled in order for consensus to work.
+
+Public GRPC API are launched on 0.0.0.0:10092. Private - 0.0.0.0:10093.
+
 ### Building
 
 To build `go-spacemesh` for your current system architecture, from the project root directory, use:

--- a/config/config.go
+++ b/config/config.go
@@ -74,6 +74,7 @@ func (cfg *Config) DataDir() string {
 type BaseConfig struct {
 	DataDirParent string `mapstructure:"data-folder"`
 	FileLock      string `mapstructure:"filelock"`
+	Standalone    bool   `mapstructure:"standalone"`
 
 	ConfigFile string `mapstructure:"config"`
 

--- a/config/presets/standalone.go
+++ b/config/presets/standalone.go
@@ -1,0 +1,83 @@
+package presets
+
+import (
+	"math/big"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/spacemeshos/post/initialization"
+
+	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/config"
+)
+
+func init() {
+	register("standalone", standalone())
+}
+
+func standalone() config.Config {
+	conf := config.DefaultConfig()
+	conf.Address = types.DefaultTestAddressConfig()
+
+	conf.Standalone = true
+	conf.DataDirParent = filepath.Join(os.TempDir(), "spacemesh")
+	conf.FileLock = filepath.Join(conf.DataDirParent, "LOCK")
+
+	conf.HARE.N = 800
+	conf.HARE.ExpectedLeaders = 10
+	conf.HARE.LimitConcurrent = 2
+	conf.HARE.LimitIterations = 2
+	conf.HARE.RoundDuration = 1 * time.Second
+	conf.HARE.WakeupDelta = 1 * time.Second
+
+	conf.Genesis = &config.GenesisConfig{
+		ExtraData: "standalone",
+	}
+
+	conf.LayerAvgSize = 50
+	conf.LayerDuration = 6 * time.Second
+	conf.Sync.Interval = 3 * time.Second
+	conf.LayersPerEpoch = 10
+
+	conf.Tortoise.Hdist = 2
+	conf.Tortoise.Zdist = 2
+
+	conf.HareEligibility.ConfidenceParam = 2
+
+	conf.POST.K1 = 12
+	conf.POST.K2 = 4
+	conf.POST.K3 = 4
+	conf.POST.LabelsPerUnit = 128
+	conf.POST.MaxNumUnits = 4
+	conf.POST.MinNumUnits = 2
+
+	conf.SMESHING.CoinbaseAccount = types.GenerateAddress([]byte("1")).String()
+	conf.SMESHING.Start = true
+	conf.SMESHING.Opts.ProviderID = int(initialization.CPUProviderID())
+	conf.SMESHING.Opts.NumUnits = 2
+	conf.SMESHING.Opts.Throttle = true
+	conf.SMESHING.Opts.DataDir = conf.DataDirParent
+
+	conf.Beacon.Kappa = 40
+	conf.Beacon.Theta = big.NewRat(1, 4)
+	conf.Beacon.FirstVotingRoundDuration = 10 * time.Second
+	conf.Beacon.GracePeriodDuration = 30 * time.Second
+	conf.Beacon.ProposalDuration = 2 * time.Second
+	conf.Beacon.VotingRoundDuration = 2 * time.Second
+	conf.Beacon.WeakCoinRoundDuration = 2 * time.Second
+	conf.Beacon.RoundsNumber = 4
+	conf.Beacon.BeaconSyncWeightUnits = 10
+	conf.Beacon.VotesLimit = 100
+
+	conf.PoETServers = []string{"http://0.0.0.0:10010"}
+	conf.POET.GracePeriod = 10 * time.Second
+	conf.POET.CycleGap = 30 * time.Second
+	conf.POET.PhaseShift = 30 * time.Second
+
+	conf.P2P.DisableNatPort = true
+
+	conf.API.PublicListener = "0.0.0.0:10092"
+	conf.API.PrivateListener = "0.0.0.0:10093"
+	return conf
+}

--- a/log/zap.go
+++ b/log/zap.go
@@ -183,6 +183,10 @@ func Context(ctx context.Context) Field {
 	return Field(zap.Inline(&marshalledContext{Context: ctx}))
 }
 
+func Any(key string, value any) Field {
+	return Field(zap.Any(key, value))
+}
+
 type marshalledContext struct {
 	context.Context
 }

--- a/node/node.go
+++ b/node/node.go
@@ -401,6 +401,13 @@ func (app *App) introduction() {
 
 // Initialize sets up an exit signal, logging and checks the clock, returns error if clock is not in sync.
 func (app *App) Initialize() (err error) {
+	lockdir := filepath.Dir(app.Config.FileLock)
+	if _, err := os.Stat(lockdir); errors.Is(err, os.ErrNotExist) {
+		err := os.Mkdir(lockdir, os.ModePerm)
+		if err != nil {
+			return fmt.Errorf("creating dir %s for lock %s: %w", lockdir, app.Config.FileLock, err)
+		}
+	}
 	fl := flock.New(app.Config.FileLock)
 	locked, err := fl.TryLock()
 	if err != nil {

--- a/node/node.go
+++ b/node/node.go
@@ -710,6 +710,7 @@ func (app *App) initServices(ctx context.Context, poetClients []activation.PoetP
 		SyncCertDistance: app.Config.Tortoise.Hdist,
 		MaxHashesInReq:   100,
 		MaxStaleDuration: time.Hour,
+		Standalone:       app.Config.Standalone,
 	}
 	newSyncer := syncer.NewSyncer(app.cachedDB, app.clock, beaconProtocol, msh, trtl, fetcher, patrol, app.certifier,
 		syncer.WithConfig(syncerConf),

--- a/node/node.go
+++ b/node/node.go
@@ -904,7 +904,7 @@ func (app *App) launchStandalone(ctx context.Context) error {
 	genesis := app.Config.Genesis.GenesisID()
 	copy(value[:], genesis[:])
 	epoch := types.GetEffectiveGenesis().GetEpoch() + 1
-	app.log.With().Warning("using standalone mode for bootstarapping beacon",
+	app.log.With().Warning("using standalone mode for bootstrapping beacon",
 		log.Uint32("epoch", epoch.Uint32()),
 		log.Stringer("beacon", value),
 	)

--- a/node/node.go
+++ b/node/node.go
@@ -21,6 +21,8 @@ import (
 	grpctags "github.com/grpc-ecosystem/go-grpc-middleware/tags"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pyroscope-io/pyroscope/pkg/agent/profiler"
+	poetconfig "github.com/spacemeshos/poet/config"
+	"github.com/spacemeshos/poet/server"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -66,8 +68,6 @@ import (
 	"github.com/spacemeshos/go-spacemesh/timesync/peersync"
 	"github.com/spacemeshos/go-spacemesh/tortoise"
 	"github.com/spacemeshos/go-spacemesh/txs"
-	poetconfig "github.com/spacemeshos/poet/config"
-	"github.com/spacemeshos/poet/server"
 )
 
 const (

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -884,16 +884,24 @@ func TestGenesisConfig(t *testing.T) {
 }
 
 func TestFlock(t *testing.T) {
-	app := New()
-	app.Config = getTestDefaultConfig(t)
+	t.Run("sanity", func(t *testing.T) {
+		app := New()
+		app.Config = getTestDefaultConfig(t)
 
-	require.NoError(t, app.Initialize())
-	app1 := *app
-	require.ErrorContains(t, app1.Initialize(), "only one spacemesh instance")
-	app.Cleanup(context.Background())
-	require.NoError(t, app.Initialize())
-	require.NoError(t, os.Remove(filepath.Join(app.Config.FileLock)))
-	require.NoError(t, app.Initialize())
+		require.NoError(t, app.Initialize())
+		app1 := *app
+		require.ErrorContains(t, app1.Initialize(), "only one spacemesh instance")
+		app.Cleanup(context.Background())
+		require.NoError(t, app.Initialize())
+		require.NoError(t, os.Remove(filepath.Join(app.Config.FileLock)))
+		require.NoError(t, app.Initialize())
+	})
+	t.Run("dir doesn't exist", func(t *testing.T) {
+		app := New()
+		app.Config = getTestDefaultConfig(t)
+		app.Config.FileLock = filepath.Join(t.TempDir(), "newdir", "LOCK")
+		require.NoError(t, app.Initialize())
+	})
 }
 
 func getTestDefaultConfig(tb testing.TB) *config.Config {

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -387,6 +387,7 @@ func (s *Syncer) synchronize(ctx context.Context) bool {
 	syncFunc := func() bool {
 		if s.cfg.Standalone {
 			s.setLastSyncedLayer(s.ticker.CurrentLayer().Sub(1))
+			s.setATXSynced()
 			return true
 		}
 		if len(s.dataFetcher.GetPeers()) == 0 {

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -27,6 +27,7 @@ type Config struct {
 	SyncCertDistance uint32
 	MaxHashesInReq   uint32
 	MaxStaleDuration time.Duration
+	Standalone       bool
 }
 
 // DefaultConfig for the syncer.
@@ -384,6 +385,10 @@ func (s *Syncer) synchronize(ctx context.Context) bool {
 	// https://github.com/spacemeshos/go-spacemesh/issues/3970
 	// https://github.com/spacemeshos/go-spacemesh/issues/3987
 	syncFunc := func() bool {
+		if s.cfg.Standalone {
+			s.setLastSyncedLayer(s.ticker.CurrentLayer().Sub(1))
+			return true
+		}
 		if len(s.dataFetcher.GetPeers()) == 0 {
 			return false
 		}


### PR DESCRIPTION
to launch a single node network, compile go-spacemesh, launch app with standalone preset `./build/go-spacemesh --preset=standalone --genesis-time=2023-06-08T5:22:00.000Z`

this will launch both go-spacemesh and poet in the same process. epoch duration will be 1 minute, with a layer of 6s.
state will be written to /tmp/spacemesh on linux and similar temporary directories on other platforms.

public grpc - 0.0.0.0:10092, private grpc - 0.0.0.0:10093

minimal size smeshing will be enabled, just in order for consensus to work  