### PR TITLE
[Merged by Bors] - generate block right away in the non-optimistic case

### DIFF
--- a/blocks/generator_test.go
+++ b/blocks/generator_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/datastore"
 	"github.com/spacemeshos/go-spacemesh/genvm/sdk/wallet"
 	"github.com/spacemeshos/go-spacemesh/hare"
+	"github.com/spacemeshos/go-spacemesh/hare/eligibility"
 	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/log/logtest"
 	"github.com/spacemeshos/go-spacemesh/signing"
@@ -168,17 +169,15 @@ func createProposals(
 		if to > len(txIDs) {
 			to = len(txIDs)
 		}
-		p := createProposal(t, activeSet, layerID, meshHash, activeSet[i], signers[i], txIDs[from:to], 1)
-		p.ActiveSet = activeSet
+		p := createProposal(t, db, activeSet, layerID, meshHash, activeSet[i], signers[i], txIDs[from:to], 1)
 		plist = append(plist, p)
-		require.NoError(t, proposals.Add(db, p))
-		require.NoError(t, ballots.Add(db, &p.Ballot))
 	}
 	return plist
 }
 
 func createProposal(
 	t *testing.T,
+	db sql.Executor,
 	activeSet types.ATXIDList,
 	lid types.LayerID,
 	meshHash types.Hash32,
@@ -207,6 +206,8 @@ func createProposal(
 	p.Signature = signer.Sign(signing.BALLOT, p.SignedBytes())
 	p.SmesherID = signer.NodeID()
 	require.NoError(t, p.Initialize())
+	require.NoError(t, ballots.Add(db, &p.Ballot))
+	require.NoError(t, proposals.Add(db, p))
 	return p
 }
 
@@ -239,8 +240,8 @@ func Test_SerialProcessing(t *testing.T) {
 	wg.Add(numLayers)
 	for i := uint32(1); i <= uint32(numLayers); i++ {
 		lid := types.LayerID(i)
-		tg.mockCert.EXPECT().RegisterForCert(gomock.Any(), lid, types.EmptyBlockID).Return(nil)
-		tg.mockCert.EXPECT().CertifyIfEligible(gomock.Any(), gomock.Any(), lid, types.EmptyBlockID).Return(nil)
+		tg.mockCert.EXPECT().RegisterForCert(gomock.Any(), lid, types.EmptyBlockID)
+		tg.mockCert.EXPECT().CertifyIfEligible(gomock.Any(), gomock.Any(), lid, types.EmptyBlockID)
 		tg.mockMesh.EXPECT().ProcessLayerPerHareOutput(gomock.Any(), lid, types.EmptyBlockID, false).Do(
 			func(_ context.Context, gotL types.LayerID, gotB types.BlockID, _ bool) error {
 				require.NoError(t, layers.SetApplied(tg.cdb, gotL, gotB))
@@ -270,7 +271,7 @@ func Test_SerialProcessing(t *testing.T) {
 	wg.Wait()
 }
 
-func Test_processHareOutput(t *testing.T) {
+func Test_run(t *testing.T) {
 	numTXs := 1000
 	for _, tc := range []struct {
 		desc       string
@@ -300,6 +301,7 @@ func Test_processHareOutput(t *testing.T) {
 			tg := createTestGenerator(t)
 			tg.cfg.BlockGasLimit = tc.gasLimit
 			layerID := types.GetEffectiveGenesis().Add(100)
+			require.NoError(t, layers.SetApplied(tg.cdb, layerID-1, types.EmptyBlockID))
 			var meshHash types.Hash32
 			if tc.optimistic {
 				meshHash = types.RandomHash()
@@ -312,7 +314,7 @@ func Test_processHareOutput(t *testing.T) {
 			activeSet := types.ToATXIDs(atxes)
 			plist := createProposals(t, tg.cdb, layerID, meshHash, signers, activeSet, txIDs)
 			pids := types.ToProposalIDs(plist)
-			tg.mockFetch.EXPECT().GetProposals(gomock.Any(), pids).Return(nil)
+			tg.mockFetch.EXPECT().GetProposals(gomock.Any(), pids)
 
 			var block *types.Block
 			if tc.optimistic {
@@ -363,136 +365,253 @@ func Test_processHareOutput(t *testing.T) {
 					require.Equal(t, block.ID(), got)
 					return nil
 				})
-			require.NoError(t, tg.processHareOutput(hare.LayerOutput{Ctx: context.Background(), Layer: layerID, Proposals: pids}))
+			tg.mockPatrol.EXPECT().CompleteHare(layerID)
+			tg.Start()
+			tg.hareCh <- hare.LayerOutput{Ctx: context.Background(), Layer: layerID, Proposals: pids}
+			require.Eventually(t, func() bool { return len(tg.hareCh) == 0 }, time.Second, 100*time.Millisecond)
+			tg.Stop()
 		})
 	}
 }
 
-func Test_processHareOutput_corner_cases(t *testing.T) {
+func Test_processHareOutput_EmptyOutput(t *testing.T) {
 	tg := createTestGenerator(t)
 	layerID := types.GetEffectiveGenesis().Add(100)
+	require.NoError(t, layers.SetApplied(tg.cdb, layerID-1, types.EmptyBlockID))
+	tg.Start()
+	tg.mockCert.EXPECT().RegisterForCert(gomock.Any(), layerID, types.EmptyBlockID)
+	tg.mockCert.EXPECT().CertifyIfEligible(gomock.Any(), gomock.Any(), layerID, types.EmptyBlockID)
+	tg.mockMesh.EXPECT().ProcessLayerPerHareOutput(gomock.Any(), layerID, types.EmptyBlockID, false)
+	tg.mockPatrol.EXPECT().CompleteHare(layerID)
+	tg.hareCh <- hare.LayerOutput{Ctx: context.Background(), Layer: layerID}
+	require.Eventually(t, func() bool { return len(tg.hareCh) == 0 }, time.Second, 100*time.Millisecond)
+	tg.Stop()
+}
 
-	t.Run("empty output", func(t *testing.T) {
-		tg.mockCert.EXPECT().RegisterForCert(gomock.Any(), layerID, types.EmptyBlockID).Return(nil)
-		tg.mockCert.EXPECT().CertifyIfEligible(gomock.Any(), gomock.Any(), layerID, types.EmptyBlockID).Return(nil)
-		tg.mockMesh.EXPECT().ProcessLayerPerHareOutput(gomock.Any(), layerID, types.EmptyBlockID, false).Return(nil)
-		require.NoError(t, tg.processHareOutput(hare.LayerOutput{Ctx: context.Background(), Layer: layerID}))
-	})
+func Test_run_FetchFailed(t *testing.T) {
+	tg := createTestGenerator(t)
+	layerID := types.GetEffectiveGenesis().Add(100)
+	require.NoError(t, layers.SetApplied(tg.cdb, layerID-1, types.EmptyBlockID))
+	tg.Start()
+	pids := []types.ProposalID{{1}, {2}, {3}}
+	tg.mockFetch.EXPECT().GetProposals(gomock.Any(), pids).DoAndReturn(
+		func(_ context.Context, _ []types.ProposalID) error {
+			return errors.New("unknown")
+		})
+	tg.hareCh <- hare.LayerOutput{Ctx: context.Background(), Layer: layerID, Proposals: pids}
+	require.Eventually(t, func() bool { return len(tg.hareCh) == 0 }, time.Second, 100*time.Millisecond)
+	tg.Stop()
+}
+
+func Test_run_DiffHasFromConsensus(t *testing.T) {
+	tg := createTestGenerator(t)
+	layerID := types.GetEffectiveGenesis().Add(100)
+	require.NoError(t, layers.SetApplied(tg.cdb, layerID-1, types.EmptyBlockID))
+	tg.Start()
 
 	// create multiple proposals with overlapping TXs
-	numTXs := 1000
-	numProposals := 10
-	txIDs := createAndSaveTxs(t, numTXs, tg.cdb)
-	signers, atxes := createATXs(t, tg.cdb, (layerID.GetEpoch() - 1).FirstLayer(), numProposals)
+	txIDs := createAndSaveTxs(t, 100, tg.cdb)
+	signers, atxes := createATXs(t, tg.cdb, (layerID.GetEpoch() - 1).FirstLayer(), 10)
 	activeSet := types.ToATXIDs(atxes)
 	meshHash := types.RandomHash()
 	plist := createProposals(t, tg.cdb, layerID, meshHash, signers, activeSet, txIDs)
 	pids := types.ToProposalIDs(plist)
+	require.NoError(t, layers.SetMeshHash(tg.cdb, layerID.Sub(1), types.RandomHash()))
 
-	errUnknown := errors.New("unknown")
-	t.Run("fetch failed", func(t *testing.T) {
-		tg.mockFetch.EXPECT().GetProposals(gomock.Any(), pids).Return(errUnknown)
-		require.ErrorIs(t, tg.processHareOutput(hare.LayerOutput{Ctx: context.Background(), Layer: layerID, Proposals: pids}), errUnknown)
-	})
-
-	tg.mockFetch.EXPECT().GetProposals(gomock.Any(), pids).Return(nil).AnyTimes()
-	t.Run("node mesh differ from consensus", func(t *testing.T) {
-		require.NoError(t, layers.SetMeshHash(tg.cdb, layerID.Sub(1), types.RandomHash()))
-		require.ErrorIs(t, tg.processHareOutput(hare.LayerOutput{Ctx: context.Background(), Layer: layerID, Proposals: pids}), errNodeHasBadMeshHash)
-	})
-
-	t.Run("execute failed", func(t *testing.T) {
-		require.NoError(t, layers.SetMeshHash(tg.cdb, layerID.Sub(1), meshHash))
-		tg.mockExec.EXPECT().ExecuteOptimistic(gomock.Any(), layerID, uint64(baseTickHeight), gomock.Any(), gomock.Any()).DoAndReturn(
-			func(_ context.Context, lid types.LayerID, tickHeight uint64, rewards []types.AnyReward, tids []types.TransactionID) (*types.Block, error) {
-				require.Len(t, tids, len(txIDs))
-				return nil, errUnknown
-			})
-		require.ErrorIs(t, tg.processHareOutput(hare.LayerOutput{Ctx: context.Background(), Layer: layerID, Proposals: pids}), errUnknown)
-	})
-
-	block := types.NewExistingBlock(types.BlockID{1, 2, 3}, types.InnerBlock{LayerIndex: layerID})
-	t.Run("failed to add block", func(t *testing.T) {
-		tg.mockExec.EXPECT().ExecuteOptimistic(gomock.Any(), layerID, uint64(baseTickHeight), gomock.Any(), gomock.Any()).Return(block, nil)
-		tg.mockMesh.EXPECT().AddBlockWithTXs(gomock.Any(), gomock.Any()).Return(errUnknown)
-		require.ErrorIs(t, tg.processHareOutput(hare.LayerOutput{Ctx: context.Background(), Layer: layerID, Proposals: pids}), errUnknown)
-	})
-
-	t.Run("failure to register cert ignored", func(t *testing.T) {
-		tg.mockExec.EXPECT().ExecuteOptimistic(gomock.Any(), layerID, uint64(baseTickHeight), gomock.Any(), gomock.Any()).Return(block, nil)
-		tg.mockMesh.EXPECT().AddBlockWithTXs(gomock.Any(), gomock.Any()).Return(nil)
-		tg.mockCert.EXPECT().RegisterForCert(gomock.Any(), layerID, gomock.Any()).Return(errUnknown)
-		tg.mockCert.EXPECT().CertifyIfEligible(gomock.Any(), gomock.Any(), layerID, gomock.Any()).Return(nil)
-		tg.mockMesh.EXPECT().ProcessLayerPerHareOutput(gomock.Any(), layerID, block.ID(), true).Return(nil)
-		require.NoError(t, tg.processHareOutput(hare.LayerOutput{Ctx: context.Background(), Layer: layerID, Proposals: pids}))
-	})
-
-	t.Run("failure to certify ignored", func(t *testing.T) {
-		tg.mockExec.EXPECT().ExecuteOptimistic(gomock.Any(), layerID, uint64(baseTickHeight), gomock.Any(), gomock.Any()).Return(block, nil)
-		tg.mockMesh.EXPECT().AddBlockWithTXs(gomock.Any(), gomock.Any()).Return(nil)
-		tg.mockCert.EXPECT().RegisterForCert(gomock.Any(), layerID, gomock.Any()).Return(nil)
-		tg.mockCert.EXPECT().CertifyIfEligible(gomock.Any(), gomock.Any(), layerID, gomock.Any()).Return(errUnknown)
-		tg.mockMesh.EXPECT().ProcessLayerPerHareOutput(gomock.Any(), layerID, block.ID(), true).Return(nil)
-		require.NoError(t, tg.processHareOutput(hare.LayerOutput{Ctx: context.Background(), Layer: layerID, Proposals: pids}))
-	})
-
-	t.Run("mesh failed to process", func(t *testing.T) {
-		tg.mockExec.EXPECT().ExecuteOptimistic(gomock.Any(), layerID, uint64(baseTickHeight), gomock.Any(), gomock.Any()).Return(block, nil)
-		tg.mockMesh.EXPECT().AddBlockWithTXs(gomock.Any(), block).Return(nil)
-		tg.mockCert.EXPECT().RegisterForCert(gomock.Any(), layerID, block.ID()).Return(nil)
-		tg.mockCert.EXPECT().CertifyIfEligible(gomock.Any(), gomock.Any(), layerID, block.ID()).Return(nil)
-		tg.mockMesh.EXPECT().ProcessLayerPerHareOutput(gomock.Any(), layerID, block.ID(), true).Return(errUnknown)
-		require.ErrorIs(t, tg.processHareOutput(hare.LayerOutput{Ctx: context.Background(), Layer: layerID, Proposals: pids}), errUnknown)
-	})
-
-	t.Run("all good", func(t *testing.T) {
-		tg.mockExec.EXPECT().ExecuteOptimistic(gomock.Any(), layerID, uint64(baseTickHeight), gomock.Any(), gomock.Any()).Return(block, nil)
-		tg.mockMesh.EXPECT().AddBlockWithTXs(gomock.Any(), block).Return(nil)
-		tg.mockCert.EXPECT().RegisterForCert(gomock.Any(), layerID, block.ID()).Return(nil)
-		tg.mockCert.EXPECT().CertifyIfEligible(gomock.Any(), gomock.Any(), layerID, block.ID()).Return(nil)
-		tg.mockMesh.EXPECT().ProcessLayerPerHareOutput(gomock.Any(), layerID, block.ID(), true).Return(nil)
-		require.NoError(t, tg.processHareOutput(hare.LayerOutput{Ctx: context.Background(), Layer: layerID, Proposals: pids}))
-	})
+	tg.mockFetch.EXPECT().GetProposals(gomock.Any(), pids)
+	tg.hareCh <- hare.LayerOutput{Ctx: context.Background(), Layer: layerID, Proposals: pids}
+	require.Eventually(t, func() bool { return len(tg.hareCh) == 0 }, time.Second, 100*time.Millisecond)
+	tg.Stop()
 }
 
-func Test_generateBlock_UnequalHeight(t *testing.T) {
+func Test_run_ExecuteFailed(t *testing.T) {
+	tg := createTestGenerator(t)
+	layerID := types.GetEffectiveGenesis().Add(100)
+	require.NoError(t, layers.SetApplied(tg.cdb, layerID-1, types.EmptyBlockID))
+	tg.Start()
+	txIDs := createAndSaveTxs(t, 100, tg.cdb)
+	signers, atxes := createATXs(t, tg.cdb, (layerID.GetEpoch() - 1).FirstLayer(), 10)
+	activeSet := types.ToATXIDs(atxes)
+	meshHash := types.RandomHash()
+	plist := createProposals(t, tg.cdb, layerID, meshHash, signers, activeSet, txIDs)
+	pids := types.ToProposalIDs(plist)
+	require.NoError(t, layers.SetMeshHash(tg.cdb, layerID.Sub(1), meshHash))
+
+	tg.mockFetch.EXPECT().GetProposals(gomock.Any(), pids).AnyTimes()
+	tg.mockExec.EXPECT().ExecuteOptimistic(gomock.Any(), layerID, uint64(baseTickHeight), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, lid types.LayerID, tickHeight uint64, rewards []types.AnyReward, tids []types.TransactionID) (*types.Block, error) {
+			require.Len(t, tids, len(txIDs))
+			return nil, errors.New("unknown")
+		}).AnyTimes()
+	tg.hareCh <- hare.LayerOutput{Ctx: context.Background(), Layer: layerID, Proposals: pids}
+	require.Eventually(t, func() bool { return len(tg.hareCh) == 0 }, time.Second, 100*time.Millisecond)
+	tg.Stop()
+}
+
+func Test_run_AddBlockFailed(t *testing.T) {
+	tg := createTestGenerator(t)
+	layerID := types.GetEffectiveGenesis().Add(100)
+	require.NoError(t, layers.SetApplied(tg.cdb, layerID-1, types.EmptyBlockID))
+	tg.Start()
+	txIDs := createAndSaveTxs(t, 100, tg.cdb)
+	signers, atxes := createATXs(t, tg.cdb, (layerID.GetEpoch() - 1).FirstLayer(), 10)
+	activeSet := types.ToATXIDs(atxes)
+	meshHash := types.RandomHash()
+	plist := createProposals(t, tg.cdb, layerID, meshHash, signers, activeSet, txIDs)
+	pids := types.ToProposalIDs(plist)
+	require.NoError(t, layers.SetMeshHash(tg.cdb, layerID.Sub(1), meshHash))
+
+	tg.mockFetch.EXPECT().GetProposals(gomock.Any(), pids).AnyTimes()
+	block := types.NewExistingBlock(types.BlockID{1, 2, 3}, types.InnerBlock{LayerIndex: layerID})
+	tg.mockExec.EXPECT().ExecuteOptimistic(gomock.Any(), layerID, uint64(baseTickHeight), gomock.Any(), gomock.Any()).Return(block, nil).AnyTimes()
+	tg.mockMesh.EXPECT().AddBlockWithTXs(gomock.Any(), gomock.Any()).Return(errors.New("unknown")).AnyTimes()
+	tg.hareCh <- hare.LayerOutput{Ctx: context.Background(), Layer: layerID, Proposals: pids}
+	require.Eventually(t, func() bool { return len(tg.hareCh) == 0 }, time.Second, 100*time.Millisecond)
+	tg.Stop()
+}
+
+func Test_run_RegisterCertFailureIgnored(t *testing.T) {
+	tg := createTestGenerator(t)
+	layerID := types.GetEffectiveGenesis().Add(100)
+	require.NoError(t, layers.SetApplied(tg.cdb, layerID-1, types.EmptyBlockID))
+	tg.Start()
+	txIDs := createAndSaveTxs(t, 100, tg.cdb)
+	signers, atxes := createATXs(t, tg.cdb, (layerID.GetEpoch() - 1).FirstLayer(), 10)
+	activeSet := types.ToATXIDs(atxes)
+	meshHash := types.RandomHash()
+	plist := createProposals(t, tg.cdb, layerID, meshHash, signers, activeSet, txIDs)
+	pids := types.ToProposalIDs(plist)
+	require.NoError(t, layers.SetMeshHash(tg.cdb, layerID.Sub(1), meshHash))
+
+	tg.mockFetch.EXPECT().GetProposals(gomock.Any(), pids).AnyTimes()
+	block := types.NewExistingBlock(types.BlockID{1, 2, 3}, types.InnerBlock{LayerIndex: layerID})
+	tg.mockExec.EXPECT().ExecuteOptimistic(gomock.Any(), layerID, uint64(baseTickHeight), gomock.Any(), gomock.Any()).Return(block, nil)
+	tg.mockMesh.EXPECT().AddBlockWithTXs(gomock.Any(), gomock.Any())
+	tg.mockCert.EXPECT().RegisterForCert(gomock.Any(), layerID, gomock.Any()).Return(errors.New("unknown"))
+	tg.mockCert.EXPECT().CertifyIfEligible(gomock.Any(), gomock.Any(), layerID, gomock.Any())
+	tg.mockMesh.EXPECT().ProcessLayerPerHareOutput(gomock.Any(), layerID, block.ID(), true)
+	tg.mockPatrol.EXPECT().CompleteHare(layerID)
+	tg.hareCh <- hare.LayerOutput{Ctx: context.Background(), Layer: layerID, Proposals: pids}
+	require.Eventually(t, func() bool { return len(tg.hareCh) == 0 }, time.Second, 100*time.Millisecond)
+	tg.Stop()
+}
+
+func Test_run_CertifyFailureIgnored(t *testing.T) {
+	tg := createTestGenerator(t)
+	layerID := types.GetEffectiveGenesis().Add(100)
+	require.NoError(t, layers.SetApplied(tg.cdb, layerID-1, types.EmptyBlockID))
+	tg.Start()
+	txIDs := createAndSaveTxs(t, 100, tg.cdb)
+	signers, atxes := createATXs(t, tg.cdb, (layerID.GetEpoch() - 1).FirstLayer(), 10)
+	activeSet := types.ToATXIDs(atxes)
+	meshHash := types.RandomHash()
+	plist := createProposals(t, tg.cdb, layerID, meshHash, signers, activeSet, txIDs)
+	pids := types.ToProposalIDs(plist)
+	require.NoError(t, layers.SetMeshHash(tg.cdb, layerID.Sub(1), meshHash))
+
+	tg.mockFetch.EXPECT().GetProposals(gomock.Any(), pids).AnyTimes()
+	block := types.NewExistingBlock(types.BlockID{1, 2, 3}, types.InnerBlock{LayerIndex: layerID})
+	tg.mockExec.EXPECT().ExecuteOptimistic(gomock.Any(), layerID, uint64(baseTickHeight), gomock.Any(), gomock.Any()).Return(block, nil)
+	tg.mockMesh.EXPECT().AddBlockWithTXs(gomock.Any(), gomock.Any())
+	tg.mockCert.EXPECT().RegisterForCert(gomock.Any(), layerID, gomock.Any())
+	tg.mockCert.EXPECT().CertifyIfEligible(gomock.Any(), gomock.Any(), layerID, gomock.Any()).Return(errors.New("unknown"))
+	tg.mockMesh.EXPECT().ProcessLayerPerHareOutput(gomock.Any(), layerID, block.ID(), true)
+	tg.mockPatrol.EXPECT().CompleteHare(layerID)
+	tg.hareCh <- hare.LayerOutput{Ctx: context.Background(), Layer: layerID, Proposals: pids}
+	require.Eventually(t, func() bool { return len(tg.hareCh) == 0 }, time.Second, 100*time.Millisecond)
+	tg.Stop()
+}
+
+func Test_run_ProcessLayerFailed(t *testing.T) {
+	tg := createTestGenerator(t)
+	layerID := types.GetEffectiveGenesis().Add(100)
+	require.NoError(t, layers.SetApplied(tg.cdb, layerID-1, types.EmptyBlockID))
+	tg.Start()
+	txIDs := createAndSaveTxs(t, 100, tg.cdb)
+	signers, atxes := createATXs(t, tg.cdb, (layerID.GetEpoch() - 1).FirstLayer(), 10)
+	activeSet := types.ToATXIDs(atxes)
+	meshHash := types.RandomHash()
+	plist := createProposals(t, tg.cdb, layerID, meshHash, signers, activeSet, txIDs)
+	pids := types.ToProposalIDs(plist)
+	require.NoError(t, layers.SetMeshHash(tg.cdb, layerID.Sub(1), meshHash))
+
+	tg.mockFetch.EXPECT().GetProposals(gomock.Any(), pids).AnyTimes()
+	block := types.NewExistingBlock(types.BlockID{1, 2, 3}, types.InnerBlock{LayerIndex: layerID})
+	tg.mockExec.EXPECT().ExecuteOptimistic(gomock.Any(), layerID, uint64(baseTickHeight), gomock.Any(), gomock.Any()).Return(block, nil).AnyTimes()
+	tg.mockMesh.EXPECT().AddBlockWithTXs(gomock.Any(), gomock.Any()).AnyTimes()
+	tg.mockCert.EXPECT().RegisterForCert(gomock.Any(), layerID, gomock.Any()).AnyTimes()
+	tg.mockCert.EXPECT().CertifyIfEligible(gomock.Any(), gomock.Any(), layerID, gomock.Any()).AnyTimes()
+	tg.mockMesh.EXPECT().ProcessLayerPerHareOutput(gomock.Any(), layerID, block.ID(), true).Return(errors.New("unknown")).AnyTimes()
+	tg.hareCh <- hare.LayerOutput{Ctx: context.Background(), Layer: layerID, Proposals: pids}
+	require.Eventually(t, func() bool { return len(tg.hareCh) == 0 }, time.Second, 100*time.Millisecond)
+	tg.Stop()
+}
+
+func Test_processHareOutput_UnequalHeight(t *testing.T) {
 	tg := createTestGenerator(t)
 	layerID := types.GetEffectiveGenesis().Add(100)
 	numProposals := 10
 	rng := rand.New(rand.NewSource(10101))
-	max := uint64(0)
+	maxHeight := uint64(0)
 	signers, atxes := createModifiedATXs(t, tg.cdb, (layerID.GetEpoch() - 1).FirstLayer(), numProposals, func(atx *types.ActivationTx) (*types.VerifiedActivationTx, error) {
 		n := rng.Uint64()
-		if n > max {
-			max = n
+		if n > maxHeight {
+			maxHeight = n
 		}
 		return atx.Verify(n, 1)
 	})
 	activeSet := types.ToATXIDs(atxes)
 	pList := createProposals(t, tg.cdb, layerID, types.Hash32{}, signers, activeSet, nil)
-	block, executed, err := tg.generateBlock(context.Background(), tg.logger, layerID, pList)
+	ho := hare.LayerOutput{
+		Ctx:       context.Background(),
+		Layer:     layerID,
+		Proposals: types.ToProposalIDs(pList),
+	}
+	tg.mockFetch.EXPECT().GetProposals(ho.Ctx, ho.Proposals)
+	var got types.BlockID
+	tg.mockMesh.EXPECT().AddBlockWithTXs(ho.Ctx, gomock.Any()).DoAndReturn(
+		func(_ context.Context, b *types.Block) error {
+			got = b.ID()
+			return nil
+		})
+	tg.mockCert.EXPECT().RegisterForCert(ho.Ctx, layerID, gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ types.LayerID, bid types.BlockID) error {
+			require.Equal(t, got, bid)
+			return nil
+		})
+	tg.mockCert.EXPECT().CertifyIfEligible(ho.Ctx, gomock.Any(), layerID, gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ log.Log, _ types.LayerID, bid types.BlockID) error {
+			require.Equal(t, got, bid)
+			return eligibility.ErrNotActive
+		})
+	bi, err := tg.processHareOutput(ho)
 	require.NoError(t, err)
-	require.False(t, executed)
-	require.Equal(t, max, block.TickHeight)
-	require.Len(t, block.Rewards, numProposals)
+	require.NotNil(t, bi.block)
+	require.Equal(t, maxHeight, bi.block.TickHeight)
+	require.Len(t, bi.block.Rewards, numProposals)
 	// numUnit is the ATX weight. eligible slots per epoch is 3 for each atx, each proposal has 1 eligibility
 	// the expected weight for each eligibility is `numUnit` * 1/3
 	expWeight := new(big.Rat).SetInt64(numUnit * 1 / 3)
-	checkRewards(t, atxes, expWeight, block.Rewards)
+	checkRewards(t, atxes, expWeight, bi.block.Rewards)
 }
 
-func Test_generateBlock_bad_state(t *testing.T) {
+func Test_processHareOutput_bad_state(t *testing.T) {
 	tg := createTestGenerator(t)
 	layerID := types.GetEffectiveGenesis().Add(100)
 	signers, atxes := createATXs(t, tg.cdb, (layerID.GetEpoch() - 1).FirstLayer(), 1)
 	activeSet := types.ToATXIDs(atxes)
 
 	t.Run("tx missing", func(t *testing.T) {
-		p := createProposal(t, activeSet, layerID, types.Hash32{}, activeSet[0], signers[0], []types.TransactionID{types.RandomTransactionID()}, 1)
-		block, executed, err := tg.generateBlock(context.Background(), tg.logger, layerID, []*types.Proposal{p})
+		p := createProposal(t, tg.cdb, activeSet, layerID, types.Hash32{}, activeSet[0], signers[0], []types.TransactionID{types.RandomTransactionID()}, 1)
+		ho := hare.LayerOutput{
+			Ctx:       context.Background(),
+			Layer:     layerID,
+			Proposals: types.ToProposalIDs([]*types.Proposal{p}),
+		}
+		tg.mockFetch.EXPECT().GetProposals(ho.Ctx, ho.Proposals)
+		bi, err := tg.processHareOutput(ho)
 		require.ErrorIs(t, err, errProposalTxMissing)
-		require.False(t, executed)
-		require.Nil(t, block)
+		require.Nil(t, bi)
 	})
 
 	t.Run("tx header missing", func(t *testing.T) {
@@ -500,15 +619,20 @@ func Test_generateBlock_bad_state(t *testing.T) {
 			RawTx: types.NewRawTx([]byte{1, 1, 1}),
 		}
 		require.NoError(t, transactions.Add(tg.cdb, &tx, time.Now()))
-		p := createProposal(t, activeSet, layerID, types.Hash32{}, activeSet[0], signers[0], []types.TransactionID{tx.ID}, 1)
-		block, executed, err := tg.generateBlock(context.Background(), tg.logger, layerID, []*types.Proposal{p})
+		p := createProposal(t, tg.cdb, activeSet, layerID, types.Hash32{}, activeSet[0], signers[0], []types.TransactionID{tx.ID}, 1)
+		ho := hare.LayerOutput{
+			Ctx:       context.Background(),
+			Layer:     layerID,
+			Proposals: types.ToProposalIDs([]*types.Proposal{p}),
+		}
+		tg.mockFetch.EXPECT().GetProposals(ho.Ctx, ho.Proposals)
+		bi, err := tg.processHareOutput(ho)
 		require.ErrorIs(t, err, errProposalTxHdrMissing)
-		require.False(t, executed)
-		require.Nil(t, block)
+		require.Nil(t, bi)
 	})
 }
 
-func Test_generateBlock_EmptyProposals(t *testing.T) {
+func Test_processHareOutput_EmptyProposals(t *testing.T) {
 	tg := createTestGenerator(t)
 	numProposals := 10
 	lid := types.GetEffectiveGenesis().Add(20)
@@ -516,24 +640,45 @@ func Test_generateBlock_EmptyProposals(t *testing.T) {
 	activeSet := types.ToATXIDs(atxes)
 	plist := make([]*types.Proposal, 0, numProposals)
 	for i := 0; i < numProposals; i++ {
-		p := createProposal(t, activeSet, lid, types.Hash32{}, activeSet[i], signers[i], nil, 1)
+		p := createProposal(t, tg.cdb, activeSet, lid, types.Hash32{}, activeSet[i], signers[i], nil, 1)
 		plist = append(plist, p)
 	}
-	block, executed, err := tg.generateBlock(context.Background(), tg.logger, lid, plist)
+	ho := hare.LayerOutput{
+		Ctx:       context.Background(),
+		Layer:     lid,
+		Proposals: types.ToProposalIDs(plist),
+	}
+	tg.mockFetch.EXPECT().GetProposals(ho.Ctx, ho.Proposals)
+	var got types.BlockID
+	tg.mockMesh.EXPECT().AddBlockWithTXs(ho.Ctx, gomock.Any()).DoAndReturn(
+		func(_ context.Context, b *types.Block) error {
+			got = b.ID()
+			return nil
+		})
+	tg.mockCert.EXPECT().RegisterForCert(ho.Ctx, lid, gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ types.LayerID, bid types.BlockID) error {
+			require.Equal(t, got, bid)
+			return nil
+		})
+	tg.mockCert.EXPECT().CertifyIfEligible(ho.Ctx, gomock.Any(), lid, gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ log.Log, _ types.LayerID, bid types.BlockID) error {
+			require.Equal(t, got, bid)
+			return eligibility.ErrNotActive
+		})
+	bi, err := tg.processHareOutput(ho)
 	require.NoError(t, err)
-	require.False(t, executed)
-	require.NotEqual(t, types.EmptyBlockID, block.ID())
-
-	require.Equal(t, lid, block.LayerIndex)
-	require.Empty(t, block.TxIDs)
-	require.Len(t, block.Rewards, numProposals)
+	require.NotNil(t, bi)
+	require.NotNil(t, bi.block)
+	require.Equal(t, lid, bi.block.LayerIndex)
+	require.Empty(t, bi.block.TxIDs)
+	require.Len(t, bi.block.Rewards, numProposals)
 	// numUint is the ATX weight. eligible slots per epoch is 3 for each atx, each proposal has 1 eligibility
 	// the expected weight for each eligibility is `numUnit` * 1/3
 	expWeight := new(big.Rat).SetInt64(numUnit * 1 / 3)
-	checkRewards(t, atxes, expWeight, block.Rewards)
+	checkRewards(t, atxes, expWeight, bi.block.Rewards)
 }
 
-func Test_generateBlock_StableBlockID(t *testing.T) {
+func Test_processHareOutput_StableBlockID(t *testing.T) {
 	tg := createTestGenerator(t)
 	layerID := types.GetEffectiveGenesis().Add(100)
 	// create multiple proposals with overlapping TXs
@@ -543,25 +688,43 @@ func Test_generateBlock_StableBlockID(t *testing.T) {
 	signers, atxes := createATXs(t, tg.cdb, (layerID.GetEpoch() - 1).FirstLayer(), numProposals)
 	activeSet := types.ToATXIDs(atxes)
 	plist := createProposals(t, tg.cdb, layerID, types.Hash32{}, signers, activeSet, txIDs)
-	block, executed, err := tg.generateBlock(context.Background(), tg.logger, layerID, plist)
+	ho1 := hare.LayerOutput{
+		Ctx:       context.Background(),
+		Layer:     layerID,
+		Proposals: types.ToProposalIDs(plist),
+	}
+	tg.mockFetch.EXPECT().GetProposals(ho1.Ctx, ho1.Proposals)
+	tg.mockMesh.EXPECT().AddBlockWithTXs(ho1.Ctx, gomock.Any())
+	tg.mockCert.EXPECT().RegisterForCert(ho1.Ctx, layerID, gomock.Any())
+	tg.mockCert.EXPECT().CertifyIfEligible(ho1.Ctx, gomock.Any(), layerID, gomock.Any()).Return(eligibility.ErrNotActive)
+	bi1, err := tg.processHareOutput(ho1)
 	require.NoError(t, err)
-	require.False(t, executed)
-	require.NotEqual(t, types.EmptyBlockID, block.ID())
-	require.Equal(t, layerID, block.LayerIndex)
-	require.Len(t, block.TxIDs, numTXs)
+	require.NotNil(t, bi1)
+	require.NotNil(t, bi1.block)
+	require.NotEqual(t, types.EmptyBlockID, bi1.block.ID())
+	require.Equal(t, layerID, bi1.block.LayerIndex)
+	require.Len(t, bi1.block.TxIDs, numTXs)
 
 	// reorder the proposals
 	ordered := plist[numProposals/2 : numProposals]
 	ordered = append(ordered, plist[0:numProposals/2]...)
 	require.NotEqual(t, plist, ordered)
-	block2, executed, err := tg.generateBlock(context.Background(), tg.logger, layerID, ordered)
+	ho2 := hare.LayerOutput{
+		Ctx:       context.Background(),
+		Layer:     layerID,
+		Proposals: types.ToProposalIDs(ordered),
+	}
+	tg.mockFetch.EXPECT().GetProposals(ho2.Ctx, ho2.Proposals)
+	tg.mockMesh.EXPECT().AddBlockWithTXs(ho2.Ctx, gomock.Any())
+	tg.mockCert.EXPECT().RegisterForCert(ho2.Ctx, layerID, gomock.Any())
+	tg.mockCert.EXPECT().CertifyIfEligible(ho2.Ctx, gomock.Any(), layerID, gomock.Any()).Return(eligibility.ErrNotActive)
+	bi2, err := tg.processHareOutput(ho2)
 	require.NoError(t, err)
-	require.False(t, executed)
-	require.Equal(t, block, block2)
-	require.Equal(t, block.ID(), block2.ID())
+	require.NotNil(t, bi2)
+	require.Equal(t, bi1.block, bi2.block)
 }
 
-func Test_generateBlock_SameATX(t *testing.T) {
+func Test_processHareOutput_SameATX(t *testing.T) {
 	tg := createTestGenerator(t)
 	layerID := types.GetEffectiveGenesis().Add(100)
 	numTXs := 1000
@@ -570,16 +733,21 @@ func Test_generateBlock_SameATX(t *testing.T) {
 	signers, atxes := createATXs(t, tg.cdb, (layerID.GetEpoch() - 1).FirstLayer(), numProposals)
 	activeSet := types.ToATXIDs(atxes)
 	atxID := activeSet[0]
-	proposal1 := createProposal(t, activeSet, layerID, types.Hash32{}, atxID, signers[0], txIDs[0:500], 1)
-	proposal2 := createProposal(t, activeSet, layerID, types.Hash32{}, atxID, signers[0], txIDs[400:], 1)
+	proposal1 := createProposal(t, tg.cdb, activeSet, layerID, types.Hash32{}, atxID, signers[0], txIDs[0:500], 1)
+	proposal2 := createProposal(t, tg.cdb, activeSet, layerID, types.Hash32{}, atxID, signers[0], txIDs[400:], 1)
 	plist := []*types.Proposal{proposal1, proposal2}
-	block, executed, err := tg.generateBlock(context.Background(), tg.logger, layerID, plist)
+	ho := hare.LayerOutput{
+		Ctx:       context.Background(),
+		Layer:     layerID,
+		Proposals: types.ToProposalIDs(plist),
+	}
+	tg.mockFetch.EXPECT().GetProposals(ho.Ctx, ho.Proposals)
+	bi, err := tg.processHareOutput(ho)
 	require.ErrorIs(t, err, errDuplicateATX)
-	require.False(t, executed)
-	require.Nil(t, block)
+	require.Nil(t, bi)
 }
 
-func Test_generateBlock_EmptyATXID(t *testing.T) {
+func Test_processHareOutput_EmptyATXID(t *testing.T) {
 	tg := createTestGenerator(t)
 	layerID := types.GetEffectiveGenesis().Add(100)
 	// create multiple proposals with overlapping TXs
@@ -588,37 +756,50 @@ func Test_generateBlock_EmptyATXID(t *testing.T) {
 	txIDs := createAndSaveTxs(t, numTXs, tg.cdb)
 	signers, atxes := createATXs(t, tg.cdb, (layerID.GetEpoch() - 1).FirstLayer(), numProposals)
 	activeSet := types.ToATXIDs(atxes)
-	plist := createProposals(t, tg.cdb, layerID, types.Hash32{}, signers, activeSet, txIDs)
-	// set the last proposal ID to be empty
-	types.SortProposals(plist)
-	plist[numProposals-1].AtxID = types.EmptyATXID
-	block, executed, err := tg.generateBlock(context.Background(), tg.logger, layerID, plist)
+	plist := createProposals(t, tg.cdb, layerID, types.Hash32{}, signers[1:], activeSet[1:], txIDs[1:])
+	p := createProposal(t, tg.cdb, activeSet, layerID, types.Hash32{}, types.EmptyATXID, signers[0], txIDs, 1)
+	plist = append(plist, p)
+	ho := hare.LayerOutput{
+		Ctx:       context.Background(),
+		Layer:     layerID,
+		Proposals: types.ToProposalIDs(plist),
+	}
+	tg.mockFetch.EXPECT().GetProposals(ho.Ctx, ho.Proposals)
+	bi, err := tg.processHareOutput(ho)
 	require.ErrorIs(t, err, errInvalidATXID)
-	require.False(t, executed)
-	require.Nil(t, block)
+	require.Nil(t, bi)
 }
 
-func Test_generateBlock_MultipleEligibilities(t *testing.T) {
+func Test_processHareOutput_MultipleEligibilities(t *testing.T) {
 	tg := createTestGenerator(t)
 	layerID := types.GetEffectiveGenesis().Add(100)
 	ids := createAndSaveTxs(t, 1000, tg.cdb)
 	signers, atxes := createATXs(t, tg.cdb, (layerID.GetEpoch() - 1).FirstLayer(), 10)
 	activeSet := types.ToATXIDs(atxes)
 	plist := []*types.Proposal{
-		createProposal(t, activeSet, layerID, types.Hash32{}, atxes[0].ID(), signers[0], ids, 2),
-		createProposal(t, activeSet, layerID, types.Hash32{}, atxes[1].ID(), signers[1], ids, 1),
-		createProposal(t, activeSet, layerID, types.Hash32{}, atxes[2].ID(), signers[2], ids, 5),
+		createProposal(t, tg.cdb, activeSet, layerID, types.Hash32{}, atxes[0].ID(), signers[0], ids, 2),
+		createProposal(t, tg.cdb, activeSet, layerID, types.Hash32{}, atxes[1].ID(), signers[1], ids, 1),
+		createProposal(t, tg.cdb, activeSet, layerID, types.Hash32{}, atxes[2].ID(), signers[2], ids, 5),
 	}
-
-	block, executed, err := tg.generateBlock(context.Background(), tg.logger, layerID, plist)
+	ho := hare.LayerOutput{
+		Ctx:       context.Background(),
+		Layer:     layerID,
+		Proposals: types.ToProposalIDs(plist),
+	}
+	tg.mockFetch.EXPECT().GetProposals(ho.Ctx, ho.Proposals)
+	tg.mockMesh.EXPECT().AddBlockWithTXs(ho.Ctx, gomock.Any())
+	tg.mockCert.EXPECT().RegisterForCert(ho.Ctx, layerID, gomock.Any())
+	tg.mockCert.EXPECT().CertifyIfEligible(ho.Ctx, gomock.Any(), layerID, gomock.Any()).Return(eligibility.ErrNotActive)
+	bi, err := tg.processHareOutput(ho)
 	require.NoError(t, err)
-	require.False(t, executed)
-	require.Len(t, block.Rewards, len(plist))
+	require.NotNil(t, bi)
+	require.NotNil(t, bi.block)
+	require.Len(t, bi.block.Rewards, len(plist))
 	sort.Slice(plist, func(i, j int) bool {
 		return bytes.Compare(plist[i].AtxID.Bytes(), plist[j].AtxID.Bytes()) < 0
 	})
 	totalWeight := new(big.Rat)
-	for i, r := range block.Rewards {
+	for i, r := range bi.block.Rewards {
 		require.Equal(t, plist[i].AtxID, r.AtxID)
 		got := r.Weight.ToBigRat()
 		// numUint is the ATX weight. eligible slots per epoch is 3 for each atx

--- a/blocks/utils.go
+++ b/blocks/utils.go
@@ -2,6 +2,7 @@ package blocks
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -36,6 +37,7 @@ type meshState struct {
 }
 
 type proposalMetadata struct {
+	ctx        context.Context
 	lid        types.LayerID
 	proposals  []*types.Proposal
 	tids       []types.TransactionID
@@ -45,6 +47,7 @@ type proposalMetadata struct {
 }
 
 func getProposalMetadata(
+	ctx context.Context,
 	logger log.Log,
 	cdb *datastore.CachedDB,
 	cfg Config,
@@ -53,6 +56,7 @@ func getProposalMetadata(
 ) (*proposalMetadata, error) {
 	var (
 		md = &proposalMetadata{
+			ctx:       ctx,
 			lid:       lid,
 			proposals: proposals,
 		}

--- a/blocks/utils.go
+++ b/blocks/utils.go
@@ -38,7 +38,7 @@ type meshState struct {
 type proposalMetadata struct {
 	lid        types.LayerID
 	proposals  []*types.Proposal
-	mtxs       []*types.MeshTransaction
+	tids       []types.TransactionID
 	tickHeight uint64
 	rewards    []types.AnyReward
 	optFilter  bool
@@ -55,8 +55,8 @@ func getProposalMetadata(
 		md = &proposalMetadata{
 			lid:       lid,
 			proposals: proposals,
-			mtxs:      []*types.MeshTransaction{},
 		}
+		mtxs       []*types.MeshTransaction
 		seen       = make(map[types.TransactionID]struct{})
 		meshHashes = make(map[types.Hash32]*meshState)
 		err        error
@@ -88,10 +88,9 @@ func getProposalMetadata(
 				return nil, fmt.Errorf("%w: inconsistent state: tx %s is missing header", errProposalTxHdrMissing, mtx.ID)
 			}
 			seen[tid] = struct{}{}
-			md.mtxs = append(md.mtxs, mtx)
+			mtxs = append(mtxs, mtx)
 		}
 	}
-
 	majority := cfg.OptFilterThreshold * len(proposals)
 	var majorityState *meshState
 	for _, ms := range meshHashes {
@@ -106,28 +105,39 @@ func getProposalMetadata(
 	}
 	if majorityState == nil {
 		logger.With().Info("no consensus on mesh hash. NOT doing optimistic filtering", lid)
-		return md, nil
+	} else {
+		ownMeshHash, err := layers.GetAggregatedHash(cdb, lid.Sub(1))
+		if err != nil {
+			return nil, fmt.Errorf("get prev mesh hash %w", err)
+		}
+		if ownMeshHash != majorityState.hash {
+			return nil, fmt.Errorf("%w: majority %v, node %v", errNodeHasBadMeshHash, majorityState.hash, ownMeshHash)
+		}
+		logger.With().Debug("consensus on mesh hash. doing optimistic filtering",
+			lid,
+			log.Stringer("mesh_hash", majorityState.hash))
+		md.optFilter = true
 	}
-	ownMeshHash, err := layers.GetAggregatedHash(cdb, lid.Sub(1))
-	if err != nil {
-		return nil, fmt.Errorf("get prev mesh hash %w", err)
+	if len(mtxs) > 0 {
+		var gasLimit uint64
+		if !md.optFilter {
+			gasLimit = cfg.BlockGasLimit
+		}
+		blockSeed := types.CalcProposalsHash32(types.ToProposalIDs(md.proposals), nil).Bytes()
+		md.tids, err = getBlockTXs(logger, mtxs, blockSeed, gasLimit)
+		if err != nil {
+			return nil, err
+		}
 	}
-	if ownMeshHash != majorityState.hash {
-		return nil, fmt.Errorf("%w: majority %v, node %v", errNodeHasBadMeshHash, majorityState.hash, ownMeshHash)
-	}
-	md.optFilter = true
-	logger.With().Debug("consensus on mesh hash. doing optimistic filtering",
-		lid,
-		log.Stringer("mesh_hash", majorityState.hash))
 	return md, nil
 }
 
-func getBlockTXs(logger log.Log, pmd *proposalMetadata, blockSeed []byte, gasLimit uint64) ([]types.TransactionID, error) {
+func getBlockTXs(logger log.Log, mtxs []*types.MeshTransaction, blockSeed []byte, gasLimit uint64) ([]types.TransactionID, error) {
 	stateF := func(_ types.Address) (uint64, uint64) {
 		return 0, math.MaxUint64
 	}
 	txCache := txs.NewCache(stateF, logger)
-	if err := txCache.BuildFromTXs(pmd.mtxs, blockSeed); err != nil {
+	if err := txCache.BuildFromTXs(mtxs, blockSeed); err != nil {
 		return nil, fmt.Errorf("build txs for block: %w", err)
 	}
 	byAddrAndNonce := txCache.GetMempool(logger)
@@ -135,7 +145,7 @@ func getBlockTXs(logger log.Log, pmd *proposalMetadata, blockSeed []byte, gasLim
 		logger.With().Warning("no feasible txs for block")
 		return nil, nil
 	}
-	candidates := make([]*txs.NanoTX, 0, len(pmd.mtxs))
+	candidates := make([]*txs.NanoTX, 0, len(mtxs))
 	byTid := make(map[types.TransactionID]*txs.NanoTX)
 	for _, acctTXs := range byAddrAndNonce {
 		candidates = append(candidates, acctTXs...)

--- a/blocks/utils_test.go
+++ b/blocks/utils_test.go
@@ -50,26 +50,26 @@ func Test_getBlockTXs(t *testing.T) {
 
 	blockSeed := types.RandomHash().Bytes()
 	// no pruning
-	got, err := getBlockTXs(logtest.New(t), &proposalMetadata{mtxs: mtxs}, blockSeed, 0)
+	got, err := getBlockTXs(logtest.New(t), mtxs, blockSeed, 0)
 	require.NoError(t, err)
 	require.Len(t, got, len(mtxs))
 	checkInNonceOrder(t, got, byTid)
 
 	// make sure order is stable
-	got2, err := getBlockTXs(logtest.New(t), &proposalMetadata{mtxs: mtxs}, blockSeed, 0)
+	got2, err := getBlockTXs(logtest.New(t), mtxs, blockSeed, 0)
 	require.NoError(t, err)
 	require.Equal(t, got, got2)
 
 	// pruning
 	expSize := len(mtxs) / 2
 	gasLimit := uint64(expSize) * defaultGas
-	got, err = getBlockTXs(logtest.New(t), &proposalMetadata{mtxs: mtxs}, blockSeed, gasLimit)
+	got, err = getBlockTXs(logtest.New(t), mtxs, blockSeed, gasLimit)
 	require.NoError(t, err)
 	require.Len(t, got, expSize)
 	checkInNonceOrder(t, got, byTid)
 
 	// make sure order is stable
-	got2, err = getBlockTXs(logtest.New(t), &proposalMetadata{mtxs: mtxs}, blockSeed, gasLimit)
+	got2, err = getBlockTXs(logtest.New(t), mtxs, blockSeed, gasLimit)
 	require.NoError(t, err)
 	require.Equal(t, got, got2)
 
@@ -77,12 +77,12 @@ func Test_getBlockTXs(t *testing.T) {
 	for _, mtx := range mtxs {
 		mtx.LayerID = types.LayerID(11)
 	}
-	got, err = getBlockTXs(logtest.New(t), &proposalMetadata{mtxs: mtxs}, blockSeed, 0)
+	got, err = getBlockTXs(logtest.New(t), mtxs, blockSeed, 0)
 	require.NoError(t, err)
 	require.Empty(t, got)
 
 	// empty block
-	got, err = getBlockTXs(logtest.New(t), &proposalMetadata{}, blockSeed, 0)
+	got, err = getBlockTXs(logtest.New(t), nil, blockSeed, 0)
 	require.NoError(t, err)
 	require.Empty(t, got)
 }

--- a/proposals/handler.go
+++ b/proposals/handler.go
@@ -215,7 +215,7 @@ func (h *Handler) HandleSyncedProposal(ctx context.Context, peer p2p.Peer, data 
 func (h *Handler) HandleProposal(ctx context.Context, peer p2p.Peer, data []byte) error {
 	err := h.handleProposal(ctx, peer, data)
 	if err != nil && !errors.Is(err, errMalformedData) && !errors.Is(err, errKnownProposal) {
-		h.logger.WithContext(ctx).With().Warning("failed to process proposal gossip", log.Err(err))
+		h.logger.WithContext(ctx).With().Debug("failed to process proposal gossip", log.Err(err))
 	}
 	return err
 }
@@ -280,7 +280,7 @@ func (h *Handler) handleProposal(ctx context.Context, peer p2p.Peer, data []byte
 	t3 := time.Now()
 	proof, err := h.processBallot(ctx, logger, &p.Ballot)
 	if err != nil && !errors.Is(err, errKnownBallot) && !errors.Is(err, errMaliciousBallot) {
-		logger.With().Warning("failed to process ballot", log.Err(err))
+		logger.With().Debug("failed to process ballot", log.Err(err))
 		return err
 	}
 	proposalDuration.WithLabelValues(ballot).Observe(float64(time.Since(t3)))
@@ -378,7 +378,7 @@ func (h *Handler) checkBallotSyntacticValidity(ctx context.Context, logger log.L
 
 	t1 := time.Now()
 	if err := h.checkBallotDataAvailability(ctx, b); err != nil {
-		logger.With().Warning("ballot data availability check failed", log.Err(err))
+		logger.With().Debug("ballot data availability check failed", log.Err(err))
 		return nil, err
 	}
 	ballotDuration.WithLabelValues(fetchRef).Observe(float64(time.Since(t1)))

--- a/systest/cluster/nodes.go
+++ b/systest/cluster/nodes.go
@@ -12,7 +12,9 @@ import (
 
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	apimetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -182,7 +184,10 @@ func (n *NodeClient) Invoke(ctx context.Context, method string, args any, reply 
 	}
 	err = conn.Invoke(ctx, method, args, reply, opts...)
 	if err != nil {
-		n.resetConn(conn)
+		s, _ := status.FromError(err)
+		if s.Code() != codes.InvalidArgument {
+			n.resetConn(conn)
+		}
 	}
 	return err
 }

--- a/systest/cluster/nodes.go
+++ b/systest/cluster/nodes.go
@@ -185,7 +185,9 @@ func (n *NodeClient) Invoke(ctx context.Context, method string, args any, reply 
 	err = conn.Invoke(ctx, method, args, reply, opts...)
 	if err != nil {
 		s, _ := status.FromError(err)
-		if s.Code() != codes.InvalidArgument {
+		if s.Code() != codes.InvalidArgument && s.Code() != codes.Canceled {
+			// check for app error. this is not exhaustive.
+			// the goal is to reset connection if pods were redeployed and changed IP
 			n.resetConn(conn)
 		}
 	}

--- a/systest/tests/checkpoint_test.go
+++ b/systest/tests/checkpoint_test.go
@@ -65,7 +65,7 @@ func TestCheckpoint(t *testing.T) {
 	stop := first + 2
 	receiver := types.GenerateAddress([]byte{11, 1, 1})
 	tctx.Log.Infow("sending transactions", "from", first, "to", stop-1)
-	sendTransactions(ctx, eg, tctx.Log, cl, first, stop, receiver, 1, 100)
+	require.NoError(t, sendTransactions(ctx, eg, tctx.Log, cl, first, stop, receiver, 1, 100))
 	require.NoError(t, eg.Wait())
 
 	require.NoError(t, waitLayer(tctx, cl.Client(0), snapshotLayer))

--- a/systest/tests/common.go
+++ b/systest/tests/common.go
@@ -61,6 +61,8 @@ func sendTransactions(ctx context.Context, eg *errgroup.Group, logger *zap.Sugar
 				logger.Debugw("submitting transactions",
 					"layer", layer.Layer.Number.Number,
 					"client", client.Name,
+					"account", i,
+					"nonce", nonce,
 					"batch", batch,
 				)
 			}
@@ -74,7 +76,7 @@ func sendTransactions(ctx context.Context, eg *errgroup.Group, logger *zap.Sugar
 						break
 					}
 					if logger != nil {
-						logger.Warnw("failed to spend", "client", spendClient.Name, "err", err.Error())
+						logger.Warnw("failed to spend", "client", spendClient.Name, "account", i, "nonce", nonce+uint64(j), "err", err.Error())
 					}
 					spendClient = cl.Client((i + k + 1) % cl.Total())
 				}

--- a/systest/tests/partition_test.go
+++ b/systest/tests/partition_test.go
@@ -60,7 +60,7 @@ func testPartition(t *testing.T, tctx *testcontext.Context, cl *cluster.Cluster,
 	tctx.Log.Debug("sending transactions...")
 	eg2, ctx2 := errgroup.WithContext(tctx)
 	receiver := types.GenerateAddress([]byte{11, 1, 1})
-	sendTransactions(ctx2, eg2, nil, cl, first, stop, receiver, 10, 100)
+	require.NoError(t, sendTransactions(ctx2, eg2, tctx.Log, cl, first, stop, receiver, 10, 100))
 
 	type stateUpdate struct {
 		layer  uint32

--- a/systest/tests/partition_test.go
+++ b/systest/tests/partition_test.go
@@ -48,6 +48,8 @@ func testPartition(t *testing.T, tctx *testcontext.Context, cl *cluster.Cluster,
 			"percentage", pct,
 			"split", startSplit,
 			"rejoin", rejoin,
+			"last", last,
+			"stop", stop,
 			"left", left,
 			"right", right,
 		)
@@ -116,7 +118,7 @@ func testPartition(t *testing.T, tctx *testcontext.Context, cl *cluster.Cluster,
 		}
 		latestStates[update.client][update.layer] = update.hash
 	}
-	for layer := uint32(layersPerEpoch * 2); layer <= last; layer++ {
+	for layer := layersPerEpoch * 2; layer <= last; layer++ {
 		tctx.Log.Debugw("client states",
 			"layer", layer,
 			"num_states", len(hashes[layer]),
@@ -139,7 +141,7 @@ func testPartition(t *testing.T, tctx *testcontext.Context, cl *cluster.Cluster,
 	for i := 1; i < cl.Total(); i++ {
 		clientState := latestStates[cl.Client(i).Name]
 		agree := true
-		for layer := uint32(layersPerEpoch * 2); layer <= last; layer++ {
+		for layer := layersPerEpoch * 2; layer <= last; layer++ {
 			if clientState[layer] != refState[layer] {
 				tctx.Log.Errorw("client state differs from ref state",
 					"client", cl.Client(i).Name,

--- a/systest/tests/transactions_test.go
+++ b/systest/tests/transactions_test.go
@@ -37,7 +37,7 @@ func testTransactions(t *testing.T, tctx *testcontext.Context, cl *cluster.Clust
 	before := response.AccountWrapper.StateCurrent.Balance
 
 	eg, ctx := errgroup.WithContext(tctx)
-	sendTransactions(ctx, eg, tctx.Log, cl, first, stopSending, receiver, batch, amount)
+	require.NoError(t, sendTransactions(ctx, eg, tctx.Log, cl, first, stopSending, receiver, batch, amount))
 	txs := make([][]*pb.Transaction, cl.Total())
 
 	for i := 0; i < cl.Total(); i++ {

--- a/txs/cache.go
+++ b/txs/cache.go
@@ -238,7 +238,7 @@ func (ac *accountCache) addBatch(logger log.Log, nonce2TXs map[uint64][]*NanoTX,
 	for _, nonce := range sortedNonce {
 		best := findBest(nonce2TXs[nonce], balance, blockSeed)
 		if best == nil {
-			logger.With().Warning("no feasible transactions at nonce",
+			logger.With().Debug("no feasible transactions at nonce",
 				log.Uint64("nonce", nonce),
 				log.Uint64("balance", balance))
 			continue
@@ -287,7 +287,7 @@ func findBest(ntxs []*NanoTX, balance uint64, blockSeed []byte) *NanoTX {
 //   - nonce not present: add to cache.
 func (ac *accountCache) add(logger log.Log, tx *types.Transaction, received time.Time) error {
 	if tx.Nonce < ac.startNonce {
-		logger.With().Warning("nonce too small",
+		logger.With().Debug("nonce too small",
 			tx.ID,
 			log.Uint64("next_nonce", ac.startNonce),
 			log.Uint64("tx_nonce", tx.Nonce))
@@ -361,7 +361,7 @@ func (ac *accountCache) getMempool(logger log.Log) []*NanoTX {
 		if !found && cand.layer() == 0 {
 			found = true
 		} else if found && cand.layer() != 0 {
-			logger.With().Warning("some proposals/blocks packed txs out of order",
+			logger.With().Debug("some proposals/blocks packed txs out of order",
 				cand.id(),
 				cand.layer(),
 				cand.block(),
@@ -439,7 +439,7 @@ func groupTXsByPrincipal(logger log.Log, mtxs []*types.MeshTransaction) map[type
 		if len(byPrincipal[principal][mtx.Nonce]) < maxTXsPerNonce {
 			byPrincipal[principal][mtx.Nonce] = append(byPrincipal[principal][mtx.Nonce], NewNanoTX(mtx))
 		} else {
-			logger.With().Warning("too many txs in same nonce. ignoring tx",
+			logger.With().Debug("too many txs in same nonce. ignoring tx",
 				mtx.ID,
 				principal,
 				log.Uint64("nonce", mtx.Nonce),
@@ -501,7 +501,7 @@ func (c *Cache) BuildFromTXs(rst []*types.MeshTransaction, blockSeed []byte) err
 			return err
 		}
 		if c.pending[principal].shouldEvict() {
-			c.logger.With().Warning("account has pending txs but none feasible",
+			c.logger.With().Debug("account has pending txs but none feasible",
 				principal,
 				log.Array("batch", nonceMarshaller(nonce2TXs)))
 		} else {

--- a/txs/cache.go
+++ b/txs/cache.go
@@ -508,7 +508,7 @@ func (c *Cache) BuildFromTXs(rst []*types.MeshTransaction, blockSeed []byte) err
 			acctsAdded++
 		}
 	}
-	c.logger.Info("added pending tx for %d accounts", acctsAdded)
+	c.logger.Debug("added pending tx for %d accounts", acctsAdded)
 	return nil
 }
 
@@ -790,7 +790,7 @@ func (c *Cache) GetMempool(logger log.Log) map[types.Address][]*NanoTX {
 	defer c.mu.Unlock()
 
 	all := make(map[types.Address][]*NanoTX)
-	logger.With().Info("cache has pending accounts", log.Int("num_acct", len(c.pending)))
+	logger.With().Debug("cache has pending accounts", log.Int("num_acct", len(c.pending)))
 	for addr, accCache := range c.pending {
 		txs := accCache.getMempool(logger.WithFields(addr))
 		if len(txs) > 0 {


### PR DESCRIPTION
## Motivation
Closes #4482

## Changes
- when optimistic filtering is OFF, generate a block right away regardless of layer order
- when hare output empty block, or a non-optimistic generated block, certify the hare output right away

note that block execution is still kept sequential