### PR TITLE
[Merged by Bors] - systest: run TestSmeshing without subtests

### DIFF
--- a/.github/workflows/systest.yml
+++ b/.github/workflows/systest.yml
@@ -114,7 +114,7 @@ jobs:
           node_selector: cloud.google.com/gke-nodepool=gha
           size: 50
           bootstrap: 4m
-          level: debug
+          level: info
           clusters: 4
         run: make -C systest run test_name=.
 

--- a/.github/workflows/systest.yml
+++ b/.github/workflows/systest.yml
@@ -114,7 +114,7 @@ jobs:
           node_selector: cloud.google.com/gke-nodepool=gha
           size: 50
           bootstrap: 4m
-          level: info
+          level: debug
           clusters: 4
         run: make -C systest run test_name=.
 

--- a/systest/tests/smeshing_test.go
+++ b/systest/tests/smeshing_test.go
@@ -22,15 +22,8 @@ func TestSmeshing(t *testing.T) {
 	tctx := testcontext.New(t, testcontext.Labels("sanity"))
 	cl, err := cluster.ReuseWait(tctx, cluster.WithKeys(10))
 	require.NoError(t, err)
-
-	t.Run("Proposals", func(t *testing.T) {
-		t.Parallel()
-		testSmeshing(t, tctx, cl)
-	})
-	t.Run("Transactions", func(t *testing.T) {
-		t.Parallel()
-		testTransactions(t, tctx, cl, 8)
-	})
+	testSmeshing(t, tctx, cl)
+	testTransactions(t, tctx, cl, 8)
 }
 
 func testSmeshing(t *testing.T, tctx *testcontext.Context, cl *cluster.Cluster) {


### PR DESCRIPTION
parallel subtests may get stopped to let run other parallel tests, that was apparently leading to some unexpected behavior and flakes, this change simplifies TestSmeshing execution.

> running transactions test	{"from": 46, "stop sending": 54, "expected transactions": 710}
> TestSmeshing	watching layer between	{"first": 28, "last": 43}

closes: https://github.com/spacemeshos/go-spacemesh/issues/4497


