### PR TITLE
[Merged by Bors] - Assign loaded initial post

### DIFF
--- a/activation/activation.go
+++ b/activation/activation.go
@@ -71,7 +71,6 @@ type Builder struct {
 	nipostBuilder     nipostBuilder
 	postSetupProvider postSetupProvider
 	initialPost       *types.Post
-	initialPostMeta   *types.PostMetadata
 
 	// smeshingMutex protects `StartSmeshing` and `StopSmeshing` from concurrent access
 	smeshingMutex sync.Mutex
@@ -275,7 +274,7 @@ func (b *Builder) generateInitialPost(ctx context.Context) error {
 	// Create the initial post and save it.
 	startTime := time.Now()
 	var err error
-	b.initialPost, b.initialPostMeta, err = b.postSetupProvider.GenerateProof(ctx, shared.ZeroChallenge)
+	b.initialPost, _, err = b.postSetupProvider.GenerateProof(ctx, shared.ZeroChallenge)
 	if err != nil {
 		return fmt.Errorf("post execution: %w", err)
 	}

--- a/activation/activation.go
+++ b/activation/activation.go
@@ -267,7 +267,8 @@ func (b *Builder) generateInitialPost(ctx context.Context) error {
 		return nil
 	}
 	// ...and if we don't have an initial POST persisted already.
-	if _, err := loadPost(b.nipostBuilder.DataDir()); err == nil {
+	if post, err := loadPost(b.nipostBuilder.DataDir()); err == nil {
+		b.initialPost = post
 		return nil
 	}
 

--- a/activation/activation_test.go
+++ b/activation/activation_test.go
@@ -143,7 +143,6 @@ func newTestBuilder(tb testing.TB, opts ...BuilderOption) *testAtxBuilder {
 		Nonce:   0,
 		Indices: make([]byte, 10),
 	}
-	b.initialPostMeta = &types.PostMetadata{}
 	tab.Builder = b
 	dir := tb.TempDir()
 	tab.mnipost.EXPECT().DataDir().Return(dir).AnyTimes()


### PR DESCRIPTION
## Motivation
`b.initialPost` should be assigned to actually make use of the persisted initial POST.

## Changes
- assign `b.initialPost` when loading persisted POST
- removed unused `b.initialPostMeta`

## DevOps Notes
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
