### PR TITLE
[Merged by Bors] - Fix broken release workflow (git lfs)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,8 @@ jobs:
 
       - name: Check out Git repository
         uses: actions/checkout@v3
+        with:
+          lfs: true
 
       - name: Setup Go
         uses: actions/setup-go@v4


### PR DESCRIPTION
## Motivation
Introduced in https://github.com/spacemeshos/go-spacemesh/pull/4450

I've updated the release workflow and installed git-lfs on self-hosted runners.

Failed job: https://github.com/spacemeshos/go-spacemesh/actions/runs/5255882540
Fixed job: https://github.com/spacemeshos/go-spacemesh/actions/runs/5263306011