### PR TITLE
[Merged by Bors] - hare: re-gossip eligibility proof for previously known malicious identity

### DIFF
--- a/hare/algorithm.go
+++ b/hare/algorithm.go
@@ -199,6 +199,7 @@ func newConsensusProcess(
 	stateQuerier stateQuerier,
 	signing *signing.EdSigner,
 	edVerifier *signing.EdVerifier,
+	et *EligibilityTracker,
 	nid types.NodeID,
 	nonce *types.VRFPostIndex,
 	p2p pubsub.Publisher,
@@ -224,7 +225,7 @@ func newConsensusProcess(
 		pending:   make(map[types.NodeID]*Message, cfg.N),
 		Log:       logger,
 		mTracker:  newMsgsTracker(),
-		eTracker:  NewEligibilityTracker(cfg.N),
+		eTracker:  et,
 		clock:     clock,
 	}
 	proc.ctx, proc.cancel = context.WithCancel(ctx)

--- a/hare/algorithm_test.go
+++ b/hare/algorithm_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/hare/mocks"
 	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/log/logtest"
+	pubsubmocks "github.com/spacemeshos/go-spacemesh/p2p/pubsub/mocks"
 	"github.com/spacemeshos/go-spacemesh/signing"
 	smocks "github.com/spacemeshos/go-spacemesh/system/mocks"
 )
@@ -136,9 +137,10 @@ func (mct *mockCommitTracker) BuildCertificate() *Certificate {
 
 type testBroker struct {
 	*Broker
-	mockMesh   *mocks.Mockmesh
-	mockStateQ *mocks.MockstateQuerier
-	mockSyncS  *smocks.MockSyncStateProvider
+	mockMesh      *mocks.Mockmesh
+	mockStateQ    *mocks.MockstateQuerier
+	mockSyncS     *smocks.MockSyncStateProvider
+	mockPublisher *pubsubmocks.MockPublisher
 }
 
 func buildBroker(tb testing.TB, testName string) *testBroker {
@@ -150,15 +152,16 @@ func buildBrokerWithLimit(tb testing.TB, testName string, limit int) *testBroker
 	mockStateQ := mocks.NewMockstateQuerier(ctrl)
 	mockSyncS := smocks.NewMockSyncStateProvider(ctrl)
 	mockMesh := mocks.NewMockmesh(ctrl)
-	mch := make(chan *types.MalfeasanceGossip, 1)
 	edVerifier, err := signing.NewEdVerifier()
 	require.NoError(tb, err)
+	mpub := pubsubmocks.NewMockPublisher(ctrl)
 	return &testBroker{
 		Broker: newBroker(mockMesh, edVerifier, &mockEligibilityValidator{valid: 1}, mockStateQ, mockSyncS,
-			mch, limit, logtest.New(tb).WithName(testName)),
-		mockMesh:   mockMesh,
-		mockSyncS:  mockSyncS,
-		mockStateQ: mockStateQ,
+			mpub, limit, logtest.New(tb).WithName(testName)),
+		mockMesh:      mockMesh,
+		mockSyncS:     mockSyncS,
+		mockStateQ:    mockStateQ,
+		mockPublisher: mpub,
 	}
 }
 

--- a/hare/algorithm_test.go
+++ b/hare/algorithm_test.go
@@ -156,7 +156,7 @@ func buildBrokerWithLimit(tb testing.TB, testName string, limit int) *testBroker
 	require.NoError(tb, err)
 	mpub := pubsubmocks.NewMockPublisher(ctrl)
 	return &testBroker{
-		Broker: newBroker(mockMesh, edVerifier, &mockEligibilityValidator{valid: 1}, mockStateQ, mockSyncS,
+		Broker: newBroker(config.DefaultConfig(), mockMesh, edVerifier, &mockEligibilityValidator{valid: 1}, mockStateQ, mockSyncS,
 			mpub, limit, logtest.New(tb).WithName(testName)),
 		mockMesh:      mockMesh,
 		mockSyncS:     mockSyncS,
@@ -337,6 +337,7 @@ func generateConsensusProcessWithConfig(tb testing.TB, cfg config.Config, inbox 
 		sq,
 		edSigner,
 		edVerifier,
+		NewEligibilityTracker(cfg.N),
 		types.BytesToNodeID(edPubkey.Bytes()),
 		&nonce,
 		noopPubSub(tb),

--- a/hare/broker.go
+++ b/hare/broker.go
@@ -367,6 +367,7 @@ func (b *Broker) CleanOldLayers(current types.LayerID) {
 	for lid := range b.trackers {
 		if lid <= b.minDeleted {
 			delete(b.trackers, lid)
+			delete(b.pending, lid)
 		}
 	}
 }

--- a/hare/broker_test.go
+++ b/hare/broker_test.go
@@ -62,7 +62,7 @@ func TestBroker_Received(t *testing.T) {
 	t.Cleanup(broker.Close)
 
 	lid := types.LayerID(1)
-	inbox, err := broker.Register(context.Background(), lid)
+	inbox, _, err := broker.Register(context.Background(), lid)
 	assert.Nil(t, err)
 
 	serMsg := createMessage(t, lid)
@@ -91,7 +91,7 @@ func TestBroker_MaxConcurrentProcesses(t *testing.T) {
 	broker.mu.RUnlock()
 
 	// this statement should cause inbox1 to be unregistered
-	inbox5, _ := broker.Register(context.Background(), instanceID5)
+	inbox5, _, _ := broker.Register(context.Background(), instanceID5)
 	broker.mu.RLock()
 	assert.Equal(t, 4, len(broker.outbox))
 	broker.mu.RUnlock()
@@ -103,7 +103,7 @@ func TestBroker_MaxConcurrentProcesses(t *testing.T) {
 	assert.Nil(t, broker.outbox[instanceID1])
 	broker.mu.RUnlock()
 
-	inbox6, _ := broker.Register(context.Background(), instanceID6)
+	inbox6, _, _ := broker.Register(context.Background(), instanceID6)
 	broker.mu.RLock()
 	assert.Equal(t, 4, len(broker.outbox))
 	broker.mu.RUnlock()
@@ -176,11 +176,11 @@ func TestBroker_MultipleInstanceIds(t *testing.T) {
 	broker.Start(context.Background())
 	t.Cleanup(broker.Close)
 
-	inbox1, err := broker.Register(context.Background(), instanceID1)
+	inbox1, _, err := broker.Register(context.Background(), instanceID1)
 	require.NoError(t, err)
-	inbox2, err := broker.Register(context.Background(), instanceID2)
+	inbox2, _, err := broker.Register(context.Background(), instanceID2)
 	require.NoError(t, err)
-	inbox3, err := broker.Register(context.Background(), instanceID3)
+	inbox3, _, err := broker.Register(context.Background(), instanceID3)
 	require.NoError(t, err)
 
 	var wg sync.WaitGroup
@@ -269,7 +269,7 @@ func TestBroker_HandleMaliciousHareMessage(t *testing.T) {
 	broker.Start(ctx)
 	t.Cleanup(broker.Close)
 
-	inbox, err := broker.Register(context.Background(), instanceID1)
+	inbox, et, err := broker.Register(context.Background(), instanceID1)
 	require.NoError(t, err)
 
 	signer, err := signing.NewEdSigner()
@@ -284,6 +284,8 @@ func TestBroker_HandleMaliciousHareMessage(t *testing.T) {
 	msg, ok := got.(*Message)
 	require.True(t, ok)
 	require.EqualValues(t, m, msg)
+
+	require.False(t, et.Dishonest(signer.NodeID(), m.Round))
 
 	proof := types.MalfeasanceProof{
 		Layer: types.LayerID(1111),
@@ -311,12 +313,13 @@ func TestBroker_HandleMaliciousHareMessage(t *testing.T) {
 			require.Equal(t, *gossip, gotG)
 			return nil
 		})
-	require.Error(t, broker.HandleMessage(ctx, "", data))
-	require.Len(t, inbox, 1)
-	got = <-inbox
-	em, ok := got.(*types.HareEligibilityGossip)
-	require.True(t, ok)
-	require.EqualValues(t, gossip.Eligibility, em)
+	require.ErrorContains(t, broker.HandleMessage(ctx, "", data), "known malicious")
+	require.True(t, et.Dishonest(signer.NodeID(), gossip.Eligibility.Round))
+
+	// receive the same gossip should not cause the eligibility to get gossiped again
+	broker.mockMesh.EXPECT().GetMalfeasanceProof(signer.NodeID()).Return(&proof, nil)
+	require.ErrorContains(t, broker.HandleMessage(ctx, "", data), "known malicious")
+	require.True(t, et.Dishonest(signer.NodeID(), gossip.Eligibility.Round))
 }
 
 func TestBroker_HandleEligibility(t *testing.T) {
@@ -347,7 +350,7 @@ func TestBroker_HandleEligibility(t *testing.T) {
 
 	t.Run("node not synced", func(t *testing.T) {
 		broker.mockSyncS.EXPECT().IsSynced(gomock.Any()).Return(false)
-		inbox, err = broker.Register(context.Background(), instanceID1)
+		inbox, _, err = broker.Register(context.Background(), instanceID1)
 		require.ErrorIs(t, err, errInstanceNotSynced)
 		require.Nil(t, inbox)
 	})
@@ -355,7 +358,7 @@ func TestBroker_HandleEligibility(t *testing.T) {
 	t.Run("beacon not synced", func(t *testing.T) {
 		broker.mockSyncS.EXPECT().IsSynced(gomock.Any()).Return(true)
 		broker.mockSyncS.EXPECT().IsBeaconSynced(gomock.Any()).Return(false)
-		inbox, err = broker.Register(context.Background(), instanceID1)
+		inbox, _, err = broker.Register(context.Background(), instanceID1)
 		require.ErrorIs(t, err, errInstanceNotSynced)
 		require.Nil(t, inbox)
 	})
@@ -364,7 +367,7 @@ func TestBroker_HandleEligibility(t *testing.T) {
 		errUnknown := errors.New("blah")
 		broker.mockSyncS.EXPECT().IsSynced(gomock.Any()).Return(true)
 		broker.mockSyncS.EXPECT().IsBeaconSynced(gomock.Any()).Return(true)
-		inbox, err = broker.Register(context.Background(), instanceID1)
+		inbox, _, err = broker.Register(context.Background(), instanceID1)
 		require.NoError(t, err)
 		require.NotNil(t, inbox)
 		broker.mockStateQ.EXPECT().IsIdentityActiveOnConsensusView(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, errUnknown)
@@ -375,7 +378,7 @@ func TestBroker_HandleEligibility(t *testing.T) {
 	t.Run("identity not active", func(t *testing.T) {
 		broker.mockSyncS.EXPECT().IsSynced(gomock.Any()).Return(true)
 		broker.mockSyncS.EXPECT().IsBeaconSynced(gomock.Any()).Return(true)
-		inbox, err = broker.Register(context.Background(), instanceID1)
+		inbox, _, err = broker.Register(context.Background(), instanceID1)
 		require.NoError(t, err)
 		require.NotNil(t, inbox)
 		broker.mockStateQ.EXPECT().IsIdentityActiveOnConsensusView(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
@@ -386,7 +389,7 @@ func TestBroker_HandleEligibility(t *testing.T) {
 	t.Run("identity not eligible", func(t *testing.T) {
 		broker.mockSyncS.EXPECT().IsSynced(gomock.Any()).Return(true)
 		broker.mockSyncS.EXPECT().IsBeaconSynced(gomock.Any()).Return(true)
-		inbox, err = broker.Register(context.Background(), instanceID1)
+		inbox, _, err = broker.Register(context.Background(), instanceID1)
 		require.NoError(t, err)
 		require.NotNil(t, inbox)
 		broker.mockStateQ.EXPECT().IsIdentityActiveOnConsensusView(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil)
@@ -397,7 +400,7 @@ func TestBroker_HandleEligibility(t *testing.T) {
 	t.Run("identity eligible", func(t *testing.T) {
 		broker.mockSyncS.EXPECT().IsSynced(gomock.Any()).Return(true)
 		broker.mockSyncS.EXPECT().IsBeaconSynced(gomock.Any()).Return(true)
-		inbox, err = broker.Register(context.Background(), instanceID1)
+		inbox, _, err = broker.Register(context.Background(), instanceID1)
 		require.NoError(t, err)
 		require.NotNil(t, inbox)
 		broker.mockStateQ.EXPECT().IsIdentityActiveOnConsensusView(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil)
@@ -474,7 +477,7 @@ func TestBroker_Register3(t *testing.T) {
 	broker.HandleMessage(context.Background(), "", mustEncode(t, m))
 	time.Sleep(1 * time.Millisecond)
 	client := mockClient{instanceID1}
-	ch, _ := broker.Register(context.Background(), client.id)
+	ch, _, _ := broker.Register(context.Background(), client.id)
 	timer := time.NewTimer(2 * time.Second)
 	for {
 		select {
@@ -494,7 +497,7 @@ func TestBroker_PubkeyExtraction(t *testing.T) {
 	broker.mockMesh.EXPECT().GetMalfeasanceProof(gomock.Any())
 	broker.Start(context.Background())
 	t.Cleanup(broker.Close)
-	inbox, _ := broker.Register(context.Background(), instanceID1)
+	inbox, _, _ := broker.Register(context.Background(), instanceID1)
 
 	signer, err := signing.NewEdSigner()
 	require.NoError(t, err)
@@ -568,7 +571,7 @@ func TestBroker_Register4(t *testing.T) {
 	b.Start(context.Background())
 	t.Cleanup(b.Close)
 
-	c, e := b.Register(context.Background(), instanceID1)
+	c, _, e := b.Register(context.Background(), instanceID1)
 	r.NoError(e)
 
 	b.mu.RLock()
@@ -576,7 +579,7 @@ func TestBroker_Register4(t *testing.T) {
 	b.mu.RUnlock()
 
 	b.mockSyncS.EXPECT().IsSynced(gomock.Any()).Return(false)
-	_, e = b.Register(context.Background(), instanceID2)
+	_, _, e = b.Register(context.Background(), instanceID2)
 	r.NotNil(e)
 }
 
@@ -598,13 +601,13 @@ func TestBroker_eventLoop(t *testing.T) {
 	r.Error(b.HandleMessage(context.Background(), "", mustEncode(t, m)))
 
 	b.mockSyncS.EXPECT().IsSynced(gomock.Any()).Return(false)
-	_, e := b.Register(context.Background(), instanceID1)
+	_, _, e := b.Register(context.Background(), instanceID1)
 	r.NotNil(e)
 
 	// synced
 	b.mockSyncS.EXPECT().IsSynced(gomock.Any()).Return(true).AnyTimes()
 	b.mockSyncS.EXPECT().IsBeaconSynced(gomock.Any()).Return(true).AnyTimes()
-	c, e := b.Register(context.Background(), instanceID1)
+	c, _, e := b.Register(context.Background(), instanceID1)
 	r.Nil(e)
 	r.Equal(nil, b.HandleMessage(context.Background(), "", mustEncode(t, m)))
 	recM := <-c
@@ -624,7 +627,7 @@ func TestBroker_eventLoop(t *testing.T) {
 	m.SmesherID = signer.NodeID()
 	r.Error(b.HandleMessage(context.Background(), "", mustEncode(t, m)))
 
-	c, e = b.Register(context.Background(), instanceID3)
+	c, _, e = b.Register(context.Background(), instanceID3)
 	r.Nil(e)
 	r.Equal(nil, b.HandleMessage(context.Background(), "", mustEncode(t, m)))
 	recM = <-c
@@ -658,25 +661,67 @@ func Test_validate(t *testing.T) {
 	r.ErrorIs(e, errFutureMsg)
 }
 
-func TestBroker_clean(t *testing.T) {
+func minDeleted(b *testBroker) types.LayerID {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return b.minDeleted
+}
+
+func hasTracker(b *testBroker, lid types.LayerID) bool {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	_, ok := b.trackers[lid]
+	return ok
+}
+
+func TestBroker_CleanOldLayers(t *testing.T) {
 	r := require.New(t)
 	b := buildBroker(t, t.Name())
+	b.mockSyncS.EXPECT().IsSynced(gomock.Any()).Return(true).AnyTimes()
+	b.mockSyncS.EXPECT().IsBeaconSynced(gomock.Any()).Return(true).AnyTimes()
 
-	ten := instanceID0.Add(10)
-	b.setLatestLayer(context.Background(), ten.Sub(1))
+	require.Equal(t, types.GetEffectiveGenesis(), minDeleted(b))
 
+	plusFive := types.GetEffectiveGenesis().Add(5)
+	plusTen := types.GetEffectiveGenesis().Add(10)
+	b.Register(context.Background(), plusFive)
+	b.Register(context.Background(), plusTen)
+
+	b.CleanOldLayers(plusTen)
+	r.Equal(plusFive-1, minDeleted(b))
+
+	b.Unregister(context.Background(), plusFive)
+	b.CleanOldLayers(plusTen)
+	r.Equal(plusTen-1, minDeleted(b))
+
+	// received lots of spam from past and future
+	past := plusFive - 4
+	future := plusTen + 10
 	b.mu.Lock()
-	b.outbox[5] = make(chan any)
+	for lid := past; lid <= future; lid++ {
+		b.trackers[lid] = NewEligibilityTracker(10)
+	}
 	b.mu.Unlock()
 
-	b.cleanOldLayers()
-	r.Equal(ten.Sub(2), b.minDeleted)
+	b.CleanOldLayers(plusTen)
+	require.Equal(t, plusTen-1, minDeleted(b))
+	for lid := types.LayerID(0); lid < plusTen; lid++ {
+		require.False(t, hasTracker(b, lid), lid)
+	}
+	for lid := plusTen; lid <= future; lid++ {
+		require.True(t, hasTracker(b, lid))
+	}
 
-	b.mu.Lock()
-	delete(b.outbox, 5)
-	b.mu.Unlock()
+	b.Unregister(context.Background(), plusTen)
+	b.CleanOldLayers(plusTen)
+	require.Equal(t, plusTen, minDeleted(b))
+	require.False(t, hasTracker(b, plusTen))
 
-	b.cleanOldLayers()
+	for lid := plusTen + 1; lid <= future; lid++ {
+		require.True(t, hasTracker(b, lid))
+		b.CleanOldLayers(lid)
+		require.False(t, hasTracker(b, lid))
+	}
 }
 
 func TestBroker_Flow(t *testing.T) {
@@ -703,7 +748,7 @@ func TestBroker_Flow(t *testing.T) {
 	m1 := builder.Sign(signer1).Build()
 	b.HandleMessage(context.Background(), "", mustEncode(t, m1))
 
-	ch1, e := b.Register(context.Background(), instanceID1)
+	ch1, _, e := b.Register(context.Background(), instanceID1)
 	r.NoError(e)
 	<-ch1
 
@@ -718,7 +763,7 @@ func TestBroker_Flow(t *testing.T) {
 		SetValues(NewDefaultEmptySet()).
 		SetEligibilityCount(1)
 	m2 := builder.Sign(signer2).Build()
-	ch2, e := b.Register(context.Background(), instanceID2)
+	ch2, _, e := b.Register(context.Background(), instanceID2)
 	r.NoError(e)
 
 	b.HandleMessage(context.Background(), "", mustEncode(t, m1))
@@ -730,12 +775,14 @@ func TestBroker_Flow(t *testing.T) {
 	b.Register(context.Background(), instanceID3)
 	b.Register(context.Background(), instanceID4)
 	b.Unregister(context.Background(), instanceID2)
-	r.Equal(instanceID0, b.minDeleted)
+	b.CleanOldLayers(instanceID4)
+	r.Equal(instanceID0, minDeleted(b))
 
 	// check still receiving msgs on ch1
 	b.HandleMessage(context.Background(), "", mustEncode(t, m1))
 	<-ch1
 
 	b.Unregister(context.Background(), instanceID1)
-	r.Equal(instanceID2, b.minDeleted)
+	b.CleanOldLayers(instanceID4)
+	r.Equal(instanceID2, minDeleted(b))
 }

--- a/hare/consensus_test.go
+++ b/hare/consensus_test.go
@@ -184,7 +184,7 @@ func createConsensusProcess(
 	oracle.Register(isHonest, sig.NodeID())
 	edVerifier, err := signing.NewEdVerifier()
 	require.NoError(tb, err)
-	c, err := broker.Register(ctx, layer)
+	c, et, err := broker.Register(ctx, layer)
 	require.NoError(tb, err)
 	nonce := types.VRFPostIndex(1)
 	mch := make(chan *types.MalfeasanceGossip, cfg.N)
@@ -203,6 +203,7 @@ func createConsensusProcess(
 		broker.mockStateQ,
 		sig,
 		edVerifier,
+		et,
 		sig.NodeID(),
 		&nonce,
 		network,

--- a/hare/eligibility_tracker.go
+++ b/hare/eligibility_tracker.go
@@ -1,6 +1,10 @@
 package hare
 
-import "github.com/spacemeshos/go-spacemesh/common/types"
+import (
+	"sync"
+
+	"github.com/spacemeshos/go-spacemesh/common/types"
+)
 
 type Cred struct {
 	Count  uint16
@@ -11,6 +15,8 @@ type EligibilityTracker struct {
 	expectedSize int
 	// the eligible identities (string(publicKeyBytes)) for each round and whether it is honest
 	nodesByRound map[uint32]map[types.NodeID]*Cred
+
+	mu sync.RWMutex
 }
 
 func NewEligibilityTracker(size int) *EligibilityTracker {
@@ -21,6 +27,8 @@ func NewEligibilityTracker(size int) *EligibilityTracker {
 }
 
 func (et *EligibilityTracker) ForEach(round uint32, apply func(types.NodeID, *Cred)) {
+	et.mu.RLock()
+	defer et.mu.RUnlock()
 	_, ok := et.nodesByRound[round]
 	if !ok {
 		return
@@ -30,13 +38,31 @@ func (et *EligibilityTracker) ForEach(round uint32, apply func(types.NodeID, *Cr
 	}
 }
 
-func (et *EligibilityTracker) Track(nodeID types.NodeID, round uint32, count uint16, honest bool) {
+// Track records a miner's eligibility in a given round and returns if it was known malicious prior to the update.
+func (et *EligibilityTracker) Track(nodeID types.NodeID, round uint32, count uint16, honest bool) bool {
+	et.mu.Lock()
+	defer et.mu.Unlock()
 	if _, ok := et.nodesByRound[round]; !ok {
 		et.nodesByRound[round] = make(map[types.NodeID]*Cred, et.expectedSize)
 	}
-	if _, ok := et.nodesByRound[round][nodeID]; !ok {
+	cred, ok := et.nodesByRound[round][nodeID]
+	wasDishonest := cred != nil && !cred.Honest
+	if !ok {
 		et.nodesByRound[round][nodeID] = &Cred{Count: count, Honest: honest}
 	} else if !honest { // only update if the identity is newly malicious
 		et.nodesByRound[round][nodeID].Honest = false
 	}
+	return wasDishonest
+}
+
+// Dishonest returns whether an eligible identity is known malicious.
+func (et *EligibilityTracker) Dishonest(nodeID types.NodeID, round uint32) bool {
+	et.mu.RLock()
+	defer et.mu.RUnlock()
+	if _, ok := et.nodesByRound[round]; ok {
+		if cred, ok2 := et.nodesByRound[round][nodeID]; ok2 {
+			return !cred.Honest
+		}
+	}
+	return false
 }

--- a/hare/hare.go
+++ b/hare/hare.go
@@ -192,7 +192,7 @@ func New(
 	if h.msh == nil {
 		h.msh = defaultMesh{CachedDB: cdb}
 	}
-	h.broker = newBroker(h.msh, edVerifier, ev, stateQ, syncState, h.mchMalfeasance, conf.LimitConcurrent, logger)
+	h.broker = newBroker(h.msh, edVerifier, ev, stateQ, syncState, publisher, conf.LimitConcurrent, logger)
 
 	return h
 }

--- a/hare/hare.go
+++ b/hare/hare.go
@@ -29,6 +29,7 @@ type consensusFactory func(
 	types.LayerID,
 	*Set,
 	Rolacle,
+	*EligibilityTracker,
 	*signing.EdSigner,
 	*types.VRFPostIndex,
 	pubsub.Publisher,
@@ -178,8 +179,8 @@ func New(
 	h.wcChan = make(chan wcReport, h.config.Hdist)
 	h.outputs = make(map[types.LayerID][]types.ProposalID, h.config.Hdist) // we keep results about LayerBuffer past layers
 	h.cps = make(map[types.LayerID]Consensus, h.config.LimitConcurrent)
-	h.factory = func(ctx context.Context, conf config.Config, instanceId types.LayerID, s *Set, oracle Rolacle, signing *signing.EdSigner, nonce *types.VRFPostIndex, p2p pubsub.Publisher, comm communication, clock RoundClock) Consensus {
-		return newConsensusProcess(ctx, conf, instanceId, s, oracle, stateQ, signing, edVerifier, nid, nonce, p2p, comm, ev, clock, logger)
+	h.factory = func(ctx context.Context, conf config.Config, instanceId types.LayerID, s *Set, oracle Rolacle, et *EligibilityTracker, signing *signing.EdSigner, nonce *types.VRFPostIndex, p2p pubsub.Publisher, comm communication, clock RoundClock) Consensus {
+		return newConsensusProcess(ctx, conf, instanceId, s, oracle, stateQ, signing, edVerifier, et, nid, nonce, p2p, comm, ev, clock, logger)
 	}
 
 	h.nodeID = nid
@@ -192,7 +193,7 @@ func New(
 	if h.msh == nil {
 		h.msh = defaultMesh{CachedDB: cdb}
 	}
-	h.broker = newBroker(h.msh, edVerifier, ev, stateQ, syncState, publisher, conf.LimitConcurrent, logger)
+	h.broker = newBroker(h.config, h.msh, edVerifier, ev, stateQ, syncState, publisher, conf.LimitConcurrent, logger)
 
 	return h
 }
@@ -378,7 +379,7 @@ func (h *Hare) onTick(ctx context.Context, lid types.LayerID) (bool, error) {
 		nonce = &nnc
 	}
 
-	ch, err := h.broker.Register(ctx, lid)
+	ch, et, err := h.broker.Register(ctx, lid)
 	if err != nil {
 		return false, fmt.Errorf("broker register: %w", err)
 	}
@@ -391,7 +392,7 @@ func (h *Hare) onTick(ctx context.Context, lid types.LayerID) (bool, error) {
 	props := goodProposals(ctx, h.Log, h.msh, h.nodeID, lid, beacon)
 	preNumProposals.Add(float64(len(props)))
 	set := NewSet(props)
-	cp := h.factory(ctx, h.config, lid, set, h.rolacle, h.sign, nonce, h.publisher, comm, clock)
+	cp := h.factory(ctx, h.config, lid, set, h.rolacle, et, h.sign, nonce, h.publisher, comm, clock)
 
 	h.With().Debug("starting hare",
 		log.Context(ctx),
@@ -586,6 +587,7 @@ func (h *Hare) tickLoop(ctx context.Context) {
 			if err != nil && !errors.Is(err, context.Canceled) {
 				h.With().Warning("hare failed", log.Context(ctx), layer, log.Err(err))
 			}
+			h.broker.CleanOldLayers(layer)
 		case <-h.ctx.Done():
 			return
 		}

--- a/hare/hare_test.go
+++ b/hare/hare_test.go
@@ -198,7 +198,7 @@ func TestHare_OutputCollectionLoop(t *testing.T) {
 	require.NoError(t, h.Start(context.Background()))
 
 	lyrID := types.LayerID(8)
-	_, err := h.broker.Register(context.Background(), lyrID)
+	_, _, err := h.broker.Register(context.Background(), lyrID)
 	require.NoError(t, err)
 	time.Sleep(1 * time.Second)
 
@@ -295,7 +295,7 @@ func TestHare_onTick(t *testing.T) {
 	createdChan := make(chan struct{}, 1)
 	startedChan := make(chan struct{}, 1)
 	var nmcp *mockConsensusProcess
-	h.factory = func(ctx context.Context, cfg config.Config, instanceId types.LayerID, s *Set, oracle Rolacle, sig *signing.EdSigner, _ *types.VRFPostIndex, p2p pubsub.Publisher, comm communication, clock RoundClock) Consensus {
+	h.factory = func(ctx context.Context, cfg config.Config, instanceId types.LayerID, s *Set, oracle Rolacle, et *EligibilityTracker, sig *signing.EdSigner, _ *types.VRFPostIndex, p2p pubsub.Publisher, comm communication, clock RoundClock) Consensus {
 		nmcp = newMockConsensusProcess(cfg, instanceId, s, oracle, sig, p2p, comm.report, comm.wc, startedChan)
 		close(createdChan)
 		return nmcp
@@ -366,7 +366,7 @@ func TestHare_onTick_notMining(t *testing.T) {
 	createdChan := make(chan struct{}, 1)
 	startedChan := make(chan struct{}, 1)
 	var nmcp *mockConsensusProcess
-	h.factory = func(ctx context.Context, cfg config.Config, instanceId types.LayerID, s *Set, oracle Rolacle, sig *signing.EdSigner, _ *types.VRFPostIndex, p2p pubsub.Publisher, comm communication, clock RoundClock) Consensus {
+	h.factory = func(ctx context.Context, cfg config.Config, instanceId types.LayerID, s *Set, oracle Rolacle, et *EligibilityTracker, sig *signing.EdSigner, _ *types.VRFPostIndex, p2p pubsub.Publisher, comm communication, clock RoundClock) Consensus {
 		nmcp = newMockConsensusProcess(cfg, instanceId, s, oracle, sig, p2p, comm.report, comm.wc, startedChan)
 		close(createdChan)
 		return nmcp


### PR DESCRIPTION
## Motivation
Closes #4521

## Changes
- immediately re-gossip the eligibility when receiving a hare msg from a previously known malicious identity
- share eligibility tracker btwn broker and consensus processes so we can check whether we have previously gossiped eligibility proof for the same identity/layer/round
- make sure broker's old data is cleaned up on every layer tick