### PR TITLE
[Merged by Bors] - tortoise: use zap directly and make logging cheaper

### DIFF
--- a/log/logtest/log.go
+++ b/log/logtest/log.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"testing"
 
+	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest"
 
@@ -11,6 +12,10 @@ import (
 )
 
 const testLogLevel = "TEST_LOG_LEVEL"
+
+func Zap(tb testing.TB, override ...zapcore.Level) *zap.Logger {
+	return New(tb, override...).Zap()
+}
 
 // New creates log.Log instance that will use testing.TB.Log internally.
 func New(tb testing.TB, override ...zapcore.Level) log.Log {

--- a/log/zap.go
+++ b/log/zap.go
@@ -104,6 +104,10 @@ func ShortStringer(name string, val ShortString) Field {
 	return Field(zap.Stringer(name, shortStringAdapter{val: val}))
 }
 
+func ZShortStringer(name string, val ShortString) zap.Field {
+	return zap.Stringer(name, shortStringAdapter{val: val})
+}
+
 // Binary will encode binary content in base64 when logged.
 func Binary(name string, val []byte) Field {
 	return Field(zap.Binary(name, val))
@@ -181,6 +185,10 @@ func Array(name string, array ArrayMarshaler) Field {
 // Context inlines requestId and sessionId fields if they are present.
 func Context(ctx context.Context) Field {
 	return Field(zap.Inline(&marshalledContext{Context: ctx}))
+}
+
+func ZContext(ctx context.Context) zap.Field {
+	return zap.Inline(&marshalledContext{Context: ctx})
 }
 
 func Any(key string, value any) Field {

--- a/tortoise/algorithm.go
+++ b/tortoise/algorithm.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/common/types/result"
 	"github.com/spacemeshos/go-spacemesh/log"
+	"go.uber.org/zap"
 )
 
 // Config for protocol parameters.
@@ -40,7 +41,7 @@ func DefaultConfig() Config {
 
 // Tortoise is a thread safe verifying tortoise wrapper, it just locks all actions.
 type Tortoise struct {
-	logger log.Log
+	logger *zap.Logger
 	ctx    context.Context
 	cfg    Config
 
@@ -55,7 +56,7 @@ type Opt func(t *Tortoise)
 // WithLogger defines logger for tortoise.
 func WithLogger(logger log.Log) Opt {
 	return func(t *Tortoise) {
-		t.logger = logger
+		t.logger = logger.Zap()
 	}
 }
 
@@ -77,16 +78,16 @@ func WithTracer(opts ...TraceOpt) Opt {
 func New(opts ...Opt) (*Tortoise, error) {
 	t := &Tortoise{
 		ctx:    context.Background(),
-		logger: log.NewNop(),
+		logger: log.NewNop().Zap(),
 		cfg:    DefaultConfig(),
 	}
 	for _, opt := range opts {
 		opt(t)
 	}
 	if t.cfg.Hdist < t.cfg.Zdist {
-		t.logger.With().Panic("hdist must be >= zdist",
-			log.Uint32("hdist", t.cfg.Hdist),
-			log.Uint32("zdist", t.cfg.Zdist),
+		t.logger.Panic("hdist must be >= zdist",
+			zap.Uint32("hdist", t.cfg.Hdist),
+			zap.Uint32("zdist", t.cfg.Zdist),
 		)
 	}
 	t.trtl = newTurtle(t.logger, t.cfg)
@@ -115,10 +116,10 @@ func (t *Tortoise) LatestComplete() types.LayerID {
 func (t *Tortoise) OnWeakCoin(lid types.LayerID, coin bool) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	t.logger.With().Debug("on weakcoin",
-		log.Uint32("layer_id", lid.Uint32()),
-		log.Uint32("evicted", t.trtl.evicted.Uint32()),
-		log.Bool("coin", coin),
+	t.logger.Debug("on weakcoin",
+		zap.Uint32("layer_id", lid.Uint32()),
+		zap.Uint32("evicted", t.trtl.evicted.Uint32()),
+		zap.Bool("coin", coin),
 	)
 	if lid <= t.trtl.evicted {
 		return
@@ -138,10 +139,10 @@ func (t *Tortoise) OnBeacon(eid types.EpochID, beacon types.Beacon) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	firstInWindow := t.trtl.evicted.Add(1).GetEpoch()
-	t.logger.With().Debug("on beacon",
-		log.Uint32("epoch id", eid.Uint32()),
-		log.Uint32("first epoch", firstInWindow.Uint32()),
-		log.Stringer("beacon", beacon),
+	t.logger.Debug("on beacon",
+		zap.Uint32("epoch id", eid.Uint32()),
+		zap.Uint32("first epoch", firstInWindow.Uint32()),
+		zap.Stringer("beacon", beacon),
 	)
 	if eid < firstInWindow {
 		return
@@ -265,7 +266,9 @@ func (t *Tortoise) OnBallot(ballot *types.BallotTortoiseData) {
 	err := t.trtl.onBallot(ballot)
 	if err != nil {
 		errorsCounter.Inc()
-		t.logger.With().Error("failed to save state from ballot", ballot.ID, log.Err(err))
+		t.logger.Error("failed to save state from ballot",
+			zap.Stringer("ballot", ballot.ID),
+			zap.Error(err))
 	}
 	if t.tracer != nil {
 		t.tracer.On(&BallotTrace{Ballot: ballot})
@@ -383,10 +386,10 @@ func (t *Tortoise) Updates() []result.Layer {
 	}
 	rst, err := t.results(t.trtl.pending, t.trtl.processed)
 	if err != nil {
-		t.logger.With().Panic("unexpected error",
-			log.Uint32("pending", t.trtl.pending.Uint32()),
-			log.Uint32("processed", t.trtl.pending.Uint32()),
-			log.Err(err),
+		t.logger.Panic("unexpected error",
+			zap.Uint32("pending", t.trtl.pending.Uint32()),
+			zap.Uint32("processed", t.trtl.pending.Uint32()),
+			zap.Error(err),
 		)
 	}
 	t.trtl.pending = 0

--- a/tortoise/algorithm.go
+++ b/tortoise/algorithm.go
@@ -6,10 +6,11 @@ import (
 	"sync"
 	"time"
 
+	"go.uber.org/zap"
+
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/common/types/result"
 	"github.com/spacemeshos/go-spacemesh/log"
-	"go.uber.org/zap"
 )
 
 // Config for protocol parameters.

--- a/tortoise/full.go
+++ b/tortoise/full.go
@@ -3,8 +3,9 @@ package tortoise
 import (
 	"time"
 
-	"github.com/spacemeshos/go-spacemesh/common/types"
 	"go.uber.org/zap"
+
+	"github.com/spacemeshos/go-spacemesh/common/types"
 )
 
 func newFullTortoise(config Config, state *state) *full {

--- a/tortoise/full_test.go
+++ b/tortoise/full_test.go
@@ -61,7 +61,7 @@ func TestFullBallotFilter(t *testing.T) {
 			config := Config{}
 			config.BadBeaconVoteDelayLayers = tc.distance
 			require.Equal(t, tc.expect, newFullTortoise(config, state).shouldBeDelayed(
-				logtest.New(t), &tc.ballot))
+				logtest.Zap(t), &tc.ballot))
 		})
 	}
 }
@@ -321,7 +321,7 @@ func TestFullCountVotes(t *testing.T) {
 	} {
 		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
-			logger := logtest.New(t)
+			logger := logtest.Zap(t)
 			tortoise := defaultAlgorithm(t)
 			var activeset []types.ATXID
 			for i := range tc.activeset {
@@ -544,7 +544,7 @@ func TestFullVerify(t *testing.T) {
 				}
 				layer.blocks = append(layer.blocks, block)
 			}
-			require.Equal(t, tc.validity != nil, full.verify(logtest.New(t), target))
+			require.Equal(t, tc.validity != nil, full.verify(logtest.Zap(t), target))
 			if tc.validity != nil {
 				for i, expect := range tc.validity {
 					require.Equal(t, expect, layer.blocks[i].validity)

--- a/tortoise/tortoise.go
+++ b/tortoise/tortoise.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/spacemeshos/fixed"
+	"go.uber.org/zap"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/log"
@@ -21,7 +22,7 @@ var errBeaconUnavailable = errors.New("beacon unavailable")
 
 type turtle struct {
 	Config
-	logger log.Log
+	logger *zap.Logger
 
 	*state
 
@@ -41,7 +42,7 @@ type turtle struct {
 }
 
 // newTurtle creates a new verifying tortoise algorithm instance.
-func newTurtle(logger log.Log, config Config) *turtle {
+func newTurtle(logger *zap.Logger, config Config) *turtle {
 	t := &turtle{
 		Config: config,
 		state:  newState(),
@@ -84,10 +85,10 @@ func (t *turtle) evict(ctx context.Context) {
 	if !ok {
 		return
 	}
-	t.logger.With().Debug("evict in memory state",
-		log.Stringer("pending", t.pending),
-		log.Stringer("from_layer", t.evicted.Add(1)),
-		log.Stringer("upto_layer", windowStart),
+	t.logger.Debug("evict in memory state",
+		zap.Stringer("pending", t.pending),
+		zap.Stringer("from_layer", t.evicted.Add(1)),
+		zap.Stringer("upto_layer", windowStart),
 	)
 	if !windowStart.After(t.evicted) {
 		return
@@ -128,7 +129,7 @@ func (t *turtle) EncodeVotes(ctx context.Context, conf *encodeConf) (*types.Opin
 		return nil, err
 	}
 	var (
-		logger = t.logger.WithContext(ctx)
+		logger = t.logger.With(log.ZContext(ctx))
 		err    error
 
 		current = t.last.Add(1)
@@ -152,18 +153,18 @@ func (t *turtle) EncodeVotes(ctx context.Context, conf *encodeConf) (*types.Opin
 			opinion, err = t.encodeVotes(ctx, base, t.evicted.Add(1), current)
 			if err == nil {
 				metrics.LayerDistanceToBaseBallot.WithLabelValues().Observe(float64(t.last - base.layer))
-				logger.With().Info("encoded votes",
-					log.Stringer("base ballot", base.id),
-					log.Stringer("base layer", base.layer),
-					log.Stringer("voting layer", current),
-					log.Inline(opinion),
+				logger.Info("encoded votes",
+					zap.Stringer("base ballot", base.id),
+					zap.Stringer("base layer", base.layer),
+					zap.Stringer("voting layer", current),
+					zap.Inline(opinion),
 				)
 				return opinion, nil
 			}
-			logger.With().Debug("failed to encode votes using base ballot id",
-				base.id,
-				log.Err(err),
-				log.Stringer("current layer", current),
+			logger.Debug("failed to encode votes using base ballot id",
+				zap.Stringer("ballot", base.id),
+				zap.Error(err),
+				zap.Stringer("current layer", current),
 			)
 		}
 	}
@@ -180,9 +181,10 @@ func (t *turtle) encodeVotes(
 	start types.LayerID,
 	current types.LayerID,
 ) (*types.Opinion, error) {
-	logger := t.logger.WithContext(ctx).WithFields(
-		log.Stringer("base layer", base.layer),
-		log.Stringer("current layer", current),
+	logger := t.logger.With(
+		log.ZContext(ctx),
+		zap.Stringer("base layer", base.layer),
+		zap.Stringer("current layer", current),
 	)
 	votes := types.Votes{
 		Base: base.id,
@@ -197,7 +199,7 @@ func (t *turtle) encodeVotes(
 			return nil, fmt.Errorf("ballot %s can't be used as a base ballot", base.id)
 		}
 		if lvote.vote != abstain && !layer.hareTerminated {
-			logger.With().Debug("voting abstain on the layer", lvote.lid)
+			logger.Debug("voting abstain on the layer", zap.Uint32("lid", lvote.lid.Uint32()))
 			votes.Abstain = append(votes.Abstain, lvote.lid)
 			continue
 		}
@@ -213,14 +215,14 @@ func (t *turtle) encodeVotes(
 			}
 			switch vote {
 			case support:
-				logger.With().Debug("support before base ballot", log.Inline(block))
+				logger.Debug("support before base ballot", zap.Inline(block))
 				votes.Support = append(votes.Support, block.header())
 			case against:
-				logger.With().Debug("explicit against overwrites base ballot opinion", log.Inline(block))
+				logger.Debug("explicit against overwrites base ballot opinion", zap.Inline(block))
 				votes.Against = append(votes.Against, block.header())
 			case abstain:
-				logger.With().Error("layers that are not terminated should have been encoded earlier",
-					log.Inline(block), log.Stringer("reason", reason),
+				logger.Error("layers that are not terminated should have been encoded earlier",
+					zap.Inline(block), zap.Stringer("reason", reason),
 				)
 			}
 		}
@@ -229,7 +231,7 @@ func (t *turtle) encodeVotes(
 	for lid := base.layer; lid.Before(current); lid = lid.Add(1) {
 		layer := t.layer(lid)
 		if !layer.hareTerminated {
-			logger.With().Debug("voting abstain on the layer", lid)
+			logger.Debug("voting abstain on the layer", zap.Uint32("lid", lid.Uint32()))
 			votes.Abstain = append(votes.Abstain, lid)
 			continue
 		}
@@ -240,13 +242,13 @@ func (t *turtle) encodeVotes(
 			}
 			switch vote {
 			case support:
-				logger.With().Debug("support after base ballot", log.Inline(block), log.Stringer("reason", reason))
+				logger.Debug("support after base ballot", zap.Inline(block), zap.Stringer("reason", reason))
 				votes.Support = append(votes.Support, block.header())
 			case against:
-				logger.With().Debug("implicit against after base ballot", log.Inline(block), log.Stringer("reason", reason))
+				logger.Debug("implicit against after base ballot", zap.Inline(block), zap.Stringer("reason", reason))
 			case abstain:
 				logger.With().Error("layers that are not terminated should have been encoded earlier",
-					log.Inline(block), log.Stringer("reason", reason),
+					zap.Inline(block), zap.Stringer("reason", reason),
 				)
 			}
 		}
@@ -289,7 +291,7 @@ func (t *turtle) getFullVote(verified, current types.LayerID, block *blockInfo) 
 }
 
 func (t *turtle) onLayer(ctx context.Context, last types.LayerID) {
-	t.logger.With().Debug("on layer", last)
+	t.logger.Debug("on layer", zap.Uint32("last", last.Uint32()))
 	defer t.evict(ctx)
 	if last.After(t.last) {
 		t.last = last
@@ -332,9 +334,9 @@ func (t *turtle) onLayer(ctx context.Context, last types.LayerID) {
 			t.pending = types.MinLayer(t.pending, t.last)
 		}
 
-		t.logger.With().Debug("initial local opinion",
-			layer.lid,
-			log.Stringer("local opinion", layer.opinion))
+		t.logger.Debug("initial local opinion",
+			zap.Uint32("lid", layer.lid.Uint32()),
+			zap.Stringer("local opinion", layer.opinion))
 
 		// terminate layer that falls out of the zdist window and wasn't terminated
 		// by any other component
@@ -348,23 +350,24 @@ func (t *turtle) onLayer(ctx context.Context, last types.LayerID) {
 	t.verifyLayers()
 }
 
-func (t *turtle) switchModes(logger log.Log) {
+func (t *turtle) switchModes() {
 	t.isFull = !t.isFull
 	if t.isFull {
 		modeGauge.Set(1)
 	} else {
 		modeGauge.Set(0)
 	}
-	logger.With().Debug("switching tortoise mode",
-		log.Uint32("hdist", t.Hdist),
-		log.Stringer("processed_layer", t.processed),
-		log.Stringer("verified_layer", t.verified),
-		log.Bool("is full", t.isFull),
+	t.logger.Debug("switching tortoise mode",
+		zap.Uint32("last", t.last.Uint32()),
+		zap.Uint32("hdist", t.Hdist),
+		zap.Stringer("processed_layer", t.processed),
+		zap.Stringer("verified_layer", t.verified),
+		zap.Bool("is full", t.isFull),
 	)
 }
 
-func (t *turtle) countBallot(logger log.Log, ballot *ballotInfo) error {
-	bad, err := t.compareBeacons(t.logger, ballot.id, ballot.layer, ballot.reference.beacon)
+func (t *turtle) countBallot(logger *zap.Logger, ballot *ballotInfo) error {
+	bad, err := t.compareBeacons(logger, ballot.id, ballot.layer, ballot.reference.beacon)
 	if err != nil {
 		return fmt.Errorf("%w: %s", errBeaconUnavailable, err.Error())
 	}
@@ -379,28 +382,28 @@ func (t *turtle) countBallot(logger log.Log, ballot *ballotInfo) error {
 func (t *turtle) verifyLayers() {
 	// TODO(dshulyak) simplify processing of layers and notifications
 	var (
-		logger = t.logger.WithFields(
-			log.Stringer("last layer", t.last),
+		zaplog = t.logger.With(
+			zap.Stringer("last layer", t.last),
 		)
 		verified = maxLayer(t.evicted, types.GetEffectiveGenesis())
 	)
 	for target := t.evicted.Add(1); target.Before(t.processed); target = target.Add(1) {
-		success := t.verifying.verify(logger, target)
+		success := t.verifying.verify(zaplog, target)
 		if success && t.isFull {
-			t.switchModes(logger)
+			t.switchModes()
 		}
 		if !success && (t.isFull || !withinDistance(t.Hdist, target, t.last)) {
 			if !t.isFull {
-				t.switchModes(logger)
+				t.switchModes()
 				for counted := maxLayer(t.full.counted.Add(1), t.evicted.Add(1)); !counted.After(t.processed); counted = counted.Add(1) {
 					for _, ballot := range t.ballots[counted] {
-						t.full.countBallot(logger, ballot)
+						t.full.countBallot(zaplog, ballot)
 					}
-					t.full.countDelayed(logger, counted)
+					t.full.countDelayed(zaplog, counted)
 					t.full.counted = counted
 				}
 			}
-			success = t.full.verify(logger, target)
+			success = t.full.verify(zaplog, target)
 		}
 
 		layer := t.layer(target)
@@ -437,12 +440,16 @@ func (t *turtle) verifyLayers() {
 				t.changedOpinion.max = types.MaxLayer(t.changedOpinion.max, target)
 			}
 			if block.validity == abstain {
-				logger.With().Fatal("bug: layer should not be verified if there is an undecided block", target, block.id)
+				zaplog.With().Fatal("bug: layer should not be verified if there is an undecided block",
+					zap.Uint32("target", target.Uint32()),
+					zap.Stringer("block", block.id))
 			}
-			logger.With().Debug("update validity", block.layer, block.id,
-				log.Stringer("validity", block.validity),
-				log.Stringer("hare", block.hare),
-				log.Stringer("emitted", block.emitted),
+			zaplog.Debug("update validity",
+				zap.Uint32("lid", block.layer.Uint32()),
+				zap.Stringer("block", block.id),
+				zap.Stringer("validity", block.validity),
+				zap.Stringer("hare", block.hare),
+				zap.Stringer("emitted", block.emitted),
 			)
 			block.emitted = block.validity
 		}
@@ -450,7 +457,7 @@ func (t *turtle) verifyLayers() {
 	t.verified = verified
 	verifiedLayer.Set(float64(t.verified))
 	if t.changedOpinion.min != 0 && !withinDistance(t.Hdist, t.changedOpinion.max, t.last) {
-		logger.With().Debug("changed opinion outside hdist", log.Stringer("from", t.changedOpinion.min), log.Stringer("to", t.changedOpinion.max))
+		zaplog.Debug("changed opinion outside hdist", zap.Stringer("from", t.changedOpinion.min), zap.Stringer("to", t.changedOpinion.max))
 		t.onOpinionChange(t.changedOpinion.min)
 		t.changedOpinion.min = 0
 		t.changedOpinion.max = 0
@@ -477,7 +484,7 @@ func (t *turtle) onBlock(header types.BlockHeader, data bool, valid bool) {
 		}
 		return
 	}
-	t.logger.With().Debug("on data block", log.Inline(&header))
+	t.logger.Debug("on data block", zap.Inline(&header))
 
 	binfo := newBlockInfo(header)
 	binfo.data = data
@@ -504,7 +511,14 @@ func (t *turtle) onHareOutput(lid types.LayerID, bid types.BlockID) {
 		previous types.BlockID
 		exists   bool
 	)
-	t.logger.With().Debug("on hare output", lid, bid, log.Bool("empty", bid == types.EmptyBlockID), log.Uint32("processed", t.processed.Uint32()), log.Uint32("hdist", t.Hdist), log.Uint32("last", t.last.Uint32()))
+	t.logger.Debug("on hare output",
+		zap.Uint32("lid", lid.Uint32()),
+		zap.Stringer("block", bid),
+		zap.Bool("empty", bid == types.EmptyBlockID),
+		zap.Uint32("processed", t.processed.Uint32()),
+		zap.Uint32("hdist", t.Hdist),
+		zap.Uint32("last", t.last.Uint32()),
+	)
 	layer.hareTerminated = true
 	for i := range layer.blocks {
 		block := layer.blocks[i]
@@ -522,11 +536,11 @@ func (t *turtle) onHareOutput(lid types.LayerID, bid types.BlockID) {
 		return
 	}
 	if !lid.After(t.processed) && withinDistance(t.Config.Hdist, lid, t.last) {
-		t.logger.With().Debug("local opinion changed within hdist",
-			lid,
-			log.Stringer("verified", t.verified),
-			log.Stringer("previous", previous),
-			log.Stringer("new", bid),
+		t.logger.Debug("local opinion changed within hdist",
+			zap.Uint32("lid", lid.Uint32()),
+			zap.Stringer("verified", t.verified),
+			zap.Stringer("previous", previous),
+			zap.Stringer("new", bid),
 		)
 		t.onOpinionChange(lid)
 	}
@@ -541,9 +555,9 @@ func (t *turtle) onOpinionChange(lid types.LayerID) {
 		if opinion != layer.opinion {
 			t.pending = types.MinLayer(t.pending, lid)
 		}
-		t.logger.With().Debug("computed local opinion",
-			layer.lid,
-			log.Stringer("local opinion", layer.opinion))
+		t.logger.Debug("computed local opinion",
+			zap.Uint32("lid", layer.lid.Uint32()),
+			zap.Stringer("local opinion", layer.opinion))
 	}
 	t.verifying.resetWeights(lid)
 	for target := lid.Add(1); !target.After(t.processed); target = target.Add(1) {
@@ -555,16 +569,16 @@ func (t *turtle) onAtx(atx *types.AtxTortoiseData) {
 	start := time.Now()
 	epoch := t.epoch(atx.TargetEpoch)
 	if _, exist := epoch.atxs[atx.ID]; !exist {
-		t.logger.With().Debug("on atx",
-			log.Stringer("id", atx.ID),
-			log.Uint32("epoch", uint32(atx.TargetEpoch)),
-			log.Uint64("weight", atx.Weight),
-			log.Uint64("height", atx.Height),
+		t.logger.Debug("on atx",
+			zap.Stringer("id", atx.ID),
+			zap.Uint32("epoch", uint32(atx.TargetEpoch)),
+			zap.Uint64("weight", atx.Weight),
+			zap.Uint64("height", atx.Height),
 		)
 		epoch.atxs[atx.ID] = atxInfo{weight: atx.Weight, height: atx.Height}
 		if atx.Weight > math.MaxInt64 {
 			// atx weight is not expected to overflow int64
-			t.logger.With().Fatal("fixme: atx size overflows int64", log.Uint64("weight", atx.Weight))
+			t.logger.Fatal("fixme: atx size overflows int64", zap.Uint64("weight", atx.Weight))
 		}
 		epoch.weight = epoch.weight.Add(fixed.New64(int64(atx.Weight)))
 		atxsNumber.Inc()
@@ -587,9 +601,9 @@ func (t *turtle) decodeBallot(ballot *types.BallotTortoiseData) (*ballotInfo, ty
 		return nil, 0, nil
 	}
 
-	t.logger.With().Debug("on ballot",
-		log.Inline(ballot),
-		log.Uint32("processed", t.processed.Uint32()),
+	t.logger.Debug("on ballot",
+		zap.Inline(ballot),
+		zap.Uint32("processed", t.processed.Uint32()),
 	)
 
 	var (
@@ -602,8 +616,8 @@ func (t *turtle) decodeBallot(ballot *types.BallotTortoiseData) (*ballotInfo, ty
 	} else {
 		base = t.state.ballotRefs[ballot.Opinion.Votes.Base]
 		if base == nil {
-			t.logger.With().Warning("base ballot not in state",
-				log.Stringer("base", ballot.Opinion.Votes.Base),
+			t.logger.Warn("base ballot not in state",
+				zap.Stringer("base", ballot.Opinion.Votes.Base),
 			)
 			return nil, 0, nil
 		}
@@ -636,8 +650,8 @@ func (t *turtle) decodeBallot(ballot *types.BallotTortoiseData) (*ballotInfo, ty
 		ptr := *ballot.Ref
 		ref, exists := t.state.ballotRefs[ptr]
 		if !exists {
-			t.logger.With().Warning("ref ballot not in state",
-				log.Stringer("ref", ptr),
+			t.logger.Warn("ref ballot not in state",
+				zap.Stringer("ref", ptr),
 			)
 			return nil, 0, nil
 		}
@@ -666,14 +680,16 @@ func (t *turtle) decodeBallot(ballot *types.BallotTortoiseData) (*ballotInfo, ty
 		).Mul(fixed.New(int(ballot.Eligibilities)))
 	} else {
 		binfo.malicious = true
-		t.logger.With().Warning("ballot from malicious identity will have zeroed weight", ballot.Layer, ballot.ID)
+		t.logger.Warn("ballot from malicious identity will have zeroed weight",
+			zap.Uint32("lid", ballot.Layer.Uint32()),
+			zap.Stringer("ballot", ballot.ID))
 	}
 
-	t.logger.With().Debug("computed weight and height for ballot",
-		ballot.ID,
-		log.Stringer("weight", binfo.weight),
-		log.Uint64("height", refinfo.height),
-		log.Uint32("lid", ballot.Layer.Uint32()),
+	t.logger.Debug("computed weight and height for ballot",
+		zap.Stringer("ballot", ballot.ID),
+		zap.Stringer("weight", binfo.weight),
+		zap.Uint64("height", refinfo.height),
+		zap.Uint32("lid", ballot.Layer.Uint32()),
 	)
 
 	votes, min, err := decodeVotes(t.evicted, binfo.layer, base, ballot.Opinion.Votes)
@@ -681,9 +697,10 @@ func (t *turtle) decodeBallot(ballot *types.BallotTortoiseData) (*ballotInfo, ty
 		return nil, 0, err
 	}
 	binfo.votes = votes
-	t.logger.With().Debug("decoded exceptions",
-		binfo.id, binfo.layer,
-		log.Stringer("opinion", binfo.opinion()),
+	t.logger.Debug("decoded exceptions",
+		zap.Stringer("block", binfo.id),
+		zap.Uint32("lid", binfo.layer.Uint32()),
+		zap.Stringer("opinion", binfo.opinion()),
 	)
 	decodeBallotDuration.Observe(float64(time.Since(start).Nanoseconds()))
 	return binfo, min, nil
@@ -710,7 +727,7 @@ func (t *turtle) storeBallot(ballot *ballotInfo, min types.LayerID) {
 			if errors.Is(err, errBeaconUnavailable) {
 				t.retryLater(ballot)
 			} else {
-				t.logger.Panic("unexpected error in counting ballots", log.Err(err))
+				t.logger.Panic("unexpected error in counting ballots", zap.Error(err))
 			}
 		}
 	}
@@ -725,17 +742,17 @@ func (t *turtle) onBallot(ballot *types.BallotTortoiseData) error {
 	return nil
 }
 
-func (t *turtle) compareBeacons(logger log.Log, bid types.BallotID, lid types.LayerID, beacon types.Beacon) (bool, error) {
+func (t *turtle) compareBeacons(logger *zap.Logger, bid types.BallotID, lid types.LayerID, beacon types.Beacon) (bool, error) {
 	epoch := t.epoch(lid.GetEpoch())
 	if epoch.beacon == nil {
 		return false, errBeaconUnavailable
 	}
 	if beacon != *epoch.beacon {
-		logger.With().Debug("ballot has different beacon",
-			log.Uint32("layer_id", lid.Uint32()),
-			log.Stringer("block", bid),
-			log.ShortStringer("ballot_beacon", beacon),
-			log.ShortStringer("epoch_beacon", epoch.beacon),
+		logger.Debug("ballot has different beacon",
+			zap.Uint32("layer_id", lid.Uint32()),
+			zap.Stringer("block", bid),
+			log.ZShortStringer("ballot_beacon", beacon),
+			log.ZShortStringer("epoch_beacon", epoch.beacon),
 		)
 		return true, nil
 	}

--- a/tortoise/tortoise.go
+++ b/tortoise/tortoise.go
@@ -398,7 +398,7 @@ func (t *turtle) countBallot(ballot *ballotInfo) error {
 
 func (t *turtle) verifyLayers() {
 	// TODO(dshulyak) simplify processing of layers and notifications
-	var verified = maxLayer(t.evicted, types.GetEffectiveGenesis())
+	verified := maxLayer(t.evicted, types.GetEffectiveGenesis())
 
 	for target := t.evicted.Add(1); target.Before(t.processed); target = target.Add(1) {
 		success := t.verifying.verify(t.logger, target)

--- a/tortoise/tortoise_test.go
+++ b/tortoise/tortoise_test.go
@@ -771,16 +771,15 @@ func TestBallotHasGoodBeacon(t *testing.T) {
 
 	trtl := defaultAlgorithm(t)
 
-	logger := logtest.Zap(t)
 	trtl.OnBeacon(layerID.GetEpoch(), epochBeacon)
-	badBeacon, err := trtl.trtl.compareBeacons(logger, ballot.ID(), ballot.Layer, epochBeacon)
+	badBeacon, err := trtl.trtl.compareBeacons(ballot.ID(), ballot.Layer, epochBeacon)
 	assert.NoError(t, err)
 	assert.False(t, badBeacon)
 
 	// bad beacon
 	beacon := types.RandomBeacon()
 	require.NotEqual(t, epochBeacon, beacon)
-	badBeacon, err = trtl.trtl.compareBeacons(logger, ballot.ID(), ballot.Layer, beacon)
+	badBeacon, err = trtl.trtl.compareBeacons(ballot.ID(), ballot.Layer, beacon)
 	assert.NoError(t, err)
 	assert.True(t, badBeacon)
 }

--- a/tortoise/tortoise_test.go
+++ b/tortoise/tortoise_test.go
@@ -771,7 +771,7 @@ func TestBallotHasGoodBeacon(t *testing.T) {
 
 	trtl := defaultAlgorithm(t)
 
-	logger := logtest.New(t)
+	logger := logtest.Zap(t)
 	trtl.OnBeacon(layerID.GetEpoch(), epochBeacon)
 	badBeacon, err := trtl.trtl.compareBeacons(logger, ballot.ID(), ballot.Layer, epochBeacon)
 	assert.NoError(t, err)

--- a/tortoise/util.go
+++ b/tortoise/util.go
@@ -3,9 +3,10 @@ package tortoise
 import (
 	"sort"
 
-	"github.com/spacemeshos/go-spacemesh/common/types"
-	"github.com/spacemeshos/go-spacemesh/log"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/spacemeshos/go-spacemesh/common/types"
 )
 
 const (
@@ -100,9 +101,9 @@ func verifyLayer(logger *zap.Logger, blocks []*blockInfo, getDecision func(*bloc
 }
 
 func zapBlocks(blocks []*blockInfo) zap.Field {
-	return zap.Array("blocks", log.ArrayMarshalerFunc(func(encoder log.ArrayEncoder) error {
+	return zap.Array("blocks", zapcore.ArrayMarshalerFunc(func(encoder zapcore.ArrayEncoder) error {
 		for i := range blocks {
-			encoder.AppendObject(log.ObjectMarshallerFunc(func(encoder log.ObjectEncoder) error {
+			encoder.AppendObject(zapcore.ObjectMarshalerFunc(func(encoder zapcore.ObjectEncoder) error {
 				encoder.AddString("decision", blocks[i].validity.String())
 				encoder.AddString("id", blocks[i].id.String())
 				encoder.AddString("weight", blocks[i].margin.String())

--- a/tortoise/util.go
+++ b/tortoise/util.go
@@ -52,7 +52,7 @@ func maxLayer(i, j types.LayerID) types.LayerID {
 	return j
 }
 
-func verifyLayer(logger *zap.Logger, blocks []*blockInfo, getDecision func(*blockInfo) sign) bool {
+func verifyLayer(logger *zap.Logger, blocks []*blockInfo, getDecision func(*blockInfo) sign) (bool, bool) {
 	// order blocks by height in ascending order
 	// if there is a support before any abstain
 	// and a previous height is lower than the current one
@@ -82,7 +82,7 @@ func verifyLayer(logger *zap.Logger, blocks []*blockInfo, getDecision func(*bloc
 			if supported != nil && block.height > supported.height {
 				decision = against
 			} else {
-				return false
+				return false, false
 			}
 		} else if decision == support {
 			supported = block
@@ -96,23 +96,21 @@ func verifyLayer(logger *zap.Logger, blocks []*blockInfo, getDecision func(*bloc
 		}
 		blocks[i].validity = decision
 	}
-	if changes {
-		logger.Info("candidate layer is verified",
-			zap.Array("blocks",
-				log.ArrayMarshalerFunc(func(encoder log.ArrayEncoder) error {
-					for i := range blocks {
-						encoder.AppendObject(log.ObjectMarshallerFunc(func(encoder log.ObjectEncoder) error {
-							encoder.AddString("decision", blocks[i].validity.String())
-							encoder.AddString("id", blocks[i].id.String())
-							encoder.AddString("weight", blocks[i].margin.String())
-							encoder.AddUint64("height", blocks[i].height)
-							encoder.AddBool("data", blocks[i].data)
-							return nil
-						}))
-					}
-					return nil
-				})),
-		)
-	}
-	return true
+	return true, changes
+}
+
+func zapBlocks(blocks []*blockInfo) zap.Field {
+	return zap.Array("blocks", log.ArrayMarshalerFunc(func(encoder log.ArrayEncoder) error {
+		for i := range blocks {
+			encoder.AppendObject(log.ObjectMarshallerFunc(func(encoder log.ObjectEncoder) error {
+				encoder.AddString("decision", blocks[i].validity.String())
+				encoder.AddString("id", blocks[i].id.String())
+				encoder.AddString("weight", blocks[i].margin.String())
+				encoder.AddUint64("height", blocks[i].height)
+				encoder.AddBool("data", blocks[i].data)
+				return nil
+			}))
+		}
+		return nil
+	}))
 }

--- a/tortoise/util.go
+++ b/tortoise/util.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/log"
+	"go.uber.org/zap"
 )
 
 const (
@@ -51,7 +52,7 @@ func maxLayer(i, j types.LayerID) types.LayerID {
 	return j
 }
 
-func verifyLayer(logger log.Log, blocks []*blockInfo, getDecision func(*blockInfo) sign) bool {
+func verifyLayer(logger *zap.Logger, blocks []*blockInfo, getDecision func(*blockInfo) sign) bool {
 	// order blocks by height in ascending order
 	// if there is a support before any abstain
 	// and a previous height is lower than the current one
@@ -67,13 +68,13 @@ func verifyLayer(logger log.Log, blocks []*blockInfo, getDecision func(*blockInf
 	)
 	for i, block := range blocks {
 		decision := getDecision(block)
-		logger.With().Debug("decision for a block",
-			log.Int("ith", i),
-			block.id,
-			block.layer,
-			log.Stringer("decision", decision),
-			log.Stringer("weight", block.margin),
-			log.Uint64("height", block.height),
+		logger.Debug("decision for a block",
+			zap.Int("ith", i),
+			zap.Stringer("block", block.id),
+			zap.Stringer("lid", block.layer),
+			zap.Stringer("decision", decision),
+			zap.Stringer("weight", block.margin),
+			zap.Uint64("height", block.height),
 		)
 
 		if decision == abstain {
@@ -96,8 +97,8 @@ func verifyLayer(logger log.Log, blocks []*blockInfo, getDecision func(*blockInf
 		blocks[i].validity = decision
 	}
 	if changes {
-		logger.With().Info("candidate layer is verified",
-			log.Array("blocks",
+		logger.Info("candidate layer is verified",
+			zap.Array("blocks",
 				log.ArrayMarshalerFunc(func(encoder log.ArrayEncoder) error {
 					for i := range blocks {
 						encoder.AppendObject(log.ObjectMarshallerFunc(func(encoder log.ObjectEncoder) error {

--- a/tortoise/verifying.go
+++ b/tortoise/verifying.go
@@ -3,9 +3,10 @@ package tortoise
 import (
 	"time"
 
+	"go.uber.org/zap"
+
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/log"
-	"go.uber.org/zap"
 )
 
 func newVerifying(config Config, state *state) *verifying {

--- a/tortoise/verifying.go
+++ b/tortoise/verifying.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/log"
+	"go.uber.org/zap"
 )
 
 func newVerifying(config Config, state *state) *verifying {
@@ -32,23 +33,23 @@ func (v *verifying) resetWeights(voted types.LayerID) {
 	}
 }
 
-func (v *verifying) countBallot(logger log.Log, ballot *ballotInfo) {
+func (v *verifying) countBallot(logger *zap.Logger, ballot *ballotInfo) {
 	start := time.Now()
 
 	prev := v.layer(ballot.layer.Sub(1))
 	counted := !(ballot.conditions.badBeacon ||
 		prev.opinion != ballot.opinion() ||
 		prev.verifying.referenceHeight > ballot.reference.height)
-	logger.With().Debug("count ballot in verifying mode",
-		ballot.layer,
-		ballot.id,
-		log.ShortStringer("ballot opinion", ballot.opinion()),
-		log.ShortStringer("local opinion", prev.opinion),
-		log.Bool("bad beacon", ballot.conditions.badBeacon),
-		log.Stringer("weight", ballot.weight),
-		log.Uint64("reference height", prev.verifying.referenceHeight),
-		log.Uint64("ballot height", ballot.reference.height),
-		log.Bool("counted", counted),
+	logger.Debug("count ballot in verifying mode",
+		zap.Stringer("lid", ballot.layer),
+		zap.Stringer("ballot", ballot.id),
+		log.ZShortStringer("ballot opinion", ballot.opinion()),
+		log.ZShortStringer("local opinion", prev.opinion),
+		zap.Bool("bad beacon", ballot.conditions.badBeacon),
+		zap.Stringer("weight", ballot.weight),
+		zap.Uint64("reference height", prev.verifying.referenceHeight),
+		zap.Uint64("ballot height", ballot.reference.height),
+		zap.Bool("counted", counted),
 	)
 	if !counted {
 		return
@@ -62,16 +63,16 @@ func (v *verifying) countBallot(logger log.Log, ballot *ballotInfo) {
 	vcountBallotDuration.Observe(float64(time.Since(start).Nanoseconds()))
 }
 
-func (v *verifying) countVotes(logger log.Log, ballots []*ballotInfo) {
+func (v *verifying) countVotes(logger *zap.Logger, ballots []*ballotInfo) {
 	for _, ballot := range ballots {
 		v.countBallot(logger, ballot)
 	}
 }
 
-func (v *verifying) verify(logger log.Log, lid types.LayerID) bool {
+func (v *verifying) verify(logger *zap.Logger, lid types.LayerID) bool {
 	layer := v.layer(lid)
 	if !layer.hareTerminated {
-		logger.With().Debug("hare is not terminated")
+		logger.Debug("hare is not terminated")
 		return false
 	}
 
@@ -85,26 +86,26 @@ func (v *verifying) verify(logger log.Log, lid types.LayerID) bool {
 	}
 
 	threshold := v.globalThreshold(v.Config, lid)
-	logger = logger.WithFields(
-		log.String("verifier", "verifying"),
-		log.Stringer("candidate layer", lid),
-		log.Stringer("margin", margin),
-		log.Stringer("uncounted", uncounted),
-		log.Stringer("total good weight", v.totalGoodWeight),
-		log.Stringer("good uncounted", layer.verifying.goodUncounted),
-		log.Stringer("global threshold", threshold),
+	zaplog := logger.With(
+		zap.String("verifier", "verifying"),
+		zap.Stringer("candidate layer", lid),
+		zap.Stringer("margin", margin),
+		zap.Stringer("uncounted", uncounted),
+		zap.Stringer("total good weight", v.totalGoodWeight),
+		zap.Stringer("good uncounted", layer.verifying.goodUncounted),
+		zap.Stringer("global threshold", threshold),
 	)
 	if crossesThreshold(margin, threshold) != support {
-		logger.With().Debug("doesn't cross global threshold")
+		zaplog.Debug("doesn't cross global threshold")
 		return false
 	} else {
-		logger.With().Debug("crosses global threshold")
+		zaplog.Debug("crosses global threshold")
 	}
 	if len(layer.blocks) == 0 {
-		logger.With().Debug("candidate layer is empty")
+		zaplog.Debug("candidate layer is empty")
 	}
 	return verifyLayer(
-		logger,
+		zaplog,
 		layer.blocks,
 		func(block *blockInfo) sign {
 			if block.height > layer.verifying.referenceHeight {

--- a/tortoise/verifying_test.go
+++ b/tortoise/verifying_test.go
@@ -116,7 +116,7 @@ func TestVerifyingProcessLayer(t *testing.T) {
 	} {
 		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
-			logger := logtest.New(t)
+			logger := logtest.Zap(t)
 			v := newVerifying(Config{}, newState())
 			v.processed = start.Add(1).Add(uint32(len(tc.ballots)))
 
@@ -577,7 +577,7 @@ func TestVerifying_Verify(t *testing.T) {
 	} {
 		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
-			logger := logtest.New(t)
+			logger := logtest.Zap(t)
 
 			state := newState()
 			state.epochs = epochs


### PR DESCRIPTION
noticed that our wrapper, string formatting for fixed float, and logger initialization make tortoise unnecessarily slow during restarts. flamegraph below explains the problem