### PR TITLE
[Merged by Bors] - Discard objects from future

### DIFF
--- a/activation/activation_test.go
+++ b/activation/activation_test.go
@@ -33,8 +33,6 @@ const (
 	layersPerEpoch                 = 10
 	layerDuration                  = time.Second
 	postGenesisEpoch types.EpochID = 2
-
-	testTickSize = 1
 )
 
 func TestMain(m *testing.M) {
@@ -69,13 +67,13 @@ func newActivationTx(
 	prevATX types.ATXID,
 	positioningATX types.ATXID,
 	cATX *types.ATXID,
-	PublishEpoch types.EpochID,
+	publishEpoch types.EpochID,
 	startTick, numTicks uint64,
 	coinbase types.Address,
 	numUnits uint32,
 	nipost *types.NIPost,
 ) *types.VerifiedActivationTx {
-	challenge := newChallenge(sequence, prevATX, positioningATX, PublishEpoch, cATX)
+	challenge := newChallenge(sequence, prevATX, positioningATX, publishEpoch, cATX)
 	atx := newAtx(t, sig, challenge, nipost, numUnits, coinbase)
 	if sequence == 0 {
 		nodeID := sig.NodeID()

--- a/activation/handler.go
+++ b/activation/handler.go
@@ -518,7 +518,7 @@ func (h *Handler) handleGossipAtx(ctx context.Context, peer p2p.Peer, msg []byte
 		return fmt.Errorf("nil nipst in gossip for atx %s", atx.ShortString())
 	}
 
-	h.registerHashes(&atx, peer) // TODO(mafa): should this be done after the ATX was validated?
+	h.registerHashes(&atx, peer)
 	if err := h.fetcher.GetPoetProof(ctx, atx.GetPoetProofRef()); err != nil {
 		return fmt.Errorf("received atx (%v) with syntactically invalid or missing PoET proof (%x): %w",
 			atx.ShortString(), atx.GetPoetProofRef().ShortString(), err,

--- a/activation/handler.go
+++ b/activation/handler.go
@@ -143,7 +143,6 @@ func (h *Handler) ProcessAtx(ctx context.Context, atx *types.VerifiedActivationT
 		atx.ID(),
 		atx.PublishEpoch,
 		log.Stringer("smesher", atx.SmesherID),
-		atx.PublishEpoch,
 	)
 	if err := h.ContextuallyValidateAtx(atx); err != nil {
 		h.log.WithContext(ctx).With().Warning("atx failed contextual validation",
@@ -353,7 +352,7 @@ func (h *Handler) storeAtx(ctx context.Context, atx *types.VerifiedActivationTx)
 		return fmt.Errorf("checking if node is malicious: %w", err)
 	}
 	var proof *types.MalfeasanceProof
-	if err = h.cdb.WithTx(ctx, func(dbtx *sql.Tx) error {
+	if err := h.cdb.WithTx(ctx, func(dbtx *sql.Tx) error {
 		if !malicious {
 			prev, err := atxs.GetByEpochAndNodeID(dbtx, atx.PublishEpoch, atx.SmesherID)
 			if err != nil && !errors.Is(err, sql.ErrNotFound) {
@@ -379,7 +378,7 @@ func (h *Handler) storeAtx(ctx context.Context, atx *types.VerifiedActivationTx)
 						Data: &atxProof,
 					},
 				}
-				if err = h.cdb.AddMalfeasanceProof(atx.SmesherID, proof, dbtx); err != nil {
+				if err := h.cdb.AddMalfeasanceProof(atx.SmesherID, proof, dbtx); err != nil {
 					return fmt.Errorf("adding malfeasance proof: %w", err)
 				}
 				h.log.WithContext(ctx).With().Warning("smesher produced more than one atx in the same epoch",
@@ -389,7 +388,7 @@ func (h *Handler) storeAtx(ctx context.Context, atx *types.VerifiedActivationTx)
 				)
 			}
 		}
-		if err = atxs.Add(dbtx, atx); err != nil && !errors.Is(err, sql.ErrObjectExists) {
+		if err := atxs.Add(dbtx, atx); err != nil && !errors.Is(err, sql.ErrObjectExists) {
 			return fmt.Errorf("add atx to db: %w", err)
 		}
 		return nil
@@ -491,6 +490,12 @@ func (h *Handler) handleGossipAtx(ctx context.Context, peer p2p.Peer, msg []byte
 	epochStart := h.clock.LayerToTime(atx.PublishEpoch.FirstLayer())
 	poetRoundEnd := epochStart.Add(h.poetCfg.PhaseShift - h.poetCfg.CycleGap)
 	latency := receivedTime.Sub(poetRoundEnd)
+	if latency < 0 {
+		// received an ATX from the future, ignore
+		// TODO(mafa): generate malfeasance proof?
+		return fmt.Errorf("received ATX from the future: %w", errMalformedData)
+	}
+
 	metrics.ReportMessageLatency(pubsub.AtxProtocol, pubsub.AtxProtocol, latency)
 
 	atx.SetReceived(receivedTime.Local())
@@ -515,22 +520,20 @@ func (h *Handler) handleGossipAtx(ctx context.Context, peer p2p.Peer, msg []byte
 
 	h.registerHashes(&atx, peer)
 	if err := h.fetcher.GetPoetProof(ctx, atx.GetPoetProofRef()); err != nil {
-		return fmt.Errorf("received atx (%v) with syntactically invalid or missing PoET proof (%x): %v",
-			atx.ShortString(), atx.GetPoetProofRef().ShortString(), err)
+		return fmt.Errorf("received atx (%v) with syntactically invalid or missing PoET proof (%x): %w", atx.ShortString(), atx.GetPoetProofRef().ShortString(), err)
 	}
 
 	if err := h.FetchAtxReferences(ctx, &atx); err != nil {
-		return fmt.Errorf("received atx (%v) with missing references of prev or pos id %v, %v, %v",
-			atx.ID().ShortString(), atx.PrevATXID.ShortString(), atx.PositioningATX.ShortString(), log.Err(err))
+		return fmt.Errorf("received atx (%v) with missing references of prev or pos id %v, %v: %w", atx.ID().ShortString(), atx.PrevATXID.ShortString(), atx.PositioningATX.ShortString(), err)
 	}
 
 	vAtx, err := h.SyntacticallyValidateAtx(ctx, &atx)
 	if err != nil {
-		return fmt.Errorf("received syntactically invalid atx %v: %v", atx.ShortString(), err)
+		return fmt.Errorf("received syntactically invalid atx %v: %w", atx.ShortString(), err)
 	}
 	err = h.ProcessAtx(ctx, vAtx)
 	if err != nil {
-		return fmt.Errorf("cannot process atx %v: %v", atx.ShortString(), err)
+		return fmt.Errorf("cannot process atx %v: %w", atx.ShortString(), err)
 		// TODO(anton): blacklist peer
 	}
 	events.ReportNewActivation(vAtx)

--- a/activation/handler_test.go
+++ b/activation/handler_test.go
@@ -32,8 +32,6 @@ import (
 
 const layersPerEpochBig = 1000
 
-const testTickSize = 1
-
 func newMerkleProof(t testing.TB, challenge types.Hash32, otherLeafs []types.Hash32) (types.MerkleProof, types.Hash32) {
 	t.Helper()
 	tree, err := merkle.NewTreeBuilder().
@@ -101,9 +99,7 @@ func newTestHandler(tb testing.TB, goldenATXID types.ATXID) *testHandler {
 	mReceiver1 := NewMockAtxReceiver(ctrl)
 	mReceiver2 := NewMockAtxReceiver(ctrl)
 
-	testTickSize := uint64(1)
-
-	atxHdlr := NewHandler(cdb, verifier, mclock, mpub, mockFetch, types.GetLayersPerEpoch(), testTickSize, goldenATXID, mValidator, []AtxReceiver{mReceiver1, mReceiver2}, lg, PoetConfig{})
+	atxHdlr := NewHandler(cdb, verifier, mclock, mpub, mockFetch, types.GetLayersPerEpoch(), 1, goldenATXID, mValidator, []AtxReceiver{mReceiver1, mReceiver2}, lg, PoetConfig{})
 	return &testHandler{
 		Handler: atxHdlr,
 

--- a/activation/handler_test.go
+++ b/activation/handler_test.go
@@ -1089,8 +1089,7 @@ func TestHandler_AtxWeight(t *testing.T) {
 				PositioningATX:     goldenATXID,
 				InitialPostIndices: []byte{1},
 				PublishEpoch:       types.LayerID(1).GetEpoch().Add(layersPerEpoch),
-
-				CommitmentATX: &goldenATXID,
+				CommitmentATX:      &goldenATXID,
 			},
 			NumUnits: units,
 			NIPost: &types.NIPost{

--- a/activation/handler_test.go
+++ b/activation/handler_test.go
@@ -218,7 +218,7 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 		atxHdlr.mValidator.EXPECT().NIPostChallenge(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 		atxHdlr.mValidator.EXPECT().PositioningAtx(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 
-		_, err = atxHdlr.SyntacticallyValidateAtx(context.Background(), atx)
+		_, err := atxHdlr.SyntacticallyValidateAtx(context.Background(), atx)
 		require.NoError(t, err)
 	})
 
@@ -241,7 +241,7 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 		atxHdlr.mValidator.EXPECT().PositioningAtx(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 		atxHdlr.mValidator.EXPECT().VRFNonce(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 
-		_, err = atxHdlr.SyntacticallyValidateAtx(context.Background(), atx)
+		_, err := atxHdlr.SyntacticallyValidateAtx(context.Background(), atx)
 		require.NoError(t, err)
 	})
 
@@ -305,7 +305,7 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 		atxHdlr.mValidator.EXPECT().NIPostChallenge(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 		atxHdlr.mValidator.EXPECT().VRFNonce(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("invalid VRF"))
 
-		_, err = atxHdlr.SyntacticallyValidateAtx(context.Background(), atx)
+		_, err := atxHdlr.SyntacticallyValidateAtx(context.Background(), atx)
 		require.ErrorContains(t, err, "invalid VRFNonce")
 	})
 
@@ -337,7 +337,7 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 		atxHdlr.mValidator.EXPECT().NIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(uint64(1), nil)
 		atxHdlr.mValidator.EXPECT().PositioningAtx(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 
-		_, err = atxHdlr.SyntacticallyValidateAtx(context.Background(), atx)
+		_, err := atxHdlr.SyntacticallyValidateAtx(context.Background(), atx)
 		require.NoError(t, err)
 	})
 
@@ -353,7 +353,7 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 
 		atxHdlr.mclock.EXPECT().CurrentLayer().Return(currentLayer)
 
-		_, err = atxHdlr.SyntacticallyValidateAtx(context.Background(), atx)
+		_, err := atxHdlr.SyntacticallyValidateAtx(context.Background(), atx)
 		require.ErrorContains(t, err, "atx publish epoch is too far in the future")
 	})
 
@@ -431,7 +431,7 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 
 		atxHdlr.mclock.EXPECT().CurrentLayer().Return(currentLayer)
 
-		_, err = atxHdlr.SyntacticallyValidateAtx(context.Background(), atx)
+		_, err := atxHdlr.SyntacticallyValidateAtx(context.Background(), atx)
 		require.ErrorContains(t, err, "NodeID is missing")
 	})
 
@@ -457,7 +457,7 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 		atxHdlr.mValidator.EXPECT().InitialNIPostChallenge(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 		atxHdlr.mValidator.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 
-		_, err = atxHdlr.SyntacticallyValidateAtx(context.Background(), atx)
+		_, err := atxHdlr.SyntacticallyValidateAtx(context.Background(), atx)
 		require.ErrorContains(t, err, "VRFNonce is missing")
 	})
 
@@ -486,7 +486,7 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 		atxHdlr.mValidator.EXPECT().VRFNonce(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("invalid VRF nonce"))
 		atxHdlr.mValidator.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 
-		_, err = atxHdlr.SyntacticallyValidateAtx(context.Background(), atx)
+		_, err := atxHdlr.SyntacticallyValidateAtx(context.Background(), atx)
 		require.ErrorContains(t, err, "invalid VRF nonce")
 	})
 
@@ -568,7 +568,7 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 
 		atxHdlr.mclock.EXPECT().CurrentLayer().Return(currentLayer)
 
-		_, err = atxHdlr.SyntacticallyValidateAtx(context.Background(), atx)
+		_, err := atxHdlr.SyntacticallyValidateAtx(context.Background(), atx)
 		require.EqualError(t, err, "prevATX declared, but NodeID is included")
 	})
 }

--- a/proposals/handler.go
+++ b/proposals/handler.go
@@ -42,7 +42,6 @@ var (
 	errKnownProposal         = errors.New("known proposal")
 	errKnownBallot           = errors.New("known ballot")
 	errMaliciousBallot       = errors.New("malicious ballot")
-	errWrongSmesherID        = errors.New("ballot atx from a different smesher")
 )
 
 // Handler processes Proposal from gossip and, if deems it valid, propagates it to peers.

--- a/proposals/handler.go
+++ b/proposals/handler.go
@@ -160,16 +160,6 @@ func (h *Handler) HandleSyncedBallot(ctx context.Context, peer p2p.Peer, data []
 	if b.AtxID == types.EmptyATXID || b.AtxID == h.cfg.GoldenATXID {
 		return errInvalidATXID
 	}
-	hdr, err := h.cdb.GetAtxHeader(b.AtxID)
-	if err != nil {
-		return fmt.Errorf("ballot atx hdr %w", err)
-	}
-	if hdr.NodeID != b.SmesherID {
-		return fmt.Errorf("%w: expected %v, got %v", errWrongSmesherID, b.SmesherID, hdr.NodeID)
-	}
-	if hdr.TargetEpoch() != b.Layer.GetEpoch() {
-		return fmt.Errorf("%w: ballot atx epoch %v, ballot epoch %v", errInvalidATXID, hdr.TargetEpoch(), b.Layer.GetEpoch())
-	}
 	ballotDuration.WithLabelValues(decodeInit).Observe(float64(time.Since(t0)))
 
 	t1 := time.Now()
@@ -261,19 +251,6 @@ func (h *Handler) handleProposal(ctx context.Context, peer p2p.Peer, data []byte
 	if p.AtxID == types.EmptyATXID || p.AtxID == h.cfg.GoldenATXID {
 		badData.Inc()
 		return errInvalidATXID
-	}
-	hdr, err := h.cdb.GetAtxHeader(p.AtxID)
-	if err != nil {
-		badData.Inc()
-		return fmt.Errorf("proposal atx hdr %w", err)
-	}
-	if hdr.NodeID != p.SmesherID {
-		badData.Inc()
-		return fmt.Errorf("%w: expected %v, got %v", errWrongSmesherID, p.SmesherID, hdr.NodeID)
-	}
-	if hdr.TargetEpoch() != p.Layer.GetEpoch() {
-		badData.Inc()
-		return fmt.Errorf("%w: proposal atx epoch %v, proposal epoch %v", errInvalidATXID, hdr.TargetEpoch(), p.Layer.GetEpoch())
 	}
 	proposalDuration.WithLabelValues(decodeInit).Observe(float64(time.Since(t0)))
 

--- a/proposals/interface.go
+++ b/proposals/interface.go
@@ -2,6 +2,7 @@ package proposals
 
 import (
 	"context"
+	"time"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/tortoise"
@@ -30,4 +31,9 @@ type vrfVerifier interface {
 
 type nonceFetcher interface {
 	VRFNonce(types.NodeID, types.EpochID) (types.VRFPostIndex, error)
+}
+
+type layerClock interface {
+	CurrentLayer() types.LayerID
+	LayerToTime(types.LayerID) time.Time
 }

--- a/proposals/mocks.go
+++ b/proposals/mocks.go
@@ -7,6 +7,7 @@ package proposals
 import (
 	context "context"
 	reflect "reflect"
+	time "time"
 
 	gomock "github.com/golang/mock/gomock"
 	types "github.com/spacemeshos/go-spacemesh/common/types"
@@ -242,4 +243,55 @@ func (m *MocknonceFetcher) VRFNonce(arg0 types.NodeID, arg1 types.EpochID) (type
 func (mr *MocknonceFetcherMockRecorder) VRFNonce(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VRFNonce", reflect.TypeOf((*MocknonceFetcher)(nil).VRFNonce), arg0, arg1)
+}
+
+// MocklayerClock is a mock of layerClock interface.
+type MocklayerClock struct {
+	ctrl     *gomock.Controller
+	recorder *MocklayerClockMockRecorder
+}
+
+// MocklayerClockMockRecorder is the mock recorder for MocklayerClock.
+type MocklayerClockMockRecorder struct {
+	mock *MocklayerClock
+}
+
+// NewMocklayerClock creates a new mock instance.
+func NewMocklayerClock(ctrl *gomock.Controller) *MocklayerClock {
+	mock := &MocklayerClock{ctrl: ctrl}
+	mock.recorder = &MocklayerClockMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MocklayerClock) EXPECT() *MocklayerClockMockRecorder {
+	return m.recorder
+}
+
+// CurrentLayer mocks base method.
+func (m *MocklayerClock) CurrentLayer() types.LayerID {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CurrentLayer")
+	ret0, _ := ret[0].(types.LayerID)
+	return ret0
+}
+
+// CurrentLayer indicates an expected call of CurrentLayer.
+func (mr *MocklayerClockMockRecorder) CurrentLayer() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CurrentLayer", reflect.TypeOf((*MocklayerClock)(nil).CurrentLayer))
+}
+
+// LayerToTime mocks base method.
+func (m *MocklayerClock) LayerToTime(arg0 types.LayerID) time.Time {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LayerToTime", arg0)
+	ret0, _ := ret[0].(time.Time)
+	return ret0
+}
+
+// LayerToTime indicates an expected call of LayerToTime.
+func (mr *MocklayerClockMockRecorder) LayerToTime(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LayerToTime", reflect.TypeOf((*MocklayerClock)(nil).LayerToTime), arg0)
 }


### PR DESCRIPTION
## Motivation
Closes #4411 

## Changes
- Add check to `SyntacticallyValidateAtx` to ensure that an ATX cannot claim to be published in an epoch further in the future than current epoch + 1
- Add check to handlers for Proposals and Ballots to ensure their layer is within the target epoch of their referenced ATXs

## Test Plan
- Add test for new verification
- Updated tests in `activation/handler.go` to contain less code repetition. Additionally sub-tests now all run in parallel, the main tests do not, because some of them use different `LayersPerEpoch` which would be racy if they were executed in parallel.
- Added tests for Proposal and Ballot handlers for new checks.

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
