### PR TITLE
[Merged by Bors] - hare: dont vote on malicious proposals

### DIFF
--- a/hare/hare.go
+++ b/hare/hare.go
@@ -470,10 +470,21 @@ func goodProposals(ctx context.Context, logger log.Log, msh mesh, nodeID types.N
 	if ownHdr != nil {
 		ownTickHeight = ownHdr.TickHeight()
 	}
+	atxs := map[types.ATXID]int{}
+	for _, p := range props {
+		atxs[p.AtxID]++
+	}
 	for _, p := range props {
 		if p.IsMalicious() {
 			logger.With().Warning("not voting on proposal from malicious identity",
 				log.Stringer("id", p.ID()),
+			)
+			continue
+		}
+		if atxs[p.AtxID] > 1 {
+			logger.With().Warning("proposal with same atx added twice in the recorded set",
+				log.Stringer("id", p.ID()),
+				log.Stringer("atxid", p.AtxID),
 			)
 			continue
 		}

--- a/hare/hare.go
+++ b/hare/hare.go
@@ -481,8 +481,9 @@ func goodProposals(ctx context.Context, logger log.Log, msh mesh, nodeID types.N
 			)
 			continue
 		}
-		if atxs[p.AtxID] > 1 {
-			logger.With().Warning("proposal with same atx added twice in the recorded set",
+		if n := atxs[p.AtxID]; n > 1 {
+			logger.With().Warning("proposal with same atx added several times in the recorded set",
+				log.Int("n", n),
 				log.Stringer("id", p.ID()),
 				log.Stringer("atxid", p.AtxID),
 			)

--- a/hare/hare.go
+++ b/hare/hare.go
@@ -471,6 +471,12 @@ func goodProposals(ctx context.Context, logger log.Log, msh mesh, nodeID types.N
 		ownTickHeight = ownHdr.TickHeight()
 	}
 	for _, p := range props {
+		if p.IsMalicious() {
+			logger.With().Warning("not voting on proposal from malicious identity",
+				log.Stringer("id", p.ID()),
+			)
+			continue
+		}
 		if ownHdr != nil {
 			hdr, err := msh.GetAtxHeader(p.AtxID)
 			if err != nil {

--- a/hare/hare_test.go
+++ b/hare/hare_test.go
@@ -452,6 +452,7 @@ func TestHare_goodProposal(t *testing.T) {
 		beacons     [3]types.Beacon
 		baseHeights [3]uint64
 		malicious   [3]bool
+		atxids      [3]*types.ATXID
 		refBallot   []int
 		expected    []int
 	}{
@@ -498,6 +499,13 @@ func TestHare_goodProposal(t *testing.T) {
 			malicious:   [3]bool{false, true, true},
 			expected:    []int{0},
 		},
+		{
+			name:        "reusing atxids",
+			beacons:     [3]types.Beacon{nodeBeacon, nodeBeacon, nodeBeacon},
+			baseHeights: [3]uint64{nodeBaseHeight, nodeBaseHeight, nodeBaseHeight},
+			atxids:      [3]*types.ATXID{{1}, {1}},
+			expected:    []int{2},
+		},
 	}
 
 	for _, tc := range tt {
@@ -515,6 +523,8 @@ func TestHare_goodProposal(t *testing.T) {
 			for i, p := range pList {
 				if tc.malicious[i] {
 					p.SetMalicious()
+				} else if tc.atxids[i] != nil {
+					p.AtxID = *tc.atxids[i]
 				} else {
 					mockMesh.EXPECT().GetAtxHeader(p.AtxID).Return(&types.ActivationTxHeader{BaseTickHeight: tc.baseHeights[i], TickCount: 1}, nil)
 				}


### PR DESCRIPTION
related: https://github.com/spacemeshos/go-spacemesh/issues/4510

we don't count ballot weight, but we still store equivocating ballots. this is more of a safety measure as we shouldn't even store equivocating proposal.