### PR TITLE
[Merged by Bors] - p2p: parametrize accept queue length and extend libp2p observability

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -80,8 +80,9 @@ func AddCommands(cmd *cobra.Command) {
 
 	cmd.PersistentFlags().IntVar(&cfg.DatabaseConnections, "db-connections",
 		cfg.DatabaseConnections, "configure number of active connections to enable parallel read requests")
-	cmd.PersistentFlags().BoolVar(&cfg.P2P.Flood, "db-latency-metering",
+	cmd.PersistentFlags().BoolVar(&cfg.DatabaseLatencyMetering, "db-latency-metering",
 		cfg.DatabaseLatencyMetering, "if enabled collect latency histogram for every database query")
+
 	/** ======================== P2P Flags ========================== **/
 
 	cmd.PersistentFlags().StringVar(&cfg.P2P.Listen, "listen",
@@ -90,6 +91,11 @@ func AddCommands(cmd *cobra.Command) {
 		cfg.P2P.Flood, "flood created messages to all peers")
 	cmd.PersistentFlags().BoolVar(&cfg.P2P.DisableNatPort, "disable-natport",
 		cfg.P2P.DisableNatPort, "disable nat port-mapping (if enabled upnp protocol is used to negotiate external port with router)")
+	cmd.PersistentFlags().BoolVar(&cfg.P2P.DisableReusePort,
+		"disable-reuseport",
+		cfg.P2P.DisableReusePort,
+		"disables SO_REUSEPORT for tcp sockets. Try disabling this if your node can't reach bootnodes in the network",
+	)
 	cmd.PersistentFlags().IntVar(&cfg.P2P.LowPeers, "low-peers",
 		cfg.P2P.LowPeers, "low watermark for the number of connections")
 	cmd.PersistentFlags().IntVar(&cfg.P2P.HighPeers, "high-peers",

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -96,6 +96,16 @@ func AddCommands(cmd *cobra.Command) {
 		cfg.P2P.DisableReusePort,
 		"disables SO_REUSEPORT for tcp sockets. Try disabling this if your node can't reach bootnodes in the network",
 	)
+	cmd.PersistentFlags().BoolVar(&cfg.P2P.Metrics,
+		"p2p-metrics",
+		cfg.P2P.Metrics,
+		"enable extended metrics collection from libp2p components",
+	)
+	cmd.PersistentFlags().IntVar(&cfg.P2P.AcceptQueue,
+		"p2p-accept-queue",
+		cfg.P2P.AcceptQueue,
+		"number of connections that are fully setup before accepting new connections",
+	)
 	cmd.PersistentFlags().IntVar(&cfg.P2P.LowPeers, "low-peers",
 		cfg.P2P.LowPeers, "low watermark for the number of connections")
 	cmd.PersistentFlags().IntVar(&cfg.P2P.HighPeers, "high-peers",

--- a/p2p/host.go
+++ b/p2p/host.go
@@ -12,11 +12,15 @@ import (
 	"github.com/libp2p/go-libp2p/core/protocol"
 	"github.com/libp2p/go-libp2p/core/transport"
 	"github.com/libp2p/go-libp2p/p2p/host/peerstore/pstoremem"
+	rcmgr "github.com/libp2p/go-libp2p/p2p/host/resource-manager"
+	rcmgrObs "github.com/libp2p/go-libp2p/p2p/host/resource-manager/obs"
 	"github.com/libp2p/go-libp2p/p2p/muxer/yamux"
 	"github.com/libp2p/go-libp2p/p2p/net/connmgr"
 	tptu "github.com/libp2p/go-libp2p/p2p/net/upgrader"
 	"github.com/libp2p/go-libp2p/p2p/security/noise"
 	"github.com/libp2p/go-libp2p/p2p/transport/tcp"
+	"github.com/prometheus/client_golang/prometheus"
+	"go.uber.org/zap"
 
 	"github.com/spacemeshos/go-spacemesh/log"
 	p2pmetrics "github.com/spacemeshos/go-spacemesh/p2p/metrics"
@@ -32,6 +36,7 @@ func DefaultConfig() Config {
 		HighPeers:          100,
 		GracePeersShutdown: 30 * time.Second,
 		MaxMessageSize:     2 << 20,
+		AcceptQueue:        tptu.AcceptQueueLength,
 	}
 }
 
@@ -52,11 +57,13 @@ type Config struct {
 	LowPeers         int      `mapstructure:"low-peers"`
 	HighPeers        int      `mapstructure:"high-peers"`
 	AdvertiseAddress string   `mapstructure:"advertise-address"`
+	AcceptQueue      int      `mapstructure:"p2p-accept-queue"`
+	Metrics          bool     `mapstructure:"p2p-metrics"`
 }
 
 // New initializes libp2p host configured for spacemesh.
 func New(_ context.Context, logger log.Log, cfg Config, prologue []byte, opts ...Opt) (*Host, error) {
-	logger.Info("starting libp2p host with config %+v", cfg)
+	logger.Zap().Info("starting libp2p host", zap.Any("config", &cfg))
 	key, err := EnsureIdentity(cfg.DataDir)
 	if err != nil {
 		return nil, err
@@ -83,6 +90,9 @@ func New(_ context.Context, logger log.Log, cfg Config, prologue []byte, opts ..
 			if cfg.DisableReusePort {
 				opts = append(opts, tcp.DisableReuseport())
 			}
+			if cfg.Metrics {
+				opts = append(opts, tcp.WithMetrics())
+			}
 			return tcp.NewTCPTransport(upgrader, rcmgr, opts...)
 		}),
 		libp2p.Security(noise.ID, func(id protocol.ID, privkey crypto.PrivKey, muxers []tptu.StreamMuxer) (*noise.SessionTransport, error) {
@@ -98,8 +108,14 @@ func New(_ context.Context, logger log.Log, cfg Config, prologue []byte, opts ..
 		libp2p.Peerstore(ps),
 		libp2p.BandwidthReporter(p2pmetrics.NewBandwidthCollector()),
 	}
+	if cfg.Metrics {
+		lopts = append(lopts, setupResourcesManager)
+	}
 	if !cfg.DisableNatPort {
 		lopts = append(lopts, libp2p.NATPortMap())
+	}
+	if cfg.AcceptQueue != 0 {
+		tptu.AcceptQueueLength = cfg.AcceptQueue
 	}
 	h, err := libp2p.New(lopts...)
 	if err != nil {
@@ -107,11 +123,29 @@ func New(_ context.Context, logger log.Log, cfg Config, prologue []byte, opts ..
 	}
 	h.Network().Notify(p2pmetrics.NewConnectionsMeeter())
 
-	logger.With().Info("local node identity",
-		log.String("identity", h.ID().String()),
-	)
+	logger.Zap().Info("local node identity", zap.Stringer("identity", h.ID()))
 	// TODO(dshulyak) this is small mess. refactor to avoid this patching
 	// both New and Upgrade should use options.
 	opts = append(opts, WithConfig(cfg), WithLog(logger))
 	return Upgrade(h, opts...)
+}
+
+func setupResourcesManager(cfg *libp2p.Config) error {
+	rcmgrObs.MustRegisterWith(prometheus.DefaultRegisterer)
+	str, err := rcmgrObs.NewStatsTraceReporter()
+	if err != nil {
+		return err
+	}
+	limits := rcmgr.DefaultLimits
+	libp2p.SetDefaultServiceLimits(&limits)
+
+	mgr, err := rcmgr.NewResourceManager(
+		rcmgr.NewFixedLimiter(limits.AutoScale()),
+		rcmgr.WithTraceReporter(str),
+	)
+	if err != nil {
+		return err
+	}
+	cfg.Apply(libp2p.ResourceManager(mgr))
+	return nil
 }


### PR DESCRIPTION
bootnodes were slow to accept new connections, when we had to restart whole network. accept queue may have a direct impact on that, so we can increase it to 32/64. it will increase upper bound for resources usage on bootnodes, but should be fine.

new option is `---p2p-accept-queue=64`, and config p2p: {"p2p-accept-queue": 64}.

metrics for tcp transport and libp2p resource manager will be collected if enabled with `--p2p-metrics`. or p2p: {"p2p-metrics": true}