### PR TITLE
[Merged by Bors] - p2p: enable discovery after all local protocols were registered

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -905,7 +905,9 @@ func (app *App) initServices(ctx context.Context, poetClients []activation.PoetP
 			peersync.WithConfig(app.Config.TIME.Peersync),
 		)
 	}
-
+	if err := app.host.Start(); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/p2p/peerexchange/discovery.go
+++ b/p2p/peerexchange/discovery.go
@@ -44,6 +44,7 @@ type Discovery struct {
 	host   host.Host
 	cfg    Config
 
+	ctx    context.Context
 	cancel context.CancelFunc
 	eg     errgroup.Group
 
@@ -60,6 +61,7 @@ func New(logger log.Log, h host.Host, config Config) (*Discovery, error) {
 		cfg:    config,
 		logger: logger,
 		host:   h,
+		ctx:    ctx,
 		cancel: cancel,
 		book:   book.New(),
 	}
@@ -103,8 +105,13 @@ func New(logger log.Log, h host.Host, config Config) (*Discovery, error) {
 			return nil, err
 		}
 	}
-	d.scanPeers(ctx)
 	return d, nil
+}
+
+// StartScan starts background goroutine to connect with known peers
+// and scan for new ones.
+func (d *Discovery) StartScan() {
+	d.scanPeers(d.ctx)
 }
 
 func (d *Discovery) recovery(ctx context.Context) error {
@@ -203,7 +210,6 @@ func (d *Discovery) scanPeers(ctx context.Context) {
 				}
 				return err
 			}
-
 		}
 	})
 }

--- a/p2p/peerexchange/discovery_test.go
+++ b/p2p/peerexchange/discovery_test.go
@@ -38,6 +38,7 @@ func TestDiscovery_CrawlMesh(t *testing.T) {
 		cfg.Bootnodes = append(cfg.Bootnodes, bootnode.String())
 		instance, err := New(logger, h, cfg)
 		require.NoError(t, err)
+		instance.StartScan()
 		t.Cleanup(instance.Stop)
 	}
 


### PR DESCRIPTION
related: https://github.com/spacemeshos/go-spacemesh/issues/4542

libp2p communicates the set of enabled protocols after completing secure handshake.
if some of the protocols were not registered before completing initial identify protocol round, it will result in errors
as in attached github issue.