### PR TITLE
Wait for Builder goroutines to finish in UT

### DIFF
--- a/activation/activation_test.go
+++ b/activation/activation_test.go
@@ -345,6 +345,9 @@ func TestBuilder_StartSmeshingAvoidsPanickingIfPrepareInitializerReturnsError(t 
 		require.Fail(t, "test timed out or failed")
 	}
 
+	tab.stop()
+	tab.eg.Wait()
+
 	// Now verify that a panic does not occur if PrepareInitializer returns an error
 	l = log.NewMockLogger(gomock.NewController(t))
 	tab = newTestBuilder(t)
@@ -366,6 +369,7 @@ func TestBuilder_StartSmeshingAvoidsPanickingIfPrepareInitializerReturnsError(t 
 	goroutineCount := runtime.NumGoroutine()
 	tab.StartSmeshing(tab.coinbase, PostSetupOpts{})
 	require.Equal(t, goroutineCount, runtime.NumGoroutine())
+	tab.eg.Wait()
 }
 
 func TestBuilder_StopSmeshing_failsWhenNotStarted(t *testing.T) {


### PR DESCRIPTION
## Motivation
The UT is flaky because it mocks a logger and an extra warning log is sometimes emitted. The log is emitted only sporadically because there is a race between the background Builder's goroutine (spawned in b.run() and the test finishing and clearing the test temp directory).
Closes #4544 

## Changes
Wait for Builder's goroutines to finish before returning from the test.

## Test Plan
The test should not be flaky anymore

## DevOps Notes
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
