### PR TITLE
[Merged by Bors] - Override SDKROOT to v12.3 on arm64 mac

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,12 @@ jobs:
       - name: Add OpenCL support for Linux
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: sudo apt-get update -q && sudo apt-get install -qy ocl-icd-opencl-dev libpocl2
-      # `make build` reads version from version.txt but in Windows it doesn't work therefore passing version explicitly
+
+      - name: Oveeride SDKROOT for macOS
+        if: ${{ contains(matrix.os, 'macos') && runner.arch == 'arm64' }}
+        run: echo "SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk" >> "$GITHUB_ENV"
+
+        # `make build` reads version from version.txt but in Windows it doesn't work therefore passing version explicitly
       - name: Build go-spacemesh
         shell: bash
         run: |


### PR DESCRIPTION
## Motivation
Apparently, it needs the older SDK for the linking.
Closes #https://github.com/spacemeshos/post-rs/issues/94


## Changes
Override SDKROOT when building on the self-hosted mac arm64.

## Test Plan
Test joining TESTNET-05 on M1.