### PR TITLE
[Merged by Bors] - checkpoint: query the vrf nonce for the right epoch

### DIFF
--- a/checkpoint/runner.go
+++ b/checkpoint/runner.go
@@ -45,7 +45,7 @@ func checkpointDB(ctx context.Context, db *sql.Database, snapshot types.LayerID)
 		if err != nil {
 			return nil, fmt.Errorf("atxs snapshot commitment: %w", err)
 		}
-		vrfNonce, err := atxs.VRFNonce(tx, catx.SmesherID, snapshot.GetEpoch())
+		vrfNonce, err := atxs.VRFNonce(tx, catx.SmesherID, catx.Epoch+1)
 		if err != nil {
 			return nil, fmt.Errorf("atxs snapshot nonce: %w", err)
 		}

--- a/checkpoint/runner_test.go
+++ b/checkpoint/runner_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	types.SetLayersPerEpoch(1)
+	types.SetLayersPerEpoch(2)
 	res := m.Run()
 	os.Exit(res)
 }


### PR DESCRIPTION
## Motivation
current code queries the vrf nonce using the wrong epoch.

the test failed after layers per epoch changed to 2, but passed after the code was corrected
