### PR TITLE
[Merged by Bors] - Redefine LSB to return the least significant bit

### DIFF
--- a/beacon/weakcoin/weak_coin.go
+++ b/beacon/weakcoin/weak_coin.go
@@ -318,7 +318,7 @@ func (wc *WeakCoin) FinishRound(ctx context.Context) {
 		logger.Warning("completed round without valid proposals")
 		return
 	}
-	coinflip := wc.smallest.LSB()&1 == 1
+	coinflip := wc.smallest.LSB() == 1
 
 	wc.coins[wc.round] = coinflip
 	logger.With().Info("completed round with beacon weak coin",

--- a/common/types/signatures.go
+++ b/common/types/signatures.go
@@ -84,7 +84,7 @@ func (s *VrfSignature) Cmp(x *VrfSignature) int {
 	return 0
 }
 
-// LSB returns the least significant byte of the signature.
+// LSB returns the least significant bit of the signature, so either 0 or 1.
 func (s *VrfSignature) LSB() byte {
-	return s[0]
+	return s[0] & 1
 }

--- a/hare/preroundtracker.go
+++ b/hare/preroundtracker.go
@@ -52,7 +52,7 @@ func (pre *preRoundTracker) OnPreRound(ctx context.Context, msg *Message) {
 	if msg.Eligibility.Proof.Cmp(pre.bestVRF) == -1 {
 		pre.bestVRF = &msg.Eligibility.Proof
 		// store lowest-order bit as coin toss value
-		pre.coinflip = msg.Eligibility.Proof.LSB()&byte(1) == byte(1)
+		pre.coinflip = msg.Eligibility.Proof.LSB() == 1
 		pre.logger.With().Debug("got new best vrf value",
 			log.Stringer("smesher", msg.SmesherID),
 			log.Stringer("vrf", msg.Eligibility.Proof),

--- a/signing/vrf_test.go
+++ b/signing/vrf_test.go
@@ -101,7 +101,7 @@ func Test_VRF_LSB_evenly_distributed(t *testing.T) {
 		require.NoError(t, err, "failed to read random bytes")
 
 		sig := vrfSig.Sign(msg)
-		lsb[sig.LSB()&1]++
+		lsb[sig.LSB()]++
 	}
 
 	// Assert


### PR DESCRIPTION
## Motivation
Previously LSB returned the least significant byte, but in all usages we used only the least significant bit.

This deduplicates the use of bit-wise operators to retrieve the least significant bit.

## Changes
`VrfSignature.LSB()`

## Test Plan
Lets see if CI passes

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
