### PR TITLE
[Merged by Bors] - hare: capture signed msg hash after signature was verified

### DIFF
--- a/hare/broker.go
+++ b/hare/broker.go
@@ -172,6 +172,7 @@ func (b *Broker) HandleMessage(ctx context.Context, _ p2p.Peer, msg []byte) erro
 		isEarly = true
 	}
 
+	hareMsg.signedHash = types.BytesToHash(hareMsg.InnerMessage.HashBytes())
 	if !b.edVerifier.Verify(signing.HARE, hareMsg.SmesherID, hareMsg.SignedBytes(), hareMsg.Signature) {
 		logger.With().Error("failed to verify signature",
 			log.Int("sig_len", len(hareMsg.Signature)),

--- a/hare/broker.go
+++ b/hare/broker.go
@@ -172,14 +172,14 @@ func (b *Broker) HandleMessage(ctx context.Context, _ p2p.Peer, msg []byte) erro
 		isEarly = true
 	}
 
-	hareMsg.signedHash = types.BytesToHash(hareMsg.InnerMessage.HashBytes())
 	if !b.edVerifier.Verify(signing.HARE, hareMsg.SmesherID, hareMsg.SignedBytes(), hareMsg.Signature) {
 		logger.With().Error("failed to verify signature",
 			log.Int("sig_len", len(hareMsg.Signature)),
 		)
 		return fmt.Errorf("verify ed25519 signature")
 	}
-	// create msg
+	hareMsg.signedHash = types.BytesToHash(hareMsg.InnerMessage.HashBytes())
+
 	if err := checkIdentity(ctx, b.Log, hareMsg, b.stateQuerier); err != nil {
 		logger.With().Warning("message validation failed: could not construct msg", log.Err(err))
 		return err

--- a/hare/broker_test.go
+++ b/hare/broker_test.go
@@ -619,12 +619,14 @@ func TestBroker_eventLoop(t *testing.T) {
 	m.Layer = instanceID2
 	m.Signature = signer.Sign(signing.HARE, m.SignedBytes())
 	m.SmesherID = signer.NodeID()
+	m.signedHash = types.BytesToHash(m.InnerMessage.HashBytes())
 	r.Equal(nil, b.HandleMessage(context.Background(), "", mustEncode(t, m)))
 
 	// future message
 	m.Layer = instanceID3
 	m.Signature = signer.Sign(signing.HARE, m.SignedBytes())
 	m.SmesherID = signer.NodeID()
+	m.signedHash = types.BytesToHash(m.InnerMessage.HashBytes())
 	r.Error(b.HandleMessage(context.Background(), "", mustEncode(t, m)))
 
 	c, _, e = b.Register(context.Background(), instanceID3)

--- a/hare/builder.go
+++ b/hare/builder.go
@@ -23,8 +23,8 @@ type Message struct {
 	// capture the message hash signed by smesher.
 	// some redundant data were removed before signing to reduce network traffic.
 	// after the receiver verified the signature, the inner messages may be altered
-	// to add back redundant data back. for example, values in the nested messages
-	// in a Certificate are trimmed before gossipping and added back after signature is
+	// to add back redundant data. for example, Values in the nested messages
+	// of a Certificate are trimmed before gossipping and added back after signature is
 	// verified. we want to capture the original hash signed by the smesher.
 	signedHash types.Hash32
 }

--- a/hare/builder.go
+++ b/hare/builder.go
@@ -19,6 +19,14 @@ type Message struct {
 	Signature types.EdSignature
 
 	Eligibility types.HareEligibility
+
+	// capture the message hash signed by smesher.
+	// some redundant data were removed before signing to reduce network traffic.
+	// after the receiver verified the signature, the inner messages may be altered
+	// to add back redundant data back. for example, values in the nested messages
+	// in a Certificate are trimmed before gossipping and added back after signature is
+	// verified. we want to capture the original hash signed by the smesher.
+	signedHash types.Hash32
 }
 
 // MessageFromBuffer builds an Hare message from the provided bytes buffer.

--- a/hare/committracker.go
+++ b/hare/committracker.go
@@ -62,7 +62,7 @@ func (ct *commitTracker) OnCommit(ctx context.Context, msg *Message) {
 	metadata := types.HareMetadata{
 		Layer:   msg.Layer,
 		Round:   msg.Round,
-		MsgHash: types.BytesToHash(msg.HashBytes()),
+		MsgHash: msg.signedHash,
 	}
 	if prev, ok := ct.seenSenders[msg.SmesherID]; ok {
 		if !prev.InnerMsg.Equivocation(&metadata) {

--- a/hare/committracker_test.go
+++ b/hare/committracker_test.go
@@ -15,8 +15,9 @@ func BuildCommitMsg(signer *signing.EdSigner, s *Set) *Message {
 	builder := newMessageBuilder()
 	builder.SetType(commit).SetLayer(instanceID1).SetRoundCounter(commitRound).SetCommittedRound(ki).SetValues(s)
 	builder.SetEligibilityCount(1)
-	builder = builder.Sign(signer)
-	return builder.Build()
+	m := builder.Sign(signer).Build()
+	m.signedHash = types.BytesToHash(m.InnerMessage.HashBytes())
+	return m
 }
 
 func TestCommitTracker_OnCommit(t *testing.T) {

--- a/hare/consensus_test.go
+++ b/hare/consensus_test.go
@@ -14,12 +14,15 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/datastore"
 	"github.com/spacemeshos/go-spacemesh/eligibility"
 	"github.com/spacemeshos/go-spacemesh/hare/config"
 	"github.com/spacemeshos/go-spacemesh/log/logtest"
+	"github.com/spacemeshos/go-spacemesh/malfeasance"
 	"github.com/spacemeshos/go-spacemesh/p2p"
 	"github.com/spacemeshos/go-spacemesh/p2p/pubsub"
 	"github.com/spacemeshos/go-spacemesh/signing"
+	"github.com/spacemeshos/go-spacemesh/sql"
 )
 
 // Test the consensus process as a whole
@@ -513,13 +516,9 @@ func (ps *delayedPubSub) Register(protocol string, handler pubsub.GossipHandler)
 }
 
 func TestEquivocation(t *testing.T) {
-	if testing.Short() {
-		t.Skip()
-	}
-
 	test := newConsensusTest()
 
-	cfg := config.Config{N: 16, RoundDuration: 2 * time.Second, ExpectedLeaders: 5, LimitIterations: 1000, Hdist: 20}
+	cfg := config.Config{N: 16, RoundDuration: 2 * time.Second, ExpectedLeaders: 5, LimitIterations: 1, Hdist: 20}
 	totalNodes := 20
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -535,6 +534,11 @@ func TestEquivocation(t *testing.T) {
 	i := 0
 	badGuy, err := signing.NewEdSigner()
 	require.NoError(t, err)
+
+	// this database is used to validate malfeasance proofs only.
+	lg := logtest.New(t)
+	cdb := datastore.NewCachedDB(sql.InMemory(), lg)
+	createIdentity(t, cdb.Database, badGuy)
 	mchs := make([]chan *types.MalfeasanceGossip, 0, totalNodes)
 	dishonestFunc := func() {
 		ps, err := pubsub.New(ctx, logtest.New(t), mesh.Hosts()[i], pubsub.DefaultConfig())
@@ -542,6 +546,9 @@ func TestEquivocation(t *testing.T) {
 		tcp := createConsensusProcess(t, ctx, badGuy, false, cfg, oracle,
 			&equivocatePubSub{ps: ps, sig: badGuy},
 			test.initialSets[i], instanceID1)
+		// FIXME https://github.com/spacemeshos/go-spacemesh/issues/4585
+		// so the Certificate can be valid despite one known equivocator
+		tcp.cp.validator.(*syntaxContextValidator).threshold = cfg.N / 2
 		test.dishonest = append(test.dishonest, tcp.cp)
 		test.brokers = append(test.brokers, tcp.broker)
 		mchs = append(mchs, tcp.mch)
@@ -556,6 +563,9 @@ func TestEquivocation(t *testing.T) {
 		sig, err := signing.NewEdSigner()
 		require.NoError(t, err)
 		tcp := createConsensusProcess(t, ctx, sig, true, cfg, oracle, ps, test.initialSets[i], instanceID1)
+		// FIXME https://github.com/spacemeshos/go-spacemesh/issues/4585
+		// so the Certificate can be valid despite one known equivocator
+		tcp.cp.validator.(*syntaxContextValidator).threshold = cfg.N / 2
 		test.procs = append(test.procs, tcp.cp)
 		test.brokers = append(test.brokers, tcp.broker)
 		mchs = append(mchs, tcp.mch)
@@ -569,9 +579,14 @@ func TestEquivocation(t *testing.T) {
 	test.WaitForTimedTermination(t, 40*time.Second)
 	// every node should detect a pre-round equivocator
 	for _, ch := range mchs {
-		require.Len(t, ch, 1)
-		gossip := <-ch
-		require.Equal(t, badGuy.NodeID(), gossip.Eligibility.NodeID)
+		require.Greater(t, len(ch), 1)
+		close(ch)
+		for gossip := range ch {
+			require.Equal(t, badGuy.NodeID(), gossip.Eligibility.NodeID)
+			nid, err := malfeasance.Validate(ctx, lg, cdb, test.brokers[0].edVerifier, nil, gossip)
+			require.NoError(t, err)
+			require.Equal(t, badGuy.NodeID(), nid)
+		}
 	}
 }
 
@@ -585,13 +600,11 @@ func (eps *equivocatePubSub) Publish(ctx context.Context, protocol string, data 
 	if err != nil {
 		return fmt.Errorf("decode published data: %w", err)
 	}
-	if msg.Type == pre {
-		msg.Values = []types.ProposalID{types.RandomProposalID()}
-		msg.Signature = eps.sig.Sign(signing.HARE, msg.SignedBytes())
-		msg.SmesherID = eps.sig.NodeID()
-		if err = eps.ps.Publish(ctx, protocol, msg.Bytes()); err != nil {
-			return fmt.Errorf("publish equivocate message: %w", err)
-		}
+	msg.Values = []types.ProposalID{types.RandomProposalID()}
+	msg.Signature = eps.sig.Sign(signing.HARE, msg.SignedBytes())
+	msg.SmesherID = eps.sig.NodeID()
+	if err = eps.ps.Publish(ctx, protocol, msg.Bytes()); err != nil {
+		return fmt.Errorf("publish equivocate message: %w", err)
 	}
 	if err = eps.ps.Publish(ctx, protocol, data); err != nil {
 		return fmt.Errorf("publish original message: %w", err)

--- a/hare/notifytracker.go
+++ b/hare/notifytracker.go
@@ -45,7 +45,7 @@ func (nt *notifyTracker) OnNotify(ctx context.Context, msg *Message) bool {
 	metadata := types.HareMetadata{
 		Layer:   msg.Layer,
 		Round:   msg.Round,
-		MsgHash: types.BytesToHash(msg.HashBytes()),
+		MsgHash: msg.signedHash,
 	}
 
 	if prev, exist := nt.notifies[msg.SmesherID]; exist { // already seenSenders

--- a/hare/notifytracker_test.go
+++ b/hare/notifytracker_test.go
@@ -20,7 +20,9 @@ func BuildNotifyMsg(signing *signing.EdSigner, s *Set) *Message {
 	cert.AggMsgs.Messages = []Message{*BuildCommitMsg(signing, s)}
 	builder.SetCertificate(cert)
 	builder.SetEligibilityCount(1)
-	return builder.Sign(signing).Build()
+	m := builder.Sign(signing).Build()
+	m.signedHash = types.BytesToHash(m.InnerMessage.HashBytes())
+	return m
 }
 
 func TestNotifyTracker_OnNotify(t *testing.T) {

--- a/hare/preroundtracker.go
+++ b/hare/preroundtracker.go
@@ -63,11 +63,10 @@ func (pre *preRoundTracker) OnPreRound(ctx context.Context, msg *Message) {
 	sToTrack := NewSet(msg.Values)         // assume track all Values
 	alreadyTracked := NewDefaultEmptySet() // assume nothing tracked so far
 
-	msgHash := types.BytesToHash(msg.HashBytes())
 	metadata := types.HareMetadata{
 		Layer:   msg.Layer,
 		Round:   msg.Round,
-		MsgHash: msgHash,
+		MsgHash: msg.signedHash,
 	}
 	if prev, exist := pre.preRound[msg.SmesherID]; exist { // not first pre-round msg from this sender
 		if prev.InnerMsg.Equivocation(&metadata) {

--- a/hare/preroundtracker_test.go
+++ b/hare/preroundtracker_test.go
@@ -44,7 +44,9 @@ func BuildPreRoundMsg(sig *signing.EdSigner, s *Set, roleProof types.VrfSignatur
 	builder := newMessageBuilder()
 	builder.SetType(pre).SetLayer(instanceID1).SetRoundCounter(preRound).SetCommittedRound(ki).SetValues(s).SetRoleProof(roleProof)
 	builder.SetEligibilityCount(1)
-	return builder.Sign(sig).Build()
+	m := builder.Sign(sig).Build()
+	m.signedHash = types.BytesToHash(m.InnerMessage.HashBytes())
+	return m
 }
 
 func TestPreRoundTracker_OnPreRound(t *testing.T) {

--- a/hare/proposaltracker.go
+++ b/hare/proposaltracker.go
@@ -60,7 +60,7 @@ func (pt *proposalTracker) OnProposal(ctx context.Context, msg *Message) {
 			InnerMsg: types.HareMetadata{
 				Layer:   pt.proposal.Layer,
 				Round:   pt.proposal.Round,
-				MsgHash: types.BytesToHash(pt.proposal.HashBytes()),
+				MsgHash: pt.proposal.signedHash,
 			},
 			SmesherID: pt.proposal.SmesherID,
 			Signature: pt.proposal.Signature,
@@ -69,7 +69,7 @@ func (pt *proposalTracker) OnProposal(ctx context.Context, msg *Message) {
 			InnerMsg: types.HareMetadata{
 				Layer:   msg.Layer,
 				Round:   msg.Round,
-				MsgHash: types.BytesToHash(msg.HashBytes()),
+				MsgHash: msg.signedHash,
 			},
 			SmesherID: msg.SmesherID,
 			Signature: msg.Signature,
@@ -115,7 +115,7 @@ func (pt *proposalTracker) OnLateProposal(ctx context.Context, msg *Message) {
 				InnerMsg: types.HareMetadata{
 					Layer:   pt.proposal.Layer,
 					Round:   pt.proposal.Round,
-					MsgHash: types.BytesToHash(pt.proposal.HashBytes()),
+					MsgHash: pt.proposal.signedHash,
 				},
 				SmesherID: pt.proposal.SmesherID,
 				Signature: pt.proposal.Signature,
@@ -124,7 +124,7 @@ func (pt *proposalTracker) OnLateProposal(ctx context.Context, msg *Message) {
 				InnerMsg: types.HareMetadata{
 					Layer:   msg.Layer,
 					Round:   msg.Round,
-					MsgHash: types.BytesToHash(msg.HashBytes()),
+					MsgHash: msg.signedHash,
 				},
 				SmesherID: msg.SmesherID,
 				Signature: msg.Signature,

--- a/hare/proposaltracker_test.go
+++ b/hare/proposaltracker_test.go
@@ -15,7 +15,9 @@ func buildProposalMsg(sig *signing.EdSigner, s *Set, signature types.VrfSignatur
 	builder := newMessageBuilder().SetRoleProof(signature)
 	builder.SetType(proposal).SetLayer(instanceID1).SetRoundCounter(proposalRound).SetCommittedRound(ki).SetValues(s).SetSVP(buildSVP(ki, NewSetFromValues(types.ProposalID{1})))
 	builder.SetEligibilityCount(1)
-	return builder.Sign(sig).Build()
+	m := builder.Sign(sig).Build()
+	m.signedHash = types.BytesToHash(m.InnerMessage.HashBytes())
+	return m
 }
 
 func BuildProposalMsg(sig *signing.EdSigner, s *Set) *Message {

--- a/hare/statustracker.go
+++ b/hare/statustracker.go
@@ -39,7 +39,7 @@ func (st *statusTracker) RecordStatus(ctx context.Context, msg *Message) {
 	metadata := types.HareMetadata{
 		Layer:   msg.Layer,
 		Round:   msg.Round,
-		MsgHash: types.BytesToHash(msg.HashBytes()),
+		MsgHash: msg.signedHash,
 	}
 	if prev, exist := st.statuses[msg.SmesherID]; exist { // already handled this sender's status msg
 		st.logger.WithContext(ctx).With().Warning("duplicate status message detected",
@@ -48,7 +48,7 @@ func (st *statusTracker) RecordStatus(ctx context.Context, msg *Message) {
 		prevMetadata := types.HareMetadata{
 			Layer:   prev.Layer,
 			Round:   prev.Round,
-			MsgHash: types.BytesToHash(prev.HashBytes()),
+			MsgHash: prev.signedHash,
 		}
 		if !prevMetadata.Equivocation(&metadata) {
 			return

--- a/hare/statustracker_test.go
+++ b/hare/statustracker_test.go
@@ -26,7 +26,9 @@ func buildStatusMsg(sig *signing.EdSigner, s *Set, ki uint32) *Message {
 		SetCommittedRound(ki).
 		SetValues(s).
 		SetEligibilityCount(1)
-	return builder.Sign(sig).Build()
+	m := builder.Sign(sig).Build()
+	m.signedHash = types.BytesToHash(m.InnerMessage.HashBytes())
+	return m
 }
 
 func BuildStatusMsg(sig *signing.EdSigner, s *Set) *Message {


### PR DESCRIPTION
## Motivation
@dshulyak added an equivocation systest https://github.com/spacemeshos/go-spacemesh/pull/4571
and found the following errors

{"L":"WARN","T":"2023-06-22T05:46:51.007-0400","N":"fe110.hare","M":"failed to validate malfeasance proof","node_id":"fe110000e8e0e5bba83b9af12bfc0010d7055f746147da06b072c2b780a487ee","module":"hare","protocol":"hr1_malfloop","sessionId":"cd191dde-8ada-4947-996a-f45af55fe083","proof":{"generated_layer":65,"type":"hare equivocation","msgs":{"first":{"layer":65,"round":3,"msgHash":"0xbed08ecf25c6f42f85f576d124a9e8cf99efd1ced68ee9be2118a117a2dd04c4"},"second":{"layer":65,"round":3,"msgHash":"0x1f04df88e7517796646aa862ae2dad31743ca264fa0b413e4578864ee829cf28"}}},"hare eligibility":{"layer":65,"round":3,"smesher":"f5fb794d62940e9b591ad986c188c5d6fe4b6786429c1af9834ece6b2f327d0a","count":60,"proof":"f6e36ae9538fd07eacd06ec8bc6b398f543397fba8f95a73a259460223ed98a333f02a5014295c97f81c6e82dd78fe55693e33f6640b229da486895ad234690af944b2edbc444bd1939642e9aa703603"},"errmsg":"invalid signature","name":"hare"}
