### PR TITLE
[Merged by Bors] - Ensure libpthread is linked statically on windows

### DIFF
--- a/Makefile-libs.Inc
+++ b/Makefile-libs.Inc
@@ -29,6 +29,7 @@ ifeq ($(GOOS),windows)
 	platform := windows
 	export PATH := $(PATH):$(PROJ_DIR)build
 	EXE := .exe
+	CGO_LDFLAGS := $(CGO_LDFLAGS) -Wl,-Bstatic -lpthread -Wl,-Bdynamic
 else
 	TEMP := /tmp
 	ifeq ($(GOOS),darwin)


### PR DESCRIPTION
## Motivation
Link lpthread statically on windows to not require mingw to start go-spacemesh

## Changes
- adds ldflags on windows for statically linking lpthread.

## Test Plan
n/a

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
