### PR TITLE
[Merged by Bors] - fix flaky TestGetLastIDByNodeID 

### DIFF
--- a/sql/atxs/atxs_test.go
+++ b/sql/atxs/atxs_test.go
@@ -303,7 +303,7 @@ func TestGetLastIDByNodeID(t *testing.T) {
 	atx3, err := newAtx(sig2, withPublishEpoch(3))
 	require.NoError(t, err)
 
-	atx4, err := newAtx(sig2, withPublishEpoch(3))
+	atx4, err := newAtx(sig2, withPublishEpoch(4))
 	require.NoError(t, err)
 	atx4.Sequence = atx3.Sequence + 1
 	atx4.Signature = sig2.Sign(signing.ATX, atx4.SignedBytes())


### PR DESCRIPTION
## Motivation
https://github.com/spacemeshos/go-spacemesh/actions/runs/5359172950/jobs/9722429425?pr=4580

```
=== RUN   TestGetLastIDByNodeID
    atxs_test.go:323: 
        	Error Trace:	D:/a/go-spacemesh/go-spacemesh/sql/atxs/atxs_test.go:323
        	Error:      	Not equal: 
        	            	expected: types.ATXID{0x1b, 0x7b, 0x1e, 0xe8, 0x28, 0xdd, 0xd6, 0x32, 0xe, 0x9f, 0x3f, 0xee, 0xc4, 0xf8, 0xdc, 0x8, 0xb0, 0x68, 0x6d, 0x59, 0x19, 0xd1, 0x58, 0xfc, 0xe8, 0x87, 0x43, 0xfe, 0xa4, 0x82, 0xf2, 0x19}
        	            	actual  : types.ATXID{0xf, 0x88, 0x87, 0x80, 0x5e, 0x32, 0xf4, 0xc9, 0x4a, 0x36, 0xc3, 0xa8, 0x20, 0x77, 0xbf, 0xf9, 0x80, 0x8b, 0x15, 0x2a, 0xac, 0x50, 0xaf, 0x1e, 0xd5, 0x5f, 0xd3, 0x66, 0x76, 0xc1, 0x31, 0xba}
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1,4 +1,4 @@
        	            	 (types.ATXID) (len=32) {
        	            	- 00000000  1b 7b 1e e8 28 dd d6 32  0e 9f 3f ee c4 f8 dc 08  |.{..(..2..?.....|
        	            	- 00000010  b0 68 6d 59 19 d1 58 fc  e8 87 43 fe a4 82 f2 19  |.hmY..X...C.....|
        	            	+ 00000000  0f 88 87 80 5e 32 f4 c9  4a 36 c3 a8 20 77 bf f9  |....^2..J6.. w..|
        	            	+ 00000010  80 8b 15 2a ac 50 af 1e  d5 5f d3 66 76 c1 31 ba  |...*.P..._.fv.1.|
        	            	 }
        	Test:       	TestGetLastIDByNodeID
--- FAIL: TestGetLastIDByNodeID (0.01s)
```