### PR TITLE
[Merged by Bors] - tx: get rid of sleeps in tests

### DIFF
--- a/api/grpcserver/grpcserver_test.go
+++ b/api/grpcserver/grpcserver_test.go
@@ -2630,7 +2630,7 @@ func TestEventsReceived(t *testing.T) {
 
 	svm := vm.New(sql.InMemory(), vm.WithLogger(logtest.New(t)))
 	conState := txs.NewConservativeState(svm, sql.InMemory(), txs.WithLogger(logtest.New(t).WithName("conState")))
-	conState.AddToCache(context.Background(), globalTx)
+	conState.AddToCache(context.Background(), globalTx, time.Now())
 
 	weight := new(big.Rat).SetFloat64(18.7)
 	require.NoError(t, err)

--- a/txs/conservative_state.go
+++ b/txs/conservative_state.go
@@ -112,8 +112,7 @@ func (cs *ConservativeState) Validation(raw types.RawTx) system.ValidationReques
 }
 
 // AddToCache adds the provided transaction to the conservative cache.
-func (cs *ConservativeState) AddToCache(ctx context.Context, tx *types.Transaction) error {
-	received := time.Now()
+func (cs *ConservativeState) AddToCache(ctx context.Context, tx *types.Transaction, received time.Time) error {
 	if err := cs.cache.Add(ctx, cs.db, tx, received, false); err != nil {
 		return err
 	}

--- a/txs/conservative_state_test.go
+++ b/txs/conservative_state_test.go
@@ -183,13 +183,13 @@ func TestSelectProposalTXs_ExhaustMemPool(t *testing.T) {
 	numTXs := numTXsInProposal - 1
 	lid := types.LayerID(97)
 	bid := types.BlockID{100}
-	now := time.Now()
+	now := time.Now().Add(-time.Duration(numTXs/2+1) * time.Second)
 	expected := make([]types.TransactionID, 0, numTXs)
-	for i := numTXs - 1; i >= 0; i-- {
+	for i := 0; i < numTXs; i++ {
 		// to check if transaction with the same received timestamp are sorted correctly (lexicographically)
 		// we set the timestamp of every two transactions to be the same:
 		// e.g. 1st == 2nd, 3rd == 4th, etc.
-		received := now.Add(-time.Duration(i/2) * time.Second)
+		received := now.Add(time.Duration(i/2) * time.Second)
 
 		signer, err := signing.NewEdSigner()
 		require.NoError(t, err)

--- a/txs/conservative_state_test.go
+++ b/txs/conservative_state_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"math"
 	"math/rand"
+	"sort"
 	"testing"
 	"time"
 
@@ -116,7 +117,7 @@ func addBatch(tb testing.TB, tcs *testConState, numTXs int) ([]types.Transaction
 		tcs.mvm.EXPECT().GetBalance(addr).Return(defaultBalance, nil).Times(1)
 		tcs.mvm.EXPECT().GetNonce(addr).Return(nonce, nil).Times(1)
 		tx := newTx(tb, nonce+5, defaultAmount, defaultFee, signer)
-		require.NoError(tb, tcs.AddToCache(context.Background(), tx))
+		require.NoError(tb, tcs.AddToCache(context.Background(), tx, time.Now()))
 		ids = append(ids, tx.ID)
 		txs = append(txs, tx)
 	}
@@ -135,11 +136,11 @@ func TestSelectProposalTXs(t *testing.T) {
 		tcs.mvm.EXPECT().GetBalance(addr).Return(defaultBalance, nil).Times(1)
 		tcs.mvm.EXPECT().GetNonce(addr).Return(uint64(1), nil).Times(1)
 		tx1 := newTx(t, 4, defaultAmount, defaultFee, signer)
-		require.NoError(t, tcs.AddToCache(context.Background(), tx1))
+		require.NoError(t, tcs.AddToCache(context.Background(), tx1, time.Now()))
 		// all the TXs with nonce 1 are pending in database
 		require.NoError(t, tcs.LinkTXsWithBlock(lid, bid, []types.TransactionID{tx1.ID}))
 		tx2 := newTx(t, 6, defaultAmount, defaultFee, signer)
-		require.NoError(t, tcs.AddToCache(context.Background(), tx2))
+		require.NoError(t, tcs.AddToCache(context.Background(), tx2, time.Now()))
 	}
 
 	got := tcs.SelectProposalTXs(lid, 1)
@@ -167,11 +168,11 @@ func TestSelectProposalTXs_ExhaustGas(t *testing.T) {
 		tcs.mvm.EXPECT().GetBalance(addr).Return(defaultBalance, nil).Times(1)
 		tcs.mvm.EXPECT().GetNonce(addr).Return(uint64(0), nil).Times(1)
 		tx1 := newTx(t, 0, defaultAmount, defaultFee, signer)
-		require.NoError(t, tcs.AddToCache(context.Background(), tx1))
+		require.NoError(t, tcs.AddToCache(context.Background(), tx1, time.Now()))
 		// all the TXs with nonce 0 are pending in database
 		require.NoError(t, tcs.LinkTXsWithBlock(lid, bid, []types.TransactionID{tx1.ID}))
 		tx2 := newTx(t, 1, defaultAmount, defaultFee, signer)
-		require.NoError(t, tcs.AddToCache(context.Background(), tx2))
+		require.NoError(t, tcs.AddToCache(context.Background(), tx2, time.Now()))
 	}
 	got := tcs.SelectProposalTXs(lid, 1)
 	require.Len(t, got, expSize)
@@ -183,24 +184,40 @@ func TestSelectProposalTXs_ExhaustMemPool(t *testing.T) {
 	lid := types.LayerID(97)
 	bid := types.BlockID{100}
 	expected := make([]types.TransactionID, 0, numTXs)
-	for i := 0; i < numTXs; i++ {
+	for i := numTXs; i > 0; i-- {
+		// to check if transaction with the same received timestamp are sorted correctly (lexicographically)
+		// we set the timestamp of every two transactions to be the same:
+		// e.g. 1st == 2nd, 3rd == 4th, etc.
+		received := time.Now().Add(-time.Duration(i%2) * time.Second)
+
 		signer, err := signing.NewEdSigner()
 		require.NoError(t, err)
 		addr := types.GenerateAddress(signer.PublicKey().Bytes())
 		tcs.mvm.EXPECT().GetBalance(addr).Return(defaultBalance, nil).Times(1)
 		tcs.mvm.EXPECT().GetNonce(addr).Return(uint64(0), nil).Times(1)
 
-		time.Sleep(20 * time.Millisecond) // to make sure received time is different for each TX (windows resolution is ~ 15ms)
 		tx1 := newTx(t, 0, defaultAmount, defaultFee, signer)
-		require.NoError(t, tcs.AddToCache(context.Background(), tx1))
+		require.NoError(t, tcs.AddToCache(context.Background(), tx1, received))
 		// all the TXs with nonce 0 are pending in database
 		require.NoError(t, tcs.LinkTXsWithBlock(lid, bid, []types.TransactionID{tx1.ID}))
 
-		time.Sleep(20 * time.Millisecond)
 		tx2 := newTx(t, 1, defaultAmount, defaultFee, signer)
-		require.NoError(t, tcs.AddToCache(context.Background(), tx2))
+		require.NoError(t, tcs.AddToCache(context.Background(), tx2, received.Add(5*time.Millisecond)))
 		expected = append(expected, tx2.ID)
 	}
+
+	sort.Slice(expected, func(i, j int) bool {
+		first := tcs.cache.cachedTXs[expected[i]]
+		second := tcs.cache.cachedTXs[expected[j]]
+
+		if first.Fee() != second.Fee() {
+			return first.Fee() > second.Fee()
+		}
+		if !first.Received.Equal(second.Received) {
+			return first.Received.Before(second.Received)
+		}
+		return first.ID.Compare(second.ID)
+	})
 
 	// no reshuffling happens when mempool is exhausted. two list should be exactly the same
 	got := tcs.SelectProposalTXs(lid, 1)
@@ -224,13 +241,13 @@ func TestSelectProposalTXs_SamePrincipal(t *testing.T) {
 	tcs.mvm.EXPECT().GetNonce(addr).Return(uint64(0), nil).Times(1)
 	for i := 0; i < numInBlock; i++ {
 		tx := newTx(t, uint64(i), defaultAmount, defaultFee, signer)
-		require.NoError(t, tcs.AddToCache(context.Background(), tx))
+		require.NoError(t, tcs.AddToCache(context.Background(), tx, time.Now()))
 		require.NoError(t, tcs.LinkTXsWithBlock(lid, bid, []types.TransactionID{tx.ID}))
 	}
 	expected := make([]types.TransactionID, 0, numTXsInProposal)
 	for i := 0; i < numTXs; i++ {
 		tx := newTx(t, uint64(numInBlock+i), defaultAmount, defaultFee, signer)
-		require.NoError(t, tcs.AddToCache(context.Background(), tx))
+		require.NoError(t, tcs.AddToCache(context.Background(), tx, time.Now()))
 		if i < numTXsInProposal {
 			expected = append(expected, tx.ID)
 		}
@@ -261,20 +278,20 @@ func TestSelectProposalTXs_TwoPrincipals(t *testing.T) {
 	allTXs := make(map[types.TransactionID]*types.Transaction)
 	for i := 0; i < numInDBs; i++ {
 		tx := newTx(t, uint64(i), defaultAmount, defaultFee, signer1)
-		require.NoError(t, tcs.AddToCache(context.Background(), tx))
+		require.NoError(t, tcs.AddToCache(context.Background(), tx, time.Now()))
 		require.NoError(t, tcs.LinkTXsWithBlock(lid, bid, []types.TransactionID{tx.ID}))
 		allTXs[tx.ID] = tx
 		tx = newTx(t, uint64(i), defaultAmount, defaultFee, signer2)
-		require.NoError(t, tcs.AddToCache(context.Background(), tx))
+		require.NoError(t, tcs.AddToCache(context.Background(), tx, time.Now()))
 		require.NoError(t, tcs.LinkTXsWithBlock(lid, bid, []types.TransactionID{tx.ID}))
 		allTXs[tx.ID] = tx
 	}
 	for i := 0; i < numTXs; i++ {
 		tx := newTx(t, uint64(numInDBs+i), defaultAmount, defaultFee, signer1)
-		require.NoError(t, tcs.AddToCache(context.Background(), tx))
+		require.NoError(t, tcs.AddToCache(context.Background(), tx, time.Now()))
 		allTXs[tx.ID] = tx
 		tx = newTx(t, uint64(numInDBs+i), defaultAmount, defaultFee, signer2)
-		require.NoError(t, tcs.AddToCache(context.Background(), tx))
+		require.NoError(t, tcs.AddToCache(context.Background(), tx, time.Now()))
 		allTXs[tx.ID] = tx
 	}
 	got := tcs.SelectProposalTXs(lid, 1)
@@ -304,10 +321,10 @@ func TestGetProjection(t *testing.T) {
 	tcs.mvm.EXPECT().GetBalance(addr).Return(defaultBalance, nil).Times(1)
 	tcs.mvm.EXPECT().GetNonce(addr).Return(nonce, nil).Times(1)
 	tx1 := newTx(t, nonce, defaultAmount, defaultFee, signer)
-	require.NoError(t, tcs.AddToCache(context.Background(), tx1))
+	require.NoError(t, tcs.AddToCache(context.Background(), tx1, time.Now()))
 	require.NoError(t, tcs.LinkTXsWithBlock(types.LayerID(10), types.BlockID{100}, []types.TransactionID{tx1.ID}))
 	tx2 := newTx(t, nonce+1, defaultAmount, defaultFee, signer)
-	require.NoError(t, tcs.AddToCache(context.Background(), tx2))
+	require.NoError(t, tcs.AddToCache(context.Background(), tx2, time.Now()))
 
 	got, balance := tcs.GetProjection(addr)
 	require.EqualValues(t, nonce+2, got)
@@ -322,7 +339,7 @@ func TestAddToCache(t *testing.T) {
 	tcs.mvm.EXPECT().GetBalance(addr).Return(defaultBalance, nil).Times(1)
 	tcs.mvm.EXPECT().GetNonce(addr).Return(nonce, nil).Times(1)
 	tx := newTx(t, nonce, defaultAmount, defaultFee, signer)
-	require.NoError(t, tcs.AddToCache(context.Background(), tx))
+	require.NoError(t, tcs.AddToCache(context.Background(), tx, time.Now()))
 	has := tcs.cache.Has(tx.ID)
 	require.True(t, has)
 	got, err := transactions.Get(tcs.db, tx.ID)
@@ -341,7 +358,7 @@ func TestAddToCache_BadNonceNotPersisted(t *testing.T) {
 	}
 	tcs.mvm.EXPECT().GetBalance(tx.Principal).Return(defaultBalance, nil).Times(1)
 	tcs.mvm.EXPECT().GetNonce(tx.Principal).Return(tx.Nonce+1, nil).Times(1)
-	require.ErrorIs(t, tcs.AddToCache(context.Background(), tx), errBadNonce)
+	require.ErrorIs(t, tcs.AddToCache(context.Background(), tx, time.Now()), errBadNonce)
 	checkTXNotInDB(t, tcs.db, tx.ID)
 }
 
@@ -356,7 +373,7 @@ func TestAddToCache_NonceGap(t *testing.T) {
 	}
 	tcs.mvm.EXPECT().GetBalance(tx.Principal).Return(defaultBalance, nil).Times(1)
 	tcs.mvm.EXPECT().GetNonce(tx.Principal).Return(tx.Nonce-2, nil).Times(1)
-	require.NoError(t, tcs.AddToCache(context.Background(), tx))
+	require.NoError(t, tcs.AddToCache(context.Background(), tx, time.Now()))
 	require.True(t, tcs.cache.Has(tx.ID))
 	require.False(t, tcs.cache.MoreInDB(tx.Principal))
 	checkTXStateFromDB(t, tcs.db, []*types.MeshTransaction{{Transaction: *tx}}, types.MEMPOOL)
@@ -370,7 +387,7 @@ func TestAddToCache_InsufficientBalance(t *testing.T) {
 	tcs.mvm.EXPECT().GetBalance(addr).Return(defaultAmount, nil).Times(1)
 	tcs.mvm.EXPECT().GetNonce(addr).Return(nonce, nil).Times(1)
 	tx := newTx(t, nonce, defaultAmount, defaultFee, signer)
-	require.NoError(t, tcs.AddToCache(context.Background(), tx))
+	require.NoError(t, tcs.AddToCache(context.Background(), tx, time.Now()))
 	checkNoTX(t, tcs.cache, tx.ID)
 	require.True(t, tcs.cache.MoreInDB(addr))
 	checkTXStateFromDB(t, tcs.db, []*types.MeshTransaction{{Transaction: *tx}}, types.MEMPOOL)
@@ -387,7 +404,7 @@ func TestAddToCache_TooManyForOneAccount(t *testing.T) {
 	for i := 0; i <= maxTXsPerAcct; i++ {
 		tx := newTx(t, nonce+uint64(i), defaultAmount, defaultFee, signer)
 		mtxs = append(mtxs, &types.MeshTransaction{Transaction: *tx})
-		require.NoError(t, tcs.AddToCache(context.Background(), tx))
+		require.NoError(t, tcs.AddToCache(context.Background(), tx, time.Now()))
 	}
 	require.True(t, tcs.cache.MoreInDB(addr))
 	checkTXStateFromDB(t, tcs.db, mtxs, types.MEMPOOL)
@@ -401,7 +418,7 @@ func TestGetMeshTransaction(t *testing.T) {
 	tcs.mvm.EXPECT().GetBalance(addr).Return(defaultBalance, nil).Times(1)
 	tcs.mvm.EXPECT().GetNonce(addr).Return(nonce, nil).Times(1)
 	tx := newTx(t, nonce, defaultAmount, defaultFee, signer)
-	require.NoError(t, tcs.AddToCache(context.Background(), tx))
+	require.NoError(t, tcs.AddToCache(context.Background(), tx, time.Now()))
 	mtx, err := tcs.GetMeshTransaction(tx.ID)
 	require.NoError(t, err)
 	require.Equal(t, types.MEMPOOL, mtx.State)

--- a/txs/conservative_state_test.go
+++ b/txs/conservative_state_test.go
@@ -183,12 +183,13 @@ func TestSelectProposalTXs_ExhaustMemPool(t *testing.T) {
 	numTXs := numTXsInProposal - 1
 	lid := types.LayerID(97)
 	bid := types.BlockID{100}
+	now := time.Now()
 	expected := make([]types.TransactionID, 0, numTXs)
 	for i := numTXs - 1; i >= 0; i-- {
 		// to check if transaction with the same received timestamp are sorted correctly (lexicographically)
 		// we set the timestamp of every two transactions to be the same:
 		// e.g. 1st == 2nd, 3rd == 4th, etc.
-		received := time.Now().Add(-time.Duration(i/2) * time.Second)
+		received := now.Add(-time.Duration(i/2) * time.Second)
 
 		signer, err := signing.NewEdSigner()
 		require.NoError(t, err)

--- a/txs/conservative_state_test.go
+++ b/txs/conservative_state_test.go
@@ -184,11 +184,11 @@ func TestSelectProposalTXs_ExhaustMemPool(t *testing.T) {
 	lid := types.LayerID(97)
 	bid := types.BlockID{100}
 	expected := make([]types.TransactionID, 0, numTXs)
-	for i := numTXs; i > 0; i-- {
+	for i := numTXs - 1; i >= 0; i-- {
 		// to check if transaction with the same received timestamp are sorted correctly (lexicographically)
 		// we set the timestamp of every two transactions to be the same:
 		// e.g. 1st == 2nd, 3rd == 4th, etc.
-		received := time.Now().Add(-time.Duration(i%2) * time.Second)
+		received := time.Now().Add(-time.Duration(i/2) * time.Second)
 
 		signer, err := signing.NewEdSigner()
 		require.NoError(t, err)

--- a/txs/handler.go
+++ b/txs/handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/prometheus/client_golang/prometheus"
@@ -99,7 +100,7 @@ func (th *TxHandler) VerifyAndCacheTx(ctx context.Context, msg []byte) error {
 	if !req.Verify() {
 		return fmt.Errorf("%w: %s", errVerify, raw.ID)
 	}
-	if err := th.state.AddToCache(ctx, &types.Transaction{RawTx: raw, TxHeader: header}); err != nil {
+	if err := th.state.AddToCache(ctx, &types.Transaction{RawTx: raw, TxHeader: header}, time.Now()); err != nil {
 		th.logger.WithContext(ctx).With().Warning("failed to add tx to conservative cache",
 			raw.ID,
 			log.Err(err),

--- a/txs/handler_test.go
+++ b/txs/handler_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/libp2p/go-libp2p/core/crypto"
@@ -118,8 +119,8 @@ func gossipExpectations(t *testing.T, fee uint64, hasErr, parseErr, addErr error
 		if parseErr == nil && fee != 0 {
 			req.EXPECT().Verify().Times(1).Return(verify)
 			if verify {
-				cstate.EXPECT().AddToCache(gomock.Any(), gomock.Any()).DoAndReturn(
-					func(_ context.Context, got *types.Transaction) error {
+				cstate.EXPECT().AddToCache(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+					func(_ context.Context, got *types.Transaction, _ time.Time) error {
 						assert.Equal(t, tx.ID, got.ID) // causing ID to be calculated
 						assert.Equal(t, tx, got)
 						return addErr

--- a/txs/interface.go
+++ b/txs/interface.go
@@ -2,6 +2,7 @@ package txs
 
 import (
 	"context"
+	"time"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/log"
@@ -13,7 +14,7 @@ import (
 type conservativeState interface {
 	HasTx(types.TransactionID) (bool, error)
 	Validation(types.RawTx) system.ValidationRequest
-	AddToCache(context.Context, *types.Transaction) error
+	AddToCache(context.Context, *types.Transaction, time.Time) error
 	AddToDB(*types.Transaction) error
 	GetMeshTransaction(types.TransactionID) (*types.MeshTransaction, error)
 }

--- a/txs/mempool_iterator.go
+++ b/txs/mempool_iterator.go
@@ -26,7 +26,15 @@ func (pq priorityQueue) Len() int { return len(pq) }
 // Less implements head.Interface.
 func (pq priorityQueue) Less(i, j int) bool {
 	// We want Pop to give us the highest, not lowest, fee, so we use greater than here.
-	return pq[i].Fee() > pq[j].Fee() || (pq[i].Fee() == pq[j].Fee() && pq[i].Received.Before(pq[j].Received))
+	if pq[i].Fee() != pq[j].Fee() {
+		return pq[i].Fee() > pq[j].Fee()
+	}
+	// if fees are equal, we want the older tx first
+	if !pq[i].Received.Equal(pq[j].Received) {
+		return pq[i].Received.Before(pq[j].Received)
+	}
+	// if fees and timestamps are equal, we want the tx with the lower ID first
+	return pq[i].ID.Compare(pq[j].ID)
 }
 
 // Swap implements head.Interface.

--- a/txs/txs_mocks.go
+++ b/txs/txs_mocks.go
@@ -7,6 +7,7 @@ package txs
 import (
 	context "context"
 	reflect "reflect"
+	time "time"
 
 	gomock "github.com/golang/mock/gomock"
 	types "github.com/spacemeshos/go-spacemesh/common/types"
@@ -38,17 +39,17 @@ func (m *MockconservativeState) EXPECT() *MockconservativeStateMockRecorder {
 }
 
 // AddToCache mocks base method.
-func (m *MockconservativeState) AddToCache(arg0 context.Context, arg1 *types.Transaction) error {
+func (m *MockconservativeState) AddToCache(arg0 context.Context, arg1 *types.Transaction, arg2 time.Time) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddToCache", arg0, arg1)
+	ret := m.ctrl.Call(m, "AddToCache", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // AddToCache indicates an expected call of AddToCache.
-func (mr *MockconservativeStateMockRecorder) AddToCache(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockconservativeStateMockRecorder) AddToCache(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddToCache", reflect.TypeOf((*MockconservativeState)(nil).AddToCache), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddToCache", reflect.TypeOf((*MockconservativeState)(nil).AddToCache), arg0, arg1, arg2)
 }
 
 // AddToDB mocks base method.


### PR DESCRIPTION
## Motivation
In #4575 sleeps were added to tx tests to ensure that they pass on windows. This fixes the code to not require the sleeps any more.

## Changes
TX are now sorted in the priority queue according to the following:

- largest fee
- if equal earliest receive time
- (new) if also equal transaction ID

on *nix systems it is near impossible for two transactions to be received on at the same time (within 2 ns). On windows however for two timestamps to be considered equal they can be up to 15 ms apart. Tis might cause the order of transactions to randomly change in the pool, that's why an additional check was added to determine the priority.

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
