### PR TITLE
[Merged by Bors] - beacon: speed up slow test

### DIFF
--- a/beacon/beacon_test.go
+++ b/beacon/beacon_test.go
@@ -874,19 +874,19 @@ func TestBeacon_proposalPassesEligibilityThreshold(t *testing.T) {
 		wEarly, wOntime int
 	}{
 		{
-			name:    "100K atxs",
-			wEarly:  90_000,
-			wOntime: 100_000,
+			name:    "30 atxs",
+			wEarly:  27,
+			wOntime: 30,
+		},
+		{
+			name:    "1K atxs",
+			wEarly:  900,
+			wOntime: 1_000,
 		},
 		{
 			name:    "10K atxs",
 			wEarly:  9_000,
 			wOntime: 10_000,
-		},
-		{
-			name:    "30 atxs",
-			wEarly:  27,
-			wOntime: 30,
 		},
 	}
 


### PR DESCRIPTION
## Motivation
`TestBeacon_proposalPassesEligibilityThreshold` is a test that takes ~ 10 seconds to complete on my machine. The fastest GH runner (ubuntu) needs ~ 70 seconds for it. If we want to also execute it on slower runners (`linux/arm64` and `darwin/arm64`), we should speed it up so it doesn't time out.

## Changes
Reduce amount of proposals that are processed in test from 10k to 1k thereby speeding up the test by a factor of ~ 10.

## Test Plan
n/a

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
