### PR TITLE
[Merged by Bors] - timesync: await layer should return a read only channel

### DIFF
--- a/activation/activation_test.go
+++ b/activation/activation_test.go
@@ -193,7 +193,7 @@ func publishAtx(
 	ch := make(chan struct{})
 	close(ch)
 	tab.mclock.EXPECT().AwaitLayer(publishEpoch.FirstLayer()).DoAndReturn(
-		func(got types.LayerID) chan struct{} {
+		func(got types.LayerID) <-chan struct{} {
 			// advance to publish layer
 			if currLayer.Before(got) {
 				*currLayer = got
@@ -484,7 +484,7 @@ func TestBuilder_PublishActivationTx_FaultyNet(t *testing.T) {
 	done := make(chan struct{})
 	close(done)
 	tab.mclock.EXPECT().AwaitLayer(publishEpoch.FirstLayer()).DoAndReturn(
-		func(got types.LayerID) chan struct{} {
+		func(got types.LayerID) <-chan struct{} {
 			// advance to publish layer
 			if currLayer.Before(got) {
 				currLayer = got
@@ -580,7 +580,7 @@ func TestBuilder_PublishActivationTx_RebuildNIPostWhenTargetEpochPassed(t *testi
 	done := make(chan struct{})
 	close(done)
 	tab.mclock.EXPECT().AwaitLayer(publishEpoch.FirstLayer()).DoAndReturn(
-		func(got types.LayerID) chan struct{} {
+		func(got types.LayerID) <-chan struct{} {
 			// advance to publish layer
 			if currLayer.Before(got) {
 				currLayer = got
@@ -698,13 +698,13 @@ func TestBuilder_PublishActivationTx_PrevATXWithoutPrevATX(t *testing.T) {
 			genesis := time.Now().Add(-time.Duration(currentLayer) * layerDuration)
 			return genesis.Add(layerDuration * time.Duration(layer))
 		}).AnyTimes()
-	tab.mclock.EXPECT().AwaitLayer(vPosAtx.PublishEpoch.FirstLayer().Add(layersPerEpoch)).DoAndReturn(func(layer types.LayerID) chan struct{} {
+	tab.mclock.EXPECT().AwaitLayer(vPosAtx.PublishEpoch.FirstLayer().Add(layersPerEpoch)).DoAndReturn(func(layer types.LayerID) <-chan struct{} {
 		ch := make(chan struct{})
 		close(ch)
 		return ch
 	}).Times(1)
 
-	tab.mclock.EXPECT().AwaitLayer(gomock.Not(vPosAtx.PublishEpoch.FirstLayer().Add(layersPerEpoch))).DoAndReturn(func(types.LayerID) chan struct{} {
+	tab.mclock.EXPECT().AwaitLayer(gomock.Not(vPosAtx.PublishEpoch.FirstLayer().Add(layersPerEpoch))).DoAndReturn(func(types.LayerID) <-chan struct{} {
 		ch := make(chan struct{})
 		return ch
 	}).Times(1)
@@ -783,13 +783,13 @@ func TestBuilder_PublishActivationTx_TargetsEpochBasedOnPosAtx(t *testing.T) {
 			genesis := time.Now().Add(-time.Duration(currentLayer) * layerDuration)
 			return genesis.Add(layerDuration * time.Duration(layer))
 		}).AnyTimes()
-	tab.mclock.EXPECT().AwaitLayer(vPosAtx.PublishEpoch.FirstLayer().Add(layersPerEpoch)).DoAndReturn(func(types.LayerID) chan struct{} {
+	tab.mclock.EXPECT().AwaitLayer(vPosAtx.PublishEpoch.FirstLayer().Add(layersPerEpoch)).DoAndReturn(func(types.LayerID) <-chan struct{} {
 		ch := make(chan struct{})
 		close(ch)
 		return ch
 	}).Times(1)
 
-	tab.mclock.EXPECT().AwaitLayer(gomock.Not(vPosAtx.PublishEpoch.FirstLayer().Add(layersPerEpoch))).DoAndReturn(func(types.LayerID) chan struct{} {
+	tab.mclock.EXPECT().AwaitLayer(gomock.Not(vPosAtx.PublishEpoch.FirstLayer().Add(layersPerEpoch))).DoAndReturn(func(types.LayerID) <-chan struct{} {
 		ch := make(chan struct{})
 		return ch
 	}).Times(1)
@@ -937,7 +937,7 @@ func TestBuilder_NIPostPublishRecovery(t *testing.T) {
 	done := make(chan struct{})
 	close(done)
 	tab.mclock.EXPECT().AwaitLayer(publishEpoch.FirstLayer()).DoAndReturn(
-		func(got types.LayerID) chan struct{} {
+		func(got types.LayerID) <-chan struct{} {
 			// advance to publish layer
 			if currLayer.Before(got) {
 				currLayer = got

--- a/activation/interface.go
+++ b/activation/interface.go
@@ -35,7 +35,7 @@ type nipostValidator interface {
 }
 
 type layerClock interface {
-	AwaitLayer(layerID types.LayerID) chan struct{}
+	AwaitLayer(layerID types.LayerID) <-chan struct{}
 	CurrentLayer() types.LayerID
 	LayerToTime(types.LayerID) time.Time
 }

--- a/activation/mocks.go
+++ b/activation/mocks.go
@@ -276,10 +276,10 @@ func (m *MocklayerClock) EXPECT() *MocklayerClockMockRecorder {
 }
 
 // AwaitLayer mocks base method.
-func (m *MocklayerClock) AwaitLayer(layerID types.LayerID) chan struct{} {
+func (m *MocklayerClock) AwaitLayer(layerID types.LayerID) <-chan struct{} {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AwaitLayer", layerID)
-	ret0, _ := ret[0].(chan struct{})
+	ret0, _ := ret[0].(<-chan struct{})
 	return ret0
 }
 

--- a/beacon/interface.go
+++ b/beacon/interface.go
@@ -27,7 +27,7 @@ type eligibilityChecker interface {
 type layerClock interface {
 	LayerToTime(types.LayerID) time.Time
 	CurrentLayer() types.LayerID
-	AwaitLayer(types.LayerID) chan struct{}
+	AwaitLayer(types.LayerID) <-chan struct{}
 }
 
 type vrfSigner interface {

--- a/beacon/mocks.go
+++ b/beacon/mocks.go
@@ -189,10 +189,10 @@ func (m *MocklayerClock) EXPECT() *MocklayerClockMockRecorder {
 }
 
 // AwaitLayer mocks base method.
-func (m *MocklayerClock) AwaitLayer(arg0 types.LayerID) chan struct{} {
+func (m *MocklayerClock) AwaitLayer(arg0 types.LayerID) <-chan struct{} {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AwaitLayer", arg0)
-	ret0, _ := ret[0].(chan struct{})
+	ret0, _ := ret[0].(<-chan struct{})
 	return ret0
 }
 

--- a/blocks/certifier_test.go
+++ b/blocks/certifier_test.go
@@ -142,7 +142,7 @@ func TestStartStop(t *testing.T) {
 	ch := make(chan struct{}, 1)
 	tc.mClk.EXPECT().CurrentLayer().Return(lid).AnyTimes()
 	tc.mClk.EXPECT().AwaitLayer(gomock.Any()).DoAndReturn(
-		func(_ types.LayerID) chan struct{} {
+		func(_ types.LayerID) <-chan struct{} {
 			return ch
 		}).AnyTimes()
 	tc.Start()
@@ -587,7 +587,7 @@ func Test_OldLayersPruned(t *testing.T) {
 	pruned := make(chan struct{}, 1)
 	tc.mClk.EXPECT().CurrentLayer().Return(current).AnyTimes()
 	tc.mClk.EXPECT().AwaitLayer(gomock.Any()).DoAndReturn(
-		func(got types.LayerID) chan struct{} {
+		func(got types.LayerID) <-chan struct{} {
 			if got == current.Add(1) {
 				close(pruned)
 			}

--- a/blocks/interface.go
+++ b/blocks/interface.go
@@ -23,7 +23,7 @@ type executor interface {
 }
 
 type layerClock interface {
-	AwaitLayer(layerID types.LayerID) chan struct{}
+	AwaitLayer(layerID types.LayerID) <-chan struct{}
 	CurrentLayer() types.LayerID
 }
 

--- a/blocks/mocks/mocks.go
+++ b/blocks/mocks/mocks.go
@@ -161,10 +161,10 @@ func (m *MocklayerClock) EXPECT() *MocklayerClockMockRecorder {
 }
 
 // AwaitLayer mocks base method.
-func (m *MocklayerClock) AwaitLayer(layerID types.LayerID) chan struct{} {
+func (m *MocklayerClock) AwaitLayer(layerID types.LayerID) <-chan struct{} {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AwaitLayer", layerID)
-	ret0, _ := ret[0].(chan struct{})
+	ret0, _ := ret[0].(<-chan struct{})
 	return ret0
 }
 

--- a/events/interfaces.go
+++ b/events/interfaces.go
@@ -5,6 +5,6 @@ import (
 )
 
 type LayerClock interface {
-	AwaitLayer(layerID types.LayerID) chan struct{}
+	AwaitLayer(layerID types.LayerID) <-chan struct{}
 	CurrentLayer() types.LayerID
 }

--- a/hare/flows_test.go
+++ b/hare/flows_test.go
@@ -198,7 +198,7 @@ func (m *mockClock) LayerToTime(layer types.LayerID) time.Time {
 	return m.layerTime[layer]
 }
 
-func (m *mockClock) AwaitLayer(layer types.LayerID) chan struct{} {
+func (m *mockClock) AwaitLayer(layer types.LayerID) <-chan struct{} {
 	m.m.Lock()
 	defer m.m.Unlock()
 

--- a/hare/hare.go
+++ b/hare/hare.go
@@ -58,7 +58,7 @@ type RoundClock interface {
 // layer number to a clock time.
 type LayerClock interface {
 	LayerToTime(types.LayerID) time.Time
-	AwaitLayer(types.LayerID) chan struct{}
+	AwaitLayer(types.LayerID) <-chan struct{}
 	CurrentLayer() types.LayerID
 }
 

--- a/miner/interface.go
+++ b/miner/interface.go
@@ -29,7 +29,7 @@ type nonceFetcher interface {
 }
 
 type layerClock interface {
-	AwaitLayer(layerID types.LayerID) chan struct{}
+	AwaitLayer(layerID types.LayerID) <-chan struct{}
 	CurrentLayer() types.LayerID
 	LayerToTime(types.LayerID) time.Time
 }

--- a/miner/mocks.go
+++ b/miner/mocks.go
@@ -220,10 +220,10 @@ func (m *MocklayerClock) EXPECT() *MocklayerClockMockRecorder {
 }
 
 // AwaitLayer mocks base method.
-func (m *MocklayerClock) AwaitLayer(layerID types.LayerID) chan struct{} {
+func (m *MocklayerClock) AwaitLayer(layerID types.LayerID) <-chan struct{} {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AwaitLayer", layerID)
-	ret0, _ := ret[0].(chan struct{})
+	ret0, _ := ret[0].(<-chan struct{})
 	return ret0
 }
 

--- a/miner/proposal_builder_test.go
+++ b/miner/proposal_builder_test.go
@@ -118,14 +118,14 @@ func TestBuilder_StartAndClose(t *testing.T) {
 
 	current := types.LayerID(layersPerEpoch * 3)
 	b.mClock.EXPECT().CurrentLayer().Return(current)
-	b.mClock.EXPECT().AwaitLayer(current.Add(1)).DoAndReturn(func(types.LayerID) chan struct{} {
+	b.mClock.EXPECT().AwaitLayer(current.Add(1)).DoAndReturn(func(types.LayerID) <-chan struct{} {
 		ch := make(chan struct{})
 		close(ch)
 		return ch
 	})
 
 	b.mClock.EXPECT().CurrentLayer().Return(current.Add(1))
-	b.mClock.EXPECT().AwaitLayer(current.Add(2)).DoAndReturn(func(types.LayerID) chan struct{} {
+	b.mClock.EXPECT().AwaitLayer(current.Add(2)).DoAndReturn(func(types.LayerID) <-chan struct{} {
 		return make(chan struct{})
 	})
 
@@ -144,7 +144,7 @@ func TestBuilder_HandleLayer_MultipleProposals(t *testing.T) {
 
 	layerID := types.LayerID(layersPerEpoch * 3)
 	b.mClock.EXPECT().CurrentLayer().Return(layerID).AnyTimes()
-	b.mClock.EXPECT().AwaitLayer(layerID.Add(1)).DoAndReturn(func(types.LayerID) chan struct{} {
+	b.mClock.EXPECT().AwaitLayer(layerID.Add(1)).DoAndReturn(func(types.LayerID) <-chan struct{} {
 		return make(chan struct{})
 	}).AnyTimes()
 	require.NoError(t, b.Start(context.Background()))
@@ -216,7 +216,7 @@ func TestBuilder_HandleLayer_OneProposal(t *testing.T) {
 
 	layerID := types.LayerID(layersPerEpoch * 3)
 	b.mClock.EXPECT().CurrentLayer().Return(layerID).AnyTimes()
-	b.mClock.EXPECT().AwaitLayer(layerID.Add(1)).DoAndReturn(func(types.LayerID) chan struct{} {
+	b.mClock.EXPECT().AwaitLayer(layerID.Add(1)).DoAndReturn(func(types.LayerID) <-chan struct{} {
 		return make(chan struct{})
 	}).AnyTimes()
 	require.NoError(t, b.Start(context.Background()))
@@ -451,7 +451,7 @@ func TestBuilder_HandleLayer_CanceledDuringBuilding(t *testing.T) {
 
 	layerID := types.LayerID(layersPerEpoch * 3)
 	b.mClock.EXPECT().CurrentLayer().Return(layerID).AnyTimes()
-	b.mClock.EXPECT().AwaitLayer(layerID.Add(1)).DoAndReturn(func(types.LayerID) chan struct{} {
+	b.mClock.EXPECT().AwaitLayer(layerID.Add(1)).DoAndReturn(func(types.LayerID) <-chan struct{} {
 		return make(chan struct{})
 	}).AnyTimes()
 	require.NoError(t, b.Start(context.Background()))
@@ -486,7 +486,7 @@ func TestBuilder_HandleLayer_PublishError(t *testing.T) {
 
 	layerID := types.LayerID(layersPerEpoch * 3)
 	b.mClock.EXPECT().CurrentLayer().Return(layerID).AnyTimes()
-	b.mClock.EXPECT().AwaitLayer(layerID.Add(1)).DoAndReturn(func(types.LayerID) chan struct{} {
+	b.mClock.EXPECT().AwaitLayer(layerID.Add(1)).DoAndReturn(func(types.LayerID) <-chan struct{} {
 		return make(chan struct{})
 	}).AnyTimes()
 	require.NoError(t, b.Start(context.Background()))
@@ -523,7 +523,7 @@ func TestBuilder_HandleLayer_NotVerified(t *testing.T) {
 
 	layerID := types.LayerID(layersPerEpoch * 3)
 	b.mClock.EXPECT().CurrentLayer().Return(layerID).AnyTimes()
-	b.mClock.EXPECT().AwaitLayer(layerID.Add(1)).DoAndReturn(func(types.LayerID) chan struct{} {
+	b.mClock.EXPECT().AwaitLayer(layerID.Add(1)).DoAndReturn(func(types.LayerID) <-chan struct{} {
 		return make(chan struct{})
 	}).AnyTimes()
 	require.NoError(t, b.Start(context.Background()))
@@ -568,7 +568,7 @@ func TestBuilder_HandleLayer_NoHareOutput(t *testing.T) {
 
 	layerID := types.LayerID(layersPerEpoch * 5)
 	b.mClock.EXPECT().CurrentLayer().Return(layerID).AnyTimes()
-	b.mClock.EXPECT().AwaitLayer(layerID.Add(1)).DoAndReturn(func(types.LayerID) chan struct{} {
+	b.mClock.EXPECT().AwaitLayer(layerID.Add(1)).DoAndReturn(func(types.LayerID) <-chan struct{} {
 		return make(chan struct{})
 	}).AnyTimes()
 	require.NoError(t, b.Start(context.Background()))
@@ -613,7 +613,7 @@ func TestBuilder_HandleLayer_MeshHashErrorOK(t *testing.T) {
 
 	layerID := types.LayerID(layersPerEpoch * 3)
 	b.mClock.EXPECT().CurrentLayer().Return(layerID).AnyTimes()
-	b.mClock.EXPECT().AwaitLayer(layerID.Add(1)).DoAndReturn(func(types.LayerID) chan struct{} {
+	b.mClock.EXPECT().AwaitLayer(layerID.Add(1)).DoAndReturn(func(types.LayerID) <-chan struct{} {
 		return make(chan struct{})
 	}).AnyTimes()
 	require.NoError(t, b.Start(context.Background()))

--- a/timesync/clock.go
+++ b/timesync/clock.go
@@ -166,7 +166,7 @@ func (t *NodeClock) CurrentLayer() types.LayerID {
 
 // AwaitLayer returns a channel that will be signaled when layer id layerID was ticked by the clock, or if this layer has passed
 // while sleeping. it does so by closing the returned channel.
-func (t *NodeClock) AwaitLayer(layerID types.LayerID) chan struct{} {
+func (t *NodeClock) AwaitLayer(layerID types.LayerID) <-chan struct{} {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 


### PR DESCRIPTION
## Motivation
A read only channel (`<-chan`) cannot be closed. Since the channel returned from `AwaitLayer` is shared by multiple components this adds an additional layer of safety where callers of `AwaitLayer` cannot close the received channel, but rather only the clock itself.

## Changes
Change `AwaitLayer` to return a read only channel.

## Test Plan
n/a

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
