### PR TITLE
[Merged by Bors] - Don't override proving opts in testnet preset

### DIFF
--- a/config/presets/testnet.go
+++ b/config/presets/testnet.go
@@ -3,7 +3,6 @@ package presets
 import (
 	"time"
 
-	postCfg "github.com/spacemeshos/post/config"
 	"github.com/spacemeshos/post/initialization"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
@@ -58,8 +57,6 @@ func testnet() config.Config {
 	conf.SMESHING.Opts.ProviderID = int(initialization.CPUProviderID())
 	conf.SMESHING.Opts.NumUnits = 2
 	conf.SMESHING.Opts.Throttle = true
-	// Override proof of work flags to use light mode (less memory intensive)
-	conf.SMESHING.ProvingOpts.Flags = postCfg.RecommendedPowFlags()
 
 	conf.Beacon.FirstVotingRoundDuration = 3 * time.Minute
 	conf.Beacon.GracePeriodDuration = 10 * time.Second


### PR DESCRIPTION
## Motivation
Currently, the default proving k2 PoW flags are overwritten in the testnet preset by mistake. In effect, all miners do PoW in light mode.

## Changes
Removed overwriting pow flags for proving