### PR TITLE
admin events

### DIFF
--- a/activation/activation.go
+++ b/activation/activation.go
@@ -19,6 +19,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/codec"
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/datastore"
+	"github.com/spacemeshos/go-spacemesh/events"
 	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/p2p/pubsub"
 	"github.com/spacemeshos/go-spacemesh/signing"
@@ -198,6 +199,7 @@ func (b *Builder) StartSmeshing(coinbase types.Address, opts PostSetupOpts) erro
 			return ctx.Err()
 		case <-b.syncer.RegisterForATXSynced():
 			// ensure we are ATX synced before starting the PoST Session
+			events.EmitWaitSyncATXs()
 		}
 
 		// If start session returns any error other than context.Canceled

--- a/activation/nipost.go
+++ b/activation/nipost.go
@@ -191,7 +191,7 @@ func (nb *NIPostBuilder) BuildNIPost(ctx context.Context, challenge *types.NIPos
 		getProofsCtx, cancel := context.WithDeadline(ctx, poetProofDeadline)
 		defer cancel()
 
-		events.EmitPoetWaitEnd(challenge.PublishEpoch, challenge.TargetEpoch(), now.Sub(poetProofDeadline))
+		events.EmitPoetWaitEnd(challenge.PublishEpoch, challenge.TargetEpoch(), time.Until(poetRoundEnd))
 		poetProofRef, membership, err := nb.getBestProof(getProofsCtx, nb.state.Challenge)
 		if err != nil {
 			return nil, 0, &PoetSvcUnstableError{msg: "getBestProof failed", source: err}

--- a/activation/post.go
+++ b/activation/post.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/datastore"
+	"github.com/spacemeshos/go-spacemesh/events"
 	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/sql"
 	"github.com/spacemeshos/go-spacemesh/sql/atxs"
@@ -293,8 +294,9 @@ func (mgr *PostSetupManager) StartSession(ctx context.Context) error {
 		log.String("labels_per_unit", fmt.Sprintf("%d", mgr.cfg.LabelsPerUnit)),
 		log.String("provider", fmt.Sprintf("%d", mgr.lastOpts.ProviderID)),
 	)
-
+	events.EmitInitStart(mgr.id, mgr.commitmentAtxId)
 	err = mgr.init.Initialize(ctx)
+	events.EmitInitComplete(err != nil)
 
 	mgr.mu.Lock()
 	defer mgr.mu.Unlock()

--- a/api/grpcserver/admin_service.go
+++ b/api/grpcserver/admin_service.go
@@ -2,7 +2,6 @@ package grpcserver
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -14,7 +13,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/spacemeshos/go-spacemesh/checkpoint"
 	"github.com/spacemeshos/go-spacemesh/common/types"
@@ -116,17 +114,7 @@ func (a AdminService) EventsStream(req *pb.EventStreamRequest, stream pb.AdminSe
 		case <-sub.Full():
 			return status.Errorf(codes.Canceled, "buffer is full")
 		case ev := <-sub.Out():
-			encoded, err := json.Marshal(ev.Details)
-			if err != nil {
-				return status.Errorf(codes.Internal, "failed to encode event to json."+err.Error())
-			}
-			if err := stream.Send(&pb.Event{
-				Timestamp: timestamppb.New(ev.Timestamp),
-				Failure:   ev.Failure,
-				Type:      string(ev.Type),
-				Help:      ev.Help,
-				Details:   string(encoded),
-			}); err != nil {
+			if err := stream.Send(ev.Event); err != nil {
 				return fmt.Errorf("send to stream: %w", err)
 			}
 		}

--- a/api/grpcserver/admin_service.go
+++ b/api/grpcserver/admin_service.go
@@ -94,3 +94,7 @@ func (a AdminService) Recover(ctx context.Context, req *pb.RecoverRequest) (*emp
 	}
 	return &empty.Empty{}, nil
 }
+
+func (a AdminService) EventsStream(req *pb.EventStreamRequest, stream pb.AdminService_EventsStreamServer) error {
+	return nil
+}

--- a/common/types/proposal.go
+++ b/common/types/proposal.go
@@ -20,7 +20,7 @@ const (
 	ProposalIDSize = Hash32Length
 )
 
-//go:generate scalegen -types Proposal,InnerProposal,ProposalID
+//go:generate scalegen
 
 // ProposalID is a 20-byte blake3 sum of the serialized ballot used to identify a Proposal.
 type ProposalID Hash20
@@ -171,9 +171,4 @@ func ProposalIDsToHashes(ids []ProposalID) []Hash32 {
 		hashes = append(hashes, id.AsHash32())
 	}
 	return hashes
-}
-
-type ProposalEligibility struct {
-	Layer LayerID `json:"layer"`
-	Count uint32  `json:"count"`
 }

--- a/common/types/proposal.go
+++ b/common/types/proposal.go
@@ -20,7 +20,7 @@ const (
 	ProposalIDSize = Hash32Length
 )
 
-//go:generate scalegen
+//go:generate scalegen -types Proposal,InnerProposal,ProposalID
 
 // ProposalID is a 20-byte blake3 sum of the serialized ballot used to identify a Proposal.
 type ProposalID Hash20
@@ -171,4 +171,9 @@ func ProposalIDsToHashes(ids []ProposalID) []Hash32 {
 		hashes = append(hashes, id.AsHash32())
 	}
 	return hashes
+}
+
+type ProposalEligibility struct {
+	Layer LayerID `json:"layer"`
+	Count uint32  `json:"count"`
 }

--- a/config/presets/standalone.go
+++ b/config/presets/standalone.go
@@ -72,8 +72,8 @@ func standalone() config.Config {
 
 	conf.PoETServers = []string{"http://0.0.0.0:10010"}
 	conf.POET.GracePeriod = 10 * time.Second
-	conf.POET.CycleGap = 30 * time.Second
-	conf.POET.PhaseShift = 30 * time.Second
+	conf.POET.CycleGap = 50 * time.Second
+	conf.POET.PhaseShift = 50 * time.Second
 
 	conf.P2P.DisableNatPort = true
 

--- a/config/presets/standalone.go
+++ b/config/presets/standalone.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"time"
 
+	postCfg "github.com/spacemeshos/post/config"
 	"github.com/spacemeshos/post/initialization"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
@@ -58,6 +59,7 @@ func standalone() config.Config {
 	conf.SMESHING.Opts.NumUnits = 1
 	conf.SMESHING.Opts.Throttle = true
 	conf.SMESHING.Opts.DataDir = conf.DataDirParent
+	conf.SMESHING.ProvingOpts.Flags = postCfg.RecommendedPowFlags()
 
 	conf.Beacon.Kappa = 40
 	conf.Beacon.Theta = big.NewRat(1, 4)
@@ -71,9 +73,9 @@ func standalone() config.Config {
 	conf.Beacon.VotesLimit = 100
 
 	conf.PoETServers = []string{"http://0.0.0.0:10010"}
-	conf.POET.GracePeriod = 10 * time.Second
-	conf.POET.CycleGap = 50 * time.Second
-	conf.POET.PhaseShift = 50 * time.Second
+	conf.POET.GracePeriod = 5 * time.Second
+	conf.POET.CycleGap = 30 * time.Second
+	conf.POET.PhaseShift = 30 * time.Second
 
 	conf.P2P.DisableNatPort = true
 

--- a/config/presets/standalone.go
+++ b/config/presets/standalone.go
@@ -48,14 +48,14 @@ func standalone() config.Config {
 	conf.POST.K1 = 12
 	conf.POST.K2 = 4
 	conf.POST.K3 = 4
-	conf.POST.LabelsPerUnit = 128
-	conf.POST.MaxNumUnits = 4
-	conf.POST.MinNumUnits = 2
+	conf.POST.LabelsPerUnit = 64
+	conf.POST.MaxNumUnits = 2
+	conf.POST.MinNumUnits = 1
 
 	conf.SMESHING.CoinbaseAccount = types.GenerateAddress([]byte("1")).String()
 	conf.SMESHING.Start = true
 	conf.SMESHING.Opts.ProviderID = int(initialization.CPUProviderID())
-	conf.SMESHING.Opts.NumUnits = 2
+	conf.SMESHING.Opts.NumUnits = 1
 	conf.SMESHING.Opts.Throttle = true
 	conf.SMESHING.Opts.DataDir = conf.DataDirParent
 

--- a/events/events.go
+++ b/events/events.go
@@ -144,7 +144,7 @@ func EmitEligibilities(
 	beacon types.Beacon,
 	atx types.ATXID,
 	activeSetSize uint32,
-	eligibilities []types.ProposalEligibility,
+	eligibilities map[types.LayerID][]types.VotingEligibility,
 ) {
 	const help = "Computed eligibilities for the epoch. " +
 		"Rewards will be received after publishing proposals at specified layers. " +
@@ -164,13 +164,13 @@ func EmitEligibilities(
 	)
 }
 
-func castEligibilities(eligs []types.ProposalEligibility) []*pb.ProposalEligibility {
-	rst := make([]*pb.ProposalEligibility, len(eligs))
-	for i := range eligs {
-		rst[i] = &pb.ProposalEligibility{
-			Layer: eligs[i].Layer.Uint32(),
-			Count: eligs[i].Count,
-		}
+func castEligibilities(proofs map[types.LayerID][]types.VotingEligibility) []*pb.ProposalEligibility {
+	rst := make([]*pb.ProposalEligibility, 0, len(proofs))
+	for lid, eligs := range proofs {
+		rst = append(rst, &pb.ProposalEligibility{
+			Layer: lid.Uint32(),
+			Count: uint32(len(eligs)),
+		})
 	}
 	return rst
 }

--- a/events/events.go
+++ b/events/events.go
@@ -75,7 +75,7 @@ type EventPoetWaitEnd struct {
 }
 
 func EmitPoetWaitEnd(publish, target types.EpochID, wait time.Duration) {
-	const help = "Node needs to wait for poet to complete in publish epoch." +
+	const help = "Node needs to wait for poet to complete in publish epoch. " +
 		"Once completed, node fetches challenge from poet and run post on that challenge. " +
 		"After that publish an ATX that will be eligible for rewards in target epoch."
 	emitUserEvent(
@@ -110,11 +110,11 @@ func EmitPostComplete(challenge []byte) {
 }
 
 func EmitPostFailure() {
-	const help = "Failed to compute post."
+	const help = "Node failed post execution."
 	emitUserEvent(
 		help,
 		true,
-		&pb.Event_PostFailed{PostFailed: &pb.EventPostFailed{}},
+		&pb.Event_PostComplete{PostComplete: &pb.EventPostComplete{}},
 	)
 }
 

--- a/events/events.go
+++ b/events/events.go
@@ -4,47 +4,155 @@ import (
 	"time"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/log"
 )
 
-type eventEnum int
-
-func (e eventEnum) String() string {
-	return eventEnumStrings[e]
-}
-
-var eventEnumStrings = [...]string{
-	"error",
-	"beacon",
-	"init_start",
-	"init_complete",
-	"poet_wait_start",
-	"poet_wait_complete",
-	"atx_published",
-	"proposal_eligibilities",
-	"proposal_created",
-	"identity_equivocated",
-}
-
-const (
-	eventError eventEnum = iota
-	eventBeacon
-	eventInitStart
-	eventInitStop
-	eventWaitPoetStart
-	eventWaitPoetComplete
-	eventAtxPublished
-	eventProposalEligibilities
-	eventProposalCreated
-	identityEquivocated
-)
-
-type Event struct {
-	Timestamp *time.Time `json:"ts"`
-	Enum      int        `json:"type"`
-	Event     any        `json:"event,inline,omitempty"`
-	Persist   bool       `json:"-"`
+type UserEvent struct {
+	Timestamp time.Time `json:"time"`
+	Help      string    `jsonn:"help"`
+	Details   any       `json:"details"`
 }
 
 type EventBeacon struct {
-	Beacon types.Beacon `json:"beacon"`
+	Epoch  types.EpochID `json:"epoch"`
+	Beacon types.Beacon  `json:"beacon"`
+}
+
+func EmitBeacon(epoch types.EpochID, beacon types.Beacon) {
+	emitUsersEvents(
+		"Node computed randomness beacon, it will be used to determine eligibility to participate in the consensus.",
+		EventBeacon{Epoch: epoch, Beacon: beacon},
+	)
+}
+
+type EventInitStart struct {
+	Smesher    types.NodeID `json:"smesher"`
+	Genesis    types.Hash20 `json:"genesis"`
+	Commitment types.ATXID  `json:"commitment"`
+}
+
+func EmitInitStart(smesher types.NodeID, genesis types.Hash20, commitment types.ATXID) {
+	emitUsersEvents(
+		"Node started post data initialization.",
+		EventInitStart{
+			Smesher:    smesher,
+			Genesis:    genesis,
+			Commitment: commitment,
+		},
+	)
+}
+
+type EventInitComplete struct{}
+
+func EmitInitComplete(duration time.Duration) {
+	emitUsersEvents(
+		"Node completed post data initialization.",
+		EventInitComplete{},
+	)
+}
+
+type EventPoetWait struct {
+	Wait time.Duration `json:"wait"`
+}
+
+func EmitPoetWait(wait time.Duration) {
+	emitUsersEvents(
+		"Node needs to wait for poet registration window to open.",
+		EventPoetWait{Wait: wait},
+	)
+}
+
+type EventPost struct{}
+
+func EmitPost() {
+	emitUsersEvents(
+		"Node started post execution.",
+		EventPost{},
+	)
+}
+
+type EventAtxPublished struct {
+	Current types.EpochID `json:"current"`
+	Target  types.EpochID `json:"target"`
+	Layer   types.LayerID `json:"layer"`
+	ID      types.ATXID   `json:"id"`
+	Weight  uint64        `json:"weight"`
+	Height  uint64        `json:"height"`
+}
+
+func EmitAtxPublished(
+	layer types.LayerID,
+	current, target types.EpochID,
+	id types.ATXID,
+	weight, height uint64,
+) {
+	emitUsersEvents(
+		"Published activation. Node needs to wait till the start of target epoch in order to be eligible for rewards.",
+		&EventAtxPublished{
+			Current: current,
+			Target:  target,
+			Layer:   layer,
+			ID:      id,
+			Weight:  weight,
+			Height:  height,
+		},
+	)
+}
+
+type EventEligibilities struct {
+	Epoch         types.EpochID               `json:"epoch"`
+	Beacon        types.Beacon                `json:"beacon"`
+	ATX           types.ATXID                 `json:"atx"`
+	ActiveSetHash types.Hash32                `json:"active-set-hash"`
+	Eligibilities []types.ProposalEligibility `json:"eligibilities"`
+}
+
+func EmitEligibilities(
+	epoch types.EpochID,
+	beacon types.Beacon,
+	atx types.ATXID,
+	activeset types.Hash32,
+	eligibilities []types.ProposalEligibility,
+) {
+	emitUsersEvents(
+		"Computed eligibilities for the epoch. Rewards will be received based on them.",
+		EventEligibilities{
+			Epoch:         epoch,
+			Beacon:        beacon,
+			ATX:           atx,
+			ActiveSetHash: activeset,
+			Eligibilities: eligibilities,
+		},
+	)
+}
+
+type EventProposalCreated struct {
+	Layer    types.LayerID    `json:"layer"`
+	Proposal types.ProposalID `json:"proposal"`
+	ATX      types.ATXID      `json:"atxid"`
+}
+
+func EmitProposal(layer types.LayerID, proposal types.ProposalID, atx types.ATXID) {
+	emitUsersEvents(
+		"Proposal was created. Once proposal is included into the block rewards will be received into coinbase.",
+		EventProposalCreated{
+			Layer:    layer,
+			Proposal: proposal,
+			ATX:      atx,
+		},
+	)
+}
+
+func emitUsersEvents(help string, details any) {
+	mu.RLock()
+	defer mu.RUnlock()
+	if reporter != nil {
+		if err := reporter.eventsEmitter.Emit(&UserEvent{
+			Timestamp: time.Now(),
+			Help:      help,
+			Details:   details,
+		}); err != nil {
+			log.With().Error("failed to emit event", log.Err(err))
+		}
+	}
 }

--- a/events/events.go
+++ b/events/events.go
@@ -1,0 +1,50 @@
+package events
+
+import (
+	"time"
+
+	"github.com/spacemeshos/go-spacemesh/common/types"
+)
+
+type eventEnum int
+
+func (e eventEnum) String() string {
+	return eventEnumStrings[e]
+}
+
+var eventEnumStrings = [...]string{
+	"error",
+	"beacon",
+	"init_start",
+	"init_complete",
+	"poet_wait_start",
+	"poet_wait_complete",
+	"atx_published",
+	"proposal_eligibilities",
+	"proposal_created",
+	"identity_equivocated",
+}
+
+const (
+	eventError eventEnum = iota
+	eventBeacon
+	eventInitStart
+	eventInitStop
+	eventWaitPoetStart
+	eventWaitPoetComplete
+	eventAtxPublished
+	eventProposalEligibilities
+	eventProposalCreated
+	identityEquivocated
+)
+
+type Event struct {
+	Timestamp *time.Time `json:"ts"`
+	Enum      int        `json:"type"`
+	Event     any        `json:"event,inline,omitempty"`
+	Persist   bool       `json:"-"`
+}
+
+type EventBeacon struct {
+	Beacon types.Beacon `json:"beacon"`
+}

--- a/events/events.go
+++ b/events/events.go
@@ -62,7 +62,7 @@ func EmitPoetWait(current, publish types.EpochID, wait time.Duration) {
 		false,
 		&pb.Event_PoetWait{PoetWait: &pb.EventPoetWait{
 			Current: current.Uint32(),
-			Public:  current.Uint32(),
+			Publish: publish.Uint32(),
 			Wait:    durationpb.New(wait),
 		}},
 	)

--- a/events/events.go
+++ b/events/events.go
@@ -11,12 +11,11 @@ type EventType string
 
 const (
 	TypeBeacon        = "Beacon"
-	TypeWaitAtxs      = "Download ATXs"
 	TypeInitStart     = "Init Start"
 	TypeInitComplete  = "Init Complete"
 	TypePostStart     = "Post Start"
 	TypePostComplete  = "Post Complete"
-	TypePoetWait      = "Poet Wait"
+	TypePoetWaitStart = "Poet Wait Start"
 	TypePoetWaitEnd   = "Poet Wait End"
 	TypeATXPublished  = "ATX Published"
 	TypeEligibilities = "Eligibilities"
@@ -48,7 +47,6 @@ func EmitBeacon(epoch types.EpochID, beacon types.Beacon) {
 
 type EventInitStart struct {
 	Smesher    types.NodeID `json:"smesher"`
-	Genesis    types.Hash20 `json:"genesis"`
 	Commitment types.ATXID  `json:"commitment"`
 }
 
@@ -85,7 +83,7 @@ func EmitPoetWait(current, publish types.EpochID, wait time.Duration) {
 	const help = "Node needs to wait for poet registration window in current epoch to open." +
 		"Once opened it will submit challenge and wait till poet round ends in publish epoch."
 	emitUsersEvents(
-		TypePoetWait,
+		TypePoetWaitStart,
 		help,
 		false,
 		EventPoetWait{Current: current, Publish: publish, Wait: wait},
@@ -115,7 +113,7 @@ type EventPost struct {
 }
 
 func EmitPostStart(challennge []byte) {
-	const help = "Node started post execution for challenge from a poet."
+	const help = "Node started post execution for the challenge from poet."
 	emitUsersEvents(
 		TypePostStart,
 		help,
@@ -160,8 +158,8 @@ func EmitAtxPublished(
 	id types.ATXID,
 	wait time.Duration,
 ) {
-	const help = "Published activation. " +
-		"Node needs to wait till the start of target epoch in order to be eligible for rewards."
+	const help = "Published activation for the current epoch. " +
+		"Node needs to wait till the start of the target epoch in order to be eligible for rewards."
 	emitUsersEvents(
 		TypeATXPublished,
 		help,
@@ -192,7 +190,7 @@ func EmitEligibilities(
 ) {
 	const help = "Computed eligibilities for the epoch. " +
 		"Rewards will be received after publishing proposals at specified layers. " +
-		"Total amount of rewards will be based on other participants in the layer."
+		"Total amount of rewards in SMH will be based on other participants in the layer."
 	emitUsersEvents(
 		TypeEligibilities,
 		help,

--- a/events/reporter.go
+++ b/events/reporter.go
@@ -411,53 +411,49 @@ type EventReporter struct {
 	rewardEmitter      event.Emitter
 	resultsEmitter     event.Emitter
 	proposalsEmitter   event.Emitter
+	eventsEmitter      event.Emitter
 	stopChan           chan struct{}
 }
 
 func newEventReporter() *EventReporter {
 	bus := eventbus.NewBus()
-
 	transactionEmitter, err := bus.Emitter(new(Transaction))
 	if err != nil {
 		log.With().Panic("failed to create transaction emitter", log.Err(err))
 	}
-
 	activationEmitter, err := bus.Emitter(new(ActivationTx))
 	if err != nil {
 		log.With().Panic("failed to create activation emitter", log.Err(err))
 	}
-
 	layerEmitter, err := bus.Emitter(new(LayerUpdate))
 	if err != nil {
 		log.With().Panic("failed to create layer emitter", log.Err(err))
 	}
-
 	statusEmitter, err := bus.Emitter(new(Status))
 	if err != nil {
 		log.With().Panic("failed to create status emitter", log.Err(err))
 	}
-
 	accountEmitter, err := bus.Emitter(new(Account))
 	if err != nil {
 		log.With().Panic("failed to create account emitter", log.Err(err))
 	}
-
 	rewardEmitter, err := bus.Emitter(new(Reward))
 	if err != nil {
 		log.With().Panic("failed to create reward emitter", log.Err(err))
 	}
-
 	resultsEmitter, err := bus.Emitter(new(types.TransactionWithResult))
 	if err != nil {
 		log.With().Panic("failed to create receipt emitter", log.Err(err))
 	}
-
 	errorEmitter, err := bus.Emitter(new(NodeError))
 	if err != nil {
 		log.With().Panic("failed to create error emitter", log.Err(err))
 	}
-
 	proposalsEmitter, err := bus.Emitter(new(EventProposal))
+	if err != nil {
+		log.With().Panic("failed to to create proposal emitter", log.Err(err))
+	}
+	eventsEmitter, err := bus.Emitter(new(UserEvent))
 	if err != nil {
 		log.With().Panic("failed to to create proposal emitter", log.Err(err))
 	}
@@ -473,6 +469,7 @@ func newEventReporter() *EventReporter {
 		resultsEmitter:     resultsEmitter,
 		errorEmitter:       errorEmitter,
 		proposalsEmitter:   proposalsEmitter,
+		eventsEmitter:      eventsEmitter,
 		stopChan:           make(chan struct{}),
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/pyroscope-io/pyroscope v0.37.2
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.0
 	github.com/seehuhn/mt19937 v1.0.0
-	github.com/spacemeshos/api/release/go v1.12.1-0.20230704085524-b93332933766
+	github.com/spacemeshos/api/release/go v1.12.1-0.20230704092720-edf164e650b8
 	github.com/spacemeshos/economics v0.1.0
 	github.com/spacemeshos/fixed v0.1.0
 	github.com/spacemeshos/go-scale v1.1.10

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/pyroscope-io/pyroscope v0.37.2
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.0
 	github.com/seehuhn/mt19937 v1.0.0
-	github.com/spacemeshos/api/release/go v1.12.1-0.20230704092720-edf164e650b8
+	github.com/spacemeshos/api/release/go v1.12.1-0.20230704105248-dd9e43c949b0
 	github.com/spacemeshos/economics v0.1.0
 	github.com/spacemeshos/fixed v0.1.0
 	github.com/spacemeshos/go-scale v1.1.10

--- a/go.mod
+++ b/go.mod
@@ -212,3 +212,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
+
+replace github.com/spacemeshos/api/release/go => ../api/release/go

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/pyroscope-io/pyroscope v0.37.2
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.0
 	github.com/seehuhn/mt19937 v1.0.0
-	github.com/spacemeshos/api/release/go v1.12.0
+	github.com/spacemeshos/api/release/go v1.12.1-0.20230704085524-b93332933766
 	github.com/spacemeshos/economics v0.1.0
 	github.com/spacemeshos/fixed v0.1.0
 	github.com/spacemeshos/go-scale v1.1.10
@@ -212,5 +212,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
-
-replace github.com/spacemeshos/api/release/go => ../api/release/go

--- a/go.sum
+++ b/go.sum
@@ -598,6 +598,8 @@ github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d/go.mod h1:Udh
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
 github.com/spacemeshos/api/release/go v1.12.0 h1:9Yh1NkOxtskdD6qM/ErmEhsU4003tVjx1ZTzwEi3uy4=
 github.com/spacemeshos/api/release/go v1.12.0/go.mod h1:eWQMPaXyLLaxen7GW0fL/Nfxpiqsxt6XoK+obcIrAu4=
+github.com/spacemeshos/api/release/go v1.12.1-0.20230704085524-b93332933766 h1:2U4wzhha1ysM9UaAQaBXGn4tt8XOGIJ97Es2C2FkGMA=
+github.com/spacemeshos/api/release/go v1.12.1-0.20230704085524-b93332933766/go.mod h1:6dbFQWsygFOlpPdmNNwiBbqEXAvK+s11UJO70VI1Yaw=
 github.com/spacemeshos/economics v0.1.0 h1:PJAKbhBKqbbdCYTB29pkmc8sYqK3pKUAiuAvQxuSJEg=
 github.com/spacemeshos/economics v0.1.0/go.mod h1:Bz0wRDwCOUP1A6w3cPW6iuUBGME8Tz48sIriYiohsBg=
 github.com/spacemeshos/fixed v0.1.0 h1:20KIGvxLlAsuidQrvuwwHe6PrvqeTKzbJIsScbmnUPQ=

--- a/go.sum
+++ b/go.sum
@@ -596,10 +596,6 @@ github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d/go.mod h1:UdhH50NIW0fCiwBSr0co2m7BnFLdv4fQTgdqdJTHFeE=
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
-github.com/spacemeshos/api/release/go v1.12.0 h1:9Yh1NkOxtskdD6qM/ErmEhsU4003tVjx1ZTzwEi3uy4=
-github.com/spacemeshos/api/release/go v1.12.0/go.mod h1:eWQMPaXyLLaxen7GW0fL/Nfxpiqsxt6XoK+obcIrAu4=
-github.com/spacemeshos/api/release/go v1.12.1-0.20230704085524-b93332933766 h1:2U4wzhha1ysM9UaAQaBXGn4tt8XOGIJ97Es2C2FkGMA=
-github.com/spacemeshos/api/release/go v1.12.1-0.20230704085524-b93332933766/go.mod h1:6dbFQWsygFOlpPdmNNwiBbqEXAvK+s11UJO70VI1Yaw=
 github.com/spacemeshos/api/release/go v1.12.1-0.20230704092720-edf164e650b8 h1:zXmVKL38P9/q80M8t1oZWDmMYsFEKqiDzjpwONrGLl0=
 github.com/spacemeshos/api/release/go v1.12.1-0.20230704092720-edf164e650b8/go.mod h1:6dbFQWsygFOlpPdmNNwiBbqEXAvK+s11UJO70VI1Yaw=
 github.com/spacemeshos/economics v0.1.0 h1:PJAKbhBKqbbdCYTB29pkmc8sYqK3pKUAiuAvQxuSJEg=

--- a/go.sum
+++ b/go.sum
@@ -596,8 +596,8 @@ github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d/go.mod h1:UdhH50NIW0fCiwBSr0co2m7BnFLdv4fQTgdqdJTHFeE=
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
-github.com/spacemeshos/api/release/go v1.12.1-0.20230704092720-edf164e650b8 h1:zXmVKL38P9/q80M8t1oZWDmMYsFEKqiDzjpwONrGLl0=
-github.com/spacemeshos/api/release/go v1.12.1-0.20230704092720-edf164e650b8/go.mod h1:6dbFQWsygFOlpPdmNNwiBbqEXAvK+s11UJO70VI1Yaw=
+github.com/spacemeshos/api/release/go v1.12.1-0.20230704105248-dd9e43c949b0 h1:k9YI+i20n+a6w/xFMLfCiElmxZfc9a++NUgpJRfGyIc=
+github.com/spacemeshos/api/release/go v1.12.1-0.20230704105248-dd9e43c949b0/go.mod h1:6dbFQWsygFOlpPdmNNwiBbqEXAvK+s11UJO70VI1Yaw=
 github.com/spacemeshos/economics v0.1.0 h1:PJAKbhBKqbbdCYTB29pkmc8sYqK3pKUAiuAvQxuSJEg=
 github.com/spacemeshos/economics v0.1.0/go.mod h1:Bz0wRDwCOUP1A6w3cPW6iuUBGME8Tz48sIriYiohsBg=
 github.com/spacemeshos/fixed v0.1.0 h1:20KIGvxLlAsuidQrvuwwHe6PrvqeTKzbJIsScbmnUPQ=

--- a/go.sum
+++ b/go.sum
@@ -600,6 +600,8 @@ github.com/spacemeshos/api/release/go v1.12.0 h1:9Yh1NkOxtskdD6qM/ErmEhsU4003tVj
 github.com/spacemeshos/api/release/go v1.12.0/go.mod h1:eWQMPaXyLLaxen7GW0fL/Nfxpiqsxt6XoK+obcIrAu4=
 github.com/spacemeshos/api/release/go v1.12.1-0.20230704085524-b93332933766 h1:2U4wzhha1ysM9UaAQaBXGn4tt8XOGIJ97Es2C2FkGMA=
 github.com/spacemeshos/api/release/go v1.12.1-0.20230704085524-b93332933766/go.mod h1:6dbFQWsygFOlpPdmNNwiBbqEXAvK+s11UJO70VI1Yaw=
+github.com/spacemeshos/api/release/go v1.12.1-0.20230704092720-edf164e650b8 h1:zXmVKL38P9/q80M8t1oZWDmMYsFEKqiDzjpwONrGLl0=
+github.com/spacemeshos/api/release/go v1.12.1-0.20230704092720-edf164e650b8/go.mod h1:6dbFQWsygFOlpPdmNNwiBbqEXAvK+s11UJO70VI1Yaw=
 github.com/spacemeshos/economics v0.1.0 h1:PJAKbhBKqbbdCYTB29pkmc8sYqK3pKUAiuAvQxuSJEg=
 github.com/spacemeshos/economics v0.1.0/go.mod h1:Bz0wRDwCOUP1A6w3cPW6iuUBGME8Tz48sIriYiohsBg=
 github.com/spacemeshos/fixed v0.1.0 h1:20KIGvxLlAsuidQrvuwwHe6PrvqeTKzbJIsScbmnUPQ=

--- a/miner/oracle.go
+++ b/miner/oracle.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/datastore"
+	"github.com/spacemeshos/go-spacemesh/events"
 	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/proposals"
 	"github.com/spacemeshos/go-spacemesh/signing"
@@ -98,6 +99,7 @@ func (o *Oracle) GetProposalEligibility(lid types.LayerID, beacon types.Beacon, 
 	if err != nil {
 		return nil, err
 	}
+	emitEpochEligibility(beacon, ee)
 	o.cache = ee
 	return ee, nil
 }
@@ -196,4 +198,15 @@ func (o *Oracle) calcEligibilityProofs(atx *types.ActivationTxHeader, epoch type
 		Proofs:    eligibilityProofs,
 		Slots:     numEligibleSlots,
 	}, nil
+}
+
+func emitEpochEligibility(beacon types.Beacon, elig *EpochEligibility) {
+	eligs := make([]types.ProposalEligibility, 0, len(elig.Proofs))
+	for lid := range elig.Proofs {
+		eligs = append(eligs, types.ProposalEligibility{
+			Layer: lid,
+			Count: uint32(len(elig.Proofs)),
+		})
+	}
+	events.EmitEligibilities(elig.Epoch, beacon, elig.Atx, uint32(len(elig.ActiveSet)), eligs)
 }

--- a/miner/oracle.go
+++ b/miner/oracle.go
@@ -99,7 +99,7 @@ func (o *Oracle) GetProposalEligibility(lid types.LayerID, beacon types.Beacon, 
 	if err != nil {
 		return nil, err
 	}
-	emitEpochEligibility(beacon, ee)
+	events.EmitEligibilities(ee.Epoch, beacon, ee.Atx, uint32(len(ee.ActiveSet)), ee.Proofs)
 	o.cache = ee
 	return ee, nil
 }
@@ -198,15 +198,4 @@ func (o *Oracle) calcEligibilityProofs(atx *types.ActivationTxHeader, epoch type
 		Proofs:    eligibilityProofs,
 		Slots:     numEligibleSlots,
 	}, nil
-}
-
-func emitEpochEligibility(beacon types.Beacon, elig *EpochEligibility) {
-	eligs := make([]types.ProposalEligibility, 0, len(elig.Proofs))
-	for lid := range elig.Proofs {
-		eligs = append(eligs, types.ProposalEligibility{
-			Layer: lid,
-			Count: uint32(len(elig.Proofs)),
-		})
-	}
-	events.EmitEligibilities(elig.Epoch, beacon, elig.Atx, uint32(len(elig.ActiveSet)), eligs)
 }

--- a/miner/proposal_builder.go
+++ b/miner/proposal_builder.go
@@ -435,8 +435,10 @@ func (pb *ProposalBuilder) handleLayer(ctx context.Context, layerID types.LayerI
 		}
 		if err = pb.publisher.Publish(newCtx, pubsub.ProposalProtocol, data); err != nil {
 			pb.logger.WithContext(newCtx).With().Error("failed to send proposal", log.Err(err))
+		} else {
+			events.EmitProposal(layerID, p.ID())
+			events.ReportProposal(events.ProposalCreated, p)
 		}
-		events.ReportProposal(events.ProposalCreated, p)
 		return nil
 	})
 	return nil

--- a/node/node.go
+++ b/node/node.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"math"
 	"net/http"
 	"net/url"
 	"os"
@@ -959,6 +960,7 @@ func (app *App) launchStandalone(ctx context.Context) error {
 	cfg.Service.EpochDuration = app.Config.LayerDuration * time.Duration(app.Config.LayersPerEpoch)
 	cfg.Service.CycleGap = app.Config.POET.CycleGap
 	cfg.Service.PhaseShift = app.Config.POET.PhaseShift
+	cfg.Service.PowDifficulty = math.MaxUint64
 	srv, err := server.New(ctx, *cfg)
 	if err != nil {
 		return fmt.Errorf("init poet server: %w", err)

--- a/node/node.go
+++ b/node/node.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"math"
 	"net/http"
 	"net/url"
 	"os"
@@ -960,7 +959,6 @@ func (app *App) launchStandalone(ctx context.Context) error {
 	cfg.Service.EpochDuration = app.Config.LayerDuration * time.Duration(app.Config.LayersPerEpoch)
 	cfg.Service.CycleGap = app.Config.POET.CycleGap
 	cfg.Service.PhaseShift = app.Config.POET.PhaseShift
-	cfg.Service.PowDifficulty = math.MaxUint64
 	srv, err := server.New(ctx, *cfg)
 	if err != nil {
 		return fmt.Errorf("init poet server: %w", err)

--- a/node/node.go
+++ b/node/node.go
@@ -643,6 +643,7 @@ func (app *App) initServices(ctx context.Context, poetClients []activation.PoetP
 	}
 	app.eg.Go(func() error {
 		for rst := range beaconProtocol.Results() {
+			events.EmitBeacon(rst.Epoch, rst.Beacon)
 			trtl.OnBeacon(rst.Epoch, rst.Beacon)
 		}
 		app.log.Debug("beacon results watcher exited")

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -947,13 +947,17 @@ func TestAdminEvents(t *testing.T) {
 		&pb.Event_InitComplete{},
 		&pb.Event_PostStart{},
 		&pb.Event_PostComplete{},
+		&pb.Event_PoetWait{},
 		&pb.Event_PoetWaitChallenge{},
+		&pb.Event_PostStart{},
+		&pb.Event_PostComplete{},
+		&pb.Event_AtxPublished{},
 	}
-	_ = success
-	for {
+	for _, ev := range success {
 		msg, err := stream.Recv()
 		require.NoError(t, err)
-		t.Logf("EVENT: %v. %v", time.Now(), msg)
+		t.Logf("EVENT: %v", msg)
+		require.IsType(t, ev, msg.Details)
 	}
 }
 

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -913,6 +913,7 @@ func TestAdminEvents(t *testing.T) {
 	cfg.FileLock = filepath.Join(cfg.DataDirParent, "LOCK")
 	cfg.SMESHING.Opts.DataDir = t.TempDir()
 	cfg.Genesis.GenesisTime = time.Now().Add(5 * time.Second).Format(time.RFC3339)
+	types.SetLayersPerEpoch(cfg.LayersPerEpoch)
 
 	app := New(WithConfig(&cfg), WithLog(logtest.New(t)))
 	signer, err := app.LoadOrCreateEdSigner()
@@ -956,7 +957,6 @@ func TestAdminEvents(t *testing.T) {
 	for _, ev := range success {
 		msg, err := stream.Recv()
 		require.NoError(t, err)
-		t.Logf("EVENT: %v", msg)
 		require.IsType(t, ev, msg.Details)
 	}
 }


### PR DESCRIPTION
api: https://github.com/spacemeshos/api/pull/247

launch standalone node
> ./build/go-spacemesh --preset=standalone --genesis-time=2023-07-04T9:05:00.000Z

watch events
> grpcurl -plaintext 0.0.0.0:10093 spacemesh.v1.AdminService.EventsStream

```
{
  "timestamp": "2023-07-04T08:55:00.355785009Z",
  "help": "Published proposal. Rewards will be received, once proposal is included into the block.",
  "proposal": {
    "layer": 150,
    "proposal": "i5iBp35b53G7OdTKsd9Y1tRc5HM="
  }
}
{
  "timestamp": "2023-07-04T08:55:01.025198892Z",
  "help": "Node started post execution for the challenge from poet.",
  "postStart": {
    "challenge": "mvy+3M6Ja2e8GWRsCP5Rqzuw+n8xIKtgnDGz296zKuU="
  }
}
```

admin events can be watched by subscribing to spacemesh.v1.AdminService.EventsStream. each event has 4 fields:
- timestamp
- failure. denotes that certain expected step has failed. we considered an alternative to provide a special failure events, but it would require maintaining a mapping on client side, and it is unclear if we need that. for now if any step has failure=true, user will be referred to logs or relevant documentation.
- help. this is initial approach to communicate what each events means to facilitate integration. later smapp can write better explanation and we will deprecate help.
- details. uses protobuf oneof, it enables smapp to reliably use those fields for custom representation and use this events in tests for better assertions. i considered encoding details in json, but it makes everything else worse but makes it a bit easier to add new events, which is probably not the right tradeoff