### PR TITLE
[Merged by Bors] - Disable defender also during build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,14 +110,6 @@ jobs:
           - [self-hosted, macos, arm64]
           - windows-latest
     steps:
-      - name: checkout
-        uses: actions/checkout@v3
-      - name: set up go
-        uses: actions/setup-go@v4
-        with:
-          check-latest: true
-          go-version-file: "go.mod"
-          cache: ${{ runner.arch != 'arm64' }}
       - name: Add OpenCL support - Ubuntu
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: sudo apt-get update -q && sudo apt-get install -qy ocl-icd-opencl-dev libpocl2
@@ -128,9 +120,14 @@ jobs:
         if: ${{ matrix.os == 'windows-latest' }}
         run: |
           Set-MpPreference -DisableRealtimeMonitoring $true
-      - name: Add OpenCL support - Windows
-        if: ${{ matrix.os == 'windows-latest' }}
-        run: choco install opencl-intel-cpu-runtime
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: set up go
+        uses: actions/setup-go@v4
+        with:
+          check-latest: true
+          go-version-file: "go.mod"
+          cache: ${{ runner.arch != 'arm64' }}
       - name: setup env
         run: make install
       - name: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,13 @@ jobs:
       - name: Override SDKROOT for macOS
         if: ${{ contains(matrix.os, 'macos') && runner.arch == 'arm64' }}
         run: echo "SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk" >> $GITHUB_ENV
+      - name: disable Windows Defender - Windows
+        if: ${{ matrix.os == 'windows-latest' }}
+        run: |
+          Set-MpPreference -DisableRealtimeMonitoring $true
+      - name: Add OpenCL support - Windows
+        if: ${{ matrix.os == 'windows-latest' }}
+        run: choco install opencl-intel-cpu-runtime
       - name: setup env
         run: make install
       - name: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,8 @@ jobs:
     # should not take more than 7-8 mins
     timeout-minutes: 10
     steps:
+      - name: Add OpenCL support
+        run: sudo apt-get update -q && sudo apt-get install -qy ocl-icd-opencl-dev libpocl2
       - name: checkout
         uses: actions/checkout@v3
       - name: set up go
@@ -64,8 +66,6 @@ jobs:
         with:
           check-latest: true
           go-version-file: "go.mod"
-      - name: Add OpenCL support
-        run: sudo apt-get update -q && sudo apt-get install -qy ocl-icd-opencl-dev libpocl2
       - name: fmt, tidy, generate
         run: |
           make install
@@ -89,8 +89,6 @@ jobs:
         with:
           check-latest: true
           go-version-file: "go.mod"
-      - name: Add OpenCL support
-        run: sudo apt-get update -q && sudo apt-get install -qy ocl-icd-opencl-dev libpocl2
       - name: setup env
         run: make install
       - name: lint

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           check-latest: true
           go-version-file: "go.mod"
-      - name: Add OpenCL support
+      - name: Add OpenCL support - Ubuntu
         run: sudo apt-get update -q && sudo apt-get install -qy ocl-icd-opencl-dev libpocl2
       - name: setup env
         run: make install


### PR DESCRIPTION
## Motivation
At the moment Windows defender is only disabled during unit tests to speed them up. This PR also disables it during the build.

## Changes
- Disable Windows defender during build

## Test Plan
n/a

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
