### PR TITLE
[Merged by Bors] - Improve release job to not need version.txt

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,25 +42,9 @@ jobs:
           go-version-file: "go.mod"
           cache: ${{ runner.arch != 'arm64' }}
 
-      - if: matrix.os == 'windows-latest'
-        name: Install dependencies in windows
-        uses: crazy-max/ghaction-chocolatey@v2
-        with:
-          args: install make wget zip
-
-      - name: setup env
-        run: |
-          echo "::set-env name=GOPATH::$(go env GOPATH)"
-          echo "::add-path::$(go env GOPATH)/bin"
-        shell: bash
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
-
-      - name: Read version.txt
-        id: version
-        uses: juliangruber/read-file-action@v1
-        with:
-          path: ./version.txt
+      - name: Install dependencies in windows
+        if: ${{ matrix.os == 'windows-latest' }}
+        run: choco install make wget zip
 
       - name: Add OpenCL support for Linux
         if: ${{ matrix.os == 'ubuntu-latest' }}
@@ -75,7 +59,7 @@ jobs:
         shell: bash
         run: |
           make install
-          make build VERSION=${{ steps.version.outputs.content }} BIN_DIR_WIN=./build
+          make build VERSION=${{ github.ref }} BIN_DIR_WIN=./build
       - name: Create release archive
         shell: bash
         env:

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,0 @@
-v0.0.0-unreleased


### PR DESCRIPTION
## Motivation
Update our release job to read the version from the tag rather than from `version.txt`

## Changes
Update release job by

- replacing action `crazy-max/ghaction-chocolatey@v2` by just calling `choco install`
- removing setting `GOPATH` and `PATH` explicitly. This is already done by the `actions/setup-go@v4` step.
- removing reading the version to release from `version.txt` and replace it with the name of the git tag instead

## Test Plan
n/a

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
