### PR TITLE
[Merged by Bors] - Update CI tooling and fix complaints

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -590,7 +590,7 @@ linters-settings:
   staticcheck:
     # SAxxxx checks in https://staticcheck.io/docs/configuration/options/#checks
     # Default: ["*"]
-    checks: ["all", "-SA5001"]
+    checks: ["all"]
 
 issues:
   # List of regexps of issue texts to exclude.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,11 +9,11 @@ run:
 
   # Exit code when at least one issue was found.
   # Default: 1
-  issues-exit-code: 1
+  # issues-exit-code: 1
 
   # Include test files or not.
   # Default: true
-  tests: true
+  # tests: true
 
   # List of build tags, all linters use it.
   # Default: [].
@@ -66,32 +66,429 @@ run:
 
 # output configuration options
 output:
-  # colored-line-number|line-number|json|tab|checkstyle, default is "colored-line-number"
+  # Format: colored-line-number|line-number|json|colored-tab|tab|checkstyle|code-climate|junit-xml|github-actions|teamcity
+  #
+  # Multiple can be specified by separating them by comma, output can be provided
+  # for each of them by separating format name and path by colon symbol.
+  # Output path can be either `stdout`, `stderr` or path to the file to write to.
+  # Example: "checkstyle:report.xml,json:stdout,colored-line-number"
+  #
+  # Default: colored-line-number
   format: colored-line-number
 
-  # print lines of code with issue, default is true
+  # Print lines of code with issue.
+  # Default: true
   print-issued-lines: true
 
-  # print linter name in the end of issue text, default is true
+  # Print linter name in the end of issue text.
+  # Default: true
   print-linter-name: true
+
+  # Make issues output unique by line.
+  # Default: true
+  # uniq-by-line: false
+
+  # Add a prefix to the output file references.
+  # Default is no prefix.
+  # path-prefix: ""
+
+  # Sort results by: filepath, line and column.
+  # sort-results: false
+
+linters:
+  # Disable all linters.
+  # Default: false
+  disable-all: true
+
+  # Enable specific linter
+  # https://golangci-lint.run/usage/linters/#enabled-by-default
+  enable:
+    # - asasalint
+    # - asciicheck
+    # - bidichk
+    # - bodyclose
+    # - containedctx
+    # - contextcheck
+    # - cyclop
+    # - deadcode
+    # - decorder
+    - depguard
+    # - dogsled
+    # - dupl
+    # - dupword
+    # - durationcheck
+    # - errcheck
+    # - errchkjson
+    # - errname
+    # - errorlint
+    # - execinquery
+    # - exhaustive
+    # - exhaustivestruct
+    # - exhaustruct
+    # - exportloopref
+    # - forbidigo
+    # - forcetypeassert
+    # - funlen
+    - gci
+    # - ginkgolinter
+    # - gocheckcompilerdirectives
+    # - gochecknoglobals
+    # - gochecknoinits
+    # - gocognit
+    # - goconst
+    # - gocritic
+    # - gocyclo
+    - godot
+    # - godox
+    # - goerr113
+    - gofmt
+    - gofumpt
+    # - goheader
+    # - goimports
+    # - golint
+    # - gomnd
+    # - gomoddirectives
+    # - gomodguard
+    # - goprintffuncname
+    # - gosec
+    - gosimple
+    # - gosmopolitan
+    - govet
+    # - grouper
+    # - ifshort
+    - importas
+    - ineffassign
+    # - interfacebloat
+    # - interfacer
+    # - ireturn
+    # - lll
+    # - loggercheck
+    # - maintidx
+    # - makezero
+    # - maligned
+    # - mirror
+    - misspell
+    # - musttag
+    - nakedret
+    # - nestif
+    # - nilerr
+    # - nilnil
+    # - nlreturn
+    # - noctx
+    # - nolintlint
+    # - nonamedreturns
+    # - nosnakecase
+    # - nosprintfhostport
+    # - paralleltest
+    # - prealloc
+    # - predeclared
+    # - promlinter
+    # - reassign
+    - revive
+    # - rowserrcheck
+    # - scopelint
+    # - sqlclosecheck
+    - staticcheck
+    # - structcheck
+    # - stylecheck
+    # - tagalign
+    # - tagliatelle
+    # - tenv
+    # - testableexamples
+    # - testpackage
+    # - thelper
+    # - tparallel
+    - typecheck
+    # - unconvert
+    # - unparam
+    - unused
+    # - usestdlibvars
+    # - varcheck
+    # - varnamelen
+    # - wastedassign
+    # - whitespace
+    # - wrapcheck
+    # - wsl
+    # - zerologlint
+
+  # Enable all available linters.
+  # Default: false
+  enable-all: false
+
+  # Disable specific linter
+  # https://golangci-lint.run/usage/linters/#disabled-by-default
+  # disable:
+  #   - asasalint
+  #   - asciicheck
+  #   - bidichk
+  #   - bodyclose
+  #   - containedctx
+  #   - contextcheck
+  #   - cyclop
+  #   - deadcode
+  #   - decorder
+  #   - depguard
+  #   - dogsled
+  #   - dupl
+  #   - dupword
+  #   - durationcheck
+  #   - errcheck
+  #   - errchkjson
+  #   - errname
+  #   - errorlint
+  #   - execinquery
+  #   - exhaustive
+  #   - exhaustivestruct
+  #   - exhaustruct
+  #   - exportloopref
+  #   - forbidigo
+  #   - forcetypeassert
+  #   - funlen
+  #   - gci
+  #   - ginkgolinter
+  #   - gocheckcompilerdirectives
+  #   - gochecknoglobals
+  #   - gochecknoinits
+  #   - gocognit
+  #   - goconst
+  #   - gocritic
+  #   - gocyclo
+  #   - godot
+  #   - godox
+  #   - goerr113
+  #   - gofmt
+  #   - gofumpt
+  #   - goheader
+  #   - goimports
+  #   - golint
+  #   - gomnd
+  #   - gomoddirectives
+  #   - gomodguard
+  #   - goprintffuncname
+  #   - gosec
+  #   - gosimple
+  #   - gosmopolitan
+  #   - govet
+  #   - grouper
+  #   - ifshort
+  #   - importas
+  #   - ineffassign
+  #   - interfacebloat
+  #   - interfacer
+  #   - ireturn
+  #   - lll
+  #   - loggercheck
+  #   - maintidx
+  #   - makezero
+  #   - maligned
+  #   - mirror
+  #   - misspell
+  #   - musttag
+  #   - nakedret
+  #   - nestif
+  #   - nilerr
+  #   - nilnil
+  #   - nlreturn
+  #   - noctx
+  #   - nolintlint
+  #   - nonamedreturns
+  #   - nosnakecase
+  #   - nosprintfhostport
+  #   - paralleltest
+  #   - prealloc
+  #   - predeclared
+  #   - promlinter
+  #   - reassign
+  #   - revive
+  #   - rowserrcheck
+  #   - scopelint
+  #   - sqlclosecheck
+  #   - staticcheck
+  #   - structcheck
+  #   - stylecheck
+  #   - tagalign
+  #   - tagliatelle
+  #   - tenv
+  #   - testableexamples
+  #   - testpackage
+  #   - thelper
+  #   - tparallel
+  #   - typecheck
+  #   - unconvert
+  #   - unparam
+  #   - unused
+  #   - usestdlibvars
+  #   - varcheck
+  #   - varnamelen
+  #   - wastedassign
+  #   - whitespace
+  #   - wrapcheck
+  #   - wsl
+  #   - zerologlint
+
+  # Enable presets.
+  # https://golangci-lint.run/usage/linters
+  # presets:
+  #   - bugs
+  #   - comment
+  #   - complexity
+  #   - error
+  #   - format
+  #   - import
+  #   - metalinter
+  #   - module
+  #   - performance
+  #   - sql
+  #   - style
+  #   - test
+  #   - unused
+
+  # Run only fast linters from enabled linters set (first run won't be fast)
+  # Default: false
+  fast: false
 
 # All available settings of specific linters.
 linters-settings:
-  staticcheck:
-    # SAxxxx checks in https://staticcheck.io/docs/configuration/options/#checks
+  depguard:
+    # Rules to apply.
+    #
+    # Variables:
+    # - File Variables
+    #   you can still use and exclamation mark ! in front of a variable to say not to use it.
+    #   Example !$test will match any file that is not a go test file.
+    #
+    #   `$all` - matches all go files
+    #   `$test` - matches all go test files
+    #
+    # - Package Variables
+    #
+    #  `$gostd` - matches all of go's standard library (Pulled from `GOROOT`)
+    #
+    # Default: Only allow $gostd in all files.
+    rules:
+      # Name of a rule.
+      main:
+        # List of file globs that will match this list of settings to compare against.
+        # Default: $all
+        # files:
+        #  - "!**/*_a _file.go"
+        # List of allowed packages.
+        # allow:
+        #  - $gostd
+        #  - github.com/OpenPeeDeeP
+        # Packages that are not allowed where the value is a suggestion.
+        deny:
+          - pkg: "io/ioutil"
+            desc: Use os instead
+          - pkg: "github.com/pkg/errors"
+            desc: Should be replaced by standard lib errors package
+          - pkg: "golang.org/x/xerrors"
+            desc: Should be replaced by standard lib errors package
+          - pkg: "golang.org/x/net/context"
+            desc: Should be replaced by standard lib context package
+          - pkg: "golang.org/x/crypto/ed25519"
+            desc: Should be replaced by standard lib ed25519 package
+
+  gci:
+    # Section configuration to compare against.
+    # Section names are case-insensitive and may contain parameters in ().
+    # The default order of sections is `standard > default > custom > blank > dot`,
+    # If `custom-order` is `true`, it follows the order of `sections` option.
+    # Default: ["standard", "default"]
+    sections:
+      - standard
+      - default
+      - prefix(github.com/spacemeshos/go-spacemesh)
+
+    # Skip generated files.
+    # Default: true
+    # skip-generated: false
+
+    # Enable custom order of sections.
+    # If `true`, make the section order the same as the order of `sections`.
+    # Default: false
+    # custom-order: true
+
+  goconst:
+    # Minimal length of string constant.
+    # Default: 3
+    # min-len: 3
+
+    # Minimum occurrences of constant string count to trigger issue.
+    # Default: 3
+    # min-occurrences: 3
+
+    # Ignore test files.
+    # Default: false
+    # ignore-tests: false
+
+    # Look for existing constants matching the values.
+    # Default: true
+    # match-constant: true
+
+    # Search also for duplicated numbers.
+    # Default: false
+    # numbers: false
+
+    # Minimum value, only works with goconst.numbers
+    # Default: 3
+    # min: 3
+
+    # Maximum value, only works with goconst.numbers
+    # Default: 3
+    # max: 3
+
+    # Ignore when constant is not used as function argument.
+    # Default: true
+    ignore-calls: false
+
+  godot:
+    # Comments to be checked: `declarations`, `toplevel`, or `all`.
+    # Default: declarations
+    # scope: declarations
+
+    # List of regexps for excluding particular comment lines from check.
+    # Default: []
+    exclude:
+      # Exclude todo and fixme comments.
+      - "^FIXME:"
+      - "^TODO:"
+
+    # Check that each sentence ends with a period.
+    # Default: true
+    # period: true
+
+    # Check that each sentence starts with a capital letter.
+    # Default: false
+    # capital: false
+
+  gofmt:
+    # Simplify code: gofmt with `-s` option.
+    # Default: true
+    #simplify: true
+
+    # Apply the rewrite rules to the source before reformatting.
+    # https://pkg.go.dev/cmd/gofmt
+    # Default: []
+    rewrite-rules:
+      - pattern: "interface{}"
+        replacement: "any"
+      - pattern: "a[b:len(a)]"
+        replacement: "a[b:]"
+
+  gofumpt:
+    # Module path which contains the source code being formatted.
+    # Default: ""
+    # module-path: github.com/org/project
+
+    # Choose whether to use the extra rules.
+    # Default: false
+    extra-rules: true
+
+  gosimple:
+    # Sxxxx checks in https://staticcheck.io/docs/configuration/options/#checks
     # Default: ["*"]
     checks: ["all"]
-
-  errcheck:
-    # Report about not checking of errors in type assertions: `a := b.(MyStruct)`.
-    # Such cases aren't reported by default.
-    # Default: false
-    check-type-assertions: true
-
-    # report about assignment of errors to blank identifier: `num, _ := strconv.Atoi(numStr)`.
-    # Such cases aren't reported by default.
-    # Default: false
-    check-blank: true
 
   govet:
     # Report about shadowed variables.
@@ -112,112 +509,15 @@ linters-settings:
     # Default: []
     # disable:
 
-  revive:
-    # Sets the default failure confidence.
-    # This means that linting errors with less than 0.8 confidence will be ignored.
-    # Default: 0.8
-    confidence: 0.8
-
-  gofmt:
-    # Simplify code: gofmt with `-s` option.
-    # Default: true
-    simplify: true
-
-    # Apply the rewrite rules to the source before reformatting.
-    # https://pkg.go.dev/cmd/gofmt
-    # Default: []
-    rewrite-rules:
-      - pattern: "interface{}"
-        replacement: "any"
-      - pattern: "a[b:len(a)]"
-        replacement: "a[b:]"
-
-  gocyclo:
-    # Minimal code complexity to report.
-    # Default: 30 (but we recommend 10-20)
-    min-complexity: 10
-
-  goconst:
-    # Minimal length of string constant.
-    # Default: 3
-    min-len: 3
-
-    # Minimum occurrences of constant string count to trigger issue.
-    # Default: 3
-    min-occurrences: 3
-
-  depguard:
-    # Kind of list is passed in.
-    # Allowed values: allowlist|denylist
-    # Default: denylist
-    list-type: denylist
-
-    # Check the list against standard lib.
-    # Default: false
-    include-go-root: true
-
-    # A list of packages for the list type specified.
-    # Can accept both string prefixes and string glob patterns.
-    # Default: []
-    packages:
-      - "io/ioutil"
-      - "github.com/pkg/errors"
-      - "golang.org/x/xerrors"
-      - "golang.org/x/net/context"
-      - "golang.org/x/crypto/ed25519"
-
-  misspell:
-    # Correct spellings using locale preferences for US or UK.
-    # Setting locale to US will correct the British spelling of 'colour' to 'color'.
-    # Default is to use a neutral variety of English.
-    locale: US
-
-  lll:
-    # Max line length, lines longer will be reported.
-    # '\t' is counted as 1 character by default, and can be changed with the tab-width option.
-    # Default: 120.
-    line-length: 120
-    # Tab width in spaces.
-    # Default: 1
-    tab-width: 4
-
-  nakedret:
-    # Make an issue if func has more lines of code than this setting, and it has naked returns.
-    # Default: 30
-    max-func-lines: 30
-
-  prealloc:
-    # IMPORTANT: we don't recommend using this linter before doing performance profiling.
-    # For most programs usage of prealloc will be a premature optimization.
-
-    # Report pre-allocation suggestions only on simple loops that have no returns/breaks/continues/gotos in them.
-    # Default: true
-    simple: true
-    # Report pre-allocation suggestions on range loops.
-    # Default: true
-    range-loops: true
-    # Report pre-allocation suggestions on for loops.
-    # Default: false
-    for-loops: true
-
-  gci:
-    # Section configuration to compare against.
-    # Section names are case-insensitive and may contain parameters in ().
-    # The default order of sections is `standard > default > custom > blank > dot`,
-    # If `custom-order` is `true`, it follows the order of `sections` option.
-    # Default: ["standard", "default"]
-    sections:
-      - standard
-      - default
-      - prefix(github.com/spacemeshos/go-spacemesh)
-
   importas:
     # Do not allow unaliased imports of aliased packages.
     # Default: false
-    no-unaliased: false
+    # no-unaliased: false
+
     # Do not allow non-required aliases.
     # Default: false
-    no-extra-aliases: false
+    # no-extra-aliases: false
+
     # List of aliases
     # Default: []
     alias:
@@ -234,7 +534,7 @@ linters-settings:
       - pkg: "github.com/libp2p/go-libp2p-pubsub"
         alias: pubsub
       - pkg: "github.com/libp2p/go-libp2p-pubsub/pb"
-        alias: pb
+        alias: pubsubpb
       - pkg: "github.com/libp2p/go-libp2p/p2p/net/mock"
         alias: mocknet
       - pkg: "github.com/libp2p/go-libp2p-testing/netutil"
@@ -270,114 +570,27 @@ linters-settings:
       - pkg: "k8s.io/client-go/applyconfigurations/meta/v1"
         alias: metav1
 
-  godot:
-    # Comments to be checked: `declarations`, `toplevel`, or `all`.
-    # Default: declarations
-    scope: declarations
-    # List of regexps for excluding particular comment lines from check.
-    # Default: []
-    exclude:
-      # Exclude todo and fixme comments.
-      - "^FIXME:"
-      - "^TODO:"
-    # Check that each sentence ends with a period.
-    # Default: true
-    period: true
-    # Check that each sentence starts with a capital letter.
-    # Default: false
-    capital: false
+  misspell:
+    # Correct spellings using locale preferences for US or UK.
+    # Setting locale to US will correct the British spelling of 'colour' to 'color'.
+    # Default is to use a neutral variety of English.
+    locale: US
 
-  gofumpt:
-    # Choose whether to use the extra rules.
-    # Default: false
-    extra-rules: false
+  nakedret:
+    # Make an issue if func has more lines of code than this setting, and it has naked returns.
+    # Default: 30
+    max-func-lines: 30
 
-  gosec:
-    # To select a subset of rules to run.
-    # Available rules: https://github.com/securego/gosec#available-rules
-    # Default: [] - means include all rules
-    # includes:
-    # To specify a set of rules to explicitly exclude.
-    # Available rules: https://github.com/securego/gosec#available-rules
-    # Default: []
-    # excludes:
-    # Exclude generated files
-    # Default: false
-    exclude-generated: false
-    # Filter out the issues with a lower severity than the given value.
-    # Valid options are: low, medium, high.
-    # Default: low
-    severity: medium
-    # Filter out the issues with a lower confidence than the given value.
-    # Valid options are: low, medium, high.
-    # Default: low
-    confidence: medium
-    # Concurrency value.
-    # Default: the number of logical CPUs usable by the current process.
-    concurrency: 12
+  revive:
+    # Sets the default failure confidence.
+    # This means that linting errors with less than 0.8 confidence will be ignored.
+    # Default: 0.8
+    confidence: 0.8
 
-  whitespace:
-    # Enforces newlines (or comments) after every multi-line if statement.
-    # Default: false
-    multi-if: true
-    # Enforces newlines (or comments) after every multi-line function signature.
-    # Default: false
-    multi-func: true
-
-  wrapcheck:
-    # An array of strings that specify substrings of signatures to ignore.
-    # If this set, it will override the default set of ignored signatures.
-    # See https://github.com/tomarrell/wrapcheck#configuration for more information.
-    # Default: [".Errorf(", "errors.New(", "errors.Unwrap(", ".Wrap(", ".Wrapf(", ".WithMessage(", ".WithMessagef(", ".WithStack("]
-    ignoreSigs:
-      - .Errorf(
-      - errors.New(
-      - .WithMessage(
-      - .WithMessagef(
-      - .WithStack(
-
-linters:
-  # Disable all linters.
-  # Default: false
-  disable-all: true
-  # Enable specific linter
-  # https://golangci-lint.run/usage/linters/#enabled-by-default
-  enable:
-    - gci
-    - importas
-    - govet
-    - godot
-    - gofmt
-    - gofumpt
-    - revive
-    - misspell
-    - staticcheck
-    - unused
-    - ineffassign
-    - typecheck
-    - nakedret
-    - depguard
-    - goconst
-    # - whitespace
-    # - wrapcheck
-    # - errcheck
-    # - gosec
-    # - nakedret
-    # - gocyclo
-    # - lll
-    # - prealloc
-  
-  # Enable all available linters.
-  # Default: false
-  enable-all: false
-
-  # Disable specific linter
-  # https://golangci-lint.run/usage/linters/#disabled-by-default
-  # disable:
-    
-  # Run only fast linters from enabled linters set (first run won't be fast)
-  # Default: false
-  fast: false
+  staticcheck:
+    # SAxxxx checks in https://staticcheck.io/docs/configuration/options/#checks
+    # Default: ["*"]
+    checks: ["all", "-SA5001"]
 
 issues:
   # List of regexps of issue texts to exclude.
@@ -388,29 +601,48 @@ issues:
   #
   # Default: https://golangci-lint.run/usage/false-positives/#default-exclusions
   # exclude:
-
+  #   - abcdef
   # Excluding configuration per-path, per-linter, per-text and per-source
   exclude-rules:
+    # Exclude some `staticcheck` messages.
     - linters:
         - staticcheck
-      text: SA1019
-
+      text: "SA1019:"
   # Independently of option `exclude` we use default exclude patterns,
   # it can be disabled by this option.
   # To list all excluded by default patterns execute `golangci-lint run --help`.
   # Default: true.
   exclude-use-default: false
-
+  # If set to true exclude and exclude-rules regular expressions become case-sensitive.
+  # Default: false
+  exclude-case-sensitive: false
+  # The list of ids of default excludes to include or disable.
+  # https://golangci-lint.run/usage/false-positives/#default-exclusions
+  # Default: []
+  # include:
+  #   - EXC0001
+  #   - EXC0002
+  #   - EXC0003
+  #   - EXC0004
+  #   - EXC0005
+  #   - EXC0006
+  #   - EXC0007
+  #   - EXC0008
+  #   - EXC0009
+  #   - EXC0010
+  #   - EXC0011
+  #   - EXC0012
+  #   - EXC0013
+  #   - EXC0014
+  #   - EXC0015
   # Maximum issues count per one linter.
   # Set to 0 to disable.
   # Default: 50
   max-issues-per-linter: 0
-
   # Maximum count of issues with the same text.
   # Set to 0 to disable.
   # Default: 3
   max-same-issues: 0
-
   # Show only new issues: if there are unstaged changes or untracked files,
   # only those changes are analyzed, else only changes in HEAD~ are analyzed.
   # It's a super-useful option for integration of golangci-lint into existing large codebase.
@@ -418,4 +650,10 @@ issues:
   # much better don't allow issues in new code.
   #
   # Default: false.
-  new: false
+  # new: true
+  # Show only new issues created after git revision `REV`.
+  # new-from-rev: HEAD
+  # Show only new issues created in git patch with set file path.
+  # new-from-patch: path/to/patch/file
+  # Fix found issues (if it's supported by the linter).
+  # fix: true

--- a/Makefile
+++ b/Makefile
@@ -60,11 +60,11 @@ all: install build
 install:
 	git lfs install
 	go mod download
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.52.0
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.53.3
 	go install github.com/spacemeshos/go-scale/scalegen@v1.1.10
 	go install github.com/golang/mock/mockgen
-	go install gotest.tools/gotestsum@v1.9.0
-	go install honnef.co/go/tools/cmd/staticcheck@v0.3.3
+	go install gotest.tools/gotestsum@v1.10.0
+	go install honnef.co/go/tools/cmd/staticcheck@v0.4.3
 .PHONY: install
 
 build: go-spacemesh get-profiler

--- a/activation/poet.go
+++ b/activation/poet.go
@@ -185,7 +185,7 @@ func (c *HTTPPoetClient) Proof(ctx context.Context, roundID string) (*types.Poet
 	return &proof, members, nil
 }
 
-func (c *HTTPPoetClient) req(ctx context.Context, method string, path string, reqBody proto.Message, resBody proto.Message) error {
+func (c *HTTPPoetClient) req(ctx context.Context, method, path string, reqBody, resBody proto.Message) error {
 	jsonReqBody, err := protojson.Marshal(reqBody)
 	if err != nil {
 		return fmt.Errorf("marshaling request body: %w", err)

--- a/api/grpcserver/admin_service.go
+++ b/api/grpcserver/admin_service.go
@@ -57,12 +57,10 @@ func (a AdminService) CheckpointStream(req *pb.CheckpointStreamRequest, stream p
 		return status.Errorf(codes.Unavailable, "can't send header")
 	}
 	f, err := os.Open(fname)
-	defer func() {
-		_ = f.Close()
-	}()
 	if err != nil {
 		return status.Errorf(codes.Internal, fmt.Sprintf("failed to open file %s: %s", fname, err.Error()))
 	}
+	defer f.Close()
 	var (
 		buf   = make([]byte, chunksize)
 		chunk int

--- a/api/grpcserver/mesh_service.go
+++ b/api/grpcserver/mesh_service.go
@@ -35,7 +35,7 @@ func (s MeshService) RegisterService(server *Server) {
 func NewMeshService(
 	msh meshAPI, cstate conservativeState, genTime genesisTimeAPI,
 	layersPerEpoch uint32, genesisID types.Hash20, layerDuration time.Duration,
-	layerAvgSize uint32, txsPerProposal uint32,
+	layerAvgSize, txsPerProposal uint32,
 ) *MeshService {
 	return &MeshService{
 		mesh:           msh,

--- a/beacon/handlers_test.go
+++ b/beacon/handlers_test.go
@@ -106,7 +106,7 @@ func checkProposals(t *testing.T, pd *ProtocolDriver, epoch types.EpochID, expec
 	}
 }
 
-func createFirstVote(t *testing.T, signer *signing.EdSigner, epoch types.EpochID, valid proposalList, pValid proposalList, corruptSignature bool) *FirstVotingMessage {
+func createFirstVote(t *testing.T, signer *signing.EdSigner, epoch types.EpochID, valid, pValid proposalList, corruptSignature bool) *FirstVotingMessage {
 	logger := logtest.New(t)
 	msg := &FirstVotingMessage{
 		FirstVotingMessageBody: FirstVotingMessageBody{

--- a/cmd/bootstrapper/generator.go
+++ b/cmd/bootstrapper/generator.go
@@ -62,7 +62,7 @@ func WithHttpClient(c *http.Client) Opt {
 	}
 }
 
-func NewGenerator(btcEndpoint string, smEndpoint string, opts ...Opt) *Generator {
+func NewGenerator(btcEndpoint, smEndpoint string, opts ...Opt) *Generator {
 	g := &Generator{
 		logger:      log.NewNop(),
 		fs:          afero.NewOsFs(),

--- a/common/fixture/transaction_results.go
+++ b/common/fixture/transaction_results.go
@@ -54,7 +54,7 @@ func (g *TransactionResultGenerator) WithAddresses(n int) *TransactionResultGene
 }
 
 // WithLayers updates layers.
-func (g *TransactionResultGenerator) WithLayers(start int, n int) *TransactionResultGenerator {
+func (g *TransactionResultGenerator) WithLayers(start, n int) *TransactionResultGenerator {
 	g.Layers = nil
 	for i := 1; i <= n; i++ {
 		g.Layers = append(g.Layers, types.LayerID(uint32(start+i)))

--- a/eligibility/fixedoracle.go
+++ b/eligibility/fixedoracle.go
@@ -108,7 +108,7 @@ func cloneMap(m map[types.NodeID]struct{}) map[types.NodeID]struct{} {
 	return c
 }
 
-func pickUnique(pickCount int, orig map[types.NodeID]struct{}, dest map[types.NodeID]struct{}) {
+func pickUnique(pickCount int, orig, dest map[types.NodeID]struct{}) {
 	i := 0
 	for k := range orig { // randomly pass on clients
 		if i == pickCount { // pick exactly size

--- a/genvm/vm_test.go
+++ b/genvm/vm_test.go
@@ -315,7 +315,7 @@ func (t *tester) addMultisig(total, k, n int) *tester {
 	return t
 }
 
-func (t *tester) addVesting(total int, k, n int) *tester {
+func (t *tester) addVesting(total, k, n int) *tester {
 	for i := 0; i < total; i++ {
 		ms := t.createMultisig(k, n, vesting.TemplateAddress)
 		t.addAccount(&vestingAccount{*ms})
@@ -2391,7 +2391,7 @@ func FuzzParse(f *testing.F) {
 			}
 		}
 	}
-	f.Fuzz(func(t *testing.T, version int, principal []byte, method int, payload []byte, args []byte, sig []byte) {
+	f.Fuzz(func(t *testing.T, version int, principal []byte, method int, payload, args, sig []byte) {
 		var (
 			buf = bytes.NewBuffer(nil)
 			enc = scale.NewEncoder(buf)

--- a/metrics/push.go
+++ b/metrics/push.go
@@ -11,7 +11,7 @@ import (
 
 // StartPushingMetrics begins pushing metrics to the url specified by the --metrics-push flag
 // with period specified by the --metrics-push-period flag.
-func StartPushingMetrics(url string, username string, password string, periodSec int, nodeID, networkID string) {
+func StartPushingMetrics(url, username, password string, periodSec int, nodeID, networkID string) {
 	period := time.Duration(periodSec) * time.Second
 	ticker := time.NewTicker(period)
 

--- a/miner/oracle_test.go
+++ b/miner/oracle_test.go
@@ -142,7 +142,7 @@ func TestMinerOracle(t *testing.T) {
 	testMinerOracleAndProposalValidator(t, 2, 2)
 }
 
-func testMinerOracleAndProposalValidator(t *testing.T, layerSize uint32, layersPerEpoch uint32) {
+func testMinerOracleAndProposalValidator(t *testing.T, layerSize, layersPerEpoch uint32) {
 	o := createTestOracle(t, layerSize, layersPerEpoch, 0)
 
 	ctrl := gomock.NewController(t)

--- a/node/bad_peer_test.go
+++ b/node/bad_peer_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
-	pb "github.com/libp2p/go-libp2p-pubsub/pb"
+	pubsubpb "github.com/libp2p/go-libp2p-pubsub/pb"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/protocol"
@@ -89,7 +89,7 @@ func TestPeerDisconnectForMessageResultValidationReject(t *testing.T) {
 	p := types.Proposal{}
 	bytes, err := codec.Encode(&p)
 	require.NoError(t, err)
-	m := &pb.Message{
+	m := &pubsubpb.Message{
 		Data:  bytes,
 		Topic: &protocol,
 	}
@@ -104,7 +104,7 @@ func TestPeerDisconnectForMessageResultValidationReject(t *testing.T) {
 	}
 
 	// Send message that results in ValidationReject
-	m = &pb.Message{
+	m = &pubsubpb.Message{
 		Data:  make([]byte, 20),
 		Topic: &protocol,
 	}
@@ -150,8 +150,8 @@ func getStream(c network.Conn, p protocol.ID, dir network.Direction) network.Str
 	return nil
 }
 
-func rpcWithMessages(msgs ...*pb.Message) *pubsub.RPC {
-	return &pubsub.RPC{RPC: pb.RPC{Publish: msgs}}
+func rpcWithMessages(msgs ...*pubsubpb.Message) *pubsub.RPC {
+	return &pubsub.RPC{RPC: pubsubpb.RPC{Publish: msgs}}
 }
 
 func writeRpc(rpc *pubsub.RPC, s network.Stream) error {

--- a/node/mapstructureutil/bigrat.go
+++ b/node/mapstructureutil/bigrat.go
@@ -10,7 +10,7 @@ import (
 
 // BigRatDecodeFunc mapstructure decode func for big.Rat.
 func BigRatDecodeFunc() mapstructure.DecodeHookFunc {
-	return func(f reflect.Type, t reflect.Type, data any) (any, error) {
+	return func(f, t reflect.Type, data any) (any, error) {
 		if t != reflect.TypeOf(big.Rat{}) {
 			return data, nil
 		}

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -264,7 +264,7 @@ func marshalProto(t *testing.T, msg proto.Message) string {
 	return buf.String()
 }
 
-func callEndpoint(t *testing.T, endpoint, payload string, address string) (string, int) {
+func callEndpoint(t *testing.T, endpoint, payload, address string) (string, int) {
 	url := fmt.Sprintf("http://%s/%s", address, endpoint)
 	resp, err := http.Post(url, "application/json", strings.NewReader(payload))
 	require.NoError(t, err)

--- a/p2p/pubsub/pubsub.go
+++ b/p2p/pubsub/pubsub.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
-	pb "github.com/libp2p/go-libp2p-pubsub/pb"
+	pubsubpb "github.com/libp2p/go-libp2p-pubsub/pb"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
 
@@ -164,7 +164,7 @@ func DropPeerOnValidationReject(handler GossipHandler, h host.Host, logger log.L
 	}
 }
 
-func msgID(msg *pb.Message) string {
+func msgID(msg *pubsubpb.Message) string {
 	hasher := hash.New()
 	if msg.Topic != nil {
 		hasher.Write([]byte(*msg.Topic))

--- a/proposals/util/util.go
+++ b/proposals/util/util.go
@@ -37,7 +37,7 @@ func maxWeight(a, b uint64) uint64 {
 }
 
 // GetNumEligibleSlots calculates the number of eligible slots for a smesher in an epoch.
-func GetNumEligibleSlots(weight, minWeight, totalWeight uint64, committeeSize uint32, layersPerEpoch uint32) (uint32, error) {
+func GetNumEligibleSlots(weight, minWeight, totalWeight uint64, committeeSize, layersPerEpoch uint32) (uint32, error) {
 	if totalWeight == 0 {
 		return 0, ErrZeroTotalWeight
 	}

--- a/signing/verifier_test.go
+++ b/signing/verifier_test.go
@@ -73,7 +73,7 @@ func TestVerifier_WithPrefix(t *testing.T) {
 }
 
 func Fuzz_EdVerifier(f *testing.F) {
-	f.Fuzz(func(t *testing.T, msg []byte, prefix []byte) {
+	f.Fuzz(func(t *testing.T, msg, prefix []byte) {
 		signer, err := signing.NewEdSigner(signing.WithPrefix(prefix))
 		require.NoError(t, err)
 

--- a/systest/chaos/timeskew.go
+++ b/systest/chaos/timeskew.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Timeskew adjusts CLOCK_REALTIME on the specified pods by the offset.
-func Timeskew(cctx *testcontext.Context, name string, offset string, pods ...string) (Teardown, error) {
+func Timeskew(cctx *testcontext.Context, name, offset string, pods ...string) (Teardown, error) {
 	tc := chaos.TimeChaos{}
 	tc.Name = name
 	tc.Namespace = cctx.Namespace

--- a/systest/cluster/nodes.go
+++ b/systest/cluster/nodes.go
@@ -177,7 +177,7 @@ func (n *NodeClient) resetConn(conn *grpc.ClientConn) {
 	}
 }
 
-func (n *NodeClient) Invoke(ctx context.Context, method string, args any, reply any, opts ...grpc.CallOption) error {
+func (n *NodeClient) Invoke(ctx context.Context, method string, args, reply any, opts ...grpc.CallOption) error {
 	conn, err := n.ensureConn(ctx)
 	if err != nil {
 		return err
@@ -380,7 +380,7 @@ func waitPod(ctx *testcontext.Context, id string) (*apiv1.Pod, error) {
 	}
 }
 
-func nodeLabels(name string, id string) map[string]string {
+func nodeLabels(name, id string) map[string]string {
 	return map[string]string{
 		// app identifies resource kind (Node, Poet).
 		// It can be used to select all Pods of given kind.

--- a/systest/tests/checkpoint_test.go
+++ b/systest/tests/checkpoint_test.go
@@ -207,9 +207,7 @@ func query(ctx context.Context, endpoint string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer func() {
-		_ = resp.Body.Close()
-	}()
+	defer resp.Body.Close()
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err

--- a/systest/tests/common.go
+++ b/systest/tests/common.go
@@ -324,7 +324,7 @@ func maxLayer(i, j uint32) uint32 {
 	return j
 }
 
-func nextFirstLayer(current uint32, size uint32) uint32 {
+func nextFirstLayer(current, size uint32) uint32 {
 	if over := current % size; over != 0 {
 		current += size - over
 	}
@@ -358,7 +358,7 @@ func submitSpawn(ctx context.Context, cluster *cluster.Cluster, account int, cli
 	return err
 }
 
-func submitSpend(ctx context.Context, cluster *cluster.Cluster, account int, receiver types.Address, amount uint64, nonce uint64, client *cluster.NodeClient) error {
+func submitSpend(ctx context.Context, cluster *cluster.Cluster, account int, receiver types.Address, amount, nonce uint64, client *cluster.NodeClient) error {
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 	_, err := submitTransaction(ctx,

--- a/tortoise/state.go
+++ b/tortoise/state.go
@@ -428,7 +428,7 @@ type headerWithSign struct {
 	sign   sign
 }
 
-func decodeVotes(evicted types.LayerID, blid types.LayerID, base *ballotInfo, exceptions types.Votes) (votes, types.LayerID, error) {
+func decodeVotes(evicted, blid types.LayerID, base *ballotInfo, exceptions types.Votes) (votes, types.LayerID, error) {
 	from := base.layer
 	diff := map[types.LayerID]map[types.BlockID]headerWithSign{}
 	for _, header := range exceptions.Against {

--- a/tortoise/tortoise.go
+++ b/tortoise/tortoise.go
@@ -510,7 +510,7 @@ func (t *turtle) computeEpochHeight(epoch types.EpochID) {
 	einfo.height = getMedian(heights)
 }
 
-func (t *turtle) onBlock(header types.BlockHeader, data bool, valid bool) {
+func (t *turtle) onBlock(header types.BlockHeader, data, valid bool) {
 	if header.LayerID <= t.evicted {
 		return
 	}

--- a/txs/conservative_state_test.go
+++ b/txs/conservative_state_test.go
@@ -38,7 +38,7 @@ const (
 	nonce            = uint64(1234)
 )
 
-func newTx(tb testing.TB, nonce uint64, amount, fee uint64, signer *signing.EdSigner) *types.Transaction {
+func newTx(tb testing.TB, nonce, amount, fee uint64, signer *signing.EdSigner) *types.Transaction {
 	tb.Helper()
 	var dest types.Address
 	_, err := rand.Read(dest[:])
@@ -46,7 +46,7 @@ func newTx(tb testing.TB, nonce uint64, amount, fee uint64, signer *signing.EdSi
 	return newTxWthRecipient(tb, dest, nonce, amount, fee, signer)
 }
 
-func newTxWthRecipient(tb testing.TB, dest types.Address, nonce uint64, amount, fee uint64, signer *signing.EdSigner) *types.Transaction {
+func newTxWthRecipient(tb testing.TB, dest types.Address, nonce, amount, fee uint64, signer *signing.EdSigner) *types.Transaction {
 	tb.Helper()
 	raw := wallet.Spend(signer.PrivateKey(), dest, amount,
 		nonce,


### PR DESCRIPTION
## Motivation
The tooling used in go-spacemesh CI is outdated. This PR fixes the issue.

## Changes
- update tools: `gotestsum`, `golangci-lint` and `staticcheck`
- update configuration for new version of `golangci-lint`
- fix new complaints

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
