### PR TITLE
[Merged by Bors] - Fix possible nil ptr dereference in HTTP retry check

### DIFF
--- a/activation/poet.go
+++ b/activation/poet.go
@@ -50,7 +50,9 @@ func checkRetry(ctx context.Context, resp *http.Response, err error) (bool, erro
 	if retry, err := retryablehttp.DefaultRetryPolicy(ctx, resp, err); retry || err != nil {
 		return retry, err
 	}
-
+	if err != nil {
+		return false, nil
+	}
 	if resp.StatusCode == http.StatusNotFound {
 		return true, nil
 	}

--- a/activation/poet.go
+++ b/activation/poet.go
@@ -47,16 +47,10 @@ func defaultPoetClientFunc(address string, cfg PoetConfig) (PoetProvingServiceCl
 }
 
 func checkRetry(ctx context.Context, resp *http.Response, err error) (bool, error) {
-	if retry, err := retryablehttp.DefaultRetryPolicy(ctx, resp, err); retry || err != nil {
-		return retry, err
-	}
-	if err != nil {
-		return false, nil
-	}
-	if resp.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		return true, nil
 	}
-	return false, nil
+	return retryablehttp.DefaultRetryPolicy(ctx, resp, err)
 }
 
 type PoetClientOpts func(*HTTPPoetClient)

--- a/activation/poet_test.go
+++ b/activation/poet_test.go
@@ -1,14 +1,16 @@
-package activation_test
+package activation
 
 import (
 	"bytes"
 	"context"
+	"errors"
+	"net/http"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/spacemeshos/go-spacemesh/activation"
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/signing"
 )
@@ -27,7 +29,7 @@ func TestHTTPPoet(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	c, err := activation.NewHTTPPoetTestHarness(ctx, poetDir)
+	c, err := NewHTTPPoetTestHarness(ctx, poetDir)
 	r.NoError(err)
 	r.NotNil(c)
 
@@ -42,7 +44,31 @@ func TestHTTPPoet(t *testing.T) {
 	signature := signer.Sign(signing.POET, ch.Bytes())
 	prefix := bytes.Join([][]byte{signer.Prefix(), {byte(signing.POET)}}, nil)
 
-	poetRound, err := c.Submit(context.Background(), prefix, ch.Bytes(), signature, signer.NodeID(), activation.PoetPoW{})
+	poetRound, err := c.Submit(context.Background(), prefix, ch.Bytes(), signature, signer.NodeID(), PoetPoW{})
 	r.NoError(err)
 	r.NotNil(poetRound)
+}
+
+func TestCheckRetry(t *testing.T) {
+	t.Parallel()
+	t.Run("doesn't retry on context cancellation.", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		retry, err := checkRetry(ctx, nil, nil)
+		require.ErrorIs(t, err, context.Canceled)
+		require.False(t, retry)
+	})
+	t.Run("doesn't retry on unrecoverable error.", func(t *testing.T) {
+		t.Parallel()
+		retry, err := checkRetry(context.Background(), nil, &url.Error{Err: errors.New("unsupported protocol scheme")})
+		require.NoError(t, err)
+		require.False(t, retry)
+	})
+	t.Run("retries on 404 (not found).", func(t *testing.T) {
+		t.Parallel()
+		retry, err := checkRetry(context.Background(), &http.Response{StatusCode: http.StatusNotFound}, nil)
+		require.NoError(t, err)
+		require.True(t, retry)
+	})
 }


### PR DESCRIPTION
## Motivation
Closes #4645 

## Changes
Checking for an error before dereferencing `resp`

## Test Plan
Added unit tests covering the whole `checkRetry()`.