### PR TITLE
[Merged by Bors] - Remove need for version.txt during release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,12 +54,12 @@ jobs:
         if: ${{ contains(matrix.os, 'macos') && runner.arch == 'arm64' }}
         run: echo "SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk" >> $GITHUB_ENV
 
-        # `make build` reads version from version.txt but in Windows it doesn't work therefore passing version explicitly
       - name: Build go-spacemesh
         shell: bash
         run: |
           make install
           make build VERSION=${{ github.ref }} BIN_DIR_WIN=./build
+
       - name: Create release archive
         shell: bash
         env:
@@ -80,7 +80,7 @@ jobs:
         uses: google-github-actions/upload-cloud-storage@v0
         with:
           path: ${{ env.OUTNAME }}.zip
-          destination: ${{ secrets.GCP_BUCKET }}/${{ steps.version.outputs.content }}/
+          destination: ${{ secrets.GCP_BUCKET }}/${{ github.ref }}/
 
   release:
     runs-on: ubuntu-latest
@@ -89,12 +89,6 @@ jobs:
       - name: Check out Git repository
         uses: actions/checkout@v3
 
-      - name: Read version.txt
-        id: version
-        uses: juliangruber/read-file-action@v1
-        with:
-          path: ./version.txt
-
       - name: Create Release
         uses: actions/create-release@v1
         id: create_release
@@ -102,13 +96,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name:  ${{ github.ref }}
-          release_name: Release ${{ steps.version.outputs.content }}
+          release_name: Release ${{ github.ref }}
           body: |
             ## Zip Files
-            - Windows: https://storage.googleapis.com/${{ secrets.GCP_BUCKET }}/${{ steps.version.outputs.content }}/Windows.zip
-            - macOS: https://storage.googleapis.com/${{ secrets.GCP_BUCKET }}/${{ steps.version.outputs.content }}/macOS.zip
-            - macOS arm64: https://storage.googleapis.com/${{ secrets.GCP_BUCKET }}/${{ steps.version.outputs.content }}/macOS_ARM64.zip
-            - Linux: https://storage.googleapis.com/${{ secrets.GCP_BUCKET }}/${{ steps.version.outputs.content }}/Linux.zip
-            - Linux arm64: https://storage.googleapis.com/${{ secrets.GCP_BUCKET }}/${{ steps.version.outputs.content }}/Linux_ARM64.zip
+            - Windows: https://storage.googleapis.com/${{ secrets.GCP_BUCKET }}/${{ github.ref }}/Windows.zip
+            - macOS: https://storage.googleapis.com/${{ secrets.GCP_BUCKET }}/${{ github.ref }}/macOS.zip
+            - macOS arm64: https://storage.googleapis.com/${{ secrets.GCP_BUCKET }}/${{ github.ref }}/macOS_ARM64.zip
+            - Linux: https://storage.googleapis.com/${{ secrets.GCP_BUCKET }}/${{ github.ref }}/Linux.zip
+            - Linux arm64: https://storage.googleapis.com/${{ secrets.GCP_BUCKET }}/${{ github.ref }}/Linux_ARM64.zip
           draft: false
           prerelease: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,31 +29,31 @@ jobs:
           else
             echo "OUTNAME=${{ runner.os }}" >> $GITHUB_ENV
           fi
+      
+      - name: Install dependencies in windows
+        if: ${{ matrix.os == 'windows-latest' }}
+        run: choco install make wget zip
+      - name: Add OpenCL support - Ubuntu
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: sudo apt-get update -q && sudo apt-get install -qy ocl-icd-opencl-dev libpocl2
+      - name: Override SDKROOT for macOS
+        if: ${{ contains(matrix.os, 'macos') && runner.arch == 'arm64' }}
+        run: echo "SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk" >> $GITHUB_ENV
+      - name: disable Windows Defender - Windows
+        if: ${{ matrix.os == 'windows-latest' }}
+        run: |
+          Set-MpPreference -DisableRealtimeMonitoring $true
 
       - name: Check out Git repository
         uses: actions/checkout@v3
         with:
           lfs: true
-
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
           check-latest: true
           go-version-file: "go.mod"
           cache: ${{ runner.arch != 'arm64' }}
-
-      - name: Install dependencies in windows
-        if: ${{ matrix.os == 'windows-latest' }}
-        run: choco install make wget zip
-
-      - name: Add OpenCL support for Linux
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: sudo apt-get update -q && sudo apt-get install -qy ocl-icd-opencl-dev libpocl2
-
-      - name: Override SDKROOT for macOS
-        if: ${{ contains(matrix.os, 'macos') && runner.arch == 'arm64' }}
-        run: echo "SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk" >> $GITHUB_ENV
-
       - name: Build go-spacemesh
         shell: bash
         run: |
@@ -75,7 +75,6 @@ jobs:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
           service_account_key: ${{ secrets.GCP_SA_KEY }}
           export_default_credentials: true
-
       - name: Upload zip
         uses: google-github-actions/upload-cloud-storage@v0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,5 +103,5 @@ jobs:
             - Linux: https://storage.googleapis.com/${{ secrets.GCP_BUCKET }}/${{ github.ref_name }}/Linux.zip
             - Linux arm64: https://storage.googleapis.com/${{ secrets.GCP_BUCKET }}/${{ github.ref_name }}/Linux_ARM64.zip
           generate_release_notes: true
-          draft: true
+          draft: false
           prerelease: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,13 +90,13 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Create Release
-        uses: actions/create-release@v1
+        uses: softprops/action-gh-release@v1
         id: create_release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name:  ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
+          name: Release ${{ github.ref }}
           body: |
             ## Zip Files
             - Windows: https://storage.googleapis.com/${{ secrets.GCP_BUCKET }}/${{ github.ref }}/Windows.zip
@@ -104,5 +104,6 @@ jobs:
             - macOS arm64: https://storage.googleapis.com/${{ secrets.GCP_BUCKET }}/${{ github.ref }}/macOS_ARM64.zip
             - Linux: https://storage.googleapis.com/${{ secrets.GCP_BUCKET }}/${{ github.ref }}/Linux.zip
             - Linux arm64: https://storage.googleapis.com/${{ secrets.GCP_BUCKET }}/${{ github.ref }}/Linux_ARM64.zip
-          draft: false
+          generate_release_notes: true
+          draft: true
           prerelease: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name:  ${{ github.ref }}
-          name: Release ${{ github.ref }}
           body: |
             ## Zip Files
             - Windows: https://storage.googleapis.com/${{ secrets.GCP_BUCKET }}/${{ github.ref }}/Windows.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
         shell: bash
         run: |
           make install
-          make build VERSION=${{ github.ref }} BIN_DIR_WIN=./build
+          make build VERSION=${{ github.ref_name }} BIN_DIR_WIN=./build
 
       - name: Create release archive
         shell: bash
@@ -79,7 +79,7 @@ jobs:
         uses: google-github-actions/upload-cloud-storage@v0
         with:
           path: ${{ env.OUTNAME }}.zip
-          destination: ${{ secrets.GCP_BUCKET }}/${{ github.ref }}/
+          destination: ${{ secrets.GCP_BUCKET }}/${{ github.ref_name }}/
 
   release:
     runs-on: ubuntu-latest
@@ -94,14 +94,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name:  ${{ github.ref }}
+          tag_name:  ${{ github.ref_name }}
           body: |
             ## Zip Files
-            - Windows: https://storage.googleapis.com/${{ secrets.GCP_BUCKET }}/${{ github.ref }}/Windows.zip
-            - macOS: https://storage.googleapis.com/${{ secrets.GCP_BUCKET }}/${{ github.ref }}/macOS.zip
-            - macOS arm64: https://storage.googleapis.com/${{ secrets.GCP_BUCKET }}/${{ github.ref }}/macOS_ARM64.zip
-            - Linux: https://storage.googleapis.com/${{ secrets.GCP_BUCKET }}/${{ github.ref }}/Linux.zip
-            - Linux arm64: https://storage.googleapis.com/${{ secrets.GCP_BUCKET }}/${{ github.ref }}/Linux_ARM64.zip
+            - Windows: https://storage.googleapis.com/${{ secrets.GCP_BUCKET }}/${{ github.ref_name }}/Windows.zip
+            - macOS: https://storage.googleapis.com/${{ secrets.GCP_BUCKET }}/${{ github.ref_name }}/macOS.zip
+            - macOS arm64: https://storage.googleapis.com/${{ secrets.GCP_BUCKET }}/${{ github.ref_name }}/macOS_ARM64.zip
+            - Linux: https://storage.googleapis.com/${{ secrets.GCP_BUCKET }}/${{ github.ref_name }}/Linux.zip
+            - Linux arm64: https://storage.googleapis.com/${{ secrets.GCP_BUCKET }}/${{ github.ref_name }}/Linux_ARM64.zip
           generate_release_notes: true
           draft: true
           prerelease: true

--- a/Makefile
+++ b/Makefile
@@ -140,15 +140,6 @@ cover: get-libs
 	@$(ULIMIT) CGO_LDFLAGS="$(CGO_TEST_LDFLAGS)" go test -coverprofile=cover.out -timeout 0 -p 1 -coverpkg=./... $(UNIT_TESTS)
 .PHONY: cover
 
-tag-and-build:
-	git diff --quiet || (echo "\033[0;31mWorking directory not clean!\033[0m" && git --no-pager diff && exit 1)
-	git tag ${VERSION}
-	git push origin ${VERSION}
-	DOCKER_BUILDKIT=1 docker build -t go-spacemesh:${VERSION} .
-	docker tag go-spacemesh:${VERSION} $(DOCKER_HUB)/go-spacemesh:${VERSION}
-	docker push $(DOCKER_HUB)/go-spacemesh:${VERSION}
-.PHONY: tag-and-build
-
 list-versions:
 	@echo "Latest 5 tagged versions:\n"
 	@git for-each-ref --sort=-creatordate --count=5 --format '%(creatordate:short): %(refname:short)' refs/tags

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+VERSION ?= $(shell git describe --tags)
 LDFLAGS = -ldflags "-X main.version=${VERSION} -X main.commit=${COMMIT} -X main.branch=${BRANCH}"
 include Makefile-libs.Inc
 
@@ -10,16 +11,6 @@ BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
 
 export CGO_ENABLED := 1
 export CGO_CFLAGS := $(CGO_CFLAGS) -DSQLITE_ENABLE_DBSTAT_VTAB=1
-
-# These commands cause problems on Windows
-ifeq ($(OS),Windows_NT)
-  # Just assume we're in interactive mode on Windows
-  INTERACTIVE = 1
-  VERSION ?= $(shell type version.txt)
-else
-  INTERACTIVE := $(shell [ -t 0 ] && echo 1)
-  VERSION ?= $(shell cat version.txt)
-endif
 
 # Add an indicator to the branch name if dirty and use commithash if running in detached mode
 ifeq ($(BRANCH),HEAD)
@@ -151,8 +142,6 @@ cover: get-libs
 
 tag-and-build:
 	git diff --quiet || (echo "\033[0;31mWorking directory not clean!\033[0m" && git --no-pager diff && exit 1)
-	printf "${VERSION}" > version.txt
-	git commit -m "bump version to ${VERSION}" version.txt
 	git tag ${VERSION}
 	git push origin ${VERSION}
 	DOCKER_BUILDKIT=1 docker build -t go-spacemesh:${VERSION} .


### PR DESCRIPTION
## Motivation
Last release failed because #4637 failed to remove all usages of version.txt. This PR fixes the issue.

## Changes
- `release` job was still parsing version.txt to assign file names
- `Makefile` was still parsing `version.txt

## Test Plan
Test release?

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
