### PR TITLE
[Merged by Bors] - Fix fork finder fetching too many layers

### DIFF
--- a/fetch/wire_types.go
+++ b/fetch/wire_types.go
@@ -51,11 +51,21 @@ type MeshHashRequest struct {
 	Step     uint32
 }
 
+func NewMeshHashRequest(from, to types.LayerID) *MeshHashRequest {
+	diff := to.Difference(from)
+	delta := diff/uint32(MaxHashesInReq-1) + 1
+	return &MeshHashRequest{
+		From: from,
+		To:   to,
+		Step: delta,
+	}
+}
+
 func (r *MeshHashRequest) Count() uint {
 	diff := r.To.Difference(r.From)
 	count := uint(diff/r.Step + 1)
 	if diff%r.Step != 0 {
-		// last layer is not a multiple of By, so we need to add it
+		// last layer is not a multiple of Step size, so we need to add it
 		count++
 	}
 	return count

--- a/fetch/wire_types_test.go
+++ b/fetch/wire_types_test.go
@@ -1,0 +1,21 @@
+package fetch
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/spacemeshos/go-spacemesh/common/types"
+)
+
+func Fuzz_NewMeshHashRequest(f *testing.F) {
+	// examples from https://github.com/spacemeshos/go-spacemesh/issues/4654
+	f.Add(uint32(6269), uint32(10265))
+	f.Add(uint32(6269), uint32(10149))
+	f.Add(uint32(6269), uint32(9248))
+
+	f.Fuzz(func(t *testing.T, from, to uint32) {
+		req := NewMeshHashRequest(types.LayerID(from), types.LayerID(to))
+		require.NoError(t, req.Validate())
+	})
+}

--- a/syncer/find_fork.go
+++ b/syncer/find_fork.go
@@ -167,15 +167,14 @@ func (ff *ForkFinder) FindFork(ctx context.Context, peer p2p.Peer, diffLid types
 			return 0, err
 		}
 
-		dist := bnd.to.layer.Difference(bnd.from.layer)
-		delta := dist/uint32(fetch.MaxHashesInReq) + 1
-		ownHashes, err := layers.GetAggHashes(ff.db, bnd.from.layer, bnd.to.layer, delta)
+		req := fetch.NewMeshHashRequest(bnd.from.layer, bnd.to.layer)
+		ownHashes, err := layers.GetAggHashes(ff.db, req.From, req.To, req.Step)
 		if err != nil {
 			lg.With().Error("failed own hashes lookup", log.Err(err))
 			return 0, err
 		}
 
-		lid := bnd.from.layer
+		lid := req.From
 		var latestSame, oldestDiff *layerHash
 		for i, hash := range mh.Hashes {
 			ownHash := ownHashes[i]
@@ -195,9 +194,9 @@ func (ff *ForkFinder) FindFork(ctx context.Context, peer p2p.Peer, diffLid types
 			}
 			latestSame = &layerHash{layer: lid, hash: hash}
 			ff.updateAgreement(peer, latestSame, time.Now())
-			lid = lid.Add(delta)
-			if lid.After(bnd.to.layer) {
-				lid = bnd.to.layer
+			lid = lid.Add(req.Step)
+			if lid.After(req.To) {
+				lid = req.To
 			}
 		}
 		if latestSame == nil || oldestDiff == nil {
@@ -281,15 +280,9 @@ func (ff *ForkFinder) sendRequest(ctx context.Context, logger log.Log, peer p2p.
 		logger.With().Fatal("invalid args", log.Object("boundary", bnd))
 	}
 
-	dist := bnd.to.layer.Difference(bnd.from.layer)
-	delta := dist/uint32(fetch.MaxHashesInReq) + 1
-	req := &fetch.MeshHashRequest{
-		From: bnd.from.layer,
-		To:   bnd.to.layer,
-		Step: delta,
-	}
+	req := fetch.NewMeshHashRequest(bnd.from.layer, bnd.to.layer)
 	count := req.Count()
-	logger.With().Debug("sending request", log.Uint32("delta", delta))
+	logger.With().Debug("sending request", log.Uint32("delta", req.Step))
 	mh, err := ff.fetcher.PeerMeshHashes(ctx, peer, req)
 	if err != nil {
 		return nil, fmt.Errorf("find fork hash req: %w", err)

--- a/syncer/find_fork.go
+++ b/syncer/find_fork.go
@@ -282,7 +282,7 @@ func (ff *ForkFinder) sendRequest(ctx context.Context, logger log.Log, peer p2p.
 
 	req := fetch.NewMeshHashRequest(bnd.from.layer, bnd.to.layer)
 	count := req.Count()
-	logger.With().Debug("sending request", log.Uint32("delta", req.Step))
+	logger.With().Debug("sending request", log.Object("req", req))
 	mh, err := ff.fetcher.PeerMeshHashes(ctx, peer, req)
 	if err != nil {
 		return nil, fmt.Errorf("find fork hash req: %w", err)

--- a/syncer/find_fork_test.go
+++ b/syncer/find_fork_test.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"math/rand"
 	"strconv"
 	"testing"
 	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/rand"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/fetch"
@@ -119,18 +119,16 @@ func TestForkFinder_FindFork_Permutation(t *testing.T) {
 	}
 	expected := diverge - 1
 	for lid := max; lid > expected; lid-- {
-		t.Run("lid="+strconv.Itoa(lid), func(t *testing.T) {
-			tf := newTestForkFinderWithDuration(t, time.Hour, logtest.New(t))
-			storeNodeHashes(t, tf.db, diverge, max)
-			tf.mFetcher.EXPECT().PeerMeshHashes(gomock.Any(), peer, gomock.Any()).DoAndReturn(
-				func(_ context.Context, _ p2p.Peer, req *fetch.MeshHashRequest) (*fetch.MeshHashes, error) {
-					return serveHashReq(t, req)
-				}).AnyTimes()
+		tf := newTestForkFinderWithDuration(t, time.Hour, logtest.New(t))
+		storeNodeHashes(t, tf.db, diverge, max)
+		tf.mFetcher.EXPECT().PeerMeshHashes(gomock.Any(), peer, gomock.Any()).DoAndReturn(
+			func(_ context.Context, _ p2p.Peer, req *fetch.MeshHashRequest) (*fetch.MeshHashes, error) {
+				return serveHashReq(t, req)
+			}).AnyTimes()
 
-			fork, err := tf.FindFork(context.Background(), peer, types.LayerID(uint32(lid)), layerHash(lid, true))
-			require.NoError(t, err, fmt.Sprintf("lid: %v", lid))
-			require.Equal(t, expected, int(fork))
-		})
+		fork, err := tf.FindFork(context.Background(), peer, types.LayerID(uint32(lid)), layerHash(lid, true))
+		require.NoError(t, err, fmt.Sprintf("lid: %v", lid))
+		require.Equal(t, expected, int(fork))
 	}
 }
 


### PR DESCRIPTION
## Motivation
Closes #4654

## Changes
- added `NewMeshHashRequest` to instantiate a `MeshHashRequest` with the correct step size
- added fuzzing test that checks if for any given `from` and `to` layer `Validate()` passes
  - before `Step` was calculated incorrectly and leading to `Count()` sometimes returning `MaxHashesInReq + 1` and failing validation
- ensure same calculation is used in `ForkFinder`
- updated tests

## Test Plan
- existing tests updated
- new test added

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
