### PR TITLE
[Merged by Bors] - Prevent panicking when fetching without any peers

### DIFF
--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -457,6 +457,7 @@ func (f *Fetch) organizeRequests(requests []RequestMessage) map[p2p.Peer][][]Req
 	peer2requests := make(map[p2p.Peer][]RequestMessage)
 	peers := f.host.GetPeers()
 	if len(peers) == 0 {
+		log.Info("cannot send fetch: no peers found")
 		// in loop() we will try again after the batchTimeout
 		return nil
 	}

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -459,9 +459,6 @@ func (f *Fetch) organizeRequests(requests []RequestMessage) map[p2p.Peer][][]Req
 	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
 	peer2requests := make(map[p2p.Peer][]RequestMessage)
 	peers := f.host.GetPeers()
-	if len(peers) == 0 {
-		panic("no peers")
-	}
 
 	for _, req := range requests {
 		p, exists := f.hashToPeers.GetRandom(req.Hash, req.Hint, rng)

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -98,9 +98,6 @@ func DefaultConfig() Config {
 
 // randomPeer returns a random peer from current peer list.
 func randomPeer(peers []p2p.Peer) p2p.Peer {
-	if len(peers) == 0 {
-		log.Fatal("cannot send fetch: no peers found")
-	}
 	return peers[rand.Intn(len(peers))]
 }
 
@@ -459,6 +456,10 @@ func (f *Fetch) organizeRequests(requests []RequestMessage) map[p2p.Peer][][]Req
 	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
 	peer2requests := make(map[p2p.Peer][]RequestMessage)
 	peers := f.host.GetPeers()
+	if len(peers) == 0 {
+		// in loop() we will try again after the batchTimeout
+		return nil
+	}
 
 	for _, req := range requests {
 		p, exists := f.hashToPeers.GetRandom(req.Hash, req.Hint, rng)


### PR DESCRIPTION
## Motivation
There was a debug panic that was not removed from #4374, and also `randomPeer()` would fatally exit if there were no peers.
We don't actually want to panic, when trying to service a fetch request and there are no peers, so now we check to see if we have no peers and simply return, the fetch operation is performed on a ticker and so will be re-executed after some period.

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
