### PR TITLE
[Merged by Bors] - atx: check last 2 epochs for highest tick atx

### DIFF
--- a/sql/atxs/atxs_test.go
+++ b/sql/atxs/atxs_test.go
@@ -594,8 +594,17 @@ func TestPositioningID(t *testing.T) {
 		{
 			desc: "by epoch",
 			atxs: []header{
-				{coinbase: types.Address{1}, base: 1, count: 2, epoch: 1},
-				{coinbase: types.Address{2}, base: 1, count: 1, epoch: 2},
+				{coinbase: types.Address{1}, base: 1, count: 1, epoch: 1},
+				{coinbase: types.Address{2}, base: 1, count: 2, epoch: 2},
+			},
+			expect: 1,
+		},
+		{
+			desc: "highest in prev epoch",
+			atxs: []header{
+				{coinbase: types.Address{1}, base: 1, count: 3, epoch: 1}, // too old
+				{coinbase: types.Address{1}, base: 1, count: 2, epoch: 2},
+				{coinbase: types.Address{2}, base: 1, count: 1, epoch: 3},
 			},
 			expect: 1,
 		},


### PR DESCRIPTION
## Motivation
due to different poet speed, and once poet phase shift is implemented, the highest ticked atx might be still from previous epoch (from those fast poets), and that those that built on top of them are not yet published.

to strike a balance btwn honest miners and malicious one that inject high tick atx to an old epoch, we used last two epochs to select the highest ticked atx for positioning and commitment atx. 