### PR TITLE
[Merged by Bors] - syncer: dont block initialization before genesis

### DIFF
--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -360,17 +360,17 @@ func (s *Syncer) synchronize(ctx context.Context) bool {
 		return false
 	default:
 	}
-
-	if s.ticker.CurrentLayer().Uint32() == 0 {
-		return false
-	}
-
 	// at most one synchronize process can run at any time
 	if !s.setSyncerBusy() {
 		s.logger.WithContext(ctx).Info("sync is already running, giving up")
 		return false
 	}
 	defer s.setSyncerIdle()
+
+	s.setStateBeforeSync(ctx)
+	if s.ticker.CurrentLayer().Uint32() == 0 {
+		return false
+	}
 
 	// no need to worry about race condition for s.run. only one instance of synchronize can run at a time
 	s.logger.WithContext(ctx).With().Debug("starting sync run",
@@ -381,8 +381,6 @@ func (s *Syncer) synchronize(ctx context.Context) bool {
 		log.Stringer("in_state", s.mesh.LatestLayerInState()),
 		log.Stringer("processed", s.mesh.ProcessedLayer()),
 	)
-
-	s.setStateBeforeSync(ctx)
 	// TODO
 	// https://github.com/spacemeshos/go-spacemesh/issues/3970
 	// https://github.com/spacemeshos/go-spacemesh/issues/3987

--- a/syncer/syncer_test.go
+++ b/syncer/syncer_test.go
@@ -652,3 +652,15 @@ func TestSynchronize_RecoverFromCheckpoint(t *testing.T) {
 	require.Equal(t, current.GetEpoch(), ts.syncer.lastAtxEpoch())
 	types.SetEffectiveGenesis(types.FirstEffectiveGenesis().Uint32())
 }
+
+func TestSyncBeforeGenesis(t *testing.T) {
+	ts := newSyncerWithoutSyncTimer(t)
+	ts.mTicker.advanceToLayer(0)
+	require.False(t, ts.syncer.synchronize(context.Background()))
+	select {
+	case <-ts.syncer.RegisterForATXSynced():
+	default:
+		require.Fail(t, "should consider atxs to be synced")
+	}
+	require.True(t, ts.syncer.IsSynced(context.Background()))
+}


### PR DESCRIPTION
if ticker returns 0 we should consider node to be "synced" and "atx synced" and allow to run initialization