### PR TITLE
[Merged by Bors] - Fix copy paste mistake in function comment

### DIFF
--- a/fetch/handler.go
+++ b/fetch/handler.go
@@ -37,7 +37,7 @@ func newHandler(cdb *datastore.CachedDB, cfg Config, bs *datastore.BlobStore, m 
 	}
 }
 
-// handleMaliciousIDsReq returns the IDs of all malicious nodes.
+// handleMaliciousIDsReq returns the IDs of all known malicious nodes.
 func (h *handler) handleMaliciousIDsReq(ctx context.Context, _ []byte) ([]byte, error) {
 	nodes, err := identities.GetMalicious(h.cdb)
 	if err != nil {

--- a/fetch/handler.go
+++ b/fetch/handler.go
@@ -37,7 +37,7 @@ func newHandler(cdb *datastore.CachedDB, cfg Config, bs *datastore.BlobStore, m 
 	}
 }
 
-// handleEpochInfoReq returns the ATXs published in the specified epoch.
+// handleMaliciousIDsReq returns the IDs of all malicious nodes.
 func (h *handler) handleMaliciousIDsReq(ctx context.Context, _ []byte) ([]byte, error) {
 	nodes, err := identities.GetMalicious(h.cdb)
 	if err != nil {


### PR DESCRIPTION
This commit writes a comment for `handleMaliciousIDsReq` that matches its functionality. I tried to understand what the code does, but not sure if `all malicious nodes` is the right description (is it only some of them?).

Background: I'm doing a research study on function comments that may be improvable. You can find more info and a short and optional anonymous survey [here](https://forms.office.com/e/yHv4PRXM2i).

Thanks for reviewing!