### PR TITLE
[Merged by Bors] - api, events: cache last 100 admin events in memory

### DIFF
--- a/api/grpcserver/admin_service.go
+++ b/api/grpcserver/admin_service.go
@@ -109,7 +109,6 @@ func (a AdminService) EventsStream(req *pb.EventStreamRequest, stream pb.AdminSe
 		return status.Errorf(codes.Unavailable, "can't send header")
 	}
 	buf.Iterate(func(ev events.UserEvent) bool {
-		fmt.Println(ev.Event.Help)
 		err = stream.Send(ev.Event)
 		return err == nil
 	})

--- a/events/events.go
+++ b/events/events.go
@@ -193,7 +193,7 @@ func emitUserEvent(help string, failure bool, details pb.IsEventDetails) {
 	mu.RLock()
 	defer mu.RUnlock()
 	if reporter != nil {
-		if err := reporter.eventsEmitter.Emit(UserEvent{Event: &pb.Event{
+		if err := reporter.EmitUserEvent(UserEvent{Event: &pb.Event{
 			Timestamp: timestamppb.New(time.Now()),
 			Help:      help,
 			Failure:   failure,

--- a/events/events.go
+++ b/events/events.go
@@ -193,7 +193,7 @@ func emitUserEvent(help string, failure bool, details pb.IsEventDetails) {
 	mu.RLock()
 	defer mu.RUnlock()
 	if reporter != nil {
-		if err := reporter.EmitUserEvent(UserEvent{Event: &pb.Event{
+		if err := reporter.emitUserEvent(UserEvent{Event: &pb.Event{
 			Timestamp: timestamppb.New(time.Now()),
 			Help:      help,
 			Failure:   failure,

--- a/events/reporter.go
+++ b/events/reporter.go
@@ -339,7 +339,7 @@ func SubscribeUserEvents(opts ...SubOpt) (*BufferedSubscription[UserEvent], *Rin
 	if reporter == nil {
 		return nil, nil, nil
 	}
-	return reporter.SubUserEvents(opts...)
+	return reporter.subUserEvents(opts...)
 }
 
 // The status of a layer
@@ -428,14 +428,14 @@ type EventReporter struct {
 	stopChan chan struct{}
 }
 
-func (r *EventReporter) EmitUserEvent(ev UserEvent) error {
+func (r *EventReporter) emitUserEvent(ev UserEvent) error {
 	r.events.Lock()
 	defer r.events.Unlock()
 	r.events.buf.insert(ev)
 	return r.events.emitter.Emit(ev)
 }
 
-func (r *EventReporter) SubUserEvents(opts ...SubOpt) (*BufferedSubscription[UserEvent], *Ring[UserEvent], error) {
+func (r *EventReporter) subUserEvents(opts ...SubOpt) (*BufferedSubscription[UserEvent], *Ring[UserEvent], error) {
 	r.events.Lock()
 	defer r.events.Unlock()
 	sub, err := Subscribe[UserEvent](opts...)

--- a/events/reporter.go
+++ b/events/reporter.go
@@ -570,10 +570,13 @@ func (r *Ring[T]) insert(value T) {
 }
 
 func (r *Ring[T]) Copy() *Ring[T] {
-	cp := *r
-	cp.data = make([]T, r.Len())
+	cp := &Ring[T]{
+		first: r.first,
+		last:  r.last,
+		data:  make([]T, r.Len()),
+	}
 	copy(cp.data, r.data)
-	return &cp
+	return cp
 }
 
 func (r *Ring[T]) Len() int {
@@ -590,7 +593,20 @@ func (r *Ring[T]) Iterate(iter func(val T) bool) {
 	if r.last == -1 {
 		return
 	}
-	for i := r.first; i != r.last; i = (i + 1) % len(r.data) {
+	if r.last > r.first {
+		for i := r.first; i <= r.last; i++ {
+			if !iter(r.data[i]) {
+				return
+			}
+		}
+		return
+	}
+	for i := r.first; i < len(r.data); i++ {
+		if !iter(r.data[i]) {
+			return
+		}
+	}
+	for i := 0; i < r.first; i++ {
 		if !iter(r.data[i]) {
 			return
 		}

--- a/events/reporter_test.go
+++ b/events/reporter_test.go
@@ -11,25 +11,25 @@ func TestRingBuffer(t *testing.T) {
 
 	t.Run("empty", func(t *testing.T) {
 		buffer := newRing[int](cap)
-		require.Equal(t, cap, buffer.cap())
-		buffer.iterate(func(val int) bool {
+		require.Equal(t, 0, buffer.Len())
+		buffer.Iterate(func(val int) bool {
 			require.Fail(t, "should not be called")
 			return true
 		})
 	})
-
 	t.Run("overwrite", func(t *testing.T) {
 		buffer := newRing[int](cap)
 		for i := 0; i < cap*2; i++ {
 			buffer.insert(i)
 		}
+		require.Equal(t, cap, buffer.Len())
 		expect := cap
-		buffer.iterate(func(val int) bool {
+		buffer.Iterate(func(val int) bool {
 			require.Equal(t, expect, val)
 			expect++
 			return true
 		})
-		require.Equal(t, cap*2, expect)
+		require.Equal(t, cap*2-1, expect)
 	})
 	t.Run("terminate", func(t *testing.T) {
 		buffer := newRing[int](cap)
@@ -38,12 +38,25 @@ func TestRingBuffer(t *testing.T) {
 		}
 		expect := 0
 		terminate := cap / 2
-		buffer.iterate(func(val int) bool {
+		buffer.Iterate(func(val int) bool {
 			require.Equal(t, expect, val)
 			require.Less(t, val, terminate)
 			expect++
 			return expect < terminate
 		})
 		require.Equal(t, terminate, expect)
+	})
+	t.Run("not full", func(t *testing.T) {
+		buffer := newRing[int](cap)
+		for i := 0; i < cap/2; i++ {
+			buffer.insert(i)
+		}
+		expect := 0
+		buffer.Iterate(func(val int) bool {
+			require.Equal(t, expect, val)
+			expect++
+			return true
+		})
+		require.Equal(t, cap/2-1, expect)
 	})
 }

--- a/events/reporter_test.go
+++ b/events/reporter_test.go
@@ -1,0 +1,49 @@
+package events
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRingBuffer(t *testing.T) {
+	const cap = 10
+
+	t.Run("empty", func(t *testing.T) {
+		buffer := newRing[int](cap)
+		require.Equal(t, cap, buffer.cap())
+		buffer.iterate(func(val int) bool {
+			require.Fail(t, "should not be called")
+			return true
+		})
+	})
+
+	t.Run("overwrite", func(t *testing.T) {
+		buffer := newRing[int](cap)
+		for i := 0; i < cap*2; i++ {
+			buffer.insert(i)
+		}
+		expect := cap
+		buffer.iterate(func(val int) bool {
+			require.Equal(t, expect, val)
+			expect++
+			return true
+		})
+		require.Equal(t, cap*2, expect)
+	})
+	t.Run("terminate", func(t *testing.T) {
+		buffer := newRing[int](cap)
+		for i := 0; i < cap; i++ {
+			buffer.insert(i)
+		}
+		expect := 0
+		terminate := cap / 2
+		buffer.iterate(func(val int) bool {
+			require.Equal(t, expect, val)
+			require.Less(t, val, terminate)
+			expect++
+			return expect < terminate
+		})
+		require.Equal(t, terminate, expect)
+	})
+}

--- a/events/reporter_test.go
+++ b/events/reporter_test.go
@@ -21,6 +21,11 @@ func TestRingBuffer(t *testing.T) {
 		buffer := newRing[int](cap)
 		for i := 0; i < cap*2; i++ {
 			buffer.insert(i)
+			if i < cap {
+				require.Equal(t, i+1, buffer.Len())
+			} else {
+				require.Equal(t, cap, buffer.Len())
+			}
 		}
 		require.Equal(t, cap, buffer.Len())
 		expect := cap
@@ -29,7 +34,7 @@ func TestRingBuffer(t *testing.T) {
 			expect++
 			return true
 		})
-		require.Equal(t, cap*2-1, expect)
+		require.Equal(t, cap*2, expect)
 	})
 	t.Run("terminate", func(t *testing.T) {
 		buffer := newRing[int](cap)
@@ -57,6 +62,6 @@ func TestRingBuffer(t *testing.T) {
 			expect++
 			return true
 		})
-		require.Equal(t, cap/2-1, expect)
+		require.Equal(t, cap/2, expect)
 	})
 }

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -948,24 +948,28 @@ func TestAdminEvents(t *testing.T) {
 
 	tctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
-	stream, err := client.EventsStream(tctx, &pb.EventStreamRequest{})
-	require.NoError(t, err)
-	defer stream.CloseSend()
-	success := []pb.IsEventDetails{
-		&pb.Event_InitStart{},
-		&pb.Event_InitComplete{},
-		&pb.Event_PostStart{},
-		&pb.Event_PostComplete{},
-		&pb.Event_PoetWaitRound{},
-		&pb.Event_PoetWaitProof{},
-		&pb.Event_PostStart{},
-		&pb.Event_PostComplete{},
-		&pb.Event_AtxPublished{},
-	}
-	for _, ev := range success {
-		msg, err := stream.Recv()
+
+	// 4 is arbitrary, if we received events once, they must be
+	// cached and should be returned immediately
+	for i := 0; i < 4; i++ {
+		stream, err := client.EventsStream(tctx, &pb.EventStreamRequest{})
 		require.NoError(t, err)
-		require.IsType(t, ev, msg.Details)
+		success := []pb.IsEventDetails{
+			&pb.Event_InitStart{},
+			&pb.Event_InitComplete{},
+			&pb.Event_PostStart{},
+			&pb.Event_PostComplete{},
+			&pb.Event_PoetWaitRound{},
+			&pb.Event_PoetWaitProof{},
+			&pb.Event_PostStart{},
+			&pb.Event_PostComplete{},
+			&pb.Event_AtxPublished{},
+		}
+		for _, ev := range success {
+			msg, err := stream.Recv()
+			require.NoError(t, err, "stream %d", i)
+			require.IsType(t, ev, msg.Details, "stream %d", i)
+		}
 	}
 }
 

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -955,6 +955,7 @@ func TestAdminEvents(t *testing.T) {
 		stream, err := client.EventsStream(tctx, &pb.EventStreamRequest{})
 		require.NoError(t, err)
 		success := []pb.IsEventDetails{
+			&pb.Event_Beacon{},
 			&pb.Event_InitStart{},
 			&pb.Event_InitComplete{},
 			&pb.Event_PostStart{},


### PR DESCRIPTION
grpc subscriber might be slow to join or disconnect due to flakes and other reasons, we don't want it to miss
important events because of that.

added simple ring buffer, and used it to cache last 100 user events. they are copied (pointers) and are sent to the newly created stream.
