### PR TITLE
[Merged by Bors] - Support optional minerID in K2 PoW input

### DIFF
--- a/Makefile-libs.Inc
+++ b/Makefile-libs.Inc
@@ -50,7 +50,7 @@ else
 	endif
 endif
 
-POSTRS_SETUP_REV = 0.3.0
+POSTRS_SETUP_REV = 0.4.0-rc2
 POSTRS_SETUP_ZIP = libpost-$(platform)-v$(POSTRS_SETUP_REV).zip
 POSTRS_SETUP_URL_ZIP ?= https://github.com/spacemeshos/post-rs/releases/download/v$(POSTRS_SETUP_REV)/$(POSTRS_SETUP_ZIP)
 POSTRS_PROFILER_ZIP = profiler-$(platform)-v$(POSTRS_SETUP_REV).zip

--- a/Makefile-libs.Inc
+++ b/Makefile-libs.Inc
@@ -50,7 +50,7 @@ else
 	endif
 endif
 
-POSTRS_SETUP_REV = 0.4.0-rc2
+POSTRS_SETUP_REV = 0.4.0
 POSTRS_SETUP_ZIP = libpost-$(platform)-v$(POSTRS_SETUP_REV).zip
 POSTRS_SETUP_URL_ZIP ?= https://github.com/spacemeshos/post-rs/releases/download/v$(POSTRS_SETUP_REV)/$(POSTRS_SETUP_ZIP)
 POSTRS_PROFILER_ZIP = profiler-$(platform)-v$(POSTRS_SETUP_REV).zip

--- a/activation/activation.go
+++ b/activation/activation.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/spacemeshos/post/proving"
 	"github.com/spacemeshos/post/shared"
 	"go.uber.org/atomic"
 	"golang.org/x/sync/errgroup"
@@ -276,7 +277,7 @@ func (b *Builder) generateInitialPost(ctx context.Context) error {
 	startTime := time.Now()
 	var err error
 	events.EmitPostStart(shared.ZeroChallenge)
-	b.initialPost, _, err = b.postSetupProvider.GenerateProof(ctx, shared.ZeroChallenge)
+	b.initialPost, _, err = b.postSetupProvider.GenerateProof(ctx, shared.ZeroChallenge, proving.WithPowCreator(b.nodeID.Bytes()))
 	if err != nil {
 		events.EmitPostFailure()
 		return fmt.Errorf("post execution: %w", err)

--- a/activation/activation_test.go
+++ b/activation/activation_test.go
@@ -255,7 +255,7 @@ func TestBuilder_StartSmeshingCoinbase(t *testing.T) {
 
 	tab.mpost.EXPECT().PrepareInitializer(gomock.Any(), gomock.Any()).AnyTimes()
 	tab.mpost.EXPECT().StartSession(gomock.Any()).AnyTimes()
-	tab.mpost.EXPECT().GenerateProof(gomock.Any(), gomock.Any()).AnyTimes().Return(&types.Post{}, &types.PostMetadata{}, nil)
+	tab.mpost.EXPECT().GenerateProof(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(&types.Post{}, &types.PostMetadata{}, nil)
 	tab.mclock.EXPECT().AwaitLayer(gomock.Any()).Return(make(chan struct{})).AnyTimes()
 	require.NoError(t, tab.StartSmeshing(coinbase, postSetupOpts))
 	require.Equal(t, coinbase, tab.Coinbase())
@@ -273,7 +273,7 @@ func TestBuilder_RestartSmeshing(t *testing.T) {
 		tab := newTestBuilder(t)
 		tab.mpost.EXPECT().PrepareInitializer(gomock.Any(), gomock.Any()).AnyTimes()
 		tab.mpost.EXPECT().StartSession(gomock.Any()).AnyTimes()
-		tab.mpost.EXPECT().GenerateProof(gomock.Any(), gomock.Any()).AnyTimes().Return(&types.Post{}, &types.PostMetadata{}, nil)
+		tab.mpost.EXPECT().GenerateProof(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(&types.Post{}, &types.PostMetadata{}, nil)
 		tab.mpost.EXPECT().Reset().AnyTimes()
 		ch := make(chan struct{})
 		close(ch)
@@ -326,7 +326,7 @@ func TestBuilder_StartSmeshing_PanicsOnErrInStartSession(t *testing.T) {
 	tab.log = l
 
 	// Stub these methods in case they get called
-	tab.mpost.EXPECT().GenerateProof(gomock.Any(), gomock.Any()).AnyTimes().Return(&types.Post{}, &types.PostMetadata{}, nil)
+	tab.mpost.EXPECT().GenerateProof(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(&types.Post{}, &types.PostMetadata{}, nil)
 	tab.mclock.EXPECT().AwaitLayer(gomock.Any()).AnyTimes()
 
 	// Set expectations
@@ -351,7 +351,7 @@ func TestBuilder_StartSmeshing_SessionNotStartedOnFailPrepare(t *testing.T) {
 	tab.log = l
 
 	// Stub these methods in case they get called
-	tab.mpost.EXPECT().GenerateProof(gomock.Any(), gomock.Any()).AnyTimes().Return(&types.Post{}, &types.PostMetadata{}, nil)
+	tab.mpost.EXPECT().GenerateProof(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(&types.Post{}, &types.PostMetadata{}, nil)
 	tab.mclock.EXPECT().AwaitLayer(gomock.Any()).AnyTimes()
 
 	// Set PrepareInitializer to fail
@@ -372,7 +372,7 @@ func TestBuilder_StopSmeshing_OnPoSTError(t *testing.T) {
 	tab := newTestBuilder(t)
 	tab.mpost.EXPECT().PrepareInitializer(gomock.Any(), gomock.Any()).AnyTimes()
 	tab.mpost.EXPECT().StartSession(gomock.Any()).Return(nil).AnyTimes()
-	tab.mpost.EXPECT().GenerateProof(gomock.Any(), gomock.Any()).Return(&types.Post{}, &types.PostMetadata{}, nil).AnyTimes()
+	tab.mpost.EXPECT().GenerateProof(gomock.Any(), gomock.Any(), gomock.Any()).Return(&types.Post{}, &types.PostMetadata{}, nil).AnyTimes()
 	ch := make(chan struct{})
 	close(ch)
 	now := time.Now()
@@ -1078,7 +1078,7 @@ func TestBuilder_RetryPublishActivationTx(t *testing.T) {
 
 func TestBuilder_InitialProofGeneratedOnce(t *testing.T) {
 	tab := newTestBuilder(t, WithPoetConfig(PoetConfig{PhaseShift: layerDuration * 4}))
-	tab.mpost.EXPECT().GenerateProof(gomock.Any(), shared.ZeroChallenge).Return(&types.Post{}, &types.PostMetadata{}, nil)
+	tab.mpost.EXPECT().GenerateProof(gomock.Any(), shared.ZeroChallenge, gomock.Any()).Return(&types.Post{}, &types.PostMetadata{}, nil)
 	require.NoError(t, tab.generateInitialPost(context.Background()))
 
 	posEpoch := postGenesisEpoch + 1
@@ -1104,7 +1104,7 @@ func TestBuilder_InitialProofGeneratedOnce(t *testing.T) {
 
 func TestBuilder_InitialPostIsPersisted(t *testing.T) {
 	tab := newTestBuilder(t, WithPoetConfig(PoetConfig{PhaseShift: layerDuration * 4}))
-	tab.mpost.EXPECT().GenerateProof(gomock.Any(), shared.ZeroChallenge).Return(&types.Post{}, &types.PostMetadata{}, nil)
+	tab.mpost.EXPECT().GenerateProof(gomock.Any(), shared.ZeroChallenge, gomock.Any()).Return(&types.Post{}, &types.PostMetadata{}, nil)
 	require.NoError(t, tab.generateInitialPost(context.Background()))
 
 	// GenerateProof() should not be called again
@@ -1112,7 +1112,7 @@ func TestBuilder_InitialPostIsPersisted(t *testing.T) {
 
 	// Remove the persisted post file and try again
 	require.NoError(t, os.Remove(filepath.Join(tab.nipostBuilder.DataDir(), postFilename)))
-	tab.mpost.EXPECT().GenerateProof(gomock.Any(), shared.ZeroChallenge).Return(&types.Post{}, &types.PostMetadata{}, nil)
+	tab.mpost.EXPECT().GenerateProof(gomock.Any(), shared.ZeroChallenge, gomock.Any()).Return(&types.Post{}, &types.PostMetadata{}, nil)
 	require.NoError(t, tab.generateInitialPost(context.Background()))
 }
 

--- a/activation/handler.go
+++ b/activation/handler.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/spacemeshos/post/shared"
+	"github.com/spacemeshos/post/verifying"
 	"golang.org/x/exp/maps"
 
 	"github.com/spacemeshos/go-spacemesh/codec"
@@ -53,6 +54,7 @@ type Handler struct {
 	atxChannels     map[types.ATXID]*atxChan
 	fetcher         system.Fetcher
 	poetCfg         PoetConfig
+	postCfg         PostConfig
 }
 
 // NewHandler returns a data handler for ATX.
@@ -70,6 +72,7 @@ func NewHandler(
 	tortoise system.Tortoise,
 	log log.Log,
 	poetCfg PoetConfig,
+	postCfg PostConfig,
 ) *Handler {
 	return &Handler{
 		cdb:             cdb,
@@ -86,6 +89,7 @@ func NewHandler(
 		beacon:          beacon,
 		tortoise:        tortoise,
 		poetCfg:         poetCfg,
+		postCfg:         postCfg,
 	}
 }
 
@@ -217,7 +221,14 @@ func (h *Handler) SyntacticallyValidateAtx(ctx context.Context, atx *types.Activ
 	expectedChallengeHash := atx.NIPostChallenge.Hash()
 	h.log.WithContext(ctx).With().Info("validating nipost", log.String("expected_challenge_hash", expectedChallengeHash.String()), atx.ID())
 
-	leaves, err := h.nipostValidator.NIPost(ctx, atx.SmesherID, *commitmentATX, atx.NIPost, expectedChallengeHash, atx.NumUnits)
+	verifyingOpts := []verifying.OptionFunc{}
+	if atx.PublishEpoch >= types.EpochID(h.postCfg.MinerIDInK2PowSinceEpoch) {
+		powCreatorId := atx.SmesherID
+		h.log.With().Info("Verifying NiPOST with pow creator ID", log.Named("id", powCreatorId))
+		verifyingOpts = append(verifyingOpts, verifying.WithPowCreator(powCreatorId.Bytes()))
+	}
+
+	leaves, err := h.nipostValidator.NIPost(ctx, atx.SmesherID, *commitmentATX, atx.NIPost, expectedChallengeHash, atx.NumUnits, verifyingOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("invalid nipost: %w", err)
 	}
@@ -243,7 +254,14 @@ func (h *Handler) validateInitialAtx(ctx context.Context, atx *types.ActivationT
 	initialPostMetadata := *atx.NIPost.PostMetadata
 	initialPostMetadata.Challenge = shared.ZeroChallenge
 
-	if err := h.nipostValidator.Post(ctx, atx.SmesherID, *atx.CommitmentATX, atx.InitialPost, &initialPostMetadata, atx.NumUnits); err != nil {
+	verifyingOpts := []verifying.OptionFunc{}
+	if atx.PublishEpoch >= types.EpochID(h.postCfg.MinerIDInK2PowSinceEpoch) {
+		powCreatorId := atx.SmesherID
+		h.log.With().Info("Verifying Initial POST with pow creator ID", log.Named("id", powCreatorId))
+		verifyingOpts = append(verifyingOpts, verifying.WithPowCreator(powCreatorId.Bytes()))
+	}
+
+	if err := h.nipostValidator.Post(ctx, atx.SmesherID, *atx.CommitmentATX, atx.InitialPost, &initialPostMetadata, atx.NumUnits, verifyingOpts...); err != nil {
 		return fmt.Errorf("invalid initial Post: %w", err)
 	}
 

--- a/activation/handler_test.go
+++ b/activation/handler_test.go
@@ -101,7 +101,7 @@ func newTestHandler(tb testing.TB, goldenATXID types.ATXID) *testHandler {
 	mbeacon := NewMockAtxReceiver(ctrl)
 	mtortoise := mocks.NewMockTortoise(ctrl)
 
-	atxHdlr := NewHandler(cdb, verifier, mclock, mpub, mockFetch, types.GetLayersPerEpoch(), 1, goldenATXID, mValidator, mbeacon, mtortoise, lg, PoetConfig{})
+	atxHdlr := NewHandler(cdb, verifier, mclock, mpub, mockFetch, types.GetLayersPerEpoch(), 1, goldenATXID, mValidator, mbeacon, mtortoise, lg, PoetConfig{}, PostConfig{})
 	return &testHandler{
 		Handler: atxHdlr,
 
@@ -217,7 +217,7 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 		require.NoError(t, SignAndFinalizeAtx(sig, atx))
 
 		atxHdlr.mclock.EXPECT().CurrentLayer().Return(currentLayer)
-		atxHdlr.mValidator.EXPECT().NIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(uint64(1), nil)
+		atxHdlr.mValidator.EXPECT().NIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(uint64(1), nil)
 		atxHdlr.mValidator.EXPECT().NIPostChallenge(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 		atxHdlr.mValidator.EXPECT().PositioningAtx(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 
@@ -239,7 +239,7 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 		require.NoError(t, SignAndFinalizeAtx(sig, atx))
 
 		atxHdlr.mclock.EXPECT().CurrentLayer().Return(currentLayer)
-		atxHdlr.mValidator.EXPECT().NIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(uint64(1), nil)
+		atxHdlr.mValidator.EXPECT().NIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(uint64(1), nil)
 		atxHdlr.mValidator.EXPECT().NIPostChallenge(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 		atxHdlr.mValidator.EXPECT().PositioningAtx(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 		atxHdlr.mValidator.EXPECT().VRFNonce(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
@@ -260,7 +260,7 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 		require.NoError(t, SignAndFinalizeAtx(sig, atx))
 
 		atxHdlr.mclock.EXPECT().CurrentLayer().Return(currentLayer)
-		atxHdlr.mValidator.EXPECT().NIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(uint64(1), nil)
+		atxHdlr.mValidator.EXPECT().NIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(uint64(1), nil)
 		atxHdlr.mValidator.EXPECT().NIPostChallenge(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 		atxHdlr.mValidator.EXPECT().PositioningAtx(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 
@@ -282,7 +282,7 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 		require.NoError(t, SignAndFinalizeAtx(sig, atx))
 
 		atxHdlr.mclock.EXPECT().CurrentLayer().Return(currentLayer)
-		atxHdlr.mValidator.EXPECT().NIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(uint64(1), nil)
+		atxHdlr.mValidator.EXPECT().NIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(uint64(1), nil)
 		atxHdlr.mValidator.EXPECT().NIPostChallenge(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 		atxHdlr.mValidator.EXPECT().PositioningAtx(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 		atxHdlr.mValidator.EXPECT().VRFNonce(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
@@ -335,8 +335,8 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 		atxHdlr.mclock.EXPECT().CurrentLayer().Return(currentLayer)
 		atxHdlr.mValidator.EXPECT().InitialNIPostChallenge(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 		atxHdlr.mValidator.EXPECT().VRFNonce(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-		atxHdlr.mValidator.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-		atxHdlr.mValidator.EXPECT().NIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(uint64(1), nil)
+		atxHdlr.mValidator.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+		atxHdlr.mValidator.EXPECT().NIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(uint64(1), nil)
 		atxHdlr.mValidator.EXPECT().PositioningAtx(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 
 		_, err := atxHdlr.SyntacticallyValidateAtx(context.Background(), atx)
@@ -454,7 +454,7 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 
 		atxHdlr.mclock.EXPECT().CurrentLayer().Return(currentLayer)
 		atxHdlr.mValidator.EXPECT().InitialNIPostChallenge(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-		atxHdlr.mValidator.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+		atxHdlr.mValidator.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 
 		_, err := atxHdlr.SyntacticallyValidateAtx(context.Background(), atx)
 		require.ErrorContains(t, err, "VRFNonce is missing")
@@ -482,7 +482,7 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 		atxHdlr.mclock.EXPECT().CurrentLayer().Return(currentLayer)
 		atxHdlr.mValidator.EXPECT().InitialNIPostChallenge(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 		atxHdlr.mValidator.EXPECT().VRFNonce(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("invalid VRF nonce"))
-		atxHdlr.mValidator.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+		atxHdlr.mValidator.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 
 		_, err := atxHdlr.SyntacticallyValidateAtx(context.Background(), atx)
 		require.ErrorContains(t, err, "invalid VRF nonce")
@@ -522,7 +522,7 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 
 		atxHdlr.mclock.EXPECT().CurrentLayer().Return(currentLayer)
 		atxHdlr.mValidator.EXPECT().InitialNIPostChallenge(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-		atxHdlr.mValidator.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("failed post validation"))
+		atxHdlr.mValidator.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("failed post validation"))
 
 		_, err := atxHdlr.SyntacticallyValidateAtx(context.Background(), atx)
 		require.ErrorContains(t, err, "failed post validation")
@@ -769,7 +769,7 @@ func BenchmarkActivationDb_SyntacticallyValidateAtx(b *testing.B) {
 
 	currentLayer := types.LayerID(1012)
 	atxHdlr.mclock.EXPECT().CurrentLayer().Return(currentLayer).AnyTimes()
-	atxHdlr.mValidator.EXPECT().NIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(uint64(1), nil).AnyTimes()
+	atxHdlr.mValidator.EXPECT().NIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(uint64(1), nil).AnyTimes()
 	atxHdlr.mValidator.EXPECT().NIPostChallenge(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 	atxHdlr.mValidator.EXPECT().VRFNonce(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 	atxHdlr.mValidator.EXPECT().PositioningAtx(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
@@ -1226,8 +1226,8 @@ func TestHandler_AtxWeight(t *testing.T) {
 	atxHdlr.mockFetch.EXPECT().RegisterPeerHashes(peer, []types.Hash32{proofRef})
 	atxHdlr.mockFetch.EXPECT().GetPoetProof(gomock.Any(), proofRef)
 	atxHdlr.mValidator.EXPECT().VRFNonce(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
-	atxHdlr.mValidator.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
-	atxHdlr.mValidator.EXPECT().NIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(leaves, nil)
+	atxHdlr.mValidator.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
+	atxHdlr.mValidator.EXPECT().NIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(leaves, nil)
 	atxHdlr.mValidator.EXPECT().InitialNIPostChallenge(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 	atxHdlr.mValidator.EXPECT().PositioningAtx(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 	atxHdlr.mbeacon.EXPECT().OnAtx(gomock.Any())
@@ -1270,7 +1270,7 @@ func TestHandler_AtxWeight(t *testing.T) {
 		})
 	atxHdlr.mockFetch.EXPECT().GetPoetProof(gomock.Any(), proofRef)
 	atxHdlr.mockFetch.EXPECT().GetAtxs(gomock.Any(), gomock.Any())
-	atxHdlr.mValidator.EXPECT().NIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(leaves, nil)
+	atxHdlr.mValidator.EXPECT().NIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(leaves, nil)
 	atxHdlr.mValidator.EXPECT().NIPostChallenge(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 	atxHdlr.mValidator.EXPECT().PositioningAtx(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 	atxHdlr.mbeacon.EXPECT().OnAtx(gomock.Any())

--- a/activation/handler_test.go
+++ b/activation/handler_test.go
@@ -101,7 +101,7 @@ func newTestHandler(tb testing.TB, goldenATXID types.ATXID) *testHandler {
 	mbeacon := NewMockAtxReceiver(ctrl)
 	mtortoise := mocks.NewMockTortoise(ctrl)
 
-	atxHdlr := NewHandler(cdb, verifier, mclock, mpub, mockFetch, types.GetLayersPerEpoch(), 1, goldenATXID, mValidator, mbeacon, mtortoise, lg, PoetConfig{}, PostConfig{})
+	atxHdlr := NewHandler(cdb, verifier, mclock, mpub, mockFetch, types.GetLayersPerEpoch(), 1, goldenATXID, mValidator, mbeacon, mtortoise, lg, PoetConfig{})
 	return &testHandler{
 		Handler: atxHdlr,
 

--- a/activation/interface.go
+++ b/activation/interface.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"time"
 
+	"github.com/spacemeshos/post/proving"
 	"github.com/spacemeshos/post/shared"
 	"github.com/spacemeshos/post/verifying"
 
@@ -68,7 +69,7 @@ type postSetupProvider interface {
 	PrepareInitializer(ctx context.Context, opts PostSetupOpts) error
 	StartSession(context context.Context) error
 	Reset() error
-	GenerateProof(ctx context.Context, challenge []byte) (*types.Post, *types.PostMetadata, error)
+	GenerateProof(ctx context.Context, challenge []byte, options ...proving.OptionFunc) (*types.Post, *types.PostMetadata, error)
 	CommitmentAtx() (types.ATXID, error)
 	VRFNonce() (*types.VRFPostIndex, error)
 	LastOpts() *PostSetupOpts

--- a/activation/interface.go
+++ b/activation/interface.go
@@ -25,10 +25,10 @@ type PostVerifier interface {
 type nipostValidator interface {
 	InitialNIPostChallenge(challenge *types.NIPostChallenge, atxs atxProvider, goldenATXID types.ATXID) error
 	NIPostChallenge(challenge *types.NIPostChallenge, atxs atxProvider, nodeID types.NodeID) error
-	NIPost(ctx context.Context, nodeId types.NodeID, atxId types.ATXID, NIPost *types.NIPost, expectedChallenge types.Hash32, numUnits uint32, opts ...verifying.OptionFunc) (uint64, error)
+	NIPost(ctx context.Context, publishEpoch types.EpochID, nodeId types.NodeID, atxId types.ATXID, NIPost *types.NIPost, expectedChallenge types.Hash32, numUnits uint32, opts ...verifying.OptionFunc) (uint64, error)
 
 	NumUnits(cfg *PostConfig, numUnits uint32) error
-	Post(ctx context.Context, nodeId types.NodeID, atxId types.ATXID, Post *types.Post, PostMetadata *types.PostMetadata, numUnits uint32, opts ...verifying.OptionFunc) error
+	Post(ctx context.Context, publishEpoch types.EpochID, nodeId types.NodeID, atxId types.ATXID, Post *types.Post, PostMetadata *types.PostMetadata, numUnits uint32, opts ...verifying.OptionFunc) error
 	PostMetadata(cfg *PostConfig, metadata *types.PostMetadata) error
 
 	VRFNonce(nodeId types.NodeID, commitmentAtxId types.ATXID, vrfNonce *types.VRFPostIndex, PostMetadata *types.PostMetadata, numUnits uint32) error

--- a/activation/mocks.go
+++ b/activation/mocks.go
@@ -145,9 +145,9 @@ func (mr *MocknipostValidatorMockRecorder) InitialNIPostChallenge(challenge, atx
 }
 
 // NIPost mocks base method.
-func (m *MocknipostValidator) NIPost(ctx context.Context, nodeId types.NodeID, atxId types.ATXID, NIPost *types.NIPost, expectedChallenge types.Hash32, numUnits uint32, opts ...verifying.OptionFunc) (uint64, error) {
+func (m *MocknipostValidator) NIPost(ctx context.Context, publishEpoch types.EpochID, nodeId types.NodeID, atxId types.ATXID, NIPost *types.NIPost, expectedChallenge types.Hash32, numUnits uint32, opts ...verifying.OptionFunc) (uint64, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{ctx, nodeId, atxId, NIPost, expectedChallenge, numUnits}
+	varargs := []interface{}{ctx, publishEpoch, nodeId, atxId, NIPost, expectedChallenge, numUnits}
 	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
@@ -158,9 +158,9 @@ func (m *MocknipostValidator) NIPost(ctx context.Context, nodeId types.NodeID, a
 }
 
 // NIPost indicates an expected call of NIPost.
-func (mr *MocknipostValidatorMockRecorder) NIPost(ctx, nodeId, atxId, NIPost, expectedChallenge, numUnits interface{}, opts ...interface{}) *gomock.Call {
+func (mr *MocknipostValidatorMockRecorder) NIPost(ctx, publishEpoch, nodeId, atxId, NIPost, expectedChallenge, numUnits interface{}, opts ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{ctx, nodeId, atxId, NIPost, expectedChallenge, numUnits}, opts...)
+	varargs := append([]interface{}{ctx, publishEpoch, nodeId, atxId, NIPost, expectedChallenge, numUnits}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NIPost", reflect.TypeOf((*MocknipostValidator)(nil).NIPost), varargs...)
 }
 
@@ -207,9 +207,9 @@ func (mr *MocknipostValidatorMockRecorder) PositioningAtx(id, atxs, goldenATXID,
 }
 
 // Post mocks base method.
-func (m *MocknipostValidator) Post(ctx context.Context, nodeId types.NodeID, atxId types.ATXID, Post *types.Post, PostMetadata *types.PostMetadata, numUnits uint32, opts ...verifying.OptionFunc) error {
+func (m *MocknipostValidator) Post(ctx context.Context, publishEpoch types.EpochID, nodeId types.NodeID, atxId types.ATXID, Post *types.Post, PostMetadata *types.PostMetadata, numUnits uint32, opts ...verifying.OptionFunc) error {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{ctx, nodeId, atxId, Post, PostMetadata, numUnits}
+	varargs := []interface{}{ctx, publishEpoch, nodeId, atxId, Post, PostMetadata, numUnits}
 	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
@@ -219,9 +219,9 @@ func (m *MocknipostValidator) Post(ctx context.Context, nodeId types.NodeID, atx
 }
 
 // Post indicates an expected call of Post.
-func (mr *MocknipostValidatorMockRecorder) Post(ctx, nodeId, atxId, Post, PostMetadata, numUnits interface{}, opts ...interface{}) *gomock.Call {
+func (mr *MocknipostValidatorMockRecorder) Post(ctx, publishEpoch, nodeId, atxId, Post, PostMetadata, numUnits interface{}, opts ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{ctx, nodeId, atxId, Post, PostMetadata, numUnits}, opts...)
+	varargs := append([]interface{}{ctx, publishEpoch, nodeId, atxId, Post, PostMetadata, numUnits}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Post", reflect.TypeOf((*MocknipostValidator)(nil).Post), varargs...)
 }
 

--- a/activation/mocks.go
+++ b/activation/mocks.go
@@ -11,6 +11,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	types "github.com/spacemeshos/go-spacemesh/common/types"
+	proving "github.com/spacemeshos/post/proving"
 	shared "github.com/spacemeshos/post/shared"
 	verifying "github.com/spacemeshos/post/verifying"
 )
@@ -589,9 +590,13 @@ func (mr *MockpostSetupProviderMockRecorder) Config() *gomock.Call {
 }
 
 // GenerateProof mocks base method.
-func (m *MockpostSetupProvider) GenerateProof(ctx context.Context, challenge []byte) (*types.Post, *types.PostMetadata, error) {
+func (m *MockpostSetupProvider) GenerateProof(ctx context.Context, challenge []byte, options ...proving.OptionFunc) (*types.Post, *types.PostMetadata, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GenerateProof", ctx, challenge)
+	varargs := []interface{}{ctx, challenge}
+	for _, a := range options {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "GenerateProof", varargs...)
 	ret0, _ := ret[0].(*types.Post)
 	ret1, _ := ret[1].(*types.PostMetadata)
 	ret2, _ := ret[2].(error)
@@ -599,9 +604,10 @@ func (m *MockpostSetupProvider) GenerateProof(ctx context.Context, challenge []b
 }
 
 // GenerateProof indicates an expected call of GenerateProof.
-func (mr *MockpostSetupProviderMockRecorder) GenerateProof(ctx, challenge interface{}) *gomock.Call {
+func (mr *MockpostSetupProviderMockRecorder) GenerateProof(ctx, challenge interface{}, options ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateProof", reflect.TypeOf((*MockpostSetupProvider)(nil).GenerateProof), ctx, challenge)
+	varargs := append([]interface{}{ctx, challenge}, options...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateProof", reflect.TypeOf((*MockpostSetupProvider)(nil).GenerateProof), varargs...)
 }
 
 // LastOpts mocks base method.

--- a/activation/nipost.go
+++ b/activation/nipost.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/spacemeshos/merkle-tree"
 	"github.com/spacemeshos/poet/shared"
+	"github.com/spacemeshos/post/proving"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/spacemeshos/go-spacemesh/activation/metrics"
@@ -210,7 +211,14 @@ func (nb *NIPostBuilder) BuildNIPost(ctx context.Context, challenge *types.NIPos
 		nb.log.With().Info("starting post execution", log.Binary("challenge", nb.state.PoetProofRef[:]))
 		startTime := time.Now()
 		events.EmitPostStart(nb.state.PoetProofRef[:])
-		proof, proofMetadata, err := nb.postSetupProvider.GenerateProof(ctx, nb.state.PoetProofRef[:])
+
+		opts := []proving.OptionFunc{}
+		if pubEpoch >= types.EpochID(nb.postSetupProvider.Config().MinerIDInK2PowSinceEpoch) {
+			nb.log.With().Info("Using nodeID as PoW creator")
+			opts = append(opts, proving.WithPowCreator(nb.nodeID.Bytes()))
+		}
+
+		proof, proofMetadata, err := nb.postSetupProvider.GenerateProof(ctx, nb.state.PoetProofRef[:], opts...)
 		if err != nil {
 			events.EmitPostFailure()
 			return nil, 0, fmt.Errorf("failed to generate Post: %v", err)

--- a/activation/nipost_test.go
+++ b/activation/nipost_test.go
@@ -123,6 +123,7 @@ func TestNIPostBuilderWithClients(t *testing.T) {
 		t.Parallel()
 		postCfg := DefaultPostConfig()
 		postCfg.PowDifficulty[0] = 64
+		postCfg.MinerIDInK2PowSinceEpoch = 2
 		postProvider := newTestPostManager(t, withPostConfig(postCfg))
 		logger := logtest.New(t).WithName("validator")
 		verifier, err := NewPostVerifier(postProvider.Config(), logger)
@@ -138,18 +139,19 @@ func TestNIPostBuilderWithClients(t *testing.T) {
 		)
 		_, err = v.NIPost(
 			context.Background(),
+			challenge.PublishEpoch,
 			postProvider.id,
 			postProvider.commitmentAtxId,
 			nipost,
 			challengeHash,
 			postProvider.opts.NumUnits,
 			verifying.WithLabelScryptParams(postProvider.opts.Scrypt),
-			verifying.WithPowCreator(postProvider.id.Bytes()),
 		)
 		r.NoError(err)
 
 		_, err = v.NIPost(
 			context.Background(),
+			0,
 			postProvider.id,
 			postProvider.commitmentAtxId,
 			nipost,
@@ -181,6 +183,7 @@ func TestNIPostBuilderWithClients(t *testing.T) {
 		)
 		_, err = v.NIPost(
 			context.Background(),
+			challenge.PublishEpoch,
 			postProvider.id,
 			postProvider.commitmentAtxId,
 			nipost,
@@ -192,6 +195,7 @@ func TestNIPostBuilderWithClients(t *testing.T) {
 
 		_, err = v.NIPost(
 			context.Background(),
+			types.EpochID(postCfg.MinerIDInK2PowSinceEpoch),
 			postProvider.id,
 			postProvider.commitmentAtxId,
 			nipost,
@@ -294,6 +298,7 @@ func TestNewNIPostBuilderNotInitialized(t *testing.T) {
 	v := NewValidator(poetDb, postProvider.cfg, logger, verifier)
 	_, err = v.NIPost(
 		context.Background(),
+		challenge.PublishEpoch,
 		postProvider.id,
 		postProvider.goldenATXID,
 		nipost,

--- a/activation/nipost_test.go
+++ b/activation/nipost_test.go
@@ -106,7 +106,6 @@ func TestPostSetup(t *testing.T) {
 func TestNIPostBuilderWithClients(t *testing.T) {
 	t.Parallel()
 	logtest.SetupGlobal(t)
-	r := require.New(t)
 
 	challenge := types.NIPostChallenge{
 		PublishEpoch: postGenesisEpoch + 2,
@@ -127,7 +126,7 @@ func TestNIPostBuilderWithClients(t *testing.T) {
 		postProvider := newTestPostManager(t, withPostConfig(postCfg))
 		logger := logtest.New(t).WithName("validator")
 		verifier, err := NewPostVerifier(postProvider.Config(), logger)
-		r.NoError(err)
+		require.NoError(t, err)
 		defer verifier.Close()
 
 		nipost := buildNIPost(t, postProvider, postProvider.Config(), challenge, poetDb)
@@ -147,7 +146,7 @@ func TestNIPostBuilderWithClients(t *testing.T) {
 			postProvider.opts.NumUnits,
 			verifying.WithLabelScryptParams(postProvider.opts.Scrypt),
 		)
-		r.NoError(err)
+		require.NoError(t, err)
 
 		_, err = v.NIPost(
 			context.Background(),
@@ -158,9 +157,8 @@ func TestNIPostBuilderWithClients(t *testing.T) {
 			challengeHash,
 			postProvider.opts.NumUnits,
 			verifying.WithLabelScryptParams(postProvider.opts.Scrypt),
-			// no pow creator id -> proof invalid
 		)
-		r.Error(err)
+		require.Error(t, err)
 	})
 	t.Run("POST without pow creator ID", func(t *testing.T) {
 		t.Parallel()
@@ -171,7 +169,7 @@ func TestNIPostBuilderWithClients(t *testing.T) {
 		postProvider := newTestPostManager(t, withPostConfig(postCfg))
 		logger := logtest.New(t).WithName("validator")
 		verifier, err := NewPostVerifier(postProvider.Config(), logger)
-		r.NoError(err)
+		require.NoError(t, err)
 		defer verifier.Close()
 
 		nipost := buildNIPost(t, postProvider, postCfg, challenge, poetDb)
@@ -191,7 +189,7 @@ func TestNIPostBuilderWithClients(t *testing.T) {
 			postProvider.opts.NumUnits,
 			verifying.WithLabelScryptParams(postProvider.opts.Scrypt),
 		)
-		r.NoError(err)
+		require.NoError(t, err)
 
 		_, err = v.NIPost(
 			context.Background(),
@@ -202,10 +200,8 @@ func TestNIPostBuilderWithClients(t *testing.T) {
 			challengeHash,
 			postProvider.opts.NumUnits,
 			verifying.WithLabelScryptParams(postProvider.opts.Scrypt),
-			// extra pow creator ID -> proof invalid
-			verifying.WithPowCreator(postProvider.id.Bytes()),
 		)
-		r.Error(err)
+		require.Error(t, err)
 	})
 }
 

--- a/activation/nipost_test.go
+++ b/activation/nipost_test.go
@@ -121,7 +121,9 @@ func TestNIPostBuilderWithClients(t *testing.T) {
 	t.Run("POST with pow creator ID", func(t *testing.T) {
 		t.Parallel()
 		postCfg := DefaultPostConfig()
-		postCfg.PowDifficulty[0] = 64
+		// lower threshold lowers probility of false positive
+		// when checking the negative variant
+		postCfg.PowDifficulty[0] = 1
 		postCfg.MinerIDInK2PowSinceEpoch = 2
 		postProvider := newTestPostManager(t, withPostConfig(postCfg))
 		logger := logtest.New(t).WithName("validator")
@@ -165,7 +167,7 @@ func TestNIPostBuilderWithClients(t *testing.T) {
 		postCfg := DefaultPostConfig()
 		// miner ID in K2 POW since future epoch - won't kick in.
 		postCfg.MinerIDInK2PowSinceEpoch = challenge.PublishEpoch.Uint32() + 1
-		postCfg.PowDifficulty[0] = 64
+		postCfg.PowDifficulty[0] = 1
 		postProvider := newTestPostManager(t, withPostConfig(postCfg))
 		logger := logtest.New(t).WithName("validator")
 		verifier, err := NewPostVerifier(postProvider.Config(), logger)

--- a/activation/nipost_test.go
+++ b/activation/nipost_test.go
@@ -301,7 +301,6 @@ func TestNewNIPostBuilderNotInitialized(t *testing.T) {
 		challenge.Hash(),
 		postProvider.opts.NumUnits,
 		verifying.WithLabelScryptParams(postProvider.opts.Scrypt),
-		verifying.WithPowCreator(postProvider.id.Bytes()),
 	)
 	r.NoError(err)
 }

--- a/activation/post.go
+++ b/activation/post.go
@@ -32,6 +32,8 @@ type PostConfig struct {
 	K2            uint32        `mapstructure:"post-k2"`
 	K3            uint32        `mapstructure:"post-k3"`
 	PowDifficulty PowDifficulty `mapstructure:"post-pow-difficulty"`
+	// Since when to include the miner ID in the K2 pow.
+	MinerIDInK2PowSinceEpoch uint32 `mapstructure:"post-minerid-in-k2-pow-since-epoch"`
 }
 
 func (c PostConfig) ToConfig() config.Config {
@@ -435,7 +437,7 @@ func (mgr *PostSetupManager) Reset() error {
 }
 
 // GenerateProof generates a new Post.
-func (mgr *PostSetupManager) GenerateProof(ctx context.Context, challenge []byte) (*types.Post, *types.PostMetadata, error) {
+func (mgr *PostSetupManager) GenerateProof(ctx context.Context, challenge []byte, options ...proving.OptionFunc) (*types.Post, *types.PostMetadata, error) {
 	mgr.mu.Lock()
 
 	if mgr.state != PostSetupStateComplete {
@@ -444,12 +446,15 @@ func (mgr *PostSetupManager) GenerateProof(ctx context.Context, challenge []byte
 	}
 	mgr.mu.Unlock()
 
-	proof, proofMetadata, err := proving.Generate(ctx, challenge, mgr.cfg.ToConfig(), mgr.logger.Zap(),
+	opts := []proving.OptionFunc{
 		proving.WithDataSource(mgr.cfg.ToConfig(), mgr.id.Bytes(), mgr.commitmentAtxId.Bytes(), mgr.lastOpts.DataDir),
 		proving.WithNonces(mgr.provingOpts.Nonces),
 		proving.WithThreads(mgr.provingOpts.Threads),
 		proving.WithPowFlags(mgr.provingOpts.Flags),
-	)
+	}
+	opts = append(opts, options...)
+
+	proof, proofMetadata, err := proving.Generate(ctx, challenge, mgr.cfg.ToConfig(), mgr.logger.Zap(), opts...)
 	if err != nil {
 		return nil, nil, fmt.Errorf("generate proof: %w", err)
 	}

--- a/activation/validation.go
+++ b/activation/validation.go
@@ -54,7 +54,7 @@ func NewValidator(poetDb poetDbAPI, cfg PostConfig, log log.Log, postVerifier Po
 // Some of the Post metadata fields validation values is ought to eventually be derived from
 // consensus instead of local configuration. If so, their validation should be removed to contextual validation,
 // while still syntactically-validate them here according to locally configured min/max values.
-func (v *Validator) NIPost(ctx context.Context, nodeId types.NodeID, commitmentAtxId types.ATXID, nipost *types.NIPost, expectedChallenge types.Hash32, numUnits uint32, opts ...verifying.OptionFunc) (uint64, error) {
+func (v *Validator) NIPost(ctx context.Context, publishEpoch types.EpochID, nodeId types.NodeID, commitmentAtxId types.ATXID, nipost *types.NIPost, expectedChallenge types.Hash32, numUnits uint32, opts ...verifying.OptionFunc) (uint64, error) {
 	if err := v.NumUnits(&v.cfg, numUnits); err != nil {
 		return 0, err
 	}
@@ -63,7 +63,7 @@ func (v *Validator) NIPost(ctx context.Context, nodeId types.NodeID, commitmentA
 		return 0, err
 	}
 
-	if err := v.Post(ctx, nodeId, commitmentAtxId, nipost.Post, nipost.PostMetadata, numUnits, opts...); err != nil {
+	if err := v.Post(ctx, publishEpoch, nodeId, commitmentAtxId, nipost.Post, nipost.PostMetadata, numUnits, opts...); err != nil {
 		return 0, fmt.Errorf("invalid Post: %v", err)
 	}
 
@@ -113,7 +113,7 @@ func validateMerkleProof(leaf []byte, proof *types.MerkleProof, expectedRoot []b
 
 // Post validates a Proof of Space-Time (PoST). It returns nil if validation passed or an error indicating why
 // validation failed.
-func (v *Validator) Post(ctx context.Context, nodeId types.NodeID, commitmentAtxId types.ATXID, PoST *types.Post, PostMetadata *types.PostMetadata, numUnits uint32, opts ...verifying.OptionFunc) error {
+func (v *Validator) Post(ctx context.Context, publishEpoch types.EpochID, nodeId types.NodeID, commitmentAtxId types.ATXID, PoST *types.Post, PostMetadata *types.PostMetadata, numUnits uint32, opts ...verifying.OptionFunc) error {
 	p := (*shared.Proof)(PoST)
 
 	m := &shared.ProofMetadata{
@@ -122,6 +122,12 @@ func (v *Validator) Post(ctx context.Context, nodeId types.NodeID, commitmentAtx
 		NumUnits:        numUnits,
 		Challenge:       PostMetadata.Challenge,
 		LabelsPerUnit:   PostMetadata.LabelsPerUnit,
+	}
+
+	if publishEpoch >= types.EpochID(v.cfg.MinerIDInK2PowSinceEpoch) {
+		powCreatorId := nodeId
+		v.log.With().Info("verifying POST with pow creator ID", log.Named("id", powCreatorId), log.Named("publish epoch", publishEpoch))
+		opts = append(opts, verifying.WithPowCreator(powCreatorId.Bytes()))
 	}
 
 	start := time.Now()

--- a/activation/validation_test.go
+++ b/activation/validation_test.go
@@ -575,7 +575,10 @@ func TestValidator_Validate(t *testing.T) {
 	postProvider := newTestPostManager(t)
 	nipost := buildNIPost(t, postProvider, postProvider.cfg, challenge, poetDb)
 
-	opts := []verifying.OptionFunc{verifying.WithLabelScryptParams(postProvider.opts.Scrypt)}
+	opts := []verifying.OptionFunc{
+		verifying.WithLabelScryptParams(postProvider.opts.Scrypt),
+		verifying.WithPowCreator(postProvider.id.Bytes()),
+	}
 
 	logger := logtest.New(t).WithName("validator")
 	verifier, err := NewPostVerifier(postProvider.cfg, logger)

--- a/activation/validation_test.go
+++ b/activation/validation_test.go
@@ -575,10 +575,7 @@ func TestValidator_Validate(t *testing.T) {
 	postProvider := newTestPostManager(t)
 	nipost := buildNIPost(t, postProvider, postProvider.cfg, challenge, poetDb)
 
-	opts := []verifying.OptionFunc{
-		verifying.WithLabelScryptParams(postProvider.opts.Scrypt),
-		verifying.WithPowCreator(postProvider.id.Bytes()),
-	}
+	opts := []verifying.OptionFunc{verifying.WithLabelScryptParams(postProvider.opts.Scrypt)}
 
 	logger := logtest.New(t).WithName("validator")
 	verifier, err := NewPostVerifier(postProvider.cfg, logger)

--- a/activation/validation_test.go
+++ b/activation/validation_test.go
@@ -368,11 +368,11 @@ func Test_Validation_Post(t *testing.T) {
 	post := types.Post{}
 	meta := types.PostMetadata{}
 
-	postVerifier.EXPECT().Verify(gomock.Any(), (*shared.Proof)(&post), gomock.Any()).Return(nil)
-	require.NoError(t, v.Post(context.Background(), types.EmptyNodeID, types.RandomATXID(), &post, &meta, 1))
+	postVerifier.EXPECT().Verify(gomock.Any(), (*shared.Proof)(&post), gomock.Any(), gomock.Any()).Return(nil)
+	require.NoError(t, v.Post(context.Background(), types.EpochID(0), types.EmptyNodeID, types.RandomATXID(), &post, &meta, 1))
 
-	postVerifier.EXPECT().Verify(gomock.Any(), (*shared.Proof)(&post), gomock.Any()).Return(errors.New("invalid"))
-	require.Error(t, v.Post(context.Background(), types.EmptyNodeID, types.RandomATXID(), &post, &meta, 1))
+	postVerifier.EXPECT().Verify(gomock.Any(), (*shared.Proof)(&post), gomock.Any(), gomock.Any()).Return(errors.New("invalid"))
+	require.Error(t, v.Post(context.Background(), types.EpochID(0), types.EmptyNodeID, types.RandomATXID(), &post, &meta, 1))
 }
 
 func Test_Validation_PositioningAtx(t *testing.T) {
@@ -585,33 +585,33 @@ func TestValidator_Validate(t *testing.T) {
 	r.NoError(err)
 	defer verifier.Close()
 	v := NewValidator(poetDb, postProvider.cfg, logger, verifier)
-	_, err = v.NIPost(context.Background(), postProvider.id, postProvider.commitmentAtxId, nipost, challengeHash, postProvider.opts.NumUnits, opts...)
+	_, err = v.NIPost(context.Background(), challenge.PublishEpoch, postProvider.id, postProvider.commitmentAtxId, nipost, challengeHash, postProvider.opts.NumUnits, opts...)
 	r.NoError(err)
 
-	_, err = v.NIPost(context.Background(), postProvider.id, postProvider.commitmentAtxId, nipost, types.BytesToHash([]byte("lerner")), postProvider.opts.NumUnits, opts...)
+	_, err = v.NIPost(context.Background(), challenge.PublishEpoch, postProvider.id, postProvider.commitmentAtxId, nipost, types.BytesToHash([]byte("lerner")), postProvider.opts.NumUnits, opts...)
 	r.Contains(err.Error(), "invalid membership proof")
 
 	newNIPost := *nipost
 	newNIPost.Post = &types.Post{}
-	_, err = v.NIPost(context.Background(), postProvider.id, postProvider.commitmentAtxId, &newNIPost, challengeHash, postProvider.opts.NumUnits, opts...)
+	_, err = v.NIPost(context.Background(), challenge.PublishEpoch, postProvider.id, postProvider.commitmentAtxId, &newNIPost, challengeHash, postProvider.opts.NumUnits, opts...)
 	r.Contains(err.Error(), "invalid Post")
 
 	newPostCfg := postProvider.cfg
 	newPostCfg.MinNumUnits = postProvider.opts.NumUnits + 1
 	v = NewValidator(poetDb, newPostCfg, logtest.New(t).WithName("validator"), nil)
-	_, err = v.NIPost(context.Background(), postProvider.id, postProvider.commitmentAtxId, nipost, challengeHash, postProvider.opts.NumUnits, opts...)
+	_, err = v.NIPost(context.Background(), challenge.PublishEpoch, postProvider.id, postProvider.commitmentAtxId, nipost, challengeHash, postProvider.opts.NumUnits, opts...)
 	r.EqualError(err, fmt.Sprintf("invalid `numUnits`; expected: >=%d, given: %d", newPostCfg.MinNumUnits, postProvider.opts.NumUnits))
 
 	newPostCfg = postProvider.cfg
 	newPostCfg.MaxNumUnits = postProvider.opts.NumUnits - 1
 	v = NewValidator(poetDb, newPostCfg, logtest.New(t).WithName("validator"), nil)
-	_, err = v.NIPost(context.Background(), postProvider.id, postProvider.commitmentAtxId, nipost, challengeHash, postProvider.opts.NumUnits, opts...)
+	_, err = v.NIPost(context.Background(), challenge.PublishEpoch, postProvider.id, postProvider.commitmentAtxId, nipost, challengeHash, postProvider.opts.NumUnits, opts...)
 	r.EqualError(err, fmt.Sprintf("invalid `numUnits`; expected: <=%d, given: %d", newPostCfg.MaxNumUnits, postProvider.opts.NumUnits))
 
 	newPostCfg = postProvider.cfg
 	newPostCfg.LabelsPerUnit = nipost.PostMetadata.LabelsPerUnit + 1
 	v = NewValidator(poetDb, newPostCfg, logtest.New(t).WithName("validator"), nil)
-	_, err = v.NIPost(context.Background(), postProvider.id, postProvider.commitmentAtxId, nipost, challengeHash, postProvider.opts.NumUnits, opts...)
+	_, err = v.NIPost(context.Background(), challenge.PublishEpoch, postProvider.id, postProvider.commitmentAtxId, nipost, challengeHash, postProvider.opts.NumUnits, opts...)
 	r.EqualError(err, fmt.Sprintf("invalid `LabelsPerUnit`; expected: >=%d, given: %d", newPostCfg.LabelsPerUnit, nipost.PostMetadata.LabelsPerUnit))
 }
 

--- a/checkpoint/recovery_test.go
+++ b/checkpoint/recovery_test.go
@@ -242,6 +242,7 @@ func validateAndPreserveData(tb testing.TB, db *sql.Database, deps []*types.Veri
 		mtrtl,
 		lg,
 		activation.PoetConfig{},
+		activation.PostConfig{},
 	)
 	mfetch.EXPECT().GetAtxs(gomock.Any(), gomock.Any()).AnyTimes()
 	for i, vatx := range deps {
@@ -253,13 +254,13 @@ func validateAndPreserveData(tb testing.TB, db *sql.Database, deps []*types.Veri
 		mfetch.EXPECT().GetPoetProof(gomock.Any(), vatx.GetPoetProofRef())
 		if vatx.InitialPost != nil {
 			mvalidator.EXPECT().InitialNIPostChallenge(&vatx.ActivationTx.NIPostChallenge, gomock.Any(), goldenAtx).AnyTimes()
-			mvalidator.EXPECT().Post(gomock.Any(), vatx.SmesherID, *vatx.CommitmentATX, vatx.InitialPost, gomock.Any(), vatx.NumUnits)
+			mvalidator.EXPECT().Post(gomock.Any(), vatx.SmesherID, *vatx.CommitmentATX, vatx.InitialPost, gomock.Any(), vatx.NumUnits, gomock.Any())
 			mvalidator.EXPECT().VRFNonce(vatx.SmesherID, *vatx.CommitmentATX, vatx.VRFNonce, gomock.Any(), vatx.NumUnits)
 		} else {
 			mvalidator.EXPECT().NIPostChallenge(&vatx.ActivationTx.NIPostChallenge, cdb, vatx.SmesherID)
 		}
 		mvalidator.EXPECT().PositioningAtx(&vatx.PositioningATX, cdb, goldenAtx, vatx.PublishEpoch, layersPerEpoch)
-		mvalidator.EXPECT().NIPost(gomock.Any(), vatx.SmesherID, gomock.Any(), vatx.NIPost, gomock.Any(), vatx.NumUnits)
+		mvalidator.EXPECT().NIPost(gomock.Any(), vatx.SmesherID, gomock.Any(), vatx.NIPost, gomock.Any(), vatx.NumUnits, gomock.Any())
 		mreceiver.EXPECT().OnAtx(gomock.Any())
 		mtrtl.EXPECT().OnAtx(gomock.Any())
 		require.NoError(tb, atxHandler.HandleAtxData(context.Background(), "self", encoded))

--- a/checkpoint/recovery_test.go
+++ b/checkpoint/recovery_test.go
@@ -242,7 +242,6 @@ func validateAndPreserveData(tb testing.TB, db *sql.Database, deps []*types.Veri
 		mtrtl,
 		lg,
 		activation.PoetConfig{},
-		activation.PostConfig{},
 	)
 	mfetch.EXPECT().GetAtxs(gomock.Any(), gomock.Any()).AnyTimes()
 	for i, vatx := range deps {
@@ -254,13 +253,13 @@ func validateAndPreserveData(tb testing.TB, db *sql.Database, deps []*types.Veri
 		mfetch.EXPECT().GetPoetProof(gomock.Any(), vatx.GetPoetProofRef())
 		if vatx.InitialPost != nil {
 			mvalidator.EXPECT().InitialNIPostChallenge(&vatx.ActivationTx.NIPostChallenge, gomock.Any(), goldenAtx).AnyTimes()
-			mvalidator.EXPECT().Post(gomock.Any(), vatx.SmesherID, *vatx.CommitmentATX, vatx.InitialPost, gomock.Any(), vatx.NumUnits, gomock.Any())
+			mvalidator.EXPECT().Post(gomock.Any(), vatx.PublishEpoch, vatx.SmesherID, *vatx.CommitmentATX, vatx.InitialPost, gomock.Any(), vatx.NumUnits)
 			mvalidator.EXPECT().VRFNonce(vatx.SmesherID, *vatx.CommitmentATX, vatx.VRFNonce, gomock.Any(), vatx.NumUnits)
 		} else {
 			mvalidator.EXPECT().NIPostChallenge(&vatx.ActivationTx.NIPostChallenge, cdb, vatx.SmesherID)
 		}
 		mvalidator.EXPECT().PositioningAtx(&vatx.PositioningATX, cdb, goldenAtx, vatx.PublishEpoch, layersPerEpoch)
-		mvalidator.EXPECT().NIPost(gomock.Any(), vatx.SmesherID, gomock.Any(), vatx.NIPost, gomock.Any(), vatx.NumUnits, gomock.Any())
+		mvalidator.EXPECT().NIPost(gomock.Any(), vatx.PublishEpoch, vatx.SmesherID, gomock.Any(), vatx.NIPost, gomock.Any(), vatx.NumUnits)
 		mreceiver.EXPECT().OnAtx(gomock.Any())
 		mtrtl.EXPECT().OnAtx(gomock.Any())
 		require.NoError(tb, atxHandler.HandleAtxData(context.Background(), "self", encoded))

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/spacemeshos/go-scale v1.1.10
 	github.com/spacemeshos/merkle-tree v0.2.2
 	github.com/spacemeshos/poet v0.8.6
-	github.com/spacemeshos/post v0.8.3-rc1
+	github.com/spacemeshos/post v0.8.3
 	github.com/spf13/afero v1.9.5
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/spacemeshos/go-scale v1.1.10
 	github.com/spacemeshos/merkle-tree v0.2.2
 	github.com/spacemeshos/poet v0.8.6
-	github.com/spacemeshos/post v0.8.2
+	github.com/spacemeshos/post v0.8.3-rc1
 	github.com/spf13/afero v1.9.5
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -606,8 +606,8 @@ github.com/spacemeshos/merkle-tree v0.2.2 h1:+zF+17CwVebq9UzShunUBXv16rEVKIJHh2C
 github.com/spacemeshos/merkle-tree v0.2.2/go.mod h1:0Q/z4S5Kt9qz/c3qWa7hKA1yT7n7odyysbPIUTRu/xo=
 github.com/spacemeshos/poet v0.8.6 h1:jMQ9HkJeCRqUMRTIk0HEP/5kvVdAH+OAkzOKQ0XlhJU=
 github.com/spacemeshos/poet v0.8.6/go.mod h1:Ut/aR/1Sks6/I/+GDFLqCinXW6OIIS8z9uL/zjFTTP8=
-github.com/spacemeshos/post v0.8.2 h1:TqoyiDRf8hB3DkDK9YKcgFovLnlU9981Aux1Pf15Otc=
-github.com/spacemeshos/post v0.8.2/go.mod h1:gp3SxoFfeHFLJEneCeHCQ3Wa+BBsZbycRWesl5ZQx7g=
+github.com/spacemeshos/post v0.8.3-rc1 h1:1NtPC8kZbc09UjkhQhydHzfLXwfTHAEnBzaE5XeHyWk=
+github.com/spacemeshos/post v0.8.3-rc1/go.mod h1:LDj6XQht1ZvTZurBJ+LZNf17t92qIQymWgU2sY6V2Zs=
 github.com/spacemeshos/sha256-simd v0.1.0 h1:G7Mfu5RYdQiuE+wu4ZyJ7I0TI74uqLhFnKblEnSpjYI=
 github.com/spacemeshos/sha256-simd v0.1.0/go.mod h1:O8CClVIilId7RtuCMV2+YzMj6qjVn75JsxOxaE8vcfM=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=

--- a/go.sum
+++ b/go.sum
@@ -606,8 +606,8 @@ github.com/spacemeshos/merkle-tree v0.2.2 h1:+zF+17CwVebq9UzShunUBXv16rEVKIJHh2C
 github.com/spacemeshos/merkle-tree v0.2.2/go.mod h1:0Q/z4S5Kt9qz/c3qWa7hKA1yT7n7odyysbPIUTRu/xo=
 github.com/spacemeshos/poet v0.8.6 h1:jMQ9HkJeCRqUMRTIk0HEP/5kvVdAH+OAkzOKQ0XlhJU=
 github.com/spacemeshos/poet v0.8.6/go.mod h1:Ut/aR/1Sks6/I/+GDFLqCinXW6OIIS8z9uL/zjFTTP8=
-github.com/spacemeshos/post v0.8.3-rc1 h1:1NtPC8kZbc09UjkhQhydHzfLXwfTHAEnBzaE5XeHyWk=
-github.com/spacemeshos/post v0.8.3-rc1/go.mod h1:LDj6XQht1ZvTZurBJ+LZNf17t92qIQymWgU2sY6V2Zs=
+github.com/spacemeshos/post v0.8.3 h1:zrYoHIJWzGKxYGZFObqpwxc6/TsAKtlcq7IAkNjm/A0=
+github.com/spacemeshos/post v0.8.3/go.mod h1:LDj6XQht1ZvTZurBJ+LZNf17t92qIQymWgU2sY6V2Zs=
 github.com/spacemeshos/sha256-simd v0.1.0 h1:G7Mfu5RYdQiuE+wu4ZyJ7I0TI74uqLhFnKblEnSpjYI=
 github.com/spacemeshos/sha256-simd v0.1.0/go.mod h1:O8CClVIilId7RtuCMV2+YzMj6qjVn75JsxOxaE8vcfM=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=

--- a/node/node.go
+++ b/node/node.go
@@ -649,7 +649,6 @@ func (app *App) initServices(ctx context.Context, poetClients []activation.PoetP
 		trtl,
 		app.addLogger(ATXHandlerLogger, lg),
 		poetCfg,
-		app.Config.POST,
 	)
 
 	// we can't have an epoch offset which is greater/equal than the number of layers in an epoch

--- a/node/node.go
+++ b/node/node.go
@@ -649,6 +649,7 @@ func (app *App) initServices(ctx context.Context, poetClients []activation.PoetP
 		trtl,
 		app.addLogger(ATXHandlerLogger, lg),
 		poetCfg,
+		app.Config.POST,
 	)
 
 	// we can't have an epoch offset which is greater/equal than the number of layers in an epoch


### PR DESCRIPTION
## Motivation
Closes #4656 

## Changes
Adds an optional minerID that created the k2 pow (_k2 pow creator id_) to post proving and verifying.

## Reasoning for making it optional
In order to be able to test in on a real network (devnet-401) pre-genesis. For genesis we will set `post-minerid-in-k2-pow-since-epoch = 0` and later remove the config field along with branches in code.

## Test Plan
- existing UTs
- systests
- devnet-401 (set `post-minerid-in-k2-pow-since-epoch` to the epoch near in the future)
