### PR TITLE
[Merged by Bors] - feat: persist nipost state efficiently

### DIFF
--- a/activation/nipost_state.go
+++ b/activation/nipost_state.go
@@ -1,7 +1,6 @@
 package activation
 
 import (
-	"bytes"
 	"encoding/binary"
 	"fmt"
 	"hash/crc64"
@@ -20,43 +19,71 @@ const (
 	challengeFilename = "nipost_challenge.bin"
 	builderFilename   = "nipost_builder_state.bin"
 	postFilename      = "post.bin"
-	crc64Size         = 8
 )
 
 func write(path string, data []byte) error {
-	buf := bytes.NewBuffer(nil)
-	checksum := crc64.New(crc64.MakeTable(crc64.ISO))
-	w := io.MultiWriter(buf, checksum)
-	if _, err := w.Write(data); err != nil {
-		return fmt.Errorf("write data %v: %w", path, err)
+	tmp, err := os.CreateTemp("", filepath.Base(path))
+	if err != nil {
+		return fmt.Errorf("create temporary file %s: %w", tmp.Name(), err)
 	}
 
-	crc := make([]byte, crc64Size)
+	checksum := crc64.New(crc64.MakeTable(crc64.ISO))
+	w := io.MultiWriter(tmp, checksum)
+	if _, err = w.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write data %v: %w", tmp.Name(), err)
+	}
+
+	crc := make([]byte, crc64.Size)
 	binary.BigEndian.PutUint64(crc, checksum.Sum64())
-	if _, err := buf.Write(crc); err != nil {
-		return fmt.Errorf("write checksum %v: %w", path, err)
+	if _, err = tmp.Write(crc); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write checksum %s: %w", tmp.Name(), err)
 	}
-	if err := atomic.WriteFile(path, buf); err != nil {
-		return fmt.Errorf("save file %v: %w", path, err)
+
+	if err = tmp.Close(); err != nil {
+		return fmt.Errorf("failed to close tmp file %s: %w", tmp.Name(), err)
 	}
+
+	if err = atomic.ReplaceFile(tmp.Name(), path); err != nil {
+		return fmt.Errorf("save file from %s, %s: %w", tmp.Name(), path, err)
+	}
+
 	return nil
 }
 
 func read(path string) ([]byte, error) {
-	data, err := os.ReadFile(path)
+	file, err := os.Open(path)
 	if err != nil {
-		return nil, fmt.Errorf("read file %v: %w", path, err)
+		return nil, fmt.Errorf("open file %s: %w", path, err)
 	}
+
+	defer file.Close()
+
+	fInfo, err := file.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get file info %s: %w", path, err)
+	}
+
+	data := make([]byte, fInfo.Size()-crc64.Size)
 	checksum := crc64.New(crc64.MakeTable(crc64.ISO))
-	end := len(data) - crc64Size
-	if _, err = checksum.Write(data[:end]); err != nil {
-		return nil, fmt.Errorf("read checksum %v: %w", path, err)
+	if _, err = io.TeeReader(file, checksum).Read(data); err != nil {
+		return nil, fmt.Errorf("read file %s: %w", path, err)
 	}
-	saved := binary.BigEndian.Uint64(data[end:])
-	if saved != checksum.Sum64() {
-		return nil, fmt.Errorf("wrong checksum %d, computed %d", saved, checksum.Sum64())
+
+	saved := make([]byte, crc64.Size)
+	if _, err = file.Read(saved); err != nil {
+		return nil, fmt.Errorf("read checksum %s: %w", path, err)
 	}
-	return data[:end], nil
+
+	savedChecksum := binary.BigEndian.Uint64(saved)
+
+	if savedChecksum != checksum.Sum64() {
+		return nil, fmt.Errorf(
+			"wrong checksum 0x%X, computed 0x%X", savedChecksum, checksum.Sum64())
+	}
+
+	return data, nil
 }
 
 func load(filename string, dst scale.Decodable) error {

--- a/activation/nipost_state.go
+++ b/activation/nipost_state.go
@@ -22,7 +22,7 @@ const (
 )
 
 func write(path string, data []byte) error {
-	tmp, err := os.CreateTemp("", filepath.Base(path))
+	tmp, err := os.Create(fmt.Sprintf("%s.tmp", path))
 	if err != nil {
 		return fmt.Errorf("create temporary file %s: %w", tmp.Name(), err)
 	}

--- a/activation/nipost_state_test.go
+++ b/activation/nipost_state_test.go
@@ -10,6 +10,75 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestWriteCRC(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     []byte
+		crc      []byte
+		validCRC bool
+	}{
+		{
+			name:     "validCRC",
+			data:     []byte("spacemesh"),
+			crc:      []byte{0xC6, 0x10, 0x72, 0xDF, 0x52, 0xD7, 0x74, 0x0E},
+			validCRC: true,
+		}, {
+			name:     "badCRC",
+			data:     []byte("spacemesh"),
+			crc:      []byte{0xC7, 0x11, 0x73, 0xE0, 0x53, 0xD8, 0x7, 0x0F},
+			validCRC: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), tt.name)
+			require.NoError(t, write(path, tt.data))
+
+			raw, err := os.ReadFile(path)
+			require.NoError(t, err)
+			require.Equal(t, tt.validCRC, bytes.Equal(raw, append(tt.data, tt.crc...)))
+		})
+	}
+}
+
+func TestReadCRC(t *testing.T) {
+	tests := []struct {
+		name   string
+		data   []byte
+		crc    []byte
+		errMsg string
+	}{
+		{
+			name:   "validCRC",
+			data:   []byte("spacemesh"),
+			crc:    []byte{0xC6, 0x10, 0x72, 0xDF, 0x52, 0xD7, 0x74, 0x0E},
+			errMsg: "",
+		}, {
+			name:   "badCRC",
+			data:   []byte("spacemesh"),
+			crc:    []byte{0xC7, 0x11, 0x73, 0xE0, 0x53, 0xD8, 0x75, 0x0F},
+			errMsg: "wrong checksum 0xC71173E053D8750F, computed 0xC61072DF52D7740E",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), tt.name)
+			err := atomic.WriteFile(path, bytes.NewReader(append(tt.data, tt.crc...)))
+			require.NoError(t, err)
+
+			data, err := read(path)
+			if tt.errMsg == "" {
+				require.NoError(t, err)
+				require.True(t, bytes.Equal(data, tt.data))
+			} else {
+				require.ErrorContains(t, err, tt.errMsg)
+				require.Nil(t, data)
+			}
+		})
+	}
+}
+
 func TestWriteRecover(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "test")
 	data := []byte("secret")

--- a/activation/nipost_state_test.go
+++ b/activation/nipost_state_test.go
@@ -63,7 +63,8 @@ func TestReadCRC(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			path := filepath.Join(t.TempDir(), tt.name)
+			tmp := t.TempDir()
+			path := filepath.Join(tmp, tt.name)
 			err := atomic.WriteFile(path, bytes.NewReader(append(tt.data, tt.crc...)))
 			require.NoError(t, err)
 


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
Closes #4506
<!-- `Closes #XXXX, closes #XXXX, ...` links mentioned issues to this PR and automatically closes them when this it's merged -->

## Changes
<!-- Please describe in detail the changes made -->
- write: compute CRC as the file is written. (requires two writes: content & CRC)
- read: compute CRC as the file is read.
- use CRC Size constant from CRC pkg.
- *extra: Properly close the files when reading and writing*

The changes match what was requested in #4506 with regards to storing NiPoST state.

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->

Unit tests `TestWriteCRC` & `TestReadCRC` were added to specifically test the writing and reading of valid and invalid CRCs.  
Note: The write tests do not rely on `read()` and the read tests do not rely on `write()`.

I am unsure if a more elaborate plan is needed.

## Documentation
As far as I can see, there is no documentation related to the NiPoST state storage format.

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [ ] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
  This PR changes error messages when writing and reading NiPoST states from file. Specifically:
    - write: new message `create temporary file <path>: <err>`
    - write: replace `save file <path>: err` with `save file from <tmpfile>, <path>: <err>`
    - read: replace `read file <path>: <err>` with `open file <path>: <err>`
    - read: new message `failed to get file info <path>: <err>`
    - read: change in `wrong checksum <read_cksum>, computed <computed_cksum>`: checksums are displayed in (uppercase) hex rather than decimal.
