### PR TITLE
[Merged by Bors] - Change timezone of Dockerfile to UTC

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 FROM ubuntu:22.04 AS linux
 ENV DEBIAN_FRONTEND noninteractive
 ENV SHELL /bin/bash
-ARG TZ=US/Eastern
+ARG TZ=Etc/UTC
 ENV TZ $TZ
 USER root
 RUN set -ex \


### PR DESCRIPTION
Change timezone to UTC

## Motivation
More common used timezone. 
Much easier debugging of logs if everyone uses same timezone.

## Closes 
n/a

## Changes
Changed timezone in dockerfile

## Test Plan
Build docker image
Run docker image
Check time

## DevOps Notes
Timezone changed
