### PR TITLE
[Merged by Bors] - atxs: instead of panicing on missing CommitmentATX return error

### DIFF
--- a/activation/post.go
+++ b/activation/post.go
@@ -389,17 +389,13 @@ func (mgr *PostSetupManager) commitmentAtx(ctx context.Context, dataDir string) 
 	case err == nil:
 		return types.ATXID(types.BytesToHash(m.CommitmentAtxId)), nil
 	case errors.Is(err, initialization.ErrStateMetadataFileMissing):
-		// if this node has already published an ATX, get its initial ATX and from it the commitment ATX
-		atxId, err := atxs.GetFirstIDByNodeID(mgr.db, mgr.id)
+		// if this node has already published at least one ATX get its commitment ATX from the DB
+		atxId, err := atxs.CommitmentATX(mgr.db, mgr.id)
 		if err == nil {
-			atx, err := atxs.Get(mgr.db, atxId)
-			if err != nil {
-				return types.EmptyATXID, err
-			}
-			return *atx.CommitmentATX, nil
+			return atxId, nil
 		}
 
-		// if this node has not published an ATX select the best ATX with `findCommitmentAtx`
+		// if this node has not yet published ATXs select the best ATX with `findCommitmentAtx`
 		return mgr.findCommitmentAtx(ctx)
 	default:
 		return types.EmptyATXID, fmt.Errorf("load metadata: %w", err)


### PR DESCRIPTION
## Motivation
This prevents the following panic from happening:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x0 addr=0x0 pc=0x7ff765874d80]

goroutine 1 [running]:
github.com/spacemeshos/go-spacemesh/activation.(*PostSetupManager).commitmentAtx(0xc000e03700, {0x7ff7666f6c88, 0xc00022bc40}, {0xc00038964c?, 0x13308830a28?})
	D:/a/go-spacemesh/go-spacemesh/activation/post.go:395 +0x2e0
github.com/spacemeshos/go-spacemesh/activation.(*PostSetupManager).PrepareInitializer(0xc000e03700, {0x7ff7666f6c88, 0xc00022bc40}, {{0xc00038964c, 0x3}, 0x4, 0x80000000, 0x0panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x0 addr=0x0 pc=0x7ff765874d80]
```

## Changes
Instead panicing return an error if initial ATX does not contain a commitment.

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
