### PR TITLE
fix: missing Highest

### DIFF
--- a/api/grpcserver/activation_service.go
+++ b/api/grpcserver/activation_service.go
@@ -50,6 +50,7 @@ func (s *activationService) Get(ctx context.Context, request *pb.GetRequest) (*p
 	}, nil
 }
 
+// Highest implements v1.ActivationServiceServer.
 func (s *activationService) Highest(ctx context.Context, req *empty.Empty) (*pb.HighestResponse, error) {
 	highest, err := s.atxProvider.MaxHeightAtx()
 	if err != nil {


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
```bash
$ grpcurl -plaintext 127.0.0.1:9092 list spacemesh.v1.ActivationService.Highest
Error invoking method "spacemesh.v1.ActivationService.Highest": service "spacemesh.v1.ActivationService" does not include a method named "Highest"
```
`spacemesh.v1.ActivationService.Highest`This method is not exported.
<!-- `Closes #XXXX, closes #XXXX, ...` links mentioned issues to this PR and automatically closes them when this it's merged -->

## Changes
<!-- Please describe in detail the changes made -->
before
```bash
$ grpcurl -plaintext 127.0.0.1:9092 list spacemesh.v1.ActivationService
spacemesh.v1.ActivationService.Get
```
after
```bash
$ grpcurl -plaintext 127.0.0.1:9092 list spacemesh.v1.ActivationService
spacemesh.v1.ActivationService.Get
spacemesh.v1.ActivationService.Highest
```
## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->

## TODO
<!-- This section should be removed when all items are complete -->
- [ ] Explain motivation or link existing issue(s)
- [ ] Test changes and document test plan
- [ ] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
