### PR TITLE
[Merged by Bors] - config: enable activation service by default on public endpoinnt

### DIFF
--- a/api/grpcserver/config.go
+++ b/api/grpcserver/config.go
@@ -33,7 +33,7 @@ const (
 // DefaultConfig defines the default configuration options for api.
 func DefaultConfig() Config {
 	return Config{
-		PublicServices:        []Service{Debug, GlobalState, Mesh, Transaction, Node},
+		PublicServices:        []Service{Debug, GlobalState, Mesh, Transaction, Node, Activation},
 		PublicListener:        "0.0.0.0:9092",
 		PrivateServices:       []Service{Admin, Smesher},
 		PrivateListener:       "127.0.0.1:9093",


### PR DESCRIPTION
while looking at https://github.com/spacemeshos/go-spacemesh/pull/4701 i found that "activation" wasn't
enabled by default on public endpoint 