### PR TITLE
[Merged by Bors] - Remove minerid since epoch config

### DIFF
--- a/activation/nipost.go
+++ b/activation/nipost.go
@@ -212,13 +212,7 @@ func (nb *NIPostBuilder) BuildNIPost(ctx context.Context, challenge *types.NIPos
 		startTime := time.Now()
 		events.EmitPostStart(nb.state.PoetProofRef[:])
 
-		opts := []proving.OptionFunc{}
-		if pubEpoch >= types.EpochID(nb.postSetupProvider.Config().MinerIDInK2PowSinceEpoch) {
-			nb.log.With().Info("Using nodeID as PoW creator")
-			opts = append(opts, proving.WithPowCreator(nb.nodeID.Bytes()))
-		}
-
-		proof, proofMetadata, err := nb.postSetupProvider.GenerateProof(ctx, nb.state.PoetProofRef[:], opts...)
+		proof, proofMetadata, err := nb.postSetupProvider.GenerateProof(ctx, nb.state.PoetProofRef[:], proving.WithPowCreator(nb.nodeID.Bytes()))
 		if err != nil {
 			events.EmitPostFailure()
 			return nil, 0, fmt.Errorf("failed to generate Post: %v", err)

--- a/activation/nipost_test.go
+++ b/activation/nipost_test.go
@@ -50,7 +50,6 @@ func TestNIPostBuilderWithMocks(t *testing.T) {
 
 	ctrl := gomock.NewController(t)
 	postProvider := NewMockpostSetupProvider(ctrl)
-	postProvider.EXPECT().Config().Return(PostConfig{})
 	postProvider.EXPECT().Status().Return(&PostSetupStatus{State: PostSetupStateComplete})
 	postProvider.EXPECT().GenerateProof(gomock.Any(), gomock.Any(), gomock.Any())
 
@@ -118,93 +117,32 @@ func TestNIPostBuilderWithClients(t *testing.T) {
 	).AnyTimes()
 	poetDb.EXPECT().ValidateAndStore(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
-	t.Run("POST with pow creator ID", func(t *testing.T) {
-		t.Parallel()
-		postCfg := DefaultPostConfig()
-		// lower threshold lowers probility of false positive
-		// when checking the negative variant
-		postCfg.PowDifficulty[0] = 1
-		postCfg.MinerIDInK2PowSinceEpoch = 2
-		postProvider := newTestPostManager(t, withPostConfig(postCfg))
-		logger := logtest.New(t).WithName("validator")
-		verifier, err := NewPostVerifier(postProvider.Config(), logger)
-		require.NoError(t, err)
-		defer verifier.Close()
+	postCfg := DefaultPostConfig()
+	postCfg.PowDifficulty[0] = 1
+	postProvider := newTestPostManager(t, withPostConfig(postCfg))
+	logger := logtest.New(t).WithName("validator")
+	verifier, err := NewPostVerifier(postProvider.Config(), logger)
+	require.NoError(t, err)
+	defer verifier.Close()
 
-		nipost := buildNIPost(t, postProvider, postProvider.Config(), challenge, poetDb)
-		v := NewValidator(
-			poetDb,
-			postProvider.Config(),
-			logger,
-			verifier,
-		)
-		_, err = v.NIPost(
-			context.Background(),
-			challenge.PublishEpoch,
-			postProvider.id,
-			postProvider.commitmentAtxId,
-			nipost,
-			challengeHash,
-			postProvider.opts.NumUnits,
-			verifying.WithLabelScryptParams(postProvider.opts.Scrypt),
-		)
-		require.NoError(t, err)
-
-		_, err = v.NIPost(
-			context.Background(),
-			0,
-			postProvider.id,
-			postProvider.commitmentAtxId,
-			nipost,
-			challengeHash,
-			postProvider.opts.NumUnits,
-			verifying.WithLabelScryptParams(postProvider.opts.Scrypt),
-		)
-		require.Error(t, err)
-	})
-	t.Run("POST without pow creator ID", func(t *testing.T) {
-		t.Parallel()
-		postCfg := DefaultPostConfig()
-		// miner ID in K2 POW since future epoch - won't kick in.
-		postCfg.MinerIDInK2PowSinceEpoch = challenge.PublishEpoch.Uint32() + 1
-		postCfg.PowDifficulty[0] = 1
-		postProvider := newTestPostManager(t, withPostConfig(postCfg))
-		logger := logtest.New(t).WithName("validator")
-		verifier, err := NewPostVerifier(postProvider.Config(), logger)
-		require.NoError(t, err)
-		defer verifier.Close()
-
-		nipost := buildNIPost(t, postProvider, postCfg, challenge, poetDb)
-		v := NewValidator(
-			poetDb,
-			postCfg,
-			logger,
-			verifier,
-		)
-		_, err = v.NIPost(
-			context.Background(),
-			challenge.PublishEpoch,
-			postProvider.id,
-			postProvider.commitmentAtxId,
-			nipost,
-			challengeHash,
-			postProvider.opts.NumUnits,
-			verifying.WithLabelScryptParams(postProvider.opts.Scrypt),
-		)
-		require.NoError(t, err)
-
-		_, err = v.NIPost(
-			context.Background(),
-			types.EpochID(postCfg.MinerIDInK2PowSinceEpoch),
-			postProvider.id,
-			postProvider.commitmentAtxId,
-			nipost,
-			challengeHash,
-			postProvider.opts.NumUnits,
-			verifying.WithLabelScryptParams(postProvider.opts.Scrypt),
-		)
-		require.Error(t, err)
-	})
+	nipost := buildNIPost(t, postProvider, postProvider.Config(), challenge, poetDb)
+	v := NewValidator(
+		poetDb,
+		postProvider.Config(),
+		logger,
+		verifier,
+	)
+	_, err = v.NIPost(
+		context.Background(),
+		challenge.PublishEpoch,
+		postProvider.id,
+		postProvider.commitmentAtxId,
+		nipost,
+		challengeHash,
+		postProvider.opts.NumUnits,
+		verifying.WithLabelScryptParams(postProvider.opts.Scrypt),
+	)
+	require.NoError(t, err)
 }
 
 func spawnPoet(tb testing.TB, opts ...HTTPPoetOpt) *HTTPPoetClient {
@@ -313,7 +251,6 @@ func TestNIPostBuilder_BuildNIPost(t *testing.T) {
 	dir := t.TempDir()
 
 	postProvider := NewMockpostSetupProvider(gomock.NewController(t))
-	postProvider.EXPECT().Config().Return(PostConfig{}).AnyTimes()
 	postProvider.EXPECT().Status().Return(&PostSetupStatus{State: PostSetupStateComplete}).AnyTimes()
 
 	challenge := types.NIPostChallenge{
@@ -431,7 +368,6 @@ func TestNIPostBuilder_ManyPoETs_SubmittingChallenge_DeadlineReached(t *testing.
 		PhaseShift: layerDuration * layersPerEpoch / 2,
 	}
 	postProvider := NewMockpostSetupProvider(ctrl)
-	postProvider.EXPECT().Config().Return(PostConfig{})
 	postProvider.EXPECT().Status().Return(&PostSetupStatus{State: PostSetupStateComplete})
 	postProvider.EXPECT().GenerateProof(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
 		func(ctx context.Context, challenge []byte, _ proving.OptionFunc) (*types.Post, *types.PostMetadata, error) {
@@ -490,7 +426,6 @@ func TestNIPostBuilder_ManyPoETs_WaitingForProof_DeadlineReached(t *testing.T) {
 		GracePeriod: layerDuration * layersPerEpoch / 2,
 	}
 	postProvider := NewMockpostSetupProvider(ctrl)
-	postProvider.EXPECT().Config().Return(PostConfig{})
 	postProvider.EXPECT().Status().Return(&PostSetupStatus{State: PostSetupStateComplete})
 	postProvider.EXPECT().GenerateProof(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
 		func(_ context.Context, challenge []byte, _ proving.OptionFunc) (*types.Post, *types.PostMetadata, error) {
@@ -550,7 +485,6 @@ func TestNIPostBuilder_ManyPoETs_AllFinished(t *testing.T) {
 	sig, err := signing.NewEdSigner()
 	req.NoError(err)
 	postProvider := NewMockpostSetupProvider(ctrl)
-	postProvider.EXPECT().Config().Return(PostConfig{})
 	postProvider.EXPECT().Status().Return(&PostSetupStatus{State: PostSetupStateComplete})
 	postProvider.EXPECT().GenerateProof(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
 		func(_ context.Context, challenge []byte, _ proving.OptionFunc) (*types.Post, *types.PostMetadata, error) {
@@ -795,7 +729,6 @@ func TestNIPoSTBuilder_Continues_After_Interrupted(t *testing.T) {
 		PhaseShift: layerDuration * layersPerEpoch / 2,
 	}
 	postProvider := NewMockpostSetupProvider(ctrl)
-	postProvider.EXPECT().Config().Return(PostConfig{})
 	postProvider.EXPECT().Status().Return(&PostSetupStatus{State: PostSetupStateComplete}).Times(2)
 	postProvider.EXPECT().GenerateProof(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
 		func(ctx context.Context, challenge []byte, _ proving.OptionFunc) (*types.Post, *types.PostMetadata, error) {

--- a/activation/post.go
+++ b/activation/post.go
@@ -32,8 +32,6 @@ type PostConfig struct {
 	K2            uint32        `mapstructure:"post-k2"`
 	K3            uint32        `mapstructure:"post-k3"`
 	PowDifficulty PowDifficulty `mapstructure:"post-pow-difficulty"`
-	// Since when to include the miner ID in the K2 pow.
-	MinerIDInK2PowSinceEpoch uint32 `mapstructure:"post-minerid-in-k2-pow-since-epoch"`
 }
 
 func (c PostConfig) ToConfig() config.Config {

--- a/activation/validation.go
+++ b/activation/validation.go
@@ -124,11 +124,8 @@ func (v *Validator) Post(ctx context.Context, publishEpoch types.EpochID, nodeId
 		LabelsPerUnit:   PostMetadata.LabelsPerUnit,
 	}
 
-	if publishEpoch >= types.EpochID(v.cfg.MinerIDInK2PowSinceEpoch) {
-		powCreatorId := nodeId
-		v.log.With().Info("verifying POST with pow creator ID", log.Named("id", powCreatorId), log.Named("publish epoch", publishEpoch))
-		opts = append(opts, verifying.WithPowCreator(powCreatorId.Bytes()))
-	}
+	v.log.With().Info("verifying POST with pow creator ID", log.Named("id", nodeId))
+	opts = append(opts, verifying.WithPowCreator(nodeId.Bytes()))
 
 	start := time.Now()
 	if err := v.postVerifier.Verify(ctx, p, m, opts...); err != nil {

--- a/activation/validation_test.go
+++ b/activation/validation_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/log/logtest"
+	"github.com/spacemeshos/go-spacemesh/sql"
 )
 
 func Test_Validation_VRFNonce(t *testing.T) {
@@ -568,12 +569,10 @@ func TestValidator_Validate(t *testing.T) {
 		PublishEpoch: postGenesisEpoch + 2,
 	}
 	challengeHash := challenge.Hash()
-	poetDb := NewMockpoetDbAPI(gomock.NewController(t))
-	poetDb.EXPECT().GetProof(gomock.Any()).AnyTimes().Return(&types.PoetProof{}, &challengeHash, nil)
-	poetDb.EXPECT().ValidateAndStore(gomock.Any(), gomock.Any()).Return(nil)
+	poetDb := NewPoetDb(sql.InMemory(), logtest.New(t).WithName("poetDb"))
 
 	postProvider := newTestPostManager(t)
-	nipost := buildNIPost(t, postProvider, postProvider.cfg, challenge, poetDb)
+	nipost := buildNIPost(t, postProvider, challenge, poetDb)
 
 	opts := []verifying.OptionFunc{verifying.WithLabelScryptParams(postProvider.opts.Scrypt)}
 


### PR DESCRIPTION
## Motivation
The config `post-minerid-in-k2-pow-since-epoch` was needed for backward compatibility to test on existing networks only. It's not needed (defaults to 0 basically) on the mainnet.

## Changes
Removed `post-minerid-in-k2-pow-since-epoch` config option

## Test Plan
Existing tests pass