### PR TITLE
[Merged by Bors] - devops: improve release workflow

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -23,6 +23,7 @@ jobs:
     - name: set docker image on tag push
       run: |
         if [[ "${{ github.ref }}" == "refs/tags/"* ]]; then
+          echo "DOCKER_IMAGE_REPO=go-spacemesh" >> $GITHUB_ENV
           echo "DOCKER_IMAGE_VERSION=${{ github.ref_name }}" >> $GITHUB_ENV
         fi
     - name: push go-spacemesh

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -1,7 +1,8 @@
 # Generate latest build and push it to dockerhub on push to develop branch.
 # NOTE: This workflow does not include any tests, nor any dependencies, since bors guarantees
 # that only code that passes all tests is ever pushed to develop.
-name: push to dockerhub
+name: Push to Dockerhub
+run-name: Pushing ${{ github.ref_name }} to Dockerhub
 env:
   DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
   DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
@@ -19,6 +20,11 @@ jobs:
     steps:
     - name: checkout
       uses: actions/checkout@v3
+    - name: set docker image on tag push
+      run: |
+        if [[ "${{ github.ref }}" == "refs/tags/"* ]]; then
+          echo "DOCKER_IMAGE_VERSION=${{ github.ref_name }}" >> $GITHUB_ENV
+        fi
     - name: push go-spacemesh
       run: make dockerpush
     - name: push go-bootstrapper

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -20,13 +20,19 @@ jobs:
     steps:
     - name: checkout
       uses: actions/checkout@v3
-    - name: set docker image on tag push
+    - name: Build docker images
+      run: |
+        make dockerbuild-go
+        make dockerbuild-bs
+    - name: Push docker images to dockerhub dev repo
       run: |
         if [[ "${{ github.ref }}" == "refs/tags/"* ]]; then
-          echo "DOCKER_IMAGE_REPO=go-spacemesh" >> $GITHUB_ENV
           echo "DOCKER_IMAGE_VERSION=${{ github.ref_name }}" >> $GITHUB_ENV
         fi
-    - name: push go-spacemesh
-      run: make dockerpush
-    - name: push go-bootstrapper
-      run: make dockerpush-bs
+        make dockerpush-only
+        make dockerpush-bs-only
+    - name: Push docker images to dockerhub release repo
+      if: startsWith(github.ref, 'refs/tags/')
+      run: |
+        "DOCKER_IMAGE_REPO=go-spacemesh" make dockerpush-only
+        "DOCKER_IMAGE_REPO=go-spacemesh" make dockerpush-bs-only

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -24,15 +24,17 @@ jobs:
       run: |
         make dockerbuild-go
         make dockerbuild-bs
-    - name: Push docker images to dockerhub dev repo
+    - name: Push docker images to dockerhub
       run: |
-        if [[ "${{ github.ref }}" == "refs/tags/"* ]]; then
-          echo "DOCKER_IMAGE_VERSION=${{ github.ref_name }}" >> $GITHUB_ENV
-        fi
         make dockerpush-only
         make dockerpush-bs-only
-    - name: Push docker images to dockerhub release repo
+    - name: Push docker images with version tag to dockerhub
       if: startsWith(github.ref, 'refs/tags/')
       run: |
+        echo "DOCKER_IMAGE_VERSION=${{ github.ref_name }}" >> $GITHUB_ENV
+
+        make dockerpush-only
+        make dockerpush-bs-only
+
         "DOCKER_IMAGE_REPO=go-spacemesh" make dockerpush-only
         "DOCKER_IMAGE_REPO=go-spacemesh" make dockerpush-bs-only

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
 name: Build and Release
-
+run-name: Release ${{ github.ref_name }}
 env:
   DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
   DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,6 @@
 VERSION ?= $(shell git describe --tags)
-LDFLAGS = -ldflags "-X main.version=${VERSION} -X main.commit=${COMMIT} -X main.branch=${BRANCH}"
-include Makefile-libs.Inc
-
-DOCKER_HUB ?= spacemeshos
-UNIT_TESTS ?= $(shell go list ./...  | grep -v systest/tests | grep -v cmd/node | grep -v cmd/gen-p2p-identity | grep -v cmd/trace | grep -v genvm/cmd)
-
 COMMIT = $(shell git rev-parse HEAD)
-SHA = $(shell git rev-parse --short HEAD)
 BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
-
-export CGO_ENABLED := 1
-export CGO_CFLAGS := $(CGO_CFLAGS) -DSQLITE_ENABLE_DBSTAT_VTAB=1
 
 # Add an indicator to the branch name if dirty and use commithash if running in detached mode
 ifeq ($(BRANCH),HEAD)
@@ -22,13 +12,24 @@ ifneq ($(.SHELLSTATUS),0)
 endif
 
 ifeq ($(BRANCH),develop)
-  DOCKER_IMAGE_REPO := go-spacemesh
-else
   DOCKER_IMAGE_REPO := go-spacemesh-dev
+else
+  DOCKER_IMAGE_REPO := go-spacemesh
 endif
 
-DOCKER_IMAGE = $(DOCKER_IMAGE_REPO):$(SHA)
-DOCKER_BS_IMAGE = $(DOCKER_IMAGE_REPO)-bs:$(SHA)
+DOCKER_HUB ?= spacemeshos
+SHA = $(shell git rev-parse --short HEAD)
+DOCKER_IMAGE_VERSION ?= $(SHA)
+DOCKER_IMAGE = $(DOCKER_IMAGE_REPO):$(DOCKER_IMAGE_VERSION)
+DOCKER_BS_IMAGE = $(DOCKER_IMAGE_REPO)-bs:$(DOCKER_IMAGE_VERSION)
+
+LDFLAGS = -ldflags "-X main.version=${VERSION} -X main.commit=${COMMIT} -X main.branch=${BRANCH}"
+include Makefile-libs.Inc
+
+UNIT_TESTS ?= $(shell go list ./...  | grep -v systest/tests | grep -v cmd/node | grep -v cmd/gen-p2p-identity | grep -v cmd/trace | grep -v genvm/cmd)
+
+export CGO_ENABLED := 1
+export CGO_CFLAGS := $(CGO_CFLAGS) -DSQLITE_ENABLE_DBSTAT_VTAB=1
 
 # setting extra command line params for the CI tests pytest commands
 ifdef namespace

--- a/Makefile
+++ b/Makefile
@@ -11,13 +11,8 @@ ifneq ($(.SHELLSTATUS),0)
 	BRANCH := $(BRANCH)-dirty
 endif
 
-ifeq ($(BRANCH),develop)
-  DOCKER_IMAGE_REPO := go-spacemesh-dev
-else
-  DOCKER_IMAGE_REPO := go-spacemesh
-endif
-
 DOCKER_HUB ?= spacemeshos
+DOCKER_IMAGE_REPO ?= go-spacemesh-dev
 SHA = $(shell git rev-parse --short HEAD)
 DOCKER_IMAGE_VERSION ?= $(SHA)
 DOCKER_IMAGE = $(DOCKER_IMAGE_REPO):$(DOCKER_IMAGE_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -11,12 +11,10 @@ ifneq ($(.SHELLSTATUS),0)
 	BRANCH := $(BRANCH)-dirty
 endif
 
+SHA = $(shell git rev-parse --short HEAD)
 DOCKER_HUB ?= spacemeshos
 DOCKER_IMAGE_REPO ?= go-spacemesh-dev
-SHA = $(shell git rev-parse --short HEAD)
 DOCKER_IMAGE_VERSION ?= $(SHA)
-DOCKER_IMAGE = $(DOCKER_IMAGE_REPO):$(DOCKER_IMAGE_VERSION)
-DOCKER_BS_IMAGE = $(DOCKER_IMAGE_REPO)-bs:$(DOCKER_IMAGE_VERSION)
 
 LDFLAGS = -ldflags "-X main.version=${VERSION} -X main.commit=${COMMIT} -X main.branch=${BRANCH}"
 include Makefile-libs.Inc
@@ -142,7 +140,7 @@ list-versions:
 .PHONY: list-versions
 
 dockerbuild-go:
-	DOCKER_BUILDKIT=1 docker build -t $(DOCKER_IMAGE) .
+	DOCKER_BUILDKIT=1 docker build -t go-spacemesh:$(SHA) .
 .PHONY: dockerbuild-go
 
 dockerpush: dockerbuild-go dockerpush-only
@@ -152,12 +150,12 @@ dockerpush-only:
 ifneq ($(DOCKER_USERNAME):$(DOCKER_PASSWORD),:)
 	echo "$(DOCKER_PASSWORD)" | docker login -u "$(DOCKER_USERNAME)" --password-stdin
 endif
-	docker tag $(DOCKER_IMAGE) $(DOCKER_HUB)/$(DOCKER_IMAGE)
-	docker push $(DOCKER_HUB)/$(DOCKER_IMAGE)
+	docker tag go-spacemesh:$(SHA) $(DOCKER_HUB)/$(DOCKER_IMAGE_REPO):$(DOCKER_IMAGE_VERSION)
+	docker push $(DOCKER_HUB)/$(DOCKER_IMAGE_REPO):$(DOCKER_IMAGE_VERSION)
 .PHONY: dockerpush-only
 
 dockerbuild-bs:
-	DOCKER_BUILDKIT=1 docker build -t $(DOCKER_BS_IMAGE) -f ./bootstrap.Dockerfile .
+	DOCKER_BUILDKIT=1 docker build -t go-spacemesh-bs:$(SHA) -f ./bootstrap.Dockerfile .
 .PHONY: dockerbuild-bs
 
 dockerpush-bs: dockerbuild-bs dockerpush-bs-only
@@ -167,8 +165,8 @@ dockerpush-bs-only:
 ifneq ($(DOCKER_USERNAME):$(DOCKER_PASSWORD),:)
 	echo "$(DOCKER_PASSWORD)" | docker login -u "$(DOCKER_USERNAME)" --password-stdin
 endif
-	docker tag $(DOCKER_BS_IMAGE) $(DOCKER_HUB)/$(DOCKER_BS_IMAGE)
-	docker push $(DOCKER_HUB)/$(DOCKER_BS_IMAGE)
+	docker tag go-spacemesh-bs:$(SHA) $(DOCKER_HUB)/$(DOCKER_IMAGE_REPO)-bs:$(DOCKER_IMAGE_VERSION)
+	docker push $(DOCKER_HUB)/$(DOCKER_IMAGE_REPO)-bs:$(DOCKER_IMAGE_VERSION)
 .PHONY: dockerpush-bs-only
 
 fuzz:


### PR DESCRIPTION
## Motivation
There have been inconsistencies with our release process recently. This PR addresses those and improves on it.

## Changes
- "Build and Release" workflow will now display "Release {{ tag_name }}" as title when executed
- "Push to Dockerhub" workflow had various improvements:
  - It will now use "Push {{ version }} to Dockerhub" as title
  - When triggered on a tag it will use the tag as version for the docker image, otherwise the short commit SHA is used (as before)
  - For some reason builds on `develop` were pushed to `go-spacemesh` and on other branches (and releases) to `go-spacemesh-dev`. Changed it to always push to `go-spacemesh-dev` unless instructed otherwise (by e.g. the release job when triggered through a tag).
- Updated Makefile: Push to go-spacemesh-dev with short sha by default, release job overwrites the ENV to push to go-spacemesh with tag.

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
