### PR TITLE
[Merged by Bors] - activation: stopping smeshing while initializing tries to generate proof

### DIFF
--- a/activation/activation.go
+++ b/activation/activation.go
@@ -198,14 +198,18 @@ func (b *Builder) StartSmeshing(coinbase types.Address, opts PostSetupOpts) erro
 
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			return nil
 		case <-b.syncer.RegisterForATXSynced():
 			// ensure we are ATX synced before starting the PoST Session
 		}
 
 		// If start session returns any error other than context.Canceled
 		// (which is how we signal it to stop) then we panic.
-		if err := b.postSetupProvider.StartSession(ctx); err != nil && !errors.Is(err, context.Canceled) {
+		err := b.postSetupProvider.StartSession(ctx)
+		switch {
+		case errors.Is(err, context.Canceled):
+			return nil
+		case err != nil:
 			b.log.Panic("initialization failed: %v", err)
 		}
 


### PR DESCRIPTION
## Motivation
When a smesher pauses initialization the code will try to generate a proof and fail with error "post setup incomplete"

## Changes
When initialization is paused do not try to generate a proof.

## Test Plan
Test was added that fails without the change and passes with the change.

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
