### PR TITLE
Update Dockerfile to allow CPU provider

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,7 @@ RUN set -ex \
    net-tools \
    file \
    ocl-icd-libopencl1 clinfo \
-   # required for OpenCL CPU provider
-   # pocl-opencl-icd libpocl2 \
+   pocl-opencl-icd libpocl2 \
    && apt-get clean \
    && rm -rf /var/lib/apt/lists/* \
    && locale-gen en_US.UTF-8 \


### PR DESCRIPTION
## Motivation
Allow go-spacemesh to use a CPU provider in docker container



## Changes
Allow the docker image to install pocl-opencl-icd libpocl2

## Test Plan


## TODO

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [ ] Update documentation as needed

## DevOps Notes

- [ ] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
