### PR TITLE
[Merged by Bors] - validate genesis before using

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -1194,6 +1194,10 @@ func (app *App) LoadOrCreateEdSigner() (*signing.EdSigner, error) {
 	filename := filepath.Join(app.Config.SMESHING.Opts.DataDir, edKeyFileName)
 	log.Info("Looking for identity file at `%v`", filename)
 
+	if err := app.Config.Genesis.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid genesis: %w", err)
+	}
+
 	var data []byte
 	if len(app.Config.TestConfig.SmesherKey) > 0 {
 		log.With().Error("!!!TESTING!!! using pre-configured smesher key")

--- a/node/node.go
+++ b/node/node.go
@@ -145,6 +145,10 @@ func GetCommand() *cobra.Command {
 				}
 				defer app.Unlock()
 
+				if err := app.Initialize(); err != nil {
+					return err
+				}
+
 				/* Create or load miner identity */
 				if app.edSgn, err = app.LoadOrCreateEdSigner(); err != nil {
 					return fmt.Errorf("could not retrieve identity: %w", err)
@@ -152,10 +156,6 @@ func GetCommand() *cobra.Command {
 
 				app.preserve, err = app.LoadCheckpoint(ctx)
 				if err != nil {
-					return err
-				}
-
-				if err := app.Initialize(); err != nil {
 					return err
 				}
 
@@ -1193,10 +1193,6 @@ func (app *App) stopServices(ctx context.Context) {
 func (app *App) LoadOrCreateEdSigner() (*signing.EdSigner, error) {
 	filename := filepath.Join(app.Config.SMESHING.Opts.DataDir, edKeyFileName)
 	log.Info("Looking for identity file at `%v`", filename)
-
-	if err := app.Config.Genesis.Validate(); err != nil {
-		return nil, fmt.Errorf("invalid genesis: %w", err)
-	}
 
 	var data []byte
 	if len(app.Config.TestConfig.SmesherKey) > 0 {


### PR DESCRIPTION
Currently if run `fastnet` without specifying a `genesis-time`, will panic:
```
2023-07-18T10:02:33.246+0200	INFO	00000.defaultLogger	Looking for identity file at `/home/dd/post/data/key.bin`
panic: code should have run Validate before this method
```