### PR TITLE
[Merged by Bors] - public metrics

### DIFF
--- a/activation/activation.go
+++ b/activation/activation.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/datastore"
 	"github.com/spacemeshos/go-spacemesh/events"
 	"github.com/spacemeshos/go-spacemesh/log"
+	"github.com/spacemeshos/go-spacemesh/metrics/public"
 	"github.com/spacemeshos/go-spacemesh/p2p/pubsub"
 	"github.com/spacemeshos/go-spacemesh/signing"
 	"github.com/spacemeshos/go-spacemesh/sql"
@@ -301,6 +302,7 @@ func (b *Builder) generateInitialPost(ctx context.Context) error {
 	}
 	events.EmitPostComplete(shared.ZeroChallenge)
 	metrics.PostDuration.Set(float64(time.Since(startTime).Nanoseconds()))
+	public.PostSeconds.Set(float64(time.Since(startTime)))
 	b.log.Info("created the initial post")
 	if b.verifyInitialPost(ctx, post, metadata) != nil {
 		return err

--- a/activation/nipost.go
+++ b/activation/nipost.go
@@ -18,6 +18,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/events"
 	"github.com/spacemeshos/go-spacemesh/log"
+	"github.com/spacemeshos/go-spacemesh/metrics/public"
 	"github.com/spacemeshos/go-spacemesh/signing"
 )
 
@@ -253,7 +254,7 @@ func (nb *NIPostBuilder) BuildNIPost(ctx context.Context, challenge *types.NIPos
 		events.EmitPostComplete(nb.state.PoetProofRef[:])
 		postGenDuration = time.Since(startTime)
 		nb.log.With().Info("finished post execution", log.Duration("duration", postGenDuration))
-
+		public.PostSeconds.Set(postGenDuration.Seconds())
 		nb.state.NIPost.Post = proof
 		nb.state.NIPost.PostMetadata = proofMetadata
 

--- a/activation/post.go
+++ b/activation/post.go
@@ -16,6 +16,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/datastore"
 	"github.com/spacemeshos/go-spacemesh/events"
 	"github.com/spacemeshos/go-spacemesh/log"
+	"github.com/spacemeshos/go-spacemesh/metrics/public"
 	"github.com/spacemeshos/go-spacemesh/sql"
 	"github.com/spacemeshos/go-spacemesh/sql/atxs"
 )
@@ -315,6 +316,7 @@ func (mgr *PostSetupManager) StartSession(ctx context.Context) error {
 		log.String("labels_per_unit", fmt.Sprintf("%d", mgr.cfg.LabelsPerUnit)),
 		log.String("provider", fmt.Sprintf("%d", mgr.lastOpts.ProviderID)),
 	)
+	public.InitStart.Set(float64(mgr.lastOpts.NumUnits))
 	events.EmitInitStart(mgr.id, mgr.commitmentAtxId)
 	err = mgr.init.Initialize(ctx)
 
@@ -337,6 +339,7 @@ func (mgr *PostSetupManager) StartSession(ctx context.Context) error {
 		events.EmitInitFailure(mgr.id, mgr.commitmentAtxId, err)
 		return err
 	}
+	public.InitEnd.Set(float64(mgr.lastOpts.NumUnits))
 	events.EmitInitComplete()
 
 	mgr.logger.With().Info("post setup completed",

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -44,7 +44,7 @@ func AddCommands(cmd *cobra.Command) {
 		cfg.MetricsPort, "metric server port")
 	cmd.PersistentFlags().StringVar(&cfg.MetricsPush, "metrics-push",
 		cfg.MetricsPush, "Push metrics to url")
-	cmd.PersistentFlags().IntVar(&cfg.MetricsPushPeriod, "metrics-push-period",
+	cmd.PersistentFlags().DurationVar(&cfg.MetricsPushPeriod, "metrics-push-period",
 		cfg.MetricsPushPeriod, "Push period")
 	cmd.PersistentFlags().StringArrayVar(&cfg.PoETServers, "poet-server",
 		cfg.PoETServers, "The poet server url. (temporary) Can be passed multiple times")

--- a/config/config.go
+++ b/config/config.go
@@ -85,10 +85,11 @@ type BaseConfig struct {
 	CollectMetrics bool `mapstructure:"metrics"`
 	MetricsPort    int  `mapstructure:"metrics-port"`
 
-	MetricsPush       string `mapstructure:"metrics-push"`
-	MetricsPushPeriod int    `mapstructure:"metrics-push-period"`
-	MetricsPushUser   string `mapstructure:"metrics-push-user"`
-	MetricsPushPass   string `mapstructure:"metrics-push-pass"`
+	MetricsPush       string        `mapstructure:"metrics-push"`
+	MetricsPushPeriod time.Duration `mapstructure:"metrics-push-period"`
+	MetricsPushUser   string        `mapstructure:"metrics-push-user"`
+	MetricsPushPass   string        `mapstructure:"metrics-push-pass"`
+	MetricsXorgID     string        `mapstructure:"metrics-push-xorg"`
 
 	ProfilerName string `mapstructure:"profiler-name"`
 	ProfilerURL  string `mapstructure:"profiler-url"`

--- a/config/config.go
+++ b/config/config.go
@@ -85,11 +85,11 @@ type BaseConfig struct {
 	CollectMetrics bool `mapstructure:"metrics"`
 	MetricsPort    int  `mapstructure:"metrics-port"`
 
-	MetricsPush       string        `mapstructure:"metrics-push"`
-	MetricsPushPeriod time.Duration `mapstructure:"metrics-push-period"`
-	MetricsPushUser   string        `mapstructure:"metrics-push-user"`
-	MetricsPushPass   string        `mapstructure:"metrics-push-pass"`
-	MetricsXorgID     string        `mapstructure:"metrics-push-xorg"`
+	MetricsPush       string            `mapstructure:"metrics-push"`
+	MetricsPushPeriod time.Duration     `mapstructure:"metrics-push-period"`
+	MetricsPushUser   string            `mapstructure:"metrics-push-user"`
+	MetricsPushPass   string            `mapstructure:"metrics-push-pass"`
+	MetricsPushHeader map[string]string `mapstructure:"metrics-push-header"`
 
 	ProfilerName string `mapstructure:"profiler-name"`
 	ProfilerURL  string `mapstructure:"profiler-url"`

--- a/config/mainnet.go
+++ b/config/mainnet.go
@@ -27,18 +27,6 @@ func MainnetConfig() Config {
 		panic(err)
 	}
 	p2pconfig := p2p.DefaultConfig()
-	p2pconfig.Bootnodes = []string{
-		"/dns4/mainnet-bootnode-0.spacemesh.network/tcp/5000/p2p/12D3KooWPStnitMbLyWAGr32gHmPr538mT658Thp6zTUujZt3LRf",
-		"/dns4/mainnet-bootnode-1.spacemesh.network/tcp/5000/p2p/12D3KooWJubSzXMJ6f1Fd1PgAFvuVeGFAsGe6tamH1733x4524gb",
-		"/dns4/mainnet-bootnode-2.spacemesh.network/tcp/5000/p2p/12D3KooWAsMgXLpyGdsRNjHBF3FaXwnXhyMEqWQYBXUpvCHNzFNK",
-		"/dns4/mainnet-bootnode-3.spacemesh.network/tcp/5000/p2p/12D3KooWLu9jbmTemp8eCzNvAFT88u7urfywYqQjXiBQAUCiFAFq",
-		"/dns4/mainnet-bootnode-4.spacemesh.network/tcp/5000/p2p/12D3KooWRcTWDHzptnhJn5h6CtwnokzzMaDLcXv6oM9CxQEXd5FL",
-		"/dns4/mainnet-bootnode-5.spacemesh.network/tcp/5000/p2p/12D3KooWP8fFtK7pfgdLRAZCwYsxC2pCxXDhnTiadtiCQdiyCouw",
-		"/dns4/mainnet-bootnode-6.spacemesh.network/tcp/5000/p2p/12D3KooWRS47KAs3ZLkBtE2AqjJCwxRYqZKmyLkvombJJdrca8Hz",
-		"/dns4/mainnet-bootnode-7.spacemesh.network/tcp/5000/p2p/12D3KooWNDCmQUoFPCUWbdYC2owaAXkVYQz7B37myTieiH7xzF6F",
-		"/dns4/mainnet-bootnode-8.spacemesh.network/tcp/5000/p2p/12D3KooWFYv99aGbtXnZQy6UZxyf72NpkWJp3K4HS8Py35WhKtzE",
-		"/dns4/mainnet-bootnode-9.spacemesh.network/tcp/5000/p2p/12D3KooWRQ9VPotEBjmAxBeTnnLqQgXLi1vvt4nMwo5E3Smt5bXP",
-	}
 	return Config{
 		BaseConfig: BaseConfig{
 			DataDirParent:       defaultDataDir,

--- a/config/mainnet.go
+++ b/config/mainnet.go
@@ -26,7 +26,19 @@ func MainnetConfig() Config {
 	if err := postPowDifficulty.UnmarshalText([]byte("00037ec8ec25e6d2c00000000000000000000000000000000000000000000000")); err != nil {
 		panic(err)
 	}
-
+	p2pconfig := p2p.DefaultConfig()
+	p2pconfig.Bootnodes = []string{
+		"/dns4/mainnet-bootnode-0.spacemesh.network/tcp/5000/p2p/12D3KooWPStnitMbLyWAGr32gHmPr538mT658Thp6zTUujZt3LRf",
+		"/dns4/mainnet-bootnode-1.spacemesh.network/tcp/5000/p2p/12D3KooWJubSzXMJ6f1Fd1PgAFvuVeGFAsGe6tamH1733x4524gb",
+		"/dns4/mainnet-bootnode-2.spacemesh.network/tcp/5000/p2p/12D3KooWAsMgXLpyGdsRNjHBF3FaXwnXhyMEqWQYBXUpvCHNzFNK",
+		"/dns4/mainnet-bootnode-3.spacemesh.network/tcp/5000/p2p/12D3KooWLu9jbmTemp8eCzNvAFT88u7urfywYqQjXiBQAUCiFAFq",
+		"/dns4/mainnet-bootnode-4.spacemesh.network/tcp/5000/p2p/12D3KooWRcTWDHzptnhJn5h6CtwnokzzMaDLcXv6oM9CxQEXd5FL",
+		"/dns4/mainnet-bootnode-5.spacemesh.network/tcp/5000/p2p/12D3KooWP8fFtK7pfgdLRAZCwYsxC2pCxXDhnTiadtiCQdiyCouw",
+		"/dns4/mainnet-bootnode-6.spacemesh.network/tcp/5000/p2p/12D3KooWRS47KAs3ZLkBtE2AqjJCwxRYqZKmyLkvombJJdrca8Hz",
+		"/dns4/mainnet-bootnode-7.spacemesh.network/tcp/5000/p2p/12D3KooWNDCmQUoFPCUWbdYC2owaAXkVYQz7B37myTieiH7xzF6F",
+		"/dns4/mainnet-bootnode-8.spacemesh.network/tcp/5000/p2p/12D3KooWFYv99aGbtXnZQy6UZxyf72NpkWJp3K4HS8Py35WhKtzE",
+		"/dns4/mainnet-bootnode-9.spacemesh.network/tcp/5000/p2p/12D3KooWRQ9VPotEBjmAxBeTnnLqQgXLi1vvt4nMwo5E3Smt5bXP",
+	}
 	return Config{
 		BaseConfig: BaseConfig{
 			DataDirParent:       defaultDataDir,
@@ -45,9 +57,17 @@ func MainnetConfig() Config {
 			OptFilterThreshold: 90,
 
 			TickSize: 9331200,
+			PoETServers: []string{
+				"https://mainnet-poet-0.spacemesh.network",
+				"https://mainnet-poet-1.spacemesh.network",
+				"https://mainnet-poet-2.spacemesh.network",
+				"https://poet-110.spacemesh.network",
+				"https://poet-111.spacemesh.network",
+			},
 		},
 		Genesis: &GenesisConfig{
 			GenesisTime: "2023-07-14T08:00:00Z",
+			ExtraData:   "00000000000000000001a6bc150307b5c1998045752b3c87eccf3c013036f3cc",
 			Accounts:    MainnetAccounts(),
 		},
 		Tortoise: tortoise.Config{
@@ -105,7 +125,7 @@ func MainnetConfig() Config {
 			DataDir:  os.TempDir(),
 			Interval: 30 * time.Second,
 		},
-		P2P:      p2p.DefaultConfig(),
+		P2P:      p2pconfig,
 		API:      grpcserver.DefaultConfig(),
 		TIME:     timeConfig.DefaultConfig(),
 		SMESHING: DefaultSmeshingConfig(),

--- a/metrics/public/public.go
+++ b/metrics/public/public.go
@@ -12,4 +12,18 @@ var (
 		Namespace: "smh",
 		Name:      "connections",
 	}, []string{"dir"})
+	initSize = promauto.With(Registry).NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "smh",
+		Name:      "init_size",
+	}, []string{"step"})
+	InitStart   = initSize.WithLabelValues("start")
+	InitEnd     = initSize.WithLabelValues("complete")
+	PostSeconds = promauto.With(Registry).NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "smh",
+		Name:      "post_seconds",
+	}, []string{}).WithLabelValues()
+	Version = promauto.With(Registry).NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "smh",
+		Name:      "version",
+	}, []string{"version"})
 )

--- a/metrics/public/public.go
+++ b/metrics/public/public.go
@@ -1,0 +1,15 @@
+package public
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var Registry = prometheus.NewRegistry()
+
+var (
+	Connections = promauto.With(Registry).NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "smh",
+		Name:      "connections",
+	}, []string{"dir"})
+)

--- a/metrics/push.go
+++ b/metrics/push.go
@@ -12,9 +12,11 @@ import (
 
 // StartPushingMetrics begins pushing metrics to the url specified by the --metrics-push flag
 // with period specified by the --metrics-push-period flag.
-func StartPushingMetrics(url, username, password, xorg string, period time.Duration, nodeID, networkID string) {
+func StartPushingMetrics(url, username, password string, headers map[string]string, period time.Duration, nodeID, networkID string) {
 	header := http.Header{}
-	header.Add("X-Scope-OrgId", xorg)
+	for k, v := range headers {
+		header.Add(k, v)
+	}
 	pusher := push.New(url, "go-spacemesh").Gatherer(public.Registry).
 		Grouping("node", nodeID).
 		Grouping("network", networkID).

--- a/metrics/push.go
+++ b/metrics/push.go
@@ -1,29 +1,29 @@
 package metrics
 
 import (
+	"net/http"
 	"time"
 
-	stdprometheus "github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/push"
 
 	"github.com/spacemeshos/go-spacemesh/log"
+	"github.com/spacemeshos/go-spacemesh/metrics/public"
 )
 
 // StartPushingMetrics begins pushing metrics to the url specified by the --metrics-push flag
 // with period specified by the --metrics-push-period flag.
-func StartPushingMetrics(url, username, password string, periodSec int, nodeID, networkID string) {
-	period := time.Duration(periodSec) * time.Second
-	ticker := time.NewTicker(period)
-
-	pusher := push.New(url, "go-spacemesh").Gatherer(stdprometheus.DefaultGatherer).
-		Grouping("node_id", nodeID).
-		Grouping("network_id", networkID)
-
+func StartPushingMetrics(url, username, password, xorg string, period time.Duration, nodeID, networkID string) {
+	header := http.Header{}
+	header.Add("X-Scope-OrgId", xorg)
+	pusher := push.New(url, "go-spacemesh").Gatherer(public.Registry).
+		Grouping("node", nodeID).
+		Grouping("network", networkID).
+		Header(header)
 	if username != "" && password != "" {
-		pusher.BasicAuth(username, password)
+		pusher = pusher.BasicAuth(username, password)
 	}
-
 	go func() {
+		ticker := time.NewTicker(period)
 		for range ticker.C {
 			err := pusher.Push()
 			if err != nil {

--- a/node/node.go
+++ b/node/node.go
@@ -54,6 +54,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/malfeasance"
 	"github.com/spacemeshos/go-spacemesh/mesh"
 	"github.com/spacemeshos/go-spacemesh/metrics"
+	"github.com/spacemeshos/go-spacemesh/metrics/public"
 	"github.com/spacemeshos/go-spacemesh/miner"
 	"github.com/spacemeshos/go-spacemesh/node/mapstructureutil"
 	"github.com/spacemeshos/go-spacemesh/p2p"
@@ -453,9 +454,9 @@ func (app *App) Initialize() error {
 	timeCfg.TimeConfigValues = app.Config.TIME
 
 	app.setupLogging()
-
 	app.introduction()
 
+	public.Version.WithLabelValues(cmd.Version).Set(1)
 	return nil
 }
 

--- a/node/node.go
+++ b/node/node.go
@@ -1374,9 +1374,13 @@ func (app *App) Start(ctx context.Context) error {
 	}
 
 	if app.Config.MetricsPush != "" {
-		metrics.StartPushingMetrics(app.Config.MetricsPush,
-			app.Config.MetricsPushUser, app.Config.MetricsPushPass, app.Config.MetricsPushPeriod,
-			app.host.ID().String(), app.Config.Genesis.GenesisID().ShortString())
+		metrics.StartPushingMetrics(
+			app.Config.MetricsPush,
+			app.Config.MetricsPushUser,
+			app.Config.MetricsPushPass,
+			app.Config.MetricsXorgID,
+			app.Config.MetricsPushPeriod,
+			app.host.ID().ShortString(), app.Config.Genesis.GenesisID().ShortString())
 	}
 
 	if err := app.startServices(ctx); err != nil {

--- a/node/node.go
+++ b/node/node.go
@@ -1379,7 +1379,7 @@ func (app *App) Start(ctx context.Context) error {
 			app.Config.MetricsPush,
 			app.Config.MetricsPushUser,
 			app.Config.MetricsPushPass,
-			app.Config.MetricsXorgID,
+			app.Config.MetricsPushHeader,
 			app.Config.MetricsPushPeriod,
 			app.host.ID().String()[:5], app.Config.Genesis.GenesisID().ShortString())
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -1380,7 +1380,7 @@ func (app *App) Start(ctx context.Context) error {
 			app.Config.MetricsPushPass,
 			app.Config.MetricsXorgID,
 			app.Config.MetricsPushPeriod,
-			app.host.ID().ShortString(), app.Config.Genesis.GenesisID().ShortString())
+			app.host.ID().String()[:5], app.Config.Genesis.GenesisID().ShortString())
 	}
 
 	if err := app.startServices(ctx); err != nil {

--- a/p2p/host_test.go
+++ b/p2p/host_test.go
@@ -2,9 +2,11 @@ package p2p
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/libp2p/go-libp2p/core/peer"
+	rcmgr "github.com/libp2p/go-libp2p/p2p/host/resource-manager"
 	"github.com/stretchr/testify/require"
 
 	"github.com/spacemeshos/go-spacemesh/log/logtest"
@@ -27,4 +29,13 @@ func TestPrologue(t *testing.T) {
 		Addrs: h2.Addrs(),
 	})
 	require.ErrorContains(t, err, "failed to negotiate security protocol")
+}
+
+func TestLimits(t *testing.T) {
+	limits := rcmgr.DefaultLimits
+	limits.SystemBaseLimit.ConnsInbound = 2048
+	l1 := limits.Scale((64<<30)/4, 1048576/2)
+	fmt.Printf("%+v\n", l1)
+	// {system:{Streams:18432 StreamsInbound:9216 StreamsOutbound:18432 Conns:1152 ConnsInbound:576 ConnsOutbound:1152 FD:524288 Memory:8724152320} transient:{Streams:2304 StreamsInbound:1152 StreamsOutbound:2304 Conns:320 ConnsInbound:160 ConnsOutbound:320 FD:131072 Memory:1107296256} allowlistedSystem:{Streams:18432 StreamsInbound:9216 StreamsOutbound:18432 Conns:1152 ConnsInbound:576 ConnsOutbound:1152 FD:524288 Memory:8724152320} allowlistedTransient:{Streams:2304 StreamsInbound:1152 StreamsOutbound:2304 Conns:320 ConnsInbound:160 ConnsOutbound:320 FD:131072 Memory:1107296256} serviceDefault:{Streams:20480 StreamsInbound:5120 StreamsOutbound:20480 Conns:0 ConnsInbound:0 ConnsOutbound:0 FD:0 Memory:1140850688} service:map[] servicePeerDefault:{Streams:320 StreamsInbound:160 StreamsOutbound:320 Conns:0 ConnsInbound:0 ConnsOutbound:0 FD:0 Memory:50331648} servicePeer:map[] protocolDefault:{Streams:6144 StreamsInbound:2560 StreamsOutbound:6144 Conns:0 ConnsInbound:0 ConnsOutbound:0 FD:0 Memory:1442840576} protocol:map[] protocolPeerDefault:{Streams:384 StreamsInbound:96 StreamsOutbound:192 Conns:0 ConnsInbound:0 ConnsOutbound:0 FD:0 Memory:16777248} protocolPeer:map[] peerDefault:{Streams:2560 StreamsInbound:1280 StreamsOutbound:2560 Conns:8 ConnsInbound:8 ConnsOutbound:8 FD:8192 Memory:1140850688} peer:map[] conn:{Streams:0 StreamsInbound:0 StreamsOutbound:0 Conns:1 ConnsInbound:1 ConnsOutbound:1 FD:1 Memory:33554432} stream:{Streams:1 StreamsInbound:1 StreamsOutbound:1 Conns:0 ConnsInbound:0 ConnsOutbound:0 FD:0 Memory:16777216}}
+
 }

--- a/p2p/host_test.go
+++ b/p2p/host_test.go
@@ -2,11 +2,9 @@ package p2p
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/libp2p/go-libp2p/core/peer"
-	rcmgr "github.com/libp2p/go-libp2p/p2p/host/resource-manager"
 	"github.com/stretchr/testify/require"
 
 	"github.com/spacemeshos/go-spacemesh/log/logtest"
@@ -29,13 +27,4 @@ func TestPrologue(t *testing.T) {
 		Addrs: h2.Addrs(),
 	})
 	require.ErrorContains(t, err, "failed to negotiate security protocol")
-}
-
-func TestLimits(t *testing.T) {
-	limits := rcmgr.DefaultLimits
-	limits.SystemBaseLimit.ConnsInbound = 2048
-	l1 := limits.Scale((64<<30)/4, 1048576/2)
-	fmt.Printf("%+v\n", l1)
-	// {system:{Streams:18432 StreamsInbound:9216 StreamsOutbound:18432 Conns:1152 ConnsInbound:576 ConnsOutbound:1152 FD:524288 Memory:8724152320} transient:{Streams:2304 StreamsInbound:1152 StreamsOutbound:2304 Conns:320 ConnsInbound:160 ConnsOutbound:320 FD:131072 Memory:1107296256} allowlistedSystem:{Streams:18432 StreamsInbound:9216 StreamsOutbound:18432 Conns:1152 ConnsInbound:576 ConnsOutbound:1152 FD:524288 Memory:8724152320} allowlistedTransient:{Streams:2304 StreamsInbound:1152 StreamsOutbound:2304 Conns:320 ConnsInbound:160 ConnsOutbound:320 FD:131072 Memory:1107296256} serviceDefault:{Streams:20480 StreamsInbound:5120 StreamsOutbound:20480 Conns:0 ConnsInbound:0 ConnsOutbound:0 FD:0 Memory:1140850688} service:map[] servicePeerDefault:{Streams:320 StreamsInbound:160 StreamsOutbound:320 Conns:0 ConnsInbound:0 ConnsOutbound:0 FD:0 Memory:50331648} servicePeer:map[] protocolDefault:{Streams:6144 StreamsInbound:2560 StreamsOutbound:6144 Conns:0 ConnsInbound:0 ConnsOutbound:0 FD:0 Memory:1442840576} protocol:map[] protocolPeerDefault:{Streams:384 StreamsInbound:96 StreamsOutbound:192 Conns:0 ConnsInbound:0 ConnsOutbound:0 FD:0 Memory:16777248} protocolPeer:map[] peerDefault:{Streams:2560 StreamsInbound:1280 StreamsOutbound:2560 Conns:8 ConnsInbound:8 ConnsOutbound:8 FD:8192 Memory:1140850688} peer:map[] conn:{Streams:0 StreamsInbound:0 StreamsOutbound:0 Conns:1 ConnsInbound:1 ConnsOutbound:1 FD:1 Memory:33554432} stream:{Streams:1 StreamsInbound:1 StreamsOutbound:1 Conns:0 ConnsInbound:0 ConnsOutbound:0 FD:0 Memory:16777216}}
-
 }

--- a/p2p/metrics/connections.go
+++ b/p2p/metrics/connections.go
@@ -7,6 +7,7 @@ import (
 	ma "github.com/multiformats/go-multiaddr"
 
 	"github.com/spacemeshos/go-spacemesh/metrics"
+	"github.com/spacemeshos/go-spacemesh/metrics/public"
 )
 
 var (
@@ -52,12 +53,14 @@ func (c *ConnectionsMeeter) Listen(network.Network, ma.Multiaddr) {}
 func (c *ConnectionsMeeter) ListenClose(network.Network, ma.Multiaddr) {}
 
 // Connected called when a connection opened.
-func (c *ConnectionsMeeter) Connected(network.Network, network.Conn) {
+func (c *ConnectionsMeeter) Connected(_ network.Network, conn network.Conn) {
+	public.Connections.WithLabelValues(conn.Stat().Direction.String()).Inc()
 	connections.WithLabelValues().Inc()
 }
 
 // Disconnected called when a connection closed.
-func (c *ConnectionsMeeter) Disconnected(network.Network, network.Conn) {
+func (c *ConnectionsMeeter) Disconnected(_ network.Network, conn network.Conn) {
+	public.Connections.WithLabelValues(conn.Stat().Direction.String()).Dec()
 	connections.WithLabelValues().Dec()
 }
 

--- a/p2p/metrics/connections.go
+++ b/p2p/metrics/connections.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"strings"
 	"time"
 
 	"github.com/libp2p/go-libp2p/core/network"
@@ -54,13 +55,13 @@ func (c *ConnectionsMeeter) ListenClose(network.Network, ma.Multiaddr) {}
 
 // Connected called when a connection opened.
 func (c *ConnectionsMeeter) Connected(_ network.Network, conn network.Conn) {
-	public.Connections.WithLabelValues(conn.Stat().Direction.String()).Inc()
+	public.Connections.WithLabelValues(strings.ToLower(conn.Stat().Direction.String())).Inc()
 	connections.WithLabelValues().Inc()
 }
 
 // Disconnected called when a connection closed.
 func (c *ConnectionsMeeter) Disconnected(_ network.Network, conn network.Conn) {
-	public.Connections.WithLabelValues(conn.Stat().Direction.String()).Dec()
+	public.Connections.WithLabelValues(strings.ToLower(conn.Stat().Direction.String())).Dec()
 	connections.WithLabelValues().Dec()
 }
 


### PR DESCRIPTION
subset of metrics to record:
- connections
- version
- init size started / completed
- post proof time

they will be recorded with 5 first characters from p2p public key, we probably don't want to gather information about smesher key.

example config:
```json
{
    "main": {
        "metrics-push": "https://public-metrics-gateway.spacemesh.dev/",
        "metrics-push-period": "1s",
        "metrics-push-user": "XXX",
        "metrics-push-pass": "XXXXXX",
        "metrics-push-header": {
            "X-Scope-OrgId": "XXXXXXX"
        }
    }
}
```