### PR TITLE
[Merged by Bors] - Fix misleading error

### DIFF
--- a/activation/activation.go
+++ b/activation/activation.go
@@ -527,9 +527,11 @@ func (b *Builder) PublishActivationTx(ctx context.Context) error {
 
 	challenge, err := b.loadChallenge()
 	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			logger.With().Error("failed to load atx challenge", log.Err(err))
+		}
 		logger.With().Info("building new atx challenge",
 			log.Stringer("current_epoch", b.currentEpoch()),
-			log.Err(err),
 		)
 		challenge, err = b.buildNIPostChallenge(ctx)
 		if err != nil {

--- a/activation/activation.go
+++ b/activation/activation.go
@@ -528,7 +528,7 @@ func (b *Builder) PublishActivationTx(ctx context.Context) error {
 	challenge, err := b.loadChallenge()
 	if err != nil {
 		if !errors.Is(err, os.ErrNotExist) {
-			logger.With().Error("failed to load atx challenge", log.Err(err))
+			logger.With().Warning("failed to load atx challenge", log.Err(err))
 		}
 		logger.With().Info("building new atx challenge",
 			log.Stringer("current_epoch", b.currentEpoch()),

--- a/activation/nipost_state.go
+++ b/activation/nipost_state.go
@@ -64,6 +64,9 @@ func read(path string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to get file info %s: %w", path, err)
 	}
+	if fInfo.Size() < crc64.Size {
+		return nil, fmt.Errorf("file %s is too small", path)
+	}
 
 	data := make([]byte, fInfo.Size()-crc64.Size)
 	checksum := crc64.New(crc64.MakeTable(crc64.ISO))

--- a/activation/nipost_state_test.go
+++ b/activation/nipost_state_test.go
@@ -58,6 +58,16 @@ func TestReadCRC(t *testing.T) {
 			data:   []byte("spacemesh"),
 			crc:    []byte{0xC7, 0x11, 0x73, 0xE0, 0x53, 0xD8, 0x75, 0x0F},
 			errMsg: "wrong checksum 0xC71173E053D8750F, computed 0xC61072DF52D7740E",
+		}, {
+			name:   "file too short",
+			data:   []byte("123"),
+			crc:    []byte{},
+			errMsg: "too small",
+		}, {
+			name:   "file empty",
+			data:   []byte(""),
+			crc:    []byte{0xC6, 0x10, 0x72, 0xDF, 0x52, 0xD7, 0x74, 0x0E},
+			errMsg: "wrong checksum 0xC61072DF52D7740E, computed 0x0",
 		},
 	}
 

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -410,6 +410,7 @@ func TestSpacemeshApp_JsonService(t *testing.T) {
 
 // E2E app test of the stream endpoints in the NodeService.
 func TestSpacemeshApp_NodeService(t *testing.T) {
+	t.Skip("flaky on macos-latest: https://github.com/spacemeshos/go-spacemesh/issues/4729")
 	// errlog should be used only for testing.
 	logger := logtest.New(t)
 	errlog := log.RegisterHooks(logtest.New(t, zap.ErrorLevel), events.EventHook())


### PR DESCRIPTION
## Motivation
Users often get confused by the log message when the nipost_challenge.bin doesn't exist. This is a normal situation, yet the log includes "errormsg".

## Changes
Don't log an error in case the file is not found.

Additionally, includes a fix for a bug discovered during testing. The code panicked when the file was too small (for example empty).

## Test Plan
- UT
- [x] manual test