### PR TITLE
[Merged by Bors] - fix flaky test: TestSpacemeshApp_NodeService

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,11 +102,11 @@ jobs:
       fail-fast: true
       matrix:
         os:
-          # - ubuntu-latest
-          # - [self-hosted, linux, arm64]
+          - ubuntu-latest
+          - [self-hosted, linux, arm64]
           - macos-latest
-          # - [self-hosted, macos, arm64]
-          # - windows-latest
+          - [self-hosted, macos, arm64]
+          - windows-latest
     steps:
       - name: Add OpenCL support - Ubuntu
         if: ${{ matrix.os == 'ubuntu-latest' }}
@@ -140,10 +140,10 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          # - ubuntu-latest
-          # - [self-hosted, linux, arm64]
+          - ubuntu-latest
+          - [self-hosted, linux, arm64]
           - macos-latest
-          # - [self-hosted, macos, arm64]
+          - [self-hosted, macos, arm64]
     steps:
       # as we use some request to localhost, sometimes it gives us flaky tests. try to disable tcp offloading for fix it
       # https://github.com/actions/virtual-environments/issues/1187

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,11 +102,11 @@ jobs:
       fail-fast: true
       matrix:
         os:
-          - ubuntu-latest
-          - [self-hosted, linux, arm64]
+          # - ubuntu-latest
+          # - [self-hosted, linux, arm64]
           - macos-latest
-          - [self-hosted, macos, arm64]
-          - windows-latest
+          # - [self-hosted, macos, arm64]
+          # - windows-latest
     steps:
       - name: Add OpenCL support - Ubuntu
         if: ${{ matrix.os == 'ubuntu-latest' }}
@@ -140,10 +140,10 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-latest
-          - [self-hosted, linux, arm64]
+          # - ubuntu-latest
+          # - [self-hosted, linux, arm64]
           - macos-latest
-          - [self-hosted, macos, arm64]
+          # - [self-hosted, macos, arm64]
     steps:
       # as we use some request to localhost, sometimes it gives us flaky tests. try to disable tcp offloading for fix it
       # https://github.com/actions/virtual-environments/issues/1187

--- a/activation/activation.go
+++ b/activation/activation.go
@@ -320,13 +320,19 @@ func (b *Builder) verifyInitialPost(ctx context.Context, post *types.Post, metad
 	if err != nil {
 		b.log.With().Panic("failed to fetch commitment ATX ID.", log.Err(err))
 	}
-	if err := b.validator.Post(ctx, types.EpochID(0), b.nodeID, commitmentAtxId, post, metadata, b.postSetupProvider.LastOpts().NumUnits); err != nil {
+	err = b.validator.Post(ctx, types.EpochID(0), b.nodeID, commitmentAtxId, post, metadata, b.postSetupProvider.LastOpts().NumUnits)
+	switch {
+	case errors.Is(err, context.Canceled):
+		// If the context was canceled, we don't want to emit or log errors just propagate the cancellation signal.
+		return err
+	case err != nil:
 		events.EmitInvalidPostProof()
 		b.log.With().Fatal("initial POST proof is invalid. Probably the initialized POST data is corrupted. Please verify the data with postcli and regenerate the corrupted files.", log.Err(err))
 		return err
+	default:
+		b.initialPost = post
+		return nil
 	}
-	b.initialPost = post
-	return nil
 }
 
 func (b *Builder) receivePendingPoetClients() *[]PoetProvingServiceClient {

--- a/node/bad_peer_test.go
+++ b/node/bad_peer_test.go
@@ -127,7 +127,8 @@ func NewApp(conf *config.Config) (*App, error) {
 		WithConfig(conf),
 		WithLog(log.RegisterHooks(
 			log.NewWithLevel("", zap.NewAtomicLevelAt(zapcore.DebugLevel)),
-			events.EventHook())),
+			events.EventHook()),
+		),
 	)
 
 	var err error

--- a/node/node.go
+++ b/node/node.go
@@ -130,8 +130,9 @@ func GetCommand() *cobra.Command {
 				// NOTE(dshulyak) this needs to be max level so that child logger can can be current level or below.
 				// otherwise it will fail later when child logger will try to increase level.
 				WithLog(log.RegisterHooks(
-					log.NewWithLevel("", zap.NewAtomicLevelAt(zap.InfoLevel)),
-					events.EventHook())),
+					log.NewWithLevel("node", zap.NewAtomicLevelAt(zap.InfoLevel)),
+					events.EventHook()),
+				),
 			)
 
 			run := func(ctx context.Context) error {

--- a/node/node.go
+++ b/node/node.go
@@ -1192,6 +1192,10 @@ func (app *App) stopServices(ctx context.Context) {
 	}
 
 	events.CloseEventReporter()
+	// SetGrpcLogger unfortunately is global
+	// this ensures that a test-logger isn't used after the app shuts down
+	// by e.g. a grpc connection to the node that is still open - like in TestSpacemeshApp_NodeService
+	grpczap.SetGrpcLoggerV2(grpclog, log.NewNop().Zap())
 }
 
 // LoadOrCreateEdSigner either loads a previously created ed identity for the node or creates a new one if not exists.

--- a/node/node.go
+++ b/node/node.go
@@ -130,7 +130,7 @@ func GetCommand() *cobra.Command {
 				// NOTE(dshulyak) this needs to be max level so that child logger can can be current level or below.
 				// otherwise it will fail later when child logger will try to increase level.
 				WithLog(log.RegisterHooks(
-					log.NewWithLevel("", zap.NewAtomicLevelAt(zapcore.DebugLevel)),
+					log.NewWithLevel("", zap.NewAtomicLevelAt(zap.InfoLevel)),
 					events.EventHook())),
 			)
 
@@ -293,8 +293,7 @@ func New(opts ...Option) *App {
 	for _, opt := range opts {
 		opt(app)
 	}
-	lvl := zap.NewAtomicLevelAt(zap.InfoLevel)
-	log.SetupGlobal(app.log.SetLevel(&lvl))
+	log.SetupGlobal(app.log)
 	types.SetNetworkHRP(app.Config.NetworkHRP)
 	return app
 }

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -412,22 +412,24 @@ func TestSpacemeshApp_JsonService(t *testing.T) {
 func TestSpacemeshApp_NodeService(t *testing.T) {
 	t.Skip("flaky on macos-latest: https://github.com/spacemeshos/go-spacemesh/issues/4729")
 	// errlog should be used only for testing.
-	logger := logtest.New(t)
-	errlog := log.RegisterHooks(logtest.New(t, zap.ErrorLevel), events.EventHook())
+	logger := logtest.New(t, zapcore.DebugLevel)
+	errlog := log.RegisterHooks(logger, events.EventHook())
 
 	// Use a unique port
 	port := 1240
 
+	var err error
 	app := New(WithLog(logger))
 	app.Config = getTestDefaultConfig(t)
 	app.Config.SMESHING.CoinbaseAccount = types.GenerateAddress([]byte{1}).String()
-	app.Config.SMESHING.Opts.DataDir, _ = os.MkdirTemp("", "sm-app-test-post-datadir")
+	app.Config.SMESHING.Opts.DataDir, err = os.MkdirTemp("", "sm-app-test-post-datadir")
+	require.NoError(t, err)
 
 	clock, err := timesync.NewClock(
 		timesync.WithLayerDuration(1*time.Second),
 		timesync.WithTickInterval(100*time.Millisecond),
 		timesync.WithGenesisTime(time.Now()),
-		timesync.WithLogger(logtest.New(t)),
+		timesync.WithLogger(logger),
 	)
 	require.NoError(t, err)
 	app.clock = clock

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -410,7 +410,7 @@ func TestSpacemeshApp_JsonService(t *testing.T) {
 
 // E2E app test of the stream endpoints in the NodeService.
 func TestSpacemeshApp_NodeService(t *testing.T) {
-	logger := logtest.New(t, zapcore.InfoLevel)
+	logger := logtest.New(t, zapcore.ErrorLevel)
 
 	// Use a unique port
 	port := 1240
@@ -512,7 +512,7 @@ func TestSpacemeshApp_NodeService(t *testing.T) {
 	require.NoError(t, err)
 
 	// Report two errors and make sure they're both received
-	errlog := log.RegisterHooks(logtest.New(t, zapcore.InfoLevel), events.EventHook())
+	errlog := log.RegisterHooks(logger, events.EventHook())
 	eg.Go(func() error {
 		errlog.Error("test123")
 		errlog.Error("test456")

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -411,6 +411,7 @@ func TestSpacemeshApp_JsonService(t *testing.T) {
 // E2E app test of the stream endpoints in the NodeService.
 func TestSpacemeshApp_NodeService(t *testing.T) {
 	logger := logtest.New(t, zapcore.ErrorLevel)
+	errlog := log.RegisterHooks(logger, events.EventHook()) // errlog is used to simulate errors in the app
 
 	// Use a unique port
 	port := 1240
@@ -512,7 +513,6 @@ func TestSpacemeshApp_NodeService(t *testing.T) {
 	require.NoError(t, err)
 
 	// Report two errors and make sure they're both received
-	errlog := log.RegisterHooks(logger, events.EventHook())
 	eg.Go(func() error {
 		errlog.Error("test123")
 		errlog.Error("test456")

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/proto"
-	grpczap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap"
 	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
 	pb "github.com/spacemeshos/api/release/go/spacemesh/v1"
 	"github.com/spacemeshos/post/initialization"
@@ -480,10 +479,7 @@ func TestSpacemeshApp_NodeService(t *testing.T) {
 		grpc.WithBlock(),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() {
-		assert.NoError(t, conn.Close())
-		grpczap.SetGrpcLoggerV2(grpclog, log.NewNop().Zap())
-	})
+	t.Cleanup(func() { assert.NoError(t, conn.Close()) })
 	c := pb.NewNodeServiceClient(conn)
 
 	eg.Go(func() error {

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -416,12 +416,10 @@ func TestSpacemeshApp_NodeService(t *testing.T) {
 	// Use a unique port
 	port := 1240
 
-	var err error
 	app := New(WithLog(logger))
 	app.Config = getTestDefaultConfig(t)
 	app.Config.SMESHING.CoinbaseAccount = types.GenerateAddress([]byte{1}).String()
-	app.Config.SMESHING.Opts.DataDir, err = os.MkdirTemp("", "sm-app-test-post-datadir")
-	require.NoError(t, err)
+	app.Config.SMESHING.Opts.DataDir = t.TempDir()
 
 	clock, err := timesync.NewClock(
 		timesync.WithLayerDuration(1*time.Second),


### PR DESCRIPTION
## Motivation
Closes: https://github.com/spacemeshos/go-spacemesh/issues/4729

## Changes
- The app during initialization for set the logging level to `zapcore.InfoLevel` which overwrites what ever logging configuration is passed in via `WithLog`. This was fixed, the app still starts up with `zapcore.InfoLevel` by default.
- There has been an issue with logging in tests because the logging middleware for GRPC wasn't unset when the test ended which could result in components logging after the test ended and thereby failing a test. This is now done in `app.stopServices` (since it is set up in `app.startServices`)
- After making logs visible the issue was identified: the node is shut down while it verifies its own post proof. This only happens on the `macos-latest` runner because other runners might not have completed their initial post proof yet or are already done verifying it by that time.
   - Changed verifying to only emit and log errors when an error other than `context.Cancelled` is returned.
- These changes allowed me to run the test 100 times in a row without it failing a single time:

```
go test -v -timeout 150s -run ^TestSpacemeshApp_NodeService$ github.com/spacemeshos/go-spacemesh/node -count 100
```

passes without a single iteration of the test failing.

## Test Plan
n/a

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
