### PR TITLE
[Merged by Bors] - Bump post-rs to v0.4.1 - more logs during initialization

### DIFF
--- a/Makefile-libs.Inc
+++ b/Makefile-libs.Inc
@@ -50,7 +50,7 @@ else
 	endif
 endif
 
-POSTRS_SETUP_REV = 0.4.0
+POSTRS_SETUP_REV = 0.4.1
 POSTRS_SETUP_ZIP = libpost-$(platform)-v$(POSTRS_SETUP_REV).zip
 POSTRS_SETUP_URL_ZIP ?= https://github.com/spacemeshos/post-rs/releases/download/v$(POSTRS_SETUP_REV)/$(POSTRS_SETUP_ZIP)
 POSTRS_PROFILER_ZIP = profiler-$(platform)-v$(POSTRS_SETUP_REV).zip


### PR DESCRIPTION
## Motivation
Bump post-rs to new version, which includes more logs for better view into initialization process

Changelog in https://github.com/spacemeshos/post-rs/releases/tag/v0.4.1
