### PR TITLE
[Merged by Bors] - Clean up all files upon stop smeshing

### DIFF
--- a/activation/activation.go
+++ b/activation/activation.go
@@ -251,6 +251,19 @@ func (b *Builder) StopSmeshing(deleteFiles bool) error {
 			b.log.With().Error("failed to delete post files", log.Err(err))
 			return err
 		}
+		if err := discardBuilderState(b.nipostBuilder.DataDir()); err != nil {
+			b.log.With().Error("failed to delete builder state", log.Err(err))
+			return err
+		}
+		if err := discardNipostChallenge(b.nipostBuilder.DataDir()); err != nil {
+			b.log.With().Error("failed to delete nipost challenge", log.Err(err))
+			return err
+		}
+		if err := discardPost(b.nipostBuilder.DataDir()); err != nil {
+			b.log.With().Error("failed to delete post", log.Err(err))
+			return err
+		}
+
 		return nil
 	default:
 		return fmt.Errorf("failed to stop post data creation session: %w", err)

--- a/activation/activation.go
+++ b/activation/activation.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"sync"
 	"time"
@@ -251,15 +252,15 @@ func (b *Builder) StopSmeshing(deleteFiles bool) error {
 			b.log.With().Error("failed to delete post files", log.Err(err))
 			return err
 		}
-		if err := discardBuilderState(b.nipostBuilder.DataDir()); err != nil {
+		if err := discardBuilderState(b.nipostBuilder.DataDir()); err != nil && !errors.Is(err, fs.ErrNotExist) {
 			b.log.With().Error("failed to delete builder state", log.Err(err))
 			return err
 		}
-		if err := discardNipostChallenge(b.nipostBuilder.DataDir()); err != nil {
+		if err := discardNipostChallenge(b.nipostBuilder.DataDir()); err != nil && !errors.Is(err, fs.ErrNotExist) {
 			b.log.With().Error("failed to delete nipost challenge", log.Err(err))
 			return err
 		}
-		if err := discardPost(b.nipostBuilder.DataDir()); err != nil {
+		if err := discardPost(b.nipostBuilder.DataDir()); err != nil && !errors.Is(err, fs.ErrNotExist) {
 			b.log.With().Error("failed to delete post", log.Err(err))
 			return err
 		}

--- a/activation/nipost_state.go
+++ b/activation/nipost_state.go
@@ -153,6 +153,14 @@ func loadBuilderState(dir string) (*types.NIPostBuilderState, error) {
 	return &state, nil
 }
 
+func discardBuilderState(dir string) error {
+	filename := filepath.Join(dir, builderFilename)
+	if err := os.Remove(filename); err != nil {
+		return fmt.Errorf("discarding nipost builder state: %w", err)
+	}
+	return nil
+}
+
 func savePost(dir string, post *types.Post) error {
 	if err := save(filepath.Join(dir, postFilename), post); err != nil {
 		return fmt.Errorf("saving post: %w", err)
@@ -166,4 +174,12 @@ func loadPost(dir string) (*types.Post, error) {
 		return nil, fmt.Errorf("loading post: %w", err)
 	}
 	return &post, nil
+}
+
+func discardPost(dir string) error {
+	filename := filepath.Join(dir, postFilename)
+	if err := os.Remove(filename); err != nil {
+		return fmt.Errorf("discarding post: %w", err)
+	}
+	return nil
 }


### PR DESCRIPTION
## Motivation
To avoid publishing incorrect proofs after a user re-initializes cleanup all local state when `deleteFiles` is set to `true`.

## Changes
Delete all state not just post upon StopSmeshing { deleteFiles: true }.

## Test Plan
n/a

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
