### PR TITLE
[Merged by Bors] - config: add public metrics group

### DIFF
--- a/cmd/base.go
+++ b/cmd/base.go
@@ -165,6 +165,10 @@ func EnsureCLIFlags(cmd *cobra.Command, appCFG *config.Config) error {
 			ff = reflect.TypeOf(appCFG.TestConfig)
 			elem = reflect.ValueOf(&appCFG.TestConfig).Elem()
 			assignFields(ff, elem, name)
+
+			ff = reflect.TypeOf(appCFG.PublicMetrics)
+			elem = reflect.ValueOf(&appCFG.PublicMetrics).Elem()
+			assignFields(ff, elem, name)
 		}
 	})
 	return nil

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -42,10 +42,10 @@ func AddCommands(cmd *cobra.Command) {
 		cfg.CollectMetrics, "collect node metrics")
 	cmd.PersistentFlags().IntVar(&cfg.MetricsPort, "metrics-port",
 		cfg.MetricsPort, "metric server port")
-	cmd.PersistentFlags().StringVar(&cfg.MetricsPush, "metrics-push",
-		cfg.MetricsPush, "Push metrics to url")
-	cmd.PersistentFlags().DurationVar(&cfg.MetricsPushPeriod, "metrics-push-period",
-		cfg.MetricsPushPeriod, "Push period")
+	cmd.PersistentFlags().StringVar(&cfg.PublicMetrics.MetricsURL, "metrics-push",
+		cfg.PublicMetrics.MetricsURL, "Push metrics to url")
+	cmd.PersistentFlags().DurationVar(&cfg.PublicMetrics.MetricsPushPeriod, "metrics-push-period",
+		cfg.PublicMetrics.MetricsPushPeriod, "Push period")
 	cmd.PersistentFlags().StringArrayVar(&cfg.PoETServers, "poet-server",
 		cfg.PoETServers, "The poet server url. (temporary) Can be passed multiple times")
 	cmd.PersistentFlags().StringVar(&cfg.Genesis.GenesisTime, "genesis-time",

--- a/config/config.go
+++ b/config/config.go
@@ -85,11 +85,7 @@ type BaseConfig struct {
 	CollectMetrics bool `mapstructure:"metrics"`
 	MetricsPort    int  `mapstructure:"metrics-port"`
 
-	MetricsPush       string            `mapstructure:"metrics-push"`
-	MetricsPushPeriod time.Duration     `mapstructure:"metrics-push-period"`
-	MetricsPushUser   string            `mapstructure:"metrics-push-user"`
-	MetricsPushPass   string            `mapstructure:"metrics-push-pass"`
-	MetricsPushHeader map[string]string `mapstructure:"metrics-push-header"`
+	PublicMetrics PublicMetrics `mapstructure:"public-metrics"`
 
 	ProfilerName string `mapstructure:"profiler-name"`
 	ProfilerURL  string `mapstructure:"profiler-url"`
@@ -113,6 +109,14 @@ type BaseConfig struct {
 	DatabaseLatencyMetering bool `mapstructure:"db-latency-metering"`
 
 	NetworkHRP string `mapstructure:"network-hrp"`
+}
+
+type PublicMetrics struct {
+	MetricsURL        string            `mapstructure:"metrics-url"`
+	MetricsPushPeriod time.Duration     `mapstructure:"metrics-push-period"`
+	MetricsPushUser   string            `mapstructure:"metrics-push-user"`
+	MetricsPushPass   string            `mapstructure:"metrics-push-pass"`
+	MetricsPushHeader map[string]string `mapstructure:"metrics-push-header"`
 }
 
 // SmeshingConfig defines configuration for the node's smeshing (mining).
@@ -164,8 +168,6 @@ func defaultBaseConfig() BaseConfig {
 		FileLock:            filepath.Join(os.TempDir(), "spacemesh.lock"),
 		CollectMetrics:      false,
 		MetricsPort:         1010,
-		MetricsPush:         "", // "" = doesn't push
-		MetricsPushPeriod:   60,
 		ProfilerName:        "gp-spacemesh",
 		LayerDuration:       30 * time.Second,
 		LayersPerEpoch:      3,

--- a/config/mainnet.go
+++ b/config/mainnet.go
@@ -32,7 +32,6 @@ func MainnetConfig() Config {
 			DataDirParent:       defaultDataDir,
 			FileLock:            filepath.Join(os.TempDir(), "spacemesh.lock"),
 			MetricsPort:         1010,
-			MetricsPushPeriod:   60,
 			DatabaseConnections: 16,
 			NetworkHRP:          "sm",
 

--- a/node/node.go
+++ b/node/node.go
@@ -1380,13 +1380,13 @@ func (app *App) Start(ctx context.Context) error {
 		metrics.StartMetricsServer(app.Config.MetricsPort)
 	}
 
-	if app.Config.MetricsPush != "" {
+	if app.Config.PublicMetrics.MetricsURL != "" {
 		metrics.StartPushingMetrics(
-			app.Config.MetricsPush,
-			app.Config.MetricsPushUser,
-			app.Config.MetricsPushPass,
-			app.Config.MetricsPushHeader,
-			app.Config.MetricsPushPeriod,
+			app.Config.PublicMetrics.MetricsURL,
+			app.Config.PublicMetrics.MetricsPushUser,
+			app.Config.PublicMetrics.MetricsPushPass,
+			app.Config.PublicMetrics.MetricsPushHeader,
+			app.Config.PublicMetrics.MetricsPushPeriod,
 			app.host.ID().String()[:5], app.Config.Genesis.GenesisID().ShortString())
 	}
 


### PR DESCRIPTION
the config now is 
```json

{
    "public-metrics": {
        "metrics-push": "https://public-metrics-gateway.spacemesh.network",
        "metrics-push-period": "1s",
        "metrics-push-user": "xxx",
        "metrics-push-pass": "xxx",
        "metrics-push-header": {
          "X-Scope-OrgId": "xxx-xxx"
        }
    }
}
```


to disable either remove whole config, or set metrics-push value to empty string