### PR TITLE
Revert "fix flaky test: TestSpacemeshApp_NodeService (#4728)"

### DIFF
--- a/activation/activation.go
+++ b/activation/activation.go
@@ -320,19 +320,13 @@ func (b *Builder) verifyInitialPost(ctx context.Context, post *types.Post, metad
 	if err != nil {
 		b.log.With().Panic("failed to fetch commitment ATX ID.", log.Err(err))
 	}
-	err = b.validator.Post(ctx, types.EpochID(0), b.nodeID, commitmentAtxId, post, metadata, b.postSetupProvider.LastOpts().NumUnits)
-	switch {
-	case errors.Is(err, context.Canceled):
-		// If the context was canceled, we don't want to emit or log errors just propagate the cancellation signal.
-		return err
-	case err != nil:
+	if err := b.validator.Post(ctx, types.EpochID(0), b.nodeID, commitmentAtxId, post, metadata, b.postSetupProvider.LastOpts().NumUnits); err != nil {
 		events.EmitInvalidPostProof()
 		b.log.With().Fatal("initial POST proof is invalid. Probably the initialized POST data is corrupted. Please verify the data with postcli and regenerate the corrupted files.", log.Err(err))
 		return err
-	default:
-		b.initialPost = post
-		return nil
 	}
+	b.initialPost = post
+	return nil
 }
 
 func (b *Builder) receivePendingPoetClients() *[]PoetProvingServiceClient {

--- a/node/bad_peer_test.go
+++ b/node/bad_peer_test.go
@@ -127,8 +127,7 @@ func NewApp(conf *config.Config) (*App, error) {
 		WithConfig(conf),
 		WithLog(log.RegisterHooks(
 			log.NewWithLevel("", zap.NewAtomicLevelAt(zapcore.DebugLevel)),
-			events.EventHook()),
-		),
+			events.EventHook())),
 	)
 
 	var err error

--- a/node/node.go
+++ b/node/node.go
@@ -130,9 +130,8 @@ func GetCommand() *cobra.Command {
 				// NOTE(dshulyak) this needs to be max level so that child logger can can be current level or below.
 				// otherwise it will fail later when child logger will try to increase level.
 				WithLog(log.RegisterHooks(
-					log.NewWithLevel("node", zap.NewAtomicLevelAt(zap.InfoLevel)),
-					events.EventHook()),
-				),
+					log.NewWithLevel("", zap.NewAtomicLevelAt(zapcore.DebugLevel)),
+					events.EventHook())),
 			)
 
 			run := func(ctx context.Context) error {
@@ -294,7 +293,8 @@ func New(opts ...Option) *App {
 	for _, opt := range opts {
 		opt(app)
 	}
-	log.SetupGlobal(app.log)
+	lvl := zap.NewAtomicLevelAt(zap.InfoLevel)
+	log.SetupGlobal(app.log.SetLevel(&lvl))
 	types.SetNetworkHRP(app.Config.NetworkHRP)
 	return app
 }
@@ -1192,10 +1192,6 @@ func (app *App) stopServices(ctx context.Context) {
 	}
 
 	events.CloseEventReporter()
-	// SetGrpcLogger unfortunately is global
-	// this ensures that a test-logger isn't used after the app shuts down
-	// by e.g. a grpc connection to the node that is still open - like in TestSpacemeshApp_NodeService
-	grpczap.SetGrpcLoggerV2(grpclog, log.NewNop().Zap())
 }
 
 // LoadOrCreateEdSigner either loads a previously created ed identity for the node or creates a new one if not exists.

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -410,8 +410,10 @@ func TestSpacemeshApp_JsonService(t *testing.T) {
 
 // E2E app test of the stream endpoints in the NodeService.
 func TestSpacemeshApp_NodeService(t *testing.T) {
-	logger := logtest.New(t, zapcore.ErrorLevel)
-	errlog := log.RegisterHooks(logger, events.EventHook()) // errlog is used to simulate errors in the app
+	t.Skip("flaky on macos-latest: https://github.com/spacemeshos/go-spacemesh/issues/4729")
+	// errlog should be used only for testing.
+	logger := logtest.New(t)
+	errlog := log.RegisterHooks(logtest.New(t, zap.ErrorLevel), events.EventHook())
 
 	// Use a unique port
 	port := 1240
@@ -419,13 +421,13 @@ func TestSpacemeshApp_NodeService(t *testing.T) {
 	app := New(WithLog(logger))
 	app.Config = getTestDefaultConfig(t)
 	app.Config.SMESHING.CoinbaseAccount = types.GenerateAddress([]byte{1}).String()
-	app.Config.SMESHING.Opts.DataDir = t.TempDir()
+	app.Config.SMESHING.Opts.DataDir, _ = os.MkdirTemp("", "sm-app-test-post-datadir")
 
 	clock, err := timesync.NewClock(
 		timesync.WithLayerDuration(1*time.Second),
 		timesync.WithTickInterval(100*time.Millisecond),
 		timesync.WithGenesisTime(time.Now()),
-		timesync.WithLogger(logger),
+		timesync.WithLogger(logtest.New(t)),
 	)
 	require.NoError(t, err)
 	app.clock = clock


### PR DESCRIPTION
This reverts commit e91d7352d941718979438d9e37bfed9533008211.

debug logging can't be set with this change
