### PR TITLE
[Merged by Bors] - Fix debug logging

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -130,7 +130,7 @@ func GetCommand() *cobra.Command {
 				// NOTE(dshulyak) this needs to be max level so that child logger can can be current level or below.
 				// otherwise it will fail later when child logger will try to increase level.
 				WithLog(log.RegisterHooks(
-					log.NewWithLevel("node", zap.NewAtomicLevelAt(zap.InfoLevel)),
+					log.NewWithLevel("node", zap.NewAtomicLevelAt(zap.DebugLevel)),
 					events.EventHook()),
 				),
 			)
@@ -294,7 +294,12 @@ func New(opts ...Option) *App {
 	for _, opt := range opts {
 		opt(app)
 	}
-	log.SetupGlobal(app.log)
+	// TODO(mafa): this is a hack to suppress debugging logs on 0000.defaultLogger
+	// to fix this we should get rid of the global logger and pass app.log to all
+	// components that need it
+	lvl := zap.NewAtomicLevelAt(zap.InfoLevel)
+	log.SetupGlobal(app.log.SetLevel(&lvl))
+
 	types.SetNetworkHRP(app.Config.NetworkHRP)
 	return app
 }

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -410,8 +410,8 @@ func TestSpacemeshApp_JsonService(t *testing.T) {
 
 // E2E app test of the stream endpoints in the NodeService.
 func TestSpacemeshApp_NodeService(t *testing.T) {
-	logger := logtest.New(t, zapcore.ErrorLevel)
-	errlog := log.RegisterHooks(logger, events.EventHook()) // errlog is used to simulate errors in the app
+	logger := logtest.New(t)
+	errlog := log.RegisterHooks(logtest.New(t, zap.ErrorLevel), events.EventHook()) // errlog is used to simulate errors in the app
 
 	// Use a unique port
 	port := 1240


### PR DESCRIPTION
## Motivation
#4728 broke debug logging, this reverts part of the PR to make it possible to log debug messages again when enabled via config.

## Changes
Revert some changes from #4728 

## Test Plan
n/a

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
