### PR TITLE
[Merged by Bors] - Remove global logger

### DIFF
--- a/activation/nipost_test.go
+++ b/activation/nipost_test.go
@@ -113,7 +113,6 @@ func TestPostSetup(t *testing.T) {
 
 func TestNIPostBuilderWithClients(t *testing.T) {
 	t.Parallel()
-	logtest.SetupGlobal(t)
 
 	challenge := types.NIPostChallenge{
 		PublishEpoch: postGenesisEpoch + 2,

--- a/api/grpcserver/activation_service_test.go
+++ b/api/grpcserver/activation_service_test.go
@@ -15,13 +15,14 @@ import (
 
 	"github.com/spacemeshos/go-spacemesh/api/grpcserver"
 	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/log/logtest"
 )
 
 func Test_Highest_ReturnsGoldenAtxOnError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	atxProvider := grpcserver.NewMockatxProvider(ctrl)
 	goldenAtx := types.ATXID{2, 3, 4}
-	activationService := grpcserver.NewActivationService(atxProvider, goldenAtx)
+	activationService := grpcserver.NewActivationService(atxProvider, goldenAtx, logtest.New(t).WithName("grpc.Activation"))
 
 	atxProvider.EXPECT().MaxHeightAtx().Return(types.EmptyATXID, errors.New("blah"))
 	response, err := activationService.Highest(context.Background(), &empty.Empty{})
@@ -39,7 +40,7 @@ func Test_Highest_ReturnsMaxTickHeight(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	atxProvider := grpcserver.NewMockatxProvider(ctrl)
 	goldenAtx := types.ATXID{2, 3, 4}
-	activationService := grpcserver.NewActivationService(atxProvider, goldenAtx)
+	activationService := grpcserver.NewActivationService(atxProvider, goldenAtx, logtest.New(t).WithName("grpc.Activation"))
 
 	atx := types.VerifiedActivationTx{
 		ActivationTx: &types.ActivationTx{
@@ -74,7 +75,7 @@ func Test_Highest_ReturnsMaxTickHeight(t *testing.T) {
 func TestGet_RejectInvalidAtxID(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	atxProvider := grpcserver.NewMockatxProvider(ctrl)
-	activationService := grpcserver.NewActivationService(atxProvider, types.ATXID{1})
+	activationService := grpcserver.NewActivationService(atxProvider, types.ATXID{1}, logtest.New(t).WithName("grpc.Activation"))
 
 	_, err := activationService.Get(context.Background(), &pb.GetRequest{Id: []byte{1, 2, 3}})
 	require.Error(t, err)
@@ -84,7 +85,7 @@ func TestGet_RejectInvalidAtxID(t *testing.T) {
 func TestGet_AtxNotPresent(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	atxProvider := grpcserver.NewMockatxProvider(ctrl)
-	activationService := grpcserver.NewActivationService(atxProvider, types.ATXID{1})
+	activationService := grpcserver.NewActivationService(atxProvider, types.ATXID{1}, logtest.New(t).WithName("grpc.Activation"))
 
 	id := types.RandomATXID()
 	atxProvider.EXPECT().GetFullAtx(id).Return(nil, nil)
@@ -97,7 +98,7 @@ func TestGet_AtxNotPresent(t *testing.T) {
 func TestGet_AtxProviderReturnsFailure(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	atxProvider := grpcserver.NewMockatxProvider(ctrl)
-	activationService := grpcserver.NewActivationService(atxProvider, types.ATXID{1})
+	activationService := grpcserver.NewActivationService(atxProvider, types.ATXID{1}, logtest.New(t).WithName("grpc.Activation"))
 
 	id := types.RandomATXID()
 	atxProvider.EXPECT().GetFullAtx(id).Return(&types.VerifiedActivationTx{}, errors.New(""))
@@ -110,7 +111,7 @@ func TestGet_AtxProviderReturnsFailure(t *testing.T) {
 func TestGet_HappyPath(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	atxProvider := grpcserver.NewMockatxProvider(ctrl)
-	activationService := grpcserver.NewActivationService(atxProvider, types.ATXID{1})
+	activationService := grpcserver.NewActivationService(atxProvider, types.ATXID{1}, logtest.New(t).WithName("grpc.Activation"))
 
 	id := types.RandomATXID()
 	atx := types.VerifiedActivationTx{

--- a/api/grpcserver/admin_service.go
+++ b/api/grpcserver/admin_service.go
@@ -28,13 +28,13 @@ const (
 
 // AdminService exposes endpoints for node administration.
 type AdminService struct {
-	logger  log.Log
+	logger  log.Logger
 	db      *sql.Database
 	dataDir string
 }
 
 // NewAdminService creates a new admin grpc service.
-func NewAdminService(db *sql.Database, dataDir string, lg log.Log) *AdminService {
+func NewAdminService(db *sql.Database, dataDir string, lg log.Logger) *AdminService {
 	return &AdminService{
 		logger:  lg,
 		db:      db,

--- a/api/grpcserver/admin_service_test.go
+++ b/api/grpcserver/admin_service_test.go
@@ -54,7 +54,6 @@ func createMesh(tb testing.TB, db *sql.Database) {
 }
 
 func TestAdminService_Checkpoint(t *testing.T) {
-	logtest.SetupGlobal(t)
 	db := sql.InMemory()
 	createMesh(t, db)
 	svc := NewAdminService(db, t.TempDir(), logtest.New(t))
@@ -91,7 +90,6 @@ func TestAdminService_Checkpoint(t *testing.T) {
 }
 
 func TestAdminService_CheckpointError(t *testing.T) {
-	logtest.SetupGlobal(t)
 	db := sql.InMemory()
 	svc := NewAdminService(db, t.TempDir(), logtest.New(t))
 	t.Cleanup(launchServer(t, cfg, svc))

--- a/api/grpcserver/grpcserver_test.go
+++ b/api/grpcserver/grpcserver_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/spacemeshos/merkle-tree"
 	"github.com/spacemeshos/poet/shared"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zaptest"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/genproto/googleapis/rpc/code"
 	"google.golang.org/grpc"
@@ -484,7 +483,7 @@ func marshalProto(t *testing.T, msg proto.Message) string {
 var cfg = DefaultTestConfig()
 
 func launchServer(tb testing.TB, cfg Config, services ...ServiceAPI) func() {
-	grpcService := New(cfg.PublicListener, zaptest.NewLogger(tb).Named("grpc"))
+	grpcService := New(cfg.PublicListener, logtest.New(tb).Named("grpc"))
 	jsonService := NewJSONHTTPServer(cfg.JSONListener, logtest.New(tb).WithName("grpc.JSON"))
 
 	// attach services
@@ -544,7 +543,7 @@ func TestNewServersConfig(t *testing.T) {
 	port2, err := getFreePort(0)
 	require.NoError(t, err, "Should be able to establish a connection on a port")
 
-	grpcService := New(fmt.Sprintf(":%d", port1), zaptest.NewLogger(t).Named("grpc"))
+	grpcService := New(fmt.Sprintf(":%d", port1), logtest.New(t).Named("grpc"))
 	jsonService := NewJSONHTTPServer(fmt.Sprintf(":%d", port2), logtest.New(t).WithName("grpc.JSON"))
 
 	require.Contains(t, grpcService.Listener, strconv.Itoa(port1), "Expected same port")

--- a/api/grpcserver/node_service.go
+++ b/api/grpcserver/node_service.go
@@ -20,7 +20,7 @@ import (
 // data such as node status, software version, errors, etc. It can also be used to start
 // the sync process, or to shut down the node.
 type NodeService struct {
-	appCtx      context.Context
+	logger      log.Logger
 	mesh        meshAPI
 	genTime     genesisTimeAPI
 	peerCounter peerCounter
@@ -36,16 +36,16 @@ func (s NodeService) RegisterService(server *Server) {
 
 // NewNodeService creates a new grpc service using config data.
 func NewNodeService(
-	appCtx context.Context,
 	peers peerCounter,
 	msh meshAPI,
 	genTime genesisTimeAPI,
 	syncer syncer,
 	appVersion string,
 	appCommit string,
+	lg log.Logger,
 ) *NodeService {
 	return &NodeService{
-		appCtx:      appCtx,
+		logger:      lg,
 		mesh:        msh,
 		genTime:     genTime,
 		peerCounter: peers,
@@ -57,7 +57,7 @@ func NewNodeService(
 
 // Echo returns the response for an echo api request. It's used for E2E tests.
 func (s NodeService) Echo(_ context.Context, in *pb.EchoRequest) (*pb.EchoResponse, error) {
-	log.Info("GRPC NodeService.Echo")
+	s.logger.Info("GRPC NodeService.Echo")
 	if in.Msg != nil {
 		return &pb.EchoResponse{Msg: &pb.SimpleString{Value: in.Msg.Value}}, nil
 	}
@@ -66,7 +66,7 @@ func (s NodeService) Echo(_ context.Context, in *pb.EchoRequest) (*pb.EchoRespon
 
 // Version returns the version of the node software as a semver string.
 func (s NodeService) Version(context.Context, *empty.Empty) (*pb.VersionResponse, error) {
-	log.Info("GRPC NodeService.Version")
+	s.logger.Info("GRPC NodeService.Version")
 	return &pb.VersionResponse{
 		VersionString: &pb.SimpleString{Value: s.appVersion},
 	}, nil
@@ -74,7 +74,7 @@ func (s NodeService) Version(context.Context, *empty.Empty) (*pb.VersionResponse
 
 // Build returns the build of the node software.
 func (s NodeService) Build(context.Context, *empty.Empty) (*pb.BuildResponse, error) {
-	log.Info("GRPC NodeService.Build")
+	s.logger.Info("GRPC NodeService.Build")
 	return &pb.BuildResponse{
 		BuildString: &pb.SimpleString{Value: s.appCommit},
 	}, nil
@@ -83,7 +83,7 @@ func (s NodeService) Build(context.Context, *empty.Empty) (*pb.BuildResponse, er
 // Status returns a status object providing information about the connected peers, sync status,
 // current and verified layer.
 func (s NodeService) Status(ctx context.Context, _ *pb.StatusRequest) (*pb.StatusResponse, error) {
-	log.Info("GRPC NodeService.Status")
+	s.logger.Info("GRPC NodeService.Status")
 
 	curLayer, latestLayer, verifiedLayer := s.getLayers()
 	return &pb.StatusResponse{
@@ -125,7 +125,7 @@ func (s NodeService) getLayers() (curLayer, latestLayer, verifiedLayer uint32) {
 
 // StatusStream exposes a stream of node status updates.
 func (s NodeService) StatusStream(_ *pb.StatusStreamRequest, stream pb.NodeService_StatusStreamServer) error {
-	log.Info("GRPC NodeService.StatusStream")
+	s.logger.Info("GRPC NodeService.StatusStream")
 
 	var (
 		statusCh      <-chan events.Status
@@ -139,13 +139,13 @@ func (s NodeService) StatusStream(_ *pb.StatusStreamRequest, stream pb.NodeServi
 	for {
 		select {
 		case <-statusBufFull:
-			log.Info("status buffer is full, shutting down")
+			s.logger.Info("status buffer is full, shutting down")
 			return status.Error(codes.Canceled, errStatusBufferFull)
 		case _, ok := <-statusCh:
 			// statusCh works a bit differently than the other streams. It doesn't actually
 			// send us data. Instead, it just notifies us that there's new data to be read.
 			if !ok {
-				log.Info("StatusStream closed, shutting down")
+				s.logger.Info("StatusStream closed, shutting down")
 				return nil
 			}
 			curLayer, latestLayer, verifiedLayer := s.getLayers()
@@ -164,7 +164,7 @@ func (s NodeService) StatusStream(_ *pb.StatusStreamRequest, stream pb.NodeServi
 				return fmt.Errorf("send to stream: %w", err)
 			}
 		case <-stream.Context().Done():
-			log.Info("StatusStream closing stream, client disconnected")
+			s.logger.Info("StatusStream closing stream, client disconnected")
 			return nil
 		}
 		// TODO: do we need an additional case here for a context to indicate
@@ -174,7 +174,7 @@ func (s NodeService) StatusStream(_ *pb.StatusStreamRequest, stream pb.NodeServi
 
 // ErrorStream exposes a stream of node errors.
 func (s NodeService) ErrorStream(_ *pb.ErrorStreamRequest, stream pb.NodeService_ErrorStreamServer) error {
-	log.Info("GRPC NodeService.ErrorStream")
+	s.logger.Info("GRPC NodeService.ErrorStream")
 
 	var (
 		errorsCh      <-chan events.NodeError
@@ -191,11 +191,11 @@ func (s NodeService) ErrorStream(_ *pb.ErrorStreamRequest, stream pb.NodeService
 	for {
 		select {
 		case <-errorsBufFull:
-			log.Info("errors buffer is full, shutting down")
+			s.logger.Info("errors buffer is full, shutting down")
 			return status.Error(codes.Canceled, errErrorsBufferFull)
 		case nodeError, ok := <-errorsCh:
 			if !ok {
-				log.Info("ErrorStream closed, shutting down")
+				s.logger.Info("ErrorStream closed, shutting down")
 				return nil
 			}
 
@@ -209,7 +209,7 @@ func (s NodeService) ErrorStream(_ *pb.ErrorStreamRequest, stream pb.NodeService
 				return fmt.Errorf("send to stream: %w", err)
 			}
 		case <-stream.Context().Done():
-			log.Info("ErrorStream closing stream, client disconnected")
+			s.logger.Info("ErrorStream closing stream, client disconnected")
 			return nil
 		}
 		// TODO: do we need an additional case here for a context to indicate

--- a/api/grpcserver/smesher_service_test.go
+++ b/api/grpcserver/smesher_service_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/activation"
 	"github.com/spacemeshos/go-spacemesh/api/grpcserver"
 	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/log/logtest"
 )
 
 func TestPostConfig(t *testing.T) {
@@ -22,7 +23,7 @@ func TestPostConfig(t *testing.T) {
 	postSetupProvider := activation.NewMockpostSetupProvider(ctrl)
 	smeshingProvider := activation.NewMockSmeshingProvider(ctrl)
 
-	svc := grpcserver.NewSmesherService(postSetupProvider, smeshingProvider, time.Second, activation.DefaultPostSetupOpts())
+	svc := grpcserver.NewSmesherService(postSetupProvider, smeshingProvider, time.Second, activation.DefaultPostSetupOpts(), logtest.New(t).WithName("grpc.Smesher"))
 
 	postConfig := activation.PostConfig{
 		MinNumUnits:   rand.Uint32(),
@@ -47,7 +48,7 @@ func TestStartSmeshingPassesCorrectSmeshingOpts(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	postSetupProvider := activation.NewMockpostSetupProvider(ctrl)
 	smeshingProvider := activation.NewMockSmeshingProvider(ctrl)
-	svc := grpcserver.NewSmesherService(postSetupProvider, smeshingProvider, time.Second, activation.DefaultPostSetupOpts())
+	svc := grpcserver.NewSmesherService(postSetupProvider, smeshingProvider, time.Second, activation.DefaultPostSetupOpts(), logtest.New(t).WithName("grpc.Smesher"))
 
 	types.SetNetworkHRP("stest")
 	addr, err := types.StringToAddress("stest1qqqqqqrs60l66w5uksxzmaznwq6xnhqfv56c28qlkm4a5")
@@ -79,7 +80,7 @@ func TestSmesherService_PostSetupProviders(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	postSetupProvider := activation.NewMockpostSetupProvider(ctrl)
 	smeshingProvider := activation.NewMockSmeshingProvider(ctrl)
-	svc := grpcserver.NewSmesherService(postSetupProvider, smeshingProvider, time.Second, activation.DefaultPostSetupOpts())
+	svc := grpcserver.NewSmesherService(postSetupProvider, smeshingProvider, time.Second, activation.DefaultPostSetupOpts(), logtest.New(t).WithName("grpc.Smesher"))
 
 	providers := []activation.PostSetupProvider{
 		{

--- a/api/grpcserver/transaction_service_test.go
+++ b/api/grpcserver/transaction_service_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/events"
 	vm "github.com/spacemeshos/go-spacemesh/genvm"
 	"github.com/spacemeshos/go-spacemesh/genvm/sdk/wallet"
+	"github.com/spacemeshos/go-spacemesh/log/logtest"
 	"github.com/spacemeshos/go-spacemesh/signing"
 	"github.com/spacemeshos/go-spacemesh/sql"
 	"github.com/spacemeshos/go-spacemesh/sql/transactions"
@@ -47,7 +48,7 @@ func TestTransactionService_StreamResults(t *testing.T) {
 		return nil
 	}))
 
-	svc := NewTransactionService(db, nil, nil, nil, nil, nil)
+	svc := NewTransactionService(db, nil, nil, nil, nil, nil, logtest.New(t).WithName("grpc.Transactions"))
 	t.Cleanup(launchServer(t, cfg, svc))
 
 	conn := dialGrpc(ctx, t, cfg.PublicListener)
@@ -162,7 +163,7 @@ func BenchmarkStreamResults(b *testing.B) {
 	}
 	require.NoError(b, tx.Commit())
 	require.NoError(b, tx.Release())
-	svc := NewTransactionService(db, nil, nil, nil, nil, nil)
+	svc := NewTransactionService(db, nil, nil, nil, nil, nil, logtest.New(b).WithName("grpc.Transactions"))
 	b.Cleanup(launchServer(b, cfg, svc))
 
 	conn := dialGrpc(ctx, b, cfg.PublicListener)
@@ -219,7 +220,7 @@ func TestParseTransactions(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	t.Cleanup(cancel)
 	vminst := vm.New(db)
-	t.Cleanup(launchServer(t, cfg, NewTransactionService(db, nil, nil, txs.NewConservativeState(vminst, db), nil, nil)))
+	t.Cleanup(launchServer(t, cfg, NewTransactionService(db, nil, nil, txs.NewConservativeState(vminst, db), nil, nil, logtest.New(t).WithName("grpc.Transactions"))))
 	var (
 		conn     = dialGrpc(ctx, t, cfg.PublicListener)
 		client   = pb.NewTransactionServiceClient(conn)

--- a/cmd/bootstrapper/generator_test.go
+++ b/cmd/bootstrapper/generator_test.go
@@ -14,6 +14,7 @@ import (
 	pb "github.com/spacemeshos/api/release/go/spacemesh/v1"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
 
 	"github.com/spacemeshos/go-spacemesh/api/grpcserver"
 	"github.com/spacemeshos/go-spacemesh/bootstrap"
@@ -115,9 +116,9 @@ func (m *MeshAPIMock) EpochAtxs(types.EpochID) ([]types.ATXID, error) {
 }
 
 func launchServer(tb testing.TB) func() {
-	grpcService := grpcserver.New(fmt.Sprintf("127.0.0.1:%d", grpcPort))
-	jsonService := grpcserver.NewJSONHTTPServer(fmt.Sprintf("127.0.0.1:%d", jsonport))
-	s := grpcserver.NewMeshService(&MeshAPIMock{}, nil, nil, 0, types.Hash20{}, 0, 0, 0)
+	grpcService := grpcserver.New(fmt.Sprintf("127.0.0.1:%d", grpcPort), zaptest.NewLogger(tb).Named("grpc"))
+	jsonService := grpcserver.NewJSONHTTPServer(fmt.Sprintf("127.0.0.1:%d", jsonport), logtest.New(tb).WithName("grpc.JSON"))
+	s := grpcserver.NewMeshService(&MeshAPIMock{}, nil, nil, 0, types.Hash20{}, 0, 0, 0, logtest.New(tb).WithName("grpc.Mesh"))
 
 	pb.RegisterMeshServiceServer(grpcService.GrpcServer, s)
 	// start gRPC and json servers

--- a/cmd/bootstrapper/generator_test.go
+++ b/cmd/bootstrapper/generator_test.go
@@ -14,7 +14,6 @@ import (
 	pb "github.com/spacemeshos/api/release/go/spacemesh/v1"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zaptest"
 
 	"github.com/spacemeshos/go-spacemesh/api/grpcserver"
 	"github.com/spacemeshos/go-spacemesh/bootstrap"
@@ -116,7 +115,7 @@ func (m *MeshAPIMock) EpochAtxs(types.EpochID) ([]types.ATXID, error) {
 }
 
 func launchServer(tb testing.TB) func() {
-	grpcService := grpcserver.New(fmt.Sprintf("127.0.0.1:%d", grpcPort), zaptest.NewLogger(tb).Named("grpc"))
+	grpcService := grpcserver.New(fmt.Sprintf("127.0.0.1:%d", grpcPort), logtest.New(tb).Named("grpc"))
 	jsonService := grpcserver.NewJSONHTTPServer(fmt.Sprintf("127.0.0.1:%d", jsonport), logtest.New(tb).WithName("grpc.JSON"))
 	s := grpcserver.NewMeshService(&MeshAPIMock{}, nil, nil, 0, types.Hash20{}, 0, 0, 0, logtest.New(tb).WithName("grpc.Mesh"))
 

--- a/datastore/store.go
+++ b/datastore/store.go
@@ -76,7 +76,7 @@ func (db *CachedDB) MalfeasanceCacheSize() int {
 // IsMalicious returns true if the NodeID is malicious.
 func (db *CachedDB) IsMalicious(id types.NodeID) (bool, error) {
 	if id == types.EmptyNodeID {
-		log.Fatal("invalid argument to IsMalicious")
+		db.logger.Fatal("invalid argument to IsMalicious")
 	}
 
 	db.mu.Lock()
@@ -102,7 +102,7 @@ func (db *CachedDB) IsMalicious(id types.NodeID) (bool, error) {
 // GetMalfeasanceProof gets the malfeasance proof associated with the NodeID.
 func (db *CachedDB) GetMalfeasanceProof(id types.NodeID) (*types.MalfeasanceProof, error) {
 	if id == types.EmptyNodeID {
-		log.Fatal("invalid argument to GetMalfeasanceProof")
+		db.logger.Fatal("invalid argument to GetMalfeasanceProof")
 	}
 
 	db.mu.Lock()
@@ -124,7 +124,7 @@ func (db *CachedDB) GetMalfeasanceProof(id types.NodeID) (*types.MalfeasanceProo
 
 func (db *CachedDB) CacheMalfeasanceProof(id types.NodeID, proof *types.MalfeasanceProof) {
 	if id == types.EmptyNodeID {
-		log.Fatal("invalid argument to CacheMalfeasanceProof")
+		db.logger.Fatal("invalid argument to CacheMalfeasanceProof")
 	}
 
 	db.mu.Lock()

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -457,7 +457,7 @@ func (f *Fetch) organizeRequests(requests []RequestMessage) map[p2p.Peer][][]Req
 	peer2requests := make(map[p2p.Peer][]RequestMessage)
 	peers := f.host.GetPeers()
 	if len(peers) == 0 {
-		log.Info("cannot send fetch: no peers found")
+		f.logger.Info("cannot send fetch: no peers found")
 		// in loop() we will try again after the batchTimeout
 		return nil
 	}

--- a/hare/statustracker.go
+++ b/hare/statustracker.go
@@ -131,7 +131,7 @@ func (st *statusTracker) ProposalSet(expectedSize int) *Set {
 	}
 
 	if st.maxSet == nil { // should be impossible to reach
-		log.Fatal("maxSet is unexpectedly nil")
+		st.logger.Fatal("maxSet is unexpectedly nil")
 	}
 
 	return st.maxSet

--- a/log/log.go
+++ b/log/log.go
@@ -60,8 +60,6 @@ var (
 )
 
 // GetLogger gets logger.
-//
-// Deprecated: global logger is deprecated.
 func GetLogger() Log {
 	mu.RLock()
 	defer mu.RUnlock()
@@ -70,8 +68,6 @@ func GetLogger() Log {
 }
 
 // SetLogger sets logger.
-//
-// Deprecated: global logger is deprecated.
 func SetLogger(logger Log) {
 	mu.Lock()
 	defer mu.Unlock()
@@ -80,8 +76,6 @@ func SetLogger(logger Log) {
 }
 
 // SetupGlobal overwrites global logger.
-//
-// Deprecated: global logger is deprecated.
 func SetupGlobal(logger Log) {
 	SetLogger(NewFromLog(logger.logger.Named(mainLoggerName)))
 }
@@ -138,50 +132,31 @@ func NewFromLog(l *zap.Logger) Log {
 // public wrappers abstracting away logging lib impl
 
 // Info prints formatted info level log message.
-//
-// Deprecated: global logger is deprecated.
 func Info(msg string, args ...any) {
 	GetLogger().Info(msg, args...)
 }
 
 // Debug prints formatted debug level log message.
-//
-// Deprecated: global logger is deprecated.
 func Debug(msg string, args ...any) {
 	GetLogger().Debug(msg, args...)
 }
 
-// Error prints formatted error level log message.
-//
-// Deprecated: global logger is deprecated.
-func Error(msg string, args ...any) {
-	GetLogger().Error(msg, args...)
-}
-
 // Warning prints formatted warning level log message.
-//
-// Deprecated: global logger is deprecated.
 func Warning(msg string, args ...any) {
 	GetLogger().Warning(msg, args...)
 }
 
 // Fatal prints formatted error level log message.
-//
-// Deprecated: global logger is deprecated.
 func Fatal(msg string, args ...any) {
 	GetLogger().Fatal(msg, args...)
 }
 
 // With returns a FieldLogger which you can append fields to.
-//
-// Deprecated: global logger is deprecated.
 func With() FieldLogger {
 	return FieldLogger{GetLogger().logger, GetLogger().name}
 }
 
 // Panic writes the log message and then panics.
-//
-// Deprecated: global logger is deprecated.
 func Panic(msg string, args ...any) {
 	GetLogger().Panic(msg, args...)
 }

--- a/log/log.go
+++ b/log/log.go
@@ -76,6 +76,7 @@ func SetLogger(logger Log) {
 }
 
 // SetupGlobal overwrites global logger.
+// Deprecated: global logger is deprecated.
 func SetupGlobal(logger Log) {
 	SetLogger(NewFromLog(logger.logger.Named(mainLoggerName)))
 }
@@ -132,41 +133,43 @@ func NewFromLog(l *zap.Logger) Log {
 // public wrappers abstracting away logging lib impl
 
 // Info prints formatted info level log message.
+// Deprecated: global logger is deprecated.
 func Info(msg string, args ...any) {
 	GetLogger().Info(msg, args...)
 }
 
 // Debug prints formatted debug level log message.
+// Deprecated: global logger is deprecated.
 func Debug(msg string, args ...any) {
 	GetLogger().Debug(msg, args...)
 }
 
 // Error prints formatted error level log message.
+// Deprecated: global logger is deprecated.
 func Error(msg string, args ...any) {
 	GetLogger().Error(msg, args...)
 }
 
 // Warning prints formatted warning level log message.
+// Deprecated: global logger is deprecated.
 func Warning(msg string, args ...any) {
 	GetLogger().Warning(msg, args...)
 }
 
 // Fatal prints formatted error level log message.
+// Deprecated: global logger is deprecated.
 func Fatal(msg string, args ...any) {
 	GetLogger().Fatal(msg, args...)
 }
 
 // With returns a FieldLogger which you can append fields to.
+// Deprecated: global logger is deprecated.
 func With() FieldLogger {
 	return FieldLogger{GetLogger().logger, GetLogger().name}
 }
 
-// Event returns a field logger with the Event field set to true.
-func Event() FieldLogger {
-	return GetLogger().Event()
-}
-
 // Panic writes the log message and then panics.
+// Deprecated: global logger is deprecated.
 func Panic(msg string, args ...any) {
 	GetLogger().Panic(msg, args...)
 }

--- a/log/log.go
+++ b/log/log.go
@@ -60,6 +60,8 @@ var (
 )
 
 // GetLogger gets logger.
+//
+// Deprecated: global logger is deprecated.
 func GetLogger() Log {
 	mu.RLock()
 	defer mu.RUnlock()
@@ -68,6 +70,8 @@ func GetLogger() Log {
 }
 
 // SetLogger sets logger.
+//
+// Deprecated: global logger is deprecated.
 func SetLogger(logger Log) {
 	mu.Lock()
 	defer mu.Unlock()
@@ -76,6 +80,7 @@ func SetLogger(logger Log) {
 }
 
 // SetupGlobal overwrites global logger.
+//
 // Deprecated: global logger is deprecated.
 func SetupGlobal(logger Log) {
 	SetLogger(NewFromLog(logger.logger.Named(mainLoggerName)))
@@ -133,42 +138,49 @@ func NewFromLog(l *zap.Logger) Log {
 // public wrappers abstracting away logging lib impl
 
 // Info prints formatted info level log message.
+//
 // Deprecated: global logger is deprecated.
 func Info(msg string, args ...any) {
 	GetLogger().Info(msg, args...)
 }
 
 // Debug prints formatted debug level log message.
+//
 // Deprecated: global logger is deprecated.
 func Debug(msg string, args ...any) {
 	GetLogger().Debug(msg, args...)
 }
 
 // Error prints formatted error level log message.
+//
 // Deprecated: global logger is deprecated.
 func Error(msg string, args ...any) {
 	GetLogger().Error(msg, args...)
 }
 
 // Warning prints formatted warning level log message.
+//
 // Deprecated: global logger is deprecated.
 func Warning(msg string, args ...any) {
 	GetLogger().Warning(msg, args...)
 }
 
 // Fatal prints formatted error level log message.
+//
 // Deprecated: global logger is deprecated.
 func Fatal(msg string, args ...any) {
 	GetLogger().Fatal(msg, args...)
 }
 
 // With returns a FieldLogger which you can append fields to.
+//
 // Deprecated: global logger is deprecated.
 func With() FieldLogger {
 	return FieldLogger{GetLogger().logger, GetLogger().name}
 }
 
 // Panic writes the log message and then panics.
+//
 // Deprecated: global logger is deprecated.
 func Panic(msg string, args ...any) {
 	GetLogger().Panic(msg, args...)

--- a/node/node.go
+++ b/node/node.go
@@ -1052,7 +1052,7 @@ func (app *App) initService(ctx context.Context, svc grpcserver.Service) (grpcse
 }
 
 func (app *App) newGrpc(logger *zap.Logger, endpoint string) *grpcserver.Server {
-	return grpcserver.New(endpoint, logger.Named("grpc"),
+	return grpcserver.New(endpoint, log.NewFromLog(logger.Named("grpc")),
 		grpc.ChainStreamInterceptor(grpctags.StreamServerInterceptor(), grpczap.StreamServerInterceptor(logger)),
 		grpc.ChainUnaryInterceptor(grpctags.UnaryServerInterceptor(), grpczap.UnaryServerInterceptor(logger)),
 		grpc.MaxSendMsgSize(app.Config.API.GrpcSendMsgSize),

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -998,10 +998,8 @@ func TestEmptyExtraData(t *testing.T) {
 
 func getTestDefaultConfig(tb testing.TB) *config.Config {
 	cfg, err := LoadConfigFromFile()
-	if err != nil {
-		log.Error("cannot load config from file")
-		return nil
-	}
+	require.NoError(tb, err, "cannot load config from file")
+
 	// is set to 0 to make sync start immediately when node starts
 	cfg.P2P.MinPeers = 0
 

--- a/signing/signer.go
+++ b/signing/signer.go
@@ -10,7 +10,6 @@ import (
 	oasis "github.com/oasisprotocol/curve25519-voi/primitives/ed25519"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
-	"github.com/spacemeshos/go-spacemesh/log"
 )
 
 type Domain byte
@@ -71,7 +70,6 @@ func WithPrivateKey(priv PrivateKey) EdSignerOptionFunc {
 
 		keyPair := ed25519.NewKeyFromSeed(priv[:32])
 		if !bytes.Equal(keyPair[32:], priv.Public().(ed25519.PublicKey)) {
-			log.Error("Public key and private key do not match")
 			return errors.New("private and public do not match")
 		}
 


### PR DESCRIPTION
## Motivation
 Using a global logger makes testing harder and logging configuration more complicated. This PR removes most uses of the global logger to address this.

## Changes
- Instead of the global logger services now use their own logging instance, this should reduce the number of log lines produced by `0000.defaultLogger`
- There are still a few places where the global logger is used, primarily the `common/types` package where it cannot be replaced without some bigger changes. Issue for this: https://github.com/spacemeshos/go-spacemesh/issues/4751

## Test Plan
n/a

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
