### PR TITLE
[Merged by Bors] - Add check for next poet round on mainnet to codebase.

### DIFF
--- a/activation/nipost.go
+++ b/activation/nipost.go
@@ -378,6 +378,7 @@ func membersContainChallenge(members []types.Member, challenge types.Hash32) (ui
 	return 0, fmt.Errorf("challenge is not a member of the proof")
 }
 
+// TODO(mafa): remove after next poet round; https://github.com/spacemeshos/go-spacemesh/issues/4753
 func (nb *NIPostBuilder) addPoet111ForPubEpoch1(ctx context.Context) error {
 	// because poet 111 had a hardware issue when challenges for round 0 were submitted, no node could submit to it
 	// 111 was recovered with the poet 110 DB, so all successful submissions to 110 should be able to be fetched from there as well
@@ -420,6 +421,7 @@ func (nb *NIPostBuilder) addPoet111ForPubEpoch1(ctx context.Context) error {
 }
 
 func (nb *NIPostBuilder) getBestProof(ctx context.Context, challenge types.Hash32, publishEpoch types.EpochID) (types.PoetProofRef, *types.MerkleProof, error) {
+	// TODO(mafa): remove after next poet round; https://github.com/spacemeshos/go-spacemesh/issues/4753
 	if publishEpoch == 1 {
 		err := nb.addPoet111ForPubEpoch1(ctx)
 		if err != nil {

--- a/activation/nipost_mocks.go
+++ b/activation/nipost_mocks.go
@@ -35,6 +35,20 @@ func (m *MockPoetProvingServiceClient) EXPECT() *MockPoetProvingServiceClientMoc
 	return m.recorder
 }
 
+// Address mocks base method.
+func (m *MockPoetProvingServiceClient) Address() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Address")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Address indicates an expected call of Address.
+func (mr *MockPoetProvingServiceClientMockRecorder) Address() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Address", reflect.TypeOf((*MockPoetProvingServiceClient)(nil).Address))
+}
+
 // PoetServiceID mocks base method.
 func (m *MockPoetProvingServiceClient) PoetServiceID(arg0 context.Context) (types.PoetServiceID, error) {
 	m.ctrl.T.Helper()

--- a/activation/nipost_test.go
+++ b/activation/nipost_test.go
@@ -21,12 +21,13 @@ import (
 	"github.com/spacemeshos/go-spacemesh/sql"
 )
 
-func defaultPoetServiceMock(tb testing.TB, id []byte) *MockPoetProvingServiceClient {
+func defaultPoetServiceMock(tb testing.TB, id []byte, address string) *MockPoetProvingServiceClient {
 	tb.Helper()
 	poetClient := NewMockPoetProvingServiceClient(gomock.NewController(tb))
 	poetClient.EXPECT().Submit(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(&types.PoetRound{}, nil)
 	poetClient.EXPECT().PoetServiceID(gomock.Any()).AnyTimes().Return(types.PoetServiceID{ServiceID: id}, nil)
 	poetClient.EXPECT().PowParams(gomock.Any()).AnyTimes().Return(&PoetPowParams{}, nil)
+	poetClient.EXPECT().Address().AnyTimes().Return(address).AnyTimes()
 	return poetClient
 }
 
@@ -59,7 +60,7 @@ func TestNIPostBuilderWithMocks(t *testing.T) {
 	nipostValidator := NewMocknipostValidator(ctrl)
 	nipostValidator.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(nil)
 
-	poetProvider := defaultPoetServiceMock(t, []byte("poet"))
+	poetProvider := defaultPoetServiceMock(t, []byte("poet"), "http://localhost:9999")
 	poetProvider.EXPECT().Proof(gomock.Any(), "").Return(&types.PoetProofMessage{
 		PoetProof: types.PoetProof{},
 	}, []types.Member{types.Member(challenge.Hash())}, nil)
@@ -70,8 +71,20 @@ func TestNIPostBuilderWithMocks(t *testing.T) {
 
 	sig, err := signing.NewEdSigner()
 	require.NoError(t, err)
-	nb := NewNIPostBuilder(types.NodeID{1}, postProvider, []PoetProvingServiceClient{poetProvider},
-		poetDb, t.TempDir(), logtest.New(t), sig, PoetConfig{}, mclock, WithNipostValidator(nipostValidator))
+	nb, err := NewNIPostBuilder(
+		types.NodeID{1},
+		postProvider,
+		poetDb,
+		[]string{},
+		t.TempDir(),
+		logtest.New(t),
+		sig,
+		PoetConfig{},
+		mclock,
+		WithNipostValidator(nipostValidator),
+		withPoetClients([]PoetProvingServiceClient{poetProvider}),
+	)
+	require.NoError(t, err)
 	nipost, _, err := nb.BuildNIPost(context.Background(), &challenge)
 	require.NoError(t, err)
 	require.NotNil(t, nipost)
@@ -87,7 +100,7 @@ func TestPostSetup(t *testing.T) {
 		PublishEpoch: postGenesisEpoch + 2,
 	}
 
-	poetProvider := defaultPoetServiceMock(t, []byte("poet"))
+	poetProvider := defaultPoetServiceMock(t, []byte("poet"), "http://localhost:9999")
 	poetProvider.EXPECT().Proof(gomock.Any(), "").Return(&types.PoetProofMessage{
 		PoetProof: types.PoetProof{},
 	}, []types.Member{types.Member(challenge.Hash())}, nil)
@@ -99,8 +112,20 @@ func TestPostSetup(t *testing.T) {
 	nipostValidator := NewMocknipostValidator(gomock.NewController(t))
 	nipostValidator.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(nil)
 
-	nb := NewNIPostBuilder(postProvider.id, postProvider, []PoetProvingServiceClient{poetProvider},
-		poetDb, t.TempDir(), logtest.New(t), postProvider.signer, PoetConfig{}, mclock, WithNipostValidator(nipostValidator))
+	nb, err := NewNIPostBuilder(
+		postProvider.id,
+		postProvider,
+		poetDb,
+		[]string{},
+		t.TempDir(),
+		logtest.New(t),
+		postProvider.signer,
+		PoetConfig{},
+		mclock,
+		WithNipostValidator(nipostValidator),
+		withPoetClients([]PoetProvingServiceClient{poetProvider}),
+	)
+	r.NoError(err)
 
 	r.NoError(postProvider.PrepareInitializer(context.Background(), postProvider.opts))
 	r.NoError(postProvider.StartSession(context.Background()))
@@ -177,9 +202,20 @@ func buildNIPost(tb testing.TB, postProvider *testPostManager, nipostChallenge t
 
 	signer, err := signing.NewEdSigner()
 	require.NoError(tb, err)
-	nb := NewNIPostBuilder(postProvider.id, postProvider, []PoetProvingServiceClient{poetProver},
-		poetDb, tb.TempDir(), logtest.New(tb), signer, poetCfg, mclock, WithNipostValidator(validator))
-
+	nb, err := NewNIPostBuilder(
+		postProvider.id,
+		postProvider,
+		poetDb,
+		[]string{},
+		tb.TempDir(),
+		logtest.New(tb),
+		signer,
+		poetCfg,
+		mclock,
+		WithNipostValidator(validator),
+		withPoetClients([]PoetProvingServiceClient{poetProver}),
+	)
+	require.NoError(tb, err)
 	nipost, _, err := nb.BuildNIPost(context.Background(), &nipostChallenge)
 	require.NoError(tb, err)
 	return nipost
@@ -213,8 +249,20 @@ func TestNewNIPostBuilderNotInitialized(t *testing.T) {
 	nipostValidator := NewMocknipostValidator(ctrl)
 	nipostValidator.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(nil)
 
-	nb := NewNIPostBuilder(postProvider.id, postProvider, []PoetProvingServiceClient{poetProver},
-		poetDb, t.TempDir(), logtest.New(t), postProvider.signer, PoetConfig{}, mclock, WithNipostValidator(nipostValidator))
+	nb, err := NewNIPostBuilder(
+		postProvider.id,
+		postProvider,
+		poetDb,
+		[]string{},
+		t.TempDir(),
+		logtest.New(t),
+		postProvider.signer,
+		PoetConfig{},
+		mclock,
+		WithNipostValidator(nipostValidator),
+		withPoetClients([]PoetProvingServiceClient{poetProver}),
+	)
+	require.NoError(t, err)
 
 	nipost, _, err := nb.BuildNIPost(context.Background(), &challenge)
 	r.EqualError(err, "post setup not complete")
@@ -269,7 +317,7 @@ func TestNIPostBuilder_BuildNIPost(t *testing.T) {
 		Sequence:     2,
 	}
 
-	poetProver := defaultPoetServiceMock(t, []byte("poet"))
+	poetProver := defaultPoetServiceMock(t, []byte("poet"), "http://localhost:9999")
 	poetProver.EXPECT().Proof(gomock.Any(), "").AnyTimes().Return(
 		&types.PoetProofMessage{
 			PoetProof: types.PoetProof{},
@@ -287,8 +335,20 @@ func TestNIPostBuilder_BuildNIPost(t *testing.T) {
 	sig, err := signing.NewEdSigner()
 	req.NoError(err)
 	nodeID := types.NodeID{1}
-	nb := NewNIPostBuilder(nodeID, postProvider, []PoetProvingServiceClient{poetProver},
-		poetDb, dir, logtest.New(t), sig, PoetConfig{}, mclock, WithNipostValidator(nipostValidator))
+	nb, err := NewNIPostBuilder(
+		nodeID,
+		postProvider,
+		poetDb,
+		[]string{},
+		dir,
+		logtest.New(t),
+		sig,
+		PoetConfig{},
+		mclock,
+		WithNipostValidator(nipostValidator),
+		withPoetClients([]PoetProvingServiceClient{poetProver}),
+	)
+	req.NoError(err)
 
 	postProvider.EXPECT().GenerateProof(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 	nipostValidator.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(nil)
@@ -302,7 +362,19 @@ func TestNIPostBuilder_BuildNIPost(t *testing.T) {
 	// fail post exec
 	sig, err = signing.NewEdSigner()
 	req.NoError(err)
-	nb = NewNIPostBuilder(nodeID, postProvider, []PoetProvingServiceClient{poetProver}, poetDb, dir, logtest.New(t), sig, PoetConfig{}, mclock)
+	nb, err = NewNIPostBuilder(
+		nodeID,
+		postProvider,
+		poetDb,
+		[]string{},
+		dir,
+		logtest.New(t),
+		sig,
+		PoetConfig{},
+		mclock,
+		withPoetClients([]PoetProvingServiceClient{poetProver}),
+	)
+	req.NoError(err)
 	postProvider.EXPECT().GenerateProof(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil, fmt.Errorf("error")).Times(1)
 	// check that proof ref is not called again
 	nipost, _, err = nb.BuildNIPost(context.Background(), &challenge2)
@@ -314,7 +386,20 @@ func TestNIPostBuilder_BuildNIPost(t *testing.T) {
 
 	sig, err = signing.NewEdSigner()
 	req.NoError(err)
-	nb = NewNIPostBuilder(nodeID, postProvider, []PoetProvingServiceClient{poetProver}, poetDb, dir, logtest.New(t), sig, PoetConfig{}, mclock, WithNipostValidator(nipostValidator))
+	nb, err = NewNIPostBuilder(
+		nodeID,
+		postProvider,
+		poetDb,
+		[]string{},
+		dir,
+		logtest.New(t),
+		sig,
+		PoetConfig{},
+		mclock,
+		WithNipostValidator(nipostValidator),
+		withPoetClients([]PoetProvingServiceClient{poetProver}),
+	)
+	req.NoError(err)
 	postProvider.EXPECT().GenerateProof(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 	nipostValidator.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(nil)
 	// check that proof ref is not called again
@@ -358,6 +443,7 @@ func TestNIPostBuilder_ManyPoETs_SubmittingChallenge_DeadlineReached(t *testing.
 			},
 		)
 		poet.EXPECT().PowParams(gomock.Any()).Return(&PoetPowParams{}, nil)
+		poet.EXPECT().Address().Return("http://localhost:9999")
 		poets = append(poets, poet)
 	}
 	{
@@ -366,6 +452,7 @@ func TestNIPostBuilder_ManyPoETs_SubmittingChallenge_DeadlineReached(t *testing.
 		poet.EXPECT().Submit(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&types.PoetRound{}, nil)
 		poet.EXPECT().Proof(gomock.Any(), gomock.Any()).Return(proof, []types.Member{types.Member(challenge.Hash())}, nil)
 		poet.EXPECT().PowParams(gomock.Any()).Return(&PoetPowParams{}, nil)
+		poet.EXPECT().Address().Return("http://localhost:9998")
 		poets = append(poets, poet)
 	}
 
@@ -386,7 +473,20 @@ func TestNIPostBuilder_ManyPoETs_SubmittingChallenge_DeadlineReached(t *testing.
 		},
 	)
 	nipostValidator.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(nil)
-	nb := NewNIPostBuilder(types.NodeID{1}, postProvider, poets, poetDb, t.TempDir(), logtest.New(t), sig, poetCfg, mclock, WithNipostValidator(nipostValidator))
+	nb, err := NewNIPostBuilder(
+		types.NodeID{1},
+		postProvider,
+		poetDb,
+		[]string{},
+		t.TempDir(),
+		logtest.New(t),
+		sig,
+		poetCfg,
+		mclock,
+		WithNipostValidator(nipostValidator),
+		withPoetClients(poets),
+	)
+	req.NoError(err)
 
 	// Act
 	nipost, _, err := nb.BuildNIPost(context.Background(), &challenge)
@@ -414,12 +514,12 @@ func TestNIPostBuilder_ManyPoETs_WaitingForProof_DeadlineReached(t *testing.T) {
 
 	poets := make([]PoetProvingServiceClient, 0, 2)
 	{
-		poet := defaultPoetServiceMock(t, []byte("poet0"))
+		poet := defaultPoetServiceMock(t, []byte("poet0"), "http://localhost:9999")
 		poet.EXPECT().Proof(gomock.Any(), gomock.Any()).Return(proof, []types.Member{types.Member(challenge.Hash())}, nil)
 		poets = append(poets, poet)
 	}
 	{
-		poet := defaultPoetServiceMock(t, []byte("poet1"))
+		poet := defaultPoetServiceMock(t, []byte("poet1"), "http://localhost:9998")
 		poet.EXPECT().Proof(gomock.Any(), gomock.Any()).DoAndReturn(
 			func(ctx context.Context, _ string) (*types.PoetProofMessage, []types.Member, error) {
 				// Hang up after the context expired
@@ -448,10 +548,20 @@ func TestNIPostBuilder_ManyPoETs_WaitingForProof_DeadlineReached(t *testing.T) {
 		},
 	)
 	nipostValidator.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(nil)
-	nb := NewNIPostBuilder(
-		types.NodeID{1}, postProvider, poets, poetDb,
-		t.TempDir(), logtest.New(t), sig, poetCfg, mclock, WithNipostValidator(nipostValidator),
+	nb, err := NewNIPostBuilder(
+		types.NodeID{1},
+		postProvider,
+		poetDb,
+		[]string{},
+		t.TempDir(),
+		logtest.New(t),
+		sig,
+		poetCfg,
+		mclock,
+		WithNipostValidator(nipostValidator),
+		withPoetClients(poets),
 	)
+	req.NoError(err)
 
 	// Act
 	nipost, _, err := nb.BuildNIPost(context.Background(), &challenge)
@@ -490,12 +600,12 @@ func TestNIPostBuilder_ManyPoETs_AllFinished(t *testing.T) {
 
 	poets := make([]PoetProvingServiceClient, 0, 2)
 	{
-		poet := defaultPoetServiceMock(t, []byte("poet0"))
+		poet := defaultPoetServiceMock(t, []byte("poet0"), "http://localhost:9999")
 		poet.EXPECT().Proof(gomock.Any(), "").Return(proofWorse, []types.Member{types.Member(challenge.Hash())}, nil)
 		poets = append(poets, poet)
 	}
 	{
-		poet := defaultPoetServiceMock(t, []byte("poet1"))
+		poet := defaultPoetServiceMock(t, []byte("poet1"), "http://localhost:9998")
 		poet.EXPECT().Proof(gomock.Any(), "").Return(proofBetter, []types.Member{types.Member(challenge.Hash())}, nil)
 		poets = append(poets, poet)
 	}
@@ -514,7 +624,20 @@ func TestNIPostBuilder_ManyPoETs_AllFinished(t *testing.T) {
 		},
 	)
 	nipostValidator.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(nil)
-	nb := NewNIPostBuilder(types.NodeID{1}, postProvider, poets, poetDb, t.TempDir(), logtest.New(t), sig, PoetConfig{}, mclock, WithNipostValidator(nipostValidator))
+	nb, err := NewNIPostBuilder(
+		types.NodeID{1},
+		postProvider,
+		poetDb,
+		[]string{},
+		t.TempDir(),
+		logtest.New(t),
+		sig,
+		PoetConfig{},
+		mclock,
+		WithNipostValidator(nipostValidator),
+		withPoetClients(poets),
+	)
+	req.NoError(err)
 
 	// Act
 	nipost, _, err := nb.BuildNIPost(context.Background(), &challenge)
@@ -541,8 +664,19 @@ func TestNIPostBuilder_Close(t *testing.T) {
 
 	sig, err := signing.NewEdSigner()
 	r.NoError(err)
-	nb := NewNIPostBuilder(types.NodeID{1}, postProvider, []PoetProvingServiceClient{poetProver},
-		poetDb, t.TempDir(), logtest.New(t), sig, PoetConfig{}, mclock)
+	nb, err := NewNIPostBuilder(
+		types.NodeID{1},
+		postProvider,
+		poetDb,
+		[]string{},
+		t.TempDir(),
+		logtest.New(t),
+		sig,
+		PoetConfig{},
+		mclock,
+		withPoetClients([]PoetProvingServiceClient{poetProver}),
+	)
+	r.NoError(err)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -571,9 +705,21 @@ func TestNIPSTBuilder_PoetUnstable(t *testing.T) {
 		postProver.EXPECT().Status().Return(&PostSetupStatus{State: PostSetupStateComplete})
 		poetProver := NewMockPoetProvingServiceClient(ctrl)
 		poetProver.EXPECT().PoetServiceID(gomock.Any()).AnyTimes().Return(types.PoetServiceID{}, errors.New("test"))
+		poetProver.EXPECT().Address().Return("http://localhost:9999")
 
-		nb := NewNIPostBuilder(nodeID, postProver, []PoetProvingServiceClient{poetProver},
-			poetDb, t.TempDir(), logtest.New(t), sig, poetCfg, mclock)
+		nb, err := NewNIPostBuilder(
+			nodeID,
+			postProver,
+			poetDb,
+			[]string{},
+			t.TempDir(),
+			logtest.New(t),
+			sig,
+			poetCfg,
+			mclock,
+			withPoetClients([]PoetProvingServiceClient{poetProver}),
+		)
+		require.NoError(t, err)
 		nipst, _, err := nb.BuildNIPost(context.Background(), &challenge)
 		require.ErrorIs(t, err, ErrPoetServiceUnstable)
 		require.Nil(t, nipst)
@@ -589,9 +735,22 @@ func TestNIPSTBuilder_PoetUnstable(t *testing.T) {
 		poetProver.EXPECT().PoetServiceID(gomock.Any()).AnyTimes().Return(types.PoetServiceID{ServiceID: []byte{}}, nil)
 		poetProver.EXPECT().Submit(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("test"))
 		poetProver.EXPECT().PowParams(gomock.Any()).Return(&PoetPowParams{}, nil)
+		poetProver.EXPECT().Address().Return("http://localhost:9999")
 
-		nb := NewNIPostBuilder(nodeID, postProver, []PoetProvingServiceClient{poetProver},
-			poetDb, t.TempDir(), logtest.New(t), sig, poetCfg, mclock)
+		nb, err := NewNIPostBuilder(
+			nodeID,
+			postProver,
+			poetDb,
+			[]string{},
+			t.TempDir(),
+			logtest.New(t),
+			sig,
+			poetCfg,
+			mclock,
+			withPoetClients([]PoetProvingServiceClient{poetProver}),
+		)
+		require.NoError(t, err)
+
 		nipst, _, err := nb.BuildNIPost(context.Background(), &challenge)
 		require.ErrorIs(t, err, ErrPoetServiceUnstable)
 		require.Nil(t, nipst)
@@ -612,9 +771,21 @@ func TestNIPSTBuilder_PoetUnstable(t *testing.T) {
 			},
 		)
 		poetProver.EXPECT().PowParams(gomock.Any()).Return(&PoetPowParams{}, nil)
+		poetProver.EXPECT().Address().Return("http://localhost:9999")
 
-		nb := NewNIPostBuilder(nodeID, postProver, []PoetProvingServiceClient{poetProver},
-			poetDb, t.TempDir(), logtest.New(t), sig, poetCfg, mclock)
+		nb, err := NewNIPostBuilder(
+			nodeID,
+			postProver,
+			poetDb,
+			[]string{},
+			t.TempDir(),
+			logtest.New(t),
+			sig,
+			poetCfg,
+			mclock,
+			withPoetClients([]PoetProvingServiceClient{poetProver}),
+		)
+		require.NoError(t, err)
 		nipst, _, err := nb.BuildNIPost(context.Background(), &challenge)
 		require.ErrorIs(t, err, ErrPoetServiceUnstable)
 		require.Nil(t, nipst)
@@ -626,11 +797,22 @@ func TestNIPSTBuilder_PoetUnstable(t *testing.T) {
 		mclock := defaultLayerClockMock(t)
 		postProver := NewMockpostSetupProvider(ctrl)
 		postProver.EXPECT().Status().Return(&PostSetupStatus{State: PostSetupStateComplete})
-		poetProver := defaultPoetServiceMock(t, []byte("poet"))
+		poetProver := defaultPoetServiceMock(t, []byte("poet"), "http://localhost:9999")
 		poetProver.EXPECT().Proof(gomock.Any(), "").Return(nil, nil, errors.New("failed"))
 
-		nb := NewNIPostBuilder(nodeID, postProver, []PoetProvingServiceClient{poetProver},
-			poetDb, t.TempDir(), logtest.New(t), sig, poetCfg, mclock)
+		nb, err := NewNIPostBuilder(
+			nodeID,
+			postProver,
+			poetDb,
+			[]string{},
+			t.TempDir(),
+			logtest.New(t),
+			sig,
+			poetCfg,
+			mclock,
+			withPoetClients([]PoetProvingServiceClient{poetProver}),
+		)
+		require.NoError(t, err)
 		nipst, _, err := nb.BuildNIPost(context.Background(), &challenge)
 		require.ErrorIs(t, err, ErrPoetProofNotReceived)
 		require.Nil(t, nipst)
@@ -643,11 +825,22 @@ func TestNIPSTBuilder_PoetUnstable(t *testing.T) {
 		mclock := defaultLayerClockMock(t)
 		postProver := NewMockpostSetupProvider(ctrl)
 		postProver.EXPECT().Status().Return(&PostSetupStatus{State: PostSetupStateComplete})
-		poetProver := defaultPoetServiceMock(t, []byte("poet"))
+		poetProver := defaultPoetServiceMock(t, []byte("poet"), "http://localhost:9999")
 		poetProver.EXPECT().Proof(gomock.Any(), "").Return(&types.PoetProofMessage{PoetProof: types.PoetProof{}}, []types.Member{}, nil)
 
-		nb := NewNIPostBuilder(nodeID, postProver, []PoetProvingServiceClient{poetProver},
-			poetDb, t.TempDir(), logtest.New(t), sig, poetCfg, mclock)
+		nb, err := NewNIPostBuilder(
+			nodeID,
+			postProver,
+			poetDb,
+			[]string{},
+			t.TempDir(),
+			logtest.New(t),
+			sig,
+			poetCfg,
+			mclock,
+			withPoetClients([]PoetProvingServiceClient{poetProver}),
+		)
+		require.NoError(t, err)
 		nipst, _, err := nb.BuildNIPost(context.Background(), &challenge)
 		require.ErrorIs(t, err, ErrPoetProofNotReceived)
 		require.Nil(t, nipst)
@@ -666,28 +859,45 @@ func TestNIPoSTBuilder_StaleChallenge(t *testing.T) {
 	sig, err := signing.NewEdSigner()
 	require.NoError(t, err)
 
-	ctrl := gomock.NewController(t)
-	poetDb := NewMockpoetDbAPI(ctrl)
-	mclock := NewMocklayerClock(ctrl)
-	poetProver := NewMockPoetProvingServiceClient(ctrl)
-	postProver := NewMockpostSetupProvider(ctrl)
-
 	// Act & Verify
 	t.Run("not requests poet round started", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		poetDb := NewMockpoetDbAPI(ctrl)
+		mclock := NewMocklayerClock(ctrl)
+		poetProver := NewMockPoetProvingServiceClient(ctrl)
+		poetProver.EXPECT().Address().Return("http://localhost:9999")
+		postProver := NewMockpostSetupProvider(ctrl)
 		postProver.EXPECT().Status().Return(&PostSetupStatus{State: PostSetupStateComplete})
 		mclock.EXPECT().LayerToTime(gomock.Any()).DoAndReturn(
 			func(got types.LayerID) time.Time {
 				return genesis.Add(layerDuration * time.Duration(got))
 			}).AnyTimes()
 
-		nb := NewNIPostBuilder(types.NodeID{1}, postProver, []PoetProvingServiceClient{poetProver},
-			poetDb, t.TempDir(), logtest.New(t), sig, PoetConfig{}, mclock)
+		nb, err := NewNIPostBuilder(
+			types.NodeID{1},
+			postProver,
+			poetDb,
+			[]string{},
+			t.TempDir(),
+			logtest.New(t),
+			sig,
+			PoetConfig{},
+			mclock,
+			withPoetClients([]PoetProvingServiceClient{poetProver}),
+		)
+		require.NoError(t, err)
 		nipost, _, err := nb.BuildNIPost(context.Background(), &challenge)
 		require.ErrorIs(t, err, ErrATXChallengeExpired)
 		require.ErrorContains(t, err, "poet round has already started")
 		require.Nil(t, nipost)
 	})
 	t.Run("no response before deadline", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		poetDb := NewMockpoetDbAPI(ctrl)
+		mclock := NewMocklayerClock(ctrl)
+		poetProver := NewMockPoetProvingServiceClient(ctrl)
+		poetProver.EXPECT().Address().Return("http://localhost:9999")
+		postProver := NewMockpostSetupProvider(ctrl)
 		postProver.EXPECT().Status().Return(&PostSetupStatus{State: PostSetupStateComplete})
 		mclock.EXPECT().LayerToTime(gomock.Any()).DoAndReturn(
 			func(got types.LayerID) time.Time {
@@ -695,8 +905,19 @@ func TestNIPoSTBuilder_StaleChallenge(t *testing.T) {
 			}).AnyTimes()
 
 		dir := t.TempDir()
-		nb := NewNIPostBuilder(types.NodeID{1}, postProver, []PoetProvingServiceClient{poetProver},
-			poetDb, dir, logtest.New(t), sig, PoetConfig{}, mclock)
+		nb, err := NewNIPostBuilder(
+			types.NodeID{1},
+			postProver,
+			poetDb,
+			[]string{},
+			dir,
+			logtest.New(t),
+			sig,
+			PoetConfig{},
+			mclock,
+			withPoetClients([]PoetProvingServiceClient{poetProver}),
+		)
+		require.NoError(t, err)
 		state := types.NIPostBuilderState{
 			Challenge:    challenge.Hash(),
 			PoetRequests: []types.PoetRequest{{}},
@@ -743,6 +964,7 @@ func TestNIPoSTBuilder_Continues_After_Interrupted(t *testing.T) {
 	)
 	poet.EXPECT().PowParams(gomock.Any()).Return(&PoetPowParams{}, nil)
 	poet.EXPECT().Proof(gomock.Any(), "").Return(proof, []types.Member{types.Member(challenge.Hash())}, nil)
+	poet.EXPECT().Address().Return("http://localhost:9999")
 
 	sig, err := signing.NewEdSigner()
 	req.NoError(err)
@@ -762,7 +984,20 @@ func TestNIPoSTBuilder_Continues_After_Interrupted(t *testing.T) {
 	)
 	nipostValidator := NewMocknipostValidator(ctrl)
 	nipostValidator.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(nil)
-	nb := NewNIPostBuilder(types.NodeID{1}, postProvider, []PoetProvingServiceClient{poet}, poetDb, t.TempDir(), logtest.New(t), sig, poetCfg, mclock, WithNipostValidator(nipostValidator))
+	nb, err := NewNIPostBuilder(
+		types.NodeID{1},
+		postProvider,
+		poetDb,
+		[]string{},
+		t.TempDir(),
+		logtest.New(t),
+		sig,
+		poetCfg,
+		mclock,
+		WithNipostValidator(nipostValidator),
+		withPoetClients([]PoetProvingServiceClient{poet}),
+	)
+	req.NoError(err)
 
 	// Act
 	nipost, _, err := nb.BuildNIPost(buildCtx, &challenge)

--- a/activation/poet.go
+++ b/activation/poet.go
@@ -90,6 +90,10 @@ func NewHTTPPoetClient(baseUrl string, cfg PoetConfig, opts ...PoetClientOpts) (
 	return poetClient, nil
 }
 
+func (c *HTTPPoetClient) Address() string {
+	return c.baseURL.String()
+}
+
 func (c *HTTPPoetClient) PowParams(ctx context.Context) (*PoetPowParams, error) {
 	resBody := rpcapi.PowParamsResponse{}
 	if err := c.req(ctx, http.MethodGet, "/v1/pow_params", nil, &resBody); err != nil {

--- a/node/node.go
+++ b/node/node.go
@@ -534,7 +534,7 @@ func (app *App) SetLogLevel(name, loglevel string) error {
 	return nil
 }
 
-func (app *App) initServices(ctx context.Context, poetClients []activation.PoetProvingServiceClient) error {
+func (app *App) initServices(ctx context.Context) error {
 	vrfSigner, err := app.edSgn.VRFSigner()
 	if err != nil {
 		return fmt.Errorf("could not create vrf signer: %w", err)
@@ -797,11 +797,11 @@ func (app *App) initServices(ctx context.Context, poetClients []activation.PoetP
 		app.log.Panic("failed to create post setup manager: %v", err)
 	}
 
-	nipostBuilder := activation.NewNIPostBuilder(
+	nipostBuilder, err := activation.NewNIPostBuilder(
 		app.edSgn.NodeID(),
 		postSetupMgr,
-		poetClients,
 		poetDb,
+		app.Config.PoETServers,
 		app.Config.SMESHING.Opts.DataDir,
 		app.addLogger(NipostBuilderLogger, lg),
 		app.edSgn,
@@ -809,6 +809,9 @@ func (app *App) initServices(ctx context.Context, poetClients []activation.PoetP
 		app.clock,
 		activation.WithNipostValidator(app.validator),
 	)
+	if err != nil {
+		app.log.Panic("failed to create nipost builder: %v", err)
+	}
 
 	var coinbaseAddr types.Address
 	if app.Config.SMESHING.Start {
@@ -1332,15 +1335,6 @@ func (app *App) Start(ctx context.Context) error {
 
 	lg := logger.Named(app.edSgn.NodeID().ShortString()).WithFields(app.edSgn.NodeID())
 
-	poetClients := make([]activation.PoetProvingServiceClient, 0, len(app.Config.PoETServers))
-	for _, address := range app.Config.PoETServers {
-		client, err := activation.NewHTTPPoetClient(address, app.Config.POET)
-		if err != nil {
-			return fmt.Errorf("cannot create poet client: %w", err)
-		}
-		poetClients = append(poetClients, client)
-	}
-
 	/* Initialize all protocol services */
 
 	gTime, err := time.Parse(time.RFC3339, app.Config.Genesis.GenesisTime)
@@ -1378,7 +1372,7 @@ func (app *App) Start(ctx context.Context) error {
 	if err := app.setupDBs(ctx, lg, app.Config.DataDir()); err != nil {
 		return err
 	}
-	if err := app.initServices(ctx, poetClients); err != nil {
+	if err := app.initServices(ctx); err != nil {
 		return fmt.Errorf("cannot start services: %w", err)
 	}
 


### PR DESCRIPTION
## Motivation
Closes #4745 

## Changes
- When fetching a poet proof for the publish epoch 1 the state will be updated to duplicate the request for PoET 110 to PoET 111 such that the node will also try to fetch from there even if it didn't submit a proof to it.
- `NIPoSTBuilder` was updated to store clients in a map instead of in a slice for easier access.

## Test Plan
n/a

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
