### PR TITLE
[Merged by Bors] - Move staticcheck step to lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,11 +54,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: filter-changes
     if: ${{ needs.filter-changes.outputs.nondocchanges == 'true' }}
-    # should not take more than 7-8 mins
-    timeout-minutes: 10
+    # should not take more than 2-3 mins
+    timeout-minutes: 5
     steps:
-      - name: Add OpenCL support
-        run: sudo apt-get update -q && sudo apt-get install -qy ocl-icd-opencl-dev libpocl2
       - name: checkout
         uses: actions/checkout@v3
       - name: set up go
@@ -72,16 +70,16 @@ jobs:
           make test-fmt
           make test-tidy
           make test-generate
-      - name: staticcheck
-        run: make staticcheck
 
   lint:
     runs-on: ubuntu-latest
     needs: filter-changes
     if: ${{ needs.filter-changes.outputs.nondocchanges == 'true' }}
-    # should not take more than 4-6 mins
-    timeout-minutes: 10
+    # should not take more than 15-16 mins
+    timeout-minutes: 18
     steps:
+      - name: Add OpenCL support
+        run: sudo apt-get update -q && sudo apt-get install -qy ocl-icd-opencl-dev libpocl2
       - name: checkout
         uses: actions/checkout@v3
       - name: set up go
@@ -91,6 +89,8 @@ jobs:
           go-version-file: "go.mod"
       - name: setup env
         run: make install
+      - name: staticcheck
+        run: make staticcheck
       - name: lint
         run: make lint-github-action
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,8 @@ jobs:
     # should not take more than 2-3 mins
     timeout-minutes: 5
     steps:
+      - name: Add OpenCL support
+        run: sudo apt-get update -q && sudo apt-get install -qy ocl-icd-opencl-dev libpocl2
       - name: checkout
         uses: actions/checkout@v3
       - name: set up go


### PR DESCRIPTION
## Motivation
Quicktests recently have often timed out when they should pass or fail quickly to catch easy detectable mistakes (primarily formatting and dependency issues at the moment).

The staticcheck fits well into the lint job with the other linters invoked by `golangci-lint` (btw. shouldn't staticcheck already be called by golangci-lint? 🤔 ) If the lint job takes longer that's not a big deal; it runs in parallel to most other jobs and unittests take much longer anyway so the overall time for CI won't increase by this.

## Changes
- Move `staticcheck` from quicktests job to lint job.
- Set new timeouts that should be long enough to avoid being triggered in a normal run.

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
