### PR TITLE
[Merged by Bors] - Fix logging issues in TestSpacemeshApp_NodeService

### DIFF
--- a/node/node_test.go
+++ b/node/node_test.go
@@ -49,7 +49,6 @@ import (
 	"github.com/spacemeshos/go-spacemesh/log/logtest"
 	"github.com/spacemeshos/go-spacemesh/p2p"
 	"github.com/spacemeshos/go-spacemesh/signing"
-	"github.com/spacemeshos/go-spacemesh/timesync"
 )
 
 const layersPerEpoch = 3
@@ -420,15 +419,6 @@ func TestSpacemeshApp_NodeService(t *testing.T) {
 	app.Config = getTestDefaultConfig(t)
 	app.Config.SMESHING.CoinbaseAccount = types.GenerateAddress([]byte{1}).String()
 	app.Config.SMESHING.Opts.DataDir = t.TempDir()
-
-	clock, err := timesync.NewClock(
-		timesync.WithLayerDuration(1*time.Second),
-		timesync.WithTickInterval(100*time.Millisecond),
-		timesync.WithGenesisTime(time.Now()),
-		timesync.WithLogger(logger),
-	)
-	require.NoError(t, err)
-	app.clock = clock
 
 	edSgn, err := signing.NewEdSigner()
 	require.NoError(t, err)

--- a/p2p/upgrade.go
+++ b/p2p/upgrade.go
@@ -7,8 +7,10 @@ import (
 	"sync"
 	"time"
 
+	lp2plog "github.com/ipfs/go-log/v2"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/network"
+	"go.uber.org/zap/zapcore"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/spacemeshos/go-spacemesh/log"
@@ -194,5 +196,6 @@ func (fh *Host) Stop() error {
 	if err := fh.Host.Close(); err != nil {
 		return fmt.Errorf("failed to close libp2p host: %w", err)
 	}
+	lp2plog.SetPrimaryCore(zapcore.NewNopCore())
 	return nil
 }


### PR DESCRIPTION
## Motivation
`TestSpacemeshApp_NodeService` has been flaky recently. The issues were caused by how libp2p does logging and a missing cleanup of the internal clock during the test.

## Changes
- remove custom clock in test - it is overwritten anyway by calling `app.Start()` later in the test
- ensure the global logger used by libp2p is set to a no-op logger when the node is shut down (via `p2p.Host::Stop()`)

## Test Plan
n/a

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
