### PR TITLE
[Merged by Bors] - Remove best provider option for OpenCL provider ID

### DIFF
--- a/activation/post.go
+++ b/activation/post.go
@@ -222,8 +222,8 @@ func DefaultPostSetupOpts() PostSetupOpts {
 	}
 }
 
-func (o PostSetupOpts) ToInitOpts() (config.InitOpts, error) {
-	initOpts := config.InitOpts{
+func (o PostSetupOpts) ToInitOpts() config.InitOpts {
+	return config.InitOpts{
 		DataDir:          o.DataDir,
 		NumUnits:         o.NumUnits,
 		MaxFileSize:      o.MaxFileSize,
@@ -232,7 +232,6 @@ func (o PostSetupOpts) ToInitOpts() (config.InitOpts, error) {
 		Scrypt:           o.Scrypt,
 		ComputeBatchSize: o.ComputeBatchSize,
 	}
-	return initOpts, nil
 }
 
 // PostSetupManager implements the PostProvider interface.
@@ -421,15 +420,11 @@ func (mgr *PostSetupManager) PrepareInitializer(ctx context.Context, opts PostSe
 		return err
 	}
 
-	initOpts, err := opts.ToInitOpts()
-	if err != nil {
-		return err
-	}
 	newInit, err := initialization.NewInitializer(
 		initialization.WithNodeId(mgr.id.Bytes()),
 		initialization.WithCommitmentAtxId(mgr.commitmentAtxId.Bytes()),
 		initialization.WithConfig(mgr.cfg.ToConfig()),
-		initialization.WithInitOpts(initOpts),
+		initialization.WithInitOpts(opts.ToInitOpts()),
 		initialization.WithLogger(mgr.logger.Zap()),
 	)
 	if err != nil {

--- a/activation/post.go
+++ b/activation/post.go
@@ -93,6 +93,7 @@ type PostProviderID struct {
 	value *uint32
 }
 
+// String implements pflag.Value.String.
 func (id *PostProviderID) String() string {
 	if id.value == nil {
 		return ""
@@ -100,39 +101,37 @@ func (id *PostProviderID) String() string {
 	return fmt.Sprintf("%d", *id.value)
 }
 
-// Set implements pflag.Value.Set.
-func (id *PostProviderID) Set(value string) error {
-	return id.UnmarshalText([]byte(value))
-}
-
-func (id *PostProviderID) SetUint(value uint32) {
-	id.value = new(uint32)
-	*id.value = value
-}
-
-func (id *PostProviderID) Value() *uint32 {
-	return id.value
-}
-
 // Type implements pflag.Value.Type.
 func (PostProviderID) Type() string {
 	return "PostProviderID"
 }
 
-func (id *PostProviderID) UnmarshalText(text []byte) error {
-	if len(text) == 0 {
+// Set implements pflag.Value.Set.
+func (id *PostProviderID) Set(value string) error {
+	if len(value) == 0 {
 		id.value = nil
 		return nil
 	}
 
-	i, err := strconv.ParseUint(string(text), 10, 32)
+	i, err := strconv.ParseUint(string(value), 10, 32)
 	if err != nil {
-		return fmt.Errorf("failed to parse PoST Provider ID (%s): %w", text, err)
+		return fmt.Errorf("failed to parse PoST Provider ID (\"%s\"): %w", value, err)
 	}
 
 	id.value = new(uint32)
 	*id.value = uint32(i)
 	return nil
+}
+
+// SetUint32 sets the value of the PostProviderID to the given uint32.
+func (id *PostProviderID) SetUint32(value uint32) {
+	id.value = new(uint32)
+	*id.value = value
+}
+
+// Value returns the value of the PostProviderID as a pointer to uint32.
+func (id *PostProviderID) Value() *uint32 {
+	return id.value
 }
 
 // PostProvingOpts are the options controlling POST proving process.

--- a/activation/post.go
+++ b/activation/post.go
@@ -125,8 +125,7 @@ func (id *PostProviderID) Set(value string) error {
 
 // SetInt64 sets the value of the PostProviderID to the given int64.
 func (id *PostProviderID) SetInt64(value int64) {
-	id.value = new(int64)
-	*id.value = value
+	id.value = &value
 }
 
 // Value returns the value of the PostProviderID as a pointer to uint32.

--- a/activation/post.go
+++ b/activation/post.go
@@ -113,7 +113,7 @@ func (id *PostProviderID) Set(value string) error {
 		return nil
 	}
 
-	i, err := strconv.ParseInt(value, 10, 64)
+	i, err := strconv.ParseInt(value, 10, 33)
 	if err != nil {
 		return fmt.Errorf("failed to parse PoST Provider ID (\"%s\"): %w", value, err)
 	}

--- a/activation/post_test.go
+++ b/activation/post_test.go
@@ -108,18 +108,6 @@ func TestPostSetupManager_PrepareInitializer(t *testing.T) {
 	req.Error(mgr.PrepareInitializer(ctx, opts))
 }
 
-func TestPostSetupManager_PrepareInitializer_BestProvider(t *testing.T) {
-	req := require.New(t)
-
-	mgr := newTestPostManager(t)
-
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
-	defer cancel()
-
-	mgr.opts.ProviderID = config.BestProviderID
-	req.NoError(mgr.PrepareInitializer(ctx, mgr.opts))
-}
-
 // Checks that the sequence of calls for initialization (first
 // PrepareInitializer and then StartSession) is enforced.
 func TestPostSetupManager_InitializationCallSequence(t *testing.T) {
@@ -442,7 +430,7 @@ func newTestPostManager(tb testing.TB, o ...newPostSetupMgrOptionFunc) *testPost
 
 	opts := DefaultPostSetupOpts()
 	opts.DataDir = tb.TempDir()
-	opts.ProviderID = int(initialization.CPUProviderID())
+	opts.ProviderID = uint64(initialization.CPUProviderID())
 	opts.Scrypt.N = 2 // Speedup initialization in tests.
 
 	goldenATXID := types.ATXID{2, 3, 4}

--- a/activation/post_test.go
+++ b/activation/post_test.go
@@ -430,7 +430,7 @@ func newTestPostManager(tb testing.TB, o ...newPostSetupMgrOptionFunc) *testPost
 
 	opts := DefaultPostSetupOpts()
 	opts.DataDir = tb.TempDir()
-	opts.ProviderID = uint64(initialization.CPUProviderID())
+	opts.ProviderID.SetUint(initialization.CPUProviderID())
 	opts.Scrypt.N = 2 // Speedup initialization in tests.
 
 	goldenATXID := types.ATXID{2, 3, 4}
@@ -478,5 +478,34 @@ func TestSettingPowDifficulty(t *testing.T) {
 		d := PowDifficulty{}
 		require.Error(t, d.Set(encoded))
 		require.Equal(t, PowDifficulty{}, d)
+	})
+}
+
+func TestSettingProviderID(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid value", func(t *testing.T) {
+		t.Parallel()
+		id := new(PostProviderID)
+		require.NoError(t, id.Set("1234"))
+		require.Equal(t, uint32(1234), *id.Value())
+	})
+	t.Run("no value", func(t *testing.T) {
+		t.Parallel()
+		id := new(PostProviderID)
+		require.NoError(t, id.Set(""))
+		require.Nil(t, id.Value())
+	})
+	t.Run("not a number", func(t *testing.T) {
+		t.Parallel()
+		id := new(PostProviderID)
+		require.Error(t, id.Set("asdf"))
+		require.Nil(t, id.Value())
+	})
+	t.Run("negative", func(t *testing.T) {
+		t.Parallel()
+		id := new(PostProviderID)
+		require.Error(t, id.Set("-1"))
+		require.Nil(t, id.Value())
 	})
 }

--- a/activation/post_test.go
+++ b/activation/post_test.go
@@ -470,7 +470,7 @@ func newTestPostManager(tb testing.TB, o ...newPostSetupMgrOptionFunc) *testPost
 
 	opts := DefaultPostSetupOpts()
 	opts.DataDir = tb.TempDir()
-	opts.ProviderID.SetUint(initialization.CPUProviderID())
+	opts.ProviderID.SetUint32(initialization.CPUProviderID())
 	opts.Scrypt.N = 2 // Speedup initialization in tests.
 
 	goldenATXID := types.ATXID{2, 3, 4}

--- a/activation/post_test.go
+++ b/activation/post_test.go
@@ -470,7 +470,7 @@ func newTestPostManager(tb testing.TB, o ...newPostSetupMgrOptionFunc) *testPost
 
 	opts := DefaultPostSetupOpts()
 	opts.DataDir = tb.TempDir()
-	opts.ProviderID.SetUint32(initialization.CPUProviderID())
+	opts.ProviderID.SetInt64(int64(initialization.CPUProviderID()))
 	opts.Scrypt.N = 2 // Speedup initialization in tests.
 
 	goldenATXID := types.ATXID{2, 3, 4}

--- a/activation/post_test.go
+++ b/activation/post_test.go
@@ -541,7 +541,7 @@ func TestSettingProviderID(t *testing.T) {
 		t.Parallel()
 		id := new(PostProviderID)
 		require.NoError(t, id.Set("1234"))
-		require.Equal(t, uint32(1234), *id.Value())
+		require.Equal(t, int64(1234), *id.Value())
 	})
 	t.Run("no value", func(t *testing.T) {
 		t.Parallel()
@@ -555,10 +555,11 @@ func TestSettingProviderID(t *testing.T) {
 		require.Error(t, id.Set("asdf"))
 		require.Nil(t, id.Value())
 	})
-	t.Run("negative", func(t *testing.T) {
-		t.Parallel()
-		id := new(PostProviderID)
-		require.Error(t, id.Set("-1"))
-		require.Nil(t, id.Value())
-	})
+	// TODO(mafa): re-enable test, see https://github.com/spacemeshos/go-spacemesh/issues/4801
+	// t.Run("negative", func(t *testing.T) {
+	// 	t.Parallel()
+	// 	id := new(PostProviderID)
+	// 	require.Error(t, id.Set("-1"))
+	// 	require.Nil(t, id.Value())
+	// })
 }

--- a/activation/post_test.go
+++ b/activation/post_test.go
@@ -108,6 +108,19 @@ func TestPostSetupManager_PrepareInitializer(t *testing.T) {
 	req.Error(mgr.PrepareInitializer(ctx, opts))
 }
 
+// TODO(mafa): remove, see https://github.com/spacemeshos/go-spacemesh/issues/4801
+func TestPostSetupManager_PrepareInitializer_BestProvider(t *testing.T) {
+	req := require.New(t)
+
+	mgr := newTestPostManager(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	defer cancel()
+
+	mgr.opts.ProviderID.SetInt64(-1)
+	req.NoError(mgr.PrepareInitializer(ctx, mgr.opts))
+}
+
 func TestPostSetupManager_StartSession_WithoutProvider_Error(t *testing.T) {
 	req := require.New(t)
 

--- a/activation/validation_test.go
+++ b/activation/validation_test.go
@@ -29,18 +29,20 @@ func Test_Validation_VRFNonce(t *testing.T) {
 		LabelsPerUnit: postCfg.LabelsPerUnit,
 	}
 
-	initOpts := DefaultPostSetupOpts()
-	initOpts.DataDir = t.TempDir()
-	initOpts.ProviderID = int(initialization.CPUProviderID())
+	opts := DefaultPostSetupOpts()
+	opts.DataDir = t.TempDir()
+	opts.ProviderID = uint64(initialization.CPUProviderID())
 
 	nodeId := types.BytesToNodeID(make([]byte, 32))
 	commitmentAtxId := types.EmptyATXID
 
+	initOpts, err := opts.ToInitOpts()
+	r.NoError(err)
 	init, err := initialization.NewInitializer(
 		initialization.WithNodeId(nodeId.Bytes()),
 		initialization.WithCommitmentAtxId(commitmentAtxId.Bytes()),
 		initialization.WithConfig(postCfg.ToConfig()),
-		initialization.WithInitOpts(initOpts.ToInitOpts()),
+		initialization.WithInitOpts(initOpts),
 	)
 	r.NoError(err)
 	r.NoError(init.Initialize(context.Background()))
@@ -54,27 +56,27 @@ func Test_Validation_VRFNonce(t *testing.T) {
 	t.Run("valid vrf nonce", func(t *testing.T) {
 		t.Parallel()
 
-		require.NoError(t, v.VRFNonce(nodeId, commitmentAtxId, nonce, meta, initOpts.NumUnits))
+		require.NoError(t, v.VRFNonce(nodeId, commitmentAtxId, nonce, meta, opts.NumUnits))
 	})
 
 	t.Run("invalid vrf nonce", func(t *testing.T) {
 		t.Parallel()
 
 		nonce := types.VRFPostIndex(1)
-		require.Error(t, v.VRFNonce(nodeId, commitmentAtxId, &nonce, meta, initOpts.NumUnits))
+		require.Error(t, v.VRFNonce(nodeId, commitmentAtxId, &nonce, meta, opts.NumUnits))
 	})
 
 	t.Run("wrong commitmentAtxId", func(t *testing.T) {
 		t.Parallel()
 
 		commitmentAtxId := types.ATXID{1, 2, 3}
-		require.Error(t, v.VRFNonce(nodeId, commitmentAtxId, nonce, meta, initOpts.NumUnits))
+		require.Error(t, v.VRFNonce(nodeId, commitmentAtxId, nonce, meta, opts.NumUnits))
 	})
 
 	t.Run("numUnits can be smaller", func(t *testing.T) {
 		t.Parallel()
 
-		require.NoError(t, v.VRFNonce(nodeId, commitmentAtxId, nonce, meta, initOpts.NumUnits-1))
+		require.NoError(t, v.VRFNonce(nodeId, commitmentAtxId, nonce, meta, opts.NumUnits-1))
 	})
 }
 

--- a/activation/validation_test.go
+++ b/activation/validation_test.go
@@ -31,7 +31,7 @@ func Test_Validation_VRFNonce(t *testing.T) {
 
 	opts := DefaultPostSetupOpts()
 	opts.DataDir = t.TempDir()
-	opts.ProviderID = uint64(initialization.CPUProviderID())
+	opts.ProviderID.SetUint(initialization.CPUProviderID())
 
 	nodeId := types.BytesToNodeID(make([]byte, 32))
 	commitmentAtxId := types.EmptyATXID

--- a/activation/validation_test.go
+++ b/activation/validation_test.go
@@ -29,20 +29,18 @@ func Test_Validation_VRFNonce(t *testing.T) {
 		LabelsPerUnit: postCfg.LabelsPerUnit,
 	}
 
-	opts := DefaultPostSetupOpts()
-	opts.DataDir = t.TempDir()
-	opts.ProviderID.SetUint(initialization.CPUProviderID())
+	initOpts := DefaultPostSetupOpts()
+	initOpts.DataDir = t.TempDir()
+	initOpts.ProviderID.SetUint(initialization.CPUProviderID())
 
 	nodeId := types.BytesToNodeID(make([]byte, 32))
 	commitmentAtxId := types.EmptyATXID
 
-	initOpts, err := opts.ToInitOpts()
-	r.NoError(err)
 	init, err := initialization.NewInitializer(
 		initialization.WithNodeId(nodeId.Bytes()),
 		initialization.WithCommitmentAtxId(commitmentAtxId.Bytes()),
 		initialization.WithConfig(postCfg.ToConfig()),
-		initialization.WithInitOpts(initOpts),
+		initialization.WithInitOpts(initOpts.ToInitOpts()),
 	)
 	r.NoError(err)
 	r.NoError(init.Initialize(context.Background()))
@@ -56,27 +54,27 @@ func Test_Validation_VRFNonce(t *testing.T) {
 	t.Run("valid vrf nonce", func(t *testing.T) {
 		t.Parallel()
 
-		require.NoError(t, v.VRFNonce(nodeId, commitmentAtxId, nonce, meta, opts.NumUnits))
+		require.NoError(t, v.VRFNonce(nodeId, commitmentAtxId, nonce, meta, initOpts.NumUnits))
 	})
 
 	t.Run("invalid vrf nonce", func(t *testing.T) {
 		t.Parallel()
 
 		nonce := types.VRFPostIndex(1)
-		require.Error(t, v.VRFNonce(nodeId, commitmentAtxId, &nonce, meta, opts.NumUnits))
+		require.Error(t, v.VRFNonce(nodeId, commitmentAtxId, &nonce, meta, initOpts.NumUnits))
 	})
 
 	t.Run("wrong commitmentAtxId", func(t *testing.T) {
 		t.Parallel()
 
 		commitmentAtxId := types.ATXID{1, 2, 3}
-		require.Error(t, v.VRFNonce(nodeId, commitmentAtxId, nonce, meta, opts.NumUnits))
+		require.Error(t, v.VRFNonce(nodeId, commitmentAtxId, nonce, meta, initOpts.NumUnits))
 	})
 
 	t.Run("numUnits can be smaller", func(t *testing.T) {
 		t.Parallel()
 
-		require.NoError(t, v.VRFNonce(nodeId, commitmentAtxId, nonce, meta, opts.NumUnits-1))
+		require.NoError(t, v.VRFNonce(nodeId, commitmentAtxId, nonce, meta, initOpts.NumUnits-1))
 	})
 }
 

--- a/activation/validation_test.go
+++ b/activation/validation_test.go
@@ -31,7 +31,7 @@ func Test_Validation_VRFNonce(t *testing.T) {
 
 	initOpts := DefaultPostSetupOpts()
 	initOpts.DataDir = t.TempDir()
-	initOpts.ProviderID.SetUint(initialization.CPUProviderID())
+	initOpts.ProviderID.SetUint32(initialization.CPUProviderID())
 
 	nodeId := types.BytesToNodeID(make([]byte, 32))
 	commitmentAtxId := types.EmptyATXID

--- a/activation/validation_test.go
+++ b/activation/validation_test.go
@@ -31,7 +31,7 @@ func Test_Validation_VRFNonce(t *testing.T) {
 
 	initOpts := DefaultPostSetupOpts()
 	initOpts.DataDir = t.TempDir()
-	initOpts.ProviderID.SetUint32(initialization.CPUProviderID())
+	initOpts.ProviderID.SetInt64(int64(initialization.CPUProviderID()))
 
 	nodeId := types.BytesToNodeID(make([]byte, 32))
 	commitmentAtxId := types.EmptyATXID

--- a/api/grpcserver/smesher_service.go
+++ b/api/grpcserver/smesher_service.go
@@ -82,7 +82,7 @@ func (s SmesherService) StartSmeshing(ctx context.Context, in *pb.StartSmeshingR
 	opts.DataDir = in.Opts.DataDir
 	opts.NumUnits = in.Opts.NumUnits
 	opts.MaxFileSize = in.Opts.MaxFileSize
-	opts.ProviderID = int(in.Opts.ProviderId)
+	opts.ProviderID = uint64(in.Opts.ProviderId)
 	opts.Throttle = in.Opts.Throttle
 
 	coinbaseAddr, err := types.StringToAddress(in.Coinbase.Address)

--- a/api/grpcserver/smesher_service.go
+++ b/api/grpcserver/smesher_service.go
@@ -82,7 +82,9 @@ func (s SmesherService) StartSmeshing(ctx context.Context, in *pb.StartSmeshingR
 	opts.DataDir = in.Opts.DataDir
 	opts.NumUnits = in.Opts.NumUnits
 	opts.MaxFileSize = in.Opts.MaxFileSize
-	opts.ProviderID.SetUint(in.Opts.ProviderId) // TODO(mafa): this will set the ID to 0 if not provided
+	if in.Opts.ProviderId != nil {
+		opts.ProviderID.SetUint(*in.Opts.ProviderId)
+	}
 	opts.Throttle = in.Opts.Throttle
 
 	coinbaseAddr, err := types.StringToAddress(in.Coinbase.Address)
@@ -258,11 +260,8 @@ func statusToPbStatus(status *activation.PostSetupStatus) *pb.PostSetupStatus {
 			DataDir:     status.LastOpts.DataDir,
 			NumUnits:    status.LastOpts.NumUnits,
 			MaxFileSize: status.LastOpts.MaxFileSize,
+			ProviderId:  status.LastOpts.ProviderID.Value(),
 			Throttle:    status.LastOpts.Throttle,
-		}
-		id := status.LastOpts.ProviderID.Value()
-		if id != nil { // TODO (mafa): if id is nil it will return 0 as provider ID
-			pbStatus.Opts.ProviderId = *id
 		}
 	}
 

--- a/api/grpcserver/smesher_service.go
+++ b/api/grpcserver/smesher_service.go
@@ -82,7 +82,7 @@ func (s SmesherService) StartSmeshing(ctx context.Context, in *pb.StartSmeshingR
 	opts.DataDir = in.Opts.DataDir
 	opts.NumUnits = in.Opts.NumUnits
 	opts.MaxFileSize = in.Opts.MaxFileSize
-	opts.ProviderID = uint64(in.Opts.ProviderId)
+	opts.ProviderID.SetUint(in.Opts.ProviderId) // TODO(mafa): this will set the ID to 0 if not provided
 	opts.Throttle = in.Opts.Throttle
 
 	coinbaseAddr, err := types.StringToAddress(in.Coinbase.Address)
@@ -258,8 +258,11 @@ func statusToPbStatus(status *activation.PostSetupStatus) *pb.PostSetupStatus {
 			DataDir:     status.LastOpts.DataDir,
 			NumUnits:    status.LastOpts.NumUnits,
 			MaxFileSize: status.LastOpts.MaxFileSize,
-			ProviderId:  uint32(status.LastOpts.ProviderID),
 			Throttle:    status.LastOpts.Throttle,
+		}
+		id := status.LastOpts.ProviderID.Value()
+		if id != nil { // TODO (mafa): if id is nil it will return 0 as provider ID
+			pbStatus.Opts.ProviderId = *id
 		}
 	}
 

--- a/api/grpcserver/smesher_service.go
+++ b/api/grpcserver/smesher_service.go
@@ -83,7 +83,7 @@ func (s SmesherService) StartSmeshing(ctx context.Context, in *pb.StartSmeshingR
 	opts.NumUnits = in.Opts.NumUnits
 	opts.MaxFileSize = in.Opts.MaxFileSize
 	if in.Opts.ProviderId != nil {
-		opts.ProviderID.SetUint(*in.Opts.ProviderId)
+		opts.ProviderID.SetUint32(*in.Opts.ProviderId)
 	}
 	opts.Throttle = in.Opts.Throttle
 

--- a/api/grpcserver/smesher_service.go
+++ b/api/grpcserver/smesher_service.go
@@ -83,7 +83,7 @@ func (s SmesherService) StartSmeshing(ctx context.Context, in *pb.StartSmeshingR
 	opts.NumUnits = in.Opts.NumUnits
 	opts.MaxFileSize = in.Opts.MaxFileSize
 	if in.Opts.ProviderId != nil {
-		opts.ProviderID.SetUint32(*in.Opts.ProviderId)
+		opts.ProviderID.SetInt64(int64(*in.Opts.ProviderId))
 	}
 	opts.Throttle = in.Opts.Throttle
 
@@ -256,11 +256,16 @@ func statusToPbStatus(status *activation.PostSetupStatus) *pb.PostSetupStatus {
 	pbStatus.NumLabelsWritten = status.NumLabelsWritten
 
 	if status.LastOpts != nil {
+		var providerID *uint32
+		if status.LastOpts.ProviderID.Value() != nil {
+			*providerID = uint32(*status.LastOpts.ProviderID.Value())
+		}
+
 		pbStatus.Opts = &pb.PostSetupOpts{
 			DataDir:     status.LastOpts.DataDir,
 			NumUnits:    status.LastOpts.NumUnits,
 			MaxFileSize: status.LastOpts.MaxFileSize,
-			ProviderId:  status.LastOpts.ProviderID.Value(),
+			ProviderId:  providerID,
 			Throttle:    status.LastOpts.Throttle,
 		}
 	}

--- a/api/grpcserver/smesher_service_test.go
+++ b/api/grpcserver/smesher_service_test.go
@@ -53,15 +53,16 @@ func TestStartSmeshingPassesCorrectSmeshingOpts(t *testing.T) {
 	types.SetNetworkHRP("stest")
 	addr, err := types.StringToAddress("stest1qqqqqqrs60l66w5uksxzmaznwq6xnhqfv56c28qlkm4a5")
 	require.NoError(t, err)
-	smeshingProvider.EXPECT().StartSmeshing(addr, activation.PostSetupOpts{
+	opts := activation.PostSetupOpts{
 		DataDir:          "data-dir",
 		NumUnits:         1,
 		MaxFileSize:      1024,
-		ProviderID:       7,
 		Throttle:         true,
 		Scrypt:           config.DefaultLabelParams(),
 		ComputeBatchSize: config.DefaultComputeBatchSize,
-	}).Return(nil)
+	}
+	opts.ProviderID.SetUint(7)
+	smeshingProvider.EXPECT().StartSmeshing(addr, opts).Return(nil)
 
 	_, err = svc.StartSmeshing(context.Background(), &pb.StartSmeshingRequest{
 		Coinbase: &pb.AccountId{Address: "stest1qqqqqqrs60l66w5uksxzmaznwq6xnhqfv56c28qlkm4a5"},

--- a/api/grpcserver/smesher_service_test.go
+++ b/api/grpcserver/smesher_service_test.go
@@ -53,6 +53,7 @@ func TestStartSmeshingPassesCorrectSmeshingOpts(t *testing.T) {
 	types.SetNetworkHRP("stest")
 	addr, err := types.StringToAddress("stest1qqqqqqrs60l66w5uksxzmaznwq6xnhqfv56c28qlkm4a5")
 	require.NoError(t, err)
+	providerID := uint32(7)
 	opts := activation.PostSetupOpts{
 		DataDir:          "data-dir",
 		NumUnits:         1,
@@ -61,7 +62,7 @@ func TestStartSmeshingPassesCorrectSmeshingOpts(t *testing.T) {
 		Scrypt:           config.DefaultLabelParams(),
 		ComputeBatchSize: config.DefaultComputeBatchSize,
 	}
-	opts.ProviderID.SetUint(7)
+	opts.ProviderID.SetUint(providerID)
 	smeshingProvider.EXPECT().StartSmeshing(addr, opts).Return(nil)
 
 	_, err = svc.StartSmeshing(context.Background(), &pb.StartSmeshingRequest{
@@ -70,7 +71,7 @@ func TestStartSmeshingPassesCorrectSmeshingOpts(t *testing.T) {
 			DataDir:     "data-dir",
 			NumUnits:    1,
 			MaxFileSize: 1024,
-			ProviderId:  7,
+			ProviderId:  &providerID,
 			Throttle:    true,
 		},
 	})

--- a/api/grpcserver/smesher_service_test.go
+++ b/api/grpcserver/smesher_service_test.go
@@ -62,7 +62,7 @@ func TestStartSmeshingPassesCorrectSmeshingOpts(t *testing.T) {
 		Scrypt:           config.DefaultLabelParams(),
 		ComputeBatchSize: config.DefaultComputeBatchSize,
 	}
-	opts.ProviderID.SetUint(providerID)
+	opts.ProviderID.SetUint32(providerID)
 	smeshingProvider.EXPECT().StartSmeshing(addr, opts).Return(nil)
 
 	_, err = svc.StartSmeshing(context.Background(), &pb.StartSmeshingRequest{

--- a/api/grpcserver/smesher_service_test.go
+++ b/api/grpcserver/smesher_service_test.go
@@ -62,7 +62,7 @@ func TestStartSmeshingPassesCorrectSmeshingOpts(t *testing.T) {
 		Scrypt:           config.DefaultLabelParams(),
 		ComputeBatchSize: config.DefaultComputeBatchSize,
 	}
-	opts.ProviderID.SetUint32(providerID)
+	opts.ProviderID.SetInt64(int64(providerID))
 	smeshingProvider.EXPECT().StartSmeshing(addr, opts).Return(nil)
 
 	_, err = svc.StartSmeshing(context.Background(), &pb.StartSmeshingRequest{

--- a/cmd/base.go
+++ b/cmd/base.go
@@ -79,6 +79,12 @@ func EnsureCLIFlags(cmd *cobra.Command, appCFG *config.Config) error {
 						panic(err.Error())
 					}
 					val = dst
+				case "activation.PostProviderID":
+					dst := activation.PostProviderID{}
+					if err := dst.UnmarshalText([]byte(viper.GetString(name))); err != nil {
+						panic(err.Error())
+					}
+					val = dst
 				default:
 					val = viper.Get(name)
 				}

--- a/cmd/base.go
+++ b/cmd/base.go
@@ -81,7 +81,7 @@ func EnsureCLIFlags(cmd *cobra.Command, appCFG *config.Config) error {
 					val = dst
 				case "activation.PostProviderID":
 					dst := activation.PostProviderID{}
-					if err := dst.UnmarshalText([]byte(viper.GetString(name))); err != nil {
+					if err := dst.Set(viper.GetString(name)); err != nil {
 						panic(err.Error())
 					}
 					val = dst

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -239,8 +239,8 @@ func AddCommands(cmd *cobra.Command) {
 		cfg.SMESHING.Opts.NumUnits, "")
 	cmd.PersistentFlags().Uint64Var(&cfg.SMESHING.Opts.MaxFileSize, "smeshing-opts-maxfilesize",
 		cfg.SMESHING.Opts.MaxFileSize, "")
-	cmd.PersistentFlags().Uint64Var(&cfg.SMESHING.Opts.ProviderID, "smeshing-opts-provider",
-		cfg.SMESHING.Opts.ProviderID, "")
+	cmd.PersistentFlags().VarP(&cfg.SMESHING.Opts.ProviderID, "smeshing-opts-provider",
+		"", "")
 	cmd.PersistentFlags().BoolVar(&cfg.SMESHING.Opts.Throttle, "smeshing-opts-throttle",
 		cfg.SMESHING.Opts.Throttle, "")
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -239,7 +239,7 @@ func AddCommands(cmd *cobra.Command) {
 		cfg.SMESHING.Opts.NumUnits, "")
 	cmd.PersistentFlags().Uint64Var(&cfg.SMESHING.Opts.MaxFileSize, "smeshing-opts-maxfilesize",
 		cfg.SMESHING.Opts.MaxFileSize, "")
-	cmd.PersistentFlags().IntVar(&cfg.SMESHING.Opts.ProviderID, "smeshing-opts-provider",
+	cmd.PersistentFlags().Uint64Var(&cfg.SMESHING.Opts.ProviderID, "smeshing-opts-provider",
 		cfg.SMESHING.Opts.ProviderID, "")
 	cmd.PersistentFlags().BoolVar(&cfg.SMESHING.Opts.Throttle, "smeshing-opts-throttle",
 		cfg.SMESHING.Opts.Throttle, "")

--- a/config/presets/fastnet.go
+++ b/config/presets/fastnet.go
@@ -56,7 +56,7 @@ func fastnet() config.Config {
 
 	conf.SMESHING.CoinbaseAccount = types.GenerateAddress([]byte("1")).String()
 	conf.SMESHING.Start = false
-	conf.SMESHING.Opts.ProviderID = uint64(initialization.CPUProviderID())
+	conf.SMESHING.Opts.ProviderID.SetUint(initialization.CPUProviderID())
 	conf.SMESHING.Opts.NumUnits = 2
 	conf.SMESHING.Opts.Throttle = true
 	// Override proof of work flags to use light mode (less memory intensive)

--- a/config/presets/fastnet.go
+++ b/config/presets/fastnet.go
@@ -56,7 +56,7 @@ func fastnet() config.Config {
 
 	conf.SMESHING.CoinbaseAccount = types.GenerateAddress([]byte("1")).String()
 	conf.SMESHING.Start = false
-	conf.SMESHING.Opts.ProviderID = int(initialization.CPUProviderID())
+	conf.SMESHING.Opts.ProviderID = uint64(initialization.CPUProviderID())
 	conf.SMESHING.Opts.NumUnits = 2
 	conf.SMESHING.Opts.Throttle = true
 	// Override proof of work flags to use light mode (less memory intensive)

--- a/config/presets/fastnet.go
+++ b/config/presets/fastnet.go
@@ -56,7 +56,7 @@ func fastnet() config.Config {
 
 	conf.SMESHING.CoinbaseAccount = types.GenerateAddress([]byte("1")).String()
 	conf.SMESHING.Start = false
-	conf.SMESHING.Opts.ProviderID.SetUint(initialization.CPUProviderID())
+	conf.SMESHING.Opts.ProviderID.SetUint32(initialization.CPUProviderID())
 	conf.SMESHING.Opts.NumUnits = 2
 	conf.SMESHING.Opts.Throttle = true
 	// Override proof of work flags to use light mode (less memory intensive)

--- a/config/presets/fastnet.go
+++ b/config/presets/fastnet.go
@@ -56,7 +56,7 @@ func fastnet() config.Config {
 
 	conf.SMESHING.CoinbaseAccount = types.GenerateAddress([]byte("1")).String()
 	conf.SMESHING.Start = false
-	conf.SMESHING.Opts.ProviderID.SetUint32(initialization.CPUProviderID())
+	conf.SMESHING.Opts.ProviderID.SetInt64(int64(initialization.CPUProviderID()))
 	conf.SMESHING.Opts.NumUnits = 2
 	conf.SMESHING.Opts.Throttle = true
 	// Override proof of work flags to use light mode (less memory intensive)

--- a/config/presets/standalone.go
+++ b/config/presets/standalone.go
@@ -58,7 +58,7 @@ func standalone() config.Config {
 
 	conf.SMESHING.CoinbaseAccount = types.GenerateAddress([]byte("1")).String()
 	conf.SMESHING.Start = true
-	conf.SMESHING.Opts.ProviderID = uint64(initialization.CPUProviderID())
+	conf.SMESHING.Opts.ProviderID.SetUint(initialization.CPUProviderID())
 	conf.SMESHING.Opts.NumUnits = 1
 	conf.SMESHING.Opts.Throttle = true
 	conf.SMESHING.Opts.DataDir = conf.DataDirParent

--- a/config/presets/standalone.go
+++ b/config/presets/standalone.go
@@ -58,7 +58,7 @@ func standalone() config.Config {
 
 	conf.SMESHING.CoinbaseAccount = types.GenerateAddress([]byte("1")).String()
 	conf.SMESHING.Start = true
-	conf.SMESHING.Opts.ProviderID = int(initialization.CPUProviderID())
+	conf.SMESHING.Opts.ProviderID = uint64(initialization.CPUProviderID())
 	conf.SMESHING.Opts.NumUnits = 1
 	conf.SMESHING.Opts.Throttle = true
 	conf.SMESHING.Opts.DataDir = conf.DataDirParent

--- a/config/presets/standalone.go
+++ b/config/presets/standalone.go
@@ -58,7 +58,7 @@ func standalone() config.Config {
 
 	conf.SMESHING.CoinbaseAccount = types.GenerateAddress([]byte("1")).String()
 	conf.SMESHING.Start = true
-	conf.SMESHING.Opts.ProviderID.SetUint32(initialization.CPUProviderID())
+	conf.SMESHING.Opts.ProviderID.SetInt64(int64(initialization.CPUProviderID()))
 	conf.SMESHING.Opts.NumUnits = 1
 	conf.SMESHING.Opts.Throttle = true
 	conf.SMESHING.Opts.DataDir = conf.DataDirParent

--- a/config/presets/standalone.go
+++ b/config/presets/standalone.go
@@ -58,7 +58,7 @@ func standalone() config.Config {
 
 	conf.SMESHING.CoinbaseAccount = types.GenerateAddress([]byte("1")).String()
 	conf.SMESHING.Start = true
-	conf.SMESHING.Opts.ProviderID.SetUint(initialization.CPUProviderID())
+	conf.SMESHING.Opts.ProviderID.SetUint32(initialization.CPUProviderID())
 	conf.SMESHING.Opts.NumUnits = 1
 	conf.SMESHING.Opts.Throttle = true
 	conf.SMESHING.Opts.DataDir = conf.DataDirParent

--- a/config/presets/testnet.go
+++ b/config/presets/testnet.go
@@ -56,7 +56,7 @@ func testnet() config.Config {
 
 	conf.SMESHING.CoinbaseAccount = types.GenerateAddress([]byte("1")).String()
 	conf.SMESHING.Start = false
-	conf.SMESHING.Opts.ProviderID = uint64(initialization.CPUProviderID())
+	conf.SMESHING.Opts.ProviderID.SetUint(initialization.CPUProviderID())
 	conf.SMESHING.Opts.NumUnits = 2
 	conf.SMESHING.Opts.Throttle = true
 

--- a/config/presets/testnet.go
+++ b/config/presets/testnet.go
@@ -56,7 +56,7 @@ func testnet() config.Config {
 
 	conf.SMESHING.CoinbaseAccount = types.GenerateAddress([]byte("1")).String()
 	conf.SMESHING.Start = false
-	conf.SMESHING.Opts.ProviderID = int(initialization.CPUProviderID())
+	conf.SMESHING.Opts.ProviderID = uint64(initialization.CPUProviderID())
 	conf.SMESHING.Opts.NumUnits = 2
 	conf.SMESHING.Opts.Throttle = true
 

--- a/config/presets/testnet.go
+++ b/config/presets/testnet.go
@@ -56,7 +56,7 @@ func testnet() config.Config {
 
 	conf.SMESHING.CoinbaseAccount = types.GenerateAddress([]byte("1")).String()
 	conf.SMESHING.Start = false
-	conf.SMESHING.Opts.ProviderID.SetUint32(initialization.CPUProviderID())
+	conf.SMESHING.Opts.ProviderID.SetInt64(int64(initialization.CPUProviderID()))
 	conf.SMESHING.Opts.NumUnits = 2
 	conf.SMESHING.Opts.Throttle = true
 

--- a/config/presets/testnet.go
+++ b/config/presets/testnet.go
@@ -56,7 +56,7 @@ func testnet() config.Config {
 
 	conf.SMESHING.CoinbaseAccount = types.GenerateAddress([]byte("1")).String()
 	conf.SMESHING.Start = false
-	conf.SMESHING.Opts.ProviderID.SetUint(initialization.CPUProviderID())
+	conf.SMESHING.Opts.ProviderID.SetUint32(initialization.CPUProviderID())
 	conf.SMESHING.Opts.NumUnits = 2
 	conf.SMESHING.Opts.Throttle = true
 

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/pyroscope-io/pyroscope v0.37.2
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/seehuhn/mt19937 v1.0.0
-	github.com/spacemeshos/api/release/go v1.17.0
+	github.com/spacemeshos/api/release/go v1.17.1-0.20230804164905-1af0fe873e1f
 	github.com/spacemeshos/economics v0.1.0
 	github.com/spacemeshos/fixed v0.1.0
 	github.com/spacemeshos/go-scale v1.1.10

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/spacemeshos/go-scale v1.1.10
 	github.com/spacemeshos/merkle-tree v0.2.2
 	github.com/spacemeshos/poet v0.8.7
-	github.com/spacemeshos/post v0.8.12-0.20230804123744-7e32021db1c1
+	github.com/spacemeshos/post v0.8.12-0.20230804154811-fd4a2e23197b
 	github.com/spf13/afero v1.9.5
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/spacemeshos/go-scale v1.1.10
 	github.com/spacemeshos/merkle-tree v0.2.2
 	github.com/spacemeshos/poet v0.8.7
-	github.com/spacemeshos/post v0.8.11
+	github.com/spacemeshos/post v0.8.12-0.20230804123744-7e32021db1c1
 	github.com/spf13/afero v1.9.5
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/pyroscope-io/pyroscope v0.37.2
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/seehuhn/mt19937 v1.0.0
-	github.com/spacemeshos/api/release/go v1.17.1-0.20230804164905-1af0fe873e1f
+	github.com/spacemeshos/api/release/go v1.18.0
 	github.com/spacemeshos/economics v0.1.0
 	github.com/spacemeshos/fixed v0.1.0
 	github.com/spacemeshos/go-scale v1.1.10

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/spacemeshos/go-scale v1.1.10
 	github.com/spacemeshos/merkle-tree v0.2.2
 	github.com/spacemeshos/poet v0.8.7
-	github.com/spacemeshos/post v0.8.12-0.20230804154811-fd4a2e23197b
+	github.com/spacemeshos/post v0.9.0
 	github.com/spf13/afero v1.9.5
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -647,8 +647,8 @@ github.com/spacemeshos/merkle-tree v0.2.2 h1:+zF+17CwVebq9UzShunUBXv16rEVKIJHh2C
 github.com/spacemeshos/merkle-tree v0.2.2/go.mod h1:0Q/z4S5Kt9qz/c3qWa7hKA1yT7n7odyysbPIUTRu/xo=
 github.com/spacemeshos/poet v0.8.7 h1:Q85SDIlV0Asn7AJ9TaIbE1upimcXSUixYVeSY2bFqXI=
 github.com/spacemeshos/poet v0.8.7/go.mod h1:eRT87JENlVfItdJvKtnFCnSFcceeYTRrsXfF5u5sE8k=
-github.com/spacemeshos/post v0.8.11 h1:uZo8n5wF0fGOxRzXHabU/Buu9aLyPT4YWi6ZFms9mWg=
-github.com/spacemeshos/post v0.8.11/go.mod h1:LDj6XQht1ZvTZurBJ+LZNf17t92qIQymWgU2sY6V2Zs=
+github.com/spacemeshos/post v0.8.12-0.20230804123744-7e32021db1c1 h1:+T+Pg/fHVBS7rPS4TBSUDRUo7DhLHreSFhjRlzcGpr0=
+github.com/spacemeshos/post v0.8.12-0.20230804123744-7e32021db1c1/go.mod h1:LDj6XQht1ZvTZurBJ+LZNf17t92qIQymWgU2sY6V2Zs=
 github.com/spacemeshos/sha256-simd v0.1.0 h1:G7Mfu5RYdQiuE+wu4ZyJ7I0TI74uqLhFnKblEnSpjYI=
 github.com/spacemeshos/sha256-simd v0.1.0/go.mod h1:O8CClVIilId7RtuCMV2+YzMj6qjVn75JsxOxaE8vcfM=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=

--- a/go.sum
+++ b/go.sum
@@ -635,8 +635,8 @@ github.com/smartystreets/goconvey v1.7.2 h1:9RBaZCeXEQ3UselpuwUQHltGVXvdwm6cv1hg
 github.com/smartystreets/goconvey v1.7.2/go.mod h1:Vw0tHAZW6lzCRk3xgdin6fKYcG+G3Pg9vgXWeJpQFMM=
 github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d/go.mod h1:UdhH50NIW0fCiwBSr0co2m7BnFLdv4fQTgdqdJTHFeE=
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
-github.com/spacemeshos/api/release/go v1.17.0 h1:GZT2foJ619pYLYbNGWkat8QSFJnH1u2eOWw8AwSlz/g=
-github.com/spacemeshos/api/release/go v1.17.0/go.mod h1:aSK7c2PUsle+EpC9VPAsPnsjKWDbo+NzT7kZgmzIZeM=
+github.com/spacemeshos/api/release/go v1.17.1-0.20230804164905-1af0fe873e1f h1:PA4HaUi7VDCaAP2iLTflngrxym8Od2iu3eeDUFAs7kQ=
+github.com/spacemeshos/api/release/go v1.17.1-0.20230804164905-1af0fe873e1f/go.mod h1:nC5g7IVRNxF8Kl/Tzvr7cQeYBwHN4sMTVsIEa6Ebtl4=
 github.com/spacemeshos/economics v0.1.0 h1:PJAKbhBKqbbdCYTB29pkmc8sYqK3pKUAiuAvQxuSJEg=
 github.com/spacemeshos/economics v0.1.0/go.mod h1:Bz0wRDwCOUP1A6w3cPW6iuUBGME8Tz48sIriYiohsBg=
 github.com/spacemeshos/fixed v0.1.0 h1:20KIGvxLlAsuidQrvuwwHe6PrvqeTKzbJIsScbmnUPQ=

--- a/go.sum
+++ b/go.sum
@@ -647,8 +647,8 @@ github.com/spacemeshos/merkle-tree v0.2.2 h1:+zF+17CwVebq9UzShunUBXv16rEVKIJHh2C
 github.com/spacemeshos/merkle-tree v0.2.2/go.mod h1:0Q/z4S5Kt9qz/c3qWa7hKA1yT7n7odyysbPIUTRu/xo=
 github.com/spacemeshos/poet v0.8.7 h1:Q85SDIlV0Asn7AJ9TaIbE1upimcXSUixYVeSY2bFqXI=
 github.com/spacemeshos/poet v0.8.7/go.mod h1:eRT87JENlVfItdJvKtnFCnSFcceeYTRrsXfF5u5sE8k=
-github.com/spacemeshos/post v0.8.12-0.20230804123744-7e32021db1c1 h1:+T+Pg/fHVBS7rPS4TBSUDRUo7DhLHreSFhjRlzcGpr0=
-github.com/spacemeshos/post v0.8.12-0.20230804123744-7e32021db1c1/go.mod h1:LDj6XQht1ZvTZurBJ+LZNf17t92qIQymWgU2sY6V2Zs=
+github.com/spacemeshos/post v0.8.12-0.20230804154811-fd4a2e23197b h1:HEv+B7KHoIN/TWHYJB+hjO/HHJ8aPNZEgNffbLKjnIA=
+github.com/spacemeshos/post v0.8.12-0.20230804154811-fd4a2e23197b/go.mod h1:rbHDofaGEiFuxSefJ0MPu2dMzyCvXmFWSMTXIn77lEc=
 github.com/spacemeshos/sha256-simd v0.1.0 h1:G7Mfu5RYdQiuE+wu4ZyJ7I0TI74uqLhFnKblEnSpjYI=
 github.com/spacemeshos/sha256-simd v0.1.0/go.mod h1:O8CClVIilId7RtuCMV2+YzMj6qjVn75JsxOxaE8vcfM=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=

--- a/go.sum
+++ b/go.sum
@@ -647,8 +647,8 @@ github.com/spacemeshos/merkle-tree v0.2.2 h1:+zF+17CwVebq9UzShunUBXv16rEVKIJHh2C
 github.com/spacemeshos/merkle-tree v0.2.2/go.mod h1:0Q/z4S5Kt9qz/c3qWa7hKA1yT7n7odyysbPIUTRu/xo=
 github.com/spacemeshos/poet v0.8.7 h1:Q85SDIlV0Asn7AJ9TaIbE1upimcXSUixYVeSY2bFqXI=
 github.com/spacemeshos/poet v0.8.7/go.mod h1:eRT87JENlVfItdJvKtnFCnSFcceeYTRrsXfF5u5sE8k=
-github.com/spacemeshos/post v0.8.12-0.20230804154811-fd4a2e23197b h1:HEv+B7KHoIN/TWHYJB+hjO/HHJ8aPNZEgNffbLKjnIA=
-github.com/spacemeshos/post v0.8.12-0.20230804154811-fd4a2e23197b/go.mod h1:rbHDofaGEiFuxSefJ0MPu2dMzyCvXmFWSMTXIn77lEc=
+github.com/spacemeshos/post v0.9.0 h1:nOBJf15QtYpASymHB0Kapsn5bcpUh7meLsA4uJmDUN0=
+github.com/spacemeshos/post v0.9.0/go.mod h1:rbHDofaGEiFuxSefJ0MPu2dMzyCvXmFWSMTXIn77lEc=
 github.com/spacemeshos/sha256-simd v0.1.0 h1:G7Mfu5RYdQiuE+wu4ZyJ7I0TI74uqLhFnKblEnSpjYI=
 github.com/spacemeshos/sha256-simd v0.1.0/go.mod h1:O8CClVIilId7RtuCMV2+YzMj6qjVn75JsxOxaE8vcfM=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=

--- a/go.sum
+++ b/go.sum
@@ -635,8 +635,8 @@ github.com/smartystreets/goconvey v1.7.2 h1:9RBaZCeXEQ3UselpuwUQHltGVXvdwm6cv1hg
 github.com/smartystreets/goconvey v1.7.2/go.mod h1:Vw0tHAZW6lzCRk3xgdin6fKYcG+G3Pg9vgXWeJpQFMM=
 github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d/go.mod h1:UdhH50NIW0fCiwBSr0co2m7BnFLdv4fQTgdqdJTHFeE=
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
-github.com/spacemeshos/api/release/go v1.17.1-0.20230804164905-1af0fe873e1f h1:PA4HaUi7VDCaAP2iLTflngrxym8Od2iu3eeDUFAs7kQ=
-github.com/spacemeshos/api/release/go v1.17.1-0.20230804164905-1af0fe873e1f/go.mod h1:nC5g7IVRNxF8Kl/Tzvr7cQeYBwHN4sMTVsIEa6Ebtl4=
+github.com/spacemeshos/api/release/go v1.18.0 h1:58Ep0+0C9WGYNZJWD1Ijvf3NP8ffb7rT4yJiCa6GuvY=
+github.com/spacemeshos/api/release/go v1.18.0/go.mod h1:nC5g7IVRNxF8Kl/Tzvr7cQeYBwHN4sMTVsIEa6Ebtl4=
 github.com/spacemeshos/economics v0.1.0 h1:PJAKbhBKqbbdCYTB29pkmc8sYqK3pKUAiuAvQxuSJEg=
 github.com/spacemeshos/economics v0.1.0/go.mod h1:Bz0wRDwCOUP1A6w3cPW6iuUBGME8Tz48sIriYiohsBg=
 github.com/spacemeshos/fixed v0.1.0 h1:20KIGvxLlAsuidQrvuwwHe6PrvqeTKzbJIsScbmnUPQ=

--- a/node/mapstructureutil/postproviderid.go
+++ b/node/mapstructureutil/postproviderid.go
@@ -1,0 +1,35 @@
+package mapstructureutil
+
+import (
+	"fmt"
+	"math"
+	"reflect"
+
+	"github.com/mitchellh/mapstructure"
+
+	"github.com/spacemeshos/go-spacemesh/activation"
+)
+
+// PostProviderIDDecodeFunc mapstructure decode func for activation.PostProviderID.
+func PostProviderIDDecodeFunc() mapstructure.DecodeHookFunc {
+	return func(f, t reflect.Type, data any) (any, error) {
+		if t != reflect.TypeOf(activation.PostProviderID{}) {
+			return data, nil
+		}
+
+		switch f.Kind() {
+		case reflect.Float64:
+			value := data.(float64)
+			if value > math.MaxUint32 || value < 0 || value != math.Trunc(value) {
+				return nil, fmt.Errorf("invalid provider ID value: %v", value)
+			}
+			id := activation.PostProviderID{}
+			id.SetUint32(uint32(value))
+			return id, nil
+		case reflect.String:
+			return nil, fmt.Errorf("invalid provider ID value: %v", data)
+		default:
+			return data, nil
+		}
+	}
+}

--- a/node/mapstructureutil/postproviderid.go
+++ b/node/mapstructureutil/postproviderid.go
@@ -20,11 +20,12 @@ func PostProviderIDDecodeFunc() mapstructure.DecodeHookFunc {
 		switch f.Kind() {
 		case reflect.Float64:
 			value := data.(float64)
-			if value > math.MaxUint32 || value < 0 || value != math.Trunc(value) {
+			// TODO(mafa): update check from `value < -1` to `value < 0`, see https://github.com/spacemeshos/go-spacemesh/issues/4801
+			if value > math.MaxUint32 || value < -1 || value != math.Trunc(value) {
 				return nil, fmt.Errorf("invalid provider ID value: %v", value)
 			}
 			id := activation.PostProviderID{}
-			id.SetUint32(uint32(value))
+			id.SetInt64(int64(value))
 			return id, nil
 		case reflect.String:
 			return nil, fmt.Errorf("invalid provider ID value: %v", data)

--- a/node/node.go
+++ b/node/node.go
@@ -249,6 +249,7 @@ func LoadConfigFromFile() (*config.Config, error) {
 		mapstructure.StringToTimeDurationHookFunc(),
 		mapstructure.StringToSliceHookFunc(","),
 		mapstructureutil.BigRatDecodeFunc(),
+		mapstructureutil.PostProviderIDDecodeFunc(),
 		mapstructure.TextUnmarshallerHookFunc(),
 	)
 

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -999,7 +999,7 @@ func getTestDefaultConfig(tb testing.TB) *config.Config {
 	cfg.SMESHING = config.DefaultSmeshingConfig()
 	cfg.SMESHING.Start = true
 	cfg.SMESHING.Opts.NumUnits = cfg.POST.MinNumUnits + 1
-	cfg.SMESHING.Opts.ProviderID = uint64(initialization.CPUProviderID())
+	cfg.SMESHING.Opts.ProviderID.SetUint(initialization.CPUProviderID())
 
 	// note: these need to be set sufficiently low enough that turbohare finishes well before the LayerDurationSec
 	cfg.HARE.RoundDuration = 2

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -999,7 +999,7 @@ func getTestDefaultConfig(tb testing.TB) *config.Config {
 	cfg.SMESHING = config.DefaultSmeshingConfig()
 	cfg.SMESHING.Start = true
 	cfg.SMESHING.Opts.NumUnits = cfg.POST.MinNumUnits + 1
-	cfg.SMESHING.Opts.ProviderID = int(initialization.CPUProviderID())
+	cfg.SMESHING.Opts.ProviderID = uint64(initialization.CPUProviderID())
 
 	// note: these need to be set sufficiently low enough that turbohare finishes well before the LayerDurationSec
 	cfg.HARE.RoundDuration = 2

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -783,7 +783,7 @@ func TestConfig_CustomTypes(t *testing.T) {
 			cli:    "--smeshing-opts-provider=-1",
 			config: `{"smeshing": {"smeshing-opts": {"smeshing-opts-provider": -1}}}`,
 			updatePreset: func(t *testing.T, c *config.Config) {
-				c.SMESHING.Opts.ProviderID.SetInt64(0)
+				c.SMESHING.Opts.ProviderID.SetInt64(-1)
 			},
 		},
 		{

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -774,7 +774,16 @@ func TestConfig_CustomTypes(t *testing.T) {
 			cli:    "--smeshing-opts-provider=1337",
 			config: `{"smeshing": {"smeshing-opts": {"smeshing-opts-provider": 1337}}}`,
 			updatePreset: func(t *testing.T, c *config.Config) {
-				c.SMESHING.Opts.ProviderID.SetUint32(1337)
+				c.SMESHING.Opts.ProviderID.SetInt64(1337)
+			},
+		},
+		{
+			// TODO(mafa): remove this test case, see https://github.com/spacemeshos/go-spacemesh/issues/4801
+			name:   "smeshing-opts-provider",
+			cli:    "--smeshing-opts-provider=-1",
+			config: `{"smeshing": {"smeshing-opts": {"smeshing-opts-provider": -1}}}`,
+			updatePreset: func(t *testing.T, c *config.Config) {
+				c.SMESHING.Opts.ProviderID.SetInt64(0)
 			},
 		},
 		{
@@ -881,11 +890,12 @@ func TestConfig_PostProviderID_InvalidValues(t *testing.T) {
 			cliValue:    "not-a-number",
 			configValue: "\"not-a-number\"",
 		},
-		{
-			name:        "negative number",
-			cliValue:    "-1",
-			configValue: "-1",
-		},
+		// TODO(mafa): still accepted for backward compatibility, see https://github.com/spacemeshos/go-spacemesh/issues/4801
+		// {
+		// 	name:        "negative number",
+		// 	cliValue:    "-1",
+		// 	configValue: "-1",
+		// },
 		{
 			name:        "number too large for uint32",
 			cliValue:    "4294967296",
@@ -1158,7 +1168,7 @@ func getTestDefaultConfig(tb testing.TB) *config.Config {
 	cfg.SMESHING = config.DefaultSmeshingConfig()
 	cfg.SMESHING.Start = true
 	cfg.SMESHING.Opts.NumUnits = cfg.POST.MinNumUnits + 1
-	cfg.SMESHING.Opts.ProviderID.SetUint32(initialization.CPUProviderID())
+	cfg.SMESHING.Opts.ProviderID.SetInt64(int64(initialization.CPUProviderID()))
 
 	// note: these need to be set sufficiently low enough that turbohare finishes well before the LayerDurationSec
 	cfg.HARE.RoundDuration = 2


### PR DESCRIPTION
## Motivation
Closes https://github.com/spacemeshos/post/pull/212

Merge after: https://github.com/spacemeshos/post/pull/213 and https://github.com/spacemeshos/api/pull/256

## Changes
- Smeshing Provider ID is still parsed as `uint32` from config and command line (to not unexpectedly break anything) but now can be `nil` or unset.
- `-1` has been removed as "automatically select best provider" option. Instead the user has to manually set the provider of their choice.

## Test Plan
- New tests were added that check that start smeshing fails without provider if initialization isn't complete and passes when initialization is completed
- Tests were added that ensure that provider ID is parsed correctly when passed via CLI or config

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
