### PR TITLE
hare: new node passively participate in the epoch it becomes synced

### DIFF
--- a/hare/algorithm_test.go
+++ b/hare/algorithm_test.go
@@ -179,7 +179,7 @@ func (mev *mockEligibilityValidator) ValidateEligibilityGossip(context.Context, 
 
 // We assert that the threshold X is met as long as there is at least one
 // honest vote and the sum of honest, dishonest and known equivocator is >= X.
-func TestCountInfoMeetsTrheshold(t *testing.T) {
+func TestCountInfoMeetsThreshold(t *testing.T) {
 	c := &CountInfo{}
 	c.IncHonest(1)
 	assert.True(t, c.Meet(1))
@@ -228,6 +228,7 @@ func TestConsensusProcess_TerminationLimit(t *testing.T) {
 func TestConsensusProcess_PassiveParticipant(t *testing.T) {
 	c := config.Config{N: 10, RoundDuration: 200 * time.Millisecond, ExpectedLeaders: 5, LimitIterations: 1, LimitConcurrent: 1, Hdist: 20}
 	p := generateConsensusProcessWithConfig(t, c, make(chan any, 10))
+	p.alwaysPassive = true
 	p.Start()
 	require.Eventually(t, func() bool {
 		return p.getRound()/4 == uint32(1)
@@ -379,6 +380,7 @@ func generateConsensusProcessWithConfig(tb testing.TB, cfg config.Config, inbox 
 		comm,
 		truer{},
 		newRoundClockFromCfg(logger, cfg),
+		false,
 		logger.WithName(edPubkey.String()),
 	)
 }

--- a/hare/consensus_test.go
+++ b/hare/consensus_test.go
@@ -211,6 +211,7 @@ func createConsensusProcess(
 		comm,
 		truer{},
 		newRoundClockFromCfg(logtest.New(tb), cfg),
+		false,
 		logtest.New(tb).WithName(sig.PublicKey().ShortString()),
 	)
 	return &testCP{cp: proc, broker: broker.Broker, mch: mch}

--- a/hare/flows_test.go
+++ b/hare/flows_test.go
@@ -146,6 +146,7 @@ func createTestHare(tb testing.TB, msh mesh, tcfg config.Config, clock *mockCloc
 	mockSyncS := smocks.NewMockSyncStateProvider(ctrl)
 	mockSyncS.EXPECT().IsSynced(gomock.Any()).Return(true).AnyTimes()
 	mockSyncS.EXPECT().IsBeaconSynced(gomock.Any()).Return(true).AnyTimes()
+	mockSyncS.EXPECT().SyncedLayer().Return(types.LayerID(0)).AnyTimes()
 
 	mockRoracle := mocks.NewMockRolacle(ctrl)
 	mockCoin := mocks.NewMockweakCoin(ctrl)

--- a/miner/oracle.go
+++ b/miner/oracle.go
@@ -122,7 +122,7 @@ func (o *Oracle) activesFromFirstBlock(targetEpoch types.EpochID) (uint64, uint6
 }
 
 func (o *Oracle) activeSet(targetEpoch types.EpochID) (uint64, uint64, []types.ATXID, error) {
-	if !o.syncState.SyncedBefore(targetEpoch - 1) {
+	if o.syncState.SyncedLayer() >= (targetEpoch - 1).FirstLayer() {
 		// if the node is not synced prior to `targetEpoch-1`, it doesn't have the correct receipt timestamp
 		// for all the atx and malfeasance proof, and cannot use atx grading for active set.
 		o.log.With().Info("node not synced before prior epoch, getting active set from first block",

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -499,7 +499,7 @@ func isTooFarBehind(ctx context.Context, logger log.Log, current, lastSynced typ
 
 func (s *Syncer) setStateBeforeSync(ctx context.Context) {
 	current := s.ticker.CurrentLayer()
-	if s.ticker.CurrentLayer() <= types.GetEffectiveGenesis() {
+	if current <= types.GetEffectiveGenesis() {
 		s.setTargetSyncedLayer(ctx, current)
 		s.setSyncState(ctx, synced)
 		if current.GetEpoch() == 0 {

--- a/system/mocks/sync.go
+++ b/system/mocks/sync.go
@@ -63,16 +63,16 @@ func (mr *MockSyncStateProviderMockRecorder) IsSynced(arg0 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsSynced", reflect.TypeOf((*MockSyncStateProvider)(nil).IsSynced), arg0)
 }
 
-// SyncedBefore mocks base method.
-func (m *MockSyncStateProvider) SyncedBefore(arg0 types.EpochID) bool {
+// SyncedLayer mocks base method.
+func (m *MockSyncStateProvider) SyncedLayer() types.LayerID {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SyncedBefore", arg0)
-	ret0, _ := ret[0].(bool)
+	ret := m.ctrl.Call(m, "SyncedLayer")
+	ret0, _ := ret[0].(types.LayerID)
 	return ret0
 }
 
-// SyncedBefore indicates an expected call of SyncedBefore.
-func (mr *MockSyncStateProviderMockRecorder) SyncedBefore(arg0 interface{}) *gomock.Call {
+// SyncedLayer indicates an expected call of SyncedLayer.
+func (mr *MockSyncStateProviderMockRecorder) SyncedLayer() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncedBefore", reflect.TypeOf((*MockSyncStateProvider)(nil).SyncedBefore), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncedLayer", reflect.TypeOf((*MockSyncStateProvider)(nil).SyncedLayer))
 }

--- a/system/sync.go
+++ b/system/sync.go
@@ -12,5 +12,5 @@ import (
 type SyncStateProvider interface {
 	IsSynced(context.Context) bool
 	IsBeaconSynced(types.EpochID) bool
-	SyncedBefore(types.EpochID) bool
+	SyncedLayer() types.LayerID
 }


### PR DESCRIPTION
## Motivation
<!-- Please mention the issue fixed by this PR or detailed motivation -->
following up on https://github.com/spacemeshos/go-spacemesh/pull/4718
new node should not actively participate in hare because it doesn't have correct timestamp for atxs and malfeasance proof

## Changes
for node that become synced in current epoch, only participate in hare passively.
start active participation in the next epoch.