### PR TITLE
[Merged by Bors] - p2p: add connection gater to prevent dials over max limit

### DIFF
--- a/p2p/gater.go
+++ b/p2p/gater.go
@@ -1,0 +1,34 @@
+package p2p
+
+import (
+	"github.com/libp2p/go-libp2p/core/control"
+	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/multiformats/go-multiaddr"
+)
+
+type gater struct {
+	h   host.Host
+	max int
+}
+
+func (*gater) InterceptPeerDial(_ peer.ID) bool {
+	return true
+}
+
+func (g *gater) InterceptAddrDial(pid peer.ID, m multiaddr.Multiaddr) bool {
+	return len(g.h.Network().Peers()) <= g.max
+}
+
+func (g *gater) InterceptAccept(n network.ConnMultiaddrs) bool {
+	return len(g.h.Network().Peers()) <= g.max
+}
+
+func (*gater) InterceptSecured(_ network.Direction, _ peer.ID, _ network.ConnMultiaddrs) bool {
+	return true
+}
+
+func (*gater) InterceptUpgraded(_ network.Conn) (allow bool, reason control.DisconnectReason) {
+	return true, 0
+}

--- a/p2p/host.go
+++ b/p2p/host.go
@@ -59,26 +59,28 @@ type Config struct {
 	MaxMessageSize     int
 
 	// see https://lwn.net/Articles/542629/ for reuseport explanation
-	DisableReusePort       bool        `mapstructure:"disable-reuseport"`
-	DisableNatPort         bool        `mapstructure:"disable-natport"`
-	DisableDHT             bool        `mapstructure:"disable-dht"`
-	Flood                  bool        `mapstructure:"flood"`
-	Listen                 string      `mapstructure:"listen"`
-	Bootnodes              []string    `mapstructure:"bootnodes"`
-	Direct                 []string    `mapstructure:"direct"`
-	MinPeers               int         `mapstructure:"min-peers"`
-	LowPeers               int         `mapstructure:"low-peers"`
-	HighPeers              int         `mapstructure:"high-peers"`
-	AutoscalePeers         bool        `mapstructure:"autoscale-peers"`
-	AdvertiseAddress       string      `mapstructure:"advertise-address"`
-	AcceptQueue            int         `mapstructure:"p2p-accept-queue"`
-	Metrics                bool        `mapstructure:"p2p-metrics"`
-	Bootnode               bool        `mapstructure:"p2p-bootnode"`
-	ForceReachability      string      `mapstructure:"p2p-reachability"`
-	EnableHolepunching     bool        `mapstructure:"p2p-holepunching"`
-	DisableLegacyDiscovery bool        `mapstructure:"p2p-disable-legacy-discovery"`
-	PrivateNetwork         bool        `mapstructure:"p2p-private-network"`
-	RelayServer            RelayServer `mapstructure:"relay-server"`
+	DisableReusePort         bool        `mapstructure:"disable-reuseport"`
+	DisableNatPort           bool        `mapstructure:"disable-natport"`
+	DisableConnectionManager bool        `mapstructure:"disable-connection-manager"`
+	DisableResourceManager   bool        `mapstructure:"disable-resource-manager"`
+	DisableDHT               bool        `mapstructure:"disable-dht"`
+	Flood                    bool        `mapstructure:"flood"`
+	Listen                   string      `mapstructure:"listen"`
+	Bootnodes                []string    `mapstructure:"bootnodes"`
+	Direct                   []string    `mapstructure:"direct"`
+	MinPeers                 int         `mapstructure:"min-peers"`
+	LowPeers                 int         `mapstructure:"low-peers"`
+	HighPeers                int         `mapstructure:"high-peers"`
+	AutoscalePeers           bool        `mapstructure:"autoscale-peers"`
+	AdvertiseAddress         string      `mapstructure:"advertise-address"`
+	AcceptQueue              int         `mapstructure:"p2p-accept-queue"`
+	Metrics                  bool        `mapstructure:"p2p-metrics"`
+	Bootnode                 bool        `mapstructure:"p2p-bootnode"`
+	ForceReachability        string      `mapstructure:"p2p-reachability"`
+	EnableHolepunching       bool        `mapstructure:"p2p-holepunching"`
+	DisableLegacyDiscovery   bool        `mapstructure:"p2p-disable-legacy-discovery"`
+	PrivateNetwork           bool        `mapstructure:"p2p-private-network"`
+	RelayServer              RelayServer `mapstructure:"relay-server"`
 }
 
 type RelayServer struct {
@@ -162,11 +164,14 @@ func New(_ context.Context, logger log.Log, cfg Config, prologue []byte, opts ..
 			return tp.WithSessionOptions(noise.Prologue(prologue))
 		}),
 		libp2p.Muxer("/yamux/1.0.0", &streamer),
-		libp2p.ConnectionManager(cm),
 		libp2p.Peerstore(ps),
 		libp2p.BandwidthReporter(p2pmetrics.NewBandwidthCollector()),
 		libp2p.EnableNATService(),
 		libp2p.ConnectionGater(g),
+		libp2p.Ping(false),
+	}
+	if !cfg.DisableConnectionManager {
+		lopts = append(lopts, libp2p.ConnectionManager(cm))
 	}
 	if len(cfg.AdvertiseAddress) > 0 {
 		addr, err := multiaddr.NewMultiaddr(cfg.AdvertiseAddress)
@@ -248,6 +253,9 @@ func setupResourcesManager(hostcfg Config) func(cfg *libp2p.Config) error {
 		concrete := limits.AutoScale()
 		if !hostcfg.AutoscalePeers {
 			concrete = limits.Scale(0, 0)
+		}
+		if hostcfg.DisableResourceManager {
+			concrete = rcmgr.InfiniteLimits
 		}
 		mgr, err := rcmgr.NewResourceManager(
 			rcmgr.NewFixedLimiter(concrete),


### PR DESCRIPTION
closes: https://github.com/spacemeshos/go-spacemesh/issues/4771

this change will reject dials from outbound peers when inbound number is 0.8 of high peers number.
it will not allow dials to other peers when total number of peers is higher then 1.1 of high peers number.
and node is allowed to always dial direct peers

note that dials are concurrent, so if there is a burst it is still possible that they will go over the limit for short period of time 