### PR TITLE
sync: remove gossip sync

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -863,8 +863,8 @@ func (app *App) initServices(ctx context.Context) error {
 		fetch.ValidatorFunc(pubsub.DropPeerOnValidationReject(malfeasanceHandler.HandleSyncedMalfeasanceProof, app.host, lg)),
 	)
 
-	syncHandler := func(_ context.Context, _ p2p.Peer, _ []byte) error {
-		if newSyncer.ListenToGossip() {
+	syncHandler := func(ctx context.Context, _ p2p.Peer, _ []byte) error {
+		if newSyncer.IsSynced(ctx) {
 			return nil
 		}
 		return errors.New("not synced for gossip")

--- a/syncer/metrics.go
+++ b/syncer/metrics.go
@@ -47,11 +47,10 @@ var (
 	nodeSyncState = metrics.NewGauge(
 		"sync_state",
 		namespace,
-		"node sync state in [not_synced, gossip, synced]",
+		"node sync state in [not, synced, atx_synced]",
 		[]string{"state"},
 	)
 	nodeNotSynced = nodeSyncState.WithLabelValues("not")
-	nodeGossip    = nodeSyncState.WithLabelValues("gossip")
 	nodeSynced    = nodeSyncState.WithLabelValues("synced")
 	atxSynced     = nodeSyncState.WithLabelValues("atx_synced")
 

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -186,11 +186,6 @@ func (s *Syncer) RegisterForATXSynced() chan struct{} {
 	return s.awaitATXSyncedCh
 }
 
-// ListenToGossip returns true if the node is listening to gossip for blocks/TXs data.
-func (s *Syncer) ListenToGossip() bool {
-	return s.getSyncState() == synced
-}
-
 // ListenToATXGossip returns true if the node is listening to gossip for ATXs data.
 func (s *Syncer) ListenToATXGossip() bool {
 	return s.getATXSyncState() == synced
@@ -307,7 +302,6 @@ func (s *Syncer) setSyncerIdle() {
 	s.isBusy.Store(0)
 }
 
-// syncedLayer is used to signal at which layer we can set this node to synced state.
 func (s *Syncer) setLayerTurnedSynced(lid types.LayerID) {
 	s.layerTurnedSynced.Store(lid)
 }

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -280,6 +280,9 @@ func (s *Syncer) setSyncState(ctx context.Context, newState syncState) {
 			log.Stringer("latest", s.mesh.LatestLayer()),
 			log.Stringer("processed", s.mesh.ProcessedLayer()))
 		events.ReportNodeStatusUpdate()
+		if newState == synced {
+			s.setLayerTurnedSynced(current)
+		}
 	}
 	switch newState {
 	case notSynced:
@@ -288,7 +291,6 @@ func (s *Syncer) setSyncState(ctx context.Context, newState syncState) {
 	case synced:
 		nodeNotSynced.Set(0)
 		nodeSynced.Set(1)
-		s.setLayerTurnedSynced(current)
 	}
 }
 

--- a/syncer/syncer_test.go
+++ b/syncer/syncer_test.go
@@ -120,7 +120,6 @@ func TestStartAndShutdown(t *testing.T) {
 
 	require.False(t, ts.syncer.IsSynced(ctx))
 	require.False(t, ts.syncer.ListenToATXGossip())
-	require.False(t, ts.syncer.ListenToGossip())
 
 	// the node is synced when current layer is <= 1
 	ts.syncer.Start()
@@ -128,7 +127,7 @@ func TestStartAndShutdown(t *testing.T) {
 	ts.mForkFinder.EXPECT().Purge(false).AnyTimes()
 	ts.mDataFetcher.EXPECT().PollLayerOpinions(gomock.Any(), gomock.Any()).AnyTimes()
 	require.Eventually(t, func() bool {
-		return ts.syncer.ListenToATXGossip() && ts.syncer.ListenToGossip() && ts.syncer.IsSynced(ctx)
+		return ts.syncer.ListenToATXGossip() && ts.syncer.IsSynced(ctx)
 	}, time.Second, 10*time.Millisecond)
 
 	cancel()
@@ -206,7 +205,6 @@ func TestSynchronize_AllGood(t *testing.T) {
 	require.Equal(t, current.GetEpoch(), ts.syncer.lastAtxEpoch())
 	require.True(t, ts.syncer.dataSynced())
 	require.True(t, ts.syncer.ListenToATXGossip())
-	require.True(t, ts.syncer.ListenToGossip())
 	require.True(t, ts.syncer.IsSynced(context.Background()))
 
 	wg.Add(1)
@@ -238,7 +236,6 @@ func TestSynchronize_FetchLayerDataFailed(t *testing.T) {
 	require.Equal(t, current.GetEpoch(), ts.syncer.lastAtxEpoch())
 	require.False(t, ts.syncer.dataSynced())
 	require.True(t, ts.syncer.ListenToATXGossip())
-	require.False(t, ts.syncer.ListenToGossip())
 	require.False(t, ts.syncer.IsSynced(context.Background()))
 }
 
@@ -283,7 +280,6 @@ func TestSynchronize_FailedInitialATXsSync(t *testing.T) {
 	require.Equal(t, failedEpoch-1, ts.syncer.lastAtxEpoch())
 	require.False(t, ts.syncer.dataSynced())
 	require.False(t, ts.syncer.ListenToATXGossip())
-	require.False(t, ts.syncer.ListenToGossip())
 	require.False(t, ts.syncer.IsSynced(context.Background()))
 
 	wg.Add(1)
@@ -307,7 +303,6 @@ func startWithSyncedState(t *testing.T, ts *testSyncer) types.LayerID {
 	ts.mDataFetcher.EXPECT().GetEpochATXs(gomock.Any(), gLayer.GetEpoch())
 	require.True(t, ts.syncer.synchronize(context.Background()))
 	require.True(t, ts.syncer.ListenToATXGossip())
-	require.True(t, ts.syncer.ListenToGossip())
 	require.True(t, ts.syncer.IsSynced(context.Background()))
 
 	current := gLayer.Add(2)
@@ -317,7 +312,6 @@ func startWithSyncedState(t *testing.T, ts *testSyncer) types.LayerID {
 
 	require.True(t, ts.syncer.synchronize(context.Background()))
 	require.True(t, ts.syncer.ListenToATXGossip())
-	require.True(t, ts.syncer.ListenToGossip())
 	require.True(t, ts.syncer.IsSynced(context.Background()))
 	return current
 }
@@ -406,7 +400,6 @@ func TestSynchronize_StaySyncedUponFailure(t *testing.T) {
 	require.False(t, ts.syncer.synchronize(context.Background()))
 	require.False(t, ts.syncer.dataSynced())
 	require.True(t, ts.syncer.ListenToATXGossip())
-	require.True(t, ts.syncer.ListenToGossip())
 	require.True(t, ts.syncer.IsSynced(context.Background()))
 }
 
@@ -420,7 +413,6 @@ func TestSynchronize_BecomeNotSyncedUponFailureIfNoGossip(t *testing.T) {
 	require.False(t, ts.syncer.synchronize(context.Background()))
 	require.False(t, ts.syncer.dataSynced())
 	require.True(t, ts.syncer.ListenToATXGossip())
-	require.False(t, ts.syncer.ListenToGossip())
 	require.False(t, ts.syncer.IsSynced(context.Background()))
 }
 
@@ -437,7 +429,6 @@ func TestFromNotSyncedToSynced(t *testing.T) {
 	require.False(t, ts.syncer.synchronize(context.Background()))
 	require.False(t, ts.syncer.dataSynced())
 	require.True(t, ts.syncer.ListenToATXGossip())
-	require.False(t, ts.syncer.ListenToGossip())
 	require.False(t, ts.syncer.IsSynced(context.Background()))
 
 	for lid := lyr; lid <= current; lid++ {
@@ -446,7 +437,6 @@ func TestFromNotSyncedToSynced(t *testing.T) {
 	require.True(t, ts.syncer.synchronize(context.Background()))
 	require.True(t, ts.syncer.dataSynced())
 	require.True(t, ts.syncer.ListenToATXGossip())
-	require.True(t, ts.syncer.ListenToGossip())
 	require.True(t, ts.syncer.IsSynced(context.Background()))
 }
 
@@ -462,7 +452,6 @@ func TestNetworkHasNoData(t *testing.T) {
 		require.True(t, ts.syncer.synchronize(context.Background()))
 		require.True(t, ts.syncer.dataSynced())
 		require.True(t, ts.syncer.ListenToATXGossip())
-		require.True(t, ts.syncer.ListenToGossip())
 		require.True(t, ts.syncer.IsSynced(context.Background()))
 	}
 	// the network hasn't received any data
@@ -488,7 +477,6 @@ func TestFromSyncedToNotSynced(t *testing.T) {
 	require.False(t, ts.syncer.synchronize(context.Background()))
 	require.False(t, ts.syncer.dataSynced())
 	require.True(t, ts.syncer.ListenToATXGossip())
-	require.False(t, ts.syncer.ListenToGossip())
 	require.False(t, ts.syncer.IsSynced(context.Background()))
 
 	for lid := lyr; lid <= current; lid++ {
@@ -497,7 +485,6 @@ func TestFromSyncedToNotSynced(t *testing.T) {
 	require.True(t, ts.syncer.synchronize(context.Background()))
 	require.True(t, ts.syncer.dataSynced())
 	require.True(t, ts.syncer.ListenToATXGossip())
-	require.True(t, ts.syncer.ListenToGossip())
 	require.True(t, ts.syncer.IsSynced(context.Background()))
 }
 


### PR DESCRIPTION
## Motivation
part of #4504

## Changes
- remove gossip sync state
- always sync to the current layer before changing to synced state