### PR TITLE
[Merged by Bors] - Don't rewrite poet config

### DIFF
--- a/activation/nipost.go
+++ b/activation/nipost.go
@@ -197,6 +197,7 @@ func (nb *NIPostBuilder) BuildNIPost(ctx context.Context, challenge *types.NIPos
 		log.Time("poet proof deadline", poetProofDeadline),
 		log.Stringer("publish epoch", pubEpoch),
 		log.Stringer("target epoch", challenge.TargetEpoch()),
+		log.Any("config", nb.poetCfg),
 	)
 
 	challengeHash := challenge.Hash()

--- a/activation/nipost.go
+++ b/activation/nipost.go
@@ -197,7 +197,6 @@ func (nb *NIPostBuilder) BuildNIPost(ctx context.Context, challenge *types.NIPos
 		log.Time("poet proof deadline", poetProofDeadline),
 		log.Stringer("publish epoch", pubEpoch),
 		log.Stringer("target epoch", challenge.TargetEpoch()),
-		log.Any("config", nb.poetCfg),
 	)
 
 	challengeHash := challenge.Hash()

--- a/activation/poet.go
+++ b/activation/poet.go
@@ -63,6 +63,9 @@ func withCustomHttpClient(client *http.Client) PoetClientOpts {
 
 // NewHTTPPoetClient returns new instance of HTTPPoetClient connecting to the specified url.
 func NewHTTPPoetClient(baseUrl string, cfg PoetConfig, opts ...PoetClientOpts) (*HTTPPoetClient, error) {
+	// TODO(brozansk): Take a logger and use it instead of global logger
+	log.With().Info("creating poet client", log.String("url", baseUrl), log.Int("max_retries", cfg.MaxRequestRetries), log.Stringer("retry_delay", cfg.RequestRetryDelay))
+
 	client := &retryablehttp.Client{
 		RetryMax:     cfg.MaxRequestRetries,
 		RetryWaitMin: cfg.RequestRetryDelay,

--- a/node/node.go
+++ b/node/node.go
@@ -634,11 +634,6 @@ func (app *App) initServices(ctx context.Context) error {
 		return fmt.Errorf("failed to create mesh: %w", err)
 	}
 
-	poetCfg := activation.PoetConfig{
-		PhaseShift:  app.Config.POET.PhaseShift,
-		CycleGap:    app.Config.POET.CycleGap,
-		GracePeriod: app.Config.POET.GracePeriod,
-	}
 	fetcherWrapped := &layerFetcher{}
 	atxHandler := activation.NewHandler(
 		app.cachedDB,
@@ -653,7 +648,7 @@ func (app *App) initServices(ctx context.Context) error {
 		beaconProtocol,
 		trtl,
 		app.addLogger(ATXHandlerLogger, lg),
-		poetCfg,
+		app.Config.POET,
 	)
 
 	// we can't have an epoch offset which is greater/equal than the number of layers in an epoch
@@ -802,7 +797,7 @@ func (app *App) initServices(ctx context.Context) error {
 		app.Config.SMESHING.Opts.DataDir,
 		app.addLogger(NipostBuilderLogger, lg),
 		app.edSgn,
-		poetCfg,
+		app.Config.POET,
 		app.clock,
 		activation.WithNipostValidator(app.validator),
 	)
@@ -839,7 +834,7 @@ func (app *App) initServices(ctx context.Context) error {
 		newSyncer,
 		app.addLogger("atxBuilder", lg),
 		activation.WithContext(ctx),
-		activation.WithPoetConfig(poetCfg),
+		activation.WithPoetConfig(app.Config.POET),
 		activation.WithPoetRetryInterval(app.Config.HARE.WakeupDelta),
 		activation.WithValidator(app.validator),
 	)


### PR DESCRIPTION
## Motivation
The poet config is unnecessarily and wrongly rewritten in node setup code.

## Changes
Don't rewrite poet config at all.