### PR TITLE
[Merged by Bors] - Fix failing Windows tests

### DIFF
--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -187,7 +187,7 @@ func NewFetch(cdb *datastore.CachedDB, msh meshProvider, b system.BeaconGetter, 
 		server.WithLog(f.logger),
 	}
 	if len(f.servers) == 0 {
-		h := newHandler(cdb, f.cfg, bs, msh, b, f.logger)
+		h := newHandler(cdb, bs, msh, b, f.logger)
 		f.servers[atxProtocol] = server.New(host, atxProtocol, h.handleEpochInfoReq, srvOpts...)
 		f.servers[lyrDataProtocol] = server.New(host, lyrDataProtocol, h.handleLayerDataReq, srvOpts...)
 		f.servers[lyrOpnsProtocol] = server.New(host, lyrOpnsProtocol, h.handleLayerOpinionsReq, srvOpts...)

--- a/fetch/handler.go
+++ b/fetch/handler.go
@@ -20,17 +20,15 @@ import (
 type handler struct {
 	logger log.Log
 	cdb    *datastore.CachedDB
-	cfg    Config
 	bs     *datastore.BlobStore
 	msh    meshProvider
 	beacon system.BeaconGetter
 }
 
-func newHandler(cdb *datastore.CachedDB, cfg Config, bs *datastore.BlobStore, m meshProvider, b system.BeaconGetter, lg log.Log) *handler {
+func newHandler(cdb *datastore.CachedDB, bs *datastore.BlobStore, m meshProvider, b system.BeaconGetter, lg log.Log) *handler {
 	return &handler{
 		logger: lg,
 		cdb:    cdb,
-		cfg:    cfg,
 		bs:     bs,
 		msh:    m,
 		beacon: b,

--- a/fetch/handler_test.go
+++ b/fetch/handler_test.go
@@ -35,12 +35,11 @@ type testHandler struct {
 func createTestHandler(t testing.TB) *testHandler {
 	lg := logtest.New(t)
 	cdb := datastore.NewCachedDB(sql.InMemory(), lg)
-	cfg := DefaultConfig()
 	ctrl := gomock.NewController(t)
 	mm := mocks.NewMockmeshProvider(ctrl)
 	mb := smocks.NewMockBeaconGetter(ctrl)
 	return &testHandler{
-		handler: newHandler(cdb, cfg, datastore.NewBlobStore(cdb.Database), mm, mb, lg),
+		handler: newHandler(cdb, datastore.NewBlobStore(cdb.Database), mm, mb, lg),
 		cdb:     cdb,
 		mm:      mm,
 		mb:      mb,

--- a/p2p/dhtdiscovery/discovery.go
+++ b/p2p/dhtdiscovery/discovery.go
@@ -283,7 +283,9 @@ func (d *Discovery) newDht(ctx context.Context, h host.Host, public, server bool
 	}
 	dht, err := dht.New(ctx, h, opts...)
 	if err != nil {
-		ds.Close()
+		if err := ds.Close(); err != nil {
+			d.logger.Error("error closing level datastore", zap.Error(err))
+		}
 		return err
 	}
 	d.dht = dht

--- a/p2p/dhtdiscovery/discovery.go
+++ b/p2p/dhtdiscovery/discovery.go
@@ -117,11 +117,10 @@ func New(h host.Host, opts ...Opt) (*Discovery, error) {
 		d.logger.Warn("no bootnodes in the config")
 	}
 	if !d.disableDht {
-		dht, err := newDht(ctx, h, d.public, d.server, d.dir)
+		err := d.newDht(ctx, h, d.public, d.server, d.dir)
 		if err != nil {
 			return nil, err
 		}
-		d.dht = dht
 	}
 	return &d, nil
 }
@@ -137,8 +136,9 @@ type Discovery struct {
 	ctx    context.Context
 	cancel context.CancelFunc
 
-	h   host.Host
-	dht *dht.IpfsDHT
+	h         host.Host
+	dht       *dht.IpfsDHT
+	datastore *levelds.Datastore
 
 	// how often to check if we have enough peers
 	period time.Duration
@@ -211,9 +211,12 @@ func (d *Discovery) Start() {
 func (d *Discovery) Stop() {
 	d.cancel()
 	d.eg.Wait()
-	if d.dht != nil {
+	if !d.disableDht {
 		if err := d.dht.Close(); err != nil {
 			d.logger.Error("error closing dht", zap.Error(err))
+		}
+		if err := d.datastore.Close(); err != nil {
+			d.logger.Error("error closing level datastore", zap.Error(err))
 		}
 	}
 }
@@ -252,7 +255,7 @@ func (d *Discovery) connect(eg *errgroup.Group, nodes []peer.AddrInfo) {
 	eg.Wait()
 }
 
-func newDht(ctx context.Context, h host.Host, public, server bool, dir string) (*dht.IpfsDHT, error) {
+func (d *Discovery) newDht(ctx context.Context, h host.Host, public, server bool, dir string) error {
 	ds, err := levelds.NewDatastore(dir, &levelds.Options{
 		Compression: ldbopts.NoCompression,
 		NoSync:      false,
@@ -260,7 +263,7 @@ func newDht(ctx context.Context, h host.Host, public, server bool, dir string) (
 		ReadOnly:    false,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("open leveldb at %s: %w", dir, err)
+		return fmt.Errorf("open leveldb at %s: %w", dir, err)
 	}
 	opts := []dht.Option{
 		dht.Validator(record.PublicKeyValidator{}),
@@ -278,5 +281,12 @@ func newDht(ctx context.Context, h host.Host, public, server bool, dir string) (
 	} else {
 		opts = append(opts, dht.Mode(dht.ModeAutoServer))
 	}
-	return dht.New(ctx, h, opts...)
+	dht, err := dht.New(ctx, h, opts...)
+	if err != nil {
+		ds.Close()
+		return err
+	}
+	d.dht = dht
+	d.datastore = ds
+	return nil
 }

--- a/p2p/host_test.go
+++ b/p2p/host_test.go
@@ -20,8 +20,12 @@ func TestPrologue(t *testing.T) {
 
 	h1, err := New(context.Background(), logtest.New(t), cfg1, []byte("red"))
 	require.NoError(t, err)
+	t.Cleanup(func() { h1.Stop() })
+
 	h2, err := New(context.Background(), logtest.New(t), cfg2, []byte("blue"))
 	require.NoError(t, err)
+	t.Cleanup(func() { h2.Stop() })
+
 	err = h1.Connect(context.Background(), peer.AddrInfo{
 		ID:    h2.ID(),
 		Addrs: h2.Addrs(),

--- a/p2p/persist.go
+++ b/p2p/persist.go
@@ -46,7 +46,7 @@ func writePeers(h host.Host, dir string) error {
 	}
 
 	checksum := crc64.New(crc64.MakeTable(crc64.ISO))
-	tmp, err := os.CreateTemp(dir, "connected-***")
+	tmp, err := os.CreateTemp(dir, "connected.tmp")
 	if err != nil {
 		return err
 	}

--- a/p2p/persist_test.go
+++ b/p2p/persist_test.go
@@ -22,13 +22,13 @@ func TestConnectedPersist(t *testing.T) {
 	require.NoError(t, err)
 	var eg errgroup.Group
 	eg.Go(func() error {
-		persist(ctx, logtest.New(t), mock.Hosts()[0], dir, 100*time.Microsecond)
+		persist(ctx, logtest.New(t), mock.Hosts()[0], dir, 100*time.Millisecond)
 		return nil
 	})
 	require.Eventually(t, func() bool {
 		_, err := os.Stat(filepath.Join(dir, connectedFile))
 		return err == nil
-	}, 3*time.Second, 50*time.Microsecond)
+	}, 5*time.Second, 50*time.Millisecond)
 	cancel()
 	eg.Wait()
 	peers, err := loadPeers(dir)
@@ -62,6 +62,7 @@ func TestConnectedBrokenCRC(t *testing.T) {
 	eg.Wait()
 	f, err := os.OpenFile(filepath.Join(dir, connectedFile), os.O_RDWR, 0o600)
 	require.NoError(t, err)
+	defer f.Close()
 	_, err = f.WriteAt([]byte{0, 1, 1, 1}, 0)
 	require.NoError(t, err)
 	peers, err := loadPeers(dir)


### PR DESCRIPTION
## Motivation
Several failing windows tests have been fixed.

## Changes
- `TestFetch_PeerDroppedWhenMessageResultsInValidationReject`: the instantiated p2p hosts weren't stopped correctly leading to a still open instance of `levelds.Datastore` that prevented the test from properly cleaning up
- `TestPrologue`: stopping discovery did not close the `levelds.Datastore` if dht was used
- `TestAdminEvents` was indirectly affected by the issue above
- `TestConnectedPersist` and `TestConnectedBrokenCRC` the name of the temporary file used to persist peers atomically is not legal on windows file systems, so writing the file always failed.

## Test Plan
n/a

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
