### PR TITLE
[Merged by Bors] - Skip flaky test Test_HarePreRoundEmptySet

### DIFF
--- a/hare/hare_rounds_test.go
+++ b/hare/hare_rounds_test.go
@@ -119,6 +119,9 @@ func runNodesFor(t *testing.T, ctx context.Context, nodes, leaders, maxLayers, l
 }
 
 func Test_HarePreRoundEmptySet(t *testing.T) {
+	if skipMoreTests {
+		t.SkipNow()
+	}
 	const nodes = 5
 	const layers = 2
 
@@ -160,7 +163,6 @@ func Test_HareNotEnoughStatuses(t *testing.T) {
 	if skipMoreTests {
 		t.SkipNow()
 	}
-
 	const nodes = 5
 	const layers = 2
 	m := [layers][nodes]int{}


### PR DESCRIPTION
## Motivation
This test has been unstable for quite some time:

- https://github.com/spacemeshos/go-spacemesh/issues/3079
- https://github.com/spacemeshos/go-spacemesh/issues/2953

Since the current iteration of hare will soon be replaced with a new one, we should disable this test to prevent random CI runs from failing.

## Changes
- skip test

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
