### PR TITLE
[Merged by Bors] - Remove special handling for end of PoET round 0

### DIFF
--- a/activation/nipost.go
+++ b/activation/nipost.go
@@ -12,7 +12,6 @@ import (
 	"github.com/spacemeshos/poet/shared"
 	"github.com/spacemeshos/post/proving"
 	"github.com/spacemeshos/post/verifying"
-	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/spacemeshos/go-spacemesh/activation/metrics"
@@ -29,8 +28,6 @@ import (
 // proving clients, and thus enormously reduce the cost-per-proof for PoET since each additional proof adds only
 // a small number of hash evaluations to the total cost.
 type PoetProvingServiceClient interface {
-	Address() string
-
 	PowParams(ctx context.Context) (*PoetPowParams, error)
 
 	// Submit registers a challenge in the proving service current open round.
@@ -68,7 +65,7 @@ type NIPostBuilder struct {
 	nodeID            types.NodeID
 	dataDir           string
 	postSetupProvider postSetupProvider
-	poetProvers       map[string]PoetProvingServiceClient
+	poetProvers       []PoetProvingServiceClient
 	poetDB            poetDbAPI
 	state             *types.NIPostBuilderState
 	log               log.Log
@@ -89,10 +86,7 @@ func WithNipostValidator(v nipostValidator) NIPostBuilderOption {
 // withPoetClients allows to pass in clients directly (for testing purposes).
 func withPoetClients(clients []PoetProvingServiceClient) NIPostBuilderOption {
 	return func(nb *NIPostBuilder) {
-		nb.poetProvers = make(map[string]PoetProvingServiceClient, len(clients))
-		for _, client := range clients {
-			nb.poetProvers[client.Address()] = client
-		}
+		nb.poetProvers = clients
 	}
 }
 
@@ -114,13 +108,13 @@ func NewNIPostBuilder(
 	layerClock layerClock,
 	opts ...NIPostBuilderOption,
 ) (*NIPostBuilder, error) {
-	poetClients := make(map[string]PoetProvingServiceClient, len(poetServers))
+	poetClients := make([]PoetProvingServiceClient, len(poetServers))
 	for _, address := range poetServers {
 		client, err := NewHTTPPoetClient(address, poetCfg)
 		if err != nil {
 			return nil, fmt.Errorf("cannot create poet client: %w", err)
 		}
-		poetClients[client.Address()] = client
+		poetClients = append(poetClients, client)
 	}
 
 	b := &NIPostBuilder{
@@ -155,10 +149,7 @@ func (nb *NIPostBuilder) UpdatePoETProvers(poetProvers []PoetProvingServiceClien
 	nb.state = &types.NIPostBuilderState{
 		NIPost: &types.NIPost{},
 	}
-	nb.poetProvers = make(map[string]PoetProvingServiceClient, len(poetProvers))
-	for _, poetProver := range poetProvers {
-		nb.poetProvers[poetProver.Address()] = poetProver
-	}
+	nb.poetProvers = poetProvers
 	nb.log.With().Info("updated poet proof service clients", log.Int("count", len(nb.poetProvers)))
 }
 
@@ -239,7 +230,7 @@ func (nb *NIPostBuilder) BuildNIPost(ctx context.Context, challenge *types.NIPos
 		defer cancel()
 
 		events.EmitPoetWaitProof(challenge.PublishEpoch, challenge.TargetEpoch(), time.Until(poetRoundEnd))
-		poetProofRef, membership, err := nb.getBestProof(getProofsCtx, nb.state.Challenge, challenge.PublishEpoch)
+		poetProofRef, membership, err := nb.getBestProof(getProofsCtx, nb.state.Challenge)
 		if err != nil {
 			return nil, 0, &PoetSvcUnstableError{msg: "getBestProof failed", source: err}
 		}
@@ -378,57 +369,7 @@ func membersContainChallenge(members []types.Member, challenge types.Hash32) (ui
 	return 0, fmt.Errorf("challenge is not a member of the proof")
 }
 
-// TODO(mafa): remove after next poet round; https://github.com/spacemeshos/go-spacemesh/issues/4753
-func (nb *NIPostBuilder) addPoet111ForPubEpoch1(ctx context.Context) error {
-	// because poet 111 had a hardware issue when challenges for round 0 were submitted, no node could submit to it
-	// 111 was recovered with the poet 110 DB, so all successful submissions to 110 should be able to be fetched from there as well
-
-	client111, ok := nb.poetProvers["https://poet-111.spacemesh.network"]
-	if !ok {
-		// poet 111 is not in the list, no action necessary
-		return nil
-	}
-
-	nb.log.Info("pub epoch 1 mitigation: poet 111 is in the list of poets, adding it to the state as well")
-	client110 := nb.poetProvers["https://poet-110.spacemesh.network"]
-
-	ID110, err := client110.PoetServiceID(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to get poet 110 id: %w", err)
-	}
-	ID111, err := client111.PoetServiceID(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to get poet 111 id: %w", err)
-	}
-
-	if slices.IndexFunc(nb.state.PoetRequests, func(r types.PoetRequest) bool { return bytes.Equal(r.PoetServiceID.ServiceID, ID111.ServiceID) }) != -1 {
-		nb.log.Info("poet 111 is already in the state, no action necessary")
-		return nil
-	}
-
-	poet110 := slices.IndexFunc(nb.state.PoetRequests, func(r types.PoetRequest) bool {
-		return bytes.Equal(r.PoetServiceID.ServiceID, ID110.ServiceID)
-	})
-	if poet110 == -1 {
-		return fmt.Errorf("poet 110 is not in the state, cannot add poet 111")
-	}
-	poet111 := nb.state.PoetRequests[poet110]
-	poet111.PoetServiceID.ServiceID = ID111.ServiceID
-	nb.state.PoetRequests = append(nb.state.PoetRequests, poet111)
-	nb.persistState()
-	nb.log.Info("pub epoch 1 mitigation: poet 111 added to the state")
-	return nil
-}
-
-func (nb *NIPostBuilder) getBestProof(ctx context.Context, challenge types.Hash32, publishEpoch types.EpochID) (types.PoetProofRef, *types.MerkleProof, error) {
-	// TODO(mafa): remove after next poet round; https://github.com/spacemeshos/go-spacemesh/issues/4753
-	if publishEpoch == 1 {
-		err := nb.addPoet111ForPubEpoch1(ctx)
-		if err != nil {
-			nb.log.With().Error("pub epoch 1 mitigation: failed to add poet 111 to state for pub epoch 1", log.Err(err))
-		}
-	}
-
+func (nb *NIPostBuilder) getBestProof(ctx context.Context, challenge types.Hash32) (types.PoetProofRef, *types.MerkleProof, error) {
 	type poetProof struct {
 		poet       *types.PoetProofMessage
 		membership *types.MerkleProof

--- a/activation/nipost.go
+++ b/activation/nipost.go
@@ -108,7 +108,7 @@ func NewNIPostBuilder(
 	layerClock layerClock,
 	opts ...NIPostBuilderOption,
 ) (*NIPostBuilder, error) {
-	poetClients := make([]PoetProvingServiceClient, len(poetServers))
+	poetClients := make([]PoetProvingServiceClient, 0, len(poetServers))
 	for _, address := range poetServers {
 		client, err := NewHTTPPoetClient(address, poetCfg)
 		if err != nil {

--- a/activation/nipost_mocks.go
+++ b/activation/nipost_mocks.go
@@ -35,20 +35,6 @@ func (m *MockPoetProvingServiceClient) EXPECT() *MockPoetProvingServiceClientMoc
 	return m.recorder
 }
 
-// Address mocks base method.
-func (m *MockPoetProvingServiceClient) Address() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Address")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// Address indicates an expected call of Address.
-func (mr *MockPoetProvingServiceClientMockRecorder) Address() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Address", reflect.TypeOf((*MockPoetProvingServiceClient)(nil).Address))
-}
-
 // PoetServiceID mocks base method.
 func (m *MockPoetProvingServiceClient) PoetServiceID(arg0 context.Context) (types.PoetServiceID, error) {
 	m.ctrl.T.Helper()

--- a/activation/poet.go
+++ b/activation/poet.go
@@ -93,10 +93,6 @@ func NewHTTPPoetClient(baseUrl string, cfg PoetConfig, opts ...PoetClientOpts) (
 	return poetClient, nil
 }
 
-func (c *HTTPPoetClient) Address() string {
-	return c.baseURL.String()
-}
-
 func (c *HTTPPoetClient) PowParams(ctx context.Context) (*PoetPowParams, error) {
 	resBody := rpcapi.PowParamsResponse{}
 	if err := c.req(ctx, http.MethodGet, "/v1/pow_params", nil, &resBody); err != nil {

--- a/activation/poet_client_test.go
+++ b/activation/poet_client_test.go
@@ -60,52 +60,6 @@ func Test_HTTPPoetClient_Submit(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func Test_HTTPPoetClient_Address(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, http.MethodGet, r.Method)
-
-		w.WriteHeader(http.StatusOK)
-		resp, err := protojson.Marshal(&rpcapi.InfoResponse{})
-		require.NoError(t, err)
-		w.Write(resp)
-
-		require.Equal(t, "/v1/info", r.URL.Path)
-	}))
-	defer ts.Close()
-
-	cfg := config.DefaultConfig()
-	client, err := NewHTTPPoetClient(ts.URL, PoetConfig{
-		PhaseShift: cfg.Service.PhaseShift,
-		CycleGap:   cfg.Service.CycleGap,
-	}, withCustomHttpClient(ts.Client()))
-	require.NoError(t, err)
-
-	require.Equal(t, ts.URL, client.Address())
-}
-
-func Test_HTTPPoetClient_Address_Mainnet(t *testing.T) {
-	poetCfg := config.DefaultConfig()
-
-	poETServers := []string{
-		"https://mainnet-poet-0.spacemesh.network",
-		"https://mainnet-poet-1.spacemesh.network",
-		"https://mainnet-poet-2.spacemesh.network",
-		"https://poet-110.spacemesh.network",
-		"https://poet-111.spacemesh.network",
-	}
-
-	for _, url := range poETServers {
-		t.Run(url, func(t *testing.T) {
-			client, err := NewHTTPPoetClient(url, PoetConfig{
-				PhaseShift: poetCfg.Service.PhaseShift,
-				CycleGap:   poetCfg.Service.CycleGap,
-			})
-			require.NoError(t, err)
-			require.Equal(t, url, client.Address())
-		})
-	}
-}
-
 func Test_HTTPPoetClient_Proof(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, http.MethodGet, r.Method)


### PR DESCRIPTION
## Motivation
Closes #4753 

## Changes
This reverts the changes introduced with #4745 that were needed to make nodes query from all PoETs after the end of round 0. This workaround is not needed any more.

## Test Plan
n/a

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
