### PR TITLE
[Merged by Bors] - syncer/bootstrap: reduce log and add metrics for peer error

### DIFF
--- a/bootstrap/types.go
+++ b/bootstrap/types.go
@@ -36,11 +36,5 @@ func (vd *VerifiedUpdate) MarshalLogObject(encoder log.ObjectEncoder) error {
 	encoder.AddString("epoch", vd.Data.Epoch.String())
 	encoder.AddString("beacon", vd.Data.Beacon.String())
 	encoder.AddInt("activeset_size", len(vd.Data.ActiveSet))
-	encoder.AddArray("activeset", log.ArrayMarshalerFunc(func(aencoder log.ArrayEncoder) error {
-		for _, atx := range vd.Data.ActiveSet {
-			aencoder.AppendString(atx.String())
-		}
-		return nil
-	}))
 	return nil
 }

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -570,6 +570,7 @@ func (f *Fetch) handleHashError(batchHash types.Hash32, err error) {
 			log.Stringer("hash", req.hash),
 			log.Err(err))
 		req.promise.err = err
+		peerErrors.WithLabelValues(string(req.hint)).Inc()
 		close(req.promise.completed)
 		delete(f.ongoing, req.hash)
 	}

--- a/fetch/metrics.go
+++ b/fetch/metrics.go
@@ -41,6 +41,12 @@ var (
 		subsystem,
 		"total request that hash has no data",
 		[]string{hint})
+
+	peerErrors = metrics.NewCounter(
+		"hash_peer_err",
+		subsystem,
+		"total error from sending peers hash requests",
+		[]string{hint})
 )
 
 // logCacheHit logs cache hit.

--- a/hare/eligibility/oracle.go
+++ b/hare/eligibility/oracle.go
@@ -461,12 +461,7 @@ func (o *Oracle) UpdateActiveSet(epoch types.EpochID, activeSet []types.ATXID) {
 	o.Log.With().Info("received activeset update",
 		epoch,
 		log.Int("size", len(activeSet)),
-		log.Array("activeset", log.ArrayMarshalerFunc(func(encoder log.ArrayEncoder) error {
-			for _, atxid := range activeSet {
-				encoder.AppendString(atxid.String())
-			}
-			return nil
-		})))
+	)
 	o.lock.Lock()
 	defer o.lock.Unlock()
 	if _, ok := o.fallback[epoch]; ok {

--- a/syncer/data_fetch.go
+++ b/syncer/data_fetch.go
@@ -91,6 +91,7 @@ func (d *DataFetch) PollMaliciousProofs(ctx context.Context) error {
 	}
 	errFunc := func(err error, peer p2p.Peer) {
 		d.receiveMaliciousIDs(ctx, req, peer, nil, err)
+		malPeerError.Inc()
 	}
 	if err := d.fetcher.GetMaliciousIDs(ctx, peers, okFunc, errFunc); err != nil {
 		return err
@@ -150,6 +151,7 @@ func (d *DataFetch) PollLayerData(ctx context.Context, lid types.LayerID, peers 
 	}
 	errFunc := func(err error, peer p2p.Peer) {
 		d.receiveData(ctx, req, peer, nil, err)
+		layerPeerError.Inc()
 	}
 	if err := d.fetcher.GetLayerData(ctx, peers, lid, okFunc, errFunc); err != nil {
 		return err
@@ -323,6 +325,7 @@ func (d *DataFetch) PollLayerOpinions(ctx context.Context, lid types.LayerID) ([
 	}
 	errFunc := func(err error, peer p2p.Peer) {
 		d.receiveOpinions(ctx, req, peer, nil, err)
+		opnsPeerError.Inc()
 	}
 	if err := d.fetcher.GetLayerOpinions(ctx, peers, lid, okFunc, errFunc); err != nil {
 		return nil, err
@@ -419,6 +422,7 @@ func (d *DataFetch) GetEpochATXs(ctx context.Context, epoch types.EpochID) error
 
 	ed, err := d.fetcher.PeerEpochInfo(ctx, peer, epoch)
 	if err != nil {
+		atxPeerError.Inc()
 		return fmt.Errorf("get epoch info (peer %v): %w", peer, err)
 	}
 	if len(ed.AtxIDs) == 0 {

--- a/syncer/data_fetch.go
+++ b/syncer/data_fetch.go
@@ -383,14 +383,13 @@ func (d *DataFetch) receiveOpinions(ctx context.Context, req *opinionRequest, pe
 	}
 }
 
-func (d *DataFetch) pickAtxPeer(epoch types.EpochID) p2p.Peer {
+func (d *DataFetch) pickAtxPeer(epoch types.EpochID, peers []p2p.Peer) p2p.Peer {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	if _, ok := d.atxSynced[epoch]; !ok {
 		d.atxSynced[epoch] = map[p2p.Peer]struct{}{}
 		delete(d.atxSynced, epoch-1)
 	}
-	peers := d.fetcher.GetPeers()
 	for _, p := range peers {
 		if _, ok := d.atxSynced[epoch][p]; !ok {
 			return p
@@ -411,7 +410,7 @@ func (d *DataFetch) GetEpochATXs(ctx context.Context, epoch types.EpochID) error
 	if len(peers) == 0 {
 		return errNoPeers
 	}
-	peer := d.pickAtxPeer(epoch)
+	peer := d.pickAtxPeer(epoch, peers)
 	if peer == p2p.NoPeer {
 		d.logger.WithContext(ctx).With().Debug("synced atxs from all peers",
 			epoch,

--- a/syncer/metrics.go
+++ b/syncer/metrics.go
@@ -84,4 +84,14 @@ var (
 		"synced layer",
 		[]string{},
 	).WithLabelValues()
+
+	peerError = metrics.NewCounter(
+		"peer_error",
+		namespace,
+		"total number of errors by peers",
+		[]string{"kind"})
+	atxPeerError   = peerError.WithLabelValues("atx")
+	layerPeerError = peerError.WithLabelValues("layer")
+	opnsPeerError  = peerError.WithLabelValues("opns")
+	malPeerError   = peerError.WithLabelValues("mal")
 )

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -400,10 +400,6 @@ func (s *Syncer) synchronize(ctx context.Context) bool {
 		}
 
 		if err := s.syncAtx(ctx); err != nil {
-			s.logger.WithContext(ctx).With().Warning("failed to sync atxs",
-				log.Stringer("current", s.ticker.CurrentLayer()),
-				log.Err(err),
-			)
 			return false
 		}
 
@@ -413,7 +409,6 @@ func (s *Syncer) synchronize(ctx context.Context) bool {
 		// always sync to currentLayer-1 to reduce race with gossip and hare/tortoise
 		for layerID := s.getLastSyncedLayer().Add(1); layerID.Before(s.ticker.CurrentLayer()); layerID = layerID.Add(1) {
 			if err := s.syncLayer(ctx, layerID); err != nil {
-				s.logger.WithContext(ctx).With().Warning("failed to fetch layer", layerID, log.Err(err))
 				return false
 			}
 			s.setLastSyncedLayer(layerID)


### PR DESCRIPTION
## Motivation
- reduce logging in syncer and active set
- add metrics for peer error
- add thread-safety to data fetcher's atx sync cache