### PR TITLE
[Merged by Bors] - atx: verify syntactic correctness before fetching deps

### DIFF
--- a/activation/activation.go
+++ b/activation/activation.go
@@ -342,7 +342,7 @@ func (b *Builder) verifyInitialPost(ctx context.Context, post *types.Post, metad
 	if err != nil {
 		b.log.With().Panic("failed to fetch commitment ATX ID.", log.Err(err))
 	}
-	err = b.validator.Post(ctx, types.EpochID(0), b.nodeID, commitmentAtxId, post, metadata, b.postSetupProvider.LastOpts().NumUnits)
+	err = b.validator.Post(ctx, b.nodeID, commitmentAtxId, post, metadata, b.postSetupProvider.LastOpts().NumUnits)
 	switch {
 	case errors.Is(err, context.Canceled):
 		// If the context was canceled, we don't want to emit or log errors just propagate the cancellation signal.

--- a/activation/handler_test.go
+++ b/activation/handler_test.go
@@ -101,7 +101,7 @@ func newTestHandler(tb testing.TB, goldenATXID types.ATXID) *testHandler {
 	mbeacon := NewMockAtxReceiver(ctrl)
 	mtortoise := mocks.NewMockTortoise(ctrl)
 
-	atxHdlr := NewHandler(cdb, verifier, mclock, mpub, mockFetch, types.GetLayersPerEpoch(), 1, goldenATXID, mValidator, mbeacon, mtortoise, lg, PoetConfig{})
+	atxHdlr := NewHandler(cdb, verifier, mclock, mpub, mockFetch, 1, goldenATXID, mValidator, mbeacon, mtortoise, lg, PoetConfig{})
 	return &testHandler{
 		Handler: atxHdlr,
 
@@ -217,11 +217,11 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 		require.NoError(t, SignAndFinalizeAtx(sig, atx))
 
 		atxHdlr.mclock.EXPECT().CurrentLayer().Return(currentLayer)
+		require.NoError(t, atxHdlr.SyntacticallyValidate(context.Background(), atx))
 		atxHdlr.mValidator.EXPECT().NIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(uint64(1), nil)
 		atxHdlr.mValidator.EXPECT().NIPostChallenge(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-		atxHdlr.mValidator.EXPECT().PositioningAtx(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-
-		_, err := atxHdlr.SyntacticallyValidateAtx(context.Background(), atx)
+		atxHdlr.mValidator.EXPECT().PositioningAtx(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+		_, err = atxHdlr.SyntacticallyValidateDeps(context.Background(), atx)
 		require.NoError(t, err)
 	})
 
@@ -239,12 +239,13 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 		require.NoError(t, SignAndFinalizeAtx(sig, atx))
 
 		atxHdlr.mclock.EXPECT().CurrentLayer().Return(currentLayer)
+
+		require.NoError(t, atxHdlr.SyntacticallyValidate(context.Background(), atx))
 		atxHdlr.mValidator.EXPECT().NIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(uint64(1), nil)
 		atxHdlr.mValidator.EXPECT().NIPostChallenge(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-		atxHdlr.mValidator.EXPECT().PositioningAtx(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+		atxHdlr.mValidator.EXPECT().PositioningAtx(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 		atxHdlr.mValidator.EXPECT().VRFNonce(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-
-		_, err := atxHdlr.SyntacticallyValidateAtx(context.Background(), atx)
+		_, err = atxHdlr.SyntacticallyValidateDeps(context.Background(), atx)
 		require.NoError(t, err)
 	})
 
@@ -260,11 +261,11 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 		require.NoError(t, SignAndFinalizeAtx(sig, atx))
 
 		atxHdlr.mclock.EXPECT().CurrentLayer().Return(currentLayer)
+		require.NoError(t, atxHdlr.SyntacticallyValidate(context.Background(), atx))
 		atxHdlr.mValidator.EXPECT().NIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(uint64(1), nil)
 		atxHdlr.mValidator.EXPECT().NIPostChallenge(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-		atxHdlr.mValidator.EXPECT().PositioningAtx(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-
-		vAtx, err := atxHdlr.SyntacticallyValidateAtx(context.Background(), atx)
+		atxHdlr.mValidator.EXPECT().PositioningAtx(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+		vAtx, err := atxHdlr.SyntacticallyValidateDeps(context.Background(), atx)
 		require.NoError(t, err)
 		require.Equal(t, uint32(90), vAtx.NumUnits)
 		require.Equal(t, uint32(90), vAtx.EffectiveNumUnits())
@@ -282,12 +283,12 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 		require.NoError(t, SignAndFinalizeAtx(sig, atx))
 
 		atxHdlr.mclock.EXPECT().CurrentLayer().Return(currentLayer)
+		require.NoError(t, atxHdlr.SyntacticallyValidate(context.Background(), atx))
 		atxHdlr.mValidator.EXPECT().NIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(uint64(1), nil)
 		atxHdlr.mValidator.EXPECT().NIPostChallenge(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-		atxHdlr.mValidator.EXPECT().PositioningAtx(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+		atxHdlr.mValidator.EXPECT().PositioningAtx(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 		atxHdlr.mValidator.EXPECT().VRFNonce(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-
-		vAtx, err := atxHdlr.SyntacticallyValidateAtx(context.Background(), atx)
+		vAtx, err := atxHdlr.SyntacticallyValidateDeps(context.Background(), atx)
 		require.NoError(t, err)
 		require.Equal(t, uint32(110), vAtx.NumUnits)
 		require.Equal(t, uint32(100), vAtx.EffectiveNumUnits())
@@ -305,11 +306,11 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 		require.NoError(t, SignAndFinalizeAtx(sig, atx))
 
 		atxHdlr.mclock.EXPECT().CurrentLayer().Return(currentLayer)
+		require.NoError(t, atxHdlr.SyntacticallyValidate(context.Background(), atx))
 		atxHdlr.mValidator.EXPECT().NIPostChallenge(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 		atxHdlr.mValidator.EXPECT().VRFNonce(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("invalid VRF"))
-
-		_, err := atxHdlr.SyntacticallyValidateAtx(context.Background(), atx)
-		require.ErrorContains(t, err, "invalid VRFNonce")
+		_, err = atxHdlr.SyntacticallyValidateDeps(context.Background(), atx)
+		require.ErrorContains(t, err, "invalid vrf nonce")
 	})
 
 	t.Run("valid initial atx", func(t *testing.T) {
@@ -333,13 +334,13 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 		require.NoError(t, SignAndFinalizeAtx(sig, atx))
 
 		atxHdlr.mclock.EXPECT().CurrentLayer().Return(currentLayer)
-		atxHdlr.mValidator.EXPECT().InitialNIPostChallenge(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-		atxHdlr.mValidator.EXPECT().VRFNonce(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 		atxHdlr.mValidator.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+		atxHdlr.mValidator.EXPECT().VRFNonce(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+		require.NoError(t, atxHdlr.SyntacticallyValidate(context.Background(), atx))
+		atxHdlr.mValidator.EXPECT().InitialNIPostChallenge(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 		atxHdlr.mValidator.EXPECT().NIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(uint64(1), nil)
-		atxHdlr.mValidator.EXPECT().PositioningAtx(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-
-		_, err := atxHdlr.SyntacticallyValidateAtx(context.Background(), atx)
+		atxHdlr.mValidator.EXPECT().PositioningAtx(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+		_, err = atxHdlr.SyntacticallyValidateDeps(context.Background(), atx)
 		require.NoError(t, err)
 	})
 
@@ -355,7 +356,7 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 
 		atxHdlr.mclock.EXPECT().CurrentLayer().Return(currentLayer)
 
-		_, err := atxHdlr.SyntacticallyValidateAtx(context.Background(), atx)
+		err := atxHdlr.SyntacticallyValidate(context.Background(), atx)
 		require.ErrorContains(t, err, "atx publish epoch is too far in the future")
 	})
 
@@ -370,9 +371,9 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 		require.NoError(t, SignAndFinalizeAtx(sig, atx))
 
 		atxHdlr.mclock.EXPECT().CurrentLayer().Return(currentLayer)
+		require.NoError(t, atxHdlr.SyntacticallyValidate(context.Background(), atx))
 		atxHdlr.mValidator.EXPECT().NIPostChallenge(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("nipost error"))
-
-		_, err := atxHdlr.SyntacticallyValidateAtx(context.Background(), atx)
+		_, err = atxHdlr.SyntacticallyValidateDeps(context.Background(), atx)
 		require.EqualError(t, err, "nipost error")
 	})
 
@@ -387,10 +388,10 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 		require.NoError(t, SignAndFinalizeAtx(sig, atx))
 
 		atxHdlr.mclock.EXPECT().CurrentLayer().Return(currentLayer)
+		require.NoError(t, atxHdlr.SyntacticallyValidate(context.Background(), atx))
 		atxHdlr.mValidator.EXPECT().NIPostChallenge(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-		atxHdlr.mValidator.EXPECT().PositioningAtx(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("bad positioning atx"))
-
-		_, err := atxHdlr.SyntacticallyValidateAtx(context.Background(), atx)
+		atxHdlr.mValidator.EXPECT().PositioningAtx(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("bad positioning atx"))
+		_, err := atxHdlr.SyntacticallyValidateDeps(context.Background(), atx)
 		require.EqualError(t, err, "bad positioning atx")
 	})
 
@@ -408,11 +409,16 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 		}
 		atx.InnerActivationTx.NodeID = new(types.NodeID)
 		*atx.InnerActivationTx.NodeID = sig.NodeID()
+		vrfNonce := types.VRFPostIndex(11)
+		atx.VRFNonce = &vrfNonce
+		atx.SmesherID = sig.NodeID()
 
 		atxHdlr.mclock.EXPECT().CurrentLayer().Return(currentLayer)
+		atxHdlr.mValidator.EXPECT().Post(gomock.Any(), sig.NodeID(), cATX, atx.InitialPost, gomock.Any(), atx.NumUnits)
+		atxHdlr.mValidator.EXPECT().VRFNonce(sig.NodeID(), cATX, &vrfNonce, gomock.Any(), atx.NumUnits)
+		require.NoError(t, atxHdlr.SyntacticallyValidate(context.Background(), atx))
 		atxHdlr.mValidator.EXPECT().InitialNIPostChallenge(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("bad initial nipost"))
-
-		_, err := atxHdlr.SyntacticallyValidateAtx(context.Background(), atx)
+		_, err := atxHdlr.SyntacticallyValidateDeps(context.Background(), atx)
 		require.EqualError(t, err, "bad initial nipost")
 	})
 
@@ -431,33 +437,27 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 
 		atxHdlr.mclock.EXPECT().CurrentLayer().Return(currentLayer)
 
-		_, err := atxHdlr.SyntacticallyValidateAtx(context.Background(), atx)
-		require.ErrorContains(t, err, "NodeID is missing")
+		err = atxHdlr.SyntacticallyValidate(context.Background(), atx)
+		require.ErrorContains(t, err, "node id is missing")
 	})
 
 	t.Run("missing VRF nonce in initial atx", func(t *testing.T) {
 		t.Parallel()
-
 		atxHdlr := newTestHandler(t, goldenATXID)
 
-		ctxID := posAtx.ID()
-		challenge := newChallenge(0, types.EmptyATXID, posAtx.ID(), currentLayer.GetEpoch(), &ctxID)
-		atx := newAtx(t, sig, challenge, &types.NIPost{}, 100, types.GenerateAddress([]byte("aaaa")))
+		cATX := posAtx.ID()
+		challenge := newChallenge(0, types.EmptyATXID, posAtx.ID(), currentLayer.GetEpoch(), &cATX)
+		atx := newAtx(t, sig, challenge, npst, 100, types.GenerateAddress([]byte("aaaa")))
 		atx.InitialPost = &types.Post{
 			Nonce:   0,
 			Indices: make([]byte, 10),
 		}
-		atx.InnerActivationTx.NodeID = new(types.NodeID)
-		*atx.InnerActivationTx.NodeID = sig.NodeID()
-		atx.NIPost = newNIPostWithChallenge(t, atx.NIPostChallenge.Hash(), poetRef)
-		require.NoError(t, SignAndFinalizeAtx(sig, atx))
+		nodeID := sig.NodeID()
+		atx.InnerActivationTx.NodeID = &nodeID
 
 		atxHdlr.mclock.EXPECT().CurrentLayer().Return(currentLayer)
-		atxHdlr.mValidator.EXPECT().InitialNIPostChallenge(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-		atxHdlr.mValidator.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-
-		_, err := atxHdlr.SyntacticallyValidateAtx(context.Background(), atx)
-		require.ErrorContains(t, err, "VRFNonce is missing")
+		err = atxHdlr.SyntacticallyValidate(context.Background(), atx)
+		require.ErrorContains(t, err, "vrf nonce is missing")
 	})
 
 	t.Run("invalid VRF nonce in initial atx", func(t *testing.T) {
@@ -480,11 +480,10 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 		require.NoError(t, SignAndFinalizeAtx(sig, atx))
 
 		atxHdlr.mclock.EXPECT().CurrentLayer().Return(currentLayer)
-		atxHdlr.mValidator.EXPECT().InitialNIPostChallenge(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-		atxHdlr.mValidator.EXPECT().VRFNonce(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("invalid VRF nonce"))
 		atxHdlr.mValidator.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+		atxHdlr.mValidator.EXPECT().VRFNonce(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("invalid VRF nonce"))
 
-		_, err := atxHdlr.SyntacticallyValidateAtx(context.Background(), atx)
+		err = atxHdlr.SyntacticallyValidate(context.Background(), atx)
 		require.ErrorContains(t, err, "invalid VRF nonce")
 	})
 
@@ -499,8 +498,8 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 
 		atxHdlr.mclock.EXPECT().CurrentLayer().Return(currentLayer)
 
-		_, err := atxHdlr.SyntacticallyValidateAtx(context.Background(), atx)
-		require.EqualError(t, err, "no prevATX declared, but initial Post is not included")
+		err = atxHdlr.SyntacticallyValidate(context.Background(), atx)
+		require.EqualError(t, err, "no prev atx declared, but initial post is not included")
 	})
 
 	t.Run("prevAtx not declared but validation of initial post fails", func(t *testing.T) {
@@ -521,10 +520,9 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 		*atx.InnerActivationTx.NodeID = sig.NodeID()
 
 		atxHdlr.mclock.EXPECT().CurrentLayer().Return(currentLayer)
-		atxHdlr.mValidator.EXPECT().InitialNIPostChallenge(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 		atxHdlr.mValidator.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("failed post validation"))
 
-		_, err := atxHdlr.SyntacticallyValidateAtx(context.Background(), atx)
+		err := atxHdlr.SyntacticallyValidate(context.Background(), atx)
 		require.ErrorContains(t, err, "failed post validation")
 	})
 
@@ -543,10 +541,9 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 		require.NoError(t, SignAndFinalizeAtx(sig, atx))
 
 		atxHdlr.mclock.EXPECT().CurrentLayer().Return(currentLayer)
-		atxHdlr.mValidator.EXPECT().NIPostChallenge(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 
-		_, err := atxHdlr.SyntacticallyValidateAtx(context.Background(), atx)
-		require.EqualError(t, err, "prevATX declared, but initial Post is included")
+		err = atxHdlr.SyntacticallyValidate(context.Background(), atx)
+		require.EqualError(t, err, "prev atx declared, but initial post is included")
 	})
 
 	t.Run("prevAtx declared but NodeID is included", func(t *testing.T) {
@@ -564,8 +561,8 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 
 		atxHdlr.mclock.EXPECT().CurrentLayer().Return(currentLayer)
 
-		_, err := atxHdlr.SyntacticallyValidateAtx(context.Background(), atx)
-		require.EqualError(t, err, "prevATX declared, but NodeID is included")
+		err = atxHdlr.SyntacticallyValidate(context.Background(), atx)
+		require.EqualError(t, err, "prev atx declared, but node id is included")
 	})
 }
 
@@ -763,61 +760,6 @@ func TestHandler_ProcessAtxStoresNewVRFNonce(t *testing.T) {
 	require.Equal(t, nonce2, got)
 }
 
-func BenchmarkActivationDb_SyntacticallyValidateAtx(b *testing.B) {
-	r := require.New(b)
-
-	goldenATXID := types.ATXID{2, 3, 4}
-	atxHdlr := newTestHandler(b, goldenATXID)
-
-	currentLayer := types.LayerID(1012)
-	atxHdlr.mclock.EXPECT().CurrentLayer().Return(currentLayer).AnyTimes()
-	atxHdlr.mValidator.EXPECT().NIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(uint64(1), nil).AnyTimes()
-	atxHdlr.mValidator.EXPECT().NIPostChallenge(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
-	atxHdlr.mValidator.EXPECT().VRFNonce(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
-	atxHdlr.mValidator.EXPECT().PositioningAtx(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
-
-	sig, err := signing.NewEdSigner()
-	r.NoError(err)
-
-	coinbase := types.GenerateAddress([]byte("c012ba5e"))
-	var atxList []*types.VerifiedActivationTx
-	for i := 0; i < 300; i++ {
-		atxList = append(atxList, newActivationTx(b, sig, 0, types.EmptyATXID, types.EmptyATXID, &goldenATXID, types.LayerID(1).GetEpoch(), 0, 100, coinbase, 100, &types.NIPost{}))
-	}
-
-	poetRef := []byte{0x12, 0x21}
-	for _, atx := range atxList {
-		atx.NIPost = newNIPostWithChallenge(b, atx.NIPostChallenge.Hash(), poetRef)
-	}
-
-	challenge := newChallenge(0, types.EmptyATXID, goldenATXID, currentLayer.GetEpoch(), &goldenATXID)
-	npst := newNIPostWithChallenge(b, challenge.Hash(), poetRef)
-	prevAtx := newActivationTx(b, sig, 0, types.EmptyATXID, goldenATXID, &goldenATXID, currentLayer.GetEpoch()-1, 0, 100, coinbase, 100, npst)
-	r.NoError(atxs.Add(atxHdlr.cdb, prevAtx))
-
-	challenge = newChallenge(1, prevAtx.ID(), prevAtx.ID(), currentLayer.GetEpoch()+1, nil)
-	atx := newAtx(b, sig, challenge, &types.NIPost{}, 100, coinbase)
-	nonce := types.VRFPostIndex(1)
-	atx.VRFNonce = &nonce
-	atx.NIPost = newNIPostWithChallenge(b, atx.NIPostChallenge.Hash(), poetRef)
-	require.NoError(b, SignAndFinalizeAtx(sig, atx))
-
-	start := time.Now()
-	_, err = atxHdlr.SyntacticallyValidateAtx(context.Background(), atx)
-	b.Logf("\nSyntactic validation took %v\n", time.Since(start))
-	r.NoError(err)
-
-	start = time.Now()
-	vAtx, err := atxHdlr.SyntacticallyValidateAtx(context.Background(), atx)
-	b.Logf("\nSecond syntactic validation took %v\n", time.Since(start))
-	r.NoError(err)
-
-	start = time.Now()
-	err = atxHdlr.ContextuallyValidateAtx(vAtx)
-	b.Logf("\nContextual validation took %v\n\n", time.Since(start))
-	r.NoError(err)
-}
-
 func BenchmarkNewActivationDb(b *testing.B) {
 	r := require.New(b)
 
@@ -934,6 +876,97 @@ func TestHandler_AwaitAtx(t *testing.T) {
 	r.Len(atxHdlr.atxChannels, 0) // last unsubscribe clears the channel
 }
 
+func TestHandler_HandleGossipAtx(t *testing.T) {
+	goldenATXID := types.ATXID{2, 3, 4}
+	atxHdlr := newTestHandler(t, goldenATXID)
+
+	sig1, err := signing.NewEdSigner()
+	require.NoError(t, err)
+	nodeID1 := sig1.NodeID()
+	nipost := newNIPostWithChallenge(t, types.HexToHash32("0x3333"), []byte{0xba, 0xbe})
+	vrfNonce := types.VRFPostIndex(12345)
+	first := &types.ActivationTx{
+		InnerActivationTx: types.InnerActivationTx{
+			NIPostChallenge: types.NIPostChallenge{
+				PublishEpoch:   1,
+				Sequence:       0,
+				PrevATXID:      types.EmptyATXID,
+				PositioningATX: goldenATXID,
+				CommitmentATX:  &goldenATXID,
+				InitialPost:    nipost.Post,
+			},
+			Coinbase: types.Address{2, 3, 4},
+			NumUnits: 2,
+			NIPost:   nipost,
+			NodeID:   &nodeID1,
+			VRFNonce: &vrfNonce,
+		},
+		SmesherID: nodeID1,
+	}
+	first.Signature = sig1.Sign(signing.ATX, first.SignedBytes())
+	first.SetEffectiveNumUnits(first.NumUnits)
+	first.SetReceived(time.Now())
+	_, err = first.Verify(0, 2)
+	require.NoError(t, err)
+
+	second := &types.ActivationTx{
+		InnerActivationTx: types.InnerActivationTx{
+			NIPostChallenge: types.NIPostChallenge{
+				PublishEpoch:   2,
+				Sequence:       1,
+				PrevATXID:      first.ID(),
+				PositioningATX: first.ID(),
+			},
+			Coinbase: types.Address{2, 3, 4},
+			NumUnits: 2,
+			NIPost:   nipost,
+		},
+		SmesherID: nodeID1,
+	}
+	second.Signature = sig1.Sign(signing.ATX, second.SignedBytes())
+	secondData, err := codec.Encode(second)
+	require.NoError(t, err)
+
+	atxHdlr.mclock.EXPECT().CurrentLayer().Return(second.PublishEpoch.FirstLayer())
+	atxHdlr.mclock.EXPECT().LayerToTime(gomock.Any()).Return(time.Now())
+	atxHdlr.mockFetch.EXPECT().RegisterPeerHashes(gomock.Any(), gomock.Any())
+	atxHdlr.mockFetch.EXPECT().GetPoetProof(gomock.Any(), second.GetPoetProofRef()).Return(errors.New("woof"))
+	err = atxHdlr.HandleGossipAtx(context.Background(), "", secondData)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "missing poet proof")
+
+	atxHdlr.mclock.EXPECT().CurrentLayer().Return(second.PublishEpoch.FirstLayer())
+	atxHdlr.mclock.EXPECT().LayerToTime(gomock.Any()).Return(time.Now())
+	atxHdlr.mockFetch.EXPECT().RegisterPeerHashes(gomock.Any(), gomock.Any())
+	atxHdlr.mockFetch.EXPECT().GetPoetProof(gomock.Any(), second.GetPoetProofRef())
+	atxHdlr.mockFetch.EXPECT().GetAtxs(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, ids []types.ATXID) error {
+			require.ElementsMatch(t, []types.ATXID{first.ID()}, ids)
+			data, err := codec.Encode(first)
+			require.NoError(t, err)
+			atxHdlr.mclock.EXPECT().CurrentLayer().Return(first.PublishEpoch.FirstLayer())
+			atxHdlr.mclock.EXPECT().LayerToTime(gomock.Any()).Return(time.Now())
+			atxHdlr.mValidator.EXPECT().Post(gomock.Any(), nodeID1, goldenATXID, first.InitialPost, gomock.Any(), first.NumUnits)
+			atxHdlr.mValidator.EXPECT().VRFNonce(nodeID1, goldenATXID, &vrfNonce, gomock.Any(), first.NumUnits)
+			atxHdlr.mockFetch.EXPECT().RegisterPeerHashes(gomock.Any(), gomock.Any())
+			atxHdlr.mockFetch.EXPECT().GetPoetProof(gomock.Any(), first.GetPoetProofRef())
+			atxHdlr.mValidator.EXPECT().InitialNIPostChallenge(&first.NIPostChallenge, gomock.Any(), goldenATXID)
+			atxHdlr.mValidator.EXPECT().PositioningAtx(&goldenATXID, gomock.Any(), goldenATXID, first.PublishEpoch)
+			atxHdlr.mValidator.EXPECT().NIPost(gomock.Any(), nodeID1, goldenATXID, second.NIPost, gomock.Any(), second.NumUnits)
+			atxHdlr.mbeacon.EXPECT().OnAtx(gomock.Any())
+			atxHdlr.mtortoise.EXPECT().OnAtx(gomock.Any())
+			require.NoError(t, atxHdlr.HandleGossipAtx(context.Background(), "", data))
+			return nil
+		},
+	)
+	atxHdlr.mValidator.EXPECT().NIPostChallenge(&second.NIPostChallenge, gomock.Any(), nodeID1)
+	atxHdlr.mValidator.EXPECT().NIPost(gomock.Any(), nodeID1, goldenATXID, second.NIPost, gomock.Any(), second.NumUnits)
+	atxHdlr.mValidator.EXPECT().PositioningAtx(&second.PositioningATX, gomock.Any(), goldenATXID, second.PublishEpoch)
+	atxHdlr.mbeacon.EXPECT().OnAtx(gomock.Any())
+	atxHdlr.mtortoise.EXPECT().OnAtx(gomock.Any())
+	require.NoError(t, atxHdlr.HandleGossipAtx(context.Background(), "", secondData))
+}
+
 func TestHandler_HandleSyncedAtx(t *testing.T) {
 	// Arrange
 	goldenATXID := types.ATXID{2, 3, 4}
@@ -953,7 +986,7 @@ func TestHandler_HandleSyncedAtx(t *testing.T) {
 		require.NoError(t, err)
 
 		atxHdlr.mclock.EXPECT().LayerToTime(gomock.Any()).Return(time.Now())
-		require.EqualError(t, atxHdlr.HandleSyncedAtx(context.Background(), atx.ID().Hash32(), p2p.NoPeer, buf), fmt.Sprintf("nil nipst in gossip for atx %v", atx.ID()))
+		require.EqualError(t, atxHdlr.HandleSyncedAtx(context.Background(), atx.ID().Hash32(), p2p.NoPeer, buf), fmt.Sprintf("nil nipst for atx %v", atx.ID()))
 	})
 
 	t.Run("known atx is ignored by handleAtxData", func(t *testing.T) {
@@ -1035,7 +1068,7 @@ func BenchmarkGetAtxHeaderWithConcurrentProcessAtx(b *testing.B) {
 }
 
 // Check that we're not trying to sync an ATX that references the golden ATX or an empty ATX (i.e. not adding it to the sync queue).
-func TestHandler_FetchAtxReferences(t *testing.T) {
+func TestHandler_FetchReferences(t *testing.T) {
 	goldenATXID := types.ATXID{2, 3, 4}
 
 	sig, err := signing.NewEdSigner()
@@ -1054,8 +1087,9 @@ func TestHandler_FetchAtxReferences(t *testing.T) {
 		nipost := newNIPostWithChallenge(t, types.HexToHash32("55555"), []byte("66666"))
 		atx := newAtx(t, sig, challenge, nipost, 2, coinbase)
 
+		atxHdlr.mockFetch.EXPECT().GetPoetProof(gomock.Any(), atx.GetPoetProofRef())
 		atxHdlr.mockFetch.EXPECT().GetAtxs(gomock.Any(), gomock.InAnyOrder([]types.ATXID{atx.PositioningATX, atx.PrevATXID})).Return(nil)
-		require.NoError(t, atxHdlr.FetchAtxReferences(context.Background(), atx))
+		require.NoError(t, atxHdlr.FetchReferences(context.Background(), atx))
 	})
 
 	t.Run("valid prev ATX and golden pos ATX", func(t *testing.T) {
@@ -1067,8 +1101,9 @@ func TestHandler_FetchAtxReferences(t *testing.T) {
 		nipost := newNIPostWithChallenge(t, types.HexToHash32("55555"), []byte("66666"))
 		atx := newAtx(t, sig, challenge, nipost, 2, coinbase)
 
+		atxHdlr.mockFetch.EXPECT().GetPoetProof(gomock.Any(), atx.GetPoetProofRef())
 		atxHdlr.mockFetch.EXPECT().GetAtxs(gomock.Any(), []types.ATXID{atx.PrevATXID}).Return(nil)
-		require.NoError(t, atxHdlr.FetchAtxReferences(context.Background(), atx))
+		require.NoError(t, atxHdlr.FetchReferences(context.Background(), atx))
 	})
 
 	t.Run("valid prev ATX and empty pos ATX", func(t *testing.T) {
@@ -1080,8 +1115,9 @@ func TestHandler_FetchAtxReferences(t *testing.T) {
 		nipost := newNIPostWithChallenge(t, types.HexToHash32("55555"), []byte("66666"))
 		atx := newAtx(t, sig, challenge, nipost, 2, coinbase)
 
+		atxHdlr.mockFetch.EXPECT().GetPoetProof(gomock.Any(), atx.GetPoetProofRef())
 		atxHdlr.mockFetch.EXPECT().GetAtxs(gomock.Any(), []types.ATXID{atx.PrevATXID}).Return(nil)
-		require.NoError(t, atxHdlr.FetchAtxReferences(context.Background(), atx))
+		require.NoError(t, atxHdlr.FetchReferences(context.Background(), atx))
 	})
 
 	t.Run("empty prev ATX, valid pos ATX and valid commitment ATX", func(t *testing.T) {
@@ -1094,8 +1130,9 @@ func TestHandler_FetchAtxReferences(t *testing.T) {
 		atx := newAtx(t, sig, challenge, nipost, 2, coinbase)
 		atx.CommitmentATX = &commitATX
 
+		atxHdlr.mockFetch.EXPECT().GetPoetProof(gomock.Any(), atx.GetPoetProofRef())
 		atxHdlr.mockFetch.EXPECT().GetAtxs(gomock.Any(), gomock.InAnyOrder([]types.ATXID{atx.PositioningATX, *atx.CommitmentATX})).Return(nil)
-		require.NoError(t, atxHdlr.FetchAtxReferences(context.Background(), atx))
+		require.NoError(t, atxHdlr.FetchReferences(context.Background(), atx))
 	})
 
 	t.Run("empty prev ATX, valid pos ATX and golden commitment ATX", func(t *testing.T) {
@@ -1108,8 +1145,9 @@ func TestHandler_FetchAtxReferences(t *testing.T) {
 		atx := newAtx(t, sig, challenge, nipost, 2, coinbase)
 		atx.CommitmentATX = &goldenATXID
 
+		atxHdlr.mockFetch.EXPECT().GetPoetProof(gomock.Any(), atx.GetPoetProofRef())
 		atxHdlr.mockFetch.EXPECT().GetAtxs(gomock.Any(), []types.ATXID{atx.PositioningATX}).Return(nil)
-		require.NoError(t, atxHdlr.FetchAtxReferences(context.Background(), atx))
+		require.NoError(t, atxHdlr.FetchReferences(context.Background(), atx))
 	})
 
 	t.Run("empty prev ATX, empty pos ATX", func(t *testing.T) {
@@ -1121,7 +1159,8 @@ func TestHandler_FetchAtxReferences(t *testing.T) {
 		nipost := newNIPostWithChallenge(t, types.HexToHash32("55555"), []byte("66666"))
 		atx := newAtx(t, sig, challenge, nipost, 2, coinbase)
 
-		require.NoError(t, atxHdlr.FetchAtxReferences(context.Background(), atx))
+		atxHdlr.mockFetch.EXPECT().GetPoetProof(gomock.Any(), atx.GetPoetProofRef())
+		require.NoError(t, atxHdlr.FetchReferences(context.Background(), atx))
 	})
 
 	t.Run("same prev and pos ATX", func(t *testing.T) {
@@ -1133,8 +1172,36 @@ func TestHandler_FetchAtxReferences(t *testing.T) {
 		nipost := newNIPostWithChallenge(t, types.HexToHash32("55555"), []byte("66666"))
 		atx := newAtx(t, sig, challenge, nipost, 2, coinbase)
 
+		atxHdlr.mockFetch.EXPECT().GetPoetProof(gomock.Any(), atx.GetPoetProofRef())
 		atxHdlr.mockFetch.EXPECT().GetAtxs(gomock.Any(), []types.ATXID{atx.PrevATXID}).Return(nil)
-		require.NoError(t, atxHdlr.FetchAtxReferences(context.Background(), atx))
+		require.NoError(t, atxHdlr.FetchReferences(context.Background(), atx))
+	})
+
+	t.Run("no poet proofs", func(t *testing.T) {
+		t.Parallel()
+		atxHdlr := newTestHandler(t, goldenATXID)
+
+		coinbase := types.Address{2, 4, 5}
+		challenge := newChallenge(1, types.EmptyATXID, types.EmptyATXID, types.LayerID(22).GetEpoch(), nil)
+		nipost := newNIPostWithChallenge(t, types.HexToHash32("55555"), []byte("66666"))
+		atx := newAtx(t, sig, challenge, nipost, 2, coinbase)
+
+		atxHdlr.mockFetch.EXPECT().GetPoetProof(gomock.Any(), atx.GetPoetProofRef()).Return(errors.New("pooh"))
+		require.Error(t, atxHdlr.FetchReferences(context.Background(), atx))
+	})
+
+	t.Run("no atxs", func(t *testing.T) {
+		t.Parallel()
+		atxHdlr := newTestHandler(t, goldenATXID)
+
+		coinbase := types.Address{2, 4, 5}
+		challenge := newChallenge(1, prevATX, prevATX, types.LayerID(22).GetEpoch(), nil)
+		nipost := newNIPostWithChallenge(t, types.HexToHash32("55555"), []byte("66666"))
+		atx := newAtx(t, sig, challenge, nipost, 2, coinbase)
+
+		atxHdlr.mockFetch.EXPECT().GetPoetProof(gomock.Any(), atx.GetPoetProofRef())
+		atxHdlr.mockFetch.EXPECT().GetAtxs(gomock.Any(), []types.ATXID{atx.PrevATXID}).Return(errors.New("pooh"))
+		require.Error(t, atxHdlr.FetchReferences(context.Background(), atx))
 	})
 }
 
@@ -1188,7 +1255,7 @@ func TestHandler_AtxWeight(t *testing.T) {
 	atxHdlr.mValidator.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 	atxHdlr.mValidator.EXPECT().NIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(leaves, nil)
 	atxHdlr.mValidator.EXPECT().InitialNIPostChallenge(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-	atxHdlr.mValidator.EXPECT().PositioningAtx(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	atxHdlr.mValidator.EXPECT().PositioningAtx(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 	atxHdlr.mbeacon.EXPECT().OnAtx(gomock.Any())
 	atxHdlr.mtortoise.EXPECT().OnAtx(gomock.Any())
 	require.NoError(t, atxHdlr.HandleSyncedAtx(context.Background(), atx1.ID().Hash32(), peer, buf))
@@ -1231,7 +1298,7 @@ func TestHandler_AtxWeight(t *testing.T) {
 	atxHdlr.mockFetch.EXPECT().GetAtxs(gomock.Any(), gomock.Any())
 	atxHdlr.mValidator.EXPECT().NIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(leaves, nil)
 	atxHdlr.mValidator.EXPECT().NIPostChallenge(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-	atxHdlr.mValidator.EXPECT().PositioningAtx(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	atxHdlr.mValidator.EXPECT().PositioningAtx(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 	atxHdlr.mbeacon.EXPECT().OnAtx(gomock.Any())
 	atxHdlr.mtortoise.EXPECT().OnAtx(gomock.Any())
 	require.NoError(t, atxHdlr.HandleSyncedAtx(context.Background(), atx2.ID().Hash32(), peer, buf))
@@ -1286,7 +1353,7 @@ func TestHandler_WrongHash(t *testing.T) {
 	atxHdlr.mValidator.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 	atxHdlr.mValidator.EXPECT().NIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(uint64(111), nil)
 	atxHdlr.mValidator.EXPECT().InitialNIPostChallenge(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-	atxHdlr.mValidator.EXPECT().PositioningAtx(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	atxHdlr.mValidator.EXPECT().PositioningAtx(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 	err = atxHdlr.HandleSyncedAtx(context.Background(), types.RandomHash(), peer, buf)
 	require.ErrorIs(t, err, errWrongHash)
 	require.ErrorIs(t, err, pubsub.ErrValidationReject)

--- a/activation/handler_test.go
+++ b/activation/handler_test.go
@@ -221,7 +221,7 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 		atxHdlr.mValidator.EXPECT().NIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(uint64(1), nil)
 		atxHdlr.mValidator.EXPECT().NIPostChallenge(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 		atxHdlr.mValidator.EXPECT().PositioningAtx(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-		_, err = atxHdlr.SyntacticallyValidateDeps(context.Background(), atx)
+		_, err := atxHdlr.SyntacticallyValidateDeps(context.Background(), atx)
 		require.NoError(t, err)
 	})
 
@@ -245,7 +245,7 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 		atxHdlr.mValidator.EXPECT().NIPostChallenge(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 		atxHdlr.mValidator.EXPECT().PositioningAtx(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 		atxHdlr.mValidator.EXPECT().VRFNonce(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-		_, err = atxHdlr.SyntacticallyValidateDeps(context.Background(), atx)
+		_, err := atxHdlr.SyntacticallyValidateDeps(context.Background(), atx)
 		require.NoError(t, err)
 	})
 
@@ -309,7 +309,7 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 		require.NoError(t, atxHdlr.SyntacticallyValidate(context.Background(), atx))
 		atxHdlr.mValidator.EXPECT().NIPostChallenge(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 		atxHdlr.mValidator.EXPECT().VRFNonce(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("invalid VRF"))
-		_, err = atxHdlr.SyntacticallyValidateDeps(context.Background(), atx)
+		_, err := atxHdlr.SyntacticallyValidateDeps(context.Background(), atx)
 		require.ErrorContains(t, err, "invalid vrf nonce")
 	})
 
@@ -340,7 +340,7 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 		atxHdlr.mValidator.EXPECT().InitialNIPostChallenge(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 		atxHdlr.mValidator.EXPECT().NIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(uint64(1), nil)
 		atxHdlr.mValidator.EXPECT().PositioningAtx(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-		_, err = atxHdlr.SyntacticallyValidateDeps(context.Background(), atx)
+		_, err := atxHdlr.SyntacticallyValidateDeps(context.Background(), atx)
 		require.NoError(t, err)
 	})
 
@@ -373,7 +373,7 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 		atxHdlr.mclock.EXPECT().CurrentLayer().Return(currentLayer)
 		require.NoError(t, atxHdlr.SyntacticallyValidate(context.Background(), atx))
 		atxHdlr.mValidator.EXPECT().NIPostChallenge(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("nipost error"))
-		_, err = atxHdlr.SyntacticallyValidateDeps(context.Background(), atx)
+		_, err := atxHdlr.SyntacticallyValidateDeps(context.Background(), atx)
 		require.EqualError(t, err, "nipost error")
 	})
 
@@ -437,7 +437,7 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 
 		atxHdlr.mclock.EXPECT().CurrentLayer().Return(currentLayer)
 
-		err = atxHdlr.SyntacticallyValidate(context.Background(), atx)
+		err := atxHdlr.SyntacticallyValidate(context.Background(), atx)
 		require.ErrorContains(t, err, "node id is missing")
 	})
 
@@ -456,7 +456,7 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 		atx.InnerActivationTx.NodeID = &nodeID
 
 		atxHdlr.mclock.EXPECT().CurrentLayer().Return(currentLayer)
-		err = atxHdlr.SyntacticallyValidate(context.Background(), atx)
+		err := atxHdlr.SyntacticallyValidate(context.Background(), atx)
 		require.ErrorContains(t, err, "vrf nonce is missing")
 	})
 
@@ -483,7 +483,7 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 		atxHdlr.mValidator.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 		atxHdlr.mValidator.EXPECT().VRFNonce(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("invalid VRF nonce"))
 
-		err = atxHdlr.SyntacticallyValidate(context.Background(), atx)
+		err := atxHdlr.SyntacticallyValidate(context.Background(), atx)
 		require.ErrorContains(t, err, "invalid VRF nonce")
 	})
 
@@ -542,7 +542,7 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 
 		atxHdlr.mclock.EXPECT().CurrentLayer().Return(currentLayer)
 
-		err = atxHdlr.SyntacticallyValidate(context.Background(), atx)
+		err := atxHdlr.SyntacticallyValidate(context.Background(), atx)
 		require.EqualError(t, err, "prev atx declared, but initial post is included")
 	})
 
@@ -561,7 +561,7 @@ func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
 
 		atxHdlr.mclock.EXPECT().CurrentLayer().Return(currentLayer)
 
-		err = atxHdlr.SyntacticallyValidate(context.Background(), atx)
+		err := atxHdlr.SyntacticallyValidate(context.Background(), atx)
 		require.EqualError(t, err, "prev atx declared, but node id is included")
 	})
 }

--- a/activation/interface.go
+++ b/activation/interface.go
@@ -25,14 +25,14 @@ type PostVerifier interface {
 type nipostValidator interface {
 	InitialNIPostChallenge(challenge *types.NIPostChallenge, atxs atxProvider, goldenATXID types.ATXID) error
 	NIPostChallenge(challenge *types.NIPostChallenge, atxs atxProvider, nodeID types.NodeID) error
-	NIPost(ctx context.Context, publishEpoch types.EpochID, nodeId types.NodeID, atxId types.ATXID, NIPost *types.NIPost, expectedChallenge types.Hash32, numUnits uint32, opts ...verifying.OptionFunc) (uint64, error)
+	NIPost(ctx context.Context, nodeId types.NodeID, atxId types.ATXID, NIPost *types.NIPost, expectedChallenge types.Hash32, numUnits uint32, opts ...verifying.OptionFunc) (uint64, error)
 
 	NumUnits(cfg *PostConfig, numUnits uint32) error
-	Post(ctx context.Context, publishEpoch types.EpochID, nodeId types.NodeID, atxId types.ATXID, Post *types.Post, PostMetadata *types.PostMetadata, numUnits uint32, opts ...verifying.OptionFunc) error
+	Post(ctx context.Context, nodeId types.NodeID, atxId types.ATXID, Post *types.Post, PostMetadata *types.PostMetadata, numUnits uint32, opts ...verifying.OptionFunc) error
 	PostMetadata(cfg *PostConfig, metadata *types.PostMetadata) error
 
 	VRFNonce(nodeId types.NodeID, commitmentAtxId types.ATXID, vrfNonce *types.VRFPostIndex, PostMetadata *types.PostMetadata, numUnits uint32) error
-	PositioningAtx(id *types.ATXID, atxs atxProvider, goldenATXID types.ATXID, pubepoch types.EpochID, layersPerEpoch uint32) error
+	PositioningAtx(id *types.ATXID, atxs atxProvider, goldenATXID types.ATXID, pubepoch types.EpochID) error
 }
 
 type layerClock interface {

--- a/activation/interface.go
+++ b/activation/interface.go
@@ -32,7 +32,7 @@ type nipostValidator interface {
 	PostMetadata(cfg *PostConfig, metadata *types.PostMetadata) error
 
 	VRFNonce(nodeId types.NodeID, commitmentAtxId types.ATXID, vrfNonce *types.VRFPostIndex, PostMetadata *types.PostMetadata, numUnits uint32) error
-	PositioningAtx(id *types.ATXID, atxs atxProvider, goldenATXID types.ATXID, pubepoch types.EpochID) error
+	PositioningAtx(id types.ATXID, atxs atxProvider, goldenATXID types.ATXID, pubepoch types.EpochID) error
 }
 
 type layerClock interface {

--- a/activation/mocks.go
+++ b/activation/mocks.go
@@ -387,13 +387,13 @@ func (c *nipostValidatorPositioningAtxCall) Return(arg0 error) *nipostValidatorP
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *nipostValidatorPositioningAtxCall) Do(f func(*types.ATXID, atxProvider, types.ATXID, types.EpochID) error) *nipostValidatorPositioningAtxCall {
+func (c *nipostValidatorPositioningAtxCall) Do(f func(types.ATXID, atxProvider, types.ATXID, types.EpochID) error) *nipostValidatorPositioningAtxCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *nipostValidatorPositioningAtxCall) DoAndReturn(f func(*types.ATXID, atxProvider, types.ATXID, types.EpochID) error) *nipostValidatorPositioningAtxCall {
+func (c *nipostValidatorPositioningAtxCall) DoAndReturn(f func(types.ATXID, atxProvider, types.ATXID, types.EpochID) error) *nipostValidatorPositioningAtxCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/activation/mocks.go
+++ b/activation/mocks.go
@@ -361,7 +361,7 @@ func (c *nipostValidatorNumUnitsCall) DoAndReturn(f func(*PostConfig, uint32) er
 }
 
 // PositioningAtx mocks base method.
-func (m *MocknipostValidator) PositioningAtx(id *types.ATXID, atxs atxProvider, goldenATXID types.ATXID, pubepoch types.EpochID) error {
+func (m *MocknipostValidator) PositioningAtx(id types.ATXID, atxs atxProvider, goldenATXID types.ATXID, pubepoch types.EpochID) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PositioningAtx", id, atxs, goldenATXID, pubepoch)
 	ret0, _ := ret[0].(error)

--- a/activation/mocks.go
+++ b/activation/mocks.go
@@ -241,9 +241,9 @@ func (c *nipostValidatorInitialNIPostChallengeCall) DoAndReturn(f func(*types.NI
 }
 
 // NIPost mocks base method.
-func (m *MocknipostValidator) NIPost(ctx context.Context, publishEpoch types.EpochID, nodeId types.NodeID, atxId types.ATXID, NIPost *types.NIPost, expectedChallenge types.Hash32, numUnits uint32, opts ...verifying.OptionFunc) (uint64, error) {
+func (m *MocknipostValidator) NIPost(ctx context.Context, nodeId types.NodeID, atxId types.ATXID, NIPost *types.NIPost, expectedChallenge types.Hash32, numUnits uint32, opts ...verifying.OptionFunc) (uint64, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{ctx, publishEpoch, nodeId, atxId, NIPost, expectedChallenge, numUnits}
+	varargs := []interface{}{ctx, nodeId, atxId, NIPost, expectedChallenge, numUnits}
 	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
@@ -254,9 +254,9 @@ func (m *MocknipostValidator) NIPost(ctx context.Context, publishEpoch types.Epo
 }
 
 // NIPost indicates an expected call of NIPost.
-func (mr *MocknipostValidatorMockRecorder) NIPost(ctx, publishEpoch, nodeId, atxId, NIPost, expectedChallenge, numUnits interface{}, opts ...interface{}) *nipostValidatorNIPostCall {
+func (mr *MocknipostValidatorMockRecorder) NIPost(ctx, nodeId, atxId, NIPost, expectedChallenge, numUnits interface{}, opts ...interface{}) *nipostValidatorNIPostCall {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{ctx, publishEpoch, nodeId, atxId, NIPost, expectedChallenge, numUnits}, opts...)
+	varargs := append([]interface{}{ctx, nodeId, atxId, NIPost, expectedChallenge, numUnits}, opts...)
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NIPost", reflect.TypeOf((*MocknipostValidator)(nil).NIPost), varargs...)
 	return &nipostValidatorNIPostCall{Call: call}
 }
@@ -273,13 +273,13 @@ func (c *nipostValidatorNIPostCall) Return(arg0 uint64, arg1 error) *nipostValid
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *nipostValidatorNIPostCall) Do(f func(context.Context, types.EpochID, types.NodeID, types.ATXID, *types.NIPost, types.Hash32, uint32, ...verifying.OptionFunc) (uint64, error)) *nipostValidatorNIPostCall {
+func (c *nipostValidatorNIPostCall) Do(f func(context.Context, types.NodeID, types.ATXID, *types.NIPost, types.Hash32, uint32, ...verifying.OptionFunc) (uint64, error)) *nipostValidatorNIPostCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *nipostValidatorNIPostCall) DoAndReturn(f func(context.Context, types.EpochID, types.NodeID, types.ATXID, *types.NIPost, types.Hash32, uint32, ...verifying.OptionFunc) (uint64, error)) *nipostValidatorNIPostCall {
+func (c *nipostValidatorNIPostCall) DoAndReturn(f func(context.Context, types.NodeID, types.ATXID, *types.NIPost, types.Hash32, uint32, ...verifying.OptionFunc) (uint64, error)) *nipostValidatorNIPostCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -361,17 +361,17 @@ func (c *nipostValidatorNumUnitsCall) DoAndReturn(f func(*PostConfig, uint32) er
 }
 
 // PositioningAtx mocks base method.
-func (m *MocknipostValidator) PositioningAtx(id *types.ATXID, atxs atxProvider, goldenATXID types.ATXID, pubepoch types.EpochID, layersPerEpoch uint32) error {
+func (m *MocknipostValidator) PositioningAtx(id *types.ATXID, atxs atxProvider, goldenATXID types.ATXID, pubepoch types.EpochID) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PositioningAtx", id, atxs, goldenATXID, pubepoch, layersPerEpoch)
+	ret := m.ctrl.Call(m, "PositioningAtx", id, atxs, goldenATXID, pubepoch)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // PositioningAtx indicates an expected call of PositioningAtx.
-func (mr *MocknipostValidatorMockRecorder) PositioningAtx(id, atxs, goldenATXID, pubepoch, layersPerEpoch interface{}) *nipostValidatorPositioningAtxCall {
+func (mr *MocknipostValidatorMockRecorder) PositioningAtx(id, atxs, goldenATXID, pubepoch interface{}) *nipostValidatorPositioningAtxCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PositioningAtx", reflect.TypeOf((*MocknipostValidator)(nil).PositioningAtx), id, atxs, goldenATXID, pubepoch, layersPerEpoch)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PositioningAtx", reflect.TypeOf((*MocknipostValidator)(nil).PositioningAtx), id, atxs, goldenATXID, pubepoch)
 	return &nipostValidatorPositioningAtxCall{Call: call}
 }
 
@@ -387,21 +387,21 @@ func (c *nipostValidatorPositioningAtxCall) Return(arg0 error) *nipostValidatorP
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *nipostValidatorPositioningAtxCall) Do(f func(*types.ATXID, atxProvider, types.ATXID, types.EpochID, uint32) error) *nipostValidatorPositioningAtxCall {
+func (c *nipostValidatorPositioningAtxCall) Do(f func(*types.ATXID, atxProvider, types.ATXID, types.EpochID) error) *nipostValidatorPositioningAtxCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *nipostValidatorPositioningAtxCall) DoAndReturn(f func(*types.ATXID, atxProvider, types.ATXID, types.EpochID, uint32) error) *nipostValidatorPositioningAtxCall {
+func (c *nipostValidatorPositioningAtxCall) DoAndReturn(f func(*types.ATXID, atxProvider, types.ATXID, types.EpochID) error) *nipostValidatorPositioningAtxCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // Post mocks base method.
-func (m *MocknipostValidator) Post(ctx context.Context, publishEpoch types.EpochID, nodeId types.NodeID, atxId types.ATXID, Post *types.Post, PostMetadata *types.PostMetadata, numUnits uint32, opts ...verifying.OptionFunc) error {
+func (m *MocknipostValidator) Post(ctx context.Context, nodeId types.NodeID, atxId types.ATXID, Post *types.Post, PostMetadata *types.PostMetadata, numUnits uint32, opts ...verifying.OptionFunc) error {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{ctx, publishEpoch, nodeId, atxId, Post, PostMetadata, numUnits}
+	varargs := []interface{}{ctx, nodeId, atxId, Post, PostMetadata, numUnits}
 	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
@@ -411,9 +411,9 @@ func (m *MocknipostValidator) Post(ctx context.Context, publishEpoch types.Epoch
 }
 
 // Post indicates an expected call of Post.
-func (mr *MocknipostValidatorMockRecorder) Post(ctx, publishEpoch, nodeId, atxId, Post, PostMetadata, numUnits interface{}, opts ...interface{}) *nipostValidatorPostCall {
+func (mr *MocknipostValidatorMockRecorder) Post(ctx, nodeId, atxId, Post, PostMetadata, numUnits interface{}, opts ...interface{}) *nipostValidatorPostCall {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{ctx, publishEpoch, nodeId, atxId, Post, PostMetadata, numUnits}, opts...)
+	varargs := append([]interface{}{ctx, nodeId, atxId, Post, PostMetadata, numUnits}, opts...)
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Post", reflect.TypeOf((*MocknipostValidator)(nil).Post), varargs...)
 	return &nipostValidatorPostCall{Call: call}
 }
@@ -430,13 +430,13 @@ func (c *nipostValidatorPostCall) Return(arg0 error) *nipostValidatorPostCall {
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *nipostValidatorPostCall) Do(f func(context.Context, types.EpochID, types.NodeID, types.ATXID, *types.Post, *types.PostMetadata, uint32, ...verifying.OptionFunc) error) *nipostValidatorPostCall {
+func (c *nipostValidatorPostCall) Do(f func(context.Context, types.NodeID, types.ATXID, *types.Post, *types.PostMetadata, uint32, ...verifying.OptionFunc) error) *nipostValidatorPostCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *nipostValidatorPostCall) DoAndReturn(f func(context.Context, types.EpochID, types.NodeID, types.ATXID, *types.Post, *types.PostMetadata, uint32, ...verifying.OptionFunc) error) *nipostValidatorPostCall {
+func (c *nipostValidatorPostCall) DoAndReturn(f func(context.Context, types.NodeID, types.ATXID, *types.Post, *types.PostMetadata, uint32, ...verifying.OptionFunc) error) *nipostValidatorPostCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/activation/nipost.go
+++ b/activation/nipost.go
@@ -296,7 +296,6 @@ func (nb *NIPostBuilder) BuildNIPost(ctx context.Context, challenge *types.NIPos
 		}
 		if err := nb.validator.Post(
 			postCtx,
-			challenge.PublishEpoch,
 			nb.nodeID,
 			commitmentAtxId,
 			proof,

--- a/activation/nipost_test.go
+++ b/activation/nipost_test.go
@@ -1056,7 +1056,7 @@ func TestNIPostBuilder_Mainnet_PoetRound3_Workaround(t *testing.T) {
 	postProvider.EXPECT().GenerateProof(gomock.Any(), gomock.Any(), gomock.Any())
 
 	nipostValidator := NewMocknipostValidator(ctrl)
-	nipostValidator.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(nil)
+	nipostValidator.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(nil)
 
 	poets := make([]PoetProvingServiceClient, 0, 2)
 	{

--- a/activation/nipost_test.go
+++ b/activation/nipost_test.go
@@ -61,7 +61,7 @@ func TestNIPostBuilderWithMocks(t *testing.T) {
 	postProvider.EXPECT().GenerateProof(gomock.Any(), gomock.Any(), gomock.Any())
 
 	nipostValidator := NewMocknipostValidator(ctrl)
-	nipostValidator.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(nil)
+	nipostValidator.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(nil)
 
 	poetProvider := defaultPoetServiceMock(t, []byte("poet"), "http://localhost:9999")
 	poetProvider.EXPECT().Proof(gomock.Any(), "").Return(&types.PoetProofMessage{
@@ -113,7 +113,7 @@ func TestPostSetup(t *testing.T) {
 	mclock := defaultLayerClockMock(t)
 
 	nipostValidator := NewMocknipostValidator(gomock.NewController(t))
-	nipostValidator.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(nil)
+	nipostValidator.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(nil)
 
 	nb, err := NewNIPostBuilder(
 		postProvider.id,
@@ -158,7 +158,6 @@ func TestNIPostBuilderWithClients(t *testing.T) {
 	nipost := buildNIPost(t, postProvider, challenge, poetDb, v)
 	_, err = v.NIPost(
 		context.Background(),
-		challenge.PublishEpoch,
 		postProvider.id,
 		postProvider.commitmentAtxId,
 		nipost,
@@ -261,7 +260,7 @@ func TestNewNIPostBuilderNotInitialized(t *testing.T) {
 	mclock := defaultLayerClockMock(t)
 
 	nipostValidator := NewMocknipostValidator(ctrl)
-	nipostValidator.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(nil)
+	nipostValidator.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(nil)
 
 	nb, err := NewNIPostBuilder(
 		postProvider.id,
@@ -295,7 +294,6 @@ func TestNewNIPostBuilderNotInitialized(t *testing.T) {
 	v := NewValidator(poetDb, postProvider.cfg, logger, verifier)
 	_, err = v.NIPost(
 		context.Background(),
-		challenge.PublishEpoch,
 		postProvider.id,
 		postProvider.goldenATXID,
 		nipost,
@@ -363,8 +361,8 @@ func TestNIPostBuilder_BuildNIPost(t *testing.T) {
 	)
 	req.NoError(err)
 
-	postProvider.EXPECT().GenerateProof(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
-	nipostValidator.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(nil)
+	postProvider.EXPECT().GenerateProof(gomock.Any(), gomock.Any(), gomock.Any())
+	nipostValidator.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 	nipost, err := nb.BuildNIPost(context.Background(), &challenge)
 	req.NoError(err)
 	req.NotNil(nipost)
@@ -414,7 +412,7 @@ func TestNIPostBuilder_BuildNIPost(t *testing.T) {
 	)
 	req.NoError(err)
 	postProvider.EXPECT().GenerateProof(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
-	nipostValidator.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(nil)
+	nipostValidator.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(nil)
 	// check that proof ref is not called again
 	nipost, err = nb.BuildNIPost(context.Background(), &challenge2)
 	req.NoError(err)
@@ -422,8 +420,8 @@ func TestNIPostBuilder_BuildNIPost(t *testing.T) {
 
 	// test state not loading if other challenge provided
 	poetDb.EXPECT().ValidateAndStore(gomock.Any(), gomock.Any()).Return(nil)
-	postProvider.EXPECT().GenerateProof(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
-	nipostValidator.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(nil)
+	postProvider.EXPECT().GenerateProof(gomock.Any(), gomock.Any(), gomock.Any())
+	nipostValidator.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 	nipost, err = nb.BuildNIPost(context.Background(), &challenge3)
 	req.NoError(err)
 	req.NotNil(nipost)
@@ -485,7 +483,7 @@ func TestNIPostBuilder_ManyPoETs_SubmittingChallenge_DeadlineReached(t *testing.
 			}, nil
 		},
 	)
-	nipostValidator.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(nil)
+	nipostValidator.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(nil)
 	nb, err := NewNIPostBuilder(
 		types.NodeID{1},
 		postProvider,
@@ -561,7 +559,7 @@ func TestNIPostBuilder_ManyPoETs_AllFinished(t *testing.T) {
 			}, nil
 		},
 	)
-	nipostValidator.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(nil)
+	nipostValidator.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(nil)
 	nb, err := NewNIPostBuilder(
 		types.NodeID{1},
 		postProvider,
@@ -965,7 +963,7 @@ func TestNIPoSTBuilder_Continues_After_Interrupted(t *testing.T) {
 		},
 	)
 	nipostValidator := NewMocknipostValidator(ctrl)
-	nipostValidator.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(nil)
+	nipostValidator.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(nil)
 	nb, err := NewNIPostBuilder(
 		types.NodeID{1},
 		postProvider,

--- a/activation/validation.go
+++ b/activation/validation.go
@@ -64,7 +64,7 @@ func (v *Validator) NIPost(ctx context.Context, nodeId types.NodeID, commitmentA
 	}
 
 	if err := v.Post(ctx, nodeId, commitmentAtxId, nipost.Post, nipost.PostMetadata, numUnits, opts...); err != nil {
-		return 0, fmt.Errorf("invalid Post: %v", err)
+		return 0, fmt.Errorf("invalid Post: %w", err)
 	}
 
 	var ref types.PoetProofRef
@@ -172,7 +172,7 @@ func (*Validator) VRFNonce(nodeId types.NodeID, commitmentAtxId types.ATXID, vrf
 
 func (v *Validator) InitialNIPostChallenge(challenge *types.NIPostChallenge, atxs atxProvider, goldenATXID types.ATXID) error {
 	if challenge.CommitmentATX == nil {
-		v.log.Panic("commitment atx is nil")
+		return errors.New("nil commitment atx in initial post challenge")
 	}
 
 	if *challenge.CommitmentATX != goldenATXID {
@@ -213,16 +213,16 @@ func (*Validator) NIPostChallenge(challenge *types.NIPostChallenge, atxs atxProv
 	return nil
 }
 
-func (v *Validator) PositioningAtx(id *types.ATXID, atxs atxProvider, goldenATXID types.ATXID, pubepoch types.EpochID) error {
-	if *id == types.EmptyATXID {
-		v.log.Panic("empty positioning atx")
+func (v *Validator) PositioningAtx(id types.ATXID, atxs atxProvider, goldenATXID types.ATXID, pubepoch types.EpochID) error {
+	if id == types.EmptyATXID {
+		return errors.New("positioning atx id is empty")
 	}
-	if *id == goldenATXID {
+	if id == goldenATXID {
 		return nil
 	}
-	posAtx, err := atxs.GetAtxHeader(*id)
+	posAtx, err := atxs.GetAtxHeader(id)
 	if err != nil {
-		return &ErrAtxNotFound{Id: *id, source: err}
+		return &ErrAtxNotFound{Id: id, source: err}
 	}
 	if posAtx.PublishEpoch >= pubepoch {
 		return fmt.Errorf("positioning atx epoch (%v) must be before %v", posAtx.PublishEpoch, pubepoch)

--- a/activation/validation_test.go
+++ b/activation/validation_test.go
@@ -322,7 +322,7 @@ func Test_Validation_PositioningAtx(t *testing.T) {
 			},
 		}, nil)
 
-		err := v.PositioningAtx(&posAtxId, atxProvider, goldenAtxId, 2)
+		err := v.PositioningAtx(posAtxId, atxProvider, goldenAtxId, 2)
 		require.NoError(t, err)
 	})
 
@@ -333,7 +333,7 @@ func Test_Validation_PositioningAtx(t *testing.T) {
 
 		atxProvider := NewMockatxProvider(ctrl)
 
-		err := v.PositioningAtx(&goldenAtxId, atxProvider, goldenAtxId, types.LayerID(1012).GetEpoch())
+		err := v.PositioningAtx(goldenAtxId, atxProvider, goldenAtxId, types.LayerID(1012).GetEpoch())
 		require.NoError(t, err)
 	})
 
@@ -344,7 +344,7 @@ func Test_Validation_PositioningAtx(t *testing.T) {
 
 		atxProvider := NewMockatxProvider(ctrl)
 
-		err := v.PositioningAtx(&goldenAtxId, atxProvider, goldenAtxId, 5)
+		err := v.PositioningAtx(goldenAtxId, atxProvider, goldenAtxId, 5)
 		require.NoError(t, err)
 	})
 
@@ -357,7 +357,7 @@ func Test_Validation_PositioningAtx(t *testing.T) {
 		atxProvider := NewMockatxProvider(ctrl)
 		atxProvider.EXPECT().GetAtxHeader(posAtxId).Return(nil, errors.New("db error"))
 
-		err := v.PositioningAtx(&posAtxId, atxProvider, goldenAtxId, types.LayerID(1012).GetEpoch())
+		err := v.PositioningAtx(posAtxId, atxProvider, goldenAtxId, types.LayerID(1012).GetEpoch())
 		require.ErrorIs(t, err, &ErrAtxNotFound{Id: posAtxId})
 		require.ErrorContains(t, err, "db error")
 	})
@@ -376,7 +376,7 @@ func Test_Validation_PositioningAtx(t *testing.T) {
 			},
 		}, nil)
 
-		err := v.PositioningAtx(&posAtxId, atxProvider, goldenAtxId, 3)
+		err := v.PositioningAtx(posAtxId, atxProvider, goldenAtxId, 3)
 		require.EqualError(t, err, "positioning atx epoch (5) must be before 3")
 	})
 
@@ -394,7 +394,7 @@ func Test_Validation_PositioningAtx(t *testing.T) {
 			},
 		}, nil)
 
-		err := v.PositioningAtx(&posAtxId, atxProvider, goldenAtxId, 10)
+		err := v.PositioningAtx(posAtxId, atxProvider, goldenAtxId, 10)
 		require.NoError(t, err)
 	})
 }

--- a/activation/validation_test.go
+++ b/activation/validation_test.go
@@ -126,38 +126,6 @@ func Test_Validation_InitialNIPostChallenge(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("sequence number is not zero", func(t *testing.T) {
-		t.Parallel()
-
-		challenge := &types.NIPostChallenge{
-			Sequence: 1,
-		}
-		err := v.InitialNIPostChallenge(challenge, nil, goldenATXID)
-		require.EqualError(t, err, "no prevATX declared, but sequence number not zero")
-	})
-
-	t.Run("missing initial post", func(t *testing.T) {
-		t.Parallel()
-		posAtxId := types.ATXID{1, 2, 3}
-
-		challenge := newChallenge(0, types.EmptyATXID, posAtxId, types.LayerID(2).GetEpoch(), &goldenATXID)
-
-		err := v.InitialNIPostChallenge(&challenge, nil, goldenATXID)
-		require.EqualError(t, err, "no prevATX declared, but initial Post is not included in challenge")
-	})
-
-	t.Run("missing commitment atx", func(t *testing.T) {
-		t.Parallel()
-
-		posAtxId := types.ATXID{1, 2, 3}
-
-		challenge := newChallenge(0, types.EmptyATXID, posAtxId, types.LayerID(2).GetEpoch(), nil)
-		challenge.InitialPost = &types.Post{}
-
-		err := v.InitialNIPostChallenge(&challenge, nil, goldenATXID)
-		require.EqualError(t, err, "no prevATX declared, but commitmentATX is missing")
-	})
-
 	t.Run("commitment atx from wrong pub layer", func(t *testing.T) {
 		t.Parallel()
 
@@ -302,54 +270,6 @@ func Test_Validation_NIPostChallenge(t *testing.T) {
 		err := v.NIPostChallenge(&challenge, atxProvider, nodeId)
 		require.EqualError(t, err, "sequence number is not one more than prev sequence number")
 	})
-
-	t.Run("challenge contains initial post", func(t *testing.T) {
-		t.Parallel()
-
-		nodeId := types.RandomNodeID()
-
-		prevAtxId := types.ATXID{3, 2, 1}
-		posAtxId := types.ATXID{1, 2, 3}
-
-		challenge := newChallenge(10, prevAtxId, posAtxId, 2, nil)
-		challenge.InitialPost = &types.Post{}
-
-		atxProvider := NewMockatxProvider(ctrl)
-		atxProvider.EXPECT().GetAtxHeader(prevAtxId).Return(&types.ActivationTxHeader{
-			NIPostChallenge: types.NIPostChallenge{
-				PublishEpoch: 1,
-				Sequence:     9,
-			},
-			NodeID: nodeId,
-		}, nil)
-
-		err := v.NIPostChallenge(&challenge, atxProvider, nodeId)
-		require.EqualError(t, err, "prevATX declared, but initial Post is included in challenge")
-	})
-
-	t.Run("challenge contains commitment atx", func(t *testing.T) {
-		t.Parallel()
-
-		nodeId := types.RandomNodeID()
-
-		prevAtxId := types.ATXID{3, 2, 1}
-		posAtxId := types.ATXID{1, 2, 3}
-
-		challenge := newChallenge(10, prevAtxId, posAtxId, 2, nil)
-		challenge.CommitmentATX = &types.ATXID{9, 9, 9}
-
-		atxProvider := NewMockatxProvider(ctrl)
-		atxProvider.EXPECT().GetAtxHeader(prevAtxId).Return(&types.ActivationTxHeader{
-			NIPostChallenge: types.NIPostChallenge{
-				PublishEpoch: 1,
-				Sequence:     9,
-			},
-			NodeID: nodeId,
-		}, nil)
-
-		err := v.NIPostChallenge(&challenge, atxProvider, nodeId)
-		require.EqualError(t, err, "prevATX declared, but commitmentATX is included")
-	})
 }
 
 func Test_Validation_Post(t *testing.T) {
@@ -369,10 +289,10 @@ func Test_Validation_Post(t *testing.T) {
 	meta := types.PostMetadata{}
 
 	postVerifier.EXPECT().Verify(gomock.Any(), (*shared.Proof)(&post), gomock.Any(), gomock.Any()).Return(nil)
-	require.NoError(t, v.Post(context.Background(), types.EpochID(0), types.EmptyNodeID, types.RandomATXID(), &post, &meta, 1))
+	require.NoError(t, v.Post(context.Background(), types.EmptyNodeID, types.RandomATXID(), &post, &meta, 1))
 
 	postVerifier.EXPECT().Verify(gomock.Any(), (*shared.Proof)(&post), gomock.Any(), gomock.Any()).Return(errors.New("invalid"))
-	require.Error(t, v.Post(context.Background(), types.EpochID(0), types.EmptyNodeID, types.RandomATXID(), &post, &meta, 1))
+	require.Error(t, v.Post(context.Background(), types.EmptyNodeID, types.RandomATXID(), &post, &meta, 1))
 }
 
 func Test_Validation_PositioningAtx(t *testing.T) {
@@ -402,7 +322,7 @@ func Test_Validation_PositioningAtx(t *testing.T) {
 			},
 		}, nil)
 
-		err := v.PositioningAtx(&posAtxId, atxProvider, goldenAtxId, 2, layersPerEpochBig)
+		err := v.PositioningAtx(&posAtxId, atxProvider, goldenAtxId, 2)
 		require.NoError(t, err)
 	})
 
@@ -413,7 +333,7 @@ func Test_Validation_PositioningAtx(t *testing.T) {
 
 		atxProvider := NewMockatxProvider(ctrl)
 
-		err := v.PositioningAtx(&goldenAtxId, atxProvider, goldenAtxId, types.LayerID(1012).GetEpoch(), layersPerEpochBig)
+		err := v.PositioningAtx(&goldenAtxId, atxProvider, goldenAtxId, types.LayerID(1012).GetEpoch())
 		require.NoError(t, err)
 	})
 
@@ -424,19 +344,8 @@ func Test_Validation_PositioningAtx(t *testing.T) {
 
 		atxProvider := NewMockatxProvider(ctrl)
 
-		err := v.PositioningAtx(&goldenAtxId, atxProvider, goldenAtxId, 5, layersPerEpochBig)
+		err := v.PositioningAtx(&goldenAtxId, atxProvider, goldenAtxId, 5)
 		require.NoError(t, err)
-	})
-
-	t.Run("fail at empty positioning atx", func(t *testing.T) {
-		t.Parallel()
-
-		goldenAtxId := types.ATXID{9, 9, 9}
-
-		atxProvider := NewMockatxProvider(ctrl)
-
-		err := v.PositioningAtx(&types.EmptyATXID, atxProvider, goldenAtxId, types.LayerID(1012).GetEpoch(), layersPerEpochBig)
-		require.EqualError(t, err, "empty positioning atx")
 	})
 
 	t.Run("fail when posAtx is not found", func(t *testing.T) {
@@ -448,7 +357,7 @@ func Test_Validation_PositioningAtx(t *testing.T) {
 		atxProvider := NewMockatxProvider(ctrl)
 		atxProvider.EXPECT().GetAtxHeader(posAtxId).Return(nil, errors.New("db error"))
 
-		err := v.PositioningAtx(&posAtxId, atxProvider, goldenAtxId, types.LayerID(1012).GetEpoch(), layersPerEpochBig)
+		err := v.PositioningAtx(&posAtxId, atxProvider, goldenAtxId, types.LayerID(1012).GetEpoch())
 		require.ErrorIs(t, err, &ErrAtxNotFound{Id: posAtxId})
 		require.ErrorContains(t, err, "db error")
 	})
@@ -467,7 +376,7 @@ func Test_Validation_PositioningAtx(t *testing.T) {
 			},
 		}, nil)
 
-		err := v.PositioningAtx(&posAtxId, atxProvider, goldenAtxId, 3, layersPerEpochBig)
+		err := v.PositioningAtx(&posAtxId, atxProvider, goldenAtxId, 3)
 		require.EqualError(t, err, "positioning atx epoch (5) must be before 3")
 	})
 
@@ -485,7 +394,7 @@ func Test_Validation_PositioningAtx(t *testing.T) {
 			},
 		}, nil)
 
-		err := v.PositioningAtx(&posAtxId, atxProvider, goldenAtxId, 10, layersPerEpochBig)
+		err := v.PositioningAtx(&posAtxId, atxProvider, goldenAtxId, 10)
 		require.NoError(t, err)
 	})
 }
@@ -582,33 +491,33 @@ func TestValidator_Validate(t *testing.T) {
 
 	opts := []verifying.OptionFunc{verifying.WithLabelScryptParams(postProvider.opts.Scrypt)}
 
-	_, err = v.NIPost(context.Background(), challenge.PublishEpoch, postProvider.id, postProvider.commitmentAtxId, nipost, challengeHash, postProvider.opts.NumUnits, opts...)
+	_, err = v.NIPost(context.Background(), postProvider.id, postProvider.commitmentAtxId, nipost, challengeHash, postProvider.opts.NumUnits, opts...)
 	r.NoError(err)
 
-	_, err = v.NIPost(context.Background(), challenge.PublishEpoch, postProvider.id, postProvider.commitmentAtxId, nipost, types.BytesToHash([]byte("lerner")), postProvider.opts.NumUnits, opts...)
+	_, err = v.NIPost(context.Background(), postProvider.id, postProvider.commitmentAtxId, nipost, types.BytesToHash([]byte("lerner")), postProvider.opts.NumUnits, opts...)
 	r.Contains(err.Error(), "invalid membership proof")
 
 	newNIPost := *nipost
 	newNIPost.Post = &types.Post{}
-	_, err = v.NIPost(context.Background(), challenge.PublishEpoch, postProvider.id, postProvider.commitmentAtxId, &newNIPost, challengeHash, postProvider.opts.NumUnits, opts...)
+	_, err = v.NIPost(context.Background(), postProvider.id, postProvider.commitmentAtxId, &newNIPost, challengeHash, postProvider.opts.NumUnits, opts...)
 	r.Contains(err.Error(), "invalid Post")
 
 	newPostCfg := postProvider.cfg
 	newPostCfg.MinNumUnits = postProvider.opts.NumUnits + 1
 	v = NewValidator(poetDb, newPostCfg, logtest.New(t).WithName("validator"), nil)
-	_, err = v.NIPost(context.Background(), challenge.PublishEpoch, postProvider.id, postProvider.commitmentAtxId, nipost, challengeHash, postProvider.opts.NumUnits, opts...)
+	_, err = v.NIPost(context.Background(), postProvider.id, postProvider.commitmentAtxId, nipost, challengeHash, postProvider.opts.NumUnits, opts...)
 	r.EqualError(err, fmt.Sprintf("invalid `numUnits`; expected: >=%d, given: %d", newPostCfg.MinNumUnits, postProvider.opts.NumUnits))
 
 	newPostCfg = postProvider.cfg
 	newPostCfg.MaxNumUnits = postProvider.opts.NumUnits - 1
 	v = NewValidator(poetDb, newPostCfg, logtest.New(t).WithName("validator"), nil)
-	_, err = v.NIPost(context.Background(), challenge.PublishEpoch, postProvider.id, postProvider.commitmentAtxId, nipost, challengeHash, postProvider.opts.NumUnits, opts...)
+	_, err = v.NIPost(context.Background(), postProvider.id, postProvider.commitmentAtxId, nipost, challengeHash, postProvider.opts.NumUnits, opts...)
 	r.EqualError(err, fmt.Sprintf("invalid `numUnits`; expected: <=%d, given: %d", newPostCfg.MaxNumUnits, postProvider.opts.NumUnits))
 
 	newPostCfg = postProvider.cfg
 	newPostCfg.LabelsPerUnit = nipost.PostMetadata.LabelsPerUnit + 1
 	v = NewValidator(poetDb, newPostCfg, logtest.New(t).WithName("validator"), nil)
-	_, err = v.NIPost(context.Background(), challenge.PublishEpoch, postProvider.id, postProvider.commitmentAtxId, nipost, challengeHash, postProvider.opts.NumUnits, opts...)
+	_, err = v.NIPost(context.Background(), postProvider.id, postProvider.commitmentAtxId, nipost, challengeHash, postProvider.opts.NumUnits, opts...)
 	r.EqualError(err, fmt.Sprintf("invalid `LabelsPerUnit`; expected: >=%d, given: %d", newPostCfg.LabelsPerUnit, nipost.PostMetadata.LabelsPerUnit))
 }
 

--- a/checkpoint/recovery_test.go
+++ b/checkpoint/recovery_test.go
@@ -256,7 +256,7 @@ func validateAndPreserveData(tb testing.TB, db *sql.Database, deps []*types.Veri
 		} else {
 			mvalidator.EXPECT().NIPostChallenge(&vatx.ActivationTx.NIPostChallenge, cdb, vatx.SmesherID)
 		}
-		mvalidator.EXPECT().PositioningAtx(&vatx.PositioningATX, cdb, goldenAtx, vatx.PublishEpoch)
+		mvalidator.EXPECT().PositioningAtx(vatx.PositioningATX, cdb, goldenAtx, vatx.PublishEpoch)
 		mvalidator.EXPECT().NIPost(gomock.Any(), vatx.SmesherID, gomock.Any(), vatx.NIPost, gomock.Any(), vatx.NumUnits).Return(uint64(1111111), nil)
 		mreceiver.EXPECT().OnAtx(gomock.Any())
 		mtrtl.EXPECT().OnAtx(gomock.Any())

--- a/checkpoint/recovery_test.go
+++ b/checkpoint/recovery_test.go
@@ -217,7 +217,6 @@ func TestRecover_SameRecoveryInfo(t *testing.T) {
 
 func validateAndPreserveData(tb testing.TB, db *sql.Database, deps []*types.VerifiedActivationTx, proofs []*types.PoetProofMessage) {
 	lg := logtest.New(tb)
-	layersPerEpoch := uint32(3)
 	edVerifier, err := signing.NewEdVerifier()
 	require.NoError(tb, err)
 	poetDb := activation.NewPoetDb(db, lg)
@@ -234,7 +233,6 @@ func validateAndPreserveData(tb testing.TB, db *sql.Database, deps []*types.Veri
 		mclock,
 		nil,
 		mfetch,
-		layersPerEpoch,
 		10,
 		goldenAtx,
 		mvalidator,
@@ -253,13 +251,13 @@ func validateAndPreserveData(tb testing.TB, db *sql.Database, deps []*types.Veri
 		mfetch.EXPECT().GetPoetProof(gomock.Any(), vatx.GetPoetProofRef())
 		if vatx.InitialPost != nil {
 			mvalidator.EXPECT().InitialNIPostChallenge(&vatx.ActivationTx.NIPostChallenge, gomock.Any(), goldenAtx).AnyTimes()
-			mvalidator.EXPECT().Post(gomock.Any(), vatx.PublishEpoch, vatx.SmesherID, *vatx.CommitmentATX, vatx.InitialPost, gomock.Any(), vatx.NumUnits)
+			mvalidator.EXPECT().Post(gomock.Any(), vatx.SmesherID, *vatx.CommitmentATX, vatx.InitialPost, gomock.Any(), vatx.NumUnits)
 			mvalidator.EXPECT().VRFNonce(vatx.SmesherID, *vatx.CommitmentATX, vatx.VRFNonce, gomock.Any(), vatx.NumUnits)
 		} else {
 			mvalidator.EXPECT().NIPostChallenge(&vatx.ActivationTx.NIPostChallenge, cdb, vatx.SmesherID)
 		}
-		mvalidator.EXPECT().PositioningAtx(&vatx.PositioningATX, cdb, goldenAtx, vatx.PublishEpoch, layersPerEpoch)
-		mvalidator.EXPECT().NIPost(gomock.Any(), vatx.PublishEpoch, vatx.SmesherID, gomock.Any(), vatx.NIPost, gomock.Any(), vatx.NumUnits).Return(uint64(1111111), nil)
+		mvalidator.EXPECT().PositioningAtx(&vatx.PositioningATX, cdb, goldenAtx, vatx.PublishEpoch)
+		mvalidator.EXPECT().NIPost(gomock.Any(), vatx.SmesherID, gomock.Any(), vatx.NIPost, gomock.Any(), vatx.NumUnits).Return(uint64(1111111), nil)
 		mreceiver.EXPECT().OnAtx(gomock.Any())
 		mtrtl.EXPECT().OnAtx(gomock.Any())
 		require.NoError(tb, atxHandler.HandleSyncedAtx(context.Background(), vatx.ID().Hash32(), "self", encoded))

--- a/node/node.go
+++ b/node/node.go
@@ -652,7 +652,6 @@ func (app *App) initServices(ctx context.Context) error {
 		app.clock,
 		app.host,
 		fetcherWrapped,
-		layersPerEpoch,
 		app.Config.TickSize,
 		goldenATXID,
 		validator,


### PR DESCRIPTION
## Motivation
part of #4632

## Changes
break syntactic checks into 3 steps:
- do all the syntactically correctness checks on the current atx without its dependencies
- fetching atx dependencies, including poet proof, prev/positioning/commitment atxs
- do the syntactic checks based on the referenced atxs.