### PR TITLE
generator, blocks: request blocks when tortoise crossed local threshold

### DIFF
--- a/blocks/generator_test.go
+++ b/blocks/generator_test.go
@@ -56,7 +56,7 @@ type testGenerator struct {
 	*Generator
 	mockMesh   *mocks.MockmeshProvider
 	mockExec   *mocks.Mockexecutor
-	mockFetch  *smocks.MockProposalFetcher
+	mockFetch  *smocks.MockProposalBlockFetcher
 	mockCert   *mocks.Mockcertifier
 	mockPatrol *mocks.MocklayerPatrol
 }
@@ -67,7 +67,7 @@ func createTestGenerator(t *testing.T) *testGenerator {
 	tg := &testGenerator{
 		mockMesh:   mocks.NewMockmeshProvider(ctrl),
 		mockExec:   mocks.NewMockexecutor(ctrl),
-		mockFetch:  smocks.NewMockProposalFetcher(ctrl),
+		mockFetch:  smocks.NewMockProposalBlockFetcher(ctrl),
 		mockCert:   mocks.NewMockcertifier(ctrl),
 		mockPatrol: mocks.NewMocklayerPatrol(ctrl),
 	}

--- a/proposals/handler.go
+++ b/proposals/handler.go
@@ -190,6 +190,9 @@ func collectHashes(a any) []types.Hash32 {
 		if b.RefBallot != types.EmptyBallotID {
 			hashes = append(hashes, b.RefBallot.AsHash32())
 		}
+		for _, header := range b.Votes.Support {
+			hashes = append(hashes, header.ID.AsHash32())
+		}
 		return hashes
 	}
 	log.Fatal("unexpected type")

--- a/proposals/handler_test.go
+++ b/proposals/handler_test.go
@@ -1282,6 +1282,9 @@ func TestCollectHashes(t *testing.T) {
 	b := p.Ballot
 	expected := []types.Hash32{b.RefBallot.AsHash32()}
 	expected = append(expected, b.Votes.Base.AsHash32())
+	for _, header := range b.Votes.Support {
+		expected = append(expected, header.ID.AsHash32())
+	}
 	require.ElementsMatch(t, expected, collectHashes(b))
 
 	expected = append(expected, types.TransactionIDsToHashes(p.TxIDs)...)

--- a/system/fetcher.go
+++ b/system/fetcher.go
@@ -15,7 +15,7 @@ type Fetcher interface {
 	BlockFetcher
 	PoetProofFetcher
 	BallotFetcher
-	ProposalFetcher
+	ProposalBlockFetcher
 	TxFetcher
 	PeerTracker
 }
@@ -46,9 +46,10 @@ type BallotFetcher interface {
 	GetBallots(context.Context, []types.BallotID) error
 }
 
-// ProposalFetcher defines an interface for fetching Proposal from remote peers.
-type ProposalFetcher interface {
+// ProposalBlockFetcher defines an interface for fetching Proposal from remote peers.
+type ProposalBlockFetcher interface {
 	GetProposals(context.Context, []types.ProposalID) error
+	GetBlocks(context.Context, []types.BlockID) error
 }
 
 // PeerTracker defines an interface to track peer hashes.

--- a/system/mocks/fetcher.go
+++ b/system/mocks/fetcher.go
@@ -345,31 +345,45 @@ func (mr *MockBallotFetcherMockRecorder) GetBallots(arg0, arg1 interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBallots", reflect.TypeOf((*MockBallotFetcher)(nil).GetBallots), arg0, arg1)
 }
 
-// MockProposalFetcher is a mock of ProposalFetcher interface.
-type MockProposalFetcher struct {
+// MockProposalBlockFetcher is a mock of ProposalBlockFetcher interface.
+type MockProposalBlockFetcher struct {
 	ctrl     *gomock.Controller
-	recorder *MockProposalFetcherMockRecorder
+	recorder *MockProposalBlockFetcherMockRecorder
 }
 
-// MockProposalFetcherMockRecorder is the mock recorder for MockProposalFetcher.
-type MockProposalFetcherMockRecorder struct {
-	mock *MockProposalFetcher
+// MockProposalBlockFetcherMockRecorder is the mock recorder for MockProposalBlockFetcher.
+type MockProposalBlockFetcherMockRecorder struct {
+	mock *MockProposalBlockFetcher
 }
 
-// NewMockProposalFetcher creates a new mock instance.
-func NewMockProposalFetcher(ctrl *gomock.Controller) *MockProposalFetcher {
-	mock := &MockProposalFetcher{ctrl: ctrl}
-	mock.recorder = &MockProposalFetcherMockRecorder{mock}
+// NewMockProposalBlockFetcher creates a new mock instance.
+func NewMockProposalBlockFetcher(ctrl *gomock.Controller) *MockProposalBlockFetcher {
+	mock := &MockProposalBlockFetcher{ctrl: ctrl}
+	mock.recorder = &MockProposalBlockFetcherMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockProposalFetcher) EXPECT() *MockProposalFetcherMockRecorder {
+func (m *MockProposalBlockFetcher) EXPECT() *MockProposalBlockFetcherMockRecorder {
 	return m.recorder
 }
 
+// GetBlocks mocks base method.
+func (m *MockProposalBlockFetcher) GetBlocks(arg0 context.Context, arg1 []types.BlockID) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBlocks", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// GetBlocks indicates an expected call of GetBlocks.
+func (mr *MockProposalBlockFetcherMockRecorder) GetBlocks(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlocks", reflect.TypeOf((*MockProposalBlockFetcher)(nil).GetBlocks), arg0, arg1)
+}
+
 // GetProposals mocks base method.
-func (m *MockProposalFetcher) GetProposals(arg0 context.Context, arg1 []types.ProposalID) error {
+func (m *MockProposalBlockFetcher) GetProposals(arg0 context.Context, arg1 []types.ProposalID) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetProposals", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -377,9 +391,9 @@ func (m *MockProposalFetcher) GetProposals(arg0 context.Context, arg1 []types.Pr
 }
 
 // GetProposals indicates an expected call of GetProposals.
-func (mr *MockProposalFetcherMockRecorder) GetProposals(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockProposalBlockFetcherMockRecorder) GetProposals(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProposals", reflect.TypeOf((*MockProposalFetcher)(nil).GetProposals), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProposals", reflect.TypeOf((*MockProposalBlockFetcher)(nil).GetProposals), arg0, arg1)
 }
 
 // MockPeerTracker is a mock of PeerTracker interface.


### PR DESCRIPTION
closes: https://github.com/spacemeshos/go-spacemesh/issues/4824

- first improvement is to register peers that supported blocks, otherwise we will be guessing from whom to request the block
- and when mesh is called by sync or block builder it may send request to fetch blocks from registered peers. previously it would do so only in sync code path, which is less robust and might be delayed by fork finder
