### PR TITLE
log: change consensus results log level to debug

### DIFF
--- a/mesh/mesh.go
+++ b/mesh/mesh.go
@@ -305,7 +305,7 @@ func (msh *Mesh) ProcessLayer(ctx context.Context, lid types.LayerID) error {
 	}
 	// TODO(dshulyak) https://github.com/spacemeshos/go-spacemesh/issues/4425
 	if len(results) > 0 {
-		msh.logger.With().Info("consensus results",
+		msh.logger.With().Debug("consensus results",
 			log.Context(ctx),
 			log.Uint32("layer_id", lid.Uint32()),
 			log.Array("results", log.ArrayMarshalerFunc(func(encoder log.ArrayEncoder) error {


### PR DESCRIPTION
## Motivation
Disable consensus results logging on `Info` level. The `go-spacemesh` creates about 3GB log file in 12 hours now. 

## Changes
Consensus results log level from `Info` to `Debug`

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->

## TODO
<!-- This section should be removed when all items are complete -->
- [ ] Explain motivation or link existing issue(s)
- [ ] Test changes and document test plan
- [ ] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
