### PR TITLE
[Merged by Bors] - fetch: check hash for received data

### DIFF
--- a/activation/handler.go
+++ b/activation/handler.go
@@ -457,9 +457,15 @@ func (h *Handler) GetEpochAtxs(epochID types.EpochID) (ids []types.ATXID, err er
 	return
 }
 
-// HandleAtxData handles atxs received by sync.
-func (h *Handler) HandleAtxData(ctx context.Context, peer p2p.Peer, data []byte) error {
-	err := h.HandleGossipAtx(ctx, peer, data)
+// HandleSyncedAtx handles atxs received by sync.
+func (h *Handler) HandleSyncedAtx(ctx context.Context, expHash types.Hash32, peer p2p.Peer, data []byte) error {
+	err := h.handleAtx(ctx, expHash, peer, data)
+	if err != nil && !errors.Is(err, errMalformedData) && !errors.Is(err, errKnownAtx) {
+		h.log.WithContext(ctx).With().Warning("failed to process synced atx",
+			log.Stringer("sender", peer),
+			log.Err(err),
+		)
+	}
 	if errors.Is(err, errKnownAtx) {
 		return nil
 	}
@@ -479,7 +485,7 @@ func (h *Handler) registerHashes(atx *types.ActivationTx, peer p2p.Peer) {
 
 // HandleGossipAtx handles the atx gossip data channel.
 func (h *Handler) HandleGossipAtx(ctx context.Context, peer p2p.Peer, msg []byte) error {
-	err := h.handleGossipAtx(ctx, peer, msg)
+	err := h.handleAtx(ctx, types.Hash32{}, peer, msg)
 	if err != nil && !errors.Is(err, errMalformedData) && !errors.Is(err, errKnownAtx) {
 		h.log.WithContext(ctx).With().Warning("failed to process atx gossip",
 			log.Stringer("sender", peer),
@@ -489,7 +495,7 @@ func (h *Handler) HandleGossipAtx(ctx context.Context, peer p2p.Peer, msg []byte
 	return err
 }
 
-func (h *Handler) handleGossipAtx(ctx context.Context, peer p2p.Peer, msg []byte) error {
+func (h *Handler) handleAtx(ctx context.Context, expHash types.Hash32, peer p2p.Peer, msg []byte) error {
 	receivedTime := time.Now()
 	var atx types.ActivationTx
 	if err := codec.Decode(msg, &atx); err != nil {
@@ -538,10 +544,14 @@ func (h *Handler) handleGossipAtx(ctx context.Context, peer p2p.Peer, msg []byte
 	if err != nil {
 		return fmt.Errorf("received syntactically invalid atx %v: %w", atx.ShortString(), err)
 	}
+
+	if expHash != (types.Hash32{}) && vAtx.ID().Hash32() != expHash {
+		return fmt.Errorf("fetched wrong atx hash. want %s, got %s", expHash.ShortString(), vAtx.ID().Hash32().ShortString())
+	}
+
 	err = h.ProcessAtx(ctx, vAtx)
 	if err != nil {
 		return fmt.Errorf("cannot process atx %v: %w", atx.ShortString(), err)
-		// TODO(anton): blacklist peer
 	}
 	events.ReportNewActivation(vAtx)
 	logger.With().Info("new atx", log.Inline(vAtx), log.Int("size", len(msg)))

--- a/activation/handler.go
+++ b/activation/handler.go
@@ -28,6 +28,7 @@ import (
 var (
 	errKnownAtx      = errors.New("known atx")
 	errMalformedData = fmt.Errorf("%w: malformed data", pubsub.ErrValidationReject)
+	errWrongHash     = fmt.Errorf("%w: incorrect hash", pubsub.ErrValidationReject)
 	errMaliciousATX  = errors.New("malicious atx")
 )
 
@@ -546,7 +547,7 @@ func (h *Handler) handleAtx(ctx context.Context, expHash types.Hash32, peer p2p.
 	}
 
 	if expHash != (types.Hash32{}) && vAtx.ID().Hash32() != expHash {
-		return fmt.Errorf("fetched wrong atx hash. want %s, got %s", expHash.ShortString(), vAtx.ID().Hash32().ShortString())
+		return fmt.Errorf("%w: atx want %s, got %s", errWrongHash, expHash.ShortString(), vAtx.ID().Hash32().ShortString())
 	}
 
 	err = h.ProcessAtx(ctx, vAtx)

--- a/activation/handler_test.go
+++ b/activation/handler_test.go
@@ -953,7 +953,7 @@ func TestHandler_HandleAtxData(t *testing.T) {
 		require.NoError(t, err)
 
 		atxHdlr.mclock.EXPECT().LayerToTime(gomock.Any()).Return(time.Now())
-		require.EqualError(t, atxHdlr.HandleAtxData(context.Background(), p2p.NoPeer, buf), fmt.Sprintf("nil nipst in gossip for atx %v", atx.ID()))
+		require.EqualError(t, atxHdlr.HandleSyncedAtx(context.Background(), atx.ID().Hash32(), p2p.NoPeer, buf), fmt.Sprintf("nil nipst in gossip for atx %v", atx.ID()))
 	})
 
 	t.Run("known atx is ignored by handleAtxData", func(t *testing.T) {
@@ -971,7 +971,7 @@ func TestHandler_HandleAtxData(t *testing.T) {
 		require.NoError(t, err)
 
 		atxHdlr.mclock.EXPECT().LayerToTime(gomock.Any()).Return(time.Now())
-		require.NoError(t, atxHdlr.HandleAtxData(context.Background(), p2p.NoPeer, buf))
+		require.NoError(t, atxHdlr.HandleSyncedAtx(context.Background(), atx.ID().Hash32(), p2p.NoPeer, buf))
 
 		atxHdlr.mclock.EXPECT().LayerToTime(gomock.Any()).Return(time.Now())
 		require.Error(t, atxHdlr.HandleGossipAtx(context.Background(), "", buf))
@@ -988,7 +988,7 @@ func TestHandler_HandleAtxData(t *testing.T) {
 		require.NoError(t, err)
 
 		atxHdlr.mclock.EXPECT().LayerToTime(gomock.Any()).Return(time.Now())
-		require.ErrorContains(t, atxHdlr.HandleAtxData(context.Background(), p2p.NoPeer, buf), "failed to verify atx signature")
+		require.ErrorContains(t, atxHdlr.HandleSyncedAtx(context.Background(), atx.ID().Hash32(), p2p.NoPeer, buf), "failed to verify atx signature")
 	})
 }
 
@@ -1191,7 +1191,7 @@ func TestHandler_AtxWeight(t *testing.T) {
 	atxHdlr.mValidator.EXPECT().PositioningAtx(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 	atxHdlr.mbeacon.EXPECT().OnAtx(gomock.Any())
 	atxHdlr.mtortoise.EXPECT().OnAtx(gomock.Any())
-	require.NoError(t, atxHdlr.HandleAtxData(context.Background(), peer, buf))
+	require.NoError(t, atxHdlr.HandleSyncedAtx(context.Background(), atx1.ID().Hash32(), peer, buf))
 
 	stored1, err := atxHdlr.cdb.GetAtxHeader(atx1.ID())
 	require.NoError(t, err)
@@ -1234,7 +1234,7 @@ func TestHandler_AtxWeight(t *testing.T) {
 	atxHdlr.mValidator.EXPECT().PositioningAtx(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 	atxHdlr.mbeacon.EXPECT().OnAtx(gomock.Any())
 	atxHdlr.mtortoise.EXPECT().OnAtx(gomock.Any())
-	require.NoError(t, atxHdlr.HandleAtxData(context.Background(), peer, buf))
+	require.NoError(t, atxHdlr.HandleSyncedAtx(context.Background(), atx2.ID().Hash32(), peer, buf))
 
 	stored2, err := atxHdlr.cdb.GetAtxHeader(atx2.ID())
 	require.NoError(t, err)

--- a/activation/poetdb.go
+++ b/activation/poetdb.go
@@ -55,11 +55,19 @@ func (db *PoetDb) ValidateAndStore(ctx context.Context, proofMessage *types.Poet
 }
 
 // ValidateAndStoreMsg validates and stores a new PoET proof.
-func (db *PoetDb) ValidateAndStoreMsg(ctx context.Context, _ p2p.Peer, data []byte) error {
+func (db *PoetDb) ValidateAndStoreMsg(ctx context.Context, expHash types.Hash32, _ p2p.Peer, data []byte) error {
 	var proofMessage types.PoetProofMessage
 	if err := codec.Decode(data, &proofMessage); err != nil {
 		return fmt.Errorf("parse message: %w", err)
 	}
+	ref, err := proofMessage.Ref()
+	if err != nil {
+		return err
+	}
+	if types.Hash32(ref) != expHash {
+		return fmt.Errorf("fetched wrong poet proof hash. want %s, got %s", expHash.ShortString(), types.Hash32(ref).ShortString())
+	}
+
 	return db.ValidateAndStore(ctx, &proofMessage)
 }
 

--- a/blocks/handler.go
+++ b/blocks/handler.go
@@ -55,7 +55,7 @@ func NewHandler(f system.Fetcher, db *sql.Database, m meshProvider, opts ...Opt)
 }
 
 // HandleSyncedBlock handles Block data from sync.
-func (h *Handler) HandleSyncedBlock(ctx context.Context, peer p2p.Peer, data []byte) error {
+func (h *Handler) HandleSyncedBlock(ctx context.Context, expHash types.Hash32, peer p2p.Peer, data []byte) error {
 	logger := h.logger.WithContext(ctx)
 
 	var b types.Block
@@ -65,6 +65,11 @@ func (h *Handler) HandleSyncedBlock(ctx context.Context, peer p2p.Peer, data []b
 	}
 	// set the block ID when received
 	b.Initialize()
+
+	if b.ID().AsHash32() != expHash {
+		return fmt.Errorf("fetched wrong block hash. want %s, got %s", expHash.ShortString(), b.ID().String())
+	}
+
 	if b.LayerIndex <= types.GetEffectiveGenesis() {
 		return fmt.Errorf("block before effective genesis: layer %v", b.LayerIndex)
 	}

--- a/blocks/handler.go
+++ b/blocks/handler.go
@@ -17,6 +17,7 @@ import (
 
 var (
 	errMalformedData  = fmt.Errorf("%w: malformed data", pubsub.ErrValidationReject)
+	errWrongHash      = fmt.Errorf("%w: incorrect hash", pubsub.ErrValidationReject)
 	errInvalidRewards = errors.New("invalid rewards")
 	errDuplicateTX    = errors.New("duplicate TxID in proposal")
 )
@@ -67,7 +68,7 @@ func (h *Handler) HandleSyncedBlock(ctx context.Context, expHash types.Hash32, p
 	b.Initialize()
 
 	if b.ID().AsHash32() != expHash {
-		return fmt.Errorf("fetched wrong block hash. want %s, got %s", expHash.ShortString(), b.ID().String())
+		return fmt.Errorf("%w: block want %s, got %s", errWrongHash, expHash.ShortString(), b.ID().String())
 	}
 
 	if b.LayerIndex <= types.GetEffectiveGenesis() {

--- a/checkpoint/recovery_test.go
+++ b/checkpoint/recovery_test.go
@@ -262,7 +262,7 @@ func validateAndPreserveData(tb testing.TB, db *sql.Database, deps []*types.Veri
 		mvalidator.EXPECT().NIPost(gomock.Any(), vatx.PublishEpoch, vatx.SmesherID, gomock.Any(), vatx.NIPost, gomock.Any(), vatx.NumUnits).Return(uint64(1111111), nil)
 		mreceiver.EXPECT().OnAtx(gomock.Any())
 		mtrtl.EXPECT().OnAtx(gomock.Any())
-		require.NoError(tb, atxHandler.HandleAtxData(context.Background(), "self", encoded))
+		require.NoError(tb, atxHandler.HandleSyncedAtx(context.Background(), vatx.ID().Hash32(), "self", encoded))
 		err = poetDb.ValidateAndStore(context.Background(), proofs[i])
 		require.ErrorContains(tb, err, "failed to validate poet proof for poetID 706f65745f round 1337")
 	}

--- a/fetch/fetch_test.go
+++ b/fetch/fetch_test.go
@@ -89,11 +89,11 @@ func createFetch(tb testing.TB) *testFetch {
 	return tf
 }
 
-func goodReceiver(context.Context, p2p.Peer, []byte) error {
+func goodReceiver(context.Context, types.Hash32, p2p.Peer, []byte) error {
 	return nil
 }
 
-func badReceiver(context.Context, p2p.Peer, []byte) error {
+func badReceiver(context.Context, types.Hash32, p2p.Peer, []byte) error {
 	return errors.New("bad receiver")
 }
 
@@ -371,7 +371,7 @@ func TestFetch_PeerDroppedWhenMessageResultsInValidationReject(t *testing.T) {
 	t.Cleanup(fetcher.Stop)
 
 	// We set a validatior just for atxs, this validator does not drop connections
-	vf := ValidatorFunc(func(ctx context.Context, id peer.ID, data []byte) error { return pubsub.ErrValidationReject })
+	vf := ValidatorFunc(func(context.Context, types.Hash32, peer.ID, []byte) error { return pubsub.ErrValidationReject })
 	fetcher.SetValidators(vf, nil, nil, nil, nil, nil, nil, nil)
 
 	// Request an atx by hash
@@ -387,7 +387,7 @@ func TestFetch_PeerDroppedWhenMessageResultsInValidationReject(t *testing.T) {
 	}
 
 	// Now wrap the atx validator with  DropPeerOnValidationReject and set it again
-	fetcher.SetValidators(ValidatorFunc(pubsub.DropPeerOnValidationReject(vf, h, lg)), nil, nil, nil, nil, nil, nil, nil)
+	fetcher.SetValidators(ValidatorFunc(pubsub.DropPeerOnSyncValidationReject(vf, h, lg)), nil, nil, nil, nil, nil, nil, nil)
 
 	// Request an atx by hash
 	_, err = fetcher.getHash(ctx, types.Hash32{}, datastore.ATXDB, fetcher.validators.atx.HandleMessage)

--- a/fetch/interface.go
+++ b/fetch/interface.go
@@ -18,20 +18,20 @@ type requester interface {
 // SyncValidators so that we can mock the behavior of GossipHandlers. If we
 // didn't need to mock GossipHandler behavior then we could use GossipHandlers
 // directly and do away with both ValidatorFunc and SyncValidator.
-type ValidatorFunc pubsub.GossipHandler
+type ValidatorFunc pubsub.SyncHandler
 
-func (f ValidatorFunc) HandleMessage(ctx context.Context, peer p2p.Peer, msg []byte) error {
-	return f(ctx, peer, msg)
+func (f ValidatorFunc) HandleMessage(ctx context.Context, hash types.Hash32, peer p2p.Peer, msg []byte) error {
+	return f(ctx, hash, peer, msg)
 }
 
 // SyncValidator exists to allow for mocking of GossipHandlers through the use
 // of ValidatorFunc.
 type SyncValidator interface {
-	HandleMessage(context.Context, p2p.Peer, []byte) error
+	HandleMessage(context.Context, types.Hash32, p2p.Peer, []byte) error
 }
 
 type PoetValidator interface {
-	ValidateAndStoreMsg(context.Context, p2p.Peer, []byte) error
+	ValidateAndStoreMsg(context.Context, types.Hash32, p2p.Peer, []byte) error
 }
 
 type meshProvider interface {

--- a/fetch/mesh_data.go
+++ b/fetch/mesh_data.go
@@ -27,7 +27,7 @@ func (f *Fetch) GetAtxs(ctx context.Context, ids []types.ATXID) error {
 	return f.getHashes(ctx, hashes, datastore.ATXDB, f.validators.atx.HandleMessage)
 }
 
-type dataReceiver func(context.Context, p2p.Peer, []byte) error
+type dataReceiver func(context.Context, types.Hash32, p2p.Peer, []byte) error
 
 func (f *Fetch) getHashes(ctx context.Context, hashes []types.Hash32, hint datastore.Hint, receiver dataReceiver) error {
 	var eg multierror.Group

--- a/fetch/mesh_data_test.go
+++ b/fetch/mesh_data_test.go
@@ -41,9 +41,9 @@ func (f *testFetch) withMethod(method int) *testFetch {
 
 func (f *testFetch) expectTransactionCall(times int) *gomock.Call {
 	if f.method == txsForBlock {
-		return f.mTxBlocksH.EXPECT().HandleMessage(gomock.Any(), gomock.Any(), gomock.Any()).Times(times)
+		return f.mTxBlocksH.EXPECT().HandleMessage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(times)
 	} else if f.method == txsForProposal {
-		return f.mTxProposalH.EXPECT().HandleMessage(gomock.Any(), gomock.Any(), gomock.Any()).Times(times)
+		return f.mTxProposalH.EXPECT().HandleMessage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(times)
 	}
 	return nil
 }
@@ -73,7 +73,7 @@ func startTestLoop(t *testing.T, f *Fetch, eg *errgroup.Group, stop chan struct{
 			default:
 				f.mu.Lock()
 				for h, req := range f.unprocessed {
-					require.NoError(t, req.validator(req.ctx, p2p.NoPeer, []byte{}))
+					require.NoError(t, req.validator(req.ctx, types.Hash32{}, p2p.NoPeer, []byte{}))
 					close(req.promise.completed)
 					delete(f.unprocessed, h)
 				}
@@ -176,7 +176,7 @@ func TestFetch_getHashes(t *testing.T) {
 						}
 						res := responses[r.Hash]
 						resBatch.Responses = append(resBatch.Responses, res)
-						f.mBlocksH.EXPECT().HandleMessage(gomock.Any(), p, res.Data).Return(tc.hdlrErr)
+						f.mBlocksH.EXPECT().HandleMessage(gomock.Any(), res.Hash, p, res.Data).Return(tc.hdlrErr)
 					}
 					bts, err := codec.Encode(&resBatch)
 					require.NoError(t, err)
@@ -197,7 +197,7 @@ func TestFetch_getHashes(t *testing.T) {
 func TestFetch_GetMalfeasanceProofs(t *testing.T) {
 	nodeIDs := []types.NodeID{{1}, {2}, {3}}
 	f := createFetch(t)
-	f.mMalH.EXPECT().HandleMessage(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(len(nodeIDs))
+	f.mMalH.EXPECT().HandleMessage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(len(nodeIDs))
 
 	stop := make(chan struct{}, 1)
 	var eg errgroup.Group
@@ -215,7 +215,7 @@ func TestFetch_GetBlocks(t *testing.T) {
 	}
 	blockIDs := types.ToBlockIDs(blks)
 	f := createFetch(t)
-	f.mBlocksH.EXPECT().HandleMessage(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(len(blockIDs))
+	f.mBlocksH.EXPECT().HandleMessage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(len(blockIDs))
 
 	stop := make(chan struct{}, 1)
 	var eg errgroup.Group
@@ -233,7 +233,7 @@ func TestFetch_GetBallots(t *testing.T) {
 	}
 	ballotIDs := types.ToBallotIDs(blts)
 	f := createFetch(t)
-	f.mBallotH.EXPECT().HandleMessage(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(len(ballotIDs))
+	f.mBallotH.EXPECT().HandleMessage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(len(ballotIDs))
 
 	stop := make(chan struct{}, 1)
 	var eg errgroup.Group
@@ -298,7 +298,7 @@ func TestFetch_GetProposals(t *testing.T) {
 	}
 	proposalIDs := types.ToProposalIDs(proposals)
 	f := createFetch(t)
-	f.mProposalH.EXPECT().HandleMessage(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(len(proposalIDs))
+	f.mProposalH.EXPECT().HandleMessage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(len(proposalIDs))
 
 	stop := make(chan struct{}, 1)
 	var eg errgroup.Group
@@ -385,7 +385,7 @@ func genATXs(tb testing.TB, num uint32) []*types.ActivationTx {
 func TestGetATXs(t *testing.T) {
 	atxs := genATXs(t, 2)
 	f := createFetch(t)
-	f.mAtxH.EXPECT().HandleMessage(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(len(atxs))
+	f.mAtxH.EXPECT().HandleMessage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(len(atxs))
 
 	stop := make(chan struct{}, 1)
 	var eg errgroup.Group
@@ -400,7 +400,7 @@ func TestGetATXs(t *testing.T) {
 func TestGetPoetProof(t *testing.T) {
 	f := createFetch(t)
 	h := types.RandomHash()
-	f.mPoetH.EXPECT().HandleMessage(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	f.mPoetH.EXPECT().HandleMessage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 
 	stop := make(chan struct{}, 1)
 	var eg errgroup.Group

--- a/fetch/mocks/mocks.go
+++ b/fetch/mocks/mocks.go
@@ -74,17 +74,17 @@ func (m *MockSyncValidator) EXPECT() *MockSyncValidatorMockRecorder {
 }
 
 // HandleMessage mocks base method.
-func (m *MockSyncValidator) HandleMessage(arg0 context.Context, arg1 p2p.Peer, arg2 []byte) error {
+func (m *MockSyncValidator) HandleMessage(arg0 context.Context, arg1 types.Hash32, arg2 p2p.Peer, arg3 []byte) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HandleMessage", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "HandleMessage", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // HandleMessage indicates an expected call of HandleMessage.
-func (mr *MockSyncValidatorMockRecorder) HandleMessage(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockSyncValidatorMockRecorder) HandleMessage(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleMessage", reflect.TypeOf((*MockSyncValidator)(nil).HandleMessage), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleMessage", reflect.TypeOf((*MockSyncValidator)(nil).HandleMessage), arg0, arg1, arg2, arg3)
 }
 
 // MockPoetValidator is a mock of PoetValidator interface.
@@ -111,17 +111,17 @@ func (m *MockPoetValidator) EXPECT() *MockPoetValidatorMockRecorder {
 }
 
 // ValidateAndStoreMsg mocks base method.
-func (m *MockPoetValidator) ValidateAndStoreMsg(arg0 context.Context, arg1 p2p.Peer, arg2 []byte) error {
+func (m *MockPoetValidator) ValidateAndStoreMsg(arg0 context.Context, arg1 types.Hash32, arg2 p2p.Peer, arg3 []byte) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ValidateAndStoreMsg", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "ValidateAndStoreMsg", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ValidateAndStoreMsg indicates an expected call of ValidateAndStoreMsg.
-func (mr *MockPoetValidatorMockRecorder) ValidateAndStoreMsg(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockPoetValidatorMockRecorder) ValidateAndStoreMsg(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateAndStoreMsg", reflect.TypeOf((*MockPoetValidator)(nil).ValidateAndStoreMsg), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateAndStoreMsg", reflect.TypeOf((*MockPoetValidator)(nil).ValidateAndStoreMsg), arg0, arg1, arg2, arg3)
 }
 
 // MockmeshProvider is a mock of meshProvider interface.

--- a/malfeasance/handler.go
+++ b/malfeasance/handler.go
@@ -21,6 +21,7 @@ import (
 var (
 	ErrKnownProof    = errors.New("known proof")
 	errMalformedData = fmt.Errorf("%w: malformed data", pubsub.ErrValidationReject)
+	errWrongHash     = fmt.Errorf("%w: incorrect hash", pubsub.ErrValidationReject)
 )
 
 // Handler processes MalfeasanceProof from gossip and, if deems it valid, propagates it to peers.
@@ -61,7 +62,7 @@ func (h *Handler) HandleSyncedMalfeasanceProof(ctx context.Context, expHash type
 	}
 	nodeID, err := validateAndSave(ctx, h.logger, h.cdb, h.edVerifier, h.cp, h.tortoise, &types.MalfeasanceGossip{MalfeasanceProof: p})
 	if err == nil && types.Hash32(nodeID) != expHash {
-		return fmt.Errorf("fetched wrong tx hash for proposal. want %s, got %s", expHash.ShortString(), nodeID.ShortString())
+		return fmt.Errorf("%w: malfesance proof want %s, got %s", errWrongHash, expHash.ShortString(), nodeID.ShortString())
 	}
 	return err
 }

--- a/malfeasance/handler.go
+++ b/malfeasance/handler.go
@@ -52,14 +52,18 @@ func NewHandler(
 }
 
 // HandleSyncedMalfeasanceProof is the sync validator for MalfeasanceProof.
-func (h *Handler) HandleSyncedMalfeasanceProof(ctx context.Context, _ p2p.Peer, data []byte) error {
+func (h *Handler) HandleSyncedMalfeasanceProof(ctx context.Context, expHash types.Hash32, _ p2p.Peer, data []byte) error {
 	var p types.MalfeasanceProof
 	if err := codec.Decode(data, &p); err != nil {
 		numMalformed.Inc()
 		h.logger.With().Error("malformed message (sync)", log.Context(ctx), log.Err(err))
 		return errMalformedData
 	}
-	return validateAndSave(ctx, h.logger, h.cdb, h.edVerifier, h.cp, h.tortoise, &types.MalfeasanceGossip{MalfeasanceProof: p})
+	nodeID, err := validateAndSave(ctx, h.logger, h.cdb, h.edVerifier, h.cp, h.tortoise, &types.MalfeasanceGossip{MalfeasanceProof: p})
+	if err == nil && types.Hash32(nodeID) != expHash {
+		return fmt.Errorf("fetched wrong tx hash for proposal. want %s, got %s", expHash.ShortString(), nodeID.ShortString())
+	}
+	return err
 }
 
 // HandleMalfeasanceProof is the gossip receiver for MalfeasanceGossip.
@@ -81,7 +85,8 @@ func (h *Handler) HandleMalfeasanceProof(ctx context.Context, peer p2p.Peer, dat
 		updateMetrics(p.Proof)
 		return nil
 	}
-	return validateAndSave(ctx, h.logger, h.cdb, h.edVerifier, h.cp, h.tortoise, &p)
+	_, err := validateAndSave(ctx, h.logger, h.cdb, h.edVerifier, h.cp, h.tortoise, &p)
+	return err
 }
 
 func validateAndSave(
@@ -92,10 +97,10 @@ func validateAndSave(
 	cp consensusProtocol,
 	trt tortoise,
 	p *types.MalfeasanceGossip,
-) error {
+) (types.NodeID, error) {
 	nodeID, err := Validate(ctx, logger, cdb, edVerifier, cp, p)
 	if err != nil {
-		return err
+		return types.EmptyNodeID, err
 	}
 	if err := cdb.WithTx(ctx, func(dbtx *sql.Tx) error {
 		malicious, err := identities.IsMalicious(dbtx, nodeID)
@@ -121,7 +126,7 @@ func validateAndSave(
 				log.Err(err),
 			)
 		}
-		return err
+		return types.EmptyNodeID, err
 	}
 	trt.OnMalfeasance(nodeID)
 	cdb.CacheMalfeasanceProof(nodeID, &p.MalfeasanceProof)
@@ -130,7 +135,7 @@ func validateAndSave(
 		log.Stringer("smesher", nodeID),
 		log.Inline(p),
 	)
-	return nil
+	return nodeID, nil
 }
 
 func Validate(

--- a/malfeasance/handler_test.go
+++ b/malfeasance/handler_test.go
@@ -885,7 +885,7 @@ func TestHandler_HandleSyncedMalfeasanceProof_multipleATXs(t *testing.T) {
 	data, err := codec.Encode(&proof)
 	require.NoError(t, err)
 	trt.EXPECT().OnMalfeasance(sig.NodeID())
-	require.NoError(t, h.HandleSyncedMalfeasanceProof(context.Background(), "peer", data))
+	require.NoError(t, h.HandleSyncedMalfeasanceProof(context.Background(), types.Hash32(sig.NodeID()), "peer", data))
 
 	malicious, err = identities.IsMalicious(db, sig.NodeID())
 	require.NoError(t, err)
@@ -941,7 +941,7 @@ func TestHandler_HandleSyncedMalfeasanceProof_multipleBallots(t *testing.T) {
 	data, err := codec.Encode(&proof)
 	require.NoError(t, err)
 	trt.EXPECT().OnMalfeasance(sig.NodeID())
-	require.NoError(t, h.HandleSyncedMalfeasanceProof(context.Background(), "peer", data))
+	require.NoError(t, h.HandleSyncedMalfeasanceProof(context.Background(), types.Hash32(sig.NodeID()), "peer", data))
 
 	malicious, err = identities.IsMalicious(db, sig.NodeID())
 	require.NoError(t, err)
@@ -1000,7 +1000,7 @@ func TestHandler_HandleSyncedMalfeasanceProof_hareEquivocation(t *testing.T) {
 	data, err := codec.Encode(&proof)
 	require.NoError(t, err)
 	trt.EXPECT().OnMalfeasance(sig.NodeID())
-	require.NoError(t, h.HandleSyncedMalfeasanceProof(context.Background(), "peer", data))
+	require.NoError(t, h.HandleSyncedMalfeasanceProof(context.Background(), types.Hash32(sig.NodeID()), "peer", data))
 
 	malicious, err = identities.IsMalicious(db, sig.NodeID())
 	require.NoError(t, err)

--- a/node/node.go
+++ b/node/node.go
@@ -852,14 +852,14 @@ func (app *App) initServices(ctx context.Context) error {
 		trtl,
 	)
 	fetcher.SetValidators(
-		fetch.ValidatorFunc(pubsub.DropPeerOnValidationReject(atxHandler.HandleAtxData, app.host, lg)),
-		fetch.ValidatorFunc(pubsub.DropPeerOnValidationReject(poetDb.ValidateAndStoreMsg, app.host, lg)),
-		fetch.ValidatorFunc(pubsub.DropPeerOnValidationReject(proposalListener.HandleSyncedBallot, app.host, lg)),
-		fetch.ValidatorFunc(pubsub.DropPeerOnValidationReject(blockHandler.HandleSyncedBlock, app.host, lg)),
-		fetch.ValidatorFunc(pubsub.DropPeerOnValidationReject(proposalListener.HandleSyncedProposal, app.host, lg)),
-		fetch.ValidatorFunc(pubsub.DropPeerOnValidationReject(app.txHandler.HandleBlockTransaction, app.host, lg)),
-		fetch.ValidatorFunc(pubsub.DropPeerOnValidationReject(app.txHandler.HandleProposalTransaction, app.host, lg)),
-		fetch.ValidatorFunc(pubsub.DropPeerOnValidationReject(malfeasanceHandler.HandleSyncedMalfeasanceProof, app.host, lg)),
+		fetch.ValidatorFunc(pubsub.DropPeerOnSyncValidationReject(atxHandler.HandleSyncedAtx, app.host, lg)),
+		fetch.ValidatorFunc(pubsub.DropPeerOnSyncValidationReject(poetDb.ValidateAndStoreMsg, app.host, lg)),
+		fetch.ValidatorFunc(pubsub.DropPeerOnSyncValidationReject(proposalListener.HandleSyncedBallot, app.host, lg)),
+		fetch.ValidatorFunc(pubsub.DropPeerOnSyncValidationReject(blockHandler.HandleSyncedBlock, app.host, lg)),
+		fetch.ValidatorFunc(pubsub.DropPeerOnSyncValidationReject(proposalListener.HandleSyncedProposal, app.host, lg)),
+		fetch.ValidatorFunc(pubsub.DropPeerOnSyncValidationReject(app.txHandler.HandleBlockTransaction, app.host, lg)),
+		fetch.ValidatorFunc(pubsub.DropPeerOnSyncValidationReject(app.txHandler.HandleProposalTransaction, app.host, lg)),
+		fetch.ValidatorFunc(pubsub.DropPeerOnSyncValidationReject(malfeasanceHandler.HandleSyncedMalfeasanceProof, app.host, lg)),
 	)
 
 	syncHandler := func(_ context.Context, _ p2p.Peer, _ []byte) error {
@@ -1445,17 +1445,18 @@ func (app *App) preserveAfterRecovery(ctx context.Context) {
 			)
 			continue
 		}
-		if err := app.poetDb.ValidateAndStoreMsg(ctx, p2p.NoPeer, encoded); err != nil {
+		hash := app.preserve.Deps[i].GetPoetProofRef()
+		if err := app.poetDb.ValidateAndStoreMsg(ctx, hash, p2p.NoPeer, encoded); err != nil {
 			app.log.With().Error("failed to preserve poet proof after checkpoint",
 				log.Stringer("atx id", app.preserve.Deps[i].ID()),
-				log.String("poet proof ref", app.preserve.Deps[i].GetPoetProofRef().ShortString()),
+				log.String("poet proof ref", hash.ShortString()),
 				log.Err(err),
 			)
 			continue
 		}
 		app.log.With().Info("preserved poet proof after checkpoint",
 			log.Stringer("atx id", app.preserve.Deps[i].ID()),
-			log.String("poet proof ref", app.preserve.Deps[i].GetPoetProofRef().ShortString()),
+			log.String("poet proof ref", hash.ShortString()),
 		)
 	}
 	for _, vatx := range app.preserve.Deps {
@@ -1467,7 +1468,7 @@ func (app *App) preserveAfterRecovery(ctx context.Context) {
 			)
 			continue
 		}
-		if err := app.atxHandler.HandleAtxData(ctx, p2p.NoPeer, encoded); err != nil {
+		if err := app.atxHandler.HandleSyncedAtx(ctx, vatx.ID().Hash32(), p2p.NoPeer, encoded); err != nil {
 			app.log.With().Error("failed to preserve atx after checkpoint",
 				log.Inline(vatx),
 				log.Err(err),

--- a/p2p/pubsub/pubsub.go
+++ b/p2p/pubsub/pubsub.go
@@ -11,6 +11,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
 
+	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/hash"
 	"github.com/spacemeshos/go-spacemesh/log"
 	p2pmetrics "github.com/spacemeshos/go-spacemesh/p2p/metrics"
@@ -130,6 +131,9 @@ type PublishSubsciber interface {
 // GossipHandler is a function that is for receiving p2p messages.
 type GossipHandler = func(context.Context, peer.ID, []byte) error
 
+// SyncHandler is a function that is for receiving synced data.
+type SyncHandler = func(context.Context, types.Hash32, peer.ID, []byte) error
+
 // ErrValidationReject is returned by a GossipHandler to indicate that the
 // pubsub validation result is ValidationReject. ValidationAccept is indicated
 // by a nil error and ValidationIgnore is indicated by any error that is not a
@@ -148,11 +152,28 @@ func ChainGossipHandler(handlers ...GossipHandler) GossipHandler {
 	}
 }
 
-// DropPeerValidationReject wraps a gossip handler to provide a handler that drops a
+// DropPeerOnValidationReject wraps a gossip handler to provide a handler that drops a
 // peer if the wrapped handler returns ErrValidationReject.
 func DropPeerOnValidationReject(handler GossipHandler, h host.Host, logger log.Log) GossipHandler {
 	return func(ctx context.Context, peer peer.ID, data []byte) error {
 		err := handler(ctx, peer, data)
+		if errors.Is(err, ErrValidationReject) {
+			p2pmetrics.DroppedConnectionsValidationReject.Inc()
+			err := h.Network().ClosePeer(peer)
+			if err != nil {
+				logger.With().Debug("failed to close peer",
+					log.String("peer", peer.ShortString()),
+					log.Err(err),
+				)
+			}
+		}
+		return err
+	}
+}
+
+func DropPeerOnSyncValidationReject(handler SyncHandler, h host.Host, logger log.Log) SyncHandler {
+	return func(ctx context.Context, hash types.Hash32, peer peer.ID, data []byte) error {
+		err := handler(ctx, hash, peer, data)
 		if errors.Is(err, ErrValidationReject) {
 			p2pmetrics.DroppedConnectionsValidationReject.Inc()
 			err := h.Network().ClosePeer(peer)

--- a/proposals/handler.go
+++ b/proposals/handler.go
@@ -26,6 +26,7 @@ import (
 
 var (
 	errMalformedData         = fmt.Errorf("%w: malformed data", pubsub.ErrValidationReject)
+	errWrongHash             = fmt.Errorf("%w: incorrect hash", pubsub.ErrValidationReject)
 	errInitialize            = errors.New("failed to initialize")
 	errInvalidATXID          = errors.New("ballot has invalid ATXID")
 	errMissingEpochData      = errors.New("epoch data is missing in ref ballot")
@@ -158,7 +159,7 @@ func (h *Handler) HandleSyncedBallot(ctx context.Context, expHash types.Hash32, 
 	}
 
 	if b.ID().AsHash32() != expHash {
-		return fmt.Errorf("fetched wrong ballot hash. want %s, got %s", expHash.ShortString(), b.ID().String())
+		return fmt.Errorf("%w: ballot want %s, got %s", errWrongHash, expHash.ShortString(), b.ID().String())
 	}
 
 	if b.AtxID == types.EmptyATXID || b.AtxID == h.cfg.GoldenATXID {
@@ -256,7 +257,7 @@ func (h *Handler) handleProposal(ctx context.Context, expHash types.Hash32, peer
 	}
 
 	if expHash != (types.Hash32{}) && p.ID().AsHash32() != expHash {
-		return fmt.Errorf("fetched wrong proposal hash. want %s, got %s", expHash.ShortString(), p.ID().AsHash32().ShortString())
+		return fmt.Errorf("%w: proposal want %s, got %s", errWrongHash, expHash.ShortString(), p.ID().AsHash32().ShortString())
 	}
 
 	if p.AtxID == types.EmptyATXID || p.AtxID == h.cfg.GoldenATXID {

--- a/proposals/handler_test.go
+++ b/proposals/handler_test.go
@@ -285,6 +285,16 @@ func TestBallot_BadSignature(t *testing.T) {
 	require.ErrorContains(t, got, "failed to verify ballot signature")
 }
 
+func TestBallot_WrongHash(t *testing.T) {
+	th := createTestHandlerNoopDecoder(t)
+	b := createBallot(t)
+	data := encodeBallot(t, b)
+	peer := p2p.Peer("buddy")
+	err := th.HandleSyncedBallot(context.Background(), types.RandomHash(), peer, data)
+	require.ErrorIs(t, err, errWrongHash)
+	require.ErrorIs(t, err, pubsub.ErrValidationReject)
+}
+
 func TestBallot_KnownBallot(t *testing.T) {
 	th := createTestHandlerNoopDecoder(t)
 	b := createBallot(t)
@@ -885,6 +895,15 @@ func TestProposal_InconsistentSmeshers(t *testing.T) {
 
 	require.Error(t, th.HandleProposal(context.Background(), "", data))
 	checkProposal(t, th.cdb, p, false)
+}
+
+func TestProposal_WrongHash(t *testing.T) {
+	th := createTestHandlerNoopDecoder(t)
+	p := createProposal(t)
+	data := encodeProposal(t, p)
+	err := th.HandleSyncedProposal(context.Background(), types.RandomHash(), p2p.NoPeer, data)
+	require.ErrorIs(t, err, errWrongHash)
+	require.ErrorIs(t, err, pubsub.ErrValidationReject)
 }
 
 func TestProposal_KnownProposal(t *testing.T) {

--- a/proposals/handler_test.go
+++ b/proposals/handler_test.go
@@ -273,7 +273,7 @@ func TestBallot_MalformedData(t *testing.T) {
 	b := createBallot(t)
 	data, err := codec.Encode(&b.InnerBallot)
 	require.NoError(t, err)
-	require.ErrorIs(t, th.HandleSyncedBallot(context.Background(), p2p.NoPeer, data), errMalformedData)
+	require.ErrorIs(t, th.HandleSyncedBallot(context.Background(), b.ID().AsHash32(), p2p.NoPeer, data), errMalformedData)
 }
 
 func TestBallot_BadSignature(t *testing.T) {
@@ -281,7 +281,7 @@ func TestBallot_BadSignature(t *testing.T) {
 	b := createBallot(t)
 	b.Signature[types.EdSignatureSize-1] = 0xff
 	data := encodeBallot(t, b)
-	got := th.HandleSyncedBallot(context.Background(), p2p.NoPeer, data)
+	got := th.HandleSyncedBallot(context.Background(), b.ID().AsHash32(), p2p.NoPeer, data)
 	require.ErrorContains(t, got, "failed to verify ballot signature")
 }
 
@@ -293,7 +293,7 @@ func TestBallot_KnownBallot(t *testing.T) {
 	data := encodeBallot(t, b)
 	peer := p2p.Peer("buddy")
 	th.mf.EXPECT().RegisterPeerHashes(peer, collectHashes(*b))
-	require.NoError(t, th.HandleSyncedBallot(context.Background(), peer, data))
+	require.NoError(t, th.HandleSyncedBallot(context.Background(), b.ID().AsHash32(), peer, data))
 }
 
 func TestBallot_BeforeEffectiveGenesis(t *testing.T) {
@@ -302,7 +302,7 @@ func TestBallot_BeforeEffectiveGenesis(t *testing.T) {
 	b.Layer = types.GetEffectiveGenesis()
 	b = signAndInit(t, b)
 	data := encodeBallot(t, b)
-	require.ErrorContains(t, th.HandleSyncedBallot(context.Background(), "", data), "ballot before effective genesis")
+	require.ErrorContains(t, th.HandleSyncedBallot(context.Background(), b.ID().AsHash32(), "", data), "ballot before effective genesis")
 }
 
 func TestBallot_EmptyATXID(t *testing.T) {
@@ -311,7 +311,7 @@ func TestBallot_EmptyATXID(t *testing.T) {
 	b.AtxID = types.EmptyATXID
 	b = signAndInit(t, b)
 	data := encodeBallot(t, b)
-	require.ErrorIs(t, th.HandleSyncedBallot(context.Background(), "", data), errInvalidATXID)
+	require.ErrorIs(t, th.HandleSyncedBallot(context.Background(), b.ID().AsHash32(), "", data), errInvalidATXID)
 }
 
 func TestBallot_GoldenATXID(t *testing.T) {
@@ -320,7 +320,7 @@ func TestBallot_GoldenATXID(t *testing.T) {
 	b.AtxID = genGoldenATXID()
 	b = signAndInit(t, b)
 	data := encodeBallot(t, b)
-	require.ErrorIs(t, th.HandleSyncedBallot(context.Background(), "", data), errInvalidATXID)
+	require.ErrorIs(t, th.HandleSyncedBallot(context.Background(), b.ID().AsHash32(), "", data), errInvalidATXID)
 }
 
 func TestBallot_RefBallotMissingEpochData(t *testing.T) {
@@ -332,7 +332,7 @@ func TestBallot_RefBallotMissingEpochData(t *testing.T) {
 	data := encodeBallot(t, b)
 	peer := p2p.Peer("buddy")
 	th.mf.EXPECT().RegisterPeerHashes(peer, collectHashes(*b))
-	require.ErrorIs(t, th.HandleSyncedBallot(context.Background(), peer, data), errMissingEpochData)
+	require.ErrorIs(t, th.HandleSyncedBallot(context.Background(), b.ID().AsHash32(), peer, data), errMissingEpochData)
 }
 
 func TestBallot_RefBallotMissingBeacon(t *testing.T) {
@@ -344,7 +344,7 @@ func TestBallot_RefBallotMissingBeacon(t *testing.T) {
 	data := encodeBallot(t, b)
 	peer := p2p.Peer("buddy")
 	th.mf.EXPECT().RegisterPeerHashes(peer, collectHashes(*b))
-	require.ErrorIs(t, th.HandleSyncedBallot(context.Background(), peer, data), errMissingBeacon)
+	require.ErrorIs(t, th.HandleSyncedBallot(context.Background(), b.ID().AsHash32(), peer, data), errMissingBeacon)
 }
 
 func TestBallot_RefBallotEmptyActiveSet(t *testing.T) {
@@ -356,7 +356,7 @@ func TestBallot_RefBallotEmptyActiveSet(t *testing.T) {
 	createAtx(t, th.cdb.Database, b.Layer.GetEpoch()-1, b.AtxID, b.SmesherID)
 	peer := p2p.Peer("buddy")
 	th.mf.EXPECT().RegisterPeerHashes(peer, collectHashes(*b))
-	require.ErrorIs(t, th.HandleSyncedBallot(context.Background(), peer, data), errEmptyActiveSet)
+	require.ErrorIs(t, th.HandleSyncedBallot(context.Background(), b.ID().AsHash32(), peer, data), errEmptyActiveSet)
 }
 
 func TestBallot_RefBallotDuplicateInActiveSet(t *testing.T) {
@@ -368,7 +368,7 @@ func TestBallot_RefBallotDuplicateInActiveSet(t *testing.T) {
 	data := encodeBallot(t, b)
 	peer := p2p.Peer("buddy")
 	th.mf.EXPECT().RegisterPeerHashes(peer, collectHashes(*b))
-	require.ErrorIs(t, th.HandleSyncedBallot(context.Background(), peer, data), errActiveSetNotSorted)
+	require.ErrorIs(t, th.HandleSyncedBallot(context.Background(), b.ID().AsHash32(), peer, data), errActiveSetNotSorted)
 }
 
 func TestBallot_RefBallotActiveSetNotSorted(t *testing.T) {
@@ -383,7 +383,7 @@ func TestBallot_RefBallotActiveSetNotSorted(t *testing.T) {
 	data := encodeBallot(t, b)
 	peer := p2p.Peer("buddy")
 	th.mf.EXPECT().RegisterPeerHashes(peer, collectHashes(*b))
-	require.ErrorIs(t, th.HandleSyncedBallot(context.Background(), peer, data), errActiveSetNotSorted)
+	require.ErrorIs(t, th.HandleSyncedBallot(context.Background(), b.ID().AsHash32(), peer, data), errActiveSetNotSorted)
 }
 
 func TestBallot_RefBallotBadActiveSetHash(t *testing.T) {
@@ -395,7 +395,7 @@ func TestBallot_RefBallotBadActiveSetHash(t *testing.T) {
 	data := encodeBallot(t, b)
 	peer := p2p.Peer("buddy")
 	th.mf.EXPECT().RegisterPeerHashes(peer, collectHashes(*b))
-	require.ErrorIs(t, th.HandleSyncedBallot(context.Background(), peer, data), errBadActiveSetHash)
+	require.ErrorIs(t, th.HandleSyncedBallot(context.Background(), b.ID().AsHash32(), peer, data), errBadActiveSetHash)
 }
 
 func TestBallot_NotRefBallotButHasEpochData(t *testing.T) {
@@ -407,7 +407,7 @@ func TestBallot_NotRefBallotButHasEpochData(t *testing.T) {
 	data := encodeBallot(t, b)
 	peer := p2p.Peer("buddy")
 	th.mf.EXPECT().RegisterPeerHashes(peer, collectHashes(*b))
-	require.ErrorIs(t, th.HandleSyncedBallot(context.Background(), peer, data), errUnexpectedEpochData)
+	require.ErrorIs(t, th.HandleSyncedBallot(context.Background(), b.ID().AsHash32(), peer, data), errUnexpectedEpochData)
 }
 
 func TestBallot_BallotDoubleVotedWithinHdist(t *testing.T) {
@@ -432,7 +432,7 @@ func TestBallot_BallotDoubleVotedWithinHdist(t *testing.T) {
 	th.mf.EXPECT().GetBallots(gomock.Any(), []types.BallotID{b.Votes.Base, b.RefBallot}).Return(nil).Times(1)
 	th.md.EXPECT().GetMissingActiveSet(gomock.Any(), types.ATXIDList{b.AtxID}).Return(types.ATXIDList{b.AtxID})
 	th.mf.EXPECT().GetAtxs(gomock.Any(), types.ATXIDList{b.AtxID}).Return(nil).Times(1)
-	require.ErrorIs(t, th.HandleSyncedBallot(context.Background(), peer, data), errDoubleVoting)
+	require.ErrorIs(t, th.HandleSyncedBallot(context.Background(), b.ID().AsHash32(), peer, data), errDoubleVoting)
 }
 
 func TestBallot_BallotDoubleVotedWithinHdist_LyrBfrHdist(t *testing.T) {
@@ -458,7 +458,7 @@ func TestBallot_BallotDoubleVotedWithinHdist_LyrBfrHdist(t *testing.T) {
 	th.mf.EXPECT().GetBallots(gomock.Any(), []types.BallotID{b.Votes.Base, b.RefBallot}).Return(nil).Times(1)
 	th.md.EXPECT().GetMissingActiveSet(gomock.Any(), types.ATXIDList{b.AtxID}).Return(types.ATXIDList{b.AtxID})
 	th.mf.EXPECT().GetAtxs(gomock.Any(), types.ATXIDList{b.AtxID}).Return(nil).Times(1)
-	require.ErrorIs(t, th.HandleSyncedBallot(context.Background(), peer, data), errDoubleVoting)
+	require.ErrorIs(t, th.HandleSyncedBallot(context.Background(), b.ID().AsHash32(), peer, data), errDoubleVoting)
 }
 
 func TestBallot_BallotDoubleVotedOutsideHdist(t *testing.T) {
@@ -490,7 +490,7 @@ func TestBallot_BallotDoubleVotedOutsideHdist(t *testing.T) {
 			return true, nil
 		})
 	th.mm.EXPECT().AddBallot(context.Background(), b).Return(nil, nil)
-	require.NoError(t, th.HandleSyncedBallot(context.Background(), peer, data))
+	require.NoError(t, th.HandleSyncedBallot(context.Background(), b.ID().AsHash32(), peer, data))
 }
 
 func TestBallot_ConflictingForAndAgainst(t *testing.T) {
@@ -515,7 +515,7 @@ func TestBallot_ConflictingForAndAgainst(t *testing.T) {
 	th.mf.EXPECT().GetBallots(gomock.Any(), []types.BallotID{b.Votes.Base, b.RefBallot}).Return(nil).Times(1)
 	th.md.EXPECT().GetMissingActiveSet(gomock.Any(), types.ATXIDList{b.AtxID}).Return(types.ATXIDList{b.AtxID})
 	th.mf.EXPECT().GetAtxs(gomock.Any(), types.ATXIDList{b.AtxID}).Return(nil).Times(1)
-	require.ErrorIs(t, th.HandleSyncedBallot(context.Background(), peer, data), errConflictingExceptions)
+	require.ErrorIs(t, th.HandleSyncedBallot(context.Background(), b.ID().AsHash32(), peer, data), errConflictingExceptions)
 }
 
 func TestBallot_ConflictingForAndAbstain(t *testing.T) {
@@ -540,7 +540,7 @@ func TestBallot_ConflictingForAndAbstain(t *testing.T) {
 	th.mf.EXPECT().GetBallots(gomock.Any(), []types.BallotID{b.Votes.Base, b.RefBallot}).Return(nil).Times(1)
 	th.md.EXPECT().GetMissingActiveSet(gomock.Any(), types.ATXIDList{b.AtxID}).Return(types.ATXIDList{b.AtxID})
 	th.mf.EXPECT().GetAtxs(gomock.Any(), types.ATXIDList{b.AtxID}).Return(nil).Times(1)
-	require.ErrorIs(t, th.HandleSyncedBallot(context.Background(), peer, data), errConflictingExceptions)
+	require.ErrorIs(t, th.HandleSyncedBallot(context.Background(), b.ID().AsHash32(), peer, data), errConflictingExceptions)
 }
 
 func TestBallot_ConflictingAgainstAndAbstain(t *testing.T) {
@@ -566,7 +566,7 @@ func TestBallot_ConflictingAgainstAndAbstain(t *testing.T) {
 	th.mf.EXPECT().GetBallots(gomock.Any(), []types.BallotID{b.Votes.Base, b.RefBallot}).Return(nil).Times(1)
 	th.md.EXPECT().GetMissingActiveSet(gomock.Any(), types.ATXIDList{b.AtxID}).Return(types.ATXIDList{b.AtxID})
 	th.mf.EXPECT().GetAtxs(gomock.Any(), types.ATXIDList{b.AtxID}).Return(nil).Times(1)
-	require.ErrorIs(t, th.HandleSyncedBallot(context.Background(), peer, data), errConflictingExceptions)
+	require.ErrorIs(t, th.HandleSyncedBallot(context.Background(), b.ID().AsHash32(), peer, data), errConflictingExceptions)
 }
 
 func TestBallot_ExceedMaxExceptions(t *testing.T) {
@@ -592,7 +592,7 @@ func TestBallot_ExceedMaxExceptions(t *testing.T) {
 	th.mf.EXPECT().GetBallots(gomock.Any(), []types.BallotID{b.Votes.Base, b.RefBallot}).Return(nil).Times(1)
 	th.md.EXPECT().GetMissingActiveSet(gomock.Any(), types.ATXIDList{b.AtxID}).Return(types.ATXIDList{b.AtxID})
 	th.mf.EXPECT().GetAtxs(gomock.Any(), types.ATXIDList{b.AtxID}).Return(nil).Times(1)
-	require.ErrorIs(t, th.HandleSyncedBallot(context.Background(), peer, data), errExceptionsOverflow)
+	require.ErrorIs(t, th.HandleSyncedBallot(context.Background(), b.ID().AsHash32(), peer, data), errExceptionsOverflow)
 }
 
 func TestBallot_BallotsNotAvailable(t *testing.T) {
@@ -605,7 +605,7 @@ func TestBallot_BallotsNotAvailable(t *testing.T) {
 	peer := p2p.Peer("buddy")
 	th.mf.EXPECT().RegisterPeerHashes(peer, collectHashes(*b))
 	th.mf.EXPECT().GetBallots(gomock.Any(), []types.BallotID{b.Votes.Base, b.RefBallot}).Return(errUnknown).Times(1)
-	require.ErrorIs(t, th.HandleSyncedBallot(context.Background(), peer, data), errUnknown)
+	require.ErrorIs(t, th.HandleSyncedBallot(context.Background(), b.ID().AsHash32(), peer, data), errUnknown)
 }
 
 func TestBallot_ATXsNotAvailable(t *testing.T) {
@@ -619,7 +619,7 @@ func TestBallot_ATXsNotAvailable(t *testing.T) {
 	errUnknown := errors.New("unknown")
 	th.md.EXPECT().GetMissingActiveSet(gomock.Any(), types.ATXIDList{b.AtxID}).Return(types.ATXIDList{b.AtxID})
 	th.mf.EXPECT().GetAtxs(gomock.Any(), types.ATXIDList{b.AtxID}).Return(errUnknown).Times(1)
-	require.ErrorIs(t, th.HandleSyncedBallot(context.Background(), peer, data), errUnknown)
+	require.ErrorIs(t, th.HandleSyncedBallot(context.Background(), b.ID().AsHash32(), peer, data), errUnknown)
 }
 
 func TestBallot_ErrorCheckingEligible(t *testing.T) {
@@ -648,7 +648,7 @@ func TestBallot_ErrorCheckingEligible(t *testing.T) {
 			require.Equal(t, b.ID(), ballot.ID())
 			return false, errors.New("unknown")
 		})
-	require.ErrorIs(t, th.HandleSyncedBallot(context.Background(), peer, data), errNotEligible)
+	require.ErrorIs(t, th.HandleSyncedBallot(context.Background(), b.ID().AsHash32(), peer, data), errNotEligible)
 }
 
 func TestBallot_NotEligible(t *testing.T) {
@@ -677,7 +677,7 @@ func TestBallot_NotEligible(t *testing.T) {
 			require.Equal(t, b.ID(), ballot.ID())
 			return false, nil
 		})
-	require.ErrorIs(t, th.HandleSyncedBallot(context.Background(), peer, data), errNotEligible)
+	require.ErrorIs(t, th.HandleSyncedBallot(context.Background(), b.ID().AsHash32(), peer, data), errNotEligible)
 }
 
 func TestBallot_Success(t *testing.T) {
@@ -711,7 +711,7 @@ func TestBallot_Success(t *testing.T) {
 	decoded := &tortoise.DecodedBallot{BallotTortoiseData: b.ToTortoiseData()}
 	th.md.EXPECT().DecodeBallot(decoded.BallotTortoiseData).Return(decoded, nil)
 	th.md.EXPECT().StoreBallot(decoded).Return(nil)
-	require.NoError(t, th.HandleSyncedBallot(context.Background(), peer, data))
+	require.NoError(t, th.HandleSyncedBallot(context.Background(), b.ID().AsHash32(), peer, data))
 }
 
 func TestBallot_MaliciousProofIgnoredInSyncFlow(t *testing.T) {
@@ -745,7 +745,7 @@ func TestBallot_MaliciousProofIgnoredInSyncFlow(t *testing.T) {
 	decoded := &tortoise.DecodedBallot{BallotTortoiseData: b.ToTortoiseData()}
 	th.md.EXPECT().DecodeBallot(decoded.BallotTortoiseData).Return(decoded, nil)
 	th.md.EXPECT().StoreBallot(decoded).Return(nil)
-	require.NoError(t, th.HandleSyncedBallot(context.Background(), peer, data))
+	require.NoError(t, th.HandleSyncedBallot(context.Background(), b.ID().AsHash32(), peer, data))
 }
 
 func TestBallot_RefBallot(t *testing.T) {
@@ -778,7 +778,7 @@ func TestBallot_RefBallot(t *testing.T) {
 			return true, nil
 		})
 	th.mm.EXPECT().AddBallot(context.Background(), b).Return(nil, nil)
-	require.NoError(t, th.HandleSyncedBallot(context.Background(), peer, data))
+	require.NoError(t, th.HandleSyncedBallot(context.Background(), b.ID().AsHash32(), peer, data))
 }
 
 func TestBallot_DecodeBeforeVotesConsistency(t *testing.T) {
@@ -802,7 +802,7 @@ func TestBallot_DecodeBeforeVotesConsistency(t *testing.T) {
 
 	decoded := &tortoise.DecodedBallot{BallotTortoiseData: b.ToTortoiseData()}
 	th.md.EXPECT().DecodeBallot(decoded.BallotTortoiseData).Return(decoded, expected)
-	require.ErrorIs(t, th.HandleSyncedBallot(context.Background(), peer, data), expected)
+	require.ErrorIs(t, th.HandleSyncedBallot(context.Background(), b.ID().AsHash32(), peer, data), expected)
 }
 
 func TestBallot_DecodedStoreFailure(t *testing.T) {
@@ -825,7 +825,7 @@ func TestBallot_DecodedStoreFailure(t *testing.T) {
 	th.md.EXPECT().DecodeBallot(decoded.BallotTortoiseData).Return(decoded, nil)
 	th.mm.EXPECT().AddBallot(context.Background(), b).Return(nil, nil)
 	th.md.EXPECT().StoreBallot(decoded).Return(expected)
-	require.ErrorIs(t, th.HandleSyncedBallot(context.Background(), peer, data), expected)
+	require.ErrorIs(t, th.HandleSyncedBallot(context.Background(), b.ID().AsHash32(), peer, data), expected)
 }
 
 func TestProposal_MalformedData(t *testing.T) {
@@ -833,7 +833,7 @@ func TestProposal_MalformedData(t *testing.T) {
 	p := createProposal(t)
 	data, err := codec.Encode(&p.InnerProposal)
 	require.NoError(t, err)
-	require.ErrorIs(t, th.HandleSyncedProposal(context.Background(), p2p.NoPeer, data), errMalformedData)
+	require.ErrorIs(t, th.HandleSyncedProposal(context.Background(), p.ID().AsHash32(), p2p.NoPeer, data), errMalformedData)
 	require.ErrorIs(t, th.HandleProposal(context.Background(), "", data), pubsub.ErrValidationReject)
 	checkProposal(t, th.cdb, p, false)
 }
@@ -843,7 +843,7 @@ func TestProposal_BeforeEffectiveGenesis(t *testing.T) {
 	p := createProposal(t)
 	p.Layer = types.GetEffectiveGenesis()
 	data := encodeProposal(t, p)
-	got := th.HandleSyncedProposal(context.Background(), p2p.NoPeer, data)
+	got := th.HandleSyncedProposal(context.Background(), p.ID().AsHash32(), p2p.NoPeer, data)
 	require.ErrorContains(t, got, "proposal before effective genesis")
 
 	require.Error(t, th.HandleProposal(context.Background(), "", data))
@@ -855,7 +855,7 @@ func TestProposal_BadSignature(t *testing.T) {
 	p := createProposal(t)
 	p.Signature = types.EmptyEdSignature
 	data := encodeProposal(t, p)
-	got := th.HandleSyncedProposal(context.Background(), p2p.NoPeer, data)
+	got := th.HandleSyncedProposal(context.Background(), p.ID().AsHash32(), p2p.NoPeer, data)
 	require.ErrorContains(t, got, "failed to verify proposal signature")
 
 	require.Error(t, th.HandleProposal(context.Background(), "", data))
@@ -880,7 +880,7 @@ func TestProposal_InconsistentSmeshers(t *testing.T) {
 	p.SmesherID = signer2.NodeID()
 
 	data := encodeProposal(t, p)
-	got := th.HandleSyncedProposal(context.Background(), p2p.NoPeer, data)
+	got := th.HandleSyncedProposal(context.Background(), p.ID().AsHash32(), p2p.NoPeer, data)
 	require.ErrorContains(t, got, "failed to verify proposal signature")
 
 	require.Error(t, th.HandleProposal(context.Background(), "", data))
@@ -894,7 +894,7 @@ func TestProposal_KnownProposal(t *testing.T) {
 	require.NoError(t, ballots.Add(th.cdb, &p.Ballot))
 	require.NoError(t, proposals.Add(th.cdb, p))
 	data := encodeProposal(t, p)
-	require.NoError(t, th.HandleSyncedProposal(context.Background(), p2p.NoPeer, data))
+	require.NoError(t, th.HandleSyncedProposal(context.Background(), p.ID().AsHash32(), p2p.NoPeer, data))
 	require.Error(t, th.HandleProposal(context.Background(), "", data))
 	checkProposal(t, th.cdb, p, true)
 }
@@ -932,7 +932,7 @@ func TestProposal_DuplicateTXs(t *testing.T) {
 		})
 	peer := p2p.Peer("buddy")
 	th.mf.EXPECT().RegisterPeerHashes(peer, collectHashes(*p))
-	require.ErrorIs(t, th.HandleSyncedProposal(context.Background(), peer, data), errDuplicateTX)
+	require.ErrorIs(t, th.HandleSyncedProposal(context.Background(), p.ID().AsHash32(), peer, data), errDuplicateTX)
 	checkProposal(t, th.cdb, p, false)
 }
 
@@ -970,7 +970,7 @@ func TestProposal_TXsNotAvailable(t *testing.T) {
 	peer := p2p.Peer("buddy")
 	th.mf.EXPECT().RegisterPeerHashes(peer, collectHashes(*p))
 	th.mf.EXPECT().GetProposalTxs(gomock.Any(), p.TxIDs).Return(errUnknown).Times(1)
-	require.ErrorIs(t, th.HandleSyncedProposal(context.Background(), peer, data), errUnknown)
+	require.ErrorIs(t, th.HandleSyncedProposal(context.Background(), p.ID().AsHash32(), peer, data), errUnknown)
 	checkProposal(t, th.cdb, p, false)
 }
 
@@ -1008,7 +1008,7 @@ func TestProposal_FailedToAddProposalTXs(t *testing.T) {
 	th.mf.EXPECT().RegisterPeerHashes(peer, collectHashes(*p))
 	errUnknown := errors.New("unknown")
 	th.mm.EXPECT().AddTXsFromProposal(gomock.Any(), p.Layer, p.ID(), p.TxIDs).Return(errUnknown).Times(1)
-	require.ErrorIs(t, th.HandleSyncedProposal(context.Background(), peer, data), errUnknown)
+	require.ErrorIs(t, th.HandleSyncedProposal(context.Background(), p.ID().AsHash32(), peer, data), errUnknown)
 	checkProposal(t, th.cdb, p, true)
 }
 
@@ -1227,7 +1227,7 @@ func TestProposal_ValidProposal(t *testing.T) {
 	peer := p2p.Peer("buddy")
 	th.mf.EXPECT().RegisterPeerHashes(peer, collectHashes(*p))
 	th.mm.EXPECT().AddTXsFromProposal(gomock.Any(), p.Layer, p.ID(), p.TxIDs).Return(nil).Times(1)
-	require.NoError(t, th.HandleSyncedProposal(context.Background(), peer, data))
+	require.NoError(t, th.HandleSyncedProposal(context.Background(), p.ID().AsHash32(), peer, data))
 	checkProposal(t, th.cdb, p, true)
 }
 
@@ -1264,7 +1264,7 @@ func TestMetrics(t *testing.T) {
 	peer := p2p.Peer("buddy")
 	th.mf.EXPECT().RegisterPeerHashes(peer, collectHashes(*p))
 	th.mm.EXPECT().AddTXsFromProposal(gomock.Any(), p.Layer, p.ID(), p.TxIDs).Return(nil).Times(1)
-	require.NoError(t, th.HandleSyncedProposal(context.Background(), peer, data))
+	require.NoError(t, th.HandleSyncedProposal(context.Background(), p.ID().AsHash32(), peer, data))
 	checkProposal(t, th.cdb, p, true)
 	counts, err := testutil.GatherAndCount(prometheus.DefaultGatherer, "spacemesh_proposals_proposal_size")
 	require.NoError(t, err)

--- a/txs/conservative_state_test.go
+++ b/txs/conservative_state_test.go
@@ -589,7 +589,7 @@ func TestConsistentHandling(t *testing.T) {
 			instances[1].mvm.EXPECT().Validation(txs[i].RawTx).Times(1).Return(failed)
 
 			require.Equal(t, nil, instances[0].handler().HandleGossipTransaction(context.Background(), p2p.NoPeer, txs[i].Raw))
-			require.NoError(t, instances[1].handler().HandleBlockTransaction(context.Background(), p2p.NoPeer, txs[i].Raw))
+			require.NoError(t, instances[1].handler().HandleBlockTransaction(context.Background(), txs[i].ID.Hash32(), p2p.NoPeer, txs[i].Raw))
 		}
 		block := types.NewExistingBlock(types.BlockID{byte(lid)},
 			types.InnerBlock{

--- a/txs/handler_test.go
+++ b/txs/handler_test.go
@@ -15,9 +15,35 @@ import (
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/log/logtest"
 	"github.com/spacemeshos/go-spacemesh/p2p"
+	"github.com/spacemeshos/go-spacemesh/p2p/pubsub"
 	"github.com/spacemeshos/go-spacemesh/signing"
 	smocks "github.com/spacemeshos/go-spacemesh/system/mocks"
 )
+
+func Test_WrongHash(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	cstate := NewMockconservativeState(ctrl)
+	_, pub, err := crypto.GenerateEd25519Key(nil)
+	require.NoError(t, err)
+	id, err := peer.IDFromPublicKey(pub)
+	require.NoError(t, err)
+	th := NewTxHandler(cstate, id, logtest.New(t))
+
+	signer, err := signing.NewEdSigner()
+	require.NoError(t, err)
+	tx := newTx(t, 3, 10, 1, signer)
+	cstate.EXPECT().HasTx(tx.ID).Return(false, nil)
+	err = th.HandleBlockTransaction(context.Background(), types.RandomHash(), p2p.NoPeer, tx.Raw)
+	require.ErrorIs(t, err, errWrongHash)
+	require.ErrorIs(t, err, pubsub.ErrValidationReject)
+	cstate.EXPECT().GetMeshTransaction(tx.ID).Return(nil, nil)
+	req := smocks.NewMockValidationRequest(ctrl)
+	req.EXPECT().Parse().Times(1).Return(tx.TxHeader, nil)
+	cstate.EXPECT().Validation(tx.RawTx).Times(1).Return(req)
+	err = th.HandleProposalTransaction(context.Background(), types.RandomHash(), p2p.NoPeer, tx.Raw)
+	require.ErrorIs(t, err, errWrongHash)
+	require.ErrorIs(t, err, pubsub.ErrValidationReject)
+}
 
 func Test_HandleBlock(t *testing.T) {
 	for _, tc := range []struct {

--- a/txs/handler_test.go
+++ b/txs/handler_test.go
@@ -82,7 +82,7 @@ func Test_HandleBlock(t *testing.T) {
 					cstate.EXPECT().AddToDB(&types.Transaction{RawTx: tx.RawTx}).Return(tc.addErr)
 				}
 			}
-			err = th.HandleBlockTransaction(context.Background(), p2p.NoPeer, tx.Raw)
+			err = th.HandleBlockTransaction(context.Background(), tx.ID.Hash32(), p2p.NoPeer, tx.Raw)
 			if tc.failed {
 				require.Error(t, err)
 			} else {
@@ -293,7 +293,7 @@ func Test_HandleProposal(t *testing.T) {
 				tc.hasErr, tc.parseErr, tc.addErr,
 				tc.has, tc.verify, tc.noHeader,
 			)
-			err := th.HandleProposalTransaction(context.Background(), p2p.NoPeer, tx.Raw)
+			err := th.HandleProposalTransaction(context.Background(), tx.ID.Hash32(), p2p.NoPeer, tx.Raw)
 			if tc.fail {
 				require.Error(t, err)
 			} else {


### PR DESCRIPTION
## Motivation
Closes #3797

## Changes
- add SyncHandler in p2p for dropping peers
- in data handler's path, check the expected hash received on the sync path