### PR TITLE
[Merged by Bors] - block certificate: only sync latest certs in catch up sync

### DIFF
--- a/mesh/mesh.go
+++ b/mesh/mesh.go
@@ -29,6 +29,8 @@ import (
 	"github.com/spacemeshos/go-spacemesh/system"
 )
 
+var ErrMissingBlock = errors.New("missing blocks")
+
 // Mesh is the logic layer above our mesh.DB database.
 type Mesh struct {
 	logger log.Log
@@ -321,7 +323,7 @@ func (msh *Mesh) ProcessLayer(ctx context.Context, lid types.LayerID) error {
 		case <-ctx.Done():
 		case msh.missingBlocks <- missing:
 		}
-		return fmt.Errorf("request missing blocks %v", missing)
+		return fmt.Errorf("%w: request missing blocks %v", ErrMissingBlock, missing)
 	}
 	if err := msh.ensureStateConsistent(ctx, results); err != nil {
 		return err

--- a/syncer/state_syncer.go
+++ b/syncer/state_syncer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/spacemeshos/go-spacemesh/mesh"
 	"time"
 
 	"go.uber.org/zap/zapcore"
@@ -103,7 +104,9 @@ func (s *Syncer) processLayers(ctx context.Context) error {
 		// even if it fails to fetch opinions, we still go ahead to ProcessLayer so that the tortoise
 		// has a chance to count ballots and form its own opinions
 		if err := s.mesh.ProcessLayer(ctx, lid); err != nil {
-			s.logger.WithContext(ctx).With().Warning("mesh failed to process layer from sync", lid, log.Err(err))
+			if !errors.Is(err, mesh.ErrMissingBlock) {
+				s.logger.WithContext(ctx).With().Warning("mesh failed to process layer from sync", lid, log.Err(err))
+			}
 		}
 	}
 	s.logger.WithContext(ctx).With().Debug("end of state sync",

--- a/syncer/state_syncer.go
+++ b/syncer/state_syncer.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/spacemeshos/go-spacemesh/mesh"
 	"time"
 
 	"go.uber.org/zap/zapcore"
@@ -13,6 +12,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/fetch"
 	"github.com/spacemeshos/go-spacemesh/log"
+	"github.com/spacemeshos/go-spacemesh/mesh"
 	"github.com/spacemeshos/go-spacemesh/p2p"
 	"github.com/spacemeshos/go-spacemesh/sql"
 	"github.com/spacemeshos/go-spacemesh/sql/certificates"
@@ -195,8 +195,7 @@ func (s *Syncer) adopt(ctx context.Context, lid types.LayerID, opinions []*fetch
 
 func (s *Syncer) certCutoffLayer() types.LayerID {
 	cutoff := types.GetEffectiveGenesis()
-	// TODO: change this to current layer after https://github.com/spacemeshos/go-spacemesh/issues/2921 is done
-	last := s.mesh.ProcessedLayer()
+	last := s.ticker.CurrentLayer()
 	if last.Uint32() > s.cfg.SyncCertDistance {
 		limit := last.Sub(s.cfg.SyncCertDistance)
 		if limit.After(cutoff) {

--- a/syncer/state_syncer_test.go
+++ b/syncer/state_syncer_test.go
@@ -37,6 +37,7 @@ func opinions(prevHash types.Hash32) []*fetch.LayerOpinion {
 func TestProcessLayers_MultiLayers(t *testing.T) {
 	gLid := types.GetEffectiveGenesis()
 	ts := newSyncerWithoutSyncTimer(t)
+	ts.syncer.cfg.SyncCertDistance = 10000
 	ts.syncer.setATXSynced()
 	current := gLid.Add(10)
 	ts.syncer.setLastSyncedLayer(current.Sub(1))


### PR DESCRIPTION
## Motivation
currently for a new node joining the network, it needs to sync all block certificate from genesis.
there is no need. we can rely on full tortoise to advance the state during catch up sync and only sync cert right before it catch up to current layer.