### PR TITLE
[Merged by Bors] - serve malfeasance proof over grpc

### DIFF
--- a/api/grpcserver/activation_service.go
+++ b/api/grpcserver/activation_service.go
@@ -2,6 +2,7 @@ package grpcserver
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/golang/protobuf/ptypes/empty"
@@ -10,7 +11,9 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/events"
 	"github.com/spacemeshos/go-spacemesh/log"
+	"github.com/spacemeshos/go-spacemesh/sql"
 )
 
 type activationService struct {
@@ -42,12 +45,28 @@ func (s *activationService) Get(ctx context.Context, request *pb.GetRequest) (*p
 	atxId := types.ATXID(types.BytesToHash(request.Id))
 	atx, err := s.atxProvider.GetFullAtx(atxId)
 	if err != nil || atx == nil {
-		s.logger.With().Debug("failed to get the ATX", log.Err(err), log.Stringer("id", atxId))
+		s.logger.With().Error("failed to get ATX",
+			log.Stringer("atx id", atxId),
+			log.Err(err),
+		)
 		return nil, status.Error(codes.NotFound, "id was not found")
 	}
-	return &pb.GetResponse{
+	proof, err := s.atxProvider.GetMalfeasanceProof(atx.SmesherID)
+	if err != nil && !errors.Is(err, sql.ErrNotFound) {
+		s.logger.With().Error("failed to get malfeasance proof",
+			log.Stringer("smesher", atx.SmesherID),
+			log.Stringer("id", atxId),
+			log.Err(err),
+		)
+		return nil, status.Error(codes.NotFound, "id was not found")
+	}
+	resp := &pb.GetResponse{
 		Atx: convertActivation(atx),
-	}, nil
+	}
+	if proof != nil {
+		resp.MalfeasanceProof = events.ToMalfeasancePB(atx.SmesherID, proof, false)
+	}
+	return resp, nil
 }
 
 func (s *activationService) Highest(ctx context.Context, req *empty.Empty) (*pb.HighestResponse, error) {

--- a/api/grpcserver/activation_service.go
+++ b/api/grpcserver/activation_service.go
@@ -45,7 +45,7 @@ func (s *activationService) Get(ctx context.Context, request *pb.GetRequest) (*p
 	atxId := types.ATXID(types.BytesToHash(request.Id))
 	atx, err := s.atxProvider.GetFullAtx(atxId)
 	if err != nil || atx == nil {
-		s.logger.With().Error("failed to get ATX",
+		s.logger.With().Debug("failed to get ATX",
 			log.Stringer("atx id", atxId),
 			log.Err(err),
 		)

--- a/api/grpcserver/interface.go
+++ b/api/grpcserver/interface.go
@@ -45,6 +45,7 @@ type txValidator interface {
 type atxProvider interface {
 	GetFullAtx(id types.ATXID) (*types.VerifiedActivationTx, error)
 	MaxHeightAtx() (types.ATXID, error)
+	GetMalfeasanceProof(id types.NodeID) (*types.MalfeasanceProof, error)
 }
 
 type postSetupProvider interface {

--- a/api/grpcserver/mesh_service.go
+++ b/api/grpcserver/mesh_service.go
@@ -2,17 +2,21 @@ package grpcserver
 
 import (
 	"context"
+	"encoding/hex"
+	"errors"
 	"fmt"
 	"time"
 
 	pb "github.com/spacemeshos/api/release/go/spacemesh/v1"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/datastore"
 	"github.com/spacemeshos/go-spacemesh/events"
 	"github.com/spacemeshos/go-spacemesh/log"
+	"github.com/spacemeshos/go-spacemesh/sql"
 )
 
 // MeshService exposes mesh data such as accounts, blocks, and transactions.
@@ -609,4 +613,69 @@ func (s MeshService) EpochStream(req *pb.EpochStreamRequest, stream pb.MeshServi
 		log.Int("malicious", mal),
 	)
 	return nil
+}
+
+func (s MeshService) MalfeasanceQuery(ctx context.Context, req *pb.MalfeasanceRequest) (*pb.MalfeasanceResponse, error) {
+	var id types.NodeID
+	if len(req.SmesherHex) == 0 {
+		if len(req.Smesher.Id) != types.NodeIDSize {
+			return nil, status.Error(codes.InvalidArgument,
+				fmt.Sprintf("invalid smesher id length (%d), expected (%d)", len(req.Smesher.Id), types.NodeIDSize))
+		}
+		id = types.BytesToNodeID(req.Smesher.Id)
+	} else {
+		parsed, err := hex.DecodeString(req.SmesherHex)
+		if err != nil {
+			return nil, status.Error(codes.InvalidArgument, err.Error())
+		}
+		id = types.BytesToNodeID(parsed)
+	}
+	proof, err := s.cdb.GetMalfeasanceProof(id)
+	if err != nil && !errors.Is(err, sql.ErrNotFound) {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+	return &pb.MalfeasanceResponse{
+		Proof: events.ToMalfeasancePB(id, proof, req.IncludeProof),
+	}, nil
+}
+
+func (s MeshService) MalfeasanceStream(req *pb.MalfeasanceStreamRequest, stream pb.MeshService_MalfeasanceStreamServer) error {
+	sub := events.SubscribeMalfeasance()
+	if sub == nil {
+		return status.Errorf(codes.FailedPrecondition, "event reporting is not enabled")
+	}
+	eventch, fullch := consumeEvents[events.EventMalfeasance](stream.Context(), sub)
+	if err := stream.SendHeader(metadata.MD{}); err != nil {
+		return status.Errorf(codes.Unavailable, "can't send header")
+	}
+
+	// first serve those already existed locally.
+	if err := s.cdb.IterateMalfeasanceProofs(func(id types.NodeID, mp *types.MalfeasanceProof) error {
+		select {
+		case <-stream.Context().Done():
+			return nil
+		default:
+			res := &pb.MalfeasanceStreamResponse{
+				Proof: events.ToMalfeasancePB(id, mp, req.IncludeProof),
+			}
+			return stream.Send(res)
+		}
+	}); err != nil {
+		return status.Error(codes.Internal, err.Error())
+	}
+
+	for {
+		select {
+		case <-stream.Context().Done():
+			return nil
+		case <-fullch:
+			return status.Errorf(codes.Canceled, "buffer is full")
+		case ev := <-eventch:
+			if err := stream.Send(&pb.MalfeasanceStreamResponse{
+				Proof: events.ToMalfeasancePB(ev.Smesher, ev.Proof, req.IncludeProof),
+			}); err != nil {
+				return status.Error(codes.Internal, fmt.Errorf("send to stream: %w", err).Error())
+			}
+		}
+	}
 }

--- a/api/grpcserver/mesh_service.go
+++ b/api/grpcserver/mesh_service.go
@@ -620,6 +620,10 @@ func (s MeshService) MalfeasanceQuery(ctx context.Context, req *pb.MalfeasanceRe
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
+	if l := len(parsed); l != types.NodeIDSize {
+		return nil, status.Error(codes.InvalidArgument,
+			fmt.Sprintf("invalid smesher id length (%d), expected (%d)", l, types.NodeIDSize))
+	}
 	id := types.BytesToNodeID(parsed)
 	proof, err := s.cdb.GetMalfeasanceProof(id)
 	if err != nil && !errors.Is(err, sql.ErrNotFound) {

--- a/api/grpcserver/mesh_service.go
+++ b/api/grpcserver/mesh_service.go
@@ -616,20 +616,11 @@ func (s MeshService) EpochStream(req *pb.EpochStreamRequest, stream pb.MeshServi
 }
 
 func (s MeshService) MalfeasanceQuery(ctx context.Context, req *pb.MalfeasanceRequest) (*pb.MalfeasanceResponse, error) {
-	var id types.NodeID
-	if len(req.SmesherHex) == 0 {
-		if len(req.Smesher.Id) != types.NodeIDSize {
-			return nil, status.Error(codes.InvalidArgument,
-				fmt.Sprintf("invalid smesher id length (%d), expected (%d)", len(req.Smesher.Id), types.NodeIDSize))
-		}
-		id = types.BytesToNodeID(req.Smesher.Id)
-	} else {
-		parsed, err := hex.DecodeString(req.SmesherHex)
-		if err != nil {
-			return nil, status.Error(codes.InvalidArgument, err.Error())
-		}
-		id = types.BytesToNodeID(parsed)
+	parsed, err := hex.DecodeString(req.SmesherHex)
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
+	id := types.BytesToNodeID(parsed)
 	proof, err := s.cdb.GetMalfeasanceProof(id)
 	if err != nil && !errors.Is(err, sql.ErrNotFound) {
 		return nil, status.Error(codes.Internal, err.Error())

--- a/api/grpcserver/mesh_service_test.go
+++ b/api/grpcserver/mesh_service_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/golang/mock/gomock"
 	pb "github.com/spacemeshos/api/release/go/spacemesh/v1"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/spacemeshos/go-spacemesh/codec"
 	"github.com/spacemeshos/go-spacemesh/common/types"
@@ -149,10 +151,15 @@ func TestMeshService_MalfeasanceQuery(t *testing.T) {
 	nodeID, proof := BallotMalfeasance(t, db)
 
 	req := &pb.MalfeasanceRequest{
-		SmesherHex:   hex.EncodeToString(nodeID.Bytes()),
+		SmesherHex:   "0123456789abcdef",
 		IncludeProof: true,
 	}
 	resp, err := client.MalfeasanceQuery(context.Background(), req)
+	require.Equal(t, status.Code(err), codes.InvalidArgument)
+	require.Nil(t, resp)
+
+	req.SmesherHex = hex.EncodeToString(nodeID.Bytes())
+	resp, err = client.MalfeasanceQuery(context.Background(), req)
 	require.NoError(t, err)
 	require.Equal(t, nodeID, types.BytesToNodeID(resp.Proof.SmesherId.Id))
 	require.EqualValues(t, layer, resp.Proof.Layer.Number)

--- a/api/grpcserver/mesh_service_test.go
+++ b/api/grpcserver/mesh_service_test.go
@@ -1,0 +1,228 @@
+package grpcserver
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	pb "github.com/spacemeshos/api/release/go/spacemesh/v1"
+	"github.com/stretchr/testify/require"
+
+	"github.com/spacemeshos/go-spacemesh/codec"
+	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/datastore"
+	"github.com/spacemeshos/go-spacemesh/events"
+	"github.com/spacemeshos/go-spacemesh/log/logtest"
+	"github.com/spacemeshos/go-spacemesh/signing"
+	"github.com/spacemeshos/go-spacemesh/sql"
+	"github.com/spacemeshos/go-spacemesh/sql/identities"
+)
+
+const (
+	epoch = 7
+	layer = 123
+)
+
+func AtxMalfeasance(tb testing.TB, db sql.Executor) (types.NodeID, *types.MalfeasanceProof) {
+	sig, err := signing.NewEdSigner()
+	require.NoError(tb, err)
+	ap := types.AtxProof{
+		Messages: [2]types.AtxProofMsg{
+			{
+				InnerMsg: types.ATXMetadata{
+					PublishEpoch: types.EpochID(epoch),
+					MsgHash:      types.RandomHash(),
+				},
+			},
+			{
+				InnerMsg: types.ATXMetadata{
+					PublishEpoch: types.EpochID(epoch),
+					MsgHash:      types.RandomHash(),
+				},
+			},
+		},
+	}
+	ap.Messages[0].Signature = sig.Sign(signing.ATX, ap.Messages[0].SignedBytes())
+	ap.Messages[0].SmesherID = sig.NodeID()
+	ap.Messages[1].Signature = sig.Sign(signing.ATX, ap.Messages[1].SignedBytes())
+	ap.Messages[1].SmesherID = sig.NodeID()
+	mp := &types.MalfeasanceProof{
+		Layer: types.LayerID(layer),
+		Proof: types.Proof{
+			Type: types.MultipleATXs,
+			Data: &ap,
+		},
+	}
+	data, err := codec.Encode(mp)
+	require.NoError(tb, err)
+	require.NoError(tb, identities.SetMalicious(db, sig.NodeID(), data, time.Now()))
+	return sig.NodeID(), mp
+}
+
+func BallotMalfeasance(tb testing.TB, db sql.Executor) (types.NodeID, *types.MalfeasanceProof) {
+	sig, err := signing.NewEdSigner()
+	require.NoError(tb, err)
+	bp := types.BallotProof{
+		Messages: [2]types.BallotProofMsg{
+			{
+				InnerMsg: types.BallotMetadata{
+					Layer:   types.LayerID(layer),
+					MsgHash: types.RandomHash(),
+				},
+			},
+			{
+				InnerMsg: types.BallotMetadata{
+					Layer:   types.LayerID(layer),
+					MsgHash: types.RandomHash(),
+				},
+			},
+		},
+	}
+	bp.Messages[0].Signature = sig.Sign(signing.BALLOT, bp.Messages[0].SignedBytes())
+	bp.Messages[0].SmesherID = sig.NodeID()
+	bp.Messages[1].Signature = sig.Sign(signing.BALLOT, bp.Messages[1].SignedBytes())
+	bp.Messages[1].SmesherID = sig.NodeID()
+	mp := &types.MalfeasanceProof{
+		Layer: types.LayerID(layer),
+		Proof: types.Proof{
+			Type: types.MultipleBallots,
+			Data: &bp,
+		},
+	}
+	data, err := codec.Encode(mp)
+	require.NoError(tb, err)
+	require.NoError(tb, identities.SetMalicious(db, sig.NodeID(), data, time.Now()))
+	return sig.NodeID(), mp
+}
+
+func HareMalfeasance(tb testing.TB, db sql.Executor) (types.NodeID, *types.MalfeasanceProof) {
+	sig, err := signing.NewEdSigner()
+	require.NoError(tb, err)
+	hp := types.HareProof{
+		Messages: [2]types.HareProofMsg{
+			{
+				InnerMsg: types.HareMetadata{
+					Layer:   types.LayerID(layer),
+					Round:   3,
+					MsgHash: types.RandomHash(),
+				},
+			},
+			{
+				InnerMsg: types.HareMetadata{
+					Layer:   types.LayerID(layer),
+					Round:   3,
+					MsgHash: types.RandomHash(),
+				},
+			},
+		},
+	}
+	hp.Messages[0].Signature = sig.Sign(signing.HARE, hp.Messages[0].SignedBytes())
+	hp.Messages[0].SmesherID = sig.NodeID()
+	hp.Messages[1].Signature = sig.Sign(signing.HARE, hp.Messages[1].SignedBytes())
+	hp.Messages[1].SmesherID = sig.NodeID()
+	mp := &types.MalfeasanceProof{
+		Layer: types.LayerID(layer),
+		Proof: types.Proof{
+			Type: types.HareEquivocation,
+			Data: &hp,
+		},
+	}
+	data, err := codec.Encode(mp)
+	require.NoError(tb, err)
+	require.NoError(tb, identities.SetMalicious(db, sig.NodeID(), data, time.Now()))
+	return sig.NodeID(), mp
+}
+
+func TestMeshService_MalfeasanceQuery(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	genTime := NewMockgenesisTimeAPI(ctrl)
+	db := sql.InMemory()
+	srv := NewMeshService(datastore.NewCachedDB(db, logtest.New(t)), meshAPIMock, conStateAPI, genTime, layersPerEpoch, types.Hash20{}, layerDuration, layerAvgSize, txsPerProposal, logtest.New(t).WithName("grpc.Mesh"))
+	t.Cleanup(launchServer(t, cfg, srv))
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	conn := dialGrpc(ctx, t, cfg.PublicListener)
+	client := pb.NewMeshServiceClient(conn)
+	nodeID, proof := BallotMalfeasance(t, db)
+
+	req := &pb.MalfeasanceRequest{
+		Smesher:      &pb.SmesherId{Id: nodeID.Bytes()},
+		IncludeProof: true,
+	}
+	resp, err := client.MalfeasanceQuery(context.Background(), req)
+	require.NoError(t, err)
+	require.Equal(t, nodeID, types.BytesToNodeID(resp.Proof.SmesherId.Id))
+	require.EqualValues(t, layer, resp.Proof.Layer.Number)
+	require.Equal(t, pb.MalfeasanceProof_MALFEASANCE_BALLOT, resp.Proof.Kind)
+	require.Equal(t, events.ToMalfeasancePB(nodeID, proof, true), resp.Proof)
+	require.NotEmpty(t, resp.Proof.Proof)
+	var got types.MalfeasanceProof
+	require.NoError(t, codec.Decode(resp.Proof.Proof, &got))
+	require.Equal(t, *proof, got)
+
+	req.IncludeProof = false
+	resp, err = client.MalfeasanceQuery(context.Background(), req)
+	require.NoError(t, err)
+	require.Empty(t, resp.Proof.Proof)
+}
+
+func TestMeshService_MalfeasanceStream(t *testing.T) {
+	events.InitializeReporter()
+	t.Cleanup(events.CloseEventReporter)
+
+	ctrl := gomock.NewController(t)
+	genTime := NewMockgenesisTimeAPI(ctrl)
+	db := sql.InMemory()
+	srv := NewMeshService(datastore.NewCachedDB(db, logtest.New(t)), meshAPIMock, conStateAPI, genTime, layersPerEpoch, types.Hash20{}, layerDuration, layerAvgSize, txsPerProposal, logtest.New(t).WithName("grpc.Mesh"))
+	t.Cleanup(launchServer(t, cfg, srv))
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	conn := dialGrpc(ctx, t, cfg.PublicListener)
+	client := pb.NewMeshServiceClient(conn)
+
+	for i := 0; i < 10; i++ {
+		AtxMalfeasance(t, db)
+		BallotMalfeasance(t, db)
+		HareMalfeasance(t, db)
+	}
+
+	stream, err := client.MalfeasanceStream(ctx, &pb.MalfeasanceStreamRequest{})
+	require.NoError(t, err)
+	_, err = stream.Header()
+	require.NoError(t, err)
+
+	var total, atx, ballot, hare int
+	for i := 0; i < 30; i++ {
+		resp, err := stream.Recv()
+		require.NoError(t, err)
+		total++
+		got := resp.Proof
+		switch got.Kind {
+		case pb.MalfeasanceProof_MALFEASANCE_ATX:
+			atx++
+		case pb.MalfeasanceProof_MALFEASANCE_BALLOT:
+			ballot++
+		case pb.MalfeasanceProof_MALFEASANCE_HARE:
+			hare++
+		}
+		require.EqualValues(t, got.Layer.Number, layer)
+	}
+	require.Equal(t, 30, total)
+	require.Equal(t, 10, atx)
+	require.Equal(t, 10, ballot)
+	require.Equal(t, 10, hare)
+
+	id, proof := AtxMalfeasance(t, db)
+	events.ReportMalfeasance(id, proof)
+	resp, err := stream.Recv()
+	require.NoError(t, err)
+	require.Equal(t, events.ToMalfeasancePB(id, proof, false), resp.Proof)
+	id, proof = BallotMalfeasance(t, db)
+	events.ReportMalfeasance(id, proof)
+	resp, err = stream.Recv()
+	require.NoError(t, err)
+	require.Equal(t, events.ToMalfeasancePB(id, proof, false), resp.Proof)
+}

--- a/api/grpcserver/mesh_service_test.go
+++ b/api/grpcserver/mesh_service_test.go
@@ -2,6 +2,7 @@ package grpcserver
 
 import (
 	"context"
+	"encoding/hex"
 	"testing"
 	"time"
 
@@ -148,7 +149,7 @@ func TestMeshService_MalfeasanceQuery(t *testing.T) {
 	nodeID, proof := BallotMalfeasance(t, db)
 
 	req := &pb.MalfeasanceRequest{
-		Smesher:      &pb.SmesherId{Id: nodeID.Bytes()},
+		SmesherHex:   hex.EncodeToString(nodeID.Bytes()),
 		IncludeProof: true,
 	}
 	resp, err := client.MalfeasanceQuery(context.Background(), req)

--- a/api/grpcserver/mocks.go
+++ b/api/grpcserver/mocks.go
@@ -337,6 +337,21 @@ func (mr *MockatxProviderMockRecorder) GetFullAtx(id interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFullAtx", reflect.TypeOf((*MockatxProvider)(nil).GetFullAtx), id)
 }
 
+// GetMalfeasanceProof mocks base method.
+func (m *MockatxProvider) GetMalfeasanceProof(id types.NodeID) (*types.MalfeasanceProof, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMalfeasanceProof", id)
+	ret0, _ := ret[0].(*types.MalfeasanceProof)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetMalfeasanceProof indicates an expected call of GetMalfeasanceProof.
+func (mr *MockatxProviderMockRecorder) GetMalfeasanceProof(id interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMalfeasanceProof", reflect.TypeOf((*MockatxProvider)(nil).GetMalfeasanceProof), id)
+}
+
 // MaxHeightAtx mocks base method.
 func (m *MockatxProvider) MaxHeightAtx() (types.ATXID, error) {
 	m.ctrl.T.Helper()

--- a/common/types/malfeasance.go
+++ b/common/types/malfeasance.go
@@ -1,7 +1,10 @@
 package types
 
 import (
+	"encoding/hex"
 	"errors"
+	"fmt"
+	"strings"
 	"time"
 
 	"github.com/spacemeshos/go-scale"
@@ -246,4 +249,41 @@ func (m *HareProofMsg) SignedBytes() []byte {
 		log.With().Fatal("failed to serialize MultiBlockProposalsMsg", log.Err(err))
 	}
 	return data
+}
+
+func MalfeasanceInfo(smesher NodeID, mp *MalfeasanceProof) string {
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("generate layer: %v\n", mp.Layer))
+	b.WriteString(fmt.Sprintf("smesher id: %s\n", smesher.String()))
+	switch mp.Proof.Type {
+	case MultipleATXs:
+		p, ok := mp.Proof.Data.(*AtxProof)
+		if ok {
+			b.WriteString(fmt.Sprintf("cause: smesher published multiple ATXs in epoch %d\n", p.Messages[0].InnerMsg.PublishEpoch))
+			b.WriteString(fmt.Sprintf("1st message hash: %s\n", hex.EncodeToString(p.Messages[0].InnerMsg.MsgHash.Bytes())))
+			b.WriteString(fmt.Sprintf("1st message signature: %s\n", hex.EncodeToString(p.Messages[0].Signature.Bytes())))
+			b.WriteString(fmt.Sprintf("2nd message hash: %s\n", hex.EncodeToString(p.Messages[1].InnerMsg.MsgHash.Bytes())))
+			b.WriteString(fmt.Sprintf("2nd message signature: %s\n", hex.EncodeToString(p.Messages[1].Signature.Bytes())))
+		}
+	case MultipleBallots:
+		p, ok := mp.Proof.Data.(*BallotProof)
+		if ok {
+			b.WriteString(fmt.Sprintf("cause: smesher published multiple ballots in layer %d\n", p.Messages[0].InnerMsg.Layer))
+			b.WriteString(fmt.Sprintf("1st message hash: %s\n", hex.EncodeToString(p.Messages[0].InnerMsg.MsgHash.Bytes())))
+			b.WriteString(fmt.Sprintf("1st message signature: %s\n", hex.EncodeToString(p.Messages[0].Signature.Bytes())))
+			b.WriteString(fmt.Sprintf("2nd message hash: %s\n", hex.EncodeToString(p.Messages[1].InnerMsg.MsgHash.Bytes())))
+			b.WriteString(fmt.Sprintf("2nd message signature: %s\n", hex.EncodeToString(p.Messages[1].Signature.Bytes())))
+		}
+	case HareEquivocation:
+		p, ok := mp.Proof.Data.(*HareProof)
+		if ok {
+			b.WriteString(fmt.Sprintf("cause: smesher published multiple hare messages in layer %d round %d\n",
+				p.Messages[0].InnerMsg.Layer, p.Messages[0].InnerMsg.Round))
+			b.WriteString(fmt.Sprintf("1st message hash: %s\n", hex.EncodeToString(p.Messages[0].InnerMsg.MsgHash.Bytes())))
+			b.WriteString(fmt.Sprintf("1st message signature: %s\n", hex.EncodeToString(p.Messages[0].Signature.Bytes())))
+			b.WriteString(fmt.Sprintf("2nd message hash: %s\n", hex.EncodeToString(p.Messages[1].InnerMsg.MsgHash.Bytes())))
+			b.WriteString(fmt.Sprintf("2nd message signature: %s\n", hex.EncodeToString(p.Messages[1].Signature.Bytes())))
+		}
+	}
+	return b.String()
 }

--- a/datastore/store.go
+++ b/datastore/store.go
@@ -228,6 +228,23 @@ func (db *CachedDB) IterateEpochATXHeaders(epoch types.EpochID, iter func(*types
 	return nil
 }
 
+func (db *CachedDB) IterateMalfeasanceProofs(iter func(types.NodeID, *types.MalfeasanceProof) error) error {
+	ids, err := identities.GetMalicious(db)
+	if err != nil {
+		return err
+	}
+	for _, id := range ids {
+		proof, err := db.GetMalfeasanceProof(id)
+		if err != nil {
+			return err
+		}
+		if err := iter(id, proof); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // GetLastAtx gets the last atx header of specified node ID.
 func (db *CachedDB) GetLastAtx(nodeID types.NodeID) (*types.ActivationTxHeader, error) {
 	if atxid, err := atxs.GetLastIDByNodeID(db, nodeID); err != nil {

--- a/events/events.go
+++ b/events/events.go
@@ -1,12 +1,16 @@
 package events
 
 import (
+	"encoding/hex"
+	"fmt"
+	"strings"
 	"time"
 
 	pb "github.com/spacemeshos/api/release/go/spacemesh/v1"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"github.com/spacemeshos/go-spacemesh/codec"
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/log"
 )
@@ -213,6 +217,19 @@ func EmitProposal(layer types.LayerID, proposal types.ProposalID) {
 	)
 }
 
+func EmitOwnMalfeasanceProof(id types.NodeID, mp *types.MalfeasanceProof) {
+	const help = "Committed malicious behavior. Identity will be canceled."
+	emitUserEvent(
+		help,
+		false,
+		&pb.Event_Malfeasance{
+			Malfeasance: &pb.EventMalfeasance{
+				Proof: ToMalfeasancePB(id, mp, false),
+			},
+		},
+	)
+}
+
 func emitUserEvent(help string, failure bool, details pb.IsEventDetails) {
 	mu.RLock()
 	defer mu.RUnlock()
@@ -226,4 +243,67 @@ func emitUserEvent(help string, failure bool, details pb.IsEventDetails) {
 			log.With().Error("failed to emit event", log.Err(err))
 		}
 	}
+}
+
+func ToMalfeasancePB(smesher types.NodeID, mp *types.MalfeasanceProof, includeProof bool) *pb.MalfeasanceProof {
+	if mp == nil {
+		return &pb.MalfeasanceProof{}
+	}
+	kind := pb.MalfeasanceProof_MALFEASANCE_UNSPECIFIED
+	switch mp.Proof.Type {
+	case types.MultipleATXs:
+		kind = pb.MalfeasanceProof_MALFEASANCE_ATX
+	case types.MultipleBallots:
+		kind = pb.MalfeasanceProof_MALFEASANCE_BALLOT
+	case types.HareEquivocation:
+		kind = pb.MalfeasanceProof_MALFEASANCE_HARE
+	}
+	result := &pb.MalfeasanceProof{
+		SmesherId: &pb.SmesherId{Id: smesher.Bytes()},
+		Layer:     &pb.LayerNumber{Number: mp.Layer.Uint32()},
+		Kind:      kind,
+		DebugInfo: MalfeasanceInfo(smesher, mp),
+	}
+	if includeProof {
+		data, _ := codec.Encode(mp)
+		result.Proof = data
+	}
+	return result
+}
+
+func MalfeasanceInfo(smesher types.NodeID, mp *types.MalfeasanceProof) string {
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("generate layer: %v\n", mp.Layer))
+	b.WriteString(fmt.Sprintf("smesher id: %v\n", smesher))
+	switch mp.Proof.Type {
+	case types.MultipleATXs:
+		p, ok := mp.Proof.Data.(*types.AtxProof)
+		if ok {
+			b.WriteString(fmt.Sprintf("cause: smesher published multiple ATXs in epoch %d\n", p.Messages[0].InnerMsg.PublishEpoch))
+			b.WriteString(fmt.Sprintf("1st message hash: %s\n", hex.EncodeToString(p.Messages[0].InnerMsg.MsgHash.Bytes())))
+			b.WriteString(fmt.Sprintf("1st message signature: %s\n", hex.EncodeToString(p.Messages[0].Signature.Bytes())))
+			b.WriteString(fmt.Sprintf("2nd message hash: %s\n", hex.EncodeToString(p.Messages[1].InnerMsg.MsgHash.Bytes())))
+			b.WriteString(fmt.Sprintf("2nd message signature: %s\n", hex.EncodeToString(p.Messages[1].Signature.Bytes())))
+		}
+	case types.MultipleBallots:
+		p, ok := mp.Proof.Data.(*types.BallotProof)
+		if ok {
+			b.WriteString(fmt.Sprintf("cause: smesher published multiple ballots in layer %d\n", p.Messages[0].InnerMsg.Layer))
+			b.WriteString(fmt.Sprintf("1st message hash: %s\n", hex.EncodeToString(p.Messages[0].InnerMsg.MsgHash.Bytes())))
+			b.WriteString(fmt.Sprintf("1st message signature: %s\n", hex.EncodeToString(p.Messages[0].Signature.Bytes())))
+			b.WriteString(fmt.Sprintf("2nd message hash: %s\n", hex.EncodeToString(p.Messages[1].InnerMsg.MsgHash.Bytes())))
+			b.WriteString(fmt.Sprintf("2nd message signature: %s\n", hex.EncodeToString(p.Messages[1].Signature.Bytes())))
+		}
+	case types.HareEquivocation:
+		p, ok := mp.Proof.Data.(*types.HareProof)
+		if ok {
+			b.WriteString(fmt.Sprintf("cause: smesher published multiple hare messages in layer %d round %d\n",
+				p.Messages[0].InnerMsg.Layer, p.Messages[0].InnerMsg.Round))
+			b.WriteString(fmt.Sprintf("1st message hash: %s\n", hex.EncodeToString(p.Messages[0].InnerMsg.MsgHash.Bytes())))
+			b.WriteString(fmt.Sprintf("1st message signature: %s\n", hex.EncodeToString(p.Messages[0].Signature.Bytes())))
+			b.WriteString(fmt.Sprintf("2nd message hash: %s\n", hex.EncodeToString(p.Messages[1].InnerMsg.MsgHash.Bytes())))
+			b.WriteString(fmt.Sprintf("2nd message signature: %s\n", hex.EncodeToString(p.Messages[1].Signature.Bytes())))
+		}
+	}
+	return b.String()
 }

--- a/events/events.go
+++ b/events/events.go
@@ -1,9 +1,6 @@
 package events
 
 import (
-	"encoding/hex"
-	"fmt"
-	"strings"
 	"time"
 
 	pb "github.com/spacemeshos/api/release/go/spacemesh/v1"
@@ -262,48 +259,11 @@ func ToMalfeasancePB(smesher types.NodeID, mp *types.MalfeasanceProof, includePr
 		SmesherId: &pb.SmesherId{Id: smesher.Bytes()},
 		Layer:     &pb.LayerNumber{Number: mp.Layer.Uint32()},
 		Kind:      kind,
-		DebugInfo: MalfeasanceInfo(smesher, mp),
+		DebugInfo: types.MalfeasanceInfo(smesher, mp),
 	}
 	if includeProof {
 		data, _ := codec.Encode(mp)
 		result.Proof = data
 	}
 	return result
-}
-
-func MalfeasanceInfo(smesher types.NodeID, mp *types.MalfeasanceProof) string {
-	var b strings.Builder
-	b.WriteString(fmt.Sprintf("generate layer: %v\n", mp.Layer))
-	b.WriteString(fmt.Sprintf("smesher id: %v\n", smesher))
-	switch mp.Proof.Type {
-	case types.MultipleATXs:
-		p, ok := mp.Proof.Data.(*types.AtxProof)
-		if ok {
-			b.WriteString(fmt.Sprintf("cause: smesher published multiple ATXs in epoch %d\n", p.Messages[0].InnerMsg.PublishEpoch))
-			b.WriteString(fmt.Sprintf("1st message hash: %s\n", hex.EncodeToString(p.Messages[0].InnerMsg.MsgHash.Bytes())))
-			b.WriteString(fmt.Sprintf("1st message signature: %s\n", hex.EncodeToString(p.Messages[0].Signature.Bytes())))
-			b.WriteString(fmt.Sprintf("2nd message hash: %s\n", hex.EncodeToString(p.Messages[1].InnerMsg.MsgHash.Bytes())))
-			b.WriteString(fmt.Sprintf("2nd message signature: %s\n", hex.EncodeToString(p.Messages[1].Signature.Bytes())))
-		}
-	case types.MultipleBallots:
-		p, ok := mp.Proof.Data.(*types.BallotProof)
-		if ok {
-			b.WriteString(fmt.Sprintf("cause: smesher published multiple ballots in layer %d\n", p.Messages[0].InnerMsg.Layer))
-			b.WriteString(fmt.Sprintf("1st message hash: %s\n", hex.EncodeToString(p.Messages[0].InnerMsg.MsgHash.Bytes())))
-			b.WriteString(fmt.Sprintf("1st message signature: %s\n", hex.EncodeToString(p.Messages[0].Signature.Bytes())))
-			b.WriteString(fmt.Sprintf("2nd message hash: %s\n", hex.EncodeToString(p.Messages[1].InnerMsg.MsgHash.Bytes())))
-			b.WriteString(fmt.Sprintf("2nd message signature: %s\n", hex.EncodeToString(p.Messages[1].Signature.Bytes())))
-		}
-	case types.HareEquivocation:
-		p, ok := mp.Proof.Data.(*types.HareProof)
-		if ok {
-			b.WriteString(fmt.Sprintf("cause: smesher published multiple hare messages in layer %d round %d\n",
-				p.Messages[0].InnerMsg.Layer, p.Messages[0].InnerMsg.Round))
-			b.WriteString(fmt.Sprintf("1st message hash: %s\n", hex.EncodeToString(p.Messages[0].InnerMsg.MsgHash.Bytes())))
-			b.WriteString(fmt.Sprintf("1st message signature: %s\n", hex.EncodeToString(p.Messages[0].Signature.Bytes())))
-			b.WriteString(fmt.Sprintf("2nd message hash: %s\n", hex.EncodeToString(p.Messages[1].InnerMsg.MsgHash.Bytes())))
-			b.WriteString(fmt.Sprintf("2nd message signature: %s\n", hex.EncodeToString(p.Messages[1].Signature.Bytes())))
-		}
-	}
-	return b.String()
 }

--- a/events/malfeasance.go
+++ b/events/malfeasance.go
@@ -1,0 +1,37 @@
+package events
+
+import (
+	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/log"
+)
+
+// EventMalfeasance includes the malfeasance proof.
+type EventMalfeasance struct {
+	Smesher types.NodeID
+	Proof   *types.MalfeasanceProof
+}
+
+// SubscribeMalfeasance subscribes malfeasance events.
+func SubscribeMalfeasance() Subscription {
+	mu.RLock()
+	defer mu.RUnlock()
+	if reporter != nil {
+		sub, err := reporter.bus.Subscribe(new(EventMalfeasance))
+		if err != nil {
+			log.With().Panic("Failed to subscribe to malfeasance proof")
+		}
+		return sub
+	}
+	return nil
+}
+
+// ReportMalfeasance reports a malfeasance proof.
+func ReportMalfeasance(nodeID types.NodeID, mp *types.MalfeasanceProof) {
+	mu.RLock()
+	defer mu.RUnlock()
+	if reporter != nil {
+		if err := reporter.malfeasanceEmitter.Emit(EventMalfeasance{Smesher: nodeID, Proof: mp}); err != nil {
+			log.With().Error("failed to emit malfeasance proof", log.Err(err))
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/pyroscope-io/pyroscope v0.37.2
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/seehuhn/mt19937 v1.0.0
-	github.com/spacemeshos/api/release/go v1.18.0
+	github.com/spacemeshos/api/release/go v1.18.1-0.20230816005645-799e2a2c64e7
 	github.com/spacemeshos/economics v0.1.0
 	github.com/spacemeshos/fixed v0.1.0
 	github.com/spacemeshos/go-scale v1.1.10

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/pyroscope-io/pyroscope v0.37.2
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/seehuhn/mt19937 v1.0.0
-	github.com/spacemeshos/api/release/go v1.18.1-0.20230816145459-03b178b521ff
+	github.com/spacemeshos/api/release/go v1.19.0
 	github.com/spacemeshos/economics v0.1.0
 	github.com/spacemeshos/fixed v0.1.0
 	github.com/spacemeshos/go-scale v1.1.10

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/pyroscope-io/pyroscope v0.37.2
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/seehuhn/mt19937 v1.0.0
-	github.com/spacemeshos/api/release/go v1.18.1-0.20230816005645-799e2a2c64e7
+	github.com/spacemeshos/api/release/go v1.18.1-0.20230816145459-03b178b521ff
 	github.com/spacemeshos/economics v0.1.0
 	github.com/spacemeshos/fixed v0.1.0
 	github.com/spacemeshos/go-scale v1.1.10

--- a/go.sum
+++ b/go.sum
@@ -635,12 +635,8 @@ github.com/smartystreets/goconvey v1.7.2 h1:9RBaZCeXEQ3UselpuwUQHltGVXvdwm6cv1hg
 github.com/smartystreets/goconvey v1.7.2/go.mod h1:Vw0tHAZW6lzCRk3xgdin6fKYcG+G3Pg9vgXWeJpQFMM=
 github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d/go.mod h1:UdhH50NIW0fCiwBSr0co2m7BnFLdv4fQTgdqdJTHFeE=
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
-github.com/spacemeshos/api/release/go v1.18.0 h1:58Ep0+0C9WGYNZJWD1Ijvf3NP8ffb7rT4yJiCa6GuvY=
-github.com/spacemeshos/api/release/go v1.18.0/go.mod h1:nC5g7IVRNxF8Kl/Tzvr7cQeYBwHN4sMTVsIEa6Ebtl4=
-github.com/spacemeshos/api/release/go v1.18.1-0.20230815194447-c5bba9adddc5 h1:m5u1v8FXY53qzRrN+41555h/epkhUsHctzAxvbN2vzM=
-github.com/spacemeshos/api/release/go v1.18.1-0.20230815194447-c5bba9adddc5/go.mod h1:nC5g7IVRNxF8Kl/Tzvr7cQeYBwHN4sMTVsIEa6Ebtl4=
-github.com/spacemeshos/api/release/go v1.18.1-0.20230816005645-799e2a2c64e7 h1:mrVf3ivx0D0BTllYbQAbIYmvQ5FrkHiERDMfkqNrAnw=
-github.com/spacemeshos/api/release/go v1.18.1-0.20230816005645-799e2a2c64e7/go.mod h1:nC5g7IVRNxF8Kl/Tzvr7cQeYBwHN4sMTVsIEa6Ebtl4=
+github.com/spacemeshos/api/release/go v1.18.1-0.20230816145459-03b178b521ff h1:zfNegCytNfTLteAsKMtHelEYYOjOU4nO07k3B0X/RMY=
+github.com/spacemeshos/api/release/go v1.18.1-0.20230816145459-03b178b521ff/go.mod h1:nC5g7IVRNxF8Kl/Tzvr7cQeYBwHN4sMTVsIEa6Ebtl4=
 github.com/spacemeshos/economics v0.1.0 h1:PJAKbhBKqbbdCYTB29pkmc8sYqK3pKUAiuAvQxuSJEg=
 github.com/spacemeshos/economics v0.1.0/go.mod h1:Bz0wRDwCOUP1A6w3cPW6iuUBGME8Tz48sIriYiohsBg=
 github.com/spacemeshos/fixed v0.1.0 h1:20KIGvxLlAsuidQrvuwwHe6PrvqeTKzbJIsScbmnUPQ=

--- a/go.sum
+++ b/go.sum
@@ -637,6 +637,10 @@ github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d/go.mod h1:Udh
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
 github.com/spacemeshos/api/release/go v1.18.0 h1:58Ep0+0C9WGYNZJWD1Ijvf3NP8ffb7rT4yJiCa6GuvY=
 github.com/spacemeshos/api/release/go v1.18.0/go.mod h1:nC5g7IVRNxF8Kl/Tzvr7cQeYBwHN4sMTVsIEa6Ebtl4=
+github.com/spacemeshos/api/release/go v1.18.1-0.20230815194447-c5bba9adddc5 h1:m5u1v8FXY53qzRrN+41555h/epkhUsHctzAxvbN2vzM=
+github.com/spacemeshos/api/release/go v1.18.1-0.20230815194447-c5bba9adddc5/go.mod h1:nC5g7IVRNxF8Kl/Tzvr7cQeYBwHN4sMTVsIEa6Ebtl4=
+github.com/spacemeshos/api/release/go v1.18.1-0.20230816005645-799e2a2c64e7 h1:mrVf3ivx0D0BTllYbQAbIYmvQ5FrkHiERDMfkqNrAnw=
+github.com/spacemeshos/api/release/go v1.18.1-0.20230816005645-799e2a2c64e7/go.mod h1:nC5g7IVRNxF8Kl/Tzvr7cQeYBwHN4sMTVsIEa6Ebtl4=
 github.com/spacemeshos/economics v0.1.0 h1:PJAKbhBKqbbdCYTB29pkmc8sYqK3pKUAiuAvQxuSJEg=
 github.com/spacemeshos/economics v0.1.0/go.mod h1:Bz0wRDwCOUP1A6w3cPW6iuUBGME8Tz48sIriYiohsBg=
 github.com/spacemeshos/fixed v0.1.0 h1:20KIGvxLlAsuidQrvuwwHe6PrvqeTKzbJIsScbmnUPQ=

--- a/go.sum
+++ b/go.sum
@@ -635,8 +635,8 @@ github.com/smartystreets/goconvey v1.7.2 h1:9RBaZCeXEQ3UselpuwUQHltGVXvdwm6cv1hg
 github.com/smartystreets/goconvey v1.7.2/go.mod h1:Vw0tHAZW6lzCRk3xgdin6fKYcG+G3Pg9vgXWeJpQFMM=
 github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d/go.mod h1:UdhH50NIW0fCiwBSr0co2m7BnFLdv4fQTgdqdJTHFeE=
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
-github.com/spacemeshos/api/release/go v1.18.1-0.20230816145459-03b178b521ff h1:zfNegCytNfTLteAsKMtHelEYYOjOU4nO07k3B0X/RMY=
-github.com/spacemeshos/api/release/go v1.18.1-0.20230816145459-03b178b521ff/go.mod h1:nC5g7IVRNxF8Kl/Tzvr7cQeYBwHN4sMTVsIEa6Ebtl4=
+github.com/spacemeshos/api/release/go v1.19.0 h1:QPt1nUuSVQ4DfZPNsSAuJpjjYlbS9HJhDunE7K8rn08=
+github.com/spacemeshos/api/release/go v1.19.0/go.mod h1:nC5g7IVRNxF8Kl/Tzvr7cQeYBwHN4sMTVsIEa6Ebtl4=
 github.com/spacemeshos/economics v0.1.0 h1:PJAKbhBKqbbdCYTB29pkmc8sYqK3pKUAiuAvQxuSJEg=
 github.com/spacemeshos/economics v0.1.0/go.mod h1:Bz0wRDwCOUP1A6w3cPW6iuUBGME8Tz48sIriYiohsBg=
 github.com/spacemeshos/fixed v0.1.0 h1:20KIGvxLlAsuidQrvuwwHe6PrvqeTKzbJIsScbmnUPQ=

--- a/malfeasance/handler.go
+++ b/malfeasance/handler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/codec"
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/datastore"
+	"github.com/spacemeshos/go-spacemesh/events"
 	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/p2p"
 	"github.com/spacemeshos/go-spacemesh/p2p/pubsub"
@@ -29,6 +30,7 @@ type Handler struct {
 	logger     log.Log
 	cdb        *datastore.CachedDB
 	self       p2p.Peer
+	nodeID     types.NodeID
 	cp         consensusProtocol
 	edVerifier SigVerifier
 	tortoise   tortoise
@@ -38,6 +40,7 @@ func NewHandler(
 	cdb *datastore.CachedDB,
 	lg log.Log,
 	self p2p.Peer,
+	nodeID types.NodeID,
 	cp consensusProtocol,
 	edVerifier SigVerifier,
 	tortoise tortoise,
@@ -46,9 +49,18 @@ func NewHandler(
 		logger:     lg,
 		cdb:        cdb,
 		self:       self,
+		nodeID:     nodeID,
 		cp:         cp,
 		edVerifier: edVerifier,
 		tortoise:   tortoise,
+	}
+}
+
+func (h *Handler) reportMalfeasance(smesher types.NodeID, mp *types.MalfeasanceProof) {
+	h.tortoise.OnMalfeasance(smesher)
+	events.ReportMalfeasance(smesher, mp)
+	if h.nodeID == smesher {
+		events.EmitOwnMalfeasanceProof(smesher, mp)
 	}
 }
 
@@ -60,7 +72,7 @@ func (h *Handler) HandleSyncedMalfeasanceProof(ctx context.Context, expHash type
 		h.logger.With().Error("malformed message (sync)", log.Context(ctx), log.Err(err))
 		return errMalformedData
 	}
-	nodeID, err := validateAndSave(ctx, h.logger, h.cdb, h.edVerifier, h.cp, h.tortoise, &types.MalfeasanceGossip{MalfeasanceProof: p})
+	nodeID, err := h.validateAndSave(ctx, &types.MalfeasanceGossip{MalfeasanceProof: p})
 	if err == nil && types.Hash32(nodeID) != expHash {
 		return fmt.Errorf("%w: malfesance proof want %s, got %s", errWrongHash, expHash.ShortString(), nodeID.ShortString())
 	}
@@ -80,40 +92,32 @@ func (h *Handler) HandleMalfeasanceProof(ctx context.Context, peer p2p.Peer, dat
 		if err != nil {
 			return err
 		}
-		h.tortoise.OnMalfeasance(id)
+		h.reportMalfeasance(id, &p.MalfeasanceProof)
 		// node saves malfeasance proof eagerly/atomically with the malicious data.
 		// it has validated the proof before saving to db.
 		updateMetrics(p.Proof)
 		return nil
 	}
-	_, err := validateAndSave(ctx, h.logger, h.cdb, h.edVerifier, h.cp, h.tortoise, &p)
+	_, err := h.validateAndSave(ctx, &p)
 	return err
 }
 
-func validateAndSave(
-	ctx context.Context,
-	logger log.Log,
-	cdb *datastore.CachedDB,
-	edVerifier SigVerifier,
-	cp consensusProtocol,
-	trt tortoise,
-	p *types.MalfeasanceGossip,
-) (types.NodeID, error) {
-	nodeID, err := Validate(ctx, logger, cdb, edVerifier, cp, p)
+func (h *Handler) validateAndSave(ctx context.Context, p *types.MalfeasanceGossip) (types.NodeID, error) {
+	nodeID, err := Validate(ctx, h.logger, h.cdb, h.edVerifier, h.cp, p)
 	if err != nil {
 		return types.EmptyNodeID, err
 	}
-	if err := cdb.WithTx(ctx, func(dbtx *sql.Tx) error {
+	if err := h.cdb.WithTx(ctx, func(dbtx *sql.Tx) error {
 		malicious, err := identities.IsMalicious(dbtx, nodeID)
 		if err != nil {
 			return fmt.Errorf("check known malicious: %w", err)
 		} else if malicious {
-			logger.WithContext(ctx).With().Debug("known malicious identity", log.Stringer("smesher", nodeID))
+			h.logger.WithContext(ctx).With().Debug("known malicious identity", log.Stringer("smesher", nodeID))
 			return ErrKnownProof
 		}
 		encoded, err := codec.Encode(&p.MalfeasanceProof)
 		if err != nil {
-			logger.With().Panic("failed to encode MalfeasanceProof", log.Err(err))
+			h.logger.With().Panic("failed to encode MalfeasanceProof", log.Err(err))
 		}
 		if err := identities.SetMalicious(dbtx, nodeID, encoded, time.Now()); err != nil {
 			return fmt.Errorf("add malfeasance proof: %w", err)
@@ -121,7 +125,7 @@ func validateAndSave(
 		return nil
 	}); err != nil {
 		if !errors.Is(err, ErrKnownProof) {
-			logger.WithContext(ctx).With().Error("failed to save MalfeasanceProof",
+			h.logger.WithContext(ctx).With().Error("failed to save MalfeasanceProof",
 				log.Stringer("smesher", nodeID),
 				log.Inline(p),
 				log.Err(err),
@@ -129,10 +133,10 @@ func validateAndSave(
 		}
 		return types.EmptyNodeID, err
 	}
-	trt.OnMalfeasance(nodeID)
-	cdb.CacheMalfeasanceProof(nodeID, &p.MalfeasanceProof)
+	h.reportMalfeasance(nodeID, &p.MalfeasanceProof)
+	h.cdb.CacheMalfeasanceProof(nodeID, &p.MalfeasanceProof)
 	updateMetrics(p.Proof)
-	logger.WithContext(ctx).With().Info("new malfeasance proof",
+	h.logger.WithContext(ctx).With().Info("new malfeasance proof",
 		log.Stringer("smesher", nodeID),
 		log.Inline(p),
 	)

--- a/malfeasance/handler_test.go
+++ b/malfeasance/handler_test.go
@@ -53,7 +53,7 @@ func TestHandler_HandleMalfeasanceProof_multipleATXs(t *testing.T) {
 	sigVerifier, err := signing.NewEdVerifier()
 	require.NoError(t, err)
 
-	h := malfeasance.NewHandler(datastore.NewCachedDB(db, lg), lg, "self", types.NodeID{}, mcp, sigVerifier, trt)
+	h := malfeasance.NewHandler(datastore.NewCachedDB(db, lg), lg, "self", types.EmptyNodeID, mcp, sigVerifier, trt)
 	sig, err := signing.NewEdSigner()
 	require.NoError(t, err)
 	lid := types.LayerID(11)
@@ -261,7 +261,7 @@ func TestHandler_HandleMalfeasanceProof_multipleBallots(t *testing.T) {
 	sigVerifier, err := signing.NewEdVerifier()
 	require.NoError(t, err)
 
-	h := malfeasance.NewHandler(datastore.NewCachedDB(db, lg), lg, "self", types.NodeID{}, mcp, sigVerifier, trt)
+	h := malfeasance.NewHandler(datastore.NewCachedDB(db, lg), lg, "self", types.EmptyNodeID, mcp, sigVerifier, trt)
 	sig, err := signing.NewEdSigner()
 	require.NoError(t, err)
 	lid := types.LayerID(11)
@@ -476,7 +476,7 @@ func TestHandler_HandleMalfeasanceProof_hareEquivocation(t *testing.T) {
 	sigVerifier, err := signing.NewEdVerifier()
 	require.NoError(t, err)
 
-	h := malfeasance.NewHandler(datastore.NewCachedDB(db, lg), lg, "self", types.NodeID{}, mcp, sigVerifier, trt)
+	h := malfeasance.NewHandler(datastore.NewCachedDB(db, lg), lg, "self", types.EmptyNodeID, mcp, sigVerifier, trt)
 	sig, err := signing.NewEdSigner()
 	require.NoError(t, err)
 	lid := types.LayerID(11)
@@ -706,7 +706,7 @@ func TestHandler_HandleMalfeasanceProof_validateHare(t *testing.T) {
 	sigVerifier, err := signing.NewEdVerifier()
 	require.NoError(t, err)
 
-	h := malfeasance.NewHandler(datastore.NewCachedDB(db, lg), lg, "self", types.NodeID{}, mcp, sigVerifier, trt)
+	h := malfeasance.NewHandler(datastore.NewCachedDB(db, lg), lg, "self", types.EmptyNodeID, mcp, sigVerifier, trt)
 	sig, err := signing.NewEdSigner()
 	require.NoError(t, err)
 	createIdentity(t, db, sig)
@@ -787,7 +787,7 @@ func TestHandler_CrossDomain(t *testing.T) {
 	sigVerifier, err := signing.NewEdVerifier()
 	require.NoError(t, err)
 
-	h := malfeasance.NewHandler(datastore.NewCachedDB(db, lg), lg, "self", types.NodeID{}, mcp, sigVerifier, trt)
+	h := malfeasance.NewHandler(datastore.NewCachedDB(db, lg), lg, "self", types.EmptyNodeID, mcp, sigVerifier, trt)
 	sig, err := signing.NewEdSigner()
 	require.NoError(t, err)
 	createIdentity(t, db, sig)
@@ -845,7 +845,7 @@ func TestHandler_HandleSyncedMalfeasanceProof_multipleATXs(t *testing.T) {
 	sigVerifier, err := signing.NewEdVerifier()
 	require.NoError(t, err)
 
-	h := malfeasance.NewHandler(datastore.NewCachedDB(db, lg), lg, "self", types.NodeID{}, mcp, sigVerifier, trt)
+	h := malfeasance.NewHandler(datastore.NewCachedDB(db, lg), lg, "self", types.EmptyNodeID, mcp, sigVerifier, trt)
 	sig, err := signing.NewEdSigner()
 	require.NoError(t, err)
 	createIdentity(t, db, sig)
@@ -902,7 +902,7 @@ func TestHandler_HandleSyncedMalfeasanceProof_multipleBallots(t *testing.T) {
 	sigVerifier, err := signing.NewEdVerifier()
 	require.NoError(t, err)
 
-	h := malfeasance.NewHandler(datastore.NewCachedDB(db, lg), lg, "self", types.NodeID{}, mcp, sigVerifier, trt)
+	h := malfeasance.NewHandler(datastore.NewCachedDB(db, lg), lg, "self", types.EmptyNodeID, mcp, sigVerifier, trt)
 	sig, err := signing.NewEdSigner()
 	require.NoError(t, err)
 	createIdentity(t, db, sig)
@@ -958,7 +958,7 @@ func TestHandler_HandleSyncedMalfeasanceProof_hareEquivocation(t *testing.T) {
 	sigVerifier, err := signing.NewEdVerifier()
 	require.NoError(t, err)
 
-	h := malfeasance.NewHandler(datastore.NewCachedDB(db, lg), lg, "self", types.NodeID{}, mcp, sigVerifier, trt)
+	h := malfeasance.NewHandler(datastore.NewCachedDB(db, lg), lg, "self", types.EmptyNodeID, mcp, sigVerifier, trt)
 	sig, err := signing.NewEdSigner()
 	require.NoError(t, err)
 	createIdentity(t, db, sig)
@@ -1017,7 +1017,7 @@ func TestHandler_HandleSyncedMalfeasanceProof_wrongHash(t *testing.T) {
 	sigVerifier, err := signing.NewEdVerifier()
 	require.NoError(t, err)
 
-	h := malfeasance.NewHandler(datastore.NewCachedDB(db, lg), lg, "self", types.NodeID{}, mcp, sigVerifier, trt)
+	h := malfeasance.NewHandler(datastore.NewCachedDB(db, lg), lg, "self", types.EmptyNodeID, mcp, sigVerifier, trt)
 	sig, err := signing.NewEdSigner()
 	require.NoError(t, err)
 	createIdentity(t, db, sig)

--- a/malfeasance/handler_test.go
+++ b/malfeasance/handler_test.go
@@ -53,7 +53,7 @@ func TestHandler_HandleMalfeasanceProof_multipleATXs(t *testing.T) {
 	sigVerifier, err := signing.NewEdVerifier()
 	require.NoError(t, err)
 
-	h := malfeasance.NewHandler(datastore.NewCachedDB(db, lg), lg, "self", mcp, sigVerifier, trt)
+	h := malfeasance.NewHandler(datastore.NewCachedDB(db, lg), lg, "self", types.NodeID{}, mcp, sigVerifier, trt)
 	sig, err := signing.NewEdSigner()
 	require.NoError(t, err)
 	lid := types.LayerID(11)
@@ -261,7 +261,7 @@ func TestHandler_HandleMalfeasanceProof_multipleBallots(t *testing.T) {
 	sigVerifier, err := signing.NewEdVerifier()
 	require.NoError(t, err)
 
-	h := malfeasance.NewHandler(datastore.NewCachedDB(db, lg), lg, "self", mcp, sigVerifier, trt)
+	h := malfeasance.NewHandler(datastore.NewCachedDB(db, lg), lg, "self", types.NodeID{}, mcp, sigVerifier, trt)
 	sig, err := signing.NewEdSigner()
 	require.NoError(t, err)
 	lid := types.LayerID(11)
@@ -476,7 +476,7 @@ func TestHandler_HandleMalfeasanceProof_hareEquivocation(t *testing.T) {
 	sigVerifier, err := signing.NewEdVerifier()
 	require.NoError(t, err)
 
-	h := malfeasance.NewHandler(datastore.NewCachedDB(db, lg), lg, "self", mcp, sigVerifier, trt)
+	h := malfeasance.NewHandler(datastore.NewCachedDB(db, lg), lg, "self", types.NodeID{}, mcp, sigVerifier, trt)
 	sig, err := signing.NewEdSigner()
 	require.NoError(t, err)
 	lid := types.LayerID(11)
@@ -706,7 +706,7 @@ func TestHandler_HandleMalfeasanceProof_validateHare(t *testing.T) {
 	sigVerifier, err := signing.NewEdVerifier()
 	require.NoError(t, err)
 
-	h := malfeasance.NewHandler(datastore.NewCachedDB(db, lg), lg, "self", mcp, sigVerifier, trt)
+	h := malfeasance.NewHandler(datastore.NewCachedDB(db, lg), lg, "self", types.NodeID{}, mcp, sigVerifier, trt)
 	sig, err := signing.NewEdSigner()
 	require.NoError(t, err)
 	createIdentity(t, db, sig)
@@ -787,7 +787,7 @@ func TestHandler_CrossDomain(t *testing.T) {
 	sigVerifier, err := signing.NewEdVerifier()
 	require.NoError(t, err)
 
-	h := malfeasance.NewHandler(datastore.NewCachedDB(db, lg), lg, "self", mcp, sigVerifier, trt)
+	h := malfeasance.NewHandler(datastore.NewCachedDB(db, lg), lg, "self", types.NodeID{}, mcp, sigVerifier, trt)
 	sig, err := signing.NewEdSigner()
 	require.NoError(t, err)
 	createIdentity(t, db, sig)
@@ -845,7 +845,7 @@ func TestHandler_HandleSyncedMalfeasanceProof_multipleATXs(t *testing.T) {
 	sigVerifier, err := signing.NewEdVerifier()
 	require.NoError(t, err)
 
-	h := malfeasance.NewHandler(datastore.NewCachedDB(db, lg), lg, "self", mcp, sigVerifier, trt)
+	h := malfeasance.NewHandler(datastore.NewCachedDB(db, lg), lg, "self", types.NodeID{}, mcp, sigVerifier, trt)
 	sig, err := signing.NewEdSigner()
 	require.NoError(t, err)
 	createIdentity(t, db, sig)
@@ -902,7 +902,7 @@ func TestHandler_HandleSyncedMalfeasanceProof_multipleBallots(t *testing.T) {
 	sigVerifier, err := signing.NewEdVerifier()
 	require.NoError(t, err)
 
-	h := malfeasance.NewHandler(datastore.NewCachedDB(db, lg), lg, "self", mcp, sigVerifier, trt)
+	h := malfeasance.NewHandler(datastore.NewCachedDB(db, lg), lg, "self", types.NodeID{}, mcp, sigVerifier, trt)
 	sig, err := signing.NewEdSigner()
 	require.NoError(t, err)
 	createIdentity(t, db, sig)
@@ -958,7 +958,7 @@ func TestHandler_HandleSyncedMalfeasanceProof_hareEquivocation(t *testing.T) {
 	sigVerifier, err := signing.NewEdVerifier()
 	require.NoError(t, err)
 
-	h := malfeasance.NewHandler(datastore.NewCachedDB(db, lg), lg, "self", mcp, sigVerifier, trt)
+	h := malfeasance.NewHandler(datastore.NewCachedDB(db, lg), lg, "self", types.NodeID{}, mcp, sigVerifier, trt)
 	sig, err := signing.NewEdSigner()
 	require.NoError(t, err)
 	createIdentity(t, db, sig)
@@ -1017,7 +1017,7 @@ func TestHandler_HandleSyncedMalfeasanceProof_wrongHash(t *testing.T) {
 	sigVerifier, err := signing.NewEdVerifier()
 	require.NoError(t, err)
 
-	h := malfeasance.NewHandler(datastore.NewCachedDB(db, lg), lg, "self", mcp, sigVerifier, trt)
+	h := malfeasance.NewHandler(datastore.NewCachedDB(db, lg), lg, "self", types.NodeID{}, mcp, sigVerifier, trt)
 	sig, err := signing.NewEdSigner()
 	require.NoError(t, err)
 	createIdentity(t, db, sig)

--- a/node/node.go
+++ b/node/node.go
@@ -848,6 +848,7 @@ func (app *App) initServices(ctx context.Context) error {
 		app.cachedDB,
 		app.addLogger(MalfeasanceLogger, lg),
 		app.host.ID(),
+		app.edSgn.NodeID(),
 		app.hare,
 		app.edVerifier,
 		trtl,


### PR DESCRIPTION
## Motivation
as title
depends on https://github.com/spacemeshos/api/pull/259

## Changes
- add MeshService.MalfeasanceStream and MeshService:MalfeasanceQuery
- add malfeasance proof to ActivationService.Get
- add own malfeasance proof to node event update

## output
```
{
  "proof": {
    "smesherId": {
      "id": "8JhffQsAWuCBQ8YRWrLpOj8tesNx/SKV611TDbPnXCA="
    },
    "layer": {
      "number": 8112
    },
    "kind": "MALFEASANCE_HARE",
    "debugInfo": "generate layer: 8112\nsmesher id: f0985f7d0b005ae08143c6115ab2e93a3f2d7ac371fd2295eb5d530db3e75c20\ncause: smesher published multiple hare messages in layer 8112 round 3\n1st message hash: 9c40b8789bad681d25081f85af7f9a4af87c5d70ac0637934b4e6fc935b9566c\n1st message signature: efdb895917b2303442a3b0c8f455c5cea79f8a2969af2c7f5b3bbbbfa09a77441e3d886e049f39dbf4dc0d49e78537fe3035de2d25d9d295f02c4928677ea107\n2nd message hash: d005c8ff6ece20cb87acc7ea97d5473559a3e197f9a66621505383132515a2ae\n2nd message signature: f3c014fd0f1353896222f22ee71b7fb2a10623394d4905b8ea447ac2e45350e487de04df71448cb19012b897728bb8580499b3e16a5edb546333b432a927d301\n"
  }
}
```