### PR TITLE
[Merged by Bors] - Fix pushing of release docker image

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -31,10 +31,10 @@ jobs:
     - name: Push docker images with version tag to dockerhub
       if: startsWith(github.ref, 'refs/tags/')
       run: |
-        echo "DOCKER_IMAGE_VERSION=${{ github.ref_name }}" >> $GITHUB_ENV
-
+        export DOCKER_IMAGE_VERSION="${{ github.ref_name }}"
         make dockerpush-only
         make dockerpush-bs-only
 
-        "DOCKER_IMAGE_REPO=go-spacemesh" make dockerpush-only
-        "DOCKER_IMAGE_REPO=go-spacemesh" make dockerpush-bs-only
+        export DOCKER_IMAGE_REPO="go-spacemesh"
+        make dockerpush-only
+        make dockerpush-bs-only


### PR DESCRIPTION
## Motivation
Fixes release image not being able to be pushed to Dockerhub.

## Changes
Instead of adding the `IMAGE_VERSION` and `IMAGE_REPO` to the `GITHUB_ENV`, export the variables to be consumed by `make`

## Test Plan
- before change: https://github.com/spacemeshos/go-spacemesh/actions/runs/5879937119/job/15945110779
- after change: https://github.com/spacemeshos/go-spacemesh/actions/runs/5880044833/job/15945440425

(the created tags and images have already been deleted since I used them only for testing)

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
