### PR TITLE
[Merged by Bors] - Add jitter to spread out requests to get poet proof and submit challenge

### DIFF
--- a/activation/activation.go
+++ b/activation/activation.go
@@ -51,8 +51,8 @@ const (
 
 	// Jitter added to the wait time before building a nipost challenge.
 	// It's expressed as % of poet grace period which translates to:
-	// mainnet (grace period 1h) -> 36s
-	// systest (grace period 10s) -> 0.1s
+	//  mainnet (grace period 1h) -> 36s
+	//  systest (grace period 10s) -> 0.1s
 	maxNipostChallengeBuildJitter = 1.0
 )
 

--- a/activation/activation.go
+++ b/activation/activation.go
@@ -46,7 +46,15 @@ func DefaultPoetConfig() PoetConfig {
 	}
 }
 
-const defaultPoetRetryInterval = 5 * time.Second
+const (
+	defaultPoetRetryInterval = 5 * time.Second
+
+	// Jitter added to the wait time before building a nipost challenge.
+	// It's expressed as % of poet grace period which translates to:
+	// mainnet (grace period 1h) -> 36s
+	// systest (grace period 10s) -> 0.1s
+	maxNipostChallengeBuildJitter = 1.0
+)
 
 // Config defines configuration for Builder.
 type Config struct {
@@ -432,8 +440,8 @@ func (b *Builder) buildNIPostChallenge(ctx context.Context) (*types.NIPostChalle
 			ErrATXChallengeExpired, current, -until)
 	}
 	metrics.PublishOntimeWindowLatency.Observe(until.Seconds())
-	if until > b.poetCfg.GracePeriod {
-		wait := until - b.poetCfg.GracePeriod
+	wait := timeToWaitToBuildNipostChallenge(until, b.poetCfg.GracePeriod)
+	if wait >= 0 {
 		b.log.WithContext(ctx).With().Debug("waiting for fresh atxs",
 			log.Duration("till poet round", until),
 			log.Uint32("current epoch", current.Uint32()),
@@ -720,4 +728,9 @@ func SignAndFinalizeAtx(signer *signing.EdSigner, atx *types.ActivationTx) error
 	atx.Signature = signer.Sign(signing.ATX, atx.SignedBytes())
 	atx.SmesherID = signer.NodeID()
 	return atx.Initialize()
+}
+
+func timeToWaitToBuildNipostChallenge(untilRoundStart, gracePeriod time.Duration) time.Duration {
+	jitter := randomDurationInRange(time.Duration(0), gracePeriod*maxNipostChallengeBuildJitter/100.0)
+	return untilRoundStart + jitter - gracePeriod
 }

--- a/activation/nipost.go
+++ b/activation/nipost.go
@@ -33,12 +33,12 @@ const (
 	// Gives the poet service time to generate proof after a round ends (~8s on mainnet).
 	// mainnet -> 8.64s
 	// systest -> 0.36s.
-	MinPoetGetProofJitter = 0.02
+	minPoetGetProofJitter = 0.02
 
 	// The maximum jitter value before querying for the proof.
 	// mainnet -> 17.28s
 	// systest -> 0.72s.
-	MaxPoetGetProofJitter = 0.04
+	maxPoetGetProofJitter = 0.04
 )
 
 //go:generate mockgen -package=activation -destination=./nipost_mocks.go -source=./nipost.go PoetProvingServiceClient
@@ -503,8 +503,8 @@ func randomDurationInRange(min, max time.Duration) time.Duration {
 // Calculate the time to wait before querying for the proof
 // We add a jitter to avoid all nodes querying for the proof at the same time.
 func calcGetProofWaitTime(tillRoundEnd, cycleGap time.Duration) (waitTime time.Duration) {
-	minWaitTime := time.Duration(float64(cycleGap) * MinPoetGetProofJitter / 100.0)
-	maxWaitTime := time.Duration(float64(cycleGap) * MaxPoetGetProofJitter / 100.0)
-	jitter := randomDurationInRange(minWaitTime, maxWaitTime)
+	minJitter := time.Duration(float64(cycleGap) * minPoetGetProofJitter / 100.0)
+	maxJitter := time.Duration(float64(cycleGap) * maxPoetGetProofJitter / 100.0)
+	jitter := randomDurationInRange(minJitter, maxJitter)
 	return tillRoundEnd + jitter
 }

--- a/activation/nipost.go
+++ b/activation/nipost.go
@@ -26,18 +26,18 @@ import (
 const (
 	// Jitter values to avoid all nodes querying the poet at the same time.
 	// Note: the jitter values are represented as a percentage of cycle gap.
-	// mainnet cycle-gap: 12h
-	// systest cycle-gap: 30s.
+	//  mainnet cycle-gap: 12h
+	//  systest cycle-gap: 30s
 
 	// Minimum jitter value before querying for the proof.
 	// Gives the poet service time to generate proof after a round ends (~8s on mainnet).
-	// mainnet -> 8.64s
-	// systest -> 0.36s.
+	//  mainnet -> 8.64s
+	//  systest -> 0.36s
 	minPoetGetProofJitter = 0.02
 
 	// The maximum jitter value before querying for the proof.
-	// mainnet -> 17.28s
-	// systest -> 0.72s.
+	//  mainnet -> 17.28s
+	//  systest -> 0.72s
 	maxPoetGetProofJitter = 0.04
 )
 

--- a/activation/nipost_test.go
+++ b/activation/nipost_test.go
@@ -1086,7 +1086,7 @@ func TestCalculatingGetProofWaitTime(t *testing.T) {
 		cycleGap := 12 * time.Hour
 		waitTime := calcGetProofWaitTime(time.Hour, cycleGap)
 
-		require.Greater(t, waitTime, time.Hour+time.Duration(float64(cycleGap)*MinPoetGetProofJitter/100))
-		require.LessOrEqual(t, waitTime, time.Hour+time.Duration(float64(cycleGap)*MaxPoetGetProofJitter/100))
+		require.Greater(t, waitTime, time.Hour+time.Duration(float64(cycleGap)*minPoetGetProofJitter/100))
+		require.LessOrEqual(t, waitTime, time.Hour+time.Duration(float64(cycleGap)*maxPoetGetProofJitter/100))
 	})
 }

--- a/activation/nipost_test.go
+++ b/activation/nipost_test.go
@@ -1078,21 +1078,15 @@ func TestCalculatingGetProofWaitTime(t *testing.T) {
 	t.Parallel()
 	t.Run("past round end", func(t *testing.T) {
 		t.Parallel()
-		roundEnd := time.Now().Add(-time.Hour)
-		waitTime, jitter := calcGetProofWaitTime(roundEnd, time.Hour*12)
-
-		require.Equal(t, time.Duration(0), waitTime)
-		require.Equal(t, time.Duration(0), jitter)
+		waitTime := calcGetProofWaitTime(-time.Hour, time.Hour*12)
+		require.Less(t, waitTime, time.Duration(0))
 	})
 	t.Run("before round end", func(t *testing.T) {
 		t.Parallel()
-		roundEnd := time.Now().Add(time.Hour)
-		waitTime, jitter := calcGetProofWaitTime(roundEnd, time.Hour*12)
+		cycleGap := 12 * time.Hour
+		waitTime := calcGetProofWaitTime(time.Hour, cycleGap)
 
-		require.Greater(t, waitTime, time.Duration(0))
-		require.LessOrEqual(t, waitTime, time.Hour)
-
-		require.NotZero(t, jitter)
-		require.LessOrEqual(t, jitter, time.Duration(12*float64(time.Hour)*MaxPoetGetProofJitter/100))
+		require.Greater(t, waitTime, time.Hour+time.Duration(float64(cycleGap)*MinPoetGetProofJitter/100))
+		require.LessOrEqual(t, waitTime, time.Hour+time.Duration(float64(cycleGap)*MaxPoetGetProofJitter/100))
 	})
 }


### PR DESCRIPTION
## Motivation
Closes #4860 

## Changes
Add small positive jitter when:
- waiting for a poet round to end (to get proof),
- waiting to build a nipost challenge (to spread out challenge registrations).
Jitter is only added if the round end is in the future to avoid unnecessary wait.

The range of jitter duration is calculated as a percentage of a cycle gap duration so it also works in unit tests and system tests. 

### Jitter before getting the proof
The min and max % (0.02% and 0.04%) were chosen so that on mainnet:
- minimum jitter is roughly equivalent to the time it takes to generate a proof on bare metal poets (it happens after the round ends): 8.64s. This helps avoid situations when many nodes got a 404 response.
- maximum jitter is 2xmin - roughly 17s

### Jitter before submitting challenges
on mainnet:
- min = 0s
- max = 36s (1% of grace period)

## Test Plan
Added unit tests checking calculating wait and jitter times.