### PR TITLE
[Merged by Bors] - Fix out of memory issue when recovering and processing layers in tortoise

### DIFF
--- a/common/types/layer.go
+++ b/common/types/layer.go
@@ -238,7 +238,7 @@ func NewLayer(layerIndex LayerID) *Layer {
 	}
 }
 
-// MinLayer returs minimal nonzero layer.
+// MinLayer returns minimal nonzero layer.
 func MinLayer(i, j LayerID) LayerID {
 	if i == 0 {
 		return j
@@ -250,7 +250,7 @@ func MinLayer(i, j LayerID) LayerID {
 	return j
 }
 
-// MaxLayer returs max layer.
+// MaxLayer returns max layer.
 func MaxLayer(i, j LayerID) LayerID {
 	if i > j {
 		return i

--- a/mesh/mesh.go
+++ b/mesh/mesh.go
@@ -290,10 +290,8 @@ func (msh *Mesh) ProcessLayer(ctx context.Context, lid types.LayerID) error {
 	}
 	results := msh.trtl.Updates()
 	pending := msh.pendingUpdates.min != 0
-	if len(results) > 0 {
-		msh.pendingUpdates.min = types.MinLayer(msh.pendingUpdates.min, results[0].Layer)
-		msh.pendingUpdates.max = types.MaxLayer(msh.pendingUpdates.max, results[len(results)-1].Layer)
-	}
+	msh.pendingUpdates.min = types.MinLayer(msh.pendingUpdates.min, results[0].Layer)
+	msh.pendingUpdates.max = types.MaxLayer(msh.pendingUpdates.max, results[len(results)-1].Layer)
 	next := msh.LatestLayerInState() + 1
 	if next < msh.pendingUpdates.min {
 		msh.pendingUpdates.min = next

--- a/mesh/mesh.go
+++ b/mesh/mesh.go
@@ -290,8 +290,10 @@ func (msh *Mesh) ProcessLayer(ctx context.Context, lid types.LayerID) error {
 	}
 	results := msh.trtl.Updates()
 	pending := msh.pendingUpdates.min != 0
-	msh.pendingUpdates.min = types.MinLayer(msh.pendingUpdates.min, results[0].Layer)
-	msh.pendingUpdates.max = types.MaxLayer(msh.pendingUpdates.max, results[len(results)-1].Layer)
+	if len(results) > 0 {
+		msh.pendingUpdates.min = types.MinLayer(msh.pendingUpdates.min, results[0].Layer)
+		msh.pendingUpdates.max = types.MaxLayer(msh.pendingUpdates.max, results[len(results)-1].Layer)
+	}
 	next := msh.LatestLayerInState() + 1
 	if next < msh.pendingUpdates.min {
 		msh.pendingUpdates.min = next
@@ -335,8 +337,7 @@ func (msh *Mesh) ProcessLayer(ctx context.Context, lid types.LayerID) error {
 		return err
 	}
 	if len(missing) > 0 {
-		lastApplicable := applicable[len(applicable)-1]
-		msh.pendingUpdates.min = types.MinLayer(msh.LatestLayerInState()+1, lastApplicable.Layer)
+		msh.pendingUpdates.min = applicable[len(applicable)-1].Layer
 		msh.pendingUpdates.max = types.MaxLayer(msh.pendingUpdates.min, msh.pendingUpdates.max)
 	} else {
 		msh.pendingUpdates.min = 0

--- a/mesh/mesh.go
+++ b/mesh/mesh.go
@@ -337,7 +337,9 @@ func (msh *Mesh) ProcessLayer(ctx context.Context, lid types.LayerID) error {
 		return err
 	}
 	if len(missing) > 0 {
-		msh.pendingUpdates.min = msh.LatestLayerInState()
+		lastApplicable := applicable[len(applicable)-1]
+		msh.pendingUpdates.min = types.MinLayer(msh.LatestLayerInState()+1, lastApplicable.Layer)
+		msh.pendingUpdates.max = types.MaxLayer(msh.pendingUpdates.min, msh.pendingUpdates.max)
 	} else {
 		msh.pendingUpdates.min = 0
 		msh.pendingUpdates.max = 0

--- a/tortoise/algorithm.go
+++ b/tortoise/algorithm.go
@@ -455,7 +455,7 @@ func (t *Tortoise) results(from, to types.LayerID) ([]result.Layer, error) {
 	if from > to {
 		return nil, fmt.Errorf("requested range (%d - %d) is invalid", from, to)
 	}
-	rst := make([]result.Layer, 0, to-from)
+	rst := make([]result.Layer, 0, to-from+1)
 	for lid := from; lid <= to; lid++ {
 		layer := t.trtl.layer(lid)
 		blocks := make([]result.Block, 0, len(layer.blocks))

--- a/tortoise/algorithm.go
+++ b/tortoise/algorithm.go
@@ -452,6 +452,9 @@ func (t *Tortoise) results(from, to types.LayerID) ([]result.Layer, error) {
 	if from <= t.trtl.evicted {
 		return nil, fmt.Errorf("requested layer %d is before evicted %d", from, t.trtl.evicted)
 	}
+	if from > to {
+		return nil, fmt.Errorf("requested range (%d - %d) is invalid", from, to)
+	}
 	rst := make([]result.Layer, 0, to-from)
 	for lid := from; lid <= to; lid++ {
 		layer := t.trtl.layer(lid)

--- a/tortoise/recover.go
+++ b/tortoise/recover.go
@@ -122,12 +122,13 @@ func RecoverLayer(ctx context.Context, trtl *Tortoise, db *datastore.CachedDB, b
 	}
 	if lid <= current {
 		trtl.TallyVotes(ctx, lid)
-	}
-	opinion, err := layers.GetAggregatedHash(db, lid-1)
-	if err == nil {
-		trtl.resetPending(lid-1, opinion)
-	} else if !errors.Is(err, sql.ErrNotFound) {
-		return fmt.Errorf("check opinion %w", err)
+
+		opinion, err := layers.GetAggregatedHash(db, lid-1)
+		if err == nil {
+			trtl.resetPending(lid-1, opinion)
+		} else if !errors.Is(err, sql.ErrNotFound) {
+			return fmt.Errorf("check opinion %w", err)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
## Motivation
Fix an out of memory issue caused by integer underflow in tortoise.

## Changes
- The requested range can result in an underflow if `t.trtl.pending` is higher than `t.trtl.processed`. Added a check to prevent allocating too much memory (node will still panic but with a clearer message as to why).
- The root cause was identified to be `RecoverLayer` in the `tortoise` package that kept increasing the "pending" layer to beyond "processed"

## Test Plan
n/a

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
