### PR TITLE
[Merged by Bors] - support existing multiple bootstrap files

### DIFF
--- a/bootstrap/updater.go
+++ b/bootstrap/updater.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -212,7 +213,7 @@ func (u *Updater) addUpdate(epoch types.EpochID, suffix string) {
 	switch suffix {
 	case SuffixActiveSet, SuffixBeacon, SuffixBoostrap:
 	default:
-		u.logger.With().Fatal("unexpected suffix for fallback files", log.String("suffix", suffix))
+		return
 	}
 	if _, ok := u.updates[epoch]; !ok {
 		u.updates[epoch] = map[string]struct{}{}
@@ -419,6 +420,33 @@ func validateData(cfg Config, update *Update) (*VerifiedUpdate, error) {
 	return verified, nil
 }
 
+func renameLegacyFile(fs afero.Fs, path string) string {
+	var idx int
+	for _, suffix := range []string{SuffixBoostrap, SuffixBeacon, SuffixActiveSet} {
+		if strings.HasSuffix(path, suffix) {
+			return path
+		}
+	}
+	for _, suffix := range []string{SuffixBoostrap, SuffixBeacon, SuffixActiveSet} {
+		idx = strings.Index(path, fmt.Sprintf("-%s-", suffix))
+		if idx > -1 {
+			break
+		}
+	}
+	if idx < 0 {
+		return ""
+	}
+	newPath := path[:idx+suffixLen+1]
+	if exists, _ := afero.Exists(fs, newPath); exists {
+		_ = fs.Remove(path)
+		return ""
+	}
+	if err := fs.Rename(path, newPath); err != nil {
+		return ""
+	}
+	return newPath
+}
+
 func load(fs afero.Fs, cfg Config, current types.EpochID) ([]*VerifiedUpdate, error) {
 	dir := bootstrapDir(cfg.DataDir)
 	_, err := fs.Stat(dir)
@@ -437,7 +465,10 @@ func load(fs afero.Fs, cfg Config, current types.EpochID) ([]*VerifiedUpdate, er
 			return nil, fmt.Errorf("read epoch dir %v: %w", dir, err)
 		}
 		for _, f := range files {
-			persisted := filepath.Join(edir, f.Name())
+			persisted := renameLegacyFile(fs, filepath.Join(edir, f.Name()))
+			if persisted == "" {
+				continue
+			}
 			data, err := afero.ReadFile(fs, persisted)
 			if err != nil {
 				return nil, fmt.Errorf("read bootstrap file %v: %w", persisted, err)

--- a/bootstrap/updater_test.go
+++ b/bootstrap/updater_test.go
@@ -122,6 +122,97 @@ func checkUpdate4(t *testing.T, got *bootstrap.VerifiedUpdate) {
 
 type checkFunc func(*testing.T, *bootstrap.VerifiedUpdate)
 
+func TestLoad_BackwardCompatible(t *testing.T) {
+	epoch := 2
+	tcs := []struct {
+		desc              string
+		filenames         []string
+		persisted, suffix string
+	}{
+		{
+			desc:      "legacy timestamp bootstrap",
+			filenames: []string{"epoch-2-update-bs-2023-08-10T06-00-08", "epoch-2-update-bs-2023-08-10T08-00-09"},
+			persisted: "epoch-2-update-bs",
+			suffix:    bootstrap.SuffixBoostrap,
+		},
+		{
+			desc:      "legacy timestamp beacon",
+			filenames: []string{"epoch-2-update-bc-2023-08-10T06-00-08", "epoch-2-update-bc-2023-08-10T08-00-09"},
+			persisted: "epoch-2-update-bc",
+			suffix:    bootstrap.SuffixBeacon,
+		},
+		{
+			desc:      "legacy timestamp active set",
+			filenames: []string{"epoch-2-update-as-2023-08-10T06-00-08", "epoch-2-update-as-2023-08-10T08-00-09"},
+			persisted: "epoch-2-update-as",
+			suffix:    bootstrap.SuffixActiveSet,
+		},
+		{
+			desc:      "legacy timestamp huh",
+			filenames: []string{"epoch-2-update-huh-2023-08-10T06-00-08"},
+		},
+		{
+			desc:      "bootstrap",
+			filenames: []string{"epoch-2-update-bs"},
+			persisted: "epoch-2-update-bs",
+			suffix:    bootstrap.SuffixBoostrap,
+		},
+		{
+			desc:      "beacon",
+			filenames: []string{"epoch-2-update-bc"},
+			persisted: "epoch-2-update-bc",
+			suffix:    bootstrap.SuffixBeacon,
+		},
+		{
+			desc:      "active set",
+			filenames: []string{"epoch-2-update-as"},
+			persisted: "epoch-2-update-as",
+			suffix:    bootstrap.SuffixActiveSet,
+		},
+	}
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := bootstrap.DefaultConfig()
+			fs := afero.NewMemMapFs()
+			persistDir := filepath.Join(cfg.DataDir, bootstrap.DirName)
+			for _, file := range tc.filenames {
+				path := filepath.Join(persistDir, strconv.Itoa(epoch), file)
+				require.NoError(t, fs.MkdirAll(path, 0o700))
+				require.NoError(t, afero.WriteFile(fs, path, []byte(update2), 0o400))
+			}
+			mc := bootstrap.NewMocklayerClock(gomock.NewController(t))
+			mc.EXPECT().CurrentLayer().Return(current.FirstLayer())
+			updater := bootstrap.New(
+				mc,
+				bootstrap.WithConfig(cfg),
+				bootstrap.WithLogger(logtest.New(t)),
+				bootstrap.WithFilesystem(fs),
+			)
+			require.NoError(t, updater.Load(context.Background()))
+			if tc.suffix != "" {
+				require.True(t, updater.Downloaded(types.EpochID(epoch), tc.suffix))
+			} else {
+				require.False(t, updater.Downloaded(types.EpochID(epoch), bootstrap.SuffixBoostrap))
+				require.False(t, updater.Downloaded(types.EpochID(epoch), bootstrap.SuffixActiveSet))
+				require.False(t, updater.Downloaded(types.EpochID(epoch), bootstrap.SuffixBeacon))
+			}
+			if tc.persisted != "" {
+				edir := filepath.Join(persistDir, strconv.Itoa(epoch))
+				exists, err := afero.Exists(fs, filepath.Join(edir, tc.persisted))
+				require.NoError(t, err)
+				require.True(t, exists)
+				all, err := afero.ReadDir(fs, edir)
+				require.NoError(t, err)
+				require.Len(t, all, 1)
+				require.Equal(t, tc.persisted, all[0].Name())
+			}
+		})
+	}
+}
+
 func TestLoad(t *testing.T) {
 	tcs := []struct {
 		desc        string
@@ -136,12 +227,12 @@ func TestLoad(t *testing.T) {
 			desc: "recovery required",
 			persisted: map[types.EpochID][]string{
 				current - 2: {bootstrap.SuffixBoostrap, update1},
-				current - 1: {bootstrap.SuffixBoostrap, update2},
+				current - 1: {bootstrap.SuffixActiveSet, update2},
 				current:     {bootstrap.SuffixBeacon, update3},
 				current + 1: {bootstrap.SuffixActiveSet, update4},
 			},
 			cached: map[types.EpochID]string{
-				current - 1: bootstrap.SuffixBoostrap,
+				current - 1: bootstrap.SuffixActiveSet,
 				current:     bootstrap.SuffixBeacon,
 				current + 1: bootstrap.SuffixActiveSet,
 			},


### PR DESCRIPTION
## Motivation
https://github.com/spacemeshos/go-spacemesh/pull/4858 was not a backward compatible fix.

explorer's node running with latest in develop crashed with

```
{"L":"INFO","T":"2023-08-18T16:28:53.473Z","N":"ff765.bootstrap","M":"loaded bootstrap file","node_id":"ff76543be7a1919e65ac9eac4739aa467b0e0baa202825a77b223fc9c791dc70","module":"bootstrap","persisted":"/root/data/node/bootstrap/2/epoch-2-update-bs-2023-08-10T06-00-08","epoch":"2","beacon":"0xe3e3389e","activeset_size":2367,"name":"bootstrap"}
1
{"L":"FATAL","T":"2023-08-18T16:28:53.473Z","N":"ff765.bootstrap","M":"unexpected suffix for fallback files","node_id":"ff76543be7a1919e65ac9eac4739aa467b0e0baa202825a77b223fc9c791dc70","module":"bootstrap","suffix":"08","name":"bootstrap"}
```

## changes
- rename legacy files with timestamp to the correct one ("epoch-2-update-bs-2023-08-10T06-00-08" -> "epoch-2-update-bs")
- delete extra files

## testing
- unit test
- manually test with mainnet. sync a node with mainnet and restart multiple times so that there are multiple boostrap files for epoch 2. run new code and saw that only 1 file left "epoch-2-update-bs"
