### PR TITLE
[Merged by Bors] - miner oracle use ref ballot for active set

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -70,7 +70,8 @@ func (cfg *Config) DataDir() string {
 }
 
 type TestConfig struct {
-	SmesherKey string `mapstructure:"testing-smesher-key"`
+	SmesherKey      string `mapstructure:"testing-smesher-key"`
+	MinerGoodAtxPct int
 }
 
 // BaseConfig defines the default configuration options for spacemesh app.

--- a/config/presets/fastnet.go
+++ b/config/presets/fastnet.go
@@ -22,6 +22,8 @@ func fastnet() config.Config {
 	types.SetNetworkHRP(conf.NetworkHRP) // set to generate coinbase
 	conf.BaseConfig.OptFilterThreshold = 90
 
+	conf.BaseConfig.TestConfig.MinerGoodAtxPct = 50
+
 	conf.HARE.N = 800
 	conf.HARE.ExpectedLeaders = 10
 	conf.HARE.LimitConcurrent = 5

--- a/miner/oracle.go
+++ b/miner/oracle.go
@@ -180,7 +180,7 @@ func (o *Oracle) activeSet(targetEpoch types.EpochID) (uint64, uint64, types.ATX
 
 	if total := numOmitted + len(atxids); total == 0 {
 		return 0, 0, types.EmptyATXID, nil, errEmptyActiveSet
-	} else if numOmitted*100/total > 100-o.cfg.syncedPct {
+	} else if numOmitted*100/total > 100-o.cfg.goodAtxPct {
 		// if the node is not synced during `targetEpoch-1`, it doesn't have the correct receipt timestamp
 		// for all the atx and malfeasance proof. this active set is not usable.
 		// TODO: change after timing info of ATXs and malfeasance proofs is sync'ed from peers as well
@@ -198,6 +198,7 @@ func (o *Oracle) activeSet(targetEpoch types.EpochID) (uint64, uint64, types.ATX
 		o.log.With().Info("active set selected for proposal",
 			log.Int("num atx", len(atxids)),
 			log.Int("num omitted", numOmitted),
+			log.Int("min atx good pct", o.cfg.goodAtxPct),
 		)
 	}
 	return ownWeight, totalWeight, ownAtx, atxids, nil

--- a/miner/oracle.go
+++ b/miner/oracle.go
@@ -190,7 +190,7 @@ func (o *Oracle) activeSet(targetEpoch types.EpochID) (uint64, uint64, types.ATX
 			return 0, 0, types.EmptyATXID, nil, err
 		}
 		o.log.With().Info("miner not synced during prior epoch, active set from first block",
-			log.Int("num atx", len(atxids)),
+			log.Int("all atx", total),
 			log.Int("num omitted", numOmitted),
 			log.Int("num block atx", len(atxids)),
 		)
@@ -209,11 +209,11 @@ func refBallot(db sql.Executor, epoch types.EpochID, nodeID types.NodeID) (*type
 		return nil, nil
 	}
 	if err != nil {
-		return nil, fmt.Errorf("failed to get refballot: %w", err)
+		return nil, fmt.Errorf("miner get refballot: %w", err)
 	}
 	ballot, err := ballots.Get(db, ref)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get ballot: %w", err)
+		return nil, fmt.Errorf("miner get ballot: %w", err)
 	}
 	return ballot, nil
 }
@@ -235,11 +235,11 @@ func (o *Oracle) calcEligibilityProofs(lid types.LayerID, epoch types.EpochID, b
 		minerWeight, totalWeight, ownAtx, activeSet, err = o.activeSet(epoch)
 	} else {
 		activeSet = ref.ActiveSet
-		minerWeight, totalWeight, ownAtx, err = infoFromActiveSet(o.cdb, o.vrfSigner.NodeID(), activeSet)
 		o.log.With().Info("use active set from ref ballot",
 			ref.ID(),
 			log.Int("num atx", len(activeSet)),
 		)
+		minerWeight, totalWeight, ownAtx, err = infoFromActiveSet(o.cdb, o.vrfSigner.NodeID(), activeSet)
 	}
 	if err != nil {
 		return nil, err

--- a/miner/oracle_test.go
+++ b/miner/oracle_test.go
@@ -375,7 +375,7 @@ func TestOracle_NewNode(t *testing.T) {
 			avgLayerSize := uint32(10)
 			lyrsPerEpoch := uint32(20)
 			o := createTestOracle(t, avgLayerSize, lyrsPerEpoch, 0)
-			o.cfg.syncedPct = 90
+			o.cfg.goodAtxPct = 90
 			lid := types.LayerID(lyrsPerEpoch * 3)
 			o.mClock.EXPECT().LayerToTime(gomock.Any()).Return(time.Now())
 			common := types.RandomActiveSet(100)

--- a/miner/oracle_test.go
+++ b/miner/oracle_test.go
@@ -194,7 +194,6 @@ func testMinerOracleAndProposalValidator(t *testing.T, layerSize, layersPerEpoch
 	endLayer := types.LayerID(numberOfEpochsToTest * layersPerEpoch).Add(startLayer)
 	counterValuesSeen := map[uint32]int{}
 	epochStart := time.Now()
-	o.mSync.EXPECT().SyncedBefore(gomock.Any()).Return(true).AnyTimes()
 	o.mClock.EXPECT().LayerToTime(gomock.Any()).Return(epochStart).AnyTimes()
 	received := epochStart.Add(-5 * networkDelay)
 	epochInfo := genATXForTargetEpochs(t, o.cdb, types.EpochID(startEpoch), types.EpochID(startEpoch+numberOfEpochsToTest), o.edSigner, layersPerEpoch, received)
@@ -233,7 +232,6 @@ func TestOracle_OwnATXNotFound(t *testing.T) {
 	layersPerEpoch := uint32(20)
 	o := createTestOracle(t, avgLayerSize, layersPerEpoch, 0)
 	lid := types.LayerID(layersPerEpoch * 3)
-	o.mSync.EXPECT().SyncedBefore(types.EpochID(2)).Return(true)
 	o.mClock.EXPECT().LayerToTime(lid).Return(time.Now())
 	ee, err := o.ProposalEligibility(lid, types.RandomBeacon(), types.VRFPostIndex(1))
 	require.ErrorIs(t, err, errMinerHasNoATXInPreviousEpoch)
@@ -250,7 +248,6 @@ func TestOracle_EligibilityCached(t *testing.T) {
 	info, ok := epochInfo[lid.GetEpoch()]
 	require.True(t, ok)
 	o.mClock.EXPECT().LayerToTime(lid).Return(received.Add(time.Hour)).AnyTimes()
-	o.mSync.EXPECT().SyncedBefore(types.EpochID(2)).Return(true).AnyTimes()
 	ee1, err := o.ProposalEligibility(lid, info.beacon, types.VRFPostIndex(1))
 	require.NoError(t, err)
 	require.NotNil(t, ee1)
@@ -273,7 +270,6 @@ func TestOracle_MinimalActiveSetWeight(t *testing.T) {
 	info, ok := epochInfo[lid.GetEpoch()]
 	require.True(t, ok)
 
-	o.mSync.EXPECT().SyncedBefore(types.EpochID(2)).Return(true).AnyTimes()
 	o.mClock.EXPECT().LayerToTime(lid).Return(received.Add(time.Hour)).AnyTimes()
 	ee1, err := o.ProposalEligibility(lid, info.beacon, types.VRFPostIndex(1))
 	require.NoError(t, err)
@@ -294,7 +290,6 @@ func TestOracle_ATXGrade(t *testing.T) {
 	o := createTestOracle(t, avgLayerSize, layersPerEpoch, 0)
 	lid := types.LayerID(layersPerEpoch * 3)
 	epochStart := time.Now()
-	o.mSync.EXPECT().SyncedBefore(types.EpochID(2)).Return(true)
 	o.mClock.EXPECT().LayerToTime(lid).Return(epochStart)
 
 	goodTime := epochStart.Add(-4*networkDelay - time.Nanosecond)
@@ -362,7 +357,7 @@ func createBallots(tb testing.TB, cdb *datastore.CachedDB, lid types.LayerID, nu
 	return result
 }
 
-func TestOracle_NotSyncedBeforeLastEpoch(t *testing.T) {
+func TestOracle_NewNode(t *testing.T) {
 	for _, tc := range []struct {
 		desc          string
 		ownAtxInBlock bool
@@ -380,8 +375,9 @@ func TestOracle_NotSyncedBeforeLastEpoch(t *testing.T) {
 			avgLayerSize := uint32(10)
 			lyrsPerEpoch := uint32(20)
 			o := createTestOracle(t, avgLayerSize, lyrsPerEpoch, 0)
+			o.cfg.syncedPct = 90
 			lid := types.LayerID(lyrsPerEpoch * 3)
-
+			o.mClock.EXPECT().LayerToTime(gomock.Any()).Return(time.Now())
 			common := types.RandomActiveSet(100)
 			blts := createBallots(t, o.cdb, lid, 20, common)
 			expected := common
@@ -418,7 +414,6 @@ func TestOracle_NotSyncedBeforeLastEpoch(t *testing.T) {
 				expected = append(expected, ownAtx)
 			}
 
-			o.mSync.EXPECT().SyncedBefore(types.EpochID(2)).Return(false)
 			ee, err := o.ProposalEligibility(lid, types.RandomBeacon(), types.VRFPostIndex(1))
 			require.NoError(t, err)
 			require.NotNil(t, ee)
@@ -432,8 +427,6 @@ func TestRefBallot(t *testing.T) {
 	avgLayerSize := uint32(10)
 	lyrsPerEpoch := uint32(20)
 	o := createTestOracle(t, avgLayerSize, lyrsPerEpoch, 0)
-	o.mSync.EXPECT().SyncedBefore(gomock.Any()).Return(true)
-	o.mClock.EXPECT().LayerToTime(gomock.Any()).Return(time.Now())
 
 	layer := types.LayerID(100)
 
@@ -457,8 +450,11 @@ func TestRefBallot(t *testing.T) {
 	ballot.SetID(types.BallotID{1})
 	require.NoError(t, ballots.Add(o.cdb, &ballot))
 
+	genATXForTargetEpochs(t, o.cdb, layer.GetEpoch(), layer.GetEpoch()+1, o.edSigner, layersPerEpoch, time.Now().Add(-1*time.Hour))
 	ee, err := o.calcEligibilityProofs(layer, layer.GetEpoch(), types.Beacon{}, types.VRFPostIndex(101))
 	require.NoError(t, err)
 	require.NotEmpty(t, ee)
 	require.Equal(t, 1, int(ee.Slots))
+	require.Equal(t, atx.ID(), ee.Atx)
+	require.ElementsMatch(t, ballot.ActiveSet, ee.ActiveSet)
 }

--- a/miner/proposal_builder.go
+++ b/miner/proposal_builder.go
@@ -67,6 +67,9 @@ type config struct {
 	minActiveSetWeight uint64
 	nodeID             types.NodeID
 	networkDelay       time.Duration
+
+	// used to determine whether a node has enough information on the active set this epoch
+	syncedPct int
 }
 
 type defaultFetcher struct {
@@ -173,6 +176,7 @@ func NewProposalBuilder(
 	for _, opt := range opts {
 		opt(pb)
 	}
+	pb.cfg.syncedPct = 90
 	if pb.proposalOracle == nil {
 		pb.proposalOracle = newMinerOracle(pb.cfg, clock, cdb, vrfSigner, syncer, pb.logger)
 	}

--- a/miner/proposal_builder.go
+++ b/miner/proposal_builder.go
@@ -69,7 +69,7 @@ type config struct {
 	networkDelay       time.Duration
 
 	// used to determine whether a node has enough information on the active set this epoch
-	syncedPct int
+	goodAtxPct int
 }
 
 type defaultFetcher struct {
@@ -133,6 +133,12 @@ func WithNetworkDelay(delay time.Duration) Opt {
 	}
 }
 
+func WithMinGoodAtxPct(pct int) Opt {
+	return func(pb *ProposalBuilder) {
+		pb.cfg.goodAtxPct = pct
+	}
+}
+
 func withOracle(o proposalOracle) Opt {
 	return func(pb *ProposalBuilder) {
 		pb.proposalOracle = o
@@ -176,7 +182,6 @@ func NewProposalBuilder(
 	for _, opt := range opts {
 		opt(pb)
 	}
-	pb.cfg.syncedPct = 90
 	if pb.proposalOracle == nil {
 		pb.proposalOracle = newMinerOracle(pb.cfg, clock, cdb, vrfSigner, syncer, pb.logger)
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -763,6 +763,11 @@ func (app *App) initServices(ctx context.Context) error {
 		app.addLogger(HareLogger, lg),
 	)
 
+	minerGoodAtxPct := 90
+	if app.Config.TestConfig.MinerGoodAtxPct > 0 {
+		// only set this for systest TestEquivocation.
+		minerGoodAtxPct = app.Config.TestConfig.MinerGoodAtxPct
+	}
 	proposalBuilder := miner.NewProposalBuilder(
 		ctx,
 		app.clock,
@@ -780,6 +785,7 @@ func (app *App) initServices(ctx context.Context) error {
 		miner.WithMinimalActiveSetWeight(app.Config.Tortoise.MinimalActiveSetWeight),
 		miner.WithHdist(app.Config.Tortoise.Hdist),
 		miner.WithNetworkDelay(app.Config.HARE.WakeupDelta),
+		miner.WithMinGoodAtxPct(minerGoodAtxPct),
 		miner.WithLogger(app.addLogger(ProposalBuilderLogger, lg)),
 	)
 

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -214,11 +214,6 @@ func (s *Syncer) IsSynced(ctx context.Context) bool {
 	return s.getSyncState() == synced
 }
 
-// SyncedBefore returns true if the node became synced before `epoch` starts.
-func (s *Syncer) SyncedBefore(epoch types.EpochID) bool {
-	return s.getSyncState() == synced && s.getTargetSyncedLayer() < epoch.FirstLayer()
-}
-
 func (s *Syncer) IsBeaconSynced(epoch types.EpochID) bool {
 	_, err := s.beacon.GetBeacon(epoch)
 	return err == nil

--- a/system/mocks/sync.go
+++ b/system/mocks/sync.go
@@ -62,17 +62,3 @@ func (mr *MockSyncStateProviderMockRecorder) IsSynced(arg0 interface{}) *gomock.
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsSynced", reflect.TypeOf((*MockSyncStateProvider)(nil).IsSynced), arg0)
 }
-
-// SyncedBefore mocks base method.
-func (m *MockSyncStateProvider) SyncedBefore(arg0 types.EpochID) bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SyncedBefore", arg0)
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// SyncedBefore indicates an expected call of SyncedBefore.
-func (mr *MockSyncStateProviderMockRecorder) SyncedBefore(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncedBefore", reflect.TypeOf((*MockSyncStateProvider)(nil).SyncedBefore), arg0)
-}

--- a/system/sync.go
+++ b/system/sync.go
@@ -12,5 +12,4 @@ import (
 type SyncStateProvider interface {
 	IsSynced(context.Context) bool
 	IsBeaconSynced(types.EpochID) bool
-	SyncedBefore(types.EpochID) bool
 }


### PR DESCRIPTION
## Motivation
Closes #4837
Closes #4838

## Changes
- use active set from ref ballot when available
- new criteria to decide if a node should use epoch's first block to derive active set:
  90% of its epoch active set do not have acceptable grade