### PR TITLE
add metrics for optimistic filtering and block execution

### DIFF
--- a/blocks/metrics.go
+++ b/blocks/metrics.go
@@ -69,3 +69,19 @@ func (c *collector) Collect(ch chan<- prometheus.Metric) {
 		ch <- prometheus.MustNewConstMetric(c.epochCertCount, prometheus.CounterValue, float64(cnt), epoch.String())
 	}
 }
+
+var (
+	optimistic = metrics.NewCounter(
+		"opt",
+		namespace,
+		"number of times blocks are optimistically filtered",
+		[]string{},
+	).WithLabelValues()
+
+	agreement = metrics.NewGauge(
+		"agreement",
+		namespace,
+		"percentage agreement on state",
+		[]string{},
+	).WithLabelValues()
+)

--- a/mesh/executor.go
+++ b/mesh/executor.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/datastore"
 	vm "github.com/spacemeshos/go-spacemesh/genvm"
 	"github.com/spacemeshos/go-spacemesh/log"
+	"github.com/spacemeshos/go-spacemesh/mesh/metrics"
 	"github.com/spacemeshos/go-spacemesh/sql/layers"
 	"github.com/spacemeshos/go-spacemesh/sql/transactions"
 	"github.com/spacemeshos/go-spacemesh/txs"
@@ -118,6 +119,7 @@ func (e *Executor) ExecuteOptimistic(
 		log.Int("skipped", len(ineffective)),
 		log.Int("rewards", len(b.Rewards)),
 	)
+	metrics.ExecOpt.Inc()
 	return b, nil
 }
 
@@ -160,6 +162,7 @@ func (e *Executor) Execute(ctx context.Context, lid types.LayerID, block *types.
 		log.Duration("duration", time.Since(start)),
 		log.Int("count", len(executed)),
 	)
+	metrics.Exec.Inc()
 	return nil
 }
 

--- a/mesh/metrics/prometheus.go
+++ b/mesh/metrics/prometheus.go
@@ -21,14 +21,14 @@ var LayerNumBlocks = metrics.NewHistogramWithBuckets(
 )
 
 var ExecOpt = metrics.NewCounter(
-	"opt",
+	"exec_opt",
 	Subsystem,
 	"number of times blocks are optimistically executed",
 	[]string{},
 ).WithLabelValues()
 
 var Exec = metrics.NewCounter(
-	"opt",
+	"exec",
 	Subsystem,
 	"number of times blocks are executed",
 	[]string{},

--- a/mesh/metrics/prometheus.go
+++ b/mesh/metrics/prometheus.go
@@ -19,3 +19,17 @@ var LayerNumBlocks = metrics.NewHistogramWithBuckets(
 	[]string{},
 	prometheus.ExponentialBuckets(1, 2, 16),
 )
+
+var ExecOpt = metrics.NewCounter(
+	"opt",
+	Subsystem,
+	"number of times blocks are optimistically executed",
+	[]string{},
+).WithLabelValues()
+
+var Exec = metrics.NewCounter(
+	"opt",
+	Subsystem,
+	"number of times blocks are executed",
+	[]string{},
+).WithLabelValues()


### PR DESCRIPTION
## Motivation
as title

## Changes
add metrics for
- optimistic filtering is enabled
- percentage agreement on state from proposals
- block executed optimistically
- block executed non-optimistically