### PR TITLE
[Merged by Bors] - datastore: parametrize and increase cache size

### DIFF
--- a/cmd/base.go
+++ b/cmd/base.go
@@ -183,6 +183,10 @@ func EnsureCLIFlags(cmd *cobra.Command, appCFG *config.Config) error {
 			ff = reflect.TypeOf(appCFG.PublicMetrics)
 			elem = reflect.ValueOf(&appCFG.PublicMetrics).Elem()
 			assignFields(ff, elem, name)
+
+			ff = reflect.TypeOf(appCFG.Cache)
+			elem = reflect.ValueOf(&appCFG.Cache).Elem()
+			assignFields(ff, elem, name)
 		}
 	})
 	return nil

--- a/config/config.go
+++ b/config/config.go
@@ -15,6 +15,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/beacon"
 	"github.com/spacemeshos/go-spacemesh/bootstrap"
 	"github.com/spacemeshos/go-spacemesh/checkpoint"
+	"github.com/spacemeshos/go-spacemesh/datastore"
 	"github.com/spacemeshos/go-spacemesh/fetch"
 	vm "github.com/spacemeshos/go-spacemesh/genvm"
 	hareConfig "github.com/spacemeshos/go-spacemesh/hare/config"
@@ -61,6 +62,7 @@ type Config struct {
 	Bootstrap       bootstrap.Config      `mapstructure:"bootstrap"`
 	Sync            syncer.Config         `mapstructure:"syncer"`
 	Recovery        checkpoint.Config     `mapstructure:"recovery"`
+	Cache           datastore.Config      `mapstructure:"cache"`
 }
 
 // DataDir returns the absolute path to use for the node's data. This is the tilde-expanded path given in the config
@@ -150,6 +152,7 @@ func DefaultConfig() Config {
 		Bootstrap:       bootstrap.DefaultConfig(),
 		Sync:            syncer.DefaultConfig(),
 		Recovery:        checkpoint.DefaultConfig(),
+		Cache:           datastore.DefaultConfig(),
 	}
 }
 

--- a/config/mainnet.go
+++ b/config/mainnet.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/beacon"
 	"github.com/spacemeshos/go-spacemesh/bootstrap"
 	"github.com/spacemeshos/go-spacemesh/checkpoint"
+	"github.com/spacemeshos/go-spacemesh/datastore"
 	"github.com/spacemeshos/go-spacemesh/fetch"
 	hareConfig "github.com/spacemeshos/go-spacemesh/hare/config"
 	eligConfig "github.com/spacemeshos/go-spacemesh/hare/eligibility/config"
@@ -138,5 +139,6 @@ func MainnetConfig() Config {
 			Standalone:       false,
 		},
 		Recovery: checkpoint.DefaultConfig(),
+		Cache:    datastore.DefaultConfig(),
 	}
 }

--- a/datastore/store.go
+++ b/datastore/store.go
@@ -20,11 +20,6 @@ import (
 	"github.com/spacemeshos/go-spacemesh/sql/transactions"
 )
 
-const (
-	atxHdrCacheSize      = 2000
-	malfeasanceCacheSize = 1000
-)
-
 type VrfNonceKey struct {
 	ID    types.NodeID
 	Epoch types.EpochID
@@ -85,7 +80,7 @@ func NewCachedDB(db *sql.Database, lg log.Log, opts ...Opt) *CachedDB {
 		lg.Fatal("failed to create malfeasance cache", err)
 	}
 
-	vrfNonceCache, err := lru.New[VrfNonceKey, *types.VRFPostIndex](atxHdrCacheSize)
+	vrfNonceCache, err := lru.New[VrfNonceKey, *types.VRFPostIndex](o.cfg.ATXSize)
 	if err != nil {
 		lg.Fatal("failed to create vrf nonce cache", err)
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -1289,7 +1289,7 @@ func (app *App) setupDBs(ctx context.Context, lg log.Log, dbPath string) error {
 	if app.Config.CollectMetrics {
 		app.dbMetrics = dbmetrics.NewDBMetricsCollector(ctx, sqlDB, app.addLogger(StateDbLogger, lg), 5*time.Minute)
 	}
-	app.cachedDB = datastore.NewCachedDB(sqlDB, app.addLogger(CachedDBLogger, lg))
+	app.cachedDB = datastore.NewCachedDB(sqlDB, app.addLogger(CachedDBLogger, lg), datastore.WithConfig(app.Config.Cache))
 	return nil
 }
 


### PR DESCRIPTION
tried to sync node and noticed that it spends a lot of time looping over activeset in eligibility validation. i will open an issue to optimize that code path, but for now we need to increase number of activations stored in cache.

related: https://github.com/spacemeshos/go-spacemesh/issues/4883