### PR TITLE
Fix nil pointer dereference

### DIFF
--- a/api/grpcserver/admin_service.go
+++ b/api/grpcserver/admin_service.go
@@ -13,6 +13,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/durationpb"
 
 	"github.com/spacemeshos/go-spacemesh/checkpoint"
 	"github.com/spacemeshos/go-spacemesh/common/types"
@@ -31,14 +32,16 @@ type AdminService struct {
 	logger  log.Logger
 	db      *sql.Database
 	dataDir string
+	p       peers
 }
 
 // NewAdminService creates a new admin grpc service.
-func NewAdminService(db *sql.Database, dataDir string, lg log.Logger) *AdminService {
+func NewAdminService(db *sql.Database, dataDir string, lg log.Logger, p peers) *AdminService {
 	return &AdminService{
 		logger:  lg,
 		db:      db,
 		dataDir: dataDir,
+		p:       p,
 	}
 }
 
@@ -127,4 +130,38 @@ func (a AdminService) EventsStream(req *pb.EventStreamRequest, stream pb.AdminSe
 			}
 		}
 	}
+}
+
+func (a AdminService) PeerInfoStream(_ *empty.Empty, stream pb.AdminService_PeerInfoStreamServer) error {
+	for _, p := range a.p.GetPeers() {
+		select {
+		case <-stream.Context().Done():
+			return nil
+		default:
+			info := a.p.ConnectedPeerInfo(p)
+			// There is no guarantee that the peers originally returned will still
+			// be connected by the time we call ConnectedPeerInfo.
+			if info == nil {
+				continue
+			}
+			connections := make([]*pb.ConnectionInfo, len(info.Connections))
+			for j, c := range info.Connections {
+				connections[j] = &pb.ConnectionInfo{
+					Address:  c.Address.String(),
+					Uptime:   durationpb.New(c.Uptime),
+					Outbound: c.Outbound,
+				}
+			}
+			err := stream.Send(&pb.PeerInfo{
+				Id:          info.ID.String(),
+				Connections: connections,
+				Tags:        info.Tags,
+			})
+			if err != nil {
+				return fmt.Errorf("send to stream: %w", err)
+			}
+		}
+	}
+
+	return nil
 }

--- a/api/grpcserver/admin_service_test.go
+++ b/api/grpcserver/admin_service_test.go
@@ -56,7 +56,7 @@ func createMesh(tb testing.TB, db *sql.Database) {
 func TestAdminService_Checkpoint(t *testing.T) {
 	db := sql.InMemory()
 	createMesh(t, db)
-	svc := NewAdminService(db, t.TempDir(), logtest.New(t))
+	svc := NewAdminService(db, t.TempDir(), logtest.New(t), nil)
 	t.Cleanup(launchServer(t, cfg, svc))
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -91,7 +91,7 @@ func TestAdminService_Checkpoint(t *testing.T) {
 
 func TestAdminService_CheckpointError(t *testing.T) {
 	db := sql.InMemory()
-	svc := NewAdminService(db, t.TempDir(), logtest.New(t))
+	svc := NewAdminService(db, t.TempDir(), logtest.New(t), nil)
 	t.Cleanup(launchServer(t, cfg, svc))
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/api/grpcserver/grpc.go
+++ b/api/grpcserver/grpc.go
@@ -19,10 +19,15 @@ type ServiceAPI interface {
 
 // Server is a very basic grpc server.
 type Server struct {
-	Listener   string
-	logger     log.Logger
-	GrpcServer *grpc.Server
-	grp        errgroup.Group
+	Listener string
+	logger   log.Logger
+	// BoundAddress contains the address that the server bound to, useful if
+	// the server uses a dynamic port. It is set during startup and can be
+	// safely accessed after Start has completed (I.E. the returned channel has
+	// been waited on)
+	BoundAddress string
+	GrpcServer   *grpc.Server
+	grp          errgroup.Group
 }
 
 // New creates and returns a new Server with port and interface.
@@ -51,6 +56,7 @@ func (s *Server) Start() error {
 		s.logger.Error("error listening: %v", err)
 		return err
 	}
+	s.BoundAddress = lis.Addr().String()
 	reflection.Register(s.GrpcServer)
 	s.grp.Go(func() error {
 		if err := s.GrpcServer.Serve(lis); err != nil {

--- a/api/grpcserver/interface.go
+++ b/api/grpcserver/interface.go
@@ -60,6 +60,12 @@ type peerCounter interface {
 	PeerCount() uint64
 }
 
+// Peers is an api to get peer related info.
+type peers interface {
+	ConnectedPeerInfo(p2p.Peer) *p2p.PeerInfo
+	GetPeers() []p2p.Peer
+}
+
 // genesisTimeAPI is an API to get genesis time and current layer of the system.
 type genesisTimeAPI interface {
 	GenesisTime() time.Time

--- a/api/grpcserver/mocks.go
+++ b/api/grpcserver/mocks.go
@@ -485,6 +485,57 @@ func (mr *MockpeerCounterMockRecorder) PeerCount() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PeerCount", reflect.TypeOf((*MockpeerCounter)(nil).PeerCount))
 }
 
+// Mockpeers is a mock of peers interface.
+type Mockpeers struct {
+	ctrl     *gomock.Controller
+	recorder *MockpeersMockRecorder
+}
+
+// MockpeersMockRecorder is the mock recorder for Mockpeers.
+type MockpeersMockRecorder struct {
+	mock *Mockpeers
+}
+
+// NewMockpeers creates a new mock instance.
+func NewMockpeers(ctrl *gomock.Controller) *Mockpeers {
+	mock := &Mockpeers{ctrl: ctrl}
+	mock.recorder = &MockpeersMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *Mockpeers) EXPECT() *MockpeersMockRecorder {
+	return m.recorder
+}
+
+// ConnectedPeerInfo mocks base method.
+func (m *Mockpeers) ConnectedPeerInfo(arg0 p2p.Peer) *p2p.PeerInfo {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ConnectedPeerInfo", arg0)
+	ret0, _ := ret[0].(*p2p.PeerInfo)
+	return ret0
+}
+
+// ConnectedPeerInfo indicates an expected call of ConnectedPeerInfo.
+func (mr *MockpeersMockRecorder) ConnectedPeerInfo(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectedPeerInfo", reflect.TypeOf((*Mockpeers)(nil).ConnectedPeerInfo), arg0)
+}
+
+// GetPeers mocks base method.
+func (m *Mockpeers) GetPeers() []p2p.Peer {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPeers")
+	ret0, _ := ret[0].([]p2p.Peer)
+	return ret0
+}
+
+// GetPeers indicates an expected call of GetPeers.
+func (mr *MockpeersMockRecorder) GetPeers() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPeers", reflect.TypeOf((*Mockpeers)(nil).GetPeers))
+}
+
 // MockgenesisTimeAPI is a mock of genesisTimeAPI interface.
 type MockgenesisTimeAPI struct {
 	ctrl     *gomock.Controller

--- a/api/grpcserver/smesher_service.go
+++ b/api/grpcserver/smesher_service.go
@@ -258,6 +258,7 @@ func statusToPbStatus(status *activation.PostSetupStatus) *pb.PostSetupStatus {
 	if status.LastOpts != nil {
 		var providerID *uint32
 		if status.LastOpts.ProviderID.Value() != nil {
+			providerID = new(uint32)
 			*providerID = uint32(*status.LastOpts.ProviderID.Value())
 		}
 

--- a/api/grpcserver/smesher_service_test.go
+++ b/api/grpcserver/smesher_service_test.go
@@ -117,3 +117,85 @@ func TestSmesherService_PostSetupProviders(t *testing.T) {
 	require.EqualValues(t, providers[1].ID, resp.Providers[1].Id)
 	require.Equal(t, uint64(100_000), resp.Providers[1].Performance)
 }
+
+func TestSmesherService_PostSetupStatus(t *testing.T) {
+	t.Run("completed", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		postSetupProvider := activation.NewMockpostSetupProvider(ctrl)
+		smeshingProvider := activation.NewMockSmeshingProvider(ctrl)
+		svc := grpcserver.NewSmesherService(postSetupProvider, smeshingProvider, time.Second, activation.DefaultPostSetupOpts(), logtest.New(t).WithName("grpc.Smesher"))
+
+		postSetupProvider.EXPECT().Status().Return(&activation.PostSetupStatus{
+			State:            activation.PostSetupStateComplete,
+			NumLabelsWritten: 1_000,
+			LastOpts:         nil,
+		})
+		resp, err := svc.PostSetupStatus(context.Background(), &emptypb.Empty{})
+		require.NoError(t, err)
+		require.Equal(t, pb.PostSetupStatus_STATE_COMPLETE, resp.Status.State)
+		require.EqualValues(t, 1_000, resp.Status.NumLabelsWritten)
+		require.Nil(t, resp.Status.Opts)
+	})
+
+	t.Run("completed with last Opts", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		postSetupProvider := activation.NewMockpostSetupProvider(ctrl)
+		smeshingProvider := activation.NewMockSmeshingProvider(ctrl)
+		svc := grpcserver.NewSmesherService(postSetupProvider, smeshingProvider, time.Second, activation.DefaultPostSetupOpts(), logtest.New(t).WithName("grpc.Smesher"))
+
+		id := activation.PostProviderID{}
+		id.SetInt64(1)
+		opts := activation.PostSetupOpts{
+			DataDir:     "data-dir",
+			NumUnits:    4,
+			MaxFileSize: 1024,
+			ProviderID:  id,
+			Throttle:    true,
+		}
+		postSetupProvider.EXPECT().Status().Return(&activation.PostSetupStatus{
+			State:            activation.PostSetupStateComplete,
+			NumLabelsWritten: 1_000,
+			LastOpts:         &opts,
+		})
+		resp, err := svc.PostSetupStatus(context.Background(), &emptypb.Empty{})
+		require.NoError(t, err)
+		require.Equal(t, pb.PostSetupStatus_STATE_COMPLETE, resp.Status.State)
+		require.EqualValues(t, 1_000, resp.Status.NumLabelsWritten)
+		require.Equal(t, "data-dir", resp.Status.Opts.DataDir)
+		require.EqualValues(t, 4, resp.Status.Opts.NumUnits)
+		require.EqualValues(t, 1024, resp.Status.Opts.MaxFileSize)
+		require.EqualValues(t, 1, *resp.Status.Opts.ProviderId)
+		require.True(t, resp.Status.Opts.Throttle)
+	})
+
+	t.Run("in progress", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		postSetupProvider := activation.NewMockpostSetupProvider(ctrl)
+		smeshingProvider := activation.NewMockSmeshingProvider(ctrl)
+		svc := grpcserver.NewSmesherService(postSetupProvider, smeshingProvider, time.Second, activation.DefaultPostSetupOpts(), logtest.New(t).WithName("grpc.Smesher"))
+
+		id := activation.PostProviderID{}
+		id.SetInt64(100)
+		opts := activation.PostSetupOpts{
+			DataDir:     "data-dir",
+			NumUnits:    4,
+			MaxFileSize: 1024,
+			ProviderID:  id,
+			Throttle:    false,
+		}
+		postSetupProvider.EXPECT().Status().Return(&activation.PostSetupStatus{
+			State:            activation.PostSetupStateInProgress,
+			NumLabelsWritten: 1_000,
+			LastOpts:         &opts,
+		})
+		resp, err := svc.PostSetupStatus(context.Background(), &emptypb.Empty{})
+		require.NoError(t, err)
+		require.Equal(t, pb.PostSetupStatus_STATE_IN_PROGRESS, resp.Status.State)
+		require.EqualValues(t, 1_000, resp.Status.NumLabelsWritten)
+		require.Equal(t, "data-dir", resp.Status.Opts.DataDir)
+		require.EqualValues(t, 4, resp.Status.Opts.NumUnits)
+		require.EqualValues(t, 1024, resp.Status.Opts.MaxFileSize)
+		require.EqualValues(t, 100, *resp.Status.Opts.ProviderId)
+		require.False(t, resp.Status.Opts.Throttle)
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/pyroscope-io/pyroscope v0.37.2
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/seehuhn/mt19937 v1.0.0
-	github.com/spacemeshos/api/release/go v1.19.0
+	github.com/spacemeshos/api/release/go v1.20.0
 	github.com/spacemeshos/economics v0.1.0
 	github.com/spacemeshos/fixed v0.1.0
 	github.com/spacemeshos/go-scale v1.1.10

--- a/go.sum
+++ b/go.sum
@@ -606,8 +606,8 @@ github.com/smartystreets/goconvey v1.7.2 h1:9RBaZCeXEQ3UselpuwUQHltGVXvdwm6cv1hg
 github.com/smartystreets/goconvey v1.7.2/go.mod h1:Vw0tHAZW6lzCRk3xgdin6fKYcG+G3Pg9vgXWeJpQFMM=
 github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d/go.mod h1:UdhH50NIW0fCiwBSr0co2m7BnFLdv4fQTgdqdJTHFeE=
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
-github.com/spacemeshos/api/release/go v1.19.0 h1:QPt1nUuSVQ4DfZPNsSAuJpjjYlbS9HJhDunE7K8rn08=
-github.com/spacemeshos/api/release/go v1.19.0/go.mod h1:nC5g7IVRNxF8Kl/Tzvr7cQeYBwHN4sMTVsIEa6Ebtl4=
+github.com/spacemeshos/api/release/go v1.20.0 h1:9HEWDTXyE5mSfca8C5tIXauI1igeUO8CLm5LM6X6y0k=
+github.com/spacemeshos/api/release/go v1.20.0/go.mod h1:nC5g7IVRNxF8Kl/Tzvr7cQeYBwHN4sMTVsIEa6Ebtl4=
 github.com/spacemeshos/economics v0.1.0 h1:PJAKbhBKqbbdCYTB29pkmc8sYqK3pKUAiuAvQxuSJEg=
 github.com/spacemeshos/economics v0.1.0/go.mod h1:Bz0wRDwCOUP1A6w3cPW6iuUBGME8Tz48sIriYiohsBg=
 github.com/spacemeshos/fixed v0.1.0 h1:20KIGvxLlAsuidQrvuwwHe6PrvqeTKzbJIsScbmnUPQ=

--- a/node/adminservice_api_test.go
+++ b/node/adminservice_api_test.go
@@ -1,0 +1,79 @@
+package node
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/libp2p/go-libp2p/core/peer"
+	pb "github.com/spacemeshos/api/release/go/spacemesh/v1"
+	"github.com/stretchr/testify/require"
+
+	"github.com/spacemeshos/go-spacemesh/api/grpcserver"
+	"github.com/spacemeshos/go-spacemesh/config"
+	"github.com/spacemeshos/go-spacemesh/log/logtest"
+)
+
+func TestPeerInfoApi(t *testing.T) {
+	cfg := config.DefaultTestConfig()
+	cfg.P2P.DisableNatPort = true
+	cfg.P2P.Listen = "/ip4/127.0.0.1/tcp/0"
+
+	cfg.API.PublicListener = "0.0.0.0:0"
+	cfg.API.PrivateServices = nil
+	cfg.API.PublicServices = []string{grpcserver.Admin}
+	l := logtest.New(t)
+	networkSize := 3
+	network := NewTestNetwork(t, cfg, l, networkSize)
+	infos := make([][]*pb.PeerInfo, networkSize)
+	for i, app := range network {
+		adminapi := pb.NewAdminServiceClient(app.Conn)
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+		defer cancel()
+
+		streamClient, err := adminapi.PeerInfoStream(ctx, &empty.Empty{})
+		require.NoError(t, err)
+		for {
+			info, err := streamClient.Recv()
+			if err == io.EOF {
+				break
+			}
+			require.NoError(t, err)
+			infos[i] = append(infos[i], info)
+		}
+	}
+
+	for i, app := range network {
+		for j, innerApp := range network {
+			if j == i {
+				continue
+			}
+			peers := infos[i]
+			require.Len(t, peers, networkSize-1, "expecting each node to have connections to all other nodes")
+			peer := getPeerInfo(peers, innerApp.host.ID())
+			require.NotNil(t, peer, "info is missing connection to %v")
+			require.Len(t, peer.Connections, 1, "expecting only 1 connection to each peer")
+			require.Equal(t, innerApp.host.Addrs()[0].String(), peer.Connections[0].Address, "connection address should match address of peer")
+			require.Greater(t, peer.Connections[0].Uptime.AsDuration(), time.Duration(0), "uptime should be set")
+			outbound := peer.Connections[0].Outbound
+
+			// Check that outbound matches with the other side of the connection
+			otherSide := getPeerInfo(infos[j], app.host.ID())
+			require.NotNil(t, peer, "one side missing peer connection")
+			require.Len(t, otherSide.Connections, 1, "expecting only 1 connection to each peer")
+			require.Equal(t, outbound, !otherSide.Connections[0].Outbound, "expecting pairwise connections to agree on outbound direction")
+		}
+	}
+}
+
+func getPeerInfo(peers []*pb.PeerInfo, id peer.ID) *pb.PeerInfo {
+	str := id.String()
+	for _, p := range peers {
+		if str == p.Id {
+			return p
+		}
+	}
+	return nil
+}

--- a/node/node.go
+++ b/node/node.go
@@ -1051,7 +1051,7 @@ func (app *App) initService(ctx context.Context, svc grpcserver.Service) (grpcse
 	case grpcserver.Node:
 		return grpcserver.NewNodeService(app.host, app.mesh, app.clock, app.syncer, cmd.Version, cmd.Commit, logger.WithName("Node")), nil
 	case grpcserver.Admin:
-		return grpcserver.NewAdminService(app.db, app.Config.DataDir(), logger.WithName("Admin")), nil
+		return grpcserver.NewAdminService(app.db, app.Config.DataDir(), logger.WithName("Admin"), app.host), nil
 	case grpcserver.Smesher:
 		return grpcserver.NewSmesherService(app.postSetupMgr, app.atxBuilder, app.Config.API.SmesherStreamInterval, app.Config.SMESHING.Opts, logger.WithName("Smesher")), nil
 	case grpcserver.Transaction:

--- a/node/util_test.go
+++ b/node/util_test.go
@@ -1,0 +1,118 @@
+package node
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/config"
+	"github.com/spacemeshos/go-spacemesh/log"
+)
+
+// NewTestNetwork creates a network of fully connected nodes.
+func NewTestNetwork(t *testing.T, conf config.Config, l log.Log, size int) []*TestApp {
+	// We need to set this global state
+	types.SetLayersPerEpoch(conf.LayersPerEpoch)
+	types.SetNetworkHRP(conf.NetworkHRP) // set to generate coinbase
+
+	// To save an epoch of startup time, we bootstrap (meaning we manually set
+	// it) the beacon for epoch 2 so that in epoch 3 hare can start.
+	bootstrapEpoch := (types.GetEffectiveGenesis() + 1).GetEpoch()
+	bootstrapBeacon := types.Beacon{}
+	genesis := conf.Genesis.GenesisID()
+	copy(bootstrapBeacon[:], genesis[:])
+
+	// This context is used to call Start on a node and canceling it will
+	// shutdown the node. (Hence no timeout has been set).
+	ctx, cancel := context.WithCancel(context.Background())
+	g, grpContext := errgroup.WithContext(ctx)
+	var apps []*TestApp
+
+	t.Cleanup(func() {
+		cancel()
+		// Wait for nodes to shutdown
+		g.Wait()
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+		defer cancel()
+		for _, a := range apps {
+			a.Cleanup(ctx)
+		}
+	})
+
+	for i := 0; i < size; i++ {
+		// Copy config, services don't modify their config, so we just need to
+		// be careful here when we modify any pointer values in the config.
+		c := conf
+		dir := t.TempDir()
+		c.DataDirParent = dir
+		c.SMESHING.Opts.DataDir = dir
+		c.SMESHING.CoinbaseAccount = types.GenerateAddress([]byte(strconv.Itoa(i))).String()
+		c.FileLock = filepath.Join(c.DataDirParent, "LOCK")
+
+		app := NewApp(t, &c, l)
+		instanceIndex := i
+		g.Go(func() error {
+			err := app.Start(grpContext)
+			if err != nil && !errors.Is(err, context.Canceled) {
+				t.Logf("failed to start instance %d: %v", instanceIndex, err)
+			}
+			return err
+		})
+		<-app.Started()
+		err := app.beaconProtocol.UpdateBeacon(bootstrapEpoch, bootstrapBeacon)
+		require.NoError(t, err, "failed to bootstrap beacon for node %q", i)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		conn, err := grpc.DialContext(ctx, app.grpcPublicService.BoundAddress,
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+			grpc.WithBlock(),
+		)
+		require.NoError(t, err)
+		apps = append(apps, &TestApp{app, conn})
+	}
+
+	// Connect all nodes to each other
+	for i := 0; i < size; i++ {
+		for j := i + 1; j < size; j++ {
+			err := apps[i].Host().Connect(context.Background(), peer.AddrInfo{
+				ID:    apps[j].Host().ID(),
+				Addrs: apps[j].Host().Addrs(),
+			})
+			require.NoError(t, err)
+		}
+	}
+	return apps
+}
+
+func NewApp(t *testing.T, conf *config.Config, l log.Log) *App {
+	app := New(
+		WithConfig(conf),
+		WithLog(l),
+	)
+
+	err := app.Initialize()
+	require.NoError(t, err)
+
+	/* Create or load miner identity */
+	app.edSgn, err = app.LoadOrCreateEdSigner()
+	require.NoError(t, err, "could not retrieve identity")
+
+	return app
+}
+
+type TestApp struct {
+	*App
+	Conn *grpc.ClientConn
+}

--- a/p2p/host.go
+++ b/p2p/host.go
@@ -131,20 +131,33 @@ func New(_ context.Context, logger log.Log, cfg Config, prologue []byte, opts ..
 	if err != nil {
 		return nil, fmt.Errorf("can't create peer store: %w", err)
 	}
-	// leaves a small room for outbound connections in order to
-	// reduce risk of network isolation
-	g := &gater{
-		inbound:  int(float64(cfg.HighPeers) * cfg.InboundFraction),
-		outbound: int(float64(cfg.HighPeers) * cfg.OutboundFraction),
-		direct:   map[peer.ID]struct{}{},
+
+	bootnodesMap := make(map[peer.ID]struct{})
+	bootnodes, err := parseIntoAddr(cfg.Bootnodes)
+	if err != nil {
+		return nil, err
 	}
+	for _, pid := range bootnodes {
+		bootnodesMap[pid.ID] = struct{}{}
+	}
+
+	directMap := make(map[peer.ID]struct{})
 	direct, err := parseIntoAddr(cfg.Direct)
 	if err != nil {
 		return nil, err
 	}
 	for _, pid := range direct {
-		g.direct[pid.ID] = struct{}{}
+		directMap[pid.ID] = struct{}{}
 	}
+	// leaves a small room for outbound connections in order to
+	// reduce risk of network isolation
+	g := &gater{
+		inbound:  int(float64(cfg.HighPeers) * cfg.InboundFraction),
+		outbound: int(float64(cfg.HighPeers) * cfg.OutboundFraction),
+		direct:   directMap,
+	}
+
+	g.direct = directMap
 	lopts := []libp2p.Option{
 		libp2p.Identity(key),
 		libp2p.ListenAddrStrings(cfg.Listen),
@@ -186,10 +199,6 @@ func New(_ context.Context, logger log.Log, cfg Config, prologue []byte, opts ..
 		}))
 	}
 	if cfg.EnableHolepunching {
-		bootnodes, err := parseIntoAddr(cfg.Bootnodes)
-		if err != nil {
-			return nil, err
-		}
 		lopts = append(lopts,
 			libp2p.EnableHolePunching(),
 			libp2p.EnableAutoRelayWithStaticRelays(bootnodes))
@@ -224,7 +233,7 @@ func New(_ context.Context, logger log.Log, cfg Config, prologue []byte, opts ..
 	logger.Zap().Info("local node identity", zap.Stringer("identity", h.ID()))
 	// TODO(dshulyak) this is small mess. refactor to avoid this patching
 	// both New and Upgrade should use options.
-	opts = append(opts, WithConfig(cfg), WithLog(logger))
+	opts = append(opts, WithConfig(cfg), WithLog(logger), WithBootnodes(bootnodesMap), WithDirectNodes(directMap))
 	return Upgrade(h, opts...)
 }
 

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -1,9 +1,27 @@
 package p2p
 
-import "github.com/libp2p/go-libp2p/core/peer"
+import (
+	"time"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+	ma "github.com/multiformats/go-multiaddr"
+)
 
 // Peer is an alias to libp2p's peer.ID.
 type Peer = peer.ID
+
+// PeerInfo groups relevant information about a peer.
+type PeerInfo struct {
+	ID          Peer
+	Connections []ConnectionInfo
+	Tags        []string
+}
+
+type ConnectionInfo struct {
+	Address  ma.Multiaddr
+	Uptime   time.Duration
+	Outbound bool
+}
 
 // NoPeer is used when peer doesn't matter.
 const NoPeer Peer = ""

--- a/p2p/upgrade.go
+++ b/p2p/upgrade.go
@@ -10,6 +10,7 @@ import (
 	lp2plog "github.com/ipfs/go-log/v2"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/protocol"
 	"go.uber.org/zap/zapcore"
 	"golang.org/x/sync/errgroup"
@@ -52,6 +53,18 @@ func WithNodeReporter(reporter func()) Opt {
 	}
 }
 
+func WithDirectNodes(direct map[peer.ID]struct{}) Opt {
+	return func(fh *Host) {
+		fh.direct = direct
+	}
+}
+
+func WithBootnodes(bootnodes map[peer.ID]struct{}) Opt {
+	return func(fh *Host) {
+		fh.bootnode = bootnodes
+	}
+}
+
 // Host is a conveniency wrapper for all p2p related functionality required to run
 // a full spacemesh node.
 type Host struct {
@@ -74,6 +87,8 @@ type Host struct {
 
 	discovery *discovery.Discovery
 	legacy    *peerexchange.Discovery
+
+	direct, bootnode map[peer.ID]struct{}
 }
 
 // Upgrade creates Host instance from host.Host.
@@ -168,6 +183,39 @@ func Upgrade(h host.Host, opts ...Opt) (*Host, error) {
 // GetPeers returns connected peers.
 func (fh *Host) GetPeers() []Peer {
 	return fh.Host.Network().Peers()
+}
+
+// ConnectedPeerInfo retrieves a peer info object for the given peer.ID, if the
+// given peer is not connected then nil is returned.
+func (fh *Host) ConnectedPeerInfo(id peer.ID) *PeerInfo {
+	conns := fh.Network().ConnsToPeer(id)
+	// there's no sync between  Peers() and ConnsToPeer() so by the time we
+	// try to get the conns they may not exist.
+	if len(conns) == 0 {
+		return nil
+	}
+
+	var connections []ConnectionInfo
+	for _, c := range conns {
+		connections = append(connections, ConnectionInfo{
+			Address:  c.RemoteMultiaddr(),
+			Uptime:   time.Since(c.Stat().Opened),
+			Outbound: c.Stat().Direction == network.DirOutbound,
+		})
+	}
+	var tags []string
+
+	if _, ok := fh.direct[id]; ok {
+		tags = append(tags, "direct")
+	}
+	if _, ok := fh.bootnode[id]; ok {
+		tags = append(tags, "bootnode")
+	}
+	return &PeerInfo{
+		ID:          id,
+		Connections: connections,
+		Tags:        tags,
+	}
 }
 
 // PeerCount returns number of connected peers.


### PR DESCRIPTION
## Motivation
Latest release causes a `nil` pointer dereference error for some users:

```
2023-08-21T19:48:11.170+0800	INFO	grpc.Smesher	GRPC SmesherService.PostSetupStatus	{"module": "grpc"}
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x1 addr=0x0 pc=0x7ff6c6731597]

goroutine 27356 [running]:
github.com/spacemeshos/go-spacemesh/api/grpcserver.statusToPbStatus(...)
	D:/a/go-spacemesh/go-spacemesh/api/grpcserver/smesher_service.go:261
github.com/spacemeshos/go-spacemesh/api/grpcserver.SmesherService.PostSetupStatus({{0x7ff6c75ea7e8, 0xc0148d8510}, {0x7ff6c75dff30, 0xc008a7c800}, {0x7ff6c75e7370, 0xc000626540}, 0x3b9aca00, {{0xc0006b3008, 0x14}, 0x1c, ...}}, ...)
	D:/a/go-spacemesh/go-spacemesh/api/grpcserver/smesher_service.go:180 +0x97
github.com/spacemeshos/api/release/go/spacemesh/v1._SmesherService_PostSetupStatus_Handler.func1({0x7ff6c75def38, 0xc001ae2ea0}, {0x7ff6c6f7d200?, 0xc001ae2d50})
	C:/Users/runneradmin/go/pkg/mod/github.com/spacemeshos/api/release/go@v1.19.0/spacemesh/v1/smesher.pb.go:673 +0x78
github.com/grpc-ecosystem/go-grpc-middleware/logging/zap.UnaryServerInterceptor.func1({0x7ff6c75def38, 0xc001ae2db0}, {0x7ff6c6f7d200, 0xc001ae2d50}, 0xc000514ee0, 0xc003ad7800)
	C:/Users/runneradmin/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/logging/zap/server_interceptors.go:31 +0x115
google.golang.org/grpc.getChainUnaryHandler.func1({0x7ff6c75def38, 0xc001ae2db0}, {0x7ff6c6f7d200, 0xc001ae2d50})
	C:/Users/runneradmin/go/pkg/mod/google.golang.org/grpc@v1.57.0/server.go:1179 +0xb9
github.com/grpc-ecosystem/go-grpc-middleware/tags.UnaryServerInterceptor.func1({0x7ff6c75def38?, 0xc001ae2cf0?}, {0x7ff6c6f7d200, 0xc001ae2d50}, 0xc000514ee0, 0xc014a5d3c0)
	C:/Users/runneradmin/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/tags/interceptors.go:23 +0xa6
google.golang.org/grpc.chainUnaryInterceptors.func1({0x7ff6c75def38, 0xc001ae2cf0}, {0x7ff6c6f7d200, 0xc001ae2d50}, 0xc006235a58?, 0x7ff6c6ecd660?)
	C:/Users/runneradmin/go/pkg/mod/google.golang.org/grpc@v1.57.0/server.go:1170 +0x8f
github.com/spacemeshos/api/release/go/spacemesh/v1._SmesherService_PostSetupStatus_Handler({0x7ff6c70c1f00?, 0xc000278a20}, {0x7ff6c75def38, 0xc001ae2cf0}, 0xc0065aae70, 0xc005512820)
	C:/Users/runneradmin/go/pkg/mod/github.com/spacemeshos/api/release/go@v1.19.0/spacemesh/v1/smesher.pb.gopanic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x1 addr=0x0 pc=0x7ff6c6731597]
```

## Changes
- ensure ProviderID is initialized before dereferencing

## Test Plan
- new tests were added that failed the same way as reported by affected users and pass with the change.

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
