### PR TITLE
Fix nil pointer dereference

### DIFF
--- a/api/grpcserver/smesher_service.go
+++ b/api/grpcserver/smesher_service.go
@@ -258,6 +258,7 @@ func statusToPbStatus(status *activation.PostSetupStatus) *pb.PostSetupStatus {
 	if status.LastOpts != nil {
 		var providerID *uint32
 		if status.LastOpts.ProviderID.Value() != nil {
+			providerID = new(uint32)
 			*providerID = uint32(*status.LastOpts.ProviderID.Value())
 		}
 

--- a/api/grpcserver/smesher_service_test.go
+++ b/api/grpcserver/smesher_service_test.go
@@ -117,3 +117,85 @@ func TestSmesherService_PostSetupProviders(t *testing.T) {
 	require.EqualValues(t, providers[1].ID, resp.Providers[1].Id)
 	require.Equal(t, uint64(100_000), resp.Providers[1].Performance)
 }
+
+func TestSmesherService_PostSetupStatus(t *testing.T) {
+	t.Run("completed", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		postSetupProvider := activation.NewMockpostSetupProvider(ctrl)
+		smeshingProvider := activation.NewMockSmeshingProvider(ctrl)
+		svc := grpcserver.NewSmesherService(postSetupProvider, smeshingProvider, time.Second, activation.DefaultPostSetupOpts(), logtest.New(t).WithName("grpc.Smesher"))
+
+		postSetupProvider.EXPECT().Status().Return(&activation.PostSetupStatus{
+			State:            activation.PostSetupStateComplete,
+			NumLabelsWritten: 1_000,
+			LastOpts:         nil,
+		})
+		resp, err := svc.PostSetupStatus(context.Background(), &emptypb.Empty{})
+		require.NoError(t, err)
+		require.Equal(t, pb.PostSetupStatus_STATE_COMPLETE, resp.Status.State)
+		require.EqualValues(t, 1_000, resp.Status.NumLabelsWritten)
+		require.Nil(t, resp.Status.Opts)
+	})
+
+	t.Run("completed with last Opts", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		postSetupProvider := activation.NewMockpostSetupProvider(ctrl)
+		smeshingProvider := activation.NewMockSmeshingProvider(ctrl)
+		svc := grpcserver.NewSmesherService(postSetupProvider, smeshingProvider, time.Second, activation.DefaultPostSetupOpts(), logtest.New(t).WithName("grpc.Smesher"))
+
+		id := activation.PostProviderID{}
+		id.SetInt64(1)
+		opts := activation.PostSetupOpts{
+			DataDir:     "data-dir",
+			NumUnits:    4,
+			MaxFileSize: 1024,
+			ProviderID:  id,
+			Throttle:    true,
+		}
+		postSetupProvider.EXPECT().Status().Return(&activation.PostSetupStatus{
+			State:            activation.PostSetupStateComplete,
+			NumLabelsWritten: 1_000,
+			LastOpts:         &opts,
+		})
+		resp, err := svc.PostSetupStatus(context.Background(), &emptypb.Empty{})
+		require.NoError(t, err)
+		require.Equal(t, pb.PostSetupStatus_STATE_COMPLETE, resp.Status.State)
+		require.EqualValues(t, 1_000, resp.Status.NumLabelsWritten)
+		require.Equal(t, "data-dir", resp.Status.Opts.DataDir)
+		require.EqualValues(t, 4, resp.Status.Opts.NumUnits)
+		require.EqualValues(t, 1024, resp.Status.Opts.MaxFileSize)
+		require.EqualValues(t, 1, *resp.Status.Opts.ProviderId)
+		require.True(t, resp.Status.Opts.Throttle)
+	})
+
+	t.Run("in progress", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		postSetupProvider := activation.NewMockpostSetupProvider(ctrl)
+		smeshingProvider := activation.NewMockSmeshingProvider(ctrl)
+		svc := grpcserver.NewSmesherService(postSetupProvider, smeshingProvider, time.Second, activation.DefaultPostSetupOpts(), logtest.New(t).WithName("grpc.Smesher"))
+
+		id := activation.PostProviderID{}
+		id.SetInt64(100)
+		opts := activation.PostSetupOpts{
+			DataDir:     "data-dir",
+			NumUnits:    4,
+			MaxFileSize: 1024,
+			ProviderID:  id,
+			Throttle:    false,
+		}
+		postSetupProvider.EXPECT().Status().Return(&activation.PostSetupStatus{
+			State:            activation.PostSetupStateInProgress,
+			NumLabelsWritten: 1_000,
+			LastOpts:         &opts,
+		})
+		resp, err := svc.PostSetupStatus(context.Background(), &emptypb.Empty{})
+		require.NoError(t, err)
+		require.Equal(t, pb.PostSetupStatus_STATE_IN_PROGRESS, resp.Status.State)
+		require.EqualValues(t, 1_000, resp.Status.NumLabelsWritten)
+		require.Equal(t, "data-dir", resp.Status.Opts.DataDir)
+		require.EqualValues(t, 4, resp.Status.Opts.NumUnits)
+		require.EqualValues(t, 1024, resp.Status.Opts.MaxFileSize)
+		require.EqualValues(t, 100, *resp.Status.Opts.ProviderId)
+		require.False(t, resp.Status.Opts.Throttle)
+	})
+}


### PR DESCRIPTION
## Motivation
Latest release causes a `nil` pointer dereference error for some users:

```
2023-08-21T19:48:11.170+0800	INFO	grpc.Smesher	GRPC SmesherService.PostSetupStatus	{"module": "grpc"}
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x1 addr=0x0 pc=0x7ff6c6731597]

goroutine 27356 [running]:
github.com/spacemeshos/go-spacemesh/api/grpcserver.statusToPbStatus(...)
	D:/a/go-spacemesh/go-spacemesh/api/grpcserver/smesher_service.go:261
github.com/spacemeshos/go-spacemesh/api/grpcserver.SmesherService.PostSetupStatus({{0x7ff6c75ea7e8, 0xc0148d8510}, {0x7ff6c75dff30, 0xc008a7c800}, {0x7ff6c75e7370, 0xc000626540}, 0x3b9aca00, {{0xc0006b3008, 0x14}, 0x1c, ...}}, ...)
	D:/a/go-spacemesh/go-spacemesh/api/grpcserver/smesher_service.go:180 +0x97
github.com/spacemeshos/api/release/go/spacemesh/v1._SmesherService_PostSetupStatus_Handler.func1({0x7ff6c75def38, 0xc001ae2ea0}, {0x7ff6c6f7d200?, 0xc001ae2d50})
	C:/Users/runneradmin/go/pkg/mod/github.com/spacemeshos/api/release/go@v1.19.0/spacemesh/v1/smesher.pb.go:673 +0x78
github.com/grpc-ecosystem/go-grpc-middleware/logging/zap.UnaryServerInterceptor.func1({0x7ff6c75def38, 0xc001ae2db0}, {0x7ff6c6f7d200, 0xc001ae2d50}, 0xc000514ee0, 0xc003ad7800)
	C:/Users/runneradmin/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/logging/zap/server_interceptors.go:31 +0x115
google.golang.org/grpc.getChainUnaryHandler.func1({0x7ff6c75def38, 0xc001ae2db0}, {0x7ff6c6f7d200, 0xc001ae2d50})
	C:/Users/runneradmin/go/pkg/mod/google.golang.org/grpc@v1.57.0/server.go:1179 +0xb9
github.com/grpc-ecosystem/go-grpc-middleware/tags.UnaryServerInterceptor.func1({0x7ff6c75def38?, 0xc001ae2cf0?}, {0x7ff6c6f7d200, 0xc001ae2d50}, 0xc000514ee0, 0xc014a5d3c0)
	C:/Users/runneradmin/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/tags/interceptors.go:23 +0xa6
google.golang.org/grpc.chainUnaryInterceptors.func1({0x7ff6c75def38, 0xc001ae2cf0}, {0x7ff6c6f7d200, 0xc001ae2d50}, 0xc006235a58?, 0x7ff6c6ecd660?)
	C:/Users/runneradmin/go/pkg/mod/google.golang.org/grpc@v1.57.0/server.go:1170 +0x8f
github.com/spacemeshos/api/release/go/spacemesh/v1._SmesherService_PostSetupStatus_Handler({0x7ff6c70c1f00?, 0xc000278a20}, {0x7ff6c75def38, 0xc001ae2cf0}, 0xc0065aae70, 0xc005512820)
	C:/Users/runneradmin/go/pkg/mod/github.com/spacemeshos/api/release/go@v1.19.0/spacemesh/v1/smesher.pb.gopanic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x1 addr=0x0 pc=0x7ff6c6731597]
```

## Changes
- ensure ProviderID is initialized before dereferencing

## Test Plan
- new tests were added that failed the same way as reported by affected users and pass with the change.

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
