### PR TITLE
[Merged by Bors] - Fix handling of PoET proof fetching timeout

### DIFF
--- a/activation/activation.go
+++ b/activation/activation.go
@@ -624,11 +624,10 @@ func (b *Builder) poetRoundStart(epoch types.EpochID) time.Time {
 func (b *Builder) createAtx(ctx context.Context, challenge *types.NIPostChallenge) (*types.ActivationTx, error) {
 	pubEpoch := challenge.PublishEpoch
 
-	nipost, postDuration, err := b.nipostBuilder.BuildNIPost(ctx, challenge)
+	nipost, err := b.nipostBuilder.BuildNIPost(ctx, challenge)
 	if err != nil {
 		return nil, fmt.Errorf("build NIPost: %w", err)
 	}
-	metrics.PostDuration.Set(float64(postDuration.Nanoseconds()))
 
 	b.log.With().Info("awaiting atx publication epoch",
 		log.Stringer("pub_epoch", pubEpoch),

--- a/activation/activation_test.go
+++ b/activation/activation_test.go
@@ -30,7 +30,7 @@ import (
 // ========== Vars / Consts ==========
 
 const (
-	layersPerEpoch                 = 5
+	layersPerEpoch                 = 10
 	layerDuration                  = time.Second
 	postGenesisEpoch types.EpochID = 2
 )

--- a/activation/interface.go
+++ b/activation/interface.go
@@ -43,7 +43,7 @@ type layerClock interface {
 
 type nipostBuilder interface {
 	UpdatePoETProvers([]PoetProvingServiceClient)
-	BuildNIPost(ctx context.Context, challenge *types.NIPostChallenge) (*types.NIPost, time.Duration, error)
+	BuildNIPost(ctx context.Context, challenge *types.NIPostChallenge) (*types.NIPost, error)
 	DataDir() string
 }
 

--- a/activation/mocks.go
+++ b/activation/mocks.go
@@ -342,13 +342,12 @@ func (m *MocknipostBuilder) EXPECT() *MocknipostBuilderMockRecorder {
 }
 
 // BuildNIPost mocks base method.
-func (m *MocknipostBuilder) BuildNIPost(ctx context.Context, challenge *types.NIPostChallenge) (*types.NIPost, time.Duration, error) {
+func (m *MocknipostBuilder) BuildNIPost(ctx context.Context, challenge *types.NIPostChallenge) (*types.NIPost, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BuildNIPost", ctx, challenge)
 	ret0, _ := ret[0].(*types.NIPost)
-	ret1, _ := ret[1].(time.Duration)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // BuildNIPost indicates an expected call of BuildNIPost.

--- a/activation/nipost_test.go
+++ b/activation/nipost_test.go
@@ -243,10 +243,14 @@ func TestNewNIPostBuilderNotInitialized(t *testing.T) {
 
 	postProvider := newTestPostManager(t)
 
+	epoch := layersPerEpoch * layerDuration
 	poetCfg := PoetConfig{
+		PhaseShift:  epoch / 5,
+		CycleGap:    epoch / 10,
 		GracePeriod: 1 * time.Second,
 	}
-	poetProver := spawnPoet(t, WithGenesis(time.Now()), WithEpochDuration(time.Second))
+	genesis := time.Now()
+	poetProver := spawnPoet(t, WithGenesis(genesis), WithEpochDuration(epoch), WithPhaseShift(poetCfg.PhaseShift), WithCycleGap(poetCfg.CycleGap))
 
 	ctrl := gomock.NewController(t)
 	poetDb := NewMockpoetDbAPI(ctrl)
@@ -1070,15 +1074,15 @@ func TestCalculatingGetProofWaitTime(t *testing.T) {
 	t.Parallel()
 	t.Run("past round end", func(t *testing.T) {
 		t.Parallel()
-		waitTime := calcGetProofWaitTime(-time.Hour, time.Hour*12)
-		require.Less(t, waitTime, time.Duration(0))
+		deadline := proofDeadline(time.Now().Add(-time.Hour), time.Hour*12)
+		require.Less(t, time.Until(deadline), time.Duration(0))
 	})
 	t.Run("before round end", func(t *testing.T) {
 		t.Parallel()
 		cycleGap := 12 * time.Hour
-		waitTime := calcGetProofWaitTime(time.Hour, cycleGap)
+		deadline := proofDeadline(time.Now().Add(time.Hour), cycleGap)
 
-		require.Greater(t, waitTime, time.Hour+time.Duration(float64(cycleGap)*minPoetGetProofJitter/100))
-		require.LessOrEqual(t, waitTime, time.Hour+time.Duration(float64(cycleGap)*maxPoetGetProofJitter/100))
+		require.Greater(t, time.Until(deadline), time.Hour+time.Duration(float64(cycleGap)*minPoetGetProofJitter/100))
+		require.LessOrEqual(t, time.Until(deadline), time.Hour+time.Duration(float64(cycleGap)*maxPoetGetProofJitter/100))
 	})
 }

--- a/activation/nipost_test.go
+++ b/activation/nipost_test.go
@@ -49,10 +49,6 @@ func TestNIPostBuilderWithMocks(t *testing.T) {
 		PublishEpoch: postGenesisEpoch + 2,
 	}
 
-	poetCfg := PoetConfig{
-		GracePeriod: 1 * time.Second,
-	}
-
 	ctrl := gomock.NewController(t)
 	postProvider := NewMockpostSetupProvider(ctrl)
 	postProvider.EXPECT().Status().Return(&PostSetupStatus{State: PostSetupStateComplete})
@@ -82,7 +78,7 @@ func TestNIPostBuilderWithMocks(t *testing.T) {
 		t.TempDir(),
 		logtest.New(t),
 		sig,
-		poetCfg,
+		PoetConfig{},
 		mclock,
 		WithNipostValidator(nipostValidator),
 		withPoetClients([]PoetProvingServiceClient{poetProvider}),
@@ -101,10 +97,6 @@ func TestPostSetup(t *testing.T) {
 
 	challenge := types.NIPostChallenge{
 		PublishEpoch: postGenesisEpoch + 2,
-	}
-
-	poetCfg := PoetConfig{
-		GracePeriod: 1 * time.Second,
 	}
 
 	poetProvider := defaultPoetServiceMock(t, []byte("poet"))
@@ -127,7 +119,7 @@ func TestPostSetup(t *testing.T) {
 		t.TempDir(),
 		logtest.New(t),
 		postProvider.signer,
-		poetCfg,
+		PoetConfig{},
 		mclock,
 		WithNipostValidator(nipostValidator),
 		withPoetClients([]PoetProvingServiceClient{poetProvider}),
@@ -319,10 +311,6 @@ func TestNIPostBuilder_BuildNIPost(t *testing.T) {
 	postProvider.EXPECT().CommitmentAtx().Return(types.EmptyATXID, nil).AnyTimes()
 	postProvider.EXPECT().LastOpts().Return(&PostSetupOpts{}).AnyTimes()
 
-	poetCfg := PoetConfig{
-		GracePeriod: 1 * time.Second,
-	}
-
 	challenge := types.NIPostChallenge{
 		PublishEpoch: postGenesisEpoch + 2,
 	}
@@ -361,7 +349,7 @@ func TestNIPostBuilder_BuildNIPost(t *testing.T) {
 		dir,
 		logtest.New(t),
 		sig,
-		poetCfg,
+		PoetConfig{},
 		mclock,
 		WithNipostValidator(nipostValidator),
 		withPoetClients([]PoetProvingServiceClient{poetProver}),
@@ -388,7 +376,7 @@ func TestNIPostBuilder_BuildNIPost(t *testing.T) {
 		dir,
 		logtest.New(t),
 		sig,
-		poetCfg,
+		PoetConfig{},
 		mclock,
 		withPoetClients([]PoetProvingServiceClient{poetProver}),
 	)
@@ -412,7 +400,7 @@ func TestNIPostBuilder_BuildNIPost(t *testing.T) {
 		dir,
 		logtest.New(t),
 		sig,
-		poetCfg,
+		PoetConfig{},
 		mclock,
 		WithNipostValidator(nipostValidator),
 		withPoetClients([]PoetProvingServiceClient{poetProver}),
@@ -475,8 +463,7 @@ func TestNIPostBuilder_ManyPoETs_SubmittingChallenge_DeadlineReached(t *testing.
 	sig, err := signing.NewEdSigner()
 	req.NoError(err)
 	poetCfg := PoetConfig{
-		PhaseShift:  layerDuration * layersPerEpoch / 2,
-		GracePeriod: 1 * time.Second,
+		PhaseShift: layerDuration * layersPerEpoch / 2,
 	}
 	postProvider := NewMockpostSetupProvider(ctrl)
 	postProvider.EXPECT().Status().Return(&PostSetupStatus{State: PostSetupStateComplete})
@@ -534,10 +521,6 @@ func TestNIPostBuilder_ManyPoETs_AllFinished(t *testing.T) {
 		},
 	}
 
-	poetCfg := PoetConfig{
-		GracePeriod: 1 * time.Second,
-	}
-
 	ctrl := gomock.NewController(t)
 	nipostValidator := NewMocknipostValidator(ctrl)
 	poetDb := NewMockpoetDbAPI(ctrl)
@@ -578,7 +561,7 @@ func TestNIPostBuilder_ManyPoETs_AllFinished(t *testing.T) {
 		t.TempDir(),
 		logtest.New(t),
 		sig,
-		poetCfg,
+		PoetConfig{},
 		mclock,
 		WithNipostValidator(nipostValidator),
 		withPoetClients(poets),
@@ -637,8 +620,7 @@ func TestNIPSTBuilder_PoetUnstable(t *testing.T) {
 		PublishEpoch: postGenesisEpoch + 1,
 	}
 	poetCfg := PoetConfig{
-		PhaseShift:  layerDuration,
-		GracePeriod: 1 * time.Second,
+		PhaseShift: layerDuration,
 	}
 
 	sig, err := signing.NewEdSigner()
@@ -954,8 +936,7 @@ func TestNIPoSTBuilder_Continues_After_Interrupted(t *testing.T) {
 	sig, err := signing.NewEdSigner()
 	req.NoError(err)
 	poetCfg := PoetConfig{
-		PhaseShift:  layerDuration * layersPerEpoch / 2,
-		GracePeriod: 1 * time.Second,
+		PhaseShift: layerDuration * layersPerEpoch / 2,
 	}
 	postProvider := NewMockpostSetupProvider(ctrl)
 	postProvider.EXPECT().Status().Return(&PostSetupStatus{State: PostSetupStateComplete}).Times(2)

--- a/config/presets/fastnet.go
+++ b/config/presets/fastnet.go
@@ -75,5 +75,9 @@ func fastnet() config.Config {
 	conf.Beacon.BeaconSyncWeightUnits = 10
 	conf.Beacon.VotesLimit = 100
 
+	conf.POET.GracePeriod = 10 * time.Second
+	conf.POET.CycleGap = 30 * time.Second
+	conf.POET.PhaseShift = 30 * time.Second
+
 	return conf
 }


### PR DESCRIPTION
## Motivation
Closes #4901

## Changes
Deadlines and Timeouts in the NiPoST builder have been updated for Phase 1 (fetching PoET Proofs):

- Deadline Before: end of publish epoch; this is too late. In system tests this causes a test to fail if a singe PoET is slow to respond
- Deadline Now: end of publish epoch - cycle gap. A node that is able to build a PoST proof within the cycle gap (which is necessary to not miss an epoch) has enough time left to publish an ATX if it receives it until then.
- Additionally a timeout for fetching PoET Proofs has been added. For this timeout I used the PoET config `grace-period`.
  - For nodes that are online at the start of the cycle gap this means the same deadline for fetching a PoET proof as before
  - For nodes that are offline when the PoET round ends this means they can still fetch a PoET proof later if the deadline has not yet been met
  - TODO: GracePeriod is not a good name for this config, it should rather be called "PoET Request Timeout" or similar. Also 1 hour is way to much, on mainnet this can easily be 1 minute or even less, in system tests it's 10 seconds at the moment.
  - Not using a timeout here can lead in some cases to the client trying to download a proof from a non-responding PoET until it is to late to publish an ATX, while a valid proof from another PoET might have been available already.
- I changed `calcGetProofWaitTime` to not calculate a duration to a deadline
  - There might be some time that passes between calculating the duration and using it (especially since this calculating and using the wait time happens on 2 different go routines). This can cause problems when the wait time and deadline are close together (e.g. tests with very short epoch durations). Using time instead of duration minimizes this problem.

## Test Plan
<!-- Please specify how these changes were tested 
(e.g. unit tests, manual testing, etc.) -->

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
