### PR TITLE
[Merged by Bors] - Removed devops notes from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,7 +7,7 @@ Closes #
 <!-- Please describe in detail the changes made -->
 
 ## Test Plan
-<!-- Please specify how these changes were tested 
+<!-- Please specify how these changes were tested
 (e.g. unit tests, manual testing, etc.) -->
 
 ## TODO
@@ -15,10 +15,4 @@ Closes #
 - [ ] Explain motivation or link existing issue(s)
 - [ ] Test changes and document test plan
 - [ ] Update documentation as needed
-
-## DevOps Notes
-<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
-- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
-- [x] This PR does not affect public APIs
-- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
-- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
+- [ ] Update [changelog](../CHANGELOG.md) as needed


### PR DESCRIPTION
## Motivation
The DevOps notes are not used.

## Changes
Removed _Devlops notes_ section from PR template