### PR TITLE
[Merged by Bors] - use tortoise data for ballot eligibility validation

### DIFF
--- a/miner/oracle_test.go
+++ b/miner/oracle_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/sql/certificates"
 	"github.com/spacemeshos/go-spacemesh/sql/identities"
 	"github.com/spacemeshos/go-spacemesh/system/mocks"
+	"github.com/spacemeshos/go-spacemesh/tortoise"
 )
 
 const (
@@ -181,11 +182,24 @@ func testMinerOracleAndProposalValidator(t *testing.T, layerSize, layersPerEpoch
 	mbc := mocks.NewMockBeaconCollector(ctrl)
 	vrfVerifier := proposals.NewMockvrfVerifier(ctrl)
 	vrfVerifier.EXPECT().Verify(gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
+	tmock := proposals.NewMockballotDecoder(ctrl)
+	tmock.EXPECT().GetBallot(gomock.Any()).AnyTimes().DoAndReturn(func(id types.BallotID) *tortoise.BallotData {
+		ballot, err := ballots.Get(o.cdb, id)
+		require.NoError(t, err)
+		return &tortoise.BallotData{
+			ID:           ballot.ID(),
+			Layer:        ballot.Layer,
+			ATXID:        ballot.AtxID,
+			Smesher:      ballot.SmesherID,
+			Beacon:       ballot.EpochData.Beacon,
+			Eligiblities: ballot.EpochData.EligibilityCount,
+		}
+	})
 
 	nonceFetcher := proposals.NewMocknonceFetcher(ctrl)
 	nonce := types.VRFPostIndex(rand.Uint64())
 
-	validator := proposals.NewEligibilityValidator(layerSize, layersPerEpoch, 0, o.mClock, o.cdb, mbc, o.log.WithName("blkElgValidator"), vrfVerifier,
+	validator := proposals.NewEligibilityValidator(layerSize, layersPerEpoch, 0, o.mClock, tmock, o.cdb, mbc, o.log.WithName("blkElgValidator"), vrfVerifier,
 		proposals.WithNonceFetcher(nonceFetcher),
 	)
 

--- a/miner/oracle_test.go
+++ b/miner/oracle_test.go
@@ -182,7 +182,7 @@ func testMinerOracleAndProposalValidator(t *testing.T, layerSize, layersPerEpoch
 	mbc := mocks.NewMockBeaconCollector(ctrl)
 	vrfVerifier := proposals.NewMockvrfVerifier(ctrl)
 	vrfVerifier.EXPECT().Verify(gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
-	tmock := proposals.NewMockballotDecoder(ctrl)
+	tmock := proposals.NewMocktortoiseProvider(ctrl)
 	tmock.EXPECT().GetBallot(gomock.Any()).AnyTimes().DoAndReturn(func(id types.BallotID) *tortoise.BallotData {
 		ballot, err := ballots.Get(o.cdb, id)
 		require.NoError(t, err)

--- a/proposals/eligibility_validator.go
+++ b/proposals/eligibility_validator.go
@@ -29,7 +29,7 @@ type Validator struct {
 	minActiveSetWeight uint64
 	avgLayerSize       uint32
 	layersPerEpoch     uint32
-	tortoise           ballotDecoder
+	tortoise           tortoiseProvider
 	cdb                *datastore.CachedDB
 	clock              layerClock
 	beacons            system.BeaconCollector
@@ -49,7 +49,7 @@ func WithNonceFetcher(nf nonceFetcher) ValidatorOpt {
 
 // NewEligibilityValidator returns a new EligibilityValidator.
 func NewEligibilityValidator(
-	avgLayerSize, layersPerEpoch uint32, minActiveSetWeight uint64, clock layerClock, tortoise ballotDecoder, cdb *datastore.CachedDB, bc system.BeaconCollector, lg log.Log, vrfVerifier vrfVerifier, opts ...ValidatorOpt,
+	avgLayerSize, layersPerEpoch uint32, minActiveSetWeight uint64, clock layerClock, tortoise tortoiseProvider, cdb *datastore.CachedDB, bc system.BeaconCollector, lg log.Log, vrfVerifier vrfVerifier, opts ...ValidatorOpt,
 ) *Validator {
 	v := &Validator{
 		minActiveSetWeight: minActiveSetWeight,

--- a/proposals/eligibility_validator_test.go
+++ b/proposals/eligibility_validator_test.go
@@ -536,7 +536,8 @@ func TestEligibilityValidator(t *testing.T) {
 
 			lg := logtest.New(t)
 			db := datastore.NewCachedDB(sql.InMemory(), lg)
-			tv := NewEligibilityValidator(layerAvgSize, layersPerEpoch, tc.minWeight, ms.mclock, db, ms.mbc, lg, ms.mvrf,
+			tv := NewEligibilityValidator(layerAvgSize, layersPerEpoch, tc.minWeight, ms.mclock, ms.md,
+				db, ms.mbc, lg, ms.mvrf,
 				WithNonceFetcher(db),
 			)
 			for _, atx := range tc.atxs {

--- a/proposals/handler.go
+++ b/proposals/handler.go
@@ -55,7 +55,7 @@ type Handler struct {
 	fetcher    system.Fetcher
 	mesh       meshProvider
 	validator  eligibilityValidator
-	tortoise   ballotDecoder
+	tortoise   tortoiseProvider
 	clock      layerClock
 }
 
@@ -108,7 +108,7 @@ func NewHandler(
 	f system.Fetcher,
 	bc system.BeaconCollector,
 	m meshProvider,
-	tortoise ballotDecoder,
+	tortoise tortoiseProvider,
 	verifier vrfVerifier,
 	clock layerClock,
 	opts ...Opt,

--- a/proposals/handler.go
+++ b/proposals/handler.go
@@ -18,7 +18,6 @@ import (
 	"github.com/spacemeshos/go-spacemesh/p2p/pubsub"
 	"github.com/spacemeshos/go-spacemesh/signing"
 	"github.com/spacemeshos/go-spacemesh/sql"
-	"github.com/spacemeshos/go-spacemesh/sql/ballots"
 	"github.com/spacemeshos/go-spacemesh/sql/proposals"
 	"github.com/spacemeshos/go-spacemesh/system"
 	"github.com/spacemeshos/go-spacemesh/tortoise"
@@ -56,7 +55,7 @@ type Handler struct {
 	fetcher    system.Fetcher
 	mesh       meshProvider
 	validator  eligibilityValidator
-	decoder    ballotDecoder
+	tortoise   ballotDecoder
 	clock      layerClock
 }
 
@@ -109,7 +108,7 @@ func NewHandler(
 	f system.Fetcher,
 	bc system.BeaconCollector,
 	m meshProvider,
-	decoder ballotDecoder,
+	tortoise ballotDecoder,
 	verifier vrfVerifier,
 	clock layerClock,
 	opts ...Opt,
@@ -122,14 +121,14 @@ func NewHandler(
 		publisher:  p,
 		fetcher:    f,
 		mesh:       m,
-		decoder:    decoder,
+		tortoise:   tortoise,
 		clock:      clock,
 	}
 	for _, opt := range opts {
 		opt(b)
 	}
 	if b.validator == nil {
-		b.validator = NewEligibilityValidator(b.cfg.LayerSize, b.cfg.LayersPerEpoch, b.cfg.MinimalActiveSetWeight, clock, cdb, bc, b.logger, verifier)
+		b.validator = NewEligibilityValidator(b.cfg.LayerSize, b.cfg.LayersPerEpoch, b.cfg.MinimalActiveSetWeight, clock, tortoise, cdb, bc, b.logger, verifier)
 	}
 	return b
 }
@@ -235,7 +234,7 @@ func (h *Handler) handleProposal(ctx context.Context, expHash types.Hash32, peer
 	}
 	if p.Layer <= types.GetEffectiveGenesis() {
 		preGenesis.Inc()
-		return fmt.Errorf("proposal before effective genesis: layer %v", p.Layer)
+		return fmt.Errorf("proposal bedbfore effective genesis: layer %v", p.Layer)
 	}
 
 	latency := receivedTime.Sub(h.clock.LayerToTime(p.Layer))
@@ -340,15 +339,10 @@ func (h *Handler) handleProposal(ctx context.Context, expHash types.Hash32, peer
 }
 
 func (h *Handler) processBallot(ctx context.Context, logger log.Log, b *types.Ballot) (*types.MalfeasanceProof, error) {
-	t0 := time.Now()
-	if has, err := ballots.Has(h.cdb, b.ID()); err != nil {
-		logger.With().Error("failed to look up ballot", log.Err(err))
-		return nil, fmt.Errorf("lookup ballot %v: %w", b.ID(), err)
-	} else if has {
+	if data := h.tortoise.GetBallot(b.ID()); data != nil {
 		known.Inc()
 		return nil, fmt.Errorf("%w: ballot %s", errKnownBallot, b.ID())
 	}
-	ballotDuration.WithLabelValues(dbLookup).Observe(float64(time.Since(t0)))
 
 	logger.With().Info("new ballot", log.Inline(b))
 
@@ -367,7 +361,7 @@ func (h *Handler) processBallot(ctx context.Context, logger log.Log, b *types.Ba
 		return nil, fmt.Errorf("save ballot: %w", err)
 	}
 	ballotDuration.WithLabelValues(dbSave).Observe(float64(time.Since(t1)))
-	if err := h.decoder.StoreBallot(decoded); err != nil {
+	if err := h.tortoise.StoreBallot(decoded); err != nil {
 		if errors.Is(err, tortoise.ErrBallotExists) {
 			return nil, fmt.Errorf("%w: %s", errKnownBallot, b.ID())
 		}
@@ -395,7 +389,7 @@ func (h *Handler) checkBallotSyntacticValidity(ctx context.Context, logger log.L
 	t2 := time.Now()
 	// ballot can be decoded only if all dependencies (blocks, ballots, atxs) were downloaded
 	// and added to the tortoise.
-	decoded, err := h.decoder.DecodeBallot(b.ToTortoiseData())
+	decoded, err := h.tortoise.DecodeBallot(b.ToTortoiseData())
 	if err != nil {
 		return nil, fmt.Errorf("decode ballot %s: %w", b.ID(), err)
 	}
@@ -499,16 +493,15 @@ func (h *Handler) checkVotesConsistency(ctx context.Context, b *types.Ballot) er
 
 func (h *Handler) checkBallotDataAvailability(ctx context.Context, b *types.Ballot) error {
 	var blts []types.BallotID
-	if b.Votes.Base != types.EmptyBallotID {
+	if b.Votes.Base != types.EmptyBallotID && h.tortoise.GetBallot(b.Votes.Base) == nil {
 		blts = append(blts, b.Votes.Base)
 	}
-	if b.RefBallot != types.EmptyBallotID {
+	if b.RefBallot != types.EmptyBallotID && h.tortoise.GetBallot(b.RefBallot) == nil {
 		blts = append(blts, b.RefBallot)
 	}
 	if err := h.fetcher.GetBallots(ctx, blts); err != nil {
 		return fmt.Errorf("fetch ballots: %w", err)
 	}
-
 	if err := h.fetchReferencedATXs(ctx, b); err != nil {
 		return fmt.Errorf("fetch referenced ATXs: %w", err)
 	}
@@ -520,7 +513,7 @@ func (h *Handler) fetchReferencedATXs(ctx context.Context, b *types.Ballot) erro
 	if b.EpochData != nil {
 		atxs = append(atxs, b.ActiveSet...)
 	}
-	if err := h.fetcher.GetAtxs(ctx, h.decoder.GetMissingActiveSet(b.Layer.GetEpoch(), atxs)); err != nil {
+	if err := h.fetcher.GetAtxs(ctx, h.tortoise.GetMissingActiveSet(b.Layer.GetEpoch(), atxs)); err != nil {
 		return fmt.Errorf("proposal get ATXs: %w", err)
 	}
 	return nil

--- a/proposals/handler.go
+++ b/proposals/handler.go
@@ -234,7 +234,7 @@ func (h *Handler) handleProposal(ctx context.Context, expHash types.Hash32, peer
 	}
 	if p.Layer <= types.GetEffectiveGenesis() {
 		preGenesis.Inc()
-		return fmt.Errorf("proposal bedbfore effective genesis: layer %v", p.Layer)
+		return fmt.Errorf("proposal before effective genesis: layer %v", p.Layer)
 	}
 
 	latency := receivedTime.Sub(h.clock.LayerToTime(p.Layer))

--- a/proposals/handler_test.go
+++ b/proposals/handler_test.go
@@ -47,7 +47,7 @@ type mockSet struct {
 	mclock *MocklayerClock
 	mm     *MockmeshProvider
 	mv     *MockeligibilityValidator
-	md     *MockballotDecoder
+	md     *MocktortoiseProvider
 	mvrf   *MockvrfVerifier
 }
 
@@ -77,7 +77,7 @@ func fullMockSet(tb testing.TB) *mockSet {
 		mclock: NewMocklayerClock(ctrl),
 		mm:     NewMockmeshProvider(ctrl),
 		mv:     NewMockeligibilityValidator(ctrl),
-		md:     NewMockballotDecoder(ctrl),
+		md:     NewMocktortoiseProvider(ctrl),
 		mvrf:   NewMockvrfVerifier(ctrl),
 	}
 }

--- a/proposals/interface.go
+++ b/proposals/interface.go
@@ -20,6 +20,7 @@ type eligibilityValidator interface {
 }
 
 type ballotDecoder interface {
+	GetBallot(types.BallotID) *tortoise.BallotData
 	GetMissingActiveSet(types.EpochID, []types.ATXID) []types.ATXID
 	DecodeBallot(*types.BallotTortoiseData) (*tortoise.DecodedBallot, error)
 	StoreBallot(*tortoise.DecodedBallot) error

--- a/proposals/interface.go
+++ b/proposals/interface.go
@@ -19,7 +19,7 @@ type eligibilityValidator interface {
 	CheckEligibility(context.Context, *types.Ballot) (bool, error)
 }
 
-type ballotDecoder interface {
+type tortoiseProvider interface {
 	GetBallot(types.BallotID) *tortoise.BallotData
 	GetMissingActiveSet(types.EpochID, []types.ATXID) []types.ATXID
 	DecodeBallot(*types.BallotTortoiseData) (*tortoise.DecodedBallot, error)

--- a/proposals/mocks.go
+++ b/proposals/mocks.go
@@ -142,6 +142,20 @@ func (mr *MockballotDecoderMockRecorder) DecodeBallot(arg0 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DecodeBallot", reflect.TypeOf((*MockballotDecoder)(nil).DecodeBallot), arg0)
 }
 
+// GetBallot mocks base method.
+func (m *MockballotDecoder) GetBallot(arg0 types.BallotID) *tortoise.BallotData {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBallot", arg0)
+	ret0, _ := ret[0].(*tortoise.BallotData)
+	return ret0
+}
+
+// GetBallot indicates an expected call of GetBallot.
+func (mr *MockballotDecoderMockRecorder) GetBallot(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBallot", reflect.TypeOf((*MockballotDecoder)(nil).GetBallot), arg0)
+}
+
 // GetMissingActiveSet mocks base method.
 func (m *MockballotDecoder) GetMissingActiveSet(arg0 types.EpochID, arg1 []types.ATXID) []types.ATXID {
 	m.ctrl.T.Helper()

--- a/proposals/mocks.go
+++ b/proposals/mocks.go
@@ -104,31 +104,31 @@ func (mr *MockeligibilityValidatorMockRecorder) CheckEligibility(arg0, arg1 inte
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckEligibility", reflect.TypeOf((*MockeligibilityValidator)(nil).CheckEligibility), arg0, arg1)
 }
 
-// MockballotDecoder is a mock of ballotDecoder interface.
-type MockballotDecoder struct {
+// MocktortoiseProvider is a mock of tortoiseProvider interface.
+type MocktortoiseProvider struct {
 	ctrl     *gomock.Controller
-	recorder *MockballotDecoderMockRecorder
+	recorder *MocktortoiseProviderMockRecorder
 }
 
-// MockballotDecoderMockRecorder is the mock recorder for MockballotDecoder.
-type MockballotDecoderMockRecorder struct {
-	mock *MockballotDecoder
+// MocktortoiseProviderMockRecorder is the mock recorder for MocktortoiseProvider.
+type MocktortoiseProviderMockRecorder struct {
+	mock *MocktortoiseProvider
 }
 
-// NewMockballotDecoder creates a new mock instance.
-func NewMockballotDecoder(ctrl *gomock.Controller) *MockballotDecoder {
-	mock := &MockballotDecoder{ctrl: ctrl}
-	mock.recorder = &MockballotDecoderMockRecorder{mock}
+// NewMocktortoiseProvider creates a new mock instance.
+func NewMocktortoiseProvider(ctrl *gomock.Controller) *MocktortoiseProvider {
+	mock := &MocktortoiseProvider{ctrl: ctrl}
+	mock.recorder = &MocktortoiseProviderMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockballotDecoder) EXPECT() *MockballotDecoderMockRecorder {
+func (m *MocktortoiseProvider) EXPECT() *MocktortoiseProviderMockRecorder {
 	return m.recorder
 }
 
 // DecodeBallot mocks base method.
-func (m *MockballotDecoder) DecodeBallot(arg0 *types.BallotTortoiseData) (*tortoise.DecodedBallot, error) {
+func (m *MocktortoiseProvider) DecodeBallot(arg0 *types.BallotTortoiseData) (*tortoise.DecodedBallot, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DecodeBallot", arg0)
 	ret0, _ := ret[0].(*tortoise.DecodedBallot)
@@ -137,13 +137,13 @@ func (m *MockballotDecoder) DecodeBallot(arg0 *types.BallotTortoiseData) (*torto
 }
 
 // DecodeBallot indicates an expected call of DecodeBallot.
-func (mr *MockballotDecoderMockRecorder) DecodeBallot(arg0 interface{}) *gomock.Call {
+func (mr *MocktortoiseProviderMockRecorder) DecodeBallot(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DecodeBallot", reflect.TypeOf((*MockballotDecoder)(nil).DecodeBallot), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DecodeBallot", reflect.TypeOf((*MocktortoiseProvider)(nil).DecodeBallot), arg0)
 }
 
 // GetBallot mocks base method.
-func (m *MockballotDecoder) GetBallot(arg0 types.BallotID) *tortoise.BallotData {
+func (m *MocktortoiseProvider) GetBallot(arg0 types.BallotID) *tortoise.BallotData {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetBallot", arg0)
 	ret0, _ := ret[0].(*tortoise.BallotData)
@@ -151,13 +151,13 @@ func (m *MockballotDecoder) GetBallot(arg0 types.BallotID) *tortoise.BallotData 
 }
 
 // GetBallot indicates an expected call of GetBallot.
-func (mr *MockballotDecoderMockRecorder) GetBallot(arg0 interface{}) *gomock.Call {
+func (mr *MocktortoiseProviderMockRecorder) GetBallot(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBallot", reflect.TypeOf((*MockballotDecoder)(nil).GetBallot), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBallot", reflect.TypeOf((*MocktortoiseProvider)(nil).GetBallot), arg0)
 }
 
 // GetMissingActiveSet mocks base method.
-func (m *MockballotDecoder) GetMissingActiveSet(arg0 types.EpochID, arg1 []types.ATXID) []types.ATXID {
+func (m *MocktortoiseProvider) GetMissingActiveSet(arg0 types.EpochID, arg1 []types.ATXID) []types.ATXID {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMissingActiveSet", arg0, arg1)
 	ret0, _ := ret[0].([]types.ATXID)
@@ -165,13 +165,13 @@ func (m *MockballotDecoder) GetMissingActiveSet(arg0 types.EpochID, arg1 []types
 }
 
 // GetMissingActiveSet indicates an expected call of GetMissingActiveSet.
-func (mr *MockballotDecoderMockRecorder) GetMissingActiveSet(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MocktortoiseProviderMockRecorder) GetMissingActiveSet(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMissingActiveSet", reflect.TypeOf((*MockballotDecoder)(nil).GetMissingActiveSet), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMissingActiveSet", reflect.TypeOf((*MocktortoiseProvider)(nil).GetMissingActiveSet), arg0, arg1)
 }
 
 // StoreBallot mocks base method.
-func (m *MockballotDecoder) StoreBallot(arg0 *tortoise.DecodedBallot) error {
+func (m *MocktortoiseProvider) StoreBallot(arg0 *tortoise.DecodedBallot) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StoreBallot", arg0)
 	ret0, _ := ret[0].(error)
@@ -179,9 +179,9 @@ func (m *MockballotDecoder) StoreBallot(arg0 *tortoise.DecodedBallot) error {
 }
 
 // StoreBallot indicates an expected call of StoreBallot.
-func (mr *MockballotDecoderMockRecorder) StoreBallot(arg0 interface{}) *gomock.Call {
+func (mr *MocktortoiseProviderMockRecorder) StoreBallot(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StoreBallot", reflect.TypeOf((*MockballotDecoder)(nil).StoreBallot), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StoreBallot", reflect.TypeOf((*MocktortoiseProvider)(nil).StoreBallot), arg0)
 }
 
 // MockvrfVerifier is a mock of vrfVerifier interface.

--- a/tortoise/algorithm.go
+++ b/tortoise/algorithm.go
@@ -312,6 +312,32 @@ type DecodedBallot struct {
 	minHint types.LayerID
 }
 
+type BallotData struct {
+	ID           types.BallotID
+	Layer        types.LayerID
+	ATXID        types.ATXID
+	Smesher      types.NodeID
+	Beacon       types.Beacon
+	Eligiblities uint32
+}
+
+func (t *Tortoise) GetBallot(id types.BallotID) *BallotData {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	info := t.trtl.ballotRefs[id]
+	if info == nil {
+		return nil
+	}
+	return &BallotData{
+		ID:           id,
+		Layer:        info.layer,
+		ATXID:        info.reference.atxid,
+		Smesher:      info.reference.smesher,
+		Beacon:       info.reference.beacon,
+		Eligiblities: info.reference.expectedBallots,
+	}
+}
+
 // DecodeBallot decodes ballot if it wasn't processed earlier.
 func (t *Tortoise) DecodeBallot(ballot *types.BallotTortoiseData) (*DecodedBallot, error) {
 	start := time.Now()

--- a/tortoise/algorithm_test.go
+++ b/tortoise/algorithm_test.go
@@ -1,0 +1,46 @@
+package tortoise
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetBallot(t *testing.T) {
+	const n = 2
+	var activeset []*atxAction
+	s := newSession(t)
+	for i := 0; i < n; i++ {
+		activeset = append(
+			activeset,
+			s.smesher(i).atx(1, new(aopt).height(100).weight(400)),
+		)
+	}
+
+	ref := s.smesher(0).atx(1).ballot(1, new(bopt).
+		beacon("a").
+		activeset(activeset...).
+		eligibilities(s.layerSize/n))
+
+	secondary := s.smesher(0).atx(1).ballot(2)
+
+	trt := s.tortoise()
+	s.runOn(trt)
+
+	require.Equal(t, trt.GetBallot(ref.ID), &BallotData{
+		ID:           ref.ID,
+		Layer:        ref.Layer,
+		ATXID:        ref.AtxID,
+		Smesher:      ref.Smesher,
+		Beacon:       ref.EpochData.Beacon,
+		Eligiblities: ref.EpochData.Eligibilities,
+	})
+	require.Equal(t, trt.GetBallot(secondary.ID), &BallotData{
+		ID:           secondary.ID,
+		Layer:        secondary.Layer,
+		ATXID:        secondary.AtxID,
+		Smesher:      secondary.Smesher,
+		Beacon:       ref.EpochData.Beacon,
+		Eligiblities: ref.EpochData.Eligibilities,
+	})
+}

--- a/tortoise/state.go
+++ b/tortoise/state.go
@@ -221,9 +221,12 @@ type (
 	}
 
 	referenceInfo struct {
-		weight *big.Rat
-		height uint64
-		beacon types.Beacon
+		smesher         types.NodeID
+		atxid           types.ATXID
+		expectedBallots uint32
+		beacon          types.Beacon
+		weight          *big.Rat
+		height          uint64
 	}
 
 	ballotInfo struct {

--- a/tortoise/tortoise.go
+++ b/tortoise/tortoise.go
@@ -697,9 +697,12 @@ func (t *turtle) decodeBallot(ballot *types.BallotTortoiseData) (*ballotInfo, ty
 			return nil, 0, err
 		}
 		refinfo = &referenceInfo{
-			height: atx.height,
-			beacon: ballot.EpochData.Beacon,
-			weight: big.NewRat(int64(atx.weight), int64(expected)),
+			smesher:         ballot.Smesher,
+			atxid:           ballot.AtxID,
+			expectedBallots: ballot.EpochData.Eligibilities,
+			beacon:          ballot.EpochData.Beacon,
+			height:          atx.height,
+			weight:          big.NewRat(int64(atx.weight), int64(expected)),
 		}
 	} else if ballot.Ref != nil {
 		ptr := *ballot.Ref


### PR DESCRIPTION
related: https://github.com/spacemeshos/go-spacemesh/issues/4927

this change eliminates database lookups on ballot validation path, with an exception of when lru cache is not sufficient to hold
vrf nonces and activations. in that case we will have to load them from db, that can be optimized later by fitting more in lru cache https://github.com/spacemeshos/go-spacemesh/pull/4935 or reusing tortoise dataset as well

- fetcher will be asked for ballots only if we don't have them in memory
- reference ballots for eligibility validation will be fetched from tortoise
