### PR TITLE
[Merged by Bors] - hare3: switch to sync validation for gossip messages

### DIFF
--- a/hare/consensus_test.go
+++ b/hare/consensus_test.go
@@ -498,7 +498,7 @@ func (ps *delayedPubSub) Publish(ctx context.Context, protocol string, msg []byt
 	return nil
 }
 
-func (ps *delayedPubSub) Register(protocol string, handler pubsub.GossipHandler) {
+func (ps *delayedPubSub) Register(protocol string, handler pubsub.GossipHandler, opts ...pubsub.ValidatorOpt) {
 	if ps.recvDelay != 0 {
 		handler = func(ctx context.Context, pid p2p.Peer, msg []byte) error {
 			rng := time.Duration(rand.Uint32()) * time.Second % ps.recvDelay
@@ -609,6 +609,6 @@ func (eps *equivocatePubSub) Publish(ctx context.Context, protocol string, data 
 	return nil
 }
 
-func (eps *equivocatePubSub) Register(protocol string, handler pubsub.GossipHandler) {
+func (eps *equivocatePubSub) Register(protocol string, handler pubsub.GossipHandler, opts ...pubsub.ValidatorOpt) {
 	eps.ps.Register(protocol, handler)
 }

--- a/hare/flows_test.go
+++ b/hare/flows_test.go
@@ -106,7 +106,7 @@ type p2pManipulator struct {
 	err          error
 }
 
-func (m *p2pManipulator) Register(protocol string, handler pubsub.GossipHandler) {
+func (m *p2pManipulator) Register(protocol string, handler pubsub.GossipHandler, opts ...pubsub.ValidatorOpt) {
 	m.nd.Register(protocol, handler)
 }
 

--- a/hare3/hare.go
+++ b/hare3/hare.go
@@ -207,7 +207,7 @@ func (h *Hare) Coins() <-chan WeakCoinOutput {
 }
 
 func (h *Hare) Start() {
-	h.pubsub.Register(h.config.ProtocolName, h.Handler)
+	h.pubsub.Register(h.config.ProtocolName, h.Handler, pubsub.WithValidatorInline(true))
 	current := h.nodeclock.CurrentLayer() + 1
 	enabled := types.MaxLayer(current, h.config.EnableLayer)
 	enabled = types.MaxLayer(enabled, types.GetEffectiveGenesis()+1)

--- a/hare3/hare_test.go
+++ b/hare3/hare_test.go
@@ -198,7 +198,7 @@ func (n *node) withOracle() *node {
 
 func (n *node) withPublisher() *node {
 	n.mpublisher = pmocks.NewMockPublishSubsciber(n.ctrl)
-	n.mpublisher.EXPECT().Register(gomock.Any(), gomock.Any()).AnyTimes()
+	n.mpublisher.EXPECT().Register(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 	return n
 }
 

--- a/p2p/pubsub/mocks/publisher.go
+++ b/p2p/pubsub/mocks/publisher.go
@@ -73,15 +73,20 @@ func (m *MockSubscriber) EXPECT() *MockSubscriberMockRecorder {
 }
 
 // Register mocks base method.
-func (m *MockSubscriber) Register(arg0 string, arg1 pubsub.GossipHandler) {
+func (m *MockSubscriber) Register(arg0 string, arg1 pubsub.GossipHandler, arg2 ...pubsub.ValidatorOpt) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Register", arg0, arg1)
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	m.ctrl.Call(m, "Register", varargs...)
 }
 
 // Register indicates an expected call of Register.
-func (mr *MockSubscriberMockRecorder) Register(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockSubscriberMockRecorder) Register(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Register", reflect.TypeOf((*MockSubscriber)(nil).Register), arg0, arg1)
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Register", reflect.TypeOf((*MockSubscriber)(nil).Register), varargs...)
 }
 
 // MockPublishSubsciber is a mock of PublishSubsciber interface.
@@ -122,13 +127,18 @@ func (mr *MockPublishSubsciberMockRecorder) Publish(arg0, arg1, arg2 interface{}
 }
 
 // Register mocks base method.
-func (m *MockPublishSubsciber) Register(arg0 string, arg1 pubsub.GossipHandler) {
+func (m *MockPublishSubsciber) Register(arg0 string, arg1 pubsub.GossipHandler, arg2 ...pubsub.ValidatorOpt) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Register", arg0, arg1)
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	m.ctrl.Call(m, "Register", varargs...)
 }
 
 // Register indicates an expected call of Register.
-func (mr *MockPublishSubsciberMockRecorder) Register(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockPublishSubsciberMockRecorder) Register(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Register", reflect.TypeOf((*MockPublishSubsciber)(nil).Register), arg0, arg1)
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Register", reflect.TypeOf((*MockPublishSubsciber)(nil).Register), varargs...)
 }

--- a/p2p/pubsub/pubsub.go
+++ b/p2p/pubsub/pubsub.go
@@ -119,8 +119,12 @@ type Publisher interface {
 
 // Subscriber is an interface for subcribing to messages.
 type Subscriber interface {
-	Register(string, GossipHandler)
+	Register(string, GossipHandler, ...ValidatorOpt)
 }
+
+type ValidatorOpt = pubsub.ValidatorOpt
+
+var WithValidatorInline = pubsub.WithValidatorInline
 
 // PublishSubsciber common interface for publisher and subscribing.
 type PublishSubsciber interface {

--- a/p2p/pubsub/wrapper.go
+++ b/p2p/pubsub/wrapper.go
@@ -26,7 +26,7 @@ type PubSub struct {
 }
 
 // Register handler for topic.
-func (ps *PubSub) Register(topic string, handler GossipHandler) {
+func (ps *PubSub) Register(topic string, handler GossipHandler, opts ...ValidatorOpt) {
 	ps.mu.Lock()
 	defer ps.mu.Unlock()
 	if _, exist := ps.topics[topic]; exist {
@@ -47,7 +47,7 @@ func (ps *PubSub) Register(topic string, handler GossipHandler) {
 		default:
 			return pubsub.ValidationAccept
 		}
-	})
+	}, opts...)
 	topich, err := ps.pubsub.Join(topic)
 	if err != nil {
 		ps.logger.With().Panic("failed to join a topic", log.String("topic", topic), log.Err(err))


### PR DESCRIPTION
currently every validation request spawns new goroutine, the main reason for that was
to enable fetching over network without blocking other threads.

however hare3 will be spawning many goroutines and it will be much more efficient to execute protocol inline.
the same is true for beacon.