### PR TITLE
[Merged by Bors] - tortoise: load ref ballots before other

### DIFF
--- a/tortoise/recover.go
+++ b/tortoise/recover.go
@@ -111,7 +111,14 @@ func RecoverLayer(ctx context.Context, trtl *Tortoise, db *datastore.CachedDB, b
 		return err
 	}
 	for _, ballot := range ballotsrst {
-		trtl.OnBallot(ballot.ToTortoiseData())
+		if ballot.EpochData != nil {
+			trtl.OnBallot(ballot.ToTortoiseData())
+		}
+	}
+	for _, ballot := range ballotsrst {
+		if ballot.EpochData == nil {
+			trtl.OnBallot(ballot.ToTortoiseData())
+		}
 	}
 	coin, err := layers.GetWeakCoin(db, lid)
 	if err != nil && !errors.Is(err, sql.ErrNotFound) {


### PR DESCRIPTION
this can be seen as attack, where ref ballots is published, everyone is using that as base ballot, 
and then ref ballot gets cancelled. 
we still need to load it in state, otherwise it may block counting honest ballots
