### PR TITLE
[Merged by Bors] - miner: parametrize threshold for picking active set from first block

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -74,8 +74,7 @@ func (cfg *Config) DataDir() string {
 }
 
 type TestConfig struct {
-	SmesherKey      string `mapstructure:"testing-smesher-key"`
-	MinerGoodAtxPct int
+	SmesherKey string `mapstructure:"testing-smesher-key"`
 }
 
 // BaseConfig defines the default configuration options for spacemesh app.
@@ -114,6 +113,10 @@ type BaseConfig struct {
 	DatabaseLatencyMetering bool `mapstructure:"db-latency-metering"`
 
 	NetworkHRP string `mapstructure:"network-hrp"`
+
+	// MinerGoodAtxsPercent is a threshold to decide if tortoise activeset should be
+	// picked from first block insted of synced data.
+	MinerGoodAtxsPercent int `mapstructure:"miner-good-atxs-percent"`
 }
 
 type PublicMetrics struct {

--- a/config/presets/fastnet.go
+++ b/config/presets/fastnet.go
@@ -23,7 +23,8 @@ func fastnet() config.Config {
 	types.SetNetworkHRP(conf.NetworkHRP) // set to generate coinbase
 	conf.BaseConfig.OptFilterThreshold = 90
 
-	conf.BaseConfig.TestConfig.MinerGoodAtxPct = 50
+	// set for systest TestEquivocation
+	conf.BaseConfig.MinerGoodAtxsPercent = 50
 
 	conf.HARE.Disable = 1 // non-zero low layer will prevent hare1 from running
 	conf.HARE.N = 800

--- a/node/node.go
+++ b/node/node.go
@@ -789,9 +789,8 @@ func (app *App) initServices(ctx context.Context) error {
 	}
 
 	minerGoodAtxPct := 90
-	if app.Config.TestConfig.MinerGoodAtxPct > 0 {
-		// only set this for systest TestEquivocation.
-		minerGoodAtxPct = app.Config.TestConfig.MinerGoodAtxPct
+	if app.Config.MinerGoodAtxsPercent > 0 {
+		minerGoodAtxPct = app.Config.MinerGoodAtxsPercent
 	}
 	proposalBuilder := miner.NewProposalBuilder(
 		ctx,


### PR DESCRIPTION
this is not a protocol parameter, no reason to hardcode, this is local heuristic for a node to decide if it wants to build block from atxs synced on time, or from first block
