### PR TITLE
[Merged by Bors] - miner: do not omit own atx in active set

### DIFF
--- a/miner/oracle.go
+++ b/miner/oracle.go
@@ -155,7 +155,7 @@ func (o *Oracle) activeSet(targetEpoch types.EpochID) (uint64, uint64, types.ATX
 		if err != nil {
 			return err
 		}
-		if grade != Good {
+		if grade != Good && header.NodeID != o.cfg.nodeID {
 			o.log.With().Info("atx omitted from active set",
 				header.ID,
 				log.Int("grade", int(grade)),

--- a/proposals/handler.go
+++ b/proposals/handler.go
@@ -410,7 +410,11 @@ func (h *Handler) checkBallotSyntacticValidity(ctx context.Context, logger log.L
 	t4 := time.Now()
 	if eligible, err := h.validator.CheckEligibility(ctx, b); err != nil || !eligible {
 		notEligible.Inc()
-		return nil, fmt.Errorf("%w: %v", errNotEligible, err.Error())
+		var reason string
+		if err != nil {
+			reason = err.Error()
+		}
+		return nil, fmt.Errorf("%w: %v", errNotEligible, reason)
 	}
 	ballotDuration.WithLabelValues(eligible).Observe(float64(time.Since(t4)))
 

--- a/proposals/handler.go
+++ b/proposals/handler.go
@@ -410,7 +410,7 @@ func (h *Handler) checkBallotSyntacticValidity(ctx context.Context, logger log.L
 	t4 := time.Now()
 	if eligible, err := h.validator.CheckEligibility(ctx, b); err != nil || !eligible {
 		notEligible.Inc()
-		return nil, errNotEligible
+		return nil, fmt.Errorf("%w: %v", errNotEligible, err.Error())
 	}
 	ballotDuration.WithLabelValues(eligible).Observe(float64(time.Since(t4)))
 


### PR DESCRIPTION
## Motivation
syncing from devnet-405, malicious identities filter out own atx and cause other nodes to fail processing the ballot

```
2023-09-02T14:58:23.344-0700	WARN	5fbb1.sync	failed fetching new ballots	{"node_id": "5fbb17185b5850709b3c545e3be4fbea25a30d3362a0627d974495e96d8b640b", "module": "sync", "sessionId": "6123c073-483d-41ad-b514-77e47167f48f", "layer_id": 11549, "ballot_ids": ["6a70a5a8d0", "f3205c8f79", "1efadf7bbe", "dc0881473b", "57577ea37f", "1f3110b841", "c9f0910457", "f2e8dac11e", "c97b5ff911", "f824639d3b"], "errmsg": "hint: ballotDB, hash: 0x1f3110b8411255368ffc35e90c2f17ad3a898a13000000000000000000000000, err: fetch ballots: hint: ballotDB, hash: 0x926af68ad85b7db9d5a0fbd57ddefdbb32838149000000000000000000000000, err: ballot not eligible: atx 086658fac6 from ballot 926af68ad8 (refballot 926af68ad8) is not included into the active set\nhint: ballotDB, hash: 0xc9f0910457dfab80334c80e77cf6673fe408adcb000000000000000000000000, err: fetch ballots: hint: ballotDB, hash: 0x37df2b14296708054511e2627f1094f5b8528eb3000000000000000000000000, err: fetch ballots: hint: ballotDB, hash: 0x5b91d74480e89f741045aa9c4f95501b02fc3d53000000000000000000000000, err: ballot not eligible: atx e9aff052ae from ballot 5b91d74480 (refballot 5b91d74480) is not included into the active set", "name": "sync"}
```