### PR TITLE
[Merged by Bors] - Avoid races in postVerifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 See [RELEASE](./RELEASE.md) for workflow instructions.
 
+## UNRELEASED
+
+### Upgrade information
+
+### Highlights
+
+### Features
+
+### Improvements
+
+* [#4965](https://github.com/spacemeshos/go-spacemesh/pull/4965) Updates to PoST to prevent races and corruption of `postdata_metadata.json`.
+
 ## v1.1.4
 
 ### Upgrade information

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ See [RELEASE](./RELEASE.md) for workflow instructions.
 
 ### Improvements
 
-* [#4965](https://github.com/spacemeshos/go-spacemesh/pull/4965) Updates to PoST to prevent races and corruption of `postdata_metadata.json`.
+* [#4965](https://github.com/spacemeshos/go-spacemesh/pull/4965) Updates to PoST:
+  * Prevent errors when shutting down the node that can result in a crash
+  * `postdata_metadata.json` is now updated atomically to prevent corruption of the file.
 
 ## v1.1.4
 

--- a/activation/post_verifier.go
+++ b/activation/post_verifier.go
@@ -118,6 +118,8 @@ func (v *OffloadingPostVerifier) Verify(ctx context.Context, p *shared.Proof, m 
 	select {
 	case res := <-job.result:
 		return res
+	case <-v.stopped:
+		return fmt.Errorf("verifier is closed")
 	case <-ctx.Done():
 		return fmt.Errorf("waiting for verification result: %w", ctx.Err())
 	}

--- a/activation/post_verifier.go
+++ b/activation/post_verifier.go
@@ -106,14 +106,11 @@ func (v *OffloadingPostVerifier) Verify(ctx context.Context, p *shared.Proof, m 
 		opts:     opts,
 		result:   make(chan error, 1),
 	}
-	select {
-	case <-v.stopped:
-		return fmt.Errorf("verifier is closed")
-	default:
-	}
 
 	select {
 	case v.channel <- job:
+	case <-v.stopped:
+		return fmt.Errorf("verifier is closed")
 	case <-ctx.Done():
 		return fmt.Errorf("submitting verifying job: %w", ctx.Err())
 	}

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/spacemeshos/go-scale v1.1.10
 	github.com/spacemeshos/merkle-tree v0.2.3
 	github.com/spacemeshos/poet v0.9.1
-	github.com/spacemeshos/post v0.9.3
+	github.com/spacemeshos/post v0.9.4-0.20230905092229-49fa3266160d
 	github.com/spf13/afero v1.9.5
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/spacemeshos/go-scale v1.1.10
 	github.com/spacemeshos/merkle-tree v0.2.3
 	github.com/spacemeshos/poet v0.9.1
-	github.com/spacemeshos/post v0.9.4-0.20230905092229-49fa3266160d
+	github.com/spacemeshos/post v0.9.4-0.20230906080430-bc06d3f20254
 	github.com/spf13/afero v1.9.5
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/spacemeshos/go-scale v1.1.10
 	github.com/spacemeshos/merkle-tree v0.2.3
 	github.com/spacemeshos/poet v0.9.1
-	github.com/spacemeshos/post v0.9.4-0.20230906080430-bc06d3f20254
+	github.com/spacemeshos/post v0.9.4
 	github.com/spf13/afero v1.9.5
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -622,8 +622,8 @@ github.com/spacemeshos/merkle-tree v0.2.3 h1:zGEgOR9nxAzJr0EWjD39QFngwFEOxfxMloE
 github.com/spacemeshos/merkle-tree v0.2.3/go.mod h1:VomOcQ5pCBXz7goiWMP5hReyqOfDXGSKbrH2GB9Htww=
 github.com/spacemeshos/poet v0.9.1 h1:10wiGjuuGCZq9mAuQjRvNCpE5Uv0KU6yW5eynUCIECU=
 github.com/spacemeshos/poet v0.9.1/go.mod h1:ccxzHl5IRSenCSqonPI8M+5vPNwN+o3QU2X41bhbcao=
-github.com/spacemeshos/post v0.9.4-0.20230906080430-bc06d3f20254 h1:OqpBiAY1M7iE4Bs0PDCfibtLzvOFxbUPzNBajrme0oM=
-github.com/spacemeshos/post v0.9.4-0.20230906080430-bc06d3f20254/go.mod h1:xroXgbvQG6asqAYJzAPvNMIctGwgpagSRq9bHID9O68=
+github.com/spacemeshos/post v0.9.4 h1:l/KGneUnLH5imy2Uml7G9kBnJuzl4ag0ku3U0OWaTxc=
+github.com/spacemeshos/post v0.9.4/go.mod h1:YjYLMcFFSpxrI86TW2rhyWCWRRFG+8LPiONgARNuaP4=
 github.com/spacemeshos/sha256-simd v0.1.0 h1:G7Mfu5RYdQiuE+wu4ZyJ7I0TI74uqLhFnKblEnSpjYI=
 github.com/spacemeshos/sha256-simd v0.1.0/go.mod h1:O8CClVIilId7RtuCMV2+YzMj6qjVn75JsxOxaE8vcfM=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=

--- a/go.sum
+++ b/go.sum
@@ -622,8 +622,8 @@ github.com/spacemeshos/merkle-tree v0.2.3 h1:zGEgOR9nxAzJr0EWjD39QFngwFEOxfxMloE
 github.com/spacemeshos/merkle-tree v0.2.3/go.mod h1:VomOcQ5pCBXz7goiWMP5hReyqOfDXGSKbrH2GB9Htww=
 github.com/spacemeshos/poet v0.9.1 h1:10wiGjuuGCZq9mAuQjRvNCpE5Uv0KU6yW5eynUCIECU=
 github.com/spacemeshos/poet v0.9.1/go.mod h1:ccxzHl5IRSenCSqonPI8M+5vPNwN+o3QU2X41bhbcao=
-github.com/spacemeshos/post v0.9.3 h1:3khU8uSxjicOYrfg3tFP26YyTkbsmbJt1uLJN93ScH4=
-github.com/spacemeshos/post v0.9.3/go.mod h1:sWxWEfxH4wc4D2KCY0kBMu4ezz/v52Km/N023SaCcNE=
+github.com/spacemeshos/post v0.9.4-0.20230905092229-49fa3266160d h1:Wdpu3YDU4lNBY1jM9qyS6DPSg2k3XxSz53qr8OWWPhk=
+github.com/spacemeshos/post v0.9.4-0.20230905092229-49fa3266160d/go.mod h1:sWxWEfxH4wc4D2KCY0kBMu4ezz/v52Km/N023SaCcNE=
 github.com/spacemeshos/sha256-simd v0.1.0 h1:G7Mfu5RYdQiuE+wu4ZyJ7I0TI74uqLhFnKblEnSpjYI=
 github.com/spacemeshos/sha256-simd v0.1.0/go.mod h1:O8CClVIilId7RtuCMV2+YzMj6qjVn75JsxOxaE8vcfM=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=

--- a/go.sum
+++ b/go.sum
@@ -622,8 +622,8 @@ github.com/spacemeshos/merkle-tree v0.2.3 h1:zGEgOR9nxAzJr0EWjD39QFngwFEOxfxMloE
 github.com/spacemeshos/merkle-tree v0.2.3/go.mod h1:VomOcQ5pCBXz7goiWMP5hReyqOfDXGSKbrH2GB9Htww=
 github.com/spacemeshos/poet v0.9.1 h1:10wiGjuuGCZq9mAuQjRvNCpE5Uv0KU6yW5eynUCIECU=
 github.com/spacemeshos/poet v0.9.1/go.mod h1:ccxzHl5IRSenCSqonPI8M+5vPNwN+o3QU2X41bhbcao=
-github.com/spacemeshos/post v0.9.4-0.20230905092229-49fa3266160d h1:Wdpu3YDU4lNBY1jM9qyS6DPSg2k3XxSz53qr8OWWPhk=
-github.com/spacemeshos/post v0.9.4-0.20230905092229-49fa3266160d/go.mod h1:sWxWEfxH4wc4D2KCY0kBMu4ezz/v52Km/N023SaCcNE=
+github.com/spacemeshos/post v0.9.4-0.20230906080430-bc06d3f20254 h1:OqpBiAY1M7iE4Bs0PDCfibtLzvOFxbUPzNBajrme0oM=
+github.com/spacemeshos/post v0.9.4-0.20230906080430-bc06d3f20254/go.mod h1:xroXgbvQG6asqAYJzAPvNMIctGwgpagSRq9bHID9O68=
 github.com/spacemeshos/sha256-simd v0.1.0 h1:G7Mfu5RYdQiuE+wu4ZyJ7I0TI74uqLhFnKblEnSpjYI=
 github.com/spacemeshos/sha256-simd v0.1.0/go.mod h1:O8CClVIilId7RtuCMV2+YzMj6qjVn75JsxOxaE8vcfM=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=

--- a/node/node.go
+++ b/node/node.go
@@ -1031,13 +1031,6 @@ func (app *App) startServices(ctx context.Context) error {
 	if err := app.fetcher.Start(); err != nil {
 		return fmt.Errorf("failed to start fetcher: %w", err)
 	}
-	app.eg.Go(func() error {
-		app.postVerifier.Start(ctx)
-		// Start only returns when the context expires (which means the system
-		// is shutting down). We do the closing of the post verifier here so
-		// it's ensured that start has returned before we call Close.
-		return app.postVerifier.Close()
-	})
 	app.syncer.Start()
 	app.beaconProtocol.Start(ctx)
 
@@ -1208,6 +1201,10 @@ func (app *App) stopServices(ctx context.Context) {
 
 	if app.atxBuilder != nil {
 		_ = app.atxBuilder.StopSmeshing(false)
+	}
+
+	if app.postVerifier != nil {
+		app.postVerifier.Close()
 	}
 
 	if app.hare != nil {


### PR DESCRIPTION
## Motivation
Closes #4910, merge after https://github.com/spacemeshos/post/pull/232.

## Changes
- Removed `Start` method, a verifier returned from `NewOffloadingPostVerifier` is ready to be used
- `Close` cancels ongoing verifications and avoids new ones being started
- Updated `node.go` to use the new API

## Test Plan
- existing tests pass

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
