### PR TITLE
[Merged by Bors] - Skip mocks in codecov

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -14,4 +14,5 @@ ignore:
   - "cmd"
   - "**/*_scale.go"
   - "**/*mock*.go"
+  - "**/mocks/*.go"
   - systest


### PR DESCRIPTION
Don't include mocks in the Codecov report.