### PR TITLE
[Merged by Bors] - Fix import for github.com/go-llsqlite/crawshaw

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/benbjohnson/clock v1.3.5
 	github.com/chaos-mesh/chaos-mesh/api v0.0.0-20230907091128-3c83a50b6d59
 	github.com/cosmos/btcutil v1.0.5
-	github.com/go-llsqlite/crawshaw v0.0.0-20230904103556-219a9360a2c0
+	github.com/go-llsqlite/crawshaw v0.0.0-20230910110433-7e901377eb6c
 	github.com/gofrs/flock v0.8.1
 	github.com/golang/protobuf v1.5.3
 	github.com/google/go-cmp v0.5.9

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/benbjohnson/clock v1.3.5
 	github.com/chaos-mesh/chaos-mesh/api v0.0.0-20230907091128-3c83a50b6d59
 	github.com/cosmos/btcutil v1.0.5
-	github.com/go-llsqlite/llsqlite v0.0.0-20230612031458-a9e271fe723a
+	github.com/go-llsqlite/crawshaw v0.0.0-20230904103556-219a9360a2c0
 	github.com/gofrs/flock v0.8.1
 	github.com/golang/protobuf v1.5.3
 	github.com/google/go-cmp v0.5.9

--- a/go.sum
+++ b/go.sum
@@ -161,8 +161,8 @@ github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vbaY=
-github.com/go-llsqlite/crawshaw v0.0.0-20230904103556-219a9360a2c0 h1:gBgO8x7vT06pP8D3v/IQ38mBnITO8lUDQyTq9nilUaI=
-github.com/go-llsqlite/crawshaw v0.0.0-20230904103556-219a9360a2c0/go.mod h1:Hw0HOqxPMRCkOI87dESIgpdJrRR43OwYN0tbEFyG4OQ=
+github.com/go-llsqlite/crawshaw v0.0.0-20230910110433-7e901377eb6c h1:pm7z8uwA2q3s8fAsJmKuGckNohqIrw2PRtv6yJ6z0Ro=
+github.com/go-llsqlite/crawshaw v0.0.0-20230910110433-7e901377eb6c/go.mod h1:UdTSzmN3nr5dJNuZCsbPLfhSQB76u16rWh8pn+WFx9Q=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
 github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/go.sum
+++ b/go.sum
@@ -161,8 +161,8 @@ github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vbaY=
-github.com/go-llsqlite/llsqlite v0.0.0-20230612031458-a9e271fe723a h1:2GgRlm6BrV7CIOjjE/o7WJs6foe33AqCQC8bnl1RJQc=
-github.com/go-llsqlite/llsqlite v0.0.0-20230612031458-a9e271fe723a/go.mod h1:suaTfGNQ00ObHGOoHxPb8pkAki7jm0/ZkR2rcY9yF1s=
+github.com/go-llsqlite/crawshaw v0.0.0-20230904103556-219a9360a2c0 h1:gBgO8x7vT06pP8D3v/IQ38mBnITO8lUDQyTq9nilUaI=
+github.com/go-llsqlite/crawshaw v0.0.0-20230904103556-219a9360a2c0/go.mod h1:Hw0HOqxPMRCkOI87dESIgpdJrRR43OwYN0tbEFyG4OQ=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
 github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/sql/database.go
+++ b/sql/database.go
@@ -7,8 +7,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/go-llsqlite/llsqlite"
-	"github.com/go-llsqlite/llsqlite/sqlitex"
+	sqlite "github.com/go-llsqlite/crawshaw"
+	"github.com/go-llsqlite/crawshaw/sqlitex"
 	"github.com/prometheus/client_golang/prometheus"
 )
 

--- a/sql/functions.go
+++ b/sql/functions.go
@@ -3,7 +3,7 @@ package sql
 import (
 	"fmt"
 
-	"github.com/go-llsqlite/llsqlite"
+	sqlite "github.com/go-llsqlite/crawshaw"
 )
 
 func registerFunctions(conn *sqlite.Conn) error {


### PR DESCRIPTION
## Motivation
The library has been renamed from `github.com/go-llsqlite/llsqlite` to `github.com/go-llsqlite/crawshaw`. The old URL links to the new repository.

## Changes
- Update import paths and update dependency to most recent version

## Test Plan
existing tests pass

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [ ] Update [changelog](../CHANGELOG.md) as needed
