### PR TITLE
do not mark self malicious

### DIFF
--- a/activation/handler.go
+++ b/activation/handler.go
@@ -364,7 +364,7 @@ func (h *Handler) storeAtx(ctx context.Context, atx *types.VerifiedActivationTx)
 	}
 	var proof *types.MalfeasanceProof
 	if err := h.cdb.WithTx(ctx, func(dbtx *sql.Tx) error {
-		if !malicious {
+		if !malicious && atx.SmesherID != types.MinerNodeID() {
 			prev, err := atxs.GetByEpochAndNodeID(dbtx, atx.PublishEpoch, atx.SmesherID)
 			if err != nil && !errors.Is(err, sql.ErrNotFound) {
 				return err

--- a/common/types/nodeid.go
+++ b/common/types/nodeid.go
@@ -9,6 +9,18 @@ import (
 	"github.com/spacemeshos/go-spacemesh/log"
 )
 
+var ownNodeID NodeID
+
+func SetMinerNodeID(id NodeID) {
+	if ownNodeID == EmptyNodeID {
+		ownNodeID = id
+	}
+}
+
+func MinerNodeID() NodeID {
+	return ownNodeID
+}
+
 // BytesToNodeID is a helper to copy buffer into NodeID struct.
 func BytesToNodeID(buf []byte) (id NodeID) {
 	copy(id[:], buf)

--- a/hare/hare.go
+++ b/hare/hare.go
@@ -714,6 +714,9 @@ func (h *Hare) malfeasanceLoop(ctx context.Context) {
 			if err != nil {
 				h.WithContext(ctx).With().Panic("failed to encode MalfeasanceProof", log.Err(err))
 			}
+			if gossip.Eligibility.NodeID == types.MinerNodeID() {
+				continue
+			}
 			if err := identities.SetMalicious(h.msh.Cache(), gossip.Eligibility.NodeID, encoded, time.Now()); err != nil {
 				h.With().Error("failed to save MalfeasanceProof",
 					log.Context(ctx),

--- a/hare3/hare.go
+++ b/hare3/hare.go
@@ -286,7 +286,7 @@ func (h *Hare) Handler(ctx context.Context, peer p2p.Peer, buf []byte) error {
 	gossip, equivocation := session.OnInput(input)
 	h.log.Debug("after on message", log.ZShortStringer("hash", input.msgHash), zap.Bool("gossip", gossip))
 	submitLatency.Observe(time.Since(start).Seconds())
-	if equivocation != nil && !malicious {
+	if equivocation != nil && !malicious && msg.Sender != types.MinerNodeID() {
 		h.log.Debug("registered equivocation",
 			zap.Uint32("lid", msg.Layer.Uint32()),
 			zap.Stringer("sender", equivocation.Messages[0].SmesherID))

--- a/malfeasance/handler.go
+++ b/malfeasance/handler.go
@@ -107,6 +107,10 @@ func (h *Handler) validateAndSave(ctx context.Context, p *types.MalfeasanceGossi
 	if err != nil {
 		return types.EmptyNodeID, err
 	}
+	if nodeID == types.MinerNodeID() {
+		h.logger.WithContext(ctx).With().Warning("received gossip for own malfeasance proof", log.Inline(&p.MalfeasanceProof))
+		return nodeID, nil
+	}
 	if err := h.cdb.WithTx(ctx, func(dbtx *sql.Tx) error {
 		malicious, err := identities.IsMalicious(dbtx, nodeID)
 		if err != nil {

--- a/mesh/mesh.go
+++ b/mesh/mesh.go
@@ -567,7 +567,7 @@ func (msh *Mesh) AddBallot(ctx context.Context, ballot *types.Ballot) (*types.Ma
 	// ballots.LayerBallotByNodeID and ballots.Add should be atomic
 	// otherwise concurrent ballots.Add from the same smesher may not be noticed
 	if err = msh.cdb.WithTx(ctx, func(dbtx *sql.Tx) error {
-		if !malicious {
+		if !malicious && ballot.SmesherID != types.MinerNodeID() {
 			prev, err := ballots.LayerBallotByNodeID(dbtx, ballot.Layer, ballot.SmesherID)
 			if err != nil && !errors.Is(err, sql.ErrNotFound) {
 				return err

--- a/node/node.go
+++ b/node/node.go
@@ -163,6 +163,7 @@ func GetCommand() *cobra.Command {
 				if app.edSgn, err = app.LoadOrCreateEdSigner(); err != nil {
 					return fmt.Errorf("could not retrieve identity: %w", err)
 				}
+				types.SetMinerNodeID(app.edSgn.NodeID())
 
 				app.preserve, err = app.LoadCheckpoint(ctx)
 				if err != nil {


### PR DESCRIPTION
## Motivation
to ease adoption of testnet

## Changes
- statically set miner's own node id
- whenever malfeasance proof is generated, check that it's not self