### PR TITLE
[Merged by Bors] - Add new PoET config "poet-request-timeout" and use it instead of GracePeriod for timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ See [RELEASE](./RELEASE.md) for workflow instructions.
 
 ### Upgrade information
 
-A new config `poet-request-timeout` has been added, that defines the timeout for PoET requests. It defaults to 10 seconds.
+A new config `poet-request-timeout` has been added, that defines the timeout for requesting PoET proofs.
+It defaults to 9 minutes so there is enough time to retry if the request fails.
 
 ### Highlights
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 See [RELEASE](./RELEASE.md) for workflow instructions.
 
+## UNRELEASED
+
+### Upgrade information
+
+A new config `poet-request-timeout` has been added, that defines the timeout for PoET requests. It defaults to 10 seconds.
+
+### Highlights
+
+### Features
+
+### Improvements
+
 ## v1.1.5
 
 ### Upgrade information

--- a/activation/activation_test.go
+++ b/activation/activation_test.go
@@ -1278,9 +1278,9 @@ func TestWaitingToBuildNipostChallengeWithJitter(t *testing.T) {
 		// ───▲─────|──────|─────────|----> time
 		//    │     └jitter|         └round start
 		//   now
-		wait := timeToWaitToBuildNipostChallenge(2*time.Hour, time.Hour)
-		require.Greater(t, wait, time.Hour)
-		require.LessOrEqual(t, wait, time.Hour+time.Second*36)
+		deadline := buildNipostChallengeStartDeadline(time.Now().Add(2*time.Hour), time.Hour)
+		require.Greater(t, deadline, time.Now().Add(time.Hour))
+		require.LessOrEqual(t, deadline, time.Now().Add(time.Hour+time.Second*36))
 	})
 	t.Run("after grace period, within max jitter value", func(t *testing.T) {
 		//          ┌──grace period──┐
@@ -1288,10 +1288,10 @@ func TestWaitingToBuildNipostChallengeWithJitter(t *testing.T) {
 		// ─────────|──▲────|────────|----> time
 		//          └ji│tter|        └round start
 		//            now
-		wait := timeToWaitToBuildNipostChallenge(time.Hour-time.Second*10, time.Hour)
-		require.GreaterOrEqual(t, wait, -time.Second*10)
+		deadline := buildNipostChallengeStartDeadline(time.Now().Add(time.Hour-time.Second*10), time.Hour)
+		require.GreaterOrEqual(t, deadline, time.Now().Add(-time.Second*10))
 		// jitter is 1% = 36s for 1h grace period
-		require.LessOrEqual(t, wait, time.Second*(36-10))
+		require.LessOrEqual(t, deadline, time.Now().Add(time.Second*(36-10)))
 	})
 	t.Run("after jitter max value", func(t *testing.T) {
 		//          ┌──grace period──┐
@@ -1299,7 +1299,7 @@ func TestWaitingToBuildNipostChallengeWithJitter(t *testing.T) {
 		// ─────────|──────|──▲──────|----> time
 		//          └jitter|  │       └round start
 		//                   now
-		wait := timeToWaitToBuildNipostChallenge(time.Hour-time.Second*37, time.Hour)
-		require.Less(t, wait, time.Duration(0))
+		deadline := buildNipostChallengeStartDeadline(time.Now().Add(time.Hour-time.Second*37), time.Hour)
+		require.Less(t, deadline, time.Now())
 	})
 }

--- a/activation/nipost_test.go
+++ b/activation/nipost_test.go
@@ -198,6 +198,7 @@ func buildNIPost(tb testing.TB, postProvider *testPostManager, nipostChallenge t
 		PhaseShift:        epoch / 5,
 		CycleGap:          epoch / 10,
 		GracePeriod:       epoch / 10,
+		RequestTimeout:    epoch / 20,
 		RequestRetryDelay: epoch / 100,
 		MaxRequestRetries: 10,
 	}
@@ -244,6 +245,7 @@ func TestNewNIPostBuilderNotInitialized(t *testing.T) {
 		PhaseShift:        epoch / 5,
 		CycleGap:          epoch / 10,
 		GracePeriod:       epoch / 10,
+		RequestTimeout:    epoch / 20,
 		RequestRetryDelay: epoch / 100,
 		MaxRequestRetries: 10,
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -256,7 +256,9 @@ func AddCommands(cmd *cobra.Command) {
 	cmd.PersistentFlags().DurationVar(&cfg.POET.CycleGap, "cycle-gap",
 		cfg.POET.CycleGap, "cycle gap of poet server")
 	cmd.PersistentFlags().DurationVar(&cfg.POET.GracePeriod, "grace-period",
-		cfg.POET.GracePeriod, "propagation time for ATXs in the network")
+		cfg.POET.GracePeriod, "time before PoET round starts when the node builds and submits a challenge")
+	cmd.PersistentFlags().DurationVar(&cfg.POET.RequestTimeout, "poet-request-timeout",
+		cfg.POET.RequestTimeout, "timeout for poet requests")
 
 	/**======================== bootstrap data updater Flags ========================== **/
 	cmd.PersistentFlags().StringVar(&cfg.Bootstrap.URL, "bootstrap-url",

--- a/config/mainnet.go
+++ b/config/mainnet.go
@@ -108,8 +108,8 @@ func MainnetConfig() Config {
 			PhaseShift:        240 * time.Hour,
 			CycleGap:          12 * time.Hour,
 			GracePeriod:       1 * time.Hour,
-			RequestTimeout:    550 * time.Second, // RequestRetryDelay * 2 * MaxRequestRetries*(MaxRequestRetries+1)/2
-			RequestRetryDelay: 5 * time.Second,
+			RequestTimeout:    1100 * time.Second, // RequestRetryDelay * 2 * MaxRequestRetries*(MaxRequestRetries+1)/2
+			RequestRetryDelay: 10 * time.Second,
 			MaxRequestRetries: 10,
 		},
 		POST: activation.PostConfig{

--- a/config/mainnet.go
+++ b/config/mainnet.go
@@ -108,6 +108,7 @@ func MainnetConfig() Config {
 			PhaseShift:        240 * time.Hour,
 			CycleGap:          12 * time.Hour,
 			GracePeriod:       1 * time.Hour,
+			RequestTimeout:    10 * time.Second,
 			RequestRetryDelay: 10 * time.Second,
 			MaxRequestRetries: 10,
 		},

--- a/config/mainnet.go
+++ b/config/mainnet.go
@@ -108,8 +108,8 @@ func MainnetConfig() Config {
 			PhaseShift:        240 * time.Hour,
 			CycleGap:          12 * time.Hour,
 			GracePeriod:       1 * time.Hour,
-			RequestTimeout:    10 * time.Second,
-			RequestRetryDelay: 10 * time.Second,
+			RequestTimeout:    550 * time.Second, // RequestRetryDelay * 2 * MaxRequestRetries*(MaxRequestRetries+1)/2
+			RequestRetryDelay: 5 * time.Second,
 			MaxRequestRetries: 10,
 		},
 		POST: activation.PostConfig{

--- a/config/presets/fastnet.go
+++ b/config/presets/fastnet.go
@@ -88,6 +88,7 @@ func fastnet() config.Config {
 	conf.Beacon.VotesLimit = 100
 
 	conf.POET.GracePeriod = 10 * time.Second
+	conf.POET.RequestTimeout = 3 * time.Second
 	conf.POET.CycleGap = 30 * time.Second
 	conf.POET.PhaseShift = 30 * time.Second
 

--- a/config/presets/fastnet.go
+++ b/config/presets/fastnet.go
@@ -88,9 +88,11 @@ func fastnet() config.Config {
 	conf.Beacon.VotesLimit = 100
 
 	conf.POET.GracePeriod = 10 * time.Second
-	conf.POET.RequestTimeout = 3 * time.Second
 	conf.POET.CycleGap = 30 * time.Second
 	conf.POET.PhaseShift = 30 * time.Second
+	conf.POET.RequestTimeout = 12 * time.Second // RequestRetryDelay * 2 * MaxRequestRetries*(MaxRequestRetries+1)/2
+	conf.POET.RequestRetryDelay = 1 * time.Second
+	conf.POET.MaxRequestRetries = 3
 
 	return conf
 }

--- a/config/presets/standalone.go
+++ b/config/presets/standalone.go
@@ -77,9 +77,11 @@ func standalone() config.Config {
 
 	conf.PoETServers = []string{"http://0.0.0.0:10010"}
 	conf.POET.GracePeriod = 12 * time.Second
-	conf.POET.RequestTimeout = 4 * time.Second
 	conf.POET.CycleGap = 30 * time.Second
 	conf.POET.PhaseShift = 30 * time.Second
+	conf.POET.RequestTimeout = 12 * time.Second // RequestRetryDelay * 2 * MaxRequestRetries*(MaxRequestRetries+1)/2
+	conf.POET.RequestRetryDelay = 1 * time.Second
+	conf.POET.MaxRequestRetries = 3
 
 	conf.P2P.DisableNatPort = true
 

--- a/config/presets/standalone.go
+++ b/config/presets/standalone.go
@@ -76,7 +76,8 @@ func standalone() config.Config {
 	conf.Beacon.VotesLimit = 100
 
 	conf.PoETServers = []string{"http://0.0.0.0:10010"}
-	conf.POET.GracePeriod = 5 * time.Second
+	conf.POET.GracePeriod = 10 * time.Second
+	conf.POET.RequestTimeout = 3 * time.Second
 	conf.POET.CycleGap = 30 * time.Second
 	conf.POET.PhaseShift = 30 * time.Second
 

--- a/config/presets/standalone.go
+++ b/config/presets/standalone.go
@@ -76,8 +76,8 @@ func standalone() config.Config {
 	conf.Beacon.VotesLimit = 100
 
 	conf.PoETServers = []string{"http://0.0.0.0:10010"}
-	conf.POET.GracePeriod = 10 * time.Second
-	conf.POET.RequestTimeout = 3 * time.Second
+	conf.POET.GracePeriod = 12 * time.Second
+	conf.POET.RequestTimeout = 4 * time.Second
 	conf.POET.CycleGap = 30 * time.Second
 	conf.POET.PhaseShift = 30 * time.Second
 

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -1116,7 +1116,7 @@ func TestAdminEvents(t *testing.T) {
 		grpc.WithBlock(),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { conn.Close() })
+	t.Cleanup(func() { assert.NoError(t, conn.Close()) })
 	client := pb.NewAdminServiceClient(conn)
 
 	tctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
@@ -1144,6 +1144,7 @@ func TestAdminEvents(t *testing.T) {
 			require.NoError(t, err, "stream %d", i)
 			require.IsType(t, ev, msg.Details, "stream %d", i)
 		}
+		require.NoError(t, stream.CloseSend())
 	}
 }
 


### PR DESCRIPTION
## Motivation
The NiPoST builder uses `GracePeriod` for two different (unrelated) things: one is a duration relative to a PoET round start. A node waits until then before it starts creating and submitting a challenge to PoET (so that it uses the highest possible ATX it sees until then).

The other use is as a request timeout for requests to PoET. For this a new config parameter "poet-request-timeout" is added to the config. This allows to set much shorter timeouts (1 hour on mainnet is much too long).

## Changes
- add new config parameter "poet-request-timeout"
- the defaults are calculated from the maximum time a request can take based on the linear jitter backoff

## Test Plan
existing tests pass

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
