### PR TITLE
[Merged by Bors] - hare: use epoch first applied block for hare active set

### DIFF
--- a/hare/eligibility/oracle.go
+++ b/hare/eligibility/oracle.go
@@ -421,7 +421,7 @@ func (o *Oracle) computeActiveSet(ctx context.Context, targetEpoch types.EpochID
 		return activeSet, nil
 	}
 
-	activeSet, err := miner.ActiveSetFromEpochFirstCertifiedBlock(o.cdb, targetEpoch)
+	activeSet, err := miner.ActiveSetFromEpochFirstBlock(o.cdb, targetEpoch)
 	if err != nil && !errors.Is(err, sql.ErrNotFound) {
 		return nil, err
 	}

--- a/hare/eligibility/oracle_test.go
+++ b/hare/eligibility/oracle_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/sql/atxs"
 	"github.com/spacemeshos/go-spacemesh/sql/ballots"
 	"github.com/spacemeshos/go-spacemesh/sql/blocks"
-	"github.com/spacemeshos/go-spacemesh/sql/certificates"
+	"github.com/spacemeshos/go-spacemesh/sql/layers"
 	"github.com/spacemeshos/go-spacemesh/system/mocks"
 )
 
@@ -99,7 +99,7 @@ func createBlock(tb testing.TB, cdb *datastore.CachedDB, blts []*types.Ballot) {
 	}
 	block.Initialize()
 	require.NoError(tb, blocks.Add(cdb, block))
-	require.NoError(tb, certificates.Add(cdb, blts[0].Layer, &types.Certificate{BlockID: block.ID()}))
+	require.NoError(tb, layers.SetApplied(cdb, block.LayerIndex, block.ID()))
 }
 
 func createLayerData(tb testing.TB, cdb *datastore.CachedDB, lid types.LayerID, numMiners int) []types.NodeID {

--- a/miner/util.go
+++ b/miner/util.go
@@ -9,17 +9,8 @@ import (
 	"github.com/spacemeshos/go-spacemesh/sql"
 	"github.com/spacemeshos/go-spacemesh/sql/ballots"
 	"github.com/spacemeshos/go-spacemesh/sql/blocks"
-	"github.com/spacemeshos/go-spacemesh/sql/certificates"
 	"github.com/spacemeshos/go-spacemesh/sql/layers"
 )
-
-func ActiveSetFromEpochFirstCertifiedBlock(db sql.Executor, epoch types.EpochID) ([]types.ATXID, error) {
-	bid, err := certificates.FirstInEpoch(db, epoch)
-	if err != nil {
-		return nil, err
-	}
-	return activeSetFromBlock(db, bid)
-}
 
 func ActiveSetFromEpochFirstBlock(db sql.Executor, epoch types.EpochID) ([]types.ATXID, error) {
 	bid, err := layers.FirstAppliedInEpoch(db, epoch)


### PR DESCRIPTION
## Motivation
follow up on #4997 doing the same for hare active set