### PR TITLE
[Merged by Bors] - Fix dependabot not working for go-spacemesh repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 env:
+  go-version: "1.21"
   GCLOUD_KEY: ${{ secrets.GCLOUD_KEY }}
   PROJECT_NAME: ${{ secrets.PROJECT_NAME }}
   CLUSTER_NAME: ${{ secrets.CLUSTER_NAME }}
@@ -65,7 +66,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           check-latest: true
-          go-version-file: "go.mod"
+          go-version: ${{ env.go-version }}
       - name: fmt, tidy, generate
         run: |
           make install
@@ -88,7 +89,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           check-latest: true
-          go-version-file: "go.mod"
+          go-version: ${{ env.go-version }}
       - name: setup env
         run: make install
       - name: staticcheck
@@ -126,7 +127,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           check-latest: true
-          go-version-file: "go.mod"
+          go-version: ${{ env.go-version }}
           cache: ${{ runner.arch != 'arm64' }}
       - name: setup env
         run: make install
@@ -174,7 +175,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           check-latest: true
-          go-version-file: "go.mod"
+          go-version: ${{ env.go-version }}
           cache: ${{ runner.arch != 'arm64' }}
       - name: Add OpenCL support - Ubuntu
         if: ${{ matrix.os == 'ubuntu-latest' }}
@@ -242,7 +243,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           check-latest: true
-          go-version-file: "go.mod"
+          go-version: ${{ env.go-version }}
           cache: ${{ runner.arch != 'arm64' }}
       - name: Add OpenCL support - Ubuntu
         if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/spacemeshos/go-spacemesh
 
-go 1.21.0
+go 1.21.1
 
 require (
 	cloud.google.com/go/storage v1.33.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/spacemeshos/go-spacemesh
 
-go 1.21
+go 1.21.0
 
 require (
 	cloud.google.com/go/storage v1.33.0


### PR DESCRIPTION
## Motivation
`dependabot` has troubles parsing a `go.mod` file with `go 1.21` if it doesn't specify a patch version. (see https://github.com/dependabot/dependabot-core/issues/7895). This PR fixes the issue.

Summary from https://go.dev/doc/toolchain:
The version in `go.mod` now specifies the **minimum** version of go that is required to build the module and **must include** a patch version. Additionally if the module or any of its dependencies require a newer version of go than the compiler the compiler will auto download the required `toolchain`, i.e. the compiler will essentially download the minimum required version of itself if it's older than the newest versions specified by the module or its dependencies.

`go 1.21.0` instructs the compiler to use at least version 1.21.0 or any newer version (if specified by e.g. a dependency) when building the module. We do not need to update the patch version with every new release of go unless go-spacemesh is affected by a bug that was fixed in that release.

`actions/setup-go` doesn't use the newest patch version with `check-version` when it is already specified. With the new behavior this is also not needed, as the `go build` command will automatically download the required toolchain if needed. In case we still want to automatically use the newest patch version to build our binaries we have to set `1.21` and `check-version=true` explicitly for `actions/setup-go`.

## Changes
- specify a minor version in `go.mod` until `dependabot` is able to parse `go 1.21`
- Update `ci.yml` to explicitly use the newest patch version of 1.21 when building go-spacemesh.

## Test Plan
n/a

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
