### PR TITLE
[Merged by Bors] - Replace clock mocking library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.21
 require (
 	cloud.google.com/go/storage v1.33.0
 	github.com/ALTree/bigfloat v0.2.0
-	github.com/benbjohnson/clock v1.3.5
 	github.com/chaos-mesh/chaos-mesh/api v0.0.0-20230912033821-30d9600a7db0
 	github.com/cosmos/btcutil v1.0.5
 	github.com/go-llsqlite/crawshaw v0.0.0-20230910110433-7e901377eb6c
@@ -21,6 +20,7 @@ require (
 	github.com/hashicorp/golang-lru/v2 v2.0.6
 	github.com/ipfs/go-ds-leveldb v0.5.0
 	github.com/ipfs/go-log/v2 v2.5.1
+	github.com/jonboulle/clockwork v0.2.2
 	github.com/libp2p/go-libp2p v0.31.0
 	github.com/libp2p/go-libp2p-kad-dht v0.25.1
 	github.com/libp2p/go-libp2p-pubsub v0.9.3
@@ -68,6 +68,7 @@ require (
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
 	cloud.google.com/go/iam v1.1.1 // indirect
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 // indirect
+	github.com/benbjohnson/clock v1.3.5 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/c0mm4nd/go-ripemd v0.0.0-20200326052756-bd1759ad7d10 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -368,6 +368,8 @@ github.com/jellevandenhooff/dkim v0.0.0-20150330215556-f50fe3d243e1/go.mod h1:E0
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jessevdk/go-flags v1.5.0 h1:1jKYvbxEjfUl0fmqTCOfonvskHHXMjBySTLW4y9LFvc=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
+github.com/jonboulle/clockwork v0.2.2 h1:UOGuzwb1PwsrDAObMuhUnj0p5ULPj8V/xJ7Kx9qUBdQ=
+github.com/jonboulle/clockwork v0.2.2/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=

--- a/timesync/clock_options.go
+++ b/timesync/clock_options.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/benbjohnson/clock"
+	"github.com/jonboulle/clockwork"
 
 	"github.com/spacemeshos/go-spacemesh/log"
 )
 
 type option struct {
-	clock         clock.Clock
+	clock         clockwork.Clock
 	genesisTime   time.Time
 	layerDuration time.Duration
 	tickInterval  time.Duration
@@ -44,7 +44,7 @@ func (o *option) validate() error {
 type OptionFunc func(*option) error
 
 // withClock specifies which clock the NodeClock should use. Defaults to the real clock.
-func withClock(clock clock.Clock) OptionFunc {
+func withClock(clock clockwork.Clock) OptionFunc {
 	return func(opts *option) error {
 		opts.clock = clock
 		return nil


### PR DESCRIPTION
## Motivation
`github.com/benbjohnson/clock` has been archived a while ago. This PR replaces the outdated dependency with `github.com/jonboulle/clockwork`.

## Changes
- Replace uses of `github.com/benbjohnson/clock` with `github.com/jonboulle/clockwork`

## Test Plan
existing tests pass

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
