### PR TITLE
[Merged by Bors] - refuse old proposals from gossip

### DIFF
--- a/blocks/generator.go
+++ b/blocks/generator.go
@@ -135,7 +135,19 @@ func (g *Generator) Stop() {
 	}
 }
 
+func (g *Generator) pruneAsync(lid types.LayerID) {
+	g.eg.Go(func() error {
+		start := time.Now()
+		if err := proposals.DeleteBefore(g.cdb, lid); err != nil {
+			g.logger.With().Error("failed to delete old proposals", lid, log.Err(err))
+		}
+		deleteLatency.Observe(time.Since(start).Seconds())
+		return nil
+	})
+}
+
 func (g *Generator) run() error {
+	g.pruneAsync(g.msh.LatestLayerInState())
 	var maxLayer types.LayerID
 	for {
 		select {
@@ -167,16 +179,7 @@ func (g *Generator) run() error {
 			if len(g.optimisticOutput) > 0 {
 				g.processOptimisticLayers(maxLayer)
 			}
-			start := time.Now()
-			if err := proposals.Delete(g.cdb, out.Layer); err != nil {
-				g.logger.With().Error("failed to delete old proposals",
-					out.Layer,
-					log.Err(err),
-				)
-			}
-			duration := time.Since(start)
-			g.logger.With().Info("deleted proposal", log.Duration("duration", duration))
-			deleteLatency.Observe(duration.Seconds())
+			g.pruneAsync(out.Layer)
 		case <-time.After(g.cfg.GenBlockInterval):
 			if len(g.optimisticOutput) > 0 {
 				g.processOptimisticLayers(maxLayer)

--- a/blocks/generator.go
+++ b/blocks/generator.go
@@ -167,12 +167,16 @@ func (g *Generator) run() error {
 			if len(g.optimisticOutput) > 0 {
 				g.processOptimisticLayers(maxLayer)
 			}
+			start := time.Now()
 			if err := proposals.Delete(g.cdb, out.Layer); err != nil {
 				g.logger.With().Error("failed to delete old proposals",
 					out.Layer,
 					log.Err(err),
 				)
 			}
+			duration := time.Since(start)
+			g.logger.With().Info("deleted proposal", log.Duration("duration", duration))
+			deleteLatency.Observe(duration.Seconds())
 		case <-time.After(g.cfg.GenBlockInterval):
 			if len(g.optimisticOutput) > 0 {
 				g.processOptimisticLayers(maxLayer)

--- a/blocks/generator_test.go
+++ b/blocks/generator_test.go
@@ -69,6 +69,7 @@ func createTestGenerator(t *testing.T) *testGenerator {
 		mockCert:   mocks.NewMockcertifier(ctrl),
 		mockPatrol: mocks.NewMocklayerPatrol(ctrl),
 	}
+	tg.mockMesh.EXPECT().LatestLayerInState().Return(types.LayerID(1)).AnyTimes()
 	lg := logtest.New(t)
 	cdb := datastore.NewCachedDB(sql.InMemory(), lg)
 	tg.Generator = NewGenerator(cdb, tg.mockExec, tg.mockMesh, tg.mockFetch, tg.mockCert, tg.mockPatrol,

--- a/blocks/generator_test.go
+++ b/blocks/generator_test.go
@@ -69,7 +69,7 @@ func createTestGenerator(t *testing.T) *testGenerator {
 		mockCert:   mocks.NewMockcertifier(ctrl),
 		mockPatrol: mocks.NewMocklayerPatrol(ctrl),
 	}
-	tg.mockMesh.EXPECT().LatestLayerInState().Return(types.LayerID(1)).AnyTimes()
+	tg.mockMesh.EXPECT().ProcessedLayer().Return(types.LayerID(1)).AnyTimes()
 	lg := logtest.New(t)
 	cdb := datastore.NewCachedDB(sql.InMemory(), lg)
 	tg.Generator = NewGenerator(cdb, tg.mockExec, tg.mockMesh, tg.mockFetch, tg.mockCert, tg.mockPatrol,
@@ -326,7 +326,11 @@ func Test_run(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			tg := createTestGenerator(t)
 			tg.cfg.BlockGasLimit = tc.gasLimit
+			tg.mockMesh = mocks.NewMockmeshProvider(gomock.NewController(t))
+			tg.msh = tg.mockMesh
 			layerID := types.GetEffectiveGenesis().Add(100)
+			processed := layerID - 1
+			tg.mockMesh.EXPECT().ProcessedLayer().DoAndReturn(func() types.LayerID { return processed }).AnyTimes()
 			require.NoError(t, layers.SetApplied(tg.cdb, layerID-1, types.EmptyBlockID))
 			var meshHash types.Hash32
 			if tc.optimistic {
@@ -399,6 +403,7 @@ func Test_run(t *testing.T) {
 			tg.mockMesh.EXPECT().ProcessLayerPerHareOutput(gomock.Any(), layerID, gomock.Any(), tc.optimistic).DoAndReturn(
 				func(_ context.Context, _ types.LayerID, got types.BlockID, _ bool) error {
 					require.Equal(t, block.ID(), got)
+					processed = layerID
 					return nil
 				})
 			tg.mockPatrol.EXPECT().CompleteHare(layerID)

--- a/blocks/interface.go
+++ b/blocks/interface.go
@@ -14,7 +14,7 @@ type layerPatrol interface {
 }
 
 type meshProvider interface {
-	LatestLayerInState() types.LayerID
+	ProcessedLayer() types.LayerID
 	AddBlockWithTXs(context.Context, *types.Block) error
 	ProcessLayerPerHareOutput(context.Context, types.LayerID, types.BlockID, bool) error
 }

--- a/blocks/interface.go
+++ b/blocks/interface.go
@@ -14,6 +14,7 @@ type layerPatrol interface {
 }
 
 type meshProvider interface {
+	LatestLayerInState() types.LayerID
 	AddBlockWithTXs(context.Context, *types.Block) error
 	ProcessLayerPerHareOutput(context.Context, types.LayerID, types.BlockID, bool) error
 }

--- a/blocks/metrics.go
+++ b/blocks/metrics.go
@@ -30,6 +30,14 @@ var (
 	failFetchCnt   = blockGenCount.WithLabelValues(failFetch)
 	failGenCnt     = blockGenCount.WithLabelValues(failGen)
 	failErrCnt     = blockGenCount.WithLabelValues(internalErr)
+
+	deleteLatency = metrics.NewHistogramWithBuckets(
+		"delete_duration",
+		namespace,
+		"duration in second to delete old proposals",
+		[]string{},
+		prometheus.ExponentialBuckets(0.01, 2, 10),
+	).WithLabelValues()
 )
 
 type collector struct {

--- a/blocks/mocks/mocks.go
+++ b/blocks/mocks/mocks.go
@@ -133,6 +133,44 @@ func (c *meshProviderAddBlockWithTXsCall) DoAndReturn(f func(context.Context, *t
 	return c
 }
 
+// LatestLayerInState mocks base method.
+func (m *MockmeshProvider) LatestLayerInState() types.LayerID {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LatestLayerInState")
+	ret0, _ := ret[0].(types.LayerID)
+	return ret0
+}
+
+// LatestLayerInState indicates an expected call of LatestLayerInState.
+func (mr *MockmeshProviderMockRecorder) LatestLayerInState() *meshProviderLatestLayerInStateCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LatestLayerInState", reflect.TypeOf((*MockmeshProvider)(nil).LatestLayerInState))
+	return &meshProviderLatestLayerInStateCall{Call: call}
+}
+
+// meshProviderLatestLayerInStateCall wrap *gomock.Call
+type meshProviderLatestLayerInStateCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *meshProviderLatestLayerInStateCall) Return(arg0 types.LayerID) *meshProviderLatestLayerInStateCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *meshProviderLatestLayerInStateCall) Do(f func() types.LayerID) *meshProviderLatestLayerInStateCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *meshProviderLatestLayerInStateCall) DoAndReturn(f func() types.LayerID) *meshProviderLatestLayerInStateCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // ProcessLayerPerHareOutput mocks base method.
 func (m *MockmeshProvider) ProcessLayerPerHareOutput(arg0 context.Context, arg1 types.LayerID, arg2 types.BlockID, arg3 bool) error {
 	m.ctrl.T.Helper()

--- a/blocks/mocks/mocks.go
+++ b/blocks/mocks/mocks.go
@@ -133,44 +133,6 @@ func (c *meshProviderAddBlockWithTXsCall) DoAndReturn(f func(context.Context, *t
 	return c
 }
 
-// LatestLayerInState mocks base method.
-func (m *MockmeshProvider) LatestLayerInState() types.LayerID {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LatestLayerInState")
-	ret0, _ := ret[0].(types.LayerID)
-	return ret0
-}
-
-// LatestLayerInState indicates an expected call of LatestLayerInState.
-func (mr *MockmeshProviderMockRecorder) LatestLayerInState() *meshProviderLatestLayerInStateCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LatestLayerInState", reflect.TypeOf((*MockmeshProvider)(nil).LatestLayerInState))
-	return &meshProviderLatestLayerInStateCall{Call: call}
-}
-
-// meshProviderLatestLayerInStateCall wrap *gomock.Call
-type meshProviderLatestLayerInStateCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *meshProviderLatestLayerInStateCall) Return(arg0 types.LayerID) *meshProviderLatestLayerInStateCall {
-	c.Call = c.Call.Return(arg0)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *meshProviderLatestLayerInStateCall) Do(f func() types.LayerID) *meshProviderLatestLayerInStateCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *meshProviderLatestLayerInStateCall) DoAndReturn(f func() types.LayerID) *meshProviderLatestLayerInStateCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // ProcessLayerPerHareOutput mocks base method.
 func (m *MockmeshProvider) ProcessLayerPerHareOutput(arg0 context.Context, arg1 types.LayerID, arg2 types.BlockID, arg3 bool) error {
 	m.ctrl.T.Helper()
@@ -205,6 +167,44 @@ func (c *meshProviderProcessLayerPerHareOutputCall) Do(f func(context.Context, t
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *meshProviderProcessLayerPerHareOutputCall) DoAndReturn(f func(context.Context, types.LayerID, types.BlockID, bool) error) *meshProviderProcessLayerPerHareOutputCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// ProcessedLayer mocks base method.
+func (m *MockmeshProvider) ProcessedLayer() types.LayerID {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ProcessedLayer")
+	ret0, _ := ret[0].(types.LayerID)
+	return ret0
+}
+
+// ProcessedLayer indicates an expected call of ProcessedLayer.
+func (mr *MockmeshProviderMockRecorder) ProcessedLayer() *meshProviderProcessedLayerCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessedLayer", reflect.TypeOf((*MockmeshProvider)(nil).ProcessedLayer))
+	return &meshProviderProcessedLayerCall{Call: call}
+}
+
+// meshProviderProcessedLayerCall wrap *gomock.Call
+type meshProviderProcessedLayerCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *meshProviderProcessedLayerCall) Return(arg0 types.LayerID) *meshProviderProcessedLayerCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *meshProviderProcessedLayerCall) Do(f func() types.LayerID) *meshProviderProcessedLayerCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *meshProviderProcessedLayerCall) DoAndReturn(f func() types.LayerID) *meshProviderProcessedLayerCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/proposals/handler.go
+++ b/proposals/handler.go
@@ -262,7 +262,7 @@ func (h *Handler) handleProposal(ctx context.Context, expHash types.Hash32, peer
 		preGenesis.Inc()
 		return fmt.Errorf("proposal before effective genesis: layer %v", p.Layer)
 	}
-	if p.Layer < h.clock.CurrentLayer() {
+	if p.Layer <= h.mesh.ProcessedLayer() {
 		// old proposals have no use for the node
 		tooLate.Inc()
 		return fmt.Errorf("proposal too late: layer %v", p.Layer)

--- a/proposals/handler.go
+++ b/proposals/handler.go
@@ -262,6 +262,11 @@ func (h *Handler) handleProposal(ctx context.Context, expHash types.Hash32, peer
 		preGenesis.Inc()
 		return fmt.Errorf("proposal before effective genesis: layer %v", p.Layer)
 	}
+	if p.Layer < h.clock.CurrentLayer() {
+		// old proposals have no use for the node
+		tooLate.Inc()
+		return fmt.Errorf("proposal too late: layer %v", p.Layer)
+	}
 
 	latency := receivedTime.Sub(h.clock.LayerToTime(p.Layer))
 	metrics.ReportMessageLatency(pubsub.ProposalProtocol, pubsub.ProposalProtocol, latency)
@@ -311,7 +316,9 @@ func (h *Handler) handleProposal(ctx context.Context, expHash types.Hash32, peer
 	}
 	proposalDuration.WithLabelValues(dbLookup).Observe(float64(time.Since(t1)))
 
-	logger.With().Info("new proposal", log.Int("num_txs", len(p.TxIDs)))
+	logger.With().Info("new proposal",
+		log.String("exp hash", expHash.ShortString()),
+		log.Int("num_txs", len(p.TxIDs)))
 	t2 := time.Now()
 	h.fetcher.RegisterPeerHashes(peer, collectHashes(p))
 	proposalDuration.WithLabelValues(peerHashes).Observe(float64(time.Since(t2)))

--- a/proposals/handler_test.go
+++ b/proposals/handler_test.go
@@ -876,6 +876,20 @@ func TestProposal_BeforeEffectiveGenesis(t *testing.T) {
 	checkProposal(t, th.cdb, p, false)
 }
 
+func TestProposal_NotCurrentLayer(t *testing.T) {
+	th := createTestHandlerNoopDecoder(t)
+	lid := types.LayerID(11)
+	th.mockSet.setCurrentLayer(lid)
+	p := createProposal(t)
+	p.Layer = lid - 1
+	data := encodeProposal(t, p)
+	got := th.HandleSyncedProposal(context.Background(), p.ID().AsHash32(), p2p.NoPeer, data)
+	require.ErrorContains(t, got, "proposal too late")
+
+	require.Error(t, th.HandleProposal(context.Background(), "", data))
+	checkProposal(t, th.cdb, p, false)
+}
+
 func TestProposal_BadSignature(t *testing.T) {
 	th := createTestHandlerNoopDecoder(t)
 	p := createProposal(t)

--- a/proposals/handler_test.go
+++ b/proposals/handler_test.go
@@ -60,6 +60,7 @@ func (ms *mockSet) decodeAnyBallots() *mockSet {
 
 func (ms *mockSet) setCurrentLayer(layer types.LayerID) *mockSet {
 	ms.mclock.EXPECT().CurrentLayer().Return(layer).AnyTimes()
+	ms.mm.EXPECT().ProcessedLayer().Return(layer - 1).AnyTimes()
 	ms.mclock.EXPECT().LayerToTime(gomock.Any()).Return(time.Now().Add(-5 * time.Second)).AnyTimes()
 	return ms
 }
@@ -877,7 +878,7 @@ func TestProposal_BeforeEffectiveGenesis(t *testing.T) {
 	checkProposal(t, th.cdb, p, false)
 }
 
-func TestProposal_NotCurrentLayer(t *testing.T) {
+func TestProposal_TooOld(t *testing.T) {
 	th := createTestHandlerNoopDecoder(t)
 	lid := types.LayerID(11)
 	th.mockSet.setCurrentLayer(lid)
@@ -1486,7 +1487,7 @@ func TestHandleSyncedProposalActiveSet(t *testing.T) {
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			th := createTestHandler(t)
-			th.mclock.EXPECT().CurrentLayer().Return(acceptEmpty - 1).AnyTimes()
+			th.mm.EXPECT().ProcessedLayer().Return(acceptEmpty - 2).AnyTimes()
 			th.cfg.AllowEmptyActiveSet = acceptEmpty
 			pid := p2p.Peer("any")
 

--- a/proposals/interface.go
+++ b/proposals/interface.go
@@ -11,6 +11,7 @@ import (
 //go:generate mockgen -typed -package=proposals -destination=./mocks.go -source=./interface.go
 
 type meshProvider interface {
+	ProcessedLayer() types.LayerID
 	AddBallot(context.Context, *types.Ballot) (*types.MalfeasanceProof, error)
 	AddTXsFromProposal(context.Context, types.LayerID, types.ProposalID, []types.TransactionID) error
 }

--- a/proposals/metrics.go
+++ b/proposals/metrics.go
@@ -93,6 +93,7 @@ var (
 	malformed      = processErrors.WithLabelValues("mal")
 	failedInit     = processErrors.WithLabelValues("init")
 	known          = processErrors.WithLabelValues("known")
+	tooLate        = processErrors.WithLabelValues("late")
 	preGenesis     = processErrors.WithLabelValues("genesis")
 	badSigProposal = processErrors.WithLabelValues("sigp")
 	badSigBallot   = processErrors.WithLabelValues("sigb")

--- a/proposals/mocks.go
+++ b/proposals/mocks.go
@@ -114,6 +114,44 @@ func (c *meshProviderAddTXsFromProposalCall) DoAndReturn(f func(context.Context,
 	return c
 }
 
+// ProcessedLayer mocks base method.
+func (m *MockmeshProvider) ProcessedLayer() types.LayerID {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ProcessedLayer")
+	ret0, _ := ret[0].(types.LayerID)
+	return ret0
+}
+
+// ProcessedLayer indicates an expected call of ProcessedLayer.
+func (mr *MockmeshProviderMockRecorder) ProcessedLayer() *meshProviderProcessedLayerCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessedLayer", reflect.TypeOf((*MockmeshProvider)(nil).ProcessedLayer))
+	return &meshProviderProcessedLayerCall{Call: call}
+}
+
+// meshProviderProcessedLayerCall wrap *gomock.Call
+type meshProviderProcessedLayerCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *meshProviderProcessedLayerCall) Return(arg0 types.LayerID) *meshProviderProcessedLayerCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *meshProviderProcessedLayerCall) Do(f func() types.LayerID) *meshProviderProcessedLayerCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *meshProviderProcessedLayerCall) DoAndReturn(f func() types.LayerID) *meshProviderProcessedLayerCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // MockeligibilityValidator is a mock of eligibilityValidator interface.
 type MockeligibilityValidator struct {
 	ctrl     *gomock.Controller

--- a/sql/proposals/proposals.go
+++ b/sql/proposals/proposals.go
@@ -186,7 +186,7 @@ func decodeProposal(stmt *sql.Statement) (*types.Proposal, error) {
 	return proposal, nil
 }
 
-func Delete(db sql.Executor, lid types.LayerID) error {
+func DeleteBefore(db sql.Executor, lid types.LayerID) error {
 	if _, err := db.Exec(`delete from proposals where layer < ?1;`,
 		func(stmt *sql.Statement) {
 			stmt.BindInt64(1, int64(lid))

--- a/sql/proposals/proposals_test.go
+++ b/sql/proposals/proposals_test.go
@@ -57,7 +57,7 @@ func TestDelete(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, got, numProps)
 	}
-	require.NoError(t, Delete(db, types.LayerID(maxLayers)))
+	require.NoError(t, DeleteBefore(db, types.LayerID(maxLayers)))
 	for i := 1; i < maxLayers; i++ {
 		_, err := GetByLayer(db, types.LayerID(i))
 		require.ErrorIs(t, err, sql.ErrNotFound)


### PR DESCRIPTION
## Motivation
there are a lot of old proposals floating in the gossip network.
deleting old proposals in #4993 forced the node to process/save these old proposals repeatedly

## Changes
- refuse proposals older than current layer
- add metrics/log for time it takes to delete proposals