### PR TITLE
Add nats and extra info to coinbaseReward

### DIFF
--- a/common/types/block.go
+++ b/common/types/block.go
@@ -109,6 +109,8 @@ type AnyReward struct {
 // CoinbaseReward contains the reward information by coinbase, used as an interface to VM.
 type CoinbaseReward struct {
 	Coinbase Address
+	AtxID    ATXID
+	NodeID   NodeID
 	Weight   RatNum
 }
 

--- a/common/types/transaction.go
+++ b/common/types/transaction.go
@@ -148,6 +148,8 @@ type Reward struct {
 	TotalReward uint64
 	LayerReward uint64
 	Coinbase    Address
+	AtxID       ATXID
+	NodeID      NodeID
 }
 
 // NewRawTx computes id from raw bytes and returns the object.

--- a/config/config.go
+++ b/config/config.go
@@ -21,6 +21,7 @@ import (
 	hareConfig "github.com/spacemeshos/go-spacemesh/hare/config"
 	eligConfig "github.com/spacemeshos/go-spacemesh/hare/eligibility/config"
 	"github.com/spacemeshos/go-spacemesh/hare3"
+	"github.com/spacemeshos/go-spacemesh/nats"
 	"github.com/spacemeshos/go-spacemesh/p2p"
 	"github.com/spacemeshos/go-spacemesh/syncer"
 	timeConfig "github.com/spacemeshos/go-spacemesh/timesync/config"
@@ -50,6 +51,7 @@ type Config struct {
 	Tortoise        tortoise.Config       `mapstructure:"tortoise"`
 	P2P             p2p.Config            `mapstructure:"p2p"`
 	API             grpcserver.Config     `mapstructure:"api"`
+	NATS            nats.Config           `mapstructure:"nats"`
 	HARE            hareConfig.Config     `mapstructure:"hare"`
 	HARE3           hare3.Config          `mapstructure:"hare3"`
 	HareEligibility eligConfig.Config     `mapstructure:"hare-eligibility"`
@@ -144,6 +146,7 @@ func DefaultConfig() Config {
 		Tortoise:        tortoise.DefaultConfig(),
 		P2P:             p2p.DefaultConfig(),
 		API:             grpcserver.DefaultConfig(),
+		NATS:            nats.DefaultConfig(),
 		HARE:            hareConfig.DefaultConfig(),
 		HARE3:           hare3.DefaultConfig(),
 		HareEligibility: eligConfig.DefaultConfig(),

--- a/config/mainnet.go
+++ b/config/mainnet.go
@@ -17,6 +17,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/fetch"
 	hareConfig "github.com/spacemeshos/go-spacemesh/hare/config"
 	eligConfig "github.com/spacemeshos/go-spacemesh/hare/eligibility/config"
+	"github.com/spacemeshos/go-spacemesh/nats"
 	"github.com/spacemeshos/go-spacemesh/p2p"
 	"github.com/spacemeshos/go-spacemesh/syncer"
 	timeConfig "github.com/spacemeshos/go-spacemesh/timesync/config"
@@ -128,6 +129,7 @@ func MainnetConfig() Config {
 		},
 		P2P:      p2pconfig,
 		API:      grpcserver.DefaultConfig(),
+		NATS:     nats.DefaultConfig(),
 		TIME:     timeConfig.DefaultConfig(),
 		SMESHING: smeshing,
 		FETCH:    fetch.DefaultConfig(),

--- a/events/reporter.go
+++ b/events/reporter.go
@@ -202,6 +202,22 @@ func SubscribeTxs() Subscription {
 	return nil
 }
 
+// SubscribeTxsResult subscribes to new transactions.
+func SubscribeTxsResult() Subscription {
+	mu.RLock()
+	defer mu.RUnlock()
+
+	if reporter != nil {
+		sub, err := reporter.bus.Subscribe(new(types.TransactionWithResult))
+		if err != nil {
+			log.With().Panic("Failed to subscribe to transactions result")
+		}
+
+		return sub
+	}
+	return nil
+}
+
 // SubscribeActivations subscribes to activations.
 func SubscribeActivations() Subscription {
 	mu.RLock()
@@ -386,6 +402,8 @@ type Reward struct {
 	Total       uint64
 	LayerReward uint64
 	Coinbase    types.Address
+	AtxID       types.ATXID
+	NodeID      types.NodeID
 }
 
 // Transaction wraps a tx with its layer ID and validity info.

--- a/genvm/rewards.go
+++ b/genvm/rewards.go
@@ -58,6 +58,8 @@ func (v *VM) addRewards(lctx ApplyContext, ss *core.StagedCache, fees uint64, bl
 			Coinbase:    blockReward.Coinbase,
 			TotalReward: totalReward.Uint64(),
 			LayerReward: subsidyReward.Uint64(),
+			AtxID:       blockReward.AtxID,
+			NodeID:      blockReward.NodeID,
 		}
 		result = append(result, reward)
 		account, err := ss.Get(blockReward.Coinbase)

--- a/genvm/vm.go
+++ b/genvm/vm.go
@@ -263,6 +263,8 @@ func (v *VM) Apply(lctx ApplyContext, txs []types.Transaction, blockRewards []ty
 			Total:       reward.TotalReward,
 			LayerReward: reward.LayerReward,
 			Coinbase:    reward.Coinbase,
+			AtxID:       reward.AtxID,
+			NodeID:      reward.NodeID,
 		})
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/multiformats/go-multiaddr v0.11.0
 	github.com/multiformats/go-varint v0.0.7
 	github.com/natefinch/atomic v1.0.1
+	github.com/nats-io/nats.go v1.29.0
 	github.com/oasisprotocol/curve25519-voi v0.0.0-20230904125328-1f23a7beb09a
 	github.com/prometheus/client_golang v1.16.0
 	github.com/prometheus/common v0.44.0
@@ -159,6 +160,9 @@ require (
 	github.com/multiformats/go-multihash v0.2.3 // indirect
 	github.com/multiformats/go-multistream v0.4.1 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/nats-io/nats-server/v2 v2.9.22 // indirect
+	github.com/nats-io/nkeys v0.4.4 // indirect
+	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/nullstyle/go-xdr v0.0.0-20180726165426-f4c839f75077 // indirect
 	github.com/nxadm/tail v1.4.8 // indirect
 	github.com/onsi/ginkgo/v2 v2.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -459,6 +459,8 @@ github.com/mikioh/tcpinfo v0.0.0-20190314235526-30a79bb1804b/go.mod h1:lxPUiZwKo
 github.com/mikioh/tcpopt v0.0.0-20190314235656-172688c1accc h1:PTfri+PuQmWDqERdnNMiD9ZejrlswWrCpBEZgWOiTrc=
 github.com/mikioh/tcpopt v0.0.0-20190314235656-172688c1accc/go.mod h1:cGKTAVKx4SxOuR/czcZ/E2RSJ3sfHs8FpHhQ5CWMf9s=
 github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1/go.mod h1:pD8RvIylQ358TN4wwqatJ8rNavkEINozVn9DtGI3dfQ=
+github.com/minio/highwayhash v1.0.2 h1:Aak5U0nElisjDCfPSG79Tgzkn2gl66NxOMspRrKnA/g=
+github.com/minio/highwayhash v1.0.2/go.mod h1:BQskDq+xkJ12lmlUUi7U0M5Swg3EWR+dLTk+kldvVxY=
 github.com/minio/sha256-simd v0.1.1-0.20190913151208-6de447530771/go.mod h1:B5e1o+1/KgNmWrSQK08Y6Z1Vb5pwIktudl0J58iy0KM=
 github.com/minio/sha256-simd v1.0.1 h1:6kaan5IFmwTNynnKKpDHe6FWHohJOHhCPchzK49dzMM=
 github.com/minio/sha256-simd v1.0.1/go.mod h1:Pz6AKMiUdngCLpeTL/RJY1M9rUuPMYujV5xJjtbRSN8=
@@ -501,6 +503,16 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/natefinch/atomic v1.0.1 h1:ZPYKxkqQOx3KZ+RsbnP/YsgvxWQPGxjC0oBt2AhwV0A=
 github.com/natefinch/atomic v1.0.1/go.mod h1:N/D/ELrljoqDyT3rZrsUmtsuzvHkeB/wWjHV22AZRbM=
+github.com/nats-io/jwt/v2 v2.5.0 h1:WQQ40AAlqqfx+f6ku+i0pOVm+ASirD4fUh+oQsiE9Ak=
+github.com/nats-io/jwt/v2 v2.5.0/go.mod h1:24BeQtRwxRV8ruvC4CojXlx/WQ/VjuwlYiH+vu/+ibI=
+github.com/nats-io/nats-server/v2 v2.9.22 h1:rzl88pqWFFrU4G00ed+JnY+uGHSLZ+3jrxDnJxzKwGA=
+github.com/nats-io/nats-server/v2 v2.9.22/go.mod h1:wEjrEy9vnqIGE4Pqz4/c75v9Pmaq7My2IgFmnykc4C0=
+github.com/nats-io/nats.go v1.29.0 h1:dSXZ+SZeGyTdHVYeXimeq12FsIpb9dM8CJ2IZFiHcyE=
+github.com/nats-io/nats.go v1.29.0/go.mod h1:XpbWUlOElGwTYbMR7imivs7jJj9GtK7ypv321Wp6pjc=
+github.com/nats-io/nkeys v0.4.4 h1:xvBJ8d69TznjcQl9t6//Q5xXuVhyYiSos6RPtvQNTwA=
+github.com/nats-io/nkeys v0.4.4/go.mod h1:XUkxdLPTufzlihbamfzQ7mw/VGx6ObUs+0bN5sNvt64=
+github.com/nats-io/nuid v1.0.1 h1:5iA8DT8V7q8WK2EScv2padNa/rTESc1KdnPw4TC2paw=
+github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
 github.com/neelance/astrewrite v0.0.0-20160511093645-99348263ae86/go.mod h1:kHJEU3ofeGjhHklVoIGuVj85JJwZ6kWPaJwCIxgnFmo=
 github.com/neelance/sourcemap v0.0.0-20151028013722-8c68805598ab/go.mod h1:Qr6/a/Q4r9LP1IltGz7tA7iOK1WonHEYhu1HRBA7ZiM=
 github.com/nullstyle/go-xdr v0.0.0-20180726165426-f4c839f75077 h1:A804awGqaW7i61y8KnbtHmh3scqbNuTJqcycq3u5ZAU=

--- a/mesh/executor.go
+++ b/mesh/executor.go
@@ -173,6 +173,8 @@ func (e *Executor) convertRewards(rewards []types.AnyReward) ([]types.CoinbaseRe
 		res = append(res, types.CoinbaseReward{
 			Coinbase: atx.Coinbase,
 			Weight:   r.Weight,
+			AtxID:    r.AtxID,
+			NodeID:   atx.NodeID,
 		})
 	}
 	sort.Slice(res, func(i, j int) bool {

--- a/nats/config.go
+++ b/nats/config.go
@@ -1,0 +1,17 @@
+package nats
+
+import "time"
+
+type Config struct {
+	NatsEnabled bool          `mapstructure:"nats-enabled"`
+	NatsUrl     string        `mapstructure:"nats-url"`
+	NatsMaxAge  time.Duration `mapstructure:"nats-max-age"`
+}
+
+func DefaultConfig() Config {
+	return Config{
+		NatsEnabled: false,
+		NatsUrl:     "nats://0.0.0.0:4222",
+		NatsMaxAge:  365 * 24 * time.Hour,
+	}
+}

--- a/nats/nats_connector.go
+++ b/nats/nats_connector.go
@@ -1,0 +1,208 @@
+package nats
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/libp2p/go-libp2p/core/event"
+	"github.com/nats-io/nats.go"
+	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/events"
+	"github.com/spacemeshos/go-spacemesh/log"
+)
+
+type NatsConnector struct {
+	nc                   *nats.Conn
+	layersSubscription   event.Subscription
+	rewardsSubscription  event.Subscription
+	txSubscription       event.Subscription
+	txResultSubscription event.Subscription
+	atxSubscription      event.Subscription
+}
+
+func NewNatsConnector(config Config) (*NatsConnector, error) {
+	natsURL := config.NatsUrl
+	nc, err := nats.Connect(natsURL)
+	if err != nil {
+		log.With().Warning("failed to connect to nats")
+		return &NatsConnector{}, err
+	}
+	js, err := nc.JetStream()
+	if err != nil {
+		log.With().Warning("failed to create jetstream")
+		return &NatsConnector{}, err
+	}
+	layersSubscription := addLayers(js, config)
+	rewardsSubscription := addRewards(js, config)
+	txSubscription := addTransations(js, config)
+	txResultSubscription := addTransationsResult(js, config)
+	atxSubscription := addATXs(js, config)
+	return &NatsConnector{
+		nc:                   nc,
+		layersSubscription:   layersSubscription,
+		rewardsSubscription:  rewardsSubscription,
+		txSubscription:       txSubscription,
+		txResultSubscription: txResultSubscription,
+		atxSubscription:      atxSubscription,
+	}, err
+
+}
+
+func addLayers(js nats.JetStreamContext, config Config) event.Subscription {
+	js.AddStream(&nats.StreamConfig{
+		Name:     "layers",
+		Subjects: []string{"layers"},
+		MaxAge:   config.NatsMaxAge,
+	})
+	layersSubscription := events.SubscribeLayers()
+	if layersSubscription != nil {
+		fmt.Print("NATS subscribed to layers")
+		go func() {
+			for l := range layersSubscription.Out() {
+				event, ok := l.(events.LayerUpdate)
+				if !ok {
+					log.With().Warning("received invalid event type - dropping")
+					continue
+				}
+				jsonData, err := json.Marshal(event)
+				if err != nil {
+					log.With().Warning("failed to serialize event")
+					continue
+				}
+				js.Publish("layers", jsonData)
+			}
+		}()
+	}
+	return layersSubscription
+}
+
+func addRewards(js nats.JetStreamContext, config Config) event.Subscription {
+	js.AddStream(&nats.StreamConfig{
+		Name:     "rewards",
+		Subjects: []string{"rewards"},
+		MaxAge:   config.NatsMaxAge,
+	})
+	rewardsSubscription := events.SubscribeRewards()
+	if rewardsSubscription != nil {
+		fmt.Print("NATS subscribed to rewards")
+		go func() {
+			for r := range rewardsSubscription.Out() {
+				event, ok := r.(events.Reward)
+				if !ok {
+					log.With().Warning("received invalid event type - dropping")
+					continue
+				}
+				jsonData, err := json.Marshal(event)
+				if err != nil {
+					log.With().Warning("failed to serialize event")
+					continue
+				}
+				js.Publish("rewards", jsonData)
+			}
+		}()
+	}
+	return rewardsSubscription
+}
+
+func addTransations(js nats.JetStreamContext, config Config) event.Subscription {
+	js.AddStream(&nats.StreamConfig{
+		Name:     "transactions-created",
+		Subjects: []string{"transactions.created"},
+		MaxAge:   config.NatsMaxAge,
+	})
+	txSubscription := events.SubscribeTxs()
+	if txSubscription != nil {
+		fmt.Print("NATS subscribed to transactions")
+		go func() {
+			for r := range txSubscription.Out() {
+				event, ok := r.(events.Transaction)
+				if !ok {
+					log.With().Warning("received invalid event type - dropping")
+					continue
+				}
+				jsonData, err := json.Marshal(event)
+				if err != nil {
+					log.With().Warning("failed to serialize event")
+					continue
+				}
+				js.Publish("transactions.created", jsonData)
+			}
+		}()
+	}
+	return txSubscription
+}
+
+func addTransationsResult(js nats.JetStreamContext, config Config) event.Subscription {
+	js.AddStream(&nats.StreamConfig{
+		Name:     "transactions-result",
+		Subjects: []string{"transactions.result"},
+		MaxAge:   config.NatsMaxAge,
+	})
+	txResultSubscription := events.SubscribeTxsResult()
+	if txResultSubscription != nil {
+		fmt.Print("NATS subscribed to transactions results")
+		go func() {
+			for r := range txResultSubscription.Out() {
+				event, ok := r.(types.TransactionWithResult)
+				if !ok {
+					log.With().Warning("received invalid event type - dropping")
+					continue
+				}
+				jsonData, err := json.Marshal(event)
+				if err != nil {
+					log.With().Warning("failed to serialize event")
+					continue
+				}
+				js.Publish("transactions.result", jsonData)
+			}
+		}()
+	}
+	return txResultSubscription
+}
+
+func addATXs(js nats.JetStreamContext, config Config) event.Subscription {
+	js.AddStream(&nats.StreamConfig{
+		Name:     "atx",
+		Subjects: []string{"atx"},
+		MaxAge:   config.NatsMaxAge,
+	})
+	atxSubscription := events.SubscribeActivations()
+	if atxSubscription != nil {
+		fmt.Print("NATS subscribed to atx")
+		go func() {
+			for r := range atxSubscription.Out() {
+				event, ok := r.(events.ActivationTx)
+				if !ok {
+					log.With().Warning("received invalid event type - dropping")
+					continue
+				}
+				jsonData, err := json.Marshal(event)
+				if err != nil {
+					log.With().Warning("failed to serialize event")
+					continue
+				}
+				js.Publish("atx", jsonData)
+			}
+		}()
+	}
+	return atxSubscription
+}
+
+func (n *NatsConnector) Close() {
+	n.nc.Drain()
+	if err := n.layersSubscription.Close(); err != nil {
+		log.With().Panic("Failed to close subscription", log.Err(err))
+	}
+	if err := n.rewardsSubscription.Close(); err != nil {
+		log.With().Panic("Failed to close subscription", log.Err(err))
+	}
+	if err := n.txSubscription.Close(); err != nil {
+		log.With().Panic("Failed to close subscription", log.Err(err))
+	}
+	if err := n.txResultSubscription.Close(); err != nil {
+		log.With().Panic("Failed to close subscription", log.Err(err))
+	}
+	if err := n.atxSubscription.Close(); err != nil {
+		log.With().Panic("Failed to close subscription", log.Err(err))
+	}
+}


### PR DESCRIPTION
## Motivation
Want to be able to index the node events in a reliable way. NATS jetstream provides durability to events, this means a view database can be indexed without having to run the full node from a clean state.

## Changes
New NATS package and NATS configuration added. Opt in.
Atx id and node id added to CoinbaseReward and reward event.

## Test Plan
It was manually tested on a mainet node and events are produced properly to NATS.

## TODO
- Tweak and add more NATS configurations. (Currently the default configuration for the stream it to keep event for one year).