### PR TITLE
[Merged by Bors] - remove read/write for ballot.ActiveSet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Support for old certificate sync protocol is dropped. This update is incompatibl
 
 ### Improvements
 * [#5021](https://github.com/spacemeshos/go-spacemesh/pull/5021) Drop support for old certificate sync protocol.
+* [#5024](https://github.com/spacemeshos/go-spacemesh/pull/5024) Active set will be saved in state separately from ballots.
 
 ## v1.1.5
 
@@ -41,7 +42,7 @@ active set will not be gossipped together with proposals. That was the main netw
   * `postdata_metadata.json` is now updated atomically to prevent corruption of the file.
 * [#4956](https://github.com/spacemeshos/go-spacemesh/pull/4956) Active set is will not be gossipped in every proposal.
   Active set usually contains list of atxs that targets current epoch. As the number of atxs grows this object grows as well.
-* [#4993](https://github.com/spacemeshos/go-spacemesh/pull/4993) Drop proposals after genering a block. This limits growth of the state.
+* [#4993](https://github.com/spacemeshos/go-spacemesh/pull/4993) Drop proposals after generating a block. This limits growth of the state.
 
 ## v1.1.4
 

--- a/blocks/generator_test.go
+++ b/blocks/generator_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/log/logtest"
 	"github.com/spacemeshos/go-spacemesh/signing"
 	"github.com/spacemeshos/go-spacemesh/sql"
+	"github.com/spacemeshos/go-spacemesh/sql/activesets"
 	"github.com/spacemeshos/go-spacemesh/sql/atxs"
 	"github.com/spacemeshos/go-spacemesh/sql/ballots"
 	"github.com/spacemeshos/go-spacemesh/sql/layers"
@@ -192,10 +193,10 @@ func createProposal(
 					EpochData: &types.EpochData{
 						Beacon:           types.RandomBeacon(),
 						EligibilityCount: uint32(layerSize * epochSize / len(activeSet)),
+						ActiveSetHash:    activeSet.Hash(),
 					},
 				},
 				EligibilityProofs: make([]types.VotingEligibility, numEligibility),
-				ActiveSet:         activeSet,
 			},
 			TxIDs:    txIDs,
 			MeshHash: meshHash,
@@ -207,6 +208,7 @@ func createProposal(
 	require.NoError(t, p.Initialize())
 	require.NoError(t, ballots.Add(db, &p.Ballot))
 	require.NoError(t, proposals.Add(db, p))
+	activesets.Add(db, activeSet.Hash(), &types.EpochActiveSet{Set: activeSet})
 	return p
 }
 

--- a/blocks/utils_test.go
+++ b/blocks/utils_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/log/logtest"
 	"github.com/spacemeshos/go-spacemesh/signing"
 	"github.com/spacemeshos/go-spacemesh/sql"
+	"github.com/spacemeshos/go-spacemesh/sql/activesets"
 	"github.com/spacemeshos/go-spacemesh/sql/layers"
 )
 
@@ -103,7 +104,7 @@ func Test_getProposalMetadata(t *testing.T) {
 	cfg := Config{OptFilterThreshold: 70}
 	lid := types.LayerID(111)
 	_, atxs := createATXs(t, cdb, (lid.GetEpoch() - 1).FirstLayer(), 10)
-	actives := types.ToATXIDs(atxs)
+	actives := types.ATXIDList(types.ToATXIDs(atxs))
 	props := make([]*types.Proposal, 0, 10)
 	hash1 := types.Hash32{1, 2, 3}
 	hash2 := types.Hash32{3, 2, 1}
@@ -119,11 +120,14 @@ func Test_getProposalMetadata(t *testing.T) {
 		for j := 0; j <= i; j++ {
 			p.EligibilityProofs = append(p.EligibilityProofs, types.VotingEligibility{J: uint32(j + 1)})
 		}
-		p.EpochData = &types.EpochData{}
-		p.ActiveSet = actives
+		p.EpochData = &types.EpochData{ActiveSetHash: actives.Hash()}
 		p.EpochData.EligibilityCount = uint32(i + 1)
 		props = append(props, &p)
 	}
+	require.NoError(t, activesets.Add(cdb, actives.Hash(), &types.EpochActiveSet{
+		Epoch: lid.GetEpoch(),
+		Set:   actives,
+	}))
 	require.NoError(t, layers.SetMeshHash(cdb, lid-1, hash2))
 
 	// only 5 / 10 proposals has the same state

--- a/common/types/ballot.go
+++ b/common/types/ballot.go
@@ -289,12 +289,12 @@ func (b *Ballot) IsMalicious() bool {
 // MarshalLogObject implements logging encoder for Ballot.
 func (b *Ballot) MarshalLogObject(encoder log.ObjectEncoder) error {
 	var (
-		activeSetSize = 0
-		beacon        Beacon
+		activeHash Hash32
+		beacon     Beacon
 	)
 
 	if b.EpochData != nil {
-		activeSetSize = len(b.ActiveSet)
+		activeHash = b.EpochData.ActiveSetHash
 		beacon = b.EpochData.Beacon
 	}
 
@@ -309,7 +309,7 @@ func (b *Ballot) MarshalLogObject(encoder log.ObjectEncoder) error {
 	encoder.AddInt("abstain", len(b.Votes.Abstain))
 	encoder.AddString("atx_id", b.AtxID.String())
 	encoder.AddString("ref_ballot", b.RefBallot.String())
-	encoder.AddInt("active_set_size", activeSetSize)
+	encoder.AddString("active set hash", activeHash.ShortString())
 	encoder.AddString("beacon", beacon.ShortString())
 	encoder.AddObject("votes", &b.Votes)
 	return nil

--- a/config/mainnet.go
+++ b/config/mainnet.go
@@ -77,7 +77,6 @@ func MainnetConfig() Config {
 			// 1000 - is assumed minimal number of units
 			// 5000 - half of the expected poet ticks
 			MinimalActiveSetWeight: 1000 * 5000,
-			EmitEmptyActiveSet:     20000,
 		},
 		HARE: hareConfig.Config{
 			N:               200,

--- a/hare/eligibility/oracle.go
+++ b/hare/eligibility/oracle.go
@@ -465,7 +465,11 @@ func (o *Oracle) activeSetFromRefBallots(epoch types.EpochID) ([]types.ATXID, er
 		}
 		actives, err := activesets.Get(o.cdb, ballot.EpochData.ActiveSetHash)
 		if err != nil {
-			o.Log.With().Error("active set missing from ref ballot", log.Inline(ballot))
+			o.Log.With().Error("failed to get active set",
+				log.String("actives hash", ballot.EpochData.ActiveSetHash.ShortString()),
+				log.String("ballot ", ballot.ID().String()),
+				log.Err(err),
+			)
 			continue
 		}
 		for _, id := range actives.Set {

--- a/hare/eligibility/oracle.go
+++ b/hare/eligibility/oracle.go
@@ -19,6 +19,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/miner"
 	"github.com/spacemeshos/go-spacemesh/signing"
 	"github.com/spacemeshos/go-spacemesh/sql"
+	"github.com/spacemeshos/go-spacemesh/sql/activesets"
 	"github.com/spacemeshos/go-spacemesh/sql/ballots"
 	"github.com/spacemeshos/go-spacemesh/system"
 )
@@ -462,11 +463,20 @@ func (o *Oracle) activeSetFromRefBallots(epoch types.EpochID) ([]types.ATXID, er
 			o.Log.With().Debug("beacon mismatch", log.Stringer("local", beacon), log.Object("ballot", ballot))
 			continue
 		}
-		for _, id := range ballot.ActiveSet {
+		actives, err := activesets.Get(o.cdb, ballot.EpochData.ActiveSetHash)
+		if err != nil {
+			o.Log.With().Error("active set missing from ref ballot", log.Inline(ballot))
+			continue
+		}
+		for _, id := range actives.Set {
 			activeMap[id] = struct{}{}
 		}
 	}
-	o.Log.With().Warning("using tortoise active set", log.Uint32("epoch", epoch.Uint32()), log.Stringer("beacon", beacon))
+	o.Log.With().Warning("using tortoise active set",
+		log.Int("actives size", len(activeMap)),
+		log.Uint32("epoch", epoch.Uint32()),
+		log.Stringer("beacon", beacon),
+	)
 	return maps.Keys(activeMap), nil
 }
 

--- a/hare/eligibility/oracle_test.go
+++ b/hare/eligibility/oracle_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/log/logtest"
 	"github.com/spacemeshos/go-spacemesh/signing"
 	"github.com/spacemeshos/go-spacemesh/sql"
+	"github.com/spacemeshos/go-spacemesh/sql/activesets"
 	"github.com/spacemeshos/go-spacemesh/sql/atxs"
 	"github.com/spacemeshos/go-spacemesh/sql/ballots"
 	"github.com/spacemeshos/go-spacemesh/sql/blocks"
@@ -64,7 +65,7 @@ func defaultOracle(t testing.TB) *testOracle {
 	return to
 }
 
-func createBallots(tb testing.TB, cdb *datastore.CachedDB, lid types.LayerID, activeSet []types.ATXID, miners []types.NodeID) []*types.Ballot {
+func createBallots(tb testing.TB, cdb *datastore.CachedDB, lid types.LayerID, activeSet types.ATXIDList, miners []types.NodeID) []*types.Ballot {
 	tb.Helper()
 	numBallots := ballotsPerLayer
 	if len(activeSet) < numBallots {
@@ -76,12 +77,15 @@ func createBallots(tb testing.TB, cdb *datastore.CachedDB, lid types.LayerID, ac
 		b.Layer = lid
 		b.AtxID = activeSet[i]
 		b.RefBallot = types.EmptyBallotID
-		b.EpochData = &types.EpochData{}
-		b.ActiveSet = activeSet
+		b.EpochData = &types.EpochData{ActiveSetHash: activeSet.Hash()}
 		b.Signature = types.RandomEdSignature()
 		b.SmesherID = miners[i]
 		require.NoError(tb, b.Initialize())
 		require.NoError(tb, ballots.Add(cdb, b))
+		activesets.Add(cdb, b.EpochData.ActiveSetHash, &types.EpochActiveSet{
+			Epoch: lid.GetEpoch(),
+			Set:   activeSet,
+		})
 		result = append(result, b)
 	}
 	return result
@@ -659,11 +663,10 @@ func TestActiveSetDD(t *testing.T) {
 	t.Parallel()
 
 	target := types.EpochID(4)
-	bgen := func(id types.BallotID, lid types.LayerID, node types.NodeID, beacon types.Beacon, atxs []types.ATXID, option ...func(*types.Ballot)) types.Ballot {
+	bgen := func(id types.BallotID, lid types.LayerID, node types.NodeID, beacon types.Beacon, atxs types.ATXIDList, option ...func(*types.Ballot)) types.Ballot {
 		ballot := types.Ballot{}
 		ballot.Layer = lid
-		ballot.EpochData = &types.EpochData{Beacon: beacon}
-		ballot.ActiveSet = atxs
+		ballot.EpochData = &types.EpochData{Beacon: beacon, ActiveSetHash: atxs.Hash()}
 		ballot.SmesherID = node
 		ballot.SetID(id)
 		for _, opt := range option {
@@ -693,12 +696,13 @@ func TestActiveSetDD(t *testing.T) {
 		beacon  types.Beacon // local beacon
 		ballots []types.Ballot
 		atxs    []*types.VerifiedActivationTx
+		actives []types.ATXIDList
 		expect  any
 	}{
 		{
-			"merged activesets",
-			types.Beacon{1},
-			[]types.Ballot{
+			desc:   "merged activesets",
+			beacon: types.Beacon{1},
+			ballots: []types.Ballot{
 				bgen(
 					types.BallotID{1},
 					target.FirstLayer(),
@@ -714,17 +718,18 @@ func TestActiveSetDD(t *testing.T) {
 					[]types.ATXID{{2}, {3}},
 				),
 			},
-			[]*types.VerifiedActivationTx{
+			atxs: []*types.VerifiedActivationTx{
 				agen(types.ATXID{1}, types.NodeID{1}),
 				agen(types.ATXID{2}, types.NodeID{2}),
 				agen(types.ATXID{3}, types.NodeID{3}),
 			},
-			[]types.ATXID{{1}, {2}, {3}},
+			actives: []types.ATXIDList{{{1}, {2}}, {{2}, {3}}},
+			expect:  []types.ATXID{{1}, {2}, {3}},
 		},
 		{
-			"filter by beacon",
-			types.Beacon{1},
-			[]types.Ballot{
+			desc:   "filter by beacon",
+			beacon: types.Beacon{1},
+			ballots: []types.Ballot{
 				bgen(
 					types.BallotID{1},
 					target.FirstLayer(),
@@ -740,16 +745,17 @@ func TestActiveSetDD(t *testing.T) {
 					[]types.ATXID{{2}, {3}},
 				),
 			},
-			[]*types.VerifiedActivationTx{
+			atxs: []*types.VerifiedActivationTx{
 				agen(types.ATXID{1}, types.NodeID{1}),
 				agen(types.ATXID{2}, types.NodeID{2}),
 			},
-			[]types.ATXID{{1}, {2}},
+			actives: []types.ATXIDList{{{1}, {2}}, {{2}, {3}}},
+			expect:  []types.ATXID{{1}, {2}},
 		},
 		{
-			"no local beacon",
-			types.EmptyBeacon,
-			[]types.Ballot{
+			desc:   "no local beacon",
+			beacon: types.EmptyBeacon,
+			ballots: []types.Ballot{
 				bgen(
 					types.BallotID{1},
 					target.FirstLayer(),
@@ -765,13 +771,14 @@ func TestActiveSetDD(t *testing.T) {
 					[]types.ATXID{{2}, {3}},
 				),
 			},
-			[]*types.VerifiedActivationTx{},
-			"not found",
+			atxs:    []*types.VerifiedActivationTx{},
+			actives: []types.ATXIDList{{{1}, {2}}, {{2}, {3}}},
+			expect:  "not found",
 		},
 		{
-			"unknown atxs",
-			types.Beacon{1},
-			[]types.Ballot{
+			desc:   "unknown atxs",
+			beacon: types.Beacon{1},
+			ballots: []types.Ballot{
 				bgen(
 					types.BallotID{1},
 					target.FirstLayer(),
@@ -787,13 +794,14 @@ func TestActiveSetDD(t *testing.T) {
 					[]types.ATXID{{2}, {3}},
 				),
 			},
-			[]*types.VerifiedActivationTx{},
-			"get ATX",
+			atxs:    []*types.VerifiedActivationTx{},
+			actives: []types.ATXIDList{{{1}, {2}}, {{2}, {3}}},
+			expect:  "get ATX",
 		},
 		{
-			"ballot no epoch data",
-			types.Beacon{1},
-			[]types.Ballot{
+			desc:   "ballot no epoch data",
+			beacon: types.Beacon{1},
+			ballots: []types.Ballot{
 				bgen(
 					types.BallotID{1},
 					target.FirstLayer(),
@@ -812,16 +820,17 @@ func TestActiveSetDD(t *testing.T) {
 					[]types.ATXID{{2}, {3}},
 				),
 			},
-			[]*types.VerifiedActivationTx{
+			atxs: []*types.VerifiedActivationTx{
 				agen(types.ATXID{2}, types.NodeID{2}),
 				agen(types.ATXID{3}, types.NodeID{3}),
 			},
-			[]types.ATXID{{2}, {3}},
+			actives: []types.ATXIDList{{{2}, {3}}},
+			expect:  []types.ATXID{{2}, {3}},
 		},
 		{
-			"wrong target epoch",
-			types.Beacon{1},
-			[]types.Ballot{
+			desc:   "wrong target epoch",
+			beacon: types.Beacon{1},
+			ballots: []types.Ballot{
 				bgen(
 					types.BallotID{1},
 					target.FirstLayer(),
@@ -830,18 +839,22 @@ func TestActiveSetDD(t *testing.T) {
 					[]types.ATXID{{1}},
 				),
 			},
-			[]*types.VerifiedActivationTx{
+			atxs: []*types.VerifiedActivationTx{
 				agen(types.ATXID{1}, types.NodeID{1}, func(verified *types.VerifiedActivationTx) {
 					verified.PublishEpoch = target
 				}),
 			},
-			"no epoch atx found",
+			actives: []types.ATXIDList{{{1}}},
+			expect:  "no epoch atx found",
 		},
 	} {
 		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()
 			oracle := defaultOracle(t)
+			for _, actives := range tc.actives {
+				require.NoError(t, activesets.Add(oracle.cdb, actives.Hash(), &types.EpochActiveSet{Set: actives}))
+			}
 			for _, ballot := range tc.ballots {
 				require.NoError(t, ballots.Add(oracle.cdb, &ballot))
 			}

--- a/hare/hare_test.go
+++ b/hare/hare_test.go
@@ -88,11 +88,9 @@ func randomProposal(lyrID types.LayerID, beacon types.Beacon) *types.Proposal {
 					Layer: lyrID,
 					AtxID: types.RandomATXID(),
 					EpochData: &types.EpochData{
-						ActiveSetHash: types.RandomHash(),
-						Beacon:        beacon,
+						Beacon: beacon,
 					},
 				},
-				ActiveSet: types.RandomActiveSet(10),
 			},
 		},
 	}
@@ -570,11 +568,6 @@ func TestHare_goodProposals(t *testing.T) {
 					pList[i].EpochData = nil
 					pList[i].RefBallot = refBallot.ID()
 					mockMesh.EXPECT().Ballot(pList[1].RefBallot).Return(refBallot, nil)
-					for _, id := range refBallot.ActiveSet {
-						nodeID := types.RandomNodeID()
-						mockMesh.EXPECT().GetAtxHeader(id).Return(&types.ActivationTxHeader{BaseTickHeight: 11, TickCount: 1, NodeID: nodeID}, nil).AnyTimes()
-						mockMesh.EXPECT().GetMalfeasanceProof(nodeID).AnyTimes()
-					}
 				}
 			}
 			for i, p := range pList {
@@ -584,13 +577,6 @@ func TestHare_goodProposals(t *testing.T) {
 					p.AtxID = *tc.atxids[i]
 				} else {
 					mockMesh.EXPECT().GetAtxHeader(p.AtxID).Return(&types.ActivationTxHeader{BaseTickHeight: tc.baseHeights[i], TickCount: 1}, nil)
-				}
-				if p.EpochData != nil {
-					for _, id := range p.ActiveSet {
-						nodeID := types.RandomNodeID()
-						mockMesh.EXPECT().GetAtxHeader(id).Return(&types.ActivationTxHeader{BaseTickHeight: 11, TickCount: 1, NodeID: nodeID}, nil).AnyTimes()
-						mockMesh.EXPECT().GetMalfeasanceProof(nodeID).AnyTimes()
-					}
 				}
 			}
 			nodeID := types.NodeID{1, 2, 3}

--- a/hare3/hare_test.go
+++ b/hare3/hare_test.go
@@ -325,7 +325,7 @@ func (cl *lockstepCluster) nogossip() {
 	}
 }
 
-func (cl *lockstepCluster) activeSet() []types.ATXID {
+func (cl *lockstepCluster) activeSet() types.ATXIDList {
 	var ids []types.ATXID
 	unique := map[types.ATXID]struct{}{}
 	for _, n := range cl.nodes {
@@ -350,9 +350,9 @@ func (cl *lockstepCluster) genProposals(lid types.LayerID) {
 		}
 		proposal := &types.Proposal{}
 		proposal.Layer = lid
-		proposal.ActiveSet = active
 		proposal.EpochData = &types.EpochData{
-			Beacon: cl.t.beacon,
+			Beacon:        cl.t.beacon,
+			ActiveSetHash: active.Hash(),
 		}
 		proposal.AtxID = n.atx.ID()
 		proposal.SmesherID = n.signer.NodeID()

--- a/miner/oracle.go
+++ b/miner/oracle.go
@@ -14,6 +14,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/proposals"
 	"github.com/spacemeshos/go-spacemesh/signing"
 	"github.com/spacemeshos/go-spacemesh/sql"
+	"github.com/spacemeshos/go-spacemesh/sql/activesets"
 	"github.com/spacemeshos/go-spacemesh/sql/ballots"
 	"github.com/spacemeshos/go-spacemesh/system"
 )
@@ -216,7 +217,11 @@ func (o *Oracle) calcEligibilityProofs(lid types.LayerID, epoch types.EpochID, b
 	if ref == nil {
 		minerWeight, totalWeight, ownAtx, activeSet, err = o.activeSet(epoch)
 	} else {
-		activeSet = ref.ActiveSet
+		if epochActives, err := activesets.Get(o.cdb, ref.EpochData.ActiveSetHash); err != nil {
+			return nil, err
+		} else {
+			activeSet = epochActives.Set
+		}
 		o.log.With().Info("use active set from ref ballot",
 			ref.ID(),
 			log.Int("num atx", len(activeSet)),

--- a/miner/oracle_test.go
+++ b/miner/oracle_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/proposals"
 	"github.com/spacemeshos/go-spacemesh/signing"
 	"github.com/spacemeshos/go-spacemesh/sql"
+	"github.com/spacemeshos/go-spacemesh/sql/activesets"
 	"github.com/spacemeshos/go-spacemesh/sql/atxs"
 	"github.com/spacemeshos/go-spacemesh/sql/ballots"
 	"github.com/spacemeshos/go-spacemesh/sql/blocks"
@@ -102,7 +103,6 @@ func genBallotWithEligibility(
 				EligibilityCount: ee.Slots,
 			},
 		},
-		ActiveSet:         ee.ActiveSet,
 		EligibilityProofs: ee.Proofs[lid],
 	}
 	ballot.Signature = signer.Sign(signing.BALLOT, ballot.SignedBytes())
@@ -216,6 +216,7 @@ func testMinerOracleAndProposalValidator(t *testing.T, layerSize, layersPerEpoch
 		require.True(t, ok)
 		ee, err := o.ProposalEligibility(layer, info.beacon, nonce)
 		require.NoError(t, err)
+		activesets.Add(o.cdb, ee.ActiveSet.Hash(), &types.EpochActiveSet{Epoch: ee.Epoch, Set: ee.ActiveSet})
 
 		for _, proof := range ee.Proofs[layer] {
 			b := genBallotWithEligibility(t, o.edSigner, info.beacon, layer, ee)
@@ -380,11 +381,16 @@ func createBallots(tb testing.TB, cdb *datastore.CachedDB, lid types.LayerID, nu
 		b.Layer = lid
 		b.AtxID = types.RandomATXID()
 		b.RefBallot = types.EmptyBallotID
-		b.EpochData = &types.EpochData{}
-		b.ActiveSet = common
-		b.ActiveSet = append(b.ActiveSet, b.AtxID)
+		b.EpochData = &types.EpochData{
+			ActiveSetHash: types.RandomHash(),
+		}
 		b.Signature = types.RandomEdSignature()
 		b.SmesherID = types.RandomNodeID()
+		actives := append(common, b.AtxID)
+		require.NoError(tb, activesets.Add(cdb, b.EpochData.ActiveSetHash, &types.EpochActiveSet{
+			Epoch: lid.GetEpoch(),
+			Set:   actives,
+		}))
 		require.NoError(tb, b.Initialize())
 		require.NoError(tb, ballots.Add(cdb, b))
 		result = append(result, b)
@@ -480,10 +486,14 @@ func TestRefBallot(t *testing.T) {
 	ballot.Layer = layer
 	ballot.AtxID = atx.ID()
 	ballot.SmesherID = o.edSigner.NodeID()
-	ballot.EpochData = &types.EpochData{EligibilityCount: 1}
-	ballot.ActiveSet = []types.ATXID{ballot.AtxID}
+	actives := types.ATXIDList{ballot.AtxID}
+	ballot.EpochData = &types.EpochData{EligibilityCount: 1, ActiveSetHash: actives.Hash()}
 	ballot.SetID(types.BallotID{1})
 	require.NoError(t, ballots.Add(o.cdb, &ballot))
+	activesets.Add(o.cdb, ballot.EpochData.ActiveSetHash, &types.EpochActiveSet{
+		Epoch: layer.GetEpoch(),
+		Set:   actives,
+	})
 
 	genATXForTargetEpochs(t, o.cdb, layer.GetEpoch(), layer.GetEpoch()+1, o.edSigner, layersPerEpoch, time.Now().Add(-1*time.Hour))
 	ee, err := o.calcEligibilityProofs(layer, layer.GetEpoch(), types.Beacon{}, types.VRFPostIndex(101))
@@ -491,5 +501,5 @@ func TestRefBallot(t *testing.T) {
 	require.NotEmpty(t, ee)
 	require.Equal(t, 1, int(ee.Slots))
 	require.Equal(t, atx.ID(), ee.Atx)
-	require.ElementsMatch(t, ballot.ActiveSet, ee.ActiveSet)
+	require.ElementsMatch(t, actives, ee.ActiveSet)
 }

--- a/miner/oracle_test.go
+++ b/miner/oracle_test.go
@@ -224,7 +224,7 @@ func testMinerOracleAndProposalValidator(t *testing.T, layerSize, layersPerEpoch
 			o.mClock.EXPECT().CurrentLayer().Return(layer)
 			mbc.EXPECT().ReportBeaconFromBallot(layer.GetEpoch(), b, info.beacon, gomock.Any()).Times(1)
 			nonceFetcher.EXPECT().VRFNonce(b.SmesherID, layer.GetEpoch()).Return(nonce, nil).Times(1)
-			eligible, err := validator.CheckEligibility(context.Background(), b)
+			eligible, err := validator.CheckEligibility(context.Background(), b, ee.ActiveSet)
 			require.NoError(t, err, "at layer %d, with layersPerEpoch %d", layer, layersPerEpoch)
 			require.True(t, eligible, "should be eligible at layer %d, but isn't", layer)
 			counterValuesSeen[proof.J]++

--- a/miner/proposal_builder.go
+++ b/miner/proposal_builder.go
@@ -66,7 +66,6 @@ type config struct {
 	layersPerEpoch     uint32
 	hdist              uint32
 	minActiveSetWeight uint64
-	emitEmptyActiveSet types.LayerID
 	nodeID             types.NodeID
 	networkDelay       time.Duration
 
@@ -79,7 +78,6 @@ func (c *config) MarshalLogObject(encoder log.ObjectEncoder) error {
 	encoder.AddUint32("epoch size", c.layersPerEpoch)
 	encoder.AddUint32("hdist", c.hdist)
 	encoder.AddUint64("min active weight", c.minActiveSetWeight)
-	encoder.AddUint32("emit empty set", c.emitEmptyActiveSet.Uint32())
 	encoder.AddDuration("network delay", c.networkDelay)
 	encoder.AddInt("good atx percent", c.goodAtxPct)
 	return nil
@@ -149,12 +147,6 @@ func WithNetworkDelay(delay time.Duration) Opt {
 func WithMinGoodAtxPct(pct int) Opt {
 	return func(pb *ProposalBuilder) {
 		pb.cfg.goodAtxPct = pct
-	}
-}
-
-func WithEmitEmptyActiveSet(lid types.LayerID) Opt {
-	return func(pb *ProposalBuilder) {
-		pb.cfg.emitEmptyActiveSet = lid
 	}
 }
 
@@ -301,9 +293,6 @@ func (pb *ProposalBuilder) createProposal(
 			TxIDs:    txIDs,
 			MeshHash: pb.decideMeshHash(ctx, layerID),
 		},
-	}
-	if p.EpochData != nil && layerID < pb.cfg.emitEmptyActiveSet {
-		p.ActiveSet = epochEligibility.ActiveSet
 	}
 	p.Ballot.Signature = pb.signer.Sign(signing.BALLOT, p.Ballot.SignedBytes())
 	p.SmesherID = pb.signer.NodeID()

--- a/miner/util.go
+++ b/miner/util.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/sql"
+	"github.com/spacemeshos/go-spacemesh/sql/activesets"
 	"github.com/spacemeshos/go-spacemesh/sql/ballots"
 	"github.com/spacemeshos/go-spacemesh/sql/blocks"
 	"github.com/spacemeshos/go-spacemesh/sql/layers"
@@ -33,7 +34,11 @@ func activeSetFromBlock(db sql.Executor, bid types.BlockID) ([]types.ATXID, erro
 		if err != nil {
 			return nil, fmt.Errorf("actives get ballot: %w", err)
 		}
-		for _, id := range ballot.ActiveSet {
+		actives, err := activesets.Get(db, ballot.EpochData.ActiveSetHash)
+		if err != nil {
+			return nil, fmt.Errorf("actives get active hash for ballot %s: %w", ballot.ID().String(), err)
+		}
+		for _, id := range actives.Set {
 			activeMap[id] = struct{}{}
 		}
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -673,7 +673,6 @@ func (app *App) initServices(ctx context.Context) error {
 			MaxExceptions:          trtlCfg.MaxExceptions,
 			Hdist:                  trtlCfg.Hdist,
 			MinimalActiveSetWeight: trtlCfg.MinimalActiveSetWeight,
-			AllowEmptyActiveSet:    trtlCfg.EmitEmptyActiveSet,
 		}),
 	)
 
@@ -803,7 +802,6 @@ func (app *App) initServices(ctx context.Context) error {
 		miner.WithLayerSize(layerSize),
 		miner.WithLayerPerEpoch(layersPerEpoch),
 		miner.WithMinimalActiveSetWeight(app.Config.Tortoise.MinimalActiveSetWeight),
-		miner.WithEmitEmptyActiveSet(app.Config.Tortoise.EmitEmptyActiveSet),
 		miner.WithHdist(app.Config.Tortoise.Hdist),
 		miner.WithNetworkDelay(app.Config.HARE.WakeupDelta),
 		miner.WithMinGoodAtxPct(minerGoodAtxPct),

--- a/proposals/eligibility_validator.go
+++ b/proposals/eligibility_validator.go
@@ -10,7 +10,6 @@ import (
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/datastore"
 	"github.com/spacemeshos/go-spacemesh/log"
-	"github.com/spacemeshos/go-spacemesh/sql/activesets"
 	"github.com/spacemeshos/go-spacemesh/system"
 )
 
@@ -71,7 +70,7 @@ func NewEligibilityValidator(
 }
 
 // CheckEligibility checks that a ballot is eligible in the layer that it specifies.
-func (v *Validator) CheckEligibility(ctx context.Context, ballot *types.Ballot) (bool, error) {
+func (v *Validator) CheckEligibility(ctx context.Context, ballot *types.Ballot, actives []types.ATXID) (bool, error) {
 	if len(ballot.EligibilityProofs) == 0 {
 		return false, fmt.Errorf("empty eligibility list is invalid (ballot %s)", ballot.ID())
 	}
@@ -93,7 +92,7 @@ func (v *Validator) CheckEligibility(ctx context.Context, ballot *types.Ballot) 
 	var data *types.EpochData
 	if ballot.EpochData != nil && ballot.Layer.GetEpoch() == v.clock.CurrentLayer().GetEpoch() {
 		var err error
-		data, err = v.validateReference(ballot, owned)
+		data, err = v.validateReference(ballot, actives, owned)
 		if err != nil {
 			return false, err
 		}
@@ -137,19 +136,15 @@ func (v *Validator) CheckEligibility(ctx context.Context, ballot *types.Ballot) 
 }
 
 // validateReference executed for reference ballots in latest epoch.
-func (v *Validator) validateReference(ballot *types.Ballot, owned *types.ActivationTxHeader) (*types.EpochData, error) {
+func (v *Validator) validateReference(ballot *types.Ballot, actives []types.ATXID, owned *types.ActivationTxHeader) (*types.EpochData, error) {
 	if ballot.EpochData.Beacon == types.EmptyBeacon {
 		return nil, fmt.Errorf("%w: ref ballot %v", errMissingBeacon, ballot.ID())
 	}
-	activeSet, err := activesets.Get(v.cdb, ballot.EpochData.ActiveSetHash)
-	if err != nil {
-		return nil, err
-	}
-	if len(activeSet.Set) == 0 {
+	if len(actives) == 0 {
 		return nil, fmt.Errorf("%w: ref ballot %v", errEmptyActiveSet, ballot.ID())
 	}
 	var totalWeight uint64
-	for _, atxID := range activeSet.Set {
+	for _, atxID := range actives {
 		atx, err := v.cdb.GetAtxHeader(atxID)
 		if err != nil {
 			return nil, fmt.Errorf("atx in active set is missing %v: %w", atxID, err)

--- a/proposals/eligibility_validator_test.go
+++ b/proposals/eligibility_validator_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/spacemeshos/go-spacemesh/datastore"
 	"github.com/spacemeshos/go-spacemesh/log/logtest"
 	"github.com/spacemeshos/go-spacemesh/sql"
-	"github.com/spacemeshos/go-spacemesh/sql/activesets"
 	"github.com/spacemeshos/go-spacemesh/sql/atxs"
 	"github.com/spacemeshos/go-spacemesh/tortoise"
 )
@@ -569,16 +568,13 @@ func TestEligibilityValidator(t *testing.T) {
 			for _, atx := range tc.atxs {
 				require.NoError(t, atxs.Add(db, &atx))
 			}
-			if tc.actives != nil {
-				require.NoError(t, activesets.Add(db, tc.actives.Hash(), &types.EpochActiveSet{Set: tc.actives}))
-			}
 			for _, ballot := range tc.ballots {
 				ballots[ballot.ID()] = &ballot
 			}
 			if !tc.fail {
 				ms.mbc.EXPECT().ReportBeaconFromBallot(tc.executed.Layer.GetEpoch(), &tc.executed, gomock.Any(), gomock.Any())
 			}
-			rst, err := tv.CheckEligibility(context.Background(), &tc.executed)
+			rst, err := tv.CheckEligibility(context.Background(), &tc.executed, tc.actives)
 			assert.Equal(t, !tc.fail, rst)
 			if len(tc.err) == 0 {
 				assert.Empty(t, err)

--- a/proposals/handler.go
+++ b/proposals/handler.go
@@ -66,7 +66,6 @@ type Config struct {
 	MaxExceptions          int
 	Hdist                  uint32
 	MinimalActiveSetWeight uint64
-	AllowEmptyActiveSet    types.LayerID
 }
 
 // defaultConfig for BlockHandler.
@@ -271,13 +270,6 @@ func (h *Handler) handleProposal(ctx context.Context, expHash types.Hash32, peer
 	latency := receivedTime.Sub(h.clock.LayerToTime(p.Layer))
 	metrics.ReportMessageLatency(pubsub.ProposalProtocol, pubsub.ProposalProtocol, latency)
 
-	set := p.ActiveSet
-	// on sync path activeset is downloaded together with proposal
-	// but starting at layer AllowEmptyActiveSet proposals are signed without activeset
-	if p.Layer >= h.cfg.AllowEmptyActiveSet {
-		p.ActiveSet = nil
-	}
-
 	if !h.edVerifier.Verify(signing.PROPOSAL, p.SmesherID, p.SignedBytes(), p.Signature) {
 		badSigProposal.Inc()
 		return fmt.Errorf("failed to verify proposal signature")
@@ -288,8 +280,6 @@ func (h *Handler) handleProposal(ctx context.Context, expHash types.Hash32, peer
 	}
 
 	// set the proposal ID when received
-	// It mustn't contain the active set if layer >= AllowEmptyActiveSet
-	// (p.Initialize uses SignedBytes again).
 	if err := p.Initialize(); err != nil {
 		failedInit.Inc()
 		return errInitialize
@@ -297,7 +287,6 @@ func (h *Handler) handleProposal(ctx context.Context, expHash types.Hash32, peer
 	if expHash != (types.Hash32{}) && p.ID().AsHash32() != expHash {
 		return fmt.Errorf("%w: proposal want %s, got %s", errWrongHash, expHash.ShortString(), p.ID().AsHash32().ShortString())
 	}
-	p.ActiveSet = set
 
 	if p.AtxID == types.EmptyATXID || p.AtxID == h.cfg.GoldenATXID {
 		badData.Inc()
@@ -392,6 +381,7 @@ func (h *Handler) processBallot(ctx context.Context, logger log.Log, b *types.Ba
 	if err != nil {
 		return nil, err
 	}
+	b.ActiveSet = nil
 
 	t1 := time.Now()
 	proof, err := h.mesh.AddBallot(ctx, b)
@@ -473,9 +463,7 @@ func (h *Handler) checkBallotDataIntegrity(ctx context.Context, b *types.Ballot)
 		if b.EpochData.Beacon == types.EmptyBeacon {
 			return errMissingBeacon
 		}
-		if len(b.ActiveSet) == 0 && b.Layer < h.cfg.AllowEmptyActiveSet {
-			return fmt.Errorf("%w: empty active set ballot %s", pubsub.ErrValidationReject, b.ID().String())
-		}
+		// TODO: remove after the network no longer populate ActiveSet in ballot.
 		if len(b.ActiveSet) != 0 {
 			if err := h.handleSet(ctx, b.EpochData.ActiveSetHash, types.EpochActiveSet{
 				Epoch: b.Layer.GetEpoch(),
@@ -494,10 +482,6 @@ func (h *Handler) checkBallotDataIntegrity(ctx context.Context, b *types.Ballot)
 			if len(set.Set) == 0 {
 				return fmt.Errorf("%w: empty active set ballot %s", pubsub.ErrValidationReject, b.ID().String())
 			}
-			// NOTE(dshulyak) sidecar is still stored in reference ballot, so that
-			// nodes that won't update on time will be able to download it
-			// with sync
-			b.ActiveSet = set.Set
 		}
 	} else if b.EpochData != nil {
 		return errUnexpectedEpochData

--- a/proposals/handler_test.go
+++ b/proposals/handler_test.go
@@ -494,8 +494,8 @@ func TestBallot_BallotDoubleVotedOutsideHdist(t *testing.T) {
 	th.mf.EXPECT().GetBallots(gomock.Any(), []types.BallotID{b.Votes.Base, b.RefBallot}).Return(nil).Times(1)
 	th.md.EXPECT().GetMissingActiveSet(gomock.Any(), types.ATXIDList{b.AtxID}).Return(types.ATXIDList{b.AtxID})
 	th.mf.EXPECT().GetAtxs(gomock.Any(), types.ATXIDList{b.AtxID}).Return(nil).Times(1)
-	th.mv.EXPECT().CheckEligibility(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, ballot *types.Ballot) (bool, error) {
+	th.mv.EXPECT().CheckEligibility(gomock.Any(), gomock.Any(), nil).DoAndReturn(
+		func(_ context.Context, ballot *types.Ballot, _ []types.ATXID) (bool, error) {
 			require.Equal(t, b.ID(), ballot.ID())
 			return true, nil
 		})
@@ -653,8 +653,8 @@ func TestBallot_ErrorCheckingEligible(t *testing.T) {
 	th.mf.EXPECT().GetBallots(gomock.Any(), []types.BallotID{b.Votes.Base, b.RefBallot}).Return(nil).Times(1)
 	th.md.EXPECT().GetMissingActiveSet(gomock.Any(), types.ATXIDList{b.AtxID}).Return(types.ATXIDList{b.AtxID})
 	th.mf.EXPECT().GetAtxs(gomock.Any(), types.ATXIDList{b.AtxID}).Return(nil).Times(1)
-	th.mv.EXPECT().CheckEligibility(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(ctx context.Context, ballot *types.Ballot) (bool, error) {
+	th.mv.EXPECT().CheckEligibility(gomock.Any(), gomock.Any(), nil).DoAndReturn(
+		func(ctx context.Context, ballot *types.Ballot, _ []types.ATXID) (bool, error) {
 			require.Equal(t, b.ID(), ballot.ID())
 			return false, errors.New("unknown")
 		})
@@ -682,8 +682,8 @@ func TestBallot_NotEligible(t *testing.T) {
 	th.mf.EXPECT().GetBallots(gomock.Any(), []types.BallotID{b.Votes.Base, b.RefBallot}).Return(nil).Times(1)
 	th.md.EXPECT().GetMissingActiveSet(gomock.Any(), types.ATXIDList{b.AtxID}).Return(types.ATXIDList{b.AtxID})
 	th.mf.EXPECT().GetAtxs(gomock.Any(), types.ATXIDList{b.AtxID}).Return(nil).Times(1)
-	th.mv.EXPECT().CheckEligibility(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(ctx context.Context, ballot *types.Ballot) (bool, error) {
+	th.mv.EXPECT().CheckEligibility(gomock.Any(), gomock.Any(), nil).DoAndReturn(
+		func(ctx context.Context, ballot *types.Ballot, _ []types.ATXID) (bool, error) {
 			require.Equal(t, b.ID(), ballot.ID())
 			return false, nil
 		})
@@ -712,8 +712,8 @@ func TestBallot_Success(t *testing.T) {
 	th.mf.EXPECT().GetBallots(gomock.Any(), []types.BallotID{b.Votes.Base, b.RefBallot}).Return(nil).Times(1)
 	th.md.EXPECT().GetMissingActiveSet(gomock.Any(), types.ATXIDList{b.AtxID}).Return(types.ATXIDList{b.AtxID})
 	th.mf.EXPECT().GetAtxs(gomock.Any(), types.ATXIDList{b.AtxID}).Return(nil).Times(1)
-	th.mv.EXPECT().CheckEligibility(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, ballot *types.Ballot) (bool, error) {
+	th.mv.EXPECT().CheckEligibility(gomock.Any(), gomock.Any(), nil).DoAndReturn(
+		func(_ context.Context, ballot *types.Ballot, _ []types.ATXID) (bool, error) {
 			require.Equal(t, b.ID(), ballot.ID())
 			return true, nil
 		})
@@ -746,8 +746,8 @@ func TestBallot_MaliciousProofIgnoredInSyncFlow(t *testing.T) {
 	th.mf.EXPECT().GetBallots(gomock.Any(), []types.BallotID{b.Votes.Base, b.RefBallot}).Return(nil).Times(1)
 	th.md.EXPECT().GetMissingActiveSet(gomock.Any(), types.ATXIDList{b.AtxID}).Return(types.ATXIDList{b.AtxID})
 	th.mf.EXPECT().GetAtxs(gomock.Any(), types.ATXIDList{b.AtxID}).Return(nil).Times(1)
-	th.mv.EXPECT().CheckEligibility(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, ballot *types.Ballot) (bool, error) {
+	th.mv.EXPECT().CheckEligibility(gomock.Any(), gomock.Any(), nil).DoAndReturn(
+		func(_ context.Context, ballot *types.Ballot, _ []types.ATXID) (bool, error) {
 			require.Equal(t, b.ID(), ballot.ID())
 			return true, nil
 		})
@@ -786,8 +786,8 @@ func TestBallot_RefBallot(t *testing.T) {
 			Set:   activeSet,
 		})
 	})
-	th.mv.EXPECT().CheckEligibility(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, ballot *types.Ballot) (bool, error) {
+	th.mv.EXPECT().CheckEligibility(gomock.Any(), gomock.Any(), activeSet).DoAndReturn(
+		func(_ context.Context, ballot *types.Ballot, _ []types.ATXID) (bool, error) {
 			require.Equal(t, b.ID(), ballot.ID())
 			return true, nil
 		})
@@ -833,7 +833,7 @@ func TestBallot_DecodedStoreFailure(t *testing.T) {
 	th.mf.EXPECT().GetBallots(gomock.Any(), []types.BallotID{b.Votes.Base, b.RefBallot}).Return(nil).Times(1)
 	th.md.EXPECT().GetMissingActiveSet(gomock.Any(), types.ATXIDList{b.AtxID}).Return(types.ATXIDList{b.AtxID})
 	th.mf.EXPECT().GetAtxs(gomock.Any(), types.ATXIDList{b.AtxID}).Return(nil).Times(1)
-	th.mv.EXPECT().CheckEligibility(gomock.Any(), gomock.Any()).Return(true, nil).Times(1)
+	th.mv.EXPECT().CheckEligibility(gomock.Any(), gomock.Any(), nil).Return(true, nil).Times(1)
 
 	decoded := &tortoise.DecodedBallot{BallotTortoiseData: b.ToTortoiseData()}
 	th.md.EXPECT().DecodeBallot(decoded.BallotTortoiseData).Return(decoded, nil)
@@ -958,8 +958,8 @@ func TestProposal_DuplicateTXs(t *testing.T) {
 	th.mf.EXPECT().GetBallots(gomock.Any(), []types.BallotID{p.Votes.Base, p.RefBallot}).Return(nil).Times(1)
 	th.md.EXPECT().GetMissingActiveSet(gomock.Any(), types.ATXIDList{p.AtxID}).Return(types.ATXIDList{p.AtxID})
 	th.mf.EXPECT().GetAtxs(gomock.Any(), types.ATXIDList{p.AtxID}).Return(nil).Times(1)
-	th.mv.EXPECT().CheckEligibility(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(ctx context.Context, ballot *types.Ballot) (bool, error) {
+	th.mv.EXPECT().CheckEligibility(gomock.Any(), gomock.Any(), nil).DoAndReturn(
+		func(ctx context.Context, ballot *types.Ballot, _ []types.ATXID) (bool, error) {
 			require.Equal(t, p.Ballot.ID(), ballot.ID())
 			return true, nil
 		})
@@ -993,8 +993,8 @@ func TestProposal_TXsNotAvailable(t *testing.T) {
 	th.mf.EXPECT().GetBallots(gomock.Any(), []types.BallotID{p.Votes.Base, p.RefBallot}).Return(nil).Times(1)
 	th.md.EXPECT().GetMissingActiveSet(gomock.Any(), types.ATXIDList{p.AtxID}).Return(types.ATXIDList{p.AtxID})
 	th.mf.EXPECT().GetAtxs(gomock.Any(), types.ATXIDList{p.AtxID}).Return(nil).Times(1)
-	th.mv.EXPECT().CheckEligibility(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(ctx context.Context, ballot *types.Ballot) (bool, error) {
+	th.mv.EXPECT().CheckEligibility(gomock.Any(), gomock.Any(), nil).DoAndReturn(
+		func(ctx context.Context, ballot *types.Ballot, _ []types.ATXID) (bool, error) {
 			require.Equal(t, p.Ballot.ID(), ballot.ID())
 			return true, nil
 		})
@@ -1031,8 +1031,8 @@ func TestProposal_FailedToAddProposalTXs(t *testing.T) {
 	th.mf.EXPECT().GetBallots(gomock.Any(), []types.BallotID{p.Votes.Base, p.RefBallot}).Return(nil).Times(1)
 	th.md.EXPECT().GetMissingActiveSet(gomock.Any(), types.ATXIDList{p.AtxID}).Return(types.ATXIDList{p.AtxID})
 	th.mf.EXPECT().GetAtxs(gomock.Any(), types.ATXIDList{p.AtxID}).Return(nil).Times(1)
-	th.mv.EXPECT().CheckEligibility(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(ctx context.Context, ballot *types.Ballot) (bool, error) {
+	th.mv.EXPECT().CheckEligibility(gomock.Any(), gomock.Any(), nil).DoAndReturn(
+		func(ctx context.Context, ballot *types.Ballot, _ []types.ATXID) (bool, error) {
 			require.Equal(t, p.Ballot.ID(), ballot.ID())
 			return true, nil
 		})
@@ -1072,8 +1072,8 @@ func TestProposal_ProposalGossip_Concurrent(t *testing.T) {
 	th.mf.EXPECT().GetBallots(gomock.Any(), []types.BallotID{p.Votes.Base, p.RefBallot}).Return(nil).MinTimes(1).MaxTimes(2)
 	th.md.EXPECT().GetMissingActiveSet(gomock.Any(), types.ATXIDList{p.AtxID}).Return(types.ATXIDList{p.AtxID}).MinTimes(1).MaxTimes(2)
 	th.mf.EXPECT().GetAtxs(gomock.Any(), types.ATXIDList{p.AtxID}).Return(nil).MinTimes(1).MaxTimes(2)
-	th.mv.EXPECT().CheckEligibility(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(ctx context.Context, ballot *types.Ballot) (bool, error) {
+	th.mv.EXPECT().CheckEligibility(gomock.Any(), gomock.Any(), nil).DoAndReturn(
+		func(ctx context.Context, ballot *types.Ballot, _ []types.ATXID) (bool, error) {
 			require.Equal(t, p.Ballot.ID(), ballot.ID())
 			return true, nil
 		}).MinTimes(1).MaxTimes(2)
@@ -1132,8 +1132,8 @@ func TestProposal_BroadcastMaliciousGossip(t *testing.T) {
 	th.mf.EXPECT().GetBallots(gomock.Any(), []types.BallotID{pMal.Votes.Base, pMal.RefBallot})
 	th.md.EXPECT().GetMissingActiveSet(gomock.Any(), types.ATXIDList{pMal.AtxID}).Return(types.ATXIDList{pMal.AtxID})
 	th.mf.EXPECT().GetAtxs(gomock.Any(), types.ATXIDList{pMal.AtxID})
-	th.mv.EXPECT().CheckEligibility(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(ctx context.Context, ballot *types.Ballot) (bool, error) {
+	th.mv.EXPECT().CheckEligibility(gomock.Any(), gomock.Any(), nil).DoAndReturn(
+		func(ctx context.Context, ballot *types.Ballot, _ []types.ATXID) (bool, error) {
 			require.Equal(t, pMal.Ballot.ID(), ballot.ID())
 			return true, nil
 		})
@@ -1206,8 +1206,8 @@ func TestProposal_ProposalGossip_Fetched(t *testing.T) {
 			th.mf.EXPECT().GetBallots(gomock.Any(), []types.BallotID{p.Votes.Base, p.RefBallot}).Return(nil)
 			th.md.EXPECT().GetMissingActiveSet(gomock.Any(), types.ATXIDList{p.AtxID}).Return(types.ATXIDList{p.AtxID})
 			th.mf.EXPECT().GetAtxs(gomock.Any(), types.ATXIDList{p.AtxID}).Return(nil)
-			th.mv.EXPECT().CheckEligibility(gomock.Any(), gomock.Any()).DoAndReturn(
-				func(ctx context.Context, ballot *types.Ballot) (bool, error) {
+			th.mv.EXPECT().CheckEligibility(gomock.Any(), gomock.Any(), nil).DoAndReturn(
+				func(ctx context.Context, ballot *types.Ballot, _ []types.ATXID) (bool, error) {
 					require.Equal(t, p.Ballot.ID(), ballot.ID())
 					if tc.propFetched {
 						// a separate goroutine fetched the propFetched and saved it to database
@@ -1251,8 +1251,8 @@ func TestProposal_ValidProposal(t *testing.T) {
 	th.mf.EXPECT().GetBallots(gomock.Any(), []types.BallotID{p.Votes.Base, p.RefBallot}).Return(nil).Times(1)
 	th.md.EXPECT().GetMissingActiveSet(gomock.Any(), types.ATXIDList{p.AtxID}).Return(types.ATXIDList{p.AtxID})
 	th.mf.EXPECT().GetAtxs(gomock.Any(), types.ATXIDList{p.AtxID}).Return(nil).Times(1)
-	th.mv.EXPECT().CheckEligibility(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(ctx context.Context, ballot *types.Ballot) (bool, error) {
+	th.mv.EXPECT().CheckEligibility(gomock.Any(), gomock.Any(), nil).DoAndReturn(
+		func(ctx context.Context, ballot *types.Ballot, _ []types.ATXID) (bool, error) {
 			require.Equal(t, p.Ballot.ID(), ballot.ID())
 			return true, nil
 		})
@@ -1288,8 +1288,8 @@ func TestMetrics(t *testing.T) {
 	th.mf.EXPECT().GetBallots(gomock.Any(), []types.BallotID{p.Votes.Base, p.RefBallot}).Return(nil).Times(1)
 	th.md.EXPECT().GetMissingActiveSet(gomock.Any(), types.ATXIDList{p.AtxID}).Return(types.ATXIDList{p.AtxID})
 	th.mf.EXPECT().GetAtxs(gomock.Any(), types.ATXIDList{p.AtxID}).Return(nil).Times(1)
-	th.mv.EXPECT().CheckEligibility(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(ctx context.Context, ballot *types.Ballot) (bool, error) {
+	th.mv.EXPECT().CheckEligibility(gomock.Any(), gomock.Any(), nil).DoAndReturn(
+		func(ctx context.Context, ballot *types.Ballot, _ []types.ATXID) (bool, error) {
 			require.Equal(t, p.Ballot.ID(), ballot.ID())
 			return true, nil
 		})
@@ -1423,7 +1423,7 @@ func TestHandleSyncedProposalActiveSet(t *testing.T) {
 	set := types.ATXIDList{{1}, {2}}
 	lid := types.LayerID(20)
 	good := gproposal(signer, types.ATXID{1}, lid, &types.EpochData{
-		ActiveSetHash: types.ATXIDList(set).Hash(),
+		ActiveSetHash: set.Hash(),
 		Beacon:        types.Beacon{1},
 	})
 	require.NoError(t, good.Initialize())
@@ -1445,7 +1445,7 @@ func TestHandleSyncedProposalActiveSet(t *testing.T) {
 	th.mf.EXPECT().GetAtxs(gomock.Any(), gomock.Any()).AnyTimes()
 	th.mf.EXPECT().GetBallots(gomock.Any(), gomock.Any()).AnyTimes()
 	th.mockSet.decodeAnyBallots()
-	th.mv.EXPECT().CheckEligibility(gomock.Any(), gomock.Any()).AnyTimes().Return(true, nil)
+	th.mv.EXPECT().CheckEligibility(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(true, nil)
 	th.mm.EXPECT().AddBallot(gomock.Any(), gomock.Any()).AnyTimes()
 	th.mm.EXPECT().AddTXsFromProposal(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 

--- a/proposals/handler_test.go
+++ b/proposals/handler_test.go
@@ -163,10 +163,9 @@ func withLayer(lid types.LayerID) createBallotOpt {
 	}
 }
 
-func withAnyRefData() createBallotOpt {
+func withRefData(activeSet types.ATXIDList) createBallotOpt {
 	return func(b *types.Ballot) {
 		b.RefBallot = types.EmptyBallotID
-		activeSet := types.ATXIDList{types.RandomATXID(), types.RandomATXID()}
 		sort.Slice(activeSet, func(i, j int) bool {
 			return bytes.Compare(activeSet[i].Bytes(), activeSet[j].Bytes()) < 0
 		})
@@ -174,7 +173,6 @@ func withAnyRefData() createBallotOpt {
 			ActiveSetHash: activeSet.Hash(),
 			Beacon:        types.RandomBeacon(),
 		}
-		b.ActiveSet = activeSet
 	}
 }
 
@@ -256,16 +254,14 @@ func signAndInit(tb testing.TB, b *types.Ballot) *types.Ballot {
 	return b
 }
 
-func createRefBallot(t *testing.T) *types.Ballot {
+func createRefBallot(t *testing.T, actives types.ATXIDList) *types.Ballot {
 	t.Helper()
 	b := types.RandomBallot()
 	b.RefBallot = types.EmptyBallotID
-	activeSet := types.ATXIDList{types.ATXID{1, 2, 3}, types.ATXID{2, 3, 4}}
 	b.EpochData = &types.EpochData{
-		ActiveSetHash: activeSet.Hash(),
+		ActiveSetHash: actives.Hash(),
 		Beacon:        types.RandomBeacon(),
 	}
-	b.ActiveSet = activeSet
 	return b
 }
 
@@ -347,7 +343,7 @@ func TestBallot_GoldenATXID(t *testing.T) {
 
 func TestBallot_RefBallotMissingEpochData(t *testing.T) {
 	th := createTestHandlerNoopDecoder(t)
-	b := createRefBallot(t)
+	b := createRefBallot(t, types.ATXIDList{{1}, {2}})
 	b.EpochData = nil
 	signAndInit(t, b)
 	createAtx(t, th.cdb.Database, b.Layer.GetEpoch()-1, b.AtxID, b.SmesherID)
@@ -359,7 +355,9 @@ func TestBallot_RefBallotMissingEpochData(t *testing.T) {
 
 func TestBallot_RefBallotMissingBeacon(t *testing.T) {
 	th := createTestHandlerNoopDecoder(t)
-	b := createRefBallot(t)
+	activeSet := types.ATXIDList{{1}, {2}}
+	b := createRefBallot(t, activeSet)
+	require.NoError(t, activesets.Add(th.cdb, activeSet.Hash(), &types.EpochActiveSet{Set: activeSet}))
 	b.EpochData.Beacon = types.EmptyBeacon
 	signAndInit(t, b)
 	createAtx(t, th.cdb.Database, b.Layer.GetEpoch()-1, b.AtxID, b.SmesherID)
@@ -371,8 +369,8 @@ func TestBallot_RefBallotMissingBeacon(t *testing.T) {
 
 func TestBallot_RefBallotEmptyActiveSet(t *testing.T) {
 	th := createTestHandlerNoopDecoder(t)
-	b := createRefBallot(t)
-	b.ActiveSet = nil
+	activeSet := types.ATXIDList{{1}, {2}}
+	b := createRefBallot(t, activeSet)
 	signAndInit(t, b)
 	data := codec.MustEncode(b)
 	createAtx(t, th.cdb.Database, b.Layer.GetEpoch()-1, b.AtxID, b.SmesherID)
@@ -382,10 +380,12 @@ func TestBallot_RefBallotEmptyActiveSet(t *testing.T) {
 	require.ErrorIs(t, th.HandleSyncedBallot(context.Background(), b.ID().AsHash32(), peer, data), sql.ErrNotFound)
 }
 
+// TODO: remove after the network no longer populate ActiveSet in ballot.
 func TestBallot_RefBallotDuplicateInActiveSet(t *testing.T) {
 	th := createTestHandlerNoopDecoder(t)
-	b := createRefBallot(t)
-	b.ActiveSet = append(b.ActiveSet, b.ActiveSet[0])
+	activeSet := types.ATXIDList{{1}, {2}, {1}}
+	b := createRefBallot(t, activeSet)
+	b.ActiveSet = activeSet
 	signAndInit(t, b)
 	createAtx(t, th.cdb.Database, b.Layer.GetEpoch()-1, b.AtxID, b.SmesherID)
 	data := codec.MustEncode(b)
@@ -394,31 +394,18 @@ func TestBallot_RefBallotDuplicateInActiveSet(t *testing.T) {
 	require.ErrorContains(t, th.HandleSyncedBallot(context.Background(), b.ID().AsHash32(), peer, data), "not sorted")
 }
 
+// TODO: remove after the network no longer populate ActiveSet in ballot.
 func TestBallot_RefBallotActiveSetNotSorted(t *testing.T) {
 	th := createTestHandlerNoopDecoder(t)
-	b := createRefBallot(t)
-	b.ActiveSet = types.RandomActiveSet(11)
-	sort.Slice(b.ActiveSet, func(i, j int) bool {
-		return bytes.Compare(b.ActiveSet[i].Bytes(), b.ActiveSet[j].Bytes()) > 0
-	})
+	activeSet := types.ATXIDList(types.RandomActiveSet(11))
+	b := createRefBallot(t, activeSet)
+	b.ActiveSet = activeSet
 	signAndInit(t, b)
 	createAtx(t, th.cdb.Database, b.Layer.GetEpoch()-1, b.AtxID, b.SmesherID)
 	data := codec.MustEncode(b)
 	peer := p2p.Peer("buddy")
 	th.mf.EXPECT().RegisterPeerHashes(peer, collectHashes(*b))
 	require.ErrorContains(t, th.HandleSyncedBallot(context.Background(), b.ID().AsHash32(), peer, data), "not sorted")
-}
-
-func TestBallot_RefBallotBadActiveSetHash(t *testing.T) {
-	th := createTestHandlerNoopDecoder(t)
-	b := createRefBallot(t)
-	b.EpochData.ActiveSetHash = types.Hash32{}
-	signAndInit(t, b)
-	createAtx(t, th.cdb.Database, b.Layer.GetEpoch()-1, b.AtxID, b.SmesherID)
-	data := codec.MustEncode(b)
-	peer := p2p.Peer("buddy")
-	th.mf.EXPECT().RegisterPeerHashes(peer, collectHashes(*b))
-	require.ErrorContains(t, th.HandleSyncedBallot(context.Background(), b.ID().AsHash32(), peer, data), "wrong hash")
 }
 
 func TestBallot_NotRefBallotButHasEpochData(t *testing.T) {
@@ -778,10 +765,11 @@ func TestBallot_RefBallot(t *testing.T) {
 		types.NewExistingBlock(types.BlockID{1}, types.InnerBlock{LayerIndex: lid.Sub(1)}),
 		types.NewExistingBlock(types.BlockID{2}, types.InnerBlock{LayerIndex: lid.Sub(2)}),
 	}
+	activeSet := types.ATXIDList{{1}, {2}, {3}}
 	b := createBallot(t,
 		withLayer(lid),
 		withSupportBlocks(supported...),
-		withAnyRefData(),
+		withRefData(activeSet),
 	)
 	createAtx(t, th.cdb.Database, b.Layer.GetEpoch()-1, b.AtxID, b.SmesherID)
 	for _, blk := range supported {
@@ -792,10 +780,10 @@ func TestBallot_RefBallot(t *testing.T) {
 	th.mf.EXPECT().GetBallots(gomock.Any(), []types.BallotID{b.Votes.Base}).Return(nil).Times(1)
 	th.md.EXPECT().GetMissingActiveSet(b.Layer.GetEpoch(), []types.ATXID{b.AtxID}).Return([]types.ATXID{b.AtxID})
 	th.mf.EXPECT().GetAtxs(gomock.Any(), []types.ATXID{b.AtxID})
-	th.mf.EXPECT().GetActiveSet(gomock.Any(), b.EpochData.ActiveSetHash).DoAndReturn(func(_ context.Context, hash types.Hash32) error {
+	th.mf.EXPECT().GetActiveSet(gomock.Any(), activeSet.Hash()).DoAndReturn(func(_ context.Context, hash types.Hash32) error {
 		return activesets.Add(th.cdb, hash, &types.EpochActiveSet{
 			Epoch: b.Layer.GetEpoch(),
-			Set:   b.ActiveSet,
+			Set:   activeSet,
 		})
 	})
 	th.mv.EXPECT().CheckEligibility(gomock.Any(), gomock.Any()).DoAndReturn(
@@ -804,9 +792,7 @@ func TestBallot_RefBallot(t *testing.T) {
 			return true, nil
 		})
 	th.mm.EXPECT().AddBallot(context.Background(), b).Return(nil, nil)
-	received := *b
-	received.ActiveSet = nil
-	require.NoError(t, th.HandleSyncedBallot(context.Background(), b.ID().AsHash32(), peer, codec.MustEncode(&received)))
+	require.NoError(t, th.HandleSyncedBallot(context.Background(), b.ID().AsHash32(), peer, codec.MustEncode(b)))
 }
 
 func TestBallot_DecodeBeforeVotesConsistency(t *testing.T) {
@@ -1416,13 +1402,12 @@ func TestHandleActiveSet(t *testing.T) {
 	}
 }
 
-func gproposal(signer *signing.EdSigner, atxid types.ATXID, activeset []types.ATXID,
+func gproposal(signer *signing.EdSigner, atxid types.ATXID,
 	layer types.LayerID, edata *types.EpochData,
 ) types.Proposal {
 	p := types.Proposal{}
 	p.Layer = layer
 	p.AtxID = atxid
-	p.ActiveSet = activeset
 	p.EpochData = edata
 	p.Ballot.Signature = signer.Sign(signing.BALLOT, p.Ballot.SignedBytes())
 	p.Ballot.SmesherID = signer.NodeID()
@@ -1435,85 +1420,35 @@ func TestHandleSyncedProposalActiveSet(t *testing.T) {
 	signer, err := signing.NewEdSigner()
 	require.NoError(t, err)
 
-	set := []types.ATXID{{1}, {2}}
-	const acceptEmpty = 20
-	good := gproposal(signer, types.ATXID{1}, set, acceptEmpty-1, &types.EpochData{
+	set := types.ATXIDList{{1}, {2}}
+	lid := types.LayerID(20)
+	good := gproposal(signer, types.ATXID{1}, lid, &types.EpochData{
 		ActiveSetHash: types.ATXIDList(set).Hash(),
 		Beacon:        types.Beacon{1},
 	})
 	require.NoError(t, good.Initialize())
+	th := createTestHandler(t)
+	pid := p2p.Peer("any")
 
-	woActive := good
-	woActive.ActiveSet = nil
-
-	notSigned := gproposal(signer, types.ATXID{1}, nil, acceptEmpty, &types.EpochData{
-		ActiveSetHash: types.ATXIDList(set).Hash(),
-		Beacon:        types.Beacon{1},
-	})
-	require.NoError(t, notSigned.Initialize())
-	notSigned.ActiveSet = set
-
-	notSignedEmpty := notSigned
-	notSignedEmpty.ActiveSet = nil
-	for _, tc := range []struct {
-		desc       string
-		data       []byte
-		id         types.Hash32
-		requestSet []types.ATXID
-		err        string
-	}{
-		{
-			desc: "before empty signed active set",
-			data: codec.MustEncode(&good),
-			id:   good.ID().AsHash32(),
+	th.mm.EXPECT().ProcessedLayer().Return(lid - 2).AnyTimes()
+	th.mclock.EXPECT().LayerToTime(gomock.Any())
+	th.mf.EXPECT().RegisterPeerHashes(pid, gomock.Any()).AnyTimes()
+	th.md.EXPECT().GetMissingActiveSet(gomock.Any(), gomock.Any()).AnyTimes()
+	th.mf.EXPECT().GetActiveSet(gomock.Any(), set.Hash()).DoAndReturn(
+		func(_ context.Context, got types.Hash32) error {
+			require.NoError(t, activesets.Add(th.cdb, got, &types.EpochActiveSet{
+				Set: set,
+			}))
+			return nil
 		},
-		{
-			desc: "before empty without active set",
-			data: codec.MustEncode(&woActive),
-			id:   woActive.ID().AsHash32(),
-			err:  "failed to verify proposal signature",
-		},
-		{
-			desc: "after empty not signed active set",
-			data: codec.MustEncode(&notSigned),
-			id:   notSigned.ID().AsHash32(),
-		},
-		{
-			desc:       "after empty not signed active set empty",
-			data:       codec.MustEncode(&notSignedEmpty),
-			id:         notSigned.ID().AsHash32(),
-			requestSet: set,
-		},
-	} {
-		t.Run(tc.desc, func(t *testing.T) {
-			th := createTestHandler(t)
-			th.mm.EXPECT().ProcessedLayer().Return(acceptEmpty - 2).AnyTimes()
-			th.cfg.AllowEmptyActiveSet = acceptEmpty
-			pid := p2p.Peer("any")
+	)
+	th.mf.EXPECT().GetAtxs(gomock.Any(), gomock.Any()).AnyTimes()
+	th.mf.EXPECT().GetBallots(gomock.Any(), gomock.Any()).AnyTimes()
+	th.mockSet.decodeAnyBallots()
+	th.mv.EXPECT().CheckEligibility(gomock.Any(), gomock.Any()).AnyTimes().Return(true, nil)
+	th.mm.EXPECT().AddBallot(gomock.Any(), gomock.Any()).AnyTimes()
+	th.mm.EXPECT().AddTXsFromProposal(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 
-			th.mclock.EXPECT().LayerToTime(gomock.Any())
-			th.mf.EXPECT().RegisterPeerHashes(pid, gomock.Any()).AnyTimes()
-			th.md.EXPECT().GetMissingActiveSet(gomock.Any(), gomock.Any()).AnyTimes()
-			if tc.requestSet != nil {
-				id := types.ATXIDList(tc.requestSet).Hash()
-				th.mf.EXPECT().GetActiveSet(gomock.Any(), id)
-				require.NoError(t, activesets.Add(th.cdb, id, &types.EpochActiveSet{
-					Set: tc.requestSet,
-				}))
-			}
-			th.mf.EXPECT().GetAtxs(gomock.Any(), gomock.Any()).AnyTimes()
-			th.mf.EXPECT().GetBallots(gomock.Any(), gomock.Any()).AnyTimes()
-			th.mockSet.decodeAnyBallots()
-			th.mv.EXPECT().CheckEligibility(gomock.Any(), gomock.Any()).AnyTimes().Return(true, nil)
-			th.mm.EXPECT().AddBallot(gomock.Any(), gomock.Any()).AnyTimes()
-			th.mm.EXPECT().AddTXsFromProposal(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
-
-			err := th.HandleSyncedProposal(context.Background(), tc.id, pid, tc.data)
-			if len(tc.err) > 0 {
-				require.ErrorContains(t, err, tc.err)
-			} else {
-				require.NoError(t, err)
-			}
-		})
-	}
+	err = th.HandleSyncedProposal(context.Background(), good.ID().AsHash32(), pid, codec.MustEncode(&good))
+	require.NoError(t, err)
 }

--- a/proposals/interface.go
+++ b/proposals/interface.go
@@ -17,7 +17,7 @@ type meshProvider interface {
 }
 
 type eligibilityValidator interface {
-	CheckEligibility(context.Context, *types.Ballot) (bool, error)
+	CheckEligibility(context.Context, *types.Ballot, []types.ATXID) (bool, error)
 }
 
 type tortoiseProvider interface {

--- a/proposals/mocks.go
+++ b/proposals/mocks.go
@@ -176,18 +176,18 @@ func (m *MockeligibilityValidator) EXPECT() *MockeligibilityValidatorMockRecorde
 }
 
 // CheckEligibility mocks base method.
-func (m *MockeligibilityValidator) CheckEligibility(arg0 context.Context, arg1 *types.Ballot) (bool, error) {
+func (m *MockeligibilityValidator) CheckEligibility(arg0 context.Context, arg1 *types.Ballot, arg2 []types.ATXID) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CheckEligibility", arg0, arg1)
+	ret := m.ctrl.Call(m, "CheckEligibility", arg0, arg1, arg2)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CheckEligibility indicates an expected call of CheckEligibility.
-func (mr *MockeligibilityValidatorMockRecorder) CheckEligibility(arg0, arg1 interface{}) *eligibilityValidatorCheckEligibilityCall {
+func (mr *MockeligibilityValidatorMockRecorder) CheckEligibility(arg0, arg1, arg2 interface{}) *eligibilityValidatorCheckEligibilityCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckEligibility", reflect.TypeOf((*MockeligibilityValidator)(nil).CheckEligibility), arg0, arg1)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckEligibility", reflect.TypeOf((*MockeligibilityValidator)(nil).CheckEligibility), arg0, arg1, arg2)
 	return &eligibilityValidatorCheckEligibilityCall{Call: call}
 }
 
@@ -203,13 +203,13 @@ func (c *eligibilityValidatorCheckEligibilityCall) Return(arg0 bool, arg1 error)
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *eligibilityValidatorCheckEligibilityCall) Do(f func(context.Context, *types.Ballot) (bool, error)) *eligibilityValidatorCheckEligibilityCall {
+func (c *eligibilityValidatorCheckEligibilityCall) Do(f func(context.Context, *types.Ballot, []types.ATXID) (bool, error)) *eligibilityValidatorCheckEligibilityCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *eligibilityValidatorCheckEligibilityCall) DoAndReturn(f func(context.Context, *types.Ballot) (bool, error)) *eligibilityValidatorCheckEligibilityCall {
+func (c *eligibilityValidatorCheckEligibilityCall) DoAndReturn(f func(context.Context, *types.Ballot, []types.ATXID) (bool, error)) *eligibilityValidatorCheckEligibilityCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/proposals/util/util.go
+++ b/proposals/util/util.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/datastore"
+	"github.com/spacemeshos/go-spacemesh/sql/activesets"
 	"github.com/spacemeshos/go-spacemesh/sql/ballots"
 )
 
@@ -61,16 +62,20 @@ func ComputeWeightPerEligibility(
 			return nil, fmt.Errorf("%w: missing ref ballot %s (for %s)", err, ballot.RefBallot, ballot.ID())
 		}
 	}
-	if len(refBallot.ActiveSet) == 0 {
-		return nil, fmt.Errorf("ref ballot missing active set %s (for %s)", ballot.RefBallot, ballot.ID())
-	}
 	if refBallot.EpochData == nil {
 		return nil, fmt.Errorf("epoch data is nil on ballot %d/%s", refBallot.Layer, refBallot.ID())
 	}
 	if refBallot.EpochData.EligibilityCount == 0 {
 		return nil, fmt.Errorf("eligibility count is 0 on ballot %d/%s", refBallot.Layer, refBallot.ID())
 	}
-	for _, atxID := range refBallot.ActiveSet {
+	actives, err := activesets.Get(cdb, refBallot.EpochData.ActiveSetHash)
+	if err != nil {
+		return nil, fmt.Errorf("get active set %s (%s)", refBallot.EpochData.ActiveSetHash.ShortString(), refBallot.ID())
+	}
+	if len(actives.Set) == 0 {
+		return nil, fmt.Errorf("empty active set %s (%s)", refBallot.EpochData.ActiveSetHash.ShortString(), refBallot.ID())
+	}
+	for _, atxID := range actives.Set {
 		hdr, err = cdb.GetAtxHeader(atxID)
 		if err != nil {
 			return nil, fmt.Errorf("%w: missing atx %s in active set of %s (for %s)", err, atxID, refBallot.ID(), ballot.ID())

--- a/tortoise/algorithm.go
+++ b/tortoise/algorithm.go
@@ -27,8 +27,7 @@ type Config struct {
 	// MinimalActiveSetWeight denotes weight that will replace weight
 	// recorded in the first ballot, if that weight is less than minimal
 	// for purposes of eligibility computation.
-	MinimalActiveSetWeight uint64        `mapstructure:"tortoise-activeset-weight"`
-	EmitEmptyActiveSet     types.LayerID `mapstructure:"emit-empty-active-set"`
+	MinimalActiveSetWeight uint64 `mapstructure:"tortoise-activeset-weight"`
 
 	LayerSize uint32
 }

--- a/tortoise/tortoise_test.go
+++ b/tortoise/tortoise_test.go
@@ -862,7 +862,6 @@ func TestDecodeVotes(t *testing.T) {
 		require.NoError(t, err)
 		ballot := types.NewExistingBallot(types.BallotID{3, 3, 3}, types.EmptyEdSignature, types.EmptyNodeID, ballots[0].Layer)
 		ballot.InnerBallot = ballots[0].InnerBallot
-		ballot.ActiveSet = ballots[0].ActiveSet
 		hasher := opinionhash.New()
 		supported := types.BlockID{2, 2, 2}
 		hasher.WriteSupport(supported, 0)
@@ -2284,7 +2283,6 @@ func TestSwitchMode(t *testing.T) {
 			ballot := types.NewExistingBallot(types.BallotID{byte(i)}, types.EmptyEdSignature, types.EmptyNodeID, template.Layer)
 			ballot.InnerBallot = template.InnerBallot
 			ballot.EligibilityProofs = template.EligibilityProofs
-			ballot.ActiveSet = template.ActiveSet
 			tortoise.OnBallot(ballot.ToTortoiseData())
 		}
 		tortoise.TallyVotes(ctx, last)
@@ -2332,7 +2330,6 @@ func TestOnBallotComputeOpinion(t *testing.T) {
 		ballot := types.NewExistingBallot(id, types.EmptyEdSignature, types.EmptyNodeID, rst[0].Layer)
 		ballot.InnerBallot = rst[0].InnerBallot
 		ballot.EligibilityProofs = rst[0].EligibilityProofs
-		ballot.ActiveSet = rst[0].ActiveSet
 		ballot.Votes.Base = types.EmptyBallotID
 		ballot.Votes.Support = nil
 		ballot.Votes.Against = nil


### PR DESCRIPTION
## Motivation
Closes #4984

## Changes
- drop EmitEmptyActiveSet config
- remove all access to Ballot.ActiveSet and look up from db instead
- remove all writes of Ballot.ActiveSet

after this PR, miner will still accept proposal/ballot with non-empty active sets, but will save ballots without active set.