### PR TITLE
[Merged by Bors] - Remove PoET workaround for round 3

### DIFF
--- a/activation/nipost.go
+++ b/activation/nipost.go
@@ -7,12 +7,12 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
+	"slices"
 	"time"
 
 	"github.com/spacemeshos/merkle-tree"
 	"github.com/spacemeshos/poet/shared"
 	"github.com/spacemeshos/post/proving"
-	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/spacemeshos/go-spacemesh/activation/metrics"
@@ -469,14 +469,6 @@ func (nb *NIPostBuilder) addPoETMitigation(ctx context.Context, from, to string,
 
 func (nb *NIPostBuilder) getBestProof(ctx context.Context, challenge types.Hash32, publishEpoch types.EpochID) (types.PoetProofRef, *types.MerkleProof, error) {
 	switch publishEpoch {
-	case 4:
-		// because PoET 111 had a hardware issue when challenges for round 3 were submitted, no node could submit to it
-		// 111 was recovered with the PoET 110 DB, so all successful submissions to 110 should be able to be fetched from there as well
-		// TODO(mafa): remove after next PoET round; https://github.com/spacemeshos/go-spacemesh/issues/4968
-		err := nb.addPoETMitigation(ctx, "https://poet-110.spacemesh.network", "https://poet-111.spacemesh.network", 4)
-		if err != nil {
-			nb.log.With().Error("pub epoch 4 mitigation: failed to add PoET 111 to state for pub epoch 4", log.Err(err))
-		}
 	case 5:
 		// PoET 112 came online after the registration window for round 4 ended, so no node could submit to it
 		// 112 was initialized with the PoET 110 DB, so all successful submissions to 110 should be able to be fetched from there as well

--- a/activation/nipost_test.go
+++ b/activation/nipost_test.go
@@ -1049,13 +1049,6 @@ func TestNIPostBuilder_Mainnet_PoetRound3_Workaround(t *testing.T) {
 		epoch types.EpochID
 	}{
 		{
-			// TODO(mafa): remove after epoch 4 end; https://github.com/spacemeshos/go-spacemesh/issues/4968
-			name:  "epoch 4: PoET 111 restore with PoET 110",
-			from:  "https://poet-110.spacemesh.network",
-			to:    "https://poet-111.spacemesh.network",
-			epoch: 4,
-		},
-		{
 			// TODO(mafa): remove after epoch 5 end; https://github.com/spacemeshos/go-spacemesh/issues/5030
 			name:  "epoch 5: PoET 112 restore with PoET 110",
 			from:  "https://poet-110.spacemesh.network",


### PR DESCRIPTION
## Motivation
Closes #4968 

This removes the workaround added for PoET round 3. Merge after 2023-09-22 08:00 UTC, when epoch 4 ends.

## Changes
- remove workaround

## Test Plan
existing tests pass

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
