### PR TITLE
[Merged by Bors] - hare3: simpify and deflake synchronization in cluster tests

### DIFF
--- a/hare3/hare_test.go
+++ b/hare3/hare_test.go
@@ -265,8 +265,6 @@ type lockstepCluster struct {
 	}
 
 	timestamp time.Time
-	start     chan struct{}
-	complete  chan struct{}
 }
 
 func (cl *lockstepCluster) addNode(n *node) {
@@ -313,13 +311,9 @@ func (cl *lockstepCluster) addEquivocators(n int) *lockstepCluster {
 }
 
 func (cl *lockstepCluster) nogossip() {
-	cl.start = make(chan struct{}, len(cl.nodes))
-	cl.complete = make(chan struct{}, len(cl.nodes))
 	for _, n := range cl.nodes {
 		require.NoError(cl.t, beacons.Add(n.db, cl.t.genesis.GetEpoch()+1, cl.t.beacon))
 		n.mpublisher.EXPECT().Publish(gomock.Any(), gomock.Any(), gomock.Any()).Do(func(ctx context.Context, _ string, msg []byte) error {
-			cl.timedReceive(cl.start)
-			cl.timedSend(cl.complete)
 			return nil
 		}).AnyTimes()
 	}
@@ -380,8 +374,6 @@ func (cl *lockstepCluster) genProposals(lid types.LayerID) {
 }
 
 func (cl *lockstepCluster) setup() {
-	cl.start = make(chan struct{}, len(cl.nodes))
-	cl.complete = make(chan struct{}, len(cl.nodes))
 	active := cl.activeSet()
 	for _, n := range cl.nodes {
 		require.NoError(cl.t, beacons.Add(n.db, cl.t.genesis.GetEpoch()+1, cl.t.beacon))
@@ -393,11 +385,9 @@ func (cl *lockstepCluster) setup() {
 		}
 		n.oracle.UpdateActiveSet(cl.t.genesis.GetEpoch()+1, active)
 		n.mpublisher.EXPECT().Publish(gomock.Any(), gomock.Any(), gomock.Any()).Do(func(ctx context.Context, _ string, msg []byte) error {
-			cl.timedReceive(cl.start)
 			for _, other := range cl.nodes {
 				other.hare.Handler(ctx, "self", msg)
 			}
-			cl.timedSend(cl.complete)
 			return nil
 		}).AnyTimes()
 	}
@@ -411,52 +401,30 @@ func (cl *lockstepCluster) movePreround(layer types.LayerID) {
 		n.nclock.StartLayer(layer)
 		n.clock.Advance(cl.timestamp.Sub(n.clock.Now()))
 	}
-	send := 0
 	for _, n := range cl.nodes {
-		if n.tracer.waitEligibility() != nil {
-			send++
-		}
+		n.tracer.waitEligibility()
 	}
-	for i := 0; i < send; i++ {
-		cl.timedSend(cl.start)
-	}
-	for i := 0; i < send; i++ {
-		cl.timedReceive(cl.complete)
+	for _, n := range cl.nodes {
+		n.tracer.waitSent()
 	}
 }
 
 func (cl *lockstepCluster) moveRound() {
 	cl.timestamp = cl.timestamp.Add(cl.t.cfg.RoundDuration)
-	send := 0
 	for _, n := range cl.nodes {
 		n.clock.Advance(cl.timestamp.Sub(n.clock.Now()))
 	}
 	for _, n := range cl.nodes {
-		if n.tracer.waitEligibility() != nil {
-			send++
-		}
+		n.tracer.waitEligibility()
 	}
-	for i := 0; i < send; i++ {
-		cl.timedSend(cl.start)
-	}
-	for i := 0; i < send; i++ {
-		cl.timedReceive(cl.complete)
+	for _, n := range cl.nodes {
+		n.tracer.waitSent()
 	}
 }
 
-func (cl *lockstepCluster) timedSend(ch chan struct{}) {
-	select {
-	case ch <- struct{}{}:
-	case <-time.After(time.Second):
-		require.FailNow(cl.t, "send timed out")
-	}
-}
-
-func (cl *lockstepCluster) timedReceive(ch chan struct{}) {
-	select {
-	case <-ch:
-	case <-time.After(time.Second):
-		require.FailNow(cl.t, "receive timed out")
+func (cl *lockstepCluster) waitStopped() {
+	for _, n := range cl.nodes {
+		n.tracer.waitStopped()
 	}
 }
 
@@ -464,7 +432,8 @@ func newTestTracer(tb testing.TB) *testTracer {
 	return &testTracer{
 		TB:          tb,
 		stopped:     make(chan types.LayerID, 100),
-		eligibility: make(chan *types.HareEligibility, 100),
+		eligibility: make(chan *types.HareEligibility),
+		sent:        make(chan *Message),
 	}
 }
 
@@ -472,6 +441,7 @@ type testTracer struct {
 	testing.TB
 	stopped     chan types.LayerID
 	eligibility chan *types.HareEligibility
+	sent        chan *Message
 }
 
 func (t *testTracer) waitStopped() types.LayerID {
@@ -496,6 +466,17 @@ func (t *testTracer) waitEligibility() *types.HareEligibility {
 	return nil
 }
 
+func (t *testTracer) waitSent() *Message {
+	wait := time.Second
+	select {
+	case <-time.After(wait):
+		require.FailNow(t, "no message", "wait %v", wait)
+	case m := <-t.sent:
+		return m
+	}
+	return nil
+}
+
 func (*testTracer) OnStart(types.LayerID) {}
 
 func (t *testTracer) OnStop(lid types.LayerID) {
@@ -506,13 +487,22 @@ func (t *testTracer) OnStop(lid types.LayerID) {
 }
 
 func (t *testTracer) OnActive(el *types.HareEligibility) {
+	wait := time.Second
 	select {
+	case <-time.After(wait):
+		require.FailNow(t, "eligibility can't be sent", "wait %v", wait)
 	case t.eligibility <- el:
-	default:
 	}
 }
 
-func (*testTracer) OnMessageSent(*Message) {}
+func (t *testTracer) OnMessageSent(m *Message) {
+	wait := time.Second
+	select {
+	case <-time.After(wait):
+		require.FailNow(t, "message can't be sent", "wait %v", wait)
+	case t.sent <- m:
+	}
+}
 
 func (*testTracer) OnMessageReceived(*Message) {}
 
@@ -540,8 +530,8 @@ func testHare(t *testing.T, active, inactive, equivocators int, opts ...clusterO
 		cluster.moveRound()
 	}
 	var consistent []types.ProposalID
+	cluster.waitStopped()
 	for _, n := range cluster.nodes {
-		n.tracer.waitStopped()
 		select {
 		case coin := <-n.hare.Coins():
 			require.Equal(t, coin.Layer, layer)
@@ -596,6 +586,7 @@ func TestIterationLimit(t *testing.T) {
 	for i := 0; i < int(tst.cfg.IterationsLimit)*int(notify); i++ {
 		cluster.moveRound()
 	}
+	cluster.waitStopped()
 	require.Empty(t, cluster.nodes[0].hare.Running())
 	require.False(t, cluster.nodes[0].patrol.IsHareInCharge(layer))
 }
@@ -630,6 +621,9 @@ func TestHandler(t *testing.T) {
 		Add(tst.layerDuration * time.Duration(layer)).
 		Add(tst.cfg.PreroundDelay)).Sub(n.clock.Now()))
 	elig := n.tracer.waitEligibility()
+	n.tracer.waitSent()
+	n.tracer.waitEligibility()
+
 	t.Run("malformed", func(t *testing.T) {
 		require.ErrorIs(t, n.hare.Handler(context.Background(), "", []byte("malformed")),
 			pubsub.ErrValidationReject)

--- a/hare3/hare_test.go
+++ b/hare3/hare_test.go
@@ -313,9 +313,7 @@ func (cl *lockstepCluster) addEquivocators(n int) *lockstepCluster {
 func (cl *lockstepCluster) nogossip() {
 	for _, n := range cl.nodes {
 		require.NoError(cl.t, beacons.Add(n.db, cl.t.genesis.GetEpoch()+1, cl.t.beacon))
-		n.mpublisher.EXPECT().Publish(gomock.Any(), gomock.Any(), gomock.Any()).Do(func(ctx context.Context, _ string, msg []byte) error {
-			return nil
-		}).AnyTimes()
+		n.mpublisher.EXPECT().Publish(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	}
 }
 


### PR DESCRIPTION
closes: https://github.com/spacemeshos/go-spacemesh/issues/4990

there are 2 important events that needs to be in sync:
1. walltime.Sub(t.clock.Now()) needs to be called after call to Advance in tests
2. Advance needs to be called after all eligible messages were processed

1st synchronization point is realized by waiting on computing vrf. code calls Advance, and waits for read on eligibility channel. note that event is submitted even if eligibility is nil.
2nd synchronization point is realized by waiting until message is processed by all nodes in the cluster. code calls Publish, when Publish exists message was delivered and processed by every node. so when read on sent channel is received we know that all messages were processed.