### PR TITLE
[Merged by Bors] - Fix nil pointer panic on error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,12 @@ Support for old certificate sync protocol is dropped. This update is incompatibl
 ### Features
 
 ### Improvements
+
 * [#4998](https://github.com/spacemeshos/go-spacemesh/pull/4998) First phase of state size reduction.
   Ephemeral data are deleted and state compacted at the time of upgrade. In steady-state, data is pruned periodically.
 * [#5021](https://github.com/spacemeshos/go-spacemesh/pull/5021) Drop support for old certificate sync protocol.
 * [#5024](https://github.com/spacemeshos/go-spacemesh/pull/5024) Active set will be saved in state separately from ballots.
+* [#5035](https://github.com/spacemeshos/go-spacemesh/pull/5035) Fix possible nil pointer panic when node fails to persist nipost builder state.
 
 ## v1.1.5
 

--- a/activation/nipost_state.go
+++ b/activation/nipost_state.go
@@ -2,6 +2,7 @@ package activation
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"hash/crc64"
 	"io"
@@ -22,30 +23,31 @@ const (
 )
 
 func write(path string, data []byte) error {
-	tmp, err := os.Create(fmt.Sprintf("%s.tmp", path))
+	tmpName := fmt.Sprintf("%s.tmp", path)
+	tmp, err := os.Create(tmpName)
 	if err != nil {
-		return fmt.Errorf("create temporary file %s: %w", tmp.Name(), err)
+		return fmt.Errorf("create temporary file %s: %w", tmpName, err)
 	}
 
 	checksum := crc64.New(crc64.MakeTable(crc64.ISO))
 	w := io.MultiWriter(tmp, checksum)
-	if _, err = w.Write(data); err != nil {
-		_ = tmp.Close()
+	if _, err := w.Write(data); err != nil {
+		err = errors.Join(err, tmp.Close())
 		return fmt.Errorf("write data %v: %w", tmp.Name(), err)
 	}
 
 	crc := make([]byte, crc64.Size)
 	binary.BigEndian.PutUint64(crc, checksum.Sum64())
-	if _, err = tmp.Write(crc); err != nil {
-		_ = tmp.Close()
+	if _, err := tmp.Write(crc); err != nil {
+		err = errors.Join(err, tmp.Close())
 		return fmt.Errorf("write checksum %s: %w", tmp.Name(), err)
 	}
 
-	if err = tmp.Close(); err != nil {
+	if err := tmp.Close(); err != nil {
 		return fmt.Errorf("failed to close tmp file %s: %w", tmp.Name(), err)
 	}
 
-	if err = atomic.ReplaceFile(tmp.Name(), path); err != nil {
+	if err := atomic.ReplaceFile(tmp.Name(), path); err != nil {
 		return fmt.Errorf("save file from %s, %s: %w", tmp.Name(), path, err)
 	}
 
@@ -57,7 +59,6 @@ func read(path string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("open file %s: %w", path, err)
 	}
-
 	defer file.Close()
 
 	fInfo, err := file.Stat()
@@ -70,20 +71,19 @@ func read(path string) ([]byte, error) {
 
 	data := make([]byte, fInfo.Size()-crc64.Size)
 	checksum := crc64.New(crc64.MakeTable(crc64.ISO))
-	if _, err = io.TeeReader(file, checksum).Read(data); err != nil {
+	if _, err := io.TeeReader(file, checksum).Read(data); err != nil {
 		return nil, fmt.Errorf("read file %s: %w", path, err)
 	}
 
 	saved := make([]byte, crc64.Size)
-	if _, err = file.Read(saved); err != nil {
+	if _, err := file.Read(saved); err != nil {
 		return nil, fmt.Errorf("read checksum %s: %w", path, err)
 	}
 
 	savedChecksum := binary.BigEndian.Uint64(saved)
 
 	if savedChecksum != checksum.Sum64() {
-		return nil, fmt.Errorf(
-			"wrong checksum 0x%X, computed 0x%X", savedChecksum, checksum.Sum64())
+		return nil, fmt.Errorf("wrong checksum 0x%X, computed 0x%X", savedChecksum, checksum.Sum64())
 	}
 
 	return data, nil


### PR DESCRIPTION
## Motivation
Closes #5034 

## Changes
- do not call `tmp.Name()` on error since `tmp` might be `nil`.

## Test Plan
n/a

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed