### PR TITLE
[Merged by Bors] - add index for faster query to get refballot

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -1338,7 +1338,7 @@ func (app *App) setupDBs(ctx context.Context, lg log.Log) error {
 	sqlDB, err := sql.Open("file:"+filepath.Join(dbPath, dbFile),
 		sql.WithConnections(app.Config.DatabaseConnections),
 		sql.WithLatencyMetering(app.Config.DatabaseLatencyMetering),
-		sql.WithV4Migration(util.ExtractActiveSet),
+		sql.WithV5Migration(util.ExtractActiveSet),
 	)
 	if err != nil {
 		return fmt.Errorf("open sqlite db %w", err)

--- a/sql/database.go
+++ b/sql/database.go
@@ -61,7 +61,7 @@ type conf struct {
 	enableLatency bool
 
 	// TODO: remove after state is pruned for majority
-	v4Migration func(Executor) error
+	v5Migration func(Executor) error
 }
 
 // WithConnections overwrites number of pooled connections.
@@ -78,9 +78,9 @@ func WithMigrations(migrations Migrations) Opt {
 	}
 }
 
-func WithV4Migration(cb func(Executor) error) Opt {
+func WithV5Migration(cb func(Executor) error) Opt {
 	return func(c *conf) {
-		c.v4Migration = cb
+		c.v5Migration = cb
 	}
 }
 
@@ -145,9 +145,9 @@ func Open(uri string, opts ...Opt) (*Database, error) {
 		if err != nil {
 			return nil, err
 		}
-		if before <= 3 && after == 4 && config.v4Migration != nil {
-			// v4 migration (active set extraction) needs the 3rd migration to execute first
-			if err := config.v4Migration(db); err != nil {
+		if before <= 4 && after == 5 && config.v5Migration != nil {
+			// v5 migration (active set extraction) needs the 4rd migration to execute first
+			if err := config.v5Migration(db); err != nil {
 				return nil, err
 			}
 			if err := Vacuum(db); err != nil {

--- a/sql/migrations/0004_next.sql
+++ b/sql/migrations/0004_next.sql
@@ -1,4 +1,0 @@
-DELETE FROM proposals;
-DELETE FROM proposal_transactions;
-UPDATE certificates SET cert = NULL WHERE layer < 19000;
-CREATE INDEX ballots_by_atx_by_layer ON ballots (atx, layer asc);

--- a/sql/migrations/0004_next.sql
+++ b/sql/migrations/0004_next.sql
@@ -1,3 +1,4 @@
 DELETE FROM proposals;
 DELETE FROM proposal_transactions;
 UPDATE certificates SET cert = NULL WHERE layer < 19000;
+CREATE INDEX ballots_by_atx_by_layer ON ballots (atx, layer asc);

--- a/sql/migrations/0004_v1.1.7.sql
+++ b/sql/migrations/0004_v1.1.7.sql
@@ -1,0 +1,1 @@
+CREATE INDEX ballots_by_atx_by_layer ON ballots (atx, layer asc);

--- a/sql/migrations/0005_next.sql
+++ b/sql/migrations/0005_next.sql
@@ -1,0 +1,3 @@
+DELETE FROM proposals;
+DELETE FROM proposal_transactions;
+UPDATE certificates SET cert = NULL WHERE layer < 19000;

--- a/sql/migrations_test.go
+++ b/sql/migrations_test.go
@@ -15,5 +15,5 @@ func TestMigrationsAppliedOnce(t *testing.T) {
 		return true
 	})
 	require.NoError(t, err)
-	require.Equal(t, version, 4)
+	require.Equal(t, version, 5)
 }


### PR DESCRIPTION
there was a regression in proposal builder that started to use codepath that was used in different domain, which was executed once per epoch. now this is executed on every proposal creation and might be too slow.