### PR TITLE
[Merged by Bors] - Add missing RequestTimeout in testnet default params

### DIFF
--- a/activation/nipost_test.go
+++ b/activation/nipost_test.go
@@ -243,7 +243,7 @@ func TestNewNIPostBuilderNotInitialized(t *testing.T) {
 		PhaseShift:        epoch / 5,
 		CycleGap:          epoch / 10,
 		GracePeriod:       epoch / 10,
-		RequestTimeout:    epoch / 20,
+		RequestTimeout:    epoch / 10,
 		RequestRetryDelay: epoch / 100,
 		MaxRequestRetries: 10,
 	}

--- a/config/presets/testnet.go
+++ b/config/presets/testnet.go
@@ -108,6 +108,7 @@ func testnet() config.Config {
 			PhaseShift:        12 * time.Hour,
 			CycleGap:          2 * time.Hour,
 			GracePeriod:       10 * time.Minute,
+			RequestTimeout:    550 * time.Second, // RequestRetryDelay * 2 * MaxRequestRetries*(MaxRequestRetries+1)/2
 			RequestRetryDelay: 5 * time.Second,
 			MaxRequestRetries: 10,
 		},


### PR DESCRIPTION
## Motivation
The `testnet` preset is missing the `POET.RequestTimeout` parameter causing requests to fail. Additionally if `RequestTimeout` isn't set its treated as "no timeout"

## Changes
- add missing parameter
- change 0 to mean "no timeout"

## Test Plan
n/a

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
