### PR TITLE
[Merged by Bors] - make tortoise recovery interruptible

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -623,6 +623,7 @@ func (app *App) initServices(ctx context.Context) error {
 	}
 	start := time.Now()
 	trtl, err := tortoise.Recover(
+		ctx,
 		app.cachedDB,
 		app.clock.CurrentLayer(), beaconProtocol, trtlopts...,
 	)

--- a/tortoise/recover_test.go
+++ b/tortoise/recover_test.go
@@ -52,7 +52,7 @@ func TestRecoverState(t *testing.T) {
 	}
 	require.Equal(t, last.Sub(1), verified)
 
-	tortoise2, err := Recover(s.GetState(0).DB, last, s.GetState(0).Beacons, WithLogger(logtest.New(t)), WithConfig(cfg))
+	tortoise2, err := Recover(context.Background(), s.GetState(0).DB, last, s.GetState(0).Beacons, WithLogger(logtest.New(t)), WithConfig(cfg))
 	require.NoError(t, err)
 	verified = tortoise2.LatestComplete()
 	require.Equal(t, last.Sub(1), verified)
@@ -69,7 +69,7 @@ func TestRecoverEmpty(t *testing.T) {
 
 	cfg := defaultTestConfig()
 	cfg.LayerSize = size
-	tortoise, err := Recover(s.GetState(0).DB, 100, s.GetState(0).Beacons, WithLogger(logtest.New(t)), WithConfig(cfg))
+	tortoise, err := Recover(context.Background(), s.GetState(0).DB, 100, s.GetState(0).Beacons, WithLogger(logtest.New(t)), WithConfig(cfg))
 	require.NoError(t, err)
 	require.NotNil(t, tortoise)
 }
@@ -93,7 +93,7 @@ func TestRecoverWithOpinion(t *testing.T) {
 		}
 		last = rst
 	}
-	tortoise, err := Recover(s.GetState(0).DB, last.Layer, s.GetState(0).Beacons, WithLogger(logtest.New(t)), WithConfig(cfg))
+	tortoise, err := Recover(context.Background(), s.GetState(0).DB, last.Layer, s.GetState(0).Beacons, WithLogger(logtest.New(t)), WithConfig(cfg))
 	require.NoError(t, err)
 	require.NotNil(t, tortoise)
 	updates := tortoise.Updates()

--- a/tortoise/tracer_test.go
+++ b/tortoise/tracer_test.go
@@ -43,7 +43,7 @@ func TestTracer(t *testing.T) {
 	t.Run("recover", func(t *testing.T) {
 		t.Parallel()
 		path := filepath.Join(t.TempDir(), "tortoise.trace")
-		trt, err := Recover(s.GetState(0).DB, last, s.GetState(0).Beacons, WithTracer(WithOutput(path)))
+		trt, err := Recover(context.Background(), s.GetState(0).DB, last, s.GetState(0).Beacons, WithTracer(WithOutput(path)))
 		require.NoError(t, err)
 		trt.Updates()
 		trt.Results(types.GetEffectiveGenesis(), trt.LatestComplete())


### PR DESCRIPTION
related: https://github.com/spacemeshos/go-spacemesh/issues/3006

check if context was cancelled , and exit with context error if it was cancelled