### PR TITLE
[Merged by Bors] - sql: dont read dbstat by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ Support for old certificate sync protocol is dropped. This update is incompatibl
 ### Features
 
 * [#5031](https://github.com/spacemeshos/go-spacemesh/pull/5031) Nodes will also fetch from PoET 112 for round 4 if they were able to register to PoET 110.
+* [#5067](https://github.com/spacemeshos/go-spacemesh/pull/5067) dbstat virtual table can be read periodically to collect table/index sizes.
+
+In order to enable provide following configuration:
+```json
+"main": {
+    "db-size-metering-interval": "10m"
+}
+```
 
 ### Improvements
 

--- a/config/config.go
+++ b/config/config.go
@@ -108,9 +108,10 @@ type BaseConfig struct {
 	OptFilterThreshold int    `mapstructure:"optimistic-filtering-threshold"`
 	TickSize           uint64 `mapstructure:"tick-size"`
 
-	DatabaseConnections     int           `mapstructure:"db-connections"`
-	DatabaseLatencyMetering bool          `mapstructure:"db-latency-metering"`
-	DatabasePruneInterval   time.Duration `mapstructure:"db-prune-interval"`
+	DatabaseConnections          int           `mapstructure:"db-connections"`
+	DatabaseLatencyMetering      bool          `mapstructure:"db-latency-metering"`
+	DatabaseSizeMeteringInterval time.Duration `mapstructure:"db-size-metering-interval"`
+	DatabasePruneInterval        time.Duration `mapstructure:"db-prune-interval"`
 
 	NetworkHRP string `mapstructure:"network-hrp"`
 
@@ -174,21 +175,22 @@ func DefaultTestConfig() Config {
 // DefaultBaseConfig returns a default configuration for spacemesh.
 func defaultBaseConfig() BaseConfig {
 	return BaseConfig{
-		DataDirParent:         defaultDataDir,
-		FileLock:              filepath.Join(os.TempDir(), "spacemesh.lock"),
-		CollectMetrics:        false,
-		MetricsPort:           1010,
-		ProfilerName:          "gp-spacemesh",
-		LayerDuration:         30 * time.Second,
-		LayersPerEpoch:        3,
-		PoETServers:           []string{"127.0.0.1"},
-		TxsPerProposal:        100,
-		BlockGasLimit:         math.MaxUint64,
-		OptFilterThreshold:    90,
-		TickSize:              100,
-		DatabaseConnections:   16,
-		DatabasePruneInterval: 30 * time.Minute,
-		NetworkHRP:            "sm",
+		DataDirParent:                defaultDataDir,
+		FileLock:                     filepath.Join(os.TempDir(), "spacemesh.lock"),
+		CollectMetrics:               false,
+		MetricsPort:                  1010,
+		ProfilerName:                 "gp-spacemesh",
+		LayerDuration:                30 * time.Second,
+		LayersPerEpoch:               3,
+		PoETServers:                  []string{"127.0.0.1"},
+		TxsPerProposal:               100,
+		BlockGasLimit:                math.MaxUint64,
+		OptFilterThreshold:           90,
+		TickSize:                     100,
+		DatabaseConnections:          16,
+		DatabaseSizeMeteringInterval: 10 * time.Minute,
+		DatabasePruneInterval:        30 * time.Minute,
+		NetworkHRP:                   "sm",
 	}
 }
 

--- a/config/mainnet.go
+++ b/config/mainnet.go
@@ -42,12 +42,13 @@ func MainnetConfig() Config {
 	logging.TrtlLoggerLevel = zapcore.WarnLevel.String()
 	return Config{
 		BaseConfig: BaseConfig{
-			DataDirParent:         defaultDataDir,
-			FileLock:              filepath.Join(os.TempDir(), "spacemesh.lock"),
-			MetricsPort:           1010,
-			DatabaseConnections:   16,
-			DatabasePruneInterval: 30 * time.Minute,
-			NetworkHRP:            "sm",
+			DataDirParent:                defaultDataDir,
+			FileLock:                     filepath.Join(os.TempDir(), "spacemesh.lock"),
+			MetricsPort:                  1010,
+			DatabaseConnections:          16,
+			DatabaseSizeMeteringInterval: 60 * time.Minute,
+			DatabasePruneInterval:        30 * time.Minute,
+			NetworkHRP:                   "sm",
 
 			LayerDuration:  5 * time.Minute,
 			LayerAvgSize:   50,

--- a/config/mainnet.go
+++ b/config/mainnet.go
@@ -42,13 +42,12 @@ func MainnetConfig() Config {
 	logging.TrtlLoggerLevel = zapcore.WarnLevel.String()
 	return Config{
 		BaseConfig: BaseConfig{
-			DataDirParent:                defaultDataDir,
-			FileLock:                     filepath.Join(os.TempDir(), "spacemesh.lock"),
-			MetricsPort:                  1010,
-			DatabaseConnections:          16,
-			DatabaseSizeMeteringInterval: 60 * time.Minute,
-			DatabasePruneInterval:        30 * time.Minute,
-			NetworkHRP:                   "sm",
+			DataDirParent:         defaultDataDir,
+			FileLock:              filepath.Join(os.TempDir(), "spacemesh.lock"),
+			MetricsPort:           1010,
+			DatabaseConnections:   16,
+			DatabasePruneInterval: 30 * time.Minute,
+			NetworkHRP:            "sm",
 
 			LayerDuration:  5 * time.Minute,
 			LayerAvgSize:   50,

--- a/config/presets/testnet.go
+++ b/config/presets/testnet.go
@@ -47,11 +47,12 @@ func testnet() config.Config {
 	defaultdir := filepath.Join(home, "spacemesh-testnet", "/")
 	return config.Config{
 		BaseConfig: config.BaseConfig{
-			DataDirParent:       defaultdir,
-			FileLock:            filepath.Join(os.TempDir(), "spacemesh.lock"),
-			MetricsPort:         1010,
-			DatabaseConnections: 16,
-			NetworkHRP:          "stest",
+			DataDirParent:                defaultdir,
+			FileLock:                     filepath.Join(os.TempDir(), "spacemesh.lock"),
+			MetricsPort:                  1010,
+			DatabaseConnections:          16,
+			DatabaseSizeMeteringInterval: 10 * time.Minute,
+			NetworkHRP:                   "stest",
 
 			LayerDuration:  5 * time.Minute,
 			LayerAvgSize:   50,

--- a/node/node.go
+++ b/node/node.go
@@ -1341,8 +1341,8 @@ func (app *App) setupDBs(ctx context.Context, lg log.Log) error {
 		return fmt.Errorf("open sqlite db %w", err)
 	}
 	app.db = sqlDB
-	if app.Config.CollectMetrics {
-		app.dbMetrics = dbmetrics.NewDBMetricsCollector(ctx, sqlDB, app.addLogger(StateDbLogger, lg), 5*time.Minute)
+	if app.Config.CollectMetrics && app.Config.DatabaseSizeMeteringInterval != 0 {
+		app.dbMetrics = dbmetrics.NewDBMetricsCollector(ctx, sqlDB, app.addLogger(StateDbLogger, lg), app.Config.DatabaseSizeMeteringInterval)
 	}
 	app.cachedDB = datastore.NewCachedDB(sqlDB, app.addLogger(CachedDBLogger, lg), datastore.WithConfig(app.Config.Cache))
 	return nil


### PR DESCRIPTION
this is debug information and can be enabled to be collected.
moreover reading dbstat frequently can interfere with other workloads.