### PR TITLE
[Merged by Bors] - change default p2p log level to warn

### DIFF
--- a/config/logging.go
+++ b/config/logging.go
@@ -52,7 +52,7 @@ func DefaultLoggingConfig() LoggerConfig {
 		Encoder:                   ConsoleLogEncoder,
 		AppLoggerLevel:            defaultLoggingLevel.String(),
 		GrpcLoggerLevel:           defaultLoggingLevel.String(),
-		P2PLoggerLevel:            defaultLoggingLevel.String(),
+		P2PLoggerLevel:            zapcore.WarnLevel.String(),
 		PostLoggerLevel:           defaultLoggingLevel.String(),
 		StateDbLoggerLevel:        defaultLoggingLevel.String(),
 		StateLoggerLevel:          defaultLoggingLevel.String(),


### PR DESCRIPTION
closes: https://github.com/spacemeshos/go-spacemesh/issues/5037