### PR TITLE
[Merged by Bors] - Fix flaky Test_NodeClock_Await_WithClockMovingBackwards

### DIFF
--- a/timesync/clock_test.go
+++ b/timesync/clock_test.go
@@ -206,7 +206,7 @@ func Test_NodeClock_Await_WithClockMovingBackwards(t *testing.T) {
 
 	select {
 	case <-clock.AwaitLayer(types.LayerID(10)):
-		require.Greater(t, time.Now(), genesis.Add(10*layerDuration))
+		require.GreaterOrEqual(t, time.Now(), genesis.Add(10*layerDuration))
 	default:
 		require.Fail(t, "awaited layer didn't signal")
 	}


### PR DESCRIPTION
## Motivation
On Windows `Test_NodeClock_Await_WithClockMovingBackwards` regularly fails, see e.g. here: https://github.com/spacemeshos/go-spacemesh/actions/runs/6297761414/job/17095365624

```
=== RUN   Test_NodeClock_Await_WithClockMovingBackwards
    clock_test.go:209: 
        	Error Trace:	D:/a/go-spacemesh/go-spacemesh/timesync/clock_test.go:209
        	Error:      	"2023-09-25 10:24:13.1951654 +0000 UTC m=+2.031383101" is not greater than "2023-09-25 10:24:13.1951654 +0000 UTC m=+2.031383101"
        	Test:       	Test_NodeClock_Await_WithClockMovingBackwards
--- FAIL: Test_NodeClock_Await_WithClockMovingBackwards (0.03s)
```

The reason is that on Windows the resolution of the clock isn't high enough to show a time difference between the call to  `clock.AwaitLayer` and the next call to `time.Now()` resulting.

## Changes
- Use `GreaterOrEqual` to assert instead of `Greater`.

## Test Plan
n/a

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
