### PR TITLE
[Merged by Bors] - Fixing flaky poet tests on windows

### DIFF
--- a/activation/nipost_test.go
+++ b/activation/nipost_test.go
@@ -180,7 +180,8 @@ func spawnPoet(tb testing.TB, opts ...HTTPPoetOpt) *HTTPPoetTestHarness {
 		eg.Wait()
 	})
 	eg.Go(func() error {
-		return poetProver.Service.Start(ctx)
+		err := poetProver.Service.Start(ctx)
+		return errors.Join(err, poetProver.Service.Close())
 	})
 
 	return poetProver

--- a/activation/poet_test.go
+++ b/activation/poet_test.go
@@ -36,7 +36,8 @@ func TestHTTPPoet(t *testing.T) {
 	r.NotNil(c)
 
 	eg.Go(func() error {
-		return c.Service.Start(ctx)
+		err := c.Service.Start(ctx)
+		return errors.Join(err, c.Service.Close())
 	})
 
 	client, err := NewHTTPPoetClient(c.RestURL().String(), DefaultPoetConfig(), WithLogger(zaptest.NewLogger(t)))


### PR DESCRIPTION
## Motivation
A few PoET test fail on windows because the test cleanup fails to remove temporary directories created during the test. For instance here: https://github.com/spacemeshos/go-spacemesh/actions/runs/6297761414/job/17095365624

```
=== RUN   TestAdminEvents
...
    testing.go:1225: TempDir RemoveAll cleanup: remove C:\Users\RUNNER~1\AppData\Local\Temp\TestAdminEvents2616476190\001\poet\db\proofs\000001.log: The process cannot access the file because it is being used by another process.
--- FAIL: TestAdminEvents (69.10s)
```

## Changes
- Ensure PoET Service is closed before the test ends.

## Test Plan
existing tests pass

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [ ] Update [changelog](../CHANGELOG.md) as needed
