### PR TITLE
[Merged by Bors] - Fix flaky TestAccountMeshDataStream_comprehensive

### DIFF
--- a/api/grpcserver/admin_service_test.go
+++ b/api/grpcserver/admin_service_test.go
@@ -57,7 +57,8 @@ func TestAdminService_Checkpoint(t *testing.T) {
 	db := sql.InMemory()
 	createMesh(t, db)
 	svc := NewAdminService(db, t.TempDir(), nil)
-	t.Cleanup(launchServer(t, cfg, svc))
+	cfg, cleanup := launchServer(t, svc)
+	t.Cleanup(cleanup)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -92,7 +93,8 @@ func TestAdminService_Checkpoint(t *testing.T) {
 func TestAdminService_CheckpointError(t *testing.T) {
 	db := sql.InMemory()
 	svc := NewAdminService(db, t.TempDir(), nil)
-	t.Cleanup(launchServer(t, cfg, svc))
+	cfg, cleanup := launchServer(t, svc)
+	t.Cleanup(cleanup)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -111,7 +113,8 @@ func TestAdminService_Recovery(t *testing.T) {
 	svc := NewAdminService(db, t.TempDir(), nil)
 	svc.recover = func() { recoveryCalled.Store(true) }
 
-	t.Cleanup(launchServer(t, cfg, svc))
+	cfg, cleanup := launchServer(t, svc)
+	t.Cleanup(cleanup)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()

--- a/api/grpcserver/config.go
+++ b/api/grpcserver/config.go
@@ -47,8 +47,8 @@ func DefaultConfig() Config {
 // DefaultTestConfig returns the default config for tests.
 func DefaultTestConfig() Config {
 	conf := DefaultConfig()
-	conf.PublicListener = "127.0.0.1:19092"
-	conf.PrivateListener = "127.0.0.1:19093"
-	conf.JSONListener = "127.0.0.1:19094"
+	conf.PublicListener = "127.0.0.1:0"
+	conf.PrivateListener = "127.0.0.1:0"
+	conf.JSONListener = "127.0.0.1:0"
 	return conf
 }

--- a/api/grpcserver/grpc.go
+++ b/api/grpcserver/grpc.go
@@ -60,7 +60,7 @@ func (s *Server) Start() error {
 	reflection.Register(s.GrpcServer)
 	s.grp.Go(func() error {
 		if err := s.GrpcServer.Serve(lis); err != nil {
-			s.logger.Error("error stopping grpc server: %v", err)
+			s.logger.Error("error serving grpc server: %v", err)
 			return err
 		}
 		return nil

--- a/api/grpcserver/grpc.go
+++ b/api/grpcserver/grpc.go
@@ -19,7 +19,7 @@ type ServiceAPI interface {
 
 // Server is a very basic grpc server.
 type Server struct {
-	Listener string
+	listener string
 	logger   log.Logger
 	// BoundAddress contains the address that the server bound to, useful if
 	// the server uses a dynamic port. It is set during startup and can be
@@ -34,7 +34,7 @@ type Server struct {
 func New(listener string, lg log.Logger, opts ...grpc.ServerOption) *Server {
 	opts = append(opts, ServerOptions...)
 	return &Server{
-		Listener:   listener,
+		listener:   listener,
 		logger:     lg,
 		GrpcServer: grpc.NewServer(opts...),
 	}
@@ -43,7 +43,7 @@ func New(listener string, lg log.Logger, opts ...grpc.ServerOption) *Server {
 // Start starts the server.
 func (s *Server) Start() error {
 	s.logger.With().Info("starting grpc server",
-		log.String("address", s.Listener),
+		log.String("address", s.listener),
 		log.Array("services", log.ArrayMarshalerFunc(func(encoder log.ArrayEncoder) error {
 			for svc := range s.GrpcServer.GetServiceInfo() {
 				encoder.AppendString(svc)
@@ -51,7 +51,7 @@ func (s *Server) Start() error {
 			return nil
 		})),
 	)
-	lis, err := net.Listen("tcp", s.Listener)
+	lis, err := net.Listen("tcp", s.listener)
 	if err != nil {
 		s.logger.Error("error listening: %v", err)
 		return err

--- a/api/grpcserver/grpcserver_test.go
+++ b/api/grpcserver/grpcserver_test.go
@@ -503,8 +503,7 @@ func launchServer(tb testing.TB, services ...ServiceAPI) (Config, func()) {
 	}
 }
 
-func callEndpoint(t *testing.T, cfg Config, endpoint, payload string) (string, int) {
-	url := fmt.Sprintf("http://%s/%s", cfg.JSONListener, endpoint)
+func callEndpoint(t *testing.T, url, payload string) (string, int) {
 	resp, err := http.Post(url, "application/json", strings.NewReader(payload))
 	require.NoError(t, err)
 	require.Equal(t, "application/json", resp.Header.Get("Content-Type"))
@@ -2382,14 +2381,14 @@ func TestJsonApi(t *testing.T) {
 
 	// generate request payload (api input params)
 	payload = marshalProto(t, &pb.EchoRequest{Msg: &pb.SimpleString{Value: message}})
-	respBody, respStatus := callEndpoint(t, cfg, "v1/node/echo", payload)
+	respBody, respStatus := callEndpoint(t, fmt.Sprintf("http://%s/%s", cfg.JSONListener, "v1/node/echo"), payload)
 	require.Equal(t, http.StatusOK, respStatus)
 	var msg pb.EchoResponse
 	require.NoError(t, jsonpb.UnmarshalString(respBody, &msg))
 	require.Equal(t, message, msg.Msg.Value)
 
 	// Test MeshService
-	respBody2, respStatus2 := callEndpoint(t, cfg, "v1/mesh/genesistime", "")
+	respBody2, respStatus2 := callEndpoint(t, fmt.Sprintf("http://%s/%s", cfg.JSONListener, "v1/mesh/genesistime"), "")
 	require.Equal(t, http.StatusOK, respStatus2)
 	var msg2 pb.GenesisTimeResponse
 	require.NoError(t, jsonpb.UnmarshalString(respBody2, &msg2))

--- a/api/grpcserver/grpcserver_test.go
+++ b/api/grpcserver/grpcserver_test.go
@@ -27,6 +27,7 @@ import (
 	pb "github.com/spacemeshos/api/release/go/spacemesh/v1"
 	"github.com/spacemeshos/merkle-tree"
 	"github.com/spacemeshos/poet/shared"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 	"golang.org/x/sync/errgroup"
@@ -159,10 +160,6 @@ func newAddress(t *testing.T) types.Address {
 
 func TestMain(m *testing.M) {
 	types.SetLayersPerEpoch(layersPerEpoch)
-
-	// run on a random port
-	cfg.PublicListener = fmt.Sprintf("127.0.0.1:%d", 1024+rand.Intn(9999))
-	cfg.PrivateListener = fmt.Sprintf("127.0.0.1:%d", 1024+rand.Intn(9999))
 
 	var err error
 	signer, err = signing.NewEdSigner()
@@ -477,9 +474,15 @@ func marshalProto(t *testing.T, msg proto.Message) string {
 	return buf.String()
 }
 
-var cfg = DefaultTestConfig()
+func launchServer(tb testing.TB, services ...ServiceAPI) (Config, func()) {
+	cfg := DefaultTestConfig()
 
-func launchServer(tb testing.TB, cfg Config, services ...ServiceAPI) func() {
+	// run on a random port
+	port := 1024 + rand.Intn(9997)
+	cfg.PublicListener = fmt.Sprintf("127.0.0.1:%d", port)
+	cfg.PrivateListener = fmt.Sprintf("127.0.0.1:%d", port+1)
+	cfg.JSONListener = fmt.Sprintf("127.0.0.1:%d", port+2)
+
 	grpcService := New(cfg.PublicListener, logtest.New(tb).Named("grpc"))
 	jsonService := NewJSONHTTPServer(cfg.JSONListener, logtest.New(tb).WithName("grpc.JSON"))
 
@@ -496,13 +499,13 @@ func launchServer(tb testing.TB, cfg Config, services ...ServiceAPI) func() {
 		require.NoError(tb, err)
 	}
 
-	return func() {
-		require.NoError(tb, jsonService.Shutdown(context.Background()))
-		_ = grpcService.Close()
+	return cfg, func() {
+		assert.NoError(tb, jsonService.Shutdown(context.Background()))
+		assert.NoError(tb, grpcService.Close())
 	}
 }
 
-func callEndpoint(t *testing.T, endpoint, payload string) (string, int) {
+func callEndpoint(t *testing.T, cfg Config, endpoint, payload string) (string, int) {
 	url := fmt.Sprintf("http://%s/%s", cfg.JSONListener, endpoint)
 	resp, err := http.Post(url, "application/json", strings.NewReader(payload))
 	require.NoError(t, err)
@@ -554,7 +557,8 @@ func TestNodeService(t *testing.T) {
 	version := "v0.0.0"
 	build := "cafebabe"
 	grpcService := NewNodeService(peerCounter, meshAPIMock, genTime, syncer, version, build)
-	t.Cleanup(launchServer(t, cfg, grpcService))
+	cfg, cleanup := launchServer(t, grpcService)
+	t.Cleanup(cleanup)
 
 	conn := dialGrpc(ctx, t, cfg.PublicListener)
 	c := pb.NewNodeServiceClient(conn)
@@ -641,7 +645,8 @@ func TestNodeService(t *testing.T) {
 
 func TestGlobalStateService(t *testing.T) {
 	svc := NewGlobalStateService(meshAPIMock, conStateAPI)
-	t.Cleanup(launchServer(t, cfg, svc))
+	cfg, cleanup := launchServer(t, svc)
+	t.Cleanup(cleanup)
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
@@ -915,7 +920,8 @@ func TestSmesherService(t *testing.T) {
 	postProvider.EXPECT().Providers().Return(nil, nil).AnyTimes()
 	smeshingAPI := &SmeshingAPIMock{}
 	svc := NewSmesherService(postProvider, smeshingAPI, 10*time.Millisecond, activation.DefaultPostSetupOpts())
-	t.Cleanup(launchServer(t, cfg, svc))
+	cfg, cleanup := launchServer(t, svc)
+	t.Cleanup(cleanup)
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
@@ -1044,7 +1050,8 @@ func TestMeshService(t *testing.T) {
 	db := datastore.NewCachedDB(sql.InMemory(), logtest.New(t))
 	grpcService := NewMeshService(db, meshAPIMock, conStateAPI, genTime, layersPerEpoch, types.Hash20{}, layerDuration, layerAvgSize, txsPerProposal)
 	require.NoError(t, activesets.Add(db, ballot1.EpochData.ActiveSetHash, &types.EpochActiveSet{Set: types.ATXIDList{globalAtx.ID(), globalAtx2.ID()}}))
-	t.Cleanup(launchServer(t, cfg, grpcService))
+	cfg, cleanup := launchServer(t, grpcService)
+	t.Cleanup(cleanup)
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
@@ -1554,7 +1561,8 @@ func TestTransactionServiceSubmitUnsync(t *testing.T) {
 	txHandler.EXPECT().VerifyAndCacheTx(gomock.Any(), gomock.Any()).Return(nil)
 
 	grpcService := NewTransactionService(sql.InMemory(), publisher, meshAPIMock, conStateAPI, syncer, txHandler)
-	t.Cleanup(launchServer(t, cfg, grpcService))
+	cfg, cleanup := launchServer(t, grpcService)
+	t.Cleanup(cleanup)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -1592,7 +1600,8 @@ func TestTransactionServiceSubmitInvalidTx(t *testing.T) {
 	txHandler.EXPECT().VerifyAndCacheTx(gomock.Any(), gomock.Any()).Return(errors.New("failed validation"))
 
 	grpcService := NewTransactionService(sql.InMemory(), publisher, meshAPIMock, conStateAPI, syncer, txHandler)
-	t.Cleanup(launchServer(t, cfg, grpcService))
+	cfg, cleanup := launchServer(t, grpcService)
+	t.Cleanup(cleanup)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -1624,7 +1633,8 @@ func TestTransactionService_SubmitNoConcurrency(t *testing.T) {
 	txHandler.EXPECT().VerifyAndCacheTx(gomock.Any(), gomock.Any()).Return(nil).Times(numTxs)
 
 	grpcService := NewTransactionService(sql.InMemory(), publisher, meshAPIMock, conStateAPI, syncer, txHandler)
-	t.Cleanup(launchServer(t, cfg, grpcService))
+	cfg, cleanup := launchServer(t, grpcService)
+	t.Cleanup(cleanup)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -1651,7 +1661,8 @@ func TestTransactionService(t *testing.T) {
 	txHandler.EXPECT().VerifyAndCacheTx(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 	grpcService := NewTransactionService(sql.InMemory(), publisher, meshAPIMock, conStateAPI, syncer, txHandler)
-	t.Cleanup(launchServer(t, cfg, grpcService))
+	cfg, cleanup := launchServer(t, grpcService)
+	t.Cleanup(cleanup)
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
@@ -1990,7 +2001,8 @@ func TestAccountMeshDataStream_comprehensive(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	genTime := NewMockgenesisTimeAPI(ctrl)
 	grpcService := NewMeshService(datastore.NewCachedDB(sql.InMemory(), logtest.New(t)), meshAPIMock, conStateAPI, genTime, layersPerEpoch, types.Hash20{}, layerDuration, layerAvgSize, txsPerProposal)
-	t.Cleanup(launchServer(t, cfg, grpcService))
+	cfg, cleanup := launchServer(t, grpcService)
+	t.Cleanup(cleanup)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -2033,7 +2045,7 @@ func TestAccountMeshDataStream_comprehensive(t *testing.T) {
 
 	_, err = stream.Recv()
 	require.Error(t, err)
-	require.Equal(t, status.Convert(err).Code(), codes.DeadlineExceeded)
+	require.Contains(t, []codes.Code{codes.Unknown, codes.DeadlineExceeded}, status.Convert(err).Code())
 }
 
 func TestAccountDataStream_comprehensive(t *testing.T) {
@@ -2045,7 +2057,8 @@ func TestAccountDataStream_comprehensive(t *testing.T) {
 	t.Cleanup(events.CloseEventReporter)
 
 	svc := NewGlobalStateService(meshAPIMock, conStateAPI)
-	t.Cleanup(launchServer(t, cfg, svc))
+	cfg, cleanup := launchServer(t, svc)
+	t.Cleanup(cleanup)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -2103,7 +2116,8 @@ func TestGlobalStateStream_comprehensive(t *testing.T) {
 	t.Cleanup(events.CloseEventReporter)
 
 	svc := NewGlobalStateService(meshAPIMock, conStateAPI)
-	t.Cleanup(launchServer(t, cfg, svc))
+	cfg, cleanup := launchServer(t, svc)
+	t.Cleanup(cleanup)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -2166,7 +2180,8 @@ func TestLayerStream_comprehensive(t *testing.T) {
 	db := datastore.NewCachedDB(sql.InMemory(), logtest.New(t))
 	grpcService := NewMeshService(db, meshAPIMock, conStateAPI, genTime, layersPerEpoch, types.Hash20{}, layerDuration, layerAvgSize, txsPerProposal)
 	require.NoError(t, activesets.Add(db, ballot1.EpochData.ActiveSetHash, &types.EpochActiveSet{Set: types.ATXIDList{globalAtx.ID(), globalAtx2.ID()}}))
-	t.Cleanup(launchServer(t, cfg, grpcService))
+	cfg, cleanup := launchServer(t, grpcService)
+	t.Cleanup(cleanup)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -2308,7 +2323,7 @@ func TestMultiService(t *testing.T) {
 	genTime.EXPECT().GenesisTime().Return(genesis)
 	svc1 := NewNodeService(peerCounter, meshAPIMock, genTime, syncer, "v0.0.0", "cafebabe")
 	svc2 := NewMeshService(datastore.NewCachedDB(sql.InMemory(), logtest.New(t)), meshAPIMock, conStateAPI, genTime, layersPerEpoch, types.Hash20{}, layerDuration, layerAvgSize, txsPerProposal)
-	shutDown := launchServer(t, cfg, svc1, svc2)
+	cfg, shutDown := launchServer(t, svc1, svc2)
 	t.Cleanup(shutDown)
 
 	c1 := pb.NewNodeServiceClient(dialGrpc(ctx, t, cfg.PublicListener))
@@ -2345,7 +2360,7 @@ func TestJsonApi(t *testing.T) {
 	const message = "hello world!"
 
 	// we cannot start the gateway service without enabling at least one service
-	shutDown := launchServer(t, cfg)
+	cfg, shutDown := launchServer(t)
 	t.Cleanup(shutDown)
 	payload := marshalProto(t, &pb.EchoRequest{Msg: &pb.SimpleString{Value: message}})
 	url := fmt.Sprintf("http://%s/%s", cfg.JSONListener, "v1/node/echo")
@@ -2363,19 +2378,20 @@ func TestJsonApi(t *testing.T) {
 	genTime.EXPECT().GenesisTime().Return(genesis)
 	svc1 := NewNodeService(peerCounter, meshAPIMock, genTime, syncer, "v0.0.0", "cafebabe")
 	svc2 := NewMeshService(datastore.NewCachedDB(sql.InMemory(), logtest.New(t)), meshAPIMock, conStateAPI, genTime, layersPerEpoch, types.Hash20{}, layerDuration, layerAvgSize, txsPerProposal)
-	t.Cleanup(launchServer(t, cfg, svc1, svc2))
+	cfg, cleanup := launchServer(t, svc1, svc2)
+	t.Cleanup(cleanup)
 	time.Sleep(time.Second)
 
 	// generate request payload (api input params)
 	payload = marshalProto(t, &pb.EchoRequest{Msg: &pb.SimpleString{Value: message}})
-	respBody, respStatus := callEndpoint(t, "v1/node/echo", payload)
+	respBody, respStatus := callEndpoint(t, cfg, "v1/node/echo", payload)
 	require.Equal(t, http.StatusOK, respStatus)
 	var msg pb.EchoResponse
 	require.NoError(t, jsonpb.UnmarshalString(respBody, &msg))
 	require.Equal(t, message, msg.Msg.Value)
 
 	// Test MeshService
-	respBody2, respStatus2 := callEndpoint(t, "v1/mesh/genesistime", "")
+	respBody2, respStatus2 := callEndpoint(t, cfg, "v1/mesh/genesistime", "")
 	require.Equal(t, http.StatusOK, respStatus2)
 	var msg2 pb.GenesisTimeResponse
 	require.NoError(t, jsonpb.UnmarshalString(respBody2, &msg2))
@@ -2388,7 +2404,8 @@ func TestDebugService(t *testing.T) {
 	mOracle := NewMockoracle(ctrl)
 	db := sql.InMemory()
 	svc := NewDebugService(db, conStateAPI, identity, mOracle)
-	t.Cleanup(launchServer(t, cfg, svc))
+	cfg, cleanup := launchServer(t, svc)
+	t.Cleanup(cleanup)
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
@@ -2491,7 +2508,8 @@ func TestEventsReceived(t *testing.T) {
 
 	txService := NewTransactionService(sql.InMemory(), nil, meshAPIMock, conStateAPI, nil, nil)
 	gsService := NewGlobalStateService(meshAPIMock, conStateAPI)
-	t.Cleanup(launchServer(t, cfg, txService, gsService))
+	cfg, cleanup := launchServer(t, txService, gsService)
+	t.Cleanup(cleanup)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -2568,7 +2586,8 @@ func TestTransactionsRewards(t *testing.T) {
 	events.InitializeReporter()
 	t.Cleanup(events.CloseEventReporter)
 
-	t.Cleanup(launchServer(t, cfg, NewGlobalStateService(meshAPIMock, conStateAPI)))
+	cfg, cleanup := launchServer(t, NewGlobalStateService(meshAPIMock, conStateAPI))
+	t.Cleanup(cleanup)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	t.Cleanup(cancel)
@@ -2634,7 +2653,8 @@ func TestVMAccountUpdates(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { db.Close() })
 	svm := vm.New(db, vm.WithLogger(logtest.New(t)))
-	t.Cleanup(launchServer(t, cfg, NewGlobalStateService(nil, txs.NewConservativeState(svm, db))))
+	cfg, cleanup := launchServer(t, NewGlobalStateService(nil, txs.NewConservativeState(svm, db)))
+	t.Cleanup(cleanup)
 
 	keys := make([]*signing.EdSigner, 10)
 	accounts := make([]types.Account, len(keys))
@@ -2731,7 +2751,8 @@ func TestMeshService_EpochStream(t *testing.T) {
 	genTime := NewMockgenesisTimeAPI(ctrl)
 	db := sql.InMemory()
 	srv := NewMeshService(datastore.NewCachedDB(db, logtest.New(t)), meshAPIMock, conStateAPI, genTime, layersPerEpoch, types.Hash20{}, layerDuration, layerAvgSize, txsPerProposal)
-	t.Cleanup(launchServer(t, cfg, srv))
+	cfg, cleanup := launchServer(t, srv)
+	t.Cleanup(cleanup)
 
 	epoch := types.EpochID(3)
 	atxids := types.RandomActiveSet(100)

--- a/api/grpcserver/http_server.go
+++ b/api/grpcserver/http_server.go
@@ -112,7 +112,7 @@ func (s *JSONHTTPServer) StartService(
 	s.grp.Go(func() error {
 		if err := s.server.Serve(lis); err != nil {
 			s.logger.Error("error from grpc http server: %v", err)
-			return err
+			return nil
 		}
 		return nil
 	})

--- a/api/grpcserver/http_server.go
+++ b/api/grpcserver/http_server.go
@@ -17,11 +17,16 @@ import (
 // JSONHTTPServer is a JSON http server providing the Spacemesh API.
 // It is implemented using a grpc-gateway. See https://github.com/grpc-ecosystem/grpc-gateway .
 type JSONHTTPServer struct {
-	logger log.Logger
-
 	listener string
-	server   *http.Server
-	grp      errgroup.Group
+	logger   log.Logger
+
+	// BoundAddress contains the address that the server bound to, useful if
+	// the server uses a dynamic port. It is set during startup and can be
+	// safely accessed after Start has completed (I.E. the returned channel has
+	// been waited on)
+	BoundAddress string
+	server       *http.Server
+	grp          errgroup.Group
 }
 
 // NewJSONHTTPServer creates a new json http server.
@@ -100,6 +105,7 @@ func (s *JSONHTTPServer) StartService(
 		s.logger.Error("error listening: %v", err)
 		return err
 	}
+	s.BoundAddress = lis.Addr().String()
 	s.server = &http.Server{
 		Handler: mux,
 	}

--- a/api/grpcserver/mesh_service_test.go
+++ b/api/grpcserver/mesh_service_test.go
@@ -142,7 +142,8 @@ func TestMeshService_MalfeasanceQuery(t *testing.T) {
 	genTime := NewMockgenesisTimeAPI(ctrl)
 	db := sql.InMemory()
 	srv := NewMeshService(datastore.NewCachedDB(db, logtest.New(t)), meshAPIMock, conStateAPI, genTime, layersPerEpoch, types.Hash20{}, layerDuration, layerAvgSize, txsPerProposal)
-	t.Cleanup(launchServer(t, cfg, srv))
+	cfg, cleanup := launchServer(t, srv)
+	t.Cleanup(cleanup)
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
@@ -184,7 +185,8 @@ func TestMeshService_MalfeasanceStream(t *testing.T) {
 	genTime := NewMockgenesisTimeAPI(ctrl)
 	db := sql.InMemory()
 	srv := NewMeshService(datastore.NewCachedDB(db, logtest.New(t)), meshAPIMock, conStateAPI, genTime, layersPerEpoch, types.Hash20{}, layerDuration, layerAvgSize, txsPerProposal)
-	t.Cleanup(launchServer(t, cfg, srv))
+	cfg, cleanup := launchServer(t, srv)
+	t.Cleanup(cleanup)
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()

--- a/api/grpcserver/transaction_service_test.go
+++ b/api/grpcserver/transaction_service_test.go
@@ -48,7 +48,8 @@ func TestTransactionService_StreamResults(t *testing.T) {
 	}))
 
 	svc := NewTransactionService(db, nil, nil, nil, nil, nil)
-	t.Cleanup(launchServer(t, cfg, svc))
+	cfg, cleanup := launchServer(t, svc)
+	t.Cleanup(cleanup)
 
 	conn := dialGrpc(ctx, t, cfg.PublicListener)
 	client := pb.NewTransactionServiceClient(conn)
@@ -163,7 +164,8 @@ func BenchmarkStreamResults(b *testing.B) {
 	require.NoError(b, tx.Commit())
 	require.NoError(b, tx.Release())
 	svc := NewTransactionService(db, nil, nil, nil, nil, nil)
-	b.Cleanup(launchServer(b, cfg, svc))
+	cfg, cleanup := launchServer(b, svc)
+	b.Cleanup(cleanup)
 
 	conn := dialGrpc(ctx, b, cfg.PublicListener)
 	client := pb.NewTransactionServiceClient(conn)
@@ -219,7 +221,8 @@ func TestParseTransactions(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	t.Cleanup(cancel)
 	vminst := vm.New(db)
-	t.Cleanup(launchServer(t, cfg, NewTransactionService(db, nil, nil, txs.NewConservativeState(vminst, db), nil, nil)))
+	cfg, cleanup := launchServer(t, NewTransactionService(db, nil, nil, txs.NewConservativeState(vminst, db), nil, nil))
+	t.Cleanup(cleanup)
 	var (
 		conn     = dialGrpc(ctx, t, cfg.PublicListener)
 		client   = pb.NewTransactionServiceClient(conn)


### PR DESCRIPTION
## Motivation
Closes #4171 

Occasionally the test will fail with an incorrect assertion of an error. The stream receive can fail either because the deadline was exceeded or due to bad timing for another (random) reason. Since it doesn't matter which return code is received, just that the stream ended I changed the assertion to also allow `code.Unkown`.

## Changes
- change assertion to allow `codes.DeadlineExceeded` and `codes.Unkown` instead of just the former.
- Additionally get rid of the global GRPC config. This will allow to run GRPC service tests in parallel (which will be used by https://github.com/spacemeshos/go-spacemesh/pull/5061)

## Test Plan
<!-- Please specify how these changes were tested
(e.g. unit tests, manual testing, etc.) -->

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
