### PR TITLE
[Merged by Bors] - increase cache size to 50 000 for next release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ In order to enable provide following configuration:
 * [#5021](https://github.com/spacemeshos/go-spacemesh/pull/5021) Drop support for old certificate sync protocol.
 * [#5024](https://github.com/spacemeshos/go-spacemesh/pull/5024) Active set will be saved in state separately from ballots.
 * [#5035](https://github.com/spacemeshos/go-spacemesh/pull/5035) Fix possible nil pointer panic when node fails to persist nipost builder state.
+* [#5079](https://github.com/spacemeshos/go-spacemesh/pull/5079) increase atx cache to 50 000 to reduce disk reads.
 
 ## v1.1.5
 

--- a/datastore/store.go
+++ b/datastore/store.go
@@ -46,7 +46,7 @@ type Config struct {
 
 func DefaultConfig() Config {
 	return Config{
-		ATXSize:         20_000,
+		ATXSize:         50_000,
 		MalfeasenceSize: 1_000,
 	}
 }


### PR DESCRIPTION
there are many places that have to read atxs, if number of atxs in epoch larger then what we cache it causes cache threshing
signficant and disk reads. for example in this epoch nodes in cloud peek every 5m with 140MB/s reads.

i set it to 50 000 to account for possible growth in the next epoch.