### PR TITLE
[Merged by Bors] - Close PoET server in standalone preset on shutdown

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -987,13 +987,13 @@ func (app *App) launchStandalone(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("init poet server: %w", err)
 	}
-	app.log.With().Warning("lauching poet in standalone mode", log.Any("config", cfg))
+	app.log.With().Warning("launching poet in standalone mode", log.Any("config", cfg))
 	app.eg.Go(func() error {
 		if err := srv.Start(ctx); err != nil {
 			app.log.With().Error("poet server failed", log.Err(err))
 			return err
 		}
-		return nil
+		return srv.Close()
 	})
 	return nil
 }


### PR DESCRIPTION
## Motivation
Followup to https://github.com/spacemeshos/go-spacemesh/pull/5074. This fixes the `TestAdminEvents` test failing on windows.

## Changes
- Add missing `Close` on shutdown for poet server

## Test Plan
<!-- Please specify how these changes were tested
(e.g. unit tests, manual testing, etc.) -->

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
