### PR TITLE
[Merged by Bors] - Fix "log.SetLogger(...) was never called" warning

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -91,6 +91,7 @@ require (
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/go-logr/zapr v1.2.4 // indirect
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.22.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -743,6 +743,7 @@ go.uber.org/fx v1.20.0 h1:ZMC/pnRvhsthOZh9MZjMq5U8Or3mA9zBSPaLnzs3ihQ=
 go.uber.org/fx v1.20.0/go.mod h1:qCUj0btiR3/JnanEr1TYEePfSw6o/4qYJscgvzQ5Ub0=
 go.uber.org/goleak v1.1.10/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A=
 go.uber.org/goleak v1.1.11-0.20210813005559-691160354723/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
+go.uber.org/goleak v1.1.11/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
 go.uber.org/goleak v1.2.1 h1:NBol2c7O1ZokfZ0LEU9K6Whx/KnwvepVetCUhtKja4A=
 go.uber.org/goleak v1.2.1/go.mod h1:qlT2yGI9QafXHhZZLxlSuNsMw3FFLxBr+tBRlmO1xH4=
 go.uber.org/mock v0.3.0 h1:3mUxI1No2/60yUYax92Pt8eNOEecx2D3lcXZh2NEZJo=
@@ -755,6 +756,7 @@ go.uber.org/tools v0.0.0-20190618225709-2cfd321de3ee/go.mod h1:vJERXedbb3MVM5f9E
 go.uber.org/zap v1.16.0/go.mod h1:MA8QOfq0BHJwdXa996Y4dYkAqRKB8/1K1QMMZVaNZjQ=
 go.uber.org/zap v1.18.1/go.mod h1:xg/QME4nWcxGxrpdeYfq7UvYrLh66cuVKdrbD1XF/NI=
 go.uber.org/zap v1.19.1/go.mod h1:j3DNczoxDZroyBnOT1L/Q79cfUMGZxlv/9dzN7SM1rI=
+go.uber.org/zap v1.24.0/go.mod h1:2kMP+WWQ8aoFoedH3T2sq6iJ2yDWpHbP0f6MQbS9Gkg=
 go.uber.org/zap v1.26.0 h1:sI7k6L95XOKS281NhVKOFCUNIvv9e0w4BF8N3u+tCRo=
 go.uber.org/zap v1.26.0/go.mod h1:dtElttAiwGvoJ/vj4IwHBS/gXsEu/pZ50mUIRWuG0so=
 go4.org v0.0.0-20180809161055-417644f6feb5/go.mod h1:MkTOUMDaeVYJUOUsaDXIhWPZYa1yOyC1qaOBpL57BhE=

--- a/systest/testcontext/context.go
+++ b/systest/testcontext/context.go
@@ -25,6 +25,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	k8szap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/spacemeshos/go-spacemesh/systest/parameters"
 )
@@ -288,6 +290,8 @@ func New(t *testing.T, opts ...Opt) *Context {
 	scheme := runtime.NewScheme()
 	require.NoError(t, chaos.AddToScheme(scheme))
 
+	// prevent sigs.k8s.io/controller-runtime from complaining about log.SetLogger never being called
+	log.SetLogger(k8szap.New())
 	generic, err := client.New(config, client.Options{Scheme: scheme})
 	require.NoError(t, err)
 


### PR DESCRIPTION
## Motivation
System tests sometimes complain with a warning about this issue:

```
[controller-runtime] log.SetLogger(...) was never called; logs will not be displayed.
Detected at:
	>  goroutine 89 [running]:
	>  runtime/debug.Stack()
	>  	/usr/local/go/src/runtime/debug/stack.go:24 +0x5e
	>  sigs.k8s.io/controller-runtime/pkg/log.eventuallyFulfillRoot()
	>  	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.2/pkg/log/log.go:60 +0xcd
	>  sigs.k8s.io/controller-runtime/pkg/log.(*delegatingLogSink).WithName(0xc0001f3400, {0x1d7b101, 0x14})
	>  	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.2/pkg/log/deleg.go:147 +0x45
	>  github.com/go-logr/logr.Logger.WithName({{0x201aac0, 0xc0001f3400}, 0x0}, {0x1d7b101?, 0x1d63709?})
	>  	/go/pkg/mod/github.com/go-logr/logr@v1.2.4/logr.go:336 +0x3d
	>  sigs.k8s.io/controller-runtime/pkg/client.newClient(0x1d09720?, {0x0, 0xc003dfa3f0, {0x0, 0x0}, 0x0, {0x0, 0x0}, 0x0})
	>  	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.2/pkg/client/client.go:122 +0xec
	>  sigs.k8s.io/controller-runtime/pkg/client.New(0x20024e0?, {0x0, 0xc003dfa3f0, {0x0, 0x0}, 0x0, {0x0, 0x0}, 0x0})
	>  	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.2/pkg/client/client.go:103 +0x7d
	>  github.com/spacemeshos/go-spacemesh/systest/testcontext.New(0xc000187380, {0xc0003c5f18, 0x1, 0x5ac?})
	>  	/build/systest/testcontext/context.go:291 +0x32e
	>  github.com/spacemeshos/go-spacemesh/systest/tests.TestPartition_30_70(0xc0001031e0?)
	>  	/build/systest/tests/partition_test.go:174 +0xc8
	>  testing.tRunner(0xc000187380, 0x1e6c4c0)
	>  	/usr/local/go/src/testing/testing.go:1595 +0xff
	>  created by testing.(*T).Run in goroutine 1
	>  	/usr/local/go/src/testing/testing.go:1648 +0x3ad
```

This PR tries to fix that warning

## Changes
- set a logger for controller-runtime in system tests

## Test Plan
n/a

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
