### PR TITLE
[Merged by Bors] - Completely remove github.com/golang/protobuf dependency

### DIFF
--- a/api/grpcserver/activation_service.go
+++ b/api/grpcserver/activation_service.go
@@ -5,12 +5,12 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	pb "github.com/spacemeshos/api/release/go/spacemesh/v1"
 	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/events"
@@ -68,7 +68,7 @@ func (s *activationService) Get(ctx context.Context, request *pb.GetRequest) (*p
 	return resp, nil
 }
 
-func (s *activationService) Highest(ctx context.Context, req *empty.Empty) (*pb.HighestResponse, error) {
+func (s *activationService) Highest(ctx context.Context, req *emptypb.Empty) (*pb.HighestResponse, error) {
 	highest, err := s.atxProvider.MaxHeightAtx()
 	if err != nil {
 		return &pb.HighestResponse{

--- a/api/grpcserver/activation_service_test.go
+++ b/api/grpcserver/activation_service_test.go
@@ -6,12 +6,12 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/golang/protobuf/ptypes/empty"
 	pb "github.com/spacemeshos/api/release/go/spacemesh/v1"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/spacemeshos/go-spacemesh/api/grpcserver"
 	"github.com/spacemeshos/go-spacemesh/common/types"
@@ -26,7 +26,7 @@ func Test_Highest_ReturnsGoldenAtxOnError(t *testing.T) {
 	activationService := grpcserver.NewActivationService(atxProvider, goldenAtx)
 
 	atxProvider.EXPECT().MaxHeightAtx().Return(types.EmptyATXID, errors.New("blah"))
-	response, err := activationService.Highest(context.Background(), &empty.Empty{})
+	response, err := activationService.Highest(context.Background(), &emptypb.Empty{})
 	require.NoError(t, err)
 	require.Equal(t, goldenAtx.Bytes(), response.Atx.Id.Id)
 	require.Nil(t, response.Atx.Layer)
@@ -62,7 +62,7 @@ func Test_Highest_ReturnsMaxTickHeight(t *testing.T) {
 	atxProvider.EXPECT().MaxHeightAtx().Return(id, nil)
 	atxProvider.EXPECT().GetFullAtx(id).Return(&atx, nil)
 
-	response, err := activationService.Highest(context.Background(), &empty.Empty{})
+	response, err := activationService.Highest(context.Background(), &emptypb.Empty{})
 	require.NoError(t, err)
 	require.Equal(t, atx.ID().Bytes(), response.Atx.Id.Id)
 	require.Equal(t, atx.PublishEpoch.Uint32(), response.Atx.Layer.Number)

--- a/api/grpcserver/admin_service.go
+++ b/api/grpcserver/admin_service.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	pb "github.com/spacemeshos/api/release/go/spacemesh/v1"
 	"github.com/spf13/afero"
@@ -16,6 +15,7 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/spacemeshos/go-spacemesh/checkpoint"
 	"github.com/spacemeshos/go-spacemesh/common/types"
@@ -102,10 +102,10 @@ func (a AdminService) CheckpointStream(req *pb.CheckpointStreamRequest, stream p
 	}
 }
 
-func (a AdminService) Recover(ctx context.Context, _ *pb.RecoverRequest) (*empty.Empty, error) {
+func (a AdminService) Recover(ctx context.Context, _ *pb.RecoverRequest) (*emptypb.Empty, error) {
 	ctxzap.Info(ctx, "going to recover from checkpoint")
 	a.recover()
-	return &empty.Empty{}, nil
+	return &emptypb.Empty{}, nil
 }
 
 func (a AdminService) EventsStream(req *pb.EventStreamRequest, stream pb.AdminService_EventsStreamServer) error {
@@ -140,7 +140,7 @@ func (a AdminService) EventsStream(req *pb.EventStreamRequest, stream pb.AdminSe
 	}
 }
 
-func (a AdminService) PeerInfoStream(_ *empty.Empty, stream pb.AdminService_PeerInfoStreamServer) error {
+func (a AdminService) PeerInfoStream(_ *emptypb.Empty, stream pb.AdminService_PeerInfoStreamServer) error {
 	for _, p := range a.p.GetPeers() {
 		select {
 		case <-stream.Context().Done():

--- a/api/grpcserver/debug_service.go
+++ b/api/grpcserver/debug_service.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	pb "github.com/spacemeshos/api/release/go/spacemesh/v1"
 	"go.uber.org/zap"
@@ -78,7 +77,7 @@ func (d DebugService) Accounts(ctx context.Context, in *pb.AccountsRequest) (*pb
 }
 
 // NetworkInfo query provides NetworkInfoResponse.
-func (d DebugService) NetworkInfo(ctx context.Context, _ *empty.Empty) (*pb.NetworkInfoResponse, error) {
+func (d DebugService) NetworkInfo(ctx context.Context, _ *emptypb.Empty) (*pb.NetworkInfoResponse, error) {
 	return &pb.NetworkInfoResponse{Id: d.identity.ID().String()}, nil
 }
 

--- a/api/grpcserver/grpcserver_test.go
+++ b/api/grpcserver/grpcserver_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/protobuf/ptypes/empty"
 	pb "github.com/spacemeshos/api/release/go/spacemesh/v1"
 	"github.com/spacemeshos/merkle-tree"
 	"github.com/spacemeshos/poet/shared"
@@ -33,6 +32,7 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/spacemeshos/go-spacemesh/activation"
 	"github.com/spacemeshos/go-spacemesh/codec"
@@ -584,12 +584,12 @@ func TestNodeService(t *testing.T) {
 			require.Equal(t, "Must include `Msg`", grpcStatus.Message())
 		}},
 		{"Version", func(t *testing.T) {
-			res, err := c.Version(context.Background(), &empty.Empty{})
+			res, err := c.Version(context.Background(), &emptypb.Empty{})
 			require.NoError(t, err)
 			require.Equal(t, version, res.VersionString.Value)
 		}},
 		{"Build", func(t *testing.T) {
-			res, err := c.Build(context.Background(), &empty.Empty{})
+			res, err := c.Build(context.Background(), &emptypb.Empty{})
 			require.NoError(t, err)
 			require.Equal(t, build, res.BuildString.Value)
 		}},
@@ -620,7 +620,7 @@ func TestNodeService(t *testing.T) {
 			require.Equal(t, layerVerified.Uint32(), res.Status.VerifiedLayer.Number)
 		}},
 		{"NodeInfo", func(t *testing.T) {
-			resp, err := c.NodeInfo(ctx, &empty.Empty{})
+			resp, err := c.NodeInfo(ctx, &emptypb.Empty{})
 			require.NoError(t, err)
 			require.Equal(t, resp.Hrp, types.NetworkHRP())
 			require.Equal(t, resp.FirstGenesis, types.FirstEffectiveGenesis().Uint32())
@@ -921,7 +921,7 @@ func TestSmesherService(t *testing.T) {
 	c := pb.NewSmesherServiceClient(conn)
 
 	t.Run("IsSmeshing", func(t *testing.T) {
-		res, err := c.IsSmeshing(context.Background(), &empty.Empty{})
+		res, err := c.IsSmeshing(context.Background(), &emptypb.Empty{})
 		require.NoError(t, err)
 		require.False(t, res.IsSmeshing, "expected IsSmeshing to be false")
 	})
@@ -954,7 +954,7 @@ func TestSmesherService(t *testing.T) {
 	})
 
 	t.Run("SmesherID", func(t *testing.T) {
-		res, err := c.SmesherID(context.Background(), &empty.Empty{})
+		res, err := c.SmesherID(context.Background(), &emptypb.Empty{})
 		require.NoError(t, err)
 		require.NoError(t, err)
 		require.Equal(t, signer.NodeID().Bytes(), res.PublicKey)
@@ -976,7 +976,7 @@ func TestSmesherService(t *testing.T) {
 	})
 
 	t.Run("Coinbase", func(t *testing.T) {
-		res, err := c.Coinbase(context.Background(), &empty.Empty{})
+		res, err := c.Coinbase(context.Background(), &emptypb.Empty{})
 		require.NoError(t, err)
 		addr, err := types.StringToAddress(res.AccountId.Address)
 		require.NoError(t, err)
@@ -984,7 +984,7 @@ func TestSmesherService(t *testing.T) {
 	})
 
 	t.Run("MinGas", func(t *testing.T) {
-		_, err := c.MinGas(context.Background(), &empty.Empty{})
+		_, err := c.MinGas(context.Background(), &emptypb.Empty{})
 		require.Error(t, err)
 		statusCode := status.Code(err)
 		require.Equal(t, codes.Unimplemented, statusCode)
@@ -1005,7 +1005,7 @@ func TestSmesherService(t *testing.T) {
 	t.Run("PostSetupStatusStream", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-		stream, err := c.PostSetupStatusStream(ctx, &empty.Empty{})
+		stream, err := c.PostSetupStatusStream(ctx, &emptypb.Empty{})
 		require.NoError(t, err)
 
 		// Expecting the stream to return updates before closing.
@@ -2450,7 +2450,7 @@ func TestDebugService(t *testing.T) {
 		id := p2p.Peer("test")
 		identity.EXPECT().ID().Return(id)
 
-		response, err := c.NetworkInfo(context.Background(), &empty.Empty{})
+		response, err := c.NetworkInfo(context.Background(), &emptypb.Empty{})
 		require.NoError(t, err)
 		require.NotNil(t, response)
 		require.Equal(t, id.String(), response.Id)
@@ -2477,7 +2477,7 @@ func TestDebugService(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 		defer cancel()
-		stream, err := c.ProposalsStream(ctx, &empty.Empty{})
+		stream, err := c.ProposalsStream(ctx, &emptypb.Empty{})
 		require.NoError(t, err)
 
 		_, err = stream.Header()

--- a/api/grpcserver/node_service.go
+++ b/api/grpcserver/node_service.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	pb "github.com/spacemeshos/api/release/go/spacemesh/v1"
 	"go.uber.org/zap/zapcore"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/events"
@@ -61,14 +61,14 @@ func (s NodeService) Echo(_ context.Context, in *pb.EchoRequest) (*pb.EchoRespon
 }
 
 // Version returns the version of the node software as a semver string.
-func (s NodeService) Version(context.Context, *empty.Empty) (*pb.VersionResponse, error) {
+func (s NodeService) Version(context.Context, *emptypb.Empty) (*pb.VersionResponse, error) {
 	return &pb.VersionResponse{
 		VersionString: &pb.SimpleString{Value: s.appVersion},
 	}, nil
 }
 
 // Build returns the build of the node software.
-func (s NodeService) Build(context.Context, *empty.Empty) (*pb.BuildResponse, error) {
+func (s NodeService) Build(context.Context, *emptypb.Empty) (*pb.BuildResponse, error) {
 	return &pb.BuildResponse{
 		BuildString: &pb.SimpleString{Value: s.appCommit},
 	}, nil
@@ -89,7 +89,7 @@ func (s NodeService) Status(ctx context.Context, _ *pb.StatusRequest) (*pb.Statu
 	}, nil
 }
 
-func (s NodeService) NodeInfo(context.Context, *empty.Empty) (*pb.NodeInfoResponse, error) {
+func (s NodeService) NodeInfo(context.Context, *emptypb.Empty) (*pb.NodeInfoResponse, error) {
 	return &pb.NodeInfoResponse{
 		Hrp:              types.NetworkHRP(),
 		FirstGenesis:     types.FirstEffectiveGenesis().Uint32(),

--- a/api/grpcserver/smesher_service.go
+++ b/api/grpcserver/smesher_service.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	pb "github.com/spacemeshos/api/release/go/spacemesh/v1"
 	"github.com/spacemeshos/post/config"
@@ -15,6 +14,7 @@ import (
 	rpcstatus "google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/spacemeshos/go-spacemesh/activation"
 	"github.com/spacemeshos/go-spacemesh/common/types"
@@ -45,7 +45,7 @@ func NewSmesherService(post postSetupProvider, smeshing activation.SmeshingProvi
 }
 
 // IsSmeshing reports whether the node is smeshing.
-func (s SmesherService) IsSmeshing(context.Context, *empty.Empty) (*pb.IsSmeshingResponse, error) {
+func (s SmesherService) IsSmeshing(context.Context, *emptypb.Empty) (*pb.IsSmeshingResponse, error) {
 	return &pb.IsSmeshingResponse{IsSmeshing: s.smeshingProvider.Smeshing()}, nil
 }
 
@@ -119,12 +119,12 @@ func (s SmesherService) StopSmeshing(ctx context.Context, in *pb.StopSmeshingReq
 }
 
 // SmesherID returns the smesher ID of this node.
-func (s SmesherService) SmesherID(context.Context, *empty.Empty) (*pb.SmesherIDResponse, error) {
+func (s SmesherService) SmesherID(context.Context, *emptypb.Empty) (*pb.SmesherIDResponse, error) {
 	return &pb.SmesherIDResponse{PublicKey: s.smeshingProvider.SmesherID().Bytes()}, nil
 }
 
 // Coinbase returns the current coinbase setting of this node.
-func (s SmesherService) Coinbase(context.Context, *empty.Empty) (*pb.CoinbaseResponse, error) {
+func (s SmesherService) Coinbase(context.Context, *emptypb.Empty) (*pb.CoinbaseResponse, error) {
 	return &pb.CoinbaseResponse{AccountId: &pb.AccountId{Address: s.smeshingProvider.Coinbase().String()}}, nil
 }
 
@@ -146,7 +146,7 @@ func (s SmesherService) SetCoinbase(_ context.Context, in *pb.SetCoinbaseRequest
 }
 
 // MinGas returns the current mingas setting of this node.
-func (s SmesherService) MinGas(context.Context, *empty.Empty) (*pb.MinGasResponse, error) {
+func (s SmesherService) MinGas(context.Context, *emptypb.Empty) (*pb.MinGasResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "this endpoint is not implemented")
 }
 
@@ -161,13 +161,13 @@ func (s SmesherService) EstimatedRewards(context.Context, *pb.EstimatedRewardsRe
 }
 
 // PostSetupStatus returns post data status.
-func (s SmesherService) PostSetupStatus(ctx context.Context, _ *empty.Empty) (*pb.PostSetupStatusResponse, error) {
+func (s SmesherService) PostSetupStatus(ctx context.Context, _ *emptypb.Empty) (*pb.PostSetupStatusResponse, error) {
 	status := s.postSetupProvider.Status()
 	return &pb.PostSetupStatusResponse{Status: statusToPbStatus(status)}, nil
 }
 
 // PostSetupStatusStream exposes a stream of status updates during post setup.
-func (s SmesherService) PostSetupStatusStream(_ *empty.Empty, stream pb.SmesherService_PostSetupStatusStreamServer) error {
+func (s SmesherService) PostSetupStatusStream(_ *emptypb.Empty, stream pb.SmesherService_PostSetupStatusStreamServer) error {
 	timer := time.NewTicker(s.streamInterval)
 	defer timer.Stop()
 
@@ -216,7 +216,7 @@ func (s SmesherService) PostSetupProviders(ctx context.Context, in *pb.PostSetup
 }
 
 // PostConfig returns the Post protocol config.
-func (s SmesherService) PostConfig(context.Context, *empty.Empty) (*pb.PostConfigResponse, error) {
+func (s SmesherService) PostConfig(context.Context, *emptypb.Empty) (*pb.PostConfigResponse, error) {
 	cfg := s.postSetupProvider.Config()
 
 	return &pb.PostConfigResponse{

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/cosmos/btcutil v1.0.5
 	github.com/go-llsqlite/crawshaw v0.4.0
 	github.com/gofrs/flock v0.8.1
-	github.com/golang/protobuf v1.5.3
 	github.com/google/go-cmp v0.5.9
 	github.com/google/gofuzz v1.2.0
 	github.com/google/uuid v1.3.1
@@ -99,6 +98,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/mock v1.6.0 // indirect
+	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
 	github.com/google/gopacket v1.1.19 // indirect

--- a/hare/flows_test.go
+++ b/hare/flows_test.go
@@ -26,7 +26,6 @@ type HareWrapper struct {
 	termination chan struct{}
 	clock       *mockClock
 	hare        []*Hare
-	//lint:ignore U1000 pending https://github.com/spacemeshos/go-spacemesh/issues/4001
 	initialSets []*Set
 	outputs     map[types.LayerID][]*Set
 }

--- a/node/adminservice_api_test.go
+++ b/node/adminservice_api_test.go
@@ -6,10 +6,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/libp2p/go-libp2p/core/peer"
 	pb "github.com/spacemeshos/api/release/go/spacemesh/v1"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/spacemeshos/go-spacemesh/api/grpcserver"
 	"github.com/spacemeshos/go-spacemesh/config"
@@ -34,7 +34,7 @@ func TestPeerInfoApi(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 		defer cancel()
 
-		streamClient, err := adminapi.PeerInfoStream(ctx, &empty.Empty{})
+		streamClient, err := adminapi.PeerInfoStream(ctx, &emptypb.Empty{})
 		require.NoError(t, err)
 		for {
 			info, err := streamClient.Recv()

--- a/systest/tests/common.go
+++ b/systest/tests/common.go
@@ -1,6 +1,5 @@
 package tests
 
-//lint:file-ignore U1000 func waitAll is unused
 import (
 	"context"
 	"errors"
@@ -9,12 +8,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/protobuf/ptypes/empty"
 	pb "github.com/spacemeshos/api/release/go/spacemesh/v1"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/genproto/googleapis/rpc/code"
+	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/genvm/sdk"
@@ -252,7 +251,7 @@ func watchTransactionResults(ctx context.Context,
 func watchProposals(ctx context.Context, eg *errgroup.Group, client *cluster.NodeClient, collector func(*pb.Proposal) (bool, error)) {
 	eg.Go(func() error {
 		dbg := pb.NewDebugServiceClient(client)
-		proposals, err := dbg.ProposalsStream(ctx, &empty.Empty{})
+		proposals, err := dbg.ProposalsStream(ctx, &emptypb.Empty{})
 		if err != nil {
 			return fmt.Errorf("proposal stream for %s: %w", client.Name, err)
 		}


### PR DESCRIPTION
## Motivation
Follow up to https://github.com/spacemeshos/go-spacemesh/pull/5092. This completely removes `github.com/golang/protobuf` as a direct dependency.

## Changes
- Replace `github.com/golang/protobuf` with `google.golang.org/protobuf`

## Test Plan
<!-- Please specify how these changes were tested
(e.g. unit tests, manual testing, etc.) -->

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
