### PR TITLE
[Merged by Bors] - Deflake tests by giving nipost builder more time in tests

### DIFF
--- a/activation/nipost_test.go
+++ b/activation/nipost_test.go
@@ -194,11 +194,11 @@ func buildNIPost(tb testing.TB, postProvider *testPostManager, nipostChallenge t
 
 	epoch := layersPerEpoch * layerDuration
 	poetCfg := PoetConfig{
-		PhaseShift:        epoch / 5,
-		CycleGap:          epoch / 10,
-		GracePeriod:       epoch / 10,
-		RequestTimeout:    epoch / 10,
-		RequestRetryDelay: epoch / 100,
+		PhaseShift:        epoch / 2,
+		CycleGap:          epoch / 5,
+		GracePeriod:       epoch / 5,
+		RequestTimeout:    epoch / 5,
+		RequestRetryDelay: epoch / 50,
 		MaxRequestRetries: 10,
 	}
 


### PR DESCRIPTION
## Motivation
Closes #5060

Deflakes `TestValidator_Validate` and `TestNIPostBuilderWithClients`

## Changes
- Extend timeouts to avoid tests failing because of them

## Test Plan
n/a

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
