### PR TITLE
[Merged by Bors] - Add poet112 and bootnodes to the config

### DIFF
--- a/config/mainnet.go
+++ b/config/mainnet.go
@@ -32,6 +32,19 @@ func MainnetConfig() Config {
 	}
 	p2pconfig := p2p.DefaultConfig()
 
+	p2pconfig.Bootnodes = []string{
+		"/dns4/mainnet-bootnode-0.spacemesh.network/tcp/5000/p2p/12D3KooWPStnitMbLyWAGr32gHmPr538mT658Thp6zTUujZt3LRf",
+		"/dns4/mainnet-bootnode-2.spacemesh.network/tcp/5000/p2p/12D3KooWAsMgXLpyGdsRNjHBF3FaXwnXhyMEqWQYBXUpvCHNzFNK",
+		"/dns4/mainnet-bootnode-4.spacemesh.network/tcp/5000/p2p/12D3KooWRcTWDHzptnhJn5h6CtwnokzzMaDLcXv6oM9CxQEXd5FL",
+		"/dns4/mainnet-bootnode-6.spacemesh.network/tcp/5000/p2p/12D3KooWRS47KAs3ZLkBtE2AqjJCwxRYqZKmyLkvombJJdrca8Hz",
+		"/dns4/mainnet-bootnode-8.spacemesh.network/tcp/5000/p2p/12D3KooWFYv99aGbtXnZQy6UZxyf72NpkWJp3K4HS8Py35WhKtzE",
+		"/dns4/mainnet-bootnode-10.spacemesh.network/tcp/5000/p2p/12D3KooWHK5m83sNj2eNMJMGAngcS9gBja27ho83t79Q2CD4iRjQ",
+		"/dns4/mainnet-bootnode-12.spacemesh.network/tcp/5000/p2p/12D3KooWG4gk8GtMsAjYxHtbNC7oEoBTMRLbLDpKgSQMQkYBFRsw",
+		"/dns4/mainnet-bootnode-14.spacemesh.network/tcp/5000/p2p/12D3KooWRkZMjGNrQfRyeKQC9U58cUwAfyQMtjNsupixkBFag8AY",
+		"/dns4/mainnet-bootnode-16.spacemesh.network/tcp/5000/p2p/12D3KooWDAFRuFrMNgVQMDy8cgD71GLtPyYyfQzFxMZr2yUBgjHK",
+		"/dns4/mainnet-bootnode-18.spacemesh.network/tcp/5000/p2p/12D3KooWMJmdfwxDctuGGoTYJD8Wj9jubQBbPfrgrzzXaQ1RTKE6",
+	}
+
 	smeshing := DefaultSmeshingConfig()
 	smeshing.ProvingOpts.Nonces = 288
 	smeshing.ProvingOpts.Threads = uint(runtime.NumCPU() * 3 / 4)
@@ -65,6 +78,7 @@ func MainnetConfig() Config {
 				"https://mainnet-poet-2.spacemesh.network",
 				"https://poet-110.spacemesh.network",
 				"https://poet-111.spacemesh.network",
+				"https://poet-112.spacemesh.network",
 			},
 		},
 		Genesis: &GenesisConfig{


### PR DESCRIPTION
Some time ago, we decided to NOT include these ( https://github.com/spacemeshos/go-spacemesh/pull/4714 ), but I think we're stable enough on the bootnodes and poet servers currently, so we can commit to it.