### PR TITLE
[Merged by Bors] - Simplify VRFSigner() method to not return an error

### DIFF
--- a/beacon/beacon.go
+++ b/beacon/beacon.go
@@ -109,7 +109,6 @@ func New(
 	publisher pubsub.Publisher,
 	edSigner *signing.EdSigner,
 	edVerifier *signing.EdVerifier,
-	vrfSigner vrfSigner,
 	vrfVerifier vrfVerifier,
 	cdb *datastore.CachedDB,
 	clock layerClock,
@@ -123,7 +122,6 @@ func New(
 		publisher:      publisher,
 		edSigner:       edSigner,
 		edVerifier:     edVerifier,
-		vrfSigner:      vrfSigner,
 		vrfVerifier:    vrfVerifier,
 		cdb:            cdb,
 		clock:          clock,
@@ -147,7 +145,7 @@ func New(
 	}
 
 	if pd.weakCoin == nil {
-		pd.weakCoin = weakcoin.New(pd.publisher, vrfSigner, vrfVerifier, pd.nonceFetcher, pd,
+		pd.weakCoin = weakcoin.New(pd.publisher, edSigner.VRFSigner(), vrfVerifier, pd.nonceFetcher, pd,
 			pd.msgTimes,
 			weakcoin.WithLog(pd.logger.WithName("weakCoin")),
 			weakcoin.WithMaxRound(pd.config.RoundsNumber),
@@ -173,7 +171,6 @@ type ProtocolDriver struct {
 	publisher    pubsub.Publisher
 	edSigner     *signing.EdSigner
 	edVerifier   *signing.EdVerifier
-	vrfSigner    vrfSigner
 	vrfVerifier  vrfVerifier
 	nonceFetcher nonceFetcher
 	weakCoin     coin
@@ -834,7 +831,7 @@ func (pd *ProtocolDriver) sendProposal(ctx context.Context, epoch types.EpochID,
 	}
 
 	logger := pd.logger.WithContext(ctx).WithFields(epoch)
-	vrfSig := buildSignedProposal(ctx, pd.logger, pd.vrfSigner, epoch, nonce)
+	vrfSig := buildSignedProposal(ctx, pd.logger, pd.edSigner.VRFSigner(), epoch, nonce)
 	proposal := ProposalFromVrf(vrfSig)
 	m := ProposalMessage{
 		EpochID:      epoch,

--- a/beacon/handlers_test.go
+++ b/beacon/handlers_test.go
@@ -190,8 +190,7 @@ func Test_HandleProposal_InitEpoch(t *testing.T) {
 
 	signer, err := signing.NewEdSigner()
 	require.NoError(t, err)
-	vrfSigner, err := signer.VRFSigner()
-	require.NoError(t, err)
+	vrfSigner := signer.VRFSigner()
 	epochStart := time.Now()
 	createATX(t, tpd.cdb, epoch.FirstLayer().Sub(1), signer, 10, epochStart.Add(-1*time.Minute))
 
@@ -214,13 +213,11 @@ func Test_HandleProposal_Success(t *testing.T) {
 
 	signer1, err := signing.NewEdSigner()
 	require.NoError(t, err)
-	vrfSigner1, err := signer1.VRFSigner()
-	require.NoError(t, err)
+	vrfSigner1 := signer1.VRFSigner()
 
 	signer2, err := signing.NewEdSigner()
 	require.NoError(t, err)
-	vrfSigner2, err := signer2.VRFSigner()
-	require.NoError(t, err)
+	vrfSigner2 := signer2.VRFSigner()
 
 	epochStart := time.Now()
 	mockChecker := NewMockeligibilityChecker(gomock.NewController(t))
@@ -269,13 +266,11 @@ func Test_HandleProposal_Malicious(t *testing.T) {
 
 	signer1, err := signing.NewEdSigner()
 	require.NoError(t, err)
-	vrfSigner1, err := signer1.VRFSigner()
-	require.NoError(t, err)
+	vrfSigner1 := signer1.VRFSigner()
 
 	signer2, err := signing.NewEdSigner()
 	require.NoError(t, err)
-	vrfSigner2, err := signer2.VRFSigner()
-	require.NoError(t, err)
+	vrfSigner2 := signer2.VRFSigner()
 
 	epochStart := time.Now()
 	mockChecker := NewMockeligibilityChecker(gomock.NewController(t))
@@ -324,8 +319,7 @@ func Test_HandleProposal_Shutdown(t *testing.T) {
 
 	signer, err := signing.NewEdSigner()
 	require.NoError(t, err)
-	vrfSigner, err := signer.VRFSigner()
-	require.NoError(t, err)
+	vrfSigner := signer.VRFSigner()
 
 	msg := createProposal(t, vrfSigner, epoch, false)
 	msgBytes, err := codec.Encode(msg)
@@ -347,8 +341,7 @@ func Test_HandleProposal_NotInProtocolStillWorks(t *testing.T) {
 
 	signer, err := signing.NewEdSigner()
 	require.NoError(t, err)
-	vrfSigner, err := signer.VRFSigner()
-	require.NoError(t, err)
+	vrfSigner := signer.VRFSigner()
 
 	msg := createProposal(t, vrfSigner, epoch, false)
 	msgBytes, err := codec.Encode(msg)
@@ -387,8 +380,7 @@ func Test_handleProposal_Corrupted(t *testing.T) {
 
 	signer, err := signing.NewEdSigner()
 	require.NoError(t, err)
-	vrfSigner, err := signer.VRFSigner()
-	require.NoError(t, err)
+	vrfSigner := signer.VRFSigner()
 
 	msg := []byte("guaranteed to be  malformed")
 	got := tpd.HandleProposal(context.Background(), "peerID", msg)
@@ -407,8 +399,7 @@ func Test_handleProposal_EpochTooOld(t *testing.T) {
 
 	signer, err := signing.NewEdSigner()
 	require.NoError(t, err)
-	vrfSigner, err := signer.VRFSigner()
-	require.NoError(t, err)
+	vrfSigner := signer.VRFSigner()
 
 	msg := createProposal(t, vrfSigner, epoch-1, false)
 	msgBytes, err := codec.Encode(msg)
@@ -434,8 +425,7 @@ func Test_handleProposal_NextEpoch(t *testing.T) {
 	rng := rand.New(rand.NewSource(1))
 	signer, err := signing.NewEdSigner(signing.WithKeyFromRand(rng))
 	require.NoError(t, err)
-	vrfSigner, err := signer.VRFSigner()
-	require.NoError(t, err)
+	vrfSigner := signer.VRFSigner()
 
 	now := time.Now()
 	mockChecker := NewMockeligibilityChecker(gomock.NewController(t))
@@ -478,8 +468,7 @@ func Test_handleProposal_NextEpochTooEarly(t *testing.T) {
 
 	signer, err := signing.NewEdSigner()
 	require.NoError(t, err)
-	vrfSigner, err := signer.VRFSigner()
-	require.NoError(t, err)
+	vrfSigner := signer.VRFSigner()
 
 	msg := createProposal(t, vrfSigner, nextEpoch, false)
 	msgBytes, err := codec.Encode(msg)
@@ -510,8 +499,7 @@ func Test_handleProposal_EpochTooFarAhead(t *testing.T) {
 
 	signer, err := signing.NewEdSigner()
 	require.NoError(t, err)
-	vrfSigner, err := signer.VRFSigner()
-	require.NoError(t, err)
+	vrfSigner := signer.VRFSigner()
 
 	msg := createProposal(t, vrfSigner, epoch+2, false)
 	msgBytes, err := codec.Encode(msg)
@@ -535,8 +523,7 @@ func Test_handleProposal_BadVrfSignature(t *testing.T) {
 
 	signer, err := signing.NewEdSigner()
 	require.NoError(t, err)
-	vrfSigner, err := signer.VRFSigner()
-	require.NoError(t, err)
+	vrfSigner := signer.VRFSigner()
 
 	epochStart := time.Now()
 	mockChecker := NewMockeligibilityChecker(gomock.NewController(t))
@@ -573,8 +560,7 @@ func Test_handleProposal_AlreadyProposed(t *testing.T) {
 	rng := rand.New(rand.NewSource(101))
 	signer, err := signing.NewEdSigner(signing.WithKeyFromRand(rng))
 	require.NoError(t, err)
-	vrfSigner, err := signer.VRFSigner()
-	require.NoError(t, err)
+	vrfSigner := signer.VRFSigner()
 
 	epochStart := time.Now()
 	mockChecker := NewMockeligibilityChecker(gomock.NewController(t))
@@ -622,8 +608,7 @@ func Test_handleProposal_PotentiallyValid_Timing(t *testing.T) {
 
 	signer, err := signing.NewEdSigner()
 	require.NoError(t, err)
-	vrfSigner, err := signer.VRFSigner()
-	require.NoError(t, err)
+	vrfSigner := signer.VRFSigner()
 
 	epochStart := time.Now()
 	mockChecker := NewMockeligibilityChecker(gomock.NewController(t))
@@ -659,8 +644,7 @@ func Test_handleProposal_PotentiallyValid_Threshold(t *testing.T) {
 
 	signer, err := signing.NewEdSigner()
 	require.NoError(t, err)
-	vrfSigner, err := signer.VRFSigner()
-	require.NoError(t, err)
+	vrfSigner := signer.VRFSigner()
 
 	epochStart := time.Now()
 	mockChecker := NewMockeligibilityChecker(gomock.NewController(t))
@@ -697,8 +681,7 @@ func Test_handleProposal_Invalid_Timing(t *testing.T) {
 
 	signer, err := signing.NewEdSigner()
 	require.NoError(t, err)
-	vrfSigner, err := signer.VRFSigner()
-	require.NoError(t, err)
+	vrfSigner := signer.VRFSigner()
 
 	epochStart := time.Now()
 	mockChecker := NewMockeligibilityChecker(gomock.NewController(t))
@@ -729,8 +712,7 @@ func Test_handleProposal_Invalid_threshold(t *testing.T) {
 
 	signer, err := signing.NewEdSigner()
 	require.NoError(t, err)
-	vrfSigner, err := signer.VRFSigner()
-	require.NoError(t, err)
+	vrfSigner := signer.VRFSigner()
 
 	epochStart := time.Now()
 	mockChecker := NewMockeligibilityChecker(gomock.NewController(t))
@@ -763,8 +745,7 @@ func Test_handleProposal_MinerMissingATX(t *testing.T) {
 
 	signer, err := signing.NewEdSigner()
 	require.NoError(t, err)
-	vrfSigner, err := signer.VRFSigner()
-	require.NoError(t, err)
+	vrfSigner := signer.VRFSigner()
 
 	epochStart := time.Now()
 	mockChecker := NewMockeligibilityChecker(gomock.NewController(t))

--- a/beacon/weakcoin/weak_coin_test.go
+++ b/beacon/weakcoin/weak_coin_test.go
@@ -417,8 +417,7 @@ func TestWeakCoinEncodingRegression(t *testing.T) {
 		signing.WithKeyFromRand(rng),
 	)
 	require.NoError(t, err)
-	vrfSig, err := signer.VRFSigner()
-	require.NoError(t, err)
+	vrfSig := signer.VRFSigner()
 
 	mockAllowance := weakcoin.NewMockallowance(gomock.NewController(t))
 	mockAllowance.EXPECT().MinerAllowance(epoch, gomock.Any()).DoAndReturn(
@@ -473,8 +472,7 @@ func TestWeakCoinExchangeProposals(t *testing.T) {
 
 		signer, err := signing.NewEdSigner(signing.WithKeyFromRand(rng))
 		require.NoError(t, err)
-		vrfSigner, err := signer.VRFSigner()
-		require.NoError(t, err)
+		vrfSigner := signer.VRFSigner()
 
 		vrfSigners[i] = vrfSigner
 	}

--- a/hare/eligibility/oracle_test.go
+++ b/hare/eligibility/oracle_test.go
@@ -333,8 +333,7 @@ func Test_VrfSignVerify(t *testing.T) {
 	require.NoError(t, err)
 
 	o := defaultOracle(t)
-	o.vrfSigner, err = signer.VRFSigner()
-	require.NoError(t, err)
+	o.vrfSigner = signer.VRFSigner()
 	nid := signer.NodeID()
 
 	lid := types.EpochID(5).FirstLayer()
@@ -395,8 +394,7 @@ func Test_Proof_BeaconError(t *testing.T) {
 
 	signer, err := signing.NewEdSigner()
 	require.NoError(t, err)
-	o.vrfSigner, err = signer.VRFSigner()
-	require.NoError(t, err)
+	o.vrfSigner = signer.VRFSigner()
 
 	layer := types.LayerID(2)
 	errUnknown := errors.New("unknown")
@@ -413,8 +411,7 @@ func Test_Proof(t *testing.T) {
 
 	signer, err := signing.NewEdSigner()
 	require.NoError(t, err)
-	vrfSigner, err := signer.VRFSigner()
-	require.NoError(t, err)
+	vrfSigner := signer.VRFSigner()
 
 	o.vrfSigner = vrfSigner
 	sig, err := o.Proof(context.Background(), layer, 3)

--- a/hare3/hare_test.go
+++ b/hare3/hare_test.go
@@ -135,17 +135,13 @@ func (n *node) withSigner() *node {
 	signer, err := signing.NewEdSigner(signing.WithKeyFromRand(n.t.rng))
 	require.NoError(n.t, err)
 	n.signer = signer
-	vrfsigner, err := signer.VRFSigner()
-	require.NoError(n.t, err)
-	n.vrfsigner = vrfsigner
+	n.vrfsigner = signer.VRFSigner()
 	return n
 }
 
 func (n *node) reuseSigner(signer *signing.EdSigner) *node {
 	n.signer = signer
-	vrfsigner, err := signer.VRFSigner()
-	require.NoError(n.t, err)
-	n.vrfsigner = vrfsigner
+	n.vrfsigner = signer.VRFSigner()
 	return n
 }
 

--- a/hare3/legacy_oracle.go
+++ b/hare3/legacy_oracle.go
@@ -45,11 +45,7 @@ func (lg *legacyOracle) validate(msg *Message) grade {
 }
 
 func (lg *legacyOracle) active(signer *signing.EdSigner, beacon types.Beacon, layer types.LayerID, ir IterRound) *types.HareEligibility {
-	vrfs, err := signer.VRFSigner()
-	if err != nil {
-		panic("can't cast ed signer to vrf signer")
-	}
-	vrf := lg.oracle.GenVRF(context.Background(), vrfs, beacon, layer, ir.Absolute())
+	vrf := lg.oracle.GenVRF(context.Background(), signer.VRFSigner(), beacon, layer, ir.Absolute())
 	committee := int(lg.config.Committee)
 	if ir.Round == propose {
 		committee = int(lg.config.Leaders)

--- a/miner/proposal_builder.go
+++ b/miner/proposal_builder.go
@@ -365,7 +365,7 @@ func (pb *ProposalBuilder) initSessionData(ctx context.Context, lid types.LayerI
 			weight, set, err := generateActiveSet(
 				pb.logger,
 				pb.cdb,
-				pb.signer.MustVRFSigner(),
+				pb.signer.VRFSigner(),
 				pb.session.epoch,
 				pb.clock.LayerToTime(pb.session.epoch.FirstLayer()),
 				pb.cfg.GoodAtxPercent,
@@ -410,7 +410,7 @@ func (pb *ProposalBuilder) initSessionData(ctx context.Context, lid types.LayerI
 	}
 	if pb.session.eligibilities.proofs == nil {
 		pb.session.eligibilities.proofs = calcEligibilityProofs(
-			pb.signer.MustVRFSigner(),
+			pb.signer.VRFSigner(),
 			pb.session.epoch,
 			pb.session.beacon,
 			pb.session.nonce,

--- a/miner/proposal_builder_test.go
+++ b/miner/proposal_builder_test.go
@@ -149,10 +149,7 @@ func expectCounters(
 	js ...uint32,
 ) expectOpt {
 	return func(p *types.Proposal) {
-		vsigner, err := signer.VRFSigner()
-		if err != nil {
-			panic(err)
-		}
+		vsigner := signer.VRFSigner()
 		for _, j := range js {
 			p.EligibilityProofs = append(p.EligibilityProofs, types.VotingEligibility{
 				J:   j,

--- a/node/node.go
+++ b/node/node.go
@@ -541,10 +541,7 @@ func (app *App) SetLogLevel(name, loglevel string) error {
 }
 
 func (app *App) initServices(ctx context.Context) error {
-	vrfSigner, err := app.edSgn.VRFSigner()
-	if err != nil {
-		return fmt.Errorf("could not create vrf signer: %w", err)
-	}
+	vrfSigner := app.edSgn.VRFSigner()
 	layerSize := app.Config.LayerAvgSize
 	layersPerEpoch := types.GetLayersPerEpoch()
 	lg := app.log.Named(app.edSgn.NodeID().ShortString()).WithFields(app.edSgn.NodeID())
@@ -614,7 +611,7 @@ func (app *App) initServices(ctx context.Context) error {
 	}
 
 	vrfVerifier := signing.NewVRFVerifier()
-	beaconProtocol := beacon.New(app.edSgn.NodeID(), app.host, app.edSgn, app.edVerifier, vrfSigner, vrfVerifier, app.cachedDB, app.clock,
+	beaconProtocol := beacon.New(app.edSgn.NodeID(), app.host, app.edSgn, app.edVerifier, vrfVerifier, app.cachedDB, app.clock,
 		beacon.WithContext(ctx),
 		beacon.WithConfig(app.Config.Beacon),
 		beacon.WithLogger(app.addLogger(BeaconLogger, lg)),

--- a/signing/signer.go
+++ b/signing/signer.go
@@ -151,19 +151,11 @@ func (es *EdSigner) PrivateKey() PrivateKey {
 }
 
 // VRFSigner wraps same ed25519 key to provide ecvrf.
-func (es *EdSigner) VRFSigner() (*VRFSigner, error) {
+func (es *EdSigner) VRFSigner() *VRFSigner {
 	return &VRFSigner{
 		privateKey: oasis.PrivateKey(es.priv),
 		nodeID:     es.NodeID(),
-	}, nil
-}
-
-func (es *EdSigner) MustVRFSigner() *VRFSigner {
-	signer, err := es.VRFSigner()
-	if err != nil {
-		panic(err)
 	}
-	return signer
 }
 
 func (es *EdSigner) Prefix() []byte {

--- a/signing/vrf_test.go
+++ b/signing/vrf_test.go
@@ -14,10 +14,7 @@ func Fuzz_VRFSignAndVerify(f *testing.F) {
 		edSig, err := NewEdSigner()
 		require.NoError(t, err, "failed to create EdSigner")
 
-		vrfSig, err := edSig.VRFSigner()
-		require.NoError(t, err, "failed to create VRF signer")
-
-		signature := vrfSig.Sign(message)
+		signature := edSig.VRFSigner().Sign(message)
 		require.NoError(t, err, "failed to sign message")
 
 		ok := VRFVerify(edSig.NodeID(), message, signature)
@@ -35,11 +32,8 @@ func Test_VRFSignAndVerify(t *testing.T) {
 	require.NoError(t, err, "failed to create EdSigner")
 
 	// Act & Assert
-	vrfSig, err := signer.VRFSigner()
-	require.NoError(t, err, "failed to create VRF signer")
-
 	message := []byte("hello world")
-	signature := vrfSig.Sign(message)
+	signature := signer.VRFSigner().Sign(message)
 
 	vrfVerify := NewVRFVerifier()
 	ok := vrfVerify.Verify(signer.NodeID(), message, signature)
@@ -52,8 +46,7 @@ func Test_VRFSigner_NodeIDAndPublicKey(t *testing.T) {
 	require.NoError(t, err, "failed to create EdSigner")
 
 	// Act
-	vrfSig, err := signer.VRFSigner()
-	require.NoError(t, err, "failed to create VRF signer")
+	vrfSig := signer.VRFSigner()
 
 	// Assert
 	require.Equal(t, signer.NodeID(), vrfSig.NodeID(), "VRF signer node ID does not match Ed signer node ID")
@@ -65,8 +58,7 @@ func Test_VRFVerifier(t *testing.T) {
 	// Arrange
 	signer, err := NewEdSigner()
 	require.NoError(t, err, "failed to create EdSigner")
-	vrfSig, err := signer.VRFSigner()
-	require.NoError(t, err, "failed to create VRF signer")
+	vrfSig := signer.VRFSigner()
 
 	// Act & Assert
 	sig := vrfSig.Sign([]byte("hello world"))
@@ -88,9 +80,6 @@ func Test_VRF_LSB_evenly_distributed(t *testing.T) {
 	// Arrange
 	signer, err := NewEdSigner()
 	require.NoError(t, err, "failed to create EdSigner")
-	vrfSig, err := signer.VRFSigner()
-	require.NoError(t, err, "failed to create VRF signer")
-
 	iterations := 10_000
 
 	// Act
@@ -100,7 +89,7 @@ func Test_VRF_LSB_evenly_distributed(t *testing.T) {
 		_, err := rand.Read(msg)
 		require.NoError(t, err, "failed to read random bytes")
 
-		sig := vrfSig.Sign(msg)
+		sig := signer.VRFSigner().Sign(msg)
 		lsb[sig.LSB()]++
 	}
 


### PR DESCRIPTION
Cleanup `VRFSigner()` method to not return a redundant error.