### PR TITLE
[Merged by Bors] - Beacon cleanups

### DIFF
--- a/beacon/beacon.go
+++ b/beacon/beacon.go
@@ -575,7 +575,6 @@ func (pd *ProtocolDriver) initEpochStateIfNotPresent(logger log.Log, epoch types
 				log.Stringer("smesher", header.NodeID))
 		}
 		if header.NodeID == pd.edSigner.NodeID() {
-			// TODO(poszu): support many IDs
 			active = true
 		}
 		return nil

--- a/beacon/beacon.go
+++ b/beacon/beacon.go
@@ -2,7 +2,6 @@ package beacon
 
 import (
 	"context"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"math/big"
@@ -12,7 +11,6 @@ import (
 
 	"github.com/ALTree/bigfloat"
 	"github.com/spacemeshos/fixed"
-	"go.uber.org/zap/zapcore"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/spacemeshos/go-spacemesh/beacon/metrics"
@@ -771,12 +769,7 @@ func calcBeacon(logger log.Log, set proposalSet) types.Beacon {
 	logger.With().Info("calculated beacon",
 		beacon,
 		log.Int("num_hashes", len(allProposals)),
-		log.Array("proposals", zapcore.ArrayMarshalerFunc(func(enc zapcore.ArrayEncoder) error {
-			for _, h := range allProposals {
-				enc.AppendString(hex.EncodeToString(h[:]))
-			}
-			return nil
-		})),
+		log.Array("proposals", allProposals),
 	)
 	return beacon
 }

--- a/beacon/beacon.go
+++ b/beacon/beacon.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/ALTree/bigfloat"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/spacemeshos/fixed"
 	"golang.org/x/sync/errgroup"
 
@@ -204,7 +203,6 @@ type ProtocolDriver struct {
 
 	// metrics
 	metricsCollector *metrics.BeaconMetricsCollector
-	metricsRegistry  *prometheus.Registry
 }
 
 // SetSyncState updates sync state provider. Must be executed only once.
@@ -213,13 +211,6 @@ func (pd *ProtocolDriver) SetSyncState(sync system.SyncStateProvider) {
 		pd.logger.Fatal("sync state provider can be updated only once")
 	}
 	pd.sync = sync
-}
-
-// for testing.
-func (pd *ProtocolDriver) setMetricsRegistry(registry *prometheus.Registry) {
-	pd.mu.Lock()
-	defer pd.mu.Unlock()
-	pd.metricsRegistry = registry
 }
 
 // Start starts listening for layers and outputs.

--- a/beacon/beacon_test.go
+++ b/beacon/beacon_test.go
@@ -110,7 +110,6 @@ func newTestDriver(tb testing.TB, cfg Config, p pubsub.Publisher) *testProtocolD
 		withNonceFetcher(tpd.mNonceFetcher),
 	)
 	tpd.ProtocolDriver.SetSyncState(tpd.mSync)
-	tpd.ProtocolDriver.setMetricsRegistry(prometheus.NewPedanticRegistry())
 	return tpd
 }
 

--- a/beacon/beacon_test.go
+++ b/beacon/beacon_test.go
@@ -103,7 +103,7 @@ func newTestDriver(tb testing.TB, cfg Config, p pubsub.Publisher) *testProtocolD
 	tpd.mNonceFetcher.EXPECT().VRFNonce(gomock.Any(), gomock.Any()).AnyTimes().Return(types.VRFPostIndex(1), nil)
 
 	tpd.cdb = datastore.NewCachedDB(sql.InMemory(), lg)
-	tpd.ProtocolDriver = New(minerID, p, edSgn, edVerify, tpd.mVerifier, tpd.cdb, tpd.mClock,
+	tpd.ProtocolDriver = New(p, edSgn, edVerify, tpd.mVerifier, tpd.cdb, tpd.mClock,
 		WithConfig(cfg),
 		WithLogger(lg),
 		withWeakCoin(coinValueMock(tb, true)),
@@ -159,11 +159,11 @@ func TestBeacon_MultipleNodes(t *testing.T) {
 			for _, node := range testNodes {
 				switch protocol {
 				case pubsub.BeaconProposalProtocol:
-					require.NoError(t, node.HandleProposal(ctx, p2p.Peer(node.nodeID.ShortString()), data))
+					require.NoError(t, node.HandleProposal(ctx, p2p.Peer(node.edSigner.NodeID().ShortString()), data))
 				case pubsub.BeaconFirstVotesProtocol:
-					require.NoError(t, node.HandleFirstVotes(ctx, p2p.Peer(node.nodeID.ShortString()), data))
+					require.NoError(t, node.HandleFirstVotes(ctx, p2p.Peer(node.edSigner.NodeID().ShortString()), data))
 				case pubsub.BeaconFollowingVotesProtocol:
-					require.NoError(t, node.HandleFollowingVotes(ctx, p2p.Peer(node.nodeID.ShortString()), data))
+					require.NoError(t, node.HandleFollowingVotes(ctx, p2p.Peer(node.edSigner.NodeID().ShortString()), data))
 				case pubsub.BeaconWeakCoinProtocol:
 				}
 			}
@@ -228,11 +228,11 @@ func TestBeacon_MultipleNodes_OnlyOneHonest(t *testing.T) {
 			for _, node := range testNodes {
 				switch protocol {
 				case pubsub.BeaconProposalProtocol:
-					require.NoError(t, node.HandleProposal(ctx, p2p.Peer(node.nodeID.ShortString()), data))
+					require.NoError(t, node.HandleProposal(ctx, p2p.Peer(node.edSigner.NodeID().ShortString()), data))
 				case pubsub.BeaconFirstVotesProtocol:
-					require.NoError(t, node.HandleFirstVotes(ctx, p2p.Peer(node.nodeID.ShortString()), data))
+					require.NoError(t, node.HandleFirstVotes(ctx, p2p.Peer(node.edSigner.NodeID().ShortString()), data))
 				case pubsub.BeaconFollowingVotesProtocol:
-					require.NoError(t, node.HandleFollowingVotes(ctx, p2p.Peer(node.nodeID.ShortString()), data))
+					require.NoError(t, node.HandleFollowingVotes(ctx, p2p.Peer(node.edSigner.NodeID().ShortString()), data))
 				case pubsub.BeaconWeakCoinProtocol:
 				}
 			}
@@ -264,7 +264,7 @@ func TestBeacon_MultipleNodes_OnlyOneHonest(t *testing.T) {
 		for _, db := range dbs {
 			createATX(t, db, atxPublishLid, node.edSigner, 1, time.Now().Add(-1*time.Second))
 			if i != 0 {
-				require.NoError(t, identities.SetMalicious(db, node.nodeID, []byte("bad"), time.Now()))
+				require.NoError(t, identities.SetMalicious(db, node.edSigner.NodeID(), []byte("bad"), time.Now()))
 			}
 		}
 	}

--- a/beacon/handlers.go
+++ b/beacon/handlers.go
@@ -2,7 +2,6 @@ package beacon
 
 import (
 	"context"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"math/big"
@@ -69,7 +68,7 @@ func (pd *ProtocolDriver) HandleProposal(ctx context.Context, peer p2p.Peer, msg
 
 	logger = pd.logger.WithContext(ctx).WithFields(m.EpochID, log.Stringer("smesher", m.NodeID))
 	proposal := ProposalFromVrf(m.VRFSignature)
-	logger.With().Debug("new beacon proposal", log.String("proposal", hex.EncodeToString(proposal[:])))
+	logger.With().Debug("new beacon proposal", log.Inline(proposal))
 
 	st, err := pd.initEpochStateIfNotPresent(logger, m.EpochID)
 	if err != nil {
@@ -104,7 +103,7 @@ func (pd *ProtocolDriver) classifyProposal(
 	epochStart := pd.clock.LayerToTime(m.EpochID.FirstLayer())
 	proposal := ProposalFromVrf(m.VRFSignature)
 	logger = logger.WithFields(
-		log.String("proposal", hex.EncodeToString(proposal[:])),
+		log.Inline(proposal),
 		log.Time("atx_timestamp", atxReceived),
 		log.Stringer("next_epoch_start", epochStart),
 		log.Time("received_time", receivedTime),
@@ -144,7 +143,7 @@ func (pd *ProtocolDriver) classifyProposal(
 		logger.With().Debug("valid beacon proposal",
 			log.Duration("atx delay", atxDelay),
 			log.Duration("proposal delay", proposalDelay),
-			log.String("proposal", hex.EncodeToString(proposal[:])),
+			log.Inline(proposal),
 		)
 		return valid
 	case atxDelay <= pd.config.GracePeriodDuration &&
@@ -153,7 +152,7 @@ func (pd *ProtocolDriver) classifyProposal(
 		logger.With().Debug("potentially valid beacon proposal",
 			log.Duration("atx delay", atxDelay),
 			log.Duration("proposal delay", proposalDelay),
-			log.String("proposal", hex.EncodeToString(proposal[:])),
+			log.Inline(proposal),
 		)
 		return potentiallyValid
 	default:
@@ -161,13 +160,13 @@ func (pd *ProtocolDriver) classifyProposal(
 			logger.With().Warning("invalid beacon proposal",
 				log.Duration("atx delay", atxDelay),
 				log.Duration("proposal delay", proposalDelay),
-				log.String("proposal", hex.EncodeToString(proposal[:])),
+				log.Inline(proposal),
 			)
 		} else {
 			logger.With().Debug("proposal did not pass thresholds",
 				log.Duration("atx delay", atxDelay),
 				log.Duration("proposal delay", proposalDelay),
-				log.String("proposal", hex.EncodeToString(proposal[:])),
+				log.Inline(proposal),
 			)
 		}
 	}

--- a/beacon/handlers.go
+++ b/beacon/handlers.go
@@ -356,10 +356,7 @@ func (pd *ProtocolDriver) HandleFollowingVotes(ctx context.Context, peer p2p.Pee
 }
 
 func (pd *ProtocolDriver) verifyFollowingVotes(ctx context.Context, m FollowingVotingMessage) (types.NodeID, error) {
-	messageBytes, err := codec.Encode(&m.FollowingVotingMessageBody)
-	if err != nil {
-		pd.logger.With().Fatal("failed to serialize voting message", log.Err(err))
-	}
+	messageBytes := codec.MustEncode(&m.FollowingVotingMessageBody)
 	if !pd.edVerifier.Verify(signing.BEACON_FOLLOWUP_MSG, m.SmesherID, messageBytes, m.Signature) {
 		return types.EmptyNodeID, fmt.Errorf("[round %v] verify signature %s: failed", types.FirstRound, m.Signature)
 	}

--- a/beacon/message.go
+++ b/beacon/message.go
@@ -1,7 +1,10 @@
 package beacon
 
 import (
+	"encoding/hex"
+
 	"github.com/spacemeshos/go-scale"
+	"go.uber.org/zap/zapcore"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
 )
@@ -32,6 +35,11 @@ func (p *Proposal) EncodeScale(e *scale.Encoder) (int, error) {
 // DecodeScale implements scale codec interface.
 func (p *Proposal) DecodeScale(d *scale.Decoder) (int, error) {
 	return scale.DecodeByteArray(d, p[:])
+}
+
+func (p Proposal) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	enc.AddString("proposal", hex.EncodeToString(p[:]))
+	return nil
 }
 
 func ProposalFromVrf(vrf types.VrfSignature) Proposal {

--- a/beacon/proposal_list.go
+++ b/beacon/proposal_list.go
@@ -2,10 +2,12 @@ package beacon
 
 import (
 	"bytes"
+	"encoding/hex"
 	"sort"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/hash"
+	"go.uber.org/zap/zapcore"
 )
 
 type proposalList []Proposal
@@ -22,12 +24,18 @@ func (hl proposalList) hash() types.Hash32 {
 	hasher := hash.New()
 
 	for _, proposal := range hl {
-		if _, err := hasher.Write(proposal[:]); err != nil {
-			panic("should not happen") // an error is never returned: https://golang.org/pkg/hash/#Hash
-		}
+		// an error is never returned: https://golang.org/pkg/hash/#Hash
+		hasher.Write(proposal[:])
 	}
 
 	var rst types.Hash32
 	hasher.Sum(rst[:0])
 	return rst
+}
+
+func (hl proposalList) MarshalLogArray(enc zapcore.ArrayEncoder) error {
+	for _, proposal := range hl {
+		enc.AppendString(hex.EncodeToString(proposal[:]))
+	}
+	return nil
 }

--- a/beacon/proposal_list.go
+++ b/beacon/proposal_list.go
@@ -5,9 +5,10 @@ import (
 	"encoding/hex"
 	"sort"
 
+	"go.uber.org/zap/zapcore"
+
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/hash"
-	"go.uber.org/zap/zapcore"
 )
 
 type proposalList []Proposal

--- a/beacon/proposal_set.go
+++ b/beacon/proposal_set.go
@@ -1,5 +1,11 @@
 package beacon
 
+import (
+	"encoding/hex"
+
+	"go.uber.org/zap/zapcore"
+)
+
 type proposalSet map[Proposal]struct{}
 
 func (vs proposalSet) list() proposalList {
@@ -14,4 +20,11 @@ func (vs proposalSet) list() proposalList {
 
 func (vs proposalSet) sort() proposalList {
 	return vs.list().sort()
+}
+
+func (p proposalSet) MarshalLogArray(enc zapcore.ArrayEncoder) error {
+	for proposal := range p {
+		enc.AppendString(hex.EncodeToString(proposal[:]))
+	}
+	return nil
 }

--- a/beacon/proposal_set.go
+++ b/beacon/proposal_set.go
@@ -4,22 +4,13 @@ import (
 	"encoding/hex"
 
 	"go.uber.org/zap/zapcore"
+	"golang.org/x/exp/maps"
 )
 
 type proposalSet map[Proposal]struct{}
 
-func (vs proposalSet) list() proposalList {
-	votes := make(proposalList, 0)
-
-	for vote := range vs {
-		votes = append(votes, vote)
-	}
-
-	return votes
-}
-
 func (vs proposalSet) sort() proposalList {
-	return vs.list().sort()
+	return proposalList(maps.Keys(vs)).sort()
 }
 
 func (p proposalSet) MarshalLogArray(enc zapcore.ArrayEncoder) error {

--- a/beacon/state.go
+++ b/beacon/state.go
@@ -1,7 +1,6 @@
 package beacon
 
 import (
-	"encoding/hex"
 	"fmt"
 	"math/big"
 	"time"
@@ -90,9 +89,7 @@ func (s *state) addVote(proposal Proposal, vote uint, voteWeight *big.Int) {
 	if _, ok := s.votesMargin[proposal]; !ok {
 		// voteMargin is updated during the proposal phase.
 		// ignore votes on proposals not in the original proposals.
-		s.logger.With().Warning("ignoring vote for unknown proposal",
-			log.String("proposal", hex.EncodeToString(proposal[:])),
-		)
+		s.logger.With().Warning("ignoring vote for unknown proposal", log.Inline(proposal))
 		return
 	}
 	if vote == up {

--- a/beacon/votes_calc.go
+++ b/beacon/votes_calc.go
@@ -4,8 +4,9 @@ import (
 	"encoding/hex"
 	"math/big"
 
-	"github.com/spacemeshos/go-spacemesh/log"
 	"go.uber.org/zap/zapcore"
+
+	"github.com/spacemeshos/go-spacemesh/log"
 )
 
 func calcVotes(logger log.Log, theta *big.Float, s *state) (allVotes, proposalList) {

--- a/beacon/votes_calc.go
+++ b/beacon/votes_calc.go
@@ -1,14 +1,21 @@
 package beacon
 
 import (
-	"fmt"
+	"encoding/hex"
 	"math/big"
 
 	"github.com/spacemeshos/go-spacemesh/log"
+	"go.uber.org/zap/zapcore"
 )
 
 func calcVotes(logger log.Log, theta *big.Float, s *state) (allVotes, proposalList) {
-	logger.With().Debug("calculating votes", log.String("vote_margins", fmt.Sprint(s.votesMargin)))
+	logger.With().Debug("calculating votes", log.Object("vote_margins", zapcore.ObjectMarshalerFunc(
+		func(enc zapcore.ObjectEncoder) error {
+			for vote, margin := range s.votesMargin {
+				enc.AddString(hex.EncodeToString(vote[:]), margin.String())
+			}
+			return nil
+		})))
 
 	ownCurrentRoundVotes := allVotes{
 		support: make(proposalSet),
@@ -30,8 +37,9 @@ func calcVotes(logger log.Log, theta *big.Float, s *state) (allVotes, proposalLi
 		}
 	}
 	logger.With().Debug("calculated votes for one round",
-		log.String("for_votes", fmt.Sprint(ownCurrentRoundVotes.support)),
-		log.String("against_votes", fmt.Sprint(ownCurrentRoundVotes.against)))
+		log.Array("for_votes", ownCurrentRoundVotes.support),
+		log.Array("against_votes", ownCurrentRoundVotes.against),
+	)
 
 	return ownCurrentRoundVotes, undecided
 }

--- a/beacon/weakcoin/weak_coin.go
+++ b/beacon/weakcoin/weak_coin.go
@@ -266,12 +266,7 @@ func (wc *WeakCoin) prepareProposal(epoch types.EpochID, nonce types.VRFPostInde
 				NodeID:       wc.signer.NodeID(),
 				VRFSignature: signature,
 			}
-			msg, err := codec.Encode(&message)
-			if err != nil {
-				wc.logger.With().Fatal("failed to serialize weak coin message", log.Err(err))
-			}
-
-			broadcast = msg
+			broadcast = codec.MustEncode(&message)
 			smallest = &signature
 		}
 	}
@@ -354,10 +349,5 @@ func (wc *WeakCoin) encodeProposal(epoch types.EpochID, nonce types.VRFPostIndex
 		Round: round,
 		Unit:  unit,
 	}
-
-	b, err := codec.Encode(message)
-	if err != nil {
-		wc.logger.With().Fatal("failed to encode weak coin vrf msg", log.Err(err))
-	}
-	return b
+	return codec.MustEncode(message)
 }

--- a/beacon/weakcoin/weak_coin_test.go
+++ b/beacon/weakcoin/weak_coin_test.go
@@ -36,13 +36,6 @@ func noopBroadcaster(tb testing.TB, ctrl *gomock.Controller) *mocks.MockPublishe
 	return bc
 }
 
-func encoded(tb testing.TB, msg weakcoin.Message) []byte {
-	tb.Helper()
-	buf, err := codec.Encode(&msg)
-	require.NoError(tb, err)
-	return buf
-}
-
 func staticSigner(tb testing.TB, ctrl *gomock.Controller, nodeId types.NodeID, sig types.VrfSignature) *weakcoin.MockvrfSigner {
 	tb.Helper()
 	signer := weakcoin.NewMockvrfSigner(ctrl)
@@ -100,7 +93,7 @@ func TestWeakCoin(t *testing.T) {
 			nodeSig:  oneLSBSig,
 			mining:   false,
 			expected: false,
-			msg: encoded(t, weakcoin.Message{
+			msg: codec.MustEncode(&weakcoin.Message{
 				Epoch:        epoch,
 				Round:        round,
 				Unit:         1,
@@ -114,7 +107,7 @@ func TestWeakCoin(t *testing.T) {
 			nodeSig:  oneLSBSig,
 			mining:   true,
 			expected: true,
-			msg: encoded(t, weakcoin.Message{
+			msg: codec.MustEncode(&weakcoin.Message{
 				Epoch:        epoch,
 				Round:        round,
 				Unit:         1,
@@ -128,7 +121,7 @@ func TestWeakCoin(t *testing.T) {
 			nodeSig:  higherThreshold,
 			mining:   true,
 			expected: false,
-			msg: encoded(t, weakcoin.Message{
+			msg: codec.MustEncode(&weakcoin.Message{
 				Epoch:        epoch,
 				Round:        round,
 				Unit:         1,
@@ -223,7 +216,7 @@ func TestWeakCoin_HandleProposal(t *testing.T) {
 			desc:         "ValidProposal",
 			startedEpoch: epoch,
 			startedRound: round,
-			msg: encoded(t, weakcoin.Message{
+			msg: codec.MustEncode(&weakcoin.Message{
 				Epoch:        epoch,
 				Round:        round,
 				Unit:         allowance,
@@ -243,7 +236,7 @@ func TestWeakCoin_HandleProposal(t *testing.T) {
 			desc:         "ExceedAllowance",
 			startedEpoch: epoch,
 			startedRound: round,
-			msg: encoded(t, weakcoin.Message{
+			msg: codec.MustEncode(&weakcoin.Message{
 				Epoch:        epoch,
 				Round:        round,
 				Unit:         allowance + 1,
@@ -256,7 +249,7 @@ func TestWeakCoin_HandleProposal(t *testing.T) {
 			desc:         "ExceedThreshold",
 			startedEpoch: epoch,
 			startedRound: round,
-			msg: encoded(t, weakcoin.Message{
+			msg: codec.MustEncode(&weakcoin.Message{
 				Epoch:        epoch,
 				Round:        round,
 				Unit:         allowance,
@@ -269,7 +262,7 @@ func TestWeakCoin_HandleProposal(t *testing.T) {
 			desc:         "PreviousEpoch",
 			startedEpoch: epoch,
 			startedRound: round,
-			msg: encoded(t, weakcoin.Message{
+			msg: codec.MustEncode(&weakcoin.Message{
 				Epoch:        epoch - 1,
 				Round:        round,
 				Unit:         allowance,
@@ -282,7 +275,7 @@ func TestWeakCoin_HandleProposal(t *testing.T) {
 			desc:         "NextEpoch",
 			startedEpoch: epoch,
 			startedRound: round,
-			msg: encoded(t, weakcoin.Message{
+			msg: codec.MustEncode(&weakcoin.Message{
 				Epoch:        epoch + 1,
 				Round:        round,
 				Unit:         allowance,
@@ -295,7 +288,7 @@ func TestWeakCoin_HandleProposal(t *testing.T) {
 			desc:         "PreviousRound",
 			startedEpoch: epoch,
 			startedRound: round,
-			msg: encoded(t, weakcoin.Message{
+			msg: codec.MustEncode(&weakcoin.Message{
 				Epoch:        epoch,
 				Round:        round - 1,
 				Unit:         allowance,
@@ -308,7 +301,7 @@ func TestWeakCoin_HandleProposal(t *testing.T) {
 			desc:         "NextRound",
 			startedEpoch: epoch,
 			startedRound: round,
-			msg: encoded(t, weakcoin.Message{
+			msg: codec.MustEncode(&weakcoin.Message{
 				Epoch:        epoch,
 				Round:        round + 1,
 				Unit:         allowance,
@@ -374,7 +367,7 @@ func TestWeakCoinNextRoundBufferOverflow(t *testing.T) {
 	wc.StartEpoch(context.Background(), epoch)
 	wc.StartRound(context.Background(), round, nil)
 	for i := 0; i < bufSize; i++ {
-		wc.HandleProposal(context.Background(), "", encoded(t, weakcoin.Message{
+		wc.HandleProposal(context.Background(), "", codec.MustEncode(&weakcoin.Message{
 			Epoch:        epoch,
 			Round:        nextRound,
 			Unit:         1,
@@ -382,7 +375,7 @@ func TestWeakCoinNextRoundBufferOverflow(t *testing.T) {
 			VRFSignature: oneLSBSig,
 		}))
 	}
-	wc.HandleProposal(context.Background(), "", encoded(t, weakcoin.Message{
+	wc.HandleProposal(context.Background(), "", codec.MustEncode(&weakcoin.Message{
 		Epoch:        epoch,
 		Round:        nextRound,
 		Unit:         1,

--- a/node/node.go
+++ b/node/node.go
@@ -613,7 +613,7 @@ func (app *App) initServices(ctx context.Context) error {
 	}
 
 	vrfVerifier := signing.NewVRFVerifier()
-	beaconProtocol := beacon.New(app.edSgn.NodeID(), app.host, app.edSgn, app.edVerifier, vrfVerifier, app.cachedDB, app.clock,
+	beaconProtocol := beacon.New(app.host, app.edSgn, app.edVerifier, vrfVerifier, app.cachedDB, app.clock,
 		beacon.WithContext(ctx),
 		beacon.WithConfig(app.Config.Beacon),
 		beacon.WithLogger(app.addLogger(BeaconLogger, lg)),


### PR DESCRIPTION
Some clean-ups in beacon code:
- removed redundant:
  -  nodeID (can be derived from edSigner)
  -  and metricsRegistry (unused
- use `codec.MustEncode` where an error lead to shutdown anyway
- avoid costly eager marshaling for log purposes

:bulb: It's recommended to review commit-by-commit as changes are separated.