### PR TITLE
[Merged by Bors] - fetch: parametrize success rate threshold

### DIFF
--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -175,12 +175,12 @@ func NewFetch(
 	opts ...Option,
 ) *Fetch {
 	bs := datastore.NewBlobStore(cdb.Database)
+
 	f := &Fetch{
 		cfg:         DefaultConfig(),
 		logger:      log.NewNop(),
 		bs:          bs,
 		host:        host,
-		peers:       peers.New(),
 		servers:     map[string]requester{},
 		unprocessed: make(map[types.Hash32]*request),
 		ongoing:     make(map[types.Hash32]*request),
@@ -190,6 +190,11 @@ func NewFetch(
 	for _, opt := range opts {
 		opt(f)
 	}
+	popts := []peers.Opt{}
+	if f.cfg.PeersRateThreshold != 0 {
+		popts = append(popts, peers.WithRateThreshold(f.cfg.PeersRateThreshold))
+	}
+	f.peers = peers.New(popts...)
 	// NOTE(dshulyak) this is to avoid tests refactoring.
 	// there is one test that covers this part.
 	if host != nil {

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -95,6 +95,7 @@ func DefaultConfig() Config {
 		BatchSize:            20,
 		RequestTimeout:       time.Second * time.Duration(10),
 		MaxRetriesForRequest: 100,
+		PeersRateThreshold:   0.02,
 	}
 }
 

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -84,6 +84,7 @@ type Config struct {
 	BatchSize, QueueSize int
 	RequestTimeout       time.Duration // in seconds
 	MaxRetriesForRequest int
+	PeersRateThreshold   float64 `mapstructure:"peers-rate-threshold"`
 }
 
 // DefaultConfig is the default config for the fetch component.

--- a/fetch/peers/peers_test.go
+++ b/fetch/peers/peers_test.go
@@ -19,7 +19,7 @@ type event struct {
 }
 
 func withEvents(events []event) *Peers {
-	tracker := New()
+	tracker := New(WithRateThreshold(0.1))
 	for _, ev := range events {
 		if ev.delete {
 			tracker.Delete(ev.id)


### PR DESCRIPTION
this threshold used to determine if peers are seen as equally responsive within certain threshold.
parametrizing it to run some experiments