### PR TITLE
[Merged by Bors] - Specify gcloud version in release and systest jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,8 +70,9 @@ jobs:
           rm -f $OUTNAME/post.h
           zip -r $OUTNAME.zip $OUTNAME
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v1
         with:
+          version: "450.0.0"
           project_id: ${{ secrets.GCP_PROJECT_ID }}
           service_account_key: ${{ secrets.GCP_SA_KEY }}
           export_default_credentials: true

--- a/.github/workflows/systest.yml
+++ b/.github/workflows/systest.yml
@@ -69,6 +69,8 @@ jobs:
 
       - name: Configure gcloud
         uses: "google-github-actions/setup-gcloud@v1"
+        with:
+          version: "450.0.0"
 
       - name: Configure gke authentication plugin
         run: gcloud components install gke-gcloud-auth-plugin --quiet


### PR DESCRIPTION
## Motivation
Not specifying a version leads the jobs to download the latest version on every build. Since a new version of gcloud is released on average once per week and those installations take up ~550 MB on our runners and are not removed automatically this eventually fills up the disks of the runners.

## Changes
- Specify a gcloud version in `systests` and `release` jobs. This way only that version is downloaded and re-used on every subsequent run.
-  We can manually update gcloud to a newer version if needed.

## Test Plan
n/a

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
