### PR TITLE
[Merged by Bors] - Remove confusing clock warning

### DIFF
--- a/timesync/clock.go
+++ b/timesync/clock.go
@@ -136,14 +136,12 @@ func (t *NodeClock) tick() {
 		)
 		d := t.lastTicked.Difference(layer)
 		tickDistance.Observe(float64(-d))
-	case layer.Difference(t.lastTicked) > 1:
-		// don't warn right after fresh startup
-		if t.lastTicked != 0 {
-			t.log.With().Warning("clock skipped layers",
-				log.Stringer("layer", layer),
-				log.Stringer("last_ticked_layer", t.lastTicked),
-			)
-		}
+	// don't warn right after fresh startup
+	case layer.Difference(t.lastTicked) > 1 && t.lastTicked > 0:
+		t.log.With().Warning("clock skipped layers",
+			log.Stringer("layer", layer),
+			log.Stringer("last_ticked_layer", t.lastTicked),
+		)
 		d := layer.Difference(t.lastTicked)
 		tickDistance.Observe(float64(d))
 	case layer == t.lastTicked:

--- a/timesync/clock.go
+++ b/timesync/clock.go
@@ -137,10 +137,13 @@ func (t *NodeClock) tick() {
 		d := t.lastTicked.Difference(layer)
 		tickDistance.Observe(float64(-d))
 	case layer.Difference(t.lastTicked) > 1:
-		t.log.With().Warning("clock skipped layers",
-			log.Stringer("layer", layer),
-			log.Stringer("last_ticked_layer", t.lastTicked),
-		)
+		// don't warn right after fresh startup
+		if t.lastTicked != 0 {
+			t.log.With().Warning("clock skipped layers",
+				log.Stringer("layer", layer),
+				log.Stringer("last_ticked_layer", t.lastTicked),
+			)
+		}
 		d := layer.Difference(t.lastTicked)
 		tickDistance.Observe(float64(d))
 	case layer == t.lastTicked:


### PR DESCRIPTION
Don't warn about skipping layers right after fresh start. This causes constant confusion among community members.