### PR TITLE
[Merged by Bors] - Try possible fix for flaky TestAdminEvents on Windows

### DIFF
--- a/config/presets/standalone.go
+++ b/config/presets/standalone.go
@@ -75,7 +75,7 @@ func standalone() config.Config {
 	conf.Beacon.BeaconSyncWeightUnits = 10
 	conf.Beacon.VotesLimit = 100
 
-	conf.PoETServers = []string{"http://0.0.0.0:10010"}
+	conf.PoETServers = []string{"http://127.0.0.1:10010"}
 	conf.POET.GracePeriod = 12 * time.Second
 	conf.POET.CycleGap = 30 * time.Second
 	conf.POET.PhaseShift = 30 * time.Second
@@ -86,7 +86,7 @@ func standalone() config.Config {
 	conf.P2P.DisableNatPort = true
 
 	conf.API.PublicListener = "0.0.0.0:10092"
-	conf.API.PrivateListener = "0.0.0.0:10093"
+	conf.API.PrivateListener = "127.0.0.1:10093"
 
 	conf.POSTService.NodeAddress = "http://127.0.0.1:10093"
 	return conf


### PR DESCRIPTION
## Motivation
Instead of trying to access the local PoET via `0.0.0.0:10010` access it via `127.0.0.1:10010`. The first address seems to cause problems on some Windows systems

## Changes
Updated standalone config to use 127.0.0.1 for local addresses instead of 0.0.0.0

## Test Plan
n/a

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
