### PR TITLE
[Merged by Bors] - Support multiple signers in certifier

### DIFF
--- a/blocks/certifier.go
+++ b/blocks/certifier.go
@@ -220,7 +220,7 @@ func (c *Certifier) RegisterForCert(ctx context.Context, lid types.LayerID, bid 
 
 // CertifyIfEligible signs the hare output, along with its role proof as a certifier, and gossip the CertifyMessage
 // if the node is eligible to be a certifier.
-func (c *Certifier) CertifyIfEligible(ctx context.Context, logger log.Log, lid types.LayerID, bid types.BlockID) error {
+func (c *Certifier) CertifyIfEligible(ctx context.Context, lid types.LayerID, bid types.BlockID) error {
 	if _, err := c.beacon.GetBeacon(lid.GetEpoch()); err != nil {
 		return errBeaconNotAvailable
 	}
@@ -234,7 +234,7 @@ func (c *Certifier) CertifyIfEligible(ctx context.Context, logger log.Log, lid t
 	for _, s := range c.signers {
 		s := s
 		eg.Go(func() error {
-			if err := c.certifySingleSigner(ctx, logger, s, lid, bid); err != nil {
+			if err := c.certifySingleSigner(ctx, s, lid, bid); err != nil {
 				errsMu.Lock()
 				errs = errors.Join(errs, fmt.Errorf("certifying block %v/%v by %s: %w", lid, bid, s.NodeID().ShortString(), err))
 				errsMu.Unlock()
@@ -247,7 +247,7 @@ func (c *Certifier) CertifyIfEligible(ctx context.Context, logger log.Log, lid t
 	return errs
 }
 
-func (c *Certifier) certifySingleSigner(ctx context.Context, logger log.Log, s *signing.EdSigner, lid types.LayerID, bid types.BlockID) error {
+func (c *Certifier) certifySingleSigner(ctx context.Context, s *signing.EdSigner, lid types.LayerID, bid types.BlockID) error {
 	// check if the signer is eligible to certify the hare output
 	proof, err := c.oracle.Proof(ctx, s.VRFSigner(), lid, eligibility.CertifyRound)
 	if err != nil {

--- a/blocks/certifier_test.go
+++ b/blocks/certifier_test.go
@@ -77,7 +77,12 @@ func generateBlock(t *testing.T, db *datastore.CachedDB) *types.Block {
 	return block
 }
 
-func genCertifyMsg(tb testing.TB, lid types.LayerID, bid types.BlockID, cnt uint16) (types.NodeID, *types.CertifyMessage) {
+func genCertifyMsg(
+	tb testing.TB,
+	lid types.LayerID,
+	bid types.BlockID,
+	cnt uint16,
+) (types.NodeID, *types.CertifyMessage) {
 	tb.Helper()
 	signer, err := signing.NewEdSigner()
 	require.NoError(tb, err)
@@ -94,7 +99,11 @@ func genCertifyMsg(tb testing.TB, lid types.LayerID, bid types.BlockID, cnt uint
 	return signer.NodeID(), msg
 }
 
-func genEncodedMsg(t *testing.T, lid types.LayerID, bid types.BlockID) (types.NodeID, *types.CertifyMessage, []byte) {
+func genEncodedMsg(
+	t *testing.T,
+	lid types.LayerID,
+	bid types.BlockID,
+) (types.NodeID, *types.CertifyMessage, []byte) {
 	t.Helper()
 	nid, msg := genCertifyMsg(t, lid, bid, defaultCnt)
 	data, err := codec.Encode(msg)
@@ -102,7 +111,12 @@ func genEncodedMsg(t *testing.T, lid types.LayerID, bid types.BlockID) (types.No
 	return nid, msg, data
 }
 
-func verifyCerts(t *testing.T, db *datastore.CachedDB, lid types.LayerID, expected map[types.BlockID]bool) {
+func verifyCerts(
+	t *testing.T,
+	db *datastore.CachedDB,
+	lid types.LayerID,
+	expected map[types.BlockID]bool,
+) {
 	t.Helper()
 	var allValids []types.BlockID
 	certs, err := certificates.Get(db, lid)
@@ -157,7 +171,8 @@ func Test_HandleSyncedCertificate(t *testing.T) {
 	sigs := make([]types.CertifyMessage, numMsgs)
 	for i := 0; i < numMsgs; i++ {
 		nid, msg, _ := genEncodedMsg(t, b.LayerIndex, b.ID())
-		tc.mOracle.EXPECT().Validate(gomock.Any(), b.LayerIndex, eligibility.CertifyRound, tc.cfg.CommitteeSize, nid, msg.Proof, defaultCnt).
+		tc.mOracle.EXPECT().
+			Validate(gomock.Any(), b.LayerIndex, eligibility.CertifyRound, tc.cfg.CommitteeSize, nid, msg.Proof, defaultCnt).
 			Return(true, nil)
 		sigs[i] = *msg
 	}
@@ -178,7 +193,8 @@ func Test_HandleSyncedCertificate_HareOutputTrumped(t *testing.T) {
 	sigs := make([]types.CertifyMessage, numMsgs)
 	for i := 0; i < numMsgs; i++ {
 		nid, msg, _ := genEncodedMsg(t, b.LayerIndex, b.ID())
-		tc.mOracle.EXPECT().Validate(gomock.Any(), b.LayerIndex, eligibility.CertifyRound, tc.cfg.CommitteeSize, nid, msg.Proof, defaultCnt).
+		tc.mOracle.EXPECT().
+			Validate(gomock.Any(), b.LayerIndex, eligibility.CertifyRound, tc.cfg.CommitteeSize, nid, msg.Proof, defaultCnt).
 			Return(true, nil)
 		sigs[i] = *msg
 	}
@@ -230,7 +246,8 @@ func Test_HandleSyncedCertificate_MultipleCertificates(t *testing.T) {
 				nid, msg, _ := genEncodedMsg(t, b.LayerIndex, bid)
 				oldCert.Signatures = append(oldCert.Signatures, *msg)
 				if !tc.sameBid {
-					tcc.mOracle.EXPECT().Validate(gomock.Any(), b.LayerIndex, eligibility.CertifyRound, tcc.cfg.CommitteeSize, nid, msg.Proof, defaultCnt).
+					tcc.mOracle.EXPECT().
+						Validate(gomock.Any(), b.LayerIndex, eligibility.CertifyRound, tcc.cfg.CommitteeSize, nid, msg.Proof, defaultCnt).
 						Return(tc.valid, nil)
 				}
 			}
@@ -239,7 +256,8 @@ func Test_HandleSyncedCertificate_MultipleCertificates(t *testing.T) {
 			sigs := make([]types.CertifyMessage, numMsgs)
 			for i := 0; i < numMsgs; i++ {
 				nid, msg, _ := genEncodedMsg(t, b.LayerIndex, b.ID())
-				tcc.mOracle.EXPECT().Validate(gomock.Any(), b.LayerIndex, eligibility.CertifyRound, tcc.cfg.CommitteeSize, nid, msg.Proof, defaultCnt).
+				tcc.mOracle.EXPECT().
+					Validate(gomock.Any(), b.LayerIndex, eligibility.CertifyRound, tcc.cfg.CommitteeSize, nid, msg.Proof, defaultCnt).
 					Return(true, nil)
 				sigs[i] = *msg
 			}
@@ -252,7 +270,11 @@ func Test_HandleSyncedCertificate_MultipleCertificates(t *testing.T) {
 			} else {
 				tcc.mTortoise.EXPECT().OnHareOutput(b.LayerIndex, b.ID())
 			}
-			require.ErrorIs(t, tcc.HandleSyncedCertificate(context.Background(), b.LayerIndex, cert), tc.err)
+			require.ErrorIs(
+				t,
+				tcc.HandleSyncedCertificate(context.Background(), b.LayerIndex, cert),
+				tc.err,
+			)
 			expected := map[types.BlockID]bool{}
 			if tc.err == nil {
 				if tc.sameBid {
@@ -280,7 +302,8 @@ func Test_HandleSyncedCertificate_NotEnoughEligibility(t *testing.T) {
 	sigs := make([]types.CertifyMessage, numMsgs)
 	for i := 0; i < numMsgs; i++ {
 		nid, msg, _ := genEncodedMsg(t, b.LayerIndex, b.ID())
-		tc.mOracle.EXPECT().Validate(gomock.Any(), b.LayerIndex, eligibility.CertifyRound, tc.cfg.CommitteeSize, nid, msg.Proof, defaultCnt).
+		tc.mOracle.EXPECT().
+			Validate(gomock.Any(), b.LayerIndex, eligibility.CertifyRound, tc.cfg.CommitteeSize, nid, msg.Proof, defaultCnt).
 			Return(true, nil)
 		sigs[i] = *msg
 	}
@@ -288,7 +311,11 @@ func Test_HandleSyncedCertificate_NotEnoughEligibility(t *testing.T) {
 		BlockID:    b.ID(),
 		Signatures: sigs,
 	}
-	require.ErrorIs(t, tc.HandleSyncedCertificate(context.Background(), b.LayerIndex, cert), errInvalidCert)
+	require.ErrorIs(
+		t,
+		tc.HandleSyncedCertificate(context.Background(), b.LayerIndex, cert),
+		errInvalidCert,
+	)
 	require.Empty(t, tc.CertCount())
 }
 
@@ -354,10 +381,14 @@ func Test_HandleCertifyMessage(t *testing.T) {
 				current = current.Sub(uint32(-1 * tc.diff))
 			}
 			testCert.mClk.EXPECT().CurrentLayer().Return(current).AnyTimes()
-			testCert.mb.EXPECT().GetBeacon(b.LayerIndex.GetEpoch()).Return(types.RandomBeacon(), nil)
+			testCert.mb.EXPECT().
+				GetBeacon(b.LayerIndex.GetEpoch()).
+				Return(types.RandomBeacon(), nil)
 			require.NoError(t, testCert.RegisterForCert(context.Background(), b.LayerIndex, b.ID()))
-			testCert.mOracle.EXPECT().Validate(gomock.Any(), b.LayerIndex, eligibility.CertifyRound, testCert.cfg.CommitteeSize, nid, msg.Proof, defaultCnt).
-				Return(true, nil).AnyTimes()
+			testCert.mOracle.EXPECT().
+				Validate(gomock.Any(), b.LayerIndex, eligibility.CertifyRound, testCert.cfg.CommitteeSize, nid, msg.Proof, defaultCnt).
+				Return(true, nil).
+				AnyTimes()
 			res := testCert.HandleCertifyMessage(context.Background(), "peer", encoded)
 			require.True(t, tc.expected(res))
 			require.Empty(t, testCert.CertCount())
@@ -388,18 +419,25 @@ func Test_HandleCertifyMessage_Certified(t *testing.T) {
 			ho := types.RandomBlockID()
 			require.NoError(t, certificates.SetHareOutput(tcc.db, b.LayerIndex, ho))
 			tcc.mClk.EXPECT().CurrentLayer().Return(b.LayerIndex).AnyTimes()
-			tcc.mb.EXPECT().GetBeacon(b.LayerIndex.GetEpoch()).Return(types.RandomBeacon(), nil).AnyTimes()
+			tcc.mb.EXPECT().
+				GetBeacon(b.LayerIndex.GetEpoch()).
+				Return(types.RandomBeacon(), nil).
+				AnyTimes()
 			require.NoError(t, tcc.RegisterForCert(context.Background(), b.LayerIndex, b.ID()))
 			if tc.concurrent {
-				tcc.mOracle.EXPECT().Validate(gomock.Any(), b.LayerIndex, eligibility.CertifyRound, tcc.cfg.CommitteeSize, gomock.Any(), gomock.Any(), defaultCnt).
-					Return(true, nil).MinTimes(cutoff).MaxTimes(numMsgs)
+				tcc.mOracle.EXPECT().
+					Validate(gomock.Any(), b.LayerIndex, eligibility.CertifyRound, tcc.cfg.CommitteeSize, gomock.Any(), gomock.Any(), defaultCnt).
+					Return(true, nil).
+					MinTimes(cutoff).
+					MaxTimes(numMsgs)
 			}
 			tcc.mTortoise.EXPECT().OnHareOutput(b.LayerIndex, b.ID())
 			var wg sync.WaitGroup
 			for i := 0; i < numMsgs; i++ {
 				nid, msg, encoded := genEncodedMsg(t, b.LayerIndex, b.ID())
 				if !tc.concurrent && i < cutoff { // we know exactly which msgs will be validated
-					tcc.mOracle.EXPECT().Validate(gomock.Any(), b.LayerIndex, eligibility.CertifyRound, tcc.cfg.CommitteeSize, nid, msg.Proof, defaultCnt).
+					tcc.mOracle.EXPECT().
+						Validate(gomock.Any(), b.LayerIndex, eligibility.CertifyRound, tcc.cfg.CommitteeSize, nid, msg.Proof, defaultCnt).
 						Return(true, nil)
 				}
 				if tc.concurrent {
@@ -458,14 +496,18 @@ func Test_HandleCertifyMessage_MultipleCertificates(t *testing.T) {
 				nid, msg, _ := genEncodedMsg(t, b.LayerIndex, bid)
 				oldCert.Signatures = append(oldCert.Signatures, *msg)
 				if !tc.sameBid {
-					tcc.mOracle.EXPECT().Validate(gomock.Any(), b.LayerIndex, eligibility.CertifyRound, tcc.cfg.CommitteeSize, nid, msg.Proof, defaultCnt).
+					tcc.mOracle.EXPECT().
+						Validate(gomock.Any(), b.LayerIndex, eligibility.CertifyRound, tcc.cfg.CommitteeSize, nid, msg.Proof, defaultCnt).
 						Return(tc.valid, nil)
 				}
 			}
 			require.NoError(t, certificates.Add(tcc.db, b.LayerIndex, oldCert))
 
 			tcc.mClk.EXPECT().CurrentLayer().Return(b.LayerIndex).AnyTimes()
-			tcc.mb.EXPECT().GetBeacon(b.LayerIndex.GetEpoch()).Return(types.RandomBeacon(), nil).AnyTimes()
+			tcc.mb.EXPECT().
+				GetBeacon(b.LayerIndex.GetEpoch()).
+				Return(types.RandomBeacon(), nil).
+				AnyTimes()
 			require.NoError(t, tcc.RegisterForCert(context.Background(), b.LayerIndex, b.ID()))
 			if tc.err != nil {
 				tcc.mTortoise.EXPECT().OnHareOutput(b.LayerIndex, types.EmptyBlockID)
@@ -475,7 +517,8 @@ func Test_HandleCertifyMessage_MultipleCertificates(t *testing.T) {
 			for i := 0; i < numMsgs; i++ {
 				nid, msg, encoded := genEncodedMsg(t, b.LayerIndex, b.ID())
 				if i < cutoff { // we know exactly which msgs will be validated
-					tcc.mOracle.EXPECT().Validate(gomock.Any(), b.LayerIndex, eligibility.CertifyRound, tcc.cfg.CommitteeSize, nid, msg.Proof, defaultCnt).
+					tcc.mOracle.EXPECT().
+						Validate(gomock.Any(), b.LayerIndex, eligibility.CertifyRound, tcc.cfg.CommitteeSize, nid, msg.Proof, defaultCnt).
 						Return(true, nil)
 				}
 				tcc.HandleCertifyMessage(context.Background(), "peer", encoded)
@@ -505,10 +548,14 @@ func Test_HandleCertifyMessage_NotRegistered(t *testing.T) {
 	b := generateBlock(t, tc.db)
 	tc.mClk.EXPECT().CurrentLayer().Return(b.LayerIndex).AnyTimes()
 	tc.mb.EXPECT().GetBeacon(b.LayerIndex.GetEpoch()).Return(types.RandomBeacon(), nil).AnyTimes()
-	require.NoError(t, tc.RegisterForCert(context.Background(), b.LayerIndex, types.RandomBlockID()))
+	require.NoError(
+		t,
+		tc.RegisterForCert(context.Background(), b.LayerIndex, types.RandomBlockID()),
+	)
 	for i := 0; i < numMsgs; i++ {
 		nid, msg, encoded := genEncodedMsg(t, b.LayerIndex, b.ID())
-		tc.mOracle.EXPECT().Validate(gomock.Any(), b.LayerIndex, eligibility.CertifyRound, tc.cfg.CommitteeSize, nid, msg.Proof, defaultCnt).
+		tc.mOracle.EXPECT().
+			Validate(gomock.Any(), b.LayerIndex, eligibility.CertifyRound, tc.cfg.CommitteeSize, nid, msg.Proof, defaultCnt).
 			Return(true, nil)
 		res := tc.HandleCertifyMessage(context.Background(), "peer", encoded)
 		require.Equal(t, nil, res)
@@ -539,10 +586,14 @@ func Test_HandleCertifyMessage_LayerNotRegistered(t *testing.T) {
 	b := generateBlock(t, tc.db)
 	nid, msg, encoded := genEncodedMsg(t, b.LayerIndex, b.ID())
 
-	require.NoError(t, tc.RegisterForCert(context.Background(), b.LayerIndex.Add(1), types.RandomBlockID()))
+	require.NoError(
+		t,
+		tc.RegisterForCert(context.Background(), b.LayerIndex.Add(1), types.RandomBlockID()),
+	)
 	tc.mClk.EXPECT().CurrentLayer().Return(b.LayerIndex).AnyTimes()
 	tc.mb.EXPECT().GetBeacon(b.LayerIndex.GetEpoch()).Return(types.RandomBeacon(), nil)
-	tc.mOracle.EXPECT().Validate(gomock.Any(), b.LayerIndex, eligibility.CertifyRound, tc.cfg.CommitteeSize, nid, msg.Proof, defaultCnt).
+	tc.mOracle.EXPECT().
+		Validate(gomock.Any(), b.LayerIndex, eligibility.CertifyRound, tc.cfg.CommitteeSize, nid, msg.Proof, defaultCnt).
 		Return(true, nil)
 	res := tc.HandleCertifyMessage(context.Background(), "peer", encoded)
 	require.Equal(t, nil, res)
@@ -553,10 +604,14 @@ func Test_HandleCertifyMessage_BlockNotRegistered(t *testing.T) {
 	b := generateBlock(t, tc.db)
 	nid, msg, encoded := genEncodedMsg(t, b.LayerIndex, b.ID())
 
-	require.NoError(t, tc.RegisterForCert(context.Background(), b.LayerIndex, types.RandomBlockID()))
+	require.NoError(
+		t,
+		tc.RegisterForCert(context.Background(), b.LayerIndex, types.RandomBlockID()),
+	)
 	tc.mClk.EXPECT().CurrentLayer().Return(b.LayerIndex).AnyTimes()
 	tc.mb.EXPECT().GetBeacon(b.LayerIndex.GetEpoch()).Return(types.RandomBeacon(), nil)
-	tc.mOracle.EXPECT().Validate(gomock.Any(), b.LayerIndex, eligibility.CertifyRound, tc.cfg.CommitteeSize, nid, msg.Proof, defaultCnt).
+	tc.mOracle.EXPECT().
+		Validate(gomock.Any(), b.LayerIndex, eligibility.CertifyRound, tc.cfg.CommitteeSize, nid, msg.Proof, defaultCnt).
 		Return(true, nil)
 	res := tc.HandleCertifyMessage(context.Background(), "peer", encoded)
 	require.Equal(t, nil, res)
@@ -601,26 +656,37 @@ func Test_OldLayersPruned(t *testing.T) {
 }
 
 func Test_CertifyIfEligible(t *testing.T) {
+	numSigners := 3
 	tc := newTestCertifier(t, 3)
 	b := generateBlock(t, tc.db)
 	tc.mb.EXPECT().GetBeacon(b.LayerIndex.GetEpoch()).Return(types.RandomBeacon(), nil)
 	proof := types.RandomVrfSignature()
 
-	tc.mOracle.EXPECT().Proof(gomock.Any(), gomock.Cond(func(s any) bool { _, ok := tc.signers[s.(*signing.VRFSigner).NodeID()]; return ok }), b.LayerIndex, eligibility.CertifyRound).Times(len(tc.signers)).Return(proof, nil)
-	tc.mOracle.EXPECT().CalcEligibility(gomock.Any(), b.LayerIndex, eligibility.CertifyRound, tc.cfg.CommitteeSize, gomock.Any(), proof).Times(len(tc.signers)).Return(defaultCnt, nil)
-	tc.mPub.EXPECT().Publish(gomock.Any(), pubsub.BlockCertify, gomock.Any()).Times(len(tc.signers)).DoAndReturn(
-		func(_ context.Context, _ string, got []byte) error {
-			var msg types.CertifyMessage
-			require.NoError(t, codec.Decode(got, &msg))
+	tc.mOracle.EXPECT().
+		Proof(gomock.Any(), gomock.Cond(func(s any) bool { _, ok := tc.signers[s.(*signing.VRFSigner).NodeID()]; return ok }), b.LayerIndex, eligibility.CertifyRound).
+		Times(numSigners).
+		Return(proof, nil)
+	tc.mOracle.EXPECT().
+		CalcEligibility(gomock.Any(), b.LayerIndex, eligibility.CertifyRound, tc.cfg.CommitteeSize, gomock.Any(), proof).
+		Times(numSigners).
+		Return(defaultCnt, nil)
+	tc.mPub.EXPECT().
+		Publish(gomock.Any(), pubsub.BlockCertify, gomock.Any()).
+		Times(numSigners).
+		DoAndReturn(
+			func(_ context.Context, _ string, got []byte) error {
+				var msg types.CertifyMessage
+				require.NoError(t, codec.Decode(got, &msg))
 
-			ok := signing.NewEdVerifier().Verify(signing.HARE, msg.SmesherID, msg.Bytes(), msg.Signature)
-			require.True(t, ok)
-			require.Equal(t, b.LayerIndex, msg.LayerID)
-			require.Equal(t, b.ID(), msg.BlockID)
-			require.Equal(t, proof, msg.Proof)
-			require.Equal(t, defaultCnt, msg.EligibilityCnt)
-			return nil
-		})
+				ok := signing.NewEdVerifier().
+					Verify(signing.HARE, msg.SmesherID, msg.Bytes(), msg.Signature)
+				require.True(t, ok)
+				require.Equal(t, b.LayerIndex, msg.LayerID)
+				require.Equal(t, b.ID(), msg.BlockID)
+				require.Equal(t, proof, msg.Proof)
+				require.Equal(t, defaultCnt, msg.EligibilityCnt)
+				return nil
+			})
 	require.NoError(t, tc.CertifyIfEligible(context.Background(), b.LayerIndex, b.ID()))
 }
 
@@ -629,8 +695,12 @@ func Test_CertifyIfEligible_NotEligible(t *testing.T) {
 	b := generateBlock(t, tc.db)
 	tc.mb.EXPECT().GetBeacon(b.LayerIndex.GetEpoch()).Return(types.RandomBeacon(), nil)
 	proof := types.RandomVrfSignature()
-	tc.mOracle.EXPECT().Proof(gomock.Any(), gomock.Any(), b.LayerIndex, eligibility.CertifyRound).Return(proof, nil)
-	tc.mOracle.EXPECT().CalcEligibility(gomock.Any(), b.LayerIndex, eligibility.CertifyRound, tc.cfg.CommitteeSize, gomock.Any(), proof).Return(uint16(0), nil)
+	tc.mOracle.EXPECT().
+		Proof(gomock.Any(), gomock.Any(), b.LayerIndex, eligibility.CertifyRound).
+		Return(proof, nil)
+	tc.mOracle.EXPECT().
+		CalcEligibility(gomock.Any(), b.LayerIndex, eligibility.CertifyRound, tc.cfg.CommitteeSize, gomock.Any(), proof).
+		Return(0, nil)
 	require.NoError(t, tc.CertifyIfEligible(context.Background(), b.LayerIndex, b.ID()))
 }
 
@@ -640,8 +710,12 @@ func Test_CertifyIfEligible_EligibilityErr(t *testing.T) {
 	tc.mb.EXPECT().GetBeacon(b.LayerIndex.GetEpoch()).Return(types.RandomBeacon(), nil)
 	errUnknown := errors.New("unknown")
 	proof := types.RandomVrfSignature()
-	tc.mOracle.EXPECT().Proof(gomock.Any(), gomock.Any(), b.LayerIndex, eligibility.CertifyRound).Return(proof, nil)
-	tc.mOracle.EXPECT().CalcEligibility(gomock.Any(), b.LayerIndex, eligibility.CertifyRound, tc.cfg.CommitteeSize, gomock.Any(), proof).Return(uint16(0), errUnknown)
+	tc.mOracle.EXPECT().
+		Proof(gomock.Any(), gomock.Any(), b.LayerIndex, eligibility.CertifyRound).
+		Return(proof, nil)
+	tc.mOracle.EXPECT().
+		CalcEligibility(gomock.Any(), b.LayerIndex, eligibility.CertifyRound, tc.cfg.CommitteeSize, gomock.Any(), proof).
+		Return(0, errUnknown)
 	require.ErrorIs(t, tc.CertifyIfEligible(context.Background(), b.LayerIndex, b.ID()), errUnknown)
 }
 
@@ -650,7 +724,9 @@ func Test_CertifyIfEligible_ProofErr(t *testing.T) {
 	b := generateBlock(t, tc.db)
 	tc.mb.EXPECT().GetBeacon(b.LayerIndex.GetEpoch()).Return(types.RandomBeacon(), nil)
 	errUnknown := errors.New("unknown")
-	tc.mOracle.EXPECT().Proof(gomock.Any(), gomock.Any(), b.LayerIndex, eligibility.CertifyRound).Return(types.EmptyVrfSignature, errUnknown)
+	tc.mOracle.EXPECT().
+		Proof(gomock.Any(), gomock.Any(), b.LayerIndex, eligibility.CertifyRound).
+		Return(types.EmptyVrfSignature, errUnknown)
 	require.ErrorIs(t, tc.CertifyIfEligible(context.Background(), b.LayerIndex, b.ID()), errUnknown)
 }
 
@@ -658,5 +734,9 @@ func Test_CertifyIfEligible_BeaconNotAvailable(t *testing.T) {
 	tc := newTestCertifier(t, 1)
 	b := generateBlock(t, tc.db)
 	tc.mb.EXPECT().GetBeacon(b.LayerIndex.GetEpoch()).Return(types.EmptyBeacon, errors.New("meh"))
-	require.ErrorIs(t, tc.CertifyIfEligible(context.Background(), b.LayerIndex, b.ID()), errBeaconNotAvailable)
+	require.ErrorIs(
+		t,
+		tc.CertifyIfEligible(context.Background(), b.LayerIndex, b.ID()),
+		errBeaconNotAvailable,
+	)
 }

--- a/blocks/certifier_test.go
+++ b/blocks/certifier_test.go
@@ -621,7 +621,7 @@ func Test_CertifyIfEligible(t *testing.T) {
 			require.Equal(t, defaultCnt, msg.EligibilityCnt)
 			return nil
 		})
-	require.NoError(t, tc.CertifyIfEligible(context.Background(), tc.logger, b.LayerIndex, b.ID()))
+	require.NoError(t, tc.CertifyIfEligible(context.Background(), b.LayerIndex, b.ID()))
 }
 
 func Test_CertifyIfEligible_NotEligible(t *testing.T) {
@@ -631,7 +631,7 @@ func Test_CertifyIfEligible_NotEligible(t *testing.T) {
 	proof := types.RandomVrfSignature()
 	tc.mOracle.EXPECT().Proof(gomock.Any(), gomock.Any(), b.LayerIndex, eligibility.CertifyRound).Return(proof, nil)
 	tc.mOracle.EXPECT().CalcEligibility(gomock.Any(), b.LayerIndex, eligibility.CertifyRound, tc.cfg.CommitteeSize, gomock.Any(), proof).Return(uint16(0), nil)
-	require.NoError(t, tc.CertifyIfEligible(context.Background(), tc.logger, b.LayerIndex, b.ID()))
+	require.NoError(t, tc.CertifyIfEligible(context.Background(), b.LayerIndex, b.ID()))
 }
 
 func Test_CertifyIfEligible_EligibilityErr(t *testing.T) {
@@ -642,7 +642,7 @@ func Test_CertifyIfEligible_EligibilityErr(t *testing.T) {
 	proof := types.RandomVrfSignature()
 	tc.mOracle.EXPECT().Proof(gomock.Any(), gomock.Any(), b.LayerIndex, eligibility.CertifyRound).Return(proof, nil)
 	tc.mOracle.EXPECT().CalcEligibility(gomock.Any(), b.LayerIndex, eligibility.CertifyRound, tc.cfg.CommitteeSize, gomock.Any(), proof).Return(uint16(0), errUnknown)
-	require.ErrorIs(t, tc.CertifyIfEligible(context.Background(), tc.logger, b.LayerIndex, b.ID()), errUnknown)
+	require.ErrorIs(t, tc.CertifyIfEligible(context.Background(), b.LayerIndex, b.ID()), errUnknown)
 }
 
 func Test_CertifyIfEligible_ProofErr(t *testing.T) {
@@ -651,12 +651,12 @@ func Test_CertifyIfEligible_ProofErr(t *testing.T) {
 	tc.mb.EXPECT().GetBeacon(b.LayerIndex.GetEpoch()).Return(types.RandomBeacon(), nil)
 	errUnknown := errors.New("unknown")
 	tc.mOracle.EXPECT().Proof(gomock.Any(), gomock.Any(), b.LayerIndex, eligibility.CertifyRound).Return(types.EmptyVrfSignature, errUnknown)
-	require.ErrorIs(t, tc.CertifyIfEligible(context.Background(), tc.logger, b.LayerIndex, b.ID()), errUnknown)
+	require.ErrorIs(t, tc.CertifyIfEligible(context.Background(), b.LayerIndex, b.ID()), errUnknown)
 }
 
 func Test_CertifyIfEligible_BeaconNotAvailable(t *testing.T) {
 	tc := newTestCertifier(t, 1)
 	b := generateBlock(t, tc.db)
 	tc.mb.EXPECT().GetBeacon(b.LayerIndex.GetEpoch()).Return(types.EmptyBeacon, errors.New("meh"))
-	require.ErrorIs(t, tc.CertifyIfEligible(context.Background(), tc.logger, b.LayerIndex, b.ID()), errBeaconNotAvailable)
+	require.ErrorIs(t, tc.CertifyIfEligible(context.Background(), b.LayerIndex, b.ID()), errBeaconNotAvailable)
 }

--- a/blocks/generator.go
+++ b/blocks/generator.go
@@ -301,7 +301,7 @@ func (g *Generator) saveAndCertify(ctx context.Context, lid types.LayerID, block
 		)
 	}
 
-	if err := g.cert.CertifyIfEligible(ctx, g.logger, lid, hareOutput); err != nil && !errors.Is(err, eligibility.ErrNotActive) {
+	if err := g.cert.CertifyIfEligible(ctx, lid, hareOutput); err != nil && !errors.Is(err, eligibility.ErrNotActive) {
 		g.logger.With().Warning("failed to certify block",
 			log.Context(ctx),
 			lid,

--- a/blocks/generator_test.go
+++ b/blocks/generator_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/spacemeshos/go-spacemesh/genvm/sdk/wallet"
 	"github.com/spacemeshos/go-spacemesh/hare"
 	"github.com/spacemeshos/go-spacemesh/hare/eligibility"
-	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/log/logtest"
 	"github.com/spacemeshos/go-spacemesh/signing"
 	"github.com/spacemeshos/go-spacemesh/sql"
@@ -266,7 +265,7 @@ func Test_SerialExecution(t *testing.T) {
 	lid := layerID + 3
 	tg.mockMesh.EXPECT().AddBlockWithTXs(gomock.Any(), gomock.Any())
 	tg.mockCert.EXPECT().RegisterForCert(gomock.Any(), lid, gomock.Any())
-	tg.mockCert.EXPECT().CertifyIfEligible(gomock.Any(), gomock.Any(), lid, gomock.Any())
+	tg.mockCert.EXPECT().CertifyIfEligible(gomock.Any(), lid, gomock.Any())
 	tg.mockMesh.EXPECT().ProcessLayerPerHareOutput(gomock.Any(), lid, gomock.Any(), false)
 	tg.mockPatrol.EXPECT().CompleteHare(lid)
 	tg.hareCh <- genData(t, tg.cdb, lid, false)
@@ -279,7 +278,7 @@ func Test_SerialExecution(t *testing.T) {
 	lid = layerID + 2
 	tg.mockMesh.EXPECT().AddBlockWithTXs(gomock.Any(), gomock.Any())
 	tg.mockCert.EXPECT().RegisterForCert(gomock.Any(), lid, gomock.Any())
-	tg.mockCert.EXPECT().CertifyIfEligible(gomock.Any(), gomock.Any(), lid, gomock.Any())
+	tg.mockCert.EXPECT().CertifyIfEligible(gomock.Any(), lid, gomock.Any())
 	tg.mockMesh.EXPECT().ProcessLayerPerHareOutput(gomock.Any(), lid, gomock.Any(), false)
 	tg.mockPatrol.EXPECT().CompleteHare(lid)
 	tg.hareCh <- genData(t, tg.cdb, lid, false)
@@ -290,7 +289,7 @@ func Test_SerialExecution(t *testing.T) {
 			Return(types.NewExistingBlock(types.RandomBlockID(), types.InnerBlock{LayerIndex: lyr}), nil)
 		tg.mockMesh.EXPECT().AddBlockWithTXs(gomock.Any(), gomock.Any())
 		tg.mockCert.EXPECT().RegisterForCert(gomock.Any(), lyr, gomock.Any())
-		tg.mockCert.EXPECT().CertifyIfEligible(gomock.Any(), gomock.Any(), lyr, gomock.Any())
+		tg.mockCert.EXPECT().CertifyIfEligible(gomock.Any(), lyr, gomock.Any())
 		tg.mockMesh.EXPECT().ProcessLayerPerHareOutput(gomock.Any(), lyr, gomock.Any(), true)
 		tg.mockPatrol.EXPECT().CompleteHare(lyr)
 	}
@@ -387,8 +386,8 @@ func Test_run(t *testing.T) {
 					require.Equal(t, block.ID(), got)
 					return nil
 				})
-			tg.mockCert.EXPECT().CertifyIfEligible(gomock.Any(), gomock.Any(), layerID, gomock.Any()).DoAndReturn(
-				func(_ context.Context, _ log.Log, _ types.LayerID, got types.BlockID) error {
+			tg.mockCert.EXPECT().CertifyIfEligible(gomock.Any(), layerID, gomock.Any()).DoAndReturn(
+				func(_ context.Context, _ types.LayerID, got types.BlockID) error {
 					require.Equal(t, block.ID(), got)
 					return nil
 				})
@@ -413,7 +412,7 @@ func Test_processHareOutput_EmptyOutput(t *testing.T) {
 	require.NoError(t, layers.SetApplied(tg.cdb, layerID-1, types.EmptyBlockID))
 	tg.Start(context.Background())
 	tg.mockCert.EXPECT().RegisterForCert(gomock.Any(), layerID, types.EmptyBlockID)
-	tg.mockCert.EXPECT().CertifyIfEligible(gomock.Any(), gomock.Any(), layerID, types.EmptyBlockID)
+	tg.mockCert.EXPECT().CertifyIfEligible(gomock.Any(), layerID, types.EmptyBlockID)
 	tg.mockMesh.EXPECT().ProcessLayerPerHareOutput(gomock.Any(), layerID, types.EmptyBlockID, false)
 	tg.mockPatrol.EXPECT().CompleteHare(layerID)
 	tg.hareCh <- hare.LayerOutput{Ctx: context.Background(), Layer: layerID}
@@ -525,7 +524,7 @@ func Test_run_RegisterCertFailureIgnored(t *testing.T) {
 	tg.mockExec.EXPECT().ExecuteOptimistic(gomock.Any(), layerID, uint64(baseTickHeight), gomock.Any(), gomock.Any()).Return(block, nil)
 	tg.mockMesh.EXPECT().AddBlockWithTXs(gomock.Any(), gomock.Any())
 	tg.mockCert.EXPECT().RegisterForCert(gomock.Any(), layerID, gomock.Any()).Return(errors.New("unknown"))
-	tg.mockCert.EXPECT().CertifyIfEligible(gomock.Any(), gomock.Any(), layerID, gomock.Any())
+	tg.mockCert.EXPECT().CertifyIfEligible(gomock.Any(), layerID, gomock.Any())
 	tg.mockMesh.EXPECT().ProcessLayerPerHareOutput(gomock.Any(), layerID, block.ID(), true)
 	tg.mockPatrol.EXPECT().CompleteHare(layerID)
 	tg.hareCh <- hare.LayerOutput{Ctx: context.Background(), Layer: layerID, Proposals: pids}
@@ -551,7 +550,7 @@ func Test_run_CertifyFailureIgnored(t *testing.T) {
 	tg.mockExec.EXPECT().ExecuteOptimistic(gomock.Any(), layerID, uint64(baseTickHeight), gomock.Any(), gomock.Any()).Return(block, nil)
 	tg.mockMesh.EXPECT().AddBlockWithTXs(gomock.Any(), gomock.Any())
 	tg.mockCert.EXPECT().RegisterForCert(gomock.Any(), layerID, gomock.Any())
-	tg.mockCert.EXPECT().CertifyIfEligible(gomock.Any(), gomock.Any(), layerID, gomock.Any()).Return(errors.New("unknown"))
+	tg.mockCert.EXPECT().CertifyIfEligible(gomock.Any(), layerID, gomock.Any()).Return(errors.New("unknown"))
 	tg.mockMesh.EXPECT().ProcessLayerPerHareOutput(gomock.Any(), layerID, block.ID(), true)
 	tg.mockPatrol.EXPECT().CompleteHare(layerID)
 	tg.hareCh <- hare.LayerOutput{Ctx: context.Background(), Layer: layerID, Proposals: pids}
@@ -577,7 +576,7 @@ func Test_run_ProcessLayerFailed(t *testing.T) {
 	tg.mockExec.EXPECT().ExecuteOptimistic(gomock.Any(), layerID, uint64(baseTickHeight), gomock.Any(), gomock.Any()).Return(block, nil)
 	tg.mockMesh.EXPECT().AddBlockWithTXs(gomock.Any(), gomock.Any())
 	tg.mockCert.EXPECT().RegisterForCert(gomock.Any(), layerID, gomock.Any())
-	tg.mockCert.EXPECT().CertifyIfEligible(gomock.Any(), gomock.Any(), layerID, gomock.Any())
+	tg.mockCert.EXPECT().CertifyIfEligible(gomock.Any(), layerID, gomock.Any())
 	tg.mockMesh.EXPECT().ProcessLayerPerHareOutput(gomock.Any(), layerID, block.ID(), true).Return(errors.New("unknown"))
 	tg.mockPatrol.EXPECT().CompleteHare(layerID)
 	tg.hareCh <- hare.LayerOutput{Ctx: context.Background(), Layer: layerID, Proposals: pids}
@@ -617,8 +616,8 @@ func Test_processHareOutput_UnequalHeight(t *testing.T) {
 			require.Equal(t, block.ID(), bid)
 			return nil
 		})
-	tg.mockCert.EXPECT().CertifyIfEligible(ho.Ctx, gomock.Any(), layerID, gomock.Any()).DoAndReturn(
-		func(_ context.Context, _ log.Log, _ types.LayerID, bid types.BlockID) error {
+	tg.mockCert.EXPECT().CertifyIfEligible(ho.Ctx, layerID, gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ types.LayerID, bid types.BlockID) error {
 			require.Equal(t, block.ID(), bid)
 			return eligibility.ErrNotActive
 		})
@@ -706,8 +705,8 @@ func Test_processHareOutput_EmptyProposals(t *testing.T) {
 			require.Equal(t, block.ID(), bid)
 			return nil
 		})
-	tg.mockCert.EXPECT().CertifyIfEligible(ho.Ctx, gomock.Any(), lid, gomock.Any()).DoAndReturn(
-		func(_ context.Context, _ log.Log, _ types.LayerID, bid types.BlockID) error {
+	tg.mockCert.EXPECT().CertifyIfEligible(ho.Ctx, lid, gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ types.LayerID, bid types.BlockID) error {
 			require.Equal(t, block.ID(), bid)
 			return eligibility.ErrNotActive
 		})
@@ -746,7 +745,7 @@ func Test_processHareOutput_StableBlockID(t *testing.T) {
 	tg.mockFetch.EXPECT().GetProposals(ho1.Ctx, ho1.Proposals)
 	tg.mockMesh.EXPECT().AddBlockWithTXs(ho1.Ctx, gomock.Any())
 	tg.mockCert.EXPECT().RegisterForCert(ho1.Ctx, layerID, gomock.Any())
-	tg.mockCert.EXPECT().CertifyIfEligible(ho1.Ctx, gomock.Any(), layerID, gomock.Any()).Return(eligibility.ErrNotActive)
+	tg.mockCert.EXPECT().CertifyIfEligible(ho1.Ctx, layerID, gomock.Any()).Return(eligibility.ErrNotActive)
 	tg.mockMesh.EXPECT().ProcessLayerPerHareOutput(gomock.Any(), layerID, gomock.Any(), false)
 	tg.mockPatrol.EXPECT().CompleteHare(layerID)
 	got1, err := tg.processHareOutput(ho1)
@@ -767,7 +766,7 @@ func Test_processHareOutput_StableBlockID(t *testing.T) {
 	tg.mockFetch.EXPECT().GetProposals(ho2.Ctx, ho2.Proposals)
 	tg.mockMesh.EXPECT().AddBlockWithTXs(ho2.Ctx, gomock.Any())
 	tg.mockCert.EXPECT().RegisterForCert(ho2.Ctx, layerID, gomock.Any())
-	tg.mockCert.EXPECT().CertifyIfEligible(ho2.Ctx, gomock.Any(), layerID, gomock.Any()).Return(eligibility.ErrNotActive)
+	tg.mockCert.EXPECT().CertifyIfEligible(ho2.Ctx, layerID, gomock.Any()).Return(eligibility.ErrNotActive)
 	tg.mockMesh.EXPECT().ProcessLayerPerHareOutput(gomock.Any(), layerID, gomock.Any(), false)
 	tg.mockPatrol.EXPECT().CompleteHare(layerID)
 	got2, err := tg.processHareOutput(ho2)
@@ -842,7 +841,7 @@ func Test_processHareOutput_MultipleEligibilities(t *testing.T) {
 	tg.mockFetch.EXPECT().GetProposals(ho.Ctx, ho.Proposals)
 	tg.mockMesh.EXPECT().AddBlockWithTXs(ho.Ctx, gomock.Any())
 	tg.mockCert.EXPECT().RegisterForCert(ho.Ctx, layerID, gomock.Any())
-	tg.mockCert.EXPECT().CertifyIfEligible(ho.Ctx, gomock.Any(), layerID, gomock.Any()).Return(eligibility.ErrNotActive)
+	tg.mockCert.EXPECT().CertifyIfEligible(ho.Ctx, layerID, gomock.Any()).Return(eligibility.ErrNotActive)
 	tg.mockMesh.EXPECT().ProcessLayerPerHareOutput(gomock.Any(), layerID, gomock.Any(), false)
 	tg.mockPatrol.EXPECT().CompleteHare(layerID)
 	got, err := tg.processHareOutput(ho)

--- a/blocks/interface.go
+++ b/blocks/interface.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
-	"github.com/spacemeshos/go-spacemesh/log"
 )
 
 //go:generate mockgen -typed -package=mocks -destination=./mocks/mocks.go -source=./interface.go
@@ -30,7 +29,7 @@ type layerClock interface {
 
 type certifier interface {
 	RegisterForCert(context.Context, types.LayerID, types.BlockID) error
-	CertifyIfEligible(context.Context, log.Log, types.LayerID, types.BlockID) error
+	CertifyIfEligible(context.Context, types.LayerID, types.BlockID) error
 }
 
 type tortoiseProvider interface {

--- a/blocks/mocks/mocks.go
+++ b/blocks/mocks/mocks.go
@@ -13,7 +13,6 @@ import (
 	reflect "reflect"
 
 	types "github.com/spacemeshos/go-spacemesh/common/types"
-	log "github.com/spacemeshos/go-spacemesh/log"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -398,17 +397,17 @@ func (m *Mockcertifier) EXPECT() *MockcertifierMockRecorder {
 }
 
 // CertifyIfEligible mocks base method.
-func (m *Mockcertifier) CertifyIfEligible(arg0 context.Context, arg1 log.Log, arg2 types.LayerID, arg3 types.BlockID) error {
+func (m *Mockcertifier) CertifyIfEligible(arg0 context.Context, arg1 types.LayerID, arg2 types.BlockID) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CertifyIfEligible", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "CertifyIfEligible", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CertifyIfEligible indicates an expected call of CertifyIfEligible.
-func (mr *MockcertifierMockRecorder) CertifyIfEligible(arg0, arg1, arg2, arg3 any) *certifierCertifyIfEligibleCall {
+func (mr *MockcertifierMockRecorder) CertifyIfEligible(arg0, arg1, arg2 any) *certifierCertifyIfEligibleCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CertifyIfEligible", reflect.TypeOf((*Mockcertifier)(nil).CertifyIfEligible), arg0, arg1, arg2, arg3)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CertifyIfEligible", reflect.TypeOf((*Mockcertifier)(nil).CertifyIfEligible), arg0, arg1, arg2)
 	return &certifierCertifyIfEligibleCall{Call: call}
 }
 
@@ -424,13 +423,13 @@ func (c *certifierCertifyIfEligibleCall) Return(arg0 error) *certifierCertifyIfE
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *certifierCertifyIfEligibleCall) Do(f func(context.Context, log.Log, types.LayerID, types.BlockID) error) *certifierCertifyIfEligibleCall {
+func (c *certifierCertifyIfEligibleCall) Do(f func(context.Context, types.LayerID, types.BlockID) error) *certifierCertifyIfEligibleCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *certifierCertifyIfEligibleCall) DoAndReturn(f func(context.Context, log.Log, types.LayerID, types.BlockID) error) *certifierCertifyIfEligibleCall {
+func (c *certifierCertifyIfEligibleCall) DoAndReturn(f func(context.Context, types.LayerID, types.BlockID) error) *certifierCertifyIfEligibleCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/eligibility/fixedoracle.go
+++ b/eligibility/fixedoracle.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/hash"
 	"github.com/spacemeshos/go-spacemesh/log"
+	"github.com/spacemeshos/go-spacemesh/signing"
 )
 
 // FixedRolacle is an eligibility simulator with pre-determined honest and faulty participants.
@@ -226,7 +227,7 @@ func (fo *FixedRolacle) eligible(ctx context.Context, layer types.LayerID, round
 }
 
 // Proof generates a proof for the round. used to satisfy interface.
-func (fo *FixedRolacle) Proof(ctx context.Context, layer types.LayerID, round uint32) (types.VrfSignature, error) {
+func (fo *FixedRolacle) Proof(ctx context.Context, _ *signing.VRFSigner, layer types.LayerID, round uint32) (types.VrfSignature, error) {
 	kInBytes := make([]byte, 4)
 	binary.LittleEndian.PutUint32(kInBytes, round)
 	h := hash.New()

--- a/hare/algorithm.go
+++ b/hare/algorithm.go
@@ -750,7 +750,7 @@ func (proc *consensusProcess) onRoundBegin(ctx context.Context) {
 func (proc *consensusProcess) initDefaultBuilder(s *Set) (*messageBuilder, error) {
 	builder := newMessageBuilder().SetLayer(proc.layer)
 	builder = builder.SetRoundCounter(proc.getRound()).SetCommittedRound(proc.committedRound).SetValues(s)
-	proof, err := proc.oracle.Proof(context.TODO(), proc.layer, proc.getRound())
+	proof, err := proc.oracle.Proof(context.TODO(), proc.signer.VRFSigner(), proc.layer, proc.getRound())
 	if err != nil {
 		return nil, fmt.Errorf("init default builder: %w", err)
 	}
@@ -921,7 +921,7 @@ func (proc *consensusProcess) shouldParticipate(ctx context.Context) bool {
 // Returns the role matching the current round if eligible for this round, false otherwise.
 func (proc *consensusProcess) currentRole(ctx context.Context) role {
 	logger := proc.WithContext(ctx).WithFields(proc.layer)
-	proof, err := proc.oracle.Proof(ctx, proc.layer, proc.getRound())
+	proof, err := proc.oracle.Proof(ctx, proc.signer.VRFSigner(), proc.layer, proc.getRound())
 	if err != nil {
 		logger.With().Error("failed to get eligibility proof from oracle", log.Err(err))
 		return passive

--- a/hare/algorithm_test.go
+++ b/hare/algorithm_test.go
@@ -240,7 +240,7 @@ func TestConsensusProcess_eventLoop(t *testing.T) {
 
 	mo := mocks.NewMockRolacle(gomock.NewController(t))
 	mo.EXPECT().IsIdentityActiveOnConsensusView(gomock.Any(), gomock.Any(), proc.layer).Return(true, nil).Times(1)
-	mo.EXPECT().Proof(gomock.Any(), proc.layer, proc.getRound()).Return(types.EmptyVrfSignature, nil).Times(2)
+	mo.EXPECT().Proof(gomock.Any(), proc.signer.VRFSigner(), proc.layer, proc.getRound()).Return(types.EmptyVrfSignature, nil).Times(2)
 	mo.EXPECT().CalcEligibility(gomock.Any(), proc.layer, proc.getRound(), gomock.Any(), proc.nid, gomock.Any()).Return(uint16(1), nil).Times(1)
 	proc.oracle = mo
 	proc.value = NewSetFromValues(types.ProposalID{1}, types.ProposalID{2})
@@ -265,7 +265,7 @@ func TestConsensusProcess_StartAndStop(t *testing.T) {
 
 	mo := mocks.NewMockRolacle(gomock.NewController(t))
 	mo.EXPECT().IsIdentityActiveOnConsensusView(gomock.Any(), gomock.Any(), proc.layer).Return(true, nil).AnyTimes()
-	mo.EXPECT().Proof(gomock.Any(), gomock.Any(), gomock.Any()).Return(types.EmptyVrfSignature, nil).AnyTimes()
+	mo.EXPECT().Proof(gomock.Any(), proc.signer.VRFSigner(), gomock.Any(), gomock.Any()).Return(types.EmptyVrfSignature, nil).AnyTimes()
 	mo.EXPECT().CalcEligibility(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), proc.nid, gomock.Any()).Return(uint16(1), nil).AnyTimes()
 	proc.oracle = mo
 
@@ -411,7 +411,7 @@ func TestConsensusProcess_isEligible_NotEligible(t *testing.T) {
 	mo := mocks.NewMockRolacle(ctrl)
 	proc.oracle = mo
 
-	mo.EXPECT().Proof(gomock.Any(), proc.layer, proc.getRound()).Return(types.EmptyVrfSignature, nil).Times(1)
+	mo.EXPECT().Proof(gomock.Any(), proc.signer.VRFSigner(), proc.layer, proc.getRound()).Return(types.EmptyVrfSignature, nil).Times(1)
 	mo.EXPECT().IsIdentityActiveOnConsensusView(gomock.Any(), gomock.Any(), proc.layer).Return(true, nil).Times(1)
 	mo.EXPECT().CalcEligibility(gomock.Any(), proc.layer, proc.getRound(), gomock.Any(), proc.nid, gomock.Any()).Return(uint16(0), nil).Times(1)
 	require.False(t, proc.shouldParticipate(context.Background()))
@@ -424,7 +424,7 @@ func TestConsensusProcess_isEligible_Eligible(t *testing.T) {
 	mo := mocks.NewMockRolacle(ctrl)
 	proc.oracle = mo
 
-	mo.EXPECT().Proof(gomock.Any(), proc.layer, proc.getRound()).Return(types.EmptyVrfSignature, nil).Times(1)
+	mo.EXPECT().Proof(gomock.Any(), proc.signer.VRFSigner(), proc.layer, proc.getRound()).Return(types.EmptyVrfSignature, nil).Times(1)
 	mo.EXPECT().IsIdentityActiveOnConsensusView(gomock.Any(), gomock.Any(), proc.layer).Return(true, nil).Times(1)
 	mo.EXPECT().CalcEligibility(gomock.Any(), proc.layer, proc.getRound(), gomock.Any(), proc.nid, gomock.Any()).Return(uint16(1), nil).Times(1)
 	require.True(t, proc.shouldParticipate(context.Background()))
@@ -631,7 +631,7 @@ func TestConsensusProcess_beginStatusRound(t *testing.T) {
 
 	mo := mocks.NewMockRolacle(ctrl)
 	mo.EXPECT().IsIdentityActiveOnConsensusView(gomock.Any(), gomock.Any(), proc.layer).Return(true, nil).Times(1)
-	mo.EXPECT().Proof(gomock.Any(), proc.layer, proc.getRound()).Return(types.EmptyVrfSignature, nil).Times(2)
+	mo.EXPECT().Proof(gomock.Any(), proc.signer.VRFSigner(), proc.layer, proc.getRound()).Return(types.EmptyVrfSignature, nil).Times(2)
 	mo.EXPECT().CalcEligibility(gomock.Any(), proc.layer, proc.getRound(), gomock.Any(), proc.nid, gomock.Any()).Return(uint16(1), nil).Times(1)
 	proc.oracle = mo
 
@@ -658,7 +658,7 @@ func TestConsensusProcess_beginProposalRound(t *testing.T) {
 
 	mo := mocks.NewMockRolacle(ctrl)
 	mo.EXPECT().IsIdentityActiveOnConsensusView(gomock.Any(), gomock.Any(), proc.layer).Return(true, nil).Times(1)
-	mo.EXPECT().Proof(gomock.Any(), proc.layer, proc.getRound()).Return(types.EmptyVrfSignature, nil).Times(2)
+	mo.EXPECT().Proof(gomock.Any(), proc.signer.VRFSigner(), proc.layer, proc.getRound()).Return(types.EmptyVrfSignature, nil).Times(2)
 	mo.EXPECT().CalcEligibility(gomock.Any(), proc.layer, proc.getRound(), gomock.Any(), proc.nid, gomock.Any()).Return(uint16(1), nil).Times(1)
 	proc.oracle = mo
 
@@ -694,7 +694,7 @@ func TestConsensusProcess_beginCommitRound(t *testing.T) {
 
 	preCommitTracker := proc.commitTracker
 	mo.EXPECT().IsIdentityActiveOnConsensusView(gomock.Any(), gomock.Any(), proc.layer).Return(true, nil).Times(1)
-	mo.EXPECT().Proof(gomock.Any(), proc.layer, proc.getRound()).Return(types.EmptyVrfSignature, nil).Times(1)
+	mo.EXPECT().Proof(gomock.Any(), proc.signer.VRFSigner(), proc.layer, proc.getRound()).Return(types.EmptyVrfSignature, nil).Times(1)
 	mo.EXPECT().CalcEligibility(gomock.Any(), proc.layer, proc.getRound(), gomock.Any(), proc.nid, gomock.Any()).Return(uint16(0), nil).Times(1)
 	proc.beginCommitRound(context.Background())
 	require.NotEqual(t, preCommitTracker, proc.commitTracker)
@@ -702,7 +702,7 @@ func TestConsensusProcess_beginCommitRound(t *testing.T) {
 	mpt.isConflicting = false
 	mpt.proposedSet = NewSetFromValues(types.ProposalID{1})
 	mo.EXPECT().IsIdentityActiveOnConsensusView(gomock.Any(), gomock.Any(), proc.layer).Return(true, nil).Times(1)
-	mo.EXPECT().Proof(gomock.Any(), proc.layer, proc.getRound()).Return(types.EmptyVrfSignature, nil).Times(2)
+	mo.EXPECT().Proof(gomock.Any(), proc.signer.VRFSigner(), proc.layer, proc.getRound()).Return(types.EmptyVrfSignature, nil).Times(2)
 	mo.EXPECT().CalcEligibility(gomock.Any(), proc.layer, proc.getRound(), gomock.Any(), proc.nid, gomock.Any()).Return(uint16(1), nil).Times(1)
 	proc.beginCommitRound(context.Background())
 	require.Equal(t, 1, network.getCount())

--- a/hare/eligibility/oracle.go
+++ b/hare/eligibility/oracle.go
@@ -72,7 +72,6 @@ type Oracle struct {
 
 	beacons        system.BeaconGetter
 	cdb            *datastore.CachedDB
-	vrfSigner      *signing.VRFSigner
 	vrfVerifier    vrfVerifier
 	layersPerEpoch uint32
 	cfg            config.Config
@@ -84,7 +83,6 @@ func New(
 	beacons system.BeaconGetter,
 	db *datastore.CachedDB,
 	vrfVerifier vrfVerifier,
-	vrfSigner *signing.VRFSigner,
 	layersPerEpoch uint32,
 	cfg config.Config,
 	logger log.Log,
@@ -98,7 +96,6 @@ func New(
 		beacons:        beacons,
 		cdb:            db,
 		vrfVerifier:    vrfVerifier,
-		vrfSigner:      vrfSigner,
 		layersPerEpoch: layersPerEpoch,
 		activesCache:   ac,
 		fallback:       map[types.EpochID][]types.ATXID{},
@@ -337,12 +334,12 @@ func (o *Oracle) CalcEligibility(
 }
 
 // Proof returns the role proof for the current Layer & Round.
-func (o *Oracle) Proof(ctx context.Context, layer types.LayerID, round uint32) (types.VrfSignature, error) {
+func (o *Oracle) Proof(ctx context.Context, signer *signing.VRFSigner, layer types.LayerID, round uint32) (types.VrfSignature, error) {
 	beacon, err := o.beacons.GetBeacon(layer.GetEpoch())
 	if err != nil {
 		return types.EmptyVrfSignature, fmt.Errorf("get beacon: %w", err)
 	}
-	return o.GenVRF(ctx, o.vrfSigner, beacon, layer, round), nil
+	return o.GenVRF(ctx, signer, beacon, layer, round), nil
 }
 
 // GenVRF generates vrf for hare eligibility.

--- a/hare/eligibility/oracle.go
+++ b/hare/eligibility/oracle.go
@@ -339,11 +339,11 @@ func (o *Oracle) Proof(ctx context.Context, signer *signing.VRFSigner, layer typ
 	if err != nil {
 		return types.EmptyVrfSignature, fmt.Errorf("get beacon: %w", err)
 	}
-	return o.GenVRF(ctx, signer, beacon, layer, round), nil
+	return GenVRF(ctx, signer, beacon, layer, round), nil
 }
 
 // GenVRF generates vrf for hare eligibility.
-func (o *Oracle) GenVRF(ctx context.Context, signer *signing.VRFSigner, beacon types.Beacon, layer types.LayerID, round uint32) types.VrfSignature {
+func GenVRF(ctx context.Context, signer *signing.VRFSigner, beacon types.Beacon, layer types.LayerID, round uint32) types.VrfSignature {
 	return signer.Sign(codec.MustEncode(&VrfMessage{Type: types.EligibilityHare, Beacon: beacon, Round: round, Layer: layer}))
 }
 

--- a/hare/flows_test.go
+++ b/hare/flows_test.go
@@ -286,7 +286,7 @@ func Test_multipleCPs(t *testing.T) {
 		pubsubs = append(pubsubs, ps)
 		h := createTestHare(t, meshes[i], cfg, test.clock, ps, t.Name())
 		h.mockRoracle.EXPECT().IsIdentityActiveOnConsensusView(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).AnyTimes()
-		h.mockRoracle.EXPECT().Proof(gomock.Any(), gomock.Any(), gomock.Any()).Return(types.EmptyVrfSignature, nil).AnyTimes()
+		h.mockRoracle.EXPECT().Proof(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(types.EmptyVrfSignature, nil).AnyTimes()
 		h.mockRoracle.EXPECT().CalcEligibility(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(uint16(1), nil).AnyTimes()
 		h.mockRoracle.EXPECT().Validate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).AnyTimes()
 		h.mockCoin.EXPECT().Set(gomock.Any(), gomock.Any()).AnyTimes()
@@ -405,7 +405,7 @@ func Test_multipleCPsAndIterations(t *testing.T) {
 		mp2p := &p2pManipulator{nd: ps, stalledLayer: types.GetEffectiveGenesis().Add(1), err: errors.New("fake err")}
 		h := createTestHare(t, meshes[i], cfg, test.clock, mp2p, t.Name())
 		h.mockRoracle.EXPECT().IsIdentityActiveOnConsensusView(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).AnyTimes()
-		h.mockRoracle.EXPECT().Proof(gomock.Any(), gomock.Any(), gomock.Any()).Return(types.EmptyVrfSignature, nil).AnyTimes()
+		h.mockRoracle.EXPECT().Proof(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(types.EmptyVrfSignature, nil).AnyTimes()
 		h.mockRoracle.EXPECT().CalcEligibility(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(uint16(1), nil).AnyTimes()
 		h.mockRoracle.EXPECT().Validate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).AnyTimes()
 		h.mockCoin.EXPECT().Set(gomock.Any(), gomock.Any()).AnyTimes()

--- a/hare/hare_rounds_test.go
+++ b/hare/hare_rounds_test.go
@@ -97,7 +97,7 @@ func runNodesFor(t *testing.T, ctx context.Context, nodes, leaders, maxLayers, l
 
 		th := &testHare{createTestHare(t, mockMesh, cfg, w.clock, mp2p, t.Name()), i}
 		th.mockRoracle.EXPECT().IsIdentityActiveOnConsensusView(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).AnyTimes()
-		th.mockRoracle.EXPECT().Proof(gomock.Any(), gomock.Any(), gomock.Any()).Return(types.EmptyVrfSignature, nil).AnyTimes()
+		th.mockRoracle.EXPECT().Proof(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(types.EmptyVrfSignature, nil).AnyTimes()
 		th.mockRoracle.EXPECT().CalcEligibility(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
 			func(_ context.Context, layer types.LayerID, round uint32, committeeSize int, id types.NodeID, sig types.VrfSignature) (uint16, error) {
 				return oracle(layer, round, committeeSize, id, sig, th)

--- a/hare/interfaces.go
+++ b/hare/interfaces.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/datastore"
+	"github.com/spacemeshos/go-spacemesh/signing"
 )
 
 //go:generate mockgen -typed -package=mocks -destination=./mocks/mocks.go -source=./interfaces.go
@@ -17,7 +18,7 @@ type layerPatrol interface {
 type Rolacle interface {
 	Validate(context.Context, types.LayerID, uint32, int, types.NodeID, types.VrfSignature, uint16) (bool, error)
 	CalcEligibility(context.Context, types.LayerID, uint32, int, types.NodeID, types.VrfSignature) (uint16, error)
-	Proof(context.Context, types.LayerID, uint32) (types.VrfSignature, error)
+	Proof(context.Context, *signing.VRFSigner, types.LayerID, uint32) (types.VrfSignature, error)
 	IsIdentityActiveOnConsensusView(context.Context, types.NodeID, types.LayerID) (bool, error)
 }
 

--- a/hare/mocks/mocks.go
+++ b/hare/mocks/mocks.go
@@ -14,6 +14,7 @@ import (
 
 	types "github.com/spacemeshos/go-spacemesh/common/types"
 	datastore "github.com/spacemeshos/go-spacemesh/datastore"
+	signing "github.com/spacemeshos/go-spacemesh/signing"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -178,18 +179,18 @@ func (c *RolacleIsIdentityActiveOnConsensusViewCall) DoAndReturn(f func(context.
 }
 
 // Proof mocks base method.
-func (m *MockRolacle) Proof(arg0 context.Context, arg1 types.LayerID, arg2 uint32) (types.VrfSignature, error) {
+func (m *MockRolacle) Proof(arg0 context.Context, arg1 *signing.VRFSigner, arg2 types.LayerID, arg3 uint32) (types.VrfSignature, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Proof", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "Proof", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(types.VrfSignature)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Proof indicates an expected call of Proof.
-func (mr *MockRolacleMockRecorder) Proof(arg0, arg1, arg2 any) *RolacleProofCall {
+func (mr *MockRolacleMockRecorder) Proof(arg0, arg1, arg2, arg3 any) *RolacleProofCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Proof", reflect.TypeOf((*MockRolacle)(nil).Proof), arg0, arg1, arg2)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Proof", reflect.TypeOf((*MockRolacle)(nil).Proof), arg0, arg1, arg2, arg3)
 	return &RolacleProofCall{Call: call}
 }
 
@@ -205,13 +206,13 @@ func (c *RolacleProofCall) Return(arg0 types.VrfSignature, arg1 error) *RolacleP
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *RolacleProofCall) Do(f func(context.Context, types.LayerID, uint32) (types.VrfSignature, error)) *RolacleProofCall {
+func (c *RolacleProofCall) Do(f func(context.Context, *signing.VRFSigner, types.LayerID, uint32) (types.VrfSignature, error)) *RolacleProofCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *RolacleProofCall) DoAndReturn(f func(context.Context, types.LayerID, uint32) (types.VrfSignature, error)) *RolacleProofCall {
+func (c *RolacleProofCall) DoAndReturn(f func(context.Context, *signing.VRFSigner, types.LayerID, uint32) (types.VrfSignature, error)) *RolacleProofCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/hare3/hare_test.go
+++ b/hare3/hare_test.go
@@ -188,7 +188,7 @@ func (n *node) withOracle() *node {
 	beaconget.EXPECT().GetBeacon(gomock.Any()).DoAndReturn(func(epoch types.EpochID) (types.Beacon, error) {
 		return beacons.Get(n.db, epoch)
 	}).AnyTimes()
-	n.oracle = eligibility.New(beaconget, n.db, signing.NewVRFVerifier(), n.vrfsigner, layersPerEpoch, config.DefaultConfig(), log.NewNop())
+	n.oracle = eligibility.New(beaconget, n.db, signing.NewVRFVerifier(), layersPerEpoch, config.DefaultConfig(), log.NewNop())
 	return n
 }
 

--- a/hare3/legacy_oracle.go
+++ b/hare3/legacy_oracle.go
@@ -14,7 +14,6 @@ import (
 type oracle interface {
 	Validate(context.Context, types.LayerID, uint32, int, types.NodeID, types.VrfSignature, uint16) (bool, error)
 	CalcEligibility(context.Context, types.LayerID, uint32, int, types.NodeID, types.VrfSignature) (uint16, error)
-	GenVRF(context.Context, *signing.VRFSigner, types.Beacon, types.LayerID, uint32) types.VrfSignature
 }
 
 type legacyOracle struct {
@@ -45,7 +44,7 @@ func (lg *legacyOracle) validate(msg *Message) grade {
 }
 
 func (lg *legacyOracle) active(signer *signing.EdSigner, beacon types.Beacon, layer types.LayerID, ir IterRound) *types.HareEligibility {
-	vrf := lg.oracle.GenVRF(context.Background(), signer.VRFSigner(), beacon, layer, ir.Absolute())
+	vrf := eligibility.GenVRF(context.Background(), signer.VRFSigner(), beacon, layer, ir.Absolute())
 	committee := int(lg.config.Committee)
 	if ir.Round == propose {
 		committee = int(lg.config.Leaders)

--- a/node/node.go
+++ b/node/node.go
@@ -546,7 +546,6 @@ func (app *App) SetLogLevel(name, loglevel string) error {
 }
 
 func (app *App) initServices(ctx context.Context) error {
-	vrfSigner := app.edSgn.VRFSigner()
 	layerSize := app.Config.LayerAvgSize
 	layersPerEpoch := types.GetLayersPerEpoch()
 	lg := app.log.Named(app.edSgn.NodeID().ShortString()).WithFields(app.edSgn.NodeID())
@@ -760,7 +759,6 @@ func (app *App) initServices(ctx context.Context) error {
 		beaconProtocol,
 		app.cachedDB,
 		vrfVerifier,
-		vrfSigner,
 		app.Config.LayersPerEpoch,
 		app.Config.HareEligibility,
 		app.addLogger(HareOracleLogger, lg),
@@ -779,8 +777,6 @@ func (app *App) initServices(ctx context.Context) error {
 	app.certifier = blocks.NewCertifier(
 		app.cachedDB,
 		app.hOracle,
-		app.edSgn.NodeID(),
-		app.edSgn,
 		app.edVerifier,
 		app.host,
 		app.clock,
@@ -794,6 +790,7 @@ func (app *App) initServices(ctx context.Context) error {
 		}),
 		blocks.WithCertifierLogger(app.addLogger(BlockCertLogger, lg)),
 	)
+	app.certifier.Register(app.edSgn)
 
 	flog := app.addLogger(Fetcher, lg)
 	fetcher := fetch.NewFetch(app.cachedDB, msh, beaconProtocol, app.host,


### PR DESCRIPTION
Closes #5086 

## Changes
- `Certifier` keeps a set of signers
- removed signer from the hare Oracle. It now takes vrf signer as an argument to `Proof()` method
- removed logging from `CertifyIfEligible` in favor of returning context-rich errors, which are logged up the stack

## Test Plan
- existing tests for `CertifyIfElligible` were extended to use many (3) signers
- each signer must publish a block certification message
