### PR TITLE
[Merged by Bors] - Add Info request to post client

### DIFF
--- a/activation/interface.go
+++ b/activation/interface.go
@@ -105,5 +105,6 @@ type postService interface {
 }
 
 type PostClient interface {
+	Info(ctx context.Context) (*types.PostInfo, error)
 	Proof(ctx context.Context, challenge []byte) (*types.Post, *types.PostMetadata, error)
 }

--- a/activation/mocks.go
+++ b/activation/mocks.go
@@ -1888,6 +1888,45 @@ func (m *MockPostClient) EXPECT() *MockPostClientMockRecorder {
 	return m.recorder
 }
 
+// Info mocks base method.
+func (m *MockPostClient) Info(ctx context.Context) (*types.PostInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Info", ctx)
+	ret0, _ := ret[0].(*types.PostInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Info indicates an expected call of Info.
+func (mr *MockPostClientMockRecorder) Info(ctx any) *PostClientInfoCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Info", reflect.TypeOf((*MockPostClient)(nil).Info), ctx)
+	return &PostClientInfoCall{Call: call}
+}
+
+// PostClientInfoCall wrap *gomock.Call
+type PostClientInfoCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *PostClientInfoCall) Return(arg0 *types.PostInfo, arg1 error) *PostClientInfoCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *PostClientInfoCall) Do(f func(context.Context) (*types.PostInfo, error)) *PostClientInfoCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *PostClientInfoCall) DoAndReturn(f func(context.Context) (*types.PostInfo, error)) *PostClientInfoCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // Proof mocks base method.
 func (m *MockPostClient) Proof(ctx context.Context, challenge []byte) (*types.Post, *types.PostMetadata, error) {
 	m.ctrl.T.Helper()

--- a/api/grpcserver/post_client.go
+++ b/api/grpcserver/post_client.go
@@ -29,81 +29,131 @@ func newPostClient(con chan<- postCommand) *postClient {
 	}
 }
 
+func (pc *postClient) Info(ctx context.Context) (*types.PostInfo, error) {
+	req := &pb.NodeRequest{
+		Kind: &pb.NodeRequest_Metadata{
+			Metadata: &pb.MetadataRequest{},
+		},
+	}
+	resp, err := pc.send(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	metadataResp := resp.GetMetadata()
+	if metadataResp == nil {
+		return nil, fmt.Errorf("unexpected response of type: %T", resp.GetKind())
+	}
+	meta := metadataResp.GetMeta()
+	if meta == nil {
+		return nil, fmt.Errorf("post metadata is nil")
+	}
+	var nonce *types.VRFPostIndex
+	if meta.Nonce != nil {
+		nonce = new(types.VRFPostIndex)
+		*nonce = types.VRFPostIndex(meta.GetNonce())
+	}
+	return &types.PostInfo{
+		NodeID:        types.BytesToNodeID(meta.GetNodeId()),
+		CommitmentATX: types.BytesToATXID(meta.GetCommitmentAtxId()),
+		Nonce:         nonce,
+
+		NumUnits:      meta.GetNumUnits(),
+		LabelsPerUnit: meta.GetLabelsPerUnit(),
+	}, nil
+}
+
 func (pc *postClient) Proof(ctx context.Context, challenge []byte) (*types.Post, *types.PostMetadata, error) {
-	resp := make(chan *pb.ServiceResponse, 1)
-	cmd := postCommand{
-		req: &pb.NodeRequest{
-			Kind: &pb.NodeRequest_GenProof{
-				GenProof: &pb.GenProofRequest{
-					Challenge: challenge,
-				},
+	req := &pb.NodeRequest{
+		Kind: &pb.NodeRequest_GenProof{
+			GenProof: &pb.GenProofRequest{
+				Challenge: challenge,
 			},
 		},
+	}
+
+	var proofResp *pb.GenProofResponse
+	for {
+		resp, err := pc.send(ctx, req)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		proofResp = resp.GetGenProof()
+		if proofResp == nil {
+			return nil, nil, fmt.Errorf("unexpected response of type: %T", resp.GetKind())
+		}
+
+		switch proofResp.GetStatus() {
+		case pb.GenProofStatus_GEN_PROOF_STATUS_ERROR:
+			return nil, nil, fmt.Errorf("error generating proof: %s", proofResp)
+		case pb.GenProofStatus_GEN_PROOF_STATUS_UNSPECIFIED:
+			return nil, nil, fmt.Errorf("unspecified error generating proof: %s", proofResp)
+		case pb.GenProofStatus_GEN_PROOF_STATUS_OK:
+		default:
+			return nil, nil, fmt.Errorf("unknown status: %s", proofResp)
+		}
+
+		if proofResp.GetProof() != nil {
+			break
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, nil, ctx.Err()
+		case <-time.After(2 * time.Second):
+			// TODO(mafa): make polling interval configurable
+			continue
+		}
+	}
+
+	proof := proofResp.GetProof()
+	metaData := proofResp.GetMetadata()
+	if metaData == nil {
+		return nil, nil, fmt.Errorf("proof metadata is nil")
+	}
+	if !bytes.Equal(metaData.GetChallenge(), challenge) {
+		return nil, nil, fmt.Errorf("unexpected challenge: %x", metaData.GetChallenge())
+	}
+	proofMeta := metaData.GetMeta()
+	if proofMeta == nil {
+		return nil, nil, fmt.Errorf("post metadata is nil")
+	}
+	post := &types.Post{
+		Nonce:   proof.GetNonce(),
+		Indices: proof.GetIndices(),
+		Pow:     proof.GetPow(),
+	}
+	postMeta := &types.PostMetadata{
+		Challenge:     metaData.GetChallenge(),
+		LabelsPerUnit: proofMeta.GetLabelsPerUnit(),
+	}
+	return post, postMeta, nil
+}
+
+func (pc *postClient) send(ctx context.Context, req *pb.NodeRequest) (*pb.ServiceResponse, error) {
+	resp := make(chan *pb.ServiceResponse, 1)
+	cmd := postCommand{
+		req:  req,
 		resp: resp,
 	}
 
-	for {
-		// send command
-		select {
-		case <-pc.closed:
-			return nil, nil, fmt.Errorf("post client closed")
-		case <-ctx.Done():
-			return nil, nil, ctx.Err()
-		case pc.con <- cmd:
-		}
+	// send command
+	select {
+	case <-pc.closed:
+		return nil, fmt.Errorf("post client closed")
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case pc.con <- cmd:
+	}
 
-		// receive response
-		select {
-		case <-pc.closed:
-			return nil, nil, fmt.Errorf("post client closed")
-		case <-ctx.Done():
-			return nil, nil, ctx.Err()
-		case resp := <-resp:
-			proofResp := resp.GetGenProof()
-			if proofResp == nil {
-				return nil, nil, fmt.Errorf("unexpected response of type: %T", resp.GetKind())
-			}
-			switch proofResp.GetStatus() {
-			case pb.GenProofStatus_GEN_PROOF_STATUS_OK:
-				if proofResp.GetProof() == nil {
-					select {
-					case <-ctx.Done():
-						return nil, nil, ctx.Err()
-					case <-time.After(2 * time.Second):
-						// TODO(mafa): make polling interval configurable
-						continue
-					}
-				}
-
-				proof := proofResp.GetProof()
-				proofMeta := proofResp.GetMetadata()
-				if proofMeta == nil {
-					return nil, nil, fmt.Errorf("proof metadata is nil")
-				}
-
-				if !bytes.Equal(proofMeta.GetChallenge(), challenge) {
-					return nil, nil, fmt.Errorf("unexpected challenge: %x", proofMeta.GetChallenge())
-				}
-
-				postMeta := proofMeta.GetMeta()
-				if postMeta == nil {
-					return nil, nil, fmt.Errorf("post metadata is nil")
-				}
-
-				return &types.Post{
-						Nonce:   proof.GetNonce(),
-						Indices: proof.GetIndices(),
-						Pow:     proof.GetPow(),
-					}, &types.PostMetadata{
-						Challenge:     proofMeta.GetChallenge(),
-						LabelsPerUnit: postMeta.GetLabelsPerUnit(),
-					}, nil
-			case pb.GenProofStatus_GEN_PROOF_STATUS_ERROR:
-				return nil, nil, fmt.Errorf("error generating proof: %s", proofResp)
-			case pb.GenProofStatus_GEN_PROOF_STATUS_UNSPECIFIED:
-				return nil, nil, fmt.Errorf("unspecified error generating proof: %s", proofResp)
-			}
-		}
+	// receive response
+	select {
+	case <-pc.closed:
+		return nil, fmt.Errorf("post client closed")
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case resp := <-resp:
+		return resp, nil
 	}
 }
 

--- a/api/grpcserver/post_client.go
+++ b/api/grpcserver/post_client.go
@@ -107,14 +107,14 @@ func (pc *postClient) Proof(ctx context.Context, challenge []byte) (*types.Post,
 	}
 
 	proof := proofResp.GetProof()
-	metaData := proofResp.GetMetadata()
-	if metaData == nil {
+	metadata := proofResp.GetMetadata()
+	if metadata == nil {
 		return nil, nil, fmt.Errorf("proof metadata is nil")
 	}
-	if !bytes.Equal(metaData.GetChallenge(), challenge) {
-		return nil, nil, fmt.Errorf("unexpected challenge: %x", metaData.GetChallenge())
+	if !bytes.Equal(metadata.GetChallenge(), challenge) {
+		return nil, nil, fmt.Errorf("unexpected challenge: %x", metadata.GetChallenge())
 	}
-	proofMeta := metaData.GetMeta()
+	proofMeta := metadata.GetMeta()
 	if proofMeta == nil {
 		return nil, nil, fmt.Errorf("post metadata is nil")
 	}
@@ -124,7 +124,7 @@ func (pc *postClient) Proof(ctx context.Context, challenge []byte) (*types.Post,
 		Pow:     proof.GetPow(),
 	}
 	postMeta := &types.PostMetadata{
-		Challenge:     metaData.GetChallenge(),
+		Challenge:     metadata.GetChallenge(),
 		LabelsPerUnit: proofMeta.GetLabelsPerUnit(),
 	}
 	return post, postMeta, nil

--- a/common/types/post.go
+++ b/common/types/post.go
@@ -1,0 +1,11 @@
+package types
+
+// PostInfo contains information about the PoST as returned by the service.
+type PostInfo struct {
+	NodeID        NodeID
+	CommitmentATX ATXID
+	Nonce         *VRFPostIndex
+
+	NumUnits      uint32
+	LabelsPerUnit uint64
+}


### PR DESCRIPTION
## Motivation
Part of #5149 

This extends the `PostClient` to be able to fetch metadata about the PoST from the service

## Changes
- Add method to fetch metadata from PoST service

## Test Plan
- Tests were added for new functionality with and without TLS

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
