### PR TITLE
[Merged by Bors] - keep activesets for one more epoch

### DIFF
--- a/proposals/handler.go
+++ b/proposals/handler.go
@@ -463,7 +463,11 @@ func (h *Handler) checkBallotDataIntegrity(ctx context.Context, b *types.Ballot)
 		if b.EpochData.Beacon == types.EmptyBeacon {
 			return nil, errMissingBeacon
 		}
-		if b.Layer.GetEpoch() == h.clock.CurrentLayer().GetEpoch() {
+		epoch := h.clock.CurrentLayer().GetEpoch()
+		if epoch > 0 {
+			epoch-- // download activesets in the previous epoch too
+		}
+		if b.Layer.GetEpoch() >= epoch {
 			if err := h.fetcher.GetActiveSet(ctx, b.EpochData.ActiveSetHash); err != nil {
 				return nil, err
 			}

--- a/prune/prune.go
+++ b/prune/prune.go
@@ -85,7 +85,12 @@ func (p *Pruner) Prune(current types.LayerID) error {
 	propTxLatency.Observe(time.Since(start).Seconds())
 	if current.GetEpoch() > p.activesetEpoch {
 		start = time.Now()
-		if err := activesets.DeleteBeforeEpoch(p.db, current.GetEpoch()); err != nil {
+		epoch := current.GetEpoch()
+		if epoch > 0 {
+			epoch--
+		}
+		// current - 1 as activesets will be fetched in hare eligibility oracle
+		if err := activesets.DeleteBeforeEpoch(p.db, epoch); err != nil {
 			return err
 		}
 		activeSetLatency.Observe(time.Since(start).Seconds())

--- a/prune/prune.go
+++ b/prune/prune.go
@@ -91,7 +91,7 @@ func (p *Pruner) Prune(current types.LayerID) error {
 		}
 		// current - 1 as activesets will be fetched in hare eligibility oracle
 		// for example if we are in epoch 9, we want to prune 7 and below
-		// as activesets from 8 will be stil be needed at the beggining of epoch 8
+		// as activesets from 8 will be stil be needed at the beginning of epoch 8
 		if err := activesets.DeleteBeforeEpoch(p.db, epoch); err != nil {
 			return err
 		}

--- a/prune/prune.go
+++ b/prune/prune.go
@@ -90,6 +90,8 @@ func (p *Pruner) Prune(current types.LayerID) error {
 			epoch--
 		}
 		// current - 1 as activesets will be fetched in hare eligibility oracle
+		// for example if we are in epoch 9, we want to prune 7 and below
+		// as activesets from 8 will be stil be needed at the beggining of epoch 8
 		if err := activesets.DeleteBeforeEpoch(p.db, epoch); err != nil {
 			return err
 		}

--- a/prune/prune_test.go
+++ b/prune/prune_test.go
@@ -83,7 +83,7 @@ func TestPrune(t *testing.T) {
 	for epoch, epochSets := range sets {
 		for _, id := range epochSets {
 			_, err := activesets.Get(db, id)
-			if epoch >= current.GetEpoch() {
+			if epoch >= current.GetEpoch()-1 {
 				require.NoError(t, err)
 			} else {
 				require.ErrorIs(t, err, sql.ErrNotFound)

--- a/sql/migrations/0007_next.sql
+++ b/sql/migrations/0007_next.sql
@@ -1,2 +1,3 @@
 ALTER TABLE activesets ADD epoch INT DEFAULT 0 NOT NULL;
 CREATE INDEX activesets_by_epoch ON activesets (epoch asc);
+UPDATE activesets SET epoch = 7 WHERE epoch = 0;


### PR DESCRIPTION
activesets in epoch X are used during epoch X and at the start of epoch X + 1. therefore we should not prune them
immediately at the start of epoch X.