### PR TITLE
[Merged by Bors] - activation: Remove deprecated best provider option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,20 +39,28 @@ See [RELEASE](./RELEASE.md) for workflow instructions.
 
 * [#5171](https://github.com/spacemeshos/go-spacemesh/pull/5171) Set minimal active set according to the observed number of atxs.
 
-  It will prevent ballots that underreport observed atxs from spamming the network. It doesn't have impact on rewards.
+  It will prevent ballots that under report observed atxs from spamming the network. It doesn't have impact on rewards.
 
-* [#5169](https://github.com/spacemeshos/go-spacemesh/pull/5169) Support prunning activesets.
+* [#5169](https://github.com/spacemeshos/go-spacemesh/pull/5169) Support pruning activesets.
 
   As of epoch 6 activesets storage size is about ~1.5GB. They are not useful after verifying eligibilities
   for ballots in the current epoch and can be pruned.
 
   Pruning will be enabled starting from epoch 8, e.g in epoch 8 we will prune all activesets for epochs 7 and below.
   We should also run an archival node that doesn't prune them. To disable pruning we should configure
+  
   ```json
   "main": {
       "prune-activesets-from": 4294967295
   }
-  ``` 
+  ```
+
+* [#5189](https://github.com/spacemeshos/go-spacemesh/pull/5189) Removed deprecated "Best Provider" option for initialization.
+
+  With v1.1.0 (<https://github.com/spacemeshos/go-spacemesh/releases/tag/v1.1.0>) selecting `-1` as `smeshing-opts-provider` has been deprecated. This option has now been removed.
+  Nodes that already finished initialization can leave this setting empty, as it is not required any more to be set when no initialization is performed. For nodes that have not
+  yet created their initial proof the operator has to specify which provider to use. For Smapp users this is done automatically by Smapp, users that do not use Smapp may use
+  `postcli -printProviders` (<https://github.com/spacemeshos/post/releases>) to list their OpenCL providers and associated IDs.
 
 ## v1.2.0
 

--- a/activation/e2e/nipost_test.go
+++ b/activation/e2e/nipost_test.go
@@ -145,7 +145,7 @@ func TestNIPostBuilderWithClients(t *testing.T) {
 
 	opts := activation.DefaultPostSetupOpts()
 	opts.DataDir = t.TempDir()
-	opts.ProviderID.SetInt64(int64(initialization.CPUProviderID()))
+	opts.ProviderID.SetUint32(initialization.CPUProviderID())
 	opts.Scrypt.N = 2 // Speedup initialization in tests.
 	initPost(t, logger.Named("manager"), mgr, opts)
 
@@ -318,7 +318,7 @@ func TestNewNIPostBuilderNotInitialized(t *testing.T) {
 
 	opts := activation.DefaultPostSetupOpts()
 	opts.DataDir = t.TempDir()
-	opts.ProviderID.SetInt64(int64(initialization.CPUProviderID()))
+	opts.ProviderID.SetUint32(initialization.CPUProviderID())
 	opts.Scrypt.N = 2 // Speedup initialization in tests.
 	t.Cleanup(launchPostSupervisor(t, logger, grpcCfg, opts))
 

--- a/activation/e2e/validation_test.go
+++ b/activation/e2e/validation_test.go
@@ -39,7 +39,7 @@ func TestValidator_Validate(t *testing.T) {
 
 	opts := activation.DefaultPostSetupOpts()
 	opts.DataDir = t.TempDir()
-	opts.ProviderID.SetInt64(int64(initialization.CPUProviderID()))
+	opts.ProviderID.SetUint32(initialization.CPUProviderID())
 	opts.Scrypt.N = 2 // Speedup initialization in tests.
 	initPost(t, logger.Named("manager"), mgr, opts)
 

--- a/activation/post_test.go
+++ b/activation/post_test.go
@@ -103,17 +103,6 @@ func TestPostSetupManager_PrepareInitializer(t *testing.T) {
 	req.Error(mgr.PrepareInitializer(ctx, opts))
 }
 
-// TODO(mafa): remove, see https://github.com/spacemeshos/go-spacemesh/issues/4801
-func TestPostSetupManager_PrepareInitializer_BestProvider(t *testing.T) {
-	mgr := newTestPostManager(t)
-
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
-	defer cancel()
-
-	mgr.opts.ProviderID.SetInt64(-1)
-	require.NoError(t, mgr.PrepareInitializer(ctx, mgr.opts))
-}
-
 func TestPostSetupManager_StartSession_WithoutProvider_Error(t *testing.T) {
 	req := require.New(t)
 
@@ -341,14 +330,6 @@ func TestPostSetupManager_Providers_includesCPU(t *testing.T) {
 	require.Fail(t, "no CPU provider found")
 }
 
-func TestPostSetupManager_BestProvider(t *testing.T) {
-	mgr := newTestPostManager(t)
-
-	providers, err := mgr.bestProvider()
-	require.NoError(t, err)
-	require.NotNil(t, providers)
-}
-
 func TestPostSetupManager_Benchmark(t *testing.T) {
 	mgr := newTestPostManager(t)
 
@@ -410,7 +391,7 @@ func newTestPostManager(tb testing.TB) *testPostManager {
 
 	opts := DefaultPostSetupOpts()
 	opts.DataDir = tb.TempDir()
-	opts.ProviderID.SetInt64(int64(initialization.CPUProviderID()))
+	opts.ProviderID.SetUint32(initialization.CPUProviderID())
 	opts.Scrypt.N = 2 // Speedup initialization in tests.
 
 	goldenATXID := types.ATXID{2, 3, 4}

--- a/activation/post_types.go
+++ b/activation/post_types.go
@@ -38,7 +38,7 @@ func (d *PowDifficulty) UnmarshalText(text []byte) error {
 }
 
 type PostProviderID struct {
-	value *int64
+	value *uint32
 }
 
 // String implements pflag.Value.String.
@@ -61,23 +61,23 @@ func (id *PostProviderID) Set(value string) error {
 		return nil
 	}
 
-	i, err := strconv.ParseInt(value, 10, 33)
+	i, err := strconv.ParseUint(value, 10, 32)
 	if err != nil {
 		return fmt.Errorf("failed to parse PoST Provider ID (\"%s\"): %w", value, err)
 	}
 
-	id.value = new(int64)
-	*id.value = int64(i)
+	id.value = new(uint32)
+	*id.value = uint32(i)
 	return nil
 }
 
 // SetInt64 sets the value of the PostProviderID to the given int64.
-func (id *PostProviderID) SetInt64(value int64) {
+func (id *PostProviderID) SetUint32(value uint32) {
 	id.value = &value
 }
 
 // Value returns the value of the PostProviderID as a pointer to uint32.
-func (id *PostProviderID) Value() *int64 {
+func (id *PostProviderID) Value() *uint32 {
 	return id.value
 }
 

--- a/activation/post_types_test.go
+++ b/activation/post_types_test.go
@@ -49,7 +49,7 @@ func TestSettingProviderID(t *testing.T) {
 		t.Parallel()
 		id := new(PostProviderID)
 		require.NoError(t, id.Set("1234"))
-		require.Equal(t, int64(1234), *id.Value())
+		require.Equal(t, uint32(1234), *id.Value())
 	})
 	t.Run("no value", func(t *testing.T) {
 		t.Parallel()
@@ -63,13 +63,12 @@ func TestSettingProviderID(t *testing.T) {
 		require.Error(t, id.Set("asdf"))
 		require.Nil(t, id.Value())
 	})
-	// TODO(mafa): re-enable test, see https://github.com/spacemeshos/go-spacemesh/issues/4801
-	// t.Run("negative", func(t *testing.T) {
-	// 	t.Parallel()
-	// 	id := new(PostProviderID)
-	// 	require.Error(t, id.Set("-1"))
-	// 	require.Nil(t, id.Value())
-	// })
+	t.Run("negative", func(t *testing.T) {
+		t.Parallel()
+		id := new(PostProviderID)
+		require.Error(t, id.Set("-1"))
+		require.Nil(t, id.Value())
+	})
 }
 
 func TestSettingPostPowFlags(t *testing.T) {

--- a/activation/validation_test.go
+++ b/activation/validation_test.go
@@ -29,7 +29,7 @@ func Test_Validation_VRFNonce(t *testing.T) {
 
 	initOpts := DefaultPostSetupOpts()
 	initOpts.DataDir = t.TempDir()
-	initOpts.ProviderID.SetInt64(int64(initialization.CPUProviderID()))
+	initOpts.ProviderID.SetUint32(initialization.CPUProviderID())
 
 	nodeId := types.BytesToNodeID(make([]byte, 32))
 	commitmentAtxId := types.EmptyATXID

--- a/api/grpcserver/post_service_test.go
+++ b/api/grpcserver/post_service_test.go
@@ -241,7 +241,7 @@ func Test_Metadata(t *testing.T) {
 
 	opts := activation.DefaultPostSetupOpts()
 	opts.DataDir = t.TempDir()
-	opts.ProviderID.SetInt64(int64(initialization.CPUProviderID()))
+	opts.ProviderID.SetUint32(initialization.CPUProviderID())
 	opts.Scrypt.N = 2 // Speedup initialization in tests.
 	id, commitmentAtxId := initPost(t, log.Named("post"), opts)
 	postCleanup := launchPostSupervisor(t, log.Named("supervisor"), cfg, opts)

--- a/api/grpcserver/post_service_test.go
+++ b/api/grpcserver/post_service_test.go
@@ -120,7 +120,7 @@ func Test_GenerateProof(t *testing.T) {
 
 	opts := activation.DefaultPostSetupOpts()
 	opts.DataDir = t.TempDir()
-	opts.ProviderID.SetInt64(int64(initialization.CPUProviderID()))
+	opts.ProviderID.SetUint32(initialization.CPUProviderID())
 	opts.Scrypt.N = 2 // Speedup initialization in tests.
 	id, _ := initPost(t, log.Named("post"), opts)
 	postCleanup := launchPostSupervisor(t, log.Named("supervisor"), cfg, opts)
@@ -163,7 +163,7 @@ func Test_GenerateProof_TLS(t *testing.T) {
 
 	opts := activation.DefaultPostSetupOpts()
 	opts.DataDir = t.TempDir()
-	opts.ProviderID.SetInt64(int64(initialization.CPUProviderID()))
+	opts.ProviderID.SetUint32(initialization.CPUProviderID())
 	opts.Scrypt.N = 2 // Speedup initialization in tests.
 	id, _ := initPost(t, log.Named("post"), opts)
 	postCleanup := launchPostSupervisorTLS(t, log.Named("supervisor"), cfg, opts)
@@ -206,7 +206,7 @@ func Test_GenerateProof_Cancel(t *testing.T) {
 
 	opts := activation.DefaultPostSetupOpts()
 	opts.DataDir = t.TempDir()
-	opts.ProviderID.SetInt64(int64(initialization.CPUProviderID()))
+	opts.ProviderID.SetUint32(initialization.CPUProviderID())
 	opts.Scrypt.N = 2 // Speedup initialization in tests.
 	id, _ := initPost(t, log.Named("post"), opts)
 	t.Cleanup(launchPostSupervisor(t, log.Named("supervisor"), cfg, opts))
@@ -281,7 +281,7 @@ func Test_GenerateProof_MultipleServices(t *testing.T) {
 
 	opts := activation.DefaultPostSetupOpts()
 	opts.DataDir = t.TempDir()
-	opts.ProviderID.SetInt64(int64(initialization.CPUProviderID()))
+	opts.ProviderID.SetUint32(initialization.CPUProviderID())
 	opts.Scrypt.N = 2 // Speedup initialization in tests.
 
 	// all but one should not be able to register to the node (i.e. open a stream to it).

--- a/api/grpcserver/smesher_service.go
+++ b/api/grpcserver/smesher_service.go
@@ -91,7 +91,7 @@ func (s SmesherService) StartSmeshing(ctx context.Context, in *pb.StartSmeshingR
 	opts.NumUnits = in.Opts.NumUnits
 	opts.MaxFileSize = in.Opts.MaxFileSize
 	if in.Opts.ProviderId != nil {
-		opts.ProviderID.SetInt64(int64(*in.Opts.ProviderId))
+		opts.ProviderID.SetUint32(*in.Opts.ProviderId)
 	}
 	opts.Throttle = in.Opts.Throttle
 

--- a/api/grpcserver/smesher_service_test.go
+++ b/api/grpcserver/smesher_service_test.go
@@ -62,7 +62,7 @@ func TestStartSmeshingPassesCorrectSmeshingOpts(t *testing.T) {
 		Scrypt:           config.DefaultLabelParams(),
 		ComputeBatchSize: config.DefaultComputeBatchSize,
 	}
-	opts.ProviderID.SetInt64(int64(providerID))
+	opts.ProviderID.SetUint32(providerID)
 	postSupervisor.EXPECT().Start().Return(nil)
 	smeshingProvider.EXPECT().StartSmeshing(addr, opts).Return(nil)
 
@@ -148,7 +148,7 @@ func TestSmesherService_PostSetupStatus(t *testing.T) {
 		svc := grpcserver.NewSmesherService(postSetupProvider, smeshingProvider, postSupervisor, time.Second, activation.DefaultPostSetupOpts())
 
 		id := activation.PostProviderID{}
-		id.SetInt64(1)
+		id.SetUint32(1)
 		opts := activation.PostSetupOpts{
 			DataDir:     "data-dir",
 			NumUnits:    4,
@@ -180,7 +180,7 @@ func TestSmesherService_PostSetupStatus(t *testing.T) {
 		svc := grpcserver.NewSmesherService(postSetupProvider, smeshingProvider, postSupervisor, time.Second, activation.DefaultPostSetupOpts())
 
 		id := activation.PostProviderID{}
-		id.SetInt64(100)
+		id.SetUint32(100)
 		opts := activation.PostSetupOpts{
 			DataDir:     "data-dir",
 			NumUnits:    4,

--- a/config/presets/fastnet.go
+++ b/config/presets/fastnet.go
@@ -72,7 +72,7 @@ func fastnet() config.Config {
 	types.SetNetworkHRP(conf.NetworkHRP) // ensure that the correct HRP is set when generating the address below
 	conf.SMESHING.CoinbaseAccount = types.GenerateAddress([]byte("1")).String()
 	conf.SMESHING.Start = false
-	conf.SMESHING.Opts.ProviderID.SetInt64(int64(initialization.CPUProviderID()))
+	conf.SMESHING.Opts.ProviderID.SetUint32(initialization.CPUProviderID())
 	conf.SMESHING.Opts.NumUnits = 2
 	conf.SMESHING.Opts.ComputeBatchSize = 128
 	conf.SMESHING.Opts.Scrypt.N = 2 // faster scrypt

--- a/config/presets/standalone.go
+++ b/config/presets/standalone.go
@@ -58,7 +58,7 @@ func standalone() config.Config {
 	types.SetNetworkHRP(conf.NetworkHRP) // ensure that the correct HRP is set when generating the address below
 	conf.SMESHING.CoinbaseAccount = types.GenerateAddress([]byte("1")).String()
 	conf.SMESHING.Start = true
-	conf.SMESHING.Opts.ProviderID.SetInt64(int64(initialization.CPUProviderID()))
+	conf.SMESHING.Opts.ProviderID.SetUint32(initialization.CPUProviderID())
 	conf.SMESHING.Opts.NumUnits = 1
 	conf.SMESHING.Opts.Throttle = true
 	conf.SMESHING.Opts.DataDir = conf.DataDirParent

--- a/config/presets/testnet.go
+++ b/config/presets/testnet.go
@@ -35,7 +35,7 @@ func testnet() config.Config {
 	p2pconfig := p2p.DefaultConfig()
 
 	smeshing := config.DefaultSmeshingConfig()
-	smeshing.Opts.ProviderID.SetInt64(int64(initialization.CPUProviderID()))
+	smeshing.Opts.ProviderID.SetUint32(initialization.CPUProviderID())
 	smeshing.ProvingOpts.Nonces = 288
 	smeshing.ProvingOpts.Threads = uint(runtime.NumCPU() * 3 / 4)
 	if smeshing.ProvingOpts.Threads < 1 {

--- a/node/mapstructureutil/postproviderid.go
+++ b/node/mapstructureutil/postproviderid.go
@@ -20,12 +20,11 @@ func PostProviderIDDecodeFunc() mapstructure.DecodeHookFunc {
 		switch f.Kind() {
 		case reflect.Float64:
 			value := data.(float64)
-			// TODO(mafa): update check from `value < -1` to `value < 0`, see https://github.com/spacemeshos/go-spacemesh/issues/4801
-			if value > math.MaxUint32 || value < -1 || value != math.Trunc(value) {
+			if value > math.MaxUint32 || value < 0 || value != math.Trunc(value) {
 				return nil, fmt.Errorf("invalid provider ID value: %v", value)
 			}
 			id := activation.PostProviderID{}
-			id.SetInt64(int64(value))
+			id.SetUint32(uint32(value))
 			return id, nil
 		case reflect.String:
 			return nil, fmt.Errorf("invalid provider ID value: %v", data)

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -828,16 +828,7 @@ func TestConfig_CustomTypes(t *testing.T) {
 			cli:    "--smeshing-opts-provider=1337",
 			config: `{"smeshing": {"smeshing-opts": {"smeshing-opts-provider": 1337}}}`,
 			updatePreset: func(t *testing.T, c *config.Config) {
-				c.SMESHING.Opts.ProviderID.SetInt64(1337)
-			},
-		},
-		{
-			// TODO(mafa): remove this test case, see https://github.com/spacemeshos/go-spacemesh/issues/4801
-			name:   "smeshing-opts-provider",
-			cli:    "--smeshing-opts-provider=-1",
-			config: `{"smeshing": {"smeshing-opts": {"smeshing-opts-provider": -1}}}`,
-			updatePreset: func(t *testing.T, c *config.Config) {
-				c.SMESHING.Opts.ProviderID.SetInt64(-1)
+				c.SMESHING.Opts.ProviderID.SetUint32(1337)
 			},
 		},
 		{
@@ -946,12 +937,11 @@ func TestConfig_PostProviderID_InvalidValues(t *testing.T) {
 			cliValue:    "not-a-number",
 			configValue: "\"not-a-number\"",
 		},
-		// TODO(mafa): still accepted for backward compatibility, see https://github.com/spacemeshos/go-spacemesh/issues/4801
-		// {
-		// 	name:        "negative number",
-		// 	cliValue:    "-1",
-		// 	configValue: "-1",
-		// },
+		{
+			name:        "negative number",
+			cliValue:    "-1",
+			configValue: "-1",
+		},
 		{
 			name:        "number too large for uint32",
 			cliValue:    "4294967296",
@@ -1247,7 +1237,7 @@ func getTestDefaultConfig(tb testing.TB) *config.Config {
 	cfg.SMESHING = config.DefaultSmeshingConfig()
 	cfg.SMESHING.Start = true
 	cfg.SMESHING.Opts.NumUnits = cfg.POST.MinNumUnits + 1
-	cfg.SMESHING.Opts.ProviderID.SetInt64(int64(initialization.CPUProviderID()))
+	cfg.SMESHING.Opts.ProviderID.SetUint32(initialization.CPUProviderID())
 
 	// note: these need to be set sufficiently low enough that turbohare finishes well before the LayerDurationSec
 	cfg.HARE.RoundDuration = 2


### PR DESCRIPTION
## Motivation
Closes #4801

## Changes
- remove `-1` as option for `providerID`
- remove autobenchmarking

## Test Plan
- removed tests for autobenchmarking
- updated existing tests to reject `-1` as valid option for Provider ID

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
