### PR TITLE
Add ProcessExitGroup to ensure children are killed on exit

### DIFF
--- a/activation/post_supervisor.go
+++ b/activation/post_supervisor.go
@@ -228,7 +228,8 @@ func (ps *PostSupervisor) captureCmdOutput(pipe io.ReadCloser) func() error {
 func (ps *PostSupervisor) runCmd(ctx context.Context, cmdCfg PostSupervisorConfig, postCfg PostConfig, postOpts PostSetupOpts, provingOpts PostProvingOpts) error {
 	g, err := NewProcessExitGroup()
 	if err != nil {
-		return err
+		ps.logger.Fatal("process exit group", zap.Error(err))
+		return nil
 	}
 	defer g.Dispose()
 
@@ -268,14 +269,16 @@ func (ps *PostSupervisor) runCmd(ctx context.Context, cmdCfg PostSupervisorConfi
 		cmd.Dir = filepath.Dir(cmdCfg.PostServiceCmd)
 		pipe, err := cmd.StderrPipe()
 		if err != nil {
-			return fmt.Errorf("setup stderr pipe for post service: %w", err)
+			ps.logger.Error("setup stderr pipe for post service", zap.Error(err))
+			return nil
 		}
 
 		var eg errgroup.Group
 		eg.Go(ps.captureCmdOutput(pipe))
 		if err := g.StartCommand(cmd); err != nil {
 			pipe.Close()
-			return fmt.Errorf("start post service: %w", err)
+			ps.logger.Error("start post service", zap.Error(err))
+			return nil
 		}
 		ps.logger.Info("post service started", zap.Int("pid", cmd.Process.Pid), zap.String("cmd", cmd.String()))
 		ps.pid.Store(int64(cmd.Process.Pid))

--- a/activation/post_supervisor.go
+++ b/activation/post_supervisor.go
@@ -275,7 +275,7 @@ func (ps *PostSupervisor) runCmd(ctx context.Context, cmdCfg PostSupervisorConfi
 		eg.Go(ps.captureCmdOutput(pipe))
 		if err := g.StartCommand(cmd); err != nil {
 			pipe.Close()
-			return err
+			return fmt.Errorf("start post service: %w", err)
 		}
 		ps.logger.Info("post service started", zap.Int("pid", cmd.Process.Pid), zap.String("cmd", cmd.String()))
 		ps.pid.Store(int64(cmd.Process.Pid))

--- a/activation/post_supervisor_nix.go
+++ b/activation/post_supervisor_nix.go
@@ -2,4 +2,34 @@
 
 package activation
 
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+// DefaultPostServiceName is the default name of the post service executable.
 const DefaultPostServiceName = "service"
+
+// ProcessExitGroup holds references to processes that should be closed when the main process exits.
+type ProcessExitGroup struct{}
+
+// NewProcessExitGroup returns a new ProcessExitGroup.
+func NewProcessExitGroup() (ProcessExitGroup, error) {
+	return ProcessExitGroup{}, nil
+}
+
+// Dispose closes the ProcessExitGroup.
+func (g ProcessExitGroup) Dispose() error {
+	return nil
+}
+
+// StartCommand starts the given command and adds it to the ProcessExitGroup.
+func (g ProcessExitGroup) StartCommand(cmd *exec.Cmd) error {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true, Pgid: os.Getpid()}
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start post service: %w", err)
+	}
+	return nil
+}

--- a/activation/post_supervisor_nix.go
+++ b/activation/post_supervisor_nix.go
@@ -26,6 +26,10 @@ func (g ProcessExitGroup) Dispose() error {
 
 // StartCommand starts the given command and adds it to the ProcessExitGroup.
 func (g ProcessExitGroup) StartCommand(cmd *exec.Cmd) error {
+	// Note: this doesn't actually ensure that the child process will be killed when the
+	// parent process is killed, it only assigns it the same process group ID.
+	//
+	// Getting the same behavior on Linux and Mac requires the child process to listen
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true, Pgid: os.Getpid()}
 	if err := cmd.Start(); err != nil {
 		return err

--- a/activation/post_supervisor_nix.go
+++ b/activation/post_supervisor_nix.go
@@ -3,7 +3,6 @@
 package activation
 
 import (
-	"fmt"
 	"os"
 	"os/exec"
 	"syscall"
@@ -29,7 +28,7 @@ func (g ProcessExitGroup) Dispose() error {
 func (g ProcessExitGroup) StartCommand(cmd *exec.Cmd) error {
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true, Pgid: os.Getpid()}
 	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("start post service: %w", err)
+		return err
 	}
 	return nil
 }

--- a/activation/post_supervisor_win.go
+++ b/activation/post_supervisor_win.go
@@ -12,7 +12,7 @@ import (
 // DefaultPostServiceName is the default name of the post service executable.
 const DefaultPostServiceName = "service.exe"
 
-// process is used to retrieve process information from the handle in an unsafe way.
+// process is used to retrieve the process handle from the process ID in an unsafe way.
 type process struct {
 	Pid    int
 	Handle uintptr

--- a/activation/post_supervisor_win.go
+++ b/activation/post_supervisor_win.go
@@ -3,7 +3,6 @@
 package activation
 
 import (
-	"fmt"
 	"os/exec"
 	"unsafe"
 
@@ -53,7 +52,7 @@ func (g ProcessExitGroup) Dispose() error {
 // StartCommand starts the given command and adds it to the ProcessExitGroup.
 func (g ProcessExitGroup) StartCommand(cmd *exec.Cmd) error {
 	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("start post service: %w", err)
+		return err
 	}
 	return windows.AssignProcessToJobObject(
 		windows.Handle(g),

--- a/activation/post_supervisor_win.go
+++ b/activation/post_supervisor_win.go
@@ -2,4 +2,61 @@
 
 package activation
 
+import (
+	"fmt"
+	"os/exec"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// DefaultPostServiceName is the default name of the post service executable.
 const DefaultPostServiceName = "service.exe"
+
+// process is used to retrieve process information from the handle in an unsafe way.
+type process struct {
+	Pid    int
+	Handle uintptr
+}
+
+// ProcessExitGroup holds references to processes that should be closed when the main process exits.
+type ProcessExitGroup windows.Handle
+
+// NewProcessExitGroup returns a new ProcessExitGroup.
+func NewProcessExitGroup() (ProcessExitGroup, error) {
+	handle, err := windows.CreateJobObject(nil, nil)
+	if err != nil {
+		return 0, err
+	}
+
+	info := windows.JOBOBJECT_EXTENDED_LIMIT_INFORMATION{
+		BasicLimitInformation: windows.JOBOBJECT_BASIC_LIMIT_INFORMATION{
+			LimitFlags: windows.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+		},
+	}
+	if _, err := windows.SetInformationJobObject(
+		handle,
+		windows.JobObjectExtendedLimitInformation,
+		uintptr(unsafe.Pointer(&info)),
+		uint32(unsafe.Sizeof(info))); err != nil {
+		return 0, err
+	}
+
+	return ProcessExitGroup(handle), nil
+}
+
+// Dispose closes the ProcessExitGroup.
+func (g ProcessExitGroup) Dispose() error {
+	return windows.CloseHandle(windows.Handle(g))
+}
+
+// StartCommand starts the given command and adds it to the ProcessExitGroup.
+func (g ProcessExitGroup) StartCommand(cmd *exec.Cmd) error {
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start post service: %w", err)
+	}
+	return windows.AssignProcessToJobObject(
+		windows.Handle(g),
+		windows.Handle((*process)(unsafe.Pointer(cmd.Process)).Handle),
+	)
+}

--- a/go.mod
+++ b/go.mod
@@ -51,6 +51,7 @@ require (
 	go.uber.org/zap v1.26.0
 	golang.org/x/exp v0.0.0-20231006140011-7918f672742d
 	golang.org/x/sync v0.4.0
+	golang.org/x/sys v0.13.0
 	golang.org/x/time v0.3.0
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20231016165738-49dd2c1f3d0b
 	google.golang.org/grpc v1.59.0
@@ -203,7 +204,6 @@ require (
 	golang.org/x/mod v0.13.0 // indirect
 	golang.org/x/net v0.17.0 // indirect
 	golang.org/x/oauth2 v0.12.0 // indirect
-	golang.org/x/sys v0.13.0 // indirect
 	golang.org/x/term v0.13.0 // indirect
 	golang.org/x/text v0.13.0 // indirect
 	golang.org/x/tools v0.14.0 // indirect


### PR DESCRIPTION
## Motivation
If the node exits unexpectedly or is killed with `SIGKILL` instead of `SIGTERM` it will not kill post services that it spawned.

This PR fixes this by adding a job object that kills processes assigned to it on close. For information on how this works see the official Microsoft documentation on job objects: https://learn.microsoft.com/en-us/windows/win32/api/jobapi2/nf-jobapi2-assignprocesstojobobject and https://learn.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-jobobject_basic_limit_information

## Changes
- On windows `ProcessExitGroup` adds the new process to a job object (itself) and ensures that they are closed when itself is closed
- On other systems the ProcessExitGroup only ensures that new processes are in the same process group as the main process.

For windows this ensures that if the main process crashes / is killed all commands started through the `ProcessExitGroup` will be killed as well. On other systems this is only true for crashes. Killing the node with `kill -9` will not cause the child processes to exit automatically. For this they have to listen to signals about their parent and close themselves.

## Test Plan
- n/a

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
