### PR TITLE
[Merged by Bors] - Remove nodeid from nipostbuilder

### DIFF
--- a/activation/e2e/nipost_test.go
+++ b/activation/e2e/nipost_test.go
@@ -167,7 +167,6 @@ func TestNIPostBuilderWithClients(t *testing.T) {
 	}, 10*time.Second, 100*time.Millisecond, "timed out waiting for connection")
 
 	nb, err := activation.NewNIPostBuilder(
-		sig.NodeID(),
 		poetDb,
 		svc,
 		[]string{poetProver.RestURL().String()},
@@ -221,7 +220,6 @@ func TestNIPostBuilder_Close(t *testing.T) {
 	svc := grpcserver.NewPostService(logger)
 
 	nb, err := activation.NewNIPostBuilder(
-		sig.NodeID(),
 		poetDb,
 		svc,
 		[]string{poetProver.RestURL().String()},
@@ -284,7 +282,6 @@ func TestNewNIPostBuilderNotInitialized(t *testing.T) {
 	t.Cleanup(cleanup)
 
 	nb, err := activation.NewNIPostBuilder(
-		sig.NodeID(),
 		poetDb,
 		svc,
 		[]string{poetProver.RestURL().String()},

--- a/activation/e2e/validation_test.go
+++ b/activation/e2e/validation_test.go
@@ -81,7 +81,6 @@ func TestValidator_Validate(t *testing.T) {
 	}, 10*time.Second, 100*time.Millisecond, "timed out waiting for connection")
 
 	nb, err := activation.NewNIPostBuilder(
-		sig.NodeID(),
 		poetDb,
 		svc,
 		[]string{poetProver.RestURL().String()},

--- a/activation/nipost_test.go
+++ b/activation/nipost_test.go
@@ -66,7 +66,6 @@ func TestNIPostBuilderWithMocks(t *testing.T) {
 	postService.EXPECT().Client(sig.NodeID()).Return(postClient, nil)
 
 	nb, err := NewNIPostBuilder(
-		sig.NodeID(),
 		poetDb,
 		postService,
 		[]string{},
@@ -106,7 +105,6 @@ func TestPostSetup(t *testing.T) {
 	postService.EXPECT().Client(postProvider.id).Return(postClient, nil)
 
 	nb, err := NewNIPostBuilder(
-		postProvider.id,
 		poetDb,
 		postService,
 		[]string{},
@@ -169,7 +167,6 @@ func TestNIPostBuilder_BuildNIPost(t *testing.T) {
 	postService.EXPECT().Client(sig.NodeID()).Return(postClient, nil).AnyTimes()
 
 	nb, err := NewNIPostBuilder(
-		sig.NodeID(),
 		poetDb,
 		postService,
 		[]string{},
@@ -191,7 +188,6 @@ func TestNIPostBuilder_BuildNIPost(t *testing.T) {
 
 	// fail post exec
 	nb, err = NewNIPostBuilder(
-		sig.NodeID(),
 		poetDb,
 		postService,
 		[]string{},
@@ -215,7 +211,6 @@ func TestNIPostBuilder_BuildNIPost(t *testing.T) {
 	poetDb = NewMockpoetDbAPI(ctrl)
 
 	nb, err = NewNIPostBuilder(
-		sig.NodeID(),
 		poetDb,
 		postService,
 		[]string{},
@@ -292,7 +287,6 @@ func TestNIPostBuilder_ManyPoETs_SubmittingChallenge_DeadlineReached(t *testing.
 	postService := NewMockpostService(ctrl)
 	postService.EXPECT().Client(sig.NodeID()).Return(postClient, nil)
 	nb, err := NewNIPostBuilder(
-		sig.NodeID(),
 		poetDb,
 		postService,
 		[]string{},
@@ -359,7 +353,6 @@ func TestNIPostBuilder_ManyPoETs_AllFinished(t *testing.T) {
 	postService.EXPECT().Client(sig.NodeID()).Return(postClient, nil)
 
 	nb, err := NewNIPostBuilder(
-		sig.NodeID(),
 		poetDb,
 		postService,
 		[]string{},
@@ -404,7 +397,6 @@ func TestNIPSTBuilder_PoetUnstable(t *testing.T) {
 		postService := NewMockpostService(ctrl)
 
 		nb, err := NewNIPostBuilder(
-			sig.NodeID(),
 			poetDb,
 			postService,
 			[]string{},
@@ -433,7 +425,6 @@ func TestNIPSTBuilder_PoetUnstable(t *testing.T) {
 		postService := NewMockpostService(ctrl)
 
 		nb, err := NewNIPostBuilder(
-			sig.NodeID(),
 			poetDb,
 			postService,
 			[]string{},
@@ -468,7 +459,6 @@ func TestNIPSTBuilder_PoetUnstable(t *testing.T) {
 		postService := NewMockpostService(ctrl)
 
 		nb, err := NewNIPostBuilder(
-			sig.NodeID(),
 			poetDb,
 			postService,
 			[]string{},
@@ -494,7 +484,6 @@ func TestNIPSTBuilder_PoetUnstable(t *testing.T) {
 		postService := NewMockpostService(ctrl)
 
 		nb, err := NewNIPostBuilder(
-			sig.NodeID(),
 			poetDb,
 			postService,
 			[]string{},
@@ -521,7 +510,6 @@ func TestNIPSTBuilder_PoetUnstable(t *testing.T) {
 		postService := NewMockpostService(ctrl)
 
 		nb, err := NewNIPostBuilder(
-			sig.NodeID(),
 			poetDb,
 			postService,
 			[]string{},
@@ -565,7 +553,6 @@ func TestNIPoSTBuilder_StaleChallenge(t *testing.T) {
 		postService := NewMockpostService(ctrl)
 
 		nb, err := NewNIPostBuilder(
-			sig.NodeID(),
 			poetDb,
 			postService,
 			[]string{},
@@ -598,7 +585,6 @@ func TestNIPoSTBuilder_StaleChallenge(t *testing.T) {
 
 		dir := t.TempDir()
 		nb, err := NewNIPostBuilder(
-			sig.NodeID(),
 			poetDb,
 			postService,
 			[]string{},
@@ -636,7 +622,6 @@ func TestNIPoSTBuilder_StaleChallenge(t *testing.T) {
 
 		dir := t.TempDir()
 		nb, err := NewNIPostBuilder(
-			sig.NodeID(),
 			poetDb,
 			postService,
 			[]string{},
@@ -712,7 +697,6 @@ func TestNIPoSTBuilder_Continues_After_Interrupted(t *testing.T) {
 	postService.EXPECT().Client(sig.NodeID()).Return(postClient, nil)
 
 	nb, err := NewNIPostBuilder(
-		sig.NodeID(),
 		poetDb,
 		postService,
 		[]string{},
@@ -863,7 +847,6 @@ func TestNIPostBuilder_Mainnet_Poet_Workaround(t *testing.T) {
 			postService.EXPECT().Client(sig.NodeID()).Return(postClient, nil)
 
 			nb, err := NewNIPostBuilder(
-				sig.NodeID(),
 				poetDb,
 				postService,
 				[]string{},

--- a/node/node.go
+++ b/node/node.go
@@ -923,7 +923,6 @@ func (app *App) initServices(ctx context.Context) error {
 	app.grpcPostService = grpcserver.NewPostService(app.addLogger(PostServiceLogger, lg).Zap())
 
 	nipostBuilder, err := activation.NewNIPostBuilder(
-		app.edSgn.NodeID(),
 		poetDb,
 		app.grpcPostService,
 		app.Config.PoETServers,


### PR DESCRIPTION
## Motivation
De-duplicate nodeID handling in nipostBuilder. It doesn't need to be stored as a field as it can be acquired from the signer.

## Changes
- removed nodeID field from nipostBuilder
- simplify the `submitPoetChallenges()` argument list, sign challenge inside

## Test Plan
No functional changes - existing tests should pass