### PR TITLE
[Merged by Bors] - sync: improve peer selection

### DIFF
--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -240,11 +240,7 @@ func NewFetch(
 	for _, opt := range opts {
 		opt(f)
 	}
-	popts := []peers.Opt{}
-	if f.cfg.PeersRateThreshold != 0 {
-		popts = append(popts, peers.WithRateThreshold(f.cfg.PeersRateThreshold))
-	}
-	f.peers = peers.New(popts...)
+	f.peers = peers.New()
 	// NOTE(dshulyak) this is to avoid tests refactoring.
 	// there is one test that covers this part.
 	if host != nil {


### PR DESCRIPTION
previous version had several downsides:
- new peers weren't actively tried, unless they sent unique data. this version set new peer latency to 0.8 of average global latency, so that we can try it unless we are connected with a significantly faster peer.
- if fast peer started to fail, node would continue to request from it until success rate shifts significantly. current version will de-prioritize it faster by scaling average latency with increased fail rate.