### PR TITLE
[Merged by Bors] - Removed API to update poet servers from SmesherService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ See [RELEASE](./RELEASE.md) for workflow instructions.
 
   Pruning will be enabled starting from epoch 8, e.g in epoch 8 we will prune all activesets for epochs 7 and below.
   We should also run an archival node that doesn't prune them. To disable pruning we should configure
-  
+
   ```json
   "main": {
       "prune-activesets-from": 4294967295
@@ -61,6 +61,8 @@ See [RELEASE](./RELEASE.md) for workflow instructions.
   Nodes that already finished initialization can leave this setting empty, as it is not required any more to be set when no initialization is performed. For nodes that have not
   yet created their initial proof the operator has to specify which provider to use. For Smapp users this is done automatically by Smapp, users that do not use Smapp may use
   `postcli -printProviders` (<https://github.com/spacemeshos/post/releases>) to list their OpenCL providers and associated IDs.
+
+* [#5209](https://github.com/spacemeshos/go-spacemesh/pull/5209) Removed API to update poet servers from SmesherService.
 
 ## v1.2.0
 

--- a/activation/activation.go
+++ b/activation/activation.go
@@ -321,10 +321,6 @@ func (b *Builder) generateInitialPost(ctx context.Context) error {
 	return nil
 }
 
-func (b *Builder) receivePendingPoetClients() *[]poetClient {
-	return b.pendingPoetClients.Swap(nil)
-}
-
 func (b *Builder) run(ctx context.Context) {
 	defer b.log.Info("atx builder stopped")
 
@@ -343,10 +339,6 @@ func (b *Builder) run(ctx context.Context) {
 	}
 
 	for {
-		if poetClients := b.receivePendingPoetClients(); poetClients != nil {
-			b.nipostBuilder.UpdatePoETProvers(*poetClients)
-		}
-
 		ctx := log.WithNewSessionID(ctx)
 		err := b.PublishActivationTx(ctx)
 		if err == nil {

--- a/activation/activation_test.go
+++ b/activation/activation_test.go
@@ -1157,46 +1157,6 @@ func TestBuilder_InitialPostIsPersisted(t *testing.T) {
 	require.NoError(t, tab.generateInitialPost(context.Background()))
 }
 
-func TestBuilder_UpdatePoets(t *testing.T) {
-	r := require.New(t)
-
-	tab := newTestBuilder(t, WithPoETClientInitializer(func(string, PoetConfig) (poetClient, error) {
-		poet := NewMockpoetClient(gomock.NewController(t))
-		poet.EXPECT().
-			PoetServiceID(gomock.Any()).
-			AnyTimes().
-			Return(types.PoetServiceID{ServiceID: []byte("poetid")}, nil)
-		return poet, nil
-	}))
-
-	r.Nil(tab.Builder.receivePendingPoetClients())
-
-	err := tab.Builder.UpdatePoETServers(context.Background(), []string{"http://poet0", "http://poet1"})
-	r.NoError(err)
-
-	clients := tab.Builder.receivePendingPoetClients()
-	r.NotNil(clients)
-	r.Len(*clients, 2)
-	r.Nil(tab.Builder.receivePendingPoetClients())
-}
-
-func TestBuilder_UpdatePoetsUnstable(t *testing.T) {
-	r := require.New(t)
-
-	tab := newTestBuilder(t, WithPoETClientInitializer(func(string, PoetConfig) (poetClient, error) {
-		poet := NewMockpoetClient(gomock.NewController(t))
-		poet.EXPECT().
-			PoetServiceID(gomock.Any()).
-			AnyTimes().
-			Return(types.PoetServiceID{ServiceID: []byte("poetid")}, errors.New("ERROR"))
-		return poet, nil
-	}))
-
-	err := tab.Builder.UpdatePoETServers(context.Background(), []string{"http://poet0", "http://poet1"})
-	r.ErrorIs(err, ErrPoetServiceUnstable)
-	r.Nil(tab.receivePendingPoetClients())
-}
-
 func TestWaitPositioningAtx(t *testing.T) {
 	genesis := time.Now()
 	for _, tc := range []struct {

--- a/activation/interface.go
+++ b/activation/interface.go
@@ -61,7 +61,6 @@ type layerClock interface {
 }
 
 type nipostBuilder interface {
-	UpdatePoETProvers([]poetClient)
 	BuildNIPost(ctx context.Context, challenge *types.NIPostChallenge) (*types.NIPost, error)
 	DataDir() string
 }
@@ -92,7 +91,6 @@ type SmeshingProvider interface {
 	SmesherID() types.NodeID
 	Coinbase() types.Address
 	SetCoinbase(coinbase types.Address)
-	UpdatePoETServers(ctx context.Context, endpoints []string) error
 }
 
 // poetClient servers as an interface to communicate with a PoET server.

--- a/activation/mocks.go
+++ b/activation/mocks.go
@@ -747,42 +747,6 @@ func (c *nipostBuilderDataDirCall) DoAndReturn(f func() string) *nipostBuilderDa
 	return c
 }
 
-// UpdatePoETProvers mocks base method.
-func (m *MocknipostBuilder) UpdatePoETProvers(arg0 []poetClient) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "UpdatePoETProvers", arg0)
-}
-
-// UpdatePoETProvers indicates an expected call of UpdatePoETProvers.
-func (mr *MocknipostBuilderMockRecorder) UpdatePoETProvers(arg0 any) *nipostBuilderUpdatePoETProversCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePoETProvers", reflect.TypeOf((*MocknipostBuilder)(nil).UpdatePoETProvers), arg0)
-	return &nipostBuilderUpdatePoETProversCall{Call: call}
-}
-
-// nipostBuilderUpdatePoETProversCall wrap *gomock.Call
-type nipostBuilderUpdatePoETProversCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *nipostBuilderUpdatePoETProversCall) Return() *nipostBuilderUpdatePoETProversCall {
-	c.Call = c.Call.Return()
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *nipostBuilderUpdatePoETProversCall) Do(f func([]poetClient)) *nipostBuilderUpdatePoETProversCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *nipostBuilderUpdatePoETProversCall) DoAndReturn(f func([]poetClient)) *nipostBuilderUpdatePoETProversCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // Mocksyncer is a mock of syncer interface.
 type Mocksyncer struct {
 	ctrl     *gomock.Controller
@@ -1326,44 +1290,6 @@ func (c *SmeshingProviderStopSmeshingCall) Do(f func(bool) error) *SmeshingProvi
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *SmeshingProviderStopSmeshingCall) DoAndReturn(f func(bool) error) *SmeshingProviderStopSmeshingCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// UpdatePoETServers mocks base method.
-func (m *MockSmeshingProvider) UpdatePoETServers(ctx context.Context, endpoints []string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdatePoETServers", ctx, endpoints)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// UpdatePoETServers indicates an expected call of UpdatePoETServers.
-func (mr *MockSmeshingProviderMockRecorder) UpdatePoETServers(ctx, endpoints any) *SmeshingProviderUpdatePoETServersCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePoETServers", reflect.TypeOf((*MockSmeshingProvider)(nil).UpdatePoETServers), ctx, endpoints)
-	return &SmeshingProviderUpdatePoETServersCall{Call: call}
-}
-
-// SmeshingProviderUpdatePoETServersCall wrap *gomock.Call
-type SmeshingProviderUpdatePoETServersCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *SmeshingProviderUpdatePoETServersCall) Return(arg0 error) *SmeshingProviderUpdatePoETServersCall {
-	c.Call = c.Call.Return(arg0)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *SmeshingProviderUpdatePoETServersCall) Do(f func(context.Context, []string) error) *SmeshingProviderUpdatePoETServersCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *SmeshingProviderUpdatePoETServersCall) DoAndReturn(f func(context.Context, []string) error) *SmeshingProviderUpdatePoETServersCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/api/grpcserver/grpcserver_test.go
+++ b/api/grpcserver/grpcserver_test.go
@@ -635,34 +635,6 @@ func TestSmesherService(t *testing.T) {
 		_, err = stream.Recv()
 		require.ErrorContains(t, err, context.Canceled.Error())
 	})
-
-	t.Run("UpdatePoetServer", func(t *testing.T) {
-		t.Parallel()
-		c, ctx := setupSmesherService(t)
-		c.smeshingProvider.EXPECT().UpdatePoETServers(gomock.Any(), gomock.Any()).Return(nil)
-		res, err := c.UpdatePoetServers(ctx, &pb.UpdatePoetServersRequest{Urls: []string{"test"}})
-		require.NoError(t, err)
-		require.EqualValues(t, res.Status.Code, code.Code_OK)
-	})
-	t.Run("UpdatePoetServerUnavailable", func(t *testing.T) {
-		t.Parallel()
-		c, ctx := setupSmesherService(t)
-		c.smeshingProvider.EXPECT().
-			UpdatePoETServers(gomock.Any(), gomock.Any()).
-			Return(activation.ErrPoetServiceUnstable)
-		urls := []string{"test"}
-		res, err := c.UpdatePoetServers(ctx, &pb.UpdatePoetServersRequest{Urls: urls})
-		require.Nil(t, res)
-		require.ErrorIs(
-			t,
-			err,
-			status.Errorf(
-				codes.Unavailable,
-				"can't reach poet service (%v). retry later",
-				activation.ErrPoetServiceUnstable,
-			),
-		)
-	})
 }
 
 func TestMeshService(t *testing.T) {

--- a/api/grpcserver/smesher_service.go
+++ b/api/grpcserver/smesher_service.go
@@ -2,7 +2,6 @@ package grpcserver
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -282,22 +281,4 @@ func statusToPbStatus(status *activation.PostSetupStatus) *pb.PostSetupStatus {
 	}
 
 	return pbStatus
-}
-
-// UpdatePoetServers update server that is used for generating PoETs.
-func (s SmesherService) UpdatePoetServers(
-	ctx context.Context,
-	req *pb.UpdatePoetServersRequest,
-) (*pb.UpdatePoetServersResponse, error) {
-	err := s.smeshingProvider.UpdatePoETServers(ctx, req.Urls)
-	if err == nil {
-		return &pb.UpdatePoetServersResponse{
-			Status: &rpcstatus.Status{Code: int32(code.Code_OK)},
-		}, nil
-	}
-	switch {
-	case errors.Is(err, activation.ErrPoetServiceUnstable):
-		return nil, status.Errorf(codes.Unavailable, "can't reach poet service (%v). retry later", err)
-	}
-	return nil, status.Errorf(codes.Internal, "failed to update poet server")
 }

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/prometheus/common v0.45.0
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/seehuhn/mt19937 v1.0.0
-	github.com/spacemeshos/api/release/go v1.22.1-0.20231031115421-976938e0572f
+	github.com/spacemeshos/api/release/go v1.23.0
 	github.com/spacemeshos/economics v0.1.1
 	github.com/spacemeshos/fixed v0.1.1
 	github.com/spacemeshos/go-scale v1.1.12

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/prometheus/common v0.45.0
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/seehuhn/mt19937 v1.0.0
-	github.com/spacemeshos/api/release/go v1.22.0
+	github.com/spacemeshos/api/release/go v1.22.1-0.20231031115421-976938e0572f
 	github.com/spacemeshos/economics v0.1.1
 	github.com/spacemeshos/fixed v0.1.1
 	github.com/spacemeshos/go-scale v1.1.12

--- a/go.sum
+++ b/go.sum
@@ -641,8 +641,8 @@ github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d/go.mod h1:Udh
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
-github.com/spacemeshos/api/release/go v1.22.0 h1:a90pk3CK2QQdJRhHkjKB5dz8xdJV4ILxQRZj5bZdtLc=
-github.com/spacemeshos/api/release/go v1.22.0/go.mod h1:SwqQxbhAF7tN3Qr34eVzczCB3KyTbkHH12U82eqfy6M=
+github.com/spacemeshos/api/release/go v1.22.1-0.20231031115421-976938e0572f h1:zI2djzaU9JcX11bAy4H7dzn2tsDOjRMNe4qjgDjuH/0=
+github.com/spacemeshos/api/release/go v1.22.1-0.20231031115421-976938e0572f/go.mod h1:SwqQxbhAF7tN3Qr34eVzczCB3KyTbkHH12U82eqfy6M=
 github.com/spacemeshos/economics v0.1.1 h1:BPgMoTaeQ05ME6wEA1+MvXMp+wvXr51bIuN23thrCAk=
 github.com/spacemeshos/economics v0.1.1/go.mod h1:76nTjugYRiQ5/eD/DQs2dXPPilp28URMswUKncfdanY=
 github.com/spacemeshos/fixed v0.1.1 h1:N1y4SUpq1EV+IdJrWJwUCt1oBFzeru/VKVcBsvPc2Fk=

--- a/go.sum
+++ b/go.sum
@@ -641,8 +641,8 @@ github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d/go.mod h1:Udh
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
-github.com/spacemeshos/api/release/go v1.22.1-0.20231031115421-976938e0572f h1:zI2djzaU9JcX11bAy4H7dzn2tsDOjRMNe4qjgDjuH/0=
-github.com/spacemeshos/api/release/go v1.22.1-0.20231031115421-976938e0572f/go.mod h1:SwqQxbhAF7tN3Qr34eVzczCB3KyTbkHH12U82eqfy6M=
+github.com/spacemeshos/api/release/go v1.23.0 h1:hqTvEMpnf+N/1vPyn5Qhhya6yiDU4+Sj9cuEg7pDkl4=
+github.com/spacemeshos/api/release/go v1.23.0/go.mod h1:SwqQxbhAF7tN3Qr34eVzczCB3KyTbkHH12U82eqfy6M=
 github.com/spacemeshos/economics v0.1.1 h1:BPgMoTaeQ05ME6wEA1+MvXMp+wvXr51bIuN23thrCAk=
 github.com/spacemeshos/economics v0.1.1/go.mod h1:76nTjugYRiQ5/eD/DQs2dXPPilp28URMswUKncfdanY=
 github.com/spacemeshos/fixed v0.1.1 h1:N1y4SUpq1EV+IdJrWJwUCt1oBFzeru/VKVcBsvPc2Fk=

--- a/systest/cluster/cluster.go
+++ b/systest/cluster/cluster.go
@@ -209,7 +209,7 @@ func (c *Cluster) GenesisID() types.Hash20 {
 }
 
 func (c *Cluster) nextSmesher() int {
-	if c.smeshers <= c.bootnodes {
+	if c.smeshers == 0 {
 		return 0
 	}
 	return decodeOrdinal(c.clients[len(c.clients)-1].Name) + 1
@@ -455,9 +455,17 @@ func (c *Cluster) AddBootnodes(cctx *testcontext.Context, n int) error {
 type SmesherDeploymentConfig struct {
 	flags []DeploymentFlag
 	keys  []ed25519.PrivateKey
+
+	noDefaultPoets bool
 }
 
 type DeploymentOpt func(cfg *SmesherDeploymentConfig)
+
+func NoDefaultPoets() DeploymentOpt {
+	return func(cfg *SmesherDeploymentConfig) {
+		cfg.noDefaultPoets = true
+	}
+}
 
 func WithFlags(flags ...DeploymentFlag) DeploymentOpt {
 	return func(cfg *SmesherDeploymentConfig) {

--- a/systest/tests/common.go
+++ b/systest/tests/common.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
-	"google.golang.org/genproto/googleapis/rpc/code"
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
@@ -439,17 +438,6 @@ func getVerifiedLayer(ctx context.Context, node *cluster.NodeClient) (*pb.Layer,
 		return nil, err
 	}
 	return getLayer(ctx, node, resp.Status.VerifiedLayer.Number)
-}
-
-func updatePoetServers(ctx context.Context, node *cluster.NodeClient, targets []string) (bool, error) {
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
-	svc := pb.NewSmesherServiceClient(node)
-	resp, err := svc.UpdatePoetServers(ctx, &pb.UpdatePoetServersRequest{Urls: targets})
-	if err != nil {
-		return false, err
-	}
-	return resp.Status.Code == int32(code.Code_OK), nil
 }
 
 type txClient struct {

--- a/systest/tests/poets_test.go
+++ b/systest/tests/poets_test.go
@@ -122,55 +122,52 @@ func testPoetDies(t *testing.T, tctx *testcontext.Context, cl *cluster.Cluster) 
 }
 
 func TestNodesUsingDifferentPoets(t *testing.T) {
-	t.Parallel()
 	tctx := testcontext.New(t, testcontext.Labels("sanity"))
 	if tctx.PoetSize < 2 {
 		t.Skip("Skipping test for using different poets - test configured with less then 2 poets")
 	}
-	logger := tctx.Log.Named("TestNodesUsingDifferentPoets")
 
-	cl, err := cluster.ReuseWait(tctx, cluster.WithKeys(10))
-	require.NoError(t, err)
-	logger.Debug("Obtained cluster")
+	cl := cluster.New(tctx, cluster.WithKeys(10))
+	require.NoError(t, cl.AddBootnodes(tctx, 2))
+	require.NoError(t, cl.AddBootstrappers(tctx))
+	require.NoError(t, cl.AddPoets(tctx))
 
-	poetEndpoints := make([]string, 0, tctx.PoetSize)
-	for i := 0; i < tctx.PoetSize; i++ {
-		poetEndpoints = append(poetEndpoints, cluster.MakePoetEndpoint(i))
-	}
-
-	for i := 0; i < cl.Total(); i++ {
-		node := cl.Client(i)
-		endpoint := poetEndpoints[i%len(poetEndpoints)]
-		logger.Debugw("updating node's poet server", "node", node.Name, "poet", endpoint)
-		updated, err := updatePoetServers(tctx, node, []string{endpoint})
+	for i := 0; i < tctx.ClusterSize-2; i++ {
+		poet := cluster.MakePoetEndpoint(i % tctx.PoetSize)
+		tctx.Log.Debugw("adding smesher node", "id", i, "poet", poet)
+		err := cl.AddSmeshers(
+			tctx,
+			1,
+			cluster.NoDefaultPoets(),
+			cluster.WithFlags(cluster.PoetEndpoint(poet)),
+		)
 		require.NoError(t, err)
-		require.True(t, updated)
 	}
+	require.NoError(t, cl.WaitAll(tctx))
 
 	layersCount := uint32(layersToCheck.Get(tctx.Parameters))
 	layersPerEpoch := uint32(testcontext.LayersPerEpoch.Get(tctx.Parameters))
 	first := nextFirstLayer(currentLayer(tctx, t, cl.Client(0)), layersPerEpoch)
 	last := first + layersCount - 1
-	logger.Debugw("watching layers between", "first", first, "last", last)
+	tctx.Log.Debugw("watching layers between", "first", first, "last", last)
 
 	createdch := make(chan *pb.Proposal, cl.Total()*(int(layersCount)))
 
 	eg, ctx := errgroup.WithContext(tctx)
 	for i := 0; i < cl.Total(); i++ {
-		clientId := i
-		client := cl.Client(clientId)
-		logger.Debugw("watching", "client", client.Name, "clientId", clientId)
+		client := cl.Client(i)
+		tctx.Log.Debugw("watching", "client", client.Name)
 		watchProposals(ctx, eg, client, func(proposal *pb.Proposal) (bool, error) {
 			if proposal.Layer.Number < first {
 				return true, nil
 			}
 			if proposal.Layer.Number > last {
-				logger.Debugw("proposal watcher is done", "client", client.Name)
+				tctx.Log.Debugw("proposal watcher is done", "client", client.Name)
 				return false, nil
 			}
 
 			if proposal.Status == pb.Proposal_Created {
-				logger.Debugw("received proposal event",
+				tctx.Log.Debugw("received proposal event",
 					"client", client.Name,
 					"id", hex.EncodeToString(proposal.Smesher.Id),
 					"layer", proposal.Layer.Number,

--- a/systest/tests/steps_test.go
+++ b/systest/tests/steps_test.go
@@ -31,38 +31,6 @@ func TestStepCreate(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestStepDeletePoets(t *testing.T) {
-	tctx := testcontext.New(t, testcontext.SkipClusterLimits())
-	cl, err := cluster.Reuse(tctx, cluster.WithKeys(10))
-	require.NoError(t, err)
-
-	tctx.Log.Debugw("deleting poet servers", "poets", cl.Poets())
-	require.NoError(t, cl.DeletePoets(tctx))
-}
-
-func TestStepRedeployPoets(t *testing.T) {
-	tctx := testcontext.New(t, testcontext.SkipClusterLimits())
-	cl, err := cluster.Reuse(tctx, cluster.WithKeys(10))
-	require.NoError(t, err)
-
-	require.Zero(t, cl.Poets())
-	tctx.Log.Debug("adding poet servers")
-	require.NoError(t, cl.AddPoets(tctx))
-
-	poetEndpoints := make([]string, 0, tctx.PoetSize)
-	for i := 0; i < tctx.PoetSize; i++ {
-		poetEndpoints = append(poetEndpoints, cluster.MakePoetEndpoint(i))
-	}
-
-	for i := 0; i < cl.Total(); i++ {
-		node := cl.Client(i)
-		tctx.Log.Debugw("updating node's poet server", "node", node.Name, "poets", poetEndpoints)
-		updated, err := updatePoetServers(tctx, node, poetEndpoints)
-		require.NoError(t, err)
-		require.True(t, updated)
-	}
-}
-
 func TestStepShortDisconnect(t *testing.T) {
 	tctx := testcontext.New(t, testcontext.SkipClusterLimits())
 	cl, err := cluster.Reuse(tctx, cluster.WithKeys(10))


### PR DESCRIPTION
## Motivation
Remove the API to live-update poet servers

## Changes
- updated the api dep to https://github.com/spacemeshos/api/pull/280, merge after this
- removed relevant code
- updated the system tests using this API
- fixed a problem in system tests where multiple `smesher-0` nodes are created all of which but 1 are destroyed - I believe this causes recent flakiness of systests.

## Test Plan
Existing tests pass
