### PR TITLE
Update CI to use merge queues instead of bors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: CI
 
 env:
-  go-version: "1.21"
   GCLOUD_KEY: ${{ secrets.GCLOUD_KEY }}
   PROJECT_NAME: ${{ secrets.PROJECT_NAME }}
   CLUSTER_NAME: ${{ secrets.CLUSTER_NAME }}
@@ -19,12 +18,9 @@ env:
 on:
   # Allow manually triggering this workflow
   workflow_dispatch:
-  # run for all pull requests and pushes to certain branches
+  # run for all pull requests and merge groups
   pull_request:
-  push:
-    branches:
-      - staging
-      - trying
+  merge_group:
 
 concurrency:
   group: ${{ github.base_ref == 'staging' && 'smci-staging' || format('smci-{0}-{1}', github.workflow, github.ref) }}
@@ -66,7 +62,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           check-latest: true
-          go-version: ${{ env.go-version }}
+          go-version-file: "go.mod"
       - name: fmt, tidy, generate
         run: |
           make install
@@ -89,7 +85,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           check-latest: true
-          go-version: ${{ env.go-version }}
+          go-version-file: "go.mod"
       - name: setup env
         run: make install
       - name: staticcheck
@@ -127,7 +123,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           check-latest: true
-          go-version: ${{ env.go-version }}
+          go-version-file: "go.mod"
           cache: ${{ runner.arch != 'arm64' }}
       - name: setup env
         run: make install
@@ -177,7 +173,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           check-latest: true
-          go-version: ${{ env.go-version }}
+          go-version-file: "go.mod"
           cache: ${{ runner.arch != 'arm64' }}
       - name: Add OpenCL support - Ubuntu
         if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -1,5 +1,5 @@
 # Generate latest build and push it to dockerhub on push to develop branch.
-# NOTE: This workflow does not include any tests, nor any dependencies, since bors guarantees
+# NOTE: This workflow does not include any tests, nor any dependencies, since github merge queues ensure
 # that only code that passes all tests is ever pushed to develop.
 name: Push to Dockerhub
 run-name: Pushing ${{ github.ref_name }} to Dockerhub

--- a/.github/workflows/systest-pr.yml
+++ b/.github/workflows/systest-pr.yml
@@ -1,0 +1,15 @@
+## This is a dummy worklfow that is executed on pull requests to set the required `systest-status`
+## to passed. It is not executed during a merge group run; instead the real job will be executed
+## to prevent a merge group from passing if the system tests fail.
+
+name: System tests
+on:
+  # run for all pull requests
+  pull_request:
+
+jobs:
+  systest-status:
+    runs-on: ubuntu-latest
+    steps:
+      - name: System tests are skipped during PR trigger
+        run: exit 0

--- a/.github/workflows/systest.yml
+++ b/.github/workflows/systest.yml
@@ -2,10 +2,8 @@ name: System tests
 on:
   # Allow manually triggering this workflow
   workflow_dispatch:
-  push:
-    branches:
-      - staging
-      - trying
+  merge_group:
+
 env:
   GCLOUD_KEY: ${{ secrets.GCLOUD_KEY }}
   PROJECT_NAME: ${{ secrets.PROJECT_NAME }}


### PR DESCRIPTION
## Motivation
Bors it seems has finally been discontinued. This updates our CI to work with Github Merge Queues in a similar fashion as it did before when we were using bors:

- PRs immediately trigger the jobs in `ci.yml` and only allow adding to a merge queue if all jobs in this file pass
- While in the merge queue jobs in both `ci.yml` and `systest.yml` are executed and only of all of them pass the code is merged to the target branch.
- Manual execution of system tests now needs to be done via Actions -> System tests -> Run Workflow on the GH homepage

**NOTE:** merging this requires updating the branch protection rules for `develop` - see `test-merge-queue` branch protection rules as a reference.

## Changes
- a dummy systest workflow is added that is only executed on the PR trigger and always passes
  - this is needed because `systest-status` needs to be a requirement for both triggering the merge and successfully completing it
- removed bors configuration from ci and systest jobs.

## Test Plan
n/a

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
