### PR TITLE
[Merged by Bors] - Fix flaky errors

### DIFF
--- a/activation/activation.go
+++ b/activation/activation.go
@@ -561,18 +561,17 @@ func (b *Builder) PublishActivationTx(ctx context.Context) error {
 		}
 	}
 
-	events.EmitAtxPublished(
-		atx.PublishEpoch, atx.TargetEpoch(),
-		atx.ID(),
-		time.Until(b.layerClock.LayerToTime(atx.TargetEpoch().FirstLayer())),
-	)
-
 	if err := nipost.RemoveChallenge(b.localDB, b.signer.NodeID()); err != nil {
 		return fmt.Errorf("discarding challenge after published ATX: %w", err)
 	}
 	if err := nipost.RemoveInitialPost(b.localDB, b.signer.NodeID()); err != nil {
 		return fmt.Errorf("discarding initial post after published ATX: %w", err)
 	}
+	events.EmitAtxPublished(
+		atx.PublishEpoch, atx.TargetEpoch(),
+		atx.ID(),
+		time.Until(b.layerClock.LayerToTime(atx.TargetEpoch().FirstLayer())),
+	)
 	return nil
 }
 

--- a/activation/post_verifier_test.go
+++ b/activation/post_verifier_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/spacemeshos/go-spacemesh/activation"
 	"github.com/spacemeshos/go-spacemesh/log"
+	"github.com/spacemeshos/go-spacemesh/log/logtest"
 )
 
 func TestOffloadingPostVerifier(t *testing.T) {
@@ -78,13 +79,13 @@ func TestPostVerifierNoRaceOnClose(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	proof := shared.Proof{}
-	metadata := shared.ProofMetadata{}
+	var proof shared.Proof
+	var metadata shared.ProofMetadata
 
 	verifier := activation.NewMockPostVerifier(gomock.NewController(t))
 	offloadingVerifier := activation.NewOffloadingPostVerifier(
 		[]activation.PostVerifier{verifier},
-		log.NewDefault(t.Name()),
+		logtest.New(t),
 	)
 	defer offloadingVerifier.Close()
 	verifier.EXPECT().Close().AnyTimes().Return(nil)
@@ -97,7 +98,7 @@ func TestPostVerifierNoRaceOnClose(t *testing.T) {
 		return offloadingVerifier.Close()
 	})
 
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 50; i++ {
 		ms := 10 * i
 		eg.Go(func() error {
 			time.Sleep(time.Duration(ms) * time.Millisecond)


### PR DESCRIPTION
## Motivation
Fixes a few flaky tests that prevented merges yesterday and today.

Closes https://github.com/spacemeshos/go-spacemesh/issues/5076
Closes https://github.com/spacemeshos/go-spacemesh/issues/4692
Closes https://github.com/spacemeshos/go-spacemesh/issues/4074

## Changes
- `TestBuilder_PublishActivationTx_NoPrevATX_PublishFails_InitialPost_preserve`: the test was updated to wait until the challenge was actually cleaned up to assert it was removed. Before there was a possible race where the test asserted that the challenge was deleted before the data was removed from the db.
- `TestBuilder_RetryPublishActivationTx`: another possible race condition where the state might not yet be cleaned up when the tests asserts it. Test now waits for the `AtxPublished` event which is now triggered after the state has been cleaned up to fix the possible race.
- `TestOffloadingPostVerifier` increased the number of calls to `offloadingVerifier.Verify`. Before there was a chance that the `offloadingVerifier` was closed only after the last call to `Verify`, not triggering the error we are asserting against. Calling `Verify` more often over a longer time period should prevent this.
- `TestQueued`: before the number of successfully processed messages would just barely be above 50, which occasionally due to timings/slow runner would cause only 50 or 49 messages to be processed successfully. With the changed parameters now ~75 out of the 100 messages should be processed successfully preventing random flakes.
- `TestCache_Account_Add_NonceTooSmall`: this test and others in the same package use `createSingleAccountTestCache` to create a cache for an account. The nonce of that account would be random between 0 and 1000. When it is set to 0 the test will underflow the value and not trigger the `errBadNonce` error that we are asserting against. Updated random number generation for all tests to ensure uniform distribution of values & prevent rare outliers.

## Test Plan
n/a

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
