### PR TITLE
[Merged by Bors] - Fix late publication of ATXs not possible

### DIFF
--- a/activation/activation.go
+++ b/activation/activation.go
@@ -443,6 +443,23 @@ func (b *Builder) buildNIPostChallenge(ctx context.Context) (*types.NIPostChalle
 	case <-b.syncer.RegisterForATXSynced():
 	}
 	current := b.layerClock.CurrentLayer().GetEpoch()
+
+	challenge, err := nipost.Challenge(b.localDB, b.signer.NodeID())
+	switch {
+	case errors.Is(err, sql.ErrNotFound):
+		// build new challenge
+	case err != nil:
+		return nil, fmt.Errorf("get nipost challenge: %w", err)
+	case challenge.PublishEpoch < current:
+		// challenge is stale
+		if err := nipost.RemoveChallenge(b.localDB, b.signer.NodeID()); err != nil {
+			return nil, fmt.Errorf("remove stale nipost challenge: %w", err)
+		}
+	default:
+		// challenge is fresh
+		return challenge, nil
+	}
+
 	prev, err := b.cdb.GetLastAtx(b.signer.NodeID())
 	switch {
 	case err == nil:
@@ -478,22 +495,6 @@ func (b *Builder) buildNIPostChallenge(ctx context.Context) (*types.NIPostChalle
 	posAtx, err := b.GetPositioningAtx()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get positioning ATX: %w", err)
-	}
-
-	challenge, err := nipost.Challenge(b.localDB, b.signer.NodeID())
-	switch {
-	case errors.Is(err, sql.ErrNotFound):
-		// build new challenge
-	case err != nil:
-		return nil, fmt.Errorf("get nipost challenge: %w", err)
-	case challenge.PublishEpoch < current:
-		// challenge is stale
-		if err := nipost.RemoveChallenge(b.localDB, b.signer.NodeID()); err != nil {
-			return nil, fmt.Errorf("remove stale nipost challenge: %w", err)
-		}
-	default:
-		// challenge is fresh
-		return challenge, nil
 	}
 
 	prevAtx, err := b.cdb.GetLastAtx(b.signer.NodeID())

--- a/activation/activation_test.go
+++ b/activation/activation_test.go
@@ -609,6 +609,85 @@ func TestBuilder_PublishActivationTx_FaultyNet(t *testing.T) {
 	require.ErrorIs(t, err, sql.ErrNotFound)
 }
 
+func TestBuilder_PublishActivationTx_UsesExistingChallengeOnLatePublish(t *testing.T) {
+	poetCfg := PoetConfig{
+		PhaseShift: layerDuration * 4,
+	}
+	tab := newTestBuilder(t, WithPoetConfig(poetCfg))
+	posEpoch := postGenesisEpoch
+	currLayer := (postGenesisEpoch + 1).FirstLayer().Add(5) // late for poet round start
+	challenge := newChallenge(1, types.ATXID{1, 2, 3}, types.ATXID{1, 2, 3}, postGenesisEpoch, nil)
+	nipostData := newNIPostWithChallenge(t, types.HexToHash32("55555"), []byte("66666"))
+	prevAtx := newAtx(t, tab.sig, challenge, nipostData, posEpoch.Uint32(), types.Address{})
+	SignAndFinalizeAtx(tab.sig, prevAtx)
+	vPrevAtx, err := prevAtx.Verify(0, 1)
+	require.NoError(t, err)
+	require.NoError(t, atxs.Add(tab.cdb, vPrevAtx))
+
+	publishEpoch := currLayer.GetEpoch()
+	tab.mclock.EXPECT().CurrentLayer().DoAndReturn(func() types.LayerID { return currLayer }).AnyTimes()
+	tab.mclock.EXPECT().LayerToTime(gomock.Any()).DoAndReturn(
+		func(got types.LayerID) time.Time {
+			// time.Now() ~= currentLayer
+			genesis := time.Now().Add(-time.Duration(currLayer) * layerDuration)
+			return genesis.Add(layerDuration * time.Duration(got))
+		}).AnyTimes()
+	nonce := types.VRFPostIndex(123)
+	commitmentATX := types.RandomATXID()
+	tab.mpostClient.EXPECT().Info(gomock.Any()).Return(&types.PostInfo{
+		NodeID:        tab.sig.NodeID(),
+		CommitmentATX: commitmentATX,
+		Nonce:         &nonce,
+
+		NumUnits:      DefaultPostSetupOpts().NumUnits,
+		LabelsPerUnit: DefaultPostConfig().LabelsPerUnit,
+	}, nil).AnyTimes()
+	tab.mnipost.EXPECT().BuildNIPost(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, challenge *types.NIPostChallenge) (*types.NIPost, error) {
+			currLayer = currLayer.Add(1)
+			return newNIPostWithChallenge(t, challenge.Hash(), []byte("66666")), nil
+		})
+	done := make(chan struct{})
+	close(done)
+	tab.mclock.EXPECT().AwaitLayer(publishEpoch.FirstLayer()).DoAndReturn(
+		func(got types.LayerID) <-chan struct{} {
+			// advance to publish layer
+			if currLayer.Before(got) {
+				currLayer = got
+			}
+			return done
+		})
+
+	// store challenge in DB
+	ch := &types.NIPostChallenge{
+		Sequence:       vPrevAtx.Sequence + 1,
+		PrevATXID:      vPrevAtx.ID(),
+		PublishEpoch:   vPrevAtx.PublishEpoch + 1,
+		PositioningATX: vPrevAtx.ID(),
+	}
+
+	require.NoError(t, nipost.AddChallenge(tab.localDb, tab.sig.NodeID(), ch))
+
+	tab.mpub.EXPECT().Publish(gomock.Any(), pubsub.AtxProtocol, gomock.Any()).DoAndReturn(
+		// publish succeeds
+		func(_ context.Context, _ string, got []byte) error {
+			var gotAtx types.ActivationTx
+			require.NoError(t, codec.Decode(got, &gotAtx))
+			gotAtx.SetReceived(time.Now().Local())
+			require.NoError(t, gotAtx.Initialize())
+			require.Equal(t, *ch, gotAtx.NIPostChallenge)
+			return nil
+		},
+	)
+
+	// create and publish ATX
+	require.NoError(t, tab.PublishActivationTx(context.Background()))
+
+	// state is cleaned up
+	_, err = nipost.Challenge(tab.localDB, tab.sig.NodeID())
+	require.ErrorIs(t, err, sql.ErrNotFound)
+}
+
 func TestBuilder_PublishActivationTx_RebuildNIPostWhenTargetEpochPassed(t *testing.T) {
 	tab := newTestBuilder(t, WithPoetConfig(PoetConfig{PhaseShift: layerDuration * 4}))
 	posEpoch := types.EpochID(2)


### PR DESCRIPTION
## Motivation
Closes #5272 

## Changes
If the node failed to publish an ATX during the cycle gap and is restarted after the new PoET round started, the ATX builder incorrectly waits until the next cycle gap before checking for the existing challenge or building a new one. Instead it should verify and use the existing challenge to publish an ATX asap to be still be eligible for rewards in the upcoming epoch.

Example:

In epoch 8 a user missed the PoET registration deadline due to a crash, without the fix the node would now wait until epoch 9 to discard the challenge, build a new one and register at PoET.

With the fix the node will take the existing challenge and immediately build and publish an ATX.

This way the affected user will receive rewards in epoch 9 and only miss rewards in epoch 10; without the fix they would miss rewards for both epochs.

## Test Plan
- a new test was added to verify the changed behavior is correct

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
