### PR TITLE
[Merged by Bors] - hare3: fix overlow in multiplication

### DIFF
--- a/hare3/types.go
+++ b/hare3/types.go
@@ -61,7 +61,7 @@ func (ir IterRound) IsMessageRound() bool {
 }
 
 func (ir IterRound) Absolute() uint32 {
-	return uint32(ir.Iter*uint8(notify) + uint8(ir.Round))
+	return uint32(ir.Iter)*uint32(notify) + uint32(ir.Round)
 }
 
 type Value struct {

--- a/hare3/types_test.go
+++ b/hare3/types_test.go
@@ -10,6 +10,11 @@ import (
 	"github.com/spacemeshos/go-spacemesh/common/types"
 )
 
+func TestAbsoluteMaxValue(t *testing.T) {
+	ir := IterRound{Iter: 40, Round: notify}
+	require.EqualValues(t, 41*7, ir.Absolute())
+}
+
 func TestMessageMarshall(t *testing.T) {
 	enc := zapcore.NewMapObjectEncoder()
 	msg := &Message{Body: Body{Value: Value{Proposals: []types.ProposalID{{}}}}}


### PR DESCRIPTION
we are running with smaller limit (4 iteration) that fits uint8,
but we plan to eventually raise to 40 which would overflow multiplication in Absolute function
