### PR TITLE
[Merged by Bors] - Fix localdb migrations on checkpoint recovery

### DIFF
--- a/checkpoint/recovery.go
+++ b/checkpoint/recovery.go
@@ -107,7 +107,10 @@ func Recover(
 		return nil, fmt.Errorf("open old database: %w", err)
 	}
 	defer db.Close()
-	localDB, err := localsql.Open("file:" + filepath.Join(cfg.DataDir, cfg.LocalDbFile))
+	localDB, err := localsql.Open(
+		"file:"+filepath.Join(cfg.DataDir, cfg.LocalDbFile),
+		sql.WithMigration(localsql.New0002Migration(cfg.DataDir)),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("open old local database: %w", err)
 	}


### PR DESCRIPTION
## Motivation
The in-code migration 0002 of local DB is not executed on checkpoint recovery. It causes the checkpoint systests fail in #5221.

## Changes
Apply 0002 migration on the checkpoint recovery path.