### PR TITLE
[Merged by Bors] - Don't allow builds with "...nomain" git tag to run on mainnet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,12 @@ DOCKER_HUB ?= spacemeshos
 DOCKER_IMAGE_REPO ?= go-spacemesh-dev
 DOCKER_IMAGE_VERSION ?= $(SHA)
 
-LDFLAGS = -ldflags "-X main.version=${VERSION} -X main.commit=${COMMIT} -X main.branch=${BRANCH}"
+C_LDFLAGS = -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.branch=${BRANCH}
+ifneq (,$(findstring nomain,$(VERSION)))
+    C_LDFLAGS += -X main.noMainNet=true
+endif
+LDFLAGS = -ldflags "$(C_LDFLAGS)"
+
 include Makefile-libs.Inc
 
 UNIT_TESTS ?= $(shell go list ./...  | grep -v systest/tests | grep -v cmd/node | grep -v cmd/gen-p2p-identity | grep -v cmd/trace | grep -v genvm/cmd)

--- a/cmd/base.go
+++ b/cmd/base.go
@@ -24,6 +24,9 @@ var (
 
 	// Commit is the git commit used to build the app. Designed to be overwritten by make.
 	Commit string
+
+	// Prohibit this build from running on the mainnet.
+	NoMainNet bool
 )
 
 // EnsureCLIFlags checks flag types and converts them.

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -12,15 +12,17 @@ import (
 )
 
 var (
-	version string
-	commit  string
-	branch  string
+	version   string
+	commit    string
+	branch    string
+	noMainNet string
 )
 
 func main() { // run the app
 	cmd.Version = version
 	cmd.Commit = commit
 	cmd.Branch = branch
+	cmd.NoMainNet = noMainNet == "true"
 	if err := node.GetCommand().Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)

--- a/node/node.go
+++ b/node/node.go
@@ -131,6 +131,11 @@ func GetCommand() *cobra.Command {
 			if conf.LOGGING.Encoder == config.JSONLogEncoder {
 				log.JSONLog(true)
 			}
+
+			if cmd.NoMainNet && onMainNet(conf) {
+				log.With().Fatal("this is a testnet-only build not intended for mainnet")
+			}
+
 			app := New(
 				WithConfig(conf),
 				// NOTE(dshulyak) this needs to be max level so that child logger can can be current level or below.
@@ -1834,4 +1839,8 @@ func (w tortoiseWeakCoin) Set(lid types.LayerID, value bool) error {
 	}
 	w.tortoise.OnWeakCoin(lid, value)
 	return nil
+}
+
+func onMainNet(conf *config.Config) bool {
+	return conf.Genesis.GenesisTime == config.MainnetConfig().Genesis.GenesisTime
 }


### PR DESCRIPTION
Some versions are test builds that are not intended for use on the mainnet.
This PR makes it possible to enforce that by making any builds from git tags that contain `nomain` substring refuse to run on the mainnet.