### PR TITLE
miner: pick activeset deterministically from the first block

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -119,10 +119,6 @@ type BaseConfig struct {
 
 	NetworkHRP string `mapstructure:"network-hrp"`
 
-	// MinerGoodAtxsPercent is a threshold to decide if tortoise activeset should be
-	// picked from first block instead of synced data.
-	MinerGoodAtxsPercent int `mapstructure:"miner-good-atxs-percent"`
-
 	RegossipAtxInterval time.Duration `mapstructure:"regossip-atx-interval"`
 }
 

--- a/config/presets/fastnet.go
+++ b/config/presets/fastnet.go
@@ -23,9 +23,6 @@ func fastnet() config.Config {
 	conf.BaseConfig.OptFilterThreshold = 90
 	conf.BaseConfig.DatabasePruneInterval = time.Minute
 
-	// set for systest TestEquivocation
-	conf.BaseConfig.MinerGoodAtxsPercent = 50
-
 	conf.HARE3.Enable = true
 	conf.HARE3.DisableLayer = types.LayerID(math.MaxUint32)
 	conf.HARE3.Committee = 800

--- a/miner/proposal_builder_test.go
+++ b/miner/proposal_builder_test.go
@@ -522,6 +522,108 @@ func TestBuild(t *testing.T) {
 			},
 		},
 		{
+			desc: "first block not in the first layer",
+			opts: []Opt{
+				WithNetworkDelay(10 * time.Second),
+			},
+			steps: []step{
+				{
+					lid:    17,
+					beacon: types.Beacon{1},
+					atxs: []*types.VerifiedActivationTx{
+						gatx(types.ATXID{1}, 2, signer.NodeID(), 1, genAtxWithNonce(777)),
+						gatx(types.ATXID{2}, 2, types.NodeID{2}, 1, genAtxWithReceived(time.Unix(20, 0))),
+						gatx(types.ATXID{3}, 2, types.NodeID{3}, 1, genAtxWithReceived(time.Unix(20, 0))),
+					},
+					activeset: gactiveset(types.ATXID{2}, types.ATXID{3}),
+					ballots: []*types.Ballot{
+						gballot(types.BallotID{11}, types.ATXID{3}, types.NodeID{5}, 15, &types.EpochData{
+							ActiveSetHash: gactiveset(types.ATXID{2}, types.ATXID{3}).Hash(),
+						}),
+					},
+					blocks: []*types.Block{
+						gblock(16, types.ATXID{3}),
+					},
+					opinion:        &types.Opinion{Hash: types.Hash32{1}},
+					txs:            []types.TransactionID{},
+					latestComplete: 16,
+					expectProposal: expectProposal(
+						signer, 17, types.ATXID{1}, types.Opinion{Hash: types.Hash32{1}},
+						expectEpochData(
+							gactiveset(types.ATXID{2}, types.ATXID{3}),
+							25,
+							types.Beacon{1},
+						),
+						expectCounters(signer, 3, types.Beacon{1}, 777, 3, 7, 10, 14, 15, 21),
+					),
+				},
+			},
+		},
+		{
+			desc: "first block empty",
+			opts: []Opt{
+				WithNetworkDelay(10 * time.Second),
+			},
+			steps: []step{
+				{
+					lid:    16,
+					beacon: types.Beacon{1},
+					atxs: []*types.VerifiedActivationTx{
+						gatx(types.ATXID{1}, 2, signer.NodeID(), 1, genAtxWithNonce(777)),
+						gatx(types.ATXID{2}, 2, types.NodeID{2}, 1, genAtxWithNonce(777)),
+						gatx(types.ATXID{3}, 2, types.NodeID{3}, 1, genAtxWithReceived(time.Unix(20, 0))),
+					},
+					blocks: []*types.Block{
+						gblock(15),
+					},
+					opinion:        &types.Opinion{Hash: types.Hash32{1}},
+					txs:            []types.TransactionID{},
+					latestComplete: 15,
+					expectProposal: expectProposal(
+						signer, 16, types.ATXID{1}, types.Opinion{Hash: types.Hash32{1}},
+						expectEpochData(
+							gactiveset(types.ATXID{1}, types.ATXID{2}),
+							25,
+							types.Beacon{1},
+						),
+						expectCounters(signer, 3, types.Beacon{1}, 777, 2, 5, 11, 19, 22, 24),
+					),
+				},
+			},
+		},
+		{
+			desc: "first block missing ballot",
+			opts: []Opt{
+				WithNetworkDelay(10 * time.Second),
+			},
+			steps: []step{
+				{
+					lid:    16,
+					beacon: types.Beacon{1},
+					atxs: []*types.VerifiedActivationTx{
+						gatx(types.ATXID{1}, 2, signer.NodeID(), 1, genAtxWithNonce(777)),
+						gatx(types.ATXID{2}, 2, types.NodeID{2}, 1, genAtxWithNonce(777)),
+						gatx(types.ATXID{3}, 2, types.NodeID{3}, 1, genAtxWithReceived(time.Unix(20, 0))),
+					},
+					blocks: []*types.Block{
+						gblock(15, types.ATXID{4}),
+					},
+					opinion:        &types.Opinion{Hash: types.Hash32{1}},
+					txs:            []types.TransactionID{},
+					latestComplete: 15,
+					expectProposal: expectProposal(
+						signer, 16, types.ATXID{1}, types.Opinion{Hash: types.Hash32{1}},
+						expectEpochData(
+							gactiveset(types.ATXID{1}, types.ATXID{2}),
+							25,
+							types.Beacon{1},
+						),
+						expectCounters(signer, 3, types.Beacon{1}, 777, 2, 5, 11, 19, 22, 24),
+					),
+				},
+			},
+		},
+		{
 			desc: "invalid first ballot",
 			steps: []step{
 				{

--- a/miner/proposal_builder_test.go
+++ b/miner/proposal_builder_test.go
@@ -487,7 +487,6 @@ func TestBuild(t *testing.T) {
 			desc: "first block activeset",
 			opts: []Opt{
 				WithNetworkDelay(10 * time.Second),
-				WithMinGoodAtxPercent(50),
 			},
 			steps: []step{
 				{
@@ -498,33 +497,14 @@ func TestBuild(t *testing.T) {
 						gatx(types.ATXID{2}, 2, types.NodeID{2}, 1, genAtxWithReceived(time.Unix(20, 0))),
 						gatx(types.ATXID{3}, 2, types.NodeID{3}, 1, genAtxWithReceived(time.Unix(20, 0))),
 					},
-					expectErr: "first block",
-				},
-				{
-					lid: 16,
-					blocks: []*types.Block{
-						gblock(15, types.ATXID{4}), // this atx and ballot doesn't exist
-					},
-					expectErr: "actives get ballot",
-				},
-				{
-					lid: 16,
+					activeset: gactiveset(types.ATXID{2}, types.ATXID{3}),
 					ballots: []*types.Ballot{
-						gballot(types.BallotID{11}, types.ATXID{4}, types.NodeID{5}, 15, &types.EpochData{
-							ActiveSetHash: gactiveset(types.ATXID{1}, types.ATXID{2}).Hash(),
+						gballot(types.BallotID{11}, types.ATXID{3}, types.NodeID{5}, 15, &types.EpochData{
+							ActiveSetHash: gactiveset(types.ATXID{2}, types.ATXID{3}).Hash(),
 						}),
 					},
-					expectErr: "get active hash for ballot",
-				},
-				{
-					lid:       16,
-					activeset: gactiveset(types.ATXID{1}, types.ATXID{2}),
-					expectErr: "get ATXs from DB: get id 0400000000",
-				},
-				{
-					lid: 16,
-					atxs: []*types.VerifiedActivationTx{
-						gatx(types.ATXID{4}, 2, types.NodeID{4}, 1, genAtxWithReceived(time.Unix(20, 0))),
+					blocks: []*types.Block{
+						gblock(15, types.ATXID{3}),
 					},
 					opinion:        &types.Opinion{Hash: types.Hash32{1}},
 					txs:            []types.TransactionID{},
@@ -532,11 +512,11 @@ func TestBuild(t *testing.T) {
 					expectProposal: expectProposal(
 						signer, 16, types.ATXID{1}, types.Opinion{Hash: types.Hash32{1}},
 						expectEpochData(
-							gactiveset(types.ATXID{1}, types.ATXID{2}, types.ATXID{4}),
-							16,
+							gactiveset(types.ATXID{2}, types.ATXID{3}),
+							25,
 							types.Beacon{1},
 						),
-						expectCounters(signer, 3, types.Beacon{1}, 777, 2, 5, 11),
+						expectCounters(signer, 3, types.Beacon{1}, 777, 2, 5, 11, 19, 22, 24),
 					),
 				},
 			},

--- a/node/node.go
+++ b/node/node.go
@@ -846,10 +846,6 @@ func (app *App) initServices(ctx context.Context) error {
 		blocks.WithGeneratorLogger(app.addLogger(BlockGenLogger, lg)),
 	)
 
-	minerGoodAtxPct := 90
-	if app.Config.MinerGoodAtxsPercent > 0 {
-		minerGoodAtxPct = app.Config.MinerGoodAtxsPercent
-	}
 	proposalBuilder := miner.New(
 		app.clock,
 		app.cachedDB,
@@ -863,7 +859,6 @@ func (app *App) initServices(ctx context.Context) error {
 		miner.WithHdist(app.Config.Tortoise.Hdist),
 		// TODO(dshulyak) ???
 		miner.WithNetworkDelay(app.Config.HARE3.PreroundDelay),
-		miner.WithMinGoodAtxPercent(minerGoodAtxPct),
 		miner.WithLogger(app.addLogger(ProposalBuilderLogger, lg)),
 	)
 	proposalBuilder.Register(app.edSgn)


### PR DESCRIPTION
related: https://github.com/spacemeshos/go-spacemesh/issues/5282

in the latest epoch there are many different activesets that causes unnecessary state growth and noticeable increases
load on the network. the root cause of that is suboptimal propagation of atxs.

in order to mitigate this problem all ballots after first epoch will select activeset deterministically using first applied block.
this is the same method that we are using to select hare active set. 

if picking activeset from a first block results in error due to any reason we are using graded activeset.
also graded activeset is a default option for the first layer in the epoch. 