### PR TITLE
[Merged by Bors] - miner: select active sets that were received 2 hours before start

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -124,6 +124,10 @@ type BaseConfig struct {
 	MinerGoodAtxsPercent int `mapstructure:"miner-good-atxs-percent"`
 
 	RegossipAtxInterval time.Duration `mapstructure:"regossip-atx-interval"`
+
+	// ATXGradeDelay is used to grade ATXs for selection in tortoise active set.
+	// See grading fuction in miner/proposals_builder.go
+	ATXGradeDelay time.Duration `mapstructure:"atx-grade-delay"`
 }
 
 type PublicMetrics struct {
@@ -201,6 +205,7 @@ func defaultBaseConfig() BaseConfig {
 		DatabaseSizeMeteringInterval: 10 * time.Minute,
 		DatabasePruneInterval:        30 * time.Minute,
 		NetworkHRP:                   "sm",
+		ATXGradeDelay:                10 * time.Second,
 	}
 }
 

--- a/config/mainnet.go
+++ b/config/mainnet.go
@@ -91,6 +91,7 @@ func MainnetConfig() Config {
 				"https://poet-112.spacemesh.network",
 			},
 			RegossipAtxInterval: 2 * time.Hour,
+			ATXGradeDelay:       30 * time.Minute,
 		},
 		Genesis: &GenesisConfig{
 			GenesisTime: "2023-07-14T08:00:00Z",

--- a/config/presets/testnet.go
+++ b/config/presets/testnet.go
@@ -73,6 +73,7 @@ func testnet() config.Config {
 			TickSize:            666514,
 			PoETServers:         []string{},
 			RegossipAtxInterval: time.Hour,
+			ATXGradeDelay:       30 * time.Minute,
 		},
 		Genesis: &config.GenesisConfig{
 			GenesisTime: "2023-09-13T18:00:00Z",

--- a/node/node.go
+++ b/node/node.go
@@ -861,8 +861,7 @@ func (app *App) initServices(ctx context.Context) error {
 		miner.WithLayerPerEpoch(layersPerEpoch),
 		miner.WithMinimalActiveSetWeight(app.Config.Tortoise.MinimalActiveSetWeight),
 		miner.WithHdist(app.Config.Tortoise.Hdist),
-		// TODO(dshulyak) ???
-		miner.WithNetworkDelay(app.Config.HARE3.PreroundDelay),
+		miner.WithNetworkDelay(app.Config.ATXGradeDelay),
 		miner.WithMinGoodAtxPercent(minerGoodAtxPct),
 		miner.WithLogger(app.addLogger(ProposalBuilderLogger, lg)),
 	)


### PR DESCRIPTION
related: https://github.com/spacemeshos/go-spacemesh/issues/5282

this should reduce variability in encoded active sets.
previous grader was using hare preround delay, which is 25s and not sufficient for atx to propagate across the network.