### PR TITLE
[Merged by Bors] - Do not delete initial post from local DB

### DIFF
--- a/activation/activation.go
+++ b/activation/activation.go
@@ -519,9 +519,6 @@ func (b *Builder) PublishActivationTx(ctx context.Context) error {
 	if err := nipost.RemoveChallenge(b.localDB, b.signer.NodeID()); err != nil {
 		return fmt.Errorf("discarding challenge after published ATX: %w", err)
 	}
-	if err := nipost.RemoveInitialPost(b.localDB, b.signer.NodeID()); err != nil {
-		return fmt.Errorf("discarding initial post after published ATX: %w", err)
-	}
 	events.EmitAtxPublished(
 		atx.PublishEpoch, atx.TargetEpoch(),
 		atx.ID(),

--- a/activation/activation_test.go
+++ b/activation/activation_test.go
@@ -805,9 +805,6 @@ func TestBuilder_PublishActivationTx_NoPrevATX(t *testing.T) {
 	require.NotNil(t, atx)
 
 	// state is cleaned up
-	_, err = nipost.InitialPost(tab.localDB, tab.sig.NodeID())
-	require.ErrorIs(t, err, sql.ErrNotFound)
-
 	_, err = nipost.Challenge(tab.localDB, tab.sig.NodeID())
 	require.ErrorIs(t, err, sql.ErrNotFound)
 }
@@ -1344,19 +1341,6 @@ func TestBuilder_InitialPostIsPersisted(t *testing.T) {
 	require.NoError(t, tab.buildInitialPost(context.Background()))
 
 	// postClient.Proof() should not be called again
-	require.NoError(t, tab.buildInitialPost(context.Background()))
-
-	// Remove the persisted post file and try again
-	require.NoError(t, nipost.RemoveInitialPost(tab.localDb, tab.signer.NodeID()))
-	tab.mpostClient.EXPECT().Proof(gomock.Any(), shared.ZeroChallenge).
-		Return(
-			&types.Post{Indices: make([]byte, 10)},
-			&types.PostInfo{
-				CommitmentATX: types.RandomATXID(),
-				Nonce:         new(types.VRFPostIndex),
-			},
-			nil,
-		)
 	require.NoError(t, tab.buildInitialPost(context.Background()))
 }
 

--- a/sql/localsql/nipost/nipost.go
+++ b/sql/localsql/nipost/nipost.go
@@ -37,16 +37,6 @@ func AddInitialPost(db sql.Executor, nodeID types.NodeID, post Post) error {
 	return nil
 }
 
-func RemoveInitialPost(db sql.Executor, nodeID types.NodeID) error {
-	enc := func(stmt *sql.Statement) {
-		stmt.BindBytes(1, nodeID.Bytes())
-	}
-	if _, err := db.Exec(`delete from initial_post where id = ?1;`, enc, nil); err != nil {
-		return fmt.Errorf("remove initial post for %s: %w", nodeID, err)
-	}
-	return nil
-}
-
 func InitialPost(db sql.Executor, nodeID types.NodeID) (*Post, error) {
 	var post *Post
 	enc := func(stmt *sql.Statement) {

--- a/sql/localsql/nipost/nipost_test.go
+++ b/sql/localsql/nipost/nipost_test.go
@@ -30,13 +30,6 @@ func Test_AddInitialPost(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, got)
 	require.Equal(t, post, *got)
-
-	err = RemoveInitialPost(db, nodeID)
-	require.NoError(t, err)
-
-	got, err = InitialPost(db, nodeID)
-	require.ErrorIs(t, err, sql.ErrNotFound)
-	require.Nil(t, got)
 }
 
 func Test_AddInitialPost_NoDuplicates(t *testing.T) {


### PR DESCRIPTION
## Motivation
Part of #5206 do not delete the initial PoST from the local DB. The initial post will be needed in the future to request PoET certificates and there is no drawback to keep it around for now.

## Changes
- remove `RemoveInitialPost` function and adapt tests.

## Test Plan
- existing tests have been updated

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
