### PR TITLE
[Merged by Bors] - Fix flaky test in timesync package

### DIFF
--- a/timesync/clock_test.go
+++ b/timesync/clock_test.go
@@ -155,7 +155,10 @@ func Test_NodeClock_Await_BeforeGenesis(t *testing.T) {
 
 	select {
 	case <-clock.AwaitLayer(types.LayerID(0)):
-		require.WithinRange(t, time.Now(), genesis, genesis.Add(tickInterval))
+		min := genesis
+		// allow for some delay (if tick interval aligns with layer duration)
+		max := genesis.Add(tickInterval).Add(10 * time.Millisecond)
+		require.WithinRange(t, time.Now(), min, max)
 	case <-time.After(5 * time.Second):
 		require.Fail(t, "timeout")
 	}


### PR DESCRIPTION
## Motivation
Fixes a flaky test in the `timesync` package.

## Changes
`Test_NodeClock_Await_BeforeGenesis` checks that awaiting a layer happens timely (within one tick interval). The test occasionally fails, when the tick interval aligns with the layer timing causing it to be a few µs late. The fix is to increase the allowed "lateness" slightly to not fail when this happens.

## Test Plan
n/a

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
