### PR TITLE
[Merged by Bors] - hare/eligibility: refactor expensive logging

### DIFF
--- a/hare/eligibility/oracle.go
+++ b/hare/eligibility/oracle.go
@@ -160,11 +160,6 @@ func (o *Oracle) minerWeight(ctx context.Context, layer types.LayerID, id types.
 
 	w, ok := actives.set[id]
 	if !ok {
-		o.With().Debug("miner is not active in specified layer",
-			log.Int("active_set_size", len(actives.set)),
-			log.String("actives", fmt.Sprintf("%v", actives)),
-			layer, log.Stringer("id.Key", id),
-		)
 		return 0, fmt.Errorf("%w: %v", ErrNotActive, id)
 	}
 	return w, nil
@@ -275,7 +270,7 @@ func (o *Oracle) Validate(
 	defer func() {
 		if msg := recover(); msg != nil {
 			o.WithContext(ctx).With().Fatal("panic in validate",
-				log.String("msg", fmt.Sprint(msg)),
+				log.Any("msg", msg),
 				log.Int("n", n),
 				log.String("p", p.String()),
 				log.String("vrf_frac", vrfFrac.String()),
@@ -294,8 +289,8 @@ func (o *Oracle) Validate(
 		id,
 		log.Uint16("eligibility_count", eligibilityCount),
 		log.Int("n", n),
-		log.String("p", p.String()),
-		log.String("vrf_frac", vrfFrac.String()),
+		log.Float64("p", p.Float()),
+		log.Float64("vrf_frac", vrfFrac.Float()),
 		log.Int("x", x),
 	)
 	return false, nil
@@ -322,11 +317,11 @@ func (o *Oracle) CalcEligibility(
 				layer,
 				layer.GetEpoch(),
 				log.Uint32("round_id", round),
-				log.String("msg", fmt.Sprint(msg)),
+				log.Any("msg", msg),
 				log.Int("committee_size", committeeSize),
 				log.Int("n", n),
-				log.String("p", fmt.Sprintf("%g", p.Float())),
-				log.String("vrf_frac", fmt.Sprintf("%g", vrfFrac.Float())),
+				log.Float64("p", p.Float()),
+				log.Float64("vrf_frac", vrfFrac.Float()),
 			)
 		}
 	}()
@@ -337,8 +332,8 @@ func (o *Oracle) CalcEligibility(
 		log.Uint32("round_id", round),
 		log.Int("committee_size", committeeSize),
 		log.Int("n", n),
-		log.String("p", fmt.Sprintf("%g", p.Float())),
-		log.String("vrf_frac", fmt.Sprintf("%g", vrfFrac.Float())),
+		log.Float64("p", p.Float()),
+		log.Float64("vrf_frac", vrfFrac.Float()),
 	)
 
 	for x := 0; x < n; x++ {

--- a/log/zap.go
+++ b/log/zap.go
@@ -140,6 +140,11 @@ func Uint64(name string, val uint64) Field {
 	return Field(zap.Uint64(name, val))
 }
 
+// Float64 returns a float64 Field.
+func Float64(name string, val float64) Field {
+	return Field(zap.Float64(name, val))
+}
+
 // Namespace make next fields be inside a namespace.
 func Namespace(name string) Field {
 	return Field(zap.Namespace(name))


### PR DESCRIPTION
mainly to remove encoding a set of ids if identity is inactive. 
it is very expensive to serialize to string thousands of 32 bytes values.

i started to refactor oracle https://github.com/spacemeshos/go-spacemesh/pull/5283
but won't finish it for some time.