### PR TITLE
[Merged by Bors] - Allow nodes to be started ready for remote smeshing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
         shell: bash
         run: |
           make install
-          make build VERSION=${{ github.ref_name }} BIN_DIR_WIN=./build
+          make build VERSION=${{ github.ref_name }}
 
       - name: Create release archive
         shell: bash

--- a/activation/activation.go
+++ b/activation/activation.go
@@ -58,7 +58,6 @@ const (
 
 // Config defines configuration for Builder.
 type Config struct {
-	CoinbaseAccount  types.Address
 	GoldenATXID      types.ATXID
 	LayersPerEpoch   uint32
 	RegossipInterval time.Duration
@@ -143,7 +142,6 @@ func NewBuilder(
 	b := &Builder{
 		parentCtx:         context.Background(),
 		signer:            signer,
-		coinbaseAccount:   conf.CoinbaseAccount,
 		goldenATXID:       conf.GoldenATXID,
 		regossipInterval:  conf.RegossipInterval,
 		cdb:               cdb,

--- a/activation/activation_test.go
+++ b/activation/activation_test.go
@@ -107,7 +107,6 @@ type testAtxBuilder struct {
 	cdb         *datastore.CachedDB
 	localDb     *localsql.Database
 	sig         *signing.EdSigner
-	coinbase    types.Address
 	goldenATXID types.ATXID
 
 	mpub        *mocks.MockPublisher
@@ -128,7 +127,6 @@ func newTestBuilder(tb testing.TB, opts ...BuilderOption) *testAtxBuilder {
 		cdb:         datastore.NewCachedDB(sql.InMemory(), lg),
 		localDb:     localsql.InMemory(),
 		sig:         edSigner,
-		coinbase:    types.GenerateAddress([]byte("33333")),
 		goldenATXID: types.ATXID(types.HexToHash32("77777")),
 		mpub:        mocks.NewMockPublisher(ctrl),
 		mpostSvc:    NewMockpostService(ctrl),
@@ -142,9 +140,8 @@ func newTestBuilder(tb testing.TB, opts ...BuilderOption) *testAtxBuilder {
 	opts = append(opts, WithValidator(tab.mValidator))
 
 	cfg := Config{
-		CoinbaseAccount: tab.coinbase,
-		GoldenATXID:     tab.goldenATXID,
-		LayersPerEpoch:  layersPerEpoch,
+		GoldenATXID:    tab.goldenATXID,
+		LayersPerEpoch: layersPerEpoch,
 	}
 
 	tab.msync.EXPECT().RegisterForATXSynced().DoAndReturn(closedChan).AnyTimes()

--- a/api/grpcserver/config.go
+++ b/api/grpcserver/config.go
@@ -12,7 +12,7 @@ type Config struct {
 	PrivateListener string `mapstructure:"grpc-private-listener"`
 	TLSServices     []Service
 	TLSListener     string `mapstructure:"grpc-tls-listener"`
-	TLSCACert       string `mapstructure:"gprc-tls-ca-cert"`
+	TLSCACert       string `mapstructure:"grpc-tls-ca-cert"`
 	TLSCert         string `mapstructure:"grpc-tls-cert"`
 	TLSKey          string `mapstructure:"grpc-tls-key"`
 	GrpcSendMsgSize int    `mapstructure:"grpc-send-msg-size"`

--- a/node/node.go
+++ b/node/node.go
@@ -1335,6 +1335,9 @@ func (app *App) startAPIServices(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
+		if err := app.grpcTLSServer.Start(); err != nil {
+			return err
+		}
 	}
 
 	if len(app.Config.API.JSONListener) > 0 {

--- a/systest/cluster/nodes.go
+++ b/systest/cluster/nodes.go
@@ -106,7 +106,7 @@ const (
 	poetConfigMapName      = "poet"
 	spacemeshConfigMapName = "spacemesh"
 
-	// smeshers are splitted in 10 approximately equal buckets
+	// smeshers are split in 10 approximately equal buckets
 	// to enable running chaos mesh tasks on the different parts of the cluster.
 	buckets = 10
 )


### PR DESCRIPTION
## Motivation
This changes the node startup in a way to allow a node to receive a remote PoST service connection.

## Changes
- if `--smeshing-start` is provided, but no `--smeshing-coinbase` the node will panic during startup
  - if both are provided node operates in supervised mode (smapp usecase)
  - if the provided coinbase is not valid the node will also panic during startup
- if `--smeshing-coinbase` is provided, but not `--smeshing-start` the node will be prepared to accept connections from remote PoST services
  - this additionally requires the following config parameters to be set to actually work (**TODO**: verify those during startup?)
    - `grpc-tls-listener`
    - `grpc-tls-ca-cert`
    - `grpc-tls-cert`
    - `grpc-tls-key`
- if neither `--smeshing-start` nor `--smeshing-coinbase` are provided the node can still be instructed to start (and stop) the supervised PoST mode via GRPC (**required for system tests** - coinbase is passed as argument and verified by node)
- if `--smeshing-coinbase` is not defined, but the TLS listener is set up correctly, remote connections should succeed but the node will not start smeshing (i.e. register at PoET, generate PoST proofs, publish ATXs, etc.)

## Test Plan
TODO: add system tests with remote post service

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [ ] Update [changelog](../CHANGELOG.md) as needed
