### PR TITLE
[Merged by Bors] - Swap stdlib for oasis for ed25519 signing and verification

### DIFF
--- a/genvm/cmd/gen/gen.go
+++ b/genvm/cmd/gen/gen.go
@@ -2,11 +2,11 @@ package gen
 
 import (
 	"bytes"
-	"crypto/ed25519"
 	"encoding/hex"
 	"fmt"
 	"os"
 
+	"github.com/oasisprotocol/curve25519-voi/primitives/ed25519"
 	"github.com/spacemeshos/economics/constants"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"

--- a/node/node.go
+++ b/node/node.go
@@ -1887,6 +1887,10 @@ func (app *App) Start(ctx context.Context) error {
 			return nil
 		})
 	}
+
+	// TODO(mafa): add code to fetch all ATXs from DB, decode and verify their signatures with
+	// the updated app.edVerifier and see if oasis is compatible to stdlib signatures.
+
 	// app blocks until it receives a signal to exit
 	// this signal may come from the node or from sig-abort (ctrl-c)
 	select {

--- a/node/node.go
+++ b/node/node.go
@@ -1905,6 +1905,8 @@ func (app *App) Start(ctx context.Context) error {
 
 		app.log.Info("checking ATX signatures")
 
+		count := 0
+
 		// check ATX signatures
 		atxs.IterateAtxs(app.cachedDB, 0, app.clock.CurrentLayer().GetEpoch(), func(atx *types.VerifiedActivationTx) bool {
 			// verify atx signature
@@ -1914,8 +1916,16 @@ func (app *App) Start(ctx context.Context) error {
 					log.Err(err),
 				)
 			}
+
+			count++
+			if count%1000 == 0 {
+				app.log.With().Info("verifying ATX signatures", log.Int("count", count))
+			}
+
 			return true
 		})
+
+		app.log.With().Info("ATX signatures verified", log.Int("count", count))
 		return nil
 	})
 

--- a/node/node.go
+++ b/node/node.go
@@ -1904,7 +1904,7 @@ func (app *App) Start(ctx context.Context) error {
 
 // verifyDB performs a verification of ATX signatures in the database.
 //
-//nolint:unused
+//lint:ignore U1000 This function is currently unused but is left here for future use.
 func (app *App) verifyDB(ctx context.Context) {
 	app.eg.Go(func() error {
 		app.log.Info("checking ATX signatures")

--- a/node/node.go
+++ b/node/node.go
@@ -1888,46 +1888,46 @@ func (app *App) Start(ctx context.Context) error {
 		})
 	}
 
-	app.eg.Go(func() error {
-	loop:
-		for {
-			app.log.Info("waiting for atx sync")
-			select {
-			case <-app.syncer.RegisterForATXSynced():
-				app.log.Info("atx sync done")
-				break loop
-			case <-ctx.Done():
-				return nil
-			case <-time.After(1 * time.Minute):
-				// wait for atx sync
-			}
-		}
+	// app.eg.Go(func() error {
+	// loop:
+	// 	for {
+	// 		app.log.Info("waiting for atx sync")
+	// 		select {
+	// 		case <-app.syncer.RegisterForATXSynced():
+	// 			app.log.Info("atx sync done")
+	// 			break loop
+	// 		case <-ctx.Done():
+	// 			return nil
+	// 		case <-time.After(1 * time.Minute):
+	// 			// wait for atx sync
+	// 		}
+	// 	}
 
-		app.log.Info("checking ATX signatures")
+	// 	app.log.Info("checking ATX signatures")
 
-		count := 0
+	// 	count := 0
 
-		// check ATX signatures
-		atxs.IterateAtxs(app.cachedDB, 0, app.clock.CurrentLayer().GetEpoch(), func(atx *types.VerifiedActivationTx) bool {
-			// verify atx signature
-			if !app.edVerifier.Verify(signing.ATX, atx.SmesherID, atx.SignedBytes(), atx.Signature) {
-				app.log.With().Error("ATX signature verification failed",
-					log.String("atx", atx.ShortString()),
-					log.Err(err),
-				)
-			}
+	// 	// check ATX signatures
+	// 	atxs.IterateAtxs(app.cachedDB, 0, app.clock.CurrentLayer().GetEpoch(), func(atx *types.VerifiedActivationTx) bool {
+	// 		// verify atx signature
+	// 		if !app.edVerifier.Verify(signing.ATX, atx.SmesherID, atx.SignedBytes(), atx.Signature) {
+	// 			app.log.With().Error("ATX signature verification failed",
+	// 				log.String("atx", atx.ShortString()),
+	// 				log.Err(err),
+	// 			)
+	// 		}
 
-			count++
-			if count%1000 == 0 {
-				app.log.With().Info("verifying ATX signatures", log.Int("count", count))
-			}
+	// 		count++
+	// 		if count%1000 == 0 {
+	// 			app.log.With().Info("verifying ATX signatures", log.Int("count", count))
+	// 		}
 
-			return true
-		})
+	// 		return true
+	// 	})
 
-		app.log.With().Info("ATX signatures verified", log.Int("count", count))
-		return nil
-	})
+	// 	app.log.With().Info("ATX signatures verified", log.Int("count", count))
+	// 	return nil
+	// })
 
 	// app blocks until it receives a signal to exit
 	// this signal may come from the node or from sig-abort (ctrl-c)

--- a/signing/keys.go
+++ b/signing/keys.go
@@ -1,8 +1,9 @@
 package signing
 
 import (
-	"crypto/ed25519"
 	"encoding/hex"
+
+	"github.com/oasisprotocol/curve25519-voi/primitives/ed25519"
 
 	"github.com/spacemeshos/go-spacemesh/log"
 )

--- a/signing/signer.go
+++ b/signing/signer.go
@@ -2,7 +2,6 @@ package signing
 
 import (
 	"bytes"
-	"crypto/ed25519"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -10,7 +9,7 @@ import (
 	"os"
 	"path/filepath"
 
-	oasis "github.com/oasisprotocol/curve25519-voi/primitives/ed25519"
+	"github.com/oasisprotocol/curve25519-voi/primitives/ed25519"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
 )
@@ -203,7 +202,7 @@ func (es *EdSigner) Name() string {
 // VRFSigner wraps same ed25519 key to provide ecvrf.
 func (es *EdSigner) VRFSigner() *VRFSigner {
 	return &VRFSigner{
-		privateKey: oasis.PrivateKey(es.priv),
+		privateKey: ed25519.PrivateKey(es.priv),
 		nodeID:     es.NodeID(),
 	}
 }

--- a/signing/signer_test.go
+++ b/signing/signer_test.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	voi "github.com/oasisprotocol/curve25519-voi/primitives/ed25519"
 	"github.com/stretchr/testify/require"
 )
 
@@ -145,21 +144,6 @@ func TestEdSigner_Sign(t *testing.T) {
 
 	ok := ed25519.Verify(ed.PublicKey().Bytes(), signed, sig[:])
 	require.Truef(t, ok, "failed to verify message %x with sig %x", m, sig)
-}
-
-func Fuzz_Bla(f *testing.F) {
-	pub, priv, err := ed25519.GenerateKey(nil)
-	require.NoError(f, err)
-
-	f.Fuzz(func(t *testing.T, m []byte) {
-		sig := ed25519.Sign(priv, m)
-
-		ok := ed25519.Verify(pub, m, sig)
-		require.Truef(t, ok, "failed to verify message %x with sig %x", m, sig)
-
-		ok = voi.Verify((voi.PublicKey)(pub), m, sig)
-		require.Truef(t, ok, "failed to verify message %x with sig %x", m, sig)
-	})
 }
 
 func TestEdSigner_ValidKeyEncoding(t *testing.T) {

--- a/signing/signer_test.go
+++ b/signing/signer_test.go
@@ -2,7 +2,6 @@ package signing
 
 import (
 	"bytes"
-	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/hex"
 	"io/fs"
@@ -10,6 +9,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/oasisprotocol/curve25519-voi/primitives/ed25519"
 	"github.com/stretchr/testify/require"
 )
 

--- a/signing/signer_test.go
+++ b/signing/signer_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	voi "github.com/oasisprotocol/curve25519-voi/primitives/ed25519"
 	"github.com/stretchr/testify/require"
 )
 
@@ -144,6 +145,21 @@ func TestEdSigner_Sign(t *testing.T) {
 
 	ok := ed25519.Verify(ed.PublicKey().Bytes(), signed, sig[:])
 	require.Truef(t, ok, "failed to verify message %x with sig %x", m, sig)
+}
+
+func Fuzz_Bla(f *testing.F) {
+	pub, priv, err := ed25519.GenerateKey(nil)
+	require.NoError(f, err)
+
+	f.Fuzz(func(t *testing.T, m []byte) {
+		sig := ed25519.Sign(priv, m)
+
+		ok := ed25519.Verify(pub, m, sig)
+		require.Truef(t, ok, "failed to verify message %x with sig %x", m, sig)
+
+		ok = voi.Verify((voi.PublicKey)(pub), m, sig)
+		require.Truef(t, ok, "failed to verify message %x with sig %x", m, sig)
+	})
 }
 
 func TestEdSigner_ValidKeyEncoding(t *testing.T) {

--- a/signing/verifier.go
+++ b/signing/verifier.go
@@ -1,7 +1,7 @@
 package signing
 
 import (
-	"crypto/ed25519"
+	"github.com/oasisprotocol/curve25519-voi/primitives/ed25519"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
 )

--- a/signing/verifier_test.go
+++ b/signing/verifier_test.go
@@ -1,10 +1,10 @@
 package signing_test
 
 import (
-	"crypto/ed25519"
 	"crypto/rand"
 	"testing"
 
+	"github.com/oasisprotocol/curve25519-voi/primitives/ed25519"
 	"github.com/stretchr/testify/require"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"

--- a/systest/cluster/cluster.go
+++ b/systest/cluster/cluster.go
@@ -2,7 +2,6 @@ package cluster
 
 import (
 	"context"
-	"crypto/ed25519"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -11,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/oasisprotocol/curve25519-voi/primitives/ed25519"
 	pb "github.com/spacemeshos/api/release/go/spacemesh/v1"
 	"go.uber.org/zap"
 	"golang.org/x/exp/maps"

--- a/systest/cluster/nodes.go
+++ b/systest/cluster/nodes.go
@@ -2,7 +2,6 @@ package cluster
 
 import (
 	"context"
-	"crypto/ed25519"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
@@ -15,6 +14,7 @@ import (
 	"time"
 
 	"github.com/mitchellh/mapstructure"
+	"github.com/oasisprotocol/curve25519-voi/primitives/ed25519"
 	"github.com/spf13/viper"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"

--- a/systest/tests/equivocation_test.go
+++ b/systest/tests/equivocation_test.go
@@ -1,10 +1,10 @@
 package tests
 
 import (
-	"crypto/ed25519"
 	"sync"
 	"testing"
 
+	"github.com/oasisprotocol/curve25519-voi/primitives/ed25519"
 	pb "github.com/spacemeshos/api/release/go/spacemesh/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"


### PR DESCRIPTION
## Motivation

Swap stdlib for oasis and check if existing ATXs pass signature verification with oasis library.

## Description

I swapped the ed25519 library and ran the verification code in `node.go`. All exiting ATXs (as of 2024-03-08) passed verification:

```
2024-03-08T20:16:13.767+0100	INFO	node	ATX signatures verified	{"count": 5932640, "name": ""}
```

## Test Plan

n/a

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
