### PR TITLE
[Merged by Bors] - Raise the atx-size cache to 300_000

### DIFF
--- a/datastore/store.go
+++ b/datastore/store.go
@@ -50,7 +50,7 @@ type Config struct {
 
 func DefaultConfig() Config {
 	return Config{
-		ATXSize:         150_000,
+		ATXSize:         300_000,
 		MalfeasenceSize: 1_000,
 	}
 }


### PR DESCRIPTION
To cache this and previous epoch ATXes. It should help with diskIO and CPU during the official poet CG & epochs.