### PR TITLE
[Merged by Bors] - P2P decentralization improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,15 @@ for more information on how to configure the node to work with the PoST service.
   query rewards by smesherID. Additionally, it does not re-index old data. Rewards will contain smesherID going forward,
   but to refresh data for all rewards, a node will have to delete its database and resync from genesis.
 
+* [#5329](https://github.com/spacemeshos/go-spacemesh/pull/5329) P2P decentralization improvements. Added support for QUIC
+  transport and DHT routing discovery for finding peers and relays. Also, added the `ping-peers` feature which is useful
+  during connectivity troubleshooting. `static-relays` feature can be used to provide a static list of circuit v2 relays
+  nodes when automatic relay discovery is not desired. All of the relay server resource settings are now configurable. Most
+  of the new functionality is disabled by default unless explicitly enabled in the config via `enable-routing-discovery`,
+  `routing-discovery-advertise`, `enable-quic-transport`, `static-relays` and `ping-peers` options in the `p2p` config
+  section. The non-conditional changes include values/provides support on all of the nodes, which will enable DHT to
+  function efficiently for routing discovery.
+
 ## Release v1.2.9
 
 ### Improvements

--- a/README.md
+++ b/README.md
@@ -439,6 +439,49 @@ as on UNIX-based systems.
 - This is a great way to get a feel for the protocol and the platform and to start hacking on Spacemesh.
 - Follow the steps in our [Local Testnet Guide](https://testnet.spacemesh.io/#/README)
 
+### Improved decentralization and P2P diagnostic features
+
+**WARNING! THIS IS EXPERIMENTAL FUNCTIONALITY, USE WITH CARE!**
+
+In order to make the p2p network more decentralized, the following options are provided:
+- `"enable-routing-discovery": true`: enables routing discovery for finding new peers, including those behind NAT, ans
+  also for discovering relay nodes which are used for NAT hole punching. Note that hole punching can be done when both
+  ends of the connection are behind an endpoint-independent ("cone") NAT.
+- `"routing-discovery-advertise": true` advertises this node for discovery by other peers, even if it is behind NAT.
+- `"enable-quic-transport": true`: enables QUIC transport which, together with TCP transport, heightens the changes of
+  successful NAT hole punching.
+- `"enable-tcp-transport": false` disables TCP transport. This option is intended to be used for debugging purposes
+  only!
+- `"static-relays": ["/dns4/relay.example.com/udp/5000/quic-v1/p2p/...", ...]` provides a static list of relay nodes for
+  use for NAT hole punching in case of routing discovery based relay search is not to be used.
+- `"ping-peers": ["p2p_id_1", "p2p_id_2", ...]` runs P2P ping against the specified peers, logging the results.
+
+For the purpose of debugging P2P connectivity issues, the following command can also be used:
+```console
+$ grpcurl -plaintext 127.0.0.1:9093 spacemesh.v1.DebugService.NetworkInfo
+{
+  "id": "12D3Koo...",
+  "listenAddresses": [
+    "/ip4/0.0.0.0/tcp/50212",
+    "/ip4/0.0.0.0/udp/59458/quic-v1",
+    "/p2p-circuit"
+  ],
+  "knownAddresses": [
+    "/ip4/127.0.0.1/tcp/50212",
+    "/ip4/127.0.0.1/udp/59458/quic-v1",
+    "/ip4/192.168.33.5/tcp/50212",
+    "/ip4/192.168.33.5/udp/59458/quic-v1",
+    "/ip4/.../tcp/37670/p2p/12D3Koo.../p2p-circuit",
+    "/ip4/.../udp/37659/quic-v1/p2p/12D3Koo.../p2p-circuit",
+    "/ip4/.../tcp/31960/p2p/12D3Koo.../p2p-circuit",
+    "/ip4/.../udp/33377/quic-v1/p2p/12D3Koo.../p2p-circuit"
+  ],
+  "natTypeUdp": "Cone",
+  "natTypeTcp": "Cone",
+  "reachability": "Private"
+}
+```
+
 #### Next Steps
 
 - Please visit our [wiki](https://github.com/spacemeshos/go-spacemesh/wiki)

--- a/api/grpcserver/debug_service.go
+++ b/api/grpcserver/debug_service.go
@@ -3,9 +3,11 @@ package grpcserver
 import (
 	"context"
 	"fmt"
+	"sort"
 
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	"github.com/libp2p/go-libp2p/core/network"
 	pb "github.com/spacemeshos/api/release/go/spacemesh/v1"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
@@ -24,7 +26,7 @@ import (
 type DebugService struct {
 	db       *sql.Database
 	conState conservativeState
-	identity networkIdentity
+	netInfo  networkInfo
 	oracle   oracle
 }
 
@@ -43,11 +45,11 @@ func (d DebugService) String() string {
 }
 
 // NewDebugService creates a new grpc service using config data.
-func NewDebugService(db *sql.Database, conState conservativeState, host networkIdentity, oracle oracle) *DebugService {
+func NewDebugService(db *sql.Database, conState conservativeState, host networkInfo, oracle oracle) *DebugService {
 	return &DebugService{
 		db:       db,
 		conState: conState,
-		identity: host,
+		netInfo:  host,
 		oracle:   oracle,
 	}
 }
@@ -91,7 +93,21 @@ func (d DebugService) Accounts(ctx context.Context, in *pb.AccountsRequest) (*pb
 
 // NetworkInfo query provides NetworkInfoResponse.
 func (d DebugService) NetworkInfo(ctx context.Context, _ *emptypb.Empty) (*pb.NetworkInfoResponse, error) {
-	return &pb.NetworkInfoResponse{Id: d.identity.ID().String()}, nil
+	resp := &pb.NetworkInfoResponse{Id: d.netInfo.ID().String()}
+	for _, a := range d.netInfo.ListenAddresses() {
+		resp.ListenAddresses = append(resp.ListenAddresses, a.String())
+	}
+	sort.Strings(resp.ListenAddresses)
+	for _, a := range d.netInfo.KnownAddresses() {
+		resp.KnownAddresses = append(resp.KnownAddresses, a.String())
+	}
+	sort.Strings(resp.KnownAddresses)
+	udpNATType, tcpNATType := d.netInfo.NATDeviceType()
+	resp.NatTypeUdp = convertNATType(udpNATType)
+	resp.NatTypeTcp = convertNATType(tcpNATType)
+	resp.Reachability = convertReachability(d.netInfo.Reachability())
+	resp.DhtServerEnabled = d.netInfo.DHTServerEnabled()
+	return resp, nil
 }
 
 // ActiveSet query provides hare active set for the specified epoch.
@@ -157,4 +173,26 @@ func castEventProposal(ev *events.EventProposal) *pb.Proposal {
 		})
 	}
 	return proposal
+}
+
+func convertNATType(natType network.NATDeviceType) pb.NetworkInfoResponse_NATType {
+	switch natType {
+	case network.NATDeviceTypeCone:
+		return pb.NetworkInfoResponse_Cone
+	case network.NATDeviceTypeSymmetric:
+		return pb.NetworkInfoResponse_Symmetric
+	default:
+		return pb.NetworkInfoResponse_NATTypeUnknown
+	}
+}
+
+func convertReachability(r network.Reachability) pb.NetworkInfoResponse_Reachability {
+	switch r {
+	case network.ReachabilityPublic:
+		return pb.NetworkInfoResponse_Public
+	case network.ReachabilityPrivate:
+		return pb.NetworkInfoResponse_Private
+	default:
+		return pb.NetworkInfoResponse_ReachabilityUnknown
+	}
 }

--- a/api/grpcserver/grpcserver_test.go
+++ b/api/grpcserver/grpcserver_test.go
@@ -17,6 +17,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/libp2p/go-libp2p/core/network"
+	ma "github.com/multiformats/go-multiaddr"
 	pb "github.com/spacemeshos/api/release/go/spacemesh/v1"
 	"github.com/spacemeshos/merkle-tree"
 	"github.com/spacemeshos/poet/shared"
@@ -2043,10 +2045,10 @@ func TestMultiService(t *testing.T) {
 
 func TestDebugService(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	identity := NewMocknetworkIdentity(ctrl)
+	netInfo := NewMocknetworkInfo(ctrl)
 	mOracle := NewMockoracle(ctrl)
 	db := sql.InMemory()
-	svc := NewDebugService(db, conStateAPI, identity, mOracle)
+	svc := NewDebugService(db, conStateAPI, netInfo, mOracle)
 	cfg, cleanup := launchServer(t, svc)
 	t.Cleanup(cleanup)
 
@@ -2097,13 +2099,33 @@ func TestDebugService(t *testing.T) {
 
 	t.Run("networkID", func(t *testing.T) {
 		id := p2p.Peer("test")
-		identity.EXPECT().ID().Return(id)
+		netInfo.EXPECT().ID().Return(id)
+		netInfo.EXPECT().ListenAddresses().Return([]ma.Multiaddr{
+			mustParseMultiaddr("/ip4/0.0.0.0/tcp/5000"),
+			mustParseMultiaddr("/ip4/0.0.0.0/udp/5001/quic-v1"),
+		})
+		netInfo.EXPECT().KnownAddresses().Return([]ma.Multiaddr{
+			mustParseMultiaddr("/ip4/10.36.0.221/tcp/5000"),
+			mustParseMultiaddr("/ip4/10.36.0.221/udp/5001/quic-v1"),
+		})
+		netInfo.EXPECT().NATDeviceType().Return(network.NATDeviceTypeCone, network.NATDeviceTypeSymmetric)
+		netInfo.EXPECT().Reachability().Return(network.ReachabilityPrivate)
+		netInfo.EXPECT().DHTServerEnabled().Return(true)
 
 		response, err := c.NetworkInfo(context.Background(), &emptypb.Empty{})
 		require.NoError(t, err)
 		require.NotNil(t, response)
 		require.Equal(t, id.String(), response.Id)
+		require.Equal(t, []string{"/ip4/0.0.0.0/tcp/5000", "/ip4/0.0.0.0/udp/5001/quic-v1"},
+			response.ListenAddresses)
+		require.Equal(t, []string{"/ip4/10.36.0.221/tcp/5000", "/ip4/10.36.0.221/udp/5001/quic-v1"},
+			response.KnownAddresses)
+		require.Equal(t, pb.NetworkInfoResponse_Cone, response.NatTypeUdp)
+		require.Equal(t, pb.NetworkInfoResponse_Symmetric, response.NatTypeTcp)
+		require.Equal(t, pb.NetworkInfoResponse_Private, response.Reachability)
+		require.True(t, response.DhtServerEnabled)
 	})
+
 	t.Run("ActiveSet", func(t *testing.T) {
 		epoch := types.EpochID(3)
 		activeSet := types.RandomActiveSet(11)
@@ -2444,4 +2466,12 @@ func TestMeshService_EpochStream(t *testing.T) {
 		got = append(got, types.ATXID(types.BytesToHash(resp.GetId().GetId())))
 	}
 	require.ElementsMatch(t, expected, got)
+}
+
+func mustParseMultiaddr(s string) ma.Multiaddr {
+	maddr, err := ma.NewMultiaddr(s)
+	if err != nil {
+		panic("can't parse multiaddr: " + err.Error())
+	}
+	return maddr
 }

--- a/api/grpcserver/interface.go
+++ b/api/grpcserver/interface.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"time"
 
+	"github.com/libp2p/go-libp2p/core/network"
+	ma "github.com/multiformats/go-multiaddr"
+
 	"github.com/spacemeshos/go-spacemesh/activation"
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/p2p"
@@ -12,9 +15,14 @@ import (
 
 //go:generate mockgen -typed -package=grpcserver -destination=./mocks.go -source=./interface.go
 
-// networkIdentity interface.
-type networkIdentity interface {
+// networkInfo interface.
+type networkInfo interface {
 	ID() p2p.Peer
+	ListenAddresses() []ma.Multiaddr
+	KnownAddresses() []ma.Multiaddr
+	NATDeviceType() (udpNATType, tcpNATType network.NATDeviceType)
+	Reachability() network.Reachability
+	DHTServerEnabled() bool
 }
 
 // conservativeState is an API for reading state and transaction/mempool data.

--- a/api/grpcserver/mocks.go
+++ b/api/grpcserver/mocks.go
@@ -13,6 +13,8 @@ import (
 	reflect "reflect"
 	time "time"
 
+	network "github.com/libp2p/go-libp2p/core/network"
+	multiaddr "github.com/multiformats/go-multiaddr"
 	activation "github.com/spacemeshos/go-spacemesh/activation"
 	types "github.com/spacemeshos/go-spacemesh/common/types"
 	p2p "github.com/spacemeshos/go-spacemesh/p2p"
@@ -20,31 +22,69 @@ import (
 	gomock "go.uber.org/mock/gomock"
 )
 
-// MocknetworkIdentity is a mock of networkIdentity interface.
-type MocknetworkIdentity struct {
+// MocknetworkInfo is a mock of networkInfo interface.
+type MocknetworkInfo struct {
 	ctrl     *gomock.Controller
-	recorder *MocknetworkIdentityMockRecorder
+	recorder *MocknetworkInfoMockRecorder
 }
 
-// MocknetworkIdentityMockRecorder is the mock recorder for MocknetworkIdentity.
-type MocknetworkIdentityMockRecorder struct {
-	mock *MocknetworkIdentity
+// MocknetworkInfoMockRecorder is the mock recorder for MocknetworkInfo.
+type MocknetworkInfoMockRecorder struct {
+	mock *MocknetworkInfo
 }
 
-// NewMocknetworkIdentity creates a new mock instance.
-func NewMocknetworkIdentity(ctrl *gomock.Controller) *MocknetworkIdentity {
-	mock := &MocknetworkIdentity{ctrl: ctrl}
-	mock.recorder = &MocknetworkIdentityMockRecorder{mock}
+// NewMocknetworkInfo creates a new mock instance.
+func NewMocknetworkInfo(ctrl *gomock.Controller) *MocknetworkInfo {
+	mock := &MocknetworkInfo{ctrl: ctrl}
+	mock.recorder = &MocknetworkInfoMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MocknetworkIdentity) EXPECT() *MocknetworkIdentityMockRecorder {
+func (m *MocknetworkInfo) EXPECT() *MocknetworkInfoMockRecorder {
 	return m.recorder
 }
 
+// DHTServerEnabled mocks base method.
+func (m *MocknetworkInfo) DHTServerEnabled() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DHTServerEnabled")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// DHTServerEnabled indicates an expected call of DHTServerEnabled.
+func (mr *MocknetworkInfoMockRecorder) DHTServerEnabled() *networkInfoDHTServerEnabledCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DHTServerEnabled", reflect.TypeOf((*MocknetworkInfo)(nil).DHTServerEnabled))
+	return &networkInfoDHTServerEnabledCall{Call: call}
+}
+
+// networkInfoDHTServerEnabledCall wrap *gomock.Call
+type networkInfoDHTServerEnabledCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *networkInfoDHTServerEnabledCall) Return(arg0 bool) *networkInfoDHTServerEnabledCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *networkInfoDHTServerEnabledCall) Do(f func() bool) *networkInfoDHTServerEnabledCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *networkInfoDHTServerEnabledCall) DoAndReturn(f func() bool) *networkInfoDHTServerEnabledCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // ID mocks base method.
-func (m *MocknetworkIdentity) ID() p2p.Peer {
+func (m *MocknetworkInfo) ID() p2p.Peer {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ID")
 	ret0, _ := ret[0].(p2p.Peer)
@@ -52,31 +92,184 @@ func (m *MocknetworkIdentity) ID() p2p.Peer {
 }
 
 // ID indicates an expected call of ID.
-func (mr *MocknetworkIdentityMockRecorder) ID() *networkIdentityIDCall {
+func (mr *MocknetworkInfoMockRecorder) ID() *networkInfoIDCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ID", reflect.TypeOf((*MocknetworkIdentity)(nil).ID))
-	return &networkIdentityIDCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ID", reflect.TypeOf((*MocknetworkInfo)(nil).ID))
+	return &networkInfoIDCall{Call: call}
 }
 
-// networkIdentityIDCall wrap *gomock.Call
-type networkIdentityIDCall struct {
+// networkInfoIDCall wrap *gomock.Call
+type networkInfoIDCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *networkIdentityIDCall) Return(arg0 p2p.Peer) *networkIdentityIDCall {
+func (c *networkInfoIDCall) Return(arg0 p2p.Peer) *networkInfoIDCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *networkIdentityIDCall) Do(f func() p2p.Peer) *networkIdentityIDCall {
+func (c *networkInfoIDCall) Do(f func() p2p.Peer) *networkInfoIDCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *networkIdentityIDCall) DoAndReturn(f func() p2p.Peer) *networkIdentityIDCall {
+func (c *networkInfoIDCall) DoAndReturn(f func() p2p.Peer) *networkInfoIDCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// KnownAddresses mocks base method.
+func (m *MocknetworkInfo) KnownAddresses() []multiaddr.Multiaddr {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "KnownAddresses")
+	ret0, _ := ret[0].([]multiaddr.Multiaddr)
+	return ret0
+}
+
+// KnownAddresses indicates an expected call of KnownAddresses.
+func (mr *MocknetworkInfoMockRecorder) KnownAddresses() *networkInfoKnownAddressesCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "KnownAddresses", reflect.TypeOf((*MocknetworkInfo)(nil).KnownAddresses))
+	return &networkInfoKnownAddressesCall{Call: call}
+}
+
+// networkInfoKnownAddressesCall wrap *gomock.Call
+type networkInfoKnownAddressesCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *networkInfoKnownAddressesCall) Return(arg0 []multiaddr.Multiaddr) *networkInfoKnownAddressesCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *networkInfoKnownAddressesCall) Do(f func() []multiaddr.Multiaddr) *networkInfoKnownAddressesCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *networkInfoKnownAddressesCall) DoAndReturn(f func() []multiaddr.Multiaddr) *networkInfoKnownAddressesCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// ListenAddresses mocks base method.
+func (m *MocknetworkInfo) ListenAddresses() []multiaddr.Multiaddr {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListenAddresses")
+	ret0, _ := ret[0].([]multiaddr.Multiaddr)
+	return ret0
+}
+
+// ListenAddresses indicates an expected call of ListenAddresses.
+func (mr *MocknetworkInfoMockRecorder) ListenAddresses() *networkInfoListenAddressesCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListenAddresses", reflect.TypeOf((*MocknetworkInfo)(nil).ListenAddresses))
+	return &networkInfoListenAddressesCall{Call: call}
+}
+
+// networkInfoListenAddressesCall wrap *gomock.Call
+type networkInfoListenAddressesCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *networkInfoListenAddressesCall) Return(arg0 []multiaddr.Multiaddr) *networkInfoListenAddressesCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *networkInfoListenAddressesCall) Do(f func() []multiaddr.Multiaddr) *networkInfoListenAddressesCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *networkInfoListenAddressesCall) DoAndReturn(f func() []multiaddr.Multiaddr) *networkInfoListenAddressesCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// NATDeviceType mocks base method.
+func (m *MocknetworkInfo) NATDeviceType() (network.NATDeviceType, network.NATDeviceType) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NATDeviceType")
+	ret0, _ := ret[0].(network.NATDeviceType)
+	ret1, _ := ret[1].(network.NATDeviceType)
+	return ret0, ret1
+}
+
+// NATDeviceType indicates an expected call of NATDeviceType.
+func (mr *MocknetworkInfoMockRecorder) NATDeviceType() *networkInfoNATDeviceTypeCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NATDeviceType", reflect.TypeOf((*MocknetworkInfo)(nil).NATDeviceType))
+	return &networkInfoNATDeviceTypeCall{Call: call}
+}
+
+// networkInfoNATDeviceTypeCall wrap *gomock.Call
+type networkInfoNATDeviceTypeCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *networkInfoNATDeviceTypeCall) Return(udpNATType, tcpNATType network.NATDeviceType) *networkInfoNATDeviceTypeCall {
+	c.Call = c.Call.Return(udpNATType, tcpNATType)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *networkInfoNATDeviceTypeCall) Do(f func() (network.NATDeviceType, network.NATDeviceType)) *networkInfoNATDeviceTypeCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *networkInfoNATDeviceTypeCall) DoAndReturn(f func() (network.NATDeviceType, network.NATDeviceType)) *networkInfoNATDeviceTypeCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// Reachability mocks base method.
+func (m *MocknetworkInfo) Reachability() network.Reachability {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Reachability")
+	ret0, _ := ret[0].(network.Reachability)
+	return ret0
+}
+
+// Reachability indicates an expected call of Reachability.
+func (mr *MocknetworkInfoMockRecorder) Reachability() *networkInfoReachabilityCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reachability", reflect.TypeOf((*MocknetworkInfo)(nil).Reachability))
+	return &networkInfoReachabilityCall{Call: call}
+}
+
+// networkInfoReachabilityCall wrap *gomock.Call
+type networkInfoReachabilityCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *networkInfoReachabilityCall) Return(arg0 network.Reachability) *networkInfoReachabilityCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *networkInfoReachabilityCall) Do(f func() network.Reachability) *networkInfoReachabilityCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *networkInfoReachabilityCall) DoAndReturn(f func() network.Reachability) *networkInfoReachabilityCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/cmd/base.go
+++ b/cmd/base.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/config"
 	"github.com/spacemeshos/go-spacemesh/node/flags"
+	"github.com/spacemeshos/go-spacemesh/p2p"
 )
 
 var (
@@ -88,6 +89,13 @@ func EnsureCLIFlags(cmd *cobra.Command, appCFG *config.Config) error {
 						panic(err.Error())
 					}
 					val = dst
+				case "p2p.AddressList":
+					var al p2p.AddressList
+					alv := flags.NewAddressListValue(al, &al)
+					if err := alv.Set(viper.GetString(name)); err != nil {
+						panic(err.Error())
+					}
+					val = al
 				default:
 					val = viper.Get(name)
 				}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -133,8 +133,8 @@ func AddCommands(cmd *cobra.Command) {
 		"enable QUIC transport")
 	cmd.PersistentFlags().BoolVar(&cfg.P2P.EnableRoutingDiscovery, "enable-routing-discovery", cfg.P2P.EnableQUICTransport,
 		"enable routing discovery")
-	cmd.PersistentFlags().BoolVar(&cfg.P2P.RoutingDiscoveryNoAdvertise, "routing-discovery-no-advertise",
-		cfg.P2P.RoutingDiscoveryNoAdvertise, "disable advertise for routing discovery")
+	cmd.PersistentFlags().BoolVar(&cfg.P2P.RoutingDiscoveryAdvertise, "routing-discovery-advertise",
+		cfg.P2P.RoutingDiscoveryAdvertise, "advertise for routing discovery")
 
 	/** ======================== TIME Flags ========================== **/
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -117,7 +117,8 @@ func AddCommands(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringSliceVar(&cfg.P2P.Bootnodes, "bootnodes",
 		cfg.P2P.Bootnodes, "entrypoints into the network")
 	cmd.PersistentFlags().StringSliceVar(&cfg.P2P.PingPeers, "ping-peers", cfg.P2P.Bootnodes, "peers to ping")
-	cmd.PersistentFlags().StringSliceVar(&cfg.P2P.Relays, "relays", cfg.P2P.Bootnodes, "static relay list")
+	cmd.PersistentFlags().StringSliceVar(&cfg.P2P.StaticRelays, "static-relays",
+		cfg.P2P.Bootnodes, "static relay list")
 	cmd.PersistentFlags().StringVar(&cfg.P2P.AdvertiseAddress, "advertise-address",
 		cfg.P2P.AdvertiseAddress, "libp2p address with identity (example: /dns4/bootnode.spacemesh.io/tcp/5003)")
 	cmd.PersistentFlags().StringSliceVar(&cfg.P2P.AdvertiseAddresses, "advertise-addresses",

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -84,10 +84,8 @@ func AddCommands(cmd *cobra.Command) {
 
 	/** ======================== P2P Flags ========================== **/
 
-	cmd.PersistentFlags().StringVar(&cfg.P2P.Listen, "listen",
-		cfg.P2P.Listen, "address for listening")
-	cmd.PersistentFlags().StringSliceVar(&cfg.P2P.ListenAddresses, "listen-addresses",
-		cfg.P2P.ListenAddresses, "addresses for listening")
+	cmd.PersistentFlags().Var(flags.NewAddressListValue(cfg.P2P.Listen, &cfg.P2P.Listen),
+		"listen", "address(es) for listening")
 	cmd.PersistentFlags().BoolVar(&cfg.P2P.Flood, "flood",
 		cfg.P2P.Flood, "flood created messages to all peers")
 	cmd.PersistentFlags().BoolVar(&cfg.P2P.DisableNatPort, "disable-natport", cfg.P2P.DisableNatPort,
@@ -118,11 +116,10 @@ func AddCommands(cmd *cobra.Command) {
 		cfg.P2P.Bootnodes, "entrypoints into the network")
 	cmd.PersistentFlags().StringSliceVar(&cfg.P2P.PingPeers, "ping-peers", cfg.P2P.Bootnodes, "peers to ping")
 	cmd.PersistentFlags().StringSliceVar(&cfg.P2P.StaticRelays, "static-relays",
-		cfg.P2P.Bootnodes, "static relay list")
-	cmd.PersistentFlags().StringVar(&cfg.P2P.AdvertiseAddress, "advertise-address",
-		cfg.P2P.AdvertiseAddress, "libp2p address with identity (example: /dns4/bootnode.spacemesh.io/tcp/5003)")
-	cmd.PersistentFlags().StringSliceVar(&cfg.P2P.AdvertiseAddresses, "advertise-addresses",
-		cfg.P2P.AdvertiseAddresses, "libp2p addresses with identity (example: /dns4/bootnode.spacemesh.io/tcp/5003)")
+		cfg.P2P.StaticRelays, "static relay list")
+	cmd.PersistentFlags().Var(flags.NewAddressListValue(cfg.P2P.AdvertiseAddress, &cfg.P2P.AdvertiseAddress),
+		"advertise-address",
+		"libp2p address(es) with identity (example: /dns4/bootnode.spacemesh.io/tcp/5003)")
 	cmd.PersistentFlags().BoolVar(&cfg.P2P.Bootnode, "p2p-bootnode", cfg.P2P.Bootnode,
 		"gossipsub and discovery will be running in a mode suitable for bootnode")
 	cmd.PersistentFlags().BoolVar(&cfg.P2P.PrivateNetwork, "p2p-private-network", cfg.P2P.PrivateNetwork,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -116,6 +116,8 @@ func AddCommands(cmd *cobra.Command) {
 		cfg.P2P.MinPeers, "actively search for peers until you get this much")
 	cmd.PersistentFlags().StringSliceVar(&cfg.P2P.Bootnodes, "bootnodes",
 		cfg.P2P.Bootnodes, "entrypoints into the network")
+	cmd.PersistentFlags().StringSliceVar(&cfg.P2P.PingPeers, "ping-peers", cfg.P2P.Bootnodes, "peers to ping")
+	cmd.PersistentFlags().StringSliceVar(&cfg.P2P.Relays, "relays", cfg.P2P.Bootnodes, "static relay list")
 	cmd.PersistentFlags().StringVar(&cfg.P2P.AdvertiseAddress, "advertise-address",
 		cfg.P2P.AdvertiseAddress, "libp2p address with identity (example: /dns4/bootnode.spacemesh.io/tcp/5003)")
 	cmd.PersistentFlags().StringSliceVar(&cfg.P2P.AdvertiseAddresses, "advertise-addresses",
@@ -124,6 +126,14 @@ func AddCommands(cmd *cobra.Command) {
 		"gossipsub and discovery will be running in a mode suitable for bootnode")
 	cmd.PersistentFlags().BoolVar(&cfg.P2P.PrivateNetwork, "p2p-private-network", cfg.P2P.PrivateNetwork,
 		"discovery will work in private mode. mostly useful for testing, don't set in public networks")
+	cmd.PersistentFlags().BoolVar(&cfg.P2P.ForceDHTServer, "force-dht-server", cfg.P2P.ForceDHTServer,
+		"force DHT server mode")
+	cmd.PersistentFlags().BoolVar(&cfg.P2P.EnableTCPTransport, "enable-tcp-transport", cfg.P2P.EnableTCPTransport,
+		"enable TCP transport")
+	cmd.PersistentFlags().BoolVar(&cfg.P2P.EnableQUICTransport, "enable-quic-transport", cfg.P2P.EnableQUICTransport,
+		"enable QUIC transport")
+	cmd.PersistentFlags().BoolVar(&cfg.P2P.EnableRoutingDiscovery, "enable-routing-discovery", cfg.P2P.EnableQUICTransport,
+		"enable routing discovery")
 
 	/** ======================== TIME Flags ========================== **/
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -115,6 +115,7 @@ func AddCommands(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringSliceVar(&cfg.P2P.Bootnodes, "bootnodes",
 		cfg.P2P.Bootnodes, "entrypoints into the network")
 	cmd.PersistentFlags().StringSliceVar(&cfg.P2P.PingPeers, "ping-peers", cfg.P2P.Bootnodes, "peers to ping")
+	cmd.PersistentFlags().DurationVar(&cfg.P2P.PingInterval, "ping-interval", cfg.P2P.PingInterval, "ping interval")
 	cmd.PersistentFlags().StringSliceVar(&cfg.P2P.StaticRelays, "static-relays",
 		cfg.P2P.StaticRelays, "static relay list")
 	cmd.PersistentFlags().Var(flags.NewAddressListValue(cfg.P2P.AdvertiseAddress, &cfg.P2P.AdvertiseAddress),

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -134,6 +134,8 @@ func AddCommands(cmd *cobra.Command) {
 		"enable QUIC transport")
 	cmd.PersistentFlags().BoolVar(&cfg.P2P.EnableRoutingDiscovery, "enable-routing-discovery", cfg.P2P.EnableQUICTransport,
 		"enable routing discovery")
+	cmd.PersistentFlags().BoolVar(&cfg.P2P.RoutingDiscoveryNoAdvertise, "routing-discovery-no-advertise",
+		cfg.P2P.RoutingDiscoveryNoAdvertise, "disable advertise for routing discovery")
 
 	/** ======================== TIME Flags ========================== **/
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -84,8 +84,8 @@ func AddCommands(cmd *cobra.Command) {
 
 	/** ======================== P2P Flags ========================== **/
 
-	cmd.PersistentFlags().StringVar(&cfg.P2P.Listen, "listen",
-		cfg.P2P.Listen, "address for listening")
+	cmd.PersistentFlags().StringSliceVar(&cfg.P2P.ListenAddresses, "listen",
+		cfg.P2P.ListenAddresses, "address for listening")
 	cmd.PersistentFlags().BoolVar(&cfg.P2P.Flood, "flood",
 		cfg.P2P.Flood, "flood created messages to all peers")
 	cmd.PersistentFlags().BoolVar(&cfg.P2P.DisableNatPort, "disable-natport", cfg.P2P.DisableNatPort,
@@ -114,8 +114,8 @@ func AddCommands(cmd *cobra.Command) {
 		cfg.P2P.MinPeers, "actively search for peers until you get this much")
 	cmd.PersistentFlags().StringSliceVar(&cfg.P2P.Bootnodes, "bootnodes",
 		cfg.P2P.Bootnodes, "entrypoints into the network")
-	cmd.PersistentFlags().StringVar(&cfg.P2P.AdvertiseAddress, "advertise-address",
-		cfg.P2P.AdvertiseAddress, "libp2p address with identity (example: /dns4/bootnode.spacemesh.io/tcp/5003)")
+	cmd.PersistentFlags().StringSliceVar(&cfg.P2P.AdvertiseAddresses, "advertise-address",
+		cfg.P2P.AdvertiseAddresses, "libp2p address(es) with identity (example: /dns4/bootnode.spacemesh.io/tcp/5003)")
 	cmd.PersistentFlags().BoolVar(&cfg.P2P.Bootnode, "p2p-bootnode", cfg.P2P.Bootnode,
 		"gossipsub and discovery will be running in a mode suitable for bootnode")
 	cmd.PersistentFlags().BoolVar(&cfg.P2P.PrivateNetwork, "p2p-private-network", cfg.P2P.PrivateNetwork,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -84,8 +84,10 @@ func AddCommands(cmd *cobra.Command) {
 
 	/** ======================== P2P Flags ========================== **/
 
-	cmd.PersistentFlags().StringSliceVar(&cfg.P2P.ListenAddresses, "listen",
-		cfg.P2P.ListenAddresses, "address for listening")
+	cmd.PersistentFlags().StringVar(&cfg.P2P.Listen, "listen",
+		cfg.P2P.Listen, "address for listening")
+	cmd.PersistentFlags().StringSliceVar(&cfg.P2P.ListenAddresses, "listen-addresses",
+		cfg.P2P.ListenAddresses, "addresses for listening")
 	cmd.PersistentFlags().BoolVar(&cfg.P2P.Flood, "flood",
 		cfg.P2P.Flood, "flood created messages to all peers")
 	cmd.PersistentFlags().BoolVar(&cfg.P2P.DisableNatPort, "disable-natport", cfg.P2P.DisableNatPort,
@@ -114,8 +116,10 @@ func AddCommands(cmd *cobra.Command) {
 		cfg.P2P.MinPeers, "actively search for peers until you get this much")
 	cmd.PersistentFlags().StringSliceVar(&cfg.P2P.Bootnodes, "bootnodes",
 		cfg.P2P.Bootnodes, "entrypoints into the network")
-	cmd.PersistentFlags().StringSliceVar(&cfg.P2P.AdvertiseAddresses, "advertise-address",
-		cfg.P2P.AdvertiseAddresses, "libp2p address(es) with identity (example: /dns4/bootnode.spacemesh.io/tcp/5003)")
+	cmd.PersistentFlags().StringVar(&cfg.P2P.AdvertiseAddress, "advertise-address",
+		cfg.P2P.AdvertiseAddress, "libp2p address with identity (example: /dns4/bootnode.spacemesh.io/tcp/5003)")
+	cmd.PersistentFlags().StringSliceVar(&cfg.P2P.AdvertiseAddresses, "advertise-addresses",
+		cfg.P2P.AdvertiseAddresses, "libp2p addresses with identity (example: /dns4/bootnode.spacemesh.io/tcp/5003)")
 	cmd.PersistentFlags().BoolVar(&cfg.P2P.Bootnode, "p2p-bootnode", cfg.P2P.Bootnode,
 		"gossipsub and discovery will be running in a mode suitable for bootnode")
 	cmd.PersistentFlags().BoolVar(&cfg.P2P.PrivateNetwork, "p2p-private-network", cfg.P2P.PrivateNetwork,

--- a/fetch/fetch_test.go
+++ b/fetch/fetch_test.go
@@ -339,7 +339,7 @@ func TestFetch_PeerDroppedWhenMessageResultsInValidationReject(t *testing.T) {
 		MaxRetriesForRequest: 3,
 	}
 	p2pconf := p2p.DefaultConfig()
-	p2pconf.Listen = "/ip4/127.0.0.1/tcp/0"
+	p2pconf.Listen = p2p.MustParseAddresses("/ip4/127.0.0.1/tcp/0")
 	p2pconf.DataDir = t.TempDir()
 
 	// Good host

--- a/fetch/fetch_test.go
+++ b/fetch/fetch_test.go
@@ -343,13 +343,13 @@ func TestFetch_PeerDroppedWhenMessageResultsInValidationReject(t *testing.T) {
 	p2pconf.DataDir = t.TempDir()
 
 	// Good host
-	h, err := p2p.New(ctx, lg, p2pconf, []byte{})
+	h, err := p2p.New(ctx, lg, p2pconf, []byte{}, []byte{})
 	require.NoError(t, err)
 	t.Cleanup(func() { assert.NoError(t, h.Stop()) })
 
 	// Bad host, will send a message that results in validation reject
 	p2pconf.DataDir = t.TempDir()
-	badPeerHost, err := p2p.New(ctx, lg, p2pconf, []byte{})
+	badPeerHost, err := p2p.New(ctx, lg, p2pconf, []byte{}, []byte{})
 	require.NoError(t, err)
 	t.Cleanup(func() { assert.NoError(t, badPeerHost.Stop()) })
 

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/libp2p/go-libp2p-kad-dht v0.25.2
 	github.com/libp2p/go-libp2p-pubsub v0.10.0
 	github.com/libp2p/go-libp2p-record v0.2.0
+	github.com/libp2p/go-msgio v0.3.0
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/multiformats/go-multiaddr v0.12.0
 	github.com/multiformats/go-varint v0.0.7
@@ -31,9 +32,10 @@ require (
 	github.com/oasisprotocol/curve25519-voi v0.0.0-20230904125328-1f23a7beb09a
 	github.com/prometheus/client_golang v1.17.0
 	github.com/prometheus/common v0.45.0
+	github.com/quic-go/quic-go v0.39.4
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/seehuhn/mt19937 v1.0.0
-	github.com/spacemeshos/api/release/go v1.24.0
+	github.com/spacemeshos/api/release/go v1.24.1-0.20231205133442-1da5e0bc7f72
 	github.com/spacemeshos/economics v0.1.1
 	github.com/spacemeshos/fixed v0.1.1
 	github.com/spacemeshos/go-scale v1.1.12
@@ -139,7 +141,6 @@ require (
 	github.com/libp2p/go-libp2p-asn-util v0.3.0 // indirect
 	github.com/libp2p/go-libp2p-kbucket v0.6.3 // indirect
 	github.com/libp2p/go-libp2p-routing-helpers v0.7.2 // indirect
-	github.com/libp2p/go-msgio v0.3.0 // indirect
 	github.com/libp2p/go-nat v0.2.0 // indirect
 	github.com/libp2p/go-netroute v0.2.1 // indirect
 	github.com/libp2p/go-reuseport v0.4.0 // indirect
@@ -179,7 +180,6 @@ require (
 	github.com/prometheus/procfs v0.11.1 // indirect
 	github.com/quic-go/qpack v0.4.0 // indirect
 	github.com/quic-go/qtls-go1-20 v0.3.4 // indirect
-	github.com/quic-go/quic-go v0.39.4 // indirect
 	github.com/quic-go/webtransport-go v0.6.0 // indirect
 	github.com/raulk/go-watchdog v1.3.0 // indirect
 	github.com/robfig/cron/v3 v3.0.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/quic-go/quic-go v0.39.4
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/seehuhn/mt19937 v1.0.0
-	github.com/spacemeshos/api/release/go v1.24.1-0.20231205133442-1da5e0bc7f72
+	github.com/spacemeshos/api/release/go v1.25.0
 	github.com/spacemeshos/economics v0.1.1
 	github.com/spacemeshos/fixed v0.1.1
 	github.com/spacemeshos/go-scale v1.1.12

--- a/go.sum
+++ b/go.sum
@@ -621,8 +621,8 @@ github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d/go.mod h1:Udh
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
-github.com/spacemeshos/api/release/go v1.24.0 h1:uB4ZdmbHpodtpTyb7tDGxkTyb0nqr6fOIKv47SUChwk=
-github.com/spacemeshos/api/release/go v1.24.0/go.mod h1:SwqQxbhAF7tN3Qr34eVzczCB3KyTbkHH12U82eqfy6M=
+github.com/spacemeshos/api/release/go v1.24.1-0.20231205133442-1da5e0bc7f72 h1:g5syNcTENeJ+07uT0G8lzo/dz5ePqTxfPdvqLpUy2LQ=
+github.com/spacemeshos/api/release/go v1.24.1-0.20231205133442-1da5e0bc7f72/go.mod h1:SwqQxbhAF7tN3Qr34eVzczCB3KyTbkHH12U82eqfy6M=
 github.com/spacemeshos/economics v0.1.1 h1:BPgMoTaeQ05ME6wEA1+MvXMp+wvXr51bIuN23thrCAk=
 github.com/spacemeshos/economics v0.1.1/go.mod h1:76nTjugYRiQ5/eD/DQs2dXPPilp28URMswUKncfdanY=
 github.com/spacemeshos/fixed v0.1.1 h1:N1y4SUpq1EV+IdJrWJwUCt1oBFzeru/VKVcBsvPc2Fk=

--- a/go.sum
+++ b/go.sum
@@ -621,8 +621,8 @@ github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d/go.mod h1:Udh
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
-github.com/spacemeshos/api/release/go v1.24.1-0.20231205133442-1da5e0bc7f72 h1:g5syNcTENeJ+07uT0G8lzo/dz5ePqTxfPdvqLpUy2LQ=
-github.com/spacemeshos/api/release/go v1.24.1-0.20231205133442-1da5e0bc7f72/go.mod h1:SwqQxbhAF7tN3Qr34eVzczCB3KyTbkHH12U82eqfy6M=
+github.com/spacemeshos/api/release/go v1.25.0 h1:HqIykavooxUxZySiN7yiILRX+Kx6WxM1NF6w72PNmMc=
+github.com/spacemeshos/api/release/go v1.25.0/go.mod h1:Ffvt8Zl5K6k0In0OF7PUJ2JoxrW8zBRXKF1kG0abigg=
 github.com/spacemeshos/economics v0.1.1 h1:BPgMoTaeQ05ME6wEA1+MvXMp+wvXr51bIuN23thrCAk=
 github.com/spacemeshos/economics v0.1.1/go.mod h1:76nTjugYRiQ5/eD/DQs2dXPPilp28URMswUKncfdanY=
 github.com/spacemeshos/fixed v0.1.1 h1:N1y4SUpq1EV+IdJrWJwUCt1oBFzeru/VKVcBsvPc2Fk=

--- a/node/adminservice_api_test.go
+++ b/node/adminservice_api_test.go
@@ -14,13 +14,14 @@ import (
 	"github.com/spacemeshos/go-spacemesh/api/grpcserver"
 	"github.com/spacemeshos/go-spacemesh/config"
 	"github.com/spacemeshos/go-spacemesh/log/logtest"
+	"github.com/spacemeshos/go-spacemesh/p2p"
 )
 
 func TestPeerInfoApi(t *testing.T) {
 	cfg := config.DefaultTestConfig()
 	cfg.Genesis.Accounts = nil
 	cfg.P2P.DisableNatPort = true
-	cfg.P2P.Listen = "/ip4/127.0.0.1/tcp/0"
+	cfg.P2P.Listen = p2p.MustParseAddresses("/ip4/127.0.0.1/tcp/0")
 
 	cfg.API.PublicListener = "0.0.0.0:0"
 	cfg.API.PrivateServices = nil

--- a/node/bad_peer_test.go
+++ b/node/bad_peer_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/config"
 	"github.com/spacemeshos/go-spacemesh/log/logtest"
+	"github.com/spacemeshos/go-spacemesh/p2p"
 	ps "github.com/spacemeshos/go-spacemesh/p2p/pubsub"
 )
 
@@ -32,7 +33,7 @@ func TestPeerDisconnectForMessageResultValidationReject(t *testing.T) {
 	conf1 := config.DefaultTestConfig()
 	conf1.DataDirParent = t.TempDir()
 	conf1.FileLock = filepath.Join(conf1.DataDirParent, "LOCK")
-	conf1.P2P.Listen = "/ip4/127.0.0.1/tcp/0"
+	conf1.P2P.Listen = p2p.MustParseAddresses("/ip4/127.0.0.1/tcp/0")
 	// We setup the api to listen on an OS assigned port, which avoids the second instance getting stuck when
 	conf1.API.PublicListener = "0.0.0.0:0"
 	conf1.API.PrivateListener = "0.0.0.0:0"
@@ -45,7 +46,7 @@ func TestPeerDisconnectForMessageResultValidationReject(t *testing.T) {
 	*conf2.Genesis = *conf1.Genesis
 	conf2.DataDirParent = t.TempDir()
 	conf2.FileLock = filepath.Join(conf2.DataDirParent, "LOCK")
-	conf2.P2P.Listen = "/ip4/127.0.0.1/tcp/0"
+	conf2.P2P.Listen = p2p.MustParseAddresses("/ip4/127.0.0.1/tcp/0")
 	conf2.API.PublicListener = "0.0.0.0:0"
 	conf2.API.PrivateListener = "0.0.0.0:0"
 	app2 := NewApp(t, &conf2, l)

--- a/node/flags/addresslist.go
+++ b/node/flags/addresslist.go
@@ -1,0 +1,94 @@
+package flags
+
+import (
+	"encoding/csv"
+	"strings"
+
+	"github.com/spacemeshos/go-spacemesh/p2p"
+)
+
+// AddressListValue wraps an AddressList to make it possible to use it
+// like a slice value in pflag.
+type AddressListValue struct {
+	value   *p2p.AddressList
+	changed bool
+}
+
+// NewAddressListValue creates an AddressListValue that wraps the
+// specified AddressList.
+func NewAddressListValue(val p2p.AddressList, p *p2p.AddressList) *AddressListValue {
+	alv := new(AddressListValue)
+	alv.value = p
+	*alv.value = val
+	return alv
+}
+
+// Set implements pflag.Value.
+func (alv *AddressListValue) Set(val string) error {
+	v, err := readAsCSV(val)
+	if err != nil {
+		return err
+	}
+	if !alv.changed {
+		*alv.value = v
+	} else {
+		*alv.value = append(*alv.value, v...)
+	}
+	alv.changed = true
+	return nil
+}
+
+// String implements pflag.Value.
+func (alv *AddressListValue) String() string {
+	return alv.value.String()
+}
+
+// Type implements pflag.Value.
+func (alv *AddressListValue) Type() string {
+	return "addressList"
+}
+
+// Append implements pflag.SliceValue.
+func (alv *AddressListValue) Append(val string) error {
+	al, err := p2p.AddressListFromString(val)
+	if err != nil {
+		return err
+	}
+	*alv.value = append(*alv.value, al...)
+	return nil
+}
+
+// GetSlice implements pflag.SliceValue.
+func (alv *AddressListValue) GetSlice() []string {
+	r := make([]string, len(*alv.value))
+	for n, ma := range *alv.value {
+		r[n] = ma.String()
+	}
+	return r
+}
+
+// Replace implements pflag.SliceValue.
+func (alv *AddressListValue) Replace(val []string) error {
+	al, err := p2p.AddressListFromStringSlice(val)
+	if err != nil {
+		return err
+	}
+	*alv.value = al
+	return nil
+}
+
+func readAsCSV(val string) (p2p.AddressList, error) {
+	if strings.HasPrefix(val, "[") && strings.HasSuffix(val, "]") {
+		val = val[1 : len(val)-1]
+	}
+	if val == "" {
+		return p2p.AddressList{}, nil
+	}
+	stringReader := strings.NewReader(val)
+	csvReader := csv.NewReader(stringReader)
+	l, err := csvReader.Read()
+	if err != nil {
+		return nil, err
+	}
+	return p2p.AddressListFromStringSlice(l)
+}

--- a/node/flags/addresslist_test.go
+++ b/node/flags/addresslist_test.go
@@ -1,0 +1,29 @@
+package flags
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/spacemeshos/go-spacemesh/p2p"
+)
+
+func TestAddressList(t *testing.T) {
+	al := p2p.MustParseAddresses("/ip4/0.0.0.0/tcp/7513")
+	alv := NewAddressListValue(al, &al)
+	require.Equal(t, []string{"/ip4/0.0.0.0/tcp/7513"}, alv.GetSlice())
+	require.Equal(t, "addressList", alv.Type())
+	require.Equal(t, "[/ip4/0.0.0.0/tcp/7513]", alv.String())
+	require.NoError(t, alv.Set("[/ip4/0.0.0.0/tcp/5000]")) // replace the default value
+	require.Equal(t, "[/ip4/0.0.0.0/tcp/5000]", alv.String())
+	require.NoError(t, alv.Set("/ip4/0.0.0.0/udp/0/quic-v1,/ip4/0.0.0.0/tcp/5002")) // append more values
+	require.Equal(t, "[/ip4/0.0.0.0/tcp/5000,/ip4/0.0.0.0/udp/0/quic-v1,/ip4/0.0.0.0/tcp/5002]", alv.String())
+	require.NoError(t, alv.Replace([]string{"/ip4/0.0.0.0/tcp/4999"}))
+	require.NoError(t, alv.Append("/ip4/0.0.0.0/tcp/5001"))
+	require.Equal(t, "[/ip4/0.0.0.0/tcp/4999,/ip4/0.0.0.0/tcp/5001]", alv.String())
+
+	require.Error(t, alv.Set("abc,def"))
+	require.Error(t, alv.Replace([]string{"foobar"}))
+	require.Error(t, alv.Append("barbaz"))
+	require.Equal(t, "[/ip4/0.0.0.0/tcp/4999,/ip4/0.0.0.0/tcp/5001]", alv.String())
+}

--- a/node/mapstructureutil/addresslist.go
+++ b/node/mapstructureutil/addresslist.go
@@ -1,0 +1,41 @@
+package mapstructureutil
+
+import (
+	"reflect"
+
+	"github.com/mitchellh/mapstructure"
+
+	"github.com/spacemeshos/go-spacemesh/p2p"
+)
+
+// AddressListDecodeFunc mapstructure decode func for p2p.AddressList.
+// AddressList can be represented either by a string or by a slice of strings.
+func AddressListDecodeFunc() mapstructure.DecodeHookFunc {
+	return func(f, t reflect.Type, data any) (any, error) {
+		if t != reflect.TypeOf(p2p.AddressList(nil)) {
+			return data, nil
+		}
+
+		switch f.Kind() {
+		case reflect.Slice:
+			v := reflect.ValueOf(data)
+			items := make([]string, v.Len())
+			for n := 0; n < v.Len(); n++ {
+				item := v.Index(n).Interface()
+				switch s := item.(type) {
+				case string:
+					items[n] = s
+				default:
+					return data, nil
+				}
+			}
+			r, err := p2p.AddressListFromStringSlice(items)
+			return r, err
+		case reflect.String:
+			r, err := p2p.AddressListFromString(data.(string))
+			return r, err
+		default:
+			return data, nil
+		}
+	}
+}

--- a/node/node.go
+++ b/node/node.go
@@ -261,6 +261,7 @@ func LoadConfigFromFile() (*config.Config, error) {
 	hook := mapstructure.ComposeDecodeHookFunc(
 		mapstructure.StringToTimeDurationHookFunc(),
 		mapstructure.StringToSliceHookFunc(","),
+		mapstructureutil.AddressListDecodeFunc(),
 		mapstructureutil.BigRatDecodeFunc(),
 		mapstructureutil.PostProviderIDDecodeFunc(),
 		mapstructure.TextUnmarshallerHookFunc(),

--- a/node/node.go
+++ b/node/node.go
@@ -58,6 +58,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/miner"
 	"github.com/spacemeshos/go-spacemesh/node/mapstructureutil"
 	"github.com/spacemeshos/go-spacemesh/p2p"
+	"github.com/spacemeshos/go-spacemesh/p2p/handshake"
 	"github.com/spacemeshos/go-spacemesh/p2p/pubsub"
 	"github.com/spacemeshos/go-spacemesh/proposals"
 	"github.com/spacemeshos/go-spacemesh/prune"
@@ -1696,7 +1697,14 @@ func (app *App) startSynchronous(ctx context.Context) (err error) {
 		app.Config.Genesis.GenesisID(),
 		types.GetEffectiveGenesis(),
 	)
-	app.host, err = p2p.New(ctx, p2plog, cfg, []byte(prologue),
+	// Prevent testnet nodes from working on the mainnet, but
+	// don't use the network cookie on mainnet as this technique
+	// may be replaced later
+	nc := handshake.NoNetworkCookie
+	if !onMainNet(app.Config) {
+		nc = handshake.NetworkCookie(prologue)
+	}
+	app.host, err = p2p.New(ctx, p2plog, cfg, []byte(prologue), nc,
 		p2p.WithNodeReporter(events.ReportNodeStatusUpdate),
 	)
 	if err != nil {

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -811,7 +811,7 @@ func TestConfig_CustomTypes(t *testing.T) {
 			},
 		},
 		{
-			name: "address-list-single",
+			name: "address-list-multiple",
 			cli: "--listen=/ip4/0.0.0.0/tcp/5555 --listen=/ip4/0.0.0.0/udp/5555/quic-v1" +
 				" --advertise-address=/ip4/10.20.30.40/tcp/5555" +
 				" --advertise-address=/ip4/10.20.30.40/udp/5555/quic-v1",

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -581,7 +582,7 @@ func TestSpacemeshApp_TransactionService(t *testing.T) {
 		app.Config.API.PrivateServices = nil
 
 		// Prevent obnoxious warning in macOS
-		app.Config.P2P.Listen = "/ip4/127.0.0.1/tcp/7073"
+		app.Config.P2P.Listen = p2p.MustParseAddresses("/ip4/127.0.0.1/tcp/7073")
 
 		// Avoid waiting for new connections.
 		app.Config.P2P.MinPeers = 0
@@ -800,6 +801,32 @@ func TestConfig_CustomTypes(t *testing.T) {
 				copy(c.POST.PowDifficulty[:], diff)
 			},
 		},
+		{
+			name:   "address-list-single",
+			cli:    "--listen=/ip4/0.0.0.0/tcp/5555 --advertise-address=/ip4/10.20.30.40/tcp/5555",
+			config: `{"p2p":{"listen":"/ip4/0.0.0.0/tcp/5555","advertise-address":"/ip4/10.20.30.40/tcp/5555"}}`,
+			updatePreset: func(t *testing.T, c *config.Config) {
+				c.P2P.Listen = p2p.MustParseAddresses("/ip4/0.0.0.0/tcp/5555")
+				c.P2P.AdvertiseAddress = p2p.MustParseAddresses("/ip4/10.20.30.40/tcp/5555")
+			},
+		},
+		{
+			name: "address-list-single",
+			cli: "--listen=/ip4/0.0.0.0/tcp/5555 --listen=/ip4/0.0.0.0/udp/5555/quic-v1" +
+				" --advertise-address=/ip4/10.20.30.40/tcp/5555" +
+				" --advertise-address=/ip4/10.20.30.40/udp/5555/quic-v1",
+			config: `{"p2p":{"listen":["/ip4/0.0.0.0/tcp/5555","/ip4/0.0.0.0/udp/5555/quic-v1"],
+                                  "advertise-address":[
+                                    "/ip4/10.20.30.40/tcp/5555","/ip4/10.20.30.40/udp/5555/quic-v1"]}}`,
+			updatePreset: func(t *testing.T, c *config.Config) {
+				c.P2P.Listen = p2p.MustParseAddresses(
+					"/ip4/0.0.0.0/tcp/5555",
+					"/ip4/0.0.0.0/udp/5555/quic-v1")
+				c.P2P.AdvertiseAddress = p2p.MustParseAddresses(
+					"/ip4/10.20.30.40/tcp/5555",
+					"/ip4/10.20.30.40/udp/5555/quic-v1")
+			},
+		},
 	}
 
 	for _, tc := range tt {
@@ -809,7 +836,7 @@ func TestConfig_CustomTypes(t *testing.T) {
 
 			c := &cobra.Command{}
 			cmd.AddCommands(c)
-			require.NoError(t, c.ParseFlags([]string{tc.cli}))
+			require.NoError(t, c.ParseFlags(strings.Fields(tc.cli)))
 
 			t.Cleanup(viper.Reset)
 			t.Cleanup(cmd.ResetConfig)
@@ -847,7 +874,7 @@ func TestConfig_CustomTypes(t *testing.T) {
 
 			c := &cobra.Command{}
 			cmd.AddCommands(c)
-			require.NoError(t, c.ParseFlags([]string{tc.cli}))
+			require.NoError(t, c.ParseFlags(strings.Fields(tc.cli)))
 
 			viper.Set("preset", name)
 			t.Cleanup(viper.Reset)

--- a/p2p/addresslist.go
+++ b/p2p/addresslist.go
@@ -1,0 +1,64 @@
+package p2p
+
+import (
+	"bytes"
+	"encoding/csv"
+	"fmt"
+	"strings"
+
+	"github.com/multiformats/go-multiaddr"
+)
+
+// AddressList represents a list of addresses.
+type AddressList []multiaddr.Multiaddr
+
+// AddressListFromStringSlice parses strings in the slice into
+// Multiaddr values and returns them as an AddressList.
+func AddressListFromStringSlice(s []string) (AddressList, error) {
+	al := make(AddressList, len(s))
+	for n, s := range s {
+		ma, err := multiaddr.NewMultiaddr(s)
+		if err != nil {
+			return nil, fmt.Errorf("address %s is not a valid multiaddr: %w", s, err)
+		}
+		al[n] = ma
+	}
+
+	return al, nil
+}
+
+// AddressListFromString parses a string containing a Multiaddr
+// and returns it as an AddressList.
+func AddressListFromString(s string) (AddressList, error) {
+	return AddressListFromStringSlice([]string{s})
+}
+
+// MustParseAddresses parses multiaddr strings into AddressList, and
+// panics upon any parse errors.
+func MustParseAddresses(s ...string) AddressList {
+	al, err := AddressListFromStringSlice(s)
+	if err != nil {
+		panic(err)
+	}
+	return al
+}
+
+// String implements Stringer.
+func (al AddressList) String() string {
+	str, _ := writeAsCSV(al)
+	return "[" + str + "]"
+}
+
+func writeAsCSV(vals AddressList) (string, error) {
+	strs := make([]string, len(vals))
+	for n, v := range vals {
+		strs[n] = v.String()
+	}
+	var b bytes.Buffer
+	w := csv.NewWriter(&b)
+	if err := w.Write(strs); err != nil {
+		return "", err
+	}
+	w.Flush()
+	return strings.TrimSuffix(b.String(), "\n"), nil
+}

--- a/p2p/dhtdiscovery/discovery.go
+++ b/p2p/dhtdiscovery/discovery.go
@@ -22,6 +22,8 @@ const (
 	discoveryNS       = "spacemesh-disc"
 	discoveryTag      = "spacemesh-disc"
 	discoveryTagValue = 1
+	protocolPrefix          = "/spacekad"
+	ProtocolID              = protocolPrefix + "/kad/1.0.0"
 )
 
 type Opt func(*Discovery)

--- a/p2p/dhtdiscovery/discovery.go
+++ b/p2p/dhtdiscovery/discovery.go
@@ -2,7 +2,9 @@ package discovery
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	levelds "github.com/ipfs/go-ds-leveldb"
@@ -20,11 +22,14 @@ import (
 
 const (
 	discoveryNS             = "spacemesh-disc"
+	relayNS                 = "spacemesh-disc-relay"
 	discoveryTag            = "spacemesh-disc"
-	discoveryTagValue       = 1
+	discoveryTagValue       = 10 // 5 is used for kbucket (DHT)
 	discoveryHighPeersDelay = 10 * time.Second
 	protocolPrefix          = "/spacekad"
 	ProtocolID              = protocolPrefix + "/kad/1.0.0"
+	advertiseInterval       = 10 * time.Second
+	findPeersRetryDelay     = 1 * time.Second
 )
 
 type Opt func(*Discovery)
@@ -107,24 +112,23 @@ func WithRelayCandidateChannel(relayCh chan<- peer.AddrInfo) Opt {
 	}
 }
 
-func EnableRoutingDiscovery() Opt {
+func EnableRoutingDiscovery(advertise bool) Opt {
 	return func(d *Discovery) {
 		d.enableRoutingDiscovery = true
+		d.advertise = advertise
 	}
 }
 
 type DiscoveryHost interface {
 	host.Host
 	NeedPeerDiscovery() bool
+	HaveRelay() bool
 }
 
 func New(h DiscoveryHost, opts ...Opt) (*Discovery, error) {
-	ctx, cancel := context.WithCancel(context.Background())
 	d := Discovery{
 		public:            true,
 		logger:            zap.NewNop(),
-		ctx:               ctx,
-		cancel:            cancel,
 		h:                 h,
 		period:            10 * time.Second,
 		timeout:           30 * time.Second,
@@ -138,12 +142,6 @@ func New(h DiscoveryHost, opts ...Opt) (*Discovery, error) {
 	if len(d.bootnodes) == 0 {
 		d.logger.Warn("no bootnodes in the config")
 	}
-	if !d.disableDht {
-		err := d.newDht(ctx, h, d.public, d.server, d.dir)
-		if err != nil {
-			return nil, err
-		}
-	}
 	return &d, nil
 }
 
@@ -154,15 +152,17 @@ type Discovery struct {
 	dir                    string
 	relayCh                chan<- peer.AddrInfo
 	enableRoutingDiscovery bool
+	advertise              bool
 
 	logger *zap.Logger
 	eg     errgroup.Group
-	ctx    context.Context
 	cancel context.CancelFunc
 
 	h         DiscoveryHost
+	dhtLock   sync.Mutex
 	dht       *dht.IpfsDHT
 	datastore *levelds.Datastore
+	disc      *p2pdiscr.RoutingDiscovery
 
 	// how often to check if we have enough peers
 	period time.Duration
@@ -173,17 +173,70 @@ type Discovery struct {
 	backup, bootnodes   []peer.AddrInfo
 }
 
-func (d *Discovery) DHT() *dht.IpfsDHT { return d.dht }
-
-func (d *Discovery) Start() {
-	d.eg.Go(d.ensureAtLeastMinPeers)
-	if d.enableRoutingDiscovery {
-		d.eg.Go(d.discoverPeers)
+func (d *Discovery) FindPeer(ctx context.Context, p peer.ID) (peer.AddrInfo, error) {
+	d.dhtLock.Lock()
+	dht := d.dht
+	d.dhtLock.Unlock()
+	if dht == nil {
+		return peer.AddrInfo{}, errors.New("discovery not started")
 	}
+	return dht.FindPeer(ctx, p)
+}
+
+func (d *Discovery) setupDHT(ctx context.Context) error {
+	d.dhtLock.Lock()
+	defer d.dhtLock.Unlock()
+	return d.newDht(ctx, d.h, d.public, d.server, d.dir)
+}
+
+func (d *Discovery) Start(ctx context.Context) error {
+	if d.cancel != nil {
+		return nil
+	}
+	var startCtx context.Context
+	startCtx, d.cancel = context.WithCancel(ctx)
+
+	if !d.disableDht {
+		if err := d.setupDHT(ctx); err != nil {
+			return err
+		}
+	}
+
+	d.eg.Go(func() error {
+		return d.ensureAtLeastMinPeers(startCtx)
+	})
+
+	if !d.disableDht {
+		d.disc = p2pdiscr.NewRoutingDiscovery(d.dht)
+		if d.advertise {
+			d.eg.Go(func() error {
+				return d.advertiseNS(startCtx, discoveryNS, nil)
+			})
+		}
+		if d.enableRoutingDiscovery {
+			d.eg.Go(func() error {
+				return d.discoverPeers(startCtx)
+			})
+		}
+		d.eg.Go(func() error {
+			return d.advertiseNS(startCtx, relayNS, d.h.HaveRelay)
+		})
+		if d.relayCh != nil {
+			d.eg.Go(func() error {
+				return d.discoverRelays(startCtx)
+			})
+		}
+	}
+
+	return nil
 }
 
 func (d *Discovery) Stop() {
+	if d.cancel == nil {
+		return
+	}
 	d.cancel()
+	d.cancel = nil
 	d.eg.Wait()
 	if !d.disableDht {
 		if err := d.dht.Close(); err != nil {
@@ -195,11 +248,11 @@ func (d *Discovery) Stop() {
 	}
 }
 
-func (d *Discovery) bootstrap() {
+func (d *Discovery) bootstrap(ctx context.Context) {
 	if d.dht == nil {
 		return
 	}
-	ctx, cancel := context.WithTimeout(d.ctx, d.bootstrapDuration)
+	ctx, cancel := context.WithTimeout(ctx, d.bootstrapDuration)
 	defer cancel()
 	if err := d.dht.Bootstrap(ctx); err != nil {
 		d.logger.Error("unexpected error from discovery dht", zap.Error(err))
@@ -207,8 +260,8 @@ func (d *Discovery) bootstrap() {
 	<-ctx.Done()
 }
 
-func (d *Discovery) connect(eg *errgroup.Group, nodes []peer.AddrInfo) {
-	ctx, cancel := context.WithTimeout(d.ctx, d.timeout)
+func (d *Discovery) connect(ctx context.Context, eg *errgroup.Group, nodes []peer.AddrInfo) {
+	conCtx, cancel := context.WithTimeout(ctx, d.timeout)
 	defer cancel()
 	for _, boot := range nodes {
 		boot := boot
@@ -217,7 +270,7 @@ func (d *Discovery) connect(eg *errgroup.Group, nodes []peer.AddrInfo) {
 			continue
 		}
 		eg.Go(func() error {
-			if err := d.h.Connect(ctx, boot); err != nil {
+			if err := d.h.Connect(conCtx, boot); err != nil {
 				d.logger.Warn("failed to connect",
 					zap.Stringer("address", boot),
 					zap.Error(err),
@@ -265,7 +318,7 @@ func (d *Discovery) newDht(ctx context.Context, h host.Host, public, server bool
 	return nil
 }
 
-func (d *Discovery) ensureAtLeastMinPeers() error {
+func (d *Discovery) ensureAtLeastMinPeers(ctx context.Context) error {
 	var connEg errgroup.Group
 	disconnected := make(chan struct{}, 1)
 	disconnected <- struct{}{} // trigger bootstrap when node starts immediately
@@ -282,7 +335,7 @@ func (d *Discovery) ensureAtLeastMinPeers() error {
 	ticker := time.NewTicker(d.period)
 	for {
 		select {
-		case <-d.ctx.Done():
+		case <-ctx.Done():
 			ticker.Stop()
 			d.h.Network().StopNotify(notifiee)
 			return nil
@@ -296,37 +349,57 @@ func (d *Discovery) ensureAtLeastMinPeers() error {
 				zap.Int("connected", connected),
 			)
 		} else {
-			d.connect(&connEg, d.backup)
+			d.connect(ctx, &connEg, d.backup)
 			// no reason to spend more resources if we got enough from backup
 			if connected := len(d.h.Network().Peers()); connected >= d.minPeers {
 				continue
 			}
-			d.connect(&connEg, d.bootnodes)
-			d.bootstrap()
+			d.connect(ctx, &connEg, d.bootnodes)
+			d.bootstrap(ctx)
 		}
 	}
 }
 
-func (d *Discovery) discoverPeers() error {
-	disc := p2pdiscr.NewRoutingDiscovery(d.dht)
-
-	ticker := time.NewTicker(time.Second * 1)
-	defer ticker.Stop()
-	peerCh, err := disc.FindPeers(d.ctx, discoveryNS)
-	if err != nil {
-		return fmt.Errorf("error finding peers: %w", err)
+func (d *Discovery) peerHasTag(p peer.ID) bool {
+	ti := d.h.ConnManager().GetTagInfo(p)
+	if ti == nil {
+		return false
 	}
+	_, found := ti.Tags[discoveryTag]
+	return found
+}
 
-	reAdvCh := time.After(10 * time.Second)
-
+func (d *Discovery) advertiseNS(ctx context.Context, ns string, active func() bool) error {
 	for {
+		var ttl time.Duration
+		if active == nil || active() {
+			var err error
+			d.logger.Debug("advertising for routing discovery", zap.String("ns", ns))
+			ttl, err = d.disc.Advertise(ctx, ns, p2pdisc.TTL(advertiseInterval))
+			if err != nil {
+				d.logger.Error("failed to re-advertise for discovery", zap.String("ns", ns), zap.Error(err))
+				ttl = advertiseInterval
+			}
+		} else {
+			ttl = advertiseInterval
+		}
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(ttl):
+		}
+	}
+}
+
+func (d *Discovery) discoverPeers(ctx context.Context) error {
+	for p := range d.findPeersContinuously(ctx, discoveryNS) {
 		wasSuspended := false
 		for !d.h.NeedPeerDiscovery() {
 			wasSuspended = true
 			d.logger.With().Info("suspending routing discovery",
 				zap.Duration("delay", discoveryHighPeersDelay))
 			select {
-			case <-d.ctx.Done():
+			case <-ctx.Done():
 				return nil
 			case <-time.After(discoveryHighPeersDelay):
 			}
@@ -335,45 +408,76 @@ func (d *Discovery) discoverPeers() error {
 			d.logger.With().Info("resuming routing discovery")
 		}
 
-		select {
-		case <-d.ctx.Done():
-			return nil
-		case <-reAdvCh:
-			ttl, err := disc.Advertise(d.ctx, discoveryNS, p2pdisc.TTL(10*time.Second))
-			if err != nil {
-				d.logger.Error("failed to re-advertise for discovery", zap.Error(err))
-				reAdvCh = time.After(10 * time.Second)
+		if p.ID == d.h.ID() {
+			continue
+		}
+		freshlyConnected := !d.peerHasTag(p.ID)
+		// trim open conns to free up some space
+		d.h.ConnManager().TrimOpenConns(ctx)
+		// tag peer to prioritize it over the peers found by other means
+		d.h.ConnManager().TagPeer(p.ID, discoveryTag, discoveryTagValue)
+		if d.h.Network().Connectedness(p.ID) != network.Connected {
+			if _, err := d.h.Network().DialPeer(ctx, p.ID); err != nil {
+				d.logger.Error("error dialing peer", zap.Any("peer", p),
+					zap.Error(err))
 				continue
 			}
-			reAdvCh = time.After(ttl)
-		case p, ok := <-peerCh:
-			if !ok {
-				time.Sleep(time.Second) // FIXME
-				peerCh, err = disc.FindPeers(d.ctx, discoveryNS)
-				if err != nil {
-					return fmt.Errorf("error finding peers: %w", err)
-				}
-				continue
-			}
-			if p.ID == d.h.ID() {
-				continue
-			}
-			if d.h.Network().Connectedness(p.ID) != network.Connected {
-				if _, err = d.h.Network().DialPeer(d.ctx, p.ID); err != nil {
-					d.logger.Error("error dialing peer", zap.Any("peer", p),
-						zap.Error(err))
-					continue
-				}
-			}
-			// tag peer to prioritize it over the peers found by other means
-			d.h.ConnManager().TagPeer(p.ID, discoveryTag, discoveryTagValue)
+			freshlyConnected = true
+		}
+		if freshlyConnected {
 			d.logger.Info("found peer via rendezvous", zap.Any("peer", p))
-			if d.relayCh != nil && len(p.Addrs) != 0 {
-				select {
-				case d.relayCh <- p:
-				default: // do not block
-				}
-			}
 		}
 	}
+
+	return nil
 }
+
+func (d *Discovery) discoverRelays(ctx context.Context) error {
+	for p := range d.findPeersContinuously(ctx, relayNS) {
+		if len(p.Addrs) != 0 {
+			d.logger.Debug("found relay candidate", zap.Any("p", p))
+			d.relayCh <- p
+		}
+	}
+	return nil
+}
+
+func (d *Discovery) findPeersContinuously(ctx context.Context, ns string) <-chan peer.AddrInfo {
+	r := make(chan peer.AddrInfo)
+	d.eg.Go(func() error {
+		var peerCh <-chan peer.AddrInfo
+		for {
+			if peerCh == nil {
+				var err error
+				peerCh, err = d.disc.FindPeers(ctx, ns)
+				if err != nil {
+					d.logger.Error("error finding relay peers", zap.Error(err))
+					select {
+					case <-ctx.Done():
+						return nil
+					case <-time.After(findPeersRetryDelay):
+					}
+				}
+			}
+
+			select {
+			case <-ctx.Done():
+				return nil
+			case p, ok := <-peerCh:
+				if !ok {
+					peerCh = nil
+					select {
+					case <-ctx.Done():
+						return nil
+					case <-time.After(findPeersRetryDelay):
+					}
+					continue
+				}
+				r <- p
+			}
+		}
+	})
+	return r
+}
+
+// TBD: don't store the context, create DHT during start

--- a/p2p/dhtdiscovery/discovery.go
+++ b/p2p/dhtdiscovery/discovery.go
@@ -224,16 +224,16 @@ func (d *Discovery) Start() error {
 			d.eg.Go(func() error {
 				return d.discoverPeers(startCtx)
 			})
+			if d.relayCh != nil {
+				d.eg.Go(func() error {
+					d.discoverRelays(startCtx)
+					return nil
+				})
+			}
 		}
 		d.eg.Go(func() error {
 			return d.advertiseNS(startCtx, relayNS, d.h.HaveRelay)
 		})
-		if d.relayCh != nil {
-			d.eg.Go(func() error {
-				d.discoverRelays(startCtx)
-				return nil
-			})
-		}
 	}
 
 	return nil

--- a/p2p/dhtdiscovery/discovery.go
+++ b/p2p/dhtdiscovery/discovery.go
@@ -19,9 +19,10 @@ import (
 )
 
 const (
-	discoveryNS       = "spacemesh-disc"
-	discoveryTag      = "spacemesh-disc"
-	discoveryTagValue = 1
+	discoveryNS             = "spacemesh-disc"
+	discoveryTag            = "spacemesh-disc"
+	discoveryTagValue       = 1
+	discoveryHighPeersDelay = 10 * time.Second
 	protocolPrefix          = "/spacekad"
 	ProtocolID              = protocolPrefix + "/kad/1.0.0"
 )
@@ -100,7 +101,24 @@ func DisableDHT() Opt {
 	}
 }
 
-func New(h host.Host, opts ...Opt) (*Discovery, error) {
+func WithRelayCandidateChannel(relayCh chan<- peer.AddrInfo) Opt {
+	return func(d *Discovery) {
+		d.relayCh = relayCh
+	}
+}
+
+func EnableRoutingDiscovery() Opt {
+	return func(d *Discovery) {
+		d.enableRoutingDiscovery = true
+	}
+}
+
+type DiscoveryHost interface {
+	host.Host
+	NeedPeerDiscovery() bool
+}
+
+func New(h DiscoveryHost, opts ...Opt) (*Discovery, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	d := Discovery{
 		public:            true,
@@ -130,17 +148,19 @@ func New(h host.Host, opts ...Opt) (*Discovery, error) {
 }
 
 type Discovery struct {
-	public     bool
-	server     bool
-	disableDht bool
-	dir        string
+	public                 bool
+	server                 bool
+	disableDht             bool
+	dir                    string
+	relayCh                chan<- peer.AddrInfo
+	enableRoutingDiscovery bool
 
 	logger *zap.Logger
 	eg     errgroup.Group
 	ctx    context.Context
 	cancel context.CancelFunc
 
-	h         host.Host
+	h         DiscoveryHost
 	dht       *dht.IpfsDHT
 	datastore *levelds.Datastore
 
@@ -153,9 +173,13 @@ type Discovery struct {
 	backup, bootnodes   []peer.AddrInfo
 }
 
+func (d *Discovery) DHT() *dht.IpfsDHT { return d.dht }
+
 func (d *Discovery) Start() {
 	d.eg.Go(d.ensureAtLeastMinPeers)
-	d.eg.Go(d.discoverPeers)
+	if d.enableRoutingDiscovery {
+		d.eg.Go(d.discoverPeers)
+	}
 }
 
 func (d *Discovery) Stop() {
@@ -218,7 +242,7 @@ func (d *Discovery) newDht(ctx context.Context, h host.Host, public, server bool
 	opts := []dht.Option{
 		dht.Validator(record.PublicKeyValidator{}),
 		dht.Datastore(ds),
-		dht.ProtocolPrefix("/spacekad"),
+		dht.ProtocolPrefix(protocolPrefix),
 	}
 	if public {
 		opts = append(opts, dht.QueryFilter(dht.PublicQueryFilter),
@@ -284,68 +308,67 @@ func (d *Discovery) ensureAtLeastMinPeers() error {
 }
 
 func (d *Discovery) discoverPeers() error {
-	d.logger.Info("QQQQQ: start")
-	var disc = p2pdiscr.NewRoutingDiscovery(d.dht)
+	disc := p2pdiscr.NewRoutingDiscovery(d.dht)
 
 	ticker := time.NewTicker(time.Second * 1)
 	defer ticker.Stop()
 	peerCh, err := disc.FindPeers(d.ctx, discoveryNS)
 	if err != nil {
-		d.logger.Info("QQQQQ: find peers fail")
 		return fmt.Errorf("error finding peers: %w", err)
 	}
 
-	d.logger.Info("QQQQQ: looking for peers")
 	reAdvCh := time.After(10 * time.Second)
 
 	for {
+		for !d.h.NeedPeerDiscovery() {
+			d.logger.With().Info("suspending routing discovery",
+				zap.Duration("delay", discoveryHighPeersDelay))
+			select {
+			case <-d.ctx.Done():
+				return nil
+			case <-time.After(discoveryHighPeersDelay):
+			}
+		}
+
 		select {
 		case <-d.ctx.Done():
-			d.logger.Info("QQQQQ: done looking for peers")
 			return nil
 		case <-reAdvCh:
-			d.logger.Info("QQQQQ: re-advertise")
 			ttl, err := disc.Advertise(d.ctx, discoveryNS, p2pdisc.TTL(10*time.Second))
 			if err != nil {
 				d.logger.Error("failed to re-advertise for discovery", zap.Error(err))
-				ttl = 10 * time.Second
+				reAdvCh = time.After(10 * time.Second)
 				continue
 			}
 			reAdvCh = time.After(ttl)
 		case p, ok := <-peerCh:
 			if !ok {
-				d.logger.Info("QQQQQ: no more peers, retrying find")
 				time.Sleep(time.Second) // FIXME
 				peerCh, err = disc.FindPeers(d.ctx, discoveryNS)
 				if err != nil {
-					d.logger.Info("QQQQQ: repeated find peers fail")
 					return fmt.Errorf("error finding peers: %w", err)
 				}
 				continue
 			}
 			if p.ID == d.h.ID() {
-				d.logger.Info("QQQQQ: found self")
 				continue
 			}
 			if d.h.Network().Connectedness(p.ID) != network.Connected {
-				d.logger.Info("QQQQQ: dialing peer", zap.Any("peer", p))
 				if _, err = d.h.Network().DialPeer(d.ctx, p.ID); err != nil {
-					d.logger.Info("QQQQQ: fail dialing peer", zap.Any("peer", p), zap.Error(err))
 					d.logger.Error("error dialing peer", zap.Any("peer", p),
 						zap.Error(err))
 					continue
 				}
-				// tag peer to prioritize it over the peers found by other means
-				d.h.ConnManager().TagPeer(p.ID, discoveryTag, discoveryTagValue)
-				d.logger.Info("found peer via rendezvous", zap.Any("peer", p))
-			} else {
-				d.logger.Info("QQQQQ: found already connected peer", zap.Any("peer", p))
+			}
+			// tag peer to prioritize it over the peers found by other means
+			d.h.ConnManager().TagPeer(p.ID, discoveryTag, discoveryTagValue)
+			d.logger.Info("found peer via rendezvous", zap.Any("peer", p))
+			if d.relayCh != nil && len(p.Addrs) != 0 {
+				select {
+				case d.relayCh <- p:
+				default: // do not block
+				}
 			}
 		}
 	}
-	// TagPeer
-	// GetTagInfo
-	// TBD: try not too grab too many peers when there are enough connected peers found through rendezvous -- cancel context, later restart if needed
-	// TBD: tag peer in the conn manager
-	// TBD: to consider: tag DHT-enabled peers too
 }

--- a/p2p/dhtdiscovery/discovery.go
+++ b/p2p/dhtdiscovery/discovery.go
@@ -320,7 +320,9 @@ func (d *Discovery) discoverPeers() error {
 	reAdvCh := time.After(10 * time.Second)
 
 	for {
+		wasSuspended := false
 		for !d.h.NeedPeerDiscovery() {
+			wasSuspended = true
 			d.logger.With().Info("suspending routing discovery",
 				zap.Duration("delay", discoveryHighPeersDelay))
 			select {
@@ -328,6 +330,9 @@ func (d *Discovery) discoverPeers() error {
 				return nil
 			case <-time.After(discoveryHighPeersDelay):
 			}
+		}
+		if wasSuspended {
+			d.logger.With().Info("resuming routing discovery")
 		}
 
 		select {

--- a/p2p/dhtdiscovery/discovery_test.go
+++ b/p2p/dhtdiscovery/discovery_test.go
@@ -2,9 +2,11 @@ package discovery
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
+	dht "github.com/libp2p/go-libp2p-kad-dht"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
 	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
@@ -21,43 +23,101 @@ type discHost struct {
 
 var _ DiscoveryHost = &discHost{}
 
-func makeDiscHost(h host.Host) *discHost {
-	return &discHost{Host: h}
+func makeDiscHost(h host.Host, needPeerDiscovery, haveRelay bool) *discHost {
+	return &discHost{
+		Host:              h,
+		needPeerDiscovery: needPeerDiscovery,
+		haveRelay:         haveRelay,
+	}
 }
 
 func (h *discHost) NeedPeerDiscovery() bool { return h.needPeerDiscovery }
 func (h *discHost) HaveRelay() bool         { return h.haveRelay }
 
 func TestSanity(t *testing.T) {
-	mock, err := mocknet.FullMeshLinked(4)
+	mock, err := mocknet.FullMeshLinked(7)
+	for n, h := range mock.Hosts() {
+		t.Logf("Host %d: %s", n, h.ID())
+	}
 	require.NoError(t, err)
 	discs := make([]*Discovery, len(mock.Hosts()))
 	t.Cleanup(func() {
 		for _, disc := range discs {
-
 			disc.Stop()
 		}
 	})
-	boot := makeDiscHost(mock.Hosts()[0])
+	// Let the bootnode have suspended peer discovery.
+	// It knows all the nodes anyway. Also, do not advertise
+	// it for routing discovery as all the nodes know about
+	// their bootnode, too.
+	boot := makeDiscHost(mock.Hosts()[0], false, false)
 	logger := logtest.New(t).Zap()
 	bootdisc, err := New(boot,
 		WithPeriod(100*time.Microsecond),
+		EnableRoutingDiscovery(),
 		Private(),
-		Server(),
 		WithLogger(logger),
+		WithMode(dht.ModeServer),
 	)
 	require.NoError(t, err)
 	bootdisc.Start(context.Background())
 	defer bootdisc.Stop()
 	discs[0] = bootdisc
 	require.NoError(t, err)
+	relayChans := make([]chan peer.AddrInfo, len(mock.Hosts()))
+	nodeOpts := []struct {
+		// Nodes that run DHT in client mode (/.../kad/... protocol not supported)
+		// are much harder to come by without enabling routing discovery
+		dhtMode       dht.ModeOpt
+		relayService  bool
+		lookForRelays bool
+	}{
+		{
+			// 1
+			dhtMode:      dht.ModeServer,
+			relayService: true,
+		},
+		{
+			// 2
+			dhtMode:       dht.ModeServer,
+			lookForRelays: true,
+		},
+		{
+			// 3
+			dhtMode:       dht.ModeServer,
+			lookForRelays: true,
+		},
+		{
+			// 4
+			dhtMode:       dht.ModeServer,
+			lookForRelays: true,
+		},
+		{
+			// 5
+			dhtMode:       dht.ModeClient,
+			lookForRelays: true,
+		},
+		{
+			// 6
+			dhtMode:       dht.ModeClient,
+			lookForRelays: true,
+		},
+	}
 	for i, h := range mock.Hosts()[1:] {
-		disc, err := New(makeDiscHost(h),
+		opts := []Opt{
 			Private(),
 			WithLogger(logger),
 			WithBootnodes([]peer.AddrInfo{{ID: boot.ID(), Addrs: boot.Addrs()}}),
-			EnableRoutingDiscovery(true),
-		)
+			EnableRoutingDiscovery(),
+			AdvertiseForPeerDiscovery(),
+			WithMode(nodeOpts[i].dhtMode),
+		}
+		if nodeOpts[i].lookForRelays {
+			relayCh := make(chan peer.AddrInfo)
+			relayChans[1+i] = relayCh
+			opts = append(opts, WithRelayCandidateChannel(relayCh))
+		}
+		disc, err := New(makeDiscHost(h, true, nodeOpts[i].relayService), opts...)
 		require.NoError(t, err)
 		disc.Start(context.Background())
 		defer disc.Stop()
@@ -70,6 +130,27 @@ func TestSanity(t *testing.T) {
 			}
 		}
 		return true
-	}, 3*time.Second, 50*time.Microsecond)
-	// TODO: capture advertised peers and relays
+	}, 15*time.Second, 100*time.Millisecond)
+
+	// Wait till every node looking for relays have discovered
+	// the node 1 which has relay service enabled
+	var wg sync.WaitGroup
+	for n, ch := range relayChans {
+		n := n
+		ch := ch
+		if ch == nil {
+			continue
+		}
+		wg.Add(1)
+		go func() {
+			select {
+			case p := <-ch:
+				require.Equal(t, mock.Hosts()[1].ID(), p.ID)
+			case <-time.After(3 * time.Second):
+				t.Errorf("timed out waiting for relay id for peer %d", n)
+			}
+			wg.Done()
+		}()
+	}
+	wg.Wait()
 }

--- a/p2p/handshake/handshake.go
+++ b/p2p/handshake/handshake.go
@@ -75,7 +75,7 @@ func WithRetryInterval(i time.Duration) Option {
 	}
 }
 
-// WithLog specifies handshake retry count.
+// WithAttempts specifies handshake retry count.
 func WithAttempts(n int) Option {
 	return func(w *transportWrapper) {
 		w.attempts = n

--- a/p2p/handshake/handshake.go
+++ b/p2p/handshake/handshake.go
@@ -1,0 +1,278 @@
+package handshake
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/transport"
+	"github.com/libp2p/go-msgio"
+	ma "github.com/multiformats/go-multiaddr"
+
+	"github.com/spacemeshos/go-spacemesh/log"
+)
+
+const (
+	handshakeTimeout       = 5 * time.Second
+	handshakeAttempts      = 3
+	handshakeRetryInterval = 1 * time.Second
+	maxCookieSize          = 64
+)
+
+var cookieStreamPrefix = []byte{
+	0x21, 0x23, 0x42, 0x42,
+}
+
+// NetworkCookie specifies a sequence of bytes that can be used to
+// prevent peers from different networks from communicating with each
+// other.
+type NetworkCookie []byte
+
+// NoNetworkCookie represents an empty NetworkCookie.
+var NoNetworkCookie NetworkCookie = nil
+
+// Empty returns true if the network cookie is empty.
+func (nc NetworkCookie) Empty() bool {
+	return len(nc) == 0
+}
+
+// String returns string representation of the NetworkCookie, which is
+// a hex string.
+func (nc NetworkCookie) String() string {
+	return hex.EncodeToString(nc)
+}
+
+// Equal returns true if this cookie is the same as the other cookie.
+func (nc NetworkCookie) Equal(other NetworkCookie) bool {
+	return bytes.Equal(nc, other)
+}
+
+// Option specifies a handshake option.
+type Option func(w *transportWrapper)
+
+// WithLog specifies a logger for handshake.
+func WithLog(logger log.Log) Option {
+	return func(w *transportWrapper) {
+		w.logger = logger
+	}
+}
+
+// WithLog specifies handshake timeout.
+func WithTimeout(t time.Duration) Option {
+	return func(w *transportWrapper) {
+		w.timeout = t
+	}
+}
+
+// WithLog specifies handshake retry interval.
+func WithRetryInterval(i time.Duration) Option {
+	return func(w *transportWrapper) {
+		w.retryInterval = i
+	}
+}
+
+// WithLog specifies handshake retry count.
+func WithAttempts(n int) Option {
+	return func(w *transportWrapper) {
+		w.attempts = n
+	}
+}
+
+type transportWrapper struct {
+	transport.Transport
+	nc            NetworkCookie
+	logger        log.Log
+	timeout       time.Duration
+	retryInterval time.Duration
+	attempts      int
+}
+
+var (
+	_ transport.Transport = &transportWrapper{}
+	_ io.Closer           = &transportWrapper{}
+)
+
+// MaybeWrapTransport adds a handshake wrapper around the Transport if
+// network cookie nc is not empty, otherwise it just returns the
+// transport.
+func MaybeWrapTransport(t transport.Transport, nc NetworkCookie, opts ...Option) transport.Transport {
+	if nc.Empty() {
+		return t
+	}
+	tr := &transportWrapper{
+		Transport:     t,
+		nc:            nc,
+		logger:        log.NewNop(),
+		timeout:       handshakeTimeout,
+		retryInterval: handshakeRetryInterval,
+		attempts:      handshakeAttempts,
+	}
+	for _, opt := range opts {
+		opt(tr)
+	}
+	return tr
+}
+
+func (tr *transportWrapper) Dial(ctx context.Context, raddr ma.Multiaddr, p peer.ID) (transport.CapableConn, error) {
+	c, err := tr.Transport.Dial(ctx, raddr, p)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := 0; i < tr.attempts; i++ {
+		var retry bool
+		retry, err = tr.handshake(ctx, c)
+		switch {
+		case err == nil:
+			return c, nil
+		case retry:
+			tr.logger.With().Error("transport wrapper handshake error",
+				log.Int("attempt", i+1),
+				log.Int("handshakeAttempts", tr.attempts),
+				log.Err(err))
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(handshakeRetryInterval):
+			}
+		default:
+			return nil, err
+		}
+	}
+
+	return nil, err
+}
+
+func (tr *transportWrapper) handshake(ctx context.Context, c transport.CapableConn) (retry bool, err error) {
+	attemptCtx, cancel := context.WithTimeout(ctx, handshakeTimeout)
+	defer cancel()
+	s, err := c.OpenStream(attemptCtx)
+	if err != nil {
+		return true, err
+	}
+
+	defer s.Close()
+	s.SetDeadline(time.Now().Add(tr.timeout))
+
+	if err := writeCookie(s, tr.nc); err != nil {
+		return true, err
+	}
+
+	remoteCookie, mayHaveCookie, err := readCookie(s)
+	if err != nil {
+		return mayHaveCookie, err
+	}
+
+	if !tr.nc.Equal(remoteCookie) {
+		return false, fmt.Errorf("cookie mismatch: %s instead of expected %s", remoteCookie, tr.nc)
+	}
+
+	return false, nil
+}
+
+func (tr *transportWrapper) Listen(laddr ma.Multiaddr) (transport.Listener, error) {
+	l, err := tr.Transport.Listen(laddr)
+	if err != nil {
+		return nil, ma.ErrProtocolNotFound
+	}
+	return &listenerWrapper{
+		Listener: l,
+		nc:       tr.nc,
+		logger:   tr.logger,
+		timeout:  tr.timeout,
+		attempts: tr.attempts,
+	}, nil
+}
+
+func (tr *transportWrapper) Close() error {
+	if c, ok := tr.Transport.(io.Closer); ok {
+		return c.Close()
+	}
+
+	return nil
+}
+
+type listenerWrapper struct {
+	transport.Listener
+	nc       NetworkCookie
+	logger   log.Log
+	timeout  time.Duration
+	attempts int
+}
+
+var _ transport.Listener = &listenerWrapper{}
+
+func (l *listenerWrapper) Accept() (transport.CapableConn, error) {
+	for {
+		c, err := l.Listener.Accept()
+		if err != nil {
+			return nil, err
+		}
+		for i := 0; i < l.attempts; i++ {
+			retry, err := l.handshake(c)
+			switch {
+			case err == nil:
+				return c, nil
+			case retry:
+				l.logger.With().Error("transport wrapper handshake error",
+					log.Int("attempt", i+1),
+					log.Int("handshakeAttempts", l.attempts),
+					log.Err(err))
+			default:
+				l.logger.With().Error("handshake failed", log.Err(err))
+			}
+		}
+	}
+}
+
+func (l *listenerWrapper) handshake(c transport.CapableConn) (retry bool, err error) {
+	s, err := c.AcceptStream()
+	if err != nil {
+		return true, err
+	}
+	defer s.Close()
+	s.SetDeadline(time.Now().Add(l.timeout))
+
+	remoteCookie, mayHaveCookie, err := readCookie(s)
+	if err != nil {
+		return mayHaveCookie, err
+	}
+
+	// Write our cookie even in case of mismatch so that the
+	// peer sees the reason for disconnect immediately
+	if err := writeCookie(s, l.nc); err != nil {
+		return true, err
+	}
+
+	if !l.nc.Equal(remoteCookie) {
+		return false, fmt.Errorf("cookie mismatch: %s instead of expected %s", remoteCookie, l.nc)
+	}
+
+	return false, nil
+}
+
+func writeCookie(w io.Writer, nc NetworkCookie) error {
+	if _, err := w.Write(cookieStreamPrefix); err != nil {
+		return err
+	}
+	return msgio.NewVarintWriter(w).WriteMsg(nc)
+}
+
+func readCookie(r io.Reader) (nc NetworkCookie, mayHaveCookie bool, err error) {
+	buf := make([]byte, len(cookieStreamPrefix))
+	if _, err := io.ReadFull(r, buf); err != nil {
+		return nil, true, err
+	}
+	if !bytes.Equal(cookieStreamPrefix, buf) {
+		return nil, false, fmt.Errorf("the remote endpoint doesn't have a cookie")
+	}
+	b, err := msgio.NewVarintReaderSize(r, maxCookieSize).ReadMsg()
+	if err != nil {
+		return nil, true, err
+	}
+	return NetworkCookie(b), true, err
+}

--- a/p2p/handshake/handshake_test.go
+++ b/p2p/handshake/handshake_test.go
@@ -1,0 +1,156 @@
+package handshake
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/transport"
+	quic "github.com/libp2p/go-libp2p/p2p/transport/quic"
+	"github.com/libp2p/go-libp2p/p2p/transport/quicreuse"
+	ma "github.com/multiformats/go-multiaddr"
+	quicgo "github.com/quic-go/quic-go"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/spacemeshos/go-spacemesh/log"
+	"github.com/spacemeshos/go-spacemesh/log/logtest"
+)
+
+func createPeer(t *testing.T) (peer.ID, crypto.PrivKey) {
+	pk, _, err := crypto.GenerateECDSAKeyPair(rand.Reader)
+	require.NoError(t, err)
+	id, err := peer.IDFromPrivateKey(pk)
+	require.NoError(t, err)
+	return id, pk
+}
+
+func newConnManager(t *testing.T, opts ...quicreuse.Option) *quicreuse.ConnManager {
+	t.Helper()
+	cm, err := quicreuse.NewConnManager(quicgo.StatelessResetKey{}, quicgo.TokenGeneratorKey{}, opts...)
+	require.NoError(t, err)
+	t.Cleanup(func() { cm.Close() })
+	return cm
+}
+
+func wrapTransport(t transport.Transport, nc NetworkCookie, logger log.Log) transport.Transport {
+	return MaybeWrapTransport(t, nc, WithLog(logger), WithTimeout(300*time.Millisecond), WithAttempts(2))
+}
+
+func TestTransportWrapper(t *testing.T) {
+	type testcase struct {
+		name         string
+		clientCookie NetworkCookie
+		serverCookie NetworkCookie
+		dialError    bool
+		readError    bool
+	}
+
+	testcases := []testcase{
+		{
+			name: "no cookies",
+		},
+		{
+			name:         "matching cookies",
+			clientCookie: NetworkCookie{0, 1, 2, 3},
+			serverCookie: NetworkCookie{0, 1, 2, 3},
+		},
+		{
+			name:         "non-matching cookies",
+			clientCookie: NetworkCookie{0, 1, 2, 3},
+			serverCookie: NetworkCookie{0, 1, 2, 0},
+			dialError:    true,
+		},
+		{
+			name:         "client cookie missing",
+			serverCookie: NetworkCookie{0, 1, 2, 3},
+			readError:    true,
+		},
+		{
+			name:         "server cookie missing",
+			clientCookie: NetworkCookie{0, 1, 2, 3},
+			dialError:    true,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			serverID, serverKey := createPeer(t)
+			_, clientKey := createPeer(t)
+
+			logger := logtest.New(t)
+
+			serverTransport, err := quic.NewTransport(serverKey, newConnManager(t), nil, nil, nil)
+			serverTransport = wrapTransport(serverTransport, tc.serverCookie, logger)
+			require.NoError(t, err)
+			defer serverTransport.(io.Closer).Close()
+
+			ln, err := serverTransport.Listen(ma.StringCast("/ip4/127.0.0.1/udp/0/quic-v1"))
+			require.NoError(t, err)
+			var eg errgroup.Group
+			eg.Go(func() error {
+				c, err := ln.Accept()
+				if err != nil {
+					return fmt.Errorf("Accept error: %w", err)
+				}
+				t.Logf("accepted")
+				s, err := c.AcceptStream()
+				if err != nil {
+					return fmt.Errorf("AcceptStream error: %w", err)
+				}
+				defer s.Close()
+				buf := make([]byte, 4)
+				_, err = io.ReadFull(s, buf)
+				if err != nil {
+					return fmt.Errorf("read error: %w", err)
+				}
+				exp := []byte{10, 20, 30, 40}
+				if !bytes.Equal(buf, exp) {
+					return fmt.Errorf("data mismatch: expected %s, got %s",
+						hex.EncodeToString(exp), hex.EncodeToString(buf))
+				}
+				_, err = s.Write([]byte{11, 22, 33, 44})
+				if err != nil {
+					return fmt.Errorf("write error: %w", err)
+				}
+				return nil
+			})
+
+			defer eg.Wait()
+			defer ln.Close()
+
+			clientTransport, err := quic.NewTransport(clientKey, newConnManager(t), nil, nil, nil)
+			clientTransport = wrapTransport(clientTransport, tc.clientCookie, logger)
+			require.NoError(t, err)
+			defer clientTransport.(io.Closer).Close()
+
+			c, err := clientTransport.Dial(context.Background(), ln.Multiaddr(), serverID)
+			if tc.dialError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				s, err := c.OpenStream(context.Background())
+				require.NoError(t, err)
+				defer s.Close()
+				_, err = s.Write([]byte{10, 20, 30, 40})
+				require.NoError(t, err)
+				buf := make([]byte, 4)
+				_, err = io.ReadFull(s, buf)
+				if tc.readError {
+					require.Error(t, err)
+				} else {
+					require.NoError(t, err)
+					require.Equal(t, buf, []byte{11, 22, 33, 44})
+					require.NoError(t, eg.Wait())
+				}
+			}
+		})
+	}
+}

--- a/p2p/host.go
+++ b/p2p/host.go
@@ -1,15 +1,22 @@
 package p2p
 
 import (
+	"bytes"
 	"context"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	lp2plog "github.com/ipfs/go-log/v2"
 	"github.com/libp2p/go-libp2p"
+	ccmgr "github.com/libp2p/go-libp2p/core/connmgr"
 	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/pnet"
 	"github.com/libp2p/go-libp2p/core/protocol"
 	"github.com/libp2p/go-libp2p/core/transport"
 	"github.com/libp2p/go-libp2p/p2p/host/peerstore/pstoremem"
@@ -19,7 +26,9 @@ import (
 	tptu "github.com/libp2p/go-libp2p/p2p/net/upgrader"
 	"github.com/libp2p/go-libp2p/p2p/protocol/circuitv2/relay"
 	"github.com/libp2p/go-libp2p/p2p/security/noise"
+	p2ptls "github.com/libp2p/go-libp2p/p2p/security/tls"
 	quic "github.com/libp2p/go-libp2p/p2p/transport/quic"
+	"github.com/libp2p/go-libp2p/p2p/transport/quicreuse"
 	"github.com/libp2p/go-libp2p/p2p/transport/tcp"
 	"github.com/multiformats/go-multiaddr"
 	"github.com/prometheus/client_golang/prometheus"
@@ -28,6 +37,10 @@ import (
 	"github.com/spacemeshos/go-spacemesh/log"
 	p2pmetrics "github.com/spacemeshos/go-spacemesh/p2p/metrics"
 )
+
+// TODO: use proper registered PEN. See also:
+// https://github.com/libp2p/specs/pull/151/commits/15e57e758874bb85dbf711bfa165e48a26ece20d
+var tlsExtensionID = []int{1, 3, 6, 1, 4, 1, 123456, 1}
 
 // DefaultConfig config.
 func DefaultConfig() Config {
@@ -160,6 +173,34 @@ func (cfg *Config) Validate() error {
 	return nil
 }
 
+func validateTLSCertChain(chain []*x509.Certificate, prologue []byte) error {
+	if len(chain) != 1 {
+		return errors.New("expected one certificates in the chain")
+	}
+
+	cert := chain[0]
+	for _, ext := range cert.Extensions {
+		if !ext.Id.Equal(tlsExtensionID) {
+			continue
+		}
+
+		for i, oident := range cert.UnhandledCriticalExtensions {
+			if oident.Equal(ext.Id) {
+				cert.UnhandledCriticalExtensions = slices.Delete(cert.UnhandledCriticalExtensions, i, i+1)
+				break
+			}
+		}
+
+		if bytes.Equal(ext.Value, prologue) {
+			return nil
+		}
+
+		return errors.New("prologue mismatch")
+	}
+
+	return errors.New("prologue extension not found")
+}
+
 // New initializes libp2p host configured for spacemesh.
 func New(
 	_ context.Context,
@@ -219,6 +260,18 @@ func New(
 		direct:   directMap,
 	}
 
+	certTemplate, err := p2ptls.CertTemplate()
+	if err != nil {
+		return nil, err
+	}
+
+	certTemplate.ExtraExtensions = []pkix.Extension{
+		{
+			Id:    tlsExtensionID,
+			Value: prologue,
+		},
+	}
+
 	g.direct = directMap
 	lopts := []libp2p.Option{
 		libp2p.Identity(key),
@@ -236,7 +289,14 @@ func New(
 				return tcp.NewTCPTransport(upgrader, rcmgr, opts...)
 			},
 		),
-		libp2p.Transport(quic.NewTransport),
+		libp2p.Transport(func(key crypto.PrivKey, connManager *quicreuse.ConnManager, psk pnet.PSK, gater ccmgr.ConnectionGater, rcmgr network.ResourceManager) (transport.Transport, error) {
+			return quic.NewTransport(key, connManager, psk, gater, rcmgr,
+				quic.WithCertTemplate(certTemplate),
+				quic.WithVerifyPeerCertificate(func(chain []*x509.Certificate) error {
+					err := validateTLSCertChain(chain, prologue)
+					return err
+				}))
+		}),
 		libp2p.Security(
 			noise.ID,
 			func(id protocol.ID, privkey crypto.PrivKey, muxers []tptu.StreamMuxer) (*noise.SessionTransport, error) {

--- a/p2p/host.go
+++ b/p2p/host.go
@@ -86,6 +86,7 @@ func DefaultConfig() Config {
 		GossipQueueSize:             50000,
 		GossipValidationThrottle:    50000,
 		GossipAtxValidationThrottle: 50000,
+		PingInterval:                time.Second,
 		EnableTCPTransport:          true,
 		EnableQUICTransport:         false,
 		AdvertiseInterval:           time.Minute,
@@ -135,6 +136,7 @@ type Config struct {
 	GossipValidationThrottle    int           `mapstructure:"gossip-validation-throttle"`
 	GossipAtxValidationThrottle int           `mapstructure:"gossip-atx-validation-throttle"`
 	PingPeers                   []string      `mapstructure:"ping-peers"`
+	PingInterval                time.Duration `mapstructure:"ping-interval"`
 	Relay                       bool          `mapstructure:"relay"`
 	StaticRelays                []string      `mapstructure:"static-relays"`
 	EnableTCPTransport          bool          `mapstructure:"enable-tcp-transport"`

--- a/p2p/host.go
+++ b/p2p/host.go
@@ -106,6 +106,7 @@ type Config struct {
 	Metrics                     bool        `mapstructure:"p2p-metrics"`
 	Bootnode                    bool        `mapstructure:"p2p-bootnode"`
 	ForceReachability           string      `mapstructure:"p2p-reachability"`
+	ForceDHTServer              bool        `mapstructure:"force-dht-server"`
 	EnableHolepunching          bool        `mapstructure:"p2p-holepunching"`
 	PrivateNetwork              bool        `mapstructure:"p2p-private-network"`
 	RelayServer                 RelayServer `mapstructure:"relay-server"`

--- a/p2p/host.go
+++ b/p2p/host.go
@@ -3,6 +3,7 @@ package p2p
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	lp2plog "github.com/ipfs/go-log/v2"
@@ -19,6 +20,7 @@ import (
 	tptu "github.com/libp2p/go-libp2p/p2p/net/upgrader"
 	"github.com/libp2p/go-libp2p/p2p/protocol/circuitv2/relay"
 	"github.com/libp2p/go-libp2p/p2p/security/noise"
+	quic "github.com/libp2p/go-libp2p/p2p/transport/quic"
 	"github.com/libp2p/go-libp2p/p2p/transport/tcp"
 	"github.com/multiformats/go-multiaddr"
 	"github.com/prometheus/client_golang/prometheus"
@@ -199,7 +201,10 @@ func New(
 	g.direct = directMap
 	lopts := []libp2p.Option{
 		libp2p.Identity(key),
-		libp2p.ListenAddrStrings(cfg.Listen),
+		// TODO: use separate "multiListen" field or smth,
+		// using the space-separated list is ugly (just for
+		// testing)
+		libp2p.ListenAddrStrings(strings.Fields(cfg.Listen)...),
 		libp2p.UserAgent("go-spacemesh"),
 		libp2p.Transport(
 			func(upgrader transport.Upgrader, rcmgr network.ResourceManager) (transport.Transport, error) {
@@ -213,6 +218,7 @@ func New(
 				return tcp.NewTCPTransport(upgrader, rcmgr, opts...)
 			},
 		),
+		libp2p.Transport(quic.NewTransport),
 		libp2p.Security(
 			noise.ID,
 			func(id protocol.ID, privkey crypto.PrivKey, muxers []tptu.StreamMuxer) (*noise.SessionTransport, error) {

--- a/p2p/host.go
+++ b/p2p/host.go
@@ -178,6 +178,7 @@ func New(
 	logger log.Log,
 	cfg Config,
 	prologue []byte,
+	quicNetCookie handshake.NetworkCookie,
 	opts ...Opt,
 ) (*Host, error) {
 	if err := cfg.Validate(); err != nil {
@@ -279,8 +280,7 @@ func New(
 					if err != nil {
 						return nil, err
 					}
-					// QQQQQ: no prologue in case of mainnet (perhaps)
-					return handshake.MaybeWrapTransport(tr, prologue,
+					return handshake.MaybeWrapTransport(tr, quicNetCookie,
 						handshake.WithLog(logger)), nil
 				}),
 		)

--- a/p2p/host.go
+++ b/p2p/host.go
@@ -334,10 +334,12 @@ func New(
 				return nil, err
 			}
 			lopts = append(lopts, libp2p.EnableAutoRelayWithStaticRelays(relays))
-		} else {
+		} else if cfg.EnableRoutingDiscovery {
 			peerSrc, relayCh := relayPeerSource(logger)
 			lopts = append(lopts, libp2p.EnableAutoRelayWithPeerSource(peerSrc))
 			opts = append(opts, WithRelayCandidateChannel(relayCh))
+		} else {
+			lopts = append(lopts, libp2p.EnableAutoRelayWithStaticRelays(bootnodes))
 		}
 	} else {
 		lopts = append(lopts, libp2p.DisableRelay())

--- a/p2p/host.go
+++ b/p2p/host.go
@@ -3,7 +3,6 @@ package p2p
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	lp2plog "github.com/ipfs/go-log/v2"
@@ -33,7 +32,7 @@ import (
 // DefaultConfig config.
 func DefaultConfig() Config {
 	return Config{
-		Listen:                 "/ip4/0.0.0.0/tcp/7513",
+		ListenAddresses:        []string{"/ip4/0.0.0.0/tcp/7513"},
 		Flood:                  false,
 		MinPeers:               20,
 		LowPeers:               40,
@@ -92,6 +91,7 @@ type Config struct {
 	DisableDHT                  bool        `mapstructure:"disable-dht"`
 	Flood                       bool        `mapstructure:"flood"`
 	Listen                      string      `mapstructure:"listen"`
+	ListenAddresses             []string    `mapstructure:"listen-addresses"`
 	Bootnodes                   []string    `mapstructure:"bootnodes"`
 	Direct                      []string    `mapstructure:"direct"`
 	MinPeers                    int         `mapstructure:"min-peers"`
@@ -126,8 +126,15 @@ type RelayServer struct {
 	TTL          time.Duration `mapstructure:"ttl"`
 }
 
+func (cfg *Config) allListenAddrs() []string {
+	if cfg.Listen == "" {
+		return cfg.ListenAddresses
+	}
+	return append(cfg.ListenAddresses, cfg.Listen)
+}
+
 func (cfg *Config) allAdvertisedAddrs() []string {
-	if len(cfg.AdvertiseAddress) == 0 {
+	if cfg.AdvertiseAddress == "" {
 		return cfg.AdvertiseAddresses
 	}
 	return append(cfg.AdvertiseAddresses, cfg.AdvertiseAddress)
@@ -143,7 +150,7 @@ func (cfg *Config) Validate() error {
 		}
 	}
 
-	for _, addrStr := range cfg.allAdvertisedAddrs() {
+	for _, addrStr := range append(cfg.allAdvertisedAddrs(), cfg.allAdvertisedAddrs()...) {
 		_, err := multiaddr.NewMultiaddr(addrStr)
 		if err != nil {
 			return fmt.Errorf("address %s is not a valid multiaddr %w", addrStr, err)
@@ -215,10 +222,7 @@ func New(
 	g.direct = directMap
 	lopts := []libp2p.Option{
 		libp2p.Identity(key),
-		// TODO: use separate "multiListen" field or smth,
-		// using the space-separated list is ugly (just for
-		// testing)
-		libp2p.ListenAddrStrings(strings.Fields(cfg.Listen)...),
+		libp2p.ListenAddrStrings(cfg.allListenAddrs()...),
 		libp2p.UserAgent("go-spacemesh"),
 		libp2p.Transport(
 			func(upgrader transport.Upgrader, rcmgr network.ResourceManager) (transport.Transport, error) {

--- a/p2p/host.go
+++ b/p2p/host.go
@@ -142,7 +142,7 @@ type Config struct {
 	EnableTCPTransport          bool          `mapstructure:"enable-tcp-transport"`
 	EnableQUICTransport         bool          `mapstructure:"enable-quic-transport"`
 	EnableRoutingDiscovery      bool          `mapstructure:"enable-routing-discovery"`
-	RoutingDiscoveryNoAdvertise bool          `mapstructure:"routing-discovery-no-advertise"`
+	RoutingDiscoveryAdvertise   bool          `mapstructure:"routing-discovery-advertise"`
 	AdvertiseInterval           time.Duration `mapstructure:"advertise-interval"`
 }
 

--- a/p2p/host.go
+++ b/p2p/host.go
@@ -101,6 +101,7 @@ type Config struct {
 	OutboundFraction            float64     `mapstructure:"outbound-fraction"`
 	AutoscalePeers              bool        `mapstructure:"autoscale-peers"`
 	AdvertiseAddress            string      `mapstructure:"advertise-address"`
+	AdvertiseAddresses          []string    `mapstructure:"advertise-addresses"`
 	AcceptQueue                 int         `mapstructure:"p2p-accept-queue"`
 	Metrics                     bool        `mapstructure:"p2p-metrics"`
 	Bootnode                    bool        `mapstructure:"p2p-bootnode"`
@@ -113,12 +114,22 @@ type Config struct {
 	GossipQueueSize             int         `mapstructure:"gossip-queue-size"`
 	GossipValidationThrottle    int         `mapstructure:"gossip-validation-throttle"`
 	GossipAtxValidationThrottle int         `mapstructure:"gossip-atx-validation-throttle"`
+	PingPeers                   []string    `mapstructure:"ping-peers"`
+	Relay                       bool        `mapstructure:"relay"`
+	Relays                      []string    `mapstructure:"relays"`
 }
 
 type RelayServer struct {
 	Enable       bool          `mapstructure:"enable"`
 	Reservations int           `mapstructure:"reservations"`
 	TTL          time.Duration `mapstructure:"ttl"`
+}
+
+func (cfg *Config) allAdvertisedAddrs() []string {
+	if len(cfg.AdvertiseAddress) == 0 {
+		return cfg.AdvertiseAddresses
+	}
+	return append(cfg.AdvertiseAddresses, cfg.AdvertiseAddress)
 }
 
 func (cfg *Config) Validate() error {
@@ -130,12 +141,14 @@ func (cfg *Config) Validate() error {
 			)
 		}
 	}
-	if len(cfg.AdvertiseAddress) > 0 {
-		_, err := multiaddr.NewMultiaddr(cfg.AdvertiseAddress)
+
+	for _, addrStr := range cfg.allAdvertisedAddrs() {
+		_, err := multiaddr.NewMultiaddr(addrStr)
 		if err != nil {
-			return fmt.Errorf("address %s is not a valid multiaddr %w", cfg.AdvertiseAddress, err)
+			return fmt.Errorf("address %s is not a valid multiaddr %w", addrStr, err)
 		}
 	}
+
 	return nil
 }
 
@@ -239,15 +252,19 @@ func New(
 	if !cfg.DisableConnectionManager {
 		lopts = append(lopts, libp2p.ConnectionManager(cm))
 	}
-	if len(cfg.AdvertiseAddress) > 0 {
-		addr, err := multiaddr.NewMultiaddr(cfg.AdvertiseAddress)
-		if err != nil {
-			panic(err) // validated in config
+	if allAdvAddrs := cfg.allAdvertisedAddrs(); len(allAdvAddrs) > 0 {
+		var addrs []multiaddr.Multiaddr
+		for _, addrStr := range allAdvAddrs {
+			addr, err := multiaddr.NewMultiaddr(addrStr)
+			if err != nil {
+				panic(err) // validated in config
+			}
+			addrs = append(addrs, addr)
 		}
 		lopts = append(
 			lopts,
 			libp2p.AddrsFactory(func([]multiaddr.Multiaddr) []multiaddr.Multiaddr {
-				return []multiaddr.Multiaddr{addr}
+				return addrs
 			}),
 		)
 	}
@@ -261,6 +278,16 @@ func New(
 		resources.MaxReservations = cfg.RelayServer.Reservations
 		resources.ReservationTTL = cfg.RelayServer.TTL
 		lopts = append(lopts, libp2p.EnableRelayService(relay.WithResources(resources)))
+	}
+	if cfg.Relay {
+		lopts = append(lopts, libp2p.EnableRelay())
+	}
+	if len(cfg.Relays) != 0 {
+		relays, err := parseIntoAddr(cfg.Relays)
+		if err != nil {
+			return nil, err
+		}
+		lopts = append(lopts, libp2p.EnableAutoRelayWithStaticRelays(relays))
 	}
 	if cfg.ForceReachability == PublicReachability {
 		lopts = append(lopts, libp2p.ForceReachabilityPublic())

--- a/p2p/host.go
+++ b/p2p/host.go
@@ -1,13 +1,9 @@
 package p2p
 
 import (
-	"bytes"
 	"context"
-	"crypto/x509"
-	"crypto/x509/pkix"
 	"errors"
 	"fmt"
-	"slices"
 	"time"
 
 	lp2plog "github.com/ipfs/go-log/v2"
@@ -26,7 +22,6 @@ import (
 	tptu "github.com/libp2p/go-libp2p/p2p/net/upgrader"
 	"github.com/libp2p/go-libp2p/p2p/protocol/circuitv2/relay"
 	"github.com/libp2p/go-libp2p/p2p/security/noise"
-	p2ptls "github.com/libp2p/go-libp2p/p2p/security/tls"
 	quic "github.com/libp2p/go-libp2p/p2p/transport/quic"
 	"github.com/libp2p/go-libp2p/p2p/transport/quicreuse"
 	"github.com/libp2p/go-libp2p/p2p/transport/tcp"
@@ -35,12 +30,9 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/spacemeshos/go-spacemesh/log"
+	"github.com/spacemeshos/go-spacemesh/p2p/handshake"
 	p2pmetrics "github.com/spacemeshos/go-spacemesh/p2p/metrics"
 )
-
-// TODO: use proper registered PEN. See also:
-// https://github.com/libp2p/specs/pull/151/commits/15e57e758874bb85dbf711bfa165e48a26ece20d
-var tlsExtensionID = []int{1, 3, 6, 1, 4, 1, 123456, 1}
 
 // DefaultConfig config.
 func DefaultConfig() Config {
@@ -180,34 +172,6 @@ func (cfg *Config) Validate() error {
 	return nil
 }
 
-func validateTLSCertChain(chain []*x509.Certificate, prologue []byte) error {
-	if len(chain) != 1 {
-		return errors.New("expected one certificates in the chain")
-	}
-
-	cert := chain[0]
-	for _, ext := range cert.Extensions {
-		if !ext.Id.Equal(tlsExtensionID) {
-			continue
-		}
-
-		for i, oident := range cert.UnhandledCriticalExtensions {
-			if oident.Equal(ext.Id) {
-				cert.UnhandledCriticalExtensions = slices.Delete(cert.UnhandledCriticalExtensions, i, i+1)
-				break
-			}
-		}
-
-		if bytes.Equal(ext.Value, prologue) {
-			return nil
-		}
-
-		return errors.New("prologue mismatch")
-	}
-
-	return errors.New("prologue extension not found")
-}
-
 // New initializes libp2p host configured for spacemesh.
 func New(
 	_ context.Context,
@@ -267,18 +231,6 @@ func New(
 		direct:   directMap,
 	}
 
-	certTemplate, err := p2ptls.CertTemplate()
-	if err != nil {
-		return nil, err
-	}
-
-	certTemplate.ExtraExtensions = []pkix.Extension{
-		{
-			Id:    tlsExtensionID,
-			Value: prologue,
-		},
-	}
-
 	g.direct = directMap
 	lopts := []libp2p.Option{
 		libp2p.Identity(key),
@@ -324,12 +276,13 @@ func New(
 					gater ccmgr.ConnectionGater,
 					rcmgr network.ResourceManager,
 				) (transport.Transport, error) {
-					return quic.NewTransport(key, connManager, psk, gater, rcmgr,
-						quic.WithCertTemplate(certTemplate),
-						quic.WithVerifyPeerCertificate(func(chain []*x509.Certificate) error {
-							err := validateTLSCertChain(chain, prologue)
-							return err
-						}))
+					tr, err := quic.NewTransport(key, connManager, psk, gater, rcmgr)
+					if err != nil {
+						return nil, err
+					}
+					// QQQQQ: no prologue in case of mainnet (perhaps)
+					return handshake.MaybeWrapTransport(tr, prologue,
+						handshake.WithLog(logger)), nil
 				}),
 		)
 	}

--- a/p2p/host.go
+++ b/p2p/host.go
@@ -88,6 +88,7 @@ func DefaultConfig() Config {
 		GossipAtxValidationThrottle: 50000,
 		EnableTCPTransport:          true,
 		EnableQUICTransport:         false,
+		AdvertiseInterval:           time.Minute,
 	}
 }
 
@@ -104,42 +105,43 @@ type Config struct {
 	MaxMessageSize     int
 
 	// see https://lwn.net/Articles/542629/ for reuseport explanation
-	DisableReusePort            bool        `mapstructure:"disable-reuseport"`
-	DisableNatPort              bool        `mapstructure:"disable-natport"`
-	DisableConnectionManager    bool        `mapstructure:"disable-connection-manager"`
-	DisableResourceManager      bool        `mapstructure:"disable-resource-manager"`
-	DisableDHT                  bool        `mapstructure:"disable-dht"`
-	Flood                       bool        `mapstructure:"flood"`
-	Listen                      AddressList `mapstructure:"listen"`
-	Bootnodes                   []string    `mapstructure:"bootnodes"`
-	Direct                      []string    `mapstructure:"direct"`
-	MinPeers                    int         `mapstructure:"min-peers"`
-	LowPeers                    int         `mapstructure:"low-peers"`
-	HighPeers                   int         `mapstructure:"high-peers"`
-	InboundFraction             float64     `mapstructure:"inbound-fraction"`
-	OutboundFraction            float64     `mapstructure:"outbound-fraction"`
-	AutoscalePeers              bool        `mapstructure:"autoscale-peers"`
-	AdvertiseAddress            AddressList `mapstructure:"advertise-address"`
-	AcceptQueue                 int         `mapstructure:"p2p-accept-queue"`
-	Metrics                     bool        `mapstructure:"p2p-metrics"`
-	Bootnode                    bool        `mapstructure:"p2p-bootnode"`
-	ForceReachability           string      `mapstructure:"p2p-reachability"`
-	ForceDHTServer              bool        `mapstructure:"force-dht-server"`
-	EnableHolepunching          bool        `mapstructure:"p2p-holepunching"`
-	PrivateNetwork              bool        `mapstructure:"p2p-private-network"`
-	RelayServer                 RelayServer `mapstructure:"relay-server"`
-	IP4Blocklist                []string    `mapstructure:"ip4-blocklist"`
-	IP6Blocklist                []string    `mapstructure:"ip6-blocklist"`
-	GossipQueueSize             int         `mapstructure:"gossip-queue-size"`
-	GossipValidationThrottle    int         `mapstructure:"gossip-validation-throttle"`
-	GossipAtxValidationThrottle int         `mapstructure:"gossip-atx-validation-throttle"`
-	PingPeers                   []string    `mapstructure:"ping-peers"`
-	Relay                       bool        `mapstructure:"relay"`
-	StaticRelays                []string    `mapstructure:"static-relays"`
-	EnableTCPTransport          bool        `mapstructure:"enable-tcp-transport"`
-	EnableQUICTransport         bool        `mapstructure:"enable-quic-transport"`
-	EnableRoutingDiscovery      bool        `mapstructure:"enable-routing-discovery"`
-	RoutingDiscoveryNoAdvertise bool        `mapstructure:"routing-discovery-no-advertise"`
+	DisableReusePort            bool          `mapstructure:"disable-reuseport"`
+	DisableNatPort              bool          `mapstructure:"disable-natport"`
+	DisableConnectionManager    bool          `mapstructure:"disable-connection-manager"`
+	DisableResourceManager      bool          `mapstructure:"disable-resource-manager"`
+	DisableDHT                  bool          `mapstructure:"disable-dht"`
+	Flood                       bool          `mapstructure:"flood"`
+	Listen                      AddressList   `mapstructure:"listen"`
+	Bootnodes                   []string      `mapstructure:"bootnodes"`
+	Direct                      []string      `mapstructure:"direct"`
+	MinPeers                    int           `mapstructure:"min-peers"`
+	LowPeers                    int           `mapstructure:"low-peers"`
+	HighPeers                   int           `mapstructure:"high-peers"`
+	InboundFraction             float64       `mapstructure:"inbound-fraction"`
+	OutboundFraction            float64       `mapstructure:"outbound-fraction"`
+	AutoscalePeers              bool          `mapstructure:"autoscale-peers"`
+	AdvertiseAddress            AddressList   `mapstructure:"advertise-address"`
+	AcceptQueue                 int           `mapstructure:"p2p-accept-queue"`
+	Metrics                     bool          `mapstructure:"p2p-metrics"`
+	Bootnode                    bool          `mapstructure:"p2p-bootnode"`
+	ForceReachability           string        `mapstructure:"p2p-reachability"`
+	ForceDHTServer              bool          `mapstructure:"force-dht-server"`
+	EnableHolepunching          bool          `mapstructure:"p2p-holepunching"`
+	PrivateNetwork              bool          `mapstructure:"p2p-private-network"`
+	RelayServer                 RelayServer   `mapstructure:"relay-server"`
+	IP4Blocklist                []string      `mapstructure:"ip4-blocklist"`
+	IP6Blocklist                []string      `mapstructure:"ip6-blocklist"`
+	GossipQueueSize             int           `mapstructure:"gossip-queue-size"`
+	GossipValidationThrottle    int           `mapstructure:"gossip-validation-throttle"`
+	GossipAtxValidationThrottle int           `mapstructure:"gossip-atx-validation-throttle"`
+	PingPeers                   []string      `mapstructure:"ping-peers"`
+	Relay                       bool          `mapstructure:"relay"`
+	StaticRelays                []string      `mapstructure:"static-relays"`
+	EnableTCPTransport          bool          `mapstructure:"enable-tcp-transport"`
+	EnableQUICTransport         bool          `mapstructure:"enable-quic-transport"`
+	EnableRoutingDiscovery      bool          `mapstructure:"enable-routing-discovery"`
+	RoutingDiscoveryNoAdvertise bool          `mapstructure:"routing-discovery-no-advertise"`
+	AdvertiseInterval           time.Duration `mapstructure:"advertise-interval"`
 }
 
 type RelayServer struct {

--- a/p2p/host.go
+++ b/p2p/host.go
@@ -81,6 +81,8 @@ func DefaultConfig() Config {
 		GossipQueueSize:             50000,
 		GossipValidationThrottle:    50000,
 		GossipAtxValidationThrottle: 50000,
+		EnableTCPTransport:          true,
+		EnableQUICTransport:         false,
 	}
 }
 
@@ -131,6 +133,8 @@ type Config struct {
 	PingPeers                   []string    `mapstructure:"ping-peers"`
 	Relay                       bool        `mapstructure:"relay"`
 	Relays                      []string    `mapstructure:"relays"`
+	EnableTCPTransport          bool        `mapstructure:"enable-tcp-transport"`
+	EnableQUICTransport         bool        `mapstructure:"enable-quic-transport"`
 }
 
 type RelayServer struct {
@@ -154,6 +158,9 @@ func (cfg *Config) advertisedAddrs() []string {
 }
 
 func (cfg *Config) Validate() error {
+	if !cfg.EnableTCPTransport && !cfg.EnableQUICTransport {
+		return errors.New("no transports enabled")
+	}
 	if len(cfg.ForceReachability) > 0 {
 		if cfg.ForceReachability != PublicReachability &&
 			cfg.ForceReachability != PrivateReachability {
@@ -277,46 +284,54 @@ func New(
 		libp2p.Identity(key),
 		libp2p.ListenAddrStrings(cfg.listenAddrs()...),
 		libp2p.UserAgent("go-spacemesh"),
-		libp2p.Transport(
-			func(upgrader transport.Upgrader, rcmgr network.ResourceManager) (transport.Transport, error) {
-				opts := []tcp.Option{}
-				if cfg.DisableReusePort {
-					opts = append(opts, tcp.DisableReuseport())
-				}
-				if cfg.Metrics {
-					opts = append(opts, tcp.WithMetrics())
-				}
-				return tcp.NewTCPTransport(upgrader, rcmgr, opts...)
-			},
-		),
-		libp2p.Transport(
-			func(key crypto.PrivKey, connManager *quicreuse.ConnManager, psk pnet.PSK,
-				gater ccmgr.ConnectionGater,
-				rcmgr network.ResourceManager,
-			) (transport.Transport, error) {
-				return quic.NewTransport(key, connManager, psk, gater, rcmgr,
-					quic.WithCertTemplate(certTemplate),
-					quic.WithVerifyPeerCertificate(func(chain []*x509.Certificate) error {
-						err := validateTLSCertChain(chain, prologue)
-						return err
-					}))
-			}),
-		libp2p.Security(
-			noise.ID,
-			func(id protocol.ID, privkey crypto.PrivKey, muxers []tptu.StreamMuxer) (*noise.SessionTransport, error) {
-				tp, err := noise.New(id, privkey, muxers)
-				if err != nil {
-					return nil, err
-				}
-				return tp.WithSessionOptions(noise.Prologue(prologue))
-			},
-		),
 		libp2p.Muxer("/yamux/1.0.0", &streamer),
 		libp2p.Peerstore(ps),
 		libp2p.BandwidthReporter(p2pmetrics.NewBandwidthCollector()),
 		libp2p.EnableNATService(),
 		libp2p.ConnectionGater(g),
 		libp2p.Ping(false),
+	}
+	if cfg.EnableTCPTransport {
+		lopts = append(lopts,
+			libp2p.Transport(
+				func(upgrader transport.Upgrader, rcmgr network.ResourceManager) (transport.Transport, error) {
+					opts := []tcp.Option{}
+					if cfg.DisableReusePort {
+						opts = append(opts, tcp.DisableReuseport())
+					}
+					if cfg.Metrics {
+						opts = append(opts, tcp.WithMetrics())
+					}
+					return tcp.NewTCPTransport(upgrader, rcmgr, opts...)
+				},
+			),
+			libp2p.Security(
+				noise.ID,
+				func(id protocol.ID, privkey crypto.PrivKey, muxers []tptu.StreamMuxer) (*noise.SessionTransport, error) {
+					tp, err := noise.New(id, privkey, muxers)
+					if err != nil {
+						return nil, err
+					}
+					return tp.WithSessionOptions(noise.Prologue(prologue))
+				},
+			),
+		)
+	}
+	if cfg.EnableQUICTransport {
+		lopts = append(lopts,
+			libp2p.Transport(
+				func(key crypto.PrivKey, connManager *quicreuse.ConnManager, psk pnet.PSK,
+					gater ccmgr.ConnectionGater,
+					rcmgr network.ResourceManager,
+				) (transport.Transport, error) {
+					return quic.NewTransport(key, connManager, psk, gater, rcmgr,
+						quic.WithCertTemplate(certTemplate),
+						quic.WithVerifyPeerCertificate(func(chain []*x509.Certificate) error {
+							err := validateTLSCertChain(chain, prologue)
+							return err
+						}))
+				}),
+		)
 	}
 	if !cfg.DisableConnectionManager {
 		lopts = append(lopts, libp2p.ConnectionManager(cm))

--- a/p2p/host.go
+++ b/p2p/host.go
@@ -241,7 +241,6 @@ func New(
 		libp2p.BandwidthReporter(p2pmetrics.NewBandwidthCollector()),
 		libp2p.EnableNATService(),
 		libp2p.ConnectionGater(g),
-		libp2p.Ping(false),
 	}
 	if cfg.EnableTCPTransport {
 		lopts = append(lopts,

--- a/p2p/host_test.go
+++ b/p2p/host_test.go
@@ -11,24 +11,56 @@ import (
 )
 
 func TestPrologue(t *testing.T) {
-	cfg1 := DefaultConfig()
-	cfg1.DataDir = t.TempDir()
-	cfg1.Listen = "/ip4/127.0.0.1/tcp/0"
-	cfg2 := DefaultConfig()
-	cfg2.DataDir = t.TempDir()
-	cfg2.Listen = "/ip4/127.0.0.1/tcp/0"
+	for _, tc := range []struct {
+		desc   string
+		listen string
+		errStr string
+	}{
+		{
+			desc:   "tcp",
+			listen: "/ip4/127.0.0.1/tcp/0",
+			errStr: "failed to negotiate security protocol",
+		},
+		{
+			desc:   "quic",
+			listen: "/ip4/0.0.0.0/udp/0/quic-v1",
+			errStr: "prologue mismatch",
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			cfg1 := DefaultConfig()
+			cfg1.DataDir = t.TempDir()
+			cfg1.Listen = tc.listen
+			cfg2 := DefaultConfig()
+			cfg2.DataDir = t.TempDir()
+			cfg2.Listen = tc.listen
+			cfg3 := DefaultConfig()
+			cfg3.DataDir = t.TempDir()
+			cfg3.Listen = tc.listen
 
-	h1, err := New(context.Background(), logtest.New(t), cfg1, []byte("red"))
-	require.NoError(t, err)
-	t.Cleanup(func() { h1.Stop() })
+			h1, err := New(context.Background(), logtest.New(t), cfg1, []byte("red"))
+			require.NoError(t, err)
+			t.Cleanup(func() { h1.Stop() })
 
-	h2, err := New(context.Background(), logtest.New(t), cfg2, []byte("blue"))
-	require.NoError(t, err)
-	t.Cleanup(func() { h2.Stop() })
+			h2, err := New(context.Background(), logtest.New(t), cfg2, []byte("blue"))
+			require.NoError(t, err)
+			t.Cleanup(func() { h2.Stop() })
 
-	err = h1.Connect(context.Background(), peer.AddrInfo{
-		ID:    h2.ID(),
-		Addrs: h2.Addrs(),
-	})
-	require.ErrorContains(t, err, "failed to negotiate security protocol")
+			h3, err := New(context.Background(), logtest.New(t), cfg3, []byte("red"))
+			require.NoError(t, err)
+			t.Cleanup(func() { h3.Stop() })
+
+			err = h1.Connect(context.Background(), peer.AddrInfo{
+				ID:    h2.ID(),
+				Addrs: h2.Addrs(),
+			})
+			require.ErrorContains(t, err, tc.errStr)
+
+			err = h1.Connect(context.Background(), peer.AddrInfo{
+				ID:    h3.ID(),
+				Addrs: h3.Addrs(),
+			})
+			require.NoError(t, err)
+		})
+	}
 }

--- a/p2p/host_test.go
+++ b/p2p/host_test.go
@@ -11,32 +11,39 @@ import (
 )
 
 func TestPrologue(t *testing.T) {
-	for _, tc := range []struct {
-		desc   string
-		listen string
-		errStr string
-	}{
+	type testcase struct {
+		desc       string
+		listen     string
+		enableQUIC bool
+		errStr     string
+	}
+	var testcases = []testcase{
 		{
 			desc:   "tcp",
 			listen: "/ip4/127.0.0.1/tcp/0",
 			errStr: "failed to negotiate security protocol",
 		},
 		{
-			desc:   "quic",
-			listen: "/ip4/0.0.0.0/udp/0/quic-v1",
-			errStr: "prologue mismatch",
+			desc:       "quic",
+			listen:     "/ip4/0.0.0.0/udp/0/quic-v1",
+			enableQUIC: true,
+			errStr:     "cookie mismatch",
 		},
-	} {
+	}
+	for _, tc := range testcases {
 		t.Run(tc.desc, func(t *testing.T) {
 			cfg1 := DefaultConfig()
 			cfg1.DataDir = t.TempDir()
 			cfg1.Listen = tc.listen
+			cfg1.EnableQUICTransport = tc.enableQUIC
 			cfg2 := DefaultConfig()
 			cfg2.DataDir = t.TempDir()
 			cfg2.Listen = tc.listen
+			cfg2.EnableQUICTransport = tc.enableQUIC
 			cfg3 := DefaultConfig()
 			cfg3.DataDir = t.TempDir()
 			cfg3.Listen = tc.listen
+			cfg3.EnableQUICTransport = tc.enableQUIC
 
 			h1, err := New(context.Background(), logtest.New(t), cfg1, []byte("red"))
 			require.NoError(t, err)

--- a/p2p/host_test.go
+++ b/p2p/host_test.go
@@ -13,19 +13,19 @@ import (
 func TestPrologue(t *testing.T) {
 	type testcase struct {
 		desc       string
-		listen     string
+		listen     AddressList
 		enableQUIC bool
 		errStr     string
 	}
 	testcases := []testcase{
 		{
 			desc:   "tcp",
-			listen: "/ip4/127.0.0.1/tcp/0",
+			listen: MustParseAddresses("/ip4/127.0.0.1/tcp/0"),
 			errStr: "failed to negotiate security protocol",
 		},
 		{
 			desc:       "quic",
-			listen:     "/ip4/0.0.0.0/udp/0/quic-v1",
+			listen:     MustParseAddresses("/ip4/0.0.0.0/udp/0/quic-v1"),
 			enableQUIC: true,
 			errStr:     "cookie mismatch",
 		},

--- a/p2p/host_test.go
+++ b/p2p/host_test.go
@@ -17,7 +17,7 @@ func TestPrologue(t *testing.T) {
 		enableQUIC bool
 		errStr     string
 	}
-	var testcases = []testcase{
+	testcases := []testcase{
 		{
 			desc:   "tcp",
 			listen: "/ip4/127.0.0.1/tcp/0",

--- a/p2p/host_test.go
+++ b/p2p/host_test.go
@@ -45,15 +45,18 @@ func TestPrologue(t *testing.T) {
 			cfg3.Listen = tc.listen
 			cfg3.EnableQUICTransport = tc.enableQUIC
 
-			h1, err := New(context.Background(), logtest.New(t), cfg1, []byte("red"))
+			nc1 := []byte("red")
+			h1, err := New(context.Background(), logtest.New(t), cfg1, nc1, nc1)
 			require.NoError(t, err)
 			t.Cleanup(func() { h1.Stop() })
 
-			h2, err := New(context.Background(), logtest.New(t), cfg2, []byte("blue"))
+			nc2 := []byte("blue")
+			h2, err := New(context.Background(), logtest.New(t), cfg2, nc2, nc2)
 			require.NoError(t, err)
 			t.Cleanup(func() { h2.Stop() })
 
-			h3, err := New(context.Background(), logtest.New(t), cfg3, []byte("red"))
+			nc3 := []byte("red")
+			h3, err := New(context.Background(), logtest.New(t), cfg3, nc3, nc3)
 			require.NoError(t, err)
 			t.Cleanup(func() { h3.Stop() })
 

--- a/p2p/ping.go
+++ b/p2p/ping.go
@@ -1,0 +1,118 @@
+package p2p
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/p2p/protocol/ping"
+	ma "github.com/multiformats/go-multiaddr"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/spacemeshos/go-spacemesh/log"
+)
+
+const (
+	pingInterval = time.Second
+)
+
+type pingStat struct {
+	numSuccess int
+	numFail    int
+}
+
+type Ping struct {
+	sync.Mutex
+	logger log.Log
+	h      host.Host
+	peers  []peer.ID
+	stats  map[peer.ID]*pingStat
+	ctx    context.Context
+	cancel context.CancelFunc
+	eg     errgroup.Group
+}
+
+func NewPing(logger log.Log, h host.Host, peers []peer.ID) *Ping {
+	p := &Ping{
+		logger: logger,
+		h:      h,
+		peers:  peers,
+		stats:  make(map[peer.ID]*pingStat),
+	}
+	return p
+}
+
+func (p *Ping) Start() {
+	if p.cancel != nil {
+		return
+	}
+	p.ctx, p.cancel = context.WithCancel(context.Background())
+	p.logger.With().Info("QQQQQ: start ping (common)", log.Any("peers", p.peers))
+	for _, peer := range p.peers {
+		p.startForPeer(peer)
+	}
+}
+
+func (p *Ping) startForPeer(peer peer.ID) {
+	p.logger.With().Info("QQQQQ: start ping", log.Stringer("peer", peer))
+	ch := ping.Ping(p.ctx, p.h, peer)
+	p.eg.Go(func() error {
+		for r := range ch {
+			var addrs []ma.Multiaddr
+			for _, c := range p.h.Network().ConnsToPeer(peer) {
+				addrs = append(addrs, c.RemoteMultiaddr())
+			}
+			p.record(peer, r.Error == nil)
+			if r.Error != nil {
+				p.logger.With().Error("PING failed",
+					log.Stringer("peer", peer),
+					log.Any("addrs", addrs),
+					log.Err(r.Error))
+			} else {
+				p.logger.With().Info("PING succeeded",
+					log.Stringer("peer", peer),
+					log.Any("addrs", addrs),
+					log.Duration("rtt", r.RTT))
+			}
+			select {
+			case <-p.ctx.Done():
+				return p.ctx.Err()
+			case <-time.After(pingInterval):
+			}
+		}
+		return nil
+	})
+}
+
+func (p *Ping) record(peer peer.ID, success bool) {
+	p.Lock()
+	defer p.Unlock()
+	st := p.stats[peer]
+	if st == nil {
+		st = &pingStat{}
+		p.stats[peer] = st
+	}
+	if success {
+		p.stats[peer].numSuccess++
+	} else {
+		p.stats[peer].numFail++
+	}
+}
+
+func (p *Ping) Stats(peer peer.ID) (numSuccess, numFail int) {
+	p.Lock()
+	defer p.Unlock()
+	st := p.stats[peer]
+	return st.numSuccess, st.numFail
+}
+
+func (p *Ping) Stop() {
+	if p.cancel == nil {
+		return
+	}
+	p.cancel()
+	p.cancel = nil
+	p.eg.Wait()
+}

--- a/p2p/ping.go
+++ b/p2p/ping.go
@@ -2,6 +2,7 @@ package p2p
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -11,13 +12,13 @@ import (
 	"github.com/libp2p/go-libp2p/core/routing"
 	"github.com/libp2p/go-libp2p/p2p/protocol/ping"
 	ma "github.com/multiformats/go-multiaddr"
+	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
-
-	"github.com/spacemeshos/go-spacemesh/log"
 )
 
 const (
-	pingInterval = time.Second
+	pingInterval   = time.Second
+	pingProtectTag = "spacemesh-ping"
 )
 
 type pingStat struct {
@@ -27,17 +28,16 @@ type pingStat struct {
 
 type Ping struct {
 	sync.Mutex
-	logger log.Log
+	logger *zap.Logger
 	h      host.Host
 	peers  []peer.ID
 	pr     routing.PeerRouting
 	stats  map[peer.ID]*pingStat
-	ctx    context.Context
 	cancel context.CancelFunc
 	eg     errgroup.Group
 }
 
-func NewPing(logger log.Log, h host.Host, peers []peer.ID, pr routing.PeerRouting) *Ping {
+func NewPing(logger *zap.Logger, h host.Host, peers []peer.ID, pr routing.PeerRouting) *Ping {
 	p := &Ping{
 		logger: logger,
 		h:      h,
@@ -48,14 +48,24 @@ func NewPing(logger log.Log, h host.Host, peers []peer.ID, pr routing.PeerRoutin
 	return p
 }
 
-func (p *Ping) Start() {
+func (p *Ping) Start(ctx context.Context) {
 	if p.cancel != nil {
 		return
 	}
-	p.ctx, p.cancel = context.WithCancel(context.Background())
+	var startCtx context.Context
+	startCtx, p.cancel = context.WithCancel(context.Background())
 	for _, peer := range p.peers {
-		p.startForPeer(peer)
+		p.startForPeer(startCtx, peer)
 	}
+}
+
+func (p *Ping) Stop() {
+	if p.cancel == nil {
+		return
+	}
+	p.cancel()
+	p.cancel = nil
+	p.eg.Wait()
 }
 
 func (p *Ping) doPing(ctx context.Context, peerID peer.ID) (<-chan ping.Result, error) {
@@ -67,63 +77,57 @@ func (p *Ping) doPing(ctx context.Context, peerID peer.ID) (<-chan ping.Result, 
 	return ping.Ping(ctx, p.h, peerID), nil
 }
 
-func (p *Ping) startForPeer(peerID peer.ID) {
-	p.h.ConnManager().Protect(peerID, "sm-ping")
+// runForPeer runs ping for the specific peer till an error occurs
+// or the context is canceled.
+func (p *Ping) runForPeer(ctx context.Context, peerID peer.ID, addrs []ma.Multiaddr) error {
+	pingCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	ch, err := p.doPing(pingCtx, peerID)
+	if err != nil {
+		return err
+	}
 
+	for r := range ch {
+		p.record(peerID, r.Error == nil)
+		if r.Error != nil {
+			return r.Error
+		} else {
+			p.logger.Info("PING succeeded",
+				zap.Stringer("peer", peerID),
+				zap.Any("addrs", addrs),
+				zap.Duration("rtt", r.RTT))
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(pingInterval):
+		}
+	}
+
+	return nil
+}
+
+func (p *Ping) startForPeer(ctx context.Context, peerID peer.ID) {
+	p.h.ConnManager().Protect(peerID, pingProtectTag)
 	p.eg.Go(func() error {
-		var ctx context.Context
-		var cancel context.CancelFunc
-		defer func() {
-			if cancel != nil {
-				cancel()
-			}
-		}()
-	OUTER:
 		for {
-			if cancel != nil {
-				cancel()
+			var addrs []ma.Multiaddr
+			for _, c := range p.h.Network().ConnsToPeer(peerID) {
+				addrs = append(addrs, c.RemoteMultiaddr())
 			}
-			ctx, cancel = context.WithCancel(p.ctx)
-			ch, err := p.doPing(ctx, peerID)
-			if err != nil {
-				cancel()
-				p.logger.With().Error("pre-PING connect failed", log.Err(err))
-				select {
-				case <-p.ctx.Done():
-					return p.ctx.Err()
-				case <-time.After(pingInterval):
-					continue
-				}
+			err := p.runForPeer(ctx, peerID, addrs)
+			if errors.Is(err, context.Canceled) {
+				return nil
 			}
-
-			for r := range ch {
-				var addrs []ma.Multiaddr
-				for _, c := range p.h.Network().ConnsToPeer(peerID) {
-					addrs = append(addrs, c.RemoteMultiaddr())
-				}
-				p.record(peerID, r.Error == nil)
-				if r.Error != nil {
-					p.logger.With().Error("PING failed",
-						log.Stringer("peer", peerID),
-						log.Any("addrs", addrs),
-						log.Err(r.Error))
-					continue OUTER
-				} else {
-					p.logger.With().Info("PING succeeded",
-						log.Stringer("peer", peerID),
-						log.Any("addrs", addrs),
-						log.Duration("rtt", r.RTT))
-				}
-				select {
-				case <-p.ctx.Done():
-					cancel()
-					return p.ctx.Err()
-				case <-time.After(pingInterval):
-				}
+			p.logger.Error("PING failed",
+				zap.Stringer("peer", peerID),
+				zap.Any("addrs", addrs),
+				zap.Error(err))
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(pingInterval):
 			}
-
-			cancel()
-			return nil
 		}
 	})
 }
@@ -146,15 +150,9 @@ func (p *Ping) record(peerID peer.ID, success bool) {
 func (p *Ping) Stats(peerID peer.ID) (numSuccess, numFail int) {
 	p.Lock()
 	defer p.Unlock()
-	st := p.stats[peerID]
-	return st.numSuccess, st.numFail
-}
-
-func (p *Ping) Stop() {
-	if p.cancel == nil {
-		return
+	st, found := p.stats[peerID]
+	if !found {
+		return 0, 0
 	}
-	p.cancel()
-	p.cancel = nil
-	p.eg.Wait()
+	return st.numSuccess, st.numFail
 }

--- a/p2p/ping_test.go
+++ b/p2p/ping_test.go
@@ -16,7 +16,6 @@ func TestPing(t *testing.T) {
 		desc       string
 		listen     string
 		enableQUIC bool
-		errStr     string
 	}
 
 	testcases := []testcase{

--- a/p2p/ping_test.go
+++ b/p2p/ping_test.go
@@ -39,7 +39,7 @@ func TestPing(t *testing.T) {
 			nc := []byte("foobar")
 			h1, err := New(context.Background(), logtest.New(t), cfg1, nc, nc)
 			require.NoError(t, err)
-			h1.discovery.Start(context.Background())
+			h1.discovery.Start()
 			t.Cleanup(func() { h1.Stop() })
 
 			cfg2 := DefaultConfig()
@@ -49,7 +49,7 @@ func TestPing(t *testing.T) {
 			cfg2.PingPeers = []string{h1.ID().String()}
 			h2, err := New(context.Background(), logtest.New(t), cfg2, nc, nc)
 			require.NoError(t, err)
-			h2.discovery.Start(context.Background())
+			h2.discovery.Start()
 			t.Cleanup(func() { h2.Stop() })
 
 			err = h2.Connect(context.Background(), peer.AddrInfo{
@@ -58,7 +58,7 @@ func TestPing(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			h2.Ping().Start(context.Background())
+			h2.Ping().Start()
 			t.Cleanup(h2.Ping().Stop)
 
 			require.Eventually(t, func() bool {

--- a/p2p/ping_test.go
+++ b/p2p/ping_test.go
@@ -1,0 +1,69 @@
+package p2p
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/stretchr/testify/require"
+
+	"github.com/spacemeshos/go-spacemesh/log/logtest"
+)
+
+func TestPing(t *testing.T) {
+	type testcase struct {
+		desc       string
+		listen     string
+		enableQUIC bool
+		errStr     string
+	}
+
+	testcases := []testcase{
+		{
+			desc:   "tcp",
+			listen: "/ip4/127.0.0.1/tcp/0",
+		},
+		{
+			desc:       "quic",
+			listen:     "/ip4/0.0.0.0/udp/0/quic-v1",
+			enableQUIC: true,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.desc, func(t *testing.T) {
+			cfg1 := DefaultConfig()
+			cfg1.DataDir = t.TempDir()
+			cfg1.Listen = tc.listen
+			cfg1.EnableQUICTransport = tc.enableQUIC
+			h1, err := New(context.Background(), logtest.New(t), cfg1, []byte("foobar"))
+			require.NoError(t, err)
+			t.Cleanup(func() { h1.Stop() })
+
+			cfg2 := DefaultConfig()
+			cfg2.DataDir = t.TempDir()
+			cfg2.Listen = tc.listen
+			cfg2.EnableQUICTransport = tc.enableQUIC
+			cfg2.PingPeers = []string{h1.ID().String()}
+			h2, err := New(context.Background(), logtest.New(t), cfg2, []byte("foobar"))
+			require.NoError(t, err)
+			t.Cleanup(func() { h2.Stop() })
+
+			err = h2.Connect(context.Background(), peer.AddrInfo{
+				ID:    h1.ID(),
+				Addrs: h1.Addrs(),
+			})
+			require.NoError(t, err)
+
+			h2.Ping().Start()
+			t.Cleanup(h2.Ping().Stop)
+
+			require.Eventually(t, func() bool {
+				numSuccess, numFail := h2.Ping().Stats(h1.ID())
+				t.Logf("ping stats: success %d fail %d", numSuccess, numFail)
+				return numSuccess > 1
+			}, 10*time.Second, 100*time.Millisecond, "waiting for ping to succeed")
+		})
+	}
+}

--- a/p2p/ping_test.go
+++ b/p2p/ping_test.go
@@ -37,7 +37,8 @@ func TestPing(t *testing.T) {
 			cfg1.DataDir = t.TempDir()
 			cfg1.Listen = tc.listen
 			cfg1.EnableQUICTransport = tc.enableQUIC
-			h1, err := New(context.Background(), logtest.New(t), cfg1, []byte("foobar"))
+			nc := []byte("foobar")
+			h1, err := New(context.Background(), logtest.New(t), cfg1, nc, nc)
 			require.NoError(t, err)
 			t.Cleanup(func() { h1.Stop() })
 
@@ -46,7 +47,7 @@ func TestPing(t *testing.T) {
 			cfg2.Listen = tc.listen
 			cfg2.EnableQUICTransport = tc.enableQUIC
 			cfg2.PingPeers = []string{h1.ID().String()}
-			h2, err := New(context.Background(), logtest.New(t), cfg2, []byte("foobar"))
+			h2, err := New(context.Background(), logtest.New(t), cfg2, nc, nc)
 			require.NoError(t, err)
 			t.Cleanup(func() { h2.Stop() })
 

--- a/p2p/ping_test.go
+++ b/p2p/ping_test.go
@@ -14,18 +14,18 @@ import (
 func TestPing(t *testing.T) {
 	type testcase struct {
 		desc       string
-		listen     string
+		listen     AddressList
 		enableQUIC bool
 	}
 
 	testcases := []testcase{
 		{
 			desc:   "tcp",
-			listen: "/ip4/127.0.0.1/tcp/0",
+			listen: MustParseAddresses("/ip4/127.0.0.1/tcp/0"),
 		},
 		{
 			desc:       "quic",
-			listen:     "/ip4/0.0.0.0/udp/0/quic-v1",
+			listen:     MustParseAddresses("/ip4/0.0.0.0/udp/0/quic-v1"),
 			enableQUIC: true,
 		},
 	}

--- a/p2p/ping_test.go
+++ b/p2p/ping_test.go
@@ -39,6 +39,7 @@ func TestPing(t *testing.T) {
 			nc := []byte("foobar")
 			h1, err := New(context.Background(), logtest.New(t), cfg1, nc, nc)
 			require.NoError(t, err)
+			h1.discovery.Start(context.Background())
 			t.Cleanup(func() { h1.Stop() })
 
 			cfg2 := DefaultConfig()
@@ -48,6 +49,7 @@ func TestPing(t *testing.T) {
 			cfg2.PingPeers = []string{h1.ID().String()}
 			h2, err := New(context.Background(), logtest.New(t), cfg2, nc, nc)
 			require.NoError(t, err)
+			h2.discovery.Start(context.Background())
 			t.Cleanup(func() { h2.Stop() })
 
 			err = h2.Connect(context.Background(), peer.AddrInfo{
@@ -56,7 +58,7 @@ func TestPing(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			h2.Ping().Start()
+			h2.Ping().Start(context.Background())
 			t.Cleanup(h2.Ping().Stop)
 
 			require.Eventually(t, func() bool {

--- a/p2p/upgrade.go
+++ b/p2p/upgrade.go
@@ -157,6 +157,7 @@ func Upgrade(h host.Host, opts ...Opt) (*Host, error) {
 		discovery.WithDir(cfg.DataDir),
 		discovery.WithBootnodes(bootnodes),
 		discovery.WithLogger(fh.logger.Zap()),
+		discovery.WithAdvertiseInterval(fh.cfg.AdvertiseInterval),
 	}
 	if cfg.PrivateNetwork {
 		dopts = append(dopts, discovery.Private())

--- a/p2p/upgrade.go
+++ b/p2p/upgrade.go
@@ -4,14 +4,18 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"sync"
 	"time"
 
 	lp2plog "github.com/ipfs/go-log/v2"
+	"github.com/libp2p/go-libp2p/core/event"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/protocol"
+	"github.com/libp2p/go-libp2p/p2p/host/eventbus"
+	ma "github.com/multiformats/go-multiaddr"
 	"go.uber.org/zap/zapcore"
 	"golang.org/x/sync/errgroup"
 
@@ -86,6 +90,18 @@ type Host struct {
 
 	discovery        *discovery.Discovery
 	direct, bootnode map[peer.ID]struct{}
+
+	natTypeSub event.Subscription
+	natType    struct {
+		sync.Mutex
+		udpNATType network.NATDeviceType
+		tcpNATType network.NATDeviceType
+	}
+	reachSub     event.Subscription
+	reachability struct {
+		sync.Mutex
+		value network.Reachability
+	}
 
 	ping *Ping
 }
@@ -179,6 +195,31 @@ func Upgrade(h host.Host, opts ...Opt) (*Host, error) {
 			},
 		})
 	}
+
+	var peers []peer.ID
+	for _, p := range cfg.PingPeers {
+		peerID, err := peer.Decode(p)
+		if err != nil {
+			fh.logger.With().Warning("ignoring invalid ping peer", log.Err(err))
+			continue
+		}
+		peers = append(peers, peerID)
+	}
+	if len(peers) != 0 {
+		fh.ping = NewPing(fh.logger, fh, peers, fh.discovery.DHT())
+	}
+
+	fh.natTypeSub, err = fh.EventBus().Subscribe(new(event.EvtNATDeviceTypeChanged),
+		eventbus.Name("nat type changed (Host)"))
+	if err != nil {
+		return nil, fmt.Errorf("failed to subscribe to reachability NAT type event: %s", err)
+	}
+	fh.reachSub, err = fh.EventBus().Subscribe(new(event.EvtLocalReachabilityChanged),
+		eventbus.Name("reachability changed (Host)"))
+	if err != nil {
+		return nil, fmt.Errorf("failed to subscribe to reachability NAT type event: %s", err)
+	}
+
 	return fh, nil
 }
 
@@ -224,6 +265,36 @@ func (fh *Host) ConnectedPeerInfo(id peer.ID) *PeerInfo {
 	}
 }
 
+// ListenAddresses returns the addresses on which this host listens.
+func (fh *Host) ListenAddresses() []ma.Multiaddr {
+	return fh.Network().ListenAddresses()
+}
+
+// KnownAddresses returns the addresses by which the peers know this one.
+func (fh *Host) KnownAddresses() []ma.Multiaddr {
+	return fh.Network().Peerstore().Addrs(fh.ID())
+}
+
+// NATDeviceType returns NATDeviceType returns the NAT device types for
+// UDP and TCP so far for this host.
+func (fh *Host) NATDeviceType() (udpNATType, tcpNATType network.NATDeviceType) {
+	fh.natType.Lock()
+	defer fh.natType.Unlock()
+	return fh.natType.udpNATType, fh.natType.tcpNATType
+}
+
+// Reachability returns reachability of the host (public, private, unknown).
+func (fh *Host) Reachability() network.Reachability {
+	fh.reachability.Lock()
+	defer fh.reachability.Unlock()
+	return fh.reachability.value
+}
+
+// DHTServerEnabled returns true if the server has DHT running in server mode.
+func (fh *Host) DHTServerEnabled() bool {
+	return slices.Contains(fh.Mux().Protocols(), discovery.ProtocolID)
+}
+
 // PeerCount returns number of connected peers.
 func (fh *Host) PeerCount() uint64 {
 	return uint64(len(fh.Host.Network().Peers()))
@@ -256,6 +327,7 @@ func (fh *Host) Start() error {
 			return nil
 		})
 	}
+	fh.eg.Go(fh.trackNetEvents)
 	return nil
 }
 
@@ -269,10 +341,49 @@ func (fh *Host) Stop() error {
 	fh.cancel()
 	fh.closed.closed = true
 	fh.discovery.Stop()
+	fh.reachSub.Close()
+	fh.natTypeSub.Close()
 	fh.eg.Wait()
 	if err := fh.Host.Close(); err != nil {
 		return fmt.Errorf("failed to close libp2p host: %w", err)
 	}
 	lp2plog.SetPrimaryCore(zapcore.NewNopCore())
 	return nil
+}
+
+func (fh *Host) trackNetEvents() error {
+	natEvCh := fh.natTypeSub.Out()
+	reachEvCh := fh.reachSub.Out()
+	for {
+		select {
+		case ev, ok := <-natEvCh:
+			if !ok {
+				return nil
+			}
+			natEv := ev.(event.EvtNATDeviceTypeChanged)
+			fh.logger.With().Info("NAT type changed",
+				log.Stringer("transportProtocol", natEv.TransportProtocol),
+				log.Stringer("type", natEv.NatDeviceType))
+			fh.natType.Lock()
+			switch natEv.TransportProtocol {
+			case network.NATTransportUDP:
+				fh.natType.udpNATType = natEv.NatDeviceType
+			case network.NATTransportTCP:
+				fh.natType.tcpNATType = natEv.NatDeviceType
+			}
+			fh.natType.Unlock()
+		case ev, ok := <-reachEvCh:
+			if !ok {
+				return nil
+			}
+			reachEv := ev.(event.EvtLocalReachabilityChanged)
+			fh.logger.With().Info("local reachability changed",
+				log.Stringer("reachability", reachEv.Reachability))
+			fh.reachability.Lock()
+			fh.reachability.value = reachEv.Reachability
+			fh.reachability.Unlock()
+		case <-fh.ctx.Done():
+			return fh.ctx.Err()
+		}
+	}
 }

--- a/p2p/upgrade.go
+++ b/p2p/upgrade.go
@@ -211,7 +211,7 @@ func Upgrade(h host.Host, opts ...Opt) (*Host, error) {
 		peers = append(peers, peerID)
 	}
 	if len(peers) != 0 {
-		fh.ping = NewPing(fh.logger, fh, peers, fh.discovery)
+		fh.ping = NewPing(fh.logger.Zap(), fh, peers, fh.discovery)
 	}
 
 	fh.natTypeSub, err = fh.EventBus().Subscribe(new(event.EvtNATDeviceTypeChanged),
@@ -363,7 +363,7 @@ func (fh *Host) Start() error {
 	}
 	fh.discovery.Start(fh.ctx)
 	if fh.ping != nil {
-		fh.ping.Start()
+		fh.ping.Start(fh.ctx)
 	}
 	if !fh.cfg.Bootnode {
 		fh.eg.Go(func() error {

--- a/p2p/upgrade.go
+++ b/p2p/upgrade.go
@@ -182,7 +182,7 @@ func Upgrade(h host.Host, opts ...Opt) (*Host, error) {
 	if fh.cfg.EnableRoutingDiscovery {
 		dopts = append(dopts, discovery.EnableRoutingDiscovery())
 	}
-	if !fh.cfg.RoutingDiscoveryNoAdvertise {
+	if fh.cfg.RoutingDiscoveryAdvertise {
 		dopts = append(dopts, discovery.AdvertiseForPeerDiscovery())
 	}
 

--- a/p2p/upgrade.go
+++ b/p2p/upgrade.go
@@ -361,9 +361,9 @@ func (fh *Host) Start() error {
 	if fh.closed.closed {
 		return errors.New("p2p: closed")
 	}
-	fh.discovery.Start(fh.ctx)
+	fh.discovery.Start()
 	if fh.ping != nil {
-		fh.ping.Start(fh.ctx)
+		fh.ping.Start()
 	}
 	if !fh.cfg.Bootnode {
 		fh.eg.Go(func() error {

--- a/p2p/upgrade.go
+++ b/p2p/upgrade.go
@@ -138,7 +138,7 @@ func Upgrade(h host.Host, opts ...Opt) (*Host, error) {
 	if cfg.DisableDHT {
 		dopts = append(dopts, discovery.DisableDHT())
 	}
-	if cfg.Bootnode {
+	if cfg.Bootnode || cfg.ForceDHTServer {
 		dopts = append(dopts, discovery.Server())
 	} else {
 		backup, err := loadPeers(cfg.DataDir)

--- a/p2p/upgrade.go
+++ b/p2p/upgrade.go
@@ -112,6 +112,7 @@ func Upgrade(h host.Host, opts ...Opt) (*Host, error) {
 	}
 	for _, peer := range direct {
 		h.ConnManager().Protect(peer.ID, "direct")
+		// TBD: also protect ping
 	}
 	if fh.PubSub, err = pubsub.New(fh.ctx, fh.logger, h, pubsub.Config{
 		Flood:          cfg.Flood,
@@ -146,6 +147,18 @@ func Upgrade(h host.Host, opts ...Opt) (*Host, error) {
 		} else if len(backup) > 0 {
 			dopts = append(dopts, discovery.WithBackup(backup))
 		}
+	}
+	if len(cfg.PingPeers) != 0 {
+		var peers []peer.ID
+		for _, p := range cfg.PingPeers {
+			peerID, err := peer.Decode(p)
+			if err != nil {
+				fh.logger.With().Warning("ignoring invalid ping peer", log.Err(err))
+				continue
+			}
+			peers = append(peers, peerID)
+		}
+		dopts = append(dopts, discovery.WithPingPeers(peers))
 	}
 	dhtdisc, err := discovery.New(fh, dopts...)
 	if err != nil {

--- a/p2p/upgrade.go
+++ b/p2p/upgrade.go
@@ -212,7 +212,7 @@ func Upgrade(h host.Host, opts ...Opt) (*Host, error) {
 		peers = append(peers, peerID)
 	}
 	if len(peers) != 0 {
-		fh.ping = NewPing(fh.logger.Zap(), fh, peers, fh.discovery)
+		fh.ping = NewPing(fh.logger.Zap(), fh, peers, fh.discovery, WithPingInterval(fh.cfg.PingInterval))
 	}
 
 	fh.natTypeSub, err = fh.EventBus().Subscribe(new(event.EvtNATDeviceTypeChanged),

--- a/p2p/upgrade.go
+++ b/p2p/upgrade.go
@@ -309,18 +309,20 @@ func (fh *Host) NeedPeerDiscovery() bool {
 	}
 
 	// Check if we have Cone NAT for either TCP or UDP. If so,
-	// hole punching should work for other NATed nodes
+	// hole punching should work for other NATed nodes. Also, in
+	// case of an unknown NAT type, assume there's chance at hole
+	// punching
 	udpNATType, tcpNATType := fh.NATDeviceType()
-	if fh.cfg.EnableQUICTransport && udpNATType == network.NATDeviceTypeCone {
+	if fh.cfg.EnableQUICTransport && udpNATType != network.NATDeviceTypeSymmetric {
 		return true
 	}
-	if fh.cfg.EnableTCPTransport && tcpNATType == network.NATDeviceTypeCone {
+	if fh.cfg.EnableTCPTransport && tcpNATType != network.NATDeviceTypeSymmetric {
 		return true
 	}
 
-	// Symmetric / unknown NAT, hole punching will not work so
-	// we're not looking for NATed peers. Will only connect to the
-	// nodes with DHT Server mode
+	// Symmetric NAT for both TCP and UDP, hole punching will not
+	// work so we're not looking for NATed peers. Will only
+	// connect to the nodes with DHT Server mode
 	return false
 }
 


### PR DESCRIPTION
## Motivation

This PR implements changes needed for spacemeshos/pm#275, except for measurement

## Changes
* Introduce Routing Discovery to contact peers behind NATs
* Introduce dynamic v2 relay discovery which is needed for hole punching. The idea is to have a wider array of circuit-v2 passive relays which should be much safer than old libp2p active relays (which were disabled in e.g. Filecoin due to security concerns)
* Introduce QUIC transport to improve chances at hole punching, with testnet-mainnet "crosstalk" protection based on a transport-level handshake mechanism
  * the handshake is not used on mainnet. That way, connections between mainnet and testnet nodes are still prevented, as testnet peers expect the handshake, but if/when my libp2p changes are merged (libp2p/go-libp2p#2658) or libp2p gets private network support
* Make it possible to listen on multiple addresses and advertise multiple addresses
* Extend DebugService with additional P2P info needed for hole punching diagnostics (needs spacemeshos/api#285)
* Add `ping-peers` config option to facilitate P2P network issue diagnostics
* Add `force-dht-server` config option that is useful during troubleshooting DHT and hole-punching issues

`ping-peers` and `force-dht-server` were initially considered to be temporary features, but I think it might make sense to keep them for various P2P network troubleshooting scenarios.

All of the changes are disabled in the config by default, except for:
* libp2p Ping service is enabled by default to make diagnostics easier
* DHT Values and Providers as these will make DHT Routing Peer discovery work efficiently from the beginning when we enable this feature in the configs
* Bootnodes aren't used as relays by default anymore. v2 relays have very limited capacity by default and bootnode relay servers' reservations are very quickly exhausted. Need to either specify a static relay list or enable routing discovery, which searches for more available relays as needed

## Test Plan
* Tested using k8s several clusters with cone NATs enabled via `bridge` CNI plugin (via Multus) -- backported to v1.2.8
* Added a Mac node for testing

## TODO
- [x] Have spacemeshos/api#285 merged and updated to the new `api` release
- [x] Retest using an image based on this branch (not backport)
- [ ] Decide on whether/how to extend systests to include NAT testing
- [ ] To check: TCP holepunching tends to happen more than QUIC (might be related to the handshake mechanism)
- [ ] ~~To consider: try picking up some % (e.g.: 50%) of non-infra peers during routing discovery~~ (doesn't work too well, need something more involved for that)

Maybe as a follow-up (depending on how soon this gets reviewed):
- Include new metrics / check if they're already present
  - NAT type (UDP / TCP) - Cone / Symmetric / Unknown
  - Reachability - Public / Private / Unknown
  - N of "advertised" peers found via routing discovery
  - N of TCP and UDP (QUIC) peers
  - N of peers reached via relayed connections (these being present for a long time may indicate hole-punching troubles, usually relayed connections go away relatively quickly)
  - N of relay reservations this node managed to obtain
  - Whether routing discovery is active or suspended (e.g. b/c `low-peers` N of peers has been reached)
  - Whether DHT is in the `Server` or `Client` mode
- systests checking NATed connections