### PR TITLE
[Merged by Bors] - Increase default timeouts

### DIFF
--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -125,7 +125,7 @@ func DefaultConfig() Config {
 		BatchTimeout:         50 * time.Millisecond,
 		QueueSize:            20,
 		BatchSize:            20,
-		RequestTimeout:       10 * time.Second,
+		RequestTimeout:       20 * time.Second,
 		MaxRetriesForRequest: 100,
 		ServersConfig: map[string]ServerConfig{
 			// serves 1 MB of data

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -125,7 +125,7 @@ func DefaultConfig() Config {
 		BatchTimeout:         50 * time.Millisecond,
 		QueueSize:            20,
 		BatchSize:            20,
-		RequestTimeout:       20 * time.Second,
+		RequestTimeout:       25 * time.Second,
 		MaxRetriesForRequest: 100,
 		ServersConfig: map[string]ServerConfig{
 			// serves 1 MB of data

--- a/p2p/host.go
+++ b/p2p/host.go
@@ -165,6 +165,7 @@ func New(
 		return nil, fmt.Errorf("p2p create conn mgr: %w", err)
 	}
 	streamer := *yamux.DefaultTransport
+	streamer.Config().ConnectionWriteTimeout = 20 * time.Second // should be NOT exposed in the config
 	ps, err := pstoremem.NewPeerstore()
 	if err != nil {
 		return nil, fmt.Errorf("can't create peer store: %w", err)

--- a/p2p/host.go
+++ b/p2p/host.go
@@ -165,7 +165,7 @@ func New(
 		return nil, fmt.Errorf("p2p create conn mgr: %w", err)
 	}
 	streamer := *yamux.DefaultTransport
-	streamer.Config().ConnectionWriteTimeout = 20 * time.Second // should be NOT exposed in the config
+	streamer.Config().ConnectionWriteTimeout = 25 * time.Second // should be NOT exposed in the config
 	ps, err := pstoremem.NewPeerstore()
 	if err != nil {
 		return nil, fmt.Errorf("can't create peer store: %w", err)

--- a/p2p/server/server.go
+++ b/p2p/server/server.go
@@ -120,7 +120,7 @@ func New(h Host, proto string, handler Handler, opts ...Opt) *Server {
 		protocol:            proto,
 		handler:             handler,
 		h:                   h,
-		timeout:             20 * time.Second,
+		timeout:             25 * time.Second,
 		requestLimit:        10240,
 		queueSize:           1000,
 		requestsPerInterval: 100,

--- a/p2p/server/server.go
+++ b/p2p/server/server.go
@@ -120,7 +120,7 @@ func New(h Host, proto string, handler Handler, opts ...Opt) *Server {
 		protocol:            proto,
 		handler:             handler,
 		h:                   h,
-		timeout:             10 * time.Second,
+		timeout:             20 * time.Second,
 		requestLimit:        10240,
 		queueSize:           1000,
 		requestsPerInterval: 100,


### PR DESCRIPTION
We're seeing a lot of `I/O deadline` and general timeouts currently in the network. Increasing the timeouts to 25s from standard 10s could help with some of them.
