### PR TITLE
[Merged by Bors] - Prepare network for more nodes

### DIFF
--- a/datastore/store.go
+++ b/datastore/store.go
@@ -44,13 +44,15 @@ type CachedDB struct {
 }
 
 type Config struct {
+	// ATXSize must be larger than the sum of all ATXs in last 2 epochs to be effective
+	// (Epoch 12: ~ 300k, Epoch 11: ~ 200k)
 	ATXSize         int `mapstructure:"atx-size"`
 	MalfeasenceSize int `mapstructure:"malfeasence-size"`
 }
 
 func DefaultConfig() Config {
 	return Config{
-		ATXSize:         300_000,
+		ATXSize:         600_000,
 		MalfeasenceSize: 1_000,
 	}
 }

--- a/fetch/wire_types.go
+++ b/fetch/wire_types.go
@@ -22,7 +22,7 @@ type RequestMessage struct {
 // ResponseMessage is sent to the node as a response.
 type ResponseMessage struct {
 	Hash types.Hash32
-	Data []byte `scale:"max=10485760"` // limit to 10MiB
+	Data []byte `scale:"max=20971520"` // limit to 20 MiB
 }
 
 // RequestBatch is a batch of requests and a hash of all requests as ID.
@@ -105,7 +105,7 @@ type MaliciousIDs struct {
 }
 
 type EpochData struct {
-	AtxIDs []types.ATXID `scale:"max=200000"` // max. expected number of ATXs per epoch is 100_000
+	AtxIDs []types.ATXID `scale:"max=500000"` // for epoch 12 > 300k ATXs are expected, added some safety margin
 }
 
 // LayerData is the data response for a given layer ID.

--- a/fetch/wire_types_scale.go
+++ b/fetch/wire_types_scale.go
@@ -55,7 +55,7 @@ func (t *ResponseMessage) EncodeScale(enc *scale.Encoder) (total int, err error)
 		total += n
 	}
 	{
-		n, err := scale.EncodeByteSliceWithLimit(enc, t.Data, 10485760)
+		n, err := scale.EncodeByteSliceWithLimit(enc, t.Data, 20971520)
 		if err != nil {
 			return total, err
 		}
@@ -73,7 +73,7 @@ func (t *ResponseMessage) DecodeScale(dec *scale.Decoder) (total int, err error)
 		total += n
 	}
 	{
-		field, n, err := scale.DecodeByteSliceWithLimit(dec, 10485760)
+		field, n, err := scale.DecodeByteSliceWithLimit(dec, 20971520)
 		if err != nil {
 			return total, err
 		}
@@ -258,7 +258,7 @@ func (t *MaliciousIDs) DecodeScale(dec *scale.Decoder) (total int, err error) {
 
 func (t *EpochData) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	{
-		n, err := scale.EncodeStructSliceWithLimit(enc, t.AtxIDs, 200000)
+		n, err := scale.EncodeStructSliceWithLimit(enc, t.AtxIDs, 500000)
 		if err != nil {
 			return total, err
 		}
@@ -269,7 +269,7 @@ func (t *EpochData) EncodeScale(enc *scale.Encoder) (total int, err error) {
 
 func (t *EpochData) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	{
-		field, n, err := scale.DecodeStructSliceWithLimit[types.ATXID](dec, 200000)
+		field, n, err := scale.DecodeStructSliceWithLimit[types.ATXID](dec, 500000)
 		if err != nil {
 			return total, err
 		}

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,6 @@ require (
 	github.com/libp2p/go-libp2p-record v0.2.0
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/multiformats/go-multiaddr v0.12.0
-	github.com/multiformats/go-varint v0.0.7
 	github.com/natefinch/atomic v1.0.1
 	github.com/oasisprotocol/curve25519-voi v0.0.0-20230904125328-1f23a7beb09a
 	github.com/prometheus/client_golang v1.17.0
@@ -164,6 +163,7 @@ require (
 	github.com/multiformats/go-multicodec v0.9.0 // indirect
 	github.com/multiformats/go-multihash v0.2.3 // indirect
 	github.com/multiformats/go-multistream v0.5.0 // indirect
+	github.com/multiformats/go-varint v0.0.7 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/nullstyle/go-xdr v0.0.0-20180726165426-f4c839f75077 // indirect
 	github.com/nxadm/tail v1.4.8 // indirect

--- a/node/bad_peer_test.go
+++ b/node/bad_peer_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/protocol"
-	varint "github.com/multiformats/go-varint"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 
@@ -143,15 +142,17 @@ func rpcWithMessages(msgs ...*pubsubpb.Message) *pubsub.RPC {
 
 func writeRpc(rpc *pubsub.RPC, s network.Stream) error {
 	size := uint64(rpc.Size())
-
-	buf := make([]byte, varint.UvarintSize(size)+int(size))
-
-	n := binary.PutUvarint(buf, size)
-	_, err := rpc.MarshalTo(buf[n:])
-	if err != nil {
+	sizeBuf := make([]byte, binary.MaxVarintLen64)
+	n := binary.PutUvarint(sizeBuf, size)
+	sizeBuf = sizeBuf[:n]
+	if _, err := s.Write(sizeBuf); err != nil {
 		return err
 	}
 
-	_, err = s.Write(buf)
+	buf := make([]byte, size)
+	if _, err := rpc.MarshalTo(buf); err != nil {
+		return err
+	}
+	_, err := s.Write(buf)
 	return err
 }

--- a/p2p/server/server.go
+++ b/p2p/server/server.go
@@ -12,7 +12,6 @@ import (
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/protocol"
-	"github.com/multiformats/go-varint"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/time/rate"
 
@@ -188,7 +187,7 @@ func (s *Server) queueHandler(ctx context.Context, stream network.Stream) {
 	_ = stream.SetDeadline(time.Now().Add(s.timeout))
 	defer stream.SetDeadline(time.Time{})
 	rd := bufio.NewReader(stream)
-	size, err := varint.ReadUvarint(rd)
+	size, err := binary.ReadUvarint(rd)
 	if err != nil {
 		return
 	}

--- a/p2p/server/server.go
+++ b/p2p/server/server.go
@@ -84,7 +84,7 @@ type Handler func(context.Context, []byte) ([]byte, error)
 
 // Response is a server response.
 type Response struct {
-	Data  []byte `scale:"max=10485760"` // 10 MiB
+	Data  []byte `scale:"max=20971520"` // 20 MiB
 	Error string `scale:"max=1024"`     // TODO(mafa): make error code instead of string
 }
 

--- a/p2p/server/server_scale.go
+++ b/p2p/server/server_scale.go
@@ -9,7 +9,7 @@ import (
 
 func (t *Response) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	{
-		n, err := scale.EncodeByteSliceWithLimit(enc, t.Data, 10485760)
+		n, err := scale.EncodeByteSliceWithLimit(enc, t.Data, 20971520)
 		if err != nil {
 			return total, err
 		}
@@ -27,7 +27,7 @@ func (t *Response) EncodeScale(enc *scale.Encoder) (total int, err error) {
 
 func (t *Response) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	{
-		field, n, err := scale.DecodeByteSliceWithLimit(dec, 10485760)
+		field, n, err := scale.DecodeByteSliceWithLimit(dec, 20971520)
 		if err != nil {
 			return total, err
 		}


### PR DESCRIPTION
## Motivation
This is in anticipation for upcoming epochs, so that nodes can handle 300k+ active identities.

## Changes
- Increase sizes for various wire types
- Increase ATXHeader Cache to be able to hold the ATXs for Epoch 11 and Epoch 12 at the same time

## Test Plan
n/a

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
