### PR TITLE
[Merged by Bors] - Revert part of #5339

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/libp2p/go-libp2p-record v0.2.0
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/multiformats/go-multiaddr v0.12.0
+	github.com/multiformats/go-varint v0.0.7
 	github.com/natefinch/atomic v1.0.1
 	github.com/oasisprotocol/curve25519-voi v0.0.0-20230904125328-1f23a7beb09a
 	github.com/prometheus/client_golang v1.17.0
@@ -163,7 +164,6 @@ require (
 	github.com/multiformats/go-multicodec v0.9.0 // indirect
 	github.com/multiformats/go-multihash v0.2.3 // indirect
 	github.com/multiformats/go-multistream v0.5.0 // indirect
-	github.com/multiformats/go-varint v0.0.7 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/nullstyle/go-xdr v0.0.0-20180726165426-f4c839f75077 // indirect
 	github.com/nxadm/tail v1.4.8 // indirect

--- a/p2p/server/server.go
+++ b/p2p/server/server.go
@@ -12,6 +12,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/protocol"
+	"github.com/multiformats/go-varint"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/time/rate"
 
@@ -187,7 +188,7 @@ func (s *Server) queueHandler(ctx context.Context, stream network.Stream) {
 	_ = stream.SetDeadline(time.Now().Add(s.timeout))
 	defer stream.SetDeadline(time.Time{})
 	rd := bufio.NewReader(stream)
-	size, err := binary.ReadUvarint(rd)
+	size, err := varint.ReadUvarint(rd)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
## Motivation
Reverts part of #5339

## Changes
`PutUvarint` from standard library and `github.com/multiformats/go-varint` do not behave exactly the same. With Go 1.20 to the stdlib implementation was fixed to detect short reads, but in contrast to `github.com/multiformats/go-varint` it will still not return an error when decoding non-minimal encodings of integers.

## Test Plan
n/a

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
