### PR TITLE
[Merged by Bors] - Increase p2p response data size to 40MiB

### DIFF
--- a/p2p/server/server.go
+++ b/p2p/server/server.go
@@ -84,7 +84,7 @@ type Handler func(context.Context, []byte) ([]byte, error)
 
 // Response is a server response.
 type Response struct {
-	Data  []byte `scale:"max=20971520"` // 20 MiB
+	Data  []byte `scale:"max=41943040"` // 40 MiB
 	Error string `scale:"max=1024"`     // TODO(mafa): make error code instead of string
 }
 
@@ -220,7 +220,12 @@ func (s *Server) queueHandler(ctx context.Context, stream network.Stream) {
 
 	wr := bufio.NewWriter(stream)
 	if _, err := codec.EncodeTo(wr, &resp); err != nil {
-		s.logger.With().Warning("failed to write response", log.Err(err))
+		s.logger.With().Warning(
+			"failed to write response",
+			log.Int("resp.Data len", len(resp.Data)),
+			log.Int("resp.Error len", len(resp.Error)),
+			log.Err(err),
+		)
 		return
 	}
 	if err := wr.Flush(); err != nil {

--- a/p2p/server/server_scale.go
+++ b/p2p/server/server_scale.go
@@ -9,7 +9,7 @@ import (
 
 func (t *Response) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	{
-		n, err := scale.EncodeByteSliceWithLimit(enc, t.Data, 20971520)
+		n, err := scale.EncodeByteSliceWithLimit(enc, t.Data, 41943040)
 		if err != nil {
 			return total, err
 		}
@@ -27,7 +27,7 @@ func (t *Response) EncodeScale(enc *scale.Encoder) (total int, err error) {
 
 func (t *Response) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	{
-		field, n, err := scale.DecodeByteSliceWithLimit(dec, 20971520)
+		field, n, err := scale.DecodeByteSliceWithLimit(dec, 41943040)
 		if err != nil {
 			return total, err
 		}


### PR DESCRIPTION
## Motivation
Increase p2p response data size to 40MiB.

Also added log to show the actual data size in case of encoding failure.