### PR TITLE
[Merged by Bors] - Add no-main-override config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,9 @@ for more information on how to configure the node to work with the PoST service.
   section. The non-conditional changes include values/provides support on all of the nodes, which will enable DHT to
   function efficiently for routing discovery.
 
+* [#5367](https://github.com/spacemeshos/go-spacemesh/pull/5367) Add `no-main-override` toplevel config option and
+  `--no-main-override` CLI option that makes it possible to run "nomain" builds on mainnet.
+
 ## Release v1.2.9
 
 ### Improvements

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -82,6 +82,9 @@ func AddCommands(cmd *cobra.Command) {
 	cmd.PersistentFlags().DurationVar(&cfg.DatabasePruneInterval, "db-prune-interval",
 		cfg.DatabasePruneInterval, "configure interval for database pruning")
 
+	cmd.PersistentFlags().BoolVar(&cfg.NoMainOverride, "no-main-override",
+		cfg.NoMainOverride, "force 'nomain' builds to run on the mainnet")
+
 	/** ======================== P2P Flags ========================== **/
 
 	cmd.PersistentFlags().Var(flags.NewAddressListValue(cfg.P2P.Listen, &cfg.P2P.Listen),

--- a/config/config.go
+++ b/config/config.go
@@ -128,6 +128,9 @@ type BaseConfig struct {
 	// ATXGradeDelay is used to grade ATXs for selection in tortoise active set.
 	// See grading fuction in miner/proposals_builder.go
 	ATXGradeDelay time.Duration `mapstructure:"atx-grade-delay"`
+
+	// NoMainOverride forces the "nomain" builds to run on the mainnet
+	NoMainOverride bool `mapstructure:"no-main-override"`
 }
 
 type PublicMetrics struct {

--- a/node/node.go
+++ b/node/node.go
@@ -133,7 +133,7 @@ func GetCommand() *cobra.Command {
 				log.JSONLog(true)
 			}
 
-			if cmd.NoMainNet && onMainNet(conf) {
+			if cmd.NoMainNet && onMainNet(conf) && !conf.NoMainOverride {
 				log.With().Fatal("this is a testnet-only build not intended for mainnet")
 			}
 


### PR DESCRIPTION
This makes it possible to force "nomain" builds to run on mainnet.

## Motivation

Sometimes it is necessary to try a "nomain" build with mainnet.

## Changes

This adds `no-main-override` toplevel config option (bool) and also `--no-main-override` command line flag.
