### PR TITLE
Autoscale post verifying workers (#5354)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 See [RELEASE](./RELEASE.md) for workflow instructions.
 
+## Release v1.2.12
+
+### Improvements
+
+* [#5373](https://github.com/spacemeshos/go-spacemesh/pull/5373) automatic scaling of post verifying workers to a lower value (1 by default) when POST proving starts.
+  The workers are scaled up when POST proving finishes.
+
 ## Release v1.2.11
 
 ### Improvements

--- a/activation/interface.go
+++ b/activation/interface.go
@@ -22,6 +22,11 @@ type PostVerifier interface {
 	io.Closer
 	Verify(ctx context.Context, p *shared.Proof, m *shared.ProofMetadata, opts ...verifying.OptionFunc) error
 }
+
+type scaler interface {
+	scale(int)
+}
+
 type nipostValidator interface {
 	InitialNIPostChallenge(challenge *types.NIPostChallenge, atxs atxProvider, goldenATXID types.ATXID) error
 	NIPostChallenge(challenge *types.NIPostChallenge, atxs atxProvider, nodeID types.NodeID) error

--- a/activation/metrics/metrics.go
+++ b/activation/metrics/metrics.go
@@ -24,6 +24,13 @@ var PoetPowDuration = metrics.NewGauge(
 	[]string{},
 ).WithLabelValues()
 
+var PostVerificationQueue = metrics.NewGauge(
+	"post_verification_waiting_total",
+	namespace,
+	"the number of POSTs waiting to be verified",
+	[]string{},
+).WithLabelValues()
+
 var (
 	publishWindowLatency = metrics.NewHistogramWithBuckets(
 		"publish_window_seconds",

--- a/activation/mocks.go
+++ b/activation/mocks.go
@@ -183,6 +183,65 @@ func (c *PostVerifierVerifyCall) DoAndReturn(f func(context.Context, *shared.Pro
 	return c
 }
 
+// Mockscaler is a mock of scaler interface.
+type Mockscaler struct {
+	ctrl     *gomock.Controller
+	recorder *MockscalerMockRecorder
+}
+
+// MockscalerMockRecorder is the mock recorder for Mockscaler.
+type MockscalerMockRecorder struct {
+	mock *Mockscaler
+}
+
+// NewMockscaler creates a new mock instance.
+func NewMockscaler(ctrl *gomock.Controller) *Mockscaler {
+	mock := &Mockscaler{ctrl: ctrl}
+	mock.recorder = &MockscalerMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *Mockscaler) EXPECT() *MockscalerMockRecorder {
+	return m.recorder
+}
+
+// scale mocks base method.
+func (m *Mockscaler) scale(arg0 int) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "scale", arg0)
+}
+
+// scale indicates an expected call of scale.
+func (mr *MockscalerMockRecorder) scale(arg0 any) *scalerscaleCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "scale", reflect.TypeOf((*Mockscaler)(nil).scale), arg0)
+	return &scalerscaleCall{Call: call}
+}
+
+// scalerscaleCall wrap *gomock.Call
+type scalerscaleCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *scalerscaleCall) Return() *scalerscaleCall {
+	c.Call = c.Call.Return()
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *scalerscaleCall) Do(f func(int)) *scalerscaleCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *scalerscaleCall) DoAndReturn(f func(int)) *scalerscaleCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // MocknipostValidator is a mock of nipostValidator interface.
 type MocknipostValidator struct {
 	ctrl     *gomock.Controller

--- a/activation/nipost_test.go
+++ b/activation/nipost_test.go
@@ -149,7 +149,7 @@ func TestNIPostBuilderWithClients(t *testing.T) {
 	postCfg.PowDifficulty[0] = 1
 	postProvider := newTestPostManager(t, withPostConfig(postCfg))
 	logger := logtest.New(t).WithName("validator")
-	verifier, err := NewPostVerifier(postProvider.Config(), logger)
+	verifier, err := NewPostVerifier(postProvider.Config(), zaptest.NewLogger(t))
 	require.NoError(t, err)
 	defer verifier.Close()
 
@@ -292,7 +292,7 @@ func TestNewNIPostBuilderNotInitialized(t *testing.T) {
 	r.NotNil(nipost)
 
 	logger := logtest.New(t).WithName("validator")
-	verifier, err := NewPostVerifier(postProvider.cfg, logger)
+	verifier, err := NewPostVerifier(postProvider.cfg, zaptest.NewLogger(t))
 	r.NoError(err)
 	defer verifier.Close()
 	v := NewValidator(poetDb, postProvider.cfg, postProvider.opts.Scrypt, logger, verifier)

--- a/activation/post.go
+++ b/activation/post.go
@@ -155,6 +155,9 @@ func DefaultPostProvingOpts() PostProvingOpts {
 type PostProofVerifyingOpts struct {
 	// Number of workers spawned to verify proofs.
 	Workers int `mapstructure:"smeshing-opts-verifying-workers"`
+	// The minimum number of verifying workers to keep
+	// while POST is being generated in parallel.
+	MinWorkers int `mapstructure:"smeshing-opts-verifying-min-workers"`
 	// Flags used for the PoW verification.
 	Flags config.PowFlags `mapstructure:"smeshing-opts-verifying-powflags"`
 }
@@ -165,8 +168,9 @@ func DefaultPostVerifyingOpts() PostProofVerifyingOpts {
 		workers = 1
 	}
 	return PostProofVerifyingOpts{
-		Workers: workers,
-		Flags:   config.DefaultVerifyingPowFlags(),
+		MinWorkers: 1,
+		Workers:    workers,
+		Flags:      config.DefaultVerifyingPowFlags(),
 	}
 }
 

--- a/activation/post_verifier.go
+++ b/activation/post_verifier.go
@@ -4,50 +4,97 @@ import (
 	"context"
 	"fmt"
 
+	pb "github.com/spacemeshos/api/release/go/spacemesh/v1"
 	"github.com/spacemeshos/post/config"
 	"github.com/spacemeshos/post/shared"
 	"github.com/spacemeshos/post/verifying"
+	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/spacemeshos/go-spacemesh/activation/metrics"
 	"github.com/spacemeshos/go-spacemesh/common/types"
-	"github.com/spacemeshos/go-spacemesh/log"
+	"github.com/spacemeshos/go-spacemesh/events"
 )
 
 type verifyPostJob struct {
+	ctx      context.Context // context of Verify() call
 	proof    *shared.Proof
 	metadata *shared.ProofMetadata
 	opts     []verifying.OptionFunc
 	result   chan error
 }
 
+type autoscaler struct {
+	sub *events.BufferedSubscription[events.UserEvent]
+}
+
+func newAutoscaler() (*autoscaler, error) {
+	sub, err := events.SubscribeMatched(func(t *events.UserEvent) bool {
+		switch t.Event.Details.(type) {
+		case (*pb.Event_PostStart):
+			return true
+		case (*pb.Event_PostComplete):
+			return true
+		default:
+			return false
+		}
+	}, events.WithBuffer(5))
+
+	return &autoscaler{sub: sub}, err
+}
+
+func (a autoscaler) run(stop chan struct{}, s scaler, min, target int) {
+	for {
+		select {
+		case e := <-a.sub.Out():
+			switch e.Event.Details.(type) {
+			case (*pb.Event_PostStart):
+				s.scale(min)
+			case (*pb.Event_PostComplete):
+				s.scale(target)
+			}
+		case <-stop:
+			a.sub.Close()
+			return
+		}
+	}
+}
+
 type OffloadingPostVerifier struct {
-	eg      errgroup.Group
-	stop    context.CancelFunc
-	stopped <-chan struct{}
-	log     log.Log
-	workers []*postVerifierWorker
-	channel chan<- *verifyPostJob
+	eg       errgroup.Group
+	log      *zap.Logger
+	verifier PostVerifier
+	workers  []*postVerifierWorker
+	jobs     chan *verifyPostJob
+	stop     chan struct{} // signal to stop all goroutines
 }
 
 type postVerifierWorker struct {
 	verifier PostVerifier
-	log      log.Log
-	channel  <-chan *verifyPostJob
+	log      *zap.Logger
+	jobs     <-chan *verifyPostJob
+	stop     chan struct{} // signal to stop this worker
+	shutdown chan struct{} // signal that the verifier is closing
 }
 
 type postVerifier struct {
 	*verifying.ProofVerifier
-	logger log.Log
+	logger *zap.Logger
 	cfg    config.Config
 }
 
-func (v *postVerifier) Verify(ctx context.Context, p *shared.Proof, m *shared.ProofMetadata, opts ...verifying.OptionFunc) error {
-	v.logger.WithContext(ctx).With().Debug("verifying post", log.FieldNamed("proof_node_id", types.BytesToNodeID(m.NodeId)))
-	return v.ProofVerifier.Verify(p, m, v.cfg, v.logger.Zap(), opts...)
+func (v *postVerifier) Verify(
+	ctx context.Context,
+	p *shared.Proof,
+	m *shared.ProofMetadata,
+	opts ...verifying.OptionFunc,
+) error {
+	v.logger.Debug("verifying post", zap.Stringer("proof_node_id", types.BytesToNodeID(m.NodeId)))
+	return v.ProofVerifier.Verify(p, m, v.cfg, v.logger, opts...)
 }
 
 // NewPostVerifier creates a new post verifier.
-func NewPostVerifier(cfg PostConfig, logger log.Log, opts ...verifying.OptionFunc) (PostVerifier, error) {
+func NewPostVerifier(cfg PostConfig, logger *zap.Logger, opts ...verifying.OptionFunc) (PostVerifier, error) {
 	verifier, err := verifying.NewProofVerifier(opts...)
 	if err != nil {
 		return nil, err
@@ -59,57 +106,86 @@ func NewPostVerifier(cfg PostConfig, logger log.Log, opts ...verifying.OptionFun
 // NewOffloadingPostVerifier creates a new post proof verifier with the given number of workers.
 // The verifier will distribute incoming proofs between the workers.
 // It will block if all workers are busy.
-func NewOffloadingPostVerifier(verifiers []PostVerifier, logger log.Log) *OffloadingPostVerifier {
-	numWorkers := len(verifiers)
-	channel := make(chan *verifyPostJob, numWorkers)
-	workers := make([]*postVerifierWorker, 0, numWorkers)
-
-	for i, verifier := range verifiers {
-		workers = append(workers, &postVerifierWorker{
-			verifier: verifier,
-			log:      logger.Named(fmt.Sprintf("worker-%d", i)),
-			channel:  channel,
-		})
-	}
-	logger.With().Info("created post verifier", log.Int("num_workers", numWorkers))
-
-	ctx, cancel := context.WithCancel(context.Background())
-	stopped := make(chan struct{})
+//
+// SAFETY: The `verifier` must be safe to use concurrently.
+//
+// The verifier must be closed after use with Close().
+func NewOffloadingPostVerifier(verifier PostVerifier, numWorkers int, logger *zap.Logger) *OffloadingPostVerifier {
 	v := &OffloadingPostVerifier{
-		log:     logger,
-		workers: workers,
-		channel: channel,
-		stopped: stopped,
-		stop: func() {
-			cancel()
-			select {
-			case <-stopped:
-			default:
-				close(stopped)
-			}
-		},
+		log:      logger,
+		workers:  make([]*postVerifierWorker, 0, numWorkers),
+		jobs:     make(chan *verifyPostJob, numWorkers),
+		stop:     make(chan struct{}),
+		verifier: verifier,
 	}
 
 	v.log.Info("starting post verifier")
-	for _, worker := range v.workers {
-		worker := worker
-		v.eg.Go(func() error { return worker.start(ctx) })
-	}
+	v.scale(numWorkers)
 	v.log.Info("started post verifier")
 	return v
 }
 
-func (v *OffloadingPostVerifier) Verify(ctx context.Context, p *shared.Proof, m *shared.ProofMetadata, opts ...verifying.OptionFunc) error {
+// Turn on automatic scaling of the number of workers.
+// The number of workers will be scaled between `min` and `target` (inclusive).
+func (v *OffloadingPostVerifier) Autoscale(min, target int) {
+	a, err := newAutoscaler()
+	if err != nil {
+		v.log.Panic("failed to create autoscaler", zap.Error(err))
+	}
+	v.eg.Go(func() error { a.run(v.stop, v, min, target); return nil })
+}
+
+// Scale the number of workers to the given number.
+//
+// SAFETY: Must not be called concurrently.
+// This is satisified by the fact that the only caller is the autoscaler,
+// which executes scale() serially.
+func (v *OffloadingPostVerifier) scale(target int) {
+	v.log.Info("scaling post verifier", zap.Int("current", len(v.workers)), zap.Int("new", target))
+
+	if target > len(v.workers) {
+		// scale up
+		for i := len(v.workers); i < target; i++ {
+			w := &postVerifierWorker{
+				verifier: v.verifier,
+				log:      v.log.Named(fmt.Sprintf("worker-%d", len(v.workers))),
+				jobs:     v.jobs,
+				stop:     make(chan struct{}),
+				shutdown: v.stop,
+			}
+			v.workers = append(v.workers, w)
+			v.eg.Go(func() error { w.start(); return nil })
+		}
+	} else if target < len(v.workers) {
+		// scale down
+		toKeep, toStop := v.workers[:target], v.workers[target:]
+		v.workers = toKeep
+		for _, worker := range toStop {
+			close(worker.stop)
+		}
+	}
+}
+
+func (v *OffloadingPostVerifier) Verify(
+	ctx context.Context,
+	p *shared.Proof,
+	m *shared.ProofMetadata,
+	opts ...verifying.OptionFunc,
+) error {
 	job := &verifyPostJob{
+		ctx:      ctx,
 		proof:    p,
 		metadata: m,
 		opts:     opts,
 		result:   make(chan error, 1),
 	}
 
+	metrics.PostVerificationQueue.Inc()
+	defer metrics.PostVerificationQueue.Dec()
+
 	select {
-	case v.channel <- job:
-	case <-v.stopped:
+	case v.jobs <- job:
+	case <-v.stop:
 		return fmt.Errorf("verifier is closed")
 	case <-ctx.Done():
 		return fmt.Errorf("submitting verifying job: %w", ctx.Err())
@@ -118,7 +194,7 @@ func (v *OffloadingPostVerifier) Verify(ctx context.Context, p *shared.Proof, m 
 	select {
 	case res := <-job.result:
 		return res
-	case <-v.stopped:
+	case <-v.stop:
 		return fmt.Errorf("verifier is closed")
 	case <-ctx.Done():
 		return fmt.Errorf("waiting for verification result: %w", ctx.Err())
@@ -126,28 +202,32 @@ func (v *OffloadingPostVerifier) Verify(ctx context.Context, p *shared.Proof, m 
 }
 
 func (v *OffloadingPostVerifier) Close() error {
+	select {
+	case <-v.stop:
+		return nil
+	default:
+	}
 	v.log.Info("stopping post verifier")
-	v.stop()
+	close(v.stop)
 	v.eg.Wait()
 
-	for _, worker := range v.workers {
-		if err := worker.verifier.Close(); err != nil {
-			return err
-		}
-	}
+	v.verifier.Close()
 	v.log.Info("stopped post verifier")
 	return nil
 }
 
-func (w *postVerifierWorker) start(ctx context.Context) error {
-	w.log.Info("starting post proof verifier worker")
+func (w *postVerifierWorker) start() {
+	w.log.Info("starting")
+	defer w.log.Info("stopped")
+
 	for {
 		select {
-		case <-ctx.Done():
-			w.log.Info("stopped post proof verifier worker")
-			return ctx.Err()
-		case job := <-w.channel:
-			job.result <- w.verifier.Verify(ctx, job.proof, job.metadata, job.opts...)
+		case <-w.shutdown:
+			return
+		case <-w.stop:
+			return
+		case job := <-w.jobs:
+			job.result <- w.verifier.Verify(job.ctx, job.proof, job.metadata, job.opts...)
 		}
 	}
 }

--- a/activation/post_verifier_scaling_test.go
+++ b/activation/post_verifier_scaling_test.go
@@ -1,0 +1,69 @@
+package activation
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/spacemeshos/post/shared"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	"go.uber.org/zap/zaptest"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/spacemeshos/go-spacemesh/events"
+)
+
+func TestAutoScaling(t *testing.T) {
+	events.InitializeReporter()
+	t.Cleanup(events.CloseEventReporter)
+
+	mockScaler := NewMockscaler(gomock.NewController(t))
+	var done atomic.Bool
+	gomock.InOrder(
+		mockScaler.EXPECT().scale(1),                                    // on start
+		mockScaler.EXPECT().scale(5),                                    // on complete
+		mockScaler.EXPECT().scale(5).Do(func(int) { done.Store(true) }), // on failed
+	)
+
+	stop := make(chan struct{})
+	var eg errgroup.Group
+	autoscaler, err := newAutoscaler()
+	require.NoError(t, err)
+	eg.Go(func() error {
+		autoscaler.run(stop, mockScaler, 1, 5)
+		return nil
+	})
+
+	events.EmitPostStart(nil)
+	events.EmitPostComplete(nil)
+	events.EmitPostFailure()
+	require.Eventually(t, done.Load, time.Second, 10*time.Millisecond)
+
+	close(stop)
+	eg.Wait()
+}
+
+func TestPostVerifierScaling(t *testing.T) {
+	// 0 workers - no one will verify the proof
+	mockVerifier := NewMockPostVerifier(gomock.NewController(t))
+	v := NewOffloadingPostVerifier(mockVerifier, 0, zaptest.NewLogger(t))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	err := v.Verify(ctx, &shared.Proof{}, &shared.ProofMetadata{})
+	require.Error(t, err, context.Canceled)
+
+	mockVerifier.EXPECT().Verify(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	v.scale(1)
+	err = v.Verify(context.Background(), &shared.Proof{}, &shared.ProofMetadata{})
+	require.NoError(t, err)
+
+	v.scale(0)
+	ctx, cancel = context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	err = v.Verify(ctx, &shared.Proof{}, &shared.ProofMetadata{})
+	require.Error(t, err, context.Canceled)
+}

--- a/activation/post_verifier_test.go
+++ b/activation/post_verifier_test.go
@@ -9,83 +9,63 @@ import (
 	"github.com/spacemeshos/post/shared"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+	"go.uber.org/zap/zaptest"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/spacemeshos/go-spacemesh/activation"
-	"github.com/spacemeshos/go-spacemesh/log"
-	"github.com/spacemeshos/go-spacemesh/log/logtest"
 )
 
 func TestOffloadingPostVerifier(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
 	proof := shared.Proof{}
 	metadata := shared.ProofMetadata{}
 
 	verifier := activation.NewMockPostVerifier(gomock.NewController(t))
-	offloadingVerifier := activation.NewOffloadingPostVerifier(
-		[]activation.PostVerifier{verifier},
-		log.NewDefault(t.Name()),
-	)
+	offloadingVerifier := activation.NewOffloadingPostVerifier(verifier, 1, zaptest.NewLogger(t))
 	defer offloadingVerifier.Close()
 	verifier.EXPECT().Close().Return(nil)
 
 	verifier.EXPECT().Verify(gomock.Any(), &proof, &metadata, gomock.Any()).Return(nil)
-	err := offloadingVerifier.Verify(ctx, &proof, &metadata)
+	err := offloadingVerifier.Verify(context.Background(), &proof, &metadata)
 	require.NoError(t, err)
 
 	verifier.EXPECT().Verify(gomock.Any(), &proof, &metadata, gomock.Any()).Return(errors.New("invalid proof!"))
-	err = offloadingVerifier.Verify(ctx, &proof, &metadata)
+	err = offloadingVerifier.Verify(context.Background(), &proof, &metadata)
 	require.ErrorContains(t, err, "invalid proof!")
 }
 
 func TestPostVerifierDetectsInvalidProof(t *testing.T) {
-	verifier, err := activation.NewPostVerifier(activation.PostConfig{}, logtest.New(t))
+	verifier, err := activation.NewPostVerifier(activation.PostConfig{}, zaptest.NewLogger(t))
 	require.NoError(t, err)
 	defer verifier.Close()
 	require.Error(t, verifier.Verify(context.Background(), &shared.Proof{}, &shared.ProofMetadata{}))
 }
 
 func TestPostVerifierVerifyAfterStop(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
 	proof := shared.Proof{}
 	metadata := shared.ProofMetadata{}
 
 	verifier := activation.NewMockPostVerifier(gomock.NewController(t))
-	offloadingVerifier := activation.NewOffloadingPostVerifier(
-		[]activation.PostVerifier{verifier},
-		log.NewDefault(t.Name()),
-	)
+	offloadingVerifier := activation.NewOffloadingPostVerifier(verifier, 1, zaptest.NewLogger(t))
 	defer offloadingVerifier.Close()
-	verifier.EXPECT().Close().Return(nil)
 
 	verifier.EXPECT().Verify(gomock.Any(), &proof, &metadata, gomock.Any()).Return(nil)
-	err := offloadingVerifier.Verify(ctx, &proof, &metadata)
+	err := offloadingVerifier.Verify(context.Background(), &proof, &metadata)
 	require.NoError(t, err)
 
 	// Stop the verifier
 	verifier.EXPECT().Close().Return(nil)
 	offloadingVerifier.Close()
 
-	err = offloadingVerifier.Verify(ctx, &proof, &metadata)
+	err = offloadingVerifier.Verify(context.Background(), &proof, &metadata)
 	require.EqualError(t, err, "verifier is closed")
 }
 
 func TestPostVerifierNoRaceOnClose(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	proof := shared.Proof{}
-	metadata := shared.ProofMetadata{}
+	var proof shared.Proof
+	var metadata shared.ProofMetadata
 
 	verifier := activation.NewMockPostVerifier(gomock.NewController(t))
-	offloadingVerifier := activation.NewOffloadingPostVerifier(
-		[]activation.PostVerifier{verifier},
-		log.NewDefault(t.Name()),
-	)
+	offloadingVerifier := activation.NewOffloadingPostVerifier(verifier, 1, zaptest.NewLogger(t))
 	defer offloadingVerifier.Close()
 	verifier.EXPECT().Close().AnyTimes().Return(nil)
 	verifier.EXPECT().Verify(gomock.Any(), &proof, &metadata, gomock.Any()).AnyTimes().Return(nil)
@@ -101,24 +81,21 @@ func TestPostVerifierNoRaceOnClose(t *testing.T) {
 		ms := 10 * i
 		eg.Go(func() error {
 			time.Sleep(time.Duration(ms) * time.Millisecond)
-			return offloadingVerifier.Verify(ctx, &proof, &metadata)
+			return offloadingVerifier.Verify(context.Background(), &proof, &metadata)
 		})
 	}
 
 	require.EqualError(t, eg.Wait(), "verifier is closed")
 }
 
-func TestPostVerifierReturnsOnCtxCanceledWhenBlockedVerifying(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+func TestPostVerifierClose(t *testing.T) {
+	verifier := activation.NewMockPostVerifier(gomock.NewController(t))
+	// 0 workers - no one will verify the proof
+	v := activation.NewOffloadingPostVerifier(verifier, 0, zaptest.NewLogger(t))
 
-	v := activation.NewOffloadingPostVerifier(
-		[]activation.PostVerifier{
-			// empty list of verifiers - no one will verify the proof
-		}, log.NewDefault(t.Name()))
-
+	verifier.EXPECT().Close().Return(nil)
 	require.NoError(t, v.Close())
 
-	err := v.Verify(ctx, &shared.Proof{}, &shared.ProofMetadata{})
+	err := v.Verify(context.Background(), &shared.Proof{}, &shared.ProofMetadata{})
 	require.EqualError(t, err, "verifier is closed")
 }

--- a/activation/validation_test.go
+++ b/activation/validation_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spacemeshos/post/shared"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+	"go.uber.org/zap/zaptest"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/log/logtest"
@@ -481,7 +482,7 @@ func TestValidator_Validate(t *testing.T) {
 
 	logger := logtest.New(t).WithName("validator")
 	postProvider := newTestPostManager(t)
-	verifier, err := NewPostVerifier(postProvider.cfg, logger)
+	verifier, err := NewPostVerifier(postProvider.cfg, zaptest.NewLogger(t))
 	r.NoError(err)
 	defer verifier.Close()
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -245,6 +245,24 @@ func AddCommands(cmd *cobra.Command) {
 	cmd.PersistentFlags().BoolVar(&cfg.SMESHING.Opts.Throttle, "smeshing-opts-throttle",
 		cfg.SMESHING.Opts.Throttle, "")
 
+	/**======================== PoST Proving Flags ========================== **/
+
+	cmd.PersistentFlags().UintVar(&cfg.SMESHING.ProvingOpts.Threads, "smeshing-opts-proving-threads",
+		cfg.SMESHING.ProvingOpts.Threads, "")
+	cmd.PersistentFlags().UintVar(&cfg.SMESHING.ProvingOpts.Nonces, "smeshing-opts-proving-nonces",
+		cfg.SMESHING.ProvingOpts.Nonces, "")
+
+	/**======================== PoST Verifying Flags ========================== **/
+
+	cmd.PersistentFlags().IntVar(
+		&cfg.SMESHING.VerifyingOpts.MinWorkers,
+		"smeshing-opts-verifying-min-threads",
+		cfg.SMESHING.VerifyingOpts.MinWorkers,
+		"Minimal number of threads to use for verifying PoSTs (used while PoST is generated)",
+	)
+	cmd.PersistentFlags().IntVar(&cfg.SMESHING.VerifyingOpts.Workers, "smeshing-opts-verifying-threads",
+		cfg.SMESHING.VerifyingOpts.Workers, "")
+
 	/**======================== Consensus Flags ========================== **/
 
 	cmd.PersistentFlags().Uint32Var(&cfg.LayersPerEpoch, "layers-per-epoch",

--- a/node/node.go
+++ b/node/node.go
@@ -549,21 +549,21 @@ func (app *App) initServices(ctx context.Context) error {
 	poetDb := activation.NewPoetDb(app.db, app.addLogger(PoetDbLogger, lg))
 
 	nipostValidatorLogger := app.addLogger(NipostValidatorLogger, lg)
-	postVerifiers := make([]activation.PostVerifier, 0, app.Config.SMESHING.VerifyingOpts.Workers)
+
 	lg.Debug("creating post verifier")
 	verifier, err := activation.NewPostVerifier(
 		app.Config.POST,
-		nipostValidatorLogger,
+		nipostValidatorLogger.Zap(),
 		verifying.WithPowFlags(app.Config.SMESHING.VerifyingOpts.Flags),
 	)
 	lg.With().Debug("created post verifier", log.Err(err))
 	if err != nil {
 		return err
 	}
-	for i := 0; i < app.Config.SMESHING.VerifyingOpts.Workers; i++ {
-		postVerifiers = append(postVerifiers, verifier)
-	}
-	app.postVerifier = activation.NewOffloadingPostVerifier(postVerifiers, nipostValidatorLogger)
+	minWorkers := app.Config.SMESHING.VerifyingOpts.MinWorkers
+	workers := app.Config.SMESHING.VerifyingOpts.Workers
+	app.postVerifier = activation.NewOffloadingPostVerifier(verifier, workers, nipostValidatorLogger.Zap())
+	app.postVerifier.Autoscale(minWorkers, workers)
 
 	validator := activation.NewValidator(
 		poetDb,


### PR DESCRIPTION
Verifying POST proofs is CPU-intensive. By default, it uses 3/4 CPU cores. It is a problem during the cycle gap for the nodes that take longer to generate the POST proof than the others - new ATXs start to drop in and verifying them fights for CPU with the proving process. In such a situation, proving is more important so sacrificing ATX verification speed is an acceptable tradeoff.

Added a way to scale the number of workers that verify POST proofs (in incoming ATXs) up and down.

There is an auto scaler that reacts to POST events (started/finished) by scaling the number of workers down/up respectively.

The minimum and maximum number of workers is configurable with `smeshing-opts-verifying-min-workers` and `smeshing-opts-verifying-workers` respectively.

Added unit tests.
