### PR TITLE
Fix flake in TestBuilder_RestartSmeshing/Single_threaded

### DIFF
--- a/activation/activation_test.go
+++ b/activation/activation_test.go
@@ -291,7 +291,7 @@ func TestBuilder_RestartSmeshing(t *testing.T) {
 			require.NoError(t, builder.StartSmeshing(types.Address{}, PostSetupOpts{}))
 			require.Never(t, func() bool { return !builder.Smeshing() }, 400*time.Microsecond, 50*time.Microsecond, "failed on execution %d", i)
 			require.NoError(t, builder.StopSmeshing(true))
-			require.Eventually(t, func() bool { return !builder.Smeshing() }, 100*time.Millisecond, time.Millisecond, "failed on execution %d", i)
+			require.Eventually(t, func() bool { return !builder.Smeshing() }, 1*time.Second, time.Millisecond, "failed on execution %d", i)
 		}
 	})
 


### PR DESCRIPTION
This problem is not relevant for current `develop` branch

## Motivation
Fix flaky test on the v1.2 branch

## Changes
Increase timeout in the `Eventually()` call

## Test Plan
CI needs to pass
