### PR TITLE
[Merged by Bors] - wait until sync download atxs before requesting atxs from recent epochs

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -1176,6 +1176,11 @@ func (app *App) listenToUpdates(ctx context.Context) {
 					app.proposalBuilder.UpdateActiveSet(epoch, set)
 
 					app.eg.Go(func() error {
+						select {
+						case <-app.syncer.RegisterForATXSynced():
+						case <-ctx.Done():
+							return nil
+						}
 						if err := atxsync.Download(
 							ctx,
 							10*time.Second,

--- a/syncer/atxsync/atxsync_test.go
+++ b/syncer/atxsync/atxsync_test.go
@@ -91,7 +91,7 @@ func TestDownload(t *testing.T) {
 		{
 			desc:     "exit on context",
 			ctx:      canceled,
-			retry:    1,
+			retry:    time.Minute,
 			existing: []*types.VerifiedActivationTx{atx(id(1))},
 			fetched: []fetchRequest{
 				{request: []types.ATXID{id(2)}, error: errors.New("test")},


### PR DESCRIPTION
atx requests are recursive. for example if node requests atxs from epoch 10, but it doesn't have dependencies from previous epoch. it will first download atxs from epoch 10, keep them in memory, check that dependencies are missing, download dependencies that are likely from previous epoch (9 in this example). therefore it will keep whole chain in memory, until it download and verifies them.

to avoid such recursive behavior, node will download hinted atxs only after sync downloads atxs in epoch order. 