### PR TITLE
[Merged by Bors] - hare3: bump max number of proposals to 500

### DIFF
--- a/hare3/types.go
+++ b/hare3/types.go
@@ -75,7 +75,7 @@ func (ir IterRound) Absolute() uint32 {
 
 type Value struct {
 	// Proposals is set in messages for preround and propose rounds.
-	Proposals []types.ProposalID `scale:"max=200"`
+	Proposals []types.ProposalID `scale:"max=500"`
 	// Reference is set in messages for commit and notify rounds.
 	Reference *types.Hash32
 }

--- a/hare3/types_scale.go
+++ b/hare3/types_scale.go
@@ -48,7 +48,7 @@ func (t *IterRound) DecodeScale(dec *scale.Decoder) (total int, err error) {
 
 func (t *Value) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	{
-		n, err := scale.EncodeStructSliceWithLimit(enc, t.Proposals, 200)
+		n, err := scale.EncodeStructSliceWithLimit(enc, t.Proposals, 500)
 		if err != nil {
 			return total, err
 		}
@@ -66,7 +66,7 @@ func (t *Value) EncodeScale(enc *scale.Encoder) (total int, err error) {
 
 func (t *Value) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	{
-		field, n, err := scale.DecodeStructSliceWithLimit[types.ProposalID](dec, 200)
+		field, n, err := scale.DecodeStructSliceWithLimit[types.ProposalID](dec, 500)
 		if err != nil {
 			return total, err
 		}


### PR DESCRIPTION
expected number of proposals is set to 50, this limit is maintained as long as there are less than 4032*50 atxs in the epoch.
after that it will be bloated due to protocol rule that everyone gets atleast one reward per week.
