### PR TITLE
[Merged by Bors] - p2p: fix ResourceManager configuration

### DIFF
--- a/p2p/host.go
+++ b/p2p/host.go
@@ -351,9 +351,7 @@ func New(
 	} else if cfg.ForceReachability == PrivateReachability {
 		lopts = append(lopts, libp2p.ForceReachabilityPrivate())
 	}
-	if cfg.Metrics {
-		lopts = append(lopts, setupResourcesManager(cfg))
-	}
+	lopts = append(lopts, setupResourcesManager(cfg))
 	if !cfg.DisableNatPort {
 		lopts = append(lopts, libp2p.NATPortMap())
 	}
@@ -389,6 +387,9 @@ func setupResourcesManager(hostcfg Config) func(cfg *libp2p.Config) error {
 		}
 		highPeers := hostcfg.HighPeers
 		limits := rcmgr.DefaultLimits
+		limits.ConnBaseLimit.ConnsInbound = highPeers
+		limits.ConnBaseLimit.ConnsOutbound = highPeers
+		limits.ConnBaseLimit.Conns = 2 * highPeers
 		limits.SystemBaseLimit.ConnsInbound = highPeers
 		limits.SystemBaseLimit.ConnsOutbound = highPeers
 		limits.SystemBaseLimit.Conns = 2 * highPeers
@@ -399,7 +400,9 @@ func setupResourcesManager(hostcfg Config) func(cfg *libp2p.Config) error {
 		limits.ServiceBaseLimit.StreamsInbound = 8 * highPeers
 		limits.ServiceBaseLimit.StreamsOutbound = 8 * highPeers
 		limits.ServiceBaseLimit.Streams = 16 * highPeers
-
+		limits.StreamBaseLimit.StreamsInbound = 8 * highPeers
+		limits.StreamBaseLimit.StreamsOutbound = 8 * highPeers
+		limits.StreamBaseLimit.Streams = 16 * highPeers
 		limits.ProtocolBaseLimit.StreamsInbound = 8 * highPeers
 		limits.ProtocolBaseLimit.StreamsOutbound = 8 * highPeers
 		limits.ProtocolBaseLimit.Streams = 16 * highPeers


### PR DESCRIPTION
## Motivation
go-libp2p `ResourceManager` was being configured only when metrics were enabled in the config, causing unwanted limits on connections / streams and warnings like this:
```
WARN    p2p-config      config/config.go:304    rcmgr limit conflicts with connmgr limit: conn manager high watermark limit: 20, exceeds the system connection limit of: 1      {"node_id": "...", "module": "p2p"}
```

## Changes
Always configure `ResourceManager`. Set the limits to infinte when `"disable-resource-manager": true` is used.

## Test Plan
Need to check how well p2p connectivity works with this change, with `true` and `false` values for `disable-resource-manager`

## TODO
<!-- This section should be removed when all items are complete -->
- [ ] Verify the impact on the p2p connectivity
- [ ] Update [changelog](../CHANGELOG.md) as needed
