### PR TITLE
[Merged by Bors] - Wait for ATX-synced before selecting commitment ATX

### DIFF
--- a/activation/e2e/nipost_test.go
+++ b/activation/e2e/nipost_test.go
@@ -73,14 +73,7 @@ func launchPostSupervisor(
 	provingOpts := activation.DefaultPostProvingOpts()
 	provingOpts.RandomXMode = activation.PostRandomXModeLight
 
-	syncer := activation.NewMocksyncer(gomock.NewController(tb))
-	syncer.EXPECT().RegisterForATXSynced().DoAndReturn(func() <-chan struct{} {
-		ch := make(chan struct{})
-		close(ch)
-		return ch
-	}).AnyTimes()
-
-	ps, err := activation.NewPostSupervisor(log, cmdCfg, postCfg, provingOpts, mgr, syncer)
+	ps, err := activation.NewPostSupervisor(log, cmdCfg, postCfg, provingOpts, mgr)
 	require.NoError(tb, err)
 	require.NotNil(tb, ps)
 	require.NoError(tb, ps.Start(postOpts))
@@ -106,11 +99,11 @@ func launchServer(tb testing.TB, services ...grpcserver.ServiceAPI) (grpcserver.
 	return cfg, func() { assert.NoError(tb, server.Close()) }
 }
 
-func initPost(tb testing.TB, logger *zap.Logger, mgr *activation.PostSetupManager, opts activation.PostSetupOpts) {
+func initPost(tb testing.TB, mgr *activation.PostSetupManager, opts activation.PostSetupOpts) {
 	tb.Helper()
 
 	// Create data.
-	require.NoError(tb, mgr.PrepareInitializer(opts))
+	require.NoError(tb, mgr.PrepareInitializer(context.Background(), opts))
 	require.NoError(tb, mgr.StartSession(context.Background()))
 	require.Equal(tb, activation.PostSetupStateComplete, mgr.Status().State)
 }
@@ -126,14 +119,21 @@ func TestNIPostBuilderWithClients(t *testing.T) {
 	cfg := activation.DefaultPostConfig()
 	cdb := datastore.NewCachedDB(sql.InMemory(), log.NewFromLog(logger))
 
-	mgr, err := activation.NewPostSetupManager(sig.NodeID(), cfg, logger, cdb, goldenATX)
+	syncer := activation.NewMocksyncer(gomock.NewController(t))
+	syncer.EXPECT().RegisterForATXSynced().AnyTimes().DoAndReturn(func() <-chan struct{} {
+		synced := make(chan struct{})
+		close(synced)
+		return synced
+	})
+
+	mgr, err := activation.NewPostSetupManager(sig.NodeID(), cfg, logger, cdb, goldenATX, syncer)
 	require.NoError(t, err)
 
 	opts := activation.DefaultPostSetupOpts()
 	opts.DataDir = t.TempDir()
 	opts.ProviderID.SetUint32(initialization.CPUProviderID())
 	opts.Scrypt.N = 2 // Speedup initialization in tests.
-	initPost(t, logger.Named("manager"), mgr, opts)
+	initPost(t, mgr, opts)
 
 	// ensure that genesis aligns with layer timings
 	genesis := time.Now().Add(layerDuration).Round(layerDuration)
@@ -265,7 +265,14 @@ func TestNewNIPostBuilderNotInitialized(t *testing.T) {
 	cfg := activation.DefaultPostConfig()
 	cdb := datastore.NewCachedDB(sql.InMemory(), log.NewFromLog(logger))
 
-	mgr, err := activation.NewPostSetupManager(sig.NodeID(), cfg, logger, cdb, goldenATX)
+	syncer := activation.NewMocksyncer(gomock.NewController(t))
+	syncer.EXPECT().RegisterForATXSynced().AnyTimes().DoAndReturn(func() <-chan struct{} {
+		synced := make(chan struct{})
+		close(synced)
+		return synced
+	})
+
+	mgr, err := activation.NewPostSetupManager(sig.NodeID(), cfg, logger, cdb, goldenATX, syncer)
 	require.NoError(t, err)
 
 	// ensure that genesis aligns with layer timings

--- a/activation/e2e/validation_test.go
+++ b/activation/e2e/validation_test.go
@@ -34,14 +34,21 @@ func TestValidator_Validate(t *testing.T) {
 	cfg := activation.DefaultPostConfig()
 	cdb := datastore.NewCachedDB(sql.InMemory(), log.NewFromLog(logger))
 
-	mgr, err := activation.NewPostSetupManager(sig.NodeID(), cfg, logger, cdb, goldenATX)
+	syncer := activation.NewMocksyncer(gomock.NewController(t))
+	syncer.EXPECT().RegisterForATXSynced().AnyTimes().DoAndReturn(func() <-chan struct{} {
+		synced := make(chan struct{})
+		close(synced)
+		return synced
+	})
+
+	mgr, err := activation.NewPostSetupManager(sig.NodeID(), cfg, logger, cdb, goldenATX, syncer)
 	require.NoError(t, err)
 
 	opts := activation.DefaultPostSetupOpts()
 	opts.DataDir = t.TempDir()
 	opts.ProviderID.SetUint32(initialization.CPUProviderID())
 	opts.Scrypt.N = 2 // Speedup initialization in tests.
-	initPost(t, logger.Named("manager"), mgr, opts)
+	initPost(t, mgr, opts)
 
 	// ensure that genesis aligns with layer timings
 	genesis := time.Now().Add(layerDuration).Round(layerDuration)

--- a/activation/interface.go
+++ b/activation/interface.go
@@ -83,7 +83,7 @@ type atxProvider interface {
 // This interface is used by the atx builder and currently implemented by the PostSetupManager.
 // Eventually most of the functionality will be moved to the PoSTClient.
 type postSetupProvider interface {
-	PrepareInitializer(opts PostSetupOpts) error
+	PrepareInitializer(ctx context.Context, opts PostSetupOpts) error
 	StartSession(context context.Context) error
 	Status() *PostSetupStatus
 	Reset() error

--- a/activation/mocks.go
+++ b/activation/mocks.go
@@ -954,17 +954,17 @@ func (m *MockpostSetupProvider) EXPECT() *MockpostSetupProviderMockRecorder {
 }
 
 // PrepareInitializer mocks base method.
-func (m *MockpostSetupProvider) PrepareInitializer(opts PostSetupOpts) error {
+func (m *MockpostSetupProvider) PrepareInitializer(ctx context.Context, opts PostSetupOpts) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PrepareInitializer", opts)
+	ret := m.ctrl.Call(m, "PrepareInitializer", ctx, opts)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // PrepareInitializer indicates an expected call of PrepareInitializer.
-func (mr *MockpostSetupProviderMockRecorder) PrepareInitializer(opts any) *postSetupProviderPrepareInitializerCall {
+func (mr *MockpostSetupProviderMockRecorder) PrepareInitializer(ctx, opts any) *postSetupProviderPrepareInitializerCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareInitializer", reflect.TypeOf((*MockpostSetupProvider)(nil).PrepareInitializer), opts)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareInitializer", reflect.TypeOf((*MockpostSetupProvider)(nil).PrepareInitializer), ctx, opts)
 	return &postSetupProviderPrepareInitializerCall{Call: call}
 }
 
@@ -980,13 +980,13 @@ func (c *postSetupProviderPrepareInitializerCall) Return(arg0 error) *postSetupP
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *postSetupProviderPrepareInitializerCall) Do(f func(PostSetupOpts) error) *postSetupProviderPrepareInitializerCall {
+func (c *postSetupProviderPrepareInitializerCall) Do(f func(context.Context, PostSetupOpts) error) *postSetupProviderPrepareInitializerCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *postSetupProviderPrepareInitializerCall) DoAndReturn(f func(PostSetupOpts) error) *postSetupProviderPrepareInitializerCall {
+func (c *postSetupProviderPrepareInitializerCall) DoAndReturn(f func(context.Context, PostSetupOpts) error) *postSetupProviderPrepareInitializerCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/activation/post.go
+++ b/activation/post.go
@@ -77,7 +77,7 @@ func DefaultPostProvingOpts() PostProvingOpts {
 	}
 }
 
-// PostProvingOpts are the options controlling POST proving process.
+// PostProofVerifyingOpts are the options controlling POST proving process.
 type PostProofVerifyingOpts struct {
 	// Number of workers spawned to verify proofs.
 	Workers int `mapstructure:"smeshing-opts-verifying-workers"`
@@ -169,6 +169,7 @@ func (o PostSetupOpts) ToInitOpts() config.InitOpts {
 type PostSetupManager struct {
 	id              types.NodeID
 	commitmentAtxId types.ATXID
+	syncer          syncer
 
 	cfg         PostConfig
 	logger      *zap.Logger
@@ -188,6 +189,7 @@ func NewPostSetupManager(
 	logger *zap.Logger,
 	db *datastore.CachedDB,
 	goldenATXID types.ATXID,
+	syncer syncer,
 ) (*PostSetupManager, error) {
 	mgr := &PostSetupManager{
 		id:          id,
@@ -196,6 +198,7 @@ func NewPostSetupManager(
 		db:          db,
 		goldenATXID: goldenATXID,
 		state:       PostSetupStateNotStarted,
+		syncer:      syncer,
 	}
 
 	return mgr, nil
@@ -298,7 +301,8 @@ func (mgr *PostSetupManager) StartSession(ctx context.Context) error {
 // (StartSession can take days to complete). After the first call to this
 // method subsequent calls to this method will return an error until
 // StartSession has completed execution.
-func (mgr *PostSetupManager) PrepareInitializer(opts PostSetupOpts) error {
+func (mgr *PostSetupManager) PrepareInitializer(ctx context.Context, opts PostSetupOpts) error {
+	mgr.logger.Info("preparing post initializer", zap.Any("opts", opts))
 	mgr.mu.Lock()
 	defer mgr.mu.Unlock()
 	if mgr.state == PostSetupStatePrepared || mgr.state == PostSetupStateInProgress {
@@ -306,7 +310,7 @@ func (mgr *PostSetupManager) PrepareInitializer(opts PostSetupOpts) error {
 	}
 
 	var err error
-	mgr.commitmentAtxId, err = mgr.commitmentAtx(opts.DataDir)
+	mgr.commitmentAtxId, err = mgr.commitmentAtx(ctx, opts.DataDir)
 	if err != nil {
 		return err
 	}
@@ -329,7 +333,7 @@ func (mgr *PostSetupManager) PrepareInitializer(opts PostSetupOpts) error {
 	return nil
 }
 
-func (mgr *PostSetupManager) commitmentAtx(dataDir string) (types.ATXID, error) {
+func (mgr *PostSetupManager) commitmentAtx(ctx context.Context, dataDir string) (types.ATXID, error) {
 	m, err := initialization.LoadMetadata(dataDir)
 	switch {
 	case err == nil:
@@ -349,7 +353,7 @@ func (mgr *PostSetupManager) commitmentAtx(dataDir string) (types.ATXID, error) 
 		}
 
 		// if this node has not published an ATX select the best ATX with `findCommitmentAtx`
-		return mgr.findCommitmentAtx()
+		return mgr.findCommitmentAtx(ctx)
 	default:
 		return types.EmptyATXID, fmt.Errorf("load metadata: %w", err)
 	}
@@ -358,7 +362,15 @@ func (mgr *PostSetupManager) commitmentAtx(dataDir string) (types.ATXID, error) 
 // findCommitmentAtx determines the best commitment ATX to use for the node.
 // It will use the ATX with the highest height seen by the node and defaults to the goldenATX,
 // when no ATXs have yet been published.
-func (mgr *PostSetupManager) findCommitmentAtx() (types.ATXID, error) {
+func (mgr *PostSetupManager) findCommitmentAtx(ctx context.Context) (types.ATXID, error) {
+	mgr.logger.Info("waiting for ATXs to sync before selecting commitment ATX")
+	select {
+	case <-ctx.Done():
+		return types.EmptyATXID, ctx.Err()
+	case <-mgr.syncer.RegisterForATXSynced():
+		mgr.logger.Info("ATXs synced - selecting commitment ATX")
+	}
+
 	atx, err := atxs.GetIDWithMaxHeight(mgr.db, types.EmptyNodeID)
 	switch {
 	case errors.Is(err, sql.ErrNotFound):

--- a/activation/post_supervisor.go
+++ b/activation/post_supervisor.go
@@ -68,7 +68,6 @@ type PostSupervisor struct {
 	provingOpts PostProvingOpts
 
 	postSetupProvider postSetupProvider
-	syncer            syncer
 
 	pid atomic.Int64 // pid of the running post service, only for tests.
 
@@ -84,7 +83,6 @@ func NewPostSupervisor(
 	postCfg PostConfig,
 	provingOpts PostProvingOpts,
 	postSetupProvider postSetupProvider,
-	syncer syncer,
 ) (*PostSupervisor, error) {
 	if _, err := os.Stat(cmdCfg.PostServiceCmd); err != nil {
 		return nil, fmt.Errorf("post service binary not found: %s", cmdCfg.PostServiceCmd)
@@ -97,7 +95,6 @@ func NewPostSupervisor(
 		provingOpts: provingOpts,
 
 		postSetupProvider: postSetupProvider,
-		syncer:            syncer,
 	}, nil
 }
 
@@ -141,27 +138,24 @@ func (ps *PostSupervisor) Start(opts PostSetupOpts) error {
 		return fmt.Errorf("post service already started")
 	}
 
-	// TODO(mafa): verify that opts don't delete existing files?
-
-	err := ps.postSetupProvider.PrepareInitializer(opts)
-	if err != nil {
-		return fmt.Errorf("prepare initializer: %w", err)
-	}
+	// TODO(mafa): verify that opts don't delete existing files
 
 	ps.eg = errgroup.Group{} // reset errgroup to allow restarts.
 	ctx, stop := context.WithCancel(context.Background())
 	ps.stop = stop
 	ps.eg.Go(func() error {
-		select {
-		case <-ctx.Done():
+		// If it returns any error other than context.Canceled
+		// (which is how we signal it to stop) then we shutdown.
+		err := ps.postSetupProvider.PrepareInitializer(ctx, opts)
+		switch {
+		case errors.Is(err, context.Canceled):
 			return nil
-		case <-ps.syncer.RegisterForATXSynced():
-			// ensure we are ATX synced before starting the PoST Session
+		case err != nil:
+			ps.logger.Fatal("preparing POST initializer failed", zap.Error(err))
+			return err
 		}
 
-		// If start session returns any error other than context.Canceled
-		// (which is how we signal it to stop) then we panic.
-		err := ps.postSetupProvider.StartSession(ctx)
+		err = ps.postSetupProvider.StartSession(ctx)
 		switch {
 		case errors.Is(err, context.Canceled):
 			return nil
@@ -230,7 +224,7 @@ func (ps *PostSupervisor) runCmd(
 
 		"--min-num-units", strconv.FormatUint(uint64(postCfg.MinNumUnits), 10),
 		"--max-num-units", strconv.FormatUint(uint64(postCfg.MaxNumUnits), 10),
-		"--labels-per-unit", strconv.FormatUint(uint64(postCfg.LabelsPerUnit), 10),
+		"--labels-per-unit", strconv.FormatUint(postCfg.LabelsPerUnit, 10),
 		"--k1", strconv.FormatUint(uint64(postCfg.K1), 10),
 		"--k2", strconv.FormatUint(uint64(postCfg.K2), 10),
 		"--k3", strconv.FormatUint(uint64(postCfg.K3), 10),

--- a/activation/post_supervisor_test.go
+++ b/activation/post_supervisor_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"runtime"
+	"sync/atomic"
 	"syscall"
 	"testing"
 	"time"
@@ -31,7 +32,7 @@ func Test_PostSupervisor_ErrorOnMissingBinary(t *testing.T) {
 	postCfg := DefaultPostConfig()
 	provingOpts := DefaultPostProvingOpts()
 
-	ps, err := NewPostSupervisor(log.Named("supervisor"), cmdCfg, postCfg, provingOpts, nil, nil)
+	ps, err := NewPostSupervisor(log.Named("supervisor"), cmdCfg, postCfg, provingOpts, nil)
 	require.ErrorContains(t, err, "post service binary not found")
 	require.Nil(t, ps)
 }
@@ -43,15 +44,23 @@ func Test_PostSupervisor_StopWithoutStart(t *testing.T) {
 	postCfg := DefaultPostConfig()
 	provingOpts := DefaultPostProvingOpts()
 
-	ps, err := NewPostSupervisor(log.Named("supervisor"), cmdCfg, postCfg, provingOpts, nil, nil)
+	ps, err := NewPostSupervisor(log.Named("supervisor"), cmdCfg, postCfg, provingOpts, nil)
 	require.NoError(t, err)
 	require.NotNil(t, ps)
 
 	require.NoError(t, ps.Stop(false))
 }
 
+type hookF func(*zapcore.CheckedEntry,  []zapcore.Field)
+func (f hookF) OnWrite(ce *zapcore.CheckedEntry, fields []zapcore.Field) {
+	f(ce, fields)
+}
+
 func Test_PostSupervisor_Start_FailPrepare(t *testing.T) {
-	log := zaptest.NewLogger(t)
+	fatalled := atomic.Bool{}
+	log := zaptest.NewLogger(t).WithOptions(zap.WithFatalHook(hookF(func(*zapcore.CheckedEntry,  []zapcore.Field) {
+		fatalled.Store(true)
+	})))
 
 	cmdCfg := DefaultTestPostServiceConfig()
 	postCfg := DefaultPostConfig()
@@ -60,13 +69,15 @@ func Test_PostSupervisor_Start_FailPrepare(t *testing.T) {
 
 	mgr := NewMockpostSetupProvider(gomock.NewController(t))
 	testErr := errors.New("test error")
-	mgr.EXPECT().PrepareInitializer(postOpts).Return(testErr)
+	mgr.EXPECT().PrepareInitializer(gomock.Any(), postOpts).Return(testErr)
 
-	ps, err := NewPostSupervisor(log.Named("supervisor"), cmdCfg, postCfg, provingOpts, mgr, nil)
+	ps, err := NewPostSupervisor(log.Named("supervisor"), cmdCfg, postCfg, provingOpts, mgr)
 	require.NoError(t, err)
 	require.NotNil(t, ps)
 
-	require.ErrorIs(t, ps.Start(postOpts), testErr)
+	require.NoError(t, ps.Start(postOpts))
+	require.Eventually(t, fatalled.Load, time.Second, time.Millisecond*100)
+	require.ErrorIs(t, ps.Stop(false), testErr)
 }
 
 type fatalHook struct {
@@ -93,13 +104,10 @@ func Test_PostSupervisor_Start_FailStartSession(t *testing.T) {
 
 	ctrl := gomock.NewController(t)
 	mgr := NewMockpostSetupProvider(ctrl)
-	mgr.EXPECT().PrepareInitializer(postOpts).Return(nil)
+	mgr.EXPECT().PrepareInitializer(gomock.Any(), postOpts).Return(nil)
 	mgr.EXPECT().StartSession(gomock.Any()).Return(errors.New("failed start session"))
 
-	sync := NewMocksyncer(ctrl)
-	sync.EXPECT().RegisterForATXSynced().DoAndReturn(closedChan)
-
-	ps, err := NewPostSupervisor(log.Named("supervisor"), cmdCfg, postCfg, provingOpts, mgr, sync)
+	ps, err := NewPostSupervisor(log.Named("supervisor"), cmdCfg, postCfg, provingOpts, mgr)
 	require.NoError(t, err)
 	require.NotNil(t, ps)
 
@@ -117,13 +125,10 @@ func Test_PostSupervisor_StartsServiceCmd(t *testing.T) {
 
 	ctrl := gomock.NewController(t)
 	mgr := NewMockpostSetupProvider(ctrl)
-	mgr.EXPECT().PrepareInitializer(postOpts).Return(nil)
+	mgr.EXPECT().PrepareInitializer(gomock.Any(), postOpts).Return(nil)
 	mgr.EXPECT().StartSession(gomock.Any()).Return(nil)
 
-	sync := NewMocksyncer(ctrl)
-	sync.EXPECT().RegisterForATXSynced().DoAndReturn(closedChan)
-
-	ps, err := NewPostSupervisor(log.Named("supervisor"), cmdCfg, postCfg, provingOpts, mgr, sync)
+	ps, err := NewPostSupervisor(log.Named("supervisor"), cmdCfg, postCfg, provingOpts, mgr)
 	require.NoError(t, err)
 	require.NotNil(t, ps)
 
@@ -158,13 +163,10 @@ func Test_PostSupervisor_Restart_Possible(t *testing.T) {
 
 	ctrl := gomock.NewController(t)
 	mgr := NewMockpostSetupProvider(ctrl)
-	mgr.EXPECT().PrepareInitializer(postOpts).Return(nil)
+	mgr.EXPECT().PrepareInitializer(gomock.Any(), postOpts).Return(nil)
 	mgr.EXPECT().StartSession(gomock.Any()).Return(nil)
 
-	sync := NewMocksyncer(ctrl)
-	sync.EXPECT().RegisterForATXSynced().DoAndReturn(closedChan).AnyTimes()
-
-	ps, err := NewPostSupervisor(log.Named("supervisor"), cmdCfg, postCfg, provingOpts, mgr, sync)
+	ps, err := NewPostSupervisor(log.Named("supervisor"), cmdCfg, postCfg, provingOpts, mgr)
 	require.NoError(t, err)
 	require.NotNil(t, ps)
 
@@ -175,7 +177,7 @@ func Test_PostSupervisor_Restart_Possible(t *testing.T) {
 	require.NoError(t, ps.Stop(false))
 	require.Eventually(t, func() bool { return ps.pid.Load() == 0 }, 5*time.Second, 100*time.Millisecond)
 
-	mgr.EXPECT().PrepareInitializer(postOpts).Return(nil)
+	mgr.EXPECT().PrepareInitializer(gomock.Any(), postOpts).Return(nil)
 	mgr.EXPECT().StartSession(gomock.Any()).Return(nil)
 	require.NoError(t, ps.Start(postOpts))
 	require.Eventually(t, func() bool { return ps.pid.Load() != 0 }, 5*time.Second, 100*time.Millisecond)
@@ -194,13 +196,10 @@ func Test_PostSupervisor_LogFatalOnCrash(t *testing.T) {
 
 	ctrl := gomock.NewController(t)
 	mgr := NewMockpostSetupProvider(ctrl)
-	mgr.EXPECT().PrepareInitializer(postOpts).Return(nil)
+	mgr.EXPECT().PrepareInitializer(gomock.Any(), postOpts).Return(nil)
 	mgr.EXPECT().StartSession(gomock.Any()).Return(nil)
 
-	sync := NewMocksyncer(ctrl)
-	sync.EXPECT().RegisterForATXSynced().DoAndReturn(closedChan)
-
-	ps, err := NewPostSupervisor(log.Named("supervisor"), cmdCfg, postCfg, provingOpts, mgr, sync)
+	ps, err := NewPostSupervisor(log.Named("supervisor"), cmdCfg, postCfg, provingOpts, mgr)
 	require.NoError(t, err)
 	require.NotNil(t, ps)
 
@@ -231,13 +230,10 @@ func Test_PostSupervisor_LogFatalOnInvalidConfig(t *testing.T) {
 
 	ctrl := gomock.NewController(t)
 	mgr := NewMockpostSetupProvider(ctrl)
-	mgr.EXPECT().PrepareInitializer(postOpts).Return(nil)
+	mgr.EXPECT().PrepareInitializer(gomock.Any(), postOpts).Return(nil)
 	mgr.EXPECT().StartSession(gomock.Any()).Return(nil)
 
-	sync := NewMocksyncer(ctrl)
-	sync.EXPECT().RegisterForATXSynced().DoAndReturn(closedChan)
-
-	ps, err := NewPostSupervisor(log.Named("supervisor"), cmdCfg, postCfg, provingOpts, mgr, sync)
+	ps, err := NewPostSupervisor(log.Named("supervisor"), cmdCfg, postCfg, provingOpts, mgr)
 	require.NoError(t, err)
 	require.NotNil(t, ps)
 
@@ -265,13 +261,10 @@ func Test_PostSupervisor_StopOnError(t *testing.T) {
 
 	ctrl := gomock.NewController(t)
 	mgr := NewMockpostSetupProvider(ctrl)
-	mgr.EXPECT().PrepareInitializer(postOpts).Return(nil)
+	mgr.EXPECT().PrepareInitializer(gomock.Any(), postOpts).Return(nil)
 	mgr.EXPECT().StartSession(gomock.Any()).Return(nil)
 
-	sync := NewMocksyncer(ctrl)
-	sync.EXPECT().RegisterForATXSynced().DoAndReturn(closedChan)
-
-	ps, err := NewPostSupervisor(log.Named("supervisor"), cmdCfg, postCfg, provingOpts, mgr, sync)
+	ps, err := NewPostSupervisor(log.Named("supervisor"), cmdCfg, postCfg, provingOpts, mgr)
 	require.NoError(t, err)
 	require.NotNil(t, ps)
 
@@ -293,9 +286,8 @@ func Test_PostSupervisor_Providers_includesCPU(t *testing.T) {
 
 	ctrl := gomock.NewController(t)
 	mgr := NewMockpostSetupProvider(ctrl)
-	sync := NewMocksyncer(ctrl)
 
-	ps, err := NewPostSupervisor(log.Named("supervisor"), cmdCfg, postCfg, provingOpts, mgr, sync)
+	ps, err := NewPostSupervisor(log.Named("supervisor"), cmdCfg, postCfg, provingOpts, mgr)
 	require.NoError(t, err)
 
 	providers, err := ps.Providers()
@@ -318,9 +310,8 @@ func Test_PostSupervisor_Benchmark(t *testing.T) {
 
 	ctrl := gomock.NewController(t)
 	mgr := NewMockpostSetupProvider(ctrl)
-	sync := NewMocksyncer(ctrl)
 
-	ps, err := NewPostSupervisor(log.Named("supervisor"), cmdCfg, postCfg, provingOpts, mgr, sync)
+	ps, err := NewPostSupervisor(log.Named("supervisor"), cmdCfg, postCfg, provingOpts, mgr)
 	require.NoError(t, err)
 
 	providers, err := ps.Providers()

--- a/activation/post_test.go
+++ b/activation/post_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spacemeshos/post/initialization"
 	"github.com/spacemeshos/post/shared"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 	"go.uber.org/zap/zaptest"
 	"golang.org/x/sync/errgroup"
 
@@ -49,20 +50,20 @@ func TestPostSetupManager(t *testing.T) {
 	})
 
 	// Create data.
-	require.NoError(t, mgr.PrepareInitializer(mgr.opts))
+	require.NoError(t, mgr.PrepareInitializer(context.Background(), mgr.opts))
 	require.NoError(t, mgr.StartSession(context.Background()))
 	require.NoError(t, eg.Wait())
 	require.Equal(t, PostSetupStateComplete, mgr.Status().State)
 
 	// Create data (same opts).
-	require.NoError(t, mgr.PrepareInitializer(mgr.opts))
+	require.NoError(t, mgr.PrepareInitializer(context.Background(), mgr.opts))
 	require.NoError(t, mgr.StartSession(context.Background()))
 
 	// Cleanup.
 	require.NoError(t, mgr.Reset())
 
 	// Create data (same opts, after deletion).
-	require.NoError(t, mgr.PrepareInitializer(mgr.opts))
+	require.NoError(t, mgr.PrepareInitializer(context.Background(), mgr.opts))
 	require.NoError(t, mgr.StartSession(context.Background()))
 	require.Equal(t, PostSetupStateComplete, mgr.Status().State)
 }
@@ -77,27 +78,27 @@ func TestPostSetupManager_PrepareInitializer(t *testing.T) {
 	mgr := newTestPostManager(t)
 
 	// check no error with good options.
-	req.NoError(mgr.PrepareInitializer(mgr.opts))
+	req.NoError(mgr.PrepareInitializer(context.Background(), mgr.opts))
 
 	defaultConfig := config.DefaultConfig()
 
 	// Check that invalid options return errors
 	opts := mgr.opts
 	opts.ComputeBatchSize = 3
-	req.Error(mgr.PrepareInitializer(opts))
+	req.Error(mgr.PrepareInitializer(context.Background(), opts))
 
 	opts = mgr.opts
 	opts.NumUnits = defaultConfig.MaxNumUnits + 1
-	req.Error(mgr.PrepareInitializer(opts))
+	req.Error(mgr.PrepareInitializer(context.Background(), opts))
 
 	opts = mgr.opts
 	opts.NumUnits = defaultConfig.MinNumUnits - 1
-	req.Error(mgr.PrepareInitializer(opts))
+	req.Error(mgr.PrepareInitializer(context.Background(), opts))
 
 	opts = mgr.opts
 	opts.Scrypt.N = 0
 	req.Error(opts.Scrypt.Validate())
-	req.Error(mgr.PrepareInitializer(opts))
+	req.Error(mgr.PrepareInitializer(context.Background(), opts))
 }
 
 func TestPostSetupManager_StartSession_WithoutProvider_Error(t *testing.T) {
@@ -107,7 +108,7 @@ func TestPostSetupManager_StartSession_WithoutProvider_Error(t *testing.T) {
 	mgr.opts.ProviderID.value = nil
 
 	// Create data.
-	req.NoError(mgr.PrepareInitializer(mgr.opts)) // prepare is fine without provider
+	req.NoError(mgr.PrepareInitializer(context.Background(), mgr.opts)) // prepare is fine without provider
 	req.ErrorContains(mgr.StartSession(context.Background()), "no provider specified")
 
 	req.Equal(PostSetupStateError, mgr.Status().State)
@@ -122,7 +123,7 @@ func TestPostSetupManager_StartSession_WithoutProviderAfterInit_OK(t *testing.T)
 	defer cancel()
 
 	// Create data.
-	req.NoError(mgr.PrepareInitializer(mgr.opts))
+	req.NoError(mgr.PrepareInitializer(ctx, mgr.opts))
 	req.NoError(mgr.StartSession(ctx))
 
 	req.Equal(PostSetupStateComplete, mgr.Status().State)
@@ -134,7 +135,7 @@ func TestPostSetupManager_StartSession_WithoutProviderAfterInit_OK(t *testing.T)
 	ctx, cancel = context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
 
-	req.NoError(mgr.PrepareInitializer(mgr.opts))
+	req.NoError(mgr.PrepareInitializer(ctx, mgr.opts))
 	req.NoError(mgr.StartSession(ctx))
 
 	req.Equal(PostSetupStateComplete, mgr.Status().State)
@@ -153,10 +154,10 @@ func TestPostSetupManager_InitializationCallSequence(t *testing.T) {
 	// Should fail since we have not prepared.
 	req.Error(mgr.StartSession(ctx))
 
-	req.NoError(mgr.PrepareInitializer(mgr.opts))
+	req.NoError(mgr.PrepareInitializer(ctx, mgr.opts))
 
 	// Should fail since we need to call StartSession after PrepareInitializer.
-	req.Error(mgr.PrepareInitializer(mgr.opts))
+	req.Error(mgr.PrepareInitializer(ctx, mgr.opts))
 
 	req.NoError(mgr.StartSession(ctx))
 
@@ -170,7 +171,7 @@ func TestPostSetupManager_StateError(t *testing.T) {
 
 	mgr := newTestPostManager(t)
 	mgr.opts.NumUnits = 0
-	req.Error(mgr.PrepareInitializer(mgr.opts))
+	req.Error(mgr.PrepareInitializer(context.Background(), mgr.opts))
 	// Verify Status returns StateError
 	req.Equal(PostSetupStateError, mgr.Status().State)
 }
@@ -186,7 +187,7 @@ func TestPostSetupManager_InitialStatus(t *testing.T) {
 	req.Zero(status.NumLabelsWritten)
 
 	// Create data.
-	req.NoError(mgr.PrepareInitializer(mgr.opts))
+	req.NoError(mgr.PrepareInitializer(context.Background(), mgr.opts))
 	req.NoError(mgr.StartSession(context.Background()))
 	req.Equal(PostSetupStateComplete, mgr.Status().State)
 
@@ -210,7 +211,7 @@ func TestPostSetupManager_Stop(t *testing.T) {
 	req.Zero(status.NumLabelsWritten)
 
 	// Create data.
-	req.NoError(mgr.PrepareInitializer(mgr.opts))
+	req.NoError(mgr.PrepareInitializer(context.Background(), mgr.opts))
 	req.NoError(mgr.StartSession(context.Background()))
 
 	// Verify state.
@@ -223,7 +224,7 @@ func TestPostSetupManager_Stop(t *testing.T) {
 	req.Equal(PostSetupStateNotStarted, mgr.Status().State)
 
 	// Create data again.
-	req.NoError(mgr.PrepareInitializer(mgr.opts))
+	req.NoError(mgr.PrepareInitializer(context.Background(), mgr.opts))
 	req.NoError(mgr.StartSession(context.Background()))
 
 	// Verify state.
@@ -238,7 +239,7 @@ func TestPostSetupManager_Stop_WhileInProgress(t *testing.T) {
 	mgr.opts.NumUnits = mgr.cfg.MaxNumUnits
 
 	// Create data.
-	req.NoError(mgr.PrepareInitializer(mgr.opts))
+	req.NoError(mgr.PrepareInitializer(context.Background(), mgr.opts))
 	ctx, cancel := context.WithCancel(context.Background())
 	var eg errgroup.Group
 	eg.Go(func() error {
@@ -261,7 +262,7 @@ func TestPostSetupManager_Stop_WhileInProgress(t *testing.T) {
 	req.LessOrEqual(status.NumLabelsWritten, uint64(mgr.opts.NumUnits)*mgr.cfg.LabelsPerUnit)
 
 	// Continue to create data.
-	req.NoError(mgr.PrepareInitializer(mgr.opts))
+	req.NoError(mgr.PrepareInitializer(context.Background(), mgr.opts))
 	req.NoError(mgr.StartSession(context.Background()))
 
 	// Verify status.
@@ -274,7 +275,7 @@ func TestPostSetupManager_findCommitmentAtx_UsesLatestAtx(t *testing.T) {
 	mgr := newTestPostManager(t)
 
 	latestAtx := addPrevAtx(t, mgr.db, 1, mgr.signer)
-	atx, err := mgr.findCommitmentAtx()
+	atx, err := mgr.findCommitmentAtx(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, latestAtx.ID(), atx)
 }
@@ -282,7 +283,7 @@ func TestPostSetupManager_findCommitmentAtx_UsesLatestAtx(t *testing.T) {
 func TestPostSetupManager_findCommitmentAtx_DefaultsToGoldenAtx(t *testing.T) {
 	mgr := newTestPostManager(t)
 
-	atx, err := mgr.findCommitmentAtx()
+	atx, err := mgr.findCommitmentAtx(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, mgr.goldenATXID, atx)
 }
@@ -292,12 +293,13 @@ func TestPostSetupManager_getCommitmentAtx_getsCommitmentAtxFromPostMetadata(t *
 
 	// write commitment atx to metadata
 	commitmentAtx := types.RandomATXID()
-	initialization.SaveMetadata(mgr.opts.DataDir, &shared.PostMetadata{
+	err := initialization.SaveMetadata(mgr.opts.DataDir, &shared.PostMetadata{
 		CommitmentAtxId: commitmentAtx.Bytes(),
 		NodeId:          mgr.signer.NodeID().Bytes(),
 	})
+	require.NoError(t, err)
 
-	atxid, err := mgr.commitmentAtx(mgr.opts.DataDir)
+	atxid, err := mgr.commitmentAtx(context.Background(), mgr.opts.DataDir)
 	require.NoError(t, err)
 	require.NotNil(t, atxid)
 	require.Equal(t, commitmentAtx, atxid)
@@ -312,7 +314,7 @@ func TestPostSetupManager_getCommitmentAtx_getsCommitmentAtxFromInitialAtx(t *te
 	atx.CommitmentATX = &commitmentAtx
 	addAtx(t, mgr.cdb, mgr.signer, atx)
 
-	atxid, err := mgr.commitmentAtx(mgr.opts.DataDir)
+	atxid, err := mgr.commitmentAtx(context.Background(), mgr.opts.DataDir)
 	require.NoError(t, err)
 	require.Equal(t, commitmentAtx, atxid)
 }
@@ -340,8 +342,13 @@ func newTestPostManager(tb testing.TB) *testPostManager {
 
 	goldenATXID := types.ATXID{2, 3, 4}
 
+	syncer := NewMocksyncer(gomock.NewController(tb))
+	synced := make(chan struct{})
+	close(synced)
+	syncer.EXPECT().RegisterForATXSynced().AnyTimes().Return(synced)
+
 	cdb := datastore.NewCachedDB(sql.InMemory(), logtest.New(tb))
-	mgr, err := NewPostSetupManager(id, DefaultPostConfig(), zaptest.NewLogger(tb), cdb, goldenATXID)
+	mgr, err := NewPostSetupManager(id, DefaultPostConfig(), zaptest.NewLogger(tb), cdb, goldenATXID, syncer)
 	require.NoError(tb, err)
 
 	return &testPostManager{

--- a/activation/post_verifier_test.go
+++ b/activation/post_verifier_test.go
@@ -67,6 +67,7 @@ func TestPostVerifierNoRaceOnClose(t *testing.T) {
 	verifier := activation.NewMockPostVerifier(gomock.NewController(t))
 	offloadingVerifier := activation.NewOffloadingPostVerifier(verifier, 1, zaptest.NewLogger(t))
 	defer offloadingVerifier.Close()
+
 	verifier.EXPECT().Close().AnyTimes().Return(nil)
 	verifier.EXPECT().Verify(gomock.Any(), &proof, &metadata, gomock.Any()).AnyTimes().Return(nil)
 

--- a/api/grpcserver/post_service_test.go
+++ b/api/grpcserver/post_service_test.go
@@ -43,10 +43,6 @@ func launchPostSupervisor(
 	id := sig.NodeID()
 	goldenATXID := types.RandomATXID()
 
-	cdb := datastore.NewCachedDB(sql.InMemory(), logtest.New(tb))
-	mgr, err := activation.NewPostSetupManager(id, postCfg, log.Named("post manager"), cdb, goldenATXID)
-	require.NoError(tb, err)
-
 	syncer := activation.NewMocksyncer(gomock.NewController(tb))
 	syncer.EXPECT().RegisterForATXSynced().DoAndReturn(func() <-chan struct{} {
 		ch := make(chan struct{})
@@ -54,8 +50,12 @@ func launchPostSupervisor(
 		return ch
 	})
 
+	cdb := datastore.NewCachedDB(sql.InMemory(), logtest.New(tb))
+	mgr, err := activation.NewPostSetupManager(id, postCfg, log.Named("post manager"), cdb, goldenATXID, syncer)
+	require.NoError(tb, err)
+
 	// start post supervisor
-	ps, err := activation.NewPostSupervisor(log, serviceCfg, postCfg, provingOpts, mgr, syncer)
+	ps, err := activation.NewPostSupervisor(log, serviceCfg, postCfg, provingOpts, mgr)
 	require.NoError(tb, err)
 	require.NotNil(tb, ps)
 	require.NoError(tb, ps.Start(postOpts))
@@ -83,10 +83,6 @@ func launchPostSupervisorTLS(
 	id := sig.NodeID()
 	goldenATXID := types.RandomATXID()
 
-	cdb := datastore.NewCachedDB(sql.InMemory(), logtest.New(tb))
-	mgr, err := activation.NewPostSetupManager(id, postCfg, log.Named("post manager"), cdb, goldenATXID)
-	require.NoError(tb, err)
-
 	syncer := activation.NewMocksyncer(gomock.NewController(tb))
 	syncer.EXPECT().RegisterForATXSynced().DoAndReturn(func() <-chan struct{} {
 		ch := make(chan struct{})
@@ -94,7 +90,11 @@ func launchPostSupervisorTLS(
 		return ch
 	})
 
-	ps, err := activation.NewPostSupervisor(log, serviceCfg, postCfg, provingOpts, mgr, syncer)
+	cdb := datastore.NewCachedDB(sql.InMemory(), logtest.New(tb))
+	mgr, err := activation.NewPostSetupManager(id, postCfg, log.Named("post manager"), cdb, goldenATXID, syncer)
+	require.NoError(tb, err)
+
+	ps, err := activation.NewPostSupervisor(log, serviceCfg, postCfg, provingOpts, mgr)
 	require.NoError(tb, err)
 	require.NotNil(tb, ps)
 	require.NoError(tb, ps.Start(postOpts))

--- a/node/node.go
+++ b/node/node.go
@@ -892,7 +892,9 @@ func (app *App) initServices(ctx context.Context) error {
 		app.edSgn.NodeID(),
 		app.Config.POST,
 		app.addLogger(PostLogger, lg).Zap(),
-		app.cachedDB, goldenATXID,
+		app.cachedDB,
+		goldenATXID,
+		newSyncer,
 	)
 	if err != nil {
 		return fmt.Errorf("create post setup manager: %v", err)
@@ -904,7 +906,6 @@ func (app *App) initServices(ctx context.Context) error {
 		app.Config.POST,
 		app.Config.SMESHING.ProvingOpts,
 		postSetupMgr,
-		newSyncer,
 	)
 	if err != nil {
 		return fmt.Errorf("init post service: %w", err)


### PR DESCRIPTION
## Motivation
We need to wait to be ATX-synced before selecting a commitment ATX to select the best possible one.

## Changes
- moved waiting for ATX-synced to the function that finds the best ATX for commitment ATX
- post supervisor doesn't always wait for ATX-synced before it starts post-service

## Test Plan
Existing tests pass
