### PR TITLE
[Merged by Bors] - Add "until" field to PoetWaitRound, PoetWaitProof, AtxPublished events

### DIFF
--- a/activation/activation.go
+++ b/activation/activation.go
@@ -395,7 +395,7 @@ func (b *Builder) buildNIPostChallenge(ctx context.Context) (*types.NIPostChalle
 			zap.Uint32("current epoch", current.Uint32()),
 			zap.Duration("wait", time.Until(wait)),
 		)
-		events.EmitPoetWaitRound(current, current+1, time.Until(wait))
+		events.EmitPoetWaitRound(current, current+1, wait)
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
@@ -504,7 +504,7 @@ func (b *Builder) PublishActivationTx(ctx context.Context) error {
 	events.EmitAtxPublished(
 		atx.PublishEpoch, atx.TargetEpoch(),
 		atx.ID(),
-		time.Until(b.layerClock.LayerToTime(atx.TargetEpoch().FirstLayer())),
+		b.layerClock.LayerToTime(atx.TargetEpoch().FirstLayer()),
 	)
 	return nil
 }

--- a/activation/nipost.go
+++ b/activation/nipost.go
@@ -250,7 +250,7 @@ func (nb *NIPostBuilder) BuildNIPost(
 			)
 		}
 
-		events.EmitPoetWaitProof(challenge.PublishEpoch, challenge.TargetEpoch(), time.Until(poetRoundEnd))
+		events.EmitPoetWaitProof(challenge.PublishEpoch, challenge.TargetEpoch(), poetRoundEnd)
 		poetProofRef, membership, err = nb.getBestProof(ctx, challenge.Hash(), challenge.PublishEpoch)
 		if err != nil {
 			return nil, &PoetSvcUnstableError{msg: "getBestProof failed", source: err}

--- a/events/events.go
+++ b/events/events.go
@@ -70,7 +70,7 @@ func EmitInitComplete() {
 	)
 }
 
-func EmitPoetWaitRound(current, publish types.EpochID, wait time.Duration) {
+func EmitPoetWaitRound(current, publish types.EpochID, wait time.Time) {
 	const help = "Node is waiting for PoET registration window in current epoch to open. " +
 		"After this it will submit challenge and wait until PoET round ends in publish epoch."
 	emitUserEvent(
@@ -79,7 +79,8 @@ func EmitPoetWaitRound(current, publish types.EpochID, wait time.Duration) {
 		&pb.Event_PoetWaitRound{PoetWaitRound: &pb.EventPoetWaitRound{
 			Current: current.Uint32(),
 			Publish: publish.Uint32(),
-			Wait:    durationpb.New(wait),
+			Wait:    durationpb.New(time.Until(wait)),
+			Until:   timestamppb.New(wait),
 		}},
 	)
 }
@@ -90,7 +91,7 @@ type EventPoetWaitEnd struct {
 	Wait    time.Duration `json:"wait"`
 }
 
-func EmitPoetWaitProof(publish, target types.EpochID, wait time.Duration) {
+func EmitPoetWaitProof(publish, target types.EpochID, wait time.Time) {
 	const help = "Node is waiting for PoET to complete. " +
 		"After it's complete, the node will fetch the PoET proof, generate a PoST proof, " +
 		"and finally publish an ATX to establish eligibility for rewards in the target epoch."
@@ -101,7 +102,8 @@ func EmitPoetWaitProof(publish, target types.EpochID, wait time.Duration) {
 			PoetWaitProof: &pb.EventPoetWaitProof{
 				Publish: publish.Uint32(),
 				Target:  target.Uint32(),
-				Wait:    durationpb.New(wait),
+				Wait:    durationpb.New(time.Until(wait)),
+				Until:   timestamppb.New(wait),
 			},
 		},
 	)
@@ -164,7 +166,7 @@ func EmitInvalidPostProof() {
 func EmitAtxPublished(
 	current, target types.EpochID,
 	id types.ATXID,
-	wait time.Duration,
+	wait time.Time,
 ) {
 	const help = "Node published activation for the current epoch. " +
 		"It now needs to wait until the target epoch when it will be eligible for rewards."
@@ -176,7 +178,8 @@ func EmitAtxPublished(
 				Current: current.Uint32(),
 				Target:  target.Uint32(),
 				Id:      id[:],
-				Wait:    durationpb.New(wait),
+				Wait:    durationpb.New(time.Until(wait)),
+				Until:   timestamppb.New(wait),
 			},
 		},
 	)

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/quic-go/quic-go v0.41.0
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/seehuhn/mt19937 v1.0.0
-	github.com/spacemeshos/api/release/go v1.25.0
+	github.com/spacemeshos/api/release/go v1.26.0
 	github.com/spacemeshos/economics v0.1.2
 	github.com/spacemeshos/fixed v0.1.1
 	github.com/spacemeshos/go-scale v1.1.12

--- a/go.sum
+++ b/go.sum
@@ -616,8 +616,8 @@ github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d/go.mod h1:Udh
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
-github.com/spacemeshos/api/release/go v1.25.0 h1:HqIykavooxUxZySiN7yiILRX+Kx6WxM1NF6w72PNmMc=
-github.com/spacemeshos/api/release/go v1.25.0/go.mod h1:Ffvt8Zl5K6k0In0OF7PUJ2JoxrW8zBRXKF1kG0abigg=
+github.com/spacemeshos/api/release/go v1.26.0 h1:wop4OoID/2o8BEwNP/wypCIy//CDTnv14perIZo0WOU=
+github.com/spacemeshos/api/release/go v1.26.0/go.mod h1:cQXfRiIRPc8c6bh9+VAK/GwD0zYCu7jKcos/cPaDYcI=
 github.com/spacemeshos/economics v0.1.2 h1:kw8cE5SMa/7svHOGorCd2w8ef1y8iP0p47/2VDOK8Ns=
 github.com/spacemeshos/economics v0.1.2/go.mod h1:ngeWn5E/jy9dJP1MHyuk3ehF8NBMTYhchqVDhAHUUNk=
 github.com/spacemeshos/fixed v0.1.1 h1:N1y4SUpq1EV+IdJrWJwUCt1oBFzeru/VKVcBsvPc2Fk=


### PR DESCRIPTION
## Motivation
Many people currently use the gRPC AdminService's EventStream for simple go-spacemesh monitoring. This PR adds an "until" field to the PoetWaitRound, PoetWaitProof and AtxPublished events to make it a bit easier to see until when the node will wait after those events ([related recent discussion in Discord](https://discord.com/channels/623195163510046732/691262184050786305/1194552731378122782)).

Example events after this change:

```json
  "poetWaitRound": {
    "current": 12,                                        
    "publish": 13,                                        
    "wait": "29238.819235612s",
    "until": "2024-01-09T07:00:21.151608967Z"
  }

  "poetWaitProof": {
    "publish": 13,
    "target": 14,
    "wait": "987972.244983544s",
    "until": "2024-01-20T20:00:00.000003843Z"
  }
  
  "atxPublished": {                                                                                                  
    "current": 12,                                                                                                   
    "target": 13,
    "id": "...", 
    "wait": "292017.668117248s",               
    "until": "2024-01-12T08:00:00.000001993Z"
  }
```

## Changes
Set the `until` field in the PoetWaitRound, PoetWaitProof, AtxPublished event.

This change depends on https://github.com/spacemeshos/api/pull/297. ~~Updates to go.mod/go.sum are pending until a new tagged version of `api`.~~

## Test Plan
Manual testing

## TODO
<!-- This section should be removed when all items are complete -->
- [X] Explain motivation or link existing issue(s)
- [X] Test changes and document test plan
- [ ] Update documentation as needed
- [ ] Update [changelog](../CHANGELOG.md) as needed
