### PR TITLE
Backport #5424: increase limits for ATX broadcast and caches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ See [RELEASE](./RELEASE.md) for workflow instructions.
 * [#5419](https://github.com/spacemeshos/go-spacemesh/pull/5419) Fixed `0.0.0.0` not being a valid listen address for
   `grpc-private-listener`.
 
+* [#5424](https://github.com/spacemeshos/go-spacemesh/pull/5424) Further increased limits for message sizes and caches
+  to compensate for the increased number of nodes on the network.
+
 ## Release v1.3
 
 ### Upgrade information

--- a/datastore/store.go
+++ b/datastore/store.go
@@ -52,7 +52,7 @@ type Config struct {
 
 func DefaultConfig() Config {
 	return Config{
-		ATXSize:         600_000,
+		ATXSize:         1_000_000, // to be in line with fetch.EpochData size (see fetch/wire_types.go)
 		MalfeasanceSize: 1_000,
 	}
 }

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -124,7 +124,7 @@ func DefaultConfig() Config {
 	return Config{
 		BatchTimeout:         50 * time.Millisecond,
 		QueueSize:            20,
-		BatchSize:            20,
+		BatchSize:            10,
 		RequestTimeout:       25 * time.Second,
 		MaxRetriesForRequest: 100,
 		ServersConfig: map[string]ServerConfig{

--- a/fetch/handler.go
+++ b/fetch/handler.go
@@ -77,7 +77,8 @@ func (h *handler) handleEpochInfoReq(ctx context.Context, msg []byte) ([]byte, e
 	}
 	h.logger.WithContext(ctx).With().Debug("serve: responded to epoch info request",
 		epoch,
-		log.Int("atx_count", len(ed.AtxIDs)))
+		log.Int("atx_count", len(ed.AtxIDs)),
+	)
 	bts, err := codec.Encode(&ed)
 	if err != nil {
 		h.logger.WithContext(ctx).With().Fatal("serve: failed to serialize epoch atx", epoch, log.Err(err))

--- a/fetch/wire_types.go
+++ b/fetch/wire_types.go
@@ -28,16 +28,16 @@ type ResponseMessage struct {
 // RequestBatch is a batch of requests and a hash of all requests as ID.
 type RequestBatch struct {
 	ID types.Hash32
-	// depends on fetch config `BatchSize` which defaults to 20, more than 1000 seems unlikely
-	Requests []RequestMessage `scale:"max=1000"`
+	// depends on fetch config `BatchSize` which defaults to 10, more than 100 seems unlikely
+	Requests []RequestMessage `scale:"max=100"`
 }
 
 // ResponseBatch is the response struct send for a RequestBatch. the ResponseBatch ID must be the same
 // as stated in RequestBatch even if not all Data is present.
 type ResponseBatch struct {
 	ID types.Hash32
-	// depends on fetch config `BatchSize` which defaults to 20, more than 1000 seems unlikely
-	Responses []ResponseMessage `scale:"max=1000"`
+	// depends on fetch config `BatchSize` which defaults to 10, more than 100 seems unlikely
+	Responses []ResponseMessage `scale:"max=100"`
 }
 
 // MeshHashRequest is used by ForkFinder to request the hashes of layers from
@@ -105,7 +105,7 @@ type MaliciousIDs struct {
 }
 
 type EpochData struct {
-	AtxIDs []types.ATXID `scale:"max=500000"` // for epoch 12 > 300k ATXs are expected, added some safety margin
+	AtxIDs []types.ATXID `scale:"max=1000000"` // for epoch 13 > 800k ATXs are expected, added some safety margin
 }
 
 // LayerData is the data response for a given layer ID.

--- a/fetch/wire_types_scale.go
+++ b/fetch/wire_types_scale.go
@@ -92,7 +92,7 @@ func (t *RequestBatch) EncodeScale(enc *scale.Encoder) (total int, err error) {
 		total += n
 	}
 	{
-		n, err := scale.EncodeStructSliceWithLimit(enc, t.Requests, 1000)
+		n, err := scale.EncodeStructSliceWithLimit(enc, t.Requests, 100)
 		if err != nil {
 			return total, err
 		}
@@ -110,7 +110,7 @@ func (t *RequestBatch) DecodeScale(dec *scale.Decoder) (total int, err error) {
 		total += n
 	}
 	{
-		field, n, err := scale.DecodeStructSliceWithLimit[RequestMessage](dec, 1000)
+		field, n, err := scale.DecodeStructSliceWithLimit[RequestMessage](dec, 100)
 		if err != nil {
 			return total, err
 		}
@@ -129,7 +129,7 @@ func (t *ResponseBatch) EncodeScale(enc *scale.Encoder) (total int, err error) {
 		total += n
 	}
 	{
-		n, err := scale.EncodeStructSliceWithLimit(enc, t.Responses, 1000)
+		n, err := scale.EncodeStructSliceWithLimit(enc, t.Responses, 100)
 		if err != nil {
 			return total, err
 		}
@@ -147,7 +147,7 @@ func (t *ResponseBatch) DecodeScale(dec *scale.Decoder) (total int, err error) {
 		total += n
 	}
 	{
-		field, n, err := scale.DecodeStructSliceWithLimit[ResponseMessage](dec, 1000)
+		field, n, err := scale.DecodeStructSliceWithLimit[ResponseMessage](dec, 100)
 		if err != nil {
 			return total, err
 		}
@@ -258,7 +258,7 @@ func (t *MaliciousIDs) DecodeScale(dec *scale.Decoder) (total int, err error) {
 
 func (t *EpochData) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	{
-		n, err := scale.EncodeStructSliceWithLimit(enc, t.AtxIDs, 500000)
+		n, err := scale.EncodeStructSliceWithLimit(enc, t.AtxIDs, 1000000)
 		if err != nil {
 			return total, err
 		}
@@ -269,7 +269,7 @@ func (t *EpochData) EncodeScale(enc *scale.Encoder) (total int, err error) {
 
 func (t *EpochData) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	{
-		field, n, err := scale.DecodeStructSliceWithLimit[types.ATXID](dec, 500000)
+		field, n, err := scale.DecodeStructSliceWithLimit[types.ATXID](dec, 1000000)
 		if err != nil {
 			return total, err
 		}


### PR DESCRIPTION
## Motivation
Backports #5424 for `v1.3`

## Changes
- see #5424 
- update CHANGELOG.md

## Test Plan
n/a

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
