### PR TITLE
[Merged by Bors] - Fix TestSyncSimulateMultiple

### DIFF
--- a/timesync/peersync/sync_test.go
+++ b/timesync/peersync/sync_test.go
@@ -2,6 +2,7 @@ package peersync
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -143,15 +144,19 @@ func TestSyncSimulateMultiple(t *testing.T) {
 	}
 	require.NoError(t, mesh.ConnectAllButSelf())
 
+	// First create all instances so they register in the protocol
+	// and then start them.
 	for i, delay := range delays {
 		sync := New(hosts[i], hosts[i],
 			WithConfig(config),
 			WithTime(delayedTime(delay)),
-			WithLog(logtest.New(t).Named(hosts[i].ID().String())),
+			WithLog(logtest.New(t).Named(fmt.Sprintf("%d-%s", i, hosts[i].ID()))),
 		)
+		instances = append(instances, sync)
+	}
+	for _, sync := range instances {
 		sync.Start()
 		t.Cleanup(sync.Stop)
-		instances = append(instances, sync)
 	}
 	for i, inst := range instances {
 		if errors[i] == nil {


### PR DESCRIPTION
## Motivation
The test was flaky because the instances were created in a loop and started immediately. The test would fail if any goroutine called in `sync.Start()` started before other peers registered in the protocol.

## Changes
Create all peers first (so they register in the protocol) and then start them.

## Test Plan
Passed 10k test runs.