### PR TITLE
Hotfix panic on activeset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 See [RELEASE](./RELEASE.md) for workflow instructions.
 
+## Release v1.3.2
+
+### Improvements
+
+* [#5432](https://github.com/spacemeshos/go-spacemesh/pull/5419) Fixed a possible race that is caused by a node
+  processing the same bootstrapped active set twice.
+
 ## Release v1.3.1
 
 ### Improvements

--- a/node/node.go
+++ b/node/node.go
@@ -101,6 +101,7 @@ const (
 	PoetDbLogger           = "poetDb"
 	TrtlLogger             = "trtl"
 	ATXHandlerLogger       = "atxHandler"
+	ATXBuilderLogger       = "atxBuilder"
 	MeshLogger             = "mesh"
 	SyncLogger             = "sync"
 	HareOracleLogger       = "hareOracle"
@@ -359,6 +360,7 @@ type App struct {
 	edVerifier        *signing.EdVerifier
 	beaconProtocol    *beacon.ProtocolDriver
 	log               log.Log
+	syncLogger        log.Log
 	svm               *vm.VM
 	conState          *txs.ConservativeState
 	fetcher           *fetch.Fetch
@@ -507,6 +509,10 @@ func (app *App) Cleanup(ctx context.Context) {
 // Wrap the top-level logger to add context info and set the level for a
 // specific module.
 func (app *App) addLogger(name string, logger log.Log) log.Log {
+	// TODO(mafa): this method is not safe to be called concurrently, as it will create a new logger every time
+	// calling it with the same name twice will create two loggers with the same name (instead of returning the
+	// existing one)
+
 	lvl := zap.NewAtomicLevel()
 	loggers, err := decodeLoggers(app.Config.LOGGING)
 	if err != nil {
@@ -802,6 +808,8 @@ func (app *App) initServices(ctx context.Context) error {
 	syncerConf.HareDelayLayers = app.Config.Tortoise.Zdist
 	syncerConf.SyncCertDistance = app.Config.Tortoise.Hdist
 	syncerConf.Standalone = app.Config.Standalone
+
+	app.syncLogger = app.addLogger(SyncLogger, lg)
 	newSyncer := syncer.NewSyncer(
 		app.cachedDB,
 		app.clock,
@@ -812,7 +820,7 @@ func (app *App) initServices(ctx context.Context) error {
 		patrol,
 		app.certifier,
 		syncer.WithConfig(syncerConf),
-		syncer.WithLogger(app.addLogger(SyncLogger, lg)),
+		syncer.WithLogger(app.syncLogger),
 	)
 	// TODO(dshulyak) this needs to be improved, but dependency graph is a bit complicated
 	beaconProtocol.SetSyncState(newSyncer)
@@ -939,7 +947,7 @@ func (app *App) initServices(ctx context.Context) error {
 		nipostBuilder,
 		app.clock,
 		newSyncer,
-		app.addLogger("atxBuilder", lg).Zap(),
+		app.addLogger(ATXBuilderLogger, lg).Zap(),
 		activation.WithContext(ctx),
 		activation.WithPoetConfig(app.Config.POET),
 		// TODO(dshulyak) makes no sense. how we ended using it?
@@ -1189,7 +1197,7 @@ func (app *App) listenToUpdates(ctx context.Context) {
 						if err := atxsync.Download(
 							ctx,
 							10*time.Second,
-							app.addLogger(SyncLogger, app.log).Zap(),
+							app.syncLogger.Zap(),
 							app.db,
 							app.fetcher,
 							set,


### PR DESCRIPTION
## Motivation
This change fixes a possible panic when a node downloads an activeset via bootstrapper and is slow to process it (thereby processing it twice and causing a race)

## Changes
- Instead of instantiating the logger twice, instantiate it once during startup and re-use it for every update that is processed
- Proper fix would be to prevent an update from being processed more than once in the first place and making `addLogger` in `node.go` concurrency safe/return an existing logger if it has already been called for the given name.

## Test Plan
n/a

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
