### PR TITLE
[Merged by Bors] - Fix race on bootstrap activeset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,23 @@ configuration is as follows:
 
 ### Improvements
 
+## Release v1.3.2
+
+### Improvements
+
+* [#5432](https://github.com/spacemeshos/go-spacemesh/pull/5419) Fixed a possible race that is caused by a node
+  processing the same bootstrapped active set twice.
+
+## Release v1.3.1
+
+### Improvements
+
+* [#5419](https://github.com/spacemeshos/go-spacemesh/pull/5419) Fixed `0.0.0.0` not being a valid listen address for
+  `grpc-private-listener`.
+
+* [#5424](https://github.com/spacemeshos/go-spacemesh/pull/5424) Further increased limits for message sizes and caches
+  to compensate for the increased number of nodes on the network.
+
 ## Release v1.3
 
 ### Upgrade information

--- a/node/node.go
+++ b/node/node.go
@@ -508,12 +508,11 @@ func (app *App) Cleanup(ctx context.Context) {
 }
 
 // Wrap the top-level logger to add context info and set the level for a
-// specific module.
+// specific module. Calling this method and will create a new logger every time
+// and not re-use an existing logger with the same name.
+//
+// This method is not safe to be called concurrently.
 func (app *App) addLogger(name string, logger log.Log) log.Log {
-	// TODO(mafa): this method is not safe to be called concurrently, as it will create a new logger every time
-	// calling it with the same name twice will create two loggers with the same name (instead of returning the
-	// existing one)
-
 	lvl := zap.NewAtomicLevel()
 	loggers, err := decodeLoggers(app.Config.LOGGING)
 	if err != nil {


### PR DESCRIPTION
## Motivation
This ports the hotfix #5432 for `v1.3.1` to `develop`.

New nodes will download all existing activesets (right now one for Epoch 12 and one for Epoch 13) and causing them to call `addLogger` concurrently. The method is not safe to be called from multiple go-routines.

## Changes
- Prevent a possible race in `addLogger` by not calling it every time a new activeset is found

## Test Plan
n/a

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
