### PR TITLE
Disable DHT values and providers by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,7 @@ In order to make the p2p network more decentralized, the following options are p
   also for discovering relay nodes which are used for NAT hole punching. Note that hole punching can be done when both
   ends of the connection are behind an endpoint-independent ("cone") NAT.
 - `"routing-discovery-advertise": true` advertises this node for discovery by other peers, even if it is behind NAT.
+- `"routing-discovery-propagate": true` enables "values" and "providers" DHT features which are required to propagate routing discovery info through KAD.
 - `"enable-quic-transport": true`: enables QUIC transport which, together with TCP transport, heightens the changes of
   successful NAT hole punching.
 - `"enable-tcp-transport": false` disables TCP transport. This option is intended to be used for debugging purposes

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -141,6 +141,8 @@ func AddCommands(cmd *cobra.Command) {
 		"enable routing discovery")
 	cmd.PersistentFlags().BoolVar(&cfg.P2P.RoutingDiscoveryAdvertise, "routing-discovery-advertise",
 		cfg.P2P.RoutingDiscoveryAdvertise, "advertise for routing discovery")
+	cmd.PersistentFlags().BoolVar(&cfg.P2P.RoutingDiscoveryPropagate, "routing-discovery-propagate",
+		cfg.P2P.RoutingDiscoveryPropagate, "propagate routing discovery info through DHT")
 
 	/** ======================== TIME Flags ========================== **/
 

--- a/p2p/host.go
+++ b/p2p/host.go
@@ -143,6 +143,7 @@ type Config struct {
 	EnableQUICTransport         bool          `mapstructure:"enable-quic-transport"`
 	EnableRoutingDiscovery      bool          `mapstructure:"enable-routing-discovery"`
 	RoutingDiscoveryAdvertise   bool          `mapstructure:"routing-discovery-advertise"`
+	RoutingDiscoveryPropagate   bool          `mapstructure:"routing-discovery-propagate"`
 	AdvertiseInterval           time.Duration `mapstructure:"advertise-interval"`
 }
 

--- a/p2p/upgrade.go
+++ b/p2p/upgrade.go
@@ -179,11 +179,27 @@ func Upgrade(h host.Host, opts ...Opt) (*Host, error) {
 	if fh.relayCh != nil {
 		dopts = append(dopts, discovery.WithRelayCandidateChannel(fh.relayCh))
 	}
-	if fh.cfg.EnableRoutingDiscovery {
-		dopts = append(dopts, discovery.EnableRoutingDiscovery())
+	if fh.cfg.RoutingDiscoveryPropagate {
+		dopts = append(dopts, discovery.RoutingDiscoveryPropagate())
 	}
+	if fh.cfg.EnableRoutingDiscovery {
+		if fh.cfg.RoutingDiscoveryPropagate {
+			dopts = append(dopts, discovery.EnableRoutingDiscovery())
+		} else {
+			fh.logger.With().Warning(
+				"can't set enable-routing-discovery without routing-discovery-propagate",
+				log.Err(err))
+		}
+	}
+
 	if fh.cfg.RoutingDiscoveryAdvertise {
-		dopts = append(dopts, discovery.AdvertiseForPeerDiscovery())
+		if fh.cfg.RoutingDiscoveryPropagate {
+			dopts = append(dopts, discovery.AdvertiseForPeerDiscovery())
+		} else {
+			fh.logger.With().Warning(
+				"can't set enable-routing-discovery without routing-discovery-propagate",
+				log.Err(err))
+		}
 	}
 
 	dhtdisc, err := discovery.New(fh, dopts...)


### PR DESCRIPTION
Will need to be enabled explicitly via `routing-discovery-propagate` p2p config option

## Motivation
Mitigation of excess DHT traffic due to spammy routing discovery propagation

## Changes
DHT values and providers feature needs to be enabled explicitly via `routing-discovery-propagate` option

## Test Plan
Tested using a mainnet node

