### PR TITLE
[Merged by Bors] - p2p: set default advertise-interval to 1h instead of 1m

### DIFF
--- a/p2p/host.go
+++ b/p2p/host.go
@@ -89,7 +89,7 @@ func DefaultConfig() Config {
 		PingInterval:                time.Second,
 		EnableTCPTransport:          true,
 		EnableQUICTransport:         false,
-		AdvertiseInterval:           time.Minute,
+		AdvertiseInterval:           time.Hour,
 	}
 }
 


### PR DESCRIPTION
Reduce spamminess of routing discovery advertisement

## Motivation
Sending out routing discovery advertisement every minute turned out to be causing a lot of DHT traffic

## Changes
Set default advertise-interval to 1h instead of 1m
