### PR TITLE
[Merged by Bors] - Fix possible nil-pointer dereference in blocks.Generator

### DIFF
--- a/blocks/generator_test.go
+++ b/blocks/generator_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/spacemeshos/go-spacemesh/activation"
 	"github.com/spacemeshos/go-spacemesh/atxsdata"
@@ -263,26 +262,6 @@ func Test_StartStop(t *testing.T) {
 func Test_StopBeforeStart(t *testing.T) {
 	tg := createTestGenerator(t)
 	tg.Stop()
-}
-
-func Test_NoRaceStartStop(t *testing.T) {
-	tg := createTestGenerator(t)
-	var eg errgroup.Group
-
-	eg.Go(func() error {
-		for i := 0; i < 1000; i++ {
-			tg.Start(context.Background())
-		}
-		return nil
-	})
-	eg.Go(func() error {
-		for i := 0; i < 1000; i++ {
-			tg.Stop()
-		}
-		return nil
-	})
-
-	require.NoError(t, eg.Wait())
 }
 
 func genData(


### PR DESCRIPTION
## Motivation
Closes #5440

## Changes
Ensure that calling `Stop` is always safe, even if `Start` has not been called before.

## Test Plan
- Added tests to check if stop is always safe to be called.

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
