### PR TITLE
[Merged by Bors] - Limit concurrent gethash in getatxs

### DIFF
--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -18,7 +18,6 @@ import (
 	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/p2p"
 	"github.com/spacemeshos/go-spacemesh/p2p/server"
-	"github.com/spacemeshos/go-spacemesh/system"
 )
 
 const (
@@ -219,8 +218,6 @@ type Fetch struct {
 // NewFetch creates a new Fetch struct.
 func NewFetch(
 	cdb *datastore.CachedDB,
-	msh meshProvider,
-	b system.BeaconGetter,
 	host *p2p.Host,
 	opts ...Option,
 ) *Fetch {
@@ -266,7 +263,7 @@ func NewFetch(
 
 	f.batchTimeout = time.NewTicker(f.cfg.BatchTimeout)
 	if len(f.servers) == 0 {
-		h := newHandler(cdb, bs, msh, b, f.logger)
+		h := newHandler(cdb, bs, f.logger)
 		f.registerServer(host, atxProtocol, h.handleEpochInfoReq)
 		f.registerServer(host, lyrDataProtocol, h.handleLayerDataReq)
 		f.registerServer(host, hashProtocol, h.handleHashReq)

--- a/fetch/fetch_test.go
+++ b/fetch/fetch_test.go
@@ -33,7 +33,6 @@ type testFetch struct {
 	mMHashS *mocks.Mockrequester
 	mOpn2S  *mocks.Mockrequester
 
-	mMesh        *mocks.MockmeshProvider
 	mMalH        *mocks.MockSyncValidator
 	mAtxH        *mocks.MockSyncValidator
 	mBallotH     *mocks.MockSyncValidator
@@ -78,7 +77,7 @@ func createFetch(tb testing.TB) *testFetch {
 	}
 	lg := logtest.New(tb)
 
-	tf.Fetch = NewFetch(datastore.NewCachedDB(sql.InMemory(), lg), tf.mMesh, nil, nil,
+	tf.Fetch = NewFetch(datastore.NewCachedDB(sql.InMemory(), lg), nil,
 		WithContext(context.TODO()),
 		WithConfig(cfg),
 		WithLogger(lg),
@@ -115,7 +114,7 @@ func badReceiver(context.Context, types.Hash32, p2p.Peer, []byte) error {
 
 func TestFetch_Start(t *testing.T) {
 	lg := logtest.New(t)
-	f := NewFetch(datastore.NewCachedDB(sql.InMemory(), lg), nil, nil, nil,
+	f := NewFetch(datastore.NewCachedDB(sql.InMemory(), lg), nil,
 		WithContext(context.TODO()),
 		WithConfig(DefaultConfig()),
 		WithLogger(lg),
@@ -276,7 +275,7 @@ func TestFetch_Loop_BatchRequestMax(t *testing.T) {
 				return nil
 			}).
 		Times(2)
-		// 3 requests with batch size 2 -> 2 sends
+	// 3 requests with batch size 2 -> 2 sends
 
 	hint := datastore.POETDB
 
@@ -385,7 +384,7 @@ func TestFetch_PeerDroppedWhenMessageResultsInValidationReject(t *testing.T) {
 	})
 	defer eg.Wait()
 
-	fetcher := NewFetch(datastore.NewCachedDB(sql.InMemory(), lg), nil, nil, h,
+	fetcher := NewFetch(datastore.NewCachedDB(sql.InMemory(), lg), h,
 		WithContext(ctx),
 		WithConfig(cfg),
 		WithLogger(lg),

--- a/fetch/fetch_test.go
+++ b/fetch/fetch_test.go
@@ -74,6 +74,7 @@ func createFetch(tb testing.TB) *testFetch {
 		QueueSize:            1000,
 		RequestTimeout:       3 * time.Second,
 		MaxRetriesForRequest: 3,
+		GetAtxsConcurrency:   DefaultConfig().GetAtxsConcurrency,
 	}
 	lg := logtest.New(tb)
 

--- a/fetch/handler.go
+++ b/fetch/handler.go
@@ -14,30 +14,23 @@ import (
 	"github.com/spacemeshos/go-spacemesh/sql/certificates"
 	"github.com/spacemeshos/go-spacemesh/sql/identities"
 	"github.com/spacemeshos/go-spacemesh/sql/layers"
-	"github.com/spacemeshos/go-spacemesh/system"
 )
 
 type handler struct {
 	logger log.Log
 	cdb    *datastore.CachedDB
 	bs     *datastore.BlobStore
-	msh    meshProvider
-	beacon system.BeaconGetter
 }
 
 func newHandler(
 	cdb *datastore.CachedDB,
 	bs *datastore.BlobStore,
-	m meshProvider,
-	b system.BeaconGetter,
 	lg log.Log,
 ) *handler {
 	return &handler{
 		logger: lg,
 		cdb:    cdb,
 		bs:     bs,
-		msh:    m,
-		beacon: b,
 	}
 }
 

--- a/fetch/handler_test.go
+++ b/fetch/handler_test.go
@@ -6,13 +6,11 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"go.uber.org/mock/gomock"
 
 	"github.com/spacemeshos/go-spacemesh/activation"
 	"github.com/spacemeshos/go-spacemesh/codec"
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/datastore"
-	"github.com/spacemeshos/go-spacemesh/fetch/mocks"
 	"github.com/spacemeshos/go-spacemesh/log/logtest"
 	"github.com/spacemeshos/go-spacemesh/signing"
 	"github.com/spacemeshos/go-spacemesh/sql"
@@ -22,27 +20,19 @@ import (
 	"github.com/spacemeshos/go-spacemesh/sql/certificates"
 	"github.com/spacemeshos/go-spacemesh/sql/identities"
 	"github.com/spacemeshos/go-spacemesh/sql/layers"
-	smocks "github.com/spacemeshos/go-spacemesh/system/mocks"
 )
 
 type testHandler struct {
 	*handler
 	cdb *datastore.CachedDB
-	mm  *mocks.MockmeshProvider
-	mb  *smocks.MockBeaconGetter
 }
 
 func createTestHandler(t testing.TB) *testHandler {
 	lg := logtest.New(t)
 	cdb := datastore.NewCachedDB(sql.InMemory(), lg)
-	ctrl := gomock.NewController(t)
-	mm := mocks.NewMockmeshProvider(ctrl)
-	mb := smocks.NewMockBeaconGetter(ctrl)
 	return &testHandler{
-		handler: newHandler(cdb, datastore.NewBlobStore(cdb.Database), mm, mb, lg),
+		handler: newHandler(cdb, datastore.NewBlobStore(cdb.Database), lg),
 		cdb:     cdb,
-		mm:      mm,
-		mb:      mb,
 	}
 }
 

--- a/fetch/interface.go
+++ b/fetch/interface.go
@@ -40,10 +40,6 @@ type PoetValidator interface {
 	ValidateAndStoreMsg(context.Context, types.Hash32, p2p.Peer, []byte) error
 }
 
-type meshProvider interface {
-	LastVerified() types.LayerID
-}
-
 type host interface {
 	ID() p2p.Peer
 }

--- a/fetch/limiter.go
+++ b/fetch/limiter.go
@@ -1,0 +1,20 @@
+package fetch
+
+import (
+	"context"
+)
+
+type limiter interface {
+	Acquire(ctx context.Context, n int64) error
+	Release(n int64)
+}
+
+type getHashesOpts struct {
+	limiter limiter
+}
+
+type noLimit struct{}
+
+func (noLimit) Acquire(context.Context, int64) error { return nil }
+
+func (noLimit) Release(int64) {}

--- a/fetch/mesh_data.go
+++ b/fetch/mesh_data.go
@@ -26,7 +26,7 @@ func (f *Fetch) GetAtxs(ctx context.Context, ids []types.ATXID) error {
 	}
 	f.logger.WithContext(ctx).With().Debug("requesting atxs from peer", log.Int("num_atxs", len(ids)))
 	hashes := types.ATXIDsToHashes(ids)
-	//TODO(poszu): use limit from config?
+	// TODO(poszu): use limit from config?
 	limiter := semaphore.NewWeighted(100)
 	return f.getHashes(ctx, hashes, datastore.ATXDB, f.validators.atx.HandleMessage, withLimiter(limiter))
 }

--- a/fetch/mesh_data.go
+++ b/fetch/mesh_data.go
@@ -60,6 +60,7 @@ func (f *Fetch) getHashes(
 	var mu sync.Mutex
 	for i, hash := range hashes {
 		if err := options.limiter.Acquire(ctx, 1); err != nil {
+			pendingMetric.Add(float64(i - len(hashes)))
 			return fmt.Errorf("acquiring slot to get hash: %w", err)
 		}
 		p, err := f.getHash(ctx, hash, hint, receiver)

--- a/fetch/mesh_data_test.go
+++ b/fetch/mesh_data_test.go
@@ -7,6 +7,8 @@ import (
 	"sync"
 	"testing"
 
+	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 	"golang.org/x/sync/errgroup"
@@ -15,9 +17,13 @@ import (
 	"github.com/spacemeshos/go-spacemesh/codec"
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/datastore"
+	"github.com/spacemeshos/go-spacemesh/fetch/mocks"
 	"github.com/spacemeshos/go-spacemesh/genvm/sdk/wallet"
+	"github.com/spacemeshos/go-spacemesh/log/logtest"
 	"github.com/spacemeshos/go-spacemesh/p2p"
+	"github.com/spacemeshos/go-spacemesh/p2p/server"
 	"github.com/spacemeshos/go-spacemesh/signing"
+	"github.com/spacemeshos/go-spacemesh/sql"
 )
 
 const (
@@ -790,6 +796,80 @@ func TestFetch_GetCert(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Test if GetAtxs() limits the number of concurrent requests to `cfg.GetAtxsConcurrency`
+func Test_GetAtxsLimiting(t *testing.T) {
+	mesh, err := mocknet.FullMeshConnected(2)
+	require.NoError(t, err)
+
+	const (
+		totalRequests     = 100
+		getAtxConcurrency = 10
+	)
+
+	srv := server.New(
+		mesh.Hosts()[1],
+		hashProtocol,
+		func(_ context.Context, data []byte) ([]byte, error) {
+			var requestBatch RequestBatch
+			require.NoError(t, codec.Decode(data, &requestBatch))
+			resBatch := ResponseBatch{
+				ID: requestBatch.ID,
+			}
+			require.Len(t, requestBatch.Requests, getAtxConcurrency)
+			for _, r := range requestBatch.Requests {
+				resBatch.Responses = append(resBatch.Responses, ResponseMessage{Hash: r.Hash})
+			}
+			response, err := codec.Encode(&resBatch)
+			require.NoError(t, err)
+			return response, nil
+		},
+	)
+
+	var (
+		eg          errgroup.Group
+		ctx, cancel = context.WithCancel(context.Background())
+	)
+	defer cancel()
+	eg.Go(func() error {
+		return srv.Run(ctx)
+	})
+	t.Cleanup(func() {
+		assert.NoError(t, eg.Wait())
+	})
+
+	cfg := DefaultConfig()
+	// should do only `cfg.GetAtxsConcurrency` requests at a time even though batch size is 1000
+	cfg.BatchSize = 1000
+	cfg.GetAtxsConcurrency = getAtxConcurrency
+
+	cdb := datastore.NewCachedDB(sql.InMemory(), logtest.New(t))
+	client := server.New(mesh.Hosts()[0], hashProtocol, nil)
+	host, err := p2p.Upgrade(mesh.Hosts()[0])
+	require.NoError(t, err)
+	f := NewFetch(cdb, host,
+		WithContext(context.Background()),
+		withServers(map[string]requester{hashProtocol: client}),
+		WithConfig(cfg),
+	)
+
+	atxValidatorMock := mocks.NewMockSyncValidator(gomock.NewController(t))
+	f.validators = &dataValidators{
+		atx: atxValidatorMock,
+	}
+	require.NoError(t, f.Start())
+	t.Cleanup(f.Stop)
+
+	var atxIds []types.ATXID
+	for i := 0; i < totalRequests; i++ {
+		id := types.RandomATXID()
+		atxIds = append(atxIds, id)
+		atxValidatorMock.EXPECT().HandleMessage(gomock.Any(), id.Hash32(), mesh.Hosts()[1].ID(), gomock.Any())
+	}
+
+	err = f.GetAtxs(context.Background(), atxIds)
+	require.NoError(t, err)
 }
 
 func FuzzCertRequest(f *testing.F) {

--- a/fetch/mesh_data_test.go
+++ b/fetch/mesh_data_test.go
@@ -798,7 +798,7 @@ func TestFetch_GetCert(t *testing.T) {
 	}
 }
 
-// Test if GetAtxs() limits the number of concurrent requests to `cfg.GetAtxsConcurrency`
+// Test if GetAtxs() limits the number of concurrent requests to `cfg.GetAtxsConcurrency`.
 func Test_GetAtxsLimiting(t *testing.T) {
 	mesh, err := mocknet.FullMeshConnected(2)
 	require.NoError(t, err)

--- a/fetch/metrics.go
+++ b/fetch/metrics.go
@@ -30,6 +30,12 @@ var (
 		"total hash requests",
 		[]string{hint})
 
+	pendingHashReqs = metrics.NewGauge(
+		"pending_hash_reqs",
+		subsystem,
+		"pending hash requests",
+		[]string{hint})
+
 	hashMissing = metrics.NewCounter(
 		"hash_missing",
 		subsystem,

--- a/fetch/mocks/mocks.go
+++ b/fetch/mocks/mocks.go
@@ -238,67 +238,6 @@ func (c *PoetValidatorValidateAndStoreMsgCall) DoAndReturn(f func(context.Contex
 	return c
 }
 
-// MockmeshProvider is a mock of meshProvider interface.
-type MockmeshProvider struct {
-	ctrl     *gomock.Controller
-	recorder *MockmeshProviderMockRecorder
-}
-
-// MockmeshProviderMockRecorder is the mock recorder for MockmeshProvider.
-type MockmeshProviderMockRecorder struct {
-	mock *MockmeshProvider
-}
-
-// NewMockmeshProvider creates a new mock instance.
-func NewMockmeshProvider(ctrl *gomock.Controller) *MockmeshProvider {
-	mock := &MockmeshProvider{ctrl: ctrl}
-	mock.recorder = &MockmeshProviderMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockmeshProvider) EXPECT() *MockmeshProviderMockRecorder {
-	return m.recorder
-}
-
-// LastVerified mocks base method.
-func (m *MockmeshProvider) LastVerified() types.LayerID {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LastVerified")
-	ret0, _ := ret[0].(types.LayerID)
-	return ret0
-}
-
-// LastVerified indicates an expected call of LastVerified.
-func (mr *MockmeshProviderMockRecorder) LastVerified() *meshProviderLastVerifiedCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LastVerified", reflect.TypeOf((*MockmeshProvider)(nil).LastVerified))
-	return &meshProviderLastVerifiedCall{Call: call}
-}
-
-// meshProviderLastVerifiedCall wrap *gomock.Call
-type meshProviderLastVerifiedCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *meshProviderLastVerifiedCall) Return(arg0 types.LayerID) *meshProviderLastVerifiedCall {
-	c.Call = c.Call.Return(arg0)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *meshProviderLastVerifiedCall) Do(f func() types.LayerID) *meshProviderLastVerifiedCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *meshProviderLastVerifiedCall) DoAndReturn(f func() types.LayerID) *meshProviderLastVerifiedCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // Mockhost is a mock of host interface.
 type Mockhost struct {
 	ctrl     *gomock.Controller

--- a/node/node.go
+++ b/node/node.go
@@ -789,7 +789,7 @@ func (app *App) initServices(ctx context.Context) error {
 	app.certifier.Register(app.edSgn)
 
 	flog := app.addLogger(Fetcher, lg)
-	fetcher := fetch.NewFetch(app.cachedDB, msh, beaconProtocol, app.host,
+	fetcher := fetch.NewFetch(app.cachedDB, app.host,
 		fetch.WithContext(ctx),
 		fetch.WithConfig(app.Config.FETCH),
 		fetch.WithLogger(flog),


### PR DESCRIPTION
## Motivation
`Fetcher::GetAtxs()` might spawn tens (hundreds) of concurrent _get hash_ requests and all responses will be queued up in the ATX validator callback. There should be some backpressure to avoid querying more ATXs at one time than we can reasonably handle.

## Changes
- use a semaphore as a request limiter to limit the number of concurrent `Fetcher::getHash()` for ATX sync,
- added a _pending hash requests_ gauge metric,
- cleaned up unused stuff in fetcher/handler.go
