### PR TITLE
Backport #5334: Hotfix for API queries for activations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,15 @@ for more information on how to configure the node to work with the PoST service.
   query rewards by smesherID. Additionally, it does not re-index old data. Rewards will contain smesherID going forward,
   but to refresh data for all rewards, a node will have to delete its database and resync from genesis.
 
+
+* [#5334](https://github.com/spacemeshos/go-spacemesh/pull/5334) Hotfix for API queries for activations.
+  Two API endpoints (`MeshService.{AccountMeshDataQuery,LayersQuery}`) were broken because they attempt to read
+  all activation data for an epoch. As the number of activations per epoch has grown, this brute force query (i.e.,
+  without appropriate database indices) became very expensive and could cause the node to hang and consume an enormous
+  amount of resources. This hotfix removes all activation data from these endpoints so that they still work for
+  querying other data. It also modifies `LayersQuery` to not return any _ineffective_ transactions in blocks, since
+  there's currently no way to distinguish between effective and ineffective transactions using the API.
+
 * [#5329](https://github.com/spacemeshos/go-spacemesh/pull/5329) P2P decentralization improvements. Added support for QUIC
   transport and DHT routing discovery for finding peers and relays. Also, added the `ping-peers` feature which is useful
   during connectivity troubleshooting. `static-relays` feature can be used to provide a static list of circuit v2 relays

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 See [RELEASE](./RELEASE.md) for workflow instructions.
 
+## UNRELEASED 
+
+### Improvements
+
+* [#5334](https://github.com/spacemeshos/go-spacemesh/pull/5334) Hotfix for API queries for activations.
+  Two API endpoints (`MeshService.{AccountMeshDataQuery,LayersQuery}`) were broken because they attempt to read
+  all activation data for an epoch. As the number of activations per epoch has grown, this brute force query (i.e.,
+  without appropriate database indices) became very expensive and could cause the node to hang and consume an enormous
+  amount of resources. This hotfix removes all activation data from these endpoints so that they still work for
+  querying other data. It also modifies `LayersQuery` to not return any _ineffective_ transactions in blocks, since
+  there's currently no way to distinguish between effective and ineffective transactions using the API.
+
 ## Release v1.3.2
 
 ### Improvements
@@ -102,15 +114,6 @@ for more information on how to configure the node to work with the PoST service.
   (`GlobalStateService.{AccountDataQuery,AccountDataStream,GlobalStateStream}`), it does not yet expose an endpoint to
   query rewards by smesherID. Additionally, it does not re-index old data. Rewards will contain smesherID going forward,
   but to refresh data for all rewards, a node will have to delete its database and resync from genesis.
-
-
-* [#5334](https://github.com/spacemeshos/go-spacemesh/pull/5334) Hotfix for API queries for activations.
-  Two API endpoints (`MeshService.{AccountMeshDataQuery,LayersQuery}`) were broken because they attempt to read
-  all activation data for an epoch. As the number of activations per epoch has grown, this brute force query (i.e.,
-  without appropriate database indices) became very expensive and could cause the node to hang and consume an enormous
-  amount of resources. This hotfix removes all activation data from these endpoints so that they still work for
-  querying other data. It also modifies `LayersQuery` to not return any _ineffective_ transactions in blocks, since
-  there's currently no way to distinguish between effective and ineffective transactions using the API.
 
 * [#5329](https://github.com/spacemeshos/go-spacemesh/pull/5329) P2P decentralization improvements. Added support for QUIC
   transport and DHT routing discovery for finding peers and relays. Also, added the `ping-peers` feature which is useful

--- a/api/grpcserver/interface.go
+++ b/api/grpcserver/interface.go
@@ -87,6 +87,7 @@ type genesisTimeAPI interface {
 type meshAPI interface {
 	GetATXs(context.Context, []types.ATXID) (map[types.ATXID]*types.VerifiedActivationTx, []types.ATXID)
 	GetLayer(types.LayerID) (*types.Layer, error)
+	GetLayerVerified(types.LayerID) (*types.Block, error)
 	GetRewardsByCoinbase(types.Address) ([]*types.Reward, error)
 	GetRewardsBySmesherId(id types.NodeID) ([]*types.Reward, error)
 	LatestLayer() types.LayerID

--- a/api/grpcserver/mocks.go
+++ b/api/grpcserver/mocks.go
@@ -1561,6 +1561,45 @@ func (c *meshAPIGetLayerCall) DoAndReturn(f func(types.LayerID) (*types.Layer, e
 	return c
 }
 
+// GetLayerVerified mocks base method.
+func (m *MockmeshAPI) GetLayerVerified(arg0 types.LayerID) (*types.Block, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetLayerVerified", arg0)
+	ret0, _ := ret[0].(*types.Block)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetLayerVerified indicates an expected call of GetLayerVerified.
+func (mr *MockmeshAPIMockRecorder) GetLayerVerified(arg0 any) *meshAPIGetLayerVerifiedCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLayerVerified", reflect.TypeOf((*MockmeshAPI)(nil).GetLayerVerified), arg0)
+	return &meshAPIGetLayerVerifiedCall{Call: call}
+}
+
+// meshAPIGetLayerVerifiedCall wrap *gomock.Call
+type meshAPIGetLayerVerifiedCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *meshAPIGetLayerVerifiedCall) Return(arg0 *types.Block, arg1 error) *meshAPIGetLayerVerifiedCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *meshAPIGetLayerVerifiedCall) Do(f func(types.LayerID) (*types.Block, error)) *meshAPIGetLayerVerifiedCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *meshAPIGetLayerVerifiedCall) DoAndReturn(f func(types.LayerID) (*types.Block, error)) *meshAPIGetLayerVerifiedCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetRewardsByCoinbase mocks base method.
 func (m *MockmeshAPI) GetRewardsByCoinbase(arg0 types.Address) ([]*types.Reward, error) {
 	m.ctrl.T.Helper()

--- a/mesh/mesh.go
+++ b/mesh/mesh.go
@@ -191,6 +191,21 @@ func (msh *Mesh) GetLayer(lid types.LayerID) (*types.Layer, error) {
 	return types.NewExistingLayer(lid, blts, blks), nil
 }
 
+// GetLayerVerified returns the verified, canonical block for a layer (or none for an empty layer).
+func (msh *Mesh) GetLayerVerified(lid types.LayerID) (*types.Block, error) {
+	applied, err := layers.GetApplied(msh.cdb, lid)
+	switch {
+	case errors.Is(err, sql.ErrNotFound):
+		return nil, nil
+	case err != nil:
+		return nil, fmt.Errorf("get applied %v: %w", lid, err)
+	case applied.IsEmpty():
+		return nil, nil
+	default:
+		return blocks.Get(msh.cdb, applied)
+	}
+}
+
 // ProcessedLayer returns the last processed layer ID.
 func (msh *Mesh) ProcessedLayer() types.LayerID {
 	return msh.processedLayer.Load().(types.LayerID)

--- a/mesh/mesh_test.go
+++ b/mesh/mesh_test.go
@@ -263,6 +263,32 @@ func TestMesh_WakeUp(t *testing.T) {
 	require.Equal(t, latestState, gotLS)
 }
 
+func TestMesh_GetLayerVerified(t *testing.T) {
+	tm := createTestMesh(t)
+	id := types.GetEffectiveGenesis().Add(1)
+	blk, err := tm.GetLayerVerified(id)
+	require.NoError(t, err)
+	require.Nil(t, blk)
+
+	// now create some blocks in the layer
+	blks := createLayerBlocks(t, tm.db, tm.Mesh, id)
+	blk, err = tm.GetLayerVerified(id)
+
+	// still expect no result since no layer is marked as verified
+	require.NoError(t, err)
+	require.Nil(t, blk)
+
+	// now set one of the layers as applied
+	require.NoError(t, layers.SetApplied(tm.db, id, blks[2].ID()))
+
+	// finally we expect a result
+	blk, err = tm.GetLayerVerified(id)
+	require.NoError(t, err)
+	require.NotNil(t, blk)
+	require.Equal(t, id, blk.LayerIndex)
+	require.Equal(t, blks[2].ID(), blk.ID())
+}
+
 func TestMesh_GetLayer(t *testing.T) {
 	tm := createTestMesh(t)
 	id := types.GetEffectiveGenesis().Add(1)
@@ -933,7 +959,7 @@ func TestProcessLayerPerHareOutput(t *testing.T) {
 				Updates().
 				Return(nil).
 				AnyTimes()
-				// this makes ProcessLayer noop
+			// this makes ProcessLayer noop
 			for _, c := range tc.certs {
 				if c.cert.Cert != nil {
 					require.NoError(t, certificates.Add(tm.cdb, c.layer, c.cert.Cert))


### PR DESCRIPTION
Merged to develop: https://github.com/spacemeshos/go-spacemesh/pull/5334

Modify `MeshService.LayersQuery` to return ONLY the single, canonical block for each queried layer. Fixes performance issues for now by not querying any activations, proposals, etc.

Modify `MeshService.AccountMeshDataQuery` not to query activations to prevent memory/CPU bomb

## Motivation
Closes #5315
Closes #5006

## Changes
- Add method to mesh to return single, valid, applied block for a given layer
- Modify `MeshService.LayersQuery` to use this new method
- Additionally, remove query for activations (leave this empty for now)
- Modify `MeshService.AccountMeshDataQuery` not to query activations

## Test Plan
Tests updated

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
