### PR TITLE
[Merged by Bors] - systest: drop to 30 nodes

### DIFF
--- a/.github/workflows/systest.yml
+++ b/.github/workflows/systest.yml
@@ -113,7 +113,7 @@ jobs:
           label: sanity
           storage: premium-rwo=10Gi
           node_selector: cloud.google.com/gke-nodepool=gha
-          size: 50
+          size: 30
           bootstrap: 4m
           level: info
           clusters: 4


### PR DESCRIPTION
it was long pending change. there is technically no reason to run with 50, just historically happened that we use that value.

additionally lower number may improve cluster resource usage (not sure if thats the problem).
