### PR TITLE
[Merged by Bors] - p2p: provide a separate metric for failed requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,8 @@ configuration is as follows:
 
 ### Features
 
+* [#5462](https://github.com/spacemeshos/go-spacemesh/pull/5462) Add separate metric for failed p2p server requests
+
 ### Improvements
 
 ## Release v1.3.3

--- a/p2p/server/metrics.go
+++ b/p2p/server/metrics.go
@@ -58,6 +58,7 @@ func newTracker(protocol string) *tracker {
 		queue:                queue.WithLabelValues(protocol),
 		targetRps:            targetRps.WithLabelValues(protocol),
 		completed:            requests.WithLabelValues(protocol, "completed"),
+		failed:               requests.WithLabelValues(protocol, "failed"),
 		accepted:             requests.WithLabelValues(protocol, "accepted"),
 		dropped:              requests.WithLabelValues(protocol, "dropped"),
 		serverLatency:        serverLatency.WithLabelValues(protocol),
@@ -71,6 +72,7 @@ type tracker struct {
 	queue                               prometheus.Gauge
 	targetRps                           prometheus.Gauge
 	completed                           prometheus.Counter
+	failed                              prometheus.Counter
 	accepted                            prometheus.Counter
 	dropped                             prometheus.Counter
 	serverLatency                       prometheus.Observer

--- a/p2p/server/metrics.go
+++ b/p2p/server/metrics.go
@@ -36,6 +36,11 @@ var (
 		"requests counter",
 		[]string{protoLabel, "state"},
 	)
+	clientRequests = metrics.NewCounter(
+		"client_requests",
+		namespace,
+		"client request counter",
+		[]string{protoLabel, "state"})
 	clientLatency = metrics.NewHistogramWithBuckets(
 		"client_latency_seconds",
 		namespace,
@@ -61,6 +66,9 @@ func newTracker(protocol string) *tracker {
 		failed:               requests.WithLabelValues(protocol, "failed"),
 		accepted:             requests.WithLabelValues(protocol, "accepted"),
 		dropped:              requests.WithLabelValues(protocol, "dropped"),
+		clientSucceeded:      clientRequests.WithLabelValues(protocol, "succeeded"),
+		clientFailed:         clientRequests.WithLabelValues(protocol, "failed"),
+		clientServerError:    clientRequests.WithLabelValues(protocol, "server_error"),
 		serverLatency:        serverLatency.WithLabelValues(protocol),
 		clientLatency:        clientLatency.WithLabelValues(protocol, "success"),
 		clientLatencyFailure: clientLatency.WithLabelValues(protocol, "failure"),
@@ -75,6 +83,9 @@ type tracker struct {
 	failed                              prometheus.Counter
 	accepted                            prometheus.Counter
 	dropped                             prometheus.Counter
+	clientSucceeded                     prometheus.Counter
+	clientFailed                        prometheus.Counter
+	clientServerError                   prometheus.Counter
 	serverLatency                       prometheus.Observer
 	clientLatency, clientLatencyFailure prometheus.Observer
 }

--- a/p2p/server/server.go
+++ b/p2p/server/server.go
@@ -234,6 +234,7 @@ func (s *Server) queueHandler(ctx context.Context, stream network.Stream) bool {
 	}
 	if err := wr.Flush(); err != nil {
 		s.logger.With().Warning("failed to flush stream", log.Err(err))
+		return false
 	}
 
 	return true

--- a/p2p/server/server.go
+++ b/p2p/server/server.go
@@ -274,8 +274,13 @@ func (s *Server) Request(
 		case s.metrics == nil:
 			return
 		case err != nil:
+			s.metrics.clientFailed.Inc()
 			s.metrics.clientLatencyFailure.Observe(time.Since(start).Seconds())
+		case len(data.Error) > 0:
+			s.metrics.clientServerError.Inc()
+			s.metrics.clientLatency.Observe(time.Since(start).Seconds())
 		case err == nil:
+			s.metrics.clientSucceeded.Inc()
 			s.metrics.clientLatency.Observe(time.Since(start).Seconds())
 		}
 	}()


### PR DESCRIPTION
When handling the requests, distinguish completed requests from failed

## Motivation
Failed requests (e.g. due to i/o deadline exceeded errors) are currently counted as "completed", which is not entirely correct

## Changes
Added `spacemesh_server_requests{protocol="...",state="failed"}` metric.

## Test Plan
Query metrics on a node
