### PR TITLE
[Merged by Bors] - Do not allow config settings to be changed if not explicitly tagged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,6 @@ See [RELEASE](./RELEASE.md) for workflow instructions.
 
 ### Upgrade information
 
-#### Stricter configuration parsing
-
-With [#5466](https://github.com/spacemeshos/go-spacemesh/pull/5466) The configuration parser now rejects unknown
-settings in the configuration file. This means that if you have old settings that are not used by the node anymore in
-your configuration file, the node will fail to start informing you about the unknown settings. To fix this, remove the
-unknown fields and start the node again.
-
 #### New poets configuration
 
 Upgrading requires changes in config and in CLI flags (if not using the default).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ See [RELEASE](./RELEASE.md) for workflow instructions.
 
 ### Upgrade information
 
+#### Stricter configuration parsing
+
+With [#5466](https://github.com/spacemeshos/go-spacemesh/pull/5466) The configuration parser now rejects unknown
+settings in the configuration file. This means that if you have old settings that are not used by the node anymore in
+your configuration file, the node will fail to start informing you about the unknown settings. To fix this, remove the
+unknown fields and start the node again.
+
 #### New poets configuration
 
 Upgrading requires changes in config and in CLI flags (if not using the default).

--- a/api/grpcserver/config.go
+++ b/api/grpcserver/config.go
@@ -19,7 +19,7 @@ type Config struct {
 	GrpcRecvMsgSize int    `mapstructure:"grpc-recv-msg-size"`
 	JSONListener    string `mapstructure:"grpc-json-listener"`
 
-	SmesherStreamInterval time.Duration
+	SmesherStreamInterval time.Duration `mapstructure:"smesherstreaminterval"`
 }
 
 type Service = string

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -98,14 +98,16 @@ func (s ServerConfig) toOpts() []server.Opt {
 
 // Config is the configuration file of the Fetch component.
 type Config struct {
-	BatchTimeout         time.Duration
-	BatchSize, QueueSize int
-	MaxRetriesForRequest int
+	BatchTimeout         time.Duration           `mapstructure:"batchtimeout"`
+	BatchSize            int                     `mapstructure:"batchsize"`
+	QueueSize            int                     `mapstructure:"queuesize"`
+	MaxRetriesForRequest int                     `mapstructure:"maxretriesforrequest"`
 	RequestTimeout       time.Duration           `mapstructure:"request-timeout"`
 	EnableServerMetrics  bool                    `mapstructure:"servers-metrics"`
 	ServersConfig        map[string]ServerConfig `mapstructure:"servers"`
 	PeersRateThreshold   float64                 `mapstructure:"peers-rate-threshold"`
-	GetAtxsConcurrency   int64                   // The maximum number of concurrent requests to get ATXs.
+	// The maximum number of concurrent requests to get ATXs.
+	GetAtxsConcurrency int64 `mapstructure:"getatxsconcurrency"`
 }
 
 func (c Config) getServerConfig(protocol string) ServerConfig {

--- a/hare3/hare.go
+++ b/hare3/hare.go
@@ -42,8 +42,8 @@ type Config struct {
 	RoundDuration   time.Duration `mapstructure:"round-duration"`
 	// LogStats if true will log iteration statistics with INFO level at the start of the next iteration.
 	// This requires additional computation and should be used for debugging only.
-	LogStats     bool `mapstructure:"log-stats"`
-	ProtocolName string
+	LogStats     bool   `mapstructure:"log-stats"`
+	ProtocolName string `mapstructure:"protocolname"`
 }
 
 func (cfg *Config) Validate(zdist time.Duration) error {

--- a/node/node.go
+++ b/node/node.go
@@ -277,7 +277,6 @@ func LoadConfigFromFile() (*config.Config, error) {
 		viper.DecodeHook(hook),
 		withZeroFields(),
 		withIgnoreUntagged(),
-		withErrorUnused(),
 	}
 
 	// load config if it was loaded to the viper
@@ -296,12 +295,6 @@ func withZeroFields() viper.DecoderConfigOption {
 func withIgnoreUntagged() viper.DecoderConfigOption {
 	return func(cfg *mapstructure.DecoderConfig) {
 		cfg.IgnoreUntaggedFields = true
-	}
-}
-
-func withErrorUnused() viper.DecoderConfigOption {
-	return func(cfg *mapstructure.DecoderConfig) {
-		cfg.ErrorUnused = true
 	}
 }
 

--- a/node/node.go
+++ b/node/node.go
@@ -273,9 +273,16 @@ func LoadConfigFromFile() (*config.Config, error) {
 		mapstructure.TextUnmarshallerHookFunc(),
 	)
 
+	opts := []viper.DecoderConfigOption{
+		viper.DecodeHook(hook),
+		withZeroFields(),
+		withIgnoreUntagged(),
+		withErrorUnused(),
+	}
+
 	// load config if it was loaded to the viper
-	if err := viper.Unmarshal(&conf, viper.DecodeHook(hook), withZeroFields()); err != nil {
-		return nil, fmt.Errorf("unmarshal viper: %w", err)
+	if err := viper.Unmarshal(&conf, opts...); err != nil {
+		return nil, fmt.Errorf("unmarshal config: %w", err)
 	}
 	return &conf, nil
 }
@@ -283,6 +290,18 @@ func LoadConfigFromFile() (*config.Config, error) {
 func withZeroFields() viper.DecoderConfigOption {
 	return func(cfg *mapstructure.DecoderConfig) {
 		cfg.ZeroFields = true
+	}
+}
+
+func withIgnoreUntagged() viper.DecoderConfigOption {
+	return func(cfg *mapstructure.DecoderConfig) {
+		cfg.IgnoreUntaggedFields = true
+	}
+}
+
+func withErrorUnused() viper.DecoderConfigOption {
+	return func(cfg *mapstructure.DecoderConfig) {
+		cfg.ErrorUnused = true
 	}
 }
 

--- a/p2p/host.go
+++ b/p2p/host.go
@@ -102,8 +102,8 @@ const (
 type Config struct {
 	DataDir            string
 	LogLevel           log.Level
-	GracePeersShutdown time.Duration
-	MaxMessageSize     int
+	GracePeersShutdown time.Duration `mapstructure:"gracepeersshutdown"`
+	MaxMessageSize     int           `mapstructure:"maxmessagesize"`
 
 	// see https://lwn.net/Articles/542629/ for reuseport explanation
 	DisableReusePort            bool          `mapstructure:"disable-reuseport"`

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -21,15 +21,15 @@ import (
 
 // Config is the config params for syncer.
 type Config struct {
-	Interval                 time.Duration
-	EpochEndFraction         float64
+	Interval                 time.Duration `mapstructure:"interval"`
+	EpochEndFraction         float64       `mapstructure:"epochendfraction"`
 	HareDelayLayers          uint32
 	SyncCertDistance         uint32
-	MaxStaleDuration         time.Duration
+	MaxStaleDuration         time.Duration `mapstructure:"maxstaleduration"`
 	Standalone               bool
-	GossipDuration           time.Duration
-	DisableAtxReconciliation bool   `mapstructure:"disable-atx-reconciliation"`
-	OutOfSyncThresholdLayers uint32 `mapstructure:"out-of-sync-threshold"`
+	GossipDuration           time.Duration `mapstructure:"gossipduration"`
+	DisableAtxReconciliation bool          `mapstructure:"disable-atx-reconciliation"`
+	OutOfSyncThresholdLayers uint32        `mapstructure:"out-of-sync-threshold"`
 }
 
 // DefaultConfig for the syncer.


### PR DESCRIPTION
## Motivation
The code to parse the config file is missing `IgnoreUntaggedFields` that I believe should be set:

- We do have a lot of config parameters that are overwritten with other values during startup:
  - `config.Tortoise.LayerSize`: always overwritten by `config.LayerAvgSize`
  - `config.P2P.DataDir`: always overwritten by `filepath.Join(config.DataDir(), "p2p")`
  - `config.P2P.LogLevel`: always overwritten by `config.Logging.P2PLoggerLevel`
  - `config.Certificate.CertifyThreshold`: always overwritten by `config.Certificate.CommitteeSize/2 + 1`
  - `config.Certificate.LayerBuffer`: always overwritten by `config.Tortoise.Zdist`
  - `config.Certificate.NumLayersToKeep`: always overwritten by `config.Tortoise.Zdist * 2`
  - `config.Bootstrap.DataDir`: always overwritten by `config.DataDirParent`
  - `config.Bootstrap.Interval`: always overwritten by `config.LayerDuration / 5`
  - `config.Sync.HareDelayLayers`: always overwritten by `config.Tortoise.Zdist`
  - `config.Sync.SyncCertDistance`: always overwritten by `app.Config.Tortoise.Hdist`
  - `config.Sync.Standalone`: always overwritten by `app.Config.Standalone`
- For the remaining untagged fields I added `mapstructure` tags with the same name as the fields name to keep backwards compatibility
  - arguably most of them probably shouldn't be configured and we should just not allow setting them via the config file
  - but to not break existing setups (which I don't think exist 😉 ) I added tags to those fields

## Changes
- add `IgnoreUntaggedFields` to config parse settings
- tagged possibly used fields to keep backwards compatibility with existing setups

## Test Plan
- existing tests pass

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
