### PR TITLE
[Merged by Bors] - Improve events emitted by node when post proofing

### DIFF
--- a/activation/activation.go
+++ b/activation/activation.go
@@ -76,7 +76,6 @@ type Builder struct {
 	cdb              *datastore.CachedDB
 	localDB          *localsql.Database
 	publisher        pubsub.Publisher
-	postService      postService
 	nipostBuilder    nipostBuilder
 	validator        nipostValidator
 
@@ -131,7 +130,6 @@ func NewBuilder(
 	cdb *datastore.CachedDB,
 	localDB *localsql.Database,
 	publisher pubsub.Publisher,
-	postService postService,
 	nipostBuilder nipostBuilder,
 	layerClock layerClock,
 	syncer syncer,
@@ -146,7 +144,6 @@ func NewBuilder(
 		cdb:               cdb,
 		localDB:           localDB,
 		publisher:         publisher,
-		postService:       postService,
 		nipostBuilder:     nipostBuilder,
 		layerClock:        layerClock,
 		syncer:            syncer,

--- a/activation/activation.go
+++ b/activation/activation.go
@@ -167,6 +167,7 @@ func (b *Builder) proof(ctx context.Context, challenge []byte) (*types.Post, *ty
 		if err != nil {
 			select {
 			case <-ctx.Done():
+				events.EmitPostFailure()
 				return nil, nil, ctx.Err()
 			case <-time.After(2 * time.Second): // Wait a few seconds and try connecting again
 				retries++ // TODO(mafa): emit event warning user about lost connection after a few retries
@@ -181,6 +182,7 @@ func (b *Builder) proof(ctx context.Context, challenge []byte) (*types.Post, *ty
 			b.log.Warn("post service connection dropped - trying to reconnect", zap.Error(err))
 			select {
 			case <-ctx.Done():
+				events.EmitPostFailure()
 				return nil, nil, ctx.Err()
 			case <-time.After(2 * time.Second):
 				continue

--- a/activation/activation_test.go
+++ b/activation/activation_test.go
@@ -110,7 +110,6 @@ type testAtxBuilder struct {
 	goldenATXID types.ATXID
 
 	mpub        *mocks.MockPublisher
-	mpostSvc    *MockpostService
 	mnipost     *MocknipostBuilder
 	mpostClient *MockPostClient
 	mclock      *MocklayerClock
@@ -129,7 +128,6 @@ func newTestBuilder(tb testing.TB, opts ...BuilderOption) *testAtxBuilder {
 		sig:         edSigner,
 		goldenATXID: types.ATXID(types.HexToHash32("77777")),
 		mpub:        mocks.NewMockPublisher(ctrl),
-		mpostSvc:    NewMockpostService(ctrl),
 		mnipost:     NewMocknipostBuilder(ctrl),
 		mpostClient: NewMockPostClient(ctrl),
 		mclock:      NewMocklayerClock(ctrl),
@@ -145,7 +143,6 @@ func newTestBuilder(tb testing.TB, opts ...BuilderOption) *testAtxBuilder {
 	}
 
 	tab.msync.EXPECT().RegisterForATXSynced().DoAndReturn(closedChan).AnyTimes()
-	tab.mpostSvc.EXPECT().Client(tab.sig.NodeID()).Return(tab.mpostClient, nil).AnyTimes()
 
 	b := NewBuilder(
 		cfg,
@@ -153,7 +150,6 @@ func newTestBuilder(tb testing.TB, opts ...BuilderOption) *testAtxBuilder {
 		tab.cdb,
 		tab.localDb,
 		tab.mpub,
-		tab.mpostSvc,
 		tab.mnipost,
 		tab.mclock,
 		tab.msync,

--- a/activation/activation_test.go
+++ b/activation/activation_test.go
@@ -277,13 +277,11 @@ func TestBuilder_StartSmeshingCoinbase(t *testing.T) {
 	tab := newTestBuilder(t)
 	coinbase := types.Address{1, 1, 1}
 
-	tab.mpostClient.EXPECT().
-		Proof(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, b []byte) (*types.Post, *types.PostInfo, error) {
+	tab.mnipost.EXPECT().Proof(gomock.Any(), shared.ZeroChallenge).DoAndReturn(
+		func(ctx context.Context, b []byte) (*types.Post, *types.PostInfo, error) {
 			<-ctx.Done()
 			return nil, nil, ctx.Err()
-		}).
-		AnyTimes()
+		})
 	tab.mValidator.EXPECT().
 		Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		AnyTimes().
@@ -303,12 +301,11 @@ func TestBuilder_StartSmeshingCoinbase(t *testing.T) {
 func TestBuilder_RestartSmeshing(t *testing.T) {
 	getBuilder := func(t *testing.T) *Builder {
 		tab := newTestBuilder(t)
-		tab.mpostClient.EXPECT().Proof(gomock.Any(), shared.ZeroChallenge).AnyTimes().DoAndReturn(
-			func(ctx context.Context, _ []byte) (*types.Post, *types.PostInfo, error) {
+		tab.mnipost.EXPECT().Proof(gomock.Any(), shared.ZeroChallenge).AnyTimes().DoAndReturn(
+			func(ctx context.Context, b []byte) (*types.Post, *types.PostInfo, error) {
 				<-ctx.Done()
 				return nil, nil, ctx.Err()
-			},
-		)
+			})
 
 		ch := make(chan struct{})
 		close(ch)
@@ -365,13 +362,11 @@ func TestBuilder_StopSmeshing_Delete(t *testing.T) {
 			return nil, ctx.Err()
 		}).
 		AnyTimes()
-	tab.mpostClient.EXPECT().
-		Proof(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, b []byte) (*types.Post, *types.PostInfo, error) {
+	tab.mnipost.EXPECT().Proof(gomock.Any(), shared.ZeroChallenge).DoAndReturn(
+		func(ctx context.Context, b []byte) (*types.Post, *types.PostInfo, error) {
 			<-ctx.Done()
 			return nil, nil, ctx.Err()
-		}).
-		AnyTimes()
+		}).AnyTimes()
 
 	// add challenge to DB
 	refChallenge := &types.NIPostChallenge{
@@ -1267,15 +1262,14 @@ func TestBuilder_RetryPublishActivationTx(t *testing.T) {
 
 func TestBuilder_InitialProofGeneratedOnce(t *testing.T) {
 	tab := newTestBuilder(t, WithPoetConfig(PoetConfig{PhaseShift: layerDuration * 4}))
-	tab.mpostClient.EXPECT().Proof(gomock.Any(), shared.ZeroChallenge).
-		Return(
-			&types.Post{Indices: make([]byte, 10)},
-			&types.PostInfo{
-				CommitmentATX: types.RandomATXID(),
-				Nonce:         new(types.VRFPostIndex),
-			},
-			nil,
-		)
+	tab.mnipost.EXPECT().Proof(gomock.Any(), shared.ZeroChallenge).Return(
+		&types.Post{Indices: make([]byte, 10)},
+		&types.PostInfo{
+			CommitmentATX: types.RandomATXID(),
+			Nonce:         new(types.VRFPostIndex),
+		},
+		nil,
+	)
 	tab.mValidator.EXPECT().
 		Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		AnyTimes().
@@ -1305,15 +1299,14 @@ func TestBuilder_InitialProofGeneratedOnce(t *testing.T) {
 
 func TestBuilder_InitialPostIsPersisted(t *testing.T) {
 	tab := newTestBuilder(t, WithPoetConfig(PoetConfig{PhaseShift: layerDuration * 4}))
-	tab.mpostClient.EXPECT().Proof(gomock.Any(), shared.ZeroChallenge).
-		Return(
-			&types.Post{Indices: make([]byte, 10)},
-			&types.PostInfo{
-				CommitmentATX: types.RandomATXID(),
-				Nonce:         new(types.VRFPostIndex),
-			},
-			nil,
-		)
+	tab.mnipost.EXPECT().Proof(gomock.Any(), shared.ZeroChallenge).Return(
+		&types.Post{Indices: make([]byte, 10)},
+		&types.PostInfo{
+			CommitmentATX: types.RandomATXID(),
+			Nonce:         new(types.VRFPostIndex),
+		},
+		nil,
+	)
 	tab.mValidator.EXPECT().
 		Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		AnyTimes().

--- a/activation/interface.go
+++ b/activation/interface.go
@@ -2,6 +2,7 @@ package activation
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"time"
 
@@ -124,6 +125,8 @@ type poetDbAPI interface {
 	GetProof(types.PoetProofRef) (*types.PoetProof, *types.Hash32, error)
 	ValidateAndStore(ctx context.Context, proofMessage *types.PoetProofMessage) error
 }
+
+var ErrPostClientClosed = fmt.Errorf("post client closed")
 
 type postService interface {
 	Client(nodeId types.NodeID) (PostClient, error)

--- a/activation/interface.go
+++ b/activation/interface.go
@@ -69,6 +69,7 @@ type layerClock interface {
 
 type nipostBuilder interface {
 	BuildNIPost(ctx context.Context, challenge *types.NIPostChallenge) (*nipost.NIPostState, error)
+	Proof(ctx context.Context, challenge []byte) (*types.Post, *types.PostInfo, error)
 	ResetState() error
 }
 

--- a/activation/mocks.go
+++ b/activation/mocks.go
@@ -769,6 +769,46 @@ func (c *nipostBuilderBuildNIPostCall) DoAndReturn(f func(context.Context, *type
 	return c
 }
 
+// Proof mocks base method.
+func (m *MocknipostBuilder) Proof(ctx context.Context, challenge []byte) (*types.Post, *types.PostInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Proof", ctx, challenge)
+	ret0, _ := ret[0].(*types.Post)
+	ret1, _ := ret[1].(*types.PostInfo)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// Proof indicates an expected call of Proof.
+func (mr *MocknipostBuilderMockRecorder) Proof(ctx, challenge any) *nipostBuilderProofCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Proof", reflect.TypeOf((*MocknipostBuilder)(nil).Proof), ctx, challenge)
+	return &nipostBuilderProofCall{Call: call}
+}
+
+// nipostBuilderProofCall wrap *gomock.Call
+type nipostBuilderProofCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *nipostBuilderProofCall) Return(arg0 *types.Post, arg1 *types.PostInfo, arg2 error) *nipostBuilderProofCall {
+	c.Call = c.Call.Return(arg0, arg1, arg2)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *nipostBuilderProofCall) Do(f func(context.Context, []byte) (*types.Post, *types.PostInfo, error)) *nipostBuilderProofCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *nipostBuilderProofCall) DoAndReturn(f func(context.Context, []byte) (*types.Post, *types.PostInfo, error)) *nipostBuilderProofCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // ResetState mocks base method.
 func (m *MocknipostBuilder) ResetState() error {
 	m.ctrl.T.Helper()

--- a/activation/nipost.go
+++ b/activation/nipost.go
@@ -116,7 +116,7 @@ func (nb *NIPostBuilder) ResetState() error {
 	return nil
 }
 
-func (nb *NIPostBuilder) proof(ctx context.Context, challenge []byte) (*types.Post, *types.PostInfo, error) {
+func (nb *NIPostBuilder) Proof(ctx context.Context, challenge []byte) (*types.Post, *types.PostInfo, error) {
 	started := false
 	retries := 0
 	for {
@@ -287,11 +287,10 @@ func (nb *NIPostBuilder) BuildNIPost(
 
 		nb.log.Info("starting post execution", zap.Binary("challenge", poetProofRef[:]))
 		startTime := time.Now()
-		proof, postInfo, err := nb.proof(postCtx, poetProofRef[:])
+		proof, postInfo, err := nb.Proof(postCtx, poetProofRef[:])
 		if err != nil {
 			return nil, fmt.Errorf("failed to generate Post: %w", err)
 		}
-		events.EmitPostComplete(poetProofRef[:])
 		postGenDuration := time.Since(startTime)
 		nb.log.Info("finished post execution", zap.Duration("duration", postGenDuration))
 		metrics.PostDuration.Set(float64(postGenDuration.Nanoseconds()))

--- a/activation/nipost.go
+++ b/activation/nipost.go
@@ -146,14 +146,7 @@ func (nb *NIPostBuilder) Proof(ctx context.Context, challenge []byte) (*types.Po
 		post, postInfo, err := client.Proof(ctx, challenge)
 		switch {
 		case errors.Is(err, ErrPostClientClosed):
-			nb.log.Warn("post service connection dropped - waiting for reconnect", zap.Error(err))
-			select {
-			case <-ctx.Done():
-				events.EmitPostFailure()
-				return nil, nil, ctx.Err()
-			case <-time.After(2 * time.Second): // Wait a few seconds and try connecting again
-				continue
-			}
+			continue
 		case err != nil:
 			events.EmitPostFailure()
 			return nil, nil, err

--- a/activation/nipost.go
+++ b/activation/nipost.go
@@ -117,7 +117,7 @@ func (nb *NIPostBuilder) ResetState() error {
 }
 
 func (nb *NIPostBuilder) proof(ctx context.Context, challenge []byte) (*types.Post, *types.PostInfo, error) {
-	events.EmitPostStart(challenge)
+	started := false
 	retries := 0
 	for {
 		client, err := nb.postService.Client(nb.signer.NodeID())
@@ -131,6 +131,10 @@ func (nb *NIPostBuilder) proof(ctx context.Context, challenge []byte) (*types.Po
 				continue
 			}
 		}
+		if !started {
+			events.EmitPostStart(challenge)
+			started = true
+		}
 
 		retries = 0
 		post, postInfo, err := client.Proof(ctx, challenge)
@@ -141,7 +145,7 @@ func (nb *NIPostBuilder) proof(ctx context.Context, challenge []byte) (*types.Po
 			case <-ctx.Done():
 				events.EmitPostFailure()
 				return nil, nil, ctx.Err()
-			case <-time.After(2 * time.Second):
+			case <-time.After(2 * time.Second): // Wait a few seconds and try connecting again
 				continue
 			}
 		case err != nil:

--- a/api/grpcserver/post_client.go
+++ b/api/grpcserver/post_client.go
@@ -8,6 +8,7 @@ import (
 
 	pb "github.com/spacemeshos/api/release/go/spacemesh/v1"
 
+	"github.com/spacemeshos/go-spacemesh/activation"
 	"github.com/spacemeshos/go-spacemesh/common/types"
 )
 
@@ -149,7 +150,7 @@ func (pc *postClient) send(ctx context.Context, req *pb.NodeRequest) (*pb.Servic
 	// send command
 	select {
 	case <-pc.closed:
-		return nil, fmt.Errorf("post client closed")
+		return nil, activation.ErrPostClientClosed
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	case pc.con <- cmd:
@@ -158,7 +159,7 @@ func (pc *postClient) send(ctx context.Context, req *pb.NodeRequest) (*pb.Servic
 	// receive response
 	select {
 	case <-pc.closed:
-		return nil, fmt.Errorf("post client closed")
+		return nil, activation.ErrPostClientClosed
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	case resp := <-resp:

--- a/node/node.go
+++ b/node/node.go
@@ -949,7 +949,6 @@ func (app *App) initServices(ctx context.Context) error {
 		app.cachedDB,
 		app.localDB,
 		app.host,
-		app.grpcPostService,
 		nipostBuilder,
 		app.clock,
 		newSyncer,


### PR DESCRIPTION
## Motivation
This PR aims at improving event emission from node in case the connection between it and the post service unexpectedly drops.

## Changes
- When the connection drops the client is closed (unchanged), any pending request now returns a typed error `ErrPostClientClosed`
- `NIPostBuilder` and `activation.Builder` check for this error and retry querying PoST after 2 seconds
  - In supervised mode this is should be sufficient - if the post service is down the node will `log.Fatal` anyway
  - In remote/multi mode the node should emit an additional event informing the user that the connection dropped and check after reconnection that the proof is still in progress (both require new API)

## Test Plan
- existing tests pass
- manual testing

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
