### PR TITLE
[Merged by Bors] - Improve DB logging

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -1599,9 +1599,9 @@ func (app *App) setupDBs(ctx context.Context, lg log.Log) error {
 	if err != nil {
 		return fmt.Errorf("failed to load migrations: %w", err)
 	}
-	dbLog := app.addLogger(StateDbLogger, lg).Zap()
+	dbLog := app.addLogger(StateDbLogger, lg)
 	dbopts := []sql.Opt{
-		sql.WithLogger(dbLog),
+		sql.WithLogger(dbLog.Zap()),
 		sql.WithMigrations(migrations),
 		sql.WithConnections(app.Config.DatabaseConnections),
 		sql.WithLatencyMetering(app.Config.DatabaseLatencyMetering),
@@ -1619,7 +1619,7 @@ func (app *App) setupDBs(ctx context.Context, lg log.Log) error {
 		app.dbMetrics = dbmetrics.NewDBMetricsCollector(
 			ctx,
 			app.db,
-			app.addLogger(StateDbLogger, lg),
+			dbLog,
 			app.Config.DatabaseSizeMeteringInterval,
 		)
 	}
@@ -1649,7 +1649,7 @@ func (app *App) setupDBs(ctx context.Context, lg log.Log) error {
 		return fmt.Errorf("load local migrations: %w", err)
 	}
 	localDB, err := localsql.Open("file:"+filepath.Join(dbPath, localDbFile),
-		sql.WithLogger(dbLog),
+		sql.WithLogger(dbLog.Zap()),
 		sql.WithMigrations(migrations),
 		sql.WithMigration(localsql.New0001Migration(app.Config.SMESHING.Opts.DataDir)),
 		sql.WithMigration(localsql.New0002Migration(app.Config.SMESHING.Opts.DataDir)),

--- a/node/node.go
+++ b/node/node.go
@@ -1599,7 +1599,9 @@ func (app *App) setupDBs(ctx context.Context, lg log.Log) error {
 	if err != nil {
 		return fmt.Errorf("failed to load migrations: %w", err)
 	}
+	dbLog := app.addLogger(StateDbLogger, lg).Zap()
 	dbopts := []sql.Opt{
+		sql.WithLogger(dbLog),
 		sql.WithMigrations(migrations),
 		sql.WithConnections(app.Config.DatabaseConnections),
 		sql.WithLatencyMetering(app.Config.DatabaseLatencyMetering),
@@ -1647,6 +1649,7 @@ func (app *App) setupDBs(ctx context.Context, lg log.Log) error {
 		return fmt.Errorf("load local migrations: %w", err)
 	}
 	localDB, err := localsql.Open("file:"+filepath.Join(dbPath, localDbFile),
+		sql.WithLogger(dbLog),
 		sql.WithMigrations(migrations),
 		sql.WithMigration(localsql.New0001Migration(app.Config.SMESHING.Opts.DataDir)),
 		sql.WithMigration(localsql.New0002Migration(app.Config.SMESHING.Opts.DataDir)),

--- a/sql/database.go
+++ b/sql/database.go
@@ -12,8 +12,7 @@ import (
 	sqlite "github.com/go-llsqlite/crawshaw"
 	"github.com/go-llsqlite/crawshaw/sqlitex"
 	"github.com/prometheus/client_golang/prometheus"
-
-	"github.com/spacemeshos/go-spacemesh/log"
+	"go.uber.org/zap"
 )
 
 var (
@@ -63,6 +62,7 @@ func defaultConf() *conf {
 		connections:   16,
 		migrations:    migrations,
 		skipMigration: map[int]struct{}{},
+		logger:        zap.NewNop(),
 	}
 }
 
@@ -73,12 +73,19 @@ type conf struct {
 	vacuumState   int
 	migrations    []Migration
 	enableLatency bool
+	logger        *zap.Logger
 }
 
 // WithConnections overwrites number of pooled connections.
 func WithConnections(n int) Opt {
 	return func(c *conf) {
 		c.connections = n
+	}
+}
+
+func WithLogger(logger *zap.Logger) Opt {
+	return func(c *conf) {
+		c.logger = logger
 	}
 }
 
@@ -173,7 +180,11 @@ func Open(uri string, opts ...Opt) (*Database, error) {
 		if err != nil {
 			return nil, err
 		}
-		log.With().Info("running migrations", log.Int("current version", before))
+		config.logger.Info("running migrations",
+			zap.String("uri", uri),
+			zap.Int("current version", before),
+			zap.Int("target version", config.migrations[len(config.migrations)-1].Order()),
+		)
 		tx, err := db.Tx(context.Background())
 		if err != nil {
 			return nil, err

--- a/sql/database.go
+++ b/sql/database.go
@@ -180,10 +180,14 @@ func Open(uri string, opts ...Opt) (*Database, error) {
 		if err != nil {
 			return nil, err
 		}
+		after := 0
+		if len(config.migrations) > 0 {
+			after = config.migrations[len(config.migrations)-1].Order()
+		}
 		config.logger.Info("running migrations",
 			zap.String("uri", uri),
 			zap.Int("current version", before),
-			zap.Int("target version", config.migrations[len(config.migrations)-1].Order()),
+			zap.Int("target version", after),
 		)
 		tx, err := db.Tx(context.Background())
 		if err != nil {


### PR DESCRIPTION
## Motivation
When running migrations the node doesn't display for which DB it runs the migrations. This PR adds that information.

## Changes
- Add more info to the DB migration log: `current version`, `target version` and `uri` of the DB.

## Test Plan
existing tests pass

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
