### PR TITLE
[Merged by Bors] - Add tests for new GRPC disconnect handling logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,10 +80,6 @@ configuration is as follows:
 
 * [#5464](https://github.com/spacemeshos/go-spacemesh/pull/5464) Make fetch request timeout configurable.
 
-* [#5467](https://github.com/spacemeshos/go-spacemesh/pull/5467)
-  Fix a bug that could cause ATX sync to stall because of exhausted limit of concurrent requests for dependencies.
-  Fetching dependencies of an ATX is not limited anymore.
-
 ## Release v1.3.5
 
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,28 @@ configuration is as follows:
 ### Improvements
 
 * [#5464](https://github.com/spacemeshos/go-spacemesh/pull/5464) Make fetch request timeout configurable.
+
+* [#5467](https://github.com/spacemeshos/go-spacemesh/pull/5467)
+  Fix a bug that could cause ATX sync to stall because of exhausted limit of concurrent requests for dependencies.
+  Fetching dependencies of an ATX is not limited anymore.
+
+## Release v1.3.5
+
+### Improvements
+
+* [#5470](https://github.com/spacemeshos/go-spacemesh/pull/5470)
+  Fixed a bug in event reporting where the node reports a disconnection from the PoST service as a "PoST failed" event.
+  Disconnections cannot be avoided completely and do not interrupt the PoST proofing process. As long as the PoST
+  service reconnects within a reasonable time, the node will continue to operate normally without reporting any errors
+  via the event API.
+
+  Users of a remote setup should make sure that the PoST service is actually running and can reach the node. Observe
+  the log of both apps for indications of a connection problem.
+
+## Release v1.3.4
+
+### Improvements
+
 * [#5467](https://github.com/spacemeshos/go-spacemesh/pull/5467)
   Fix a bug that could cause ATX sync to stall because of exhausted limit of concurrent requests for dependencies.
   Fetching dependencies of an ATX is not limited anymore.

--- a/activation/interface.go
+++ b/activation/interface.go
@@ -128,6 +128,7 @@ type poetDbAPI interface {
 }
 
 var ErrPostClientClosed = fmt.Errorf("post client closed")
+var ErrPostClientNotConnected = fmt.Errorf("post service not registered")
 
 type postService interface {
 	Client(nodeId types.NodeID) (PostClient, error)

--- a/activation/interface.go
+++ b/activation/interface.go
@@ -127,8 +127,10 @@ type poetDbAPI interface {
 	ValidateAndStore(ctx context.Context, proofMessage *types.PoetProofMessage) error
 }
 
-var ErrPostClientClosed = fmt.Errorf("post client closed")
-var ErrPostClientNotConnected = fmt.Errorf("post service not registered")
+var (
+	ErrPostClientClosed       = fmt.Errorf("post client closed")
+	ErrPostClientNotConnected = fmt.Errorf("post service not registered")
+)
 
 type postService interface {
 	Client(nodeId types.NodeID) (PostClient, error)

--- a/activation/nipost.go
+++ b/activation/nipost.go
@@ -132,7 +132,10 @@ func (nb *NIPostBuilder) Proof(ctx context.Context, challenge []byte) (*types.Po
 				retries++
 				if retries%10 == 0 { // every 20 seconds inform user about lost connection (for remote post service)
 					// TODO(mafa): emit event warning user about lost connection
-					nb.log.Warn("post service not connected - waiting for reconnection", zap.Error(err))
+					nb.log.Warn("post service not connected - waiting for reconnection",
+						zap.Stringer("service id", nb.signer.NodeID()),
+						zap.Error(err),
+					)
 				}
 				continue
 			}

--- a/activation/nipost_test.go
+++ b/activation/nipost_test.go
@@ -7,11 +7,18 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spacemeshos/post/shared"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest"
+	"go.uber.org/zap/zaptest/observer"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/events"
 	"github.com/spacemeshos/go-spacemesh/signing"
 	"github.com/spacemeshos/go-spacemesh/sql"
 	"github.com/spacemeshos/go-spacemesh/sql/localsql"
@@ -39,6 +46,337 @@ func defaultLayerClockMock(ctrl *gomock.Controller) *MocklayerClock {
 		},
 	)
 	return mclock
+}
+
+func Test_NIPost_PostClientHandling(t *testing.T) {
+	t.Run("connect then complete", func(t *testing.T) {
+		// post client connects, starts post, then completes successfully
+
+		sig, err := signing.NewEdSigner()
+		require.NoError(t, err)
+
+		ctrl := gomock.NewController(t)
+		poetDb := NewMockpoetDbAPI(ctrl)
+		mclock := defaultLayerClockMock(ctrl)
+		postService := NewMockpostService(ctrl)
+		postClient := NewMockPostClient(ctrl)
+
+		logger := zaptest.NewLogger(t)
+		nb, err := NewNIPostBuilder(
+			localsql.InMemory(),
+			poetDb,
+			postService,
+			[]types.PoetServer{},
+			logger,
+			sig,
+			PoetConfig{},
+			mclock,
+		)
+		require.NoError(t, err)
+
+		expectedEvents := setupEventListener(t)
+
+		postService.EXPECT().Client(sig.NodeID()).DoAndReturn(
+			func(types.NodeID) (PostClient, error) {
+				expectedEvents <- func(e events.UserEvent) {
+					event := e.Event.GetPostStart()
+					if !assert.NotNil(t, event, "wrong event type") {
+						return
+					}
+
+					assert.EqualValues(t, shared.ZeroChallenge, event.Challenge)
+				}
+				return postClient, nil
+			})
+		postClient.EXPECT().Proof(gomock.Any(), gomock.Any()).DoAndReturn(
+			func(context.Context, []byte) (*types.Post, *types.PostInfo, error) {
+				expectedEvents <- func(e events.UserEvent) {
+					event := e.Event.GetPostComplete()
+					if !assert.NotNil(t, event, "wrong event type") {
+						return
+					}
+
+					assert.EqualValues(t, shared.ZeroChallenge, event.Challenge)
+					assert.Equal(t, false, e.Event.Failure)
+					assert.Equal(t, "Node finished PoST execution using PoET challenge.", e.Event.Help)
+				}
+
+				return &types.Post{}, &types.PostInfo{}, nil
+			})
+
+		nipost, nipostInfo, err := nb.Proof(context.Background(), shared.ZeroChallenge)
+		require.NoError(t, err)
+		require.NotNil(t, nipost)
+		require.NotNil(t, nipostInfo)
+	})
+
+	t.Run("connect then error", func(t *testing.T) {
+		// post client connects, starts post, then fails with an error that is not a disconnect
+
+		sig, err := signing.NewEdSigner()
+		require.NoError(t, err)
+
+		ctrl := gomock.NewController(t)
+		poetDb := NewMockpoetDbAPI(ctrl)
+		mclock := defaultLayerClockMock(ctrl)
+		postService := NewMockpostService(ctrl)
+		postClient := NewMockPostClient(ctrl)
+
+		logger := zaptest.NewLogger(t)
+		nb, err := NewNIPostBuilder(
+			localsql.InMemory(),
+			poetDb,
+			postService,
+			[]types.PoetServer{},
+			logger,
+			sig,
+			PoetConfig{},
+			mclock,
+		)
+		require.NoError(t, err)
+
+		expectedEvents := setupEventListener(t)
+		expectedErr := errors.New("some error")
+
+		postService.EXPECT().Client(sig.NodeID()).DoAndReturn(
+			func(types.NodeID) (PostClient, error) {
+				expectedEvents <- func(e events.UserEvent) {
+					event := e.Event.GetPostStart()
+					if !assert.NotNil(t, event, "wrong event type") {
+						return
+					}
+
+					assert.EqualValues(t, shared.ZeroChallenge, event.Challenge)
+				}
+				return postClient, nil
+			})
+		postClient.EXPECT().Proof(gomock.Any(), gomock.Any()).DoAndReturn(
+			func(context.Context, []byte) (*types.Post, *types.PostInfo, error) {
+				expectedEvents <- func(e events.UserEvent) {
+					event := e.Event.GetPostComplete()
+					if !assert.NotNil(t, event, "wrong event type") {
+						return
+					}
+
+					assert.Equal(t, true, e.Event.Failure)
+					assert.Equal(t, "Node failed PoST execution.", e.Event.Help)
+				}
+
+				return nil, nil, expectedErr
+			})
+
+		nipost, nipostInfo, err := nb.Proof(context.Background(), shared.ZeroChallenge)
+		require.ErrorIs(t, err, expectedErr)
+		require.Nil(t, nipost)
+		require.Nil(t, nipostInfo)
+	})
+
+	t.Run("connect, disconnect, reconnect then complete", func(t *testing.T) {
+		// post client connects, starts post, disconnects in between but completes successfully
+
+		sig, err := signing.NewEdSigner()
+		require.NoError(t, err)
+
+		ctrl := gomock.NewController(t)
+		poetDb := NewMockpoetDbAPI(ctrl)
+		mclock := defaultLayerClockMock(ctrl)
+		postService := NewMockpostService(ctrl)
+		postClient := NewMockPostClient(ctrl)
+
+		logger := zaptest.NewLogger(t)
+		nb, err := NewNIPostBuilder(
+			localsql.InMemory(),
+			poetDb,
+			postService,
+			[]types.PoetServer{},
+			logger,
+			sig,
+			PoetConfig{},
+			mclock,
+		)
+		require.NoError(t, err)
+
+		expectedEvents := setupEventListener(t)
+
+		postService.EXPECT().Client(sig.NodeID()).DoAndReturn(
+			func(types.NodeID) (PostClient, error) {
+				expectedEvents <- func(e events.UserEvent) {
+					event := e.Event.GetPostStart()
+					if !assert.NotNil(t, event, "wrong event type") {
+						return
+					}
+
+					assert.EqualValues(t, shared.ZeroChallenge, event.Challenge)
+				}
+				return postClient, nil
+			})
+		postClient.EXPECT().Proof(gomock.Any(), gomock.Any()).Return(nil, nil, ErrPostClientClosed).Times(1)
+		postService.EXPECT().Client(sig.NodeID()).Return(postClient, nil)
+		postClient.EXPECT().Proof(gomock.Any(), gomock.Any()).DoAndReturn(
+			func(context.Context, []byte) (*types.Post, *types.PostInfo, error) {
+				expectedEvents <- func(e events.UserEvent) {
+					event := e.Event.GetPostComplete()
+					if !assert.NotNil(t, event, "wrong event type") {
+						return
+					}
+
+					assert.EqualValues(t, shared.ZeroChallenge, event.Challenge)
+					assert.Equal(t, false, e.Event.Failure)
+					assert.Equal(t, "Node finished PoST execution using PoET challenge.", e.Event.Help)
+				}
+
+				return &types.Post{}, &types.PostInfo{}, nil
+			})
+
+		nipost, nipostInfo, err := nb.Proof(context.Background(), shared.ZeroChallenge)
+		require.NoError(t, err)
+		require.NotNil(t, nipost)
+		require.NotNil(t, nipostInfo)
+	})
+
+	t.Run("connect, disconnect, reconnect then error", func(t *testing.T) {
+		// post client connects, starts post, disconnects in between and then fails to complete
+
+		sig, err := signing.NewEdSigner()
+		require.NoError(t, err)
+
+		ctrl := gomock.NewController(t)
+		poetDb := NewMockpoetDbAPI(ctrl)
+		mclock := defaultLayerClockMock(ctrl)
+		postService := NewMockpostService(ctrl)
+		postClient := NewMockPostClient(ctrl)
+
+		logger := zaptest.NewLogger(t)
+		nb, err := NewNIPostBuilder(
+			localsql.InMemory(),
+			poetDb,
+			postService,
+			[]types.PoetServer{},
+			logger,
+			sig,
+			PoetConfig{},
+			mclock,
+		)
+		require.NoError(t, err)
+
+		expectedEvents := setupEventListener(t)
+		expectedErr := errors.New("some error")
+
+		postService.EXPECT().Client(sig.NodeID()).DoAndReturn(
+			func(types.NodeID) (PostClient, error) {
+				expectedEvents <- func(e events.UserEvent) {
+					event := e.Event.GetPostStart()
+					if !assert.NotNil(t, event, "wrong event type") {
+						return
+					}
+
+					assert.EqualValues(t, shared.ZeroChallenge, event.Challenge)
+				}
+				return postClient, nil
+			})
+		postClient.EXPECT().Proof(gomock.Any(), gomock.Any()).Return(nil, nil, ErrPostClientClosed).Times(1)
+		postService.EXPECT().Client(sig.NodeID()).Return(postClient, nil)
+		postClient.EXPECT().Proof(gomock.Any(), gomock.Any()).DoAndReturn(
+			func(context.Context, []byte) (*types.Post, *types.PostInfo, error) {
+				expectedEvents <- func(e events.UserEvent) {
+					event := e.Event.GetPostComplete()
+					if !assert.NotNil(t, event, "wrong event type") {
+						return
+					}
+
+					assert.Equal(t, true, e.Event.Failure)
+					assert.Equal(t, "Node failed PoST execution.", e.Event.Help)
+				}
+
+				return nil, nil, expectedErr
+			})
+
+		nipost, nipostInfo, err := nb.Proof(context.Background(), shared.ZeroChallenge)
+		require.ErrorIs(t, err, expectedErr)
+		require.Nil(t, nipost)
+		require.Nil(t, nipostInfo)
+	})
+
+	t.Run("repeated connection failure", func(t *testing.T) {
+		t.Parallel()
+
+		sig, err := signing.NewEdSigner()
+		require.NoError(t, err)
+
+		ctrl := gomock.NewController(t)
+		poetDb := NewMockpoetDbAPI(ctrl)
+		mclock := defaultLayerClockMock(ctrl)
+		postService := NewMockpostService(ctrl)
+
+		observer, observedLogs := observer.New(zapcore.WarnLevel)
+		logger := zap.New(observer)
+
+		nb, err := NewNIPostBuilder(
+			localsql.InMemory(),
+			poetDb,
+			postService,
+			[]types.PoetServer{},
+			logger,
+			sig,
+			PoetConfig{},
+			mclock,
+		)
+		require.NoError(t, err)
+
+		setupEventListener(t) // no events
+
+		ctx, cancel := context.WithCancel(context.Background())
+		postService.EXPECT().Client(sig.NodeID()).Return(nil, ErrPostClientNotConnected).Times(10)
+		postService.EXPECT().Client(sig.NodeID()).DoAndReturn(
+			func(types.NodeID) (PostClient, error) {
+				cancel()
+				return nil, ErrPostClientNotConnected
+			}).Times(1)
+
+		nipost, nipostInfo, err := nb.Proof(ctx, shared.ZeroChallenge)
+		require.ErrorIs(t, err, context.Canceled)
+		require.Nil(t, nipost)
+		require.Nil(t, nipostInfo)
+
+		require.Equal(t, 1, observedLogs.Len(), "expected 1 log message")
+		require.Equal(t, zapcore.WarnLevel, observedLogs.All()[0].Level)
+		require.Equal(t, "post service not connected - waiting for reconnection", observedLogs.All()[0].Message)
+		require.Equal(t, sig.NodeID().String(), observedLogs.All()[0].ContextMap()["service id"])
+	})
+}
+
+func setupEventListener(t *testing.T) chan<- func(events.UserEvent) {
+	events.InitializeReporter()
+	sub, _, err := events.SubscribeUserEvents(events.WithBuffer(10))
+	require.NoError(t, err)
+
+	expectedEvents := make(chan func(events.UserEvent), 10)
+	var eg errgroup.Group
+	eg.Go(func() error {
+		for event := range sub.Out() {
+			select {
+			case ev, ok := <-expectedEvents:
+				if !ok {
+					assert.Fail(t, "unexpected event: %v", event)
+					return nil
+				}
+				ev(event)
+			case <-time.After(5 * time.Second):
+				assert.Fail(t, "timeout waiting for event")
+				return nil
+			}
+		}
+		_, ok := <-expectedEvents
+		assert.False(t, ok, "expected more events")
+		return nil
+	})
+	t.Cleanup(func() { eg.Wait() })
+	t.Cleanup(func() { sub.Close() })
+	t.Cleanup(func() {
+		close(expectedEvents)
+		time.Sleep(100 * time.Millisecond) // give subscription some time to handle all events
+	})
+	return expectedEvents
 }
 
 func Test_NIPostBuilder_ResetState(t *testing.T) {

--- a/api/grpcserver/post_service.go
+++ b/api/grpcserver/post_service.go
@@ -109,7 +109,7 @@ func (s *PostService) Client(nodeId types.NodeID) (activation.PostClient, error)
 
 	// TODO(mafa): select correct client based on node id
 	if s.client == nil {
-		return nil, fmt.Errorf("post service not registered")
+		return nil, activation.ErrPostClientNotConnected
 	}
 
 	return s.client, nil

--- a/events/subscription.go
+++ b/events/subscription.go
@@ -85,6 +85,7 @@ func (sub *BufferedSubscription[T]) run(ctx context.Context, s Subscription, mat
 	for {
 		select {
 		case <-ctx.Done():
+			close(sub.result)
 			return
 		case evt := <-s.Out():
 			typed := evt.(T)


### PR DESCRIPTION
## Motivation
Follow up to #5469. This adds unit tests to assert that in the event of a connection drop or error the correct events and logs are emitted.

## Changes
Added tests for various scenarios:
- proof -> complete
- proof -> fail
- proof -> disconnect & reconnect -> complete
- proof -> disconnect -> fail to reconnect

## Test Plan
new tests

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
