### PR TITLE
[Merged by Bors] - Add info log entries for longer activities during node startup

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -659,6 +659,7 @@ func (app *App) initServices(ctx context.Context) error {
 		app.log.With().Info("tortoise will trace execution")
 		trtlopts = append(trtlopts, tortoise.WithTracer())
 	}
+	app.log.Info("initializing tortoise")
 	start := time.Now()
 	trtl, err := tortoise.Recover(
 		ctx,
@@ -1623,6 +1624,7 @@ func (app *App) setupDBs(ctx context.Context, lg log.Log) error {
 			app.Config.DatabaseSizeMeteringInterval,
 		)
 	}
+	app.log.Info("starting cache warmup")
 	start := time.Now()
 	data, err := atxsdata.Warm(
 		app.db,


### PR DESCRIPTION
## Motivation

When watching go-spacemesh log output during startup, log output pauses after a "running migrations" log message while the node warms up the cache. Another time, log output pauses after "registered signing key", while the node initialises the tortoise. These pauses inadvertantly lead people to believe that it's the migrations or key registration that takes up time, where in truth it is another activity.

## Changes

Add "starting" log messages for two activities which take a longer time during startup, to more accurately indicate what the node is doing.