### PR TITLE
[Merged by Bors] - p2p: make AutoNAT service limits configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ configuration is as follows:
 ### Improvements
 
 * [#5464](https://github.com/spacemeshos/go-spacemesh/pull/5464) Make fetch request timeout configurable.
+* [#5479](https://github.com/spacemeshos/go-spacemesh/pull/5479) p2p: make AutoNAT service limits configurable.
 
 ## Release v1.3.5
 

--- a/p2p/host.go
+++ b/p2p/host.go
@@ -90,6 +90,12 @@ func DefaultConfig() Config {
 		EnableTCPTransport:          true,
 		EnableQUICTransport:         false,
 		AdvertiseInterval:           time.Minute,
+		AutoNATServer: AutoNATServer{
+			// Defaults taken from libp2p
+			GlobalMax:   30,
+			PeerMax:     3,
+			ResetPeriod: time.Minute,
+		},
 	}
 }
 
@@ -144,6 +150,13 @@ type Config struct {
 	EnableRoutingDiscovery      bool          `mapstructure:"enable-routing-discovery"`
 	RoutingDiscoveryAdvertise   bool          `mapstructure:"routing-discovery-advertise"`
 	AdvertiseInterval           time.Duration `mapstructure:"advertise-interval"`
+	AutoNATServer               AutoNATServer `mapstructure:"auto-nat-server"`
+}
+
+type AutoNATServer struct {
+	GlobalMax   int           `mapstructure:"global-max"`
+	PeerMax     int           `mapstructure:"peer-max"`
+	ResetPeriod time.Duration `mapstructure:"reset-period"`
 }
 
 type RelayServer struct {
@@ -246,6 +259,10 @@ func New(
 		libp2p.Peerstore(ps),
 		libp2p.BandwidthReporter(p2pmetrics.NewBandwidthCollector()),
 		libp2p.EnableNATService(),
+		libp2p.AutoNATServiceRateLimit(
+			cfg.AutoNATServer.GlobalMax,
+			cfg.AutoNATServer.PeerMax,
+			cfg.AutoNATServer.ResetPeriod),
 		libp2p.ConnectionGater(g),
 	}
 	if cfg.EnableTCPTransport {


### PR DESCRIPTION
## Motivation
With current AutoNAT service limits, many nodes can't request dialback and determine their reachability status. This means they keep DHT in server mode even if they're behind NAT, and that in turn leads to "poisoning" of DHT with many unreachable peers

## Changes
Add `"auto-nat-server"` section to the p2p config

## Test Plan
Verified it on a mainnet node
