### PR TITLE
[Merged by Bors] - Temporary disable macos-12-large runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,15 +107,13 @@ jobs:
         os:
           - ubuntu-latest
           - [self-hosted, linux, arm64]
-          - macos-12-large
+          # - macos-12-large
           - [self-hosted, macOS, arm64]
           - windows-latest
     steps:
       - name: Add OpenCL support - Ubuntu
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: sudo apt-get update -q && sudo apt-get install -qy ocl-icd-opencl-dev libpocl2
-
-
       - name: disable Windows Defender - Windows
         if: ${{ matrix.os == 'windows-latest' }}
         run: |
@@ -144,7 +142,7 @@ jobs:
         os:
           - ubuntu-latest
           - [self-hosted, linux, arm64]
-          - macos-12-large
+          # - macos-12-large
           - [self-hosted, macOS, arm64]
           - windows-latest
     steps:


### PR DESCRIPTION
## Motivation
`macos-12-large` runners are currently often blocking our CI. This PR temporary disables them (only CI - not release) until we find a better way to deal with them or decide to not support Intel Macs any more.

## Changes
- disable `macos-12-large` in CI
- `macos-12-large` is still used for a release build until it is decides to either self host or stop supporting it

## Test Plan
- n/a

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
