### PR TITLE
[Merged by Bors] - Resolve post path relative to working directory

### DIFF
--- a/activation/post_supervisor.go
+++ b/activation/post_supervisor.go
@@ -259,7 +259,6 @@ func (ps *PostSupervisor) runCmd(
 		cmdCfg.PostServiceCmd,
 		args...,
 	)
-	cmd.Dir = filepath.Dir(cmdCfg.PostServiceCmd)
 	pipe, err := cmd.StderrPipe()
 	if err != nil {
 		ps.logger.Error("setup stderr pipe for post service", zap.Error(err))


### PR DESCRIPTION
## Motivation
The post directory is resolved unintuitively when a relative path is specified. At the moment it is taken relative to the location of the service binary, while it should be resolved relative to the current working directory.

## Changes
- don't set working directory of post service explicitly, this will cause the process to inherit the working directory from its parent (go-spacemesh)

## Test Plan
existing tests pass
