### PR TITLE
[Merged by Bors] - Update PR template and bors configuration

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,17 +1,22 @@
 ## Motivation
-<!-- Please mention the issue fixed by this PR or detailed motivation -->
-Closes #
-<!-- `Closes #XXXX, closes #XXXX, ...` links mentioned issues to this PR and automatically closes them when this it's merged -->
 
-## Changes
-<!-- Please describe in detail the changes made -->
+<!-- Give a brief description of the motivation for this PR. 1-2 sentences is fine. -->
+
+## Description
+
+<!-- If applicable please mention the issue addressed by this PR -->
+<!-- `Closes #XXXX` links mentioned issues to this PR and automatically closes them when this it's merged -->
+
+<!-- Please describe in detail the changes made. Focus on the reasoning rather than describing the change -->
 
 ## Test Plan
-<!-- Please specify how these changes were tested
-(e.g. unit tests, manual testing, etc.) -->
+
+<!-- Please specify how these changes were tested (e.g. unit tests, manual testing, etc.) -->
 
 ## TODO
-<!-- This section should be removed when all items are complete -->
+
+<!-- Please tick off the TODOs when completed -->
+
 - [ ] Explain motivation or link existing issue(s)
 - [ ] Test changes and document test plan
 - [ ] Update documentation as needed

--- a/bors.toml
+++ b/bors.toml
@@ -1,7 +1,9 @@
 status = ["ci-status", "systest-status"]
 
+block_labels = [ "do-not-merge-yet" ]
 required_approvals = 1
 delete_merged_branches = true
 update_base_for_deletes = true
 use_squash_merge = true
+cut_body_after = "## Description"
 timeout_sec = 10800            # 3 hours


### PR DESCRIPTION
## Motivation

This change updates the template for PRs and bors configuration to not include the whole PR description after merging.

## Description

- Bors at the moment is configured to include the whole PR description into a merge. This is usually not helpful. The new setup of PR template and bors configuration should now only include the `Motivation` section of the PR description which is intended to give a short summary about the change.
- Additionally a new label `do-not-merge-yet` has been added that maintainers can use to flag a PR to not accidentally be merged.

## Test Plan

n/a

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
