### PR TITLE
[Merged by Bors] - Make routing discovery more configurable and less spammy by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,8 @@ configuration is as follows:
 * [#5479](https://github.com/spacemeshos/go-spacemesh/pull/5479) p2p: make AutoNAT service limits configurable.
 * [#5489](https://github.com/spacemeshos/go-spacemesh/pull/5489)
   Fix problem in POST proving where too many files were opened at the same time.
+* [#5494](https://github.com/spacemeshos/go-spacemesh/pull/5494)
+  Make routing discovery more configurable and less spammy by default.
 
 ## Release v1.3.5
 

--- a/p2p/dhtdiscovery/discovery.go
+++ b/p2p/dhtdiscovery/discovery.go
@@ -122,9 +122,9 @@ func AdvertiseForPeerDiscovery() Opt {
 	}
 }
 
-func WithAdvertiseRetryDelay(aint time.Duration) Opt {
+func WithAdvertiseRetryDelay(value time.Duration) Opt {
 	return func(d *Discovery) {
-		d.advertiseRetryDelay = aint
+		d.advertiseRetryDelay = value
 	}
 }
 

--- a/p2p/dhtdiscovery/discovery.go
+++ b/p2p/dhtdiscovery/discovery.go
@@ -128,21 +128,21 @@ func WithAdvertiseRetryDelay(value time.Duration) Opt {
 	}
 }
 
-func WithAdvertiseDelay(ad time.Duration) Opt {
+func WithAdvertiseDelay(value time.Duration) Opt {
 	return func(d *Discovery) {
-		d.advertiseDelay = ad
+		d.advertiseDelay = value
 	}
 }
 
-func WithAdvertiseInterval(aint time.Duration) Opt {
+func WithAdvertiseInterval(value time.Duration) Opt {
 	return func(d *Discovery) {
-		d.advertiseInterval = aint
+		d.advertiseInterval = value
 	}
 }
 
-func WithFindPeersRetryDelay(fd time.Duration) Opt {
+func WithFindPeersRetryDelay(value time.Duration) Opt {
 	return func(d *Discovery) {
-		d.findPeersRetryDelay = fd
+		d.findPeersRetryDelay = value
 	}
 }
 

--- a/p2p/dhtdiscovery/discovery_test.go
+++ b/p2p/dhtdiscovery/discovery_test.go
@@ -58,6 +58,7 @@ func TestSanity(t *testing.T) {
 		Private(),
 		WithLogger(logger),
 		WithMode(dht.ModeServer),
+		WithFindPeersRetryDelay(1*time.Second),
 	)
 	require.NoError(t, err)
 	bootdisc.Start()
@@ -111,6 +112,10 @@ func TestSanity(t *testing.T) {
 			EnableRoutingDiscovery(),
 			AdvertiseForPeerDiscovery(),
 			WithMode(nodeOpts[i].dhtMode),
+			WithAdvertiseDelay(10 * time.Millisecond),
+			WithAdvertiseInterval(1 * time.Minute),
+			WithAdvertiseRetryDelay(1 * time.Second),
+			WithFindPeersRetryDelay(1 * time.Second),
 		}
 		if nodeOpts[i].lookForRelays {
 			relayCh := make(chan peer.AddrInfo)

--- a/p2p/host.go
+++ b/p2p/host.go
@@ -89,12 +89,17 @@ func DefaultConfig() Config {
 		PingInterval:                time.Second,
 		EnableTCPTransport:          true,
 		EnableQUICTransport:         false,
-		AdvertiseInterval:           time.Hour,
 		AutoNATServer: AutoNATServer{
 			// Defaults taken from libp2p
 			GlobalMax:   30,
 			PeerMax:     3,
 			ResetPeriod: time.Minute,
+		},
+		DiscoveryTimings: DiscoveryTimings{
+			AdvertiseDelay:      time.Hour,
+			AdvertiseInterval:   time.Hour,
+			AdvertiseRetryDelay: time.Minute,
+			FindPeersRetryDelay: time.Minute,
 		},
 	}
 }
@@ -112,45 +117,52 @@ type Config struct {
 	MaxMessageSize     int           `mapstructure:"maxmessagesize"`
 
 	// see https://lwn.net/Articles/542629/ for reuseport explanation
-	DisableReusePort            bool          `mapstructure:"disable-reuseport"`
-	DisableNatPort              bool          `mapstructure:"disable-natport"`
-	DisableConnectionManager    bool          `mapstructure:"disable-connection-manager"`
-	DisableResourceManager      bool          `mapstructure:"disable-resource-manager"`
-	DisableDHT                  bool          `mapstructure:"disable-dht"`
-	Flood                       bool          `mapstructure:"flood"`
-	Listen                      AddressList   `mapstructure:"listen"`
-	Bootnodes                   []string      `mapstructure:"bootnodes"`
-	Direct                      []string      `mapstructure:"direct"`
-	MinPeers                    int           `mapstructure:"min-peers"`
-	LowPeers                    int           `mapstructure:"low-peers"`
-	HighPeers                   int           `mapstructure:"high-peers"`
-	InboundFraction             float64       `mapstructure:"inbound-fraction"`
-	OutboundFraction            float64       `mapstructure:"outbound-fraction"`
-	AutoscalePeers              bool          `mapstructure:"autoscale-peers"`
-	AdvertiseAddress            AddressList   `mapstructure:"advertise-address"`
-	AcceptQueue                 int           `mapstructure:"p2p-accept-queue"`
-	Metrics                     bool          `mapstructure:"p2p-metrics"`
-	Bootnode                    bool          `mapstructure:"p2p-bootnode"`
-	ForceReachability           string        `mapstructure:"p2p-reachability"`
-	ForceDHTServer              bool          `mapstructure:"force-dht-server"`
-	EnableHolepunching          bool          `mapstructure:"p2p-holepunching"`
-	PrivateNetwork              bool          `mapstructure:"p2p-private-network"`
-	RelayServer                 RelayServer   `mapstructure:"relay-server"`
-	IP4Blocklist                []string      `mapstructure:"ip4-blocklist"`
-	IP6Blocklist                []string      `mapstructure:"ip6-blocklist"`
-	GossipQueueSize             int           `mapstructure:"gossip-queue-size"`
-	GossipValidationThrottle    int           `mapstructure:"gossip-validation-throttle"`
-	GossipAtxValidationThrottle int           `mapstructure:"gossip-atx-validation-throttle"`
-	PingPeers                   []string      `mapstructure:"ping-peers"`
-	PingInterval                time.Duration `mapstructure:"ping-interval"`
-	Relay                       bool          `mapstructure:"relay"`
-	StaticRelays                []string      `mapstructure:"static-relays"`
-	EnableTCPTransport          bool          `mapstructure:"enable-tcp-transport"`
-	EnableQUICTransport         bool          `mapstructure:"enable-quic-transport"`
-	EnableRoutingDiscovery      bool          `mapstructure:"enable-routing-discovery"`
-	RoutingDiscoveryAdvertise   bool          `mapstructure:"routing-discovery-advertise"`
-	AdvertiseInterval           time.Duration `mapstructure:"advertise-interval"`
-	AutoNATServer               AutoNATServer `mapstructure:"auto-nat-server"`
+	DisableReusePort            bool             `mapstructure:"disable-reuseport"`
+	DisableNatPort              bool             `mapstructure:"disable-natport"`
+	DisableConnectionManager    bool             `mapstructure:"disable-connection-manager"`
+	DisableResourceManager      bool             `mapstructure:"disable-resource-manager"`
+	DisableDHT                  bool             `mapstructure:"disable-dht"`
+	Flood                       bool             `mapstructure:"flood"`
+	Listen                      AddressList      `mapstructure:"listen"`
+	Bootnodes                   []string         `mapstructure:"bootnodes"`
+	Direct                      []string         `mapstructure:"direct"`
+	MinPeers                    int              `mapstructure:"min-peers"`
+	LowPeers                    int              `mapstructure:"low-peers"`
+	HighPeers                   int              `mapstructure:"high-peers"`
+	InboundFraction             float64          `mapstructure:"inbound-fraction"`
+	OutboundFraction            float64          `mapstructure:"outbound-fraction"`
+	AutoscalePeers              bool             `mapstructure:"autoscale-peers"`
+	AdvertiseAddress            AddressList      `mapstructure:"advertise-address"`
+	AcceptQueue                 int              `mapstructure:"p2p-accept-queue"`
+	Metrics                     bool             `mapstructure:"p2p-metrics"`
+	Bootnode                    bool             `mapstructure:"p2p-bootnode"`
+	ForceReachability           string           `mapstructure:"p2p-reachability"`
+	ForceDHTServer              bool             `mapstructure:"force-dht-server"`
+	EnableHolepunching          bool             `mapstructure:"p2p-holepunching"`
+	PrivateNetwork              bool             `mapstructure:"p2p-private-network"`
+	RelayServer                 RelayServer      `mapstructure:"relay-server"`
+	IP4Blocklist                []string         `mapstructure:"ip4-blocklist"`
+	IP6Blocklist                []string         `mapstructure:"ip6-blocklist"`
+	GossipQueueSize             int              `mapstructure:"gossip-queue-size"`
+	GossipValidationThrottle    int              `mapstructure:"gossip-validation-throttle"`
+	GossipAtxValidationThrottle int              `mapstructure:"gossip-atx-validation-throttle"`
+	PingPeers                   []string         `mapstructure:"ping-peers"`
+	PingInterval                time.Duration    `mapstructure:"ping-interval"`
+	Relay                       bool             `mapstructure:"relay"`
+	StaticRelays                []string         `mapstructure:"static-relays"`
+	EnableTCPTransport          bool             `mapstructure:"enable-tcp-transport"`
+	EnableQUICTransport         bool             `mapstructure:"enable-quic-transport"`
+	EnableRoutingDiscovery      bool             `mapstructure:"enable-routing-discovery"`
+	RoutingDiscoveryAdvertise   bool             `mapstructure:"routing-discovery-advertise"`
+	DiscoveryTimings            DiscoveryTimings `mapstructure:"discovery-timings"`
+	AutoNATServer               AutoNATServer    `mapstructure:"auto-nat-server"`
+}
+
+type DiscoveryTimings struct {
+	AdvertiseDelay      time.Duration `mapstructure:"advertise-delay"`
+	AdvertiseInterval   time.Duration `mapstructure:"advertise-interval"`
+	AdvertiseRetryDelay time.Duration `mapstructure:"advertise-retry-delay"`
+	FindPeersRetryDelay time.Duration `mapstructure:"find-peers-retry-delay"`
 }
 
 type AutoNATServer struct {

--- a/p2p/upgrade.go
+++ b/p2p/upgrade.go
@@ -157,7 +157,10 @@ func Upgrade(h host.Host, opts ...Opt) (*Host, error) {
 		discovery.WithDir(cfg.DataDir),
 		discovery.WithBootnodes(bootnodes),
 		discovery.WithLogger(fh.logger.Zap()),
-		discovery.WithAdvertiseInterval(fh.cfg.AdvertiseInterval),
+		discovery.WithAdvertiseDelay(fh.cfg.DiscoveryTimings.AdvertiseDelay),
+		discovery.WithAdvertiseInterval(fh.cfg.DiscoveryTimings.AdvertiseInterval),
+		discovery.WithAdvertiseRetryDelay(fh.cfg.DiscoveryTimings.AdvertiseInterval),
+		discovery.WithFindPeersRetryDelay(fh.cfg.DiscoveryTimings.FindPeersRetryDelay),
 	}
 	if cfg.PrivateNetwork {
 		dopts = append(dopts, discovery.Private())


### PR DESCRIPTION
## Motivation

Enabling routing discovery advertisement causes too much of kad (DHT) traffic on the nodes with DHT server mode enabled (public IP)

## Description

Add `discovery-timings` section in the p2p config for tuning routing discovery intervals and timeouts.
Less spammy defaults:
* only start advertising after 1h of uptime (but still start discovering the peers behind NAT immediately)
* use 1h TTL / re-advertise interval
* use 1m interval for discovery / advertisement retries

## Test Plan

Tested by running a node on mainnet and observing discovery of other peers