### PR TITLE
[Merged by Bors] - Fix flaky TestCalcEligibilityWithSpaceUnit

### DIFF
--- a/hare/eligibility/oracle_test.go
+++ b/hare/eligibility/oracle_test.go
@@ -298,13 +298,7 @@ func TestCalcEligibilityWithSpaceUnit(t *testing.T) {
 				eligibilityCount += res
 			}
 
-			diff := committeeSize - int(eligibilityCount)
-			if diff < 0 {
-				diff = -diff
-			}
-			t.Logf("diff=%d (%g%% of committeeSize)", diff, 100*float64(diff)/float64(committeeSize))
-			require.Less(t, diff, committeeSize*15/100) // up to 15% difference
-
+			require.InDelta(t, committeeSize, eligibilityCount, committeeSize*15/100) // up to 15% difference
 			// a correct check would be to calculate the expected variance of the binomial distribution
 			// which depends on the number of miners and the number of units each miner has
 			// and then assert that the difference is within 3 standard deviations of the expected value

--- a/hare/eligibility/oracle_test.go
+++ b/hare/eligibility/oracle_test.go
@@ -303,9 +303,11 @@ func TestCalcEligibilityWithSpaceUnit(t *testing.T) {
 				diff = -diff
 			}
 			t.Logf("diff=%d (%g%% of committeeSize)", diff, 100*float64(diff)/float64(committeeSize))
-			require.Less(t, diff, committeeSize/10) // up to 10% difference
-			// While it's theoretically possible to get a result higher than 10%, I've run this many times and haven't seen
-			// anything higher than 6% and it's usually under 3%.
+			require.Less(t, diff, committeeSize*15/100) // up to 15% difference
+
+			// a correct check would be to calculate the expected variance of the binomial distribution
+			// which depends on the number of miners and the number of units each miner has
+			// and then assert that the difference is within 3 standard deviations of the expected value
 		})
 	}
 }


### PR DESCRIPTION
## Motivation

`TestCalcEligibilityWithSpaceUnit` has been flaky for some time because it asserts probabilistic values that can lie outside the expected range with a small chance.

## Description

<!-- If applicable please mention the issue addressed by this PR -->
<!-- `Closes #XXXX` links mentioned issues to this PR and automatically closes them when this it's merged -->
Closes #4668 
<!-- Please describe in detail the changes made. Focus on the reasoning rather than describing the change -->
This increases the allowed deviation from the expected value from 10% to 15%. A proper fix would calculate the variance and fail if the calculated committee size is 3 sd above or below the expected value (800).

I seem to not be smart enough to calculate this correctly; the eligibility count varies with the eligibility of every miner in the active set, which again varies based on the weight of the miner and the total weight of the epoch.

## Test Plan

I ran this test with `go test -count=200 -run ^TestCalcEligibilityWithSpaceUnit$ github.com/spacemeshos/go-spacemesh/hare/eligibility` and it didn't fail a single time. However this doesn't mean that the test would detect a bias in the algorithm that calculates eligibilities.

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
