### PR TITLE
[Merged by Bors] - Half of the CPU threads by default assigned to verifying

### DIFF
--- a/activation/post.go
+++ b/activation/post.go
@@ -91,7 +91,7 @@ type PostProofVerifyingOpts struct {
 }
 
 func DefaultPostVerifyingOpts() PostProofVerifyingOpts {
-	workers := runtime.NumCPU() * 3 / 4
+	workers := runtime.NumCPU() * 1 / 2
 	if workers < 1 {
 		workers = 1
 	}


### PR DESCRIPTION
Now we assign 3/4 that kills the performance of most of the laptops and systems where someone tries to do something else besides using go-sm.