### PR TITLE
Backport - Reduce default number of CPUs used for verifying incoming proofs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ See [RELEASE](./RELEASE.md) for workflow instructions.
 * [#5489](https://github.com/spacemeshos/go-spacemesh/pull/5489)
   Fix problem in POST proving where too many files were opened at the same time.
 
+* [#5498](https://github.com/spacemeshos/go-spacemesh/pull/5498)
+  Reduce the default number of CPU cores that are used for verifying incoming ATXs to half of the available cores.
+
 ## Release v1.3.5
 
 ### Improvements

--- a/activation/post.go
+++ b/activation/post.go
@@ -89,7 +89,7 @@ type PostProofVerifyingOpts struct {
 }
 
 func DefaultPostVerifyingOpts() PostProofVerifyingOpts {
-	workers := runtime.NumCPU() * 3 / 4
+	workers := runtime.NumCPU() * 1 / 2
 	if workers < 1 {
 		workers = 1
 	}


### PR DESCRIPTION
## Motivation

Backport of #5498 - half CPU cores for verification

## Description

Backport of #5498

## Test Plan

n/a

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
