### PR TITLE
[Merged by Bors] - Improve DB tests

### DIFF
--- a/sql/database_test.go
+++ b/sql/database_test.go
@@ -128,14 +128,26 @@ func TestDatabaseSkipMigrations(t *testing.T) {
 
 func TestDatabaseVacuumState(t *testing.T) {
 	dir := t.TempDir()
+
+	ctrl := gomock.NewController(t)
+	migration1 := NewMockMigration(ctrl)
+	migration1.EXPECT().Order().Return(1).AnyTimes()
+	migration1.EXPECT().Apply(gomock.Any()).Return(nil).Times(1)
+
+	migration2 := NewMockMigration(ctrl)
+	migration2.EXPECT().Order().Return(2).AnyTimes()
+	migration2.EXPECT().Apply(gomock.Any()).Return(nil).Times(1)
+
 	dbFile := filepath.Join(dir, "test.sql")
-	db, err := Open("file:" + dbFile)
+	db, err := Open("file:"+dbFile,
+		WithMigrations([]Migration{migration1}),
+	)
 	require.NoError(t, err)
 	require.NoError(t, db.Close())
 
 	db, err = Open("file:"+dbFile,
-		WithMigrations([]Migration{}),
-		WithVacuumState(10),
+		WithMigrations([]Migration{migration1, migration2}),
+		WithVacuumState(2),
 	)
 	require.NoError(t, err)
 	require.NoError(t, db.Close())

--- a/sql/migrations_test.go
+++ b/sql/migrations_test.go
@@ -1,6 +1,7 @@
 package sql
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -15,5 +16,11 @@ func TestMigrationsAppliedOnce(t *testing.T) {
 		return true
 	})
 	require.NoError(t, err)
-	require.Equal(t, version, 10)
+
+	migrations, err := StateMigrations()
+	require.NoError(t, err)
+	expectedVersion := slices.MaxFunc(migrations, func(a, b Migration) int {
+		return a.Order() - b.Order()
+	})
+	require.Equal(t, expectedVersion.Order(), version)
 }


### PR DESCRIPTION
## Motivation

This PR improves two tests in the `sql` package that are currently required to be updated every time a new migration is added. Instead the tests are now self contained and don't fail after adding a migration.

## Description

- `TestDatabaseVacuumState` this test fails when adding a migration because the layer at which the DB vacuum is applied needs to be the latest layer for the test to successfully assert the compression. Instead of using the default (real) migration the tests now uses 2 mocked migrations and will not fail again when adding new migrations
- `TestMigrationsAppliedOnce` the test asserts that a new DB is migrated to the newest version according to the migrations we have in place. Instead of manually having to update the test every time a new migration is added the test now checks what should be the correct version after migration and asserts for that.

## Test Plan

<!-- Please specify how these changes were tested (e.g. unit tests, manual testing, etc.) -->
- new tests pass

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
