### PR TITLE
[Merged by Bors] - Make fetcher limit to 60MiB

### DIFF
--- a/fetch/wire_types.go
+++ b/fetch/wire_types.go
@@ -22,7 +22,7 @@ type RequestMessage struct {
 // ResponseMessage is sent to the node as a response.
 type ResponseMessage struct {
 	Hash types.Hash32
-	Data []byte `scale:"max=41943040"` // limit to 40 MiB
+	Data []byte `scale:"max=62914560"` // limit to 60 MiB
 }
 
 // RequestBatch is a batch of requests and a hash of all requests as ID.

--- a/fetch/wire_types_scale.go
+++ b/fetch/wire_types_scale.go
@@ -55,7 +55,7 @@ func (t *ResponseMessage) EncodeScale(enc *scale.Encoder) (total int, err error)
 		total += n
 	}
 	{
-		n, err := scale.EncodeByteSliceWithLimit(enc, t.Data, 41943040)
+		n, err := scale.EncodeByteSliceWithLimit(enc, t.Data, 62914560)
 		if err != nil {
 			return total, err
 		}
@@ -73,7 +73,7 @@ func (t *ResponseMessage) DecodeScale(dec *scale.Decoder) (total int, err error)
 		total += n
 	}
 	{
-		field, n, err := scale.DecodeByteSliceWithLimit(dec, 41943040)
+		field, n, err := scale.DecodeByteSliceWithLimit(dec, 62914560)
 		if err != nil {
 			return total, err
 		}

--- a/p2p/server/server.go
+++ b/p2p/server/server.go
@@ -95,7 +95,7 @@ type Handler func(context.Context, []byte) ([]byte, error)
 
 // Response is a server response.
 type Response struct {
-	Data  []byte `scale:"max=41943040"` // 40 MiB
+	Data  []byte `scale:"max=62914560"` // 60 MiB
 	Error string `scale:"max=1024"`     // TODO(mafa): make error code instead of string
 }
 

--- a/p2p/server/server_scale.go
+++ b/p2p/server/server_scale.go
@@ -9,7 +9,7 @@ import (
 
 func (t *Response) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	{
-		n, err := scale.EncodeByteSliceWithLimit(enc, t.Data, 41943040)
+		n, err := scale.EncodeByteSliceWithLimit(enc, t.Data, 62914560)
 		if err != nil {
 			return total, err
 		}
@@ -27,7 +27,7 @@ func (t *Response) EncodeScale(enc *scale.Encoder) (total int, err error) {
 
 func (t *Response) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	{
-		field, n, err := scale.DecodeByteSliceWithLimit(dec, 41943040)
+		field, n, err := scale.DecodeByteSliceWithLimit(dec, 62914560)
 		if err != nil {
 			return total, err
 		}


### PR DESCRIPTION
1.5M atx is about 53-54MB small room, and we end up with 60.