### PR TITLE
[Merged by Bors] - mesh: notify tortoise about applying only verified layers

### DIFF
--- a/mesh/mesh.go
+++ b/mesh/mesh.go
@@ -306,7 +306,6 @@ func (msh *Mesh) ProcessLayer(ctx context.Context, lid types.LayerID) error {
 					encoder.AppendObject(&results[i])
 				}
 				return nil
-
 			})),
 		)
 	}

--- a/mesh/mesh.go
+++ b/mesh/mesh.go
@@ -306,6 +306,7 @@ func (msh *Mesh) ProcessLayer(ctx context.Context, lid types.LayerID) error {
 					encoder.AppendObject(&results[i])
 				}
 				return nil
+
 			})),
 		)
 	}
@@ -399,8 +400,12 @@ func (msh *Mesh) applyResults(ctx context.Context, results []result.Layer) error
 		}); err != nil {
 			return err
 		}
-		msh.trtl.OnApplied(layer.Layer, layer.Opinion)
 		if layer.Verified {
+			// tortoise will evict layer when OnApplied is called.
+			// however we also apply layers before contextual validity was determined (e.g block.Valid field)
+			// in such case we would apply block because of hare, and then we may evict event when block.Valid was set
+			// but before it was saved to database
+			msh.trtl.OnApplied(layer.Layer, layer.Opinion)
 			events.ReportLayerUpdate(events.LayerUpdate{
 				LayerID: layer.Layer,
 				Status:  events.LayerStatusTypeApplied,

--- a/mesh/mesh_test.go
+++ b/mesh/mesh_test.go
@@ -757,7 +757,6 @@ func TestProcessLayer(t *testing.T) {
 
 			tm := createTestMesh(t)
 			tm.mockTortoise.EXPECT().TallyVotes(gomock.Any(), gomock.Any()).AnyTimes()
-			tm.mockTortoise.EXPECT().OnApplied(gomock.Any(), gomock.Any()).AnyTimes()
 			tm.mockVM.EXPECT().GetStateRoot().AnyTimes()
 			tm.mockVM.EXPECT().Revert(gomock.Any()).AnyTimes()
 			tm.mockState.EXPECT().RevertCache(gomock.Any()).AnyTimes()
@@ -770,6 +769,21 @@ func TestProcessLayer(t *testing.T) {
 						UpdateCache(gomock.Any(), gomock.Any(), executed, gomock.Any(), gomock.Any()).
 						Return(nil)
 				}
+
+				for _, update := range c.updates {
+					hasData := true
+					allInvalid := true
+					for _, block := range update.Blocks {
+						hasData = hasData && block.Data
+						allInvalid = allInvalid && block.Invalid
+					}
+					if update.Verified && (hasData || allInvalid) {
+						tm.mockTortoise.EXPECT().OnApplied(update.Layer, update.Opinion)
+					} else {
+						break
+					}
+				}
+
 				tm.mockTortoise.EXPECT().Updates().Return(c.updates)
 				ensuresDatabaseConsistent(t, tm.cdb, c.updates)
 				err := tm.ProcessLayer(context.TODO(), lid)


### PR DESCRIPTION
followup for https://github.com/spacemeshos/go-spacemesh/pull/5514

we apply layers to the state when tortoise either verified them, or in-order layer was certified by hare, 
but not yet verified by tortoise.

OnApplied call is used to notify tortoise that information about consensus state was used and tortoise is free to get rid of it.
however there is a possible race, such as:
1. tortoise notified that hare=true
2. mesh applied block with hare=true
3. tortoise notified that valid=true
4. mesh called OnApplied for previous, without reading latest information. 

this race would lead to missing `validity` field in blocks table.