### PR TITLE
[Merged by Bors] - Fix size for EpochData type

### DIFF
--- a/common/types/activation.go
+++ b/common/types/activation.go
@@ -503,5 +503,7 @@ func ATXIDsToHashes(ids []ATXID) []Hash32 {
 
 type EpochActiveSet struct {
 	Epoch EpochID
-	Set   []ATXID `scale:"max=1500000"`
+
+	// when we change scale max, we also need to adjust `EpochData` in fetch/wire_types.go
+	Set []ATXID `scale:"max=1500000"`
 }

--- a/common/types/activation.go
+++ b/common/types/activation.go
@@ -503,7 +503,5 @@ func ATXIDsToHashes(ids []ATXID) []Hash32 {
 
 type EpochActiveSet struct {
 	Epoch EpochID
-
-	// when we change scale max, we also need to adjust `EpochData` in fetch/wire_types.go
-	Set []ATXID `scale:"max=1500000"`
+	Set   []ATXID `scale:"max=1500000"` // to be in line with `EpochData` in fetch/wire_types.go
 }

--- a/datastore/store.go
+++ b/datastore/store.go
@@ -45,14 +45,13 @@ type CachedDB struct {
 
 type Config struct {
 	// ATXSize must be larger than the sum of all ATXs in last 2 epochs to be effective
-	// (Epoch 12: ~ 300k, Epoch 11: ~ 200k)
 	ATXSize         int `mapstructure:"atx-size"`
 	MalfeasanceSize int `mapstructure:"malfeasance-size"`
 }
 
 func DefaultConfig() Config {
 	return Config{
-		ATXSize:         1_000_000, // to be in line with fetch.EpochData size (see fetch/wire_types.go)
+		ATXSize:         3_000_000, // to be in line with 2*`EpochData` size (see fetch/wire_types.go) - see comment above
 		MalfeasanceSize: 1_000,
 	}
 }

--- a/fetch/wire_types.go
+++ b/fetch/wire_types.go
@@ -105,7 +105,8 @@ type MaliciousIDs struct {
 }
 
 type EpochData struct {
-	// when we change scale max, we also need to adjust `EpochActiveSet` in common/types/activation.go
+	// to be in line with `EpochActiveSet` in common/types/activation.go
+	// and DefaultConfig in datastore/store.go
 	AtxIDs []types.ATXID `scale:"max=1500000"`
 }
 

--- a/fetch/wire_types.go
+++ b/fetch/wire_types.go
@@ -105,7 +105,8 @@ type MaliciousIDs struct {
 }
 
 type EpochData struct {
-	AtxIDs []types.ATXID `scale:"max=1000000"` // for epoch 13 > 800k ATXs are expected, added some safety margin
+	// when we change scale max, we also need to adjust `EpochActiveSet` in common/types/activation.go
+	AtxIDs []types.ATXID `scale:"max=1500000"`
 }
 
 // LayerData is the data response for a given layer ID.

--- a/fetch/wire_types_scale.go
+++ b/fetch/wire_types_scale.go
@@ -258,7 +258,7 @@ func (t *MaliciousIDs) DecodeScale(dec *scale.Decoder) (total int, err error) {
 
 func (t *EpochData) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	{
-		n, err := scale.EncodeStructSliceWithLimit(enc, t.AtxIDs, 1000000)
+		n, err := scale.EncodeStructSliceWithLimit(enc, t.AtxIDs, 1500000)
 		if err != nil {
 			return total, err
 		}
@@ -269,7 +269,7 @@ func (t *EpochData) EncodeScale(enc *scale.Encoder) (total int, err error) {
 
 func (t *EpochData) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	{
-		field, n, err := scale.DecodeStructSliceWithLimit[types.ATXID](dec, 1000000)
+		field, n, err := scale.DecodeStructSliceWithLimit[types.ATXID](dec, 1500000)
 		if err != nil {
 			return total, err
 		}


### PR DESCRIPTION
## Motivation

Adjusts the `EpochData` type to also be able to handle 1.5 Mio ATXs

## Description

Whenever we adjust either `EpochData` or `EpochActiveSet` we also need to adjust the other to the same value.

## Test Plan

n/a

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
