### PR TITLE
Add CLI flag and config option to disable DB vacuuming during startup

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -84,6 +84,8 @@ func AddCommands(cmd *cobra.Command) {
 		cfg.DatabaseLatencyMetering, "if enabled collect latency histogram for every database query")
 	cmd.PersistentFlags().DurationVar(&cfg.DatabasePruneInterval, "db-prune-interval",
 		cfg.DatabasePruneInterval, "configure interval for database pruning")
+	cmd.PersistentFlags().BoolVar(&cfg.DatabaseVacuumDisable, "db-vacuum-disable",
+		cfg.DatabaseVacuumDisable, "disable vacuum of db on node startup")
 
 	cmd.PersistentFlags().BoolVar(&cfg.NoMainOverride, "no-main-override",
 		cfg.NoMainOverride, "force 'nomain' builds to run on the mainnet")

--- a/config/config.go
+++ b/config/config.go
@@ -115,6 +115,7 @@ type BaseConfig struct {
 	DatabaseLatencyMetering      bool          `mapstructure:"db-latency-metering"`
 	DatabaseSizeMeteringInterval time.Duration `mapstructure:"db-size-metering-interval"`
 	DatabasePruneInterval        time.Duration `mapstructure:"db-prune-interval"`
+	DatabaseVacuumDisable        bool          `mapstructure:"db-vacuum-disable"`
 	DatabaseVacuumState          int           `mapstructure:"db-vacuum-state"`
 	DatabaseSkipMigrations       []int         `mapstructure:"db-skip-migrations"`
 
@@ -217,6 +218,7 @@ func defaultBaseConfig() BaseConfig {
 		DatabaseConnections:          16,
 		DatabaseSizeMeteringInterval: 10 * time.Minute,
 		DatabasePruneInterval:        30 * time.Minute,
+		DatabaseVacuumDisable:        false,
 		NetworkHRP:                   "sm",
 		ATXGradeDelay:                10 * time.Second,
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -1669,6 +1669,7 @@ func (app *App) setupDBs(ctx context.Context, lg log.Log) error {
 		sql.WithMigrations(migrations),
 		sql.WithConnections(app.Config.DatabaseConnections),
 		sql.WithLatencyMetering(app.Config.DatabaseLatencyMetering),
+		sql.WithVacuumDisabled(app.Config.DatabaseVacuumDisable),
 		sql.WithVacuumState(app.Config.DatabaseVacuumState),
 	}
 	if len(app.Config.DatabaseSkipMigrations) > 0 {


### PR DESCRIPTION
## Motivation

Automatic DB vacuuming is helpful for the "home user". However, when managing a large number of nodes, this comes at the cost of significant IO and a noticeable node startup delay. In-place VACUUM also needs up to twice the original database's size [1], which can quickly become a problem with restarting multiple nodes.

When managing many nodes, many operators hot-copy database snapshots from "golden" reference nodes (using `VACUUM INTO`) around, thus making the additional vacuuming during startup completely redundant.

It's thus desireable to give experienced operators more choice over if and when to vacuum the state database.

[1] https://www.sqlite.org/lang_vacuum.html

## Changes

Add a `--db-vacuum-disable` CLI flag (and corresponding configuration item) which, when passed, completely disables state.sql VACUUM during startup.