### PR TITLE
[Merged by Bors] - p2p: fix request timeout

### DIFF
--- a/p2p/server/server.go
+++ b/p2p/server/server.go
@@ -322,7 +322,7 @@ func (s *Server) Request(
 }
 
 func (s *Server) request(ctx context.Context, pid peer.ID, req []byte) (*Response, error) {
-	ctx, cancel := context.WithTimeout(ctx, s.timeout)
+	ctx, cancel := context.WithTimeout(ctx, s.hardTimeout)
 	defer cancel()
 
 	var stream network.Stream


### PR DESCRIPTION
## Motivation

The context timeout for client-side P2P request code is wrong, effectively blocking the advantage of adjustable deadline.

## Description

Use hard timeout (the longer one) for the context.

## Test Plan

Run a node, observe timeout errors

