### PR TITLE
[Merged by Bors] - blocks/certifier: use sql database directly

### DIFF
--- a/blocks/certifier.go
+++ b/blocks/certifier.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/spacemeshos/go-spacemesh/codec"
 	"github.com/spacemeshos/go-spacemesh/common/types"
-	"github.com/spacemeshos/go-spacemesh/datastore"
 	"github.com/spacemeshos/go-spacemesh/hare/eligibility"
 	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/p2p"
@@ -81,7 +80,7 @@ type Certifier struct {
 	stop    func()
 	stopped atomic.Bool
 
-	db         *datastore.CachedDB
+	db         *sql.Database
 	oracle     eligibility.Rolacle
 	signers    map[types.NodeID]*signing.EdSigner
 	edVerifier *signing.EdVerifier
@@ -99,7 +98,7 @@ type Certifier struct {
 
 // NewCertifier creates new block certifier.
 func NewCertifier(
-	db *datastore.CachedDB,
+	db *sql.Database,
 	o eligibility.Rolacle,
 
 	v *signing.EdVerifier,

--- a/blocks/certifier_test.go
+++ b/blocks/certifier_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/spacemeshos/go-spacemesh/blocks/mocks"
 	"github.com/spacemeshos/go-spacemesh/codec"
 	"github.com/spacemeshos/go-spacemesh/common/types"
-	"github.com/spacemeshos/go-spacemesh/datastore"
 	"github.com/spacemeshos/go-spacemesh/hare/eligibility"
 	"github.com/spacemeshos/go-spacemesh/log/logtest"
 	"github.com/spacemeshos/go-spacemesh/p2p/pubsub"
@@ -28,7 +27,7 @@ const defaultCnt = uint16(2)
 
 type testCertifier struct {
 	*Certifier
-	db        *datastore.CachedDB
+	db        *sql.Database
 	mOracle   *eligibility.MockRolacle
 	mPub      *pubsubmock.MockPublisher
 	mClk      *mocks.MocklayerClock
@@ -39,7 +38,7 @@ type testCertifier struct {
 func newTestCertifier(t *testing.T, signers int) *testCertifier {
 	t.Helper()
 	types.SetLayersPerEpoch(3)
-	db := datastore.NewCachedDB(sql.InMemory(), logtest.New(t))
+	db := sql.InMemory()
 	ctrl := gomock.NewController(t)
 	mo := eligibility.NewMockRolacle(ctrl)
 	mp := pubsubmock.NewMockPublisher(ctrl)
@@ -66,7 +65,7 @@ func newTestCertifier(t *testing.T, signers int) *testCertifier {
 	}
 }
 
-func generateBlock(t *testing.T, db *datastore.CachedDB) *types.Block {
+func generateBlock(t *testing.T, db sql.Executor) *types.Block {
 	t.Helper()
 	block := types.NewExistingBlock(
 		types.RandomBlockID(),
@@ -112,7 +111,7 @@ func genEncodedMsg(
 
 func verifyCerts(
 	t *testing.T,
-	db *datastore.CachedDB,
+	db sql.Executor,
 	lid types.LayerID,
 	expected map[types.BlockID]bool,
 ) {

--- a/node/node.go
+++ b/node/node.go
@@ -800,7 +800,7 @@ func (app *App) initServices(ctx context.Context) error {
 	app.Config.Certificate.LayerBuffer = app.Config.Tortoise.Zdist
 	app.Config.Certificate.NumLayersToKeep = app.Config.Tortoise.Zdist * 2
 	app.certifier = blocks.NewCertifier(
-		app.cachedDB,
+		app.db,
 		app.hOracle,
 		app.edVerifier,
 		app.host,


### PR DESCRIPTION
related: https://github.com/spacemeshos/go-spacemesh/issues/5039

it wasn't using any methods that are caching state, so it is a simple cleanup.