### PR TITLE
[backport] disable mesh agreement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 See [RELEASE](./RELEASE.md) for workflow instructions.
 
+## UNRELEASED
+
+### Improvements
+
+* [#5548](https://github.com/spacemeshos/go-spacemesh/pull/5548) Disable mesh aggremenet sync protocol.
+
+  It reduces number of requests for historical activation ids.
+
 ## Release v1.3.9
 
 ### Improvements

--- a/config/mainnet.go
+++ b/config/mainnet.go
@@ -169,6 +169,7 @@ func MainnetConfig() Config {
 			Standalone:               false,
 			GossipDuration:           50 * time.Second,
 			OutOfSyncThresholdLayers: 36, // 3h
+			DisableMeshAgreement:     true,
 			DisableAtxReconciliation: true,
 		},
 		Recovery: checkpoint.DefaultConfig(),

--- a/syncer/state_syncer.go
+++ b/syncer/state_syncer.go
@@ -85,7 +85,7 @@ func (s *Syncer) processLayers(ctx context.Context) error {
 						Warning("failed to adopt peer opinions", lid, log.Err(err))
 				}
 			}
-			if s.IsSynced(ctx) {
+			if s.IsSynced(ctx) && !s.cfg.DisableMeshAgreement {
 				if err = s.checkMeshAgreement(ctx, lid, opinions); err != nil &&
 					errors.Is(err, errMeshHashDiverged) {
 					s.logger.WithContext(ctx).

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -28,6 +28,7 @@ type Config struct {
 	MaxStaleDuration         time.Duration
 	Standalone               bool
 	GossipDuration           time.Duration
+	DisableMeshAgreement     bool   `mapstructure:"disable-mesh-agreement"`
 	DisableAtxReconciliation bool   `mapstructure:"disable-atx-reconciliation"`
 	OutOfSyncThresholdLayers uint32 `mapstructure:"out-of-sync-threshold"`
 }


### PR DESCRIPTION
the goal of mesh agreement is to download ballots and activations when partitions made individual progress. such as in Partition_50_50 or 70_30 tests.

however on mainnet it creates unnecessary load by triggering queries to download atx. i suggest to disable that and wait for set reconciliation to fix it.

related: https://github.com/spacemeshos/go-spacemesh/issues/5519
