### PR TITLE
[Merged by Bors] - p2p: use decaying tags for fetch peers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,8 @@ configuration is as follows:
 
 ### Improvements
 
+* [#5564](https://github.com/spacemeshos/go-spacemesh/pull/5564) Use decaying tags for fetch peers. This prevents
+  libp2p's Connection Manager from breaking sync.
 * [#5418](https://github.com/spacemeshos/go-spacemesh/pull/5418) Add `grpc-post-listener` to separate post service from
   `grpc-private-listener` and not require mTLS for the post service.
 

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -108,7 +108,8 @@ type Config struct {
 	ServersConfig        map[string]ServerConfig `mapstructure:"servers"`
 	PeersRateThreshold   float64                 `mapstructure:"peers-rate-threshold"`
 	// The maximum number of concurrent requests to get ATXs.
-	GetAtxsConcurrency int64 `mapstructure:"getatxsconcurrency"`
+	GetAtxsConcurrency int64                  `mapstructure:"getatxsconcurrency"`
+	DecayingTag        server.DecayingTagSpec `mapstructure:"decaying-tag"`
 }
 
 func (c Config) getServerConfig(protocol string) ServerConfig {
@@ -151,6 +152,12 @@ func DefaultConfig() Config {
 		},
 		PeersRateThreshold: 0.02,
 		GetAtxsConcurrency: 100,
+		DecayingTag: server.DecayingTagSpec{
+			Interval: time.Minute,
+			Inc:      1000,
+			Dec:      1000,
+			Cap:      10000,
+		},
 	}
 }
 
@@ -293,6 +300,7 @@ func (f *Fetch) registerServer(
 		server.WithTimeout(f.cfg.RequestTimeout),
 		server.WithHardTimeout(f.cfg.RequestHardTimeout),
 		server.WithLog(f.logger),
+		server.WithDecayingTag(f.cfg.DecayingTag),
 	}
 	if f.cfg.EnableServerMetrics {
 		opts = append(opts, server.WithMetrics())

--- a/p2p/server/interface.go
+++ b/p2p/server/interface.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"time"
 
+	"github.com/libp2p/go-libp2p/core/connmgr"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/protocol"
@@ -17,6 +18,7 @@ type Host interface {
 	SetStreamHandler(protocol.ID, network.StreamHandler)
 	NewStream(context.Context, peer.ID, ...protocol.ID) (network.Stream, error)
 	Network() network.Network
+	ConnManager() connmgr.ConnManager
 }
 
 type peerStream interface {

--- a/p2p/server/mocks/mocks.go
+++ b/p2p/server/mocks/mocks.go
@@ -13,6 +13,7 @@ import (
 	reflect "reflect"
 	time "time"
 
+	connmgr "github.com/libp2p/go-libp2p/core/connmgr"
 	network "github.com/libp2p/go-libp2p/core/network"
 	peer "github.com/libp2p/go-libp2p/core/peer"
 	protocol "github.com/libp2p/go-libp2p/core/protocol"
@@ -40,6 +41,44 @@ func NewMockHost(ctrl *gomock.Controller) *MockHost {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockHost) EXPECT() *MockHostMockRecorder {
 	return m.recorder
+}
+
+// ConnManager mocks base method.
+func (m *MockHost) ConnManager() connmgr.ConnManager {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ConnManager")
+	ret0, _ := ret[0].(connmgr.ConnManager)
+	return ret0
+}
+
+// ConnManager indicates an expected call of ConnManager.
+func (mr *MockHostMockRecorder) ConnManager() *HostConnManagerCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnManager", reflect.TypeOf((*MockHost)(nil).ConnManager))
+	return &HostConnManagerCall{Call: call}
+}
+
+// HostConnManagerCall wrap *gomock.Call
+type HostConnManagerCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *HostConnManagerCall) Return(arg0 connmgr.ConnManager) *HostConnManagerCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *HostConnManagerCall) Do(f func() connmgr.ConnManager) *HostConnManagerCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *HostConnManagerCall) DoAndReturn(f func() connmgr.ConnManager) *HostConnManagerCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
 }
 
 // Network mocks base method.


### PR DESCRIPTION
## Motivation

When there's some peer churn (connection manager enabled, which is the default), fetch can be interrupted by connection manager dropping connections which are currently used for fetching. This can happen both for fetch clients and servers, breaking sync.

## Description

When a peer connection is used for any fetch request (both on client and server side), a decaying tag is applied to that peer so that the connection with it is kept for some time. After there are no fetch requests for a while (~10 min by default), the decaying tag is removed.

## Test Plan

Verify sync
