### PR TITLE
[Merged by Bors] - hare3: increase preround delay and round length in the standalone

### DIFF
--- a/config/presets/standalone.go
+++ b/config/presets/standalone.go
@@ -36,8 +36,8 @@ func standalone() config.Config {
 	conf.Sync.Interval = 3 * time.Second
 	conf.LayersPerEpoch = 10
 
-	conf.HARE3.PreroundDelay = 100 * time.Millisecond
-	conf.HARE3.RoundDuration = 1 * time.Millisecond
+	conf.HARE3.PreroundDelay = 1 * time.Second
+	conf.HARE3.RoundDuration = 100 * time.Millisecond
 
 	conf.Tortoise.Hdist = 2
 	conf.Tortoise.Zdist = 2


### PR DESCRIPTION
increase preround delay to 1s. after 1s hare will check which proposals were submitted, apparently on local node 100ms
was not always sufficient. round duration is increased to 100ms, hare has to process generated messages within this duration,
1ms seemed to be ok, but i decided to bump it just in case as well. 

it is also important to cleanup /tmp/spacemesh directory, as previous state will conflict with new and prevent standalone from working.

closes: https://github.com/spacemeshos/go-spacemesh/issues/5551