### PR TITLE
[Merged by Bors] - Adjust to 2.2M ATXs

### DIFF
--- a/common/types/activation.go
+++ b/common/types/activation.go
@@ -30,7 +30,7 @@ const (
 	Invalid
 )
 
-// ATXID is a 32-bit hash used to identify an activation transaction.
+// ATXID is a 32 byte hash used to identify an activation transaction.
 type ATXID Hash32
 
 const (
@@ -520,5 +520,5 @@ func ATXIDsToHashes(ids []ATXID) []Hash32 {
 
 type EpochActiveSet struct {
 	Epoch EpochID
-	Set   []ATXID `scale:"max=1500000"` // to be in line with `EpochData` in fetch/wire_types.go
+	Set   []ATXID `scale:"max=2200000"` // to be in line with `EpochData` in fetch/wire_types.go
 }

--- a/common/types/activation_scale.go
+++ b/common/types/activation_scale.go
@@ -423,7 +423,7 @@ func (t *EpochActiveSet) EncodeScale(enc *scale.Encoder) (total int, err error) 
 		total += n
 	}
 	{
-		n, err := scale.EncodeStructSliceWithLimit(enc, t.Set, 1500000)
+		n, err := scale.EncodeStructSliceWithLimit(enc, t.Set, 2200000)
 		if err != nil {
 			return total, err
 		}
@@ -442,7 +442,7 @@ func (t *EpochActiveSet) DecodeScale(dec *scale.Decoder) (total int, err error) 
 		t.Epoch = EpochID(field)
 	}
 	{
-		field, n, err := scale.DecodeStructSliceWithLimit[ATXID](dec, 1500000)
+		field, n, err := scale.DecodeStructSliceWithLimit[ATXID](dec, 2200000)
 		if err != nil {
 			return total, err
 		}

--- a/datastore/store.go
+++ b/datastore/store.go
@@ -59,7 +59,7 @@ type Config struct {
 
 func DefaultConfig() Config {
 	return Config{
-		ATXSize:         3_000_000, // to be in line with 2*`EpochData` size (see fetch/wire_types.go) - see comment above
+		ATXSize:         4_400_000, // to be in line with 2*`EpochData` size (see fetch/wire_types.go) - see comment above
 		MalfeasanceSize: 1_000,
 	}
 }

--- a/fetch/wire_types.go
+++ b/fetch/wire_types.go
@@ -22,7 +22,7 @@ type RequestMessage struct {
 // ResponseMessage is sent to the node as a response.
 type ResponseMessage struct {
 	Hash types.Hash32
-	Data []byte `scale:"max=62914560"` // limit to 60 MiB
+	Data []byte `scale:"max=89128960"` // limit to 85 MiB
 }
 
 // RequestBatch is a batch of requests and a hash of all requests as ID.
@@ -107,7 +107,8 @@ type MaliciousIDs struct {
 type EpochData struct {
 	// to be in line with `EpochActiveSet` in common/types/activation.go
 	// and DefaultConfig in datastore/store.go
-	AtxIDs []types.ATXID `scale:"max=1500000"`
+	// also double-check the size of `ResponseMessage` above
+	AtxIDs []types.ATXID `scale:"max=2200000"`
 }
 
 // LayerData is the data response for a given layer ID.

--- a/fetch/wire_types_scale.go
+++ b/fetch/wire_types_scale.go
@@ -55,7 +55,7 @@ func (t *ResponseMessage) EncodeScale(enc *scale.Encoder) (total int, err error)
 		total += n
 	}
 	{
-		n, err := scale.EncodeByteSliceWithLimit(enc, t.Data, 62914560)
+		n, err := scale.EncodeByteSliceWithLimit(enc, t.Data, 89128960)
 		if err != nil {
 			return total, err
 		}
@@ -73,7 +73,7 @@ func (t *ResponseMessage) DecodeScale(dec *scale.Decoder) (total int, err error)
 		total += n
 	}
 	{
-		field, n, err := scale.DecodeByteSliceWithLimit(dec, 62914560)
+		field, n, err := scale.DecodeByteSliceWithLimit(dec, 89128960)
 		if err != nil {
 			return total, err
 		}
@@ -258,7 +258,7 @@ func (t *MaliciousIDs) DecodeScale(dec *scale.Decoder) (total int, err error) {
 
 func (t *EpochData) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	{
-		n, err := scale.EncodeStructSliceWithLimit(enc, t.AtxIDs, 1500000)
+		n, err := scale.EncodeStructSliceWithLimit(enc, t.AtxIDs, 2200000)
 		if err != nil {
 			return total, err
 		}
@@ -269,7 +269,7 @@ func (t *EpochData) EncodeScale(enc *scale.Encoder) (total int, err error) {
 
 func (t *EpochData) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	{
-		field, n, err := scale.DecodeStructSliceWithLimit[types.ATXID](dec, 1500000)
+		field, n, err := scale.DecodeStructSliceWithLimit[types.ATXID](dec, 2200000)
 		if err != nil {
 			return total, err
 		}


### PR DESCRIPTION
## Motivation

Current limits allow for 1.5M ATXs. This leaves room for a ~36% increase over the previous epoch. Growth in the current epoch may exceed this, so prepare for that chance and increase the limits.

(I realise that this change _may_ be obsolete with upcoming changes to sync. It may be helpful to merge and backport this change to a 1.3.x release early anyway, just in the sync changes either won't obsolete the ATX limit increase or the sync changes don't become ready in time for the next CG.)

## Description

Epoch 14 had ~1.1M ATXs. The strongest epoch-over-epoch growth in the past epochs was ~90%. This change adjusts ATX limits to handle another 90% growth (with some wiggle room) in the current epoch.

Details: Increase EpochData and EpochActiveSet wire types to accommodate up to 2.2M ATXs. Increase fetcher data size limit to 85MiB, to adjust for these wire types. Increase the ATX cache to 4.4M, per the 2*EpochData guideline.

Add a comment to hint at the necessity of adjusting ResponseMessage size when adjusting EpochData size.

Also, fix a comment typo misleading about the ATX ID size.