### PR TITLE
Clean up logging

### DIFF
--- a/activation/handler.go
+++ b/activation/handler.go
@@ -269,7 +269,7 @@ func (h *Handler) SyntacticallyValidateDeps(
 			return nil, fmt.Errorf("adding malfeasance proof: %w", err)
 		}
 		if err := h.publisher.Publish(ctx, pubsub.MalfeasanceProof, codec.MustEncode(&gossip)); err != nil {
-			h.log.With().Error("failed to broadcast malfeasance proof", log.Err(err))
+			h.log.With().Error("failed to broadcast malfeasance proof after validating nipost", log.Err(err))
 		}
 		h.cdb.CacheMalfeasanceProof(atx.SmesherID, &gossip.MalfeasanceProof)
 		h.tortoise.OnMalfeasance(atx.SmesherID)
@@ -454,7 +454,7 @@ func (h *Handler) storeAtx(ctx context.Context, atx *types.VerifiedActivationTx)
 				return fmt.Errorf("add malfeasance proof: %w", err)
 			}
 
-			h.log.WithContext(ctx).With().Warning("smesher produced more than one atx in the same epoch",
+			h.log.WithContext(ctx).With().Info("smesher produced more than one atx in the same epoch",
 				log.Stringer("smesher", atx.SmesherID),
 				log.Object("prev", prev),
 				log.Object("curr", atx),
@@ -493,7 +493,7 @@ func (h *Handler) storeAtx(ctx context.Context, atx *types.VerifiedActivationTx)
 			h.log.With().Fatal("failed to encode malfeasance gossip", log.Err(err))
 		}
 		if err = h.publisher.Publish(ctx, pubsub.MalfeasanceProof, encodedProof); err != nil {
-			h.log.With().Error("failed to broadcast malfeasance proof", log.Err(err))
+			h.log.With().Warning("failed to broadcast malfeasance proof after store atx", log.Err(err))
 			return fmt.Errorf("broadcast atx malfeasance proof: %w", err)
 		}
 		return errMaliciousATX

--- a/activation/handler.go
+++ b/activation/handler.go
@@ -126,7 +126,7 @@ func (h *Handler) ProcessAtx(ctx context.Context, atx *types.VerifiedActivationT
 		log.Stringer("smesher", atx.SmesherID),
 	)
 	if err := h.ContextuallyValidateAtx(atx); err != nil {
-		h.log.WithContext(ctx).With().Warning("atx failed contextual validation",
+		h.log.WithContext(ctx).With().Info("atx failed contextual validation",
 			atx.ID(),
 			log.Stringer("smesher", atx.SmesherID),
 			log.Err(err),

--- a/activation/poetdb.go
+++ b/activation/poetdb.go
@@ -114,7 +114,7 @@ func (db *PoetDb) StoreProof(ctx context.Context, ref types.PoetProofRef, proofM
 			proofMessage.PoetServiceID[:5], proofMessage.RoundID, err)
 	}
 
-	db.log.WithContext(ctx).With().Info("stored poet proof",
+	db.log.WithContext(ctx).With().Debug("stored poet proof",
 		log.String("poet_proof_id", fmt.Sprintf("%x", ref[:5])),
 		log.String("round_id", proofMessage.RoundID),
 		log.String("poet_service_id", fmt.Sprintf("%x", proofMessage.PoetServiceID[:5])),

--- a/api/grpcserver/grpc.go
+++ b/api/grpcserver/grpc.go
@@ -44,7 +44,7 @@ type Server struct {
 }
 
 func unaryGrpcLogStart(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
-	ctxzap.Info(ctx, "started unary call")
+	ctxzap.Debug(ctx, "started unary call")
 	return handler(ctx, req)
 }
 
@@ -54,7 +54,7 @@ func streamingGrpcLogStart(
 	_ *grpc.StreamServerInfo,
 	handler grpc.StreamHandler,
 ) error {
-	ctxzap.Info(stream.Context(), "started streaming call")
+	ctxzap.Debug(stream.Context(), "started streaming call")
 	return handler(srv, stream)
 }
 

--- a/config/logging.go
+++ b/config/logging.go
@@ -55,7 +55,7 @@ func DefaultLoggingConfig() LoggerConfig {
 		Encoder:                    ConsoleLogEncoder,
 		AppLoggerLevel:             defaultLoggingLevel.String(),
 		GrpcLoggerLevel:            defaultLoggingLevel.String(),
-		P2PLoggerLevel:             zapcore.WarnLevel.String(),
+		P2PLoggerLevel:             defaultLoggingLevel.String(),
 		PostLoggerLevel:            defaultLoggingLevel.String(),
 		StateDbLoggerLevel:         defaultLoggingLevel.String(),
 		AtxHandlerLevel:            defaultLoggingLevel.String(),

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -565,7 +565,7 @@ func (f *Fetch) send(requests []RequestMessage) {
 			go func() {
 				data, err := f.sendBatch(peer, batch)
 				if err != nil {
-					f.logger.With().Warning(
+					f.logger.With().Debug(
 						"failed to send batch request",
 						log.Stringer("batch", batch.ID),
 						log.Stringer("peer", peer),
@@ -674,7 +674,7 @@ func (f *Fetch) handleHashError(batch *batchInfo, err error) {
 			continue
 		}
 		f.logger.WithContext(req.ctx).With().
-			Warning("hash request failed", log.Stringer("hash", req.hash), log.Err(err))
+			Debug("hash request failed", log.Stringer("hash", req.hash), log.Err(err))
 		req.promise.err = err
 		peerErrors.WithLabelValues(string(req.hint)).Inc()
 		close(req.promise.completed)

--- a/fetch/mesh_data.go
+++ b/fetch/mesh_data.go
@@ -99,7 +99,7 @@ func (f *Fetch) getHashes(
 				options.limiter.Release(1)
 				pendingMetric.Add(-1)
 				if p.err != nil {
-					f.logger.Debug("failed to get hash",
+					f.logger.WithContext(ctx).With().Debug("failed to get hash",
 						log.String("hint", string(hint)),
 						log.Stringer("hash", h),
 						log.Err(p.err),

--- a/fetch/mesh_data.go
+++ b/fetch/mesh_data.go
@@ -68,6 +68,8 @@ func (f *Fetch) getHashes(
 
 	var eg errgroup.Group
 	var failed atomic.Uint64
+	f.logger.Info("attempting to fetch hash objects",
+		log.Uint64("count", uint64(len(hashes))))
 	for i, hash := range hashes {
 		if err := options.limiter.Acquire(ctx, 1); err != nil {
 			pendingMetric.Add(float64(i - len(hashes)))
@@ -110,6 +112,8 @@ func (f *Fetch) getHashes(
 	}
 
 	eg.Wait()
+	f.logger.Info("finished fetching hash objects",
+		log.Uint64("count", uint64(len(hashes))))
 	if failed.Load() > 0 {
 		return fmt.Errorf("failed to fetch %d hashes out of %d", failed.Load(), len(hashes))
 	}

--- a/fetch/mesh_data.go
+++ b/fetch/mesh_data.go
@@ -68,7 +68,7 @@ func (f *Fetch) getHashes(
 
 	var eg errgroup.Group
 	var failed atomic.Uint64
-	f.logger.Info("attempting to fetch hash objects",
+	f.logger.WithContext(ctx).With().Info("attempting to fetch hash objects",
 		log.Uint64("count", uint64(len(hashes))))
 	for i, hash := range hashes {
 		if err := options.limiter.Acquire(ctx, 1); err != nil {
@@ -112,8 +112,7 @@ func (f *Fetch) getHashes(
 	}
 
 	eg.Wait()
-	f.logger.Info("finished fetching hash objects",
-		log.Uint64("count", uint64(len(hashes))))
+	f.logger.WithContext(ctx).With().Info("finished fetching hash objects")
 	if failed.Load() > 0 {
 		return fmt.Errorf("failed to fetch %d hashes out of %d", failed.Load(), len(hashes))
 	}

--- a/miner/proposal_builder.go
+++ b/miner/proposal_builder.go
@@ -387,7 +387,7 @@ func (pb *ProposalBuilder) decideMeshHash(ctx context.Context, current types.Lay
 }
 
 func (pb *ProposalBuilder) UpdateActiveSet(epoch types.EpochID, activeSet []types.ATXID) {
-	pb.logger.With().Info("received activeset update",
+	pb.logger.With().Debug("received activeset update",
 		epoch,
 		log.Int("size", len(activeSet)),
 	)

--- a/node/node.go
+++ b/node/node.go
@@ -1856,8 +1856,10 @@ func (app *App) startSynchronous(ctx context.Context) (err error) {
 	cfg := app.Config.P2P
 	cfg.DataDir = filepath.Join(app.Config.DataDir(), "p2p")
 	p2plog := app.addLogger(P2PLogger, lg)
-	// if addLogger won't add a level we will use a default 0 (info).
-	cfg.LogLevel = app.getLevel(P2PLogger)
+
+	// our p2p code logs at the default level (Info), but we want the lower level libp2p logging
+	// to be less verbose
+	cfg.LogLevel = zapcore.WarnLevel
 	prologue := fmt.Sprintf("%x-%v",
 		app.Config.Genesis.GenesisID(),
 		types.GetEffectiveGenesis(),

--- a/p2p/dhtdiscovery/discovery.go
+++ b/p2p/dhtdiscovery/discovery.go
@@ -300,7 +300,7 @@ func (d *Discovery) connect(ctx context.Context, eg *errgroup.Group, nodes []pee
 		}
 		eg.Go(func() error {
 			if err := d.h.Connect(conCtx, boot); err != nil {
-				d.logger.Warn("failed to connect",
+				d.logger.Debug("failed to connect",
 					zap.Stringer("address", boot),
 					zap.Error(err),
 				)
@@ -333,14 +333,14 @@ func (d *Discovery) setupDHT(ctx context.Context) error {
 			dht.RoutingTableFilter(dht.PublicRoutingTableFilter))
 	}
 	opts = append(opts, dht.Mode(d.mode))
-	dht, err := dht.New(ctx, d.h, opts...)
+	myDht, err := dht.New(ctx, d.h, opts...)
 	if err != nil {
 		if err := ds.Close(); err != nil {
 			d.logger.Error("error closing level datastore", zap.Error(err))
 		}
 		return err
 	}
-	d.dht = dht
+	d.dht = myDht
 	d.datastore = ds
 	return nil
 }

--- a/p2p/upgrade.go
+++ b/p2p/upgrade.go
@@ -409,7 +409,7 @@ func (fh *Host) trackNetEvents() error {
 				return nil
 			}
 			natEv := ev.(event.EvtNATDeviceTypeChanged)
-			fh.logger.With().Info("NAT type changed",
+			fh.logger.With().Debug("NAT type changed",
 				log.Stringer("transportProtocol", natEv.TransportProtocol),
 				log.Stringer("type", natEv.NatDeviceType))
 			fh.natType.Lock()
@@ -425,7 +425,7 @@ func (fh *Host) trackNetEvents() error {
 				return nil
 			}
 			reachEv := ev.(event.EvtLocalReachabilityChanged)
-			fh.logger.With().Info("local reachability changed",
+			fh.logger.With().Debug("local reachability changed",
 				log.Stringer("reachability", reachEv.Reachability))
 			fh.reachability.Lock()
 			fh.reachability.value = reachEv.Reachability

--- a/proposals/handler.go
+++ b/proposals/handler.go
@@ -391,7 +391,7 @@ func (h *Handler) handleProposal(ctx context.Context, expHash types.Hash32, peer
 		}
 		if err = h.publisher.Publish(ctx, pubsub.MalfeasanceProof, encodedProof); err != nil {
 			failedPublish.Inc()
-			logger.With().Error("failed to broadcast malfeasance proof", log.Err(err))
+			logger.With().Error("failed to broadcast malfeasance proof after process ballot", log.Err(err))
 			return fmt.Errorf("broadcast ballot malfeasance proof: %w", err)
 		}
 		return errMaliciousBallot

--- a/syncer/data_fetch.go
+++ b/syncer/data_fetch.go
@@ -310,7 +310,7 @@ func (d *DataFetch) GetEpochATXs(ctx context.Context, epoch types.EpochID) error
 		return fmt.Errorf("get epoch info (peer %v): %w", peer, err)
 	}
 	if len(ed.AtxIDs) == 0 {
-		d.logger.WithContext(ctx).With().Debug("peer has zero atx",
+		d.logger.WithContext(ctx).With().Debug("peer has no atx data",
 			epoch,
 			log.Stringer("peer", peer),
 		)
@@ -326,6 +326,12 @@ func (d *DataFetch) GetEpochATXs(ctx context.Context, epoch types.EpochID) error
 		log.Int("missing", len(missing)),
 	)
 	if len(missing) > 0 {
+		d.logger.WithContext(ctx).With().Info("fetching missing epoch atxs",
+			epoch,
+			log.Stringer("peer", peer),
+			log.Int("total", len(ed.AtxIDs)),
+			log.Int("missing", len(missing)),
+		)
 		if err := d.fetcher.GetAtxs(ctx, missing); err != nil {
 			return fmt.Errorf("get ATXs: %w", err)
 		}

--- a/syncer/data_fetch.go
+++ b/syncer/data_fetch.go
@@ -310,7 +310,7 @@ func (d *DataFetch) GetEpochATXs(ctx context.Context, epoch types.EpochID) error
 		return fmt.Errorf("get epoch info (peer %v): %w", peer, err)
 	}
 	if len(ed.AtxIDs) == 0 {
-		d.logger.WithContext(ctx).With().Debug("peer have zero atx",
+		d.logger.WithContext(ctx).With().Debug("peer has zero atx",
 			epoch,
 			log.Stringer("peer", peer),
 		)

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -416,11 +416,15 @@ func (s *Syncer) syncAtx(ctx context.Context) error {
 	if !s.ListenToATXGossip() {
 		s.logger.WithContext(ctx).With().Info("beginning atx sync from genesis", s.ticker.CurrentLayer())
 		for epoch := s.lastAtxEpoch() + 1; epoch <= s.ticker.CurrentLayer().GetEpoch(); epoch++ {
+			s.logger.WithContext(ctx).With().Info("syncing epoch atxs",
+				epoch,
+				log.Uint32("epoch_id_current", uint32(s.ticker.CurrentLayer().GetEpoch())),
+			)
 			if err := s.fetchATXsForEpoch(ctx, epoch); err != nil {
 				return err
 			}
 			s.logger.WithContext(ctx).With().Info("synced atxs through epoch",
-				log.Uint32("epoch_id_synced", uint32(epoch)),
+				epoch,
 				log.Uint32("epoch_id_current", uint32(s.ticker.CurrentLayer().GetEpoch())),
 			)
 		}


### PR DESCRIPTION
## Motivation

A developer should be able to tell what's going on by following the node log. This cleans up a lot of the noise in the logs and highlights important information such as sync status. No log lines are removed, but verbosity is decreased (e.g., warn -> info, info -> debug). libp2p logs in particular are moved to warn level.

## Test Plan

N/A, no logic changes

## TODO

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [ ] Update documentation as needed
- [ ] Update [changelog](../CHANGELOG.md) as needed
