### PR TITLE
[Merged by Bors] - metrics: meter how long request spends in queue and sql connection wait time

### DIFF
--- a/p2p/server/metrics.go
+++ b/p2p/server/metrics.go
@@ -46,14 +46,21 @@ var (
 		namespace,
 		"latency since initiating a request",
 		[]string{protoLabel, "result"},
-		prometheus.ExponentialBuckets(0.01, 2, 10),
+		prometheus.ExponentialBuckets(0.01, 2, 20),
 	)
 	serverLatency = metrics.NewHistogramWithBuckets(
 		"server_latency_seconds",
 		namespace,
 		"latency since accepting new stream",
 		[]string{protoLabel},
-		prometheus.ExponentialBuckets(0.01, 2, 10),
+		prometheus.ExponentialBuckets(0.01, 2, 20),
+	)
+	inQueueLatency = metrics.NewHistogramWithBuckets(
+		"in_queue_latency_seconds",
+		namespace,
+		"latency spent in queue",
+		[]string{protoLabel},
+		prometheus.ExponentialBuckets(0.01, 2, 20),
 	)
 )
 
@@ -69,6 +76,7 @@ func newTracker(protocol string) *tracker {
 		clientSucceeded:      clientRequests.WithLabelValues(protocol, "succeeded"),
 		clientFailed:         clientRequests.WithLabelValues(protocol, "failed"),
 		clientServerError:    clientRequests.WithLabelValues(protocol, "server_error"),
+		inQueueLatency:       inQueueLatency.WithLabelValues(protocol),
 		serverLatency:        serverLatency.WithLabelValues(protocol),
 		clientLatency:        clientLatency.WithLabelValues(protocol, "success"),
 		clientLatencyFailure: clientLatency.WithLabelValues(protocol, "failure"),
@@ -86,6 +94,7 @@ type tracker struct {
 	clientSucceeded                     prometheus.Counter
 	clientFailed                        prometheus.Counter
 	clientServerError                   prometheus.Counter
+	inQueueLatency                      prometheus.Observer
 	serverLatency                       prometheus.Observer
 	clientLatency, clientLatencyFailure prometheus.Observer
 }

--- a/p2p/server/server.go
+++ b/p2p/server/server.go
@@ -204,6 +204,9 @@ func (s *Server) Run(ctx context.Context) error {
 			eg.Wait()
 			return nil
 		case req := <-queue:
+			if s.metrics != nil {
+				s.metrics.inQueueLatency.Observe(time.Since(req.received).Seconds())
+			}
 			if err := limit.Wait(ctx); err != nil {
 				eg.Wait()
 				return nil

--- a/sql/database.go
+++ b/sql/database.go
@@ -238,8 +238,17 @@ type Database struct {
 	latency *prometheus.HistogramVec
 }
 
-func (db *Database) getTx(ctx context.Context, initstmt string) (*Tx, error) {
+func (db *Database) getConn(ctx context.Context) *sqlite.Conn {
+	start := time.Now()
 	conn := db.pool.Get(ctx)
+	if conn != nil {
+		connWaitLatency.Observe(time.Since(start).Seconds())
+	}
+	return conn
+}
+
+func (db *Database) getTx(ctx context.Context, initstmt string) (*Tx, error) {
+	conn := db.getConn(ctx)
 	if conn == nil {
 		return nil, ErrNoConnection
 	}
@@ -303,7 +312,7 @@ func (db *Database) WithTxImmediate(ctx context.Context, exec func(*Tx) error) e
 // Note that Exec will block until database is closed or statement has finished.
 // If application needs to control statement execution lifetime use one of the transaction.
 func (db *Database) Exec(query string, encoder Encoder, decoder Decoder) (int, error) {
-	conn := db.pool.Get(context.Background())
+	conn := db.getConn(context.Background())
 	if conn == nil {
 		return 0, ErrNoConnection
 	}

--- a/sql/metrics.go
+++ b/sql/metrics.go
@@ -17,3 +17,11 @@ func newQueryLatency() *prometheus.HistogramVec {
 		prometheus.ExponentialBuckets(100_000, 2, 20),
 	)
 }
+
+var connWaitLatency = metrics.NewHistogramWithBuckets(
+	"conn_wait_seconds",
+	namespace,
+	"time spent in waiting for a connection from a pool",
+	[]string{},
+	prometheus.ExponentialBuckets(0.01, 2, 20),
+).WithLabelValues()


### PR DESCRIPTION
introduced two metrics:
- histogram p2p_server_in_queue_latency_seconds 

describes how long each request waited in the queue before it was received by the handler, for example if queue is overly long, such as size=1000 and req/s=10, request may remain in queue for 100 intervals where interval is usually 1s, which is probably a misconfiguration and will lead to many timed out requests.

- histogram p2p_conn_wait_seconds

number of connections to sqlite is configured in advance and is a way to limit memory usage. however if requests are taking too long then the likelihood of starvation is high, and this is a metric to monitor that. generally should remain very low