### PR TITLE
[Merged by Bors] - Avoid redundant blob encoding in fetcher client side.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,8 @@ configuration is as follows:
   make sure your post service now connects to `grpc-post-listener` instead of `grpc-private-listener`. If you are
   connecting to a remote post service over the internet we strongly recommend using mTLS via `grpc-tls-listener`.
 
+* [5602](https://github.com/spacemeshos/go-spacemesh/pull/5602) Optimize client side of fetcher to avoid encoding when not needed.
+
 ## Release v1.3.8
 
 ### Features

--- a/datastore/store.go
+++ b/datastore/store.go
@@ -407,3 +407,29 @@ func (bs *BlobStore) Get(hint Hint, key []byte) ([]byte, error) {
 	}
 	return nil, fmt.Errorf("blob store not found %s", hint)
 }
+
+func (bs *BlobStore) Has(hint Hint, key []byte) (bool, error) {
+	switch hint {
+	case ATXDB:
+		return atxs.Has(bs.DB, types.BytesToATXID(key))
+	case ProposalDB:
+		return proposals.Has(bs.DB, types.ProposalID(types.BytesToHash(key).ToHash20()))
+	case BallotDB:
+		id := types.BallotID(types.BytesToHash(key).ToHash20())
+		return ballots.Has(bs.DB, id)
+	case BlockDB:
+		id := types.BlockID(types.BytesToHash(key).ToHash20())
+		return blocks.Has(bs.DB, id)
+	case TXDB:
+		return transactions.Has(bs.DB, types.TransactionID(types.BytesToHash(key)))
+	case POETDB:
+		var ref types.PoetProofRef
+		copy(ref[:], key)
+		return poets.Has(bs.DB, ref)
+	case Malfeasance:
+		return identities.IsMalicious(bs.DB, types.BytesToNodeID(key))
+	case ActiveSet:
+		return activesets.Has(bs.DB, key)
+	}
+	return false, fmt.Errorf("blob store not found %s", hint)
+}

--- a/datastore/store_test.go
+++ b/datastore/store_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/log/logtest"
 	"github.com/spacemeshos/go-spacemesh/signing"
 	"github.com/spacemeshos/go-spacemesh/sql"
+	"github.com/spacemeshos/go-spacemesh/sql/activesets"
 	"github.com/spacemeshos/go-spacemesh/sql/atxs"
 	"github.com/spacemeshos/go-spacemesh/sql/ballots"
 	"github.com/spacemeshos/go-spacemesh/sql/blocks"
@@ -213,9 +214,17 @@ func TestBlobStore_GetATXBlob(t *testing.T) {
 	vAtx, err := atx.Verify(0, 1)
 	require.NoError(t, err)
 
+	has, err := bs.Has(datastore.ATXDB, atx.ID().Bytes())
+	require.NoError(t, err)
+	require.False(t, has)
+
 	_, err = bs.Get(datastore.ATXDB, atx.ID().Bytes())
 	require.ErrorIs(t, err, sql.ErrNotFound)
+
 	require.NoError(t, atxs.Add(db, vAtx))
+	has, err = bs.Has(datastore.ATXDB, atx.ID().Bytes())
+	require.NoError(t, err)
+	require.True(t, has)
 	got, err := bs.Get(datastore.ATXDB, atx.ID().Bytes())
 	require.NoError(t, err)
 
@@ -242,9 +251,16 @@ func TestBlobStore_GetBallotBlob(t *testing.T) {
 	blt.SmesherID = sig.NodeID()
 	require.NoError(t, blt.Initialize())
 
+	has, err := bs.Has(datastore.BallotDB, blt.ID().Bytes())
+	require.NoError(t, err)
+	require.False(t, has)
 	_, err = bs.Get(datastore.BallotDB, blt.ID().Bytes())
 	require.ErrorIs(t, err, sql.ErrNotFound)
+
 	require.NoError(t, ballots.Add(db, blt))
+	has, err = bs.Has(datastore.BallotDB, blt.ID().Bytes())
+	require.NoError(t, err)
+	require.True(t, has)
 	got, err := bs.Get(datastore.BallotDB, blt.ID().Bytes())
 	require.NoError(t, err)
 	var gotB types.Ballot
@@ -269,15 +285,24 @@ func TestBlobStore_GetBlockBlob(t *testing.T) {
 	}
 	blk.Initialize()
 
-	_, err := bs.Get(datastore.BlockDB, blk.ID().Bytes())
+	has, err := bs.Has(datastore.BlockDB, blk.ID().Bytes())
+	require.NoError(t, err)
+	require.False(t, has)
+
+	_, err = bs.Get(datastore.BlockDB, blk.ID().Bytes())
 	require.ErrorIs(t, err, sql.ErrNotFound)
+
 	require.NoError(t, blocks.Add(db, &blk))
+	has, err = bs.Has(datastore.BlockDB, blk.ID().Bytes())
+	require.NoError(t, err)
+	require.True(t, has)
 	got, err := bs.Get(datastore.BlockDB, blk.ID().Bytes())
 	require.NoError(t, err)
 	var gotB types.Block
 	require.NoError(t, codec.Decode(got, &gotB))
 	gotB.Initialize()
 	require.Equal(t, blk, gotB)
+
 	_, err = bs.Get(datastore.ProposalDB, blk.ID().Bytes())
 	require.ErrorIs(t, err, sql.ErrNotFound)
 }
@@ -291,11 +316,18 @@ func TestBlobStore_GetPoetBlob(t *testing.T) {
 	sid := []byte("sid0")
 	rid := "rid0"
 
-	_, err := bs.Get(datastore.POETDB, ref)
+	has, err := bs.Has(datastore.POETDB, ref)
+	require.NoError(t, err)
+	require.False(t, has)
+
+	_, err = bs.Get(datastore.POETDB, ref)
 	require.ErrorIs(t, err, sql.ErrNotFound)
 	var poetRef types.PoetProofRef
 	copy(poetRef[:], ref)
 	require.NoError(t, poets.Add(db, poetRef, poet, sid, rid))
+	has, err = bs.Has(datastore.POETDB, ref)
+	require.NoError(t, err)
+	require.True(t, has)
 	got, err := bs.Get(datastore.POETDB, ref)
 	require.NoError(t, err)
 	require.True(t, bytes.Equal(poet, got))
@@ -322,18 +354,22 @@ func TestBlobStore_GetProposalBlob(t *testing.T) {
 	p.SmesherID = signer.NodeID()
 	require.NoError(t, p.Initialize())
 
+	has, err := bs.Has(datastore.ProposalDB, p.ID().Bytes())
+	require.NoError(t, err)
+	require.False(t, has)
 	_, err = bs.Get(datastore.ProposalDB, p.ID().Bytes())
 	require.ErrorIs(t, err, sql.ErrNotFound)
-	require.NoError(t, ballots.Add(db, blt))
+
 	require.NoError(t, proposals.Add(db, &p))
+	has, err = bs.Has(datastore.ProposalDB, p.ID().Bytes())
+	require.NoError(t, err)
+	require.True(t, has)
 	got, err := bs.Get(datastore.ProposalDB, p.ID().Bytes())
 	require.NoError(t, err)
 	var gotP types.Proposal
 	require.NoError(t, codec.Decode(got, &gotP))
 	require.NoError(t, gotP.Initialize())
 	require.Equal(t, p, gotP)
-	_, err = bs.Get(datastore.BlockDB, p.ID().Bytes())
-	require.ErrorIs(t, err, sql.ErrNotFound)
 }
 
 func TestBlobStore_GetTXBlob(t *testing.T) {
@@ -344,9 +380,17 @@ func TestBlobStore_GetTXBlob(t *testing.T) {
 	tx.Raw = []byte{1, 1, 1}
 	tx.ID = types.TransactionID{1}
 
-	_, err := bs.Get(datastore.TXDB, tx.ID.Bytes())
+	has, err := bs.Has(datastore.TXDB, tx.ID.Bytes())
+	require.NoError(t, err)
+	require.False(t, has)
+
+	_, err = bs.Get(datastore.TXDB, tx.ID.Bytes())
 	require.ErrorIs(t, err, sql.ErrNotFound)
+
 	require.NoError(t, transactions.Add(db, tx, time.Now()))
+	has, err = bs.Has(datastore.TXDB, tx.ID.Bytes())
+	require.NoError(t, err)
+	require.True(t, has)
 	got, err := bs.Get(datastore.TXDB, tx.ID.Bytes())
 	require.NoError(t, err)
 	require.Equal(t, tx.Raw, got)
@@ -372,10 +416,41 @@ func TestBlobStore_GetMalfeasanceBlob(t *testing.T) {
 	require.NoError(t, err)
 	nodeID := types.NodeID{1, 2, 3}
 
+	has, err := bs.Has(datastore.Malfeasance, nodeID.Bytes())
+	require.NoError(t, err)
+	require.False(t, has)
+
 	_, err = bs.Get(datastore.Malfeasance, nodeID.Bytes())
 	require.ErrorIs(t, err, sql.ErrNotFound)
+
 	require.NoError(t, identities.SetMalicious(db, nodeID, encoded, time.Now()))
+	has, err = bs.Has(datastore.Malfeasance, nodeID.Bytes())
+	require.NoError(t, err)
+	require.True(t, has)
 	got, err := bs.Get(datastore.Malfeasance, nodeID.Bytes())
 	require.NoError(t, err)
 	require.Equal(t, encoded, got)
+}
+
+func TestBlobStore_GetActiveSet(t *testing.T) {
+	db := sql.InMemory()
+	bs := datastore.NewBlobStore(db)
+
+	as := &types.EpochActiveSet{Epoch: 7}
+	hash := types.ATXIDList(as.Set).Hash()
+
+	has, err := bs.Has(datastore.ActiveSet, hash.Bytes())
+	require.NoError(t, err)
+	require.False(t, has)
+
+	_, err = bs.Get(datastore.ActiveSet, hash.Bytes())
+	require.ErrorIs(t, err, sql.ErrNotFound)
+
+	require.NoError(t, activesets.Add(db, hash, as))
+	has, err = bs.Has(datastore.ActiveSet, hash.Bytes())
+	require.NoError(t, err)
+	require.True(t, has)
+	got, err := bs.Get(datastore.ActiveSet, hash.Bytes())
+	require.NoError(t, err)
+	require.Equal(t, codec.MustEncode(as), got)
 }

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -499,7 +499,7 @@ func (f *Fetch) failAfterRetry(hash types.Hash32) {
 	}
 
 	// first check if we have it locally from gossips
-	if _, err := f.bs.Get(req.hint, hash.Bytes()); err == nil {
+	if has, err := f.bs.Has(req.hint, hash.Bytes()); err == nil && has {
 		close(req.promise.completed)
 		delete(f.ongoing, hash)
 		return
@@ -696,7 +696,7 @@ func (f *Fetch) getHash(
 	}
 
 	// check if we already have this hash locally
-	if _, err := f.bs.Get(h, hash.Bytes()); err == nil {
+	if has, err := f.bs.Has(h, hash.Bytes()); err == nil && has {
 		return nil, nil
 	}
 

--- a/sql/activesets/activesets.go
+++ b/sql/activesets/activesets.go
@@ -83,3 +83,15 @@ func DeleteBeforeEpoch(db sql.Executor, epoch types.EpochID) error {
 	}
 	return nil
 }
+
+func Has(db sql.Executor, id []byte) (bool, error) {
+	rows, err := db.Exec(
+		"select 1 from activesets where id = ?1;",
+		func(stmt *sql.Statement) { stmt.BindBytes(1, id) },
+		nil,
+	)
+	if err != nil {
+		return false, fmt.Errorf("has activeset %s: %w", id, err)
+	}
+	return rows > 0, nil
+}


### PR DESCRIPTION
## Description

The client (requester) side of the fetcher only needs to check if it has the requested thing locally. Currently, it encodes the thing in the process.

Added a `Has(id)` method to the blobstore that only checks the presence of the `id`.

:bulb: Maybe the `BlobStore` could use an LRU cache keyed by the `id` to keep track of "present" things to reduce the number of DB queries on the client side.

## Test Plan

Existing tests pass

## TODO
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
