### PR TITLE
[Merged by Bors] - Do not try to sync over transient connections

### DIFF
--- a/fetch/peers/peers.go
+++ b/fetch/peers/peers.go
@@ -54,14 +54,15 @@ type Peers struct {
 	globalLatency float64
 }
 
-func (p *Peers) Add(id peer.ID) {
+func (p *Peers) Add(id peer.ID) bool {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	_, exist := p.peers[id]
 	if exist {
-		return
+		return false
 	}
 	p.peers[id] = &data{id: id}
+	return true
 }
 
 func (p *Peers) Delete(id peer.ID) {

--- a/p2p/upgrade.go
+++ b/p2p/upgrade.go
@@ -237,8 +237,18 @@ func (fh *Host) GetPeers() []Peer {
 	return fh.Host.Network().Peers()
 }
 
+// Connected returns true if the specified peer is connected.
+// Peers that only have transient connections to them aren't considered connected.
 func (fh *Host) Connected(p Peer) bool {
-	return fh.Host.Network().Connectedness(p) == network.Connected
+	if fh.Host.Network().Connectedness(p) != network.Connected {
+		return false
+	}
+	for _, c := range fh.Host.Network().ConnsToPeer(p) {
+		if !c.Stat().Transient {
+			return true
+		}
+	}
+	return false
 }
 
 // ConnectedPeerInfo retrieves a peer info object for the given peer.ID, if the


### PR DESCRIPTION
## Motivation

Transient connections are relayed connections which should only be used for hole punching. Trying to sync over them never succeeds due to resource limits, etc.

## Description

Do not try to use transient connections for sync.

## Test Plan

Verified by syncing a node with routing discovery and relay enabled, so that hole punching is happening continuously and there are always some temporary relayed connections.
Writing a proper test case for this change is possible in theory, but it's a little too involved compared to the change itself as it requires starting a relay host, obtaining a reservation with it, etc.

