### PR TITLE
[Merged by Bors] - Skip IPv6 tests if IPv6 isn't available

### DIFF
--- a/p2p/host_test.go
+++ b/p2p/host_test.go
@@ -2,6 +2,7 @@ package p2p
 
 import (
 	"context"
+	"net"
 	"testing"
 
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -82,6 +83,7 @@ func TestBlocklist(t *testing.T) {
 	type testcase struct {
 		desc           string
 		address        string
+		requireIPv6    bool
 		clearBlocklist bool
 		errStr         string
 	}
@@ -93,9 +95,10 @@ func TestBlocklist(t *testing.T) {
 			errStr:  "gater disallows connection to peer",
 		},
 		{
-			desc:    "local IPv6 disallowed",
-			address: "/ip6/::/tcp/0",
-			errStr:  "gater disallows connection to peer",
+			desc:        "local IPv6 disallowed",
+			address:     "/ip6/::/tcp/0",
+			requireIPv6: true,
+			errStr:      "gater disallows connection to peer",
 		},
 		{
 			desc:           "local IPv4 allowed",
@@ -103,14 +106,32 @@ func TestBlocklist(t *testing.T) {
 			clearBlocklist: true,
 		},
 		{
-			desc:           "local IPv4 allowed",
+			desc:           "local IPv6 allowed",
 			address:        "/ip6/::/tcp/0",
+			requireIPv6:    true,
 			clearBlocklist: true,
 		},
 	}
 
+	ifs, err := net.InterfaceAddrs()
+	require.NoError(t, err)
+
+	ipv6Available := false
+
+	// check if at least one interface is IPv6
+	for _, ifa := range ifs {
+		if ipnet, ok := ifa.(*net.IPNet); ok && ipnet.IP.To4() == nil {
+			ipv6Available = true
+			break
+		}
+	}
+
 	for _, tc := range testcases {
 		t.Run(tc.desc, func(t *testing.T) {
+			if tc.requireIPv6 && !ipv6Available {
+				t.Skip("IPv6 not available")
+			}
+
 			cfg1 := DefaultConfig()
 			cfg1.DataDir = t.TempDir()
 			cfg1.Listen = MustParseAddresses(tc.address)

--- a/p2p/host_test.go
+++ b/p2p/host_test.go
@@ -113,12 +113,11 @@ func TestBlocklist(t *testing.T) {
 		},
 	}
 
+	ipv6Available := false
 	ifs, err := net.InterfaceAddrs()
 	require.NoError(t, err)
 
-	ipv6Available := false
-
-	// check if at least one interface is IPv6
+	// check if at least one interface has an IPv6 address
 	for _, ifa := range ifs {
 		if ipnet, ok := ifa.(*net.IPNet); ok && ipnet.IP.To4() == nil {
 			ipv6Available = true


### PR DESCRIPTION
## Motivation

Some tests fail with a false positive when IPv6 isn't available on the system executing the test. This skips those tests if IPv6 cannot be found.

## Description

Added a check that at least one interface returned by `net.InterfaceAddrs()` has an IPv6 address, if not it skips tests that require IPv6.

## Test Plan

n/a

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed