### PR TITLE
[Merged by Bors] - always check in database when txs are downloaded from block

### DIFF
--- a/txs/conservative_state.go
+++ b/txs/conservative_state.go
@@ -171,12 +171,8 @@ func (cs *ConservativeState) AddToDB(tx *types.Transaction) error {
 	return transactions.Add(cs.db, tx, time.Now())
 }
 
-// HasTx returns true if transaction exists in the cache.
+// HasTx returns true if transaction exists in the database.
 func (cs *ConservativeState) HasTx(tid types.TransactionID) (bool, error) {
-	if cs.cache.Has(tid) {
-		return true, nil
-	}
-
 	has, err := transactions.Has(cs.db, tid)
 	if err != nil {
 		return false, fmt.Errorf("has tx: %w", err)


### PR DESCRIPTION
closes: https://github.com/spacemeshos/go-spacemesh/issues/5616
after: https://github.com/spacemeshos/go-spacemesh/pull/5642

i wasn't able to understand what is happening with caching in mempool, but it must be an issue with caching, 
so i just patched it to look directly in the database