### PR TITLE
[Merged by Bors] - Add index on ATXs that makes epoch ATX requests faster

### DIFF
--- a/sql/migrations/state/0014_atxs_extra_index.sql
+++ b/sql/migrations/state/0014_atxs_extra_index.sql
@@ -1,0 +1,2 @@
+-- retrieve epoch info faster
+CREATE INDEX atxs_by_epoch_id on atxs (epoch, id);


### PR DESCRIPTION
## Motivation

Based on #5591, it appears that epoch ATX SQL requests can be made faster by adding another index on ATXs

## Description

Adds the following index
```
CREATE INDEX atxs_by_epoch_id on atxs (epoch, id);
```
which removes extra `DeferredSeek` from epoch ATX SELECTs
