### PR TITLE
[Merged by Bors] - revert window size to 10k

### DIFF
--- a/config/mainnet.go
+++ b/config/mainnet.go
@@ -121,7 +121,7 @@ func MainnetConfig() Config {
 		Tortoise: tortoise.Config{
 			Hdist:                    10,
 			Zdist:                    2,
-			WindowSize:               4032,
+			WindowSize:               10000,
 			MaxExceptions:            1000,
 			BadBeaconVoteDelayLayers: 4032,
 			MinimalActiveSetWeight: []types.EpochMinimalActiveWeight{


### PR DESCRIPTION
closes: https://github.com/spacemeshos/go-spacemesh/issues/5623

this value needs to be versioned in order for sync to work reliably. it has to be 10 000 when 28000 layers are synced, otherwise tortoise can't decode many ballots, which breaks the sync completely.

it can be changed to lower number when layers 28000++ are processed, but some code to make it versioned is not so trivial.

 