### PR TITLE
Exclude faulty macos-runner from v1.3 branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       nondocchanges: ${{ steps.filter.outputs.nondoc }}
     steps:
       - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@v3
         id: filter
         with:
           # this pattern matches using picomatch syntax (used by this third party Action), which is slightly
@@ -107,15 +107,13 @@ jobs:
         os:
           - ubuntu-latest
           - [self-hosted, linux, arm64]
-          - macos-12-large
-          - [self-hosted, macOS, arm64]
+          # - macos-12-large
+          - [go-spacemesh, m2-pro]
           - windows-latest
     steps:
       - name: Add OpenCL support - Ubuntu
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: sudo apt-get update -q && sudo apt-get install -qy ocl-icd-opencl-dev libpocl2
-
-
       - name: disable Windows Defender - Windows
         if: ${{ matrix.os == 'windows-latest' }}
         run: |
@@ -144,8 +142,8 @@ jobs:
         os:
           - ubuntu-latest
           - [self-hosted, linux, arm64]
-          - macos-12-large
-          - [self-hosted, macOS, arm64]
+          # - macos-12-large
+          - [go-spacemesh, m2-pro]
           - windows-latest
     steps:
       # as we use some request to localhost, sometimes it gives us flaky tests. try to disable tcp offloading for fix it
@@ -157,7 +155,7 @@ jobs:
           sudo ethtool -K eth0 rx off
 
       - name: disable TCP/UDP offload - MacOS
-        if: ${{ matrix.os == 'macos-12-large' || matrix.os == '[self-hosted, macOS, arm64]' }}
+        if: ${{ matrix.os == 'macos-12-large' || matrix.os == '[go-spacemesh, m2-pro]' }}
         run: |
           sudo sysctl -w net.link.generic.system.hwcksum_tx=0
           sudo sysctl -w net.link.generic.system.hwcksum_rx=0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
             outname_sufix: "linux-arm64"
           - os: macos-12-large
             outname_sufix: "mac-amd64"
-          - os: [self-hosted, macOS, arm64]
+          - os: [go-spacemesh, m2-pro]
             outname_sufix: "mac-arm64"
           - os: windows-latest
             outname_sufix: "win-amd64"
@@ -84,7 +84,7 @@ jobs:
           destination: ${{ secrets.GCP_BUCKET }}/${{ github.ref_name }}/
 
       - name: Install coreutils
-        if: ${{ matrix.os == 'macos-12-large' || matrix.os == '[self-hosted, macOS, arm64]' }}
+        if: ${{ matrix.os == 'macos-12-large' || matrix.os == '[go-spacemesh, m2-pro]' }}
         run: brew install coreutils
 
       - name: Calculate the hashsum of the zip file


### PR DESCRIPTION
## Motivation

This should fix flaky CI runs on the v1.3 branch

## Description

Update runner tags for v1.3 branch

## Test Plan

N/A

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
