### PR TITLE
[Merged by Bors] - Rename node_state.sql to local.sql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,9 @@ encrypted connection between the post service and the node over insecure connect
 
 Smeshers using the default setup with a supervised post service do not need to make changes to their node configuration.
 
-#### Fully migrated local state into `node_state.sql`
+#### Fully migrated local state into `local.sql`
 
-With this release the node has fully migrated its local state into `node_state.sql`. During the first start after the
+With this release the node has fully migrated its local state into `local.sql`. During the first start after the
 upgrade the node will migrate the data from disk and store it in the database. This change also allows the PoST data
 directory to be set to read only after the migration is complete, as the node will no longer write to it.
 
@@ -176,7 +176,7 @@ and permanent ineligibility for rewards.
 
 ### Improvements
 
-* [#5219](https://github.com/spacemeshos/go-spacemesh/pull/5219) Migrate data from `nipost_builder_state.bin` to `node_state.sql`.
+* [#5219](https://github.com/spacemeshos/go-spacemesh/pull/5219) Migrate data from `nipost_builder_state.bin` to `local.sql`.
 
   The node will automatically migrate the data from disk and store it in the database. The migration will take place at the
   first startup after the upgrade.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -176,6 +176,10 @@ and permanent ineligibility for rewards.
 
 ### Improvements
 
+* [#5641](https://github.com/spacemeshos/go-spacemesh/pull/5641) Rename `node_state.sql` to `local.sql`.
+
+  To avoid confusion with the `state.sql` database, the `node_state.sql` database has been renamed to `local.sql`.
+
 * [#5219](https://github.com/spacemeshos/go-spacemesh/pull/5219) Migrate data from `nipost_builder_state.bin` to `local.sql`.
 
   The node will automatically migrate the data from disk and store it in the database. The migration will take place at the

--- a/checkpoint/recovery.go
+++ b/checkpoint/recovery.go
@@ -196,7 +196,6 @@ func recoverFromLocalFile(
 				// continue to recover from checkpoint despite failure to preserve own atx
 				continue
 			}
-
 			logger.With().Info("collected own atx deps",
 				log.Context(ctx),
 				nodeID,
@@ -217,13 +216,14 @@ func recoverFromLocalFile(
 	slices.SortStableFunc(allDeps, func(i, j *types.VerifiedActivationTx) int {
 		return int(i.PublishEpoch) - int(j.PublishEpoch)
 	})
-	allProofs := maps.Values(proofs)
-	// sort PoET proofs by ref
-	slices.SortFunc(allProofs, func(i, j *types.PoetProofMessage) int {
-		iRef, _ := i.Ref()
-		jRef, _ := j.Ref()
-		return bytes.Compare(iRef[:], jRef[:])
-	})
+	allProofs := make([]*types.PoetProofMessage, 0, len(proofs))
+	for _, dep := range allDeps {
+		proof, ok := proofs[types.PoetProofRef(dep.GetPoetProofRef())]
+		if !ok {
+			return nil, fmt.Errorf("missing poet proof for atx %v", dep.ID())
+		}
+		allProofs = append(allProofs, proof)
+	}
 
 	// all is ready. backup the old data and create new.
 	backupDir, err := backupOldDb(fs, cfg.DataDir, cfg.DbFile)
@@ -386,16 +386,20 @@ func collectOwnAtxDeps(
 			ref,
 			log.Bool("own", own),
 		)
-		deps, proofs, err = collectDeps(db, goldenATX, ref, all)
+		deps, proofs, err = collectDeps(db, ref, all)
 		if err != nil {
 			return nil, nil, err
 		}
+		logger.With().Debug("collected atx and deps",
+			ref,
+			log.Int("deps", len(deps)),
+		)
 	}
 	if nipostCh != nil {
 		logger.With().Info("collecting pending atx and deps", log.Object("nipost", nipostCh))
 		// any previous atx in nipost should already be captured earlier
 		// we only care about positioning atx here
-		deps2, proofs2, err := collectDeps(db, goldenATX, nipostCh.PositioningATX, all)
+		deps2, proofs2, err := collectDeps(db, nipostCh.PositioningATX, all)
 		if err != nil {
 			return nil, nil, fmt.Errorf("deps from nipost positioning atx (%v): %w", nipostCh.PositioningATX, err)
 		}
@@ -407,12 +411,11 @@ func collectOwnAtxDeps(
 
 func collectDeps(
 	db *sql.Database,
-	goldenAtxId types.ATXID,
 	ref types.ATXID,
 	all map[types.ATXID]struct{},
 ) (map[types.ATXID]*types.VerifiedActivationTx, map[types.PoetProofRef]*types.PoetProofMessage, error) {
 	deps := make(map[types.ATXID]*types.VerifiedActivationTx)
-	if err := collect(db, goldenAtxId, ref, all, deps); err != nil {
+	if err := collect(db, ref, all, deps); err != nil {
 		return nil, nil, err
 	}
 	proofs, err := poetProofs(db, deps)
@@ -424,7 +427,6 @@ func collectDeps(
 
 func collect(
 	db *sql.Database,
-	goldenAtxID types.ATXID,
 	ref types.ATXID,
 	all map[types.ATXID]struct{},
 	deps map[types.ATXID]*types.VerifiedActivationTx,
@@ -440,22 +442,14 @@ func collect(
 		return fmt.Errorf("atx %v belong to previous snapshot. cannot be preserved", ref)
 	}
 	if atx.CommitmentATX != nil {
-		if err = collect(db, goldenAtxID, *atx.CommitmentATX, all, deps); err != nil {
-			return err
-		}
-	} else {
-		commitment, err := atxs.CommitmentATX(db, atx.SmesherID)
-		if err != nil {
-			return fmt.Errorf("get commitment for ref atx %v: %w", ref, err)
-		}
-		if err := collect(db, goldenAtxID, commitment, all, deps); err != nil {
+		if err = collect(db, *atx.CommitmentATX, all, deps); err != nil {
 			return err
 		}
 	}
-	if err = collect(db, goldenAtxID, atx.PrevATXID, all, deps); err != nil {
+	if err = collect(db, atx.PrevATXID, all, deps); err != nil {
 		return err
 	}
-	if err = collect(db, goldenAtxID, atx.PositioningATX, all, deps); err != nil {
+	if err = collect(db, atx.PositioningATX, all, deps); err != nil {
 		return err
 	}
 	deps[ref] = atx
@@ -477,11 +471,7 @@ func poetProofs(
 		if err := codec.Decode(proof, &msg); err != nil {
 			return nil, fmt.Errorf("decode poet proof (%v): %w", vatx.ID(), err)
 		}
-		ref, err := msg.Ref()
-		if err != nil {
-			return nil, fmt.Errorf("get poet proof ref (%v): %w", vatx.ID(), err)
-		}
-		proofs[ref] = &msg
+		proofs[types.PoetProofRef(vatx.GetPoetProofRef())] = &msg
 	}
 	return proofs, nil
 }

--- a/checkpoint/recovery.go
+++ b/checkpoint/recovery.go
@@ -182,6 +182,10 @@ func recoverFromLocalFile(
 	deps := make(map[types.ATXID]*types.VerifiedActivationTx)
 	proofs := make(map[types.PoetProofRef]*types.PoetProofMessage)
 	if cfg.PreserveOwnAtx {
+		logger.With().Info("preserving own atx deps",
+			log.Context(ctx),
+			log.Int("num identities", len(cfg.NodeIDs)),
+		)
 		for _, nodeID := range cfg.NodeIDs {
 			nodeDeps, nodeProofs, err := collectOwnAtxDeps(logger, db, localDB, nodeID, cfg.GoldenAtx, data)
 			if err != nil {

--- a/checkpoint/recovery.go
+++ b/checkpoint/recovery.go
@@ -445,6 +445,14 @@ func collect(
 		if err = collect(db, *atx.CommitmentATX, all, deps); err != nil {
 			return err
 		}
+	} else {
+		commitment, err := atxs.CommitmentATX(db, atx.SmesherID)
+		if err != nil {
+			return fmt.Errorf("get commitment for ref atx %v: %w", ref, err)
+		}
+		if err = collect(db, commitment, all, deps); err != nil {
+			return err
+		}
 	}
 	if err = collect(db, atx.PrevATXID, all, deps); err != nil {
 		return err

--- a/node/node.go
+++ b/node/node.go
@@ -1781,6 +1781,12 @@ func (app *App) setupDBs(ctx context.Context, lg log.Log) error {
 	return nil
 }
 
+// MigrateLocalDB migrates the old node_state.sql to the new local.sql
+//
+// This function is idempotent and can be called multiple times without side effects.
+// It will only migrate the old db to the new db if the old db exists and the new db does not.
+//
+// TODO(mafa): this can be removed in the future when we are sure that all nodes have migrated to the new db.
 func (app *App) MigrateLocalDB(lg *zap.Logger, dbPath string, clients []localsql.PoetClient) error {
 	oldDBFile := filepath.Join(dbPath, oldLocalDbFile)
 	dbFile := filepath.Join(dbPath, localDbFile)

--- a/node/node.go
+++ b/node/node.go
@@ -432,7 +432,10 @@ func (app *App) LoadCheckpoint(ctx context.Context) (*checkpoint.PreservedData, 
 	if restore == 0 {
 		return nil, fmt.Errorf("restore layer not set")
 	}
-	nodeIDs := make([]types.NodeID, 0, len(app.signers))
+	nodeIDs := make([]types.NodeID, len(app.signers))
+	for i, sig := range app.signers {
+		nodeIDs[i] = sig.NodeID()
+	}
 	cfg := &checkpoint.RecoverConfig{
 		GoldenAtx:      types.ATXID(app.Config.Genesis.GoldenATX()),
 		DataDir:        app.Config.DataDir(),

--- a/node/node.go
+++ b/node/node.go
@@ -1833,6 +1833,9 @@ func (app *App) MigrateLocalDB(lg *zap.Logger, dbPath string, clients []localsql
 	if _, err := oldDB.Exec(fmt.Sprintf("VACUUM INTO '%s'", dbFile), nil, nil); err != nil {
 		return fmt.Errorf("vacuum %s to %s: %w", oldDBFile, dbFile, err)
 	}
+	if err := oldDB.Close(); err != nil {
+		return fmt.Errorf("close %s: %w", oldDBFile, err)
+	}
 	if err := atomic.ReplaceFile(oldDBFile, fmt.Sprintf("%s.bak", oldDBFile)); err != nil {
 		return fmt.Errorf("renaming %s to %s: %w", oldDBFile, fmt.Sprintf("%s.bak", oldDBFile), err)
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -1769,7 +1769,7 @@ func (app *App) setupDBs(ctx context.Context, lg log.Log) error {
 		return err
 	}
 
-	localDB, err := localsql.Open("file:"+dbFile,
+	localDB, err := localsql.Open("file:"+filepath.Join(dbPath, localDbFile),
 		sql.WithLogger(dbLog.Zap()),
 		sql.WithMigrations(migrations),
 		sql.WithMigration(localsql.New0001Migration(app.Config.SMESHING.Opts.DataDir)),

--- a/node/node_identities.go
+++ b/node/node_identities.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/natefinch/atomic"
+
 	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/signing"
 )
@@ -83,7 +85,7 @@ func (app *App) MigrateExistingIdentity() error {
 		return fmt.Errorf("failed to close legacy identity file: %w", err)
 	}
 
-	if err := os.Rename(oldKey, oldKey+".bak"); err != nil {
+	if err := atomic.ReplaceFile(oldKey, oldKey+".bak"); err != nil {
 		return fmt.Errorf("failed to rename legacy identity file: %w", err)
 	}
 


### PR DESCRIPTION
## Motivation

`node_state.sql` seems to be confused with the node's `state.sql` regularly. To avoid confusion, rename it to `local.sql`

## Description

- Add code that renames `node_state.sql` to `local.sql`
  - uses `VACUUM INTO` to create a new file containing all content from `node_state.sql`
  - renames `node_state.sql` to `node_state.sql.bak`
  - fails when both DB exist
  - no-op if `node_state.sql` doesn't exist
- Update CHANGELOG to use the new name instead of the old

## Test Plan

Added tests for migration code

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
