### PR TITLE
[Merged by Bors] - Register supervised ID in atxBuilder after init is done

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,7 +128,7 @@ Make sure to replace `provider` with your provider of choice and `numUnits` with
 initialize. The `commitmentAtxId` is the commitment ATX ID for the identity you want to initialize. For details on the
 usage of `postcli` please refer to [postcli README](https://github.com/spacemeshos/post/cmd/postcli/README.md).
 
-During initialization `postcli` will generate a new private key and store it in the PoST data directory as `<identity>.key`.
+During initialization `postcli` will generate a new private key and store it in the PoST data directory as `identity.key`.
 Copy this file to your `data/identities` directory and rename it to `xxx.key` where `xxx` is a unique identifier for
 the identity. The node will automatically pick up the new identity and manage its lifecycle after a restart.
 
@@ -141,9 +141,9 @@ node. For details refer to the [post-service README](https://github.com/spacemes
 If you have multiple nodes running and want to migrate to use only one node for all identities:
 
 1. Stop all nodes.
-2. Copy the `<identity>.key` files from the PoST data directories of all nodes to the data directory of the node you
-   want to use for both identities and into the folder `data/identities`. The name of the key file is the public key
-   by default to make it easier to match the key to the identity.
+2. Copy the `identity.key` files from the PoST data directories of all nodes to the `data/identities` directory of the
+   node you want to use for those identities. The choose names for the key files that makes it easy to distinguish which
+   key belongs to which identity.
 3. Start the node managing the identities.
 4. For every identity setup a post service to use the existing PoST data for that identity and connect to the node.
    For details refer to the [post-service README](https://github.com/spacemeshos/post-rs/blob/main/service/README.md).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,7 +113,7 @@ at a PoET server the PoST services can be stopped with only the node having to b
 This change moves the private keys associated for an identity from the PoST data directory to the node's data directory
 and into the folder `identities` (i.e. if `state.sql` is in folder `data` the keys will now be stored in `data/identities`).
 The node will automatically migrate the `key.bin` file from the PoST data directory during the first startup and copy
-it to the new location as `identity.key`. The content of the file stays unchanged (= the private key of the identity hex-encoded).
+it to the new location as `local.key`. The content of the file stays unchanged (= the private key of the identity hex-encoded).
 
 ##### Adding new identities/PoST services to a node
 
@@ -128,7 +128,7 @@ Make sure to replace `provider` with your provider of choice and `numUnits` with
 initialize. The `commitmentAtxId` is the commitment ATX ID for the identity you want to initialize. For details on the
 usage of `postcli` please refer to [postcli README](https://github.com/spacemeshos/post/cmd/postcli/README.md).
 
-During initialization `postcli` will generate a new private key and store it in the PoST data directory as `key.bin`.
+During initialization `postcli` will generate a new private key and store it in the PoST data directory as `<identity>.key`.
 Copy this file to your `data/identities` directory and rename it to `xxx.key` where `xxx` is a unique identifier for
 the identity. The node will automatically pick up the new identity and manage its lifecycle after a restart.
 
@@ -141,9 +141,9 @@ node. For details refer to the [post-service README](https://github.com/spacemes
 If you have multiple nodes running and want to migrate to use only one node for all identities:
 
 1. Stop all nodes.
-2. Copy the `key.bin` files from the PoST data directories of all nodes to the data directory of the node you want to
-   use for both identities and into the folder `data/identities`. Rename the files to `xxx.key` where `xxx` is a unique
-   identifier for each identity.
+2. Copy the `<identity>.key` files from the PoST data directories of all nodes to the data directory of the node you
+   want to use for both identities and into the folder `data/identities`. The name of the key file is the public key
+   by default to make it easier to match the key to the identity.
 3. Start the node managing the identities.
 4. For every identity setup a post service to use the existing PoST data for that identity and connect to the node.
    For details refer to the [post-service README](https://github.com/spacemeshos/post-rs/blob/main/service/README.md).

--- a/activation/e2e/activation_test.go
+++ b/activation/e2e/activation_test.go
@@ -73,7 +73,7 @@ func Test_BuilderWithMultipleClients(t *testing.T) {
 			opts.DataDir = t.TempDir()
 			opts.NumUnits = uint32(rand.Int31n(int32(cfg.MaxNumUnits/2-cfg.MinNumUnits))) + cfg.MinNumUnits
 			initPost(t, mgr, opts, sig.NodeID())
-			t.Cleanup(launchPostSupervisor(t, logger, mgr, sig.NodeID(), grpcCfg, opts))
+			t.Cleanup(launchPostSupervisor(t, logger, mgr, sig, grpcCfg, opts))
 
 			require.Eventually(t, func() bool {
 				_, err := svc.Client(sig.NodeID())

--- a/activation/e2e/nipost_test.go
+++ b/activation/e2e/nipost_test.go
@@ -77,7 +77,7 @@ func launchPostSupervisor(
 	ps, err := activation.NewPostSupervisor(log, cmdCfg, postCfg, provingOpts, mgr)
 	require.NoError(tb, err)
 	require.NotNil(tb, ps)
-	require.NoError(tb, ps.Start(postOpts, id))
+	require.NoError(tb, ps.Start(postOpts, id, func() {}))
 	return func() { assert.NoError(tb, ps.Stop(false)) }
 }
 

--- a/activation/e2e/nipost_test.go
+++ b/activation/e2e/nipost_test.go
@@ -64,7 +64,7 @@ func launchPostSupervisor(
 	tb testing.TB,
 	log *zap.Logger,
 	mgr *activation.PostSetupManager,
-	id types.NodeID,
+	sig *signing.EdSigner,
 	cfg grpcserver.Config,
 	postOpts activation.PostSetupOpts,
 ) func() {
@@ -74,10 +74,12 @@ func launchPostSupervisor(
 	provingOpts := activation.DefaultPostProvingOpts()
 	provingOpts.RandomXMode = activation.PostRandomXModeLight
 
-	ps, err := activation.NewPostSupervisor(log, cmdCfg, postCfg, provingOpts, mgr)
+	builder := activation.NewMockAtxBuilder(gomock.NewController(tb))
+	builder.EXPECT().Register(gomock.Any())
+	ps, err := activation.NewPostSupervisor(log, cmdCfg, postCfg, provingOpts, mgr, builder)
 	require.NoError(tb, err)
 	require.NotNil(tb, ps)
-	require.NoError(tb, ps.Start(postOpts, id, func() {}))
+	require.NoError(tb, ps.Start(postOpts, sig))
 	return func() { assert.NoError(tb, ps.Stop(false)) }
 }
 
@@ -174,7 +176,7 @@ func TestNIPostBuilderWithClients(t *testing.T) {
 	grpcCfg, cleanup := launchServer(t, svc)
 	t.Cleanup(cleanup)
 
-	t.Cleanup(launchPostSupervisor(t, logger, mgr, sig.NodeID(), grpcCfg, opts))
+	t.Cleanup(launchPostSupervisor(t, logger, mgr, sig, grpcCfg, opts))
 
 	require.Eventually(t, func() bool {
 		_, err := svc.Client(sig.NodeID())
@@ -326,7 +328,7 @@ func TestNewNIPostBuilderNotInitialized(t *testing.T) {
 	opts.DataDir = t.TempDir()
 	opts.ProviderID.SetUint32(initialization.CPUProviderID())
 	opts.Scrypt.N = 2 // Speedup initialization in tests.
-	t.Cleanup(launchPostSupervisor(t, logger, mgr, sig.NodeID(), grpcCfg, opts))
+	t.Cleanup(launchPostSupervisor(t, logger, mgr, sig, grpcCfg, opts))
 
 	require.Eventually(t, func() bool {
 		_, err := svc.Client(sig.NodeID())
@@ -399,7 +401,7 @@ func Test_NIPostBuilderWithMultipleClients(t *testing.T) {
 
 			opts.DataDir = t.TempDir()
 			initPost(t, mgr, opts, sig.NodeID())
-			t.Cleanup(launchPostSupervisor(t, logger, mgr, sig.NodeID(), grpcCfg, opts))
+			t.Cleanup(launchPostSupervisor(t, logger, mgr, sig, grpcCfg, opts))
 
 			require.Eventually(t, func() bool {
 				_, err := svc.Client(sig.NodeID())

--- a/activation/e2e/validation_test.go
+++ b/activation/e2e/validation_test.go
@@ -87,7 +87,7 @@ func TestValidator_Validate(t *testing.T) {
 	grpcCfg, cleanup := launchServer(t, svc)
 	t.Cleanup(cleanup)
 
-	t.Cleanup(launchPostSupervisor(t, logger, mgr, sig.NodeID(), grpcCfg, opts))
+	t.Cleanup(launchPostSupervisor(t, logger, mgr, sig, grpcCfg, opts))
 
 	require.Eventually(t, func() bool {
 		_, err := svc.Client(sig.NodeID())

--- a/activation/interface.go
+++ b/activation/interface.go
@@ -144,6 +144,10 @@ var (
 	ErrPostClientNotConnected = fmt.Errorf("post service not registered")
 )
 
+type AtxBuilder interface {
+	Register(sig *signing.EdSigner)
+}
+
 type postService interface {
 	Client(nodeId types.NodeID) (PostClient, error)
 }

--- a/activation/mocks.go
+++ b/activation/mocks.go
@@ -1767,6 +1767,65 @@ func (c *MockpoetDbAPIValidateAndStoreCall) DoAndReturn(f func(context.Context, 
 	return c
 }
 
+// MockAtxBuilder is a mock of AtxBuilder interface.
+type MockAtxBuilder struct {
+	ctrl     *gomock.Controller
+	recorder *MockAtxBuilderMockRecorder
+}
+
+// MockAtxBuilderMockRecorder is the mock recorder for MockAtxBuilder.
+type MockAtxBuilderMockRecorder struct {
+	mock *MockAtxBuilder
+}
+
+// NewMockAtxBuilder creates a new mock instance.
+func NewMockAtxBuilder(ctrl *gomock.Controller) *MockAtxBuilder {
+	mock := &MockAtxBuilder{ctrl: ctrl}
+	mock.recorder = &MockAtxBuilderMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockAtxBuilder) EXPECT() *MockAtxBuilderMockRecorder {
+	return m.recorder
+}
+
+// Register mocks base method.
+func (m *MockAtxBuilder) Register(sig *signing.EdSigner) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Register", sig)
+}
+
+// Register indicates an expected call of Register.
+func (mr *MockAtxBuilderMockRecorder) Register(sig any) *MockAtxBuilderRegisterCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Register", reflect.TypeOf((*MockAtxBuilder)(nil).Register), sig)
+	return &MockAtxBuilderRegisterCall{Call: call}
+}
+
+// MockAtxBuilderRegisterCall wrap *gomock.Call
+type MockAtxBuilderRegisterCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockAtxBuilderRegisterCall) Return() *MockAtxBuilderRegisterCall {
+	c.Call = c.Call.Return()
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockAtxBuilderRegisterCall) Do(f func(*signing.EdSigner)) *MockAtxBuilderRegisterCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockAtxBuilderRegisterCall) DoAndReturn(f func(*signing.EdSigner)) *MockAtxBuilderRegisterCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // MockpostService is a mock of postService interface.
 type MockpostService struct {
 	ctrl     *gomock.Controller

--- a/activation/post_supervisor.go
+++ b/activation/post_supervisor.go
@@ -132,7 +132,7 @@ func (ps *PostSupervisor) Status() *PostSetupStatus {
 	return ps.postSetupProvider.Status()
 }
 
-func (ps *PostSupervisor) Start(opts PostSetupOpts, id types.NodeID) error {
+func (ps *PostSupervisor) Start(opts PostSetupOpts, id types.NodeID, onInitDone func()) error {
 	ps.mtx.Lock()
 	defer ps.mtx.Unlock()
 	if ps.stop != nil {
@@ -164,6 +164,7 @@ func (ps *PostSupervisor) Start(opts PostSetupOpts, id types.NodeID) error {
 			ps.logger.Fatal("initialization failed", zap.Error(err))
 			return err
 		}
+		onInitDone()
 
 		return ps.runCmd(ctx, ps.cmdCfg, ps.postCfg, opts, ps.provingOpts)
 	})

--- a/activation/post_supervisor_test.go
+++ b/activation/post_supervisor_test.go
@@ -69,7 +69,7 @@ func Test_PostSupervisor_Start_FailPrepare(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, ps)
 
-	require.NoError(t, ps.Start(postOpts, nodeID))
+	require.NoError(t, ps.Start(postOpts, nodeID, func() {}))
 	require.ErrorIs(t, ps.Stop(false), testErr)
 }
 
@@ -105,7 +105,7 @@ func Test_PostSupervisor_Start_FailStartSession(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, ps)
 
-	require.NoError(t, ps.Start(postOpts, nodeID))
+	require.NoError(t, ps.Start(postOpts, nodeID, func() {}))
 	require.EqualError(t, ps.eg.Wait(), "failed start session")
 }
 
@@ -127,7 +127,7 @@ func Test_PostSupervisor_StartsServiceCmd(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, ps)
 
-	require.NoError(t, ps.Start(postOpts, nodeID))
+	require.NoError(t, ps.Start(postOpts, nodeID, func() {}))
 	t.Cleanup(func() { assert.NoError(t, ps.Stop(false)) })
 
 	require.Eventually(t, func() bool { return ps.pid.Load() != 0 }, 5*time.Second, 100*time.Millisecond)
@@ -166,7 +166,7 @@ func Test_PostSupervisor_Restart_Possible(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, ps)
 
-	require.NoError(t, ps.Start(postOpts, nodeID))
+	require.NoError(t, ps.Start(postOpts, nodeID, func() {}))
 	t.Cleanup(func() { assert.NoError(t, ps.Stop(false)) })
 	require.Eventually(t, func() bool { return ps.pid.Load() != 0 }, 5*time.Second, 100*time.Millisecond)
 
@@ -175,7 +175,7 @@ func Test_PostSupervisor_Restart_Possible(t *testing.T) {
 
 	mgr.EXPECT().PrepareInitializer(gomock.Any(), postOpts, nodeID).Return(nil)
 	mgr.EXPECT().StartSession(gomock.Any(), nodeID).Return(nil)
-	require.NoError(t, ps.Start(postOpts, nodeID))
+	require.NoError(t, ps.Start(postOpts, nodeID, func() {}))
 	require.Eventually(t, func() bool { return ps.pid.Load() != 0 }, 5*time.Second, 100*time.Millisecond)
 
 	require.NoError(t, ps.Stop(false))
@@ -200,7 +200,7 @@ func Test_PostSupervisor_LogFatalOnCrash(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, ps)
 
-	require.NoError(t, ps.Start(postOpts, nodeID))
+	require.NoError(t, ps.Start(postOpts, nodeID, func() {}))
 	t.Cleanup(func() { assert.NoError(t, ps.Stop(false)) })
 
 	require.Eventually(t, func() bool { return ps.pid.Load() != 0 }, 5*time.Second, 100*time.Millisecond)
@@ -235,7 +235,7 @@ func Test_PostSupervisor_LogFatalOnInvalidConfig(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, ps)
 
-	require.NoError(t, ps.Start(postOpts, nodeID))
+	require.NoError(t, ps.Start(postOpts, nodeID, func() {}))
 	t.Cleanup(func() { assert.NoError(t, ps.Stop(false)) })
 
 	require.Eventually(t, func() bool { return ps.pid.Load() != 0 }, 5*time.Second, 100*time.Millisecond)
@@ -267,7 +267,7 @@ func Test_PostSupervisor_StopOnError(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, ps)
 
-	require.NoError(t, ps.Start(postOpts, nodeID))
+	require.NoError(t, ps.Start(postOpts, nodeID, func() {}))
 	t.Cleanup(func() { assert.NoError(t, ps.Stop(false)) })
 	require.Eventually(t, func() bool { return ps.pid.Load() != 0 }, 5*time.Second, 100*time.Millisecond)
 

--- a/activation/post_supervisor_test.go
+++ b/activation/post_supervisor_test.go
@@ -16,7 +16,7 @@ import (
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest"
 
-	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/signing"
 )
 
 func closedChan() <-chan struct{} {
@@ -33,7 +33,7 @@ func Test_PostSupervisor_ErrorOnMissingBinary(t *testing.T) {
 	postCfg := DefaultPostConfig()
 	provingOpts := DefaultPostProvingOpts()
 
-	ps, err := NewPostSupervisor(log.Named("supervisor"), cmdCfg, postCfg, provingOpts, nil)
+	ps, err := NewPostSupervisor(log.Named("supervisor"), cmdCfg, postCfg, provingOpts, nil, nil)
 	require.ErrorContains(t, err, "post service binary not found")
 	require.Nil(t, ps)
 }
@@ -45,7 +45,7 @@ func Test_PostSupervisor_StopWithoutStart(t *testing.T) {
 	postCfg := DefaultPostConfig()
 	provingOpts := DefaultPostProvingOpts()
 
-	ps, err := NewPostSupervisor(log.Named("supervisor"), cmdCfg, postCfg, provingOpts, nil)
+	ps, err := NewPostSupervisor(log.Named("supervisor"), cmdCfg, postCfg, provingOpts, nil, nil)
 	require.NoError(t, err)
 	require.NotNil(t, ps)
 
@@ -59,17 +59,19 @@ func Test_PostSupervisor_Start_FailPrepare(t *testing.T) {
 	postCfg := DefaultPostConfig()
 	postOpts := DefaultPostSetupOpts()
 	provingOpts := DefaultPostProvingOpts()
-	nodeID := types.RandomNodeID()
+	sig, err := signing.NewEdSigner()
+	require.NoError(t, err)
 
-	mgr := NewMockpostSetupProvider(gomock.NewController(t))
+	ctrl := gomock.NewController(t)
+	mgr := NewMockpostSetupProvider(ctrl)
 	testErr := errors.New("test error")
-	mgr.EXPECT().PrepareInitializer(gomock.Any(), postOpts, nodeID).Return(testErr)
-
-	ps, err := NewPostSupervisor(log.Named("supervisor"), cmdCfg, postCfg, provingOpts, mgr)
+	mgr.EXPECT().PrepareInitializer(gomock.Any(), postOpts, sig.NodeID()).Return(testErr)
+	builder := NewMockAtxBuilder(ctrl)
+	ps, err := NewPostSupervisor(log.Named("supervisor"), cmdCfg, postCfg, provingOpts, mgr, builder)
 	require.NoError(t, err)
 	require.NotNil(t, ps)
 
-	require.NoError(t, ps.Start(postOpts, nodeID, func() {}))
+	require.NoError(t, ps.Start(postOpts, sig))
 	require.ErrorIs(t, ps.Stop(false), testErr)
 }
 
@@ -94,18 +96,19 @@ func Test_PostSupervisor_Start_FailStartSession(t *testing.T) {
 	postCfg := DefaultPostConfig()
 	postOpts := DefaultPostSetupOpts()
 	provingOpts := DefaultPostProvingOpts()
-	nodeID := types.RandomNodeID()
+	sig, err := signing.NewEdSigner()
+	require.NoError(t, err)
 
 	ctrl := gomock.NewController(t)
 	mgr := NewMockpostSetupProvider(ctrl)
-	mgr.EXPECT().PrepareInitializer(gomock.Any(), postOpts, nodeID).Return(nil)
-	mgr.EXPECT().StartSession(gomock.Any(), nodeID).Return(errors.New("failed start session"))
-
-	ps, err := NewPostSupervisor(log.Named("supervisor"), cmdCfg, postCfg, provingOpts, mgr)
+	mgr.EXPECT().PrepareInitializer(gomock.Any(), postOpts, sig.NodeID()).Return(nil)
+	mgr.EXPECT().StartSession(gomock.Any(), sig.NodeID()).Return(errors.New("failed start session"))
+	builder := NewMockAtxBuilder(ctrl)
+	ps, err := NewPostSupervisor(log.Named("supervisor"), cmdCfg, postCfg, provingOpts, mgr, builder)
 	require.NoError(t, err)
 	require.NotNil(t, ps)
 
-	require.NoError(t, ps.Start(postOpts, nodeID, func() {}))
+	require.NoError(t, ps.Start(postOpts, sig))
 	require.EqualError(t, ps.eg.Wait(), "failed start session")
 }
 
@@ -116,18 +119,20 @@ func Test_PostSupervisor_StartsServiceCmd(t *testing.T) {
 	postCfg := DefaultPostConfig()
 	postOpts := DefaultPostSetupOpts()
 	provingOpts := DefaultPostProvingOpts()
-	nodeID := types.RandomNodeID()
+	sig, err := signing.NewEdSigner()
+	require.NoError(t, err)
 
 	ctrl := gomock.NewController(t)
 	mgr := NewMockpostSetupProvider(ctrl)
-	mgr.EXPECT().PrepareInitializer(gomock.Any(), postOpts, nodeID).Return(nil)
-	mgr.EXPECT().StartSession(gomock.Any(), nodeID).Return(nil)
-
-	ps, err := NewPostSupervisor(log.Named("supervisor"), cmdCfg, postCfg, provingOpts, mgr)
+	mgr.EXPECT().PrepareInitializer(gomock.Any(), postOpts, sig.NodeID()).Return(nil)
+	mgr.EXPECT().StartSession(gomock.Any(), sig.NodeID()).Return(nil)
+	builder := NewMockAtxBuilder(ctrl)
+	builder.EXPECT().Register(sig)
+	ps, err := NewPostSupervisor(log.Named("supervisor"), cmdCfg, postCfg, provingOpts, mgr, builder)
 	require.NoError(t, err)
 	require.NotNil(t, ps)
 
-	require.NoError(t, ps.Start(postOpts, nodeID, func() {}))
+	require.NoError(t, ps.Start(postOpts, sig))
 	t.Cleanup(func() { assert.NoError(t, ps.Stop(false)) })
 
 	require.Eventually(t, func() bool { return ps.pid.Load() != 0 }, 5*time.Second, 100*time.Millisecond)
@@ -155,27 +160,30 @@ func Test_PostSupervisor_Restart_Possible(t *testing.T) {
 	postCfg := DefaultPostConfig()
 	postOpts := DefaultPostSetupOpts()
 	provingOpts := DefaultPostProvingOpts()
-	nodeID := types.RandomNodeID()
+	sig, err := signing.NewEdSigner()
+	require.NoError(t, err)
 
 	ctrl := gomock.NewController(t)
 	mgr := NewMockpostSetupProvider(ctrl)
-	mgr.EXPECT().PrepareInitializer(gomock.Any(), postOpts, nodeID).Return(nil)
-	mgr.EXPECT().StartSession(gomock.Any(), nodeID).Return(nil)
-
-	ps, err := NewPostSupervisor(log.Named("supervisor"), cmdCfg, postCfg, provingOpts, mgr)
+	mgr.EXPECT().PrepareInitializer(gomock.Any(), postOpts, sig.NodeID()).Return(nil)
+	mgr.EXPECT().StartSession(gomock.Any(), sig.NodeID()).Return(nil)
+	builder := NewMockAtxBuilder(ctrl)
+	builder.EXPECT().Register(sig)
+	ps, err := NewPostSupervisor(log.Named("supervisor"), cmdCfg, postCfg, provingOpts, mgr, builder)
 	require.NoError(t, err)
 	require.NotNil(t, ps)
 
-	require.NoError(t, ps.Start(postOpts, nodeID, func() {}))
+	require.NoError(t, ps.Start(postOpts, sig))
 	t.Cleanup(func() { assert.NoError(t, ps.Stop(false)) })
 	require.Eventually(t, func() bool { return ps.pid.Load() != 0 }, 5*time.Second, 100*time.Millisecond)
 
 	require.NoError(t, ps.Stop(false))
 	require.Eventually(t, func() bool { return ps.pid.Load() == 0 }, 5*time.Second, 100*time.Millisecond)
 
-	mgr.EXPECT().PrepareInitializer(gomock.Any(), postOpts, nodeID).Return(nil)
-	mgr.EXPECT().StartSession(gomock.Any(), nodeID).Return(nil)
-	require.NoError(t, ps.Start(postOpts, nodeID, func() {}))
+	mgr.EXPECT().PrepareInitializer(gomock.Any(), postOpts, sig.NodeID()).Return(nil)
+	mgr.EXPECT().StartSession(gomock.Any(), sig.NodeID()).Return(nil)
+	builder.EXPECT().Register(sig)
+	require.NoError(t, ps.Start(postOpts, sig))
 	require.Eventually(t, func() bool { return ps.pid.Load() != 0 }, 5*time.Second, 100*time.Millisecond)
 
 	require.NoError(t, ps.Stop(false))
@@ -189,18 +197,20 @@ func Test_PostSupervisor_LogFatalOnCrash(t *testing.T) {
 	postCfg := DefaultPostConfig()
 	postOpts := DefaultPostSetupOpts()
 	provingOpts := DefaultPostProvingOpts()
-	nodeID := types.RandomNodeID()
+	sig, err := signing.NewEdSigner()
+	require.NoError(t, err)
 
 	ctrl := gomock.NewController(t)
 	mgr := NewMockpostSetupProvider(ctrl)
-	mgr.EXPECT().PrepareInitializer(gomock.Any(), postOpts, nodeID).Return(nil)
-	mgr.EXPECT().StartSession(gomock.Any(), nodeID).Return(nil)
-
-	ps, err := NewPostSupervisor(log.Named("supervisor"), cmdCfg, postCfg, provingOpts, mgr)
+	mgr.EXPECT().PrepareInitializer(gomock.Any(), postOpts, sig.NodeID()).Return(nil)
+	mgr.EXPECT().StartSession(gomock.Any(), sig.NodeID()).Return(nil)
+	builder := NewMockAtxBuilder(ctrl)
+	builder.EXPECT().Register(sig)
+	ps, err := NewPostSupervisor(log.Named("supervisor"), cmdCfg, postCfg, provingOpts, mgr, builder)
 	require.NoError(t, err)
 	require.NotNil(t, ps)
 
-	require.NoError(t, ps.Start(postOpts, nodeID, func() {}))
+	require.NoError(t, ps.Start(postOpts, sig))
 	t.Cleanup(func() { assert.NoError(t, ps.Stop(false)) })
 
 	require.Eventually(t, func() bool { return ps.pid.Load() != 0 }, 5*time.Second, 100*time.Millisecond)
@@ -224,18 +234,20 @@ func Test_PostSupervisor_LogFatalOnInvalidConfig(t *testing.T) {
 	postCfg := DefaultPostConfig()
 	postOpts := DefaultPostSetupOpts()
 	provingOpts := DefaultPostProvingOpts()
-	nodeID := types.RandomNodeID()
+	sig, err := signing.NewEdSigner()
+	require.NoError(t, err)
 
 	ctrl := gomock.NewController(t)
 	mgr := NewMockpostSetupProvider(ctrl)
-	mgr.EXPECT().PrepareInitializer(gomock.Any(), postOpts, nodeID).Return(nil)
-	mgr.EXPECT().StartSession(gomock.Any(), nodeID).Return(nil)
-
-	ps, err := NewPostSupervisor(log.Named("supervisor"), cmdCfg, postCfg, provingOpts, mgr)
+	mgr.EXPECT().PrepareInitializer(gomock.Any(), postOpts, sig.NodeID()).Return(nil)
+	mgr.EXPECT().StartSession(gomock.Any(), sig.NodeID()).Return(nil)
+	builder := NewMockAtxBuilder(ctrl)
+	builder.EXPECT().Register(sig)
+	ps, err := NewPostSupervisor(log.Named("supervisor"), cmdCfg, postCfg, provingOpts, mgr, builder)
 	require.NoError(t, err)
 	require.NotNil(t, ps)
 
-	require.NoError(t, ps.Start(postOpts, nodeID, func() {}))
+	require.NoError(t, ps.Start(postOpts, sig))
 	t.Cleanup(func() { assert.NoError(t, ps.Stop(false)) })
 
 	require.Eventually(t, func() bool { return ps.pid.Load() != 0 }, 5*time.Second, 100*time.Millisecond)
@@ -256,18 +268,20 @@ func Test_PostSupervisor_StopOnError(t *testing.T) {
 	postCfg := DefaultPostConfig()
 	postOpts := DefaultPostSetupOpts()
 	provingOpts := DefaultPostProvingOpts()
-	nodeID := types.RandomNodeID()
+	sig, err := signing.NewEdSigner()
+	require.NoError(t, err)
 
 	ctrl := gomock.NewController(t)
 	mgr := NewMockpostSetupProvider(ctrl)
-	mgr.EXPECT().PrepareInitializer(gomock.Any(), postOpts, nodeID).Return(nil)
-	mgr.EXPECT().StartSession(gomock.Any(), nodeID).Return(nil)
-
-	ps, err := NewPostSupervisor(log.Named("supervisor"), cmdCfg, postCfg, provingOpts, mgr)
+	mgr.EXPECT().PrepareInitializer(gomock.Any(), postOpts, sig.NodeID()).Return(nil)
+	mgr.EXPECT().StartSession(gomock.Any(), sig.NodeID()).Return(nil)
+	builder := NewMockAtxBuilder(ctrl)
+	builder.EXPECT().Register(sig)
+	ps, err := NewPostSupervisor(log.Named("supervisor"), cmdCfg, postCfg, provingOpts, mgr, builder)
 	require.NoError(t, err)
 	require.NotNil(t, ps)
 
-	require.NoError(t, ps.Start(postOpts, nodeID, func() {}))
+	require.NoError(t, ps.Start(postOpts, sig))
 	t.Cleanup(func() { assert.NoError(t, ps.Stop(false)) })
 	require.Eventually(t, func() bool { return ps.pid.Load() != 0 }, 5*time.Second, 100*time.Millisecond)
 
@@ -285,8 +299,8 @@ func Test_PostSupervisor_Providers_includesCPU(t *testing.T) {
 
 	ctrl := gomock.NewController(t)
 	mgr := NewMockpostSetupProvider(ctrl)
-
-	ps, err := NewPostSupervisor(log.Named("supervisor"), cmdCfg, postCfg, provingOpts, mgr)
+	builder := NewMockAtxBuilder(ctrl)
+	ps, err := NewPostSupervisor(log.Named("supervisor"), cmdCfg, postCfg, provingOpts, mgr, builder)
 	require.NoError(t, err)
 
 	providers, err := ps.Providers()
@@ -309,8 +323,8 @@ func Test_PostSupervisor_Benchmark(t *testing.T) {
 
 	ctrl := gomock.NewController(t)
 	mgr := NewMockpostSetupProvider(ctrl)
-
-	ps, err := NewPostSupervisor(log.Named("supervisor"), cmdCfg, postCfg, provingOpts, mgr)
+	builder := NewMockAtxBuilder(ctrl)
+	ps, err := NewPostSupervisor(log.Named("supervisor"), cmdCfg, postCfg, provingOpts, mgr, builder)
 	require.NoError(t, err)
 
 	providers, err := ps.Providers()

--- a/api/grpcserver/grpcserver_test.go
+++ b/api/grpcserver/grpcserver_test.go
@@ -618,7 +618,7 @@ func TestSmesherService(t *testing.T) {
 			gomock.Cond(
 				func(postOpts any) bool { return postOpts.(activation.PostSetupOpts).MaxFileSize == opts.MaxFileSize },
 			),
-		), nodeID).Return(nil)
+		), nodeID, gomock.Any()).Return(nil)
 		res, err := c.StartSmeshing(ctx, &pb.StartSmeshingRequest{
 			Opts:     opts,
 			Coinbase: coinbase,

--- a/api/grpcserver/interface.go
+++ b/api/grpcserver/interface.go
@@ -57,7 +57,7 @@ type atxProvider interface {
 }
 
 type postSupervisor interface {
-	Start(opts activation.PostSetupOpts, id types.NodeID) error
+	Start(opts activation.PostSetupOpts, id types.NodeID, onInitDone func()) error
 	Stop(deleteFiles bool) error
 
 	Config() activation.PostConfig

--- a/api/grpcserver/interface.go
+++ b/api/grpcserver/interface.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/activation"
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/p2p"
+	"github.com/spacemeshos/go-spacemesh/signing"
 	"github.com/spacemeshos/go-spacemesh/system"
 )
 
@@ -57,7 +58,7 @@ type atxProvider interface {
 }
 
 type postSupervisor interface {
-	Start(opts activation.PostSetupOpts, id types.NodeID, onInitDone func()) error
+	Start(opts activation.PostSetupOpts, sig *signing.EdSigner) error
 	Stop(deleteFiles bool) error
 
 	Config() activation.PostConfig

--- a/api/grpcserver/mocks.go
+++ b/api/grpcserver/mocks.go
@@ -1090,17 +1090,17 @@ func (c *MockpostSupervisorProvidersCall) DoAndReturn(f func() ([]activation.Pos
 }
 
 // Start mocks base method.
-func (m *MockpostSupervisor) Start(opts activation.PostSetupOpts, id *signing.EdSigner) error {
+func (m *MockpostSupervisor) Start(opts activation.PostSetupOpts, sig *signing.EdSigner) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Start", opts, id)
+	ret := m.ctrl.Call(m, "Start", opts, sig)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Start indicates an expected call of Start.
-func (mr *MockpostSupervisorMockRecorder) Start(opts, id any) *MockpostSupervisorStartCall {
+func (mr *MockpostSupervisorMockRecorder) Start(opts, sig any) *MockpostSupervisorStartCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockpostSupervisor)(nil).Start), opts, id)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockpostSupervisor)(nil).Start), opts, sig)
 	return &MockpostSupervisorStartCall{Call: call}
 }
 

--- a/api/grpcserver/mocks.go
+++ b/api/grpcserver/mocks.go
@@ -19,6 +19,7 @@ import (
 	activation "github.com/spacemeshos/go-spacemesh/activation"
 	types "github.com/spacemeshos/go-spacemesh/common/types"
 	p2p "github.com/spacemeshos/go-spacemesh/p2p"
+	signing "github.com/spacemeshos/go-spacemesh/signing"
 	system "github.com/spacemeshos/go-spacemesh/system"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -1089,17 +1090,17 @@ func (c *MockpostSupervisorProvidersCall) DoAndReturn(f func() ([]activation.Pos
 }
 
 // Start mocks base method.
-func (m *MockpostSupervisor) Start(opts activation.PostSetupOpts, id types.NodeID, onInitDone func()) error {
+func (m *MockpostSupervisor) Start(opts activation.PostSetupOpts, id *signing.EdSigner) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Start", opts, id, onInitDone)
+	ret := m.ctrl.Call(m, "Start", opts, id)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Start indicates an expected call of Start.
-func (mr *MockpostSupervisorMockRecorder) Start(opts, id, onInitDone any) *MockpostSupervisorStartCall {
+func (mr *MockpostSupervisorMockRecorder) Start(opts, id any) *MockpostSupervisorStartCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockpostSupervisor)(nil).Start), opts, id, onInitDone)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockpostSupervisor)(nil).Start), opts, id)
 	return &MockpostSupervisorStartCall{Call: call}
 }
 
@@ -1115,13 +1116,13 @@ func (c *MockpostSupervisorStartCall) Return(arg0 error) *MockpostSupervisorStar
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockpostSupervisorStartCall) Do(f func(activation.PostSetupOpts, types.NodeID, func()) error) *MockpostSupervisorStartCall {
+func (c *MockpostSupervisorStartCall) Do(f func(activation.PostSetupOpts, *signing.EdSigner) error) *MockpostSupervisorStartCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockpostSupervisorStartCall) DoAndReturn(f func(activation.PostSetupOpts, types.NodeID, func()) error) *MockpostSupervisorStartCall {
+func (c *MockpostSupervisorStartCall) DoAndReturn(f func(activation.PostSetupOpts, *signing.EdSigner) error) *MockpostSupervisorStartCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/api/grpcserver/mocks.go
+++ b/api/grpcserver/mocks.go
@@ -1089,17 +1089,17 @@ func (c *MockpostSupervisorProvidersCall) DoAndReturn(f func() ([]activation.Pos
 }
 
 // Start mocks base method.
-func (m *MockpostSupervisor) Start(opts activation.PostSetupOpts, id types.NodeID) error {
+func (m *MockpostSupervisor) Start(opts activation.PostSetupOpts, id types.NodeID, onInitDone func()) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Start", opts, id)
+	ret := m.ctrl.Call(m, "Start", opts, id, onInitDone)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Start indicates an expected call of Start.
-func (mr *MockpostSupervisorMockRecorder) Start(opts, id any) *MockpostSupervisorStartCall {
+func (mr *MockpostSupervisorMockRecorder) Start(opts, id, onInitDone any) *MockpostSupervisorStartCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockpostSupervisor)(nil).Start), opts, id)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockpostSupervisor)(nil).Start), opts, id, onInitDone)
 	return &MockpostSupervisorStartCall{Call: call}
 }
 
@@ -1115,13 +1115,13 @@ func (c *MockpostSupervisorStartCall) Return(arg0 error) *MockpostSupervisorStar
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockpostSupervisorStartCall) Do(f func(activation.PostSetupOpts, types.NodeID) error) *MockpostSupervisorStartCall {
+func (c *MockpostSupervisorStartCall) Do(f func(activation.PostSetupOpts, types.NodeID, func()) error) *MockpostSupervisorStartCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockpostSupervisorStartCall) DoAndReturn(f func(activation.PostSetupOpts, types.NodeID) error) *MockpostSupervisorStartCall {
+func (c *MockpostSupervisorStartCall) DoAndReturn(f func(activation.PostSetupOpts, types.NodeID, func()) error) *MockpostSupervisorStartCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/api/grpcserver/post_service_test.go
+++ b/api/grpcserver/post_service_test.go
@@ -61,7 +61,7 @@ func launchPostSupervisor(
 	ps, err := activation.NewPostSupervisor(log, serviceCfg, postCfg, provingOpts, mgr)
 	require.NoError(tb, err)
 	require.NotNil(tb, ps)
-	require.NoError(tb, ps.Start(postOpts, sig.NodeID()))
+	require.NoError(tb, ps.Start(postOpts, sig.NodeID(), func() {}))
 	return sig.NodeID(), func() { assert.NoError(tb, ps.Stop(false)) }
 }
 
@@ -102,7 +102,7 @@ func launchPostSupervisorTLS(
 	ps, err := activation.NewPostSupervisor(log, serviceCfg, postCfg, provingOpts, mgr)
 	require.NoError(tb, err)
 	require.NotNil(tb, ps)
-	require.NoError(tb, ps.Start(postOpts, sig.NodeID()))
+	require.NoError(tb, ps.Start(postOpts, sig.NodeID(), func() {}))
 	return sig.NodeID(), func() { assert.NoError(tb, ps.Stop(false)) }
 }
 

--- a/api/grpcserver/smesher_service.go
+++ b/api/grpcserver/smesher_service.go
@@ -87,7 +87,7 @@ func (s SmesherService) StartSmeshing(
 	if s.nodeID == nil {
 		return nil, status.Errorf(codes.FailedPrecondition, "node is not configured for supervised smeshing")
 	}
-	if err := s.postSupervisor.Start(opts, *s.nodeID); err != nil {
+	if err := s.postSupervisor.Start(opts, *s.nodeID, func() {}); err != nil {
 		ctxzap.Error(ctx, "failed to start post supervisor", zap.Error(err))
 		return nil, status.Error(codes.Internal, fmt.Sprintf("failed to start post supervisor: %v", err))
 	}

--- a/api/grpcserver/smesher_service_test.go
+++ b/api/grpcserver/smesher_service_test.go
@@ -76,7 +76,7 @@ func TestStartSmeshingPassesCorrectSmeshingOpts(t *testing.T) {
 		ComputeBatchSize: config.DefaultComputeBatchSize,
 	}
 	opts.ProviderID.SetUint32(providerID)
-	postSupervisor.EXPECT().Start(opts, nodeID).Return(nil)
+	postSupervisor.EXPECT().Start(opts, nodeID, gomock.Any()).Return(nil)
 	smeshingProvider.EXPECT().StartSmeshing(addr).Return(nil)
 
 	_, err = svc.StartSmeshing(context.Background(), &pb.StartSmeshingRequest{

--- a/node/node.go
+++ b/node/node.go
@@ -1025,13 +1025,15 @@ func (app *App) initServices(ctx context.Context) error {
 		activation.WithValidator(app.validator),
 		activation.WithPostValidityDelay(app.Config.PostValidDelay),
 	)
-	if len(app.signers) > 1 {
+	if len(app.signers) > 1 || !app.Config.SMESHING.Start {
 		// in a remote setup we register eagerly so the atxBuilder can inform about missing
-		// connections to post services asap
+		// connections to post services asap. Any setup with more than one signer is considered
+		// a remote setup. If there is only one signer and smeshing is disabled we also consider it a
+		// remote setup.
 		//
 		// in a supervised setup the postSetupManager will register at the atxBuilder
-		// as soon as it finished initializing, to avoid warning about a missing connections when
-		// this is expected
+		// as soon as it finished initializing, to avoid warning about a missing connection when
+		// the supervised post service isn't ready yet
 		for _, sig := range app.signers {
 			atxBuilder.Register(sig)
 		}

--- a/node/node.go
+++ b/node/node.go
@@ -1025,12 +1025,12 @@ func (app *App) initServices(ctx context.Context) error {
 		activation.WithValidator(app.validator),
 		activation.WithPostValidityDelay(app.Config.PostValidDelay),
 	)
-	if len(app.signers) > 1 {
+	if len(app.signers) > 1 || app.signers[0].Name() != supervisedIDKeyFileName {
 		// in a remote setup we register eagerly so the atxBuilder can warn about missing connections asap.
 		// Any setup with more than one signer is considered a remote setup. If there is only one signer it
-		// is either a supervised or non-smeshing setup.
+		// is considered a remote setup if the key for the signer has not been sourced from `supervisedIDKeyFileName`.
 		//
-		// Either way, in a supervised setup the postSetupManager will register at the atxBuilder when
+		// In a supervised setup the postSetupManager will register at the atxBuilder when
 		// it finished initializing, to avoid warning about a missing connection when the supervised post
 		// service isn't ready yet.
 		for _, sig := range app.signers {

--- a/node/node.go
+++ b/node/node.go
@@ -1025,7 +1025,7 @@ func (app *App) initServices(ctx context.Context) error {
 		activation.WithValidator(app.validator),
 		activation.WithPostValidityDelay(app.Config.PostValidDelay),
 	)
-	if len(app.signers) > 1 || !app.Config.SMESHING.Start {
+	if len(app.signers) > 1 || (len(app.signers) == 1 && !app.Config.SMESHING.Start) {
 		// in a remote setup we register eagerly so the atxBuilder can inform about missing
 		// connections to post services asap. Any setup with more than one signer is considered
 		// a remote setup. If there is only one signer and smeshing is disabled we also consider it a

--- a/node/node_identities.go
+++ b/node/node_identities.go
@@ -186,6 +186,23 @@ func (app *App) LoadIdentities() error {
 		return fmt.Errorf("duplicate key found in identity files")
 	}
 
+	if len(signers) > 1 {
+		app.log.Info("Loaded %d identities from disk", len(signers))
+		for _, sig := range signers {
+			if sig.Name() == supervisedIDKeyFileName {
+				app.log.Error(
+					"Identities contain key for supervised smeshing (%s). This is not supported in remote smeshing.",
+					supervisedIDKeyFileName,
+				)
+				app.log.Error(
+					"Please ensure you do not have a key file named %s in your identities directory when using remote smeshing.",
+					supervisedIDKeyFileName,
+				)
+				return fmt.Errorf("supervised key found in remote smeshing mode")
+			}
+		}
+	}
+
 	app.signers = signers
 	return nil
 }

--- a/node/node_identities.go
+++ b/node/node_identities.go
@@ -149,23 +149,8 @@ func (app *App) LoadIdentities() error {
 			return nil
 		}
 
-		// read hex data from file
-		dst := make([]byte, signing.PrivateKeySize)
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return fmt.Errorf("failed to open identity file at %s: %w", path, err)
-		}
-
-		n, err := hex.Decode(dst, data)
-		if err != nil {
-			return fmt.Errorf("decoding private key in %s: %w", d.Name(), err)
-		}
-		if n != signing.PrivateKeySize {
-			return fmt.Errorf("invalid key size %d/%d for %s", n, signing.PrivateKeySize, d.Name())
-		}
-
 		signer, err := signing.NewEdSigner(
-			signing.WithPrivateKey(dst),
+			signing.FromFile(path),
 			signing.WithPrefix(app.Config.Genesis.GenesisID().Bytes()),
 		)
 		if err != nil {

--- a/node/node_identities_test.go
+++ b/node/node_identities_test.go
@@ -93,12 +93,6 @@ func TestSpacemeshApp_NewIdentity(t *testing.T) {
 		require.Len(t, app.signers, 1)
 		newKey := app.signers[0].PublicKey()
 		require.NotEqual(t, existingKey, newKey) // new key was created and loaded
-
-		err = app.LoadIdentities()
-		require.NoError(t, err)
-		require.Len(t, app.signers, 2)
-		require.Equal(t, app.signers[0].PublicKey(), existingKey)
-		require.Equal(t, app.signers[1].PublicKey(), newKey)
 	})
 }
 

--- a/node/node_identities_test.go
+++ b/node/node_identities_test.go
@@ -28,13 +28,16 @@ func setupAppWithKeys(tb testing.TB, data ...[]byte) (*App, *observer.ObservedLo
 		return app, observedLogs
 	}
 
-	key := data[0]
-	keyFile := filepath.Join(app.Config.DataDirParent, keyDir, supervisedIDKeyFileName)
-	require.NoError(tb, os.MkdirAll(filepath.Dir(keyFile), 0o700))
-	require.NoError(tb, os.WriteFile(keyFile, key, 0o600))
+	require.NoError(tb, os.MkdirAll(filepath.Join(app.Config.DataDirParent, keyDir), 0o700))
+	if len(data) == 1 {
+		key := data[0]
+		keyFile := filepath.Join(app.Config.DataDirParent, keyDir, supervisedIDKeyFileName)
+		require.NoError(tb, os.WriteFile(keyFile, key, 0o600))
+		return app, observedLogs
+	}
 
-	for i, key := range data[1:] {
-		keyFile = filepath.Join(app.Config.DataDirParent, keyDir, fmt.Sprintf("identity_%d.key", i))
+	for i, key := range data {
+		keyFile := filepath.Join(app.Config.DataDirParent, keyDir, fmt.Sprintf("identity_%d.key", i))
 		require.NoError(tb, os.WriteFile(keyFile, key, 0o600))
 	}
 	return app, observedLogs
@@ -168,5 +171,45 @@ func TestSpacemeshApp_LoadIdentities(t *testing.T) {
 		log2 := observedLogs.FilterField(zap.String("public_key", key2.PublicKey().ShortString()))
 		require.Len(t, log2.All(), 1)
 		require.Contains(t, log2.All()[0].Message, "duplicate key")
+	})
+
+	t.Run("supervised key alongside others", func(t *testing.T) {
+		key, err := signing.NewEdSigner()
+		require.NoError(t, err)
+		key1, err := signing.NewEdSigner()
+		require.NoError(t, err)
+		key2, err := signing.NewEdSigner()
+		require.NoError(t, err)
+
+		app, _ := setupAppWithKeys(t,
+			[]byte(hex.EncodeToString(key1.PrivateKey())),
+			[]byte(hex.EncodeToString(key2.PrivateKey())),
+		)
+
+		dst := make([]byte, hex.EncodedLen(len(key.PrivateKey())))
+		hex.Encode(dst, key.PrivateKey())
+		err = os.WriteFile(filepath.Join(app.Config.DataDirParent, keyDir, supervisedIDKeyFileName), dst, 0o600)
+		require.NoError(t, err)
+		err = app.LoadIdentities()
+		require.ErrorContains(t, err, "supervised key found in remote smeshing mode")
+	})
+
+	t.Run("multiple good keys", func(t *testing.T) {
+		key1, err := signing.NewEdSigner()
+		require.NoError(t, err)
+		key2, err := signing.NewEdSigner()
+		require.NoError(t, err)
+		key3, err := signing.NewEdSigner()
+		require.NoError(t, err)
+
+		app, _ := setupAppWithKeys(t,
+			[]byte(hex.EncodeToString(key1.PrivateKey())),
+			[]byte(hex.EncodeToString(key2.PrivateKey())),
+			[]byte(hex.EncodeToString(key3.PrivateKey())),
+		)
+
+		err = app.LoadIdentities()
+		require.NoError(t, err)
+		require.Len(t, app.signers, 3)
 	})
 }

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -1315,7 +1315,7 @@ func launchPostSupervisor(
 	ps, err := activation.NewPostSupervisor(log, cmdCfg, postCfg, provingOpts, mgr)
 	require.NoError(tb, err)
 	require.NotNil(tb, ps)
-	require.NoError(tb, ps.Start(postOpts, id))
+	require.NoError(tb, ps.Start(postOpts, id, func() {}))
 	return func() { assert.NoError(tb, ps.Stop(false)) }
 }
 

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -1150,6 +1150,7 @@ func TestAdminEvents_MultiSmesher(t *testing.T) {
 
 	<-app.Started()
 	for _, signer := range app.signers {
+		signer := signer
 		mgr, err := activation.NewPostSetupManager(
 			cfg.POST,
 			logger.Zap(),
@@ -1168,6 +1169,7 @@ func TestAdminEvents_MultiSmesher(t *testing.T) {
 			cfg.API.PostListener,
 			cfg.POST,
 			cfg.SMESHING.Opts,
+			func() { app.atxBuilder.Register(signer) },
 		))
 	}
 

--- a/signing/signer_test.go
+++ b/signing/signer_test.go
@@ -1,21 +1,134 @@
 package signing
 
 import (
+	"bytes"
 	"crypto/ed25519"
 	"crypto/rand"
+	"encoding/hex"
+	"io/fs"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewEdSignerFromBuffer(t *testing.T) {
-	b := []byte{1, 2, 3}
-	_, err := NewEdSigner(WithPrivateKey(b))
-	require.ErrorContains(t, err, "too small")
+func Test_NewEdSigner_WithPrivateKey(t *testing.T) {
+	t.Run("key too short", func(t *testing.T) {
+		_, err := NewEdSigner(WithPrivateKey(make([]byte, 63)))
+		require.ErrorContains(t, err, "invalid key length")
+	})
 
-	b = make([]byte, 64)
-	_, err = NewEdSigner(WithPrivateKey(b))
-	require.ErrorContains(t, err, "private and public do not match")
+	t.Run("key too long", func(t *testing.T) {
+		_, err := NewEdSigner(WithPrivateKey(make([]byte, 65)))
+		require.ErrorContains(t, err, "invalid key length")
+	})
+
+	t.Run("key mismatch", func(t *testing.T) {
+		_, err := NewEdSigner(WithPrivateKey(make([]byte, 64)))
+		require.ErrorContains(t, err, "private and public do not match")
+	})
+
+	t.Run("valid key", func(t *testing.T) {
+		ed, err := NewEdSigner()
+		require.NoError(t, err)
+
+		key := ed.PrivateKey()
+		ed2, err := NewEdSigner(WithPrivateKey(key))
+		require.NoError(t, err)
+		require.Equal(t, ed.priv, ed2.priv)
+		require.Equal(t, ed.PublicKey(), ed2.PublicKey())
+	})
+
+	t.Run("fails if private key already set", func(t *testing.T) {
+		ed, err := NewEdSigner()
+		require.NoError(t, err)
+
+		key := ed.PrivateKey()
+		_, err = NewEdSigner(WithPrivateKey(key), WithPrivateKey(key))
+		require.ErrorContains(t, err, "invalid option WithPrivateKey: private key already set")
+
+		keyFile := filepath.Join(t.TempDir(), "identity.key")
+		dst := make([]byte, hex.EncodedLen(len(ed.PrivateKey())))
+		hex.Encode(dst, ed.PrivateKey())
+		err = os.WriteFile(keyFile, dst, 0o600)
+		require.NoError(t, err)
+
+		_, err = NewEdSigner(FromFile(keyFile), WithPrivateKey(key))
+		require.ErrorContains(t, err, "invalid option WithPrivateKey: private key already set")
+	})
+}
+
+func Test_NewEdSigner_FromFile(t *testing.T) {
+	t.Run("invalid file", func(t *testing.T) {
+		_, err := NewEdSigner(FromFile("nonexistent"))
+		require.ErrorIs(t, err, fs.ErrNotExist)
+		require.ErrorContains(t, err, "failed to open identity file at nonexistent")
+	})
+
+	t.Run("invalid key", func(t *testing.T) {
+		keyFile := filepath.Join(t.TempDir(), "identity.key")
+		key := bytes.Repeat([]byte{0}, PrivateKeySize*2)
+		err := os.WriteFile(keyFile, key, 0o600)
+		require.NoError(t, err)
+
+		_, err = NewEdSigner(FromFile(keyFile))
+		require.ErrorContains(t, err, "decoding private key in identity.key")
+	})
+
+	t.Run("invalid key size - too short", func(t *testing.T) {
+		keyFile := filepath.Join(t.TempDir(), "identity.key")
+		key := bytes.Repeat([]byte{0}, 63)
+		dst := make([]byte, hex.EncodedLen(len(key)))
+		hex.Encode(dst, key)
+		err := os.WriteFile(keyFile, dst, 0o600)
+		require.NoError(t, err)
+
+		_, err = NewEdSigner(FromFile(keyFile))
+		require.ErrorContains(t, err, "invalid key size 63/64 for identity.key")
+	})
+
+	t.Run("invalid key size - too long", func(t *testing.T) {
+		keyFile := filepath.Join(t.TempDir(), "identity.key")
+		key := bytes.Repeat([]byte{0}, 65)
+		dst := make([]byte, hex.EncodedLen(len(key)))
+		hex.Encode(dst, key)
+		err := os.WriteFile(keyFile, dst, 0o600)
+		require.NoError(t, err)
+
+		_, err = NewEdSigner(FromFile(keyFile))
+		require.ErrorContains(t, err, "invalid key size 65/64 for identity.key")
+	})
+
+	t.Run("valid key", func(t *testing.T) {
+		ed, err := NewEdSigner()
+		require.NoError(t, err)
+
+		keyFile := filepath.Join(t.TempDir(), "identity.key")
+		dst := make([]byte, hex.EncodedLen(len(ed.PrivateKey())))
+		hex.Encode(dst, ed.PrivateKey())
+		err = os.WriteFile(keyFile, dst, 0o600)
+		require.NoError(t, err)
+
+		ed2, err := NewEdSigner(FromFile(keyFile))
+		require.NoError(t, err)
+		require.Equal(t, ed.priv, ed2.priv)
+		require.Equal(t, ed.PublicKey(), ed2.PublicKey())
+	})
+
+	t.Run("fails if private key already set", func(t *testing.T) {
+		ed, err := NewEdSigner()
+		require.NoError(t, err)
+
+		keyFile := filepath.Join(t.TempDir(), "identity.key")
+		dst := make([]byte, hex.EncodedLen(len(ed.PrivateKey())))
+		hex.Encode(dst, ed.PrivateKey())
+		err = os.WriteFile(keyFile, dst, 0o600)
+		require.NoError(t, err)
+
+		_, err = NewEdSigner(WithPrivateKey(ed.PrivateKey()), FromFile(keyFile))
+		require.ErrorContains(t, err, "invalid option FromFile: private key already set")
+	})
 }
 
 func TestEdSigner_Sign(t *testing.T) {
@@ -38,17 +151,6 @@ func TestEdSigner_ValidKeyEncoding(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, []byte(ed.priv[32:]), ed.PublicKey().Bytes())
-}
-
-func TestEdSigner_WithPrivateKey(t *testing.T) {
-	ed, err := NewEdSigner()
-	require.NoError(t, err)
-
-	key := ed.PrivateKey()
-	ed2, err := NewEdSigner(WithPrivateKey(key))
-	require.NoError(t, err)
-	require.Equal(t, ed.priv, ed2.priv)
-	require.Equal(t, ed.PublicKey(), ed2.PublicKey())
 }
 
 func TestPublicKey_ShortString(t *testing.T) {

--- a/systest/tests/distributed_post_verification_test.go
+++ b/systest/tests/distributed_post_verification_test.go
@@ -134,7 +134,7 @@ func TestPostMalfeasanceProof(t *testing.T) {
 		postSetupMgr,
 	)
 	require.NoError(t, err)
-	require.NoError(t, postSupervisor.Start(cfg.SMESHING.Opts, signer.NodeID()))
+	require.NoError(t, postSupervisor.Start(cfg.SMESHING.Opts, signer.NodeID(), func() {}))
 	t.Cleanup(func() { assert.NoError(t, postSupervisor.Stop(false)) })
 
 	// 2. create ATX with invalid POST labels


### PR DESCRIPTION
## Motivation

Currently, the supervised ID is registered immediately (possibly before its POST is initialized, which can take a long time). This will trigger warning logs `post service not connected - waiting for reconnection` to be emitted every 20 s potentially for days which this PR addresses.

## Description

With the changes of this PR if the node runs in supervised mode instead of registering the PoST service eagerly it will be registered by the `postSetupManager` as soon as initialization is completed. This will cause the warning to never be printed in a supervised setup because if the node expects the post service to be connected but it isn't it will shut down with an error message.

The behavior for remote smeshing (1 or multiple identities) is unchanged. The `atxBuilder` will log immediately when no connection is available and it needs access to a post service - this happens only when it tries to generate a proof.

In summary:
- if multiple key files are found it is considered a remote smeshing setup
   - `local.key` is not allowed to be present in this case and will print an error and shut down
   - `local.key` is also the file that is used to generate a key in if no key was found during startup (and where an existing `key.bin` file will be migrated to)
   - keys are registered eagerly in the atxBuilder, i.e. if any post service is expected to be connected but it is not the node will print warnings
- if only one key file is found and it is NOT `local.key`
   - remote smeshing setup with only one post service, handled as if multiple keys were found
- if only one key file is found and it IS `local.key`
   - supervised setup - can be smeshing or non-smeshing (based on config / CLI parameters and can be started and stopped via GRPC for backwards compatibility)
   - key is registered lazily in the `atxBuilder` by the postSetupManager, i.e. after `initialization` finished
   - this should never print a warning about a missing connection, because the node will shut down in a supervised setup if no post service is connected when it expects one (after some delay and will print why).

## Test Plan

existing tests

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
