### PR TITLE
[Merged by Bors] - Avoid printing stacktrace when testing panic logs

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -113,12 +113,6 @@ func NewWithLevel(module string, level zap.AtomicLevel, hooks ...func(zapcore.En
 	return NewFromLog(log)
 }
 
-// RegisterHooks wraps provided loggers with hooks.
-func RegisterHooks(lg Log, hooks ...func(zapcore.Entry) error) Log {
-	core := zapcore.RegisterHooks(lg.logger.Core(), hooks...)
-	return NewFromLog(zap.New(core))
-}
-
 // NewDefault creates a Log with the default log level.
 func NewDefault(module string) Log {
 	return NewWithLevel(module, zap.NewAtomicLevelAt(DefaultLevel()))

--- a/node/node.go
+++ b/node/node.go
@@ -155,10 +155,7 @@ func GetCommand() *cobra.Command {
 				WithConfig(&conf),
 				// NOTE(dshulyak) this needs to be max level so that child logger can can be current level or below.
 				// otherwise it will fail later when child logger will try to increase level.
-				WithLog(log.RegisterHooks(
-					log.NewWithLevel("node", zap.NewAtomicLevelAt(zap.DebugLevel)),
-					events.EventHook()),
-				),
+				WithLog(log.NewWithLevel("node", zap.NewAtomicLevelAt(zap.DebugLevel), events.EventHook())),
 			)
 
 			// os.Interrupt for all systems, especially windows, syscall.SIGTERM is mainly for docker.


### PR DESCRIPTION
## Motivation

Zap v1.27.0 adds a panic hook. We can use it to intercept panic in the test which checks the logging of panic messages, and to avoid confusing test output.

## Description

as above

## Test Plan

existing tests

## TODO
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [ ] Update documentation as needed
- [ ] Update [changelog](../CHANGELOG.md) as needed
