### PR TITLE
[Merged by Bors] - Make epoch filter optional for ActivationsCount endpoint

### DIFF
--- a/api/grpcserver/v2alpha1/activation.go
+++ b/api/grpcserver/v2alpha1/activation.go
@@ -264,13 +264,14 @@ func (s *ActivationService) ActivationsCount(
 	ctx context.Context,
 	request *spacemeshv2alpha1.ActivationsCountRequest,
 ) (*spacemeshv2alpha1.ActivationsCountResponse, error) {
-	ops := builder.Operations{Filter: []builder.Op{
-		{
+	ops := builder.Operations{}
+	if request.Epoch != nil {
+		ops.Filter = append(ops.Filter, builder.Op{
 			Field: builder.Epoch,
 			Token: builder.Eq,
-			Value: int64(request.Epoch),
-		},
-	}}
+			Value: int64(*request.Epoch),
+		})
+	}
 
 	count, err := atxs.CountAtxsByOps(s.db, ops)
 	if err != nil {

--- a/api/grpcserver/v2alpha1/activation_test.go
+++ b/api/grpcserver/v2alpha1/activation_test.go
@@ -227,9 +227,18 @@ func TestActivationService_ActivationsCount(t *testing.T) {
 	conn := dialGrpc(ctx, t, cfg)
 	client := spacemeshv2alpha1.NewActivationServiceClient(conn)
 
-	count, err := client.ActivationsCount(ctx, &spacemeshv2alpha1.ActivationsCountRequest{
-		Epoch: activations[3].PublishEpoch.Uint32(),
+	t.Run("count without filter", func(t *testing.T) {
+		count, err := client.ActivationsCount(ctx, &spacemeshv2alpha1.ActivationsCountRequest{})
+		require.NoError(t, err)
+		require.Len(t, activations, int(count.Count))
 	})
-	require.NoError(t, err)
-	require.Len(t, activations, int(count.Count))
+
+	t.Run("count with filter", func(t *testing.T) {
+		epoch := activations[3].PublishEpoch.Uint32()
+		count, err := client.ActivationsCount(ctx, &spacemeshv2alpha1.ActivationsCountRequest{
+			Epoch: &epoch,
+		})
+		require.NoError(t, err)
+		require.Len(t, activations, int(count.Count))
+	})
 }

--- a/api/grpcserver/v2alpha1/activation_test.go
+++ b/api/grpcserver/v2alpha1/activation_test.go
@@ -212,12 +212,19 @@ func TestActivationService_ActivationsCount(t *testing.T) {
 	db := sql.InMemory()
 	ctx := context.Background()
 
-	gen := fixture.NewAtxsGenerator().WithEpochs(0, 1)
-	activations := make([]types.VerifiedActivationTx, 30)
-	for i := range activations {
-		atx := gen.Next()
+	genEpoch3 := fixture.NewAtxsGenerator().WithEpochs(3, 1)
+	epoch3ATXs := make([]types.VerifiedActivationTx, 30)
+	for i := range epoch3ATXs {
+		atx := genEpoch3.Next()
 		require.NoError(t, atxs.Add(db, atx))
-		activations[i] = *atx
+		epoch3ATXs[i] = *atx
+	}
+	genEpoch5 := fixture.NewAtxsGenerator().WithEpochs(5, 1)
+	epoch5ATXs := make([]types.VerifiedActivationTx, 10) // ensure the number here is different from above
+	for i := range epoch5ATXs {
+		atx := genEpoch5.Next()
+		require.NoError(t, atxs.Add(db, atx))
+		epoch5ATXs[i] = *atx
 	}
 
 	svc := NewActivationService(db)
@@ -230,15 +237,24 @@ func TestActivationService_ActivationsCount(t *testing.T) {
 	t.Run("count without filter", func(t *testing.T) {
 		count, err := client.ActivationsCount(ctx, &spacemeshv2alpha1.ActivationsCountRequest{})
 		require.NoError(t, err)
-		require.Len(t, activations, int(count.Count))
+		require.Equal(t, len(epoch3ATXs)+len(epoch5ATXs), int(count.Count))
 	})
 
 	t.Run("count with filter", func(t *testing.T) {
-		epoch := activations[3].PublishEpoch.Uint32()
-		count, err := client.ActivationsCount(ctx, &spacemeshv2alpha1.ActivationsCountRequest{
+		epoch := uint32(3)
+		epoch3Count, err := client.ActivationsCount(ctx, &spacemeshv2alpha1.ActivationsCountRequest{
 			Epoch: &epoch,
 		})
 		require.NoError(t, err)
-		require.Len(t, activations, int(count.Count))
+		require.Len(t, epoch3ATXs, int(epoch3Count.Count))
+
+		epoch = uint32(5)
+		epoch5Count, err := client.ActivationsCount(ctx, &spacemeshv2alpha1.ActivationsCountRequest{
+			Epoch: &epoch,
+		})
+		require.NoError(t, err)
+		require.Len(t, epoch5ATXs, int(epoch5Count.Count))
+
+		require.NotEqual(t, int(epoch3Count.Count), int(epoch5Count.Count))
 	})
 }

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/quic-go/quic-go v0.41.0
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/seehuhn/mt19937 v1.0.0
-	github.com/spacemeshos/api/release/go v1.30.0
+	github.com/spacemeshos/api/release/go v1.31.0
 	github.com/spacemeshos/economics v0.1.2
 	github.com/spacemeshos/fixed v0.1.1
 	github.com/spacemeshos/go-scale v1.1.12

--- a/go.sum
+++ b/go.sum
@@ -622,8 +622,8 @@ github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d/go.mod h1:Udh
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
-github.com/spacemeshos/api/release/go v1.30.0 h1:jJUsMiIvGcm/eLOCuKO8/j4y+9vlsW6s36ThODTmIvE=
-github.com/spacemeshos/api/release/go v1.30.0/go.mod h1:MsRwGvD0mAguy5Cri9EsE8VPK25J5zywa+A7sX9Fi40=
+github.com/spacemeshos/api/release/go v1.31.0 h1:ZNKZ06KAKMlC6SgrXglD6Pwe0LXfzOiLuOLdbmjs2BI=
+github.com/spacemeshos/api/release/go v1.31.0/go.mod h1:jyW98UJyTx4Ji8WETPiKJJONAJP0OqoWtTTd3VQWtBs=
 github.com/spacemeshos/economics v0.1.2 h1:kw8cE5SMa/7svHOGorCd2w8ef1y8iP0p47/2VDOK8Ns=
 github.com/spacemeshos/economics v0.1.2/go.mod h1:ngeWn5E/jy9dJP1MHyuk3ehF8NBMTYhchqVDhAHUUNk=
 github.com/spacemeshos/fixed v0.1.1 h1:N1y4SUpq1EV+IdJrWJwUCt1oBFzeru/VKVcBsvPc2Fk=


### PR DESCRIPTION
## Motivation
We need to display the amount of synced activations in Smapp.
It is kinda weird to request its amount only filtered by epochs, so I made such a filter optional.

## Description
If `epoch` is zero (or not set) — do not filter Atxs by epoch.