### PR TITLE
[Merged by Bors] - sql: fix deadlock in querycache

### DIFF
--- a/activation/activation.go
+++ b/activation/activation.go
@@ -680,7 +680,7 @@ func (b *Builder) Regossip(ctx context.Context, nodeID types.NodeID) error {
 	} else if err != nil {
 		return err
 	}
-	blob, err := atxs.GetBlob(b.cdb, atx.Bytes())
+	blob, err := atxs.GetBlob(ctx, b.cdb, atx.Bytes())
 	if err != nil {
 		return fmt.Errorf("get blob %s: %w", atx.ShortString(), err)
 	}

--- a/activation/activation_multi_test.go
+++ b/activation/activation_multi_test.go
@@ -195,7 +195,7 @@ func TestRegossip(t *testing.T) {
 			}
 		}
 
-		blob, err := atxs.GetBlob(tab.cdb, refAtx.ID().Bytes())
+		blob, err := atxs.GetBlob(context.Background(), tab.cdb, refAtx.ID().Bytes())
 		require.NoError(t, err)
 
 		// atx will be regossiped once (by the smesher)

--- a/activation/handler.go
+++ b/activation/handler.go
@@ -489,8 +489,8 @@ func (h *Handler) storeAtx(ctx context.Context, atx *types.VerifiedActivationTx)
 }
 
 // GetEpochAtxs returns all valid ATXs received in the epoch epochID.
-func (h *Handler) GetEpochAtxs(epochID types.EpochID) (ids []types.ATXID, err error) {
-	ids, err = atxs.GetIDsByEpoch(h.cdb, epochID)
+func (h *Handler) GetEpochAtxs(ctx context.Context, epochID types.EpochID) (ids []types.ATXID, err error) {
+	ids, err = atxs.GetIDsByEpoch(ctx, h.cdb, epochID)
 	h.log.With().Debug("returned epoch atxs", epochID,
 		log.Int("count", len(ids)),
 		log.String("atxs", fmt.Sprint(ids)))

--- a/cmd/activeset/activeset.go
+++ b/cmd/activeset/activeset.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"flag"
 	"fmt"
@@ -32,7 +33,7 @@ Example:
 	db, err := sql.Open("file:" + dbpath)
 	must(err, "can't open db at dbpath=%v. err=%s\n", dbpath, err)
 
-	ids, err := atxs.GetIDsByEpoch(db, types.EpochID(publish))
+	ids, err := atxs.GetIDsByEpoch(context.Background(), db, types.EpochID(publish))
 	must(err, "get ids by epoch %d. dbpath=%v. err=%s\n", publish, dbpath, err)
 	var weight uint64
 	for _, id := range ids {

--- a/datastore/store.go
+++ b/datastore/store.go
@@ -267,7 +267,7 @@ func (db *CachedDB) IterateEpochATXHeaders(
 	epoch types.EpochID,
 	iter func(*types.ActivationTxHeader) error,
 ) error {
-	ids, err := atxs.GetIDsByEpoch(db, epoch-1)
+	ids, err := atxs.GetIDsByEpoch(context.Background(), db, epoch-1)
 	if err != nil {
 		return err
 	}
@@ -370,10 +370,10 @@ type BlobStore struct {
 }
 
 // Get gets an ATX as bytes by an ATX ID as bytes.
-func (bs *BlobStore) Get(hint Hint, key []byte) ([]byte, error) {
+func (bs *BlobStore) Get(ctx context.Context, hint Hint, key []byte) ([]byte, error) {
 	switch hint {
 	case ATXDB:
-		return atxs.GetBlob(bs.DB, key)
+		return atxs.GetBlob(ctx, bs.DB, key)
 	case ProposalDB:
 		return bs.proposals.GetBlob(types.ProposalID(types.BytesToHash(key).ToHash20()))
 	case BallotDB:
@@ -407,7 +407,7 @@ func (bs *BlobStore) Get(hint Hint, key []byte) ([]byte, error) {
 	case Malfeasance:
 		return identities.GetMalfeasanceBlob(bs.DB, key)
 	case ActiveSet:
-		return activesets.GetBlob(bs.DB, key)
+		return activesets.GetBlob(ctx, bs.DB, key)
 	}
 	return nil, fmt.Errorf("blob store not found %s", hint)
 }

--- a/fetch/handler.go
+++ b/fetch/handler.go
@@ -67,8 +67,8 @@ func (h *handler) handleEpochInfoReq(ctx context.Context, msg []byte) ([]byte, e
 	}
 
 	cacheKey := sql.QueryCacheKey(atxs.CacheKindEpochATXs, epoch.String())
-	return sql.WithCachedSubKey(h.cdb, cacheKey, fetchSubKey, func() ([]byte, error) {
-		atxids, err := atxs.GetIDsByEpoch(h.cdb, epoch)
+	return sql.WithCachedSubKey(ctx, h.cdb, cacheKey, fetchSubKey, func(ctx context.Context) ([]byte, error) {
+		atxids, err := atxs.GetIDsByEpoch(ctx, h.cdb, epoch)
 		if err != nil {
 			h.logger.With().Warning("serve: failed to get epoch atx IDs",
 				epoch, log.Err(err), log.Context(ctx))
@@ -189,7 +189,7 @@ func (h *handler) handleHashReq(ctx context.Context, data []byte) ([]byte, error
 	// be included in the response at all
 	for _, r := range requestBatch.Requests {
 		totalHashReqs.WithLabelValues(string(r.Hint)).Add(1)
-		res, err := h.bs.Get(r.Hint, r.Hash.Bytes())
+		res, err := h.bs.Get(ctx, r.Hint, r.Hash.Bytes())
 		if err != nil {
 			h.logger.With().Debug("serve: remote peer requested nonexistent hash",
 				log.Context(ctx),

--- a/sql/activesets/activesets.go
+++ b/sql/activesets/activesets.go
@@ -1,6 +1,7 @@
 package activesets
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/spacemeshos/go-spacemesh/codec"
@@ -53,9 +54,9 @@ func Get(db sql.Executor, id types.Hash32) (*types.EpochActiveSet, error) {
 	return &rst, nil
 }
 
-func GetBlob(db sql.Executor, id []byte) ([]byte, error) {
+func GetBlob(ctx context.Context, db sql.Executor, id []byte) ([]byte, error) {
 	cacheKey := sql.QueryCacheKey(CacheKindActiveSetBlob, string(id))
-	return sql.WithCachedValue(db, cacheKey, func() ([]byte, error) {
+	return sql.WithCachedValue(ctx, db, cacheKey, func(context.Context) ([]byte, error) {
 		var rst []byte
 		rows, err := db.Exec("select active_set from activesets where id = ?1;",
 			func(stmt *sql.Statement) {

--- a/sql/atxs/atxs.go
+++ b/sql/atxs/atxs.go
@@ -1,6 +1,7 @@
 package atxs
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -216,9 +217,9 @@ func GetIDByEpochAndNodeID(db sql.Executor, epoch types.EpochID, nodeID types.No
 }
 
 // GetIDsByEpoch gets ATX IDs for a given epoch.
-func GetIDsByEpoch(db sql.Executor, epoch types.EpochID) (ids []types.ATXID, err error) {
+func GetIDsByEpoch(ctx context.Context, db sql.Executor, epoch types.EpochID) (ids []types.ATXID, err error) {
 	cacheKey := sql.QueryCacheKey(CacheKindEpochATXs, epoch.String())
-	return sql.WithCachedValue(db, cacheKey, func() (ids []types.ATXID, err error) {
+	return sql.WithCachedValue(ctx, db, cacheKey, func(context.Context) (ids []types.ATXID, err error) {
 		enc := func(stmt *sql.Statement) {
 			stmt.BindInt64(1, int64(epoch))
 		}
@@ -264,9 +265,9 @@ func VRFNonce(db sql.Executor, id types.NodeID, epoch types.EpochID) (nonce type
 }
 
 // GetBlob loads ATX as an encoded blob, ready to be sent over the wire.
-func GetBlob(db sql.Executor, id []byte) (buf []byte, err error) {
+func GetBlob(ctx context.Context, db sql.Executor, id []byte) (buf []byte, err error) {
 	cacheKey := sql.QueryCacheKey(CacheKindATXBlob, string(id))
-	return sql.WithCachedValue(db, cacheKey, func() ([]byte, error) {
+	return sql.WithCachedValue(ctx, db, cacheKey, func(context.Context) ([]byte, error) {
 		if rows, err := db.Exec("select atx from atxs where id = ?1",
 			func(stmt *sql.Statement) {
 				stmt.BindBytes(1, id)

--- a/sql/querycache_test.go
+++ b/sql/querycache_test.go
@@ -1,6 +1,7 @@
 package sql
 
 import (
+	"context"
 	"errors"
 	"strconv"
 	"testing"
@@ -10,45 +11,46 @@ import (
 
 func TestCache(t *testing.T) {
 	c := &queryCache{}
+	ctx := context.Background()
 
-	_, err := WithCachedValue(c, QueryCacheKey("tst", "foo"), func() (int, error) {
+	_, err := WithCachedValue(ctx, c, QueryCacheKey("tst", "foo"), func(context.Context) (int, error) {
 		return 0, errors.New("error retrieving value")
 	})
 	require.Error(t, err)
 
-	v, err := WithCachedValue(c, QueryCacheKey("tst", "foo"), func() (int, error) {
+	v, err := WithCachedValue(ctx, c, QueryCacheKey("tst", "foo"), func(context.Context) (int, error) {
 		return 42, nil
 	})
 	require.NoError(t, err)
 	require.Equal(t, 42, v)
 
-	s, err := WithCachedSubKey(c, QueryCacheKey("tst", "foo"), "sk1", func() (string, error) {
+	s, err := WithCachedSubKey(ctx, c, QueryCacheKey("tst", "foo"), "sk1", func(context.Context) (string, error) {
 		return "abc", nil
 	})
 	require.NoError(t, err)
 	require.Equal(t, "abc", s)
 
-	v, err = WithCachedValue(c, QueryCacheKey("tst", "foo"), func() (int, error) {
+	v, err = WithCachedValue(ctx, c, QueryCacheKey("tst", "foo"), func(context.Context) (int, error) {
 		t.Fatal("unexpected call for cached value")
 		return 0, nil
 	})
 	require.NoError(t, err)
 	require.Equal(t, 42, v)
 
-	v, err = WithCachedValue(c, QueryCacheKey("anotherkind", "foo"), func() (int, error) {
+	v, err = WithCachedValue(ctx, c, QueryCacheKey("anotherkind", "foo"), func(context.Context) (int, error) {
 		return 12345, nil
 	})
 	require.NoError(t, err)
 	require.Equal(t, 12345, v)
 
-	s, err = WithCachedSubKey(c, QueryCacheKey("tst", "foo"), "sk1", func() (string, error) {
+	s, err = WithCachedSubKey(ctx, c, QueryCacheKey("tst", "foo"), "sk1", func(context.Context) (string, error) {
 		t.Fatal("unexpected call for cached value")
 		return "", nil
 	})
 	require.NoError(t, err)
 	require.Equal(t, "abc", s)
 
-	v, err = WithCachedValue(c, QueryCacheKey("tst", "bar"), func() (int, error) {
+	v, err = WithCachedValue(ctx, c, QueryCacheKey("tst", "bar"), func(context.Context) (int, error) {
 		return 4242, nil
 	})
 	require.NoError(t, err)
@@ -61,17 +63,18 @@ func TestCacheEviction(t *testing.T) {
 			"kind1": 10,
 		},
 	}
+	ctx := context.Background()
 
 	// use up all 10 items in the LRU cache (both key and subkey is counted)
 	for i := 1; i <= 5; i++ {
 		k := strconv.Itoa(i)
-		v, err := WithCachedValue(c, QueryCacheKey("kind1", k), func() (int, error) {
+		v, err := WithCachedValue(ctx, c, QueryCacheKey("kind1", k), func(context.Context) (int, error) {
 			return i, nil
 		})
 		require.NoError(t, err)
 		require.Equal(t, i, v)
 
-		s, err := WithCachedSubKey(c, QueryCacheKey("kind1", k), "sk1", func() (int, error) {
+		s, err := WithCachedSubKey(ctx, c, QueryCacheKey("kind1", k), "sk1", func(context.Context) (int, error) {
 			return i * 10, nil
 		})
 		require.NoError(t, err)
@@ -79,7 +82,7 @@ func TestCacheEviction(t *testing.T) {
 	}
 
 	// This should cause the oldest key to be evicted with all of its subkeys
-	v, err := WithCachedValue(c, QueryCacheKey("kind1", "6"), func() (int, error) {
+	v, err := WithCachedValue(ctx, c, QueryCacheKey("kind1", "6"), func(context.Context) (int, error) {
 		return 6, nil
 	})
 	require.NoError(t, err)
@@ -88,13 +91,13 @@ func TestCacheEviction(t *testing.T) {
 	// ... other keys and subkeys stay in place.
 	for i := 2; i <= 5; i++ {
 		k := strconv.Itoa(i)
-		v, err := WithCachedValue(c, QueryCacheKey("kind1", k), func() (int, error) {
+		v, err := WithCachedValue(ctx, c, QueryCacheKey("kind1", k), func(context.Context) (int, error) {
 			return 0, errors.New("unexpected retrieve call")
 		})
 		require.NoError(t, err)
 		require.Equal(t, i, v)
 
-		s, err := WithCachedSubKey(c, QueryCacheKey("kind1", k), "sk1", func() (int, error) {
+		s, err := WithCachedSubKey(ctx, c, QueryCacheKey("kind1", k), "sk1", func(context.Context) (int, error) {
 			return 0, errors.New("unexpected retrieve call")
 		})
 		require.NoError(t, err)
@@ -103,14 +106,14 @@ func TestCacheEviction(t *testing.T) {
 
 	// Cache key evicted. We're checking it after the loop b/c re-adding the keys
 	// will cause more evictions
-	v, err = WithCachedValue(c, QueryCacheKey("kind1", "0"), func() (int, error) {
+	v, err = WithCachedValue(ctx, c, QueryCacheKey("kind1", "0"), func(context.Context) (int, error) {
 		return 42, nil
 	})
 	require.NoError(t, err)
 	require.Equal(t, 42, v)
 
 	// subkey evicted
-	s, err := WithCachedSubKey(c, QueryCacheKey("kind1", "0"), "sk1", func() (int, error) {
+	s, err := WithCachedSubKey(ctx, c, QueryCacheKey("kind1", "0"), "sk1", func(context.Context) (int, error) {
 		return 4242, nil
 	})
 	require.NoError(t, err)
@@ -119,31 +122,32 @@ func TestCacheEviction(t *testing.T) {
 
 func TestCacheSlice(t *testing.T) {
 	c := &queryCache{}
+	ctx := context.Background()
 
 	// ignored as no cached value yet
 	AppendToCachedSlice(c, QueryCacheKey("tst", "foo"), "def")
 
-	s, err := WithCachedValue(c, QueryCacheKey("tst", "foo"), func() ([]string, error) {
+	s, err := WithCachedValue(ctx, c, QueryCacheKey("tst", "foo"), func(context.Context) ([]string, error) {
 		return []string{"abc", "def"}, nil
 	})
 	require.NoError(t, err)
 	require.Equal(t, []string{"abc", "def"}, s)
 
-	s, err = WithCachedValue(c, QueryCacheKey("tst", "foo"), func() ([]string, error) {
+	s, err = WithCachedValue(ctx, c, QueryCacheKey("tst", "foo"), func(context.Context) ([]string, error) {
 		t.Fatal("unexpected call for cached value")
 		return nil, nil
 	})
 	require.NoError(t, err)
 	require.Equal(t, []string{"abc", "def"}, s)
 
-	v, err := WithCachedSubKey(c, QueryCacheKey("tst", "foo"), "sk1", func() (int, error) {
+	v, err := WithCachedSubKey(ctx, c, QueryCacheKey("tst", "foo"), "sk1", func(context.Context) (int, error) {
 		return 42, nil
 	})
 	require.NoError(t, err)
 	require.Equal(t, 42, v)
 
 	AppendToCachedSlice(c, QueryCacheKey("tst", "foo"), "qqq")
-	s, err = WithCachedValue(c, QueryCacheKey("tst", "foo"), func() ([]string, error) {
+	s, err = WithCachedValue(ctx, c, QueryCacheKey("tst", "foo"), func(context.Context) ([]string, error) {
 		t.Fatal("unexpected call for cached value")
 		return nil, nil
 	})
@@ -151,14 +155,14 @@ func TestCacheSlice(t *testing.T) {
 	require.Equal(t, []string{"abc", "def", "qqq"}, s)
 
 	// invalidated
-	v, err = WithCachedSubKey(c, QueryCacheKey("tst", "foo"), "sk1", func() (int, error) {
+	v, err = WithCachedSubKey(ctx, c, QueryCacheKey("tst", "foo"), "sk1", func(context.Context) (int, error) {
 		return 4242, nil
 	})
 	require.NoError(t, err)
 	require.Equal(t, 4242, v)
 
 	c.ClearCache()
-	s, err = WithCachedValue(c, QueryCacheKey("tst", "foo"), func() ([]string, error) {
+	s, err = WithCachedValue(ctx, c, QueryCacheKey("tst", "foo"), func(context.Context) ([]string, error) {
 		return []string{"new"}, nil
 	})
 	require.NoError(t, err)
@@ -166,27 +170,28 @@ func TestCacheSlice(t *testing.T) {
 }
 
 func TestNoCache(t *testing.T) {
+	ctx := context.Background()
 	for _, nc := range []any{nil, struct{}{}, (*queryCache)(nil)} {
-		s, err := WithCachedValue(nc, QueryCacheKey("tst", "foo"), func() ([]string, error) {
+		s, err := WithCachedValue(ctx, nc, QueryCacheKey("tst", "foo"), func(context.Context) ([]string, error) {
 			return []string{"abc", "def"}, nil
 		})
 		require.NoError(t, err)
 		require.Equal(t, []string{"abc", "def"}, s)
 
 		AppendToCachedSlice(nc, QueryCacheKey("tst", "foo"), "qqq")
-		s, err = WithCachedValue(nc, QueryCacheKey("tst", "foo"), func() ([]string, error) {
+		s, err = WithCachedValue(ctx, nc, QueryCacheKey("tst", "foo"), func(context.Context) ([]string, error) {
 			return []string{"abc", "def", "ghi"}, nil
 		})
 		require.NoError(t, err)
 		require.Equal(t, []string{"abc", "def", "ghi"}, s)
 
-		v, err := WithCachedSubKey(nc, QueryCacheKey("tst", "foo"), "sk1", func() (int, error) {
+		v, err := WithCachedSubKey(ctx, nc, QueryCacheKey("tst", "foo"), "sk1", func(context.Context) (int, error) {
 			return 4242, nil
 		})
 		require.NoError(t, err)
 		require.Equal(t, 4242, v)
 
-		v, err = WithCachedSubKey(nc, QueryCacheKey("tst", "foo"), "sk1", func() (int, error) {
+		v, err = WithCachedSubKey(ctx, nc, QueryCacheKey("tst", "foo"), "sk1", func(context.Context) (int, error) {
 			return 4243, nil
 		})
 		require.NoError(t, err)

--- a/tortoise/recover_test.go
+++ b/tortoise/recover_test.go
@@ -241,7 +241,7 @@ func TestRecoverOnlyAtxs(t *testing.T) {
 	)
 	require.NoError(t, err)
 	epoch := types.EpochID(2)
-	ids, err := atxs.GetIDsByEpoch(s.GetState(0).DB, epoch)
+	ids, err := atxs.GetIDsByEpoch(context.Background(), s.GetState(0).DB, epoch)
 	require.NoError(t, err)
 	require.NotEmpty(t, ids)
 	require.Empty(t, recovered.GetMissingActiveSet(epoch+1, ids), "target epoch %v", epoch+1)


### PR DESCRIPTION
## Motivation

Query cache may cause deadlock in some cases, such as a new ATX arriving while an epoch info request is being processed.

## Description

Don't do recursive `RLock()`. Detect recursive `GetValue()` calls by passing a Context.
Recursive query cache calls which are presently used in the epoch info fetch handler will be no longer needed after the fetcher becomes streaming-only, but for the time being, the change is still necessary.

## Test Plan

Testing on mainnet nodes