### PR TITLE
[Merged by Bors] - GRPC service to retrieve state of post proving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,6 +172,29 @@ and permanent ineligibility for rewards.
   To collect rewards for every identity, the associated PoST service must be running and connected to the node during
   the cyclegap set in the node's configuration.
 
+* [#5651](https://github.com/spacemeshos/go-spacemesh/pull/5651)
+  New GRPC service `spacemesh.v1.PostInfoService.PostStates` allowing to check the status of
+  PoST proving of all registered identities. It's usefull for operators to figure out when
+  post-services for each identity need to be up or can be shutdown.
+
+  An example output:
+  ```json
+  {
+    "states": [
+      {
+        "id": "874uW9N/y0PwUXxJ8Kb8Q2Yd+sqhpGJYkLbjlkIz5Ig=",
+        "state": "IDLE",
+        "name": "post0.key"
+      },
+      {
+        "id": "sBq/pHUHtzczY1quuG2muPGkksfVldwnH0M/eUPc3qE=",
+        "state": "PROVING",
+        "name": "post1.key"
+      }
+    ]
+  }
+  ```
+
 ### Features
 
 ### Improvements

--- a/activation/activation.go
+++ b/activation/activation.go
@@ -183,6 +183,17 @@ func (b *Builder) Smeshing() bool {
 	return b.stop != nil
 }
 
+// PostState returns the current state of the post service for each registered smesher.
+func (b *Builder) PostState() map[types.NodeID]int {
+	b.smeshingMutex.Lock()
+	defer b.smeshingMutex.Unlock()
+	state := make(map[types.NodeID]int, len(b.signers))
+	for id := range b.signers {
+		state[id] = 1
+	}
+	return state
+}
+
 // StartSmeshing is the main entry point of the atx builder. It runs the main
 // loop of the builder in a new go-routine and shouldn't be called more than
 // once without calling StopSmeshing in between. If the post data is incomplete

--- a/activation/activation_multi_test.go
+++ b/activation/activation_multi_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/spacemeshos/go-spacemesh/codec"
 	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/events"
 	"github.com/spacemeshos/go-spacemesh/p2p/pubsub"
 	"github.com/spacemeshos/go-spacemesh/sql"
 	"github.com/spacemeshos/go-spacemesh/sql/atxs"
@@ -223,6 +224,10 @@ func TestRegossip(t *testing.T) {
 func Test_Builder_Multi_InitialPost(t *testing.T) {
 	tab := newTestBuilder(t, 5, WithPoetConfig(PoetConfig{PhaseShift: layerDuration * 4}))
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, tab.postStates.watchEvents(ctx))
+
 	var eg errgroup.Group
 	for _, sig := range tab.signers {
 		sig := sig
@@ -241,18 +246,32 @@ func Test_Builder_Multi_InitialPost(t *testing.T) {
 
 			commitmentATX := types.RandomATXID()
 			tab.mValidator.EXPECT().Post(gomock.Any(), sig.NodeID(), commitmentATX, post, meta, numUnits).Return(nil)
-			tab.mnipost.EXPECT().Proof(gomock.Any(), sig.NodeID(), shared.ZeroChallenge).Return(
-				post,
-				&types.PostInfo{
-					CommitmentATX: commitmentATX,
-					Nonce:         new(types.VRFPostIndex),
-					NumUnits:      numUnits,
-					NodeID:        sig.NodeID(),
-					LabelsPerUnit: tab.conf.LabelsPerUnit,
-				},
-				nil,
-			)
+			tab.mnipost.EXPECT().Proof(gomock.Any(), sig.NodeID(), shared.ZeroChallenge).DoAndReturn(
+				func(ctx context.Context, id types.NodeID, challenge []byte) (*types.Post, *types.PostInfo, error) {
+					events.EmitPostStart(id, challenge)
+					require.Eventually(t, func() bool {
+						states := tab.PostStates()
+						require.Contains(t, states, id)
+						return stateProving == postState(states[id])
+					}, time.Second*5, time.Millisecond*100)
 
+					events.EmitPostComplete(id, challenge)
+					require.Eventually(t, func() bool {
+						states := tab.PostStates()
+						require.Contains(t, states, id)
+						return stateIdle == postState(states[id])
+					}, time.Second*5, time.Millisecond*100)
+
+					return post,
+						&types.PostInfo{
+							CommitmentATX: commitmentATX,
+							Nonce:         new(types.VRFPostIndex),
+							NumUnits:      numUnits,
+							NodeID:        sig.NodeID(),
+							LabelsPerUnit: tab.conf.LabelsPerUnit,
+						},
+						nil
+				})
 			require.NoError(t, tab.buildInitialPost(context.Background(), sig.NodeID()))
 
 			// postClient.Proof() should not be called again

--- a/activation/activation_multi_test.go
+++ b/activation/activation_multi_test.go
@@ -250,16 +250,22 @@ func Test_Builder_Multi_InitialPost(t *testing.T) {
 				func(ctx context.Context, id types.NodeID, challenge []byte) (*types.Post, *types.PostInfo, error) {
 					events.EmitPostStart(id, challenge)
 					require.Eventually(t, func() bool {
-						states := tab.PostStates()
-						require.Contains(t, states, id)
-						return stateProving == postState(states[id])
+						for desc, state := range tab.PostStates() {
+							if id == desc.NodeID() {
+								return state == types.PostStateProving
+							}
+						}
+						return false
 					}, time.Second*5, time.Millisecond*100)
 
 					events.EmitPostComplete(id, challenge)
 					require.Eventually(t, func() bool {
-						states := tab.PostStates()
-						require.Contains(t, states, id)
-						return stateIdle == postState(states[id])
+						for desc, state := range tab.PostStates() {
+							if id == desc.NodeID() {
+								return state == types.PostStateIdle
+							}
+						}
+						return false
 					}, time.Second*5, time.Millisecond*100)
 
 					return post,

--- a/activation/activation_multi_test.go
+++ b/activation/activation_multi_test.go
@@ -226,7 +226,7 @@ func Test_Builder_Multi_InitialPost(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	require.NoError(t, tab.postStates.watchEvents(ctx))
+	go tab.postStates.watchEvents(ctx)
 
 	var eg errgroup.Group
 	for _, sig := range tab.signers {

--- a/activation/interface.go
+++ b/activation/interface.go
@@ -156,3 +156,8 @@ type PostClient interface {
 	Info(ctx context.Context) (*types.PostInfo, error)
 	Proof(ctx context.Context, challenge []byte) (*types.Post, *types.PostInfo, error)
 }
+
+type PostStates interface {
+	Set(id types.NodeID, state types.PostState)
+	Get() map[types.NodeID]types.PostState
+}

--- a/activation/mocks.go
+++ b/activation/mocks.go
@@ -1989,3 +1989,100 @@ func (c *MockPostClientProofCall) DoAndReturn(f func(context.Context, []byte) (*
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
+
+// MockPostStates is a mock of PostStates interface.
+type MockPostStates struct {
+	ctrl     *gomock.Controller
+	recorder *MockPostStatesMockRecorder
+}
+
+// MockPostStatesMockRecorder is the mock recorder for MockPostStates.
+type MockPostStatesMockRecorder struct {
+	mock *MockPostStates
+}
+
+// NewMockPostStates creates a new mock instance.
+func NewMockPostStates(ctrl *gomock.Controller) *MockPostStates {
+	mock := &MockPostStates{ctrl: ctrl}
+	mock.recorder = &MockPostStatesMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockPostStates) EXPECT() *MockPostStatesMockRecorder {
+	return m.recorder
+}
+
+// Get mocks base method.
+func (m *MockPostStates) Get() map[types.NodeID]types.PostState {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Get")
+	ret0, _ := ret[0].(map[types.NodeID]types.PostState)
+	return ret0
+}
+
+// Get indicates an expected call of Get.
+func (mr *MockPostStatesMockRecorder) Get() *MockPostStatesGetCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockPostStates)(nil).Get))
+	return &MockPostStatesGetCall{Call: call}
+}
+
+// MockPostStatesGetCall wrap *gomock.Call
+type MockPostStatesGetCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockPostStatesGetCall) Return(arg0 map[types.NodeID]types.PostState) *MockPostStatesGetCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockPostStatesGetCall) Do(f func() map[types.NodeID]types.PostState) *MockPostStatesGetCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockPostStatesGetCall) DoAndReturn(f func() map[types.NodeID]types.PostState) *MockPostStatesGetCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// Set mocks base method.
+func (m *MockPostStates) Set(id types.NodeID, state types.PostState) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Set", id, state)
+}
+
+// Set indicates an expected call of Set.
+func (mr *MockPostStatesMockRecorder) Set(id, state any) *MockPostStatesSetCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Set", reflect.TypeOf((*MockPostStates)(nil).Set), id, state)
+	return &MockPostStatesSetCall{Call: call}
+}
+
+// MockPostStatesSetCall wrap *gomock.Call
+type MockPostStatesSetCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockPostStatesSetCall) Return() *MockPostStatesSetCall {
+	c.Call = c.Call.Return()
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockPostStatesSetCall) Do(f func(types.NodeID, types.PostState)) *MockPostStatesSetCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockPostStatesSetCall) DoAndReturn(f func(types.NodeID, types.PostState)) *MockPostStatesSetCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}

--- a/activation/post_states.go
+++ b/activation/post_states.go
@@ -1,16 +1,12 @@
 package activation
 
 import (
-	"context"
-	"fmt"
 	"maps"
 	"sync"
 
-	pb "github.com/spacemeshos/api/release/go/spacemesh/v1"
 	"go.uber.org/zap"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
-	"github.com/spacemeshos/go-spacemesh/events"
 )
 
 type postStates struct {
@@ -19,14 +15,14 @@ type postStates struct {
 	states map[types.NodeID]types.PostState
 }
 
-func newPostStates(log *zap.Logger) postStates {
-	return postStates{
+func NewPostStates(log *zap.Logger) *postStates {
+	return &postStates{
 		log:    log,
 		states: make(map[types.NodeID]types.PostState),
 	}
 }
 
-func (s *postStates) set(id types.NodeID, state types.PostState) {
+func (s *postStates) Set(id types.NodeID, state types.PostState) {
 	s.mu.Lock()
 	s.states[id] = state
 	s.mu.Unlock()
@@ -34,42 +30,10 @@ func (s *postStates) set(id types.NodeID, state types.PostState) {
 	s.log.Info("post state changed", zap.Stringer("id", id), zap.Stringer("state", state))
 }
 
-func (s *postStates) get() map[types.NodeID]types.PostState {
+func (s *postStates) Get() map[types.NodeID]types.PostState {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	copy := make(map[types.NodeID]types.PostState, len(s.states))
 	maps.Copy(copy, s.states)
 	return copy
-}
-
-func (s *postStates) watchEvents(ctx context.Context) error {
-	events.InitializeReporter()
-	sub, err := events.SubscribeMatched(func(t *events.UserEvent) bool {
-		switch t.Event.Details.(type) {
-		case *pb.Event_PostStart:
-			return true
-		case *pb.Event_PostComplete:
-			return true
-		default:
-			return false
-		}
-	}, events.WithBuffer(50))
-	if err != nil {
-		return fmt.Errorf("subscribing to post events: %w", err)
-	}
-
-	for {
-		select {
-		case e := <-sub.Out():
-			switch e.Event.Details.(type) {
-			case *pb.Event_PostStart:
-				s.set(types.BytesToNodeID(e.Event.GetPostStart().Smesher), types.PostStateProving)
-			case *pb.Event_PostComplete:
-				s.set(types.BytesToNodeID(e.Event.GetPostComplete().Smesher), types.PostStateIdle)
-			}
-		case <-ctx.Done():
-			sub.Close()
-			return nil
-		}
-	}
 }

--- a/activation/post_states.go
+++ b/activation/post_states.go
@@ -1,0 +1,103 @@
+package activation
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	pb "github.com/spacemeshos/api/release/go/spacemesh/v1"
+	"go.uber.org/zap"
+
+	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/events"
+)
+
+type postStates struct {
+	log            *zap.Logger
+	mu             sync.RWMutex
+	states         map[types.NodeID]postState
+	watchingStates sync.Once
+}
+
+func newPostStates(log *zap.Logger) postStates {
+	return postStates{
+		log:    log,
+		states: make(map[types.NodeID]postState),
+	}
+}
+
+type postState int
+
+// Values must match the ones described in github.com/spacemeshos/go-spacemesh/api/grpcserver/interface.go
+// under the postState interface.
+const (
+	stateIdle postState = iota
+	stateProving
+)
+
+func (s postState) String() string {
+	switch s {
+	case stateIdle:
+		return "idle"
+	case stateProving:
+		return "proving"
+	default:
+		panic(fmt.Sprintf("unknown post state %d", s))
+	}
+}
+
+func (s *postStates) set(id types.NodeID, state postState) {
+	s.mu.Lock()
+	s.states[id] = state
+	s.mu.Unlock()
+
+	s.log.Info("post state changed", zap.Stringer("id", id), zap.Stringer("state", state))
+}
+
+func (s *postStates) get() map[types.NodeID]int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	states := make(map[types.NodeID]int, len(s.states))
+	for id, state := range s.states {
+		states[id] = int(state)
+	}
+	return states
+}
+
+func (s *postStates) watchEvents(ctx context.Context) error {
+	var result error
+	s.watchingStates.Do(func() {
+		events.InitializeReporter()
+		sub, err := events.SubscribeMatched(func(t *events.UserEvent) bool {
+			switch t.Event.Details.(type) {
+			case *pb.Event_PostStart:
+				return true
+			case *pb.Event_PostComplete:
+				return true
+			default:
+				return false
+			}
+		}, events.WithBuffer(50))
+		if err != nil {
+			result = fmt.Errorf("subscribing to post events: %w", err)
+		}
+
+		go func() {
+			for {
+				select {
+				case e := <-sub.Out():
+					switch e.Event.Details.(type) {
+					case *pb.Event_PostStart:
+						s.set(types.BytesToNodeID(e.Event.GetPostStart().Smesher), stateProving)
+					case *pb.Event_PostComplete:
+						s.set(types.BytesToNodeID(e.Event.GetPostComplete().Smesher), stateIdle)
+					}
+				case <-ctx.Done():
+					sub.Close()
+					return
+				}
+			}
+		}()
+	})
+	return result
+}

--- a/activation/post_states_test.go
+++ b/activation/post_states_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spacemeshos/post/shared"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
+	"golang.org/x/exp/maps"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/events"
@@ -17,24 +18,29 @@ func TestPostStates_RegisteredStartsIdle(t *testing.T) {
 	tab := newTestBuilder(t, 3)
 
 	states := tab.PostStates()
-	for id := range tab.signers {
-		require.Contains(t, states, id)
-		require.Equal(t, stateIdle, postState(states[id]))
+	require.Len(t, states, len(tab.signers))
+
+	iDsInStates := make([]types.NodeID, 0)
+	for desc, state := range states {
+		require.Contains(t, tab.signers, desc.NodeID())
+		require.Equal(t, types.PostStateIdle, state)
+		iDsInStates = append(iDsInStates, desc.NodeID())
 	}
+	require.ElementsMatch(t, maps.Keys(tab.signers), iDsInStates)
 }
 
 func TestPostStates_SetState(t *testing.T) {
 	postStates := newPostStates(zaptest.NewLogger(t))
 	id := types.RandomNodeID()
 
-	postStates.set(id, stateProving)
+	postStates.set(id, types.PostStateProving)
 	states := postStates.get()
 	require.Len(t, states, 1)
-	require.Equal(t, stateProving, postState(states[id]))
+	require.Equal(t, types.PostStateProving, states[id])
 
-	postStates.set(id, stateIdle)
+	postStates.set(id, types.PostStateIdle)
 	states = postStates.get()
-	require.Equal(t, stateIdle, postState(states[id]))
+	require.Equal(t, types.PostStateIdle, states[id])
 }
 
 func TestPostStates_ReactsOnEvents(t *testing.T) {
@@ -46,24 +52,24 @@ func TestPostStates_ReactsOnEvents(t *testing.T) {
 
 	ids := []types.NodeID{types.RandomNodeID(), types.RandomNodeID()}
 	for _, id := range ids {
-		postStates.set(id, stateIdle)
+		postStates.set(id, types.PostStateIdle)
 	}
 
 	// Reacts to Post Start
 	events.EmitPostStart(ids[0], shared.ZeroChallenge)
 	require.Eventually(t, func() bool {
-		return stateProving == postState(postStates.get()[ids[0]])
+		return types.PostStateProving == postStates.get()[ids[0]]
 	}, time.Second*5, time.Millisecond*100)
 
 	states := postStates.get()
 	for _, id := range ids[1:] {
 		require.Contains(t, states, id)
-		require.Equal(t, stateIdle, postState(states[id]))
+		require.Equal(t, types.PostStateIdle, states[id])
 	}
 
 	// Reacts to Post Complete
 	events.EmitPostComplete(ids[0], shared.ZeroChallenge)
 	require.Eventually(t, func() bool {
-		return stateIdle == postState(postStates.get()[ids[0]])
+		return types.PostStateIdle == postStates.get()[ids[0]]
 	}, time.Second*5, time.Millisecond*100)
 }

--- a/activation/post_states_test.go
+++ b/activation/post_states_test.go
@@ -1,0 +1,69 @@
+package activation
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/spacemeshos/post/shared"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/events"
+)
+
+func TestPostStates_RegisteredStartsIdle(t *testing.T) {
+	tab := newTestBuilder(t, 3)
+
+	states := tab.PostStates()
+	for id := range tab.signers {
+		require.Contains(t, states, id)
+		require.Equal(t, stateIdle, postState(states[id]))
+	}
+}
+
+func TestPostStates_SetState(t *testing.T) {
+	postStates := newPostStates(zaptest.NewLogger(t))
+	id := types.RandomNodeID()
+
+	postStates.set(id, stateProving)
+	states := postStates.get()
+	require.Len(t, states, 1)
+	require.Equal(t, stateProving, postState(states[id]))
+
+	postStates.set(id, stateIdle)
+	states = postStates.get()
+	require.Equal(t, stateIdle, postState(states[id]))
+}
+
+func TestPostStates_ReactsOnEvents(t *testing.T) {
+	postStates := newPostStates(zaptest.NewLogger(t))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, postStates.watchEvents(ctx))
+
+	ids := []types.NodeID{types.RandomNodeID(), types.RandomNodeID()}
+	for _, id := range ids {
+		postStates.set(id, stateIdle)
+	}
+
+	// Reacts to Post Start
+	events.EmitPostStart(ids[0], shared.ZeroChallenge)
+	require.Eventually(t, func() bool {
+		return stateProving == postState(postStates.get()[ids[0]])
+	}, time.Second*5, time.Millisecond*100)
+
+	states := postStates.get()
+	for _, id := range ids[1:] {
+		require.Contains(t, states, id)
+		require.Equal(t, stateIdle, postState(states[id]))
+	}
+
+	// Reacts to Post Complete
+	events.EmitPostComplete(ids[0], shared.ZeroChallenge)
+	require.Eventually(t, func() bool {
+		return stateIdle == postState(postStates.get()[ids[0]])
+	}, time.Second*5, time.Millisecond*100)
+}

--- a/activation/post_states_test.go
+++ b/activation/post_states_test.go
@@ -48,7 +48,7 @@ func TestPostStates_ReactsOnEvents(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	require.NoError(t, postStates.watchEvents(ctx))
+	go postStates.watchEvents(ctx)
 
 	ids := []types.NodeID{types.RandomNodeID(), types.RandomNodeID()}
 	for _, id := range ids {

--- a/api/grpcserver/config.go
+++ b/api/grpcserver/config.go
@@ -35,7 +35,7 @@ const (
 	Activation               Service = "activation"
 	Smesher                  Service = "smesher"
 	Post                     Service = "post"
-	PostInfo                 Service = "postinfo"
+	PostInfo                 Service = "postInfo"
 	Node                     Service = "node"
 	ActivationV2Alpha1       Service = "activation_v2alpha1"
 	ActivationStreamV2Alpha1 Service = "activation_stream_v2alpha1"

--- a/api/grpcserver/config.go
+++ b/api/grpcserver/config.go
@@ -35,6 +35,7 @@ const (
 	Activation               Service = "activation"
 	Smesher                  Service = "smesher"
 	Post                     Service = "post"
+	PostInfo                 Service = "postinfo"
 	Node                     Service = "node"
 	ActivationV2Alpha1       Service = "activation_v2alpha1"
 	ActivationStreamV2Alpha1 Service = "activation_stream_v2alpha1"
@@ -52,9 +53,9 @@ func DefaultConfig() Config {
 		PublicListener:        "0.0.0.0:9092",
 		PrivateServices:       []Service{Admin, Smesher, Debug, ActivationStreamV2Alpha1, RewardStreamV2Alpha1},
 		PrivateListener:       "127.0.0.1:9093",
-		PostServices:          []Service{Post},
+		PostServices:          []Service{Post, PostInfo},
 		PostListener:          "127.0.0.1:9094",
-		TLSServices:           []Service{Post},
+		TLSServices:           []Service{Post, PostInfo},
 		TLSListener:           "",
 		JSONListener:          "",
 		GrpcSendMsgSize:       1024 * 1024 * 10,

--- a/api/grpcserver/interface.go
+++ b/api/grpcserver/interface.go
@@ -57,6 +57,9 @@ type atxProvider interface {
 	GetMalfeasanceProof(id types.NodeID) (*types.MalfeasanceProof, error)
 }
 
+type atxBuilder interface {
+}
+
 type postSupervisor interface {
 	Start(opts activation.PostSetupOpts, sig *signing.EdSigner) error
 	Stop(deleteFiles bool) error

--- a/api/grpcserver/interface.go
+++ b/api/grpcserver/interface.go
@@ -58,6 +58,7 @@ type atxProvider interface {
 }
 
 type atxBuilder interface {
+	PostState() map[types.NodeID]int
 }
 
 type postSupervisor interface {

--- a/api/grpcserver/interface.go
+++ b/api/grpcserver/interface.go
@@ -57,8 +57,12 @@ type atxProvider interface {
 	GetMalfeasanceProof(id types.NodeID) (*types.MalfeasanceProof, error)
 }
 
-type atxBuilder interface {
-	PostState() map[types.NodeID]int
+type postState interface {
+	// PostStates returns the current state of all registered IDs.
+	// Meaning:
+	// * 0 - idle
+	// * 1 - proving.
+	PostStates() map[types.NodeID]int
 }
 
 type postSupervisor interface {

--- a/api/grpcserver/interface.go
+++ b/api/grpcserver/interface.go
@@ -59,10 +59,7 @@ type atxProvider interface {
 
 type postState interface {
 	// PostStates returns the current state of all registered IDs.
-	// Meaning:
-	// * 0 - idle
-	// * 1 - proving.
-	PostStates() map[types.NodeID]int
+	PostStates() map[types.IdentityDescriptor]types.PostState
 }
 
 type postSupervisor interface {

--- a/api/grpcserver/mocks.go
+++ b/api/grpcserver/mocks.go
@@ -974,10 +974,10 @@ func (m *MockpostState) EXPECT() *MockpostStateMockRecorder {
 }
 
 // PostStates mocks base method.
-func (m *MockpostState) PostStates() map[types.NodeID]int {
+func (m *MockpostState) PostStates() map[types.IdentityDescriptor]types.PostState {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PostStates")
-	ret0, _ := ret[0].(map[types.NodeID]int)
+	ret0, _ := ret[0].(map[types.IdentityDescriptor]types.PostState)
 	return ret0
 }
 
@@ -994,19 +994,19 @@ type MockpostStatePostStatesCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockpostStatePostStatesCall) Return(arg0 map[types.NodeID]int) *MockpostStatePostStatesCall {
+func (c *MockpostStatePostStatesCall) Return(arg0 map[types.IdentityDescriptor]types.PostState) *MockpostStatePostStatesCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockpostStatePostStatesCall) Do(f func() map[types.NodeID]int) *MockpostStatePostStatesCall {
+func (c *MockpostStatePostStatesCall) Do(f func() map[types.IdentityDescriptor]types.PostState) *MockpostStatePostStatesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockpostStatePostStatesCall) DoAndReturn(f func() map[types.NodeID]int) *MockpostStatePostStatesCall {
+func (c *MockpostStatePostStatesCall) DoAndReturn(f func() map[types.IdentityDescriptor]types.PostState) *MockpostStatePostStatesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/api/grpcserver/mocks.go
+++ b/api/grpcserver/mocks.go
@@ -950,6 +950,67 @@ func (c *MockatxProviderMaxHeightAtxCall) DoAndReturn(f func() (types.ATXID, err
 	return c
 }
 
+// MockpostState is a mock of postState interface.
+type MockpostState struct {
+	ctrl     *gomock.Controller
+	recorder *MockpostStateMockRecorder
+}
+
+// MockpostStateMockRecorder is the mock recorder for MockpostState.
+type MockpostStateMockRecorder struct {
+	mock *MockpostState
+}
+
+// NewMockpostState creates a new mock instance.
+func NewMockpostState(ctrl *gomock.Controller) *MockpostState {
+	mock := &MockpostState{ctrl: ctrl}
+	mock.recorder = &MockpostStateMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockpostState) EXPECT() *MockpostStateMockRecorder {
+	return m.recorder
+}
+
+// PostStates mocks base method.
+func (m *MockpostState) PostStates() map[types.NodeID]int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PostStates")
+	ret0, _ := ret[0].(map[types.NodeID]int)
+	return ret0
+}
+
+// PostStates indicates an expected call of PostStates.
+func (mr *MockpostStateMockRecorder) PostStates() *MockpostStatePostStatesCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostStates", reflect.TypeOf((*MockpostState)(nil).PostStates))
+	return &MockpostStatePostStatesCall{Call: call}
+}
+
+// MockpostStatePostStatesCall wrap *gomock.Call
+type MockpostStatePostStatesCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockpostStatePostStatesCall) Return(arg0 map[types.NodeID]int) *MockpostStatePostStatesCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockpostStatePostStatesCall) Do(f func() map[types.NodeID]int) *MockpostStatePostStatesCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockpostStatePostStatesCall) DoAndReturn(f func() map[types.NodeID]int) *MockpostStatePostStatesCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // MockpostSupervisor is a mock of postSupervisor interface.
 type MockpostSupervisor struct {
 	ctrl     *gomock.Controller

--- a/api/grpcserver/post_info_service.go
+++ b/api/grpcserver/post_info_service.go
@@ -1,0 +1,43 @@
+package grpcserver
+
+import (
+	"context"
+
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	pb "github.com/spacemeshos/api/release/go/spacemesh/v1"
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+)
+
+// PostInfoService provides information about connected PostServices.
+type PostInfoService struct {
+	log *zap.Logger
+
+	builder atxBuilder
+}
+
+// RegisterService registers this service with a grpc server instance.
+func (s *PostInfoService) RegisterService(server *grpc.Server) {
+	pb.RegisterPostInfoServiceServer(server, s)
+}
+
+func (s *PostInfoService) RegisterHandlerService(mux *runtime.ServeMux) error {
+	return pb.RegisterPostInfoServiceHandlerServer(context.Background(), mux, s)
+}
+
+// String returns the name of this service.
+func (s *PostInfoService) String() string {
+	return "PostInfoService"
+}
+
+// NewPostInfoService creates a new instance of the post info grpc service.
+func NewPostInfoService(log *zap.Logger, builder atxBuilder) *PostInfoService {
+	return &PostInfoService{
+		log:     log,
+		builder: builder,
+	}
+}
+
+func (s *PostInfoService) ServiceStates(context.Context, *pb.ServiceStatesRequest) (*pb.ServiceStatesResponse, error) {
+	return &pb.ServiceStatesResponse{}, nil
+}

--- a/api/grpcserver/post_info_service.go
+++ b/api/grpcserver/post_info_service.go
@@ -2,12 +2,20 @@ package grpcserver
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	pb "github.com/spacemeshos/api/release/go/spacemesh/v1"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
+
+var statusMap map[int]pb.ServiceState_Status = map[int]pb.ServiceState_Status{
+	1: pb.ServiceState_READY_PROOFING,
+	2: pb.ServiceState_PROOF_RECEIVED,
+}
 
 // PostInfoService provides information about connected PostServices.
 type PostInfoService struct {
@@ -39,5 +47,23 @@ func NewPostInfoService(log *zap.Logger, builder atxBuilder) *PostInfoService {
 }
 
 func (s *PostInfoService) ServiceStates(context.Context, *pb.ServiceStatesRequest) (*pb.ServiceStatesResponse, error) {
-	return &pb.ServiceStatesResponse{}, nil
+	state := s.builder.PostState()
+	pbState := make([]*pb.ServiceState, 0, len(state))
+	for nodeID, state := range state {
+		nodeState, ok := statusMap[state]
+		if !ok {
+			s.log.Warn("unknown status",
+				zap.Stringer("node_id", nodeID),
+				zap.Int("status", state),
+			)
+			return nil, status.Error(codes.Internal, fmt.Sprintf("identity %s is in unknown state", nodeID.String()))
+		}
+
+		pbState = append(pbState, &pb.ServiceState{
+			NodeId: nodeID.Bytes(),
+			Status: nodeState,
+		})
+	}
+
+	return &pb.ServiceStatesResponse{States: pbState}, nil
 }

--- a/api/grpcserver/post_info_service_test.go
+++ b/api/grpcserver/post_info_service_test.go
@@ -1,0 +1,42 @@
+package grpcserver
+
+import (
+	"context"
+	"testing"
+
+	pb "github.com/spacemeshos/api/release/go/spacemesh/v1"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/spacemeshos/go-spacemesh/common/types"
+)
+
+func TestPostInfoService(t *testing.T) {
+	log := zaptest.NewLogger(t)
+	mpostStates := NewMockpostState(gomock.NewController(t))
+	svc := NewPostInfoService(log, mpostStates)
+	cfg, cleanup := launchServer(t, svc)
+	t.Cleanup(cleanup)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	conn := dialGrpc(ctx, t, cfg)
+
+	// create client
+	client := pb.NewPostInfoServiceClient(conn)
+
+	states := map[types.NodeID]int{types.RandomNodeID(): 0, types.RandomNodeID(): 1}
+	mpostStates.EXPECT().PostStates().Return(states)
+	resp, err := client.PostStates(ctx, &pb.PostStatesRequest{})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	for id, state := range states {
+		require.Contains(t, resp.States, &pb.PostState{
+			Id:    id.Bytes(),
+			State: pb.PostState_State(state),
+		})
+	}
+}

--- a/api/grpcserver/post_service.go
+++ b/api/grpcserver/post_service.go
@@ -43,7 +43,7 @@ func (s *PostService) String() string {
 	return "PostService"
 }
 
-// NewPostService creates a new grpc service using config data.
+// NewPostService creates a new instance of the post grpc service.
 func NewPostService(log *zap.Logger) *PostService {
 	return &PostService{
 		log:    log,

--- a/common/types/post.go
+++ b/common/types/post.go
@@ -1,5 +1,7 @@
 package types
 
+import "fmt"
+
 // PostInfo contains information about the PoST as returned by the service.
 type PostInfo struct {
 	NodeID        NodeID
@@ -8,4 +10,29 @@ type PostInfo struct {
 
 	NumUnits      uint32
 	LabelsPerUnit uint64
+}
+
+type PostState int
+
+const (
+	// PostStateIdle is the state of a PoST service that is not currently proving.
+	PostStateIdle PostState = iota
+	// PostStateProving is the state of a PoST service that is currently proving.
+	PostStateProving
+)
+
+func (s PostState) String() string {
+	switch s {
+	case PostStateIdle:
+		return "idle"
+	case PostStateProving:
+		return "proving"
+	default:
+		panic(fmt.Sprintf("unknown post state %d", s))
+	}
+}
+
+type IdentityDescriptor interface {
+	Name() string
+	NodeID() NodeID
 }

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/quic-go/quic-go v0.41.0
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/seehuhn/mt19937 v1.0.0
-	github.com/spacemeshos/api/release/go v1.31.1-0.20240307123722-883a88bf00e0
+	github.com/spacemeshos/api/release/go v1.32.0
 	github.com/spacemeshos/economics v0.1.2
 	github.com/spacemeshos/fixed v0.1.1
 	github.com/spacemeshos/go-scale v1.1.12

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/quic-go/quic-go v0.41.0
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/seehuhn/mt19937 v1.0.0
-	github.com/spacemeshos/api/release/go v1.30.1-0.20240305194355-6215d9d634b8
+	github.com/spacemeshos/api/release/go v1.30.1-0.20240307090034-8715b293cd5b
 	github.com/spacemeshos/economics v0.1.2
 	github.com/spacemeshos/fixed v0.1.1
 	github.com/spacemeshos/go-scale v1.1.12

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/quic-go/quic-go v0.41.0
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/seehuhn/mt19937 v1.0.0
-	github.com/spacemeshos/api/release/go v1.30.1-0.20240307090034-8715b293cd5b
+	github.com/spacemeshos/api/release/go v1.30.1-0.20240307120915-6bc092034376
 	github.com/spacemeshos/economics v0.1.2
 	github.com/spacemeshos/fixed v0.1.1
 	github.com/spacemeshos/go-scale v1.1.12

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/quic-go/quic-go v0.41.0
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/seehuhn/mt19937 v1.0.0
-	github.com/spacemeshos/api/release/go v1.31.0
+	github.com/spacemeshos/api/release/go v1.30.1-0.20240305194355-6215d9d634b8
 	github.com/spacemeshos/economics v0.1.2
 	github.com/spacemeshos/fixed v0.1.1
 	github.com/spacemeshos/go-scale v1.1.12

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/quic-go/quic-go v0.41.0
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/seehuhn/mt19937 v1.0.0
-	github.com/spacemeshos/api/release/go v1.30.1-0.20240307120915-6bc092034376
+	github.com/spacemeshos/api/release/go v1.31.1-0.20240307123722-883a88bf00e0
 	github.com/spacemeshos/economics v0.1.2
 	github.com/spacemeshos/fixed v0.1.1
 	github.com/spacemeshos/go-scale v1.1.12

--- a/go.sum
+++ b/go.sum
@@ -622,8 +622,8 @@ github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d/go.mod h1:Udh
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
-github.com/spacemeshos/api/release/go v1.31.0 h1:ZNKZ06KAKMlC6SgrXglD6Pwe0LXfzOiLuOLdbmjs2BI=
-github.com/spacemeshos/api/release/go v1.31.0/go.mod h1:jyW98UJyTx4Ji8WETPiKJJONAJP0OqoWtTTd3VQWtBs=
+github.com/spacemeshos/api/release/go v1.30.1-0.20240305194355-6215d9d634b8 h1:LEIrODcVBeenqFYHgIyZEHGTIiJ24h16+i3HJh84erk=
+github.com/spacemeshos/api/release/go v1.30.1-0.20240305194355-6215d9d634b8/go.mod h1:MsRwGvD0mAguy5Cri9EsE8VPK25J5zywa+A7sX9Fi40=
 github.com/spacemeshos/economics v0.1.2 h1:kw8cE5SMa/7svHOGorCd2w8ef1y8iP0p47/2VDOK8Ns=
 github.com/spacemeshos/economics v0.1.2/go.mod h1:ngeWn5E/jy9dJP1MHyuk3ehF8NBMTYhchqVDhAHUUNk=
 github.com/spacemeshos/fixed v0.1.1 h1:N1y4SUpq1EV+IdJrWJwUCt1oBFzeru/VKVcBsvPc2Fk=

--- a/go.sum
+++ b/go.sum
@@ -622,8 +622,8 @@ github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d/go.mod h1:Udh
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
-github.com/spacemeshos/api/release/go v1.31.1-0.20240307123722-883a88bf00e0 h1:vqI9p/2ab3NfdnGBQvIzcjtnAbSiGOTq75PL/uWQFss=
-github.com/spacemeshos/api/release/go v1.31.1-0.20240307123722-883a88bf00e0/go.mod h1:jyW98UJyTx4Ji8WETPiKJJONAJP0OqoWtTTd3VQWtBs=
+github.com/spacemeshos/api/release/go v1.32.0 h1:UZXWXyusFDDNjUs9w3qkHU1e24AuOFOzWbhuMojulT8=
+github.com/spacemeshos/api/release/go v1.32.0/go.mod h1:r8wNnfmUXQ3NOxn8uKRyX+yDUVLK9q3+BVc+TIuKv9w=
 github.com/spacemeshos/economics v0.1.2 h1:kw8cE5SMa/7svHOGorCd2w8ef1y8iP0p47/2VDOK8Ns=
 github.com/spacemeshos/economics v0.1.2/go.mod h1:ngeWn5E/jy9dJP1MHyuk3ehF8NBMTYhchqVDhAHUUNk=
 github.com/spacemeshos/fixed v0.1.1 h1:N1y4SUpq1EV+IdJrWJwUCt1oBFzeru/VKVcBsvPc2Fk=

--- a/go.sum
+++ b/go.sum
@@ -622,8 +622,8 @@ github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d/go.mod h1:Udh
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
-github.com/spacemeshos/api/release/go v1.30.1-0.20240305194355-6215d9d634b8 h1:LEIrODcVBeenqFYHgIyZEHGTIiJ24h16+i3HJh84erk=
-github.com/spacemeshos/api/release/go v1.30.1-0.20240305194355-6215d9d634b8/go.mod h1:MsRwGvD0mAguy5Cri9EsE8VPK25J5zywa+A7sX9Fi40=
+github.com/spacemeshos/api/release/go v1.30.1-0.20240307090034-8715b293cd5b h1:C7FB2jlvKCcME9D7uqzj7+/TSc4TXCeRjoHs4pzoSQ4=
+github.com/spacemeshos/api/release/go v1.30.1-0.20240307090034-8715b293cd5b/go.mod h1:MsRwGvD0mAguy5Cri9EsE8VPK25J5zywa+A7sX9Fi40=
 github.com/spacemeshos/economics v0.1.2 h1:kw8cE5SMa/7svHOGorCd2w8ef1y8iP0p47/2VDOK8Ns=
 github.com/spacemeshos/economics v0.1.2/go.mod h1:ngeWn5E/jy9dJP1MHyuk3ehF8NBMTYhchqVDhAHUUNk=
 github.com/spacemeshos/fixed v0.1.1 h1:N1y4SUpq1EV+IdJrWJwUCt1oBFzeru/VKVcBsvPc2Fk=

--- a/go.sum
+++ b/go.sum
@@ -622,8 +622,8 @@ github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d/go.mod h1:Udh
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
-github.com/spacemeshos/api/release/go v1.30.1-0.20240307120915-6bc092034376 h1:kxTTfg55Z3wnbwvFOumtVwPLW3mX6Q0FSiVE4RUN92o=
-github.com/spacemeshos/api/release/go v1.30.1-0.20240307120915-6bc092034376/go.mod h1:MsRwGvD0mAguy5Cri9EsE8VPK25J5zywa+A7sX9Fi40=
+github.com/spacemeshos/api/release/go v1.31.1-0.20240307123722-883a88bf00e0 h1:vqI9p/2ab3NfdnGBQvIzcjtnAbSiGOTq75PL/uWQFss=
+github.com/spacemeshos/api/release/go v1.31.1-0.20240307123722-883a88bf00e0/go.mod h1:jyW98UJyTx4Ji8WETPiKJJONAJP0OqoWtTTd3VQWtBs=
 github.com/spacemeshos/economics v0.1.2 h1:kw8cE5SMa/7svHOGorCd2w8ef1y8iP0p47/2VDOK8Ns=
 github.com/spacemeshos/economics v0.1.2/go.mod h1:ngeWn5E/jy9dJP1MHyuk3ehF8NBMTYhchqVDhAHUUNk=
 github.com/spacemeshos/fixed v0.1.1 h1:N1y4SUpq1EV+IdJrWJwUCt1oBFzeru/VKVcBsvPc2Fk=

--- a/go.sum
+++ b/go.sum
@@ -622,8 +622,8 @@ github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d/go.mod h1:Udh
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
-github.com/spacemeshos/api/release/go v1.30.1-0.20240307090034-8715b293cd5b h1:C7FB2jlvKCcME9D7uqzj7+/TSc4TXCeRjoHs4pzoSQ4=
-github.com/spacemeshos/api/release/go v1.30.1-0.20240307090034-8715b293cd5b/go.mod h1:MsRwGvD0mAguy5Cri9EsE8VPK25J5zywa+A7sX9Fi40=
+github.com/spacemeshos/api/release/go v1.30.1-0.20240307120915-6bc092034376 h1:kxTTfg55Z3wnbwvFOumtVwPLW3mX6Q0FSiVE4RUN92o=
+github.com/spacemeshos/api/release/go v1.30.1-0.20240307120915-6bc092034376/go.mod h1:MsRwGvD0mAguy5Cri9EsE8VPK25J5zywa+A7sX9Fi40=
 github.com/spacemeshos/economics v0.1.2 h1:kw8cE5SMa/7svHOGorCd2w8ef1y8iP0p47/2VDOK8Ns=
 github.com/spacemeshos/economics v0.1.2/go.mod h1:ngeWn5E/jy9dJP1MHyuk3ehF8NBMTYhchqVDhAHUUNk=
 github.com/spacemeshos/fixed v0.1.1 h1:N1y4SUpq1EV+IdJrWJwUCt1oBFzeru/VKVcBsvPc2Fk=

--- a/node/node.go
+++ b/node/node.go
@@ -988,6 +988,7 @@ func (app *App) initServices(ctx context.Context) error {
 		return fmt.Errorf("create post setup manager: %v", err)
 	}
 
+	postStates := activation.NewPostStates(app.addLogger(PostLogger, lg).Zap())
 	grpcPostService, err := app.grpcService(grpcserver.Post, lg)
 	if err != nil {
 		return fmt.Errorf("init post grpc service: %w", err)
@@ -1000,6 +1001,7 @@ func (app *App) initServices(ctx context.Context) error {
 		app.addLogger(NipostBuilderLogger, lg).Zap(),
 		app.Config.POET,
 		app.clock,
+		activation.NipostbuilderWithPostStates(postStates),
 	)
 	if err != nil {
 		return fmt.Errorf("create nipost builder: %w", err)
@@ -1025,6 +1027,7 @@ func (app *App) initServices(ctx context.Context) error {
 		activation.WithPoetRetryInterval(app.Config.HARE3.PreroundDelay),
 		activation.WithValidator(app.validator),
 		activation.WithPostValidityDelay(app.Config.PostValidDelay),
+		activation.WithPostStates(postStates),
 	)
 	if len(app.signers) > 1 || app.signers[0].Name() != supervisedIDKeyFileName {
 		// in a remote setup we register eagerly so the atxBuilder can warn about missing connections asap.

--- a/node/node.go
+++ b/node/node.go
@@ -100,6 +100,7 @@ const (
 	P2PLogger              = "p2p"
 	PostLogger             = "post"
 	PostServiceLogger      = "postService"
+	PostInfoServiceLogger  = "postInfoService"
 	StateDbLogger          = "stateDb"
 	BeaconLogger           = "beacon"
 	CachedDBLogger         = "cachedDB"
@@ -1430,6 +1431,10 @@ func (app *App) grpcService(svc grpcserver.Service, lg log.Log) (grpcserver.Serv
 		return service, nil
 	case grpcserver.Post:
 		service := grpcserver.NewPostService(app.addLogger(PostServiceLogger, lg).Zap())
+		app.grpcServices[svc] = service
+		return service, nil
+	case grpcserver.PostInfo:
+		service := grpcserver.NewPostInfoService(app.addLogger(PostInfoServiceLogger, lg).Zap(), app.atxBuilder)
 		app.grpcServices[svc] = service
 		return service, nil
 	case grpcserver.Transaction:


### PR DESCRIPTION
## Description

Added a new GRPC service that provides a way to get the state of POST proving for all registered identities.

Each identity starts as _Idle_ and transitions to _Proving_ when POST proving phase starts (when the post-service becomes required). This informs the operator that it is time to switch the post-service ON.
The state transitions back to _Idle_ in one of two conditions:
- post proving completed successfully,
- we selected a new nipost challenge. In this situation, the node will need to re-register in poet and will not need to prove until it gets a new poet proof (i.e. for ~2 weeks).

The state does NOT transition from _Proving_ to _Idle_ when post proving fails because it might retry (and hence need the post-service again) and we don't want to confuse the operator with multiple state switches.

## Test Plan

Added unit tests

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [ ] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
