### PR TITLE
[Merged by Bors] - Instead of failing log a waring if PoET is missing during migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ With this release the node has fully migrated its local state into `local.sql`. 
 upgrade the node will migrate the data from disk and store it in the database. This change also allows the PoST data
 directory to be set to read only after the migration is complete, as the node will no longer write to it.
 
+**NOTE:** To ensure a successful migration make sure that the config contains all PoETs your node is using.
+
 #### New poets configuration
 
 Upgrading requires changes in config and in CLI flags (if not using the default).
@@ -174,10 +176,11 @@ and permanent ineligibility for rewards.
 
 * [#5651](https://github.com/spacemeshos/go-spacemesh/pull/5651)
   New GRPC service `spacemesh.v1.PostInfoService.PostStates` allowing to check the status of
-  PoST proving of all registered identities. It's usefull for operators to figure out when
+  PoST proving of all registered identities. It's useful for operators to figure out when
   post-services for each identity need to be up or can be shutdown.
 
   An example output:
+
   ```json
   {
     "states": [

--- a/node/node.go
+++ b/node/node.go
@@ -1798,7 +1798,7 @@ func (app *App) setupDBs(ctx context.Context, lg log.Log) error {
 		sql.WithMigrations(migrations),
 		sql.WithMigration(localsql.New0001Migration(app.Config.SMESHING.Opts.DataDir)),
 		sql.WithMigration(localsql.New0002Migration(app.Config.SMESHING.Opts.DataDir)),
-		sql.WithMigration(localsql.New0003Migration(app.Config.SMESHING.Opts.DataDir, clients)),
+		sql.WithMigration(localsql.New0003Migration(dbLog.Zap(), app.Config.SMESHING.Opts.DataDir, clients)),
 		sql.WithConnections(app.Config.DatabaseConnections),
 	)
 	if err != nil {
@@ -1849,7 +1849,7 @@ func (app *App) MigrateLocalDB(lg *zap.Logger, dbPath string, clients []localsql
 		sql.WithMigrations(migrations),
 		sql.WithMigration(localsql.New0001Migration(app.Config.SMESHING.Opts.DataDir)),
 		sql.WithMigration(localsql.New0002Migration(app.Config.SMESHING.Opts.DataDir)),
-		sql.WithMigration(localsql.New0003Migration(app.Config.SMESHING.Opts.DataDir, clients)),
+		sql.WithMigration(localsql.New0003Migration(lg, app.Config.SMESHING.Opts.DataDir, clients)),
 		sql.WithConnections(app.Config.DatabaseConnections),
 	)
 	if err != nil {

--- a/sql/localsql/0003_migration.go
+++ b/sql/localsql/0003_migration.go
@@ -22,7 +22,11 @@ import (
 var mainnetPoet2ServiceID []byte
 
 func init() {
-	mainnetPoet2ServiceID, _ = base64.StdEncoding.DecodeString("8RXEI0MwO3uJUINFFlOm/uTjJCneV9FidMpXmn55G8Y=")
+	var err error
+	mainnetPoet2ServiceID, err = base64.StdEncoding.DecodeString("8RXEI0MwO3uJUINFFlOm/uTjJCneV9FidMpXmn55G8Y=")
+	if err != nil {
+		panic(fmt.Errorf("failed to decode mainnet poet 2 service id: %w", err))
+	}
 }
 
 func New0003Migration(log *zap.Logger, dataDir string, poetClients []PoetClient) *migration0003 {

--- a/sql/localsql/0003_migration_test.go
+++ b/sql/localsql/0003_migration_test.go
@@ -2,6 +2,7 @@ package localsql
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
 	"path/filepath"
 	"sort"
@@ -145,23 +146,9 @@ func Test_0003Migration_Phase0_missing_poet_client(t *testing.T) {
 		sql.WithMigrations(migrations),
 	)
 
-	observer, observedLogs := observer.New(zapcore.WarnLevel)
-	logger := zap.New(observer)
-
-	ctrl := gomock.NewController(t)
-	poetClient1 := NewMockPoetClient(ctrl)
-	poetClient1.EXPECT().PoetServiceID(gomock.Any()).AnyTimes().
-		Return([]byte("service1"))
-	poetClient1.EXPECT().Address().AnyTimes().Return("http://poet1.com")
-
-	err = New0003Migration(logger, dataDir, []PoetClient{poetClient1}).Apply(db)
-	require.NoError(t, err)
-	require.Equal(t, 1, observedLogs.Len(), "expected 1 log message")
-	require.Equal(t, zapcore.WarnLevel, observedLogs.All()[0].Level)
-	require.Contains(t, observedLogs.All()[0].Message, "failed to resolve address for poet service id")
-	require.Equal(t, state.PoetRequests[1].PoetServiceID.ServiceID, observedLogs.All()[0].ContextMap()["service_id"])
-
-	require.NoFileExists(t, filepath.Join(dataDir, builderFilename))
+	err = New0003Migration(zaptest.NewLogger(t), dataDir, nil).Apply(db)
+	require.ErrorContains(t, err, "no poet client found")
+	require.FileExists(t, filepath.Join(dataDir, builderFilename))
 }
 
 func Test_0003Migration_Phase0_Complete(t *testing.T) {
@@ -243,6 +230,94 @@ func Test_0003Migration_Phase0_Complete(t *testing.T) {
 			require.Equal(t, state.PoetRequests[i].PoetRound.ID, stmt.ColumnText(2))
 			require.Equal(t, endTime.Unix(), stmt.ColumnInt64(3))
 			i++
+			return true
+		})
+	require.NoError(t, err)
+
+	require.NoFileExists(t, filepath.Join(dataDir, builderFilename))
+}
+
+func Test_0003Migration_Phase0_MainnetPoet2(t *testing.T) {
+	dataDir := t.TempDir()
+
+	mainnetPoet2, err := hex.DecodeString("f115c42343303b7b895083451653a6fee4e32429de57d16274ca579a7e791bc6")
+	require.NoError(t, err)
+
+	endTime := time.Now()
+	state := &NIPostBuilderState{
+		PoetRequests: []PoetRequest{
+			{
+				PoetRound: &types.PoetRound{
+					ID:  "101",
+					End: types.RoundEnd(endTime),
+				},
+				PoetServiceID: PoetServiceID{
+					ServiceID: []byte("service1"),
+				},
+			},
+			{
+				PoetRound: &types.PoetRound{
+					ID:  "102",
+					End: types.RoundEnd(endTime),
+				},
+				PoetServiceID: PoetServiceID{
+					ServiceID: mainnetPoet2,
+				},
+			},
+		},
+	}
+	require.NoError(t, saveBuilderState(dataDir, state))
+	require.FileExists(t, filepath.Join(dataDir, builderFilename))
+
+	nodeID := types.RandomNodeID()
+	nonce := uint64(1024)
+	err = initialization.SaveMetadata(dataDir, &shared.PostMetadata{
+		NodeId:   nodeID.Bytes(),
+		NumUnits: 8,
+		Nonce:    &nonce,
+	})
+	require.NoError(t, err)
+
+	migrations, err := sql.LocalMigrations()
+	require.NoError(t, err)
+	sort.Slice(migrations, func(i, j int) bool { return migrations[i].Order() < migrations[j].Order() })
+	migrations = migrations[:2]
+	db := InMemory(
+		sql.WithMigrations(migrations),
+	)
+
+	observer, observedLogs := observer.New(zapcore.InfoLevel)
+	logger := zap.New(observer)
+
+	ctrl := gomock.NewController(t)
+	poetClient1 := NewMockPoetClient(ctrl)
+	poetClient1.EXPECT().PoetServiceID(gomock.Any()).AnyTimes().
+		Return([]byte("service1"))
+	poetClient1.EXPECT().Address().AnyTimes().Return("http://poet1.com")
+
+	poetClient2 := NewMockPoetClient(ctrl)
+	poetClient2.EXPECT().PoetServiceID(gomock.Any()).AnyTimes().
+		Return([]byte("service2"))
+	poetClient2.EXPECT().Address().AnyTimes().Return("http://poet2.com")
+
+	err = New0003Migration(logger, dataDir, []PoetClient{poetClient1}).Apply(db)
+	require.NoError(t, err)
+	require.Equal(t, 1, observedLogs.Len(), "expected 1 log message")
+	require.Equal(t, zapcore.InfoLevel, observedLogs.All()[0].Level)
+	require.Contains(t, observedLogs.All()[0].Message, "`mainnet-poet-2.spacemesh.network` has been retired")
+
+	_, err = db.Exec("select hash, address, round_id, round_end from poet_registration where id = ?1;",
+		func(stmt *sql.Statement) {
+			stmt.BindBytes(1, nodeID.Bytes())
+		},
+		func(stmt *sql.Statement) bool {
+			buf := make([]byte, stmt.ColumnLen(0))
+			stmt.ColumnBytes(0, buf)
+
+			require.Equal(t, state.Challenge.Bytes(), buf)
+			require.Equal(t, "http://poet1.com", stmt.ColumnText(1))
+			require.Equal(t, state.PoetRequests[0].PoetRound.ID, stmt.ColumnText(2))
+			require.Equal(t, endTime.Unix(), stmt.ColumnInt64(3))
 			return true
 		})
 	require.NoError(t, err)
@@ -642,4 +717,7 @@ func Test_0003Migration_Rollback(t *testing.T) {
 	require.NoError(t, tx.Release())
 
 	require.FileExists(t, filepath.Join(dataDir, builderFilename))
+
+	// rolling back again is no-op
+	require.NoError(t, migration.Rollback())
 }


### PR DESCRIPTION
## Motivation

If a PoET isn't in the config of the node during local DB migration the migration will fail. This changes the code to only print a warning in this case and removing the PoET registration from the state.

## Description

`mainnet-poet-2` has been removed from code in #5640 causing a migration of the local state to fail when the node still has a registration for that PoET.

**NOTE:** If a user hasn't setup their config correctly this change will not migrate their local state correctly - possibly causing them to lose an epoch of rewards, while before the node would fail with an error during startup.

## Test Plan

existing tests were updated for the new behavior.

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
