### PR TITLE
[Merged by Bors] - add explicit order by for latest account

### DIFF
--- a/sql/accounts/accounts.go
+++ b/sql/accounts/accounts.go
@@ -46,7 +46,8 @@ func Latest(db sql.Executor, address types.Address) (types.Account, error) {
 	account, err := load(
 		db,
 		address,
-		"select balance, next_nonce, layer_updated, template, state from accounts where address = ?1;",
+		`select balance, next_nonce, layer_updated, template, state from accounts where address = ?1 
+		order by layer_updated desc;`,
 		func(stmt *sql.Statement) {
 			stmt.BindBytes(1, address.Bytes())
 		},
@@ -61,7 +62,7 @@ func Latest(db sql.Executor, address types.Address) (types.Account, error) {
 func Get(db sql.Executor, address types.Address, layer types.LayerID) (types.Account, error) {
 	account, err := load(db, address,
 		`select balance, next_nonce, layer_updated, template, state
-		 from accounts where address = ?1 and layer_updated <= ?2;`,
+		 from accounts where address = ?1 and layer_updated <= ?2 order by layer_updated desc;`,
 		func(stmt *sql.Statement) {
 			stmt.BindBytes(1, address.Bytes())
 			stmt.BindInt64(2, int64(layer))


### PR DESCRIPTION
closes: https://github.com/spacemeshos/go-spacemesh/issues/4825

it was overlooked in initial development. the order is not guaranteed by sqlite despite primary key ordered by in the order that is expected by vm . so sqlite free to choose any order it "likes" for optimal reasons. generally the optimal should be iterating over (account, layer_update) tree, but on different environment it may not be true