### PR TITLE
split atxs blobs from the fields that we use for consensus

### DIFF
--- a/sql/accounts/accounts.go
+++ b/sql/accounts/accounts.go
@@ -46,7 +46,8 @@ func Latest(db sql.Executor, address types.Address) (types.Account, error) {
 	account, err := load(
 		db,
 		address,
-		"select balance, next_nonce, layer_updated, template, state from accounts where address = ?1;",
+		`select balance, next_nonce, layer_updated, template, state from accounts where address = ?1 
+		order by layer_updated desc;`,
 		func(stmt *sql.Statement) {
 			stmt.BindBytes(1, address.Bytes())
 		},

--- a/sql/migrations/state/0016_split_atxs.sql
+++ b/sql/migrations/state/0016_split_atxs.sql
@@ -1,0 +1,40 @@
+DROP INDEX atxs_by_pubkey_by_epoch_desc;
+DROP INDEX atxs_by_epoch_by_pubkey;
+DROP INDEX atxs_by_epoch_by_pubkey_nonce;
+DROP INDEX atxs_by_coinbase;
+ALTER TABLE atxs RENAME TO atxs_old;
+
+CREATE TABLE atxs_blobs
+(
+    id                  CHAR(32) PRIMARY KEY,
+    atx                 BLOB
+);
+
+CREATE TABLE atxs 
+(
+    epoch               INT NOT NULL,
+    id                  CHAR(32),
+    effective_num_units INT NOT NULL,
+    commitment_atx      CHAR(32),
+    nonce               UNSIGNED LONG INT,
+    base_tick_height    UNSIGNED LONG INT,
+    tick_count          UNSIGNED LONG INT,
+    sequence            UNSIGNED LONG INT,
+    pubkey              CHAR(32),
+    coinbase            CHAR(24),
+    received            INT NOT NULL,
+    PRIMARY KEY (epoch, id)
+);
+
+INSERT INTO atxs (epoch, id, effective_num_units, commitment_atx, nonce, base_tick_height, tick_count, sequence, pubkey, coinbase, received)
+  SELECT epoch, id, effective_num_units, commitment_atx, nonce, base_tick_height, tick_count, sequence, pubkey, coinbase, received
+  FROM atxs_old;
+
+INSERT INTO atxs_blobs (id, atx) SELECT id, atx FROM atxs_old;
+
+DROP TABLE atxs_old;
+
+CREATE INDEX atxs_by_pubkey_by_epoch_desc ON atxs (pubkey, epoch desc);
+CREATE INDEX atxs_by_epoch_by_pubkey ON atxs (epoch, pubkey);
+CREATE INDEX atxs_by_coinbase ON atxs (coinbase);
+CREATE INDEX atxs_by_epoch_by_pubkey_nonce ON atxs (pubkey, epoch desc, nonce) WHERE nonce IS NOT NULL;

--- a/tortoise/replay/replay_test.go
+++ b/tortoise/replay/replay_test.go
@@ -51,13 +51,14 @@ func TestReplayMainnet(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	db, err := sql.Open(fmt.Sprintf("file:%s?mode=ro", *dbpath))
+	db, err := sql.Open(fmt.Sprintf("file:%s", *dbpath))
 	require.NoError(t, err)
 
 	start := time.Now()
 	atxsdata, err := atxsdata.Warm(db,
 		atxsdata.WithCapacityFromLayers(cfg.Tortoise.WindowSize, cfg.LayersPerEpoch),
 	)
+	zlog.Info("warmed atxsdata", zap.Duration("duration", time.Since(start)))
 	require.NoError(t, err)
 	trtl, err := tortoise.Recover(
 		context.Background(),


### PR DESCRIPTION
on my computer it reduces loading time from 1.30m to 18s without caches on linux.
but we can also go further and avoid loading anything at all, as now relevant data should always remain in kernel (os) page cache due to smaller size, and will not slow critical parts.

database size didn't change:
atxs_blobs|8104210432
atxs|804847616