### PR TITLE
separate ballot blobs from ballot data used for consensus

### DIFF
--- a/sql/accounts/accounts.go
+++ b/sql/accounts/accounts.go
@@ -46,7 +46,8 @@ func Latest(db sql.Executor, address types.Address) (types.Account, error) {
 	account, err := load(
 		db,
 		address,
-		"select balance, next_nonce, layer_updated, template, state from accounts where address = ?1;",
+		`select balance, next_nonce, layer_updated, template, state from accounts where address = ?1 
+		order by layer_updated desc;`,
 		func(stmt *sql.Statement) {
 			stmt.BindBytes(1, address.Bytes())
 		},

--- a/sql/migration_extension/0017.go
+++ b/sql/migration_extension/0017.go
@@ -1,0 +1,125 @@
+package migration_extension
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spacemeshos/go-spacemesh/codec"
+	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/sql"
+	"github.com/spacemeshos/go-spacemesh/sql/ballots"
+)
+
+// M0017 executes 0017_dedup_ballots.sql, and it also migrates existing data from original unified ballots table.
+// This migration requires parsing ballot data, so it is not straighforward to execute just by using sql.
+func M0017() *migration0017 {
+	return &migration0017{}
+}
+
+type migration0017 struct{}
+
+type refTuple struct {
+	beacon             types.Beacon
+	totalEligibilities uint32
+}
+
+func (migration0017) Name() string {
+	return "dedup_ballots"
+}
+
+func (migration0017) Order() int {
+	return 17
+}
+
+func (migration0017) Rollback() error {
+	return nil
+}
+
+func (m *migration0017) Apply(db sql.Executor) error {
+	version, err := sql.Version(db)
+	if err != nil {
+		return fmt.Errorf("get db version: %w", err)
+	}
+	if version >= m.Order() {
+		return nil
+	}
+	path := "migrations/state/0017_dedup_ballots.sql"
+	f, err := sql.MigrationsFS().Open(path)
+	if err != nil {
+		return fmt.Errorf("read migration `%s` from embedded fs: %w", path, err)
+	}
+	scanner := sql.SQLScanner(f)
+	for scanner.Scan() {
+		_, err = db.Exec(scanner.Text(), nil, nil)
+		if err != nil {
+			return fmt.Errorf("exec migration `%s`: %w", path, err)
+		}
+	}
+	// 5991539 ballots at the start of epoch 17
+	// 20 bytes per id, 9 bytes per tuple
+	// at most it should be around 200MB with map ampflication
+	// if every ballot is a reference ballot
+	var (
+		refCache  = map[types.BallotID]refTuple{}
+		firstPass = true
+		ierr      error
+	)
+	iter := func(id types.BallotID, reader io.Reader) bool {
+		var ballot types.Ballot
+		if _, err := codec.DecodeFrom(reader, &ballot); err != nil {
+			panic(err)
+		}
+		var ref refTuple
+		if ballot.EpochData != nil && firstPass {
+			// this is a reference to a beacon
+			ref = refTuple{
+				beacon:             ballot.EpochData.Beacon,
+				totalEligibilities: ballot.EpochData.EligibilityCount,
+			}
+			refCache[id] = ref
+		} else if !firstPass && ballot.EpochData == nil {
+			ref = refCache[ballot.RefBallot]
+		} else {
+			// skip non-reference ballots in the first pass
+			// and reference ballots in the second pass
+			return true
+		}
+
+		opinion := types.Opinion{
+			Votes: ballot.Votes,
+			Hash:  ballot.OpinionHash,
+		}
+		ballotTuple := ballots.BallotTuple{
+			Layer:              ballot.Layer,
+			ID:                 id,
+			ATX:                ballot.AtxID,
+			Node:               ballot.SmesherID,
+			Eligibilities:      uint32(len(ballot.EligibilityProofs)),
+			TotalEligibilities: ref.totalEligibilities,
+			Beacon:             ref.beacon,
+			Opinion:            opinion.Hash,
+		}
+		if err := ballots.AddMinimalOpinion(db, ballot.Layer, opinion.Hash, opinion); err != nil {
+			ierr = fmt.Errorf("add minimal opinion: %w", err)
+			return false
+		}
+		if err := ballots.AddBallotTuple(db, &ballotTuple); err != nil {
+			ierr = fmt.Errorf("add ballot tuple: %w", err)
+			return false
+		}
+		return true
+	}
+	// in the first pass we populate refCache, we don't have order for blob iteration,
+	// and nested selects will make things slower than 2 passes
+	if err := ballots.IterateBlobs(db, iter); err != nil || ierr != nil {
+		return fmt.Errorf("iterate ballots, first pass: %w, %w", err, ierr)
+	}
+	firstPass = false
+	if err := ballots.IterateBlobs(db, iter); err != nil || ierr != nil {
+		return fmt.Errorf("iterate ballots, second pass: %w, %w", err, ierr)
+	}
+	if _, err := db.Exec(fmt.Sprintf("PRAGMA user_version = %d;", m.Order()), nil, nil); err != nil {
+		return fmt.Errorf("update user_version to %d: %w", m.Order(), err)
+	}
+	return nil
+}

--- a/sql/migrations/state/0016_split_atxs.sql
+++ b/sql/migrations/state/0016_split_atxs.sql
@@ -1,0 +1,40 @@
+DROP INDEX atxs_by_pubkey_by_epoch_desc;
+DROP INDEX atxs_by_epoch_by_pubkey;
+DROP INDEX atxs_by_epoch_by_pubkey_nonce;
+DROP INDEX atxs_by_coinbase;
+ALTER TABLE atxs RENAME TO atxs_old;
+
+CREATE TABLE atxs_blobs
+(
+    id                  CHAR(32) PRIMARY KEY,
+    atx                 BLOB
+);
+
+CREATE TABLE atxs 
+(
+    epoch               INT NOT NULL,
+    id                  CHAR(32),
+    effective_num_units INT NOT NULL,
+    commitment_atx      CHAR(32),
+    nonce               UNSIGNED LONG INT,
+    base_tick_height    UNSIGNED LONG INT,
+    tick_count          UNSIGNED LONG INT,
+    sequence            UNSIGNED LONG INT,
+    pubkey              CHAR(32),
+    coinbase            CHAR(24),
+    received            INT NOT NULL,
+    PRIMARY KEY (epoch, id)
+);
+
+INSERT INTO atxs (epoch, id, effective_num_units, commitment_atx, nonce, base_tick_height, tick_count, sequence, pubkey, coinbase, received)
+  SELECT epoch, id, effective_num_units, commitment_atx, nonce, base_tick_height, tick_count, sequence, pubkey, coinbase, received
+  FROM atxs_old;
+
+INSERT INTO atxs_blobs (id, atx) SELECT id, atx FROM atxs_old;
+
+DROP TABLE atxs_old;
+
+CREATE INDEX atxs_by_pubkey_by_epoch_desc ON atxs (pubkey, epoch desc);
+CREATE INDEX atxs_by_epoch_by_pubkey ON atxs (epoch, pubkey);
+CREATE INDEX atxs_by_coinbase ON atxs (coinbase);
+CREATE INDEX atxs_by_epoch_by_pubkey_nonce ON atxs (pubkey, epoch desc, nonce) WHERE nonce IS NOT NULL;

--- a/sql/migrations/state/0017_dedup_ballots.sql
+++ b/sql/migrations/state/0017_dedup_ballots.sql
@@ -1,0 +1,38 @@
+DROP INDEX ballots_by_layer_by_pubkey;
+DROP INDEX ballots_by_atx_by_layer;
+ALTER TABLE ballots RENAME TO ballots_old;
+
+CREATE TABLE ballot_opinions
+(   
+    layer     INT NOT NULL,
+    opinion   CHAR(32) NOT NULL,
+    encoded   BLOB,
+    PRIMARY KEY (layer, opinion)
+);
+
+CREATE TABLE ballots
+(
+    layer               INT NOT NULL,
+    id                  CHAR(20) NOT NULL,
+    atx                 CHAR(32) NOT NULL,
+    pubkey              CHAR(32) NOT NULL,
+    eligibilities       INT NOT NULL,
+    beacon              VARCHAR NOT NULL,
+    total_eligibilities INT NOT NULL,
+    opinion             CHAR(32) NOT NULL,
+    FOREIGN KEY (layer, opinion) REFERENCES ballot_opinions (layer, opinion),
+    PRIMARY KEY (layer, id)
+);
+
+CREATE INDEX ballots_by_layer_by_pubkey ON ballots (layer, pubkey);
+CREATE INDEX ballots_by_atx_by_layer ON ballots (atx, layer);
+
+CREATE TABLE ballot_blobs
+(
+    id        CHAR(20) PRIMARY KEY,
+    ballot    BLOB
+);
+
+INSERT INTO ballot_blobs (id, ballot) SELECT id, ballot FROM ballots_old;
+
+DROP TABLE ballots_old;

--- a/tortoise/replay/replay_test.go
+++ b/tortoise/replay/replay_test.go
@@ -51,13 +51,14 @@ func TestReplayMainnet(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	db, err := sql.Open(fmt.Sprintf("file:%s?mode=ro", *dbpath))
+	db, err := sql.Open(fmt.Sprintf("file:%s", *dbpath))
 	require.NoError(t, err)
 
 	start := time.Now()
 	atxsdata, err := atxsdata.Warm(db,
 		atxsdata.WithCapacityFromLayers(cfg.Tortoise.WindowSize, cfg.LayersPerEpoch),
 	)
+	zlog.Info("warmed atxsdata", zap.Duration("duration", time.Since(start)))
 	require.NoError(t, err)
 	trtl, err := tortoise.Recover(
 		context.Background(),


### PR DESCRIPTION
it also moves opinions into separate table, which keeps only minimal opinion.

{"L":"INFO","T":"2024-03-10T10:29:16.707+0100","N":"replay","M":"loaded atxs data","duration":"15.557262605s"}
{"L":"INFO","T":"2024-03-10T10:30:03.268+0100","N":"replay","M":"initialized","duration":"1m2.118649367s","mode":"full","heap":984.3203125,"updates":[{"layer":68967,"opinion":"f6360397c7","verified":true,"blocks":[{"id":"3ce3d641eb","layer":68967,"height":141015,"valid":true,"invalid":false,"hare":true,"data":true,"local":true}]},{"layer":68968,"opinion":"4ee7d7a5bc","verified":false,"blocks":[]}]}

in this last case the bottleneck is not disk reads, but a bug that caused tortoise to switch into full mode, due to missed updates on validity. it should be fixed with v1.4, but reminder to debug it

```
sqlite> select layer, hex(id), validity from blocks where layer > 64000 and validity is null;
66634|C8E8BE5527C580ED22EA9C1D5768F6BCB2B16609000000000000000000000000|
67862|054D5F164E38F43EAA8093A42815AEA84781C44F000000000000000000000000|
68967|3CE3D641EB995D9E750517BA929805530980E6BD000000000000000000000000|
```

fixed version in verifying mode

{"L":"INFO","T":"2024-03-10T14:12:33.588+0100","N":"replay","M":"loaded atxs data","duration":"16.306246838s"}
{"L":"INFO","T":"2024-03-10T14:12:39.471+0100","N":"replay","M":"initialized","duration":"5.810418096s","mode":"verifying","heap":1000.6640625,"updates":[{"layer":68968,"opinion":"4ee7d7a5bc","verified":false,"blocks":[]}]}