### PR TITLE
experiment zstd chunk compression and consensus history growth

### DIFF
--- a/atxsdata/warmup.go
+++ b/atxsdata/warmup.go
@@ -36,30 +36,32 @@ func Warmup(db sql.Executor, cache *Data) error {
 	cache.OnEpoch(applied.GetEpoch())
 
 	var ierr error
-	if err := atxs.IterateAtxs(db, cache.Evicted(), latest, func(vatx *types.VerifiedActivationTx) bool {
-		nonce, err := atxs.VRFNonce(db, vatx.SmesherID, vatx.TargetEpoch())
-		if err != nil {
-			ierr = fmt.Errorf("missing nonce %w", err)
-			return false
-		}
-		malicious, err := identities.IsMalicious(db, vatx.SmesherID)
-		if err != nil {
-			ierr = err
-			return false
-		}
-		cache.Add(
-			vatx.TargetEpoch(),
-			vatx.SmesherID,
-			vatx.Coinbase,
-			vatx.ID(),
-			vatx.GetWeight(),
-			vatx.BaseTickHeight(),
-			vatx.TickHeight(),
-			nonce,
-			malicious,
-		)
-		return true
-	}); err != nil {
+	if err := atxs.IterateAtxsData(db, cache.Evicted(), latest,
+		func(id types.ATXID, node types.NodeID, epoch types.EpochID, coinbase types.Address, weight uint64, base, height uint64) bool {
+			target := epoch + 1
+			nonce, err := atxs.VRFNonce(db, node, target)
+			if err != nil {
+				ierr = fmt.Errorf("missing nonce %w", err)
+				return false
+			}
+			malicious, err := identities.IsMalicious(db, node)
+			if err != nil {
+				ierr = err
+				return false
+			}
+			cache.Add(
+				target,
+				node,
+				coinbase,
+				id,
+				weight,
+				base,
+				height,
+				nonce,
+				malicious,
+			)
+			return true
+		}); err != nil {
 		return err
 	}
 	return ierr

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -366,6 +366,19 @@ func (f *Fetch) Start() error {
 				return srv.Run(f.shutdownCtx)
 			})
 		}
+		f.eg.Go(func() error {
+			for {
+				select {
+				case <-f.shutdownCtx.Done():
+					return nil
+				case <-time.After(10 * time.Minute):
+					stats := f.peers.Stats()
+					f.logger.With().
+						Error("peers stats", log.Inline(&stats))
+				}
+
+			}
+		})
 	})
 	return nil
 }

--- a/fetch/peers/peers.go
+++ b/fetch/peers/peers.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/libp2p/go-libp2p/core/peer"
+	"go.uber.org/zap/zapcore"
 
 	"github.com/spacemeshos/go-spacemesh/p2p"
 )
@@ -170,4 +171,60 @@ func (p *Peers) Total() int {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	return len(p.peers)
+}
+
+func (p *Peers) Stats() Stats {
+	best := p.SelectBest(3)
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	stats := Stats{
+		Total:                len(p.peers),
+		GlobalAverageLatency: p.globalLatency,
+	}
+	for _, peer := range best {
+		peerData, exist := p.peers[peer]
+		if !exist {
+			continue
+		}
+		stats.BestPeers = append(stats.BestPeers, PeerStats{
+			ID:       peerData.id,
+			Success:  peerData.success,
+			Failures: peerData.failures,
+			Latency:  peerData.averageLatency,
+		})
+	}
+	return stats
+}
+
+type Stats struct {
+	Total                int
+	GlobalAverageLatency float64
+	BestPeers            []PeerStats
+}
+
+func (s *Stats) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	enc.AddInt("total", s.Total)
+	enc.AddFloat64("global average latency", s.GlobalAverageLatency)
+	enc.AddArray("best peers", zapcore.ArrayMarshalerFunc(func(arrEnc zapcore.ArrayEncoder) error {
+		for _, peer := range s.BestPeers {
+			arrEnc.AppendObject(&peer)
+		}
+		return nil
+	}))
+	return nil
+}
+
+type PeerStats struct {
+	ID       peer.ID
+	Success  int
+	Failures int
+	Latency  float64
+}
+
+func (p *PeerStats) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	enc.AddString("id", p.ID.String())
+	enc.AddInt("success", p.Success)
+	enc.AddInt("failures", p.Failures)
+	enc.AddFloat64("latency per 1024 bytes", p.Latency)
+	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -69,6 +69,7 @@ require (
 	cloud.google.com/go/compute v1.24.0 // indirect
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
 	cloud.google.com/go/iam v1.1.6 // indirect
+	github.com/DataDog/zstd v1.5.5 // indirect
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 // indirect
 	github.com/anacrolix/chansync v0.3.0 // indirect
 	github.com/anacrolix/missinggo v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -52,6 +52,8 @@ github.com/ALTree/bigfloat v0.2.0 h1:AwNzawrpFuw55/YDVlcPw0F0cmmXrmngBHhVrvdXPvM
 github.com/ALTree/bigfloat v0.2.0/go.mod h1:+NaH2gLeY6RPBPPQf4aRotPPStg+eXc8f9ZaE4vRfD4=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/DataDog/zstd v1.5.5 h1:oWf5W7GtOLgp6bciQYDmhHHjdhYkALu6S/5Ni9ZgSvQ=
+github.com/DataDog/zstd v1.5.5/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/RoaringBitmap/roaring v0.4.7/go.mod h1:8khRDP4HmeXns4xIj9oGrKSz7XTQiJx2zgh7AcNke4w=
 github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 h1:s6gZFSlWYmbqAuRjVTiNNhvNRfY2Wxp9nhfyel4rklc=
 github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137/go.mod h1:OMCwj8VM1Kc9e19TLln2VL61YJF0x1XFtfdL4JdbSyE=

--- a/sql/accounts/accounts.go
+++ b/sql/accounts/accounts.go
@@ -46,7 +46,8 @@ func Latest(db sql.Executor, address types.Address) (types.Account, error) {
 	account, err := load(
 		db,
 		address,
-		"select balance, next_nonce, layer_updated, template, state from accounts where address = ?1;",
+		`select balance, next_nonce, layer_updated, template, state from accounts where address = ?1 
+		order by layer_updated desc;`,
 		func(stmt *sql.Statement) {
 			stmt.BindBytes(1, address.Bytes())
 		},
@@ -61,7 +62,7 @@ func Latest(db sql.Executor, address types.Address) (types.Account, error) {
 func Get(db sql.Executor, address types.Address, layer types.LayerID) (types.Account, error) {
 	account, err := load(db, address,
 		`select balance, next_nonce, layer_updated, template, state
-		 from accounts where address = ?1 and layer_updated <= ?2;`,
+		 from accounts where address = ?1 and layer_updated <= ?2 order by layer_updated desc;`,
 		func(stmt *sql.Statement) {
 			stmt.BindBytes(1, address.Bytes())
 			stmt.BindInt64(2, int64(layer))

--- a/sql/atxs/atxs.go
+++ b/sql/atxs/atxs.go
@@ -508,10 +508,10 @@ func IterateAtxsData(
 			stmt.ColumnBytes(1, node[:])
 			epoch := types.EpochID(uint32(stmt.ColumnInt64(2)))
 			var coinbase types.Address
-			stmt.ColumnBytes(2, coinbase[:])
-			weight := uint64(stmt.ColumnInt64(3))
-			base := uint64(stmt.ColumnInt64(4))
-			ticks := uint64(stmt.ColumnInt64(5))
+			stmt.ColumnBytes(3, coinbase[:])
+			weight := uint64(stmt.ColumnInt64(4))
+			base := uint64(stmt.ColumnInt64(5))
+			ticks := uint64(stmt.ColumnInt64(6))
 			return fn(id, node, epoch, coinbase, weight*ticks, base, base+ticks)
 		},
 	)

--- a/sql/atxs/atxs.go
+++ b/sql/atxs/atxs.go
@@ -521,24 +521,6 @@ func IterateAtxsData(
 	return nil
 }
 
-func IterateAtxs(db sql.Executor, from, to types.EpochID, fn func(*types.VerifiedActivationTx) bool) error {
-	var derr error
-	_, err := db.Exec(fullQuery+" where epoch between ?1 and ?2", func(stmt *sql.Statement) {
-		stmt.BindInt64(1, int64(from.Uint32()))
-		stmt.BindInt64(2, int64(to.Uint32()))
-	}, decoder(func(atx *types.VerifiedActivationTx, err error) bool {
-		if atx != nil {
-			return fn(atx)
-		}
-		derr = err
-		return derr == nil
-	}))
-	if err != nil {
-		return err
-	}
-	return derr
-}
-
 func SetValidity(db sql.Executor, id types.ATXID, validity types.Validity) error {
 	_, err := db.Exec("UPDATE atxs SET validity = ?1 where id = ?2;",
 		func(stmt *sql.Statement) {

--- a/sql/atxsync/atxsync.go
+++ b/sql/atxsync/atxsync.go
@@ -50,13 +50,15 @@ func SaveSyncState(db sql.Executor, epoch types.EpochID, states map[types.ATXID]
 	return nil
 }
 
-func SaveRequestTime(db sql.Executor, epoch types.EpochID, timestamp time.Time) error {
+func SaveRequest(db sql.Executor, epoch types.EpochID, timestamp time.Time, total, downloaded int64) error {
 	_, err := db.Exec(`insert into atx_sync_requests 
-	(epoch, timestamp) values (?1, ?2)
-	on conflict(epoch) do update set timestamp = ?2;`,
+	(epoch, timestamp, total, downloaded) values (?1, ?2, ?3, ?4)
+	on conflict(epoch) do update set timestamp = ?2, total = ?3, downloaded = ?4;`,
 		func(stmt *sql.Statement) {
 			stmt.BindInt64(1, int64(epoch))
 			stmt.BindInt64(2, timestamp.Unix())
+			stmt.BindInt64(3, total)
+			stmt.BindInt64(4, downloaded)
 		}, nil)
 	if err != nil {
 		return fmt.Errorf("insert request time for epoch %v failed: %w", epoch, err)
@@ -64,21 +66,27 @@ func SaveRequestTime(db sql.Executor, epoch types.EpochID, timestamp time.Time) 
 	return nil
 }
 
-func GetRequestTime(db sql.Executor, epoch types.EpochID) (time.Time, error) {
-	var timestamp time.Time
-	rows, err := db.Exec("select timestamp from atx_sync_requests where epoch = ?1",
+func GetRequest(db sql.Executor, epoch types.EpochID) (time.Time, int64, int64, error) {
+	var (
+		timestamp  time.Time
+		total      int64
+		downloaded int64
+	)
+	rows, err := db.Exec("select timestamp, total, downloaded from atx_sync_requests where epoch = ?1",
 		func(stmt *sql.Statement) {
 			stmt.BindInt64(1, int64(epoch))
 		}, func(stmt *sql.Statement) bool {
 			timestamp = time.Unix(stmt.ColumnInt64(0), 0)
+			total = stmt.ColumnInt64(1)
+			downloaded = stmt.ColumnInt64(2)
 			return true
 		})
 	if err != nil {
-		return time.Time{}, fmt.Errorf("select request time for epoch %v failed: %w", epoch, err)
+		return time.Time{}, 0, 0, fmt.Errorf("select request time for epoch %v failed: %w", epoch, err)
 	} else if rows == 0 {
-		return time.Time{}, fmt.Errorf("%w: no request time for epoch %v", sql.ErrNotFound, epoch)
+		return time.Time{}, 0, 0, fmt.Errorf("%w: no request time for epoch %v", sql.ErrNotFound, epoch)
 	}
-	return timestamp, nil
+	return timestamp, total, downloaded, nil
 }
 
 func Clear(db sql.Executor) error {

--- a/sql/migration_extension/0017.go
+++ b/sql/migration_extension/0017.go
@@ -1,0 +1,125 @@
+package migration_extension
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spacemeshos/go-spacemesh/codec"
+	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/sql"
+	"github.com/spacemeshos/go-spacemesh/sql/ballots"
+)
+
+// M0017 executes 0017_dedup_ballots.sql, and it also migrates existing data from original unified ballots table.
+// This migration requires parsing ballot data, so it is not straighforward to execute just by using sql.
+func M0017() *migration0017 {
+	return &migration0017{}
+}
+
+type migration0017 struct{}
+
+type refTuple struct {
+	beacon             types.Beacon
+	totalEligibilities uint32
+}
+
+func (migration0017) Name() string {
+	return "dedup_ballots"
+}
+
+func (migration0017) Order() int {
+	return 17
+}
+
+func (migration0017) Rollback() error {
+	return nil
+}
+
+func (m *migration0017) Apply(db sql.Executor) error {
+	version, err := sql.Version(db)
+	if err != nil {
+		return fmt.Errorf("get db version: %w", err)
+	}
+	if version >= m.Order() {
+		return nil
+	}
+	path := "migrations/state/0017_dedup_ballots.sql"
+	f, err := sql.MigrationsFS().Open(path)
+	if err != nil {
+		return fmt.Errorf("read migration `%s` from embedded fs: %w", path, err)
+	}
+	scanner := sql.SQLScanner(f)
+	for scanner.Scan() {
+		_, err = db.Exec(scanner.Text(), nil, nil)
+		if err != nil {
+			return fmt.Errorf("exec migration `%s`: %w", path, err)
+		}
+	}
+	// 5991539 ballots at the start of epoch 17
+	// 20 bytes per id, 9 bytes per tuple
+	// at most it should be around 200MB with map ampflication
+	// if every ballot is a reference ballot
+	var (
+		refCache  = map[types.BallotID]refTuple{}
+		firstPass = true
+		ierr      error
+	)
+	iter := func(id types.BallotID, reader io.Reader) bool {
+		var ballot types.Ballot
+		if _, err := codec.DecodeFrom(reader, &ballot); err != nil {
+			panic(err)
+		}
+		var ref refTuple
+		if ballot.EpochData != nil && firstPass {
+			// this is a reference to a beacon
+			ref = refTuple{
+				beacon:             ballot.EpochData.Beacon,
+				totalEligibilities: ballot.EpochData.EligibilityCount,
+			}
+			refCache[id] = ref
+		} else if !firstPass && ballot.EpochData == nil {
+			ref = refCache[ballot.RefBallot]
+		} else {
+			// skip non-reference ballots in the first pass
+			// and reference ballots in the second pass
+			return true
+		}
+
+		opinion := types.Opinion{
+			Votes: ballot.Votes,
+			Hash:  ballot.OpinionHash,
+		}
+		ballotTuple := ballots.BallotTuple{
+			Layer:              ballot.Layer,
+			ID:                 id,
+			ATX:                ballot.AtxID,
+			Node:               ballot.SmesherID,
+			Eligibilities:      uint32(len(ballot.EligibilityProofs)),
+			TotalEligibilities: ref.totalEligibilities,
+			Beacon:             ref.beacon,
+			Opinion:            opinion.Hash,
+		}
+		if err := ballots.AddMinimalOpinion(db, ballot.Layer, opinion.Hash, opinion); err != nil {
+			ierr = fmt.Errorf("add minimal opinion: %w", err)
+			return false
+		}
+		if err := ballots.AddBallotTuple(db, &ballotTuple); err != nil {
+			ierr = fmt.Errorf("add ballot tuple: %w", err)
+			return false
+		}
+		return true
+	}
+	// in the first pass we populate refCache, we don't have order for blob iteration,
+	// and nested selects will make things slower than 2 passes
+	if err := ballots.IterateBlobs(db, iter); err != nil || ierr != nil {
+		return fmt.Errorf("iterate ballots, first pass: %w, %w", err, ierr)
+	}
+	firstPass = false
+	if err := ballots.IterateBlobs(db, iter); err != nil || ierr != nil {
+		return fmt.Errorf("iterate ballots, second pass: %w, %w", err, ierr)
+	}
+	if _, err := db.Exec(fmt.Sprintf("PRAGMA user_version = %d;", m.Order()), nil, nil); err != nil {
+		return fmt.Errorf("update user_version to %d: %w", m.Order(), err)
+	}
+	return nil
+}

--- a/sql/migrations/local/0005_fast_startup.sql
+++ b/sql/migrations/local/0005_fast_startup.sql
@@ -1,0 +1,2 @@
+ALTER TABLE atx_sync_requests ADD COLUMN total INTEGER;
+ALTER TABLE atx_sync_requests ADD COLUMN downloaded INTEGER;

--- a/sql/migrations/state/0015_nonce_index.sql
+++ b/sql/migrations/state/0015_nonce_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX atxs_by_epoch_by_pubkey_nonce ON atxs (pubkey, epoch desc, nonce) WHERE nonce IS NOT NULL;

--- a/sql/migrations/state/0016_split_atxs.sql
+++ b/sql/migrations/state/0016_split_atxs.sql
@@ -1,0 +1,40 @@
+DROP INDEX atxs_by_pubkey_by_epoch_desc;
+DROP INDEX atxs_by_epoch_by_pubkey;
+DROP INDEX atxs_by_epoch_by_pubkey_nonce;
+DROP INDEX atxs_by_coinbase;
+ALTER TABLE atxs RENAME TO atxs_old;
+
+CREATE TABLE atxs_blobs
+(
+    id                  CHAR(32) PRIMARY KEY,
+    atx                 BLOB
+);
+
+CREATE TABLE atxs 
+(
+    epoch               INT NOT NULL,
+    id                  CHAR(32),
+    effective_num_units INT NOT NULL,
+    commitment_atx      CHAR(32),
+    nonce               UNSIGNED LONG INT,
+    base_tick_height    UNSIGNED LONG INT,
+    tick_count          UNSIGNED LONG INT,
+    sequence            UNSIGNED LONG INT,
+    pubkey              CHAR(32),
+    coinbase            CHAR(24),
+    received            INT NOT NULL,
+    PRIMARY KEY (epoch, id)
+);
+
+INSERT INTO atxs (epoch, id, effective_num_units, commitment_atx, nonce, base_tick_height, tick_count, sequence, pubkey, coinbase, received)
+  SELECT epoch, id, effective_num_units, commitment_atx, nonce, base_tick_height, tick_count, sequence, pubkey, coinbase, received
+  FROM atxs_old;
+
+INSERT INTO atxs_blobs (id, atx) SELECT id, atx FROM atxs_old;
+
+DROP TABLE atxs_old;
+
+CREATE INDEX atxs_by_pubkey_by_epoch_desc ON atxs (pubkey, epoch desc);
+CREATE INDEX atxs_by_epoch_by_pubkey ON atxs (epoch, pubkey);
+CREATE INDEX atxs_by_coinbase ON atxs (coinbase);
+CREATE INDEX atxs_by_epoch_by_pubkey_nonce ON atxs (pubkey, epoch desc, nonce) WHERE nonce IS NOT NULL;

--- a/sql/migrations/state/0017_dedup_ballots.sql
+++ b/sql/migrations/state/0017_dedup_ballots.sql
@@ -1,0 +1,38 @@
+DROP INDEX ballots_by_layer_by_pubkey;
+DROP INDEX ballots_by_atx_by_layer;
+ALTER TABLE ballots RENAME TO ballots_old;
+
+CREATE TABLE ballot_opinions
+(   
+    layer     INT NOT NULL,
+    opinion   CHAR(32) NOT NULL,
+    encoded   BLOB,
+    PRIMARY KEY (layer, opinion)
+);
+
+CREATE TABLE ballots
+(
+    layer               INT NOT NULL,
+    id                  CHAR(20) NOT NULL,
+    atx                 CHAR(32) NOT NULL,
+    pubkey              CHAR(32) NOT NULL,
+    eligibilities       INT NOT NULL,
+    beacon              VARCHAR NOT NULL,
+    total_eligibilities INT NOT NULL,
+    opinion             CHAR(32) NOT NULL,
+    FOREIGN KEY (layer, opinion) REFERENCES ballot_opinions (layer, opinion),
+    PRIMARY KEY (layer, id)
+);
+
+CREATE INDEX ballots_by_layer_by_pubkey ON ballots (layer, pubkey);
+CREATE INDEX ballots_by_atx_by_layer ON ballots (atx, layer);
+
+CREATE TABLE ballot_blobs
+(
+    id        CHAR(20) PRIMARY KEY,
+    ballot    BLOB
+);
+
+INSERT INTO ballot_blobs (id, ballot) SELECT id, ballot FROM ballots_old;
+
+DROP TABLE ballots_old;

--- a/syncer/atxsync/syncer_test.go
+++ b/syncer/atxsync/syncer_test.go
@@ -130,10 +130,7 @@ func TestSyncer(t *testing.T) {
 		}
 		require.NoError(t, atxsync.SaveSyncState(tester.localdb, publish, state, tester.cfg.AtxsBatch))
 		lastSuccess := now.Add(-tester.cfg.EpochInfoInterval)
-		require.NoError(t, atxsync.SaveRequestTime(tester.localdb, publish, lastSuccess))
-		for id := range state {
-			require.NoError(t, atxs.Add(tester.db, atx(id)))
-		}
+		require.NoError(t, atxsync.SaveRequest(tester.localdb, publish, lastSuccess, 2, 2))
 		require.NoError(t, tester.syncer.Download(context.Background(), publish, time.Now()))
 	})
 	t.Run("immediate epoch info retries", func(t *testing.T) {

--- a/syncer/state_syncer.go
+++ b/syncer/state_syncer.go
@@ -55,7 +55,7 @@ func (s *Syncer) processLayers(ctx context.Context) error {
 
 	// used to make sure we only resync from the same peer once during each run.
 	resyncPeers := make(map[p2p.Peer]struct{})
-	for lid := start; lid <= s.getLastSyncedLayer(); lid++ {
+	for lid := start; lid <= s.getLastSyncedLayer()+1; lid++ {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -401,6 +401,10 @@ func (s *Syncer) synchronize(ctx context.Context) bool {
 		// always sync to currentLayer-1 to reduce race with gossip and hare/tortoise
 		for layerID := s.getLastSyncedLayer().Add(1); layerID.Before(s.ticker.CurrentLayer()); layerID = layerID.Add(1) {
 			if err := s.syncLayer(ctx, layerID); err != nil {
+				if !errors.Is(err, context.Canceled) {
+					s.logger.With().
+						Warning("failed to sync layer", log.Context(ctx), log.Err(err), layerID)
+				}
 				return false
 			}
 			s.setLastSyncedLayer(layerID)
@@ -570,7 +574,7 @@ func (s *Syncer) syncMalfeasance(ctx context.Context) error {
 
 func (s *Syncer) syncLayer(ctx context.Context, layerID types.LayerID, peers ...p2p.Peer) error {
 	if err := s.dataFetcher.PollLayerData(ctx, layerID, peers...); err != nil {
-		return fmt.Errorf("PollLayerData: %w", err)
+		return fmt.Errorf("download layer data %v: %w", layerID, err)
 	}
 	dataLayer.Set(float64(layerID))
 	return nil

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -228,6 +228,8 @@ func (s *Syncer) IsBeaconSynced(epoch types.EpochID) bool {
 
 // Start starts the main sync loop that tries to sync data for every SyncInterval.
 func (s *Syncer) Start() {
+	// start syncer loop immediately
+	interval := time.Duration(0)
 	s.syncOnce.Do(func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		s.stop = cancel
@@ -241,7 +243,7 @@ func (s *Syncer) Start() {
 				case <-ctx.Done():
 					s.logger.WithContext(ctx).Info("stopping sync to shutdown")
 					return fmt.Errorf("shutdown context done: %w", ctx.Err())
-				case <-time.After(s.cfg.Interval):
+				case <-time.After(interval):
 					ok := s.synchronize(ctx)
 					if ok {
 						runSuccess.Inc()
@@ -249,6 +251,7 @@ func (s *Syncer) Start() {
 						runFail.Inc()
 					}
 				}
+				interval = s.cfg.Interval
 			}
 		})
 		s.logger.WithContext(ctx).Info("starting syncer layer processing loop")

--- a/tortoise/replay/replay_test.go
+++ b/tortoise/replay/replay_test.go
@@ -75,6 +75,8 @@ func TestReplayMainnet(t *testing.T) {
 	)
 	require.NoError(t, err)
 
+	finish := time.Since(start)
+
 	// run it after recovery, but before updates, as update may result in eviction from memory
 	runtime.GC()
 	var after runtime.MemStats
@@ -84,7 +86,7 @@ func TestReplayMainnet(t *testing.T) {
 
 	zlog.Info(
 		"initialized",
-		zap.Duration("duration", time.Since(start)),
+		zap.Duration("duration", finish),
 		zap.Stringer("mode", trtl.Mode()),
 		zap.Float64("heap", float64(after.HeapInuse-before.HeapInuse)/1024/1024),
 		zap.Array("updates", log.ArrayMarshalerFunc(func(encoder log.ArrayEncoder) error {

--- a/tortoise/replay/replay_test.go
+++ b/tortoise/replay/replay_test.go
@@ -51,13 +51,14 @@ func TestReplayMainnet(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	db, err := sql.Open(fmt.Sprintf("file:%s?mode=ro", *dbpath))
+	db, err := sql.Open(fmt.Sprintf("file:%s", *dbpath))
 	require.NoError(t, err)
 
 	start := time.Now()
 	atxsdata, err := atxsdata.Warm(db,
 		atxsdata.WithCapacityFromLayers(cfg.Tortoise.WindowSize, cfg.LayersPerEpoch),
 	)
+	zlog.Info("warmed atxsdata", zap.Duration("duration", time.Since(start)))
 	require.NoError(t, err)
 	trtl, err := tortoise.Recover(
 		context.Background(),


### PR DESCRIPTION
atxs
> // chunk size 2000 compressed 1032770 uncompressed 1915016 ratio 0.5393009771197734 duration 64.290344ms level 5

ballots
> // chunk size 5000 compressed 955630 uncompressed 1908897 ratio 0.5006189438193889 duration 54.430003ms level 5

generally chunk of 2MB get compressed by half. compressing each individual message doesn't do anything, some time it actually blows things up

#### ballots state without compression

```
sqlite> SELECT name, sum(pgsize) as sum FROM dbstat where name like "ballot%" group by name order by sum desc;
ballot_blobs|2510262272
ballots|850739200
ballots_by_layer_by_pubkey|271732736
ballots_by_atx_by_layer|270766080
ballot_opinions|112787456
sqlite> select count(*) from ballot_blobs;
5991539
sqlite> select (2510262272. / 5991539);
418.96785984369
```

around 420 bytes per ballot, including the ballot itself plus overhead of storing it in sqlite tree structure.

stats for common encoded values:
```
empty 207
with epoch data 244 // beacon + total eligibility count
single eligibility 325 // vrf proof
single support 347 // single vote
```

#### atxs state without compression

```
sqlite> SELECT name, sum(pgsize) as sum FROM dbstat where name like "atxs%" group by name order by sum desc;
atxs_blobs|8104210432
sqlite> select count(*) from atxs_blobs;
5932641
sqlite> select (8104210432. / 5932641);
1366.03755932645
```

around 1366 per atx

#### relative state growth with compression

note that we can do compression using chunks, as we never need to read full atxs/ballots, the actual data that we use for consensus is significantly smaller. the only reason why we need to store original blobs is for data availability, so that newly joined nodes can trust the network.

atx blobs will be around 40% of non-compressed. 
ballot blobs will be around 45% of non-compressed.
