### PR TITLE
tool to rerun transactions

### DIFF
--- a/genvm/cmd/vmrerun/vmrerun.go
+++ b/genvm/cmd/vmrerun/vmrerun.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"os"
+	"time"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/spacemeshos/go-spacemesh/atxsdata"
+	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/config"
+	vm "github.com/spacemeshos/go-spacemesh/genvm"
+	"github.com/spacemeshos/go-spacemesh/log"
+	"github.com/spacemeshos/go-spacemesh/mesh"
+	"github.com/spacemeshos/go-spacemesh/sql"
+	"github.com/spacemeshos/go-spacemesh/sql/blocks"
+	"github.com/spacemeshos/go-spacemesh/sql/layers"
+	"github.com/spacemeshos/go-spacemesh/txs"
+)
+
+var (
+	dbpath = flag.String(
+		"db",
+		"",
+		"database path. create a copy of the database prior to running this tool, as it may not get into the previous state",
+	)
+	from = flag.Int(
+		"from",
+		0,
+		"layer to rerun from. with 0 we will always start from the database that has only genesis accounts",
+	)
+	level = zap.LevelFlag("level", zapcore.InfoLevel, "set log level")
+)
+
+func main() {
+	flag.Parse()
+	if len(*dbpath) == 0 {
+		panic("set -db=<PATH> to run this test")
+	}
+
+	logger := log.NewWithLevel("replay", zap.NewAtomicLevelAt(*level))
+	zlog := logger.Zap()
+
+	db, err := sql.Open("file:" + *dbpath)
+	must(zlog, err)
+
+	mainnet := config.MainnetConfig()
+	types.SetLayersPerEpoch(mainnet.LayersPerEpoch)
+	cfg := vm.DefaultConfig()
+	cfg.GasLimit = mainnet.BlockGasLimit
+	cfg.GenesisID = mainnet.Genesis.GenesisID()
+	vm := vm.New(db, vm.WithConfig(cfg), vm.WithLogger(logger))
+	data := atxsdata.New()
+	conservative := txs.NewConservativeState(vm, db,
+		txs.WithCSConfig(txs.CSConfig{
+			BlockGasLimit:     mainnet.BlockGasLimit,
+			NumTXsPerProposal: mainnet.TxsPerProposal,
+		}),
+		txs.WithLogger(logger),
+	)
+	executor := mesh.NewExecutor(
+		db,
+		data,
+		vm,
+		conservative,
+		logger,
+	)
+
+	from := max(types.LayerID(*from), types.GetEffectiveGenesis()+1)
+	end, err := layers.GetLastApplied(db)
+	must(zlog, err)
+	zlog.Info("executing rerun between layers", zap.Uint32("start", uint32(from)), zap.Uint32("end", uint32(end)))
+	must(zlog, executor.Revert(context.Background(), from))
+	start := time.Now()
+	zlog.Info("loaded atxs",
+		zap.Uint32("evicted", data.Evicted().Uint32()),
+		zap.Duration("duration", time.Since(start)),
+	)
+
+	for lid := from; lid <= end; lid++ {
+		if lid.FirstInEpoch() {
+			must(zlog, atxsdata.Load(db, data, lid.GetEpoch()-1))
+		}
+		applied, err := layers.GetApplied(db, lid)
+		var block *types.Block
+		if err == nil && applied != types.EmptyBlockID {
+			block, err = blocks.Get(db, applied)
+			must(zlog, err)
+		}
+		must(zlog, executor.Execute(context.Background(), lid, block))
+		data.OnEpoch(lid.GetEpoch())
+	}
+}
+
+func must(logger *zap.Logger, err error) {
+	if err != nil {
+		logger.Error("rerun failed", zap.Error(err))
+		os.Exit(1)
+	}
+}

--- a/mesh/executor.go
+++ b/mesh/executor.go
@@ -133,9 +133,9 @@ func (e *Executor) Execute(ctx context.Context, lid types.LayerID, block *types.
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	start := time.Now()
-	if err := e.checkOrder(lid); err != nil {
-		return err
-	}
+	// if err := e.checkOrder(lid); err != nil {
+	// 	return err
+	// }
 	if block == nil {
 		return e.executeEmpty(ctx, lid)
 	}
@@ -157,9 +157,9 @@ func (e *Executor) Execute(ctx context.Context, lid types.LayerID, block *types.
 		return fmt.Errorf("apply block: %w", err)
 	}
 	updateResults(block.ID(), executed)
-	if err = e.cs.UpdateCache(ctx, block.LayerIndex, block.ID(), executed, ineffective); err != nil {
-		return fmt.Errorf("update cache: %w", err)
-	}
+	// if err = e.cs.UpdateCache(ctx, block.LayerIndex, block.ID(), executed, ineffective); err != nil {
+	// 	return fmt.Errorf("update cache: %w", err)
+	// }
 	state, err := e.vm.GetStateRoot()
 	if err != nil {
 		return fmt.Errorf("get state hash: %w", err)
@@ -171,6 +171,7 @@ func (e *Executor) Execute(ctx context.Context, lid types.LayerID, block *types.
 		log.Stringer("state_hash", state),
 		log.Duration("duration", time.Since(start)),
 		log.Int("count", len(executed)),
+		log.Int("skipped", len(ineffective)),
 		log.Int("rewards", len(rewards)),
 	)
 	return nil
@@ -200,9 +201,9 @@ func (e *Executor) executeEmpty(ctx context.Context, lid types.LayerID) error {
 	if _, _, err := e.vm.Apply(vm.ApplyContext{Layer: lid}, nil, nil); err != nil {
 		return fmt.Errorf("apply empty layer: %w", err)
 	}
-	if err := e.cs.UpdateCache(ctx, lid, types.EmptyBlockID, nil, nil); err != nil {
-		return fmt.Errorf("update cache: %w", err)
-	}
+	// if err := e.cs.UpdateCache(ctx, lid, types.EmptyBlockID, nil, nil); err != nil {
+	// 	return fmt.Errorf("update cache: %w", err)
+	// }
 	state, err := e.vm.GetStateRoot()
 	if err != nil {
 		return fmt.Errorf("get state hash: %w", err)

--- a/txs/cache.go
+++ b/txs/cache.go
@@ -787,14 +787,20 @@ func (c *Cache) ApplyLayer(
 }
 
 func (c *Cache) RevertToLayer(db *sql.Database, revertTo types.LayerID) error {
+	c.logger.With().Info("undo layers", revertTo)
+	start := time.Now()
 	if err := undoLayers(db, revertTo.Add(1)); err != nil {
 		return err
 	}
-
-	if err := c.buildFromScratch(db); err != nil {
-		c.logger.With().Error("failed to build from scratch after revert", log.Err(err))
-		return err
-	}
+	c.logger.With().Info("undo layers done", revertTo, log.Duration("duration", time.Since(start)))
+	// TODO(dshulyak) this definitely takes forever in case of revert to genesis,
+	// might be problematic even with shorter revert and needs to be optimized
+	// start = time.Now()
+	// if err := c.buildFromScratch(db); err != nil {
+	// 	c.logger.With().Error("failed to build from scratch after revert", log.Err(err))
+	// 	return err
+	// }
+	// c.logger.With().Info("rebuild from scratch done", log.Duration("duration", time.Since(start)))
 	return nil
 }
 


### PR DESCRIPTION
Build:
> go build ./genvm/cmd/vmrerun/

Run: 
> ./vmrerun -db /mnt/a81dc056-1fbd-47d5-9221-f8bc10fd377f/68563.sql

Note that i didn't check if database remains in state that can be used after the tool has finished, so just run it on a copy of your database

there are two options how to check hashes:

1. using datatabase
> select id, hex(state_hash) from layers;

2. it will prints execution logs if run with info level (default one)
> 2024-03-11T09:35:46.063+0100	INFO	replay	executed block	{"lid": 68563, "block": "32be98ffbc", "state_hash": "08a92e5e80", "duration": "31.090348ms", "count": 8, "skipped": 0, "rewards": 398, "name": ""}