### PR TITLE
[Merged by Bors] - Flaky test TestRewardService_List/coinbase

### DIFF
--- a/api/grpcserver/v2alpha1/reward_test.go
+++ b/api/grpcserver/v2alpha1/reward_test.go
@@ -23,7 +23,7 @@ func TestRewardService_List(t *testing.T) {
 	db := sql.InMemory()
 	ctx := context.Background()
 
-	gen := fixture.NewRewardsGenerator()
+	gen := fixture.NewRewardsGenerator().WithAddresses(100).WithUniqueCoinbase()
 	rwds := make([]types.Reward, 100)
 	for i := range rwds {
 		rwd := gen.Next()

--- a/common/fixture/rewards.go
+++ b/common/fixture/rewards.go
@@ -53,7 +53,7 @@ func (g *RewardsGenerator) WithLayers(start, n int) *RewardsGenerator {
 	return g
 }
 
-// WithUniqueCoinbase will generate every reward with different address
+// WithUniqueCoinbase will generate every reward with different address.
 func (g *RewardsGenerator) WithUniqueCoinbase() *RewardsGenerator {
 	g.UniqueCoinbase = true
 	return g


### PR DESCRIPTION
## Motivation

This change fixes problem with test flakiness.
RewardsGenerator was changed to generate rewards with unique coinbases to avoid problem with order of data between DB and generated list of rewards.
