### PR TITLE
[Merged by Bors] - Add node merge tool

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -26,6 +26,7 @@ jobs:
       uses: actions/checkout@v4
     - name: Build docker images
       run: |
+        export VERSION="${{ github.ref_name }}"
         make dockerbuild-go
         make dockerbuild-bs
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,10 @@ jobs:
         run: |
           make install
           make build VERSION=${{ github.ref_name }}
+      - name: Build node-merge
+        shell: bash
+        run: |
+          make node-merge VERSION=${{ github.ref_name }}
 
       - name: Create release archive
         shell: bash

--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,10 @@ get-libs: get-postrs-lib get-postrs-service
 
 get-profiler: get-postrs-profiler
 
+merge-nodes:
+	cd cmd/merge-nodes ; go build -o $(BIN_DIR)$@$(EXE) -ldflags "-X main.version=${VERSION}" .
+.PHONY: merge-nodes
+
 gen-p2p-identity:
 	cd cmd/gen-p2p-identity ; go build -o $(BIN_DIR)$@$(EXE) .
 .PHONY: gen-p2p-identity
@@ -149,7 +153,10 @@ list-versions:
 .PHONY: list-versions
 
 dockerbuild-go:
-	DOCKER_BUILDKIT=1 docker build -t go-spacemesh:$(SHA) -t $(DOCKER_HUB)/$(DOCKER_IMAGE_REPO):$(DOCKER_IMAGE_VERSION) .
+	DOCKER_BUILDKIT=1 docker build \
+		--build-arg VERSION=${VERSION} \
+		-t go-spacemesh:$(SHA) \
+		-t $(DOCKER_HUB)/$(DOCKER_IMAGE_REPO):$(DOCKER_IMAGE_VERSION) .
 .PHONY: dockerbuild-go
 
 dockerpush: dockerbuild-go dockerpush-only

--- a/api/grpcserver/grpcserver_test.go
+++ b/api/grpcserver/grpcserver_test.go
@@ -535,7 +535,7 @@ func TestNewLocalServer(t *testing.T) {
 			svc := NewNodeService(peerCounter, meshApi, genTime, syncer, "v0.0.0", "cafebabe")
 			grpcService, err := NewWithServices(cfg.PostListener, logger, cfg, []ServiceAPI{svc})
 			if tc.warn {
-				require.Equal(t, observedLogs.Len(), 1, "Expected a warning log")
+				require.Equal(t, 1, observedLogs.Len(), "Expected a warning log")
 				require.Equal(t, observedLogs.All()[0].Message, "unsecured grpc server is listening on a public IP address")
 				require.Equal(t, observedLogs.All()[0].ContextMap()["address"], tc.listener)
 				return

--- a/cmd/merge-nodes/internal/errors.go
+++ b/cmd/merge-nodes/internal/errors.go
@@ -1,0 +1,17 @@
+package internal
+
+import (
+	"errors"
+	"fmt"
+)
+
+var ErrSupervisedNode = errors.New("merging of supervised smeshing nodes is not supported")
+
+type ErrInvalidSchemaVersion struct {
+	Expected int
+	Actual   int
+}
+
+func (e ErrInvalidSchemaVersion) Error() string {
+	return fmt.Sprintf("invalid schema version: expected %d got %d", e.Expected, e.Actual)
+}

--- a/cmd/merge-nodes/internal/errors.go
+++ b/cmd/merge-nodes/internal/errors.go
@@ -2,16 +2,7 @@ package internal
 
 import (
 	"errors"
-	"fmt"
 )
 
 var ErrSupervisedNode = errors.New("merging of supervised smeshing nodes is not supported")
-
-type ErrInvalidSchemaVersion struct {
-	Expected int
-	Actual   int
-}
-
-func (e ErrInvalidSchemaVersion) Error() string {
-	return fmt.Sprintf("invalid schema version: expected %d got %d", e.Expected, e.Actual)
-}
+var ErrInvalidSchema = errors.New("database has an invalid schema version")

--- a/cmd/merge-nodes/internal/errors.go
+++ b/cmd/merge-nodes/internal/errors.go
@@ -4,5 +4,7 @@ import (
 	"errors"
 )
 
-var ErrSupervisedNode = errors.New("merging of supervised smeshing nodes is not supported")
-var ErrInvalidSchema = errors.New("database has an invalid schema version")
+var (
+	ErrSupervisedNode = errors.New("merging of supervised smeshing nodes is not supported")
+	ErrInvalidSchema  = errors.New("database has an invalid schema version")
+)

--- a/cmd/merge-nodes/internal/merge_action.go
+++ b/cmd/merge-nodes/internal/merge_action.go
@@ -53,19 +53,6 @@ func MergeDBs(ctx context.Context, dbLog *zap.Logger, from, to string) error {
 		if err != nil {
 			return err
 		}
-		// -------------
-		// this code should not be needed but without it, Test_MergeDBs_Successful_Empty_Dir fails on INSERT initial_post
-		// with sqlite.SQLITE_CONSTRAINT_PRIMARYKEY error
-		if err := dstDB.Close(); err != nil {
-			return fmt.Errorf("close target database: %w", err)
-		}
-		dstDB, err = localsql.Open("file:"+filepath.Join(to, localDbFile),
-			sql.WithLogger(dbLog),
-		)
-		if err != nil {
-			return err
-		}
-		// -------------
 	case err != nil:
 		return err
 	default:
@@ -152,16 +139,16 @@ func MergeDBs(ctx context.Context, dbLog *zap.Logger, from, to string) error {
 		if _, err := tx.Exec("ATTACH DATABASE ?1 AS srcDB;", enc, nil); err != nil {
 			return fmt.Errorf("attach source database: %w", err)
 		}
-		if _, err := tx.Exec("INSERT INTO initial_post SELECT * FROM srcDB.initial_post;", nil, nil); err != nil {
+		if _, err := tx.Exec("INSERT INTO main.initial_post SELECT * FROM srcDB.initial_post;", nil, nil); err != nil {
 			return fmt.Errorf("merge initial_post: %w", err)
 		}
-		if _, err := tx.Exec("INSERT INTO challenge SELECT * FROM srcDB.challenge;", nil, nil); err != nil {
+		if _, err := tx.Exec("INSERT INTO main.challenge SELECT * FROM srcDB.challenge;", nil, nil); err != nil {
 			return fmt.Errorf("merge challenge: %w", err)
 		}
-		if _, err := tx.Exec("INSERT INTO poet_registration SELECT * FROM srcDB.poet_registration;", nil, nil); err != nil {
+		if _, err := tx.Exec("INSERT INTO main.poet_registration SELECT * FROM srcDB.poet_registration;", nil, nil); err != nil {
 			return fmt.Errorf("merge poet_registration: %w", err)
 		}
-		if _, err := tx.Exec("INSERT INTO nipost SELECT * FROM srcDB.nipost;", nil, nil); err != nil {
+		if _, err := tx.Exec("INSERT INTO main.nipost SELECT * FROM srcDB.nipost;", nil, nil); err != nil {
 			return fmt.Errorf("merge nipost: %w", err)
 		}
 		return nil

--- a/cmd/merge-nodes/internal/merge_action.go
+++ b/cmd/merge-nodes/internal/merge_action.go
@@ -145,7 +145,9 @@ func MergeDBs(ctx context.Context, dbLog *zap.Logger, from, to string) error {
 		if _, err := tx.Exec("INSERT INTO main.challenge SELECT * FROM srcDB.challenge;", nil, nil); err != nil {
 			return fmt.Errorf("merge challenge: %w", err)
 		}
-		if _, err := tx.Exec("INSERT INTO main.poet_registration SELECT * FROM srcDB.poet_registration;", nil, nil); err != nil {
+		if _, err := tx.Exec(
+			"INSERT INTO main.poet_registration SELECT * FROM srcDB.poet_registration;", nil, nil,
+		); err != nil {
 			return fmt.Errorf("merge poet_registration: %w", err)
 		}
 		if _, err := tx.Exec("INSERT INTO main.nipost SELECT * FROM srcDB.nipost;", nil, nil); err != nil {

--- a/cmd/merge-nodes/internal/merge_action.go
+++ b/cmd/merge-nodes/internal/merge_action.go
@@ -1,0 +1,151 @@
+package internal
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/natefinch/atomic"
+	"go.uber.org/zap"
+
+	"github.com/spacemeshos/go-spacemesh/sql"
+	"github.com/spacemeshos/go-spacemesh/sql/localsql"
+)
+
+const (
+	localDbFile = "local.sql"
+
+	keyDir                  = "identities"
+	supervisedIDKeyFileName = "local.key"
+)
+
+type ErrInvalidSchemaVersion struct {
+	Expected int
+	Actual   int
+}
+
+func (e ErrInvalidSchemaVersion) Error() string {
+	return fmt.Sprintf("invalid schema version: expected %d got %d", e.Expected, e.Actual)
+}
+
+func MergeDBs(ctx context.Context, dbLog *zap.Logger, name, from, to string) error {
+	// Open the target database
+	dstDB, err := openDB(dbLog, to)
+	var schemaErr ErrInvalidSchemaVersion
+	switch {
+	case errors.As(err, &schemaErr):
+		dbLog.Error("target database has an invalid schema version - aborting merge",
+			zap.Int("db version", schemaErr.Actual),
+			zap.Int("expected version", schemaErr.Expected),
+		)
+		return err
+	case err != nil:
+		return err
+	}
+	defer dstDB.Close()
+
+	// Open the source database
+	srcDB, err := openDB(dbLog, from)
+	switch {
+	case errors.As(err, &schemaErr):
+		dbLog.Error("source database has an invalid schema version - aborting merge",
+			zap.Int("db version", schemaErr.Actual),
+			zap.Int("expected version", schemaErr.Expected),
+		)
+		return err
+	case err != nil:
+		return err
+	}
+	if err := srcDB.Close(); err != nil {
+		return fmt.Errorf("close source database: %w", err)
+	}
+
+	dstKey := filepath.Join(to, keyDir, name+".key")
+	if _, err := os.Stat(dstKey); err == nil {
+		return fmt.Errorf("destination key file %s: %w", dstKey, fs.ErrExist)
+	}
+
+	srcKey := filepath.Join(from, keyDir, supervisedIDKeyFileName)
+	f, err := os.Open(srcKey)
+	if err != nil {
+		return fmt.Errorf("open source key file %s: %w", srcKey, err)
+	}
+	defer f.Close()
+
+	dbLog.Info("merging databases", zap.String("from", from), zap.String("to", to))
+	err = dstDB.WithTx(ctx, func(tx *sql.Tx) error {
+		enc := func(stmt *sql.Statement) {
+			stmt.BindText(1, filepath.Join(from, localDbFile))
+		}
+		if _, err := tx.Exec("ATTACH DATABASE ?1 AS srcDB;", enc, nil); err != nil {
+			return fmt.Errorf("attach source database: %w", err)
+		}
+		if _, err := tx.Exec("INSERT INTO initial_post SELECT * FROM srcDB.initial_post;", nil, nil); err != nil {
+			return fmt.Errorf("merge initial_post: %w", err)
+		}
+		if _, err := tx.Exec("INSERT INTO challenge SELECT * FROM srcDB.challenge;", nil, nil); err != nil {
+			return fmt.Errorf("merge challenge: %w", err)
+		}
+		if _, err := tx.Exec("INSERT INTO poet_registration SELECT * FROM srcDB.poet_registration;", nil, nil); err != nil {
+			return fmt.Errorf("merge poet_registration: %w", err)
+		}
+		if _, err := tx.Exec("INSERT INTO nipost SELECT * FROM srcDB.nipost;", nil, nil); err != nil {
+			return fmt.Errorf("merge nipost: %w", err)
+		}
+		if err := atomic.WriteFile(dstKey, f); err != nil {
+			return fmt.Errorf("write destination key file %s: %w", dstKey, err)
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("start transaction: %w", err)
+	}
+
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("close source key file %s: %w", srcKey, err)
+	}
+	if err := dstDB.Close(); err != nil {
+		return fmt.Errorf("close target database: %w", err)
+	}
+	return nil
+}
+
+func openDB(dbLog *zap.Logger, path string) (*localsql.Database, error) {
+	dbPath := filepath.Join(path, localDbFile)
+	if _, err := os.Stat(dbPath); err != nil {
+		return nil, fmt.Errorf("open source database %s: %w", dbPath, err)
+	}
+
+	migrations, err := sql.LocalMigrations()
+	if err != nil {
+		return nil, fmt.Errorf("get local migrations: %w", err)
+	}
+
+	srcDB, err := localsql.Open("file:"+dbPath,
+		sql.WithLogger(dbLog),
+		sql.WithMigrations([]sql.Migration{}), // do not migrate database when opening
+	)
+	if err != nil {
+		return nil, fmt.Errorf("open source database %s: %w", dbPath, err)
+	}
+
+	// check if the source database has the right schema
+	var version int
+	_, err = srcDB.Exec("PRAGMA user_version;", nil, func(stmt *sql.Statement) bool {
+		version = stmt.ColumnInt(0)
+		return true
+	})
+	if err != nil {
+		return nil, fmt.Errorf("get source database schema for %s: %w", dbPath, err)
+	}
+	if version != len(migrations) {
+		return nil, ErrInvalidSchemaVersion{
+			Expected: len(migrations),
+			Actual:   version,
+		}
+	}
+	return srcDB, nil
+}

--- a/cmd/merge-nodes/internal/merge_action_test.go
+++ b/cmd/merge-nodes/internal/merge_action_test.go
@@ -31,7 +31,7 @@ func Test_MergeDBs_InvalidTargetScheme(t *testing.T) {
 	migrations, err := sql.LocalMigrations()
 	require.NoError(t, err)
 
-	_, err = localsql.Open("file:"+filepath.Join(tmpDst, "/local.sql"),
+	_, err = localsql.Open("file:"+filepath.Join(tmpDst, localDbFile),
 		sql.WithMigrations(migrations[:2]), // old DB
 	)
 	require.NoError(t, err)
@@ -59,7 +59,7 @@ func Test_MergeDBs_TargetIsSupervised(t *testing.T) {
 	err = os.WriteFile(filepath.Join(tmpDst, keyDir, supervisedIDKeyFileName), []byte("key"), 0o600)
 	require.NoError(t, err)
 
-	_, err = localsql.Open("file:" + filepath.Join(tmpDst, "/local.sql"))
+	_, err = localsql.Open("file:" + filepath.Join(tmpDst, localDbFile))
 	require.NoError(t, err)
 
 	err = MergeDBs(context.Background(), logger, "", tmpDst)
@@ -73,7 +73,7 @@ func Test_MergeDBs_InvalidSourcePath(t *testing.T) {
 	logger := zaptest.NewLogger(t)
 	tmpDst := t.TempDir()
 
-	_, err := localsql.Open("file:" + filepath.Join(tmpDst, "/local.sql"))
+	_, err := localsql.Open("file:" + filepath.Join(tmpDst, localDbFile))
 	require.NoError(t, err)
 
 	err = MergeDBs(context.Background(), logger, "/invalid/source/path", tmpDst)
@@ -89,11 +89,11 @@ func Test_MergeDBs_InvalidSourceScheme(t *testing.T) {
 	migrations, err := sql.LocalMigrations()
 	require.NoError(t, err)
 
-	_, err = localsql.Open("file:" + filepath.Join(tmpDst, "/local.sql"))
+	_, err = localsql.Open("file:" + filepath.Join(tmpDst, localDbFile))
 	require.NoError(t, err)
 
 	tmpSrc := t.TempDir()
-	_, err = localsql.Open("file:"+filepath.Join(tmpSrc, "/local.sql"),
+	_, err = localsql.Open("file:"+filepath.Join(tmpSrc, localDbFile),
 		sql.WithMigrations(migrations[:2]), // old DB
 	)
 	require.NoError(t, err)
@@ -115,7 +115,7 @@ func Test_MergeDBs_SourceIsSupervised(t *testing.T) {
 	logger := zap.New(observer)
 	tmpDst := t.TempDir()
 
-	_, err := localsql.Open("file:" + filepath.Join(tmpDst, "/local.sql"))
+	_, err := localsql.Open("file:" + filepath.Join(tmpDst, localDbFile))
 	require.NoError(t, err)
 
 	tmpSrc := t.TempDir()
@@ -126,7 +126,7 @@ func Test_MergeDBs_SourceIsSupervised(t *testing.T) {
 	err = os.WriteFile(filepath.Join(tmpSrc, keyDir, supervisedIDKeyFileName), []byte("key"), 0o600)
 	require.NoError(t, err)
 
-	_, err = localsql.Open("file:" + filepath.Join(tmpSrc, "/local.sql"))
+	_, err = localsql.Open("file:" + filepath.Join(tmpSrc, localDbFile))
 	require.NoError(t, err)
 
 	err = MergeDBs(context.Background(), logger, tmpSrc, tmpDst)
@@ -139,7 +139,7 @@ func Test_MergeDBs_SourceIsSupervised(t *testing.T) {
 func Test_MergeDBs_InvalidSourceKey(t *testing.T) {
 	tmpDst := t.TempDir()
 
-	_, err := localsql.Open("file:" + filepath.Join(tmpDst, "/local.sql"))
+	_, err := localsql.Open("file:" + filepath.Join(tmpDst, localDbFile))
 	require.NoError(t, err)
 
 	tmpSrc := t.TempDir()
@@ -149,7 +149,7 @@ func Test_MergeDBs_InvalidSourceKey(t *testing.T) {
 	err = os.WriteFile(filepath.Join(tmpSrc, keyDir, "invalid.key"), []byte("key"), 0o600)
 	require.NoError(t, err)
 
-	_, err = localsql.Open("file:" + filepath.Join(tmpSrc, "/local.sql"))
+	_, err = localsql.Open("file:" + filepath.Join(tmpSrc, localDbFile))
 	require.NoError(t, err)
 
 	err = MergeDBs(context.Background(), zaptest.NewLogger(t), tmpSrc, tmpDst)
@@ -165,7 +165,7 @@ func Test_MergeDBs_TargetKeyAlreadyExists(t *testing.T) {
 	err = os.WriteFile(filepath.Join(tmpDst, keyDir, "exists.key"), []byte("key"), 0o600)
 	require.NoError(t, err)
 
-	_, err = localsql.Open("file:" + filepath.Join(tmpDst, "/local.sql"))
+	_, err = localsql.Open("file:" + filepath.Join(tmpDst, localDbFile))
 	require.NoError(t, err)
 
 	tmpSrc := t.TempDir()
@@ -180,7 +180,7 @@ func Test_MergeDBs_TargetKeyAlreadyExists(t *testing.T) {
 	err = os.WriteFile(filepath.Join(tmpSrc, keyDir, "exists.key"), key, 0o600)
 	require.NoError(t, err)
 
-	_, err = localsql.Open("file:" + filepath.Join(tmpSrc, "/local.sql"))
+	_, err = localsql.Open("file:" + filepath.Join(tmpSrc, localDbFile))
 	require.NoError(t, err)
 
 	err = MergeDBs(context.Background(), zaptest.NewLogger(t), tmpSrc, tmpDst)
@@ -201,7 +201,7 @@ func Test_MergeDBs_Successful_Existing_Node(t *testing.T) {
 	err = os.WriteFile(filepath.Join(tmpDst, keyDir, "id1.key"), key, 0o600)
 	require.NoError(t, err)
 
-	dstDB, err := localsql.Open("file:" + filepath.Join(tmpDst, "/local.sql"))
+	dstDB, err := localsql.Open("file:" + filepath.Join(tmpDst, localDbFile))
 	require.NoError(t, err)
 
 	sig1Ch := &types.NIPostChallenge{
@@ -253,7 +253,7 @@ func Test_MergeDBs_Successful_Existing_Node(t *testing.T) {
 	err = os.WriteFile(filepath.Join(tmpSrc, keyDir, "id2.key"), key, 0o600)
 	require.NoError(t, err)
 
-	srcDB, err := localsql.Open("file:" + filepath.Join(tmpSrc, "/local.sql"))
+	srcDB, err := localsql.Open("file:" + filepath.Join(tmpSrc, localDbFile))
 	require.NoError(t, err)
 
 	cAtx := types.RandomATXID()
@@ -305,7 +305,7 @@ func Test_MergeDBs_Successful_Existing_Node(t *testing.T) {
 	require.FileExists(t, filepath.Join(tmpDst, keyDir, "id1.key"))
 	require.FileExists(t, filepath.Join(tmpDst, keyDir, "id2.key"))
 
-	dstDB, err = localsql.Open("file:" + filepath.Join(tmpDst, "/local.sql"))
+	dstDB, err = localsql.Open("file:" + filepath.Join(tmpDst, localDbFile))
 	require.NoError(t, err)
 
 	ch, err := nipost.Challenge(dstDB, sig1.NodeID())
@@ -350,7 +350,7 @@ func Test_MergeDBs_Successful_Empty_Dir(t *testing.T) {
 	err = os.WriteFile(filepath.Join(tmpSrc, keyDir, "id.key"), key, 0o600)
 	require.NoError(t, err)
 
-	srcDB, err := localsql.Open("file:" + filepath.Join(tmpSrc, "/local.sql"))
+	srcDB, err := localsql.Open("file:" + filepath.Join(tmpSrc, localDbFile))
 	require.NoError(t, err)
 
 	cAtx := types.RandomATXID()
@@ -401,7 +401,7 @@ func Test_MergeDBs_Successful_Empty_Dir(t *testing.T) {
 
 	require.FileExists(t, filepath.Join(tmpDst, keyDir, "id.key"))
 
-	dstDB, err := localsql.Open("file:" + filepath.Join(tmpDst, "/local.sql"))
+	dstDB, err := localsql.Open("file:" + filepath.Join(tmpDst, localDbFile))
 	require.NoError(t, err)
 
 	ch, err := nipost.Challenge(dstDB, sig.NodeID())

--- a/cmd/merge-nodes/internal/merge_action_test.go
+++ b/cmd/merge-nodes/internal/merge_action_test.go
@@ -81,7 +81,6 @@ func Test_MergeDBs_InvalidSourcePath(t *testing.T) {
 
 	err = MergeDBs(context.Background(), logger, "/invalid/source/path", tmpDst)
 	require.ErrorIs(t, err, fs.ErrNotExist)
-	require.ErrorContains(t, err, "/invalid/source/path")
 }
 
 func Test_MergeDBs_InvalidSourceScheme(t *testing.T) {

--- a/cmd/merge-nodes/internal/merge_action_test.go
+++ b/cmd/merge-nodes/internal/merge_action_test.go
@@ -1,0 +1,286 @@
+package internal
+
+import (
+	"context"
+	"encoding/hex"
+	"io/fs"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/signing"
+	"github.com/spacemeshos/go-spacemesh/sql"
+	"github.com/spacemeshos/go-spacemesh/sql/localsql"
+	"github.com/spacemeshos/go-spacemesh/sql/localsql/nipost"
+)
+
+func Test_MergeDBs_InvalidTargetPath(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+
+	err := MergeDBs(context.Background(), logger, "", "", "/invalid/target/path")
+	require.ErrorIs(t, err, fs.ErrNotExist)
+	require.ErrorContains(t, err, "/invalid/target/path")
+}
+
+func Test_MergeDBs_InvalidTargetScheme(t *testing.T) {
+	observer, observedLogs := observer.New(zapcore.WarnLevel)
+	logger := zap.New(observer)
+	tmpDst := t.TempDir()
+
+	migrations, err := sql.LocalMigrations()
+	require.NoError(t, err)
+
+	_, err = localsql.Open("file:"+filepath.Join(tmpDst, "/local.sql"),
+		sql.WithMigrations(migrations[:2]), // old DB
+	)
+	require.NoError(t, err)
+
+	err = MergeDBs(context.Background(), logger, "", "", tmpDst)
+	var schemaErr ErrInvalidSchemaVersion
+	require.ErrorAs(t, err, &schemaErr)
+	require.Equal(t, schemaErr.Expected, len(migrations))
+	require.Equal(t, schemaErr.Actual, 2)
+
+	require.Equal(t, 1, observedLogs.Len(), "Expected a warning log")
+	require.Equal(t, observedLogs.All()[0].Message, "target database has an invalid schema version - aborting merge")
+	require.Equal(t, observedLogs.All()[0].ContextMap()["db version"], int64(2))
+	require.Equal(t, observedLogs.All()[0].ContextMap()["expected version"], int64(len(migrations)))
+}
+
+func Test_MergeDBs_InvalidSourcePath(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+	tmpDst := t.TempDir()
+
+	_, err := localsql.Open("file:" + filepath.Join(tmpDst, "/local.sql"))
+	require.NoError(t, err)
+
+	err = MergeDBs(context.Background(), logger, "", "/invalid/source/path", tmpDst)
+	require.ErrorIs(t, err, fs.ErrNotExist)
+	require.ErrorContains(t, err, "/invalid/source/path")
+}
+
+func Test_MergeDBs_InvalidSourceScheme(t *testing.T) {
+	observer, observedLogs := observer.New(zapcore.WarnLevel)
+	logger := zap.New(observer)
+	tmpDst := t.TempDir()
+
+	migrations, err := sql.LocalMigrations()
+	require.NoError(t, err)
+
+	_, err = localsql.Open("file:" + filepath.Join(tmpDst, "/local.sql"))
+	require.NoError(t, err)
+
+	tmpSrc := t.TempDir()
+	_, err = localsql.Open("file:"+filepath.Join(tmpSrc, "/local.sql"),
+		sql.WithMigrations(migrations[:2]), // old DB
+	)
+	require.NoError(t, err)
+
+	err = MergeDBs(context.Background(), logger, "", tmpSrc, tmpDst)
+	var schemaErr ErrInvalidSchemaVersion
+	require.ErrorAs(t, err, &schemaErr)
+	require.Equal(t, schemaErr.Expected, len(migrations))
+	require.Equal(t, schemaErr.Actual, 2)
+
+	require.Equal(t, 1, observedLogs.Len(), "Expected a warning log")
+	require.Equal(t, observedLogs.All()[0].Message, "source database has an invalid schema version - aborting merge")
+	require.Equal(t, observedLogs.All()[0].ContextMap()["db version"], int64(2))
+	require.Equal(t, observedLogs.All()[0].ContextMap()["expected version"], int64(len(migrations)))
+}
+
+func Test_MergeDBs_MissingSourceKey(t *testing.T) {
+	tmpDst := t.TempDir()
+
+	_, err := localsql.Open("file:" + filepath.Join(tmpDst, "/local.sql"))
+	require.NoError(t, err)
+
+	tmpSrc := t.TempDir()
+	_, err = localsql.Open("file:" + filepath.Join(tmpSrc, "/local.sql"))
+	require.NoError(t, err)
+
+	err = MergeDBs(context.Background(), zaptest.NewLogger(t), "", tmpSrc, tmpDst)
+	require.ErrorIs(t, err, fs.ErrNotExist)
+	require.ErrorContains(t, err, "open source key file")
+}
+
+func Test_MergeDBs_TargetKeyAlreadyExists(t *testing.T) {
+	tmpDst := t.TempDir()
+	err := os.MkdirAll(filepath.Join(tmpDst, keyDir), 0o755)
+	require.NoError(t, err)
+
+	err = os.WriteFile(filepath.Join(tmpDst, keyDir, "exists.key"), []byte("key"), 0o644)
+	require.NoError(t, err)
+
+	_, err = localsql.Open("file:" + filepath.Join(tmpDst, "/local.sql"))
+	require.NoError(t, err)
+
+	tmpSrc := t.TempDir()
+	err = os.MkdirAll(filepath.Join(tmpSrc, keyDir), 0o755)
+	require.NoError(t, err)
+
+	err = os.WriteFile(filepath.Join(tmpSrc, keyDir, supervisedIDKeyFileName), []byte("key"), 0o644)
+	require.NoError(t, err)
+
+	_, err = localsql.Open("file:" + filepath.Join(tmpSrc, "/local.sql"))
+	require.NoError(t, err)
+
+	err = MergeDBs(context.Background(), zaptest.NewLogger(t), "exists", tmpSrc, tmpDst)
+	require.ErrorIs(t, err, fs.ErrExist)
+	require.ErrorContains(t, err, "destination key file")
+}
+
+func Test_MergeDBs_Successful(t *testing.T) {
+	tmpDst := t.TempDir()
+	err := os.MkdirAll(filepath.Join(tmpDst, keyDir), 0o700)
+	require.NoError(t, err)
+
+	sig1, err := signing.NewEdSigner()
+	require.NoError(t, err)
+
+	dst := make([]byte, hex.EncodedLen(len(sig1.PrivateKey())))
+	hex.Encode(dst, sig1.PrivateKey())
+	err = os.WriteFile(filepath.Join(tmpDst, keyDir, supervisedIDKeyFileName), dst, 0o600)
+	require.NoError(t, err)
+
+	dstDB, err := localsql.Open("file:" + filepath.Join(tmpDst, "/local.sql"))
+	require.NoError(t, err)
+
+	sig1Ch := &types.NIPostChallenge{
+		PublishEpoch:   types.EpochID(rand.Uint32()),
+		Sequence:       rand.Uint64(),
+		PrevATXID:      types.RandomATXID(),
+		PositioningATX: types.RandomATXID(),
+	}
+	err = nipost.AddChallenge(dstDB, sig1.NodeID(), sig1Ch)
+	require.NoError(t, err)
+
+	sig1Post := nipost.Post{
+		Nonce:    rand.Uint32(),
+		Pow:      rand.Uint64(),
+		Indices:  types.RandomBytes(32),
+		NumUnits: rand.Uint32(),
+	}
+	err = nipost.AddInitialPost(dstDB, sig1.NodeID(), sig1Post)
+	require.NoError(t, err)
+
+	sig1Poet1 := nipost.PoETRegistration{
+		ChallengeHash: sig1Ch.Hash(),
+		Address:       "http://poet1.spacemesh.io",
+		RoundID:       "1",
+		RoundEnd:      time.Now().Round(time.Second),
+	}
+	sig1Poet2 := nipost.PoETRegistration{
+		ChallengeHash: sig1Ch.Hash(),
+		Address:       "http://poet2.spacemesh.io",
+		RoundID:       "10",
+		RoundEnd:      time.Now().Round(time.Second),
+	}
+	err = nipost.AddPoetRegistration(dstDB, sig1.NodeID(), sig1Poet1)
+	require.NoError(t, err)
+	err = nipost.AddPoetRegistration(dstDB, sig1.NodeID(), sig1Poet2)
+	require.NoError(t, err)
+
+	require.NoError(t, dstDB.Close())
+
+	tmpSrc := t.TempDir()
+	err = os.MkdirAll(filepath.Join(tmpSrc, keyDir), 0o700)
+	require.NoError(t, err)
+
+	sig2, err := signing.NewEdSigner()
+	require.NoError(t, err)
+
+	dst = make([]byte, hex.EncodedLen(len(sig2.PrivateKey())))
+	hex.Encode(dst, sig2.PrivateKey())
+	err = os.WriteFile(filepath.Join(tmpSrc, keyDir, supervisedIDKeyFileName), dst, 0o600)
+	require.NoError(t, err)
+
+	srcDB, err := localsql.Open("file:" + filepath.Join(tmpSrc, "/local.sql"))
+	require.NoError(t, err)
+
+	cAtx := types.RandomATXID()
+	sig2Ch := &types.NIPostChallenge{
+		PublishEpoch:   types.EpochID(rand.Uint32()),
+		Sequence:       rand.Uint64(),
+		PositioningATX: types.RandomATXID(),
+		CommitmentATX:  &cAtx,
+		InitialPost: &types.Post{
+			Nonce:   rand.Uint32(),
+			Pow:     rand.Uint64(),
+			Indices: types.RandomBytes(32),
+		},
+	}
+	err = nipost.AddChallenge(srcDB, sig2.NodeID(), sig2Ch)
+	require.NoError(t, err)
+
+	sig2Post := nipost.Post{
+		Nonce:    rand.Uint32(),
+		Pow:      rand.Uint64(),
+		Indices:  types.RandomBytes(32),
+		NumUnits: rand.Uint32(),
+	}
+	err = nipost.AddInitialPost(srcDB, sig2.NodeID(), sig2Post)
+	require.NoError(t, err)
+
+	sig2Poet1 := nipost.PoETRegistration{
+		ChallengeHash: sig1Ch.Hash(),
+		Address:       "http://poet1.spacemesh.io",
+		RoundID:       "1",
+		RoundEnd:      time.Now().Round(time.Second),
+	}
+	sig2Poet2 := nipost.PoETRegistration{
+		ChallengeHash: sig1Ch.Hash(),
+		Address:       "http://poet2.spacemesh.io",
+		RoundID:       "10",
+		RoundEnd:      time.Now().Round(time.Second),
+	}
+	err = nipost.AddPoetRegistration(srcDB, sig2.NodeID(), sig2Poet1)
+	require.NoError(t, err)
+	err = nipost.AddPoetRegistration(srcDB, sig2.NodeID(), sig2Poet2)
+	require.NoError(t, err)
+
+	require.NoError(t, srcDB.Close())
+
+	err = MergeDBs(context.Background(), zaptest.NewLogger(t), "otherNode", tmpSrc, tmpDst)
+	require.NoError(t, err)
+
+	require.FileExists(t, filepath.Join(tmpDst, keyDir, "otherNode.key"))
+	require.FileExists(t, filepath.Join(tmpDst, keyDir, supervisedIDKeyFileName))
+
+	dstDB, err = localsql.Open("file:" + filepath.Join(tmpDst, "/local.sql"))
+	require.NoError(t, err)
+
+	ch, err := nipost.Challenge(dstDB, sig1.NodeID())
+	require.NoError(t, err)
+	require.Equal(t, sig1Ch, ch)
+
+	post, err := nipost.InitialPost(dstDB, sig1.NodeID())
+	require.NoError(t, err)
+	require.Equal(t, sig1Post, *post)
+
+	poet1, err := nipost.PoetRegistrations(dstDB, sig1.NodeID())
+	require.NoError(t, err)
+	require.Equal(t, poet1[0], sig1Poet1)
+	require.Equal(t, poet1[1], sig1Poet2)
+
+	ch, err = nipost.Challenge(dstDB, sig2.NodeID())
+	require.NoError(t, err)
+	require.Equal(t, sig2Ch, ch)
+
+	post, err = nipost.InitialPost(dstDB, sig2.NodeID())
+	require.NoError(t, err)
+	require.Equal(t, sig2Post, *post)
+
+	poet2, err := nipost.PoetRegistrations(dstDB, sig2.NodeID())
+	require.NoError(t, err)
+	require.Equal(t, poet2[0], sig2Poet1)
+	require.Equal(t, poet2[1], sig2Poet2)
+}

--- a/cmd/merge-nodes/internal/merge_action_test.go
+++ b/cmd/merge-nodes/internal/merge_action_test.go
@@ -23,14 +23,6 @@ import (
 	"github.com/spacemeshos/go-spacemesh/sql/localsql/nipost"
 )
 
-func Test_MergeDBs_InvalidTargetPath(t *testing.T) {
-	logger := zaptest.NewLogger(t)
-
-	err := MergeDBs(context.Background(), logger, "", "", "/invalid/target/path")
-	require.ErrorIs(t, err, fs.ErrNotExist)
-	require.ErrorContains(t, err, "/invalid/target/path")
-}
-
 func Test_MergeDBs_InvalidTargetScheme(t *testing.T) {
 	observer, observedLogs := observer.New(zapcore.WarnLevel)
 	logger := zap.New(observer)
@@ -44,7 +36,7 @@ func Test_MergeDBs_InvalidTargetScheme(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	err = MergeDBs(context.Background(), logger, "", "", tmpDst)
+	err = MergeDBs(context.Background(), logger, "", tmpDst)
 	var schemaErr ErrInvalidSchemaVersion
 	require.ErrorAs(t, err, &schemaErr)
 	require.Equal(t, schemaErr.Expected, len(migrations))
@@ -56,6 +48,27 @@ func Test_MergeDBs_InvalidTargetScheme(t *testing.T) {
 	require.Equal(t, observedLogs.All()[0].ContextMap()["expected version"], int64(len(migrations)))
 }
 
+func Test_MergeDBs_TargetIsSupervised(t *testing.T) {
+	observer, observedLogs := observer.New(zapcore.WarnLevel)
+	logger := zap.New(observer)
+	tmpDst := t.TempDir()
+
+	err := os.MkdirAll(filepath.Join(tmpDst, keyDir), 0o700)
+	require.NoError(t, err)
+
+	err = os.WriteFile(filepath.Join(tmpDst, keyDir, supervisedIDKeyFileName), []byte("key"), 0o600)
+	require.NoError(t, err)
+
+	_, err = localsql.Open("file:" + filepath.Join(tmpDst, "/local.sql"))
+	require.NoError(t, err)
+
+	err = MergeDBs(context.Background(), logger, "", tmpDst)
+	require.ErrorIs(t, err, ErrSupervisedNode)
+
+	require.Equal(t, 1, observedLogs.Len(), "Expected a warning log")
+	require.Contains(t, observedLogs.All()[0].Message, "target appears to be a supervised node")
+}
+
 func Test_MergeDBs_InvalidSourcePath(t *testing.T) {
 	logger := zaptest.NewLogger(t)
 	tmpDst := t.TempDir()
@@ -63,7 +76,7 @@ func Test_MergeDBs_InvalidSourcePath(t *testing.T) {
 	_, err := localsql.Open("file:" + filepath.Join(tmpDst, "/local.sql"))
 	require.NoError(t, err)
 
-	err = MergeDBs(context.Background(), logger, "", "/invalid/source/path", tmpDst)
+	err = MergeDBs(context.Background(), logger, "/invalid/source/path", tmpDst)
 	require.ErrorIs(t, err, fs.ErrNotExist)
 	require.ErrorContains(t, err, "/invalid/source/path")
 }
@@ -85,7 +98,7 @@ func Test_MergeDBs_InvalidSourceScheme(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	err = MergeDBs(context.Background(), logger, "", tmpSrc, tmpDst)
+	err = MergeDBs(context.Background(), logger, tmpSrc, tmpDst)
 	var schemaErr ErrInvalidSchemaVersion
 	require.ErrorAs(t, err, &schemaErr)
 	require.Equal(t, schemaErr.Expected, len(migrations))
@@ -97,48 +110,85 @@ func Test_MergeDBs_InvalidSourceScheme(t *testing.T) {
 	require.Equal(t, observedLogs.All()[0].ContextMap()["expected version"], int64(len(migrations)))
 }
 
-func Test_MergeDBs_MissingSourceKey(t *testing.T) {
+func Test_MergeDBs_SourceIsSupervised(t *testing.T) {
+	observer, observedLogs := observer.New(zapcore.WarnLevel)
+	logger := zap.New(observer)
 	tmpDst := t.TempDir()
 
 	_, err := localsql.Open("file:" + filepath.Join(tmpDst, "/local.sql"))
 	require.NoError(t, err)
 
 	tmpSrc := t.TempDir()
+
+	err = os.MkdirAll(filepath.Join(tmpSrc, keyDir), 0o700)
+	require.NoError(t, err)
+
+	err = os.WriteFile(filepath.Join(tmpSrc, keyDir, supervisedIDKeyFileName), []byte("key"), 0o600)
+	require.NoError(t, err)
+
 	_, err = localsql.Open("file:" + filepath.Join(tmpSrc, "/local.sql"))
 	require.NoError(t, err)
 
-	err = MergeDBs(context.Background(), zaptest.NewLogger(t), "", tmpSrc, tmpDst)
-	require.ErrorIs(t, err, fs.ErrNotExist)
-	require.ErrorContains(t, err, "open source key file")
+	err = MergeDBs(context.Background(), logger, tmpSrc, tmpDst)
+	require.ErrorIs(t, err, ErrSupervisedNode)
+
+	require.Equal(t, 1, observedLogs.Len(), "Expected a warning log")
+	require.Contains(t, observedLogs.All()[0].Message, "source appears to be a supervised node")
+}
+
+func Test_MergeDBs_InvalidSourceKey(t *testing.T) {
+	tmpDst := t.TempDir()
+
+	_, err := localsql.Open("file:" + filepath.Join(tmpDst, "/local.sql"))
+	require.NoError(t, err)
+
+	tmpSrc := t.TempDir()
+	err = os.MkdirAll(filepath.Join(tmpSrc, keyDir), 0o700)
+	require.NoError(t, err)
+
+	err = os.WriteFile(filepath.Join(tmpSrc, keyDir, "invalid.key"), []byte("key"), 0o600)
+	require.NoError(t, err)
+
+	_, err = localsql.Open("file:" + filepath.Join(tmpSrc, "/local.sql"))
+	require.NoError(t, err)
+
+	err = MergeDBs(context.Background(), zaptest.NewLogger(t), tmpSrc, tmpDst)
+	require.ErrorContains(t, err, "not a valid key file")
+	require.ErrorContains(t, err, "invalid.key")
 }
 
 func Test_MergeDBs_TargetKeyAlreadyExists(t *testing.T) {
 	tmpDst := t.TempDir()
-	err := os.MkdirAll(filepath.Join(tmpDst, keyDir), 0o755)
+	err := os.MkdirAll(filepath.Join(tmpDst, keyDir), 0o700)
 	require.NoError(t, err)
 
-	err = os.WriteFile(filepath.Join(tmpDst, keyDir, "exists.key"), []byte("key"), 0o644)
+	err = os.WriteFile(filepath.Join(tmpDst, keyDir, "exists.key"), []byte("key"), 0o600)
 	require.NoError(t, err)
 
 	_, err = localsql.Open("file:" + filepath.Join(tmpDst, "/local.sql"))
 	require.NoError(t, err)
 
 	tmpSrc := t.TempDir()
-	err = os.MkdirAll(filepath.Join(tmpSrc, keyDir), 0o755)
+	err = os.MkdirAll(filepath.Join(tmpSrc, keyDir), 0o700)
 	require.NoError(t, err)
 
-	err = os.WriteFile(filepath.Join(tmpSrc, keyDir, supervisedIDKeyFileName), []byte("key"), 0o644)
+	signer, err := signing.NewEdSigner()
+	require.NoError(t, err)
+
+	key := make([]byte, hex.EncodedLen(len(signer.PrivateKey())))
+	hex.Encode(key, signer.PrivateKey())
+	err = os.WriteFile(filepath.Join(tmpSrc, keyDir, "exists.key"), key, 0o600)
 	require.NoError(t, err)
 
 	_, err = localsql.Open("file:" + filepath.Join(tmpSrc, "/local.sql"))
 	require.NoError(t, err)
 
-	err = MergeDBs(context.Background(), zaptest.NewLogger(t), "exists", tmpSrc, tmpDst)
+	err = MergeDBs(context.Background(), zaptest.NewLogger(t), tmpSrc, tmpDst)
 	require.ErrorIs(t, err, fs.ErrExist)
-	require.ErrorContains(t, err, "destination key file")
+	require.ErrorContains(t, err, "exists.key")
 }
 
-func Test_MergeDBs_Successful(t *testing.T) {
+func Test_MergeDBs_Successful_Existing_Node(t *testing.T) {
 	tmpDst := t.TempDir()
 	err := os.MkdirAll(filepath.Join(tmpDst, keyDir), 0o700)
 	require.NoError(t, err)
@@ -146,9 +196,9 @@ func Test_MergeDBs_Successful(t *testing.T) {
 	sig1, err := signing.NewEdSigner()
 	require.NoError(t, err)
 
-	dst := make([]byte, hex.EncodedLen(len(sig1.PrivateKey())))
-	hex.Encode(dst, sig1.PrivateKey())
-	err = os.WriteFile(filepath.Join(tmpDst, keyDir, supervisedIDKeyFileName), dst, 0o600)
+	key := make([]byte, hex.EncodedLen(len(sig1.PrivateKey())))
+	hex.Encode(key, sig1.PrivateKey())
+	err = os.WriteFile(filepath.Join(tmpDst, keyDir, "id1.key"), key, 0o600)
 	require.NoError(t, err)
 
 	dstDB, err := localsql.Open("file:" + filepath.Join(tmpDst, "/local.sql"))
@@ -198,9 +248,9 @@ func Test_MergeDBs_Successful(t *testing.T) {
 	sig2, err := signing.NewEdSigner()
 	require.NoError(t, err)
 
-	dst = make([]byte, hex.EncodedLen(len(sig2.PrivateKey())))
-	hex.Encode(dst, sig2.PrivateKey())
-	err = os.WriteFile(filepath.Join(tmpSrc, keyDir, supervisedIDKeyFileName), dst, 0o600)
+	key = make([]byte, hex.EncodedLen(len(sig2.PrivateKey())))
+	hex.Encode(key, sig2.PrivateKey())
+	err = os.WriteFile(filepath.Join(tmpSrc, keyDir, "id2.key"), key, 0o600)
 	require.NoError(t, err)
 
 	srcDB, err := localsql.Open("file:" + filepath.Join(tmpSrc, "/local.sql"))
@@ -231,13 +281,13 @@ func Test_MergeDBs_Successful(t *testing.T) {
 	require.NoError(t, err)
 
 	sig2Poet1 := nipost.PoETRegistration{
-		ChallengeHash: sig1Ch.Hash(),
+		ChallengeHash: sig2Ch.Hash(),
 		Address:       "http://poet1.spacemesh.io",
 		RoundID:       "1",
 		RoundEnd:      time.Now().Round(time.Second),
 	}
 	sig2Poet2 := nipost.PoETRegistration{
-		ChallengeHash: sig1Ch.Hash(),
+		ChallengeHash: sig2Ch.Hash(),
 		Address:       "http://poet2.spacemesh.io",
 		RoundID:       "10",
 		RoundEnd:      time.Now().Round(time.Second),
@@ -249,11 +299,11 @@ func Test_MergeDBs_Successful(t *testing.T) {
 
 	require.NoError(t, srcDB.Close())
 
-	err = MergeDBs(context.Background(), zaptest.NewLogger(t), "otherNode", tmpSrc, tmpDst)
+	err = MergeDBs(context.Background(), zaptest.NewLogger(t), tmpSrc, tmpDst)
 	require.NoError(t, err)
 
-	require.FileExists(t, filepath.Join(tmpDst, keyDir, "otherNode.key"))
-	require.FileExists(t, filepath.Join(tmpDst, keyDir, supervisedIDKeyFileName))
+	require.FileExists(t, filepath.Join(tmpDst, keyDir, "id1.key"))
+	require.FileExists(t, filepath.Join(tmpDst, keyDir, "id2.key"))
 
 	dstDB, err = localsql.Open("file:" + filepath.Join(tmpDst, "/local.sql"))
 	require.NoError(t, err)
@@ -283,4 +333,87 @@ func Test_MergeDBs_Successful(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, poet2[0], sig2Poet1)
 	require.Equal(t, poet2[1], sig2Poet2)
+}
+
+func Test_MergeDBs_Successful_Empty_Dir(t *testing.T) {
+	tmpDst := t.TempDir()
+
+	tmpSrc := t.TempDir()
+	err := os.MkdirAll(filepath.Join(tmpSrc, keyDir), 0o700)
+	require.NoError(t, err)
+
+	sig, err := signing.NewEdSigner()
+	require.NoError(t, err)
+
+	key := make([]byte, hex.EncodedLen(len(sig.PrivateKey())))
+	hex.Encode(key, sig.PrivateKey())
+	err = os.WriteFile(filepath.Join(tmpSrc, keyDir, "id.key"), key, 0o600)
+	require.NoError(t, err)
+
+	srcDB, err := localsql.Open("file:" + filepath.Join(tmpSrc, "/local.sql"))
+	require.NoError(t, err)
+
+	cAtx := types.RandomATXID()
+	sigCh := &types.NIPostChallenge{
+		PublishEpoch:   types.EpochID(rand.Uint32()),
+		Sequence:       rand.Uint64(),
+		PositioningATX: types.RandomATXID(),
+		CommitmentATX:  &cAtx,
+		InitialPost: &types.Post{
+			Nonce:   rand.Uint32(),
+			Pow:     rand.Uint64(),
+			Indices: types.RandomBytes(32),
+		},
+	}
+	err = nipost.AddChallenge(srcDB, sig.NodeID(), sigCh)
+	require.NoError(t, err)
+
+	sigPost := nipost.Post{
+		Nonce:    rand.Uint32(),
+		Pow:      rand.Uint64(),
+		Indices:  types.RandomBytes(32),
+		NumUnits: rand.Uint32(),
+	}
+	err = nipost.AddInitialPost(srcDB, sig.NodeID(), sigPost)
+	require.NoError(t, err)
+
+	sigPoet1 := nipost.PoETRegistration{
+		ChallengeHash: sigCh.Hash(),
+		Address:       "http://poet1.spacemesh.io",
+		RoundID:       "1",
+		RoundEnd:      time.Now().Round(time.Second),
+	}
+	sigPoet2 := nipost.PoETRegistration{
+		ChallengeHash: sigCh.Hash(),
+		Address:       "http://poet2.spacemesh.io",
+		RoundID:       "10",
+		RoundEnd:      time.Now().Round(time.Second),
+	}
+	err = nipost.AddPoetRegistration(srcDB, sig.NodeID(), sigPoet1)
+	require.NoError(t, err)
+	err = nipost.AddPoetRegistration(srcDB, sig.NodeID(), sigPoet2)
+	require.NoError(t, err)
+
+	require.NoError(t, srcDB.Close())
+
+	err = MergeDBs(context.Background(), zaptest.NewLogger(t), tmpSrc, tmpDst)
+	require.NoError(t, err)
+
+	require.FileExists(t, filepath.Join(tmpDst, keyDir, "id.key"))
+
+	dstDB, err := localsql.Open("file:" + filepath.Join(tmpDst, "/local.sql"))
+	require.NoError(t, err)
+
+	ch, err := nipost.Challenge(dstDB, sig.NodeID())
+	require.NoError(t, err)
+	require.Equal(t, sigCh, ch)
+
+	post, err := nipost.InitialPost(dstDB, sig.NodeID())
+	require.NoError(t, err)
+	require.Equal(t, sigPost, *post)
+
+	poet, err := nipost.PoetRegistrations(dstDB, sig.NodeID())
+	require.NoError(t, err)
+	require.Equal(t, poet[0], sigPoet1)
+	require.Equal(t, poet[1], sigPoet2)
 }

--- a/cmd/merge-nodes/internal/merge_action_test.go
+++ b/cmd/merge-nodes/internal/merge_action_test.go
@@ -24,8 +24,6 @@ import (
 )
 
 func Test_MergeDBs_InvalidTargetScheme(t *testing.T) {
-	observer, observedLogs := observer.New(zapcore.WarnLevel)
-	logger := zap.New(observer)
 	tmpDst := t.TempDir()
 
 	migrations, err := sql.LocalMigrations()
@@ -37,11 +35,9 @@ func Test_MergeDBs_InvalidTargetScheme(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, db.Close())
 
-	err = MergeDBs(context.Background(), logger, "", tmpDst)
+	err = MergeDBs(context.Background(), zaptest.NewLogger(t), "", tmpDst)
 	require.ErrorIs(t, err, ErrInvalidSchema)
-
-	require.Equal(t, 1, observedLogs.Len(), "Expected a warning log")
-	require.Equal(t, observedLogs.All()[0].Message, "target database has an invalid schema version - aborting merge")
+	require.ErrorContains(t, err, "target database")
 }
 
 func Test_MergeDBs_TargetIsSupervised(t *testing.T) {
@@ -79,8 +75,6 @@ func Test_MergeDBs_InvalidSourcePath(t *testing.T) {
 }
 
 func Test_MergeDBs_InvalidSourceScheme(t *testing.T) {
-	observer, observedLogs := observer.New(zapcore.WarnLevel)
-	logger := zap.New(observer)
 	tmpDst := t.TempDir()
 
 	migrations, err := sql.LocalMigrations()
@@ -97,10 +91,9 @@ func Test_MergeDBs_InvalidSourceScheme(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, db.Close())
 
-	err = MergeDBs(context.Background(), logger, tmpSrc, tmpDst)
+	err = MergeDBs(context.Background(), zaptest.NewLogger(t), tmpSrc, tmpDst)
 	require.ErrorIs(t, err, ErrInvalidSchema)
-
-	require.Equal(t, 1, observedLogs.Len(), "Expected a warning log")
+	require.ErrorContains(t, err, "source database")
 }
 
 func Test_MergeDBs_SourceIsSupervised(t *testing.T) {

--- a/cmd/merge-nodes/internal/merge_action_test.go
+++ b/cmd/merge-nodes/internal/merge_action_test.go
@@ -38,15 +38,10 @@ func Test_MergeDBs_InvalidTargetScheme(t *testing.T) {
 	require.NoError(t, db.Close())
 
 	err = MergeDBs(context.Background(), logger, "", tmpDst)
-	var schemaErr ErrInvalidSchemaVersion
-	require.ErrorAs(t, err, &schemaErr)
-	require.Equal(t, schemaErr.Expected, len(migrations))
-	require.Equal(t, schemaErr.Actual, 2)
+	require.ErrorIs(t, err, ErrInvalidSchema)
 
 	require.Equal(t, 1, observedLogs.Len(), "Expected a warning log")
 	require.Equal(t, observedLogs.All()[0].Message, "target database has an invalid schema version - aborting merge")
-	require.Equal(t, observedLogs.All()[0].ContextMap()["db version"], int64(2))
-	require.Equal(t, observedLogs.All()[0].ContextMap()["expected version"], int64(len(migrations)))
 }
 
 func Test_MergeDBs_TargetIsSupervised(t *testing.T) {
@@ -103,15 +98,9 @@ func Test_MergeDBs_InvalidSourceScheme(t *testing.T) {
 	require.NoError(t, db.Close())
 
 	err = MergeDBs(context.Background(), logger, tmpSrc, tmpDst)
-	var schemaErr ErrInvalidSchemaVersion
-	require.ErrorAs(t, err, &schemaErr)
-	require.Equal(t, schemaErr.Expected, len(migrations))
-	require.Equal(t, schemaErr.Actual, 2)
+	require.ErrorIs(t, err, ErrInvalidSchema)
 
 	require.Equal(t, 1, observedLogs.Len(), "Expected a warning log")
-	require.Equal(t, observedLogs.All()[0].Message, "source database has an invalid schema version - aborting merge")
-	require.Equal(t, observedLogs.All()[0].ContextMap()["db version"], int64(2))
-	require.Equal(t, observedLogs.All()[0].ContextMap()["expected version"], int64(len(migrations)))
 }
 
 func Test_MergeDBs_SourceIsSupervised(t *testing.T) {

--- a/cmd/merge-nodes/main.go
+++ b/cmd/merge-nodes/main.go
@@ -15,26 +15,25 @@ var version string
 
 func main() {
 	app := &cli.App{
-		Name:    "Spacemesh Node Merger",
-		Usage:   "Merge two or more Spacemesh nodes into one",
+		Name: "Spacemesh Node Merger",
+		Usage: "Merge identities of two Spacemesh nodes into one.\n" +
+			"The `from` node will be merged into the `to` node, leaving the `from` node untouched.\n" +
+			"The `to` node can be an existing node or an empty folder.\n" +
+			"Be sure to backup the `to` node before running this command.\n" +
+			"NOTE: both `from` and `to` nodes must be upgraded to the latest version before running this command.\n" +
+			"NOTE: after upgrading and starting the nodes at least once, convert them to remote nodes before merging.",
 		Version: version,
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:     "from",
 				Aliases:  []string{"f"},
-				Usage:    "The `data` folder(s) to read identities from and merge into one node",
+				Usage:    "The `data` folder to read identities from and merge into `to`",
 				Required: true,
 			},
 			&cli.StringFlag{
 				Name:     "to",
 				Aliases:  []string{"t"},
-				Usage:    "The `data` folder to write the merged node to",
-				Required: true,
-			},
-			&cli.StringFlag{
-				Name:     "name",
-				Aliases:  []string{"n"},
-				Usage:    "The `name` of the identity merged from `from` to `to`",
+				Usage:    "The `data` folder to write the merged node to. Can be an existing remote node or an empty folder.",
 				Required: true,
 			},
 		},
@@ -46,7 +45,7 @@ func main() {
 				return fmt.Errorf("create logger: %w", err)
 			}
 			defer dbLog.Sync()
-			return internal.MergeDBs(ctx.Context, dbLog, ctx.String("name"), ctx.String("from"), ctx.String("to"))
+			return internal.MergeDBs(ctx.Context, dbLog, ctx.String("from"), ctx.String("to"))
 		},
 	}
 

--- a/cmd/merge-nodes/main.go
+++ b/cmd/merge-nodes/main.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/urfave/cli/v2"
+	"go.uber.org/zap"
+
+	"github.com/spacemeshos/go-spacemesh/cmd/merge-nodes/internal"
+)
+
+func main() {
+	app := &cli.App{
+		Name:  "Spacemesh Node Merger",
+		Usage: "Merge two or more Spacemesh nodes into one",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:     "from",
+				Aliases:  []string{"f"},
+				Usage:    "The `data` folder(s) to read identities from and merge into one node",
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:     "to",
+				Aliases:  []string{"t"},
+				Usage:    "The `data` folder to write the merged node to",
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:     "name",
+				Aliases:  []string{"n"},
+				Usage:    "The `name` of the identity merged from `from` to `to`",
+				Required: true,
+			},
+		},
+		Action: func(ctx *cli.Context) error {
+			cfg := zap.NewProductionConfig()
+			cfg.Encoding = "console"
+			dbLog, err := cfg.Build()
+			if err != nil {
+				return fmt.Errorf("create logger: %w", err)
+			}
+			defer dbLog.Sync()
+			return internal.MergeDBs(ctx.Context, dbLog, ctx.String("name"), ctx.String("from"), ctx.String("to"))
+		},
+	}
+
+	if err := app.Run(os.Args); err != nil {
+		log.Fatalf("app run: %v\n", err)
+	}
+}

--- a/cmd/merge-nodes/main.go
+++ b/cmd/merge-nodes/main.go
@@ -11,10 +11,13 @@ import (
 	"github.com/spacemeshos/go-spacemesh/cmd/merge-nodes/internal"
 )
 
+var version string
+
 func main() {
 	app := &cli.App{
-		Name:  "Spacemesh Node Merger",
-		Usage: "Merge two or more Spacemesh nodes into one",
+		Name:    "Spacemesh Node Merger",
+		Usage:   "Merge two or more Spacemesh nodes into one",
+		Version: version,
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:     "from",

--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	github.com/spf13/viper v1.18.2
 	github.com/stretchr/testify v1.9.0
 	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
+	github.com/urfave/cli/v2 v2.27.1
 	github.com/zeebo/blake3 v0.2.3
 	go.uber.org/mock v0.4.0
 	go.uber.org/zap v1.27.0
@@ -80,6 +81,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/containerd/cgroups v1.1.0 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.3 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/davidlazar/go-crypto v0.0.0-20200604182044-b73af7476f6c // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 // indirect
@@ -182,6 +184,7 @@ require (
 	github.com/quic-go/webtransport-go v0.6.0 // indirect
 	github.com/raulk/go-watchdog v1.3.0 // indirect
 	github.com/robfig/cron/v3 v3.0.1 // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sagikazarmark/locafero v0.4.0 // indirect
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
@@ -190,6 +193,7 @@ require (
 	github.com/spf13/cast v1.6.0 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/whyrusleeping/go-keyspace v0.0.0-20160322163242-5b898ac5add1 // indirect
+	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.48.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.48.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -110,6 +110,7 @@ github.com/cosmos/btcutil v1.0.5 h1:t+ZFcX77LpKtDBhjucvnOH8C2l2ioGsBNEQ3jef8xFk=
 github.com/cosmos/btcutil v1.0.5/go.mod h1:IyB7iuqZMJlthe2tkIFL33xPyzbFYP0XVdS8P5lUPis=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/cpuguy83/go-md2man/v2 v2.0.3 h1:qMCsGGgs+MAzDFyp9LpAe1Lqy/fY/qCovCm0qnXZOBM=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -576,6 +577,7 @@ github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjR
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryszard/goskiplist v0.0.0-20150312221310-2dfbae5fcf46/go.mod h1:uAQ5PCi+MFsC7HjREoAz1BU+Mq60+05gifQSsHSDG/8=
 github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6keLGt6kNQ=
@@ -676,6 +678,8 @@ github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cb
 github.com/tinylib/msgp v1.0.2/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=
 github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli v1.22.10/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+github.com/urfave/cli/v2 v2.27.1 h1:8xSQ6szndafKVRmfyeUMxkNUJQMjL1F2zmsZ+qHpfho=
+github.com/urfave/cli/v2 v2.27.1/go.mod h1:8qnjx1vcq5s2/wpsqoZFndg2CE5tNFyrTvS6SinrnYQ=
 github.com/viant/assertly v0.4.8/go.mod h1:aGifi++jvCrUaklKEKT0BU95igDNaqkvz+49uaYMPRU=
 github.com/viant/toolbox v0.24.0/go.mod h1:OxMCG57V0PXuIP2HNQrtJf2CjqdmbrOx5EkMILuUhzM=
 github.com/warpfork/go-wish v0.0.0-20220906213052-39a1cc7a02d0 h1:GDDkbFiaK8jsSDJfjId/PEGEShv6ugrt4kYsC5UIDaQ=
@@ -683,6 +687,8 @@ github.com/warpfork/go-wish v0.0.0-20220906213052-39a1cc7a02d0/go.mod h1:x6AKhvS
 github.com/whyrusleeping/go-keyspace v0.0.0-20160322163242-5b898ac5add1 h1:EKhdznlJHPMoKr0XTrX+IlJs1LH3lyx2nfr1dOlZ79k=
 github.com/whyrusleeping/go-keyspace v0.0.0-20160322163242-5b898ac5add1/go.mod h1:8UvriyWtv5Q5EOgjHaSseUEdkQfvwFv1I/In/O2M9gc=
 github.com/willf/bitset v1.1.9/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
+github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRTfdpNzjtPYqr8smhKouy9mxVdGPU=
+github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673/go.mod h1:N3UwUGtsrSj3ccvlPHLoLsHnpR27oXr4ZE984MbSER8=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/node/node.go
+++ b/node/node.go
@@ -1794,16 +1794,16 @@ func (app *App) setupDBs(ctx context.Context, lg log.Log) error {
 			return fmt.Errorf("failed to create poet client: %w", err)
 		}
 	}
-	migrations, err = sql.LocalMigrations()
-	if err != nil {
-		return fmt.Errorf("load local migrations: %w", err)
-	}
 
 	// Migrate `node_state.sql` to `local.sql`
 	if err := app.MigrateLocalDB(dbLog.Zap(), dbPath, clients); err != nil {
 		return err
 	}
 
+	migrations, err = sql.LocalMigrations()
+	if err != nil {
+		return fmt.Errorf("load local migrations: %w", err)
+	}
 	localDB, err := localsql.Open("file:"+filepath.Join(dbPath, localDbFile),
 		sql.WithLogger(dbLog.Zap()),
 		sql.WithMigrations(migrations),
@@ -2003,8 +2003,6 @@ func (app *App) startSynchronous(ctx context.Context) (err error) {
 		}
 	}
 
-	lg := logger
-
 	/* Initialize all protocol services */
 
 	gTime, err := time.Parse(time.RFC3339, app.Config.Genesis.GenesisTime)
@@ -2015,17 +2013,17 @@ func (app *App) startSynchronous(ctx context.Context) (err error) {
 		timesync.WithLayerDuration(app.Config.LayerDuration),
 		timesync.WithTickInterval(1*time.Second),
 		timesync.WithGenesisTime(gTime),
-		timesync.WithLogger(app.addLogger(ClockLogger, lg).Zap()),
+		timesync.WithLogger(app.addLogger(ClockLogger, logger).Zap()),
 	)
 	if err != nil {
 		return fmt.Errorf("cannot create clock: %w", err)
 	}
 
-	lg.Info("initializing p2p services")
+	logger.Info("initializing p2p services")
 
 	cfg := app.Config.P2P
 	cfg.DataDir = filepath.Join(app.Config.DataDir(), "p2p")
-	p2plog := app.addLogger(P2PLogger, lg)
+	p2plog := app.addLogger(P2PLogger, logger)
 	// if addLogger won't add a level we will use a default 0 (info).
 	cfg.LogLevel = app.getLevel(P2PLogger)
 	prologue := fmt.Sprintf("%x-%v",
@@ -2046,7 +2044,7 @@ func (app *App) startSynchronous(ctx context.Context) (err error) {
 		return fmt.Errorf("initialize p2p host: %w", err)
 	}
 
-	if err := app.setupDBs(ctx, lg); err != nil {
+	if err := app.setupDBs(ctx, logger); err != nil {
 		return err
 	}
 	if err := app.initServices(ctx); err != nil {

--- a/node/node.go
+++ b/node/node.go
@@ -245,9 +245,6 @@ func GetCommand() *cobra.Command {
 		Short: "Show version info",
 		Run: func(c *cobra.Command, args []string) {
 			fmt.Print(cmd.Version)
-			if cmd.Commit != "" {
-				fmt.Printf("+%s", cmd.Commit)
-			}
 			fmt.Println()
 		},
 	}

--- a/tortoise/data/README.md
+++ b/tortoise/data/README.md
@@ -1,25 +1,30 @@
 Tortoise execution traces
 ===
 
-Traces can be collected from a local or cloud environment, and they are meant to be used as a regression tests. Good source of traces are executions from system tests (see ./systest directory) that we run in the cloud.
+Traces can be collected from a local or cloud environment, and they are meant to be used as a regression tests. Good
+source of traces are executions from system tests (see ./systest directory) that we run in the cloud.
 
 To download the trace:
+
 - go to the grafana
 - find a pod that you are interested in
-- query tracer. example
-> {namespace="test-kaih", pod="smesher-10-6f86f487c-knfqm"} | json | logger="tracer"
-- click download, and postprocess file to reduce amount of data. example
-> cat Explore-logs-2023-06-01\ 15\ 59\ 49.json |  jq -c '.[].line | fromjson | {"t": .t, "o": .o}' &> ~/go-spacemesh/tortoise/data/partition_50_50_split_other_side.json
+- query tracer example
+  > {namespace="test-kaih", pod="smesher-10-6f86f487c-knfqm"} | json | logger="tracer"
+- click download, and postprocess file to reduce amount of data. example:
+  > cat Explore-logs-2023-06-01\ 15\ 59\ 49.json |  jq -c '.[].line | fromjson | {"t": .t, "o": .o}' &> ~/go-spacemesh/tortoise/data/partition_50_50_split_other_side.json
 
-Note that whole execution might be very large, and you will have to tweak period to download trace in one go. Alternatively you can use [logcli](https://grafana.com/docs/loki/latest/tools/logcli/).
+Note that whole execution might be very large, and you will have to tweak period to download trace in one go.
+Alternatively you can use [logcli](https://grafana.com/docs/loki/latest/tools/logcli/).
 
-If trace is downloaded from a system test, please prefix it with a name of system tests and smesher number, so that it can be recovered if it won't be compatible.
+If trace is downloaded from a system test, please prefix it with a name of system tests and smesher number, so that it
+can be recovered if it won't be compatible.
 
-How to run?
-===
+h2. How to run
 
-All traces in the `./tortoise/data` directory will be executed as a part of automated tests. Additionally there is a command line tool to debug trace interactively, it can be used with [delve](https://github.com/go-delve/delve).
+All traces in the `./tortoise/data` directory will be executed as a part of automated tests. Additionally there is a
+command line tool to debug trace interactively, it can be used with [delve](https://github.com/go-delve/delve).
 
-In the example below breakpoint will be placed after executing event. Debug logger will allow you to see what happened. Also you can place a breakpoint wherever you want and recompile `trace`.
+In the example below breakpoint will be placed after executing event. Debug logger will allow you to see what happened.
+Also you can place a breakpoint wherever you want and recompile `trace`.
 
 > dlv exec ./trace -- -breakpoint -level=debug ./tortoise/data/partition_50_50_long.json

--- a/tortoise/data/README.md
+++ b/tortoise/data/README.md
@@ -1,30 +1,25 @@
 Tortoise execution traces
 ===
 
-Traces can be collected from a local or cloud environment, and they are meant to be used as a regression tests. Good
-source of traces are executions from system tests (see ./systest directory) that we run in the cloud.
+Traces can be collected from a local or cloud environment, and they are meant to be used as a regression tests. Good source of traces are executions from system tests (see ./systest directory) that we run in the cloud.
 
 To download the trace:
-
 - go to the grafana
 - find a pod that you are interested in
-- query tracer example
-  > {namespace="test-kaih", pod="smesher-10-6f86f487c-knfqm"} | json | logger="tracer"
-- click download, and postprocess file to reduce amount of data. example:
-  > cat Explore-logs-2023-06-01\ 15\ 59\ 49.json |  jq -c '.[].line | fromjson | {"t": .t, "o": .o}' &> ~/go-spacemesh/tortoise/data/partition_50_50_split_other_side.json
+- query tracer. example
+> {namespace="test-kaih", pod="smesher-10-6f86f487c-knfqm"} | json | logger="tracer"
+- click download, and postprocess file to reduce amount of data. example
+> cat Explore-logs-2023-06-01\ 15\ 59\ 49.json |  jq -c '.[].line | fromjson | {"t": .t, "o": .o}' &> ~/go-spacemesh/tortoise/data/partition_50_50_split_other_side.json
 
-Note that whole execution might be very large, and you will have to tweak period to download trace in one go.
-Alternatively you can use [logcli](https://grafana.com/docs/loki/latest/tools/logcli/).
+Note that whole execution might be very large, and you will have to tweak period to download trace in one go. Alternatively you can use [logcli](https://grafana.com/docs/loki/latest/tools/logcli/).
 
-If trace is downloaded from a system test, please prefix it with a name of system tests and smesher number, so that it
-can be recovered if it won't be compatible.
+If trace is downloaded from a system test, please prefix it with a name of system tests and smesher number, so that it can be recovered if it won't be compatible.
 
-h2. How to run
+How to run?
+===
 
-All traces in the `./tortoise/data` directory will be executed as a part of automated tests. Additionally there is a
-command line tool to debug trace interactively, it can be used with [delve](https://github.com/go-delve/delve).
+All traces in the `./tortoise/data` directory will be executed as a part of automated tests. Additionally there is a command line tool to debug trace interactively, it can be used with [delve](https://github.com/go-delve/delve).
 
-In the example below breakpoint will be placed after executing event. Debug logger will allow you to see what happened.
-Also you can place a breakpoint wherever you want and recompile `trace`.
+In the example below breakpoint will be placed after executing event. Debug logger will allow you to see what happened. Also you can place a breakpoint wherever you want and recompile `trace`.
 
 > dlv exec ./trace -- -breakpoint -level=debug ./tortoise/data/partition_50_50_long.json


### PR DESCRIPTION
## Motivation

Adds a new command / tool for merging two nodes into one. Additionally the CI has been updated to include the new tool in a release and build docker images using the right version.

## Description

The CLI tool takes 2 parameters:

- `--from` which specifies the `data-dir` of the source node which's identities shall be merged to the target node
- `--to` which specifies the `data-dir` of the target node that receives the identities and state of the source node, can be an empty directory (so that a user can setup a new node with all their existing identities merged)

The tool only works with nodes that are set up for remote smeshing (i.e. have no `local.key` or supervised post service configuration). It will copy all identities from the source node to the target node while preserving their (file) names and will fail on conflicts (e.g. trying to merge the state of the same identity twice).

## Test Plan

Tests for the new tool have been added.

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [ ] Update documentation as needed
- [ ] Update [changelog](../CHANGELOG.md) as needed
