### PR TITLE
[Merged by Bors] - tune down logs that don't provide additional information

### DIFF
--- a/blocks/certifier.go
+++ b/blocks/certifier.go
@@ -464,7 +464,7 @@ func (c *Certifier) tryGenCert(
 		return nil
 	}
 
-	logger.With().Info("generating certificate",
+	logger.With().Debug("generating certificate",
 		log.Uint16("eligibility_count", c.certifyMsgs[lid][bid].totalEligibility),
 		log.Int("num_msg", len(c.certifyMsgs[lid][bid].signatures)),
 	)

--- a/blocks/generator.go
+++ b/blocks/generator.go
@@ -222,7 +222,7 @@ func (g *Generator) processHareOutput(ctx context.Context, out hare3.ConsensusOu
 		}
 		block.Initialize()
 		hareOutput = block.ID()
-		g.logger.With().Info("generated block", out.Layer, block.ID())
+		g.logger.With().Debug("generated block", out.Layer, block.ID())
 	}
 	if err := g.saveAndCertify(ctx, out.Layer, block); err != nil {
 		return block, err
@@ -254,14 +254,14 @@ func (g *Generator) processOptimisticLayers(max types.LayerID) {
 				failGenCnt.Inc()
 				return err
 			}
-			g.logger.With().Info("generated block (optimistic)", lid, block.ID())
+			g.logger.With().Debug("generated block (optimistic)", lid, block.ID())
 			if err = g.msh.ProcessLayerPerHareOutput(md.ctx, lid, block.ID(), true); err != nil {
 				return err
 			}
 			return nil
 		}
 		if err = doit(); err != nil {
-			g.logger.With().Error("failed to process optimistic layer",
+			g.logger.With().Warning("failed to process optimistic layer",
 				log.Context(md.ctx),
 				lid,
 				log.Err(err),

--- a/timesync/peersync/sync.go
+++ b/timesync/peersync/sync.go
@@ -151,7 +151,7 @@ func (s *Sync) streamHandler(stream network.Stream) {
 	defer stream.SetDeadline(time.Time{})
 	var request Request
 	if _, err := codec.DecodeFrom(stream, &request); err != nil {
-		s.log.With().Warning("can't decode request", log.Err(err))
+		s.log.With().Debug("can't decode request", log.Err(err))
 		return
 	}
 	resp := Response{
@@ -159,7 +159,7 @@ func (s *Sync) streamHandler(stream network.Stream) {
 		Timestamp: uint64(s.time.Now().UnixNano()),
 	}
 	if _, err := codec.EncodeTo(stream, &resp); err != nil {
-		s.log.With().Warning("can't encode response", log.Err(err))
+		s.log.With().Debug("can't encode response", log.Err(err))
 	}
 }
 
@@ -268,19 +268,19 @@ func (s *Sync) GetOffset(ctx context.Context, id uint64, prs []p2p.Peer) (time.D
 			logger := s.log.WithFields(log.Stringer("pid", pid)).With()
 			stream, err := s.h.NewStream(network.WithNoDial(ctx, "existing connection"), pid, protocolName)
 			if err != nil {
-				logger.Warning("failed to create new stream", log.Err(err))
+				logger.Debug("failed to create new stream", log.Err(err))
 				return
 			}
 			defer stream.Close()
 			_ = stream.SetDeadline(s.time.Now().Add(s.config.RoundTimeout))
 			defer stream.SetDeadline(time.Time{})
 			if _, err := stream.Write(buf); err != nil {
-				logger.Warning("failed to send a request", log.Err(err))
+				logger.Debug("failed to send a request", log.Err(err))
 				return
 			}
 			var resp Response
 			if _, err := codec.DecodeFrom(stream, &resp); err != nil {
-				logger.Warning("failed to read response from peer", log.Err(err))
+				logger.Debug("failed to read response from peer", log.Err(err))
 				return
 			}
 			select {


### PR DESCRIPTION
- don't spam with warnings if timesync can't communicate with a peer
- block builder logs are not useful as info, as the same information will appear in executor
- certificate generation is expected, and not useful as info as well