### PR TITLE
[Merged by Bors] - Remove max connection age for GRPC

### DIFF
--- a/api/grpcserver/grpc.go
+++ b/api/grpcserver/grpc.go
@@ -134,16 +134,10 @@ func New(listener string, logger *zap.Logger, config Config, grpcOpts ...grpc.Se
 		grpc.MaxRecvMsgSize(config.GrpcRecvMsgSize),
 	}
 
-	// this is done to prevent routers from cleaning up our connections (e.g aws load balances..)
-	// TODO: these parameters work for now but we might need to revisit or add them as configuration
-	// TODO: Configure maxconns, maxconcurrentcons ..
 	opts = append(opts,
 		grpc.KeepaliveParams(keepalive.ServerParameters{
-			MaxConnectionIdle:     time.Minute * 120,
-			MaxConnectionAge:      time.Minute * 180,
-			MaxConnectionAgeGrace: time.Minute * 10,
-			Time:                  time.Minute,
-			Timeout:               time.Minute * 3,
+			Time:    time.Minute,
+			Timeout: 10 * time.Second,
 		}),
 	)
 

--- a/node/node.go
+++ b/node/node.go
@@ -32,6 +32,8 @@ import (
 	"go.uber.org/zap/zapcore"
 	"golang.org/x/exp/maps"
 	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/keepalive"
 
 	"github.com/spacemeshos/go-spacemesh/activation"
 	"github.com/spacemeshos/go-spacemesh/api/grpcserver"
@@ -1545,6 +1547,14 @@ func (app *App) startAPIServices(ctx context.Context) error {
 			logger.Zap(),
 			app.Config.API,
 			maps.Values(publicSvcs),
+			// public server needs restriction on max connection age to prevent attacks
+			grpc.KeepaliveParams(keepalive.ServerParameters{
+				MaxConnectionIdle:     2 * time.Hour,
+				MaxConnectionAge:      3 * time.Hour,
+				MaxConnectionAgeGrace: 10 * time.Minute,
+				Time:                  time.Minute,
+				Timeout:               10 * time.Second,
+			}),
 		)
 		if err != nil {
 			return err


### PR DESCRIPTION
## Motivation

Removes max connection age for all GRPC servers except for the public.

## Description

To prevent regular disconnects between the node and the post-service we set the `MaxConnectionAge` to infinity.

## Test Plan

n/a

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
