### PR TITLE
[Merged by Bors] - p2p: add gossip-peer-outbound-queue-size setting

### DIFF
--- a/p2p/host.go
+++ b/p2p/host.go
@@ -144,6 +144,7 @@ type Config struct {
 	IP4Blocklist                []string         `mapstructure:"ip4-blocklist"`
 	IP6Blocklist                []string         `mapstructure:"ip6-blocklist"`
 	GossipQueueSize             int              `mapstructure:"gossip-queue-size"`
+	GossipPeerOutboundQueueSize int              `mapstructure:"gossip-peer-outbound-queue-size"`
 	GossipValidationThrottle    int              `mapstructure:"gossip-validation-throttle"`
 	GossipAtxValidationThrottle int              `mapstructure:"gossip-atx-validation-throttle"`
 	PingPeers                   []string         `mapstructure:"ping-peers"`

--- a/p2p/pubsub/pubsub.go
+++ b/p2p/pubsub/pubsub.go
@@ -79,7 +79,7 @@ const (
 
 // DefaultConfig for PubSub.
 func DefaultConfig() Config {
-	return Config{Flood: true, QueueSize: 10000, Throttle: 10000}
+	return Config{Flood: true, PeerOutboundQueueSize: 8192, QueueSize: 10000, Throttle: 10000}
 }
 
 // Config for PubSub.
@@ -88,10 +88,11 @@ type Config struct {
 	IsBootnode bool
 	Bootnodes  []peer.AddrInfo
 	// Direct peers should be configured on both ends.
-	Direct         []peer.AddrInfo
-	MaxMessageSize int
-	QueueSize      int
-	Throttle       int
+	Direct                []peer.AddrInfo
+	MaxMessageSize        int
+	PeerOutboundQueueSize int
+	QueueSize             int
+	Throttle              int
 }
 
 // New creates PubSub instance.

--- a/p2p/upgrade.go
+++ b/p2p/upgrade.go
@@ -141,13 +141,14 @@ func Upgrade(h host.Host, opts ...Opt) (*Host, error) {
 		// TBD: also protect ping
 	}
 	if fh.PubSub, err = pubsub.New(fh.ctx, fh.logger, h, pubsub.Config{
-		Flood:          cfg.Flood,
-		IsBootnode:     cfg.Bootnode,
-		Direct:         direct,
-		Bootnodes:      bootnodes,
-		MaxMessageSize: cfg.MaxMessageSize,
-		QueueSize:      cfg.GossipQueueSize,
-		Throttle:       cfg.GossipValidationThrottle,
+		Flood:                 cfg.Flood,
+		IsBootnode:            cfg.Bootnode,
+		Direct:                direct,
+		Bootnodes:             bootnodes,
+		MaxMessageSize:        cfg.MaxMessageSize,
+		QueueSize:             cfg.GossipQueueSize,
+		PeerOutboundQueueSize: cfg.GossipPeerOutboundQueueSize,
+		Throttle:              cfg.GossipValidationThrottle,
 	}); err != nil {
 		return nil, fmt.Errorf("failed to initialize pubsub: %w", err)
 	}


### PR DESCRIPTION
## Motivation

Pubsub peer outbound queue size is currently hardcoded to 8192. This parameter appears to affect memory consumption and much lower values are used in most projects (the default value in `go-libp2p-pubsub` is 32). Need to make this parameter tunable, but let's keep 8192 as a "verified" default for now.

## Description

Added `gossip-peer-outbound-queue-size` param in the `p2p` config section.
Defaults to 8192 which was hardcoded previously

## Test Plan

Verified on mainnet
