### PR TITLE
[Merged by Bors] - Add build of tools to CI to not fail on release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,9 @@ jobs:
           - [go-spacemesh, m2-pro]
           - windows-latest
     steps:
+      - name: Add OpenCL support - Ubuntu
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: sudo apt-get update -q && sudo apt-get install -qy ocl-icd-opencl-dev libpocl2
       - name: disable Windows Defender - Windows
         if: ${{ matrix.os == 'windows-latest' }}
         run: |
@@ -242,6 +245,7 @@ jobs:
       - filter-changes
       - quicktests
       - lint
+      - build-tools
       - build
       - unittests
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,40 @@ jobs:
       - name: lint
         run: make lint-github-action
 
+  build-tools:
+    runs-on: ${{ matrix.os }}
+    needs: filter-changes
+    if: ${{ needs.filter-changes.outputs.nondocchanges == 'true' }}
+    strategy:
+      fail-fast: true
+      matrix:
+        os:
+          - ubuntu-latest
+          - [self-hosted, linux, arm64]
+          # - macos-12-large
+          - [go-spacemesh, m2-pro]
+          - windows-latest
+    steps:
+      - name: disable Windows Defender - Windows
+        if: ${{ matrix.os == 'windows-latest' }}
+        run: |
+          Set-MpPreference -DisableRealtimeMonitoring $true
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: set up go
+        uses: actions/setup-go@v5
+        with:
+          check-latest: true
+          go-version: ${{ env.go-version }}
+      - name: setup env
+        run: make install
+      - name: build merge-nodes
+        run: make merge-nodes
+      - name: build gen-p2p-identity
+        run: make gen-p2p-identity
+      - name: build bootstrapper
+        run: make bootstrapper
+
   build:
     runs-on: ${{ matrix.os }}
     needs: filter-changes

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ LDFLAGS = -ldflags "$(C_LDFLAGS)"
 
 include Makefile-libs.Inc
 
-UNIT_TESTS ?= $(shell go list ./...  | grep -v systest/tests | grep -v cmd/node | grep -v cmd/gen-p2p-identity | grep -v cmd/trace | grep -v genvm/cmd)
+UNIT_TESTS ?= $(shell go list ./...  | grep -v systest/tests | grep -v genvm/cmd)
 
 export CGO_ENABLED := 1
 export CGO_CFLAGS := $(CGO_CFLAGS) -DSQLITE_ENABLE_DBSTAT_VTAB=1

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ get-libs: get-postrs-lib get-postrs-service
 
 get-profiler: get-postrs-profiler
 
-merge-nodes:
+merge-nodes: get-libs
 	cd cmd/merge-nodes ; go build -o $(BIN_DIR)$@$(EXE) -ldflags "-X main.version=${VERSION}" .
 .PHONY: merge-nodes
 


### PR DESCRIPTION
## Motivation

Adds build steps for tools beside the node.

## Description

Add build steps so that PRs breaking a build of one of the tools is caught before we make a release.

## Test Plan

n/a

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
