### PR TITLE
[Merged by Bors] - Use base64 instead of hex to log service id / public key

### DIFF
--- a/sql/localsql/0003_migration.go
+++ b/sql/localsql/0003_migration.go
@@ -157,9 +157,10 @@ func (m migration0003) moveNipostStateToDb(db sql.Executor, dataDir string) erro
 			continue
 		}
 
+		poetPubKey := base64.StdEncoding.EncodeToString(req.PoetServiceID.ServiceID)
 		address, err := m.getAddress(req.PoetServiceID)
 		if err != nil {
-			return fmt.Errorf("get address for poet service id %x: %w", req.PoetServiceID.ServiceID, err)
+			return fmt.Errorf("get address for poet service id %s: %w", poetPubKey, err)
 		}
 
 		enc := func(stmt *sql.Statement) {
@@ -178,7 +179,7 @@ func (m migration0003) moveNipostStateToDb(db sql.Executor, dataDir string) erro
 
 		m.logger.Info("PoET registration added to database",
 			zap.String("node_id", types.BytesToNodeID(meta.NodeId).ShortString()),
-			zap.String("poet_service_id", base64.StdEncoding.EncodeToString(req.PoetServiceID.ServiceID)),
+			zap.String("poet_service_id", poetPubKey),
 			zap.String("address", address),
 			zap.String("round_id", req.PoetRound.ID),
 			zap.Time("round_end", req.PoetRound.End.IntoTime()),
@@ -252,7 +253,8 @@ func (m migration0003) getAddress(serviceID PoetServiceID) (string, error) {
 			return client.Address(), nil
 		}
 	}
-	return "", fmt.Errorf("no poet client found for service id %x", serviceID.ServiceID)
+	key := base64.StdEncoding.EncodeToString(serviceID.ServiceID)
+	return "", fmt.Errorf("no poet client found for service id %s", key)
 }
 
 func (m migration0003) getChallengeHash(db sql.Executor, nodeID types.NodeID) (types.Hash32, error) {


### PR DESCRIPTION
## Motivation

Keys are logged as hex instead of base64. Since the config contains them in base64 and the `/v1/info` endpoint also displays the key in base64 the logger should too.

## Description

Just logging improvements to make it easier to match keys of PoETs.

## Test Plan

n/a

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
