### PR TITLE
[Merged by Bors] - Fix possible race in ProtocolDriver on Close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 See [RELEASE](./RELEASE.md) for workflow instructions.
 
+## UNRELEASED
+
+### Upgrade information
+
+### Highlights
+
+### Features
+
+### Improvements
+
+* [#5707](https://github.com/spacemeshos/go-spacemesh/pull/5707) Fix a race on closing a channel when the node is
+  shutting down.
+
 ## Release v1.4.0
 
 ### Upgrade information
@@ -228,9 +241,10 @@ and permanent ineligibility for rewards.
 
 ### Features
 
-* [#5678](https://github.com/spacemeshos/go-spacemesh/pull/5678) API to for changing log level without restarting a node. Examples: 
-  > grpcurl -plaintext -d '{"module": "sync", "level": "debug"}' 127.0.0.1:9093 spacemesh.v1.DebugService.ChangeLogLevel
+* [#5678](https://github.com/spacemeshos/go-spacemesh/pull/5678) API to for changing log level without restarting a
+  node. Examples:
 
+  > grpcurl -plaintext -d '{"module": "sync", "level": "debug"}' 127.0.0.1:9093 spacemesh.v1.DebugService.ChangeLogLevel
   > grpcurl -plaintext -d '{"module": "*", "level": "debug"}' 127.0.0.1:9093 spacemesh.v1.DebugService.ChangeLogLevel
 
   "*" will replace log level for all known modules, expect that some of them will spam too much.

--- a/beacon/beacon_test.go
+++ b/beacon/beacon_test.go
@@ -505,7 +505,7 @@ func TestBeacon_NoRaceOnClose(t *testing.T) {
 		beacons:          make(map[types.EpochID]types.Beacon),
 		cdb:              datastore.NewCachedDB(sql.InMemory(), logtest.New(t)),
 		clock:            mclock,
-		cancel:           func() {},
+		closed:           make(chan struct{}),
 		results:          make(chan result.Beacon, 100),
 		metricsCollector: metrics.NewBeaconMetricsCollector(nil, logtest.New(t).WithName("metrics")),
 	}

--- a/beacon/beacon_test.go
+++ b/beacon/beacon_test.go
@@ -15,8 +15,10 @@ import (
 	"github.com/spacemeshos/fixed"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/spacemeshos/go-spacemesh/activation"
+	"github.com/spacemeshos/go-spacemesh/beacon/metrics"
 	"github.com/spacemeshos/go-spacemesh/beacon/weakcoin"
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/common/types/result"
@@ -494,6 +496,38 @@ func TestBeaconWithMetrics(t *testing.T) {
 	}
 
 	tpd.Close()
+}
+
+func TestBeacon_NoRaceOnClose(t *testing.T) {
+	mclock := NewMocklayerClock(gomock.NewController(t))
+	pd := &ProtocolDriver{
+		logger:           logtest.New(t).WithName("Beacon"),
+		beacons:          make(map[types.EpochID]types.Beacon),
+		cdb:              datastore.NewCachedDB(sql.InMemory(), logtest.New(t)),
+		clock:            mclock,
+		cancel:           func() {},
+		results:          make(chan result.Beacon, 100),
+		metricsCollector: metrics.NewBeaconMetricsCollector(nil, logtest.New(t).WithName("metrics")),
+	}
+	// check for a race between onResult and Close
+	var eg errgroup.Group
+	eg.Go(func() error {
+		for i := 0; i < 1000; i++ {
+			time.Sleep(1 * time.Millisecond)
+			pd.onResult(types.EpochID(i), types.Beacon{})
+		}
+		return nil
+	})
+	eg.Go(func() error {
+		resultChan := pd.Results()
+		for result := range resultChan {
+			t.Log(result)
+		}
+		return nil
+	})
+	time.Sleep(300 * time.Millisecond)
+	pd.Close()
+	require.NoError(t, eg.Wait())
 }
 
 func TestBeacon_BeaconsWithDatabase(t *testing.T) {

--- a/node/node.go
+++ b/node/node.go
@@ -684,7 +684,6 @@ func (app *App) initServices(ctx context.Context) error {
 		vrfVerifier,
 		app.cachedDB,
 		app.clock,
-		beacon.WithContext(ctx),
 		beacon.WithConfig(app.Config.Beacon),
 		beacon.WithLogger(app.addLogger(BeaconLogger, lg)),
 	)


### PR DESCRIPTION
## Motivation

We have recently seen a few reports of this issue. While this isn't the actual cause of any problems (as something else needs to go wrong first for this problem to even trigger), it still makes it hard to identify the real cause of a problem.

This fixes the race so we can more easily identify the actual problem of a node shutting down early.

## Description

Closes https://github.com/spacemeshos/go-spacemesh/issues/5166.

This is a quick fix for the race on close error we have seen a lot more recently. `ProtocolDriver` could be further improved to make it clearer what his happening when on the results channel (or even use a completely different pattern of notifying subscribers) but I refrained from too many optimizations in this PR.

## Test Plan

- existing tests pass
- a new test was added that causes a race without my changes, but passes with my fixes

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
