### PR TITLE
[Merged by Bors] - Don't print stacktrace on error in merge-nodes

### DIFF
--- a/cmd/merge-nodes/main.go
+++ b/cmd/merge-nodes/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"log"
+	"fmt"
 	"os"
 
 	"github.com/urfave/cli/v2"
@@ -17,7 +17,8 @@ func main() {
 	cfg.Encoding = "console"
 	dbLog, err := cfg.Build()
 	if err != nil {
-		log.Fatalln("create logger:", err)
+		fmt.Println("create logger:", err)
+		os.Exit(1)
 	}
 	defer dbLog.Sync()
 
@@ -50,8 +51,7 @@ func main() {
 	}
 
 	if err := app.Run(os.Args); err != nil {
-		dbLog.Fatal("app run:",
-			zap.Error(err),
-		)
+		dbLog.Sugar().Warnln("app run:", err)
+		os.Exit(1)
 	}
 }


### PR DESCRIPTION
## Motivation

Do not print a stack trace when `merge-nodes` exits with an error to not confuse users.

## Description

The change will cause `merge-nodes` to only print the error message without a full stack trace, otherwise users confuse an incorrect use of the tool with a bug in it.

## Test Plan

n/a

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
