### PR TITLE
Add check to not overwrite an existing key when migrating after downgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ See [RELEASE](./RELEASE.md) for workflow instructions.
 * [#5707](https://github.com/spacemeshos/go-spacemesh/pull/5707) Fix a race on closing a channel when the node is
   shutting down.
 
+* [#5709](https://github.com/spacemeshos/go-spacemesh/pull/5709) Prevent users from accidentally deleting their keys,
+  if they downgrade to v1.3.x and upgrade again.
+
 ## Release v1.4.0
 
 ### Upgrade information

--- a/node/node_identities.go
+++ b/node/node_identities.go
@@ -79,6 +79,17 @@ func (app *App) MigrateExistingIdentity() error {
 		return fmt.Errorf("stat %s: %w", newKey, err)
 	}
 
+	_, err = os.Stat(oldKey + ".bak")
+	switch {
+	case errors.Is(err, fs.ErrNotExist):
+		// no backup, migrate old to new
+	case err == nil:
+		// backup already exists - something is wrong
+		return fmt.Errorf("%w: backup %s already exists", fs.ErrExist, oldKey+".bak")
+	case err != nil:
+		return fmt.Errorf("stat %s: %w", oldKey+".bak", err)
+	}
+
 	dst, err := os.Create(newKey)
 	if err != nil {
 		return fmt.Errorf("failed to create new identity file: %w", err)

--- a/node/node_identities.go
+++ b/node/node_identities.go
@@ -68,6 +68,17 @@ func (app *App) MigrateExistingIdentity() error {
 		return fmt.Errorf("failed to create directory for identity file: %w", err)
 	}
 
+	_, err = os.Stat(newKey)
+	switch {
+	case errors.Is(err, fs.ErrNotExist):
+		// no new key, migrate old to new
+	case err == nil:
+		// both exist, error
+		return fmt.Errorf("%w: both %s and %s exist", fs.ErrExist, newKey, oldKey)
+	case err != nil:
+		return fmt.Errorf("stat %s: %w", newKey, err)
+	}
+
 	dst, err := os.Create(newKey)
 	if err != nil {
 		return fmt.Errorf("failed to create new identity file: %w", err)


### PR DESCRIPTION
## Motivation

Downgrading to v1.3.x after upgrading to v1.4.x will generate a new key that when the node is updated again to v1.4.x will overwrite the existing key.

This adds a check that prevents the node from overwriting a possibly already existing key.

## Description

When migrating the key the code now checks if there is already a `local.key` before copying the old key there.

## Test Plan

- added test for this specific occurance

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
