### PR TITLE
Do not allow opening a DB with a newer schema than expected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ See [RELEASE](./RELEASE.md) for workflow instructions.
 * [#5707](https://github.com/spacemeshos/go-spacemesh/pull/5707) Fix a race on closing a channel when the node is
   shutting down.
 
+* [#5710](https://github.com/spacemeshos/go-spacemesh/pull/5710) Node now checks the database version and will refuse to
+  start if it is newer than expected.
+
 ## Release v1.4.0
 
 ### Upgrade information

--- a/cmd/merge-nodes/internal/merge_action.go
+++ b/cmd/merge-nodes/internal/merge_action.go
@@ -165,7 +165,7 @@ func openDB(dbLog *zap.Logger, path string) (*localsql.Database, error) {
 
 	db, err := localsql.Open("file:"+dbPath,
 		sql.WithLogger(dbLog),
-		sql.WithMigrations(nil),
+		sql.WithMigrations(nil), // do not migrate database when opening
 	)
 	if err != nil {
 		return nil, fmt.Errorf("open source database %s: %w", dbPath, err)

--- a/cmd/merge-nodes/internal/merge_action.go
+++ b/cmd/merge-nodes/internal/merge_action.go
@@ -165,7 +165,7 @@ func openDB(dbLog *zap.Logger, path string) (*localsql.Database, error) {
 
 	db, err := localsql.Open("file:"+dbPath,
 		sql.WithLogger(dbLog),
-		sql.WithMigrations([]sql.Migration{}), // do not migrate database when opening
+		sql.WithMigrations(nil),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("open source database %s: %w", dbPath, err)

--- a/sql/database.go
+++ b/sql/database.go
@@ -24,6 +24,8 @@ var (
 	ErrNotFound = errors.New("database: not found")
 	// ErrObjectExists is returned if database constraints didn't allow to insert an object.
 	ErrObjectExists = errors.New("database: object exists")
+	// ErrTooNew is returned if database version is newer than expected.
+	ErrTooNew = errors.New("database version is too new")
 )
 
 const (
@@ -205,6 +207,14 @@ func Open(uri string, opts ...Opt) (*Database, error) {
 		after := 0
 		if len(config.migrations) > 0 {
 			after = config.migrations[len(config.migrations)-1].Order()
+		}
+		if before > after {
+			config.logger.Error("database version is newer than expected - downgrade is not supported",
+				zap.String("uri", uri),
+				zap.Int("current version", before),
+				zap.Int("target version", after),
+			)
+			return nil, fmt.Errorf("%w: %d > %d", ErrTooNew, before, after)
 		}
 		config.logger.Info("running migrations",
 			zap.String("uri", uri),

--- a/sql/database.go
+++ b/sql/database.go
@@ -209,6 +209,7 @@ func Open(uri string, opts ...Opt) (*Database, error) {
 			after = config.migrations[len(config.migrations)-1].Order()
 		}
 		if before > after {
+			pool.Close()
 			config.logger.Error("database version is newer than expected - downgrade is not supported",
 				zap.String("uri", uri),
 				zap.Int("current version", before),

--- a/sql/database_test.go
+++ b/sql/database_test.go
@@ -170,3 +170,26 @@ func TestQueryCount(t *testing.T) {
 	require.Error(t, err)
 	require.Equal(t, 2, db.QueryCount())
 }
+
+func Test_MigrationFailsIfDatabaseTooNew(t *testing.T) {
+	dir := t.TempDir()
+
+	ctrl := gomock.NewController(t)
+	migration1 := NewMockMigration(ctrl)
+	migration1.EXPECT().Order().Return(1).AnyTimes()
+
+	migration2 := NewMockMigration(ctrl)
+	migration2.EXPECT().Order().Return(2).AnyTimes()
+
+	dbFile := filepath.Join(dir, "test.sql")
+	db, err := Open("file:" + dbFile)
+	require.NoError(t, err)
+	_, err = db.Exec("PRAGMA user_version = 3", nil, nil)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	_, err = Open("file:"+dbFile,
+		WithMigrations([]Migration{migration1, migration2}),
+	)
+	require.Error(t, err)
+}

--- a/sql/database_test.go
+++ b/sql/database_test.go
@@ -191,5 +191,5 @@ func Test_Migration_FailsIfDatabaseTooNew(t *testing.T) {
 	_, err = Open("file:"+dbFile,
 		WithMigrations([]Migration{migration1, migration2}),
 	)
-	require.Error(t, err)
+	require.ErrorIs(t, err, ErrTooNew)
 }

--- a/sql/database_test.go
+++ b/sql/database_test.go
@@ -171,7 +171,7 @@ func TestQueryCount(t *testing.T) {
 	require.Equal(t, 2, db.QueryCount())
 }
 
-func Test_MigrationFailsIfDatabaseTooNew(t *testing.T) {
+func Test_Migration_FailsIfDatabaseTooNew(t *testing.T) {
 	dir := t.TempDir()
 
 	ctrl := gomock.NewController(t)

--- a/sql/migrations_test.go
+++ b/sql/migrations_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestMigrationsAppliedOnce(t *testing.T) {
+func Test_MigrationsAppliedOnce(t *testing.T) {
 	db := InMemory()
 
 	var version int


### PR DESCRIPTION
## Motivation

Downgrading a node is generally not supported as DB migrations cannot be rolled back. This adds a check if a node tries to open a DB that is newer than expected and prevents this.

## Description

If a database schema is newer than expected prevent the node opening it and possibly writing invalid data to it.

## Test Plan

- added a test that checks if opening a DB with a newer schema than expected fails.

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
