### PR TITLE
[Merged by Bors] - Log "waiting to trigger smeshing via API" only in supervised mode

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -1363,7 +1363,8 @@ func (app *App) startServices(ctx context.Context) error {
 		); err != nil {
 			return fmt.Errorf("start post service: %w", err)
 		}
-	} else {
+	} else if len(app.signers) == 1 && app.signers[0].Name() == supervisedIDKeyFileName {
+		// supervised setup but not started
 		app.log.Info("smeshing not started, waiting to be triggered via smesher api")
 	}
 


### PR DESCRIPTION
## Motivation

Log should only be printed in supervised mode.

## Description

Adds a check to only print that log when the node is setup with supervised smeshing.

## Test Plan

n/a

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
