### PR TITLE
[Merged by Bors] - dont pass interuptible context to with tx

### DIFF
--- a/syncer/atxsync/syncer.go
+++ b/syncer/atxsync/syncer.go
@@ -324,7 +324,7 @@ func (s *Syncer) downloadAtxs(
 			}
 		}
 
-		if err := s.localdb.WithTx(ctx, func(tx *sql.Tx) error {
+		if err := s.localdb.WithTx(context.Background(), func(tx *sql.Tx) error {
 			if err := atxsync.SaveRequest(tx, publish, lastSuccess, int64(len(state)), int64(len(downloaded))); err != nil {
 				return fmt.Errorf("failed to save request time: %w", err)
 			}


### PR DESCRIPTION
interrupting connection in the middle of writes doesn't rollback transaction, and leads to future writes deadlocking.
it probably needs to be removed from Tx/WithTx API at all, it is only safe to use with single statement.

```
{"L":"WARN","T":"2024-03-15T21:22:15.583Z","N":"node.sync","M":"background atx sync failed","sessionId":"b4540da2","epoch_id":5,"errmsg":"failed to persist state for epoch 5: insert synced atx id 5/f34cac63b5 failed: prepare insert into atx_sync_state \n\t\t(epoch, id, requests) values (?1, ?2, ?3)\n\t\ton conflict(epoch, id) do update set requests = ?3;: sqlite.Stmt.ClearBindings: SQLITE_INTERRUPT (insert into atx_sync_state \n\t\t(epoch, id, requests) values (?1, ?2, ?3)\n\t\ton conflict(epoch, id) do update set requests = ?3;)","name":"sync"}

{"L":"WARN","T":"2024-03-15T21:23:15.606Z","N":"node.sync","M":"background atx sync failed","sessionId":"0d233121","epoch_id":6,"errmsg":"failed to persist state for epoch 6: begin: sqlite.Stmt.Step: SQLITE_BUSY: database is locked (BEGIN IMMEDIATE;)","name":"sync"}  
{"L":"WARN","T":"2024-03-15T21:24:15.621Z","N":"node.sync","M":"background atx sync failed","sessionId":"a2b64219","epoch_id":7,"errmsg":"failed to persist state for epoch 7: begin: sqlite.Stmt.Step: SQLITE_BUSY: database is locked (BEGIN IMMEDIATE;)","name":"sync"}
{"L":"WARN","T":"2024-03-15T21:25:15.640Z","N":"node.sync","M":"background atx sync failed","sessionId":"e9039bf3","epoch_id":8,"errmsg":"failed to persist state for epoch 8: begin: sqlite.Stmt.Step: SQLITE_BUSY: database is locked (BEGIN IMMEDIATE;)","name":"sync"}
```