### PR TITLE
[Merged by Bors] - Skip code coverage job if no code was changed

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,8 +9,26 @@ on:
       - develop
 
 jobs:
+  filter-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      nondocchanges: ${{ steps.filter.outputs.nondoc }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          # this pattern matches using picomatch syntax (used by this third party Action), which is slightly
+          # different than GitHub syntax: it matches any file in any path ending in '.md'. this checks if
+          # any non-markdown files were changed.
+          filters: |
+            nondoc:
+              - '!**/*.md'
+
   coverage:
     runs-on: ubuntu-latest
+    needs: filter-changes
+    if: ${{ needs.filter-changes.outputs.nondocchanges == 'true' }}
     steps:
       - name: disable TCP/UDP offload
         run: |


### PR DESCRIPTION
## Motivation

The code coverage job at the moment is always executed even on PRs that have no code changed. This PR adds a filter that prevents this.

## Description

There is no need to execute code coverage on a PR that doesn't change code - just like we don't run tests or build jobs on such a PR. This adds a filter to prevent github action from executing the coverage job on a PR without changes to code.

## Test Plan

- n/a

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
