### PR TITLE
dont interrupt sync if ballots in the layer were ignored or rejected

### DIFF
--- a/fetch/mesh_data.go
+++ b/fetch/mesh_data.go
@@ -399,7 +399,7 @@ func (f *Fetch) GetCert(
 	return nil, fmt.Errorf("failed to get cert %v/%s from %d peers: %w", lid, bid.String(), len(peers), ctx.Err())
 }
 
-var ErrIgnore = errors.New("fecth: ignore")
+var ErrIgnore = errors.New("fetch: ignore")
 
 type BatchError struct {
 	Errors map[types.Hash32]error

--- a/fetch/mesh_data.go
+++ b/fetch/mesh_data.go
@@ -16,6 +16,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/datastore"
 	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/p2p"
+	"github.com/spacemeshos/go-spacemesh/p2p/pubsub"
 	"github.com/spacemeshos/go-spacemesh/p2p/server"
 	"github.com/spacemeshos/go-spacemesh/system"
 )
@@ -398,6 +399,8 @@ func (f *Fetch) GetCert(
 	return nil, fmt.Errorf("failed to get cert %v/%s from %d peers: %w", lid, bid.String(), len(peers), ctx.Err())
 }
 
+var ErrIgnore = errors.New("fecth: ignore")
+
 type BatchError struct {
 	Errors map[types.Hash32]error
 }
@@ -422,4 +425,25 @@ func (b *BatchError) Error() string {
 		builder.WriteString(err.Error())
 	}
 	return builder.String()
+}
+
+func (b *BatchError) Ignore() bool {
+	for hash := range b.Errors {
+		if !b.IsIgnored(hash) {
+			return false
+		}
+	}
+	return true
+}
+
+func (b *BatchError) IsIgnored(hash types.Hash32) bool {
+	err := b.Errors[hash]
+	if err == nil {
+		return false
+	}
+	nested := &BatchError{}
+	if errors.As(err, &nested) && nested.Ignore() {
+		return true
+	}
+	return errors.Is(err, pubsub.ErrValidationReject) || errors.Is(err, ErrIgnore)
 }

--- a/fetch/mesh_data_test.go
+++ b/fetch/mesh_data_test.go
@@ -850,7 +850,7 @@ func TestBatchErrorIgnore(t *testing.T) {
 			desc: "random error",
 			error: BatchError{
 				Errors: map[types.Hash32]error{
-					types.Hash32{1}: errors.New("random error"),
+					{1}: errors.New("random error"),
 				},
 			},
 		},
@@ -858,7 +858,7 @@ func TestBatchErrorIgnore(t *testing.T) {
 			desc: "reject",
 			error: BatchError{
 				Errors: map[types.Hash32]error{
-					types.Hash32{1}: pubsub.ErrValidationReject,
+					{1}: pubsub.ErrValidationReject,
 				},
 			},
 			ignored: true,
@@ -867,7 +867,7 @@ func TestBatchErrorIgnore(t *testing.T) {
 			desc: "ignore",
 			error: BatchError{
 				Errors: map[types.Hash32]error{
-					types.Hash32{1}: ErrIgnore,
+					{1}: ErrIgnore,
 				},
 			},
 			ignored: true,
@@ -876,9 +876,9 @@ func TestBatchErrorIgnore(t *testing.T) {
 			desc: "recursive reject",
 			error: BatchError{
 				Errors: map[types.Hash32]error{
-					types.Hash32{1}: &BatchError{
+					{1}: &BatchError{
 						Errors: map[types.Hash32]error{
-							types.Hash32{2}: pubsub.ErrValidationReject,
+							{2}: pubsub.ErrValidationReject,
 						},
 					},
 				},
@@ -889,9 +889,9 @@ func TestBatchErrorIgnore(t *testing.T) {
 			desc: "recursive ignore",
 			error: BatchError{
 				Errors: map[types.Hash32]error{
-					types.Hash32{1}: &BatchError{
+					{1}: &BatchError{
 						Errors: map[types.Hash32]error{
-							types.Hash32{2}: ErrIgnore,
+							{2}: ErrIgnore,
 						},
 					},
 				},
@@ -902,12 +902,12 @@ func TestBatchErrorIgnore(t *testing.T) {
 			desc: "random error with reject",
 			error: BatchError{
 				Errors: map[types.Hash32]error{
-					types.Hash32{1}: &BatchError{
+					{1}: &BatchError{
 						Errors: map[types.Hash32]error{
-							types.Hash32{2}: pubsub.ErrValidationReject,
+							{2}: pubsub.ErrValidationReject,
 						},
 					},
-					types.Hash32{3}: errors.New("random error"),
+					{3}: errors.New("random error"),
 				},
 			},
 		},

--- a/fetch/mesh_data_test.go
+++ b/fetch/mesh_data_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/genvm/sdk/wallet"
 	"github.com/spacemeshos/go-spacemesh/log/logtest"
 	"github.com/spacemeshos/go-spacemesh/p2p"
+	"github.com/spacemeshos/go-spacemesh/p2p/pubsub"
 	"github.com/spacemeshos/go-spacemesh/p2p/server"
 	"github.com/spacemeshos/go-spacemesh/proposals/store"
 	"github.com/spacemeshos/go-spacemesh/signing"
@@ -831,6 +832,89 @@ func Test_GetAtxsLimiting(t *testing.T) {
 				err = f.GetAtxs(context.Background(), atxIds, system.WithoutLimiting())
 			}
 			require.NoError(t, err)
+		})
+	}
+}
+
+func TestBatchErrorIgnore(t *testing.T) {
+	for _, tc := range []struct {
+		desc    string
+		error   BatchError
+		ignored bool
+	}{
+		{
+			desc:    "empty",
+			ignored: true,
+		},
+		{
+			desc: "random error",
+			error: BatchError{
+				Errors: map[types.Hash32]error{
+					types.Hash32{1}: errors.New("random error"),
+				},
+			},
+		},
+		{
+			desc: "reject",
+			error: BatchError{
+				Errors: map[types.Hash32]error{
+					types.Hash32{1}: pubsub.ErrValidationReject,
+				},
+			},
+			ignored: true,
+		},
+		{
+			desc: "ignore",
+			error: BatchError{
+				Errors: map[types.Hash32]error{
+					types.Hash32{1}: ErrIgnore,
+				},
+			},
+			ignored: true,
+		},
+		{
+			desc: "recursive reject",
+			error: BatchError{
+				Errors: map[types.Hash32]error{
+					types.Hash32{1}: &BatchError{
+						Errors: map[types.Hash32]error{
+							types.Hash32{2}: pubsub.ErrValidationReject,
+						},
+					},
+				},
+			},
+			ignored: true,
+		},
+		{
+			desc: "recursive ignore",
+			error: BatchError{
+				Errors: map[types.Hash32]error{
+					types.Hash32{1}: &BatchError{
+						Errors: map[types.Hash32]error{
+							types.Hash32{2}: ErrIgnore,
+						},
+					},
+				},
+			},
+			ignored: true,
+		},
+		{
+			desc: "random error with reject",
+			error: BatchError{
+				Errors: map[types.Hash32]error{
+					types.Hash32{1}: &BatchError{
+						Errors: map[types.Hash32]error{
+							types.Hash32{2}: pubsub.ErrValidationReject,
+						},
+					},
+					types.Hash32{3}: errors.New("random error"),
+				},
+			},
+		},
+	} {
+		tc := tc
+		t.Run(tc.desc, func(t *testing.T) {
+			require.Equal(t, tc.ignored, tc.error.Ignore())
 		})
 	}
 }

--- a/proposals/eligibility_validator.go
+++ b/proposals/eligibility_validator.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spacemeshos/go-spacemesh/atxsdata"
 	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/fetch"
 	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/miner/minweight"
 	"github.com/spacemeshos/go-spacemesh/p2p/pubsub"
@@ -114,7 +115,7 @@ func (v *Validator) CheckEligibility(ctx context.Context, ballot *types.Ballot, 
 			MustSerializeVRFMessage(data.Beacon, ballot.Layer.GetEpoch(), atx.Nonce, proof.J), proof.Sig) {
 			return fmt.Errorf(
 				"%w: proof contains incorrect VRF signature. beacon: %v, epoch: %v, counter: %v, vrfSig: %s",
-				pubsub.ErrValidationReject,
+				fetch.ErrIgnore,
 				data.Beacon.ShortString(),
 				ballot.Layer.GetEpoch(),
 				proof.J,

--- a/proposals/handler.go
+++ b/proposals/handler.go
@@ -14,6 +14,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/atxsdata"
 	"github.com/spacemeshos/go-spacemesh/codec"
 	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/fetch"
 	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/metrics"
 	"github.com/spacemeshos/go-spacemesh/p2p"
@@ -481,11 +482,16 @@ func (h *Handler) checkBallotSyntacticValidity(
 	ballotDuration.WithLabelValues(fetchRef).Observe(float64(time.Since(t1)))
 
 	t2 := time.Now()
-	// ballot can be decoded only if all dependencies (blocks, ballots, atxs) were downloaded
+	// ballot can be decoded only if all dependencies (ballots, atxs) were downloaded
 	// and added to the tortoise.
 	decoded, err := h.tortoise.DecodeBallot(b.ToTortoiseData())
 	if err != nil {
-		return nil, fmt.Errorf("failed to decode ballot id %s err %w", b.ID().AsHash32().ShortString(), err)
+		return nil, fmt.Errorf(
+			"%w: failed to decode ballot id %s. %v",
+			fetch.ErrIgnore,
+			b.ID().AsHash32().ShortString(),
+			err,
+		)
 	}
 	ballotDuration.WithLabelValues(decode).Observe(float64(time.Since(t2)))
 
@@ -543,6 +549,7 @@ func (h *Handler) checkBallotDataIntegrity(ctx context.Context, b *types.Ballot)
 						b.ID().String(),
 					)
 				}
+
 				computed, used := h.atxsdata.WeightForSet(set.Epoch, set.Set)
 				for i := range used {
 					if !used[i] {

--- a/proposals/handler_test.go
+++ b/proposals/handler_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/atxsdata"
 	"github.com/spacemeshos/go-spacemesh/codec"
 	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/fetch"
 	"github.com/spacemeshos/go-spacemesh/log/logtest"
 	"github.com/spacemeshos/go-spacemesh/p2p"
 	"github.com/spacemeshos/go-spacemesh/p2p/pubsub"
@@ -806,7 +807,9 @@ func TestBallot_DecodeBeforeVotesConsistency(t *testing.T) {
 
 	decoded := &tortoise.DecodedBallot{BallotTortoiseData: b.ToTortoiseData()}
 	th.md.EXPECT().DecodeBallot(decoded.BallotTortoiseData).Return(decoded, expected)
-	require.ErrorIs(t, th.HandleSyncedBallot(context.Background(), b.ID().AsHash32(), peer, data), expected)
+	err := th.HandleSyncedBallot(context.Background(), b.ID().AsHash32(), peer, data)
+	require.ErrorIs(t, err, fetch.ErrIgnore)
+	require.Contains(t, err.Error(), expected.Error())
 }
 
 func TestBallot_DecodedStoreFailure(t *testing.T) {

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/datastore"
 	"github.com/spacemeshos/go-spacemesh/events"
+	"github.com/spacemeshos/go-spacemesh/fetch"
 	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/mesh"
 	"github.com/spacemeshos/go-spacemesh/p2p"
@@ -401,12 +402,18 @@ func (s *Syncer) synchronize(ctx context.Context) bool {
 		// always sync to currentLayer-1 to reduce race with gossip and hare/tortoise
 		for layerID := s.getLastSyncedLayer().Add(1); layerID.Before(s.ticker.CurrentLayer()); layerID = layerID.Add(1) {
 			if err := s.syncLayer(ctx, layerID); err != nil {
-				if !errors.Is(err, context.Canceled) {
-					// BatchError spams too much, in case of no progress enable debug mode for sync
+				batchError := &fetch.BatchError{}
+				if errors.As(err, &batchError) && batchError.Ignore() {
 					s.logger.With().
-						Debug("failed to sync layer", log.Context(ctx), log.Err(err), layerID)
+						Info("remaining ballots are rejected in the layer", log.Context(ctx), log.Err(err), layerID)
+				} else {
+					if !errors.Is(err, context.Canceled) {
+						// BatchError spams too much, in case of no progress enable debug mode for sync
+						s.logger.With().
+							Debug("failed to sync layer", log.Context(ctx), log.Err(err), layerID)
+					}
+					return false
 				}
-				return false
 			}
 			s.setLastSyncedLayer(layerID)
 		}
@@ -583,7 +590,7 @@ func (s *Syncer) syncMalfeasance(ctx context.Context) error {
 
 func (s *Syncer) syncLayer(ctx context.Context, layerID types.LayerID, peers ...p2p.Peer) error {
 	if err := s.dataFetcher.PollLayerData(ctx, layerID, peers...); err != nil {
-		return fmt.Errorf("download layer data %v: %w", layerID, err)
+		return err
 	}
 	dataLayer.Set(float64(layerID))
 	return nil


### PR DESCRIPTION
related: https://github.com/spacemeshos/go-spacemesh/issues/5701

in the implementation sync loop will repeatedly asks for objects even if it can't process them.
in this pr we allow sync to make progress if the remaining objects in the layer can't be processed with retries.
 