### PR TITLE
[Merged by Bors] - Fix `signer.EdSigner::file` not set when new key is generated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 See [RELEASE](./RELEASE.md) for workflow instructions.
 
+## UNRELEASED
+
+### Upgrade information
+
+### Highlights
+
+### Features
+
+### Improvements
+
+* [#5730](https://github.com/spacemeshos/go-spacemesh/pull/5730) Fixed a bug where the node behaves incorrectly when
+  first started with supervised smeshing.
+
 ## Release v1.4.1
 
 ### Improvements

--- a/node/node_identities.go
+++ b/node/node_identities.go
@@ -120,23 +120,13 @@ func (app *App) NewIdentity() error {
 		return fmt.Errorf("failed to create directory for identity file: %w", err)
 	}
 
+	keyFile := filepath.Join(dir, supervisedIDKeyFileName)
 	signer, err := signing.NewEdSigner(
 		signing.WithPrefix(app.Config.Genesis.GenesisID().Bytes()),
+		signing.ToFile(keyFile),
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create identity: %w", err)
-	}
-
-	keyFile := filepath.Join(dir, supervisedIDKeyFileName)
-	if _, err := os.Stat(keyFile); err == nil {
-		return fmt.Errorf("identity file %s already exists: %w", supervisedIDKeyFileName, fs.ErrExist)
-	}
-
-	dst := make([]byte, hex.EncodedLen(len(signer.PrivateKey())))
-	hex.Encode(dst, signer.PrivateKey())
-	err = os.WriteFile(keyFile, dst, 0o600)
-	if err != nil {
-		return fmt.Errorf("failed to write identity file: %w", err)
 	}
 
 	app.log.With().Info("Created new identity",

--- a/node/node_identities_test.go
+++ b/node/node_identities_test.go
@@ -50,6 +50,7 @@ func TestSpacemeshApp_NewIdentity(t *testing.T) {
 		err := app.NewIdentity()
 		require.NoError(t, err)
 		require.Len(t, app.signers, 1)
+		require.FileExists(t, filepath.Join(app.Config.DataDirParent, keyDir, supervisedIDKeyFileName))
 	})
 
 	t.Run("no key but existing directory", func(t *testing.T) {
@@ -59,6 +60,7 @@ func TestSpacemeshApp_NewIdentity(t *testing.T) {
 		err := app.NewIdentity()
 		require.NoError(t, err)
 		require.Len(t, app.signers, 1)
+		require.FileExists(t, filepath.Join(app.Config.DataDirParent, keyDir, supervisedIDKeyFileName))
 	})
 
 	t.Run("existing key is not overwritten", func(t *testing.T) {

--- a/node/node_identities_test.go
+++ b/node/node_identities_test.go
@@ -70,8 +70,8 @@ func TestSpacemeshApp_NewIdentity(t *testing.T) {
 
 		app, _ := setupAppWithKeys(t, []byte(hex.EncodeToString(signer.PrivateKey())))
 		err = app.NewIdentity()
-		require.ErrorContains(t, err, fmt.Sprintf("identity file %s already exists", supervisedIDKeyFileName))
 		require.ErrorIs(t, err, fs.ErrExist)
+		require.ErrorContains(t, err, fmt.Sprintf("save identity file %s", supervisedIDKeyFileName))
 		require.Empty(t, app.signers)
 
 		err = app.LoadIdentities()

--- a/signing/signer.go
+++ b/signing/signer.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 
@@ -67,11 +68,26 @@ func WithPrefix(prefix []byte) EdSignerOptionFunc {
 	}
 }
 
+// ToFile writes the private key to a file after creation.
+func ToFile(path string) EdSignerOptionFunc {
+	return func(opt *edSignerOption) error {
+		if opt.file != "" {
+			return errors.New("invalid option ToFile: file already set")
+		}
+		opt.file = path
+		return nil
+	}
+}
+
 // FromFile loads the private key from a file.
 func FromFile(path string) EdSignerOptionFunc {
 	return func(opt *edSignerOption) error {
 		if opt.priv != nil {
 			return errors.New("invalid option FromFile: private key already set")
+		}
+
+		if opt.file != "" {
+			return errors.New("invalid option FromFile: file already set")
 		}
 
 		// read hex data from file
@@ -160,6 +176,19 @@ func NewEdSigner(opts ...EdSignerOptionFunc) (*EdSigner, error) {
 			return nil, fmt.Errorf("could not generate key pair: %w", err)
 		}
 		cfg.priv = priv
+
+		if cfg.file != "" {
+			if _, err := os.Stat(cfg.file); err == nil {
+				return nil, fmt.Errorf("identity file %s already exists: %w", filepath.Base(cfg.file), fs.ErrExist)
+			}
+
+			dst := make([]byte, hex.EncodedLen(len(cfg.priv)))
+			hex.Encode(dst, cfg.priv)
+			err = os.WriteFile(cfg.file, dst, 0o600)
+			if err != nil {
+				return nil, fmt.Errorf("failed to write identity file: %w", err)
+			}
+		}
 	}
 	sig := &EdSigner{
 		priv:   cfg.priv,

--- a/signing/signer.go
+++ b/signing/signer.go
@@ -178,8 +178,14 @@ func NewEdSigner(opts ...EdSignerOptionFunc) (*EdSigner, error) {
 		cfg.priv = priv
 
 		if cfg.file != "" {
-			if _, err := os.Stat(cfg.file); err == nil {
-				return nil, fmt.Errorf("identity file %s already exists: %w", filepath.Base(cfg.file), fs.ErrExist)
+			_, err := os.Stat(cfg.file)
+			switch {
+			case errors.Is(err, fs.ErrNotExist):
+			// continue
+			case err != nil:
+				return nil, fmt.Errorf("stat identity file %s: %w", filepath.Base(cfg.file), err)
+			default: // err == nil
+				return nil, fmt.Errorf("save identity file %s: %w", filepath.Base(cfg.file), fs.ErrExist)
 			}
 
 			dst := make([]byte, hex.EncodedLen(len(cfg.priv)))

--- a/signing/signer.go
+++ b/signing/signer.go
@@ -225,7 +225,10 @@ func (es *EdSigner) PrivateKey() PrivateKey {
 
 // Name returns the name of the signer. This is the filename of the identity file.
 func (es *EdSigner) Name() string {
-	return es.file
+	if es.file == "" {
+		return ""
+	}
+	return filepath.Base(es.file)
 }
 
 // VRFSigner wraps same ed25519 key to provide ecvrf.

--- a/signing/signer_test.go
+++ b/signing/signer_test.go
@@ -182,7 +182,7 @@ func TestEdSigner_ToFile(t *testing.T) {
 
 		_, err = NewEdSigner(ToFile(path))
 		require.ErrorIs(t, err, fs.ErrExist)
-		require.ErrorContains(t, err, "identity.key already exists")
+		require.ErrorContains(t, err, "save identity file identity.key")
 
 		_, err = NewEdSigner(FromFile(path), ToFile(path))
 		require.ErrorContains(t, err, "invalid option ToFile: file already set")

--- a/signing/signer_test.go
+++ b/signing/signer_test.go
@@ -31,6 +31,7 @@ func Test_NewEdSigner_WithPrivateKey(t *testing.T) {
 
 	t.Run("valid key", func(t *testing.T) {
 		ed, err := NewEdSigner()
+		require.Empty(t, ed.Name())
 		require.NoError(t, err)
 
 		key := ed.PrivateKey()
@@ -38,6 +39,7 @@ func Test_NewEdSigner_WithPrivateKey(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, ed.priv, ed2.priv)
 		require.Equal(t, ed.PublicKey(), ed2.PublicKey())
+		require.Empty(t, ed2.Name())
 	})
 
 	t.Run("fails if private key already set", func(t *testing.T) {
@@ -114,6 +116,7 @@ func Test_NewEdSigner_FromFile(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, ed.priv, ed2.priv)
 		require.Equal(t, ed.PublicKey(), ed2.PublicKey())
+		require.Equal(t, "identity.key", ed2.Name())
 	})
 
 	t.Run("fails if private key already set", func(t *testing.T) {
@@ -143,6 +146,7 @@ func TestEdSigner_ToFile(t *testing.T) {
 
 		ed, err := NewEdSigner(ToFile(path))
 		require.NoError(t, err)
+		require.Equal(t, "identity.key", ed.Name())
 
 		require.FileExists(t, path)
 		data, err := os.ReadFile(path)


### PR DESCRIPTION
## Motivation

This fixes inconstant behaviour when the node starts for the first time and generates a key. In that case a key is generated and persisted on disk, but the node isn't aware that the key was loaded from `local.key` resulting in inconsistent behaviour.

## Description

`node.App::NewIdentity` is used to generate a key when no key was found during startup. This generated key is then persisted but the created instance of `signing.EdSigner` is never updated to include the "source" of the key. This results in various inconsistencies when the node is first started, because parts of the code believe the key is not `local.key` but a non-supervised key.

I moved persisting the key into a functional option of the `signing.EdSigner` such that a new key generated with it will automatically be in the right state.

## Test Plan

- existing tests pass
- new tests were added to check for the changed behavior

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
