### PR TITLE
[Merged by Bors] - systest: fix RBAC handling

### DIFF
--- a/.github/workflows/systest.yml
+++ b/.github/workflows/systest.yml
@@ -124,6 +124,7 @@ jobs:
           bootstrap: 4m
           level: ${{ inputs.log_level }}
           clusters: 4
+          norbac: 1
         run: make -C systest run test_name=${{ inputs.test_name }}
 
       - name: Delete pod

--- a/systest/Makefile
+++ b/systest/Makefile
@@ -81,11 +81,11 @@ run: gomplate $(run_deps)
 	@echo "launching test job with name=$(test_job_name) and testid=$(test_id)"
 	@testid=$(test_id) job_name=$(test_job_name) image=$(image_name) command="$(command)" \
 	  gomplate --file systest_job.yml.tmpl | kubectl apply -f -
-	@if [ -z "${norbac} ]; then \
+	@if [ -z "${norbac}" ]; then \
 	  testid=$(test_id) job_name=$(test_job_name) image=$(image_name) command="$(command)" \
-	    gomplate --file systest_rbac.yml.tmpl | kubectl apply -f -
+	    gomplate --file systest_rbac.yml.tmpl | kubectl apply -f -; \
 	fi
-	until kubectl get jobs $(test_job_name); do sleep 1; done
+	until kubectl get pod -l job-name=$(test_job_name) | grep -q .; do sleep 1; done
 	kubectl wait --timeout=30s --for=condition=ready -l job-name=$(test_job_name) pod
 	kubectl logs job/$(test_job_name) -f --ignore-errors
 	test_job_name=$(test_job_name) bash ./wait_for_job.sh

--- a/systest/Makefile
+++ b/systest/Makefile
@@ -79,7 +79,12 @@ gomplate:
 .PHONY: run
 run: gomplate $(run_deps)
 	@echo "launching test job with name=$(test_job_name) and testid=$(test_id)"
-	@testid=$(test_id) job_name=$(test_job_name) image=$(image_name) command="$(command)" gomplate --file systest_job.yml.tmpl | kubectl apply -f -
+	@testid=$(test_id) job_name=$(test_job_name) image=$(image_name) command="$(command)" \
+	  gomplate --file systest_job.yml.tmpl | kubectl apply -f -
+	@if [ -z "${norbac} ]; then \
+	  testid=$(test_id) job_name=$(test_job_name) image=$(image_name) command="$(command)" \
+	    gomplate --file systest_rbac.yml.tmpl | kubectl apply -f -
+	fi
 	until kubectl get jobs $(test_job_name); do sleep 1; done
 	kubectl wait --timeout=30s --for=condition=ready -l job-name=$(test_job_name) pod
 	kubectl logs job/$(test_job_name) -f --ignore-errors

--- a/systest/Makefile
+++ b/systest/Makefile
@@ -74,6 +74,8 @@ config: template
 gomplate:
 	@go install github.com/hairyhenderson/gomplate/v4/cmd/gomplate@v4.0.0-pre-1
 
+# Using bash to invoke ./wait_for_job.sh script to avoid problems on Mac
+# where /bin/bash is an old bash
 .PHONY: run
 run: gomplate $(run_deps)
 	@echo "launching test job with name=$(test_job_name) and testid=$(test_id)"
@@ -81,7 +83,7 @@ run: gomplate $(run_deps)
 	until kubectl get jobs $(test_job_name); do sleep 1; done
 	kubectl wait --timeout=30s --for=condition=ready -l job-name=$(test_job_name) pod
 	kubectl logs job/$(test_job_name) -f --ignore-errors
-	test_job_name=$(test_job_name) ./wait_for_job.sh
+	test_job_name=$(test_job_name) bash ./wait_for_job.sh
 
 .PHONY: clean
 clean:

--- a/systest/Makefile
+++ b/systest/Makefile
@@ -79,11 +79,14 @@ gomplate:
 .PHONY: run
 run: gomplate $(run_deps)
 	@echo "launching test job with name=$(test_job_name) and testid=$(test_id)"
-	@testid=$(test_id) job_name=$(test_job_name) image=$(image_name) command="$(command)" \
-	  gomplate --file systest_job.yml.tmpl | kubectl apply -f -
 	@if [ -z "${norbac}" ]; then \
+	  testid=$(test_id) job_name=$(test_job_name) image=$(image_name) command="$(command)" rbac=1 \
+	    gomplate --file systest_job.yml.tmpl | kubectl apply -f -; \
 	  testid=$(test_id) job_name=$(test_job_name) image=$(image_name) command="$(command)" \
 	    gomplate --file systest_rbac.yml.tmpl | kubectl apply -f -; \
+	else \
+	  testid=$(test_id) job_name=$(test_job_name) image=$(image_name) command="$(command)" \
+	    gomplate --file systest_job.yml.tmpl | kubectl apply -f -; \
 	fi
 	until kubectl get pod -l job-name=$(test_job_name) | grep -q .; do sleep 1; done
 	kubectl wait --timeout=30s --for=condition=ready -l job-name=$(test_job_name) pod

--- a/systest/README.md
+++ b/systest/README.md
@@ -13,7 +13,7 @@ This testing setup can run on top of any k8s installation. The instructions belo
     sudo install minikube-linux-amd64 /usr/local/bin/minikube
     ```
 
-2. Grant permissions for default `serviceaccount` so that it will be allowed to create namespaces by client that runs in-cluster.
+2. Grant permissions for default `serviceaccount` so that it will be allowed to create namespaces by client that runs in-cluster. NOTE: this step is optional, do it only if you're experiencing RBAC related problems with a throwaway cluster. Never perform it on a real cluster!
 
     ```bash
     kubectl create clusterrolebinding serviceaccounts-cluster-admin \

--- a/systest/cluster/nodes.go
+++ b/systest/cluster/nodes.go
@@ -498,7 +498,6 @@ func waitPod(ctx *testcontext.Context, id string) (*apiv1.Pod, error) {
 	}
 	defer watcher.Stop()
 	for {
-		var pod *apiv1.Pod
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
@@ -506,7 +505,10 @@ func waitPod(ctx *testcontext.Context, id string) (*apiv1.Pod, error) {
 			if !open {
 				return nil, fmt.Errorf("watcher is terminated while waiting for pod with id %v", id)
 			}
-			pod = ev.Object.(*apiv1.Pod)
+			pod, ok := ev.Object.(*apiv1.Pod)
+			if !ok {
+				continue
+			}
 			if pod.Status.Phase == apiv1.PodRunning && areContainersReady(pod) {
 				return pod, nil
 			}

--- a/systest/systest_job.yml.tmpl
+++ b/systest/systest_job.yml.tmpl
@@ -21,3 +21,34 @@ spec:
         imagePullPolicy: IfNotPresent
         name: {{ .Env.job_name}}
       restartPolicy: Never
+      serviceAccount: {{ .Env.job_name }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Env.job_name }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Env.job_name }}
+rules:
+- apiGroups: [""]
+  resources: ["services","namespaces","configmaps","pods"]
+  verbs: ["get","create","patch","update","list","watch"]
+- apiGroups: ["apps"]
+  resources: ["deployments"]
+  verbs: ["get","create","patch","update","list","watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Env.job_name }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Env.job_name }}
+  namespace: testnet-10x
+roleRef:
+  kind: ClusterRole
+  name: {{ .Env.job_name }}
+  apiGroup: rbac.authorization.k8s.io

--- a/systest/systest_job.yml.tmpl
+++ b/systest/systest_job.yml.tmpl
@@ -22,33 +22,3 @@ spec:
         name: {{ .Env.job_name}}
       restartPolicy: Never
       serviceAccount: {{ .Env.job_name }}
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: {{ .Env.job_name }}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: {{ .Env.job_name }}
-rules:
-- apiGroups: [""]
-  resources: ["services","namespaces","configmaps","pods"]
-  verbs: ["get","create","patch","update","list","watch"]
-- apiGroups: ["apps"]
-  resources: ["deployments"]
-  verbs: ["get","create","patch","update","list","watch"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: {{ .Env.job_name }}
-subjects:
-- kind: ServiceAccount
-  name: {{ .Env.job_name }}
-  namespace: testnet-10x
-roleRef:
-  kind: ClusterRole
-  name: {{ .Env.job_name }}
-  apiGroup: rbac.authorization.k8s.io

--- a/systest/systest_job.yml.tmpl
+++ b/systest/systest_job.yml.tmpl
@@ -21,4 +21,6 @@ spec:
         imagePullPolicy: IfNotPresent
         name: {{ .Env.job_name}}
       restartPolicy: Never
+      {{ if (index .Env "rbac") }}
       serviceAccount: {{ .Env.job_name }}
+      {{ end }}

--- a/systest/systest_rbac.yml.tmpl
+++ b/systest/systest_rbac.yml.tmpl
@@ -1,0 +1,33 @@
+# Template for Systest RBAC objects
+# Uses gomplate syntax (see https://gomplate.ca)
+# Usage:
+# testid=<> job_name=<> image=<> command=<> gomplate --file systest_rbac.yml.tmpl -o systest_rbac.yml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Env.job_name }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Env.job_name }}
+rules:
+- apiGroups: [""]
+  resources: ["services","namespaces","configmaps","pods"]
+  verbs: ["get","create","patch","update","list","watch"]
+- apiGroups: ["apps"]
+  resources: ["deployments"]
+  verbs: ["get","create","patch","update","list","watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Env.job_name }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Env.job_name }}
+  namespace: testnet-10x
+roleRef:
+  kind: ClusterRole
+  name: {{ .Env.job_name }}
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
## Motivation

It may be convenient to run the systests against an existing cluster, yet the current setup requires admin permissions for the default service account. Applying such settings compromises cluster security and should only be done on throwaway clusters. It's also not considered to be a good practice in general.

Besides, `waitPod` was sometimes crashing due to bad type cast.

## Description

Don't require admin permissions for the default service account, so that the tests can be run against an existing cluster without compromising its security settings.
Also, don't crash if an event with a Status instead of a Pod arrives when waiting for a pod.

## Test Plan

Check locally; do `bors try`.

## TODO

- [X] Explain motivation or link existing issue(s)
- [ ] Test changes and document test plan
- [X] Update documentation as needed

