### PR TITLE
[Merged by Bors] - fetch: don't hold database connections for long in streaming mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ See [RELEASE](./RELEASE.md) for workflow instructions.
   `127.0.0.1:0` instead of `127.0.0.1:9094`. This will ensure that a node binds the post service to a random free port
   and prevents multiple instances of the post service from binding to the same port.
 
+* [#5735](https://github.com/spacemeshos/go-spacemesh/pull/5735) Don't hold database connections for long in fetcher
+  streaming mode
+
 ## Release v1.4.1
 
 ### Improvements

--- a/fetch/handler.go
+++ b/fetch/handler.go
@@ -65,9 +65,16 @@ func (h *handler) handleMaliciousIDsReq(ctx context.Context, _ []byte) ([]byte, 
 
 func (h *handler) handleMaliciousIDsReqStream(ctx context.Context, msg []byte, s io.ReadWriter) error {
 	if err := h.streamIDs(ctx, s, func(cbk retrieveCallback) error {
-		return identities.IterateMalicious(h.cdb, func(total int, id types.NodeID) error {
-			return cbk(total, id[:])
-		})
+		nodeIDs, err := identities.GetMalicious(h.cdb)
+		if err != nil {
+			h.logger.With().Warning("serve: failed to get malicious IDs",
+				log.Context(ctx), log.Err(err))
+			return err
+		}
+		for _, nodeID := range nodeIDs {
+			cbk(len(nodeIDs), nodeID[:])
+		}
+		return nil
 	}); err != nil {
 		h.logger.With().
 			Debug("serve: failed to stream malicious node IDs",
@@ -114,9 +121,16 @@ func (h *handler) handleEpochInfoReqStream(ctx context.Context, msg []byte, s io
 		return err
 	}
 	if err := h.streamIDs(ctx, s, func(cbk retrieveCallback) error {
-		return atxs.IterateIDsByEpoch(h.cdb, epoch, func(total int, id types.ATXID) error {
-			return cbk(total, id[:])
-		})
+		atxids, err := atxs.GetIDsByEpoch(ctx, h.cdb, epoch)
+		if err != nil {
+			h.logger.With().Warning("serve: failed to get epoch atx IDs",
+				epoch, log.Err(err), log.Context(ctx))
+			return err
+		}
+		for _, atxID := range atxids {
+			cbk(len(atxids), atxID[:])
+		}
+		return nil
 	}); err != nil {
 		h.logger.With().Debug("serve: failed to stream epoch atx IDs",
 			log.Context(ctx), epoch, log.Err(err))
@@ -453,17 +467,24 @@ func (h *handler) handleMeshHashReqStream(ctx context.Context, reqData []byte, s
 			log.Context(ctx), log.Err(err))
 		return errBadRequest
 	}
-	if err := req.Validate(); err != nil {
-		h.logger.With().Debug("failed to validate mesh hash request",
-			log.Context(ctx), log.Err(err))
-		return err
-	}
 
 	if err := h.streamIDs(ctx, s, func(cbk retrieveCallback) error {
-		return layers.IterateAggHashes(
-			h.cdb, req.From, req.To, req.Step, func(total int, id types.Hash32) error {
-				return cbk(total, id[:])
-			})
+		if err := req.Validate(); err != nil {
+			h.logger.With().Debug("failed to validate mesh hash request",
+				log.Context(ctx), log.Err(err))
+			return err
+		}
+
+		hashes, err := layers.GetAggHashes(h.cdb, req.From, req.To, req.Step)
+		if err != nil {
+			h.logger.With().Warning("serve: failed to get mesh hashes",
+				log.Context(ctx), log.Err(err))
+			return err
+		}
+		for _, id := range hashes {
+			cbk(len(hashes), id[:])
+		}
+		return nil
 	}); err != nil {
 		h.logger.With().
 			Debug("serve: failed to stream mesh hashes",


### PR DESCRIPTION
## Motivation

In streaming mode, database connections could be held for long time, causing database connection pool starvation

## Description

This is a simple fix that ensures that fetches the necessary slices of IDs from the database before streaming them.
In a followup, SQL cache support for malfeasant node IDs will be added.

## Test Plan

Test on mainnet

## TODO

<!-- Please tick off the TODOs when completed -->

- [X] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update [changelog](../CHANGELOG.md) as needed
