### PR TITLE
[Merged by Bors] - sql: fix epoch ATX ID cache deadlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ See [RELEASE](./RELEASE.md) for workflow instructions.
 * [#5735](https://github.com/spacemeshos/go-spacemesh/pull/5735) Don't hold database connections for long in fetcher
   streaming mode
 
+* [#5738](https://github.com/spacemeshos/go-spacemesh/pull/5738) sql: fix epoch ATX ID cache deadlock
+
 ## Release v1.4.1
 
 ### Improvements

--- a/activation/handler.go
+++ b/activation/handler.go
@@ -472,6 +472,7 @@ func (h *Handler) storeAtx(ctx context.Context, atx *types.VerifiedActivationTx)
 	}); err != nil {
 		return nil, fmt.Errorf("store atx: %w", err)
 	}
+	atxs.AtxAdded(h.cdb, atx)
 	if proof != nil {
 		h.cdb.CacheMalfeasanceProof(atx.SmesherID, proof)
 		h.tortoise.OnMalfeasance(atx.SmesherID)

--- a/fetch/handler_test.go
+++ b/fetch/handler_test.go
@@ -361,6 +361,7 @@ func testHandleEpochInfoReqWithQueryCache(
 	for i := 0; i < 10; i++ {
 		vatx := newAtx(t, epoch)
 		require.NoError(t, atxs.Add(th.cdb, vatx))
+		atxs.AtxAdded(th.cdb, vatx)
 		expected.AtxIDs = append(expected.AtxIDs, vatx.ID())
 	}
 
@@ -379,6 +380,7 @@ func testHandleEpochInfoReqWithQueryCache(
 	// Add another ATX which should be appended to the cached slice
 	vatx := newAtx(t, epoch)
 	require.NoError(t, atxs.Add(th.cdb, vatx))
+	atxs.AtxAdded(th.cdb, vatx)
 	expected.AtxIDs = append(expected.AtxIDs, vatx.ID())
 	require.Equal(t, 12, qc.QueryCount())
 

--- a/sql/atxs/atxs.go
+++ b/sql/atxs/atxs.go
@@ -388,9 +388,13 @@ func Add(db sql.Executor, atx *types.VerifiedActivationTx) error {
 	if err != nil {
 		return fmt.Errorf("insert ATX ID %v: %w", atx.ID(), err)
 	}
+	return nil
+}
+
+// AtxAdded updates epoch query cache with new ATX, if the query cache is enabled.
+func AtxAdded(db sql.Executor, atx *types.VerifiedActivationTx) {
 	epochCacheKey := sql.QueryCacheKey(CacheKindEpochATXs, atx.PublishEpoch.String())
 	sql.AppendToCachedSlice(db, epochCacheKey, atx.ID())
-	return nil
 }
 
 type Filter func(types.ATXID) bool

--- a/sql/atxs/atxs_test.go
+++ b/sql/atxs/atxs_test.go
@@ -445,6 +445,7 @@ func TestGetIDsByEpochCached(t *testing.T) {
 
 	for _, atx := range []*types.VerifiedActivationTx{atx1, atx2, atx3, atx4} {
 		require.NoError(t, atxs.Add(db, atx))
+		atxs.AtxAdded(db, atx)
 	}
 
 	require.Equal(t, 4, db.QueryCount())
@@ -475,6 +476,7 @@ func TestGetIDsByEpochCached(t *testing.T) {
 		atxs.Add(tx, atx5)
 		return nil
 	}))
+	atxs.AtxAdded(db, atx5)
 	require.Equal(t, 8, db.QueryCount())
 
 	ids3, err := atxs.GetIDsByEpoch(ctx, db, e3)


### PR DESCRIPTION
## Motivation

SQL query cache deadlocks b/c during transactions, SQLite lock is held while cache update lock is being acquired.

## Description

Fixes the deadlock by bringing cached slice update out of the transactions.

## Test Plan

Verified on mainnet

