### PR TITLE
[Merged by Bors] - drop hash registrations on epoch info responnse

### DIFF
--- a/fetch/mesh_data.go
+++ b/fetch/mesh_data.go
@@ -303,7 +303,6 @@ func (f *Fetch) PeerEpochInfo(ctx context.Context, peer p2p.Peer, epoch types.Ep
 			return nil, fmt.Errorf("decoding epoch data: %w", err)
 		}
 	}
-	f.RegisterPeerHashes(peer, types.ATXIDsToHashes(ed.AtxIDs))
 	return ed, nil
 }
 


### PR DESCRIPTION
we keep a mapping of hashes to peers that should have those hashes, 
however epoch info is too large to fit in that cache (it is currently around 2_000_000), so
registering it is ineffective and simply thrashes lru cache that we use for that mapping.

if we don't have mapping for a hash, we will use best peers instead.