### PR TITLE
[Merged by Bors] - fetch: fix handling hash request errors in streaming mode

### DIFF
--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -730,7 +730,7 @@ func (f *Fetch) streamBatch(peer p2p.Peer, batch *batchInfo) error {
 	// Request is synchronous, it will return errors only if size of the bytes buffer
 	// is large or target peer is not connected
 	req := codec.MustEncode(&batch.RequestBatch)
-	return f.meteredStreamRequest(
+	err := f.meteredStreamRequest(
 		f.shutdownCtx, hashProtocol, peer, req,
 		func(ctx context.Context, s io.ReadWriter) (int, error) {
 			batchMap := batch.toMap()
@@ -739,13 +739,6 @@ func (f *Fetch) streamBatch(peer p2p.Peer, batch *batchInfo) error {
 				return f.receiveStreamedBatch(ctx, s, batch, batchMap)
 			})
 			if err != nil {
-				f.logger.With().Debug(
-					"failed to send batch request",
-					log.Stringer("batch", batch.ID),
-					log.Stringer("peer", peer),
-					log.Err(err),
-				)
-				f.handleHashError(batch, err)
 				return n, err
 			}
 
@@ -762,6 +755,16 @@ func (f *Fetch) streamBatch(peer p2p.Peer, batch *batchInfo) error {
 
 			return n, nil
 		})
+	if err != nil {
+		f.logger.With().Debug(
+			"failed to send batch request",
+			log.Stringer("batch", batch.ID),
+			log.Stringer("peer", peer),
+			log.Err(err),
+		)
+		f.handleHashError(batch, err)
+	}
+	return err
 }
 
 func (f *Fetch) receiveStreamedBatch(

--- a/fetch/mesh_data_test.go
+++ b/fetch/mesh_data_test.go
@@ -107,7 +107,7 @@ func generateLayerContent(t *testing.T) []byte {
 	return out
 }
 
-func TestFetch_getHashes(t *testing.T) {
+func testFetch_getHashes(t *testing.T, streaming bool) {
 	blks := []*types.Block{
 		genLayerBlock(types.LayerID(10), types.RandomTXSet(10)),
 		genLayerBlock(types.LayerID(11), types.RandomTXSet(10)),
@@ -119,6 +119,7 @@ func TestFetch_getHashes(t *testing.T) {
 		name      string
 		fetchErrs map[types.Hash32]struct{}
 		hdlrErr   error
+		reqErr    error
 	}{
 		{
 			name: "all hashes fetched",
@@ -126,6 +127,10 @@ func TestFetch_getHashes(t *testing.T) {
 		{
 			name:      "all hashes failed",
 			fetchErrs: map[types.Hash32]struct{}{hashes[0]: {}, hashes[1]: {}, hashes[2]: {}},
+		},
+		{
+			name:   "hash request failed",
+			reqErr: errors.New("request failed"),
 		},
 		{
 			name:      "some hashes failed",
@@ -146,6 +151,7 @@ func TestFetch_getHashes(t *testing.T) {
 			f.cfg.QueueSize = 3
 			f.cfg.BatchSize = 2
 			f.cfg.MaxRetriesForRequest = 0
+			f.cfg.Streaming = streaming
 			peers := []p2p.Peer{p2p.Peer("buddy 0"), p2p.Peer("buddy 1")}
 			for _, peer := range peers {
 				f.peers.Add(peer)
@@ -162,47 +168,76 @@ func TestFetch_getHashes(t *testing.T) {
 				}
 				responses[h] = res
 			}
-			f.mHashS.EXPECT().
-				Request(gomock.Any(), gomock.Any(), gomock.Any()).
-				DoAndReturn(
-					func(_ context.Context, p p2p.Peer, req []byte) ([]byte, error) {
-						var rb RequestBatch
-						err := codec.Decode(req, &rb)
-						require.NoError(t, err)
+			requestFn := func(_ context.Context, p p2p.Peer, req []byte) ([]byte, error) {
+				if tc.reqErr != nil {
+					return nil, tc.reqErr
+				}
+				var rb RequestBatch
+				err := codec.Decode(req, &rb)
+				require.NoError(t, err)
 
-						resBatch := ResponseBatch{
-							ID: rb.ID,
-						}
-						for _, r := range rb.Requests {
-							if _, ok := tc.fetchErrs[r.Hash]; ok {
-								continue
+				resBatch := ResponseBatch{
+					ID: rb.ID,
+				}
+				for _, r := range rb.Requests {
+					if _, ok := tc.fetchErrs[r.Hash]; ok {
+						continue
+					}
+					res := responses[r.Hash]
+					resBatch.Responses = append(resBatch.Responses, res)
+					f.mBlocksH.EXPECT().
+						HandleMessage(gomock.Any(), res.Hash, p, res.Data).
+						Return(tc.hdlrErr)
+				}
+				bts, err := codec.Encode(&resBatch)
+				require.NoError(t, err)
+
+				return bts, nil
+			}
+			if streaming {
+				f.mHashS.EXPECT().
+					StreamRequest(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					DoAndReturn(
+						func(
+							ctx context.Context,
+							p p2p.Peer,
+							req []byte,
+							cbk server.StreamRequestCallback,
+						) error {
+							b, err := requestFn(ctx, p, req)
+							if err != nil {
+								return err
 							}
-							res := responses[r.Hash]
-							resBatch.Responses = append(resBatch.Responses, res)
-							f.mBlocksH.EXPECT().
-								HandleMessage(gomock.Any(), res.Hash, p, res.Data).
-								Return(tc.hdlrErr)
-						}
-						bts, err := codec.Encode(&resBatch)
-						require.NoError(t, err)
+							resp := &server.Response{Data: b}
+							buf := bytes.NewBuffer(codec.MustEncode(resp))
+							return cbk(ctx, buf)
+						}).
+					Times(len(peers))
+			} else {
+				f.mHashS.EXPECT().
+					Request(gomock.Any(), gomock.Any(), gomock.Any()).
+					DoAndReturn(requestFn).
+					Times(len(peers))
+			}
 
-						return bts, nil
-					}).
-				Times(len(peers))
-
-			got := f.getHashes(
+			err := f.getHashes(
 				context.Background(),
 				hashes,
 				datastore.BlockDB,
 				f.validators.block.HandleMessage,
 			)
-			if len(tc.fetchErrs) > 0 || tc.hdlrErr != nil {
-				require.NotEmpty(t, got)
+			if len(tc.fetchErrs) > 0 || tc.hdlrErr != nil || tc.reqErr != nil {
+				require.Error(t, err)
 			} else {
-				require.Empty(t, got)
+				require.NoError(t, err)
 			}
 		})
 	}
+}
+
+func TestFetch_getHashes(t *testing.T) {
+	t.Run("no streaming", func(t *testing.T) { testFetch_getHashes(t, false) })
+	t.Run("streaming", func(t *testing.T) { testFetch_getHashes(t, true) })
 }
 
 func TestFetch_GetMalfeasanceProofs(t *testing.T) {


### PR DESCRIPTION
## Motivation

Hash fetching could get stuck upon request errors, blocking sync

## Description

Fix handling hash errors (avoid having unsatisfied promises)

## Test Plan

Tested on mainnet

