### PR TITLE
[Merged by Bors] - disable log that tx was already received from gossip

### DIFF
--- a/txs/handler.go
+++ b/txs/handler.go
@@ -65,7 +65,9 @@ func (th *TxHandler) HandleGossipTransaction(ctx context.Context, peer p2p.Peer,
 	err := th.VerifyAndCacheTx(ctx, msg)
 	updateMetrics(err, gossipTxCount)
 	if err != nil {
-		th.logger.WithContext(ctx).With().Warning("failed to handle tx", log.Err(err))
+		if !errors.Is(err, errDuplicateTX) {
+			th.logger.WithContext(ctx).With().Warning("failed to handle tx", log.Err(err))
+		}
 		return err
 	}
 	return nil


### PR DESCRIPTION
duplicates are expected on gossip, there is no need to log that,
but we want to return an error up the stack so that it is not gossiped further

> 2024-03-21T09:34:27.947Z        WARN    node.txHandler  failed to handle tx     {"requestId": "17e4c758", "errmsg": "tx already exists", "name": "txHandler"}
> 2024-03-21T09:36:36.947Z        WARN    node.txHandler  failed to handle tx     {"requestId": "e3a015ef", "errmsg": "tx already exists", "name": "txHandler"}
