### PR TITLE
[Merged by Bors] - Fix segmentation fault during initial post

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 See [RELEASE](./RELEASE.md) for workflow instructions.
 
+## UNRELEASED
+
+### Upgrade information
+
+### Highlights
+
+### Features
+
+### Improvements
+
+* [#5753](ttps://github.com/spacemeshos/go-spacemesh/pull/5753) Fix for a possible segmentation fault in setups with
+  remote post services when an identity does their initial proof.
+
 ## Release v1.4.2
 
 ### Improvements

--- a/activation/activation.go
+++ b/activation/activation.go
@@ -325,6 +325,12 @@ func (b *Builder) buildInitialPost(ctx context.Context, nodeID types.NodeID) err
 	if err != nil {
 		return fmt.Errorf("post execution: %w", err)
 	}
+	if postInfo.Nonce == nil {
+		b.log.Error("initial PoST is invalid: missing VRF nonce. Check your PoST data",
+			log.ZShortStringer("smesherID", nodeID),
+		)
+		return errors.New("nil VRF nonce")
+	}
 	initialPost := nipost.Post{
 		Nonce:   post.Nonce,
 		Indices: post.Indices,

--- a/activation/activation_test.go
+++ b/activation/activation_test.go
@@ -1544,8 +1544,8 @@ func TestBuilder_InitialPostLogErrorMissingVRFNonce(t *testing.T) {
 	tab.mValidator.EXPECT().Post(gomock.Any(), sig.NodeID(), commitmentATX, initialPost, meta, numUnits).
 		Return(nil)
 	require.ErrorContains(t, tab.buildInitialPost(context.Background(), sig.NodeID()), "nil VRF nonce")
-	observedLogs := tab.observedLogs.FilterLevelExact(zapcore.ErrorLevel)
 
+	observedLogs := tab.observedLogs.FilterLevelExact(zapcore.ErrorLevel)
 	require.Equal(t, 1, observedLogs.Len(), "expected 1 log message")
 	require.Equal(t, zapcore.ErrorLevel, observedLogs.All()[0].Level)
 	require.Equal(t, "initial PoST is invalid: missing VRF nonce. Check your PoST data", observedLogs.All()[0].Message)

--- a/activation/activation_test.go
+++ b/activation/activation_test.go
@@ -14,7 +14,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 	"golang.org/x/exp/maps"
 	"golang.org/x/sync/errgroup"
 
@@ -23,6 +25,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/datastore"
 	datastoremocks "github.com/spacemeshos/go-spacemesh/datastore/mocks"
 	"github.com/spacemeshos/go-spacemesh/events"
+	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/log/logtest"
 	"github.com/spacemeshos/go-spacemesh/p2p/pubsub"
 	"github.com/spacemeshos/go-spacemesh/p2p/pubsub/mocks"
@@ -114,17 +117,20 @@ type testAtxBuilder struct {
 	localDb     *localsql.Database
 	goldenATXID types.ATXID
 
-	mctrl       *gomock.Controller
-	mpub        *mocks.MockPublisher
-	mnipost     *MocknipostBuilder
-	mpostClient *MockPostClient
-	mclock      *MocklayerClock
-	msync       *Mocksyncer
-	mValidator  *MocknipostValidator
+	observedLogs *observer.ObservedLogs
+	mctrl        *gomock.Controller
+	mpub         *mocks.MockPublisher
+	mnipost      *MocknipostBuilder
+	mpostClient  *MockPostClient
+	mclock       *MocklayerClock
+	msync        *Mocksyncer
+	mValidator   *MocknipostValidator
 }
 
 func newTestBuilder(tb testing.TB, numSigners int, opts ...BuilderOption) *testAtxBuilder {
-	lg := logtest.New(tb, zapcore.DebugLevel)
+	observer, observedLogs := observer.New(zapcore.DebugLevel)
+	logger := zap.New(observer)
+	lg := log.NewFromLog(logger)
 
 	ctrl := gomock.NewController(tb)
 	tab := &testAtxBuilder{
@@ -132,13 +138,14 @@ func newTestBuilder(tb testing.TB, numSigners int, opts ...BuilderOption) *testA
 		localDb:     localsql.InMemory(sql.WithConnections(numSigners)),
 		goldenATXID: types.ATXID(types.HexToHash32("77777")),
 
-		mctrl:       ctrl,
-		mpub:        mocks.NewMockPublisher(ctrl),
-		mnipost:     NewMocknipostBuilder(ctrl),
-		mpostClient: NewMockPostClient(ctrl),
-		mclock:      NewMocklayerClock(ctrl),
-		msync:       NewMocksyncer(ctrl),
-		mValidator:  NewMocknipostValidator(ctrl),
+		observedLogs: observedLogs,
+		mctrl:        ctrl,
+		mpub:         mocks.NewMockPublisher(ctrl),
+		mnipost:      NewMocknipostBuilder(ctrl),
+		mpostClient:  NewMockPostClient(ctrl),
+		mclock:       NewMocklayerClock(ctrl),
+		msync:        NewMocksyncer(ctrl),
+		mValidator:   NewMocknipostValidator(ctrl),
 	}
 
 	opts = append(opts, WithValidator(tab.mValidator))
@@ -158,7 +165,7 @@ func newTestBuilder(tb testing.TB, numSigners int, opts ...BuilderOption) *testA
 		tab.mnipost,
 		tab.mclock,
 		tab.msync,
-		lg.Zap(),
+		logger,
 		opts...,
 	)
 	tab.Builder = b
@@ -1505,6 +1512,59 @@ func TestBuilder_InitialPostIsPersisted(t *testing.T) {
 	require.NoError(t, tab.buildInitialPost(context.Background(), sig.NodeID()))
 
 	// postClient.Proof() should not be called again
+	require.NoError(t, tab.buildInitialPost(context.Background(), sig.NodeID()))
+}
+
+func TestBuilder_InitialPostLogErrorMissingVRFNonce(t *testing.T) {
+	tab := newTestBuilder(t, 1, WithPoetConfig(PoetConfig{PhaseShift: layerDuration * 4}))
+	sig := maps.Values(tab.signers)[0]
+
+	commitmentATX := types.RandomATXID()
+	numUnits := uint32(12)
+	initialPost := &types.Post{
+		Nonce:   rand.Uint32(),
+		Indices: types.RandomBytes(10),
+		Pow:     rand.Uint64(),
+	}
+	meta := &types.PostMetadata{
+		Challenge:     shared.ZeroChallenge,
+		LabelsPerUnit: tab.conf.LabelsPerUnit,
+	}
+	tab.mnipost.EXPECT().Proof(gomock.Any(), sig.NodeID(), shared.ZeroChallenge).Return(
+		initialPost,
+		&types.PostInfo{
+			NodeID:        sig.NodeID(),
+			CommitmentATX: commitmentATX,
+
+			NumUnits:      numUnits,
+			LabelsPerUnit: tab.conf.LabelsPerUnit,
+		},
+		nil,
+	)
+	tab.mValidator.EXPECT().Post(gomock.Any(), sig.NodeID(), commitmentATX, initialPost, meta, numUnits).
+		Return(nil)
+	require.ErrorContains(t, tab.buildInitialPost(context.Background(), sig.NodeID()), "nil VRF nonce")
+	observedLogs := tab.observedLogs.FilterLevelExact(zapcore.ErrorLevel)
+
+	require.Equal(t, 1, observedLogs.Len(), "expected 1 log message")
+	require.Equal(t, zapcore.ErrorLevel, observedLogs.All()[0].Level)
+	require.Equal(t, "initial PoST is invalid: missing VRF nonce. Check your PoST data", observedLogs.All()[0].Message)
+	require.Equal(t, sig.NodeID().ShortString(), observedLogs.All()[0].ContextMap()["smesherID"])
+
+	// postClient.Proof() should be called again and no error if vrf nonce is provided
+	nonce := types.VRFPostIndex(rand.Uint64())
+	tab.mnipost.EXPECT().Proof(gomock.Any(), sig.NodeID(), shared.ZeroChallenge).Return(
+		initialPost,
+		&types.PostInfo{
+			NodeID:        sig.NodeID(),
+			CommitmentATX: commitmentATX,
+			Nonce:         &nonce,
+
+			NumUnits:      numUnits,
+			LabelsPerUnit: tab.conf.LabelsPerUnit,
+		},
+		nil,
+	)
 	require.NoError(t, tab.buildInitialPost(context.Background(), sig.NodeID()))
 }
 


### PR DESCRIPTION
## Motivation

This fixes a possible segmentation fault when building an initial post in a setup with a remote post service.

## Description

Closes #5752 

The cause of the segmentation fault is a missing VRF Nonce in the Metadata sent by the PoST service. This is usually caused by starting the PoST service before the data it uses has been completely initialized.

This fix only prevents the node from crashing in this case. It will instead log an error now (every 5 minutes) informing the user that they have to check the PoST data for completeness.

## Test Plan

- a new tests was added to check for this specific behavior

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
