### PR TITLE
[Merged by Bors] - Use fixed gcloud version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,6 +80,8 @@ jobs:
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: "450.0.0"
 
       - name: Upload zip
         uses: google-github-actions/upload-cloud-storage@v2
@@ -144,6 +146,8 @@ jobs:
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: "450.0.0"
 
       - name: Upload sha256sums
         uses: google-github-actions/upload-cloud-storage@v2


### PR DESCRIPTION
## Motivation

This pins the gcloud version in the build jobs preventing them from running out of disk space.

## Description

Gcloud has a new release every few days and that new release gets installed without the old one being removed if no version is pinned.

This over multiple weeks causes the self hosted runners to fill up on data and their disks run full causing them to fail builds that they normally wouldn't.

## Test Plan

- n/a

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
