### PR TITLE
lower request timeout for faster recovery from partition for system tests

### DIFF
--- a/config/presets/fastnet.go
+++ b/config/presets/fastnet.go
@@ -54,6 +54,7 @@ func fastnet() config.Config {
 	conf.Sync.AtxSync.EpochInfoInterval = 20 * time.Second
 	conf.LayersPerEpoch = 4
 	conf.RegossipAtxInterval = 30 * time.Second
+	conf.FETCH.RequestTimeout = 2 * time.Second
 
 	conf.Tortoise.Hdist = 4
 	conf.Tortoise.Zdist = 2


### PR DESCRIPTION
was debugging flaky partition 30_70 and 50_50 tests.

in both of those tests some nodes were "stuck" on requests to the peers that were on the other side of partition.
connections to them are blocked, but they wait for 25s to receive a response. this prevents them from moving to peers
on their own side of the partition and completing requests.

also since layer time is 15s, if they are blocked on several such requests they will not be able to make progress and fall into unsynced state.

https://github.com/spacemeshos/go-spacemesh/actions/runs/8375974512/job/22934603108
https://github.com/spacemeshos/go-spacemesh/actions/runs/8364722559/job/22900753485