### PR TITLE
[Merged by Bors] - increase verbosity and try higher ax/1 limits in system tests

### DIFF
--- a/systest/parameters/fastnet/smesher.json
+++ b/systest/parameters/fastnet/smesher.json
@@ -12,7 +12,14 @@
     },
     "fetch": {
         "servers-metrics": true,
-        "log-peer-stats-interval": "1m"
+        "log-peer-stats-interval": "30s",
+        "servers": {
+            "ax/1": {
+                "interval": "1s",
+                "queue": 200,
+                "requests": 100
+            }
+        }
     },
     "smeshing": {
         "smeshing-verifying-opts": {
@@ -21,6 +28,8 @@
     },
     "logging": {
         "txHandler": "debug",
-        "grpc": "debug"
+        "grpc": "debug",
+        "sync": "debug",
+        "fetcher": "debug"
     }
 }


### PR DESCRIPTION
mainly want to increase verbosity for sync and fetch, to understand better why partition tests are flaky.
but just in case also bumped ax/1 limits for system tests