### PR TITLE
[Merged by Bors] - Increase limits on wire types to support 2.7 mio ATXs

### DIFF
--- a/common/types/ballot.go
+++ b/common/types/ballot.go
@@ -60,17 +60,18 @@ type Ballot struct {
 	// the proofs are vrf signatures and need not be included in the ballot's signature.
 	//
 	// The number of eligibility proofs depends on the smeshers weight and the total weight of the network.
-	// For epoch 16 the largest smesher had 888 SUs and the total weight of the network was ~20.2 Mio SUs.
-	// This means that the largest smesher received 888 / 20,200,000 = 0.0044% of all eligibility slots for the epoch.
+	// For epoch 16 the largest smesher had 1 337 SUs and the total weight of the network was ~20.2 Mio SUs.
+	// This means that the largest smesher received 1 337 / 26 481 043 SU = 0.005% of all eligibility slots for the
+	// epoch.
 	// There are 4032 layers in an epoch and 50 eligibility slots per layer, so the largest smesher received
-	// 0.0044% * 4032 * 50 = ~9 eligibility slots.
+	// 0.005% * 4032 * 50 = ~10 eligibility slots.
 	//
 	// Assuming the largest smesher won't control more than 10% of space in the network, we can assume that the
 	// highest number of eligibilities in a single ballot will be below 25000. (10% of 4032 * 50 = 20160)
 	EligibilityProofs []VotingEligibility `scale:"max=25000"`
 	// from the smesher's view, the set of ATXs eligible to vote and propose block content in this epoch
 	// only present in smesher's first ballot of the epoch
-	ActiveSet []ATXID `scale:"max=2200000"`
+	ActiveSet []ATXID `scale:"max=2700000"`
 
 	// the following fields are kept private and from being serialized
 	ballotID BallotID

--- a/common/types/ballot_scale.go
+++ b/common/types/ballot_scale.go
@@ -44,7 +44,7 @@ func (t *Ballot) EncodeScale(enc *scale.Encoder) (total int, err error) {
 		total += n
 	}
 	{
-		n, err := scale.EncodeStructSliceWithLimit(enc, t.ActiveSet, 2200000)
+		n, err := scale.EncodeStructSliceWithLimit(enc, t.ActiveSet, 2700000)
 		if err != nil {
 			return total, err
 		}
@@ -91,7 +91,7 @@ func (t *Ballot) DecodeScale(dec *scale.Decoder) (total int, err error) {
 		t.EligibilityProofs = field
 	}
 	{
-		field, n, err := scale.DecodeStructSliceWithLimit[ATXID](dec, 2200000)
+		field, n, err := scale.DecodeStructSliceWithLimit[ATXID](dec, 2700000)
 		if err != nil {
 			return total, err
 		}

--- a/common/types/block.go
+++ b/common/types/block.go
@@ -77,14 +77,14 @@ type InnerBlock struct {
 	// In this case they will get all 50 available slots in all 4032 layers of the epoch.
 	// Additionally every other identity on the network that successfully published an ATX will get 1 slot.
 	//
-	// If we expect 2.2 Mio ATXs that would be a total of 2.2 Mio + 50 * 4032 = 2,401,600 slots.
+	// If we expect 2.7 Mio ATXs that would be a total of 2.7 Mio + 50 * 4032 = 2 901 600 slots.
 	// Since these are randomly distributed across the epoch, we can expect an average of n * p =
-	// 2,401,600 / 4032 = 595.7 rewards in a block with a standard deviation of sqrt(n * p * (1 - p)) =
-	// sqrt(2,401,600 * 1/4032 * 4031/4032) = 24.4
+	// 2 901 600 / 4032 = 719.6 rewards in a block with a standard deviation of sqrt(n * p * (1 - p)) =
+	// sqrt(2 901 600 * 1/4032 * 4031/4032) = 26.8
 	//
-	// This means that we can expect a maximum of 595.7 + 6*24.4 = 743 rewards per block with
+	// This means that we can expect a maximum of 719.6 + 6*26.8 = 880.6 rewards per block with
 	// > 99.9997% probability.
-	Rewards []AnyReward     `scale:"max=800"`
+	Rewards []AnyReward     `scale:"max=900"`
 	TxIDs   []TransactionID `scale:"max=100000"`
 }
 

--- a/common/types/block_scale.go
+++ b/common/types/block_scale.go
@@ -45,7 +45,7 @@ func (t *InnerBlock) EncodeScale(enc *scale.Encoder) (total int, err error) {
 		total += n
 	}
 	{
-		n, err := scale.EncodeStructSliceWithLimit(enc, t.Rewards, 800)
+		n, err := scale.EncodeStructSliceWithLimit(enc, t.Rewards, 900)
 		if err != nil {
 			return total, err
 		}
@@ -79,7 +79,7 @@ func (t *InnerBlock) DecodeScale(dec *scale.Decoder) (total int, err error) {
 		t.TickHeight = uint64(field)
 	}
 	{
-		field, n, err := scale.DecodeStructSliceWithLimit[AnyReward](dec, 800)
+		field, n, err := scale.DecodeStructSliceWithLimit[AnyReward](dec, 900)
 		if err != nil {
 			return total, err
 		}

--- a/fetch/wire_types.go
+++ b/fetch/wire_types.go
@@ -22,7 +22,7 @@ type RequestMessage struct {
 // ResponseMessage is sent to the node as a response.
 type ResponseMessage struct {
 	Hash types.Hash32
-	Data []byte `scale:"max=89128960"` // limit to 85 MiB - keep in line with Response.Data in `p2p/server/server.go`
+	Data []byte `scale:"max=104857600"` // limit to 100 MiB - keep in line with Response.Data in `p2p/server/server.go`
 }
 
 // RequestBatch is a batch of requests and a hash of all requests as ID.
@@ -114,7 +114,7 @@ type EpochData struct {
 	// - the size of `Rewards` in the type `InnerBlock` in common/types/block.go
 	// - the size of `Ballots` in the type `LayerData` below
 	// - the size of `Proposals` in the type `Value` in hare3/types.go
-	AtxIDs []types.ATXID `scale:"max=2200000"`
+	AtxIDs []types.ATXID `scale:"max=2700000"`
 }
 
 // LayerData is the data response for a given layer ID.
@@ -125,14 +125,14 @@ type LayerData struct {
 	// In this case they will get all 50 available slots in all 4032 layers of the epoch.
 	// Additionally every other identity on the network that successfully published an ATX will get 1 slot.
 	//
-	// If we expect 2.2 Mio ATXs that would be a total of 2.2 Mio + 50 * 4032 = 2,401,600 slots.
+	// If we expect 2.7 Mio ATXs that would be a total of 2.7 Mio + 50 * 4032 = 2 901 600 slots.
 	// Since these are randomly distributed across the epoch, we can expect an average of n * p =
-	// 2,401,600 / 4032 = 595.7 ballots in a layer with a standard deviation of sqrt(n * p * (1 - p)) =
-	// sqrt(2,401,600 * 1/4032 * 4031/4032) = 24.4
+	// 2 901 600 / 4032 = 719.6 ballots in a layer with a standard deviation of sqrt(n * p * (1 - p)) =
+	// sqrt(2 901 600 * 1/4032 * 4031/4032) = 26.8
 	//
-	// This means that we can expect a maximum of 595.7 + 6*24.4 = 743 ballots per layer with
+	// This means that we can expect a maximum of 719.6 + 6*26.8 = 880.6 ballots per layer with
 	// > 99.9997% probability.
-	Ballots []types.BallotID `scale:"max=800"`
+	Ballots []types.BallotID `scale:"max=900"`
 }
 
 type OpinionRequest struct {

--- a/fetch/wire_types_scale.go
+++ b/fetch/wire_types_scale.go
@@ -55,7 +55,7 @@ func (t *ResponseMessage) EncodeScale(enc *scale.Encoder) (total int, err error)
 		total += n
 	}
 	{
-		n, err := scale.EncodeByteSliceWithLimit(enc, t.Data, 89128960)
+		n, err := scale.EncodeByteSliceWithLimit(enc, t.Data, 104857600)
 		if err != nil {
 			return total, err
 		}
@@ -73,7 +73,7 @@ func (t *ResponseMessage) DecodeScale(dec *scale.Decoder) (total int, err error)
 		total += n
 	}
 	{
-		field, n, err := scale.DecodeByteSliceWithLimit(dec, 89128960)
+		field, n, err := scale.DecodeByteSliceWithLimit(dec, 104857600)
 		if err != nil {
 			return total, err
 		}
@@ -258,7 +258,7 @@ func (t *MaliciousIDs) DecodeScale(dec *scale.Decoder) (total int, err error) {
 
 func (t *EpochData) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	{
-		n, err := scale.EncodeStructSliceWithLimit(enc, t.AtxIDs, 2200000)
+		n, err := scale.EncodeStructSliceWithLimit(enc, t.AtxIDs, 2700000)
 		if err != nil {
 			return total, err
 		}
@@ -269,7 +269,7 @@ func (t *EpochData) EncodeScale(enc *scale.Encoder) (total int, err error) {
 
 func (t *EpochData) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	{
-		field, n, err := scale.DecodeStructSliceWithLimit[types.ATXID](dec, 2200000)
+		field, n, err := scale.DecodeStructSliceWithLimit[types.ATXID](dec, 2700000)
 		if err != nil {
 			return total, err
 		}
@@ -281,7 +281,7 @@ func (t *EpochData) DecodeScale(dec *scale.Decoder) (total int, err error) {
 
 func (t *LayerData) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	{
-		n, err := scale.EncodeStructSliceWithLimit(enc, t.Ballots, 800)
+		n, err := scale.EncodeStructSliceWithLimit(enc, t.Ballots, 900)
 		if err != nil {
 			return total, err
 		}
@@ -292,7 +292,7 @@ func (t *LayerData) EncodeScale(enc *scale.Encoder) (total int, err error) {
 
 func (t *LayerData) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	{
-		field, n, err := scale.DecodeStructSliceWithLimit[types.BallotID](dec, 800)
+		field, n, err := scale.DecodeStructSliceWithLimit[types.BallotID](dec, 900)
 		if err != nil {
 			return total, err
 		}

--- a/hare3/types.go
+++ b/hare3/types.go
@@ -81,14 +81,14 @@ type Value struct {
 	// In this case they will get all 50 available slots in all 4032 layers of the epoch.
 	// Additionally every other identity on the network that successfully published an ATX will get 1 slot.
 	//
-	// If we expect 2.2 Mio ATXs that would be a total of 2.2 Mio + 50 * 4032 = 2,401,600 slots.
+	// If we expect 2.7 Mio ATXs that would be a total of 2.7 Mio + 50 * 4032 = 2 901 600 slots.
 	// Since these are randomly distributed across the epoch, we can expect an average of n * p =
-	// 2,401,600 / 4032 = 595.7 eligibilities in a layer with a standard deviation of sqrt(n * p * (1 - p)) =
-	// sqrt(2,401,600 * 1/4032 * 4031/4032) = 24.4
+	// 2 901 600 / 4032 = 719.6 eligibilities in a layer with a standard deviation of sqrt(n * p * (1 - p)) =
+	// sqrt(2 901 600 * 1/4032 * 4031/4032) = 26.8
 	//
-	// This means that we can expect a maximum of 595.7 + 6*24.4 = 743 eligibilities in a layer with
+	// This means that we can expect a maximum of 719.6 + 6*26.8 = 880.6 eligibilities in a layer with
 	// > 99.9997% probability.
-	Proposals []types.ProposalID `scale:"max=800"`
+	Proposals []types.ProposalID `scale:"max=900"`
 	// Reference is set in messages for commit and notify rounds.
 	Reference *types.Hash32
 }

--- a/hare3/types_scale.go
+++ b/hare3/types_scale.go
@@ -48,7 +48,7 @@ func (t *IterRound) DecodeScale(dec *scale.Decoder) (total int, err error) {
 
 func (t *Value) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	{
-		n, err := scale.EncodeStructSliceWithLimit(enc, t.Proposals, 800)
+		n, err := scale.EncodeStructSliceWithLimit(enc, t.Proposals, 900)
 		if err != nil {
 			return total, err
 		}
@@ -66,7 +66,7 @@ func (t *Value) EncodeScale(enc *scale.Encoder) (total int, err error) {
 
 func (t *Value) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	{
-		field, n, err := scale.DecodeStructSliceWithLimit[types.ProposalID](dec, 800)
+		field, n, err := scale.DecodeStructSliceWithLimit[types.ProposalID](dec, 900)
 		if err != nil {
 			return total, err
 		}

--- a/p2p/server/server.go
+++ b/p2p/server/server.go
@@ -140,8 +140,8 @@ func (err *ServerError) Error() string {
 
 // Response is a server response.
 type Response struct {
-	Data  []byte `scale:"max=89128960"` // 85 MiB
-	Error string `scale:"max=1024"`     // TODO(mafa): make error code instead of string
+	Data  []byte `scale:"max=104857600"` // 100 MiB - keep in line with ResponseMessage.Data in `fetch/wire_types.go`
+	Error string `scale:"max=1024"`      // TODO(mafa): make error code instead of string
 }
 
 // Server for the Handler.

--- a/p2p/server/server_scale.go
+++ b/p2p/server/server_scale.go
@@ -9,7 +9,7 @@ import (
 
 func (t *Response) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	{
-		n, err := scale.EncodeByteSliceWithLimit(enc, t.Data, 89128960)
+		n, err := scale.EncodeByteSliceWithLimit(enc, t.Data, 104857600)
 		if err != nil {
 			return total, err
 		}
@@ -27,7 +27,7 @@ func (t *Response) EncodeScale(enc *scale.Encoder) (total int, err error) {
 
 func (t *Response) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	{
-		field, n, err := scale.DecodeByteSliceWithLimit(dec, 89128960)
+		field, n, err := scale.DecodeByteSliceWithLimit(dec, 104857600)
 		if err != nil {
 			return total, err
 		}


### PR DESCRIPTION
## Motivation

This PR increases the limits on wire types to ensure that go-spacemesh can support up to 2.7 Mio ATXs.

## Description

I recalculated the necessary limits and updated the scale limits accordingly.

## Test Plan

- existing tests pass

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
