### PR TITLE
[Merged by Bors] - Fix incorrect EpochActiveSet size

### DIFF
--- a/common/types/activation.go
+++ b/common/types/activation.go
@@ -521,5 +521,5 @@ func ATXIDsToHashes(ids []ATXID) []Hash32 {
 
 type EpochActiveSet struct {
 	Epoch EpochID
-	Set   []ATXID `scale:"max=2200000"` // to be in line with `EpochData` in fetch/wire_types.go
+	Set   []ATXID `scale:"max=2700000"` // to be in line with `EpochData` in fetch/wire_types.go
 }

--- a/common/types/activation_scale.go
+++ b/common/types/activation_scale.go
@@ -423,7 +423,7 @@ func (t *EpochActiveSet) EncodeScale(enc *scale.Encoder) (total int, err error) 
 		total += n
 	}
 	{
-		n, err := scale.EncodeStructSliceWithLimit(enc, t.Set, 2200000)
+		n, err := scale.EncodeStructSliceWithLimit(enc, t.Set, 2700000)
 		if err != nil {
 			return total, err
 		}
@@ -442,7 +442,7 @@ func (t *EpochActiveSet) DecodeScale(dec *scale.Decoder) (total int, err error) 
 		t.Epoch = EpochID(field)
 	}
 	{
-		field, n, err := scale.DecodeStructSliceWithLimit[ATXID](dec, 2200000)
+		field, n, err := scale.DecodeStructSliceWithLimit[ATXID](dec, 2700000)
 		if err != nil {
 			return total, err
 		}


### PR DESCRIPTION
## Motivation

Fix missing update for epoch active set data type.

## Description

In #5773 the size of epoch active set wasn't increased, I checked the other places and they should all be updated correctly.

## Test Plan

n/a

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
