### PR TITLE
[Merged by Bors] - fetch: detect bad slice sizes early on the client side

### DIFF
--- a/common/types/activation.go
+++ b/common/types/activation.go
@@ -523,3 +523,5 @@ type EpochActiveSet struct {
 	Epoch EpochID
 	Set   []ATXID `scale:"max=2700000"` // to be in line with `EpochData` in fetch/wire_types.go
 }
+
+var MaxEpochActiveSetSize = scale.MustGetMaxElements[EpochActiveSet]("Set")

--- a/fetch/mesh_data.go
+++ b/fetch/mesh_data.go
@@ -450,7 +450,7 @@ func readIDSlice[V any, H scale.DecodablePtr[V]](r io.Reader, slice *[]V, limit 
 		d := scale.NewDecoder(r)
 		lth, total, err = scale.DecodeLen(d, limit)
 		if err != nil {
-			return 0, err
+			return total, err
 		}
 		if int(lth*types.Hash32Length)+total != int(respLen) {
 			return total, errors.New("bad slice length")

--- a/fetch/mesh_data.go
+++ b/fetch/mesh_data.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/spacemeshos/go-scale"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/spacemeshos/go-spacemesh/activation"
@@ -232,9 +233,7 @@ func (f *Fetch) GetMaliciousIDs(ctx context.Context, peer p2p.Peer) ([]types.Nod
 		if err := f.meteredStreamRequest(
 			ctx, malProtocol, peer, []byte{},
 			func(ctx context.Context, s io.ReadWriter) (int, error) {
-				return server.ReadResponse(s, func(respLen uint32) (n int, err error) {
-					return codec.DecodeFrom(s, &malIDs)
-				})
+				return readIDSlice(s, &malIDs.NodeIDs, maxMaliciousIDs)
 			},
 		); err != nil {
 			return nil, err
@@ -270,9 +269,7 @@ func (f *Fetch) peerEpochInfoStreamed(ctx context.Context, peer p2p.Peer, epochB
 	if err := f.meteredStreamRequest(
 		ctx, atxProtocol, peer, epochBytes,
 		func(ctx context.Context, s io.ReadWriter) (int, error) {
-			return server.ReadResponse(s, func(respLen uint32) (n int, err error) {
-				return codec.DecodeFrom(s, &ed)
-			})
+			return readIDSlice(s, &ed.AtxIDs, maxEpochDataAtxIDs)
 		},
 	); err != nil {
 		return nil, err
@@ -310,20 +307,17 @@ func (f *Fetch) PeerEpochInfo(ctx context.Context, peer p2p.Peer, epoch types.Ep
 	return ed, nil
 }
 
-func (f *Fetch) peerMeshHashesStreamed(ctx context.Context, peer p2p.Peer, reqBytes []byte) ([]types.Hash32, error) {
-	var hashes []types.Hash32
+func (f *Fetch) peerMeshHashesStreamed(ctx context.Context, peer p2p.Peer, reqBytes []byte) (*MeshHashes, error) {
+	var mh MeshHashes
 	if err := f.meteredStreamRequest(
 		ctx, meshHashProtocol, peer, reqBytes,
 		func(ctx context.Context, s io.ReadWriter) (int, error) {
-			return server.ReadResponse(s, func(respLen uint32) (n int, err error) {
-				hashes, n, err = codec.ReadSlice[types.Hash32](s)
-				return n, err
-			})
+			return readIDSlice(s, &mh.Hashes, maxMeshHashes)
 		},
 	); err != nil {
 		return nil, err
 	}
-	return hashes, nil
+	return &mh, nil
 }
 
 func (f *Fetch) PeerMeshHashes(ctx context.Context, peer p2p.Peer, req *MeshHashRequest) (*MeshHashes, error) {
@@ -337,25 +331,21 @@ func (f *Fetch) PeerMeshHashes(ctx context.Context, peer p2p.Peer, req *MeshHash
 		f.logger.With().Fatal("failed to encode mesh hash request", log.Err(err))
 	}
 
-	var hashes []types.Hash32
 	if f.cfg.Streaming {
-		hashes, err = f.peerMeshHashesStreamed(ctx, peer, reqData)
-		if err != nil {
-			return nil, err
-		}
+		return f.peerMeshHashesStreamed(ctx, peer, reqData)
 	} else {
 		data, err := f.meteredRequest(ctx, meshHashProtocol, peer, reqData)
 		if err != nil {
 			return nil, err
 		}
-		hashes, err = codec.DecodeSlice[types.Hash32](data)
+		hashes, err := codec.DecodeSlice[types.Hash32](data)
 		if err != nil {
 			return nil, fmt.Errorf("decoding hashes response: %w", err)
 		}
+		return &MeshHashes{
+			Hashes: hashes,
+		}, nil
 	}
-	return &MeshHashes{
-		Hashes: hashes,
-	}, nil
 }
 
 func (f *Fetch) GetCert(
@@ -448,4 +438,31 @@ func (b *BatchError) IsIgnored(hash types.Hash32) bool {
 		return true
 	}
 	return errors.Is(err, pubsub.ErrValidationReject) || errors.Is(err, ErrIgnore)
+}
+
+func readIDSlice[V any, H scale.DecodablePtr[V]](r io.Reader, slice *[]V, limit uint32) (int, error) {
+	return server.ReadResponse(r, func(respLen uint32) (int, error) {
+		var (
+			lth   uint32
+			total int
+			err   error
+		)
+		d := scale.NewDecoder(r)
+		lth, total, err = scale.DecodeLen(d, limit)
+		if err != nil {
+			return 0, err
+		}
+		if int(lth*types.Hash32Length)+total != int(respLen) {
+			return total, errors.New("bad slice length")
+		}
+		*slice = make([]V, lth)
+		for i := uint32(0); i < lth; i++ {
+			n, err := H(&(*slice)[i]).DecodeScale(d)
+			total += n
+			if err != nil {
+				return total, err
+			}
+		}
+		return total, err
+	})
 }

--- a/fetch/wire_types.go
+++ b/fetch/wire_types.go
@@ -3,6 +3,8 @@ package fetch
 import (
 	"fmt"
 
+	"github.com/spacemeshos/go-scale"
+
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/datastore"
 	"github.com/spacemeshos/go-spacemesh/log"
@@ -12,6 +14,18 @@ import (
 //go:generate scalegen
 
 const MaxHashesInReq = 100
+
+var (
+	maxEpochDataAtxIDs = scale.MustGetMaxElements[EpochData]("AtxIDs")
+	maxMaliciousIDs    = scale.MustGetMaxElements[MaliciousIDs]("NodeIDs")
+	maxMeshHashes      = scale.MustGetMaxElements[MeshHashes]("Hashes")
+)
+
+func init() {
+	if maxEpochDataAtxIDs != types.MaxEpochActiveSetSize {
+		panic("MaxEpochDataAtxIDs and MaxEpochActiveSetSize differ")
+	}
+}
 
 // RequestMessage is sent to the peer for hash query.
 type RequestMessage struct {

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/spacemeshos/api/release/go v1.35.0
 	github.com/spacemeshos/economics v0.1.2
 	github.com/spacemeshos/fixed v0.1.1
-	github.com/spacemeshos/go-scale v1.1.14-0.20240326170741-fb06c4722c6f
+	github.com/spacemeshos/go-scale v1.1.14
 	github.com/spacemeshos/merkle-tree v0.2.3
 	github.com/spacemeshos/poet v0.10.2
 	github.com/spacemeshos/post v0.12.6

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/spacemeshos/api/release/go v1.35.0
 	github.com/spacemeshos/economics v0.1.2
 	github.com/spacemeshos/fixed v0.1.1
-	github.com/spacemeshos/go-scale v1.1.14-0.20240326163113-233b60cc3384
+	github.com/spacemeshos/go-scale v1.1.14-0.20240326170741-fb06c4722c6f
 	github.com/spacemeshos/merkle-tree v0.2.3
 	github.com/spacemeshos/poet v0.10.2
 	github.com/spacemeshos/post v0.12.6

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/spacemeshos/api/release/go v1.35.0
 	github.com/spacemeshos/economics v0.1.2
 	github.com/spacemeshos/fixed v0.1.1
-	github.com/spacemeshos/go-scale v1.1.13
+	github.com/spacemeshos/go-scale v1.1.14-0.20240326163113-233b60cc3384
 	github.com/spacemeshos/merkle-tree v0.2.3
 	github.com/spacemeshos/poet v0.10.2
 	github.com/spacemeshos/post v0.12.6

--- a/go.sum
+++ b/go.sum
@@ -566,8 +566,8 @@ github.com/spacemeshos/economics v0.1.2 h1:kw8cE5SMa/7svHOGorCd2w8ef1y8iP0p47/2V
 github.com/spacemeshos/economics v0.1.2/go.mod h1:ngeWn5E/jy9dJP1MHyuk3ehF8NBMTYhchqVDhAHUUNk=
 github.com/spacemeshos/fixed v0.1.1 h1:N1y4SUpq1EV+IdJrWJwUCt1oBFzeru/VKVcBsvPc2Fk=
 github.com/spacemeshos/fixed v0.1.1/go.mod h1:B/moObha9wGnwljZP+w/dYAwzv097aL9VV8Oyv2cM/E=
-github.com/spacemeshos/go-scale v1.1.14-0.20240326163113-233b60cc3384 h1:20/nqml35cW4qr7kOLSD2dsHEtFYnLfeFxqy+ZbySMU=
-github.com/spacemeshos/go-scale v1.1.14-0.20240326163113-233b60cc3384/go.mod h1:HV6e3/X5h9u2aFpYKJxt7PY/fBuLBegEKWgeZJ+/5jE=
+github.com/spacemeshos/go-scale v1.1.14-0.20240326170741-fb06c4722c6f h1:4JY1KtDaBbC1+YosEpNuNCctdPH0jhl5LDpH6lLRAKU=
+github.com/spacemeshos/go-scale v1.1.14-0.20240326170741-fb06c4722c6f/go.mod h1:HV6e3/X5h9u2aFpYKJxt7PY/fBuLBegEKWgeZJ+/5jE=
 github.com/spacemeshos/merkle-tree v0.2.3 h1:zGEgOR9nxAzJr0EWjD39QFngwFEOxfxMloEJZtAysas=
 github.com/spacemeshos/merkle-tree v0.2.3/go.mod h1:VomOcQ5pCBXz7goiWMP5hReyqOfDXGSKbrH2GB9Htww=
 github.com/spacemeshos/poet v0.10.2 h1:FVb0xgCFcjZyIGBQ92SlOZVx4KCmlCRRL4JSHL6LMGU=

--- a/go.sum
+++ b/go.sum
@@ -566,8 +566,8 @@ github.com/spacemeshos/economics v0.1.2 h1:kw8cE5SMa/7svHOGorCd2w8ef1y8iP0p47/2V
 github.com/spacemeshos/economics v0.1.2/go.mod h1:ngeWn5E/jy9dJP1MHyuk3ehF8NBMTYhchqVDhAHUUNk=
 github.com/spacemeshos/fixed v0.1.1 h1:N1y4SUpq1EV+IdJrWJwUCt1oBFzeru/VKVcBsvPc2Fk=
 github.com/spacemeshos/fixed v0.1.1/go.mod h1:B/moObha9wGnwljZP+w/dYAwzv097aL9VV8Oyv2cM/E=
-github.com/spacemeshos/go-scale v1.1.13 h1:y5rl/qmN0tE38ErpCeq8Ofq4+fCKRWF1qUIjA2KguWw=
-github.com/spacemeshos/go-scale v1.1.13/go.mod h1:HV6e3/X5h9u2aFpYKJxt7PY/fBuLBegEKWgeZJ+/5jE=
+github.com/spacemeshos/go-scale v1.1.14-0.20240326163113-233b60cc3384 h1:20/nqml35cW4qr7kOLSD2dsHEtFYnLfeFxqy+ZbySMU=
+github.com/spacemeshos/go-scale v1.1.14-0.20240326163113-233b60cc3384/go.mod h1:HV6e3/X5h9u2aFpYKJxt7PY/fBuLBegEKWgeZJ+/5jE=
 github.com/spacemeshos/merkle-tree v0.2.3 h1:zGEgOR9nxAzJr0EWjD39QFngwFEOxfxMloEJZtAysas=
 github.com/spacemeshos/merkle-tree v0.2.3/go.mod h1:VomOcQ5pCBXz7goiWMP5hReyqOfDXGSKbrH2GB9Htww=
 github.com/spacemeshos/poet v0.10.2 h1:FVb0xgCFcjZyIGBQ92SlOZVx4KCmlCRRL4JSHL6LMGU=

--- a/go.sum
+++ b/go.sum
@@ -566,8 +566,8 @@ github.com/spacemeshos/economics v0.1.2 h1:kw8cE5SMa/7svHOGorCd2w8ef1y8iP0p47/2V
 github.com/spacemeshos/economics v0.1.2/go.mod h1:ngeWn5E/jy9dJP1MHyuk3ehF8NBMTYhchqVDhAHUUNk=
 github.com/spacemeshos/fixed v0.1.1 h1:N1y4SUpq1EV+IdJrWJwUCt1oBFzeru/VKVcBsvPc2Fk=
 github.com/spacemeshos/fixed v0.1.1/go.mod h1:B/moObha9wGnwljZP+w/dYAwzv097aL9VV8Oyv2cM/E=
-github.com/spacemeshos/go-scale v1.1.14-0.20240326170741-fb06c4722c6f h1:4JY1KtDaBbC1+YosEpNuNCctdPH0jhl5LDpH6lLRAKU=
-github.com/spacemeshos/go-scale v1.1.14-0.20240326170741-fb06c4722c6f/go.mod h1:HV6e3/X5h9u2aFpYKJxt7PY/fBuLBegEKWgeZJ+/5jE=
+github.com/spacemeshos/go-scale v1.1.14 h1:q+M/8WDfaETTT8ENKYig/ENv4XnjAsjjKMIEpiLydtU=
+github.com/spacemeshos/go-scale v1.1.14/go.mod h1:HV6e3/X5h9u2aFpYKJxt7PY/fBuLBegEKWgeZJ+/5jE=
 github.com/spacemeshos/merkle-tree v0.2.3 h1:zGEgOR9nxAzJr0EWjD39QFngwFEOxfxMloEJZtAysas=
 github.com/spacemeshos/merkle-tree v0.2.3/go.mod h1:VomOcQ5pCBXz7goiWMP5hReyqOfDXGSKbrH2GB9Htww=
 github.com/spacemeshos/poet v0.10.2 h1:FVb0xgCFcjZyIGBQ92SlOZVx4KCmlCRRL4JSHL6LMGU=


### PR DESCRIPTION
## Motivation

When reading server responses consisting of slices of hashes, such as `EpochData`, in case if the response has wrong length, it's possible to stop reading it early without consuming the whole stream. 
Also, `fetch.EpochData.AtxIDs` slice size must be in line with `types.EpochActiveSet`, but this requirement has been violated at some point: #5779 

## Description

Validate slice sizes against the response size early in streaming mode without reading the whole slice.
Also, ensure that `fetch.EpochData.AtxIDs` slice size is in line with `types.EpochActiveSet` in common/types/activation.go

## Test Plan

Make sure tests pass

## TODO

- [x] Merge spacemeshos/go-scale#83
- [x] Release a new go-scale version
- [x] Update deps
