### PR TITLE
[Merged by Bors] - Increase num of supported ATXs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ See [RELEASE](./RELEASE.md) for workflow instructions.
 
 * [#5797](https://github.com/spacemeshos/go-spacemesh/pull/5797) Improve logging around ATX building process.
 
+* [#5802](https://github.com/spacemeshos/go-spacemesh/pull/5802) Increase the number of supported ATX per epoch to 3.5 Mio.
+
 ### Features
 
 ## Release v1.4.4

--- a/common/types/activation.go
+++ b/common/types/activation.go
@@ -521,7 +521,7 @@ func ATXIDsToHashes(ids []ATXID) []Hash32 {
 
 type EpochActiveSet struct {
 	Epoch EpochID
-	Set   []ATXID `scale:"max=2700000"` // to be in line with `EpochData` in fetch/wire_types.go
+	Set   []ATXID `scale:"max=3500000"` // to be in line with `EpochData` in fetch/wire_types.go
 }
 
 var MaxEpochActiveSetSize = scale.MustGetMaxElements[EpochActiveSet]("Set")

--- a/common/types/activation_scale.go
+++ b/common/types/activation_scale.go
@@ -423,7 +423,7 @@ func (t *EpochActiveSet) EncodeScale(enc *scale.Encoder) (total int, err error) 
 		total += n
 	}
 	{
-		n, err := scale.EncodeStructSliceWithLimit(enc, t.Set, 2700000)
+		n, err := scale.EncodeStructSliceWithLimit(enc, t.Set, 3500000)
 		if err != nil {
 			return total, err
 		}
@@ -442,7 +442,7 @@ func (t *EpochActiveSet) DecodeScale(dec *scale.Decoder) (total int, err error) 
 		t.Epoch = EpochID(field)
 	}
 	{
-		field, n, err := scale.DecodeStructSliceWithLimit[ATXID](dec, 2700000)
+		field, n, err := scale.DecodeStructSliceWithLimit[ATXID](dec, 3500000)
 		if err != nil {
 			return total, err
 		}

--- a/common/types/ballot.go
+++ b/common/types/ballot.go
@@ -71,7 +71,7 @@ type Ballot struct {
 	EligibilityProofs []VotingEligibility `scale:"max=25000"`
 	// from the smesher's view, the set of ATXs eligible to vote and propose block content in this epoch
 	// only present in smesher's first ballot of the epoch
-	ActiveSet []ATXID `scale:"max=2700000"`
+	ActiveSet []ATXID `scale:"max=3500000"`
 
 	// the following fields are kept private and from being serialized
 	ballotID BallotID

--- a/common/types/ballot_scale.go
+++ b/common/types/ballot_scale.go
@@ -44,7 +44,7 @@ func (t *Ballot) EncodeScale(enc *scale.Encoder) (total int, err error) {
 		total += n
 	}
 	{
-		n, err := scale.EncodeStructSliceWithLimit(enc, t.ActiveSet, 2700000)
+		n, err := scale.EncodeStructSliceWithLimit(enc, t.ActiveSet, 3500000)
 		if err != nil {
 			return total, err
 		}
@@ -91,7 +91,7 @@ func (t *Ballot) DecodeScale(dec *scale.Decoder) (total int, err error) {
 		t.EligibilityProofs = field
 	}
 	{
-		field, n, err := scale.DecodeStructSliceWithLimit[ATXID](dec, 2700000)
+		field, n, err := scale.DecodeStructSliceWithLimit[ATXID](dec, 3500000)
 		if err != nil {
 			return total, err
 		}

--- a/common/types/block.go
+++ b/common/types/block.go
@@ -77,14 +77,14 @@ type InnerBlock struct {
 	// In this case they will get all 50 available slots in all 4032 layers of the epoch.
 	// Additionally every other identity on the network that successfully published an ATX will get 1 slot.
 	//
-	// If we expect 2.7 Mio ATXs that would be a total of 2.7 Mio + 50 * 4032 = 2 901 600 slots.
+	// If we expect 3.5 Mio ATXs that would be a total of 3.5 Mio + 50 * 4032 = 3 701 600 slots.
 	// Since these are randomly distributed across the epoch, we can expect an average of n * p =
-	// 2 901 600 / 4032 = 719.6 rewards in a block with a standard deviation of sqrt(n * p * (1 - p)) =
-	// sqrt(2 901 600 * 1/4032 * 4031/4032) = 26.8
+	// 3 701 600 / 4032 = 918.1 rewards in a block with a standard deviation of sqrt(n * p * (1 - p)) =
+	// sqrt(3 701 600 * 1/4032 * 4031/4032) = 30.3
 	//
-	// This means that we can expect a maximum of 719.6 + 6*26.8 = 880.6 rewards per block with
+	// This means that we can expect a maximum of 918.1 + 6*30.3 = 1100.0 rewards per block with
 	// > 99.9997% probability.
-	Rewards []AnyReward     `scale:"max=900"`
+	Rewards []AnyReward     `scale:"max=1100"`
 	TxIDs   []TransactionID `scale:"max=100000"`
 }
 

--- a/common/types/block_scale.go
+++ b/common/types/block_scale.go
@@ -45,7 +45,7 @@ func (t *InnerBlock) EncodeScale(enc *scale.Encoder) (total int, err error) {
 		total += n
 	}
 	{
-		n, err := scale.EncodeStructSliceWithLimit(enc, t.Rewards, 900)
+		n, err := scale.EncodeStructSliceWithLimit(enc, t.Rewards, 1100)
 		if err != nil {
 			return total, err
 		}
@@ -79,7 +79,7 @@ func (t *InnerBlock) DecodeScale(dec *scale.Decoder) (total int, err error) {
 		t.TickHeight = uint64(field)
 	}
 	{
-		field, n, err := scale.DecodeStructSliceWithLimit[AnyReward](dec, 900)
+		field, n, err := scale.DecodeStructSliceWithLimit[AnyReward](dec, 1100)
 		if err != nil {
 			return total, err
 		}

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -549,8 +549,7 @@ func (f *Fetch) receiveResponse(data []byte, batch *batchInfo) {
 		f.mu.Unlock()
 
 		if !ok {
-			f.logger.With().Warning("response received for unknown hash",
-				log.Stringer("hash", resp.Hash))
+			f.logger.With().Warning("response received for unknown hash", log.Stringer("hash", resp.Hash))
 			continue
 		}
 

--- a/fetch/wire_types_scale.go
+++ b/fetch/wire_types_scale.go
@@ -55,7 +55,7 @@ func (t *ResponseMessage) EncodeScale(enc *scale.Encoder) (total int, err error)
 		total += n
 	}
 	{
-		n, err := scale.EncodeByteSliceWithLimit(enc, t.Data, 104857600)
+		n, err := scale.EncodeByteSliceWithLimit(enc, t.Data, 125829120)
 		if err != nil {
 			return total, err
 		}
@@ -73,7 +73,7 @@ func (t *ResponseMessage) DecodeScale(dec *scale.Decoder) (total int, err error)
 		total += n
 	}
 	{
-		field, n, err := scale.DecodeByteSliceWithLimit(dec, 104857600)
+		field, n, err := scale.DecodeByteSliceWithLimit(dec, 125829120)
 		if err != nil {
 			return total, err
 		}
@@ -235,7 +235,7 @@ func (t *MeshHashes) DecodeScale(dec *scale.Decoder) (total int, err error) {
 
 func (t *MaliciousIDs) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	{
-		n, err := scale.EncodeStructSliceWithLimit(enc, t.NodeIDs, 100000)
+		n, err := scale.EncodeStructSliceWithLimit(enc, t.NodeIDs, 3500000)
 		if err != nil {
 			return total, err
 		}
@@ -246,7 +246,7 @@ func (t *MaliciousIDs) EncodeScale(enc *scale.Encoder) (total int, err error) {
 
 func (t *MaliciousIDs) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	{
-		field, n, err := scale.DecodeStructSliceWithLimit[types.NodeID](dec, 100000)
+		field, n, err := scale.DecodeStructSliceWithLimit[types.NodeID](dec, 3500000)
 		if err != nil {
 			return total, err
 		}
@@ -258,7 +258,7 @@ func (t *MaliciousIDs) DecodeScale(dec *scale.Decoder) (total int, err error) {
 
 func (t *EpochData) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	{
-		n, err := scale.EncodeStructSliceWithLimit(enc, t.AtxIDs, 2700000)
+		n, err := scale.EncodeStructSliceWithLimit(enc, t.AtxIDs, 3500000)
 		if err != nil {
 			return total, err
 		}
@@ -269,7 +269,7 @@ func (t *EpochData) EncodeScale(enc *scale.Encoder) (total int, err error) {
 
 func (t *EpochData) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	{
-		field, n, err := scale.DecodeStructSliceWithLimit[types.ATXID](dec, 2700000)
+		field, n, err := scale.DecodeStructSliceWithLimit[types.ATXID](dec, 3500000)
 		if err != nil {
 			return total, err
 		}
@@ -281,7 +281,7 @@ func (t *EpochData) DecodeScale(dec *scale.Decoder) (total int, err error) {
 
 func (t *LayerData) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	{
-		n, err := scale.EncodeStructSliceWithLimit(enc, t.Ballots, 900)
+		n, err := scale.EncodeStructSliceWithLimit(enc, t.Ballots, 1100)
 		if err != nil {
 			return total, err
 		}
@@ -292,7 +292,7 @@ func (t *LayerData) EncodeScale(enc *scale.Encoder) (total int, err error) {
 
 func (t *LayerData) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	{
-		field, n, err := scale.DecodeStructSliceWithLimit[types.BallotID](dec, 900)
+		field, n, err := scale.DecodeStructSliceWithLimit[types.BallotID](dec, 1100)
 		if err != nil {
 			return total, err
 		}

--- a/hare3/types.go
+++ b/hare3/types.go
@@ -81,14 +81,14 @@ type Value struct {
 	// In this case they will get all 50 available slots in all 4032 layers of the epoch.
 	// Additionally every other identity on the network that successfully published an ATX will get 1 slot.
 	//
-	// If we expect 2.7 Mio ATXs that would be a total of 2.7 Mio + 50 * 4032 = 2 901 600 slots.
+	// If we expect 2.7 Mio ATXs that would be a total of 2.7 Mio + 50 * 4032 = 3 701 600 slots.
 	// Since these are randomly distributed across the epoch, we can expect an average of n * p =
-	// 2 901 600 / 4032 = 719.6 eligibilities in a layer with a standard deviation of sqrt(n * p * (1 - p)) =
-	// sqrt(2 901 600 * 1/4032 * 4031/4032) = 26.8
+	// 3 701 600 / 4032 = 918.1 eligibilities in a layer with a standard deviation of sqrt(n * p * (1 - p)) =
+	// sqrt(3 701 600 * 1/4032 * 4031/4032) = 1100.0
 	//
-	// This means that we can expect a maximum of 719.6 + 6*26.8 = 880.6 eligibilities in a layer with
+	// This means that we can expect a maximum of 918.1 + 6*1100.0 = 880.6 eligibilities in a layer with
 	// > 99.9997% probability.
-	Proposals []types.ProposalID `scale:"max=900"`
+	Proposals []types.ProposalID `scale:"max=1100"`
 	// Reference is set in messages for commit and notify rounds.
 	Reference *types.Hash32
 }

--- a/hare3/types_scale.go
+++ b/hare3/types_scale.go
@@ -48,7 +48,7 @@ func (t *IterRound) DecodeScale(dec *scale.Decoder) (total int, err error) {
 
 func (t *Value) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	{
-		n, err := scale.EncodeStructSliceWithLimit(enc, t.Proposals, 900)
+		n, err := scale.EncodeStructSliceWithLimit(enc, t.Proposals, 1100)
 		if err != nil {
 			return total, err
 		}
@@ -66,7 +66,7 @@ func (t *Value) EncodeScale(enc *scale.Encoder) (total int, err error) {
 
 func (t *Value) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	{
-		field, n, err := scale.DecodeStructSliceWithLimit[types.ProposalID](dec, 900)
+		field, n, err := scale.DecodeStructSliceWithLimit[types.ProposalID](dec, 1100)
 		if err != nil {
 			return total, err
 		}

--- a/p2p/server/server.go
+++ b/p2p/server/server.go
@@ -140,7 +140,8 @@ func (err *ServerError) Error() string {
 
 // Response is a server response.
 type Response struct {
-	Data  []byte `scale:"max=104857600"` // 100 MiB - keep in line with ResponseMessage.Data in `fetch/wire_types.go`
+	// keep in line with limit of ResponseMessage.Data in `fetch/wire_types.go`
+	Data  []byte `scale:"max=125829120"` // 120 MiB > 3.5 mio ATX * 32 bytes per ID
 	Error string `scale:"max=1024"`      // TODO(mafa): make error code instead of string
 }
 

--- a/p2p/server/server_scale.go
+++ b/p2p/server/server_scale.go
@@ -9,7 +9,7 @@ import (
 
 func (t *Response) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	{
-		n, err := scale.EncodeByteSliceWithLimit(enc, t.Data, 104857600)
+		n, err := scale.EncodeByteSliceWithLimit(enc, t.Data, 125829120)
 		if err != nil {
 			return total, err
 		}
@@ -27,7 +27,7 @@ func (t *Response) EncodeScale(enc *scale.Encoder) (total int, err error) {
 
 func (t *Response) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	{
-		field, n, err := scale.DecodeByteSliceWithLimit(dec, 104857600)
+		field, n, err := scale.DecodeByteSliceWithLimit(dec, 125829120)
 		if err != nil {
 			return total, err
 		}


### PR DESCRIPTION
## Motivation

2.7 Mio ATXs might not be enough for the next epoch already. This increases limits of types to support up to 3.5 Mio ATXs per epoch.

## Description

All types with limits that will be hit when the number of ATXs increases have been adjusted to support up to 3.5 Mio active users.

## Test Plan

n/a

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
