### PR TITLE
[Merged by Bors] - Nipost builder take challenge hash and publish epoch

### DIFF
--- a/activation/activation_multi_test.go
+++ b/activation/activation_multi_test.go
@@ -404,7 +404,7 @@ func Test_Builder_Multi_HappyPath(t *testing.T) {
 			VRFNonce: types.VRFPostIndex(rand.Uint64()),
 		}
 		nipostState[sig.NodeID()] = state
-		tab.mnipost.EXPECT().BuildNIPost(gomock.Any(), sig, ref).Return(state, nil)
+		tab.mnipost.EXPECT().BuildNIPost(gomock.Any(), sig, ref.PublishEpoch, ref.Hash()).Return(state, nil)
 
 		// awaiting atx publication epoch log
 		tab.mclock.EXPECT().CurrentLayer().DoAndReturn(

--- a/activation/activation_test.go
+++ b/activation/activation_test.go
@@ -210,10 +210,10 @@ func publishAtx(
 		NumUnits:      DefaultPostSetupOpts().NumUnits,
 		LabelsPerUnit: DefaultPostConfig().LabelsPerUnit,
 	}, nil).AnyTimes()
-	tab.mnipost.EXPECT().BuildNIPost(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, _ *signing.EdSigner, challenge *types.NIPostChallenge) (*nipost.NIPostState, error) {
+	tab.mnipost.EXPECT().BuildNIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ *signing.EdSigner, _ types.EpochID, ch types.Hash32) (*nipost.NIPostState, error) {
 			*currLayer = currLayer.Add(buildNIPostLayerDuration)
-			return newNIPostWithChallenge(tb, challenge.Hash(), []byte("66666")), nil
+			return newNIPostWithChallenge(tb, ch, []byte("66666")), nil
 		})
 	ch := make(chan struct{})
 	close(ch)
@@ -462,7 +462,9 @@ func TestBuilder_Loop_WaitsOnStaleChallenge(t *testing.T) {
 			return genesis.Add(layerDuration * time.Duration(got))
 		}).AnyTimes()
 
-	tab.mnipost.EXPECT().BuildNIPost(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, ErrATXChallengeExpired)
+	tab.mnipost.EXPECT().
+		BuildNIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil, ErrATXChallengeExpired)
 	tab.mnipost.EXPECT().ResetState(sig.NodeID()).Return(nil)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -528,10 +530,10 @@ func TestBuilder_PublishActivationTx_FaultyNet(t *testing.T) {
 		NumUnits:      DefaultPostSetupOpts().NumUnits,
 		LabelsPerUnit: DefaultPostConfig().LabelsPerUnit,
 	}, nil).AnyTimes()
-	tab.mnipost.EXPECT().BuildNIPost(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, _ *signing.EdSigner, challenge *types.NIPostChallenge) (*nipost.NIPostState, error) {
+	tab.mnipost.EXPECT().BuildNIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ *signing.EdSigner, _ types.EpochID, ch types.Hash32) (*nipost.NIPostState, error) {
 			currLayer = currLayer.Add(layersPerEpoch)
-			return newNIPostWithChallenge(t, challenge.Hash(), []byte("66666")), nil
+			return newNIPostWithChallenge(t, ch, []byte("66666")), nil
 		})
 	done := make(chan struct{})
 	close(done)
@@ -619,10 +621,10 @@ func TestBuilder_PublishActivationTx_UsesExistingChallengeOnLatePublish(t *testi
 		NumUnits:      DefaultPostSetupOpts().NumUnits,
 		LabelsPerUnit: DefaultPostConfig().LabelsPerUnit,
 	}, nil).AnyTimes()
-	tab.mnipost.EXPECT().BuildNIPost(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, _ *signing.EdSigner, challenge *types.NIPostChallenge) (*nipost.NIPostState, error) {
+	tab.mnipost.EXPECT().BuildNIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ *signing.EdSigner, _ types.EpochID, ch types.Hash32) (*nipost.NIPostState, error) {
 			currLayer = currLayer.Add(1)
-			return newNIPostWithChallenge(t, challenge.Hash(), []byte("66666")), nil
+			return newNIPostWithChallenge(t, ch, []byte("66666")), nil
 		})
 	done := make(chan struct{})
 	close(done)
@@ -698,10 +700,10 @@ func TestBuilder_PublishActivationTx_RebuildNIPostWhenTargetEpochPassed(t *testi
 			genesis := time.Now().Add(-time.Duration(currLayer) * layerDuration)
 			return genesis.Add(layerDuration * time.Duration(got))
 		}).AnyTimes()
-	tab.mnipost.EXPECT().BuildNIPost(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, _ *signing.EdSigner, challenge *types.NIPostChallenge) (*nipost.NIPostState, error) {
+	tab.mnipost.EXPECT().BuildNIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ *signing.EdSigner, _ types.EpochID, ch types.Hash32) (*nipost.NIPostState, error) {
 			currLayer = currLayer.Add(layersPerEpoch)
-			return newNIPostWithChallenge(t, challenge.Hash(), []byte("66666")), nil
+			return newNIPostWithChallenge(t, ch, []byte("66666")), nil
 		})
 	done := make(chan struct{})
 	close(done)
@@ -882,7 +884,9 @@ func TestBuilder_PublishActivationTx_NoPrevATX_PublishFails_InitialPost_preserve
 			return genesis.Add(layerDuration * time.Duration(got))
 		}).AnyTimes()
 
-	tab.mnipost.EXPECT().BuildNIPost(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, ErrATXChallengeExpired)
+	tab.mnipost.EXPECT().
+		BuildNIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil, ErrATXChallengeExpired)
 	tab.mnipost.EXPECT().ResetState(sig.NodeID()).Return(nil)
 
 	ch := make(chan struct{})
@@ -998,10 +1002,10 @@ func TestBuilder_PublishActivationTx_PrevATXWithoutPrevATX(t *testing.T) {
 		LabelsPerUnit: DefaultPostConfig().LabelsPerUnit,
 	}, nil).AnyTimes()
 
-	tab.mnipost.EXPECT().BuildNIPost(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, _ *signing.EdSigner, challenge *types.NIPostChallenge) (*nipost.NIPostState, error) {
+	tab.mnipost.EXPECT().BuildNIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ *signing.EdSigner, _ types.EpochID, ch types.Hash32) (*nipost.NIPostState, error) {
 			currentLayer = currentLayer.Add(5)
-			return newNIPostWithChallenge(t, challenge.Hash(), poetBytes), nil
+			return newNIPostWithChallenge(t, ch, poetBytes), nil
 		})
 
 	tab.mValidator.EXPECT().VerifyChain(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
@@ -1098,10 +1102,10 @@ func TestBuilder_PublishActivationTx_TargetsEpochBasedOnPosAtx(t *testing.T) {
 		LabelsPerUnit: DefaultPostConfig().LabelsPerUnit,
 	}, nil).AnyTimes()
 
-	tab.mnipost.EXPECT().BuildNIPost(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, _ *signing.EdSigner, challenge *types.NIPostChallenge) (*nipost.NIPostState, error) {
+	tab.mnipost.EXPECT().BuildNIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ *signing.EdSigner, _ types.EpochID, ch types.Hash32) (*nipost.NIPostState, error) {
 			currentLayer = currentLayer.Add(layersPerEpoch)
-			return newNIPostWithChallenge(t, challenge.Hash(), poetBytes), nil
+			return newNIPostWithChallenge(t, ch, poetBytes), nil
 		})
 
 	tab.mValidator.EXPECT().VerifyChain(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
@@ -1189,7 +1193,7 @@ func TestBuilder_PublishActivationTx_FailsWhenNIPostBuilderFails(t *testing.T) {
 			return genesis.Add(layerDuration * time.Duration(got))
 		}).AnyTimes()
 	nipostErr := errors.New("NIPost builder error")
-	tab.mnipost.EXPECT().BuildNIPost(gomock.Any(), sig, gomock.Any()).Return(nil, nipostErr)
+	tab.mnipost.EXPECT().BuildNIPost(gomock.Any(), sig, gomock.Any(), gomock.Any()).Return(nil, nipostErr)
 	tab.mValidator.EXPECT().VerifyChain(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 	require.ErrorIs(t, tab.PublishActivationTx(context.Background(), sig), nipostErr)
 
@@ -1331,22 +1335,26 @@ func TestBuilder_RetryPublishActivationTx(t *testing.T) {
 	tries := 0
 	var last time.Time
 	builderConfirmation := make(chan struct{})
-	tab.mnipost.EXPECT().BuildNIPost(gomock.Any(), gomock.Any(), gomock.Any()).Times(expectedTries).DoAndReturn(
-		func(_ context.Context, _ *signing.EdSigner, challenge *types.NIPostChallenge) (*nipost.NIPostState, error) {
-			now := time.Now()
-			if now.Sub(last) < retryInterval {
-				require.FailNow(t, "retry interval not respected")
-			}
+	tab.mnipost.EXPECT().
+		BuildNIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Times(expectedTries).
+		DoAndReturn(
+			// nolint:lll
+			func(_ context.Context, _ *signing.EdSigner, _ types.EpochID, ch types.Hash32) (*nipost.NIPostState, error) {
+				now := time.Now()
+				if now.Sub(last) < retryInterval {
+					require.FailNow(t, "retry interval not respected")
+				}
 
-			tries++
-			t.Logf("try %d: %s", tries, now)
-			if tries < expectedTries {
-				return nil, ErrPoetServiceUnstable
-			}
-			close(builderConfirmation)
-			return newNIPostWithChallenge(t, challenge.Hash(), poetBytes), nil
-		},
-	)
+				tries++
+				t.Logf("try %d: %s", tries, now)
+				if tries < expectedTries {
+					return nil, ErrPoetServiceUnstable
+				}
+				close(builderConfirmation)
+				return newNIPostWithChallenge(t, ch, poetBytes), nil
+			},
+		)
 
 	tab.mnipost.EXPECT().ResetState(sig.NodeID()).Return(nil)
 	tab.mValidator.EXPECT().VerifyChain(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
@@ -1597,7 +1605,7 @@ func TestWaitPositioningAtx(t *testing.T) {
 			// everything else are stubs that are irrelevant for the test
 			tab.mpostClient.EXPECT().Info(gomock.Any()).Return(&types.PostInfo{}, nil).AnyTimes()
 			tab.mnipost.EXPECT().ResetState(sig.NodeID()).Return(nil)
-			tab.mnipost.EXPECT().BuildNIPost(gomock.Any(), gomock.Any(), gomock.Any()).
+			tab.mnipost.EXPECT().BuildNIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 				Return(&nipost.NIPostState{}, nil)
 			closed := make(chan struct{})
 			close(closed)

--- a/activation/activation_test.go
+++ b/activation/activation_test.go
@@ -211,9 +211,9 @@ func publishAtx(
 		LabelsPerUnit: DefaultPostConfig().LabelsPerUnit,
 	}, nil).AnyTimes()
 	tab.mnipost.EXPECT().BuildNIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, _ *signing.EdSigner, _ types.EpochID, ch types.Hash32) (*nipost.NIPostState, error) {
+		func(_ context.Context, _ *signing.EdSigner, _ types.EpochID, _ types.Hash32) (*nipost.NIPostState, error) {
 			*currLayer = currLayer.Add(buildNIPostLayerDuration)
-			return newNIPostWithChallenge(tb, ch, []byte("66666")), nil
+			return newNIPostWithPoet(tb, []byte("66666")), nil
 		})
 	ch := make(chan struct{})
 	close(ch)
@@ -404,7 +404,7 @@ func TestBuilder_PublishActivationTx_HappyFlow(t *testing.T) {
 		PositioningATX: tab.goldenATXID,
 		CommitmentATX:  &tab.goldenATXID,
 	}
-	nipostData := newNIPostWithChallenge(t, types.HexToHash32("55555"), []byte("66666"))
+	nipostData := newNIPostWithPoet(t, []byte("66666"))
 	prevAtx := newAtx(ch, nipostData.NIPost, 2, types.Address{})
 	require.NoError(t, SignAndFinalizeAtx(sig, prevAtx))
 	vPrevAtx, err := prevAtx.Verify(0, 1)
@@ -447,7 +447,7 @@ func TestBuilder_Loop_WaitsOnStaleChallenge(t *testing.T) {
 		PositioningATX: tab.goldenATXID,
 		CommitmentATX:  &tab.goldenATXID,
 	}
-	nipostData := newNIPostWithChallenge(t, types.HexToHash32("55555"), []byte("66666"))
+	nipostData := newNIPostWithPoet(t, []byte("66666"))
 	prevAtx := newAtx(ch, nipostData.NIPost, 2, types.Address{})
 	require.NoError(t, SignAndFinalizeAtx(sig, prevAtx))
 	vPrevAtx, err := prevAtx.Verify(0, 1)
@@ -505,7 +505,7 @@ func TestBuilder_PublishActivationTx_FaultyNet(t *testing.T) {
 		PositioningATX: tab.goldenATXID,
 		CommitmentATX:  &tab.goldenATXID,
 	}
-	nipostData := newNIPostWithChallenge(t, types.HexToHash32("55555"), []byte("66666"))
+	nipostData := newNIPostWithPoet(t, []byte("66666"))
 	prevAtx := newAtx(ch, nipostData.NIPost, 2, types.Address{})
 	require.NoError(t, SignAndFinalizeAtx(sig, prevAtx))
 	vPrevAtx, err := prevAtx.Verify(0, 1)
@@ -531,9 +531,9 @@ func TestBuilder_PublishActivationTx_FaultyNet(t *testing.T) {
 		LabelsPerUnit: DefaultPostConfig().LabelsPerUnit,
 	}, nil).AnyTimes()
 	tab.mnipost.EXPECT().BuildNIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, _ *signing.EdSigner, _ types.EpochID, ch types.Hash32) (*nipost.NIPostState, error) {
+		func(_ context.Context, _ *signing.EdSigner, _ types.EpochID, _ types.Hash32) (*nipost.NIPostState, error) {
 			currLayer = currLayer.Add(layersPerEpoch)
-			return newNIPostWithChallenge(t, ch, []byte("66666")), nil
+			return newNIPostWithPoet(t, []byte("66666")), nil
 		})
 	done := make(chan struct{})
 	close(done)
@@ -596,7 +596,7 @@ func TestBuilder_PublishActivationTx_UsesExistingChallengeOnLatePublish(t *testi
 		PositioningATX: types.ATXID{1, 2, 3},
 		CommitmentATX:  nil,
 	}
-	nipostData := newNIPostWithChallenge(t, types.HexToHash32("55555"), []byte("66666"))
+	nipostData := newNIPostWithPoet(t, []byte("66666"))
 	prevAtx := newAtx(challenge, nipostData.NIPost, posEpoch.Uint32(), types.Address{})
 	require.NoError(t, SignAndFinalizeAtx(sig, prevAtx))
 	vPrevAtx, err := prevAtx.Verify(0, 1)
@@ -622,9 +622,9 @@ func TestBuilder_PublishActivationTx_UsesExistingChallengeOnLatePublish(t *testi
 		LabelsPerUnit: DefaultPostConfig().LabelsPerUnit,
 	}, nil).AnyTimes()
 	tab.mnipost.EXPECT().BuildNIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, _ *signing.EdSigner, _ types.EpochID, ch types.Hash32) (*nipost.NIPostState, error) {
+		func(_ context.Context, _ *signing.EdSigner, _ types.EpochID, _ types.Hash32) (*nipost.NIPostState, error) {
 			currLayer = currLayer.Add(1)
-			return newNIPostWithChallenge(t, ch, []byte("66666")), nil
+			return newNIPostWithPoet(t, []byte("66666")), nil
 		})
 	done := make(chan struct{})
 	close(done)
@@ -682,7 +682,7 @@ func TestBuilder_PublishActivationTx_RebuildNIPostWhenTargetEpochPassed(t *testi
 		PositioningATX: types.ATXID{1, 2, 3},
 		CommitmentATX:  nil,
 	}
-	nipostData := newNIPostWithChallenge(t, types.HexToHash32("55555"), []byte("66666"))
+	nipostData := newNIPostWithPoet(t, []byte("66666"))
 	prevAtx := newAtx(ch, nipostData.NIPost, 2, types.Address{})
 	require.NoError(t, SignAndFinalizeAtx(sig, prevAtx))
 	vPrevAtx, err := prevAtx.Verify(0, 1)
@@ -701,9 +701,9 @@ func TestBuilder_PublishActivationTx_RebuildNIPostWhenTargetEpochPassed(t *testi
 			return genesis.Add(layerDuration * time.Duration(got))
 		}).AnyTimes()
 	tab.mnipost.EXPECT().BuildNIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, _ *signing.EdSigner, _ types.EpochID, ch types.Hash32) (*nipost.NIPostState, error) {
+		func(_ context.Context, _ *signing.EdSigner, _ types.EpochID, _ types.Hash32) (*nipost.NIPostState, error) {
 			currLayer = currLayer.Add(layersPerEpoch)
-			return newNIPostWithChallenge(t, ch, []byte("66666")), nil
+			return newNIPostWithPoet(t, []byte("66666")), nil
 		})
 	done := make(chan struct{})
 	close(done)
@@ -786,7 +786,7 @@ func TestBuilder_PublishActivationTx_NoPrevATX(t *testing.T) {
 		PositioningATX: types.ATXID{1, 2, 3},
 		CommitmentATX:  nil,
 	}
-	nipostData := newNIPostWithChallenge(t, types.HexToHash32("55555"), []byte("66666"))
+	nipostData := newNIPostWithPoet(t, []byte("66666"))
 	otherSigner, err := signing.NewEdSigner()
 	require.NoError(t, err)
 	posAtx := newAtx(challenge, nipostData.NIPost, 2, types.Address{})
@@ -842,7 +842,7 @@ func TestBuilder_PublishActivationTx_NoPrevATX_PublishFails_InitialPost_preserve
 		PositioningATX: types.ATXID{1, 2, 3},
 		CommitmentATX:  nil,
 	}
-	nipostData := newNIPostWithChallenge(t, types.HexToHash32("55555"), []byte("66666"))
+	nipostData := newNIPostWithPoet(t, []byte("66666"))
 	otherSigner, err := signing.NewEdSigner()
 	require.NoError(t, err)
 	posAtx := newAtx(challenge, nipostData.NIPost, 2, types.Address{})
@@ -951,7 +951,7 @@ func TestBuilder_PublishActivationTx_PrevATXWithoutPrevATX(t *testing.T) {
 		CommitmentATX:  &tab.goldenATXID,
 	}
 	poetBytes := []byte("66666")
-	nipostData := newNIPostWithChallenge(t, types.HexToHash32("55555"), poetBytes)
+	nipostData := newNIPostWithPoet(t, poetBytes)
 	posAtx := newAtx(challenge, nipostData.NIPost, 2, types.Address{})
 	require.NoError(t, SignAndFinalizeAtx(otherSigner, posAtx))
 	vPosAtx, err := posAtx.Verify(0, 2)
@@ -1003,9 +1003,9 @@ func TestBuilder_PublishActivationTx_PrevATXWithoutPrevATX(t *testing.T) {
 	}, nil).AnyTimes()
 
 	tab.mnipost.EXPECT().BuildNIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, _ *signing.EdSigner, _ types.EpochID, ch types.Hash32) (*nipost.NIPostState, error) {
+		func(_ context.Context, _ *signing.EdSigner, _ types.EpochID, _ types.Hash32) (*nipost.NIPostState, error) {
 			currentLayer = currentLayer.Add(5)
-			return newNIPostWithChallenge(t, ch, poetBytes), nil
+			return newNIPostWithPoet(t, poetBytes), nil
 		})
 
 	tab.mValidator.EXPECT().VerifyChain(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
@@ -1066,7 +1066,7 @@ func TestBuilder_PublishActivationTx_TargetsEpochBasedOnPosAtx(t *testing.T) {
 		CommitmentATX:  &types.ATXID{4, 5, 6},
 	}
 	poetBytes := []byte("66666")
-	nipostData := newNIPostWithChallenge(t, types.HexToHash32("55555"), poetBytes)
+	nipostData := newNIPostWithPoet(t, poetBytes)
 	posAtx := newAtx(challenge, nipostData.NIPost, 2, types.Address{})
 	require.NoError(t, SignAndFinalizeAtx(otherSigner, posAtx))
 	vPosAtx, err := posAtx.Verify(0, 1)
@@ -1103,9 +1103,9 @@ func TestBuilder_PublishActivationTx_TargetsEpochBasedOnPosAtx(t *testing.T) {
 	}, nil).AnyTimes()
 
 	tab.mnipost.EXPECT().BuildNIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, _ *signing.EdSigner, _ types.EpochID, ch types.Hash32) (*nipost.NIPostState, error) {
+		func(_ context.Context, _ *signing.EdSigner, _ types.EpochID, _ types.Hash32) (*nipost.NIPostState, error) {
 			currentLayer = currentLayer.Add(layersPerEpoch)
-			return newNIPostWithChallenge(t, ch, poetBytes), nil
+			return newNIPostWithPoet(t, poetBytes), nil
 		})
 
 	tab.mValidator.EXPECT().VerifyChain(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
@@ -1178,7 +1178,7 @@ func TestBuilder_PublishActivationTx_FailsWhenNIPostBuilderFails(t *testing.T) {
 		PositioningATX: types.ATXID{1, 2, 3},
 		CommitmentATX:  nil,
 	}
-	nipostData := newNIPostWithChallenge(t, types.HexToHash32("55555"), []byte("66666"))
+	nipostData := newNIPostWithPoet(t, []byte("66666"))
 	posAtx := newAtx(ch, nipostData.NIPost, 2, types.Address{})
 	require.NoError(t, SignAndFinalizeAtx(sig, posAtx))
 	vPosAtx, err := posAtx.Verify(0, 1)
@@ -1208,7 +1208,7 @@ func TestBuilder_PublishActivationTx_Serialize(t *testing.T) {
 	sig, err := signing.NewEdSigner()
 	require.NoError(t, err)
 
-	nipost := newNIPostWithChallenge(t, types.HexToHash32("55555"), []byte("66666"))
+	nipost := newNIPostWithPoet(t, []byte("66666"))
 	coinbase := types.Address{4, 5, 6}
 	atx := newActivationTx(
 		t,
@@ -1265,7 +1265,7 @@ func TestBuilder_SignAtx(t *testing.T) {
 		PositioningATX: prevAtx,
 		CommitmentATX:  nil,
 	}
-	nipost := newNIPostWithChallenge(t, types.HexToHash32("55555"), []byte("66666"))
+	nipost := newNIPostWithPoet(t, []byte("66666"))
 	atx := newAtx(challenge, nipost.NIPost, 100, types.Address{})
 	require.NoError(t, SignAndFinalizeAtx(sig, atx))
 
@@ -1303,7 +1303,7 @@ func TestBuilder_RetryPublishActivationTx(t *testing.T) {
 		CommitmentATX:  nil,
 	}
 	poetBytes := []byte("66666")
-	nipostData := newNIPostWithChallenge(t, types.HexToHash32("55555"), poetBytes)
+	nipostData := newNIPostWithPoet(t, poetBytes)
 	prevAtx := newAtx(challenge, nipostData.NIPost, 2, types.Address{})
 	require.NoError(t, SignAndFinalizeAtx(sig, prevAtx))
 	vPrevAtx, err := prevAtx.Verify(0, 1)
@@ -1340,7 +1340,7 @@ func TestBuilder_RetryPublishActivationTx(t *testing.T) {
 		Times(expectedTries).
 		DoAndReturn(
 			// nolint:lll
-			func(_ context.Context, _ *signing.EdSigner, _ types.EpochID, ch types.Hash32) (*nipost.NIPostState, error) {
+			func(_ context.Context, _ *signing.EdSigner, _ types.EpochID, _ types.Hash32) (*nipost.NIPostState, error) {
 				now := time.Now()
 				if now.Sub(last) < retryInterval {
 					require.FailNow(t, "retry interval not respected")
@@ -1352,7 +1352,7 @@ func TestBuilder_RetryPublishActivationTx(t *testing.T) {
 					return nil, ErrPoetServiceUnstable
 				}
 				close(builderConfirmation)
-				return newNIPostWithChallenge(t, ch, poetBytes), nil
+				return newNIPostWithPoet(t, poetBytes), nil
 			},
 		)
 
@@ -1462,7 +1462,7 @@ func TestBuilder_InitialProofGeneratedOnce(t *testing.T) {
 		CommitmentATX:  &tab.goldenATXID,
 	}
 	poetByte := []byte("66666")
-	nipost := newNIPostWithChallenge(t, types.HexToHash32("55555"), poetByte)
+	nipost := newNIPostWithPoet(t, poetByte)
 	prevAtx := newAtx(challenge, nipost.NIPost, 2, types.Address{})
 	require.NoError(t, SignAndFinalizeAtx(sig, prevAtx))
 	vPrevAtx, err := prevAtx.Verify(0, 1)
@@ -1696,7 +1696,7 @@ func TestGetPositioningAtxPicksAtxWithValidChain(t *testing.T) {
 		PositioningATX: tab.goldenATXID,
 		CommitmentATX:  &tab.goldenATXID,
 	}
-	nipostData := newNIPostWithChallenge(t, types.HexToHash32(""), []byte("0"))
+	nipostData := newNIPostWithPoet(t, []byte("0"))
 	invalidAtx := newAtx(ch, nipostData.NIPost, 2, types.Address{})
 	require.NoError(t, SignAndFinalizeAtx(sigInvalid, invalidAtx))
 	vInvalidAtx, err := invalidAtx.Verify(0, 100)
@@ -1706,7 +1706,7 @@ func TestGetPositioningAtxPicksAtxWithValidChain(t *testing.T) {
 	// Valid chain with lower height
 	sigValid, err := signing.NewEdSigner()
 	require.NoError(t, err)
-	nipostData = newNIPostWithChallenge(t, types.HexToHash32(""), []byte("1"))
+	nipostData = newNIPostWithPoet(t, []byte("1"))
 	validAtx := newAtx(ch, nipostData.NIPost, 2, types.Address{})
 	require.NoError(t, SignAndFinalizeAtx(sigValid, validAtx))
 	vValidAtx, err := validAtx.Verify(0, 1)

--- a/activation/e2e/activation_test.go
+++ b/activation/e2e/activation_test.go
@@ -209,7 +209,7 @@ func Test_BuilderWithMultipleClients(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		require.Equal(t, postGenesisEpoch, atx.NIPostChallenge.TargetEpoch())
+		require.Equal(t, postGenesisEpoch, atx.TargetEpoch())
 		require.Equal(t, types.EmptyATXID, atx.NIPostChallenge.PrevATXID)
 		require.Equal(t, goldenATX, atx.NIPostChallenge.PositioningATX)
 		require.Equal(t, uint64(0), atx.NIPostChallenge.Sequence)

--- a/activation/e2e/nipost_test.go
+++ b/activation/e2e/nipost_test.go
@@ -196,7 +196,7 @@ func TestNIPostBuilderWithClients(t *testing.T) {
 	challenge := types.NIPostChallenge{
 		PublishEpoch: postGenesisEpoch + 2,
 	}
-	nipost, err := nb.BuildNIPost(context.Background(), sig, &challenge)
+	nipost, err := nb.BuildNIPost(context.Background(), sig, challenge.PublishEpoch, challenge.Hash())
 	require.NoError(t, err)
 
 	v := activation.NewValidator(nil, poetDb, cfg, opts.Scrypt, verifier)
@@ -250,7 +250,7 @@ func TestNIPostBuilder_Close(t *testing.T) {
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	nipost, err := nb.BuildNIPost(ctx, sig, &challenge)
+	nipost, err := nb.BuildNIPost(ctx, sig, challenge.PublishEpoch, challenge.Hash())
 	require.ErrorIs(t, err, context.Canceled)
 	require.Nil(t, nipost)
 }
@@ -336,7 +336,7 @@ func TestNewNIPostBuilderNotInitialized(t *testing.T) {
 	challenge := types.NIPostChallenge{
 		PublishEpoch: postGenesisEpoch + 2,
 	}
-	nipost, err := nb.BuildNIPost(context.Background(), sig, &challenge)
+	nipost, err := nb.BuildNIPost(context.Background(), sig, challenge.PublishEpoch, challenge.Hash())
 	require.NoError(t, err)
 	require.NotNil(t, nipost)
 
@@ -458,7 +458,7 @@ func Test_NIPostBuilderWithMultipleClients(t *testing.T) {
 	}
 	for _, sig := range signers {
 		eg.Go(func() error {
-			nipost, err := nb.BuildNIPost(context.Background(), sig, &challenge)
+			nipost, err := nb.BuildNIPost(context.Background(), sig, challenge.PublishEpoch, challenge.Hash())
 			require.NoError(t, err)
 
 			v := activation.NewValidator(nil, poetDb, cfg, opts.Scrypt, verifier)

--- a/activation/e2e/validation_test.go
+++ b/activation/e2e/validation_test.go
@@ -111,7 +111,7 @@ func TestValidator_Validate(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	nipost, err := nb.BuildNIPost(context.Background(), sig, &challenge)
+	nipost, err := nb.BuildNIPost(context.Background(), sig, challenge.PublishEpoch, challenge.Hash())
 	require.NoError(t, err)
 
 	v := activation.NewValidator(cdb, poetDb, cfg, opts.Scrypt, verifier)

--- a/activation/interface.go
+++ b/activation/interface.go
@@ -83,7 +83,8 @@ type nipostBuilder interface {
 	BuildNIPost(
 		ctx context.Context,
 		sig *signing.EdSigner,
-		challenge *types.NIPostChallenge,
+		publish types.EpochID,
+		challenge types.Hash32,
 	) (*nipost.NIPostState, error)
 	Proof(ctx context.Context, nodeID types.NodeID, challenge []byte) (*types.Post, *types.PostInfo, error)
 	ResetState(types.NodeID) error

--- a/activation/mocks.go
+++ b/activation/mocks.go
@@ -824,18 +824,18 @@ func (m *MocknipostBuilder) EXPECT() *MocknipostBuilderMockRecorder {
 }
 
 // BuildNIPost mocks base method.
-func (m *MocknipostBuilder) BuildNIPost(ctx context.Context, sig *signing.EdSigner, challenge *types.NIPostChallenge) (*nipost.NIPostState, error) {
+func (m *MocknipostBuilder) BuildNIPost(ctx context.Context, sig *signing.EdSigner, publish types.EpochID, challenge types.Hash32) (*nipost.NIPostState, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BuildNIPost", ctx, sig, challenge)
+	ret := m.ctrl.Call(m, "BuildNIPost", ctx, sig, publish, challenge)
 	ret0, _ := ret[0].(*nipost.NIPostState)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // BuildNIPost indicates an expected call of BuildNIPost.
-func (mr *MocknipostBuilderMockRecorder) BuildNIPost(ctx, sig, challenge any) *MocknipostBuilderBuildNIPostCall {
+func (mr *MocknipostBuilderMockRecorder) BuildNIPost(ctx, sig, publish, challenge any) *MocknipostBuilderBuildNIPostCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildNIPost", reflect.TypeOf((*MocknipostBuilder)(nil).BuildNIPost), ctx, sig, challenge)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildNIPost", reflect.TypeOf((*MocknipostBuilder)(nil).BuildNIPost), ctx, sig, publish, challenge)
 	return &MocknipostBuilderBuildNIPostCall{Call: call}
 }
 
@@ -851,13 +851,13 @@ func (c *MocknipostBuilderBuildNIPostCall) Return(arg0 *nipost.NIPostState, arg1
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MocknipostBuilderBuildNIPostCall) Do(f func(context.Context, *signing.EdSigner, *types.NIPostChallenge) (*nipost.NIPostState, error)) *MocknipostBuilderBuildNIPostCall {
+func (c *MocknipostBuilderBuildNIPostCall) Do(f func(context.Context, *signing.EdSigner, types.EpochID, types.Hash32) (*nipost.NIPostState, error)) *MocknipostBuilderBuildNIPostCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MocknipostBuilderBuildNIPostCall) DoAndReturn(f func(context.Context, *signing.EdSigner, *types.NIPostChallenge) (*nipost.NIPostState, error)) *MocknipostBuilderBuildNIPostCall {
+func (c *MocknipostBuilderBuildNIPostCall) DoAndReturn(f func(context.Context, *signing.EdSigner, types.EpochID, types.Hash32) (*nipost.NIPostState, error)) *MocknipostBuilderBuildNIPostCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/activation/nipost_test.go
+++ b/activation/nipost_test.go
@@ -413,7 +413,7 @@ func Test_NIPostBuilder_WithMocks(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	nipost, err := nb.BuildNIPost(context.Background(), sig, &challenge)
+	nipost, err := nb.BuildNIPost(context.Background(), sig, challenge.PublishEpoch, challenge.Hash())
 	require.NoError(t, err)
 	require.NotNil(t, nipost)
 }
@@ -455,7 +455,7 @@ func TestPostSetup(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	nipost, err := nb.BuildNIPost(context.Background(), sig, &challenge)
+	nipost, err := nb.BuildNIPost(context.Background(), sig, challenge.PublishEpoch, challenge.Hash())
 	require.NoError(t, err)
 	require.NotNil(t, nipost)
 }
@@ -519,7 +519,7 @@ func TestNIPostBuilder_BuildNIPost(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	nipost, err := nb.BuildNIPost(context.Background(), sig, &challenge)
+	nipost, err := nb.BuildNIPost(context.Background(), sig, challenge.PublishEpoch, challenge.Hash())
 	require.NoError(t, err)
 	require.NotNil(t, nipost)
 
@@ -542,7 +542,7 @@ func TestNIPostBuilder_BuildNIPost(t *testing.T) {
 	postClient.EXPECT().Proof(gomock.Any(), gomock.Any()).Return(nil, nil, errors.New("error"))
 
 	// check that proof ref is not called again
-	nipost, err = nb.BuildNIPost(context.Background(), sig, &challenge)
+	nipost, err = nb.BuildNIPost(context.Background(), sig, challenge.PublishEpoch, challenge.Hash())
 	require.Nil(t, nipost)
 	require.Error(t, err)
 
@@ -567,7 +567,7 @@ func TestNIPostBuilder_BuildNIPost(t *testing.T) {
 	)
 
 	// check that proof ref is not called again
-	nipost, err = nb.BuildNIPost(context.Background(), sig, &challenge)
+	nipost, err = nb.BuildNIPost(context.Background(), sig, challenge.PublishEpoch, challenge.Hash())
 	require.NoError(t, err)
 	require.NotNil(t, nipost)
 }
@@ -661,7 +661,7 @@ func TestNIPostBuilder_ManyPoETs_SubmittingChallenge_DeadlineReached(t *testing.
 	require.NoError(t, err)
 
 	// Act
-	nipost, err := nb.BuildNIPost(context.Background(), sig, &challenge)
+	nipost, err := nb.BuildNIPost(context.Background(), sig, challenge.PublishEpoch, challenge.Hash())
 	require.NoError(t, err)
 
 	// Verify
@@ -729,7 +729,7 @@ func TestNIPostBuilder_ManyPoETs_AllFinished(t *testing.T) {
 	require.NoError(t, err)
 
 	// Act
-	nipost, err := nb.BuildNIPost(context.Background(), sig, &challenge)
+	nipost, err := nb.BuildNIPost(context.Background(), sig, challenge.PublishEpoch, challenge.Hash())
 	require.NoError(t, err)
 
 	// Verify
@@ -774,7 +774,7 @@ func TestNIPSTBuilder_PoetUnstable(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		nipst, err := nb.BuildNIPost(context.Background(), sig, &challenge)
+		nipst, err := nb.BuildNIPost(context.Background(), sig, challenge.PublishEpoch, challenge.Hash())
 		require.ErrorIs(t, err, ErrPoetServiceUnstable)
 		require.Nil(t, nipst)
 	})
@@ -812,7 +812,7 @@ func TestNIPSTBuilder_PoetUnstable(t *testing.T) {
 			withPoetClients([]poetClient{poetProver}),
 		)
 		require.NoError(t, err)
-		nipst, err := nb.BuildNIPost(context.Background(), sig, &challenge)
+		nipst, err := nb.BuildNIPost(context.Background(), sig, challenge.PublishEpoch, challenge.Hash())
 		require.ErrorIs(t, err, ErrPoetServiceUnstable)
 		require.Nil(t, nipst)
 	})
@@ -836,7 +836,7 @@ func TestNIPSTBuilder_PoetUnstable(t *testing.T) {
 			withPoetClients([]poetClient{poetProver}),
 		)
 		require.NoError(t, err)
-		nipst, err := nb.BuildNIPost(context.Background(), sig, &challenge)
+		nipst, err := nb.BuildNIPost(context.Background(), sig, challenge.PublishEpoch, challenge.Hash())
 		require.ErrorIs(t, err, ErrPoetProofNotReceived)
 		require.Nil(t, nipst)
 	})
@@ -863,7 +863,7 @@ func TestNIPSTBuilder_PoetUnstable(t *testing.T) {
 			withPoetClients([]poetClient{poetProver}),
 		)
 		require.NoError(t, err)
-		nipst, err := nb.BuildNIPost(context.Background(), sig, &challenge)
+		nipst, err := nb.BuildNIPost(context.Background(), sig, challenge.PublishEpoch, challenge.Hash())
 		require.ErrorIs(t, err, ErrPoetProofNotReceived)
 		require.Nil(t, nipst)
 	})
@@ -907,7 +907,7 @@ func TestNIPoSTBuilder_StaleChallenge(t *testing.T) {
 		require.NoError(t, err)
 
 		challenge := types.NIPostChallenge{PublishEpoch: currLayer.GetEpoch()}
-		nipost, err := nb.BuildNIPost(context.Background(), sig, &challenge)
+		nipost, err := nb.BuildNIPost(context.Background(), sig, challenge.PublishEpoch, challenge.Hash())
 		require.ErrorIs(t, err, ErrATXChallengeExpired)
 		require.ErrorContains(t, err, "poet round has already started")
 		require.Nil(t, nipost)
@@ -950,7 +950,7 @@ func TestNIPoSTBuilder_StaleChallenge(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		nipost, err := nb.BuildNIPost(context.Background(), sig, challenge)
+		nipost, err := nb.BuildNIPost(context.Background(), sig, challenge.PublishEpoch, challenge.Hash())
 		require.ErrorIs(t, err, ErrATXChallengeExpired)
 		require.ErrorContains(t, err, "poet proof for pub epoch")
 		require.Nil(t, nipost)
@@ -997,7 +997,7 @@ func TestNIPoSTBuilder_StaleChallenge(t *testing.T) {
 		err = nipost.UpdatePoetProofRef(db, sig.NodeID(), [32]byte{1, 2, 3}, &types.MerkleProof{})
 		require.NoError(t, err)
 
-		nipost, err := nb.BuildNIPost(context.Background(), sig, challenge)
+		nipost, err := nb.BuildNIPost(context.Background(), sig, challenge.PublishEpoch, challenge.Hash())
 		require.ErrorIs(t, err, ErrATXChallengeExpired)
 		require.ErrorContains(t, err, "deadline to publish ATX for pub epoch")
 		require.Nil(t, nipost)
@@ -1073,7 +1073,7 @@ func TestNIPoSTBuilder_Continues_After_Interrupted(t *testing.T) {
 	require.NoError(t, err)
 
 	// Act
-	nipost, err := nb.BuildNIPost(buildCtx, sig, &challenge)
+	nipost, err := nb.BuildNIPost(buildCtx, sig, challenge.PublishEpoch, challenge.Hash())
 	require.ErrorIs(t, err, context.Canceled)
 	require.Nil(t, nipost)
 
@@ -1082,7 +1082,7 @@ func TestNIPoSTBuilder_Continues_After_Interrupted(t *testing.T) {
 		Submit(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(&types.PoetRound{}, nil)
 
-	nipost, err = nb.BuildNIPost(context.Background(), sig, &challenge)
+	nipost, err = nb.BuildNIPost(context.Background(), sig, challenge.PublishEpoch, challenge.Hash())
 	require.NoError(t, err)
 
 	// Verify
@@ -1221,7 +1221,7 @@ func TestNIPostBuilder_Mainnet_Poet_Workaround(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			nipost, err := nb.BuildNIPost(context.Background(), sig, &challenge)
+			nipost, err := nb.BuildNIPost(context.Background(), sig, challenge.PublishEpoch, challenge.Hash())
 			require.NoError(t, err)
 			require.NotNil(t, nipost)
 		})

--- a/activation/validation_test.go
+++ b/activation/validation_test.go
@@ -540,7 +540,8 @@ func Test_Validate_PostMetadata(t *testing.T) {
 func TestValidateMerkleProof(t *testing.T) {
 	challenge := types.CalcHash32([]byte("challenge"))
 
-	proof, root := newMerkleProof(t, challenge, []types.Hash32{
+	proof, root := newMerkleProof(t, []types.Hash32{
+		challenge,
 		types.BytesToHash([]byte("leaf2")),
 		types.BytesToHash([]byte("leaf3")),
 		types.BytesToHash([]byte("leaf4")),
@@ -584,7 +585,7 @@ func TestVerifyChainDeps(t *testing.T) {
 		PositioningATX: goldenATXID,
 		CommitmentATX:  &goldenATXID,
 	}
-	nipostData := newNIPostWithChallenge(t, types.HexToHash32(""), []byte("00"))
+	nipostData := newNIPostWithPoet(t, []byte("00"))
 	invalidAtx := newAtx(ch, nipostData.NIPost, 2, types.Address{})
 	require.NoError(t, SignAndFinalizeAtx(signer, invalidAtx))
 	vInvalidAtx, err := invalidAtx.Verify(0, 1)
@@ -600,7 +601,7 @@ func TestVerifyChainDeps(t *testing.T) {
 			PositioningATX: goldenATXID,
 			CommitmentATX:  nil,
 		}
-		nipostData = newNIPostWithChallenge(t, types.HexToHash32(""), []byte("01"))
+		nipostData = newNIPostWithPoet(t, []byte("01"))
 		atx := newAtx(ch, nipostData.NIPost, 2, types.Address{})
 		require.NoError(t, SignAndFinalizeAtx(signer, atx))
 		vAtx, err := atx.Verify(0, 1)
@@ -625,7 +626,7 @@ func TestVerifyChainDeps(t *testing.T) {
 			PositioningATX: vInvalidAtx.ID(),
 			CommitmentATX:  nil,
 		}
-		nipostData = newNIPostWithChallenge(t, types.HexToHash32(""), []byte("02"))
+		nipostData = newNIPostWithPoet(t, []byte("02"))
 		atx := newAtx(ch, nipostData.NIPost, 2, types.Address{})
 		require.NoError(t, SignAndFinalizeAtx(signer, atx))
 		vAtx, err := atx.Verify(0, 1)
@@ -651,7 +652,7 @@ func TestVerifyChainDeps(t *testing.T) {
 			PositioningATX: goldenATXID,
 			CommitmentATX:  &commitmentAtxID,
 		}
-		nipostData = newNIPostWithChallenge(t, types.HexToHash32(""), []byte("03"))
+		nipostData = newNIPostWithPoet(t, []byte("03"))
 		atx := newAtx(ch, nipostData.NIPost, 2, types.Address{})
 		require.NoError(t, SignAndFinalizeAtx(signer, atx))
 		vAtx, err := atx.Verify(0, 1)
@@ -675,7 +676,7 @@ func TestVerifyChainDeps(t *testing.T) {
 			PositioningATX: vInvalidAtx.ID(),
 			CommitmentATX:  nil,
 		}
-		nipostData = newNIPostWithChallenge(t, types.HexToHash32(""), []byte("04"))
+		nipostData = newNIPostWithPoet(t, []byte("04"))
 		atx := newAtx(ch, nipostData.NIPost, 2, types.Address{})
 		require.NoError(t, SignAndFinalizeAtx(signer, atx))
 		vAtx, err := atx.Verify(0, 1)
@@ -698,7 +699,7 @@ func TestVerifyChainDeps(t *testing.T) {
 			PositioningATX: vInvalidAtx.ID(),
 			CommitmentATX:  nil,
 		}
-		nipostData = newNIPostWithChallenge(t, types.HexToHash32(""), []byte("05"))
+		nipostData = newNIPostWithPoet(t, []byte("05"))
 		atx := newAtx(ch, nipostData.NIPost, 2, types.Address{})
 		require.NoError(t, SignAndFinalizeAtx(signer, atx))
 		vAtx, err := atx.Verify(0, 1)
@@ -722,7 +723,7 @@ func TestVerifyChainDeps(t *testing.T) {
 			PositioningATX: vInvalidAtx.ID(),
 			CommitmentATX:  nil,
 		}
-		nipostData = newNIPostWithChallenge(t, types.HexToHash32(""), []byte("06"))
+		nipostData = newNIPostWithPoet(t, []byte("06"))
 		atx := newAtx(ch, nipostData.NIPost, 2, types.Address{})
 		require.NoError(t, SignAndFinalizeAtx(signer, atx))
 		vAtx, err := atx.Verify(0, 1)

--- a/common/types/activation.go
+++ b/common/types/activation.go
@@ -148,12 +148,6 @@ func (challenge *NIPostChallenge) String() string {
 	)
 }
 
-// TargetEpoch returns the target epoch of the NIPostChallenge. This is the epoch in which the miner is eligible
-// to participate thanks to the ATX.
-func (challenge *NIPostChallenge) TargetEpoch() EpochID {
-	return challenge.PublishEpoch + 1
-}
-
 // InnerActivationTx is a set of all of an ATX's fields, except the signature. To generate the ATX signature, this
 // structure is serialized and signed. It includes the header fields, as well as the larger fields that are only used
 // for validation: the NIPost and the initial Post.
@@ -216,6 +210,12 @@ func NewActivationTx(
 		},
 	}
 	return atx
+}
+
+// TargetEpoch returns the target epoch of the ATX. This is the epoch in which the miner is eligible
+// to participate thanks to the ATX.
+func (atx *ActivationTx) TargetEpoch() EpochID {
+	return atx.PublishEpoch + 1
 }
 
 // Golden returns true if atx is from a checkpoint snapshot.

--- a/common/types/activation_tx_header.go
+++ b/common/types/activation_tx_header.go
@@ -46,6 +46,10 @@ func (atxh *ActivationTxHeader) GetWeight() uint64 {
 	return getWeight(uint64(atxh.EffectiveNumUnits), atxh.TickCount)
 }
 
+func (atxh *ActivationTxHeader) TargetEpoch() EpochID {
+	return atxh.PublishEpoch + 1
+}
+
 func getWeight(numUnits, tickCount uint64) uint64 {
 	return safeMul(numUnits, tickCount)
 }

--- a/events/events.go
+++ b/events/events.go
@@ -89,7 +89,7 @@ func EmitPoetWaitRound(nodeID types.NodeID, current, publish types.EpochID, wait
 	)
 }
 
-func EmitPoetWaitProof(nodeID types.NodeID, publish, target types.EpochID, wait time.Time) {
+func EmitPoetWaitProof(nodeID types.NodeID, publish types.EpochID, wait time.Time) {
 	const help = "Node is waiting for PoET to complete. " +
 		"After it's complete, the node will fetch the PoET proof, generate a PoST proof, " +
 		"and finally publish an ATX to establish eligibility for rewards in the target epoch."
@@ -99,7 +99,7 @@ func EmitPoetWaitProof(nodeID types.NodeID, publish, target types.EpochID, wait 
 		&pb.Event_PoetWaitProof{
 			PoetWaitProof: &pb.EventPoetWaitProof{
 				Publish: publish.Uint32(),
-				Target:  target.Uint32(),
+				Target:  publish.Add(1).Uint32(),
 				Wait:    durationpb.New(time.Until(wait)),
 				Until:   timestamppb.New(wait),
 				Smesher: nodeID.Bytes(),

--- a/systest/tests/distributed_post_verification_test.go
+++ b/systest/tests/distributed_post_verification_test.go
@@ -195,7 +195,7 @@ func TestPostMalfeasanceProof(t *testing.T) {
 		break
 	}
 
-	nipost, err := nipostBuilder.BuildNIPost(ctx, signer, challenge)
+	nipost, err := nipostBuilder.BuildNIPost(ctx, signer, challenge.PublishEpoch, challenge.Hash())
 	require.NoError(t, err)
 
 	// 2.2 Create ATX with invalid POST


### PR DESCRIPTION
## Motivation

Part of the effort of refactoring the activation path as preparation for ATX V2.

## Description

The nipost builder only cares about the hash of the challenge (to submit it to the poet) and the publish epoch (for scheduling). It does not need to know the contents of the challenge. As there will be a new version of the `NipostChallenge struct`, it makes sense to simplify and pass only the required data.

Also, I moved `TargetEpoch()` from `NipostChallenge struct` to `ActivationTx` as I want to remove every unnecessary method from the challenge type and in the code were are mostly interested in target epoch in the context of an ATX, not the challenge.

Additionally, simplified `newNIPostWithChallenge()`. It doesn't need to be passed the challenge. The MerkleProof, that is built for it (+ a few dummy leafs) does not contain it anyway.

## Test Plan

Existing tests pass

## TODO

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [ ] Update documentation as needed
- [ ] Update [changelog](../CHANGELOG.md) as needed
