### PR TITLE
p2p: fix connecting to bootnodes

### DIFF
--- a/p2p/dhtdiscovery/discovery.go
+++ b/p2p/dhtdiscovery/discovery.go
@@ -293,6 +293,7 @@ func (d *Discovery) connect(ctx context.Context, eg *errgroup.Group, nodes []pee
 	conCtx, cancel := context.WithTimeout(ctx, d.timeout)
 	defer cancel()
 	for _, boot := range nodes {
+		boot := boot
 		if boot.ID == d.h.ID() {
 			d.logger.Debug("not dialing self")
 			continue


### PR DESCRIPTION
## Motivation

There was loop variable capture that had some chance to make go-sm only try to connect to a subset of required bootnodes, and alo messed up logging

## Description

Fix loop variable capture
