### PR TITLE
[Merged by Bors] - fetch: use streaming mode by default

### DIFF
--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -180,6 +180,7 @@ func DefaultConfig() Config {
 			// 64 bytes
 			OpnProtocol: {Queue: 10000, Requests: 1000, Interval: time.Second},
 		},
+		Streaming:          true,
 		GetAtxsConcurrency: 100,
 		DecayingTag: server.DecayingTagSpec{
 			Interval: time.Minute,


### PR DESCRIPTION
## Motivation

Streaming mode of the fetcher is stable enough and can be used by default.

## Description

Use streaming mode by default in the fetcher