### PR TITLE
[Merged by Bors] - Fix the GH Action CI error. 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ jobs:
       nondocchanges: ${{ steps.filter.outputs.nondoc }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ssh-key: ${{ secrets.GH_ACTION_PRIVATE_KEY }}
       - uses: dorny/paths-filter@v3
         id: filter
         with:
@@ -62,6 +64,8 @@ jobs:
         run: sudo apt-get update -q && sudo apt-get install -qy ocl-icd-opencl-dev libpocl2
       - name: checkout
         uses: actions/checkout@v4
+        with:
+          ssh-key: ${{ secrets.GH_ACTION_PRIVATE_KEY }}
       - name: set up go
         uses: actions/setup-go@v5
         with:
@@ -85,6 +89,8 @@ jobs:
         run: sudo apt-get update -q && sudo apt-get install -qy ocl-icd-opencl-dev libpocl2
       - name: checkout
         uses: actions/checkout@v4
+        with:
+          ssh-key: ${{ secrets.GH_ACTION_PRIVATE_KEY }}
       - name: set up go
         uses: actions/setup-go@v5
         with:
@@ -120,6 +126,8 @@ jobs:
           Set-MpPreference -DisableRealtimeMonitoring $true
       - name: checkout
         uses: actions/checkout@v4
+        with:
+          ssh-key: ${{ secrets.GH_ACTION_PRIVATE_KEY }}
       - name: set up go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,8 @@ jobs:
           Set-MpPreference -DisableRealtimeMonitoring $true
       - name: checkout
         uses: actions/checkout@v4
+        with:
+          ssh-key: ${{ secrets.GH_ACTION_PRIVATE_KEY }}
       - name: set up go
         uses: actions/setup-go@v5
         with:
@@ -208,6 +210,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           lfs: true
+          ssh-key: ${{ secrets.GH_ACTION_PRIVATE_KEY }}
       - name: set up go
         uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
## Motivation

Fix the GH Action CI error. 

## Description

After been reported the CI issue, was noticed the checkout action is trying to use the ssh git without having any private key associated. To fix that issue, I created a read-only ssh key on the go-spacemesh repository and force the checkout action to use the that. 


Works proof: https://github.com/spacemeshos/go-spacemesh/actions/runs/8601697390