### PR TITLE
[Merged by Bors] - Don't allow post service connection if no coinbase is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ See [RELEASE](./RELEASE.md) for workflow instructions.
 
 * [#5803](https://github.com/spacemeshos/go-spacemesh/pull/5803) Fixed PoST verifiers autoscaling for 1:N setups.
 
-### Features
+* [#5819](https://github.com/spacemeshos/go-spacemesh/pull/5819) The node will now refuse connections from post services
+  if no coinbase account is set.
 
 ## Release v1.4.4
 

--- a/activation/e2e/activation_test.go
+++ b/activation/e2e/activation_test.go
@@ -53,6 +53,7 @@ func Test_BuilderWithMultipleClients(t *testing.T) {
 	}).AnyTimes()
 
 	svc := grpcserver.NewPostService(logger)
+	svc.AllowConnections(true)
 	grpcCfg, cleanup := launchServer(t, svc)
 	t.Cleanup(cleanup)
 

--- a/activation/e2e/nipost_test.go
+++ b/activation/e2e/nipost_test.go
@@ -171,6 +171,7 @@ func TestNIPostBuilderWithClients(t *testing.T) {
 	poetDb := activation.NewPoetDb(db, log.NewFromLog(logger).Named("poetDb"))
 
 	svc := grpcserver.NewPostService(logger)
+	svc.AllowConnections(true)
 	grpcCfg, cleanup := launchServer(t, svc)
 	t.Cleanup(cleanup)
 
@@ -232,6 +233,7 @@ func TestNIPostBuilder_Close(t *testing.T) {
 	)
 
 	svc := grpcserver.NewPostService(logger)
+	svc.AllowConnections(true)
 
 	db := localsql.InMemory()
 	nb, err := activation.NewNIPostBuilder(
@@ -307,6 +309,7 @@ func TestNewNIPostBuilderNotInitialized(t *testing.T) {
 	poetDb := activation.NewPoetDb(db, log.NewFromLog(logger).Named("poetDb"))
 
 	svc := grpcserver.NewPostService(logger)
+	svc.AllowConnections(true)
 	grpcCfg, cleanup := launchServer(t, svc)
 	t.Cleanup(cleanup)
 
@@ -381,6 +384,7 @@ func Test_NIPostBuilderWithMultipleClients(t *testing.T) {
 	})
 
 	svc := grpcserver.NewPostService(logger)
+	svc.AllowConnections(true)
 	grpcCfg, cleanup := launchServer(t, svc)
 	t.Cleanup(cleanup)
 

--- a/activation/e2e/validation_test.go
+++ b/activation/e2e/validation_test.go
@@ -84,6 +84,7 @@ func TestValidator_Validate(t *testing.T) {
 	poetDb := activation.NewPoetDb(sql.InMemory(), log.NewFromLog(logger).Named("poetDb"))
 
 	svc := grpcserver.NewPostService(logger)
+	svc.AllowConnections(true)
 	grpcCfg, cleanup := launchServer(t, svc)
 	t.Cleanup(cleanup)
 

--- a/api/grpcserver/grpcserver_test.go
+++ b/api/grpcserver/grpcserver_test.go
@@ -553,15 +553,18 @@ type smesherServiceConn struct {
 
 	smeshingProvider *activation.MockSmeshingProvider
 	postSupervisor   *MockpostSupervisor
+	grpcPostService  *MockgrpcPostService
 }
 
 func setupSmesherService(t *testing.T, sig *signing.EdSigner) (*smesherServiceConn, context.Context) {
 	ctrl, mockCtx := gomock.WithContext(context.Background(), t)
 	smeshingProvider := activation.NewMockSmeshingProvider(ctrl)
 	postSupervisor := NewMockpostSupervisor(ctrl)
+	grpcPostService := NewMockgrpcPostService(ctrl)
 	svc := NewSmesherService(
 		smeshingProvider,
 		postSupervisor,
+		grpcPostService,
 		10*time.Millisecond,
 		activation.DefaultPostSetupOpts(),
 		sig,
@@ -580,6 +583,7 @@ func setupSmesherService(t *testing.T, sig *signing.EdSigner) (*smesherServiceCo
 
 		smeshingProvider: smeshingProvider,
 		postSupervisor:   postSupervisor,
+		grpcPostService:  grpcPostService,
 	}, mockCtx
 }
 
@@ -633,6 +637,7 @@ func TestSmesherService(t *testing.T) {
 					return postOpts.(activation.PostSetupOpts).MaxFileSize == opts.MaxFileSize
 				}),
 			), sig).Return(nil)
+		c.grpcPostService.EXPECT().AllowConnections(true)
 		res, err := c.StartSmeshing(ctx, &pb.StartSmeshingRequest{
 			Opts:     opts,
 			Coinbase: coinbase,

--- a/api/grpcserver/interface.go
+++ b/api/grpcserver/interface.go
@@ -72,6 +72,10 @@ type postSupervisor interface {
 	Benchmark(p activation.PostSetupProvider) (int, error)
 }
 
+type grpcPostService interface {
+	AllowConnections(allow bool)
+}
+
 // peerCounter is an api to get amount of connected peers.
 type peerCounter interface {
 	PeerCount() uint64

--- a/api/grpcserver/mocks.go
+++ b/api/grpcserver/mocks.go
@@ -1264,6 +1264,65 @@ func (c *MockpostSupervisorStopCall) DoAndReturn(f func(bool) error) *MockpostSu
 	return c
 }
 
+// MockgrpcPostService is a mock of grpcPostService interface.
+type MockgrpcPostService struct {
+	ctrl     *gomock.Controller
+	recorder *MockgrpcPostServiceMockRecorder
+}
+
+// MockgrpcPostServiceMockRecorder is the mock recorder for MockgrpcPostService.
+type MockgrpcPostServiceMockRecorder struct {
+	mock *MockgrpcPostService
+}
+
+// NewMockgrpcPostService creates a new mock instance.
+func NewMockgrpcPostService(ctrl *gomock.Controller) *MockgrpcPostService {
+	mock := &MockgrpcPostService{ctrl: ctrl}
+	mock.recorder = &MockgrpcPostServiceMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockgrpcPostService) EXPECT() *MockgrpcPostServiceMockRecorder {
+	return m.recorder
+}
+
+// AllowConnections mocks base method.
+func (m *MockgrpcPostService) AllowConnections(allow bool) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "AllowConnections", allow)
+}
+
+// AllowConnections indicates an expected call of AllowConnections.
+func (mr *MockgrpcPostServiceMockRecorder) AllowConnections(allow any) *MockgrpcPostServiceAllowConnectionsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllowConnections", reflect.TypeOf((*MockgrpcPostService)(nil).AllowConnections), allow)
+	return &MockgrpcPostServiceAllowConnectionsCall{Call: call}
+}
+
+// MockgrpcPostServiceAllowConnectionsCall wrap *gomock.Call
+type MockgrpcPostServiceAllowConnectionsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockgrpcPostServiceAllowConnectionsCall) Return() *MockgrpcPostServiceAllowConnectionsCall {
+	c.Call = c.Call.Return()
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockgrpcPostServiceAllowConnectionsCall) Do(f func(bool)) *MockgrpcPostServiceAllowConnectionsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockgrpcPostServiceAllowConnectionsCall) DoAndReturn(f func(bool)) *MockgrpcPostServiceAllowConnectionsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // MockpeerCounter is a mock of peerCounter interface.
 type MockpeerCounter struct {
 	ctrl     *gomock.Controller

--- a/api/grpcserver/post_service.go
+++ b/api/grpcserver/post_service.go
@@ -75,7 +75,7 @@ func (s *PostService) connectionAllowed() bool {
 // requests to the PoST node and receive responses.
 func (s *PostService) Register(stream pb.PostService_RegisterServer) error {
 	if !s.connectionAllowed() {
-		return status.Error(codes.PermissionDenied, "connection not allowed: node has no coinbase set in config")
+		return status.Error(codes.FailedPrecondition, "connection not allowed: node has no coinbase set in config")
 	}
 
 	err := stream.SendMsg(&pb.NodeRequest{

--- a/api/grpcserver/post_service_test.go
+++ b/api/grpcserver/post_service_test.go
@@ -362,6 +362,6 @@ func Test_PostService_Connection_NotAllowed(t *testing.T) {
 
 	_, err = stream.Recv()
 	require.Error(t, err)
-	require.Equal(t, codes.PermissionDenied, status.Code(err))
+	require.Equal(t, codes.FailedPrecondition, status.Code(err))
 	require.ErrorContains(t, err, "connection not allowed")
 }

--- a/api/grpcserver/smesher_service.go
+++ b/api/grpcserver/smesher_service.go
@@ -27,6 +27,7 @@ import (
 type SmesherService struct {
 	smeshingProvider activation.SmeshingProvider
 	postSupervisor   postSupervisor
+	grpcPostService  grpcPostService
 
 	streamInterval time.Duration
 	cmdCfg         *activation.PostSupervisorConfig
@@ -52,6 +53,7 @@ func (s SmesherService) String() string {
 func NewSmesherService(
 	smeshing activation.SmeshingProvider,
 	postSupervisor postSupervisor,
+	grpcPostService grpcPostService,
 	streamInterval time.Duration,
 	postOpts activation.PostSetupOpts,
 	sig *signing.EdSigner,
@@ -59,6 +61,7 @@ func NewSmesherService(
 	return &SmesherService{
 		smeshingProvider: smeshing,
 		postSupervisor:   postSupervisor,
+		grpcPostService:  grpcPostService,
 		streamInterval:   streamInterval,
 		postOpts:         postOpts,
 		sig:              sig,
@@ -101,6 +104,7 @@ func (s SmesherService) StartSmeshing(
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse in.Coinbase.Address `%s`: %w", in.Coinbase.Address, err)
 	}
+	s.grpcPostService.AllowConnections(true)
 
 	if err := s.postSupervisor.Start(*s.cmdCfg, opts, s.sig); err != nil {
 		ctxzap.Error(ctx, "failed to start post supervisor", zap.Error(err))

--- a/api/grpcserver/smesher_service_test.go
+++ b/api/grpcserver/smesher_service_test.go
@@ -24,9 +24,11 @@ func TestPostConfig(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	smeshingProvider := activation.NewMockSmeshingProvider(ctrl)
 	postSupervisor := grpcserver.NewMockpostSupervisor(ctrl)
+	grpcPostService := grpcserver.NewMockgrpcPostService(ctrl)
 	svc := grpcserver.NewSmesherService(
 		smeshingProvider,
 		postSupervisor,
+		grpcPostService,
 		time.Second,
 		activation.DefaultPostSetupOpts(),
 		nil,
@@ -55,12 +57,14 @@ func TestStartSmeshingPassesCorrectSmeshingOpts(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	smeshingProvider := activation.NewMockSmeshingProvider(ctrl)
 	postSupervisor := grpcserver.NewMockpostSupervisor(ctrl)
+	grpcPostService := grpcserver.NewMockgrpcPostService(ctrl)
 	sig, err := signing.NewEdSigner()
 	require.NoError(t, err)
 	cmdCfg := activation.DefaultTestPostServiceConfig()
 	svc := grpcserver.NewSmesherService(
 		smeshingProvider,
 		postSupervisor,
+		grpcPostService,
 		time.Second,
 		activation.DefaultPostSetupOpts(),
 		sig,
@@ -82,6 +86,7 @@ func TestStartSmeshingPassesCorrectSmeshingOpts(t *testing.T) {
 	opts.ProviderID.SetUint32(providerID)
 	postSupervisor.EXPECT().Start(cmdCfg, opts, sig).Return(nil)
 	smeshingProvider.EXPECT().StartSmeshing(addr).Return(nil)
+	grpcPostService.EXPECT().AllowConnections(true)
 
 	_, err = svc.StartSmeshing(context.Background(), &pb.StartSmeshingRequest{
 		Coinbase: &pb.AccountId{Address: "stest1qqqqqqrs60l66w5uksxzmaznwq6xnhqfv56c28qlkm4a5"},
@@ -100,11 +105,13 @@ func TestStartSmeshing_ErrorOnMissingPostServiceConfig(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	smeshingProvider := activation.NewMockSmeshingProvider(ctrl)
 	postSupervisor := grpcserver.NewMockpostSupervisor(ctrl)
+	grpcPostService := grpcserver.NewMockgrpcPostService(ctrl)
 	sig, err := signing.NewEdSigner()
 	require.NoError(t, err)
 	svc := grpcserver.NewSmesherService(
 		smeshingProvider,
 		postSupervisor,
+		grpcPostService,
 		time.Second,
 		activation.DefaultPostSetupOpts(),
 		sig,
@@ -139,9 +146,11 @@ func TestStartSmeshing_ErrorOnMultiSmeshingSetup(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	smeshingProvider := activation.NewMockSmeshingProvider(ctrl)
 	postSupervisor := grpcserver.NewMockpostSupervisor(ctrl)
+	grpcPostService := grpcserver.NewMockgrpcPostService(ctrl)
 	svc := grpcserver.NewSmesherService(
 		smeshingProvider,
 		postSupervisor,
+		grpcPostService,
 		time.Second,
 		activation.DefaultPostSetupOpts(),
 		nil, // no nodeID in multi smesher setup
@@ -178,9 +187,11 @@ func TestSmesherService_PostSetupProviders(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	smeshingProvider := activation.NewMockSmeshingProvider(ctrl)
 	postSupervisor := grpcserver.NewMockpostSupervisor(ctrl)
+	grpcPostService := grpcserver.NewMockgrpcPostService(ctrl)
 	svc := grpcserver.NewSmesherService(
 		smeshingProvider,
 		postSupervisor,
+		grpcPostService,
 		time.Second,
 		activation.DefaultPostSetupOpts(),
 		nil, // no nodeID in multi smesher setup
@@ -225,9 +236,11 @@ func TestSmesherService_PostSetupStatus(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		smeshingProvider := activation.NewMockSmeshingProvider(ctrl)
 		postSupervisor := grpcserver.NewMockpostSupervisor(ctrl)
+		grpcPostService := grpcserver.NewMockgrpcPostService(ctrl)
 		svc := grpcserver.NewSmesherService(
 			smeshingProvider,
 			postSupervisor,
+			grpcPostService,
 			time.Second,
 			activation.DefaultPostSetupOpts(),
 			nil,
@@ -249,9 +262,11 @@ func TestSmesherService_PostSetupStatus(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		smeshingProvider := activation.NewMockSmeshingProvider(ctrl)
 		postSupervisor := grpcserver.NewMockpostSupervisor(ctrl)
+		grpcPostService := grpcserver.NewMockgrpcPostService(ctrl)
 		svc := grpcserver.NewSmesherService(
 			smeshingProvider,
 			postSupervisor,
+			grpcPostService,
 			time.Second,
 			activation.DefaultPostSetupOpts(),
 			nil,
@@ -286,9 +301,11 @@ func TestSmesherService_PostSetupStatus(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		smeshingProvider := activation.NewMockSmeshingProvider(ctrl)
 		postSupervisor := grpcserver.NewMockpostSupervisor(ctrl)
+		grpcPostService := grpcserver.NewMockgrpcPostService(ctrl)
 		svc := grpcserver.NewSmesherService(
 			smeshingProvider,
 			postSupervisor,
+			grpcPostService,
 			time.Second,
 			activation.DefaultPostSetupOpts(),
 			nil,
@@ -324,9 +341,11 @@ func TestSmesherService_SmesherID(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	smeshingProvider := activation.NewMockSmeshingProvider(ctrl)
 	postSupervisor := grpcserver.NewMockpostSupervisor(ctrl)
+	grpcPostService := grpcserver.NewMockgrpcPostService(ctrl)
 	svc := grpcserver.NewSmesherService(
 		smeshingProvider,
 		postSupervisor,
+		grpcPostService,
 		time.Second,
 		activation.DefaultPostSetupOpts(),
 		nil,

--- a/node/node.go
+++ b/node/node.go
@@ -1420,9 +1420,14 @@ func (app *App) grpcService(svc grpcserver.Service, lg log.Log) (grpcserver.Serv
 			// StartSmeshing is only supported in a supervised setup (single signer)
 			sig = app.signers[0]
 		}
+		postService, err := app.grpcService(grpcserver.Post, lg)
+		if err != nil {
+			return nil, err
+		}
 		service := grpcserver.NewSmesherService(
 			app.atxBuilder,
 			app.postSupervisor,
+			postService.(*grpcserver.PostService),
 			app.Config.API.SmesherStreamInterval,
 			app.Config.SMESHING.Opts,
 			sig,
@@ -1431,6 +1436,7 @@ func (app *App) grpcService(svc grpcserver.Service, lg log.Log) (grpcserver.Serv
 		return service, nil
 	case grpcserver.Post:
 		service := grpcserver.NewPostService(app.addLogger(PostServiceLogger, lg).Zap())
+		service.AllowConnections(app.Config.SMESHING.CoinbaseAccount != "")
 		app.grpcServices[svc] = service
 		return service, nil
 	case grpcserver.PostInfo:

--- a/node/node.go
+++ b/node/node.go
@@ -1436,7 +1436,11 @@ func (app *App) grpcService(svc grpcserver.Service, lg log.Log) (grpcserver.Serv
 		return service, nil
 	case grpcserver.Post:
 		service := grpcserver.NewPostService(app.addLogger(PostServiceLogger, lg).Zap())
-		service.AllowConnections(app.Config.SMESHING.CoinbaseAccount != "")
+		isCoinbaseSet := app.Config.SMESHING.CoinbaseAccount != ""
+		if !isCoinbaseSet {
+			lg.Warning("coinbase account is not set, connections from remote post services will be rejected")
+		}
+		service.AllowConnections(isCoinbaseSet)
 		app.grpcServices[svc] = service
 		return service, nil
 	case grpcserver.PostInfo:

--- a/systest/tests/distributed_post_verification_test.go
+++ b/systest/tests/distributed_post_verification_test.go
@@ -150,6 +150,7 @@ func TestPostMalfeasanceProof(t *testing.T) {
 	t.Cleanup(clock.Close)
 
 	grpcPostService := grpcserver.NewPostService(logger.Named("grpc-post-service"))
+	grpcPostService.AllowConnections(true)
 	grpczap.SetGrpcLoggerV2(grpclog, logger.Named("grpc"))
 	grpcPrivateServer, err := grpcserver.NewWithServices(
 		cfg.API.PostListener,


### PR DESCRIPTION
## Motivation

The node should refuse connections from Post services when no coinbase for smeshing is set, because the ATX Builder won't be able to build ATXs then.

## Description

- Added a new state to the GRPC PostService that can set if `Register` calls by clients are allowed or not
- The allow connection status is `false` if no coinbase is set in the nodes config and `true` if there is a coinbase set
- This status changes on the GRPC `StartSmeshing` call, because it sets a coinbase address with the request

## Test Plan

- existing tests pass
- new tests added that check if connections are refused if no coinbase is set

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
