### PR TITLE
[Merged by Bors] - Split two balance-related errors

### DIFF
--- a/genvm/core/context.go
+++ b/genvm/core/context.go
@@ -177,7 +177,7 @@ func (c *Context) Consume(gas uint64) (err error) {
 	amount := gas * c.Header.GasPrice
 	if amount > c.PrincipalAccount.Balance {
 		amount = c.PrincipalAccount.Balance
-		err = ErrNoBalance
+		err = ErrOutOfGas
 	} else if total := c.consumed + gas; total > c.Header.MaxGas {
 		gas = c.Header.MaxGas - c.consumed
 		amount = gas * c.Header.GasPrice

--- a/genvm/core/context_test.go
+++ b/genvm/core/context_test.go
@@ -39,10 +39,10 @@ func TestTransfer(t *testing.T) {
 }
 
 func TestConsume(t *testing.T) {
-	t.Run("NoBalance", func(t *testing.T) {
+	t.Run("OutOfGas", func(t *testing.T) {
 		ctx := core.Context{}
 		ctx.Header.GasPrice = 1
-		require.ErrorIs(t, ctx.Consume(100), core.ErrNoBalance)
+		require.ErrorIs(t, ctx.Consume(100), core.ErrOutOfGas)
 	})
 	t.Run("MaxGas", func(t *testing.T) {
 		ctx := core.Context{}

--- a/genvm/core/errors.go
+++ b/genvm/core/errors.go
@@ -12,6 +12,8 @@ var (
 	ErrInvalidNonce = errors.New("invalid nonce")
 	// ErrNoBalance raised if transaction run out of balance during execution.
 	ErrNoBalance = errors.New("no balance")
+	// ErrOutOfGas raised if account doesn't have enough funds to cover gas during execution.
+	ErrOutOfGas = errors.New("out of gas")
 	// ErrMaxGas raised if tx consumed over MaxGas value.
 	ErrMaxGas = errors.New("max gas")
 	// ErrMaxSpend raised if tx transferred over MaxSpend value.
@@ -20,7 +22,7 @@ var (
 	ErrSpawned = errors.New("account already spawned")
 	// ErrNotSpawned raised if account is not spawned.
 	ErrNotSpawned = errors.New("account is not spawned")
-	// ErrMismatchedTemplate raised if target account doesn't match template account.
+	// ErrTemplateMismatch raised if target account doesn't match template account.
 	ErrTemplateMismatch = errors.New("relay template mismatch")
 	// ErrTxLimit overflows max tx size.
 	ErrTxLimit = errors.New("overflows tx limit")

--- a/genvm/vm_test.go
+++ b/genvm/vm_test.go
@@ -941,7 +941,7 @@ func singleWalletTestCases(defaultGasPrice int, template core.Address, ref *test
 						&spendTx{0, 11, uint64(ref.estimateSpawnGas(11, 11)) - 1},
 						&selfSpawnTx{11},
 					},
-					failed: map[int]error{2: core.ErrNoBalance},
+					failed: map[int]error{2: core.ErrOutOfGas},
 					expected: map[int]change{
 						// incresed by two because previous was ineffective
 						// but internal nonce in tester was incremented
@@ -972,7 +972,7 @@ func singleWalletTestCases(defaultGasPrice int, template core.Address, ref *test
 						// send enough funds to cover spawn, but no spend
 						&spendTx{11, 12, 1},
 					},
-					failed: map[int]error{1: core.ErrNoBalance},
+					failed: map[int]error{1: core.ErrOutOfGas},
 					expected: map[int]change{
 						12: same{},
 					},
@@ -1014,7 +1014,7 @@ func singleWalletTestCases(defaultGasPrice int, template core.Address, ref *test
 					gasLimit: uint64(ref.estimateSpawnGas(0, 0) +
 						ref.estimateSpendGas(0, 10, 80_000, 1) +
 						ref.estimateSpawnGas(10, 10)),
-					failed:      map[int]error{2: core.ErrNoBalance},
+					failed:      map[int]error{2: core.ErrOutOfGas},
 					ineffective: []int{3},
 					expected: map[int]change{
 						0: spent{amount: 80_000 +
@@ -1190,7 +1190,7 @@ func singleWalletTestCases(defaultGasPrice int, template core.Address, ref *test
 						&spendTx{0, 11, uint64(ref.estimateSpawnGas(11, 11)) - 1},
 						&selfSpawnTx{11},
 					},
-					failed: map[int]error{2: core.ErrNoBalance},
+					failed: map[int]error{2: core.ErrOutOfGas},
 					expected: map[int]change{
 						0: spent{amount: ref.estimateSpawnGas(11, 11) - 1 +
 							ref.estimateSpawnGas(0, 0) +
@@ -1246,7 +1246,7 @@ func singleWalletTestCases(defaultGasPrice int, template core.Address, ref *test
 					gasLimit: uint64(ref.estimateSpawnGas(0, 0) +
 						ref.estimateSpendGas(0, 11, ref.estimateSpawnGas(11, 11)-1, 1) +
 						ref.estimateSpawnGas(11, 11)),
-					failed:  map[int]error{2: core.ErrNoBalance},
+					failed:  map[int]error{2: core.ErrOutOfGas},
 					rewards: []reward{{address: 20, share: 1}},
 					expected: map[int]change{
 						0: spent{amount: ref.estimateSpawnGas(0, 0) +
@@ -1346,7 +1346,7 @@ func singleWalletTestCases(defaultGasPrice int, template core.Address, ref *test
 						12: same{},
 					},
 					failed: map[int]error{
-						3: core.ErrNoBalance,
+						3: core.ErrOutOfGas,
 					},
 				},
 				{


### PR DESCRIPTION
Make the distinction a bit clearer between cases where there's not enough funds to send vs. not enough to cover gas metering.

## Motivation

Just makes errors clearer

## Description

Self-explanatory

## Test Plan

Existing tests updated, no need for new tests

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
