### PR TITLE
[Merged by Bors] - Avoid using types.NipostChallenge when not needed in nipost UTs

### DIFF
--- a/activation/e2e/validation_test.go
+++ b/activation/e2e/validation_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/spacemeshos/go-spacemesh/signing"
 	"github.com/spacemeshos/go-spacemesh/sql"
 	"github.com/spacemeshos/go-spacemesh/sql/localsql"
-	"github.com/spacemeshos/go-spacemesh/sql/localsql/nipost"
 )
 
 func TestValidator_Validate(t *testing.T) {
@@ -95,12 +94,7 @@ func TestValidator_Validate(t *testing.T) {
 		return err == nil
 	}, 10*time.Second, 100*time.Millisecond, "timed out waiting for connection")
 
-	db := localsql.InMemory()
-	challenge := types.NIPostChallenge{
-		PublishEpoch: postGenesisEpoch + 2,
-	}
-	require.NoError(t, nipost.AddChallenge(db, sig.NodeID(), &challenge))
-
+	challenge := types.RandomHash()
 	nb, err := activation.NewNIPostBuilder(
 		localsql.InMemory(),
 		poetDb,
@@ -112,11 +106,11 @@ func TestValidator_Validate(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	nipost, err := nb.BuildNIPost(context.Background(), sig, challenge.PublishEpoch, challenge.Hash())
+	nipost, err := nb.BuildNIPost(context.Background(), sig, postGenesisEpoch+2, challenge)
 	require.NoError(t, err)
 
 	v := activation.NewValidator(cdb, poetDb, cfg, opts.Scrypt, verifier)
-	_, err = v.NIPost(context.Background(), sig.NodeID(), goldenATX, nipost.NIPost, challenge.Hash(), nipost.NumUnits)
+	_, err = v.NIPost(context.Background(), sig.NodeID(), goldenATX, nipost.NIPost, challenge, nipost.NumUnits)
 	require.NoError(t, err)
 
 	_, err = v.NIPost(
@@ -131,13 +125,13 @@ func TestValidator_Validate(t *testing.T) {
 
 	newNIPost := *nipost.NIPost
 	newNIPost.Post = &types.Post{}
-	_, err = v.NIPost(context.Background(), sig.NodeID(), goldenATX, &newNIPost, challenge.Hash(), nipost.NumUnits)
+	_, err = v.NIPost(context.Background(), sig.NodeID(), goldenATX, &newNIPost, challenge, nipost.NumUnits)
 	require.ErrorContains(t, err, "invalid Post")
 
 	newPostCfg := cfg
 	newPostCfg.MinNumUnits = nipost.NumUnits + 1
 	v = activation.NewValidator(cdb, poetDb, newPostCfg, opts.Scrypt, nil)
-	_, err = v.NIPost(context.Background(), sig.NodeID(), goldenATX, nipost.NIPost, challenge.Hash(), nipost.NumUnits)
+	_, err = v.NIPost(context.Background(), sig.NodeID(), goldenATX, nipost.NIPost, challenge, nipost.NumUnits)
 	require.EqualError(
 		t,
 		err,
@@ -147,7 +141,7 @@ func TestValidator_Validate(t *testing.T) {
 	newPostCfg = cfg
 	newPostCfg.MaxNumUnits = nipost.NumUnits - 1
 	v = activation.NewValidator(cdb, poetDb, newPostCfg, opts.Scrypt, nil)
-	_, err = v.NIPost(context.Background(), sig.NodeID(), goldenATX, nipost.NIPost, challenge.Hash(), nipost.NumUnits)
+	_, err = v.NIPost(context.Background(), sig.NodeID(), goldenATX, nipost.NIPost, challenge, nipost.NumUnits)
 	require.EqualError(
 		t,
 		err,
@@ -157,7 +151,7 @@ func TestValidator_Validate(t *testing.T) {
 	newPostCfg = cfg
 	newPostCfg.LabelsPerUnit = nipost.PostMetadata.LabelsPerUnit + 1
 	v = activation.NewValidator(cdb, poetDb, newPostCfg, opts.Scrypt, nil)
-	_, err = v.NIPost(context.Background(), sig.NodeID(), goldenATX, nipost.NIPost, challenge.Hash(), nipost.NumUnits)
+	_, err = v.NIPost(context.Background(), sig.NodeID(), goldenATX, nipost.NIPost, challenge, nipost.NumUnits)
 	require.EqualError(
 		t,
 		err,

--- a/activation/nipost_test.go
+++ b/activation/nipost_test.go
@@ -375,16 +375,13 @@ func Test_NIPostBuilder_ResetState(t *testing.T) {
 func Test_NIPostBuilder_WithMocks(t *testing.T) {
 	t.Parallel()
 
-	challenge := types.NIPostChallenge{
-		PublishEpoch: postGenesisEpoch + 2,
-	}
-
+	challenge := types.RandomHash()
 	ctrl := gomock.NewController(t)
 
 	poetProvider := defaultPoetServiceMock(ctrl, []byte("poet"), "http://localhost:9999")
 	poetProvider.EXPECT().Proof(gomock.Any(), "").Return(&types.PoetProofMessage{
 		PoetProof: types.PoetProof{},
-	}, []types.Member{types.Member(challenge.Hash())}, nil)
+	}, []types.Member{types.Member(challenge)}, nil)
 
 	poetDb := NewMockpoetDbAPI(ctrl)
 	poetDb.EXPECT().ValidateAndStore(gomock.Any(), gomock.Any()).Return(nil)
@@ -413,15 +410,13 @@ func Test_NIPostBuilder_WithMocks(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	nipost, err := nb.BuildNIPost(context.Background(), sig, challenge.PublishEpoch, challenge.Hash())
+	nipost, err := nb.BuildNIPost(context.Background(), sig, postGenesisEpoch+2, challenge)
 	require.NoError(t, err)
 	require.NotNil(t, nipost)
 }
 
 func TestPostSetup(t *testing.T) {
-	challenge := types.NIPostChallenge{
-		PublishEpoch: postGenesisEpoch + 2,
-	}
+	challenge := types.RandomHash()
 	sig, err := signing.NewEdSigner()
 	require.NoError(t, err)
 
@@ -429,7 +424,7 @@ func TestPostSetup(t *testing.T) {
 	poetProvider := defaultPoetServiceMock(ctrl, []byte("poet"), "http://localhost:9999")
 	poetProvider.EXPECT().Proof(gomock.Any(), "").Return(&types.PoetProofMessage{
 		PoetProof: types.PoetProof{},
-	}, []types.Member{types.Member(challenge.Hash())}, nil)
+	}, []types.Member{types.Member(challenge)}, nil)
 
 	poetDb := NewMockpoetDbAPI(ctrl)
 	poetDb.EXPECT().ValidateAndStore(gomock.Any(), gomock.Any()).Return(nil)
@@ -455,7 +450,7 @@ func TestPostSetup(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	nipost, err := nb.BuildNIPost(context.Background(), sig, challenge.PublishEpoch, challenge.Hash())
+	nipost, err := nb.BuildNIPost(context.Background(), sig, postGenesisEpoch+2, challenge)
 	require.NoError(t, err)
 	require.NotNil(t, nipost)
 }
@@ -471,14 +466,6 @@ func TestNIPostBuilder_BuildNIPost(t *testing.T) {
 		PublishEpoch: postGenesisEpoch + 2,
 	}
 	require.NoError(t, nipost.AddChallenge(db, sig.NodeID(), &challenge))
-	challenge2 := types.NIPostChallenge{
-		PublishEpoch: postGenesisEpoch + 2,
-		Sequence:     1,
-	}
-	challenge3 := types.NIPostChallenge{
-		PublishEpoch: postGenesisEpoch + 2,
-		Sequence:     2,
-	}
 
 	ctrl := gomock.NewController(t)
 	poetProver := defaultPoetServiceMock(ctrl, []byte("poet"), "http://localhost:9999")
@@ -487,8 +474,8 @@ func TestNIPostBuilder_BuildNIPost(t *testing.T) {
 			PoetProof: types.PoetProof{},
 		}, []types.Member{
 			types.Member(challenge.Hash()),
-			types.Member(challenge2.Hash()),
-			types.Member(challenge3.Hash()),
+			types.Member(types.RandomHash()),
+			types.Member(types.RandomHash()),
 		}, nil,
 	)
 
@@ -589,10 +576,7 @@ func Test_NIPostBuilder_InvalidPoetAddresses(t *testing.T) {
 func TestNIPostBuilder_ManyPoETs_SubmittingChallenge_DeadlineReached(t *testing.T) {
 	t.Parallel()
 	// Arrange
-	challenge := types.NIPostChallenge{
-		PublishEpoch: postGenesisEpoch + 1,
-	}
-
+	challenge := types.RandomHash()
 	proof := &types.PoetProofMessage{PoetProof: types.PoetProof{}}
 
 	ctrl := gomock.NewController(t)
@@ -627,7 +611,7 @@ func TestNIPostBuilder_ManyPoETs_SubmittingChallenge_DeadlineReached(t *testing.
 			Return(&types.PoetRound{}, nil)
 		poet.EXPECT().
 			Proof(gomock.Any(), gomock.Any()).
-			Return(proof, []types.Member{types.Member(challenge.Hash())}, nil)
+			Return(proof, []types.Member{types.Member(challenge)}, nil)
 		poet.EXPECT().PowParams(gomock.Any()).Return(&PoetPowParams{}, nil)
 		poet.EXPECT().Address().AnyTimes().Return("http://localhost:9998")
 		poets = append(poets, poet)
@@ -661,7 +645,7 @@ func TestNIPostBuilder_ManyPoETs_SubmittingChallenge_DeadlineReached(t *testing.
 	require.NoError(t, err)
 
 	// Act
-	nipost, err := nb.BuildNIPost(context.Background(), sig, challenge.PublishEpoch, challenge.Hash())
+	nipost, err := nb.BuildNIPost(context.Background(), sig, postGenesisEpoch+2, challenge)
 	require.NoError(t, err)
 
 	// Verify
@@ -673,10 +657,7 @@ func TestNIPostBuilder_ManyPoETs_AllFinished(t *testing.T) {
 	t.Parallel()
 
 	// Arrange
-	challenge := types.NIPostChallenge{
-		PublishEpoch: postGenesisEpoch + 2,
-	}
-
+	challenge := types.RandomHash()
 	proofWorse := &types.PoetProofMessage{
 		PoetProof: types.PoetProof{
 			LeafCount: 111,
@@ -696,12 +677,12 @@ func TestNIPostBuilder_ManyPoETs_AllFinished(t *testing.T) {
 	poets := make([]poetClient, 0, 2)
 	{
 		poet := defaultPoetServiceMock(ctrl, []byte("poet0"), "http://localhost:9999")
-		poet.EXPECT().Proof(gomock.Any(), "").Return(proofWorse, []types.Member{types.Member(challenge.Hash())}, nil)
+		poet.EXPECT().Proof(gomock.Any(), "").Return(proofWorse, []types.Member{types.Member(challenge)}, nil)
 		poets = append(poets, poet)
 	}
 	{
 		poet := defaultPoetServiceMock(ctrl, []byte("poet1"), "http://localhost:9998")
-		poet.EXPECT().Proof(gomock.Any(), "").Return(proofBetter, []types.Member{types.Member(challenge.Hash())}, nil)
+		poet.EXPECT().Proof(gomock.Any(), "").Return(proofBetter, []types.Member{types.Member(challenge)}, nil)
 		poets = append(poets, poet)
 	}
 
@@ -729,7 +710,7 @@ func TestNIPostBuilder_ManyPoETs_AllFinished(t *testing.T) {
 	require.NoError(t, err)
 
 	// Act
-	nipost, err := nb.BuildNIPost(context.Background(), sig, challenge.PublishEpoch, challenge.Hash())
+	nipost, err := nb.BuildNIPost(context.Background(), sig, postGenesisEpoch+2, challenge)
 	require.NoError(t, err)
 
 	// Verify
@@ -739,9 +720,7 @@ func TestNIPostBuilder_ManyPoETs_AllFinished(t *testing.T) {
 
 func TestNIPSTBuilder_PoetUnstable(t *testing.T) {
 	t.Parallel()
-	challenge := types.NIPostChallenge{
-		PublishEpoch: postGenesisEpoch + 1,
-	}
+	challenge := types.RandomHash()
 	poetCfg := PoetConfig{
 		PhaseShift: layerDuration,
 	}
@@ -774,7 +753,7 @@ func TestNIPSTBuilder_PoetUnstable(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		nipst, err := nb.BuildNIPost(context.Background(), sig, challenge.PublishEpoch, challenge.Hash())
+		nipst, err := nb.BuildNIPost(context.Background(), sig, postGenesisEpoch+2, challenge)
 		require.ErrorIs(t, err, ErrPoetServiceUnstable)
 		require.Nil(t, nipst)
 	})
@@ -812,7 +791,7 @@ func TestNIPSTBuilder_PoetUnstable(t *testing.T) {
 			withPoetClients([]poetClient{poetProver}),
 		)
 		require.NoError(t, err)
-		nipst, err := nb.BuildNIPost(context.Background(), sig, challenge.PublishEpoch, challenge.Hash())
+		nipst, err := nb.BuildNIPost(context.Background(), sig, postGenesisEpoch+2, challenge)
 		require.ErrorIs(t, err, ErrPoetServiceUnstable)
 		require.Nil(t, nipst)
 	})
@@ -836,7 +815,7 @@ func TestNIPSTBuilder_PoetUnstable(t *testing.T) {
 			withPoetClients([]poetClient{poetProver}),
 		)
 		require.NoError(t, err)
-		nipst, err := nb.BuildNIPost(context.Background(), sig, challenge.PublishEpoch, challenge.Hash())
+		nipst, err := nb.BuildNIPost(context.Background(), sig, postGenesisEpoch+2, challenge)
 		require.ErrorIs(t, err, ErrPoetProofNotReceived)
 		require.Nil(t, nipst)
 	})
@@ -863,7 +842,7 @@ func TestNIPSTBuilder_PoetUnstable(t *testing.T) {
 			withPoetClients([]poetClient{poetProver}),
 		)
 		require.NoError(t, err)
-		nipst, err := nb.BuildNIPost(context.Background(), sig, challenge.PublishEpoch, challenge.Hash())
+		nipst, err := nb.BuildNIPost(context.Background(), sig, postGenesisEpoch+2, challenge)
 		require.ErrorIs(t, err, ErrPoetProofNotReceived)
 		require.Nil(t, nipst)
 	})
@@ -906,8 +885,7 @@ func TestNIPoSTBuilder_StaleChallenge(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		challenge := types.NIPostChallenge{PublishEpoch: currLayer.GetEpoch()}
-		nipost, err := nb.BuildNIPost(context.Background(), sig, challenge.PublishEpoch, challenge.Hash())
+		nipost, err := nb.BuildNIPost(context.Background(), sig, currLayer.GetEpoch(), types.RandomHash())
 		require.ErrorIs(t, err, ErrATXChallengeExpired)
 		require.ErrorContains(t, err, "poet round has already started")
 		require.Nil(t, nipost)
@@ -938,19 +916,20 @@ func TestNIPoSTBuilder_StaleChallenge(t *testing.T) {
 		require.NoError(t, err)
 
 		challenge := &types.NIPostChallenge{PublishEpoch: currLayer.GetEpoch() - 1}
+		challengeHash := challenge.Hash()
 		err = nipost.AddChallenge(db, sig.NodeID(), challenge)
 		require.NoError(t, err)
 
 		// successfully registered to at least one poet
 		err = nipost.AddPoetRegistration(db, sig.NodeID(), nipost.PoETRegistration{
-			ChallengeHash: challenge.Hash(),
+			ChallengeHash: challengeHash,
 			Address:       "http://poet1.com",
 			RoundID:       "1",
 			RoundEnd:      time.Now().Add(10 * time.Second),
 		})
 		require.NoError(t, err)
 
-		nipost, err := nb.BuildNIPost(context.Background(), sig, challenge.PublishEpoch, challenge.Hash())
+		nipost, err := nb.BuildNIPost(context.Background(), sig, challenge.PublishEpoch, challengeHash)
 		require.ErrorIs(t, err, ErrATXChallengeExpired)
 		require.ErrorContains(t, err, "poet proof for pub epoch")
 		require.Nil(t, nipost)
@@ -981,12 +960,13 @@ func TestNIPoSTBuilder_StaleChallenge(t *testing.T) {
 		require.NoError(t, err)
 
 		challenge := &types.NIPostChallenge{PublishEpoch: currLayer.GetEpoch() - 1}
+		challengeHash := challenge.Hash()
 		err = nipost.AddChallenge(db, sig.NodeID(), challenge)
 		require.NoError(t, err)
 
 		// successfully registered to at least one poet
 		err = nipost.AddPoetRegistration(db, sig.NodeID(), nipost.PoETRegistration{
-			ChallengeHash: challenge.Hash(),
+			ChallengeHash: challengeHash,
 			Address:       "http://poet1.com",
 			RoundID:       "1",
 			RoundEnd:      time.Now().Add(10 * time.Second),
@@ -997,7 +977,7 @@ func TestNIPoSTBuilder_StaleChallenge(t *testing.T) {
 		err = nipost.UpdatePoetProofRef(db, sig.NodeID(), [32]byte{1, 2, 3}, &types.MerkleProof{})
 		require.NoError(t, err)
 
-		nipost, err := nb.BuildNIPost(context.Background(), sig, challenge.PublishEpoch, challenge.Hash())
+		nipost, err := nb.BuildNIPost(context.Background(), sig, challenge.PublishEpoch, challengeHash)
 		require.ErrorIs(t, err, ErrATXChallengeExpired)
 		require.ErrorContains(t, err, "deadline to publish ATX for pub epoch")
 		require.Nil(t, nipost)
@@ -1010,10 +990,7 @@ func TestNIPoSTBuilder_Continues_After_Interrupted(t *testing.T) {
 	t.Parallel()
 
 	// Arrange
-	challenge := types.NIPostChallenge{
-		PublishEpoch: postGenesisEpoch + 1,
-	}
-
+	challenge := types.RandomHash()
 	proof := &types.PoetProofMessage{
 		PoetProof: types.PoetProof{
 			LeafCount: 777,
@@ -1042,7 +1019,7 @@ func TestNIPoSTBuilder_Continues_After_Interrupted(t *testing.T) {
 			return &types.PoetRound{}, context.Canceled
 		})
 	poet.EXPECT().PowParams(gomock.Any()).Times(2).Return(&PoetPowParams{}, nil)
-	poet.EXPECT().Proof(gomock.Any(), "").Return(proof, []types.Member{types.Member(challenge.Hash())}, nil)
+	poet.EXPECT().Proof(gomock.Any(), "").Return(proof, []types.Member{types.Member(challenge)}, nil)
 	poet.EXPECT().Address().AnyTimes().Return("http://localhost:9999")
 
 	poetCfg := PoetConfig{
@@ -1073,7 +1050,7 @@ func TestNIPoSTBuilder_Continues_After_Interrupted(t *testing.T) {
 	require.NoError(t, err)
 
 	// Act
-	nipost, err := nb.BuildNIPost(buildCtx, sig, challenge.PublishEpoch, challenge.Hash())
+	nipost, err := nb.BuildNIPost(buildCtx, sig, postGenesisEpoch+2, challenge)
 	require.ErrorIs(t, err, context.Canceled)
 	require.Nil(t, nipost)
 
@@ -1082,7 +1059,7 @@ func TestNIPoSTBuilder_Continues_After_Interrupted(t *testing.T) {
 		Submit(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(&types.PoetRound{}, nil)
 
-	nipost, err = nb.BuildNIPost(context.Background(), sig, challenge.PublishEpoch, challenge.Hash())
+	nipost, err = nb.BuildNIPost(context.Background(), sig, postGenesisEpoch+2, challenge)
 	require.NoError(t, err)
 
 	// Verify
@@ -1091,46 +1068,43 @@ func TestNIPoSTBuilder_Continues_After_Interrupted(t *testing.T) {
 }
 
 func TestConstructingMerkleProof(t *testing.T) {
-	challenge := types.NIPostChallenge{}
-	challengeHash := challenge.Hash()
+	challenge := types.RandomHash()
 
 	t.Run("members empty", func(t *testing.T) {
-		_, err := constructMerkleProof(challengeHash, []types.Member{})
+		_, err := constructMerkleProof(challenge, []types.Member{})
 		require.Error(t, err)
 	})
 	t.Run("not a member", func(t *testing.T) {
-		_, err := constructMerkleProof(challengeHash, []types.Member{{}, {}})
+		_, err := constructMerkleProof(challenge, []types.Member{{}, {}})
 		require.Error(t, err)
 	})
 
 	t.Run("is odd member", func(t *testing.T) {
-		otherChallenge := types.NIPostChallenge{Sequence: 1}
 		members := []types.Member{
-			types.Member(challengeHash),
-			types.Member(otherChallenge.Hash()),
+			types.Member(challenge),
+			types.Member(types.RandomHash()),
 		}
-		proof, err := constructMerkleProof(challengeHash, members)
+		proof, err := constructMerkleProof(challenge, members)
 		require.NoError(t, err)
 
 		root, err := calcRoot(members)
 		require.NoError(t, err)
 
-		err = validateMerkleProof(challengeHash[:], proof, root)
+		err = validateMerkleProof(challenge[:], proof, root)
 		require.NoError(t, err)
 	})
 	t.Run("is even member", func(t *testing.T) {
-		otherChallenge := types.NIPostChallenge{Sequence: 1}
 		members := []types.Member{
-			types.Member(otherChallenge.Hash()),
-			types.Member(challengeHash),
+			types.Member(types.RandomHash()),
+			types.Member(challenge),
 		}
-		proof, err := constructMerkleProof(challengeHash, members)
+		proof, err := constructMerkleProof(challenge, members)
 		require.NoError(t, err)
 
 		root, err := calcRoot(members)
 		require.NoError(t, err)
 
-		err = validateMerkleProof(challengeHash[:], proof, root)
+		err = validateMerkleProof(challenge[:], proof, root)
 		require.NoError(t, err)
 	})
 }
@@ -1151,10 +1125,7 @@ func TestNIPostBuilder_Mainnet_Poet_Workaround(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			challenge := types.NIPostChallenge{
-				PublishEpoch: tc.epoch,
-			}
-
+			challenge := types.RandomHash()
 			ctrl := gomock.NewController(t)
 			poets := make([]poetClient, 0, 2)
 			{
@@ -1170,7 +1141,7 @@ func TestNIPostBuilder_Mainnet_Poet_Workaround(t *testing.T) {
 				// proof is fetched from PoET
 				poetProvider.EXPECT().Proof(gomock.Any(), "").Return(&types.PoetProofMessage{
 					PoetProof: types.PoetProof{},
-				}, []types.Member{types.Member(challenge.Hash())}, nil)
+				}, []types.Member{types.Member(challenge)}, nil)
 				poets = append(poets, poetProvider)
 			}
 
@@ -1182,7 +1153,7 @@ func TestNIPostBuilder_Mainnet_Poet_Workaround(t *testing.T) {
 				// proof is still fetched from PoET
 				poetProvider.EXPECT().Proof(gomock.Any(), "").Return(&types.PoetProofMessage{
 					PoetProof: types.PoetProof{},
-				}, []types.Member{types.Member(challenge.Hash())}, nil)
+				}, []types.Member{types.Member(challenge)}, nil)
 
 				poets = append(poets, poetProvider)
 			}
@@ -1221,7 +1192,7 @@ func TestNIPostBuilder_Mainnet_Poet_Workaround(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			nipost, err := nb.BuildNIPost(context.Background(), sig, challenge.PublishEpoch, challenge.Hash())
+			nipost, err := nb.BuildNIPost(context.Background(), sig, postGenesisEpoch+2, challenge)
 			require.NoError(t, err)
 			require.NotNil(t, nipost)
 		})


### PR DESCRIPTION
## Motivation

The Nipost builder no longer takes a `types.NipostChallenge` but a `types.Hash32` hashed form.

## Description

The nipost builder tests could be simplified, which will come in handy for introducing a wire type for the nipost challenge.

## Test Plan

n/a

## TODO

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [ ] Update documentation as needed
- [ ] Update [changelog](../CHANGELOG.md) as needed
