### PR TITLE
[Merged by Bors] - Remove `Hash12` and fixes for `Hash20`

### DIFF
--- a/common/types/block.go
+++ b/common/types/block.go
@@ -128,7 +128,7 @@ type CoinbaseReward struct {
 
 // Initialize calculates and sets the Block's cached blockID.
 func (b *Block) Initialize() {
-	b.blockID = BlockID(CalcHash32(b.Bytes()).ToHash20())
+	b.blockID = BlockID(CalcHash20(b.Bytes()))
 }
 
 // Bytes returns the serialization of the InnerBlock.

--- a/common/types/block_test.go
+++ b/common/types/block_test.go
@@ -74,7 +74,7 @@ func Test_NewExistingBlock(t *testing.T) {
 func Test_BlockInitialize(t *testing.T) {
 	testBlock := types.NewExistingBlock(types.BlockID{1, 1}, types.InnerBlock{LayerIndex: types.LayerID(1)})
 
-	expectedBlockID := types.BlockID(types.CalcHash32(testBlock.Bytes()).ToHash20())
+	expectedBlockID := types.BlockID(types.CalcHash20(testBlock.Bytes()))
 	// Initialize the block for compute actual Block ID
 	testBlock.Initialize()
 	actualBlockID := testBlock.ID()

--- a/common/types/hashes.go
+++ b/common/types/hashes.go
@@ -16,21 +16,19 @@ import (
 const (
 	// Hash32Length is 32, the expected length of the hash.
 	Hash32Length = 32
-	hash20Length = 20
-	hash12Length = 12
+	Hash20Length = 20
 )
 
-// Hash12 represents the first 12 bytes of blake3 hash, mostly used for internal caches.
-type Hash12 [hash12Length]byte
+var (
+	hash20T = reflect.TypeOf(Hash20{})
+	hash32T = reflect.TypeOf(Hash32{})
+)
 
 // Hash32 represents the 32-byte blake3 hash of arbitrary data.
 type Hash32 [Hash32Length]byte
 
 // Hash20 represents the 20-byte blake3 hash of arbitrary data.
-type Hash20 [hash20Length]byte
-
-// Field returns a log field. Implements the LoggableField interface.
-func (h Hash12) Field() log.Field { return log.String("hash", hex.EncodeToString(h[:])) }
+type Hash20 [Hash20Length]byte
 
 // Bytes gets the byte representation of the underlying hash.
 func (h Hash20) Bytes() []byte { return h[:] }
@@ -68,7 +66,7 @@ func (h *Hash20) UnmarshalText(input []byte) error {
 
 // UnmarshalJSON parses a hash in hex syntax.
 func (h *Hash20) UnmarshalJSON(input []byte) error {
-	if err := util.UnmarshalFixedJSON(hashT, input, h[:]); err != nil {
+	if err := util.UnmarshalFixedJSON(hash20T, input, h[:]); err != nil {
 		return fmt.Errorf("unmarshal JSON: %w", err)
 	}
 
@@ -84,10 +82,10 @@ func (h Hash20) MarshalText() ([]byte, error) {
 // If b is larger than len(h), b will be cropped from the left.
 func (h *Hash20) SetBytes(b []byte) {
 	if len(b) > len(h) {
-		b = b[len(b)-32:]
+		b = b[len(b)-20:]
 	}
 
-	copy(h[32-len(b):], b)
+	copy(h[20-len(b):], b)
 }
 
 // ToHash32 returns a Hash32 whose first 20 bytes are the bytes of this Hash20, it is right-padded with zeros.
@@ -98,13 +96,6 @@ func (h Hash20) ToHash32() (h32 Hash32) {
 
 // Field returns a log field. Implements the LoggableField interface.
 func (h Hash20) Field() log.Field { return log.String("hash", hex.EncodeToString(h[:])) }
-
-// CalcHash12 returns the 12-byte prefix of the blake3 sum of the given byte slice.
-func CalcHash12(data []byte) (h Hash12) {
-	h32 := hash.Sum(data)
-	copy(h[:], h32[:])
-	return
-}
 
 // CalcProposalsHash32 returns the 32-byte blake3 sum of the IDs, sorted in lexicographic order. The pre-image is
 // prefixed with additionalBytes.
@@ -141,12 +132,10 @@ func CalcBlockHash32Presorted(sortedView []BlockID, additionalBytes []byte) Hash
 	return res
 }
 
-// CalcMessageHash12 returns the 12-byte blake3 sum of the given msg suffixed with protocol.
-func CalcMessageHash12(msg []byte, protocol string) Hash12 {
-	return CalcHash12(append(msg, protocol...))
+// CalcHash20 returns the 20-byte blake3 sum of the given data.
+func CalcHash20(data []byte) Hash20 {
+	return hash.Sum20(data)
 }
-
-var hashT = reflect.TypeOf(Hash32{})
 
 // CalcHash32 returns the 32-byte blake3 sum of the given data.
 func CalcHash32(data []byte) Hash32 {
@@ -199,7 +188,7 @@ func (h *Hash32) UnmarshalText(input []byte) error {
 
 // UnmarshalJSON parses a hash in hex syntax.
 func (h *Hash32) UnmarshalJSON(input []byte) error {
-	if err := util.UnmarshalFixedJSON(hashT, input, h[:]); err != nil {
+	if err := util.UnmarshalFixedJSON(hash32T, input, h[:]); err != nil {
 		return fmt.Errorf("unmarshal JSON: %w", err)
 	}
 

--- a/common/types/hashes_test.go
+++ b/common/types/hashes_test.go
@@ -5,17 +5,8 @@ import (
 
 	"github.com/spacemeshos/go-scale/tester"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
-
-func TestHash(t *testing.T) {
-	msg1 := []byte("msg1")
-	msg2 := []byte("msg2")
-	prot1 := "prot1"
-	prot2 := "prot2"
-
-	assert.NotEqual(t, CalcMessageHash12(msg1, prot1), CalcMessageHash12(msg1, prot2))
-	assert.NotEqual(t, CalcMessageHash12(msg1, prot1), CalcMessageHash12(msg2, prot1))
-}
 
 func TestConvert32_20Hash(t *testing.T) {
 	msg := []byte("abcdefghijk")
@@ -24,6 +15,24 @@ func TestConvert32_20Hash(t *testing.T) {
 	cHash32 := hash20.ToHash32()
 	hash20b := cHash32.ToHash20()
 	assert.Equal(t, hash20b, hash20)
+}
+
+func TestHash20(t *testing.T) {
+	require.Equal(t, CalcHash20([]byte("hello")), CalcHash32([]byte("hello")).ToHash20())
+}
+
+func TestHash30ToBytes(t *testing.T) {
+	b := []byte("0123456789abcdef_hello_world_how_are_you") // 40 bytes
+	var h Hash32
+	h.SetBytes(b)
+	require.Equal(t, []byte("89abcdef_hello_world_how_are_you"), h.Bytes())
+}
+
+func TestHash20ToBytes(t *testing.T) {
+	b := []byte("0123456789abcdef_hello_world_how_are_you") // 40 bytes
+	var h Hash20
+	h.SetBytes(b)
+	require.Equal(t, []byte("lo_world_how_are_you"), h.Bytes())
 }
 
 func FuzzHash32Consistency(f *testing.F) {

--- a/common/types/testutil.go
+++ b/common/types/testutil.go
@@ -71,7 +71,7 @@ func RandomBallotID() BallotID {
 	if err != nil {
 		return EmptyBallotID
 	}
-	return BallotID(id)
+	return id
 }
 
 // RandomProposalID generates a random ProposalID for testing.
@@ -81,7 +81,7 @@ func RandomProposalID() ProposalID {
 	if err != nil {
 		return ProposalID{}
 	}
-	return ProposalID(id)
+	return id
 }
 
 // RandomBlockID generates a random ProposalID for testing.

--- a/common/types/testutil.go
+++ b/common/types/testutil.go
@@ -66,22 +66,22 @@ func RandomNodeID() NodeID {
 
 // RandomBallotID generates a random BallotID for testing.
 func RandomBallotID() BallotID {
-	var b [hash20Length]byte // TODO(mafa): BallotIDSize is 32???
-	_, err := rand.Read(b[:])
+	var id BallotID
+	_, err := rand.Read(id[:])
 	if err != nil {
 		return EmptyBallotID
 	}
-	return BallotID(b)
+	return BallotID(id)
 }
 
 // RandomProposalID generates a random ProposalID for testing.
 func RandomProposalID() ProposalID {
-	var b [hash20Length]byte // TODO(mafa): ProposalIDSize is 32???
-	_, err := rand.Read(b[:])
+	var id ProposalID
+	_, err := rand.Read(id[:])
 	if err != nil {
 		return ProposalID{}
 	}
-	return ProposalID(b)
+	return ProposalID(id)
 }
 
 // RandomBlockID generates a random ProposalID for testing.

--- a/hash/hash.go
+++ b/hash/hash.go
@@ -21,3 +21,12 @@ func Sum(chunks ...[]byte) (rst [32]byte) {
 	hh.Sum(rst[:0])
 	return rst
 }
+
+func Sum20(chunks ...[]byte) (rst [20]byte) {
+	hh := New()
+	for _, chunk := range chunks {
+		hh.Write(chunk)
+	}
+	hh.Digest().Read(rst[:])
+	return rst
+}


### PR DESCRIPTION
## Description

Changes:
- changed `CalcHash32()` followed by `ToHash20` to `CalcHash20` (it will be little faster)
- removed `Hash12` which is not used
- fixed `Hash20` unmarshaling
- fixed `Hash20::SetBytes()` (it was broken but it wasn't used anywhere, could also be removed, but I left it for symmetry with `Hash32`).

## Test Plan

added few UTs

## TODO

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [ ] Update documentation as needed
- [ ] Update [changelog](../CHANGELOG.md) as needed
