### PR TITLE
[Merged by Bors] - fetch: fix flaky P2P test

### DIFF
--- a/fetch/p2p_test.go
+++ b/fetch/p2p_test.go
@@ -100,15 +100,6 @@ func createP2PFetch(
 	require.NoError(t, err)
 	t.Cleanup(func() { assert.NoError(t, clientHost.Stop()) })
 
-	// TODO: connect after both NewFetch calls
-	err = clientHost.Connect(ctx, peer.AddrInfo{
-		ID:    serverHost.ID(),
-		Addrs: serverHost.Addrs(),
-	})
-	require.NoError(t, err)
-
-	require.Len(t, clientHost.GetPeers(), 1)
-
 	var sqlOpts []sql.Opt
 	if sqlCache {
 		sqlOpts = []sql.Opt{sql.WithQueryCache(true)}
@@ -159,6 +150,14 @@ func createP2PFetch(
 	)
 	require.NoError(t, tpf.clientFetch.Start())
 	t.Cleanup(tpf.clientFetch.Stop)
+
+	err = clientHost.Connect(ctx, peer.AddrInfo{
+		ID:    serverHost.ID(),
+		Addrs: serverHost.Addrs(),
+	})
+	require.NoError(t, err)
+
+	require.Len(t, clientHost.GetPeers(), 1)
 
 	return tpf, ctx
 }

--- a/p2p/server/server.go
+++ b/p2p/server/server.go
@@ -216,10 +216,6 @@ func (s *Server) Run(ctx context.Context) error {
 	s.h.SetStreamHandler(protocol.ID(s.protocol), func(stream network.Stream) {
 		select {
 		case queue <- request{stream: stream, received: time.Now()}:
-			if s.metrics != nil {
-				s.metrics.queue.Set(float64(len(queue)))
-				s.metrics.accepted.Inc()
-			}
 		default:
 			if s.metrics != nil {
 				s.metrics.dropped.Inc()
@@ -236,6 +232,10 @@ func (s *Server) Run(ctx context.Context) error {
 			eg.Wait()
 			return nil
 		case req := <-queue:
+			if s.metrics != nil {
+				s.metrics.queue.Set(float64(len(queue)))
+				s.metrics.accepted.Inc()
+			}
 			if s.metrics != nil {
 				s.metrics.inQueueLatency.Observe(time.Since(req.received).Seconds())
 			}


### PR DESCRIPTION
## Motivation

There's a flaky P2P test in the fetch package

## Description

P2P client was connecting to early, before setting up the fetch server, so `hs/1` protocol was being used instead of `as/1` for active set hash requests in some cases, causing wrong counters to increment.
Also, the request count could not be increased in time in some cases

## Test Plan

Re-run the coverage job multiple times
