### PR TITLE
[Merged by Bors] - Allow vaults to spend received funds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ See [RELEASE](./RELEASE.md) for workflow instructions.
 ### Improvements
 
 * [#5807](https://github.com/spacemeshos/go-spacemesh/pull/5807) Implement SMIP-0002: remove vesting vault cliff.
+ 
+* [#5840](https://github.com/spacemeshos/go-spacemesh/pull/5840) Allow vaults to spend received (as well as vested)
+coins. Fixes an oversight in the genesis VM implementation.
 
 * [#5791](https://github.com/spacemeshos/go-spacemesh/pull/5791) Speed up ATX queries.
   This also fixes ambiguity of nonces for equivocating identities.

--- a/genvm/core/context.go
+++ b/genvm/core/context.go
@@ -58,6 +58,9 @@ func (c *Context) GetGenesisID() Hash20 {
 	return c.GenesisID
 }
 
+// Balance returns the account balance.
+func (c *Context) Balance() uint64 { return c.PrincipalAccount.Balance }
+
 // Template of the principal account.
 func (c *Context) Template() Template {
 	return c.PrincipalTemplate

--- a/genvm/core/context.go
+++ b/genvm/core/context.go
@@ -262,7 +262,7 @@ type RemoteContext struct {
 	template Template
 }
 
-// Balance returns the remote account balance
+// Balance returns the remote account balance.
 func (r *RemoteContext) Balance() uint64 {
 	return r.remote.Balance
 }

--- a/genvm/core/context.go
+++ b/genvm/core/context.go
@@ -262,6 +262,11 @@ type RemoteContext struct {
 	template Template
 }
 
+// Balance returns the remote account balance
+func (r *RemoteContext) Balance() uint64 {
+	return r.remote.Balance
+}
+
 // Template ...
 func (r *RemoteContext) Template() Template {
 	return r.template

--- a/genvm/core/types.go
+++ b/genvm/core/types.go
@@ -111,6 +111,7 @@ type Host interface {
 	Template() Template
 	Layer() LayerID
 	GetGenesisID() Hash20
+	Balance() uint64
 }
 
 //go:generate scalegen -types Payload

--- a/genvm/templates/vault/vault.go
+++ b/genvm/templates/vault/vault.go
@@ -57,9 +57,6 @@ func (v *Vault) Spend(host core.Host, to core.Address, amount uint64) error {
 	if !v.isOwner(host.Principal()) {
 		return ErrNotOwner
 	}
-	if v.VestingEnd < v.VestingStart {
-		return ErrMisconfigured
-	}
 	vested := v.Vested(host.Layer())
 
 	// sanity checks

--- a/genvm/templates/vault/vault.go
+++ b/genvm/templates/vault/vault.go
@@ -31,8 +31,6 @@ type Vault struct {
 	InitialUnlockAmount uint64
 	VestingStart        core.LayerID
 	VestingEnd          core.LayerID
-
-	DrainedSoFar uint64
 }
 
 func (v *Vault) isOwner(address core.Address) bool {
@@ -71,14 +69,14 @@ func (v *Vault) Spend(host core.Host, to core.Address, amount uint64) error {
 		return ErrMisconfigured
 	}
 
-	// consider only current balance (including coins received) and vested portion of initial endowment
+	// current account balance minus unvested portion of initial endowment equals unspent, vested coins
+	// plus coins received
 	if amount > host.Balance()-v.TotalAmount+vested {
 		return ErrAmountNotAvailable
 	}
 	if err := host.Transfer(to, amount); err != nil {
 		return err
 	}
-	v.DrainedSoFar += amount
 	return nil
 }
 

--- a/genvm/templates/vault/vault_scale.go
+++ b/genvm/templates/vault/vault_scale.go
@@ -44,13 +44,6 @@ func (t *Vault) EncodeScale(enc *scale.Encoder) (total int, err error) {
 		}
 		total += n
 	}
-	{
-		n, err := scale.EncodeCompact64(enc, uint64(t.DrainedSoFar))
-		if err != nil {
-			return total, err
-		}
-		total += n
-	}
 	return total, nil
 }
 
@@ -93,14 +86,6 @@ func (t *Vault) DecodeScale(dec *scale.Decoder) (total int, err error) {
 		}
 		total += n
 		t.VestingEnd = types.LayerID(field)
-	}
-	{
-		field, n, err := scale.DecodeCompact64(dec)
-		if err != nil {
-			return total, err
-		}
-		total += n
-		t.DrainedSoFar = uint64(field)
 	}
 	return total, nil
 }

--- a/genvm/templates/vault/vault_test.go
+++ b/genvm/templates/vault/vault_test.go
@@ -9,9 +9,10 @@ import (
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/genvm/core"
+	"github.com/spacemeshos/go-spacemesh/sql"
 )
 
-func TestAvailable(t *testing.T) {
+func TestVested(t *testing.T) {
 	for _, tc := range []struct {
 		desc                   string
 		start, end, lid        uint32
@@ -129,8 +130,197 @@ func TestAvailable(t *testing.T) {
 				VestingStart:        types.LayerID(tc.start),
 				VestingEnd:          types.LayerID(tc.end),
 			}
-			available := v.Available(types.LayerID(tc.lid))
+			available := v.Vested(types.LayerID(tc.lid))
 			require.Equal(t, int(tc.expect), int(available))
+		})
+	}
+}
+
+func TestSpend(t *testing.T) {
+	for _, tc := range []struct {
+		desc                   string
+		start, end, lid        uint32
+		total, received, spend uint64
+		expect                 error
+	}{
+		{
+			desc:   "zero vested before start",
+			start:  2,
+			lid:    1,
+			total:  100,
+			spend:  1,
+			expect: ErrAmountNotAvailable,
+		},
+		{
+			desc:     "allow spend of received before start",
+			start:    2,
+			lid:      1,
+			total:    100,
+			received: 10,
+			spend:    10,
+		},
+		{
+			desc:     "don't allow spend of more than received before start",
+			start:    2,
+			lid:      1,
+			total:    100,
+			received: 10,
+			spend:    11,
+			expect:   ErrAmountNotAvailable,
+		},
+		{
+			desc:     "allow spend of received at the start",
+			start:    2,
+			end:      10,
+			lid:      2,
+			total:    100,
+			received: 10,
+			spend:    10,
+		},
+		{
+			desc:     "don't allow spend of more than received at the start",
+			start:    2,
+			end:      10,
+			lid:      2,
+			total:    100,
+			received: 9,
+			spend:    10,
+			expect:   ErrAmountNotAvailable,
+		},
+		{
+			desc:  "allow spend of total vested at the end",
+			start: 2,
+			end:   10,
+			lid:   10,
+			total: 100,
+			spend: 100,
+		},
+		{
+			desc:     "allow spend of total vested plus received at the end",
+			start:    2,
+			end:      10,
+			lid:      10,
+			total:    100,
+			received: 10,
+			spend:    110,
+		},
+		{
+			desc:     "don't allow spend of more than total vested plus received at the end",
+			start:    2,
+			end:      10,
+			lid:      10,
+			total:    100,
+			received: 10,
+			spend:    111,
+			expect:   ErrAmountNotAvailable,
+		},
+		{
+			desc:  "allow spend of total vested after the end",
+			start: 2,
+			end:   10,
+			lid:   11,
+			total: 100,
+			spend: 100,
+		},
+		{
+			desc:  "allow spend of incremental vest",
+			start: 2,
+			end:   10,
+			lid:   5,
+			total: 100,
+			spend: 100 * 3 / 8,
+		},
+		{
+			desc:     "allow spend of incremental vest plus received",
+			start:    2,
+			end:      10,
+			lid:      5,
+			total:    100,
+			received: 12,
+			spend:    100*3/8 + 12,
+		},
+		{
+			desc:     "don't allow spend of more than incremental vest plus received",
+			start:    2,
+			end:      10,
+			lid:      5,
+			total:    100,
+			received: 12,
+			spend:    100*3/8 + 13,
+			expect:   ErrAmountNotAvailable,
+		},
+		{
+			desc:  "initial max uint64",
+			start: 2,
+			end:   10,
+			lid:   2,
+			total: math.MaxUint64,
+		},
+		{
+			desc:  "total max uint64",
+			start: 2,
+			end:   10,
+			lid:   1000,
+			total: math.MaxUint64,
+		},
+		{
+			desc:     "received max uint64",
+			start:    2,
+			end:      10,
+			lid:      2,
+			total:    0,
+			received: math.MaxUint64,
+		},
+		{
+			desc:     "spend received max uint64",
+			start:    2,
+			end:      10,
+			lid:      2,
+			total:    0,
+			received: math.MaxUint64,
+			spend:    math.MaxUint64,
+		},
+		{
+			desc:  "spend total max uint64",
+			start: 2,
+			end:   10,
+			lid:   1000,
+			total: math.MaxUint64,
+			spend: math.MaxUint64,
+		},
+		{
+			desc:     "spend max uint64",
+			start:    2,
+			end:      10,
+			lid:      1000,
+			total:    1000,
+			received: 1000,
+			spend:    math.MaxUint64,
+			expect:   ErrAmountNotAvailable,
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			owner := core.Address{'o'}
+			vault := Vault{
+				Owner:        owner,
+				TotalAmount:  tc.total,
+				VestingStart: types.LayerID(tc.start),
+				VestingEnd:   types.LayerID(tc.end),
+			}
+			ctx := core.Context{
+				LayerID: types.LayerID(tc.lid),
+				Loader:  core.NewStagedCache(core.DBLoader{Executor: sql.InMemory()}),
+				Header:  types.TxHeader{MaxSpend: math.MaxUint64},
+				PrincipalAccount: types.Account{
+					Address: owner,
+					Balance: tc.total + tc.received,
+				},
+			}
+			if tc.expect != nil {
+				require.ErrorIs(t, tc.expect, vault.Spend(&ctx, core.Address{1}, tc.spend))
+			} else {
+				require.NoError(t, vault.Spend(&ctx, core.Address{1}, tc.spend))
+			}
 		})
 	}
 }

--- a/genvm/vm.go
+++ b/genvm/vm.go
@@ -330,7 +330,7 @@ func (v *VM) execute(
 			continue
 		}
 		if intrinsic := core.IntrinsicGas(ctx.Gas.BaseGas, tx.GetRaw().Raw); ctx.PrincipalAccount.Balance < intrinsic {
-			logger.With().Warning("ineffective transaction. intrinstic gas not covered",
+			logger.With().Warning("ineffective transaction. intrinsic gas not covered",
 				log.Object("header", header),
 				log.Object("account", &ctx.PrincipalAccount),
 				log.Uint64("intrinsic gas", intrinsic),

--- a/genvm/vm_test.go
+++ b/genvm/vm_test.go
@@ -2579,7 +2579,7 @@ func TestVestingData(t *testing.T) {
 						// give a bit to vesting account as it needs funds to send a few transactions
 						// before receiving from the spend address
 						Address: vestaddr,
-						Balance: 200_000,
+						Balance: 300_000,
 					},
 					{
 						Address: vaultaddr,


### PR DESCRIPTION
## Motivation

Fixes an oversight in genvm implementation: vesting vaults are unable to spend received coins.

## Description

Adds a `Balance()` method to host/context to allow genvm templates to read current account balance, then updates vault spending arithmetic accordingly.

## Test Plan

Added tests in `genvm/templates/vault/vault_test.go`

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
