### PR TITLE
Backport: Revert shuffling algorithm for block TXs (#5839)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 See [RELEASE](./RELEASE.md) for workflow instructions.
 
+## Release v1.4.6
+
+### Improvements
+
+* [#5839](https://github.com/spacemeshos/go-spacemesh/pull/5839) Fix a bug where nodes would stop agreeing on the order
+  of TX within a block.
+
 ## Release v1.4.5
 
 ### Improvements

--- a/blocks/utils.go
+++ b/blocks/utils.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"math"
 	"math/big"
-	"math/rand/v2"
+	"math/rand"
 	"sort"
 
 	"github.com/seehuhn/mt19937"

--- a/txs/conservative_state.go
+++ b/txs/conservative_state.go
@@ -2,10 +2,9 @@ package txs
 
 import (
 	"context"
-	"encoding/binary"
 	"fmt"
 	"math"
-	"math/rand/v2"
+	"math/rand"
 	"time"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
@@ -108,9 +107,7 @@ func getProposalTXs(
 		return result
 	}
 	// randomly select transactions from the predicted block.
-	var seed [32]byte
-	binary.LittleEndian.PutUint64(seed[:], uint64(time.Now().UnixNano()))
-	rng := rand.New(rand.NewChaCha8(seed))
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
 	return ShuffleWithNonceOrder(logger, rng, numTXs, predictedBlock, byAddrAndNonce)
 }
 

--- a/txs/utils.go
+++ b/txs/utils.go
@@ -1,7 +1,7 @@
 package txs
 
 import (
-	"math/rand/v2"
+	"math/rand"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/log"


### PR DESCRIPTION
## Motivation

Backport of #5839 for the `v1.4` branch.

## Description

No additional changes compared ot #5839 

## Test Plan

n/a

## TODO

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
