### PR TITLE
[Merged by Bors] - Fix default malfeasance sync config in testnet preset

### DIFF
--- a/config/presets/testnet.go
+++ b/config/presets/testnet.go
@@ -26,6 +26,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/p2p"
 	"github.com/spacemeshos/go-spacemesh/syncer"
 	"github.com/spacemeshos/go-spacemesh/syncer/atxsync"
+	"github.com/spacemeshos/go-spacemesh/syncer/malsync"
 	timeConfig "github.com/spacemeshos/go-spacemesh/timesync/config"
 	"github.com/spacemeshos/go-spacemesh/tortoise"
 )
@@ -144,6 +145,7 @@ func testnet() config.Config {
 			GossipDuration:           50 * time.Second,
 			OutOfSyncThresholdLayers: 10,
 			AtxSync:                  atxsync.DefaultConfig(),
+			MalSync:                  malsync.DefaultConfig(),
 		},
 		Recovery: checkpoint.DefaultConfig(),
 		Cache:    datastore.DefaultConfig(),


### PR DESCRIPTION
## Motivation

In testnet preset values, malfeasance sync config is initialized with zeros instead of default values, causing sync to hang

## Description

Use proper malfeasance sync config in testnet preset

## Test Plan

Verified on the testnet
