### PR TITLE
[Merged by Bors] - Make distributed verification default with k3 eq 1

### DIFF
--- a/config/mainnet.go
+++ b/config/mainnet.go
@@ -167,7 +167,7 @@ func MainnetConfig() Config {
 			LabelsPerUnit: 4294967296,
 			K1:            26,
 			K2:            37,
-			K3:            37,
+			K3:            1,
 			PowDifficulty: postPowDifficulty,
 		},
 		Bootstrap: bootstrap.Config{

--- a/config/presets/fastnet.go
+++ b/config/presets/fastnet.go
@@ -65,7 +65,7 @@ func fastnet() config.Config {
 
 	conf.POST.K1 = 12
 	conf.POST.K2 = 4
-	conf.POST.K3 = 4
+	conf.POST.K3 = 1
 	conf.POST.LabelsPerUnit = 128
 	conf.POST.MaxNumUnits = 4
 	conf.POST.MinNumUnits = 2

--- a/config/presets/standalone.go
+++ b/config/presets/standalone.go
@@ -47,7 +47,7 @@ func standalone() config.Config {
 
 	conf.POST.K1 = 12
 	conf.POST.K2 = 4
-	conf.POST.K3 = 4
+	conf.POST.K3 = 1
 	conf.POST.LabelsPerUnit = 64
 	conf.POST.MaxNumUnits = 2
 	conf.POST.MinNumUnits = 1

--- a/config/presets/testnet.go
+++ b/config/presets/testnet.go
@@ -121,7 +121,7 @@ func testnet() config.Config {
 			LabelsPerUnit: 1024,
 			K1:            26,
 			K2:            37,
-			K3:            37,
+			K3:            1,
 			PowDifficulty: activation.DefaultPostConfig().PowDifficulty,
 		},
 		POSTService: activation.DefaultPostServiceConfig(),


### PR DESCRIPTION
Let's enable distributed verification by default on all networks.

This changes the mainnet and all presets to use `k3=1`