### PR TITLE
[Merged by Bors] - Use pre-encoded ATX blobs in checkpoint recovery

### DIFF
--- a/checkpoint/recovery.go
+++ b/checkpoint/recovery.go
@@ -97,8 +97,9 @@ func copyToLocalFile(
 }
 
 type AtxDep struct {
-	types.VerifiedActivationTx
-	Blob []byte
+	ID           types.ATXID
+	PublishEpoch types.EpochID
+	Blob         []byte
 }
 
 type PreservedData struct {
@@ -225,20 +226,20 @@ func recoverFromLocalFile(
 	allDeps := maps.Values(deps)
 	// sort ATXs them by publishEpoch and then by ID
 	slices.SortFunc(allDeps, func(i, j *AtxDep) int {
-		return bytes.Compare(i.ID().Bytes(), j.ID().Bytes())
+		return bytes.Compare(i.ID.Bytes(), i.ID.Bytes())
 	})
 	slices.SortStableFunc(allDeps, func(i, j *AtxDep) int {
 		return int(i.PublishEpoch) - int(j.PublishEpoch)
 	})
 	allProofs := make([]*types.PoetProofMessage, 0, len(proofs))
 	for _, dep := range allDeps {
-		poetProofRef, err := atxs.PoetProofRef(context.Background(), db, dep.ID())
+		poetProofRef, err := atxs.PoetProofRef(context.Background(), db, dep.ID)
 		if err != nil {
-			return nil, fmt.Errorf("get poet proof ref (%v): %w", dep.ID(), err)
+			return nil, fmt.Errorf("get poet proof ref (%v): %w", dep.ID, err)
 		}
 		proof, ok := proofs[poetProofRef]
 		if !ok {
-			return nil, fmt.Errorf("missing poet proof for atx %v", dep.ID())
+			return nil, fmt.Errorf("missing poet proof for atx %v", dep.ID)
 		}
 		allProofs = append(allProofs, proof)
 	}
@@ -488,8 +489,9 @@ func collect(
 	}
 
 	deps[ref] = &AtxDep{
-		VerifiedActivationTx: *atx,
-		Blob:                 blob.Bytes,
+		ID:           ref,
+		PublishEpoch: atx.PublishEpoch,
+		Blob:         blob.Bytes,
 	}
 	all[ref] = struct{}{}
 	return nil

--- a/checkpoint/recovery.go
+++ b/checkpoint/recovery.go
@@ -226,7 +226,7 @@ func recoverFromLocalFile(
 	allDeps := maps.Values(deps)
 	// sort ATXs them by publishEpoch and then by ID
 	slices.SortFunc(allDeps, func(i, j *AtxDep) int {
-		return bytes.Compare(i.ID.Bytes(), i.ID.Bytes())
+		return bytes.Compare(i.ID.Bytes(), j.ID.Bytes())
 	})
 	slices.SortStableFunc(allDeps, func(i, j *AtxDep) int {
 		return int(i.PublishEpoch) - int(j.PublishEpoch)

--- a/checkpoint/recovery_test.go
+++ b/checkpoint/recovery_test.go
@@ -227,11 +227,9 @@ func TestRecover_SameRecoveryInfo(t *testing.T) {
 func validateAndPreserveData(
 	tb testing.TB,
 	db *sql.Database,
-	deps []*types.VerifiedActivationTx,
-	proofs []*types.PoetProofMessage,
+	deps []*checkpoint.AtxDep,
 ) {
 	lg := logtest.New(tb)
-	poetDb := activation.NewPoetDb(db, lg)
 	ctrl := gomock.NewController(tb)
 	mclock := activation.NewMocklayerClock(ctrl)
 	mfetch := smocks.NewMockFetcher(ctrl)
@@ -255,12 +253,10 @@ func validateAndPreserveData(
 		lg,
 	)
 	mfetch.EXPECT().GetAtxs(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
-	for i, vatx := range deps {
-		encoded, err := codec.Encode(wire.ActivationTxToWireV1(vatx.ActivationTx))
-		require.NoError(tb, err)
+	for _, vatx := range deps {
 		mclock.EXPECT().CurrentLayer().Return(vatx.PublishEpoch.FirstLayer())
 		mfetch.EXPECT().RegisterPeerHashes(gomock.Any(), gomock.Any())
-		mfetch.EXPECT().GetPoetProof(gomock.Any(), vatx.GetPoetProofRef())
+		mfetch.EXPECT().GetPoetProof(gomock.Any(), gomock.Any())
 		if vatx.InitialPost != nil {
 			mvalidator.EXPECT().
 				InitialNIPostChallenge(&vatx.ActivationTx.NIPostChallenge, gomock.Any(), goldenAtx).
@@ -287,11 +283,7 @@ func validateAndPreserveData(
 		mvalidator.EXPECT().IsVerifyingFullPost().AnyTimes().Return(true)
 		mreceiver.EXPECT().OnAtx(gomock.Any())
 		mtrtl.EXPECT().OnAtx(gomock.Any(), gomock.Any(), gomock.Any())
-		require.NoError(tb, atxHandler.HandleSyncedAtx(context.Background(), vatx.ID().Hash32(), "self", encoded))
-		err = poetDb.ValidateAndStore(context.Background(), proofs[i])
-		require.ErrorContains(tb, err, fmt.Sprintf("failed to validate poet proof for poetID %s round 1337",
-			hex.EncodeToString(proofs[i].PoetServiceID[:5])),
-		)
+		require.NoError(tb, atxHandler.HandleSyncedAtx(context.Background(), vatx.ID().Hash32(), "self", vatx.Blob))
 	}
 }
 
@@ -299,10 +291,11 @@ func newChainedAtx(
 	tb testing.TB,
 	prev, pos types.ATXID,
 	commitAtx *types.ATXID,
+	poetProofRef types.PoetProofRef,
 	epoch uint32,
 	seq, vrfNonce uint64,
 	sig *signing.EdSigner,
-) *types.VerifiedActivationTx {
+) *checkpoint.AtxDep {
 	watx := &wire.ActivationTxV1{
 		InnerActivationTxV1: wire.InnerActivationTxV1{
 			NIPostChallengeV1: wire.NIPostChallengeV1{
@@ -314,7 +307,7 @@ func newChainedAtx(
 			},
 			NIPost: &wire.NIPostV1{
 				PostMetadata: &wire.PostMetadataV1{
-					Challenge: types.RandomBytes(5),
+					Challenge: poetProofRef[:],
 				},
 			},
 			NumUnits: 2,
@@ -336,35 +329,63 @@ func newChainedAtx(
 	atx.SetEffectiveNumUnits(atx.NumUnits)
 	atx.SetReceived(time.Now().Local())
 
-	return newvAtx(tb, atx)
+	return &checkpoint.AtxDep{
+		VerifiedActivationTx: *newvAtx(tb, atx),
+		Blob:                 codec.MustEncode(watx),
+	}
+}
+
+func randomPoetProof(tb testing.TB) (*types.PoetProofMessage, types.PoetProofRef) {
+	proof := &types.PoetProofMessage{
+		PoetProof: types.PoetProof{
+			MerkleProof: shared.MerkleProof{
+				Root:         types.RandomBytes(32),
+				ProvenLeaves: [][]byte{{1}, {2}},
+				ProofNodes:   [][]byte{{1}, {2}},
+			},
+			LeafCount: 1234,
+		},
+		PoetServiceID: types.RandomBytes(32),
+		RoundID:       "1337",
+	}
+	ref, err := proof.Ref()
+	require.NoError(tb, err)
+	return proof, ref
 }
 
 func createInterlinkedAtxChain(
 	tb testing.TB,
 	sig1 *signing.EdSigner,
 	sig2 *signing.EdSigner,
-) ([]*types.VerifiedActivationTx, []*types.PoetProofMessage) {
-	// epoch 2
-	sig1Atx1 := newChainedAtx(tb, types.EmptyATXID, goldenAtx, &goldenAtx, 2, 0, 113, sig1)
-	// epoch 3
-	sig1Atx2 := newChainedAtx(tb, sig1Atx1.ID(), sig1Atx1.ID(), nil, 3, 1, 0, sig1)
-	// epoch 4
-	sig1Atx3 := newChainedAtx(tb, sig1Atx2.ID(), sig1Atx2.ID(), nil, 4, 2, 0, sig1)
-	commitAtxID := sig1Atx2.ID()
-	sig2Atx1 := newChainedAtx(tb, types.EmptyATXID, sig1Atx2.ID(), &commitAtxID, 4, 0, 513, sig2)
-	// epoch 5
-	sig1Atx4 := newChainedAtx(tb, sig1Atx3.ID(), sig2Atx1.ID(), nil, 5, 3, 0, sig1)
-	// epoch 6
-	sig1Atx5 := newChainedAtx(tb, sig1Atx4.ID(), sig1Atx4.ID(), nil, 6, 4, 0, sig1)
-	sig2Atx2 := newChainedAtx(tb, sig2Atx1.ID(), sig1Atx4.ID(), nil, 6, 1, 0, sig2)
-	// epoch 7
-	sig1Atx6 := newChainedAtx(tb, sig1Atx5.ID(), sig2Atx2.ID(), nil, 7, 5, 0, sig1)
-	// epoch 8
-	sig2Atx3 := newChainedAtx(tb, sig2Atx2.ID(), sig1Atx6.ID(), nil, 8, 2, 0, sig2)
-	// epoch 9
-	sig1Atx7 := newChainedAtx(tb, sig1Atx6.ID(), sig2Atx3.ID(), nil, 9, 6, 0, sig1)
+) ([]*checkpoint.AtxDep, []*types.PoetProofMessage) {
+	var proofs []*types.PoetProofMessage
+	poetRef := func() types.PoetProofRef {
+		proof, ref := randomPoetProof(tb)
+		proofs = append(proofs, proof)
+		return ref
+	}
 
-	vAtxs := []*types.VerifiedActivationTx{
+	// epoch 2
+	sig1Atx1 := newChainedAtx(tb, types.EmptyATXID, goldenAtx, &goldenAtx, poetRef(), 2, 0, 113, sig1)
+	// epoch 3
+	sig1Atx2 := newChainedAtx(tb, sig1Atx1.ID(), sig1Atx1.ID(), nil, poetRef(), 3, 1, 0, sig1)
+	// epoch 4
+	sig1Atx3 := newChainedAtx(tb, sig1Atx2.ID(), sig1Atx2.ID(), nil, poetRef(), 4, 2, 0, sig1)
+	commitAtxID := sig1Atx2.ID()
+	sig2Atx1 := newChainedAtx(tb, types.EmptyATXID, sig1Atx2.ID(), &commitAtxID, poetRef(), 4, 0, 513, sig2)
+	// epoch 5
+	sig1Atx4 := newChainedAtx(tb, sig1Atx3.ID(), sig2Atx1.ID(), nil, poetRef(), 5, 3, 0, sig1)
+	// epoch 6
+	sig1Atx5 := newChainedAtx(tb, sig1Atx4.ID(), sig1Atx4.ID(), nil, poetRef(), 6, 4, 0, sig1)
+	sig2Atx2 := newChainedAtx(tb, sig2Atx1.ID(), sig1Atx4.ID(), nil, poetRef(), 6, 1, 0, sig2)
+	// epoch 7
+	sig1Atx6 := newChainedAtx(tb, sig1Atx5.ID(), sig2Atx2.ID(), nil, poetRef(), 7, 5, 0, sig1)
+	// epoch 8
+	sig2Atx3 := newChainedAtx(tb, sig2Atx2.ID(), sig1Atx6.ID(), nil, poetRef(), 8, 2, 0, sig2)
+	// epoch 9
+	sig1Atx7 := newChainedAtx(tb, sig1Atx6.ID(), sig2Atx3.ID(), nil, poetRef(), 9, 6, 0, sig1)
+
+	vAtxs := []*checkpoint.AtxDep{
 		sig1Atx1,
 		sig1Atx2,
 		sig1Atx3,
@@ -376,61 +397,39 @@ func createInterlinkedAtxChain(
 		sig2Atx3,
 		sig1Atx7,
 	}
-	var proofs []*types.PoetProofMessage
-	for range vAtxs {
-		proofMessage := &types.PoetProofMessage{
-			PoetProof: types.PoetProof{
-				MerkleProof: shared.MerkleProof{
-					Root:         types.RandomBytes(32),
-					ProvenLeaves: [][]byte{{1}, {2}},
-					ProofNodes:   [][]byte{{1}, {2}},
-				},
-				LeafCount: 1234,
-			},
-			PoetServiceID: types.RandomBytes(32),
-			RoundID:       "1337",
-		}
-		proofs = append(proofs, proofMessage)
-	}
+
 	return vAtxs, proofs
 }
 
-func createAtxChain(tb testing.TB, sig *signing.EdSigner) ([]*types.VerifiedActivationTx, []*types.PoetProofMessage) {
+func createAtxChain(tb testing.TB, sig *signing.EdSigner) ([]*checkpoint.AtxDep, []*types.PoetProofMessage) {
 	other, err := signing.NewEdSigner()
 	require.NoError(tb, err)
 	return createInterlinkedAtxChain(tb, other, sig)
 }
 
-func createAtxChainDepsOnly(tb testing.TB) ([]*types.VerifiedActivationTx, []*types.PoetProofMessage) {
+func createAtxChainDepsOnly(tb testing.TB) ([]*checkpoint.AtxDep, []*types.PoetProofMessage) {
 	other, err := signing.NewEdSigner()
 	require.NoError(tb, err)
-	// epoch 2
-	othAtx1 := newChainedAtx(tb, types.EmptyATXID, goldenAtx, &goldenAtx, 2, 0, 113, other)
-	// epoch 3
-	othAtx2 := newChainedAtx(tb, othAtx1.ID(), othAtx1.ID(), nil, 3, 1, 0, other)
-	// epoch 4
-	othAtx3 := newChainedAtx(tb, othAtx2.ID(), othAtx2.ID(), nil, 4, 2, 0, other)
-	vAtxs := []*types.VerifiedActivationTx{othAtx1, othAtx2, othAtx3}
+
 	var proofs []*types.PoetProofMessage
-	for range vAtxs {
-		proofMessage := &types.PoetProofMessage{
-			PoetProof: types.PoetProof{
-				MerkleProof: shared.MerkleProof{
-					Root:         []byte{1, 2, 3},
-					ProvenLeaves: [][]byte{{1}, {2}},
-					ProofNodes:   [][]byte{{1}, {2}},
-				},
-				LeafCount: 1234,
-			},
-			PoetServiceID: []byte("poet_id_123456"),
-			RoundID:       "1337",
-		}
-		proofs = append(proofs, proofMessage)
+	poetRef := func() types.PoetProofRef {
+		proof, ref := randomPoetProof(tb)
+		proofs = append(proofs, proof)
+		return ref
 	}
-	return vAtxs, proofs
+
+	// epoch 2
+	othAtx1 := newChainedAtx(tb, types.EmptyATXID, goldenAtx, &goldenAtx, poetRef(), 2, 0, 113, other)
+	// epoch 3
+	othAtx2 := newChainedAtx(tb, othAtx1.ID(), othAtx1.ID(), nil, poetRef(), 3, 1, 0, other)
+	// epoch 4
+	othAtx3 := newChainedAtx(tb, othAtx2.ID(), othAtx2.ID(), nil, poetRef(), 4, 2, 0, other)
+	atxDeps := []*checkpoint.AtxDep{othAtx1, othAtx2, othAtx3}
+
+	return atxDeps, proofs
 }
 
-func atxIDs(atxs []*types.VerifiedActivationTx) []types.ATXID {
+func atxIDs(atxs []*checkpoint.AtxDep) []types.ATXID {
 	ids := make([]types.ATXID, 0, len(atxs))
 	for _, atx := range atxs {
 		ids = append(ids, atx.ID())
@@ -489,18 +488,21 @@ func TestRecover_OwnAtxNotInCheckpoint_Preserve(t *testing.T) {
 	vAtxs3, proofs3 := createInterlinkedAtxChain(t, sig3, sig4)
 	vAtxs = append(vAtxs, vAtxs3...)
 	proofs = append(proofs, proofs3...)
-	validateAndPreserveData(t, oldDB, vAtxs, proofs)
+
+	validateAndPreserveData(t, oldDB, vAtxs)
 	// the proofs are not valid, but save them anyway for the purpose of testing
-	for i, vatx := range vAtxs {
-		encoded, err := codec.Encode(proofs[i])
+	for _, proof := range proofs {
+		encoded, err := codec.Encode(proof)
+		require.NoError(t, err)
+		ref, err := proof.Ref()
 		require.NoError(t, err)
 
 		err = poets.Add(
 			oldDB,
-			types.PoetProofRef(vatx.GetPoetProofRef()),
+			ref,
 			encoded,
-			proofs[i].PoetServiceID,
-			proofs[i].RoundID,
+			proof.PoetServiceID,
+			proof.RoundID,
 		)
 		require.NoError(t, err)
 	}
@@ -524,8 +526,7 @@ func TestRecover_OwnAtxNotInCheckpoint_Preserve(t *testing.T) {
 	require.NotNil(t, newDB)
 	t.Cleanup(func() { assert.NoError(t, newDB.Close()) })
 	verifyDbContent(t, newDB)
-	validateAndPreserveData(t, newDB, preserve.Deps, preserve.Proofs)
-	// note that poet proofs are not saved to newDB due to verification errors
+	validateAndPreserveData(t, newDB, preserve.Deps)
 
 	restore, err := recovery.CheckpointInfo(newDB)
 	require.NoError(t, err)
@@ -574,19 +575,22 @@ func TestRecover_OwnAtxNotInCheckpoint_Preserve_IncludePending(t *testing.T) {
 	vAtxs2, proofs2 := createInterlinkedAtxChain(t, sig2, sig3)
 	vAtxs := append(vAtxs1, vAtxs2...)
 	proofs := append(proofs1, proofs2...)
-	validateAndPreserveData(t, oldDB, vAtxs, proofs)
+	validateAndPreserveData(t, oldDB, vAtxs)
 	// the proofs are not valid, but save them anyway for the purpose of testing
-	for i, vatx := range vAtxs {
-		encoded, err := codec.Encode(proofs[i])
+	for _, proof := range proofs {
+		encoded, err := codec.Encode(proof)
 		require.NoError(t, err)
+		ref, err := proof.Ref()
+		require.NoError(t, err)
+
 		require.NoError(
 			t,
 			poets.Add(
 				oldDB,
-				types.PoetProofRef(vatx.GetPoetProofRef()),
+				ref,
 				encoded,
-				proofs[i].PoetServiceID,
-				proofs[i].RoundID,
+				proof.PoetServiceID,
+				proof.RoundID,
 			),
 		)
 	}
@@ -635,8 +639,7 @@ func TestRecover_OwnAtxNotInCheckpoint_Preserve_IncludePending(t *testing.T) {
 	require.NotNil(t, newDB)
 	t.Cleanup(func() { assert.NoError(t, newDB.Close()) })
 	verifyDbContent(t, newDB)
-	validateAndPreserveData(t, newDB, preserve.Deps, preserve.Proofs)
-	// note that poet proofs are not saved to newDB due to verification errors
+	validateAndPreserveData(t, newDB, preserve.Deps)
 
 	restore, err := recovery.CheckpointInfo(newDB)
 	require.NoError(t, err)
@@ -680,19 +683,19 @@ func TestRecover_OwnAtxNotInCheckpoint_Preserve_Still_Initializing(t *testing.T)
 	require.NotNil(t, oldDB)
 
 	vAtxs, proofs := createAtxChainDepsOnly(t)
-	validateAndPreserveData(t, oldDB, vAtxs, proofs)
+	validateAndPreserveData(t, oldDB, vAtxs)
 	// the proofs are not valid, but save them anyway for the purpose of testing
-	for i, vatx := range vAtxs {
-		encoded, err := codec.Encode(proofs[i])
+	for _, proof := range proofs {
+		encoded, err := codec.Encode(proof)
 		require.NoError(t, err)
 		require.NoError(
 			t,
 			poets.Add(
 				oldDB,
-				types.PoetProofRef(vatx.GetPoetProofRef()),
+				types.PoetProofRef(types.CalcHash32(encoded)),
 				encoded,
-				proofs[i].PoetServiceID,
-				proofs[i].RoundID,
+				proof.PoetServiceID,
+				proof.RoundID,
 			),
 		)
 	}
@@ -789,7 +792,7 @@ func TestRecover_OwnAtxNotInCheckpoint_Preserve_DepIsGolden(t *testing.T) {
 		Sequence:       golden.Sequence,
 		Coinbase:       golden.Coinbase,
 	}))
-	validateAndPreserveData(t, oldDB, vAtxs[1:], proofs[1:])
+	validateAndPreserveData(t, oldDB, vAtxs[1:])
 	// the proofs are not valid, but save them anyway for the purpose of testing
 	for i, proof := range proofs {
 		if i == 0 {
@@ -801,7 +804,7 @@ func TestRecover_OwnAtxNotInCheckpoint_Preserve_DepIsGolden(t *testing.T) {
 			t,
 			poets.Add(
 				oldDB,
-				types.PoetProofRef(vAtxs[i].GetPoetProofRef()),
+				types.PoetProofRef(types.CalcHash32(encoded)),
 				encoded,
 				proof.PoetServiceID,
 				proof.RoundID,
@@ -857,19 +860,19 @@ func TestRecover_OwnAtxNotInCheckpoint_DontPreserve(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, oldDB)
 	vAtxs, proofs := createAtxChain(t, sig)
-	validateAndPreserveData(t, oldDB, vAtxs, proofs)
+	validateAndPreserveData(t, oldDB, vAtxs)
 	// the proofs are not valid, but save them anyway for the purpose of testing
-	for i, vatx := range vAtxs {
-		encoded, err := codec.Encode(proofs[i])
+	for _, proof := range proofs {
+		encoded, err := codec.Encode(proof)
 		require.NoError(t, err)
 		require.NoError(
 			t,
 			poets.Add(
 				oldDB,
-				types.PoetProofRef(vatx.GetPoetProofRef()),
+				types.PoetProofRef(types.CalcHash32(encoded)),
 				encoded,
-				proofs[i].PoetServiceID,
-				proofs[i].RoundID,
+				proof.PoetServiceID,
+				proof.RoundID,
 			),
 		)
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -2147,23 +2147,27 @@ func (app *App) preserveAfterRecovery(ctx context.Context) {
 		hash := types.Hash32(ref)
 		if err := app.poetDb.ValidateAndStoreMsg(ctx, hash, p2p.NoPeer, encoded); err != nil {
 			app.log.With().Error("failed to preserve poet proof after checkpoint",
-				log.Stringer("atx id", app.preserve.Deps[i].ID()),
+				log.Stringer("atx id", app.preserve.Deps[i].ID),
 				log.String("poet proof ref", hash.ShortString()),
 				log.Err(err),
 			)
 			continue
 		}
 		app.log.With().Info("preserved poet proof after checkpoint",
-			log.Stringer("atx id", app.preserve.Deps[i].ID()),
+			log.Stringer("atx id", app.preserve.Deps[i].ID),
 			log.String("poet proof ref", hash.ShortString()),
 		)
 	}
 	for _, atx := range app.preserve.Deps {
-		if err := app.atxHandler.HandleSyncedAtx(ctx, atx.ID().Hash32(), p2p.NoPeer, atx.Blob); err != nil {
-			app.log.With().Error("failed to preserve atx after checkpoint", log.Inline(atx), log.Err(err))
+		if err := app.atxHandler.HandleSyncedAtx(ctx, atx.ID.Hash32(), p2p.NoPeer, atx.Blob); err != nil {
+			app.log.With().Error(
+				"failed to preserve atx after checkpoint",
+				log.ShortStringer("id", atx.ID),
+				log.Err(err),
+			)
 			continue
 		}
-		app.log.With().Info("preserved atx after checkpoint", log.Inline(atx))
+		app.log.With().Info("preserved atx after checkpoint", log.ShortStringer("id", atx.ID))
 	}
 }
 

--- a/node/node.go
+++ b/node/node.go
@@ -2141,10 +2141,7 @@ func (app *App) preserveAfterRecovery(ctx context.Context) {
 		}
 		ref, err := poetProof.Ref()
 		if err != nil {
-			app.log.With().Error("failed to get poet proof ref after checkpoint",
-				log.Object("poet proof", poetProof),
-				log.Err(err),
-			)
+			app.log.With().Error("failed to get poet proof ref after checkpoint", log.Inline(poetProof), log.Err(err))
 			continue
 		}
 		hash := types.Hash32(ref)
@@ -2163,13 +2160,10 @@ func (app *App) preserveAfterRecovery(ctx context.Context) {
 	}
 	for _, atx := range app.preserve.Deps {
 		if err := app.atxHandler.HandleSyncedAtx(ctx, atx.ID().Hash32(), p2p.NoPeer, atx.Blob); err != nil {
-			app.log.With().Error("failed to preserve atx after checkpoint",
-				log.Stringer("atx_id", atx.ID()),
-				log.Err(err),
-			)
+			app.log.With().Error("failed to preserve atx after checkpoint", log.Inline(atx), log.Err(err))
 			continue
 		}
-		app.log.With().Info("preserved atx after checkpoint", log.Stringer("atx_id", atx.ID()))
+		app.log.With().Info("preserved atx after checkpoint", log.Inline(atx))
 	}
 }
 

--- a/node/node.go
+++ b/node/node.go
@@ -2134,13 +2134,20 @@ func (app *App) preserveAfterRecovery(ctx context.Context) {
 		encoded, err := codec.Encode(poetProof)
 		if err != nil {
 			app.log.With().Error("failed to encode poet proof after checkpoint",
-				log.Stringer("atx id", app.preserve.Deps[i].ID()),
 				log.Object("poet proof", poetProof),
 				log.Err(err),
 			)
 			continue
 		}
-		hash := app.preserve.Deps[i].GetPoetProofRef()
+		ref, err := poetProof.Ref()
+		if err != nil {
+			app.log.With().Error("failed to get poet proof ref after checkpoint",
+				log.Object("poet proof", poetProof),
+				log.Err(err),
+			)
+			continue
+		}
+		hash := types.Hash32(ref)
 		if err := app.poetDb.ValidateAndStoreMsg(ctx, hash, p2p.NoPeer, encoded); err != nil {
 			app.log.With().Error("failed to preserve poet proof after checkpoint",
 				log.Stringer("atx id", app.preserve.Deps[i].ID()),
@@ -2154,25 +2161,15 @@ func (app *App) preserveAfterRecovery(ctx context.Context) {
 			log.String("poet proof ref", hash.ShortString()),
 		)
 	}
-	for _, vatx := range app.preserve.Deps {
-		encoded, err := codec.Encode(wire.ActivationTxToWireV1(vatx.ActivationTx))
-		if err != nil {
-			app.log.With().Error("failed to encode atx after checkpoint",
-				log.Inline(vatx),
-				log.Err(err),
-			)
-			continue
-		}
-		if err := app.atxHandler.HandleSyncedAtx(ctx, vatx.ID().Hash32(), p2p.NoPeer, encoded); err != nil {
+	for _, atx := range app.preserve.Deps {
+		if err := app.atxHandler.HandleSyncedAtx(ctx, atx.ID().Hash32(), p2p.NoPeer, atx.Blob); err != nil {
 			app.log.With().Error("failed to preserve atx after checkpoint",
-				log.Inline(vatx),
+				log.Stringer("atx_id", atx.ID()),
 				log.Err(err),
 			)
 			continue
 		}
-		app.log.With().Info("preserved atx after checkpoint",
-			log.Inline(vatx),
-		)
+		app.log.With().Info("preserved atx after checkpoint", log.Stringer("atx_id", atx.ID()))
 	}
 }
 

--- a/sql/atxs/atxs.go
+++ b/sql/atxs/atxs.go
@@ -794,3 +794,18 @@ func IterateForGrading(
 	}
 	return nil
 }
+
+func PoetProofRef(ctx context.Context, db sql.Executor, id types.ATXID) (types.PoetProofRef, error) {
+	var blob sql.Blob
+	if err := LoadBlob(ctx, db, id.Bytes(), &blob); err != nil {
+		return types.PoetProofRef{}, fmt.Errorf("getting blob for %s: %w", id, err)
+	}
+
+	// TODO: decide about version based on publish epoch
+	var atx wire.ActivationTxV1
+	if err := codec.Decode(blob.Bytes, &atx); err != nil {
+		return types.PoetProofRef{}, fmt.Errorf("decoding ATX blob: %w", err)
+	}
+
+	return types.PoetProofRef(atx.NIPost.PostMetadata.Challenge), nil
+}


### PR DESCRIPTION
## Motivation

It avoids encoding the ATX again when putting into the new DB.

## Description

Also, pick poet proof used by an ATX from the DB (decoding from the blob) as a preparation to drop the `NIPoST` field from `types.ActivationTx`.

## Test Plan

updated tests

## TODO

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [ ] Update documentation as needed
- [ ] Update [changelog](../CHANGELOG.md) as needed
