### PR TITLE
[Merged by Bors] - Reduce logging level of downloaded malfeasant node IDs message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ See [RELEASE](./RELEASE.md) for workflow instructions.
 * [#5863](https://github.com/spacemeshos/go-spacemesh/pull/5863) Identity files are now created with 0600 permissions,
   to prevent other users on the same system to access the private keys.
 
+* [#5866](https://github.com/spacemeshos/go-spacemesh/pull/5866) Reduce logging levels of some messages to reduce noise.
+
 ### Highlights
 
 ### Features

--- a/syncer/malsync/syncer.go
+++ b/syncer/malsync/syncer.go
@@ -317,7 +317,7 @@ func (s *Syncer) downloadNodeIDs(ctx context.Context, initial bool, updates chan
 					)
 					return nil
 				}
-				s.logger.Info("downloaded malfeasant node IDs",
+				s.logger.Debug("downloaded malfeasant node IDs",
 					log.ZContext(ctx),
 					zap.String("peer", peer.String()),
 					zap.Int("ids", len(malIDs)),


### PR DESCRIPTION
## Motivation

The message is printed multiple times and doesn't give more information than "everything's OK" to the average user. Reduced its logging level from info to debug.

## Description

Only changed logging level of one message.

## Test Plan

- n/a

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
