### PR TITLE
[Merged by Bors] - Remove `InnerActivationTx` from `types.ActivationTx`

### DIFF
--- a/activation/activation_test.go
+++ b/activation/activation_test.go
@@ -16,6 +16,7 @@ import (
 	"go.uber.org/mock/gomock"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest"
 	"go.uber.org/zap/zaptest/observer"
 	"golang.org/x/exp/maps"
 	"golang.org/x/sync/errgroup"
@@ -80,7 +81,11 @@ type testAtxBuilder struct {
 
 func newTestBuilder(tb testing.TB, numSigners int, opts ...BuilderOption) *testAtxBuilder {
 	observer, observedLogs := observer.New(zapcore.DebugLevel)
-	logger := zap.New(observer)
+	logger := zaptest.NewLogger(tb, zaptest.WrapOptions(zap.WrapCore(
+		func(core zapcore.Core) zapcore.Core {
+			return zapcore.NewTee(core, observer)
+		},
+	)))
 
 	ctrl := gomock.NewController(tb)
 	tab := &testAtxBuilder{

--- a/activation/activation_test.go
+++ b/activation/activation_test.go
@@ -51,18 +51,6 @@ func TestMain(m *testing.M) {
 
 // ========== Helper functions ==========
 
-func newAtx(
-	challenge types.NIPostChallenge,
-	numUnits uint32,
-	coinbase types.Address,
-) *types.ActivationTx {
-	atx := types.NewActivationTx(challenge, coinbase, numUnits, nil)
-	atx.SetEffectiveNumUnits(numUnits)
-	atx.SetReceived(time.Now())
-	atx.SetValidity(types.Valid)
-	return atx
-}
-
 type testAtxBuilder struct {
 	*Builder
 	db          sql.Executor

--- a/activation/activation_test.go
+++ b/activation/activation_test.go
@@ -338,7 +338,7 @@ func TestBuilder_PublishActivationTx_HappyFlow(t *testing.T) {
 
 	// create and publish ATX
 	tab.mclock.EXPECT().CurrentLayer().Return(currLayer).Times(4)
-	tab.mValidator.EXPECT().VerifyChain(gomock.Any(), sig.NodeID(), tab.goldenATXID, gomock.Any())
+	tab.mValidator.EXPECT().VerifyChain(gomock.Any(), prevAtx.ID(), tab.goldenATXID, gomock.Any())
 	atx1, err := publishAtx(t, tab, sig.NodeID(), posEpoch, &currLayer, layersPerEpoch)
 	require.NoError(t, err)
 	require.NotNil(t, atx1)
@@ -346,7 +346,7 @@ func TestBuilder_PublishActivationTx_HappyFlow(t *testing.T) {
 	// create and publish another ATX
 	currLayer = (posEpoch + 1).FirstLayer()
 	tab.mclock.EXPECT().CurrentLayer().Return(currLayer).Times(4)
-	tab.mValidator.EXPECT().VerifyChain(gomock.Any(), sig.NodeID(), tab.goldenATXID, gomock.Any())
+	tab.mValidator.EXPECT().VerifyChain(gomock.Any(), prevAtx.ID(), tab.goldenATXID, gomock.Any())
 	atx2, err := publishAtx(t, tab, sig.NodeID(), atx1.PublishEpoch, &currLayer, layersPerEpoch)
 	require.NoError(t, err)
 	require.NotNil(t, atx2)
@@ -627,7 +627,7 @@ func TestBuilder_PublishActivationTx_RebuildNIPostWhenTargetEpochPassed(t *testi
 	require.NoError(t, atxs.Add(tab.db, toVerifiedAtx(t, posAtx)))
 	tab.mclock.EXPECT().CurrentLayer().DoAndReturn(func() types.LayerID { return currLayer }).AnyTimes()
 	tab.mnipost.EXPECT().ResetState(sig.NodeID()).Return(nil)
-	tab.mValidator.EXPECT().VerifyChain(gomock.Any(), sig.NodeID(), tab.goldenATXID, gomock.Any())
+	tab.mValidator.EXPECT().VerifyChain(gomock.Any(), posAtx.ID(), tab.goldenATXID, gomock.Any())
 	built2, err := publishAtx(t, tab, sig.NodeID(), posEpoch, &currLayer, layersPerEpoch)
 	require.NoError(t, err)
 	require.NotNil(t, built2)

--- a/activation/handler_test.go
+++ b/activation/handler_test.go
@@ -106,7 +106,7 @@ func newNIPosV1tWithPoet(t testing.TB, poetRef []byte) *wire.NIPostV1 {
 	}
 }
 
-func toVerifiedAtx(t *testing.T, watx *wire.ActivationTxV1) *types.VerifiedActivationTx {
+func toVerifiedAtx(t testing.TB, watx *wire.ActivationTxV1) *types.VerifiedActivationTx {
 	t.Helper()
 	atx := wire.ActivationTxFromWireV1(watx)
 	atx.SetEffectiveNumUnits(watx.NumUnits)

--- a/activation/validation.go
+++ b/activation/validation.go
@@ -365,18 +365,43 @@ func (v *Validator) VerifyChain(ctx context.Context, id, goldenATXID types.ATXID
 	return v.verifyChainWithOpts(ctx, id, goldenATXID, options)
 }
 
-func (v *Validator) getNipost(ctx context.Context, id types.ATXID) (*types.NIPost, error) {
+type atxDeps struct {
+	nipost      types.NIPost
+	positioning types.ATXID
+	previous    types.ATXID
+	commitment  types.ATXID
+}
+
+func (v *Validator) getAtxDeps(ctx context.Context, db sql.Executor, id types.ATXID) (*atxDeps, error) {
 	var blob sql.Blob
 	if err := atxs.LoadBlob(ctx, v.db, id.Bytes(), &blob); err != nil {
 		return nil, fmt.Errorf("getting blob for %s: %w", id, err)
 	}
 
-	// TODO: decide about version based on publish epoch
+	// TODO: decide about version based on `version` column
 	var atx wire.ActivationTxV1
 	if err := codec.Decode(blob.Bytes, &atx); err != nil {
 		return nil, fmt.Errorf("decoding ATX blob: %w", err)
 	}
-	return wire.NiPostFromWireV1(atx.NIPost), nil
+	var commitment types.ATXID
+	if atx.CommitmentATXID != nil {
+		commitment = *atx.CommitmentATXID
+	} else {
+		catx, err := atxs.CommitmentATX(v.db, atx.SmesherID)
+		if err != nil {
+			return nil, fmt.Errorf("getting commitment ATX: %w", err)
+		}
+		commitment = catx
+	}
+
+	deps := &atxDeps{
+		nipost:      *wire.NiPostFromWireV1(atx.NIPost),
+		positioning: atx.PositioningATXID,
+		previous:    atx.PrevATXID,
+		commitment:  commitment,
+	}
+
+	return deps, nil
 }
 
 func (v *Validator) verifyChainWithOpts(
@@ -412,24 +437,16 @@ func (v *Validator) verifyChainWithOpts(
 	}
 
 	// validate POST fully
-	commitmentAtxId := atx.CommitmentATX
-	if commitmentAtxId == nil {
-		if atxId, err := atxs.CommitmentATX(v.db, atx.SmesherID); err != nil {
-			return fmt.Errorf("getting commitment atx: %w", err)
-		} else {
-			commitmentAtxId = &atxId
-		}
-	}
-	nipost, err := v.getNipost(ctx, id)
+	deps, err := v.getAtxDeps(ctx, v.db, id)
 	if err != nil {
-		return fmt.Errorf("getting NIPost for ATX %s: %w", id, err)
+		return fmt.Errorf("getting ATX dependencies: %w", err)
 	}
 	if err := v.Post(
 		ctx,
 		atx.SmesherID,
-		*commitmentAtxId,
-		nipost.Post,
-		nipost.PostMetadata,
+		deps.commitment,
+		deps.nipost.Post,
+		deps.nipost.PostMetadata,
 		atx.NumUnits,
 	); err != nil {
 		if err := atxs.SetValidity(v.db, id, types.Invalid); err != nil {
@@ -438,7 +455,7 @@ func (v *Validator) verifyChainWithOpts(
 		return &InvalidChainError{ID: id, src: err}
 	}
 
-	err = v.verifyChainDeps(ctx, atx.ActivationTx, goldenATXID, opts)
+	err = v.verifyChainDeps(ctx, deps, goldenATXID, opts)
 	invalidChain := &InvalidChainError{}
 	switch {
 	case err == nil:
@@ -455,23 +472,25 @@ func (v *Validator) verifyChainWithOpts(
 
 func (v *Validator) verifyChainDeps(
 	ctx context.Context,
-	atx *types.ActivationTx,
+	deps *atxDeps,
 	goldenATXID types.ATXID,
 	opts verifyChainOpts,
 ) error {
-	if atx.PrevATXID != types.EmptyATXID {
-		if err := v.verifyChainWithOpts(ctx, atx.PrevATXID, goldenATXID, opts); err != nil {
-			return fmt.Errorf("validating previous ATX %s chain: %w", atx.PrevATXID.ShortString(), err)
+	if deps.previous != types.EmptyATXID {
+		if err := v.verifyChainWithOpts(ctx, deps.previous, goldenATXID, opts); err != nil {
+			return fmt.Errorf("validating previous ATX %s chain: %w", deps.previous.ShortString(), err)
 		}
 	}
-	if atx.PositioningATX != goldenATXID {
-		if err := v.verifyChainWithOpts(ctx, atx.PositioningATX, goldenATXID, opts); err != nil {
-			return fmt.Errorf("validating positioning ATX %s chain: %w", atx.PositioningATX.ShortString(), err)
+	if deps.positioning != goldenATXID {
+		if err := v.verifyChainWithOpts(ctx, deps.positioning, goldenATXID, opts); err != nil {
+			return fmt.Errorf("validating positioning ATX %s chain: %w", deps.positioning.ShortString(), err)
 		}
 	}
-	if atx.CommitmentATX != nil && *atx.CommitmentATX != goldenATXID {
-		if err := v.verifyChainWithOpts(ctx, *atx.CommitmentATX, goldenATXID, opts); err != nil {
-			return fmt.Errorf("validating commitment ATX %s chain: %w", atx.CommitmentATX.ShortString(), err)
+	// verify commitment only if arrived at the first ATX in the chain
+	// to avoid verifying the same commitment ATX multiple times.
+	if deps.previous == types.EmptyATXID && deps.commitment != goldenATXID {
+		if err := v.verifyChainWithOpts(ctx, deps.commitment, goldenATXID, opts); err != nil {
+			return fmt.Errorf("validating commitment ATX %s chain: %w", deps.commitment.ShortString(), err)
 		}
 	}
 	return nil

--- a/activation/wire/wire_v1.go
+++ b/activation/wire/wire_v1.go
@@ -2,7 +2,6 @@ package wire
 
 import (
 	"encoding/hex"
-	"fmt"
 
 	"github.com/spacemeshos/go-spacemesh/codec"
 	"github.com/spacemeshos/go-spacemesh/common/types"
@@ -165,18 +164,6 @@ func ActivationTxToWireV1(a *types.ActivationTx) *ActivationTxV1 {
 		SmesherID: a.SmesherID,
 		Signature: a.Signature,
 	}
-}
-
-// Decode ActivationTx from bytes.
-// In future it should decide which version of ActivationTx to decode based on the publish epoch.
-func ActivationTxFromBytes(data []byte) (*types.ActivationTx, error) {
-	var wireAtx ActivationTxV1
-	err := codec.Decode(data, &wireAtx)
-	if err != nil {
-		return nil, fmt.Errorf("decoding ATX: %w", err)
-	}
-
-	return ActivationTxFromWireV1(&wireAtx, data...), nil
 }
 
 func ActivationTxFromWireV1(atx *ActivationTxV1, blob ...byte) *types.ActivationTx {

--- a/activation/wire/wire_v1.go
+++ b/activation/wire/wire_v1.go
@@ -152,10 +152,15 @@ func NIPostChallengeToWireV1(c *types.NIPostChallenge) *NIPostChallengeV1 {
 func ActivationTxToWireV1(a *types.ActivationTx) *ActivationTxV1 {
 	return &ActivationTxV1{
 		InnerActivationTxV1: InnerActivationTxV1{
-			NIPostChallengeV1: *NIPostChallengeToWireV1(&a.NIPostChallenge),
-			Coinbase:          a.Coinbase,
-			NumUnits:          a.NumUnits,
-			VRFNonce:          (*uint64)(a.VRFNonce),
+			NIPostChallengeV1: NIPostChallengeV1{
+				PublishEpoch:    a.PublishEpoch,
+				Sequence:        a.Sequence,
+				PrevATXID:       a.PrevATXID,
+				CommitmentATXID: a.CommitmentATX,
+			},
+			Coinbase: a.Coinbase,
+			NumUnits: a.NumUnits,
+			VRFNonce: (*uint64)(a.VRFNonce),
 		},
 		SmesherID: a.SmesherID,
 		Signature: a.Signature,
@@ -176,21 +181,15 @@ func ActivationTxFromBytes(data []byte) (*types.ActivationTx, error) {
 
 func ActivationTxFromWireV1(atx *ActivationTxV1, blob ...byte) *types.ActivationTx {
 	result := &types.ActivationTx{
-		InnerActivationTx: types.InnerActivationTx{
-			NIPostChallenge: types.NIPostChallenge{
-				PublishEpoch:   atx.PublishEpoch,
-				Sequence:       atx.Sequence,
-				PrevATXID:      atx.PrevATXID,
-				PositioningATX: atx.PositioningATXID,
-				CommitmentATX:  atx.CommitmentATXID,
-				InitialPost:    PostFromWireV1(atx.InitialPost),
-			},
-			Coinbase: atx.Coinbase,
-			NumUnits: atx.NumUnits,
-			VRFNonce: (*types.VRFPostIndex)(atx.VRFNonce),
-		},
-		SmesherID: atx.SmesherID,
-		Signature: atx.Signature,
+		PublishEpoch:  atx.PublishEpoch,
+		Sequence:      atx.Sequence,
+		PrevATXID:     atx.PrevATXID,
+		CommitmentATX: atx.CommitmentATXID,
+		Coinbase:      atx.Coinbase,
+		NumUnits:      atx.NumUnits,
+		VRFNonce:      (*types.VRFPostIndex)(atx.VRFNonce),
+		SmesherID:     atx.SmesherID,
+		Signature:     atx.Signature,
 		AtxBlob: types.AtxBlob{
 			Version: types.AtxV1,
 			Blob:    blob,

--- a/api/grpcserver/activation_service_test.go
+++ b/api/grpcserver/activation_service_test.go
@@ -45,16 +45,11 @@ func Test_Highest_ReturnsMaxTickHeight(t *testing.T) {
 
 	atx := types.VerifiedActivationTx{
 		ActivationTx: &types.ActivationTx{
-			InnerActivationTx: types.InnerActivationTx{
-				NIPostChallenge: types.NIPostChallenge{
-					Sequence:       rand.Uint64(),
-					PrevATXID:      types.RandomATXID(),
-					PublishEpoch:   0,
-					PositioningATX: types.RandomATXID(),
-				},
-				Coinbase: types.GenerateAddress(types.RandomBytes(32)),
-				NumUnits: rand.Uint32(),
-			},
+			Sequence:     rand.Uint64(),
+			PrevATXID:    types.RandomATXID(),
+			PublishEpoch: 0,
+			Coinbase:     types.GenerateAddress(types.RandomBytes(32)),
+			NumUnits:     rand.Uint32(),
 		},
 	}
 	id := types.RandomATXID()
@@ -117,16 +112,11 @@ func TestGet_HappyPath(t *testing.T) {
 	id := types.RandomATXID()
 	atx := types.VerifiedActivationTx{
 		ActivationTx: &types.ActivationTx{
-			InnerActivationTx: types.InnerActivationTx{
-				NIPostChallenge: types.NIPostChallenge{
-					Sequence:       rand.Uint64(),
-					PrevATXID:      types.RandomATXID(),
-					PublishEpoch:   0,
-					PositioningATX: types.RandomATXID(),
-				},
-				Coinbase: types.GenerateAddress(types.RandomBytes(32)),
-				NumUnits: rand.Uint32(),
-			},
+			Sequence:     rand.Uint64(),
+			PrevATXID:    types.RandomATXID(),
+			PublishEpoch: 0,
+			Coinbase:     types.GenerateAddress(types.RandomBytes(32)),
+			NumUnits:     rand.Uint32(),
 		},
 	}
 	atx.SetID(id)
@@ -155,17 +145,12 @@ func TestGet_IdentityCanceled(t *testing.T) {
 	id := types.RandomATXID()
 	atx := types.VerifiedActivationTx{
 		ActivationTx: &types.ActivationTx{
-			InnerActivationTx: types.InnerActivationTx{
-				NIPostChallenge: types.NIPostChallenge{
-					Sequence:       rand.Uint64(),
-					PrevATXID:      types.RandomATXID(),
-					PublishEpoch:   0,
-					PositioningATX: types.RandomATXID(),
-				},
-				Coinbase: types.GenerateAddress(types.RandomBytes(32)),
-				NumUnits: rand.Uint32(),
-			},
-			SmesherID: smesher,
+			Sequence:     rand.Uint64(),
+			PrevATXID:    types.RandomATXID(),
+			PublishEpoch: 0,
+			Coinbase:     types.GenerateAddress(types.RandomBytes(32)),
+			NumUnits:     rand.Uint32(),
+			SmesherID:    smesher,
 		},
 	}
 	atx.SetID(id)

--- a/api/grpcserver/admin_service_test.go
+++ b/api/grpcserver/admin_service_test.go
@@ -21,15 +21,11 @@ const snapshot uint32 = 15
 
 func newAtx(tb testing.TB, db *sql.Database) {
 	atx := &types.ActivationTx{
-		InnerActivationTx: types.InnerActivationTx{
-			NIPostChallenge: types.NIPostChallenge{
-				PublishEpoch:  types.EpochID(2),
-				Sequence:      0,
-				CommitmentATX: &types.ATXID{1},
-			},
-			NumUnits: 2,
-			Coinbase: types.Address{1, 2, 3},
-		},
+		PublishEpoch:  types.EpochID(2),
+		Sequence:      0,
+		CommitmentATX: &types.ATXID{1},
+		NumUnits:      2,
+		Coinbase:      types.Address{1, 2, 3},
 	}
 	atx.SetID(types.RandomATXID())
 	vrfNonce := types.VRFPostIndex(11)

--- a/api/grpcserver/grpcserver_test.go
+++ b/api/grpcserver/grpcserver_test.go
@@ -2475,12 +2475,10 @@ func TestVMAccountUpdates(t *testing.T) {
 func createAtxs(tb testing.TB, epoch types.EpochID, atxids []types.ATXID) []*types.VerifiedActivationTx {
 	all := make([]*types.VerifiedActivationTx, 0, len(atxids))
 	for _, id := range atxids {
-		atx := &types.ActivationTx{InnerActivationTx: types.InnerActivationTx{
-			NIPostChallenge: types.NIPostChallenge{
-				PublishEpoch: epoch,
-			},
-			NumUnits: 1,
-		}}
+		atx := &types.ActivationTx{
+			PublishEpoch: epoch,
+			NumUnits:     1,
+		}
 		atx.SetID(id)
 		atx.SetEffectiveNumUnits(atx.NumUnits)
 		atx.SetReceived(time.Now())

--- a/api/grpcserver/v2alpha1/activation.go
+++ b/api/grpcserver/v2alpha1/activation.go
@@ -100,7 +100,7 @@ func (s *ActivationStreamService) Stream(
 	for {
 		select {
 		case rst := <-eventsOut:
-			err = stream.Send(&spacemeshv2alpha1.Activation{
+			err := stream.Send(&spacemeshv2alpha1.Activation{
 				Versioned: &spacemeshv2alpha1.Activation_V1{V1: toAtx(rst.VerifiedActivationTx)},
 			})
 			switch {
@@ -112,7 +112,7 @@ func (s *ActivationStreamService) Stream(
 		default:
 			select {
 			case rst := <-eventsOut:
-				err = stream.Send(&spacemeshv2alpha1.Activation{
+				err := stream.Send(&spacemeshv2alpha1.Activation{
 					Versioned: &spacemeshv2alpha1.Activation_V1{V1: toAtx(rst.VerifiedActivationTx)},
 				})
 				switch {
@@ -199,10 +199,9 @@ func (s *ActivationService) List(
 	case request.Limit == 0:
 		return nil, status.Error(codes.InvalidArgument, "limit must be set to <= 100")
 	}
-
 	rst := make([]*spacemeshv2alpha1.Activation, 0, request.Limit)
-	if err := atxs.IterateAtxsOps(s.db, ops, func(vatx *types.VerifiedActivationTx) bool {
-		rst = append(rst, &spacemeshv2alpha1.Activation{Versioned: &spacemeshv2alpha1.Activation_V1{V1: toAtx(vatx)}})
+	if err := atxs.IterateAtxsOps(s.db, ops, func(atx *types.VerifiedActivationTx) bool {
+		rst = append(rst, &spacemeshv2alpha1.Activation{Versioned: &spacemeshv2alpha1.Activation_V1{V1: toAtx(atx)}})
 		return true
 	}); err != nil {
 		return nil, status.Error(codes.Internal, err.Error())

--- a/api/grpcserver/v2alpha1/activation_test.go
+++ b/api/grpcserver/v2alpha1/activation_test.go
@@ -28,8 +28,9 @@ func TestActivationService_List(t *testing.T) {
 	activations := make([]types.VerifiedActivationTx, 100)
 	for i := range activations {
 		atx := gen.Next()
-		require.NoError(t, atxs.Add(db, atx))
-		activations[i] = *atx
+		vAtx := fixture.ToVerifiedAtx(t, atx)
+		require.NoError(t, atxs.Add(db, vAtx))
+		activations[i] = *vAtx
 	}
 
 	svc := NewActivationService(db)
@@ -110,8 +111,9 @@ func TestActivationStreamService_Stream(t *testing.T) {
 	activations := make([]types.VerifiedActivationTx, 100)
 	for i := range activations {
 		atx := gen.Next()
-		require.NoError(t, atxs.Add(db, atx))
-		activations[i] = *atx
+		vAtx := fixture.ToVerifiedAtx(t, atx)
+		require.NoError(t, atxs.Add(db, vAtx))
+		activations[i] = *vAtx
 	}
 
 	svc := NewActivationStreamService(db)
@@ -151,7 +153,9 @@ func TestActivationStreamService_Stream(t *testing.T) {
 		gen = fixture.NewAtxsGenerator().WithEpochs(start, 10)
 		var streamed []*events.ActivationTx
 		for i := 0; i < n; i++ {
-			streamed = append(streamed, &events.ActivationTx{VerifiedActivationTx: gen.Next()})
+			vatx := fixture.ToVerifiedAtx(t, gen.Next())
+			require.NoError(t, atxs.Add(db, vatx))
+			streamed = append(streamed, &events.ActivationTx{VerifiedActivationTx: vatx})
 		}
 
 		for _, tc := range []struct {
@@ -201,7 +205,9 @@ func TestActivationStreamService_Stream(t *testing.T) {
 				for _, rst := range expect {
 					received, err := stream.Recv()
 					require.NoError(t, err)
-					require.Equal(t, toAtx(rst).String(), received.GetV1().String())
+					atx, err := toAtx(context.Background(), db, rst)
+					require.NoError(t, err)
+					require.Equal(t, atx.String(), received.GetV1().String())
 				}
 			})
 		}
@@ -216,8 +222,9 @@ func TestActivationService_ActivationsCount(t *testing.T) {
 	epoch3ATXs := make([]types.VerifiedActivationTx, 30)
 	for i := range epoch3ATXs {
 		atx := genEpoch3.Next()
-		require.NoError(t, atxs.Add(db, atx))
-		epoch3ATXs[i] = *atx
+		vatx := fixture.ToVerifiedAtx(t, atx)
+		require.NoError(t, atxs.Add(db, vatx))
+		epoch3ATXs[i] = *vatx
 	}
 
 	genEpoch5 := fixture.NewAtxsGenerator().WithSeed(time.Now().UnixNano()+1).
@@ -225,8 +232,9 @@ func TestActivationService_ActivationsCount(t *testing.T) {
 	epoch5ATXs := make([]types.VerifiedActivationTx, 10) // ensure the number here is different from above
 	for i := range epoch5ATXs {
 		atx := genEpoch5.Next()
-		require.NoError(t, atxs.Add(db, atx))
-		epoch5ATXs[i] = *atx
+		vatx := fixture.ToVerifiedAtx(t, atx)
+		require.NoError(t, atxs.Add(db, vatx))
+		epoch5ATXs[i] = *vatx
 	}
 
 	svc := NewActivationService(db)

--- a/api/grpcserver/v2alpha1/activation_test.go
+++ b/api/grpcserver/v2alpha1/activation_test.go
@@ -205,9 +205,7 @@ func TestActivationStreamService_Stream(t *testing.T) {
 				for _, rst := range expect {
 					received, err := stream.Recv()
 					require.NoError(t, err)
-					atx, err := toAtx(context.Background(), db, rst)
-					require.NoError(t, err)
-					require.Equal(t, atx.String(), received.GetV1().String())
+					require.Equal(t, toAtx(rst).String(), received.GetV1().String())
 				}
 			})
 		}

--- a/checkpoint/recovery.go
+++ b/checkpoint/recovery.go
@@ -233,7 +233,7 @@ func recoverFromLocalFile(
 	})
 	allProofs := make([]*types.PoetProofMessage, 0, len(proofs))
 	for _, dep := range allDeps {
-		poetProofRef, err := atxs.PoetProofRef(context.Background(), db, dep.ID)
+		poetProofRef, err := poetProofRef(context.Background(), db, dep.ID)
 		if err != nil {
 			return nil, fmt.Errorf("get poet proof ref (%v): %w", dep.ID, err)
 		}
@@ -480,7 +480,7 @@ func collect(
 		return err
 	}
 
-	posAtx, err := atxs.PositioningATX(context.Background(), db, ref)
+	posAtx, err := positioningATX(context.Background(), db, ref)
 	if err != nil {
 		return fmt.Errorf("get positioning atx for atx %v: %w", ref, err)
 	}
@@ -508,7 +508,7 @@ func poetProofs(
 ) (map[types.PoetProofRef]*types.PoetProofMessage, error) {
 	proofs := make(map[types.PoetProofRef]*types.PoetProofMessage, len(atxIds))
 	for atx := range atxIds {
-		ref, err := atxs.PoetProofRef(context.Background(), db, atx)
+		ref, err := poetProofRef(context.Background(), db, atx)
 		if err != nil {
 			return nil, fmt.Errorf("get poet proof ref: %w", err)
 		}

--- a/checkpoint/recovery.go
+++ b/checkpoint/recovery.go
@@ -479,7 +479,12 @@ func collect(
 	if err = collect(db, atx.PrevATXID, all, deps); err != nil {
 		return err
 	}
-	if err = collect(db, atx.PositioningATX, all, deps); err != nil {
+
+	posAtx, err := atxs.PositioningATX(context.Background(), db, ref)
+	if err != nil {
+		return fmt.Errorf("get positioning atx for atx %v: %w", ref, err)
+	}
+	if err = collect(db, posAtx, all, deps); err != nil {
 		return err
 	}
 	var blob sql.Blob

--- a/checkpoint/recovery_test.go
+++ b/checkpoint/recovery_test.go
@@ -260,7 +260,7 @@ func validateAndPreserveData(
 		mclock.EXPECT().CurrentLayer().Return(vatx.PublishEpoch.FirstLayer())
 		mfetch.EXPECT().RegisterPeerHashes(gomock.Any(), gomock.Any())
 		mfetch.EXPECT().GetPoetProof(gomock.Any(), gomock.Any())
-		if vatx.InitialPost != nil {
+		if vatx.PrevATXID == types.EmptyATXID {
 			mvalidator.EXPECT().
 				InitialNIPostChallengeV1(&atx.NIPostChallengeV1, gomock.Any(), goldenAtx).
 				AnyTimes()
@@ -268,7 +268,7 @@ func validateAndPreserveData(
 				gomock.Any(),
 				vatx.SmesherID,
 				*vatx.CommitmentATX,
-				vatx.InitialPost,
+				wire.PostFromWireV1(atx.InitialPost),
 				gomock.Any(),
 				vatx.NumUnits,
 				gomock.Any(),
@@ -284,7 +284,7 @@ func validateAndPreserveData(
 			mvalidator.EXPECT().NIPostChallengeV1(&atx.NIPostChallengeV1, cdb, vatx.SmesherID)
 		}
 
-		mvalidator.EXPECT().PositioningAtx(vatx.PositioningATX, cdb, goldenAtx, vatx.PublishEpoch)
+		mvalidator.EXPECT().PositioningAtx(atx.PositioningATXID, cdb, goldenAtx, vatx.PublishEpoch)
 		mvalidator.EXPECT().
 			NIPost(gomock.Any(), vatx.SmesherID, gomock.Any(), gomock.Any(), gomock.Any(), vatx.NumUnits, gomock.Any()).
 			Return(uint64(1111111), nil)

--- a/checkpoint/runner_test.go
+++ b/checkpoint/runner_test.go
@@ -201,16 +201,12 @@ func newAtx(
 	nodeID types.NodeID,
 ) *types.ActivationTx {
 	atx := &types.ActivationTx{
-		InnerActivationTx: types.InnerActivationTx{
-			NIPostChallenge: types.NIPostChallenge{
-				PublishEpoch:  types.EpochID(epoch),
-				Sequence:      seq,
-				CommitmentATX: commitAtx,
-				PrevATXID:     prevID,
-			},
-			NumUnits: 2,
-			Coinbase: types.Address{1, 2, 3},
-		},
+		PublishEpoch:  types.EpochID(epoch),
+		Sequence:      seq,
+		CommitmentATX: commitAtx,
+		PrevATXID:     prevID,
+		NumUnits:      2,
+		Coinbase:      types.Address{1, 2, 3},
 	}
 	atx.SetID(id)
 	if vrfnonce != 0 {

--- a/cmd/bootstrapper/generator_test.go
+++ b/cmd/bootstrapper/generator_test.go
@@ -47,12 +47,10 @@ var bitcoinResponse2 string
 
 func createAtxs(tb testing.TB, db sql.Executor, epoch types.EpochID, atxids []types.ATXID) {
 	for _, id := range atxids {
-		atx := &types.ActivationTx{InnerActivationTx: types.InnerActivationTx{
-			NIPostChallenge: types.NIPostChallenge{
-				PublishEpoch: epoch,
-			},
-			NumUnits: 1,
-		}}
+		atx := &types.ActivationTx{
+			PublishEpoch: epoch,
+			NumUnits:     1,
+		}
 		atx.SetID(id)
 		atx.SetEffectiveNumUnits(atx.NumUnits)
 		atx.SetReceived(time.Now())

--- a/common/fixture/atxs.go
+++ b/common/fixture/atxs.go
@@ -2,8 +2,12 @@ package fixture
 
 import (
 	"math/rand"
+	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
+	"github.com/spacemeshos/go-spacemesh/activation/wire"
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/genvm/sdk/wallet"
 	"github.com/spacemeshos/go-spacemesh/signing"
@@ -41,42 +45,39 @@ func (g *AtxsGenerator) WithEpochs(start, n int) *AtxsGenerator {
 }
 
 // Next generates VerifiedActivationTx.
-func (g *AtxsGenerator) Next() *types.VerifiedActivationTx {
-	var atx types.VerifiedActivationTx
-
+func (g *AtxsGenerator) Next() *wire.ActivationTxV1 {
 	var prevAtxId types.ATXID
 	g.rng.Read(prevAtxId[:])
 	var posAtxId types.ATXID
 	g.rng.Read(posAtxId[:])
-	var nodeId types.NodeID
-	g.rng.Read(nodeId[:])
 
-	signer, err := signing.NewEdSigner()
+	signer, err := signing.NewEdSigner(signing.WithKeyFromRand(g.rng))
 	if err != nil {
 		panic("failed to create signer")
 	}
 
-	atx = types.VerifiedActivationTx{
-		ActivationTx: &types.ActivationTx{
-			InnerActivationTx: types.InnerActivationTx{
-				NIPostChallenge: types.NIPostChallenge{
-					Sequence:       g.rng.Uint64(),
-					PrevATXID:      prevAtxId,
-					PublishEpoch:   g.Epochs[g.rng.Intn(len(g.Epochs))],
-					PositioningATX: posAtxId,
-				},
-				Coinbase: wallet.Address(signer.PublicKey().Bytes()),
-				NumUnits: g.rng.Uint32(),
+	atx := &wire.ActivationTxV1{
+		InnerActivationTxV1: wire.InnerActivationTxV1{
+			NIPostChallengeV1: wire.NIPostChallengeV1{
+				Sequence:         g.rng.Uint64(),
+				PrevATXID:        prevAtxId,
+				PublishEpoch:     g.Epochs[g.rng.Intn(len(g.Epochs))],
+				PositioningATXID: posAtxId,
 			},
-			SmesherID: nodeId,
+			Coinbase: wallet.Address(signer.PublicKey().Bytes()),
+			NumUnits: g.rng.Uint32(),
 		},
 	}
+	atx.Sign(signer)
+	return atx
+}
 
-	atx.SetEffectiveNumUnits(atx.NumUnits)
-
-	var atxId types.ATXID
-	g.rng.Read(atxId[:])
-	atx.SetID(atxId)
-
-	return &atx
+func ToVerifiedAtx(t testing.TB, watx *wire.ActivationTxV1) *types.VerifiedActivationTx {
+	t.Helper()
+	atx := wire.ActivationTxFromWireV1(watx)
+	atx.SetEffectiveNumUnits(watx.NumUnits)
+	atx.SetReceived(time.Now())
+	vAtx, err := atx.Verify(0, 1)
+	require.NoError(t, err)
+	return vAtx
 }

--- a/common/types/verified_activation.go
+++ b/common/types/verified_activation.go
@@ -53,24 +53,7 @@ func (vatx *VerifiedActivationTx) ToHeader() *ActivationTxHeader {
 
 // MarshalLogObject implements logging interface.
 func (vatx *VerifiedActivationTx) MarshalLogObject(encoder log.ObjectEncoder) error {
-	encoder.AddString("atx_id", vatx.id.String())
-	// encoder.AddString("challenge", vatx.NIPostChallenge.Hash().String())
-	encoder.AddString("smesher", vatx.SmesherID.String())
-	encoder.AddString("prev_atx_id", vatx.PrevATXID.String())
-	encoder.AddString("pos_atx_id", vatx.PositioningATX.String())
-	if vatx.CommitmentATX != nil {
-		encoder.AddString("commitment_atx_id", vatx.CommitmentATX.String())
-	}
-	if vatx.VRFNonce != nil {
-		encoder.AddUint64("vrf_nonce", uint64(*vatx.VRFNonce))
-	}
-	encoder.AddString("coinbase", vatx.Coinbase.String())
-	encoder.AddUint32("epoch", vatx.PublishEpoch.Uint32())
-	encoder.AddUint64("num_units", uint64(vatx.NumUnits))
-	if vatx.effectiveNumUnits != 0 {
-		encoder.AddUint64("effective_num_units", uint64(vatx.effectiveNumUnits))
-	}
-	encoder.AddUint64("sequence_number", vatx.Sequence)
+	encoder.AddObject("atx", vatx.ActivationTx)
 	encoder.AddUint64("base_tick_height", vatx.baseTickHeight)
 	encoder.AddUint64("tick_count", vatx.tickCount)
 	encoder.AddUint64("weight", vatx.GetWeight())

--- a/datastore/store_test.go
+++ b/datastore/store_test.go
@@ -147,13 +147,9 @@ func TestBlobStore_GetATXBlob(t *testing.T) {
 	ctx := context.Background()
 
 	atx := &types.ActivationTx{
-		InnerActivationTx: types.InnerActivationTx{
-			NIPostChallenge: types.NIPostChallenge{
-				PublishEpoch: types.EpochID(22),
-				Sequence:     11,
-			},
-			NumUnits: 11,
-		},
+		PublishEpoch: types.EpochID(22),
+		Sequence:     11,
+		NumUnits:     11,
 	}
 	signer, err := signing.NewEdSigner()
 	require.NoError(t, err)

--- a/datastore/store_test.go
+++ b/datastore/store_test.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/spacemeshos/go-spacemesh/activation"
 	"github.com/spacemeshos/go-spacemesh/activation/wire"
 	"github.com/spacemeshos/go-spacemesh/codec"
+	"github.com/spacemeshos/go-spacemesh/common/fixture"
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/datastore"
 	"github.com/spacemeshos/go-spacemesh/log/logtest"
@@ -146,18 +146,19 @@ func TestBlobStore_GetATXBlob(t *testing.T) {
 	bs := datastore.NewBlobStore(db, store.New())
 	ctx := context.Background()
 
-	atx := &types.ActivationTx{
-		PublishEpoch: types.EpochID(22),
-		Sequence:     11,
-		NumUnits:     11,
+	atx := &wire.ActivationTxV1{
+		InnerActivationTxV1: wire.InnerActivationTxV1{
+			NIPostChallengeV1: wire.NIPostChallengeV1{
+				PublishEpoch: types.EpochID(22),
+				Sequence:     11,
+			},
+			NumUnits: 11,
+		},
 	}
 	signer, err := signing.NewEdSigner()
 	require.NoError(t, err)
-	require.NoError(t, activation.SignAndFinalizeAtx(signer, atx))
-	atx.SetEffectiveNumUnits(atx.NumUnits)
-	atx.SetReceived(time.Now())
-	vAtx, err := atx.Verify(0, 1)
-	require.NoError(t, err)
+	atx.Sign(signer)
+	vAtx := fixture.ToVerifiedAtx(t, atx)
 
 	has, err := bs.Has(datastore.ATXDB, atx.ID().Bytes())
 	require.NoError(t, err)
@@ -174,11 +175,10 @@ func TestBlobStore_GetATXBlob(t *testing.T) {
 	got, err := getBytes(ctx, bs, datastore.ATXDB, atx.ID())
 	require.NoError(t, err)
 
-	gotA, err := wire.ActivationTxFromBytes(got)
-	require.NoError(t, err)
-	gotA.SetEffectiveNumUnits(gotA.NumUnits)
-	gotA.SetReceived(atx.Received())
-	require.Equal(t, atx, gotA)
+	var gotA wire.ActivationTxV1
+	codec.MustDecode(got, &gotA)
+	require.Equal(t, atx.ID(), gotA.ID())
+	require.Equal(t, atx, &gotA)
 
 	_, err = getBytes(ctx, bs, datastore.BallotDB, atx.ID())
 	require.ErrorIs(t, err, datastore.ErrNotFound)

--- a/fetch/handler_test.go
+++ b/fetch/handler_test.go
@@ -265,14 +265,10 @@ func newAtx(t *testing.T, published types.EpochID) *types.VerifiedActivationTx {
 	t.Helper()
 	nonce := types.VRFPostIndex(123)
 	atx := &types.ActivationTx{
-		InnerActivationTx: types.InnerActivationTx{
-			NIPostChallenge: types.NIPostChallenge{
-				PublishEpoch: published,
-				PrevATXID:    types.RandomATXID(),
-			},
-			NumUnits: 2,
-			VRFNonce: &nonce,
-		},
+		PublishEpoch: published,
+		PrevATXID:    types.RandomATXID(),
+		NumUnits:     2,
+		VRFNonce:     &nonce,
 	}
 
 	signer, err := signing.NewEdSigner()

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/quic-go/quic-go v0.42.0
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/seehuhn/mt19937 v1.0.0
-	github.com/spacemeshos/api/release/go v1.37.0
+	github.com/spacemeshos/api/release/go v1.38.0
 	github.com/spacemeshos/economics v0.1.3
 	github.com/spacemeshos/fixed v0.1.1
 	github.com/spacemeshos/go-scale v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -557,6 +557,8 @@ github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIK
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
 github.com/spacemeshos/api/release/go v1.37.0 h1:bN6AhSMVSmAShGxUYKwFBfzY3U1XtHezpDjt20dHjBM=
 github.com/spacemeshos/api/release/go v1.37.0/go.mod h1:Ed7SdL2YgqNg2SeShEAonW3GTPuuaGzsY5i4bgziCRo=
+github.com/spacemeshos/api/release/go v1.38.0 h1:Mz9oCjTM+IDIaeirfRPyGQQietrlPXR9Ri61KrlDIVI=
+github.com/spacemeshos/api/release/go v1.38.0/go.mod h1:khlc+6+zDFlVaoAVLnBQoD/UqsPQ5Rrsrnb++NFR3gw=
 github.com/spacemeshos/economics v0.1.3 h1:ACkq3mTebIky4Zwbs9SeSSRZrUCjU/Zk0wq9Z0BTh2A=
 github.com/spacemeshos/economics v0.1.3/go.mod h1:FH7u0FzTIm6Kpk+X5HOZDvpkgNYBKclmH86rVwYaDAo=
 github.com/spacemeshos/fixed v0.1.1 h1:N1y4SUpq1EV+IdJrWJwUCt1oBFzeru/VKVcBsvPc2Fk=

--- a/go.sum
+++ b/go.sum
@@ -555,8 +555,6 @@ github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d/go.mod h1:Udh
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
-github.com/spacemeshos/api/release/go v1.37.0 h1:bN6AhSMVSmAShGxUYKwFBfzY3U1XtHezpDjt20dHjBM=
-github.com/spacemeshos/api/release/go v1.37.0/go.mod h1:Ed7SdL2YgqNg2SeShEAonW3GTPuuaGzsY5i4bgziCRo=
 github.com/spacemeshos/api/release/go v1.38.0 h1:Mz9oCjTM+IDIaeirfRPyGQQietrlPXR9Ri61KrlDIVI=
 github.com/spacemeshos/api/release/go v1.38.0/go.mod h1:khlc+6+zDFlVaoAVLnBQoD/UqsPQ5Rrsrnb++NFR3gw=
 github.com/spacemeshos/economics v0.1.3 h1:ACkq3mTebIky4Zwbs9SeSSRZrUCjU/Zk0wq9Z0BTh2A=

--- a/hare3/eligibility/oracle_test.go
+++ b/hare3/eligibility/oracle_test.go
@@ -141,12 +141,10 @@ func (t *testOracle) createActiveSet(
 	for i, id := range activeSet {
 		nodeID := types.BytesToNodeID([]byte(strconv.Itoa(i)))
 		miners = append(miners, nodeID)
-		atx := &types.ActivationTx{InnerActivationTx: types.InnerActivationTx{
-			NIPostChallenge: types.NIPostChallenge{
-				PublishEpoch: lid.GetEpoch(),
-			},
-			NumUnits: uint32(i + 1),
-		}}
+		atx := &types.ActivationTx{
+			PublishEpoch: lid.GetEpoch(),
+			NumUnits:     uint32(i + 1),
+		}
 		nonce := types.VRFPostIndex(0)
 		atx.VRFNonce = &nonce
 		atx.SetID(id)
@@ -375,12 +373,10 @@ func Test_VrfSignVerify(t *testing.T) {
 
 	numMiners := 2
 	activeSet := types.RandomActiveSet(numMiners)
-	atx1 := &types.ActivationTx{InnerActivationTx: types.InnerActivationTx{
-		NIPostChallenge: types.NIPostChallenge{
-			PublishEpoch: prevEpoch,
-		},
-		NumUnits: 1 * 1024,
-	}}
+	atx1 := &types.ActivationTx{
+		PublishEpoch: prevEpoch,
+		NumUnits:     1 * 1024,
+	}
 	nonce := types.VRFPostIndex(0)
 	atx1.VRFNonce = &nonce
 	atx1.SetID(activeSet[0])
@@ -394,12 +390,10 @@ func Test_VrfSignVerify(t *testing.T) {
 	signer2, err := signing.NewEdSigner(signing.WithKeyFromRand(rng))
 	require.NoError(t, err)
 
-	atx2 := &types.ActivationTx{InnerActivationTx: types.InnerActivationTx{
-		NIPostChallenge: types.NIPostChallenge{
-			PublishEpoch: prevEpoch,
-		},
-		NumUnits: 9 * 1024,
-	}}
+	atx2 := &types.ActivationTx{
+		PublishEpoch: prevEpoch,
+		NumUnits:     9 * 1024,
+	}
 	nonce = types.VRFPostIndex(0)
 	atx2.VRFNonce = &nonce
 	atx2.SetID(activeSet[1])
@@ -745,9 +739,7 @@ func TestActiveSetMatrix(t *testing.T) {
 		node types.NodeID,
 		option ...func(*types.VerifiedActivationTx),
 	) *types.VerifiedActivationTx {
-		atx := &types.ActivationTx{InnerActivationTx: types.InnerActivationTx{
-			NIPostChallenge: types.NIPostChallenge{},
-		}}
+		atx := &types.ActivationTx{}
 		atx.PublishEpoch = target - 1
 		atx.SmesherID = node
 		atx.SetID(id)

--- a/proposals/handler_test.go
+++ b/proposals/handler_test.go
@@ -236,12 +236,10 @@ func createProposal(t *testing.T, opts ...any) *types.Proposal {
 }
 
 func createAtx(t *testing.T, db *sql.Database, epoch types.EpochID, atxID types.ATXID, nodeID types.NodeID) {
-	atx := &types.ActivationTx{InnerActivationTx: types.InnerActivationTx{
-		NIPostChallenge: types.NIPostChallenge{
-			PublishEpoch: epoch,
-		},
-		NumUnits: 1,
-	}}
+	atx := &types.ActivationTx{
+		PublishEpoch: epoch,
+		NumUnits:     1,
+	}
 	atx.SetID(atxID)
 	atx.SetEffectiveNumUnits(1)
 	atx.SetReceived(time.Now())

--- a/sql/atxs/atxs.go
+++ b/sql/atxs/atxs.go
@@ -796,32 +796,3 @@ func IterateForGrading(
 	}
 	return nil
 }
-
-func PoetProofRef(ctx context.Context, db sql.Executor, id types.ATXID) (types.PoetProofRef, error) {
-	var blob sql.Blob
-	if err := LoadBlob(ctx, db, id.Bytes(), &blob); err != nil {
-		return types.PoetProofRef{}, fmt.Errorf("getting blob for %s: %w", id, err)
-	}
-
-	// TODO: decide about version based the `version` column in `atx_blobs`
-	var atx wire.ActivationTxV1
-	if err := codec.Decode(blob.Bytes, &atx); err != nil {
-		return types.PoetProofRef{}, fmt.Errorf("decoding ATX blob: %w", err)
-	}
-
-	return types.PoetProofRef(atx.NIPost.PostMetadata.Challenge), nil
-}
-
-func PositioningATX(ctx context.Context, db sql.Executor, id types.ATXID) (types.ATXID, error) {
-	var blob sql.Blob
-	if err := LoadBlob(ctx, db, id.Bytes(), &blob); err != nil {
-		return types.EmptyATXID, fmt.Errorf("get blob %s: %w", id, err)
-	}
-	// TODO: decide how to decode based on the `version` column
-	var atx wire.ActivationTxV1
-	if err := codec.Decode(blob.Bytes, &atx); err != nil {
-		return types.EmptyATXID, fmt.Errorf("decode %s: %w", id, err)
-	}
-
-	return atx.PositioningATXID, nil
-}

--- a/sql/atxs/atxs.go
+++ b/sql/atxs/atxs.go
@@ -811,3 +811,17 @@ func PoetProofRef(ctx context.Context, db sql.Executor, id types.ATXID) (types.P
 
 	return types.PoetProofRef(atx.NIPost.PostMetadata.Challenge), nil
 }
+
+func PositioningATX(ctx context.Context, db sql.Executor, id types.ATXID) (types.ATXID, error) {
+	var blob sql.Blob
+	if err := LoadBlob(ctx, db, id.Bytes(), &blob); err != nil {
+		return types.EmptyATXID, fmt.Errorf("get blob %s: %w", id, err)
+	}
+	// TODO: decide how to decode based on the `version` column
+	var atx wire.ActivationTxV1
+	if err := codec.Decode(blob.Bytes, &atx); err != nil {
+		return types.EmptyATXID, fmt.Errorf("decode %s: %w", id, err)
+	}
+
+	return atx.PositioningATXID, nil
+}

--- a/sql/atxs/atxs_test.go
+++ b/sql/atxs/atxs_test.go
@@ -791,14 +791,10 @@ func withPrevATXID(id types.ATXID) createAtxOpt {
 func newAtx(signer *signing.EdSigner, opts ...createAtxOpt) (*types.VerifiedActivationTx, error) {
 	nonce := types.VRFPostIndex(42)
 	atx := &types.ActivationTx{
-		InnerActivationTx: types.InnerActivationTx{
-			NIPostChallenge: types.NIPostChallenge{
-				PrevATXID: types.RandomATXID(),
-			},
-			Coinbase: types.Address{1, 2, 3},
-			NumUnits: 2,
-			VRFNonce: &nonce,
-		},
+		PrevATXID: types.RandomATXID(),
+		Coinbase:  types.Address{1, 2, 3},
+		NumUnits:  2,
+		VRFNonce:  &nonce,
 	}
 	for _, opt := range opts {
 		opt(atx)
@@ -819,13 +815,9 @@ type header struct {
 
 func createAtx(tb testing.TB, db *sql.Database, hdr header) (types.ATXID, *signing.EdSigner) {
 	full := &types.ActivationTx{
-		InnerActivationTx: types.InnerActivationTx{
-			NIPostChallenge: types.NIPostChallenge{
-				PublishEpoch: hdr.epoch,
-			},
-			Coinbase: hdr.coinbase,
-			NumUnits: 2,
-		},
+		PublishEpoch: hdr.epoch,
+		Coinbase:     hdr.coinbase,
+		NumUnits:     2,
 	}
 	sig, err := signing.NewEdSigner()
 	require.NoError(tb, err)
@@ -980,11 +972,7 @@ func TestLatest(t *testing.T) {
 			db := sql.InMemory()
 			for i, epoch := range tc.epochs {
 				full := &types.ActivationTx{
-					InnerActivationTx: types.InnerActivationTx{
-						NIPostChallenge: types.NIPostChallenge{
-							PublishEpoch: types.EpochID(epoch),
-						},
-					},
+					PublishEpoch: types.EpochID(epoch),
 				}
 				full.SetEffectiveNumUnits(1)
 				full.SetReceived(time.Now())

--- a/sql/ballots/ballots_test.go
+++ b/sql/ballots/ballots_test.go
@@ -166,13 +166,9 @@ func TestLayerBallotBySmesher(t *testing.T) {
 
 func newAtx(signer *signing.EdSigner, layerID types.LayerID) (*types.VerifiedActivationTx, error) {
 	atx := &types.ActivationTx{
-		InnerActivationTx: types.InnerActivationTx{
-			NIPostChallenge: types.NIPostChallenge{
-				PublishEpoch: layerID.GetEpoch(),
-				PrevATXID:    types.RandomATXID(),
-			},
-			NumUnits: 2,
-		},
+		PublishEpoch: layerID.GetEpoch(),
+		PrevATXID:    types.RandomATXID(),
+		NumUnits:     2,
 	}
 
 	nodeID := signer.NodeID()

--- a/sql/migrations/state_0017_migration_test.go
+++ b/sql/migrations/state_0017_migration_test.go
@@ -38,15 +38,11 @@ func addAtx(
 	opts ...addAtxOpt,
 ) types.ATXID {
 	atx := &types.ActivationTx{
-		InnerActivationTx: types.InnerActivationTx{
-			NIPostChallenge: types.NIPostChallenge{
-				PublishEpoch: epoch,
-				Sequence:     sequence,
-				PrevATXID:    types.EmptyATXID,
-			},
-			Coinbase: types.Address{1, 2, 3},
-			NumUnits: 2,
-		},
+		PublishEpoch: epoch,
+		Sequence:     sequence,
+		PrevATXID:    types.EmptyATXID,
+		Coinbase:     types.Address{1, 2, 3},
+		NumUnits:     2,
 	}
 	for _, opt := range opts {
 		opt(atx)

--- a/syncer/atxsync/atxsync_test.go
+++ b/syncer/atxsync/atxsync_test.go
@@ -18,12 +18,10 @@ import (
 )
 
 func atx(id types.ATXID) *types.VerifiedActivationTx {
-	atx := &types.ActivationTx{InnerActivationTx: types.InnerActivationTx{
-		NIPostChallenge: types.NIPostChallenge{
-			PublishEpoch: 1,
-		},
-		NumUnits: 1,
-	}}
+	atx := &types.ActivationTx{
+		PublishEpoch: 1,
+		NumUnits:     1,
+	}
 	atx.SetID(id)
 	atx.SetEffectiveNumUnits(1)
 	atx.SetReceived(time.Now())

--- a/systest/tests/distributed_post_verification_test.go
+++ b/systest/tests/distributed_post_verification_test.go
@@ -221,6 +221,7 @@ func TestPostMalfeasanceProof(t *testing.T) {
 			NIPostChallengeV1: *challenge,
 			Coinbase:          types.Address{1, 2, 3, 4},
 			NumUnits:          nipost.NumUnits,
+			NIPost:            wire.NiPostToWireV1(nipost.NIPost),
 			NodeID:            &nodeID,
 			VRFNonce:          (*uint64)(&nipost.VRFNonce),
 		},

--- a/tortoise/threshold_test.go
+++ b/tortoise/threshold_test.go
@@ -169,12 +169,10 @@ func TestReferenceHeight(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			cdb := datastore.NewCachedDB(sql.InMemory(), logtest.New(t))
 			for i, height := range tc.heights {
-				atx := &types.ActivationTx{InnerActivationTx: types.InnerActivationTx{
-					NIPostChallenge: types.NIPostChallenge{
-						PublishEpoch: types.EpochID(tc.epoch) - 1,
-					},
-					NumUnits: 2,
-				}}
+				atx := &types.ActivationTx{
+					PublishEpoch: types.EpochID(tc.epoch) - 1,
+					NumUnits:     2,
+				}
 				atx.SetID(types.ATXID{byte(i + 1)})
 				atx.SetEffectiveNumUnits(atx.NumUnits)
 				atx.SetReceived(time.Now())

--- a/tortoise/tortoise_test.go
+++ b/tortoise/tortoise_test.go
@@ -473,12 +473,10 @@ func TestComputeExpectedWeight(t *testing.T) {
 			)
 			for i, weight := range tc.totals {
 				eid := first + types.EpochID(i)
-				atx := &types.ActivationTx{InnerActivationTx: types.InnerActivationTx{
-					NIPostChallenge: types.NIPostChallenge{
-						PublishEpoch: eid - 1,
-					},
-					NumUnits: uint32(weight),
-				}}
+				atx := &types.ActivationTx{
+					PublishEpoch: eid - 1,
+					NumUnits:     uint32(weight),
+				}
 				id := types.RandomATXID()
 				atx.SetID(id)
 				atx.SetEffectiveNumUnits(atx.NumUnits)


### PR DESCRIPTION
## Motivation

Trimming `types.ActivationTx`  as preparation for ATX V2.

## Description

Removed `InnerActivationTx` from `types.ActivationTx`. Fields picked from the nipost challenge type:
- publish epoch
- previous ATX
- commitment ATX
- sequence

Fields left to be removed:
- [in blob] Signature - it's currently only used for
  * `v2alpha1` GRPC
  * double ATX malfeasance proof (atx Handler)
- [in blob] NumUnits (we should leave effectiveNumUnits only)
- [in atxs column] Sequence - I think it's only used in checkpoint, but it shouldn't be
- [in atxs column] CommitmentATX - used in checkpoint (collecting 

## Test Plan

Existing tests pass

## TODO

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [ ] Update documentation as needed
- [ ] Update [changelog](../CHANGELOG.md) as needed
