### PR TITLE
[Merged by Bors] - fix minor error handling bug

### DIFF
--- a/sql/ballots/ballots.go
+++ b/sql/ballots/ballots.go
@@ -140,7 +140,7 @@ func LayerNoMalicious(db sql.Executor, lid types.LayerID) (rst []*types.Ballot, 
 			id := types.BallotID{}
 			stmt.ColumnBytes(0, id[:])
 			var ballot types.Ballot
-			_, derr := codec.DecodeFrom(stmt.ColumnReader(1), &ballot)
+			_, derr = codec.DecodeFrom(stmt.ColumnReader(1), &ballot)
 			if derr != nil {
 				return false
 			}


### PR DESCRIPTION
I ran [govanish](https://github.com/sivukhin/govanish) linter against `go-spacemash` repo and it found suspicious issue: compiler eliminated one err check in `LayerNoMalicious` function:
```
2024/04/23 22:14:21 it seems like your code vanished from compiled binary: func=[LayerNoMalicious], file=[/home/sivukhin/code/test-go-kek/go-spacemesh/sql/ballots/ballots.go], lines=[153-153], snippet:
	return nil, fmt.Errorf("decoding %d: %w", lid, err)
```

Indeed, this looks like a bug and anonymous function shouldn't shadow `derr` var and overwrite it instead.