### PR TITLE
[Merged by Bors] - Fix log caller in systest

### DIFF
--- a/systest/testcontext/context.go
+++ b/systest/testcontext/context.go
@@ -17,7 +17,6 @@ import (
 	chaos "github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
-	"go.uber.org/zap/zaptest"
 	"k8s.io/apimachinery/pkg/api/errors"
 	apimetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -335,6 +334,8 @@ func New(t *testing.T, opts ...Opt) *Context {
 		ns = "test-" + rngName()
 	}
 	clSize := clusterSize.Get(p)
+	logger, err := zap.NewDevelopment(zap.IncreaseLevel(logLevel), zap.AddCaller())
+	require.NoError(t, err)
 	cctx := &Context{
 		Context:           ctx,
 		Parameters:        p,
@@ -355,7 +356,7 @@ func New(t *testing.T, opts ...Opt) *Context {
 		PostServiceImage:  postServiceImage.Get(p),
 		PostInitImage:     postInitImage.Get(p),
 		NodeSelector:      nodeSelector.Get(p),
-		Log:               zaptest.NewLogger(t, zaptest.Level(logLevel)).Sugar().Named(t.Name()),
+		Log:               logger.Sugar().Named(t.Name()),
 	}
 	cctx.Storage.Class = class
 	cctx.Storage.Size = size


### PR DESCRIPTION
## Motivation

Previously, all logs showed `logger.go:146` to be the log caller.

## Description

The problem seems to be zaptest calling `t.Log` underneath that adds always the same logline: https://github.com/uber-go/zap/blob/fcf8ee58669e358bbd6460bef5c2ee7a53c0803a/zaptest/logger.go#L146.

Now, the log _caller_ is right. Additionally removed the weird indentation in front of "logger.go:146".
Before:
```
    logger.go:146: 2024-04-24T07:13:29.361Z     DEBUG   TestPostMalfeasanceProof        deploying nodes {"kind": "boot", "from": 0, "to": 1}
```
After:
```
2024-04-24T07:22:27.302Z        DEBUG   TestPostMalfeasanceProof        cluster/nodes.go:534    deploying nodes  {"kind": "boot", "from": 0, "to": 1}
```

## Test Plan

n/a

## TODO

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [ ] Update documentation as needed
- [ ] Update [changelog](../CHANGELOG.md) as needed
