### PR TITLE
[Merged by Bors] - Fix verifying ATX chain containing a checkpointed ATX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ See [RELEASE](./RELEASE.md) for workflow instructions.
 
 * [#5866](https://github.com/spacemeshos/go-spacemesh/pull/5866) Reduce logging levels of some messages to reduce noise.
 
+* [#5877](https://github.com/spacemeshos/go-spacemesh/pull/5877) Fix verifying ATX chain after checkpoint.
+
 ## (v1.5.0)
 
 ### Upgrade information

--- a/activation/validation.go
+++ b/activation/validation.go
@@ -389,6 +389,10 @@ func (v *Validator) verifyChainWithOpts(
 	if err != nil {
 		return fmt.Errorf("get atx: %w", err)
 	}
+	if atx.Golden() {
+		log.Debug("not verifying ATX chain", zap.Stringer("atx_id", id), zap.String("reason", "golden"))
+		return nil
+	}
 
 	switch {
 	case atx.Validity() == types.Valid:


### PR DESCRIPTION
## Motivation

All ATXs in the checkpoint are considered to be valid and don't require checking POST.

## Description

Because a checkpointed ATX doesn't have a blob in the database - it's not possible to obtain its PoST.

## Test Plan

Added a unit test for the fixed scenario.

## TODO

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [ ] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
