### PR TITLE
[Merged by Bors] - Switch to macos-13 for release builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
         os:
           - ubuntu-latest
           - [self-hosted, linux, arm64]
-          # - macos-12-large
+          - macos-13
           - [self-hosted, macOS, ARM64, go-spacemesh]
           - windows-latest
     steps:
@@ -174,7 +174,7 @@ jobs:
         os:
           - ubuntu-latest
           - [self-hosted, linux, arm64]
-          # - macos-12-large
+          - macos-13
           - [self-hosted, macOS, ARM64, go-spacemesh]
           - windows-latest
     steps:
@@ -218,7 +218,7 @@ jobs:
         os:
           - ubuntu-latest
           - [self-hosted, linux, arm64]
-          # - macos-12-large
+          - macos-13
           - [self-hosted, macOS, ARM64, go-spacemesh]
           - windows-latest
     steps:
@@ -231,7 +231,7 @@ jobs:
           sudo ethtool -K eth0 rx off
 
       - name: disable TCP/UDP offload - MacOS
-        if: ${{ matrix.os == 'macos-12-large' || matrix.os == '[self-hosted, macOS, ARM64, go-spacemesh]' }}
+        if: ${{ matrix.os == 'macos-13' || matrix.os == '[self-hosted, macOS, ARM64, go-spacemesh]' }}
         run: |
           sudo sysctl -w net.link.generic.system.hwcksum_tx=0
           sudo sysctl -w net.link.generic.system.hwcksum_rx=0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
             outname_sufix: "linux-amd64"
           - os: [self-hosted, linux, arm64]
             outname_sufix: "linux-arm64"
-          - os: macos-12-large
+          - os: macos-13
             outname_sufix: "mac-amd64"
           - os: [self-hosted, macOS, ARM64, go-spacemesh]
             outname_sufix: "mac-arm64"
@@ -95,7 +95,7 @@ jobs:
           destination: ${{ secrets.GCP_BUCKET }}/${{ github.ref_name }}/
 
       - name: Install coreutils
-        if: ${{ matrix.os == 'macos-12-large' || matrix.os == '[self-hosted, macOS, ARM64, go-spacemesh]' }}
+        if: ${{ matrix.os == 'macos-13' || matrix.os == '[self-hosted, macOS, ARM64, go-spacemesh]' }}
         run: brew install coreutils
 
       - name: Calculate the hashsum of the zip file

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ See [RELEASE](./RELEASE.md) for workflow instructions.
 
 ### Upgrade information
 
+With this release the minimum supported version for Intel Macs is now macOS 13 (Ventura) and for Apple Silicon Macs it
+is macOS 14 (Sonoma) or later ([#5879](https://github.com/spacemeshos/go-spacemesh/pull/5879)).
+
 ### Highlights
 
 ### Features


### PR DESCRIPTION
## Motivation

Recently Github updated `macos-latest` to arm64 this change makes sure our intel builds are actually executed on the right runner.

## Description

For releases `macos-12-large` was still used, although `macos-13` is already available (and actually not even the latest one). I also re-enabled macos builds. Before they have been disabled because `macos-12-large` was expensive to run, but `macos-13` is free.

## Test Plan

- existing tests pass on `macos-13` runner

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
