### PR TITLE
[Merged by Bors] - Added basic CORS support for JSONRPC server

### DIFF
--- a/api/grpcserver/config.go
+++ b/api/grpcserver/config.go
@@ -6,20 +6,21 @@ import (
 )
 
 type Config struct {
-	PublicServices  []Service
-	PublicListener  string `mapstructure:"grpc-public-listener"`
-	PrivateServices []Service
-	PrivateListener string `mapstructure:"grpc-private-listener"`
-	PostServices    []Service
-	PostListener    string    `mapstructure:"grpc-post-listener"`
-	TLSServices     []Service `mapstructure:"grpc-tls-services"`
-	TLSListener     string    `mapstructure:"grpc-tls-listener"`
-	TLSCACert       string    `mapstructure:"grpc-tls-ca-cert"`
-	TLSCert         string    `mapstructure:"grpc-tls-cert"`
-	TLSKey          string    `mapstructure:"grpc-tls-key"`
-	GrpcSendMsgSize int       `mapstructure:"grpc-send-msg-size"`
-	GrpcRecvMsgSize int       `mapstructure:"grpc-recv-msg-size"`
-	JSONListener    string    `mapstructure:"grpc-json-listener"`
+	PublicServices         []Service
+	PublicListener         string `mapstructure:"grpc-public-listener"`
+	PrivateServices        []Service
+	PrivateListener        string `mapstructure:"grpc-private-listener"`
+	PostServices           []Service
+	PostListener           string    `mapstructure:"grpc-post-listener"`
+	TLSServices            []Service `mapstructure:"grpc-tls-services"`
+	TLSListener            string    `mapstructure:"grpc-tls-listener"`
+	TLSCACert              string    `mapstructure:"grpc-tls-ca-cert"`
+	TLSCert                string    `mapstructure:"grpc-tls-cert"`
+	TLSKey                 string    `mapstructure:"grpc-tls-key"`
+	GrpcSendMsgSize        int       `mapstructure:"grpc-send-msg-size"`
+	GrpcRecvMsgSize        int       `mapstructure:"grpc-recv-msg-size"`
+	JSONListener           string    `mapstructure:"grpc-json-listener"`
+	JSONCorsAllowedOrigins []string  `mapstructure:"grpc-cors-allowed-origins"`
 
 	SmesherStreamInterval time.Duration `mapstructure:"smesherstreaminterval"`
 }
@@ -57,15 +58,16 @@ func DefaultConfig() Config {
 			Admin, Smesher, Debug, ActivationStreamV2Alpha1,
 			RewardStreamV2Alpha1,
 		},
-		PrivateListener:       "127.0.0.1:9093",
-		PostServices:          []Service{Post, PostInfo},
-		PostListener:          "127.0.0.1:0",
-		TLSServices:           []Service{Post, PostInfo},
-		TLSListener:           "",
-		JSONListener:          "",
-		GrpcSendMsgSize:       1024 * 1024 * 10,
-		GrpcRecvMsgSize:       1024 * 1024 * 10,
-		SmesherStreamInterval: time.Second,
+		PrivateListener:        "127.0.0.1:9093",
+		PostServices:           []Service{Post, PostInfo},
+		PostListener:           "127.0.0.1:0",
+		TLSServices:            []Service{Post, PostInfo},
+		TLSListener:            "",
+		JSONListener:           "",
+		JSONCorsAllowedOrigins: []string{""},
+		GrpcSendMsgSize:        1024 * 1024 * 10,
+		GrpcRecvMsgSize:        1024 * 1024 * 10,
+		SmesherStreamInterval:  time.Second,
 	}
 }
 

--- a/api/grpcserver/grpcserver_test.go
+++ b/api/grpcserver/grpcserver_test.go
@@ -448,7 +448,7 @@ func TestNewServersConfig(t *testing.T) {
 	require.NoError(t, err, "Should be able to establish a connection on a port")
 
 	grpcService := New(fmt.Sprintf(":%d", port1), zaptest.NewLogger(t).Named("grpc"), DefaultTestConfig())
-	jsonService := NewJSONHTTPServer(fmt.Sprintf(":%d", port2), zaptest.NewLogger(t).Named("grpc.JSON"))
+	jsonService := NewJSONHTTPServer(zaptest.NewLogger(t).Named("grpc.JSON"), fmt.Sprintf(":%d", port2), []string{})
 
 	require.Contains(t, grpcService.listener, strconv.Itoa(port1), "Expected same port")
 	require.Contains(t, jsonService.listener, strconv.Itoa(port2), "Expected same port")

--- a/api/grpcserver/http_server_test.go
+++ b/api/grpcserver/http_server_test.go
@@ -26,7 +26,7 @@ func launchJsonServer(tb testing.TB, services ...ServiceAPI) (Config, func()) {
 	cfg := DefaultTestConfig()
 
 	// run on random port
-	jsonService := NewJSONHTTPServer("127.0.0.1:0", zaptest.NewLogger(tb).Named("grpc.JSON"))
+	jsonService := NewJSONHTTPServer(zaptest.NewLogger(tb).Named("grpc.JSON"), "127.0.0.1:0", []string{})
 
 	// start json server
 	require.NoError(tb, jsonService.StartService(context.Background(), services...))

--- a/cmd/bootstrapper/generator_test.go
+++ b/cmd/bootstrapper/generator_test.go
@@ -66,7 +66,7 @@ func createAtxs(tb testing.TB, db sql.Executor, epoch types.EpochID, atxids []ty
 func launchServer(tb testing.TB, cdb *datastore.CachedDB) (grpcserver.Config, func()) {
 	cfg := grpcserver.DefaultTestConfig()
 	grpcService := grpcserver.New("127.0.0.1:0", zaptest.NewLogger(tb).Named("grpc"), cfg)
-	jsonService := grpcserver.NewJSONHTTPServer("127.0.0.1:0", zaptest.NewLogger(tb).Named("grpc.JSON"))
+	jsonService := grpcserver.NewJSONHTTPServer(zaptest.NewLogger(tb).Named("grpc.JSON"), "127.0.0.1:0", []string{})
 	s := grpcserver.NewMeshService(cdb, grpcserver.NewMockmeshAPI(gomock.NewController(tb)), nil, nil,
 		0, types.Hash20{}, 0, 0, 0)
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -178,6 +178,9 @@ func AddFlags(flagSet *pflag.FlagSet, cfg *config.Config) (configPath *string) {
 	flagSet.StringVar(&cfg.API.JSONListener, "grpc-json-listener",
 		cfg.API.JSONListener, "(Optional) endpoint to expose public grpc services via HTTP/JSON.")
 
+	flagSet.StringSliceVar(&cfg.API.JSONCorsAllowedOrigins, "grpc-cors-allowed-origin",
+		cfg.API.JSONCorsAllowedOrigins, "(Optional) CORS Allowed Origin, can be specified multiple times")
+
 	/**======================== Hare Eligibility Oracle Flags ========================== **/
 
 	flagSet.Uint32Var(&cfg.HareEligibility.ConfidenceParam, "eligibility-confidence-param",

--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/prometheus/client_model v0.6.1
 	github.com/prometheus/common v0.53.0
 	github.com/quic-go/quic-go v0.42.0
+	github.com/rs/cors v1.11.0
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/seehuhn/mt19937 v1.0.0
 	github.com/spacemeshos/api/release/go v1.37.0

--- a/go.sum
+++ b/go.sum
@@ -506,6 +506,8 @@ github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzG
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
+github.com/rs/cors v1.11.0 h1:0B9GE/r9Bc2UxRMMtymBkHTenPkHDv0CW4Y98GBY+po=
+github.com/rs/cors v1.11.0/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=

--- a/node/node.go
+++ b/node/node.go
@@ -1701,9 +1701,11 @@ func (app *App) startAPIServices(ctx context.Context) error {
 			return errors.New("start json server without public services")
 		}
 		app.jsonAPIServer = grpcserver.NewJSONHTTPServer(
-			app.Config.API.JSONListener,
 			logger.Zap().Named("JSON"),
+			app.Config.API.JSONListener,
+			app.Config.API.JSONCorsAllowedOrigins,
 		)
+
 		if err := app.jsonAPIServer.StartService(ctx, maps.Values(publicSvcs)...); err != nil {
 			return fmt.Errorf("start listen server: %w", err)
 		}


### PR DESCRIPTION
The light wallet will need CORS support to be defined. Added option to set CORS explicitly as an option. Defaults to NO cors enabled.

```
nj ~/workspace/go-spacemesh develop* $ curl -H "Origin: http://example.com" -I -X POST localhost:9999/spacemesh.v1.ActivationService/Highest
HTTP/1.1 200 OK
Access-Control-Allow-Origin: *
Content-Type: application/json
Vary: Origin
Date: Wed, 24 Apr 2024 19:16:00 GMT
Content-Length: 327

nj ~/workspace/go-spacemesh develop* $ curl -H "Origin: http://example.com" -I -X POST localhost:9999/spacemesh.v1.ActivationService/Highest
HTTP/1.1 200 OK
Content-Type: application/json
Vary: Origin
Date: Wed, 24 Apr 2024 19:16:15 GMT
Content-Length: 327
```

Because JSONRPC had no config I kept changes to the minimum needed.