### PR TITLE
[Merged by Bors] - Fix PprofHTTPServerListener in mainnet and testnet presets

### DIFF
--- a/config/mainnet.go
+++ b/config/mainnet.go
@@ -108,9 +108,10 @@ func MainnetConfig() Config {
 					Pubkey:  types.MustBase64FromString("5p/mPvmqhwdvf8U0GVrNq/9IN/HmZj5hCkFLAN04g1E="),
 				},
 			},
-			RegossipAtxInterval: 2 * time.Hour,
-			ATXGradeDelay:       30 * time.Minute,
-			PostValidDelay:      time.Duration(math.MaxInt64),
+			RegossipAtxInterval:     2 * time.Hour,
+			ATXGradeDelay:           30 * time.Minute,
+			PostValidDelay:          time.Duration(math.MaxInt64),
+			PprofHTTPServerListener: "localhost:6060",
 		},
 		Genesis: GenesisConfig{
 			GenesisTime: "2023-07-14T08:00:00Z",

--- a/config/presets/testnet.go
+++ b/config/presets/testnet.go
@@ -78,6 +78,8 @@ func testnet() config.Config {
 			TickSize:            666514,
 			RegossipAtxInterval: time.Hour,
 			ATXGradeDelay:       30 * time.Minute,
+
+			PprofHTTPServerListener: "localhost:6060",
 		},
 		Genesis: config.GenesisConfig{
 			GenesisTime: "2023-09-13T18:00:00Z",


### PR DESCRIPTION
## Motivation

#5854 did not update the presets, breaking default pprof listen address on mainnet and testnet

## Description

Apply the proper default for `PprofHTTPServerListener` to mainnet and testnet presets

## Test Plan

Checked that the profiler started listening
