### PR TITLE
[Merged by Bors] - Remove effectiveNumUnits from types.ActivationTx

### DIFF
--- a/activation/handler.go
+++ b/activation/handler.go
@@ -615,7 +615,7 @@ func (h *Handler) processATX(
 		atx.SetValidity(types.Valid)
 	}
 	atx.SetReceived(received)
-	atx.SetEffectiveNumUnits(effectiveNumUnits)
+	atx.NumUnits = effectiveNumUnits
 	vAtx, err := atx.Verify(baseTickHeight, leaves/h.tickSize)
 	if err != nil {
 		return nil, fmt.Errorf("failed to verify atx %x: %w", watx.ID(), err)

--- a/activation/handler_test.go
+++ b/activation/handler_test.go
@@ -109,7 +109,6 @@ func newNIPosV1tWithPoet(t testing.TB, poetRef []byte) *wire.NIPostV1 {
 func toVerifiedAtx(t testing.TB, watx *wire.ActivationTxV1) *types.VerifiedActivationTx {
 	t.Helper()
 	atx := wire.ActivationTxFromWireV1(watx)
-	atx.SetEffectiveNumUnits(watx.NumUnits)
 	atx.SetReceived(time.Now())
 	vAtx, err := atx.Verify(0, 1)
 	require.NoError(t, err)

--- a/activation/post_test.go
+++ b/activation/post_test.go
@@ -278,7 +278,6 @@ func TestPostSetupManager_findCommitmentAtx_UsesLatestAtx(t *testing.T) {
 	}
 	atx := types.NewActivationTx(challenge, types.Address{}, 2, nil)
 	require.NoError(t, SignAndFinalizeAtx(signer, atx))
-	atx.SetEffectiveNumUnits(atx.NumUnits)
 	atx.SetReceived(time.Now())
 	vAtx, err := atx.Verify(0, 1)
 	require.NoError(t, err)
@@ -325,7 +324,6 @@ func TestPostSetupManager_getCommitmentAtx_getsCommitmentAtxFromInitialAtx(t *te
 	atx := types.NewActivationTx(types.NIPostChallenge{}, types.Address{}, 1, nil)
 	atx.CommitmentATX = &commitmentAtx
 	require.NoError(t, SignAndFinalizeAtx(signer, atx))
-	atx.SetEffectiveNumUnits(atx.NumUnits)
 	atx.SetReceived(time.Now())
 	vAtx, err := atx.Verify(0, 1)
 	require.NoError(t, err)

--- a/api/grpcserver/admin_service_test.go
+++ b/api/grpcserver/admin_service_test.go
@@ -31,7 +31,6 @@ func newAtx(tb testing.TB, db *sql.Database) {
 	vrfNonce := types.VRFPostIndex(11)
 	atx.VRFNonce = &vrfNonce
 	atx.SmesherID = types.BytesToNodeID(types.RandomBytes(20))
-	atx.SetEffectiveNumUnits(atx.NumUnits)
 	atx.SetReceived(time.Now().Local())
 	vatx, err := atx.Verify(1111, 12)
 	require.NoError(tb, err)

--- a/api/grpcserver/grpcserver_test.go
+++ b/api/grpcserver/grpcserver_test.go
@@ -164,7 +164,6 @@ func TestMain(m *testing.M) {
 	addr2 = wallet.Address(signer2.PublicKey().Bytes())
 
 	atx := types.NewActivationTx(challenge, addr1, numUnits, nil)
-	atx.SetEffectiveNumUnits(numUnits)
 	atx.SetReceived(time.Now())
 	if err := activation.SignAndFinalizeAtx(signer, atx); err != nil {
 		log.Println("failed to sign atx:", err)
@@ -177,7 +176,6 @@ func TestMain(m *testing.M) {
 	}
 
 	atx2 := types.NewActivationTx(challenge, addr2, numUnits, nil)
-	atx2.SetEffectiveNumUnits(numUnits)
 	atx2.SetReceived(time.Now())
 	if err := activation.SignAndFinalizeAtx(signer, atx2); err != nil {
 		log.Println("failed to sign atx:", err)
@@ -2480,7 +2478,6 @@ func createAtxs(tb testing.TB, epoch types.EpochID, atxids []types.ATXID) []*typ
 			NumUnits:     1,
 		}
 		atx.SetID(id)
-		atx.SetEffectiveNumUnits(atx.NumUnits)
 		atx.SetReceived(time.Now())
 		atx.SmesherID = types.RandomNodeID()
 		vAtx, err := atx.Verify(0, 1)

--- a/atxsdata/warmup_test.go
+++ b/atxsdata/warmup_test.go
@@ -27,7 +27,6 @@ func gatx(
 	atx.PublishEpoch = epoch
 	atx.SmesherID = smesher
 	atx.SetID(id)
-	atx.SetEffectiveNumUnits(atx.NumUnits)
 	atx.SetReceived(time.Time{}.Add(1))
 	atx.VRFNonce = nonce
 	verified, err := atx.Verify(0, 100)

--- a/beacon/beacon.go
+++ b/beacon/beacon.go
@@ -358,7 +358,7 @@ func (pd *ProtocolDriver) MinerAllowance(epoch types.EpochID, nodeID types.NodeI
 	if err != nil || malicious {
 		return 0
 	}
-	return atx.NumUnits
+	return atx.EffectiveNumUnits
 }
 
 // ReportBeaconFromBallot reports the beacon value in a ballot along with the smesher's weight unit.

--- a/beacon/beacon_test.go
+++ b/beacon/beacon_test.go
@@ -123,7 +123,6 @@ func createATX(
 		&nonce,
 	)
 
-	atx.SetEffectiveNumUnits(numUnits)
 	atx.SetReceived(received)
 	require.NoError(tb, activation.SignAndFinalizeAtx(sig, atx))
 	vAtx, err := atx.Verify(0, 1)

--- a/blocks/generator_test.go
+++ b/blocks/generator_test.go
@@ -161,7 +161,6 @@ func createModifiedATXs(
 			numUnit,
 			nil,
 		)
-		atx.SetEffectiveNumUnits(numUnit)
 		atx.SetReceived(time.Now())
 		require.NoError(tb, activation.SignAndFinalizeAtx(signer, atx))
 		vAtx, err := onAtx(atx)

--- a/checkpoint/recovery_test.go
+++ b/checkpoint/recovery_test.go
@@ -338,7 +338,6 @@ func newChainedAtx(
 	watx.Signature = sig.Sign(signing.ATX, watx.SignedBytes())
 
 	atx := wire.ActivationTxFromWireV1(watx)
-	atx.SetEffectiveNumUnits(atx.NumUnits)
 	atx.SetReceived(time.Now().Local())
 
 	return &checkpoint.AtxDep{

--- a/checkpoint/runner_test.go
+++ b/checkpoint/runner_test.go
@@ -213,7 +213,6 @@ func newAtx(
 		atx.VRFNonce = (*types.VRFPostIndex)(&vrfnonce)
 	}
 	atx.SmesherID = nodeID
-	atx.SetEffectiveNumUnits(atx.NumUnits)
 	atx.SetReceived(time.Now().Local())
 	return atx
 }

--- a/cmd/bootstrapper/generator_test.go
+++ b/cmd/bootstrapper/generator_test.go
@@ -52,7 +52,6 @@ func createAtxs(tb testing.TB, db sql.Executor, epoch types.EpochID, atxids []ty
 			NumUnits:     1,
 		}
 		atx.SetID(id)
-		atx.SetEffectiveNumUnits(atx.NumUnits)
 		atx.SetReceived(time.Now())
 		atx.SmesherID = types.RandomNodeID()
 		vAtx, err := atx.Verify(0, 1)

--- a/common/fixture/atxs.go
+++ b/common/fixture/atxs.go
@@ -75,7 +75,6 @@ func (g *AtxsGenerator) Next() *wire.ActivationTxV1 {
 func ToVerifiedAtx(t testing.TB, watx *wire.ActivationTxV1) *types.VerifiedActivationTx {
 	t.Helper()
 	atx := wire.ActivationTxFromWireV1(watx)
-	atx.SetEffectiveNumUnits(watx.NumUnits)
 	atx.SetReceived(time.Now())
 	vAtx, err := atx.Verify(0, 1)
 	require.NoError(t, err)

--- a/common/types/activation_tx_header.go
+++ b/common/types/activation_tx_header.go
@@ -10,10 +10,6 @@ type ActivationTxHeader struct {
 	PublishEpoch EpochID
 	Coinbase     Address
 
-	// NumUnits holds the count of space units that have been reserved by the node for the
-	// current epoch; a unit represents a configurable amount of data for PoST
-	NumUnits uint32
-
 	// EffectiveNumUnits is the minimum of this ATX's NumUnits and the previous ATX's NumUnits
 	// NumUnit decreases become effective immediately, while NumUnit increases become effective one epoch later
 	// This is because the increased PoST size only becomes effective after a PoET proof has

--- a/common/types/verified_activation.go
+++ b/common/types/verified_activation.go
@@ -16,7 +16,7 @@ type VerifiedActivationTx struct {
 // to produce more over time. A uint64 should be large enough to hold the total weight of an epoch,
 // for at least the first few years.
 func (vatx *VerifiedActivationTx) GetWeight() uint64 {
-	return getWeight(uint64(vatx.EffectiveNumUnits()), vatx.tickCount)
+	return getWeight(uint64(vatx.NumUnits), vatx.tickCount)
 }
 
 // BaseTickHeight is a tick height of the positional atx.
@@ -38,8 +38,7 @@ func (vatx *VerifiedActivationTx) ToHeader() *ActivationTxHeader {
 	return &ActivationTxHeader{
 		PublishEpoch:      vatx.PublishEpoch,
 		Coinbase:          vatx.Coinbase,
-		NumUnits:          vatx.NumUnits,
-		EffectiveNumUnits: vatx.EffectiveNumUnits(),
+		EffectiveNumUnits: vatx.NumUnits,
 		Received:          vatx.Received(),
 
 		ID:     vatx.ID(),

--- a/fetch/handler_test.go
+++ b/fetch/handler_test.go
@@ -274,7 +274,6 @@ func newAtx(t *testing.T, published types.EpochID) *types.VerifiedActivationTx {
 	signer, err := signing.NewEdSigner()
 	require.NoError(t, err)
 	activation.SignAndFinalizeAtx(signer, atx)
-	atx.SetEffectiveNumUnits(atx.NumUnits)
 	atx.SetReceived(time.Now())
 	vatx, err := atx.Verify(0, 1)
 	require.NoError(t, err)

--- a/hare3/eligibility/oracle_test.go
+++ b/hare3/eligibility/oracle_test.go
@@ -148,7 +148,6 @@ func (t *testOracle) createActiveSet(
 		nonce := types.VRFPostIndex(0)
 		atx.VRFNonce = &nonce
 		atx.SetID(id)
-		atx.SetEffectiveNumUnits(atx.NumUnits)
 		atx.SetReceived(time.Now())
 		atx.SmesherID = types.BytesToNodeID([]byte(strconv.Itoa(i)))
 		vAtx, err := atx.Verify(0, 1)
@@ -380,7 +379,6 @@ func Test_VrfSignVerify(t *testing.T) {
 	nonce := types.VRFPostIndex(0)
 	atx1.VRFNonce = &nonce
 	atx1.SetID(activeSet[0])
-	atx1.SetEffectiveNumUnits(atx1.NumUnits)
 	atx1.SetReceived(time.Now())
 	atx1.SmesherID = signer.NodeID()
 	vAtx1, err := atx1.Verify(0, 1)
@@ -397,7 +395,6 @@ func Test_VrfSignVerify(t *testing.T) {
 	nonce = types.VRFPostIndex(0)
 	atx2.VRFNonce = &nonce
 	atx2.SetID(activeSet[1])
-	atx2.SetEffectiveNumUnits(atx2.NumUnits)
 	atx2.SetReceived(time.Now())
 	atx2.SmesherID = signer2.NodeID()
 	vAtx2, err := atx2.Verify(0, 1)
@@ -739,11 +736,12 @@ func TestActiveSetMatrix(t *testing.T) {
 		node types.NodeID,
 		option ...func(*types.VerifiedActivationTx),
 	) *types.VerifiedActivationTx {
-		atx := &types.ActivationTx{}
-		atx.PublishEpoch = target - 1
-		atx.SmesherID = node
+		atx := &types.ActivationTx{
+			PublishEpoch: target - 1,
+			SmesherID:    node,
+			NumUnits:     1,
+		}
 		atx.SetID(id)
-		atx.SetEffectiveNumUnits(1)
 		atx.SetReceived(time.Time{}.Add(1))
 		nonce := types.VRFPostIndex(0)
 		atx.VRFNonce = &nonce

--- a/hare3/hare_test.go
+++ b/hare3/hare_test.go
@@ -164,7 +164,6 @@ func (n *node) withAtx(min, max int) *node {
 	id := types.ATXID{}
 	n.t.rng.Read(id[:])
 	atx.SetID(id)
-	atx.SetEffectiveNumUnits(atx.NumUnits)
 	atx.SetReceived(n.t.start)
 	nonce := types.VRFPostIndex(n.t.rng.Uint64())
 	atx.VRFNonce = &nonce
@@ -766,7 +765,6 @@ func gatx(id types.ATXID, epoch types.EpochID, smesher types.NodeID, base, heigh
 	atx.PublishEpoch = epoch
 	atx.SmesherID = smesher
 	atx.SetID(id)
-	atx.SetEffectiveNumUnits(atx.NumUnits)
 	atx.SetReceived(time.Time{}.Add(1))
 	nonce := types.VRFPostIndex(1)
 	atx.VRFNonce = &nonce

--- a/malfeasance/handler_test.go
+++ b/malfeasance/handler_test.go
@@ -39,7 +39,6 @@ func createIdentity(t *testing.T, db *sql.Database, sig *signing.EdSigner) {
 	}
 	atx := types.NewActivationTx(challenge, types.Address{}, 1, nil)
 	require.NoError(t, activation.SignAndFinalizeAtx(sig, atx))
-	atx.SetEffectiveNumUnits(atx.NumUnits)
 	atx.SetReceived(time.Now())
 	vAtx, err := atx.Verify(0, 1)
 	require.NoError(t, err)

--- a/mesh/executor_test.go
+++ b/mesh/executor_test.go
@@ -78,7 +78,6 @@ func (t *testExecutor) createATX(epoch types.EpochID, cb types.Address) (types.A
 		&nonce,
 	)
 
-	atx.SetEffectiveNumUnits(atx.NumUnits)
 	atx.SetReceived(time.Now())
 	require.NoError(t.tb, activation.SignAndFinalizeAtx(sig, atx))
 	vAtx, err := atx.Verify(0, 1)

--- a/mesh/mesh_test.go
+++ b/mesh/mesh_test.go
@@ -136,7 +136,6 @@ func createIdentity(t *testing.T, db sql.Executor, sig *signing.EdSigner) {
 	}
 	atx := types.NewActivationTx(challenge, types.Address{}, 1, nil)
 	require.NoError(t, activation.SignAndFinalizeAtx(sig, atx))
-	atx.SetEffectiveNumUnits(atx.NumUnits)
 	atx.SetReceived(time.Now())
 	vAtx, err := atx.Verify(0, 1)
 	require.NoError(t, err)

--- a/miner/proposal_builder_test.go
+++ b/miner/proposal_builder_test.go
@@ -75,7 +75,6 @@ func gatx(
 	atx.PublishEpoch = epoch
 	atx.SmesherID = smesher
 	atx.SetID(id)
-	atx.SetEffectiveNumUnits(atx.NumUnits)
 	atx.SetReceived(time.Time{}.Add(1))
 	nonce := types.VRFPostIndex(0)
 	atx.VRFNonce = &nonce

--- a/proposals/eligibility_validator_test.go
+++ b/proposals/eligibility_validator_test.go
@@ -26,7 +26,6 @@ func gatx(
 	atx.PublishEpoch = epoch
 	atx.SmesherID = smesher
 	atx.SetID(id)
-	atx.SetEffectiveNumUnits(atx.NumUnits)
 	atx.SetReceived(time.Time{}.Add(1))
 	atx.VRFNonce = &nonce
 	verified, err := atx.Verify(0, 100)
@@ -48,7 +47,6 @@ func gatxZeroHeight(
 	atx.PublishEpoch = epoch
 	atx.SmesherID = smesher
 	atx.SetID(id)
-	atx.SetEffectiveNumUnits(atx.NumUnits)
 	atx.SetReceived(time.Time{}.Add(1))
 	atx.VRFNonce = &nonce
 	verified, err := atx.Verify(0, 0)
@@ -64,7 +62,6 @@ func gatxNilNonce(id types.ATXID, epoch types.EpochID, smesher types.NodeID, uni
 	atx.PublishEpoch = epoch
 	atx.SmesherID = smesher
 	atx.SetID(id)
-	atx.SetEffectiveNumUnits(atx.NumUnits)
 	atx.SetReceived(time.Time{}.Add(1))
 	verified, err := atx.Verify(0, 100)
 	if err != nil {

--- a/proposals/handler_test.go
+++ b/proposals/handler_test.go
@@ -241,7 +241,6 @@ func createAtx(t *testing.T, db *sql.Database, epoch types.EpochID, atxID types.
 		NumUnits:     1,
 	}
 	atx.SetID(atxID)
-	atx.SetEffectiveNumUnits(1)
 	atx.SetReceived(time.Now())
 	atx.SmesherID = nodeID
 	vAtx, err := atx.Verify(0, 1)

--- a/sql/atxs/atxs.go
+++ b/sql/atxs/atxs.go
@@ -56,11 +56,9 @@ func decoder(fn decoderCallback) sql.Decoder {
 		baseTickHeight := uint64(stmt.ColumnInt64(2))
 		tickCount := uint64(stmt.ColumnInt64(3))
 		stmt.ColumnBytes(4, a.SmesherID[:])
-		effectiveNumUnits := uint32(stmt.ColumnInt32(5))
-		a.SetEffectiveNumUnits(effectiveNumUnits)
+		a.NumUnits = uint32(stmt.ColumnInt32(5))
 		if checkpointed {
 			a.SetGolden()
-			a.NumUnits = effectiveNumUnits
 			a.SetReceived(time.Time{})
 		} else {
 			a.SetReceived(time.Unix(0, stmt.ColumnInt64(6)).Local())
@@ -432,7 +430,7 @@ func add(db sql.Executor, atx *types.VerifiedActivationTx, nonce *types.VRFPostI
 	enc := func(stmt *sql.Statement) {
 		stmt.BindBytes(1, atx.ID().Bytes())
 		stmt.BindInt64(2, int64(atx.PublishEpoch))
-		stmt.BindInt64(3, int64(atx.EffectiveNumUnits()))
+		stmt.BindInt64(3, int64(atx.NumUnits))
 		if atx.CommitmentATX != nil {
 			stmt.BindBytes(4, atx.CommitmentATX.Bytes())
 		} else {

--- a/sql/atxs/atxs_test.go
+++ b/sql/atxs/atxs_test.go
@@ -800,7 +800,6 @@ func newAtx(signer *signing.EdSigner, opts ...createAtxOpt) (*types.VerifiedActi
 		opt(atx)
 	}
 	activation.SignAndFinalizeAtx(signer, atx)
-	atx.SetEffectiveNumUnits(atx.NumUnits)
 	atx.SetReceived(time.Now().Local())
 	return atx.Verify(0, 1)
 }
@@ -824,7 +823,6 @@ func createAtx(tb testing.TB, db *sql.Database, hdr header) (types.ATXID, *signi
 
 	require.NoError(tb, activation.SignAndFinalizeAtx(sig, full))
 
-	full.SetEffectiveNumUnits(full.NumUnits)
 	full.SetReceived(time.Now())
 	vAtx, err := full.Verify(hdr.base, hdr.count)
 	require.NoError(tb, err)
@@ -973,8 +971,8 @@ func TestLatest(t *testing.T) {
 			for i, epoch := range tc.epochs {
 				full := &types.ActivationTx{
 					PublishEpoch: types.EpochID(epoch),
+					NumUnits:     1,
 				}
-				full.SetEffectiveNumUnits(1)
 				full.SetReceived(time.Now())
 				full.SetID(types.ATXID{byte(i)})
 				vAtx, err := full.Verify(0, 1)

--- a/sql/ballots/ballots_test.go
+++ b/sql/ballots/ballots_test.go
@@ -174,7 +174,6 @@ func newAtx(signer *signing.EdSigner, layerID types.LayerID) (*types.VerifiedAct
 	nodeID := signer.NodeID()
 	atx.SetID(types.ATXID{1, 2, 3})
 	atx.SmesherID = nodeID
-	atx.SetEffectiveNumUnits(atx.NumUnits)
 	atx.SetReceived(time.Now().Local())
 	return atx.Verify(0, 1)
 }

--- a/sql/migrations/state_0017_migration_test.go
+++ b/sql/migrations/state_0017_migration_test.go
@@ -48,7 +48,6 @@ func addAtx(
 		opt(atx)
 	}
 	require.NoError(t, activation.SignAndFinalizeAtx(signer, atx))
-	atx.SetEffectiveNumUnits(atx.NumUnits)
 	atx.SetReceived(time.Now().Local())
 	vAtx, err := atx.Verify(0, 1)
 	require.NoError(t, err)

--- a/syncer/atxsync/atxsync_test.go
+++ b/syncer/atxsync/atxsync_test.go
@@ -23,7 +23,6 @@ func atx(id types.ATXID) *types.VerifiedActivationTx {
 		NumUnits:     1,
 	}
 	atx.SetID(id)
-	atx.SetEffectiveNumUnits(1)
 	atx.SetReceived(time.Now())
 	copy(atx.SmesherID[:], id[:])
 	vatx, err := atx.Verify(0, 1)

--- a/tortoise/model/core.go
+++ b/tortoise/model/core.go
@@ -155,7 +155,6 @@ func (c *core) OnMessage(m Messenger, event Message) {
 		if err := activation.SignAndFinalizeAtx(c.signer, atx); err != nil {
 			c.logger.With().Fatal("failed to sign atx", log.Err(err))
 		}
-		atx.SetEffectiveNumUnits(atx.NumUnits)
 		atx.SetReceived(time.Now())
 		vAtx, err := atx.Verify(1, 2)
 		if err != nil {

--- a/tortoise/sim/generator.go
+++ b/tortoise/sim/generator.go
@@ -244,7 +244,6 @@ func (g *Generator) generateAtxs() {
 		if err := activation.SignAndFinalizeAtx(sig, atx); err != nil {
 			panic(err)
 		}
-		atx.SetEffectiveNumUnits(atx.NumUnits)
 		atx.SetReceived(time.Now())
 		vatx, err := atx.Verify(g.prevHeight[i], ticks)
 		if err != nil {

--- a/tortoise/threshold_test.go
+++ b/tortoise/threshold_test.go
@@ -174,7 +174,6 @@ func TestReferenceHeight(t *testing.T) {
 					NumUnits:     2,
 				}
 				atx.SetID(types.ATXID{byte(i + 1)})
-				atx.SetEffectiveNumUnits(atx.NumUnits)
 				atx.SetReceived(time.Now())
 				vAtx, err := atx.Verify(0, uint64(height))
 				require.NoError(t, err)

--- a/tortoise/tortoise_test.go
+++ b/tortoise/tortoise_test.go
@@ -477,9 +477,7 @@ func TestComputeExpectedWeight(t *testing.T) {
 					PublishEpoch: eid - 1,
 					NumUnits:     uint32(weight),
 				}
-				id := types.RandomATXID()
-				atx.SetID(id)
-				atx.SetEffectiveNumUnits(atx.NumUnits)
+				atx.SetID(types.RandomATXID())
 				atx.SetReceived(time.Now())
 				vAtx, err := atx.Verify(0, 1)
 				require.NoError(t, err)


### PR DESCRIPTION
The NumUnits field becomes the effective value.

## Description

Removed `types.ActivationTx.effectiveNumUnits`. The existing `types.ActivationTx.NumUnits` has a new meaning - it's the effective value.

There is an important change in the beacon - it will now use the effective number of units to calculate the miner's allowance.

## Test Plan

existing tests pass

## TODO

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [ ] Update documentation as needed
- [ ] Update [changelog](../CHANGELOG.md) as needed
