### PR TITLE
[Merged by Bors] - Don't decode ATX blob when fetching types.ActivationTx from DB

### DIFF
--- a/activation/activation.go
+++ b/activation/activation.go
@@ -770,7 +770,6 @@ func SignAndFinalizeAtx(signer *signing.EdSigner, atx *types.ActivationTx) error
 		Version: types.AtxV1,
 		Blob:    codec.MustEncode(wireAtx),
 	}
-	atx.Signature = wireAtx.Signature
 	atx.SmesherID = wireAtx.SmesherID
 	atx.SetID(types.ATXID(wireAtx.HashInnerBytes()))
 	return nil

--- a/activation/activation.go
+++ b/activation/activation.go
@@ -759,22 +759,6 @@ func (b *Builder) Regossip(ctx context.Context, nodeID types.NodeID) error {
 	return nil
 }
 
-// SignAndFinalizeAtx signs the atx with specified signer and calculates the ID of the ATX.
-// DO NOT USE for new code. This function is deprecated and will be removed.
-// The proper way to create an ATX in tests is to use the specific wire type and sign it.
-func SignAndFinalizeAtx(signer *signing.EdSigner, atx *types.ActivationTx) error {
-	wireAtx := wire.ActivationTxToWireV1(atx)
-	wireAtx.Signature = signer.Sign(signing.ATX, wireAtx.SignedBytes())
-	wireAtx.SmesherID = signer.NodeID()
-	atx.AtxBlob = types.AtxBlob{
-		Version: types.AtxV1,
-		Blob:    codec.MustEncode(wireAtx),
-	}
-	atx.SmesherID = wireAtx.SmesherID
-	atx.SetID(types.ATXID(wireAtx.HashInnerBytes()))
-	return nil
-}
-
 func buildNipostChallengeStartDeadline(roundStart time.Time, gracePeriod time.Duration) time.Time {
 	jitter := randomDurationInRange(time.Duration(0), gracePeriod*maxNipostChallengeBuildJitter/100.0)
 	return roundStart.Add(jitter).Add(-gracePeriod)

--- a/activation/handler.go
+++ b/activation/handler.go
@@ -408,7 +408,7 @@ func (h *Handler) storeAtx(
 			}
 			prevSignature, err := atxSignature(ctx, tx, prev)
 			if err != nil {
-				return err
+				return fmt.Errorf("extracting signature for malfeasance proof: %w", err)
 			}
 
 			atxProof := mwire.AtxProof{

--- a/activation/handler.go
+++ b/activation/handler.go
@@ -373,7 +373,11 @@ func (h *Handler) cacheAtx(ctx context.Context, atx *types.ActivationTx, nonce t
 }
 
 // storeAtx stores an ATX and notifies subscribers of the ATXID.
-func (h *Handler) storeAtx(ctx context.Context, atx *types.ActivationTx) (*mwire.MalfeasanceProof, error) {
+func (h *Handler) storeAtx(
+	ctx context.Context,
+	atx *types.ActivationTx,
+	signature types.EdSignature,
+) (*mwire.MalfeasanceProof, error) {
 	var nonce *types.VRFPostIndex
 	malicious, err := h.cdb.IsMalicious(atx.SmesherID)
 	if err != nil {
@@ -394,7 +398,7 @@ func (h *Handler) storeAtx(ctx context.Context, atx *types.ActivationTx) (*mwire
 		}
 
 		// do ID check to be absolutely sure.
-		if prev != nil && prev.ID() != atx.ID() {
+		if err == nil && prev != atx.ID() {
 			if _, ok := h.signers[atx.SmesherID]; ok {
 				// if we land here we tried to publish 2 ATXs in the same epoch
 				// don't punish ourselves but fail validation and thereby the handling of the incoming ATX
@@ -402,17 +406,27 @@ func (h *Handler) storeAtx(ctx context.Context, atx *types.ActivationTx) (*mwire
 					atx.PublishEpoch,
 				)
 			}
+			prevSignature, err := atxSignature(ctx, tx, prev)
+			if err != nil {
+				return err
+			}
 
-			var atxProof mwire.AtxProof
-			for i, a := range []*types.ActivationTx{prev, atx} {
-				atxProof.Messages[i] = mwire.AtxProofMsg{
+			atxProof := mwire.AtxProof{
+				Messages: [2]mwire.AtxProofMsg{{
 					InnerMsg: types.ATXMetadata{
-						PublishEpoch: a.PublishEpoch,
-						MsgHash:      a.ID().Hash32(),
+						PublishEpoch: atx.PublishEpoch,
+						MsgHash:      prev.Hash32(),
 					},
-					SmesherID: a.SmesherID,
-					Signature: a.Signature,
-				}
+					SmesherID: atx.SmesherID,
+					Signature: prevSignature,
+				}, {
+					InnerMsg: types.ATXMetadata{
+						PublishEpoch: atx.PublishEpoch,
+						MsgHash:      atx.ID().Hash32(),
+					},
+					SmesherID: atx.SmesherID,
+					Signature: signature,
+				}},
 			}
 			proof = &mwire.MalfeasanceProof{
 				Layer: atx.PublishEpoch.FirstLayer(),
@@ -431,8 +445,8 @@ func (h *Handler) storeAtx(ctx context.Context, atx *types.ActivationTx) (*mwire
 
 			h.log.WithContext(ctx).With().Warning("smesher produced more than one atx in the same epoch",
 				log.Stringer("smesher", atx.SmesherID),
-				log.Object("prev", prev),
-				log.Object("curr", atx),
+				log.Stringer("previous", prev),
+				log.Object("current", atx),
 			)
 		}
 
@@ -619,7 +633,7 @@ func (h *Handler) processATX(
 	atx.BaseTickHeight = baseTickHeight
 	atx.TickCount = leaves / h.tickSize
 
-	proof, err = h.storeAtx(ctx, atx)
+	proof, err = h.storeAtx(ctx, atx, watx.Signature)
 	if err != nil {
 		return nil, fmt.Errorf("cannot store atx %s: %w", atx.ShortString(), err)
 	}
@@ -674,4 +688,24 @@ func collectAtxDeps(goldenAtxId types.ATXID, atx *wire.ActivationTxV1) (types.Ha
 	}
 
 	return types.BytesToHash(atx.NIPost.PostMetadata.Challenge), maps.Keys(filtered)
+}
+
+// Obtain the atxSignature of the given ATX.
+func atxSignature(ctx context.Context, db sql.Executor, id types.ATXID) (types.EdSignature, error) {
+	var blob sql.Blob
+	if err := atxs.LoadBlob(ctx, db, id.Bytes(), &blob); err != nil {
+		return types.EmptyEdSignature, err
+	}
+
+	if blob.Bytes == nil {
+		// An empty blob indicates a golden ATX (after a checkpoint-recovery).
+		return types.EmptyEdSignature, fmt.Errorf("can't get signature for a golden (checkpointed) ATX: %s", id)
+	}
+
+	// TODO: decide how to decode based on the `version` column.
+	var prev wire.ActivationTxV1
+	if err := codec.Decode(blob.Bytes, &prev); err != nil {
+		return types.EmptyEdSignature, fmt.Errorf("decoding previous atx: %w", err)
+	}
+	return prev.Signature, nil
 }

--- a/activation/handler_test.go
+++ b/activation/handler_test.go
@@ -712,13 +712,14 @@ func TestHandler_StoreAtx(t *testing.T) {
 
 		atxHdlr.mbeacon.EXPECT().OnAtx(vAtx.ToHeader())
 		atxHdlr.mtortoise.EXPECT().OnAtx(gomock.Any(), vAtx.ID(), gomock.Any())
-		proof, err := atxHdlr.storeAtx(context.Background(), vAtx)
+		proof, err := atxHdlr.storeAtx(context.Background(), vAtx, watx.Signature)
 		require.NoError(t, err)
 		require.Nil(t, proof)
 
 		atxFromDb, err := atxs.Get(atxHdlr.cdb, vAtx.ID())
 		require.NoError(t, err)
 		vAtx.SetReceived(time.Unix(0, vAtx.Received().UnixNano()))
+		vAtx.AtxBlob = types.AtxBlob{}
 		require.Equal(t, vAtx, atxFromDb)
 	})
 
@@ -731,13 +732,13 @@ func TestHandler_StoreAtx(t *testing.T) {
 
 		atxHdlr.mbeacon.EXPECT().OnAtx(vAtx.ToHeader())
 		atxHdlr.mtortoise.EXPECT().OnAtx(gomock.Any(), vAtx.ID(), gomock.Any())
-		proof, err := atxHdlr.storeAtx(context.Background(), vAtx)
+		proof, err := atxHdlr.storeAtx(context.Background(), vAtx, watx.Signature)
 		require.NoError(t, err)
 		require.Nil(t, proof)
 
 		atxHdlr.mbeacon.EXPECT().OnAtx(vAtx.ToHeader())
 		// Note: tortoise is not informed about the same ATX again
-		proof, err = atxHdlr.storeAtx(context.Background(), vAtx)
+		proof, err = atxHdlr.storeAtx(context.Background(), vAtx, watx.Signature)
 		require.NoError(t, err)
 		require.Nil(t, proof)
 	})
@@ -752,7 +753,7 @@ func TestHandler_StoreAtx(t *testing.T) {
 		atxHdlr.mbeacon.EXPECT().OnAtx(vAtx0.ToHeader())
 		atxHdlr.mtortoise.EXPECT().OnAtx(gomock.Any(), vAtx0.ID(), gomock.Any())
 
-		proof, err := atxHdlr.storeAtx(context.Background(), vAtx0)
+		proof, err := atxHdlr.storeAtx(context.Background(), vAtx0, watx0.Signature)
 		require.NoError(t, err)
 		require.Nil(t, proof)
 
@@ -765,7 +766,7 @@ func TestHandler_StoreAtx(t *testing.T) {
 		atxHdlr.mtortoise.EXPECT().OnAtx(gomock.Any(), vAtx1.ID(), gomock.Any())
 		atxHdlr.mtortoise.EXPECT().OnMalfeasance(sig.NodeID())
 
-		proof, err = atxHdlr.storeAtx(context.Background(), vAtx1)
+		proof, err = atxHdlr.storeAtx(context.Background(), vAtx1, watx1.Signature)
 		require.NoError(t, err)
 		require.NotNil(t, proof)
 		require.Equal(t, mwire.MultipleATXs, proof.Proof.Type)
@@ -798,7 +799,7 @@ func TestHandler_StoreAtx(t *testing.T) {
 		atxHdlr.mbeacon.EXPECT().OnAtx(vAtx0.ToHeader())
 		atxHdlr.mtortoise.EXPECT().OnAtx(gomock.Any(), vAtx0.ID(), gomock.Any())
 
-		proof, err := atxHdlr.storeAtx(context.Background(), vAtx0)
+		proof, err := atxHdlr.storeAtx(context.Background(), vAtx0, watx0.Signature)
 		require.NoError(t, err)
 		require.Nil(t, proof)
 
@@ -807,7 +808,7 @@ func TestHandler_StoreAtx(t *testing.T) {
 		watx1.Sign(sig)
 		vAtx1 := toAtx(t, watx1)
 
-		proof, err = atxHdlr.storeAtx(context.Background(), vAtx1)
+		proof, err = atxHdlr.storeAtx(context.Background(), vAtx1, watx1.Signature)
 		require.ErrorContains(t,
 			err,
 			fmt.Sprintf("%s already published an ATX", sig.NodeID().ShortString()),

--- a/activation/post_test.go
+++ b/activation/post_test.go
@@ -277,7 +277,8 @@ func TestPostSetupManager_findCommitmentAtx_UsesLatestAtx(t *testing.T) {
 		PublishEpoch: 1,
 	}
 	atx := types.NewActivationTx(challenge, types.Address{}, 2, nil)
-	require.NoError(t, SignAndFinalizeAtx(signer, atx))
+	atx.SmesherID = signer.NodeID()
+	atx.SetID(types.RandomATXID())
 	atx.SetReceived(time.Now())
 	atx.TickCount = 1
 	require.NoError(t, err)
@@ -323,7 +324,8 @@ func TestPostSetupManager_getCommitmentAtx_getsCommitmentAtxFromInitialAtx(t *te
 	commitmentAtx := types.RandomATXID()
 	atx := types.NewActivationTx(types.NIPostChallenge{}, types.Address{}, 1, nil)
 	atx.CommitmentATX = &commitmentAtx
-	require.NoError(t, SignAndFinalizeAtx(signer, atx))
+	atx.SmesherID = signer.NodeID()
+	atx.SetID(types.RandomATXID())
 	atx.SetReceived(time.Now())
 	atx.TickCount = 1
 	require.NoError(t, atxs.Add(mgr.cdb, atx))

--- a/activation/wire/wire_v1.go
+++ b/activation/wire/wire_v1.go
@@ -162,7 +162,6 @@ func ActivationTxToWireV1(a *types.ActivationTx) *ActivationTxV1 {
 			VRFNonce: (*uint64)(a.VRFNonce),
 		},
 		SmesherID: a.SmesherID,
-		Signature: a.Signature,
 	}
 }
 
@@ -176,7 +175,6 @@ func ActivationTxFromWireV1(atx *ActivationTxV1, blob ...byte) *types.Activation
 		NumUnits:      atx.NumUnits,
 		VRFNonce:      (*types.VRFPostIndex)(atx.VRFNonce),
 		SmesherID:     atx.SmesherID,
-		Signature:     atx.Signature,
 		AtxBlob: types.AtxBlob{
 			Version: types.AtxV1,
 			Blob:    blob,

--- a/api/grpcserver/v2alpha1/activation.go
+++ b/api/grpcserver/v2alpha1/activation.go
@@ -154,7 +154,6 @@ func (s *ActivationStreamService) Stream(
 func toAtx(atx *types.ActivationTx) *spacemeshv2alpha1.ActivationV1 {
 	return &spacemeshv2alpha1.ActivationV1{
 		Id:           atx.ID().Bytes(),
-		Signature:    atx.Signature.Bytes(),
 		PublishEpoch: atx.PublishEpoch.Uint32(),
 		PreviousAtx:  atx.PrevATXID[:],
 		Coinbase:     atx.Coinbase.String(),

--- a/beacon/beacon_test.go
+++ b/beacon/beacon_test.go
@@ -17,7 +17,6 @@ import (
 	"go.uber.org/mock/gomock"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/spacemeshos/go-spacemesh/activation"
 	"github.com/spacemeshos/go-spacemesh/beacon/metrics"
 	"github.com/spacemeshos/go-spacemesh/beacon/weakcoin"
 	"github.com/spacemeshos/go-spacemesh/common/types"
@@ -124,7 +123,8 @@ func createATX(
 	)
 
 	atx.SetReceived(received)
-	require.NoError(tb, activation.SignAndFinalizeAtx(sig, atx))
+	atx.SmesherID = sig.NodeID()
+	atx.SetID(types.RandomATXID())
 	atx.TickCount = 1
 	require.NoError(tb, atxs.Add(db, atx))
 	return atx.ID()

--- a/blocks/generator_test.go
+++ b/blocks/generator_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
-	"github.com/spacemeshos/go-spacemesh/activation"
 	"github.com/spacemeshos/go-spacemesh/atxsdata"
 	"github.com/spacemeshos/go-spacemesh/blocks/mocks"
 	"github.com/spacemeshos/go-spacemesh/common/types"
@@ -163,7 +162,8 @@ func createModifiedATXs(
 			nil,
 		)
 		atx.SetReceived(time.Now())
-		require.NoError(tb, activation.SignAndFinalizeAtx(signer, atx))
+		atx.SmesherID = signer.NodeID()
+		atx.SetID(types.RandomATXID())
 		onAtx(atx)
 		data.AddFromAtx(atx, 0, false)
 		atxes = append(atxes, atx)

--- a/common/types/activation.go
+++ b/common/types/activation.go
@@ -168,9 +168,7 @@ type ActivationTx struct {
 	BaseTickHeight uint64
 	TickCount      uint64
 	VRFNonce       *VRFPostIndex
-
-	SmesherID NodeID
-	Signature EdSignature
+	SmesherID      NodeID
 
 	AtxBlob
 

--- a/fetch/mesh_data_test.go
+++ b/fetch/mesh_data_test.go
@@ -13,7 +13,6 @@ import (
 	"go.uber.org/mock/gomock"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/spacemeshos/go-spacemesh/activation"
 	"github.com/spacemeshos/go-spacemesh/codec"
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/datastore"
@@ -453,7 +452,8 @@ func genATXs(tb testing.TB, num uint32) []*types.ActivationTx {
 			i,
 			nil,
 		)
-		require.NoError(tb, activation.SignAndFinalizeAtx(sig, atx))
+		atx.SmesherID = sig.NodeID()
+		atx.SetID(types.RandomATXID())
 		atxs = append(atxs, atx)
 	}
 	return atxs

--- a/malfeasance/wire/malfeasance_test.go
+++ b/malfeasance/wire/malfeasance_test.go
@@ -28,15 +28,13 @@ func TestCodec_MultipleATXs(t *testing.T) {
 
 	var atxProof wire.AtxProof
 	for i, a := range []*types.ActivationTx{a1, a2} {
-		a.Signature = types.RandomEdSignature()
-		a.SmesherID = types.RandomNodeID()
 		atxProof.Messages[i] = wire.AtxProofMsg{
 			InnerMsg: types.ATXMetadata{
 				PublishEpoch: a.PublishEpoch,
-				// MsgHash:      types.Hash32(a.ToWireV1().HashInnerBytes()),
+				MsgHash:      types.RandomHash(),
 			},
-			SmesherID: a.SmesherID,
-			Signature: a.Signature,
+			SmesherID: types.RandomNodeID(),
+			Signature: types.RandomEdSignature(),
 		}
 	}
 	proof := &wire.MalfeasanceProof{

--- a/node/node.go
+++ b/node/node.go
@@ -36,7 +36,6 @@ import (
 	"google.golang.org/grpc/keepalive"
 
 	"github.com/spacemeshos/go-spacemesh/activation"
-	"github.com/spacemeshos/go-spacemesh/activation/wire"
 	"github.com/spacemeshos/go-spacemesh/api/grpcserver"
 	"github.com/spacemeshos/go-spacemesh/api/grpcserver/v2alpha1"
 	"github.com/spacemeshos/go-spacemesh/atxsdata"
@@ -75,7 +74,6 @@ import (
 	"github.com/spacemeshos/go-spacemesh/sql"
 	"github.com/spacemeshos/go-spacemesh/sql/activesets"
 	"github.com/spacemeshos/go-spacemesh/sql/atxs"
-	"github.com/spacemeshos/go-spacemesh/sql/builder"
 	"github.com/spacemeshos/go-spacemesh/sql/layers"
 	"github.com/spacemeshos/go-spacemesh/sql/localsql"
 	dbmetrics "github.com/spacemeshos/go-spacemesh/sql/metrics"
@@ -1946,48 +1944,6 @@ func (app *App) Start(ctx context.Context) error {
 	case err = <-app.errCh:
 		return err
 	}
-}
-
-// verifyDB performs a verification of ATX signatures in the database.
-//
-//lint:ignore U1000 This function is currently unused but is left here for future use.
-func (app *App) verifyDB(ctx context.Context) {
-	app.eg.Go(func() error {
-		app.log.Info("checking ATX signatures")
-		count := 0
-
-		// check ATX signatures
-		atxs.IterateAtxsOps(app.cachedDB, builder.Operations{}, func(atx *types.ActivationTx) bool {
-			select {
-			case <-ctx.Done():
-				// stop on context cancellation
-				return false
-			default:
-			}
-
-			// verify atx signature
-			// TODO: use atx handler to verify signature
-			if !app.edVerifier.Verify(
-				signing.ATX,
-				atx.SmesherID, wire.ActivationTxToWireV1(atx).SignedBytes(),
-				atx.Signature,
-			) {
-				app.log.With().Error("ATX signature verification failed",
-					log.Stringer("atx_id", atx.ID()),
-					log.Stringer("smesher", atx.SmesherID),
-				)
-			}
-
-			count++
-			if count%1000 == 0 {
-				app.log.With().Info("verifying ATX signatures", log.Int("count", count))
-			}
-			return true
-		})
-
-		app.log.With().Info("ATX signatures verified", log.Int("count", count))
-		return nil
-	})
 }
 
 func (app *App) startSynchronous(ctx context.Context) (err error) {

--- a/sql/atxs/atxs.go
+++ b/sql/atxs/atxs.go
@@ -4,13 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"time"
 
 	sqlite "github.com/go-llsqlite/crawshaw"
 
-	"github.com/spacemeshos/go-spacemesh/activation/wire"
-	"github.com/spacemeshos/go-spacemesh/codec"
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/sql"
 	"github.com/spacemeshos/go-spacemesh/sql/builder"
@@ -25,9 +22,9 @@ const (
 // Can't use inner join for the ATX blob here b/c this will break
 // filters that refer to the id column.
 const fullQuery = `select id,
-        (select atx from atx_blobs b where a.id = b.id) as atx,
-        base_tick_height, tick_count, pubkey,
-	effective_num_units, received, epoch, sequence, coinbase, validity, prev_id, nonce
+	(select iif(atx is null, 1, 0) from atx_blobs b where a.id = b.id) as is_golden,
+    base_tick_height, tick_count, pubkey, effective_num_units,
+	received, epoch, sequence, coinbase, validity, prev_id, nonce, commitment_atx
 	from atxs a`
 
 type decoderCallback func(*types.ActivationTx, error) bool
@@ -39,25 +36,13 @@ func decoder(fn decoderCallback) sql.Decoder {
 			id types.ATXID
 		)
 		stmt.ColumnBytes(0, id[:])
-		checkpointed := stmt.ColumnLen(1) == 0
-		if !checkpointed {
-			// FIXME: remove decoding blob once ActivationTx struct is trimmed from unncecessary fields.
-			var atxV1 wire.ActivationTxV1
-			blob, err := io.ReadAll(stmt.ColumnReader(1))
-			if err != nil {
-				return fn(nil, fmt.Errorf("read blob %w", err))
-			}
-			if err := codec.Decode(blob, &atxV1); err != nil {
-				return fn(nil, fmt.Errorf("decode %w", err))
-			}
-			a = *wire.ActivationTxFromWireV1(&atxV1, blob...)
-		}
+
 		a.SetID(id)
 		a.BaseTickHeight = uint64(stmt.ColumnInt64(2))
 		a.TickCount = uint64(stmt.ColumnInt64(3))
 		stmt.ColumnBytes(4, a.SmesherID[:])
 		a.NumUnits = uint32(stmt.ColumnInt32(5))
-		if checkpointed {
+		if checkpointed := stmt.ColumnInt(1) != 0; checkpointed {
 			a.SetGolden()
 			a.SetReceived(time.Time{})
 		} else {
@@ -72,6 +57,10 @@ func decoder(fn decoderCallback) sql.Decoder {
 		}
 		nonce := types.VRFPostIndex(stmt.ColumnInt64(12))
 		a.VRFNonce = &nonce
+		if stmt.ColumnType(13) != sqlite.SQLITE_NULL {
+			a.CommitmentATX = new(types.ATXID)
+			stmt.ColumnBytes(13, a.CommitmentATX[:])
+		}
 
 		return fn(&a, nil)
 	}
@@ -114,20 +103,25 @@ func GetByEpochAndNodeID(
 	db sql.Executor,
 	epoch types.EpochID,
 	nodeID types.NodeID,
-) (*types.ActivationTx, error) {
-	enc := func(stmt *sql.Statement) {
-		stmt.BindInt64(1, int64(epoch))
-		stmt.BindBytes(2, nodeID.Bytes())
-	}
-	q := fmt.Sprintf("%v where epoch = ?1 and pubkey = ?2 limit 1;", fullQuery)
-	v, err := load(db, q, enc)
+) (types.ATXID, error) {
+	var id types.ATXID
+	rows, err := db.Exec("select id from atxs where epoch = ?1 and pubkey = ?2 limit 1;",
+		func(stmt *sql.Statement) {
+			stmt.BindInt64(1, int64(epoch))
+			stmt.BindBytes(2, nodeID.Bytes())
+		},
+		func(stmt *sql.Statement) bool {
+			stmt.ColumnBytes(0, id[:])
+			return false
+		},
+	)
 	if err != nil {
-		return nil, fmt.Errorf("get by epoch %v nid %s: %w", epoch, nodeID.String(), err)
+		return types.EmptyATXID, fmt.Errorf("get by epoch %v nid %s: %w", epoch, nodeID.String(), err)
 	}
-	if v == nil {
-		return nil, fmt.Errorf("get by epoch %v nid %s: %w", epoch, nodeID.String(), sql.ErrNotFound)
+	if rows == 0 {
+		return types.EmptyATXID, fmt.Errorf("get by epoch %v nid %s: %w", epoch, nodeID.String(), sql.ErrNotFound)
 	}
-	return v, nil
+	return id, nil
 }
 
 // Has checks if an ATX exists by a given ATX ID.

--- a/sql/atxs/atxs_test.go
+++ b/sql/atxs/atxs_test.go
@@ -45,6 +45,7 @@ func TestGet(t *testing.T) {
 	for _, want := range atxList {
 		got, err := atxs.Get(db, want.ID())
 		require.NoError(t, err)
+		want.AtxBlob = types.AtxBlob{}
 		require.Equal(t, want, got)
 	}
 
@@ -245,19 +246,17 @@ func TestGetByEpochAndNodeID(t *testing.T) {
 
 	got, err := atxs.GetByEpochAndNodeID(db, types.EpochID(1), sig1.NodeID())
 	require.NoError(t, err)
-	require.Equal(t, atx1, got)
+	require.Equal(t, atx1.ID(), got)
 
-	got, err = atxs.GetByEpochAndNodeID(db, types.EpochID(2), sig1.NodeID())
+	_, err = atxs.GetByEpochAndNodeID(db, types.EpochID(2), sig1.NodeID())
 	require.ErrorIs(t, err, sql.ErrNotFound)
-	require.Nil(t, got)
 
-	got, err = atxs.GetByEpochAndNodeID(db, types.EpochID(1), sig2.NodeID())
+	_, err = atxs.GetByEpochAndNodeID(db, types.EpochID(1), sig2.NodeID())
 	require.ErrorIs(t, err, sql.ErrNotFound)
-	require.Nil(t, got)
 
 	got, err = atxs.GetByEpochAndNodeID(db, types.EpochID(2), sig2.NodeID())
 	require.NoError(t, err)
-	require.Equal(t, atx2, got)
+	require.Equal(t, atx2.ID(), got)
 }
 
 func TestGetLastIDByNodeID(t *testing.T) {
@@ -688,6 +687,7 @@ func TestAdd(t *testing.T) {
 
 	got, err := atxs.Get(db, atx.ID())
 	require.NoError(t, err)
+	atx.AtxBlob = types.AtxBlob{}
 	require.Equal(t, atx, got)
 }
 

--- a/tortoise/model/core.go
+++ b/tortoise/model/core.go
@@ -6,7 +6,6 @@ import (
 	"math/rand"
 	"time"
 
-	"github.com/spacemeshos/go-spacemesh/activation"
 	"github.com/spacemeshos/go-spacemesh/atxsdata"
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/datastore"
@@ -152,9 +151,8 @@ func (c *core) OnMessage(m Messenger, event Message) {
 		}
 		addr := types.GenerateAddress(c.signer.PublicKey().Bytes())
 		atx := types.NewActivationTx(nipost, addr, c.units, nil)
-		if err := activation.SignAndFinalizeAtx(c.signer, atx); err != nil {
-			c.logger.With().Fatal("failed to sign atx", log.Err(err))
-		}
+		atx.SmesherID = c.signer.NodeID()
+		atx.SetID(types.RandomATXID())
 		atx.SetReceived(time.Now())
 		atx.BaseTickHeight = 1
 		atx.TickCount = 2

--- a/tortoise/sim/generator.go
+++ b/tortoise/sim/generator.go
@@ -4,7 +4,6 @@ import (
 	"math/rand"
 	"time"
 
-	"github.com/spacemeshos/go-spacemesh/activation"
 	"github.com/spacemeshos/go-spacemesh/atxsdata"
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/log"
@@ -241,9 +240,8 @@ func (g *Generator) generateAtxs() {
 		} else {
 			ticks = uint64(intInRange(g.rng, g.ticksRange))
 		}
-		if err := activation.SignAndFinalizeAtx(sig, atx); err != nil {
-			panic(err)
-		}
+		atx.SmesherID = sig.NodeID()
+		atx.SetID(types.RandomATXID())
 		atx.SetReceived(time.Now())
 		atx.BaseTickHeight = g.prevHeight[i]
 		atx.TickCount = ticks


### PR DESCRIPTION
## Motivation

There is no need to decode the blob since types.ActivationTx only contains data available in `atxs` table.

## Description

Changed how a checkpoint (golden) ATX is recognized. The code now examines the `received` column, which always has the value `0` for them. Ideally, we would lift the `NOT NULL` constraint and store `NULL` but I didn't want to make another lengthy migration for this now. It now avoids querying `atx_blobs`, which should speed up querying ATXs.

Removed `Signature`, the last field which had to be decoded from blob. The signature is used in two places:
1. it's part of double ATX publication malfeasance proof 
  I changed the code to fetch the signature from `atx_blobs` table
2. It's part of v2alpha1.ActivationTxV1. It's not clear whether returning the signature of ATX is valuable. The user of this API could check if ATXID belongs to a specific user but nothing more - there is no way of checking if the rest of the values belong to the same ID (one would need the entire ATX blob to do this).

For now, I removed the signature in the GRPC API in go-sm code (api is unchanged).

## Test Plan

existing tests pass

## TODO

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [ ] Update documentation as needed
- [ ] Update [changelog](../CHANGELOG.md) as needed
