### PR TITLE
[Merged by Bors] - Increase supported number of ATXs to 4.5 Mio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ is macOS 14 (Sonoma) or later ([#5879](https://github.com/spacemeshos/go-spaceme
 
 * [#5877](https://github.com/spacemeshos/go-spacemesh/pull/5877) Fix verifying ATX chain after checkpoint.
 
+* [#5896](https://github.com/spacemeshos/go-spacemesh/pull/5896) Increase supported number of ATXs to 4.5 Mio.
+
 ## (v1.5.0)
 
 ### Upgrade information

--- a/common/types/activation.go
+++ b/common/types/activation.go
@@ -385,7 +385,7 @@ func ATXIDsToHashes(ids []ATXID) []Hash32 {
 
 type EpochActiveSet struct {
 	Epoch EpochID
-	Set   []ATXID `scale:"max=3500000"` // to be in line with `EpochData` in fetch/wire_types.go
+	Set   []ATXID `scale:"max=4500000"` // to be in line with `EpochData` in fetch/wire_types.go
 }
 
 var MaxEpochActiveSetSize = scale.MustGetMaxElements[EpochActiveSet]("Set")

--- a/common/types/activation_scale.go
+++ b/common/types/activation_scale.go
@@ -91,7 +91,7 @@ func (t *EpochActiveSet) EncodeScale(enc *scale.Encoder) (total int, err error) 
 		total += n
 	}
 	{
-		n, err := scale.EncodeStructSliceWithLimit(enc, t.Set, 3500000)
+		n, err := scale.EncodeStructSliceWithLimit(enc, t.Set, 4500000)
 		if err != nil {
 			return total, err
 		}
@@ -110,7 +110,7 @@ func (t *EpochActiveSet) DecodeScale(dec *scale.Decoder) (total int, err error) 
 		t.Epoch = EpochID(field)
 	}
 	{
-		field, n, err := scale.DecodeStructSliceWithLimit[ATXID](dec, 3500000)
+		field, n, err := scale.DecodeStructSliceWithLimit[ATXID](dec, 4500000)
 		if err != nil {
 			return total, err
 		}

--- a/common/types/ballot.go
+++ b/common/types/ballot.go
@@ -71,6 +71,8 @@ type Ballot struct {
 	EligibilityProofs []VotingEligibility `scale:"max=25000"`
 	// from the smesher's view, the set of ATXs eligible to vote and propose block content in this epoch
 	// only present in smesher's first ballot of the epoch
+	// this field isn't actually used any more (replaced by InnerBallot.EpochData)
+	// TODO (mafa): remove this field in Ballot v2
 	ActiveSet []ATXID `scale:"max=3500000"`
 
 	// the following fields are kept private and from being serialized

--- a/common/types/block.go
+++ b/common/types/block.go
@@ -77,14 +77,14 @@ type InnerBlock struct {
 	// In this case they will get all 50 available slots in all 4032 layers of the epoch.
 	// Additionally every other identity on the network that successfully published an ATX will get 1 slot.
 	//
-	// If we expect 3.5 Mio ATXs that would be a total of 3.5 Mio + 50 * 4032 = 3 701 600 slots.
+	// If we expect 4.5 Mio ATXs that would be a total of 4.5 Mio + 50 * 4032 = 4 701 600 slots.
 	// Since these are randomly distributed across the epoch, we can expect an average of n * p =
-	// 3 701 600 / 4032 = 918.1 rewards in a block with a standard deviation of sqrt(n * p * (1 - p)) =
-	// sqrt(3 701 600 * 1/4032 * 4031/4032) = 30.3
+	// 4 701 600 / 4032 = 1166.1 rewards in a block with a standard deviation of sqrt(n * p * (1 - p)) =
+	// sqrt(3 701 600 * 1/4032 * 4031/4032) = 34.1
 	//
-	// This means that we can expect a maximum of 918.1 + 6*30.3 = 1100.0 rewards per block with
+	// This means that we can expect a maximum of 1166.1 + 6*34.1 = 1370.9 rewards per block with
 	// > 99.9997% probability.
-	Rewards []AnyReward     `scale:"max=1100"`
+	Rewards []AnyReward     `scale:"max=1370"`
 	TxIDs   []TransactionID `scale:"max=100000"`
 }
 

--- a/common/types/block_scale.go
+++ b/common/types/block_scale.go
@@ -45,7 +45,7 @@ func (t *InnerBlock) EncodeScale(enc *scale.Encoder) (total int, err error) {
 		total += n
 	}
 	{
-		n, err := scale.EncodeStructSliceWithLimit(enc, t.Rewards, 1100)
+		n, err := scale.EncodeStructSliceWithLimit(enc, t.Rewards, 1370)
 		if err != nil {
 			return total, err
 		}
@@ -79,7 +79,7 @@ func (t *InnerBlock) DecodeScale(dec *scale.Decoder) (total int, err error) {
 		t.TickHeight = uint64(field)
 	}
 	{
-		field, n, err := scale.DecodeStructSliceWithLimit[AnyReward](dec, 1100)
+		field, n, err := scale.DecodeStructSliceWithLimit[AnyReward](dec, 1370)
 		if err != nil {
 			return total, err
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -200,7 +200,7 @@ func DefaultConfig() Config {
 		Sync:            syncer.DefaultConfig(),
 		Recovery:        checkpoint.DefaultConfig(),
 		Cache:           datastore.DefaultConfig(),
-		ActiveSet:       miner.DefaultActiveSetPrepartion(),
+		ActiveSet:       miner.DefaultActiveSetPreparation(),
 	}
 }
 

--- a/fetch/wire_types.go
+++ b/fetch/wire_types.go
@@ -37,7 +37,7 @@ type RequestMessage struct {
 type ResponseMessage struct {
 	Hash types.Hash32
 	// keep in line with limit of Response.Data in `p2p/server/server.go`
-	Data []byte `scale:"max=125829120"` // 120 MiB > 3.5 mio ATX * 32 bytes per ID
+	Data []byte `scale:"max=157286400"` // 150 MiB > 4.5 mio ATX * 32 bytes per ID
 }
 
 // RequestBatch is a batch of requests and a hash of all requests as ID.
@@ -116,7 +116,7 @@ type MeshHashes struct {
 }
 
 type MaliciousIDs struct {
-	NodeIDs []types.NodeID `scale:"max=3500000"` // to be in line with `EpochData.AtxIDs` below
+	NodeIDs []types.NodeID `scale:"max=4500000"` // to be in line with `EpochData.AtxIDs` below
 }
 
 type EpochData struct {
@@ -124,11 +124,11 @@ type EpochData struct {
 	// - the size of `ResponseMessage` above
 	// - the size of `NodeIDs` in `MaliciousIDs` above
 	// - the size of `Set` in `EpochActiveSet` in common/types/activation.go
-	// - the fields `EligibilityProofs` and `ActiveSet` in the type `Ballot` in common/types/ballot.go
+	// - the size of `EligibilityProofs` in the type `Ballot` in common/types/ballot.go
 	// - the size of `Rewards` in the type `InnerBlock` in common/types/block.go
 	// - the size of `Ballots` in the type `LayerData` below
 	// - the size of `Proposals` in the type `Value` in hare3/types.go
-	AtxIDs []types.ATXID `scale:"max=3500000"`
+	AtxIDs []types.ATXID `scale:"max=4500000"`
 }
 
 // LayerData is the data response for a given layer ID.
@@ -139,14 +139,14 @@ type LayerData struct {
 	// In this case they will get all 50 available slots in all 4032 layers of the epoch.
 	// Additionally every other identity on the network that successfully published an ATX will get 1 slot.
 	//
-	// If we expect 2.7 Mio ATXs that would be a total of 2.7 Mio + 50 * 4032 = 3 701 600 slots.
+	// If we expect 4.5 Mio ATXs that would be a total of 4.5 Mio + 50 * 4032 = 4 701 600 slots.
 	// Since these are randomly distributed across the epoch, we can expect an average of n * p =
-	// 3 701 600 / 4032 = 918.1 ballots in a layer with a standard deviation of sqrt(n * p * (1 - p)) =
-	// sqrt(3 701 600 * 1/4032 * 4031/4032) = 30.3
+	// 4 701 600 / 4032 = 1166.1 ballots in a layer with a standard deviation of sqrt(n * p * (1 - p)) =
+	// sqrt(3 701 600 * 1/4032 * 4031/4032) = 34.1
 	//
-	// This means that we can expect a maximum of 918.1 + 6*30.3 = 1100.0 ballots per layer with
+	// This means that we can expect a maximum of 1166.1 + 6*34.1 = 1370.9 ballots per layer with
 	// > 99.9997% probability.
-	Ballots []types.BallotID `scale:"max=1100"`
+	Ballots []types.BallotID `scale:"max=1370"`
 }
 
 type OpinionRequest struct {

--- a/fetch/wire_types_scale.go
+++ b/fetch/wire_types_scale.go
@@ -55,7 +55,7 @@ func (t *ResponseMessage) EncodeScale(enc *scale.Encoder) (total int, err error)
 		total += n
 	}
 	{
-		n, err := scale.EncodeByteSliceWithLimit(enc, t.Data, 125829120)
+		n, err := scale.EncodeByteSliceWithLimit(enc, t.Data, 157286400)
 		if err != nil {
 			return total, err
 		}
@@ -73,7 +73,7 @@ func (t *ResponseMessage) DecodeScale(dec *scale.Decoder) (total int, err error)
 		total += n
 	}
 	{
-		field, n, err := scale.DecodeByteSliceWithLimit(dec, 125829120)
+		field, n, err := scale.DecodeByteSliceWithLimit(dec, 157286400)
 		if err != nil {
 			return total, err
 		}
@@ -235,7 +235,7 @@ func (t *MeshHashes) DecodeScale(dec *scale.Decoder) (total int, err error) {
 
 func (t *MaliciousIDs) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	{
-		n, err := scale.EncodeStructSliceWithLimit(enc, t.NodeIDs, 3500000)
+		n, err := scale.EncodeStructSliceWithLimit(enc, t.NodeIDs, 4500000)
 		if err != nil {
 			return total, err
 		}
@@ -246,7 +246,7 @@ func (t *MaliciousIDs) EncodeScale(enc *scale.Encoder) (total int, err error) {
 
 func (t *MaliciousIDs) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	{
-		field, n, err := scale.DecodeStructSliceWithLimit[types.NodeID](dec, 3500000)
+		field, n, err := scale.DecodeStructSliceWithLimit[types.NodeID](dec, 4500000)
 		if err != nil {
 			return total, err
 		}
@@ -258,7 +258,7 @@ func (t *MaliciousIDs) DecodeScale(dec *scale.Decoder) (total int, err error) {
 
 func (t *EpochData) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	{
-		n, err := scale.EncodeStructSliceWithLimit(enc, t.AtxIDs, 3500000)
+		n, err := scale.EncodeStructSliceWithLimit(enc, t.AtxIDs, 4500000)
 		if err != nil {
 			return total, err
 		}
@@ -269,7 +269,7 @@ func (t *EpochData) EncodeScale(enc *scale.Encoder) (total int, err error) {
 
 func (t *EpochData) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	{
-		field, n, err := scale.DecodeStructSliceWithLimit[types.ATXID](dec, 3500000)
+		field, n, err := scale.DecodeStructSliceWithLimit[types.ATXID](dec, 4500000)
 		if err != nil {
 			return total, err
 		}
@@ -281,7 +281,7 @@ func (t *EpochData) DecodeScale(dec *scale.Decoder) (total int, err error) {
 
 func (t *LayerData) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	{
-		n, err := scale.EncodeStructSliceWithLimit(enc, t.Ballots, 1100)
+		n, err := scale.EncodeStructSliceWithLimit(enc, t.Ballots, 1370)
 		if err != nil {
 			return total, err
 		}
@@ -292,7 +292,7 @@ func (t *LayerData) EncodeScale(enc *scale.Encoder) (total int, err error) {
 
 func (t *LayerData) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	{
-		field, n, err := scale.DecodeStructSliceWithLimit[types.BallotID](dec, 1100)
+		field, n, err := scale.DecodeStructSliceWithLimit[types.BallotID](dec, 1370)
 		if err != nil {
 			return total, err
 		}

--- a/hare3/types.go
+++ b/hare3/types.go
@@ -82,14 +82,14 @@ type Value struct {
 	// In this case they will get all 50 available slots in all 4032 layers of the epoch.
 	// Additionally every other identity on the network that successfully published an ATX will get 1 slot.
 	//
-	// If we expect 2.7 Mio ATXs that would be a total of 2.7 Mio + 50 * 4032 = 3 701 600 slots.
+	// If we expect 4.5 Mio ATXs that would be a total of 4.5 Mio + 50 * 4032 = 4 701 600 slots.
 	// Since these are randomly distributed across the epoch, we can expect an average of n * p =
-	// 3 701 600 / 4032 = 918.1 eligibilities in a layer with a standard deviation of sqrt(n * p * (1 - p)) =
-	// sqrt(3 701 600 * 1/4032 * 4031/4032) = 1100.0
+	// 4 701 600 / 4032 = 1166.1 eligibilities in a layer with a standard deviation of sqrt(n * p * (1 - p)) =
+	// sqrt(3 701 600 * 1/4032 * 4031/4032) = 34.1
 	//
-	// This means that we can expect a maximum of 918.1 + 6*1100.0 = 880.6 eligibilities in a layer with
+	// This means that we can expect a maximum of 1166.1 + 6*34.1 = 1370.9 eligibilities in a layer with
 	// > 99.9997% probability.
-	Proposals []types.ProposalID `scale:"max=1100"`
+	Proposals []types.ProposalID `scale:"max=1370"`
 	// Reference is set in messages for commit and notify rounds.
 	Reference *types.Hash32
 }

--- a/hare3/types_scale.go
+++ b/hare3/types_scale.go
@@ -48,7 +48,7 @@ func (t *IterRound) DecodeScale(dec *scale.Decoder) (total int, err error) {
 
 func (t *Value) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	{
-		n, err := scale.EncodeStructSliceWithLimit(enc, t.Proposals, 1100)
+		n, err := scale.EncodeStructSliceWithLimit(enc, t.Proposals, 1370)
 		if err != nil {
 			return total, err
 		}
@@ -66,7 +66,7 @@ func (t *Value) EncodeScale(enc *scale.Encoder) (total int, err error) {
 
 func (t *Value) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	{
-		field, n, err := scale.DecodeStructSliceWithLimit[types.ProposalID](dec, 1100)
+		field, n, err := scale.DecodeStructSliceWithLimit[types.ProposalID](dec, 1370)
 		if err != nil {
 			return total, err
 		}

--- a/miner/proposal_builder.go
+++ b/miner/proposal_builder.go
@@ -165,7 +165,7 @@ type ActiveSetPreparation struct {
 	Tries int `mapstructure:"tries"`
 }
 
-func DefaultActiveSetPrepartion() ActiveSetPreparation {
+func DefaultActiveSetPreparation() ActiveSetPreparation {
 	return ActiveSetPreparation{
 		Window:        1 * time.Second,
 		RetryInterval: 1 * time.Second,
@@ -273,7 +273,7 @@ func New(
 	pb := &ProposalBuilder{
 		cfg: config{
 			workersLimit: runtime.NumCPU(),
-			activeSet:    DefaultActiveSetPrepartion(),
+			activeSet:    DefaultActiveSetPreparation(),
 		},
 		logger:    log.NewNop(),
 		clock:     clock,


### PR DESCRIPTION
## Motivation

Another round of increasing limits to support more ATXs per epoch.

## Description

Increased the limits on scale collections and updated documentation

## Test Plan

n/a

## TODO

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
