### PR TITLE
[Merged by Bors] - Split ATX handler to prepare for handling ATX v2

### DIFF
--- a/activation/handler.go
+++ b/activation/handler.go
@@ -7,24 +7,16 @@ import (
 	"sync"
 	"time"
 
-	"github.com/spacemeshos/post/shared"
-	"github.com/spacemeshos/post/verifying"
-	"golang.org/x/exp/maps"
-
 	"github.com/spacemeshos/go-spacemesh/activation/wire"
 	"github.com/spacemeshos/go-spacemesh/atxsdata"
 	"github.com/spacemeshos/go-spacemesh/codec"
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/datastore"
-	"github.com/spacemeshos/go-spacemesh/events"
 	"github.com/spacemeshos/go-spacemesh/log"
 	mwire "github.com/spacemeshos/go-spacemesh/malfeasance/wire"
 	"github.com/spacemeshos/go-spacemesh/p2p"
 	"github.com/spacemeshos/go-spacemesh/p2p/pubsub"
 	"github.com/spacemeshos/go-spacemesh/signing"
-	"github.com/spacemeshos/go-spacemesh/sql"
-	"github.com/spacemeshos/go-spacemesh/sql/atxs"
-	"github.com/spacemeshos/go-spacemesh/sql/identities"
 	"github.com/spacemeshos/go-spacemesh/system"
 )
 
@@ -37,27 +29,16 @@ var (
 
 // Handler processes the atxs received from all nodes and their validity status.
 type Handler struct {
-	local           p2p.Peer
-	cdb             *datastore.CachedDB
-	atxsdata        *atxsdata.Data
-	edVerifier      *signing.EdVerifier
-	clock           layerClock
-	publisher       pubsub.Publisher
-	tickSize        uint64
-	goldenATXID     types.ATXID
-	nipostValidator nipostValidator
-	beacon          AtxReceiver
-	tortoise        system.Tortoise
-	log             log.Log
-	fetcher         system.Fetcher
-
-	signerMtx sync.Mutex
-	signers   map[types.NodeID]*signing.EdSigner
+	local     p2p.Peer
+	publisher pubsub.Publisher
+	log       log.Log
 
 	// inProgress map gathers ATXs that are currently being processed.
 	// It's used to avoid processing the same ATX twice.
 	inProgress   map[types.ATXID][]chan error
 	inProgressMu sync.Mutex
+
+	v1 *HandlerV1
 }
 
 // NewHandler returns a data handler for ATX.
@@ -76,392 +57,34 @@ func NewHandler(
 	tortoise system.Tortoise,
 	log log.Log,
 ) *Handler {
-	return &Handler{
-		local:           local,
-		cdb:             cdb,
-		atxsdata:        atxsdata,
-		edVerifier:      edVerifier,
-		clock:           c,
-		publisher:       pub,
-		tickSize:        tickSize,
-		goldenATXID:     goldenATXID,
-		nipostValidator: nipostValidator,
-		log:             log,
-		fetcher:         fetcher,
-		beacon:          beacon,
-		tortoise:        tortoise,
+	h := &Handler{
+		local:     local,
+		publisher: pub,
+		log:       log,
+		v1: &HandlerV1{
+			local:           local,
+			cdb:             cdb,
+			atxsdata:        atxsdata,
+			edVerifier:      edVerifier,
+			clock:           c,
+			tickSize:        tickSize,
+			goldenATXID:     goldenATXID,
+			nipostValidator: nipostValidator,
+			log:             log,
+			fetcher:         fetcher,
+			beacon:          beacon,
+			tortoise:        tortoise,
+			signers:         make(map[types.NodeID]*signing.EdSigner),
+		},
 
-		signers:    make(map[types.NodeID]*signing.EdSigner),
 		inProgress: make(map[types.ATXID][]chan error),
 	}
+
+	return h
 }
 
 func (h *Handler) Register(sig *signing.EdSigner) {
-	h.signerMtx.Lock()
-	defer h.signerMtx.Unlock()
-	if _, exists := h.signers[sig.NodeID()]; exists {
-		h.log.With().Error("signing key already registered", log.ShortStringer("id", sig.NodeID()))
-		return
-	}
-
-	h.log.With().Info("registered signing key", log.ShortStringer("id", sig.NodeID()))
-	h.signers[sig.NodeID()] = sig
-}
-
-func (h *Handler) syntacticallyValidate(ctx context.Context, atx *wire.ActivationTxV1) error {
-	if atx.NIPost == nil {
-		return fmt.Errorf("nil nipost for atx %s", atx.ID())
-	}
-	current := h.clock.CurrentLayer().GetEpoch()
-	if atx.PublishEpoch > current+1 {
-		return fmt.Errorf("atx publish epoch is too far in the future: %d > %d", atx.PublishEpoch, current+1)
-	}
-	if atx.PositioningATXID == types.EmptyATXID {
-		return errors.New("empty positioning atx")
-	}
-
-	switch {
-	case atx.PrevATXID == types.EmptyATXID:
-		if atx.InitialPost == nil {
-			return errors.New("no prev atx declared, but initial post is not included")
-		}
-		if atx.NodeID == nil {
-			return errors.New("no prev atx declared, but node id is missing")
-		}
-		if atx.VRFNonce == nil {
-			return errors.New("no prev atx declared, but vrf nonce is missing")
-		}
-		if atx.CommitmentATXID == nil {
-			return errors.New("no prev atx declared, but commitment atx is missing")
-		}
-		if *atx.CommitmentATXID == types.EmptyATXID {
-			return errors.New("empty commitment atx")
-		}
-		if atx.Sequence != 0 {
-			return errors.New("no prev atx declared, but sequence number not zero")
-		}
-
-		// Use the NIPost's Post metadata, while overriding the challenge to a zero challenge,
-		// as expected from the initial Post.
-		initialPostMetadata := types.PostMetadata{
-			Challenge:     shared.ZeroChallenge,
-			LabelsPerUnit: atx.NIPost.PostMetadata.LabelsPerUnit,
-		}
-		if err := h.nipostValidator.VRFNonce(
-			atx.SmesherID, *atx.CommitmentATXID, *atx.VRFNonce, initialPostMetadata.LabelsPerUnit, atx.NumUnits,
-		); err != nil {
-			return fmt.Errorf("invalid vrf nonce: %w", err)
-		}
-		post := wire.PostFromWireV1(atx.InitialPost)
-		if err := h.nipostValidator.Post(
-			ctx, atx.SmesherID, *atx.CommitmentATXID, post, &initialPostMetadata, atx.NumUnits,
-		); err != nil {
-			return fmt.Errorf("invalid initial post: %w", err)
-		}
-	default:
-		if atx.NodeID != nil {
-			return errors.New("prev atx declared, but node id is included")
-		}
-		if atx.InitialPost != nil {
-			return errors.New("prev atx declared, but initial post is included")
-		}
-		if atx.CommitmentATXID != nil {
-			return errors.New("prev atx declared, but commitment atx is included")
-		}
-	}
-	return nil
-}
-
-// Obtain the commitment ATX ID for the given ATX.
-func (h *Handler) commitment(ctx context.Context, atx *wire.ActivationTxV1) (types.ATXID, error) {
-	if atx.PrevATXID == types.EmptyATXID {
-		return *atx.CommitmentATXID, nil
-	}
-	return atxs.CommitmentATX(h.cdb, atx.SmesherID)
-}
-
-// Obtain the previous ATX for the given ATX.
-// We need to decode it from the blob because we are interested in the true NumUnits value
-// that was declared by the previous ATX and the `atxs` table only holds the effective NumUnits.
-// However, in case of a golden ATX, the blob is not available and we fallback to fetching the ATX from the DB
-// to use the effective num units.
-func (h *Handler) previous(ctx context.Context, atx *wire.ActivationTxV1) (*types.ActivationTx, error) {
-	var blob sql.Blob
-	if err := atxs.LoadBlob(ctx, h.cdb, atx.PrevATXID[:], &blob); err != nil {
-		return nil, err
-	}
-
-	if blob.Bytes == nil {
-		// An empty blob indicates a golden ATX (after a checkpoint-recovery).
-		// Fallback to fetching it from the DB to get the effective NumUnits.
-		atx, err := atxs.Get(h.cdb, atx.PrevATXID)
-		if err != nil {
-			return nil, fmt.Errorf("fetching golden previous atx: %w", err)
-		}
-		return atx, nil
-	}
-
-	var prev wire.ActivationTxV1
-	if err := codec.Decode(blob.Bytes, &prev); err != nil {
-		return nil, fmt.Errorf("decoding previous atx: %w", err)
-	}
-	return wire.ActivationTxFromWireV1(&prev, blob.Bytes...), nil
-}
-
-func (h *Handler) syntacticallyValidateDeps(
-	ctx context.Context,
-	atx *wire.ActivationTxV1,
-) (leaves uint64, effectiveNumUnits uint32, proof *mwire.MalfeasanceProof, err error) {
-	commitmentATX, err := h.commitment(ctx, atx)
-	if err != nil {
-		return 0, 0, nil, fmt.Errorf("commitment atx for %s not found: %w", atx.SmesherID, err)
-	}
-
-	if atx.PrevATXID == types.EmptyATXID {
-		if err := h.nipostValidator.InitialNIPostChallengeV1(&atx.NIPostChallengeV1, h.cdb, h.goldenATXID); err != nil {
-			return 0, 0, nil, err
-		}
-		effectiveNumUnits = atx.NumUnits
-	} else {
-		previous, err := h.previous(ctx, atx)
-		if err != nil {
-			return 0, 0, nil, fmt.Errorf("fetching previous atx %s: %w", atx.PrevATXID, err)
-		}
-		if err := h.validateNonInitialAtx(ctx, atx, previous, commitmentATX); err != nil {
-			return 0, 0, nil, err
-		}
-		effectiveNumUnits = min(previous.NumUnits, atx.NumUnits)
-	}
-
-	err = h.nipostValidator.PositioningAtx(atx.PositioningATXID, h.cdb, h.goldenATXID, atx.PublishEpoch)
-	if err != nil {
-		return 0, 0, nil, err
-	}
-
-	expectedChallengeHash := atx.NIPostChallengeV1.Hash()
-	h.log.WithContext(ctx).
-		With().
-		Info("validating nipost", log.String("expected_challenge_hash", expectedChallengeHash.String()), atx.ID())
-
-	leaves, err = h.nipostValidator.NIPost(
-		ctx,
-		atx.SmesherID,
-		commitmentATX,
-		wire.NiPostFromWireV1(atx.NIPost),
-		expectedChallengeHash,
-		atx.NumUnits,
-		PostSubset([]byte(h.local)), // use the local peer ID as seed for random subset
-	)
-	var invalidIdx *verifying.ErrInvalidIndex
-	if errors.As(err, &invalidIdx) {
-		h.log.WithContext(ctx).With().Info("ATX with invalid post index", atx.ID(), log.Int("index", invalidIdx.Index))
-		proof := &mwire.MalfeasanceProof{
-			Layer: atx.PublishEpoch.FirstLayer(),
-			Proof: mwire.Proof{
-				Type: mwire.InvalidPostIndex,
-				Data: &mwire.InvalidPostIndexProof{
-					Atx:        *atx,
-					InvalidIdx: uint32(invalidIdx.Index),
-				},
-			},
-		}
-		encodedProof := codec.MustEncode(proof)
-		if err := identities.SetMalicious(h.cdb, atx.SmesherID, encodedProof, time.Now()); err != nil {
-			return 0, 0, nil, fmt.Errorf("adding malfeasance proof: %w", err)
-		}
-		h.cdb.CacheMalfeasanceProof(atx.SmesherID, proof)
-		h.tortoise.OnMalfeasance(atx.SmesherID)
-		return 0, 0, proof, nil
-	}
-	if err != nil {
-		return 0, 0, nil, fmt.Errorf("invalid nipost: %w", err)
-	}
-
-	return leaves, effectiveNumUnits, nil, err
-}
-
-func (h *Handler) validateNonInitialAtx(
-	ctx context.Context,
-	atx *wire.ActivationTxV1,
-	previous *types.ActivationTx,
-	commitment types.ATXID,
-) error {
-	if err := h.nipostValidator.NIPostChallengeV1(&atx.NIPostChallengeV1, previous, atx.SmesherID); err != nil {
-		return err
-	}
-
-	nonce := atx.VRFNonce
-	if atx.NumUnits > previous.NumUnits && nonce == nil {
-		h.log.WithContext(ctx).With().Info("post size increased without new vrf Nonce, re-validating current nonce",
-			atx.ID(),
-			log.Stringer("smesher", atx.SmesherID),
-		)
-
-		// This is not expected to happen very often, so we query the database
-		// directly here without using the cache.
-		current, err := atxs.NonceByID(h.cdb, previous.ID())
-		if err != nil {
-			return fmt.Errorf("failed to get current nonce: %w", err)
-		}
-		nonce = (*uint64)(&current)
-	}
-
-	if nonce != nil {
-		err := h.nipostValidator.
-			VRFNonce(atx.SmesherID, commitment, *nonce, atx.NIPost.PostMetadata.LabelsPerUnit, atx.NumUnits)
-		if err != nil {
-			return fmt.Errorf("invalid vrf nonce: %w", err)
-		}
-	}
-
-	return nil
-}
-
-// contextuallyValidateAtx ensures that the previous ATX referenced is the last known ATX for the referenced miner ID.
-// If a previous ATX is not referenced, it validates that indeed there's no previous known ATX for that miner ID.
-func (h *Handler) contextuallyValidateAtx(atx *wire.ActivationTxV1) error {
-	lastAtx, err := atxs.GetLastIDByNodeID(h.cdb, atx.SmesherID)
-	if err == nil && atx.PrevATXID == lastAtx {
-		// last atx referenced equals last ATX seen from node
-		return nil
-	}
-
-	if err == nil && atx.PrevATXID == types.EmptyATXID {
-		// no previous atx declared, but already seen at least one atx from node
-		return fmt.Errorf(
-			"no prev atx reported, but other atx with same node id (%v) found: %v",
-			atx.SmesherID,
-			lastAtx.ShortString(),
-		)
-	}
-
-	if err == nil && atx.PrevATXID != lastAtx {
-		// last atx referenced does not equal last ATX seen from node
-		return errors.New("last atx is not the one referenced")
-	}
-
-	if errors.Is(err, sql.ErrNotFound) && atx.PrevATXID == types.EmptyATXID {
-		// no previous atx found and none referenced
-		return nil
-	}
-
-	if err != nil && atx.PrevATXID != types.EmptyATXID {
-		// no previous atx found but previous atx referenced
-		h.log.With().Error("could not fetch node last atx",
-			atx.ID(),
-			log.Stringer("smesher", atx.SmesherID),
-			log.Err(err),
-		)
-		return fmt.Errorf("could not fetch node last atx: %w", err)
-	}
-
-	return err
-}
-
-// cacheAtx caches the atx in the atxsdata cache.
-// Returns true if the atx was cached, false otherwise.
-func (h *Handler) cacheAtx(ctx context.Context, atx *types.ActivationTx, nonce types.VRFPostIndex) *atxsdata.ATX {
-	if !h.atxsdata.IsEvicted(atx.TargetEpoch()) {
-		malicious, err := h.cdb.IsMalicious(atx.SmesherID)
-		if err != nil {
-			h.log.With().Error("failed is malicious read", log.Err(err), log.Context(ctx))
-			return nil
-		}
-		return h.atxsdata.AddFromAtx(atx, nonce, malicious)
-	}
-	return nil
-}
-
-// storeAtx stores an ATX and notifies subscribers of the ATXID.
-func (h *Handler) storeAtx(ctx context.Context, atx *types.ActivationTx) (*mwire.MalfeasanceProof, error) {
-	var nonce *types.VRFPostIndex
-	malicious, err := h.cdb.IsMalicious(atx.SmesherID)
-	if err != nil {
-		return nil, fmt.Errorf("checking if node is malicious: %w", err)
-	}
-	var proof *mwire.MalfeasanceProof
-	if err := h.cdb.WithTx(ctx, func(tx *sql.Tx) error {
-		if malicious {
-			if err := atxs.Add(tx, atx); err != nil && !errors.Is(err, sql.ErrObjectExists) {
-				return fmt.Errorf("add atx to db: %w", err)
-			}
-			return nil
-		}
-
-		prev, err := atxs.GetByEpochAndNodeID(tx, atx.PublishEpoch, atx.SmesherID)
-		if err != nil && !errors.Is(err, sql.ErrNotFound) {
-			return err
-		}
-
-		// do ID check to be absolutely sure.
-		if prev != nil && prev.ID() != atx.ID() {
-			if _, ok := h.signers[atx.SmesherID]; ok {
-				// if we land here we tried to publish 2 ATXs in the same epoch
-				// don't punish ourselves but fail validation and thereby the handling of the incoming ATX
-				return fmt.Errorf("%s already published an ATX in epoch %d", atx.SmesherID.ShortString(),
-					atx.PublishEpoch,
-				)
-			}
-
-			var atxProof mwire.AtxProof
-			for i, a := range []*types.ActivationTx{prev, atx} {
-				atxProof.Messages[i] = mwire.AtxProofMsg{
-					InnerMsg: types.ATXMetadata{
-						PublishEpoch: a.PublishEpoch,
-						MsgHash:      a.ID().Hash32(),
-					},
-					SmesherID: a.SmesherID,
-					Signature: a.Signature,
-				}
-			}
-			proof = &mwire.MalfeasanceProof{
-				Layer: atx.PublishEpoch.FirstLayer(),
-				Proof: mwire.Proof{
-					Type: mwire.MultipleATXs,
-					Data: &atxProof,
-				},
-			}
-			encoded, err := codec.Encode(proof)
-			if err != nil {
-				h.log.With().Panic("failed to encode malfeasance proof", log.Err(err))
-			}
-			if err := identities.SetMalicious(tx, atx.SmesherID, encoded, time.Now()); err != nil {
-				return fmt.Errorf("add malfeasance proof: %w", err)
-			}
-
-			h.log.WithContext(ctx).With().Warning("smesher produced more than one atx in the same epoch",
-				log.Stringer("smesher", atx.SmesherID),
-				log.Object("prev", prev),
-				log.Object("curr", atx),
-			)
-		}
-
-		nonce, err = atxs.AddGettingNonce(tx, atx)
-		if err != nil && !errors.Is(err, sql.ErrObjectExists) {
-			return fmt.Errorf("add atx to db: %w", err)
-		}
-		return nil
-	}); err != nil {
-		return nil, fmt.Errorf("store atx: %w", err)
-	}
-	if nonce == nil {
-		return nil, errors.New("no nonce")
-	}
-	atxs.AtxAdded(h.cdb, atx)
-	if proof != nil {
-		h.cdb.CacheMalfeasanceProof(atx.SmesherID, proof)
-		h.tortoise.OnMalfeasance(atx.SmesherID)
-	}
-
-	added := h.cacheAtx(ctx, atx, *nonce)
-	h.beacon.OnAtx(atx.ToHeader())
-	if added != nil {
-		h.tortoise.OnAtx(atx.TargetEpoch(), atx.ID(), added)
-	}
-
-	h.log.WithContext(ctx).With().Debug("finished storing atx in epoch", atx.ID(), atx.PublishEpoch)
-
-	return proof, nil
+	h.v1.Register(sig)
 }
 
 // HandleSyncedAtx handles atxs received by sync.
@@ -545,7 +168,7 @@ func (h *Handler) handleAtx(
 	h.inProgressMu.Unlock()
 	h.log.WithContext(ctx).With().Info("handling incoming atx", id, log.Int("size", len(msg)))
 
-	proof, err := h.processATX(ctx, peer, atx, msg, receivedTime)
+	proof, err := h.v1.processATX(ctx, peer, atx, msg, receivedTime)
 	h.inProgressMu.Lock()
 	defer h.inProgressMu.Unlock()
 	for _, ch := range h.inProgress[id] {
@@ -554,124 +177,4 @@ func (h *Handler) handleAtx(
 	}
 	delete(h.inProgress, id)
 	return proof, err
-}
-
-func (h *Handler) processATX(
-	ctx context.Context,
-	peer p2p.Peer,
-	watx wire.ActivationTxV1,
-	blob []byte,
-	received time.Time,
-) (*mwire.MalfeasanceProof, error) {
-	if !h.edVerifier.Verify(signing.ATX, watx.SmesherID, watx.SignedBytes(), watx.Signature) {
-		return nil, fmt.Errorf("invalid atx signature: %w", errMalformedData)
-	}
-
-	existing, _ := h.cdb.GetAtxHeader(watx.ID())
-	if existing != nil {
-		return nil, fmt.Errorf("%w atx %s", errKnownAtx, watx.ID())
-	}
-
-	h.log.WithContext(ctx).With().
-		Debug("processing atx", watx.ID(), watx.PublishEpoch, log.Stringer("smesherID", watx.SmesherID))
-
-	if err := h.syntacticallyValidate(ctx, &watx); err != nil {
-		return nil, fmt.Errorf("atx %s syntactically invalid: %w", watx.ID(), err)
-	}
-
-	poetRef, atxIDs := collectAtxDeps(h.goldenATXID, &watx)
-	h.registerHashes(peer, poetRef, atxIDs)
-	if err := h.fetchReferences(ctx, poetRef, atxIDs); err != nil {
-		return nil, fmt.Errorf("fetching references for atx %s: %w", watx.ID(), err)
-	}
-
-	leaves, effectiveNumUnits, proof, err := h.syntacticallyValidateDeps(ctx, &watx)
-	if err != nil {
-		return nil, fmt.Errorf("atx %s syntactically invalid based on deps: %w", watx.ID(), err)
-	}
-
-	if proof != nil {
-		return proof, err
-	}
-
-	if err := h.contextuallyValidateAtx(&watx); err != nil {
-		h.log.WithContext(ctx).With().
-			Warning("atx is contextually invalid ", watx.ID(), log.Stringer("smesherID", watx.SmesherID), log.Err(err))
-	} else {
-		h.log.WithContext(ctx).With().Debug("atx is valid", watx.ID())
-	}
-
-	var baseTickHeight uint64
-	if watx.PositioningATXID != h.goldenATXID {
-		posAtx, err := h.cdb.GetAtxHeader(watx.PositioningATXID)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get positioning atx %s: %w", watx.PositioningATXID, err)
-		}
-		baseTickHeight = posAtx.TickHeight()
-	}
-
-	atx := wire.ActivationTxFromWireV1(&watx, blob...)
-	if h.nipostValidator.IsVerifyingFullPost() {
-		atx.SetValidity(types.Valid)
-	}
-	atx.SetReceived(received)
-	atx.NumUnits = effectiveNumUnits
-	atx.BaseTickHeight = baseTickHeight
-	atx.TickCount = leaves / h.tickSize
-
-	proof, err = h.storeAtx(ctx, atx)
-	if err != nil {
-		return nil, fmt.Errorf("cannot store atx %s: %w", atx.ShortString(), err)
-	}
-
-	events.ReportNewActivation(atx)
-	h.log.WithContext(ctx).With().Info("new atx", log.Inline(atx), log.Bool("malicious", proof != nil))
-	return proof, err
-}
-
-// registerHashes registers that the given peer should be asked for
-// the hashes of the poet proof and ATXs.
-func (h *Handler) registerHashes(peer p2p.Peer, poetRef types.Hash32, atxIDs []types.ATXID) {
-	hashes := make([]types.Hash32, 0, len(atxIDs)+1)
-	for _, id := range atxIDs {
-		hashes = append(hashes, id.Hash32())
-	}
-	hashes = append(hashes, types.Hash32(poetRef))
-	h.fetcher.RegisterPeerHashes(peer, hashes)
-}
-
-// fetchReferences makes sure that the referenced poet proof and ATXs are available.
-func (h *Handler) fetchReferences(ctx context.Context, poetRef types.Hash32, atxIDs []types.ATXID) error {
-	if err := h.fetcher.GetPoetProof(ctx, poetRef); err != nil {
-		return fmt.Errorf("missing poet proof (%s): %w", poetRef.ShortString(), err)
-	}
-
-	if len(atxIDs) == 0 {
-		return nil
-	}
-
-	if err := h.fetcher.GetAtxs(ctx, atxIDs, system.WithoutLimiting()); err != nil {
-		return fmt.Errorf("missing atxs %x: %w", atxIDs, err)
-	}
-
-	h.log.WithContext(ctx).With().Debug("done fetching references", log.Int("fetched", len(atxIDs)))
-	return nil
-}
-
-// Collect unique dependencies of an ATX.
-// Filters out EmptyATXID and the golden ATX.
-func collectAtxDeps(goldenAtxId types.ATXID, atx *wire.ActivationTxV1) (types.Hash32, []types.ATXID) {
-	ids := []types.ATXID{atx.PrevATXID, atx.PositioningATXID}
-	if atx.CommitmentATXID != nil {
-		ids = append(ids, *atx.CommitmentATXID)
-	}
-
-	filtered := make(map[types.ATXID]struct{})
-	for _, id := range ids {
-		if id != types.EmptyATXID && id != goldenAtxId {
-			filtered[id] = struct{}{}
-		}
-	}
-
-	return types.BytesToHash(atx.NIPost.PostMetadata.Challenge), maps.Keys(filtered)
 }

--- a/activation/handler_test.go
+++ b/activation/handler_test.go
@@ -114,8 +114,8 @@ func toAtx(t testing.TB, watx *wire.ActivationTxV1) *types.ActivationTx {
 	return atx
 }
 
-type testHandler struct {
-	*Handler
+type handlerMocks struct {
+	goldenATXID types.ATXID
 
 	mclock     *MocklayerClock
 	mpub       *pubsubmocks.MockPublisher
@@ -125,13 +125,22 @@ type testHandler struct {
 	mtortoise  *mocks.MockTortoise
 }
 
+type testHandler struct {
+	*Handler
+
+	cdb        *datastore.CachedDB
+	edVerifier *signing.EdVerifier
+
+	handlerMocks
+}
+
 type atxHandleOpts struct {
 	postVerificationDuration time.Duration
 	poetLeaves               uint64
 	distributedPost          bool
 }
 
-func (h *testHandler) expectAtxV1(atx *wire.ActivationTxV1, nodeId types.NodeID, opts ...func(*atxHandleOpts)) {
+func (h *handlerMocks) expectAtxV1(atx *wire.ActivationTxV1, nodeId types.NodeID, opts ...func(*atxHandleOpts)) {
 	settings := atxHandleOpts{}
 	for _, opt := range opts {
 		opt(&settings)
@@ -167,657 +176,57 @@ func (h *testHandler) expectAtxV1(atx *wire.ActivationTxV1, nodeId types.NodeID,
 	h.mtortoise.EXPECT().OnAtx(gomock.Any(), gomock.Any(), gomock.Any())
 }
 
-func newTestHandler(tb testing.TB, goldenATXID types.ATXID) *testHandler {
+type testHandlerOptions struct {
+	tickSize uint64
+}
+
+func newTestHandlerMocks(tb testing.TB, golden types.ATXID) handlerMocks {
+	ctrl := gomock.NewController(tb)
+	return handlerMocks{
+		goldenATXID: golden,
+		mclock:      NewMocklayerClock(ctrl),
+		mpub:        pubsubmocks.NewMockPublisher(ctrl),
+		mockFetch:   mocks.NewMockFetcher(ctrl),
+		mValidator:  NewMocknipostValidator(ctrl),
+		mbeacon:     NewMockAtxReceiver(ctrl),
+		mtortoise:   mocks.NewMockTortoise(ctrl),
+	}
+}
+
+func newTestHandler(tb testing.TB, goldenATXID types.ATXID, opts ...func(*testHandlerOptions)) *testHandler {
 	lg := logtest.New(tb)
 	cdb := datastore.NewCachedDB(sql.InMemory(), lg)
-	ctrl := gomock.NewController(tb)
-	mclock := NewMocklayerClock(ctrl)
-	mpub := pubsubmocks.NewMockPublisher(ctrl)
-	mockFetch := mocks.NewMockFetcher(ctrl)
-	mValidator := NewMocknipostValidator(ctrl)
+	edVerifier := signing.NewEdVerifier()
 
-	mbeacon := NewMockAtxReceiver(ctrl)
-	mtortoise := mocks.NewMockTortoise(ctrl)
-
+	options := testHandlerOptions{
+		tickSize: 1,
+	}
+	for _, opt := range opts {
+		opt(&options)
+	}
+	mocks := newTestHandlerMocks(tb, goldenATXID)
 	atxHdlr := NewHandler(
 		"localID",
 		cdb,
 		atxsdata.New(),
-		signing.NewEdVerifier(),
-		mclock,
-		mpub,
-		mockFetch,
-		1,
+		edVerifier,
+		mocks.mclock,
+		mocks.mpub,
+		mocks.mockFetch,
+		options.tickSize,
 		goldenATXID,
-		mValidator,
-		mbeacon,
-		mtortoise,
+		mocks.mValidator,
+		mocks.mbeacon,
+		mocks.mtortoise,
 		lg,
 	)
 	return &testHandler{
-		Handler: atxHdlr,
+		Handler:    atxHdlr,
+		cdb:        cdb,
+		edVerifier: edVerifier,
 
-		mclock:     mclock,
-		mpub:       mpub,
-		mockFetch:  mockFetch,
-		mValidator: mValidator,
-		mbeacon:    mbeacon,
-		mtortoise:  mtortoise,
+		handlerMocks: mocks,
 	}
-}
-
-func TestHandler_SyntacticallyValidateAtx(t *testing.T) {
-	sig, err := signing.NewEdSigner()
-	require.NoError(t, err)
-
-	goldenATXID := types.RandomATXID()
-
-	setup := func(t *testing.T) (hdlr *testHandler, prev, pos *wire.ActivationTxV1) {
-		atxHdlr := newTestHandler(t, goldenATXID)
-
-		prevAtx := newInitialATXv1(t, goldenATXID)
-		prevAtx.NumUnits = 100
-		prevAtx.Sign(sig)
-		atxHdlr.expectAtxV1(prevAtx, sig.NodeID())
-		require.NoError(t, atxHdlr.HandleGossipAtx(context.Background(), "", codec.MustEncode(prevAtx)))
-
-		otherSig, err := signing.NewEdSigner()
-		require.NoError(t, err)
-
-		posAtx := newInitialATXv1(t, goldenATXID)
-		posAtx.Sign(otherSig)
-		atxHdlr.expectAtxV1(posAtx, otherSig.NodeID())
-		require.NoError(t, atxHdlr.HandleGossipAtx(context.Background(), "", codec.MustEncode(posAtx)))
-		return atxHdlr, prevAtx, posAtx
-	}
-	t.Run("valid atx", func(t *testing.T) {
-		t.Parallel()
-		atxHdlr, prevAtx, posAtx := setup(t)
-
-		atx := newChainedActivationTxV1(t, atxHdlr.goldenATXID, prevAtx, posAtx.ID())
-		atx.PositioningATXID = posAtx.ID()
-		atx.Sign(sig)
-
-		atxHdlr.mclock.EXPECT().CurrentLayer().Return(atx.PublishEpoch.FirstLayer())
-		require.NoError(t, atxHdlr.syntacticallyValidate(context.Background(), atx))
-
-		atxHdlr.mValidator.EXPECT().
-			NIPost(gomock.Any(), atx.SmesherID, goldenATXID, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-			Return(1234, nil)
-		atxHdlr.mValidator.EXPECT().NIPostChallengeV1(gomock.Any(), gomock.Any(), atx.SmesherID)
-		atxHdlr.mValidator.EXPECT().PositioningAtx(atx.PositioningATXID, gomock.Any(), goldenATXID, gomock.Any())
-		leaves, units, proof, err := atxHdlr.syntacticallyValidateDeps(context.Background(), atx)
-		require.NoError(t, err)
-		require.Equal(t, uint64(1234), leaves)
-		require.Equal(t, atx.NumUnits, units)
-		require.Nil(t, proof)
-	})
-	t.Run("valid atx with new VRF nonce", func(t *testing.T) {
-		t.Parallel()
-		atxHdlr, prevAtx, posAtx := setup(t)
-
-		newNonce := *prevAtx.VRFNonce + 100
-		atx := newChainedActivationTxV1(t, goldenATXID, prevAtx, posAtx.ID())
-		atx.VRFNonce = &newNonce
-		atx.Sign(sig)
-
-		atxHdlr.mclock.EXPECT().CurrentLayer().Return(atx.PublishEpoch.FirstLayer())
-		require.NoError(t, atxHdlr.syntacticallyValidate(context.Background(), atx))
-
-		atxHdlr.mValidator.EXPECT().
-			NIPost(gomock.Any(), gomock.Any(), goldenATXID, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-			Return(1234, nil)
-		atxHdlr.mValidator.EXPECT().NIPostChallengeV1(gomock.Any(), gomock.Any(), gomock.Any())
-		atxHdlr.mValidator.EXPECT().PositioningAtx(atx.PositioningATXID, gomock.Any(), goldenATXID, atx.PublishEpoch)
-		atxHdlr.mValidator.EXPECT().
-			VRFNonce(gomock.Any(), goldenATXID, newNonce, gomock.Any(), atx.NumUnits)
-		leaves, units, proof, err := atxHdlr.syntacticallyValidateDeps(context.Background(), atx)
-		require.NoError(t, err)
-		require.Equal(t, uint64(1234), leaves)
-		require.Equal(t, atx.NumUnits, units)
-		require.Nil(t, proof)
-	})
-	t.Run("valid atx with decreasing num units", func(t *testing.T) {
-		t.Parallel()
-		atxHdlr, prevAtx, posAtx := setup(t)
-
-		atx := newChainedActivationTxV1(t, goldenATXID, prevAtx, posAtx.ID())
-		atx.NumUnits = prevAtx.NumUnits - 10
-		atx.Sign(sig)
-
-		atxHdlr.mclock.EXPECT().CurrentLayer().Return(atx.PublishEpoch.FirstLayer())
-		require.NoError(t, atxHdlr.syntacticallyValidate(context.Background(), atx))
-		atxHdlr.mValidator.EXPECT().
-			NIPost(gomock.Any(), gomock.Any(), goldenATXID, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-			Return(uint64(1234), nil)
-		atxHdlr.mValidator.EXPECT().NIPostChallengeV1(gomock.Any(), gomock.Any(), gomock.Any())
-		atxHdlr.mValidator.EXPECT().PositioningAtx(atx.PositioningATXID, gomock.Any(), goldenATXID, atx.PublishEpoch)
-		leaves, units, proof, err := atxHdlr.syntacticallyValidateDeps(context.Background(), atx)
-		require.NoError(t, err)
-		require.Equal(t, uint64(1234), leaves)
-		require.Equal(t, atx.NumUnits, units)
-		require.Nil(t, proof)
-	})
-	t.Run("atx with increasing num units, no new VRF, old valid", func(t *testing.T) {
-		t.Parallel()
-		atxHdlr, prevAtx, posAtx := setup(t)
-
-		atx := newChainedActivationTxV1(t, goldenATXID, prevAtx, posAtx.ID())
-		atx.NumUnits = prevAtx.NumUnits + 10
-		atx.Sign(sig)
-
-		atxHdlr.mclock.EXPECT().CurrentLayer().Return(atx.PublishEpoch.FirstLayer())
-		require.NoError(t, atxHdlr.syntacticallyValidate(context.Background(), atx))
-		atxHdlr.mValidator.EXPECT().
-			NIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-			Return(uint64(1234), nil)
-		atxHdlr.mValidator.EXPECT().NIPostChallengeV1(gomock.Any(), gomock.Any(), gomock.Any())
-		atxHdlr.mValidator.EXPECT().PositioningAtx(atx.PositioningATXID, gomock.Any(), gomock.Any(), gomock.Any())
-		atxHdlr.mValidator.EXPECT().VRFNonce(gomock.Any(), goldenATXID, *prevAtx.VRFNonce, gomock.Any(), atx.NumUnits)
-		leaves, units, proof, err := atxHdlr.syntacticallyValidateDeps(context.Background(), atx)
-		require.NoError(t, err)
-		require.Equal(t, uint64(1234), leaves)
-		require.Equal(t, prevAtx.NumUnits, units)
-		require.Nil(t, proof)
-	})
-	t.Run("atx with increasing num units, no new VRF, old invalid for new size", func(t *testing.T) {
-		t.Parallel()
-		atxHdlr, prevAtx, posAtx := setup(t)
-
-		atx := newChainedActivationTxV1(t, goldenATXID, prevAtx, posAtx.ID())
-		atx.NumUnits = prevAtx.NumUnits + 10
-		atx.Sign(sig)
-
-		atxHdlr.mclock.EXPECT().CurrentLayer().Return(atx.PublishEpoch.FirstLayer())
-		require.NoError(t, atxHdlr.syntacticallyValidate(context.Background(), atx))
-
-		atxHdlr.mValidator.EXPECT().NIPostChallengeV1(gomock.Any(), gomock.Any(), gomock.Any())
-		atxHdlr.mValidator.EXPECT().
-			VRFNonce(gomock.Any(), goldenATXID, *prevAtx.VRFNonce, gomock.Any(), atx.NumUnits).
-			Return(errors.New("invalid VRF"))
-		_, _, proof, err := atxHdlr.syntacticallyValidateDeps(context.Background(), atx)
-		require.ErrorContains(t, err, "invalid VRF")
-		require.Nil(t, proof)
-	})
-	t.Run("valid initial atx", func(t *testing.T) {
-		t.Parallel()
-		atxHdlr, _, posAtx := setup(t)
-
-		ctxID := posAtx.ID()
-		atx := newInitialATXv1(t, goldenATXID)
-		atx.CommitmentATXID = &ctxID
-		atx.Sign(sig)
-
-		atxHdlr.mclock.EXPECT().CurrentLayer().Return(atx.PublishEpoch.FirstLayer())
-		atxHdlr.mValidator.EXPECT().
-			Post(gomock.Any(), gomock.Any(), ctxID, gomock.Any(), gomock.Any(), atx.NumUnits, gomock.Any())
-		atxHdlr.mValidator.EXPECT().VRFNonce(sig.NodeID(), ctxID, *atx.VRFNonce, gomock.Any(), atx.NumUnits)
-		require.NoError(t, atxHdlr.syntacticallyValidate(context.Background(), atx))
-
-		atxHdlr.mValidator.EXPECT().InitialNIPostChallengeV1(gomock.Any(), gomock.Any(), goldenATXID)
-		atxHdlr.mValidator.EXPECT().
-			NIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-			Return(uint64(777), nil)
-		atxHdlr.mValidator.EXPECT().PositioningAtx(atx.PositioningATXID, gomock.Any(), goldenATXID, atx.PublishEpoch)
-		leaves, units, proof, err := atxHdlr.syntacticallyValidateDeps(context.Background(), atx)
-		require.NoError(t, err)
-		require.Equal(t, uint64(777), leaves)
-		require.Equal(t, atx.NumUnits, units)
-		require.Nil(t, proof)
-	})
-	t.Run("atx targeting wrong publish epoch", func(t *testing.T) {
-		t.Parallel()
-		atxHdlr, prevAtx, posAtx := setup(t)
-
-		atx := newChainedActivationTxV1(t, goldenATXID, prevAtx, posAtx.ID())
-		atx.Sign(sig)
-
-		atxHdlr.mclock.EXPECT().CurrentLayer().Return((atx.PublishEpoch - 2).FirstLayer())
-		err := atxHdlr.syntacticallyValidate(context.Background(), atx)
-		require.ErrorContains(t, err, "atx publish epoch is too far in the future")
-	})
-	t.Run("failing nipost challenge validation", func(t *testing.T) {
-		t.Parallel()
-		atxHdlr, prevAtx, posAtx := setup(t)
-
-		atx := newChainedActivationTxV1(t, goldenATXID, prevAtx, posAtx.ID())
-		atx.Sign(sig)
-
-		atxHdlr.mclock.EXPECT().CurrentLayer().Return(atx.PublishEpoch.FirstLayer())
-		require.NoError(t, atxHdlr.syntacticallyValidate(context.Background(), atx))
-
-		atxHdlr.mValidator.EXPECT().
-			NIPostChallengeV1(gomock.Any(), gomock.Any(), atx.SmesherID).
-			Return(errors.New("nipost error"))
-		_, _, proof, err := atxHdlr.syntacticallyValidateDeps(context.Background(), atx)
-		require.EqualError(t, err, "nipost error")
-		require.Nil(t, proof)
-	})
-	t.Run("failing positioning atx validation", func(t *testing.T) {
-		t.Parallel()
-		atxHdlr, prevAtx, posAtx := setup(t)
-
-		atx := newChainedActivationTxV1(t, goldenATXID, prevAtx, posAtx.ID())
-		atx.Sign(sig)
-
-		atxHdlr.mclock.EXPECT().CurrentLayer().Return(atx.PublishEpoch.FirstLayer())
-		require.NoError(t, atxHdlr.syntacticallyValidate(context.Background(), atx))
-
-		atxHdlr.mValidator.EXPECT().NIPostChallengeV1(gomock.Any(), gomock.Any(), atx.SmesherID)
-		atxHdlr.mValidator.EXPECT().
-			PositioningAtx(atx.PositioningATXID, gomock.Any(), goldenATXID, atx.PublishEpoch).
-			Return(errors.New("bad positioning atx"))
-		_, _, proof, err := atxHdlr.syntacticallyValidateDeps(context.Background(), atx)
-		require.EqualError(t, err, "bad positioning atx")
-		require.Nil(t, proof)
-	})
-	t.Run("bad initial nipost challenge", func(t *testing.T) {
-		t.Parallel()
-		atxHdlr, _, posAtx := setup(t)
-
-		cATX := posAtx.ID()
-		atx := newInitialATXv1(t, cATX)
-		atx.Sign(sig)
-
-		atxHdlr.mclock.EXPECT().CurrentLayer().Return(atx.PublishEpoch.FirstLayer())
-		atxHdlr.mValidator.EXPECT().
-			Post(gomock.Any(), sig.NodeID(), cATX, gomock.Any(), gomock.Any(), atx.NumUnits, gomock.Any())
-		atxHdlr.mValidator.EXPECT().VRFNonce(sig.NodeID(), cATX, *atx.VRFNonce, gomock.Any(), atx.NumUnits)
-		require.NoError(t, atxHdlr.syntacticallyValidate(context.Background(), atx))
-
-		atxHdlr.mValidator.EXPECT().
-			InitialNIPostChallengeV1(gomock.Any(), gomock.Any(), goldenATXID).
-			Return(errors.New("bad initial nipost"))
-		_, _, proof, err := atxHdlr.syntacticallyValidateDeps(context.Background(), atx)
-		require.EqualError(t, err, "bad initial nipost")
-		require.Nil(t, proof)
-	})
-	t.Run("bad NIPoST", func(t *testing.T) {
-		t.Parallel()
-		atxHdlr, prevATX, postAtx := setup(t)
-
-		atx := newChainedActivationTxV1(t, goldenATXID, prevATX, postAtx.ID())
-		atx.Sign(sig)
-
-		atxHdlr.mclock.EXPECT().CurrentLayer().Return(atx.PublishEpoch.FirstLayer())
-		require.NoError(t, atxHdlr.syntacticallyValidate(context.Background(), atx))
-
-		atxHdlr.mValidator.EXPECT().NIPostChallengeV1(gomock.Any(), gomock.Any(), atx.SmesherID)
-		atxHdlr.mValidator.EXPECT().PositioningAtx(atx.PositioningATXID, gomock.Any(), goldenATXID, atx.PublishEpoch)
-		atxHdlr.mValidator.EXPECT().
-			NIPost(gomock.Any(), atx.SmesherID, goldenATXID, gomock.Any(), gomock.Any(), atx.NumUnits, gomock.Any()).
-			Return(0, errors.New("bad nipost"))
-		_, _, _, err := atxHdlr.syntacticallyValidateDeps(context.Background(), atx)
-		require.EqualError(t, err, "invalid nipost: bad nipost")
-	})
-	t.Run("can't find VRF nonce", func(t *testing.T) {
-		t.Parallel()
-		atxHdlr, prevATX, postAtx := setup(t)
-
-		atx := newChainedActivationTxV1(t, goldenATXID, prevATX, postAtx.ID())
-		atx.NumUnits += 100
-		atx.Sign(sig)
-
-		enc := func(stmt *sql.Statement) { stmt.BindBytes(1, atx.SmesherID.Bytes()) }
-		_, err := atxHdlr.cdb.Exec(`UPDATE atxs SET nonce = NULL WHERE pubkey = ?1;`, enc, nil)
-		require.NoError(t, err)
-
-		atxHdlr.mclock.EXPECT().CurrentLayer().Return(atx.PublishEpoch.FirstLayer())
-		require.NoError(t, atxHdlr.syntacticallyValidate(context.Background(), atx))
-
-		atxHdlr.mValidator.EXPECT().NIPostChallengeV1(gomock.Any(), gomock.Any(), atx.SmesherID)
-		_, _, _, err1 := atxHdlr.syntacticallyValidateDeps(context.Background(), atx)
-		require.ErrorContains(t, err1, "failed to get current nonce")
-	})
-	t.Run("missing NodeID in initial atx", func(t *testing.T) {
-		t.Parallel()
-		atxHdlr, _, _ := setup(t)
-
-		atx := newInitialATXv1(t, goldenATXID)
-		atx.Signature = sig.Sign(signing.ATX, atx.SignedBytes())
-		atx.SmesherID = sig.NodeID()
-
-		atxHdlr.mclock.EXPECT().CurrentLayer().Return(atx.PublishEpoch.FirstLayer())
-		err := atxHdlr.syntacticallyValidate(context.Background(), atx)
-		require.ErrorContains(t, err, "node id is missing")
-	})
-	t.Run("missing VRF nonce in initial atx", func(t *testing.T) {
-		t.Parallel()
-		atxHdlr, _, _ := setup(t)
-
-		atx := newInitialATXv1(t, goldenATXID)
-		atx.VRFNonce = nil
-		atx.Sign(sig)
-
-		atxHdlr.mclock.EXPECT().CurrentLayer().Return(atx.PublishEpoch.FirstLayer())
-		err := atxHdlr.syntacticallyValidate(context.Background(), atx)
-		require.ErrorContains(t, err, "vrf nonce is missing")
-	})
-	t.Run("invalid VRF nonce in initial atx", func(t *testing.T) {
-		t.Parallel()
-		atxHdlr, _, _ := setup(t)
-
-		atx := newInitialATXv1(t, goldenATXID)
-		atx.Sign(sig)
-
-		atxHdlr.mclock.EXPECT().CurrentLayer().Return(atx.PublishEpoch.FirstLayer())
-		atxHdlr.mValidator.EXPECT().
-			VRFNonce(atx.SmesherID, *atx.CommitmentATXID, *atx.VRFNonce, gomock.Any(), atx.NumUnits).
-			Return(errors.New("invalid VRF nonce"))
-		err := atxHdlr.syntacticallyValidate(context.Background(), atx)
-		require.ErrorContains(t, err, "invalid VRF nonce")
-	})
-	t.Run("prevAtx not declared but initial Post not included", func(t *testing.T) {
-		t.Parallel()
-		atxHdlr, prevAtx, posAtx := setup(t)
-
-		atx := newChainedActivationTxV1(t, goldenATXID, prevAtx, posAtx.ID())
-		atx.PrevATXID = types.EmptyATXID
-		atx.Sign(sig)
-
-		atxHdlr.mclock.EXPECT().CurrentLayer().Return(atx.PublishEpoch.FirstLayer())
-		err := atxHdlr.syntacticallyValidate(context.Background(), atx)
-		require.EqualError(t, err, "no prev atx declared, but initial post is not included")
-	})
-	t.Run("prevAtx not declared but commitment ATX is not included", func(t *testing.T) {
-		t.Parallel()
-		atxHdlr, _, _ := setup(t)
-
-		atx := newInitialATXv1(t, goldenATXID)
-		atx.CommitmentATXID = nil
-		atx.Sign(sig)
-
-		atxHdlr.mclock.EXPECT().CurrentLayer().Return(atx.PublishEpoch.FirstLayer())
-		err := atxHdlr.syntacticallyValidate(context.Background(), atx)
-		require.EqualError(t, err, "no prev atx declared, but commitment atx is missing")
-	})
-	t.Run("prevAtx not declared but commitment ATX is empty", func(t *testing.T) {
-		t.Parallel()
-		atxHdlr, _, _ := setup(t)
-
-		atx := newInitialATXv1(t, goldenATXID)
-		atx.CommitmentATXID = &types.EmptyATXID
-		atx.Sign(sig)
-
-		atxHdlr.mclock.EXPECT().CurrentLayer().Return(atx.PublishEpoch.FirstLayer())
-		err := atxHdlr.syntacticallyValidate(context.Background(), atx)
-		require.EqualError(t, err, "empty commitment atx")
-	})
-	t.Run("prevAtx not declared but sequence not zero", func(t *testing.T) {
-		t.Parallel()
-		atxHdlr, _, _ := setup(t)
-
-		atx := newInitialATXv1(t, goldenATXID)
-		atx.Sequence = 1
-		atx.Sign(sig)
-
-		atxHdlr.mclock.EXPECT().CurrentLayer().Return(atx.PublishEpoch.FirstLayer())
-		err := atxHdlr.syntacticallyValidate(context.Background(), atx)
-		require.EqualError(t, err, "no prev atx declared, but sequence number not zero")
-	})
-	t.Run("prevAtx not declared but validation of initial post fails", func(t *testing.T) {
-		t.Parallel()
-		atxHdlr, _, _ := setup(t)
-
-		atx := newInitialATXv1(t, goldenATXID)
-		atx.Sign(sig)
-
-		atxHdlr.mclock.EXPECT().CurrentLayer().Return(atx.PublishEpoch.FirstLayer())
-		atxHdlr.mValidator.EXPECT().
-			VRFNonce(atx.SmesherID, *atx.CommitmentATXID, *atx.VRFNonce, gomock.Any(), atx.NumUnits)
-		atxHdlr.mValidator.EXPECT().
-			Post(gomock.Any(), atx.SmesherID, gomock.Any(), gomock.Any(), gomock.Any(), atx.NumUnits, gomock.Any()).
-			Return(errors.New("failed post validation"))
-		err := atxHdlr.syntacticallyValidate(context.Background(), atx)
-		require.ErrorContains(t, err, "failed post validation")
-	})
-	t.Run("empty positioning ATX", func(t *testing.T) {
-		t.Parallel()
-		atxHdlr, _, _ := setup(t)
-
-		atx := newInitialATXv1(t, goldenATXID)
-		atx.PositioningATXID = types.EmptyATXID
-		atx.Sign(sig)
-
-		atxHdlr.mclock.EXPECT().CurrentLayer().Return(atx.PublishEpoch.FirstLayer())
-		err := atxHdlr.syntacticallyValidate(context.Background(), atx)
-		require.EqualError(t, err, "empty positioning atx")
-	})
-	t.Run("prevAtx declared but initial Post is included", func(t *testing.T) {
-		t.Parallel()
-		atxHdlr, prevAtx, _ := setup(t)
-
-		atx := newInitialATXv1(t, goldenATXID)
-		atx.PrevATXID = prevAtx.ID()
-		atx.Sign(sig)
-
-		atxHdlr.mclock.EXPECT().CurrentLayer().Return(atx.PublishEpoch.FirstLayer())
-		err := atxHdlr.syntacticallyValidate(context.Background(), atx)
-		require.EqualError(t, err, "prev atx declared, but initial post is included")
-	})
-	t.Run("prevAtx declared but NodeID is included", func(t *testing.T) {
-		t.Parallel()
-		atxHdlr, prevAtx, posAtx := setup(t)
-
-		atx := newChainedActivationTxV1(t, goldenATXID, prevAtx, posAtx.ID())
-		atx.NodeID = &types.NodeID{1, 2, 3}
-		atx.Sign(sig)
-
-		atxHdlr.mclock.EXPECT().CurrentLayer().Return(atx.PublishEpoch.FirstLayer())
-		err := atxHdlr.syntacticallyValidate(context.Background(), atx)
-		require.EqualError(t, err, "prev atx declared, but node id is included")
-	})
-	t.Run("prevAtx declared but commitmentATX is included", func(t *testing.T) {
-		t.Parallel()
-		atxHdlr, prevAtx, posAtx := setup(t)
-
-		atx := newChainedActivationTxV1(t, goldenATXID, prevAtx, posAtx.ID())
-		atx.CommitmentATXID = &types.EmptyATXID
-		atx.Sign(sig)
-
-		atxHdlr.mclock.EXPECT().CurrentLayer().Return(atx.PublishEpoch.FirstLayer())
-		err := atxHdlr.syntacticallyValidate(context.Background(), atx)
-		require.EqualError(t, err, "prev atx declared, but commitment atx is included")
-	})
-}
-
-func TestHandler_ContextuallyValidateAtx(t *testing.T) {
-	goldenATXID := types.ATXID{2, 3, 4}
-
-	sig, err := signing.NewEdSigner()
-	require.NoError(t, err)
-
-	t.Run("valid initial atx", func(t *testing.T) {
-		t.Parallel()
-
-		atx := newInitialATXv1(t, goldenATXID)
-		atx.Sign(sig)
-
-		atxHdlr := newTestHandler(t, goldenATXID)
-		require.NoError(t, atxHdlr.contextuallyValidateAtx(atx))
-	})
-
-	t.Run("missing prevAtx", func(t *testing.T) {
-		t.Parallel()
-
-		atxHdlr := newTestHandler(t, goldenATXID)
-
-		prevAtx := newInitialATXv1(t, goldenATXID)
-		atx := newChainedActivationTxV1(t, goldenATXID, prevAtx, goldenATXID)
-
-		err = atxHdlr.contextuallyValidateAtx(atx)
-		require.ErrorIs(t, err, sql.ErrNotFound)
-	})
-
-	t.Run("wrong previous atx by same node", func(t *testing.T) {
-		t.Parallel()
-
-		atxHdlr := newTestHandler(t, goldenATXID)
-
-		atx0 := newInitialATXv1(t, goldenATXID)
-		atx0.Sign(sig)
-		atxHdlr.expectAtxV1(atx0, sig.NodeID())
-		require.NoError(t, atxHdlr.HandleGossipAtx(context.Background(), "", codec.MustEncode(atx0)))
-
-		atx1 := newChainedActivationTxV1(t, goldenATXID, atx0, goldenATXID)
-		atx1.Sign(sig)
-		atxHdlr.expectAtxV1(atx1, sig.NodeID())
-		atxHdlr.mockFetch.EXPECT().GetAtxs(gomock.Any(), gomock.Any(), gomock.Any())
-		require.NoError(t, atxHdlr.HandleGossipAtx(context.Background(), "", codec.MustEncode(atx1)))
-
-		atxInvalidPrevious := newChainedActivationTxV1(t, goldenATXID, atx0, goldenATXID)
-		atxInvalidPrevious.Sign(sig)
-		err := atxHdlr.contextuallyValidateAtx(atxInvalidPrevious)
-		require.EqualError(t, err, "last atx is not the one referenced")
-	})
-
-	t.Run("wrong previous atx from different node", func(t *testing.T) {
-		t.Parallel()
-
-		otherSig, err := signing.NewEdSigner()
-		require.NoError(t, err)
-
-		atxHdlr := newTestHandler(t, goldenATXID)
-
-		atx0 := newInitialATXv1(t, goldenATXID)
-		atx0.Sign(otherSig)
-		atxHdlr.expectAtxV1(atx0, otherSig.NodeID())
-		require.NoError(t, atxHdlr.HandleGossipAtx(context.Background(), "", codec.MustEncode(atx0)))
-
-		atx1 := newInitialATXv1(t, goldenATXID)
-		atx1.Sign(sig)
-		atxHdlr.expectAtxV1(atx1, sig.NodeID())
-		require.NoError(t, atxHdlr.HandleGossipAtx(context.Background(), "", codec.MustEncode(atx1)))
-
-		atxInvalidPrevious := newChainedActivationTxV1(t, goldenATXID, atx0, goldenATXID)
-		atxInvalidPrevious.Sign(sig)
-		err = atxHdlr.contextuallyValidateAtx(atxInvalidPrevious)
-		require.EqualError(t, err, "last atx is not the one referenced")
-	})
-}
-
-func TestHandler_StoreAtx(t *testing.T) {
-	goldenATXID := types.RandomATXID()
-
-	sig, err := signing.NewEdSigner()
-	require.NoError(t, err)
-
-	t.Run("stores ATX in DB", func(t *testing.T) {
-		atxHdlr := newTestHandler(t, goldenATXID)
-
-		watx := newInitialATXv1(t, goldenATXID)
-		watx.Sign(sig)
-		vAtx := toAtx(t, watx)
-		require.NoError(t, err)
-
-		atxHdlr.mbeacon.EXPECT().OnAtx(vAtx.ToHeader())
-		atxHdlr.mtortoise.EXPECT().OnAtx(gomock.Any(), vAtx.ID(), gomock.Any())
-		proof, err := atxHdlr.storeAtx(context.Background(), vAtx)
-		require.NoError(t, err)
-		require.Nil(t, proof)
-
-		atxFromDb, err := atxs.Get(atxHdlr.cdb, vAtx.ID())
-		require.NoError(t, err)
-		vAtx.SetReceived(time.Unix(0, vAtx.Received().UnixNano()))
-		require.Equal(t, vAtx, atxFromDb)
-	})
-
-	t.Run("storing an already known ATX returns no error", func(t *testing.T) {
-		atxHdlr := newTestHandler(t, goldenATXID)
-
-		watx := newInitialATXv1(t, goldenATXID)
-		watx.Sign(sig)
-		vAtx := toAtx(t, watx)
-
-		atxHdlr.mbeacon.EXPECT().OnAtx(vAtx.ToHeader())
-		atxHdlr.mtortoise.EXPECT().OnAtx(gomock.Any(), vAtx.ID(), gomock.Any())
-		proof, err := atxHdlr.storeAtx(context.Background(), vAtx)
-		require.NoError(t, err)
-		require.Nil(t, proof)
-
-		atxHdlr.mbeacon.EXPECT().OnAtx(vAtx.ToHeader())
-		// Note: tortoise is not informed about the same ATX again
-		proof, err = atxHdlr.storeAtx(context.Background(), vAtx)
-		require.NoError(t, err)
-		require.Nil(t, proof)
-	})
-
-	t.Run("another atx for the same epoch is considered malicious", func(t *testing.T) {
-		atxHdlr := newTestHandler(t, goldenATXID)
-
-		watx0 := newInitialATXv1(t, goldenATXID)
-		watx0.Sign(sig)
-		vAtx0 := toAtx(t, watx0)
-
-		atxHdlr.mbeacon.EXPECT().OnAtx(vAtx0.ToHeader())
-		atxHdlr.mtortoise.EXPECT().OnAtx(gomock.Any(), vAtx0.ID(), gomock.Any())
-
-		proof, err := atxHdlr.storeAtx(context.Background(), vAtx0)
-		require.NoError(t, err)
-		require.Nil(t, proof)
-
-		watx1 := newInitialATXv1(t, goldenATXID)
-		watx1.Coinbase = types.GenerateAddress([]byte("aaaa"))
-		watx1.Sign(sig)
-		vAtx1 := toAtx(t, watx1)
-
-		atxHdlr.mbeacon.EXPECT().OnAtx(vAtx1.ToHeader())
-		atxHdlr.mtortoise.EXPECT().OnAtx(gomock.Any(), vAtx1.ID(), gomock.Any())
-		atxHdlr.mtortoise.EXPECT().OnMalfeasance(sig.NodeID())
-
-		proof, err = atxHdlr.storeAtx(context.Background(), vAtx1)
-		require.NoError(t, err)
-		require.NotNil(t, proof)
-		require.Equal(t, mwire.MultipleATXs, proof.Proof.Type)
-
-		proof.SetReceived(time.Time{})
-		nodeID, err := malfeasance.Validate(
-			context.Background(),
-			atxHdlr.log,
-			atxHdlr.cdb,
-			atxHdlr.edVerifier,
-			nil,
-			&mwire.MalfeasanceGossip{MalfeasanceProof: *proof},
-		)
-		require.NoError(t, err)
-		require.Equal(t, sig.NodeID(), nodeID)
-
-		malicious, err := identities.IsMalicious(atxHdlr.cdb, sig.NodeID())
-		require.NoError(t, err)
-		require.True(t, malicious)
-	})
-
-	t.Run("another atx for the same epoch for registered ID doesn't create a malfeasance proof", func(t *testing.T) {
-		atxHdlr := newTestHandler(t, goldenATXID)
-		atxHdlr.Register(sig)
-
-		watx0 := newInitialATXv1(t, goldenATXID)
-		watx0.Sign(sig)
-		vAtx0 := toAtx(t, watx0)
-
-		atxHdlr.mbeacon.EXPECT().OnAtx(vAtx0.ToHeader())
-		atxHdlr.mtortoise.EXPECT().OnAtx(gomock.Any(), vAtx0.ID(), gomock.Any())
-
-		proof, err := atxHdlr.storeAtx(context.Background(), vAtx0)
-		require.NoError(t, err)
-		require.Nil(t, proof)
-
-		watx1 := newInitialATXv1(t, goldenATXID)
-		watx1.Coinbase = types.GenerateAddress([]byte("aaaa"))
-		watx1.Sign(sig)
-		vAtx1 := toAtx(t, watx1)
-
-		proof, err = atxHdlr.storeAtx(context.Background(), vAtx1)
-		require.ErrorContains(t,
-			err,
-			fmt.Sprintf("%s already published an ATX", sig.NodeID().ShortString()),
-		)
-		require.Nil(t, proof)
-
-		malicious, err := identities.IsMalicious(atxHdlr.cdb, sig.NodeID())
-		require.NoError(t, err)
-		require.False(t, malicious)
-	})
 }
 
 func testHandler_PostMalfeasanceProofs(t *testing.T, synced bool) {
@@ -1209,71 +618,6 @@ func TestCollectDeps(t *testing.T) {
 	})
 }
 
-func TestHandler_RegistersHashesInPeer(t *testing.T) {
-	goldenATXID := types.RandomATXID()
-	peer := p2p.Peer("buddy")
-	t.Run("registers poet and atxs", func(t *testing.T) {
-		t.Parallel()
-		atxHdlr := newTestHandler(t, goldenATXID)
-
-		poet := types.RandomHash()
-		atxs := []types.ATXID{types.RandomATXID(), types.RandomATXID()}
-
-		atxHdlr.mockFetch.EXPECT().
-			RegisterPeerHashes(peer, gomock.InAnyOrder([]types.Hash32{poet, atxs[0].Hash32(), atxs[1].Hash32()}))
-		atxHdlr.registerHashes(peer, poet, atxs)
-	})
-	t.Run("registers poet", func(t *testing.T) {
-		t.Parallel()
-		atxHdlr := newTestHandler(t, goldenATXID)
-
-		poet := types.RandomHash()
-
-		atxHdlr.mockFetch.EXPECT().RegisterPeerHashes(peer, []types.Hash32{poet})
-		atxHdlr.registerHashes(peer, poet, nil)
-	})
-}
-
-func TestHandler_FetchesReferences(t *testing.T) {
-	goldenATXID := types.RandomATXID()
-	t.Run("fetch poet and atxs", func(t *testing.T) {
-		t.Parallel()
-		atxHdlr := newTestHandler(t, goldenATXID)
-
-		poet := types.RandomHash()
-		atxs := []types.ATXID{types.RandomATXID(), types.RandomATXID()}
-
-		atxHdlr.mockFetch.EXPECT().GetPoetProof(gomock.Any(), poet)
-		atxHdlr.mockFetch.EXPECT().GetAtxs(gomock.Any(), atxs, gomock.Any())
-		require.NoError(t, atxHdlr.fetchReferences(context.Background(), poet, atxs))
-	})
-
-	t.Run("no poet proofs", func(t *testing.T) {
-		t.Parallel()
-		atxHdlr := newTestHandler(t, goldenATXID)
-
-		poet := types.RandomHash()
-
-		atxHdlr.mockFetch.EXPECT().GetPoetProof(gomock.Any(), poet).Return(errors.New("pooh"))
-		require.Error(t, atxHdlr.fetchReferences(context.Background(), poet, nil))
-	})
-
-	t.Run("no atxs", func(t *testing.T) {
-		t.Parallel()
-		atxHdlr := newTestHandler(t, goldenATXID)
-
-		poet := types.RandomHash()
-		atxs := []types.ATXID{types.RandomATXID(), types.RandomATXID()}
-
-		atxHdlr.mockFetch.EXPECT().GetPoetProof(gomock.Any(), poet).Return(errors.New("pooh"))
-		require.Error(t, atxHdlr.fetchReferences(context.Background(), poet, nil))
-
-		atxHdlr.mockFetch.EXPECT().GetPoetProof(gomock.Any(), poet)
-		atxHdlr.mockFetch.EXPECT().GetAtxs(gomock.Any(), atxs, gomock.Any()).Return(errors.New("oh"))
-		require.Error(t, atxHdlr.fetchReferences(context.Background(), poet, atxs))
-	})
-}
-
 func TestHandler_AtxWeight(t *testing.T) {
 	const (
 		peer     = p2p.Peer("buddy")
@@ -1283,8 +627,7 @@ func TestHandler_AtxWeight(t *testing.T) {
 	)
 
 	goldenATXID := types.ATXID{2, 3, 4}
-	atxHdlr := newTestHandler(t, goldenATXID)
-	atxHdlr.tickSize = tickSize
+	atxHdlr := newTestHandler(t, goldenATXID, func(o *testHandlerOptions) { o.tickSize = tickSize })
 
 	sig, err := signing.NewEdSigner()
 	require.NoError(t, err)

--- a/activation/handler_v1.go
+++ b/activation/handler_v1.go
@@ -1,0 +1,535 @@
+package activation
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/spacemeshos/post/shared"
+	"github.com/spacemeshos/post/verifying"
+	"golang.org/x/exp/maps"
+
+	"github.com/spacemeshos/go-spacemesh/activation/wire"
+	"github.com/spacemeshos/go-spacemesh/atxsdata"
+	"github.com/spacemeshos/go-spacemesh/codec"
+	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/datastore"
+	"github.com/spacemeshos/go-spacemesh/events"
+	"github.com/spacemeshos/go-spacemesh/log"
+	mwire "github.com/spacemeshos/go-spacemesh/malfeasance/wire"
+	"github.com/spacemeshos/go-spacemesh/p2p"
+	"github.com/spacemeshos/go-spacemesh/signing"
+	"github.com/spacemeshos/go-spacemesh/sql"
+	"github.com/spacemeshos/go-spacemesh/sql/atxs"
+	"github.com/spacemeshos/go-spacemesh/sql/identities"
+	"github.com/spacemeshos/go-spacemesh/system"
+)
+
+// HandlerV1 processes ATXs version 1.
+type HandlerV1 struct {
+	local           p2p.Peer
+	cdb             *datastore.CachedDB
+	atxsdata        *atxsdata.Data
+	edVerifier      *signing.EdVerifier
+	clock           layerClock
+	tickSize        uint64
+	goldenATXID     types.ATXID
+	nipostValidator nipostValidator
+	beacon          AtxReceiver
+	tortoise        system.Tortoise
+	log             log.Log
+	fetcher         system.Fetcher
+
+	signerMtx sync.Mutex
+	signers   map[types.NodeID]*signing.EdSigner
+}
+
+func (h *HandlerV1) Register(sig *signing.EdSigner) {
+	h.signerMtx.Lock()
+	defer h.signerMtx.Unlock()
+	if _, exists := h.signers[sig.NodeID()]; exists {
+		h.log.With().Error("signing key already registered", log.ShortStringer("id", sig.NodeID()))
+		return
+	}
+
+	h.log.With().Info("registered signing key", log.ShortStringer("id", sig.NodeID()))
+	h.signers[sig.NodeID()] = sig
+}
+
+func (h *HandlerV1) syntacticallyValidate(ctx context.Context, atx *wire.ActivationTxV1) error {
+	if atx.NIPost == nil {
+		return fmt.Errorf("nil nipost for atx %s", atx.ID())
+	}
+	current := h.clock.CurrentLayer().GetEpoch()
+	if atx.PublishEpoch > current+1 {
+		return fmt.Errorf("atx publish epoch is too far in the future: %d > %d", atx.PublishEpoch, current+1)
+	}
+	if atx.PositioningATXID == types.EmptyATXID {
+		return errors.New("empty positioning atx")
+	}
+
+	switch {
+	case atx.PrevATXID == types.EmptyATXID:
+		if atx.InitialPost == nil {
+			return errors.New("no prev atx declared, but initial post is not included")
+		}
+		if atx.NodeID == nil {
+			return errors.New("no prev atx declared, but node id is missing")
+		}
+		if atx.VRFNonce == nil {
+			return errors.New("no prev atx declared, but vrf nonce is missing")
+		}
+		if atx.CommitmentATXID == nil {
+			return errors.New("no prev atx declared, but commitment atx is missing")
+		}
+		if *atx.CommitmentATXID == types.EmptyATXID {
+			return errors.New("empty commitment atx")
+		}
+		if atx.Sequence != 0 {
+			return errors.New("no prev atx declared, but sequence number not zero")
+		}
+
+		// Use the NIPost's Post metadata, while overriding the challenge to a zero challenge,
+		// as expected from the initial Post.
+		initialPostMetadata := types.PostMetadata{
+			Challenge:     shared.ZeroChallenge,
+			LabelsPerUnit: atx.NIPost.PostMetadata.LabelsPerUnit,
+		}
+		if err := h.nipostValidator.VRFNonce(
+			atx.SmesherID, *atx.CommitmentATXID, *atx.VRFNonce, initialPostMetadata.LabelsPerUnit, atx.NumUnits,
+		); err != nil {
+			return fmt.Errorf("invalid vrf nonce: %w", err)
+		}
+		post := wire.PostFromWireV1(atx.InitialPost)
+		if err := h.nipostValidator.Post(
+			ctx, atx.SmesherID, *atx.CommitmentATXID, post, &initialPostMetadata, atx.NumUnits,
+		); err != nil {
+			return fmt.Errorf("invalid initial post: %w", err)
+		}
+	default:
+		if atx.NodeID != nil {
+			return errors.New("prev atx declared, but node id is included")
+		}
+		if atx.InitialPost != nil {
+			return errors.New("prev atx declared, but initial post is included")
+		}
+		if atx.CommitmentATXID != nil {
+			return errors.New("prev atx declared, but commitment atx is included")
+		}
+	}
+	return nil
+}
+
+// Obtain the commitment ATX ID for the given ATX.
+func (h *HandlerV1) commitment(ctx context.Context, atx *wire.ActivationTxV1) (types.ATXID, error) {
+	if atx.PrevATXID == types.EmptyATXID {
+		return *atx.CommitmentATXID, nil
+	}
+	return atxs.CommitmentATX(h.cdb, atx.SmesherID)
+}
+
+// Obtain the previous ATX for the given ATX.
+// We need to decode it from the blob because we are interested in the true NumUnits value
+// that was declared by the previous ATX and the `atxs` table only holds the effective NumUnits.
+// However, in case of a golden ATX, the blob is not available and we fallback to fetching the ATX from the DB
+// to use the effective num units.
+func (h *HandlerV1) previous(ctx context.Context, atx *wire.ActivationTxV1) (*types.ActivationTx, error) {
+	var blob sql.Blob
+	if err := atxs.LoadBlob(ctx, h.cdb, atx.PrevATXID[:], &blob); err != nil {
+		return nil, err
+	}
+
+	if blob.Bytes == nil {
+		// An empty blob indicates a golden ATX (after a checkpoint-recovery).
+		// Fallback to fetching it from the DB to get the effective NumUnits.
+		atx, err := atxs.Get(h.cdb, atx.PrevATXID)
+		if err != nil {
+			return nil, fmt.Errorf("fetching golden previous atx: %w", err)
+		}
+		return atx, nil
+	}
+
+	var prev wire.ActivationTxV1
+	if err := codec.Decode(blob.Bytes, &prev); err != nil {
+		return nil, fmt.Errorf("decoding previous atx: %w", err)
+	}
+	return wire.ActivationTxFromWireV1(&prev, blob.Bytes...), nil
+}
+
+func (h *HandlerV1) syntacticallyValidateDeps(
+	ctx context.Context,
+	atx *wire.ActivationTxV1,
+) (leaves uint64, effectiveNumUnits uint32, proof *mwire.MalfeasanceProof, err error) {
+	commitmentATX, err := h.commitment(ctx, atx)
+	if err != nil {
+		return 0, 0, nil, fmt.Errorf("commitment atx for %s not found: %w", atx.SmesherID, err)
+	}
+
+	if atx.PrevATXID == types.EmptyATXID {
+		if err := h.nipostValidator.InitialNIPostChallengeV1(&atx.NIPostChallengeV1, h.cdb, h.goldenATXID); err != nil {
+			return 0, 0, nil, err
+		}
+		effectiveNumUnits = atx.NumUnits
+	} else {
+		previous, err := h.previous(ctx, atx)
+		if err != nil {
+			return 0, 0, nil, fmt.Errorf("fetching previous atx %s: %w", atx.PrevATXID, err)
+		}
+		if err := h.validateNonInitialAtx(ctx, atx, previous, commitmentATX); err != nil {
+			return 0, 0, nil, err
+		}
+		effectiveNumUnits = min(previous.NumUnits, atx.NumUnits)
+	}
+
+	err = h.nipostValidator.PositioningAtx(atx.PositioningATXID, h.cdb, h.goldenATXID, atx.PublishEpoch)
+	if err != nil {
+		return 0, 0, nil, err
+	}
+
+	expectedChallengeHash := atx.NIPostChallengeV1.Hash()
+	h.log.WithContext(ctx).
+		With().
+		Info("validating nipost", log.String("expected_challenge_hash", expectedChallengeHash.String()), atx.ID())
+
+	leaves, err = h.nipostValidator.NIPost(
+		ctx,
+		atx.SmesherID,
+		commitmentATX,
+		wire.NiPostFromWireV1(atx.NIPost),
+		expectedChallengeHash,
+		atx.NumUnits,
+		PostSubset([]byte(h.local)), // use the local peer ID as seed for random subset
+	)
+	var invalidIdx *verifying.ErrInvalidIndex
+	if errors.As(err, &invalidIdx) {
+		h.log.WithContext(ctx).With().Info("ATX with invalid post index", atx.ID(), log.Int("index", invalidIdx.Index))
+		proof := &mwire.MalfeasanceProof{
+			Layer: atx.PublishEpoch.FirstLayer(),
+			Proof: mwire.Proof{
+				Type: mwire.InvalidPostIndex,
+				Data: &mwire.InvalidPostIndexProof{
+					Atx:        *atx,
+					InvalidIdx: uint32(invalidIdx.Index),
+				},
+			},
+		}
+		encodedProof := codec.MustEncode(proof)
+		if err := identities.SetMalicious(h.cdb, atx.SmesherID, encodedProof, time.Now()); err != nil {
+			return 0, 0, nil, fmt.Errorf("adding malfeasance proof: %w", err)
+		}
+		h.cdb.CacheMalfeasanceProof(atx.SmesherID, proof)
+		h.tortoise.OnMalfeasance(atx.SmesherID)
+		return 0, 0, proof, nil
+	}
+	if err != nil {
+		return 0, 0, nil, fmt.Errorf("invalid nipost: %w", err)
+	}
+
+	return leaves, effectiveNumUnits, nil, err
+}
+
+func (h *HandlerV1) validateNonInitialAtx(
+	ctx context.Context,
+	atx *wire.ActivationTxV1,
+	previous *types.ActivationTx,
+	commitment types.ATXID,
+) error {
+	if err := h.nipostValidator.NIPostChallengeV1(&atx.NIPostChallengeV1, previous, atx.SmesherID); err != nil {
+		return err
+	}
+
+	nonce := atx.VRFNonce
+	if atx.NumUnits > previous.NumUnits && nonce == nil {
+		h.log.WithContext(ctx).With().Info("post size increased without new vrf Nonce, re-validating current nonce",
+			atx.ID(),
+			log.Stringer("smesher", atx.SmesherID),
+		)
+
+		// This is not expected to happen very often, so we query the database
+		// directly here without using the cache.
+		current, err := atxs.NonceByID(h.cdb, previous.ID())
+		if err != nil {
+			return fmt.Errorf("failed to get current nonce: %w", err)
+		}
+		nonce = (*uint64)(&current)
+	}
+
+	if nonce != nil {
+		err := h.nipostValidator.
+			VRFNonce(atx.SmesherID, commitment, *nonce, atx.NIPost.PostMetadata.LabelsPerUnit, atx.NumUnits)
+		if err != nil {
+			return fmt.Errorf("invalid vrf nonce: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// contextuallyValidateAtx ensures that the previous ATX referenced is the last known ATX for the referenced miner ID.
+// If a previous ATX is not referenced, it validates that indeed there's no previous known ATX for that miner ID.
+func (h *HandlerV1) contextuallyValidateAtx(atx *wire.ActivationTxV1) error {
+	lastAtx, err := atxs.GetLastIDByNodeID(h.cdb, atx.SmesherID)
+	if err == nil && atx.PrevATXID == lastAtx {
+		// last atx referenced equals last ATX seen from node
+		return nil
+	}
+
+	if err == nil && atx.PrevATXID == types.EmptyATXID {
+		// no previous atx declared, but already seen at least one atx from node
+		return fmt.Errorf(
+			"no prev atx reported, but other atx with same node id (%v) found: %v",
+			atx.SmesherID,
+			lastAtx.ShortString(),
+		)
+	}
+
+	if err == nil && atx.PrevATXID != lastAtx {
+		// last atx referenced does not equal last ATX seen from node
+		return errors.New("last atx is not the one referenced")
+	}
+
+	if errors.Is(err, sql.ErrNotFound) && atx.PrevATXID == types.EmptyATXID {
+		// no previous atx found and none referenced
+		return nil
+	}
+
+	if err != nil && atx.PrevATXID != types.EmptyATXID {
+		// no previous atx found but previous atx referenced
+		h.log.With().Error("could not fetch node last atx",
+			atx.ID(),
+			log.Stringer("smesher", atx.SmesherID),
+			log.Err(err),
+		)
+		return fmt.Errorf("could not fetch node last atx: %w", err)
+	}
+
+	return err
+}
+
+// cacheAtx caches the atx in the atxsdata cache.
+// Returns true if the atx was cached, false otherwise.
+func (h *HandlerV1) cacheAtx(ctx context.Context, atx *types.ActivationTx, nonce types.VRFPostIndex) *atxsdata.ATX {
+	if !h.atxsdata.IsEvicted(atx.TargetEpoch()) {
+		malicious, err := h.cdb.IsMalicious(atx.SmesherID)
+		if err != nil {
+			h.log.With().Error("failed is malicious read", log.Err(err), log.Context(ctx))
+			return nil
+		}
+		return h.atxsdata.AddFromAtx(atx, nonce, malicious)
+	}
+	return nil
+}
+
+// storeAtx stores an ATX and notifies subscribers of the ATXID.
+func (h *HandlerV1) storeAtx(ctx context.Context, atx *types.ActivationTx) (*mwire.MalfeasanceProof, error) {
+	var nonce *types.VRFPostIndex
+	malicious, err := h.cdb.IsMalicious(atx.SmesherID)
+	if err != nil {
+		return nil, fmt.Errorf("checking if node is malicious: %w", err)
+	}
+	var proof *mwire.MalfeasanceProof
+	if err := h.cdb.WithTx(ctx, func(tx *sql.Tx) error {
+		if malicious {
+			if err := atxs.Add(tx, atx); err != nil && !errors.Is(err, sql.ErrObjectExists) {
+				return fmt.Errorf("add atx to db: %w", err)
+			}
+			return nil
+		}
+
+		prev, err := atxs.GetByEpochAndNodeID(tx, atx.PublishEpoch, atx.SmesherID)
+		if err != nil && !errors.Is(err, sql.ErrNotFound) {
+			return err
+		}
+
+		// do ID check to be absolutely sure.
+		if prev != nil && prev.ID() != atx.ID() {
+			if _, ok := h.signers[atx.SmesherID]; ok {
+				// if we land here we tried to publish 2 ATXs in the same epoch
+				// don't punish ourselves but fail validation and thereby the handling of the incoming ATX
+				return fmt.Errorf("%s already published an ATX in epoch %d", atx.SmesherID.ShortString(),
+					atx.PublishEpoch,
+				)
+			}
+
+			var atxProof mwire.AtxProof
+			for i, a := range []*types.ActivationTx{prev, atx} {
+				atxProof.Messages[i] = mwire.AtxProofMsg{
+					InnerMsg: types.ATXMetadata{
+						PublishEpoch: a.PublishEpoch,
+						MsgHash:      a.ID().Hash32(),
+					},
+					SmesherID: a.SmesherID,
+					Signature: a.Signature,
+				}
+			}
+			proof = &mwire.MalfeasanceProof{
+				Layer: atx.PublishEpoch.FirstLayer(),
+				Proof: mwire.Proof{
+					Type: mwire.MultipleATXs,
+					Data: &atxProof,
+				},
+			}
+			encoded, err := codec.Encode(proof)
+			if err != nil {
+				h.log.With().Panic("failed to encode malfeasance proof", log.Err(err))
+			}
+			if err := identities.SetMalicious(tx, atx.SmesherID, encoded, time.Now()); err != nil {
+				return fmt.Errorf("add malfeasance proof: %w", err)
+			}
+
+			h.log.WithContext(ctx).With().Warning("smesher produced more than one atx in the same epoch",
+				log.Stringer("smesher", atx.SmesherID),
+				log.Object("prev", prev),
+				log.Object("curr", atx),
+			)
+		}
+
+		nonce, err = atxs.AddGettingNonce(tx, atx)
+		if err != nil && !errors.Is(err, sql.ErrObjectExists) {
+			return fmt.Errorf("add atx to db: %w", err)
+		}
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("store atx: %w", err)
+	}
+	if nonce == nil {
+		return nil, errors.New("no nonce")
+	}
+	atxs.AtxAdded(h.cdb, atx)
+	if proof != nil {
+		h.cdb.CacheMalfeasanceProof(atx.SmesherID, proof)
+		h.tortoise.OnMalfeasance(atx.SmesherID)
+	}
+
+	added := h.cacheAtx(ctx, atx, *nonce)
+	h.beacon.OnAtx(atx.ToHeader())
+	if added != nil {
+		h.tortoise.OnAtx(atx.TargetEpoch(), atx.ID(), added)
+	}
+
+	h.log.WithContext(ctx).With().Debug("finished storing atx in epoch", atx.ID(), atx.PublishEpoch)
+
+	return proof, nil
+}
+
+func (h *HandlerV1) processATX(
+	ctx context.Context,
+	peer p2p.Peer,
+	watx wire.ActivationTxV1,
+	blob []byte,
+	received time.Time,
+) (*mwire.MalfeasanceProof, error) {
+	if !h.edVerifier.Verify(signing.ATX, watx.SmesherID, watx.SignedBytes(), watx.Signature) {
+		return nil, fmt.Errorf("invalid atx signature: %w", errMalformedData)
+	}
+
+	existing, _ := h.cdb.GetAtxHeader(watx.ID())
+	if existing != nil {
+		return nil, fmt.Errorf("%w atx %s", errKnownAtx, watx.ID())
+	}
+
+	h.log.WithContext(ctx).With().
+		Debug("processing atx", watx.ID(), watx.PublishEpoch, log.Stringer("smesherID", watx.SmesherID))
+
+	if err := h.syntacticallyValidate(ctx, &watx); err != nil {
+		return nil, fmt.Errorf("atx %s syntactically invalid: %w", watx.ID(), err)
+	}
+
+	poetRef, atxIDs := collectAtxDeps(h.goldenATXID, &watx)
+	h.registerHashes(peer, poetRef, atxIDs)
+	if err := h.fetchReferences(ctx, poetRef, atxIDs); err != nil {
+		return nil, fmt.Errorf("fetching references for atx %s: %w", watx.ID(), err)
+	}
+
+	leaves, effectiveNumUnits, proof, err := h.syntacticallyValidateDeps(ctx, &watx)
+	if err != nil {
+		return nil, fmt.Errorf("atx %s syntactically invalid based on deps: %w", watx.ID(), err)
+	}
+
+	if proof != nil {
+		return proof, err
+	}
+
+	if err := h.contextuallyValidateAtx(&watx); err != nil {
+		h.log.WithContext(ctx).With().
+			Warning("atx is contextually invalid ", watx.ID(), log.Stringer("smesherID", watx.SmesherID), log.Err(err))
+	} else {
+		h.log.WithContext(ctx).With().Debug("atx is valid", watx.ID())
+	}
+
+	var baseTickHeight uint64
+	if watx.PositioningATXID != h.goldenATXID {
+		posAtx, err := h.cdb.GetAtxHeader(watx.PositioningATXID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get positioning atx %s: %w", watx.PositioningATXID, err)
+		}
+		baseTickHeight = posAtx.TickHeight()
+	}
+
+	atx := wire.ActivationTxFromWireV1(&watx, blob...)
+	if h.nipostValidator.IsVerifyingFullPost() {
+		atx.SetValidity(types.Valid)
+	}
+	atx.SetReceived(received)
+	atx.NumUnits = effectiveNumUnits
+	atx.BaseTickHeight = baseTickHeight
+	atx.TickCount = leaves / h.tickSize
+
+	proof, err = h.storeAtx(ctx, atx)
+	if err != nil {
+		return nil, fmt.Errorf("cannot store atx %s: %w", atx.ShortString(), err)
+	}
+
+	events.ReportNewActivation(atx)
+	h.log.WithContext(ctx).With().Info("new atx", log.Inline(atx), log.Bool("malicious", proof != nil))
+	return proof, err
+}
+
+// registerHashes registers that the given peer should be asked for
+// the hashes of the poet proof and ATXs.
+func (h *HandlerV1) registerHashes(peer p2p.Peer, poetRef types.Hash32, atxIDs []types.ATXID) {
+	hashes := make([]types.Hash32, 0, len(atxIDs)+1)
+	for _, id := range atxIDs {
+		hashes = append(hashes, id.Hash32())
+	}
+	hashes = append(hashes, types.Hash32(poetRef))
+	h.fetcher.RegisterPeerHashes(peer, hashes)
+}
+
+// fetchReferences makes sure that the referenced poet proof and ATXs are available.
+func (h *HandlerV1) fetchReferences(ctx context.Context, poetRef types.Hash32, atxIDs []types.ATXID) error {
+	if err := h.fetcher.GetPoetProof(ctx, poetRef); err != nil {
+		return fmt.Errorf("missing poet proof (%s): %w", poetRef.ShortString(), err)
+	}
+
+	if len(atxIDs) == 0 {
+		return nil
+	}
+
+	if err := h.fetcher.GetAtxs(ctx, atxIDs, system.WithoutLimiting()); err != nil {
+		return fmt.Errorf("missing atxs %x: %w", atxIDs, err)
+	}
+
+	h.log.WithContext(ctx).With().Debug("done fetching references", log.Int("fetched", len(atxIDs)))
+	return nil
+}
+
+// Collect unique dependencies of an ATX.
+// Filters out EmptyATXID and the golden ATX.
+func collectAtxDeps(goldenAtxId types.ATXID, atx *wire.ActivationTxV1) (types.Hash32, []types.ATXID) {
+	ids := []types.ATXID{atx.PrevATXID, atx.PositioningATXID}
+	if atx.CommitmentATXID != nil {
+		ids = append(ids, *atx.CommitmentATXID)
+	}
+
+	filtered := make(map[types.ATXID]struct{})
+	for _, id := range ids {
+		if id != types.EmptyATXID && id != goldenAtxId {
+			filtered[id] = struct{}{}
+		}
+	}
+
+	return types.BytesToHash(atx.NIPost.PostMetadata.Challenge), maps.Keys(filtered)
+}

--- a/activation/handler_v1_test.go
+++ b/activation/handler_v1_test.go
@@ -1,0 +1,741 @@
+package activation
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/spacemeshos/go-spacemesh/activation/wire"
+	"github.com/spacemeshos/go-spacemesh/atxsdata"
+	"github.com/spacemeshos/go-spacemesh/codec"
+	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/datastore"
+	"github.com/spacemeshos/go-spacemesh/log/logtest"
+	"github.com/spacemeshos/go-spacemesh/malfeasance"
+	mwire "github.com/spacemeshos/go-spacemesh/malfeasance/wire"
+	"github.com/spacemeshos/go-spacemesh/p2p"
+	"github.com/spacemeshos/go-spacemesh/signing"
+	"github.com/spacemeshos/go-spacemesh/sql"
+	"github.com/spacemeshos/go-spacemesh/sql/atxs"
+	"github.com/spacemeshos/go-spacemesh/sql/identities"
+)
+
+type v1TestHandler struct {
+	*HandlerV1
+
+	handlerMocks
+}
+
+func newV1TestHandler(tb testing.TB, goldenATXID types.ATXID) *v1TestHandler {
+	lg := logtest.New(tb)
+	cdb := datastore.NewCachedDB(sql.InMemory(), lg)
+	mocks := newTestHandlerMocks(tb, goldenATXID)
+	return &v1TestHandler{
+		HandlerV1: &HandlerV1{
+			local:           "localID",
+			cdb:             cdb,
+			atxsdata:        atxsdata.New(),
+			edVerifier:      signing.NewEdVerifier(),
+			clock:           mocks.mclock,
+			tickSize:        1,
+			goldenATXID:     goldenATXID,
+			nipostValidator: mocks.mValidator,
+			log:             lg,
+			fetcher:         mocks.mockFetch,
+			beacon:          mocks.mbeacon,
+			tortoise:        mocks.mtortoise,
+			signers:         make(map[types.NodeID]*signing.EdSigner),
+		},
+		handlerMocks: mocks,
+	}
+}
+
+func TestHandlerV1_SyntacticallyValidateAtx(t *testing.T) {
+	sig, err := signing.NewEdSigner()
+	require.NoError(t, err)
+
+	goldenATXID := types.RandomATXID()
+
+	setup := func(t *testing.T) (hdlr *v1TestHandler, prev, pos *wire.ActivationTxV1) {
+		atxHdlr := newV1TestHandler(t, goldenATXID)
+
+		prevAtx := newInitialATXv1(t, goldenATXID)
+		prevAtx.NumUnits = 100
+		prevAtx.Sign(sig)
+		atxHdlr.expectAtxV1(prevAtx, sig.NodeID())
+		_, err := atxHdlr.processATX(context.Background(), "", *prevAtx, codec.MustEncode(prevAtx), time.Now())
+		require.NoError(t, err)
+
+		otherSig, err := signing.NewEdSigner()
+		require.NoError(t, err)
+
+		posAtx := newInitialATXv1(t, goldenATXID)
+		posAtx.Sign(otherSig)
+		atxHdlr.expectAtxV1(posAtx, otherSig.NodeID())
+		_, err = atxHdlr.processATX(context.Background(), "", *posAtx, codec.MustEncode(posAtx), time.Now())
+		require.NoError(t, err)
+		return atxHdlr, prevAtx, posAtx
+	}
+	t.Run("valid atx", func(t *testing.T) {
+		t.Parallel()
+		atxHdlr, prevAtx, posAtx := setup(t)
+
+		atx := newChainedActivationTxV1(t, goldenATXID, prevAtx, posAtx.ID())
+		atx.PositioningATXID = posAtx.ID()
+		atx.Sign(sig)
+
+		atxHdlr.mclock.EXPECT().CurrentLayer().Return(atx.PublishEpoch.FirstLayer())
+		require.NoError(t, atxHdlr.syntacticallyValidate(context.Background(), atx))
+
+		atxHdlr.mValidator.EXPECT().
+			NIPost(gomock.Any(), atx.SmesherID, goldenATXID, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(1234, nil)
+		atxHdlr.mValidator.EXPECT().NIPostChallengeV1(gomock.Any(), gomock.Any(), atx.SmesherID)
+		atxHdlr.mValidator.EXPECT().PositioningAtx(atx.PositioningATXID, gomock.Any(), goldenATXID, gomock.Any())
+		leaves, units, proof, err := atxHdlr.syntacticallyValidateDeps(context.Background(), atx)
+		require.NoError(t, err)
+		require.Equal(t, uint64(1234), leaves)
+		require.Equal(t, atx.NumUnits, units)
+		require.Nil(t, proof)
+	})
+	t.Run("valid atx with new VRF nonce", func(t *testing.T) {
+		t.Parallel()
+		atxHdlr, prevAtx, posAtx := setup(t)
+
+		newNonce := *prevAtx.VRFNonce + 100
+		atx := newChainedActivationTxV1(t, goldenATXID, prevAtx, posAtx.ID())
+		atx.VRFNonce = &newNonce
+		atx.Sign(sig)
+
+		atxHdlr.mclock.EXPECT().CurrentLayer().Return(atx.PublishEpoch.FirstLayer())
+		require.NoError(t, atxHdlr.syntacticallyValidate(context.Background(), atx))
+
+		atxHdlr.mValidator.EXPECT().
+			NIPost(gomock.Any(), gomock.Any(), goldenATXID, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(1234, nil)
+		atxHdlr.mValidator.EXPECT().NIPostChallengeV1(gomock.Any(), gomock.Any(), gomock.Any())
+		atxHdlr.mValidator.EXPECT().PositioningAtx(atx.PositioningATXID, gomock.Any(), goldenATXID, atx.PublishEpoch)
+		atxHdlr.mValidator.EXPECT().
+			VRFNonce(gomock.Any(), goldenATXID, newNonce, gomock.Any(), atx.NumUnits)
+		leaves, units, proof, err := atxHdlr.syntacticallyValidateDeps(context.Background(), atx)
+		require.NoError(t, err)
+		require.Equal(t, uint64(1234), leaves)
+		require.Equal(t, atx.NumUnits, units)
+		require.Nil(t, proof)
+	})
+	t.Run("valid atx with decreasing num units", func(t *testing.T) {
+		t.Parallel()
+		atxHdlr, prevAtx, posAtx := setup(t)
+
+		atx := newChainedActivationTxV1(t, goldenATXID, prevAtx, posAtx.ID())
+		atx.NumUnits = prevAtx.NumUnits - 10
+		atx.Sign(sig)
+
+		atxHdlr.mclock.EXPECT().CurrentLayer().Return(atx.PublishEpoch.FirstLayer())
+		require.NoError(t, atxHdlr.syntacticallyValidate(context.Background(), atx))
+		atxHdlr.mValidator.EXPECT().
+			NIPost(gomock.Any(), gomock.Any(), goldenATXID, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(uint64(1234), nil)
+		atxHdlr.mValidator.EXPECT().NIPostChallengeV1(gomock.Any(), gomock.Any(), gomock.Any())
+		atxHdlr.mValidator.EXPECT().PositioningAtx(atx.PositioningATXID, gomock.Any(), goldenATXID, atx.PublishEpoch)
+		leaves, units, proof, err := atxHdlr.syntacticallyValidateDeps(context.Background(), atx)
+		require.NoError(t, err)
+		require.Equal(t, uint64(1234), leaves)
+		require.Equal(t, atx.NumUnits, units)
+		require.Nil(t, proof)
+	})
+	t.Run("atx with increasing num units, no new VRF, old valid", func(t *testing.T) {
+		t.Parallel()
+		atxHdlr, prevAtx, posAtx := setup(t)
+
+		atx := newChainedActivationTxV1(t, goldenATXID, prevAtx, posAtx.ID())
+		atx.NumUnits = prevAtx.NumUnits + 10
+		atx.Sign(sig)
+
+		atxHdlr.mclock.EXPECT().CurrentLayer().Return(atx.PublishEpoch.FirstLayer())
+		require.NoError(t, atxHdlr.syntacticallyValidate(context.Background(), atx))
+		atxHdlr.mValidator.EXPECT().
+			NIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(uint64(1234), nil)
+		atxHdlr.mValidator.EXPECT().NIPostChallengeV1(gomock.Any(), gomock.Any(), gomock.Any())
+		atxHdlr.mValidator.EXPECT().PositioningAtx(atx.PositioningATXID, gomock.Any(), gomock.Any(), gomock.Any())
+		atxHdlr.mValidator.EXPECT().VRFNonce(gomock.Any(), goldenATXID, *prevAtx.VRFNonce, gomock.Any(), atx.NumUnits)
+		leaves, units, proof, err := atxHdlr.syntacticallyValidateDeps(context.Background(), atx)
+		require.NoError(t, err)
+		require.Equal(t, uint64(1234), leaves)
+		require.Equal(t, prevAtx.NumUnits, units)
+		require.Nil(t, proof)
+	})
+	t.Run("atx with increasing num units, no new VRF, old invalid for new size", func(t *testing.T) {
+		t.Parallel()
+		atxHdlr, prevAtx, posAtx := setup(t)
+
+		atx := newChainedActivationTxV1(t, goldenATXID, prevAtx, posAtx.ID())
+		atx.NumUnits = prevAtx.NumUnits + 10
+		atx.Sign(sig)
+
+		atxHdlr.mclock.EXPECT().CurrentLayer().Return(atx.PublishEpoch.FirstLayer())
+		require.NoError(t, atxHdlr.syntacticallyValidate(context.Background(), atx))
+
+		atxHdlr.mValidator.EXPECT().NIPostChallengeV1(gomock.Any(), gomock.Any(), gomock.Any())
+		atxHdlr.mValidator.EXPECT().
+			VRFNonce(gomock.Any(), goldenATXID, *prevAtx.VRFNonce, gomock.Any(), atx.NumUnits).
+			Return(errors.New("invalid VRF"))
+		_, _, proof, err := atxHdlr.syntacticallyValidateDeps(context.Background(), atx)
+		require.ErrorContains(t, err, "invalid VRF")
+		require.Nil(t, proof)
+	})
+	t.Run("valid initial atx", func(t *testing.T) {
+		t.Parallel()
+		atxHdlr, _, posAtx := setup(t)
+
+		ctxID := posAtx.ID()
+		atx := newInitialATXv1(t, goldenATXID)
+		atx.CommitmentATXID = &ctxID
+		atx.Sign(sig)
+
+		atxHdlr.mclock.EXPECT().CurrentLayer().Return(atx.PublishEpoch.FirstLayer())
+		atxHdlr.mValidator.EXPECT().
+			Post(gomock.Any(), gomock.Any(), ctxID, gomock.Any(), gomock.Any(), atx.NumUnits, gomock.Any())
+		atxHdlr.mValidator.EXPECT().VRFNonce(sig.NodeID(), ctxID, *atx.VRFNonce, gomock.Any(), atx.NumUnits)
+		require.NoError(t, atxHdlr.syntacticallyValidate(context.Background(), atx))
+
+		atxHdlr.mValidator.EXPECT().InitialNIPostChallengeV1(gomock.Any(), gomock.Any(), goldenATXID)
+		atxHdlr.mValidator.EXPECT().
+			NIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(uint64(777), nil)
+		atxHdlr.mValidator.EXPECT().PositioningAtx(atx.PositioningATXID, gomock.Any(), goldenATXID, atx.PublishEpoch)
+		leaves, units, proof, err := atxHdlr.syntacticallyValidateDeps(context.Background(), atx)
+		require.NoError(t, err)
+		require.Equal(t, uint64(777), leaves)
+		require.Equal(t, atx.NumUnits, units)
+		require.Nil(t, proof)
+	})
+	t.Run("atx targeting wrong publish epoch", func(t *testing.T) {
+		t.Parallel()
+		atxHdlr, prevAtx, posAtx := setup(t)
+
+		atx := newChainedActivationTxV1(t, goldenATXID, prevAtx, posAtx.ID())
+		atx.Sign(sig)
+
+		atxHdlr.mclock.EXPECT().CurrentLayer().Return((atx.PublishEpoch - 2).FirstLayer())
+		err := atxHdlr.syntacticallyValidate(context.Background(), atx)
+		require.ErrorContains(t, err, "atx publish epoch is too far in the future")
+	})
+	t.Run("failing nipost challenge validation", func(t *testing.T) {
+		t.Parallel()
+		atxHdlr, prevAtx, posAtx := setup(t)
+
+		atx := newChainedActivationTxV1(t, goldenATXID, prevAtx, posAtx.ID())
+		atx.Sign(sig)
+
+		atxHdlr.mclock.EXPECT().CurrentLayer().Return(atx.PublishEpoch.FirstLayer())
+		require.NoError(t, atxHdlr.syntacticallyValidate(context.Background(), atx))
+
+		atxHdlr.mValidator.EXPECT().
+			NIPostChallengeV1(gomock.Any(), gomock.Any(), atx.SmesherID).
+			Return(errors.New("nipost error"))
+		_, _, proof, err := atxHdlr.syntacticallyValidateDeps(context.Background(), atx)
+		require.EqualError(t, err, "nipost error")
+		require.Nil(t, proof)
+	})
+	t.Run("failing positioning atx validation", func(t *testing.T) {
+		t.Parallel()
+		atxHdlr, prevAtx, posAtx := setup(t)
+
+		atx := newChainedActivationTxV1(t, goldenATXID, prevAtx, posAtx.ID())
+		atx.Sign(sig)
+
+		atxHdlr.mclock.EXPECT().CurrentLayer().Return(atx.PublishEpoch.FirstLayer())
+		require.NoError(t, atxHdlr.syntacticallyValidate(context.Background(), atx))
+
+		atxHdlr.mValidator.EXPECT().NIPostChallengeV1(gomock.Any(), gomock.Any(), atx.SmesherID)
+		atxHdlr.mValidator.EXPECT().
+			PositioningAtx(atx.PositioningATXID, gomock.Any(), goldenATXID, atx.PublishEpoch).
+			Return(errors.New("bad positioning atx"))
+		_, _, proof, err := atxHdlr.syntacticallyValidateDeps(context.Background(), atx)
+		require.EqualError(t, err, "bad positioning atx")
+		require.Nil(t, proof)
+	})
+	t.Run("bad initial nipost challenge", func(t *testing.T) {
+		t.Parallel()
+		atxHdlr, _, posAtx := setup(t)
+
+		cATX := posAtx.ID()
+		atx := newInitialATXv1(t, cATX)
+		atx.Sign(sig)
+
+		atxHdlr.mclock.EXPECT().CurrentLayer().Return(atx.PublishEpoch.FirstLayer())
+		atxHdlr.mValidator.EXPECT().
+			Post(gomock.Any(), sig.NodeID(), cATX, gomock.Any(), gomock.Any(), atx.NumUnits, gomock.Any())
+		atxHdlr.mValidator.EXPECT().VRFNonce(sig.NodeID(), cATX, *atx.VRFNonce, gomock.Any(), atx.NumUnits)
+		require.NoError(t, atxHdlr.syntacticallyValidate(context.Background(), atx))
+
+		atxHdlr.mValidator.EXPECT().
+			InitialNIPostChallengeV1(gomock.Any(), gomock.Any(), goldenATXID).
+			Return(errors.New("bad initial nipost"))
+		_, _, proof, err := atxHdlr.syntacticallyValidateDeps(context.Background(), atx)
+		require.EqualError(t, err, "bad initial nipost")
+		require.Nil(t, proof)
+	})
+	t.Run("bad NIPoST", func(t *testing.T) {
+		t.Parallel()
+		atxHdlr, prevATX, postAtx := setup(t)
+
+		atx := newChainedActivationTxV1(t, goldenATXID, prevATX, postAtx.ID())
+		atx.Sign(sig)
+
+		atxHdlr.mclock.EXPECT().CurrentLayer().Return(atx.PublishEpoch.FirstLayer())
+		require.NoError(t, atxHdlr.syntacticallyValidate(context.Background(), atx))
+
+		atxHdlr.mValidator.EXPECT().NIPostChallengeV1(gomock.Any(), gomock.Any(), atx.SmesherID)
+		atxHdlr.mValidator.EXPECT().PositioningAtx(atx.PositioningATXID, gomock.Any(), goldenATXID, atx.PublishEpoch)
+		atxHdlr.mValidator.EXPECT().
+			NIPost(gomock.Any(), atx.SmesherID, goldenATXID, gomock.Any(), gomock.Any(), atx.NumUnits, gomock.Any()).
+			Return(0, errors.New("bad nipost"))
+		_, _, _, err := atxHdlr.syntacticallyValidateDeps(context.Background(), atx)
+		require.EqualError(t, err, "invalid nipost: bad nipost")
+	})
+	t.Run("can't find VRF nonce", func(t *testing.T) {
+		t.Parallel()
+		atxHdlr, prevATX, postAtx := setup(t)
+
+		atx := newChainedActivationTxV1(t, goldenATXID, prevATX, postAtx.ID())
+		atx.NumUnits += 100
+		atx.Sign(sig)
+
+		enc := func(stmt *sql.Statement) { stmt.BindBytes(1, atx.SmesherID.Bytes()) }
+		_, err := atxHdlr.cdb.Exec(`UPDATE atxs SET nonce = NULL WHERE pubkey = ?1;`, enc, nil)
+		require.NoError(t, err)
+
+		atxHdlr.mclock.EXPECT().CurrentLayer().Return(atx.PublishEpoch.FirstLayer())
+		require.NoError(t, atxHdlr.syntacticallyValidate(context.Background(), atx))
+
+		atxHdlr.mValidator.EXPECT().NIPostChallengeV1(gomock.Any(), gomock.Any(), atx.SmesherID)
+		_, _, _, err1 := atxHdlr.syntacticallyValidateDeps(context.Background(), atx)
+		require.ErrorContains(t, err1, "failed to get current nonce")
+	})
+	t.Run("missing NodeID in initial atx", func(t *testing.T) {
+		t.Parallel()
+		atxHdlr, _, _ := setup(t)
+
+		atx := newInitialATXv1(t, goldenATXID)
+		atx.Signature = sig.Sign(signing.ATX, atx.SignedBytes())
+		atx.SmesherID = sig.NodeID()
+
+		atxHdlr.mclock.EXPECT().CurrentLayer().Return(atx.PublishEpoch.FirstLayer())
+		err := atxHdlr.syntacticallyValidate(context.Background(), atx)
+		require.ErrorContains(t, err, "node id is missing")
+	})
+	t.Run("missing VRF nonce in initial atx", func(t *testing.T) {
+		t.Parallel()
+		atxHdlr, _, _ := setup(t)
+
+		atx := newInitialATXv1(t, goldenATXID)
+		atx.VRFNonce = nil
+		atx.Sign(sig)
+
+		atxHdlr.mclock.EXPECT().CurrentLayer().Return(atx.PublishEpoch.FirstLayer())
+		err := atxHdlr.syntacticallyValidate(context.Background(), atx)
+		require.ErrorContains(t, err, "vrf nonce is missing")
+	})
+	t.Run("invalid VRF nonce in initial atx", func(t *testing.T) {
+		t.Parallel()
+		atxHdlr, _, _ := setup(t)
+
+		atx := newInitialATXv1(t, goldenATXID)
+		atx.Sign(sig)
+
+		atxHdlr.mclock.EXPECT().CurrentLayer().Return(atx.PublishEpoch.FirstLayer())
+		atxHdlr.mValidator.EXPECT().
+			VRFNonce(atx.SmesherID, *atx.CommitmentATXID, *atx.VRFNonce, gomock.Any(), atx.NumUnits).
+			Return(errors.New("invalid VRF nonce"))
+		err := atxHdlr.syntacticallyValidate(context.Background(), atx)
+		require.ErrorContains(t, err, "invalid VRF nonce")
+	})
+	t.Run("prevAtx not declared but initial Post not included", func(t *testing.T) {
+		t.Parallel()
+		atxHdlr, prevAtx, posAtx := setup(t)
+
+		atx := newChainedActivationTxV1(t, goldenATXID, prevAtx, posAtx.ID())
+		atx.PrevATXID = types.EmptyATXID
+		atx.Sign(sig)
+
+		atxHdlr.mclock.EXPECT().CurrentLayer().Return(atx.PublishEpoch.FirstLayer())
+		err := atxHdlr.syntacticallyValidate(context.Background(), atx)
+		require.EqualError(t, err, "no prev atx declared, but initial post is not included")
+	})
+	t.Run("prevAtx not declared but commitment ATX is not included", func(t *testing.T) {
+		t.Parallel()
+		atxHdlr, _, _ := setup(t)
+
+		atx := newInitialATXv1(t, goldenATXID)
+		atx.CommitmentATXID = nil
+		atx.Sign(sig)
+
+		atxHdlr.mclock.EXPECT().CurrentLayer().Return(atx.PublishEpoch.FirstLayer())
+		err := atxHdlr.syntacticallyValidate(context.Background(), atx)
+		require.EqualError(t, err, "no prev atx declared, but commitment atx is missing")
+	})
+	t.Run("prevAtx not declared but commitment ATX is empty", func(t *testing.T) {
+		t.Parallel()
+		atxHdlr, _, _ := setup(t)
+
+		atx := newInitialATXv1(t, goldenATXID)
+		atx.CommitmentATXID = &types.EmptyATXID
+		atx.Sign(sig)
+
+		atxHdlr.mclock.EXPECT().CurrentLayer().Return(atx.PublishEpoch.FirstLayer())
+		err := atxHdlr.syntacticallyValidate(context.Background(), atx)
+		require.EqualError(t, err, "empty commitment atx")
+	})
+	t.Run("prevAtx not declared but sequence not zero", func(t *testing.T) {
+		t.Parallel()
+		atxHdlr, _, _ := setup(t)
+
+		atx := newInitialATXv1(t, goldenATXID)
+		atx.Sequence = 1
+		atx.Sign(sig)
+
+		atxHdlr.mclock.EXPECT().CurrentLayer().Return(atx.PublishEpoch.FirstLayer())
+		err := atxHdlr.syntacticallyValidate(context.Background(), atx)
+		require.EqualError(t, err, "no prev atx declared, but sequence number not zero")
+	})
+	t.Run("prevAtx not declared but validation of initial post fails", func(t *testing.T) {
+		t.Parallel()
+		atxHdlr, _, _ := setup(t)
+
+		atx := newInitialATXv1(t, goldenATXID)
+		atx.Sign(sig)
+
+		atxHdlr.mclock.EXPECT().CurrentLayer().Return(atx.PublishEpoch.FirstLayer())
+		atxHdlr.mValidator.EXPECT().
+			VRFNonce(atx.SmesherID, *atx.CommitmentATXID, *atx.VRFNonce, gomock.Any(), atx.NumUnits)
+		atxHdlr.mValidator.EXPECT().
+			Post(gomock.Any(), atx.SmesherID, gomock.Any(), gomock.Any(), gomock.Any(), atx.NumUnits, gomock.Any()).
+			Return(errors.New("failed post validation"))
+		err := atxHdlr.syntacticallyValidate(context.Background(), atx)
+		require.ErrorContains(t, err, "failed post validation")
+	})
+	t.Run("empty positioning ATX", func(t *testing.T) {
+		t.Parallel()
+		atxHdlr, _, _ := setup(t)
+
+		atx := newInitialATXv1(t, goldenATXID)
+		atx.PositioningATXID = types.EmptyATXID
+		atx.Sign(sig)
+
+		atxHdlr.mclock.EXPECT().CurrentLayer().Return(atx.PublishEpoch.FirstLayer())
+		err := atxHdlr.syntacticallyValidate(context.Background(), atx)
+		require.EqualError(t, err, "empty positioning atx")
+	})
+	t.Run("prevAtx declared but initial Post is included", func(t *testing.T) {
+		t.Parallel()
+		atxHdlr, prevAtx, _ := setup(t)
+
+		atx := newInitialATXv1(t, goldenATXID)
+		atx.PrevATXID = prevAtx.ID()
+		atx.Sign(sig)
+
+		atxHdlr.mclock.EXPECT().CurrentLayer().Return(atx.PublishEpoch.FirstLayer())
+		err := atxHdlr.syntacticallyValidate(context.Background(), atx)
+		require.EqualError(t, err, "prev atx declared, but initial post is included")
+	})
+	t.Run("prevAtx declared but NodeID is included", func(t *testing.T) {
+		t.Parallel()
+		atxHdlr, prevAtx, posAtx := setup(t)
+
+		atx := newChainedActivationTxV1(t, goldenATXID, prevAtx, posAtx.ID())
+		atx.NodeID = &types.NodeID{1, 2, 3}
+		atx.Sign(sig)
+
+		atxHdlr.mclock.EXPECT().CurrentLayer().Return(atx.PublishEpoch.FirstLayer())
+		err := atxHdlr.syntacticallyValidate(context.Background(), atx)
+		require.EqualError(t, err, "prev atx declared, but node id is included")
+	})
+	t.Run("prevAtx declared but commitmentATX is included", func(t *testing.T) {
+		t.Parallel()
+		atxHdlr, prevAtx, posAtx := setup(t)
+
+		atx := newChainedActivationTxV1(t, goldenATXID, prevAtx, posAtx.ID())
+		atx.CommitmentATXID = &types.EmptyATXID
+		atx.Sign(sig)
+
+		atxHdlr.mclock.EXPECT().CurrentLayer().Return(atx.PublishEpoch.FirstLayer())
+		err := atxHdlr.syntacticallyValidate(context.Background(), atx)
+		require.EqualError(t, err, "prev atx declared, but commitment atx is included")
+	})
+}
+
+func TestHandler_ContextuallyValidateAtx(t *testing.T) {
+	goldenATXID := types.ATXID{2, 3, 4}
+
+	sig, err := signing.NewEdSigner()
+	require.NoError(t, err)
+
+	t.Run("valid initial atx", func(t *testing.T) {
+		t.Parallel()
+
+		atx := newInitialATXv1(t, goldenATXID)
+		atx.Sign(sig)
+
+		atxHdlr := newV1TestHandler(t, goldenATXID)
+		require.NoError(t, atxHdlr.contextuallyValidateAtx(atx))
+	})
+
+	t.Run("missing prevAtx", func(t *testing.T) {
+		t.Parallel()
+
+		atxHdlr := newV1TestHandler(t, goldenATXID)
+
+		prevAtx := newInitialATXv1(t, goldenATXID)
+		atx := newChainedActivationTxV1(t, goldenATXID, prevAtx, goldenATXID)
+
+		err = atxHdlr.contextuallyValidateAtx(atx)
+		require.ErrorIs(t, err, sql.ErrNotFound)
+	})
+
+	t.Run("wrong previous atx by same node", func(t *testing.T) {
+		t.Parallel()
+
+		atxHdlr := newV1TestHandler(t, goldenATXID)
+
+		atx0 := newInitialATXv1(t, goldenATXID)
+		atx0.Sign(sig)
+		atxHdlr.expectAtxV1(atx0, sig.NodeID())
+		_, err := atxHdlr.processATX(context.Background(), "", *atx0, codec.MustEncode(atx0), time.Now())
+		require.NoError(t, err)
+
+		atx1 := newChainedActivationTxV1(t, goldenATXID, atx0, goldenATXID)
+		atx1.Sign(sig)
+		atxHdlr.expectAtxV1(atx1, sig.NodeID())
+		atxHdlr.mockFetch.EXPECT().GetAtxs(gomock.Any(), gomock.Any(), gomock.Any())
+		_, err = atxHdlr.processATX(context.Background(), "", *atx1, codec.MustEncode(atx1), time.Now())
+		require.NoError(t, err)
+
+		atxInvalidPrevious := newChainedActivationTxV1(t, goldenATXID, atx0, goldenATXID)
+		atxInvalidPrevious.Sign(sig)
+		err = atxHdlr.contextuallyValidateAtx(atxInvalidPrevious)
+		require.EqualError(t, err, "last atx is not the one referenced")
+	})
+
+	t.Run("wrong previous atx from different node", func(t *testing.T) {
+		t.Parallel()
+
+		otherSig, err := signing.NewEdSigner()
+		require.NoError(t, err)
+
+		atxHdlr := newV1TestHandler(t, goldenATXID)
+
+		atx0 := newInitialATXv1(t, goldenATXID)
+		atx0.Sign(otherSig)
+		atxHdlr.expectAtxV1(atx0, otherSig.NodeID())
+		_, err = atxHdlr.processATX(context.Background(), "", *atx0, codec.MustEncode(atx0), time.Now())
+		require.NoError(t, err)
+
+		atx1 := newInitialATXv1(t, goldenATXID)
+		atx1.Sign(sig)
+		atxHdlr.expectAtxV1(atx1, sig.NodeID())
+		_, err = atxHdlr.processATX(context.Background(), "", *atx1, codec.MustEncode(atx1), time.Now())
+		require.NoError(t, err)
+
+		atxInvalidPrevious := newChainedActivationTxV1(t, goldenATXID, atx0, goldenATXID)
+		atxInvalidPrevious.Sign(sig)
+		err = atxHdlr.contextuallyValidateAtx(atxInvalidPrevious)
+		require.EqualError(t, err, "last atx is not the one referenced")
+	})
+}
+
+func TestHandlerV1_StoreAtx(t *testing.T) {
+	goldenATXID := types.RandomATXID()
+
+	sig, err := signing.NewEdSigner()
+	require.NoError(t, err)
+
+	t.Run("stores ATX in DB", func(t *testing.T) {
+		atxHdlr := newV1TestHandler(t, goldenATXID)
+
+		watx := newInitialATXv1(t, goldenATXID)
+		watx.Sign(sig)
+		vAtx := toAtx(t, watx)
+		require.NoError(t, err)
+
+		atxHdlr.mbeacon.EXPECT().OnAtx(vAtx.ToHeader())
+		atxHdlr.mtortoise.EXPECT().OnAtx(gomock.Any(), vAtx.ID(), gomock.Any())
+		proof, err := atxHdlr.storeAtx(context.Background(), vAtx)
+		require.NoError(t, err)
+		require.Nil(t, proof)
+
+		atxFromDb, err := atxs.Get(atxHdlr.cdb, vAtx.ID())
+		require.NoError(t, err)
+		vAtx.SetReceived(time.Unix(0, vAtx.Received().UnixNano()))
+		require.Equal(t, vAtx, atxFromDb)
+	})
+
+	t.Run("storing an already known ATX returns no error", func(t *testing.T) {
+		atxHdlr := newV1TestHandler(t, goldenATXID)
+
+		watx := newInitialATXv1(t, goldenATXID)
+		watx.Sign(sig)
+		vAtx := toAtx(t, watx)
+
+		atxHdlr.mbeacon.EXPECT().OnAtx(vAtx.ToHeader())
+		atxHdlr.mtortoise.EXPECT().OnAtx(gomock.Any(), vAtx.ID(), gomock.Any())
+		proof, err := atxHdlr.storeAtx(context.Background(), vAtx)
+		require.NoError(t, err)
+		require.Nil(t, proof)
+
+		atxHdlr.mbeacon.EXPECT().OnAtx(vAtx.ToHeader())
+		// Note: tortoise is not informed about the same ATX again
+		proof, err = atxHdlr.storeAtx(context.Background(), vAtx)
+		require.NoError(t, err)
+		require.Nil(t, proof)
+	})
+
+	t.Run("another atx for the same epoch is considered malicious", func(t *testing.T) {
+		atxHdlr := newV1TestHandler(t, goldenATXID)
+
+		watx0 := newInitialATXv1(t, goldenATXID)
+		watx0.Sign(sig)
+		vAtx0 := toAtx(t, watx0)
+
+		atxHdlr.mbeacon.EXPECT().OnAtx(vAtx0.ToHeader())
+		atxHdlr.mtortoise.EXPECT().OnAtx(gomock.Any(), vAtx0.ID(), gomock.Any())
+
+		proof, err := atxHdlr.storeAtx(context.Background(), vAtx0)
+		require.NoError(t, err)
+		require.Nil(t, proof)
+
+		watx1 := newInitialATXv1(t, goldenATXID)
+		watx1.Coinbase = types.GenerateAddress([]byte("aaaa"))
+		watx1.Sign(sig)
+		vAtx1 := toAtx(t, watx1)
+
+		atxHdlr.mbeacon.EXPECT().OnAtx(vAtx1.ToHeader())
+		atxHdlr.mtortoise.EXPECT().OnAtx(gomock.Any(), vAtx1.ID(), gomock.Any())
+		atxHdlr.mtortoise.EXPECT().OnMalfeasance(sig.NodeID())
+
+		proof, err = atxHdlr.storeAtx(context.Background(), vAtx1)
+		require.NoError(t, err)
+		require.NotNil(t, proof)
+		require.Equal(t, mwire.MultipleATXs, proof.Proof.Type)
+
+		proof.SetReceived(time.Time{})
+		nodeID, err := malfeasance.Validate(
+			context.Background(),
+			atxHdlr.log,
+			atxHdlr.cdb,
+			atxHdlr.edVerifier,
+			nil,
+			&mwire.MalfeasanceGossip{MalfeasanceProof: *proof},
+		)
+		require.NoError(t, err)
+		require.Equal(t, sig.NodeID(), nodeID)
+
+		malicious, err := identities.IsMalicious(atxHdlr.cdb, sig.NodeID())
+		require.NoError(t, err)
+		require.True(t, malicious)
+	})
+
+	t.Run("another atx for the same epoch for registered ID doesn't create a malfeasance proof", func(t *testing.T) {
+		atxHdlr := newV1TestHandler(t, goldenATXID)
+		atxHdlr.Register(sig)
+
+		watx0 := newInitialATXv1(t, goldenATXID)
+		watx0.Sign(sig)
+		vAtx0 := toAtx(t, watx0)
+
+		atxHdlr.mbeacon.EXPECT().OnAtx(vAtx0.ToHeader())
+		atxHdlr.mtortoise.EXPECT().OnAtx(gomock.Any(), vAtx0.ID(), gomock.Any())
+
+		proof, err := atxHdlr.storeAtx(context.Background(), vAtx0)
+		require.NoError(t, err)
+		require.Nil(t, proof)
+
+		watx1 := newInitialATXv1(t, goldenATXID)
+		watx1.Coinbase = types.GenerateAddress([]byte("aaaa"))
+		watx1.Sign(sig)
+		vAtx1 := toAtx(t, watx1)
+
+		proof, err = atxHdlr.storeAtx(context.Background(), vAtx1)
+		require.ErrorContains(t,
+			err,
+			fmt.Sprintf("%s already published an ATX", sig.NodeID().ShortString()),
+		)
+		require.Nil(t, proof)
+
+		malicious, err := identities.IsMalicious(atxHdlr.cdb, sig.NodeID())
+		require.NoError(t, err)
+		require.False(t, malicious)
+	})
+}
+
+func TestHandlerV1_RegistersHashesInPeer(t *testing.T) {
+	goldenATXID := types.RandomATXID()
+	peer := p2p.Peer("buddy")
+	t.Run("registers poet and atxs", func(t *testing.T) {
+		t.Parallel()
+		atxHdlr := newV1TestHandler(t, goldenATXID)
+
+		poet := types.RandomHash()
+		atxs := []types.ATXID{types.RandomATXID(), types.RandomATXID()}
+
+		atxHdlr.mockFetch.EXPECT().
+			RegisterPeerHashes(peer, gomock.InAnyOrder([]types.Hash32{poet, atxs[0].Hash32(), atxs[1].Hash32()}))
+		atxHdlr.registerHashes(peer, poet, atxs)
+	})
+	t.Run("registers poet", func(t *testing.T) {
+		t.Parallel()
+		atxHdlr := newV1TestHandler(t, goldenATXID)
+
+		poet := types.RandomHash()
+
+		atxHdlr.mockFetch.EXPECT().RegisterPeerHashes(peer, []types.Hash32{poet})
+		atxHdlr.registerHashes(peer, poet, nil)
+	})
+}
+
+func TestHandlerV1_FetchesReferences(t *testing.T) {
+	goldenATXID := types.RandomATXID()
+	t.Run("fetch poet and atxs", func(t *testing.T) {
+		t.Parallel()
+		atxHdlr := newV1TestHandler(t, goldenATXID)
+
+		poet := types.RandomHash()
+		atxs := []types.ATXID{types.RandomATXID(), types.RandomATXID()}
+
+		atxHdlr.mockFetch.EXPECT().GetPoetProof(gomock.Any(), poet)
+		atxHdlr.mockFetch.EXPECT().GetAtxs(gomock.Any(), atxs, gomock.Any())
+		require.NoError(t, atxHdlr.fetchReferences(context.Background(), poet, atxs))
+	})
+
+	t.Run("no poet proofs", func(t *testing.T) {
+		t.Parallel()
+		atxHdlr := newV1TestHandler(t, goldenATXID)
+
+		poet := types.RandomHash()
+
+		atxHdlr.mockFetch.EXPECT().GetPoetProof(gomock.Any(), poet).Return(errors.New("pooh"))
+		require.Error(t, atxHdlr.fetchReferences(context.Background(), poet, nil))
+	})
+
+	t.Run("no atxs", func(t *testing.T) {
+		t.Parallel()
+		atxHdlr := newV1TestHandler(t, goldenATXID)
+
+		poet := types.RandomHash()
+		atxs := []types.ATXID{types.RandomATXID(), types.RandomATXID()}
+
+		atxHdlr.mockFetch.EXPECT().GetPoetProof(gomock.Any(), poet).Return(errors.New("pooh"))
+		require.Error(t, atxHdlr.fetchReferences(context.Background(), poet, nil))
+
+		atxHdlr.mockFetch.EXPECT().GetPoetProof(gomock.Any(), poet)
+		atxHdlr.mockFetch.EXPECT().GetAtxs(gomock.Any(), atxs, gomock.Any()).Return(errors.New("oh"))
+		require.Error(t, atxHdlr.fetchReferences(context.Background(), poet, atxs))
+	})
+}


### PR DESCRIPTION
## Motivation

The idea is to easily add a handler for upcoming ATX V2 without affecting the handler for V1. The `Handler` should figure out the version of ATX and dispatch to a specific handler.

## Description

:bulb: there are no logic changes :bulb: 

Split `HandlerV1` out of the `Handler`. In the future, the `Handler` will check the publish epoch of the handled ATX and dispatch to the right handler.

Extracted parts of `Handler` into `HandlerV1` (handler_v1.go) and split tests into "integration" - exercising `Handler` exported methods and "unit" - exercising HandlerV1 private methods.

## Test Plan

existing tests pass

## TODO

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [ ] Update documentation as needed
- [ ] Update [changelog](../CHANGELOG.md) as needed
