### PR TITLE
systest: add QUIC support

### DIFF
--- a/.github/workflows/systest.yml
+++ b/.github/workflows/systest.yml
@@ -54,6 +54,12 @@ jobs:
 
   systest:
     runs-on: ubuntu-latest
+    strategy:
+      # fail-fast: true
+      matrix:
+        protocol:
+          - tcp
+          - quic
     if: ${{ needs.filter-changes.outputs.nondocchanges == 'true' }}
     needs:
       - filter-changes
@@ -127,6 +133,7 @@ jobs:
           level: ${{ inputs.log_level }}
           clusters: 4
           norbac: 1
+          quic: ${{ matrix.protocol == 'tcp' && 'false' || 'true' }}
         run: make -C systest run test_name=${{ inputs.test_name }}
 
       - name: Delete pod

--- a/.github/workflows/systest.yml
+++ b/.github/workflows/systest.yml
@@ -124,7 +124,7 @@ jobs:
       - name: Run tests
         timeout-minutes: 60
         env:
-          test_id: systest-${{ steps.vars.outputs.sha_short }}
+          test_id: systest-${{ steps.vars.outputs.sha_short }}${{ matrix.protocol == 'quic' && '-quic' || '' }}
           label: sanity
           storage: premium-rwo=10Gi
           node_selector: cloud.google.com/gke-nodepool=gha
@@ -139,7 +139,8 @@ jobs:
       - name: Delete pod
         if: always()
         env:
-          test_id: systest-${{ steps.vars.outputs.sha_short }}
+          test_id: systest-${{ steps.vars.outputs.sha_short }}${{ matrix.protocol == 'quic' && '-quic' || '' }}
+          quic: ${{ matrix.protocol == 'tcp' && 'false' || 'true' }}
         run: make -C systest clean
 
   systest-status:

--- a/.github/workflows/systest.yml
+++ b/.github/workflows/systest.yml
@@ -55,7 +55,7 @@ jobs:
   systest:
     runs-on: ubuntu-latest
     strategy:
-      # fail-fast: true
+      fail-fast: true
       matrix:
         protocol:
           - tcp

--- a/systest/Makefile
+++ b/systest/Makefile
@@ -10,8 +10,14 @@ post_service_image ?= $(org)/post-service:v0.7.6
 post_init_image ?= $(org)/postcli:v0.12.5
 smesher_image ?= $(org)/go-spacemesh-dev:$(version_info)
 bs_image ?= $(org)/go-spacemesh-dev-bs:$(version_info)
+quic ?= false
+ifeq ($(quic),true)
+test_id ?= systest-$(version_info)-quic
+test_job_name ?= systest-$(version_info)-$(date)-quic
+else
 test_id ?= systest-$(version_info)
 test_job_name ?= systest-$(version_info)-$(date)
+endif
 keep ?= false
 clusters ?= 1
 size ?= 10
@@ -23,7 +29,6 @@ node_selector ?=
 namespace ?=
 label ?=
 count ?= 1
-quic ?= false
 
 configname ?= $(test_job_name)
 smesher_config ?= parameters/fastnet/smesher.json

--- a/systest/Makefile
+++ b/systest/Makefile
@@ -23,6 +23,7 @@ node_selector ?=
 namespace ?=
 label ?=
 count ?= 1
+quic ?= false
 
 configname ?= $(test_job_name)
 smesher_config ?= parameters/fastnet/smesher.json
@@ -63,6 +64,7 @@ template:
 	@echo post-init-image=$(post_init_image) >> $(tmpfile)
 	@echo keep=$(keep) >> $(tmpfile)
 	@echo testid=$(test_id) >> $(tmpfile)
+	@echo quic=$(quic) >> $(tmpfile)
 
 .PHONY: config
 config: template

--- a/systest/cluster/discover.go
+++ b/systest/cluster/discover.go
@@ -26,6 +26,7 @@ func discoverNodes(ctx *testcontext.Context, kind string) ([]*NodeClient, error)
 				P2P:       7513,
 				GRPC_PUB:  9092,
 				GRPC_PRIV: 9093,
+				QUIC:      ctx.QUIC,
 			},
 		})
 	}

--- a/systest/testcontext/context.go
+++ b/systest/testcontext/context.go
@@ -132,6 +132,9 @@ var (
 	LayersPerEpoch = parameters.Int(
 		ParamLayersPerEpoch, "number of layers in an epoch", 4,
 	)
+	quic = parameters.Bool(
+		"quic", "if true, QUIC is used for the tests instead of TCP",
+	)
 )
 
 const nsfile = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
@@ -175,6 +178,7 @@ type Context struct {
 		Class string
 	}
 	NodeSelector map[string]string
+	QUIC         bool
 	Log          *zap.SugaredLogger
 }
 
@@ -356,6 +360,7 @@ func New(t *testing.T, opts ...Opt) *Context {
 		PostServiceImage:  postServiceImage.Get(p),
 		PostInitImage:     postInitImage.Get(p),
 		NodeSelector:      nodeSelector.Get(p),
+		QUIC:              quic.Get(p),
 		Log:               logger.Sugar().Named(t.Name()),
 	}
 	cctx.Storage.Class = class

--- a/systest/tests/distributed_post_verification_test.go
+++ b/systest/tests/distributed_post_verification_test.go
@@ -81,6 +81,7 @@ func TestPostMalfeasanceProof(t *testing.T) {
 	cfg.P2P.PrivateNetwork = true
 	cfg.Bootstrap.URL = cluster.BootstrapperGlobalEndpoint(ctx.Namespace, 0)
 	cfg.P2P.MinPeers = 2
+	cfg.P2P.EnableQUICTransport = ctx.QUIC
 	ctx.Log.Debugw("Prepared config", "cfg", cfg)
 
 	goldenATXID := cl.GoldenATX()


### PR DESCRIPTION
## Motivation

QUIC protocol is not verified in systests

## Description

This adds a job that runs systests using QUIC instead of TCP

## Test Plan

Make sure systests pass in both modes

## TODO

- [X] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
