### PR TITLE
[Merged by Bors] - Avoid repeated searching for positioning ATX in 1:N

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ is macOS 14 (Sonoma) or later ([#5879](https://github.com/spacemeshos/go-spaceme
 
 * [#5896](https://github.com/spacemeshos/go-spacemesh/pull/5896) Increase supported number of ATXs to 4.5 Mio.
 
+* [#5904](https://github.com/spacemeshos/go-spacemesh/pull/5904) Avoid repeated searching for positioning ATX in 1:N
+
 ## (v1.5.0)
 
 ### Upgrade information

--- a/activation/activation.go
+++ b/activation/activation.go
@@ -85,6 +85,8 @@ type Builder struct {
 	// delay before PoST in ATX is considered valid (counting from the time it was received)
 	postValidityDelay time.Duration
 
+	posAtxFinder positioningAtxFinder
+
 	// states of each known identity
 	postStates PostStates
 
@@ -94,6 +96,14 @@ type Builder struct {
 	signers       map[types.NodeID]*signing.EdSigner
 	eg            errgroup.Group
 	stop          context.CancelFunc
+}
+
+type positioningAtxFinder struct {
+	finding sync.Mutex
+	found   *struct {
+		id         types.ATXID
+		forPublish types.EpochID
+	}
 }
 
 type BuilderOption func(*Builder)
@@ -480,6 +490,7 @@ func (b *Builder) BuildNIPostChallenge(ctx context.Context, nodeID types.NodeID)
 		current++
 		until = time.Until(b.poetRoundStart(current))
 	}
+	publish := current + 1
 	metrics.PublishOntimeWindowLatency.Observe(until.Seconds())
 	wait := buildNipostChallengeStartDeadline(b.poetRoundStart(current), b.poetCfg.GracePeriod)
 	if time.Until(wait) > 0 {
@@ -488,7 +499,7 @@ func (b *Builder) BuildNIPostChallenge(ctx context.Context, nodeID types.NodeID)
 			zap.Uint32("current epoch", current.Uint32()),
 			zap.Time("waiting until", wait),
 		)
-		events.EmitPoetWaitRound(nodeID, current, current+1, wait)
+		events.EmitPoetWaitRound(nodeID, current, publish, wait)
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
@@ -496,7 +507,7 @@ func (b *Builder) BuildNIPostChallenge(ctx context.Context, nodeID types.NodeID)
 		}
 	}
 
-	posAtx, err := b.getPositioningAtx(ctx, nodeID)
+	posAtx, err := b.getPositioningAtx(ctx, nodeID, publish)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get positioning ATX: %w", err)
 	}
@@ -528,7 +539,7 @@ func (b *Builder) BuildNIPostChallenge(ctx context.Context, nodeID types.NodeID)
 			return nil, fmt.Errorf("initial POST is invalid: %w", err)
 		}
 		challenge = &types.NIPostChallenge{
-			PublishEpoch:   current + 1,
+			PublishEpoch:   publish,
 			Sequence:       0,
 			PrevATXID:      types.EmptyATXID,
 			PositioningATX: posAtx,
@@ -544,7 +555,7 @@ func (b *Builder) BuildNIPostChallenge(ctx context.Context, nodeID types.NodeID)
 	default:
 		// regular ATX challenge
 		challenge = &types.NIPostChallenge{
-			PublishEpoch:   current + 1,
+			PublishEpoch:   publish,
 			Sequence:       prevAtx.Sequence + 1,
 			PrevATXID:      prevAtx.ID(),
 			PositioningATX: posAtx,
@@ -713,8 +724,20 @@ func (b *Builder) broadcast(ctx context.Context, atx scale.Encodable) (int, erro
 }
 
 // getPositioningAtx returns atx id with the highest tick height.
-func (b *Builder) getPositioningAtx(ctx context.Context, nodeID types.NodeID) (types.ATXID, error) {
-	logger := b.log.With(log.ZShortStringer("smesherID", nodeID))
+// publish epoch is used for caching the positioning atx.
+func (b *Builder) getPositioningAtx(
+	ctx context.Context,
+	nodeID types.NodeID,
+	publish types.EpochID,
+) (types.ATXID, error) {
+	logger := b.log.With(log.ZShortStringer("smesherID", nodeID), zap.Uint32("publish epoch", publish.Uint32()))
+	b.posAtxFinder.finding.Lock()
+	defer b.posAtxFinder.finding.Unlock()
+	if found := b.posAtxFinder.found; found != nil && found.forPublish == publish {
+		logger.Info("using cached positioning atx", log.ZShortStringer("atx_id", found.id))
+		return found.id, nil
+	}
+
 	logger.Info("searching for positioning atx")
 	id, err := findFullyValidHighTickAtx(
 		ctx,
@@ -729,9 +752,17 @@ func (b *Builder) getPositioningAtx(ctx context.Context, nodeID types.NodeID) (t
 	)
 	switch {
 	case err == nil:
+		b.posAtxFinder.found = &struct {
+			id         types.ATXID
+			forPublish types.EpochID
+		}{id, publish}
 		return id, nil
 	case errors.Is(err, sql.ErrNotFound):
 		logger.Info("using golden atx as positioning atx")
+		b.posAtxFinder.found = &struct {
+			id         types.ATXID
+			forPublish types.EpochID
+		}{b.conf.GoldenATXID, publish}
 		return b.conf.GoldenATXID, nil
 	}
 	return id, err

--- a/activation/activation.go
+++ b/activation/activation.go
@@ -734,7 +734,7 @@ func (b *Builder) getPositioningAtx(
 	b.posAtxFinder.finding.Lock()
 	defer b.posAtxFinder.finding.Unlock()
 	if found := b.posAtxFinder.found; found != nil && found.forPublish == publish {
-		logger.Info("using cached positioning atx", log.ZShortStringer("atx_id", found.id))
+		logger.Debug("using cached positioning atx", log.ZShortStringer("atx_id", found.id))
 		return found.id, nil
 	}
 

--- a/activation/activation_test.go
+++ b/activation/activation_test.go
@@ -1376,7 +1376,23 @@ func TestGetPositioningAtxPicksAtxWithValidChain(t *testing.T) {
 	tab.mValidator.EXPECT().
 		VerifyChain(gomock.Any(), validAtx.ID(), tab.goldenATXID, gomock.Any())
 
-	posAtxID, err := tab.getPositioningAtx(context.Background(), sig.NodeID())
+	posAtxID, err := tab.getPositioningAtx(context.Background(), sig.NodeID(), 77)
+	require.NoError(t, err)
+	require.Equal(t, posAtxID, vValidAtx.ID())
+
+	// should use the cached positioning ATX when asked for the same publish epoch
+	posAtxID, err = tab.getPositioningAtx(context.Background(), sig.NodeID(), 77)
+	require.NoError(t, err)
+	require.Equal(t, posAtxID, vValidAtx.ID())
+
+	// should lookup again when asked for a different publish epoch
+	tab.mValidator.EXPECT().
+		VerifyChain(gomock.Any(), invalidAtx.ID(), tab.goldenATXID, gomock.Any()).
+		Return(errors.New(""))
+	tab.mValidator.EXPECT().
+		VerifyChain(gomock.Any(), validAtx.ID(), tab.goldenATXID, gomock.Any())
+
+	posAtxID, err = tab.getPositioningAtx(context.Background(), sig.NodeID(), 99)
 	require.NoError(t, err)
 	require.Equal(t, posAtxID, vValidAtx.ID())
 }
@@ -1390,7 +1406,7 @@ func TestGetPositioningAtxDbFailed(t *testing.T) {
 	expected := errors.New("db error")
 	db.EXPECT().Exec(gomock.Any(), gomock.Any(), gomock.Any()).Return(0, expected)
 
-	none, err := tab.getPositioningAtx(context.Background(), sig.NodeID())
+	none, err := tab.getPositioningAtx(context.Background(), sig.NodeID(), 99)
 	require.ErrorIs(t, err, expected)
 	require.Equal(t, types.ATXID{}, none)
 }


### PR DESCRIPTION
## Motivation

It avoids duplicated work to look up a positioning ATX and verify its chain.

## Description

Looking up a positioning ATX is serialized with a mutex and the result is cached (keyed by the publish epoch that the pos ATX is about to be used for). Only one pos ATX is cached.

## Test Plan

Added tests to verify caching.

## TODO

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [ ] Update documentation as needed
- [ ] Update [changelog](../CHANGELOG.md) as needed
