### PR TITLE
[Merged by Bors] - Support configuring ATX versions in ATX Handler

### DIFF
--- a/activation/handler.go
+++ b/activation/handler.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"sync"
 	"time"
+
+	"go.uber.org/zap/zapcore"
 
 	"github.com/spacemeshos/go-spacemesh/activation/wire"
 	"github.com/spacemeshos/go-spacemesh/atxsdata"
@@ -29,11 +32,18 @@ var (
 	errMaliciousATX  = errors.New("malicious atx")
 )
 
+type atxVersion struct {
+	// epoch since this version is valid
+	publish types.EpochID
+	types.AtxVersion
+}
+
 // Handler processes the atxs received from all nodes and their validity status.
 type Handler struct {
 	local     p2p.Peer
 	publisher pubsub.Publisher
 	log       log.Log
+	versions  []atxVersion
 
 	// inProgress map gathers ATXs that are currently being processed.
 	// It's used to avoid processing the same ATX twice.
@@ -41,6 +51,21 @@ type Handler struct {
 	inProgressMu sync.Mutex
 
 	v1 *HandlerV1
+}
+
+// HandlerOption is a functional option for the handler.
+type HandlerOption func(*Handler)
+
+func WithAtxVersion(publish types.EpochID, version types.AtxVersion) HandlerOption {
+	return func(h *Handler) {
+		h.versions = append(h.versions, atxVersion{publish, version})
+	}
+}
+
+func WithTickSize(tickSize uint64) HandlerOption {
+	return func(h *Handler) {
+		h.v1.tickSize = tickSize
+	}
 }
 
 // NewHandler returns a data handler for ATX.
@@ -52,27 +77,29 @@ func NewHandler(
 	c layerClock,
 	pub pubsub.Publisher,
 	fetcher system.Fetcher,
-	tickSize uint64,
 	goldenATXID types.ATXID,
 	nipostValidator nipostValidator,
 	beacon AtxReceiver,
 	tortoise system.Tortoise,
-	log log.Log,
-) *Handler {
+	lg log.Log,
+	opts ...HandlerOption,
+) (*Handler, error) {
 	h := &Handler{
 		local:     local,
 		publisher: pub,
-		log:       log,
+		log:       lg,
+		versions:  []atxVersion{{0, types.AtxV1}},
+
 		v1: &HandlerV1{
 			local:           local,
 			cdb:             cdb,
 			atxsdata:        atxsdata,
 			edVerifier:      edVerifier,
 			clock:           c,
-			tickSize:        tickSize,
+			tickSize:        1,
 			goldenATXID:     goldenATXID,
 			nipostValidator: nipostValidator,
-			log:             log,
+			log:             lg,
 			fetcher:         fetcher,
 			beacon:          beacon,
 			tortoise:        tortoise,
@@ -82,7 +109,48 @@ func NewHandler(
 		inProgress: make(map[types.ATXID][]chan error),
 	}
 
-	return h
+	for _, opt := range opts {
+		opt(h)
+	}
+	if err := verifyAtxVersions(h.versions); err != nil {
+		return nil, fmt.Errorf("invalid ATX versions configured (%v): %w", h.versions, err)
+	}
+
+	h.log.With().Info("atx handler created",
+		log.Array("supported ATX versions", log.ArrayMarshalerFunc(func(enc zapcore.ArrayEncoder) error {
+			for _, v := range h.versions {
+				enc.AppendString(fmt.Sprintf("v%v from epoch %d", v.AtxVersion, v.publish))
+			}
+			return nil
+		})))
+
+	return h, nil
+}
+
+func verifyAtxVersions(versions []atxVersion) error {
+	if len(versions) == 0 {
+		return errors.New("no ATX versions configured")
+	}
+	slices.SortFunc(versions, func(a, b atxVersion) int {
+		switch {
+		case a.publish < b.publish:
+			return -1
+		case a.publish > b.publish:
+			return 1
+		}
+		return 0
+	})
+	lastVersion := types.AtxV1
+	for _, v := range versions {
+		if v.AtxVersion < types.AtxV1 || v.AtxVersion > types.AtxVMAX {
+			return fmt.Errorf("ATX version: %v not in range [%v:%v]", v, types.AtxV1, types.AtxVMAX)
+		}
+		if v.AtxVersion < lastVersion {
+			return fmt.Errorf("cannot decrease ATX version from %v to %v", lastVersion, v.AtxVersion)
+		}
+		lastVersion = v.AtxVersion
+	}
+	return nil
 }
 
 func (h *Handler) Register(sig *signing.EdSigner) {
@@ -133,6 +201,45 @@ func (h *Handler) HandleGossipAtx(ctx context.Context, peer p2p.Peer, msg []byte
 	return err
 }
 
+func (h *Handler) determineVersion(msg []byte) (*types.AtxVersion, error) {
+	// The first field of all ATXs is the publish epoch, which
+	// we use to determine the version of the ATX.
+	var publish types.EpochID
+	if err := codec.Decode(msg, &publish); err != nil && !errors.Is(err, codec.ErrShortRead) {
+		return nil, fmt.Errorf("%w: %w", errMalformedData, err)
+	}
+
+	version := types.AtxV1
+	for _, v := range h.versions {
+		if publish >= v.publish {
+			version = v.AtxVersion
+		}
+	}
+	return &version, nil
+}
+
+type opaqueAtx interface {
+	ID() types.ATXID
+}
+
+func (h *Handler) decodeATX(msg []byte) (opaqueAtx, error) {
+	version, err := h.determineVersion(msg)
+	if err != nil {
+		return nil, fmt.Errorf("determining ATX version: %w", err)
+	}
+
+	switch *version {
+	case types.AtxV1:
+		var atx wire.ActivationTxV1
+		if err := codec.Decode(msg, &atx); err != nil {
+			return nil, fmt.Errorf("%w: %w", errMalformedData, err)
+		}
+		return &atx, nil
+	}
+
+	return nil, fmt.Errorf("unsupported ATX version: %v", *version)
+}
+
 func (h *Handler) handleAtx(
 	ctx context.Context,
 	expHash types.Hash32,
@@ -141,11 +248,12 @@ func (h *Handler) handleAtx(
 ) (*mwire.MalfeasanceProof, error) {
 	receivedTime := time.Now()
 
-	var atx wire.ActivationTxV1
-	if err := codec.Decode(msg, &atx); err != nil {
-		return nil, fmt.Errorf("%w: %w", errMalformedData, err)
+	opaqueAtx, err := h.decodeATX(msg)
+	if err != nil {
+		return nil, fmt.Errorf("decoding ATX: %w", err)
 	}
-	id := atx.ID()
+	id := opaqueAtx.ID()
+
 	if (expHash != types.Hash32{}) && id.Hash32() != expHash {
 		return nil, fmt.Errorf("%w: atx want %s, got %s", errWrongHash, expHash.ShortString(), id.ShortString())
 	}
@@ -170,7 +278,15 @@ func (h *Handler) handleAtx(
 	h.inProgressMu.Unlock()
 	h.log.WithContext(ctx).With().Info("handling incoming atx", id, log.Int("size", len(msg)))
 
-	proof, err := h.v1.processATX(ctx, peer, atx, msg, receivedTime)
+	var proof *mwire.MalfeasanceProof
+
+	switch atx := opaqueAtx.(type) {
+	case *wire.ActivationTxV1:
+		proof, err = h.v1.processATX(ctx, peer, atx, msg, receivedTime)
+	default:
+		panic("unreachable")
+	}
+
 	h.inProgressMu.Lock()
 	defer h.inProgressMu.Unlock()
 	for _, ch := range h.inProgress[id] {

--- a/activation/handler.go
+++ b/activation/handler.go
@@ -109,7 +109,7 @@ func NewHandler(
 	tortoise system.Tortoise,
 	lg log.Log,
 	opts ...HandlerOption,
-) (*Handler, error) {
+) *Handler {
 	h := &Handler{
 		local:     local,
 		publisher: pub,
@@ -147,7 +147,7 @@ func NewHandler(
 			return nil
 		})))
 
-	return h, nil
+	return h
 }
 
 func (h *Handler) Register(sig *signing.EdSigner) {

--- a/activation/handler_test.go
+++ b/activation/handler_test.go
@@ -838,3 +838,26 @@ func TestHandler_ConfiguringAtxVersions(t *testing.T) {
 		require.EqualValues(t, 10, versions[1].publish)
 	})
 }
+
+func TestHandler_DecodeATX(t *testing.T) {
+	t.Parallel()
+
+	t.Run("v1", func(t *testing.T) {
+		t.Parallel()
+		atxHdlr := newTestHandler(t, types.RandomATXID())
+
+		atx := newInitialATXv1(t, atxHdlr.goldenATXID)
+		atx.PublishEpoch = 2
+
+		decoded, err := atxHdlr.decodeATX(codec.MustEncode(atx))
+		require.NoError(t, err)
+		require.Equal(t, atx, decoded)
+	})
+	t.Run("v2 not supported", func(t *testing.T) {
+		t.Parallel()
+		atxHdlr := newTestHandler(t, types.RandomATXID(), WithAtxVersion(10, types.AtxV2))
+
+		_, err := atxHdlr.decodeATX(codec.MustEncode(types.EpochID(20)))
+		require.ErrorContains(t, err, "unsupported ATX version")
+	})
+}

--- a/activation/handler_test.go
+++ b/activation/handler_test.go
@@ -197,7 +197,7 @@ func newTestHandler(tb testing.TB, goldenATXID types.ATXID, opts ...HandlerOptio
 	edVerifier := signing.NewEdVerifier()
 
 	mocks := newTestHandlerMocks(tb, goldenATXID)
-	atxHdlr, err := NewHandler(
+	atxHdlr := NewHandler(
 		"localID",
 		cdb,
 		atxsdata.New(),
@@ -212,7 +212,6 @@ func newTestHandler(tb testing.TB, goldenATXID types.ATXID, opts ...HandlerOptio
 		lg,
 		opts...,
 	)
-	require.NoError(tb, err)
 	return &testHandler{
 		Handler:    atxHdlr,
 		cdb:        cdb,

--- a/activation/handler_v1_test.go
+++ b/activation/handler_v1_test.go
@@ -68,7 +68,7 @@ func TestHandlerV1_SyntacticallyValidateAtx(t *testing.T) {
 		prevAtx.NumUnits = 100
 		prevAtx.Sign(sig)
 		atxHdlr.expectAtxV1(prevAtx, sig.NodeID())
-		_, err := atxHdlr.processATX(context.Background(), "", *prevAtx, codec.MustEncode(prevAtx), time.Now())
+		_, err := atxHdlr.processATX(context.Background(), "", prevAtx, codec.MustEncode(prevAtx), time.Now())
 		require.NoError(t, err)
 
 		otherSig, err := signing.NewEdSigner()
@@ -77,7 +77,7 @@ func TestHandlerV1_SyntacticallyValidateAtx(t *testing.T) {
 		posAtx := newInitialATXv1(t, goldenATXID)
 		posAtx.Sign(otherSig)
 		atxHdlr.expectAtxV1(posAtx, otherSig.NodeID())
-		_, err = atxHdlr.processATX(context.Background(), "", *posAtx, codec.MustEncode(posAtx), time.Now())
+		_, err = atxHdlr.processATX(context.Background(), "", posAtx, codec.MustEncode(posAtx), time.Now())
 		require.NoError(t, err)
 		return atxHdlr, prevAtx, posAtx
 	}
@@ -508,14 +508,14 @@ func TestHandler_ContextuallyValidateAtx(t *testing.T) {
 		atx0 := newInitialATXv1(t, goldenATXID)
 		atx0.Sign(sig)
 		atxHdlr.expectAtxV1(atx0, sig.NodeID())
-		_, err := atxHdlr.processATX(context.Background(), "", *atx0, codec.MustEncode(atx0), time.Now())
+		_, err := atxHdlr.processATX(context.Background(), "", atx0, codec.MustEncode(atx0), time.Now())
 		require.NoError(t, err)
 
 		atx1 := newChainedActivationTxV1(t, goldenATXID, atx0, goldenATXID)
 		atx1.Sign(sig)
 		atxHdlr.expectAtxV1(atx1, sig.NodeID())
 		atxHdlr.mockFetch.EXPECT().GetAtxs(gomock.Any(), gomock.Any(), gomock.Any())
-		_, err = atxHdlr.processATX(context.Background(), "", *atx1, codec.MustEncode(atx1), time.Now())
+		_, err = atxHdlr.processATX(context.Background(), "", atx1, codec.MustEncode(atx1), time.Now())
 		require.NoError(t, err)
 
 		atxInvalidPrevious := newChainedActivationTxV1(t, goldenATXID, atx0, goldenATXID)
@@ -535,13 +535,13 @@ func TestHandler_ContextuallyValidateAtx(t *testing.T) {
 		atx0 := newInitialATXv1(t, goldenATXID)
 		atx0.Sign(otherSig)
 		atxHdlr.expectAtxV1(atx0, otherSig.NodeID())
-		_, err = atxHdlr.processATX(context.Background(), "", *atx0, codec.MustEncode(atx0), time.Now())
+		_, err = atxHdlr.processATX(context.Background(), "", atx0, codec.MustEncode(atx0), time.Now())
 		require.NoError(t, err)
 
 		atx1 := newInitialATXv1(t, goldenATXID)
 		atx1.Sign(sig)
 		atxHdlr.expectAtxV1(atx1, sig.NodeID())
-		_, err = atxHdlr.processATX(context.Background(), "", *atx1, codec.MustEncode(atx1), time.Now())
+		_, err = atxHdlr.processATX(context.Background(), "", atx1, codec.MustEncode(atx1), time.Now())
 		require.NoError(t, err)
 
 		atxInvalidPrevious := newChainedActivationTxV1(t, goldenATXID, atx0, goldenATXID)

--- a/checkpoint/recovery_test.go
+++ b/checkpoint/recovery_test.go
@@ -237,7 +237,7 @@ func validateAndPreserveData(
 	mreceiver := activation.NewMockAtxReceiver(ctrl)
 	mtrtl := smocks.NewMockTortoise(ctrl)
 	cdb := datastore.NewCachedDB(db, lg)
-	atxHandler, err := activation.NewHandler(
+	atxHandler := activation.NewHandler(
 		"",
 		cdb,
 		atxsdata.New(),
@@ -251,7 +251,6 @@ func validateAndPreserveData(
 		mtrtl,
 		lg,
 	)
-	require.NoError(tb, err)
 	mfetch.EXPECT().GetAtxs(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 	for _, dep := range deps {
 		var atx wire.ActivationTxV1

--- a/checkpoint/recovery_test.go
+++ b/checkpoint/recovery_test.go
@@ -237,7 +237,7 @@ func validateAndPreserveData(
 	mreceiver := activation.NewMockAtxReceiver(ctrl)
 	mtrtl := smocks.NewMockTortoise(ctrl)
 	cdb := datastore.NewCachedDB(db, lg)
-	atxHandler := activation.NewHandler(
+	atxHandler, err := activation.NewHandler(
 		"",
 		cdb,
 		atxsdata.New(),
@@ -245,13 +245,13 @@ func validateAndPreserveData(
 		mclock,
 		nil,
 		mfetch,
-		10,
 		goldenAtx,
 		mvalidator,
 		mreceiver,
 		mtrtl,
 		lg,
 	)
+	require.NoError(tb, err)
 	mfetch.EXPECT().GetAtxs(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 	for _, dep := range deps {
 		var atx wire.ActivationTxV1

--- a/common/types/activation.go
+++ b/common/types/activation.go
@@ -143,7 +143,11 @@ func (m *ATXMetadata) MarshalLogObject(encoder log.ObjectEncoder) error {
 
 type AtxVersion uint
 
-const AtxV1 AtxVersion = 1
+const (
+	AtxV1   AtxVersion = 1
+	AtxV2   AtxVersion = 2
+	AtxVMAX AtxVersion = AtxV2
+)
 
 type AtxBlob struct {
 	Blob    []byte

--- a/config/config.go
+++ b/config/config.go
@@ -139,6 +139,12 @@ type BaseConfig struct {
 
 	// NoMainOverride forces the "nomain" builds to run on the mainnet
 	NoMainOverride bool `mapstructure:"no-main-override"`
+
+	// ATX version switches
+	// Each entry states on which publish epoch given ATX version becomes valid.
+	// Note: There is always one valid version at any given time.
+	// ATX V1 starts with epoch 0 unless configured otherwise.
+	AtxVersions map[types.EpochID]types.AtxVersion `mapstructure:"atx-versions"`
 }
 
 type DatabaseQueryCacheSizes struct {

--- a/config/config.go
+++ b/config/config.go
@@ -144,7 +144,7 @@ type BaseConfig struct {
 	// Each entry states on which publish epoch given ATX version becomes valid.
 	// Note: There is always one valid version at any given time.
 	// ATX V1 starts with epoch 0 unless configured otherwise.
-	AtxVersions map[types.EpochID]types.AtxVersion `mapstructure:"atx-versions"`
+	AtxVersions activation.AtxVersions `mapstructure:"atx-versions"`
 }
 
 type DatabaseQueryCacheSizes struct {

--- a/node/mapstructureutil/atxversions.go
+++ b/node/mapstructureutil/atxversions.go
@@ -1,0 +1,30 @@
+package mapstructureutil
+
+import (
+	"reflect"
+
+	"github.com/mitchellh/mapstructure"
+
+	"github.com/spacemeshos/go-spacemesh/activation"
+)
+
+// AtxVersionsDecodeFunc mapstructure decode func for activation.AtxVersions.
+func AtxVersionsDecodeFunc() mapstructure.DecodeHookFunc {
+	return func(f, t reflect.Type, data any) (any, error) {
+		if t != reflect.TypeOf(activation.AtxVersions{}) {
+			return data, nil
+		}
+
+		if f.Kind() != reflect.Map {
+			return data, nil
+		}
+
+		var result activation.AtxVersions
+		err := mapstructure.WeakDecode(data, &result)
+		if err != nil {
+			return nil, err
+		}
+
+		return result, result.Validate()
+	}
+}

--- a/node/mapstructureutil/atxversions_test.go
+++ b/node/mapstructureutil/atxversions_test.go
@@ -1,0 +1,33 @@
+package mapstructureutil_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/spacemeshos/go-spacemesh/activation"
+	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/node/mapstructureutil"
+)
+
+func TestAtxVersionsHook(t *testing.T) {
+	hook := mapstructureutil.AtxVersionsDecodeFunc().(func(reflect.Type, reflect.Type, any) (any, error))
+
+	t.Run("valid", func(t *testing.T) {
+		data := map[string]any{"2": types.AtxV2}
+
+		result, err := hook(reflect.TypeOf(data), reflect.TypeOf(activation.AtxVersions{}), data)
+		require.NoError(t, err)
+
+		value, ok := result.(activation.AtxVersions)
+		require.True(t, ok)
+		require.EqualValues(t, map[types.EpochID]types.AtxVersion{2: types.AtxV2}, value)
+	})
+	t.Run("invalid", func(t *testing.T) {
+		data := map[string]any{"2": types.AtxVMAX + 1}
+
+		_, err := hook(reflect.TypeOf(data), reflect.TypeOf(activation.AtxVersions{}), data)
+		require.Error(t, err)
+	})
+}

--- a/node/node.go
+++ b/node/node.go
@@ -302,6 +302,7 @@ func loadConfig(cfg *config.Config, preset, path string) error {
 		mapstructureutil.BigRatDecodeFunc(),
 		mapstructureutil.PostProviderIDDecodeFunc(),
 		mapstructureutil.DeprecatedHook(),
+		mapstructureutil.AtxVersionsDecodeFunc(),
 		mapstructure.TextUnmarshallerHookFunc(),
 	)
 
@@ -748,13 +749,6 @@ func (app *App) initServices(ctx context.Context) error {
 
 	fetcherWrapped := &layerFetcher{}
 
-	handlerOpts := []activation.HandlerOption{
-		activation.WithTickSize(app.Config.TickSize),
-	}
-	for publish, version := range app.Config.AtxVersions {
-		handlerOpts = append(handlerOpts, activation.WithAtxVersion(publish, version))
-	}
-
 	atxHandler, err := activation.NewHandler(
 		app.host.ID(),
 		app.cachedDB,
@@ -768,7 +762,8 @@ func (app *App) initServices(ctx context.Context) error {
 		beaconProtocol,
 		trtl,
 		app.addLogger(ATXHandlerLogger, lg),
-		handlerOpts...,
+		activation.WithTickSize(app.Config.TickSize),
+		activation.WithAtxVersions(app.Config.AtxVersions),
 	)
 	if err != nil {
 		return fmt.Errorf("creating atx handler: %w", err)

--- a/node/node.go
+++ b/node/node.go
@@ -749,7 +749,7 @@ func (app *App) initServices(ctx context.Context) error {
 
 	fetcherWrapped := &layerFetcher{}
 
-	atxHandler, err := activation.NewHandler(
+	atxHandler := activation.NewHandler(
 		app.host.ID(),
 		app.cachedDB,
 		app.atxsdata,
@@ -765,9 +765,6 @@ func (app *App) initServices(ctx context.Context) error {
 		activation.WithTickSize(app.Config.TickSize),
 		activation.WithAtxVersions(app.Config.AtxVersions),
 	)
-	if err != nil {
-		return fmt.Errorf("creating atx handler: %w", err)
-	}
 	for _, sig := range app.signers {
 		atxHandler.Register(sig)
 	}


### PR DESCRIPTION
## Motivation

ATX Handler needs to know which ATX version can be published in a given epoch.

## Description

I added a new config field `atx-versions` that maps publish epoch when support for given ATX version starts. The default is to start with version 1 from epoch 0, but it is allowed to start with a different version. An example config:
```json
{
  "main": {
    "atx-versions": {
      "10": 2,
      "11": 3
    }
  }
}
```

An invalid config like below (decreasing versions) is rejected:
```json
{
  "main": {
    "atx-versions": {
      "10": 2,
      "11": 1
    }
  }
}
```

For now, the ATX handler doesn't accept ATX V2 as it cannot process them yet.

## Test Plan

Added unit-test

## TODO

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [ ] Update documentation as needed
- [ ] Update [changelog](../CHANGELOG.md) as needed
