### PR TITLE
[Merged by Bors] - Use .netrc in docker release workflow

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -26,6 +26,14 @@ jobs:
       uses: actions/checkout@v4
       with:
         ssh-key: ${{ secrets.GH_ACTION_PRIVATE_KEY }}
+
+    - uses: extractions/netrc@v2
+      with:
+        machine: github.com
+        username: ${{ secrets.GH_ACTION_TOKEN_USER }}
+        password: ${{ secrets.GH_ACTION_TOKEN }}
+      if: vars.GOPRIVATE
+    
     - name: Build docker images
       run: |
         export VERSION="${{ github.ref_name }}"


### PR DESCRIPTION
## Motivation

Follow up to https://github.com/spacemeshos/go-spacemesh/pull/5821. Add `.netrc` creation to workflow for creating docker release images

## Description

In the previous PR (https://github.com/spacemeshos/go-spacemesh/pull/5821) `.netrc` files were added to allow authentication against other repositories during build and test steps for `go get`. This adds a `.netrc` to the docker image release workflow as well.

## Test Plan

n/a

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
