### PR TITLE
[Merged by Bors] - Return ATX version along with blob

### DIFF
--- a/activation/activation.go
+++ b/activation/activation.go
@@ -777,7 +777,7 @@ func (b *Builder) Regossip(ctx context.Context, nodeID types.NodeID) error {
 		return err
 	}
 	var blob sql.Blob
-	if err := atxs.LoadBlob(ctx, b.db, atx.Bytes(), &blob); err != nil {
+	if _, err := atxs.LoadBlob(ctx, b.db, atx.Bytes(), &blob); err != nil {
 		return fmt.Errorf("get blob %s: %w", atx.ShortString(), err)
 	}
 	if len(blob.Bytes) == 0 {

--- a/activation/activation_multi_test.go
+++ b/activation/activation_multi_test.go
@@ -199,7 +199,9 @@ func TestRegossip(t *testing.T) {
 		}
 
 		var blob sql.Blob
-		require.NoError(t, atxs.LoadBlob(context.Background(), tab.db, refAtx.ID().Bytes(), &blob))
+		ver, err := atxs.LoadBlob(context.Background(), tab.db, refAtx.ID().Bytes(), &blob)
+		require.NoError(t, err)
+		require.Equal(t, types.AtxV1, ver)
 
 		// atx will be regossiped once (by the smesher)
 		tab.mclock.EXPECT().CurrentLayer().Return(layer)

--- a/activation/handler_v1.go
+++ b/activation/handler_v1.go
@@ -137,7 +137,8 @@ func (h *HandlerV1) commitment(ctx context.Context, atx *wire.ActivationTxV1) (t
 // to use the effective num units.
 func (h *HandlerV1) previous(ctx context.Context, atx *wire.ActivationTxV1) (*types.ActivationTx, error) {
 	var blob sql.Blob
-	if err := atxs.LoadBlob(ctx, h.cdb, atx.PrevATXID[:], &blob); err != nil {
+	v, err := atxs.LoadBlob(ctx, h.cdb, atx.PrevATXID[:], &blob)
+	if err != nil {
 		return nil, err
 	}
 
@@ -149,6 +150,9 @@ func (h *HandlerV1) previous(ctx context.Context, atx *wire.ActivationTxV1) (*ty
 			return nil, fmt.Errorf("fetching golden previous atx: %w", err)
 		}
 		return atx, nil
+	}
+	if v != types.AtxV1 {
+		return nil, fmt.Errorf("previous atx %s is not of version 1", atx.PrevATXID)
 	}
 
 	var prev wire.ActivationTxV1

--- a/checkpoint/recovery.go
+++ b/checkpoint/recovery.go
@@ -488,7 +488,7 @@ func collect(
 		return err
 	}
 	var blob sql.Blob
-	err = atxs.LoadBlob(context.Background(), db, ref.Bytes(), &blob)
+	_, err = atxs.LoadBlob(context.Background(), db, ref.Bytes(), &blob)
 	if err != nil {
 		return fmt.Errorf("load atx blob %v: %w", ref, err)
 	}

--- a/checkpoint/util.go
+++ b/checkpoint/util.go
@@ -168,29 +168,38 @@ func backupOldDb(fs afero.Fs, srcDir, dbFile string) (string, error) {
 
 func positioningATX(ctx context.Context, db sql.Executor, id types.ATXID) (types.ATXID, error) {
 	var blob sql.Blob
-	if err := atxs.LoadBlob(ctx, db, id.Bytes(), &blob); err != nil {
+	version, err := atxs.LoadBlob(ctx, db, id.Bytes(), &blob)
+	if err != nil {
 		return types.EmptyATXID, fmt.Errorf("get blob %s: %w", id, err)
 	}
-	// TODO: decide how to decode based on the `version` column
-	var atx wire.ActivationTxV1
-	if err := codec.Decode(blob.Bytes, &atx); err != nil {
-		return types.EmptyATXID, fmt.Errorf("decode %s: %w", id, err)
+	// TODO: implement for ATX V2
+	switch version {
+	case types.AtxV1:
+		var atx wire.ActivationTxV1
+		if err := codec.Decode(blob.Bytes, &atx); err != nil {
+			return types.EmptyATXID, fmt.Errorf("decode %s: %w", id, err)
+		}
+		return atx.PositioningATXID, nil
 	}
-
-	return atx.PositioningATXID, nil
+	return types.EmptyATXID, fmt.Errorf("unsupported ATX version: %v", version)
 }
 
 func poetProofRef(ctx context.Context, db sql.Executor, id types.ATXID) (types.PoetProofRef, error) {
 	var blob sql.Blob
-	if err := atxs.LoadBlob(ctx, db, id.Bytes(), &blob); err != nil {
+	version, err := atxs.LoadBlob(ctx, db, id.Bytes(), &blob)
+	if err != nil {
 		return types.PoetProofRef{}, fmt.Errorf("getting blob for %s: %w", id, err)
 	}
 
-	// TODO: decide about version based the `version` column in `atx_blobs`
-	var atx wire.ActivationTxV1
-	if err := codec.Decode(blob.Bytes, &atx); err != nil {
-		return types.PoetProofRef{}, fmt.Errorf("decoding ATX blob: %w", err)
-	}
+	// TODO: implement for ATX V2
+	switch version {
+	case types.AtxV1:
+		var atx wire.ActivationTxV1
+		if err := codec.Decode(blob.Bytes, &atx); err != nil {
+			return types.PoetProofRef{}, fmt.Errorf("decoding ATX blob: %w", err)
+		}
 
-	return types.PoetProofRef(atx.NIPost.PostMetadata.Challenge), nil
+		return types.PoetProofRef(atx.NIPost.PostMetadata.Challenge), nil
+	}
+	return types.PoetProofRef{}, fmt.Errorf("unsupported ATX version: %v", version)
 }

--- a/datastore/store.go
+++ b/datastore/store.go
@@ -273,7 +273,10 @@ type (
 )
 
 var loadBlobDispatch = map[Hint]loadBlobFunc{
-	ATXDB:       atxs.LoadBlob,
+	ATXDB: func(ctx context.Context, db sql.Executor, key []byte, blob *sql.Blob) error {
+		_, err := atxs.LoadBlob(ctx, db, key, blob)
+		return err
+	},
 	BallotDB:    ballots.LoadBlob,
 	BlockDB:     blocks.LoadBlob,
 	TXDB:        transactions.LoadBlob,

--- a/sql/atxs/atxs.go
+++ b/sql/atxs/atxs.go
@@ -361,10 +361,7 @@ func getBlob(ctx context.Context, db sql.Executor, id []byte, blob *sql.Blob) (t
 		func(stmt *sql.Statement) {
 			stmt.BindBytes(1, id)
 		}, func(stmt *sql.Statement) bool {
-			n := stmt.ColumnLen(0)
-			blob.Bytes = slices.Grow(blob.Bytes[0:], n)[:n]
-			stmt.ColumnReader(0).Read(blob.Bytes)
-
+			blob.FromColumn(stmt, 0)
 			version = types.AtxVersion(stmt.ColumnInt(1))
 			return true
 		},

--- a/sql/atxs/atxs.go
+++ b/sql/atxs/atxs.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	sqlite "github.com/go-llsqlite/crawshaw"
@@ -324,37 +325,58 @@ func GetBlobSizes(db sql.Executor, ids [][]byte) (sizes []int, err error) {
 }
 
 // LoadBlob loads ATX as an encoded blob, ready to be sent over the wire.
-func LoadBlob(ctx context.Context, db sql.Executor, id []byte, blob *sql.Blob) error {
+func LoadBlob(ctx context.Context, db sql.Executor, id []byte, blob *sql.Blob) (types.AtxVersion, error) {
 	if sql.IsCached(db) {
-		b, err := getBlob(ctx, db, id)
-		if err != nil {
-			return err
+		type cachedBlob struct {
+			version types.AtxVersion
+			buf     []byte
 		}
-		blob.Bytes = b
-		return nil
+		cacheKey := sql.QueryCacheKey(CacheKindATXBlob, string(id))
+		cached, err := sql.WithCachedValue(ctx, db, cacheKey, func(context.Context) (*cachedBlob, error) {
+			// We don't use the provided blob in this case to avoid
+			// storing references to the underlying slice (subsequent calls would modify it).
+			var blob sql.Blob
+			v, err := getBlob(ctx, db, id, &blob)
+			if err != nil {
+				return nil, err
+			}
+			return &cachedBlob{version: v, buf: blob.Bytes}, nil
+		})
+		if err != nil {
+			return 0, err
+		}
+
+		n := len(cached.buf)
+		blob.Bytes = slices.Grow(blob.Bytes[:0], n)[:n]
+		copy(blob.Bytes, cached.buf)
+		return cached.version, nil
 	}
-	return sql.LoadBlob(db, "select atx from atx_blobs where id = ?1", id, blob)
+
+	return getBlob(ctx, db, id, blob)
 }
 
-func getBlob(ctx context.Context, db sql.Executor, id []byte) (buf []byte, err error) {
-	cacheKey := sql.QueryCacheKey(CacheKindATXBlob, string(id))
-	return sql.WithCachedValue(ctx, db, cacheKey, func(context.Context) ([]byte, error) {
-		if rows, err := db.Exec("select atx from atx_blobs where id = ?1",
-			func(stmt *sql.Statement) {
-				stmt.BindBytes(1, id)
-			}, func(stmt *sql.Statement) bool {
-				if stmt.ColumnLen(0) > 0 {
-					buf = make([]byte, stmt.ColumnLen(0))
-					stmt.ColumnBytes(0, buf)
-				}
-				return true
-			}); err != nil {
-			return nil, fmt.Errorf("get %s: %w", types.BytesToHash(id), err)
-		} else if rows == 0 {
-			return nil, fmt.Errorf("%w: atx %s", sql.ErrNotFound, types.BytesToHash(id))
-		}
-		return buf, nil
-	})
+func getBlob(ctx context.Context, db sql.Executor, id []byte, blob *sql.Blob) (types.AtxVersion, error) {
+	var version types.AtxVersion
+	rows, err := db.Exec("select atx, version from atx_blobs where id = ?1",
+		func(stmt *sql.Statement) {
+			stmt.BindBytes(1, id)
+		}, func(stmt *sql.Statement) bool {
+			n := stmt.ColumnLen(0)
+			blob.Bytes = slices.Grow(blob.Bytes[0:], n)[:n]
+			stmt.ColumnReader(0).Read(blob.Bytes)
+
+			version = types.AtxVersion(stmt.ColumnInt(1))
+			return true
+		},
+	)
+	if err != nil {
+		return 0, fmt.Errorf("get %v: %w", types.BytesToHash(id), err)
+	}
+	if rows == 0 {
+		return 0, fmt.Errorf("%w: atx %s", sql.ErrNotFound, types.BytesToHash(id))
+	}
+
+	return version, nil
 }
 
 // NonceByID retrieves VRFNonce corresponding to the specified ATX ID.

--- a/sql/database.go
+++ b/sql/database.go
@@ -505,9 +505,12 @@ type Blob struct {
 	Bytes []byte
 }
 
+// resize the underlying byte slice to the specified size.
+// The returned slice has length equal n, but it might have a larger capacity.
+// Warning: it is not guaranteed to keep the old data.
 func (b *Blob) resize(n int) {
 	if cap(b.Bytes) < n {
-		b.Bytes = slices.Grow(b.Bytes, n)
+		b.Bytes = make([]byte, n)
 	}
 	b.Bytes = b.Bytes[:n]
 }

--- a/sql/database.go
+++ b/sql/database.go
@@ -512,7 +512,7 @@ func (b *Blob) resize(n int) {
 	b.Bytes = b.Bytes[:n]
 }
 
-func (b *Blob) fromColumn(stmt *Statement, col int) {
+func (b *Blob) FromColumn(stmt *Statement, col int) {
 	if l := stmt.ColumnLen(col); l != 0 {
 		b.resize(l)
 		stmt.ColumnBytes(col, b.Bytes)
@@ -565,7 +565,7 @@ func LoadBlob(db Executor, cmd string, id []byte, blob *Blob) error {
 		func(stmt *Statement) {
 			stmt.BindBytes(1, id)
 		}, func(stmt *Statement) bool {
-			blob.fromColumn(stmt, 0)
+			blob.FromColumn(stmt, 0)
 			return true
 		}); err != nil {
 		return fmt.Errorf("get %v: %w", types.BytesToHash(id), err)


### PR DESCRIPTION
## Motivation

Need to get the ATX version from the `atx_blobs` table to decode ATX w/o knowing epoch->version mapping everywhere in the code.

## Description

- `atxs.LoadBlob()` also returns types.AtxVersion
- refactored atxs.LoadBlob() to avoid duplicating the query code

## Test Plan

- added a UT to make sure one cannot mess the cached ATX blobs

## TODO

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [ ] Update documentation as needed
- [ ] Update [changelog](../CHANGELOG.md) as needed
