### PR TITLE
Fix store malfeasant ATX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 See [RELEASE](./RELEASE.md) for workflow instructions.
 
+## Release v1.5.3
+
+### Improvements
+
+* [#5929](https://github.com/spacemeshos/go-spacemesh/pull/5929) Fix "no nonce" error when persisting malicious
+  (initial) ATXs.
+
 ## Release v1.5.2-hotfix1
 
 This release includes our first CVE fix. A vulnerability was found in the way a node handles incoming ATXs. We urge all

--- a/activation/handler.go
+++ b/activation/handler.go
@@ -489,7 +489,7 @@ func (h *Handler) checkWrongPrevAtx(
 		// that the node referenced the wrong previous ATX
 		id, err := atxs.GetFirstIDByNodeID(tx, atx.SmesherID)
 		if err != nil {
-			return nil, fmt.Errorf("get initial atx: %w", err)
+			return nil, fmt.Errorf("get initial atx id: %w", err)
 		}
 
 		atx2, err = atxs.Get(tx, id)
@@ -593,15 +593,7 @@ func (h *Handler) storeAtx(ctx context.Context, atx *types.VerifiedActivationTx)
 		return nil, fmt.Errorf("store atx: %w", err)
 	}
 	if nonce == nil {
-		if proof == nil {
-			return nil, errors.New("no nonce")
-		}
-		// special handling for a fake initial ATX (not first, but referencing empty as previous) not containing a nonce
-		vrf, err := atxs.VRFNonce(h.cdb, atx.SmesherID, atx.PublishEpoch)
-		if err != nil {
-			return nil, fmt.Errorf("get vrf nonce: %w", err)
-		}
-		nonce = &vrf
+		return nil, errors.New("no nonce")
 	}
 	atxs.AtxAdded(h.cdb, atx)
 	if proof != nil {

--- a/activation/handler_test.go
+++ b/activation/handler_test.go
@@ -1291,6 +1291,7 @@ func TestHandler_ProcessAtx_SamePrevATX_NewInitial(t *testing.T) {
 		coinbase,
 		100,
 		&types.NIPost{PostMetadata: &types.PostMetadata{}},
+		withVrfNonce(7),
 	)
 	atxHdlr.mbeacon.EXPECT().OnAtx(gomock.Any())
 	atxHdlr.mtortoise.EXPECT().OnAtx(gomock.Any(), gomock.Any(), gomock.Any())

--- a/malfeasance/wire/malfeasance.go
+++ b/malfeasance/wire/malfeasance.go
@@ -80,7 +80,7 @@ func (mp *MalfeasanceProof) MarshalLogObject(encoder log.ObjectEncoder) error {
 		encoder.AddString("type", "invalid prev atx")
 		p, ok := mp.Proof.Data.(*InvalidPrevATXProof)
 		if ok {
-			encoder.AddString("atx1_id", p.Atx2.ID().String())
+			encoder.AddString("atx1_id", p.Atx1.ID().String())
 			encoder.AddString("atx2_id", p.Atx2.ID().String())
 			encoder.AddString("smesher", p.Atx1.SmesherID.String())
 			encoder.AddString("prev_atx", p.Atx1.PrevATXID.String())

--- a/sql/atxs/atxs.go
+++ b/sql/atxs/atxs.go
@@ -387,11 +387,7 @@ func AddGettingNonce(db sql.Executor, atx *types.VerifiedActivationTx) (*types.V
 		}
 	}
 
-	if err := add(db, atx, atx.VRFNonce); err != nil {
-		return nil, err
-	}
-
-	return atx.VRFNonce, nil
+	return atx.VRFNonce, add(db, atx, atx.VRFNonce)
 }
 
 // AddMaybeNoNonce adds an ATX for a given ATX ID. It doesn't try

--- a/sql/atxs/atxs.go
+++ b/sql/atxs/atxs.go
@@ -372,7 +372,7 @@ func Add(db sql.Executor, atx *types.VerifiedActivationTx) error {
 
 // AddGettingNonce adds an ATX for a given ATX ID and returns the nonce for the newly added ATX.
 func AddGettingNonce(db sql.Executor, atx *types.VerifiedActivationTx) (*types.VRFPostIndex, error) {
-	if atx.ActivationTx.VRFNonce == nil && atx.PrevATXID != types.EmptyATXID {
+	if atx.VRFNonce == nil && atx.PrevATXID != types.EmptyATXID {
 		nonce, err := NonceByID(db, atx.PrevATXID)
 		if err != nil && !errors.Is(err, sql.ErrNotFound) {
 			return nil, fmt.Errorf("error getting nonce: %w", err)


### PR DESCRIPTION
## Motivation

In specific cases storing an ATX will fail if it is malicious.

## Description

`atx.AddGettingNonce` might return `nil, nil` for an invalid initial ATX. Specifically an ATX that isn't the first of an identity but references `0x000...` as its previous ATX. Such an ATX might not contain a VRF nonce so it will fail to store with the error `no nonce` when persisting the malfeasance proof.

Additionally I made the check for a double `0x000...` previous ATX more efficient by just fetching the initial ATX of the identity rather than going through the complete chain to find the collision.

## Test Plan

Added a new test for the fix

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
