### PR TITLE
[Merged by Bors] - Fix caching malfeasance info in atxsdata store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ through v1.5.x first ([#5907](https://github.com/spacemeshos/go-spacemesh/pull/5
 * [#5923](https://github.com/spacemeshos/go-spacemesh/pull/5923) Fix high memory consumption and performance issues
   in the proposal handler
 
+* [#5932](https://github.com/spacemeshos/go-spacemesh/pull/5932) Fix caching malfeasance when processing new proofs
+
 ## (v1.5.0)
 
 ### Upgrade information

--- a/datastore/store.go
+++ b/datastore/store.go
@@ -44,7 +44,8 @@ type CachedDB struct {
 	sql.QueryCache
 	logger log.Log
 
-	// cache is optional
+	// cache is optional in tests. It MUST be set for the 'App'
+	// for properly checking malfeasance.
 	atxsdata *atxsdata.Data
 
 	atxCache      *lru.Cache[types.ATXID, *types.ActivationTx]
@@ -71,7 +72,8 @@ func DefaultConfig() Config {
 }
 
 type cacheOpts struct {
-	cfg Config
+	cfg      Config
+	atxsdata *atxsdata.Data
 }
 
 type Opt func(*cacheOpts)
@@ -79,6 +81,12 @@ type Opt func(*cacheOpts)
 func WithConfig(cfg Config) Opt {
 	return func(o *cacheOpts) {
 		o.cfg = cfg
+	}
+}
+
+func WithConsensusCache(c *atxsdata.Data) Opt {
+	return func(o *cacheOpts) {
+		o.atxsdata = c
 	}
 }
 
@@ -109,6 +117,7 @@ func NewCachedDB(db Executor, lg log.Log, opts ...Opt) *CachedDB {
 		Executor:         db,
 		QueryCache:       db.QueryCache(),
 		logger:           lg,
+		atxsdata:         o.atxsdata,
 		atxCache:         atxHdrCache,
 		malfeasanceCache: malfeasanceCache,
 		vrfNonceCache:    vrfNonceCache,

--- a/datastore/store_test.go
+++ b/datastore/store_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/spacemeshos/go-spacemesh/activation/wire"
+	"github.com/spacemeshos/go-spacemesh/atxsdata"
 	"github.com/spacemeshos/go-spacemesh/codec"
 	"github.com/spacemeshos/go-spacemesh/common/fixture"
 	"github.com/spacemeshos/go-spacemesh/common/types"
@@ -405,4 +406,17 @@ func TestBlobStore_GetActiveSet(t *testing.T) {
 	got, err := getBytes(ctx, bs, datastore.ActiveSet, hash)
 	require.NoError(t, err)
 	require.Equal(t, codec.MustEncode(as), got)
+}
+
+func Test_MarkingMalicious(t *testing.T) {
+	db := sql.InMemory()
+	store := atxsdata.New()
+	id := types.RandomNodeID()
+	cdb := datastore.NewCachedDB(db, logtest.New(t), datastore.WithConsensusCache(store))
+
+	cdb.CacheMalfeasanceProof(id, &mwire.MalfeasanceProof{})
+	m, err := cdb.IsMalicious(id)
+	require.NoError(t, err)
+	require.True(t, m)
+	require.True(t, store.IsMalicious(id))
 }

--- a/node/node.go
+++ b/node/node.go
@@ -1895,6 +1895,7 @@ func (app *App) setupDBs(ctx context.Context, lg log.Log) error {
 	app.log.With().Info("cache warmup", log.Duration("duration", time.Since(start)))
 	app.cachedDB = datastore.NewCachedDB(sqlDB, app.addLogger(CachedDBLogger, lg),
 		datastore.WithConfig(app.Config.Cache),
+		datastore.WithConsensusCache(data),
 	)
 
 	migrations, err = sql.LocalMigrations()


### PR DESCRIPTION
## Motivation

Hare depends on `atxsdata` to check whether a smesher is considered malicious.

## Description

Reverts part of https://github.com/spacemeshos/go-spacemesh/pull/5806/files#diff-d76a0e23ae1b705f6e5c33771a285f819b03a3bac7661fdbf3e34b3b9bdbda76 change

## Test Plan

Added unit tests and documentation specifying the purpose of atxsdata in `CachedDB`.

## TODO

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [ ] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
