### PR TITLE
[Merged by Bors] - Remove duplicated NodeID from ATXV2

### DIFF
--- a/activation/wire/wire_v2.go
+++ b/activation/wire/wire_v2.go
@@ -47,9 +47,6 @@ func (atx *ActivationTxV2) SmesherID() types.NodeID {
 type InitialAtxPartsV2 struct {
 	CommitmentATX types.ATXID
 	Post          PostV1
-	// needed make hash of the first InnerActivationTxV2 unique
-	// if the InitialPost happens to be the same for different IDs.
-	NodeID types.NodeID
 }
 
 // MarriageCertificate proves the will of ID to be married with the ID that includes this certificate.

--- a/activation/wire/wire_v2_scale.go
+++ b/activation/wire/wire_v2_scale.go
@@ -179,13 +179,6 @@ func (t *InitialAtxPartsV2) EncodeScale(enc *scale.Encoder) (total int, err erro
 		}
 		total += n
 	}
-	{
-		n, err := scale.EncodeByteArray(enc, t.NodeID[:])
-		if err != nil {
-			return total, err
-		}
-		total += n
-	}
 	return total, nil
 }
 
@@ -199,13 +192,6 @@ func (t *InitialAtxPartsV2) DecodeScale(dec *scale.Decoder) (total int, err erro
 	}
 	{
 		n, err := t.Post.DecodeScale(dec)
-		if err != nil {
-			return total, err
-		}
-		total += n
-	}
-	{
-		n, err := scale.DecodeByteArray(dec, t.NodeID[:])
 		if err != nil {
 			return total, err
 		}


### PR DESCRIPTION
## Motivation

ATX v2 will have a completely different ID calculation method and it doesn't need the extra NodeID for an initial ATX.

## Description

Removed `NodeID` from `InitialAtxPartsV2`.
## Test Plan

n/a

## TODO

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [ ] Update documentation as needed
- [ ] Update [changelog](../CHANGELOG.md) as needed
