### PR TITLE
[Merged by Bors] - Fix database error handling in malfeasance syncer

### DIFF
--- a/syncer/malsync/syncer.go
+++ b/syncer/malsync/syncer.go
@@ -361,13 +361,13 @@ func (s *Syncer) downloadMalfeasanceProofs(ctx context.Context, initial bool, up
 			sst.done()
 			if initial && sst.numSyncedPeers() >= s.cfg.MinSyncPeers {
 				if err := s.updateState(); err != nil {
-					return nil
+					return err
 				}
 				s.logger.Info("initial sync of malfeasance proofs completed", log.ZContext(ctx))
 				return nil
 			} else if !initial && gotUpdate {
 				if err := s.updateState(); err != nil {
-					return nil
+					return err
 				}
 			}
 			select {


### PR DESCRIPTION
## Motivation

Database errors were being swallowed in the malfeasance syncer

## Description

Fix error handling
