### PR TITLE
[Merged by Bors] - Fix timing out querying proof in 1:N in presence of a broken Poet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@ through v1.5.x first ([#5907](https://github.com/spacemeshos/go-spacemesh/pull/5
 
 * [#5932](https://github.com/spacemeshos/go-spacemesh/pull/5932) Fix caching malfeasance when processing new proofs
 
+* [#5943](https://github.com/spacemeshos/go-spacemesh/pull/5943) Fix timing out querying proof in 1:N in a presence of a broken Poet.
+
+  Previously, every identitiy waited for the full timeout time (~20 minutes) before giving up.
+
 ## (v1.5.0)
 
 ### Upgrade information

--- a/activation/poet.go
+++ b/activation/poet.go
@@ -351,6 +351,9 @@ func (c *PoetClient) Submit(
 }
 
 func (c *PoetClient) Proof(ctx context.Context, roundID string) (*types.PoetProof, []types.Hash32, error) {
+	getProofsCtx, cancel := withConditionalTimeout(ctx, c.requestTimeout)
+	defer cancel()
+
 	c.gettingProof.Lock()
 	defer c.gettingProof.Unlock()
 
@@ -361,8 +364,6 @@ func (c *PoetClient) Proof(ctx context.Context, roundID string) (*types.PoetProo
 		}
 	}
 
-	getProofsCtx, cancel := withConditionalTimeout(ctx, c.requestTimeout)
-	defer cancel()
 	proof, members, err := c.client.Proof(getProofsCtx, roundID)
 	if err != nil {
 		return nil, nil, fmt.Errorf("getting proof: %w", err)

--- a/activation/poet_client_test.go
+++ b/activation/poet_client_test.go
@@ -220,5 +220,5 @@ func TestPoetClient_QueryProofTimeout(t *testing.T) {
 		})
 	}
 	eg.Wait()
-	require.WithinDuration(t, start.Add(cfg.RequestTimeout), time.Now(), time.Millisecond*100)
+	require.WithinDuration(t, start.Add(cfg.RequestTimeout), time.Now(), time.Millisecond*300)
 }

--- a/activation/poet_client_test.go
+++ b/activation/poet_client_test.go
@@ -188,3 +188,37 @@ func TestPoetClient_CachesProof(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, uint64(2), proofsCalled.Load())
 }
+
+func TestPoetClient_QueryProofTimeout(t *testing.T) {
+	t.Parallel()
+
+	block := make(chan struct{})
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-block
+	}))
+	defer ts.Close()
+	defer close(block)
+
+	server := types.PoetServer{
+		Address: ts.URL,
+		Pubkey:  types.NewBase64Enc([]byte("pubkey")),
+	}
+	cfg := PoetConfig{
+		RequestTimeout: time.Millisecond * 100,
+	}
+	poet, err := newPoetClient(nil, server, cfg, zaptest.NewLogger(t))
+	require.NoError(t, err)
+	poet.client.client.HTTPClient = ts.Client()
+
+	start := time.Now()
+	eg := errgroup.Group{}
+	for range 50 {
+		eg.Go(func() error {
+			_, _, err := poet.Proof(context.Background(), "1")
+			require.ErrorIs(t, err, context.DeadlineExceeded)
+			return nil
+		})
+	}
+	eg.Wait()
+	require.WithinDuration(t, start.Add(cfg.RequestTimeout), time.Now(), time.Millisecond*100)
+}


### PR DESCRIPTION
## Motivation

## Description

Moved the context with deadline creation before locking the mutex. This way, all callers have the same timeout, instead of:
- first: timeout
- second: 2x timeout
- third: 3x timeout

:bulb: It's arguable whether the deadline should be defined in the `Proof()` method, or by the _caller_ of it. Placing it in the `Proof()` method is easier to test, hence I kept it there.

## Test Plan

Added a test that verifies N concurrent calls to `poetClient.Proof()` all end within `config.RequestTimeout +- <100ms error margin>`.

## TODO

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [ ] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
