### PR TITLE
[Merged by Bors] - Handle decodeBlock error in blocks.Layer method

### DIFF
--- a/sql/blocks/blocks_test.go
+++ b/sql/blocks/blocks_test.go
@@ -325,6 +325,6 @@ func TestLayerForMangledBlock(t *testing.T) {
 		require.NoError(t, err)
 	}
 	rst, err := Layer(db, types.LayerID(1010101))
-	require.Len(t, rst, 0)
+	require.Empty(t, rst, 0)
 	require.Error(t, err)
 }

--- a/sql/blocks/blocks_test.go
+++ b/sql/blocks/blocks_test.go
@@ -313,3 +313,18 @@ func TestLoadBlob(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []int{len(blob1.Bytes), len(blob2.Bytes), -1}, sizes)
 }
+
+func TestLayerForMangledBlock(t *testing.T) {
+	db := sql.InMemory()
+	if _, err := db.Exec("insert into blocks (id, layer, block) values (?1, ?2, ?3);",
+		func(stmt *sql.Statement) {
+			stmt.BindBytes(1, []byte(`mangled-block-id`))
+			stmt.BindInt64(2, 1010101)
+			stmt.BindBytes(3, []byte(`mangled-block`)) // this is actually should encode block
+		}, nil); err != nil {
+		require.NoError(t, err)
+	}
+	rst, err := Layer(db, types.LayerID(1010101))
+	require.Len(t, rst, 0)
+	require.Error(t, err)
+}


### PR DESCRIPTION
## Motivation

When an error occurs while decoding a block, it is not handled properly and nil is added to the slice.

## Description

Modified method to check if err occurred to avoid adding nil to the slice.

## Test Plan

Added unit test which tests Layer method for mangled block.
