### PR TITLE
[backport 5953] Set db-prune-interval for testnet preset

### DIFF
--- a/config/presets/testnet.go
+++ b/config/presets/testnet.go
@@ -64,6 +64,7 @@ func testnet() config.Config {
 			MetricsPort:                  1010,
 			DatabaseConnections:          16,
 			DatabaseSizeMeteringInterval: 10 * time.Minute,
+			DatabasePruneInterval:        30 * time.Minute,
 			NetworkHRP:                   "stest",
 
 			LayerDuration:  5 * time.Minute,


### PR DESCRIPTION
Backport of https://github.com/spacemeshos/go-spacemesh/pull/5953