### PR TITLE
[Merged by Bors] - Remote Smeshing setup incorrectly detected as supervised

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,13 @@ Upgrading to this version requires going through v1.5.x first. Removed migration
 
 * [#5888](https://github.com/spacemeshos/go-spacemesh/pull/5888) Handle DHT discovery startup errors properly
 
+* [#5932](https://github.com/spacemeshos/go-spacemesh/pull/5932) Fix caching malfeasance when processing new proofs
+
+* [#5943](https://github.com/spacemeshos/go-spacemesh/pull/5943) Fix timing out querying proof in 1:N in a presence of
+  a broken Poet.
+
+  Previously, every identity waited for the full timeout time (~20 minutes) before giving up.
+
 * [#5958](https://github.com/spacemeshos/go-spacemesh/pull/5958) Fix node incorrectly detecting a remote smeshing setup
   as supervised.
 
@@ -92,13 +99,6 @@ coins. Fixes an oversight in the genesis VM implementation.
 
 * [#5923](https://github.com/spacemeshos/go-spacemesh/pull/5923) Fix high memory consumption and performance issues
   in the proposal handler
-
-* [#5932](https://github.com/spacemeshos/go-spacemesh/pull/5932) Fix caching malfeasance when processing new proofs
-
-* [#5943](https://github.com/spacemeshos/go-spacemesh/pull/5943) Fix timing out querying proof in 1:N in a presence of
-  a broken Poet.
-
-  Previously, every identity waited for the full timeout time (~20 minutes) before giving up.
 
 ## Release v1.4.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -314,7 +314,7 @@ Make sure to replace `provider` with your provider of choice and `numUnits` with
 initialize. The `commitmentAtxId` is the commitment ATX ID for the identity you want to initialize. For details on the
 usage of `postcli` please refer to [postcli README](https://github.com/spacemeshos/post/blob/develop/cmd/postcli/README.md).
 
-During initialization `postcli` will generate a new private key and store it in the PoST data directory as `local.key`.
+During initialization `postcli` will generate a new private key and store it in the PoST data directory as `identity.key`.
 Copy this file to your `data/identities` directory and rename it to `xxx.key` where `xxx` is a unique identifier for
 the identity. The node will automatically pick up the new identity and manage its lifecycle after a restart.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@ is macOS 14 (Sonoma) or later ([#5879](https://github.com/spacemeshos/go-spaceme
 
 This update removes migration code for go-spacemesh databases created with versions before v1.5.0.
 Upgrading to this version requires going through v1.5.x first. Removed migrations for:
- * legacy keys in the post data directory ([#5907](https://github.com/spacemeshos/go-spacemesh/pull/5907)).
- * ATX blob separation and always populating nonce column in atxs ([#5942](https://github.com/spacemeshos/go-spacemesh/pull/5942))
+
+* legacy keys in the post data directory ([#5907](https://github.com/spacemeshos/go-spacemesh/pull/5907)).
+* ATX blob separation and always populating nonce column in atxs ([#5942](https://github.com/spacemeshos/go-spacemesh/pull/5942))
 
 ### Highlights
 
@@ -32,22 +33,47 @@ Upgrading to this version requires going through v1.5.x first. Removed migration
 
 * [#5888](https://github.com/spacemeshos/go-spacemesh/pull/5888) Handle DHT discovery startup errors properly
 
-* [#5896](https://github.com/spacemeshos/go-spacemesh/pull/5896) Increase supported number of ATXs to 4.5 Mio.
+* [#5958](https://github.com/spacemeshos/go-spacemesh/pull/5958) Fix node incorrectly detecting a remote smeshing setup
+  as supervised.
+
+  Ensure that your key file in `data/identities` is named `local.key` if you run a supervised node or with the change
+  the node will not start.
+
+## Release v1.5.3
+
+### Improvements
+
+* [#5929](https://github.com/spacemeshos/go-spacemesh/pull/5929) Fix "no nonce" error when persisting malicious
+  (initial) ATXs.
+
+* [#5930](https://github.com/spacemeshos/go-spacemesh/pull/5930) Check if identity for a given malfeasance proof
+  exists when validating it.
+
+## Release v1.5.2-hotfix1
+
+This release includes our first CVE fix. A vulnerability was found in the way a node handles incoming ATXs. We urge all
+node operators to update to this version as soon as possible.
+
+### Improvements
+
+* Fixed a vulnerability in the way a node handles incoming ATXs. This vulnerability allows an attacker to claim rewards
+  for a full tick amount although they should not be eligible for them.
+
+## Release v1.5.2
+
+### Improvements
 
 * [#5904](https://github.com/spacemeshos/go-spacemesh/pull/5904) Avoid repeated searching for positioning ATX in 1:N
 
 * [#5911](https://github.com/spacemeshos/go-spacemesh/pull/5911) Avoid pulling poet proof multiple times in 1:N setups
 
-* [#5923](https://github.com/spacemeshos/go-spacemesh/pull/5923) Fix high memory consumption and performance issues
-  in the proposal handler
+## Release v1.5.1
 
-* [#5932](https://github.com/spacemeshos/go-spacemesh/pull/5932) Fix caching malfeasance when processing new proofs
+### Improvements
 
-* [#5943](https://github.com/spacemeshos/go-spacemesh/pull/5943) Fix timing out querying proof in 1:N in a presence of a broken Poet.
+* [#5896](https://github.com/spacemeshos/go-spacemesh/pull/5896) Increase supported number of ATXs to 4.5 Mio.
 
-  Previously, every identitiy waited for the full timeout time (~20 minutes) before giving up.
-
-## (v1.5.0)
+## Release v1.5.0
 
 ### Upgrade information
 
@@ -64,7 +90,15 @@ coins. Fixes an oversight in the genesis VM implementation.
 * [#5791](https://github.com/spacemeshos/go-spacemesh/pull/5791) Speed up ATX queries.
   This also fixes ambiguity of nonces for equivocating identities.
 
-* [#5856](https://github.com/spacemeshos/go-spacemesh/pull/5856) Bump github.com/spacemeshos/api/release/go to v1.37.0.
+* [#5923](https://github.com/spacemeshos/go-spacemesh/pull/5923) Fix high memory consumption and performance issues
+  in the proposal handler
+
+* [#5932](https://github.com/spacemeshos/go-spacemesh/pull/5932) Fix caching malfeasance when processing new proofs
+
+* [#5943](https://github.com/spacemeshos/go-spacemesh/pull/5943) Fix timing out querying proof in 1:N in a presence of
+  a broken Poet.
+
+  Previously, every identity waited for the full timeout time (~20 minutes) before giving up.
 
 ## Release v1.4.6
 
@@ -280,7 +314,7 @@ Make sure to replace `provider` with your provider of choice and `numUnits` with
 initialize. The `commitmentAtxId` is the commitment ATX ID for the identity you want to initialize. For details on the
 usage of `postcli` please refer to [postcli README](https://github.com/spacemeshos/post/blob/develop/cmd/postcli/README.md).
 
-During initialization `postcli` will generate a new private key and store it in the PoST data directory as `identity.key`.
+During initialization `postcli` will generate a new private key and store it in the PoST data directory as `local.key`.
 Copy this file to your `data/identities` directory and rename it to `xxx.key` where `xxx` is a unique identifier for
 the identity. The node will automatically pick up the new identity and manage its lifecycle after a restart.
 

--- a/node/node.go
+++ b/node/node.go
@@ -1658,8 +1658,8 @@ func (app *App) startAPIServices(ctx context.Context) error {
 			if app.Config.SMESHING.CoinbaseAccount == "" {
 				return errors.New("smeshing enabled but no coinbase account provided")
 			}
-			if len(app.signers) > 1 {
-				return errors.New("supervised smeshing cannot be started in a multi-smeshing setup")
+			if len(app.signers) > 1 || app.signers[0].Name() != supervisedIDKeyFileName {
+				return errors.New("supervised smeshing cannot be started in a remote or multi-smeshing setup")
 			}
 			if err := app.postSupervisor.Start(
 				app.Config.POSTService,

--- a/node/node.go
+++ b/node/node.go
@@ -1659,7 +1659,12 @@ func (app *App) startAPIServices(ctx context.Context) error {
 				return errors.New("smeshing enabled but no coinbase account provided")
 			}
 			if len(app.signers) > 1 || app.signers[0].Name() != supervisedIDKeyFileName {
-				return errors.New("supervised smeshing cannot be started in a remote or multi-smeshing setup")
+				app.log.Error("supervised smeshing cannot be started in a remote or multi-smeshing setup")
+				app.log.Error(
+					"if you run a supervised node ensure your key file is named %s and try again",
+					supervisedIDKeyFileName,
+				)
+				return errors.New("smeshing enabled in remote setup")
 			}
 			if err := app.postSupervisor.Start(
 				app.Config.POSTService,

--- a/signing/signer_test.go
+++ b/signing/signer_test.go
@@ -50,7 +50,7 @@ func Test_NewEdSigner_WithPrivateKey(t *testing.T) {
 		_, err = NewEdSigner(WithPrivateKey(key), WithPrivateKey(key))
 		require.ErrorContains(t, err, "invalid option WithPrivateKey: private key already set")
 
-		keyFile := filepath.Join(t.TempDir(), "identity.key")
+		keyFile := filepath.Join(t.TempDir(), "local.key")
 		dst := make([]byte, hex.EncodedLen(len(ed.PrivateKey())))
 		hex.Encode(dst, ed.PrivateKey())
 		err = os.WriteFile(keyFile, dst, 0o600)
@@ -69,17 +69,17 @@ func Test_NewEdSigner_FromFile(t *testing.T) {
 	})
 
 	t.Run("invalid key", func(t *testing.T) {
-		keyFile := filepath.Join(t.TempDir(), "identity.key")
+		keyFile := filepath.Join(t.TempDir(), "local.key")
 		key := bytes.Repeat([]byte{0}, PrivateKeySize*2)
 		err := os.WriteFile(keyFile, key, 0o600)
 		require.NoError(t, err)
 
 		_, err = NewEdSigner(FromFile(keyFile))
-		require.ErrorContains(t, err, "decoding private key in identity.key")
+		require.ErrorContains(t, err, "decoding private key in local.key")
 	})
 
 	t.Run("invalid key size - too short", func(t *testing.T) {
-		keyFile := filepath.Join(t.TempDir(), "identity.key")
+		keyFile := filepath.Join(t.TempDir(), "local.key")
 		key := bytes.Repeat([]byte{0}, 63)
 		dst := make([]byte, hex.EncodedLen(len(key)))
 		hex.Encode(dst, key)
@@ -87,11 +87,11 @@ func Test_NewEdSigner_FromFile(t *testing.T) {
 		require.NoError(t, err)
 
 		_, err = NewEdSigner(FromFile(keyFile))
-		require.ErrorContains(t, err, "invalid key size 63/64 for identity.key")
+		require.ErrorContains(t, err, "invalid key size 63/64 for local.key")
 	})
 
 	t.Run("invalid key size - too long", func(t *testing.T) {
-		keyFile := filepath.Join(t.TempDir(), "identity.key")
+		keyFile := filepath.Join(t.TempDir(), "local.key")
 		key := bytes.Repeat([]byte{0}, 65)
 		dst := make([]byte, hex.EncodedLen(len(key)))
 		hex.Encode(dst, key)
@@ -99,14 +99,14 @@ func Test_NewEdSigner_FromFile(t *testing.T) {
 		require.NoError(t, err)
 
 		_, err = NewEdSigner(FromFile(keyFile))
-		require.ErrorContains(t, err, "invalid key size 65/64 for identity.key")
+		require.ErrorContains(t, err, "invalid key size 65/64 for local.key")
 	})
 
 	t.Run("valid key", func(t *testing.T) {
 		ed, err := NewEdSigner()
 		require.NoError(t, err)
 
-		keyFile := filepath.Join(t.TempDir(), "identity.key")
+		keyFile := filepath.Join(t.TempDir(), "local.key")
 		dst := make([]byte, hex.EncodedLen(len(ed.PrivateKey())))
 		hex.Encode(dst, ed.PrivateKey())
 		err = os.WriteFile(keyFile, dst, 0o600)
@@ -116,14 +116,14 @@ func Test_NewEdSigner_FromFile(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, ed.priv, ed2.priv)
 		require.Equal(t, ed.PublicKey(), ed2.PublicKey())
-		require.Equal(t, "identity.key", ed2.Name())
+		require.Equal(t, "local.key", ed2.Name())
 	})
 
 	t.Run("fails if private key already set", func(t *testing.T) {
 		ed, err := NewEdSigner()
 		require.NoError(t, err)
 
-		keyFile := filepath.Join(t.TempDir(), "identity.key")
+		keyFile := filepath.Join(t.TempDir(), "local.key")
 		dst := make([]byte, hex.EncodedLen(len(ed.PrivateKey())))
 		hex.Encode(dst, ed.PrivateKey())
 		err = os.WriteFile(keyFile, dst, 0o600)
@@ -142,11 +142,11 @@ func TestEdSigner_ToFile(t *testing.T) {
 	})
 
 	t.Run("valid file", func(t *testing.T) {
-		path := filepath.Join(t.TempDir(), "identity.key")
+		path := filepath.Join(t.TempDir(), "local.key")
 
 		ed, err := NewEdSigner(ToFile(path))
 		require.NoError(t, err)
-		require.Equal(t, "identity.key", ed.Name())
+		require.Equal(t, "local.key", ed.Name())
 
 		require.FileExists(t, path)
 		data, err := os.ReadFile(path)
@@ -160,7 +160,7 @@ func TestEdSigner_ToFile(t *testing.T) {
 	})
 
 	t.Run("fails if file already set", func(t *testing.T) {
-		path := filepath.Join(t.TempDir(), "identity.key")
+		path := filepath.Join(t.TempDir(), "local.key")
 
 		_, err := NewEdSigner(ToFile(path), ToFile(path))
 		require.ErrorContains(t, err, "invalid option ToFile: file already set")
@@ -170,19 +170,19 @@ func TestEdSigner_ToFile(t *testing.T) {
 		ed, err := NewEdSigner()
 		require.NoError(t, err)
 
-		_, err = NewEdSigner(WithPrivateKey(ed.PrivateKey()), ToFile(filepath.Join(t.TempDir(), "identity.key")))
+		_, err = NewEdSigner(WithPrivateKey(ed.PrivateKey()), ToFile(filepath.Join(t.TempDir(), "local.key")))
 		require.NoError(t, err)
 	})
 
 	t.Run("fails if file already exists", func(t *testing.T) {
-		path := filepath.Join(t.TempDir(), "identity.key")
+		path := filepath.Join(t.TempDir(), "local.key")
 
 		_, err := NewEdSigner(ToFile(path))
 		require.NoError(t, err)
 
 		_, err = NewEdSigner(ToFile(path))
 		require.ErrorIs(t, err, fs.ErrExist)
-		require.ErrorContains(t, err, "save identity file identity.key")
+		require.ErrorContains(t, err, "save identity file local.key")
 
 		_, err = NewEdSigner(FromFile(path), ToFile(path))
 		require.ErrorContains(t, err, "invalid option ToFile: file already set")


### PR DESCRIPTION
## Motivation

The node allows to start a remote smeshing setup with `smeshing-start` via the config, commandline or grpc API. This adds an additional check to prevent this.

## Description

During startup the node only checked if a single `.key` file was present in `data/identities` to decide if `smeshing-start` can be set. Since this one key file can be part of a remote smeshing setup this check is incomplete.

This extends the check to ensure that only supervised nodes allow `smeshing-start` to be called.

Additionally I removed the last remaining mentions of `identities.key` in tests and the `README.md` since the file has been renamed a while ago in https://github.com/spacemeshos/go-spacemesh/pull/5643

## Test Plan

- existing tests pass

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
