### PR TITLE
[Merged by Bors] - Cleanup sql code querying VRFnonce

### DIFF
--- a/atxsdata/warmup.go
+++ b/atxsdata/warmup.go
@@ -2,7 +2,6 @@ package atxsdata
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
@@ -39,8 +38,7 @@ func Warmup(db sql.Executor, cache *Data, keep types.EpochID) error {
 	}
 	cache.EvictEpoch(evict)
 
-	var ierr error
-	if err := atxs.IterateAtxsData(db, cache.Evicted(), latest,
+	return atxs.IterateAtxsData(db, cache.Evicted(), latest,
 		func(
 			id types.ATXID,
 			node types.NodeID,
@@ -49,13 +47,9 @@ func Warmup(db sql.Executor, cache *Data, keep types.EpochID) error {
 			weight,
 			base,
 			height uint64,
-			nonce *types.VRFPostIndex,
+			nonce types.VRFPostIndex,
 			malicious bool,
 		) bool {
-			if nonce == nil {
-				ierr = errors.New("missing nonce")
-				return false
-			}
 			cache.Add(
 				epoch+1,
 				node,
@@ -64,12 +58,9 @@ func Warmup(db sql.Executor, cache *Data, keep types.EpochID) error {
 				weight,
 				base,
 				height,
-				*nonce,
+				nonce,
 				malicious,
 			)
 			return true
-		}); err != nil {
-		return err
-	}
-	return ierr
+		})
 }

--- a/sql/atxs/atxs.go
+++ b/sql/atxs/atxs.go
@@ -2,7 +2,6 @@ package atxs
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -381,18 +380,14 @@ func NonceByID(db sql.Executor, id types.ATXID) (nonce types.VRFPostIndex, err e
 	enc := func(stmt *sql.Statement) {
 		stmt.BindBytes(1, id.Bytes())
 	}
-	gotNonce := false
 	dec := func(stmt *sql.Statement) bool {
-		if stmt.ColumnType(0) != sqlite.SQLITE_NULL {
-			nonce = types.VRFPostIndex(stmt.ColumnInt64(0))
-			gotNonce = true
-		}
-		return true
+		nonce = types.VRFPostIndex(stmt.ColumnInt64(0))
+		return false
 	}
 
 	if rows, err := db.Exec("select nonce from atxs where id = ?1", enc, dec); err != nil {
 		return types.VRFPostIndex(0), fmt.Errorf("get nonce for ATX id %v: %w", id, err)
-	} else if rows == 0 || !gotNonce {
+	} else if rows == 0 {
 		return types.VRFPostIndex(0), sql.ErrNotFound
 	}
 
@@ -544,12 +539,7 @@ func LatestN(db sql.Executor, n int) ([]CheckpointAtx, error) {
 		stmt.ColumnBytes(5, catx.SmesherID[:])
 		catx.Sequence = uint64(stmt.ColumnInt64(6))
 		stmt.ColumnBytes(7, catx.Coinbase[:])
-		if sql.IsNull(stmt, 8) {
-			ierr = errors.New("missing nonce")
-			return false
-		} else {
-			catx.VRFNonce = types.VRFPostIndex(stmt.ColumnInt64(8))
-		}
+		catx.VRFNonce = types.VRFPostIndex(stmt.ColumnInt64(8))
 		rst = append(rst, catx)
 		return true
 	}
@@ -643,7 +633,7 @@ func IterateAtxsData(
 		weight uint64,
 		base uint64,
 		height uint64,
-		nonce *types.VRFPostIndex,
+		nonce types.VRFPostIndex,
 		isMalicious bool,
 	) bool,
 ) error {
@@ -675,14 +665,10 @@ func IterateAtxsData(
 			effectiveUnits := uint64(stmt.ColumnInt64(4))
 			baseHeight := uint64(stmt.ColumnInt64(5))
 			ticks := uint64(stmt.ColumnInt64(6))
-			var vrfNonce *types.VRFPostIndex
-			if !sql.IsNull(stmt, 7) {
-				nonce := types.VRFPostIndex(stmt.ColumnInt64(7))
-				vrfNonce = &nonce
-			}
+			nonce := types.VRFPostIndex(stmt.ColumnInt64(7))
 			isMalicious := stmt.ColumnInt(8) != 0
 			return fn(id, node, epoch, coinbase, effectiveUnits*ticks,
-				baseHeight, baseHeight+ticks, vrfNonce, isMalicious)
+				baseHeight, baseHeight+ticks, nonce, isMalicious)
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
## Motivation

VRF nonce is saved for every ATX.

## Description

- clean up `atxs` package - removed redundant NULL checks
- keep nonce by value in CachedDB

## Test Plan

existing tests pass

## TODO

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [ ] Update documentation as needed
- [ ] Update [changelog](../CHANGELOG.md) as needed
