### PR TITLE
[Merged by Bors] - Remove ID from SubPostV2

### DIFF
--- a/activation/wire/challenge_v2.go
+++ b/activation/wire/challenge_v2.go
@@ -16,7 +16,6 @@ type NIPostChallengeV2 struct {
 	PublishEpoch     types.EpochID
 	PrevATXID        types.ATXID
 	PositioningATXID types.ATXID
-	CommitmentATXID  *types.ATXID
 	InitialPost      *PostV1
 }
 
@@ -35,9 +34,6 @@ func (c *NIPostChallengeV2) MarshalLogObject(encoder zapcore.ObjectEncoder) erro
 	encoder.AddUint32("PublishEpoch", c.PublishEpoch.Uint32())
 	encoder.AddString("PrevATXID", c.PrevATXID.String())
 	encoder.AddString("PositioningATX", c.PositioningATXID.String())
-	if c.CommitmentATXID != nil {
-		encoder.AddString("CommitmentATX", c.CommitmentATXID.String())
-	}
 	encoder.AddObject("InitialPost", c.InitialPost)
 	return nil
 }

--- a/activation/wire/challenge_v2_scale.go
+++ b/activation/wire/challenge_v2_scale.go
@@ -31,13 +31,6 @@ func (t *NIPostChallengeV2) EncodeScale(enc *scale.Encoder) (total int, err erro
 		total += n
 	}
 	{
-		n, err := scale.EncodeOption(enc, t.CommitmentATXID)
-		if err != nil {
-			return total, err
-		}
-		total += n
-	}
-	{
 		n, err := scale.EncodeOption(enc, t.InitialPost)
 		if err != nil {
 			return total, err
@@ -69,14 +62,6 @@ func (t *NIPostChallengeV2) DecodeScale(dec *scale.Decoder) (total int, err erro
 			return total, err
 		}
 		total += n
-	}
-	{
-		field, n, err := scale.DecodeOption[types.ATXID](dec)
-		if err != nil {
-			return total, err
-		}
-		total += n
-		t.CommitmentATXID = field
 	}
 	{
 		field, n, err := scale.DecodeOption[PostV1](dec)

--- a/activation/wire/wire_v2.go
+++ b/activation/wire/wire_v2.go
@@ -36,12 +36,8 @@ type ActivationTxV2 struct {
 	// Only required when the ATX includes married IDs.
 	MarriageATX *types.ATXID
 
+	SmesherID types.NodeID
 	Signature types.EdSignature
-}
-
-// The first PoST is always for the ATX owner.
-func (atx *ActivationTxV2) SmesherID() types.NodeID {
-	return atx.NiPosts[0].Posts[0].ID
 }
 
 type InitialAtxPartsV2 struct {
@@ -68,10 +64,13 @@ type MerkleProofV2 struct {
 }
 
 type SubPostV2 struct {
-	ID           types.NodeID // The ID that this PoST is for.
-	PrevATXIndex uint32       // Index of the previous ATX in the `InnerActivationTxV2.PreviousATXs` slice
-	Post         PostV1
-	NumUnits     uint32
+	// Index of marriage certificate for this ID in the 'Marriages' slice. Only valid for merged ATXs.
+	// Can be used to extract the nodeID and verify if it is married with the smesher of the ATX.
+	// Must be 0 for non-merged ATXs.
+	MarriageIndex uint32
+	PrevATXIndex  uint32 // Index of the previous ATX in the `InnerActivationTxV2.PreviousATXs` slice
+	Post          PostV1
+	NumUnits      uint32
 }
 
 type NiPostsV2 struct {

--- a/activation/wire/wire_v2_scale.go
+++ b/activation/wire/wire_v2_scale.go
@@ -73,6 +73,13 @@ func (t *ActivationTxV2) EncodeScale(enc *scale.Encoder) (total int, err error) 
 		total += n
 	}
 	{
+		n, err := scale.EncodeByteArray(enc, t.SmesherID[:])
+		if err != nil {
+			return total, err
+		}
+		total += n
+	}
+	{
 		n, err := scale.EncodeByteArray(enc, t.Signature[:])
 		if err != nil {
 			return total, err
@@ -153,6 +160,13 @@ func (t *ActivationTxV2) DecodeScale(dec *scale.Decoder) (total int, err error) 
 		}
 		total += n
 		t.MarriageATX = field
+	}
+	{
+		n, err := scale.DecodeByteArray(dec, t.SmesherID[:])
+		if err != nil {
+			return total, err
+		}
+		total += n
 	}
 	{
 		n, err := scale.DecodeByteArray(dec, t.Signature[:])
@@ -276,7 +290,7 @@ func (t *MerkleProofV2) DecodeScale(dec *scale.Decoder) (total int, err error) {
 
 func (t *SubPostV2) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	{
-		n, err := scale.EncodeByteArray(enc, t.ID[:])
+		n, err := scale.EncodeCompact32(enc, uint32(t.MarriageIndex))
 		if err != nil {
 			return total, err
 		}
@@ -308,11 +322,12 @@ func (t *SubPostV2) EncodeScale(enc *scale.Encoder) (total int, err error) {
 
 func (t *SubPostV2) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	{
-		n, err := scale.DecodeByteArray(dec, t.ID[:])
+		field, n, err := scale.DecodeCompact32(dec)
 		if err != nil {
 			return total, err
 		}
 		total += n
+		t.MarriageIndex = uint32(field)
 	}
 	{
 		field, n, err := scale.DecodeCompact32(dec)


### PR DESCRIPTION
## Description

- removed `ID` from `SubPostV2` structure. The `ID` for each post will be looked up by `MarriageIndex` field. It's the index of this ID in the equivocation set (equal to the index in `Marriages` slice of a marriage ATX).
- removed Commitment ATX from v2 nipost challenge structure.

## Test Plan

n/a

## TODO

- [x] Explain motivation or link existing issue(s)
- [ ] Test changes and document test plan
- [ ] Update documentation as needed
- [ ] Update [changelog](../CHANGELOG.md) as needed
