### PR TITLE
[Merged by Bors] - Pin version of runner images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,13 +130,13 @@ jobs:
           - [self-hosted, linux, arm64]
           - macos-13
           - [self-hosted, macOS, ARM64, go-spacemesh]
-          - windows-2019
+          - windows-2022
     steps:
       - name: Add OpenCL support - Ubuntu
         if: ${{ matrix.os == 'ubuntu-22.04' }}
         run: sudo apt-get update -q && sudo apt-get install -qy ocl-icd-opencl-dev libpocl2
       - name: disable Windows Defender - Windows
-        if: ${{ matrix.os == 'windows-2019' }}
+        if: ${{ matrix.os == 'windows-2022' }}
         run: |
           Set-MpPreference -DisableRealtimeMonitoring $true
       - name: checkout
@@ -176,13 +176,13 @@ jobs:
           - [self-hosted, linux, arm64]
           - macos-13
           - [self-hosted, macOS, ARM64, go-spacemesh]
-          - windows-2019
+          - windows-2022
     steps:
       - name: Add OpenCL support - Ubuntu
         if: ${{ matrix.os == 'ubuntu-22.04' }}
         run: sudo apt-get update -q && sudo apt-get install -qy ocl-icd-opencl-dev libpocl2
       - name: disable Windows Defender - Windows
-        if: ${{ matrix.os == 'windows-2019' }}
+        if: ${{ matrix.os == 'windows-2022' }}
         run: |
           Set-MpPreference -DisableRealtimeMonitoring $true
       - name: checkout
@@ -220,7 +220,7 @@ jobs:
           - [self-hosted, linux, arm64]
           - macos-13
           - [self-hosted, macOS, ARM64, go-spacemesh]
-          - windows-2019
+          - windows-2022
     steps:
       # as we use some request to localhost, sometimes it gives us flaky tests. try to disable tcp offloading for fix it
       # https://github.com/actions/virtual-environments/issues/1187
@@ -236,11 +236,11 @@ jobs:
           sudo sysctl -w net.link.generic.system.hwcksum_tx=0
           sudo sysctl -w net.link.generic.system.hwcksum_rx=0
       - name: disable TCP/UDP offload - Windows
-        if: ${{ matrix.os == 'windows-2019' }}
+        if: ${{ matrix.os == 'windows-2022' }}
         run: |
           Disable-NetAdapterChecksumOffload -Name * -TcpIPv4 -UdpIPv4 -TcpIPv6 -UdpIPv6
       - name: disable Windows Defender - Windows
-        if: ${{ matrix.os == 'windows-2019' }}
+        if: ${{ matrix.os == 'windows-2022' }}
         run: |
           Set-MpPreference -DisableRealtimeMonitoring $true
       - name: checkout
@@ -265,7 +265,7 @@ jobs:
         if: ${{ matrix.os == 'ubuntu-22.04' }}
         run: sudo apt-get update -q && sudo apt-get install -qy ocl-icd-opencl-dev libpocl2
       - name: Add OpenCL support - Windows
-        if: ${{ matrix.os == 'windows-2019' }}
+        if: ${{ matrix.os == 'windows-2022' }}
         run: choco install opencl-intel-cpu-runtime
       - name: setup env
         run: make install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ concurrency:
 jobs:
   ## stage 0: check which files were changed
   filter-changes:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       nondocchanges: ${{ steps.filter.outputs.nondoc }}
     steps:
@@ -55,7 +55,7 @@ jobs:
   ## these run on all pushes to all pull requests, all branches
   ## note that secrets may not be accessible in this phase
   quicktests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: filter-changes
     if: ${{ needs.filter-changes.outputs.nondocchanges == 'true' }}
     # should not take more than 2-3 mins
@@ -87,7 +87,7 @@ jobs:
           make test-generate
 
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: filter-changes
     if: ${{ needs.filter-changes.outputs.nondocchanges == 'true' }}
     # should not take more than 15-16 mins
@@ -126,17 +126,17 @@ jobs:
       fail-fast: true
       matrix:
         os:
-          - ubuntu-latest
+          - ubuntu-22.04
           - [self-hosted, linux, arm64]
           - macos-13
           - [self-hosted, macOS, ARM64, go-spacemesh]
-          - windows-latest
+          - windows-2019
     steps:
       - name: Add OpenCL support - Ubuntu
-        if: ${{ matrix.os == 'ubuntu-latest' }}
+        if: ${{ matrix.os == 'ubuntu-22.04' }}
         run: sudo apt-get update -q && sudo apt-get install -qy ocl-icd-opencl-dev libpocl2
       - name: disable Windows Defender - Windows
-        if: ${{ matrix.os == 'windows-latest' }}
+        if: ${{ matrix.os == 'windows-2019' }}
         run: |
           Set-MpPreference -DisableRealtimeMonitoring $true
       - name: checkout
@@ -172,17 +172,17 @@ jobs:
       fail-fast: true
       matrix:
         os:
-          - ubuntu-latest
+          - ubuntu-22.04
           - [self-hosted, linux, arm64]
           - macos-13
           - [self-hosted, macOS, ARM64, go-spacemesh]
-          - windows-latest
+          - windows-2019
     steps:
       - name: Add OpenCL support - Ubuntu
-        if: ${{ matrix.os == 'ubuntu-latest' }}
+        if: ${{ matrix.os == 'ubuntu-22.04' }}
         run: sudo apt-get update -q && sudo apt-get install -qy ocl-icd-opencl-dev libpocl2
       - name: disable Windows Defender - Windows
-        if: ${{ matrix.os == 'windows-latest' }}
+        if: ${{ matrix.os == 'windows-2019' }}
         run: |
           Set-MpPreference -DisableRealtimeMonitoring $true
       - name: checkout
@@ -216,16 +216,16 @@ jobs:
       fail-fast: true
       matrix:
         os:
-          - ubuntu-latest
+          - ubuntu-22.04
           - [self-hosted, linux, arm64]
           - macos-13
           - [self-hosted, macOS, ARM64, go-spacemesh]
-          - windows-latest
+          - windows-2019
     steps:
       # as we use some request to localhost, sometimes it gives us flaky tests. try to disable tcp offloading for fix it
       # https://github.com/actions/virtual-environments/issues/1187
       - name: disable TCP/UDP offload - Ubuntu
-        if: ${{ matrix.os == 'ubuntu-latest' }}
+        if: ${{ matrix.os == 'ubuntu-22.04' }}
         run: |
           sudo ethtool -K eth0 tx off
           sudo ethtool -K eth0 rx off
@@ -236,11 +236,11 @@ jobs:
           sudo sysctl -w net.link.generic.system.hwcksum_tx=0
           sudo sysctl -w net.link.generic.system.hwcksum_rx=0
       - name: disable TCP/UDP offload - Windows
-        if: ${{ matrix.os == 'windows-latest' }}
+        if: ${{ matrix.os == 'windows-2019' }}
         run: |
           Disable-NetAdapterChecksumOffload -Name * -TcpIPv4 -UdpIPv4 -TcpIPv6 -UdpIPv6
       - name: disable Windows Defender - Windows
-        if: ${{ matrix.os == 'windows-latest' }}
+        if: ${{ matrix.os == 'windows-2019' }}
         run: |
           Set-MpPreference -DisableRealtimeMonitoring $true
       - name: checkout
@@ -262,10 +262,10 @@ jobs:
           go-version: ${{ env.go-version }}
           cache: ${{ runner.arch != 'arm64' }}
       - name: Add OpenCL support - Ubuntu
-        if: ${{ matrix.os == 'ubuntu-latest' }}
+        if: ${{ matrix.os == 'ubuntu-22.04' }}
         run: sudo apt-get update -q && sudo apt-get install -qy ocl-icd-opencl-dev libpocl2
       - name: Add OpenCL support - Windows
-        if: ${{ matrix.os == 'windows-latest' }}
+        if: ${{ matrix.os == 'windows-2019' }}
         run: choco install opencl-intel-cpu-runtime
       - name: setup env
         run: make install
@@ -295,7 +295,7 @@ jobs:
       - build-tools
       - build
       - unittests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       # short-circuit success if no non-doc files were modified
       # this is the easiest way to access success/failure state of previous jobs in this workflow

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   filter-changes:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       nondocchanges: ${{ steps.filter.outputs.nondoc }}
     steps:
@@ -28,7 +28,7 @@ jobs:
               - '!**/*.md'
 
   coverage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: filter-changes
     if: ${{ needs.filter-changes.outputs.nondocchanges == 'true' }}
     steps:

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -20,7 +20,7 @@ on:
         default: ''
 jobs:
   dockerpush:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: checkout
       uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             outname_sufix: "linux-amd64"
           - os: [self-hosted, linux, arm64]
             outname_sufix: "linux-arm64"
@@ -21,22 +21,22 @@ jobs:
             outname_sufix: "mac-amd64"
           - os: [self-hosted, macOS, ARM64, go-spacemesh]
             outname_sufix: "mac-arm64"
-          - os: windows-latest
+          - os: windows-2019
             outname_sufix: "win-amd64"
     steps:
       - shell: bash
         run: echo "OUTNAME=go-spacemesh-${{ github.ref_name }}-${{ matrix.outname_sufix }}" >> $GITHUB_ENV
 
       - name: Install dependencies in windows
-        if: ${{ matrix.os == 'windows-latest' }}
+        if: ${{ matrix.os == 'windows-2019' }}
         run: choco install make wget zip
 
       - name: Add OpenCL support - Ubuntu
-        if: ${{ matrix.os == 'ubuntu-latest' }}
+        if: ${{ matrix.os == 'ubuntu-22.04' }}
         run: sudo apt-get update -q && sudo apt-get install -qy ocl-icd-opencl-dev libpocl2
 
       - name: disable Windows Defender - Windows
-        if: ${{ matrix.os == 'windows-latest' }}
+        if: ${{ matrix.os == 'windows-2019' }}
         run: |
           Set-MpPreference -DisableRealtimeMonitoring $true
 
@@ -99,13 +99,13 @@ jobs:
         run: brew install coreutils
 
       - name: Calculate the hashsum of the zip file
-        if: ${{ matrix.os != 'windows-latest' }}
+        if: ${{ matrix.os != 'windows-2019' }}
         shell: bash
         run: |
           sha256sum ${{ env.OUTNAME }}.zip | awk '{ print $1 }' > sha256-${{ matrix.outname_sufix }}.txt
 
       - name: Calculate the hashsum of the zip file (Windows)
-        if: ${{ matrix.os == 'windows-latest' }}
+        if: ${{ matrix.os == 'windows-2019' }}
         run: |
           (Get-FileHash ${{ env.OUTNAME }}.zip -Algorithm SHA256).Hash > sha256-${{ matrix.outname_sufix }}.txt
 
@@ -117,7 +117,7 @@ jobs:
           retention-days: 5
 
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: build-and-upload
     steps:
       - name: Download the artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,14 +21,14 @@ jobs:
             outname_sufix: "mac-amd64"
           - os: [self-hosted, macOS, ARM64, go-spacemesh]
             outname_sufix: "mac-arm64"
-          - os: windows-2019
+          - os: windows-2022
             outname_sufix: "win-amd64"
     steps:
       - shell: bash
         run: echo "OUTNAME=go-spacemesh-${{ github.ref_name }}-${{ matrix.outname_sufix }}" >> $GITHUB_ENV
 
       - name: Install dependencies in windows
-        if: ${{ matrix.os == 'windows-2019' }}
+        if: ${{ matrix.os == 'windows-2022' }}
         run: choco install make wget zip
 
       - name: Add OpenCL support - Ubuntu
@@ -36,7 +36,7 @@ jobs:
         run: sudo apt-get update -q && sudo apt-get install -qy ocl-icd-opencl-dev libpocl2
 
       - name: disable Windows Defender - Windows
-        if: ${{ matrix.os == 'windows-2019' }}
+        if: ${{ matrix.os == 'windows-2022' }}
         run: |
           Set-MpPreference -DisableRealtimeMonitoring $true
 
@@ -99,13 +99,13 @@ jobs:
         run: brew install coreutils
 
       - name: Calculate the hashsum of the zip file
-        if: ${{ matrix.os != 'windows-2019' }}
+        if: ${{ matrix.os != 'windows-2022' }}
         shell: bash
         run: |
           sha256sum ${{ env.OUTNAME }}.zip | awk '{ print $1 }' > sha256-${{ matrix.outname_sufix }}.txt
 
       - name: Calculate the hashsum of the zip file (Windows)
-        if: ${{ matrix.os == 'windows-2019' }}
+        if: ${{ matrix.os == 'windows-2022' }}
         run: |
           (Get-FileHash ${{ env.OUTNAME }}.zip -Algorithm SHA256).Hash > sha256-${{ matrix.outname_sufix }}.txt
 

--- a/.github/workflows/systest.yml
+++ b/.github/workflows/systest.yml
@@ -40,7 +40,7 @@ concurrency:
 
 jobs:
   filter-changes:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       nondocchanges: ${{ steps.filter.outputs.nondoc }}
     steps:
@@ -53,7 +53,7 @@ jobs:
               - '!**/*.md'
 
   systest:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: ${{ needs.filter-changes.outputs.nondocchanges == 'true' }}
     needs:
       - filter-changes
@@ -140,7 +140,7 @@ jobs:
     needs:
       - filter-changes
       - systest
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       # short-circuit success if no non-doc files were modified
       status: ${{ (needs.filter-changes.outputs.nondocchanges == 'false' || needs.systest.result == 'success') && 'success' || 'failure' }}


### PR DESCRIPTION
## Motivation

`ubuntu-latest` and `windows-latest` might change which VM we get over time. For ubuntu it is expected that in August 2024 `ubuntu-latest` will not resolve to `ubuntu-22.04` any more but to `ubuntu-24.04`. To avoid surprises we should select the oldest version we want to support and upgrade when we want to.

## Description

Replaced all instances of `ubuntu-latest` with `ubuntu-22.04` and `windows-latest` with `windows-2019`.

## Test Plan

existing tests pass

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
