### PR TITLE
[Merged by Bors] - Limit size of ActiveSet in ballot encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,12 @@ Upgrading to this version requires going through v1.5.x first. Removed migration
   deprecated inlined activeset as invalid. go-spacemesh references the active set via hash since v1.3.0, and has been
   pruning the data of old ballots since then as well.
 
+## Release v1.5.4
+
+### Improvements
+
+* [#5963](https://github.com/spacemeshos/go-spacemesh/pull/5963) Increase supported number of ATXs to 5.5 Mio.
+
 ## Release v1.5.3
 
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@ Upgrading to this version requires going through v1.5.x first. Removed migration
   Ensure that your key file in `data/identities` is named `local.key` if you run a supervised node or with the change
   the node will not start.
 
+* [#5965](https://github.com/spacemeshos/go-spacemesh/pull/5965) Start considering ballots that still contain the
+  deprecated inlined activeset as invalid. go-spacemesh references the active set via hash since v1.3.0, and has been
+  pruning the data of old ballots since then as well.
+
 ## Release v1.5.3
 
 ### Improvements

--- a/common/types/ballot.go
+++ b/common/types/ballot.go
@@ -73,7 +73,7 @@ type Ballot struct {
 	// only present in smesher's first ballot of the epoch
 	// this field isn't actually used any more (replaced by InnerBallot.EpochData)
 	// TODO (mafa): remove this field in Ballot v2
-	ActiveSet []ATXID `scale:"max=3500000"`
+	ActiveSet []ATXID `scale:"max=1"`
 
 	// the following fields are kept private and from being serialized
 	ballotID BallotID

--- a/common/types/ballot_scale.go
+++ b/common/types/ballot_scale.go
@@ -44,7 +44,7 @@ func (t *Ballot) EncodeScale(enc *scale.Encoder) (total int, err error) {
 		total += n
 	}
 	{
-		n, err := scale.EncodeStructSliceWithLimit(enc, t.ActiveSet, 3500000)
+		n, err := scale.EncodeStructSliceWithLimit(enc, t.ActiveSet, 1)
 		if err != nil {
 			return total, err
 		}
@@ -91,7 +91,7 @@ func (t *Ballot) DecodeScale(dec *scale.Decoder) (total int, err error) {
 		t.EligibilityProofs = field
 	}
 	{
-		field, n, err := scale.DecodeStructSliceWithLimit[ATXID](dec, 3500000)
+		field, n, err := scale.DecodeStructSliceWithLimit[ATXID](dec, 1)
 		if err != nil {
 			return total, err
 		}

--- a/proposals/handler.go
+++ b/proposals/handler.go
@@ -444,7 +444,7 @@ func (h *Handler) processBallot(ctx context.Context, logger log.Log, b *types.Ba
 	if err != nil {
 		return nil, err
 	}
-	b.ActiveSet = nil
+	b.ActiveSet = nil // the active set is not needed anymore
 
 	t1 := time.Now()
 	proof, err := h.mesh.AddBallot(ctx, b)

--- a/sql/ballots/ballots.go
+++ b/sql/ballots/ballots.go
@@ -62,17 +62,6 @@ func Has(db sql.Executor, id types.BallotID) (bool, error) {
 	return rows > 0, nil
 }
 
-func UpdateBlob(db sql.Executor, bid types.BallotID, blob []byte) error {
-	if _, err := db.Exec(`update ballots set ballot = ?2 where id = ?1;`,
-		func(stmt *sql.Statement) {
-			stmt.BindBytes(1, bid.Bytes())
-			stmt.BindBytes(2, blob[:])
-		}, nil); err != nil {
-		return fmt.Errorf("update blob %s: %w", bid.String(), err)
-	}
-	return nil
-}
-
 // GetBlobSizes returns the sizes of the blobs corresponding to ballots with specified
 // ids. For non-existent ballots, the corresponding items are set to -1.
 func GetBlobSizes(db sql.Executor, ids [][]byte) (sizes []int, err error) {

--- a/sql/ballots/ballots_test.go
+++ b/sql/ballots/ballots_test.go
@@ -84,26 +84,6 @@ func TestAdd(t *testing.T) {
 	require.True(t, stored.IsMalicious())
 }
 
-func TestUpdateBlob(t *testing.T) {
-	db := sql.InMemory()
-	nodeID := types.RandomNodeID()
-	ballot := types.NewExistingBallot(types.BallotID{1}, types.RandomEdSignature(), nodeID, types.LayerID(0))
-	ballot.EpochData = &types.EpochData{
-		ActiveSetHash: types.RandomHash(),
-	}
-	ballot.ActiveSet = types.RandomActiveSet(199)
-	require.NoError(t, Add(db, &ballot))
-	got, err := Get(db, types.BallotID{1})
-	require.NoError(t, err)
-	require.Equal(t, ballot, *got)
-
-	ballot.ActiveSet = nil
-	require.NoError(t, UpdateBlob(db, types.BallotID{1}, codec.MustEncode(&ballot)))
-	got, err = Get(db, types.BallotID{1})
-	require.NoError(t, err)
-	require.Empty(t, got.ActiveSet)
-}
-
 func TestHas(t *testing.T) {
 	db := sql.InMemory()
 	ballot := types.NewExistingBallot(types.BallotID{1}, types.EmptyEdSignature, types.EmptyNodeID, types.LayerID(0))


### PR DESCRIPTION
## Motivation

Don't allow a ballot to contain `ActiveSet` `ATXID`s. They are immediately discarded after receiving them but other nodes can still send ballots with a list of ATXIDs attached that is unnecessarily downloaded and decoded before being deleted.

## Description

The limit of the slice is changed to 1 (zero isn't allowed by `go-scale`). So any incoming ballot with more than 1 referenced ATX ID will be considered invalid.

Up until now the node has always deleted the `ActiveSet` before storing the encoded blob in the DB. To be sure I checked on my local node as well and it didn't have any ballots with `ActiveSet` containing ATXIDs, so this is safe to do.

## Test Plan

<!-- Please specify how these changes were tested (e.g. unit tests, manual testing, etc.) -->

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
