### PR TITLE
[Merged by Bors] - p2p: server: use zap for logging

### DIFF
--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -350,7 +350,7 @@ func (f *Fetch) registerServer(
 	opts := []server.Opt{
 		server.WithTimeout(f.cfg.RequestTimeout),
 		server.WithHardTimeout(f.cfg.RequestHardTimeout),
-		server.WithLog(f.logger),
+		server.WithLog(f.logger.Zap()),
 		server.WithDecayingTag(f.cfg.DecayingTag),
 	}
 	if f.cfg.EnableServerMetrics {

--- a/p2p/server/server_test.go
+++ b/p2p/server/server_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spacemeshos/go-scale/tester"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 	"golang.org/x/sync/errgroup"
 )

--- a/p2p/server/server_test.go
+++ b/p2p/server/server_test.go
@@ -32,7 +32,7 @@ func TestServer(t *testing.T) {
 	}
 	opts := []Opt{
 		WithTimeout(100 * time.Millisecond),
-		WithLog(zaptest.NewLogger(t)),
+		WithLog(zaptest.NewLogger(t, zaptest.Level(zap.InfoLevel))),
 		WithMetrics(),
 	}
 	client := New(mesh.Hosts()[0], proto, WrapHandler(handler), append(opts, WithRequestSizeLimit(2*limit))...)

--- a/p2p/server/server_test.go
+++ b/p2p/server/server_test.go
@@ -11,9 +11,8 @@ import (
 	"github.com/spacemeshos/go-scale/tester"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
 	"golang.org/x/sync/errgroup"
-
-	"github.com/spacemeshos/go-spacemesh/log/logtest"
 )
 
 func TestServer(t *testing.T) {
@@ -33,7 +32,7 @@ func TestServer(t *testing.T) {
 	}
 	opts := []Opt{
 		WithTimeout(100 * time.Millisecond),
-		WithLog(logtest.New(t)),
+		WithLog(zaptest.NewLogger(t)),
 		WithMetrics(),
 	}
 	client := New(mesh.Hosts()[0], proto, WrapHandler(handler), append(opts, WithRequestSizeLimit(2*limit))...)


### PR DESCRIPTION
## Motivation

Use `zap` for logging in `p2p/server` instead of the custom logger.
One of the minor changes needed for syncv2

## Description

Minor refactor
