### PR TITLE
[Merged by Bors] - p2p: server: close streams upon context cancellation

### DIFF
--- a/p2p/server/server.go
+++ b/p2p/server/server.go
@@ -246,7 +246,6 @@ func (s *Server) Run(ctx context.Context) error {
 			ctx, cancel := context.WithCancel(ctx)
 			eg.Go(func() error {
 				<-ctx.Done()
-				// deadlineAdjuster.Close() is safe to call multiple times
 				req.stream.Close()
 				return nil
 			})
@@ -367,7 +366,6 @@ func (s *Server) StreamRequest(
 		var eg errgroup.Group
 		eg.Go(func() error {
 			<-ctx.Done()
-			// deadlineAdjuster.Close() is safe to call multiple times
 			stream.Close()
 			return nil
 		})


### PR DESCRIPTION
## Motivation

When a P2P Server request is canceled or a server is stopped while serving a request, some code paths that involve blocking I/O calls may hang b/c the P2P stream is not closed upon cancellation of the context that was passed to `StreamRequest` / `Request` or `Run`. On top of that, the context which is passed to server handlers is not canceled when the server exits.

This was split off #5769 where a P2P test was hanging when trying to stop the P2P servers.

## Description

Close P2P server streams upon context cancellation. Cancel handlers' context when the handler functions exit
