### PR TITLE
[Merged by Bors] - Add ID calculation based on merkle root

### DIFF
--- a/activation/wire/wire_v1.go
+++ b/activation/wire/wire_v1.go
@@ -1,8 +1,8 @@
 package wire
 
 import (
+	"encoding/binary"
 	"encoding/hex"
-	"unsafe"
 
 	"github.com/spacemeshos/merkle-tree"
 	"go.uber.org/zap/zapcore"
@@ -50,9 +50,15 @@ func (p *PostV1) Root() []byte {
 	if err != nil {
 		panic(err)
 	}
-	tree.AddLeaf((*[4]byte)(unsafe.Pointer(&p.Nonce))[:])
+	nonce := make([]byte, 4)
+	binary.LittleEndian.PutUint32(nonce, p.Nonce)
+	tree.AddLeaf(nonce)
+
 	tree.AddLeaf(p.Indices)
-	tree.AddLeaf((*[8]byte)(unsafe.Pointer(&p.Pow))[:])
+
+	pow := make([]byte, 8)
+	binary.LittleEndian.PutUint64(pow, p.Pow)
+	tree.AddLeaf(pow)
 	return tree.Root()
 }
 

--- a/activation/wire/wire_v1.go
+++ b/activation/wire/wire_v1.go
@@ -5,7 +5,6 @@ import (
 	"unsafe"
 
 	"github.com/spacemeshos/merkle-tree"
-
 	"go.uber.org/zap/zapcore"
 
 	"github.com/spacemeshos/go-spacemesh/codec"

--- a/activation/wire/wire_v1_test.go
+++ b/activation/wire/wire_v1_test.go
@@ -1,0 +1,36 @@
+package wire
+
+import (
+	"testing"
+
+	fuzz "github.com/google/gofuzz"
+	"github.com/stretchr/testify/require"
+
+	"github.com/spacemeshos/go-spacemesh/common/types"
+)
+
+func Benchmark_ATXv1ID(b *testing.B) {
+	f := fuzz.New()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		atx := &ActivationTxV1{}
+		f.Fuzz(atx)
+		b.StartTimer()
+		atx.ID()
+	}
+}
+
+func Test_NoATXv1IDCollisions(t *testing.T) {
+	f := fuzz.New()
+
+	atxIDs := make([]types.ATXID, 0, 1000)
+	for range 1000 {
+		atx := &ActivationTxV1{}
+		f.Fuzz(atx)
+		id := atx.ID()
+		require.NotContains(t, atxIDs, id, "ATX ID collision")
+		atxIDs = append(atxIDs, id)
+	}
+}

--- a/activation/wire/wire_v2.go
+++ b/activation/wire/wire_v2.go
@@ -228,10 +228,13 @@ func (mp *MerkleProofV2) Root() []byte {
 }
 
 type SubPostV2 struct {
-	NodeID       types.NodeID // NodeID this PoST belongs to
-	PrevATXIndex uint32       // Index of the previous ATX in the `InnerActivationTxV2.PreviousATXs` slice
-	Post         PostV1
-	NumUnits     uint32
+	// Index of marriage certificate for this ID in the 'Marriages' slice. Only valid for merged ATXs.
+	// Can be used to extract the nodeID and verify if it is married with the smesher of the ATX.
+	// Must be 0 for non-merged ATXs.
+	MarriageIndex uint32
+	PrevATXIndex  uint32 // Index of the previous ATX in the `InnerActivationTxV2.PreviousATXs` slice
+	Post          PostV1
+	NumUnits      uint32
 }
 
 func (sp *SubPostV2) Root(prevATXs []types.ATXID) []byte {
@@ -241,7 +244,7 @@ func (sp *SubPostV2) Root(prevATXs []types.ATXID) []byte {
 	if err != nil {
 		panic(err)
 	}
-	tree.AddLeaf(sp.NodeID.Bytes())
+	tree.AddLeaf((*[4]byte)(unsafe.Pointer(&sp.MarriageIndex))[:])
 	if int(sp.PrevATXIndex) >= len(prevATXs) {
 		return nil // invalid index, root cannot be generated
 	}

--- a/activation/wire/wire_v2.go
+++ b/activation/wire/wire_v2.go
@@ -56,18 +56,7 @@ func (atx *ActivationTxV2) SignedBytes() []byte {
 	return atx.ID().Bytes()
 }
 
-func (atx *ActivationTxV2) ID() types.ATXID {
-	if atx.id != types.EmptyATXID {
-		return atx.id
-	}
-
-	tree, err := merkle.NewTreeBuilder().
-		WithHashFunc(atxTreeHash).
-		Build()
-	if err != nil {
-		panic(err)
-	}
-
+func (atx *ActivationTxV2) merkleTree(tree *merkle.Tree) {
 	publishEpoch := make([]byte, 4)
 	binary.LittleEndian.PutUint32(publishEpoch, atx.PublishEpoch.Uint32())
 	tree.AddLeaf(publishEpoch)
@@ -136,7 +125,20 @@ func (atx *ActivationTxV2) ID() types.ATXID {
 	} else {
 		tree.AddLeaf(types.EmptyATXID.Bytes())
 	}
+}
 
+func (atx *ActivationTxV2) ID() types.ATXID {
+	if atx.id != types.EmptyATXID {
+		return atx.id
+	}
+
+	tree, err := merkle.NewTreeBuilder().
+		WithHashFunc(atxTreeHash).
+		Build()
+	if err != nil {
+		panic(err)
+	}
+	atx.merkleTree(tree)
 	atx.id = types.ATXID(tree.Root())
 	return atx.id
 }

--- a/activation/wire/wire_v2_scale.go
+++ b/activation/wire/wire_v2_scale.go
@@ -290,7 +290,7 @@ func (t *MerkleProofV2) DecodeScale(dec *scale.Decoder) (total int, err error) {
 
 func (t *SubPostV2) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	{
-		n, err := scale.EncodeByteArray(enc, t.NodeID[:])
+		n, err := scale.EncodeCompact32(enc, uint32(t.MarriageIndex))
 		if err != nil {
 			return total, err
 		}
@@ -322,11 +322,12 @@ func (t *SubPostV2) EncodeScale(enc *scale.Encoder) (total int, err error) {
 
 func (t *SubPostV2) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	{
-		n, err := scale.DecodeByteArray(dec, t.NodeID[:])
+		field, n, err := scale.DecodeCompact32(dec)
 		if err != nil {
 			return total, err
 		}
 		total += n
+		t.MarriageIndex = uint32(field)
 	}
 	{
 		field, n, err := scale.DecodeCompact32(dec)

--- a/activation/wire/wire_v2_scale.go
+++ b/activation/wire/wire_v2_scale.go
@@ -290,7 +290,7 @@ func (t *MerkleProofV2) DecodeScale(dec *scale.Decoder) (total int, err error) {
 
 func (t *SubPostV2) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	{
-		n, err := scale.EncodeCompact32(enc, uint32(t.MarriageIndex))
+		n, err := scale.EncodeByteArray(enc, t.NodeID[:])
 		if err != nil {
 			return total, err
 		}
@@ -322,12 +322,11 @@ func (t *SubPostV2) EncodeScale(enc *scale.Encoder) (total int, err error) {
 
 func (t *SubPostV2) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	{
-		field, n, err := scale.DecodeCompact32(dec)
+		n, err := scale.DecodeByteArray(dec, t.NodeID[:])
 		if err != nil {
 			return total, err
 		}
 		total += n
-		t.MarriageIndex = uint32(field)
 	}
 	{
 		field, n, err := scale.DecodeCompact32(dec)

--- a/activation/wire/wire_v2_test.go
+++ b/activation/wire/wire_v2_test.go
@@ -16,13 +16,15 @@ func Benchmark_ATXv2ID(b *testing.B) {
 	f := fuzz.New()
 	b.ResetTimer()
 
+	var atx *ActivationTxV2
 	for i := 0; i < b.N; i++ {
 		b.StopTimer()
-		atx := &ActivationTxV2{}
+		atx = &ActivationTxV2{}
 		f.Fuzz(atx)
 		b.StartTimer()
 		atx.ID()
 	}
+	_ = atx
 }
 
 func Benchmark_ATXv2ID_WorstScenario(b *testing.B) {
@@ -120,11 +122,11 @@ func Test_GenerateDoublePublishProof(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, proof)
 
-	// a malfeasanceproof for double publish will contain
+	// a malfeasance proof for double publish will contain
 	// - the value of the PublishEpoch (here 10) - 4 bytes
 	// - the two ATX IDs - 32 bytes each
 	// - the two signatures (atx.Signature + atx.NodeID) - 64 bytes each
-	// - two merkleproofs - one per ATX - that is 128 bytes each (4 * 32)
+	// - two merkle proofs - one per ATX - that is 128 bytes each (4 * 32)
 	// total: 452 bytes instead of two full ATXs (> 20 kB each in the worst case)
 
 	publishEpochLeaf := (*[4]byte)(unsafe.Pointer(&atx.PublishEpoch))[:]

--- a/activation/wire/wire_v2_test.go
+++ b/activation/wire/wire_v2_test.go
@@ -2,8 +2,10 @@ package wire
 
 import (
 	"testing"
+	"unsafe"
 
 	fuzz "github.com/google/gofuzz"
+	"github.com/spacemeshos/merkle-tree"
 	"github.com/stretchr/testify/require"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
@@ -82,4 +84,147 @@ func Test_NoATXv2IDCollisions(t *testing.T) {
 		require.NotContains(t, atxIDs, id, "ATX ID collision")
 		atxIDs = append(atxIDs, id)
 	}
+}
+
+const PublishEpochIndex = 0
+
+func Test_GenerateDoublePublishProof(t *testing.T) {
+	atx := &ActivationTxV2{
+		PublishEpoch:   10,
+		PositioningATX: types.RandomATXID(),
+		PreviousATXs:   make([]types.ATXID, 1),
+		NiPosts: []NiPostsV2{
+			{
+				Membership: MerkleProofV2{
+					Nodes:       make([]types.Hash32, 32),
+					LeafIndices: make([]uint64, 256),
+				},
+				Challenge: types.RandomHash(),
+				Posts: []SubPostV2{
+					{
+						NodeID:       types.RandomNodeID(),
+						PrevATXIndex: 0,
+						Post: PostV1{
+							Nonce:   0,
+							Indices: make([]byte, 800),
+							Pow:     0,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	proof, err := generatePublishEpochProof(atx)
+	require.NoError(t, err)
+	require.NotNil(t, proof)
+
+	// a malfeasanceproof for double publish will contain
+	// - the value of the PublishEpoch (here 10) - 4 bytes
+	// - the two ATX IDs - 32 bytes each
+	// - the two signatures (atx.Signature + atx.NodeID) - 64 bytes each
+	// - two merkleproofs - one per ATX - that is 128 bytes each (4 * 32)
+	// total: 452 bytes instead of two full ATXs (> 20 kB each in the worst case)
+
+	publishEpochLeaf := (*[4]byte)(unsafe.Pointer(&atx.PublishEpoch))[:]
+	ok, err := merkle.ValidatePartialTree(
+		[]uint64{PublishEpochIndex},
+		[][]byte{publishEpochLeaf},
+		proof,
+		atx.ID().Bytes(),
+		atxTreeHash,
+	)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	// different PublishEpoch doesn't validate
+	publishEpochLeaf = []byte{0xFF, 0x00, 0x00, 0x00}
+	ok, err = merkle.ValidatePartialTree(
+		[]uint64{PublishEpochIndex},
+		[][]byte{publishEpochLeaf},
+		proof,
+		atx.ID().Bytes(),
+		atxTreeHash,
+	)
+	require.NoError(t, err)
+	require.False(t, ok)
+}
+
+func generatePublishEpochProof(atx *ActivationTxV2) ([][]byte, error) {
+	tree, err := merkle.NewTreeBuilder().
+		WithLeavesToProve(map[uint64]bool{PublishEpochIndex: true}).
+		WithHashFunc(atxTreeHash).
+		Build()
+	if err != nil {
+		return nil, err
+	}
+
+	tree.AddLeaf((*[4]byte)(unsafe.Pointer(&atx.PublishEpoch))[:])
+	tree.AddLeaf(atx.PositioningATX.Bytes())
+	if atx.Coinbase != nil {
+		tree.AddLeaf(atx.Coinbase.Bytes())
+	} else {
+		tree.AddLeaf(types.Address{}.Bytes())
+	}
+	if atx.Initial != nil {
+		tree.AddLeaf(atx.Initial.Root())
+	} else {
+		tree.AddLeaf(types.EmptyHash32.Bytes())
+	}
+
+	prevATXTree, err := merkle.NewTreeBuilder().
+		WithHashFunc(atxTreeHash).
+		Build()
+	if err != nil {
+		panic(err)
+	}
+	for _, prevATX := range atx.PreviousATXs {
+		prevATXTree.AddLeaf(prevATX.Bytes())
+	}
+	for i := 0; i < 256-len(atx.PreviousATXs); i++ {
+		prevATXTree.AddLeaf(types.EmptyATXID.Bytes())
+	}
+	tree.AddLeaf(prevATXTree.Root())
+
+	niPostTree, err := merkle.NewTreeBuilder().
+		WithHashFunc(atxTreeHash).
+		Build()
+	if err != nil {
+		panic(err)
+	}
+	for _, niPost := range atx.NiPosts {
+		niPostTree.AddLeaf(niPost.Root(atx.PreviousATXs))
+	}
+	for i := 0; i < 2-len(atx.NiPosts); i++ {
+		niPostTree.AddLeaf(types.EmptyHash32.Bytes())
+	}
+	tree.AddLeaf(niPostTree.Root())
+
+	if atx.VRFNonce != nil {
+		tree.AddLeaf((*[8]byte)(unsafe.Pointer(atx.VRFNonce))[:])
+	} else {
+		tree.AddLeaf([]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00})
+	}
+
+	marriagesTree, err := merkle.NewTreeBuilder().
+		WithHashFunc(atxTreeHash).
+		Build()
+	if err != nil {
+		panic(err)
+	}
+	for _, marriage := range atx.Marriages {
+		marriagesTree.AddLeaf(marriage.Root())
+	}
+	for i := 0; i < 256-len(atx.Marriages); i++ {
+		marriagesTree.AddLeaf(types.EmptyHash32.Bytes())
+	}
+	tree.AddLeaf(marriagesTree.Root())
+
+	if atx.MarriageATX != nil {
+		tree.AddLeaf(atx.MarriageATX.Bytes())
+	} else {
+		tree.AddLeaf(types.EmptyATXID.Bytes())
+	}
+
+	return tree.Proof(), nil
 }

--- a/activation/wire/wire_v2_test.go
+++ b/activation/wire/wire_v2_test.go
@@ -1,6 +1,7 @@
 package wire
 
 import (
+	"math/rand/v2"
 	"testing"
 	"unsafe"
 
@@ -102,8 +103,8 @@ func Test_GenerateDoublePublishProof(t *testing.T) {
 				Challenge: types.RandomHash(),
 				Posts: []SubPostV2{
 					{
-						NodeID:       types.RandomNodeID(),
-						PrevATXIndex: 0,
+						MarriageIndex: rand.Uint32N(256),
+						PrevATXIndex:  0,
 						Post: PostV1{
 							Nonce:   0,
 							Indices: make([]byte, 800),

--- a/activation/wire/wire_v2_test.go
+++ b/activation/wire/wire_v2_test.go
@@ -1,0 +1,85 @@
+package wire
+
+import (
+	"testing"
+
+	fuzz "github.com/google/gofuzz"
+	"github.com/stretchr/testify/require"
+
+	"github.com/spacemeshos/go-spacemesh/common/types"
+)
+
+func Benchmark_ATXv2ID(b *testing.B) {
+	f := fuzz.New()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		atx := &ActivationTxV2{}
+		f.Fuzz(atx)
+		b.StartTimer()
+		atx.ID()
+	}
+}
+
+func Benchmark_ATXv2ID_WorstScenario(b *testing.B) {
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		atx := &ActivationTxV2{
+			PublishEpoch:   0,
+			PositioningATX: types.RandomATXID(),
+			PreviousATXs:   make([]types.ATXID, 256),
+			NiPosts: []NiPostsV2{
+				{
+					Membership: MerkleProofV2{
+						Nodes:       make([]types.Hash32, 32),
+						LeafIndices: make([]uint64, 256),
+					},
+					Challenge: types.RandomHash(),
+					Posts:     make([]SubPostV2, 256),
+				},
+				{
+					Membership: MerkleProofV2{
+						Nodes:       make([]types.Hash32, 32),
+						LeafIndices: make([]uint64, 256),
+					},
+					Challenge: types.RandomHash(),
+					Posts:     make([]SubPostV2, 256), // actually the sum of all posts in `NiPosts` should be 256
+				},
+			},
+		}
+		for i := range atx.NiPosts[0].Posts {
+			atx.NiPosts[0].Posts[i].Post = PostV1{
+				Nonce:   0,
+				Indices: make([]byte, 800),
+				Pow:     0,
+			}
+		}
+		for i := range atx.NiPosts[1].Posts {
+			atx.NiPosts[1].Posts[i].Post = PostV1{
+				Nonce:   0,
+				Indices: make([]byte, 800),
+				Pow:     0,
+			}
+		}
+		atx.VRFNonce = new(uint64)
+		atx.MarriageATX = new(types.ATXID)
+		b.StartTimer()
+		atx.ID()
+	}
+}
+
+func Test_NoATXv2IDCollisions(t *testing.T) {
+	f := fuzz.New()
+
+	atxIDs := make([]types.ATXID, 0, 1000)
+	for range 1000 {
+		atx := &ActivationTxV2{}
+		f.Fuzz(atx)
+		id := atx.ID()
+		require.NotContains(t, atxIDs, id, "ATX ID collision")
+		atxIDs = append(atxIDs, id)
+	}
+}

--- a/activation/wire/wire_v2_test.go
+++ b/activation/wire/wire_v2_test.go
@@ -16,15 +16,13 @@ func Benchmark_ATXv2ID(b *testing.B) {
 	f := fuzz.New()
 	b.ResetTimer()
 
-	var atx *ActivationTxV2
 	for i := 0; i < b.N; i++ {
 		b.StopTimer()
-		atx = &ActivationTxV2{}
+		atx := &ActivationTxV2{}
 		f.Fuzz(atx)
 		b.StartTimer()
 		atx.ID()
 	}
-	_ = atx
 }
 
 func Benchmark_ATXv2ID_WorstScenario(b *testing.B) {


### PR DESCRIPTION
## Motivation

This adds the new ID calculation based on MerkleTrees to v2 ATXs.

## Description

Using merkle trees allows for efficient malfeasance proofs where every field in an ATX can be proven to have a specific value without having to include the full ATX in the malfeasance proof. Instead just the field of interest, the merkleproof(s), the signature(s) and the node ID have to be provided to proof that an identity published a malfeasant ATX.

As an example I created a small test in the `activation/wire` package that demonstrates this. In a future PR I will update the malfeasance package to include the new malfeasance proofs for V2 ATXs.

The new ID calculation in the worst case scenario takes ~1.5 ms on my Macbook which is \~500x slower than the ID calculation for ATXv1 (\~3 µs on my Macbook), but compared to the whole validation time of an ATX still negligible.

I had to change the `MarriageIndex` back to a `NodeID` field. The reason for this is that this field must be included as value in ID calculation to proof that two ATXs contain a post by the same identity without having to include additional ATXs and multiple additional proofs. Alternatively we could only use the value in ID calculation but not encode it in the ATX, but then ID calculation of an ATX would require looking up a possible `MarriageATX` and providing its certificates to the ID calculation function.

## Test Plan

added unit tests for ID cacluation.

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
