### PR TITLE
[Merged by Bors] - Only print logs in tests that fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,7 +274,7 @@ jobs:
       - name: unit tests
         timeout-minutes: 35
         env:
-          GOTESTSUM_FORMAT: standard-verbose
+          GOTESTSUM_FORMAT: standard-quiet
           GOTESTSUM_JUNITFILE: unit-tests.xml
         run: make test
       - name: Publish Test Report

--- a/activation/activation_test.go
+++ b/activation/activation_test.go
@@ -69,7 +69,7 @@ type testAtxBuilder struct {
 }
 
 func newTestBuilder(tb testing.TB, numSigners int, opts ...BuilderOption) *testAtxBuilder {
-	observer, observedLogs := observer.New(zapcore.DebugLevel)
+	observer, observedLogs := observer.New(zapcore.WarnLevel)
 	logger := zaptest.NewLogger(tb, zaptest.WrapOptions(zap.WrapCore(
 		func(core zapcore.Core) zapcore.Core {
 			return zapcore.NewTee(core, observer)
@@ -1498,7 +1498,7 @@ func TestFindFullyValidHighTickAtx(t *testing.T) {
 		mValidator := NewMocknipostValidator(gomock.NewController(t))
 		mValidator.EXPECT().VerifyChain(gomock.Any(), atxLower.ID(), golden, gomock.Any())
 
-		lg := zaptest.NewLogger(t, zaptest.Level(zap.InfoLevel))
+		lg := zaptest.NewLogger(t)
 		found, err := findFullyValidHighTickAtx(context.Background(), data, 0, golden, mValidator, lg)
 		require.NoError(t, err)
 		require.Equal(t, atxLower.ID(), found)

--- a/activation/nipost_test.go
+++ b/activation/nipost_test.go
@@ -62,7 +62,11 @@ type testNIPostBuilder struct {
 
 func newTestNIPostBuilder(tb testing.TB) *testNIPostBuilder {
 	observer, observedLogs := observer.New(zapcore.WarnLevel)
-	logger := zap.New(observer)
+	logger := zaptest.NewLogger(tb, zaptest.WrapOptions(zap.WrapCore(
+		func(core zapcore.Core) zapcore.Core {
+			return zapcore.NewTee(core, observer)
+		},
+	)))
 
 	events.InitializeReporter()
 	sub, _, err := events.SubscribeUserEvents(events.WithBuffer(10))

--- a/api/grpcserver/grpcserver_test.go
+++ b/api/grpcserver/grpcserver_test.go
@@ -468,7 +468,11 @@ func TestNewLocalServer(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			observer, observedLogs := observer.New(zapcore.WarnLevel)
-			logger := zap.New(observer)
+			logger := zaptest.NewLogger(t, zaptest.WrapOptions(zap.WrapCore(
+				func(core zapcore.Core) zapcore.Core {
+					return zapcore.NewTee(core, observer)
+				},
+			)))
 
 			ctrl := gomock.NewController(t)
 			peerCounter := NewMockpeerCounter(ctrl)

--- a/beacon/beacon_test.go
+++ b/beacon/beacon_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/spacemeshos/fixed"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
-	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 	"golang.org/x/sync/errgroup"
 
@@ -88,7 +87,7 @@ func newTestDriver(tb testing.TB, cfg Config, p pubsub.Publisher, miners int, id
 		mSync:     mocks.NewMockSyncStateProvider(ctrl),
 		mVerifier: NewMockvrfVerifier(ctrl),
 	}
-	lg := zaptest.NewLogger(tb, zaptest.Level(zap.InfoLevel)).Named(id)
+	lg := zaptest.NewLogger(tb).Named(id)
 
 	tpd.mVerifier.EXPECT().Verify(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(true)
 
@@ -491,7 +490,7 @@ func TestBeaconWithMetrics(t *testing.T) {
 
 func TestBeacon_NoRaceOnClose(t *testing.T) {
 	mclock := NewMocklayerClock(gomock.NewController(t))
-	lg := zaptest.NewLogger(t, zaptest.Level(zap.InfoLevel))
+	lg := zaptest.NewLogger(t)
 	pd := &ProtocolDriver{
 		logger:           lg.Named("Beacon"),
 		beacons:          make(map[types.EpochID]types.Beacon),
@@ -525,7 +524,7 @@ func TestBeacon_NoRaceOnClose(t *testing.T) {
 func TestBeacon_BeaconsWithDatabase(t *testing.T) {
 	t.Parallel()
 
-	lg := zaptest.NewLogger(t, zaptest.Level(zap.InfoLevel))
+	lg := zaptest.NewLogger(t)
 	mclock := NewMocklayerClock(gomock.NewController(t))
 	pd := &ProtocolDriver{
 		logger:  lg.Named("Beacon"),
@@ -578,7 +577,7 @@ func TestBeacon_BeaconsWithDatabase(t *testing.T) {
 func TestBeacon_BeaconsWithDatabaseFailure(t *testing.T) {
 	t.Parallel()
 
-	lg := zaptest.NewLogger(t, zaptest.Level(zap.InfoLevel))
+	lg := zaptest.NewLogger(t)
 	mclock := NewMocklayerClock(gomock.NewController(t))
 	pd := &ProtocolDriver{
 		logger:  lg.Named("Beacon"),
@@ -597,7 +596,7 @@ func TestBeacon_BeaconsWithDatabaseFailure(t *testing.T) {
 func TestBeacon_BeaconsCleanupOldEpoch(t *testing.T) {
 	t.Parallel()
 
-	lg := zaptest.NewLogger(t, zaptest.Level(zap.InfoLevel))
+	lg := zaptest.NewLogger(t)
 	mclock := NewMocklayerClock(gomock.NewController(t))
 	pd := &ProtocolDriver{
 		logger:         lg.Named("Beacon"),
@@ -701,7 +700,7 @@ func TestBeacon_ReportBeaconFromBallot(t *testing.T) {
 				require.Greater(t, maxWeight.Float(), 0.0)
 			}
 
-			lg := zaptest.NewLogger(t, zaptest.Level(zap.InfoLevel))
+			lg := zaptest.NewLogger(t)
 			mclock := NewMocklayerClock(gomock.NewController(t))
 			pd := &ProtocolDriver{
 				logger:         lg.Named("Beacon"),
@@ -737,7 +736,7 @@ func TestBeacon_ReportBeaconFromBallot(t *testing.T) {
 func TestBeacon_ReportBeaconFromBallot_SameBallot(t *testing.T) {
 	t.Parallel()
 
-	lg := zaptest.NewLogger(t, zaptest.Level(zap.InfoLevel))
+	lg := zaptest.NewLogger(t)
 	mclock := NewMocklayerClock(gomock.NewController(t))
 	pd := &ProtocolDriver{
 		logger:         lg.Named("Beacon"),
@@ -778,7 +777,7 @@ func TestBeacon_ensureEpochHasBeacon_BeaconAlreadyCalculated(t *testing.T) {
 	beacon := types.RandomBeacon()
 	beaconFromBallots := types.RandomBeacon()
 	pd := &ProtocolDriver{
-		logger: zaptest.NewLogger(t, zaptest.Level(zap.InfoLevel)).Named("Beacon"),
+		logger: zaptest.NewLogger(t).Named("Beacon"),
 		config: UnitTestConfig(),
 		beacons: map[types.EpochID]types.Beacon{
 			epoch: beacon,
@@ -830,7 +829,7 @@ func TestBeacon_findMajorityBeacon(t *testing.T) {
 	}
 	epoch := types.EpochID(3)
 	pd := &ProtocolDriver{
-		logger:         zaptest.NewLogger(t, zaptest.Level(zap.InfoLevel)).Named("Beacon"),
+		logger:         zaptest.NewLogger(t).Named("Beacon"),
 		config:         UnitTestConfig(),
 		beacons:        make(map[types.EpochID]types.Beacon),
 		ballotsBeacons: map[types.EpochID]map[types.Beacon]*beaconWeight{epoch: beaconFromBallots},
@@ -866,7 +865,7 @@ func TestBeacon_findMajorityBeacon_plurality(t *testing.T) {
 	}
 	epoch := types.EpochID(3)
 	pd := &ProtocolDriver{
-		logger:         zaptest.NewLogger(t, zaptest.Level(zap.InfoLevel)).Named("Beacon"),
+		logger:         zaptest.NewLogger(t).Named("Beacon"),
 		config:         UnitTestConfig(),
 		beacons:        make(map[types.EpochID]types.Beacon),
 		ballotsBeacons: map[types.EpochID]map[types.Beacon]*beaconWeight{epoch: beaconFromBallots},
@@ -902,7 +901,7 @@ func TestBeacon_findMajorityBeacon_NotEnoughBallots(t *testing.T) {
 	}
 	epoch := types.EpochID(3)
 	pd := &ProtocolDriver{
-		logger:         zaptest.NewLogger(t, zaptest.Level(zap.InfoLevel)).Named("Beacon"),
+		logger:         zaptest.NewLogger(t).Named("Beacon"),
 		config:         UnitTestConfig(),
 		beacons:        make(map[types.EpochID]types.Beacon),
 		ballotsBeacons: map[types.EpochID]map[types.Beacon]*beaconWeight{epoch: beaconFromBallots},
@@ -916,7 +915,7 @@ func TestBeacon_findMajorityBeacon_NoBeacon(t *testing.T) {
 	t.Parallel()
 
 	pd := &ProtocolDriver{
-		logger:         zaptest.NewLogger(t, zaptest.Level(zap.InfoLevel)).Named("Beacon"),
+		logger:         zaptest.NewLogger(t).Named("Beacon"),
 		config:         UnitTestConfig(),
 		beacons:        make(map[types.EpochID]types.Beacon),
 		ballotsBeacons: make(map[types.EpochID]map[types.Beacon]*beaconWeight),
@@ -1050,7 +1049,7 @@ func TestBeacon_proposalPassesEligibilityThreshold(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			logger := zaptest.NewLogger(t, zaptest.Level(zap.InfoLevel))
+			logger := zaptest.NewLogger(t)
 			checker := createProposalChecker(logger.Named("proposal checker"), cfg, tc.wEarly, tc.wOntime)
 			var numEligible, numEligibleStrict int
 			for i := 0; i < tc.wEarly; i++ {
@@ -1131,7 +1130,7 @@ func TestBeacon_getSignedProposal(t *testing.T) {
 
 			result := buildSignedProposal(
 				context.Background(),
-				zaptest.NewLogger(t, zaptest.Level(zap.InfoLevel)),
+				zaptest.NewLogger(t),
 				edSgn.VRFSigner(),
 				tc.epoch,
 				types.VRFPostIndex(1),
@@ -1149,7 +1148,7 @@ func TestBeacon_calcBeacon(t *testing.T) {
 		Proposal{0x05}: {},
 	}
 
-	beacon := calcBeacon(zaptest.NewLogger(t, zaptest.Level(zap.InfoLevel)), set)
+	beacon := calcBeacon(zaptest.NewLogger(t), set)
 	expected := types.HexToBeacon("0xe69fd154")
 	require.EqualValues(t, expected, beacon)
 }

--- a/beacon/handlers_test.go
+++ b/beacon/handlers_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
-	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 
 	"github.com/spacemeshos/go-spacemesh/codec"
@@ -86,7 +85,7 @@ func createProposal(
 ) *ProposalMessage {
 	sig := buildSignedProposal(
 		context.Background(),
-		zaptest.NewLogger(t, zaptest.Level(zap.InfoLevel)),
+		zaptest.NewLogger(t),
 		vrfSigner,
 		epoch,
 		types.VRFPostIndex(rand.Uint64()),

--- a/beacon/votes_calc_test.go
+++ b/beacon/votes_calc_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 )
 
@@ -81,7 +80,7 @@ func TestBeacon_calcVotes(t *testing.T) {
 				votesMargin: tc.votesMargin,
 			}
 			theta := new(big.Float).SetRat(big.NewRat(1, 1))
-			logger := zaptest.NewLogger(t, zaptest.Level(zap.InfoLevel)).Named(tc.name)
+			logger := zaptest.NewLogger(t).Named(tc.name)
 
 			result, undecided := calcVotes(logger, theta, eh)
 			sort.Slice(undecided, func(i, j int) bool { return bytes.Compare(undecided[i][:], undecided[j][:]) == -1 })
@@ -170,7 +169,7 @@ func TestBeacon_votingThreshold(t *testing.T) {
 			t.Parallel()
 
 			pd := ProtocolDriver{
-				logger: zaptest.NewLogger(t, zaptest.Level(zap.InfoLevel)).Named("Beacon"),
+				logger: zaptest.NewLogger(t).Named("Beacon"),
 				config: Config{},
 				theta:  new(big.Float).SetRat(tc.theta),
 			}

--- a/beacon/weakcoin/weak_coin_test.go
+++ b/beacon/weakcoin/weak_coin_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/spacemeshos/go-scale/tester"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
-	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 
 	"github.com/spacemeshos/go-spacemesh/beacon/weakcoin"
@@ -183,7 +182,7 @@ func TestWeakCoin(t *testing.T) {
 				mockAllowance,
 				&stubClock{},
 				weakcoin.WithThreshold(threshold),
-				weakcoin.WithLog(zaptest.NewLogger(t, zaptest.Level(zap.InfoLevel))),
+				weakcoin.WithLog(zaptest.NewLogger(t)),
 			)
 
 			wc.StartEpoch(context.Background(), epoch)
@@ -335,7 +334,7 @@ func TestWeakCoin_HandleProposal(t *testing.T) {
 				mockAllowance,
 				&stubClock{},
 				weakcoin.WithThreshold(threshold),
-				weakcoin.WithLog(zaptest.NewLogger(t, zaptest.Level(zap.InfoLevel))),
+				weakcoin.WithLog(zaptest.NewLogger(t)),
 			)
 
 			wc.StartEpoch(context.Background(), tc.startedEpoch)
@@ -438,7 +437,7 @@ func TestWeakCoinEncodingRegression(t *testing.T) {
 		nonceFetcher(t, ctrl),
 		mockAllowance,
 		&stubClock{},
-		weakcoin.WithLog(zaptest.NewLogger(t, zaptest.Level(zap.InfoLevel))),
+		weakcoin.WithLog(zaptest.NewLogger(t)),
 	)
 	instance.StartEpoch(context.Background(), epoch)
 	instance.StartRound(context.Background(), round, []weakcoin.Participant{
@@ -493,7 +492,7 @@ func TestWeakCoinExchangeProposals(t *testing.T) {
 			nonceFetcher(t, ctrl),
 			mockAllowance,
 			&stubClock{},
-			weakcoin.WithLog(zaptest.NewLogger(t, zaptest.Level(zap.InfoLevel)).Named(fmt.Sprintf("coin=%d", i))),
+			weakcoin.WithLog(zaptest.NewLogger(t).Named(fmt.Sprintf("coin=%d", i))),
 		)
 	}
 

--- a/cmd/merge-nodes/internal/merge_action_test.go
+++ b/cmd/merge-nodes/internal/merge_action_test.go
@@ -43,7 +43,11 @@ func Test_MergeDBs_InvalidTargetScheme(t *testing.T) {
 
 func Test_MergeDBs_TargetIsSupervised(t *testing.T) {
 	observer, observedLogs := observer.New(zapcore.WarnLevel)
-	logger := zap.New(observer)
+	logger := zaptest.NewLogger(t, zaptest.WrapOptions(zap.WrapCore(
+		func(core zapcore.Core) zapcore.Core {
+			return zapcore.NewTee(core, observer)
+		},
+	)))
 	tmpDst := t.TempDir()
 
 	err := os.MkdirAll(filepath.Join(tmpDst, keyDir), 0o700)
@@ -99,7 +103,11 @@ func Test_MergeDBs_InvalidSourceScheme(t *testing.T) {
 
 func Test_MergeDBs_SourceIsSupervised(t *testing.T) {
 	observer, observedLogs := observer.New(zapcore.WarnLevel)
-	logger := zap.New(observer)
+	logger := zaptest.NewLogger(t, zaptest.WrapOptions(zap.WrapCore(
+		func(core zapcore.Core) zapcore.Core {
+			return zapcore.NewTee(core, observer)
+		},
+	)))
 	tmpDst := t.TempDir()
 
 	db, err := localsql.Open("file:" + filepath.Join(tmpDst, localDbFile))

--- a/node/node_identities_test.go
+++ b/node/node_identities_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest"
 	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/spacemeshos/go-spacemesh/log"
@@ -21,7 +22,11 @@ import (
 
 func setupAppWithKeys(tb testing.TB, data ...[]byte) (*App, *observer.ObservedLogs) {
 	observer, observedLogs := observer.New(zapcore.WarnLevel)
-	logger := zap.New(observer)
+	logger := zaptest.NewLogger(tb, zaptest.WrapOptions(zap.WrapCore(
+		func(core zapcore.Core) zapcore.Core {
+			return zapcore.NewTee(core, observer)
+		},
+	)))
 	app := New(WithLog(log.NewFromLog(logger)))
 	app.Config.DataDirParent = tb.TempDir()
 	if len(data) == 0 {

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -349,11 +349,7 @@ func TestSpacemeshApp_NodeService(t *testing.T) {
 	logger := logtest.New(t)
 	// errlog is used to simulate errors in the app
 	errlog := log.NewFromLog(
-		zaptest.NewLogger(
-			t,
-			zaptest.Level(zap.ErrorLevel),
-			zaptest.WrapOptions(zap.Hooks(events.EventHook()), zap.WithPanicHook(&noopHook{})),
-		),
+		zaptest.NewLogger(t, zaptest.WrapOptions(zap.Hooks(events.EventHook()), zap.WithPanicHook(&noopHook{}))),
 	)
 
 	cfg := getTestDefaultConfig(t)

--- a/p2p/server/server_test.go
+++ b/p2p/server/server_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/spacemeshos/go-scale/tester"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 	"golang.org/x/sync/errgroup"
 )
@@ -33,7 +32,7 @@ func TestServer(t *testing.T) {
 	}
 	opts := []Opt{
 		WithTimeout(100 * time.Millisecond),
-		WithLog(zaptest.NewLogger(t, zaptest.Level(zap.InfoLevel))),
+		WithLog(zaptest.NewLogger(t)),
 		WithMetrics(),
 	}
 	client := New(mesh.Hosts()[0], proto, WrapHandler(handler), append(opts, WithRequestSizeLimit(2*limit))...)


### PR DESCRIPTION
## Motivation

Our tests logs contain too much noise. In a few recent tests runs that failed I couldn't even download all logs to see why they failed because the volume of logs was too much for GH to render.

## Description

`zaptest.NewLogger` captures all tests with `DEBUG` level by default. `logtest.New` captures on `INFO` level by default which can be overwritten with the `TEST_LOG_LEVEL` field. Additionally both test loggers allow to change the logging level used for any given test by passing that level to `New(Logger)`.

Since `zaptest.NewLogger` has a higher default logging level our testlogs have become more and more spammy with the gradual migration away from `logtest.New`. Instead of changing the default logging level in tests to a higher level and thereby possibly missing important logs in the case of a test fail, I instead suggest to change the verbosity of our testruns from `standard-verbose` to `standard-quiet`.

This way any passing tests won't print any logs, but failing tests will still be printed with their full logs which are `DEBUG` for `zaptest` and INFO for `logtest` if not overwritten for that specific test.

## Test Plan

- n/a

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
