### PR TITLE
[Merged by Bors] - ATX Builder support ATX V2

### DIFF
--- a/activation/activation.go
+++ b/activation/activation.go
@@ -163,7 +163,7 @@ func WithPostStates(ps PostStates) BuilderOption {
 
 func BuilderAtxVersions(v AtxVersions) BuilderOption {
 	return func(h *Builder) {
-		h.versions = append(h.versions, v.asSlice()...)
+		h.versions = append([]atxVersion{{0, types.AtxV1}}, v.asSlice()...)
 	}
 }
 

--- a/activation/activation.go
+++ b/activation/activation.go
@@ -655,9 +655,11 @@ func (b *Builder) PublishActivationTx(ctx context.Context, sig *signing.EdSigner
 	b.logger.Debug("publication epoch has arrived!", log.ZShortStringer("smesherID", sig.NodeID()))
 
 	for {
-		b.logger.Info("broadcasting",
-			zap.Object("atx", atx),
+		b.logger.Info(
+			"broadcasting ATX",
+			log.ZShortStringer("atx_id", atx.ID()),
 			log.ZShortStringer("smesherID", sig.NodeID()),
+			log.DebugField(b.logger, zap.Object("atx", atx)),
 		)
 		size, err := b.broadcast(ctx, atx)
 		if err == nil {

--- a/activation/activation_multi_test.go
+++ b/activation/activation_multi_test.go
@@ -240,7 +240,7 @@ func Test_Builder_Multi_InitialPost(t *testing.T) {
 			}
 			commitmentATX := types.RandomATXID()
 			tab.mValidator.EXPECT().
-				Post(gomock.Any(), sig.NodeID(), commitmentATX, post, gomock.Any(), numUnits)
+				PostV2(gomock.Any(), sig.NodeID(), commitmentATX, post, shared.ZeroChallenge, numUnits)
 			tab.mnipost.EXPECT().Proof(gomock.Any(), sig.NodeID(), shared.ZeroChallenge).Return(
 				post,
 				&types.PostInfo{
@@ -248,7 +248,7 @@ func Test_Builder_Multi_InitialPost(t *testing.T) {
 					Nonce:         new(types.VRFPostIndex),
 					NumUnits:      numUnits,
 					NodeID:        sig.NodeID(),
-					LabelsPerUnit: tab.conf.LabelsPerUnit,
+					LabelsPerUnit: DefaultPostConfig().LabelsPerUnit,
 				},
 				nil,
 			)
@@ -294,7 +294,7 @@ func Test_Builder_Multi_HappyPath(t *testing.T) {
 			Pow:     nipost.Pow,
 		}
 		tab.mValidator.EXPECT().
-			Post(gomock.Any(), sig.NodeID(), nipost.CommitmentATX, post, gomock.Any(), nipost.NumUnits)
+			PostV2(gomock.Any(), sig.NodeID(), nipost.CommitmentATX, post, shared.ZeroChallenge, nipost.NumUnits)
 		tab.mnipost.EXPECT().Proof(gomock.Any(), sig.NodeID(), shared.ZeroChallenge).DoAndReturn(
 			func(ctx context.Context, _ types.NodeID, _ []byte) (*types.Post, *types.PostInfo, error) {
 				<-initialPostChan
@@ -308,7 +308,7 @@ func Test_Builder_Multi_HappyPath(t *testing.T) {
 					NumUnits:      nipost.NumUnits,
 					CommitmentATX: nipost.CommitmentATX,
 					Nonce:         &nipost.VRFNonce,
-					LabelsPerUnit: tab.conf.LabelsPerUnit,
+					LabelsPerUnit: DefaultPostConfig().LabelsPerUnit,
 				}
 
 				return post, postInfo, nil
@@ -349,7 +349,7 @@ func Test_Builder_Multi_HappyPath(t *testing.T) {
 			Pow:     nipost.Pow,
 		}
 		tab.mValidator.EXPECT().
-			Post(gomock.Any(), sig.NodeID(), nipost.CommitmentATX, post, gomock.Any(), nipost.NumUnits)
+			PostV2(gomock.Any(), sig.NodeID(), nipost.CommitmentATX, post, shared.ZeroChallenge, nipost.NumUnits)
 	}
 
 	// step 3: create ATX

--- a/activation/builder_v2_test.go
+++ b/activation/builder_v2_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/spacemeshos/post/shared"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 	"golang.org/x/exp/maps"
@@ -13,12 +14,65 @@ import (
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/signing"
 	"github.com/spacemeshos/go-spacemesh/sql/atxs"
+	"github.com/spacemeshos/go-spacemesh/sql/localsql/nipost"
 )
+
+func TestBuilder_BuildsInitialAtxV2(t *testing.T) {
+	tab := newTestBuilder(t, 1,
+		WithPoetConfig(PoetConfig{PhaseShift: layerDuration}),
+		BuilderAtxVersions(AtxVersions{1: types.AtxV2}))
+	sig := maps.Values(tab.signers)[0]
+
+	initialPost := types.Post{
+		Nonce:   7,
+		Indices: []byte{1, 2, 3, 4},
+		Pow:     12,
+	}
+	commitment := tab.goldenATXID
+	post := nipost.Post{
+		Nonce:         initialPost.Nonce,
+		Indices:       initialPost.Indices,
+		Pow:           initialPost.Pow,
+		Challenge:     shared.ZeroChallenge,
+		NumUnits:      100,
+		CommitmentATX: commitment,
+		VRFNonce:      900,
+	}
+	err := nipost.AddPost(tab.localDB, sig.NodeID(), post)
+	require.NoError(t, err)
+	posEpoch := types.EpochID(0)
+	layer := posEpoch.FirstLayer()
+
+	tab.mclock.EXPECT().CurrentLayer().Return(layer).Times(4)
+	tab.mValidator.EXPECT().PostV2(gomock.Any(), sig.NodeID(), commitment, &initialPost, post.Challenge, post.NumUnits)
+
+	var atx wire.ActivationTxV2
+	publishAtx(t, tab, sig.NodeID(), posEpoch, &layer, layersPerEpoch,
+		func(_ context.Context, _ string, got []byte) error {
+			require.NoError(t, codec.Decode(got, &atx))
+
+			atxHandler := newTestHandler(t, tab.goldenATXID, WithAtxVersions(AtxVersions{1: types.AtxV2}))
+			atxHandler.expectInitialAtxV2(&atx)
+			require.NoError(t, atxHandler.HandleGossipAtx(context.Background(), "", got))
+			return nil
+		})
+	require.NotNil(t, atx)
+	require.Empty(t, atx.PreviousATXs)
+	require.Equal(t, tab.goldenATXID, atx.PositioningATX)
+	require.NotNil(t, atx.Initial)
+	require.Equal(t, initialPost, *wire.PostFromWireV1(&atx.Initial.Post))
+	require.Equal(t, commitment, atx.Initial.CommitmentATX)
+	require.Nil(t, atx.MarriageATX)
+	require.Empty(t, atx.Marriages)
+	require.Equal(t, posEpoch+1, atx.PublishEpoch)
+	require.Equal(t, sig.NodeID(), atx.SmesherID)
+	require.True(t, signing.NewEdVerifier().Verify(signing.ATX, atx.SmesherID, atx.SignedBytes(), atx.Signature))
+}
 
 func TestBuilder_SwitchesToBuildV2(t *testing.T) {
 	tab := newTestBuilder(t, 1,
 		WithPoetConfig(PoetConfig{PhaseShift: layerDuration}),
-		BuilderAtxVersions(AtxVersions{postGenesisEpoch + 2: types.AtxV2}))
+		BuilderAtxVersions(AtxVersions{4: types.AtxV2}))
 	sig := maps.Values(tab.signers)[0]
 
 	prevAtx := newInitialATXv1(t, tab.goldenATXID)
@@ -34,7 +88,7 @@ func TestBuilder_SwitchesToBuildV2(t *testing.T) {
 	require.NotNil(t, atx1)
 
 	// create and publish ATX V2
-	posEpoch = postGenesisEpoch + 1
+	posEpoch += 1
 	layer = posEpoch.FirstLayer()
 	tab.mclock.EXPECT().CurrentLayer().Return(layer).Times(4)
 	tab.mValidator.EXPECT().VerifyChain(gomock.Any(), atx1.ID(), tab.goldenATXID, gomock.Any())

--- a/activation/builder_v2_test.go
+++ b/activation/builder_v2_test.go
@@ -1,0 +1,55 @@
+package activation
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	"golang.org/x/exp/maps"
+
+	"github.com/spacemeshos/go-spacemesh/activation/wire"
+	"github.com/spacemeshos/go-spacemesh/codec"
+	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/signing"
+	"github.com/spacemeshos/go-spacemesh/sql/atxs"
+)
+
+func TestBuilder_SwitchesToBuildV2(t *testing.T) {
+	tab := newTestBuilder(t, 1,
+		WithPoetConfig(PoetConfig{PhaseShift: layerDuration}),
+		BuilderAtxVersions(AtxVersions{postGenesisEpoch + 2: types.AtxV2}))
+	sig := maps.Values(tab.signers)[0]
+
+	prevAtx := newInitialATXv1(t, tab.goldenATXID)
+	prevAtx.Sign(sig)
+	require.NoError(t, atxs.Add(tab.db, toAtx(t, prevAtx)))
+
+	posEpoch := prevAtx.PublishEpoch
+	layer := posEpoch.FirstLayer()
+
+	// create and publish ATX V1
+	tab.mclock.EXPECT().CurrentLayer().Return(layer).Times(4)
+	atx1 := publishAtxV1(t, tab, sig.NodeID(), posEpoch, &layer, layersPerEpoch)
+	require.NotNil(t, atx1)
+
+	// create and publish ATX V2
+	posEpoch = postGenesisEpoch + 1
+	layer = posEpoch.FirstLayer()
+	tab.mclock.EXPECT().CurrentLayer().Return(layer).Times(4)
+	tab.mValidator.EXPECT().VerifyChain(gomock.Any(), atx1.ID(), tab.goldenATXID, gomock.Any())
+	var atx2 wire.ActivationTxV2
+	publishAtx(t, tab, sig.NodeID(), posEpoch, &layer, layersPerEpoch,
+		func(_ context.Context, _ string, got []byte) error {
+			return codec.Decode(got, &atx2)
+		})
+	require.NotNil(t, atx2)
+	require.Equal(t, atx1.ID(), atx2.PreviousATXs[0])
+	require.Equal(t, atx1.ID(), atx2.PositioningATX)
+	require.Nil(t, atx2.Initial)
+	require.Nil(t, atx2.MarriageATX)
+	require.Empty(t, atx2.Marriages)
+	require.Equal(t, atx1.PublishEpoch+1, atx2.PublishEpoch)
+	require.Equal(t, sig.NodeID(), atx2.SmesherID)
+	require.True(t, signing.NewEdVerifier().Verify(signing.ATX, atx2.SmesherID, atx2.SignedBytes(), atx2.Signature))
+}

--- a/activation/builder_v2_test.go
+++ b/activation/builder_v2_test.go
@@ -56,7 +56,6 @@ func TestBuilder_BuildsInitialAtxV2(t *testing.T) {
 			require.NoError(t, atxHandler.HandleGossipAtx(context.Background(), "", got))
 			return nil
 		})
-	require.NotNil(t, atx)
 	require.Empty(t, atx.PreviousATXs)
 	require.Equal(t, tab.goldenATXID, atx.PositioningATX)
 	require.NotNil(t, atx.Initial)
@@ -97,7 +96,6 @@ func TestBuilder_SwitchesToBuildV2(t *testing.T) {
 		func(_ context.Context, _ string, got []byte) error {
 			return codec.Decode(got, &atx2)
 		})
-	require.NotNil(t, atx2)
 	require.Equal(t, atx1.ID(), atx2.PreviousATXs[0])
 	require.Equal(t, atx1.ID(), atx2.PositioningATX)
 	require.Nil(t, atx2.Initial)
@@ -106,4 +104,48 @@ func TestBuilder_SwitchesToBuildV2(t *testing.T) {
 	require.Equal(t, atx1.PublishEpoch+1, atx2.PublishEpoch)
 	require.Equal(t, sig.NodeID(), atx2.SmesherID)
 	require.True(t, signing.NewEdVerifier().Verify(signing.ATX, atx2.SmesherID, atx2.SignedBytes(), atx2.Signature))
+}
+
+func TestBuilder_PopulatingCoinbase(t *testing.T) {
+	tab := newTestBuilder(t, 1,
+		WithPoetConfig(PoetConfig{PhaseShift: layerDuration}),
+		BuilderAtxVersions(AtxVersions{2: types.AtxV2}))
+	sig := maps.Values(tab.signers)[0]
+
+	coinbase0 := types.Address{1, 2, 3, 4}
+	tab.SetCoinbase(coinbase0)
+
+	prevAtx := newInitialATXv1(t, tab.goldenATXID)
+	prevAtx.Coinbase = coinbase0
+	prevAtx.PublishEpoch = 1
+	prevAtx.Sign(sig)
+	require.NoError(t, atxs.Add(tab.db, toAtx(t, prevAtx)))
+
+	posEpoch := prevAtx.PublishEpoch
+	layer := posEpoch.FirstLayer()
+
+	// create and publish ATX V2
+	// it shouldn't have a coinbase because it is the same as in the previous ATX
+	tab.mclock.EXPECT().CurrentLayer().Return(layer).Times(4)
+	var atx1 wire.ActivationTxV2
+	publishAtx(t, tab, sig.NodeID(), posEpoch, &layer, layersPerEpoch,
+		func(_ context.Context, _ string, got []byte) error {
+			return codec.Decode(got, &atx1)
+		})
+	require.Nil(t, atx1.Coinbase)
+
+	// change coinbase and publish again
+	// it should have a coinbase because it is different from the one in the previous ATX
+	coinbase1 := types.Address{5, 6, 7, 8}
+	tab.SetCoinbase(coinbase1)
+
+	posEpoch += 1
+	layer = posEpoch.FirstLayer()
+	tab.mclock.EXPECT().CurrentLayer().Return(layer).Times(4)
+	var atx2 wire.ActivationTxV2
+	publishAtx(t, tab, sig.NodeID(), posEpoch, &layer, layersPerEpoch,
+		func(_ context.Context, _ string, got []byte) error {
+			return codec.Decode(got, &atx2)
+		})
+	require.Equal(t, coinbase1, *atx2.Coinbase)
 }

--- a/activation/e2e/activation_test.go
+++ b/activation/e2e/activation_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/spacemeshos/poet/registration"
 	poetShared "github.com/spacemeshos/poet/shared"
-	"github.com/spacemeshos/post/initialization"
 	"github.com/spacemeshos/post/verifying"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -67,12 +66,9 @@ func Test_BuilderWithMultipleClients(t *testing.T) {
 	grpcCfg, cleanup := launchServer(t, svc)
 	t.Cleanup(cleanup)
 
-	opts := activation.DefaultPostSetupOpts()
-	opts.ProviderID.SetUint32(initialization.CPUProviderID())
-	opts.Scrypt.N = 2 // Speedup initialization in tests.
-
 	var eg errgroup.Group
 	i := uint32(1)
+	opts := testPostSetupOpts(t)
 	for _, sig := range signers {
 		opts := opts
 		opts.DataDir = t.TempDir()

--- a/activation/e2e/builds_atx_v2_test.go
+++ b/activation/e2e/builds_atx_v2_test.go
@@ -1,0 +1,253 @@
+package activation_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/spacemeshos/post/initialization"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/spacemeshos/go-spacemesh/activation"
+	"github.com/spacemeshos/go-spacemesh/activation/wire"
+	"github.com/spacemeshos/go-spacemesh/api/grpcserver"
+	"github.com/spacemeshos/go-spacemesh/atxsdata"
+	"github.com/spacemeshos/go-spacemesh/codec"
+	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/datastore"
+	"github.com/spacemeshos/go-spacemesh/p2p/pubsub"
+	"github.com/spacemeshos/go-spacemesh/p2p/pubsub/mocks"
+	"github.com/spacemeshos/go-spacemesh/signing"
+	"github.com/spacemeshos/go-spacemesh/sql"
+	"github.com/spacemeshos/go-spacemesh/sql/atxs"
+	"github.com/spacemeshos/go-spacemesh/sql/localsql"
+	smocks "github.com/spacemeshos/go-spacemesh/system/mocks"
+	"github.com/spacemeshos/go-spacemesh/timesync"
+)
+
+func testPostSetupOpts(t *testing.T) activation.PostSetupOpts {
+	t.Helper()
+	opts := activation.DefaultPostSetupOpts()
+	opts.ProviderID.SetUint32(initialization.CPUProviderID())
+	opts.Scrypt.N = 2 // Speedup initialization in tests.
+
+	opts.DataDir = t.TempDir()
+	opts.NumUnits = 4
+	return opts
+}
+
+func TestBuilder_SwitchesToBuildV2(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	logger := zaptest.NewLogger(t)
+	goldenATX := types.ATXID{2, 3, 4}
+	coinbase := types.Address{1, 2, 3, 4, 5, 6, 7, 8}
+
+	sig, err := signing.NewEdSigner()
+	require.NoError(t, err)
+
+	cfg := activation.DefaultPostConfig()
+	db := sql.InMemory()
+	cdb := datastore.NewCachedDB(db, logger)
+
+	syncer := activation.NewMocksyncer(ctrl)
+	syncer.EXPECT().RegisterForATXSynced().DoAndReturn(func() <-chan struct{} {
+		synced := make(chan struct{})
+		close(synced)
+		return synced
+	}).AnyTimes()
+
+	svc := grpcserver.NewPostService(logger)
+	svc.AllowConnections(true)
+	grpcCfg, cleanup := launchServer(t, svc)
+	t.Cleanup(cleanup)
+
+	poetDb := activation.NewPoetDb(db, logger.Named("poetDb"))
+	verifier, err := activation.NewPostVerifier(cfg, logger.Named("verifier"))
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, verifier.Close()) })
+	opts := testPostSetupOpts(t)
+	validator := activation.NewValidator(db, poetDb, cfg, opts.Scrypt, verifier)
+
+	atxsdata := atxsdata.New()
+	mgr, err := activation.NewPostSetupManager(cfg, logger, cdb, atxsdata, goldenATX, syncer, validator)
+	require.NoError(t, err)
+
+	initPost(t, mgr, opts, sig.NodeID())
+	stop := launchPostSupervisor(t, logger, mgr, sig, grpcCfg, opts)
+	t.Cleanup(stop)
+
+	require.Eventually(t, func() bool {
+		_, err := svc.Client(sig.NodeID())
+		return err == nil
+	}, 10*time.Second, 100*time.Millisecond, "timed out waiting for connection")
+
+	// ensure that genesis aligns with layer timings
+	genesis := time.Now().Add(layerDuration).Round(layerDuration)
+	layerDuration := 2 * time.Second
+	epoch := layersPerEpoch * layerDuration
+	poetCfg := activation.PoetConfig{
+		PhaseShift:        epoch,
+		CycleGap:          epoch / 2,
+		GracePeriod:       epoch / 5,
+		RequestTimeout:    epoch / 5,
+		RequestRetryDelay: epoch / 50,
+		MaxRequestRetries: 10,
+	}
+	poetProver := spawnPoet(
+		t,
+		WithGenesis(genesis),
+		WithEpochDuration(epoch),
+		WithPhaseShift(poetCfg.PhaseShift),
+		WithCycleGap(poetCfg.CycleGap),
+	)
+
+	clock, err := timesync.NewClock(
+		timesync.WithGenesisTime(genesis),
+		timesync.WithLayerDuration(layerDuration),
+		timesync.WithTickInterval(100*time.Millisecond),
+		timesync.WithLogger(zap.NewNop()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(clock.Close)
+
+	client, err := activation.NewPoetClient(
+		poetDb,
+		poetProver.ServerCfg(),
+		poetCfg,
+		logger,
+	)
+	require.NoError(t, err)
+
+	postStates := activation.NewMockPostStates(ctrl)
+	localDB := localsql.InMemory()
+	nb, err := activation.NewNIPostBuilder(
+		localDB,
+		svc,
+		logger.Named("nipostBuilder"),
+		poetCfg,
+		clock,
+		activation.NipostbuilderWithPostStates(postStates),
+		activation.WithPoetClients(client),
+	)
+	require.NoError(t, err)
+
+	conf := activation.Config{
+		GoldenATXID:      goldenATX,
+		RegossipInterval: 0,
+	}
+
+	atxVersions := activation.AtxVersions{postGenesisEpoch: types.AtxV2}
+	edVerifier := signing.NewEdVerifier()
+	mpub := mocks.NewMockPublisher(ctrl)
+	mFetch := smocks.NewMockFetcher(ctrl)
+	mBeacon := activation.NewMockAtxReceiver(ctrl)
+	mTortoise := smocks.NewMockTortoise(ctrl)
+
+	atxHdlr := activation.NewHandler(
+		"local",
+		cdb,
+		atxsdata,
+		edVerifier,
+		clock,
+		mpub,
+		mFetch,
+		goldenATX,
+		validator,
+		mBeacon,
+		mTortoise,
+		logger,
+		activation.WithAtxVersions(atxVersions),
+	)
+
+	var previous *types.ActivationTx
+	gomock.InOrder(
+		mpub.EXPECT().Publish(gomock.Any(), pubsub.AtxProtocol, gomock.Any()).DoAndReturn(
+			func(ctx context.Context, _ string, msg []byte) error {
+				var watx wire.ActivationTxV1
+				codec.MustDecode(msg, &watx)
+
+				require.Equal(t, sig.NodeID(), watx.SmesherID)
+				require.EqualValues(t, 1, watx.PublishEpoch)
+				require.Equal(t, types.EmptyATXID, watx.PrevATXID)
+				require.Equal(t, goldenATX, watx.PositioningATXID)
+				require.Equal(t, coinbase, watx.Coinbase)
+
+				mFetch.EXPECT().RegisterPeerHashes(peer.ID("peer"), gomock.Any())
+				mFetch.EXPECT().GetPoetProof(gomock.Any(), gomock.Any())
+				mBeacon.EXPECT().OnAtx(gomock.Any())
+				mTortoise.EXPECT().OnAtx(watx.PublishEpoch+1, watx.ID(), gomock.Any())
+
+				require.NoError(t, atxHdlr.HandleGossipAtx(ctx, "peer", msg))
+
+				atx, err := atxs.Get(db, watx.ID())
+				require.NoError(t, err)
+				previous = atx
+				return nil
+			},
+		),
+		mpub.EXPECT().Publish(gomock.Any(), pubsub.AtxProtocol, gomock.Any()).DoAndReturn(
+			func(ctx context.Context, _ string, msg []byte) error {
+				var watx wire.ActivationTxV2
+				codec.MustDecode(msg, &watx)
+
+				require.Equal(t, sig.NodeID(), watx.SmesherID)
+				require.EqualValues(t, previous.PublishEpoch+1, watx.PublishEpoch)
+				require.Equal(t, previous.ID(), watx.PreviousATXs[0])
+				require.Equal(t, previous.ID(), watx.PositioningATX)
+				require.Equal(t, coinbase, *watx.Coinbase) // TODO: populate coinbase only when it changed
+
+				mFetch.EXPECT().RegisterPeerHashes(peer.ID("peer"), gomock.Any())
+				mFetch.EXPECT().GetPoetProof(gomock.Any(), gomock.Any())
+				mFetch.EXPECT().GetAtxs(gomock.Any(), gomock.Any(), gomock.Any())
+				mBeacon.EXPECT().OnAtx(gomock.Any())
+				mTortoise.EXPECT().OnAtx(gomock.Any(), gomock.Any(), gomock.Any())
+				require.NoError(t, atxHdlr.HandleGossipAtx(ctx, "peer", msg))
+
+				atx, err := atxs.Get(db, watx.ID())
+				require.NoError(t, err)
+				require.Equal(t, opts.NumUnits, atx.NumUnits)
+				require.Equal(t, coinbase, atx.Coinbase)
+				return nil
+			},
+		),
+	)
+
+	tab := activation.NewBuilder(
+		conf,
+		db,
+		atxsdata,
+		localDB,
+		mpub,
+		nb,
+		clock,
+		syncer,
+		logger,
+		activation.WithPoetConfig(poetCfg),
+		activation.WithValidator(validator),
+		activation.WithPostStates(postStates),
+		activation.BuilderAtxVersions(atxVersions),
+	)
+	gomock.InOrder(
+		// it starts by setting to IDLE
+		postStates.EXPECT().Set(sig.NodeID(), types.PostStateIdle),
+		// initial proof
+		postStates.EXPECT().Set(sig.NodeID(), types.PostStateProving),
+		postStates.EXPECT().Set(sig.NodeID(), types.PostStateIdle),
+		// post proof - 1st epoch
+		postStates.EXPECT().Set(sig.NodeID(), types.PostStateProving),
+		postStates.EXPECT().Set(sig.NodeID(), types.PostStateIdle),
+		// 2nd epoch
+		postStates.EXPECT().Set(sig.NodeID(), types.PostStateProving),
+		postStates.EXPECT().Set(sig.NodeID(), types.PostStateIdle),
+	)
+	tab.Register(sig)
+
+	require.NoError(t, tab.StartSmeshing(coinbase))
+	require.Eventually(t, ctrl.Satisfied, epoch*3, time.Second)
+	require.NoError(t, tab.StopSmeshing(false))
+}

--- a/activation/e2e/builds_atx_v2_test.go
+++ b/activation/e2e/builds_atx_v2_test.go
@@ -212,6 +212,12 @@ func TestBuilder_SwitchesToBuildV2(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, opts.NumUnits, atx.NumUnits)
 				require.Equal(t, coinbase, atx.Coinbase)
+
+				require.NotZero(t, atx.BaseTickHeight)
+				require.NotZero(t, atx.TickCount)
+				require.NotZero(t, atx.GetWeight())
+				require.NotZero(t, atx.TickHeight())
+				require.Equal(t, opts.NumUnits, atx.NumUnits)
 				return nil
 			},
 		),

--- a/activation/e2e/builds_atx_v2_test.go
+++ b/activation/e2e/builds_atx_v2_test.go
@@ -218,9 +218,10 @@ func TestBuilder_SwitchesToBuildV2(t *testing.T) {
 				require.NotZero(t, atx.GetWeight())
 				require.NotZero(t, atx.TickHeight())
 				require.Equal(t, opts.NumUnits, atx.NumUnits)
+				previous = atx
 				return nil
 			},
-		),
+		).Times(2),
 	)
 
 	tab := activation.NewBuilder(
@@ -250,10 +251,13 @@ func TestBuilder_SwitchesToBuildV2(t *testing.T) {
 		// 2nd epoch
 		postStates.EXPECT().Set(sig.NodeID(), types.PostStateProving),
 		postStates.EXPECT().Set(sig.NodeID(), types.PostStateIdle),
+		// 3rd epoch
+		postStates.EXPECT().Set(sig.NodeID(), types.PostStateProving),
+		postStates.EXPECT().Set(sig.NodeID(), types.PostStateIdle),
 	)
 	tab.Register(sig)
 
 	require.NoError(t, tab.StartSmeshing(coinbase))
-	require.Eventually(t, ctrl.Satisfied, epoch*3, time.Second)
+	require.Eventually(t, ctrl.Satisfied, epoch*4, time.Second)
 	require.NoError(t, tab.StopSmeshing(false))
 }

--- a/activation/e2e/builds_atx_v2_test.go
+++ b/activation/e2e/builds_atx_v2_test.go
@@ -199,7 +199,7 @@ func TestBuilder_SwitchesToBuildV2(t *testing.T) {
 				require.EqualValues(t, previous.PublishEpoch+1, watx.PublishEpoch)
 				require.Equal(t, previous.ID(), watx.PreviousATXs[0])
 				require.Equal(t, previous.ID(), watx.PositioningATX)
-				require.Equal(t, coinbase, *watx.Coinbase) // TODO: populate coinbase only when it changed
+				require.Nil(t, watx.Coinbase)
 
 				mFetch.EXPECT().RegisterPeerHashes(peer.ID("peer"), gomock.Any())
 				mFetch.EXPECT().GetPoetProof(gomock.Any(), gomock.Any())

--- a/activation/handler_test.go
+++ b/activation/handler_test.go
@@ -113,6 +113,7 @@ func toAtx(t testing.TB, watx *wire.ActivationTxV1) *types.ActivationTx {
 	t.Helper()
 	atx := wire.ActivationTxFromWireV1(watx)
 	atx.SetReceived(time.Now())
+	atx.BaseTickHeight = uint64(atx.PublishEpoch)
 	atx.TickCount = 1
 	return atx
 }

--- a/activation/handler_v2.go
+++ b/activation/handler_v2.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/spacemeshos/post/shared"
@@ -481,7 +482,7 @@ func (h *HandlerV2) syntacticallyValidateDeps(
 	// For a merged ATX we need to fetch the equivocation this smesher is part of.
 	equivocationSet := []types.NodeID{atx.SmesherID}
 	var totalEffectiveNumUnits uint32
-	var minLeaves uint64
+	var minLeaves uint64 = math.MaxUint64
 	var smesherCommitment *types.ATXID
 	for _, niposts := range atx.NiPosts {
 		// verify PoET memberships in a single go

--- a/activation/handler_v2_test.go
+++ b/activation/handler_v2_test.go
@@ -29,6 +29,8 @@ type v2TestHandler struct {
 	handlerMocks
 }
 
+const poetLeaves = 200
+
 func newV2TestHandler(tb testing.TB, golden types.ATXID) *v2TestHandler {
 	lg := zaptest.NewLogger(tb)
 	cdb := datastore.NewCachedDB(sql.InMemory(), lg)
@@ -76,7 +78,7 @@ func (h *handlerMocks) expectVerifyNIPoST(atx *wire.ActivationTxV2) {
 		gomock.Any(),
 		atx.NiPosts[0].Challenge,
 		gomock.Any(),
-	)
+	).Return(poetLeaves, nil)
 }
 
 func (h *handlerMocks) expectStoreAtxV2(atx *wire.ActivationTxV2) {
@@ -413,8 +415,14 @@ func TestHandlerV2_ProcessSoloATX(t *testing.T) {
 		require.NoError(t, err)
 		require.Nil(t, proof)
 
-		_, err = atxs.Get(atxHandler.cdb, atx.ID())
+		atxFromDb, err := atxs.Get(atxHandler.cdb, atx.ID())
 		require.NoError(t, err)
+		require.NotNil(t, atx)
+		require.Equal(t, atx.ID(), atxFromDb.ID())
+		require.Equal(t, *atx.Coinbase, atxFromDb.Coinbase)
+		require.EqualValues(t, poetLeaves, atxFromDb.TickCount)
+		require.EqualValues(t, poetLeaves, atxFromDb.TickHeight())
+		require.Equal(t, atx.NiPosts[0].Posts[0].NumUnits, atxFromDb.NumUnits)
 
 		// processing ATX for the second time should skip checks
 		proof, err = atxHandler.processATX(context.Background(), peer, atx, blob, time.Now())

--- a/activation/handler_v2_test.go
+++ b/activation/handler_v2_test.go
@@ -111,7 +111,7 @@ func (h *handlerMocks) expectInitialAtxV2(atx *wire.ActivationTxV2) {
 }
 
 func (h *handlerMocks) expectAtxV2(atx *wire.ActivationTxV2) {
-	h.mclock.EXPECT().CurrentLayer().Return(postGenesisEpoch.FirstLayer())
+	h.mclock.EXPECT().CurrentLayer().Return(atx.PublishEpoch.FirstLayer())
 	h.expectFetchDeps(atx)
 	h.expectVerifyNIPoST(atx)
 	h.expectStoreAtxV2(atx)

--- a/activation/validation_test.go
+++ b/activation/validation_test.go
@@ -576,6 +576,54 @@ func TestVerifyChainDeps(t *testing.T) {
 		require.ErrorIs(t, err, &InvalidChainError{ID: vAtx.ID()})
 		require.ErrorIs(t, err, expected)
 	})
+
+	t.Run("initial V2 ATX", func(t *testing.T) {
+		watx := newInitialATXv2(t, goldenATXID)
+		watx.Sign(signer)
+		atx := &types.ActivationTx{
+			PublishEpoch: watx.PublishEpoch,
+			SmesherID:    watx.SmesherID,
+			AtxBlob: types.AtxBlob{
+				Blob:    watx.SignedBytes(),
+				Version: types.AtxV2,
+			},
+		}
+		atx.SetID(watx.ID())
+		require.NoError(t, atxs.Add(db, atx))
+
+		v := NewMockPostVerifier(gomock.NewController(t))
+		expectedPost := (*shared.Proof)(wire.PostFromWireV1(&watx.NiPosts[0].Posts[0].Post))
+		v.EXPECT().Verify(ctx, expectedPost, gomock.Any(), gomock.Any())
+		validator := NewValidator(db, nil, DefaultPostConfig(), config.ScryptParams{}, v)
+		err = validator.VerifyChain(ctx, watx.ID(), goldenATXID)
+		require.NoError(t, err)
+	})
+	t.Run("non-initial V2 ATX", func(t *testing.T) {
+		initialAtx := newInitialATXv1(t, goldenATXID)
+		initialAtx.Sign(signer)
+		require.NoError(t, atxs.Add(db, toAtx(t, initialAtx)))
+
+		watx := newSoloATXv2(t, initialAtx.PublishEpoch+1, initialAtx.ID(), initialAtx.ID())
+		watx.Sign(signer)
+		atx := &types.ActivationTx{
+			PublishEpoch: watx.PublishEpoch,
+			SmesherID:    watx.SmesherID,
+			AtxBlob: types.AtxBlob{
+				Blob:    watx.SignedBytes(),
+				Version: types.AtxV2,
+			},
+		}
+		atx.SetID(watx.ID())
+		require.NoError(t, atxs.Add(db, atx))
+
+		v := NewMockPostVerifier(gomock.NewController(t))
+		expectedPost := (*shared.Proof)(wire.PostFromWireV1(&watx.NiPosts[0].Posts[0].Post))
+		v.EXPECT().Verify(ctx, (*shared.Proof)(initialAtx.NIPost.Post), gomock.Any(), gomock.Any())
+		v.EXPECT().Verify(ctx, expectedPost, gomock.Any(), gomock.Any())
+		validator := NewValidator(db, nil, DefaultPostConfig(), config.ScryptParams{}, v)
+		err = validator.VerifyChain(ctx, watx.ID(), goldenATXID)
+		require.NoError(t, err)
+	})
 }
 
 func TestVerifyChainDepsAfterCheckpoint(t *testing.T) {

--- a/activation/validation_test.go
+++ b/activation/validation_test.go
@@ -14,6 +14,7 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"github.com/spacemeshos/go-spacemesh/activation/wire"
+	"github.com/spacemeshos/go-spacemesh/codec"
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/signing"
 	"github.com/spacemeshos/go-spacemesh/sql"
@@ -584,7 +585,7 @@ func TestVerifyChainDeps(t *testing.T) {
 			PublishEpoch: watx.PublishEpoch,
 			SmesherID:    watx.SmesherID,
 			AtxBlob: types.AtxBlob{
-				Blob:    watx.SignedBytes(),
+				Blob:    codec.MustEncode(watx),
 				Version: types.AtxV2,
 			},
 		}
@@ -609,7 +610,7 @@ func TestVerifyChainDeps(t *testing.T) {
 			PublishEpoch: watx.PublishEpoch,
 			SmesherID:    watx.SmesherID,
 			AtxBlob: types.AtxBlob{
-				Blob:    watx.SignedBytes(),
+				Blob:    codec.MustEncode(watx),
 				Version: types.AtxV2,
 			},
 		}

--- a/activation/wire/challenge_v2.go
+++ b/activation/wire/challenge_v2.go
@@ -37,3 +37,12 @@ func (c *NIPostChallengeV2) MarshalLogObject(encoder zapcore.ObjectEncoder) erro
 	encoder.AddObject("InitialPost", c.InitialPost)
 	return nil
 }
+
+func NIPostChallengeToWireV2(c *types.NIPostChallenge) *NIPostChallengeV2 {
+	return &NIPostChallengeV2{
+		PublishEpoch:     c.PublishEpoch,
+		PrevATXID:        c.PrevATXID,
+		PositioningATXID: c.PositioningATX,
+		InitialPost:      PostToWireV1(c.InitialPost),
+	}
+}

--- a/activation/wire/wire_v1.go
+++ b/activation/wire/wire_v1.go
@@ -138,7 +138,7 @@ func (atx *ActivationTxV1) HashInnerBytes() (result types.Hash32) {
 	return result
 }
 
-func postToWireV1(p *types.Post) *PostV1 {
+func PostToWireV1(p *types.Post) *PostV1 {
 	if p == nil {
 		return nil
 	}
@@ -159,7 +159,7 @@ func NiPostToWireV1(n *types.NIPost) *NIPostV1 {
 			Nodes:     n.Membership.Nodes,
 			LeafIndex: n.Membership.LeafIndex,
 		},
-		Post: postToWireV1(n.Post),
+		Post: PostToWireV1(n.Post),
 		PostMetadata: &PostMetadataV1{
 			Challenge:     n.PostMetadata.Challenge,
 			LabelsPerUnit: n.PostMetadata.LabelsPerUnit,
@@ -174,7 +174,7 @@ func NIPostChallengeToWireV1(c *types.NIPostChallenge) *NIPostChallengeV1 {
 		PrevATXID:        c.PrevATXID,
 		PositioningATXID: c.PositioningATX,
 		CommitmentATXID:  c.CommitmentATX,
-		InitialPost:      postToWireV1(c.InitialPost),
+		InitialPost:      PostToWireV1(c.InitialPost),
 	}
 }
 

--- a/activation/wire/wire_v2.go
+++ b/activation/wire/wire_v2.go
@@ -294,6 +294,8 @@ func (atx *ActivationTxV2) MarshalLogObject(encoder zapcore.ObjectEncoder) error
 	if atx == nil {
 		return nil
 	}
+	encoder.AddString("ID", atx.ID().String())
+	encoder.AddString("Smesher", atx.SmesherID.String())
 	encoder.AddUint32("PublishEpoch", atx.PublishEpoch.Uint32())
 	encoder.AddString("PositioningATX", atx.PositioningATX.String())
 	if atx.Coinbase != nil {

--- a/common/types/activation.go
+++ b/common/types/activation.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"encoding/hex"
+	"strconv"
 	"time"
 
 	"github.com/spacemeshos/go-scale"
@@ -148,6 +149,17 @@ const (
 	AtxV2   AtxVersion = 2
 	AtxVMAX AtxVersion = AtxV2
 )
+
+func (v AtxVersion) String() string {
+	switch v {
+	case AtxV1:
+		return "V1"
+	case AtxV2:
+		return "V2"
+	default:
+		return strconv.Itoa(int(v))
+	}
+}
 
 type AtxBlob struct {
 	Blob    []byte

--- a/log/zap.go
+++ b/log/zap.go
@@ -332,3 +332,11 @@ func (fl FieldLogger) Panic(msg string, fields ...LoggableField) {
 func (fl FieldLogger) Fatal(msg string, fields ...LoggableField) {
 	fl.l.Fatal(msg, unpack(append(fields, String("name", fl.name)))...)
 }
+
+// DebugField is only added if debug level is enabled.
+func DebugField(logger *zap.Logger, field zap.Field) zap.Field {
+	if logger.Core().Enabled(zap.DebugLevel) {
+		return field
+	}
+	return zap.Skip()
+}

--- a/node/node.go
+++ b/node/node.go
@@ -1040,7 +1040,6 @@ func (app *App) initServices(ctx context.Context) error {
 
 	builderConfig := activation.Config{
 		GoldenATXID:      goldenATXID,
-		LabelsPerUnit:    app.Config.POST.LabelsPerUnit,
 		RegossipInterval: app.Config.RegossipAtxInterval,
 	}
 	atxBuilder := activation.NewBuilder(

--- a/node/node.go
+++ b/node/node.go
@@ -1061,6 +1061,7 @@ func (app *App) initServices(ctx context.Context) error {
 		activation.WithPostValidityDelay(app.Config.PostValidDelay),
 		activation.WithPostStates(postStates),
 		activation.WithPoets(poetClients...),
+		activation.BuilderAtxVersions(app.Config.AtxVersions),
 	)
 	if len(app.signers) > 1 || app.signers[0].Name() != supervisedIDKeyFileName {
 		// in a remote setup we register eagerly so the atxBuilder can warn about missing connections asap.

--- a/systest/parameters/fastnet/smesher.json
+++ b/systest/parameters/fastnet/smesher.json
@@ -1,5 +1,10 @@
 {
     "preset": "fastnet",
+    "main": {
+        "atx-versions": {
+            "2": 2
+        }
+    },
     "poet": {
         "phase-shift": "30s",
         "cycle-gap": "30s",

--- a/systest/tests/distributed_post_verification_test.go
+++ b/systest/tests/distributed_post_verification_test.go
@@ -205,7 +205,7 @@ func TestPostMalfeasanceProof(t *testing.T) {
 
 		challenge = &wire.NIPostChallengeV1{
 			PrevATXID:        types.EmptyATXID,
-			PublishEpoch:     2,
+			PublishEpoch:     1,
 			PositioningATXID: goldenATXID,
 			CommitmentATXID:  &postInfo.CommitmentATX,
 			InitialPost: &wire.PostV1{


### PR DESCRIPTION
## Motivation

Add support for building solo (non-merged) ATX version 2. 

## Description
Closes #5995

## Test Plan

- [x] UT
- [x] e2e integration test testing the whole pipeline (builder together with handler)
- [x] manual tests in standalone mode 
- [x] systest

All system tests were updated to produce ATX V2 since epoch 2. The nodes will build 1 ATX with version 2 in epoch 1 and switch to ATX V2. The tests in `TestAddNodes` also verify that a node can join the network after V1->V2 switch happened (so they start with V2 initial ATX).

## TODO

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [ ] Update documentation as needed
- [ ] Update [changelog](../CHANGELOG.md) as needed
