### PR TITLE
[Merged by Bors] - api: v2alpha1 TransactionList: Fix typo in EndLayer filter

### DIFF
--- a/api/grpcserver/v2alpha1/transaction.go
+++ b/api/grpcserver/v2alpha1/transaction.go
@@ -270,7 +270,7 @@ func toTransactionOperations(filter *spacemeshv2alpha1.TransactionRequest) (buil
 
 	if filter.EndLayer != nil {
 		ops.Filter = append(ops.Filter, builder.Op{
-			Field: builder.Address,
+			Field: builder.Layer,
 			Token: builder.Lte,
 			Value: int64(filter.GetEndLayer()),
 		})

--- a/api/grpcserver/v2alpha1/transaction_test.go
+++ b/api/grpcserver/v2alpha1/transaction_test.go
@@ -132,6 +132,25 @@ func TestTransactionService_List(t *testing.T) {
 		require.Equal(t, spacemeshv2alpha1.TransactionResult_TRANSACTION_STATUS_SUCCESS,
 			list.Transactions[0].TxResult.Status)
 	})
+
+	t.Run("start layer & end layer", func(t *testing.T) {
+		layer := txsList[0].Layer.Uint32()
+
+		var expectedTxs []types.TransactionWithResult
+		for _, tx := range txsList {
+			if tx.Layer.Uint32() == layer {
+				expectedTxs = append(expectedTxs, tx)
+			}
+		}
+
+		list, err := client.List(ctx, &spacemeshv2alpha1.TransactionRequest{
+			StartLayer: &layer,
+			EndLayer:   &layer,
+			Limit:      100,
+		})
+		require.NoError(t, err)
+		require.Len(t, list.Transactions, len(expectedTxs))
+	})
 }
 
 func TestTransactionService_EstimateGas(t *testing.T) {


### PR DESCRIPTION
EndLayer filter used Address field instead of Layer to prepare SQL query.