### PR TITLE
[Merged by Bors] - Make dependabot ignore libp2p libs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: github.com/libp2p/*
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
     schedule:
       interval: "daily"
     ignore:
+      # Following cutting edge releases of libp2p is risky.
+      # Latest problem fixed here: https://github.com/libp2p/go-libp2p/pull/2825
+      # We need QUIC and routing discovery systest cases before we can re-enable
+      # dependabot for libp2p
       - dependency-name: github.com/libp2p/*
 
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## Motivation

libp2p/go-libp2p#2793 broke observed address handling and consequently routing discovery mechanism, too.
This is not the first time we're having problems because of (semi-)automatic libp2p dependency updates.
Prerequisite for re-enabling automatic updates of libp2p libs: QUIC and routing discovery systests

## Description

Add dependabot exception for libp2p libraries
