### PR TITLE
[Merged by Bors] - Skip installation of golangci-lint on windows runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,6 +192,12 @@ jobs:
         if: ${{ matrix.os == 'windows-2022' }}
         run: |
           Set-MpPreference -DisableRealtimeMonitoring $true
+      - name: Set new git config - Windows
+        if: ${{ matrix.os == 'windows-2022' }}
+        run: |
+          git config --global pack.window 1
+          git config --global core.compression 0
+          git config --global http.postBuffer 524288000
       - name: checkout
         uses: actions/checkout@v4
         with:
@@ -250,6 +256,12 @@ jobs:
         if: ${{ matrix.os == 'windows-2022' }}
         run: |
           Set-MpPreference -DisableRealtimeMonitoring $true
+      - name: Set new git config - Windows
+        if: ${{ matrix.os == 'windows-2022' }}
+        run: |
+          git config --global pack.window 1
+          git config --global core.compression 0
+          git config --global http.postBuffer 524288000
       - name: checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
     steps:
       - name: Add OpenCL support
         run: sudo apt-get update -q && sudo apt-get install -qy ocl-icd-opencl-dev libpocl2
+
       - name: checkout
         uses: actions/checkout@v4
         with:
@@ -139,6 +140,12 @@ jobs:
         if: ${{ matrix.os == 'windows-2022' }}
         run: |
           Set-MpPreference -DisableRealtimeMonitoring $true
+      - name: Set new git config - Windows
+        if: ${{ matrix.os == 'windows-2022' }}
+        run: |
+          git config --global pack.window 1
+          git config --global core.compression 0
+          git config --global http.postBuffer 524288000
       - name: checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,13 @@ jobs:
         run: |
           Set-MpPreference -DisableRealtimeMonitoring $true
 
+      - name: Set new git config - Windows
+        if: ${{ matrix.os == 'windows-2022' }}
+        run: |
+          git config --global pack.window 1
+          git config --global core.compression 0
+          git config --global http.postBuffer 524288000
+
       - name: Check out Git repository
         uses: actions/checkout@v4
         with:

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ VERSION ?= $(shell git describe --tags)
 COMMIT = $(shell git rev-parse HEAD)
 BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
 
-GOLANGCI_LINT_VERSION := tag/v1.57.0 # The golangci-lint install script is broken, so we use a specific tag. I'll open a PR to fix it.
+GOLANGCI_LINT_VERSION := v1.57.0
 STATICCHECK_VERSION := v0.4.7
 GOTESTSUM_VERSION := v1.11.0
 GOSCALE_VERSION := v1.2.0
@@ -56,7 +56,13 @@ all: install build
 install:
 	git lfs install
 	go mod download
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s $(GOLANGCI_LINT_VERSION)
+
+	ifeq ($(OS), Windows_NT)
+		go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+	else
+		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s $(GOLANGCI_LINT_VERSION)
+	endif
+
 	go install github.com/spacemeshos/go-scale/scalegen@$(GOSCALE_VERSION)
 	go install go.uber.org/mock/mockgen@$(MOCKGEN_VERSION)
 	go install gotest.tools/gotestsum@$(GOTESTSUM_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -53,15 +53,18 @@ FUZZTIME ?= "10s"
 all: install build
 .PHONY: all
 
+
+
+
 install:
 	git lfs install
 	go mod download
 
-	ifeq ($(OS), Windows_NT)
-		go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
-	else
-		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s $(GOLANGCI_LINT_VERSION)
-	endif
+ifeq ($(OS),Windows_NT)
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+else
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s $(GOLANGCI_LINT_VERSION)
+endif
 
 	go install github.com/spacemeshos/go-scale/scalegen@$(GOSCALE_VERSION)
 	go install go.uber.org/mock/mockgen@$(MOCKGEN_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ VERSION ?= $(shell git describe --tags)
 COMMIT = $(shell git rev-parse HEAD)
 BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
 
-GOLANGCI_LINT_VERSION := v1.57.0
+GOLANGCI_LINT_VERSION := tag/v1.57.0 # The golangci-lint install script is broken, so we use a specific tag. I'll open a PR to fix it.
 STATICCHECK_VERSION := v0.4.7
 GOTESTSUM_VERSION := v1.11.0
 GOSCALE_VERSION := v1.2.0

--- a/Makefile
+++ b/Makefile
@@ -53,16 +53,13 @@ FUZZTIME ?= "10s"
 all: install build
 .PHONY: all
 
-
-
-
 install:
 	git lfs install
 	go mod download
 
-ifeq ($(OS),Windows_NT)
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
-else
+ifneq ($(OS),Windows_NT)
+	# On GH windows runners this fails at the moment: https://github.com/actions/runner-images/issues/10009
+	# since we don't run the linter on windows in the CI, we can skip this step for now
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s $(GOLANGCI_LINT_VERSION)
 endif
 


### PR DESCRIPTION
## Motivation

Fix some issues we had on the GH Actions

## Description
This PR solves the issue with the git checkout on the windows runner and the installation of the golangci/lint on windows too.

## Test Plan
Run the CI workflow
