### PR TITLE
[Merged by Bors] - [ATX V2] Make VRF nonce and coinbase required

### DIFF
--- a/activation/e2e/builds_atx_v2_test.go
+++ b/activation/e2e/builds_atx_v2_test.go
@@ -199,7 +199,7 @@ func TestBuilder_SwitchesToBuildV2(t *testing.T) {
 				require.EqualValues(t, previous.PublishEpoch+1, watx.PublishEpoch)
 				require.Equal(t, previous.ID(), watx.PreviousATXs[0])
 				require.Equal(t, previous.ID(), watx.PositioningATX)
-				require.Nil(t, watx.Coinbase)
+				require.Equal(t, coinbase, watx.Coinbase)
 
 				mFetch.EXPECT().RegisterPeerHashes(peer.ID("peer"), gomock.Any())
 				mFetch.EXPECT().GetPoetProof(gomock.Any(), gomock.Any())

--- a/activation/handler_v2.go
+++ b/activation/handler_v2.go
@@ -112,18 +112,13 @@ func (h *HandlerV2) processATX(
 		return proof, err
 	}
 
-	coinbase, err := h.coinbase(ctx, watx)
-	if err != nil {
-		return nil, fmt.Errorf("getting coinbase: %w", err)
-	}
-
 	atx := &types.ActivationTx{
 		PublishEpoch:   watx.PublishEpoch,
-		Coinbase:       coinbase,
+		Coinbase:       watx.Coinbase,
 		NumUnits:       parts.effectiveUnits,
 		BaseTickHeight: baseTickHeight,
 		TickCount:      parts.leaves / h.tickSize,
-		VRFNonce:       parts.vrfNonce,
+		VRFNonce:       types.VRFPostIndex(watx.VRFNonce),
 		SmesherID:      watx.SmesherID,
 		AtxBlob:        types.AtxBlob{Blob: blob, Version: types.AtxV2},
 	}
@@ -190,20 +185,13 @@ func (h *HandlerV2) syntacticallyValidate(ctx context.Context, atx *wire.Activat
 		if atx.Initial.CommitmentATX == types.EmptyATXID {
 			return errors.New("initial atx missing commitment atx")
 		}
-		if atx.VRFNonce == nil {
-			return errors.New("initial atx missing vrf nonce")
-		}
 		if len(atx.PreviousATXs) != 0 {
 			return errors.New("initial atx must not have previous atxs")
 		}
 
-		if atx.Coinbase == nil {
-			return errors.New("initial atx missing coinbase")
-		}
-
 		numUnits := atx.NiPosts[0].Posts[0].NumUnits
 		if err := h.nipostValidator.VRFNonceV2(
-			atx.SmesherID, atx.Initial.CommitmentATX, *atx.VRFNonce, numUnits,
+			atx.SmesherID, atx.Initial.CommitmentATX, atx.VRFNonce, numUnits,
 		); err != nil {
 			return fmt.Errorf("invalid vrf nonce: %w", err)
 		}
@@ -306,13 +294,6 @@ func (h *HandlerV2) collectAtxDeps(atx *wire.ActivationTxV2) ([]types.Hash32, []
 	return maps.Keys(poetRefs), maps.Keys(filtered)
 }
 
-func (h *HandlerV2) coinbase(ctx context.Context, atx *wire.ActivationTxV2) (types.Address, error) {
-	if atx.Coinbase != nil {
-		return *atx.Coinbase, nil
-	}
-	return atxs.Coinbase(h.cdb, atx.SmesherID)
-}
-
 func (h *HandlerV2) previous(ctx context.Context, id types.ATXID) (opaqueAtx, error) {
 	var blob sql.Blob
 	version, err := atxs.LoadBlob(ctx, h.cdb, id[:], &blob)
@@ -380,39 +361,6 @@ func (h *HandlerV2) validatePreviousAtx(id types.NodeID, post *wire.SubPostV2, p
 	return 0, fmt.Errorf("unexpected previous ATX type: %T", prev)
 }
 
-// VRF nonce must be valid for the collected space of all included IDs.
-// TODO: support merged ATXs.
-func (h *HandlerV2) validateVrfNonce(
-	atx *wire.ActivationTxV2,
-	previous opaqueAtx,
-	commitment types.ATXID,
-) (types.VRFPostIndex, error) {
-	numUnits := atx.TotalNumUnits()
-	needRecheck := numUnits > previous.TotalNumUnits() || atx.VRFNonce != nil
-	var nonce types.VRFPostIndex
-	if atx.VRFNonce == nil {
-		// lookup the previous nonce by this ID
-		// TODO: support merged ATXs
-		// For a merged ATX we need to follow ATXs chain for `id`, find the last ATX by this ID
-		// and check the nonce from it.
-		if atx.MarriageATX != nil {
-			return 0, errors.New("merged ATXs are not supported")
-		}
-		n, err := atxs.NonceByID(h.cdb, previous.ID())
-		if err != nil {
-			return 0, fmt.Errorf("getting nonce from previous ATX %s: %w", previous.ID(), err)
-		}
-		nonce = n
-	} else {
-		nonce = types.VRFPostIndex(*atx.VRFNonce)
-	}
-
-	if needRecheck {
-		return nonce, h.nipostValidator.VRFNonceV2(atx.SmesherID, commitment, uint64(nonce), numUnits)
-	}
-	return nonce, nil
-}
-
 func (h *HandlerV2) validateCommitmentAtx(golden, commitmentAtxId types.ATXID, publish types.EpochID) error {
 	if commitmentAtxId != golden {
 		commitment, err := atxs.Get(h.cdb, commitmentAtxId)
@@ -450,7 +398,6 @@ func (h *HandlerV2) validatePositioningAtx(publish types.EpochID, golden, positi
 type atxParts struct {
 	leaves         uint64
 	effectiveUnits uint32
-	vrfNonce       types.VRFPostIndex
 }
 
 // Syntactically validate the ATX with its dependencies.
@@ -569,13 +516,10 @@ func (h *HandlerV2) syntacticallyValidateDeps(
 	}
 
 	if atx.Initial == nil {
-		n, err := h.validateVrfNonce(atx, previousAtxs[0], *smesherCommitment)
+		err := h.nipostValidator.VRFNonceV2(atx.SmesherID, *smesherCommitment, atx.VRFNonce, atx.TotalNumUnits())
 		if err != nil {
 			return nil, nil, fmt.Errorf("validating VRF nonce: %w", err)
 		}
-		parts.vrfNonce = n
-	} else {
-		parts.vrfNonce = types.VRFPostIndex(*atx.VRFNonce)
 	}
 
 	return parts, nil, nil

--- a/activation/handler_v2_test.go
+++ b/activation/handler_v2_test.go
@@ -92,7 +92,7 @@ func (h *handlerMocks) expectInitialAtxV2(atx *wire.ActivationTxV2) {
 	h.mValidator.EXPECT().VRFNonceV2(
 		atx.SmesherID,
 		atx.Initial.CommitmentATX,
-		*atx.VRFNonce,
+		atx.VRFNonce,
 		atx.NiPosts[0].Posts[0].NumUnits,
 	)
 	h.mValidator.EXPECT().PostV2(
@@ -112,6 +112,12 @@ func (h *handlerMocks) expectInitialAtxV2(atx *wire.ActivationTxV2) {
 
 func (h *handlerMocks) expectAtxV2(atx *wire.ActivationTxV2) {
 	h.mclock.EXPECT().CurrentLayer().Return(atx.PublishEpoch.FirstLayer())
+	h.mValidator.EXPECT().VRFNonceV2(
+		atx.SmesherID,
+		gomock.Any(),
+		atx.VRFNonce,
+		atx.NiPosts[0].Posts[0].NumUnits,
+	)
 	h.expectFetchDeps(atx)
 	h.expectVerifyNIPoST(atx)
 	h.expectStoreAtxV2(atx)
@@ -200,7 +206,7 @@ func TestHandlerV2_SyntacticallyValidate_InitialAtx(t *testing.T) {
 		atxHandler.mValidator.EXPECT().VRFNonceV2(
 			sig.NodeID(),
 			atx.Initial.CommitmentATX,
-			*atx.VRFNonce,
+			atx.VRFNonce,
 			atx.NiPosts[0].Posts[0].NumUnits,
 		)
 		atxHandler.mValidator.EXPECT().PostV2(
@@ -230,28 +236,6 @@ func TestHandlerV2_SyntacticallyValidate_InitialAtx(t *testing.T) {
 		atxHandler.mclock.EXPECT().CurrentLayer()
 		err = atxHandler.syntacticallyValidate(context.Background(), atx)
 		require.ErrorContains(t, err, "initial atx must not have previous atxs")
-	})
-	t.Run("rejects when VRF nonce is nil", func(t *testing.T) {
-		t.Parallel()
-		atx := newInitialATXv2(t, golden)
-		atx.VRFNonce = nil
-		atx.Sign(sig)
-
-		atxHandler := newV2TestHandler(t, golden)
-		atxHandler.mclock.EXPECT().CurrentLayer()
-		err := atxHandler.syntacticallyValidate(context.Background(), atx)
-		require.ErrorContains(t, err, "initial atx missing vrf nonce")
-	})
-	t.Run("rejects when Coinbase is nil", func(t *testing.T) {
-		t.Parallel()
-		atx := newInitialATXv2(t, golden)
-		atx.Coinbase = nil
-		atx.Sign(sig)
-
-		atxHandler := newV2TestHandler(t, golden)
-		atxHandler.mclock.EXPECT().CurrentLayer()
-		err := atxHandler.syntacticallyValidate(context.Background(), atx)
-		require.ErrorContains(t, err, "initial atx missing coinbase")
 	})
 	t.Run("rejects when marriage ATX ref is set", func(t *testing.T) {
 		t.Parallel()
@@ -286,7 +270,7 @@ func TestHandlerV2_SyntacticallyValidate_InitialAtx(t *testing.T) {
 			VRFNonceV2(
 				sig.NodeID(),
 				atx.Initial.CommitmentATX,
-				*atx.VRFNonce,
+				atx.VRFNonce,
 				atx.NiPosts[0].Posts[0].NumUnits,
 			).
 			Return(errors.New("invalid nonce"))
@@ -303,7 +287,7 @@ func TestHandlerV2_SyntacticallyValidate_InitialAtx(t *testing.T) {
 		atxHandler.mValidator.EXPECT().VRFNonceV2(
 			sig.NodeID(),
 			atx.Initial.CommitmentATX,
-			*atx.VRFNonce,
+			atx.VRFNonce,
 			atx.NiPosts[0].Posts[0].NumUnits,
 		)
 		atxHandler.mValidator.EXPECT().
@@ -419,7 +403,7 @@ func TestHandlerV2_ProcessSoloATX(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, atx)
 		require.Equal(t, atx.ID(), atxFromDb.ID())
-		require.Equal(t, *atx.Coinbase, atxFromDb.Coinbase)
+		require.Equal(t, atx.Coinbase, atxFromDb.Coinbase)
 		require.EqualValues(t, poetLeaves, atxFromDb.TickCount)
 		require.EqualValues(t, poetLeaves, atxFromDb.TickHeight())
 		require.Equal(t, atx.NiPosts[0].Posts[0].NumUnits, atxFromDb.NumUnits)
@@ -512,12 +496,6 @@ func TestHandlerV2_ProcessSoloATX(t *testing.T) {
 		atx.NiPosts[0].Posts[0].NumUnits *= 10
 		atx.Sign(sig)
 		atxHandler.expectAtxV2(atx)
-		atxHandler.mValidator.EXPECT().VRFNonceV2(
-			sig.NodeID(),
-			prev.Initial.CommitmentATX,
-			*prev.VRFNonce,
-			atx.TotalNumUnits(),
-		)
 
 		proof, err = atxHandler.processATX(context.Background(), peer, atx, codec.MustEncode(atx), time.Now())
 		require.NoError(t, err)
@@ -526,7 +504,7 @@ func TestHandlerV2_ProcessSoloATX(t *testing.T) {
 		// picks the VRF nonce from the previous ATX
 		atxFromDb, err := atxs.Get(atxHandler.cdb, atx.ID())
 		require.NoError(t, err)
-		require.EqualValues(t, *prev.VRFNonce, atxFromDb.VRFNonce)
+		require.EqualValues(t, prev.VRFNonce, atxFromDb.VRFNonce)
 	})
 	t.Run("second ATX, previous V2, increases space (no nonce, previous invalid)", func(t *testing.T) {
 		t.Parallel()
@@ -548,7 +526,7 @@ func TestHandlerV2_ProcessSoloATX(t *testing.T) {
 		atxHandler.mValidator.EXPECT().VRFNonceV2(
 			sig.NodeID(),
 			prev.Initial.CommitmentATX,
-			*prev.VRFNonce,
+			prev.VRFNonce,
 			atx.TotalNumUnits(),
 		).Return(errors.New("vrf nonce is not valid"))
 
@@ -571,17 +549,10 @@ func TestHandlerV2_ProcessSoloATX(t *testing.T) {
 		require.NoError(t, atxs.Add(atxHandler.cdb, prev))
 
 		atx := newSoloATXv2(t, prev.PublishEpoch+1, prev.ID(), golden)
-		newNonce := uint64(123)
-		atx.VRFNonce = &newNonce
+		atx.VRFNonce = uint64(123)
 		atx.NiPosts[0].Posts[0].NumUnits *= 10
 		atx.Sign(sig)
 		atxHandler.expectAtxV2(atx)
-		atxHandler.mValidator.EXPECT().VRFNonceV2(
-			sig.NodeID(),
-			*prev.CommitmentATX,
-			*atx.VRFNonce,
-			atx.TotalNumUnits(),
-		)
 
 		proof, err := atxHandler.processATX(context.Background(), peer, atx, codec.MustEncode(atx), time.Now())
 		require.NoError(t, err)
@@ -591,7 +562,7 @@ func TestHandlerV2_ProcessSoloATX(t *testing.T) {
 		atxFromDb, err := atxs.Get(atxHandler.cdb, atx.ID())
 		require.NoError(t, err)
 		require.Equal(t, lowerNumUnits, atxFromDb.TotalNumUnits())
-		require.EqualValues(t, newNonce, atxFromDb.VRFNonce)
+		require.EqualValues(t, atx.VRFNonce, atxFromDb.VRFNonce)
 	})
 	t.Run("can't find positioning ATX", func(t *testing.T) {
 		t.Parallel()
@@ -1097,8 +1068,6 @@ func TestHandlerV2_SyntacticallyValidateDeps(t *testing.T) {
 
 func newInitialATXv2(t testing.TB, golden types.ATXID) *wire.ActivationTxV2 {
 	t.Helper()
-	nonce := uint64(999)
-	coinbase := types.GenerateAddress([]byte("aaaa"))
 	atx := &wire.ActivationTxV2{
 		PositioningATX: golden,
 		Initial:        &wire.InitialAtxPartsV2{CommitmentATX: golden},
@@ -1112,8 +1081,8 @@ func newInitialATXv2(t testing.TB, golden types.ATXID) *wire.ActivationTxV2 {
 				},
 			},
 		},
-		Coinbase: &coinbase,
-		VRFNonce: &nonce,
+		Coinbase: types.GenerateAddress([]byte("aaaa")),
+		VRFNonce: uint64(999),
 	}
 
 	return atx
@@ -1136,6 +1105,8 @@ func newSoloATXv2(t testing.TB, publish types.EpochID, prev, pos types.ATXID) *w
 				},
 			},
 		},
+		Coinbase: types.GenerateAddress([]byte("aaaa")),
+		VRFNonce: uint64(999),
 	}
 
 	return atx

--- a/activation/wire/wire_v2_scale.go
+++ b/activation/wire/wire_v2_scale.go
@@ -24,7 +24,7 @@ func (t *ActivationTxV2) EncodeScale(enc *scale.Encoder) (total int, err error) 
 		total += n
 	}
 	{
-		n, err := scale.EncodeOption(enc, t.Coinbase)
+		n, err := scale.EncodeByteArray(enc, t.Coinbase[:])
 		if err != nil {
 			return total, err
 		}
@@ -52,7 +52,7 @@ func (t *ActivationTxV2) EncodeScale(enc *scale.Encoder) (total int, err error) 
 		total += n
 	}
 	{
-		n, err := scale.EncodeCompact64Ptr(enc, t.VRFNonce)
+		n, err := scale.EncodeCompact64(enc, uint64(t.VRFNonce))
 		if err != nil {
 			return total, err
 		}
@@ -106,12 +106,11 @@ func (t *ActivationTxV2) DecodeScale(dec *scale.Decoder) (total int, err error) 
 		total += n
 	}
 	{
-		field, n, err := scale.DecodeOption[types.Address](dec)
+		n, err := scale.DecodeByteArray(dec, t.Coinbase[:])
 		if err != nil {
 			return total, err
 		}
 		total += n
-		t.Coinbase = field
 	}
 	{
 		field, n, err := scale.DecodeOption[InitialAtxPartsV2](dec)
@@ -138,12 +137,12 @@ func (t *ActivationTxV2) DecodeScale(dec *scale.Decoder) (total int, err error) 
 		t.NiPosts = field
 	}
 	{
-		field, n, err := scale.DecodeCompact64Ptr(dec)
+		field, n, err := scale.DecodeCompact64(dec)
 		if err != nil {
 			return total, err
 		}
 		total += n
-		t.VRFNonce = field
+		t.VRFNonce = uint64(field)
 	}
 	{
 		field, n, err := scale.DecodeStructSliceWithLimit[MarriageCertificate](dec, 256)

--- a/activation/wire/wire_v2_test.go
+++ b/activation/wire/wire_v2_test.go
@@ -67,7 +67,6 @@ func Benchmark_ATXv2ID_WorstScenario(b *testing.B) {
 				Pow:     0,
 			}
 		}
-		atx.VRFNonce = new(uint64)
 		atx.MarriageATX = new(types.ATXID)
 		b.StartTimer()
 		atx.ID()


### PR DESCRIPTION
## Description

Make VRF nonce and coinbase required in ATX V2 to avoid having to do a costly search of the previous ATXs tree (potentially back to genesis) to find the ATX published by the same smesher ID.

## Test Plan

Tests pass

## TODO

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [ ] Update documentation as needed
- [ ] Update [changelog](../CHANGELOG.md) as needed
