### PR TITLE
[Merged by Bors] - AtxBuilder verification of initial PoST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,10 @@ operating your own PoET and want to use certificate authentication please refer 
   ATXs. This vulnerability allows an attacker to claim rewards for a full tick amount although they should not be
   eligible for them.
 
+* [#6031](https://github.com/spacemeshos/go-spacemesh/pull/6031) Fixed an edge case where the storage units might have
+  changed after the initial PoST was generated but before the first ATX has been emitted, invalidating the initial PoST.
+  The node will now try to verify the initial PoST and regenerate it if necessary.
+
 ## Release v1.5.7
 
 ### Improvements

--- a/activation/activation.go
+++ b/activation/activation.go
@@ -398,7 +398,6 @@ func (b *Builder) run(ctx context.Context, sig *signing.EdSigner) {
 
 BUILD:
 	for {
-		fmt.Println("build initial")
 		err := b.buildInitialPost(ctx, sig.NodeID())
 		if err == nil {
 			break
@@ -409,7 +408,6 @@ BUILD:
 		case <-ctx.Done():
 			return
 		case <-b.layerClock.AwaitLayer(currentLayer.Add(1)):
-			fmt.Println("got layer")
 		}
 	}
 	var eg errgroup.Group
@@ -425,7 +423,6 @@ BUILD:
 	eg.Wait()
 
 	for {
-		fmt.Println("publish atx")
 		err := b.PublishActivationTx(ctx, sig)
 		if err == nil {
 			continue

--- a/activation/activation.go
+++ b/activation/activation.go
@@ -354,7 +354,6 @@ func (b *Builder) buildInitialPost(ctx context.Context, nodeID types.NodeID) err
 	default:
 		return fmt.Errorf("get initial post: %w", err)
 	}
-
 	// Create the initial post and save it.
 	startTime := time.Now()
 	post, postInfo, err := b.nipostBuilder.Proof(ctx, nodeID, shared.ZeroChallenge, nil)
@@ -367,6 +366,7 @@ func (b *Builder) buildInitialPost(ctx context.Context, nodeID types.NodeID) err
 		)
 		return nilVrfNonce
 	}
+
 	initialPost := nipost.Post{
 		Nonce:     post.Nonce,
 		Indices:   post.Indices,

--- a/activation/activation.go
+++ b/activation/activation.go
@@ -338,36 +338,34 @@ func (b *Builder) SmesherIDs() []types.NodeID {
 	return maps.Keys(b.signers)
 }
 
-func (b *Builder) buildInitialPost(ctx context.Context, nodeID types.NodeID) (*nipost.Post, error) {
+func (b *Builder) buildInitialPost(ctx context.Context, nodeID types.NodeID) error {
 	// Generate the initial POST if we don't have an ATX...
 	if _, err := atxs.GetLastIDByNodeID(b.db, nodeID); err == nil {
-		panic(1)
-		return nil, nil
+		return nil
 	}
 	// ...and if we haven't stored an initial post yet.
-	dbPost, err := nipost.GetPost(b.localDB, nodeID)
-	panic(2)
+	_, err := nipost.GetPost(b.localDB, nodeID)
 	switch {
 	case err == nil:
 		b.logger.Info("load initial post from db")
-		return dbPost, nil
+		return nil
 	case errors.Is(err, sql.ErrNotFound):
 		b.logger.Info("creating initial post")
 	default:
-		return nil, fmt.Errorf("get initial post: %w", err)
+		return fmt.Errorf("get initial post: %w", err)
 	}
 
 	// Create the initial post and save it.
 	startTime := time.Now()
 	post, postInfo, err := b.nipostBuilder.Proof(ctx, nodeID, shared.ZeroChallenge, nil)
 	if err != nil {
-		return nil, fmt.Errorf("post execution: %w", err)
+		return fmt.Errorf("post execution: %w", err)
 	}
 	if postInfo.Nonce == nil {
 		b.logger.Error("initial PoST is invalid: missing VRF nonce. Check your PoST data",
 			log.ZShortStringer("smesherID", nodeID),
 		)
-		return nil, nilVrfNonce
+		return nilVrfNonce
 	}
 	initialPost := nipost.Post{
 		Nonce:     post.Nonce,
@@ -385,26 +383,22 @@ func (b *Builder) buildInitialPost(ctx context.Context, nodeID types.NodeID) (*n
 		if err := nipost.RemovePost(b.localDB, nodeID); err != nil {
 			b.logger.Fatal("failed to remove initial post", log.ZShortStringer("smesherID", nodeID), zap.Error(err))
 		}
-		return nil, fmt.Errorf("initial POST is invalid: %w", err)
+		return fmt.Errorf("initial POST is invalid: %w", err)
 	}
 
 	metrics.PostDuration.Set(float64(time.Since(startTime).Nanoseconds()))
 	public.PostSeconds.Set(float64(time.Since(startTime)))
 	b.logger.Info("created the initial post")
 
-	return &initialPost, nipost.AddPost(b.localDB, nodeID, initialPost)
+	return nipost.AddPost(b.localDB, nodeID, initialPost)
 }
 
 func (b *Builder) run(ctx context.Context, sig *signing.EdSigner) {
 	defer b.logger.Info("atx builder stopped")
-	var (
-		persistedPost *nipost.Post
-		err           error
-	)
 
 OUTER:
 	for {
-		persistedPost, err = b.buildInitialPost(ctx, sig.NodeID())
+		err := b.buildInitialPost(ctx, sig.NodeID())
 		if err == nil {
 			break
 		}
@@ -429,7 +423,7 @@ OUTER:
 	eg.Wait()
 
 	for {
-		err := b.PublishActivationTx(ctx, sig, persistedPost)
+		err := b.PublishActivationTx(ctx, sig)
 		if err == nil {
 			continue
 		} else if errors.Is(err, context.Canceled) {
@@ -646,7 +640,7 @@ func (b *Builder) Coinbase() types.Address {
 }
 
 // PublishActivationTx attempts to publish an atx, it returns an error if an atx cannot be created.
-func (b *Builder) PublishActivationTx(ctx context.Context, sig *signing.EdSigner, initialPost *nipost.Post) error {
+func (b *Builder) PublishActivationTx(ctx context.Context, sig *signing.EdSigner) error {
 	challenge, err := b.BuildNIPostChallenge(ctx, sig.NodeID())
 	if err != nil {
 		return err

--- a/activation/activation.go
+++ b/activation/activation.go
@@ -33,8 +33,8 @@ import (
 )
 
 var (
-	ErrNotFound = errors.New("not found")
-	nilVrfNonce = errors.New("nil VRF nonce")
+	ErrNotFound    = errors.New("not found")
+	errNilVrfNonce = errors.New("nil VRF nonce")
 )
 
 // PoetConfig is the configuration to interact with the poet server.
@@ -364,7 +364,7 @@ func (b *Builder) buildInitialPost(ctx context.Context, nodeID types.NodeID) err
 		b.logger.Error("initial PoST is invalid: missing VRF nonce. Check your PoST data",
 			log.ZShortStringer("smesherID", nodeID),
 		)
-		return nilVrfNonce
+		return errNilVrfNonce
 	}
 
 	initialPost := nipost.Post{

--- a/activation/activation_multi_test.go
+++ b/activation/activation_multi_test.go
@@ -252,12 +252,10 @@ func Test_Builder_Multi_InitialPost(t *testing.T) {
 				},
 				nil,
 			)
-			_, err := tab.buildInitialPost(context.Background(), sig.NodeID())
-			require.NoError(t, err)
+			require.NoError(t, tab.buildInitialPost(context.Background(), sig.NodeID()))
 
 			// postClient.Proof() should not be called again
-			_, err = tab.buildInitialPost(context.Background(), sig.NodeID())
-			require.NoError(t, err)
+			require.NoError(t, tab.buildInitialPost(context.Background(), sig.NodeID()))
 			return nil
 		})
 	}

--- a/activation/activation_multi_test.go
+++ b/activation/activation_multi_test.go
@@ -27,7 +27,7 @@ func Test_Builder_Multi_StartSmeshingCoinbase(t *testing.T) {
 
 	for _, sig := range tab.signers {
 		tab.mnipost.EXPECT().Proof(gomock.Any(), sig.NodeID(), shared.ZeroChallenge, nil).DoAndReturn(
-			func(ctx context.Context, _ types.NodeID, _ []byte, _ *nipost.Post) (*types.Post, *types.PostInfo, error) {
+			func(ctx context.Context, _ types.NodeID, _ []byte, _ *types.NIPostChallenge) (*types.Post, *types.PostInfo, error) {
 				<-ctx.Done()
 				return nil, nil, ctx.Err()
 			})
@@ -52,7 +52,7 @@ func Test_Builder_Multi_RestartSmeshing(t *testing.T) {
 
 		for _, sig := range tab.signers {
 			tab.mnipost.EXPECT().Proof(gomock.Any(), sig.NodeID(), shared.ZeroChallenge, nil).AnyTimes().DoAndReturn(
-				func(ctx context.Context, _ types.NodeID, _ []byte, _ *nipost.Post) (*types.Post, *types.PostInfo, error) {
+				func(ctx context.Context, _ types.NodeID, _ []byte, _ *types.NIPostChallenge) (*types.Post, *types.PostInfo, error) {
 					<-ctx.Done()
 					return nil, nil, ctx.Err()
 				})
@@ -110,7 +110,7 @@ func Test_Builder_Multi_StopSmeshing_Delete(t *testing.T) {
 
 	for _, sig := range tab.signers {
 		tab.mnipost.EXPECT().Proof(gomock.Any(), sig.NodeID(), shared.ZeroChallenge, nil).DoAndReturn(
-			func(ctx context.Context, _ types.NodeID, _ []byte, _ *nipost.Post) (*types.Post, *types.PostInfo, error) {
+			func(ctx context.Context, _ types.NodeID, _ []byte, _ *types.NIPostChallenge) (*types.Post, *types.PostInfo, error) {
 				<-ctx.Done()
 				return nil, nil, ctx.Err()
 			})
@@ -133,7 +133,7 @@ func Test_Builder_Multi_StopSmeshing_Delete(t *testing.T) {
 
 		tab.mnipost.EXPECT().ResetState(sig.NodeID()).Return(nil)
 		tab.mnipost.EXPECT().Proof(gomock.Any(), sig.NodeID(), shared.ZeroChallenge, nil).DoAndReturn(
-			func(ctx context.Context, _ types.NodeID, _ []byte, _ *nipost.Post) (*types.Post, *types.PostInfo, error) {
+			func(ctx context.Context, _ types.NodeID, _ []byte, _ *types.NIPostChallenge) (*types.Post, *types.PostInfo, error) {
 				<-ctx.Done()
 				return nil, nil, ctx.Err()
 			})
@@ -153,7 +153,7 @@ func Test_Builder_Multi_StopSmeshing_Delete(t *testing.T) {
 
 		tab.mnipost.EXPECT().ResetState(sig.NodeID()).Return(nil)
 		tab.mnipost.EXPECT().Proof(gomock.Any(), sig.NodeID(), shared.ZeroChallenge, nil).DoAndReturn(
-			func(ctx context.Context, _ types.NodeID, _ []byte, _ *nipost.Post) (*types.Post, *types.PostInfo, error) {
+			func(ctx context.Context, _ types.NodeID, _ []byte, _ *types.NIPostChallenge) (*types.Post, *types.PostInfo, error) {
 				<-ctx.Done()
 				return nil, nil, ctx.Err()
 			})
@@ -296,7 +296,7 @@ func Test_Builder_Multi_HappyPath(t *testing.T) {
 		tab.mValidator.EXPECT().
 			PostV2(gomock.Any(), sig.NodeID(), dbPost.CommitmentATX, post, shared.ZeroChallenge, dbPost.NumUnits)
 		tab.mnipost.EXPECT().Proof(gomock.Any(), sig.NodeID(), shared.ZeroChallenge, nil).DoAndReturn(
-			func(ctx context.Context, _ types.NodeID, _ []byte, _ *nipost.Post) (*types.Post, *types.PostInfo, error) {
+			func(ctx context.Context, _ types.NodeID, _ []byte, _ *types.NIPostChallenge) (*types.Post, *types.PostInfo, error) {
 				<-initialPostChan
 				close(ch)
 				post := &types.Post{

--- a/activation/activation_multi_test.go
+++ b/activation/activation_multi_test.go
@@ -28,7 +28,8 @@ func Test_Builder_Multi_StartSmeshingCoinbase(t *testing.T) {
 
 	for _, sig := range tab.signers {
 		tab.mnipost.EXPECT().Proof(gomock.Any(), sig.NodeID(), shared.ZeroChallenge, nil).DoAndReturn(
-			func(ctx context.Context, _ types.NodeID, _ []byte, _ *types.NIPostChallenge) (*types.Post, *types.PostInfo, error) {
+			func(ctx context.Context, _ types.NodeID, _ []byte, _ *types.NIPostChallenge,
+			) (*types.Post, *types.PostInfo, error) {
 				<-ctx.Done()
 				return nil, nil, ctx.Err()
 			})
@@ -53,7 +54,8 @@ func Test_Builder_Multi_RestartSmeshing(t *testing.T) {
 
 		for _, sig := range tab.signers {
 			tab.mnipost.EXPECT().Proof(gomock.Any(), sig.NodeID(), shared.ZeroChallenge, nil).AnyTimes().DoAndReturn(
-				func(ctx context.Context, _ types.NodeID, _ []byte, _ *types.NIPostChallenge) (*types.Post, *types.PostInfo, error) {
+				func(ctx context.Context, _ types.NodeID, _ []byte, _ *types.NIPostChallenge,
+				) (*types.Post, *types.PostInfo, error) {
 					<-ctx.Done()
 					return nil, nil, ctx.Err()
 				})
@@ -111,7 +113,8 @@ func Test_Builder_Multi_StopSmeshing_Delete(t *testing.T) {
 
 	for _, sig := range tab.signers {
 		tab.mnipost.EXPECT().Proof(gomock.Any(), sig.NodeID(), shared.ZeroChallenge, nil).DoAndReturn(
-			func(ctx context.Context, _ types.NodeID, _ []byte, _ *types.NIPostChallenge) (*types.Post, *types.PostInfo, error) {
+			func(ctx context.Context, _ types.NodeID, _ []byte, _ *types.NIPostChallenge,
+			) (*types.Post, *types.PostInfo, error) {
 				<-ctx.Done()
 				return nil, nil, ctx.Err()
 			})
@@ -134,7 +137,8 @@ func Test_Builder_Multi_StopSmeshing_Delete(t *testing.T) {
 
 		tab.mnipost.EXPECT().ResetState(sig.NodeID()).Return(nil)
 		tab.mnipost.EXPECT().Proof(gomock.Any(), sig.NodeID(), shared.ZeroChallenge, nil).DoAndReturn(
-			func(ctx context.Context, _ types.NodeID, _ []byte, _ *types.NIPostChallenge) (*types.Post, *types.PostInfo, error) {
+			func(ctx context.Context, _ types.NodeID, _ []byte, _ *types.NIPostChallenge,
+			) (*types.Post, *types.PostInfo, error) {
 				<-ctx.Done()
 				return nil, nil, ctx.Err()
 			})
@@ -154,7 +158,8 @@ func Test_Builder_Multi_StopSmeshing_Delete(t *testing.T) {
 
 		tab.mnipost.EXPECT().ResetState(sig.NodeID()).Return(nil)
 		tab.mnipost.EXPECT().Proof(gomock.Any(), sig.NodeID(), shared.ZeroChallenge, nil).DoAndReturn(
-			func(ctx context.Context, _ types.NodeID, _ []byte, _ *types.NIPostChallenge) (*types.Post, *types.PostInfo, error) {
+			func(ctx context.Context, _ types.NodeID, _ []byte, _ *types.NIPostChallenge,
+			) (*types.Post, *types.PostInfo, error) {
 				<-ctx.Done()
 				return nil, nil, ctx.Err()
 			})
@@ -295,7 +300,8 @@ func Test_Builder_Multi_HappyPath(t *testing.T) {
 		tab.mValidator.EXPECT().
 			PostV2(gomock.Any(), sig.NodeID(), dbPost.CommitmentATX, post, shared.ZeroChallenge, dbPost.NumUnits)
 		tab.mnipost.EXPECT().Proof(gomock.Any(), sig.NodeID(), shared.ZeroChallenge, nil).DoAndReturn(
-			func(ctx context.Context, _ types.NodeID, _ []byte, _ *types.NIPostChallenge) (*types.Post, *types.PostInfo, error) {
+			func(ctx context.Context, _ types.NodeID, _ []byte, _ *types.NIPostChallenge,
+			) (*types.Post, *types.PostInfo, error) {
 				<-initialPostChan
 				close(ch)
 				post := &types.Post{
@@ -400,7 +406,9 @@ func Test_Builder_Multi_HappyPath(t *testing.T) {
 		nipostState[sig.NodeID()] = state
 		tab.mnipost.EXPECT().
 			BuildNIPost(gomock.Any(), sig, ref.Hash(), gomock.Any()).
-			DoAndReturn(func(_ context.Context, _ *signing.EdSigner, _ types.Hash32, postChallenge *types.NIPostChallenge) (*nipost.NIPostState, error) {
+			DoAndReturn(func(_ context.Context, _ *signing.EdSigner, _ types.Hash32,
+				postChallenge *types.NIPostChallenge,
+			) (*nipost.NIPostState, error) {
 				require.Equal(t, postChallenge.PublishEpoch, ref.PublishEpoch, "publish epoch mismatch")
 				return state, nil
 			})

--- a/activation/activation_multi_test.go
+++ b/activation/activation_multi_test.go
@@ -398,7 +398,7 @@ func Test_Builder_Multi_HappyPath(t *testing.T) {
 		}
 		nipostState[sig.NodeID()] = state
 		tab.mnipost.EXPECT().
-			BuildNIPost(gomock.Any(), sig, ref.PublishEpoch, ref.Hash(), nil).
+			BuildNIPost(gomock.Any(), sig, ref.PublishEpoch, ref.Hash(), gomock.Any()).
 			Return(state, nil)
 
 		// awaiting atx publication epoch log

--- a/activation/activation_test.go
+++ b/activation/activation_test.go
@@ -172,7 +172,7 @@ func publishAtx(
 		LabelsPerUnit: DefaultPostConfig().LabelsPerUnit,
 	}, nil).AnyTimes()
 	tab.mnipost.EXPECT().BuildNIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, _ *signing.EdSigner, _ types.EpochID, _ types.Hash32, _ *nipost.Post) (*nipost.NIPostState, error) {
+		func(_ context.Context, _ *signing.EdSigner, _ types.EpochID, _ types.Hash32, _ *types.NIPostChallenge) (*nipost.NIPostState, error) {
 			*currLayer = currLayer.Add(buildNIPostLayerDuration)
 			return newNIPostWithPoet(tb, types.RandomHash().Bytes()), nil
 		})
@@ -202,7 +202,7 @@ func Test_Builder_StartSmeshingCoinbase(t *testing.T) {
 	coinbase := types.Address{1, 1, 1}
 
 	tab.mnipost.EXPECT().Proof(gomock.Any(), sig.NodeID(), shared.ZeroChallenge, nil).DoAndReturn(
-		func(ctx context.Context, _ types.NodeID, _ []byte, _ *nipost.Post) (*types.Post, *types.PostInfo, error) {
+		func(ctx context.Context, _ types.NodeID, _ []byte, _ *types.NIPostChallenge) (*types.Post, *types.PostInfo, error) {
 			<-ctx.Done()
 			return nil, nil, ctx.Err()
 		})
@@ -224,7 +224,7 @@ func TestBuilder_RestartSmeshing(t *testing.T) {
 		sig := maps.Values(tab.signers)[0]
 
 		tab.mnipost.EXPECT().Proof(gomock.Any(), sig.NodeID(), shared.ZeroChallenge, nil).AnyTimes().DoAndReturn(
-			func(ctx context.Context, _ types.NodeID, _ []byte, _ *nipost.Post) (*types.Post, *types.PostInfo, error) {
+			func(ctx context.Context, _ types.NodeID, _ []byte, _ *types.NIPostChallenge) (*types.Post, *types.PostInfo, error) {
 				<-ctx.Done()
 				return nil, nil, ctx.Err()
 			})
@@ -280,7 +280,7 @@ func TestBuilder_StopSmeshing_Delete(t *testing.T) {
 	tab.mclock.EXPECT().AwaitLayer(gomock.Any()).Return(make(chan struct{}))
 
 	tab.mnipost.EXPECT().Proof(gomock.Any(), sig.NodeID(), shared.ZeroChallenge, nil).DoAndReturn(
-		func(ctx context.Context, _ types.NodeID, _ []byte, _ *nipost.Post) (*types.Post, *types.PostInfo, error) {
+		func(ctx context.Context, _ types.NodeID, _ []byte, _ *types.NIPostChallenge) (*types.Post, *types.PostInfo, error) {
 			<-ctx.Done()
 			return nil, nil, ctx.Err()
 		})
@@ -301,7 +301,7 @@ func TestBuilder_StopSmeshing_Delete(t *testing.T) {
 
 	tab.mnipost.EXPECT().ResetState(sig.NodeID()).Return(nil)
 	tab.mnipost.EXPECT().Proof(gomock.Any(), sig.NodeID(), shared.ZeroChallenge, nil).DoAndReturn(
-		func(ctx context.Context, _ types.NodeID, _ []byte, _ *nipost.Post) (*types.Post, *types.PostInfo, error) {
+		func(ctx context.Context, _ types.NodeID, _ []byte, _ *types.NIPostChallenge) (*types.Post, *types.PostInfo, error) {
 			<-ctx.Done()
 			return nil, nil, ctx.Err()
 		})
@@ -319,7 +319,7 @@ func TestBuilder_StopSmeshing_Delete(t *testing.T) {
 
 	tab.mnipost.EXPECT().ResetState(sig.NodeID()).Return(nil)
 	tab.mnipost.EXPECT().Proof(gomock.Any(), sig.NodeID(), shared.ZeroChallenge, nil).DoAndReturn(
-		func(ctx context.Context, _ types.NodeID, _ []byte, _ *nipost.Post) (*types.Post, *types.PostInfo, error) {
+		func(ctx context.Context, _ types.NodeID, _ []byte, _ *types.NIPostChallenge) (*types.Post, *types.PostInfo, error) {
 			<-ctx.Done()
 			return nil, nil, ctx.Err()
 		})
@@ -452,7 +452,7 @@ func TestBuilder_PublishActivationTx_FaultyNet(t *testing.T) {
 		LabelsPerUnit: DefaultPostConfig().LabelsPerUnit,
 	}, nil).AnyTimes()
 	tab.mnipost.EXPECT().BuildNIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, _ *signing.EdSigner, _ types.EpochID, _ types.Hash32, _ *nipost.Post) (*nipost.NIPostState, error) {
+		func(_ context.Context, _ *signing.EdSigner, _ types.EpochID, _ types.Hash32, _ *types.NIPostChallenge) (*nipost.NIPostState, error) {
 			currLayer = currLayer.Add(layersPerEpoch)
 			return newNIPostWithPoet(t, []byte("66666")), nil
 		})
@@ -526,7 +526,7 @@ func TestBuilder_PublishActivationTx_UsesExistingChallengeOnLatePublish(t *testi
 		LabelsPerUnit: DefaultPostConfig().LabelsPerUnit,
 	}, nil).AnyTimes()
 	tab.mnipost.EXPECT().BuildNIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, _ *signing.EdSigner, _ types.EpochID, _ types.Hash32, _ *nipost.Post) (*nipost.NIPostState, error) {
+		func(_ context.Context, _ *signing.EdSigner, _ types.EpochID, _ types.Hash32, _ *types.NIPostChallenge) (*nipost.NIPostState, error) {
 			currLayer = currLayer.Add(1)
 			return newNIPostWithPoet(t, []byte("66666")), nil
 		})
@@ -595,7 +595,7 @@ func TestBuilder_PublishActivationTx_RebuildNIPostWhenTargetEpochPassed(t *testi
 			return genesis.Add(layerDuration * time.Duration(got))
 		}).AnyTimes()
 	tab.mnipost.EXPECT().BuildNIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, _ *signing.EdSigner, _ types.EpochID, _ types.Hash32, _ *nipost.Post) (*nipost.NIPostState, error) {
+		func(_ context.Context, _ *signing.EdSigner, _ types.EpochID, _ types.Hash32, _ *types.NIPostChallenge) (*nipost.NIPostState, error) {
 			currLayer = currLayer.Add(layersPerEpoch)
 			return newNIPostWithPoet(t, []byte("66666")), nil
 		})
@@ -825,7 +825,7 @@ func TestBuilder_PublishActivationTx_PrevATXWithoutPrevATX(t *testing.T) {
 	tab.mnipost.EXPECT().
 		BuildNIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		DoAndReturn(
-			func(_ context.Context, _ *signing.EdSigner, _ types.EpochID, _ types.Hash32, _ *nipost.Post) (*nipost.NIPostState, error) {
+			func(_ context.Context, _ *signing.EdSigner, _ types.EpochID, _ types.Hash32, _ *types.NIPostChallenge) (*nipost.NIPostState, error) {
 				currentLayer = currentLayer.Add(5)
 				return newNIPostWithPoet(t, poetBytes), nil
 			})
@@ -907,7 +907,7 @@ func TestBuilder_PublishActivationTx_TargetsEpochBasedOnPosAtx(t *testing.T) {
 	}, nil).AnyTimes()
 
 	tab.mnipost.EXPECT().BuildNIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, _ *signing.EdSigner, _ types.EpochID, _ types.Hash32, _ *nipost.Post) (*nipost.NIPostState, error) {
+		func(_ context.Context, _ *signing.EdSigner, _ types.EpochID, _ types.Hash32, _ *types.NIPostChallenge) (*nipost.NIPostState, error) {
 			currentLayer = currentLayer.Add(layersPerEpoch)
 			return newNIPostWithPoet(t, poetBytes), nil
 		})
@@ -1494,7 +1494,66 @@ func TestFindFullyValidHighTickAtx(t *testing.T) {
 // submitting the first ATX, which should result in the initial PoST to be deleted
 // and for the new PoST to be generated instead (this also loses the eligibility
 // for the current epoch).
-func Test_Builder_RegenerateInitialPost(t *testing.T) {
+func Test_Builder_RegenerateInitialPost_WithDbCopy(t *testing.T) {
+	tab := newTestBuilder(t, 1)
+	sig := maps.Values(tab.signers)[0]
+	//coinbase := types.Address{1, 1, 1}
+
+	//commitmentATX := types.RandomATXID()
+	//nonce := types.VRFPostIndex(rand.Uint64())
+	//numUnits := uint32(12)
+	//initialPost := &types.Post{
+	//Nonce:   rand.Uint32(),
+	//Indices: types.RandomBytes(10),
+	//Pow:     rand.Uint64(),
+	//}
+	//tab.mnipost.EXPECT().Proof(gomock.Any(), sig.NodeID(), shared.ZeroChallenge, nil).Return(
+	//initialPost,
+	//&types.PostInfo{
+	//NodeID:        sig.NodeID(),
+	//CommitmentATX: commitmentATX,
+	//Nonce:         &nonce,
+
+	//NumUnits:      numUnits,
+	//LabelsPerUnit: DefaultPostConfig().LabelsPerUnit,
+	//},
+	//nil,
+	//)
+	//tab.mValidator.EXPECT().
+	//PostV2(gomock.Any(), sig.NodeID(), commitmentATX, initialPost, shared.ZeroChallenge, numUnits)
+	// test setup is that we need an existing post in the localdb
+	post := nipost.Post{
+		Nonce:         1,
+		Indices:       []byte{1, 2, 3},
+		Pow:           12345,
+		Challenge:     []byte{2, 3, 5},
+		NumUnits:      2,
+		CommitmentATX: types.ATXID{},
+		VRFNonce:      types.VRFPostIndex(1),
+	}
+	if err := nipost.AddPost(tab.db, sig.NodeID(), post); err != nil {
+		t.Fatal(err)
+	}
+	_, err := tab.buildInitialPost(context.Background(), sig.NodeID())
+	panic(err)
+
+	//tab.mnipost.EXPECT().Proof(gomock.Any(), sig.NodeID(), shared.ZeroChallenge).DoAndReturn(
+	//func(ctx context.Context, _ types.NodeID, _ []byte) (*types.Post, *types.PostInfo, error) {
+	//<-ctx.Done()
+	//return nil, nil, ctx.Err()
+	//})
+	//tab.mclock.EXPECT().CurrentLayer().Return(types.LayerID(0)).AnyTimes()
+	//tab.mclock.EXPECT().AwaitLayer(gomock.Any()).Return(make(chan struct{})).AnyTimes()
+	//require.NoError(t, tab.StartSmeshing(coinbase))
+	//require.Equal(t, coinbase, tab.Coinbase())
+
+	//// calling StartSmeshing more than once before calling StopSmeshing is an error
+	//require.ErrorContains(t, tab.StartSmeshing(coinbase), "already started")
+
+	//tab.mnipost.EXPECT().ResetState(sig.NodeID()).Return(nil)
+	//require.NoError(t, tab.StopSmeshing(true))
+}
+func Test_Builder_RegenerateInitialPost_WithGeneratingProof(t *testing.T) {
 	tab := newTestBuilder(t, 1)
 	sig := maps.Values(tab.signers)[0]
 	//coinbase := types.Address{1, 1, 1}

--- a/activation/activation_test.go
+++ b/activation/activation_test.go
@@ -172,7 +172,8 @@ func publishAtx(
 		LabelsPerUnit: DefaultPostConfig().LabelsPerUnit,
 	}, nil).AnyTimes()
 	tab.mnipost.EXPECT().BuildNIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, _ *signing.EdSigner, _ types.Hash32, _ *types.NIPostChallenge) (*nipost.NIPostState, error) {
+		func(_ context.Context, _ *signing.EdSigner, _ types.Hash32, _ *types.NIPostChallenge,
+		) (*nipost.NIPostState, error) {
 			*currLayer = currLayer.Add(buildNIPostLayerDuration)
 			return newNIPostWithPoet(tb, types.RandomHash().Bytes()), nil
 		})
@@ -202,7 +203,8 @@ func Test_Builder_StartSmeshingCoinbase(t *testing.T) {
 	coinbase := types.Address{1, 1, 1}
 
 	tab.mnipost.EXPECT().Proof(gomock.Any(), sig.NodeID(), shared.ZeroChallenge, nil).DoAndReturn(
-		func(ctx context.Context, _ types.NodeID, _ []byte, _ *types.NIPostChallenge) (*types.Post, *types.PostInfo, error) {
+		func(ctx context.Context, _ types.NodeID, _ []byte, _ *types.NIPostChallenge,
+		) (*types.Post, *types.PostInfo, error) {
 			<-ctx.Done()
 			return nil, nil, ctx.Err()
 		})
@@ -224,7 +226,8 @@ func TestBuilder_RestartSmeshing(t *testing.T) {
 		sig := maps.Values(tab.signers)[0]
 
 		tab.mnipost.EXPECT().Proof(gomock.Any(), sig.NodeID(), shared.ZeroChallenge, nil).AnyTimes().DoAndReturn(
-			func(ctx context.Context, _ types.NodeID, _ []byte, _ *types.NIPostChallenge) (*types.Post, *types.PostInfo, error) {
+			func(ctx context.Context, _ types.NodeID, _ []byte, _ *types.NIPostChallenge,
+			) (*types.Post, *types.PostInfo, error) {
 				<-ctx.Done()
 				return nil, nil, ctx.Err()
 			})
@@ -280,7 +283,8 @@ func TestBuilder_StopSmeshing_Delete(t *testing.T) {
 	tab.mclock.EXPECT().AwaitLayer(gomock.Any()).Return(make(chan struct{}))
 
 	tab.mnipost.EXPECT().Proof(gomock.Any(), sig.NodeID(), shared.ZeroChallenge, nil).DoAndReturn(
-		func(ctx context.Context, _ types.NodeID, _ []byte, _ *types.NIPostChallenge) (*types.Post, *types.PostInfo, error) {
+		func(ctx context.Context, _ types.NodeID, _ []byte, _ *types.NIPostChallenge,
+		) (*types.Post, *types.PostInfo, error) {
 			<-ctx.Done()
 			return nil, nil, ctx.Err()
 		})
@@ -301,7 +305,8 @@ func TestBuilder_StopSmeshing_Delete(t *testing.T) {
 
 	tab.mnipost.EXPECT().ResetState(sig.NodeID()).Return(nil)
 	tab.mnipost.EXPECT().Proof(gomock.Any(), sig.NodeID(), shared.ZeroChallenge, nil).DoAndReturn(
-		func(ctx context.Context, _ types.NodeID, _ []byte, _ *types.NIPostChallenge) (*types.Post, *types.PostInfo, error) {
+		func(ctx context.Context, _ types.NodeID, _ []byte, _ *types.NIPostChallenge,
+		) (*types.Post, *types.PostInfo, error) {
 			<-ctx.Done()
 			return nil, nil, ctx.Err()
 		})
@@ -319,7 +324,8 @@ func TestBuilder_StopSmeshing_Delete(t *testing.T) {
 
 	tab.mnipost.EXPECT().ResetState(sig.NodeID()).Return(nil)
 	tab.mnipost.EXPECT().Proof(gomock.Any(), sig.NodeID(), shared.ZeroChallenge, nil).DoAndReturn(
-		func(ctx context.Context, _ types.NodeID, _ []byte, _ *types.NIPostChallenge) (*types.Post, *types.PostInfo, error) {
+		func(ctx context.Context, _ types.NodeID, _ []byte, _ *types.NIPostChallenge,
+		) (*types.Post, *types.PostInfo, error) {
 			<-ctx.Done()
 			return nil, nil, ctx.Err()
 		})
@@ -452,7 +458,8 @@ func TestBuilder_PublishActivationTx_FaultyNet(t *testing.T) {
 		LabelsPerUnit: DefaultPostConfig().LabelsPerUnit,
 	}, nil).AnyTimes()
 	tab.mnipost.EXPECT().BuildNIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, _ *signing.EdSigner, _ types.Hash32, _ *types.NIPostChallenge) (*nipost.NIPostState, error) {
+		func(_ context.Context, _ *signing.EdSigner, _ types.Hash32, _ *types.NIPostChallenge,
+		) (*nipost.NIPostState, error) {
 			currLayer = currLayer.Add(layersPerEpoch)
 			return newNIPostWithPoet(t, []byte("66666")), nil
 		})
@@ -526,7 +533,8 @@ func TestBuilder_PublishActivationTx_UsesExistingChallengeOnLatePublish(t *testi
 		LabelsPerUnit: DefaultPostConfig().LabelsPerUnit,
 	}, nil).AnyTimes()
 	tab.mnipost.EXPECT().BuildNIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, _ *signing.EdSigner, _ types.Hash32, _ *types.NIPostChallenge) (*nipost.NIPostState, error) {
+		func(_ context.Context, _ *signing.EdSigner, _ types.Hash32, _ *types.NIPostChallenge,
+		) (*nipost.NIPostState, error) {
 			currLayer = currLayer.Add(1)
 			return newNIPostWithPoet(t, []byte("66666")), nil
 		})
@@ -595,7 +603,8 @@ func TestBuilder_PublishActivationTx_RebuildNIPostWhenTargetEpochPassed(t *testi
 			return genesis.Add(layerDuration * time.Duration(got))
 		}).AnyTimes()
 	tab.mnipost.EXPECT().BuildNIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, _ *signing.EdSigner, _ types.Hash32, _ *types.NIPostChallenge) (*nipost.NIPostState, error) {
+		func(_ context.Context, _ *signing.EdSigner, _ types.Hash32, _ *types.NIPostChallenge,
+		) (*nipost.NIPostState, error) {
 			currLayer = currLayer.Add(layersPerEpoch)
 			return newNIPostWithPoet(t, []byte("66666")), nil
 		})
@@ -825,7 +834,8 @@ func TestBuilder_PublishActivationTx_PrevATXWithoutPrevATX(t *testing.T) {
 	tab.mnipost.EXPECT().
 		BuildNIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		DoAndReturn(
-			func(_ context.Context, _ *signing.EdSigner, _ types.Hash32, _ *types.NIPostChallenge) (*nipost.NIPostState, error) {
+			func(_ context.Context, _ *signing.EdSigner, _ types.Hash32, _ *types.NIPostChallenge,
+			) (*nipost.NIPostState, error) {
 				currentLayer = currentLayer.Add(5)
 				return newNIPostWithPoet(t, poetBytes), nil
 			})
@@ -907,7 +917,8 @@ func TestBuilder_PublishActivationTx_TargetsEpochBasedOnPosAtx(t *testing.T) {
 	}, nil).AnyTimes()
 
 	tab.mnipost.EXPECT().BuildNIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, _ *signing.EdSigner, _ types.Hash32, _ *types.NIPostChallenge) (*nipost.NIPostState, error) {
+		func(_ context.Context, _ *signing.EdSigner, _ types.Hash32, _ *types.NIPostChallenge,
+		) (*nipost.NIPostState, error) {
 			currentLayer = currentLayer.Add(layersPerEpoch)
 			return newNIPostWithPoet(t, poetBytes), nil
 		})
@@ -1509,7 +1520,8 @@ func Test_Builder_RegenerateInitialPost(t *testing.T) {
 	)
 
 	tab.mValidator.EXPECT().
-		PostV2(gomock.Any(), sig.NodeID(), commitmentATX, initialPost, shared.ZeroChallenge, numUnits).Return(nil).Times(4)
+		PostV2(gomock.Any(), sig.NodeID(), commitmentATX, initialPost, shared.ZeroChallenge, numUnits).
+		Return(nil).Times(4)
 
 	tab.mclock.EXPECT().CurrentLayer().Return(types.LayerID(0)).AnyTimes()
 	tab.mclock.EXPECT().AwaitLayer(gomock.Any()).DoAndReturn(func(id types.LayerID) <-chan struct{} {

--- a/activation/activation_test.go
+++ b/activation/activation_test.go
@@ -73,7 +73,7 @@ func newTestBuilder(tb testing.TB, numSigners int, opts ...BuilderOption) *testA
 		func(core zapcore.Core) zapcore.Core {
 			return zapcore.NewTee(core, observer)
 		},
-	)), zaptest.Level(zap.WarnLevel))
+	)))
 
 	ctrl := gomock.NewController(tb)
 	tab := &testAtxBuilder{

--- a/activation/activation_test.go
+++ b/activation/activation_test.go
@@ -1490,8 +1490,9 @@ func TestFindFullyValidHighTickAtx(t *testing.T) {
 // where a node operator may change SUs after creating the initial PoST but before
 // submitting the first ATX, which should result in the initial PoST to be deleted
 // and for the new PoST to be generated instead (this also loses the eligibility
-// for the current epoch).
-func Test_Builder_RegenerateInitialPost_WithDbCopy(t *testing.T) {
+// for the current epoch). This behavior is mocked by mocking the response of the
+// proof validator.
+func Test_Builder_RegenerateInitialPost(t *testing.T) {
 	var (
 		tab           = newTestBuilder(t, 1)
 		sig           = maps.Values(tab.signers)[0]

--- a/activation/activation_test.go
+++ b/activation/activation_test.go
@@ -171,8 +171,8 @@ func publishAtx(
 		NumUnits:      DefaultPostSetupOpts().NumUnits,
 		LabelsPerUnit: DefaultPostConfig().LabelsPerUnit,
 	}, nil).AnyTimes()
-	tab.mnipost.EXPECT().BuildNIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, _ *signing.EdSigner, _ types.EpochID, _ types.Hash32, _ *types.NIPostChallenge) (*nipost.NIPostState, error) {
+	tab.mnipost.EXPECT().BuildNIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ *signing.EdSigner, _ types.Hash32, _ *types.NIPostChallenge) (*nipost.NIPostState, error) {
 			*currLayer = currLayer.Add(buildNIPostLayerDuration)
 			return newNIPostWithPoet(tb, types.RandomHash().Bytes()), nil
 		})
@@ -393,7 +393,7 @@ func TestBuilder_Loop_WaitsOnStaleChallenge(t *testing.T) {
 		}).AnyTimes()
 
 	tab.mnipost.EXPECT().
-		BuildNIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		BuildNIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(nil, ErrATXChallengeExpired)
 	tab.mnipost.EXPECT().ResetState(sig.NodeID()).Return(nil)
 
@@ -451,8 +451,8 @@ func TestBuilder_PublishActivationTx_FaultyNet(t *testing.T) {
 		NumUnits:      DefaultPostSetupOpts().NumUnits,
 		LabelsPerUnit: DefaultPostConfig().LabelsPerUnit,
 	}, nil).AnyTimes()
-	tab.mnipost.EXPECT().BuildNIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, _ *signing.EdSigner, _ types.EpochID, _ types.Hash32, _ *types.NIPostChallenge) (*nipost.NIPostState, error) {
+	tab.mnipost.EXPECT().BuildNIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ *signing.EdSigner, _ types.Hash32, _ *types.NIPostChallenge) (*nipost.NIPostState, error) {
 			currLayer = currLayer.Add(layersPerEpoch)
 			return newNIPostWithPoet(t, []byte("66666")), nil
 		})
@@ -525,8 +525,8 @@ func TestBuilder_PublishActivationTx_UsesExistingChallengeOnLatePublish(t *testi
 		NumUnits:      DefaultPostSetupOpts().NumUnits,
 		LabelsPerUnit: DefaultPostConfig().LabelsPerUnit,
 	}, nil).AnyTimes()
-	tab.mnipost.EXPECT().BuildNIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, _ *signing.EdSigner, _ types.EpochID, _ types.Hash32, _ *types.NIPostChallenge) (*nipost.NIPostState, error) {
+	tab.mnipost.EXPECT().BuildNIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ *signing.EdSigner, _ types.Hash32, _ *types.NIPostChallenge) (*nipost.NIPostState, error) {
 			currLayer = currLayer.Add(1)
 			return newNIPostWithPoet(t, []byte("66666")), nil
 		})
@@ -594,8 +594,8 @@ func TestBuilder_PublishActivationTx_RebuildNIPostWhenTargetEpochPassed(t *testi
 			genesis := time.Now().Add(-time.Duration(currLayer) * layerDuration)
 			return genesis.Add(layerDuration * time.Duration(got))
 		}).AnyTimes()
-	tab.mnipost.EXPECT().BuildNIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, _ *signing.EdSigner, _ types.EpochID, _ types.Hash32, _ *types.NIPostChallenge) (*nipost.NIPostState, error) {
+	tab.mnipost.EXPECT().BuildNIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ *signing.EdSigner, _ types.Hash32, _ *types.NIPostChallenge) (*nipost.NIPostState, error) {
 			currLayer = currLayer.Add(layersPerEpoch)
 			return newNIPostWithPoet(t, []byte("66666")), nil
 		})
@@ -729,7 +729,7 @@ func TestBuilder_PublishActivationTx_NoPrevATX_PublishFails_InitialPost_preserve
 			return genesis.Add(layerDuration * time.Duration(got))
 		}).AnyTimes()
 	tab.mnipost.EXPECT().
-		BuildNIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		BuildNIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(nil, ErrATXChallengeExpired)
 	tab.mnipost.EXPECT().ResetState(sig.NodeID()).Return(nil)
 	ch := make(chan struct{})
@@ -823,9 +823,9 @@ func TestBuilder_PublishActivationTx_PrevATXWithoutPrevATX(t *testing.T) {
 	}, nil).AnyTimes()
 
 	tab.mnipost.EXPECT().
-		BuildNIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		BuildNIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		DoAndReturn(
-			func(_ context.Context, _ *signing.EdSigner, _ types.EpochID, _ types.Hash32, _ *types.NIPostChallenge) (*nipost.NIPostState, error) {
+			func(_ context.Context, _ *signing.EdSigner, _ types.Hash32, _ *types.NIPostChallenge) (*nipost.NIPostState, error) {
 				currentLayer = currentLayer.Add(5)
 				return newNIPostWithPoet(t, poetBytes), nil
 			})
@@ -906,8 +906,8 @@ func TestBuilder_PublishActivationTx_TargetsEpochBasedOnPosAtx(t *testing.T) {
 		LabelsPerUnit: DefaultPostConfig().LabelsPerUnit,
 	}, nil).AnyTimes()
 
-	tab.mnipost.EXPECT().BuildNIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, _ *signing.EdSigner, _ types.EpochID, _ types.Hash32, _ *types.NIPostChallenge) (*nipost.NIPostState, error) {
+	tab.mnipost.EXPECT().BuildNIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ *signing.EdSigner, _ types.Hash32, _ *types.NIPostChallenge) (*nipost.NIPostState, error) {
 			currentLayer = currentLayer.Add(layersPerEpoch)
 			return newNIPostWithPoet(t, poetBytes), nil
 		})
@@ -978,7 +978,7 @@ func TestBuilder_PublishActivationTx_FailsWhenNIPostBuilderFails(t *testing.T) {
 		}).AnyTimes()
 	nipostErr := errors.New("NIPost builder error")
 	tab.mnipost.EXPECT().
-		BuildNIPost(gomock.Any(), sig, gomock.Any(), gomock.Any(), gomock.Any()).
+		BuildNIPost(gomock.Any(), sig, gomock.Any(), gomock.Any()).
 		Return(nil, nipostErr)
 	tab.mValidator.EXPECT().VerifyChain(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 	require.ErrorIs(t, tab.PublishActivationTx(context.Background(), sig), nipostErr)
@@ -1052,11 +1052,11 @@ func TestBuilder_RetryPublishActivationTx(t *testing.T) {
 	var last time.Time
 	builderConfirmation := make(chan struct{})
 	tab.mnipost.EXPECT().
-		BuildNIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		BuildNIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Times(expectedTries).
 		DoAndReturn(
 			// nolint:lll
-			func(_ context.Context, _ *signing.EdSigner, _ types.EpochID, _ types.Hash32, _ *types.NIPostChallenge) (*nipost.NIPostState, error) {
+			func(_ context.Context, _ *signing.EdSigner, _ types.Hash32, _ *types.NIPostChallenge) (*nipost.NIPostState, error) {
 				now := time.Now()
 				if now.Sub(last) < retryInterval {
 					require.FailNow(t, "retry interval not respected")
@@ -1279,7 +1279,7 @@ func TestWaitPositioningAtx(t *testing.T) {
 			tab.mpostClient.EXPECT().Info(gomock.Any()).Return(&types.PostInfo{}, nil).AnyTimes()
 			tab.mnipost.EXPECT().ResetState(sig.NodeID()).Return(nil)
 			tab.mnipost.EXPECT().
-				BuildNIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				BuildNIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 				Return(&nipost.NIPostState{}, nil)
 			closed := make(chan struct{})
 			close(closed)
@@ -1526,9 +1526,9 @@ func Test_Builder_RegenerateInitialPost(t *testing.T) {
 	tab.mnipost.EXPECT().ResetState(sig.NodeID()).Return(nil).Times(1)
 
 	tab.mnipost.EXPECT().
-		BuildNIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, ErrInvalidInitialPost)
+		BuildNIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, ErrInvalidInitialPost)
 	tab.mnipost.EXPECT().
-		BuildNIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&nipost.NIPostState{}, nil)
+		BuildNIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&nipost.NIPostState{}, nil)
 
 	tab.mnipost.EXPECT().Proof(gomock.Any(), sig.NodeID(), shared.ZeroChallenge, nil).Return(initialPost,
 		&types.PostInfo{

--- a/activation/activation_test.go
+++ b/activation/activation_test.go
@@ -1225,7 +1225,7 @@ func TestBuilder_InitialPostLogErrorMissingVRFNonce(t *testing.T) {
 	tab.mValidator.EXPECT().
 		PostV2(gomock.Any(), sig.NodeID(), commitmentATX, initialPost, shared.ZeroChallenge, numUnits)
 	err := tab.buildInitialPost(context.Background(), sig.NodeID())
-	require.ErrorIs(t, err, nilVrfNonce)
+	require.ErrorIs(t, err, errNilVrfNonce)
 
 	observedLogs := tab.observedLogs.FilterLevelExact(zapcore.ErrorLevel)
 	require.Equal(t, 1, observedLogs.Len(), "expected 1 log message")

--- a/activation/e2e/activation_test.go
+++ b/activation/e2e/activation_test.go
@@ -200,7 +200,6 @@ func Test_BuilderWithMultipleClients(t *testing.T) {
 	).Times(totalAtxs)
 
 	t.Cleanup(func() { assert.NoError(t, verifier.Close()) })
-	v := activation.NewValidator(db, poetDb, cfg, opts.Scrypt, verifier)
 	tab := activation.NewBuilder(
 		conf,
 		db,
@@ -212,7 +211,7 @@ func Test_BuilderWithMultipleClients(t *testing.T) {
 		syncer,
 		logger,
 		activation.WithPoetConfig(poetCfg),
-		activation.WithValidator(v),
+		activation.WithValidator(validator),
 		activation.WithPostStates(postStates),
 		activation.WithPoets(client),
 	)
@@ -251,7 +250,7 @@ func Test_BuilderWithMultipleClients(t *testing.T) {
 				require.Equal(t, sig.NodeID(), *atx.NodeID)
 				require.Equal(t, goldenATX, atx.PositioningATXID)
 				require.NotNil(t, atx.VRFNonce)
-				err := v.VRFNonce(
+				err := validator.VRFNonce(
 					sig.NodeID(),
 					commitment,
 					uint64(*atx.VRFNonce),
@@ -263,7 +262,7 @@ func Test_BuilderWithMultipleClients(t *testing.T) {
 				require.Nil(t, atx.VRFNonce)
 				require.Equal(t, previous, atx.PositioningATXID)
 			}
-			_, err = v.NIPost(
+			_, err = validator.NIPost(
 				context.Background(),
 				sig.NodeID(),
 				commitment,

--- a/activation/e2e/builds_atx_v2_test.go
+++ b/activation/e2e/builds_atx_v2_test.go
@@ -131,6 +131,7 @@ func TestBuilder_SwitchesToBuildV2(t *testing.T) {
 		logger.Named("nipostBuilder"),
 		poetCfg,
 		clock,
+		validator,
 		activation.NipostbuilderWithPostStates(postStates),
 		activation.WithPoetClients(client),
 	)

--- a/activation/e2e/nipost_test.go
+++ b/activation/e2e/nipost_test.go
@@ -235,7 +235,7 @@ func TestNIPostBuilderWithClients(t *testing.T) {
 	require.NoError(t, err)
 
 	challenge := types.RandomHash()
-	nipost, err := nb.BuildNIPost(context.Background(), sig, 7, challenge, nil)
+	nipost, err := nb.BuildNIPost(context.Background(), sig, challenge, &types.NIPostChallenge{PublishEpoch: 7})
 	require.NoError(t, err)
 
 	v := activation.NewValidator(nil, poetDb, cfg, opts.Scrypt, verifier)
@@ -362,7 +362,7 @@ func Test_NIPostBuilderWithMultipleClients(t *testing.T) {
 			err = nipost.AddPost(localDB, sig.NodeID(), *fullPost(post, info, shared.ZeroChallenge))
 			require.NoError(t, err)
 
-			nipost, err := nb.BuildNIPost(context.Background(), sig, 7, challenge, nil)
+			nipost, err := nb.BuildNIPost(context.Background(), sig, challenge, &types.NIPostChallenge{PublishEpoch: 7})
 			require.NoError(t, err)
 
 			v := activation.NewValidator(nil, poetDb, cfg, opts.Scrypt, verifier)

--- a/activation/e2e/nipost_test.go
+++ b/activation/e2e/nipost_test.go
@@ -340,14 +340,6 @@ func Test_NIPostBuilderWithMultipleClients(t *testing.T) {
 
 	verifier, err := activation.NewPostVerifier(cfg, logger.Named("verifier"))
 	require.NoError(t, err)
-	validator := activation.NewValidator(
-		db,
-		poetDb,
-		cfg,
-		opts.Scrypt,
-		verifier,
-	)
-
 	t.Cleanup(func() { assert.NoError(t, verifier.Close()) })
 
 	localDB := localsql.InMemory()

--- a/activation/e2e/validation_test.go
+++ b/activation/e2e/validation_test.go
@@ -110,7 +110,7 @@ func TestValidator_Validate(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	nipost, err := nb.BuildNIPost(context.Background(), sig, postGenesisEpoch+2, challenge, nil)
+	nipost, err := nb.BuildNIPost(context.Background(), sig, challenge, &types.NIPostChallenge{PublishEpoch: postGenesisEpoch + 2})
 	require.NoError(t, err)
 
 	v := activation.NewValidator(db, poetDb, cfg, opts.Scrypt, verifier)

--- a/activation/e2e/validation_test.go
+++ b/activation/e2e/validation_test.go
@@ -110,7 +110,8 @@ func TestValidator_Validate(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	nipost, err := nb.BuildNIPost(context.Background(), sig, challenge, &types.NIPostChallenge{PublishEpoch: postGenesisEpoch + 2})
+	nipost, err := nb.BuildNIPost(context.Background(), sig, challenge,
+		&types.NIPostChallenge{PublishEpoch: postGenesisEpoch + 2})
 	require.NoError(t, err)
 
 	v := activation.NewValidator(db, poetDb, cfg, opts.Scrypt, verifier)

--- a/activation/e2e/validation_test.go
+++ b/activation/e2e/validation_test.go
@@ -86,13 +86,6 @@ func TestValidator_Validate(t *testing.T) {
 	verifier, err := activation.NewPostVerifier(cfg, logger.Named("verifier"))
 	require.NoError(t, err)
 	t.Cleanup(func() { assert.NoError(t, verifier.Close()) })
-	validator := activation.NewValidator(
-		db,
-		poetDb,
-		cfg,
-		opts.Scrypt,
-		verifier,
-	)
 	svc := grpcserver.NewPostService(logger)
 	svc.AllowConnections(true)
 	grpcCfg, cleanup := launchServer(t, svc)

--- a/activation/e2e/validation_test.go
+++ b/activation/e2e/validation_test.go
@@ -86,7 +86,13 @@ func TestValidator_Validate(t *testing.T) {
 	verifier, err := activation.NewPostVerifier(cfg, logger.Named("verifier"))
 	require.NoError(t, err)
 	t.Cleanup(func() { assert.NoError(t, verifier.Close()) })
-
+	validator := activation.NewValidator(
+		db,
+		poetDb,
+		cfg,
+		opts.Scrypt,
+		verifier,
+	)
 	svc := grpcserver.NewPostService(logger)
 	svc.AllowConnections(true)
 	grpcCfg, cleanup := launchServer(t, svc)
@@ -106,11 +112,12 @@ func TestValidator_Validate(t *testing.T) {
 		logger.Named("nipostBuilder"),
 		poetCfg,
 		mclock,
+		validator,
 		activation.WithPoetClients(client),
 	)
 	require.NoError(t, err)
 
-	nipost, err := nb.BuildNIPost(context.Background(), sig, postGenesisEpoch+2, challenge)
+	nipost, err := nb.BuildNIPost(context.Background(), sig, postGenesisEpoch+2, challenge, nil)
 	require.NoError(t, err)
 
 	v := activation.NewValidator(db, poetDb, cfg, opts.Scrypt, verifier)

--- a/activation/interface.go
+++ b/activation/interface.go
@@ -53,9 +53,10 @@ type nipostBuilder interface {
 		ctx context.Context,
 		sig *signing.EdSigner,
 		publish types.EpochID,
-		challenge types.Hash32,
+		challengeHash types.Hash32,
+		initialPost *nipost.Post,
 	) (*nipost.NIPostState, error)
-	Proof(ctx context.Context, nodeID types.NodeID, challenge []byte) (*types.Post, *types.PostInfo, error)
+	Proof(ctx context.Context, nodeID types.NodeID, challenge []byte, initialPost *nipost.Post) (*types.Post, *types.PostInfo, error)
 	ResetState(types.NodeID) error
 }
 

--- a/activation/interface.go
+++ b/activation/interface.go
@@ -54,9 +54,9 @@ type nipostBuilder interface {
 		sig *signing.EdSigner,
 		publish types.EpochID,
 		challengeHash types.Hash32,
-		initialPost *nipost.Post,
+		postChallenge *types.NIPostChallenge,
 	) (*nipost.NIPostState, error)
-	Proof(ctx context.Context, nodeID types.NodeID, challenge []byte, initialPost *nipost.Post) (*types.Post, *types.PostInfo, error)
+	Proof(ctx context.Context, nodeID types.NodeID, challenge []byte, postChallenge *types.NIPostChallenge) (*types.Post, *types.PostInfo, error)
 	ResetState(types.NodeID) error
 }
 

--- a/activation/interface.go
+++ b/activation/interface.go
@@ -55,7 +55,8 @@ type nipostBuilder interface {
 		challengeHash types.Hash32,
 		postChallenge *types.NIPostChallenge,
 	) (*nipost.NIPostState, error)
-	Proof(ctx context.Context, nodeID types.NodeID, challenge []byte, postChallenge *types.NIPostChallenge) (*types.Post, *types.PostInfo, error)
+	Proof(ctx context.Context, nodeID types.NodeID, challenge []byte, postChallenge *types.NIPostChallenge,
+	) (*types.Post, *types.PostInfo, error)
 	ResetState(types.NodeID) error
 }
 

--- a/activation/interface.go
+++ b/activation/interface.go
@@ -52,7 +52,6 @@ type nipostBuilder interface {
 	BuildNIPost(
 		ctx context.Context,
 		sig *signing.EdSigner,
-		publish types.EpochID,
 		challengeHash types.Hash32,
 		postChallenge *types.NIPostChallenge,
 	) (*nipost.NIPostState, error)

--- a/activation/mocks.go
+++ b/activation/mocks.go
@@ -909,18 +909,18 @@ func (m *MocknipostBuilder) EXPECT() *MocknipostBuilderMockRecorder {
 }
 
 // BuildNIPost mocks base method.
-func (m *MocknipostBuilder) BuildNIPost(ctx context.Context, sig *signing.EdSigner, publish types.EpochID, challengeHash types.Hash32, initialPost *nipost.Post) (*nipost.NIPostState, error) {
+func (m *MocknipostBuilder) BuildNIPost(ctx context.Context, sig *signing.EdSigner, publish types.EpochID, challengeHash types.Hash32, postChallenge *types.NIPostChallenge) (*nipost.NIPostState, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BuildNIPost", ctx, sig, publish, challengeHash, initialPost)
+	ret := m.ctrl.Call(m, "BuildNIPost", ctx, sig, publish, challengeHash, postChallenge)
 	ret0, _ := ret[0].(*nipost.NIPostState)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // BuildNIPost indicates an expected call of BuildNIPost.
-func (mr *MocknipostBuilderMockRecorder) BuildNIPost(ctx, sig, publish, challengeHash, initialPost any) *MocknipostBuilderBuildNIPostCall {
+func (mr *MocknipostBuilderMockRecorder) BuildNIPost(ctx, sig, publish, challengeHash, postChallenge any) *MocknipostBuilderBuildNIPostCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildNIPost", reflect.TypeOf((*MocknipostBuilder)(nil).BuildNIPost), ctx, sig, publish, challengeHash, initialPost)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildNIPost", reflect.TypeOf((*MocknipostBuilder)(nil).BuildNIPost), ctx, sig, publish, challengeHash, postChallenge)
 	return &MocknipostBuilderBuildNIPostCall{Call: call}
 }
 
@@ -936,21 +936,21 @@ func (c *MocknipostBuilderBuildNIPostCall) Return(arg0 *nipost.NIPostState, arg1
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MocknipostBuilderBuildNIPostCall) Do(f func(context.Context, *signing.EdSigner, types.EpochID, types.Hash32, *nipost.Post) (*nipost.NIPostState, error)) *MocknipostBuilderBuildNIPostCall {
+func (c *MocknipostBuilderBuildNIPostCall) Do(f func(context.Context, *signing.EdSigner, types.EpochID, types.Hash32, *types.NIPostChallenge) (*nipost.NIPostState, error)) *MocknipostBuilderBuildNIPostCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MocknipostBuilderBuildNIPostCall) DoAndReturn(f func(context.Context, *signing.EdSigner, types.EpochID, types.Hash32, *nipost.Post) (*nipost.NIPostState, error)) *MocknipostBuilderBuildNIPostCall {
+func (c *MocknipostBuilderBuildNIPostCall) DoAndReturn(f func(context.Context, *signing.EdSigner, types.EpochID, types.Hash32, *types.NIPostChallenge) (*nipost.NIPostState, error)) *MocknipostBuilderBuildNIPostCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // Proof mocks base method.
-func (m *MocknipostBuilder) Proof(ctx context.Context, nodeID types.NodeID, challenge []byte, initialPost *nipost.Post) (*types.Post, *types.PostInfo, error) {
+func (m *MocknipostBuilder) Proof(ctx context.Context, nodeID types.NodeID, challenge []byte, postChallenge *types.NIPostChallenge) (*types.Post, *types.PostInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Proof", ctx, nodeID, challenge, initialPost)
+	ret := m.ctrl.Call(m, "Proof", ctx, nodeID, challenge, postChallenge)
 	ret0, _ := ret[0].(*types.Post)
 	ret1, _ := ret[1].(*types.PostInfo)
 	ret2, _ := ret[2].(error)
@@ -958,9 +958,9 @@ func (m *MocknipostBuilder) Proof(ctx context.Context, nodeID types.NodeID, chal
 }
 
 // Proof indicates an expected call of Proof.
-func (mr *MocknipostBuilderMockRecorder) Proof(ctx, nodeID, challenge, initialPost any) *MocknipostBuilderProofCall {
+func (mr *MocknipostBuilderMockRecorder) Proof(ctx, nodeID, challenge, postChallenge any) *MocknipostBuilderProofCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Proof", reflect.TypeOf((*MocknipostBuilder)(nil).Proof), ctx, nodeID, challenge, initialPost)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Proof", reflect.TypeOf((*MocknipostBuilder)(nil).Proof), ctx, nodeID, challenge, postChallenge)
 	return &MocknipostBuilderProofCall{Call: call}
 }
 
@@ -976,13 +976,13 @@ func (c *MocknipostBuilderProofCall) Return(arg0 *types.Post, arg1 *types.PostIn
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MocknipostBuilderProofCall) Do(f func(context.Context, types.NodeID, []byte, *nipost.Post) (*types.Post, *types.PostInfo, error)) *MocknipostBuilderProofCall {
+func (c *MocknipostBuilderProofCall) Do(f func(context.Context, types.NodeID, []byte, *types.NIPostChallenge) (*types.Post, *types.PostInfo, error)) *MocknipostBuilderProofCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MocknipostBuilderProofCall) DoAndReturn(f func(context.Context, types.NodeID, []byte, *nipost.Post) (*types.Post, *types.PostInfo, error)) *MocknipostBuilderProofCall {
+func (c *MocknipostBuilderProofCall) DoAndReturn(f func(context.Context, types.NodeID, []byte, *types.NIPostChallenge) (*types.Post, *types.PostInfo, error)) *MocknipostBuilderProofCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/activation/mocks.go
+++ b/activation/mocks.go
@@ -909,18 +909,18 @@ func (m *MocknipostBuilder) EXPECT() *MocknipostBuilderMockRecorder {
 }
 
 // BuildNIPost mocks base method.
-func (m *MocknipostBuilder) BuildNIPost(ctx context.Context, sig *signing.EdSigner, publish types.EpochID, challengeHash types.Hash32, postChallenge *types.NIPostChallenge) (*nipost.NIPostState, error) {
+func (m *MocknipostBuilder) BuildNIPost(ctx context.Context, sig *signing.EdSigner, challengeHash types.Hash32, postChallenge *types.NIPostChallenge) (*nipost.NIPostState, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BuildNIPost", ctx, sig, publish, challengeHash, postChallenge)
+	ret := m.ctrl.Call(m, "BuildNIPost", ctx, sig, challengeHash, postChallenge)
 	ret0, _ := ret[0].(*nipost.NIPostState)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // BuildNIPost indicates an expected call of BuildNIPost.
-func (mr *MocknipostBuilderMockRecorder) BuildNIPost(ctx, sig, publish, challengeHash, postChallenge any) *MocknipostBuilderBuildNIPostCall {
+func (mr *MocknipostBuilderMockRecorder) BuildNIPost(ctx, sig, challengeHash, postChallenge any) *MocknipostBuilderBuildNIPostCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildNIPost", reflect.TypeOf((*MocknipostBuilder)(nil).BuildNIPost), ctx, sig, publish, challengeHash, postChallenge)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildNIPost", reflect.TypeOf((*MocknipostBuilder)(nil).BuildNIPost), ctx, sig, challengeHash, postChallenge)
 	return &MocknipostBuilderBuildNIPostCall{Call: call}
 }
 
@@ -936,13 +936,13 @@ func (c *MocknipostBuilderBuildNIPostCall) Return(arg0 *nipost.NIPostState, arg1
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MocknipostBuilderBuildNIPostCall) Do(f func(context.Context, *signing.EdSigner, types.EpochID, types.Hash32, *types.NIPostChallenge) (*nipost.NIPostState, error)) *MocknipostBuilderBuildNIPostCall {
+func (c *MocknipostBuilderBuildNIPostCall) Do(f func(context.Context, *signing.EdSigner, types.Hash32, *types.NIPostChallenge) (*nipost.NIPostState, error)) *MocknipostBuilderBuildNIPostCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MocknipostBuilderBuildNIPostCall) DoAndReturn(f func(context.Context, *signing.EdSigner, types.EpochID, types.Hash32, *types.NIPostChallenge) (*nipost.NIPostState, error)) *MocknipostBuilderBuildNIPostCall {
+func (c *MocknipostBuilderBuildNIPostCall) DoAndReturn(f func(context.Context, *signing.EdSigner, types.Hash32, *types.NIPostChallenge) (*nipost.NIPostState, error)) *MocknipostBuilderBuildNIPostCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/activation/mocks.go
+++ b/activation/mocks.go
@@ -909,18 +909,18 @@ func (m *MocknipostBuilder) EXPECT() *MocknipostBuilderMockRecorder {
 }
 
 // BuildNIPost mocks base method.
-func (m *MocknipostBuilder) BuildNIPost(ctx context.Context, sig *signing.EdSigner, publish types.EpochID, challenge types.Hash32) (*nipost.NIPostState, error) {
+func (m *MocknipostBuilder) BuildNIPost(ctx context.Context, sig *signing.EdSigner, publish types.EpochID, challengeHash types.Hash32, initialPost *nipost.Post) (*nipost.NIPostState, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BuildNIPost", ctx, sig, publish, challenge)
+	ret := m.ctrl.Call(m, "BuildNIPost", ctx, sig, publish, challengeHash, initialPost)
 	ret0, _ := ret[0].(*nipost.NIPostState)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // BuildNIPost indicates an expected call of BuildNIPost.
-func (mr *MocknipostBuilderMockRecorder) BuildNIPost(ctx, sig, publish, challenge any) *MocknipostBuilderBuildNIPostCall {
+func (mr *MocknipostBuilderMockRecorder) BuildNIPost(ctx, sig, publish, challengeHash, initialPost any) *MocknipostBuilderBuildNIPostCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildNIPost", reflect.TypeOf((*MocknipostBuilder)(nil).BuildNIPost), ctx, sig, publish, challenge)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildNIPost", reflect.TypeOf((*MocknipostBuilder)(nil).BuildNIPost), ctx, sig, publish, challengeHash, initialPost)
 	return &MocknipostBuilderBuildNIPostCall{Call: call}
 }
 
@@ -936,21 +936,21 @@ func (c *MocknipostBuilderBuildNIPostCall) Return(arg0 *nipost.NIPostState, arg1
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MocknipostBuilderBuildNIPostCall) Do(f func(context.Context, *signing.EdSigner, types.EpochID, types.Hash32) (*nipost.NIPostState, error)) *MocknipostBuilderBuildNIPostCall {
+func (c *MocknipostBuilderBuildNIPostCall) Do(f func(context.Context, *signing.EdSigner, types.EpochID, types.Hash32, *nipost.Post) (*nipost.NIPostState, error)) *MocknipostBuilderBuildNIPostCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MocknipostBuilderBuildNIPostCall) DoAndReturn(f func(context.Context, *signing.EdSigner, types.EpochID, types.Hash32) (*nipost.NIPostState, error)) *MocknipostBuilderBuildNIPostCall {
+func (c *MocknipostBuilderBuildNIPostCall) DoAndReturn(f func(context.Context, *signing.EdSigner, types.EpochID, types.Hash32, *nipost.Post) (*nipost.NIPostState, error)) *MocknipostBuilderBuildNIPostCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // Proof mocks base method.
-func (m *MocknipostBuilder) Proof(ctx context.Context, nodeID types.NodeID, challenge []byte) (*types.Post, *types.PostInfo, error) {
+func (m *MocknipostBuilder) Proof(ctx context.Context, nodeID types.NodeID, challenge []byte, initialPost *nipost.Post) (*types.Post, *types.PostInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Proof", ctx, nodeID, challenge)
+	ret := m.ctrl.Call(m, "Proof", ctx, nodeID, challenge, initialPost)
 	ret0, _ := ret[0].(*types.Post)
 	ret1, _ := ret[1].(*types.PostInfo)
 	ret2, _ := ret[2].(error)
@@ -958,9 +958,9 @@ func (m *MocknipostBuilder) Proof(ctx context.Context, nodeID types.NodeID, chal
 }
 
 // Proof indicates an expected call of Proof.
-func (mr *MocknipostBuilderMockRecorder) Proof(ctx, nodeID, challenge any) *MocknipostBuilderProofCall {
+func (mr *MocknipostBuilderMockRecorder) Proof(ctx, nodeID, challenge, initialPost any) *MocknipostBuilderProofCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Proof", reflect.TypeOf((*MocknipostBuilder)(nil).Proof), ctx, nodeID, challenge)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Proof", reflect.TypeOf((*MocknipostBuilder)(nil).Proof), ctx, nodeID, challenge, initialPost)
 	return &MocknipostBuilderProofCall{Call: call}
 }
 
@@ -976,13 +976,13 @@ func (c *MocknipostBuilderProofCall) Return(arg0 *types.Post, arg1 *types.PostIn
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MocknipostBuilderProofCall) Do(f func(context.Context, types.NodeID, []byte) (*types.Post, *types.PostInfo, error)) *MocknipostBuilderProofCall {
+func (c *MocknipostBuilderProofCall) Do(f func(context.Context, types.NodeID, []byte, *nipost.Post) (*types.Post, *types.PostInfo, error)) *MocknipostBuilderProofCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MocknipostBuilderProofCall) DoAndReturn(f func(context.Context, types.NodeID, []byte) (*types.Post, *types.PostInfo, error)) *MocknipostBuilderProofCall {
+func (c *MocknipostBuilderProofCall) DoAndReturn(f func(context.Context, types.NodeID, []byte, *nipost.Post) (*types.Post, *types.PostInfo, error)) *MocknipostBuilderProofCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/activation/nipost.go
+++ b/activation/nipost.go
@@ -43,9 +43,7 @@ const (
 	maxPoetGetProofJitter = 0.04
 )
 
-var (
-	ErrInvalidInitialPost = errors.New("invalid initial post")
-)
+var ErrInvalidInitialPost = errors.New("invalid initial post")
 
 // NIPostBuilder holds the required state and dependencies to create Non-Interactive Proofs of Space-Time (NIPost).
 type NIPostBuilder struct {
@@ -213,7 +211,8 @@ func (nb *NIPostBuilder) BuildNIPost(
 	//  WE ARE HERE            PROOF BECOMES         ATX PUBLICATION
 	//                           AVAILABLE               DEADLINE
 
-	poetRoundStart := nb.layerClock.LayerToTime((postChallenge.PublishEpoch - 1).FirstLayer()).Add(nb.poetCfg.PhaseShift)
+	poetRoundStart := nb.layerClock.LayerToTime((postChallenge.PublishEpoch - 1).FirstLayer()).
+		Add(nb.poetCfg.PhaseShift)
 	poetRoundEnd := nb.layerClock.LayerToTime(postChallenge.PublishEpoch.FirstLayer()).
 		Add(nb.poetCfg.PhaseShift).
 		Add(-nb.poetCfg.CycleGap)

--- a/activation/nipost.go
+++ b/activation/nipost.go
@@ -156,7 +156,7 @@ func (nb *NIPostBuilder) Proof(
 		// have changed between the initial PoST and the upcoming one (initial ATX
 		// still not published)
 		// TODO change to postChallenge.InitialPost
-		if postChallenge != nil {
+		if postChallenge != nil && postChallenge.InitialPost != nil {
 			info, err := client.Info(ctx)
 			if errors.Is(err, ErrPostClientClosed) {
 				continue

--- a/activation/nipost.go
+++ b/activation/nipost.go
@@ -148,12 +148,9 @@ func (nb *NIPostBuilder) Proof(
 		}
 
 		retries = 0
-
-		// we check whether an initial post is included, if so, it means
-		// we land under the possible edge case where the storage units
-		// have changed between the initial PoST and the upcoming one (initial ATX
-		// still not published)
-		// TODO change to postChallenge.InitialPost
+		// we check whether an initial post is included in the challenge
+		// if so, we verify it to still be valid before creating the post
+		// e.g. the PoST size might have changed
 		if postChallenge != nil && postChallenge.InitialPost != nil {
 			info, err := client.Info(ctx)
 			if errors.Is(err, ErrPostClientClosed) {

--- a/activation/nipost.go
+++ b/activation/nipost.go
@@ -155,6 +155,7 @@ func (nb *NIPostBuilder) Proof(
 		// we land under the possible edge case where the storage units
 		// have changed between the initial PoST and the upcoming one (initial ATX
 		// still not published)
+		// TODO change to postChallenge.InitialPost
 		if postChallenge != nil {
 			info, err := client.Info(ctx)
 			if errors.Is(err, ErrPostClientClosed) {

--- a/activation/nipost_test.go
+++ b/activation/nipost_test.go
@@ -112,7 +112,7 @@ func Test_NIPost_PostClientHandling(t *testing.T) {
 		tnb.mPostService.EXPECT().Client(sig.NodeID()).Return(tnb.mPostClient, nil)
 		tnb.mPostClient.EXPECT().Proof(gomock.Any(), gomock.Any()).Return(&types.Post{}, &types.PostInfo{}, nil)
 
-		nipost, nipostInfo, err := tnb.Proof(context.Background(), sig.NodeID(), shared.ZeroChallenge)
+		nipost, nipostInfo, err := tnb.Proof(context.Background(), sig.NodeID(), shared.ZeroChallenge, nil)
 		require.NoError(t, err)
 		require.NotNil(t, nipost)
 		require.NotNil(t, nipostInfo)
@@ -148,7 +148,7 @@ func Test_NIPost_PostClientHandling(t *testing.T) {
 		expectedErr := errors.New("some error")
 		tnb.mPostClient.EXPECT().Proof(gomock.Any(), gomock.Any()).Return(nil, nil, expectedErr)
 
-		nipost, nipostInfo, err := tnb.Proof(context.Background(), sig.NodeID(), shared.ZeroChallenge)
+		nipost, nipostInfo, err := tnb.Proof(context.Background(), sig.NodeID(), shared.ZeroChallenge, nil)
 		require.ErrorIs(t, err, expectedErr)
 		require.Nil(t, nipost)
 		require.Nil(t, nipostInfo)
@@ -184,7 +184,7 @@ func Test_NIPost_PostClientHandling(t *testing.T) {
 		tnb.mPostService.EXPECT().Client(sig.NodeID()).Return(tnb.mPostClient, nil)
 		tnb.mPostClient.EXPECT().Proof(gomock.Any(), gomock.Any()).Return(&types.Post{}, &types.PostInfo{}, nil)
 
-		nipost, nipostInfo, err := tnb.Proof(context.Background(), sig.NodeID(), shared.ZeroChallenge)
+		nipost, nipostInfo, err := tnb.Proof(context.Background(), sig.NodeID(), shared.ZeroChallenge, nil)
 		require.NoError(t, err)
 		require.NotNil(t, nipost)
 		require.NotNil(t, nipostInfo)
@@ -252,7 +252,7 @@ func Test_NIPost_PostClientHandling(t *testing.T) {
 				return nil, ErrPostClientNotConnected
 			})
 
-		nipost, nipostInfo, err := tnb.Proof(ctx, sig.NodeID(), shared.ZeroChallenge)
+		nipost, nipostInfo, err := tnb.Proof(ctx, sig.NodeID(), shared.ZeroChallenge, nil)
 		require.ErrorIs(t, err, context.Canceled)
 		require.Nil(t, nipost)
 		require.Nil(t, nipostInfo)
@@ -273,7 +273,7 @@ func Test_NIPost_PostClientHandling(t *testing.T) {
 		expectedErr := errors.New("some error")
 		tnb.mPostClient.EXPECT().Proof(gomock.Any(), gomock.Any()).Return(nil, nil, expectedErr)
 
-		nipost, nipostInfo, err := tnb.Proof(context.Background(), sig.NodeID(), shared.ZeroChallenge)
+		nipost, nipostInfo, err := tnb.Proof(context.Background(), sig.NodeID(), shared.ZeroChallenge, nil)
 		require.ErrorIs(t, err, expectedErr)
 		require.Nil(t, nipost)
 		require.Nil(t, nipostInfo)
@@ -311,7 +311,7 @@ func Test_NIPost_PostClientHandling(t *testing.T) {
 				return nil, ErrPostClientNotConnected
 			})
 
-		nipost, nipostInfo, err := tnb.Proof(ctx, sig.NodeID(), shared.ZeroChallenge)
+		nipost, nipostInfo, err := tnb.Proof(ctx, sig.NodeID(), shared.ZeroChallenge, nil)
 		require.ErrorIs(t, err, context.Canceled)
 		require.Nil(t, nipost)
 		require.Nil(t, nipostInfo)
@@ -403,7 +403,7 @@ func Test_NIPostBuilder_WithMocks(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	nipost, err := nb.BuildNIPost(context.Background(), sig, postGenesisEpoch+2, challenge)
+	nipost, err := nb.BuildNIPost(context.Background(), sig, postGenesisEpoch+2, challenge, nil)
 	require.NoError(t, err)
 	require.NotNil(t, nipost)
 }
@@ -437,7 +437,7 @@ func TestPostSetup(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	nipost, err := nb.BuildNIPost(context.Background(), sig, postGenesisEpoch+2, challenge)
+	nipost, err := nb.BuildNIPost(context.Background(), sig, postGenesisEpoch+2, challenge, nil)
 	require.NoError(t, err)
 	require.NotNil(t, nipost)
 }
@@ -488,7 +488,7 @@ func TestNIPostBuilder_BuildNIPost(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	nipost, err := nb.BuildNIPost(context.Background(), sig, 7, challengeHash)
+	nipost, err := nb.BuildNIPost(context.Background(), sig, 7, challengeHash, nil)
 	require.NoError(t, err)
 	require.NotNil(t, nipost)
 
@@ -507,7 +507,7 @@ func TestNIPostBuilder_BuildNIPost(t *testing.T) {
 	postClient.EXPECT().Proof(gomock.Any(), gomock.Any()).Return(nil, nil, errors.New("error"))
 
 	// check that proof ref is not called again
-	nipost, err = nb.BuildNIPost(context.Background(), sig, 7, challengeHash)
+	nipost, err = nb.BuildNIPost(context.Background(), sig, 7, challengeHash, nil)
 	require.Nil(t, nipost)
 	require.Error(t, err)
 
@@ -530,7 +530,7 @@ func TestNIPostBuilder_BuildNIPost(t *testing.T) {
 	)
 
 	// check that proof ref is not called again
-	nipost, err = nb.BuildNIPost(context.Background(), sig, 7, challengeHash)
+	nipost, err = nb.BuildNIPost(context.Background(), sig, 7, challengeHash, nil)
 	require.NoError(t, err)
 	require.NotNil(t, nipost)
 }
@@ -600,7 +600,7 @@ func TestNIPostBuilder_ManyPoETs_SubmittingChallenge_DeadlineReached(t *testing.
 	require.NoError(t, err)
 
 	// Act
-	nipost, err := nb.BuildNIPost(context.Background(), sig, postGenesisEpoch+2, challenge)
+	nipost, err := nb.BuildNIPost(context.Background(), sig, postGenesisEpoch+2, challenge, nil)
 	require.NoError(t, err)
 
 	// Verify
@@ -657,7 +657,7 @@ func TestNIPostBuilder_ManyPoETs_AllFinished(t *testing.T) {
 	require.NoError(t, err)
 
 	// Act
-	nipost, err := nb.BuildNIPost(context.Background(), sig, postGenesisEpoch+2, challenge)
+	nipost, err := nb.BuildNIPost(context.Background(), sig, postGenesisEpoch+2, challenge, nil)
 	require.NoError(t, err)
 
 	// Verify
@@ -695,7 +695,7 @@ func TestNIPSTBuilder_PoetUnstable(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		nipst, err := nb.BuildNIPost(context.Background(), sig, postGenesisEpoch+2, challenge)
+		nipst, err := nb.BuildNIPost(context.Background(), sig, postGenesisEpoch+2, challenge, nil)
 		require.ErrorIs(t, err, ErrPoetServiceUnstable)
 		require.Nil(t, nipst)
 	})
@@ -730,7 +730,7 @@ func TestNIPSTBuilder_PoetUnstable(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		nipst, err := nb.BuildNIPost(context.Background(), sig, postGenesisEpoch+2, challenge)
+		nipst, err := nb.BuildNIPost(context.Background(), sig, postGenesisEpoch+2, challenge, nil)
 		require.ErrorIs(t, err, ErrPoetServiceUnstable)
 		require.Nil(t, nipst)
 	})
@@ -752,7 +752,7 @@ func TestNIPSTBuilder_PoetUnstable(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		nipst, err := nb.BuildNIPost(context.Background(), sig, postGenesisEpoch+2, challenge)
+		nipst, err := nb.BuildNIPost(context.Background(), sig, postGenesisEpoch+2, challenge, nil)
 		require.ErrorIs(t, err, ErrPoetProofNotReceived)
 		require.Nil(t, nipst)
 	})
@@ -776,7 +776,7 @@ func TestNIPSTBuilder_PoetUnstable(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		nipst, err := nb.BuildNIPost(context.Background(), sig, postGenesisEpoch+2, challenge)
+		nipst, err := nb.BuildNIPost(context.Background(), sig, postGenesisEpoch+2, challenge, nil)
 		require.ErrorIs(t, err, ErrPoetProofNotReceived)
 		require.Nil(t, nipst)
 	})
@@ -816,7 +816,7 @@ func TestNIPoSTBuilder_StaleChallenge(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		nipost, err := nb.BuildNIPost(context.Background(), sig, currLayer.GetEpoch(), types.RandomHash())
+		nipost, err := nb.BuildNIPost(context.Background(), sig, currLayer.GetEpoch(), types.RandomHash(), nil)
 		require.ErrorIs(t, err, ErrATXChallengeExpired)
 		require.ErrorContains(t, err, "poet round has already started")
 		require.Nil(t, nipost)
@@ -857,7 +857,7 @@ func TestNIPoSTBuilder_StaleChallenge(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		nipost, err := nb.BuildNIPost(context.Background(), sig, challenge.PublishEpoch, challengeHash)
+		nipost, err := nb.BuildNIPost(context.Background(), sig, challenge.PublishEpoch, challengeHash, nil)
 		require.ErrorIs(t, err, ErrATXChallengeExpired)
 		require.ErrorContains(t, err, "poet proof for pub epoch")
 		require.Nil(t, nipost)
@@ -902,7 +902,7 @@ func TestNIPoSTBuilder_StaleChallenge(t *testing.T) {
 		err = nipost.UpdatePoetProofRef(db, sig.NodeID(), [32]byte{1, 2, 3}, &types.MerkleProof{})
 		require.NoError(t, err)
 
-		nipost, err := nb.BuildNIPost(context.Background(), sig, challenge.PublishEpoch, challengeHash)
+		nipost, err := nb.BuildNIPost(context.Background(), sig, challenge.PublishEpoch, challengeHash, nil)
 		require.ErrorIs(t, err, ErrATXChallengeExpired)
 		require.ErrorContains(t, err, "deadline to publish ATX for pub epoch")
 		require.Nil(t, nipost)
@@ -964,7 +964,7 @@ func TestNIPoSTBuilder_Continues_After_Interrupted(t *testing.T) {
 	require.NoError(t, err)
 
 	// Act
-	nipost, err := nb.BuildNIPost(buildCtx, sig, postGenesisEpoch+2, challenge)
+	nipost, err := nb.BuildNIPost(buildCtx, sig, postGenesisEpoch+2, challenge, nil)
 	require.ErrorIs(t, err, context.Canceled)
 	require.Nil(t, nipost)
 
@@ -973,7 +973,7 @@ func TestNIPoSTBuilder_Continues_After_Interrupted(t *testing.T) {
 		Submit(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(&types.PoetRound{}, nil)
 
-	nipost, err = nb.BuildNIPost(context.Background(), sig, postGenesisEpoch+2, challenge)
+	nipost, err = nb.BuildNIPost(context.Background(), sig, postGenesisEpoch+2, challenge, nil)
 	require.NoError(t, err)
 
 	// Verify
@@ -1097,7 +1097,7 @@ func TestNIPostBuilder_Mainnet_Poet_Workaround(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			nipost, err := nb.BuildNIPost(context.Background(), sig, tc.epoch, challenge)
+			nipost, err := nb.BuildNIPost(context.Background(), sig, tc.epoch, challenge, nil)
 			require.NoError(t, err)
 			require.NotNil(t, nipost)
 		})
@@ -1168,6 +1168,6 @@ func TestNIPostBuilder_Close(t *testing.T) {
 	cancel()
 	challenge := types.RandomHash()
 
-	_, err = nb.BuildNIPost(ctx, sig, postGenesisEpoch+2, challenge)
+	_, err = nb.BuildNIPost(ctx, sig, postGenesisEpoch+2, challenge, nil)
 	require.Error(t, err)
 }

--- a/activation/nipost_test.go
+++ b/activation/nipost_test.go
@@ -58,6 +58,7 @@ type testNIPostBuilder struct {
 	mClock       *MocklayerClock
 	mPostService *MockpostService
 	mPostClient  *MockPostClient
+	mValidator   *MocknipostValidator
 }
 
 func newTestNIPostBuilder(tb testing.TB) *testNIPostBuilder {
@@ -88,6 +89,7 @@ func newTestNIPostBuilder(tb testing.TB) *testNIPostBuilder {
 		mPostClient:  NewMockPostClient(ctrl),
 		mLogger:      logger,
 		mClock:       defaultLayerClockMock(ctrl),
+		mValidator:   NewMocknipostValidator(ctrl),
 	}
 
 	nb, err := NewNIPostBuilder(
@@ -96,6 +98,7 @@ func newTestNIPostBuilder(tb testing.TB) *testNIPostBuilder {
 		tnb.mLogger,
 		PoetConfig{},
 		tnb.mClock,
+		tnb.mValidator,
 	)
 	require.NoError(tb, err)
 	tnb.NIPostBuilder = nb
@@ -341,6 +344,7 @@ func Test_NIPostBuilder_ResetState(t *testing.T) {
 		zaptest.NewLogger(t),
 		PoetConfig{},
 		mclock,
+		nil,
 	)
 	require.NoError(t, err)
 
@@ -399,6 +403,7 @@ func Test_NIPostBuilder_WithMocks(t *testing.T) {
 		zaptest.NewLogger(t),
 		PoetConfig{},
 		mclock,
+		nil,
 		WithPoetClients(poetProvider),
 	)
 	require.NoError(t, err)
@@ -433,6 +438,7 @@ func TestPostSetup(t *testing.T) {
 		zaptest.NewLogger(t),
 		PoetConfig{},
 		mclock,
+		nil,
 		WithPoetClients(poetProvider),
 	)
 	require.NoError(t, err)
@@ -484,6 +490,7 @@ func TestNIPostBuilder_BuildNIPost(t *testing.T) {
 		zaptest.NewLogger(t),
 		PoetConfig{},
 		mclock,
+		nil,
 		WithPoetClients(poetProver),
 	)
 	require.NoError(t, err)
@@ -500,6 +507,7 @@ func TestNIPostBuilder_BuildNIPost(t *testing.T) {
 		zaptest.NewLogger(t),
 		PoetConfig{},
 		mclock,
+		nil,
 		WithPoetClients(poetProver),
 	)
 	require.NoError(t, err)
@@ -518,6 +526,7 @@ func TestNIPostBuilder_BuildNIPost(t *testing.T) {
 		zaptest.NewLogger(t),
 		PoetConfig{},
 		mclock,
+		nil,
 		WithPoetClients(poetProver),
 	)
 	require.NoError(t, err)
@@ -595,6 +604,7 @@ func TestNIPostBuilder_ManyPoETs_SubmittingChallenge_DeadlineReached(t *testing.
 		zaptest.NewLogger(t),
 		poetCfg,
 		mclock,
+		nil,
 		WithPoetClients(poets...),
 	)
 	require.NoError(t, err)
@@ -652,6 +662,7 @@ func TestNIPostBuilder_ManyPoETs_AllFinished(t *testing.T) {
 		zaptest.NewLogger(t),
 		PoetConfig{},
 		mclock,
+		nil,
 		WithPoetClients(poets...),
 	)
 	require.NoError(t, err)
@@ -691,6 +702,7 @@ func TestNIPSTBuilder_PoetUnstable(t *testing.T) {
 			zaptest.NewLogger(t),
 			poetCfg,
 			mclock,
+			nil,
 			WithPoetClients(poetProver),
 		)
 		require.NoError(t, err)
@@ -726,6 +738,7 @@ func TestNIPSTBuilder_PoetUnstable(t *testing.T) {
 			zaptest.NewLogger(t),
 			poetCfg,
 			mclock,
+			nil,
 			WithPoetClients(poetProver),
 		)
 		require.NoError(t, err)
@@ -748,6 +761,7 @@ func TestNIPSTBuilder_PoetUnstable(t *testing.T) {
 			zaptest.NewLogger(t),
 			poetCfg,
 			mclock,
+			nil,
 			WithPoetClients(poetProver),
 		)
 		require.NoError(t, err)
@@ -772,6 +786,7 @@ func TestNIPSTBuilder_PoetUnstable(t *testing.T) {
 			zaptest.NewLogger(t),
 			poetCfg,
 			mclock,
+			nil,
 			WithPoetClients(poetProver),
 		)
 		require.NoError(t, err)
@@ -812,6 +827,7 @@ func TestNIPoSTBuilder_StaleChallenge(t *testing.T) {
 			zaptest.NewLogger(t),
 			PoetConfig{},
 			mclock,
+			nil,
 			WithPoetClients(poetProver),
 		)
 		require.NoError(t, err)
@@ -839,6 +855,7 @@ func TestNIPoSTBuilder_StaleChallenge(t *testing.T) {
 			zaptest.NewLogger(t),
 			PoetConfig{},
 			mclock,
+			nil,
 			WithPoetClients(poetProver),
 		)
 		require.NoError(t, err)
@@ -880,6 +897,7 @@ func TestNIPoSTBuilder_StaleChallenge(t *testing.T) {
 			zaptest.NewLogger(t),
 			PoetConfig{},
 			mclock,
+			nil,
 			WithPoetClients(poetProver),
 		)
 		require.NoError(t, err)
@@ -959,6 +977,7 @@ func TestNIPoSTBuilder_Continues_After_Interrupted(t *testing.T) {
 		zaptest.NewLogger(t),
 		poetCfg,
 		mclock,
+		nil,
 		WithPoetClients(poet),
 	)
 	require.NoError(t, err)
@@ -1093,6 +1112,7 @@ func TestNIPostBuilder_Mainnet_Poet_Workaround(t *testing.T) {
 				zaptest.NewLogger(t),
 				poetCfg,
 				mclock,
+				nil,
 				WithPoetClients(poets...),
 			)
 			require.NoError(t, err)
@@ -1160,6 +1180,7 @@ func TestNIPostBuilder_Close(t *testing.T) {
 		zaptest.NewLogger(t),
 		PoetConfig{},
 		defaultLayerClockMock(ctrl),
+		nil,
 		WithPoetClients(poet),
 	)
 	require.NoError(t, err)

--- a/activation/nipost_test.go
+++ b/activation/nipost_test.go
@@ -408,7 +408,8 @@ func Test_NIPostBuilder_WithMocks(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	nipost, err := nb.BuildNIPost(context.Background(), sig, challenge, &types.NIPostChallenge{PublishEpoch: postGenesisEpoch + 2})
+	nipost, err := nb.BuildNIPost(context.Background(), sig, challenge,
+		&types.NIPostChallenge{PublishEpoch: postGenesisEpoch + 2})
 	require.NoError(t, err)
 	require.NotNil(t, nipost)
 }
@@ -443,7 +444,8 @@ func TestPostSetup(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	nipost, err := nb.BuildNIPost(context.Background(), sig, challenge, &types.NIPostChallenge{PublishEpoch: postGenesisEpoch + 2})
+	nipost, err := nb.BuildNIPost(context.Background(), sig, challenge,
+		&types.NIPostChallenge{PublishEpoch: postGenesisEpoch + 2})
 	require.NoError(t, err)
 	require.NotNil(t, nipost)
 }
@@ -612,7 +614,8 @@ func TestNIPostBuilder_ManyPoETs_SubmittingChallenge_DeadlineReached(t *testing.
 	require.NoError(t, err)
 
 	// Act
-	nipost, err := nb.BuildNIPost(context.Background(), sig, challenge, &types.NIPostChallenge{PublishEpoch: postGenesisEpoch + 2})
+	nipost, err := nb.BuildNIPost(context.Background(), sig, challenge,
+		&types.NIPostChallenge{PublishEpoch: postGenesisEpoch + 2})
 	require.NoError(t, err)
 
 	// Verify
@@ -670,7 +673,8 @@ func TestNIPostBuilder_ManyPoETs_AllFinished(t *testing.T) {
 	require.NoError(t, err)
 
 	// Act
-	nipost, err := nb.BuildNIPost(context.Background(), sig, challenge, &types.NIPostChallenge{PublishEpoch: postGenesisEpoch + 2})
+	nipost, err := nb.BuildNIPost(context.Background(), sig, challenge,
+		&types.NIPostChallenge{PublishEpoch: postGenesisEpoch + 2})
 	require.NoError(t, err)
 
 	// Verify
@@ -709,7 +713,8 @@ func TestNIPSTBuilder_PoetUnstable(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		nipst, err := nb.BuildNIPost(context.Background(), sig, challenge, &types.NIPostChallenge{PublishEpoch: postGenesisEpoch + 2})
+		nipst, err := nb.BuildNIPost(context.Background(), sig, challenge,
+			&types.NIPostChallenge{PublishEpoch: postGenesisEpoch + 2})
 		require.ErrorIs(t, err, ErrPoetServiceUnstable)
 		require.Nil(t, nipst)
 	})
@@ -745,7 +750,8 @@ func TestNIPSTBuilder_PoetUnstable(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		nipst, err := nb.BuildNIPost(context.Background(), sig, challenge, &types.NIPostChallenge{PublishEpoch: postGenesisEpoch + 2})
+		nipst, err := nb.BuildNIPost(context.Background(), sig, challenge,
+			&types.NIPostChallenge{PublishEpoch: postGenesisEpoch + 2})
 		require.ErrorIs(t, err, ErrPoetServiceUnstable)
 		require.Nil(t, nipst)
 	})
@@ -768,7 +774,8 @@ func TestNIPSTBuilder_PoetUnstable(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		nipst, err := nb.BuildNIPost(context.Background(), sig, challenge, &types.NIPostChallenge{PublishEpoch: postGenesisEpoch + 2})
+		nipst, err := nb.BuildNIPost(context.Background(), sig, challenge,
+			&types.NIPostChallenge{PublishEpoch: postGenesisEpoch + 2})
 		require.ErrorIs(t, err, ErrPoetProofNotReceived)
 		require.Nil(t, nipst)
 	})
@@ -793,7 +800,8 @@ func TestNIPSTBuilder_PoetUnstable(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		nipst, err := nb.BuildNIPost(context.Background(), sig, challenge, &types.NIPostChallenge{PublishEpoch: postGenesisEpoch + 2})
+		nipst, err := nb.BuildNIPost(context.Background(), sig, challenge,
+			&types.NIPostChallenge{PublishEpoch: postGenesisEpoch + 2})
 		require.ErrorIs(t, err, ErrPoetProofNotReceived)
 		require.Nil(t, nipst)
 	})
@@ -834,7 +842,8 @@ func TestNIPoSTBuilder_StaleChallenge(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		nipost, err := nb.BuildNIPost(context.Background(), sig, types.RandomHash(), &types.NIPostChallenge{PublishEpoch: currLayer.GetEpoch()})
+		nipost, err := nb.BuildNIPost(context.Background(), sig, types.RandomHash(),
+			&types.NIPostChallenge{PublishEpoch: currLayer.GetEpoch()})
 		require.ErrorIs(t, err, ErrATXChallengeExpired)
 		require.ErrorContains(t, err, "poet round has already started")
 		require.Nil(t, nipost)
@@ -994,7 +1003,8 @@ func TestNIPoSTBuilder_Continues_After_Interrupted(t *testing.T) {
 		Submit(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(&types.PoetRound{}, nil)
 
-	nipost, err = nb.BuildNIPost(context.Background(), sig, challenge, &types.NIPostChallenge{PublishEpoch: postGenesisEpoch + 2})
+	nipost, err = nb.BuildNIPost(context.Background(), sig, challenge,
+		&types.NIPostChallenge{PublishEpoch: postGenesisEpoch + 2})
 	require.NoError(t, err)
 
 	// Verify
@@ -1119,7 +1129,8 @@ func TestNIPostBuilder_Mainnet_Poet_Workaround(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			nipost, err := nb.BuildNIPost(context.Background(), sig, challenge, &types.NIPostChallenge{PublishEpoch: tc.epoch})
+			nipost, err := nb.BuildNIPost(context.Background(), sig, challenge,
+				&types.NIPostChallenge{PublishEpoch: tc.epoch})
 			require.NoError(t, err)
 			require.NotNil(t, nipost)
 		})
@@ -1206,7 +1217,8 @@ func TestNIPostBuilderProof_WithBadInitialPost(t *testing.T) {
 			return nil, nil, ctx.Err()
 		})
 	validator := NewMocknipostValidator(ctrl)
-	validator.EXPECT().PostV2(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("some error"))
+	validator.EXPECT().PostV2(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(errors.New("some error"))
 
 	postClient := NewMockPostClient(ctrl)
 	postClient.EXPECT().Info(gomock.Any()).Return(&types.PostInfo{}, nil)

--- a/activation/nipost_test.go
+++ b/activation/nipost_test.go
@@ -408,7 +408,7 @@ func Test_NIPostBuilder_WithMocks(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	nipost, err := nb.BuildNIPost(context.Background(), sig, postGenesisEpoch+2, challenge, nil)
+	nipost, err := nb.BuildNIPost(context.Background(), sig, challenge, &types.NIPostChallenge{PublishEpoch: postGenesisEpoch + 2})
 	require.NoError(t, err)
 	require.NotNil(t, nipost)
 }
@@ -443,7 +443,7 @@ func TestPostSetup(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	nipost, err := nb.BuildNIPost(context.Background(), sig, postGenesisEpoch+2, challenge, nil)
+	nipost, err := nb.BuildNIPost(context.Background(), sig, challenge, &types.NIPostChallenge{PublishEpoch: postGenesisEpoch + 2})
 	require.NoError(t, err)
 	require.NotNil(t, nipost)
 }
@@ -495,7 +495,7 @@ func TestNIPostBuilder_BuildNIPost(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	nipost, err := nb.BuildNIPost(context.Background(), sig, 7, challengeHash, nil)
+	nipost, err := nb.BuildNIPost(context.Background(), sig, challengeHash, &types.NIPostChallenge{PublishEpoch: 7})
 	require.NoError(t, err)
 	require.NotNil(t, nipost)
 
@@ -515,7 +515,8 @@ func TestNIPostBuilder_BuildNIPost(t *testing.T) {
 	postClient.EXPECT().Proof(gomock.Any(), gomock.Any()).Return(nil, nil, errors.New("error"))
 
 	// check that proof ref is not called again
-	nipost, err = nb.BuildNIPost(context.Background(), sig, 7, challengeHash, nil)
+	nipost, err = nb.BuildNIPost(context.Background(), sig, challengeHash, &types.NIPostChallenge{PublishEpoch: 7})
+
 	require.Nil(t, nipost)
 	require.Error(t, err)
 
@@ -539,7 +540,8 @@ func TestNIPostBuilder_BuildNIPost(t *testing.T) {
 	)
 
 	// check that proof ref is not called again
-	nipost, err = nb.BuildNIPost(context.Background(), sig, 7, challengeHash, nil)
+	nipost, err = nb.BuildNIPost(context.Background(), sig, challengeHash, &types.NIPostChallenge{PublishEpoch: 7})
+
 	require.NoError(t, err)
 	require.NotNil(t, nipost)
 }
@@ -610,7 +612,7 @@ func TestNIPostBuilder_ManyPoETs_SubmittingChallenge_DeadlineReached(t *testing.
 	require.NoError(t, err)
 
 	// Act
-	nipost, err := nb.BuildNIPost(context.Background(), sig, postGenesisEpoch+2, challenge, nil)
+	nipost, err := nb.BuildNIPost(context.Background(), sig, challenge, &types.NIPostChallenge{PublishEpoch: postGenesisEpoch + 2})
 	require.NoError(t, err)
 
 	// Verify
@@ -668,7 +670,7 @@ func TestNIPostBuilder_ManyPoETs_AllFinished(t *testing.T) {
 	require.NoError(t, err)
 
 	// Act
-	nipost, err := nb.BuildNIPost(context.Background(), sig, postGenesisEpoch+2, challenge, nil)
+	nipost, err := nb.BuildNIPost(context.Background(), sig, challenge, &types.NIPostChallenge{PublishEpoch: postGenesisEpoch + 2})
 	require.NoError(t, err)
 
 	// Verify
@@ -707,7 +709,7 @@ func TestNIPSTBuilder_PoetUnstable(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		nipst, err := nb.BuildNIPost(context.Background(), sig, postGenesisEpoch+2, challenge, nil)
+		nipst, err := nb.BuildNIPost(context.Background(), sig, challenge, &types.NIPostChallenge{PublishEpoch: postGenesisEpoch + 2})
 		require.ErrorIs(t, err, ErrPoetServiceUnstable)
 		require.Nil(t, nipst)
 	})
@@ -743,7 +745,7 @@ func TestNIPSTBuilder_PoetUnstable(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		nipst, err := nb.BuildNIPost(context.Background(), sig, postGenesisEpoch+2, challenge, nil)
+		nipst, err := nb.BuildNIPost(context.Background(), sig, challenge, &types.NIPostChallenge{PublishEpoch: postGenesisEpoch + 2})
 		require.ErrorIs(t, err, ErrPoetServiceUnstable)
 		require.Nil(t, nipst)
 	})
@@ -766,7 +768,7 @@ func TestNIPSTBuilder_PoetUnstable(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		nipst, err := nb.BuildNIPost(context.Background(), sig, postGenesisEpoch+2, challenge, nil)
+		nipst, err := nb.BuildNIPost(context.Background(), sig, challenge, &types.NIPostChallenge{PublishEpoch: postGenesisEpoch + 2})
 		require.ErrorIs(t, err, ErrPoetProofNotReceived)
 		require.Nil(t, nipst)
 	})
@@ -791,7 +793,7 @@ func TestNIPSTBuilder_PoetUnstable(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		nipst, err := nb.BuildNIPost(context.Background(), sig, postGenesisEpoch+2, challenge, nil)
+		nipst, err := nb.BuildNIPost(context.Background(), sig, challenge, &types.NIPostChallenge{PublishEpoch: postGenesisEpoch + 2})
 		require.ErrorIs(t, err, ErrPoetProofNotReceived)
 		require.Nil(t, nipst)
 	})
@@ -874,7 +876,7 @@ func TestNIPoSTBuilder_StaleChallenge(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		nipost, err := nb.BuildNIPost(context.Background(), sig, challenge.PublishEpoch, challengeHash, nil)
+		nipost, err := nb.BuildNIPost(context.Background(), sig, challengeHash, challenge)
 		require.ErrorIs(t, err, ErrATXChallengeExpired)
 		require.ErrorContains(t, err, "poet proof for pub epoch")
 		require.Nil(t, nipost)
@@ -920,7 +922,7 @@ func TestNIPoSTBuilder_StaleChallenge(t *testing.T) {
 		err = nipost.UpdatePoetProofRef(db, sig.NodeID(), [32]byte{1, 2, 3}, &types.MerkleProof{})
 		require.NoError(t, err)
 
-		nipost, err := nb.BuildNIPost(context.Background(), sig, challenge.PublishEpoch, challengeHash, nil)
+		nipost, err := nb.BuildNIPost(context.Background(), sig, challengeHash, challenge)
 		require.ErrorIs(t, err, ErrATXChallengeExpired)
 		require.ErrorContains(t, err, "deadline to publish ATX for pub epoch")
 		require.Nil(t, nipost)
@@ -983,7 +985,7 @@ func TestNIPoSTBuilder_Continues_After_Interrupted(t *testing.T) {
 	require.NoError(t, err)
 
 	// Act
-	nipost, err := nb.BuildNIPost(buildCtx, sig, postGenesisEpoch+2, challenge, nil)
+	nipost, err := nb.BuildNIPost(buildCtx, sig, challenge, &types.NIPostChallenge{PublishEpoch: postGenesisEpoch + 2})
 	require.ErrorIs(t, err, context.Canceled)
 	require.Nil(t, nipost)
 
@@ -992,7 +994,7 @@ func TestNIPoSTBuilder_Continues_After_Interrupted(t *testing.T) {
 		Submit(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(&types.PoetRound{}, nil)
 
-	nipost, err = nb.BuildNIPost(context.Background(), sig, postGenesisEpoch+2, challenge, nil)
+	nipost, err = nb.BuildNIPost(context.Background(), sig, challenge, &types.NIPostChallenge{PublishEpoch: postGenesisEpoch + 2})
 	require.NoError(t, err)
 
 	// Verify
@@ -1117,7 +1119,7 @@ func TestNIPostBuilder_Mainnet_Poet_Workaround(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			nipost, err := nb.BuildNIPost(context.Background(), sig, tc.epoch, challenge, nil)
+			nipost, err := nb.BuildNIPost(context.Background(), sig, challenge, &types.NIPostChallenge{PublishEpoch: tc.epoch})
 			require.NoError(t, err)
 			require.NotNil(t, nipost)
 		})
@@ -1189,7 +1191,7 @@ func TestNIPostBuilder_Close(t *testing.T) {
 	cancel()
 	challenge := types.RandomHash()
 
-	_, err = nb.BuildNIPost(ctx, sig, postGenesisEpoch+2, challenge, nil)
+	_, err = nb.BuildNIPost(ctx, sig, challenge, &types.NIPostChallenge{PublishEpoch: postGenesisEpoch + 2})
 	require.Error(t, err)
 }
 

--- a/activation/nipost_test.go
+++ b/activation/nipost_test.go
@@ -834,7 +834,7 @@ func TestNIPoSTBuilder_StaleChallenge(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		nipost, err := nb.BuildNIPost(context.Background(), sig, currLayer.GetEpoch(), types.RandomHash(), nil)
+		nipost, err := nb.BuildNIPost(context.Background(), sig, types.RandomHash(), &types.NIPostChallenge{PublishEpoch: currLayer.GetEpoch()})
 		require.ErrorIs(t, err, ErrATXChallengeExpired)
 		require.ErrorContains(t, err, "poet round has already started")
 		require.Nil(t, nipost)

--- a/activation/post_states_test.go
+++ b/activation/post_states_test.go
@@ -66,6 +66,6 @@ func TestPostState_OnProof(t *testing.T) {
 		mpostStates.EXPECT().Set(id, types.PostStateIdle),
 	)
 
-	_, _, err = nb.Proof(context.Background(), id, []byte("abc"))
+	_, _, err = nb.Proof(context.Background(), id, []byte("abc"), nil)
 	require.NoError(t, err)
 }

--- a/activation/post_states_test.go
+++ b/activation/post_states_test.go
@@ -53,6 +53,7 @@ func TestPostState_OnProof(t *testing.T) {
 		zaptest.NewLogger(t),
 		PoetConfig{},
 		nil,
+		nil,
 		NipostbuilderWithPostStates(mpostStates),
 	)
 	require.NoError(t, err)

--- a/node/node.go
+++ b/node/node.go
@@ -1031,6 +1031,7 @@ func (app *App) initServices(ctx context.Context) error {
 		nipostLogger,
 		app.Config.POET,
 		app.clock,
+		app.validator,
 		activation.NipostbuilderWithPostStates(postStates),
 		activation.WithPoetClients(poetClients...),
 	)

--- a/systest/tests/distributed_post_verification_test.go
+++ b/systest/tests/distributed_post_verification_test.go
@@ -159,8 +159,9 @@ func TestPostMalfeasanceProof(t *testing.T) {
 	localDb := localsql.InMemory()
 	certClient := activation.NewCertifierClient(db, localDb, logger.Named("certifier"))
 	certifier := activation.NewCertifier(localDb, logger, certClient)
+	poetDb := activation.NewPoetDb(db, zap.NewNop())
 	poetClient, err := activation.NewPoetClient(
-		activation.NewPoetDb(db, zap.NewNop()),
+		poetDb,
 		types.PoetServer{
 			Address: cluster.MakePoetGlobalEndpoint(ctx.Namespace, 0),
 		}, cfg.POET,
@@ -169,12 +170,26 @@ func TestPostMalfeasanceProof(t *testing.T) {
 	)
 	require.NoError(t, err)
 
+	verifyingOpts := activation.DefaultPostVerifyingOpts()
+	verifyingOpts.Workers = 1
+	verifier, err := activation.NewPostVerifier(cfg.POST, logger, activation.WithVerifyingOpts(verifyingOpts))
+	require.NoError(t, err)
+
+	validator := activation.NewValidator(
+		db,
+		poetDb,
+		cfg.POST,
+		cfg.SMESHING.Opts.Scrypt,
+		verifier,
+	)
+
 	nipostBuilder, err := activation.NewNIPostBuilder(
 		localDb,
 		grpcPostService,
 		logger.Named("nipostBuilder"),
 		cfg.POET,
 		clock,
+		validator,
 		activation.WithPoetClients(poetClient),
 	)
 	require.NoError(t, err)
@@ -216,19 +231,26 @@ func TestPostMalfeasanceProof(t *testing.T) {
 		}
 		break
 	}
+	nipostChallenge := &types.NIPostChallenge{
+		PublishEpoch:   challenge.PublishEpoch,
+		PrevATXID:      types.EmptyATXID,
+		PositioningATX: challenge.PositioningATXID,
+		CommitmentATX:  challenge.CommitmentATXID,
+		InitialPost: &types.Post{
+			Nonce:   challenge.InitialPost.Nonce,
+			Indices: challenge.InitialPost.Indices,
+			Pow:     challenge.InitialPost.Pow,
+		}}
 
-	nipost, err := nipostBuilder.BuildNIPost(ctx, signer, challenge.PublishEpoch, challenge.Hash())
+	nipost, err := nipostBuilder.BuildNIPost(ctx, signer, challenge.Hash(), nipostChallenge)
 	require.NoError(t, err)
 
 	// 2.2 Create ATX with invalid POST
 	for i := range nipost.Post.Indices {
 		nipost.Post.Indices[i] += 1
 	}
+
 	// Sanity check that the POST is invalid
-	verifyingOpts := activation.DefaultPostVerifyingOpts()
-	verifyingOpts.Workers = 1
-	verifier, err := activation.NewPostVerifier(cfg.POST, logger, activation.WithVerifyingOpts(verifyingOpts))
-	require.NoError(t, err)
 	err = verifier.Verify(ctx, (*shared.Proof)(nipost.Post), &shared.ProofMetadata{
 		NodeId:          signer.NodeID().Bytes(),
 		CommitmentAtxId: challenge.CommitmentATXID.Bytes(),

--- a/systest/tests/distributed_post_verification_test.go
+++ b/systest/tests/distributed_post_verification_test.go
@@ -240,7 +240,8 @@ func TestPostMalfeasanceProof(t *testing.T) {
 			Nonce:   challenge.InitialPost.Nonce,
 			Indices: challenge.InitialPost.Indices,
 			Pow:     challenge.InitialPost.Pow,
-		}}
+		},
+	}
 
 	nipost, err := nipostBuilder.BuildNIPost(ctx, signer, challenge.Hash(), nipostChallenge)
 	require.NoError(t, err)


### PR DESCRIPTION
## Motivation
In #5921, an edge case is described where a node may start with a certain amount of SUs, generate an initial PoST but for possible reasons, the number of SUs may change before the first ATX is broadcasted. This means that the initial PoST is no longer valid and needs to be regenerated (costing the miner another epoch before being able to submit the initial ATX).

## Description
This PR fixes the issue by adding an extra check that verifies that the rust process has the same parameters (SUs among them) by executing a proof validation for the existing cached proof with the parameters that are used by the rust process (therefore, if the rust service is restarted with different parameters, this will be caught by this changeset).

<!-- If applicable please mention the issue addressed by this PR -->
<!-- `Closes #XXXX` links mentioned issues to this PR and automatically closes them when this it's merged -->

Closes #5921


## Test Plan

Unit test coverage in `activation_test.go` and `nipost_test.go`

## TODO

<!-- Please tick off the TODOs when completed -->

- [ ] missing test in `nipost_test.go`
- [ ] fix broken tests