### PR TITLE
[Merged by Bors] - api: v2alpha1 tx service: Use address field instead of principal & receiver

### DIFF
--- a/api/grpcserver/v2alpha1/transaction.go
+++ b/api/grpcserver/v2alpha1/transaction.go
@@ -244,13 +244,13 @@ func toTransactionOperations(filter *spacemeshv2alpha1.TransactionRequest) (buil
 		return ops, nil
 	}
 
-	if filter.GetPrincipal() != "" {
-		addr, err := types.StringToAddress(filter.GetPrincipal())
+	if filter.GetAddress() != "" {
+		addr, err := types.StringToAddress(filter.GetAddress())
 		if err != nil {
 			return builder.Operations{}, err
 		}
 		ops.Filter = append(ops.Filter, builder.Op{
-			Field: builder.Principal,
+			Field: builder.Address,
 			Token: builder.Eq,
 			Value: addr.Bytes(),
 		})
@@ -278,10 +278,6 @@ func toTransactionOperations(filter *spacemeshv2alpha1.TransactionRequest) (buil
 			Token: builder.Lte,
 			Value: int64(filter.GetEndLayer()),
 		})
-	}
-
-	if len(ops.Filter) > 0 {
-		ops.StartWith = "and"
 	}
 
 	ops.Modifiers = append(ops.Modifiers, builder.Modifier{
@@ -330,7 +326,7 @@ func toTx(tx *types.MeshTransaction, result *types.TransactionResult,
 		t.Contents = contents
 	}
 
-	if includeResult {
+	if includeResult && result != nil {
 		rst.TxResult = &spacemeshv2alpha1.TransactionResult{
 			Status:      convertTxResult(result),
 			Message:     result.Message,
@@ -368,14 +364,17 @@ func convertTxResult(result *types.TransactionResult) spacemeshv2alpha1.Transact
 }
 
 // TODO: REJECTED, INSUFFICIENT_FUNDS, CONFLICTING, MESH.
-func convertTxState(tx *types.MeshTransaction) spacemeshv2alpha1.TransactionState {
+func convertTxState(tx *types.MeshTransaction) *spacemeshv2alpha1.TransactionState {
 	switch tx.State {
 	case types.MEMPOOL:
-		return spacemeshv2alpha1.TransactionState_TRANSACTION_STATE_MEMPOOL
+		state := spacemeshv2alpha1.TransactionState_TRANSACTION_STATE_MEMPOOL
+		return &state
 	case types.APPLIED:
-		return spacemeshv2alpha1.TransactionState_TRANSACTION_STATE_PROCESSED
+		state := spacemeshv2alpha1.TransactionState_TRANSACTION_STATE_PROCESSED
+		return &state
 	default:
-		return spacemeshv2alpha1.TransactionState_TRANSACTION_STATE_UNSPECIFIED
+		state := spacemeshv2alpha1.TransactionState_TRANSACTION_STATE_UNSPECIFIED
+		return &state
 	}
 }
 

--- a/api/grpcserver/v2alpha1/transaction_test.go
+++ b/api/grpcserver/v2alpha1/transaction_test.go
@@ -87,15 +87,28 @@ func TestTransactionService_List(t *testing.T) {
 		require.Len(t, list.Transactions, len(txsList))
 	})
 
-	t.Run("principal", func(t *testing.T) {
-		principal := txsList[0].TxHeader.Principal.String()
+	t.Run("address", func(t *testing.T) {
+		address := txsList[0].Principal.String()
+		var expectedTxs []types.TransactionWithResult
+		for _, tx := range txsList {
+			found := false
+			for _, addr := range tx.TransactionResult.Addresses {
+				if addr.String() == address {
+					found = true
+					break
+				}
+			}
+			if found {
+				expectedTxs = append(expectedTxs, tx)
+			}
+		}
+
 		list, err := client.List(ctx, &spacemeshv2alpha1.TransactionRequest{
-			Principal: &principal,
-			Limit:     1,
+			Address: &address,
+			Limit:   100,
 		})
 		require.NoError(t, err)
-		require.Len(t, list.Transactions, 1)
-		require.Equal(t, list.Transactions[0].Tx.Principal, principal)
+		require.Len(t, list.Transactions, len(expectedTxs))
 	})
 
 	t.Run("tx id", func(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/rs/cors v1.11.0
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/seehuhn/mt19937 v1.0.0
-	github.com/spacemeshos/api/release/go v1.42.0
+	github.com/spacemeshos/api/release/go v1.43.2-0.20240612070402-1a65396d6c76
 	github.com/spacemeshos/economics v0.1.3
 	github.com/spacemeshos/fixed v0.1.1
 	github.com/spacemeshos/go-scale v1.2.0

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/rs/cors v1.11.0
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/seehuhn/mt19937 v1.0.0
-	github.com/spacemeshos/api/release/go v1.43.2-0.20240612070402-1a65396d6c76
+	github.com/spacemeshos/api/release/go v1.44.0
 	github.com/spacemeshos/economics v0.1.3
 	github.com/spacemeshos/fixed v0.1.1
 	github.com/spacemeshos/go-scale v1.2.0
@@ -60,7 +60,7 @@ require (
 	golang.org/x/time v0.5.0
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240528184218-531527333157
 	google.golang.org/grpc v1.64.0
-	google.golang.org/protobuf v1.34.1
+	google.golang.org/protobuf v1.34.2
 	k8s.io/api v0.30.1
 	k8s.io/apimachinery v0.30.1
 	k8s.io/client-go v0.30.1

--- a/go.sum
+++ b/go.sum
@@ -557,8 +557,8 @@ github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d/go.mod h1:Udh
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
-github.com/spacemeshos/api/release/go v1.42.0 h1:K85zw+KZA1UA3VNwvXD2UIND7NLyAiJo4Kz6ZznFEEc=
-github.com/spacemeshos/api/release/go v1.42.0/go.mod h1:aCDRfna5MA7LJWZPa4k+vTRvBUf1Swz8kcziPcdp6i8=
+github.com/spacemeshos/api/release/go v1.43.2-0.20240612070402-1a65396d6c76 h1:rCEsiPaMlZpNzrn6JzWPdqSxgf8YAMQs11e4JZqJGtk=
+github.com/spacemeshos/api/release/go v1.43.2-0.20240612070402-1a65396d6c76/go.mod h1:aCDRfna5MA7LJWZPa4k+vTRvBUf1Swz8kcziPcdp6i8=
 github.com/spacemeshos/economics v0.1.3 h1:ACkq3mTebIky4Zwbs9SeSSRZrUCjU/Zk0wq9Z0BTh2A=
 github.com/spacemeshos/economics v0.1.3/go.mod h1:FH7u0FzTIm6Kpk+X5HOZDvpkgNYBKclmH86rVwYaDAo=
 github.com/spacemeshos/fixed v0.1.1 h1:N1y4SUpq1EV+IdJrWJwUCt1oBFzeru/VKVcBsvPc2Fk=

--- a/go.sum
+++ b/go.sum
@@ -557,8 +557,8 @@ github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d/go.mod h1:Udh
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
-github.com/spacemeshos/api/release/go v1.43.2-0.20240612070402-1a65396d6c76 h1:rCEsiPaMlZpNzrn6JzWPdqSxgf8YAMQs11e4JZqJGtk=
-github.com/spacemeshos/api/release/go v1.43.2-0.20240612070402-1a65396d6c76/go.mod h1:aCDRfna5MA7LJWZPa4k+vTRvBUf1Swz8kcziPcdp6i8=
+github.com/spacemeshos/api/release/go v1.44.0 h1:bqo95CDksk8wPNQQidusjwCamx5HMUuMNSVwX08l+dw=
+github.com/spacemeshos/api/release/go v1.44.0/go.mod h1:8pxGN6/di8iBpQReiOgY+Cppi7bhJ+qJ3QiRQtJfoag=
 github.com/spacemeshos/economics v0.1.3 h1:ACkq3mTebIky4Zwbs9SeSSRZrUCjU/Zk0wq9Z0BTh2A=
 github.com/spacemeshos/economics v0.1.3/go.mod h1:FH7u0FzTIm6Kpk+X5HOZDvpkgNYBKclmH86rVwYaDAo=
 github.com/spacemeshos/fixed v0.1.1 h1:N1y4SUpq1EV+IdJrWJwUCt1oBFzeru/VKVcBsvPc2Fk=
@@ -850,8 +850,8 @@ google.golang.org/protobuf v1.22.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
-google.golang.org/protobuf v1.34.1 h1:9ddQBjfCyZPOHPUiPxpYESBLc+T8P3E+Vo4IbKZgFWg=
-google.golang.org/protobuf v1.34.1/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
+google.golang.org/protobuf v1.34.2 h1:6xV6lTsCfpGD21XK49h7MhtcApnLqkfYgPcdHftf6hg=
+google.golang.org/protobuf v1.34.2/go.mod h1:qYOHts0dSfpeUzUFpOMr/WGzszTmLH+DiWniOlNbLDw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
Use address field to query transactions by looking at touched addresses instead of principal / result decoding.