### PR TITLE
[Merged by Bors] - Use sync.Pool for blake3 hashers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,9 @@ operating your own PoET and want to use certificate authentication please refer 
   changed after the initial PoST was generated but before the first ATX has been emitted, invalidating the initial PoST.
   The node will now try to verify the initial PoST and regenerate it if necessary.
 
+* [#6044](https://github.com/spacemeshos/go-spacemesh/pull/6044) The node will now reuse `blake3` hashers in a pool which
+  reduces stress on the garbage collector.
+
 ## Release v1.5.7
 
 ### Improvements

--- a/activation/wire/wire_v1.go
+++ b/activation/wire/wire_v1.go
@@ -133,10 +133,9 @@ func (atx *ActivationTxV1) SignedBytes() []byte {
 
 func (atx *ActivationTxV1) HashInnerBytes() (result types.Hash32) {
 	h := hash.GetHasher()
+	defer hash.PutHasher(h)
 	codec.MustEncodeTo(h, &atx.InnerActivationTxV1)
 	h.Sum(result[:0])
-	h.Reset()
-	hash.PutHasher(h)
 	return result
 }
 

--- a/activation/wire/wire_v1.go
+++ b/activation/wire/wire_v1.go
@@ -132,9 +132,11 @@ func (atx *ActivationTxV1) SignedBytes() []byte {
 }
 
 func (atx *ActivationTxV1) HashInnerBytes() (result types.Hash32) {
-	h := hash.New()
+	h := hash.GetHasher()
 	codec.MustEncodeTo(h, &atx.InnerActivationTxV1)
 	h.Sum(result[:0])
+	h.Reset()
+	hash.PutHasher(h)
 	return result
 }
 

--- a/beacon/proposal_list.go
+++ b/beacon/proposal_list.go
@@ -23,10 +23,7 @@ func (hl proposalList) sort() []Proposal {
 
 func (hl proposalList) hash() types.Hash32 {
 	hasher := hash.GetHasher()
-	defer func() {
-		hasher.Reset()
-		hash.PutHasher(hasher)
-	}()
+	defer hash.PutHasher(hasher)
 
 	for _, proposal := range hl {
 		// an error is never returned: https://golang.org/pkg/hash/#Hash

--- a/beacon/proposal_list.go
+++ b/beacon/proposal_list.go
@@ -22,7 +22,11 @@ func (hl proposalList) sort() []Proposal {
 }
 
 func (hl proposalList) hash() types.Hash32 {
-	hasher := hash.New()
+	hasher := hash.GetHasher()
+	defer func() {
+		hasher.Reset()
+		hash.PutHasher(hasher)
+	}()
 
 	for _, proposal := range hl {
 		// an error is never returned: https://golang.org/pkg/hash/#Hash

--- a/common/types/atxid_list.go
+++ b/common/types/atxid_list.go
@@ -8,7 +8,7 @@ type ATXIDList []ATXID
 // Hash returns ATX ID list hash.
 func (atxList ATXIDList) Hash() Hash32 {
 	hasher := hash.GetHasher()
-
+	defer hash.PutHasher(hasher)
 	for _, id := range atxList {
 		if _, err := hasher.Write(id.Bytes()); err != nil {
 			panic("should not happen") // an error is never returned: https://golang.org/pkg/hash/#Hash
@@ -17,7 +17,5 @@ func (atxList ATXIDList) Hash() Hash32 {
 
 	var rst Hash32
 	hasher.Sum(rst[:0])
-	hasher.Reset()
-	hash.PutHasher(hasher)
 	return rst
 }

--- a/common/types/atxid_list.go
+++ b/common/types/atxid_list.go
@@ -7,7 +7,7 @@ type ATXIDList []ATXID
 
 // Hash returns ATX ID list hash.
 func (atxList ATXIDList) Hash() Hash32 {
-	hasher := hash.New()
+	hasher := hash.GetHasher()
 
 	for _, id := range atxList {
 		if _, err := hasher.Write(id.Bytes()); err != nil {
@@ -17,5 +17,7 @@ func (atxList ATXIDList) Hash() Hash32 {
 
 	var rst Hash32
 	hasher.Sum(rst[:0])
+	hasher.Reset()
+	hash.PutHasher(hasher)
 	return rst
 }

--- a/common/types/ballot.go
+++ b/common/types/ballot.go
@@ -273,12 +273,15 @@ func (b *Ballot) SignedBytes() []byte {
 
 // HashInnerBytes returns the hash of the InnerBallot.
 func (b *Ballot) HashInnerBytes() []byte {
-	h := hash.New()
+	h := hash.GetHasher()
 	_, err := codec.EncodeTo(h, &b.InnerBallot)
 	if err != nil {
 		log.With().Fatal("failed to encode InnerBallot for hashing", log.Err(err))
 	}
-	return h.Sum(nil)
+	sum := h.Sum(nil)
+	h.Reset()
+	hash.PutHasher(h)
+	return sum
 }
 
 // SetID from stored data.

--- a/common/types/ballot.go
+++ b/common/types/ballot.go
@@ -279,8 +279,7 @@ func (b *Ballot) HashInnerBytes() []byte {
 	if err != nil {
 		log.With().Fatal("failed to encode InnerBallot for hashing", log.Err(err))
 	}
-	sum := h.Sum(nil)
-	return sum
+	return h.Sum(nil)
 }
 
 // SetID from stored data.

--- a/common/types/ballot.go
+++ b/common/types/ballot.go
@@ -274,13 +274,12 @@ func (b *Ballot) SignedBytes() []byte {
 // HashInnerBytes returns the hash of the InnerBallot.
 func (b *Ballot) HashInnerBytes() []byte {
 	h := hash.GetHasher()
+	defer hash.PutHasher(h)
 	_, err := codec.EncodeTo(h, &b.InnerBallot)
 	if err != nil {
 		log.With().Fatal("failed to encode InnerBallot for hashing", log.Err(err))
 	}
 	sum := h.Sum(nil)
-	h.Reset()
-	hash.PutHasher(h)
 	return sum
 }
 

--- a/common/types/hashes.go
+++ b/common/types/hashes.go
@@ -102,14 +102,13 @@ func CalcProposalsHash32(view []ProposalID, additionalBytes []byte) Hash32 {
 // prefixed with additionalBytes.
 func CalcProposalHash32Presorted(sortedView []ProposalID, additionalBytes []byte) Hash32 {
 	hasher := hash.GetHasher()
+	defer hash.PutHasher(hasher)
 	hasher.Write(additionalBytes)
 	for _, id := range sortedView {
 		hasher.Write(id.Bytes()) // this never returns an error: https://golang.org/pkg/hash/#Hash
 	}
 	var res Hash32
 	hasher.Sum(res[:0])
-	hasher.Reset()
-	hash.PutHasher(hasher)
 	return res
 }
 

--- a/common/types/hashes.go
+++ b/common/types/hashes.go
@@ -101,13 +101,15 @@ func CalcProposalsHash32(view []ProposalID, additionalBytes []byte) Hash32 {
 // CalcProposalHash32Presorted returns the 32-byte blake3 sum of the IDs, in the order given. The pre-image is
 // prefixed with additionalBytes.
 func CalcProposalHash32Presorted(sortedView []ProposalID, additionalBytes []byte) Hash32 {
-	hasher := hash.New()
+	hasher := hash.GetHasher()
 	hasher.Write(additionalBytes)
 	for _, id := range sortedView {
 		hasher.Write(id.Bytes()) // this never returns an error: https://golang.org/pkg/hash/#Hash
 	}
 	var res Hash32
 	hasher.Sum(res[:0])
+	hasher.Reset()
+	hash.PutHasher(hasher)
 	return res
 }
 

--- a/common/types/proposal.go
+++ b/common/types/proposal.go
@@ -108,13 +108,12 @@ func (p *Proposal) SignedBytes() []byte {
 // HashInnerProposal returns the hash of the InnerProposal.
 func (p *Proposal) HashInnerProposal() []byte {
 	h := hash.GetHasher()
+	defer hash.PutHasher(h)
 	_, err := codec.EncodeTo(h, &p.InnerProposal)
 	if err != nil {
 		log.With().Fatal("failed to encode InnerProposal for hashing", log.Err(err))
 	}
 	sum := h.Sum(nil)
-	h.Reset()
-	hash.PutHasher(h)
 	return sum
 }
 

--- a/common/types/proposal.go
+++ b/common/types/proposal.go
@@ -113,8 +113,7 @@ func (p *Proposal) HashInnerProposal() []byte {
 	if err != nil {
 		log.With().Fatal("failed to encode InnerProposal for hashing", log.Err(err))
 	}
-	sum := h.Sum(nil)
-	return sum
+	return h.Sum(nil)
 }
 
 // ID returns the ProposalID.

--- a/common/types/proposal.go
+++ b/common/types/proposal.go
@@ -107,12 +107,15 @@ func (p *Proposal) SignedBytes() []byte {
 
 // HashInnerProposal returns the hash of the InnerProposal.
 func (p *Proposal) HashInnerProposal() []byte {
-	h := hash.New()
+	h := hash.GetHasher()
 	_, err := codec.EncodeTo(h, &p.InnerProposal)
 	if err != nil {
 		log.With().Fatal("failed to encode InnerProposal for hashing", log.Err(err))
 	}
-	return h.Sum(nil)
+	sum := h.Sum(nil)
+	h.Reset()
+	hash.PutHasher(h)
+	return sum
 }
 
 // ID returns the ProposalID.

--- a/config/genesis.go
+++ b/config/genesis.go
@@ -31,17 +31,14 @@ func (g *GenesisConfig) GenesisID() types.Hash20 {
 
 func (g *GenesisConfig) GoldenATX() types.Hash32 {
 	hh := hash.GetHasher()
+	defer hash.PutHasher(hh)
 	parsed, err := time.Parse(time.RFC3339, g.GenesisTime)
 	if err != nil {
 		panic("code should have run Validate before this method")
 	}
 	hh.Write([]byte(strconv.FormatInt(parsed.Unix(), 10)))
 	hh.Write([]byte(g.ExtraData))
-	sum := types.BytesToHash(hh.Sum(nil))
-
-	hh.Reset()
-	hash.PutHasher(hh)
-	return sum
+	return types.BytesToHash(hh.Sum(nil))
 }
 
 // Validate GenesisConfig.

--- a/config/genesis.go
+++ b/config/genesis.go
@@ -30,14 +30,18 @@ func (g *GenesisConfig) GenesisID() types.Hash20 {
 }
 
 func (g *GenesisConfig) GoldenATX() types.Hash32 {
-	hh := hash.New()
+	hh := hash.GetHasher()
 	parsed, err := time.Parse(time.RFC3339, g.GenesisTime)
 	if err != nil {
 		panic("code should have run Validate before this method")
 	}
 	hh.Write([]byte(strconv.FormatInt(parsed.Unix(), 10)))
 	hh.Write([]byte(g.ExtraData))
-	return types.BytesToHash(hh.Sum(nil))
+	sum := types.BytesToHash(hh.Sum(nil))
+
+	hh.Reset()
+	hash.PutHasher(hh)
+	return sum
 }
 
 // Validate GenesisConfig.

--- a/genvm/core/hash.go
+++ b/genvm/core/hash.go
@@ -16,11 +16,13 @@ func SigningBody(genesis, tx []byte) []byte {
 
 // ComputePrincipal address as the last 20 bytes from blake3(scale(template || args)).
 func ComputePrincipal(template Address, args scale.Encodable) Address {
-	hasher := hash.New()
+	hasher := hash.GetHasher()
 	encoder := scale.NewEncoder(hasher)
 	template.EncodeScale(encoder)
 	args.EncodeScale(encoder)
-	hash := hasher.Sum(nil)
-	rst := types.GenerateAddress(hash[12:])
+	sum := hasher.Sum(nil)
+	hasher.Reset()
+	hash.PutHasher(hasher)
+	rst := types.GenerateAddress(sum[12:])
 	return rst
 }

--- a/genvm/core/hash.go
+++ b/genvm/core/hash.go
@@ -17,12 +17,11 @@ func SigningBody(genesis, tx []byte) []byte {
 // ComputePrincipal address as the last 20 bytes from blake3(scale(template || args)).
 func ComputePrincipal(template Address, args scale.Encodable) Address {
 	hasher := hash.GetHasher()
+	defer hash.PutHasher(hasher)
 	encoder := scale.NewEncoder(hasher)
 	template.EncodeScale(encoder)
 	args.EncodeScale(encoder)
 	sum := hasher.Sum(nil)
-	hasher.Reset()
-	hash.PutHasher(hasher)
 	rst := types.GenerateAddress(sum[12:])
 	return rst
 }

--- a/genvm/vm.go
+++ b/genvm/vm.go
@@ -264,7 +264,6 @@ func (v *VM) Apply(
 	for _, reward := range rewardsResult {
 		events.ReportRewardReceived(reward)
 	}
-	hasher.Reset()
 	hash.PutHasher(hasher)
 
 	blockDurationPersist.Observe(float64(time.Since(t3)))

--- a/genvm/vm.go
+++ b/genvm/vm.go
@@ -217,7 +217,7 @@ func (v *VM) Apply(
 	t3 := time.Now()
 	blockDurationRewards.Observe(float64(time.Since(t2)))
 
-	hasher := hash.New()
+	hasher := hash.GetHasher()
 	encoder := scale.NewEncoder(hasher)
 	total := 0
 
@@ -249,9 +249,9 @@ func (v *VM) Apply(
 	}
 	writesPerBlock.Observe(float64(total))
 
-	var hash types.Hash32
-	hasher.Sum(hash[:0])
-	if err := layers.UpdateStateHash(tx, lctx.Layer, hash); err != nil {
+	var hashSum types.Hash32
+	hasher.Sum(hashSum[:0])
+	if err := layers.UpdateStateHash(tx, lctx.Layer, hashSum); err != nil {
 		return nil, nil, err
 	}
 	if err := tx.Commit(); err != nil {
@@ -264,6 +264,8 @@ func (v *VM) Apply(
 	for _, reward := range rewardsResult {
 		events.ReportRewardReceived(reward)
 	}
+	hasher.Reset()
+	hash.PutHasher(hasher)
 
 	blockDurationPersist.Observe(float64(time.Since(t3)))
 	blockDuration.Observe(float64(time.Since(t1)))
@@ -274,7 +276,7 @@ func (v *VM) Apply(
 		log.Uint32("layer", lctx.Layer.Uint32()),
 		log.Int("count", len(txs)-len(skipped)),
 		log.Duration("duration", time.Since(t1)),
-		log.Stringer("state_hash", hash),
+		log.Stringer("state_hash", hashSum),
 	)
 	return skipped, results, nil
 }

--- a/hare3/types.go
+++ b/hare3/types.go
@@ -109,11 +109,10 @@ type Message struct {
 
 func (m *Message) ToHash() types.Hash32 {
 	h := hash.GetHasher()
+	defer hash.PutHasher(h)
 	codec.MustEncodeTo(h, &m.Body)
 	var rst types.Hash32
 	h.Sum(rst[:0])
-	h.Reset()
-	hash.PutHasher(h)
 	return rst
 }
 

--- a/hare3/types.go
+++ b/hare3/types.go
@@ -108,10 +108,12 @@ type Message struct {
 }
 
 func (m *Message) ToHash() types.Hash32 {
-	hash := hash.New()
-	codec.MustEncodeTo(hash, &m.Body)
+	h := hash.GetHasher()
+	codec.MustEncodeTo(h, &m.Body)
 	var rst types.Hash32
-	hash.Sum(rst[:0])
+	h.Sum(rst[:0])
+	h.Reset()
+	hash.PutHasher(h)
 	return rst
 }
 

--- a/hash/hash.go
+++ b/hash/hash.go
@@ -14,19 +14,27 @@ var New = blake3.New
 
 // Sum computes 256-bit hash from chunks with blake3.
 func Sum(chunks ...[]byte) (rst [32]byte) {
-	hh := New()
+	hh := GetHasher()
 	for _, chunk := range chunks {
 		hh.Write(chunk)
 	}
 	hh.Sum(rst[:0])
+
+	// reset the hasher and put it back in the pool
+	hh.Reset()
+	PutHasher(hh)
 	return rst
 }
 
 func Sum20(chunks ...[]byte) (rst [20]byte) {
-	hh := New()
+	hh := GetHasher()
 	for _, chunk := range chunks {
 		hh.Write(chunk)
 	}
 	hh.Digest().Read(rst[:])
+
+	// reset the hasher and put it back in the pool
+	hh.Reset()
+	PutHasher(hh)
 	return rst
 }

--- a/hash/hash.go
+++ b/hash/hash.go
@@ -15,26 +15,22 @@ var New = blake3.New
 // Sum computes 256-bit hash from chunks with blake3.
 func Sum(chunks ...[]byte) (rst [32]byte) {
 	hh := GetHasher()
+	defer PutHasher(hh)
 	for _, chunk := range chunks {
 		hh.Write(chunk)
 	}
 	hh.Sum(rst[:0])
 
-	// reset the hasher and put it back in the pool
-	hh.Reset()
-	PutHasher(hh)
 	return rst
 }
 
 func Sum20(chunks ...[]byte) (rst [20]byte) {
 	hh := GetHasher()
+	defer PutHasher(hh)
 	for _, chunk := range chunks {
 		hh.Write(chunk)
 	}
 	hh.Digest().Read(rst[:])
 
-	// reset the hasher and put it back in the pool
-	hh.Reset()
-	PutHasher(hh)
 	return rst
 }

--- a/hash/hash.go
+++ b/hash/hash.go
@@ -20,7 +20,6 @@ func Sum(chunks ...[]byte) (rst [32]byte) {
 		hh.Write(chunk)
 	}
 	hh.Sum(rst[:0])
-
 	return rst
 }
 
@@ -31,6 +30,5 @@ func Sum20(chunks ...[]byte) (rst [20]byte) {
 		hh.Write(chunk)
 	}
 	hh.Digest().Read(rst[:])
-
 	return rst
 }

--- a/hash/pool.go
+++ b/hash/pool.go
@@ -15,16 +15,15 @@ var pool = &sync.Pool{
 }
 
 // GetHasher will get a blake3 hasher from the pool.
-// It may or may not allocate a new one. Consumers are expected
+// It may or may not allocate a new one. Consumers are not required
 // to call Reset() on the hasher before putting it back in
 // the pool.
 func GetHasher() *blake3.Hasher {
 	return pool.Get().(*blake3.Hasher)
 }
 
-// PutHasher returns the hasher back to the pool.
-// Consumers are expected to call Reset() on the
-// instance before putting it back in the pool.
+// PutHasher resets the hasher and puts it back to the pool.
 func PutHasher(hasher *blake3.Hasher) {
+	hasher.Reset()
 	pool.Put(hasher)
 }

--- a/hash/pool.go
+++ b/hash/pool.go
@@ -1,0 +1,30 @@
+package hash
+
+import (
+	"sync"
+
+	"github.com/zeebo/blake3"
+)
+
+// Pool is a global blake3 hasher pool. It is meant to amortize allocations
+// of blake3 hashers over time by allowing clients to reuse them.
+var pool = &sync.Pool{
+	New: func() any {
+		return blake3.New()
+	},
+}
+
+// GetHasher will get a blake3 hasher from the pool.
+// It may or may not allocate a new one. Consumers are expected
+// to call Reset() on the hasher before putting it back in
+// the pool.
+func GetHasher() *blake3.Hasher {
+	return pool.Get().(*blake3.Hasher)
+}
+
+// PutHasher returns the hasher back to the pool.
+// Consumers are expected to call Reset() on the
+// instance before putting it back in the pool.
+func PutHasher(hasher *blake3.Hasher) {
+	pool.Put(hasher)
+}

--- a/p2p/pubsub/pubsub.go
+++ b/p2p/pubsub/pubsub.go
@@ -204,12 +204,15 @@ func DropPeerOnSyncValidationReject(handler SyncHandler, h host.Host, logger log
 }
 
 func msgID(msg *pubsubpb.Message) string {
-	hasher := hash.New()
+	hasher := hash.GetHasher()
 	if msg.Topic != nil {
 		hasher.Write([]byte(*msg.Topic))
 	}
 	hasher.Write(msg.Data)
-	return string(hasher.Sum(nil))
+	sum := string(hasher.Sum(nil))
+	hasher.Reset()
+	hash.PutHasher(hasher)
+	return sum
 }
 
 func getOptions(cfg Config) []pubsub.Option {

--- a/p2p/pubsub/pubsub.go
+++ b/p2p/pubsub/pubsub.go
@@ -210,8 +210,7 @@ func msgID(msg *pubsubpb.Message) string {
 		hasher.Write([]byte(*msg.Topic))
 	}
 	hasher.Write(msg.Data)
-	sum := string(hasher.Sum(nil))
-	return sum
+	return string(hasher.Sum(nil))
 }
 
 func getOptions(cfg Config) []pubsub.Option {

--- a/p2p/pubsub/pubsub.go
+++ b/p2p/pubsub/pubsub.go
@@ -205,13 +205,12 @@ func DropPeerOnSyncValidationReject(handler SyncHandler, h host.Host, logger log
 
 func msgID(msg *pubsubpb.Message) string {
 	hasher := hash.GetHasher()
+	defer hash.PutHasher(hasher)
 	if msg.Topic != nil {
 		hasher.Write([]byte(*msg.Topic))
 	}
 	hasher.Write(msg.Data)
 	sum := string(hasher.Sum(nil))
-	hasher.Reset()
-	hash.PutHasher(hasher)
 	return sum
 }
 

--- a/tortoise/opinionhash/pool.go
+++ b/tortoise/opinionhash/pool.go
@@ -1,0 +1,27 @@
+package opinionhash
+
+import (
+	"sync"
+)
+
+// Pool is a global OpinionHasher pool. It is meant to amortize allocations
+// of OpinionHashers over time by allowing clients to reuse them.
+var pool = &sync.Pool{
+	New: func() any {
+		return New()
+	},
+}
+
+// GetHasher will get an OpinionHasher from the pool.
+// It may or may not allocate a new one. Consumers are not required
+// to call Reset() on the hasher before putting it back in
+// the pool.
+func GetHasher() *OpinionHasher {
+	return pool.Get().(*OpinionHasher)
+}
+
+// PutHasher resets the hasher and puts it back to the pool.
+func PutHasher(hasher *OpinionHasher) {
+	hasher.Reset()
+	pool.Put(hasher)
+}

--- a/tortoise/state.go
+++ b/tortoise/state.go
@@ -180,7 +180,8 @@ type layerInfo struct {
 }
 
 func (l *layerInfo) computeOpinion(hdist uint32, last types.LayerID) {
-	hasher := opinionhash.New()
+	hasher := opinionhash.GetHasher()
+	defer opinionhash.PutHasher(hasher)
 	if l.prevOpinion != nil {
 		hasher.WritePrevious(*l.prevOpinion)
 	}
@@ -372,7 +373,8 @@ func (l *layerVote) sortSupported() {
 }
 
 func (l *layerVote) computeOpinion() {
-	hasher := opinionhash.New()
+	hasher := opinionhash.GetHasher()
+	defer opinionhash.PutHasher(hasher)
 	if l.prev != nil {
 		hasher.WritePrevious(l.prev.opinion)
 	}

--- a/txs/nano_tx.go
+++ b/txs/nano_tx.go
@@ -40,8 +40,7 @@ func (n *NanoTX) combinedHash(blockSeed []byte) []byte {
 	defer hash.PutHasher(h)
 	h.Write(blockSeed)
 	h.Write(n.ID.Bytes())
-	sum := h.Sum(nil)
-	return sum
+	return h.Sum(nil)
 }
 
 // Better returns true if this transaction takes priority than `other`.

--- a/txs/nano_tx.go
+++ b/txs/nano_tx.go
@@ -37,11 +37,10 @@ func (n *NanoTX) MaxSpending() uint64 {
 
 func (n *NanoTX) combinedHash(blockSeed []byte) []byte {
 	h := hash.GetHasher()
+	defer hash.PutHasher(h)
 	h.Write(blockSeed)
 	h.Write(n.ID.Bytes())
 	sum := h.Sum(nil)
-	h.Reset()
-	hash.PutHasher(h)
 	return sum
 }
 

--- a/txs/nano_tx.go
+++ b/txs/nano_tx.go
@@ -36,10 +36,13 @@ func (n *NanoTX) MaxSpending() uint64 {
 }
 
 func (n *NanoTX) combinedHash(blockSeed []byte) []byte {
-	hash := hash.New()
-	hash.Write(blockSeed)
-	hash.Write(n.ID.Bytes())
-	return hash.Sum(nil)
+	h := hash.GetHasher()
+	h.Write(blockSeed)
+	h.Write(n.ID.Bytes())
+	sum := h.Sum(nil)
+	h.Reset()
+	hash.PutHasher(h)
+	return sum
 }
 
 // Better returns true if this transaction takes priority than `other`.


### PR DESCRIPTION
## Motivation

Improve memory allocations using a memory pool for hashers.
<!-- Give a brief description of the motivation for this PR. 1-2 sentences is fine. -->

## Description

Our nodes use a lot of blake3 hashers and this is visible on heap profiles:
```
(pprof) sample_index=alloc_space
(pprof) top
Showing nodes accounting for 51611.76GB, 79.82% of 64661.28GB total
Dropped 3308 nodes (cum <= 323.31GB)
Showing top 10 nodes out of 134
      flat  flat%   sum%        cum   cum%
28458.86GB 44.01% 44.01% 28458.86GB 44.01%  github.com/zeebo/blake3.New
 7623.76GB 11.79% 55.80%  7625.85GB 11.79%  github.com/libp2p/go-buffer-pool.(*BufferPool).Get
 4043.65GB  6.25% 62.06%  4043.65GB  6.25%  github.com/libp2p/go-libp2p-pubsub/pb.(*ControlIHave).Unmarshal
 3523.27GB  5.45% 67.50%  3523.27GB  5.45%  github.com/libp2p/go-libp2p-pubsub/pb.(*Message).Unmarshal
 2199.32GB  3.40% 70.91%  2199.32GB  3.40%  github.com/libp2p/go-libp2p-pubsub.(*GossipSubRouter).getPeers
```

This PR aims to amortize the costs of allocations of these hashers over time by using a `sync.Pool` instead of just using these hashers as one-off disposable hashers (they are built to be reused using the `Reset()` method on the `hash.Hasher` interface exactly for this purpose).

Fixes #5850
<!-- If applicable please mention the issue addressed by this PR -->
<!-- `Closes #XXXX` links mentioned issues to this PR and automatically closes them when this it's merged -->

<!-- Please describe in detail the changes made. Focus on the reasoning rather than describing the change -->

## Test Plan

- Manually test
<!-- Please specify how these changes were tested (e.g. unit tests, manual testing, etc.) -->
