### PR TITLE
[Merged by Bors] - Increase limits to support up to 7.0 Mio ATXs per epoch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,8 @@ operating your own PoET and want to use certificate authentication please refer 
 * [#6044](https://github.com/spacemeshos/go-spacemesh/pull/6044) The node will now reuse `blake3` hashers in a pool which
   reduces stress on the garbage collector.
 
+* [#6055](https://github.com/spacemeshos/go-spacemesh/pull/6055) Increased limits to support up to 7.0 Mio ATXs per epoch.
+
 ## Release v1.5.7
 
 ### Improvements

--- a/common/types/activation.go
+++ b/common/types/activation.go
@@ -396,7 +396,7 @@ func ATXIDsToHashes(ids []ATXID) []Hash32 {
 
 type EpochActiveSet struct {
 	Epoch EpochID
-	Set   []ATXID `scale:"max=6000000"` // to be in line with `EpochData` in fetch/wire_types.go
+	Set   []ATXID `scale:"max=7000000"` // to be in line with `EpochData` in fetch/wire_types.go
 }
 
 var MaxEpochActiveSetSize = scale.MustGetMaxElements[EpochActiveSet]("Set")

--- a/common/types/activation_scale.go
+++ b/common/types/activation_scale.go
@@ -91,7 +91,7 @@ func (t *EpochActiveSet) EncodeScale(enc *scale.Encoder) (total int, err error) 
 		total += n
 	}
 	{
-		n, err := scale.EncodeStructSliceWithLimit(enc, t.Set, 6000000)
+		n, err := scale.EncodeStructSliceWithLimit(enc, t.Set, 7000000)
 		if err != nil {
 			return total, err
 		}
@@ -110,7 +110,7 @@ func (t *EpochActiveSet) DecodeScale(dec *scale.Decoder) (total int, err error) 
 		t.Epoch = EpochID(field)
 	}
 	{
-		field, n, err := scale.DecodeStructSliceWithLimit[ATXID](dec, 6000000)
+		field, n, err := scale.DecodeStructSliceWithLimit[ATXID](dec, 7000000)
 		if err != nil {
 			return total, err
 		}

--- a/common/types/block.go
+++ b/common/types/block.go
@@ -77,14 +77,14 @@ type InnerBlock struct {
 	// In this case they will get all 50 available slots in all 4032 layers of the epoch.
 	// Additionally every other identity on the network that successfully published an ATX will get 1 slot.
 	//
-	// If we expect 6.0 Mio ATXs that would be a total of 6.0 Mio + 50 * 4032 = 6 201 600 slots.
+	// If we expect 7.0 Mio ATXs that would be a total of 7.0 Mio + 50 * 4032 = 7 201 600 slots.
 	// Since these are randomly distributed across the epoch, we can expect an average of n * p =
-	// 6 201 600 / 4032 = 1538.1 rewards in a block with a standard deviation of sqrt(n * p * (1 - p)) =
-	// sqrt(3 701 600 * 1/4032 * 4031/4032) = 39.2
+	// 7 201 600 / 4032 = 1786.1 rewards in a block with a standard deviation of sqrt(n * p * (1 - p)) =
+	// sqrt(7 201 600 * 1/4032 * 4031/4032) = 42.3
 	//
-	// This means that we can expect a maximum of 1538.1 + 6*39.2 = 1773.4 rewards per block with
+	// This means that we can expect a maximum of 1786.1 + 6*42.3 = 2039.7 rewards per block with
 	// > 99.9997% probability.
-	Rewards []AnyReward     `scale:"max=1775"`
+	Rewards []AnyReward     `scale:"max=2050"`
 	TxIDs   []TransactionID `scale:"max=100000"`
 }
 

--- a/common/types/block_scale.go
+++ b/common/types/block_scale.go
@@ -45,7 +45,7 @@ func (t *InnerBlock) EncodeScale(enc *scale.Encoder) (total int, err error) {
 		total += n
 	}
 	{
-		n, err := scale.EncodeStructSliceWithLimit(enc, t.Rewards, 1775)
+		n, err := scale.EncodeStructSliceWithLimit(enc, t.Rewards, 2050)
 		if err != nil {
 			return total, err
 		}
@@ -79,7 +79,7 @@ func (t *InnerBlock) DecodeScale(dec *scale.Decoder) (total int, err error) {
 		t.TickHeight = uint64(field)
 	}
 	{
-		field, n, err := scale.DecodeStructSliceWithLimit[AnyReward](dec, 1775)
+		field, n, err := scale.DecodeStructSliceWithLimit[AnyReward](dec, 2050)
 		if err != nil {
 			return total, err
 		}

--- a/fetch/wire_types.go
+++ b/fetch/wire_types.go
@@ -37,7 +37,7 @@ type RequestMessage struct {
 type ResponseMessage struct {
 	Hash types.Hash32
 	// keep in line with limit of Response.Data in `p2p/server/server.go`
-	Data []byte `scale:"max=209715200"` // 200 MiB > 6.0 mio ATX * 32 bytes per ID
+	Data []byte `scale:"max=235929600"` // 225 MiB > 7.0 mio ATX * 32 bytes per ID
 }
 
 // RequestBatch is a batch of requests and a hash of all requests as ID.
@@ -116,7 +116,7 @@ type MeshHashes struct {
 }
 
 type MaliciousIDs struct {
-	NodeIDs []types.NodeID `scale:"max=6000000"` // to be in line with `EpochData.AtxIDs` below
+	NodeIDs []types.NodeID `scale:"max=7000000"` // to be in line with `EpochData.AtxIDs` below
 }
 
 type EpochData struct {
@@ -128,7 +128,7 @@ type EpochData struct {
 	// - the size of `Rewards` in the type `InnerBlock` in common/types/block.go
 	// - the size of `Ballots` in the type `LayerData` below
 	// - the size of `Proposals` in the type `Value` in hare3/types.go
-	AtxIDs []types.ATXID `scale:"max=6000000"`
+	AtxIDs []types.ATXID `scale:"max=7000000"`
 }
 
 // LayerData is the data response for a given layer ID.
@@ -139,14 +139,14 @@ type LayerData struct {
 	// In this case they will get all 50 available slots in all 4032 layers of the epoch.
 	// Additionally every other identity on the network that successfully published an ATX will get 1 slot.
 	//
-	// If we expect 6.0 Mio ATXs that would be a total of 6.0 Mio + 50 * 4032 = 6 201 600 slots.
+	// If we expect 7.0 Mio ATXs that would be a total of 7.0 Mio + 50 * 4032 = 7 201 600 slots.
 	// Since these are randomly distributed across the epoch, we can expect an average of n * p =
-	// 6 201 600 / 4032 = 1538.1 ballots in a layer with a standard deviation of sqrt(n * p * (1 - p)) =
-	// sqrt(3 701 600 * 1/4032 * 4031/4032) = 39.2
+	// 7 201 600 / 4032 = 1786.1 ballots in a layer with a standard deviation of sqrt(n * p * (1 - p)) =
+	// sqrt(7 201 600 * 1/4032 * 4031/4032) = 42.3
 	//
-	// This means that we can expect a maximum of 1538.1 + 6*39.2 = 1773.4 ballots per layer with
+	// This means that we can expect a maximum of 1786.1 + 6*42.3 = 2039.7 ballots per layer with
 	// > 99.9997% probability.
-	Ballots []types.BallotID `scale:"max=1775"`
+	Ballots []types.BallotID `scale:"max=2050"`
 }
 
 type OpinionRequest struct {

--- a/fetch/wire_types_scale.go
+++ b/fetch/wire_types_scale.go
@@ -55,7 +55,7 @@ func (t *ResponseMessage) EncodeScale(enc *scale.Encoder) (total int, err error)
 		total += n
 	}
 	{
-		n, err := scale.EncodeByteSliceWithLimit(enc, t.Data, 209715200)
+		n, err := scale.EncodeByteSliceWithLimit(enc, t.Data, 235929600)
 		if err != nil {
 			return total, err
 		}
@@ -73,7 +73,7 @@ func (t *ResponseMessage) DecodeScale(dec *scale.Decoder) (total int, err error)
 		total += n
 	}
 	{
-		field, n, err := scale.DecodeByteSliceWithLimit(dec, 209715200)
+		field, n, err := scale.DecodeByteSliceWithLimit(dec, 235929600)
 		if err != nil {
 			return total, err
 		}
@@ -235,7 +235,7 @@ func (t *MeshHashes) DecodeScale(dec *scale.Decoder) (total int, err error) {
 
 func (t *MaliciousIDs) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	{
-		n, err := scale.EncodeStructSliceWithLimit(enc, t.NodeIDs, 6000000)
+		n, err := scale.EncodeStructSliceWithLimit(enc, t.NodeIDs, 7000000)
 		if err != nil {
 			return total, err
 		}
@@ -246,7 +246,7 @@ func (t *MaliciousIDs) EncodeScale(enc *scale.Encoder) (total int, err error) {
 
 func (t *MaliciousIDs) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	{
-		field, n, err := scale.DecodeStructSliceWithLimit[types.NodeID](dec, 6000000)
+		field, n, err := scale.DecodeStructSliceWithLimit[types.NodeID](dec, 7000000)
 		if err != nil {
 			return total, err
 		}
@@ -258,7 +258,7 @@ func (t *MaliciousIDs) DecodeScale(dec *scale.Decoder) (total int, err error) {
 
 func (t *EpochData) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	{
-		n, err := scale.EncodeStructSliceWithLimit(enc, t.AtxIDs, 6000000)
+		n, err := scale.EncodeStructSliceWithLimit(enc, t.AtxIDs, 7000000)
 		if err != nil {
 			return total, err
 		}
@@ -269,7 +269,7 @@ func (t *EpochData) EncodeScale(enc *scale.Encoder) (total int, err error) {
 
 func (t *EpochData) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	{
-		field, n, err := scale.DecodeStructSliceWithLimit[types.ATXID](dec, 6000000)
+		field, n, err := scale.DecodeStructSliceWithLimit[types.ATXID](dec, 7000000)
 		if err != nil {
 			return total, err
 		}
@@ -281,7 +281,7 @@ func (t *EpochData) DecodeScale(dec *scale.Decoder) (total int, err error) {
 
 func (t *LayerData) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	{
-		n, err := scale.EncodeStructSliceWithLimit(enc, t.Ballots, 1775)
+		n, err := scale.EncodeStructSliceWithLimit(enc, t.Ballots, 2050)
 		if err != nil {
 			return total, err
 		}
@@ -292,7 +292,7 @@ func (t *LayerData) EncodeScale(enc *scale.Encoder) (total int, err error) {
 
 func (t *LayerData) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	{
-		field, n, err := scale.DecodeStructSliceWithLimit[types.BallotID](dec, 1775)
+		field, n, err := scale.DecodeStructSliceWithLimit[types.BallotID](dec, 2050)
 		if err != nil {
 			return total, err
 		}

--- a/hare3/types.go
+++ b/hare3/types.go
@@ -82,14 +82,14 @@ type Value struct {
 	// In this case they will get all 50 available slots in all 4032 layers of the epoch.
 	// Additionally every other identity on the network that successfully published an ATX will get 1 slot.
 	//
-	// If we expect 6.0 Mio ATXs that would be a total of 6.0 Mio + 50 * 4032 = 6 201 600 slots.
+	// If we expect 7.0 Mio ATXs that would be a total of 7.0 Mio + 50 * 4032 = 7 201 600 slots.
 	// Since these are randomly distributed across the epoch, we can expect an average of n * p =
-	// 6 201 600 / 4032 = 1538.1 eligibilities in a layer with a standard deviation of sqrt(n * p * (1 - p)) =
-	// sqrt(3 701 600 * 1/4032 * 4031/4032) = 39.2
+	// 7 201 600 / 4032 = 1786.1 eligibilities in a layer with a standard deviation of sqrt(n * p * (1 - p)) =
+	// sqrt(7 201 600 * 1/4032 * 4031/4032) = 42.3
 	//
-	// This means that we can expect a maximum of 1538.1 + 6*39.2 = 1773.4 eligibilities in a layer with
+	// This means that we can expect a maximum of 1786.1 + 6*42.3 = 2039.7 eligibilities in a layer with
 	// > 99.9997% probability.
-	Proposals []types.ProposalID `scale:"max=1775"`
+	Proposals []types.ProposalID `scale:"max=2050"`
 	// Reference is set in messages for commit and notify rounds.
 	Reference *types.Hash32
 }

--- a/hare3/types_scale.go
+++ b/hare3/types_scale.go
@@ -48,7 +48,7 @@ func (t *IterRound) DecodeScale(dec *scale.Decoder) (total int, err error) {
 
 func (t *Value) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	{
-		n, err := scale.EncodeStructSliceWithLimit(enc, t.Proposals, 1775)
+		n, err := scale.EncodeStructSliceWithLimit(enc, t.Proposals, 2050)
 		if err != nil {
 			return total, err
 		}
@@ -66,7 +66,7 @@ func (t *Value) EncodeScale(enc *scale.Encoder) (total int, err error) {
 
 func (t *Value) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	{
-		field, n, err := scale.DecodeStructSliceWithLimit[types.ProposalID](dec, 1775)
+		field, n, err := scale.DecodeStructSliceWithLimit[types.ProposalID](dec, 2050)
 		if err != nil {
 			return total, err
 		}


### PR DESCRIPTION
## Motivation

Increase limits to support 7.0 Mio ATXs we expect for to see in the next 1-2 epochs.

## Description

Calculated and bump max allowed values in scale collections to support up to 7.0 Mio ATXs per epoch.

## Test Plan

- n/a

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
