### PR TITLE
perf: use atx ids with pointer semantics

### DIFF
--- a/activation/activation.go
+++ b/activation/activation.go
@@ -904,9 +904,9 @@ func (b *Builder) getPositioningAtx(
 
 	if previous != nil {
 		switch {
-		case id == b.conf.GoldenATXID:
+		case id.Equal(b.conf.GoldenATXID):
 			id = previous.ID()
-		case id != b.conf.GoldenATXID:
+		case !id.Equal(b.conf.GoldenATXID):
 			if candidate, err := atxs.Get(b.db, id); err == nil {
 				if previous.TickHeight() >= candidate.TickHeight() {
 					id = previous.ID()

--- a/activation/certifier.go
+++ b/activation/certifier.go
@@ -205,7 +205,7 @@ func (c *CertifierClient) obtainPostFromLastAtx(ctx context.Context, nodeId type
 		if commitmentAtx, err := atxs.CommitmentATX(c.db, nodeId); err != nil {
 			return nil, fmt.Errorf("failed to retrieve commitment ATX: %w", err)
 		} else {
-			atx.CommitmentATX = &commitmentAtx
+			atx.CommitmentATX = commitmentAtx
 		}
 	}
 
@@ -328,7 +328,7 @@ func (c *CertifierClient) Certify(
 }
 
 // load NIPoST for the given ATX from the database.
-func loadPost(ctx context.Context, db sql.Executor, id types.ATXID) (*types.Post, []byte, error) {
+func loadPost(ctx context.Context, db sql.Executor, id *types.ATXID) (*types.Post, []byte, error) {
 	var blob sql.Blob
 	version, err := atxs.LoadBlob(ctx, db, id.Bytes(), &blob)
 	if err != nil {

--- a/activation/certifier_test.go
+++ b/activation/certifier_test.go
@@ -130,7 +130,7 @@ func TestObtainingPost(t *testing.T) {
 			Pow:           17,
 			Challenge:     types.RandomBytes(32),
 			NumUnits:      2,
-			CommitmentATX: types.RandomATXID(),
+			CommitmentATX: *types.RandomATXID(),
 			VRFNonce:      15,
 		}
 		err := nipost.AddPost(localDb, id, post)

--- a/activation/e2e/activation_test.go
+++ b/activation/e2e/activation_test.go
@@ -76,7 +76,7 @@ func Test_BuilderWithMultipleClients(t *testing.T) {
 		i += 1
 		eg.Go(func() error {
 			validator := activation.NewMocknipostValidator(ctrl)
-			mgr, err := activation.NewPostSetupManager(cfg, logger, db, atxsdata.New(), goldenATX, syncer, validator)
+			mgr, err := activation.NewPostSetupManager(cfg, logger, db, atxsdata.New(), &goldenATX, syncer, validator)
 			require.NoError(t, err)
 
 			initPost(t, mgr, opts, sig.NodeID())
@@ -165,7 +165,7 @@ func Test_BuilderWithMultipleClients(t *testing.T) {
 	require.NoError(t, err)
 
 	conf := activation.Config{
-		GoldenATXID:      goldenATX,
+		GoldenATXID:      &goldenATX,
 		RegossipInterval: 0,
 	}
 
@@ -185,7 +185,7 @@ func Test_BuilderWithMultipleClients(t *testing.T) {
 			gotAtxs[gotAtx.SmesherID] = append(gotAtxs[gotAtx.SmesherID], gotAtx)
 			atx := wire.ActivationTxFromWireV1(&gotAtx)
 			if gotAtx.VRFNonce == nil {
-				atx.VRFNonce, err = atxs.NonceByID(db, gotAtx.PrevATXID)
+				atx.VRFNonce, err = atxs.NonceByID(db, &gotAtx.PrevATXID)
 				require.NoError(t, err)
 			}
 			logger.Debug("persisting ATX", zap.Inline(atx))
@@ -252,7 +252,7 @@ func Test_BuilderWithMultipleClients(t *testing.T) {
 				require.NotNil(t, atx.VRFNonce)
 				err := validator.VRFNonce(
 					sig.NodeID(),
-					commitment,
+					&commitment,
 					uint64(*atx.VRFNonce),
 					atx.NIPost.PostMetadata.LabelsPerUnit,
 					atx.NumUnits,
@@ -265,7 +265,7 @@ func Test_BuilderWithMultipleClients(t *testing.T) {
 			_, err = validator.NIPost(
 				context.Background(),
 				sig.NodeID(),
-				commitment,
+				&commitment,
 				wire.NiPostFromWireV1(atx.NIPost),
 				atx.NIPostChallengeV1.Hash(),
 				atx.NumUnits,
@@ -277,7 +277,7 @@ func Test_BuilderWithMultipleClients(t *testing.T) {
 			require.Equal(t, uint64(seq), atx.Sequence)
 			require.Equal(t, types.Address{}, atx.Coinbase)
 
-			previous = atx.ID()
+			previous = *atx.ID()
 		}
 	}
 }

--- a/activation/e2e/builds_atx_v2_test.go
+++ b/activation/e2e/builds_atx_v2_test.go
@@ -74,7 +74,7 @@ func TestBuilder_SwitchesToBuildV2(t *testing.T) {
 	validator := activation.NewValidator(db, poetDb, cfg, opts.Scrypt, verifier)
 
 	atxsdata := atxsdata.New()
-	mgr, err := activation.NewPostSetupManager(cfg, logger, cdb, atxsdata, goldenATX, syncer, validator)
+	mgr, err := activation.NewPostSetupManager(cfg, logger, cdb, atxsdata, &goldenATX, syncer, validator)
 	require.NoError(t, err)
 
 	initPost(t, mgr, opts, sig.NodeID())
@@ -138,7 +138,7 @@ func TestBuilder_SwitchesToBuildV2(t *testing.T) {
 	require.NoError(t, err)
 
 	conf := activation.Config{
-		GoldenATXID:      goldenATX,
+		GoldenATXID:      &goldenATX,
 		RegossipInterval: 0,
 	}
 
@@ -157,7 +157,7 @@ func TestBuilder_SwitchesToBuildV2(t *testing.T) {
 		clock,
 		mpub,
 		mFetch,
-		goldenATX,
+		&goldenATX,
 		validator,
 		mBeacon,
 		mTortoise,
@@ -174,7 +174,7 @@ func TestBuilder_SwitchesToBuildV2(t *testing.T) {
 
 				require.Equal(t, sig.NodeID(), watx.SmesherID)
 				require.EqualValues(t, 1, watx.PublishEpoch)
-				require.Equal(t, types.EmptyATXID, watx.PrevATXID)
+				require.Equal(t, types.EmptyATXID, &watx.PrevATXID)
 				require.Equal(t, goldenATX, watx.PositioningATXID)
 				require.Equal(t, coinbase, watx.Coinbase)
 

--- a/activation/e2e/builds_atx_v2_test.go
+++ b/activation/e2e/builds_atx_v2_test.go
@@ -198,8 +198,8 @@ func TestBuilder_SwitchesToBuildV2(t *testing.T) {
 
 				require.Equal(t, sig.NodeID(), watx.SmesherID)
 				require.EqualValues(t, previous.PublishEpoch+1, watx.PublishEpoch)
-				require.Equal(t, previous.ID(), watx.PreviousATXs[0])
-				require.Equal(t, previous.ID(), watx.PositioningATX)
+				require.Equal(t, *previous.ID(), watx.PreviousATXs[0])
+				require.Equal(t, *previous.ID(), watx.PositioningATX)
 				require.Equal(t, coinbase, watx.Coinbase)
 
 				mFetch.EXPECT().RegisterPeerHashes(peer.ID("peer"), gomock.Any())

--- a/activation/e2e/certifier_client_test.go
+++ b/activation/e2e/certifier_client_test.go
@@ -50,7 +50,8 @@ func TestCertification(t *testing.T) {
 		AnyTimes()
 	validator.EXPECT().VerifyChain(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 
-	mgr, err := activation.NewPostSetupManager(cfg, logger, db, atxsdata.New(), types.ATXID{2, 3, 4}, syncer, validator)
+	mgr, err := activation.NewPostSetupManager(cfg, logger, db, atxsdata.New(), &types.ATXID{2, 3, 4},
+		syncer, validator)
 	require.NoError(t, err)
 
 	opts := activation.DefaultPostSetupOpts()

--- a/activation/e2e/nipost_test.go
+++ b/activation/e2e/nipost_test.go
@@ -146,7 +146,7 @@ func TestNIPostBuilderWithClients(t *testing.T) {
 	})
 
 	validator := activation.NewMocknipostValidator(ctrl)
-	mgr, err := activation.NewPostSetupManager(cfg, logger, cdb, atxsdata.New(), goldenATX, syncer, validator)
+	mgr, err := activation.NewPostSetupManager(cfg, logger, cdb, atxsdata.New(), &goldenATX, syncer, validator)
 	require.NoError(t, err)
 
 	opts := activation.DefaultPostSetupOpts()
@@ -242,7 +242,7 @@ func TestNIPostBuilderWithClients(t *testing.T) {
 	_, err = v.NIPost(
 		context.Background(),
 		sig.NodeID(),
-		goldenATX,
+		&goldenATX,
 		nipost.NIPost,
 		challenge,
 		nipost.NumUnits,
@@ -287,7 +287,7 @@ func Test_NIPostBuilderWithMultipleClients(t *testing.T) {
 	for _, sig := range signers {
 		opts := opts
 		eg.Go(func() error {
-			mgr, err := activation.NewPostSetupManager(cfg, logger, db, atxsdata.New(), goldenATX, syncer, validator)
+			mgr, err := activation.NewPostSetupManager(cfg, logger, db, atxsdata.New(), &goldenATX, syncer, validator)
 			require.NoError(t, err)
 
 			opts.DataDir = t.TempDir()
@@ -369,7 +369,7 @@ func Test_NIPostBuilderWithMultipleClients(t *testing.T) {
 			_, err = v.NIPost(
 				context.Background(),
 				sig.NodeID(),
-				goldenATX,
+				&goldenATX,
 				nipost.NIPost,
 				challenge,
 				nipost.NumUnits,

--- a/activation/e2e/validation_test.go
+++ b/activation/e2e/validation_test.go
@@ -40,7 +40,7 @@ func TestValidator_Validate(t *testing.T) {
 		return synced
 	})
 
-	mgr, err := activation.NewPostSetupManager(cfg, logger, db, atxsdata.New(), goldenATX, syncer, validator)
+	mgr, err := activation.NewPostSetupManager(cfg, logger, db, atxsdata.New(), &goldenATX, syncer, validator)
 	require.NoError(t, err)
 
 	opts := activation.DefaultPostSetupOpts()
@@ -115,13 +115,13 @@ func TestValidator_Validate(t *testing.T) {
 	require.NoError(t, err)
 
 	v := activation.NewValidator(db, poetDb, cfg, opts.Scrypt, verifier)
-	_, err = v.NIPost(context.Background(), sig.NodeID(), goldenATX, nipost.NIPost, challenge, nipost.NumUnits)
+	_, err = v.NIPost(context.Background(), sig.NodeID(), &goldenATX, nipost.NIPost, challenge, nipost.NumUnits)
 	require.NoError(t, err)
 
 	_, err = v.NIPost(
 		context.Background(),
 		sig.NodeID(),
-		goldenATX,
+		&goldenATX,
 		nipost.NIPost,
 		types.BytesToHash([]byte("lerner")),
 		nipost.NumUnits,
@@ -130,13 +130,13 @@ func TestValidator_Validate(t *testing.T) {
 
 	newNIPost := *nipost.NIPost
 	newNIPost.Post = &types.Post{}
-	_, err = v.NIPost(context.Background(), sig.NodeID(), goldenATX, &newNIPost, challenge, nipost.NumUnits)
+	_, err = v.NIPost(context.Background(), sig.NodeID(), &goldenATX, &newNIPost, challenge, nipost.NumUnits)
 	require.ErrorContains(t, err, "invalid Post")
 
 	newPostCfg := cfg
 	newPostCfg.MinNumUnits = nipost.NumUnits + 1
 	v = activation.NewValidator(db, poetDb, newPostCfg, opts.Scrypt, nil)
-	_, err = v.NIPost(context.Background(), sig.NodeID(), goldenATX, nipost.NIPost, challenge, nipost.NumUnits)
+	_, err = v.NIPost(context.Background(), sig.NodeID(), &goldenATX, nipost.NIPost, challenge, nipost.NumUnits)
 	require.EqualError(
 		t,
 		err,
@@ -146,7 +146,7 @@ func TestValidator_Validate(t *testing.T) {
 	newPostCfg = cfg
 	newPostCfg.MaxNumUnits = nipost.NumUnits - 1
 	v = activation.NewValidator(db, poetDb, newPostCfg, opts.Scrypt, nil)
-	_, err = v.NIPost(context.Background(), sig.NodeID(), goldenATX, nipost.NIPost, challenge, nipost.NumUnits)
+	_, err = v.NIPost(context.Background(), sig.NodeID(), &goldenATX, nipost.NIPost, challenge, nipost.NumUnits)
 	require.EqualError(
 		t,
 		err,
@@ -156,7 +156,7 @@ func TestValidator_Validate(t *testing.T) {
 	newPostCfg = cfg
 	newPostCfg.LabelsPerUnit = nipost.PostMetadata.LabelsPerUnit + 1
 	v = activation.NewValidator(db, poetDb, newPostCfg, opts.Scrypt, nil)
-	_, err = v.NIPost(context.Background(), sig.NodeID(), goldenATX, nipost.NIPost, challenge, nipost.NumUnits)
+	_, err = v.NIPost(context.Background(), sig.NodeID(), &goldenATX, nipost.NIPost, challenge, nipost.NumUnits)
 	require.EqualError(
 		t,
 		err,

--- a/activation/handler_v1.go
+++ b/activation/handler_v1.go
@@ -217,7 +217,7 @@ func (h *HandlerV1) syntacticallyValidateDeps(
 		return 0, 0, nil, fmt.Errorf("commitment atx for %s not found: %w", atx.SmesherID, err)
 	}
 
-	if atx.PrevATXID == *types.EmptyATXID {
+	if atx.PrevATXID.Empty() {
 		if err := h.nipostValidator.InitialNIPostChallengeV1(&atx.NIPostChallengeV1, h.cdb, h.goldenATXID); err != nil {
 			return 0, 0, nil, err
 		}

--- a/activation/handler_v1.go
+++ b/activation/handler_v1.go
@@ -507,7 +507,7 @@ func (h *HandlerV1) checkWrongPrevAtx(
 		}
 	}
 
-	if atx2ID == types.EmptyATXID {
+	if atx2ID.Empty() {
 		// something went wrong, we couldn't find an ATX that points to the same previous ATX
 		// this should never happen since we are checking in other places that all ATXs from the same node
 		// form a chain

--- a/activation/handler_v1_test.go
+++ b/activation/handler_v1_test.go
@@ -30,7 +30,7 @@ type v1TestHandler struct {
 	handlerMocks
 }
 
-func newV1TestHandler(tb testing.TB, goldenATXID types.ATXID) *v1TestHandler {
+func newV1TestHandler(tb testing.TB, goldenATXID *types.ATXID) *v1TestHandler {
 	lg := zaptest.NewLogger(tb)
 	cdb := datastore.NewCachedDB(sql.InMemory(), lg)
 	mocks := newTestHandlerMocks(tb, goldenATXID)
@@ -84,8 +84,8 @@ func TestHandlerV1_SyntacticallyValidateAtx(t *testing.T) {
 		t.Parallel()
 		atxHdlr, prevAtx, posAtx := setup(t)
 
-		atx := newChainedActivationTxV1(t, prevAtx, posAtx.ID())
-		atx.PositioningATXID = posAtx.ID()
+		atx := newChainedActivationTxV1(t, prevAtx, *posAtx.ID())
+		atx.PositioningATXID = *posAtx.ID()
 		atx.Sign(sig)
 
 		atxHdlr.mclock.EXPECT().CurrentLayer().Return(atx.PublishEpoch.FirstLayer())
@@ -95,7 +95,7 @@ func TestHandlerV1_SyntacticallyValidateAtx(t *testing.T) {
 			NIPost(gomock.Any(), atx.SmesherID, goldenATXID, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(1234, nil)
 		atxHdlr.mValidator.EXPECT().NIPostChallengeV1(gomock.Any(), gomock.Any(), atx.SmesherID)
-		atxHdlr.mValidator.EXPECT().PositioningAtx(atx.PositioningATXID, gomock.Any(), goldenATXID, gomock.Any())
+		atxHdlr.mValidator.EXPECT().PositioningAtx(&atx.PositioningATXID, gomock.Any(), goldenATXID, gomock.Any())
 		leaves, units, proof, err := atxHdlr.syntacticallyValidateDeps(context.Background(), atx)
 		require.NoError(t, err)
 		require.Equal(t, uint64(1234), leaves)
@@ -107,7 +107,7 @@ func TestHandlerV1_SyntacticallyValidateAtx(t *testing.T) {
 		atxHdlr, prevAtx, posAtx := setup(t)
 
 		newNonce := *prevAtx.VRFNonce + 100
-		atx := newChainedActivationTxV1(t, prevAtx, posAtx.ID())
+		atx := newChainedActivationTxV1(t, prevAtx, *posAtx.ID())
 		atx.VRFNonce = &newNonce
 		atx.Sign(sig)
 
@@ -118,7 +118,7 @@ func TestHandlerV1_SyntacticallyValidateAtx(t *testing.T) {
 			NIPost(gomock.Any(), gomock.Any(), goldenATXID, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(1234, nil)
 		atxHdlr.mValidator.EXPECT().NIPostChallengeV1(gomock.Any(), gomock.Any(), gomock.Any())
-		atxHdlr.mValidator.EXPECT().PositioningAtx(atx.PositioningATXID, gomock.Any(), goldenATXID, atx.PublishEpoch)
+		atxHdlr.mValidator.EXPECT().PositioningAtx(&atx.PositioningATXID, gomock.Any(), goldenATXID, atx.PublishEpoch)
 		atxHdlr.mValidator.EXPECT().
 			VRFNonce(gomock.Any(), goldenATXID, newNonce, gomock.Any(), atx.NumUnits)
 		leaves, units, proof, err := atxHdlr.syntacticallyValidateDeps(context.Background(), atx)
@@ -131,7 +131,7 @@ func TestHandlerV1_SyntacticallyValidateAtx(t *testing.T) {
 		t.Parallel()
 		atxHdlr, prevAtx, posAtx := setup(t)
 
-		atx := newChainedActivationTxV1(t, prevAtx, posAtx.ID())
+		atx := newChainedActivationTxV1(t, prevAtx, *posAtx.ID())
 		atx.NumUnits = prevAtx.NumUnits - 10
 		atx.Sign(sig)
 
@@ -141,7 +141,7 @@ func TestHandlerV1_SyntacticallyValidateAtx(t *testing.T) {
 			NIPost(gomock.Any(), gomock.Any(), goldenATXID, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(uint64(1234), nil)
 		atxHdlr.mValidator.EXPECT().NIPostChallengeV1(gomock.Any(), gomock.Any(), gomock.Any())
-		atxHdlr.mValidator.EXPECT().PositioningAtx(atx.PositioningATXID, gomock.Any(), goldenATXID, atx.PublishEpoch)
+		atxHdlr.mValidator.EXPECT().PositioningAtx(&atx.PositioningATXID, gomock.Any(), goldenATXID, atx.PublishEpoch)
 		leaves, units, proof, err := atxHdlr.syntacticallyValidateDeps(context.Background(), atx)
 		require.NoError(t, err)
 		require.Equal(t, uint64(1234), leaves)
@@ -152,7 +152,7 @@ func TestHandlerV1_SyntacticallyValidateAtx(t *testing.T) {
 		t.Parallel()
 		atxHdlr, prevAtx, posAtx := setup(t)
 
-		atx := newChainedActivationTxV1(t, prevAtx, posAtx.ID())
+		atx := newChainedActivationTxV1(t, prevAtx, *posAtx.ID())
 		atx.NumUnits = prevAtx.NumUnits + 10
 		atx.Sign(sig)
 
@@ -162,7 +162,7 @@ func TestHandlerV1_SyntacticallyValidateAtx(t *testing.T) {
 			NIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(uint64(1234), nil)
 		atxHdlr.mValidator.EXPECT().NIPostChallengeV1(gomock.Any(), gomock.Any(), gomock.Any())
-		atxHdlr.mValidator.EXPECT().PositioningAtx(atx.PositioningATXID, gomock.Any(), gomock.Any(), gomock.Any())
+		atxHdlr.mValidator.EXPECT().PositioningAtx(&atx.PositioningATXID, gomock.Any(), gomock.Any(), gomock.Any())
 		atxHdlr.mValidator.EXPECT().VRFNonce(gomock.Any(), goldenATXID, *prevAtx.VRFNonce, gomock.Any(), atx.NumUnits)
 		leaves, units, proof, err := atxHdlr.syntacticallyValidateDeps(context.Background(), atx)
 		require.NoError(t, err)
@@ -174,7 +174,7 @@ func TestHandlerV1_SyntacticallyValidateAtx(t *testing.T) {
 		t.Parallel()
 		atxHdlr, prevAtx, posAtx := setup(t)
 
-		atx := newChainedActivationTxV1(t, prevAtx, posAtx.ID())
+		atx := newChainedActivationTxV1(t, prevAtx, *posAtx.ID())
 		atx.NumUnits = prevAtx.NumUnits + 10
 		atx.Sign(sig)
 
@@ -195,7 +195,7 @@ func TestHandlerV1_SyntacticallyValidateAtx(t *testing.T) {
 
 		ctxID := posAtx.ID()
 		atx := newInitialATXv1(t, goldenATXID)
-		atx.CommitmentATXID = &ctxID
+		atx.CommitmentATXID = ctxID
 		atx.Sign(sig)
 
 		atxHdlr.mclock.EXPECT().CurrentLayer().Return(atx.PublishEpoch.FirstLayer())
@@ -208,7 +208,7 @@ func TestHandlerV1_SyntacticallyValidateAtx(t *testing.T) {
 		atxHdlr.mValidator.EXPECT().
 			NIPost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(uint64(777), nil)
-		atxHdlr.mValidator.EXPECT().PositioningAtx(atx.PositioningATXID, gomock.Any(), goldenATXID, atx.PublishEpoch)
+		atxHdlr.mValidator.EXPECT().PositioningAtx(&atx.PositioningATXID, gomock.Any(), goldenATXID, atx.PublishEpoch)
 		leaves, units, proof, err := atxHdlr.syntacticallyValidateDeps(context.Background(), atx)
 		require.NoError(t, err)
 		require.Equal(t, uint64(777), leaves)
@@ -219,7 +219,7 @@ func TestHandlerV1_SyntacticallyValidateAtx(t *testing.T) {
 		t.Parallel()
 		atxHdlr, prevAtx, posAtx := setup(t)
 
-		atx := newChainedActivationTxV1(t, prevAtx, posAtx.ID())
+		atx := newChainedActivationTxV1(t, prevAtx, *posAtx.ID())
 		atx.Sign(sig)
 
 		atxHdlr.mclock.EXPECT().CurrentLayer().Return((atx.PublishEpoch - 2).FirstLayer())
@@ -230,7 +230,7 @@ func TestHandlerV1_SyntacticallyValidateAtx(t *testing.T) {
 		t.Parallel()
 		atxHdlr, prevAtx, posAtx := setup(t)
 
-		atx := newChainedActivationTxV1(t, prevAtx, posAtx.ID())
+		atx := newChainedActivationTxV1(t, prevAtx, *posAtx.ID())
 		atx.Sign(sig)
 
 		atxHdlr.mclock.EXPECT().CurrentLayer().Return(atx.PublishEpoch.FirstLayer())
@@ -247,7 +247,7 @@ func TestHandlerV1_SyntacticallyValidateAtx(t *testing.T) {
 		t.Parallel()
 		atxHdlr, prevAtx, posAtx := setup(t)
 
-		atx := newChainedActivationTxV1(t, prevAtx, posAtx.ID())
+		atx := newChainedActivationTxV1(t, prevAtx, *posAtx.ID())
 		atx.Sign(sig)
 
 		atxHdlr.mclock.EXPECT().CurrentLayer().Return(atx.PublishEpoch.FirstLayer())
@@ -255,7 +255,7 @@ func TestHandlerV1_SyntacticallyValidateAtx(t *testing.T) {
 
 		atxHdlr.mValidator.EXPECT().NIPostChallengeV1(gomock.Any(), gomock.Any(), atx.SmesherID)
 		atxHdlr.mValidator.EXPECT().
-			PositioningAtx(atx.PositioningATXID, gomock.Any(), goldenATXID, atx.PublishEpoch).
+			PositioningAtx(&atx.PositioningATXID, gomock.Any(), goldenATXID, atx.PublishEpoch).
 			Return(errors.New("bad positioning atx"))
 		_, _, proof, err := atxHdlr.syntacticallyValidateDeps(context.Background(), atx)
 		require.EqualError(t, err, "bad positioning atx")
@@ -286,14 +286,14 @@ func TestHandlerV1_SyntacticallyValidateAtx(t *testing.T) {
 		t.Parallel()
 		atxHdlr, prevATX, postAtx := setup(t)
 
-		atx := newChainedActivationTxV1(t, prevATX, postAtx.ID())
+		atx := newChainedActivationTxV1(t, prevATX, *postAtx.ID())
 		atx.Sign(sig)
 
 		atxHdlr.mclock.EXPECT().CurrentLayer().Return(atx.PublishEpoch.FirstLayer())
 		require.NoError(t, atxHdlr.syntacticallyValidate(context.Background(), atx))
 
 		atxHdlr.mValidator.EXPECT().NIPostChallengeV1(gomock.Any(), gomock.Any(), atx.SmesherID)
-		atxHdlr.mValidator.EXPECT().PositioningAtx(atx.PositioningATXID, gomock.Any(), goldenATXID, atx.PublishEpoch)
+		atxHdlr.mValidator.EXPECT().PositioningAtx(&atx.PositioningATXID, gomock.Any(), goldenATXID, atx.PublishEpoch)
 		atxHdlr.mValidator.EXPECT().
 			NIPost(gomock.Any(), atx.SmesherID, goldenATXID, gomock.Any(), gomock.Any(), atx.NumUnits, gomock.Any()).
 			Return(0, errors.New("bad nipost"))
@@ -333,7 +333,7 @@ func TestHandlerV1_SyntacticallyValidateAtx(t *testing.T) {
 
 		atxHdlr.mclock.EXPECT().CurrentLayer().Return(atx.PublishEpoch.FirstLayer())
 		atxHdlr.mValidator.EXPECT().
-			VRFNonce(atx.SmesherID, *atx.CommitmentATXID, *atx.VRFNonce, gomock.Any(), atx.NumUnits).
+			VRFNonce(atx.SmesherID, atx.CommitmentATXID, *atx.VRFNonce, gomock.Any(), atx.NumUnits).
 			Return(errors.New("invalid VRF nonce"))
 		err := atxHdlr.syntacticallyValidate(context.Background(), atx)
 		require.ErrorContains(t, err, "invalid VRF nonce")
@@ -342,8 +342,8 @@ func TestHandlerV1_SyntacticallyValidateAtx(t *testing.T) {
 		t.Parallel()
 		atxHdlr, prevAtx, posAtx := setup(t)
 
-		atx := newChainedActivationTxV1(t, prevAtx, posAtx.ID())
-		atx.PrevATXID = types.EmptyATXID
+		atx := newChainedActivationTxV1(t, prevAtx, *posAtx.ID())
+		atx.PrevATXID = *types.EmptyATXID
 		atx.Sign(sig)
 
 		atxHdlr.mclock.EXPECT().CurrentLayer().Return(atx.PublishEpoch.FirstLayer())
@@ -367,7 +367,7 @@ func TestHandlerV1_SyntacticallyValidateAtx(t *testing.T) {
 		atxHdlr, _, _ := setup(t)
 
 		atx := newInitialATXv1(t, goldenATXID)
-		atx.CommitmentATXID = &types.EmptyATXID
+		atx.CommitmentATXID = types.EmptyATXID
 		atx.Sign(sig)
 
 		atxHdlr.mclock.EXPECT().CurrentLayer().Return(atx.PublishEpoch.FirstLayer())
@@ -395,7 +395,7 @@ func TestHandlerV1_SyntacticallyValidateAtx(t *testing.T) {
 
 		atxHdlr.mclock.EXPECT().CurrentLayer().Return(atx.PublishEpoch.FirstLayer())
 		atxHdlr.mValidator.EXPECT().
-			VRFNonce(atx.SmesherID, *atx.CommitmentATXID, *atx.VRFNonce, gomock.Any(), atx.NumUnits)
+			VRFNonce(atx.SmesherID, atx.CommitmentATXID, *atx.VRFNonce, gomock.Any(), atx.NumUnits)
 		atxHdlr.mValidator.EXPECT().
 			Post(gomock.Any(), atx.SmesherID, gomock.Any(), gomock.Any(), gomock.Any(), atx.NumUnits, gomock.Any()).
 			Return(errors.New("failed post validation"))
@@ -407,7 +407,7 @@ func TestHandlerV1_SyntacticallyValidateAtx(t *testing.T) {
 		atxHdlr, _, _ := setup(t)
 
 		atx := newInitialATXv1(t, goldenATXID)
-		atx.PositioningATXID = types.EmptyATXID
+		atx.PositioningATXID = *types.EmptyATXID
 		atx.Sign(sig)
 
 		atxHdlr.mclock.EXPECT().CurrentLayer().Return(atx.PublishEpoch.FirstLayer())
@@ -419,7 +419,7 @@ func TestHandlerV1_SyntacticallyValidateAtx(t *testing.T) {
 		atxHdlr, prevAtx, _ := setup(t)
 
 		atx := newInitialATXv1(t, goldenATXID)
-		atx.PrevATXID = prevAtx.ID()
+		atx.PrevATXID = *prevAtx.ID()
 		atx.Sign(sig)
 
 		atxHdlr.mclock.EXPECT().CurrentLayer().Return(atx.PublishEpoch.FirstLayer())
@@ -430,7 +430,7 @@ func TestHandlerV1_SyntacticallyValidateAtx(t *testing.T) {
 		t.Parallel()
 		atxHdlr, prevAtx, posAtx := setup(t)
 
-		atx := newChainedActivationTxV1(t, prevAtx, posAtx.ID())
+		atx := newChainedActivationTxV1(t, prevAtx, *posAtx.ID())
 		atx.NodeID = &types.NodeID{1, 2, 3}
 		atx.Sign(sig)
 
@@ -442,8 +442,8 @@ func TestHandlerV1_SyntacticallyValidateAtx(t *testing.T) {
 		t.Parallel()
 		atxHdlr, prevAtx, posAtx := setup(t)
 
-		atx := newChainedActivationTxV1(t, prevAtx, posAtx.ID())
-		atx.CommitmentATXID = &types.EmptyATXID
+		atx := newChainedActivationTxV1(t, prevAtx, *posAtx.ID())
+		atx.CommitmentATXID = types.EmptyATXID
 		atx.Sign(sig)
 
 		atxHdlr.mclock.EXPECT().CurrentLayer().Return(atx.PublishEpoch.FirstLayer())
@@ -453,7 +453,7 @@ func TestHandlerV1_SyntacticallyValidateAtx(t *testing.T) {
 }
 
 func TestHandler_ContextuallyValidateAtx(t *testing.T) {
-	goldenATXID := types.ATXID{2, 3, 4}
+	goldenATXID := &types.ATXID{2, 3, 4}
 
 	sig, err := signing.NewEdSigner()
 	require.NoError(t, err)
@@ -474,7 +474,7 @@ func TestHandler_ContextuallyValidateAtx(t *testing.T) {
 		atxHdlr := newV1TestHandler(t, goldenATXID)
 
 		prevAtx := newInitialATXv1(t, goldenATXID)
-		atx := newChainedActivationTxV1(t, prevAtx, goldenATXID)
+		atx := newChainedActivationTxV1(t, prevAtx, *goldenATXID)
 
 		err = atxHdlr.contextuallyValidateAtx(atx)
 		require.ErrorIs(t, err, sql.ErrNotFound)
@@ -491,14 +491,14 @@ func TestHandler_ContextuallyValidateAtx(t *testing.T) {
 		_, err := atxHdlr.processATX(context.Background(), "", atx0, codec.MustEncode(atx0), time.Now())
 		require.NoError(t, err)
 
-		atx1 := newChainedActivationTxV1(t, atx0, goldenATXID)
+		atx1 := newChainedActivationTxV1(t, atx0, *goldenATXID)
 		atx1.Sign(sig)
 		atxHdlr.expectAtxV1(atx1, sig.NodeID())
 		atxHdlr.mockFetch.EXPECT().GetAtxs(gomock.Any(), gomock.Any(), gomock.Any())
 		_, err = atxHdlr.processATX(context.Background(), "", atx1, codec.MustEncode(atx1), time.Now())
 		require.NoError(t, err)
 
-		atxInvalidPrevious := newChainedActivationTxV1(t, atx0, goldenATXID)
+		atxInvalidPrevious := newChainedActivationTxV1(t, atx0, *goldenATXID)
 		atxInvalidPrevious.Sign(sig)
 		err = atxHdlr.contextuallyValidateAtx(atxInvalidPrevious)
 		require.EqualError(t, err, "last atx is not the one referenced")
@@ -524,7 +524,7 @@ func TestHandler_ContextuallyValidateAtx(t *testing.T) {
 		_, err = atxHdlr.processATX(context.Background(), "", atx1, codec.MustEncode(atx1), time.Now())
 		require.NoError(t, err)
 
-		atxInvalidPrevious := newChainedActivationTxV1(t, atx0, goldenATXID)
+		atxInvalidPrevious := newChainedActivationTxV1(t, atx0, *goldenATXID)
 		atxInvalidPrevious.Sign(sig)
 		err = atxHdlr.contextuallyValidateAtx(atxInvalidPrevious)
 		require.EqualError(t, err, "last atx is not the one referenced")
@@ -567,7 +567,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 		atx := toAtx(t, watx)
 
 		atxHdlr.mbeacon.EXPECT().OnAtx(gomock.Cond(func(atx any) bool {
-			return atx.(*types.ActivationTx).ID() == watx.ID()
+			return atx.(*types.ActivationTx).ID().Equal(watx.ID())
 		}))
 		atxHdlr.mtortoise.EXPECT().OnAtx(watx.PublishEpoch+1, watx.ID(), gomock.Any())
 		proof, err := atxHdlr.storeAtx(context.Background(), atx, watx)
@@ -575,7 +575,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 		require.Nil(t, proof)
 
 		atxHdlr.mbeacon.EXPECT().OnAtx(gomock.Cond(func(atx any) bool {
-			return atx.(*types.ActivationTx).ID() == watx.ID()
+			return atx.(*types.ActivationTx).ID().Equal(watx.ID())
 		}))
 		// Note: tortoise is not informed about the same ATX again
 		proof, err = atxHdlr.storeAtx(context.Background(), atx, watx)
@@ -698,7 +698,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 		require.Nil(t, proof)
 
 		// valid first non-initial ATX
-		watx1 := newChainedActivationTxV1(t, initialATX, goldenATXID)
+		watx1 := newChainedActivationTxV1(t, initialATX, *goldenATXID)
 		watx1.Sign(sig)
 		atx1 := toAtx(t, watx1)
 
@@ -710,7 +710,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 		require.NoError(t, err)
 		require.Nil(t, proof)
 
-		watx2 := newChainedActivationTxV1(t, watx1, goldenATXID)
+		watx2 := newChainedActivationTxV1(t, watx1, *goldenATXID)
 		watx2.Sign(sig)
 		atx2 := toAtx(t, watx2)
 
@@ -723,7 +723,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 		require.Nil(t, proof)
 
 		// third non-initial ATX references initial ATX as prevATX
-		watx3 := newChainedActivationTxV1(t, initialATX, goldenATXID)
+		watx3 := newChainedActivationTxV1(t, initialATX, *goldenATXID)
 		watx3.PublishEpoch = watx2.PublishEpoch + 1
 		watx3.Sign(sig)
 		atx3 := toAtx(t, watx3)
@@ -763,7 +763,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 		require.Nil(t, proof)
 
 		// valid first non-initial ATX
-		watx1 := newChainedActivationTxV1(t, wInitialATX, goldenATXID)
+		watx1 := newChainedActivationTxV1(t, wInitialATX, *goldenATXID)
 		watx1.Sign(sig)
 		atx1 := toAtx(t, watx1)
 
@@ -802,7 +802,7 @@ func TestHandlerV1_RegistersHashesInPeer(t *testing.T) {
 		atxHdlr := newV1TestHandler(t, goldenATXID)
 
 		poet := types.RandomHash()
-		atxs := []types.ATXID{types.RandomATXID(), types.RandomATXID()}
+		atxs := []*types.ATXID{types.RandomATXID(), types.RandomATXID()}
 
 		atxHdlr.mockFetch.EXPECT().
 			RegisterPeerHashes(peer, gomock.InAnyOrder([]types.Hash32{poet, atxs[0].Hash32(), atxs[1].Hash32()}))
@@ -826,7 +826,7 @@ func TestHandlerV1_FetchesReferences(t *testing.T) {
 		atxHdlr := newV1TestHandler(t, goldenATXID)
 
 		poet := types.RandomHash()
-		atxs := []types.ATXID{types.RandomATXID(), types.RandomATXID()}
+		atxs := []*types.ATXID{types.RandomATXID(), types.RandomATXID()}
 
 		atxHdlr.mockFetch.EXPECT().GetPoetProof(gomock.Any(), poet)
 		atxHdlr.mockFetch.EXPECT().GetAtxs(gomock.Any(), atxs, gomock.Any())
@@ -848,7 +848,7 @@ func TestHandlerV1_FetchesReferences(t *testing.T) {
 		atxHdlr := newV1TestHandler(t, goldenATXID)
 
 		poet := types.RandomHash()
-		atxs := []types.ATXID{types.RandomATXID(), types.RandomATXID()}
+		atxs := []*types.ATXID{types.RandomATXID(), types.RandomATXID()}
 
 		atxHdlr.mockFetch.EXPECT().GetPoetProof(gomock.Any(), poet).Return(errors.New("pooh"))
 		require.Error(t, atxHdlr.fetchReferences(context.Background(), poet, nil))

--- a/activation/handler_v2.go
+++ b/activation/handler_v2.go
@@ -157,7 +157,7 @@ func (h *HandlerV2) syntacticallyValidate(ctx context.Context, atx *wire.Activat
 	if !h.edVerifier.Verify(signing.ATX, atx.SmesherID, atx.SignedBytes(), atx.Signature) {
 		return fmt.Errorf("invalid atx signature: %w", errMalformedData)
 	}
-	if atx.PositioningATX == *types.EmptyATXID {
+	if atx.PositioningATX.Empty() {
 		return errors.New("empty positioning atx")
 	}
 	if len(atx.Marriages) != 0 {
@@ -192,7 +192,7 @@ func (h *HandlerV2) syntacticallyValidate(ctx context.Context, atx *wire.Activat
 		if atx.MarriageATX != nil {
 			return errors.New("initial atx cannot reference a marriage atx")
 		}
-		if atx.Initial.CommitmentATX == *types.EmptyATXID {
+		if atx.Initial.CommitmentATX.Empty() {
 			return errors.New("initial atx missing commitment atx")
 		}
 		if len(atx.PreviousATXs) != 0 {
@@ -215,10 +215,10 @@ func (h *HandlerV2) syntacticallyValidate(ctx context.Context, atx *wire.Activat
 	}
 
 	for i, prev := range atx.PreviousATXs {
-		if prev == *types.EmptyATXID {
+		if prev.Empty() {
 			return fmt.Errorf("previous atx[%d] is empty", i)
 		}
-		if prev == *h.goldenATXID {
+		if prev.Equal(h.goldenATXID) {
 			return fmt.Errorf("previous atx[%d] is the golden ATX", i)
 		}
 	}

--- a/activation/interface.go
+++ b/activation/interface.go
@@ -39,7 +39,7 @@ type nipostValidator interface {
 	nipostValidatorV2
 
 	// VerifyChain fully verifies all dependencies of the given ATX and the ATX itself.
-	VerifyChain(ctx context.Context, id, goldenATXID types.ATXID, opts ...VerifyChainOption) error
+	VerifyChain(ctx context.Context, id, goldenATXID *types.ATXID, opts ...VerifyChainOption) error
 }
 
 type layerClock interface {
@@ -65,7 +65,7 @@ type syncer interface {
 }
 
 type atxProvider interface {
-	GetAtx(id types.ATXID) (*types.ActivationTx, error)
+	GetAtx(id *types.ATXID) (*types.ActivationTx, error)
 }
 
 // PostSetupProvider defines the functionality required for Post setup.

--- a/activation/malfeasance.go
+++ b/activation/malfeasance.go
@@ -125,7 +125,7 @@ func (mh *InvalidPostIndexHandler) Validate(ctx context.Context, data wire.Proof
 		if err != nil {
 			return types.EmptyNodeID, fmt.Errorf("getting commitment ATX: %w", err)
 		}
-		commitmentAtx = &atx
+		commitmentAtx = atx
 	}
 	post := (*shared.Proof)(atx.NIPost.Post)
 	meta := &shared.ProofMetadata{
@@ -202,7 +202,7 @@ func (mh *InvalidPrevATXHandler) Validate(ctx context.Context, data wire.ProofDa
 		return types.EmptyNodeID, errors.New("atx2: invalid signature")
 	}
 
-	if atx1.ID() == atx2.ID() {
+	if atx1.ID().Equal(atx2.ID()) {
 		return types.EmptyNodeID, errors.New("invalid old prev ATX malfeasance proof: ATX IDs are the same")
 	}
 	if atx1.PrevATXID != atx2.PrevATXID {

--- a/activation/malfeasance_test.go
+++ b/activation/malfeasance_test.go
@@ -273,8 +273,8 @@ func TestInvalidPostIndexHandler_Validate(t *testing.T) {
 		atx := awire.ActivationTxV1{
 			InnerActivationTxV1: awire.InnerActivationTxV1{
 				NIPostChallengeV1: awire.NIPostChallengeV1{
-					PositioningATXID: types.RandomATXID(),
-					PrevATXID:        types.EmptyATXID,
+					PositioningATXID: *types.RandomATXID(),
+					PrevATXID:        *types.EmptyATXID,
 					PublishEpoch:     rand.N[types.EpochID](types.EpochID(100)),
 					Sequence:         0,
 					CommitmentATXID:  &types.ATXID{1, 2, 3},
@@ -332,8 +332,8 @@ func TestInvalidPostIndexHandler_Validate(t *testing.T) {
 		atx := awire.ActivationTxV1{
 			InnerActivationTxV1: awire.InnerActivationTxV1{
 				NIPostChallengeV1: awire.NIPostChallengeV1{
-					PositioningATXID: types.RandomATXID(),
-					PrevATXID:        types.EmptyATXID,
+					PositioningATXID: *types.RandomATXID(),
+					PrevATXID:        *types.EmptyATXID,
 					PublishEpoch:     rand.N[types.EpochID](types.EpochID(100)),
 					Sequence:         0,
 					CommitmentATXID:  &types.ATXID{1, 2, 3},
@@ -391,8 +391,8 @@ func TestInvalidPostIndexHandler_Validate(t *testing.T) {
 		atx := awire.ActivationTxV1{
 			InnerActivationTxV1: awire.InnerActivationTxV1{
 				NIPostChallengeV1: awire.NIPostChallengeV1{
-					PositioningATXID: types.RandomATXID(),
-					PrevATXID:        types.EmptyATXID,
+					PositioningATXID: *types.RandomATXID(),
+					PrevATXID:        *types.EmptyATXID,
 					PublishEpoch:     rand.N[types.EpochID](types.EpochID(100)),
 					Sequence:         0,
 					CommitmentATXID:  &types.ATXID{1, 2, 3},
@@ -461,7 +461,7 @@ func TestInvalidPrevATX_Validate(t *testing.T) {
 		atx1 := awire.ActivationTxV1{
 			InnerActivationTxV1: awire.InnerActivationTxV1{
 				NIPostChallengeV1: awire.NIPostChallengeV1{
-					PrevATXID:    prevATXID,
+					PrevATXID:    *prevATXID,
 					PublishEpoch: types.EpochID(2),
 				},
 			},
@@ -471,7 +471,7 @@ func TestInvalidPrevATX_Validate(t *testing.T) {
 		atx2 := awire.ActivationTxV1{
 			InnerActivationTxV1: awire.InnerActivationTxV1{
 				NIPostChallengeV1: awire.NIPostChallengeV1{
-					PrevATXID:    prevATXID,
+					PrevATXID:    *prevATXID,
 					PublishEpoch: types.EpochID(3),
 				},
 			},
@@ -498,7 +498,7 @@ func TestInvalidPrevATX_Validate(t *testing.T) {
 		atx1 := awire.ActivationTxV1{
 			InnerActivationTxV1: awire.InnerActivationTxV1{
 				NIPostChallengeV1: awire.NIPostChallengeV1{
-					PrevATXID:    prevATXID,
+					PrevATXID:    *prevATXID,
 					PublishEpoch: types.EpochID(2),
 				},
 			},
@@ -508,7 +508,7 @@ func TestInvalidPrevATX_Validate(t *testing.T) {
 		atx2 := awire.ActivationTxV1{
 			InnerActivationTxV1: awire.InnerActivationTxV1{
 				NIPostChallengeV1: awire.NIPostChallengeV1{
-					PrevATXID:    prevATXID,
+					PrevATXID:    *prevATXID,
 					PublishEpoch: types.EpochID(3),
 				},
 			},
@@ -536,7 +536,7 @@ func TestInvalidPrevATX_Validate(t *testing.T) {
 		atx1 := awire.ActivationTxV1{
 			InnerActivationTxV1: awire.InnerActivationTxV1{
 				NIPostChallengeV1: awire.NIPostChallengeV1{
-					PrevATXID:    prevATXID,
+					PrevATXID:    *prevATXID,
 					PublishEpoch: types.EpochID(2),
 				},
 			},
@@ -547,7 +547,7 @@ func TestInvalidPrevATX_Validate(t *testing.T) {
 		atx2 := awire.ActivationTxV1{
 			InnerActivationTxV1: awire.InnerActivationTxV1{
 				NIPostChallengeV1: awire.NIPostChallengeV1{
-					PrevATXID:    prevATXID,
+					PrevATXID:    *prevATXID,
 					PublishEpoch: types.EpochID(3),
 				},
 			},
@@ -575,7 +575,7 @@ func TestInvalidPrevATX_Validate(t *testing.T) {
 		atx1 := awire.ActivationTxV1{
 			InnerActivationTxV1: awire.InnerActivationTxV1{
 				NIPostChallengeV1: awire.NIPostChallengeV1{
-					PrevATXID:    prevATXID,
+					PrevATXID:    *prevATXID,
 					PublishEpoch: types.EpochID(2),
 				},
 			},
@@ -585,7 +585,7 @@ func TestInvalidPrevATX_Validate(t *testing.T) {
 		atx2 := awire.ActivationTxV1{
 			InnerActivationTxV1: awire.InnerActivationTxV1{
 				NIPostChallengeV1: awire.NIPostChallengeV1{
-					PrevATXID:    prevATXID,
+					PrevATXID:    *prevATXID,
 					PublishEpoch: types.EpochID(3),
 				},
 			},
@@ -614,7 +614,7 @@ func TestInvalidPrevATX_Validate(t *testing.T) {
 		atx1 := awire.ActivationTxV1{
 			InnerActivationTxV1: awire.InnerActivationTxV1{
 				NIPostChallengeV1: awire.NIPostChallengeV1{
-					PrevATXID:    prevATXID,
+					PrevATXID:    *prevATXID,
 					PublishEpoch: types.EpochID(2),
 				},
 			},
@@ -642,7 +642,7 @@ func TestInvalidPrevATX_Validate(t *testing.T) {
 		atx1 := awire.ActivationTxV1{
 			InnerActivationTxV1: awire.InnerActivationTxV1{
 				NIPostChallengeV1: awire.NIPostChallengeV1{
-					PrevATXID:    types.RandomATXID(),
+					PrevATXID:    *types.RandomATXID(),
 					PublishEpoch: types.EpochID(2),
 				},
 			},
@@ -652,7 +652,7 @@ func TestInvalidPrevATX_Validate(t *testing.T) {
 		atx2 := awire.ActivationTxV1{
 			InnerActivationTxV1: awire.InnerActivationTxV1{
 				NIPostChallengeV1: awire.NIPostChallengeV1{
-					PrevATXID:    atx1.ID(),
+					PrevATXID:    *atx1.ID(),
 					PublishEpoch: types.EpochID(3),
 				},
 			},
@@ -684,7 +684,7 @@ func TestInvalidPrevATX_Validate(t *testing.T) {
 		atx1 := awire.ActivationTxV1{
 			InnerActivationTxV1: awire.InnerActivationTxV1{
 				NIPostChallengeV1: awire.NIPostChallengeV1{
-					PrevATXID:    prevATXID,
+					PrevATXID:    *prevATXID,
 					PublishEpoch: types.EpochID(2),
 				},
 			},
@@ -694,7 +694,7 @@ func TestInvalidPrevATX_Validate(t *testing.T) {
 		atx2 := awire.ActivationTxV1{
 			InnerActivationTxV1: awire.InnerActivationTxV1{
 				NIPostChallengeV1: awire.NIPostChallengeV1{
-					PrevATXID:    prevATXID,
+					PrevATXID:    *prevATXID,
 					PublishEpoch: types.EpochID(3),
 				},
 			},

--- a/activation/mocks.go
+++ b/activation/mocks.go
@@ -271,7 +271,7 @@ func (m *MocknipostValidator) EXPECT() *MocknipostValidatorMockRecorder {
 }
 
 // InitialNIPostChallengeV1 mocks base method.
-func (m *MocknipostValidator) InitialNIPostChallengeV1(challenge *wire.NIPostChallengeV1, atxs atxProvider, goldenATXID types.ATXID) error {
+func (m *MocknipostValidator) InitialNIPostChallengeV1(challenge *wire.NIPostChallengeV1, atxs atxProvider, goldenATXID *types.ATXID) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InitialNIPostChallengeV1", challenge, atxs, goldenATXID)
 	ret0, _ := ret[0].(error)
@@ -297,13 +297,13 @@ func (c *MocknipostValidatorInitialNIPostChallengeV1Call) Return(arg0 error) *Mo
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MocknipostValidatorInitialNIPostChallengeV1Call) Do(f func(*wire.NIPostChallengeV1, atxProvider, types.ATXID) error) *MocknipostValidatorInitialNIPostChallengeV1Call {
+func (c *MocknipostValidatorInitialNIPostChallengeV1Call) Do(f func(*wire.NIPostChallengeV1, atxProvider, *types.ATXID) error) *MocknipostValidatorInitialNIPostChallengeV1Call {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MocknipostValidatorInitialNIPostChallengeV1Call) DoAndReturn(f func(*wire.NIPostChallengeV1, atxProvider, types.ATXID) error) *MocknipostValidatorInitialNIPostChallengeV1Call {
+func (c *MocknipostValidatorInitialNIPostChallengeV1Call) DoAndReturn(f func(*wire.NIPostChallengeV1, atxProvider, *types.ATXID) error) *MocknipostValidatorInitialNIPostChallengeV1Call {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -347,7 +347,7 @@ func (c *MocknipostValidatorIsVerifyingFullPostCall) DoAndReturn(f func() bool) 
 }
 
 // NIPost mocks base method.
-func (m *MocknipostValidator) NIPost(ctx context.Context, nodeId types.NodeID, commitmentAtxId types.ATXID, NIPost *types.NIPost, expectedChallenge types.Hash32, numUnits uint32, opts ...validatorOption) (uint64, error) {
+func (m *MocknipostValidator) NIPost(ctx context.Context, nodeId types.NodeID, commitmentAtxId *types.ATXID, NIPost *types.NIPost, expectedChallenge types.Hash32, numUnits uint32, opts ...validatorOption) (uint64, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{ctx, nodeId, commitmentAtxId, NIPost, expectedChallenge, numUnits}
 	for _, a := range opts {
@@ -379,13 +379,13 @@ func (c *MocknipostValidatorNIPostCall) Return(arg0 uint64, arg1 error) *Mocknip
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MocknipostValidatorNIPostCall) Do(f func(context.Context, types.NodeID, types.ATXID, *types.NIPost, types.Hash32, uint32, ...validatorOption) (uint64, error)) *MocknipostValidatorNIPostCall {
+func (c *MocknipostValidatorNIPostCall) Do(f func(context.Context, types.NodeID, *types.ATXID, *types.NIPost, types.Hash32, uint32, ...validatorOption) (uint64, error)) *MocknipostValidatorNIPostCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MocknipostValidatorNIPostCall) DoAndReturn(f func(context.Context, types.NodeID, types.ATXID, *types.NIPost, types.Hash32, uint32, ...validatorOption) (uint64, error)) *MocknipostValidatorNIPostCall {
+func (c *MocknipostValidatorNIPostCall) DoAndReturn(f func(context.Context, types.NodeID, *types.ATXID, *types.NIPost, types.Hash32, uint32, ...validatorOption) (uint64, error)) *MocknipostValidatorNIPostCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -506,7 +506,7 @@ func (c *MocknipostValidatorPoetMembershipCall) DoAndReturn(f func(context.Conte
 }
 
 // PositioningAtx mocks base method.
-func (m *MocknipostValidator) PositioningAtx(id types.ATXID, atxs atxProvider, goldenATXID types.ATXID, pubepoch types.EpochID) error {
+func (m *MocknipostValidator) PositioningAtx(id *types.ATXID, atxs atxProvider, goldenATXID *types.ATXID, pubepoch types.EpochID) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PositioningAtx", id, atxs, goldenATXID, pubepoch)
 	ret0, _ := ret[0].(error)
@@ -532,19 +532,19 @@ func (c *MocknipostValidatorPositioningAtxCall) Return(arg0 error) *MocknipostVa
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MocknipostValidatorPositioningAtxCall) Do(f func(types.ATXID, atxProvider, types.ATXID, types.EpochID) error) *MocknipostValidatorPositioningAtxCall {
+func (c *MocknipostValidatorPositioningAtxCall) Do(f func(*types.ATXID, atxProvider, *types.ATXID, types.EpochID) error) *MocknipostValidatorPositioningAtxCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MocknipostValidatorPositioningAtxCall) DoAndReturn(f func(types.ATXID, atxProvider, types.ATXID, types.EpochID) error) *MocknipostValidatorPositioningAtxCall {
+func (c *MocknipostValidatorPositioningAtxCall) DoAndReturn(f func(*types.ATXID, atxProvider, *types.ATXID, types.EpochID) error) *MocknipostValidatorPositioningAtxCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // Post mocks base method.
-func (m *MocknipostValidator) Post(ctx context.Context, nodeId types.NodeID, commitmentAtxId types.ATXID, post *types.Post, metadata *types.PostMetadata, numUnits uint32, opts ...validatorOption) error {
+func (m *MocknipostValidator) Post(ctx context.Context, nodeId types.NodeID, commitmentAtxId *types.ATXID, post *types.Post, metadata *types.PostMetadata, numUnits uint32, opts ...validatorOption) error {
 	m.ctrl.T.Helper()
 	varargs := []any{ctx, nodeId, commitmentAtxId, post, metadata, numUnits}
 	for _, a := range opts {
@@ -575,19 +575,19 @@ func (c *MocknipostValidatorPostCall) Return(arg0 error) *MocknipostValidatorPos
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MocknipostValidatorPostCall) Do(f func(context.Context, types.NodeID, types.ATXID, *types.Post, *types.PostMetadata, uint32, ...validatorOption) error) *MocknipostValidatorPostCall {
+func (c *MocknipostValidatorPostCall) Do(f func(context.Context, types.NodeID, *types.ATXID, *types.Post, *types.PostMetadata, uint32, ...validatorOption) error) *MocknipostValidatorPostCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MocknipostValidatorPostCall) DoAndReturn(f func(context.Context, types.NodeID, types.ATXID, *types.Post, *types.PostMetadata, uint32, ...validatorOption) error) *MocknipostValidatorPostCall {
+func (c *MocknipostValidatorPostCall) DoAndReturn(f func(context.Context, types.NodeID, *types.ATXID, *types.Post, *types.PostMetadata, uint32, ...validatorOption) error) *MocknipostValidatorPostCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // PostV2 mocks base method.
-func (m *MocknipostValidator) PostV2(ctx context.Context, smesherID types.NodeID, commitment types.ATXID, post *types.Post, challenge []byte, numUnits uint32, opts ...validatorOption) error {
+func (m *MocknipostValidator) PostV2(ctx context.Context, smesherID types.NodeID, commitment *types.ATXID, post *types.Post, challenge []byte, numUnits uint32, opts ...validatorOption) error {
 	m.ctrl.T.Helper()
 	varargs := []any{ctx, smesherID, commitment, post, challenge, numUnits}
 	for _, a := range opts {
@@ -618,19 +618,19 @@ func (c *MocknipostValidatorPostV2Call) Return(arg0 error) *MocknipostValidatorP
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MocknipostValidatorPostV2Call) Do(f func(context.Context, types.NodeID, types.ATXID, *types.Post, []byte, uint32, ...validatorOption) error) *MocknipostValidatorPostV2Call {
+func (c *MocknipostValidatorPostV2Call) Do(f func(context.Context, types.NodeID, *types.ATXID, *types.Post, []byte, uint32, ...validatorOption) error) *MocknipostValidatorPostV2Call {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MocknipostValidatorPostV2Call) DoAndReturn(f func(context.Context, types.NodeID, types.ATXID, *types.Post, []byte, uint32, ...validatorOption) error) *MocknipostValidatorPostV2Call {
+func (c *MocknipostValidatorPostV2Call) DoAndReturn(f func(context.Context, types.NodeID, *types.ATXID, *types.Post, []byte, uint32, ...validatorOption) error) *MocknipostValidatorPostV2Call {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // VRFNonce mocks base method.
-func (m *MocknipostValidator) VRFNonce(nodeId types.NodeID, commitmentAtxId types.ATXID, vrfNonce, labelsPerUnit uint64, numUnits uint32) error {
+func (m *MocknipostValidator) VRFNonce(nodeId types.NodeID, commitmentAtxId *types.ATXID, vrfNonce, labelsPerUnit uint64, numUnits uint32) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "VRFNonce", nodeId, commitmentAtxId, vrfNonce, labelsPerUnit, numUnits)
 	ret0, _ := ret[0].(error)
@@ -656,19 +656,19 @@ func (c *MocknipostValidatorVRFNonceCall) Return(arg0 error) *MocknipostValidato
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MocknipostValidatorVRFNonceCall) Do(f func(types.NodeID, types.ATXID, uint64, uint64, uint32) error) *MocknipostValidatorVRFNonceCall {
+func (c *MocknipostValidatorVRFNonceCall) Do(f func(types.NodeID, *types.ATXID, uint64, uint64, uint32) error) *MocknipostValidatorVRFNonceCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MocknipostValidatorVRFNonceCall) DoAndReturn(f func(types.NodeID, types.ATXID, uint64, uint64, uint32) error) *MocknipostValidatorVRFNonceCall {
+func (c *MocknipostValidatorVRFNonceCall) DoAndReturn(f func(types.NodeID, *types.ATXID, uint64, uint64, uint32) error) *MocknipostValidatorVRFNonceCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // VRFNonceV2 mocks base method.
-func (m *MocknipostValidator) VRFNonceV2(smesherID types.NodeID, commitment types.ATXID, vrfNonce uint64, numUnits uint32) error {
+func (m *MocknipostValidator) VRFNonceV2(smesherID types.NodeID, commitment *types.ATXID, vrfNonce uint64, numUnits uint32) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "VRFNonceV2", smesherID, commitment, vrfNonce, numUnits)
 	ret0, _ := ret[0].(error)
@@ -694,19 +694,19 @@ func (c *MocknipostValidatorVRFNonceV2Call) Return(arg0 error) *MocknipostValida
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MocknipostValidatorVRFNonceV2Call) Do(f func(types.NodeID, types.ATXID, uint64, uint32) error) *MocknipostValidatorVRFNonceV2Call {
+func (c *MocknipostValidatorVRFNonceV2Call) Do(f func(types.NodeID, *types.ATXID, uint64, uint32) error) *MocknipostValidatorVRFNonceV2Call {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MocknipostValidatorVRFNonceV2Call) DoAndReturn(f func(types.NodeID, types.ATXID, uint64, uint32) error) *MocknipostValidatorVRFNonceV2Call {
+func (c *MocknipostValidatorVRFNonceV2Call) DoAndReturn(f func(types.NodeID, *types.ATXID, uint64, uint32) error) *MocknipostValidatorVRFNonceV2Call {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // VerifyChain mocks base method.
-func (m *MocknipostValidator) VerifyChain(ctx context.Context, id, goldenATXID types.ATXID, opts ...VerifyChainOption) error {
+func (m *MocknipostValidator) VerifyChain(ctx context.Context, id, goldenATXID *types.ATXID, opts ...VerifyChainOption) error {
 	m.ctrl.T.Helper()
 	varargs := []any{ctx, id, goldenATXID}
 	for _, a := range opts {
@@ -737,13 +737,13 @@ func (c *MocknipostValidatorVerifyChainCall) Return(arg0 error) *MocknipostValid
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MocknipostValidatorVerifyChainCall) Do(f func(context.Context, types.ATXID, types.ATXID, ...VerifyChainOption) error) *MocknipostValidatorVerifyChainCall {
+func (c *MocknipostValidatorVerifyChainCall) Do(f func(context.Context, *types.ATXID, *types.ATXID, ...VerifyChainOption) error) *MocknipostValidatorVerifyChainCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MocknipostValidatorVerifyChainCall) DoAndReturn(f func(context.Context, types.ATXID, types.ATXID, ...VerifyChainOption) error) *MocknipostValidatorVerifyChainCall {
+func (c *MocknipostValidatorVerifyChainCall) DoAndReturn(f func(context.Context, *types.ATXID, *types.ATXID, ...VerifyChainOption) error) *MocknipostValidatorVerifyChainCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1110,7 +1110,7 @@ func (m *MockatxProvider) EXPECT() *MockatxProviderMockRecorder {
 }
 
 // GetAtx mocks base method.
-func (m *MockatxProvider) GetAtx(id types.ATXID) (*types.ActivationTx, error) {
+func (m *MockatxProvider) GetAtx(id *types.ATXID) (*types.ActivationTx, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAtx", id)
 	ret0, _ := ret[0].(*types.ActivationTx)
@@ -1137,13 +1137,13 @@ func (c *MockatxProviderGetAtxCall) Return(arg0 *types.ActivationTx, arg1 error)
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockatxProviderGetAtxCall) Do(f func(types.ATXID) (*types.ActivationTx, error)) *MockatxProviderGetAtxCall {
+func (c *MockatxProviderGetAtxCall) Do(f func(*types.ATXID) (*types.ActivationTx, error)) *MockatxProviderGetAtxCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockatxProviderGetAtxCall) DoAndReturn(f func(types.ATXID) (*types.ActivationTx, error)) *MockatxProviderGetAtxCall {
+func (c *MockatxProviderGetAtxCall) DoAndReturn(f func(*types.ATXID) (*types.ActivationTx, error)) *MockatxProviderGetAtxCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/activation/nipost.go
+++ b/activation/nipost.go
@@ -161,7 +161,7 @@ func (nb *NIPostBuilder) Proof(
 			}
 			if err := nb.validator.PostV2(ctx,
 				nodeID,
-				info.CommitmentATX,
+				&info.CommitmentATX,
 				postChallenge.InitialPost,
 				postshared.ZeroChallenge,
 				info.NumUnits,

--- a/activation/post_test.go
+++ b/activation/post_test.go
@@ -324,7 +324,7 @@ func TestPostSetupManager_getCommitmentAtx_getsCommitmentAtxFromInitialAtx(t *te
 	// add an atx by the same node
 	commitmentAtx := types.RandomATXID()
 	atx := types.NewActivationTx(types.NIPostChallenge{}, types.Address{}, 1)
-	atx.CommitmentATX = &commitmentAtx
+	atx.CommitmentATX = commitmentAtx
 	atx.SmesherID = signer.NodeID()
 	atx.SetID(types.RandomATXID())
 	atx.SetReceived(time.Now())
@@ -366,7 +366,7 @@ func newTestPostManager(tb testing.TB) *testPostManager {
 
 	logger := zaptest.NewLogger(tb)
 	cdb := datastore.NewCachedDB(sql.InMemory(), logger)
-	mgr, err := NewPostSetupManager(DefaultPostConfig(), logger, cdb, atxsdata.New(), goldenATXID, syncer, validator)
+	mgr, err := NewPostSetupManager(DefaultPostConfig(), logger, cdb, atxsdata.New(), &goldenATXID, syncer, validator)
 	require.NoError(tb, err)
 
 	return &testPostManager{

--- a/activation/validation.go
+++ b/activation/validation.go
@@ -281,7 +281,7 @@ func (v *Validator) InitialNIPostChallengeV1(
 		return errors.New("nil commitment atx in initial post challenge")
 	}
 	commitmentATXId := challenge.CommitmentATXID
-	if commitmentATXId != goldenATXID {
+	if !commitmentATXId.Equal(goldenATXID) {
 		commitmentAtx, err := atxs.GetAtx(commitmentATXId)
 		if err != nil {
 			return &ErrAtxNotFound{Id: *commitmentATXId, source: err}

--- a/activation/validation.go
+++ b/activation/validation.go
@@ -329,10 +329,10 @@ func (v *Validator) PositioningAtx(
 	goldenATXID *types.ATXID,
 	pubepoch types.EpochID,
 ) error {
-	if id == types.EmptyATXID {
+	if id.Empty() {
 		return errors.New("positioning atx id is empty")
 	}
-	if id == goldenATXID {
+	if id.Equal(goldenATXID) {
 		return nil
 	}
 	posAtx, err := atxs.GetAtx(id)

--- a/activation/validation_test.go
+++ b/activation/validation_test.go
@@ -66,7 +66,7 @@ func Test_Validation_VRFNonce(t *testing.T) {
 	t.Run("wrong commitmentAtxId", func(t *testing.T) {
 		t.Parallel()
 
-		commitmentAtxId := types.ATXID{1, 2, 3}
+		commitmentAtxId := &types.ATXID{1, 2, 3}
 		require.Error(t, v.VRFNonce(nodeId, commitmentAtxId, nonce, postCfg.LabelsPerUnit, initOpts.NumUnits))
 	})
 
@@ -105,7 +105,7 @@ func Test_Validation_InitialNIPostChallenge(t *testing.T) {
 
 		challenge := wire.NIPostChallengeV1{
 			Sequence:         0,
-			PrevATXID:        types.EmptyATXID,
+			PrevATXID:        *types.EmptyATXID,
 			PublishEpoch:     2,
 			PositioningATXID: posAtxId,
 			CommitmentATXID:  &commitmentAtxId,
@@ -113,9 +113,9 @@ func Test_Validation_InitialNIPostChallenge(t *testing.T) {
 		}
 
 		atxProvider := NewMockatxProvider(ctrl)
-		atxProvider.EXPECT().GetAtx(commitmentAtxId).Return(&types.ActivationTx{PublishEpoch: 1}, nil)
+		atxProvider.EXPECT().GetAtx(&commitmentAtxId).Return(&types.ActivationTx{PublishEpoch: 1}, nil)
 
-		err := v.InitialNIPostChallengeV1(&challenge, atxProvider, goldenATXID)
+		err := v.InitialNIPostChallengeV1(&challenge, atxProvider, &goldenATXID)
 		require.NoError(t, err)
 	})
 
@@ -124,16 +124,16 @@ func Test_Validation_InitialNIPostChallenge(t *testing.T) {
 
 		challenge := wire.NIPostChallengeV1{
 			Sequence:         0,
-			PrevATXID:        types.EmptyATXID,
+			PrevATXID:        *types.EmptyATXID,
 			PublishEpoch:     0,
-			PositioningATXID: types.RandomATXID(),
+			PositioningATXID: *types.RandomATXID(),
 			CommitmentATXID:  &goldenATXID,
 			InitialPost:      &wire.PostV1{},
 		}
 
 		atxProvider := NewMockatxProvider(ctrl)
 
-		err := v.InitialNIPostChallengeV1(&challenge, atxProvider, goldenATXID)
+		err := v.InitialNIPostChallengeV1(&challenge, atxProvider, &goldenATXID)
 		require.NoError(t, err)
 	})
 
@@ -143,22 +143,21 @@ func Test_Validation_InitialNIPostChallenge(t *testing.T) {
 		commitmentAtxId := types.ATXID{5, 6, 7}
 		challenge := wire.NIPostChallengeV1{
 			Sequence:         0,
-			PrevATXID:        types.EmptyATXID,
+			PrevATXID:        *types.EmptyATXID,
 			PublishEpoch:     1,
 			PositioningATXID: types.ATXID{1, 2, 3},
 			CommitmentATXID:  &commitmentAtxId,
 			InitialPost:      &wire.PostV1{},
 		}
 		atxProvider := NewMockatxProvider(ctrl)
-		atxProvider.EXPECT().GetAtx(commitmentAtxId).Return(&types.ActivationTx{PublishEpoch: 2}, nil)
+		atxProvider.EXPECT().GetAtx(&commitmentAtxId).Return(&types.ActivationTx{PublishEpoch: 2}, nil)
 
-		err := v.InitialNIPostChallengeV1(&challenge, atxProvider, goldenATXID)
+		err := v.InitialNIPostChallengeV1(&challenge, atxProvider, &goldenATXID)
 		require.EqualError(t, err, "challenge pubepoch (1) must be after commitment atx pubepoch (2)")
 	})
 }
 
 func Test_Validation_NIPostChallenge(t *testing.T) {
-	// Arrange
 	layers := types.GetLayersPerEpoch()
 	types.SetLayersPerEpoch(layersPerEpochBig)
 	t.Cleanup(func() { types.SetLayersPerEpoch(layers) })
@@ -183,9 +182,9 @@ func Test_Validation_NIPostChallenge(t *testing.T) {
 
 		challenge := wire.NIPostChallengeV1{
 			Sequence:         prevAtx.Sequence + 1,
-			PrevATXID:        prevAtx.ID(),
+			PrevATXID:        *prevAtx.ID(),
 			PublishEpoch:     prevAtx.PublishEpoch + 1,
-			PositioningATXID: goldenAtxID,
+			PositioningATXID: *goldenAtxID,
 		}
 
 		err := v.NIPostChallengeV1(&challenge, wire.ActivationTxFromWireV1(prevAtx), sig.NodeID())
@@ -202,9 +201,9 @@ func Test_Validation_NIPostChallenge(t *testing.T) {
 
 		challenge := wire.NIPostChallengeV1{
 			Sequence:         prevAtx.Sequence + 1,
-			PrevATXID:        prevAtx.ID(),
+			PrevATXID:        *prevAtx.ID(),
 			PublishEpoch:     prevAtx.PublishEpoch + 1,
-			PositioningATXID: goldenAtxID,
+			PositioningATXID: *goldenAtxID,
 		}
 
 		err = v.NIPostChallengeV1(&challenge, wire.ActivationTxFromWireV1(prevAtx), sig.NodeID())
@@ -219,9 +218,9 @@ func Test_Validation_NIPostChallenge(t *testing.T) {
 
 		challenge := wire.NIPostChallengeV1{
 			Sequence:         prevAtx.Sequence + 1,
-			PrevATXID:        prevAtx.ID(),
+			PrevATXID:        *prevAtx.ID(),
 			PublishEpoch:     prevAtx.PublishEpoch,
-			PositioningATXID: goldenAtxID,
+			PositioningATXID: *goldenAtxID,
 		}
 
 		err := v.NIPostChallengeV1(&challenge, wire.ActivationTxFromWireV1(prevAtx), sig.NodeID())
@@ -238,9 +237,9 @@ func Test_Validation_NIPostChallenge(t *testing.T) {
 
 		challenge := wire.NIPostChallengeV1{
 			Sequence:         prevAtx.Sequence,
-			PrevATXID:        prevAtx.ID(),
+			PrevATXID:        *prevAtx.ID(),
 			PublishEpoch:     prevAtx.PublishEpoch + 1,
-			PositioningATXID: goldenAtxID,
+			PositioningATXID: *goldenAtxID,
 		}
 
 		err := v.NIPostChallengeV1(&challenge, wire.ActivationTxFromWireV1(prevAtx), sig.NodeID())
@@ -295,9 +294,9 @@ func Test_Validation_PositioningAtx(t *testing.T) {
 		goldenAtxId := types.ATXID{9, 9, 9}
 
 		atxProvider := NewMockatxProvider(ctrl)
-		atxProvider.EXPECT().GetAtx(posAtxId).Return(&types.ActivationTx{PublishEpoch: 1}, nil)
+		atxProvider.EXPECT().GetAtx(&posAtxId).Return(&types.ActivationTx{PublishEpoch: 1}, nil)
 
-		err := v.PositioningAtx(posAtxId, atxProvider, goldenAtxId, 2)
+		err := v.PositioningAtx(&posAtxId, atxProvider, &goldenAtxId, 2)
 		require.NoError(t, err)
 	})
 
@@ -308,7 +307,7 @@ func Test_Validation_PositioningAtx(t *testing.T) {
 
 		atxProvider := NewMockatxProvider(ctrl)
 
-		err := v.PositioningAtx(goldenAtxId, atxProvider, goldenAtxId, types.LayerID(1012).GetEpoch())
+		err := v.PositioningAtx(&goldenAtxId, atxProvider, &goldenAtxId, types.LayerID(1012).GetEpoch())
 		require.NoError(t, err)
 	})
 
@@ -319,7 +318,7 @@ func Test_Validation_PositioningAtx(t *testing.T) {
 
 		atxProvider := NewMockatxProvider(ctrl)
 
-		err := v.PositioningAtx(goldenAtxId, atxProvider, goldenAtxId, 5)
+		err := v.PositioningAtx(&goldenAtxId, atxProvider, &goldenAtxId, 5)
 		require.NoError(t, err)
 	})
 
@@ -330,9 +329,9 @@ func Test_Validation_PositioningAtx(t *testing.T) {
 		goldenAtxId := types.ATXID{9, 9, 9}
 
 		atxProvider := NewMockatxProvider(ctrl)
-		atxProvider.EXPECT().GetAtx(posAtxId).Return(nil, errors.New("db error"))
+		atxProvider.EXPECT().GetAtx(&posAtxId).Return(nil, errors.New("db error"))
 
-		err := v.PositioningAtx(posAtxId, atxProvider, goldenAtxId, types.LayerID(1012).GetEpoch())
+		err := v.PositioningAtx(&posAtxId, atxProvider, &goldenAtxId, types.LayerID(1012).GetEpoch())
 		require.ErrorIs(t, err, &ErrAtxNotFound{Id: posAtxId})
 		require.ErrorContains(t, err, "db error")
 	})
@@ -344,9 +343,9 @@ func Test_Validation_PositioningAtx(t *testing.T) {
 		goldenAtxId := types.ATXID{9, 9, 9}
 
 		atxProvider := NewMockatxProvider(ctrl)
-		atxProvider.EXPECT().GetAtx(posAtxId).Return(&types.ActivationTx{PublishEpoch: 5}, nil)
+		atxProvider.EXPECT().GetAtx(&posAtxId).Return(&types.ActivationTx{PublishEpoch: 5}, nil)
 
-		err := v.PositioningAtx(posAtxId, atxProvider, goldenAtxId, 3)
+		err := v.PositioningAtx(&posAtxId, atxProvider, &goldenAtxId, 3)
 		require.EqualError(t, err, "positioning atx epoch (5) must be before 3")
 	})
 
@@ -357,9 +356,9 @@ func Test_Validation_PositioningAtx(t *testing.T) {
 		goldenAtxId := types.ATXID{9, 9, 9}
 
 		atxProvider := NewMockatxProvider(ctrl)
-		atxProvider.EXPECT().GetAtx(posAtxId).Return(&types.ActivationTx{PublishEpoch: 1}, nil)
+		atxProvider.EXPECT().GetAtx(&posAtxId).Return(&types.ActivationTx{PublishEpoch: 1}, nil)
 
-		err := v.PositioningAtx(posAtxId, atxProvider, goldenAtxId, 10)
+		err := v.PositioningAtx(&posAtxId, atxProvider, &goldenAtxId, 10)
 		require.NoError(t, err)
 	})
 }
@@ -483,7 +482,7 @@ func TestVerifyChainDeps(t *testing.T) {
 	signer, err := signing.NewEdSigner()
 	require.NoError(t, err)
 
-	invalidAtx := newInitialATXv1(t, goldenATXID)
+	invalidAtx := newInitialATXv1(t, &goldenATXID)
 	invalidAtx.Sign(signer)
 	vInvalidAtx := toAtx(t, invalidAtx)
 	vInvalidAtx.SetValidity(types.Invalid)
@@ -500,8 +499,8 @@ func TestVerifyChainDeps(t *testing.T) {
 		v.EXPECT().Verify(ctx, gomock.Any(), gomock.Any(), gomock.Any())
 
 		validator := NewValidator(db, nil, DefaultPostConfig(), config.ScryptParams{}, v)
-		err = validator.VerifyChain(ctx, vAtx.ID(), goldenATXID)
-		require.ErrorIs(t, err, &InvalidChainError{ID: invalidAtx.ID()})
+		err = validator.VerifyChain(ctx, vAtx.ID(), &goldenATXID)
+		require.ErrorIs(t, err, &InvalidChainError{ID: *invalidAtx.ID()})
 	})
 
 	t.Run("invalid pos ATX", func(t *testing.T) {
@@ -515,15 +514,15 @@ func TestVerifyChainDeps(t *testing.T) {
 		v.EXPECT().Verify(ctx, (*shared.Proof)(atx.NIPost.Post), gomock.Any(), gomock.Any())
 
 		validator := NewValidator(db, nil, DefaultPostConfig(), config.ScryptParams{}, v)
-		err = validator.VerifyChain(ctx, vAtx.ID(), goldenATXID)
-		require.ErrorIs(t, err, &InvalidChainError{ID: invalidAtx.ID()})
+		err = validator.VerifyChain(ctx, vAtx.ID(), &goldenATXID)
+		require.ErrorIs(t, err, &InvalidChainError{ID: *invalidAtx.ID()})
 	})
 
 	t.Run("invalid commitment ATX", func(t *testing.T) {
 		commitmentAtxID := vInvalidAtx.ID()
-		atx := newInitialATXv1(t, goldenATXID)
+		atx := newInitialATXv1(t, &goldenATXID)
 		atx.Sign(signer)
-		atx.CommitmentATXID = &commitmentAtxID
+		atx.CommitmentATXID = commitmentAtxID
 		vAtx := toAtx(t, atx)
 		require.NoError(t, atxs.Add(db, vAtx))
 
@@ -531,8 +530,8 @@ func TestVerifyChainDeps(t *testing.T) {
 		v := NewMockPostVerifier(ctrl)
 		v.EXPECT().Verify(ctx, (*shared.Proof)(atx.NIPost.Post), gomock.Any(), gomock.Any())
 		validator := NewValidator(db, nil, DefaultPostConfig(), config.ScryptParams{}, v)
-		err = validator.VerifyChain(ctx, vAtx.ID(), goldenATXID)
-		require.ErrorIs(t, err, &InvalidChainError{ID: invalidAtx.ID()})
+		err = validator.VerifyChain(ctx, vAtx.ID(), &goldenATXID)
+		require.ErrorIs(t, err, &InvalidChainError{ID: *invalidAtx.ID()})
 	})
 
 	t.Run("with trusted node ID", func(t *testing.T) {
@@ -544,7 +543,7 @@ func TestVerifyChainDeps(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		v := NewMockPostVerifier(ctrl)
 		validator := NewValidator(db, nil, DefaultPostConfig(), config.ScryptParams{}, v)
-		err = validator.VerifyChain(ctx, vAtx.ID(), goldenATXID, VerifyChainOpts.WithTrustedID(signer.NodeID()))
+		err = validator.VerifyChain(ctx, vAtx.ID(), &goldenATXID, VerifyChainOpts.WithTrustedID(signer.NodeID()))
 		require.NoError(t, err)
 	})
 
@@ -558,12 +557,12 @@ func TestVerifyChainDeps(t *testing.T) {
 		v := NewMockPostVerifier(ctrl)
 		validator := NewValidator(db, nil, DefaultPostConfig(), config.ScryptParams{}, v)
 		before := time.Now().Add(10 * time.Second)
-		err = validator.VerifyChain(ctx, vAtx.ID(), goldenATXID, VerifyChainOpts.AssumeValidBefore(before))
+		err = validator.VerifyChain(ctx, vAtx.ID(), &goldenATXID, VerifyChainOpts.AssumeValidBefore(before))
 		require.NoError(t, err)
 	})
 
 	t.Run("invalid top-level", func(t *testing.T) {
-		atx := newInitialATXv1(t, goldenATXID)
+		atx := newInitialATXv1(t, &goldenATXID)
 		atx.Sign(signer)
 		vAtx := toAtx(t, atx)
 		require.NoError(t, atxs.Add(db, vAtx))
@@ -573,13 +572,13 @@ func TestVerifyChainDeps(t *testing.T) {
 		expected := errors.New("post is invalid")
 		v.EXPECT().Verify(ctx, (*shared.Proof)(atx.NIPost.Post), gomock.Any(), gomock.Any()).Return(expected)
 		validator := NewValidator(db, nil, DefaultPostConfig(), config.ScryptParams{}, v)
-		err = validator.VerifyChain(ctx, vAtx.ID(), goldenATXID)
-		require.ErrorIs(t, err, &InvalidChainError{ID: vAtx.ID()})
+		err = validator.VerifyChain(ctx, vAtx.ID(), &goldenATXID)
+		require.ErrorIs(t, err, &InvalidChainError{ID: *vAtx.ID()})
 		require.ErrorIs(t, err, expected)
 	})
 
 	t.Run("initial V2 ATX", func(t *testing.T) {
-		watx := newInitialATXv2(t, goldenATXID)
+		watx := newInitialATXv2(t, &goldenATXID)
 		watx.Sign(signer)
 		atx := &types.ActivationTx{
 			PublishEpoch: watx.PublishEpoch,
@@ -596,11 +595,11 @@ func TestVerifyChainDeps(t *testing.T) {
 		expectedPost := (*shared.Proof)(wire.PostFromWireV1(&watx.NiPosts[0].Posts[0].Post))
 		v.EXPECT().Verify(ctx, expectedPost, gomock.Any(), gomock.Any())
 		validator := NewValidator(db, nil, DefaultPostConfig(), config.ScryptParams{}, v)
-		err = validator.VerifyChain(ctx, watx.ID(), goldenATXID)
+		err = validator.VerifyChain(ctx, watx.ID(), &goldenATXID)
 		require.NoError(t, err)
 	})
 	t.Run("non-initial V2 ATX", func(t *testing.T) {
-		initialAtx := newInitialATXv1(t, goldenATXID)
+		initialAtx := newInitialATXv1(t, &goldenATXID)
 		initialAtx.Sign(signer)
 		require.NoError(t, atxs.Add(db, toAtx(t, initialAtx)))
 
@@ -622,7 +621,7 @@ func TestVerifyChainDeps(t *testing.T) {
 		v.EXPECT().Verify(ctx, (*shared.Proof)(initialAtx.NIPost.Post), gomock.Any(), gomock.Any())
 		v.EXPECT().Verify(ctx, expectedPost, gomock.Any(), gomock.Any())
 		validator := NewValidator(db, nil, DefaultPostConfig(), config.ScryptParams{}, v)
-		err = validator.VerifyChain(ctx, watx.ID(), goldenATXID)
+		err = validator.VerifyChain(ctx, watx.ID(), &goldenATXID)
 		require.NoError(t, err)
 	})
 }
@@ -635,13 +634,13 @@ func TestVerifyChainDepsAfterCheckpoint(t *testing.T) {
 	require.NoError(t, err)
 
 	// The previous and positioning ATXs of the verified ATX will be a checkpointed (golden) ATX.
-	checkpointedAtx := newInitialATXv1(t, goldenATXID)
+	checkpointedAtx := newInitialATXv1(t, &goldenATXID)
 	checkpointedAtx.Sign(signer)
 	vCheckpointedAtx := toAtx(t, checkpointedAtx)
 	require.NoError(t, atxs.AddCheckpointed(db, &atxs.CheckpointAtx{
 		ID:             vCheckpointedAtx.ID(),
 		Epoch:          vCheckpointedAtx.PublishEpoch,
-		CommitmentATX:  *vCheckpointedAtx.CommitmentATX,
+		CommitmentATX:  vCheckpointedAtx.CommitmentATX,
 		VRFNonce:       vCheckpointedAtx.VRFNonce,
 		NumUnits:       vCheckpointedAtx.NumUnits,
 		BaseTickHeight: vCheckpointedAtx.BaseTickHeight,
@@ -651,7 +650,7 @@ func TestVerifyChainDepsAfterCheckpoint(t *testing.T) {
 		Coinbase:       vCheckpointedAtx.Coinbase,
 	}))
 
-	atx := newChainedActivationTxV1(t, checkpointedAtx, checkpointedAtx.ID())
+	atx := newChainedActivationTxV1(t, checkpointedAtx, *checkpointedAtx.ID())
 	atx.Sign(signer)
 	vAtx := toAtx(t, atx)
 	require.NoError(t, atxs.Add(db, vAtx))
@@ -661,7 +660,7 @@ func TestVerifyChainDepsAfterCheckpoint(t *testing.T) {
 	v.EXPECT().Verify(ctx, gomock.Any(), gomock.Any(), gomock.Any())
 
 	validator := NewValidator(db, nil, DefaultPostConfig(), config.ScryptParams{}, v)
-	err = validator.VerifyChain(ctx, vAtx.ID(), goldenATXID)
+	err = validator.VerifyChain(ctx, vAtx.ID(), &goldenATXID)
 	require.NoError(t, err)
 }
 

--- a/activation/verify_state_test.go
+++ b/activation/verify_state_test.go
@@ -29,7 +29,7 @@ func Test_CheckPrevATXs(t *testing.T) {
 	goldenATXID := types.RandomATXID()
 
 	atx1 := newInitialATXv1(t, goldenATXID, func(atx *wire.ActivationTxV1) {
-		atx.PrevATXID = prevATXID
+		atx.PrevATXID = *prevATXID
 		atx.PublishEpoch = 2
 	})
 	atx1.Sign(sig)
@@ -37,7 +37,7 @@ func Test_CheckPrevATXs(t *testing.T) {
 	require.NoError(t, atxs.Add(db, vAtx1))
 
 	atx2 := newInitialATXv1(t, goldenATXID, func(atx *wire.ActivationTxV1) {
-		atx.PrevATXID = prevATXID
+		atx.PrevATXID = *prevATXID
 		atx.PublishEpoch = 3
 	})
 	atx2.Sign(sig)
@@ -49,7 +49,7 @@ func Test_CheckPrevATXs(t *testing.T) {
 		otherSig, err := signing.NewEdSigner()
 		require.NoError(t, err)
 		atx := newInitialATXv1(t, types.RandomATXID(), func(atx *wire.ActivationTxV1) {
-			atx.PrevATXID = types.RandomATXID()
+			atx.PrevATXID = *types.RandomATXID()
 			atx.NumUnits = rand.Uint32()
 			atx.PublishEpoch = rand.N[types.EpochID](100)
 		})

--- a/activation/wire/wire_v1.go
+++ b/activation/wire/wire_v1.go
@@ -21,7 +21,7 @@ type ActivationTxV1 struct {
 	SmesherID types.NodeID
 	Signature types.EdSignature
 
-	id types.ATXID
+	id *types.ATXID
 }
 
 // InnerActivationTxV1 is a set of all of an ATX's fields, except the signature. To generate the ATX signature, this
@@ -95,14 +95,14 @@ type ATXMetadataV1 struct {
 	MsgHash types.Hash32
 }
 
-func (atx *ActivationTxV1) ID() types.ATXID {
-	if atx.id == types.EmptyATXID {
-		atx.id = types.ATXID(atx.HashInnerBytes())
+func (atx *ActivationTxV1) ID() *types.ATXID {
+	if atx.id == nil {
+		atx.id = types.AtxIdFromHash32(atx.HashInnerBytes())
 	}
 	return atx.id
 }
 
-func (atx *ActivationTxV1) SetID(id types.ATXID) {
+func (atx *ActivationTxV1) SetID(id *types.ATXID) {
 	atx.id = id
 }
 
@@ -115,7 +115,7 @@ func (atx *ActivationTxV1) TotalNumUnits() uint32 {
 }
 
 func (atx *ActivationTxV1) Sign(signer *signing.EdSigner) {
-	if atx.PrevATXID == types.EmptyATXID {
+	if atx.PrevATXID == *types.EmptyATXID {
 		nodeID := signer.NodeID()
 		atx.NodeID = &nodeID
 	}

--- a/activation/wire/wire_v1_test.go
+++ b/activation/wire/wire_v1_test.go
@@ -31,6 +31,6 @@ func Test_NoATXv1IDCollisions(t *testing.T) {
 		f.Fuzz(atx)
 		id := atx.ID()
 		require.NotContains(t, atxIDs, id, "ATX ID collision")
-		atxIDs = append(atxIDs, id)
+		atxIDs = append(atxIDs, *id)
 	}
 }

--- a/activation/wire/wire_v2.go
+++ b/activation/wire/wire_v2.go
@@ -42,7 +42,7 @@ type ActivationTxV2 struct {
 	Signature types.EdSignature
 
 	// cached fields to avoid repeated calculations
-	id types.ATXID
+	id *types.ATXID
 }
 
 func (atx *ActivationTxV2) SignedBytes() []byte {
@@ -115,8 +115,8 @@ func (atx *ActivationTxV2) merkleTree(tree *merkle.Tree) {
 	}
 }
 
-func (atx *ActivationTxV2) ID() types.ATXID {
-	if atx.id != types.EmptyATXID {
+func (atx *ActivationTxV2) ID() *types.ATXID {
+	if atx.id != nil {
 		return atx.id
 	}
 
@@ -127,7 +127,8 @@ func (atx *ActivationTxV2) ID() types.ATXID {
 		panic(err)
 	}
 	atx.merkleTree(tree)
-	atx.id = types.ATXID(tree.Root())
+	id := types.ATXID(tree.Root())
+	atx.id = &id
 	return atx.id
 }
 

--- a/activation/wire/wire_v2_test.go
+++ b/activation/wire/wire_v2_test.go
@@ -32,7 +32,7 @@ func Benchmark_ATXv2ID_WorstScenario(b *testing.B) {
 		b.StopTimer()
 		atx := &ActivationTxV2{
 			PublishEpoch:   0,
-			PositioningATX: types.RandomATXID(),
+			PositioningATX: *types.RandomATXID(),
 			PreviousATXs:   make([]types.ATXID, 256),
 			NiPosts: []NiPostsV2{
 				{
@@ -82,7 +82,7 @@ func Test_NoATXv2IDCollisions(t *testing.T) {
 		f.Fuzz(atx)
 		id := atx.ID()
 		require.NotContains(t, atxIDs, id, "ATX ID collision")
-		atxIDs = append(atxIDs, id)
+		atxIDs = append(atxIDs, *id)
 	}
 }
 
@@ -91,7 +91,7 @@ const PublishEpochIndex = 0
 func Test_GenerateDoublePublishProof(t *testing.T) {
 	atx := &ActivationTxV2{
 		PublishEpoch:   10,
-		PositioningATX: types.RandomATXID(),
+		PositioningATX: *types.RandomATXID(),
 		PreviousATXs:   make([]types.ATXID, 1),
 		NiPosts: []NiPostsV2{
 			{

--- a/api/grpcserver/activation_service.go
+++ b/api/grpcserver/activation_service.go
@@ -54,7 +54,7 @@ func (s *activationService) Get(ctx context.Context, request *pb.GetRequest) (*p
 		)
 	}
 
-	atxId := types.ATXID(types.BytesToHash(request.Id))
+	atxId := types.AtxIdFromHash32(types.BytesToHash(request.Id))
 	atx, err := s.atxProvider.GetAtx(atxId)
 	if err != nil || atx == nil {
 		ctxzap.Debug(ctx, "failed to get ATX",

--- a/api/grpcserver/activation_service_test.go
+++ b/api/grpcserver/activation_service_test.go
@@ -45,7 +45,7 @@ func Test_Highest_ReturnsMaxTickHeight(t *testing.T) {
 
 	atx := types.ActivationTx{
 		Sequence:     rand.Uint64(),
-		PrevATXID:    types.RandomATXID(),
+		PrevATXID:    *types.RandomATXID(),
 		PublishEpoch: 0,
 		Coinbase:     types.GenerateAddress(types.RandomBytes(32)),
 		NumUnits:     rand.Uint32(),
@@ -110,7 +110,7 @@ func TestGet_HappyPath(t *testing.T) {
 	id := types.RandomATXID()
 	atx := types.ActivationTx{
 		Sequence:     rand.Uint64(),
-		PrevATXID:    types.RandomATXID(),
+		PrevATXID:    *types.RandomATXID(),
 		PublishEpoch: 0,
 		Coinbase:     types.GenerateAddress(types.RandomBytes(32)),
 		NumUnits:     rand.Uint32(),
@@ -141,7 +141,7 @@ func TestGet_IdentityCanceled(t *testing.T) {
 	id := types.RandomATXID()
 	atx := types.ActivationTx{
 		Sequence:     rand.Uint64(),
-		PrevATXID:    types.RandomATXID(),
+		PrevATXID:    *types.RandomATXID(),
 		PublishEpoch: 0,
 		Coinbase:     types.GenerateAddress(types.RandomBytes(32)),
 		NumUnits:     rand.Uint32(),

--- a/api/grpcserver/interface.go
+++ b/api/grpcserver/interface.go
@@ -55,8 +55,8 @@ type txValidator interface {
 
 // atxProvider is used by ActivationService to get ATXes.
 type atxProvider interface {
-	GetAtx(id types.ATXID) (*types.ActivationTx, error)
-	MaxHeightAtx() (types.ATXID, error)
+	GetAtx(id *types.ATXID) (*types.ActivationTx, error)
+	MaxHeightAtx() (*types.ATXID, error)
 	GetMalfeasanceProof(id types.NodeID) (*wire.MalfeasanceProof, error)
 }
 
@@ -109,5 +109,5 @@ type meshAPI interface {
 }
 
 type oracle interface {
-	ActiveSet(context.Context, types.EpochID) ([]types.ATXID, error)
+	ActiveSet(context.Context, types.EpochID) ([]*types.ATXID, error)
 }

--- a/api/grpcserver/mocks.go
+++ b/api/grpcserver/mocks.go
@@ -874,7 +874,7 @@ func (m *MockatxProvider) EXPECT() *MockatxProviderMockRecorder {
 }
 
 // GetAtx mocks base method.
-func (m *MockatxProvider) GetAtx(id types.ATXID) (*types.ActivationTx, error) {
+func (m *MockatxProvider) GetAtx(id *types.ATXID) (*types.ActivationTx, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAtx", id)
 	ret0, _ := ret[0].(*types.ActivationTx)
@@ -901,13 +901,13 @@ func (c *MockatxProviderGetAtxCall) Return(arg0 *types.ActivationTx, arg1 error)
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockatxProviderGetAtxCall) Do(f func(types.ATXID) (*types.ActivationTx, error)) *MockatxProviderGetAtxCall {
+func (c *MockatxProviderGetAtxCall) Do(f func(*types.ATXID) (*types.ActivationTx, error)) *MockatxProviderGetAtxCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockatxProviderGetAtxCall) DoAndReturn(f func(types.ATXID) (*types.ActivationTx, error)) *MockatxProviderGetAtxCall {
+func (c *MockatxProviderGetAtxCall) DoAndReturn(f func(*types.ATXID) (*types.ActivationTx, error)) *MockatxProviderGetAtxCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -952,10 +952,10 @@ func (c *MockatxProviderGetMalfeasanceProofCall) DoAndReturn(f func(types.NodeID
 }
 
 // MaxHeightAtx mocks base method.
-func (m *MockatxProvider) MaxHeightAtx() (types.ATXID, error) {
+func (m *MockatxProvider) MaxHeightAtx() (*types.ATXID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MaxHeightAtx")
-	ret0, _ := ret[0].(types.ATXID)
+	ret0, _ := ret[0].(*types.ATXID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -973,19 +973,19 @@ type MockatxProviderMaxHeightAtxCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockatxProviderMaxHeightAtxCall) Return(arg0 types.ATXID, arg1 error) *MockatxProviderMaxHeightAtxCall {
+func (c *MockatxProviderMaxHeightAtxCall) Return(arg0 *types.ATXID, arg1 error) *MockatxProviderMaxHeightAtxCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockatxProviderMaxHeightAtxCall) Do(f func() (types.ATXID, error)) *MockatxProviderMaxHeightAtxCall {
+func (c *MockatxProviderMaxHeightAtxCall) Do(f func() (*types.ATXID, error)) *MockatxProviderMaxHeightAtxCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockatxProviderMaxHeightAtxCall) DoAndReturn(f func() (types.ATXID, error)) *MockatxProviderMaxHeightAtxCall {
+func (c *MockatxProviderMaxHeightAtxCall) DoAndReturn(f func() (*types.ATXID, error)) *MockatxProviderMaxHeightAtxCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1978,10 +1978,10 @@ func (m *Mockoracle) EXPECT() *MockoracleMockRecorder {
 }
 
 // ActiveSet mocks base method.
-func (m *Mockoracle) ActiveSet(arg0 context.Context, arg1 types.EpochID) ([]types.ATXID, error) {
+func (m *Mockoracle) ActiveSet(arg0 context.Context, arg1 types.EpochID) ([]*types.ATXID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ActiveSet", arg0, arg1)
-	ret0, _ := ret[0].([]types.ATXID)
+	ret0, _ := ret[0].([]*types.ATXID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1999,19 +1999,19 @@ type MockoracleActiveSetCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockoracleActiveSetCall) Return(arg0 []types.ATXID, arg1 error) *MockoracleActiveSetCall {
+func (c *MockoracleActiveSetCall) Return(arg0 []*types.ATXID, arg1 error) *MockoracleActiveSetCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockoracleActiveSetCall) Do(f func(context.Context, types.EpochID) ([]types.ATXID, error)) *MockoracleActiveSetCall {
+func (c *MockoracleActiveSetCall) Do(f func(context.Context, types.EpochID) ([]*types.ATXID, error)) *MockoracleActiveSetCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockoracleActiveSetCall) DoAndReturn(f func(context.Context, types.EpochID) ([]types.ATXID, error)) *MockoracleActiveSetCall {
+func (c *MockoracleActiveSetCall) DoAndReturn(f func(context.Context, types.EpochID) ([]*types.ATXID, error)) *MockoracleActiveSetCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/api/grpcserver/v2alpha1/activation.go
+++ b/api/grpcserver/v2alpha1/activation.go
@@ -322,7 +322,7 @@ func (m *atxsMatcher) match(t *events.ActivationTx) bool {
 	}
 
 	if len(m.Id) > 0 {
-		var atxId types.ATXID
+		atxId := new(types.ATXID)
 		copy(atxId[:], m.Id)
 
 		if t.ID() != atxId {

--- a/atxsdata/data_test.go
+++ b/atxsdata/data_test.go
@@ -37,7 +37,7 @@ func TestData(t *testing.T) {
 						types.EpochID(epoch)+1,
 						d.Node,
 						d.Coinbase,
-						atxids[epoch][i],
+						&atxids[epoch][i],
 						d.Weight,
 						d.BaseHeight,
 						d.Height,
@@ -48,7 +48,7 @@ func TestData(t *testing.T) {
 			}
 			for epoch := 0; epoch < epochs; epoch++ {
 				for i := range atxids[epoch] {
-					byatxid := c.Get(types.EpochID(epoch)+1, atxids[epoch][i])
+					byatxid := c.Get(types.EpochID(epoch)+1, &atxids[epoch][i])
 					require.Equal(t, &data[epoch][i], byatxid)
 				}
 			}
@@ -62,20 +62,20 @@ func TestData(t *testing.T) {
 				types.EpochID(epoch),
 				node,
 				types.Address{},
-				types.ATXID{byte(epoch)},
+				&types.ATXID{byte(epoch)},
 				2,
 				0,
 				0,
 				0,
 				false,
 			)
-			data := c.Get(types.EpochID(epoch), types.ATXID{byte(epoch)})
+			data := c.Get(types.EpochID(epoch), &types.ATXID{byte(epoch)})
 			require.NotNil(t, data)
 			require.False(t, data.malicious)
 		}
 		c.SetMalicious(node)
 		for epoch := 1; epoch <= 10; epoch++ {
-			data := c.Get(types.EpochID(epoch), types.ATXID{byte(epoch)})
+			data := c.Get(types.EpochID(epoch), &types.ATXID{byte(epoch)})
 			require.True(t, data.malicious)
 		}
 		require.True(t, c.IsMalicious(node))
@@ -89,8 +89,8 @@ func TestData(t *testing.T) {
 		c := New()
 		node := types.NodeID{1}
 		for epoch := 1; epoch <= epochs; epoch++ {
-			c.Add(types.EpochID(epoch), node, types.Address{}, types.ATXID{}, 2, 0, 0, 0, false)
-			data := c.Get(types.EpochID(epoch), types.ATXID{})
+			c.Add(types.EpochID(epoch), node, types.Address{}, &types.ATXID{}, 2, 0, 0, 0, false)
+			data := c.Get(types.EpochID(epoch), &types.ATXID{})
 			require.NotNil(t, data)
 		}
 
@@ -103,23 +103,23 @@ func TestData(t *testing.T) {
 	})
 	t.Run("nil responses", func(t *testing.T) {
 		c := New()
-		require.Nil(t, c.Get(0, types.ATXID{}))
-		require.Nil(t, c.Get(1, types.ATXID{}))
+		require.Nil(t, c.Get(0, &types.ATXID{}))
+		require.Nil(t, c.Get(1, &types.ATXID{}))
 
-		c.Add(1, types.NodeID{1}, types.Address{}, types.ATXID{1}, 2, 0, 0, 0, false)
-		require.Nil(t, c.Get(1, types.ATXID{}))
+		c.Add(1, types.NodeID{1}, types.Address{}, &types.ATXID{1}, 2, 0, 0, 0, false)
+		require.Nil(t, c.Get(1, &types.ATXID{}))
 	})
 	t.Run("multiple atxs", func(t *testing.T) {
 		c := New()
-		c.Add(1, types.NodeID{1}, types.Address{}, types.ATXID{1}, 1, 0, 0, 0, false)
-		c.Add(1, types.NodeID{1}, types.Address{}, types.ATXID{2}, 2, 0, 0, 0, false)
-		require.NotNil(t, c.Get(1, types.ATXID{1}))
-		require.NotNil(t, c.Get(1, types.ATXID{2}))
+		c.Add(1, types.NodeID{1}, types.Address{}, &types.ATXID{1}, 1, 0, 0, 0, false)
+		c.Add(1, types.NodeID{1}, types.Address{}, &types.ATXID{2}, 2, 0, 0, 0, false)
+		require.NotNil(t, c.Get(1, &types.ATXID{1}))
+		require.NotNil(t, c.Get(1, &types.ATXID{2}))
 	})
 	t.Run("weight for set", func(t *testing.T) {
 		c := New()
-		c.Add(1, types.NodeID{1}, types.Address{}, types.ATXID{1}, 1, 0, 0, 0, false)
-		c.Add(1, types.NodeID{1}, types.Address{}, types.ATXID{2}, 2, 0, 0, 0, false)
+		c.Add(1, types.NodeID{1}, types.Address{}, &types.ATXID{1}, 1, 0, 0, 0, false)
+		c.Add(1, types.NodeID{1}, types.Address{}, &types.ATXID{2}, 2, 0, 0, 0, false)
 
 		weight, used := c.WeightForSet(1, []types.ATXID{{1}, {2}, {3}})
 		require.Equal(t, []bool{true, true, false}, used)
@@ -133,8 +133,8 @@ func TestData(t *testing.T) {
 		c := New()
 		c.EvictEpoch(0)
 		c.EvictEpoch(3)
-		c.Add(1, types.NodeID{1}, types.Address{}, types.ATXID{1}, 500, 100, 0, 0, false)
-		require.Nil(t, c.Get(3, types.ATXID{1}))
+		c.Add(1, types.NodeID{1}, types.Address{}, &types.ATXID{1}, 500, 100, 0, 0, false)
+		require.Nil(t, c.Get(3, &types.ATXID{1}))
 		c.EvictEpoch(3)
 	})
 }
@@ -155,7 +155,7 @@ func TestMemory(t *testing.T) {
 			)
 			binary.PutUvarint(node[:], uint64(i+1))
 			binary.PutUvarint(atx[:], uint64(i+1))
-			c.Add(1, node, types.Address{}, atx, 500, 100, 0, 0, false)
+			c.Add(1, node, types.Address{}, &atx, 500, 100, 0, 0, false)
 		}
 		runtime.GC()
 		var after runtime.MemStats
@@ -185,7 +185,7 @@ func BenchmarkConcurrentReadWrite(b *testing.B) {
 		)
 		binary.PutUvarint(node[:], uint64(i+1))
 		binary.PutUvarint(atx[:], uint64(i+1))
-		c.Add(epoch, node, types.Address{}, atx, 500, 100, 0, 0, false)
+		c.Add(epoch, node, types.Address{}, &atx, 500, 100, 0, 0, false)
 	}
 	b.ResetTimer()
 
@@ -202,11 +202,11 @@ func BenchmarkConcurrentReadWrite(b *testing.B) {
 			if i%writeFraction == 0 {
 				binary.PutUvarint(node[:], size+i*core)
 				binary.PutUvarint(atx[:], size+i*core)
-				c.Add(epoch, node, types.Address{}, atx, 500, 100, 0, 0, false)
+				c.Add(epoch, node, types.Address{}, &atx, 500, 100, 0, 0, false)
 			} else {
 				binary.PutUvarint(node[:], i%size)
 				binary.PutUvarint(atx[:], i%size)
-				_ = c.Get(epoch, atx)
+				_ = c.Get(epoch, &atx)
 			}
 			i++
 		}
@@ -226,7 +226,7 @@ func benchmarkkWeightForSet(b *testing.B, size, setSize int) {
 		binary.PutUvarint(node[:], uint64(i+1))
 		binary.PutUvarint(atx[:], uint64(i+1))
 		atxs = append(atxs, atx)
-		c.Add(epoch, node, types.Address{}, atx, 500, 100, 0, 0, false)
+		c.Add(epoch, node, types.Address{}, &atx, 500, 100, 0, 0, false)
 	}
 	rng.Shuffle(size, func(i, j int) {
 		atxs[i], atxs[j] = atxs[j], atxs[i]

--- a/atxsdata/warmup.go
+++ b/atxsdata/warmup.go
@@ -40,7 +40,7 @@ func Warmup(db sql.Executor, cache *Data, keep types.EpochID) error {
 
 	return atxs.IterateAtxsData(db, cache.Evicted(), latest,
 		func(
-			id types.ATXID,
+			id *types.ATXID,
 			node types.NodeID,
 			epoch types.EpochID,
 			coinbase types.Address,

--- a/atxsdata/warmup_test.go
+++ b/atxsdata/warmup_test.go
@@ -29,7 +29,7 @@ func gatx(
 		VRFNonce:     nonce,
 		TickCount:    1,
 	}
-	atx.SetID(id)
+	atx.SetID(&id)
 	atx.SetReceived(time.Time{}.Add(1))
 	return *atx
 }

--- a/beacon/beacon_test.go
+++ b/beacon/beacon_test.go
@@ -113,7 +113,7 @@ func createATX(
 	sig *signing.EdSigner,
 	numUnits uint32,
 	received time.Time,
-) types.ATXID {
+) *types.ATXID {
 	nonce := types.VRFPostIndex(1)
 	atx := types.NewActivationTx(
 		types.NIPostChallenge{PublishEpoch: lid.GetEpoch()},

--- a/beacon/state.go
+++ b/beacon/state.go
@@ -12,7 +12,7 @@ import (
 )
 
 type minerInfo struct {
-	atxid     types.ATXID
+	atxid     *types.ATXID
 	malicious bool
 }
 

--- a/blocks/generator_test.go
+++ b/blocks/generator_test.go
@@ -275,7 +275,7 @@ func genData(
 	numProposals := 10
 	txIDs := createAndSaveTxs(t, numTXs, db)
 	signers, atxes := createATXs(t, data, (lid.GetEpoch() - 1).FirstLayer(), numProposals)
-	activeSet := types.ToATXIDs(atxes)
+	activeSet := types.PtrSliceToSlice(types.ToATXIDs(atxes))
 	var meshHash types.Hash32
 	if optimistic {
 		meshHash = types.RandomHash()
@@ -380,7 +380,7 @@ func Test_run(t *testing.T) {
 			numProposals := 10
 			txIDs := createAndSaveTxs(t, numTXs, tg.db)
 			signers, atxes := createATXs(t, tg.atxs, (layerID.GetEpoch() - 1).FirstLayer(), numProposals)
-			activeSet := types.ToATXIDs(atxes)
+			activeSet := types.PtrSliceToSlice(types.ToATXIDs(atxes))
 			plist := createProposals(t, tg.db, tg.proposals, layerID, meshHash, signers, activeSet, txIDs)
 			pids := types.ToProposalIDs(plist)
 			tg.mockFetch.EXPECT().GetProposals(gomock.Any(), pids)
@@ -493,7 +493,7 @@ func Test_run_DiffHasFromConsensus(t *testing.T) {
 	// create multiple proposals with overlapping TXs
 	txIDs := createAndSaveTxs(t, 100, tg.db)
 	signers, atxes := createATXs(t, tg.atxs, (layerID.GetEpoch() - 1).FirstLayer(), 10)
-	activeSet := types.ToATXIDs(atxes)
+	activeSet := types.PtrSliceToSlice(types.ToATXIDs(atxes))
 	meshHash := types.RandomHash()
 	plist := createProposals(t, tg.db, tg.proposals, layerID, meshHash, signers, activeSet, txIDs)
 	pids := types.ToProposalIDs(plist)
@@ -513,7 +513,7 @@ func Test_run_ExecuteFailed(t *testing.T) {
 	tg.Start(context.Background())
 	txIDs := createAndSaveTxs(t, 100, tg.db)
 	signers, atxes := createATXs(t, tg.atxs, (layerID.GetEpoch() - 1).FirstLayer(), 10)
-	activeSet := types.ToATXIDs(atxes)
+	activeSet := types.PtrSliceToSlice(types.ToATXIDs(atxes))
 	meshHash := types.RandomHash()
 	plist := createProposals(t, tg.db, tg.proposals, layerID, meshHash, signers, activeSet, txIDs)
 	pids := types.ToProposalIDs(plist)
@@ -546,7 +546,7 @@ func Test_run_AddBlockFailed(t *testing.T) {
 	tg.Start(context.Background())
 	txIDs := createAndSaveTxs(t, 100, tg.db)
 	signers, atxes := createATXs(t, tg.atxs, (layerID.GetEpoch() - 1).FirstLayer(), 10)
-	activeSet := types.ToATXIDs(atxes)
+	activeSet := types.PtrSliceToSlice(types.ToATXIDs(atxes))
 	meshHash := types.RandomHash()
 	plist := createProposals(t, tg.db, tg.proposals, layerID, meshHash, signers, activeSet, txIDs)
 	pids := types.ToProposalIDs(plist)
@@ -571,7 +571,7 @@ func Test_run_RegisterCertFailureIgnored(t *testing.T) {
 	tg.Start(context.Background())
 	txIDs := createAndSaveTxs(t, 100, tg.db)
 	signers, atxes := createATXs(t, tg.atxs, (layerID.GetEpoch() - 1).FirstLayer(), 10)
-	activeSet := types.ToATXIDs(atxes)
+	activeSet := types.PtrSliceToSlice(types.ToATXIDs(atxes))
 	meshHash := types.RandomHash()
 	plist := createProposals(t, tg.db, tg.proposals, layerID, meshHash, signers, activeSet, txIDs)
 	pids := types.ToProposalIDs(plist)
@@ -599,7 +599,7 @@ func Test_run_CertifyFailureIgnored(t *testing.T) {
 	tg.Start(context.Background())
 	txIDs := createAndSaveTxs(t, 100, tg.db)
 	signers, atxes := createATXs(t, tg.atxs, (layerID.GetEpoch() - 1).FirstLayer(), 10)
-	activeSet := types.ToATXIDs(atxes)
+	activeSet := types.PtrSliceToSlice(types.ToATXIDs(atxes))
 	meshHash := types.RandomHash()
 	plist := createProposals(t, tg.db, tg.proposals, layerID, meshHash, signers, activeSet, txIDs)
 	pids := types.ToProposalIDs(plist)
@@ -627,7 +627,7 @@ func Test_run_ProcessLayerFailed(t *testing.T) {
 	tg.Start(context.Background())
 	txIDs := createAndSaveTxs(t, 100, tg.db)
 	signers, atxes := createATXs(t, tg.atxs, (layerID.GetEpoch() - 1).FirstLayer(), 10)
-	activeSet := types.ToATXIDs(atxes)
+	activeSet := types.PtrSliceToSlice(types.ToATXIDs(atxes))
 	meshHash := types.RandomHash()
 	plist := createProposals(t, tg.db, tg.proposals, layerID, meshHash, signers, activeSet, txIDs)
 	pids := types.ToProposalIDs(plist)
@@ -669,7 +669,7 @@ func Test_processHareOutput_UnequalHeight(t *testing.T) {
 			maxHeight = max(maxHeight, atx.BaseTickHeight)
 		},
 	)
-	activeSet := types.ToATXIDs(atxes)
+	activeSet := types.PtrSliceToSlice(types.ToATXIDs(atxes))
 	pList := createProposals(t, tg.db, tg.proposals, layerID, types.Hash32{}, signers, activeSet, nil)
 	ctx := context.Background()
 	ho := hare3.ConsensusOutput{
@@ -714,7 +714,7 @@ func Test_processHareOutput_bad_state(t *testing.T) {
 	tg := createTestGenerator(t)
 	layerID := types.GetEffectiveGenesis().Add(100)
 	signers, atxes := createATXs(t, tg.atxs, (layerID.GetEpoch() - 1).FirstLayer(), 1)
-	activeSet := types.ToATXIDs(atxes)
+	activeSet := types.PtrSliceToSlice(types.ToATXIDs(atxes))
 
 	t.Run("tx missing", func(t *testing.T) {
 		p := createProposal(
@@ -775,7 +775,7 @@ func Test_processHareOutput_EmptyProposals(t *testing.T) {
 	numProposals := 10
 	lid := types.GetEffectiveGenesis().Add(20)
 	signers, atxes := createATXs(t, tg.atxs, (lid.GetEpoch() - 1).FirstLayer(), numProposals)
-	activeSet := types.ToATXIDs(atxes)
+	activeSet := types.PtrSliceToSlice(types.ToATXIDs(atxes))
 	plist := make([]*types.Proposal, 0, numProposals)
 	for i := 0; i < numProposals; i++ {
 		p := createProposal(t, tg.db, tg.proposals, activeSet, lid, types.Hash32{}, activeSet[i], signers[i], nil, 1)
@@ -828,7 +828,7 @@ func Test_processHareOutput_StableBlockID(t *testing.T) {
 	numProposals := 10
 	txIDs := createAndSaveTxs(t, numTXs, tg.db)
 	signers, atxes := createATXs(t, tg.atxs, (layerID.GetEpoch() - 1).FirstLayer(), numProposals)
-	activeSet := types.ToATXIDs(atxes)
+	activeSet := types.PtrSliceToSlice(types.ToATXIDs(atxes))
 	plist := createProposals(t, tg.db, tg.proposals, layerID, types.Hash32{}, signers, activeSet, txIDs)
 	ctx := context.Background()
 	ho1 := hare3.ConsensusOutput{
@@ -874,7 +874,7 @@ func Test_processHareOutput_SameATX(t *testing.T) {
 	numProposals := 10
 	txIDs := createAndSaveTxs(t, numTXs, tg.db)
 	signers, atxes := createATXs(t, tg.atxs, (layerID.GetEpoch() - 1).FirstLayer(), numProposals)
-	activeSet := types.ToATXIDs(atxes)
+	activeSet := types.PtrSliceToSlice(types.ToATXIDs(atxes))
 	atxID := activeSet[0]
 	plist := []*types.Proposal{
 		createProposal(t, tg.db, tg.proposals, activeSet, layerID, types.Hash32{}, atxID, signers[0], txIDs[0:500], 1),
@@ -898,9 +898,9 @@ func Test_processHareOutput_EmptyATXID(t *testing.T) {
 	numProposals := 10
 	txIDs := createAndSaveTxs(t, numTXs, tg.db)
 	signers, atxes := createATXs(t, tg.atxs, (layerID.GetEpoch() - 1).FirstLayer(), numProposals)
-	activeSet := types.ToATXIDs(atxes)
+	activeSet := types.PtrSliceToSlice(types.ToATXIDs(atxes))
 	plist := createProposals(t, tg.db, tg.proposals, layerID, types.Hash32{}, signers[1:], activeSet[1:], txIDs[1:])
-	p := createProposal(t, tg.db, tg.proposals, activeSet, layerID, types.Hash32{}, types.EmptyATXID, signers[0],
+	p := createProposal(t, tg.db, tg.proposals, activeSet, layerID, types.Hash32{}, *types.EmptyATXID, signers[0],
 		txIDs, 1,
 	)
 	plist = append(plist, p)
@@ -920,11 +920,11 @@ func Test_processHareOutput_MultipleEligibilities(t *testing.T) {
 	layerID := types.GetEffectiveGenesis().Add(100)
 	ids := createAndSaveTxs(t, 1000, tg.db)
 	signers, atxes := createATXs(t, tg.atxs, (layerID.GetEpoch() - 1).FirstLayer(), 10)
-	activeSet := types.ToATXIDs(atxes)
+	activeSet := types.PtrSliceToSlice(types.ToATXIDs(atxes))
 	plist := []*types.Proposal{
-		createProposal(t, tg.db, tg.proposals, activeSet, layerID, types.Hash32{}, atxes[0].ID(), signers[0], ids, 2),
-		createProposal(t, tg.db, tg.proposals, activeSet, layerID, types.Hash32{}, atxes[1].ID(), signers[1], ids, 1),
-		createProposal(t, tg.db, tg.proposals, activeSet, layerID, types.Hash32{}, atxes[2].ID(), signers[2], ids, 5),
+		createProposal(t, tg.db, tg.proposals, activeSet, layerID, types.Hash32{}, *atxes[0].ID(), signers[0], ids, 2),
+		createProposal(t, tg.db, tg.proposals, activeSet, layerID, types.Hash32{}, *atxes[1].ID(), signers[1], ids, 1),
+		createProposal(t, tg.db, tg.proposals, activeSet, layerID, types.Hash32{}, *atxes[2].ID(), signers[2], ids, 5),
 	}
 	ctx := context.Background()
 	ho := hare3.ConsensusOutput{
@@ -946,7 +946,7 @@ func Test_processHareOutput_MultipleEligibilities(t *testing.T) {
 	})
 	totalWeight := new(big.Rat)
 	for i, r := range got.Rewards {
-		require.Equal(t, plist[i].AtxID, r.AtxID)
+		require.Equal(t, plist[i].AtxID, *r.AtxID)
 		got := r.Weight.ToBigRat()
 		// numUint is the ATX weight. eligible slots per epoch is 3 for each atx
 		// the expected weight for each eligibility is `numUnit` * 1/3

--- a/blocks/handler.go
+++ b/blocks/handler.go
@@ -93,7 +93,7 @@ func (h *Handler) HandleSyncedBlock(ctx context.Context, expHash types.Hash32, p
 	logger.Info("new block")
 
 	if missing := h.tortoise.GetMissingActiveSet(b.LayerIndex.GetEpoch(), toAtxIDs(b.Rewards)); len(missing) > 0 {
-		h.fetcher.RegisterPeerHashes(peer, types.ATXIDsToHashes(missing))
+		h.fetcher.RegisterPeerHashes(peer, types.ATXIDsPtrToHashes(missing))
 		if err := h.fetcher.GetAtxs(ctx, missing); err != nil {
 			return err
 		}
@@ -126,10 +126,10 @@ func ValidateRewards(rewards []types.AnyReward) error {
 				reward.AtxID,
 			)
 		}
-		if _, exists := unique[reward.AtxID]; exists {
+		if _, exists := unique[*reward.AtxID]; exists {
 			return fmt.Errorf("multiple rewards for the same atx %v", reward.AtxID)
 		}
-		unique[reward.AtxID] = struct{}{}
+		unique[*reward.AtxID] = struct{}{}
 	}
 	return nil
 }
@@ -152,8 +152,8 @@ func (h *Handler) checkTransactions(ctx context.Context, peer p2p.Peer, b *types
 	return nil
 }
 
-func toAtxIDs(rewards []types.AnyReward) []types.ATXID {
-	rst := make([]types.ATXID, 0, len(rewards))
+func toAtxIDs(rewards []types.AnyReward) []*types.ATXID {
+	rst := make([]*types.ATXID, 0, len(rewards))
 	for i := range rewards {
 		rst = append(rst, rewards[i].AtxID)
 	}

--- a/blocks/handler_test.go
+++ b/blocks/handler_test.go
@@ -47,8 +47,8 @@ func TestHandleSyncedBlock(t *testing.T) {
 	good := &types.Block{InnerBlock: types.InnerBlock{
 		LayerIndex: layer,
 		Rewards: []types.AnyReward{
-			{AtxID: types.ATXID{1}, Weight: types.RatNum{Num: 1, Denom: 1}},
-			{AtxID: types.ATXID{2}, Weight: types.RatNum{Num: 1, Denom: 1}},
+			{AtxID: &types.ATXID{1}, Weight: types.RatNum{Num: 1, Denom: 1}},
+			{AtxID: &types.ATXID{2}, Weight: types.RatNum{Num: 1, Denom: 1}},
 		},
 		TxIDs: []types.TransactionID{{1}, {2}},
 	}}
@@ -57,8 +57,8 @@ func TestHandleSyncedBlock(t *testing.T) {
 	badrewards := &types.Block{InnerBlock: types.InnerBlock{
 		LayerIndex: layer,
 		Rewards: []types.AnyReward{
-			{AtxID: types.ATXID{1}},
-			{AtxID: types.ATXID{2}},
+			{AtxID: &types.ATXID{1}},
+			{AtxID: &types.ATXID{2}},
 		},
 	}}
 	badrewards.Initialize()
@@ -73,7 +73,7 @@ func TestHandleSyncedBlock(t *testing.T) {
 		id                types.Hash32
 		dup               bool
 		epoch             types.EpochID
-		tortoise, missing []types.ATXID
+		tortoise, missing []*types.ATXID
 		failAtxs          error
 		txs               []types.TransactionID
 		failTxs           error
@@ -85,8 +85,8 @@ func TestHandleSyncedBlock(t *testing.T) {
 			data:     codec.MustEncode(good),
 			id:       good.ID().AsHash32(),
 			epoch:    good.LayerIndex.GetEpoch(),
-			tortoise: []types.ATXID{{1}, {2}},
-			missing:  []types.ATXID{{2}},
+			tortoise: []*types.ATXID{{1}, {2}},
+			missing:  []*types.ATXID{{2}},
 			txs:      []types.TransactionID{{1}, {2}},
 		},
 		{
@@ -123,8 +123,8 @@ func TestHandleSyncedBlock(t *testing.T) {
 			data:     codec.MustEncode(good),
 			id:       good.ID().AsHash32(),
 			epoch:    good.LayerIndex.GetEpoch(),
-			tortoise: []types.ATXID{{1}, {2}},
-			missing:  []types.ATXID{{2}},
+			tortoise: []*types.ATXID{{1}, {2}},
+			missing:  []*types.ATXID{{2}},
 			failAtxs: errors.New("atxs failed"),
 			err:      "atxs failed",
 		},
@@ -133,8 +133,8 @@ func TestHandleSyncedBlock(t *testing.T) {
 			data:     codec.MustEncode(good),
 			id:       good.ID().AsHash32(),
 			epoch:    good.LayerIndex.GetEpoch(),
-			tortoise: []types.ATXID{{1}, {2}},
-			missing:  []types.ATXID{{2}},
+			tortoise: []*types.ATXID{{1}, {2}},
+			missing:  []*types.ATXID{{2}},
 			txs:      []types.TransactionID{{1}, {2}},
 			failTxs:  errors.New("txs failed"),
 			err:      "txs failed",
@@ -144,8 +144,8 @@ func TestHandleSyncedBlock(t *testing.T) {
 			data:     codec.MustEncode(good),
 			id:       good.ID().AsHash32(),
 			epoch:    good.LayerIndex.GetEpoch(),
-			tortoise: []types.ATXID{{1}, {2}},
-			missing:  []types.ATXID{{2}},
+			tortoise: []*types.ATXID{{1}, {2}},
+			missing:  []*types.ATXID{{2}},
 			txs:      []types.TransactionID{{1}, {2}},
 			failMesh: errors.New("add block failed"),
 			err:      "add block failed",
@@ -162,7 +162,8 @@ func TestHandleSyncedBlock(t *testing.T) {
 			}
 
 			th.mockTortoise.EXPECT().GetMissingActiveSet(tc.epoch, tc.tortoise).Return(tc.missing).MaxTimes(1)
-			th.mockFetcher.EXPECT().RegisterPeerHashes(pid, types.ATXIDsToHashes(tc.missing)).MaxTimes(1)
+			th.mockFetcher.EXPECT().RegisterPeerHashes(pid, types.ATXIDsToHashes(types.PtrSliceToSlice(tc.missing))).
+				MaxTimes(1)
 			th.mockFetcher.EXPECT().GetAtxs(gomock.Any(), tc.missing).Return(tc.failAtxs).MaxTimes(1)
 			th.mockFetcher.EXPECT().RegisterPeerHashes(pid, types.TransactionIDsToHashes(tc.txs)).MaxTimes(1)
 			th.mockFetcher.EXPECT().GetBlockTxs(gomock.Any(), tc.txs).Return(tc.failTxs).MaxTimes(1)
@@ -188,15 +189,15 @@ func TestValidateRewards(t *testing.T) {
 			desc: "sanity",
 			rewards: []types.AnyReward{
 				{
-					AtxID:  types.ATXID{1},
+					AtxID:  &types.ATXID{1},
 					Weight: types.RatNum{Num: 1, Denom: 3},
 				},
 				{
-					AtxID:  types.ATXID{2},
+					AtxID:  &types.ATXID{2},
 					Weight: types.RatNum{Num: 1, Denom: 3},
 				},
 				{
-					AtxID:  types.ATXID{3},
+					AtxID:  &types.ATXID{3},
 					Weight: types.RatNum{Num: 1, Denom: 3},
 				},
 			},
@@ -214,11 +215,11 @@ func TestValidateRewards(t *testing.T) {
 			desc: "zero num",
 			rewards: []types.AnyReward{
 				{
-					AtxID:  types.ATXID{1},
+					AtxID:  &types.ATXID{1},
 					Weight: types.RatNum{Num: 1, Denom: 3},
 				},
 				{
-					AtxID:  types.ATXID{3},
+					AtxID:  &types.ATXID{3},
 					Weight: types.RatNum{Num: 0, Denom: 3},
 				},
 			},
@@ -228,11 +229,11 @@ func TestValidateRewards(t *testing.T) {
 			desc: "zero denom",
 			rewards: []types.AnyReward{
 				{
-					AtxID:  types.ATXID{1},
+					AtxID:  &types.ATXID{1},
 					Weight: types.RatNum{Num: 1, Denom: 3},
 				},
 				{
-					AtxID:  types.ATXID{3},
+					AtxID:  &types.ATXID{3},
 					Weight: types.RatNum{Num: 1, Denom: 0},
 				},
 			},
@@ -242,15 +243,15 @@ func TestValidateRewards(t *testing.T) {
 			desc: "multiple per coinbase",
 			rewards: []types.AnyReward{
 				{
-					AtxID:  types.ATXID{1},
+					AtxID:  &types.ATXID{1},
 					Weight: types.RatNum{Num: 1, Denom: 3},
 				},
 				{
-					AtxID:  types.ATXID{3},
+					AtxID:  &types.ATXID{3},
 					Weight: types.RatNum{Num: 1, Denom: 3},
 				},
 				{
-					AtxID:  types.ATXID{1},
+					AtxID:  &types.ATXID{1},
 					Weight: types.RatNum{Num: 1, Denom: 3},
 				},
 			},

--- a/blocks/interface.go
+++ b/blocks/interface.go
@@ -39,5 +39,5 @@ type certifier interface {
 }
 
 type tortoiseProvider interface {
-	GetMissingActiveSet(types.EpochID, []types.ATXID) []types.ATXID
+	GetMissingActiveSet(types.EpochID, []*types.ATXID) []*types.ATXID
 }

--- a/blocks/mocks/mocks.go
+++ b/blocks/mocks/mocks.go
@@ -497,10 +497,10 @@ func (m *MocktortoiseProvider) EXPECT() *MocktortoiseProviderMockRecorder {
 }
 
 // GetMissingActiveSet mocks base method.
-func (m *MocktortoiseProvider) GetMissingActiveSet(arg0 types.EpochID, arg1 []types.ATXID) []types.ATXID {
+func (m *MocktortoiseProvider) GetMissingActiveSet(arg0 types.EpochID, arg1 []*types.ATXID) []*types.ATXID {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMissingActiveSet", arg0, arg1)
-	ret0, _ := ret[0].([]types.ATXID)
+	ret0, _ := ret[0].([]*types.ATXID)
 	return ret0
 }
 
@@ -517,19 +517,19 @@ type MocktortoiseProviderGetMissingActiveSetCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MocktortoiseProviderGetMissingActiveSetCall) Return(arg0 []types.ATXID) *MocktortoiseProviderGetMissingActiveSetCall {
+func (c *MocktortoiseProviderGetMissingActiveSetCall) Return(arg0 []*types.ATXID) *MocktortoiseProviderGetMissingActiveSetCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MocktortoiseProviderGetMissingActiveSetCall) Do(f func(types.EpochID, []types.ATXID) []types.ATXID) *MocktortoiseProviderGetMissingActiveSetCall {
+func (c *MocktortoiseProviderGetMissingActiveSetCall) Do(f func(types.EpochID, []*types.ATXID) []*types.ATXID) *MocktortoiseProviderGetMissingActiveSetCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MocktortoiseProviderGetMissingActiveSetCall) DoAndReturn(f func(types.EpochID, []types.ATXID) []types.ATXID) *MocktortoiseProviderGetMissingActiveSetCall {
+func (c *MocktortoiseProviderGetMissingActiveSetCall) DoAndReturn(f func(types.EpochID, []*types.ATXID) []*types.ATXID) *MocktortoiseProviderGetMissingActiveSetCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/blocks/utils.go
+++ b/blocks/utils.go
@@ -239,7 +239,7 @@ func rewardInfoAndHeight(
 	weights := make(map[types.ATXID]*big.Rat)
 	maxHeight := uint64(0)
 	for _, p := range props {
-		atx := atxs.Get(p.Layer.GetEpoch(), p.AtxID)
+		atx := atxs.Get(p.Layer.GetEpoch(), &p.AtxID)
 		if atx == nil {
 			return 0, nil, fmt.Errorf(
 				"proposal ATX not found: atx %s proposal %s", p.AtxID.ShortString(), p.ID().String(),
@@ -283,7 +283,7 @@ func rewardInfoAndHeight(
 	for _, id := range atxids {
 		weight := weights[id]
 		rewards = append(rewards, types.AnyReward{
-			AtxID: id,
+			AtxID: &id,
 			Weight: types.RatNum{
 				Num:   weight.Num().Uint64(),
 				Denom: weight.Denom().Uint64(),

--- a/blocks/utils_test.go
+++ b/blocks/utils_test.go
@@ -164,14 +164,14 @@ func Test_getProposalMetadata(t *testing.T) {
 	cfg := Config{OptFilterThreshold: 70}
 	lid := types.LayerID(111)
 	_, atxs := createATXs(t, data, (lid.GetEpoch() - 1).FirstLayer(), 10)
-	actives := types.ATXIDList(types.ToATXIDs(atxs))
+	actives := types.ATXIDList(types.PtrSliceToSlice(types.ToATXIDs(atxs)))
 	props := make([]*types.Proposal, 0, 10)
 	hash1 := types.Hash32{1, 2, 3}
 	hash2 := types.Hash32{3, 2, 1}
 	for i := 0; i < 10; i++ {
 		var p types.Proposal
 		p.Layer = lid
-		p.AtxID = atxs[i].ID()
+		p.AtxID = *atxs[i].ID()
 		if i < 5 {
 			p.MeshHash = hash1
 		} else {

--- a/checkpoint/recovery.go
+++ b/checkpoint/recovery.go
@@ -388,7 +388,7 @@ func collectOwnAtxDeps(
 
 	// check for if smesher is building any atx
 	nipostCh, _ := nipost.Challenge(localDB, nodeID)
-	if ref == types.EmptyATXID {
+	if ref.Empty() {
 		if nipostCh == nil {
 			logger.Debug("there is no own atx and none is being built")
 			return nil, nil, nil

--- a/checkpoint/runner.go
+++ b/checkpoint/runner.go
@@ -71,6 +71,9 @@ func checkpointDB(
 		if err != nil {
 			return nil, fmt.Errorf("atxs snapshot commitment: %w", err)
 		}
+		if atxSnapshot[i].CommitmentATX == nil {
+			atxSnapshot[i].CommitmentATX = new(types.ATXID)
+		}
 		copy(atxSnapshot[i].CommitmentATX[:], commitmentAtx[:])
 	}
 	for _, catx := range atxSnapshot {

--- a/checkpoint/runner_test.go
+++ b/checkpoint/runner_test.go
@@ -39,26 +39,26 @@ var allAtxs = map[types.NodeID][]*types.ActivationTx{
 		newAtx(types.ATXID{14}, types.ATXID{13}, nil, 4, 3, 123, types.BytesToNodeID([]byte("smesher1"))),
 		newAtx(types.ATXID{13}, types.ATXID{12}, nil, 3, 2, 123, types.BytesToNodeID([]byte("smesher1"))),
 		newAtx(types.ATXID{12}, types.ATXID{11}, nil, 2, 1, 123, types.BytesToNodeID([]byte("smesher1"))),
-		newAtx(types.ATXID{11}, types.EmptyATXID,
+		newAtx(types.ATXID{11}, *types.EmptyATXID,
 			&types.ATXID{1}, 1, 0, 123, types.BytesToNodeID([]byte("smesher1"))),
 	},
 
 	// smesher 2 has 1 ATX in epoch 7
 	types.BytesToNodeID([]byte("smesher2")): {
-		newAtx(types.ATXID{27}, types.EmptyATXID, &types.ATXID{2}, 7, 0, 152,
+		newAtx(types.ATXID{27}, *types.EmptyATXID, &types.ATXID{2}, 7, 0, 152,
 			types.BytesToNodeID([]byte("smesher2"))),
 	},
 
 	// smesher 3 has 1 ATX in epoch 2
 	types.BytesToNodeID([]byte("smesher3")): {
-		newAtx(types.ATXID{32}, types.EmptyATXID, &types.ATXID{3}, 2, 0, 211,
+		newAtx(types.ATXID{32}, *types.EmptyATXID, &types.ATXID{3}, 2, 0, 211,
 			types.BytesToNodeID([]byte("smesher3"))),
 	},
 
 	// smesher 4 has 1 ATX in epoch 3 and one in epoch 7
 	types.BytesToNodeID([]byte("smesher4")): {
 		newAtx(types.ATXID{47}, types.ATXID{43}, nil, 7, 1, 420, types.BytesToNodeID([]byte("smesher4"))),
-		newAtx(types.ATXID{43}, types.EmptyATXID, &types.ATXID{4}, 4, 0, 420,
+		newAtx(types.ATXID{43}, *types.EmptyATXID, &types.ATXID{4}, 4, 0, 420,
 			types.BytesToNodeID([]byte("smesher4"))),
 	},
 }
@@ -211,7 +211,7 @@ func newAtx(
 		SmesherID:     nodeID,
 		VRFNonce:      types.VRFPostIndex(vrfnonce),
 	}
-	atx.SetID(id)
+	atx.SetID(&id)
 	atx.SetReceived(time.Now().Local())
 	return atx
 }
@@ -249,8 +249,8 @@ func createMesh(t *testing.T, db *sql.Database, miners map[types.NodeID][]*types
 
 	// smesher 5 is malicious and equivocated in epoch 7
 	bad := types.BytesToNodeID([]byte("smesher5"))
-	require.NoError(t, atxs.Add(db, newAtx(types.ATXID{83}, types.EmptyATXID, &types.ATXID{27}, 7, 0, 113, bad)))
-	require.NoError(t, atxs.Add(db, newAtx(types.ATXID{97}, types.EmptyATXID, &types.ATXID{16}, 7, 0, 113, bad)))
+	require.NoError(t, atxs.Add(db, newAtx(types.ATXID{83}, *types.EmptyATXID, &types.ATXID{27}, 7, 0, 113, bad)))
+	require.NoError(t, atxs.Add(db, newAtx(types.ATXID{97}, *types.EmptyATXID, &types.ATXID{16}, 7, 0, 113, bad)))
 	require.NoError(t, identities.SetMalicious(db, bad, []byte("bad"), time.Now()))
 }
 
@@ -347,7 +347,7 @@ func TestRunner_Generate_Error(t *testing.T) {
 			snapshot := types.LayerID(5)
 			var atx *types.ActivationTx
 			if tc.missingCommitment {
-				atx = newAtx(types.ATXID{13}, types.EmptyATXID,
+				atx = newAtx(types.ATXID{13}, *types.EmptyATXID,
 					nil, 2, 1, 11, types.BytesToNodeID([]byte("smesher1")))
 			}
 			createMesh(t, db, map[types.NodeID][]*types.ActivationTx{

--- a/checkpoint/util.go
+++ b/checkpoint/util.go
@@ -166,7 +166,7 @@ func backupOldDb(fs afero.Fs, srcDir, dbFile string) (string, error) {
 	return backupDir, nil
 }
 
-func positioningATX(ctx context.Context, db sql.Executor, id types.ATXID) (types.ATXID, error) {
+func positioningATX(ctx context.Context, db sql.Executor, id *types.ATXID) (*types.ATXID, error) {
 	var blob sql.Blob
 	version, err := atxs.LoadBlob(ctx, db, id.Bytes(), &blob)
 	if err != nil {
@@ -178,18 +178,18 @@ func positioningATX(ctx context.Context, db sql.Executor, id types.ATXID) (types
 		if err := codec.Decode(blob.Bytes, &atx); err != nil {
 			return types.EmptyATXID, fmt.Errorf("decode %s: %w", id, err)
 		}
-		return atx.PositioningATXID, nil
+		return &atx.PositioningATXID, nil
 	case types.AtxV2:
 		var atx wire.ActivationTxV2
 		if err := codec.Decode(blob.Bytes, &atx); err != nil {
 			return types.EmptyATXID, fmt.Errorf("decode %s: %w", id, err)
 		}
-		return atx.PositioningATX, nil
+		return &atx.PositioningATX, nil
 	}
 	return types.EmptyATXID, fmt.Errorf("unsupported ATX version: %v", version)
 }
 
-func poetProofRefs(ctx context.Context, db sql.Executor, id types.ATXID) ([]types.PoetProofRef, error) {
+func poetProofRefs(ctx context.Context, db sql.Executor, id *types.ATXID) ([]types.PoetProofRef, error) {
 	var blob sql.Blob
 	version, err := atxs.LoadBlob(ctx, db, id.Bytes(), &blob)
 	if err != nil {

--- a/cmd/bootstrapper/generator_test.go
+++ b/cmd/bootstrapper/generator_test.go
@@ -53,7 +53,7 @@ func createAtxs(tb testing.TB, db sql.Executor, epoch types.EpochID, atxids []ty
 			TickCount:    1,
 			SmesherID:    types.RandomNodeID(),
 		}
-		atx.SetID(id)
+		atx.SetID(&id)
 		atx.SetReceived(time.Now())
 		require.NoError(tb, atxs.Add(db, atx))
 	}
@@ -102,7 +102,7 @@ func verifyUpdate(tb testing.TB, data []byte, epoch types.EpochID, expBeacon str
 func TestGenerator_Generate(t *testing.T) {
 	targetEpoch := types.EpochID(3)
 	db := sql.InMemory()
-	createAtxs(t, db, targetEpoch-1, types.RandomActiveSet(activeSetSize))
+	createAtxs(t, db, targetEpoch-1, types.PtrSliceToSlice(types.RandomActiveSet(activeSetSize)))
 	cfg, cleanup := launchServer(t, datastore.NewCachedDB(db, zaptest.NewLogger(t)))
 	t.Cleanup(cleanup)
 
@@ -170,7 +170,7 @@ func TestGenerator_CheckAPI(t *testing.T) {
 	targetEpoch := types.EpochID(3)
 	db := sql.InMemory()
 	lg := logtest.New(t)
-	createAtxs(t, db, targetEpoch-1, types.RandomActiveSet(activeSetSize))
+	createAtxs(t, db, targetEpoch-1, types.PtrSliceToSlice(types.RandomActiveSet(activeSetSize)))
 	cfg, cleanup := launchServer(t, datastore.NewCachedDB(db, lg.Zap()))
 	t.Cleanup(cleanup)
 

--- a/cmd/bootstrapper/server_test.go
+++ b/cmd/bootstrapper/server_test.go
@@ -87,7 +87,7 @@ func TestServer(t *testing.T) {
 	srv.Start(ctx, ch, np)
 
 	for _, epoch := range epochs {
-		createAtxs(t, db, epoch-1, types.RandomActiveSet(activeSetSize))
+		createAtxs(t, db, epoch-1, types.PtrSliceToSlice(types.RandomActiveSet(activeSetSize)))
 		fname := PersistedFilename(epoch, bootstrap.SuffixBootstrap)
 		require.Eventually(t, func() bool {
 			_, err := fs.Stat(fname)

--- a/cmd/merge-nodes/internal/merge_action_test.go
+++ b/cmd/merge-nodes/internal/merge_action_test.go
@@ -220,8 +220,8 @@ func Test_MergeDBs_Successful_Existing_Node(t *testing.T) {
 	sig1Ch := &types.NIPostChallenge{
 		PublishEpoch:   types.EpochID(rand.Uint32()),
 		Sequence:       rand.Uint64(),
-		PrevATXID:      types.RandomATXID(),
-		PositioningATX: types.RandomATXID(),
+		PrevATXID:      *types.RandomATXID(),
+		PositioningATX: *types.RandomATXID(),
 	}
 	err = nipost.AddChallenge(dstDB, sig1.NodeID(), sig1Ch)
 	require.NoError(t, err)
@@ -274,8 +274,8 @@ func Test_MergeDBs_Successful_Existing_Node(t *testing.T) {
 	sig2Ch := &types.NIPostChallenge{
 		PublishEpoch:   types.EpochID(rand.Uint32()),
 		Sequence:       rand.Uint64(),
-		PositioningATX: types.RandomATXID(),
-		CommitmentATX:  &cAtx,
+		PositioningATX: *types.RandomATXID(),
+		CommitmentATX:  cAtx,
 		InitialPost: &types.Post{
 			Nonce:   rand.Uint32(),
 			Pow:     rand.Uint64(),
@@ -375,8 +375,8 @@ func Test_MergeDBs_Successful_Empty_Dir(t *testing.T) {
 	sigCh := &types.NIPostChallenge{
 		PublishEpoch:   types.EpochID(rand.Uint32()),
 		Sequence:       rand.Uint64(),
-		PositioningATX: types.RandomATXID(),
-		CommitmentATX:  &cAtx,
+		PositioningATX: *types.RandomATXID(),
+		CommitmentATX:  cAtx,
 		InitialPost: &types.Post{
 			Nonce:   rand.Uint32(),
 			Pow:     rand.Uint64(),

--- a/common/types/atxid_list.go
+++ b/common/types/atxid_list.go
@@ -5,6 +5,32 @@ import "github.com/spacemeshos/go-spacemesh/hash"
 // ATXIDList defines ATX ID list.
 type ATXIDList []ATXID
 
+func ATXIDListFromPtr(a []*ATXID) ATXIDList {
+	return ATXIDList(PtrSliceToSlice(a))
+}
+
+func PtrSliceToSlice[V any](a []*V) []V {
+	if len(a) == 0 {
+		return []V{}
+	}
+	b := make([]V, len(a))
+	for i, val := range a {
+		b[i] = *val
+	}
+	return b
+}
+
+func SliceToPtrSlice[V any](a []V) []*V {
+	if len(a) == 0 {
+		return []*V{}
+	}
+	b := make([]*V, len(a))
+	for i, val := range a {
+		b[i] = &val
+	}
+	return b
+}
+
 // Hash returns ATX ID list hash.
 func (atxList ATXIDList) Hash() Hash32 {
 	hasher := hash.GetHasher()

--- a/common/types/ballot.go
+++ b/common/types/ballot.go
@@ -337,7 +337,7 @@ func (b *Ballot) ToTortoiseData() *BallotTortoiseData {
 		Smesher:       b.SmesherID,
 		Layer:         b.Layer,
 		Eligibilities: uint32(len(b.EligibilityProofs)),
-		AtxID:         b.AtxID,
+		AtxID:         &b.AtxID,
 		Opinion: Opinion{
 			Votes: b.Votes,
 			Hash:  b.OpinionHash,

--- a/common/types/block.go
+++ b/common/types/block.go
@@ -115,7 +115,7 @@ func RatNumFromBigRat(r *big.Rat) RatNum {
 
 // AnyReward contains the reward information by ATXID.
 type AnyReward struct {
-	AtxID  ATXID
+	AtxID  *ATXID
 	Weight RatNum
 }
 

--- a/common/types/block_scale.go
+++ b/common/types/block_scale.go
@@ -137,7 +137,7 @@ func (t *RatNum) DecodeScale(dec *scale.Decoder) (total int, err error) {
 
 func (t *AnyReward) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	{
-		n, err := scale.EncodeByteArray(enc, t.AtxID[:])
+		n, err := scale.EncodeOption(enc, t.AtxID)
 		if err != nil {
 			return total, err
 		}
@@ -155,11 +155,12 @@ func (t *AnyReward) EncodeScale(enc *scale.Encoder) (total int, err error) {
 
 func (t *AnyReward) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	{
-		n, err := scale.DecodeByteArray(dec, t.AtxID[:])
+		field, n, err := scale.DecodeOption[ATXID](dec)
 		if err != nil {
 			return total, err
 		}
 		total += n
+		t.AtxID = field
 	}
 	{
 		n, err := t.Weight.DecodeScale(dec)

--- a/common/types/testutil.go
+++ b/common/types/testutil.go
@@ -27,8 +27,8 @@ func RandomBeacon() Beacon {
 }
 
 // RandomActiveSet generates a random set of ATXIDs of the specified size.
-func RandomActiveSet(size int) []ATXID {
-	ids := make([]ATXID, 0, size)
+func RandomActiveSet(size int) []*ATXID {
+	ids := make([]*ATXID, 0, size)
 	for i := 0; i < size; i++ {
 		ids = append(ids, RandomATXID())
 	}
@@ -45,13 +45,14 @@ func RandomTXSet(size int) []TransactionID {
 }
 
 // RandomATXID generates a random ATXID for testing.
-func RandomATXID() ATXID {
+func RandomATXID() *ATXID {
 	var b [ATXIDSize]byte
 	_, err := rand.Read(b[:])
 	if err != nil {
 		return EmptyATXID
 	}
-	return ATXID(b)
+	v := ATXID(b)
+	return &v
 }
 
 // RandomNodeID generates a random NodeID for testing.
@@ -104,7 +105,7 @@ func RandomBallot() *Ballot {
 	return &Ballot{
 		InnerBallot: InnerBallot{
 			Layer:     LayerID(10),
-			AtxID:     RandomATXID(),
+			AtxID:     *RandomATXID(),
 			RefBallot: RandomBallotID(),
 		},
 		Votes: Votes{

--- a/common/types/tortoise_data.go
+++ b/common/types/tortoise_data.go
@@ -7,7 +7,7 @@ type BallotTortoiseData struct {
 	Smesher       NodeID         `json:"node"`
 	Layer         LayerID        `json:"lid"`
 	Eligibilities uint32         `json:"elig"`
-	AtxID         ATXID          `json:"atxid"`
+	AtxID         *ATXID         `json:"atxid"`
 	Opinion       Opinion        `json:"opinion"`
 	EpochData     *ReferenceData `json:"epochdata"`
 	Ref           *BallotID      `json:"ref"`

--- a/events/events.go
+++ b/events/events.go
@@ -31,7 +31,7 @@ func EmitBeacon(epoch types.EpochID, beacon types.Beacon) {
 	)
 }
 
-func EmitInitStart(nodeID types.NodeID, commitment types.ATXID) {
+func EmitInitStart(nodeID types.NodeID, commitment *types.ATXID) {
 	const help = "Node started PoST data initialization. Initialization will not be performed again if " +
 		"already completed."
 	emitUserEvent(
@@ -46,7 +46,7 @@ func EmitInitStart(nodeID types.NodeID, commitment types.ATXID) {
 	)
 }
 
-func EmitInitFailure(nodeID types.NodeID, commitment types.ATXID, err error) {
+func EmitInitFailure(nodeID types.NodeID, commitment *types.ATXID, err error) {
 	const help = "Node failed PoST data initialization."
 	emitUserEvent(
 		help,
@@ -182,7 +182,7 @@ func EmitInvalidPostProof(nodeID types.NodeID) {
 func EmitAtxPublished(
 	nodeID types.NodeID,
 	current, target types.EpochID,
-	atxID types.ATXID,
+	atxID *types.ATXID,
 	wait time.Time,
 ) {
 	const help = "Node published activation for the current epoch. " +
@@ -207,7 +207,7 @@ func EmitEligibilities(
 	nodeID types.NodeID,
 	epoch types.EpochID,
 	beacon types.Beacon,
-	atxID types.ATXID,
+	atxID *types.ATXID,
 	activeSetSize uint32,
 	eligibilities map[types.LayerID][]types.VotingEligibility,
 ) {

--- a/fetch/handler.go
+++ b/fetch/handler.go
@@ -102,7 +102,7 @@ func (h *handler) handleEpochInfoReq(ctx context.Context, msg []byte) ([]byte, e
 			return nil, err
 		}
 		ed := EpochData{
-			AtxIDs: atxids,
+			AtxIDs: types.PtrSliceToSlice(atxids),
 		}
 		h.logger.With().Debug("serve: responded to epoch info request",
 			epoch, log.Context(ctx), log.Int("atx_count", len(ed.AtxIDs)))

--- a/fetch/handler_test.go
+++ b/fetch/handler_test.go
@@ -271,7 +271,7 @@ func newAtx(t *testing.T, published types.EpochID) *types.ActivationTx {
 		InnerActivationTxV1: wire.InnerActivationTxV1{
 			NIPostChallengeV1: wire.NIPostChallengeV1{
 				PublishEpoch: published,
-				PrevATXID:    types.RandomATXID(),
+				PrevATXID:    *types.RandomATXID(),
 			},
 			NumUnits: 2,
 			VRFNonce: &nonce,
@@ -306,7 +306,7 @@ func TestHandleEpochInfoReq(t *testing.T) {
 				for i := 0; i < 10; i++ {
 					vatx := newAtx(t, epoch)
 					require.NoError(t, atxs.Add(th.cdb, vatx))
-					expected.AtxIDs = append(expected.AtxIDs, vatx.ID())
+					expected.AtxIDs = append(expected.AtxIDs, *vatx.ID())
 				}
 			}
 
@@ -356,7 +356,7 @@ func testHandleEpochInfoReqWithQueryCache(
 		vatx := newAtx(t, epoch)
 		require.NoError(t, atxs.Add(th.cdb, vatx))
 		atxs.AtxAdded(th.cdb, vatx)
-		expected.AtxIDs = append(expected.AtxIDs, vatx.ID())
+		expected.AtxIDs = append(expected.AtxIDs, *vatx.ID())
 	}
 
 	qc := th.cdb.Executor.(interface{ QueryCount() int })
@@ -375,7 +375,7 @@ func testHandleEpochInfoReqWithQueryCache(
 	vatx := newAtx(t, epoch)
 	require.NoError(t, atxs.Add(th.cdb, vatx))
 	atxs.AtxAdded(th.cdb, vatx)
-	expected.AtxIDs = append(expected.AtxIDs, vatx.ID())
+	expected.AtxIDs = append(expected.AtxIDs, *vatx.ID())
 	require.Equal(t, 23, qc.QueryCount())
 
 	getInfo(th, epochBytes, &got)

--- a/fetch/mesh_data.go
+++ b/fetch/mesh_data.go
@@ -25,7 +25,7 @@ import (
 var errBadRequest = errors.New("invalid request")
 
 // GetAtxs gets the data for given atx IDs and validates them. returns an error if at least one ATX cannot be fetched.
-func (f *Fetch) GetAtxs(ctx context.Context, ids []types.ATXID, opts ...system.GetAtxOpt) error {
+func (f *Fetch) GetAtxs(ctx context.Context, ids []*types.ATXID, opts ...system.GetAtxOpt) error {
 	if len(ids) == 0 {
 		return nil
 	}
@@ -37,7 +37,7 @@ func (f *Fetch) GetAtxs(ctx context.Context, ids []types.ATXID, opts ...system.G
 
 	f.logger.WithContext(ctx).With().
 		Debug("requesting atxs from peer", log.Int("num_atxs", len(ids)), log.Bool("limiting", !options.LimitingOff))
-	hashes := types.ATXIDsToHashes(ids)
+	hashes := types.ATXIDsToHashes(types.PtrSliceToSlice(ids))
 	if options.LimitingOff {
 		return f.getHashes(ctx, hashes, datastore.ATXDB, f.validators.atx.HandleMessage)
 	}

--- a/fetch/mesh_data_test.go
+++ b/fetch/mesh_data_test.go
@@ -326,7 +326,7 @@ func genLayerProposal(
 			Ballot: types.Ballot{
 				InnerBallot: types.InnerBallot{
 					Layer: layerID,
-					AtxID: types.RandomATXID(),
+					AtxID: *types.RandomATXID(),
 					EpochData: &types.EpochData{
 						Beacon: types.RandomBeacon(),
 					},
@@ -587,7 +587,7 @@ func TestFetch_GetLayerData(t *testing.T) {
 func generateEpochData(t *testing.T) (*EpochData, []byte) {
 	t.Helper()
 	ed := &EpochData{
-		AtxIDs: types.RandomActiveSet(11),
+		AtxIDs: types.PtrSliceToSlice(types.RandomActiveSet(11)),
 	}
 	data, err := codec.Encode(ed)
 	require.NoError(t, err)
@@ -899,14 +899,14 @@ func Test_GetAtxsLimiting(t *testing.T) {
 			var atxIds []types.ATXID
 			for i := 0; i < totalRequests; i++ {
 				id := types.RandomATXID()
-				atxIds = append(atxIds, id)
+				atxIds = append(atxIds, *id)
 				atxValidatorMock.EXPECT().HandleMessage(gomock.Any(), id.Hash32(), mesh.Hosts()[1].ID(), gomock.Any())
 			}
 
 			if withLimiting {
-				err = f.GetAtxs(context.Background(), atxIds)
+				err = f.GetAtxs(context.Background(), types.SliceToPtrSlice(atxIds))
 			} else {
-				err = f.GetAtxs(context.Background(), atxIds, system.WithoutLimiting())
+				err = f.GetAtxs(context.Background(), types.SliceToPtrSlice(atxIds), system.WithoutLimiting())
 			}
 			require.NoError(t, err)
 		})

--- a/fetch/p2p_test.go
+++ b/fetch/p2p_test.go
@@ -88,6 +88,7 @@ func createP2PFetch(
 	sqlCache bool,
 	opts ...Option,
 ) (*testP2PFetch, context.Context) {
+	t.Helper()
 	lg := logtest.New(t)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
 	t.Cleanup(cancel)
@@ -167,7 +168,7 @@ func (tpf *testP2PFetch) createATXs(epoch types.EpochID) []types.ATXID {
 	for i := range atxIDs {
 		atx := newAtx(tpf.t, epoch)
 		require.NoError(tpf.t, atxs.Add(tpf.serverCDB, atx))
-		atxIDs[i] = atx.ID()
+		atxIDs[i] = *atx.ID()
 	}
 	return atxIDs
 }
@@ -202,6 +203,7 @@ func forStreaming(
 	sqlCache bool,
 	toCall func(t *testing.T, ctx context.Context, tpf *testP2PFetch, errStr string),
 ) {
+	t.Helper()
 	for _, tc := range []struct {
 		name            string
 		clientStreaming bool
@@ -242,6 +244,7 @@ func forStreamingCachedUncached(
 	errStr string,
 	toCall func(t *testing.T, ctx context.Context, tpf *testP2PFetch, errStr string),
 ) {
+	t.Helper()
 	for _, tc := range []struct {
 		name     string
 		sqlCache bool
@@ -350,9 +353,9 @@ func TestP2PGetATXs(t *testing.T) {
 			tpf.verifyGetHash(
 				func() error {
 					return tpf.clientFetch.GetAtxs(
-						context.Background(), []types.ATXID{atx.ID()})
+						context.Background(), []*types.ATXID{atx.ID()})
 				},
-				errStr, "atx", "hs/1", types.Hash32(atx.ID()), atx.ID().Bytes(),
+				errStr, "atx", "hs/1", types.Hash32(*atx.ID()), atx.ID().Bytes(),
 				atx.AtxBlob.Blob)
 		})
 }

--- a/hare3/hare.go
+++ b/hare3/hare.go
@@ -557,13 +557,13 @@ func (h *Hare) selectProposals(session *session) []types.ProposalID {
 			h.log.Error("proposal with same atx added several times in the recorded set",
 				zap.Int("n", n),
 				zap.Stringer("id", p.ID()),
-				zap.Stringer("atxid", p.AtxID),
+				zap.Stringer("atxid", &p.AtxID),
 			)
 			continue
 		}
-		header := h.atxsdata.Get(target, p.AtxID)
+		header := h.atxsdata.Get(target, &p.AtxID)
 		if header == nil {
-			h.log.Error("atx is not loaded", zap.Stringer("atxid", p.AtxID))
+			h.log.Error("atx is not loaded", zap.Stringer("atxid", &p.AtxID))
 			return []types.ProposalID{}
 		}
 		if header.BaseHeight >= min.Height {

--- a/malfeasance/wire/malfeasance_test.go
+++ b/malfeasance/wire/malfeasance_test.go
@@ -224,7 +224,7 @@ func TestCodec_InvalidPrevATX(t *testing.T) {
 		InnerActivationTxV1: awire.InnerActivationTxV1{
 			NIPostChallengeV1: awire.NIPostChallengeV1{
 				PublishEpoch: lid.GetEpoch() - 1,
-				PrevATXID:    prevATXID,
+				PrevATXID:    *prevATXID,
 			},
 			Coinbase: types.Address{1, 2, 3},
 			NumUnits: 10,
@@ -236,7 +236,7 @@ func TestCodec_InvalidPrevATX(t *testing.T) {
 		InnerActivationTxV1: awire.InnerActivationTxV1{
 			NIPostChallengeV1: awire.NIPostChallengeV1{
 				PublishEpoch: lid.GetEpoch(),
-				PrevATXID:    prevATXID,
+				PrevATXID:    *prevATXID,
 			},
 			Coinbase: types.Address{1, 2, 3},
 			NumUnits: 10,

--- a/mesh/executor_test.go
+++ b/mesh/executor_test.go
@@ -66,7 +66,7 @@ func makeResults(lid types.LayerID, txs ...types.Transaction) []types.Transactio
 	return results
 }
 
-func (t *testExecutor) createATX(epoch types.EpochID, cb types.Address) (types.ATXID, types.NodeID) {
+func (t *testExecutor) createATX(epoch types.EpochID, cb types.Address) (*types.ATXID, types.NodeID) {
 	sig, err := signing.NewEdSigner()
 	require.NoError(t.tb, err)
 	atx := types.NewActivationTx(

--- a/miner/active_set_generator_test.go
+++ b/miner/active_set_generator_test.go
@@ -277,7 +277,7 @@ func TestActiveSetGenerate(t *testing.T) {
 				require.NoError(t, activesets.Add(tester.db, types.ATXIDList(ac.Set).Hash(), ac))
 			}
 			for _, fallback := range tc.fallbacks {
-				tester.gen.updateFallback(fallback.Epoch, fallback.Set)
+				tester.gen.updateFallback(fallback.Epoch, types.SliceToPtrSlice(fallback.Set))
 			}
 			if tc.epochStart != nil {
 				tester.clock.EXPECT().LayerToTime(tc.target.FirstLayer()).Return(*tc.epochStart)
@@ -292,7 +292,7 @@ func TestActiveSetGenerate(t *testing.T) {
 			if tc.expect != nil {
 				require.Equal(t, tc.expect.id, id)
 				require.Equal(t, tc.expect.weight, setWeight)
-				require.Equal(t, tc.expect.set, set)
+				require.Equal(t, tc.expect.set, types.PtrSliceToSlice(set))
 			}
 		})
 	}
@@ -314,7 +314,7 @@ func TestActiveSetEnsure(t *testing.T) {
 	terminated := make(chan struct{})
 	expected := []types.ATXID{{1}}
 	// verify that it tries compute activeset for configured number of tries
-	tester.gen.updateFallback(target, expected)
+	tester.gen.updateFallback(target, types.SliceToPtrSlice(expected))
 	tester.clock.EXPECT().CurrentLayer().Return(0).Times(tries)
 	go func() {
 		tester.gen.ensure(ctx, target)
@@ -349,6 +349,6 @@ func TestActiveSetEnsure(t *testing.T) {
 	id, weight, set, err := activeset.Get(tester.localdb, activeset.Tortoise, target)
 	require.NoError(t, err)
 	require.Equal(t, types.ATXIDList(expected).Hash(), id)
-	require.Equal(t, expected, set)
+	require.Equal(t, expected, types.PtrSliceToSlice(set))
 	require.Equal(t, 1*ticks, int(weight))
 }

--- a/miner/proposal_builder_test.go
+++ b/miner/proposal_builder_test.go
@@ -76,7 +76,7 @@ func gatx(
 		TickCount:    ticks,
 		SmesherID:    smesher,
 	}
-	atx.SetID(id)
+	atx.SetID(&id)
 	atx.SetReceived(time.Time{}.Add(1))
 	for _, opt := range opts {
 		opt(atx)
@@ -108,7 +108,7 @@ func gblock(lid types.LayerID, atxs ...types.ATXID) *types.Block {
 	block := types.Block{}
 	block.LayerIndex = lid
 	for _, atx := range atxs {
-		block.Rewards = append(block.Rewards, types.AnyReward{AtxID: atx})
+		block.Rewards = append(block.Rewards, types.AnyReward{AtxID: &atx})
 	}
 	block.Initialize()
 	return &block
@@ -804,7 +804,7 @@ func TestBuild(t *testing.T) {
 						)
 					}
 					for _, activeSet := range step.fallbackActiveSets {
-						builder.UpdateActiveSet(activeSet.epoch, activeSet.atxs)
+						builder.UpdateActiveSet(activeSet.epoch, types.SliceToPtrSlice(activeSet.atxs))
 					}
 				}
 				{

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -1100,7 +1100,7 @@ func TestAdminEvents_MultiSmesher(t *testing.T) {
 			logger.Zap(),
 			app.db,
 			app.atxsdata,
-			types.ATXID(app.Config.Genesis.GoldenATX()),
+			types.AtxIdFromHash32(app.Config.Genesis.GoldenATX()),
 			app.syncer,
 			app.validator,
 		)

--- a/proposals/eligibility_validator.go
+++ b/proposals/eligibility_validator.go
@@ -70,7 +70,7 @@ func (v *Validator) CheckEligibility(ctx context.Context, ballot *types.Ballot, 
 			ballot.ID(),
 		)
 	}
-	atx := v.atxsdata.Get(ballot.Layer.GetEpoch(), ballot.AtxID)
+	atx := v.atxsdata.Get(ballot.Layer.GetEpoch(), &ballot.AtxID)
 	if atx == nil {
 		return fmt.Errorf(
 			"failed to load atx from cache with epoch %d %s",
@@ -189,7 +189,7 @@ func (v *Validator) validateSecondary(ballot *types.Ballot) (*types.EpochData, e
 	if refdata == nil {
 		return nil, fmt.Errorf("ref ballot is missing %v", ballot.RefBallot)
 	}
-	if refdata.ATXID != ballot.AtxID {
+	if !refdata.ATXID.Equal(&ballot.AtxID) {
 		return nil, fmt.Errorf(
 			"%w: ballot (%v/%v) should be sharing atx with a reference ballot (%v/%v)",
 			pubsub.ErrValidationReject,

--- a/proposals/eligibility_validator_test.go
+++ b/proposals/eligibility_validator_test.go
@@ -28,7 +28,7 @@ func gatx(
 		TickCount:    100,
 		SmesherID:    smesher,
 	}
-	atx.SetID(id)
+	atx.SetID(&id)
 	atx.SetReceived(time.Time{}.Add(1))
 	return atx
 }
@@ -46,7 +46,7 @@ func gatxZeroHeight(
 		VRFNonce:     nonce,
 		SmesherID:    smesher,
 	}
-	atx.SetID(id)
+	atx.SetID(&id)
 	atx.SetReceived(time.Time{}.Add(1))
 	return atx
 }
@@ -58,7 +58,7 @@ func gatxNilNonce(id types.ATXID, epoch types.EpochID, smesher types.NodeID, uni
 		TickCount:    100,
 		SmesherID:    smesher,
 	}
-	atx.SetID(id)
+	atx.SetID(&id)
 	atx.SetReceived(time.Time{}.Add(1))
 	return atx
 }
@@ -545,7 +545,7 @@ func TestEligibilityValidator(t *testing.T) {
 				return &tortoise.BallotData{
 					ID:           ballot.ID(),
 					Layer:        ballot.Layer,
-					ATXID:        ballot.AtxID,
+					ATXID:        &ballot.AtxID,
 					Smesher:      ballot.SmesherID,
 					Beacon:       ballot.EpochData.Beacon,
 					Eligiblities: ballot.EpochData.EligibilityCount,

--- a/proposals/store/store_test.go
+++ b/proposals/store/store_test.go
@@ -16,7 +16,7 @@ func generateProposal(layer types.LayerID) *types.Proposal {
 	proposal.EpochData = &types.EpochData{
 		Beacon: types.RandomBeacon(),
 	}
-	proposal.AtxID = types.RandomATXID()
+	proposal.AtxID = *types.RandomATXID()
 	proposal.SmesherID = types.RandomNodeID()
 	proposal.Ballot.SmesherID = proposal.SmesherID
 	proposal.SetID(types.RandomProposalID())

--- a/sql/atxs/atxs_test.go
+++ b/sql/atxs/atxs_test.go
@@ -49,7 +49,7 @@ func TestGet(t *testing.T) {
 		require.Equal(t, want, got)
 	}
 
-	_, err := atxs.Get(db, types.ATXID(types.CalcHash32([]byte("0"))))
+	_, err := atxs.Get(db, types.AtxIdFromHash32(types.CalcHash32([]byte("0"))))
 	require.ErrorIs(t, err, sql.ErrNotFound)
 }
 
@@ -67,7 +67,7 @@ func TestAll(t *testing.T) {
 	var expected []types.ATXID
 	for _, atx := range atxList {
 		require.NoError(t, atxs.Add(db, atx))
-		expected = append(expected, atx.ID())
+		expected = append(expected, *atx.ID())
 	}
 
 	all, err := atxs.All(db)
@@ -96,7 +96,7 @@ func TestHasID(t *testing.T) {
 		require.True(t, has)
 	}
 
-	has, err := atxs.Has(db, types.ATXID(types.CalcHash32([]byte("0"))))
+	has, err := atxs.Has(db, types.AtxIdFromHash32(types.CalcHash32([]byte("0"))))
 	require.NoError(t, err)
 	require.False(t, has)
 }
@@ -185,16 +185,16 @@ func TestLatestN(t *testing.T) {
 			n:    3,
 			expected: map[types.NodeID]map[types.ATXID]struct{}{
 				sig1.NodeID(): {
-					atx1.ID(): struct{}{},
-					atx2.ID(): struct{}{},
+					*atx1.ID(): struct{}{},
+					*atx2.ID(): struct{}{},
 				},
 				sig2.NodeID(): {
-					atx3.ID(): struct{}{},
-					atx4.ID(): struct{}{},
-					atx5.ID(): struct{}{},
+					*atx3.ID(): struct{}{},
+					*atx4.ID(): struct{}{},
+					*atx5.ID(): struct{}{},
 				},
 				sig3.NodeID(): {
-					atx6.ID(): struct{}{},
+					*atx6.ID(): struct{}{},
 				},
 			},
 		},
@@ -203,15 +203,15 @@ func TestLatestN(t *testing.T) {
 			n:    2,
 			expected: map[types.NodeID]map[types.ATXID]struct{}{
 				sig1.NodeID(): {
-					atx1.ID(): struct{}{},
-					atx2.ID(): struct{}{},
+					*atx1.ID(): struct{}{},
+					*atx2.ID(): struct{}{},
 				},
 				sig2.NodeID(): {
-					atx4.ID(): struct{}{},
-					atx5.ID(): struct{}{},
+					*atx4.ID(): struct{}{},
+					*atx5.ID(): struct{}{},
 				},
 				sig3.NodeID(): {
-					atx6.ID(): struct{}{},
+					*atx6.ID(): struct{}{},
 				},
 			},
 		},
@@ -220,13 +220,13 @@ func TestLatestN(t *testing.T) {
 			n:    1,
 			expected: map[types.NodeID]map[types.ATXID]struct{}{
 				sig1.NodeID(): {
-					atx2.ID(): struct{}{},
+					*atx2.ID(): struct{}{},
 				},
 				sig2.NodeID(): {
-					atx5.ID(): struct{}{},
+					*atx5.ID(): struct{}{},
 				},
 				sig3.NodeID(): {
-					atx6.ID(): struct{}{},
+					*atx6.ID(): struct{}{},
 				},
 			},
 		},
@@ -235,7 +235,7 @@ func TestLatestN(t *testing.T) {
 			got, err := atxs.LatestN(db, tc.n)
 			require.NoError(t, err)
 			for _, catx := range got {
-				delete(tc.expected[catx.SmesherID], catx.ID)
+				delete(tc.expected[catx.SmesherID], *catx.ID)
 				if len(tc.expected[catx.SmesherID]) == 0 {
 					delete(tc.expected, catx.SmesherID)
 				}
@@ -380,7 +380,7 @@ func TestGetIDsByEpoch(t *testing.T) {
 
 	ids1, err := atxs.GetIDsByEpoch(ctx, db, e1)
 	require.NoError(t, err)
-	require.ElementsMatch(t, []types.ATXID{atx1.ID()}, ids1)
+	require.ElementsMatch(t, []*types.ATXID{atx1.ID()}, ids1)
 
 	ids2, err := atxs.GetIDsByEpoch(ctx, db, e2)
 	require.NoError(t, err)
@@ -389,7 +389,7 @@ func TestGetIDsByEpoch(t *testing.T) {
 
 	ids3, err := atxs.GetIDsByEpoch(ctx, db, e3)
 	require.NoError(t, err)
-	require.ElementsMatch(t, []types.ATXID{atx4.ID()}, ids3)
+	require.ElementsMatch(t, []*types.ATXID{atx4.ID()}, ids3)
 }
 
 func TestGetIDsByEpochCached(t *testing.T) {
@@ -423,7 +423,7 @@ func TestGetIDsByEpochCached(t *testing.T) {
 	for i := 0; i < 3; i++ {
 		ids1, err := atxs.GetIDsByEpoch(ctx, db, e1)
 		require.NoError(t, err)
-		require.ElementsMatch(t, []types.ATXID{atx1.ID()}, ids1)
+		require.ElementsMatch(t, []*types.ATXID{atx1.ID()}, ids1)
 		require.Equal(t, 9, db.QueryCount())
 	}
 
@@ -438,7 +438,7 @@ func TestGetIDsByEpochCached(t *testing.T) {
 	for i := 0; i < 3; i++ {
 		ids3, err := atxs.GetIDsByEpoch(ctx, db, e3)
 		require.NoError(t, err)
-		require.ElementsMatch(t, []types.ATXID{atx4.ID()}, ids3)
+		require.ElementsMatch(t, []*types.ATXID{atx4.ID()}, ids3)
 		require.Equal(t, 11, db.QueryCount())
 	}
 
@@ -451,7 +451,7 @@ func TestGetIDsByEpochCached(t *testing.T) {
 
 	ids3, err := atxs.GetIDsByEpoch(ctx, db, e3)
 	require.NoError(t, err)
-	require.ElementsMatch(t, []types.ATXID{atx4.ID(), atx5.ID()}, ids3)
+	require.ElementsMatch(t, []*types.ATXID{atx4.ID(), atx5.ID()}, ids3)
 	require.Equal(t, 13, db.QueryCount()) // not incremented after Add
 
 	require.Error(t, db.WithTx(context.Background(), func(tx *sql.Tx) error {
@@ -462,7 +462,7 @@ func TestGetIDsByEpochCached(t *testing.T) {
 	// atx6 should not be in the cache
 	ids4, err := atxs.GetIDsByEpoch(ctx, db, e3)
 	require.NoError(t, err)
-	require.ElementsMatch(t, []types.ATXID{atx4.ID(), atx5.ID()}, ids4)
+	require.ElementsMatch(t, []*types.ATXID{atx4.ID(), atx5.ID()}, ids4)
 	require.Equal(t, 16, db.QueryCount()) // not incremented after Add
 }
 
@@ -477,7 +477,7 @@ func Test_IterateAtxsWithMalfeasance(t *testing.T) {
 		atx := newAtx(t, sig, withPublishEpoch(types.EpochID(i/4)))
 		require.NoError(t, atxs.Add(db, atx))
 		malicious := (i % 2) == 0
-		m[atx.ID()] = malicious
+		m[*atx.ID()] = malicious
 		if malicious {
 			require.NoError(t, identities.SetMalicious(db, sig.NodeID(), []byte("bad"), time.Now()))
 		}
@@ -485,9 +485,9 @@ func Test_IterateAtxsWithMalfeasance(t *testing.T) {
 
 	n := 0
 	err := atxs.IterateAtxsWithMalfeasance(db, e1, func(atx *types.ActivationTx, malicious bool) bool {
-		require.Contains(t, m, atx.ID())
-		require.Equal(t, m[atx.ID()], malicious)
-		delete(m, atx.ID())
+		require.Contains(t, m, *atx.ID())
+		require.Equal(t, m[*atx.ID()], malicious)
+		delete(m, *atx.ID())
 		n++
 		return n < 2
 	})
@@ -507,7 +507,7 @@ func Test_IterateAtxIdsWithMalfeasance(t *testing.T) {
 		atx := newAtx(t, sig, withPublishEpoch(types.EpochID(i/4)))
 		require.NoError(t, atxs.Add(db, atx))
 		malicious := (i % 2) == 0
-		m[atx.ID()] = malicious
+		m[*atx.ID()] = malicious
 		if malicious {
 			require.NoError(t, identities.SetMalicious(db, sig.NodeID(), []byte("bad"), time.Now()))
 		}
@@ -536,7 +536,7 @@ func TestVRFNonce(t *testing.T) {
 	atx1 := newAtx(t, sig, withPublishEpoch(20), withNonce(333))
 	require.NoError(t, atxs.Add(db, atx1))
 
-	atx2 := newAtx(t, sig, withPublishEpoch(50), withNonce(777), withPrevATXID(atx1.ID()))
+	atx2 := newAtx(t, sig, withPublishEpoch(50), withNonce(777), withPrevATXID(*atx1.ID()))
 	require.NoError(t, atxs.Add(db, atx2))
 
 	// Act & Assert
@@ -754,7 +754,7 @@ func TestCheckpointATX(t *testing.T) {
 	catx := &atxs.CheckpointAtx{
 		ID:             atx.ID(),
 		Epoch:          atx.PublishEpoch,
-		CommitmentATX:  types.ATXID{1, 2, 3},
+		CommitmentATX:  &types.ATXID{1, 2, 3},
 		VRFNonce:       types.VRFPostIndex(119),
 		NumUnits:       atx.NumUnits,
 		BaseTickHeight: 1000,
@@ -795,7 +795,7 @@ func TestAdd(t *testing.T) {
 	db := sql.InMemory()
 
 	nonExistingATXID := types.ATXID(types.CalcHash32([]byte("0")))
-	_, err := atxs.Get(db, nonExistingATXID)
+	_, err := atxs.Get(db, &nonExistingATXID)
 	require.ErrorIs(t, err, sql.ErrNotFound)
 
 	sig, err := signing.NewEdSigner()
@@ -842,7 +842,7 @@ func newAtx(t testing.TB, signer *signing.EdSigner, opts ...createAtxOpt) *types
 	watx := &wire.ActivationTxV1{
 		InnerActivationTxV1: wire.InnerActivationTxV1{
 			NIPostChallengeV1: wire.NIPostChallengeV1{
-				PrevATXID: types.RandomATXID(),
+				PrevATXID: *types.RandomATXID(),
 			},
 			NumUnits: 2,
 			VRFNonce: &nonce,
@@ -885,7 +885,7 @@ func createAtx(tb testing.TB, db *sql.Database, hdr header) (types.ATXID, *signi
 		require.NoError(tb, identities.SetMalicious(db, sig.NodeID(), []byte("bad"), time.Now()))
 	}
 
-	return full.ID(), sig
+	return *full.ID(), sig
 }
 
 func TestGetIDWithMaxHeight(t *testing.T) {
@@ -996,14 +996,14 @@ func TestGetIDWithMaxHeight(t *testing.T) {
 			if tc.pref > 0 {
 				pref = sigs[tc.pref].NodeID()
 			}
-			rst, err := atxs.GetIDWithMaxHeight(db, pref, func(id types.ATXID) bool {
-				_, ok := filtered[id]
+			rst, err := atxs.GetIDWithMaxHeight(db, pref, func(id *types.ATXID) bool {
+				_, ok := filtered[*id]
 				return !ok
 			})
 			if len(tc.atxs) == 0 || tc.expect < 0 {
 				require.ErrorIs(t, err, sql.ErrNotFound)
 			} else {
-				require.Equal(t, ids[tc.expect], rst)
+				require.Equal(t, ids[tc.expect], *rst)
 			}
 		})
 	}
@@ -1028,7 +1028,7 @@ func TestLatest(t *testing.T) {
 					TickCount:    1,
 				}
 				full.SetReceived(time.Now())
-				full.SetID(types.ATXID{byte(i)})
+				full.SetID(&types.ATXID{byte(i)})
 				require.NoError(t, atxs.Add(db, full))
 			}
 			latest, err := atxs.LatestEpoch(db)
@@ -1046,8 +1046,8 @@ func Test_PrevATXCollisions(t *testing.T) {
 	// create two ATXs with the same PrevATXID
 	prevATXID := types.RandomATXID()
 
-	atx1 := newAtx(t, sig, withPublishEpoch(1), withPrevATXID(prevATXID))
-	atx2 := newAtx(t, sig, withPublishEpoch(2), withPrevATXID(prevATXID))
+	atx1 := newAtx(t, sig, withPublishEpoch(1), withPrevATXID(*prevATXID))
+	atx2 := newAtx(t, sig, withPublishEpoch(2), withPrevATXID(*prevATXID))
 
 	require.NoError(t, atxs.Add(db, atx1))
 	require.NoError(t, atxs.Add(db, atx2))
@@ -1073,7 +1073,7 @@ func Test_PrevATXCollisions(t *testing.T) {
 
 		atx2 := newAtx(t, otherSig,
 			withPublishEpoch(types.EpochID(i+1)),
-			withPrevATXID(atx.ID()),
+			withPrevATXID(*atx.ID()),
 		)
 		require.NoError(t, atxs.Add(db, atx2))
 	}
@@ -1085,7 +1085,7 @@ func Test_PrevATXCollisions(t *testing.T) {
 
 	require.Equal(t, sig.NodeID(), got[0].NodeID1)
 	require.Equal(t, sig.NodeID(), got[0].NodeID2)
-	require.ElementsMatch(t, []types.ATXID{atx1.ID(), atx2.ID()}, []types.ATXID{got[0].ATX1, got[0].ATX2})
+	require.ElementsMatch(t, []types.ATXID{*atx1.ID(), *atx2.ID()}, []types.ATXID{*got[0].ATX1, *got[0].ATX2})
 }
 
 func TestCoinbase(t *testing.T) {

--- a/sql/atxsync/atxsync.go
+++ b/sql/atxsync/atxsync.go
@@ -14,9 +14,9 @@ func GetSyncState(db sql.Executor, epoch types.EpochID) (map[types.ATXID]int, er
 		func(stmt *sql.Statement) {
 			stmt.BindInt64(1, int64(epoch))
 		}, func(stmt *sql.Statement) bool {
-			var id types.ATXID
+			id := new(types.ATXID)
 			stmt.ColumnBytes(0, id[:])
-			states[id] = int(stmt.ColumnInt64(1))
+			states[*id] = int(stmt.ColumnInt64(1))
 			return true
 		})
 	if err != nil {

--- a/sql/ballots/ballots.go
+++ b/sql/ballots/ballots.go
@@ -213,15 +213,15 @@ func LatestLayer(db sql.Executor) (types.LayerID, error) {
 	return lid, nil
 }
 
-func FirstInEpoch(db sql.Executor, atx types.ATXID, epoch types.EpochID) (*types.Ballot, error) {
+func FirstInEpoch(db sql.Executor, atx *types.ATXID, epoch types.EpochID) (*types.Ballot, error) {
 	return inEpoch(db, atx, epoch, "asc")
 }
 
-func LastInEpoch(db sql.Executor, atx types.ATXID, epoch types.EpochID) (*types.Ballot, error) {
+func LastInEpoch(db sql.Executor, atx *types.ATXID, epoch types.EpochID) (*types.Ballot, error) {
 	return inEpoch(db, atx, epoch, "desc")
 }
 
-func inEpoch(db sql.Executor, atx types.ATXID, epoch types.EpochID, order string) (*types.Ballot, error) {
+func inEpoch(db sql.Executor, atx *types.ATXID, epoch types.EpochID, order string) (*types.Ballot, error) {
 	var (
 		bid     types.BallotID
 		ballot  types.Ballot

--- a/sql/ballots/ballots_test.go
+++ b/sql/ballots/ballots_test.go
@@ -147,12 +147,12 @@ func TestLayerBallotBySmesher(t *testing.T) {
 func newAtx(signer *signing.EdSigner, layerID types.LayerID) *types.ActivationTx {
 	atx := &types.ActivationTx{
 		PublishEpoch: layerID.GetEpoch(),
-		PrevATXID:    types.RandomATXID(),
+		PrevATXID:    *types.RandomATXID(),
 		NumUnits:     2,
 		TickCount:    1,
 		SmesherID:    signer.NodeID(),
 	}
-	atx.SetID(types.ATXID{1, 2, 3})
+	atx.SetID(&types.ATXID{1, 2, 3})
 	atx.SetReceived(time.Now().Local())
 	return atx
 }
@@ -170,20 +170,20 @@ func TestFirstInEpoch(t *testing.T) {
 	require.Nil(t, got)
 
 	b1 := types.NewExistingBallot(types.BallotID{1}, types.EmptyEdSignature, sig.NodeID(), lid)
-	b1.AtxID = atx.ID()
+	b1.AtxID = *atx.ID()
 	require.NoError(t, Add(db, &b1))
 	b2 := types.NewExistingBallot(types.BallotID{2}, types.EmptyEdSignature, sig.NodeID(), lid)
-	b2.AtxID = atx.ID()
+	b2.AtxID = *atx.ID()
 	b2.EpochData = &types.EpochData{}
 	require.NoError(t, Add(db, &b2))
 	b3 := types.NewExistingBallot(types.BallotID{3}, types.EmptyEdSignature, sig.NodeID(), lid.Add(1))
-	b3.AtxID = atx.ID()
+	b3.AtxID = *atx.ID()
 	require.NoError(t, Add(db, &b3))
 
 	got, err = FirstInEpoch(db, atx.ID(), 2)
 	require.NoError(t, err)
 	require.False(t, got.IsMalicious())
-	require.Equal(t, got.AtxID, atx.ID())
+	require.Equal(t, got.AtxID, *atx.ID())
 	require.Equal(t, got.ID(), b1.ID())
 
 	last, err := LastInEpoch(db, atx.ID(), 2)
@@ -194,7 +194,7 @@ func TestFirstInEpoch(t *testing.T) {
 	got, err = FirstInEpoch(db, atx.ID(), 2)
 	require.NoError(t, err)
 	require.True(t, got.IsMalicious())
-	require.Equal(t, got.AtxID, atx.ID())
+	require.Equal(t, got.AtxID, *atx.ID())
 	require.Equal(t, got.ID(), b1.ID())
 }
 

--- a/sql/identities/identities_test.go
+++ b/sql/identities/identities_test.go
@@ -131,7 +131,7 @@ func TestMarried(t *testing.T) {
 		require.False(t, married)
 
 		atx := types.RandomATXID()
-		require.NoError(t, SetMarriage(db, id, atx))
+		require.NoError(t, SetMarriage(db, id, *atx))
 
 		married, err = Married(db, id)
 		require.NoError(t, err)
@@ -149,7 +149,7 @@ func TestMarried(t *testing.T) {
 		require.NoError(t, err)
 		require.False(t, married)
 
-		require.NoError(t, SetMarriage(db, id, types.RandomATXID()))
+		require.NoError(t, SetMarriage(db, id, *types.RandomATXID()))
 
 		married, err = Married(db, id)
 		require.NoError(t, err)
@@ -170,7 +170,7 @@ func TestEquivocationSet(t *testing.T) {
 			types.RandomNodeID(),
 		}
 		for _, id := range ids {
-			require.NoError(t, SetMarriage(db, id, atx))
+			require.NoError(t, SetMarriage(db, id, *atx))
 		}
 
 		for _, id := range ids {
@@ -199,7 +199,7 @@ func TestEquivocationSet(t *testing.T) {
 			types.RandomNodeID(),
 		}
 		for _, id := range ids {
-			require.NoError(t, SetMarriage(db, id, atx))
+			require.NoError(t, SetMarriage(db, id, *atx))
 		}
 
 		for _, id := range ids {
@@ -210,7 +210,7 @@ func TestEquivocationSet(t *testing.T) {
 
 		// try to marry via another random ATX
 		// the set should remain intact
-		require.NoError(t, SetMarriage(db, ids[0], types.RandomATXID()))
+		require.NoError(t, SetMarriage(db, ids[0], *types.RandomATXID()))
 		for _, id := range ids {
 			set, err := EquivocationSet(db, id)
 			require.NoError(t, err)
@@ -221,7 +221,7 @@ func TestEquivocationSet(t *testing.T) {
 		db := sql.InMemory()
 		atx := types.RandomATXID()
 		id := types.RandomNodeID()
-		require.NoError(t, SetMarriage(db, id, atx))
+		require.NoError(t, SetMarriage(db, id, *atx))
 
 		malicious, err := IsMalicious(db, id)
 		require.NoError(t, err)
@@ -244,7 +244,7 @@ func TestEquivocationSet(t *testing.T) {
 			types.RandomNodeID(),
 		}
 		for _, id := range ids {
-			require.NoError(t, SetMarriage(db, id, atx))
+			require.NoError(t, SetMarriage(db, id, *atx))
 		}
 
 		require.NoError(t, SetMalicious(db, ids[0], []byte("proof"), time.Now()))

--- a/sql/localsql/activeset/activeset.go
+++ b/sql/localsql/activeset/activeset.go
@@ -52,7 +52,7 @@ func Add(
 	return nil
 }
 
-func Get(db sql.Executor, kind Kind, epoch types.EpochID) (types.Hash32, uint64, []types.ATXID, error) {
+func Get(db sql.Executor, kind Kind, epoch types.EpochID) (types.Hash32, uint64, []*types.ATXID, error) {
 	var (
 		id     types.Hash32
 		weight uint64
@@ -79,5 +79,9 @@ func Get(db sql.Executor, kind Kind, epoch types.EpochID) (types.Hash32, uint64,
 	} else if rows == 0 {
 		return id, 0, nil, fmt.Errorf("%w: activeset %v for epoch %d", sql.ErrNotFound, kind, epoch)
 	}
-	return id, weight, set, nil
+	setSlice := make([]*types.ATXID, 0, len(set))
+	for _, s := range set {
+		setSlice = append(setSlice, &s)
+	}
+	return id, weight, setSlice, nil
 }

--- a/sql/localsql/activeset/activeset_test.go
+++ b/sql/localsql/activeset/activeset_test.go
@@ -39,7 +39,7 @@ func TestGet(t *testing.T) {
 	require.NoError(t, err)
 	require.EqualValues(t, expectId, id)
 	require.Equal(t, expectWeight, weight)
-	require.Equal(t, expectSet, set)
+	require.Equal(t, expectSet, types.PtrSliceToSlice(set))
 }
 
 func TestLarge(t *testing.T) {
@@ -48,5 +48,5 @@ func TestLarge(t *testing.T) {
 	require.NoError(t, Add(db, Tortoise, 1, types.Hash32{1}, 10, expect))
 	_, _, set, err := Get(db, Tortoise, 1)
 	require.NoError(t, err)
-	require.Equal(t, expect, set)
+	require.Equal(t, expect, types.PtrSliceToSlice(set))
 }

--- a/sql/localsql/nipost/challenge_test.go
+++ b/sql/localsql/nipost/challenge_test.go
@@ -21,9 +21,9 @@ func Test_AddChallenge(t *testing.T) {
 			ch: &types.NIPostChallenge{
 				PublishEpoch:   4,
 				Sequence:       0,
-				PrevATXID:      types.RandomATXID(),
-				PositioningATX: types.RandomATXID(),
-				CommitmentATX:  &commitmentATX,
+				PrevATXID:      *types.RandomATXID(),
+				PositioningATX: *types.RandomATXID(),
+				CommitmentATX:  commitmentATX,
 				InitialPost:    &types.Post{Nonce: 1, Indices: []byte{1, 2, 3}, Pow: 1},
 			},
 		},
@@ -32,8 +32,8 @@ func Test_AddChallenge(t *testing.T) {
 			ch: &types.NIPostChallenge{
 				PublishEpoch:   77,
 				Sequence:       13,
-				PrevATXID:      types.RandomATXID(),
-				PositioningATX: types.RandomATXID(),
+				PrevATXID:      *types.RandomATXID(),
+				PositioningATX: *types.RandomATXID(),
 				CommitmentATX:  nil,
 				InitialPost:    nil,
 			},
@@ -69,16 +69,16 @@ func Test_AddChallenge_NoDuplicates(t *testing.T) {
 	ch1 := &types.NIPostChallenge{
 		PublishEpoch:   4,
 		Sequence:       2,
-		PrevATXID:      types.RandomATXID(),
-		PositioningATX: types.RandomATXID(),
+		PrevATXID:      *types.RandomATXID(),
+		PositioningATX: *types.RandomATXID(),
 		CommitmentATX:  nil,
 		InitialPost:    nil,
 	}
 	ch2 := &types.NIPostChallenge{
 		PublishEpoch:   4,
 		Sequence:       3,
-		PrevATXID:      types.RandomATXID(),
-		PositioningATX: types.RandomATXID(),
+		PrevATXID:      *types.RandomATXID(),
+		PositioningATX: *types.RandomATXID(),
 		CommitmentATX:  nil,
 		InitialPost:    nil,
 	}
@@ -103,9 +103,9 @@ func Test_UpdateChallenge(t *testing.T) {
 	ch := &types.NIPostChallenge{
 		PublishEpoch:   6,
 		Sequence:       0,
-		PrevATXID:      types.RandomATXID(),
-		PositioningATX: types.RandomATXID(),
-		CommitmentATX:  &commitmentATX,
+		PrevATXID:      *types.RandomATXID(),
+		PositioningATX: *types.RandomATXID(),
+		CommitmentATX:  commitmentATX,
 		InitialPost:    &types.Post{Nonce: 1, Indices: []byte{1, 2, 3}, Pow: 1},
 	}
 
@@ -131,9 +131,9 @@ func Test_UpdatePoetProofRef(t *testing.T) {
 	ch := &types.NIPostChallenge{
 		PublishEpoch:   6,
 		Sequence:       0,
-		PrevATXID:      types.RandomATXID(),
-		PositioningATX: types.RandomATXID(),
-		CommitmentATX:  &commitmentATX,
+		PrevATXID:      *types.RandomATXID(),
+		PositioningATX: *types.RandomATXID(),
+		CommitmentATX:  commitmentATX,
 		InitialPost:    &types.Post{Nonce: 1, Indices: []byte{1, 2, 3}, Pow: 1},
 	}
 
@@ -164,9 +164,9 @@ func Test_PoetProofRef_NotSet(t *testing.T) {
 	ch := &types.NIPostChallenge{
 		PublishEpoch:   6,
 		Sequence:       0,
-		PrevATXID:      types.RandomATXID(),
-		PositioningATX: types.RandomATXID(),
-		CommitmentATX:  &commitmentATX,
+		PrevATXID:      *types.RandomATXID(),
+		PositioningATX: *types.RandomATXID(),
+		CommitmentATX:  commitmentATX,
 		InitialPost:    &types.Post{Nonce: 1, Indices: []byte{1, 2, 3}, Pow: 1},
 	}
 

--- a/sql/localsql/nipost/post_test.go
+++ b/sql/localsql/nipost/post_test.go
@@ -21,7 +21,7 @@ func Test_AddPost(t *testing.T) {
 		Challenge: shared.Challenge([]byte{4, 5, 6}),
 
 		NumUnits:      2,
-		CommitmentATX: types.RandomATXID(),
+		CommitmentATX: *types.RandomATXID(),
 		VRFNonce:      3,
 	}
 	err := AddPost(db, nodeID, post)
@@ -44,7 +44,7 @@ func Test_AddPost_NoDuplicates(t *testing.T) {
 		Challenge: shared.ZeroChallenge,
 
 		NumUnits:      2,
-		CommitmentATX: types.RandomATXID(),
+		CommitmentATX: *types.RandomATXID(),
 		VRFNonce:      3,
 	}
 	err := AddPost(db, nodeID, post)
@@ -58,7 +58,7 @@ func Test_AddPost_NoDuplicates(t *testing.T) {
 		Challenge: shared.ZeroChallenge,
 
 		NumUnits:      4,
-		CommitmentATX: types.RandomATXID(),
+		CommitmentATX: *types.RandomATXID(),
 		VRFNonce:      5,
 	}
 	err = AddPost(db, nodeID, post2)

--- a/syncer/atxsync/atxsync.go
+++ b/syncer/atxsync/atxsync.go
@@ -14,8 +14,8 @@ import (
 	"github.com/spacemeshos/go-spacemesh/system"
 )
 
-func getMissing(db *sql.Database, set []types.ATXID) ([]types.ATXID, error) {
-	missing := []types.ATXID{}
+func getMissing(db *sql.Database, set []*types.ATXID) ([]*types.ATXID, error) {
+	missing := []*types.ATXID{}
 	for _, atx := range set {
 		exist, err := atxs.Has(db, atx)
 		if err != nil {
@@ -37,7 +37,7 @@ func Download(
 	logger *zap.Logger,
 	db *sql.Database,
 	fetcher system.AtxFetcher,
-	set []types.ATXID,
+	set []*types.ATXID,
 ) error {
 	total := len(set)
 	for {

--- a/syncer/atxsync/mocks/mocks.go
+++ b/syncer/atxsync/mocks/mocks.go
@@ -44,7 +44,7 @@ func (m *Mockfetcher) EXPECT() *MockfetcherMockRecorder {
 }
 
 // GetAtxs mocks base method.
-func (m *Mockfetcher) GetAtxs(arg0 context.Context, arg1 []types.ATXID, arg2 ...system.GetAtxOpt) error {
+func (m *Mockfetcher) GetAtxs(arg0 context.Context, arg1 []*types.ATXID, arg2 ...system.GetAtxOpt) error {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -75,13 +75,13 @@ func (c *MockfetcherGetAtxsCall) Return(arg0 error) *MockfetcherGetAtxsCall {
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockfetcherGetAtxsCall) Do(f func(context.Context, []types.ATXID, ...system.GetAtxOpt) error) *MockfetcherGetAtxsCall {
+func (c *MockfetcherGetAtxsCall) Do(f func(context.Context, []*types.ATXID, ...system.GetAtxOpt) error) *MockfetcherGetAtxsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockfetcherGetAtxsCall) DoAndReturn(f func(context.Context, []types.ATXID, ...system.GetAtxOpt) error) *MockfetcherGetAtxsCall {
+func (c *MockfetcherGetAtxsCall) DoAndReturn(f func(context.Context, []*types.ATXID, ...system.GetAtxOpt) error) *MockfetcherGetAtxsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/syncer/atxsync/syncer_test.go
+++ b/syncer/atxsync/syncer_test.go
@@ -88,9 +88,10 @@ func TestSyncer(t *testing.T) {
 
 		tester.fetcher.EXPECT().
 			GetAtxs(gomock.Any(), gomock.Any()).
-			DoAndReturn(func(_ context.Context, ids []types.ATXID, _ ...system.GetAtxOpt) error {
+			DoAndReturn(func(_ context.Context, ids []*types.ATXID, _ ...system.GetAtxOpt) error {
 				for _, id := range ids {
-					require.NoError(t, atxs.Add(tester.db, atx(id)))
+					a := atx(*id)
+					require.NoError(t, atxs.Add(tester.db, a))
 				}
 				return nil
 			}).AnyTimes()
@@ -151,9 +152,10 @@ func TestSyncer(t *testing.T) {
 
 		tester.fetcher.EXPECT().
 			GetAtxs(gomock.Any(), gomock.Any()).
-			DoAndReturn(func(_ context.Context, ids []types.ATXID, _ ...system.GetAtxOpt) error {
+			DoAndReturn(func(_ context.Context, ids []*types.ATXID, _ ...system.GetAtxOpt) error {
 				for _, id := range ids {
-					require.NoError(t, atxs.Add(tester.db, atx(id)))
+					a := atx(*id)
+					require.NoError(t, atxs.Add(tester.db, a))
 				}
 				return nil
 			}).AnyTimes()
@@ -179,17 +181,18 @@ func TestSyncer(t *testing.T) {
 
 		tester.fetcher.EXPECT().
 			GetAtxs(gomock.Any(), gomock.Any()).
-			DoAndReturn(func(_ context.Context, ids []types.ATXID, _ ...system.GetAtxOpt) error {
+			DoAndReturn(func(_ context.Context, ids []*types.ATXID, _ ...system.GetAtxOpt) error {
 				require.LessOrEqual(t, len(ids), tester.cfg.AtxsBatch)
 				berr := fetch.BatchError{}
 				for _, id := range ids {
 					for _, good := range good.AtxIDs {
-						if good == id {
-							require.NoError(t, atxs.Add(tester.db, atx(id)))
+						if good == *id {
+							a := atx(*id)
+							require.NoError(t, atxs.Add(tester.db, a))
 						}
 					}
 					for _, bad := range bad.AtxIDs {
-						if bad == id {
+						if bad == *id {
 							berr.Add(bad.Hash32(), fmt.Errorf("%w: test", fetch.ErrExceedMaxRetries))
 						}
 					}

--- a/syncer/mocks/mocks.go
+++ b/syncer/mocks/mocks.go
@@ -203,7 +203,7 @@ func (m *MockfetchLogic) EXPECT() *MockfetchLogicMockRecorder {
 }
 
 // GetAtxs mocks base method.
-func (m *MockfetchLogic) GetAtxs(arg0 context.Context, arg1 []types.ATXID, arg2 ...system.GetAtxOpt) error {
+func (m *MockfetchLogic) GetAtxs(arg0 context.Context, arg1 []*types.ATXID, arg2 ...system.GetAtxOpt) error {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -234,13 +234,13 @@ func (c *MockfetchLogicGetAtxsCall) Return(arg0 error) *MockfetchLogicGetAtxsCal
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockfetchLogicGetAtxsCall) Do(f func(context.Context, []types.ATXID, ...system.GetAtxOpt) error) *MockfetchLogicGetAtxsCall {
+func (c *MockfetchLogicGetAtxsCall) Do(f func(context.Context, []*types.ATXID, ...system.GetAtxOpt) error) *MockfetchLogicGetAtxsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockfetchLogicGetAtxsCall) DoAndReturn(f func(context.Context, []types.ATXID, ...system.GetAtxOpt) error) *MockfetchLogicGetAtxsCall {
+func (c *MockfetchLogicGetAtxsCall) DoAndReturn(f func(context.Context, []*types.ATXID, ...system.GetAtxOpt) error) *MockfetchLogicGetAtxsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -934,7 +934,7 @@ func (m *Mockfetcher) EXPECT() *MockfetcherMockRecorder {
 }
 
 // GetAtxs mocks base method.
-func (m *Mockfetcher) GetAtxs(arg0 context.Context, arg1 []types.ATXID, arg2 ...system.GetAtxOpt) error {
+func (m *Mockfetcher) GetAtxs(arg0 context.Context, arg1 []*types.ATXID, arg2 ...system.GetAtxOpt) error {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -965,13 +965,13 @@ func (c *MockfetcherGetAtxsCall) Return(arg0 error) *MockfetcherGetAtxsCall {
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockfetcherGetAtxsCall) Do(f func(context.Context, []types.ATXID, ...system.GetAtxOpt) error) *MockfetcherGetAtxsCall {
+func (c *MockfetcherGetAtxsCall) Do(f func(context.Context, []*types.ATXID, ...system.GetAtxOpt) error) *MockfetcherGetAtxsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockfetcherGetAtxsCall) DoAndReturn(f func(context.Context, []types.ATXID, ...system.GetAtxOpt) error) *MockfetcherGetAtxsCall {
+func (c *MockfetcherGetAtxsCall) DoAndReturn(f func(context.Context, []*types.ATXID, ...system.GetAtxOpt) error) *MockfetcherGetAtxsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/syncer/state_syncer.go
+++ b/syncer/state_syncer.go
@@ -327,7 +327,7 @@ func (s *Syncer) ensureMeshAgreement(
 			)
 			continue
 		}
-		missing := s.tortoise.GetMissingActiveSet(diffLayer.GetEpoch(), ed.AtxIDs)
+		missing := s.tortoise.GetMissingActiveSet(diffLayer.GetEpoch(), types.SliceToPtrSlice(ed.AtxIDs))
 		if len(missing) > 0 {
 			s.logger.WithContext(ctx).With().Debug("fetching missing atxs from peer",
 				log.Stringer("peer", peer),

--- a/syncer/state_syncer_test.go
+++ b/syncer/state_syncer_test.go
@@ -375,7 +375,7 @@ func TestProcessLayers_MeshHashDiverged(t *testing.T) {
 		opn.SetPeer(p2p.Peer(strconv.Itoa(i)))
 		opns = append(opns, opn)
 		ed := &fetch.EpochData{
-			AtxIDs: types.RandomActiveSet(11),
+			AtxIDs: types.PtrSliceToSlice(types.RandomActiveSet(11)),
 		}
 		eds = append(eds, ed)
 	}
@@ -405,7 +405,8 @@ func TestProcessLayers_MeshHashDiverged(t *testing.T) {
 		} else {
 			ts.mForkFinder.EXPECT().NeedResync(instate.Sub(1), opns[i].PrevAggHash).Return(true)
 			if i != 4 {
-				ts.mTortoise.EXPECT().GetMissingActiveSet(epoch, eds[i].AtxIDs).Return(eds[i].AtxIDs)
+				ts.mTortoise.EXPECT().GetMissingActiveSet(epoch, types.SliceToPtrSlice(eds[i].AtxIDs)).
+					Return(types.SliceToPtrSlice(eds[i].AtxIDs))
 			}
 		}
 	}
@@ -426,26 +427,26 @@ func TestProcessLayers_MeshHashDiverged(t *testing.T) {
 		PeerEpochInfo(gomock.Any(), opns[5].Peer(), epoch-1).
 		Return(eds[5], nil)
 	ts.mDataFetcher.EXPECT().GetAtxs(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, got []types.ATXID, _ ...system.GetAtxOpt) error {
-			require.ElementsMatch(t, eds[0].AtxIDs, got)
+		func(_ context.Context, got []*types.ATXID, _ ...system.GetAtxOpt) error {
+			require.ElementsMatch(t, eds[0].AtxIDs, types.PtrSliceToSlice(got))
 			return nil
 		},
 	)
 	ts.mDataFetcher.EXPECT().GetAtxs(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, got []types.ATXID, _ ...system.GetAtxOpt) error {
-			require.ElementsMatch(t, eds[2].AtxIDs, got)
+		func(_ context.Context, got []*types.ATXID, _ ...system.GetAtxOpt) error {
+			require.ElementsMatch(t, eds[2].AtxIDs, types.PtrSliceToSlice(got))
 			return nil
 		},
 	)
 	ts.mDataFetcher.EXPECT().GetAtxs(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, got []types.ATXID, _ ...system.GetAtxOpt) error {
-			require.ElementsMatch(t, eds[3].AtxIDs, got)
+		func(_ context.Context, got []*types.ATXID, _ ...system.GetAtxOpt) error {
+			require.ElementsMatch(t, eds[3].AtxIDs, types.PtrSliceToSlice(got))
 			return errors.New("not available")
 		},
 	)
 	ts.mDataFetcher.EXPECT().GetAtxs(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, got []types.ATXID, _ ...system.GetAtxOpt) error {
-			require.ElementsMatch(t, eds[5].AtxIDs, got)
+		func(_ context.Context, got []*types.ATXID, _ ...system.GetAtxOpt) error {
+			require.ElementsMatch(t, eds[5].AtxIDs, types.PtrSliceToSlice(got))
 			return nil
 		},
 	)

--- a/system/fetcher.go
+++ b/system/fetcher.go
@@ -40,7 +40,7 @@ func WithoutLimiting() GetAtxOpt {
 
 // AtxFetcher defines an interface for fetching ATXs from remote peers.
 type AtxFetcher interface {
-	GetAtxs(context.Context, []types.ATXID, ...GetAtxOpt) error
+	GetAtxs(context.Context, []*types.ATXID, ...GetAtxOpt) error
 }
 
 // TxFetcher defines an interface for fetching transactions from remote peers.

--- a/system/mocks/fetcher.go
+++ b/system/mocks/fetcher.go
@@ -81,7 +81,7 @@ func (c *MockFetcherGetActiveSetCall) DoAndReturn(f func(context.Context, types.
 }
 
 // GetAtxs mocks base method.
-func (m *MockFetcher) GetAtxs(arg0 context.Context, arg1 []types.ATXID, arg2 ...system.GetAtxOpt) error {
+func (m *MockFetcher) GetAtxs(arg0 context.Context, arg1 []*types.ATXID, arg2 ...system.GetAtxOpt) error {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -112,13 +112,13 @@ func (c *MockFetcherGetAtxsCall) Return(arg0 error) *MockFetcherGetAtxsCall {
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockFetcherGetAtxsCall) Do(f func(context.Context, []types.ATXID, ...system.GetAtxOpt) error) *MockFetcherGetAtxsCall {
+func (c *MockFetcherGetAtxsCall) Do(f func(context.Context, []*types.ATXID, ...system.GetAtxOpt) error) *MockFetcherGetAtxsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockFetcherGetAtxsCall) DoAndReturn(f func(context.Context, []types.ATXID, ...system.GetAtxOpt) error) *MockFetcherGetAtxsCall {
+func (c *MockFetcherGetAtxsCall) DoAndReturn(f func(context.Context, []*types.ATXID, ...system.GetAtxOpt) error) *MockFetcherGetAtxsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -472,7 +472,7 @@ func (m *MockAtxFetcher) EXPECT() *MockAtxFetcherMockRecorder {
 }
 
 // GetAtxs mocks base method.
-func (m *MockAtxFetcher) GetAtxs(arg0 context.Context, arg1 []types.ATXID, arg2 ...system.GetAtxOpt) error {
+func (m *MockAtxFetcher) GetAtxs(arg0 context.Context, arg1 []*types.ATXID, arg2 ...system.GetAtxOpt) error {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -503,13 +503,13 @@ func (c *MockAtxFetcherGetAtxsCall) Return(arg0 error) *MockAtxFetcherGetAtxsCal
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockAtxFetcherGetAtxsCall) Do(f func(context.Context, []types.ATXID, ...system.GetAtxOpt) error) *MockAtxFetcherGetAtxsCall {
+func (c *MockAtxFetcherGetAtxsCall) Do(f func(context.Context, []*types.ATXID, ...system.GetAtxOpt) error) *MockAtxFetcherGetAtxsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockAtxFetcherGetAtxsCall) DoAndReturn(f func(context.Context, []types.ATXID, ...system.GetAtxOpt) error) *MockAtxFetcherGetAtxsCall {
+func (c *MockAtxFetcherGetAtxsCall) DoAndReturn(f func(context.Context, []*types.ATXID, ...system.GetAtxOpt) error) *MockAtxFetcherGetAtxsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/system/mocks/tortoise.go
+++ b/system/mocks/tortoise.go
@@ -43,10 +43,10 @@ func (m *MockTortoise) EXPECT() *MockTortoiseMockRecorder {
 }
 
 // GetMissingActiveSet mocks base method.
-func (m *MockTortoise) GetMissingActiveSet(arg0 types.EpochID, arg1 []types.ATXID) []types.ATXID {
+func (m *MockTortoise) GetMissingActiveSet(arg0 types.EpochID, arg1 []*types.ATXID) []*types.ATXID {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMissingActiveSet", arg0, arg1)
-	ret0, _ := ret[0].([]types.ATXID)
+	ret0, _ := ret[0].([]*types.ATXID)
 	return ret0
 }
 
@@ -63,19 +63,19 @@ type MockTortoiseGetMissingActiveSetCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockTortoiseGetMissingActiveSetCall) Return(arg0 []types.ATXID) *MockTortoiseGetMissingActiveSetCall {
+func (c *MockTortoiseGetMissingActiveSetCall) Return(arg0 []*types.ATXID) *MockTortoiseGetMissingActiveSetCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockTortoiseGetMissingActiveSetCall) Do(f func(types.EpochID, []types.ATXID) []types.ATXID) *MockTortoiseGetMissingActiveSetCall {
+func (c *MockTortoiseGetMissingActiveSetCall) Do(f func(types.EpochID, []*types.ATXID) []*types.ATXID) *MockTortoiseGetMissingActiveSetCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockTortoiseGetMissingActiveSetCall) DoAndReturn(f func(types.EpochID, []types.ATXID) []types.ATXID) *MockTortoiseGetMissingActiveSetCall {
+func (c *MockTortoiseGetMissingActiveSetCall) DoAndReturn(f func(types.EpochID, []*types.ATXID) []*types.ATXID) *MockTortoiseGetMissingActiveSetCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -157,7 +157,7 @@ func (c *MockTortoiseOnAppliedCall) DoAndReturn(f func(types.LayerID, types.Hash
 }
 
 // OnAtx mocks base method.
-func (m *MockTortoise) OnAtx(arg0 types.EpochID, arg1 types.ATXID, arg2 *atxsdata.ATX) {
+func (m *MockTortoise) OnAtx(arg0 types.EpochID, arg1 *types.ATXID, arg2 *atxsdata.ATX) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "OnAtx", arg0, arg1, arg2)
 }
@@ -181,13 +181,13 @@ func (c *MockTortoiseOnAtxCall) Return() *MockTortoiseOnAtxCall {
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockTortoiseOnAtxCall) Do(f func(types.EpochID, types.ATXID, *atxsdata.ATX)) *MockTortoiseOnAtxCall {
+func (c *MockTortoiseOnAtxCall) Do(f func(types.EpochID, *types.ATXID, *atxsdata.ATX)) *MockTortoiseOnAtxCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockTortoiseOnAtxCall) DoAndReturn(f func(types.EpochID, types.ATXID, *atxsdata.ATX)) *MockTortoiseOnAtxCall {
+func (c *MockTortoiseOnAtxCall) DoAndReturn(f func(types.EpochID, *types.ATXID, *atxsdata.ATX)) *MockTortoiseOnAtxCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/system/tortoise.go
+++ b/system/tortoise.go
@@ -20,6 +20,6 @@ type Tortoise interface {
 	Updates() []result.Layer
 	OnApplied(types.LayerID, types.Hash32) bool
 	OnMalfeasance(types.NodeID)
-	OnAtx(types.EpochID, types.ATXID, *atxsdata.ATX)
-	GetMissingActiveSet(types.EpochID, []types.ATXID) []types.ATXID
+	OnAtx(types.EpochID, *types.ATXID, *atxsdata.ATX)
+	GetMissingActiveSet(types.EpochID, []*types.ATXID) []*types.ATXID
 }

--- a/systest/cluster/cluster.go
+++ b/systest/cluster/cluster.go
@@ -258,7 +258,8 @@ func (c *Cluster) GenesisExtraData() string {
 
 // GenesisID computes id from the configuration.
 func (c *Cluster) GenesisID() types.Hash20 {
-	return c.GoldenATX().Hash32().ToHash20()
+	v := c.GoldenATX()
+	return (&v).Hash32().ToHash20()
 }
 
 func (c *Cluster) GoldenATX() types.ATXID {

--- a/systest/tests/distributed_post_verification_test.go
+++ b/systest/tests/distributed_post_verification_test.go
@@ -108,13 +108,14 @@ func TestPostMalfeasanceProof(t *testing.T) {
 		return ch
 	}).AnyTimes()
 
+	golden := cl.GoldenATX()
 	// 1. Initialize
 	postSetupMgr, err := activation.NewPostSetupManager(
 		cfg.POST,
 		logger.Named("post"),
 		datastore.NewCachedDB(sql.InMemory(), zap.NewNop()),
 		atxsdata.New(),
-		cl.GoldenATX(),
+		&golden,
 		syncer,
 		activation.NewMocknipostValidator(ctrl),
 	)
@@ -219,7 +220,7 @@ func TestPostMalfeasanceProof(t *testing.T) {
 		require.NoError(t, err)
 
 		challenge = &wire.NIPostChallengeV1{
-			PrevATXID:        types.EmptyATXID,
+			PrevATXID:        *types.EmptyATXID,
 			PublishEpoch:     1,
 			PositioningATXID: goldenATXID,
 			CommitmentATXID:  &postInfo.CommitmentATX,
@@ -233,7 +234,7 @@ func TestPostMalfeasanceProof(t *testing.T) {
 	}
 	nipostChallenge := &types.NIPostChallenge{
 		PublishEpoch:   challenge.PublishEpoch,
-		PrevATXID:      types.EmptyATXID,
+		PrevATXID:      *types.EmptyATXID,
 		PositioningATX: challenge.PositioningATXID,
 		CommitmentATX:  challenge.CommitmentATXID,
 		InitialPost: &types.Post{

--- a/tortoise/algorithm.go
+++ b/tortoise/algorithm.go
@@ -316,7 +316,7 @@ func (t *Tortoise) TallyVotes(ctx context.Context, lid types.LayerID) {
 }
 
 // OnAtx is expected to be called before ballots that use this atx.
-func (t *Tortoise) OnAtx(target types.EpochID, id types.ATXID, atx *atxsdata.ATX) {
+func (t *Tortoise) OnAtx(target types.EpochID, id *types.ATXID, atx *atxsdata.ATX) {
 	start := time.Now()
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -428,7 +428,7 @@ type DecodedBallot struct {
 type BallotData struct {
 	ID           types.BallotID
 	Layer        types.LayerID
-	ATXID        types.ATXID
+	ATXID        *types.ATXID
 	Smesher      types.NodeID
 	Beacon       types.Beacon
 	Eligiblities uint32
@@ -531,7 +531,7 @@ func (t *Tortoise) OnHareOutput(lid types.LayerID, bid types.BlockID) {
 
 // GetMissingActiveSet returns unknown atxs from the original list. It is done for a specific epoch
 // as active set atxs never cross epoch boundary.
-func (t *Tortoise) GetMissingActiveSet(target types.EpochID, atxs []types.ATXID) []types.ATXID {
+func (t *Tortoise) GetMissingActiveSet(target types.EpochID, atxs []*types.ATXID) []*types.ATXID {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	return t.trtl.atxsdata.MissingInEpoch(target, atxs)

--- a/tortoise/fixture_test.go
+++ b/tortoise/fixture_test.go
@@ -206,15 +206,15 @@ func (b *bopt) assert(onDecode func(*DecodedBallot, error), onStore func(error))
 }
 
 func (a *atxAction) execute(trt *Tortoise) {
-	trt.trtl.atxsdata.AddAtx(a.atx.target, a.atx.id, &a.atx.ATX)
-	trt.OnAtx(a.atx.target, a.atx.id, &a.atx.ATX)
+	trt.trtl.atxsdata.AddAtx(a.atx.target, &a.atx.id, &a.atx.ATX)
+	trt.OnAtx(a.atx.target, &a.atx.id, &a.atx.ATX)
 }
 
 func (a *atxAction) rawballot(id types.BallotID, n int, opts ...*bopt) *ballotAction {
 	lid := uint32(n) + types.GetEffectiveGenesis().Uint32()
 	b := types.BallotTortoiseData{}
 	b.Smesher = a.atx.Node
-	b.AtxID = a.atx.id
+	b.AtxID = &a.atx.id
 	b.Layer = types.LayerID(lid)
 	b.ID = id
 

--- a/tortoise/full_test.go
+++ b/tortoise/full_test.go
@@ -335,8 +335,8 @@ func TestFullCountVotes(t *testing.T) {
 					BaseHeight: tc.activeset[i].BaseHeight,
 					Height:     tc.activeset[i].BaseHeight + tc.activeset[i].TickCount,
 				}
-				tortoise.trtl.atxsdata.AddAtx(2, atxid, &atx)
-				tortoise.OnAtx(2, atxid, &atx)
+				tortoise.trtl.atxsdata.AddAtx(2, &atxid, &atx)
+				tortoise.OnAtx(2, &atxid, &atx)
 				activeset = append(activeset, atxid)
 				weights = append(weights, atx.Weight)
 				total += atx.Weight

--- a/tortoise/model/core.go
+++ b/tortoise/model/core.go
@@ -90,7 +90,7 @@ func (c *core) OnMessage(m Messenger, event Message) {
 		}
 		if c.refBallot == nil {
 			total := uint64(0)
-			c.atxdata.IterateInEpoch(ev.LayerID.GetEpoch(), func(_ types.ATXID, atx *atxsdata.ATX) {
+			c.atxdata.IterateInEpoch(ev.LayerID.GetEpoch(), func(_ *types.ATXID, atx *atxsdata.ATX) {
 				total += atx.Weight
 			})
 			c.eligibilities = max(uint32(c.weight*layerSize/total), 1)
@@ -158,7 +158,7 @@ func (c *core) OnMessage(m Messenger, event Message) {
 		atx.BaseTickHeight = 1
 		atx.TickCount = 2
 		c.refBallot = nil
-		c.atx = atx.ID()
+		c.atx = *atx.ID()
 		c.weight = atx.GetWeight()
 
 		m.Send(MessageAtx{Atx: atx})

--- a/tortoise/recover.go
+++ b/tortoise/recover.go
@@ -131,7 +131,7 @@ func Recover(
 }
 
 func recoverEpoch(target types.EpochID, trtl *Tortoise, db sql.Executor, atxdata *atxsdata.Data) error {
-	atxdata.IterateInEpoch(target, func(id types.ATXID, atx *atxsdata.ATX) {
+	atxdata.IterateInEpoch(target, func(id *types.ATXID, atx *atxsdata.ATX) {
 		trtl.OnAtx(target, id, atx)
 	})
 

--- a/tortoise/sim/layer.go
+++ b/tortoise/sim/layer.go
@@ -189,7 +189,7 @@ func (g *Generator) genLayer(cfg nextConf) types.LayerID {
 		ballot := &types.Ballot{
 			InnerBallot: types.InnerBallot{
 				Layer: g.nextLayer,
-				AtxID: atx.ID(),
+				AtxID: *atx.ID(),
 				EpochData: &types.EpochData{
 					EligibilityCount: n,
 					ActiveSetHash:    types.Hash32{1, 2, 3},

--- a/tortoise/state.go
+++ b/tortoise/state.go
@@ -216,7 +216,7 @@ type (
 
 	referenceInfo struct {
 		smesher         types.NodeID
-		atxid           types.ATXID
+		atxid           *types.ATXID
 		expectedBallots uint32
 		beacon          types.Beacon
 		weight          *big.Rat

--- a/tortoise/threshold_test.go
+++ b/tortoise/threshold_test.go
@@ -172,7 +172,7 @@ func TestReferenceHeight(t *testing.T) {
 					NumUnits:     2,
 					TickCount:    height,
 				}
-				atx.SetID(types.ATXID{byte(i + 1)})
+				atx.SetID(&types.ATXID{byte(i + 1)})
 				atx.SetReceived(time.Now())
 				require.NoError(t, atxs.Add(db, atx))
 			}

--- a/tortoise/tortoise.go
+++ b/tortoise/tortoise.go
@@ -523,7 +523,7 @@ func (t *turtle) computeEpochHeight(lid types.LayerID) {
 	var heights []uint64
 	t.atxsdata.IterateInEpoch(
 		lid.GetEpoch(),
-		func(_ types.ATXID, atx *atxsdata.ATX) {
+		func(_ *types.ATXID, atx *atxsdata.ATX) {
 			heights = append(heights, atx.Height)
 		},
 		atxsdata.NotMalicious,
@@ -649,7 +649,7 @@ func (t *turtle) onOpinionChange(lid types.LayerID, early bool) {
 	}
 }
 
-func (t *turtle) onAtx(target types.EpochID, id types.ATXID, atx *atxsdata.ATX) {
+func (t *turtle) onAtx(target types.EpochID, id *types.ATXID, atx *atxsdata.ATX) {
 	start := time.Now()
 	epoch := t.epoch(target)
 	mal := t.isMalfeasant(atx.Node)

--- a/tortoise/tortoise_test.go
+++ b/tortoise/tortoise_test.go
@@ -1616,7 +1616,7 @@ func TestComputeBallotWeight(t *testing.T) {
 				}
 				trtl.trtl.atxsdata.AddAtx(lid.GetEpoch(), atxID, &atx)
 				trtl.OnAtx(lid.GetEpoch(), atxID, &atx)
-				atxids = append(atxids, atxID)
+				atxids = append(atxids, *atxID)
 			}
 
 			var currentJ int
@@ -1712,7 +1712,7 @@ func TestNetworkRecoversFromFullPartition(t *testing.T) {
 	partitionEnd := last
 	s1.Merge(s2)
 	s1.GetState(0).Atxdata.IterateInEpoch(
-		partitionEnd.GetEpoch(), func(id types.ATXID, atx *atxsdata.ATX) {
+		partitionEnd.GetEpoch(), func(id *types.ATXID, atx *atxsdata.ATX) {
 			tortoise1.OnAtx(partitionEnd.GetEpoch(), id, atx)
 			tortoise2.OnAtx(partitionEnd.GetEpoch(), id, atx)
 		})
@@ -2387,8 +2387,8 @@ func TestSwitchMode(t *testing.T) {
 			Height: 200,
 			Weight: 200,
 		}
-		tortoise.trtl.atxsdata.AddAtx(types.EpochID(2), types.ATXID{1}, &atx)
-		tortoise.OnAtx(types.EpochID(2), types.ATXID{1}, &atx)
+		tortoise.trtl.atxsdata.AddAtx(types.EpochID(2), &types.ATXID{1}, &atx)
+		tortoise.OnAtx(types.EpochID(2), &types.ATXID{1}, &atx)
 		// feed ballots that vote against previously validated layer
 		// without the fix they would be ignored
 		for i := 1; i <= 16; i++ {
@@ -2892,8 +2892,8 @@ func TestEncodeVotes(t *testing.T) {
 			BaseHeight: 1,
 			Height:     2,
 		}
-		atxdata.AddAtx(lid.GetEpoch(), atxid, &atx)
-		tortoise.OnAtx(lid.GetEpoch(), atxid, &atx)
+		atxdata.AddAtx(lid.GetEpoch(), &atxid, &atx)
+		tortoise.OnAtx(lid.GetEpoch(), &atxid, &atx)
 		tortoise.OnBeacon(lid.GetEpoch(), types.EmptyBeacon)
 
 		ballot.EpochData = &types.EpochData{
@@ -3014,17 +3014,19 @@ func TestMissingActiveSet(t *testing.T) {
 	}
 	for _, atxid := range aset[:2] {
 		atx := &atxsdata.ATX{}
-		tortoise.trtl.atxsdata.AddAtx(target, atxid, atx)
-		tortoise.OnAtx(target, atxid, atx)
+		tortoise.trtl.atxsdata.AddAtx(target, &atxid, atx)
+		tortoise.OnAtx(target, &atxid, atx)
 	}
 	t.Run("empty", func(t *testing.T) {
-		require.Equal(t, aset, tortoise.GetMissingActiveSet(target+1, aset))
+		require.Equal(t, aset,
+			types.PtrSliceToSlice(tortoise.GetMissingActiveSet(target+1, types.SliceToPtrSlice(aset))))
 	})
 	t.Run("all available", func(t *testing.T) {
-		require.Empty(t, tortoise.GetMissingActiveSet(target, aset[:2]))
+		require.Empty(t, tortoise.GetMissingActiveSet(target, types.SliceToPtrSlice(aset[:2])))
 	})
 	t.Run("some available", func(t *testing.T) {
-		require.Equal(t, []types.ATXID{aset[2]}, tortoise.GetMissingActiveSet(target, aset))
+		require.Equal(t, []types.ATXID{aset[2]},
+			types.PtrSliceToSlice(tortoise.GetMissingActiveSet(target, types.SliceToPtrSlice(aset))))
 	})
 }
 

--- a/tortoise/tracer.go
+++ b/tortoise/tracer.go
@@ -174,7 +174,7 @@ func (c *ConfigTrace) Run(r *traceRunner) error {
 }
 
 type AtxTrace struct {
-	ID          types.ATXID   `json:"id"`
+	ID          *types.ATXID  `json:"id"`
 	TargetEpoch types.EpochID `json:"target"`
 	Atx         *atxsdata.ATX `json:",inline"`
 }


### PR DESCRIPTION
## Motivation
The codebase uses value semantics over ATX IDs and this puts unnecessary stress on the GC. This PR tries to mitigate most of this usage (apart from places where it is absolutely necessary/difficult to change).

## Description

The PR changes the value semantics to pointer semantics wherever possible. Unfortunately this is not possible everywhere because some of the protocol messages encode the ATX IDs as values, not pointers to values and changing this will break protocol specs. To overcome this I've introduced a couple of helper methods that help the conversions wherever necessary, between a slice to values and a slice to pointers (these are generics and can be reused, however they might cause inefficiencies with memory if abused).

Another point which cannot be changed is that `map`s that use `types.ATXID` as a key cannot be changed to be `map[*ATXID]` because the map key cannot use pointers to values (the pointer will not be dereferenced for the key, meaning that the same value pointed to by different pointers will result in different map entries).

Due to the switch to pointer semantics, several helper methods had to be introduced, for example to check whether an ATX ID is empty or to compare it against another value. This also cleans up the API and will allow future modularity with changes to these types, if necessary.

One visible thing that was noticed in tests was that some previously uninitialized fields on structs for example (that pointed to `types.ATXID`) were falling back to an empty ATX ID whenever not explicitly set. This, combined with a recurring pattern of initializing complex types without the use of a constructor but through a literal, sometimes makes refactoring difficult and ends up with a lot of magic. Constructor use is therefore encouraged.

<!-- If applicable please mention the issue addressed by this PR -->
<!-- `Closes #XXXX` links mentioned issues to this PR and automatically closes them when this it's merged -->

<!-- Please describe in detail the changes made. Focus on the reasoning rather than describing the change -->

## Test Plan

- fix remaining tests
- run on a node to see that there's no panicks
<!-- Please specify how these changes were tested (e.g. unit tests, manual testing, etc.) -->

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [ ] Test changes and document test plan
- [ ] Update documentation as needed
- [ ] Update [changelog](../CHANGELOG.md) as needed
