### PR TITLE
[Merged by Bors] - api: v2alpha1: ATX improvements and sort order filter

### DIFF
--- a/api/grpcserver/v2alpha1/activation.go
+++ b/api/grpcserver/v2alpha1/activation.go
@@ -246,7 +246,7 @@ func toAtxOperations(filter *spacemeshv2alpha1.ActivationRequest) (builder.Opera
 	if filter == nil {
 		return ops, nil
 	}
-	if filter.SmesherId != nil {
+	if len(filter.SmesherId) > 0 {
 		ops.Filter = append(ops.Filter, builder.Op{
 			Field: builder.Smesher,
 			Token: builder.In,
@@ -314,27 +314,15 @@ type atxsMatcher struct {
 
 func (m *atxsMatcher) match(t *events.ActivationTx) bool {
 	if len(m.SmesherId) > 0 {
-		found := false
-		for _, id := range m.SmesherId {
-			nodeId := types.BytesToNodeID(id)
-			if t.SmesherID == nodeId {
-				found = true
-			}
-		}
-		if !found {
+		idx := slices.IndexFunc(m.SmesherId, func(id []byte) bool { return bytes.Equal(id, t.SmesherID.Bytes()) })
+		if idx == -1 {
 			return false
 		}
 	}
 
 	if len(m.Id) > 0 {
-		found := false
-		for _, id := range m.Id {
-			atxId := types.BytesToATXID(id)
-			if t.ID() == atxId {
-				found = true
-			}
-		}
-		if !found {
+		idx := slices.IndexFunc(m.Id, func(id []byte) bool { return bytes.Equal(id, t.ID().Bytes()) })
+		if idx == -1 {
 			return false
 		}
 	}

--- a/api/grpcserver/v2alpha1/activation.go
+++ b/api/grpcserver/v2alpha1/activation.go
@@ -1,9 +1,11 @@
 package v2alpha1
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
+	"slices"
 
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
@@ -253,7 +255,7 @@ func toAtxOperations(filter *spacemeshv2alpha1.ActivationRequest) (builder.Opera
 			Value: filter.SmesherId,
 		})
 	}
-	if filter.Id != nil {
+	if len(filter.Id) > 0 {
 		ops.Filter = append(ops.Filter, builder.Op{
 			Field: builder.Id,
 			Token: builder.In,

--- a/api/grpcserver/v2alpha1/activation_test.go
+++ b/api/grpcserver/v2alpha1/activation_test.go
@@ -86,10 +86,10 @@ func TestActivationService_List(t *testing.T) {
 		require.Equal(t, activations[3].ID().Bytes(), list.GetActivations()[0].GetId())
 	})
 
-	t.Run("nodeId", func(t *testing.T) {
+	t.Run("smesherId", func(t *testing.T) {
 		list, err := client.List(ctx, &spacemeshv2alpha1.ActivationRequest{
-			Limit:  1,
-			NodeId: activations[1].SmesherID.Bytes(),
+			Limit:     1,
+			SmesherId: [][]byte{activations[1].SmesherID.Bytes()},
 		})
 		require.NoError(t, err)
 		require.Equal(t, activations[1].ID().Bytes(), list.GetActivations()[0].GetId())
@@ -98,7 +98,7 @@ func TestActivationService_List(t *testing.T) {
 	t.Run("id", func(t *testing.T) {
 		list, err := client.List(ctx, &spacemeshv2alpha1.ActivationRequest{
 			Limit: 1,
-			Id:    activations[3].ID().Bytes(),
+			Id:    [][]byte{activations[3].ID().Bytes()},
 		})
 		require.NoError(t, err)
 		require.Equal(t, activations[3].ID().Bytes(), list.GetActivations()[0].GetId())
@@ -167,15 +167,15 @@ func TestActivationStreamService_Stream(t *testing.T) {
 			{
 				desc: "ID",
 				request: &spacemeshv2alpha1.ActivationStreamRequest{
-					Id:         streamed[3].ID().Bytes(),
+					Id:         [][]byte{streamed[3].ID().Bytes()},
 					StartEpoch: start,
 					Watch:      true,
 				},
 			},
 			{
-				desc: "NodeID",
+				desc: "SmesherId",
 				request: &spacemeshv2alpha1.ActivationStreamRequest{
-					NodeId:     streamed[3].SmesherID.Bytes(),
+					SmesherId:  [][]byte{streamed[3].SmesherID.Bytes()},
 					StartEpoch: start,
 					Watch:      true,
 				},

--- a/api/grpcserver/v2alpha1/layer.go
+++ b/api/grpcserver/v2alpha1/layer.go
@@ -253,7 +253,7 @@ func toLayerOperations(filter *spacemeshv2alpha1.LayerRequest) (builder.Operatio
 
 	ops.Modifiers = append(ops.Modifiers, builder.Modifier{
 		Key:   builder.OrderBy,
-		Value: "l.id asc",
+		Value: "l.id " + filter.SortOrder.String(),
 	})
 
 	if filter.Limit != 0 {

--- a/api/grpcserver/v2alpha1/reward.go
+++ b/api/grpcserver/v2alpha1/reward.go
@@ -258,7 +258,7 @@ func toRewardOperations(filter *spacemeshv2alpha1.RewardRequest) (builder.Operat
 
 	ops.Modifiers = append(ops.Modifiers, builder.Modifier{
 		Key:   builder.OrderBy,
-		Value: "layer asc",
+		Value: "layer " + filter.SortOrder.String(),
 	})
 
 	if filter.Limit != 0 {

--- a/api/grpcserver/v2alpha1/transaction.go
+++ b/api/grpcserver/v2alpha1/transaction.go
@@ -288,7 +288,7 @@ func toTransactionOperations(filter *spacemeshv2alpha1.TransactionRequest) (buil
 
 	ops.Modifiers = append(ops.Modifiers, builder.Modifier{
 		Key:   builder.OrderBy,
-		Value: "layer asc, id",
+		Value: fmt.Sprintf("layer %s, id", filter.SortOrder.String()),
 	})
 
 	if filter.Limit != 0 {

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/rs/cors v1.11.0
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/seehuhn/mt19937 v1.0.0
-	github.com/spacemeshos/api/release/go v1.46.0
+	github.com/spacemeshos/api/release/go v1.48.0
 	github.com/spacemeshos/economics v0.1.3
 	github.com/spacemeshos/fixed v0.1.1
 	github.com/spacemeshos/go-scale v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -556,8 +556,8 @@ github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d/go.mod h1:Udh
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
-github.com/spacemeshos/api/release/go v1.46.0 h1:wm+VpTwP1mvCligEwgPo1ykDKY/omPCJtGYwatKLaE8=
-github.com/spacemeshos/api/release/go v1.46.0/go.mod h1:8pxGN6/di8iBpQReiOgY+Cppi7bhJ+qJ3QiRQtJfoag=
+github.com/spacemeshos/api/release/go v1.48.0 h1:RSg2D6ocHlsyV5XL97uuecQAXA4qHDmlDmYc8yejVOs=
+github.com/spacemeshos/api/release/go v1.48.0/go.mod h1:8pxGN6/di8iBpQReiOgY+Cppi7bhJ+qJ3QiRQtJfoag=
 github.com/spacemeshos/economics v0.1.3 h1:ACkq3mTebIky4Zwbs9SeSSRZrUCjU/Zk0wq9Z0BTh2A=
 github.com/spacemeshos/economics v0.1.3/go.mod h1:FH7u0FzTIm6Kpk+X5HOZDvpkgNYBKclmH86rVwYaDAo=
 github.com/spacemeshos/fixed v0.1.1 h1:N1y4SUpq1EV+IdJrWJwUCt1oBFzeru/VKVcBsvPc2Fk=


### PR DESCRIPTION
* Add NumUnits to Activation message
* Change name of NodeId filter to SmesherId.
* Modify Id to allow multiple entries.
* Remove signature and previous_atx from Activation message
* Update stream filters to match list filters
* Add sort_order field to tx, layer and reward List requests