### PR TITLE
[Merged by Bors] - Use zap logger in miner package

### DIFF
--- a/miner/active_set_generator_test.go
+++ b/miner/active_set_generator_test.go
@@ -8,11 +8,11 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+	"go.uber.org/zap/zaptest"
 
 	"github.com/spacemeshos/go-spacemesh/atxsdata"
 	"github.com/spacemeshos/go-spacemesh/codec"
 	"github.com/spacemeshos/go-spacemesh/common/types"
-	"github.com/spacemeshos/go-spacemesh/log/logtest"
 	"github.com/spacemeshos/go-spacemesh/miner/mocks"
 	"github.com/spacemeshos/go-spacemesh/sql"
 	"github.com/spacemeshos/go-spacemesh/sql/activesets"
@@ -73,7 +73,7 @@ func newTesterActiveSetGenerator(tb testing.TB, cfg config) *testerActiveSetGene
 		wallclock = clockwork.NewFakeClock()
 		gen       = newActiveSetGenerator(
 			cfg,
-			logtest.New(tb).Zap(),
+			zaptest.NewLogger(tb),
 			db,
 			localdb,
 			atxsdata,

--- a/miner/metrics.go
+++ b/miner/metrics.go
@@ -4,8 +4,8 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"go.uber.org/zap/zapcore"
 
-	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/metrics"
 )
 
@@ -30,7 +30,7 @@ func (lt *latencyTracker) total() time.Duration {
 	return lt.publish.Sub(lt.start)
 }
 
-func (lt *latencyTracker) MarshalLogObject(encoder log.ObjectEncoder) error {
+func (lt *latencyTracker) MarshalLogObject(encoder zapcore.ObjectEncoder) error {
 	encoder.AddDuration("data", lt.data.Sub(lt.start))
 	encoder.AddDuration("tortoise", lt.tortoise.Sub(lt.data))
 	encoder.AddDuration("hash", lt.hash.Sub(lt.tortoise))

--- a/miner/proposal_builder_test.go
+++ b/miner/proposal_builder_test.go
@@ -13,12 +13,12 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/spacemeshos/go-spacemesh/atxsdata"
 	"github.com/spacemeshos/go-spacemesh/codec"
 	"github.com/spacemeshos/go-spacemesh/common/types"
-	"github.com/spacemeshos/go-spacemesh/log/logtest"
 	"github.com/spacemeshos/go-spacemesh/malfeasance/wire"
 	"github.com/spacemeshos/go-spacemesh/miner/mocks"
 	"github.com/spacemeshos/go-spacemesh/p2p/pubsub"
@@ -755,7 +755,7 @@ func TestBuild(t *testing.T) {
 
 			clock.EXPECT().LayerToTime(gomock.Any()).Return(time.Unix(0, 0)).AnyTimes()
 
-			full := append(defaults, WithLogger(logtest.New(t)), WithSigners(signer))
+			full := append(defaults, WithLogger(zaptest.NewLogger(t)), WithSigners(signer))
 			full = append(full, tc.opts...)
 			builder := New(clock, db, localdb, atxsdata, publisher, tortoise, syncer, conState, full...)
 			var decoded chan *types.Proposal
@@ -949,7 +949,7 @@ func TestStartStop(t *testing.T) {
 		tortoise,
 		syncer,
 		conState,
-		WithLogger(logtest.New(t)),
+		WithLogger(zaptest.NewLogger(t)),
 		WithActivesetPreparation(ActiveSetPreparation{}),
 	)
 	builder.Register(signer)

--- a/node/node.go
+++ b/node/node.go
@@ -975,7 +975,7 @@ func (app *App) initServices(ctx context.Context) error {
 		miner.WithHdist(app.Config.Tortoise.Hdist),
 		miner.WithNetworkDelay(app.Config.ATXGradeDelay),
 		miner.WithMinGoodAtxPercent(minerGoodAtxPct),
-		miner.WithLogger(app.addLogger(ProposalBuilderLogger, lg)),
+		miner.WithLogger(app.addLogger(ProposalBuilderLogger, lg).Zap()),
 		miner.WithActivesetPreparation(app.Config.ActiveSet),
 	)
 	for _, sig := range app.signers {


### PR DESCRIPTION
## Motivation

Continued effort to replace deprecated `log` package with `zap`.

## Description

Replaced all usages of the `go-spacemesh/log` logger with `zap` in the `miner` package.

## Test Plan

existing tests pass

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
