### PR TITLE
[Merged by Bors] - cleanups around checkpoint-recovery

### DIFF
--- a/checkpoint/recovery.go
+++ b/checkpoint/recovery.go
@@ -109,7 +109,7 @@ func Recover(
 	cfg *RecoverConfig,
 ) (*PreservedData, error) {
 	if len(cfg.Uri) == 0 {
-		return nil, nil
+		return nil, errors.New("recovery uri not set")
 	}
 	if cfg.Restore == 0 {
 		return nil, errors.New("restore layer not set")

--- a/checkpoint/recovery.go
+++ b/checkpoint/recovery.go
@@ -108,6 +108,13 @@ func Recover(
 	fs afero.Fs,
 	cfg *RecoverConfig,
 ) (*PreservedData, error) {
+	if len(cfg.Uri) == 0 {
+		return nil, nil
+	}
+	if cfg.Restore == 0 {
+		return nil, errors.New("restore layer not set")
+	}
+	logger.Info("recovering from checkpoint", zap.String("url", cfg.Uri), zap.Stringer("restore", cfg.Restore))
 	db, err := sql.Open("file:" + filepath.Join(cfg.DataDir, cfg.DbFile))
 	if err != nil {
 		return nil, fmt.Errorf("open old database: %w", err)

--- a/checkpoint/recovery_test.go
+++ b/checkpoint/recovery_test.go
@@ -49,6 +49,7 @@ func atxEqual(
 	commitAtx types.ATXID,
 	vrfnonce types.VRFPostIndex,
 ) {
+	tb.Helper()
 	require.True(tb, bytes.Equal(sAtx.ID, vAtx.ID().Bytes()))
 	require.EqualValues(tb, sAtx.Epoch, vAtx.PublishEpoch)
 	require.True(tb, bytes.Equal(sAtx.CommitmentAtx, commitAtx.Bytes()))
@@ -63,6 +64,7 @@ func atxEqual(
 }
 
 func accountEqual(tb testing.TB, cacct types.AccountSnapshot, acct *types.Account) {
+	tb.Helper()
 	require.True(tb, bytes.Equal(cacct.Address, acct.Address.Bytes()))
 	require.Equal(tb, cacct.Balance, acct.Balance)
 	require.Equal(tb, cacct.Nonce, acct.NextNonce)
@@ -76,6 +78,7 @@ func accountEqual(tb testing.TB, cacct types.AccountSnapshot, acct *types.Accoun
 }
 
 func verifyDbContent(tb testing.TB, db *sql.Database) {
+	tb.Helper()
 	var expected types.Checkpoint
 	require.NoError(tb, json.Unmarshal([]byte(checkpointData), &expected))
 	expAtx := map[types.ATXID]types.AtxSnapshot{}
@@ -117,6 +120,7 @@ func verifyDbContent(tb testing.TB, db *sql.Database) {
 }
 
 func TestRecover(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, http.MethodGet, r.Method)
 		w.WriteHeader(http.StatusOK)
@@ -148,9 +152,6 @@ func TestRecover(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-			defer cancel()
-
 			fs := afero.NewMemMapFs()
 			cfg := &checkpoint.RecoverConfig{
 				GoldenAtx:      goldenAtx,
@@ -166,13 +167,13 @@ func TestRecover(t *testing.T) {
 			require.NoError(t, fs.MkdirAll(bsdir, 0o700))
 			db := sql.InMemory()
 			localDB := localsql.InMemory()
-			preserve, err := checkpoint.RecoverWithDb(ctx, zaptest.NewLogger(t), db, localDB, fs, cfg)
+			data, err := checkpoint.RecoverWithDb(context.Background(), zaptest.NewLogger(t), db, localDB, fs, cfg)
 			if tc.expErr != nil {
 				require.ErrorIs(t, err, tc.expErr)
 				return
 			}
 			require.NoError(t, err)
-			require.Nil(t, preserve)
+			require.Nil(t, data)
 			newDB, err := sql.Open("file:" + filepath.Join(cfg.DataDir, cfg.DbFile))
 			require.NoError(t, err)
 			require.NotNil(t, newDB)
@@ -189,6 +190,7 @@ func TestRecover(t *testing.T) {
 }
 
 func TestRecover_SameRecoveryInfo(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, http.MethodGet, r.Method)
 		w.WriteHeader(http.StatusOK)
@@ -224,11 +226,29 @@ func TestRecover_SameRecoveryInfo(t *testing.T) {
 	require.True(t, exist)
 }
 
+func TestRecover_SkipsWhenNoURI(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	d, err := checkpoint.Recover(ctx, zaptest.NewLogger(t), afero.NewMemMapFs(), &checkpoint.RecoverConfig{})
+	require.NoError(t, err)
+	require.Nil(t, d)
+}
+
+func TestRecover_RestoreLayerCannotBeZero(t *testing.T) {
+	t.Parallel()
+	cfg := &checkpoint.RecoverConfig{
+		Uri: "http://nowhere/snapshot-15",
+	}
+	_, err := checkpoint.Recover(context.Background(), zaptest.NewLogger(t), afero.NewMemMapFs(), cfg)
+	require.ErrorContains(t, err, "restore layer not set")
+}
+
 func validateAndPreserveData(
 	tb testing.TB,
 	db *sql.Database,
 	deps []*checkpoint.AtxDep,
 ) {
+	tb.Helper()
 	lg := zaptest.NewLogger(tb)
 	ctrl := gomock.NewController(tb)
 	mclock := activation.NewMocklayerClock(ctrl)
@@ -299,7 +319,6 @@ func validateAndPreserveData(
 }
 
 func newChainedAtx(
-	tb testing.TB,
 	prev, pos types.ATXID,
 	commitAtx *types.ATXID,
 	poetProofRef types.PoetProofRef,
@@ -377,24 +396,24 @@ func createInterlinkedAtxChain(
 	}
 
 	// epoch 2
-	sig1Atx1 := newChainedAtx(tb, types.EmptyATXID, goldenAtx, &goldenAtx, poetRef(), 2, 0, 113, sig1)
+	sig1Atx1 := newChainedAtx(types.EmptyATXID, goldenAtx, &goldenAtx, poetRef(), 2, 0, 113, sig1)
 	// epoch 3
-	sig1Atx2 := newChainedAtx(tb, sig1Atx1.ID, sig1Atx1.ID, nil, poetRef(), 3, 1, 0, sig1)
+	sig1Atx2 := newChainedAtx(sig1Atx1.ID, sig1Atx1.ID, nil, poetRef(), 3, 1, 0, sig1)
 	// epoch 4
-	sig1Atx3 := newChainedAtx(tb, sig1Atx2.ID, sig1Atx2.ID, nil, poetRef(), 4, 2, 0, sig1)
+	sig1Atx3 := newChainedAtx(sig1Atx2.ID, sig1Atx2.ID, nil, poetRef(), 4, 2, 0, sig1)
 	commitAtxID := sig1Atx2.ID
-	sig2Atx1 := newChainedAtx(tb, types.EmptyATXID, sig1Atx2.ID, &commitAtxID, poetRef(), 4, 0, 513, sig2)
+	sig2Atx1 := newChainedAtx(types.EmptyATXID, sig1Atx2.ID, &commitAtxID, poetRef(), 4, 0, 513, sig2)
 	// epoch 5
-	sig1Atx4 := newChainedAtx(tb, sig1Atx3.ID, sig2Atx1.ID, nil, poetRef(), 5, 3, 0, sig1)
+	sig1Atx4 := newChainedAtx(sig1Atx3.ID, sig2Atx1.ID, nil, poetRef(), 5, 3, 0, sig1)
 	// epoch 6
-	sig1Atx5 := newChainedAtx(tb, sig1Atx4.ID, sig1Atx4.ID, nil, poetRef(), 6, 4, 0, sig1)
-	sig2Atx2 := newChainedAtx(tb, sig2Atx1.ID, sig1Atx4.ID, nil, poetRef(), 6, 1, 0, sig2)
+	sig1Atx5 := newChainedAtx(sig1Atx4.ID, sig1Atx4.ID, nil, poetRef(), 6, 4, 0, sig1)
+	sig2Atx2 := newChainedAtx(sig2Atx1.ID, sig1Atx4.ID, nil, poetRef(), 6, 1, 0, sig2)
 	// epoch 7
-	sig1Atx6 := newChainedAtx(tb, sig1Atx5.ID, sig2Atx2.ID, nil, poetRef(), 7, 5, 0, sig1)
+	sig1Atx6 := newChainedAtx(sig1Atx5.ID, sig2Atx2.ID, nil, poetRef(), 7, 5, 0, sig1)
 	// epoch 8
-	sig2Atx3 := newChainedAtx(tb, sig2Atx2.ID, sig1Atx6.ID, nil, poetRef(), 8, 2, 0, sig2)
+	sig2Atx3 := newChainedAtx(sig2Atx2.ID, sig1Atx6.ID, nil, poetRef(), 8, 2, 0, sig2)
 	// epoch 9
-	sig1Atx7 := newChainedAtx(tb, sig1Atx6.ID, sig2Atx3.ID, nil, poetRef(), 9, 6, 0, sig1)
+	sig1Atx7 := newChainedAtx(sig1Atx6.ID, sig2Atx3.ID, nil, poetRef(), 9, 6, 0, sig1)
 
 	vAtxs := []*checkpoint.AtxDep{
 		sig1Atx1,
@@ -413,12 +432,14 @@ func createInterlinkedAtxChain(
 }
 
 func createAtxChain(tb testing.TB, sig *signing.EdSigner) ([]*checkpoint.AtxDep, []*types.PoetProofMessage) {
+	tb.Helper()
 	other, err := signing.NewEdSigner()
 	require.NoError(tb, err)
 	return createInterlinkedAtxChain(tb, other, sig)
 }
 
 func createAtxChainDepsOnly(tb testing.TB) ([]*checkpoint.AtxDep, []*types.PoetProofMessage) {
+	tb.Helper()
 	other, err := signing.NewEdSigner()
 	require.NoError(tb, err)
 
@@ -430,11 +451,11 @@ func createAtxChainDepsOnly(tb testing.TB) ([]*checkpoint.AtxDep, []*types.PoetP
 	}
 
 	// epoch 2
-	othAtx1 := newChainedAtx(tb, types.EmptyATXID, goldenAtx, &goldenAtx, poetRef(), 2, 0, 113, other)
+	othAtx1 := newChainedAtx(types.EmptyATXID, goldenAtx, &goldenAtx, poetRef(), 2, 0, 113, other)
 	// epoch 3
-	othAtx2 := newChainedAtx(tb, othAtx1.ID, othAtx1.ID, nil, poetRef(), 3, 1, 0, other)
+	othAtx2 := newChainedAtx(othAtx1.ID, othAtx1.ID, nil, poetRef(), 3, 1, 0, other)
 	// epoch 4
-	othAtx3 := newChainedAtx(tb, othAtx2.ID, othAtx2.ID, nil, poetRef(), 4, 2, 0, other)
+	othAtx3 := newChainedAtx(othAtx2.ID, othAtx2.ID, nil, poetRef(), 4, 2, 0, other)
 	atxDeps := []*checkpoint.AtxDep{othAtx1, othAtx2, othAtx3}
 
 	return atxDeps, proofs
@@ -505,6 +526,7 @@ func TestRecover_OwnAtxNotInCheckpoint_Preserve(t *testing.T) {
 	for _, proof := range proofs {
 		encoded, err := codec.Encode(proof)
 		require.NoError(t, err)
+
 		ref, err := proof.Ref()
 		require.NoError(t, err)
 
@@ -550,6 +572,7 @@ func TestRecover_OwnAtxNotInCheckpoint_Preserve(t *testing.T) {
 }
 
 func TestRecover_OwnAtxNotInCheckpoint_Preserve_IncludePending(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, http.MethodGet, r.Method)
 		w.WriteHeader(http.StatusOK)
@@ -591,6 +614,7 @@ func TestRecover_OwnAtxNotInCheckpoint_Preserve_IncludePending(t *testing.T) {
 	for _, proof := range proofs {
 		encoded, err := codec.Encode(proof)
 		require.NoError(t, err)
+
 		ref, err := proof.Ref()
 		require.NoError(t, err)
 
@@ -671,6 +695,7 @@ func TestRecover_OwnAtxNotInCheckpoint_Preserve_IncludePending(t *testing.T) {
 }
 
 func TestRecover_OwnAtxNotInCheckpoint_Preserve_Still_Initializing(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, http.MethodGet, r.Method)
 		w.WriteHeader(http.StatusOK)
@@ -770,6 +795,7 @@ func TestRecover_OwnAtxNotInCheckpoint_Preserve_Still_Initializing(t *testing.T)
 }
 
 func TestRecover_OwnAtxNotInCheckpoint_Preserve_DepIsGolden(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, http.MethodGet, r.Method)
 		w.WriteHeader(http.StatusOK)
@@ -852,6 +878,7 @@ func TestRecover_OwnAtxNotInCheckpoint_Preserve_DepIsGolden(t *testing.T) {
 }
 
 func TestRecover_OwnAtxNotInCheckpoint_DontPreserve(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, http.MethodGet, r.Method)
 		w.WriteHeader(http.StatusOK)
@@ -917,6 +944,7 @@ func TestRecover_OwnAtxNotInCheckpoint_DontPreserve(t *testing.T) {
 }
 
 func TestRecover_OwnAtxInCheckpoint(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, http.MethodGet, r.Method)
 		w.WriteHeader(http.StatusOK)

--- a/checkpoint/recovery_test.go
+++ b/checkpoint/recovery_test.go
@@ -927,12 +927,11 @@ func TestRecover_OwnAtxInCheckpoint(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	data, err := hex.DecodeString("0230c5d75d42b84f98800eceb47bc9cc4d803058900a50346a09ff61d56b6582")
+	nid, err := hex.DecodeString("0230c5d75d42b84f98800eceb47bc9cc4d803058900a50346a09ff61d56b6582")
 	require.NoError(t, err)
-	nid := types.BytesToNodeID(data)
-	data, err = hex.DecodeString("98e47278c1f58acfd2b670a730f28898f74eb140482a07b91ff81f9ff0b7d9f4")
+	atxid, err := hex.DecodeString("98e47278c1f58acfd2b670a730f28898f74eb140482a07b91ff81f9ff0b7d9f4")
 	require.NoError(t, err)
-	atx := newAtx(types.ATXID(types.BytesToHash(data)), types.EmptyATXID, nil, 3, 1, 0, nid)
+	atx := newAtx(types.ATXID(atxid), types.EmptyATXID, nil, 3, 1, 0, nid)
 
 	cfg := &checkpoint.RecoverConfig{
 		GoldenAtx:      goldenAtx,
@@ -940,7 +939,7 @@ func TestRecover_OwnAtxInCheckpoint(t *testing.T) {
 		DbFile:         "test.sql",
 		LocalDbFile:    "local.sql",
 		PreserveOwnAtx: true,
-		NodeIDs:        []types.NodeID{nid},
+		NodeIDs:        []types.NodeID{types.BytesToNodeID(nid)},
 		Uri:            fmt.Sprintf("%s/snapshot-15", ts.URL),
 		Restore:        types.LayerID(recoverLayer),
 	}

--- a/checkpoint/recovery_test.go
+++ b/checkpoint/recovery_test.go
@@ -226,11 +226,11 @@ func TestRecover_SameRecoveryInfo(t *testing.T) {
 	require.True(t, exist)
 }
 
-func TestRecover_SkipsWhenNoURI(t *testing.T) {
+func TestRecover_URIMustBeSet(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
-	d, err := checkpoint.Recover(ctx, zaptest.NewLogger(t), afero.NewMemMapFs(), &checkpoint.RecoverConfig{})
-	require.NoError(t, err)
+	cfg := &checkpoint.RecoverConfig{}
+	d, err := checkpoint.Recover(context.Background(), zaptest.NewLogger(t), afero.NewMemMapFs(), cfg)
+	require.ErrorContains(t, err, "uri not set")
 	require.Nil(t, d)
 }
 

--- a/checkpoint/runner_test.go
+++ b/checkpoint/runner_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"slices"
 	"testing"
 	"time"
 
@@ -30,36 +29,54 @@ func TestMain(m *testing.M) {
 	os.Exit(res)
 }
 
-var allAtxs = map[types.NodeID][]*types.ActivationTx{
+type miner struct {
+	atxs             []*types.ActivationTx
+	malfeasanceProof []byte
+}
+
+var allMiners = []miner{
 	// smesher 1 has 7 ATXs, one in each epoch from 1 to 7
-	types.BytesToNodeID([]byte("smesher1")): {
-		newAtx(types.ATXID{17}, types.ATXID{16}, nil, 7, 6, 123, types.BytesToNodeID([]byte("smesher1"))),
-		newAtx(types.ATXID{16}, types.ATXID{15}, nil, 6, 5, 123, types.BytesToNodeID([]byte("smesher1"))),
-		newAtx(types.ATXID{15}, types.ATXID{14}, nil, 5, 4, 123, types.BytesToNodeID([]byte("smesher1"))),
-		newAtx(types.ATXID{14}, types.ATXID{13}, nil, 4, 3, 123, types.BytesToNodeID([]byte("smesher1"))),
-		newAtx(types.ATXID{13}, types.ATXID{12}, nil, 3, 2, 123, types.BytesToNodeID([]byte("smesher1"))),
-		newAtx(types.ATXID{12}, types.ATXID{11}, nil, 2, 1, 123, types.BytesToNodeID([]byte("smesher1"))),
-		newAtx(types.ATXID{11}, types.EmptyATXID,
-			&types.ATXID{1}, 1, 0, 123, types.BytesToNodeID([]byte("smesher1"))),
+	{
+		atxs: []*types.ActivationTx{
+			newAtx(types.ATXID{17}, types.ATXID{16}, nil, 7, 6, 123, []byte("smesher1")),
+			newAtx(types.ATXID{16}, types.ATXID{15}, nil, 6, 5, 123, []byte("smesher1")),
+			newAtx(types.ATXID{15}, types.ATXID{14}, nil, 5, 4, 123, []byte("smesher1")),
+			newAtx(types.ATXID{14}, types.ATXID{13}, nil, 4, 3, 123, []byte("smesher1")),
+			newAtx(types.ATXID{13}, types.ATXID{12}, nil, 3, 2, 123, []byte("smesher1")),
+			newAtx(types.ATXID{12}, types.ATXID{11}, nil, 2, 1, 123, []byte("smesher1")),
+			newAtx(types.ATXID{11}, types.EmptyATXID, &types.ATXID{1}, 1, 0, 123, []byte("smesher1")),
+		},
 	},
 
 	// smesher 2 has 1 ATX in epoch 7
-	types.BytesToNodeID([]byte("smesher2")): {
-		newAtx(types.ATXID{27}, types.EmptyATXID, &types.ATXID{2}, 7, 0, 152,
-			types.BytesToNodeID([]byte("smesher2"))),
+	{
+		atxs: []*types.ActivationTx{
+			newAtx(types.ATXID{27}, types.EmptyATXID, &types.ATXID{2}, 7, 0, 152, []byte("smesher2")),
+		},
 	},
 
 	// smesher 3 has 1 ATX in epoch 2
-	types.BytesToNodeID([]byte("smesher3")): {
-		newAtx(types.ATXID{32}, types.EmptyATXID, &types.ATXID{3}, 2, 0, 211,
-			types.BytesToNodeID([]byte("smesher3"))),
+	{
+		atxs: []*types.ActivationTx{
+			newAtx(types.ATXID{32}, types.EmptyATXID, &types.ATXID{3}, 2, 0, 211, []byte("smesher3")),
+		},
 	},
 
 	// smesher 4 has 1 ATX in epoch 3 and one in epoch 7
-	types.BytesToNodeID([]byte("smesher4")): {
-		newAtx(types.ATXID{47}, types.ATXID{43}, nil, 7, 1, 420, types.BytesToNodeID([]byte("smesher4"))),
-		newAtx(types.ATXID{43}, types.EmptyATXID, &types.ATXID{4}, 4, 0, 420,
-			types.BytesToNodeID([]byte("smesher4"))),
+	{
+		atxs: []*types.ActivationTx{
+			newAtx(types.ATXID{47}, types.ATXID{43}, nil, 7, 1, 420, []byte("smesher4")),
+			newAtx(types.ATXID{43}, types.EmptyATXID, &types.ATXID{4}, 4, 0, 420, []byte("smesher4")),
+		},
+	},
+
+	// smesher 5 is malicious and equivocated in epoch 7
+	{
+		atxs: []*types.ActivationTx{
+			newAtx(types.ATXID{83}, types.EmptyATXID, &types.ATXID{27}, 7, 0, 113, []byte("smesher5")),
+			newAtx(types.ATXID{97}, types.EmptyATXID, &types.ATXID{16}, 7, 0, 113, []byte("smesher5")),
+		},
+		malfeasanceProof: []byte("im bad"),
 	},
 }
 
@@ -130,7 +147,7 @@ var allAccounts = []*types.Account{
 	},
 }
 
-func expectedCheckpoint(t *testing.T, snapshot types.LayerID, numAtxs int) *types.Checkpoint {
+func expectedCheckpoint(t *testing.T, snapshot types.LayerID, numAtxs int, miners []miner) *types.Checkpoint {
 	t.Helper()
 
 	request, err := json.Marshal(&pb.CheckpointStreamRequest{
@@ -151,8 +168,12 @@ func expectedCheckpoint(t *testing.T, snapshot types.LayerID, numAtxs int) *type
 		require.Fail(t, "numEpochs must be at least 2")
 	}
 
-	atxData := make([]types.AtxSnapshot, 0, numAtxs*len(allAtxs))
-	for _, atxs := range allAtxs {
+	atxData := make([]types.AtxSnapshot, 0, numAtxs*len(miners))
+	for _, miner := range miners {
+		if len(miner.malfeasanceProof) > 0 {
+			continue
+		}
+		atxs := miner.atxs
 		n := len(atxs)
 		if n > numAtxs {
 			n = numAtxs
@@ -198,7 +219,7 @@ func newAtx(
 	commitAtx *types.ATXID,
 	epoch uint32,
 	seq, vrfnonce uint64,
-	nodeID types.NodeID,
+	nodeID []byte,
 ) *types.ActivationTx {
 	atx := &types.ActivationTx{
 		PublishEpoch:  types.EpochID(epoch),
@@ -208,7 +229,7 @@ func newAtx(
 		NumUnits:      2,
 		Coinbase:      types.Address{1, 2, 3},
 		TickCount:     1,
-		SmesherID:     nodeID,
+		SmesherID:     types.BytesToNodeID(nodeID),
 		VRFNonce:      types.VRFPostIndex(vrfnonce),
 	}
 	atx.SetID(id)
@@ -231,71 +252,52 @@ func asAtxSnapshot(v *types.ActivationTx, cmt *types.ATXID) types.AtxSnapshot {
 	}
 }
 
-func createMesh(t *testing.T, db *sql.Database, miners map[types.NodeID][]*types.ActivationTx, accts []*types.Account) {
-	for _, vatxs := range miners {
-		vatxs = slices.Clone(vatxs)
-		// ATXs are expected to be in reverse epoch order and we want older ATXs
-		// created first so that the nonce can be retrieved from them for
-		// populating the nonce field when creating newer ones
-		slices.Reverse(vatxs)
-		for _, atx := range vatxs {
+func createMesh(t *testing.T, db *sql.Database, miners []miner, accts []*types.Account) {
+	for _, miner := range miners {
+		for _, atx := range miner.atxs {
 			require.NoError(t, atxs.Add(db, atx))
+		}
+		if proof := miner.malfeasanceProof; len(proof) > 0 {
+			require.NoError(t, identities.SetMalicious(db, miner.atxs[0].SmesherID, proof, time.Now()))
 		}
 	}
 
 	for _, it := range accts {
 		require.NoError(t, accounts.Update(db, it))
 	}
-
-	// smesher 5 is malicious and equivocated in epoch 7
-	bad := types.BytesToNodeID([]byte("smesher5"))
-	require.NoError(t, atxs.Add(db, newAtx(types.ATXID{83}, types.EmptyATXID, &types.ATXID{27}, 7, 0, 113, bad)))
-	require.NoError(t, atxs.Add(db, newAtx(types.ATXID{97}, types.EmptyATXID, &types.ATXID{16}, 7, 0, 113, bad)))
-	require.NoError(t, identities.SetMalicious(db, bad, []byte("bad"), time.Now()))
 }
 
 func TestRunner_Generate(t *testing.T) {
 	tcs := []struct {
 		desc    string
-		atxes   map[types.NodeID][]*types.ActivationTx
+		miners  []miner
 		numAtxs int
 		accts   []*types.Account
-		fail    bool
 	}{
 		{
 			desc:    "all good, 2 atxs",
-			atxes:   allAtxs,
+			miners:  allMiners,
 			numAtxs: 2,
 			accts:   allAccounts,
 		},
 		{
 			desc:    "all good, 4 atxs",
-			atxes:   allAtxs,
+			miners:  allMiners,
 			numAtxs: 4,
 			accts:   allAccounts,
 		},
 		{
 			desc:    "all good, 7 atxs",
-			atxes:   allAtxs,
+			miners:  allMiners,
 			numAtxs: 7,
 			accts:   allAccounts,
-		},
-		{
-			desc:  "no atxs",
-			accts: allAccounts,
-			fail:  true,
-		},
-		{
-			desc:  "no accounts",
-			atxes: allAtxs,
-			fail:  true,
 		},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {
 			db := sql.InMemory()
 			snapshot := types.LayerID(5)
-			createMesh(t, db, tc.atxes, tc.accts)
+			createMesh(t, db, tc.miners, tc.accts)
 
 			fs := afero.NewMemMapFs()
 			dir, err := afero.TempDir(fs, "", "Generate")
@@ -303,17 +305,13 @@ func TestRunner_Generate(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 			defer cancel()
 			err = checkpoint.Generate(ctx, fs, db, dir, snapshot, tc.numAtxs)
-			if tc.fail {
-				require.Error(t, err)
-				return
-			}
 			require.NoError(t, err)
 			fname := checkpoint.SelfCheckpointFilename(dir, snapshot)
 			persisted, err := afero.ReadFile(fs, fname)
 			require.NoError(t, err)
 			require.NoError(t, checkpoint.ValidateSchema(persisted))
 			var got types.Checkpoint
-			expected := expectedCheckpoint(t, snapshot, tc.numAtxs)
+			expected := expectedCheckpoint(t, snapshot, tc.numAtxs, tc.miners)
 			require.NoError(t, json.Unmarshal(persisted, &got))
 
 			require.True(t, cmp.Equal(
@@ -330,39 +328,45 @@ func TestRunner_Generate(t *testing.T) {
 }
 
 func TestRunner_Generate_Error(t *testing.T) {
-	const numEpochs = 2
+	t.Parallel()
+	t.Run("no commitment atx", func(t *testing.T) {
+		t.Parallel()
+		db := sql.InMemory()
+		snapshot := types.LayerID(5)
 
-	tcs := []struct {
-		desc              string
-		missingCommitment bool
-	}{
-		{
-			desc:              "no commitment atx",
-			missingCommitment: true,
-		},
-	}
-	for _, tc := range tcs {
-		t.Run(tc.desc, func(t *testing.T) {
-			db := sql.InMemory()
-			snapshot := types.LayerID(5)
-			var atx *types.ActivationTx
-			if tc.missingCommitment {
-				atx = newAtx(types.ATXID{13}, types.EmptyATXID,
-					nil, 2, 1, 11, types.BytesToNodeID([]byte("smesher1")))
-			}
-			createMesh(t, db, map[types.NodeID][]*types.ActivationTx{
-				types.BytesToNodeID([]byte("smesher1")): {atx},
-			}, allAccounts)
+		atx := newAtx(types.ATXID{13}, types.EmptyATXID, nil, 2, 1, 11, types.RandomNodeID().Bytes())
+		createMesh(t, db, []miner{{atxs: []*types.ActivationTx{atx}}}, allAccounts)
 
-			fs := afero.NewMemMapFs()
-			dir, err := afero.TempDir(fs, "", "Generate")
-			require.NoError(t, err)
-			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-			defer cancel()
-			err = checkpoint.Generate(ctx, fs, db, dir, snapshot, numEpochs)
-			if tc.missingCommitment {
-				require.ErrorContains(t, err, "atxs snapshot commitment")
-			}
-		})
-	}
+		fs := afero.NewMemMapFs()
+		dir, err := afero.TempDir(fs, "", "Generate")
+		require.NoError(t, err)
+		err = checkpoint.Generate(context.Background(), fs, db, dir, snapshot, 2)
+		require.ErrorContains(t, err, "atxs snapshot commitment")
+	})
+	t.Run("no atxs", func(t *testing.T) {
+		t.Parallel()
+		db := sql.InMemory()
+		snapshot := types.LayerID(5)
+		createMesh(t, db, nil, allAccounts)
+
+		fs := afero.NewMemMapFs()
+		dir, err := afero.TempDir(fs, "", "Generate")
+		require.NoError(t, err)
+
+		err = checkpoint.Generate(context.Background(), fs, db, dir, snapshot, 2)
+		require.Error(t, err)
+	})
+	t.Run("no accounts", func(t *testing.T) {
+		t.Parallel()
+		db := sql.InMemory()
+		snapshot := types.LayerID(5)
+		createMesh(t, db, allMiners, nil)
+
+		fs := afero.NewMemMapFs()
+		dir, err := afero.TempDir(fs, "", "Generate")
+		require.NoError(t, err)
+
+		err = checkpoint.Generate(context.Background(), fs, db, dir, snapshot, 2)
+		require.Error(t, err)
+	})
 }

--- a/checkpoint/runner_test.go
+++ b/checkpoint/runner_test.go
@@ -147,7 +147,7 @@ var allAccounts = []*types.Account{
 	},
 }
 
-func expectedCheckpoint(t *testing.T, snapshot types.LayerID, numAtxs int, miners []miner) *types.Checkpoint {
+func expectedCheckpoint(t testing.TB, snapshot types.LayerID, numAtxs int, miners []miner) *types.Checkpoint {
 	t.Helper()
 
 	request, err := json.Marshal(&pb.CheckpointStreamRequest{
@@ -252,7 +252,8 @@ func asAtxSnapshot(v *types.ActivationTx, cmt *types.ATXID) types.AtxSnapshot {
 	}
 }
 
-func createMesh(t *testing.T, db *sql.Database, miners []miner, accts []*types.Account) {
+func createMesh(t testing.TB, db *sql.Database, miners []miner, accts []*types.Account) {
+	t.Helper()
 	for _, miner := range miners {
 		for _, atx := range miner.atxs {
 			require.NoError(t, atxs.Add(db, atx))

--- a/checkpoint/runner_test.go
+++ b/checkpoint/runner_test.go
@@ -268,6 +268,7 @@ func createMesh(t *testing.T, db *sql.Database, miners []miner, accts []*types.A
 }
 
 func TestRunner_Generate(t *testing.T) {
+	t.Parallel()
 	tcs := []struct {
 		desc    string
 		miners  []miner
@@ -295,6 +296,7 @@ func TestRunner_Generate(t *testing.T) {
 	}
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
 			db := sql.InMemory()
 			snapshot := types.LayerID(5)
 			createMesh(t, db, tc.miners, tc.accts)

--- a/checkpoint/util_test.go
+++ b/checkpoint/util_test.go
@@ -17,6 +17,7 @@ import (
 var checkpointData string
 
 func TestValidateSchema(t *testing.T) {
+	t.Parallel()
 	tcs := []struct {
 		desc string
 		fail bool
@@ -79,6 +80,7 @@ func TestValidateSchema(t *testing.T) {
 }
 
 func TestRecoveryFile(t *testing.T) {
+	t.Parallel()
 	tcs := []struct {
 		desc   string
 		fname  string
@@ -118,6 +120,7 @@ func TestRecoveryFile(t *testing.T) {
 }
 
 func TestRecoveryFile_Copy(t *testing.T) {
+	t.Parallel()
 	fs := afero.NewMemMapFs()
 	rf, err := checkpoint.NewRecoveryFile(fs, filepath.Join(t.TempDir(), "test"))
 	require.NoError(t, err)
@@ -125,6 +128,7 @@ func TestRecoveryFile_Copy(t *testing.T) {
 }
 
 func TestCopyFile(t *testing.T) {
+	t.Parallel()
 	aferoFS := afero.NewMemMapFs()
 	dir := t.TempDir()
 	src := filepath.Join(dir, "test_src")

--- a/common/types/poet.go
+++ b/common/types/poet.go
@@ -20,6 +20,10 @@ type PoetServer struct {
 
 type PoetProofRef Hash32
 
+func (r *PoetProofRef) String() string {
+	return hex.EncodeToString(r[:])
+}
+
 // EmptyPoetProofRef is an empty PoET proof reference.
 var EmptyPoetProofRef = PoetProofRef{}
 

--- a/node/node.go
+++ b/node/node.go
@@ -44,7 +44,6 @@ import (
 	"github.com/spacemeshos/go-spacemesh/bootstrap"
 	"github.com/spacemeshos/go-spacemesh/checkpoint"
 	"github.com/spacemeshos/go-spacemesh/cmd"
-	"github.com/spacemeshos/go-spacemesh/codec"
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/config"
 	"github.com/spacemeshos/go-spacemesh/config/presets"
@@ -184,11 +183,6 @@ func GetCommand() *cobra.Command {
 
 			// Don't print usage on error from this point forward
 			c.SilenceUsage = true
-
-			app.preserve, err = app.LoadCheckpoint(ctx)
-			if err != nil {
-				return fmt.Errorf("loading checkpoint: %w", err)
-			}
 
 			// This blocks until the context is finished or until an error is produced
 			err = app.Start(ctx)
@@ -424,7 +418,6 @@ type App struct {
 	poetDb            *activation.PoetDb
 	postVerifier      activation.PostVerifier
 	postSupervisor    *activation.PostSupervisor
-	preserve          *checkpoint.PreservedData
 	errCh             chan error
 
 	host *p2p.Host
@@ -434,15 +427,7 @@ type App struct {
 	eg      *errgroup.Group
 }
 
-func (app *App) LoadCheckpoint(ctx context.Context) (*checkpoint.PreservedData, error) {
-	checkpointFile := app.Config.Recovery.Uri
-	restore := types.LayerID(app.Config.Recovery.Restore)
-	if len(checkpointFile) == 0 {
-		return nil, nil
-	}
-	if restore == 0 {
-		return nil, errors.New("restore layer not set")
-	}
+func (app *App) loadCheckpoint(ctx context.Context) (*checkpoint.PreservedData, error) {
 	nodeIDs := make([]types.NodeID, len(app.signers))
 	for i, sig := range app.signers {
 		nodeIDs[i] = sig.NodeID()
@@ -454,13 +439,10 @@ func (app *App) LoadCheckpoint(ctx context.Context) (*checkpoint.PreservedData, 
 		LocalDbFile:    localDbFile,
 		PreserveOwnAtx: app.Config.Recovery.PreserveOwnAtx,
 		NodeIDs:        nodeIDs,
-		Uri:            checkpointFile,
-		Restore:        restore,
+		Uri:            app.Config.Recovery.Uri,
+		Restore:        types.LayerID(app.Config.Recovery.Restore),
 	}
-	app.log.WithContext(ctx).With().Info("recover from checkpoint",
-		log.String("url", checkpointFile),
-		log.Stringer("restore", restore),
-	)
+
 	return checkpoint.Recover(ctx, app.log.Zap(), afero.NewOsFs(), cfg)
 }
 
@@ -2085,6 +2067,11 @@ func (app *App) startSynchronous(ctx context.Context) (err error) {
 		}
 	}
 
+	preserved, err := app.loadCheckpoint(ctx)
+	if err != nil {
+		return fmt.Errorf("loading checkpoint: %w", err)
+	}
+
 	/* Initialize all protocol services */
 
 	gTime, err := time.Parse(time.RFC3339, app.Config.Genesis.GenesisTime)
@@ -2129,6 +2116,7 @@ func (app *App) startSynchronous(ctx context.Context) (err error) {
 	if err := app.setupDBs(ctx, logger); err != nil {
 		return err
 	}
+
 	if err := app.initServices(ctx); err != nil {
 		return fmt.Errorf("init services: %w", err)
 	}
@@ -2153,7 +2141,7 @@ func (app *App) startSynchronous(ctx context.Context) (err error) {
 	}
 
 	// need post verifying service to start first
-	app.preserveAfterRecovery(ctx)
+	app.preserveAfterRecovery(ctx, preserved)
 
 	if err := app.startAPIServices(ctx); err != nil {
 		return err
@@ -2169,40 +2157,32 @@ func (app *App) startSynchronous(ctx context.Context) (err error) {
 	return nil
 }
 
-func (app *App) preserveAfterRecovery(ctx context.Context) {
-	if app.preserve == nil {
+func (app *App) preserveAfterRecovery(ctx context.Context, preserved *checkpoint.PreservedData) {
+	if preserved == nil {
 		app.log.Info("no need to preserve data after recovery")
 		return
 	}
-	for i, poetProof := range app.preserve.Proofs {
-		encoded, err := codec.Encode(poetProof)
-		if err != nil {
-			app.log.With().Error("failed to encode poet proof after checkpoint",
-				log.Object("poet proof", poetProof),
-				log.Err(err),
-			)
-			continue
-		}
+	for i, poetProof := range preserved.Proofs {
 		ref, err := poetProof.Ref()
 		if err != nil {
-			app.log.With().Error("failed to get poet proof ref after checkpoint", log.Inline(poetProof), log.Err(err))
+			app.log.With().Error("failed to calculated poet proof ref after checkpoint", log.Inline(poetProof))
 			continue
 		}
-		hash := types.Hash32(ref)
-		if err := app.poetDb.ValidateAndStoreMsg(ctx, hash, p2p.NoPeer, encoded); err != nil {
+
+		if err := app.poetDb.ValidateAndStore(ctx, poetProof); err != nil {
 			app.log.With().Error("failed to preserve poet proof after checkpoint",
-				log.Stringer("atx id", app.preserve.Deps[i].ID),
-				log.String("poet proof ref", hash.ShortString()),
+				log.Stringer("atx id", preserved.Deps[i].ID),
+				log.Stringer("poet proof ref", &ref),
 				log.Err(err),
 			)
 			continue
 		}
 		app.log.With().Info("preserved poet proof after checkpoint",
-			log.Stringer("atx id", app.preserve.Deps[i].ID),
-			log.String("poet proof ref", hash.ShortString()),
+			log.Stringer("atx id", preserved.Deps[i].ID),
+			log.Stringer("poet proof ref", &ref),
 		)
 	}
-	for _, atx := range app.preserve.Deps {
+	for _, atx := range preserved.Deps {
 		if err := app.atxHandler.HandleSyncedAtx(ctx, atx.ID.Hash32(), p2p.NoPeer, atx.Blob); err != nil {
 			app.log.With().Error(
 				"failed to preserve atx after checkpoint",


### PR DESCRIPTION
## Motivation

few refactors to simplify and untangle the code

## Description

- cleaned up unit tests:
  - removed implicit usage of globals (`expectedCheckpoint`)
  - reordered tests to avoid tests branching on conditions like `if tc.fail` (tests for error conditions are separate now)
- moved loading checkpoint out from the Cobra command to the app start routine
- removed `preserve *checkpoint.PreserveData` from `App struct` - it's a local variable now
- moved few checks from `node` package to `checkpoint` for better testability + added tests

## Test Plan

tests pass

## TODO

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [ ] Update documentation as needed
- [ ] Update [changelog](../CHANGELOG.md) as needed
