### PR TITLE
[Merged by Bors] - Try stabilising connection issues in systests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
         if: ${{ matrix.os == 'windows-2022' }}
         run: |
           git config --global pack.window 1
-          git config --global pack.depth 1
+          git config --global core.compression 0
           git config --global http.postBuffer 524288000
       - name: checkout
         uses: actions/checkout@v4
@@ -194,7 +194,7 @@ jobs:
         if: ${{ matrix.os == 'windows-2022' }}
         run: |
           git config --global pack.window 1
-          git config --global pack.depth 1
+          git config --global core.compression 0
           git config --global http.postBuffer 524288000
       - name: checkout
         uses: actions/checkout@v4
@@ -256,7 +256,7 @@ jobs:
         if: ${{ matrix.os == 'windows-2022' }}
         run: |
           git config --global pack.window 1
-          git config --global pack.depth 1
+          git config --global core.compression 0
           git config --global http.postBuffer 524288000
       - name: checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
         if: ${{ matrix.os == 'windows-2022' }}
         run: |
           git config --global pack.window 1
-          git config --global core.compression 0
+          git config --global pack.depth 1
           git config --global http.postBuffer 524288000
       - name: checkout
         uses: actions/checkout@v4
@@ -194,7 +194,7 @@ jobs:
         if: ${{ matrix.os == 'windows-2022' }}
         run: |
           git config --global pack.window 1
-          git config --global core.compression 0
+          git config --global pack.depth 1
           git config --global http.postBuffer 524288000
       - name: checkout
         uses: actions/checkout@v4
@@ -256,7 +256,7 @@ jobs:
         if: ${{ matrix.os == 'windows-2022' }}
         run: |
           git config --global pack.window 1
-          git config --global core.compression 0
+          git config --global pack.depth 1
           git config --global http.postBuffer 524288000
       - name: checkout
         uses: actions/checkout@v4

--- a/systest/Makefile
+++ b/systest/Makefile
@@ -36,7 +36,7 @@ ifeq ($(configname),$(test_job_name))
 	run_deps = config
 endif
 
-command := tests -test.v -test.count=$(count) -test.timeout=0 -test.run=$(test_name) -clusters=$(clusters) \
+command := tests -test.count=$(count) -test.timeout=0 -test.run=$(test_name) -clusters=$(clusters) \
 -level=$(level) -labels=$(label) -configname=$(configname)
 
 .PHONY: docker

--- a/systest/cluster/nodes.go
+++ b/systest/cluster/nodes.go
@@ -19,6 +19,7 @@ import (
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 	apiv1 "k8s.io/api/core/v1"
@@ -168,7 +169,7 @@ func (n *NodeClient) Resolve(ctx context.Context) (string, error) {
 	return pod.Status.PodIP, nil
 }
 
-func (n *NodeClient) ensurePubConn() (*grpc.ClientConn, error) {
+func (n *NodeClient) ensurePubConn(ctx context.Context) (*grpc.ClientConn, error) {
 	n.mu.Lock()
 	defer n.mu.Unlock()
 	if n.pubConn != nil {
@@ -185,8 +186,33 @@ func (n *NodeClient) ensurePubConn() (*grpc.ClientConn, error) {
 	if err != nil {
 		return nil, err
 	}
+	if err := n.waitForConnectionReady(context.Background(), conn); err != nil {
+		return nil, err
+	}
 	n.pubConn = conn
 	return n.pubConn, nil
+}
+
+// waitForConnectionReady blocks until the connection is ready. It returns an error if the context is canceled or
+// timed out.
+//
+// This doesn't guarantee that the connection will stay ready, but it makes it so that the test runner waits at least
+// until the nodes are started before querying them.
+func (n *NodeClient) waitForConnectionReady(ctx context.Context, conn *grpc.ClientConn) error {
+	// A blocking dial blocks until the clientConn is ready.
+	for {
+		s := conn.GetState()
+		if s == connectivity.Ready {
+			return nil
+		}
+		if s == connectivity.Idle {
+			conn.Connect()
+		}
+		if !conn.WaitForStateChange(ctx, s) {
+			// ctx got timeout or canceled.
+			return fmt.Errorf("waiting for connection to %s: %w", conn.Target(), ctx.Err())
+		}
+	}
 }
 
 func (n *NodeClient) resetPubConn(conn *grpc.ClientConn) {
@@ -198,7 +224,7 @@ func (n *NodeClient) resetPubConn(conn *grpc.ClientConn) {
 	}
 }
 
-func (n *NodeClient) ensurePrivConn() (*grpc.ClientConn, error) {
+func (n *NodeClient) ensurePrivConn(ctx context.Context) (*grpc.ClientConn, error) {
 	n.mu.Lock()
 	defer n.mu.Unlock()
 	if n.privConn != nil {
@@ -213,6 +239,9 @@ func (n *NodeClient) ensurePrivConn() (*grpc.ClientConn, error) {
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 	)
 	if err != nil {
+		return nil, err
+	}
+	if err := n.waitForConnectionReady(ctx, conn); err != nil {
 		return nil, err
 	}
 	n.privConn = conn
@@ -237,7 +266,7 @@ type PubNodeClient struct {
 }
 
 func (n *PubNodeClient) Invoke(ctx context.Context, method string, args, reply any, opts ...grpc.CallOption) error {
-	conn, err := n.ensurePubConn()
+	conn, err := n.ensurePubConn(ctx)
 	if err != nil {
 		return err
 	}
@@ -259,7 +288,7 @@ func (n *PubNodeClient) NewStream(
 	method string,
 	opts ...grpc.CallOption,
 ) (grpc.ClientStream, error) {
-	conn, err := n.ensurePubConn()
+	conn, err := n.ensurePubConn(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -279,7 +308,7 @@ type PrivNodeClient struct {
 }
 
 func (n *PrivNodeClient) Invoke(ctx context.Context, method string, args, reply any, opts ...grpc.CallOption) error {
-	conn, err := n.ensurePrivConn()
+	conn, err := n.ensurePrivConn(ctx)
 	if err != nil {
 		return err
 	}
@@ -301,7 +330,7 @@ func (n *PrivNodeClient) NewStream(
 	method string,
 	opts ...grpc.CallOption,
 ) (grpc.ClientStream, error) {
-	conn, err := n.ensurePrivConn()
+	conn, err := n.ensurePrivConn(ctx)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Motivation

It looks like the test runner tries to query nodes before they are actually up and ready to be queried. I added a check to the connection establishment that blocks until it becomes ready.

## Description

The additional function call will block until either a timeout happens or the connection becomes ready at which time an actual query shouldn't fail any more.

## Test Plan

existing tests pass

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
