### PR TITLE
Persist information about merged ATX members across checkpoint

### DIFF
--- a/activation/handler.go
+++ b/activation/handler.go
@@ -237,8 +237,6 @@ func (h *Handler) determineVersion(msg []byte) (*types.AtxVersion, error) {
 
 type opaqueAtx interface {
 	ID() types.ATXID
-	Published() types.EpochID
-	TotalNumUnits() uint32
 }
 
 func (h *Handler) decodeATX(msg []byte) (opaqueAtx, error) {

--- a/activation/handler_v1.go
+++ b/activation/handler_v1.go
@@ -168,47 +168,6 @@ func (h *HandlerV1) commitment(atx *wire.ActivationTxV1) (types.ATXID, error) {
 	return atxs.CommitmentATX(h.cdb, atx.SmesherID)
 }
 
-// Obtain the previous ATX for the given ATX.
-// We need to decode it from the blob because we are interested in the true NumUnits value
-// that was declared by the previous ATX and the `atxs` table only holds the effective NumUnits.
-// However, in case of a golden ATX, the blob is not available and we fallback to fetching the ATX from the DB
-// to use the effective num units.
-func (h *HandlerV1) previous(ctx context.Context, atx *wire.ActivationTxV1) (*types.ActivationTx, error) {
-	var blob sql.Blob
-	v, err := atxs.LoadBlob(ctx, h.cdb, atx.PrevATXID[:], &blob)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(blob.Bytes) == 0 {
-		// An empty blob indicates a golden ATX (after a checkpoint-recovery).
-		// Fallback to fetching it from the DB to get the effective NumUnits.
-		atx, err := atxs.Get(h.cdb, atx.PrevATXID)
-		if err != nil {
-			return nil, fmt.Errorf("fetching golden previous atx: %w", err)
-		}
-		return atx, nil
-	}
-	if v != types.AtxV1 {
-		return nil, fmt.Errorf("previous atx %s is not of version 1", atx.PrevATXID)
-	}
-
-	var prev wire.ActivationTxV1
-	if err := codec.Decode(blob.Bytes, &prev); err != nil {
-		return nil, fmt.Errorf("decoding previous atx: %w", err)
-	}
-	prev.SetID(atx.PrevATXID)
-	if prev.VRFNonce == nil {
-		nonce, err := atxs.NonceByID(h.cdb, prev.ID())
-		if err != nil {
-			return nil, fmt.Errorf("failed to get nonce of previous ATX %s: %w", prev.ID(), err)
-		}
-		prev.VRFNonce = (*uint64)(&nonce)
-	}
-
-	return wire.ActivationTxFromWireV1(&prev, blob.Bytes...), nil
-}
-
 func (h *HandlerV1) syntacticallyValidateDeps(
 	ctx context.Context,
 	atx *wire.ActivationTxV1,
@@ -224,14 +183,18 @@ func (h *HandlerV1) syntacticallyValidateDeps(
 		}
 		effectiveNumUnits = atx.NumUnits
 	} else {
-		previous, err := h.previous(ctx, atx)
+		previous, err := atxs.Get(h.cdb, atx.PrevATXID)
 		if err != nil {
 			return 0, 0, nil, fmt.Errorf("fetching previous atx %s: %w", atx.PrevATXID, err)
 		}
 		if err := h.validateNonInitialAtx(ctx, atx, previous, commitmentATX); err != nil {
 			return 0, 0, nil, err
 		}
-		effectiveNumUnits = min(previous.NumUnits, atx.NumUnits)
+		prevUnits, err := atxs.Units(h.cdb, atx.PrevATXID, atx.SmesherID)
+		if err != nil {
+			return 0, 0, nil, fmt.Errorf("fetching previous atx units: %w", err)
+		}
+		effectiveNumUnits = min(prevUnits, atx.NumUnits)
 	}
 
 	err = h.nipostValidator.PositioningAtx(atx.PositioningATXID, h.cdb, h.goldenATXID, atx.PublishEpoch)
@@ -591,6 +554,11 @@ func (h *HandlerV1) storeAtx(
 		if err != nil && !errors.Is(err, sql.ErrObjectExists) {
 			return fmt.Errorf("add atx to db: %w", err)
 		}
+		err = atxs.SetUnits(tx, atx.ID(), map[types.NodeID]uint32{atx.SmesherID: watx.NumUnits})
+		if err != nil && !errors.Is(err, sql.ErrObjectExists) {
+			return fmt.Errorf("set atx units: %w", err)
+		}
+
 		return nil
 	}); err != nil {
 		return nil, fmt.Errorf("store atx: %w", err)

--- a/activation/handler_v2_test.go
+++ b/activation/handler_v2_test.go
@@ -533,7 +533,7 @@ func TestHandlerV2_ProcessSoloATX(t *testing.T) {
 
 		atxFromDb, err := atxs.Get(atxHandler.cdb, atx.ID())
 		require.NoError(t, err)
-		require.Equal(t, atx.TotalNumUnits(), atxFromDb.TotalNumUnits())
+		require.Equal(t, atx.TotalNumUnits(), atxFromDb.NumUnits)
 	})
 	t.Run("second ATX, increases space (nonce valid)", func(t *testing.T) {
 		t.Parallel()
@@ -553,7 +553,7 @@ func TestHandlerV2_ProcessSoloATX(t *testing.T) {
 		atxFromDb, err := atxs.Get(atxHandler.cdb, atx.ID())
 		require.NoError(t, err)
 		require.EqualValues(t, atx.VRFNonce, atxFromDb.VRFNonce)
-		require.Equal(t, min(prev.TotalNumUnits(), atx.TotalNumUnits()), atxFromDb.TotalNumUnits())
+		require.Equal(t, min(prev.TotalNumUnits(), atx.TotalNumUnits()), atxFromDb.NumUnits)
 	})
 	t.Run("second ATX, increases space (nonce invalid)", func(t *testing.T) {
 		t.Parallel()
@@ -598,7 +598,7 @@ func TestHandlerV2_ProcessSoloATX(t *testing.T) {
 		// verify that the ATX was added to the DB and it has the lower effective num units
 		atxFromDb, err := atxs.Get(atxHandler.cdb, atx.ID())
 		require.NoError(t, err)
-		require.Equal(t, min(prev.TotalNumUnits(), atx.TotalNumUnits()), atxFromDb.TotalNumUnits())
+		require.Equal(t, min(prev.TotalNumUnits(), atx.TotalNumUnits()), atxFromDb.NumUnits)
 		require.EqualValues(t, atx.VRFNonce, atxFromDb.VRFNonce)
 	})
 	t.Run("can't find positioning ATX", func(t *testing.T) {

--- a/activation/wire/wire_v1.go
+++ b/activation/wire/wire_v1.go
@@ -106,14 +106,6 @@ func (atx *ActivationTxV1) SetID(id types.ATXID) {
 	atx.id = id
 }
 
-func (atx *ActivationTxV1) Published() types.EpochID {
-	return atx.PublishEpoch
-}
-
-func (atx *ActivationTxV1) TotalNumUnits() uint32 {
-	return atx.NumUnits
-}
-
 func (atx *ActivationTxV1) Sign(signer *signing.EdSigner) {
 	if atx.PrevATXID == types.EmptyATXID {
 		nodeID := signer.NodeID()

--- a/activation/wire/wire_v2.go
+++ b/activation/wire/wire_v2.go
@@ -136,10 +136,6 @@ func (atx *ActivationTxV2) Sign(signer *signing.EdSigner) {
 	atx.Signature = signer.Sign(signing.ATX, atx.SignedBytes())
 }
 
-func (atx *ActivationTxV2) Published() types.EpochID {
-	return atx.PublishEpoch
-}
-
 func (atx *ActivationTxV2) TotalNumUnits() uint32 {
 	var total uint32
 	for _, post := range atx.NiPosts {

--- a/api/grpcserver/admin_service_test.go
+++ b/api/grpcserver/admin_service_test.go
@@ -38,6 +38,7 @@ func newAtx(tb testing.TB, db *sql.Database) {
 	atx.SmesherID = types.BytesToNodeID(types.RandomBytes(20))
 	atx.SetReceived(time.Now().Local())
 	require.NoError(tb, atxs.Add(db, atx))
+	require.NoError(tb, atxs.SetUnits(db, atx.ID(), map[types.NodeID]uint32{atx.SmesherID: atx.NumUnits}))
 }
 
 func createMesh(tb testing.TB, db *sql.Database) {

--- a/api/grpcserver/v2alpha1/activation.go
+++ b/api/grpcserver/v2alpha1/activation.go
@@ -153,7 +153,7 @@ func toAtx(atx *types.ActivationTx) *spacemeshv2alpha1.Activation {
 		Coinbase:     atx.Coinbase.String(),
 		Weight:       atx.Weight,
 		Height:       atx.TickHeight(),
-		NumUnits:     atx.TotalNumUnits(),
+		NumUnits:     atx.NumUnits,
 	}
 }
 

--- a/checkpoint/checkpointdata.json
+++ b/checkpoint/checkpointdata.json
@@ -1,420 +1,1156 @@
 {
-    "command": "grpcurl -plaintext -d '{\"snapshot_layer\":15,\"num_atxs\":2}' 0.0.0.0:9093 spacemesh.v1.AdminService.CheckpointStream",
+    "command": "grpcurl -plaintext -d '{\"snapshot_layer\":1152,\"num_atxs\":2}' 0.0.0.0:9093 spacemesh.v1.AdminService.CheckpointStream",
     "version": "https://spacemesh.io/checkpoint.schema.json.1.0",
     "data": {
-        "id": "snapshot-15",
+        "id": "snapshot-1152",
         "atxs": [
             {
-                "id": "mORyeMH1is/StnCnMPKImPdOsUBIKge5H/gfn/C32fQ=",
-                "epoch": 2,
-                "commitmentAtx": "iXlw/UMbcz+h/Bm+l90zA2GnKWVg3dEEOV3fP8vdKfE=",
-                "vrfNonce": 114,
-                "numUnits": 2,
-                "baseTickHeight": 6162,
-                "tickCount": 6159,
-                "publicKey": "AjDF111CuE+YgA7OtHvJzE2AMFiQClA0agn/YdVrZYI=",
-                "sequence": 1,
-                "coinbase": "AAAAADEAAAAAAAAAAAAAAAAAAAAAAAAA"
+                "id": "u8oX7y0gk80G3d5Omcs5f8KcooWZT8wxSV5ZWyxTzgU=",
+                "epoch": 3,
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 6637,
+                "baseTickHeight": 11821,
+                "tickCount": 5913,
+                "publicKey": "ACC97STWCRc+fWqHI0wJub1eOJ8BrBY6gA67kDGPm6Y=",
+                "sequence": 2,
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "ACC97STWCRc+fWqHI0wJub1eOJ8BrBY6gA67kDGPm6Y=": 33
+                }
             },
             {
-                "id": "e7QJXNX9Xv/HGaWkXbBh7zJLjDAH05LJbn6ETVkaqJM=",
+                "id": "st5me/GMizi7orCtvY5EHAeaRiL1NQt2Xk3uIyFezXQ=",
                 "epoch": 2,
-                "commitmentAtx": "iXlw/UMbcz+h/Bm+l90zA2GnKWVg3dEEOV3fP8vdKfE=",
-                "vrfNonce": 118,
-                "numUnits": 2,
-                "baseTickHeight": 6162,
-                "tickCount": 6159,
-                "publicKey": "BEFt4bjPnzI3hKjLqtnTqT0DAZARRHkvtTvWZG5fGWo=",
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 6637,
+                "baseTickHeight": 5909,
+                "tickCount": 5912,
+                "publicKey": "ACC97STWCRc+fWqHI0wJub1eOJ8BrBY6gA67kDGPm6Y=",
                 "sequence": 1,
-                "coinbase": "AAAAADEAAAAAAAAAAAAAAAAAAAAAAAAA"
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "ACC97STWCRc+fWqHI0wJub1eOJ8BrBY6gA67kDGPm6Y=": 33
+                }
             },
             {
-                "id": "Ucq8mQbeucxEOwwUjljhuoO+zbqJl5rFQF+oSVYiKM4=",
-                "epoch": 2,
-                "commitmentAtx": "iXlw/UMbcz+h/Bm+l90zA2GnKWVg3dEEOV3fP8vdKfE=",
-                "vrfNonce": 36,
-                "numUnits": 2,
-                "baseTickHeight": 6162,
-                "tickCount": 6159,
-                "publicKey": "DWOFdx7D7nm+pb836Ke59MPfPb21ZHLMqPFwsh6r5TA=",
-                "sequence": 1,
-                "coinbase": "AAAAADEAAAAAAAAAAAAAAAAAAAAAAAAA"
+                "id": "4O/GjoomBlNJawBIT5fPI+/h0ngDWHJFtKLhFgin4p8=",
+                "epoch": 3,
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 21089,
+                "baseTickHeight": 11821,
+                "tickCount": 5913,
+                "publicKey": "AUv/xfD3TEfFuh4fAUv1w3SEvxu8j2nRcaLThno0AW8=",
+                "sequence": 2,
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "AUv/xfD3TEfFuh4fAUv1w3SEvxu8j2nRcaLThno0AW8=": 33
+                }
             },
             {
-                "id": "a3E203WsejzivHgXnnTFo5d+wTs4bXlpuk8C7cUtcVI=",
+                "id": "X1RItKn2DqhLr2pHiJ6GM+atK7yFzW0K/BuJhcmFTU8=",
                 "epoch": 2,
-                "commitmentAtx": "iXlw/UMbcz+h/Bm+l90zA2GnKWVg3dEEOV3fP8vdKfE=",
-                "vrfNonce": 118,
-                "numUnits": 2,
-                "baseTickHeight": 6162,
-                "tickCount": 6159,
-                "publicKey": "DmlnvWmNXbU/spggGtx9Eopqmcgj8XxNrLN9YDPMLs4=",
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 21089,
+                "baseTickHeight": 5909,
+                "tickCount": 5912,
+                "publicKey": "AUv/xfD3TEfFuh4fAUv1w3SEvxu8j2nRcaLThno0AW8=",
                 "sequence": 1,
-                "coinbase": "AAAAADEAAAAAAAAAAAAAAAAAAAAAAAAA"
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "AUv/xfD3TEfFuh4fAUv1w3SEvxu8j2nRcaLThno0AW8=": 33
+                }
             },
             {
-                "id": "7zwIpqALLONL+8vgJDxQE+P9W0ObYGpXzJymFmC1HPM=",
-                "epoch": 2,
-                "commitmentAtx": "iXlw/UMbcz+h/Bm+l90zA2GnKWVg3dEEOV3fP8vdKfE=",
-                "vrfNonce": 225,
-                "numUnits": 2,
-                "baseTickHeight": 6162,
-                "tickCount": 6159,
-                "publicKey": "GymS9e2sTLJoHAThUEkYG57LpwESILJIqNL7AgGhR3k=",
-                "sequence": 1,
-                "coinbase": "AAAAADEAAAAAAAAAAAAAAAAAAAAAAAAA"
+                "id": "+0cYFPMex+gSsTwNAtWuYz4WkE3m1KvaGWId9xdjLUs=",
+                "epoch": 3,
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 13207,
+                "baseTickHeight": 11821,
+                "tickCount": 5913,
+                "publicKey": "AooC1fiukLEwg1MVyMzBvSPAU3fv1ofIKVASTPqjZ2k=",
+                "sequence": 2,
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "AooC1fiukLEwg1MVyMzBvSPAU3fv1ofIKVASTPqjZ2k=": 33
+                }
             },
             {
-                "id": "m1OXiG6whx9bSgDFZEwRDzVhjYFlUo1jakPd9gP+ix0=",
+                "id": "wzqJRGHhn3Cn3ua/FUgidDFTo9C05Ch2R4KHFJhlNR0=",
                 "epoch": 2,
-                "commitmentAtx": "iXlw/UMbcz+h/Bm+l90zA2GnKWVg3dEEOV3fP8vdKfE=",
-                "vrfNonce": 28,
-                "numUnits": 2,
-                "baseTickHeight": 6162,
-                "tickCount": 6159,
-                "publicKey": "JBASUKxLLO/PeKJQRCk+hObdHINqpRm0k/GfwZsGpoU=",
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 13207,
+                "baseTickHeight": 5909,
+                "tickCount": 5912,
+                "publicKey": "AooC1fiukLEwg1MVyMzBvSPAU3fv1ofIKVASTPqjZ2k=",
                 "sequence": 1,
-                "coinbase": "AAAAADEAAAAAAAAAAAAAAAAAAAAAAAAA"
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "AooC1fiukLEwg1MVyMzBvSPAU3fv1ofIKVASTPqjZ2k=": 33
+                }
             },
             {
-                "id": "EybL87BLqJPeoOESnohH35v+cwpjKKPIoojCYD1XOyQ=",
-                "epoch": 2,
-                "commitmentAtx": "iXlw/UMbcz+h/Bm+l90zA2GnKWVg3dEEOV3fP8vdKfE=",
-                "vrfNonce": 169,
-                "numUnits": 2,
-                "baseTickHeight": 6162,
-                "tickCount": 6159,
-                "publicKey": "JLJQBNA9gK3mc4YUNeeV7uLxbl1/kU9/Eb4bx40UBRE=",
-                "sequence": 1,
-                "coinbase": "AAAAADEAAAAAAAAAAAAAAAAAAAAAAAAA"
+                "id": "oSKEDPcSMxMfVtk+xi0z/NcVplprMO/iu2+fpvPC+qs=",
+                "epoch": 3,
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 12343,
+                "baseTickHeight": 11821,
+                "tickCount": 5913,
+                "publicKey": "ArEQOhpAwiUNpATNhXPIY3HIHkabho1kASKsNNdKdrE=",
+                "sequence": 2,
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "ArEQOhpAwiUNpATNhXPIY3HIHkabho1kASKsNNdKdrE=": 33
+                }
             },
             {
-                "id": "+NsAaWCfgNnM14YBaiRr0awmIxFEfSbwQDSJY/GHEMY=",
+                "id": "OJ9XD6fJUQGtsUPnYw7NAN1Yyhj17PzmWEGcM9gc6aA=",
                 "epoch": 2,
-                "commitmentAtx": "iXlw/UMbcz+h/Bm+l90zA2GnKWVg3dEEOV3fP8vdKfE=",
-                "vrfNonce": 162,
-                "numUnits": 2,
-                "baseTickHeight": 6162,
-                "tickCount": 6159,
-                "publicKey": "JL5BCzlK9IKVctKhJuSp2H+bP5iwb4/PBXH5enXud+8=",
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 12343,
+                "baseTickHeight": 5909,
+                "tickCount": 5912,
+                "publicKey": "ArEQOhpAwiUNpATNhXPIY3HIHkabho1kASKsNNdKdrE=",
                 "sequence": 1,
-                "coinbase": "AAAAADEAAAAAAAAAAAAAAAAAAAAAAAAA"
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "ArEQOhpAwiUNpATNhXPIY3HIHkabho1kASKsNNdKdrE=": 33
+                }
             },
             {
-                "id": "8/YqDIi87zSct9QRcEKEsF7H4y/FkbDQuAnaHLDkpSI=",
-                "epoch": 2,
-                "commitmentAtx": "iXlw/UMbcz+h/Bm+l90zA2GnKWVg3dEEOV3fP8vdKfE=",
-                "vrfNonce": 251,
-                "numUnits": 2,
-                "baseTickHeight": 6162,
-                "tickCount": 6159,
-                "publicKey": "Jz2niGSkirbv7nOyGZ3+8heGVbx1q1YdANiljTiCAGQ=",
-                "sequence": 1,
-                "coinbase": "AAAAADEAAAAAAAAAAAAAAAAAAAAAAAAA"
+                "id": "BQECMwRr+6EkiU4GkbOuC7RC5aFLjcLh4khqQ5r8LAc=",
+                "epoch": 3,
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 15243,
+                "baseTickHeight": 11821,
+                "tickCount": 5913,
+                "publicKey": "A+FBnUB2mBCTBkZ/E0JuONQ4xEsXKJmvj0ubJjZ/zBU=",
+                "sequence": 2,
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "A+FBnUB2mBCTBkZ/E0JuONQ4xEsXKJmvj0ubJjZ/zBU=": 33
+                }
             },
             {
-                "id": "bxGrD1Nsk/bHeuMrmvLjLBmcbaRYyT2M1q/x1RYYpnA=",
+                "id": "lJ/Pl6ZuWhuObUqz77txuOwqL7L/Ip4GSOBh8oKmJkg=",
                 "epoch": 2,
-                "commitmentAtx": "iXlw/UMbcz+h/Bm+l90zA2GnKWVg3dEEOV3fP8vdKfE=",
-                "vrfNonce": 35,
-                "numUnits": 2,
-                "baseTickHeight": 6162,
-                "tickCount": 6159,
-                "publicKey": "R1QpJYjIYJSauXfIlWtzPRC/eP2PJMuy+iDEc/wxnFw=",
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 15243,
+                "baseTickHeight": 5909,
+                "tickCount": 5912,
+                "publicKey": "A+FBnUB2mBCTBkZ/E0JuONQ4xEsXKJmvj0ubJjZ/zBU=",
                 "sequence": 1,
-                "coinbase": "AAAAADEAAAAAAAAAAAAAAAAAAAAAAAAA"
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "A+FBnUB2mBCTBkZ/E0JuONQ4xEsXKJmvj0ubJjZ/zBU=": 33
+                }
             },
             {
-                "id": "rIcqVvi+kSuaqF/g47dbYrI9rx993oRsiqkjkvmSuy4=",
-                "epoch": 2,
-                "commitmentAtx": "iXlw/UMbcz+h/Bm+l90zA2GnKWVg3dEEOV3fP8vdKfE=",
-                "vrfNonce": 163,
-                "numUnits": 2,
-                "baseTickHeight": 6162,
-                "tickCount": 6159,
-                "publicKey": "UWcgflkxKJ2mtXopUjmQzfntrlUFP2Qly70Y+13ALFY=",
-                "sequence": 1,
-                "coinbase": "AAAAADEAAAAAAAAAAAAAAAAAAAAAAAAA"
+                "id": "9KDG7LaXqdeNr1u0qtHbov1hxNNy+J+zsy+68eHesPY=",
+                "epoch": 3,
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 6570,
+                "baseTickHeight": 11821,
+                "tickCount": 5913,
+                "publicKey": "A/2tBH5znWAlCDJngpx8t/JZuLyiMANppmocJrYpPkM=",
+                "sequence": 2,
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "A/2tBH5znWAlCDJngpx8t/JZuLyiMANppmocJrYpPkM=": 33
+                }
             },
             {
-                "id": "OOhu1255ZmVPnesTnJ7/Zo4e7k1FqsBWJ4lIRk9PtDk=",
+                "id": "M7ot7AaQ6eBYyWTivSrMFy6zNnYHry5s2It+/pgv9s0=",
                 "epoch": 2,
-                "commitmentAtx": "iXlw/UMbcz+h/Bm+l90zA2GnKWVg3dEEOV3fP8vdKfE=",
-                "vrfNonce": 224,
-                "numUnits": 2,
-                "baseTickHeight": 6162,
-                "tickCount": 6159,
-                "publicKey": "XkdK5+lrPxDLpmVgwOklWj+zATbPq355uBvfT5+Imrg=",
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 6570,
+                "baseTickHeight": 5909,
+                "tickCount": 5912,
+                "publicKey": "A/2tBH5znWAlCDJngpx8t/JZuLyiMANppmocJrYpPkM=",
                 "sequence": 1,
-                "coinbase": "AAAAADEAAAAAAAAAAAAAAAAAAAAAAAAA"
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "A/2tBH5znWAlCDJngpx8t/JZuLyiMANppmocJrYpPkM=": 33
+                }
             },
             {
-                "id": "fpDfLfjSZMhB8fSADJpBwKecaz454cW54UO3QyAIATI=",
-                "epoch": 2,
-                "commitmentAtx": "iXlw/UMbcz+h/Bm+l90zA2GnKWVg3dEEOV3fP8vdKfE=",
-                "vrfNonce": 58,
-                "numUnits": 2,
-                "baseTickHeight": 6162,
-                "tickCount": 6159,
-                "publicKey": "YTtPPMQkuHKGUzOu7OyuJo1gKgFNsGvuebF41EXfq98=",
-                "sequence": 1,
-                "coinbase": "AAAAADEAAAAAAAAAAAAAAAAAAAAAAAAA"
+                "id": "SgQflaI1iTZIqSErreZLz9/Tm2sUPl6DRW4K3WbK5YE=",
+                "epoch": 1,
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 30840,
+                "baseTickHeight": 0,
+                "tickCount": 5909,
+                "publicKey": "BAFb70vXDTH7UXJFIYnz5kL5PUYHK8BlP4zDaVUM2r4=",
+                "sequence": 0,
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "BAFb70vXDTH7UXJFIYnz5kL5PUYHK8BlP4zDaVUM2r4=": 33
+                }
             },
             {
-                "id": "CxWR7O6gq0PAlkF7sMCKpiFX1m38DPU9o63GqJY1tlI=",
-                "epoch": 2,
-                "commitmentAtx": "iXlw/UMbcz+h/Bm+l90zA2GnKWVg3dEEOV3fP8vdKfE=",
-                "vrfNonce": 160,
-                "numUnits": 2,
-                "baseTickHeight": 6162,
-                "tickCount": 6159,
-                "publicKey": "dQaH3Xu/EmSOD/YsGwERP/b2WSNwNXP3cEmFODF8OKc=",
-                "sequence": 1,
-                "coinbase": "AAAAADEAAAAAAAAAAAAAAAAAAAAAAAAA"
+                "id": "YX15FFQSwwMOge1A9KtyvNyn5kIyJiS/UQJmDbm9J0Y=",
+                "epoch": 3,
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 22475,
+                "baseTickHeight": 11821,
+                "tickCount": 5913,
+                "publicKey": "BRIqQP4O16gY5ddbIfToK0vESEwpcO3Ky0RIb72D3QE=",
+                "sequence": 2,
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "BRIqQP4O16gY5ddbIfToK0vESEwpcO3Ky0RIb72D3QE=": 33
+                }
             },
             {
-                "id": "/4mpsMHE/b/7aaiZjercT32tr+DiYG6ZuusfAjiXYL8=",
+                "id": "r9zPzkVaV+uZ8M7AToXGrcod09dYEtpyzFgaygtycHA=",
                 "epoch": 2,
-                "commitmentAtx": "iXlw/UMbcz+h/Bm+l90zA2GnKWVg3dEEOV3fP8vdKfE=",
-                "vrfNonce": 175,
-                "numUnits": 2,
-                "baseTickHeight": 6162,
-                "tickCount": 6159,
-                "publicKey": "d1V8P6y/q8zzcmTL3oNTEcwp1mRvnY44h4/gMTbrUVE=",
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 22475,
+                "baseTickHeight": 5909,
+                "tickCount": 5912,
+                "publicKey": "BRIqQP4O16gY5ddbIfToK0vESEwpcO3Ky0RIb72D3QE=",
                 "sequence": 1,
-                "coinbase": "AAAAADEAAAAAAAAAAAAAAAAAAAAAAAAA"
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "BRIqQP4O16gY5ddbIfToK0vESEwpcO3Ky0RIb72D3QE=": 33
+                }
             },
             {
-                "id": "2fVXJwJE1eDCXCwVR+A+Fs6jSkfq9xCG5QHSw+26v1Q=",
-                "epoch": 2,
-                "commitmentAtx": "iXlw/UMbcz+h/Bm+l90zA2GnKWVg3dEEOV3fP8vdKfE=",
-                "vrfNonce": 66,
-                "numUnits": 2,
-                "baseTickHeight": 6162,
-                "tickCount": 6159,
-                "publicKey": "eAg30tcT7v2wAKlImtz9+gGB9RZwOUu/oBRS3CQsDIM=",
-                "sequence": 1,
-                "coinbase": "AAAAADEAAAAAAAAAAAAAAAAAAAAAAAAA"
+                "id": "VDSd1HWFRa8XZRKMCCNWzNR0j8hau+KkfsCfI/AMhL8=",
+                "epoch": 3,
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 39956,
+                "baseTickHeight": 11821,
+                "tickCount": 4787,
+                "publicKey": "Bcl1FXmzkjAUmyac546RFNGqyrtDI7dki9L8nW7rTcs=",
+                "sequence": 0,
+                "coinbase": "AAAAAAHAd/lY2IYJI8eC1f9WpvJAJXEY",
+                "numUnits": 100,
+                "units": {
+                    "Bcl1FXmzkjAUmyac546RFNGqyrtDI7dki9L8nW7rTcs=": 100
+                }
             },
             {
-                "id": "pSCDIQkwMJw4lNWmLYoX7AxrFaln42Gx3bl+zWEBJDw=",
-                "epoch": 2,
-                "commitmentAtx": "iXlw/UMbcz+h/Bm+l90zA2GnKWVg3dEEOV3fP8vdKfE=",
-                "vrfNonce": 63,
-                "numUnits": 2,
-                "baseTickHeight": 6162,
-                "tickCount": 6159,
-                "publicKey": "gGO0GpK9K+/jK91DJBJtDz0dAFgeVrvi7CeneExQeW8=",
-                "sequence": 1,
-                "coinbase": "AAAAADEAAAAAAAAAAAAAAAAAAAAAAAAA"
+                "id": "/fZWW/5Nd9Ml3eYPamECbO5xtA3I97UBtam9sqB41S8=",
+                "epoch": 3,
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 30668,
+                "baseTickHeight": 11821,
+                "tickCount": 5913,
+                "publicKey": "BdGU5/LH7x6kyR8lmYf3o3zyxr+P3ijeE+5gPBSLY/0=",
+                "sequence": 2,
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "BdGU5/LH7x6kyR8lmYf3o3zyxr+P3ijeE+5gPBSLY/0=": 33
+                }
             },
             {
-                "id": "DNW3RHxjCwbXtcJqvZ2myYQusfI4NPQM+K1oufhkOJA=",
+                "id": "F0O6F6OAZLLpsnZMQROAiWyT08TPuIKELrV8y9M23xY=",
                 "epoch": 2,
-                "commitmentAtx": "iXlw/UMbcz+h/Bm+l90zA2GnKWVg3dEEOV3fP8vdKfE=",
-                "vrfNonce": 122,
-                "numUnits": 2,
-                "baseTickHeight": 6162,
-                "tickCount": 6159,
-                "publicKey": "lDtxQqzy1DPpFJHb/w0I/QKkfST0iF4iULkkYuhLjB0=",
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 30668,
+                "baseTickHeight": 5909,
+                "tickCount": 5912,
+                "publicKey": "BdGU5/LH7x6kyR8lmYf3o3zyxr+P3ijeE+5gPBSLY/0=",
                 "sequence": 1,
-                "coinbase": "AAAAADEAAAAAAAAAAAAAAAAAAAAAAAAA"
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "BdGU5/LH7x6kyR8lmYf3o3zyxr+P3ijeE+5gPBSLY/0=": 33
+                }
             },
             {
-                "id": "k1eMLxhzJ4XWuxKLED8PNpgWohFIs6bu84qIPGsdwPI=",
-                "epoch": 2,
-                "commitmentAtx": "iXlw/UMbcz+h/Bm+l90zA2GnKWVg3dEEOV3fP8vdKfE=",
-                "vrfNonce": 111,
-                "numUnits": 2,
-                "baseTickHeight": 6162,
-                "tickCount": 6159,
-                "publicKey": "ne6Xsdv9hyMPzm/EFk+iVvHwhe/qIKNlsnJz4+LneMY=",
-                "sequence": 1,
-                "coinbase": "AAAAADEAAAAAAAAAAAAAAAAAAAAAAAAA"
+                "id": "dLjvOPj0aop/LxSxdNhkcbfD6Z8pKYK2EjJnF+J0EjM=",
+                "epoch": 3,
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 3885,
+                "baseTickHeight": 11821,
+                "tickCount": 5913,
+                "publicKey": "Bhe+OatEVxQ0TpMcowLWe1ZGA90JMzVfk3XEKwsupT4=",
+                "sequence": 2,
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "Bhe+OatEVxQ0TpMcowLWe1ZGA90JMzVfk3XEKwsupT4=": 33
+                }
             },
             {
-                "id": "CUUdaKPTxKbboLrH5JAv9/g8eTdXgrWhomHr8ozxjO0=",
+                "id": "+pupHbOeRd9JLAxO/QMpXOtQiB8U3Dm33jhd5R4SxK4=",
                 "epoch": 2,
-                "commitmentAtx": "iXlw/UMbcz+h/Bm+l90zA2GnKWVg3dEEOV3fP8vdKfE=",
-                "vrfNonce": 9,
-                "numUnits": 2,
-                "baseTickHeight": 6162,
-                "tickCount": 6159,
-                "publicKey": "nuoQ7Ji1PSoe6TWDxea2Wd+Q3zN/CM7UsN6jzLo8E6o=",
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 3885,
+                "baseTickHeight": 5909,
+                "tickCount": 5912,
+                "publicKey": "Bhe+OatEVxQ0TpMcowLWe1ZGA90JMzVfk3XEKwsupT4=",
                 "sequence": 1,
-                "coinbase": "AAAAADEAAAAAAAAAAAAAAAAAAAAAAAAA"
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "Bhe+OatEVxQ0TpMcowLWe1ZGA90JMzVfk3XEKwsupT4=": 33
+                }
             },
             {
-                "id": "p0sG4uz9PgsjocZdge6IcsZk1PEEhCGiuGhZ7WhmX08=",
-                "epoch": 2,
-                "commitmentAtx": "iXlw/UMbcz+h/Bm+l90zA2GnKWVg3dEEOV3fP8vdKfE=",
-                "vrfNonce": 100,
-                "numUnits": 2,
-                "baseTickHeight": 6162,
-                "tickCount": 6159,
-                "publicKey": "tYesWSTOwZMS9NWkGNmNtMSSyONl0aqvuE0RaFnpa2g=",
-                "sequence": 1,
-                "coinbase": "AAAAADEAAAAAAAAAAAAAAAAAAAAAAAAA"
+                "id": "W+frEvfwgB9baZvcqFLuhc97p8OnsNUYbrqL+IQR0hw=",
+                "epoch": 3,
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 690,
+                "baseTickHeight": 11821,
+                "tickCount": 5913,
+                "publicKey": "BmuZafq227zV95QKGpdWNqfV+lniAndpD7gXfaMtNCg=",
+                "sequence": 2,
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "BmuZafq227zV95QKGpdWNqfV+lniAndpD7gXfaMtNCg=": 33
+                }
             },
             {
-                "id": "CTtqOhleEEUjf4PQ/g4cAIUNE88oIuBbkkaXH367mEM=",
+                "id": "atRH414FjVvScYRMcL1hu3WXEX92hnXoCiwEe39QL28=",
                 "epoch": 2,
-                "commitmentAtx": "iXlw/UMbcz+h/Bm+l90zA2GnKWVg3dEEOV3fP8vdKfE=",
-                "vrfNonce": 100,
-                "numUnits": 2,
-                "baseTickHeight": 6162,
-                "tickCount": 6159,
-                "publicKey": "vopmBzDRKMEACuU5/vgwJhLX36KOz26fUXvTpth0Hj8=",
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 690,
+                "baseTickHeight": 5909,
+                "tickCount": 5912,
+                "publicKey": "BmuZafq227zV95QKGpdWNqfV+lniAndpD7gXfaMtNCg=",
                 "sequence": 1,
-                "coinbase": "AAAAADEAAAAAAAAAAAAAAAAAAAAAAAAA"
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "BmuZafq227zV95QKGpdWNqfV+lniAndpD7gXfaMtNCg=": 33
+                }
             },
             {
-                "id": "WeYO5DzkmT+LOD+LPkMTpbG36nacu+MkWIFrdn4iAR8=",
-                "epoch": 2,
-                "commitmentAtx": "iXlw/UMbcz+h/Bm+l90zA2GnKWVg3dEEOV3fP8vdKfE=",
-                "vrfNonce": 187,
-                "numUnits": 2,
-                "baseTickHeight": 6162,
-                "tickCount": 6159,
-                "publicKey": "yZgoeiL/ZUh/UK29rZLj/SCuF6oRyBu8qFJlIOYM+FA=",
-                "sequence": 1,
-                "coinbase": "AAAAADEAAAAAAAAAAAAAAAAAAAAAAAAA"
+                "id": "SM7ffYm7hPVjOLxRMyirQm2Pa/JldcQeZY2F7+pth18=",
+                "epoch": 3,
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 11475,
+                "baseTickHeight": 11821,
+                "tickCount": 5913,
+                "publicKey": "B9JKogxn8v0o9xHuJhsd2tH3eI4npW6nB1fKOpZLwfM=",
+                "sequence": 2,
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "B9JKogxn8v0o9xHuJhsd2tH3eI4npW6nB1fKOpZLwfM=": 33
+                }
             },
             {
-                "id": "9R1RfLd9HtlV8dPOgMRbkSXJ4SDXHELrt89UiU9UYww=",
+                "id": "hW2Dij7tm4iyr1WFDfjmiywR5R8BHD8MOo2cWk1tiiw=",
                 "epoch": 2,
-                "commitmentAtx": "iXlw/UMbcz+h/Bm+l90zA2GnKWVg3dEEOV3fP8vdKfE=",
-                "vrfNonce": 55,
-                "numUnits": 2,
-                "baseTickHeight": 6162,
-                "tickCount": 6159,
-                "publicKey": "y6/LmwlUGbzaZ2Hp1x83HBIpG4K8OQOVKAFeT6aQ1g0=",
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 11475,
+                "baseTickHeight": 5909,
+                "tickCount": 5912,
+                "publicKey": "B9JKogxn8v0o9xHuJhsd2tH3eI4npW6nB1fKOpZLwfM=",
                 "sequence": 1,
-                "coinbase": "AAAAADEAAAAAAAAAAAAAAAAAAAAAAAAA"
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "B9JKogxn8v0o9xHuJhsd2tH3eI4npW6nB1fKOpZLwfM=": 33
+                }
             },
             {
-                "id": "F5O01qw5QxzJkV5V0MSsAposs732b79qJZbr4Umm2qM=",
-                "epoch": 2,
-                "commitmentAtx": "iXlw/UMbcz+h/Bm+l90zA2GnKWVg3dEEOV3fP8vdKfE=",
-                "vrfNonce": 184,
-                "numUnits": 2,
-                "baseTickHeight": 6162,
-                "tickCount": 6159,
-                "publicKey": "12zcRs1oRwsXdKOrF6p4SPrirOm02R2hwJudh28f1c8=",
-                "sequence": 1,
-                "coinbase": "AAAAADEAAAAAAAAAAAAAAAAAAAAAAAAA"
+                "id": "D1mUFuc07Wi+JP72xYpdIwaqPiei6klyGTaFEIJCTWA=",
+                "epoch": 3,
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 23399,
+                "baseTickHeight": 11821,
+                "tickCount": 5913,
+                "publicKey": "CEgz/V3ovWdQTQXGNmP8sfzZo8TwwLkXlABmvBMEwuw=",
+                "sequence": 2,
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "CEgz/V3ovWdQTQXGNmP8sfzZo8TwwLkXlABmvBMEwuw=": 33
+                }
             },
             {
-                "id": "sc3vQd4SIonpamSsxl+tksvz94Wljju2FncHGI4GWM8=",
+                "id": "7Q/RHUg5jd0aZ2tuViK6IWShAEe1YEhC/AxbME6JSZY=",
                 "epoch": 2,
-                "commitmentAtx": "iXlw/UMbcz+h/Bm+l90zA2GnKWVg3dEEOV3fP8vdKfE=",
-                "vrfNonce": 18,
-                "numUnits": 2,
-                "baseTickHeight": 6162,
-                "tickCount": 6159,
-                "publicKey": "9UMrQ+L5i51d9ik3SQ5202QsOa4AnDWzTj+QQC3mNg4=",
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 23399,
+                "baseTickHeight": 5909,
+                "tickCount": 5912,
+                "publicKey": "CEgz/V3ovWdQTQXGNmP8sfzZo8TwwLkXlABmvBMEwuw=",
                 "sequence": 1,
-                "coinbase": "AAAAADEAAAAAAAAAAAAAAAAAAAAAAAAA"
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "CEgz/V3ovWdQTQXGNmP8sfzZo8TwwLkXlABmvBMEwuw=": 33
+                }
+            },
+            {
+                "id": "yMaWck6Yvg5xpjxk4OwDmaCai1SboG6U6YNmlE49gQU=",
+                "epoch": 3,
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 32241,
+                "baseTickHeight": 11821,
+                "tickCount": 5913,
+                "publicKey": "Cob8IKp/r+AviRD6k5aqEhiNL3DB8yl0lXeCRi8bvcE=",
+                "sequence": 2,
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "Cob8IKp/r+AviRD6k5aqEhiNL3DB8yl0lXeCRi8bvcE=": 33
+                }
+            },
+            {
+                "id": "PlACWchG//hb6n4u8VvPfpjDriqICwWSBScRJUbLs/g=",
+                "epoch": 2,
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 32241,
+                "baseTickHeight": 5909,
+                "tickCount": 5912,
+                "publicKey": "Cob8IKp/r+AviRD6k5aqEhiNL3DB8yl0lXeCRi8bvcE=",
+                "sequence": 1,
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "Cob8IKp/r+AviRD6k5aqEhiNL3DB8yl0lXeCRi8bvcE=": 33
+                }
+            },
+            {
+                "id": "OT+i7D09UNI51Q6Oan7TxoH6TN7P+54RFVbnD02N8nc=",
+                "epoch": 3,
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 18075,
+                "baseTickHeight": 11821,
+                "tickCount": 5913,
+                "publicKey": "Co0dYdJWOa/oWQ7sNnFpd0txWWf7X4imqTBBaFTG1NE=",
+                "sequence": 2,
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "Co0dYdJWOa/oWQ7sNnFpd0txWWf7X4imqTBBaFTG1NE=": 33
+                }
+            },
+            {
+                "id": "glQtNfR9Bv2f4yRGxwjD+mrLAU+sQRMPPmVLcPJTNEE=",
+                "epoch": 2,
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 18075,
+                "baseTickHeight": 5909,
+                "tickCount": 5912,
+                "publicKey": "Co0dYdJWOa/oWQ7sNnFpd0txWWf7X4imqTBBaFTG1NE=",
+                "sequence": 1,
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "Co0dYdJWOa/oWQ7sNnFpd0txWWf7X4imqTBBaFTG1NE=": 33
+                }
+            },
+            {
+                "id": "r/b9KmCZoagOu9tgLiHtOrRDNbVKLuSbjGJokP5Wweg=",
+                "epoch": 3,
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 24726,
+                "baseTickHeight": 11821,
+                "tickCount": 5913,
+                "publicKey": "CpJgf2aYfGvPzj71QNxuUeaQKbGXDh7XJbGiju5toIU=",
+                "sequence": 2,
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "CpJgf2aYfGvPzj71QNxuUeaQKbGXDh7XJbGiju5toIU=": 33
+                }
+            },
+            {
+                "id": "89TwNgoRK2oMlazZuIPohlfaO91EHrB492Vy5PcA1/4=",
+                "epoch": 2,
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 24726,
+                "baseTickHeight": 5909,
+                "tickCount": 5912,
+                "publicKey": "CpJgf2aYfGvPzj71QNxuUeaQKbGXDh7XJbGiju5toIU=",
+                "sequence": 1,
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "CpJgf2aYfGvPzj71QNxuUeaQKbGXDh7XJbGiju5toIU=": 33
+                }
+            },
+            {
+                "id": "aFvhy5FtqoLN51s+IBC/OyD3Cutj2mXMEsjpdB2zTsI=",
+                "epoch": 3,
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 23717,
+                "baseTickHeight": 11821,
+                "tickCount": 5913,
+                "publicKey": "Cr02ZM2IWdxToYodz2vXvZQqEIVt8tm9mTbCzv1lPmA=",
+                "sequence": 2,
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "Cr02ZM2IWdxToYodz2vXvZQqEIVt8tm9mTbCzv1lPmA=": 33
+                }
+            },
+            {
+                "id": "4VTCYV91Bthl96aPzDWymWtCE9fTpxt9NbHkvWC9IhA=",
+                "epoch": 2,
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 23717,
+                "baseTickHeight": 5909,
+                "tickCount": 5912,
+                "publicKey": "Cr02ZM2IWdxToYodz2vXvZQqEIVt8tm9mTbCzv1lPmA=",
+                "sequence": 1,
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "Cr02ZM2IWdxToYodz2vXvZQqEIVt8tm9mTbCzv1lPmA=": 33
+                }
+            },
+            {
+                "id": "WTP9dTB28LDjXBaHSKmDjRFa2J4ydiYCBBYOgfFDVNg=",
+                "epoch": 3,
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 22040,
+                "baseTickHeight": 11821,
+                "tickCount": 5913,
+                "publicKey": "C0pHznKOU/MbCW3pfUBlkR7QMmOCIoYPs+KZRPd7k/k=",
+                "sequence": 2,
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "C0pHznKOU/MbCW3pfUBlkR7QMmOCIoYPs+KZRPd7k/k=": 33
+                }
+            },
+            {
+                "id": "gI7iRDf7Ma0d21dwgkBfy9CRMlJGVJR0lXTSLCsuM1U=",
+                "epoch": 2,
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 22040,
+                "baseTickHeight": 5909,
+                "tickCount": 5912,
+                "publicKey": "C0pHznKOU/MbCW3pfUBlkR7QMmOCIoYPs+KZRPd7k/k=",
+                "sequence": 1,
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "C0pHznKOU/MbCW3pfUBlkR7QMmOCIoYPs+KZRPd7k/k=": 33
+                }
+            },
+            {
+                "id": "kQrjQRsN3rNRr+hXz795Ift4JEUQo2bjHOZCP6FreKs=",
+                "epoch": 1,
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 15322,
+                "baseTickHeight": 0,
+                "tickCount": 5909,
+                "publicKey": "C4iiN5H06+0Y2w7mGqdxUPSlDtOxqA+gp6r6nDVoD8s=",
+                "sequence": 0,
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "C4iiN5H06+0Y2w7mGqdxUPSlDtOxqA+gp6r6nDVoD8s=": 33
+                }
+            },
+            {
+                "id": "ag/AMzHZ6Fcm6jcrbAsolZvzx5Fg1JYVn76a/+C+hvM=",
+                "epoch": 3,
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 23673,
+                "baseTickHeight": 11821,
+                "tickCount": 5913,
+                "publicKey": "C5nht7r1IApif0neIQwWNzBMajX7uXRMxt05giYXhnE=",
+                "sequence": 2,
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "C5nht7r1IApif0neIQwWNzBMajX7uXRMxt05giYXhnE=": 33
+                }
+            },
+            {
+                "id": "MHwh+kPx5G/ViJl8YSLBJcqYvF6R9BHWTgl5I6QLdM4=",
+                "epoch": 2,
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 23673,
+                "baseTickHeight": 5909,
+                "tickCount": 5912,
+                "publicKey": "C5nht7r1IApif0neIQwWNzBMajX7uXRMxt05giYXhnE=",
+                "sequence": 1,
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "C5nht7r1IApif0neIQwWNzBMajX7uXRMxt05giYXhnE=": 33
+                }
+            },
+            {
+                "id": "2RSj0KjzJ1ipTMXpB8fFfD63h6OMCmIqnDVLiO+56S8=",
+                "epoch": 3,
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 26008,
+                "baseTickHeight": 11821,
+                "tickCount": 5913,
+                "publicKey": "C+PrXQcTh3wbdmMpLi37vRhAoZAJE4f6/XstKX//9oU=",
+                "sequence": 2,
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "C+PrXQcTh3wbdmMpLi37vRhAoZAJE4f6/XstKX//9oU=": 33
+                }
+            },
+            {
+                "id": "cYVW4HDB7vE8CyfUG5IyfZCWlfn9OLcTqYMCI1y8iz4=",
+                "epoch": 2,
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 26008,
+                "baseTickHeight": 5909,
+                "tickCount": 5912,
+                "publicKey": "C+PrXQcTh3wbdmMpLi37vRhAoZAJE4f6/XstKX//9oU=",
+                "sequence": 1,
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "C+PrXQcTh3wbdmMpLi37vRhAoZAJE4f6/XstKX//9oU=": 33
+                }
+            },
+            {
+                "id": "EdAf9/F8T1dLeEOivsqrPKRxbvtUasCk0VsvQBQMKI0=",
+                "epoch": 3,
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 22684,
+                "baseTickHeight": 11821,
+                "tickCount": 5913,
+                "publicKey": "DAKMJyRfCnl2MeJvu87cTq4gC7PVtTd7V7k4W174hWU=",
+                "sequence": 2,
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "DAKMJyRfCnl2MeJvu87cTq4gC7PVtTd7V7k4W174hWU=": 33
+                }
+            },
+            {
+                "id": "1Phn8kpmA5vySWdUGYtnK/lLTonJqKcHA/QbdXlFDro=",
+                "epoch": 2,
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 22684,
+                "baseTickHeight": 5909,
+                "tickCount": 5912,
+                "publicKey": "DAKMJyRfCnl2MeJvu87cTq4gC7PVtTd7V7k4W174hWU=",
+                "sequence": 1,
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "DAKMJyRfCnl2MeJvu87cTq4gC7PVtTd7V7k4W174hWU=": 33
+                }
+            },
+            {
+                "id": "NRNoQkQ0rOg3Bl0IoAC6lR+iJmHoN7IWBhJnh8QnJn0=",
+                "epoch": 3,
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 12265,
+                "baseTickHeight": 11821,
+                "tickCount": 5913,
+                "publicKey": "DN9/1ySs9MOgeU0E/5qOz/JiQxjxssb+f+5SKK+qL9Q=",
+                "sequence": 2,
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "DN9/1ySs9MOgeU0E/5qOz/JiQxjxssb+f+5SKK+qL9Q=": 33
+                }
+            },
+            {
+                "id": "b753T1CB7r6FM8GZq4BicT1wwV/5BgRT42h9SqatXSk=",
+                "epoch": 2,
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 12265,
+                "baseTickHeight": 5909,
+                "tickCount": 5912,
+                "publicKey": "DN9/1ySs9MOgeU0E/5qOz/JiQxjxssb+f+5SKK+qL9Q=",
+                "sequence": 1,
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "DN9/1ySs9MOgeU0E/5qOz/JiQxjxssb+f+5SKK+qL9Q=": 33
+                }
+            },
+            {
+                "id": "XTRGnwx42zE4s5aXT5Ll2WfeKf/rKyCg/jjBbJdycs0=",
+                "epoch": 3,
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 22674,
+                "baseTickHeight": 11821,
+                "tickCount": 5913,
+                "publicKey": "DOYm61QwL7dRW1jbLSJqWRz0f+qa0CWCsFy2nPBLjno=",
+                "sequence": 2,
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "DOYm61QwL7dRW1jbLSJqWRz0f+qa0CWCsFy2nPBLjno=": 33
+                }
+            },
+            {
+                "id": "6yxuZcIVgZ5cBsJ5UDw7Y+Y5thZ67eLeZX4IAba5GcY=",
+                "epoch": 2,
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 22674,
+                "baseTickHeight": 5909,
+                "tickCount": 5912,
+                "publicKey": "DOYm61QwL7dRW1jbLSJqWRz0f+qa0CWCsFy2nPBLjno=",
+                "sequence": 1,
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "DOYm61QwL7dRW1jbLSJqWRz0f+qa0CWCsFy2nPBLjno=": 33
+                }
+            },
+            {
+                "id": "kR2yHkBpUVCh3Jc9b2XuAJRe76/bjyftydFKoSl091Q=",
+                "epoch": 3,
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 4922,
+                "baseTickHeight": 11821,
+                "tickCount": 5913,
+                "publicKey": "DT5rESAWYlrwdWb6yxNdzmBz8h+r2pT5ZcR1C24Tx/k=",
+                "sequence": 2,
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "DT5rESAWYlrwdWb6yxNdzmBz8h+r2pT5ZcR1C24Tx/k=": 33
+                }
+            },
+            {
+                "id": "/Ezt/WGbXcCb2FYvrx3BzW1bKVmVXTLjX3GsSsEeCwo=",
+                "epoch": 2,
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 4922,
+                "baseTickHeight": 5909,
+                "tickCount": 5912,
+                "publicKey": "DT5rESAWYlrwdWb6yxNdzmBz8h+r2pT5ZcR1C24Tx/k=",
+                "sequence": 1,
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "DT5rESAWYlrwdWb6yxNdzmBz8h+r2pT5ZcR1C24Tx/k=": 33
+                }
+            },
+            {
+                "id": "+AxJ02FsmpZiIuZcFedSmyHmFg3hEYe2971HQHrpZAM=",
+                "epoch": 3,
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 16077,
+                "baseTickHeight": 11821,
+                "tickCount": 5913,
+                "publicKey": "DciYS9tzU+k6iEdTuFRbWsP+XyXQsjZc+VnU6+H9u4s=",
+                "sequence": 2,
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "DciYS9tzU+k6iEdTuFRbWsP+XyXQsjZc+VnU6+H9u4s=": 33
+                }
+            },
+            {
+                "id": "ocKpf3AJ1UJ3bugthZk9VeA6I0YP6M6eE9d0FjQEjik=",
+                "epoch": 2,
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 16077,
+                "baseTickHeight": 5909,
+                "tickCount": 5912,
+                "publicKey": "DciYS9tzU+k6iEdTuFRbWsP+XyXQsjZc+VnU6+H9u4s=",
+                "sequence": 1,
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "DciYS9tzU+k6iEdTuFRbWsP+XyXQsjZc+VnU6+H9u4s=": 33
+                }
+            },
+            {
+                "id": "pNrY2xN/+6lcyUu+XuRSv3tSZSwddWKNdCRHRzYHdsk=",
+                "epoch": 3,
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 9675,
+                "baseTickHeight": 11821,
+                "tickCount": 4787,
+                "publicKey": "Dcket7piCC4pYPLmSW+kyOSJVMJwSVOK0tjL9YVzPCo=",
+                "sequence": 0,
+                "coinbase": "AAAAAAHAd/lY2IYJI8eC1f9WpvJAJXEY",
+                "numUnits": 100,
+                "units": {
+                    "Dcket7piCC4pYPLmSW+kyOSJVMJwSVOK0tjL9YVzPCo=": 100
+                }
+            },
+            {
+                "id": "Nrxz9O92lsiTaa3T+VlLCPtKrdtAI+qTZgEHltmQ7KU=",
+                "epoch": 3,
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 58506,
+                "baseTickHeight": 11821,
+                "tickCount": 4787,
+                "publicKey": "DiFP9U4LWkak2kEvWlv/vq0oJzq1rVaA9R1tF4peXlQ=",
+                "sequence": 2,
+                "coinbase": "AAAAAGESmyCRIgdK34zMqo6c3mPx08gk",
+                "numUnits": 100,
+                "units": {
+                    "DiFP9U4LWkak2kEvWlv/vq0oJzq1rVaA9R1tF4peXlQ=": 100
+                }
+            },
+            {
+                "id": "yjupkOAImAMe3C8qPw4BTBOzsvfMwz4cOJq/JiIaz8Q=",
+                "epoch": 2,
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 58506,
+                "baseTickHeight": 5909,
+                "tickCount": 4738,
+                "publicKey": "DiFP9U4LWkak2kEvWlv/vq0oJzq1rVaA9R1tF4peXlQ=",
+                "sequence": 1,
+                "coinbase": "AAAAAGESmyCRIgdK34zMqo6c3mPx08gk",
+                "numUnits": 100,
+                "units": {
+                    "DiFP9U4LWkak2kEvWlv/vq0oJzq1rVaA9R1tF4peXlQ=": 100
+                }
+            },
+            {
+                "id": "ywRGivZT8yhB8iYsCIZk6yQn5N8nvdaaGr4q/wjKPfg=",
+                "epoch": 3,
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 7966,
+                "baseTickHeight": 11821,
+                "tickCount": 4787,
+                "publicKey": "Dv1yHWybFg0snsR7l2+ytj9oTMWRW7TeZJ5zI4oaBSo=",
+                "sequence": 0,
+                "coinbase": "AAAAAAHAd/lY2IYJI8eC1f9WpvJAJXEY",
+                "numUnits": 100,
+                "units": {
+                    "Dv1yHWybFg0snsR7l2+ytj9oTMWRW7TeZJ5zI4oaBSo=": 100
+                }
+            },
+            {
+                "id": "3+bYfDia1apZVRmuB+WkMF1qh9yw1h3Rm2k3wjweF/0=",
+                "epoch": 3,
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 23535,
+                "baseTickHeight": 11821,
+                "tickCount": 5913,
+                "publicKey": "D6p6WsfM/IgCUSUPAA0/SXMl1TQypSD9y/YBgRnP9GM=",
+                "sequence": 2,
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "D6p6WsfM/IgCUSUPAA0/SXMl1TQypSD9y/YBgRnP9GM=": 33
+                }
+            },
+            {
+                "id": "APFYbXP2uO0snHwAy+mKmi1IdeTTaFIUHpIs4edv3uU=",
+                "epoch": 2,
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 23535,
+                "baseTickHeight": 5909,
+                "tickCount": 5912,
+                "publicKey": "D6p6WsfM/IgCUSUPAA0/SXMl1TQypSD9y/YBgRnP9GM=",
+                "sequence": 1,
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "D6p6WsfM/IgCUSUPAA0/SXMl1TQypSD9y/YBgRnP9GM=": 33
+                }
+            },
+            {
+                "id": "NuovdYlFeOOsueYMWaT1xeOusUYjORqUp/GqSXdV2tQ=",
+                "epoch": 1,
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 32634,
+                "baseTickHeight": 0,
+                "tickCount": 5909,
+                "publicKey": "EDfbWmIKHweeRzVwqKazchfvA5D6peR5SrwzW1Kspq8=",
+                "sequence": 0,
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "EDfbWmIKHweeRzVwqKazchfvA5D6peR5SrwzW1Kspq8=": 33
+                }
+            },
+            {
+                "id": "TxlYswDgeBY0JdM1VvJe+i/leedBJaJcEn9HpLoCawA=",
+                "epoch": 3,
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 7705,
+                "baseTickHeight": 11821,
+                "tickCount": 5913,
+                "publicKey": "EGstlX/VPlNT4hQ9KX60ZgrOiuVlJxON/3bn3TVnlL0=",
+                "sequence": 2,
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "EGstlX/VPlNT4hQ9KX60ZgrOiuVlJxON/3bn3TVnlL0=": 33
+                }
+            },
+            {
+                "id": "hP4uH1FcWDtUR3QWV3KX7gzPl1HzGOKIeFVwj41tMrI=",
+                "epoch": 2,
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 7705,
+                "baseTickHeight": 5909,
+                "tickCount": 5912,
+                "publicKey": "EGstlX/VPlNT4hQ9KX60ZgrOiuVlJxON/3bn3TVnlL0=",
+                "sequence": 1,
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "EGstlX/VPlNT4hQ9KX60ZgrOiuVlJxON/3bn3TVnlL0=": 33
+                }
+            },
+            {
+                "id": "Zvdd89yxP4UQZ4+M1Lkuc2+Dtz6VXrpLNNP9wHLPMis=",
+                "epoch": 3,
+                "commitmentAtx": "H247+9mKgBUSZX1jLEHY9u08VVli005amReDskZOb18=",
+                "vrfNonce": 17002,
+                "baseTickHeight": 11821,
+                "tickCount": 4787,
+                "publicKey": "EIcsZQ566PgTeHCHZuL/2DU5wJga8CYgplfaHI7dm74=",
+                "sequence": 0,
+                "coinbase": "AAAAAAHAd/lY2IYJI8eC1f9WpvJAJXEY",
+                "numUnits": 100,
+                "units": {
+                    "EIcsZQ566PgTeHCHZuL/2DU5wJga8CYgplfaHI7dm74=": 100
+                }
+            },
+            {
+                "id": "mZT9Em8gRsemZFG9SVetBuLBZLWSfSY50y/5HcodOKM=",
+                "epoch": 3,
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 94029,
+                "baseTickHeight": 11821,
+                "tickCount": 4787,
+                "publicKey": "EMAIBBWiUbOVERLDoqxCJ0cR77AbE5rL7oS/zYn/QcI=",
+                "sequence": 0,
+                "coinbase": "AAAAAAHAd/lY2IYJI8eC1f9WpvJAJXEY",
+                "numUnits": 100,
+                "units": {
+                    "EMAIBBWiUbOVERLDoqxCJ0cR77AbE5rL7oS/zYn/QcI=": 100
+                }
+            },
+            {
+                "id": "etp5lgS3T4FZglszYwBBB0NXHNwLqOyPvQeL3fnpeUo=",
+                "epoch": 3,
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 14750,
+                "baseTickHeight": 11821,
+                "tickCount": 5913,
+                "publicKey": "EQPH+3yXmod4ytUJ6e+dm+bhS4xy//ILsy32RQqlX2s=",
+                "sequence": 2,
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "EQPH+3yXmod4ytUJ6e+dm+bhS4xy//ILsy32RQqlX2s=": 33
+                }
+            },
+            {
+                "id": "as7Adv9h7Nw00D3ohpZQq3fHUOICr9aAB1PICyeXpUo=",
+                "epoch": 2,
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 14750,
+                "baseTickHeight": 5909,
+                "tickCount": 5912,
+                "publicKey": "EQPH+3yXmod4ytUJ6e+dm+bhS4xy//ILsy32RQqlX2s=",
+                "sequence": 1,
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "EQPH+3yXmod4ytUJ6e+dm+bhS4xy//ILsy32RQqlX2s=": 33
+                }
+            },
+            {
+                "id": "15qh75bMf2XKR1IzJp2Ahjf/xneLQqMydtdfbrgRFYE=",
+                "epoch": 3,
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 32319,
+                "baseTickHeight": 11821,
+                "tickCount": 5913,
+                "publicKey": "ESjbBN+t7xbFXgctEIJ4feolbXXSFk8i5q3h++Mrq9U=",
+                "sequence": 2,
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "ESjbBN+t7xbFXgctEIJ4feolbXXSFk8i5q3h++Mrq9U=": 33
+                }
+            },
+            {
+                "id": "5zCdf/LGXUKBBn9IydWCmHu6a366xZ04hugxY5wtgG8=",
+                "epoch": 2,
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 32319,
+                "baseTickHeight": 5909,
+                "tickCount": 5912,
+                "publicKey": "ESjbBN+t7xbFXgctEIJ4feolbXXSFk8i5q3h++Mrq9U=",
+                "sequence": 1,
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "ESjbBN+t7xbFXgctEIJ4feolbXXSFk8i5q3h++Mrq9U=": 33
+                }
+            },
+            {
+                "id": "+OJn66G9Xcs48UT/fFIQPimo+3/vZ/YQdscLn8kaFyY=",
+                "epoch": 3,
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 16699,
+                "baseTickHeight": 11821,
+                "tickCount": 5913,
+                "publicKey": "ETG4uCa9tKcGWH0H2d7g5wPVglAm7Zhqb240LblwCa4=",
+                "sequence": 2,
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "ETG4uCa9tKcGWH0H2d7g5wPVglAm7Zhqb240LblwCa4=": 33
+                }
+            },
+            {
+                "id": "4g2KCJyGkCMtZoIlpFQTcr4Hpc+VjYoW5KKDpxwEAQ4=",
+                "epoch": 2,
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 16699,
+                "baseTickHeight": 5909,
+                "tickCount": 5912,
+                "publicKey": "ETG4uCa9tKcGWH0H2d7g5wPVglAm7Zhqb240LblwCa4=",
+                "sequence": 1,
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "ETG4uCa9tKcGWH0H2d7g5wPVglAm7Zhqb240LblwCa4=": 33
+                }
+            },
+            {
+                "id": "0HUPRSUoUJvrQB/mma6+PAJ7EgwlQANVDN/IX2xRXrY=",
+                "epoch": 3,
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 31738,
+                "baseTickHeight": 11821,
+                "tickCount": 5913,
+                "publicKey": "EYAQ4iynbSb5We+vPV727FlL5Exdl6scHAoROHb65Oo=",
+                "sequence": 2,
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "EYAQ4iynbSb5We+vPV727FlL5Exdl6scHAoROHb65Oo=": 33
+                }
+            },
+            {
+                "id": "Y95gHvl1XVzNXJiEAsmJzOVTLFwXDoz7a46yQT23Tw8=",
+                "epoch": 2,
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 31738,
+                "baseTickHeight": 5909,
+                "tickCount": 5912,
+                "publicKey": "EYAQ4iynbSb5We+vPV727FlL5Exdl6scHAoROHb65Oo=",
+                "sequence": 1,
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "EYAQ4iynbSb5We+vPV727FlL5Exdl6scHAoROHb65Oo=": 33
+                }
+            },
+            {
+                "id": "DDLvIZCjunktKsaKUzlKj4YGeVX52go8fWxYFpgklkM=",
+                "epoch": 3,
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 6091,
+                "baseTickHeight": 11821,
+                "tickCount": 4787,
+                "publicKey": "EoRzhZBmKrGknTfXtE8MKdfCyc6cr9Z0FVxkqj17QLA=",
+                "sequence": 0,
+                "coinbase": "AAAAAAHAd/lY2IYJI8eC1f9WpvJAJXEY",
+                "numUnits": 100,
+                "units": {
+                    "EoRzhZBmKrGknTfXtE8MKdfCyc6cr9Z0FVxkqj17QLA=": 100
+                }
+            },
+            {
+                "id": "MEqcCKRces6Fe6grGC0R1TlU3nsw3Q/bMtj7MX6B6Ck=",
+                "epoch": 3,
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 1323,
+                "baseTickHeight": 11821,
+                "tickCount": 5913,
+                "publicKey": "EpllxhigTIVayGrULrE5AFb85bwBsXmsS0WeBBsQ48w=",
+                "sequence": 2,
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "EpllxhigTIVayGrULrE5AFb85bwBsXmsS0WeBBsQ48w=": 33
+                }
+            },
+            {
+                "id": "goHEKaMCErnmhv6aXkXvPNogWRK8NdYJApnY8ACv+Ek=",
+                "epoch": 2,
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 1323,
+                "baseTickHeight": 5909,
+                "tickCount": 5912,
+                "publicKey": "EpllxhigTIVayGrULrE5AFb85bwBsXmsS0WeBBsQ48w=",
+                "sequence": 1,
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "EpllxhigTIVayGrULrE5AFb85bwBsXmsS0WeBBsQ48w=": 33
+                }
+            },
+            {
+                "id": "BbJerrvnt3Em7hhaynF8kCnNy8e4p9k1DELAv9Ia0P0=",
+                "epoch": 3,
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 33164,
+                "baseTickHeight": 11821,
+                "tickCount": 5913,
+                "publicKey": "Ew1eFmCcpVSCD37NB6JQ1OU6dLWTASB78E03u2xO+hI=",
+                "sequence": 2,
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "Ew1eFmCcpVSCD37NB6JQ1OU6dLWTASB78E03u2xO+hI=": 33
+                }
+            },
+            {
+                "id": "2g6fNDQ6BQN19n8En0PEzw+B3JXtfUr3ToFX2y40Ykk=",
+                "epoch": 2,
+                "commitmentAtx": "zZeDLsOumFHmJ32L2IvBe0UI4rKmq5Co7km6jk8Y0cg=",
+                "vrfNonce": 33164,
+                "baseTickHeight": 5909,
+                "tickCount": 5912,
+                "publicKey": "Ew1eFmCcpVSCD37NB6JQ1OU6dLWTASB78E03u2xO+hI=",
+                "sequence": 1,
+                "coinbase": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "numUnits": 33,
+                "units": {
+                    "Ew1eFmCcpVSCD37NB6JQ1OU6dLWTASB78E03u2xO+hI=": 33
+                }
             }
         ],
         "accounts": [
             {
-                "address": "AAAAAAc6977AGOjS43n6R99qn6B6aoNE",
-                "balance": 100000000000000000,
+                "address": "AAAAAAHAd/lY2IYJI8eC1f9WpvJAJXEY",
+                "balance": 6450295402459,
                 "nonce": 0,
                 "template": null,
                 "state": null
             },
             {
-                "address": "AAAAAAsBAQAAAAAAAAAAAAAAAAAAAAAA",
-                "balance": 1000,
+                "address": "AAAAAEWFYdzEv+mfQmEIRhtXR7IavXQl",
+                "balance": 253981759502464,
                 "nonce": 0,
                 "template": null,
                 "state": null
             },
             {
-                "address": "AAAAABsxTRfAWikF+RjQ1y8vaYlkD7tD",
-                "balance": 100000000000000000,
+                "address": "AAAAAGESmyCRIgdK34zMqo6c3mPx08gk",
+                "balance": 10939325155211,
                 "nonce": 0,
                 "template": null,
                 "state": null
-            },
-            {
-                "address": "AAAAABuplkSS7uc5nwy4I5Og9PhuwFMS",
-                "balance": 99999999999863378,
-                "nonce": 2,
-                "template": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB",
-                "state": "yFk7fs/6xYbisUDOENMsr1Rt3CseVQkcSKA409KnyDE="
-            },
-            {
-                "address": "AAAAADEAAAAAAAAAAAAAAAAAAAAAAAAA",
-                "balance": 3343327309466,
-                "nonce": 0,
-                "template": null,
-                "state": null
-            },
-            {
-                "address": "AAAAAE/bRPsGcLFsZXAvgtq06B0goSxS",
-                "balance": 99999999999863378,
-                "nonce": 2,
-                "template": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB",
-                "state": "N5hEV9rrr/0l6EH/jd5RRi4uDv4zJPok9vMVAloCCjo="
-            },
-            {
-                "address": "AAAAAFoCrsQ+F8gKsTPgDIOBVD0IaOHP",
-                "balance": 99999999999863378,
-                "nonce": 2,
-                "template": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB",
-                "state": "9u1uvfA/aIeKs3wHABX5v0cuw41e88dT97J/7/rgWys="
-            },
-            {
-                "address": "AAAAAHYI4uxyryMeLuLHHDEHSdNZn+Uc",
-                "balance": 99999999999863378,
-                "nonce": 2,
-                "template": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB",
-                "state": "HqsEi7+vZ7oqINxH7lYKDpyQVerJhSvKfhSHDcI6JMg="
-            },
-            {
-                "address": "AAAAAIEtzQqCaLIJQfBXw1DuOPpQZv+y",
-                "balance": 99999999999863378,
-                "nonce": 2,
-                "template": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB",
-                "state": "UC65cj7HOPJqYagaeVy3SXy8weDmtvKRVZu+WQYqhXM="
-            },
-            {
-                "address": "AAAAAINzk5402WXIT+3ti89stMmZQiAI",
-                "balance": 99999999999863378,
-                "nonce": 2,
-                "template": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB",
-                "state": "CPvzEMLPa3bWbNTo02pqjHyI7PEEZ2lv/lGkYLwuHIs="
-            },
-            {
-                "address": "AAAAALOIq50BKZxlVKEZqONtsNlyOUeJ",
-                "balance": 99999999999863378,
-                "nonce": 2,
-                "template": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB",
-                "state": "Gfmjt6Kd+wJN6Pa4hTapZaOYJC7V/9YUodrzkVPYWeg="
-            },
-            {
-                "address": "AAAAAL1XWyitwtnCf75AjQ3alv/cOsTJ",
-                "balance": 99999999999863378,
-                "nonce": 2,
-                "template": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB",
-                "state": "epKOw7UakXzPuNQ5UmwrmC5c5VH5J8Wd/OGd++ut4KE="
-            },
-            {
-                "address": "AAAAANmtySRp9InS6YkIFZZLhRARq80t",
-                "balance": 99999999999863378,
-                "nonce": 2,
-                "template": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB",
-                "state": "6CGvkwPVkE3oRCtwM/KnS4qrsF37w40z6tE7HsQDD0E="
-            },
-            {
-                "address": "AAAAAPRFrccwTVI1jHzxBoZzFLhZqFYo",
-                "balance": 99999999999863378,
-                "nonce": 2,
-                "template": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB",
-                "state": "Q9PuZ7NKMTO5fUIgdCG0tptm7AEUjonCKEeKsAWXALk="
             }
         ]
     }

--- a/checkpoint/recovery.go
+++ b/checkpoint/recovery.go
@@ -350,6 +350,7 @@ func checkpointData(fs afero.Fs, file string, newGenesis types.LayerID) (*recove
 		cAtx.TickCount = atx.TickCount
 		cAtx.Sequence = atx.Sequence
 		copy(cAtx.Coinbase[:], atx.Coinbase)
+		cAtx.Units = atx.Units
 		allAtxs = append(allAtxs, &cAtx)
 	}
 	return &recoveryData{

--- a/checkpoint/recovery_test.go
+++ b/checkpoint/recovery_test.go
@@ -836,6 +836,7 @@ func TestRecover_OwnAtxNotInCheckpoint_Preserve_DepIsGolden(t *testing.T) {
 		SmesherID:     golden.SmesherID,
 		Sequence:      golden.Sequence,
 		Coinbase:      golden.Coinbase,
+		Units:         map[types.NodeID]uint32{golden.SmesherID: golden.NumUnits},
 	}))
 	validateAndPreserveData(t, oldDB, vAtxs[1:])
 	// the proofs are not valid, but save them anyway for the purpose of testing

--- a/checkpoint/runner.go
+++ b/checkpoint/runner.go
@@ -88,6 +88,7 @@ func checkpointDB(
 			PublicKey:      catx.SmesherID.Bytes(),
 			Sequence:       catx.Sequence,
 			Coinbase:       catx.Coinbase.Bytes(),
+			Units:          catx.Units,
 		})
 	}
 

--- a/common/types/activation.go
+++ b/common/types/activation.go
@@ -207,14 +207,6 @@ func (atx *ActivationTx) TargetEpoch() EpochID {
 	return atx.PublishEpoch + 1
 }
 
-func (atx *ActivationTx) Published() EpochID {
-	return atx.PublishEpoch
-}
-
-func (atx *ActivationTx) TotalNumUnits() uint32 {
-	return atx.NumUnits
-}
-
 // Golden returns true if atx is from a checkpoint snapshot.
 // a golden ATX is not verifiable, and is only allowed to be prev atx or positioning atx.
 func (atx *ActivationTx) Golden() bool {

--- a/common/types/checkpoint.go
+++ b/common/types/checkpoint.go
@@ -17,12 +17,15 @@ type AtxSnapshot struct {
 	Epoch          uint32 `json:"epoch"`
 	CommitmentAtx  []byte `json:"commitmentAtx"`
 	VrfNonce       uint64 `json:"vrfNonce"`
-	NumUnits       uint32 `json:"numUnits"`
 	BaseTickHeight uint64 `json:"baseTickHeight"`
 	TickCount      uint64 `json:"tickCount"`
 	PublicKey      []byte `json:"publicKey"`
 	Sequence       uint64 `json:"sequence"`
 	Coinbase       []byte `json:"coinbase"`
+	// total effective units
+	NumUnits uint32 `json:"numUnits"`
+	// actual units per smesher
+	Units map[NodeID]uint32 `json:"units"`
 }
 
 type AccountSnapshot struct {

--- a/common/types/nodeid.go
+++ b/common/types/nodeid.go
@@ -55,7 +55,7 @@ func (id *NodeID) DecodeScale(d *scale.Decoder) (int, error) {
 	return scale.DecodeByteArray(d, id[:])
 }
 
-func (id *NodeID) MarshalText() ([]byte, error) {
+func (id NodeID) MarshalText() ([]byte, error) {
 	return util.Base64Encode(id[:]), nil
 }
 

--- a/node/node.go
+++ b/node/node.go
@@ -76,6 +76,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/sql/layers"
 	"github.com/spacemeshos/go-spacemesh/sql/localsql"
 	dbmetrics "github.com/spacemeshos/go-spacemesh/sql/metrics"
+	"github.com/spacemeshos/go-spacemesh/sql/migrations"
 	"github.com/spacemeshos/go-spacemesh/syncer"
 	"github.com/spacemeshos/go-spacemesh/syncer/atxsync"
 	"github.com/spacemeshos/go-spacemesh/syncer/blockssync"
@@ -1901,14 +1902,16 @@ func (app *App) setupDBs(ctx context.Context, lg log.Log) error {
 	if err := os.MkdirAll(dbPath, os.ModePerm); err != nil {
 		return fmt.Errorf("failed to create %s: %w", dbPath, err)
 	}
+	dbLog := app.addLogger(StateDbLogger, lg)
+	m21 := migrations.New0021Migration(dbLog.Zap(), 100_000)
 	migrations, err := sql.StateMigrations()
 	if err != nil {
 		return fmt.Errorf("failed to load migrations: %w", err)
 	}
-	dbLog := app.addLogger(StateDbLogger, lg)
 	dbopts := []sql.Opt{
 		sql.WithLogger(dbLog.Zap()),
 		sql.WithMigrations(migrations),
+		sql.WithMigration(m21),
 		sql.WithConnections(app.Config.DatabaseConnections),
 		sql.WithLatencyMetering(app.Config.DatabaseLatencyMetering),
 		sql.WithVacuumState(app.Config.DatabaseVacuumState),

--- a/sql/atxs/atxs.go
+++ b/sql/atxs/atxs.go
@@ -453,16 +453,19 @@ func Add(db sql.Executor, atx *types.ActivationTx) error {
 		return fmt.Errorf("insert ATX ID %v: %w", atx.ID(), err)
 	}
 
-	enc = func(stmt *sql.Statement) {
-		stmt.BindBytes(1, atx.ID().Bytes())
-		stmt.BindBytes(2, atx.Blob)
-		stmt.BindInt64(3, int64(atx.Version))
-	}
-	_, err = db.Exec("insert into atx_blobs (id, atx, version) values (?1, ?2, ?3)", enc, nil)
-	if err != nil {
-		return fmt.Errorf("insert ATX blob %v: %w", atx.ID(), err)
-	}
+	return AddBlob(db, atx.ID(), atx.Blob, atx.Version)
+}
 
+func AddBlob(db sql.Executor, id types.ATXID, blob []byte, version types.AtxVersion) error {
+	enc := func(stmt *sql.Statement) {
+		stmt.BindBytes(1, id.Bytes())
+		stmt.BindBytes(2, blob)
+		stmt.BindInt64(3, int64(version))
+	}
+	_, err := db.Exec("insert into atx_blobs (id, atx, version) values (?1, ?2, ?3)", enc, nil)
+	if err != nil {
+		return fmt.Errorf("insert ATX blob %v: %w", id, err)
+	}
 	return nil
 }
 

--- a/sql/atxs/atxs_test.go
+++ b/sql/atxs/atxs_test.go
@@ -173,6 +173,7 @@ func TestLatestN(t *testing.T) {
 
 	for _, atx := range []*types.ActivationTx{atx1, atx2, atx3, atx4, atx5, atx6} {
 		require.NoError(t, atxs.Add(db, atx))
+		require.NoError(t, atxs.SetUnits(db, atx.ID(), map[types.NodeID]uint32{atx.SmesherID: atx.NumUnits}))
 	}
 
 	for _, tc := range []struct {
@@ -1119,5 +1120,43 @@ func TestCoinbase(t *testing.T) {
 		cb, err := atxs.Coinbase(db, sig.NodeID())
 		require.NoError(t, err)
 		require.Equal(t, atx2.Coinbase, cb)
+	})
+}
+
+func TestUnits(t *testing.T) {
+	t.Parallel()
+	t.Run("ATX not found", func(t *testing.T) {
+		t.Parallel()
+		db := sql.InMemory()
+		_, err := atxs.Units(db, types.RandomATXID(), types.RandomNodeID())
+		require.ErrorIs(t, err, sql.ErrNotFound)
+	})
+	t.Run("smesher has no units in ATX", func(t *testing.T) {
+		t.Parallel()
+		db := sql.InMemory()
+		atxID := types.RandomATXID()
+		require.NoError(t, atxs.SetUnits(db, atxID, map[types.NodeID]uint32{{1, 2, 3}: 10}))
+		_, err := atxs.Units(db, types.RandomATXID(), types.RandomNodeID())
+		require.ErrorIs(t, err, sql.ErrNotFound)
+	})
+	t.Run("returns units for given smesher in given ATX", func(t *testing.T) {
+		t.Parallel()
+		db := sql.InMemory()
+		atxID := types.RandomATXID()
+		units := map[types.NodeID]uint32{
+			{1, 2, 3}: 10,
+			{4, 5, 6}: 20,
+		}
+		require.NoError(t, atxs.SetUnits(db, atxID, units))
+
+		nodeID := types.NodeID{1, 2, 3}
+		got, err := atxs.Units(db, atxID, nodeID)
+		require.NoError(t, err)
+		require.Equal(t, units[nodeID], got)
+
+		nodeID = types.NodeID{4, 5, 6}
+		got, err = atxs.Units(db, atxID, nodeID)
+		require.NoError(t, err)
+		require.Equal(t, units[nodeID], got)
 	})
 }

--- a/sql/migrations/state/0021_atx_posts.sql
+++ b/sql/migrations/state/0021_atx_posts.sql
@@ -1,0 +1,12 @@
+-- Table showing the exact number of PoST units commited by smesher in given ATX.
+-- TODO(poszu): Migrate data for existing ATXs (require decoding blobs to be correct).
+--              Alternatively, we could take the effective numUnits from `atxs` table,
+--              which would be faster but it could cause temporary harm for ATXs growing in size.
+CREATE TABLE posts (
+    atxid  CHAR(32) NOT NULL,
+    units  INT NOT NULL,
+    pubkey CHAR(32) NOT NULL,
+    UNIQUE (atxid, pubkey)
+);
+
+CREATE INDEX posts_by_atxid_by_pubkey ON posts (atxid, pubkey);

--- a/sql/migrations/state/0021_atx_posts.sql
+++ b/sql/migrations/state/0021_atx_posts.sql
@@ -1,11 +1,8 @@
 -- Table showing the exact number of PoST units commited by smesher in given ATX.
--- TODO(poszu): Migrate data for existing ATXs (require decoding blobs to be correct).
---              Alternatively, we could take the effective numUnits from `atxs` table,
---              which would be faster but it could cause temporary harm for ATXs growing in size.
 CREATE TABLE posts (
     atxid  CHAR(32) NOT NULL,
-    units  INT NOT NULL,
     pubkey CHAR(32) NOT NULL,
+    units  INT NOT NULL,
     UNIQUE (atxid, pubkey)
 );
 

--- a/sql/migrations/state_0021_migration.go
+++ b/sql/migrations/state_0021_migration.go
@@ -1,0 +1,156 @@
+package migrations
+
+import (
+	"errors"
+	"fmt"
+
+	"go.uber.org/zap"
+
+	"github.com/spacemeshos/go-spacemesh/activation/wire"
+	"github.com/spacemeshos/go-spacemesh/codec"
+	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/sql"
+	"github.com/spacemeshos/go-spacemesh/sql/atxs"
+)
+
+type migration0021 struct {
+	batch  int
+	logger *zap.Logger
+}
+
+func New0021Migration(log *zap.Logger, batch int) *migration0021 {
+	return &migration0021{
+		logger: log,
+		batch:  batch,
+	}
+}
+
+func (*migration0021) Name() string {
+	return "populate posts table with units for each ATX"
+}
+
+func (*migration0021) Order() int {
+	return 21
+}
+
+func (*migration0021) Rollback() error {
+	return nil
+}
+
+func (m *migration0021) Apply(db sql.Executor) error {
+	if err := m.createTable(db); err != nil {
+		return err
+	}
+	var total int
+	_, err := db.Exec("SELECT count(*) FROM atx_blobs", nil, func(s *sql.Statement) bool {
+		total = s.ColumnInt(0)
+		return false
+	})
+	if err != nil {
+		return fmt.Errorf("counting all ATXs %w", err)
+	}
+	m.logger.Info("applying migration 21", zap.Int("total", total))
+
+	for offset := 0; ; offset += m.batch {
+		n, err := m.processBatch(db, offset, m.batch)
+		if err != nil {
+			return err
+		}
+
+		processed := offset + n
+		progress := float64(processed) * 100.0 / float64(total)
+		m.logger.Info("processed ATXs", zap.Float64("progress [%]", progress))
+		if processed >= total {
+			return nil
+		}
+	}
+}
+
+func (m *migration0021) createTable(db sql.Executor) error {
+	query := `CREATE TABLE posts (
+		atxid  CHAR(32) NOT NULL,
+		pubkey CHAR(32) NOT NULL,
+		units  INT NOT NULL,
+		UNIQUE (atxid, pubkey)
+	);`
+	_, err := db.Exec(query, nil, nil)
+	if err != nil {
+		return fmt.Errorf("creating posts table: %w", err)
+	}
+
+	query = "CREATE INDEX posts_by_atxid_by_pubkey ON posts (atxid, pubkey);"
+	_, err = db.Exec(query, nil, nil)
+	if err != nil {
+		return fmt.Errorf("creating index `posts_by_atxid_by_pubkey`: %w", err)
+	}
+	return nil
+}
+
+type update struct {
+	id    types.NodeID
+	units uint32
+}
+
+func (m *migration0021) processBatch(db sql.Executor, offset, size int) (int, error) {
+	var blob sql.Blob
+	var id types.ATXID
+	var procErr error
+	updates := make(map[types.ATXID]*update)
+	rows, err := db.Exec("SELECT id, atx, version FROM atx_blobs LIMIT ?1 OFFSET ?2",
+		func(s *sql.Statement) {
+			s.BindInt64(1, int64(size))
+			s.BindInt64(2, int64(offset))
+		},
+		func(stmt *sql.Statement) bool {
+			_, procErr = stmt.ColumnReader(0).Read(id[:])
+			if procErr != nil {
+				return false
+			}
+
+			blob.FromColumn(stmt, 1)
+			version := types.AtxVersion(stmt.ColumnInt(2))
+
+			upd, err := processATX(types.AtxBlob{Blob: blob.Bytes, Version: version})
+			if err != nil {
+				procErr = fmt.Errorf("processing ATX %s: %w", id, err)
+				return false
+			}
+			updates[id] = upd
+			return true
+		},
+	)
+
+	if err := errors.Join(err, procErr); err != nil {
+		return 0, fmt.Errorf("getting ATX blobs: %w", err)
+	}
+	if rows == 0 {
+		return 0, nil
+	}
+
+	if err := m.applyPendingUpdates(db, updates); err != nil {
+		return 0, fmt.Errorf("applying updates: %w", err)
+	}
+	return rows, nil
+}
+
+func (m *migration0021) applyPendingUpdates(db sql.Executor, updates map[types.ATXID]*update) error {
+	for id, upd := range updates {
+		atxs.SetUnits(db, id, map[types.NodeID]uint32{upd.id: upd.units})
+	}
+	return nil
+}
+
+func processATX(blob types.AtxBlob) (*update, error) {
+	switch blob.Version {
+	case 0:
+		fallthrough
+	case types.AtxV1:
+		var watx wire.ActivationTxV1
+		if err := codec.Decode(blob.Blob, &watx); err != nil {
+			return nil, fmt.Errorf("decoding ATX V1: %w", err)
+		}
+		return &update{watx.SmesherID, watx.NumUnits}, nil
+	default:
+		return nil, fmt.Errorf("unsupported ATX version: %d", blob.Version)
+	}
+}

--- a/sql/migrations/state_0021_migration_test.go
+++ b/sql/migrations/state_0021_migration_test.go
@@ -1,0 +1,96 @@
+package migrations
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/spacemeshos/go-spacemesh/activation/wire"
+	"github.com/spacemeshos/go-spacemesh/codec"
+	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/signing"
+	"github.com/spacemeshos/go-spacemesh/sql"
+	"github.com/spacemeshos/go-spacemesh/sql/atxs"
+)
+
+// Test that in-code migration results in the same schema as the .sql one.
+func Test0021Migration_CompatibleSchema(t *testing.T) {
+	db := sql.InMemory(
+		sql.WithLogger(zaptest.NewLogger(t)),
+		sql.WithMigration(New0021Migration(zaptest.NewLogger(t), 1000)),
+	)
+
+	var schemasInCode []string
+	_, err := db.Exec("SELECT sql FROM sqlite_schema;", nil, func(stmt *sql.Statement) bool {
+		sql := stmt.ColumnText(0)
+		sql = strings.Join(strings.Fields(sql), " ") // remove whitespace
+		schemasInCode = append(schemasInCode, sql)
+		return true
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	db = sql.InMemory()
+
+	var schemasInFile []string
+	_, err = db.Exec("SELECT sql FROM sqlite_schema;", nil, func(stmt *sql.Statement) bool {
+		sql := stmt.ColumnText(0)
+		sql = strings.Join(strings.Fields(sql), " ") // remove whitespace
+		schemasInFile = append(schemasInFile, sql)
+		return true
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	require.Equal(t, schemasInFile, schemasInCode)
+}
+
+func Test0021Migration(t *testing.T) {
+	db := sql.InMemory(
+		sql.WithLogger(zaptest.NewLogger(t)),
+		sql.WithSkipMigrations(21),
+	)
+
+	var signers [177]*signing.EdSigner
+	for i := range signers {
+		var err error
+		signers[i], err = signing.NewEdSigner()
+		require.NoError(t, err)
+	}
+	type post struct {
+		id    types.NodeID
+		units uint32
+	}
+	allPosts := make(map[types.EpochID]map[types.ATXID]post)
+	for epoch := range types.EpochID(40) {
+		allPosts[epoch] = make(map[types.ATXID]post)
+		for _, signer := range signers {
+			watx := wire.ActivationTxV1{
+				InnerActivationTxV1: wire.InnerActivationTxV1{
+					NumUnits: epoch.Uint32() * 10,
+					Coinbase: types.Address(types.RandomBytes(24)),
+				},
+				SmesherID: signer.NodeID(),
+			}
+			require.NoError(t, atxs.AddBlob(db, watx.ID(), codec.MustEncode(&watx), 0))
+			allPosts[epoch][watx.ID()] = post{
+				id:    signer.NodeID(),
+				units: watx.NumUnits,
+			}
+		}
+	}
+
+	m := New0021Migration(zaptest.NewLogger(t), 1000)
+	require.Equal(t, 21, m.Order())
+	require.NoError(t, m.Apply(db))
+
+	for _, posts := range allPosts {
+		for atx, post := range posts {
+			units, err := atxs.Units(db, atx, post.id)
+			require.NoError(t, err)
+			require.Equal(t, post.units, units)
+		}
+	}
+}


### PR DESCRIPTION
## Motivation

A merged ATX contains PoST proofs for multiple IDs. When using such ATX as the previous ATX, we must ensure that the identity which claims this ATX to be its previous one was a member of that ATX. To do this, we must persist a mapping (`ATXID`, `NODEID`) -> number of POST units across a checkpoint-restore.

As a benefit, it also simplifies and speeds up the code calculating the effective num units for ID as we don't need to decode the previous ATX blob anymore.

## Description

I added a table `posts` that maps a pair of `ATXID` and `NodeID` to units. There will be a row for every identity contributing its PoST in an ATX (1 row for ATX v1 and  1-256 rows for ATX v2). This table simplifies the calculation of effective units in the ATX handler - decoding the previous ATX blob turned into a lookup in the `posts` table.

I didn't include a `map[types.NodeID]uint32` field in the `types.ActivationTx` to avoid having to fill it every time an ATX is retrieved from the database. Reading PoSTs is only required in the ATX handler and the checkpoint generation. 

The checkpoint generation and recovery code was updated to persist the units across checkpoint.

## Test Plan

<!-- Please specify how these changes were tested (e.g. unit tests, manual testing, etc.) -->

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [ ] Test changes and document test plan
- [ ] Update documentation as needed
- [ ] Update [changelog](../CHANGELOG.md) as needed
