### PR TITLE
[Merged by Bors] - api: v2alpha1: Fix issue with filtering by address in transaction service

### DIFF
--- a/api/grpcserver/v2alpha1/transaction.go
+++ b/api/grpcserver/v2alpha1/transaction.go
@@ -256,9 +256,19 @@ func toTransactionOperations(filter *spacemeshv2alpha1.TransactionRequest) (buil
 			return builder.Operations{}, err
 		}
 		ops.Filter = append(ops.Filter, builder.Op{
-			Field: builder.Address,
-			Token: builder.Eq,
-			Value: addr.Bytes(),
+			Group: []builder.Op{
+				{
+					Field: builder.Address,
+					Token: builder.Eq,
+					Value: addr.Bytes(),
+				},
+				{
+					Field: builder.Principal,
+					Token: builder.Eq,
+					Value: addr.Bytes(),
+				},
+			},
+			GroupOperator: builder.Or,
 		})
 	}
 

--- a/api/grpcserver/v2alpha1/transaction_test.go
+++ b/api/grpcserver/v2alpha1/transaction_test.go
@@ -94,6 +94,10 @@ func TestTransactionService_List(t *testing.T) {
 		var expectedTxs []types.TransactionWithResult
 		for _, tx := range txsList {
 			found := false
+			if tx.Transaction.Principal.String() == address {
+				found = true
+			}
+
 			for _, addr := range tx.TransactionResult.Addresses {
 				if addr.String() == address {
 					found = true

--- a/sql/builder/builder.go
+++ b/sql/builder/builder.go
@@ -152,32 +152,34 @@ func BindingsFrom(operations Operations) sql.Encoder {
 		for _, op := range operations.Filter {
 			if len(op.Group) > 0 {
 				for _, groupOp := range op.Group {
-					bindValue(stmt, &bindIndex, groupOp.Value)
+					bindIndex = bindValue(stmt, bindIndex, groupOp.Value)
 				}
 			} else {
-				bindValue(stmt, &bindIndex, op.Value)
+				bindIndex = bindValue(stmt, bindIndex, op.Value)
 			}
 		}
 	}
 }
 
-func bindValue(stmt *sql.Statement, bindIndex *int, value any) {
+func bindValue(stmt *sql.Statement, bindIndex int, value any) int {
 	switch val := value.(type) {
 	case int64:
-		stmt.BindInt64(*bindIndex, val)
-		*bindIndex++
+		stmt.BindInt64(bindIndex, val)
+		bindIndex++
 	case []byte:
-		stmt.BindBytes(*bindIndex, val)
-		*bindIndex++
+		stmt.BindBytes(bindIndex, val)
+		bindIndex++
 	case types.EpochID:
-		stmt.BindInt64(*bindIndex, int64(val))
-		*bindIndex++
+		stmt.BindInt64(bindIndex, int64(val))
+		bindIndex++
 	case [][]byte:
 		for _, v := range val {
-			stmt.BindBytes(*bindIndex, v)
-			*bindIndex++
+			stmt.BindBytes(bindIndex, v)
+			bindIndex++
 		}
 	default:
 		panic(fmt.Sprintf("unexpected type %T", value))
 	}
+
+	return bindIndex
 }

--- a/sql/builder/builder.go
+++ b/sql/builder/builder.go
@@ -113,7 +113,8 @@ func FilterFrom(operations Operations) string {
 						params[j] = fmt.Sprintf("?%d", bindIndex)
 						bindIndex++
 					}
-					fmt.Fprintf(&queryBuilder, " %s%s %s (%s)", groupOp.Prefix, groupOp.Field, groupOp.Token, strings.Join(params, ", "))
+					fmt.Fprintf(&queryBuilder, " %s%s %s (%s)", groupOp.Prefix, groupOp.Field, groupOp.Token,
+						strings.Join(params, ", "))
 				} else {
 					fmt.Fprintf(&queryBuilder, " %s%s %s ?%d", groupOp.Prefix, groupOp.Field, groupOp.Token, bindIndex)
 					bindIndex++

--- a/sql/builder/builder.go
+++ b/sql/builder/builder.go
@@ -20,6 +20,13 @@ const (
 	In    token = "in"
 )
 
+type operator string
+
+const (
+	And operator = "and"
+	Or  operator = "or"
+)
+
 type field string
 
 const (
@@ -49,6 +56,9 @@ type Op struct {
 	// Value will be type casted to one the expected types.
 	// Operation will panic if it doesn't match any of expected.
 	Value any
+
+	Group         []Op
+	GroupOperator operator
 }
 
 type Modifier struct {
@@ -87,27 +97,51 @@ func FilterFrom(operations Operations) string {
 			queryBuilder.WriteString(" and")
 		}
 
-		if op.Token == In {
-			values, ok := op.Value.([][]byte)
-			if !ok {
-				panic("value for 'In' token must be a slice of []byte")
+		if len(op.Group) > 0 {
+			queryBuilder.WriteString(" (")
+			for k, groupOp := range op.Group {
+				if k != 0 {
+					queryBuilder.WriteString(fmt.Sprintf(" %s", op.GroupOperator))
+				}
+				if groupOp.Token == In {
+					values, ok := groupOp.Value.([][]byte)
+					if !ok {
+						panic("value for 'In' token must be a slice of []byte")
+					}
+					params := make([]string, len(values))
+					for j := range values {
+						params[j] = fmt.Sprintf("?%d", bindIndex)
+						bindIndex++
+					}
+					fmt.Fprintf(&queryBuilder, " %s%s %s (%s)", groupOp.Prefix, groupOp.Field, groupOp.Token, strings.Join(params, ", "))
+				} else {
+					fmt.Fprintf(&queryBuilder, " %s%s %s ?%d", groupOp.Prefix, groupOp.Field, groupOp.Token, bindIndex)
+					bindIndex++
+				}
 			}
-			params := make([]string, len(values))
-			for j := range values {
-				params[j] = fmt.Sprintf("?%d", bindIndex)
+			queryBuilder.WriteString(" )")
+		} else {
+			if op.Token == In {
+				values, ok := op.Value.([][]byte)
+				if !ok {
+					panic("value for 'In' token must be a slice of []byte")
+				}
+				params := make([]string, len(values))
+				for j := range values {
+					params[j] = fmt.Sprintf("?%d", bindIndex)
+					bindIndex++
+				}
+				fmt.Fprintf(&queryBuilder, " %s%s %s (%s)", op.Prefix, op.Field, op.Token, strings.Join(params, ", "))
+			} else {
+				fmt.Fprintf(&queryBuilder, " %s%s %s ?%d", op.Prefix, op.Field, op.Token, bindIndex)
 				bindIndex++
 			}
-			fmt.Fprintf(&queryBuilder, " %s%s %s (%s)", op.Prefix, op.Field, op.Token, strings.Join(params, ", "))
-		} else {
-			fmt.Fprintf(&queryBuilder, " %s%s %s ?%d", op.Prefix, op.Field, op.Token, bindIndex)
-			bindIndex++
 		}
 	}
 
 	for _, m := range operations.Modifiers {
 		queryBuilder.WriteString(fmt.Sprintf(" %s %v", string(m.Key), m.Value))
 	}
-
 	return queryBuilder.String()
 }
 
@@ -115,24 +149,34 @@ func BindingsFrom(operations Operations) sql.Encoder {
 	return func(stmt *sql.Statement) {
 		bindIndex := 1
 		for _, op := range operations.Filter {
-			switch value := op.Value.(type) {
-			case int64:
-				stmt.BindInt64(bindIndex, value)
-				bindIndex++
-			case []byte:
-				stmt.BindBytes(bindIndex, value)
-				bindIndex++
-			case types.EpochID:
-				stmt.BindInt64(bindIndex, int64(value))
-				bindIndex++
-			case [][]byte:
-				for _, v := range value {
-					stmt.BindBytes(bindIndex, v)
-					bindIndex++
+			if len(op.Group) > 0 {
+				for _, groupOp := range op.Group {
+					bindValue(stmt, &bindIndex, groupOp.Value)
 				}
-			default:
-				panic(fmt.Sprintf("unexpected type %T", value))
+			} else {
+				bindValue(stmt, &bindIndex, op.Value)
 			}
 		}
+	}
+}
+
+func bindValue(stmt *sql.Statement, bindIndex *int, value any) {
+	switch val := value.(type) {
+	case int64:
+		stmt.BindInt64(*bindIndex, val)
+		*bindIndex++
+	case []byte:
+		stmt.BindBytes(*bindIndex, val)
+		*bindIndex++
+	case types.EpochID:
+		stmt.BindInt64(*bindIndex, int64(val))
+		*bindIndex++
+	case [][]byte:
+		for _, v := range val {
+			stmt.BindBytes(*bindIndex, v)
+			*bindIndex++
+		}
+	default:
+		panic(fmt.Sprintf("unexpected type %T", value))
 	}
 }

--- a/sql/builder/builder_test.go
+++ b/sql/builder/builder_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestFilterFrom_WithSingleFilter(t *testing.T) {
+	t.Parallel()
 	operations := Operations{
 		Filter: []Op{
 			{Field: Epoch, Token: Eq, Value: types.EpochID(1)},

--- a/sql/builder/builder_test.go
+++ b/sql/builder/builder_test.go
@@ -1,0 +1,93 @@
+package builder
+
+import (
+	"testing"
+
+	"github.com/spacemeshos/go-spacemesh/common/types"
+)
+
+func TestFilterFrom_WithSingleFilter(t *testing.T) {
+	operations := Operations{
+		Filter: []Op{
+			{Field: Epoch, Token: Eq, Value: types.EpochID(1)},
+		},
+	}
+
+	expected := " where epoch = ?1"
+	actual := FilterFrom(operations)
+
+	if actual != expected {
+		t.Errorf("Expected '%s', but got '%s'", expected, actual)
+	}
+}
+
+func TestFilterFrom_WithMultipleFilters(t *testing.T) {
+	operations := Operations{
+		Filter: []Op{
+			{Field: Epoch, Token: Eq, Value: types.EpochID(1)},
+			{Field: Smesher, Token: Eq, Value: []byte("smesher")},
+		},
+	}
+
+	expected := " where epoch = ?1 and pubkey = ?2"
+	actual := FilterFrom(operations)
+
+	if actual != expected {
+		t.Errorf("Expected '%s', but got '%s'", expected, actual)
+	}
+}
+
+func TestFilterFrom_WithGroupFilters(t *testing.T) {
+	operations := Operations{
+		Filter: []Op{
+			{
+				Group: []Op{
+					{Field: Epoch, Token: Eq, Value: types.EpochID(1)},
+					{Field: Smesher, Token: Eq, Value: []byte("smesher")},
+				},
+				GroupOperator: And,
+			},
+		},
+	}
+
+	expected := " where ( epoch = ?1 and pubkey = ?2 )"
+	actual := FilterFrom(operations)
+
+	if actual != expected {
+		t.Errorf("Expected '%s', but got '%s'", expected, actual)
+	}
+}
+
+func TestFilterFrom_WithInToken(t *testing.T) {
+	operations := Operations{
+		Filter: []Op{
+			{Field: Epoch, Token: In, Value: [][]byte{[]byte("1"), []byte("2")}},
+		},
+	}
+
+	expected := " where epoch in (?1, ?2)"
+	actual := FilterFrom(operations)
+
+	if actual != expected {
+		t.Errorf("Expected '%s', but got '%s'", expected, actual)
+	}
+}
+
+func TestFilterFrom_WithModifiers(t *testing.T) {
+	operations := Operations{
+		Filter: []Op{
+			{Field: Epoch, Token: Eq, Value: types.EpochID(1)},
+		},
+		Modifiers: []Modifier{
+			{Key: OrderBy, Value: "epoch"},
+			{Key: Limit, Value: 10},
+		},
+	}
+
+	expected := " where epoch = ?1 order by epoch limit 10"
+	actual := FilterFrom(operations)
+
+	if actual != expected {
+		t.Errorf("Expected '%s', but got '%s'", expected, actual)
+	}
+}

--- a/sql/builder/builder_test.go
+++ b/sql/builder/builder_test.go
@@ -23,6 +23,7 @@ func TestFilterFrom_WithSingleFilter(t *testing.T) {
 }
 
 func TestFilterFrom_WithMultipleFilters(t *testing.T) {
+	t.Parallel()
 	operations := Operations{
 		Filter: []Op{
 			{Field: Epoch, Token: Eq, Value: types.EpochID(1)},
@@ -39,6 +40,7 @@ func TestFilterFrom_WithMultipleFilters(t *testing.T) {
 }
 
 func TestFilterFrom_WithGroupFilters(t *testing.T) {
+	t.Parallel()
 	operations := Operations{
 		Filter: []Op{
 			{
@@ -60,6 +62,7 @@ func TestFilterFrom_WithGroupFilters(t *testing.T) {
 }
 
 func TestFilterFrom_WithInToken(t *testing.T) {
+	t.Parallel()
 	operations := Operations{
 		Filter: []Op{
 			{Field: Epoch, Token: In, Value: [][]byte{[]byte("1"), []byte("2")}},
@@ -75,6 +78,7 @@ func TestFilterFrom_WithInToken(t *testing.T) {
 }
 
 func TestFilterFrom_WithModifiers(t *testing.T) {
+	t.Parallel()
 	operations := Operations{
 		Filter: []Op{
 			{Field: Epoch, Token: Eq, Value: types.EpochID(1)},


### PR DESCRIPTION
Transactions that don't have results yet can't be found by address field. This PR adds Group filtering to the builder to allow filtering by both address and principal at the same time.