### PR TITLE
[Merged by Bors] - Increase verbosity again

### DIFF
--- a/systest/Makefile
+++ b/systest/Makefile
@@ -36,7 +36,7 @@ ifeq ($(configname),$(test_job_name))
 	run_deps = config
 endif
 
-command := tests -test.count=$(count) -test.timeout=0 -test.run=$(test_name) -clusters=$(clusters) \
+command := tests -test.v -test.count=$(count) -test.timeout=0 -test.run=$(test_name) -clusters=$(clusters) \
 -level=$(level) -labels=$(label) -configname=$(configname)
 
 .PHONY: docker

--- a/systest/README.md
+++ b/systest/README.md
@@ -13,7 +13,9 @@ This testing setup can run on top of any k8s installation. The instructions belo
     sudo install minikube-linux-amd64 /usr/local/bin/minikube
     ```
 
-2. Grant permissions for default `serviceaccount` so that it will be allowed to create namespaces by client that runs in-cluster. NOTE: this step is optional, do it only if you're experiencing RBAC related problems with a throwaway cluster. Never perform it on a real cluster!
+2. Grant permissions for default `serviceaccount` so that it will be allowed to create namespaces by client that runs
+   in-cluster. NOTE: this step is optional, do it only if you're experiencing RBAC related problems with a throwaway
+   cluster. Never perform it on a real cluster!
 
     ```bash
     kubectl create clusterrolebinding serviceaccounts-cluster-admin \

--- a/systest/testcontext/context.go
+++ b/systest/testcontext/context.go
@@ -17,6 +17,7 @@ import (
 	chaos "github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 	"k8s.io/apimachinery/pkg/api/errors"
 	apimetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -340,8 +341,7 @@ func New(t *testing.T, opts ...Opt) *Context {
 		ns = "test-" + rngName()
 	}
 	clSize := clusterSize.Get(p)
-	logger, err := zap.NewDevelopment(zap.IncreaseLevel(logLevel), zap.AddCaller())
-	require.NoError(t, err)
+	logger := zaptest.NewLogger(t, zaptest.WrapOptions(zap.IncreaseLevel(logLevel), zap.AddCaller()))
 	cctx := &Context{
 		Context:           ctx,
 		Parameters:        p,


### PR DESCRIPTION
## Motivation

Reducing test verbosity didn't have the intended impact. Tests still write logs to the testrunner but the tests these logs are coming from aren't logged any more. This PR addresses this issue.

## Description

- made systests verbose again
- use `zaptest.Logger` instead of `zap.Logger` in system tests to see the logs at the tests they belong to instead of interlaced.

## Test Plan

exiting tests pass

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
