### PR TITLE
[Merged by Bors] - Deflake TestQueued on slower runners

### DIFF
--- a/p2p/server/server_test.go
+++ b/p2p/server/server_test.go
@@ -190,7 +190,7 @@ func TestQueued(t *testing.T) {
 		WrapHandler(func(_ context.Context, msg []byte) ([]byte, error) {
 			return msg, nil
 		}),
-		WithQueueSize(total/4),
+		WithQueueSize(total/3),
 		WithRequestsPerInterval(50, time.Second),
 		WithMetrics(),
 	)


### PR DESCRIPTION
## Motivation

On slower runners this test fails regularly because not enough clients in the simulated mesh are able to respond to the ping within a second. This slightly increases the queue size so fewer pings fail and hopefully the expected number of pings are able to succeed.

## Description

Slightly increase queue size in the test to decrease the chance of the test failing.

Before 200 executions of that test had 1-2 tests fail on my machine, 200 executions with the change didn't fail once. 🤞 

## Test Plan

test now (hopefully) doesn't fail any more

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
