### PR TITLE
[Merged by Bors] - Install linter again on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,12 +57,7 @@ install:
 	git lfs install
 	go mod download
 
-ifneq ($(OS),Windows_NT)
-	# On GH windows runners this fails at the moment: https://github.com/actions/runner-images/issues/10009
-	# since we don't run the linter on windows in the CI, we can skip this step for now
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s $(GOLANGCI_LINT_VERSION)
-endif
-
 	go install github.com/spacemeshos/go-scale/scalegen@$(GOSCALE_VERSION)
 	go install go.uber.org/mock/mockgen@$(MOCKGEN_VERSION)
 	go install gotest.tools/gotestsum@$(GOTESTSUM_VERSION)


### PR DESCRIPTION
## Motivation

The problems related to a buggy version of curl on the github windows runner seem to have been resolved. This change reverts the temporarily disabled installation on windows.

## Description

Revert disabling installation of `golangci-lint` on windows.

## Test Plan

- existing tests pass

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
