### PR TITLE
[Merged by Bors] - Raised the CPU Requests to 0.4 in systest

### DIFF
--- a/systest/cluster/nodes.go
+++ b/systest/cluster/nodes.go
@@ -62,7 +62,7 @@ var (
 		"requests and limits for smesher container",
 		&apiv1.ResourceRequirements{
 			Requests: apiv1.ResourceList{
-				apiv1.ResourceCPU:    resource.MustParse("0.2"),
+				apiv1.ResourceCPU:    resource.MustParse("0.4"),
 				apiv1.ResourceMemory: resource.MustParse("400Mi"),
 			},
 			Limits: apiv1.ResourceList{


### PR DESCRIPTION
I noticed that a lot of our systests often use 0.4 or more CPUs. And then, pretty much all of them are throttled on CPU because of resource fights.
