### PR TITLE
[Merged by Bors] - Use a fast poet backend in E2E activation tests

### DIFF
--- a/activation/activation.go
+++ b/activation/activation.go
@@ -82,7 +82,7 @@ type Builder struct {
 	syncer            syncer
 	logger            *zap.Logger
 	parentCtx         context.Context
-	poets             []PoetClient
+	poets             []PoetService
 	poetCfg           PoetConfig
 	poetRetryInterval time.Duration
 	// delay before PoST in ATX is considered valid (counting from the time it was received)
@@ -141,7 +141,7 @@ func WithPoetConfig(c PoetConfig) BuilderOption {
 	}
 }
 
-func WithPoets(poets ...PoetClient) BuilderOption {
+func WithPoets(poets ...PoetService) BuilderOption {
 	return func(b *Builder) {
 		b.poets = poets
 	}

--- a/activation/e2e/activation_test.go
+++ b/activation/e2e/activation_test.go
@@ -92,9 +92,9 @@ func Test_BuilderWithMultipleClients(t *testing.T) {
 	require.NoError(t, eg.Wait())
 
 	// ensure that genesis aligns with layer timings
-	genesis := time.Now().Add(layerDuration).Round(layerDuration)
 	layerDuration := 3 * time.Second
-	epoch := layersPerEpoch * layerDuration
+	epoch := layerDuration * layersPerEpoch
+	genesis := time.Now().Add(layerDuration).Round(layerDuration)
 	poetCfg := activation.PoetConfig{
 		PhaseShift:        epoch,
 		CycleGap:          epoch / 2,

--- a/activation/e2e/activation_test.go
+++ b/activation/e2e/activation_test.go
@@ -160,7 +160,7 @@ func Test_BuilderWithMultipleClients(t *testing.T) {
 		clock,
 		validator,
 		activation.NipostbuilderWithPostStates(postStates),
-		activation.WithPoetClients(client),
+		activation.WithPoetServices(client),
 	)
 	require.NoError(t, err)
 

--- a/activation/e2e/builds_atx_v2_test.go
+++ b/activation/e2e/builds_atx_v2_test.go
@@ -106,7 +106,7 @@ func TestBuilder_SwitchesToBuildV2(t *testing.T) {
 	t.Cleanup(clock.Close)
 
 	backend := ae2e.NewTestPoetBackend(1)
-	client := activation.NewPoetClientWithBackend(poetDb, backend, poetCfg, logger)
+	client := activation.NewPoetServiceWithClient(poetDb, backend, poetCfg, logger)
 
 	postStates := activation.NewPostStates(logger)
 	localDB := localsql.InMemory()

--- a/activation/e2e/builds_atx_v2_test.go
+++ b/activation/e2e/builds_atx_v2_test.go
@@ -105,8 +105,8 @@ func TestBuilder_SwitchesToBuildV2(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(clock.Close)
 
-	backend := ae2e.NewTestPoetBackend(1)
-	client := activation.NewPoetServiceWithClient(poetDb, backend, poetCfg, logger)
+	client := ae2e.NewTestPoetClient(1)
+	poetClient := activation.NewPoetServiceWithClient(poetDb, client, poetCfg, logger)
 
 	postStates := activation.NewPostStates(logger)
 	localDB := localsql.InMemory()
@@ -118,7 +118,7 @@ func TestBuilder_SwitchesToBuildV2(t *testing.T) {
 		clock,
 		validator,
 		activation.NipostbuilderWithPostStates(postStates),
-		activation.WithPoetClients(client),
+		activation.WithPoetServices(poetClient),
 	)
 	require.NoError(t, err)
 

--- a/activation/e2e/nipost_test.go
+++ b/activation/e2e/nipost_test.go
@@ -200,7 +200,7 @@ func TestNIPostBuilderWithClients(t *testing.T) {
 	require.NoError(t, err)
 
 	backend := ae2e.NewTestPoetBackend(1)
-	client := activation.NewPoetClientWithBackend(poetDb, backend, poetCfg, logger)
+	client := activation.NewPoetServiceWithClient(poetDb, backend, poetCfg, logger)
 
 	localDB := localsql.InMemory()
 	nb, err := activation.NewNIPostBuilder(
@@ -294,7 +294,7 @@ func Test_NIPostBuilderWithMultipleClients(t *testing.T) {
 
 	poetDb := activation.NewPoetDb(db, logger.Named("poetDb"))
 	backend := ae2e.NewTestPoetBackend(len(signers))
-	client := activation.NewPoetClientWithBackend(poetDb, backend, poetCfg, logger)
+	client := activation.NewPoetServiceWithClient(poetDb, backend, poetCfg, logger)
 
 	mclock := activation.NewMocklayerClock(ctrl)
 	mclock.EXPECT().LayerToTime(gomock.Any()).AnyTimes().DoAndReturn(

--- a/activation/e2e/nipost_test.go
+++ b/activation/e2e/nipost_test.go
@@ -199,8 +199,8 @@ func TestNIPostBuilderWithClients(t *testing.T) {
 	err = nipost.AddPost(localDb, sig.NodeID(), *fullPost(post, info, shared.ZeroChallenge))
 	require.NoError(t, err)
 
-	backend := ae2e.NewTestPoetBackend(1)
-	client := activation.NewPoetServiceWithClient(poetDb, backend, poetCfg, logger)
+	client := ae2e.NewTestPoetClient(1)
+	poetService := activation.NewPoetServiceWithClient(poetDb, client, poetCfg, logger)
 
 	localDB := localsql.InMemory()
 	nb, err := activation.NewNIPostBuilder(
@@ -210,7 +210,7 @@ func TestNIPostBuilderWithClients(t *testing.T) {
 		poetCfg,
 		mclock,
 		nil,
-		activation.WithPoetClients(client),
+		activation.WithPoetServices(poetService),
 	)
 	require.NoError(t, err)
 
@@ -293,8 +293,8 @@ func Test_NIPostBuilderWithMultipleClients(t *testing.T) {
 	}
 
 	poetDb := activation.NewPoetDb(db, logger.Named("poetDb"))
-	backend := ae2e.NewTestPoetBackend(len(signers))
-	client := activation.NewPoetServiceWithClient(poetDb, backend, poetCfg, logger)
+	client := ae2e.NewTestPoetClient(len(signers))
+	poetService := activation.NewPoetServiceWithClient(poetDb, client, poetCfg, logger)
 
 	mclock := activation.NewMocklayerClock(ctrl)
 	mclock.EXPECT().LayerToTime(gomock.Any()).AnyTimes().DoAndReturn(
@@ -315,7 +315,7 @@ func Test_NIPostBuilderWithMultipleClients(t *testing.T) {
 		poetCfg,
 		mclock,
 		validator,
-		activation.WithPoetClients(client),
+		activation.WithPoetServices(poetService),
 	)
 	require.NoError(t, err)
 

--- a/activation/e2e/poet_client.go
+++ b/activation/e2e/poet_client.go
@@ -52,7 +52,7 @@ func (p *TestPoet) Submit(
 	_ time.Time,
 	_, challenge []byte,
 	_ types.EdSignature,
-	nodeID types.NodeID,
+	_ types.NodeID,
 	_ activation.PoetAuth,
 ) (*types.PoetRound, error) {
 	if len(challenge) != 32 {

--- a/activation/e2e/poet_client.go
+++ b/activation/e2e/poet_client.go
@@ -27,7 +27,7 @@ type TestPoet struct {
 	registrations   chan []byte
 }
 
-func NewTestPoetBackend(expectedMembers int) *TestPoet {
+func NewTestPoetClient(expectedMembers int) *TestPoet {
 	return &TestPoet{
 		expectedMembers: expectedMembers,
 		registrations:   make(chan []byte, expectedMembers),

--- a/activation/e2e/poet_client.go
+++ b/activation/e2e/poet_client.go
@@ -34,10 +34,6 @@ func NewTestPoetBackend(expectedMembers int) *TestPoet {
 	}
 }
 
-func (p *TestPoet) RoundId() string {
-	return strconv.Itoa(p.round)
-}
-
 func (p *TestPoet) Id() []byte {
 	return []byte(p.Address())
 }
@@ -63,9 +59,9 @@ func (p *TestPoet) Submit(
 		return nil, errors.New("invalid challenge length")
 	}
 	p.mu.Lock()
-	p.registrations <- challenge
 	round := p.round
 	p.mu.Unlock()
+	p.registrations <- challenge
 
 	return &types.PoetRound{ID: strconv.Itoa(round), End: time.Now()}, nil
 }
@@ -74,6 +70,11 @@ func (p *TestPoet) CertifierInfo(ctx context.Context) (*url.URL, []byte, error) 
 	return nil, nil, errors.New("not supported")
 }
 
+// Build a proof.
+//
+// Waits for the expected number of registrations to be submitted
+// before starting to build the proof.
+//
 // NOT safe to be called concurrently.
 func (p *TestPoet) Proof(ctx context.Context, roundID string) (*types.PoetProofMessage, []types.Hash32, error) {
 	currentRoundId := strconv.Itoa(p.round)

--- a/activation/e2e/poet_client.go
+++ b/activation/e2e/poet_client.go
@@ -1,0 +1,151 @@
+package activation
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/spacemeshos/merkle-tree"
+	"github.com/spacemeshos/merkle-tree/cache"
+	"github.com/spacemeshos/merkle-tree/cache/readwriters"
+	"github.com/spacemeshos/poet/hash"
+	"github.com/spacemeshos/poet/shared"
+
+	"github.com/spacemeshos/go-spacemesh/activation"
+	"github.com/spacemeshos/go-spacemesh/common/types"
+)
+
+type TestPoet struct {
+	mu    sync.Mutex
+	round int
+
+	expectedMembers int
+	registrations   chan []byte
+}
+
+func NewTestPoetBackend(expectedMembers int) *TestPoet {
+	return &TestPoet{
+		expectedMembers: expectedMembers,
+		registrations:   make(chan []byte, expectedMembers),
+	}
+}
+
+func (p *TestPoet) RoundId() string {
+	return strconv.Itoa(p.round)
+}
+
+func (p *TestPoet) Id() []byte {
+	return []byte(p.Address())
+}
+
+func (p *TestPoet) Address() string {
+	return "http://poet.test"
+}
+
+func (p *TestPoet) PowParams(ctx context.Context) (*activation.PoetPowParams, error) {
+	return &activation.PoetPowParams{}, nil
+}
+
+// SAFE to be called concurrently.
+func (p *TestPoet) Submit(
+	_ context.Context,
+	_ time.Time,
+	_, challenge []byte,
+	_ types.EdSignature,
+	nodeID types.NodeID,
+	_ activation.PoetAuth,
+) (*types.PoetRound, error) {
+	if len(challenge) != 32 {
+		return nil, errors.New("invalid challenge length")
+	}
+	p.mu.Lock()
+	p.registrations <- challenge
+	round := p.round
+	p.mu.Unlock()
+
+	return &types.PoetRound{ID: strconv.Itoa(round), End: time.Now()}, nil
+}
+
+func (p *TestPoet) CertifierInfo(ctx context.Context) (*url.URL, []byte, error) {
+	return nil, nil, errors.New("not supported")
+}
+
+// NOT safe to be called concurrently.
+func (p *TestPoet) Proof(ctx context.Context, roundID string) (*types.PoetProofMessage, []types.Hash32, error) {
+	currentRoundId := strconv.Itoa(p.round)
+	if roundID != currentRoundId {
+		return nil, nil, fmt.Errorf("test error, invalid round ID (%s != expected %s)", roundID, currentRoundId)
+	}
+
+	mtree, err := merkle.NewTreeBuilder().WithHashFunc(shared.HashMembershipTreeNode).Build()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var members []types.Hash32
+	for i := 0; i < p.expectedMembers; i++ {
+		member := <-p.registrations
+		if err := mtree.AddLeaf(member[:]); err != nil {
+			return nil, nil, err
+		}
+		members = append(members, types.Hash32(member))
+	}
+	challenge := mtree.Root()
+
+	const leaves = uint64(shared.T)
+
+	treeCache := cache.NewWriter(
+		func(uint) bool { return true },
+		func(uint) (cache.LayerReadWriter, error) { return &readwriters.SliceReadWriter{}, nil },
+	)
+
+	labelHashFunc := hash.GenLabelHashFunc(challenge)
+	mekleHashFunc := hash.GenMerkleHashFunc(challenge)
+	tree, err := merkle.NewTreeBuilder().WithHashFunc(mekleHashFunc).WithCacheWriter(treeCache).Build()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	makeLabel := shared.MakeLabelFunc()
+	for i := range leaves {
+		parkedNodes := tree.GetParkedNodes(nil)
+		err := tree.AddLeaf(makeLabel(labelHashFunc, i, parkedNodes))
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	root := tree.Root()
+	cacheReader, err := treeCache.GetReader()
+	if err != nil {
+		return nil, nil, err
+	}
+	provenLeafIndices := shared.FiatShamir(root, leaves, shared.T)
+	_, provenLeaves, proofNodes, err := merkle.GenerateProof(provenLeafIndices, cacheReader)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	proof := &types.PoetProofMessage{
+		PoetProof: types.PoetProof{
+			MerkleProof: shared.MerkleProof{
+				Root:         root,
+				ProvenLeaves: provenLeaves,
+				ProofNodes:   proofNodes,
+			},
+			LeafCount: leaves,
+		},
+		RoundID:       roundID,
+		PoetServiceID: p.Id(),
+		Statement:     types.Hash32(challenge),
+	}
+
+	p.mu.Lock()
+	p.round++
+	p.mu.Unlock()
+	return proof, members, nil
+}

--- a/activation/e2e/poet_test.go
+++ b/activation/e2e/poet_test.go
@@ -41,8 +41,8 @@ func (h *HTTPPoetTestHarness) Client(
 	cfg activation.PoetConfig,
 	logger *zap.Logger,
 	opts ...activation.PoetClientOpt,
-) (activation.PoetClient, error) {
-	return activation.NewPoetClient(
+) (activation.PoetService, error) {
+	return activation.NewPoetService(
 		db,
 		h.ServerCfg(),
 		cfg,

--- a/activation/e2e/validation_test.go
+++ b/activation/e2e/validation_test.go
@@ -60,8 +60,8 @@ func TestValidator_Validate(t *testing.T) {
 	}
 
 	poetDb := activation.NewPoetDb(sql.InMemory(), logger.Named("poetDb"))
-	backend := ae2e.NewTestPoetBackend(1)
-	client := activation.NewPoetServiceWithClient(poetDb, backend, poetCfg, logger)
+	client := ae2e.NewTestPoetClient(1)
+	poetService := activation.NewPoetServiceWithClient(poetDb, client, poetCfg, logger)
 
 	mclock := activation.NewMocklayerClock(ctrl)
 	mclock.EXPECT().LayerToTime(gomock.Any()).AnyTimes().DoAndReturn(
@@ -93,7 +93,7 @@ func TestValidator_Validate(t *testing.T) {
 		poetCfg,
 		mclock,
 		validator,
-		activation.WithPoetClients(client),
+		activation.WithPoetServices(poetService),
 	)
 	require.NoError(t, err)
 

--- a/activation/e2e/validation_test.go
+++ b/activation/e2e/validation_test.go
@@ -61,7 +61,7 @@ func TestValidator_Validate(t *testing.T) {
 
 	poetDb := activation.NewPoetDb(sql.InMemory(), logger.Named("poetDb"))
 	backend := ae2e.NewTestPoetBackend(1)
-	client := activation.NewPoetClientWithBackend(poetDb, backend, poetCfg, logger)
+	client := activation.NewPoetServiceWithClient(poetDb, backend, poetCfg, logger)
 
 	mclock := activation.NewMocklayerClock(ctrl)
 	mclock.EXPECT().LayerToTime(gomock.Any()).AnyTimes().DoAndReturn(

--- a/activation/interface.go
+++ b/activation/interface.go
@@ -115,9 +115,9 @@ type SmeshingProvider interface {
 	SetCoinbase(coinbase types.Address)
 }
 
-// PoetClient servers as an interface to communicate with a PoET server.
+// PoetService servers as an interface to communicate with a PoET server.
 // It is used to submit challenges and fetch proofs.
-type PoetClient interface {
+type PoetService interface {
 	Address() string
 
 	// Submit registers a challenge in the proving service current open round.

--- a/activation/mocks.go
+++ b/activation/mocks.go
@@ -1571,31 +1571,31 @@ func (c *MockSmeshingProviderStopSmeshingCall) DoAndReturn(f func(bool) error) *
 	return c
 }
 
-// MockPoetClient is a mock of PoetClient interface.
-type MockPoetClient struct {
+// MockPoetService is a mock of PoetService interface.
+type MockPoetService struct {
 	ctrl     *gomock.Controller
-	recorder *MockPoetClientMockRecorder
+	recorder *MockPoetServiceMockRecorder
 }
 
-// MockPoetClientMockRecorder is the mock recorder for MockPoetClient.
-type MockPoetClientMockRecorder struct {
-	mock *MockPoetClient
+// MockPoetServiceMockRecorder is the mock recorder for MockPoetService.
+type MockPoetServiceMockRecorder struct {
+	mock *MockPoetService
 }
 
-// NewMockPoetClient creates a new mock instance.
-func NewMockPoetClient(ctrl *gomock.Controller) *MockPoetClient {
-	mock := &MockPoetClient{ctrl: ctrl}
-	mock.recorder = &MockPoetClientMockRecorder{mock}
+// NewMockPoetService creates a new mock instance.
+func NewMockPoetService(ctrl *gomock.Controller) *MockPoetService {
+	mock := &MockPoetService{ctrl: ctrl}
+	mock.recorder = &MockPoetServiceMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockPoetClient) EXPECT() *MockPoetClientMockRecorder {
+func (m *MockPoetService) EXPECT() *MockPoetServiceMockRecorder {
 	return m.recorder
 }
 
 // Address mocks base method.
-func (m *MockPoetClient) Address() string {
+func (m *MockPoetService) Address() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Address")
 	ret0, _ := ret[0].(string)
@@ -1603,37 +1603,37 @@ func (m *MockPoetClient) Address() string {
 }
 
 // Address indicates an expected call of Address.
-func (mr *MockPoetClientMockRecorder) Address() *MockPoetClientAddressCall {
+func (mr *MockPoetServiceMockRecorder) Address() *MockPoetServiceAddressCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Address", reflect.TypeOf((*MockPoetClient)(nil).Address))
-	return &MockPoetClientAddressCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Address", reflect.TypeOf((*MockPoetService)(nil).Address))
+	return &MockPoetServiceAddressCall{Call: call}
 }
 
-// MockPoetClientAddressCall wrap *gomock.Call
-type MockPoetClientAddressCall struct {
+// MockPoetServiceAddressCall wrap *gomock.Call
+type MockPoetServiceAddressCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockPoetClientAddressCall) Return(arg0 string) *MockPoetClientAddressCall {
+func (c *MockPoetServiceAddressCall) Return(arg0 string) *MockPoetServiceAddressCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockPoetClientAddressCall) Do(f func() string) *MockPoetClientAddressCall {
+func (c *MockPoetServiceAddressCall) Do(f func() string) *MockPoetServiceAddressCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockPoetClientAddressCall) DoAndReturn(f func() string) *MockPoetClientAddressCall {
+func (c *MockPoetServiceAddressCall) DoAndReturn(f func() string) *MockPoetServiceAddressCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // Certify mocks base method.
-func (m *MockPoetClient) Certify(ctx context.Context, id types.NodeID) (*certifier.PoetCert, error) {
+func (m *MockPoetService) Certify(ctx context.Context, id types.NodeID) (*certifier.PoetCert, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Certify", ctx, id)
 	ret0, _ := ret[0].(*certifier.PoetCert)
@@ -1642,37 +1642,37 @@ func (m *MockPoetClient) Certify(ctx context.Context, id types.NodeID) (*certifi
 }
 
 // Certify indicates an expected call of Certify.
-func (mr *MockPoetClientMockRecorder) Certify(ctx, id any) *MockPoetClientCertifyCall {
+func (mr *MockPoetServiceMockRecorder) Certify(ctx, id any) *MockPoetServiceCertifyCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Certify", reflect.TypeOf((*MockPoetClient)(nil).Certify), ctx, id)
-	return &MockPoetClientCertifyCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Certify", reflect.TypeOf((*MockPoetService)(nil).Certify), ctx, id)
+	return &MockPoetServiceCertifyCall{Call: call}
 }
 
-// MockPoetClientCertifyCall wrap *gomock.Call
-type MockPoetClientCertifyCall struct {
+// MockPoetServiceCertifyCall wrap *gomock.Call
+type MockPoetServiceCertifyCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockPoetClientCertifyCall) Return(arg0 *certifier.PoetCert, arg1 error) *MockPoetClientCertifyCall {
+func (c *MockPoetServiceCertifyCall) Return(arg0 *certifier.PoetCert, arg1 error) *MockPoetServiceCertifyCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockPoetClientCertifyCall) Do(f func(context.Context, types.NodeID) (*certifier.PoetCert, error)) *MockPoetClientCertifyCall {
+func (c *MockPoetServiceCertifyCall) Do(f func(context.Context, types.NodeID) (*certifier.PoetCert, error)) *MockPoetServiceCertifyCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockPoetClientCertifyCall) DoAndReturn(f func(context.Context, types.NodeID) (*certifier.PoetCert, error)) *MockPoetClientCertifyCall {
+func (c *MockPoetServiceCertifyCall) DoAndReturn(f func(context.Context, types.NodeID) (*certifier.PoetCert, error)) *MockPoetServiceCertifyCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // Proof mocks base method.
-func (m *MockPoetClient) Proof(ctx context.Context, roundID string) (*types.PoetProof, []types.Hash32, error) {
+func (m *MockPoetService) Proof(ctx context.Context, roundID string) (*types.PoetProof, []types.Hash32, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Proof", ctx, roundID)
 	ret0, _ := ret[0].(*types.PoetProof)
@@ -1682,37 +1682,37 @@ func (m *MockPoetClient) Proof(ctx context.Context, roundID string) (*types.Poet
 }
 
 // Proof indicates an expected call of Proof.
-func (mr *MockPoetClientMockRecorder) Proof(ctx, roundID any) *MockPoetClientProofCall {
+func (mr *MockPoetServiceMockRecorder) Proof(ctx, roundID any) *MockPoetServiceProofCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Proof", reflect.TypeOf((*MockPoetClient)(nil).Proof), ctx, roundID)
-	return &MockPoetClientProofCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Proof", reflect.TypeOf((*MockPoetService)(nil).Proof), ctx, roundID)
+	return &MockPoetServiceProofCall{Call: call}
 }
 
-// MockPoetClientProofCall wrap *gomock.Call
-type MockPoetClientProofCall struct {
+// MockPoetServiceProofCall wrap *gomock.Call
+type MockPoetServiceProofCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockPoetClientProofCall) Return(arg0 *types.PoetProof, arg1 []types.Hash32, arg2 error) *MockPoetClientProofCall {
+func (c *MockPoetServiceProofCall) Return(arg0 *types.PoetProof, arg1 []types.Hash32, arg2 error) *MockPoetServiceProofCall {
 	c.Call = c.Call.Return(arg0, arg1, arg2)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockPoetClientProofCall) Do(f func(context.Context, string) (*types.PoetProof, []types.Hash32, error)) *MockPoetClientProofCall {
+func (c *MockPoetServiceProofCall) Do(f func(context.Context, string) (*types.PoetProof, []types.Hash32, error)) *MockPoetServiceProofCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockPoetClientProofCall) DoAndReturn(f func(context.Context, string) (*types.PoetProof, []types.Hash32, error)) *MockPoetClientProofCall {
+func (c *MockPoetServiceProofCall) DoAndReturn(f func(context.Context, string) (*types.PoetProof, []types.Hash32, error)) *MockPoetServiceProofCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // Submit mocks base method.
-func (m *MockPoetClient) Submit(ctx context.Context, deadline time.Time, prefix, challenge []byte, signature types.EdSignature, nodeID types.NodeID) (*types.PoetRound, error) {
+func (m *MockPoetService) Submit(ctx context.Context, deadline time.Time, prefix, challenge []byte, signature types.EdSignature, nodeID types.NodeID) (*types.PoetRound, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Submit", ctx, deadline, prefix, challenge, signature, nodeID)
 	ret0, _ := ret[0].(*types.PoetRound)
@@ -1721,31 +1721,31 @@ func (m *MockPoetClient) Submit(ctx context.Context, deadline time.Time, prefix,
 }
 
 // Submit indicates an expected call of Submit.
-func (mr *MockPoetClientMockRecorder) Submit(ctx, deadline, prefix, challenge, signature, nodeID any) *MockPoetClientSubmitCall {
+func (mr *MockPoetServiceMockRecorder) Submit(ctx, deadline, prefix, challenge, signature, nodeID any) *MockPoetServiceSubmitCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Submit", reflect.TypeOf((*MockPoetClient)(nil).Submit), ctx, deadline, prefix, challenge, signature, nodeID)
-	return &MockPoetClientSubmitCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Submit", reflect.TypeOf((*MockPoetService)(nil).Submit), ctx, deadline, prefix, challenge, signature, nodeID)
+	return &MockPoetServiceSubmitCall{Call: call}
 }
 
-// MockPoetClientSubmitCall wrap *gomock.Call
-type MockPoetClientSubmitCall struct {
+// MockPoetServiceSubmitCall wrap *gomock.Call
+type MockPoetServiceSubmitCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockPoetClientSubmitCall) Return(arg0 *types.PoetRound, arg1 error) *MockPoetClientSubmitCall {
+func (c *MockPoetServiceSubmitCall) Return(arg0 *types.PoetRound, arg1 error) *MockPoetServiceSubmitCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockPoetClientSubmitCall) Do(f func(context.Context, time.Time, []byte, []byte, types.EdSignature, types.NodeID) (*types.PoetRound, error)) *MockPoetClientSubmitCall {
+func (c *MockPoetServiceSubmitCall) Do(f func(context.Context, time.Time, []byte, []byte, types.EdSignature, types.NodeID) (*types.PoetRound, error)) *MockPoetServiceSubmitCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockPoetClientSubmitCall) DoAndReturn(f func(context.Context, time.Time, []byte, []byte, types.EdSignature, types.NodeID) (*types.PoetRound, error)) *MockPoetClientSubmitCall {
+func (c *MockPoetServiceSubmitCall) DoAndReturn(f func(context.Context, time.Time, []byte, []byte, types.EdSignature, types.NodeID) (*types.PoetRound, error)) *MockPoetServiceSubmitCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/activation/nipost.go
+++ b/activation/nipost.go
@@ -49,7 +49,7 @@ var ErrInvalidInitialPost = errors.New("invalid initial post")
 type NIPostBuilder struct {
 	localDB *localsql.Database
 
-	poetProvers map[string]PoetClient
+	poetProvers map[string]PoetService
 	postService postService
 	logger      *zap.Logger
 	poetCfg     PoetConfig
@@ -60,9 +60,9 @@ type NIPostBuilder struct {
 
 type NIPostBuilderOption func(*NIPostBuilder)
 
-func WithPoetClients(clients ...PoetClient) NIPostBuilderOption {
+func WithPoetClients(clients ...PoetService) NIPostBuilderOption {
 	return func(nb *NIPostBuilder) {
-		nb.poetProvers = make(map[string]PoetClient, len(clients))
+		nb.poetProvers = make(map[string]PoetService, len(clients))
 		for _, client := range clients {
 			nb.poetProvers[client.Address()] = client
 		}
@@ -360,7 +360,7 @@ func (nb *NIPostBuilder) submitPoetChallenge(
 	ctx context.Context,
 	nodeID types.NodeID,
 	deadline time.Time,
-	client PoetClient,
+	client PoetService,
 	prefix, challenge []byte,
 	signature types.EdSignature,
 ) error {
@@ -428,7 +428,7 @@ func (nb *NIPostBuilder) submitPoetChallenges(
 	return nil
 }
 
-func (nb *NIPostBuilder) getPoetClient(ctx context.Context, address string) PoetClient {
+func (nb *NIPostBuilder) getPoetClient(ctx context.Context, address string) PoetService {
 	for _, client := range nb.poetProvers {
 		if address == client.Address() {
 			return client

--- a/activation/nipost.go
+++ b/activation/nipost.go
@@ -60,7 +60,7 @@ type NIPostBuilder struct {
 
 type NIPostBuilderOption func(*NIPostBuilder)
 
-func WithPoetClients(clients ...PoetService) NIPostBuilderOption {
+func WithPoetServices(clients ...PoetService) NIPostBuilderOption {
 	return func(nb *NIPostBuilder) {
 		nb.poetProvers = make(map[string]PoetService, len(clients))
 		for _, client := range clients {
@@ -428,10 +428,10 @@ func (nb *NIPostBuilder) submitPoetChallenges(
 	return nil
 }
 
-func (nb *NIPostBuilder) getPoetClient(ctx context.Context, address string) PoetService {
-	for _, client := range nb.poetProvers {
-		if address == client.Address() {
-			return client
+func (nb *NIPostBuilder) getPoetService(ctx context.Context, address string) PoetService {
+	for _, service := range nb.poetProvers {
+		if address == service.Address() {
+			return service
 		}
 	}
 	return nil
@@ -471,7 +471,7 @@ func (nb *NIPostBuilder) getBestProof(
 			zap.String("poet_address", r.Address),
 			zap.String("round", r.RoundID),
 		)
-		client := nb.getPoetClient(ctx, r.Address)
+		client := nb.getPoetService(ctx, r.Address)
 		if client == nil {
 			logger.Warn("poet client not found")
 			continue

--- a/activation/nipost_test.go
+++ b/activation/nipost_test.go
@@ -557,7 +557,7 @@ func TestNIPostBuilder_ManyPoETs_SubmittingChallenge_DeadlineReached(t *testing.
 	ctrl := gomock.NewController(t)
 	mclock := defaultLayerClockMock(ctrl)
 
-	poets := make([]PoetClient, 0, 2)
+	poets := make([]PoetService, 0, 2)
 	{
 		poet := NewMockPoetClient(ctrl)
 		poet.EXPECT().
@@ -634,7 +634,7 @@ func TestNIPostBuilder_ManyPoETs_AllFinished(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mclock := defaultLayerClockMock(ctrl)
 
-	poets := make([]PoetClient, 0, 2)
+	poets := make([]PoetService, 0, 2)
 	{
 		poet := NewMockPoetClient(ctrl)
 		poet.EXPECT().
@@ -1072,7 +1072,7 @@ func TestNIPostBuilder_Mainnet_Poet_Workaround(t *testing.T) {
 
 			challenge := types.RandomHash()
 			ctrl := gomock.NewController(t)
-			poets := make([]PoetClient, 0, 2)
+			poets := make([]PoetService, 0, 2)
 			{
 				poetProvider := NewMockPoetClient(ctrl)
 				poetProvider.EXPECT().Address().Return(tc.from)

--- a/activation/nipost_test.go
+++ b/activation/nipost_test.go
@@ -24,15 +24,15 @@ import (
 	"github.com/spacemeshos/go-spacemesh/sql/localsql/nipost"
 )
 
-func defaultPoetServiceMock(t *testing.T, ctrl *gomock.Controller, address string) *MockPoetClient {
+func defaultPoetServiceMock(t *testing.T, ctrl *gomock.Controller, address string) *MockPoetService {
 	t.Helper()
-	poetClient := NewMockPoetClient(ctrl)
-	poetClient.EXPECT().
+	poet := NewMockPoetService(ctrl)
+	poet.EXPECT().
 		Submit(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		AnyTimes().
 		Return(&types.PoetRound{}, nil)
-	poetClient.EXPECT().Address().AnyTimes().Return(address).AnyTimes()
-	return poetClient
+	poet.EXPECT().Address().AnyTimes().Return(address).AnyTimes()
+	return poet
 }
 
 func defaultLayerClockMock(ctrl *gomock.Controller) *MocklayerClock {
@@ -404,7 +404,7 @@ func Test_NIPostBuilder_WithMocks(t *testing.T) {
 		PoetConfig{},
 		mclock,
 		nil,
-		WithPoetClients(poetProvider),
+		WithPoetServices(poetProvider),
 	)
 	require.NoError(t, err)
 
@@ -440,7 +440,7 @@ func TestPostSetup(t *testing.T) {
 		PoetConfig{},
 		mclock,
 		nil,
-		WithPoetClients(poetProvider),
+		WithPoetServices(poetProvider),
 	)
 	require.NoError(t, err)
 
@@ -493,7 +493,7 @@ func TestNIPostBuilder_BuildNIPost(t *testing.T) {
 		PoetConfig{},
 		mclock,
 		nil,
-		WithPoetClients(poetProver),
+		WithPoetServices(poetProver),
 	)
 	require.NoError(t, err)
 
@@ -510,7 +510,7 @@ func TestNIPostBuilder_BuildNIPost(t *testing.T) {
 		PoetConfig{},
 		mclock,
 		nil,
-		WithPoetClients(poetProver),
+		WithPoetServices(poetProver),
 	)
 	require.NoError(t, err)
 
@@ -530,7 +530,7 @@ func TestNIPostBuilder_BuildNIPost(t *testing.T) {
 		PoetConfig{},
 		mclock,
 		nil,
-		WithPoetClients(poetProver),
+		WithPoetServices(poetProver),
 	)
 	require.NoError(t, err)
 	postClient.EXPECT().Proof(gomock.Any(), gomock.Any()).Return(
@@ -559,7 +559,7 @@ func TestNIPostBuilder_ManyPoETs_SubmittingChallenge_DeadlineReached(t *testing.
 
 	poets := make([]PoetService, 0, 2)
 	{
-		poet := NewMockPoetClient(ctrl)
+		poet := NewMockPoetService(ctrl)
 		poet.EXPECT().
 			Submit(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 			DoAndReturn(func(
@@ -576,7 +576,7 @@ func TestNIPostBuilder_ManyPoETs_SubmittingChallenge_DeadlineReached(t *testing.
 		poets = append(poets, poet)
 	}
 	{
-		poet := NewMockPoetClient(ctrl)
+		poet := NewMockPoetService(ctrl)
 		poet.EXPECT().
 			Submit(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(&types.PoetRound{}, nil)
@@ -609,7 +609,7 @@ func TestNIPostBuilder_ManyPoETs_SubmittingChallenge_DeadlineReached(t *testing.
 		poetCfg,
 		mclock,
 		nil,
-		WithPoetClients(poets...),
+		WithPoetServices(poets...),
 	)
 	require.NoError(t, err)
 
@@ -636,7 +636,7 @@ func TestNIPostBuilder_ManyPoETs_AllFinished(t *testing.T) {
 
 	poets := make([]PoetService, 0, 2)
 	{
-		poet := NewMockPoetClient(ctrl)
+		poet := NewMockPoetService(ctrl)
 		poet.EXPECT().
 			Submit(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(&types.PoetRound{}, nil)
@@ -668,7 +668,7 @@ func TestNIPostBuilder_ManyPoETs_AllFinished(t *testing.T) {
 		PoetConfig{},
 		mclock,
 		nil,
-		WithPoetClients(poets...),
+		WithPoetServices(poets...),
 	)
 	require.NoError(t, err)
 
@@ -695,7 +695,7 @@ func TestNIPSTBuilder_PoetUnstable(t *testing.T) {
 		t.Parallel()
 		ctrl := gomock.NewController(t)
 		mclock := defaultLayerClockMock(ctrl)
-		poetProver := NewMockPoetClient(ctrl)
+		poetProver := NewMockPoetService(ctrl)
 		poetProver.EXPECT().
 			Submit(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), sig.NodeID()).
 			Return(nil, errors.New("test"))
@@ -709,7 +709,7 @@ func TestNIPSTBuilder_PoetUnstable(t *testing.T) {
 			poetCfg,
 			mclock,
 			nil,
-			WithPoetClients(poetProver),
+			WithPoetServices(poetProver),
 		)
 		require.NoError(t, err)
 
@@ -722,7 +722,7 @@ func TestNIPSTBuilder_PoetUnstable(t *testing.T) {
 		t.Parallel()
 		ctrl := gomock.NewController(t)
 		mclock := defaultLayerClockMock(ctrl)
-		poetProver := NewMockPoetClient(ctrl)
+		poetProver := NewMockPoetService(ctrl)
 
 		poetProver.EXPECT().
 			Submit(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), sig.NodeID()).
@@ -746,7 +746,7 @@ func TestNIPSTBuilder_PoetUnstable(t *testing.T) {
 			poetCfg,
 			mclock,
 			nil,
-			WithPoetClients(poetProver),
+			WithPoetServices(poetProver),
 		)
 		require.NoError(t, err)
 
@@ -770,7 +770,7 @@ func TestNIPSTBuilder_PoetUnstable(t *testing.T) {
 			poetCfg,
 			mclock,
 			nil,
-			WithPoetClients(poetProver),
+			WithPoetServices(poetProver),
 		)
 		require.NoError(t, err)
 
@@ -796,7 +796,7 @@ func TestNIPSTBuilder_PoetUnstable(t *testing.T) {
 			poetCfg,
 			mclock,
 			nil,
-			WithPoetClients(poetProver),
+			WithPoetServices(poetProver),
 		)
 		require.NoError(t, err)
 
@@ -822,7 +822,7 @@ func TestNIPoSTBuilder_StaleChallenge(t *testing.T) {
 	t.Run("no requests, poet round started", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		mclock := NewMocklayerClock(ctrl)
-		poetProver := NewMockPoetClient(ctrl)
+		poetProver := NewMockPoetService(ctrl)
 		poetProver.EXPECT().Address().Return("http://localhost:9999")
 		mclock.EXPECT().LayerToTime(gomock.Any()).DoAndReturn(
 			func(got types.LayerID) time.Time {
@@ -838,7 +838,7 @@ func TestNIPoSTBuilder_StaleChallenge(t *testing.T) {
 			PoetConfig{},
 			mclock,
 			nil,
-			WithPoetClients(poetProver),
+			WithPoetServices(poetProver),
 		)
 		require.NoError(t, err)
 
@@ -851,7 +851,7 @@ func TestNIPoSTBuilder_StaleChallenge(t *testing.T) {
 	t.Run("no response before deadline", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		mclock := NewMocklayerClock(ctrl)
-		poetProver := NewMockPoetClient(ctrl)
+		poetProver := NewMockPoetService(ctrl)
 		poetProver.EXPECT().Address().Return("http://localhost:9999")
 		mclock.EXPECT().LayerToTime(gomock.Any()).DoAndReturn(
 			func(got types.LayerID) time.Time {
@@ -867,7 +867,7 @@ func TestNIPoSTBuilder_StaleChallenge(t *testing.T) {
 			PoetConfig{},
 			mclock,
 			nil,
-			WithPoetClients(poetProver),
+			WithPoetServices(poetProver),
 		)
 		require.NoError(t, err)
 
@@ -893,7 +893,7 @@ func TestNIPoSTBuilder_StaleChallenge(t *testing.T) {
 	t.Run("too late for proof generation", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		mclock := NewMocklayerClock(ctrl)
-		poetProver := NewMockPoetClient(ctrl)
+		poetProver := NewMockPoetService(ctrl)
 		poetProver.EXPECT().Address().Return("http://localhost:9999")
 		mclock.EXPECT().LayerToTime(gomock.Any()).DoAndReturn(
 			func(got types.LayerID) time.Time {
@@ -909,7 +909,7 @@ func TestNIPoSTBuilder_StaleChallenge(t *testing.T) {
 			PoetConfig{},
 			mclock,
 			nil,
-			WithPoetClients(poetProver),
+			WithPoetServices(poetProver),
 		)
 		require.NoError(t, err)
 
@@ -954,7 +954,7 @@ func TestNIPoSTBuilder_Continues_After_Interrupted(t *testing.T) {
 
 	buildCtx, cancel := context.WithCancel(context.Background())
 
-	poet := NewMockPoetClient(ctrl)
+	poet := NewMockPoetService(ctrl)
 	poet.EXPECT().
 		Submit(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		DoAndReturn(func(
@@ -989,7 +989,7 @@ func TestNIPoSTBuilder_Continues_After_Interrupted(t *testing.T) {
 		poetCfg,
 		mclock,
 		nil,
-		WithPoetClients(poet),
+		WithPoetServices(poet),
 	)
 	require.NoError(t, err)
 
@@ -1074,7 +1074,7 @@ func TestNIPostBuilder_Mainnet_Poet_Workaround(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			poets := make([]PoetService, 0, 2)
 			{
-				poetProvider := NewMockPoetClient(ctrl)
+				poetProvider := NewMockPoetService(ctrl)
 				poetProvider.EXPECT().Address().Return(tc.from)
 
 				// PoET succeeds to submit
@@ -1089,7 +1089,7 @@ func TestNIPostBuilder_Mainnet_Poet_Workaround(t *testing.T) {
 
 			{
 				// PoET fails submission
-				poetProvider := NewMockPoetClient(ctrl)
+				poetProvider := NewMockPoetService(ctrl)
 				poetProvider.EXPECT().Address().Return(tc.to)
 
 				// proof is still fetched from PoET
@@ -1125,7 +1125,7 @@ func TestNIPostBuilder_Mainnet_Poet_Workaround(t *testing.T) {
 				poetCfg,
 				mclock,
 				nil,
-				WithPoetClients(poets...),
+				WithPoetServices(poets...),
 			)
 			require.NoError(t, err)
 
@@ -1194,7 +1194,7 @@ func TestNIPostBuilder_Close(t *testing.T) {
 		PoetConfig{},
 		defaultLayerClockMock(ctrl),
 		nil,
-		WithPoetClients(poet),
+		WithPoetServices(poet),
 	)
 	require.NoError(t, err)
 
@@ -1231,7 +1231,7 @@ func TestNIPostBuilderProof_WithBadInitialPost(t *testing.T) {
 		PoetConfig{},
 		defaultLayerClockMock(ctrl),
 		validator,
-		WithPoetClients(poet),
+		WithPoetServices(poet),
 	)
 	require.NoError(t, err)
 

--- a/activation/poet.go
+++ b/activation/poet.go
@@ -360,13 +360,13 @@ func NewPoetService(
 	logger *zap.Logger,
 	opts ...PoetClientOpt,
 ) (*poetService, error) {
-	backend, err := NewHTTPPoetClient(server, cfg, WithLogger(logger))
+	client, err := NewHTTPPoetClient(server, cfg, WithLogger(logger))
 	if err != nil {
 		return nil, fmt.Errorf("creating HTTP poet client %s: %w", server.Address, err)
 	}
 	return NewPoetServiceWithClient(
 		db,
-		backend,
+		client,
 		cfg,
 		logger,
 		opts...,
@@ -375,7 +375,7 @@ func NewPoetService(
 
 func NewPoetServiceWithClient(
 	db poetDbAPI,
-	backend PoetClient,
+	client PoetClient,
 	cfg PoetConfig,
 	logger *zap.Logger,
 	opts ...PoetClientOpt,
@@ -383,7 +383,7 @@ func NewPoetServiceWithClient(
 	poetClient := &poetService{
 		db:             db,
 		logger:         logger,
-		client:         backend,
+		client:         client,
 		requestTimeout: cfg.RequestTimeout,
 		proofMembers:   make(map[string][]types.Hash32, 1),
 	}

--- a/activation/poet_client_test.go
+++ b/activation/poet_client_test.go
@@ -173,9 +173,9 @@ func TestPoetClient_CachesProof(t *testing.T) {
 	db.EXPECT().ValidateAndStore(ctx, gomock.Any())
 	db.EXPECT().ProofForRound(server.Pubkey.Bytes(), "1").Times(19)
 
-	backend, err := NewHTTPPoetClient(server, DefaultPoetConfig(), withCustomHttpClient(ts.Client()))
+	client, err := NewHTTPPoetClient(server, DefaultPoetConfig(), withCustomHttpClient(ts.Client()))
 	require.NoError(t, err)
-	poet := NewPoetServiceWithClient(db, backend, DefaultPoetConfig(), zaptest.NewLogger(t))
+	poet := NewPoetServiceWithClient(db, client, DefaultPoetConfig(), zaptest.NewLogger(t))
 
 	eg := errgroup.Group{}
 	for range 20 {
@@ -210,9 +210,9 @@ func TestPoetClient_QueryProofTimeout(t *testing.T) {
 	cfg := PoetConfig{
 		RequestTimeout: time.Millisecond * 100,
 	}
-	backend, err := NewHTTPPoetClient(server, cfg, withCustomHttpClient(ts.Client()))
+	client, err := NewHTTPPoetClient(server, cfg, withCustomHttpClient(ts.Client()))
 	require.NoError(t, err)
-	poet := NewPoetServiceWithClient(nil, backend, cfg, zaptest.NewLogger(t))
+	poet := NewPoetServiceWithClient(nil, client, cfg, zaptest.NewLogger(t))
 
 	start := time.Now()
 	eg := errgroup.Group{}
@@ -263,9 +263,9 @@ func TestPoetClient_Certify(t *testing.T) {
 		Certificate(gomock.Any(), sig.NodeID(), certifierAddress, certifierPubKey).
 		Return(&cert, nil)
 
-	backend, err := NewHTTPPoetClient(server, cfg, withCustomHttpClient(ts.Client()))
+	client, err := NewHTTPPoetClient(server, cfg, withCustomHttpClient(ts.Client()))
 	require.NoError(t, err)
-	poet := NewPoetServiceWithClient(nil, backend, cfg, zaptest.NewLogger(t), WithCertifier(mCertifier))
+	poet := NewPoetServiceWithClient(nil, client, cfg, zaptest.NewLogger(t), WithCertifier(mCertifier))
 
 	got, err := poet.Certify(context.Background(), sig.NodeID())
 	require.NoError(t, err)
@@ -313,9 +313,9 @@ func TestPoetClient_ObtainsCertOnSubmit(t *testing.T) {
 		Certificate(gomock.Any(), sig.NodeID(), certifierAddress, certifierPubKey).
 		Return(&cert, nil)
 
-	backend, err := NewHTTPPoetClient(server, cfg, withCustomHttpClient(ts.Client()))
+	client, err := NewHTTPPoetClient(server, cfg, withCustomHttpClient(ts.Client()))
 	require.NoError(t, err)
-	poet := NewPoetServiceWithClient(nil, backend, cfg, zaptest.NewLogger(t), WithCertifier(mCertifier))
+	poet := NewPoetServiceWithClient(nil, client, cfg, zaptest.NewLogger(t), WithCertifier(mCertifier))
 
 	_, err = poet.Submit(context.Background(), time.Time{}, nil, nil, types.RandomEdSignature(), sig.NodeID())
 	require.NoError(t, err)
@@ -379,9 +379,9 @@ func TestPoetClient_RecertifiesOnAuthFailure(t *testing.T) {
 			Return(&certifier.PoetCert{Data: []byte("second")}, nil),
 	)
 
-	backend, err := NewHTTPPoetClient(server, cfg, withCustomHttpClient(ts.Client()))
+	client, err := NewHTTPPoetClient(server, cfg, withCustomHttpClient(ts.Client()))
 	require.NoError(t, err)
-	poet := NewPoetServiceWithClient(nil, backend, cfg, zaptest.NewLogger(t), WithCertifier(mCertifier))
+	poet := NewPoetServiceWithClient(nil, client, cfg, zaptest.NewLogger(t), WithCertifier(mCertifier))
 
 	_, err = poet.Submit(context.Background(), time.Time{}, nil, nil, types.RandomEdSignature(), sig.NodeID())
 	require.NoError(t, err)

--- a/activation/poet_client_test.go
+++ b/activation/poet_client_test.go
@@ -173,9 +173,9 @@ func TestPoetClient_CachesProof(t *testing.T) {
 	db.EXPECT().ValidateAndStore(ctx, gomock.Any())
 	db.EXPECT().ProofForRound(server.Pubkey.Bytes(), "1").Times(19)
 
-	poet, err := NewPoetClient(db, server, DefaultPoetConfig(), zaptest.NewLogger(t))
+	backend, err := NewHTTPPoetClient(server, DefaultPoetConfig(), withCustomHttpClient(ts.Client()))
 	require.NoError(t, err)
-	poet.client.client.HTTPClient = ts.Client()
+	poet := NewPoetClientWithBackend(db, backend, DefaultPoetConfig(), zaptest.NewLogger(t))
 
 	eg := errgroup.Group{}
 	for range 20 {
@@ -210,9 +210,9 @@ func TestPoetClient_QueryProofTimeout(t *testing.T) {
 	cfg := PoetConfig{
 		RequestTimeout: time.Millisecond * 100,
 	}
-	poet, err := NewPoetClient(nil, server, cfg, zaptest.NewLogger(t))
+	backend, err := NewHTTPPoetClient(server, cfg, withCustomHttpClient(ts.Client()))
 	require.NoError(t, err)
-	poet.client.client.HTTPClient = ts.Client()
+	poet := NewPoetClientWithBackend(nil, backend, cfg, zaptest.NewLogger(t))
 
 	start := time.Now()
 	eg := errgroup.Group{}
@@ -263,9 +263,9 @@ func TestPoetClient_Certify(t *testing.T) {
 		Certificate(gomock.Any(), sig.NodeID(), certifierAddress, certifierPubKey).
 		Return(&cert, nil)
 
-	poet, err := NewPoetClient(nil, server, cfg, zaptest.NewLogger(t), WithCertifier(mCertifier))
+	backend, err := NewHTTPPoetClient(server, cfg, withCustomHttpClient(ts.Client()))
 	require.NoError(t, err)
-	poet.client.client.HTTPClient = ts.Client()
+	poet := NewPoetClientWithBackend(nil, backend, cfg, zaptest.NewLogger(t), WithCertifier(mCertifier))
 
 	got, err := poet.Certify(context.Background(), sig.NodeID())
 	require.NoError(t, err)
@@ -313,9 +313,9 @@ func TestPoetClient_ObtainsCertOnSubmit(t *testing.T) {
 		Certificate(gomock.Any(), sig.NodeID(), certifierAddress, certifierPubKey).
 		Return(&cert, nil)
 
-	poet, err := NewPoetClient(nil, server, cfg, zaptest.NewLogger(t), WithCertifier(mCertifier))
+	backend, err := NewHTTPPoetClient(server, cfg, withCustomHttpClient(ts.Client()))
 	require.NoError(t, err)
-	poet.client.client.HTTPClient = ts.Client()
+	poet := NewPoetClientWithBackend(nil, backend, cfg, zaptest.NewLogger(t), WithCertifier(mCertifier))
 
 	_, err = poet.Submit(context.Background(), time.Time{}, nil, nil, types.RandomEdSignature(), sig.NodeID())
 	require.NoError(t, err)
@@ -379,9 +379,9 @@ func TestPoetClient_RecertifiesOnAuthFailure(t *testing.T) {
 			Return(&certifier.PoetCert{Data: []byte("second")}, nil),
 	)
 
-	poet, err := NewPoetClient(nil, server, cfg, zaptest.NewLogger(t), WithCertifier(mCertifier))
+	backend, err := NewHTTPPoetClient(server, cfg, withCustomHttpClient(ts.Client()))
 	require.NoError(t, err)
-	poet.client.client.HTTPClient = ts.Client()
+	poet := NewPoetClientWithBackend(nil, backend, cfg, zaptest.NewLogger(t), WithCertifier(mCertifier))
 
 	_, err = poet.Submit(context.Background(), time.Time{}, nil, nil, types.RandomEdSignature(), sig.NodeID())
 	require.NoError(t, err)

--- a/activation/poet_client_test.go
+++ b/activation/poet_client_test.go
@@ -175,7 +175,7 @@ func TestPoetClient_CachesProof(t *testing.T) {
 
 	backend, err := NewHTTPPoetClient(server, DefaultPoetConfig(), withCustomHttpClient(ts.Client()))
 	require.NoError(t, err)
-	poet := NewPoetClientWithBackend(db, backend, DefaultPoetConfig(), zaptest.NewLogger(t))
+	poet := NewPoetServiceWithClient(db, backend, DefaultPoetConfig(), zaptest.NewLogger(t))
 
 	eg := errgroup.Group{}
 	for range 20 {
@@ -212,7 +212,7 @@ func TestPoetClient_QueryProofTimeout(t *testing.T) {
 	}
 	backend, err := NewHTTPPoetClient(server, cfg, withCustomHttpClient(ts.Client()))
 	require.NoError(t, err)
-	poet := NewPoetClientWithBackend(nil, backend, cfg, zaptest.NewLogger(t))
+	poet := NewPoetServiceWithClient(nil, backend, cfg, zaptest.NewLogger(t))
 
 	start := time.Now()
 	eg := errgroup.Group{}
@@ -265,7 +265,7 @@ func TestPoetClient_Certify(t *testing.T) {
 
 	backend, err := NewHTTPPoetClient(server, cfg, withCustomHttpClient(ts.Client()))
 	require.NoError(t, err)
-	poet := NewPoetClientWithBackend(nil, backend, cfg, zaptest.NewLogger(t), WithCertifier(mCertifier))
+	poet := NewPoetServiceWithClient(nil, backend, cfg, zaptest.NewLogger(t), WithCertifier(mCertifier))
 
 	got, err := poet.Certify(context.Background(), sig.NodeID())
 	require.NoError(t, err)
@@ -315,7 +315,7 @@ func TestPoetClient_ObtainsCertOnSubmit(t *testing.T) {
 
 	backend, err := NewHTTPPoetClient(server, cfg, withCustomHttpClient(ts.Client()))
 	require.NoError(t, err)
-	poet := NewPoetClientWithBackend(nil, backend, cfg, zaptest.NewLogger(t), WithCertifier(mCertifier))
+	poet := NewPoetServiceWithClient(nil, backend, cfg, zaptest.NewLogger(t), WithCertifier(mCertifier))
 
 	_, err = poet.Submit(context.Background(), time.Time{}, nil, nil, types.RandomEdSignature(), sig.NodeID())
 	require.NoError(t, err)
@@ -381,7 +381,7 @@ func TestPoetClient_RecertifiesOnAuthFailure(t *testing.T) {
 
 	backend, err := NewHTTPPoetClient(server, cfg, withCustomHttpClient(ts.Client()))
 	require.NoError(t, err)
-	poet := NewPoetClientWithBackend(nil, backend, cfg, zaptest.NewLogger(t), WithCertifier(mCertifier))
+	poet := NewPoetServiceWithClient(nil, backend, cfg, zaptest.NewLogger(t), WithCertifier(mCertifier))
 
 	_, err = poet.Submit(context.Background(), time.Time{}, nil, nil, types.RandomEdSignature(), sig.NodeID())
 	require.NoError(t, err)

--- a/node/node.go
+++ b/node/node.go
@@ -1010,9 +1010,9 @@ func (app *App) initServices(ctx context.Context) error {
 	)
 	certifier := activation.NewCertifier(app.localDB, nipostLogger, client)
 
-	poetClients := make([]activation.PoetClient, 0, len(app.Config.PoetServers))
+	poetClients := make([]activation.PoetService, 0, len(app.Config.PoetServers))
 	for _, server := range app.Config.PoetServers {
-		client, err := activation.NewPoetClient(
+		client, err := activation.NewPoetService(
 			poetDb,
 			server,
 			app.Config.POET,

--- a/node/node.go
+++ b/node/node.go
@@ -1033,7 +1033,7 @@ func (app *App) initServices(ctx context.Context) error {
 		app.clock,
 		app.validator,
 		activation.NipostbuilderWithPostStates(postStates),
-		activation.WithPoetClients(poetClients...),
+		activation.WithPoetServices(poetClients...),
 	)
 	if err != nil {
 		return fmt.Errorf("create nipost builder: %w", err)

--- a/systest/tests/distributed_post_verification_test.go
+++ b/systest/tests/distributed_post_verification_test.go
@@ -160,7 +160,7 @@ func TestPostMalfeasanceProof(t *testing.T) {
 	certClient := activation.NewCertifierClient(db, localDb, logger.Named("certifier"))
 	certifier := activation.NewCertifier(localDb, logger, certClient)
 	poetDb := activation.NewPoetDb(db, zap.NewNop())
-	poetClient, err := activation.NewPoetService(
+	poetService, err := activation.NewPoetService(
 		poetDb,
 		types.PoetServer{
 			Address: cluster.MakePoetGlobalEndpoint(ctx.Namespace, 0),
@@ -190,7 +190,7 @@ func TestPostMalfeasanceProof(t *testing.T) {
 		cfg.POET,
 		clock,
 		validator,
-		activation.WithPoetClients(poetClient),
+		activation.WithPoetServices(poetService),
 	)
 	require.NoError(t, err)
 

--- a/systest/tests/distributed_post_verification_test.go
+++ b/systest/tests/distributed_post_verification_test.go
@@ -160,7 +160,7 @@ func TestPostMalfeasanceProof(t *testing.T) {
 	certClient := activation.NewCertifierClient(db, localDb, logger.Named("certifier"))
 	certifier := activation.NewCertifier(localDb, logger, certClient)
 	poetDb := activation.NewPoetDb(db, zap.NewNop())
-	poetClient, err := activation.NewPoetClient(
+	poetClient, err := activation.NewPoetService(
 		poetDb,
 		types.PoetServer{
 			Address: cluster.MakePoetGlobalEndpoint(ctx.Namespace, 0),


### PR DESCRIPTION
## Motivation

The E2E tests are quite long and resource-hungry because they run a real PoET service. A poet proof needs at least 150 leaves to be valid and tests become flaky on slower runners when epoch is too short - hence the tests were configured to run even 30s epochs.

## Description

- added a test poet service that produces a minimal valid poet proof instantly
- shortened epochs in E2E tests

Tests now take around 1m30s instead of 4-5 min before and the gain will only become bigger and bigger as we add more E2E tests.

## Test Plan

Existing tests pass

## TODO

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [ ] Update documentation as needed
- [ ] Update [changelog](../CHANGELOG.md) as needed
