### PR TITLE
[Merged by Bors] - E2E test for publishing ATX after a checkpoint

### DIFF
--- a/activation/activation.go
+++ b/activation/activation.go
@@ -334,7 +334,7 @@ func (b *Builder) SmesherIDs() []types.NodeID {
 	return maps.Keys(b.signers)
 }
 
-func (b *Builder) buildInitialPost(ctx context.Context, nodeID types.NodeID) error {
+func (b *Builder) BuildInitialPost(ctx context.Context, nodeID types.NodeID) error {
 	// Generate the initial POST if we don't have an ATX...
 	if _, err := atxs.GetLastIDByNodeID(b.db, nodeID); err == nil {
 		return nil
@@ -391,7 +391,7 @@ func (b *Builder) buildInitialPost(ctx context.Context, nodeID types.NodeID) err
 
 func (b *Builder) buildPost(ctx context.Context, nodeID types.NodeID) error {
 	for {
-		err := b.buildInitialPost(ctx, nodeID)
+		err := b.BuildInitialPost(ctx, nodeID)
 		if err == nil {
 			return nil
 		}

--- a/activation/activation_multi_test.go
+++ b/activation/activation_multi_test.go
@@ -258,10 +258,10 @@ func Test_Builder_Multi_InitialPost(t *testing.T) {
 				},
 				nil,
 			)
-			require.NoError(t, tab.buildInitialPost(context.Background(), sig.NodeID()))
+			require.NoError(t, tab.BuildInitialPost(context.Background(), sig.NodeID()))
 
 			// postClient.Proof() should not be called again
-			require.NoError(t, tab.buildInitialPost(context.Background(), sig.NodeID()))
+			require.NoError(t, tab.BuildInitialPost(context.Background(), sig.NodeID()))
 			return nil
 		})
 	}

--- a/activation/activation_test.go
+++ b/activation/activation_test.go
@@ -1173,9 +1173,9 @@ func TestBuilder_InitialProofGeneratedOnce(t *testing.T) {
 	tab.mValidator.EXPECT().
 		PostV2(gomock.Any(), sig.NodeID(), post.CommitmentATX, initialPost, shared.ZeroChallenge, post.NumUnits)
 
-	require.NoError(t, tab.buildInitialPost(context.Background(), sig.NodeID()))
+	require.NoError(t, tab.BuildInitialPost(context.Background(), sig.NodeID()))
 	// postClient.Proof() should not be called again
-	require.NoError(t, tab.buildInitialPost(context.Background(), sig.NodeID()))
+	require.NoError(t, tab.BuildInitialPost(context.Background(), sig.NodeID()))
 }
 
 func TestBuilder_InitialPostIsPersisted(t *testing.T) {
@@ -1205,10 +1205,10 @@ func TestBuilder_InitialPostIsPersisted(t *testing.T) {
 	tab.mValidator.EXPECT().
 		PostV2(gomock.Any(), sig.NodeID(), commitmentATX, initialPost, shared.ZeroChallenge, numUnits)
 
-	require.NoError(t, tab.buildInitialPost(context.Background(), sig.NodeID()))
+	require.NoError(t, tab.BuildInitialPost(context.Background(), sig.NodeID()))
 
 	// postClient.Proof() should not be called again
-	require.NoError(t, tab.buildInitialPost(context.Background(), sig.NodeID()))
+	require.NoError(t, tab.BuildInitialPost(context.Background(), sig.NodeID()))
 }
 
 func TestBuilder_InitialPostLogErrorMissingVRFNonce(t *testing.T) {
@@ -1235,7 +1235,7 @@ func TestBuilder_InitialPostLogErrorMissingVRFNonce(t *testing.T) {
 	)
 	tab.mValidator.EXPECT().
 		PostV2(gomock.Any(), sig.NodeID(), commitmentATX, initialPost, shared.ZeroChallenge, numUnits)
-	err := tab.buildInitialPost(context.Background(), sig.NodeID())
+	err := tab.BuildInitialPost(context.Background(), sig.NodeID())
 	require.ErrorIs(t, err, errNilVrfNonce)
 
 	observedLogs := tab.observedLogs.FilterLevelExact(zapcore.ErrorLevel)
@@ -1258,7 +1258,7 @@ func TestBuilder_InitialPostLogErrorMissingVRFNonce(t *testing.T) {
 		},
 		nil,
 	)
-	require.NoError(t, tab.buildInitialPost(context.Background(), sig.NodeID()))
+	require.NoError(t, tab.BuildInitialPost(context.Background(), sig.NodeID()))
 }
 
 func TestWaitPositioningAtx(t *testing.T) {

--- a/activation/e2e/activation_test.go
+++ b/activation/e2e/activation_test.go
@@ -140,7 +140,6 @@ func Test_BuilderWithMultipleClients(t *testing.T) {
 		verifier,
 	)
 
-	postStates := activation.NewMockPostStates(ctrl)
 	nb, err := activation.NewNIPostBuilder(
 		localDB,
 		svc,
@@ -148,7 +147,6 @@ func Test_BuilderWithMultipleClients(t *testing.T) {
 		poetCfg,
 		clock,
 		validator,
-		activation.NipostbuilderWithPostStates(postStates),
 		activation.WithPoetServices(client),
 	)
 	require.NoError(t, err)
@@ -201,26 +199,9 @@ func Test_BuilderWithMultipleClients(t *testing.T) {
 		logger,
 		activation.WithPoetConfig(poetCfg),
 		activation.WithValidator(validator),
-		activation.WithPostStates(postStates),
 		activation.WithPoets(client),
 	)
 	for _, sig := range signers {
-		gomock.InOrder(
-			// it starts by setting to IDLE
-			postStates.EXPECT().Set(sig.NodeID(), types.PostStateIdle),
-			// initial proof
-			postStates.EXPECT().Set(sig.NodeID(), types.PostStateProving),
-			postStates.EXPECT().Set(sig.NodeID(), types.PostStateIdle),
-			// post proof - 1st epoch
-			postStates.EXPECT().Set(sig.NodeID(), types.PostStateProving),
-			postStates.EXPECT().Set(sig.NodeID(), types.PostStateIdle),
-			// 2nd epoch
-			postStates.EXPECT().Set(sig.NodeID(), types.PostStateProving),
-			postStates.EXPECT().Set(sig.NodeID(), types.PostStateIdle),
-			// 3rd epoch
-			postStates.EXPECT().Set(sig.NodeID(), types.PostStateProving),
-			postStates.EXPECT().Set(sig.NodeID(), types.PostStateIdle),
-		)
 		tab.Register(sig)
 	}
 

--- a/activation/e2e/activation_test.go
+++ b/activation/e2e/activation_test.go
@@ -60,7 +60,7 @@ func Test_BuilderWithMultipleClients(t *testing.T) {
 
 	logger := zaptest.NewLogger(t)
 	goldenATX := types.ATXID{2, 3, 4}
-	cfg := activation.DefaultPostConfig()
+	cfg := testPostConfig()
 	db := sql.InMemory()
 	localDB := localsql.InMemory()
 
@@ -71,7 +71,7 @@ func Test_BuilderWithMultipleClients(t *testing.T) {
 	var eg errgroup.Group
 	for i, sig := range signers {
 		opts := testPostSetupOpts(t)
-		opts.NumUnits = min(opts.NumUnits+2*uint32(i)*opts.NumUnits, cfg.MaxNumUnits)
+		opts.NumUnits = min(opts.NumUnits+2*uint32(i), cfg.MaxNumUnits)
 		eg.Go(func() error {
 			initPost(t, cfg, opts, sig, goldenATX, grpcCfg, svc)
 			return nil

--- a/activation/e2e/builds_atx_v2_test.go
+++ b/activation/e2e/builds_atx_v2_test.go
@@ -87,7 +87,6 @@ func TestBuilder_SwitchesToBuildV2(t *testing.T) {
 	client := ae2e.NewTestPoetClient(1)
 	poetClient := activation.NewPoetServiceWithClient(poetDb, client, poetCfg, logger)
 
-	postStates := activation.NewPostStates(logger)
 	localDB := localsql.InMemory()
 	nb, err := activation.NewNIPostBuilder(
 		localDB,
@@ -96,7 +95,6 @@ func TestBuilder_SwitchesToBuildV2(t *testing.T) {
 		poetCfg,
 		clock,
 		validator,
-		activation.NipostbuilderWithPostStates(postStates),
 		activation.WithPoetServices(poetClient),
 	)
 	require.NoError(t, err)
@@ -201,7 +199,6 @@ func TestBuilder_SwitchesToBuildV2(t *testing.T) {
 		logger,
 		activation.WithPoetConfig(poetCfg),
 		activation.WithValidator(validator),
-		activation.WithPostStates(postStates),
 		activation.BuilderAtxVersions(atxVersions),
 	)
 	tab.Register(sig)

--- a/activation/e2e/builds_atx_v2_test.go
+++ b/activation/e2e/builds_atx_v2_test.go
@@ -51,7 +51,7 @@ func TestBuilder_SwitchesToBuildV2(t *testing.T) {
 	sig, err := signing.NewEdSigner()
 	require.NoError(t, err)
 
-	cfg := activation.DefaultPostConfig()
+	cfg := testPostConfig()
 	db := sql.InMemory()
 	cdb := datastore.NewCachedDB(db, logger)
 

--- a/activation/e2e/certifier_client_test.go
+++ b/activation/e2e/certifier_client_test.go
@@ -20,6 +20,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/spacemeshos/go-spacemesh/activation"
+	"github.com/spacemeshos/go-spacemesh/api/grpcserver"
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/signing"
 	"github.com/spacemeshos/go-spacemesh/sql"
@@ -37,7 +38,12 @@ func TestCertification(t *testing.T) {
 	localDb := localsql.InMemory()
 
 	opts := testPostSetupOpts(t)
-	svc := initializeIDs(t, db, types.RandomATXID(), []*signing.EdSigner{sig}, cfg, opts)
+	svc := grpcserver.NewPostService(zaptest.NewLogger(t))
+	svc.AllowConnections(true)
+	grpcCfg, cleanup := launchServer(t, svc)
+	t.Cleanup(cleanup)
+
+	initPost(t, cfg, opts, sig, types.RandomATXID(), grpcCfg, svc)
 
 	validator := activation.NewMocknipostValidator(ctrl)
 	validator.EXPECT().

--- a/activation/e2e/certifier_client_test.go
+++ b/activation/e2e/certifier_client_test.go
@@ -33,7 +33,7 @@ func TestCertification(t *testing.T) {
 	sig, err := signing.NewEdSigner()
 	require.NoError(t, err)
 
-	cfg := activation.DefaultPostConfig()
+	cfg := testPostConfig()
 	db := sql.InMemory()
 	localDb := localsql.InMemory()
 

--- a/activation/e2e/checkpoint_test.go
+++ b/activation/e2e/checkpoint_test.go
@@ -151,7 +151,7 @@ func TestCheckpoint_PublishingSoloATXs(t *testing.T) {
 	require.NoError(t, tab.BuildInitialPost(ctx, sig.NodeID()))
 	require.NoError(t, tab.PublishActivationTx(ctx, sig))
 
-	// Execute checpoint-recovery
+	// Execute checkpoint-recovery
 	// 1. Generate checkpoint
 	require.NoError(t, accounts.Update(db, &types.Account{}))
 	snapshot := clock.CurrentLayer()

--- a/activation/e2e/checkpoint_test.go
+++ b/activation/e2e/checkpoint_test.go
@@ -183,6 +183,7 @@ func TestCheckpoint_PublishingSoloATXs(t *testing.T) {
 
 	newDB, err := sql.Open("file:" + recoveryCfg.DbPath())
 	require.NoError(t, err)
+	defer newDB.Close()
 
 	// 3. Spawn new ATX handler and builder using the new DB
 	poetDb = activation.NewPoetDb(newDB, logger.Named("poetDb"))

--- a/activation/e2e/checkpoint_test.go
+++ b/activation/e2e/checkpoint_test.go
@@ -45,7 +45,7 @@ func TestCheckpoint_PublishingSoloATXs(t *testing.T) {
 	sig, err := signing.NewEdSigner()
 	require.NoError(t, err)
 
-	cfg := activation.DefaultPostConfig()
+	cfg := testPostConfig()
 	db := sql.InMemory()
 	cdb := datastore.NewCachedDB(db, logger)
 

--- a/activation/e2e/checkpoint_test.go
+++ b/activation/e2e/checkpoint_test.go
@@ -1,0 +1,255 @@
+package activation_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/spacemeshos/go-spacemesh/activation"
+	ae2e "github.com/spacemeshos/go-spacemesh/activation/e2e"
+	"github.com/spacemeshos/go-spacemesh/activation/wire"
+	"github.com/spacemeshos/go-spacemesh/atxsdata"
+	"github.com/spacemeshos/go-spacemesh/checkpoint"
+	"github.com/spacemeshos/go-spacemesh/codec"
+	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/datastore"
+	"github.com/spacemeshos/go-spacemesh/p2p/pubsub"
+	"github.com/spacemeshos/go-spacemesh/p2p/pubsub/mocks"
+	"github.com/spacemeshos/go-spacemesh/signing"
+	"github.com/spacemeshos/go-spacemesh/sql"
+	"github.com/spacemeshos/go-spacemesh/sql/accounts"
+	"github.com/spacemeshos/go-spacemesh/sql/localsql"
+	smocks "github.com/spacemeshos/go-spacemesh/system/mocks"
+	"github.com/spacemeshos/go-spacemesh/timesync"
+)
+
+// Test activation process after a checkpoint-recovery scenario.
+//
+// The tests check if ATXs can be built and published after a checkpoint.
+
+func TestCheckpoint_PublishingSoloATXs(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	ctx := context.Background()
+	logger := zaptest.NewLogger(t)
+	goldenATX := types.ATXID{2, 3, 4}
+
+	sig, err := signing.NewEdSigner()
+	require.NoError(t, err)
+
+	cfg := activation.DefaultPostConfig()
+	db := sql.InMemory()
+	cdb := datastore.NewCachedDB(db, logger)
+
+	opts := testPostSetupOpts(t)
+	svc := initializeIDs(t, db, goldenATX, []*signing.EdSigner{sig}, cfg, opts)
+	syncer := syncedSyncer(ctrl)
+
+	poetDb := activation.NewPoetDb(db, logger.Named("poetDb"))
+	verifier, err := activation.NewPostVerifier(cfg, logger.Named("verifier"))
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, verifier.Close()) })
+
+	validator := activation.NewValidator(db, poetDb, cfg, opts.Scrypt, verifier)
+
+	epoch := layerDuration * time.Duration(layersPerEpoch)
+	poetCfg := activation.PoetConfig{
+		PhaseShift:  epoch,
+		CycleGap:    3 * epoch / 4,
+		GracePeriod: epoch / 4,
+	}
+	client := ae2e.NewTestPoetClient(1)
+	poetService := activation.NewPoetServiceWithClient(poetDb, client, poetCfg, logger)
+
+	// ensure that genesis aligns with layer timings
+	genesis := time.Now().Add(layerDuration).Round(layerDuration)
+	clock, err := timesync.NewClock(
+		timesync.WithGenesisTime(genesis),
+		timesync.WithLayerDuration(layerDuration),
+		timesync.WithTickInterval(100*time.Millisecond),
+		timesync.WithLogger(zap.NewNop()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(clock.Close)
+
+	localDB := localsql.InMemory()
+	nb, err := activation.NewNIPostBuilder(
+		localDB,
+		svc,
+		logger.Named("nipostBuilder"),
+		poetCfg,
+		clock,
+		validator,
+		activation.WithPoetServices(poetService),
+	)
+	require.NoError(t, err)
+
+	atxdata := atxsdata.New()
+	atxVersions := activation.AtxVersions{0: types.AtxV2}
+	edVerifier := signing.NewEdVerifier()
+	mpub := mocks.NewMockPublisher(ctrl)
+	mFetch := smocks.NewMockFetcher(ctrl)
+	mBeacon := activation.NewMockAtxReceiver(ctrl)
+	mTortoise := smocks.NewMockTortoise(ctrl)
+
+	atxHdlr := activation.NewHandler(
+		"local",
+		cdb,
+		atxdata,
+		edVerifier,
+		clock,
+		mpub,
+		mFetch,
+		goldenATX,
+		validator,
+		mBeacon,
+		mTortoise,
+		logger,
+		activation.WithAtxVersions(atxVersions),
+	)
+
+	tab := activation.NewBuilder(
+		activation.Config{GoldenATXID: goldenATX},
+		db,
+		atxdata,
+		localDB,
+		mpub,
+		nb,
+		clock,
+		syncer,
+		logger,
+		activation.WithPoetConfig(poetCfg),
+		activation.WithValidator(validator),
+		activation.BuilderAtxVersions(atxVersions),
+	)
+	tab.Register(sig)
+
+	var atx0ID types.ATXID
+	mpub.EXPECT().Publish(gomock.Any(), pubsub.AtxProtocol, gomock.Any()).DoAndReturn(
+		func(ctx context.Context, p string, msg []byte) error {
+			var watx wire.ActivationTxV2
+			codec.MustDecode(msg, &watx)
+			atx0ID = watx.ID()
+			peer := peer.ID(p)
+			mFetch.EXPECT().RegisterPeerHashes(peer, gomock.Any())
+			mFetch.EXPECT().GetPoetProof(gomock.Any(), gomock.Any())
+			mBeacon.EXPECT().OnAtx(gomock.Any())
+			mTortoise.EXPECT().OnAtx(gomock.Any(), gomock.Any(), gomock.Any())
+			err := atxHdlr.HandleGossipAtx(ctx, peer, msg)
+			require.NoError(t, err)
+			return err
+		},
+	)
+
+	require.NoError(t, tab.BuildInitialPost(ctx, sig.NodeID()))
+	require.NoError(t, tab.PublishActivationTx(ctx, sig))
+
+	// Execute checpoint-recovery
+	// 1. Generate checkpoint
+	require.NoError(t, accounts.Update(db, &types.Account{}))
+	snapshot := clock.CurrentLayer()
+	fs := afero.NewMemMapFs()
+	dir, err := afero.TempDir(fs, "", "Generate")
+	require.NoError(t, err)
+	err = checkpoint.Generate(ctx, fs, db, dir, snapshot, 1)
+	require.NoError(t, err)
+
+	// 2. Recover from checkpoint
+	recoveryCfg := checkpoint.RecoverConfig{
+		GoldenAtx: goldenATX,
+		DataDir:   t.TempDir(),
+		NodeIDs:   []types.NodeID{sig.NodeID()},
+		Restore:   snapshot,
+	}
+	filename := checkpoint.SelfCheckpointFilename(dir, snapshot)
+
+	var newDB *sql.Database
+	createDb := func() (*sql.Database, error) {
+		newDB = sql.InMemory()
+		return newDB, nil
+	}
+
+	data, err := checkpoint.RecoverFromLocalFile(ctx, logger, db, localDB, fs, &recoveryCfg, filename, createDb)
+	require.NoError(t, err)
+	require.NotNil(t, newDB)
+	require.Nil(t, data)
+
+	// 3. Spawn new ATX handler and builder using the new DB
+	poetDb = activation.NewPoetDb(newDB, logger.Named("poetDb"))
+	cdb = datastore.NewCachedDB(newDB, logger)
+	atxdata, err = atxsdata.Warm(newDB, 1)
+	poetService = activation.NewPoetServiceWithClient(poetDb, client, poetCfg, logger)
+	validator = activation.NewValidator(newDB, poetDb, cfg, opts.Scrypt, verifier)
+	require.NoError(t, err)
+	atxHdlr = activation.NewHandler(
+		"local",
+		cdb,
+		atxdata,
+		edVerifier,
+		clock,
+		mpub,
+		mFetch,
+		goldenATX,
+		validator,
+		mBeacon,
+		mTortoise,
+		logger,
+		activation.WithAtxVersions(atxVersions),
+	)
+
+	nb, err = activation.NewNIPostBuilder(
+		localDB,
+		svc,
+		logger.Named("nipostBuilder"),
+		poetCfg,
+		clock,
+		validator,
+		activation.WithPoetServices(poetService),
+	)
+	require.NoError(t, err)
+
+	tab = activation.NewBuilder(
+		activation.Config{GoldenATXID: goldenATX},
+		newDB,
+		atxdata,
+		localDB,
+		mpub,
+		nb,
+		clock,
+		syncer,
+		logger,
+		activation.WithPoetConfig(poetCfg),
+		activation.WithValidator(validator),
+		activation.BuilderAtxVersions(atxVersions),
+	)
+	tab.Register(sig)
+
+	// Publish ATX after recovery
+	mpub.EXPECT().Publish(gomock.Any(), pubsub.AtxProtocol, gomock.Any()).DoAndReturn(
+		func(ctx context.Context, p string, msg []byte) error {
+			var watx wire.ActivationTxV2
+			codec.MustDecode(msg, &watx)
+			require.Nil(t, watx.Initial)
+			require.Len(t, watx.PreviousATXs, 1)
+			assert.Equal(t, atx0ID, watx.PreviousATXs[0])
+
+			peer := peer.ID(p)
+			mFetch.EXPECT().RegisterPeerHashes(peer, gomock.Any())
+			mFetch.EXPECT().GetPoetProof(gomock.Any(), gomock.Any())
+			mFetch.EXPECT().GetAtxs(gomock.Any(), gomock.Any(), gomock.Any())
+			mBeacon.EXPECT().OnAtx(gomock.Any())
+			mTortoise.EXPECT().OnAtx(gomock.Any(), gomock.Any(), gomock.Any())
+			err := atxHdlr.HandleGossipAtx(ctx, peer, msg)
+			require.NoError(t, err)
+			return err
+		},
+	)
+	require.NoError(t, tab.PublishActivationTx(ctx, sig))
+}

--- a/activation/e2e/validation_test.go
+++ b/activation/e2e/validation_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/spacemeshos/post/initialization"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -15,7 +14,6 @@ import (
 	"github.com/spacemeshos/go-spacemesh/activation"
 	ae2e "github.com/spacemeshos/go-spacemesh/activation/e2e"
 	"github.com/spacemeshos/go-spacemesh/api/grpcserver"
-	"github.com/spacemeshos/go-spacemesh/atxsdata"
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/signing"
 	"github.com/spacemeshos/go-spacemesh/sql"
@@ -34,21 +32,14 @@ func TestValidator_Validate(t *testing.T) {
 	db := sql.InMemory()
 
 	validator := activation.NewMocknipostValidator(gomock.NewController(t))
-	syncer := activation.NewMocksyncer(gomock.NewController(t))
-	syncer.EXPECT().RegisterForATXSynced().AnyTimes().DoAndReturn(func() <-chan struct{} {
-		synced := make(chan struct{})
-		close(synced)
-		return synced
-	})
 
-	mgr, err := activation.NewPostSetupManager(cfg, logger, db, atxsdata.New(), goldenATX, syncer, validator)
-	require.NoError(t, err)
+	opts := testPostSetupOpts(t)
+	svc := grpcserver.NewPostService(zaptest.NewLogger(t))
+	svc.AllowConnections(true)
+	grpcCfg, cleanup := launchServer(t, svc)
+	t.Cleanup(cleanup)
 
-	opts := activation.DefaultPostSetupOpts()
-	opts.DataDir = t.TempDir()
-	opts.ProviderID.SetUint32(initialization.CPUProviderID())
-	opts.Scrypt.N = 2 // Speedup initialization in tests.
-	initPost(t, mgr, opts, sig.NodeID())
+	initPost(t, cfg, opts, sig, goldenATX, grpcCfg, svc)
 
 	// ensure that genesis aligns with layer timings
 	genesis := time.Now().Add(layerDuration).Round(layerDuration)
@@ -73,17 +64,6 @@ func TestValidator_Validate(t *testing.T) {
 	verifier, err := activation.NewPostVerifier(cfg, logger.Named("verifier"))
 	require.NoError(t, err)
 	t.Cleanup(func() { assert.NoError(t, verifier.Close()) })
-	svc := grpcserver.NewPostService(logger)
-	svc.AllowConnections(true)
-	grpcCfg, cleanup := launchServer(t, svc)
-	t.Cleanup(cleanup)
-
-	t.Cleanup(launchPostSupervisor(t, logger, mgr, sig, grpcCfg, opts))
-
-	require.Eventually(t, func() bool {
-		_, err := svc.Client(sig.NodeID())
-		return err == nil
-	}, 10*time.Second, 100*time.Millisecond, "timed out waiting for connection")
 
 	challenge := types.RandomHash()
 	nb, err := activation.NewNIPostBuilder(

--- a/activation/e2e/validation_test.go
+++ b/activation/e2e/validation_test.go
@@ -28,7 +28,7 @@ func TestValidator_Validate(t *testing.T) {
 
 	logger := zaptest.NewLogger(t)
 	goldenATX := types.ATXID{2, 3, 4}
-	cfg := activation.DefaultPostConfig()
+	cfg := testPostConfig()
 	db := sql.InMemory()
 
 	validator := activation.NewMocknipostValidator(gomock.NewController(t))

--- a/checkpoint/recovery_test.go
+++ b/checkpoint/recovery_test.go
@@ -154,14 +154,13 @@ func TestRecover(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			fs := afero.NewMemMapFs()
 			cfg := &checkpoint.RecoverConfig{
-				GoldenAtx:      goldenAtx,
-				DataDir:        t.TempDir(),
-				DbFile:         "test.sql",
-				LocalDbFile:    "local.sql",
-				PreserveOwnAtx: true,
-				NodeIDs:        []types.NodeID{types.RandomNodeID()},
-				Uri:            tc.uri,
-				Restore:        types.LayerID(recoverLayer),
+				GoldenAtx:   goldenAtx,
+				DataDir:     t.TempDir(),
+				DbFile:      "test.sql",
+				LocalDbFile: "local.sql",
+				NodeIDs:     []types.NodeID{types.RandomNodeID()},
+				Uri:         tc.uri,
+				Restore:     types.LayerID(recoverLayer),
 			}
 			bsdir := filepath.Join(cfg.DataDir, bootstrap.DirName)
 			require.NoError(t, fs.MkdirAll(bsdir, 0o700))
@@ -203,13 +202,12 @@ func TestRecover_SameRecoveryInfo(t *testing.T) {
 
 	fs := afero.NewMemMapFs()
 	cfg := &checkpoint.RecoverConfig{
-		GoldenAtx:      goldenAtx,
-		DataDir:        t.TempDir(),
-		DbFile:         "test.sql",
-		PreserveOwnAtx: true,
-		NodeIDs:        []types.NodeID{types.RandomNodeID()},
-		Uri:            fmt.Sprintf("%s/snapshot-15", ts.URL),
-		Restore:        types.LayerID(recoverLayer),
+		GoldenAtx: goldenAtx,
+		DataDir:   t.TempDir(),
+		DbFile:    "test.sql",
+		NodeIDs:   []types.NodeID{types.RandomNodeID()},
+		Uri:       fmt.Sprintf("%s/snapshot-15", ts.URL),
+		Restore:   types.LayerID(recoverLayer),
 	}
 	bsdir := filepath.Join(cfg.DataDir, bootstrap.DirName)
 	require.NoError(t, fs.MkdirAll(bsdir, 0o700))
@@ -499,14 +497,13 @@ func TestRecover_OwnAtxNotInCheckpoint_Preserve(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := &checkpoint.RecoverConfig{
-		GoldenAtx:      goldenAtx,
-		DataDir:        t.TempDir(),
-		DbFile:         "test.sql",
-		LocalDbFile:    "local.sql",
-		PreserveOwnAtx: true,
-		NodeIDs:        []types.NodeID{sig1.NodeID(), sig2.NodeID(), sig3.NodeID(), sig4.NodeID()},
-		Uri:            fmt.Sprintf("%s/snapshot-15", ts.URL),
-		Restore:        types.LayerID(recoverLayer),
+		GoldenAtx:   goldenAtx,
+		DataDir:     t.TempDir(),
+		DbFile:      "test.sql",
+		LocalDbFile: "local.sql",
+		NodeIDs:     []types.NodeID{sig1.NodeID(), sig2.NodeID(), sig3.NodeID(), sig4.NodeID()},
+		Uri:         fmt.Sprintf("%s/snapshot-15", ts.URL),
+		Restore:     types.LayerID(recoverLayer),
 	}
 
 	oldDB, err := sql.Open("file:" + filepath.Join(cfg.DataDir, cfg.DbFile))
@@ -591,14 +588,13 @@ func TestRecover_OwnAtxNotInCheckpoint_Preserve_IncludePending(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := &checkpoint.RecoverConfig{
-		GoldenAtx:      goldenAtx,
-		DataDir:        t.TempDir(),
-		DbFile:         "test.sql",
-		LocalDbFile:    "local.sql",
-		PreserveOwnAtx: true,
-		NodeIDs:        []types.NodeID{sig1.NodeID(), sig2.NodeID(), sig3.NodeID()},
-		Uri:            fmt.Sprintf("%s/snapshot-15", ts.URL),
-		Restore:        types.LayerID(recoverLayer),
+		GoldenAtx:   goldenAtx,
+		DataDir:     t.TempDir(),
+		DbFile:      "test.sql",
+		LocalDbFile: "local.sql",
+		NodeIDs:     []types.NodeID{sig1.NodeID(), sig2.NodeID(), sig3.NodeID()},
+		Uri:         fmt.Sprintf("%s/snapshot-15", ts.URL),
+		Restore:     types.LayerID(recoverLayer),
 	}
 
 	oldDB, err := sql.Open("file:" + filepath.Join(cfg.DataDir, cfg.DbFile))
@@ -712,14 +708,13 @@ func TestRecover_OwnAtxNotInCheckpoint_Preserve_Still_Initializing(t *testing.T)
 	require.NoError(t, err)
 
 	cfg := &checkpoint.RecoverConfig{
-		GoldenAtx:      goldenAtx,
-		DataDir:        t.TempDir(),
-		DbFile:         "test.sql",
-		LocalDbFile:    "local.sql",
-		PreserveOwnAtx: true,
-		NodeIDs:        []types.NodeID{sig1.NodeID(), sig2.NodeID()},
-		Uri:            fmt.Sprintf("%s/snapshot-15", ts.URL),
-		Restore:        types.LayerID(recoverLayer),
+		GoldenAtx:   goldenAtx,
+		DataDir:     t.TempDir(),
+		DbFile:      "test.sql",
+		LocalDbFile: "local.sql",
+		NodeIDs:     []types.NodeID{sig1.NodeID(), sig2.NodeID()},
+		Uri:         fmt.Sprintf("%s/snapshot-15", ts.URL),
+		Restore:     types.LayerID(recoverLayer),
 	}
 
 	oldDB, err := sql.Open("file:" + filepath.Join(cfg.DataDir, cfg.DbFile))
@@ -809,14 +804,13 @@ func TestRecover_OwnAtxNotInCheckpoint_Preserve_DepIsGolden(t *testing.T) {
 	sig, err := signing.NewEdSigner()
 	require.NoError(t, err)
 	cfg := &checkpoint.RecoverConfig{
-		GoldenAtx:      goldenAtx,
-		DataDir:        t.TempDir(),
-		DbFile:         "test.sql",
-		LocalDbFile:    "local.sql",
-		PreserveOwnAtx: true,
-		NodeIDs:        []types.NodeID{sig.NodeID()},
-		Uri:            fmt.Sprintf("%s/snapshot-15", ts.URL),
-		Restore:        types.LayerID(recoverLayer),
+		GoldenAtx:   goldenAtx,
+		DataDir:     t.TempDir(),
+		DbFile:      "test.sql",
+		LocalDbFile: "local.sql",
+		NodeIDs:     []types.NodeID{sig.NodeID()},
+		Uri:         fmt.Sprintf("%s/snapshot-15", ts.URL),
+		Restore:     types.LayerID(recoverLayer),
 	}
 
 	oldDB, err := sql.Open("file:" + filepath.Join(cfg.DataDir, cfg.DbFile))
@@ -892,14 +886,13 @@ func TestRecover_OwnAtxNotInCheckpoint_DontPreserve(t *testing.T) {
 	sig, err := signing.NewEdSigner()
 	require.NoError(t, err)
 	cfg := &checkpoint.RecoverConfig{
-		GoldenAtx:      goldenAtx,
-		DataDir:        t.TempDir(),
-		DbFile:         "test.sql",
-		LocalDbFile:    "local.sql",
-		PreserveOwnAtx: false,
-		NodeIDs:        []types.NodeID{sig.NodeID()},
-		Uri:            fmt.Sprintf("%s/snapshot-15", ts.URL),
-		Restore:        types.LayerID(recoverLayer),
+		GoldenAtx:   goldenAtx,
+		DataDir:     t.TempDir(),
+		DbFile:      "test.sql",
+		LocalDbFile: "local.sql",
+		NodeIDs:     []types.NodeID{sig.NodeID()},
+		Uri:         fmt.Sprintf("%s/snapshot-15", ts.URL),
+		Restore:     types.LayerID(recoverLayer),
 	}
 
 	oldDB, err := sql.Open("file:" + filepath.Join(cfg.DataDir, cfg.DbFile))
@@ -962,14 +955,13 @@ func TestRecover_OwnAtxInCheckpoint(t *testing.T) {
 	atx := newAtx(types.ATXID(atxid), types.EmptyATXID, nil, 3, 1, 0, nid)
 
 	cfg := &checkpoint.RecoverConfig{
-		GoldenAtx:      goldenAtx,
-		DataDir:        t.TempDir(),
-		DbFile:         "test.sql",
-		LocalDbFile:    "local.sql",
-		PreserveOwnAtx: true,
-		NodeIDs:        []types.NodeID{types.BytesToNodeID(nid)},
-		Uri:            fmt.Sprintf("%s/snapshot-15", ts.URL),
-		Restore:        types.LayerID(recoverLayer),
+		GoldenAtx:   goldenAtx,
+		DataDir:     t.TempDir(),
+		DbFile:      "test.sql",
+		LocalDbFile: "local.sql",
+		NodeIDs:     []types.NodeID{types.BytesToNodeID(nid)},
+		Uri:         fmt.Sprintf("%s/snapshot-15", ts.URL),
+		Restore:     types.LayerID(recoverLayer),
 	}
 
 	oldDB, err := sql.Open("file:" + filepath.Join(cfg.DataDir, cfg.DbFile))

--- a/node/node.go
+++ b/node/node.go
@@ -430,8 +430,8 @@ type App struct {
 func (app *App) loadCheckpoint(ctx context.Context) (*checkpoint.PreservedData, error) {
 	var nodeIDs []types.NodeID
 	if app.Config.Recovery.PreserveOwnAtx {
-		for i, sig := range app.signers {
-			nodeIDs[i] = sig.NodeID()
+		for _, sig := range app.signers {
+			nodeIDs = append(nodeIDs, sig.NodeID())
 		}
 	}
 	cfg := &checkpoint.RecoverConfig{

--- a/node/node.go
+++ b/node/node.go
@@ -428,19 +428,20 @@ type App struct {
 }
 
 func (app *App) loadCheckpoint(ctx context.Context) (*checkpoint.PreservedData, error) {
-	nodeIDs := make([]types.NodeID, len(app.signers))
-	for i, sig := range app.signers {
-		nodeIDs[i] = sig.NodeID()
+	var nodeIDs []types.NodeID
+	if app.Config.Recovery.PreserveOwnAtx {
+		for i, sig := range app.signers {
+			nodeIDs[i] = sig.NodeID()
+		}
 	}
 	cfg := &checkpoint.RecoverConfig{
-		GoldenAtx:      types.ATXID(app.Config.Genesis.GoldenATX()),
-		DataDir:        app.Config.DataDir(),
-		DbFile:         dbFile,
-		LocalDbFile:    localDbFile,
-		PreserveOwnAtx: app.Config.Recovery.PreserveOwnAtx,
-		NodeIDs:        nodeIDs,
-		Uri:            app.Config.Recovery.Uri,
-		Restore:        types.LayerID(app.Config.Recovery.Restore),
+		GoldenAtx:   types.ATXID(app.Config.Genesis.GoldenATX()),
+		DataDir:     app.Config.DataDir(),
+		DbFile:      dbFile,
+		LocalDbFile: localDbFile,
+		NodeIDs:     nodeIDs,
+		Uri:         app.Config.Recovery.Uri,
+		Restore:     types.LayerID(app.Config.Recovery.Restore),
 	}
 
 	return checkpoint.Recover(ctx, app.log.Zap(), afero.NewOsFs(), cfg)


### PR DESCRIPTION
## Motivation

Currently, this scenario is indirectly covered only by a long systest. The E2E is quicker (13s) and easier to understand and debug.

## Description

Added an E2E test that:
- publishes an initial ATX
- executes checkpoint-restore (persisting 1 epoch)
- publishes a second ATX


:bulb: I had to slightly modify the checkpoint code to be executable in tests, with in-memory DB. The checkpoint code could be refactored to be more generic, not to assume downloading the checkpoint data from an HTTP service, to avoid writing a snapshot to the disk, etc. 

:bulb: I removed the redundant `PreserveOwnAtx` field from the `RecoveryConfig`. It now preserves dependencies of all IDs passed in the `NodeIDs` slice.

:broom: Factored out code to initialize an identity (initialize data, spawn post-service etc.) to reduce boilerplate in the e2e tests.

## Test Plan

The new and existing tests pass

## TODO

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [ ] Update documentation as needed
- [ ] Update [changelog](../CHANGELOG.md) as needed
