### PR TITLE
Fix macOS linker warnings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/spacemeshos/go-scale v1.2.1
 	github.com/spacemeshos/merkle-tree v0.2.4
 	github.com/spacemeshos/poet v0.10.4
-	github.com/spacemeshos/post v0.12.9
+	github.com/spacemeshos/post v0.12.10-0.20241009082033-3650f54606a2
 	github.com/spf13/afero v1.11.0
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -641,8 +641,8 @@ github.com/spacemeshos/merkle-tree v0.2.4 h1:kA7uRGadeyULOFlBxsWRwN0v1U2B4PD4Olu
 github.com/spacemeshos/merkle-tree v0.2.4/go.mod h1:yTJd262m3pjnw8mH0j5vt3w0J+2mpM6g0xyc5Pr2zIw=
 github.com/spacemeshos/poet v0.10.4 h1:MHGG1dhMVwy5DdlsmwdRLDQTTqlPA21lSQB2PVd8MSk=
 github.com/spacemeshos/poet v0.10.4/go.mod h1:hz21GMyHb9h29CqNhVeKxCD5dxZdQK27nAqLpT46gjE=
-github.com/spacemeshos/post v0.12.9 h1:P1jTClND3LktNMmfJFtqPN85xKY0vTESb69Z55oPjt0=
-github.com/spacemeshos/post v0.12.9/go.mod h1:1RJq+6Batnv2xfH84fKJmXtOJfT+/FcL/Iwoprqep2M=
+github.com/spacemeshos/post v0.12.10-0.20241009082033-3650f54606a2 h1:ucxREIbJG0rNl63dIVRSXLMfz/Dr5fbC7Jn2jUzcbBk=
+github.com/spacemeshos/post v0.12.10-0.20241009082033-3650f54606a2/go.mod h1:1RJq+6Batnv2xfH84fKJmXtOJfT+/FcL/Iwoprqep2M=
 github.com/spacemeshos/sha256-simd v0.1.0 h1:G7Mfu5RYdQiuE+wu4ZyJ7I0TI74uqLhFnKblEnSpjYI=
 github.com/spacemeshos/sha256-simd v0.1.0/go.mod h1:O8CClVIilId7RtuCMV2+YzMj6qjVn75JsxOxaE8vcfM=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=


### PR DESCRIPTION
## Motivation

This should fix linker warnings we keep seeing on macOS.

Merge after https://github.com/spacemeshos/post/pull/297

## Description

Update post library and remove duplicate `LDFLAGS` definition in `Makefile`.

## Test Plan

- existing tests pass.

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
