### PR TITLE
[Merged by Bors] - Fix flaky TestQueued

### DIFF
--- a/p2p/server/server.go
+++ b/p2p/server/server.go
@@ -160,7 +160,7 @@ type Server struct {
 	limit   *rate.Limiter
 	sem     *semaphore.Weighted
 	queue   chan request
-	started chan struct{}
+	stopped chan struct{}
 
 	metrics *tracker // metrics can be nil
 
@@ -182,7 +182,7 @@ func New(h Host, proto string, handler StreamHandler, opts ...Opt) *Server {
 		interval:            time.Second,
 
 		queue:   make(chan request),
-		started: make(chan struct{}),
+		stopped: make(chan struct{}),
 	}
 	for _, opt := range opts {
 		opt(srv)
@@ -209,6 +209,22 @@ func New(h Host, proto string, handler StreamHandler, opts ...Opt) *Server {
 		srv.requestsPerInterval,
 	)
 	srv.sem = semaphore.NewWeighted(int64(srv.queueSize))
+	srv.h.SetStreamHandler(protocol.ID(srv.protocol), func(stream network.Stream) {
+		if !srv.sem.TryAcquire(1) {
+			if srv.metrics != nil {
+				srv.metrics.dropped.Inc()
+			}
+			stream.Close()
+			return
+		}
+		select {
+		case <-srv.stopped:
+			srv.sem.Release(1)
+			stream.Close()
+		case srv.queue <- request{stream: stream, received: time.Now()}:
+			// at most s.queueSize requests block here, the others are dropped with the semaphore
+		}
+	})
 	if srv.metrics != nil {
 		srv.metrics.targetQueue.Set(float64(srv.queueSize))
 		srv.metrics.targetRps.Set(float64(srv.limit.Limit()))
@@ -221,31 +237,12 @@ type request struct {
 	received time.Time
 }
 
-func (s *Server) Ready() <-chan struct{} {
-	return s.started
-}
-
 func (s *Server) Run(ctx context.Context) error {
-	s.h.SetStreamHandler(protocol.ID(s.protocol), func(stream network.Stream) {
-		if !s.sem.TryAcquire(1) {
-			if s.metrics != nil {
-				s.metrics.dropped.Inc()
-			}
-			stream.Close()
-			return
-		}
-		select {
-		case <-ctx.Done():
-		case s.queue <- request{stream: stream, received: time.Now()}:
-			// at most s.queueSize requests block here, the others are dropped with the semaphore
-		}
-	})
-	close(s.started)
-
 	var eg errgroup.Group
 	for {
 		select {
 		case <-ctx.Done():
+			close(s.stopped)
 			eg.Wait()
 			return nil
 		case req := <-s.queue:

--- a/p2p/server/server_test.go
+++ b/p2p/server/server_test.go
@@ -188,7 +188,7 @@ func Test_Queued(t *testing.T) {
 	srv := New(
 		wrapHost(t, mesh.Hosts()[1]),
 		proto,
-		WrapHandler(func(ctx context.Context, msg []byte) ([]byte, error) {
+		WrapHandler(func(_ context.Context, msg []byte) ([]byte, error) {
 			wg.Done()
 			<-stop
 			return msg, nil

--- a/p2p/server/server_test.go
+++ b/p2p/server/server_test.go
@@ -203,7 +203,6 @@ func Test_Queued(t *testing.T) {
 	eg.Go(func() error {
 		return srv.Run(ctx)
 	})
-	<-srv.Ready()
 	t.Cleanup(func() {
 		assert.NoError(t, eg.Wait())
 	})
@@ -254,7 +253,6 @@ func Test_RequestInterval(t *testing.T) {
 	eg.Go(func() error {
 		return srv.Run(ctx)
 	})
-	<-srv.Ready()
 	t.Cleanup(func() {
 		assert.NoError(t, eg.Wait())
 	})

--- a/p2p/server/server_test.go
+++ b/p2p/server/server_test.go
@@ -203,6 +203,7 @@ func Test_Queued(t *testing.T) {
 	eg.Go(func() error {
 		return srv.Run(ctx)
 	})
+	<-srv.Ready()
 	t.Cleanup(func() {
 		assert.NoError(t, eg.Wait())
 	})
@@ -253,6 +254,7 @@ func Test_RequestInterval(t *testing.T) {
 	eg.Go(func() error {
 		return srv.Run(ctx)
 	})
+	<-srv.Ready()
 	t.Cleanup(func() {
 		assert.NoError(t, eg.Wait())
 	})


### PR DESCRIPTION
## Motivation

This should once and for all fix the flaky `TestQueued` test that keeps preventing merges of PRs. 🙂 

## Description

I fixed various issues with races in the test that caused it to be so unstable:

- split test into two:
  - `Test_Queued` to check if too many requests are in flight at the same time new requests are not accepted (same goal as original test)
  - `Test_RequestInterval` that checks if requests are correctly rate limited
- Moved initialization code for `server.Server` in its `Run` method to the `New` function instead, this prevents the issue that clients within a test might make a request before the server is even ready to accept that request.
- instead of a buffered channel representing a queue I now use an unbuffered channel and a semaphore.
  - Before incoming requests would fill up the queue channel and simultaneously the worker routine would drain that channel again. This leads to an off by one error in terms of how many items can be in the queue at the same time.
  - The reason it even blocked on the receiver side of the queue when it full was because the underlying `errgroup.Group` had a limit set. With a semaphore this becomes more straight forward and easier to understand. It also fixes the off by one error.
  - Shutdown now also cleans up properly. Before requests in the queue channel were not handled when the server was shut down, now on the sender side of the chan those requests are handled on shutdown
- Within the test I changed the code in such a way that the first 10 requests that fill the queue block and then assert that every additional request fails (as expected). The successful requests only unblock after the assertion for the failing ones complete, removing another potential issue where depending on the test runners speed more requests could fail than expected. Now the test should pass independently of the runners speed with the exact number of expected successful and failing requests.
- With the smaller queue size the test now runs much faster than before (~ 10 ms on my machine) which makes verifying that it is now stable with `go test -failfast -count=2000 -run ^Test_Queued$ github.com/spacemeshos/go-spacemesh/p2p/server` much easier 🙂 

## Test Plan

- tests are now stable

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
