### PR TITLE
[backport] reduce hare commitee to 50 (#5793)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 See [RELEASE](./RELEASE.md) for workflow instructions.
 
+## Release v1.6.2
+
+### Improvements
+
+* [#5793](https://github.com/spacemeshos/go-spacemesh/pull/5793) Reduced hare committee 8x from 400 to 50 to decrease
+  network traffic caused by Hare.
+
 ## Release v1.6.1
 
 ### Improvements

--- a/config/mainnet.go
+++ b/config/mainnet.go
@@ -65,6 +65,10 @@ func MainnetConfig() Config {
 	hare3conf.Committee = 400
 	hare3conf.Enable = true
 	hare3conf.EnableLayer = 35117
+	hare3conf.CommitteeUpgrade = &hare3.CommitteeUpgrade{
+		Layer: 105_720, // July 15, 2024, 10:00:00 AM UTC
+		Size:  50,
+	}
 	return Config{
 		BaseConfig: BaseConfig{
 			DataDirParent:         defaultDataDir,

--- a/hare3/hare_test.go
+++ b/hare3/hare_test.go
@@ -951,3 +951,27 @@ func TestHare_AddProposal(t *testing.T) {
 	require.True(t, hare.IsKnown(p.Layer, p.ID()))
 	require.ErrorIs(t, hare.OnProposal(p), store.ErrProposalExists)
 }
+
+func TestHareConfig_CommitteeUpgrade(t *testing.T) {
+	t.Parallel()
+	t.Run("no upgrade", func(t *testing.T) {
+		cfg := Config{
+			Committee: 400,
+		}
+		require.Equal(t, cfg.Committee, cfg.CommitteeFor(0))
+		require.Equal(t, cfg.Committee, cfg.CommitteeFor(100))
+	})
+	t.Run("upgrade", func(t *testing.T) {
+		cfg := Config{
+			Committee: 400,
+			CommitteeUpgrade: &CommitteeUpgrade{
+				Layer: 16,
+				Size:  50,
+			},
+		}
+		require.EqualValues(t, cfg.Committee, cfg.CommitteeFor(0))
+		require.EqualValues(t, cfg.Committee, cfg.CommitteeFor(15))
+		require.EqualValues(t, 50, cfg.CommitteeFor(16))
+		require.EqualValues(t, 50, cfg.CommitteeFor(100))
+	})
+}

--- a/hare3/legacy_oracle.go
+++ b/hare3/legacy_oracle.go
@@ -26,7 +26,7 @@ func (lg *legacyOracle) validate(msg *Message) grade {
 	if msg.Eligibility.Count == 0 {
 		return grade0
 	}
-	committee := int(lg.config.Committee)
+	committee := int(lg.config.CommitteeFor(msg.Layer))
 	if msg.Round == propose {
 		committee = int(lg.config.Leaders)
 	}
@@ -50,7 +50,7 @@ func (lg *legacyOracle) active(
 	ir IterRound,
 ) *types.HareEligibility {
 	vrf := eligibility.GenVRF(context.Background(), signer.VRFSigner(), beacon, layer, ir.Absolute())
-	committee := int(lg.config.Committee)
+	committee := int(lg.config.CommitteeFor(layer))
 	if ir.Round == propose {
 		committee = int(lg.config.Leaders)
 	}

--- a/systest/parameters/fastnet/smesher.json
+++ b/systest/parameters/fastnet/smesher.json
@@ -27,6 +27,12 @@
             }
         }
     },
+    "hare3": {
+        "committeeupgrade": {
+            "layer": 16,
+            "size": 15
+        }
+    },
     "smeshing": {
         "smeshing-verifying-opts": {
             "smeshing-opts-verifying-min-workers": 1000000


### PR DESCRIPTION
this will reduce total gossipsub traffix x8.
comitee upgrade is scheduled to be used from layer 105_720 (July 15, 2024, 10:00:00 AM UTC). 