### PR TITLE
[Merged by Bors] - improve e2e activation tests stability

### DIFF
--- a/activation/e2e/activation_test.go
+++ b/activation/e2e/activation_test.go
@@ -85,8 +85,8 @@ func Test_BuilderWithMultipleClients(t *testing.T) {
 	genesis := time.Now().Add(layerDuration).Round(layerDuration)
 	poetCfg := activation.PoetConfig{
 		PhaseShift:        epoch,
-		CycleGap:          epoch / 2,
-		GracePeriod:       epoch / 5,
+		CycleGap:          3 * epoch / 4,
+		GracePeriod:       epoch / 4,
 		RequestTimeout:    epoch / 5,
 		RequestRetryDelay: epoch / 50,
 		MaxRequestRetries: 10,

--- a/activation/e2e/atx_merge_test.go
+++ b/activation/e2e/atx_merge_test.go
@@ -196,7 +196,6 @@ var singerKeys = [2]string{
 }
 
 func Test_MarryAndMerge(t *testing.T) {
-	t.Parallel()
 	ctrl := gomock.NewController(t)
 	signers := signers(t, singerKeys[:])
 
@@ -242,8 +241,8 @@ func Test_MarryAndMerge(t *testing.T) {
 	epoch := layersPerEpoch * layerDuration
 	poetCfg := activation.PoetConfig{
 		PhaseShift:  epoch,
-		CycleGap:    epoch / 2,
-		GracePeriod: epoch / 5,
+		CycleGap:    3 * epoch / 4,
+		GracePeriod: epoch / 4,
 	}
 
 	client := ae2e.NewTestPoetClient(2)

--- a/activation/e2e/checkpoint_merged_test.go
+++ b/activation/e2e/checkpoint_merged_test.go
@@ -35,7 +35,6 @@ import (
 )
 
 func Test_CheckpointAfterMerge(t *testing.T) {
-	t.Parallel()
 	ctrl := gomock.NewController(t)
 	signers := signers(t, singerKeys[:])
 
@@ -78,8 +77,8 @@ func Test_CheckpointAfterMerge(t *testing.T) {
 	epoch := layersPerEpoch * layerDuration
 	poetCfg := activation.PoetConfig{
 		PhaseShift:  epoch,
-		CycleGap:    epoch / 2,
-		GracePeriod: epoch / 5,
+		CycleGap:    3 * epoch / 4,
+		GracePeriod: epoch / 4,
 	}
 
 	client := ae2e.NewTestPoetClient(2)

--- a/activation/e2e/nipost_test.go
+++ b/activation/e2e/nipost_test.go
@@ -77,8 +77,8 @@ func testPostConfig() activation.PostConfig {
 	cfg := activation.DefaultPostConfig()
 	// simplify PoST parameters for faster proving
 	cfg.K1 = 12
-	cfg.K2 = 10
-	cfg.K3 = 10
+	cfg.K2 = 8
+	cfg.K3 = 8
 	cfg.LabelsPerUnit = 64
 	return cfg
 }
@@ -173,8 +173,8 @@ func TestNIPostBuilderWithClients(t *testing.T) {
 	epoch := layersPerEpoch * layerDuration
 	poetCfg := activation.PoetConfig{
 		PhaseShift:  epoch / 2,
-		CycleGap:    epoch / 4,
-		GracePeriod: epoch / 5,
+		CycleGap:    3 * epoch / 4,
+		GracePeriod: epoch / 4,
 	}
 
 	mclock := activation.NewMocklayerClock(ctrl)
@@ -267,8 +267,8 @@ func Test_NIPostBuilderWithMultipleClients(t *testing.T) {
 	epoch := layersPerEpoch * layerDuration
 	poetCfg := activation.PoetConfig{
 		PhaseShift:  epoch / 2,
-		CycleGap:    epoch / 4,
-		GracePeriod: epoch / 5,
+		CycleGap:    3 * epoch / 4,
+		GracePeriod: epoch / 4,
 	}
 
 	poetDb := activation.NewPoetDb(db, logger.Named("poetDb"))

--- a/activation/e2e/validation_test.go
+++ b/activation/e2e/validation_test.go
@@ -46,8 +46,8 @@ func TestValidator_Validate(t *testing.T) {
 	epoch := layersPerEpoch * layerDuration
 	poetCfg := activation.PoetConfig{
 		PhaseShift:  epoch / 2,
-		CycleGap:    epoch / 4,
-		GracePeriod: epoch / 5,
+		CycleGap:    3 * epoch / 4,
+		GracePeriod: epoch / 4,
 	}
 
 	poetDb := activation.NewPoetDb(sql.InMemory(), logger.Named("poetDb"))


### PR DESCRIPTION
## Motivation

The e2e tests became flaky. In failed tests, the nipost builder fails to submit in poets on time because PoST proving took longer than the cycle gap.

## Description

- extended cycle gap to 3/4 epoch
- simplified PoST
- don't run e2e tests in parallel

## Test Plan

n/a

## TODO

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [ ] Update documentation as needed
- [ ] Update [changelog](../CHANGELOG.md) as needed
