### PR TITLE
[Merged by Bors] - stabilize e2e tests - take 2

### DIFF
--- a/activation/e2e/activation_test.go
+++ b/activation/e2e/activation_test.go
@@ -64,8 +64,8 @@ func Test_BuilderWithMultipleClients(t *testing.T) {
 	db := sql.InMemory()
 	localDB := localsql.InMemory()
 
-	psOpts := grpcserver.PostServiceOpts{}
-	svc := grpcserver.NewPostService(logger, psOpts.AllowConnections(), psOpts.QueryInterval(100*time.Millisecond))
+	svc := grpcserver.NewPostService(logger, grpcserver.PostServiceQueryInterval(100*time.Millisecond))
+	svc.AllowConnections(true)
 
 	grpcCfg, cleanup := launchServer(t, svc)
 	t.Cleanup(cleanup)

--- a/activation/e2e/activation_test.go
+++ b/activation/e2e/activation_test.go
@@ -64,8 +64,9 @@ func Test_BuilderWithMultipleClients(t *testing.T) {
 	db := sql.InMemory()
 	localDB := localsql.InMemory()
 
-	svc := grpcserver.NewPostService(logger)
-	svc.AllowConnections(true)
+	psOpts := grpcserver.PostServiceOpts{}
+	svc := grpcserver.NewPostService(logger, psOpts.AllowConnections(), psOpts.QueryInterval(100*time.Millisecond))
+
 	grpcCfg, cleanup := launchServer(t, svc)
 	t.Cleanup(cleanup)
 	var eg errgroup.Group

--- a/activation/e2e/atx_merge_test.go
+++ b/activation/e2e/atx_merge_test.go
@@ -209,8 +209,9 @@ func Test_MarryAndMerge(t *testing.T) {
 	cdb := datastore.NewCachedDB(db, logger)
 	localDB := localsql.InMemory()
 
-	svc := grpcserver.NewPostService(logger)
-	svc.AllowConnections(true)
+	psOpts := grpcserver.PostServiceOpts{}
+	svc := grpcserver.NewPostService(logger, psOpts.AllowConnections(), psOpts.QueryInterval(100*time.Millisecond))
+
 	grpcCfg, cleanup := launchServer(t, svc)
 	t.Cleanup(cleanup)
 

--- a/activation/e2e/atx_merge_test.go
+++ b/activation/e2e/atx_merge_test.go
@@ -209,8 +209,8 @@ func Test_MarryAndMerge(t *testing.T) {
 	cdb := datastore.NewCachedDB(db, logger)
 	localDB := localsql.InMemory()
 
-	psOpts := grpcserver.PostServiceOpts{}
-	svc := grpcserver.NewPostService(logger, psOpts.AllowConnections(), psOpts.QueryInterval(100*time.Millisecond))
+	svc := grpcserver.NewPostService(logger, grpcserver.PostServiceQueryInterval(100*time.Millisecond))
+	svc.AllowConnections(true)
 
 	grpcCfg, cleanup := launchServer(t, svc)
 	t.Cleanup(cleanup)

--- a/activation/e2e/builds_atx_v2_test.go
+++ b/activation/e2e/builds_atx_v2_test.go
@@ -56,8 +56,8 @@ func TestBuilder_SwitchesToBuildV2(t *testing.T) {
 	cdb := datastore.NewCachedDB(db, logger)
 
 	opts := testPostSetupOpts(t)
-	psOpts := grpcserver.PostServiceOpts{}
-	svc := grpcserver.NewPostService(logger, psOpts.AllowConnections(), psOpts.QueryInterval(100*time.Millisecond))
+	svc := grpcserver.NewPostService(logger, grpcserver.PostServiceQueryInterval(100*time.Millisecond))
+	svc.AllowConnections(true)
 
 	grpcCfg, cleanup := launchServer(t, svc)
 	t.Cleanup(cleanup)

--- a/activation/e2e/builds_atx_v2_test.go
+++ b/activation/e2e/builds_atx_v2_test.go
@@ -56,8 +56,9 @@ func TestBuilder_SwitchesToBuildV2(t *testing.T) {
 	cdb := datastore.NewCachedDB(db, logger)
 
 	opts := testPostSetupOpts(t)
-	svc := grpcserver.NewPostService(logger)
-	svc.AllowConnections(true)
+	psOpts := grpcserver.PostServiceOpts{}
+	svc := grpcserver.NewPostService(logger, psOpts.AllowConnections(), psOpts.QueryInterval(100*time.Millisecond))
+
 	grpcCfg, cleanup := launchServer(t, svc)
 	t.Cleanup(cleanup)
 

--- a/activation/e2e/certifier_client_test.go
+++ b/activation/e2e/certifier_client_test.go
@@ -38,8 +38,10 @@ func TestCertification(t *testing.T) {
 	localDb := localsql.InMemory()
 
 	opts := testPostSetupOpts(t)
-	svc := grpcserver.NewPostService(zaptest.NewLogger(t))
-	svc.AllowConnections(true)
+	logger := zaptest.NewLogger(t)
+	psOpts := grpcserver.PostServiceOpts{}
+	svc := grpcserver.NewPostService(logger, psOpts.AllowConnections(), psOpts.QueryInterval(100*time.Millisecond))
+
 	grpcCfg, cleanup := launchServer(t, svc)
 	t.Cleanup(cleanup)
 

--- a/activation/e2e/certifier_client_test.go
+++ b/activation/e2e/certifier_client_test.go
@@ -39,8 +39,8 @@ func TestCertification(t *testing.T) {
 
 	opts := testPostSetupOpts(t)
 	logger := zaptest.NewLogger(t)
-	psOpts := grpcserver.PostServiceOpts{}
-	svc := grpcserver.NewPostService(logger, psOpts.AllowConnections(), psOpts.QueryInterval(100*time.Millisecond))
+	svc := grpcserver.NewPostService(logger, grpcserver.PostServiceQueryInterval(100*time.Millisecond))
+	svc.AllowConnections(true)
 
 	grpcCfg, cleanup := launchServer(t, svc)
 	t.Cleanup(cleanup)

--- a/activation/e2e/checkpoint_merged_test.go
+++ b/activation/e2e/checkpoint_merged_test.go
@@ -47,8 +47,8 @@ func Test_CheckpointAfterMerge(t *testing.T) {
 	cdb := datastore.NewCachedDB(db, logger)
 	localDB := localsql.InMemory()
 
-	psOpts := grpcserver.PostServiceOpts{}
-	svc := grpcserver.NewPostService(logger, psOpts.AllowConnections(), psOpts.QueryInterval(100*time.Millisecond))
+	svc := grpcserver.NewPostService(logger, grpcserver.PostServiceQueryInterval(100*time.Millisecond))
+	svc.AllowConnections(true)
 	grpcCfg, cleanup := launchServer(t, svc)
 	t.Cleanup(cleanup)
 

--- a/activation/e2e/checkpoint_merged_test.go
+++ b/activation/e2e/checkpoint_merged_test.go
@@ -47,8 +47,8 @@ func Test_CheckpointAfterMerge(t *testing.T) {
 	cdb := datastore.NewCachedDB(db, logger)
 	localDB := localsql.InMemory()
 
-	svc := grpcserver.NewPostService(logger)
-	svc.AllowConnections(true)
+	psOpts := grpcserver.PostServiceOpts{}
+	svc := grpcserver.NewPostService(logger, psOpts.AllowConnections(), psOpts.QueryInterval(100*time.Millisecond))
 	grpcCfg, cleanup := launchServer(t, svc)
 	t.Cleanup(cleanup)
 

--- a/activation/e2e/checkpoint_test.go
+++ b/activation/e2e/checkpoint_test.go
@@ -50,8 +50,8 @@ func TestCheckpoint_PublishingSoloATXs(t *testing.T) {
 	cdb := datastore.NewCachedDB(db, logger)
 
 	opts := testPostSetupOpts(t)
-	svc := grpcserver.NewPostService(logger)
-	svc.AllowConnections(true)
+	psOpts := grpcserver.PostServiceOpts{}
+	svc := grpcserver.NewPostService(logger, psOpts.AllowConnections(), psOpts.QueryInterval(100*time.Millisecond))
 	grpcCfg, cleanup := launchServer(t, svc)
 	t.Cleanup(cleanup)
 

--- a/activation/e2e/checkpoint_test.go
+++ b/activation/e2e/checkpoint_test.go
@@ -50,8 +50,8 @@ func TestCheckpoint_PublishingSoloATXs(t *testing.T) {
 	cdb := datastore.NewCachedDB(db, logger)
 
 	opts := testPostSetupOpts(t)
-	psOpts := grpcserver.PostServiceOpts{}
-	svc := grpcserver.NewPostService(logger, psOpts.AllowConnections(), psOpts.QueryInterval(100*time.Millisecond))
+	svc := grpcserver.NewPostService(logger, grpcserver.PostServiceQueryInterval(100*time.Millisecond))
+	svc.AllowConnections(true)
 	grpcCfg, cleanup := launchServer(t, svc)
 	t.Cleanup(cleanup)
 

--- a/activation/e2e/nipost_test.go
+++ b/activation/e2e/nipost_test.go
@@ -161,8 +161,8 @@ func TestNIPostBuilderWithClients(t *testing.T) {
 	localDb := localsql.InMemory()
 
 	opts := testPostSetupOpts(t)
-	psOpts := grpcserver.PostServiceOpts{}
-	svc := grpcserver.NewPostService(logger, psOpts.AllowConnections(), psOpts.QueryInterval(100*time.Millisecond))
+	svc := grpcserver.NewPostService(logger, grpcserver.PostServiceQueryInterval(100*time.Millisecond))
+	svc.AllowConnections(true)
 	grpcCfg, cleanup := launchServer(t, svc)
 	t.Cleanup(cleanup)
 
@@ -246,8 +246,8 @@ func Test_NIPostBuilderWithMultipleClients(t *testing.T) {
 	db := sql.InMemory()
 
 	opts := testPostSetupOpts(t)
-	psOpts := grpcserver.PostServiceOpts{}
-	svc := grpcserver.NewPostService(logger, psOpts.AllowConnections(), psOpts.QueryInterval(100*time.Millisecond))
+	svc := grpcserver.NewPostService(logger, grpcserver.PostServiceQueryInterval(100*time.Millisecond))
+	svc.AllowConnections(true)
 	grpcCfg, cleanup := launchServer(t, svc)
 	t.Cleanup(cleanup)
 	var eg errgroup.Group

--- a/activation/e2e/nipost_test.go
+++ b/activation/e2e/nipost_test.go
@@ -161,8 +161,8 @@ func TestNIPostBuilderWithClients(t *testing.T) {
 	localDb := localsql.InMemory()
 
 	opts := testPostSetupOpts(t)
-	svc := grpcserver.NewPostService(logger)
-	svc.AllowConnections(true)
+	psOpts := grpcserver.PostServiceOpts{}
+	svc := grpcserver.NewPostService(logger, psOpts.AllowConnections(), psOpts.QueryInterval(100*time.Millisecond))
 	grpcCfg, cleanup := launchServer(t, svc)
 	t.Cleanup(cleanup)
 
@@ -246,8 +246,8 @@ func Test_NIPostBuilderWithMultipleClients(t *testing.T) {
 	db := sql.InMemory()
 
 	opts := testPostSetupOpts(t)
-	svc := grpcserver.NewPostService(logger)
-	svc.AllowConnections(true)
+	psOpts := grpcserver.PostServiceOpts{}
+	svc := grpcserver.NewPostService(logger, psOpts.AllowConnections(), psOpts.QueryInterval(100*time.Millisecond))
 	grpcCfg, cleanup := launchServer(t, svc)
 	t.Cleanup(cleanup)
 	var eg errgroup.Group

--- a/activation/e2e/nipost_test.go
+++ b/activation/e2e/nipost_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	layersPerEpoch                 = 5
+	layersPerEpoch                 = 10
 	layerDuration                  = time.Second
 	postGenesisEpoch types.EpochID = 2
 )

--- a/activation/e2e/validation_test.go
+++ b/activation/e2e/validation_test.go
@@ -34,8 +34,8 @@ func TestValidator_Validate(t *testing.T) {
 	validator := activation.NewMocknipostValidator(gomock.NewController(t))
 
 	opts := testPostSetupOpts(t)
-	psOpts := grpcserver.PostServiceOpts{}
-	svc := grpcserver.NewPostService(logger, psOpts.AllowConnections(), psOpts.QueryInterval(100*time.Millisecond))
+	svc := grpcserver.NewPostService(logger, grpcserver.PostServiceQueryInterval(100*time.Millisecond))
+	svc.AllowConnections(true)
 	grpcCfg, cleanup := launchServer(t, svc)
 	t.Cleanup(cleanup)
 

--- a/activation/e2e/validation_test.go
+++ b/activation/e2e/validation_test.go
@@ -34,8 +34,8 @@ func TestValidator_Validate(t *testing.T) {
 	validator := activation.NewMocknipostValidator(gomock.NewController(t))
 
 	opts := testPostSetupOpts(t)
-	svc := grpcserver.NewPostService(zaptest.NewLogger(t))
-	svc.AllowConnections(true)
+	psOpts := grpcserver.PostServiceOpts{}
+	svc := grpcserver.NewPostService(logger, psOpts.AllowConnections(), psOpts.QueryInterval(100*time.Millisecond))
 	grpcCfg, cleanup := launchServer(t, svc)
 	t.Cleanup(cleanup)
 

--- a/api/grpcserver/post_client.go
+++ b/api/grpcserver/post_client.go
@@ -19,15 +19,17 @@ import (
 // Additionally if instructed it will start the post service and connect it to
 // the node.
 type postClient struct {
-	con chan<- postCommand
+	con           chan<- postCommand
+	queryInterval time.Duration
 
 	closed chan struct{}
 }
 
-func newPostClient(con chan<- postCommand) *postClient {
+func newPostClient(con chan<- postCommand, queryInterval time.Duration) *postClient {
 	return &postClient{
-		con:    con,
-		closed: make(chan struct{}),
+		con:           con,
+		queryInterval: queryInterval,
+		closed:        make(chan struct{}),
 	}
 }
 
@@ -102,8 +104,7 @@ func (pc *postClient) Proof(ctx context.Context, challenge []byte) (*types.Post,
 		select {
 		case <-ctx.Done():
 			return nil, nil, ctx.Err()
-		case <-time.After(2 * time.Second):
-			// TODO(mafa): make polling interval configurable
+		case <-time.After(pc.queryInterval):
 			continue
 		}
 	}

--- a/api/grpcserver/post_service.go
+++ b/api/grpcserver/post_service.go
@@ -51,15 +51,7 @@ func (s *PostService) String() string {
 
 type PostServiceOpt func(*PostService)
 
-type PostServiceOpts struct{}
-
-func (PostServiceOpts) AllowConnections() PostServiceOpt {
-	return func(s *PostService) {
-		s.allowConnections = true
-	}
-}
-
-func (PostServiceOpts) QueryInterval(interval time.Duration) PostServiceOpt {
+func PostServiceQueryInterval(interval time.Duration) PostServiceOpt {
 	return func(s *PostService) {
 		s.queryInterval = interval
 	}

--- a/systest/tests/distributed_post_verification_test.go
+++ b/systest/tests/distributed_post_verification_test.go
@@ -140,8 +140,11 @@ func TestPostMalfeasanceProof(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(clock.Close)
 
-	grpcPostService := grpcserver.NewPostService(logger.Named("grpc-post-service"))
-	grpcPostService.AllowConnections(true)
+	grpcPostService := grpcserver.NewPostService(
+		logger.Named("grpc-post-service"),
+		grpcserver.PostServiceOpts{}.AllowConnections(),
+		grpcserver.PostServiceOpts{}.QueryInterval(500*time.Millisecond),
+	)
 
 	grpcPrivateServer, err := grpcserver.NewWithServices(
 		cfg.API.PostListener,

--- a/systest/tests/distributed_post_verification_test.go
+++ b/systest/tests/distributed_post_verification_test.go
@@ -142,9 +142,9 @@ func TestPostMalfeasanceProof(t *testing.T) {
 
 	grpcPostService := grpcserver.NewPostService(
 		logger.Named("grpc-post-service"),
-		grpcserver.PostServiceOpts{}.AllowConnections(),
-		grpcserver.PostServiceOpts{}.QueryInterval(500*time.Millisecond),
+		grpcserver.PostServiceQueryInterval(500*time.Millisecond),
 	)
+	grpcPostService.AllowConnections(true)
 
 	grpcPrivateServer, err := grpcserver.NewWithServices(
 		cfg.API.PostListener,


### PR DESCRIPTION
## Motivation

Closes #6119 

## Description
There are a few problems with the e2e tests in CI happening on slow runners, visible in selected logs from a failed run:

```
[2024-07-10T12:21:02Z INFO  post::prove] generating proof with PoW flags: RandomXFlag(FLAG_HARD_AES | FLAG_JIT | FLAG_ARGON2_SSSE3 | FLAG_ARGON2_AVX2), difficulty (scaled with SU): 864691128455135232, K2PoW difficulty (scaled with SU): 3FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF	{"smesherID": "31d2a7"}
// 7s of RandomX initialization
[2024-07-10T12:21:09Z INFO  post::prove] calculating proof of work for nonces 0..16	{"smesherID": "31d2a7"}
[2024-07-10T12:21:09Z INFO  post::prove] finished k2pow in 0m 0s	{"smesherID": "31d2a7"}
[2024-07-10T12:21:09Z INFO  post::reader] Reading file: /var/folders/ng/t2lj_z6n4h30fn0h2ql_nd0c0000gn/T/Test_CheckpointAfterMerge87768266/003/postdata_0.bin	{"smesherID": "31d2a7"}
[2024-07-10T12:21:09Z INFO  post::prove] found proof for nonce: 2, pow: 0 with [8, 13, 15, 29, 45, 50, 59, 70] indices. It took 0m 0s	{"smesherID": "31d2a7"}
// 2s elapsed because the service is queried infrequently 
[2024-07-10T12:21:11Z INFO  post_service::client] proof is valid (verification took: 0.557015548s)	{"smesherID": "31d2a7"}
```

leading to the failure:

```
builder: atx expired: poet round has already started at 2024-07-10 12:21:08 +0000 UTC (now: 2024-07-10 12:21:11.227228 +0000 UTC m=+118.750801938)
```

### PoST proving time 
Despite reducing the difficulty of the PoST proof, it can still take significant time to complete. The most time-consuming part now seems to be RandomX VM initialization. In the logs above it took 7s (from 12:21:02 to 12:21:09), in other runs it took 1s - it's very undeterministic and probably depends on how busy the runner is. Unfortunately, this cannot be speeded up, unless we change the k2pow algorithm to something faster in tests (for example via a CLI flag like `--testing-mode`).

### Post Service querying interval
The post-service is queried in 2s intervals. That's too long in tests, where the cycle gap is 3.75s. If the proof were unavailable after 2s, the service would be queried again **after the CG finished** and the builder would be late for the poet round leading to test failure.

## Changes

- [x] configurable post-service query interval. The e2e tests use a 100ms interval.
- [x] TODO: make the CG/epoch longer in e2e tests or think how to speed up the PoST

## Test Plan

existing tests pass

## TODO

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [ ] Update documentation as needed
- [ ] Update [changelog](../CHANGELOG.md) as needed
