### PR TITLE
[Merged by Bors] - Scale down systests

### DIFF
--- a/.github/workflows/systest.yml
+++ b/.github/workflows/systest.yml
@@ -130,13 +130,13 @@ jobs:
           go-version-file: "go.mod"
 
       - name: Run tests
-        timeout-minutes: 60
+        timeout-minutes: 75
         env:
           test_id: systest-${{ steps.vars.outputs.sha_short }}
           label: sanity
           storage: premium-rwo=10Gi
           node_selector: cloud.google.com/gke-nodepool=systemtest
-          size: 30
+          size: 20
           bootstrap: 4m
           level: ${{ inputs.log_level }}
           clusters: 4

--- a/.github/workflows/systest.yml
+++ b/.github/workflows/systest.yml
@@ -130,7 +130,7 @@ jobs:
           go-version-file: "go.mod"
 
       - name: Run tests
-        timeout-minutes: 75
+        timeout-minutes: 60
         env:
           test_id: systest-${{ steps.vars.outputs.sha_short }}
           label: sanity


### PR DESCRIPTION
-------

## Motivation

Systests are flaking often and are not passing for #6003 despite no obvious performance-related changes in this PR.
The reason appears to be the tests requiring too much CPU.

## Description

Use cluster size 20 instead of 30 and increase timeout to 75 min from
60. We should try to increase cluster size again once we figure out
the reason for performance regression in systests.

## Test Plan

Check that systests pass