### PR TITLE
checkpoint: improve HTTP error handling

### DIFF
--- a/checkpoint/recovery.go
+++ b/checkpoint/recovery.go
@@ -41,28 +41,28 @@ type Config struct {
 	// set to false if atxs are not compatible before and after the checkpoint recovery.
 	PreserveOwnAtx bool `mapstructure:"preserve-own-atx"`
 
-	RetryCount    int           `mapstructure:"retry-count"`
-	RetryInterval time.Duration `mapstructure:"retry-interval"`
+	RetryMax   int           `mapstructure:"retry-max"`
+	RetryDelay time.Duration `mapstructure:"retry-delay"`
 }
 
 func DefaultConfig() Config {
 	return Config{
 		PreserveOwnAtx: true,
-		RetryCount:     5,
-		RetryInterval:  3 * time.Second,
+		RetryMax:       5,
+		RetryDelay:     3 * time.Second,
 	}
 }
 
 type RecoverConfig struct {
-	GoldenAtx     types.ATXID
-	DataDir       string
-	DbFile        string
-	LocalDbFile   string
-	NodeIDs       []types.NodeID // IDs to preserve own ATXs
-	Uri           string
-	Restore       types.LayerID
-	RetryCount    int
-	RetryInterval time.Duration
+	GoldenAtx   types.ATXID
+	DataDir     string
+	DbFile      string
+	LocalDbFile string
+	NodeIDs     []types.NodeID // IDs to preserve own ATXs
+	Uri         string
+	Restore     types.LayerID
+	RetryMax    int
+	RetryDelay  time.Duration
 }
 
 func (c *RecoverConfig) DbPath() string {
@@ -83,8 +83,8 @@ func copyToLocalFile(
 	fs afero.Fs,
 	dataDir, uri string,
 	restore types.LayerID,
-	retryCount int,
-	retryInterval time.Duration,
+	retryMax int,
+	retryDelay time.Duration,
 ) (string, error) {
 	parsed, err := url.Parse(uri)
 	if err != nil {
@@ -99,23 +99,12 @@ func copyToLocalFile(
 		logger.Info("old recovery data backed up", log.ZContext(ctx), zap.String("dir", bdir))
 	}
 	dst := RecoveryFilename(dataDir, filepath.Base(parsed.String()), restore)
-	for range retryCount + 1 {
-		err = httpToLocalFile(ctx, parsed, fs, dst)
-		switch {
-		case errors.Is(err, ErrTransient):
-			select {
-			case <-ctx.Done():
-				return "", ctx.Err()
-			case <-time.After(retryInterval):
-			}
-		case err != nil:
-			return "", err
-		default:
-			logger.Info("checkpoint data persisted", log.ZContext(ctx), zap.String("file", dst))
-			return dst, nil
-		}
+	if err = httpToLocalFile(ctx, parsed, fs, dst, retryMax, retryDelay); err != nil {
+		return "", err
 	}
-	return "", ErrCheckpointRequestFailed
+
+	logger.Info("checkpoint data persisted", log.ZContext(ctx), zap.String("file", dst))
+	return dst, nil
 }
 
 type AtxDep struct {
@@ -194,7 +183,7 @@ func RecoverWithDb(
 	logger.Info("recover from uri", zap.String("uri", cfg.Uri))
 	cpFile, err := copyToLocalFile(
 		ctx, logger, fs, cfg.DataDir, cfg.Uri, cfg.Restore,
-		cfg.RetryCount, cfg.RetryInterval,
+		cfg.RetryMax, cfg.RetryDelay,
 	)
 	if err != nil {
 		return nil, err

--- a/checkpoint/recovery_test.go
+++ b/checkpoint/recovery_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -119,33 +120,57 @@ func verifyDbContent(tb testing.TB, db *sql.Database) {
 	require.Empty(tb, extra)
 }
 
-func checkpointServer(t testing.TB) string {
+func checkpointServerWithFaultInjection(t testing.TB, succeed func() bool) string {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /snapshot-15", func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(checkpointData))
+		if succeed == nil || succeed() {
+			w.Write([]byte(checkpointData))
+		} else {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			w.Write([]byte("service unavailable"))
+		}
 	})
 	ts := httptest.NewServer(mux)
 	t.Cleanup(ts.Close)
 	return ts.URL
 }
 
+func checkpointServer(t testing.TB) string {
+	return checkpointServerWithFaultInjection(t, nil)
+}
+
 func TestRecover(t *testing.T) {
 	t.Parallel()
-	url := checkpointServer(t)
+	var fail atomic.Bool
+	url := checkpointServerWithFaultInjection(t, func() bool {
+		// 2nd attempt will always succeed
+		return !fail.Swap(false)
+	})
 
 	tt := []struct {
-		name   string
-		uri    string
-		expErr error
+		name    string
+		uri     string
+		expErr  error
+		reqFail bool
 	}{
 		{
 			name: "http",
 			uri:  fmt.Sprintf("%s/snapshot-15", url),
 		},
 		{
+			name:    "http+retry",
+			uri:     fmt.Sprintf("%s/snapshot-15", url),
+			reqFail: true,
+		},
+		{
+			name:   "not found",
+			uri:    fmt.Sprintf("%s/snapshot-42", url),
+			expErr: checkpoint.ErrCheckpointNotFound,
+		},
+		{
 			name:   "url unreachable",
 			uri:    "http://nowhere/snapshot-15",
-			expErr: checkpoint.ErrCheckpointNotFound,
+			expErr: checkpoint.ErrCheckpointRequestFailed,
 		},
 		{
 			name:   "ftp",
@@ -156,15 +181,18 @@ func TestRecover(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
+			fail.Store(tc.reqFail)
 			fs := afero.NewMemMapFs()
 			cfg := &checkpoint.RecoverConfig{
-				GoldenAtx:   goldenAtx,
-				DataDir:     t.TempDir(),
-				DbFile:      "test.sql",
-				LocalDbFile: "local.sql",
-				NodeIDs:     []types.NodeID{types.RandomNodeID()},
-				Uri:         tc.uri,
-				Restore:     types.LayerID(recoverLayer),
+				GoldenAtx:     goldenAtx,
+				DataDir:       t.TempDir(),
+				DbFile:        "test.sql",
+				LocalDbFile:   "local.sql",
+				NodeIDs:       []types.NodeID{types.RandomNodeID()},
+				Uri:           tc.uri,
+				Restore:       types.LayerID(recoverLayer),
+				RetryCount:    5,
+				RetryInterval: 100 * time.Millisecond,
 			}
 			bsdir := filepath.Join(cfg.DataDir, bootstrap.DirName)
 			require.NoError(t, fs.MkdirAll(bsdir, 0o700))

--- a/checkpoint/recovery_test.go
+++ b/checkpoint/recovery_test.go
@@ -184,15 +184,15 @@ func TestRecover(t *testing.T) {
 			fail.Store(tc.reqFail)
 			fs := afero.NewMemMapFs()
 			cfg := &checkpoint.RecoverConfig{
-				GoldenAtx:     goldenAtx,
-				DataDir:       t.TempDir(),
-				DbFile:        "test.sql",
-				LocalDbFile:   "local.sql",
-				NodeIDs:       []types.NodeID{types.RandomNodeID()},
-				Uri:           tc.uri,
-				Restore:       types.LayerID(recoverLayer),
-				RetryCount:    5,
-				RetryInterval: 100 * time.Millisecond,
+				GoldenAtx:   goldenAtx,
+				DataDir:     t.TempDir(),
+				DbFile:      "test.sql",
+				LocalDbFile: "local.sql",
+				NodeIDs:     []types.NodeID{types.RandomNodeID()},
+				Uri:         tc.uri,
+				Restore:     types.LayerID(recoverLayer),
+				RetryMax:    5,
+				RetryDelay:  100 * time.Millisecond,
 			}
 			bsdir := filepath.Join(cfg.DataDir, bootstrap.DirName)
 			require.NoError(t, fs.MkdirAll(bsdir, 0o700))

--- a/checkpoint/recovery_test.go
+++ b/checkpoint/recovery_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -120,104 +121,129 @@ func verifyDbContent(tb testing.TB, db *sql.Database) {
 	require.Empty(tb, extra)
 }
 
-func checkpointServerWithFaultInjection(t testing.TB, succeed func() bool) string {
+func checkpointServer(t testing.TB) string {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /snapshot-15", func(w http.ResponseWriter, r *http.Request) {
-		if succeed == nil || succeed() {
-			w.Write([]byte(checkpointData))
-		} else {
-			w.WriteHeader(http.StatusServiceUnavailable)
-			w.Write([]byte("service unavailable"))
-		}
+		w.Write([]byte(checkpointData))
 	})
 	ts := httptest.NewServer(mux)
 	t.Cleanup(ts.Close)
 	return ts.URL
 }
 
-func checkpointServer(t testing.TB) string {
-	return checkpointServerWithFaultInjection(t, nil)
-}
-
 func TestRecover(t *testing.T) {
 	t.Parallel()
-	var fail atomic.Bool
-	url := checkpointServerWithFaultInjection(t, func() bool {
-		// 2nd attempt will always succeed
-		return !fail.Swap(false)
+
+	setup := func(t *testing.T, handler http.HandlerFunc) (afero.Fs, *checkpoint.RecoverConfig) {
+		t.Helper()
+		fs := afero.NewMemMapFs()
+
+		mux := http.NewServeMux()
+		mux.HandleFunc("GET /snapshot-15", handler)
+		ts := httptest.NewServer(mux)
+		t.Cleanup(ts.Close)
+		cfg := &checkpoint.RecoverConfig{
+			GoldenAtx:   goldenAtx,
+			DataDir:     t.TempDir(),
+			DbFile:      "test.sql",
+			LocalDbFile: "local.sql",
+			NodeIDs:     []types.NodeID{types.RandomNodeID()},
+			Uri:         fmt.Sprintf("%s/snapshot-15", ts.URL),
+			Restore:     types.LayerID(recoverLayer),
+			RetryMax:    5,
+			RetryDelay:  100 * time.Millisecond,
+		}
+		require.NoError(t, fs.MkdirAll(filepath.Join(cfg.DataDir, bootstrap.DirName), 0o700))
+		return fs, cfg
+	}
+
+	t.Run("http", func(t *testing.T) {
+		db := sql.InMemory()
+		localDB := localsql.InMemory()
+		fs, cfg := setup(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(checkpointData))
+		})
+
+		data, err := checkpoint.RecoverWithDb(context.Background(), zaptest.NewLogger(t), db, localDB, fs, cfg)
+		require.NoError(t, err)
+		require.Nil(t, data)
+
+		newDB, err := sql.Open("file:" + filepath.Join(cfg.DataDir, cfg.DbFile))
+		require.NoError(t, err)
+		require.NotNil(t, newDB)
+		defer newDB.Close()
+		verifyDbContent(t, newDB)
+
+		restore, err := recovery.CheckpointInfo(newDB)
+		require.NoError(t, err)
+		require.EqualValues(t, recoverLayer, restore)
 	})
 
-	tt := []struct {
-		name    string
-		uri     string
-		expErr  error
-		reqFail bool
-	}{
-		{
-			name: "http",
-			uri:  fmt.Sprintf("%s/snapshot-15", url),
-		},
-		{
-			name:    "http+retry",
-			uri:     fmt.Sprintf("%s/snapshot-15", url),
-			reqFail: true,
-		},
-		{
-			name:   "not found",
-			uri:    fmt.Sprintf("%s/snapshot-42", url),
-			expErr: checkpoint.ErrCheckpointNotFound,
-		},
-		{
-			name:   "url unreachable",
-			uri:    "http://nowhere/snapshot-15",
-			expErr: checkpoint.ErrCheckpointRequestFailed,
-		},
-		{
-			name:   "ftp",
-			uri:    "ftp://snapshot-15",
-			expErr: checkpoint.ErrUrlSchemeNotSupported,
-		},
-	}
-
-	for _, tc := range tt {
-		t.Run(tc.name, func(t *testing.T) {
-			fail.Store(tc.reqFail)
-			fs := afero.NewMemMapFs()
-			cfg := &checkpoint.RecoverConfig{
-				GoldenAtx:   goldenAtx,
-				DataDir:     t.TempDir(),
-				DbFile:      "test.sql",
-				LocalDbFile: "local.sql",
-				NodeIDs:     []types.NodeID{types.RandomNodeID()},
-				Uri:         tc.uri,
-				Restore:     types.LayerID(recoverLayer),
-				RetryMax:    5,
-				RetryDelay:  100 * time.Millisecond,
-			}
-			bsdir := filepath.Join(cfg.DataDir, bootstrap.DirName)
-			require.NoError(t, fs.MkdirAll(bsdir, 0o700))
-			db := sql.InMemory()
-			localDB := localsql.InMemory()
-			data, err := checkpoint.RecoverWithDb(context.Background(), zaptest.NewLogger(t), db, localDB, fs, cfg)
-			if tc.expErr != nil {
-				require.ErrorIs(t, err, tc.expErr)
+	t.Run("http+retry", func(t *testing.T) {
+		t.Parallel()
+		db := sql.InMemory()
+		localDB := localsql.InMemory()
+		var fail atomic.Bool
+		fail.Store(true)
+		fs, cfg := setup(t, func(w http.ResponseWriter, r *http.Request) {
+			if fail.CompareAndSwap(true, false) { // fail on first request
+				w.WriteHeader(http.StatusServiceUnavailable)
+				w.Write([]byte("service unavailable"))
 				return
 			}
-			require.NoError(t, err)
-			require.Nil(t, data)
-			newDB, err := sql.Open("file:" + filepath.Join(cfg.DataDir, cfg.DbFile))
-			require.NoError(t, err)
-			require.NotNil(t, newDB)
-			defer newDB.Close()
-			verifyDbContent(t, newDB)
-			restore, err := recovery.CheckpointInfo(newDB)
-			require.NoError(t, err)
-			require.EqualValues(t, recoverLayer, restore)
-			exist, err := afero.Exists(fs, bsdir)
-			require.NoError(t, err)
-			require.False(t, exist)
+			w.Write([]byte(checkpointData))
 		})
-	}
+
+		data, err := checkpoint.RecoverWithDb(context.Background(), zaptest.NewLogger(t), db, localDB, fs, cfg)
+		require.NoError(t, err)
+		require.Nil(t, data)
+
+		newDB, err := sql.Open("file:" + filepath.Join(cfg.DataDir, cfg.DbFile))
+		require.NoError(t, err)
+		require.NotNil(t, newDB)
+		defer newDB.Close()
+		verifyDbContent(t, newDB)
+
+		restore, err := recovery.CheckpointInfo(newDB)
+		require.NoError(t, err)
+		require.EqualValues(t, recoverLayer, restore)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		db := sql.InMemory()
+		localDB := localsql.InMemory()
+		fs, cfg := setup(t, func(w http.ResponseWriter, r *http.Request) {})
+		cfg.Uri = strings.Replace(cfg.Uri, "/snapshot-15", "/snapshot-42", -1) // unavailable snapshot
+
+		data, err := checkpoint.RecoverWithDb(context.Background(), zaptest.NewLogger(t), db, localDB, fs, cfg)
+		require.ErrorIs(t, err, checkpoint.ErrCheckpointNotFound)
+		require.Nil(t, data)
+	})
+
+	t.Run("url unreachable", func(t *testing.T) {
+		t.Parallel()
+		db := sql.InMemory()
+		localDB := localsql.InMemory()
+		fs, cfg := setup(t, func(w http.ResponseWriter, r *http.Request) {})
+		cfg.Uri = "http://nowhere/snapshot-15" // unreachable url
+
+		data, err := checkpoint.RecoverWithDb(context.Background(), zaptest.NewLogger(t), db, localDB, fs, cfg)
+		require.ErrorIs(t, err, checkpoint.ErrCheckpointRequestFailed)
+		require.Nil(t, data)
+	})
+
+	t.Run("unsupported scheme", func(t *testing.T) {
+		t.Parallel()
+		db := sql.InMemory()
+		localDB := localsql.InMemory()
+		fs, cfg := setup(t, func(w http.ResponseWriter, r *http.Request) {})
+		cfg.Uri = "ftp://snapshot-15" // unsupported scheme
+
+		data, err := checkpoint.RecoverWithDb(context.Background(), zaptest.NewLogger(t), db, localDB, fs, cfg)
+		require.ErrorIs(t, err, checkpoint.ErrUrlSchemeNotSupported)
+		require.Nil(t, data)
+	})
 }
 
 func TestRecover_SameRecoveryInfo(t *testing.T) {

--- a/checkpoint/util.go
+++ b/checkpoint/util.go
@@ -132,8 +132,6 @@ func httpToLocalFile(
 
 	resp, err := c.Do(req)
 	if err != nil {
-		// This shouldn't really happen. According to net/http docs for Do:
-		// "Any returned error will be of type *url.Error."
 		return fmt.Errorf("%w: %w", ErrCheckpointRequestFailed, err)
 	}
 	defer resp.Body.Close()

--- a/checkpoint/util.go
+++ b/checkpoint/util.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/hashicorp/go-retryablehttp"
 	"github.com/santhosh-tekuri/jsonschema/v5"
 	"github.com/spf13/afero"
 
@@ -24,7 +25,6 @@ import (
 )
 
 var (
-	ErrTransient               = errors.New("transient error")
 	ErrCheckpointNotFound      = errors.New("checkpoint not found")
 	ErrCheckpointRequestFailed = errors.New("checkpoint request failed")
 	ErrUrlSchemeNotSupported   = errors.New("url scheme not supported")
@@ -111,36 +111,38 @@ func CopyFile(fs afero.Fs, src, dst string) error {
 	return rf.Copy(fs, srcf)
 }
 
-func httpToLocalFile(ctx context.Context, resource *url.URL, fs afero.Fs, dst string) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, resource.String(), nil)
+func httpToLocalFile(
+	ctx context.Context,
+	resource *url.URL,
+	fs afero.Fs,
+	dst string,
+	retryMax int,
+	retryDelay time.Duration,
+) error {
+	c := retryablehttp.NewClient()
+	c.RetryMax = retryMax
+	c.RetryWaitMin = retryDelay
+	c.RetryWaitMax = retryDelay * 2
+	c.Backoff = retryablehttp.LinearJitterBackoff
+
+	req, err := retryablehttp.NewRequestWithContext(ctx, http.MethodGet, resource.String(), nil)
 	if err != nil {
 		return fmt.Errorf("create http request: %w", err)
 	}
-	resp, err := (&http.Client{}).Do(req)
-	urlErr := &url.Error{}
-	switch {
-	case errors.As(err, &urlErr):
-		// It makes sense to retry on network errors.
-		return ErrTransient
-	case err != nil:
+
+	resp, err := c.Do(req)
+	if err != nil {
 		// This shouldn't really happen. According to net/http docs for Do:
 		// "Any returned error will be of type *url.Error."
-		return fmt.Errorf("http get recovery file: %w", err)
+		return fmt.Errorf("%w: %w", ErrCheckpointRequestFailed, err)
 	}
 	defer resp.Body.Close()
-	switch {
-	case resp.StatusCode == http.StatusOK:
-		// Continue
-	case resp.StatusCode == http.StatusNotFound:
-		// The checkpoint is not found. This is not considered a fatal error.
+	switch resp.StatusCode {
+	case http.StatusOK:
+	case http.StatusNotFound:
 		return ErrCheckpointNotFound
-	case resp.StatusCode%100 == 4:
-		// Can't load the checkoint but it maybe due to an unexpected server problem
-		// that is not likely to be resolved by retrying.
-		return ErrCheckpointRequestFailed
 	default:
-		// It makes sense to retry on other server errors.
-		return ErrTransient
+		return fmt.Errorf("%w: status code %d", ErrCheckpointRequestFailed, resp.StatusCode)
 	}
 	rf, err := NewRecoveryFile(fs, dst)
 	if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,6 +26,9 @@ func AddFlags(flagSet *pflag.FlagSet, cfg *config.Config) (configPath *string) {
 		"recovery-uri", cfg.Recovery.Uri, "reset the node state based on the supplied checkpoint file")
 	flagSet.Uint32Var(&cfg.Recovery.Restore,
 		"recovery-layer", cfg.Recovery.Restore, "restart the mesh with the checkpoint file at this layer")
+	flagSet.BoolVar(&cfg.Recovery.IgnoreCheckpointReqErrors,
+		"ignore-checkpoint-req-errors", cfg.Recovery.IgnoreCheckpointReqErrors,
+		"ignore checkpoint request errors")
 
 	/** ======================== BaseConfig Flags ========================== **/
 	flagSet.StringVarP(&cfg.BaseConfig.DataDirParent, "data-folder", "d",

--- a/node/node.go
+++ b/node/node.go
@@ -436,13 +436,15 @@ func (app *App) loadCheckpoint(ctx context.Context) (*checkpoint.PreservedData, 
 		}
 	}
 	cfg := &checkpoint.RecoverConfig{
-		GoldenAtx:   types.ATXID(app.Config.Genesis.GoldenATX()),
-		DataDir:     app.Config.DataDir(),
-		DbFile:      dbFile,
-		LocalDbFile: localDbFile,
-		NodeIDs:     nodeIDs,
-		Uri:         app.Config.Recovery.Uri,
-		Restore:     types.LayerID(app.Config.Recovery.Restore),
+		GoldenAtx:     types.ATXID(app.Config.Genesis.GoldenATX()),
+		DataDir:       app.Config.DataDir(),
+		DbFile:        dbFile,
+		LocalDbFile:   localDbFile,
+		NodeIDs:       nodeIDs,
+		Uri:           app.Config.Recovery.Uri,
+		Restore:       types.LayerID(app.Config.Recovery.Restore),
+		RetryCount:    app.Config.Recovery.RetryCount,
+		RetryInterval: app.Config.Recovery.RetryInterval,
 	}
 
 	return checkpoint.Recover(ctx, app.log.Zap(), afero.NewOsFs(), cfg)

--- a/node/node.go
+++ b/node/node.go
@@ -436,15 +436,15 @@ func (app *App) loadCheckpoint(ctx context.Context) (*checkpoint.PreservedData, 
 		}
 	}
 	cfg := &checkpoint.RecoverConfig{
-		GoldenAtx:     types.ATXID(app.Config.Genesis.GoldenATX()),
-		DataDir:       app.Config.DataDir(),
-		DbFile:        dbFile,
-		LocalDbFile:   localDbFile,
-		NodeIDs:       nodeIDs,
-		Uri:           app.Config.Recovery.Uri,
-		Restore:       types.LayerID(app.Config.Recovery.Restore),
-		RetryCount:    app.Config.Recovery.RetryCount,
-		RetryInterval: app.Config.Recovery.RetryInterval,
+		GoldenAtx:   types.ATXID(app.Config.Genesis.GoldenATX()),
+		DataDir:     app.Config.DataDir(),
+		DbFile:      dbFile,
+		LocalDbFile: localDbFile,
+		NodeIDs:     nodeIDs,
+		Uri:         app.Config.Recovery.Uri,
+		Restore:     types.LayerID(app.Config.Recovery.Restore),
+		RetryMax:    app.Config.Recovery.RetryMax,
+		RetryDelay:  app.Config.Recovery.RetryDelay,
 	}
 
 	return checkpoint.Recover(ctx, app.log.Zap(), afero.NewOsFs(), cfg)

--- a/node/node.go
+++ b/node/node.go
@@ -436,15 +436,16 @@ func (app *App) loadCheckpoint(ctx context.Context) (*checkpoint.PreservedData, 
 		}
 	}
 	cfg := &checkpoint.RecoverConfig{
-		GoldenAtx:   types.ATXID(app.Config.Genesis.GoldenATX()),
-		DataDir:     app.Config.DataDir(),
-		DbFile:      dbFile,
-		LocalDbFile: localDbFile,
-		NodeIDs:     nodeIDs,
-		Uri:         app.Config.Recovery.Uri,
-		Restore:     types.LayerID(app.Config.Recovery.Restore),
-		RetryMax:    app.Config.Recovery.RetryMax,
-		RetryDelay:  app.Config.Recovery.RetryDelay,
+		GoldenAtx:                 types.ATXID(app.Config.Genesis.GoldenATX()),
+		DataDir:                   app.Config.DataDir(),
+		DbFile:                    dbFile,
+		LocalDbFile:               localDbFile,
+		NodeIDs:                   nodeIDs,
+		Uri:                       app.Config.Recovery.Uri,
+		Restore:                   types.LayerID(app.Config.Recovery.Restore),
+		RetryMax:                  app.Config.Recovery.RetryMax,
+		RetryDelay:                app.Config.Recovery.RetryDelay,
+		IgnoreCheckpointReqErrors: app.Config.Recovery.IgnoreCheckpointReqErrors,
 	}
 
 	return checkpoint.Recover(ctx, app.log.Zap(), afero.NewOsFs(), cfg)

--- a/systest/cluster/nodes.go
+++ b/systest/cluster/nodes.go
@@ -899,7 +899,8 @@ func deployNode(
 			WithStartupProbe(
 				corev1.Probe().WithTCPSocket(
 					corev1.TCPSocketAction().WithPort(intstr.FromInt32(9092)),
-				).WithInitialDelaySeconds(10).WithPeriodSeconds(10),
+				).WithInitialDelaySeconds(10).WithPeriodSeconds(10).
+					WithFailureThreshold(10),
 			).
 			WithEnv(
 				corev1.EnvVar().WithName("GOMAXPROCS").WithValue("4"),
@@ -1221,6 +1222,10 @@ func BootstrapperUrl(endpoint string) DeploymentFlag {
 
 func CheckpointUrl(endpoint string) DeploymentFlag {
 	return DeploymentFlag{Name: "--recovery-uri", Value: endpoint}
+}
+
+func IgnoreCheckpointReqErrors() DeploymentFlag {
+	return DeploymentFlag{Name: "--ignore-checkpoint-req-errors", Value: strconv.FormatBool(true)}
 }
 
 func CheckpointLayer(restoreLayer uint32) DeploymentFlag {

--- a/systest/tests/checkpoint_test.go
+++ b/systest/tests/checkpoint_test.go
@@ -29,6 +29,14 @@ func reuseCluster(tctx *testcontext.Context, restoreLayer uint32) (*cluster.Clus
 		cluster.WithBootstrapEpochs([]int{2, 4, 5}),
 		cluster.WithSmesherFlag(cluster.CheckpointUrl(fmt.Sprintf("%s/checkpoint", cluster.BootstrapperEndpoint(0)))),
 		cluster.WithSmesherFlag(cluster.CheckpointLayer(restoreLayer)),
+		// The --ignore-checkpoint-req-errors flag is needed b/c in the context of
+		// TestRecovery systest, all the nodes are created with --recovery-uri
+		// flag passed, including the bootnodes.
+		// This way, they can't successfully start unless the bootstrapper is
+		// already running.
+		// But at the same time the bootstrapper requires an working go-spacemesh
+		// node to start up, thus we get a circulardependency.
+		// TODO: use a smarter go-spacemesh cluster restart mechanism
 		cluster.WithSmesherFlag(cluster.IgnoreCheckpointReqErrors()),
 	)
 }

--- a/systest/tests/checkpoint_test.go
+++ b/systest/tests/checkpoint_test.go
@@ -29,6 +29,7 @@ func reuseCluster(tctx *testcontext.Context, restoreLayer uint32) (*cluster.Clus
 		cluster.WithBootstrapEpochs([]int{2, 4, 5}),
 		cluster.WithSmesherFlag(cluster.CheckpointUrl(fmt.Sprintf("%s/checkpoint", cluster.BootstrapperEndpoint(0)))),
 		cluster.WithSmesherFlag(cluster.CheckpointLayer(restoreLayer)),
+		cluster.WithSmesherFlag(cluster.IgnoreCheckpointReqErrors()),
 	)
 }
 

--- a/systest/tests/checkpoint_test.go
+++ b/systest/tests/checkpoint_test.go
@@ -35,7 +35,7 @@ func reuseCluster(tctx *testcontext.Context, restoreLayer uint32) (*cluster.Clus
 		// This way, they can't successfully start unless the bootstrapper is
 		// already running.
 		// But at the same time the bootstrapper requires an working go-spacemesh
-		// node to start up, thus we get a circulardependency.
+		// node to start up, thus we get a circular dependency.
 		// TODO: use a smarter go-spacemesh cluster restart mechanism
 		cluster.WithSmesherFlag(cluster.IgnoreCheckpointReqErrors()),
 	)


### PR DESCRIPTION
## Motivation

When `recovery.recovery-uri` is configured and an error happens, such as network glitch or a temporary server error due to overload, go-spacemesh continues its execution without recovery, which may not be always intended behavior. This, for example, causes `TestCheckpoint` systest flakes sometimes.
The way to fix it is to retry a few times upon transient errors (such as network glitch or a 503 server error), terminating after all the retries are exhausted, continue without an error upon `404 Not Found`, and terminate go-spacemesh in other cases.

## Description

When recovering from an URL, only continue without failing if checkpoint data request fails with 404 code. If the request fails with other 4xx HTTP error code, go-spacemesh startup fails. Upon other errors, including 5xx HTTP errors and network errors, retry checkpoint data request several times.`recovery.retry-max` and `recovery.retry-delay` specify retry parameters, defaulting to 5 and 3s, respectively. go-spacemesh terminates if all the retries fail.

## Test Plan

Systests should pass