### PR TITLE
[Merged by Bors] - systest: fix RBAC rules for chaos-mesh

### DIFF
--- a/systest/systest_rbac.yml.tmpl
+++ b/systest/systest_rbac.yml.tmpl
@@ -18,6 +18,9 @@ rules:
 - apiGroups: ["apps"]
   resources: ["deployments"]
   verbs: ["get","create","patch","update","list","watch"]
+- apiGroups: ["chaos-mesh.org"]
+  resources: ["networkchaos", "timechaos", "schedule"]
+  verbs: ["get","create","patch","update","list","watch","delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
## Motivation

Systests are failing when running with RBAC enabled due to chaos-mesh object permissions

## Description

Add RBAC rules for chaos-mesh

## Test Plan

Run systests on a custom k3s cluster