### PR TITLE
[Merged by Bors] - Stabilizing E2E tests - take 3

### DIFF
--- a/activation/e2e/activation_test.go
+++ b/activation/e2e/activation_test.go
@@ -124,7 +124,7 @@ func Test_BuilderWithMultipleClients(t *testing.T) {
 	clock, err := timesync.NewClock(
 		timesync.WithGenesisTime(genesis),
 		timesync.WithLayerDuration(layerDuration),
-		timesync.WithTickInterval(100*time.Millisecond),
+		timesync.WithTickInterval(10*time.Millisecond),
 		timesync.WithLogger(zap.NewNop()),
 	)
 	require.NoError(t, err)

--- a/activation/e2e/atx_merge_test.go
+++ b/activation/e2e/atx_merge_test.go
@@ -238,7 +238,7 @@ func Test_MarryAndMerge(t *testing.T) {
 	require.NoError(t, eg.Wait())
 
 	// ensure that genesis aligns with layer timings
-	genesis := time.Now().Round(layerDuration)
+	genesis := time.Now().Add(layerDuration).Round(layerDuration)
 	epoch := layersPerEpoch * layerDuration
 	poetCfg := activation.PoetConfig{
 		PhaseShift:  epoch,
@@ -252,7 +252,7 @@ func Test_MarryAndMerge(t *testing.T) {
 	clock, err := timesync.NewClock(
 		timesync.WithGenesisTime(genesis),
 		timesync.WithLayerDuration(layerDuration),
-		timesync.WithTickInterval(100*time.Millisecond),
+		timesync.WithTickInterval(10*time.Millisecond),
 		timesync.WithLogger(zap.NewNop()),
 	)
 	require.NoError(t, err)

--- a/activation/e2e/builds_atx_v2_test.go
+++ b/activation/e2e/builds_atx_v2_test.go
@@ -2,7 +2,7 @@ package activation_test
 
 import (
 	"context"
-	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -136,8 +136,7 @@ func TestBuilder_SwitchesToBuildV2(t *testing.T) {
 	)
 
 	var previous *types.ActivationTx
-	var expectedAtxs sync.WaitGroup
-	expectedAtxs.Add(3)
+	var publishedAtxs atomic.Uint32
 	gomock.InOrder(
 		mpub.EXPECT().Publish(gomock.Any(), pubsub.AtxProtocol, gomock.Any()).DoAndReturn(
 			func(ctx context.Context, _ string, msg []byte) error {
@@ -160,7 +159,7 @@ func TestBuilder_SwitchesToBuildV2(t *testing.T) {
 				atx, err := atxs.Get(db, watx.ID())
 				require.NoError(t, err)
 				previous = atx
-				expectedAtxs.Done()
+				publishedAtxs.Add(1)
 				return nil
 			},
 		),
@@ -193,7 +192,7 @@ func TestBuilder_SwitchesToBuildV2(t *testing.T) {
 				require.NotZero(t, atx.TickHeight())
 				require.Equal(t, opts.NumUnits, atx.NumUnits)
 				previous = atx
-				expectedAtxs.Done()
+				publishedAtxs.Add(1)
 				return nil
 			},
 		).Times(2),
@@ -216,6 +215,6 @@ func TestBuilder_SwitchesToBuildV2(t *testing.T) {
 	tab.Register(sig)
 
 	require.NoError(t, tab.StartSmeshing(coinbase))
-	require.Eventually(t, func() bool { expectedAtxs.Wait(); return true }, epoch*4, time.Millisecond*100)
+	require.Eventually(t, func() bool { return publishedAtxs.Load() >= 3 }, epoch*4, time.Millisecond*100)
 	require.NoError(t, tab.StopSmeshing(false))
 }

--- a/activation/e2e/builds_atx_v2_test.go
+++ b/activation/e2e/builds_atx_v2_test.go
@@ -74,7 +74,7 @@ func TestBuilder_SwitchesToBuildV2(t *testing.T) {
 	atxsdata := atxsdata.New()
 
 	// ensure that genesis aligns with layer timings
-	genesis := time.Now().Round(layerDuration)
+	genesis := time.Now().Add(layerDuration).Round(layerDuration)
 	epoch := layersPerEpoch * layerDuration
 	poetCfg := activation.PoetConfig{
 		PhaseShift:  epoch,
@@ -85,7 +85,7 @@ func TestBuilder_SwitchesToBuildV2(t *testing.T) {
 	clock, err := timesync.NewClock(
 		timesync.WithGenesisTime(genesis),
 		timesync.WithLayerDuration(layerDuration),
-		timesync.WithTickInterval(100*time.Millisecond),
+		timesync.WithTickInterval(10*time.Millisecond),
 		timesync.WithLogger(zap.NewNop()),
 	)
 	require.NoError(t, err)

--- a/activation/e2e/checkpoint_merged_test.go
+++ b/activation/e2e/checkpoint_merged_test.go
@@ -73,7 +73,7 @@ func Test_CheckpointAfterMerge(t *testing.T) {
 	require.NoError(t, eg.Wait())
 
 	// ensure that genesis aligns with layer timings
-	genesis := time.Now().Round(layerDuration)
+	genesis := time.Now().Add(layerDuration).Round(layerDuration)
 	epoch := layersPerEpoch * layerDuration
 	poetCfg := activation.PoetConfig{
 		PhaseShift:  epoch,
@@ -87,7 +87,7 @@ func Test_CheckpointAfterMerge(t *testing.T) {
 	clock, err := timesync.NewClock(
 		timesync.WithGenesisTime(genesis),
 		timesync.WithLayerDuration(layerDuration),
-		timesync.WithTickInterval(100*time.Millisecond),
+		timesync.WithTickInterval(10*time.Millisecond),
 		timesync.WithLogger(zap.NewNop()),
 	)
 	require.NoError(t, err)

--- a/activation/e2e/validation_test.go
+++ b/activation/e2e/validation_test.go
@@ -98,7 +98,7 @@ func TestValidator_Validate(t *testing.T) {
 	newNIPost := *nipost.NIPost
 	newNIPost.Post = &types.Post{}
 	_, err = v.NIPost(context.Background(), sig.NodeID(), goldenATX, &newNIPost, challenge, nipost.NumUnits)
-	require.ErrorContains(t, err, "invalid Post")
+	require.ErrorContains(t, err, "validating Post: verifying PoST: proof indices are empty")
 
 	newPostCfg := cfg
 	newPostCfg.MinNumUnits = nipost.NumUnits + 1

--- a/activation/handler_test.go
+++ b/activation/handler_test.go
@@ -360,7 +360,7 @@ func TestHandler_HandleGossipAtx(t *testing.T) {
 	atxHdlr.mockFetch.EXPECT().GetPoetProof(gomock.Any(), types.Hash32(second.NIPost.PostMetadata.Challenge))
 	atxHdlr.mockFetch.EXPECT().GetAtxs(gomock.Any(), []types.ATXID{second.PrevATXID}, gomock.Any())
 	err = atxHdlr.HandleGossipAtx(context.Background(), "", codec.MustEncode(second))
-	require.ErrorContains(t, err, "syntactically invalid based on deps")
+	require.ErrorContains(t, err, "database: not found")
 
 	// valid first comes in
 	atxHdlr.expectAtxV1(first, sig.NodeID())

--- a/activation/handler_test.go
+++ b/activation/handler_test.go
@@ -360,7 +360,7 @@ func TestHandler_HandleGossipAtx(t *testing.T) {
 	atxHdlr.mockFetch.EXPECT().GetPoetProof(gomock.Any(), types.Hash32(second.NIPost.PostMetadata.Challenge))
 	atxHdlr.mockFetch.EXPECT().GetAtxs(gomock.Any(), []types.ATXID{second.PrevATXID}, gomock.Any())
 	err = atxHdlr.HandleGossipAtx(context.Background(), "", codec.MustEncode(second))
-	require.ErrorContains(t, err, "database: not found")
+	require.ErrorIs(t, err, sql.ErrNotFound)
 
 	// valid first comes in
 	atxHdlr.expectAtxV1(first, sig.NodeID())

--- a/activation/handler_v1.go
+++ b/activation/handler_v1.go
@@ -144,7 +144,7 @@ func (h *HandlerV1) syntacticallyValidate(ctx context.Context, atx *wire.Activat
 		if err := h.nipostValidator.Post(
 			ctx, atx.SmesherID, *atx.CommitmentATXID, post, &initialPostMetadata, atx.NumUnits,
 		); err != nil {
-			return fmt.Errorf("invalid initial post: %w", err)
+			return fmt.Errorf("validating initial post: %w", err)
 		}
 	default:
 		if atx.NodeID != nil {
@@ -244,7 +244,7 @@ func (h *HandlerV1) syntacticallyValidateDeps(
 		return 0, 0, proof, nil
 	}
 	if err != nil {
-		return 0, 0, nil, fmt.Errorf("invalid nipost: %w", err)
+		return 0, 0, nil, fmt.Errorf("validating nipost: %w", err)
 	}
 
 	return leaves, effectiveNumUnits, nil, err
@@ -606,7 +606,7 @@ func (h *HandlerV1) processATX(
 	)
 
 	if err := h.syntacticallyValidate(ctx, watx); err != nil {
-		return nil, fmt.Errorf("atx %s syntactically invalid: %w", watx.ID(), err)
+		return nil, fmt.Errorf("validating atx %s: %w", watx.ID(), err)
 	}
 
 	poetRef, atxIDs := collectAtxDeps(h.goldenATXID, watx)
@@ -617,7 +617,7 @@ func (h *HandlerV1) processATX(
 
 	leaves, effectiveNumUnits, proof, err := h.syntacticallyValidateDeps(ctx, watx)
 	if err != nil {
-		return nil, fmt.Errorf("atx %s syntactically invalid based on deps: %w", watx.ID(), err)
+		return nil, fmt.Errorf("validating atx %s (deps): %w", watx.ID(), err)
 	}
 	if proof != nil {
 		return proof, nil

--- a/activation/handler_v1_test.go
+++ b/activation/handler_v1_test.go
@@ -297,7 +297,7 @@ func TestHandlerV1_SyntacticallyValidateAtx(t *testing.T) {
 			NIPost(gomock.Any(), atx.SmesherID, goldenATXID, gomock.Any(), gomock.Any(), atx.NumUnits, gomock.Any()).
 			Return(0, errors.New("bad nipost"))
 		_, _, _, err := atxHdlr.syntacticallyValidateDeps(context.Background(), atx)
-		require.EqualError(t, err, "invalid nipost: bad nipost")
+		require.EqualError(t, err, "validating nipost: bad nipost")
 	})
 	t.Run("missing NodeID in initial atx", func(t *testing.T) {
 		t.Parallel()

--- a/activation/handler_v2.go
+++ b/activation/handler_v2.go
@@ -91,7 +91,7 @@ func (h *HandlerV2) processATX(
 	)
 
 	if err := h.syntacticallyValidate(ctx, watx); err != nil {
-		return nil, fmt.Errorf("atx %s syntactically invalid: %w", watx.ID(), err)
+		return nil, fmt.Errorf("validating atx %s: %w", watx.ID(), err)
 	}
 
 	poetRef, atxIDs := h.collectAtxDeps(watx)
@@ -112,7 +112,7 @@ func (h *HandlerV2) processATX(
 
 	parts, proof, err := h.syntacticallyValidateDeps(ctx, watx)
 	if err != nil {
-		return nil, fmt.Errorf("atx %s syntactically invalid based on deps: %w", watx.ID(), err)
+		return nil, fmt.Errorf("validating atx %s (deps): %w", watx.ID(), err)
 	}
 
 	if proof != nil {
@@ -210,7 +210,7 @@ func (h *HandlerV2) syntacticallyValidate(ctx context.Context, atx *wire.Activat
 		if err := h.nipostValidator.PostV2(
 			ctx, atx.SmesherID, atx.Initial.CommitmentATX, post, shared.ZeroChallenge, numUnits,
 		); err != nil {
-			return fmt.Errorf("invalid initial post: %w", err)
+			return fmt.Errorf("validating initial post: %w", err)
 		}
 		return nil
 	}
@@ -584,7 +584,7 @@ func (h *HandlerV2) syntacticallyValidateDeps(
 		}
 		leaves, err := h.nipostValidator.PoetMembership(ctx, &membership, niposts.Challenge, poetChallenges)
 		if err != nil {
-			return nil, nil, fmt.Errorf("invalid poet membership: %w", err)
+			return nil, nil, fmt.Errorf("validating poet membership: %w", err)
 		}
 		nipostSizes[i].ticks = leaves / h.tickSize
 	}
@@ -632,7 +632,7 @@ func (h *HandlerV2) syntacticallyValidateDeps(
 				// TODO generate malfeasance proof
 			}
 			if err != nil {
-				return nil, nil, fmt.Errorf("invalid post for ID %s: %w", id, err)
+				return nil, nil, fmt.Errorf("validating post for ID %s: %w", id.ShortString(), err)
 			}
 			parts.units[id] = post.NumUnits
 		}

--- a/activation/validation.go
+++ b/activation/validation.go
@@ -103,7 +103,7 @@ func (v *Validator) NIPost(
 
 	err := v.Post(ctx, nodeId, commitmentAtxId, nipost.Post, nipost.PostMetadata, numUnits, opts...)
 	if err != nil {
-		return 0, fmt.Errorf("invalid Post: %w", err)
+		return 0, fmt.Errorf("validating Post: %w", err)
 	}
 
 	var ref types.PoetProofRef
@@ -215,7 +215,7 @@ func (v *Validator) Post(
 
 	start := time.Now()
 	if err := v.postVerifier.Verify(ctx, p, m, callOpts...); err != nil {
-		return fmt.Errorf("verify PoST: %w", err)
+		return fmt.Errorf("verifying PoST: %w", err)
 	}
 	metrics.PostVerificationLatency.Observe(time.Since(start).Seconds())
 	return nil


### PR DESCRIPTION
## Motivation

Stabilizing activation E2E tests.

## Description

The E2E tests still fail occasionally. Example: https://github.com/spacemeshos/go-spacemesh/actions/runs/9895521631/job/27335640870

In this run, the context of the ATX builder was canceled while processing the published ATX:

```
Error:      	Received unexpected error:
        	            	atx 903f74a322 syntactically invalid based on deps: invalid post for ID fa4de87e1c2123c6537b15edd6b51d35fb0a6a14ec5b05ac79b7f90e9e4cd746: verify PoST: waiting for verification result: context canceled
```

It turns out that the `ctrl.Satisfied` becomes true before executing the callback passed to `DoAndReturn`. In result, the Builder is stopped immediately and the context passed to the ATX handler is canceled -> test fails.

:bulb: as a bonus, fixed the misleading errors. They should not say that the atx is invalid.

## Test Plan

n/a

## TODO

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [ ] Update documentation as needed
- [ ] Update [changelog](../CHANGELOG.md) as needed
