### PR TITLE
[Merged by Bors] - Fix ATX syncer hangs

### DIFF
--- a/syncer/atxsync/syncer.go
+++ b/syncer/atxsync/syncer.go
@@ -314,10 +314,10 @@ func (s *Syncer) downloadAtxs(
 						if _, exists := state[types.ATXID(hash)]; !exists {
 							continue
 						}
-						if errors.Is(err, fetch.ErrExceedMaxRetries) {
-							state[types.ATXID(hash)]++
-						} else if errors.Is(err, pubsub.ErrValidationReject) {
+						if errors.Is(err, pubsub.ErrValidationReject) {
 							state[types.ATXID(hash)] = s.cfg.RequestsLimit
+						} else {
+							state[types.ATXID(hash)]++
 						}
 					}
 				}

--- a/syncer/atxsync/syncer.go
+++ b/syncer/atxsync/syncer.go
@@ -41,7 +41,7 @@ func DefaultConfig() Config {
 	return Config{
 		EpochInfoInterval: 4 * time.Hour,
 		AtxsBatch:         1000,
-		RequestsLimit:     20,
+		RequestsLimit:     10,
 		EpochInfoPeers:    2,
 		ProgressFraction:  0.1,
 		ProgressInterval:  20 * time.Minute,

--- a/syncer/atxsync/syncer_test.go
+++ b/syncer/atxsync/syncer_test.go
@@ -190,7 +190,7 @@ func TestSyncer(t *testing.T) {
 					}
 					for _, bad := range bad.AtxIDs {
 						if bad == id {
-							berr.Add(bad.Hash32(), fmt.Errorf("%w: test", fetch.ErrExceedMaxRetries))
+							berr.Add(bad.Hash32(), fmt.Errorf("%w: test", errors.New("oh no failed")))
 						}
 					}
 				}


### PR DESCRIPTION
## Motivation

The ATX syncer was observed to be hanging when a peer serves an invalid ATX. It counts only specific errors as failed requests, instead of every failed request and never reaches the configured requests limit.

## Description

Change atxsyncer to count every failure to get an ATX as a failed request. Eventually it will give up on the invalid ATX after reaching the limit.

:bulb: Additionally, decreased the default number of retries from 20 to 10 for the ATX syncer.

:bulb: There is a related problem - the ATX handler should return a `pubsub.ErrValidationReject` for invalid ATXs to drop the malicious peer. It should also be smart enough to bubble up such error from `fetcher.GetAtxs(<deps>)` if the dependency of an ATX (e.g. previous or positioning ATX) turns out to be malicious and cannot be fetched.

## Test Plan

I updated a test to check retries on any error.

## TODO

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [ ] Update documentation as needed
- [ ] Update [changelog](../CHANGELOG.md) as needed
