### PR TITLE
[Merged by Bors] - malfeasance syncer: count every error as a failed request

### DIFF
--- a/syncer/malsync/syncer.go
+++ b/syncer/malsync/syncer.go
@@ -428,10 +428,10 @@ func (s *Syncer) downloadMalfeasanceProofs(ctx context.Context, initial bool, up
 					switch {
 					case !sst.has(nodeID):
 						continue
-					case errors.Is(err, fetch.ErrExceedMaxRetries):
-						sst.failed(nodeID)
 					case errors.Is(err, pubsub.ErrValidationReject):
 						sst.rejected(nodeID)
+					default:
+						sst.failed(nodeID)
 					}
 				}
 			}

--- a/syncer/malsync/syncer_test.go
+++ b/syncer/malsync/syncer_test.go
@@ -338,7 +338,7 @@ func TestSyncer(t *testing.T) {
 		tester.expectPeers(tester.peers)
 		tester.expectGetMaliciousIDs()
 		tester.expectGetProofs(map[types.NodeID]error{
-			nid("2"): fetch.ErrExceedMaxRetries,
+			nid("2"): errors.New("fail"),
 		})
 		epochStart := tester.clock.Now().Truncate(time.Second)
 		epochEnd := epochStart.Add(10 * time.Minute)


### PR DESCRIPTION
## Motivation

Treat every fetch error as a failed request in the malfeasance proofs syncer to avoid hanging if the fetcher returns an unrecognized error.

## Description

## Test Plan

updated test

## TODO

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [ ] Update documentation as needed
- [ ] Update [changelog](../CHANGELOG.md) as needed
