### PR TITLE
[Merged by Bors] - simplify wrong prev ATX check

### DIFF
--- a/activation/handler_v1_test.go
+++ b/activation/handler_v1_test.go
@@ -732,7 +732,6 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 		}))
 		atxHdlr.mtortoise.EXPECT().OnAtx(watx3.PublishEpoch+1, watx3.ID(), gomock.Any())
 		atxHdlr.mtortoise.EXPECT().OnMalfeasance(sig.NodeID())
-		atxHdlr.mclock.EXPECT().CurrentLayer().Return(watx3.PublishEpoch.FirstLayer())
 		proof, err = atxHdlr.storeAtx(context.Background(), atx3, watx3)
 		require.NoError(t, err)
 		require.NotNil(t, proof)

--- a/sql/atxs/atxs.go
+++ b/sql/atxs/atxs.go
@@ -939,7 +939,7 @@ func AtxWithPrevious(db sql.Executor, prev types.ATXID, id types.NodeID) (types.
 		return false
 	}
 	if prev == types.EmptyATXID {
-		rows, err = db.Exec("SELECT id FROM atxs WHERE pubkey = ?1 AND prev_id IS NULL;",
+		rows, err = db.Exec("SELECT id FROM atxs WHERE pubkey = ?1 AND prev_id IS NULL ORDER BY received ASC;",
 			func(s *sql.Statement) {
 				s.BindBytes(1, id.Bytes())
 			},
@@ -947,7 +947,7 @@ func AtxWithPrevious(db sql.Executor, prev types.ATXID, id types.NodeID) (types.
 		)
 	} else {
 		rows, err = db.Exec(`
-		SELECT id FROM atxs WHERE pubkey = ?1 AND prev_id = ?2;`,
+		SELECT id FROM atxs WHERE pubkey = ?1 AND prev_id = ?2 ORDER BY received ASC;`,
 			func(s *sql.Statement) {
 				s.BindBytes(1, id.Bytes())
 				s.BindBytes(2, prev.Bytes())

--- a/sql/atxs/atxs_test.go
+++ b/sql/atxs/atxs_test.go
@@ -1157,7 +1157,7 @@ func Test_AtxWithPrevious(t *testing.T) {
 
 	t.Run("no atxs", func(t *testing.T) {
 		db := sql.InMemory()
-		_, err := atxs.AtxWithPrevious(db, prev, types.RandomATXID(), sig.NodeID())
+		_, err := atxs.AtxWithPrevious(db, prev, sig.NodeID())
 		require.ErrorIs(t, err, sql.ErrNotFound)
 	})
 	t.Run("finds other ATX with same previous", func(t *testing.T) {
@@ -1166,7 +1166,7 @@ func Test_AtxWithPrevious(t *testing.T) {
 		atx, blob := newAtx(t, sig)
 		require.NoError(t, atxs.Add(db, atx, blob))
 
-		id, err := atxs.AtxWithPrevious(db, atx.PrevATXID, types.RandomATXID(), sig.NodeID())
+		id, err := atxs.AtxWithPrevious(db, atx.PrevATXID, sig.NodeID())
 		require.NoError(t, err)
 		require.Equal(t, atx.ID(), id)
 	})
@@ -1176,41 +1176,7 @@ func Test_AtxWithPrevious(t *testing.T) {
 		atx, blob := newAtx(t, sig, withPrevATXID(types.EmptyATXID))
 		require.NoError(t, atxs.Add(db, atx, blob))
 
-		id, err := atxs.AtxWithPrevious(db, atx.PrevATXID, types.RandomATXID(), sig.NodeID())
-		require.NoError(t, err)
-		require.Equal(t, atx.ID(), id)
-	})
-	t.Run("filters out by ATX ID", func(t *testing.T) {
-		db := sql.InMemory()
-
-		atx, blob := newAtx(t, sig)
-		require.NoError(t, atxs.Add(db, atx, blob))
-
-		atx2, blob := newAtx(t, sig, withPrevATXID(atx.PrevATXID))
-		require.NoError(t, atxs.Add(db, atx2, blob))
-
-		id, err := atxs.AtxWithPrevious(db, atx.PrevATXID, atx.ID(), sig.NodeID())
-		require.NoError(t, err)
-		require.Equal(t, atx2.ID(), id)
-
-		id, err = atxs.AtxWithPrevious(db, atx.PrevATXID, atx2.ID(), sig.NodeID())
-		require.NoError(t, err)
-		require.Equal(t, atx.ID(), id)
-	})
-	t.Run("filters out by ATX ID (empty)", func(t *testing.T) {
-		db := sql.InMemory()
-
-		atx, blob := newAtx(t, sig, withPrevATXID(types.EmptyATXID))
-		require.NoError(t, atxs.Add(db, atx, blob))
-
-		atx2, blob := newAtx(t, sig, withPrevATXID(types.EmptyATXID))
-		require.NoError(t, atxs.Add(db, atx2, blob))
-
-		id, err := atxs.AtxWithPrevious(db, atx.PrevATXID, atx.ID(), sig.NodeID())
-		require.NoError(t, err)
-		require.Equal(t, atx2.ID(), id)
-
-		id, err = atxs.AtxWithPrevious(db, atx.PrevATXID, atx2.ID(), sig.NodeID())
+		id, err := atxs.AtxWithPrevious(db, atx.PrevATXID, sig.NodeID())
 		require.NoError(t, err)
 		require.Equal(t, atx.ID(), id)
 	})
@@ -1226,11 +1192,11 @@ func Test_AtxWithPrevious(t *testing.T) {
 		atx2, blob := newAtx(t, sig2, withPrevATXID(types.EmptyATXID))
 		require.NoError(t, atxs.Add(db, atx2, blob))
 
-		id, err := atxs.AtxWithPrevious(db, atx.PrevATXID, types.RandomATXID(), sig.NodeID())
+		id, err := atxs.AtxWithPrevious(db, atx.PrevATXID, sig.NodeID())
 		require.NoError(t, err)
 		require.Equal(t, atx.ID(), id)
 
-		id, err = atxs.AtxWithPrevious(db, atx.PrevATXID, types.RandomATXID(), sig2.NodeID())
+		id, err = atxs.AtxWithPrevious(db, atx.PrevATXID, sig2.NodeID())
 		require.NoError(t, err)
 		require.Equal(t, atx2.ID(), id)
 	})


### PR DESCRIPTION
## Motivation

Simplify the check for a wrong previous ATX (V1).

## Description

The check could be simplified as we have a `prev_id` column in `atxs` table. It is enough to look up another ATX with the same previous ATX as the one subject to check.

## Test Plan

existing tests pass, added tests for the new function

## TODO

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [ ] Update documentation as needed
- [ ] Update [changelog](../CHANGELOG.md) as needed
