### PR TITLE
[Merged by Bors] - fix(fetch): close completed channel once

### DIFF
--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -58,6 +58,7 @@ type request struct {
 }
 
 type promise struct {
+	once      sync.Once
 	completed chan struct{}
 	err       error
 }
@@ -435,10 +436,10 @@ func (f *Fetch) Stop() {
 	f.cancel()
 	f.mu.Lock()
 	for _, req := range f.unprocessed {
-		close(req.promise.completed)
+		req.promise.once.Do(func() { close(req.promise.completed) })
 	}
 	for _, req := range f.ongoing {
-		close(req.promise.completed)
+		req.promise.once.Do(func() { close(req.promise.completed) })
 	}
 	f.mu.Unlock()
 
@@ -589,7 +590,7 @@ func (f *Fetch) hashValidationDone(hash types.Hash32, err error) {
 	} else {
 		f.logger.Debug("hash request done", log.ZContext(req.ctx), zap.Stringer("hash", hash))
 	}
-	close(req.promise.completed)
+	req.promise.once.Do(func() { close(req.promise.completed) })
 	delete(f.ongoing, hash)
 }
 
@@ -605,7 +606,7 @@ func (f *Fetch) failAfterRetry(hash types.Hash32) {
 
 	// first check if we have it locally from gossips
 	if has, err := f.bs.Has(req.hint, hash.Bytes()); err == nil && has {
-		close(req.promise.completed)
+		req.promise.once.Do(func() { close(req.promise.completed) })
 		delete(f.ongoing, hash)
 		return
 	}
@@ -618,7 +619,8 @@ func (f *Fetch) failAfterRetry(hash types.Hash32) {
 			zap.Int("retries", req.retries),
 		)
 		req.promise.err = ErrExceedMaxRetries
-		close(req.promise.completed)
+		req.promise.once.Do(func() { close(req.promise.completed) })
+
 	} else {
 		// put the request back to the unprocessed list
 		f.unprocessed[req.hash] = req
@@ -703,7 +705,7 @@ func (f *Fetch) organizeRequests(requests []RequestMessage) map[p2p.Peer][]*batc
 		for _, msg := range requests {
 			if req, ok := f.ongoing[msg.Hash]; ok {
 				req.promise.err = errNoPeer
-				close(req.promise.completed)
+				req.promise.once.Do(func() { close(req.promise.completed) })
 				delete(f.ongoing, req.hash)
 			} else {
 				f.logger.Error("ongoing request missing",
@@ -918,7 +920,7 @@ func (f *Fetch) handleHashError(batch *batchInfo, err error) {
 		f.logger.Debug("hash request failed", log.ZContext(req.ctx), zap.Stringer("hash", req.hash), zap.Error(err))
 		req.promise.err = err
 		peerErrors.WithLabelValues(string(req.hint)).Inc()
-		close(req.promise.completed)
+		req.promise.once.Do(func() { close(req.promise.completed) })
 		delete(f.ongoing, req.hash)
 	}
 }
@@ -956,7 +958,7 @@ func (f *Fetch) getHash(
 			hint:      h,
 			validator: receiver,
 			promise: &promise{
-				completed: make(chan struct{}, 1),
+				completed: make(chan struct{}),
 			},
 		}
 		f.logger.Debug("hash request added to queue",


### PR DESCRIPTION
## Motivation

Close completed channel once can be closed multiple times and may cause a panic. This fix adds a use of a `sync.Once` to handle this possible edge case.

## Description

The `completed` channel may be closed multiple times from different locations in the `fetch` package. It is difficult to reason about the origin of this panic. I am therefore adding a `sync.Once` to the `promise` type so that we can make sure that this only happens once.

Closes #5436 

## Test Plan

- tests passing

## TODO

<!-- Please tick off the TODOs when completed -->

- [ ] Explain motivation or link existing issue(s)
- [ ] Test changes and document test plan
- [ ] Update documentation as needed
- [ ] Update [changelog](../CHANGELOG.md) as needed
