### PR TITLE
[Merged by Bors] - don't run unit tests on macos-13 runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,7 +228,8 @@ jobs:
         os:
           - ubuntu-22.04
           - ubuntu-latest-arm-8-cores
-          - macos-13
+          # FIXME: reenable the macos runner
+          # - macos-13
           - [self-hosted, macOS, ARM64, go-spacemesh]
           - windows-2022
     steps:


### PR DESCRIPTION
## Motivation

The tests are flaky on this runner because it is sometimes extremely slow.

## Description

<!-- If applicable please mention the issue addressed by this PR -->
<!-- `Closes #XXXX` links mentioned issues to this PR and automatically closes them when this it's merged -->

<!-- Please describe in detail the changes made. Focus on the reasoning rather than describing the change -->

## Test Plan

<!-- Please specify how these changes were tested (e.g. unit tests, manual testing, etc.) -->

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [ ] Test changes and document test plan
- [ ] Update documentation as needed
- [ ] Update [changelog](../CHANGELOG.md) as needed
