### PR TITLE
[Merged by Bors] - test(systest): add fail-fast for systests

### DIFF
--- a/systest/Makefile
+++ b/systest/Makefile
@@ -23,6 +23,7 @@ storage ?= standard=1Gi
 node_selector ?=
 namespace ?=
 count ?= 1
+failfast ?= true
 
 configname ?= $(test_job_name)
 smesher_config ?= parameters/fastnet/smesher.json
@@ -35,8 +36,12 @@ ifeq ($(configname),$(test_job_name))
 	run_deps = config
 endif
 
-command := tests -test.v -test.count=$(count) -test.failfast -test.timeout=0 -test.run=$(test_name) -clusters=$(clusters) \
+command := tests -test.v -test.count=$(count) -test.timeout=0 -test.run=$(test_name) -clusters=$(clusters) \
 -level=$(level) -configname=$(configname)
+
+ifeq ($(failfast),true)
+	command := $(command) -test.failfast
+endif
 
 .PHONY: docker
 docker:

--- a/systest/Makefile
+++ b/systest/Makefile
@@ -35,7 +35,7 @@ ifeq ($(configname),$(test_job_name))
 	run_deps = config
 endif
 
-command := tests -test.v -test.count=$(count) -test.timeout=0 -test.run=$(test_name) -clusters=$(clusters) \
+command := tests -test.v -test.count=$(count) -test.failfast -test.timeout=0 -test.run=$(test_name) -clusters=$(clusters) \
 -level=$(level) -configname=$(configname)
 
 .PHONY: docker


### PR DESCRIPTION
## Motivation

systests appear to continue execution of all tests regardless if one of them failed.


## Description
This change might be debatable, because we might want to keep the configuration as is and avoid the fail-fast. One might argue that it doesn't matter if one test failed or all of them and it is better to just know earlier that the flow failed rather than having to wait for a full hour to get the signal.

If the systests weren't flaky I'd say it _might_ be better to know _which_ of the tests failed (maybe multiple, maybe just one out of all). But I'm not sure that right now this is actually of any use and maybe having a faster workflow is better for everyone.

Example can be seen here: https://github.com/spacemeshos/go-spacemesh/actions/runs/10014040215/job/27682907862 (look for `fail:` in the logs).

Opening to discussion and happy to close this if there's resistance.


## Test Plan



## TODO

- [ ] Explain motivation or link existing issue(s)
- [ ] Test changes and document test plan
- [ ] Update documentation as needed
- [ ] Update [changelog](../CHANGELOG.md) as needed
