### PR TITLE
Systest: Update kubernetes client-go dependency and configure rate limiter

### DIFF
--- a/systest/testcontext/context.go
+++ b/systest/testcontext/context.go
@@ -289,7 +289,9 @@ func New(t *testing.T, opts ...Opt) *Context {
 		t.Cleanup(func() { <-tokens })
 	}
 	config, err := rest.InClusterConfig()
-	config.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(20, 50) // The default rate limiter is too slow 5qps and 10 burst, This will prevent the client from being throttled
+
+	// The default rate limiter is too slow 5qps and 10 burst, This will prevent the client from being throttled
+	config.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(20, 50)
 	require.NoError(t, err)
 
 	clientset, err := kubernetes.NewForConfig(config)

--- a/systest/testcontext/context.go
+++ b/systest/testcontext/context.go
@@ -24,6 +24,7 @@ import (
 	corev1 "k8s.io/client-go/applyconfigurations/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/util/flowcontrol"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	k8szap "sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -288,6 +289,7 @@ func New(t *testing.T, opts ...Opt) *Context {
 		t.Cleanup(func() { <-tokens })
 	}
 	config, err := rest.InClusterConfig()
+	config.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(20, 50) // The default rate limiter is too slow 5qps and 10 burst, This will prevent the client from being throttled
 	require.NoError(t, err)
 
 	clientset, err := kubernetes.NewForConfig(config)


### PR DESCRIPTION
The code changes update the kubernetes client-go dependency and configure a rate limiter to prevent the client from being throttled. This improves the performance and prevents the client from being slowed down.

## Motivation

To reduce the client throttling during the systest execution, the client limits was increased 4x

## Test Plan

run the systest pipeline, and not find any client throttling warning.
- "due to client-side throttling, not priority and fairness, request"


## TODO

<!-- Please tick off the TODOs when completed -->

- [X] Explain motivation or link existing issue(s)
- [X] Test changes and document test plan
- [ ] Update [changelog](../CHANGELOG.md) as needed
