### PR TITLE
[Merged by Bors] - Fix api-swagger-ui workflow trigger

### DIFF
--- a/.github/workflows/api-swagger-ui.yml
+++ b/.github/workflows/api-swagger-ui.yml
@@ -5,7 +5,7 @@ env:
 
 on:
   release:
-    types: [published]
+    types: [created]
     
 jobs:
   check-version:


### PR DESCRIPTION
## Motivation

Fix the api-swagger-ui workflow trigger.

## Description

Change the GitHub Actions workflow to modify the release type to "created." This change addresses an issue where the previous release type, "published," did not pick up the release created by the release.yaml gh-action.



