### PR TITLE
[Merged by Bors] - Fix merge tool not ignoring OS files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ See [RELEASE](./RELEASE.md) for workflow instructions.
 
 * [#6185](https://github.com/spacemeshos/go-spacemesh/pull/6185) Optimize mempool
 
+* [#6187](https://github.com/spacemeshos/go-spacemesh/pull/6187) The merge tool now ignores files that are not `.key`
+  files in the `identities` directory when merging two nodes.
+
 ## Release v1.6.4
 
 ### Improvements

--- a/cmd/merge-nodes/internal/merge_action.go
+++ b/cmd/merge-nodes/internal/merge_action.go
@@ -97,10 +97,18 @@ func MergeDBs(ctx context.Context, dbLog *zap.Logger, from, to string) error {
 	if err != nil {
 		return fmt.Errorf("read target key directory: %w", err)
 	}
+	toKeyDirFiles = slices.DeleteFunc(toKeyDirFiles, func(e fs.DirEntry) bool {
+		// skip files that are not identity files
+		return filepath.Ext(e.Name()) != ".key"
+	})
 	fromKeyDirFiles, err := os.ReadDir(fromKeyDir)
 	if err != nil {
 		return fmt.Errorf("read source key directory: %w", err)
 	}
+	fromKeyDirFiles = slices.DeleteFunc(fromKeyDirFiles, func(e fs.DirEntry) bool {
+		// skip files that are not identity files
+		return filepath.Ext(e.Name()) != ".key"
+	})
 	for _, toFile := range toKeyDirFiles {
 		for _, fromFile := range fromKeyDirFiles {
 			if toFile.Name() == fromFile.Name() {

--- a/cmd/merge-nodes/internal/merge_action_test.go
+++ b/cmd/merge-nodes/internal/merge_action_test.go
@@ -215,7 +215,8 @@ func Test_MergeDBs_Successful_Existing_Node(t *testing.T) {
 	require.NoError(t, err)
 
 	// this file should be ignored
-	err = os.WriteFile(filepath.Join(tmpDst, keyDir, ".DS_Store"), types.RandomBytes(20), 0o600)
+	dstContent := types.RandomBytes(20)
+	err = os.WriteFile(filepath.Join(tmpDst, keyDir, ".DS_Store"), dstContent, 0o600)
 	require.NoError(t, err)
 
 	dstDB, err := localsql.Open("file:" + filepath.Join(tmpDst, localDbFile))
@@ -271,8 +272,10 @@ func Test_MergeDBs_Successful_Existing_Node(t *testing.T) {
 	err = os.WriteFile(filepath.Join(tmpSrc, keyDir, "id2.key"), key, 0o600)
 	require.NoError(t, err)
 
-	// this file should be ignored
+	// these files should be ignored
 	err = os.WriteFile(filepath.Join(tmpSrc, keyDir, ".DS_Store"), types.RandomBytes(20), 0o600)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(tmpSrc, keyDir, "desktop.ini"), types.RandomBytes(20), 0o600)
 	require.NoError(t, err)
 
 	srcDB, err := localsql.Open("file:" + filepath.Join(tmpSrc, localDbFile))
@@ -327,6 +330,11 @@ func Test_MergeDBs_Successful_Existing_Node(t *testing.T) {
 
 	require.FileExists(t, filepath.Join(tmpDst, keyDir, "id1.key"))
 	require.FileExists(t, filepath.Join(tmpDst, keyDir, "id2.key"))
+	require.FileExists(t, filepath.Join(tmpDst, keyDir, ".DS_Store"))
+	content, err := os.ReadFile(filepath.Join(tmpDst, keyDir, ".DS_Store"))
+	require.NoError(t, err)
+	require.Equal(t, dstContent, content)
+	require.NoFileExists(t, filepath.Join(tmpDst, keyDir, "desktop.ini"))
 
 	dstDB, err = localsql.Open("file:" + filepath.Join(tmpDst, localDbFile))
 	require.NoError(t, err)

--- a/cmd/merge-nodes/internal/merge_action_test.go
+++ b/cmd/merge-nodes/internal/merge_action_test.go
@@ -214,6 +214,10 @@ func Test_MergeDBs_Successful_Existing_Node(t *testing.T) {
 	err = os.WriteFile(filepath.Join(tmpDst, keyDir, "id1.key"), key, 0o600)
 	require.NoError(t, err)
 
+	// this file should be ignored
+	err = os.WriteFile(filepath.Join(tmpDst, keyDir, ".DS_Store"), types.RandomBytes(20), 0o600)
+	require.NoError(t, err)
+
 	dstDB, err := localsql.Open("file:" + filepath.Join(tmpDst, localDbFile))
 	require.NoError(t, err)
 
@@ -265,6 +269,10 @@ func Test_MergeDBs_Successful_Existing_Node(t *testing.T) {
 	key = make([]byte, hex.EncodedLen(len(sig2.PrivateKey())))
 	hex.Encode(key, sig2.PrivateKey())
 	err = os.WriteFile(filepath.Join(tmpSrc, keyDir, "id2.key"), key, 0o600)
+	require.NoError(t, err)
+
+	// this file should be ignored
+	err = os.WriteFile(filepath.Join(tmpSrc, keyDir, ".DS_Store"), types.RandomBytes(20), 0o600)
 	require.NoError(t, err)
 
 	srcDB, err := localsql.Open("file:" + filepath.Join(tmpSrc, localDbFile))


### PR DESCRIPTION
## Motivation

The merge tool right now copies over all files in the identities directory (including files like `.DS_Store` and `desktop.ini`). Since those are likely to be present in both locations this can block the merge tool until they are manually deleted.

This PR fixes this issue.

## Description

The merge tool now only copies `*.key` files and ignores everything else present in the `identities` folder.

## Test Plan

- existing tests pass, new test was added

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
