### PR TITLE
[Merged by Bors] - fallback to PoW if cannot recertify for poet

### DIFF
--- a/activation/certifier.go
+++ b/activation/certifier.go
@@ -138,7 +138,6 @@ func (c *Certifier) DeleteCertificate(id types.NodeID, pubkey []byte) error {
 	if err := certifierdb.DeleteCertificate(c.db, id, pubkey); err != nil {
 		return err
 	}
-	c.certifications.Forget(string(append(id.Bytes(), pubkey...)))
 	return nil
 }
 

--- a/activation/certifier.go
+++ b/activation/certifier.go
@@ -117,7 +117,15 @@ func (c *Certifier) Certificate(
 		case !errors.Is(err, sql.ErrNotFound):
 			return nil, fmt.Errorf("getting certificate from DB for: %w", err)
 		}
-		return c.Recertify(ctx, id, certifier, pubkey)
+		cert, err = c.client.Certify(ctx, id, certifier, pubkey)
+		if err != nil {
+			return nil, fmt.Errorf("certifying POST at %v: %w", certifier, err)
+		}
+
+		if err := certifierdb.AddCertificate(c.db, id, *cert, pubkey); err != nil {
+			c.logger.Warn("failed to persist poet cert", zap.Error(err))
+		}
+		return cert, nil
 	})
 
 	if err != nil {
@@ -126,21 +134,12 @@ func (c *Certifier) Certificate(
 	return cert.(*certifierdb.PoetCert), nil
 }
 
-func (c *Certifier) Recertify(
-	ctx context.Context,
-	id types.NodeID,
-	certifier *url.URL,
-	pubkey []byte,
-) (*certifierdb.PoetCert, error) {
-	cert, err := c.client.Certify(ctx, id, certifier, pubkey)
-	if err != nil {
-		return nil, fmt.Errorf("certifying POST at %v: %w", certifier, err)
+func (c *Certifier) DeleteCertificate(id types.NodeID, pubkey []byte) error {
+	if err := certifierdb.DeleteCertificate(c.db, id, pubkey); err != nil {
+		return err
 	}
-
-	if err := certifierdb.AddCertificate(c.db, id, *cert, pubkey); err != nil {
-		c.logger.Warn("failed to persist poet cert", zap.Error(err))
-	}
-	return cert, nil
+	c.certifications.Forget(string(append(id.Bytes(), pubkey...)))
+	return nil
 }
 
 type CertifierClient struct {

--- a/activation/interface.go
+++ b/activation/interface.go
@@ -176,12 +176,7 @@ type certifierService interface {
 		pubkey []byte,
 	) (*certifier.PoetCert, error)
 
-	Recertify(
-		ctx context.Context,
-		id types.NodeID,
-		certifierAddress *url.URL,
-		pubkey []byte,
-	) (*certifier.PoetCert, error)
+	DeleteCertificate(id types.NodeID, pubkey []byte) error
 }
 
 type poetDbAPI interface {

--- a/activation/mocks.go
+++ b/activation/mocks.go
@@ -1935,41 +1935,40 @@ func (c *MockcertifierServiceCertificateCall) DoAndReturn(f func(context.Context
 	return c
 }
 
-// Recertify mocks base method.
-func (m *MockcertifierService) Recertify(ctx context.Context, id types.NodeID, certifierAddress *url.URL, pubkey []byte) (*certifier.PoetCert, error) {
+// DeleteCertificate mocks base method.
+func (m *MockcertifierService) DeleteCertificate(id types.NodeID, pubkey []byte) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Recertify", ctx, id, certifierAddress, pubkey)
-	ret0, _ := ret[0].(*certifier.PoetCert)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret := m.ctrl.Call(m, "DeleteCertificate", id, pubkey)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-// Recertify indicates an expected call of Recertify.
-func (mr *MockcertifierServiceMockRecorder) Recertify(ctx, id, certifierAddress, pubkey any) *MockcertifierServiceRecertifyCall {
+// DeleteCertificate indicates an expected call of DeleteCertificate.
+func (mr *MockcertifierServiceMockRecorder) DeleteCertificate(id, pubkey any) *MockcertifierServiceDeleteCertificateCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Recertify", reflect.TypeOf((*MockcertifierService)(nil).Recertify), ctx, id, certifierAddress, pubkey)
-	return &MockcertifierServiceRecertifyCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCertificate", reflect.TypeOf((*MockcertifierService)(nil).DeleteCertificate), id, pubkey)
+	return &MockcertifierServiceDeleteCertificateCall{Call: call}
 }
 
-// MockcertifierServiceRecertifyCall wrap *gomock.Call
-type MockcertifierServiceRecertifyCall struct {
+// MockcertifierServiceDeleteCertificateCall wrap *gomock.Call
+type MockcertifierServiceDeleteCertificateCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockcertifierServiceRecertifyCall) Return(arg0 *certifier.PoetCert, arg1 error) *MockcertifierServiceRecertifyCall {
-	c.Call = c.Call.Return(arg0, arg1)
+func (c *MockcertifierServiceDeleteCertificateCall) Return(arg0 error) *MockcertifierServiceDeleteCertificateCall {
+	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockcertifierServiceRecertifyCall) Do(f func(context.Context, types.NodeID, *url.URL, []byte) (*certifier.PoetCert, error)) *MockcertifierServiceRecertifyCall {
+func (c *MockcertifierServiceDeleteCertificateCall) Do(f func(types.NodeID, []byte) error) *MockcertifierServiceDeleteCertificateCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockcertifierServiceRecertifyCall) DoAndReturn(f func(context.Context, types.NodeID, *url.URL, []byte) (*certifier.PoetCert, error)) *MockcertifierServiceRecertifyCall {
+func (c *MockcertifierServiceDeleteCertificateCall) DoAndReturn(f func(types.NodeID, []byte) error) *MockcertifierServiceDeleteCertificateCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/activation/poet_client_test.go
+++ b/activation/poet_client_test.go
@@ -1,7 +1,9 @@
 package activation
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -366,8 +368,9 @@ func TestPoetClient_RecertifiesOnAuthFailure(t *testing.T) {
 		mCertifier.EXPECT().
 			Certificate(gomock.Any(), sig.NodeID(), certifierAddress, certifierPubKey).
 			Return(&certifier.PoetCert{Data: []byte("first")}, nil),
+		mCertifier.EXPECT().DeleteCertificate(sig.NodeID(), certifierPubKey),
 		mCertifier.EXPECT().
-			Recertify(gomock.Any(), sig.NodeID(), certifierAddress, certifierPubKey).
+			Certificate(gomock.Any(), sig.NodeID(), certifierAddress, certifierPubKey).
 			Return(&certifier.PoetCert{Data: []byte("second")}, nil),
 	)
 
@@ -380,6 +383,80 @@ func TestPoetClient_RecertifiesOnAuthFailure(t *testing.T) {
 	require.Equal(t, 2, submitCount)
 	require.EqualValues(t, "first", <-certs)
 	require.EqualValues(t, "second", <-certs)
+}
+
+func TestPoetClient_FallbacksToPowWhenCannotRecertify(t *testing.T) {
+	t.Parallel()
+
+	sig, err := signing.NewEdSigner()
+	require.NoError(t, err)
+
+	certifierAddress := &url.URL{Scheme: "http", Host: "certifier"}
+	certifierPubKey := []byte("certifier-pubkey")
+
+	mux := http.NewServeMux()
+	infoResp, err := protojson.Marshal(&rpcapi.InfoResponse{
+		ServicePubkey: []byte("pubkey"),
+		Certifier: &rpcapi.InfoResponse_Cerifier{
+			Url:    certifierAddress.String(),
+			Pubkey: certifierPubKey,
+		},
+	})
+	require.NoError(t, err)
+	mux.HandleFunc("GET /v1/info", func(w http.ResponseWriter, r *http.Request) { w.Write(infoResp) })
+
+	powChallenge := []byte("challenge")
+	powResp, err := protojson.Marshal(&rpcapi.PowParamsResponse{PowParams: &rpcapi.PowParams{Challenge: powChallenge}})
+	require.NoError(t, err)
+	mux.HandleFunc("GET /v1/pow_params", func(w http.ResponseWriter, r *http.Request) { w.Write(powResp) })
+
+	submitResp, err := protojson.Marshal(&rpcapi.SubmitResponse{})
+	require.NoError(t, err)
+	submitCount := 0
+	mux.HandleFunc("POST /v1/submit", func(w http.ResponseWriter, r *http.Request) {
+		req := rpcapi.SubmitRequest{}
+		body, _ := io.ReadAll(r.Body)
+		protojson.Unmarshal(body, &req)
+
+		switch {
+		case submitCount == 0:
+			w.WriteHeader(http.StatusUnauthorized)
+		case submitCount == 1 && req.Certificate == nil && bytes.Equal(req.PowParams.Challenge, powChallenge):
+			w.Write(submitResp)
+		default:
+			w.WriteHeader(http.StatusUnauthorized)
+		}
+		submitCount++
+	})
+
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	server := types.PoetServer{
+		Address: ts.URL,
+		Pubkey:  types.NewBase64Enc([]byte("pubkey")),
+	}
+	cfg := PoetConfig{CertifierInfoCacheTTL: time.Hour}
+
+	ctrl := gomock.NewController(t)
+	mCertifier := NewMockcertifierService(ctrl)
+	gomock.InOrder(
+		mCertifier.EXPECT().
+			Certificate(gomock.Any(), sig.NodeID(), certifierAddress, certifierPubKey).
+			Return(&certifier.PoetCert{Data: []byte("first")}, nil),
+		mCertifier.EXPECT().DeleteCertificate(sig.NodeID(), certifierPubKey),
+		mCertifier.EXPECT().
+			Certificate(gomock.Any(), sig.NodeID(), certifierAddress, certifierPubKey).
+			Return(nil, errors.New("cannot recertify")),
+	)
+
+	client, err := NewHTTPPoetClient(server, cfg, withCustomHttpClient(ts.Client()))
+	require.NoError(t, err)
+	poet := NewPoetServiceWithClient(nil, client, cfg, zaptest.NewLogger(t), WithCertifier(mCertifier))
+
+	_, err = poet.Submit(context.Background(), time.Time{}, nil, nil, types.RandomEdSignature(), sig.NodeID())
+	require.NoError(t, err)
+	require.Equal(t, 2, submitCount)
 }
 
 func TestPoetService_CachesCertifierInfo(t *testing.T) {

--- a/sql/localsql/certifier/db.go
+++ b/sql/localsql/certifier/db.go
@@ -28,6 +28,19 @@ func AddCertificate(db sql.Executor, nodeID types.NodeID, cert PoetCert, cerifie
 	return nil
 }
 
+func DeleteCertificate(db sql.Executor, nodeID types.NodeID, certifierID []byte) error {
+	enc := func(stmt *sql.Statement) {
+		stmt.BindBytes(1, nodeID.Bytes())
+		stmt.BindBytes(2, certifierID)
+	}
+	if _, err := db.Exec(`
+		DELETE FROM poet_certificates WHERE node_id = ?1 AND certifier_id = ?2;`, enc, nil,
+	); err != nil {
+		return fmt.Errorf("deleting poet certificate for (%s; %x): %w", nodeID.ShortString(), certifierID, err)
+	}
+	return nil
+}
+
 func Certificate(db sql.Executor, nodeID types.NodeID, certifierID []byte) (*PoetCert, error) {
 	enc := func(stmt *sql.Statement) {
 		stmt.BindBytes(1, nodeID.Bytes())


### PR DESCRIPTION
## Motivation

Fallback to PoW if cannot recertify after poet registration failed with 401 (unauthorized).

## Description


## Test Plan

added a test covering this scenario

## TODO

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [ ] Update documentation as needed
- [ ] Update [changelog](../CHANGELOG.md) as needed
