### PR TITLE
[Merged by Bors] - cache poet's /v1/pow_params with TTL

### DIFF
--- a/activation/activation.go
+++ b/activation/activation.go
@@ -46,6 +46,7 @@ type PoetConfig struct {
 	RequestRetryDelay              time.Duration `mapstructure:"retry-delay"`
 	PositioningATXSelectionTimeout time.Duration `mapstructure:"positioning-atx-selection-timeout"`
 	CertifierInfoCacheTTL          time.Duration `mapstructure:"certifier-info-cache-ttl"`
+	PowParamsCacheTTL              time.Duration `mapstructure:"pow-params-cache-ttl"`
 	MaxRequestRetries              int           `mapstructure:"retry-max"`
 }
 
@@ -54,6 +55,7 @@ func DefaultPoetConfig() PoetConfig {
 		RequestRetryDelay:     400 * time.Millisecond,
 		MaxRequestRetries:     10,
 		CertifierInfoCacheTTL: 5 * time.Minute,
+		PowParamsCacheTTL:     5 * time.Minute,
 	}
 }
 

--- a/activation/poet.go
+++ b/activation/poet.go
@@ -333,9 +333,29 @@ func (c *HTTPPoetClient) req(ctx context.Context, method, path string, reqBody, 
 }
 
 type certifierInfo struct {
-	obtained time.Time
-	url      *url.URL
-	pubkey   []byte
+	url    *url.URL
+	pubkey []byte
+}
+
+type cachedData[T any] struct {
+	mu   sync.Mutex
+	data T
+	exp  time.Time
+	ttl  time.Duration
+}
+
+func (c *cachedData[T]) get(init func() (T, error)) (T, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if time.Now().Before(c.exp) {
+		return c.data, nil
+	}
+	d, err := init()
+	if err == nil {
+		c.data = d
+		c.exp = time.Now().Add(c.ttl)
+	}
+	return d, err
 }
 
 // poetService is a higher-level interface to communicate with a PoET service.
@@ -353,9 +373,8 @@ type poetService struct {
 
 	certifier certifierService
 
-	certifierInfoTTL   time.Duration
-	certifierInfo      certifierInfo
-	certifierInfoMutex sync.Mutex
+	certifierInfoCache cachedData[*certifierInfo]
+	powParamsCache     cachedData[*PoetPowParams]
 }
 
 type PoetServiceOpt func(*poetService)
@@ -394,12 +413,13 @@ func NewPoetServiceWithClient(
 	opts ...PoetServiceOpt,
 ) *poetService {
 	poetClient := &poetService{
-		db:               db,
-		logger:           logger,
-		client:           client,
-		requestTimeout:   cfg.RequestTimeout,
-		certifierInfoTTL: cfg.CertifierInfoCacheTTL,
-		proofMembers:     make(map[string][]types.Hash32, 1),
+		db:                 db,
+		logger:             logger,
+		client:             client,
+		requestTimeout:     cfg.RequestTimeout,
+		certifierInfoCache: cachedData[*certifierInfo]{ttl: cfg.CertifierInfoCacheTTL},
+		powParamsCache:     cachedData[*PoetPowParams]{ttl: cfg.PowParamsCacheTTL},
+		proofMembers:       make(map[string][]types.Hash32, 1),
 	}
 
 	for _, opt := range opts {
@@ -435,7 +455,7 @@ func (c *poetService) authorize(
 	logger.Debug("querying for poet pow parameters")
 	powCtx, cancel := withConditionalTimeout(ctx, c.requestTimeout)
 	defer cancel()
-	powParams, err := c.client.PowParams(powCtx)
+	powParams, err := c.powParams(powCtx)
 	if err != nil {
 		return nil, &PoetSvcUnstableError{msg: "failed to get PoW params", source: err}
 	}
@@ -552,19 +572,18 @@ func (c *poetService) recertify(ctx context.Context, id types.NodeID) (*certifie
 }
 
 func (c *poetService) getCertifierInfo(ctx context.Context) (*url.URL, []byte, error) {
-	c.certifierInfoMutex.Lock()
-	defer c.certifierInfoMutex.Unlock()
-	if time.Since(c.certifierInfo.obtained) < c.certifierInfoTTL {
-		return c.certifierInfo.url, c.certifierInfo.pubkey, nil
-	}
-	url, pubkey, err := c.client.CertifierInfo(ctx)
-	if err != nil {
-		return nil, nil, fmt.Errorf("getting certifier info: %w", err)
-	}
-	c.certifierInfo = certifierInfo{
-		obtained: time.Now(),
-		url:      url,
-		pubkey:   pubkey,
-	}
-	return c.certifierInfo.url, c.certifierInfo.pubkey, nil
+	info, err := c.certifierInfoCache.get(func() (*certifierInfo, error) {
+		url, pubkey, err := c.client.CertifierInfo(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("getting certifier info: %w", err)
+		}
+		return &certifierInfo{url: url, pubkey: pubkey}, nil
+	})
+	return info.url, info.pubkey, err
+}
+
+func (c *poetService) powParams(ctx context.Context) (*PoetPowParams, error) {
+	return c.powParamsCache.get(func() (*PoetPowParams, error) {
+		return c.client.PowParams(ctx)
+	})
 }

--- a/activation/poet.go
+++ b/activation/poet.go
@@ -579,7 +579,11 @@ func (c *poetService) getCertifierInfo(ctx context.Context) (*url.URL, []byte, e
 		}
 		return &certifierInfo{url: url, pubkey: pubkey}, nil
 	})
-	return info.url, info.pubkey, err
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return info.url, info.pubkey, nil
 }
 
 func (c *poetService) powParams(ctx context.Context) (*PoetPowParams, error) {

--- a/activation/poet_client_test.go
+++ b/activation/poet_client_test.go
@@ -414,3 +414,37 @@ func TestPoetService_CachesCertifierInfo(t *testing.T) {
 		})
 	}
 }
+
+func TestPoetService_CachesPowParams(t *testing.T) {
+	t.Parallel()
+	type test struct {
+		name string
+		ttl  time.Duration
+	}
+	for _, tc := range []test{
+		{name: "cache enabled", ttl: time.Hour},
+		{name: "cache disabled"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := DefaultPoetConfig()
+			cfg.PowParamsCacheTTL = tc.ttl
+			client := NewMockPoetClient(gomock.NewController(t))
+			poet := NewPoetServiceWithClient(nil, client, cfg, zaptest.NewLogger(t))
+
+			params := PoetPowParams{
+				Challenge:  types.RandomBytes(10),
+				Difficulty: 8,
+			}
+			exp := client.EXPECT().PowParams(gomock.Any()).Return(&params, nil)
+			if tc.ttl == 0 {
+				exp.Times(5)
+			}
+			for range 5 {
+				got, err := poet.powParams(context.Background())
+				require.NoError(t, err)
+				require.Equal(t, params, *got)
+			}
+		})
+	}
+}

--- a/config/mainnet.go
+++ b/config/mainnet.go
@@ -163,6 +163,7 @@ func MainnetConfig() Config {
 			CycleGap:                       12 * time.Hour,
 			GracePeriod:                    1 * time.Hour,
 			PositioningATXSelectionTimeout: 50 * time.Minute,
+			PowParamsCacheTTL:              5 * time.Minute,
 			// RequestTimeout = RequestRetryDelay * 2 * MaxRequestRetries*(MaxRequestRetries+1)/2
 			RequestTimeout:    1100 * time.Second,
 			RequestRetryDelay: 10 * time.Second,

--- a/config/presets/fastnet.go
+++ b/config/presets/fastnet.go
@@ -97,5 +97,6 @@ func fastnet() config.Config {
 	conf.POET.RequestTimeout = 12 * time.Second // RequestRetryDelay * 2 * MaxRequestRetries*(MaxRequestRetries+1)/2
 	conf.POET.RequestRetryDelay = 1 * time.Second
 	conf.POET.MaxRequestRetries = 3
+	conf.POET.PowParamsCacheTTL = 10 * time.Second
 	return conf
 }

--- a/config/presets/standalone.go
+++ b/config/presets/standalone.go
@@ -83,6 +83,7 @@ func standalone() config.Config {
 	conf.POET.RequestTimeout = 12 * time.Second // RequestRetryDelay * 2 * MaxRequestRetries*(MaxRequestRetries+1)/2
 	conf.POET.RequestRetryDelay = 1 * time.Second
 	conf.POET.MaxRequestRetries = 3
+	conf.POET.PowParamsCacheTTL = 10 * time.Second
 
 	conf.P2P.DisableNatPort = true
 

--- a/config/presets/testnet.go
+++ b/config/presets/testnet.go
@@ -118,6 +118,7 @@ func testnet() config.Config {
 			RequestTimeout:    550 * time.Second, // RequestRetryDelay * 2 * MaxRequestRetries*(MaxRequestRetries+1)/2
 			RequestRetryDelay: 5 * time.Second,
 			MaxRequestRetries: 10,
+			PowParamsCacheTTL: 5 * time.Minute,
 		},
 		POST: activation.PostConfig{
 			MinNumUnits:   2,


### PR DESCRIPTION
## Motivation

Similarly to /v1/info, we query /v1/pow_params very often (once per submit per node ID). As the contents returned from this endpoint change rarely (once per epoch), it makes sense to cache the result.

## Description

- factored out a small struct to encapsulate the caching + expiration logic into `cachedData struct`
- implemented caching of /v1/pow_params same way as /v1/info is already done

## Test Plan

added a test, will also test on testnet-13 where we observe lots of requests to /v1/pow_params on 1:n nodes.

## TODO

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [ ] Update documentation as needed
- [ ] Update [changelog](../CHANGELOG.md) as needed
