### PR TITLE
v2alpha1: Add PostService

### DIFF
--- a/api/grpcserver/config.go
+++ b/api/grpcserver/config.go
@@ -49,6 +49,7 @@ const (
 	TransactionV2Alpha1       Service = "transaction_v2alpha1"
 	TransactionStreamV2Alpha1 Service = "transaction_stream_v2alpha1"
 	AccountV2Alpha1           Service = "account_v2alpha1"
+	PostV2Alpha1              Service = "post_v2alpha1"
 )
 
 // DefaultConfig defines the default configuration options for api.
@@ -57,7 +58,7 @@ func DefaultConfig() Config {
 		PublicServices: []Service{
 			GlobalState, Mesh, Transaction, Node, Activation, ActivationV2Alpha1,
 			RewardV2Alpha1, NetworkV2Alpha1, NodeV2Alpha1, LayerV2Alpha1, TransactionV2Alpha1,
-			AccountV2Alpha1,
+			AccountV2Alpha1, PostV2Alpha1,
 		},
 		PublicListener: "0.0.0.0:9092",
 		PrivateServices: []Service{

--- a/api/grpcserver/v2alpha1/post.go
+++ b/api/grpcserver/v2alpha1/post.go
@@ -1,0 +1,52 @@
+package v2alpha1
+
+import (
+	"context"
+
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	spacemeshv2alpha1 "github.com/spacemeshos/api/release/go/spacemesh/v2alpha1"
+	"github.com/spacemeshos/post/config"
+	"google.golang.org/grpc"
+
+	"github.com/spacemeshos/go-spacemesh/activation"
+)
+
+const (
+	Post = "post_v2alpha1"
+)
+
+func NewPostService(postCfg activation.PostConfig) *PostService {
+	return &PostService{
+		postConfig: postCfg,
+	}
+}
+
+type PostService struct {
+	postConfig activation.PostConfig
+}
+
+func (s *PostService) RegisterService(server *grpc.Server) {
+	spacemeshv2alpha1.RegisterPostServiceServer(server, s)
+}
+
+func (s *PostService) RegisterHandlerService(mux *runtime.ServeMux) error {
+	return spacemeshv2alpha1.RegisterPostServiceHandlerServer(context.Background(), mux, s)
+}
+
+func (s *PostService) String() string {
+	return "PostService"
+}
+
+func (s *PostService) Config(
+	_ context.Context,
+	_ *spacemeshv2alpha1.PostConfigRequest,
+) (*spacemeshv2alpha1.PostConfigResponse, error) {
+	return &spacemeshv2alpha1.PostConfigResponse{
+		BitsPerLabel:  config.BitsPerLabel,
+		LabelsPerUnit: s.postConfig.LabelsPerUnit,
+		MinNumUnits:   s.postConfig.MinNumUnits,
+		MaxNumUnits:   s.postConfig.MaxNumUnits,
+		K1:            uint32(s.postConfig.K1),
+		K2:            uint32(s.postConfig.K2),
+	}, nil
+}

--- a/api/grpcserver/v2alpha1/post_test.go
+++ b/api/grpcserver/v2alpha1/post_test.go
@@ -1,0 +1,44 @@
+package v2alpha1
+
+import (
+	"context"
+	"math/rand"
+	"testing"
+
+	spacemeshv2alpha1 "github.com/spacemeshos/api/release/go/spacemesh/v2alpha1"
+	"github.com/spacemeshos/post/config"
+	"github.com/stretchr/testify/require"
+
+	"github.com/spacemeshos/go-spacemesh/activation"
+)
+
+func TestPostService_Config(t *testing.T) {
+	ctx := context.Background()
+
+	postConfig := activation.PostConfig{
+		MinNumUnits:   rand.Uint32(),
+		MaxNumUnits:   rand.Uint32(),
+		LabelsPerUnit: rand.Uint64(),
+		K1:            uint(rand.Uint32()),
+		K2:            uint(rand.Uint32()),
+	}
+
+	svc := NewPostService(postConfig)
+	cfg, cleanup := launchServer(t, svc)
+	t.Cleanup(cleanup)
+
+	conn := dialGrpc(t, cfg)
+	client := spacemeshv2alpha1.NewPostServiceClient(conn)
+
+	t.Run("post config", func(t *testing.T) {
+		res, err := client.Config(ctx, &spacemeshv2alpha1.PostConfigRequest{})
+		require.NoError(t, err)
+
+		require.Equal(t, uint32(config.BitsPerLabel), res.BitsPerLabel)
+		require.Equal(t, postConfig.LabelsPerUnit, res.LabelsPerUnit)
+		require.Equal(t, postConfig.MinNumUnits, res.MinNumUnits)
+		require.Equal(t, postConfig.MaxNumUnits, res.MaxNumUnits)
+		require.Equal(t, uint32(postConfig.K1), res.K1)
+		require.Equal(t, uint32(postConfig.K2), res.K2)
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/seehuhn/mt19937 v1.0.0
 	github.com/slok/go-http-metrics v0.12.0
-	github.com/spacemeshos/api/release/go v1.50.0
+	github.com/spacemeshos/api/release/go v1.50.1-0.20240802103624-4e8ea6889274
 	github.com/spacemeshos/economics v0.1.3
 	github.com/spacemeshos/fixed v0.1.1
 	github.com/spacemeshos/go-scale v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -602,8 +602,8 @@ github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d/go.mod h1:Udh
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
-github.com/spacemeshos/api/release/go v1.50.0 h1:M7Usg/LxymscwqYO7/Doyb+sU4lS1e+JIsSgqTDGk/0=
-github.com/spacemeshos/api/release/go v1.50.0/go.mod h1:PvgDpjfwkZLVVNExYG7wDNzgMqT3p+ppfTU2UESSF9U=
+github.com/spacemeshos/api/release/go v1.50.1-0.20240802103624-4e8ea6889274 h1:OmGS5ekafLXAskSLqgUSAJp1zTlrgxztcNlZjCLFu0U=
+github.com/spacemeshos/api/release/go v1.50.1-0.20240802103624-4e8ea6889274/go.mod h1:Qr/pVPMmN5Q5qLHSXqVMDKDCu6LkHWzGPNflylE0u00=
 github.com/spacemeshos/economics v0.1.3 h1:ACkq3mTebIky4Zwbs9SeSSRZrUCjU/Zk0wq9Z0BTh2A=
 github.com/spacemeshos/economics v0.1.3/go.mod h1:FH7u0FzTIm6Kpk+X5HOZDvpkgNYBKclmH86rVwYaDAo=
 github.com/spacemeshos/fixed v0.1.1 h1:N1y4SUpq1EV+IdJrWJwUCt1oBFzeru/VKVcBsvPc2Fk=

--- a/node/node.go
+++ b/node/node.go
@@ -1586,6 +1586,10 @@ func (app *App) grpcService(svc grpcserver.Service, lg log.Log) (grpcserver.Serv
 		service := v2alpha1.NewAccountService(app.db, app.conState)
 		app.grpcServices[svc] = service
 		return service, nil
+	case v2alpha1.Post:
+		service := v2alpha1.NewPostService(app.postSupervisor.Config())
+		app.grpcServices[svc] = service
+		return service, nil
 	}
 	return nil, fmt.Errorf("unknown service %s", svc)
 }


### PR DESCRIPTION
PostConfig is missing in v2alpha1. This PR introduces new service which returns post config.

```
message PostConfigResponse {
  uint32 bits_per_label = 1;
  uint64 labels_per_unit = 2;
  uint32 min_num_units = 3;
  uint32 max_num_units = 4;
  uint32 k1 = 5;
  uint32 k2 = 6;
}
```

Draft until https://github.com/spacemeshos/api/pull/364 is merged