### PR TITLE
[Merged by Bors] - chore: Fix errors.As usage for PoetSvcUnstableError

### DIFF
--- a/activation/activation_errors.go
+++ b/activation/activation_errors.go
@@ -8,8 +8,6 @@ import (
 var (
 	// ErrATXChallengeExpired is returned when atx missed its publication window and needs to be regenerated.
 	ErrATXChallengeExpired = errors.New("builder: atx expired")
-	// ErrPoetServiceUnstable is returned when poet quality of service is low.
-	ErrPoetServiceUnstable = &PoetSvcUnstableError{}
 	// ErrPoetProofNotReceived is returned when no poet proof was received.
 	ErrPoetProofNotReceived = errors.New("builder: didn't receive any poet proof")
 )
@@ -28,8 +26,3 @@ func (e *PoetSvcUnstableError) Error() string {
 }
 
 func (e *PoetSvcUnstableError) Unwrap() error { return e.source }
-
-func (e *PoetSvcUnstableError) Is(target error) bool {
-	_, ok := target.(*PoetSvcUnstableError)
-	return ok
-}

--- a/activation/activation_test.go
+++ b/activation/activation_test.go
@@ -1076,7 +1076,7 @@ func TestBuilder_RetryPublishActivationTx(t *testing.T) {
 				tries++
 				t.Logf("try %d: %s", tries, now)
 				if tries < expectedTries {
-					return nil, ErrPoetServiceUnstable
+					return nil, &PoetSvcUnstableError{}
 				}
 				close(builderConfirmation)
 				return newNIPostWithPoet(t, []byte("66666")), nil

--- a/activation/nipost_test.go
+++ b/activation/nipost_test.go
@@ -713,9 +713,14 @@ func TestNIPSTBuilder_PoetUnstable(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		nipst, err := nb.BuildNIPost(context.Background(), sig, challenge,
-			&types.NIPostChallenge{PublishEpoch: postGenesisEpoch + 2})
-		require.ErrorIs(t, err, ErrPoetServiceUnstable)
+		nipst, err := nb.BuildNIPost(
+			context.Background(),
+			sig,
+			challenge,
+			&types.NIPostChallenge{PublishEpoch: postGenesisEpoch + 2},
+		)
+		poetErr := &PoetSvcUnstableError{}
+		require.ErrorAs(t, err, &poetErr)
 		require.Nil(t, nipst)
 	})
 	t.Run("Submit hangs", func(t *testing.T) {
@@ -750,9 +755,14 @@ func TestNIPSTBuilder_PoetUnstable(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		nipst, err := nb.BuildNIPost(context.Background(), sig, challenge,
-			&types.NIPostChallenge{PublishEpoch: postGenesisEpoch + 2})
-		require.ErrorIs(t, err, ErrPoetServiceUnstable)
+		nipst, err := nb.BuildNIPost(
+			context.Background(),
+			sig,
+			challenge,
+			&types.NIPostChallenge{PublishEpoch: postGenesisEpoch + 2},
+		)
+		poetErr := &PoetSvcUnstableError{}
+		require.ErrorAs(t, err, &poetErr)
 		require.Nil(t, nipst)
 	})
 	t.Run("GetProof fails", func(t *testing.T) {


### PR DESCRIPTION
## Motivation

`errors.Is` is generally used to compare returned errors to a concrete instance of an error like `fs.ErrNotExists` or `io.EOF`, while `errors.As` is used to assign generic errors to an instance of a specific type if needed.

## Description

This removes the `Is` method from `PoetSvcUnstableError` and replaces usages of it with `errors.As`, which is already facilitated by the custom `Unwrap` method if needed.

This also removes the dummy instance `ErrPoetServiceUnstable` that primarily exists to assert that an error is of the type `PoetSvcUnstableError`.

## Test Plan

- existing tests pass

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
