### PR TITLE
[Merged by Bors] - test(hare): add db cleanup

### DIFF
--- a/hare3/hare_test.go
+++ b/hare3/hare_test.go
@@ -340,10 +340,12 @@ func (cl *lockstepCluster) addSigner(n int) *lockstepCluster {
 func (cl *lockstepCluster) addActive(n int) *lockstepCluster {
 	last := len(cl.nodes)
 	for i := last; i < last+n; i++ {
-		cl.addNode((&node{t: cl.t, i: i}).
+		nn := (&node{t: cl.t, i: i}).
 			withController().withSyncer().withPublisher().
 			withClock().withDb().withSigner().withAtx(cl.units.min, cl.units.max).
-			withOracle().withHare())
+			withOracle().withHare()
+		cl.t.Cleanup(func() { nn.db.Close() })
+		cl.addNode(nn)
 	}
 	return cl
 }
@@ -351,10 +353,12 @@ func (cl *lockstepCluster) addActive(n int) *lockstepCluster {
 func (cl *lockstepCluster) addInactive(n int) *lockstepCluster {
 	last := len(cl.nodes)
 	for i := last; i < last+n; i++ {
-		cl.addNode((&node{t: cl.t, i: i}).
+		nn := (&node{t: cl.t, i: i}).
 			withController().withSyncer().withPublisher().
 			withClock().withDb().withSigner().
-			withOracle().withHare())
+			withOracle().withHare()
+		cl.t.Cleanup(func() { nn.db.Close() })
+		cl.addNode(nn)
 	}
 	return cl
 }
@@ -363,11 +367,13 @@ func (cl *lockstepCluster) addEquivocators(n int) *lockstepCluster {
 	require.LessOrEqual(cl.t, n, len(cl.nodes))
 	last := len(cl.nodes)
 	for i := last; i < last+n; i++ {
-		cl.addNode((&node{t: cl.t, i: i}).
+		nn := (&node{t: cl.t, i: i}).
 			reuseSigner(cl.nodes[i-last].signer).
 			withController().withSyncer().withPublisher().
 			withClock().withDb().withAtx(cl.units.min, cl.units.max).
-			withOracle().withHare())
+			withOracle().withHare()
+		cl.t.Cleanup(func() { nn.db.Close() })
+		cl.addNode(nn)
 	}
 	return cl
 }

--- a/hare3/malfeasance_test.go
+++ b/hare3/malfeasance_test.go
@@ -26,7 +26,7 @@ type testMalfeasanceHandler struct {
 }
 
 func newTestMalfeasanceHandler(tb testing.TB) *testMalfeasanceHandler {
-	db := sql.InMemory()
+	db := sql.InMemoryTest(tb)
 	observer, observedLogs := observer.New(zapcore.WarnLevel)
 	logger := zaptest.NewLogger(tb, zaptest.WrapOptions(zap.WrapCore(
 		func(core zapcore.Core) zapcore.Core {

--- a/hare4/eligibility/oracle_test.go
+++ b/hare4/eligibility/oracle_test.go
@@ -53,7 +53,7 @@ type testOracle struct {
 }
 
 func defaultOracle(tb testing.TB) *testOracle {
-	db := sql.InMemory()
+	db := sql.InMemoryTest(tb)
 	atxsdata := atxsdata.New()
 
 	ctrl := gomock.NewController(tb)

--- a/hare4/hare_test.go
+++ b/hare4/hare_test.go
@@ -159,8 +159,8 @@ func (n *node) reuseSigner(signer *signing.EdSigner) *node {
 	return n
 }
 
-func (n *node) withDb() *node {
-	n.db = sql.InMemory()
+func (n *node) withDb(tb testing.TB) *node {
+	n.db = sql.InMemoryTest(tb)
 	n.atxsdata = atxsdata.New()
 	n.proposals = store.New()
 	return n
@@ -391,12 +391,11 @@ func (cl *lockstepCluster) addActive(n int) *lockstepCluster {
 	for i := last; i < last+n; i++ {
 		nn := (&node{t: cl.t, i: i}).
 			withController().withSyncer().withPublisher().
-			withClock().withDb().withSigner().withAtx(cl.units.min, cl.units.max).
+			withClock().withDb(cl.t).withSigner().withAtx(cl.units.min, cl.units.max).
 			withStreamRequester().withOracle().withHare()
 		if cl.mockVerify {
 			nn = nn.withVerifier()
 		}
-		cl.t.Cleanup(func() { nn.db.Close() })
 		cl.addNode(nn)
 	}
 	return cl
@@ -405,12 +404,10 @@ func (cl *lockstepCluster) addActive(n int) *lockstepCluster {
 func (cl *lockstepCluster) addInactive(n int) *lockstepCluster {
 	last := len(cl.nodes)
 	for i := last; i < last+n; i++ {
-		nn := (&node{t: cl.t, i: i}).
+		cl.addNode((&node{t: cl.t, i: i}).
 			withController().withSyncer().withPublisher().
-			withClock().withDb().withSigner().
-			withStreamRequester().withOracle().withHare()
-		cl.t.Cleanup(func() { nn.db.Close() })
-		cl.addNode(nn)
+			withClock().withDb(cl.t).withSigner().
+			withStreamRequester().withOracle().withHare())
 	}
 	return cl
 }
@@ -419,13 +416,11 @@ func (cl *lockstepCluster) addEquivocators(n int) *lockstepCluster {
 	require.LessOrEqual(cl.t, n, len(cl.nodes))
 	last := len(cl.nodes)
 	for i := last; i < last+n; i++ {
-		nn := (&node{t: cl.t, i: i}).
+		cl.addNode((&node{t: cl.t, i: i}).
 			reuseSigner(cl.nodes[i-last].signer).
 			withController().withSyncer().withPublisher().
-			withClock().withDb().withAtx(cl.units.min, cl.units.max).
-			withStreamRequester().withOracle().withHare()
-		cl.t.Cleanup(func() { nn.db.Close() })
-		cl.addNode(nn)
+			withClock().withDb(cl.t).withAtx(cl.units.min, cl.units.max).
+			withStreamRequester().withOracle().withHare())
 	}
 	return cl
 }

--- a/sql/database.go
+++ b/sql/database.go
@@ -187,7 +187,7 @@ func InMemory(opts ...Opt) *Database {
 	return db
 }
 
-// InMemoryTest returns an in-mem database for testing and ensures t.Cleanup is called.
+// InMemoryTest returns an in-mem database for testing and ensures database is closed during `tb.Cleanup`.
 func InMemoryTest(tb testing.TB, opts ...Opt) *Database {
 	opts = append(opts, WithConnections(1))
 	db, err := Open("file::memory:?mode=memory", opts...)

--- a/sql/database.go
+++ b/sql/database.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"testing"
 	"time"
 
 	sqlite "github.com/go-llsqlite/crawshaw"
@@ -176,12 +177,24 @@ func WithQueryCacheSizes(sizes map[QueryCacheKind]int) Opt {
 type Opt func(c *conf)
 
 // InMemory database for testing.
+// Please use InMemoryTest to ensure t.Cleanup is called.
 func InMemory(opts ...Opt) *Database {
 	opts = append(opts, WithConnections(1))
 	db, err := Open("file::memory:?mode=memory", opts...)
 	if err != nil {
 		panic(err)
 	}
+	return db
+}
+
+// InMemoryTest returns an in-mem database for testing and ensures t.Cleanup is called.
+func InMemoryTest(tb testing.TB, opts ...Opt) *Database {
+	opts = append(opts, WithConnections(1))
+	db, err := Open("file::memory:?mode=memory", opts...)
+	if err != nil {
+		panic(err)
+	}
+	tb.Cleanup(func() { db.Close() })
 	return db
 }
 

--- a/sql/database.go
+++ b/sql/database.go
@@ -177,7 +177,7 @@ func WithQueryCacheSizes(sizes map[QueryCacheKind]int) Opt {
 type Opt func(c *conf)
 
 // InMemory database for testing.
-// Please use InMemoryTest to ensure t.Cleanup is called.
+// Please use InMemoryTest for automatic closing of the returned db during `tb.Cleanup`.
 func InMemory(opts ...Opt) *Database {
 	opts = append(opts, WithConnections(1))
 	db, err := Open("file::memory:?mode=memory", opts...)


### PR DESCRIPTION
## Motivation

Adding a cleanup for the in-memory db we are using in hare.

## Description

There's too much dangling goroutines when we dump the output of the failing tests on hare due to the cleanup not being called on the inmem sqlite.
<!-- If applicable please mention the issue addressed by this PR -->
<!-- `Closes #XXXX` links mentioned issues to this PR and automatically closes them when this it's merged -->

<!-- Please describe in detail the changes made. Focus on the reasoning rather than describing the change -->

## Test Plan

<!-- Please specify how these changes were tested (e.g. unit tests, manual testing, etc.) -->

## TODO

<!-- Please tick off the TODOs when completed -->

- [ ] Explain motivation or link existing issue(s)
- [ ] Test changes and document test plan
- [ ] Update documentation as needed
- [ ] Update [changelog](../CHANGELOG.md) as needed
