### PR TITLE
[Merged by Bors] - Upload go-sm release builds to R2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,7 +153,7 @@ jobs:
       - name: Setup gcloud authentication
         uses: google-github-actions/auth@v2
         with:
-          credentials_json: '${{ secrets.GCP_SA_KEY }}'
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
         with:
@@ -169,16 +169,15 @@ jobs:
           mkdir sha256sum
           cp sha256sum.yaml sha256sum
       - name: Upload sha256sums to R2
-        uses: jakejarvis/s3-sync-action@master
-        with:
-          args: --acl public-read --follow-symlinks
+        run: >
+          aws s3 sync sha256sum
+          s3://${{ secrets.CLOUDFLARE_GO_SM_BUILDS_BUCKET }}/${{ github.ref_name }}
+          --endpoint-url https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com
+          --acl public-read --follow-symlinks --delete
         env:
-            AWS_S3_BUCKET: ${{ secrets.CLOUDFLARE_GO_SM_BUILDS_BUCKET }}
             AWS_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_GO_SM_BUILDS_ACCESS_KEY_ID }}
             AWS_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_GO_SM_BUILDS_SECRET_ACCESS_KEY }}
-            SOURCE_DIR: sha256sum
-            DEST_DIR: '${{ github.ref_name }}'
-            AWS_S3_ENDPOINT: https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com
+            AWS_REGION: us-east-1
       - name: Create Release
         uses: softprops/action-gh-release@v2
         id: create_release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,16 +95,15 @@ jobs:
           mkdir build-zip
           cp ${{ env.OUTNAME }}.zip build-zip
       - name: Upload zip to R2
-        uses: jakejarvis/s3-sync-action@master
-        with:
-          args: --acl public-read --follow-symlinks
+        run: >
+          aws s3 sync build-zip
+          s3://${{ secrets.CLOUDFLARE_GO_SM_BUILDS_BUCKET }}/${{ github.ref_name }}
+          --endpoint-url https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com
+          --acl public-read --follow-symlinks --delete
         env:
-            AWS_S3_BUCKET: ${{ secrets.CLOUDFLARE_GO_SM_BUILDS_BUCKET }}
             AWS_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_GO_SM_BUILDS_ACCESS_KEY_ID }}
             AWS_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_GO_SM_BUILDS_SECRET_ACCESS_KEY }}
-            SOURCE_DIR: build-zip
-            DEST_DIR: '${{ github.ref_name }}'
-            AWS_S3_ENDPOINT: https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com
+            AWS_REGION: us-east-1
       - name: Install coreutils
         if: ${{ matrix.os == 'macos-13' || matrix.os == '[self-hosted, macOS, ARM64, go-spacemesh]' }}
         run: brew install coreutils

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,7 +99,7 @@ jobs:
           aws s3 sync build-zip
           s3://${{ secrets.CLOUDFLARE_GO_SM_BUILDS_BUCKET }}/${{ github.ref_name }}
           --endpoint-url https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com
-          --acl public-read --follow-symlinks --delete
+          --acl public-read --follow-symlinks
         env:
             AWS_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_GO_SM_BUILDS_ACCESS_KEY_ID }}
             AWS_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_GO_SM_BUILDS_SECRET_ACCESS_KEY }}
@@ -173,7 +173,7 @@ jobs:
           aws s3 sync sha256sum
           s3://${{ secrets.CLOUDFLARE_GO_SM_BUILDS_BUCKET }}/${{ github.ref_name }}
           --endpoint-url https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com
-          --acl public-read --follow-symlinks --delete
+          --acl public-read --follow-symlinks
         env:
             AWS_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_GO_SM_BUILDS_ACCESS_KEY_ID }}
             AWS_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_GO_SM_BUILDS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,11 +84,27 @@ jobs:
         uses: google-github-actions/setup-gcloud@v2
         with:
           version: "469.0.0"
-      - name: Upload zip
+      - name: Upload zip to GCP
         uses: google-github-actions/upload-cloud-storage@v2
         with:
           path: ${{ env.OUTNAME }}.zip
           destination: ${{ secrets.GCP_BUCKET }}/${{ github.ref_name }}/
+      - name: Copy build
+        shell: bash
+        run: |
+          mkdir build-zip
+          cp ${{ env.OUTNAME }}.zip build-zip
+      - name: Upload zip to R2
+        uses: jakejarvis/s3-sync-action@master
+        with:
+          args: --acl public-read --follow-symlinks
+        env:
+            AWS_S3_BUCKET: ${{ secrets.CLOUDFLARE_GO_SM_BUILDS_BUCKET }}
+            AWS_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_GO_SM_BUILDS_ACCESS_KEY_ID }}
+            AWS_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_GO_SM_BUILDS_SECRET_ACCESS_KEY }}
+            SOURCE_DIR: build-zip
+            DEST_DIR: '${{ github.ref_name }}'
+            AWS_S3_ENDPOINT: https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com
       - name: Install coreutils
         if: ${{ matrix.os == 'macos-13' || matrix.os == '[self-hosted, macOS, ARM64, go-spacemesh]' }}
         run: brew install coreutils
@@ -143,11 +159,27 @@ jobs:
         uses: google-github-actions/setup-gcloud@v2
         with:
           version: "469.0.0"
-      - name: Upload sha256sums
+      - name: Upload sha256sums to GCP
         uses: google-github-actions/upload-cloud-storage@v2
         with:
           path: sha256sum.yaml
           destination: ${{ secrets.GCP_BUCKET }}/${{ github.ref_name }}/
+      - name: Copy sha256sum
+        shell: bash
+        run: |
+          mkdir sha256sum
+          cp sha256sum.yaml sha256sum
+      - name: Upload sha256sums to R2
+        uses: jakejarvis/s3-sync-action@master
+        with:
+          args: --acl public-read --follow-symlinks
+        env:
+            AWS_S3_BUCKET: ${{ secrets.CLOUDFLARE_GO_SM_BUILDS_BUCKET }}
+            AWS_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_GO_SM_BUILDS_ACCESS_KEY_ID }}
+            AWS_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_GO_SM_BUILDS_SECRET_ACCESS_KEY }}
+            SOURCE_DIR: sha256sum
+            DEST_DIR: '${{ github.ref_name }}'
+            AWS_S3_ENDPOINT: https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com
       - name: Create Release
         uses: softprops/action-gh-release@v2
         id: create_release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,14 +189,14 @@ jobs:
           tag_name:  ${{ github.ref_name }}
           body: |
             ## Zip Files
-            - Windows amd64: https://storage.googleapis.com/${{ secrets.GCP_BUCKET }}/${{ github.ref_name }}/${{ env.OUTNAME_WIN_AMD64 }}.zip
-            - macOS amd64: https://storage.googleapis.com/${{ secrets.GCP_BUCKET }}/${{ github.ref_name }}/${{ env.OUTNAME_MAC_AMD64 }}.zip
-            - macOS arm64: https://storage.googleapis.com/${{ secrets.GCP_BUCKET }}/${{ github.ref_name }}/${{ env.OUTNAME_MAC_ARM64 }}.zip
-            - Linux amd64: https://storage.googleapis.com/${{ secrets.GCP_BUCKET }}/${{ github.ref_name }}/${{ env.OUTNAME_LINUX_AMD64 }}.zip
-            - Linux arm64: https://storage.googleapis.com/${{ secrets.GCP_BUCKET }}/${{ github.ref_name }}/${{ env.OUTNAME_LINUX_ARM64 }}.zip
+            - Windows amd64: https://go-spacemesh-release-builds.spacemesh.network/${{ github.ref_name }}/${{ env.OUTNAME_WIN_AMD64 }}.zip
+            - macOS amd64: https://go-spacemesh-release-builds.spacemesh.network/${{ github.ref_name }}/${{ env.OUTNAME_MAC_AMD64 }}.zip
+            - macOS arm64: https://go-spacemesh-release-builds.spacemesh.network/${{ github.ref_name }}/${{ env.OUTNAME_MAC_ARM64 }}.zip
+            - Linux amd64: https://go-spacemesh-release-builds.spacemesh.network/${{ github.ref_name }}/${{ env.OUTNAME_LINUX_AMD64 }}.zip
+            - Linux arm64: https://go-spacemesh-release-builds.spacemesh.network/${{ github.ref_name }}/${{ env.OUTNAME_LINUX_ARM64 }}.zip
 
             ## checksum - Zip files
-            YAML with all the checksums of this version :  https://storage.googleapis.com/${{ secrets.GCP_BUCKET }}/${{ github.ref_name }}/sha256sum.yaml
+            YAML with all the checksums of this version :  https://go-spacemesh-release-builds.spacemesh.network/${{ github.ref_name }}/sha256sum.yaml
             - Windows amd64 - sha256 : ${{ env.SHA256_WIN_AMD64 }}
             - Linux amd64 - sha256: ${{ env.SHA256_LINUX_AMD64 }}
             - Linux arm64 - sha256: ${{ env.SHA256_LINUX_ARM64 }}


### PR DESCRIPTION
## Motivation

Upgrade the release process with R2 uploads to reduce costs and safeguarding against network charges and abuse, while keeping the GCP bucket as a temporary backup.

## Description

Introduces a release upload to R2 while maintaining GCP as a backup. This step is part of a larger migration plan that will eventually see the full transition to R2, including the smapp builds.

## Test Plan

Test the upload to the GCS Bucket