### PR TITLE
[Merged by Bors] - Use gotestsum in system tests

### DIFF
--- a/systest/Dockerfile
+++ b/systest/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22 as build
+FROM golang:1.22 AS build
 RUN set -ex \
     && apt-get update --fix-missing \
     && apt-get install -qy --no-install-recommends \
@@ -22,14 +22,18 @@ COPY . .
 
 RUN --mount=type=cache,id=build,target=/root/.cache/go-build go test -failfast -v -c -o ./build/tests.test ./systest/tests/
 
-FROM ubuntu:22.04
+ENV GOBIN=/bin
+RUN --mount=type=cache,id=build,target=/root/.cache/go-build go install gotest.tools/gotestsum@v1.12.0
+
+FROM golang:1.22 AS runtime
 RUN set -ex \
-   && apt-get update --fix-missing \
-   && apt-get install -qy --no-install-recommends \
-   ocl-icd-libopencl1 clinfo \
-   && apt-get clean \
-   && rm -rf /var/lib/apt/lists/*
+    && apt-get update --fix-missing \
+    && apt-get install -qy --no-install-recommends \
+    ocl-icd-libopencl1 clinfo \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 COPY --from=build /src/build/tests.test /bin/tests
+COPY --from=build /bin/gotestsum /bin/
 COPY --from=build /src/build/libpost.so /bin/
 COPY --from=build /src/build/post-service /bin/
 ENV LD_LIBRARY_PATH="/bin/"

--- a/systest/Dockerfile
+++ b/systest/Dockerfile
@@ -40,4 +40,6 @@ COPY --from=build /bin/gotestsum /bin/
 COPY --from=build /src/build/libpost.so /bin/
 COPY --from=build /src/build/post-service /bin/
 ENV LD_LIBRARY_PATH="/bin/"
+
 ENV GOVERSION=1.22
+ENV GOTESTSUM_FORMAT=standard-quiet

--- a/systest/Dockerfile
+++ b/systest/Dockerfile
@@ -23,9 +23,11 @@ COPY . .
 RUN --mount=type=cache,id=build,target=/root/.cache/go-build go test -failfast -v -c -o ./build/tests.test ./systest/tests/
 
 ENV GOBIN=/bin
+ENV CGO_ENABLED=0
+RUN --mount=type=cache,id=build,target=/root/.cache/go-build go build -o ./build/test2json -ldflags="-s -w" cmd/test2json
 RUN --mount=type=cache,id=build,target=/root/.cache/go-build go install gotest.tools/gotestsum@v1.12.0
 
-FROM golang:1.22 AS runtime
+FROM ubuntu:22.04 AS runtime
 RUN set -ex \
     && apt-get update --fix-missing \
     && apt-get install -qy --no-install-recommends \
@@ -33,7 +35,9 @@ RUN set -ex \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 COPY --from=build /src/build/tests.test /bin/tests
+COPY --from=build /src/build/test2json /bin/
 COPY --from=build /bin/gotestsum /bin/
 COPY --from=build /src/build/libpost.so /bin/
 COPY --from=build /src/build/post-service /bin/
 ENV LD_LIBRARY_PATH="/bin/"
+ENV GOVERSION=1.22

--- a/systest/Dockerfile
+++ b/systest/Dockerfile
@@ -22,9 +22,10 @@ COPY . .
 
 RUN --mount=type=cache,id=build,target=/root/.cache/go-build go test -failfast -v -c -o ./build/tests.test ./systest/tests/
 
-ENV GOBIN=/bin
 ENV CGO_ENABLED=0
 RUN --mount=type=cache,id=build,target=/root/.cache/go-build go build -o ./build/test2json -ldflags="-s -w" cmd/test2json
+
+ENV GOBIN=/bin
 RUN --mount=type=cache,id=build,target=/root/.cache/go-build go install gotest.tools/gotestsum@v1.12.0
 
 FROM ubuntu:22.04 AS runtime

--- a/systest/Makefile
+++ b/systest/Makefile
@@ -36,7 +36,8 @@ ifeq ($(configname),$(test_job_name))
 	run_deps = config
 endif
 
-command := tests -test.v -test.count=$(count) -test.timeout=60m -test.run=$(test_name) -test.parallel=$(clusters) \
+command := gotestsum --raw-command -- go tool test2json -t -p systest \
+	/bin/tests -test.v -test.count=$(count) -test.timeout=60m -test.run=$(test_name) -test.parallel=$(clusters) \
 	-test.failfast=$(failfast) -clusters=$(clusters) -level=$(level) -configname=$(configname)
 
 .PHONY: docker
@@ -78,7 +79,7 @@ config: template
 
 .PHONY: gomplate
 gomplate:
-	@go install github.com/hairyhenderson/gomplate/v4/cmd/gomplate@v4.0.0-pre-1
+	@go install github.com/hairyhenderson/gomplate/v4/cmd/gomplate@v4.1.0
 
 # Using bash to invoke ./wait_for_job.sh script to avoid problems on Mac
 # where /bin/bash is an old bash

--- a/systest/Makefile
+++ b/systest/Makefile
@@ -36,7 +36,7 @@ ifeq ($(configname),$(test_job_name))
 	run_deps = config
 endif
 
-command := gotestsum --raw-command -- go tool test2json -t -p systest \
+command := gotestsum --raw-command -- test2json -t -p systest \
 	/bin/tests -test.v -test.count=$(count) -test.timeout=60m -test.run=$(test_name) -test.parallel=$(clusters) \
 	-test.failfast=$(failfast) -clusters=$(clusters) -level=$(level) -configname=$(configname)
 


### PR DESCRIPTION
## Motivation

`gotestsum` can be used to run a compiled test binary and parse its output which would allow us to use it for system tests as well.

## Description

Updated the `Dockerfile` and `Makefile` of system tests to use `gotestsum` as runner for the tests.

## Test Plan

existing tests pass.

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
