### PR TITLE
[Merged by Bors] - Add sleep to make data race less likely

### DIFF
--- a/fetch/fetch_test.go
+++ b/fetch/fetch_test.go
@@ -169,8 +169,6 @@ func TestFetch_RequestHashBatchFromPeers(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
 			f := createFetch(t)
 			f.cfg.MaxRetriesForRequest = 0
 			peer := p2p.Peer("buddy")

--- a/fetch/p2p_test.go
+++ b/fetch/p2p_test.go
@@ -90,7 +90,6 @@ func createP2PFetch(
 ) (*testP2PFetch, context.Context) {
 	lg := zaptest.NewLogger(t)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
-	t.Cleanup(cancel)
 
 	serverHost, err := p2p.AutoStart(ctx, lg, p2pCfg(t), []byte{}, []byte{})
 	require.NoError(t, err)
@@ -99,6 +98,13 @@ func createP2PFetch(
 	clientHost, err := p2p.AutoStart(ctx, lg, p2pCfg(t), []byte{}, []byte{})
 	require.NoError(t, err)
 	t.Cleanup(func() { assert.NoError(t, clientHost.Stop()) })
+
+	t.Cleanup(func() {
+		cancel()
+		time.Sleep(10 * time.Millisecond)
+		// mafa: p2p internally uses a global logger this should prevent logging after
+		// the test ends (send PR with fix to libp2p/go-libp2p-pubsub) (go loop in pubsub.go)
+	})
 
 	var sqlOpts []sql.Opt
 	if sqlCache {


### PR DESCRIPTION
## Motivation

This adds sleeps to tests in the `fetch` package to hopefully make data races less likely.

## Description

`libp2p/go-libp2p-pubsub` internally uses a go routine with a for loop that only returns when the context is canceled. See the code here: https://github.com/libp2p/go-libp2p-pubsub/blob/19ffbb3a482caecabb8520917c631e3047a78094/pubsub.go#L668-L671

Since this signal might not reach the go routine before the test ends the log that is emitted might use the test logger of a different test causing a race. Since there is no way to not use a global logger or any signal back from `PubSub` that the go routine exited, the only thing we can do without changing `libp2p/go-libp2p-pubsub` is to sleep in the test for some time and hope that ensures the go routine exited.

## Test Plan

existing tests pass and are less flaky

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
