### PR TITLE
[Merged by Bors] - log received invalid malfeasance proofs on DEBUG

### DIFF
--- a/activation/malfeasance.go
+++ b/activation/malfeasance.go
@@ -68,7 +68,7 @@ func (mh *MalfeasanceHandler) Validate(ctx context.Context, data wire.ProofData)
 		msg1.InnerMsg.MsgHash != msg2.InnerMsg.MsgHash {
 		return msg1.SmesherID, nil
 	}
-	mh.logger.Warn("received invalid atx malfeasance proof",
+	mh.logger.Debug("received invalid atx malfeasance proof",
 		log.ZContext(ctx),
 		zap.Stringer("first_smesher", msg1.SmesherID),
 		zap.Object("first_proof", &msg1.InnerMsg),

--- a/hare3/malfeasance.go
+++ b/hare3/malfeasance.go
@@ -77,7 +77,7 @@ func (mh *MalfeasanceHandler) Validate(ctx context.Context, data wire.ProofData)
 		msg1.InnerMsg.MsgHash != msg2.InnerMsg.MsgHash {
 		return msg1.SmesherID, nil
 	}
-	mh.logger.Warn("received invalid hare malfeasance proof",
+	mh.logger.Debug("received invalid hare malfeasance proof",
 		log.ZContext(ctx),
 		zap.Stringer("first_smesher", hp.Messages[0].SmesherID),
 		zap.Object("first_proof", &hp.Messages[0].InnerMsg),

--- a/hare4/malfeasance.go
+++ b/hare4/malfeasance.go
@@ -77,7 +77,7 @@ func (mh *MalfeasanceHandler) Validate(ctx context.Context, data wire.ProofData)
 		msg1.InnerMsg.MsgHash != msg2.InnerMsg.MsgHash {
 		return msg1.SmesherID, nil
 	}
-	mh.logger.Warn("received invalid hare malfeasance proof",
+	mh.logger.Debug("received invalid hare malfeasance proof",
 		log.ZContext(ctx),
 		zap.Stringer("first_smesher", hp.Messages[0].SmesherID),
 		zap.Object("first_proof", &hp.Messages[0].InnerMsg),

--- a/malfeasance/handler.go
+++ b/malfeasance/handler.go
@@ -26,7 +26,7 @@ var (
 
 	errMalformedData = fmt.Errorf("%w: malformed data", pubsub.ErrValidationReject)
 	errWrongHash     = fmt.Errorf("%w: incorrect hash", pubsub.ErrValidationReject)
-	errInvalidProof  = fmt.Errorf("%w: invalid proof", pubsub.ErrValidationReject)
+	errUnknownProof  = fmt.Errorf("%w: unknown proof type", pubsub.ErrValidationReject)
 )
 
 type MalfeasanceType byte
@@ -153,6 +153,7 @@ func (h *Handler) HandleMalfeasanceProof(ctx context.Context, peer p2p.Peer, dat
 
 func (h *Handler) validateAndSave(ctx context.Context, p *wire.MalfeasanceGossip) (types.NodeID, error) {
 	if p.Eligibility != nil {
+		numMalformed.Inc()
 		return types.EmptyNodeID, fmt.Errorf(
 			"%w: eligibility field was deprecated with hare3",
 			pubsub.ErrValidationReject,
@@ -160,12 +161,12 @@ func (h *Handler) validateAndSave(ctx context.Context, p *wire.MalfeasanceGossip
 	}
 	nodeID, err := h.Validate(ctx, p)
 	switch {
-	case errors.Is(err, errInvalidProof):
+	case errors.Is(err, errUnknownProof):
 		numMalformed.Inc()
 		return types.EmptyNodeID, err
 	case err != nil:
 		h.countInvalidProof(&p.MalfeasanceProof)
-		return types.EmptyNodeID, err
+		return types.EmptyNodeID, errors.Join(err, pubsub.ErrValidationReject)
 	}
 	if err := h.cdb.WithTx(ctx, func(dbtx *sql.Tx) error {
 		malicious, err := identities.IsMalicious(dbtx, nodeID)
@@ -208,7 +209,7 @@ func (h *Handler) validateAndSave(ctx context.Context, p *wire.MalfeasanceGossip
 func (h *Handler) Validate(ctx context.Context, p *wire.MalfeasanceGossip) (types.NodeID, error) {
 	mh, ok := h.handlersV1[MalfeasanceType(p.Proof.Type)]
 	if !ok {
-		return types.EmptyNodeID, fmt.Errorf("%w: unknown malfeasance type", errInvalidProof)
+		return types.EmptyNodeID, fmt.Errorf("%w: unknown malfeasance type", errUnknownProof)
 	}
 
 	nodeID, err := mh.Validate(ctx, p.Proof.Data)

--- a/malfeasance/handler_test.go
+++ b/malfeasance/handler_test.go
@@ -83,7 +83,7 @@ func TestHandler_HandleMalfeasanceProof(t *testing.T) {
 		}
 
 		err := h.HandleMalfeasanceProof(context.Background(), "peer", codec.MustEncode(gossip))
-		require.ErrorIs(t, err, errInvalidProof)
+		require.ErrorIs(t, err, errUnknownProof)
 		require.ErrorIs(t, err, pubsub.ErrValidationReject)
 	})
 
@@ -113,6 +113,7 @@ func TestHandler_HandleMalfeasanceProof(t *testing.T) {
 
 		err := h.HandleMalfeasanceProof(context.Background(), "peer", codec.MustEncode(gossip))
 		require.ErrorContains(t, err, "invalid proof")
+		require.ErrorIs(t, err, pubsub.ErrValidationReject)
 	})
 
 	t.Run("valid proof", func(t *testing.T) {
@@ -223,7 +224,7 @@ func TestHandler_HandleSyncedMalfeasanceProof(t *testing.T) {
 			"peer",
 			codec.MustEncode(proof),
 		)
-		require.ErrorIs(t, err, errInvalidProof)
+		require.ErrorIs(t, err, errUnknownProof)
 		require.ErrorIs(t, err, pubsub.ErrValidationReject)
 	})
 
@@ -291,6 +292,7 @@ func TestHandler_HandleSyncedMalfeasanceProof(t *testing.T) {
 			codec.MustEncode(proof),
 		)
 		require.ErrorContains(t, err, "invalid proof")
+		require.ErrorIs(t, err, pubsub.ErrValidationReject)
 	})
 
 	t.Run("valid proof", func(t *testing.T) {

--- a/mesh/malfeasance.go
+++ b/mesh/malfeasance.go
@@ -74,7 +74,7 @@ func (mh *MalfeasanceHandler) Validate(ctx context.Context, data wire.ProofData)
 		msg1.InnerMsg.MsgHash != msg2.InnerMsg.MsgHash {
 		return msg1.SmesherID, nil
 	}
-	mh.logger.Warn("received invalid ballot malfeasance proof",
+	mh.logger.Debug("received invalid ballot malfeasance proof",
 		log.ZContext(ctx),
 		zap.Stringer("first_smesher", bp.Messages[0].SmesherID),
 		zap.Object("first_proof", &bp.Messages[0].InnerMsg),


### PR DESCRIPTION
## Motivation

Users don't need to be informed that a peer sends invalid proofs and the peer should be dropped.

## Description

- changed log level to Debug for logging about invalid proofs
- return `pubsub.ErrValidationReject` for proofs that don't pass validation

## Test Plan


## TODO

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [ ] Update documentation as needed
- [ ] Update [changelog](../CHANGELOG.md) as needed
