### PR TITLE
[Merged by Bors] - refactor: remove unused error return

### DIFF
--- a/txs/cache.go
+++ b/txs/cache.go
@@ -650,11 +650,10 @@ func (c *Cache) updateLayer(lid types.LayerID, bid types.BlockID, tids []types.T
 	for _, ID := range tids {
 		if _, ok := c.cachedTXs[ID]; !ok {
 			// transaction is not considered best in its nonce group
-			return nil
+			return
 		}
 		c.cachedTXs[ID].UpdateLayerMaybe(lid, bid)
 	}
-	return nil
 }
 
 func (c *Cache) applyEmptyLayer(db *sql.Database, lid types.LayerID) error {

--- a/txs/cache.go
+++ b/txs/cache.go
@@ -618,7 +618,8 @@ func (c *Cache) LinkTXsWithProposal(
 	if err := addToProposal(db, lid, pid, tids); err != nil {
 		return fmt.Errorf("linking txs to proposal: %w", err)
 	}
-	return c.updateLayer(lid, types.EmptyBlockID, tids)
+	c.updateLayer(lid, types.EmptyBlockID, tids)
+	return nil
 }
 
 // LinkTXsWithBlock associates the transactions to a block.
@@ -632,16 +633,17 @@ func (c *Cache) LinkTXsWithBlock(
 		return nil
 	}
 	if err := addToBlock(db, lid, bid, tids); err != nil {
-		return err
+		return fmt.Errorf("add to block: %w", err)
 	}
-	return c.updateLayer(lid, bid, tids)
+	c.updateLayer(lid, bid, tids)
+	return nil
 }
 
 // updateLayer associates the transactions to a layer and optionally a block.
 // A transaction is tagged with a layer when it's included in a proposal/block.
 // If a transaction is included in multiple proposals/blocks in different layers,
 // the lowest layer is retained.
-func (c *Cache) updateLayer(lid types.LayerID, bid types.BlockID, tids []types.TransactionID) error {
+func (c *Cache) updateLayer(lid types.LayerID, bid types.BlockID, tids []types.TransactionID) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 


### PR DESCRIPTION
## Motivation

Removes an unused error return value from the `updateLayer` signature.

## Description

<!-- If applicable please mention the issue addressed by this PR -->
<!-- `Closes #XXXX` links mentioned issues to this PR and automatically closes them when this it's merged -->

<!-- Please describe in detail the changes made. Focus on the reasoning rather than describing the change -->

## Test Plan

<!-- Please specify how these changes were tested (e.g. unit tests, manual testing, etc.) -->

## TODO

<!-- Please tick off the TODOs when completed -->

- [ ] Explain motivation or link existing issue(s)
- [ ] Test changes and document test plan
- [ ] Update documentation as needed
- [ ] Update [changelog](../CHANGELOG.md) as needed
