### PR TITLE
[Merged by Bors] - run staticcheck via golang-lint-ci only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,8 +113,6 @@ jobs:
           go-version: ${{ env.go-version }}
       - name: setup env
         run: make install
-      - name: staticcheck
-        run: make staticcheck
       - name: lint
         run: make lint-github-action
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@ COMMIT = $(shell git rev-parse HEAD)
 BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
 
 GOLANGCI_LINT_VERSION := v1.59.0
-STATICCHECK_VERSION := v0.4.7
 GOTESTSUM_VERSION := v1.12.0
 GOSCALE_VERSION := v1.2.0
 MOCKGEN_VERSION := v0.4.0
@@ -61,7 +60,6 @@ install:
 	go install github.com/spacemeshos/go-scale/scalegen@$(GOSCALE_VERSION)
 	go install go.uber.org/mock/mockgen@$(MOCKGEN_VERSION)
 	go install gotest.tools/gotestsum@$(GOTESTSUM_VERSION)
-	go install honnef.co/go/tools/cmd/staticcheck@$(STATICCHECK_VERSION)
 .PHONY: install
 
 build: go-spacemesh get-profiler get-postrs-service
@@ -111,10 +109,6 @@ test-generate:
 	@make generate
 	@git diff --name-only --diff-filter=AM --exit-code . || { echo "\nPlease rerun 'make generate' and commit changes.\n"; exit 1; }
 .PHONY: test-generate
-
-staticcheck: get-libs
-	@$(ULIMIT) CGO_LDFLAGS="$(CGO_TEST_LDFLAGS)" staticcheck ./...
-.PHONY: staticcheck
 
 test-tidy:
 	# Working directory must be clean, or this test would be destructive


### PR DESCRIPTION
## Motivation

Avoid running staticcheck in CI twice.

## Description

We currently execute staticcheck twice:
1. via golang-lint-ci
2. explicitly calling staticcheck

It's inefficient (scanning the code twice) and makes ignoring lints cumbersome as both tools understand different ignoring comments.

## Test Plan

n/a

## TODO

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [ ] Update documentation as needed
- [ ] Update [changelog](../CHANGELOG.md) as needed
