### PR TITLE
feat: add write-coalesing to atx handling

### DIFF
--- a/activation/e2e/builds_atx_v2_test.go
+++ b/activation/e2e/builds_atx_v2_test.go
@@ -134,6 +134,9 @@ func TestBuilder_SwitchesToBuildV2(t *testing.T) {
 		logger,
 		activation.WithAtxVersions(atxVersions),
 	)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go atxHdlr.Start(ctx)
 
 	var previous *types.ActivationTx
 	var publishedAtxs atomic.Uint32

--- a/activation/handler.go
+++ b/activation/handler.go
@@ -131,6 +131,7 @@ func NewHandler(
 			beacon:          beacon,
 			tortoise:        tortoise,
 			signers:         make(map[types.NodeID]*signing.EdSigner),
+			atxBatchResult:  nil,
 		},
 
 		v2: &HandlerV2{
@@ -167,6 +168,10 @@ func NewHandler(
 
 func (h *Handler) Register(sig *signing.EdSigner) {
 	h.v1.Register(sig)
+}
+
+func (h *Handler) Start(ctx context.Context) {
+	h.v1.flushAtxLoop(ctx)
 }
 
 // HandleSyncedAtx handles atxs received by sync.

--- a/activation/handler_test.go
+++ b/activation/handler_test.go
@@ -214,6 +214,9 @@ func newTestHandler(tb testing.TB, goldenATXID types.ATXID, opts ...HandlerOptio
 		lg,
 		opts...,
 	)
+	ctx, cancel := context.WithCancel(context.Background())
+	go atxHdlr.Start(ctx)
+	tb.Cleanup(func() { cancel() })
 	return &testHandler{
 		Handler:    atxHdlr,
 		cdb:        cdb,

--- a/activation/metrics/metrics.go
+++ b/activation/metrics/metrics.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	"github.com/spacemeshos/go-spacemesh/metrics"
 )
@@ -51,19 +52,19 @@ var PostVerificationLatency = metrics.NewHistogramWithBuckets(
 	prometheus.ExponentialBuckets(1, 2, 20),
 ).WithLabelValues()
 
-var WriteBatchErrorsCount = prometheus.NewCounter(metrics.NewCounterOpts(
+var WriteBatchErrorsCount = promauto.NewCounter(metrics.NewCounterOpts(
 	namespace,
 	"write_batch_errors",
 	"number of errors when writing a batch",
 ))
 
-var ErroredBatchCount = prometheus.NewCounter(metrics.NewCounterOpts(
+var ErroredBatchCount = promauto.NewCounter(metrics.NewCounterOpts(
 	namespace,
 	"errored_batch",
 	"number of batches that errored",
 ))
 
-var FlushBatchSize = prometheus.NewCounter(metrics.NewCounterOpts(
+var FlushBatchSize = promauto.NewCounter(metrics.NewCounterOpts(
 	namespace,
 	"flush_batch_size",
 	"size of flushed batch",

--- a/activation/metrics/metrics.go
+++ b/activation/metrics/metrics.go
@@ -50,3 +50,21 @@ var PostVerificationLatency = metrics.NewHistogramWithBuckets(
 	[]string{},
 	prometheus.ExponentialBuckets(1, 2, 20),
 ).WithLabelValues()
+
+var WriteBatchErrorsCount = prometheus.NewCounter(metrics.NewCounterOpts(
+	namespace,
+	"write_batch_errors",
+	"number of errors when writing a batch",
+))
+
+var ErroredBatchCount = prometheus.NewCounter(metrics.NewCounterOpts(
+	namespace,
+	"errored_batch",
+	"number of batches that errored",
+))
+
+var FlushBatchSize = prometheus.NewCounter(metrics.NewCounterOpts(
+	namespace,
+	"flush_batch_size",
+	"size of flushed batch",
+))

--- a/node/node.go
+++ b/node/node.go
@@ -746,6 +746,10 @@ func (app *App) initServices(ctx context.Context) error {
 	for _, sig := range app.signers {
 		atxHandler.Register(sig)
 	}
+	app.eg.Go(func() error {
+		atxHandler.Start(ctx)
+		return nil
+	})
 
 	// we can't have an epoch offset which is greater/equal than the number of layers in an epoch
 


### PR DESCRIPTION
## Motivation

Adds write-coalescing to leaf-atxs (that have no dependecies) written to DB from gossip and sync handlers without discrimination.

## Description

WIP.
Adds support for write coalescing for ATXs coming in from gossip or sync. Right now trying to handle the case of ATXs that have no dependencies that need to be fetched from other peers simply due to the complexity of handling the other case, but hopefully I could manage to handle both cases in this PR.

<!-- If applicable please mention the issue addressed by this PR -->
<!-- `Closes #XXXX` links mentioned issues to this PR and automatically closes them when this it's merged -->

<!-- Please describe in detail the changes made. Focus on the reasoning rather than describing the change -->

## Test Plan

<!-- Please specify how these changes were tested (e.g. unit tests, manual testing, etc.) -->

## TODO

<!-- Please tick off the TODOs when completed -->

- [ ] Explain motivation or link existing issue(s)
- [ ] Test changes and document test plan
- [ ] Update documentation as needed
- [ ] Update [changelog](../CHANGELOG.md) as needed
