### PR TITLE
[Merged by Bors] - Fix response data slice too small

### DIFF
--- a/fetch/wire_types.go
+++ b/fetch/wire_types.go
@@ -121,7 +121,8 @@ type MaliciousIDs struct {
 
 type EpochData struct {
 	// When changing this value also check
-	// - the size of `ResponseMessage` above
+	// - the size of `ResponseMessage.Data` above
+	// - the size of `Response.Data` in `p2p/server/server.go`
 	// - the size of `NodeIDs` in `MaliciousIDs` above
 	// - the size of `Set` in `EpochActiveSet` in common/types/activation.go
 	// - the size of `EligibilityProofs` in the type `Ballot` in common/types/ballot.go

--- a/p2p/server/server.go
+++ b/p2p/server/server.go
@@ -139,7 +139,7 @@ func (err *ServerError) Error() string {
 // Response is a server response.
 type Response struct {
 	// keep in line with limit of ResponseMessage.Data in `fetch/wire_types.go`
-	Data  []byte `scale:"max=209715200"` // 200 MiB > 6.0 mio ATX * 32 bytes per ID
+	Data  []byte `scale:"max=272629760"` // 260 MiB > 8.0 mio ATX * 32 bytes per ID
 	Error string `scale:"max=1024"`      // TODO(mafa): make error code instead of string
 }
 

--- a/p2p/server/server_scale.go
+++ b/p2p/server/server_scale.go
@@ -9,7 +9,7 @@ import (
 
 func (t *Response) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	{
-		n, err := scale.EncodeByteSliceWithLimit(enc, t.Data, 209715200)
+		n, err := scale.EncodeByteSliceWithLimit(enc, t.Data, 272629760)
 		if err != nil {
 			return total, err
 		}
@@ -27,7 +27,7 @@ func (t *Response) EncodeScale(enc *scale.Encoder) (total int, err error) {
 
 func (t *Response) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	{
-		field, n, err := scale.DecodeByteSliceWithLimit(dec, 209715200)
+		field, n, err := scale.DecodeByteSliceWithLimit(dec, 272629760)
 		if err != nil {
 			return total, err
 		}


### PR DESCRIPTION
## Motivation

The response msg object needs to be increased in size to allow 8.0 Mio ATXs to be processed by the node

## Description

Bring `Response.Data` in line with other objects to be able to handle 8.0 Mio ATXs

## Test Plan

- n/a

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
