### PR TITLE
[Merged by Bors] - Cleanup code and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ such and the node will continue to scan new ATXs for their validity.
 
 ### Improvements
 
+## Release v1.6.6-hotfix1
+
+### Improvements
+
+* [#6248](https://github.com/spacemeshos/go-spacemesh/pull/6248) Fixed node not being able to handle more than 6.55M
+  ATXs per epoch.
+
 ## Release v1.6.6
 
 ### Improvements

--- a/activation/handler_v2.go
+++ b/activation/handler_v2.go
@@ -32,6 +32,8 @@ import (
 	"github.com/spacemeshos/go-spacemesh/system"
 )
 
+var errAtxNotV2 = errors.New("ATX is not V2")
+
 type nipostValidatorV2 interface {
 	IsVerifyingFullPost() bool
 	VRFNonceV2(smesherID types.NodeID, commitment types.ATXID, vrfNonce uint64, numUnits uint32) error
@@ -666,88 +668,95 @@ func (h *HandlerV2) syntacticallyValidateDeps(
 	return &result, nil
 }
 
-func (h *HandlerV2) checkMalicious(ctx context.Context, tx *sql.Tx, atx *activationTx) error {
+func (h *HandlerV2) checkMalicious(ctx context.Context, tx *sql.Tx, atx *activationTx) (bool, error) {
 	malicious, err := identities.IsMalicious(tx, atx.SmesherID)
 	if err != nil {
-		return fmt.Errorf("checking if node is malicious: %w", err)
+		return malicious, fmt.Errorf("checking if node is malicious: %w", err)
 	}
 	if malicious {
-		return nil
+		return true, nil
 	}
 
 	malicious, err = h.checkDoubleMarry(ctx, tx, atx)
 	if err != nil {
-		return fmt.Errorf("checking double marry: %w", err)
+		return malicious, fmt.Errorf("checking double marry: %w", err)
 	}
 	if malicious {
-		return nil
+		return true, nil
 	}
 
 	malicious, err = h.checkDoublePost(ctx, tx, atx)
 	if err != nil {
-		return fmt.Errorf("checking double post: %w", err)
+		return malicious, fmt.Errorf("checking double post: %w", err)
 	}
 	if malicious {
-		return nil
+		return true, nil
 	}
 
 	malicious, err = h.checkDoubleMerge(ctx, tx, atx)
 	if err != nil {
-		return fmt.Errorf("checking double merge: %w", err)
-	}
-	if malicious {
-		return nil
+		return malicious, fmt.Errorf("checking double merge: %w", err)
 	}
 
-	// TODO(mafa): contextual validation:
-	// 1. check double-publish = ID contributed post to two ATXs in the same epoch
-	// 2. check previous ATX
-	// 3  ID already married (same node ID in multiple marriage certificates)
-	// 4. two ATXs referencing the same marriage certificate in the same epoch
-	return nil
+	// TODO(mafa): missing contextual validation for invalid previous ATX
+
+	return malicious, err
+}
+
+func (h *HandlerV2) fetchWireAtx(ctx context.Context, tx *sql.Tx, id types.ATXID) (*wire.ActivationTxV2, error) {
+	var blob sql.Blob
+	v, err := atxs.LoadBlob(ctx, tx, id.Bytes(), &blob)
+	if err != nil {
+		return nil, fmt.Errorf("get atx blob %s: %w", id.ShortString(), err)
+	}
+	if v != types.AtxV2 {
+		return nil, errAtxNotV2
+	}
+	atx := &wire.ActivationTxV2{}
+	codec.MustDecode(blob.Bytes, atx)
+	return atx, nil
 }
 
 func (h *HandlerV2) checkDoubleMarry(ctx context.Context, tx *sql.Tx, atx *activationTx) (bool, error) {
 	for _, m := range atx.marriages {
-		mATX, err := identities.MarriageATX(tx, m.id)
+		mATXID, err := identities.MarriageATX(tx, m.id)
 		if err != nil {
 			return false, fmt.Errorf("checking if ID is married: %w", err)
 		}
-		if mATX != atx.ID() {
-			var blob sql.Blob
-			v, err := atxs.LoadBlob(ctx, tx, mATX.Bytes(), &blob)
-			if err != nil {
-				return true, fmt.Errorf("creating double marry proof: %w", err)
-			}
-			if v != types.AtxV2 {
-				h.logger.Fatal("Failed to create double marry malfeasance proof: ATX is not v2",
-					zap.Stringer("atx_id", mATX),
-				)
-			}
-			var otherAtx wire.ActivationTxV2
-			codec.MustDecode(blob.Bytes, &otherAtx)
-
-			proof, err := wire.NewDoubleMarryProof(tx, atx.ActivationTxV2, &otherAtx, m.id)
-			if err != nil {
-				return true, fmt.Errorf("creating double marry proof: %w", err)
-			}
-			return true, h.malPublisher.Publish(ctx, m.id, proof)
+		if mATXID == atx.ID() {
+			continue
 		}
+
+		otherAtx, err := h.fetchWireAtx(ctx, tx, mATXID)
+		switch {
+		case errors.Is(err, errAtxNotV2):
+			h.logger.Fatal("Failed to create double marry malfeasance proof: ATX is not v2",
+				zap.Stringer("atx_id", mATXID),
+			)
+		case err != nil:
+			return false, fmt.Errorf("fetching other ATX: %w", err)
+		}
+
+		proof, err := wire.NewDoubleMarryProof(tx, atx.ActivationTxV2, otherAtx, m.id)
+		if err != nil {
+			return true, fmt.Errorf("creating double marry proof: %w", err)
+		}
+		return true, h.malPublisher.Publish(ctx, m.id, proof)
 	}
 	return false, nil
 }
 
 func (h *HandlerV2) checkDoublePost(ctx context.Context, tx *sql.Tx, atx *activationTx) (bool, error) {
 	for id := range atx.ids {
-		atxids, err := atxs.FindDoublePublish(tx, id, atx.PublishEpoch)
+		atxIDs, err := atxs.FindDoublePublish(tx, id, atx.PublishEpoch)
 		switch {
 		case errors.Is(err, sql.ErrNotFound):
 			continue
 		case err != nil:
 			return false, fmt.Errorf("searching for double publish: %w", err)
 		}
-		otherAtxId := slices.IndexFunc(atxids, func(other types.ATXID) bool { return other != atx.ID() })
-		otherAtx := atxids[otherAtxId]
+		otherAtxId := slices.IndexFunc(atxIDs, func(other types.ATXID) bool { return other != atx.ID() })
+		otherAtx := atxIDs[otherAtxId]
 		h.logger.Debug(
 			"found ID that has already contributed its PoST in this epoch",
 			zap.Stringer("node_id", id),
@@ -821,22 +830,16 @@ func (h *HandlerV2) storeAtx(ctx context.Context, atx *types.ActivationTx, watx 
 
 	atxs.AtxAdded(h.cdb, atx)
 
-	var malicious bool
+	malicious := false
 	err := h.cdb.WithTx(ctx, func(tx *sql.Tx) error {
 		// malfeasance check happens after storing the ATX because storing updates the marriage set
 		// that is needed for the malfeasance proof
 		// TODO(mafa): don't store own ATX if it would mark the node as malicious
 		//    this probably needs to be done by validating and storing own ATXs eagerly and skipping validation in
 		//    the gossip handler (not sync!)
-		err := h.checkMalicious(ctx, tx, watx)
-		if err != nil {
-			return fmt.Errorf("check malicious: %w", err)
-		}
-		malicious, err = identities.IsMalicious(tx, watx.SmesherID)
-		if err != nil {
-			return fmt.Errorf("checking if identity is malicious: %w", err)
-		}
-		return nil
+		var err error
+		malicious, err = h.checkMalicious(ctx, tx, watx)
+		return err
 	})
 	if err != nil {
 		return fmt.Errorf("check malicious: %w", err)

--- a/activation/wire/malfeasance_double_marry_test.go
+++ b/activation/wire/malfeasance_double_marry_test.go
@@ -21,7 +21,7 @@ func Test_DoubleMarryProof(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("valid", func(t *testing.T) {
-		db := sql.InMemory()
+		db := sql.InMemoryTest(t)
 		otherAtx := &types.ActivationTx{}
 		otherAtx.SetID(types.RandomATXID())
 		otherAtx.SmesherID = otherSig.NodeID()
@@ -50,7 +50,7 @@ func Test_DoubleMarryProof(t *testing.T) {
 	})
 
 	t.Run("does not contain same certificate owner", func(t *testing.T) {
-		db := sql.InMemory()
+		db := sql.InMemoryTest(t)
 
 		atx1 := newActivationTxV2(
 			withMarriageCertificate(sig, types.EmptyATXID, sig.NodeID()),
@@ -79,7 +79,7 @@ func Test_DoubleMarryProof(t *testing.T) {
 		atx1 := newActivationTxV2()
 		atx1.Sign(sig)
 
-		db := sql.InMemory()
+		db := sql.InMemoryTest(t)
 		proof, err := NewDoubleMarryProof(db, atx1, atx1, sig.NodeID())
 		require.ErrorContains(t, err, "ATXs have the same ID")
 		require.Nil(t, proof)
@@ -103,7 +103,7 @@ func Test_DoubleMarryProof(t *testing.T) {
 	})
 
 	t.Run("invalid marriage proof", func(t *testing.T) {
-		db := sql.InMemory()
+		db := sql.InMemoryTest(t)
 		otherAtx := &types.ActivationTx{}
 		otherAtx.SetID(types.RandomATXID())
 		otherAtx.SmesherID = otherSig.NodeID()
@@ -150,7 +150,7 @@ func Test_DoubleMarryProof(t *testing.T) {
 	})
 
 	t.Run("invalid certificate proof", func(t *testing.T) {
-		db := sql.InMemory()
+		db := sql.InMemoryTest(t)
 		otherAtx := &types.ActivationTx{}
 		otherAtx.SetID(types.RandomATXID())
 		otherAtx.SmesherID = otherSig.NodeID()
@@ -197,7 +197,7 @@ func Test_DoubleMarryProof(t *testing.T) {
 	})
 
 	t.Run("invalid atx signature", func(t *testing.T) {
-		db := sql.InMemory()
+		db := sql.InMemoryTest(t)
 		otherAtx := &types.ActivationTx{}
 		otherAtx.SetID(types.RandomATXID())
 		otherAtx.SmesherID = otherSig.NodeID()
@@ -233,7 +233,7 @@ func Test_DoubleMarryProof(t *testing.T) {
 	})
 
 	t.Run("invalid certificate signature", func(t *testing.T) {
-		db := sql.InMemory()
+		db := sql.InMemoryTest(t)
 		otherAtx := &types.ActivationTx{}
 		otherAtx.SetID(types.RandomATXID())
 		otherAtx.SmesherID = otherSig.NodeID()
@@ -269,7 +269,7 @@ func Test_DoubleMarryProof(t *testing.T) {
 	})
 
 	t.Run("unknown reference ATX", func(t *testing.T) {
-		db := sql.InMemory()
+		db := sql.InMemoryTest(t)
 
 		atx1 := newActivationTxV2(
 			withMarriageCertificate(sig, types.EmptyATXID, sig.NodeID()),

--- a/hare3/hare.go
+++ b/hare3/hare.go
@@ -129,7 +129,7 @@ type WeakCoinOutput struct {
 
 type Opt func(*Hare)
 
-func WithWallclock(clock clockwork.Clock) Opt {
+func WithWallClock(clock clockwork.Clock) Opt {
 	return func(hr *Hare) {
 		hr.wallClock = clock
 	}

--- a/hare3/hare.go
+++ b/hare3/hare.go
@@ -131,7 +131,7 @@ type Opt func(*Hare)
 
 func WithWallclock(clock clockwork.Clock) Opt {
 	return func(hr *Hare) {
-		hr.wallclock = clock
+		hr.wallClock = clock
 	}
 }
 
@@ -163,15 +163,15 @@ func WithResultsChan(c chan hare4.ConsensusOutput) Opt {
 	}
 }
 
-type nodeclock interface {
+type nodeClock interface {
 	AwaitLayer(types.LayerID) <-chan struct{}
 	CurrentLayer() types.LayerID
 	LayerToTime(types.LayerID) time.Time
 }
 
 func New(
-	nodeclock nodeclock,
-	pubsub pubsub.PublishSubsciber,
+	nodeClock nodeClock,
+	pubsub pubsub.PublishSubscriber,
 	db *sql.Database,
 	atxsdata *atxsdata.Data,
 	proposals *store.Store,
@@ -192,9 +192,9 @@ func New(
 
 		config:    DefaultConfig(),
 		log:       zap.NewNop(),
-		wallclock: clockwork.NewRealClock(),
+		wallClock: clockwork.NewRealClock(),
 
-		nodeclock: nodeclock,
+		nodeClock: nodeClock,
 		pubsub:    pubsub,
 		db:        db,
 		atxsdata:  atxsdata,
@@ -229,11 +229,11 @@ type Hare struct {
 	// options
 	config    Config
 	log       *zap.Logger
-	wallclock clockwork.Clock
+	wallClock clockwork.Clock
 
 	// dependencies
-	nodeclock nodeclock
-	pubsub    pubsub.PublishSubsciber
+	nodeClock nodeClock
+	pubsub    pubsub.PublishSubscriber
 	db        *sql.Database
 	atxsdata  *atxsdata.Data
 	proposals *store.Store
@@ -261,7 +261,7 @@ func (h *Hare) Coins() <-chan hare4.WeakCoinOutput {
 
 func (h *Hare) Start() {
 	h.pubsub.Register(h.config.ProtocolName, h.Handler, pubsub.WithValidatorInline(true))
-	current := h.nodeclock.CurrentLayer() + 1
+	current := h.nodeClock.CurrentLayer() + 1
 	enabled := max(current, h.config.EnableLayer, types.GetEffectiveGenesis()+1)
 	disabled := types.LayerID(math.MaxUint32)
 	if h.config.DisableLayer > 0 {
@@ -275,7 +275,7 @@ func (h *Hare) Start() {
 	h.eg.Go(func() error {
 		for next := enabled; next < disabled; next++ {
 			select {
-			case <-h.nodeclock.AwaitLayer(next):
+			case <-h.nodeClock.AwaitLayer(next):
 				h.log.Debug("notified", zap.Uint32("lid", next.Uint32()))
 				h.onLayer(next)
 			case <-h.ctx.Done():
@@ -349,7 +349,7 @@ func (h *Hare) Handler(ctx context.Context, peer p2p.Peer, buf []byte) error {
 		droppedMessages.Inc()
 		return errors.New("dropped by graded gossip")
 	}
-	expected := h.nodeclock.LayerToTime(msg.Layer).Add(h.config.roundStart(msg.IterRound))
+	expected := h.nodeClock.LayerToTime(msg.Layer).Add(h.config.roundStart(msg.IterRound))
 	metrics.ReportMessageLatency(h.config.ProtocolName, msg.Round.String(), time.Since(expected))
 	return nil
 }
@@ -426,12 +426,12 @@ func (h *Hare) run(session *session) error {
 	h.tracer.OnActive(session.vrfs)
 	activeLatency.Observe(time.Since(start).Seconds())
 
-	walltime := h.nodeclock.LayerToTime(session.lid).Add(h.config.PreroundDelay)
+	walltime := h.nodeClock.LayerToTime(session.lid).Add(h.config.PreroundDelay)
 	if active {
 		h.log.Debug("active in preround. waiting for preround delay", zap.Uint32("lid", session.lid.Uint32()))
 		// initial set is not needed if node is not active in preround
 		select {
-		case <-h.wallclock.After(walltime.Sub(h.wallclock.Now())):
+		case <-h.wallClock.After(walltime.Sub(h.wallClock.Now())):
 		case <-h.ctx.Done():
 			return h.ctx.Err()
 		}
@@ -459,7 +459,7 @@ func (h *Hare) run(session *session) error {
 		activeLatency.Observe(time.Since(start).Seconds())
 
 		select {
-		case <-h.wallclock.After(walltime.Sub(h.wallclock.Now())):
+		case <-h.wallClock.After(walltime.Sub(h.wallClock.Now())):
 			h.log.Debug("execute round",
 				zap.Uint32("lid", session.lid.Uint32()),
 				zap.Uint8("iter", session.proto.Iter), zap.Stringer("round", session.proto.Round),

--- a/hare3/hare_test.go
+++ b/hare3/hare_test.go
@@ -121,7 +121,7 @@ type node struct {
 	proposals  *store.Store
 
 	ctrl       *gomock.Controller
-	mpublisher *pmocks.MockPublishSubsciber
+	mpublisher *pmocks.MockPublishSubscriber
 	msyncer    *smocks.MockSyncStateProvider
 	patrol     *layerpatrol.LayerPatrol
 	tracer     *testTracer
@@ -203,7 +203,7 @@ func (n *node) withOracle() *node {
 }
 
 func (n *node) withPublisher() *node {
-	n.mpublisher = pmocks.NewMockPublishSubsciber(n.ctrl)
+	n.mpublisher = pmocks.NewMockPublishSubscriber(n.ctrl)
 	n.mpublisher.EXPECT().Register(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 	return n
 }

--- a/hare3/hare_test.go
+++ b/hare3/hare_test.go
@@ -230,7 +230,7 @@ func (n *node) withHare() *node {
 		n.patrol,
 		WithConfig(n.t.cfg),
 		WithLogger(logger),
-		WithWallclock(n.clock),
+		WithWallClock(n.clock),
 		WithTracer(tracer),
 	)
 	n.register(n.signer)

--- a/hare4/hare.go
+++ b/hare4/hare.go
@@ -151,7 +151,7 @@ func WithServer(s streamRequester) Opt {
 	}
 }
 
-func WithWallclock(clock clockwork.Clock) Opt {
+func WithWallClock(clock clockwork.Clock) Opt {
 	return func(hr *Hare) {
 		hr.wallClock = clock
 	}

--- a/hare4/hare.go
+++ b/hare4/hare.go
@@ -153,7 +153,7 @@ func WithServer(s streamRequester) Opt {
 
 func WithWallclock(clock clockwork.Clock) Opt {
 	return func(hr *Hare) {
-		hr.wallclock = clock
+		hr.wallClock = clock
 	}
 }
 
@@ -185,19 +185,19 @@ func WithResultsChan(c chan ConsensusOutput) Opt {
 	}
 }
 
-type nodeclock interface {
+type nodeClock interface {
 	AwaitLayer(types.LayerID) <-chan struct{}
 	CurrentLayer() types.LayerID
 	LayerToTime(types.LayerID) time.Time
 }
 
 func New(
-	nodeclock nodeclock,
-	pubsub pubsub.PublishSubsciber,
+	nodeClock nodeClock,
+	pubsub pubsub.PublishSubscriber,
 	db *sql.Database,
 	atxsdata *atxsdata.Data,
 	proposals *store.Store,
-	verif verifier,
+	verifier verifier,
 	oracle oracle,
 	sync system.SyncStateProvider,
 	patrol *layerpatrol.LayerPatrol,
@@ -216,14 +216,14 @@ func New(
 
 		config:    DefaultConfig(),
 		log:       zap.NewNop(),
-		wallclock: clockwork.NewRealClock(),
+		wallClock: clockwork.NewRealClock(),
 
-		nodeclock: nodeclock,
+		nodeClock: nodeClock,
 		pubsub:    pubsub,
 		db:        db,
 		atxsdata:  atxsdata,
 		proposals: proposals,
-		verifier:  verif,
+		verifier:  verifier,
 		oracle: &legacyOracle{
 			log:    zap.NewNop(),
 			oracle: oracle,
@@ -258,11 +258,11 @@ type Hare struct {
 	// options
 	config    Config
 	log       *zap.Logger
-	wallclock clockwork.Clock
+	wallClock clockwork.Clock
 
 	// dependencies
-	nodeclock nodeclock
-	pubsub    pubsub.PublishSubsciber
+	nodeClock nodeClock
+	pubsub    pubsub.PublishSubscriber
 	db        *sql.Database
 	atxsdata  *atxsdata.Data
 	proposals *store.Store
@@ -291,7 +291,7 @@ func (h *Hare) Coins() <-chan WeakCoinOutput {
 
 func (h *Hare) Start() {
 	h.pubsub.Register(h.config.ProtocolName, h.Handler, pubsub.WithValidatorInline(true))
-	current := h.nodeclock.CurrentLayer() + 1
+	current := h.nodeClock.CurrentLayer() + 1
 	enabled := max(current, h.config.EnableLayer, types.GetEffectiveGenesis()+1)
 	disabled := types.LayerID(math.MaxUint32)
 	if h.config.DisableLayer > 0 {
@@ -305,7 +305,7 @@ func (h *Hare) Start() {
 	h.eg.Go(func() error {
 		for next := enabled; next < disabled; next++ {
 			select {
-			case <-h.nodeclock.AwaitLayer(next):
+			case <-h.nodeClock.AwaitLayer(next):
 				h.log.Debug("notified", zap.Uint32("layer", next.Uint32()))
 				h.onLayer(next)
 				h.cleanMessageCache(next - 1)
@@ -560,7 +560,7 @@ func (h *Hare) Handler(ctx context.Context, peer p2p.Peer, buf []byte) error {
 		droppedMessages.Inc()
 		return errors.New("dropped by graded gossip")
 	}
-	expected := h.nodeclock.LayerToTime(msg.Layer).Add(h.config.roundStart(msg.IterRound))
+	expected := h.nodeClock.LayerToTime(msg.Layer).Add(h.config.roundStart(msg.IterRound))
 	metrics.ReportMessageLatency(h.config.ProtocolName, msg.Round.String(), time.Since(expected))
 	return nil
 }
@@ -637,12 +637,12 @@ func (h *Hare) run(session *session) error {
 	h.tracer.OnActive(session.vrfs)
 	activeLatency.Observe(time.Since(start).Seconds())
 
-	walltime := h.nodeclock.LayerToTime(session.lid).Add(h.config.PreroundDelay)
+	walltime := h.nodeClock.LayerToTime(session.lid).Add(h.config.PreroundDelay)
 	if active {
 		h.log.Debug("active in preround. waiting for preround delay", zap.Uint32("lid", session.lid.Uint32()))
 		// initial set is not needed if node is not active in preround
 		select {
-		case <-h.wallclock.After(walltime.Sub(h.wallclock.Now())):
+		case <-h.wallClock.After(walltime.Sub(h.wallClock.Now())):
 		case <-h.ctx.Done():
 			return h.ctx.Err()
 		}
@@ -670,7 +670,7 @@ func (h *Hare) run(session *session) error {
 		activeLatency.Observe(time.Since(start).Seconds())
 
 		select {
-		case <-h.wallclock.After(walltime.Sub(h.wallclock.Now())):
+		case <-h.wallClock.After(walltime.Sub(h.wallClock.Now())):
 			h.log.Debug("execute round",
 				zap.Uint32("lid", session.lid.Uint32()),
 				zap.Uint8("iter", session.proto.Iter), zap.Stringer("round", session.proto.Round),

--- a/hare4/hare_test.go
+++ b/hare4/hare_test.go
@@ -258,7 +258,7 @@ func (n *node) withHare() *node {
 		nil,
 		WithConfig(n.t.cfg),
 		WithLogger(logger),
-		WithWallclock(n.clock),
+		WithWallClock(n.clock),
 		WithTracer(tracer),
 		WithServer(n.mockStreamRequester),
 		WithLogger(z),

--- a/hare4/hare_test.go
+++ b/hare4/hare_test.go
@@ -130,7 +130,7 @@ type node struct {
 	proposals  *store.Store
 
 	ctrl                *gomock.Controller
-	mpublisher          *pmocks.MockPublishSubsciber
+	mpublisher          *pmocks.MockPublishSubscriber
 	msyncer             *smocks.MockSyncStateProvider
 	mverifier           *hmock.Mockverifier
 	mockStreamRequester *hmock.MockstreamRequester
@@ -219,7 +219,7 @@ func (n *node) withOracle() *node {
 }
 
 func (n *node) withPublisher() *node {
-	n.mpublisher = pmocks.NewMockPublishSubsciber(n.ctrl)
+	n.mpublisher = pmocks.NewMockPublishSubscriber(n.ctrl)
 	n.mpublisher.EXPECT().Register(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 	return n
 }

--- a/p2p/pubsub/mocks/publisher.go
+++ b/p2p/pubsub/mocks/publisher.go
@@ -142,31 +142,31 @@ func (c *MockSubscriberRegisterCall) DoAndReturn(f func(string, pubsub.GossipHan
 	return c
 }
 
-// MockPublishSubsciber is a mock of PublishSubsciber interface.
-type MockPublishSubsciber struct {
+// MockPublishSubscriber is a mock of PublishSubscriber interface.
+type MockPublishSubscriber struct {
 	ctrl     *gomock.Controller
-	recorder *MockPublishSubsciberMockRecorder
+	recorder *MockPublishSubscriberMockRecorder
 }
 
-// MockPublishSubsciberMockRecorder is the mock recorder for MockPublishSubsciber.
-type MockPublishSubsciberMockRecorder struct {
-	mock *MockPublishSubsciber
+// MockPublishSubscriberMockRecorder is the mock recorder for MockPublishSubscriber.
+type MockPublishSubscriberMockRecorder struct {
+	mock *MockPublishSubscriber
 }
 
-// NewMockPublishSubsciber creates a new mock instance.
-func NewMockPublishSubsciber(ctrl *gomock.Controller) *MockPublishSubsciber {
-	mock := &MockPublishSubsciber{ctrl: ctrl}
-	mock.recorder = &MockPublishSubsciberMockRecorder{mock}
+// NewMockPublishSubscriber creates a new mock instance.
+func NewMockPublishSubscriber(ctrl *gomock.Controller) *MockPublishSubscriber {
+	mock := &MockPublishSubscriber{ctrl: ctrl}
+	mock.recorder = &MockPublishSubscriberMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockPublishSubsciber) EXPECT() *MockPublishSubsciberMockRecorder {
+func (m *MockPublishSubscriber) EXPECT() *MockPublishSubscriberMockRecorder {
 	return m.recorder
 }
 
 // Publish mocks base method.
-func (m *MockPublishSubsciber) Publish(arg0 context.Context, arg1 string, arg2 []byte) error {
+func (m *MockPublishSubscriber) Publish(arg0 context.Context, arg1 string, arg2 []byte) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Publish", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -174,37 +174,37 @@ func (m *MockPublishSubsciber) Publish(arg0 context.Context, arg1 string, arg2 [
 }
 
 // Publish indicates an expected call of Publish.
-func (mr *MockPublishSubsciberMockRecorder) Publish(arg0, arg1, arg2 any) *MockPublishSubsciberPublishCall {
+func (mr *MockPublishSubscriberMockRecorder) Publish(arg0, arg1, arg2 any) *MockPublishSubscriberPublishCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Publish", reflect.TypeOf((*MockPublishSubsciber)(nil).Publish), arg0, arg1, arg2)
-	return &MockPublishSubsciberPublishCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Publish", reflect.TypeOf((*MockPublishSubscriber)(nil).Publish), arg0, arg1, arg2)
+	return &MockPublishSubscriberPublishCall{Call: call}
 }
 
-// MockPublishSubsciberPublishCall wrap *gomock.Call
-type MockPublishSubsciberPublishCall struct {
+// MockPublishSubscriberPublishCall wrap *gomock.Call
+type MockPublishSubscriberPublishCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockPublishSubsciberPublishCall) Return(arg0 error) *MockPublishSubsciberPublishCall {
+func (c *MockPublishSubscriberPublishCall) Return(arg0 error) *MockPublishSubscriberPublishCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockPublishSubsciberPublishCall) Do(f func(context.Context, string, []byte) error) *MockPublishSubsciberPublishCall {
+func (c *MockPublishSubscriberPublishCall) Do(f func(context.Context, string, []byte) error) *MockPublishSubscriberPublishCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockPublishSubsciberPublishCall) DoAndReturn(f func(context.Context, string, []byte) error) *MockPublishSubsciberPublishCall {
+func (c *MockPublishSubscriberPublishCall) DoAndReturn(f func(context.Context, string, []byte) error) *MockPublishSubscriberPublishCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // Register mocks base method.
-func (m *MockPublishSubsciber) Register(arg0 string, arg1 pubsub.GossipHandler, arg2 ...pubsub.ValidatorOpt) {
+func (m *MockPublishSubscriber) Register(arg0 string, arg1 pubsub.GossipHandler, arg2 ...pubsub.ValidatorOpt) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -214,32 +214,32 @@ func (m *MockPublishSubsciber) Register(arg0 string, arg1 pubsub.GossipHandler, 
 }
 
 // Register indicates an expected call of Register.
-func (mr *MockPublishSubsciberMockRecorder) Register(arg0, arg1 any, arg2 ...any) *MockPublishSubsciberRegisterCall {
+func (mr *MockPublishSubscriberMockRecorder) Register(arg0, arg1 any, arg2 ...any) *MockPublishSubscriberRegisterCall {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]any{arg0, arg1}, arg2...)
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Register", reflect.TypeOf((*MockPublishSubsciber)(nil).Register), varargs...)
-	return &MockPublishSubsciberRegisterCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Register", reflect.TypeOf((*MockPublishSubscriber)(nil).Register), varargs...)
+	return &MockPublishSubscriberRegisterCall{Call: call}
 }
 
-// MockPublishSubsciberRegisterCall wrap *gomock.Call
-type MockPublishSubsciberRegisterCall struct {
+// MockPublishSubscriberRegisterCall wrap *gomock.Call
+type MockPublishSubscriberRegisterCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockPublishSubsciberRegisterCall) Return() *MockPublishSubsciberRegisterCall {
+func (c *MockPublishSubscriberRegisterCall) Return() *MockPublishSubscriberRegisterCall {
 	c.Call = c.Call.Return()
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockPublishSubsciberRegisterCall) Do(f func(string, pubsub.GossipHandler, ...pubsub.ValidatorOpt)) *MockPublishSubsciberRegisterCall {
+func (c *MockPublishSubscriberRegisterCall) Do(f func(string, pubsub.GossipHandler, ...pubsub.ValidatorOpt)) *MockPublishSubscriberRegisterCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockPublishSubsciberRegisterCall) DoAndReturn(f func(string, pubsub.GossipHandler, ...pubsub.ValidatorOpt)) *MockPublishSubsciberRegisterCall {
+func (c *MockPublishSubscriberRegisterCall) DoAndReturn(f func(string, pubsub.GossipHandler, ...pubsub.ValidatorOpt)) *MockPublishSubscriberRegisterCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/p2p/pubsub/pubsub.go
+++ b/p2p/pubsub/pubsub.go
@@ -133,8 +133,8 @@ var (
 	WithValidatorConcurrency = pubsub.WithValidatorConcurrency
 )
 
-// PublishSubsciber common interface for publisher and subscribing.
-type PublishSubsciber interface {
+// PublishSubscriber common interface for publisher and subscribing.
+type PublishSubscriber interface {
 	Publisher
 	Subscriber
 }


### PR DESCRIPTION
## Motivation

This updates the changelog after the release of `v1.6.6-hotfix1` and fixes a few typos in code.

## Description

- Updates CHANGELOG
- all code changes are typo fixes except
- `activation/handler_v2.go`: simplified code to not having to query an identity again about its standing
  - before if an identity was found to be malfeasant `checkMalfeasance` would return and then we would query again if it was found to be malicious, now `checkMalfeasance` just returns `true` if an identity is considered a bad actor.

## Test Plan

- existing tests pass

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
