### PR TITLE
feat: add write-coalesing to atx handling

### DIFF
--- a/activation/atxwriter/atxwriter.go
+++ b/activation/atxwriter/atxwriter.go
@@ -1,0 +1,148 @@
+package atxwriter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/spacemeshos/go-spacemesh/activation/wire"
+	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/sql"
+	"github.com/spacemeshos/go-spacemesh/sql/atxs"
+)
+
+var writerDelay = 100 * time.Millisecond
+
+type AtxWriter struct {
+	db     db
+	logger *zap.Logger
+
+	atxMu          sync.Mutex
+	ticker         *time.Ticker
+	pool           *sync.Pool
+	atxBatch       map[types.ATXID]atxBatchItem
+	atxBatchResult *batchResult
+}
+
+func New(db db, logger *zap.Logger) *AtxWriter {
+	// create a stopped ticker so we could reuse it later on
+	ticker := time.NewTicker(writerDelay)
+	ticker.Stop()
+
+	writer := &AtxWriter{
+		db:     db,
+		logger: logger,
+		ticker: ticker,
+		pool: &sync.Pool{
+			New: func() any {
+				s := make(map[types.ATXID]atxBatchItem)
+				return &s
+			},
+		},
+		atxBatchResult: &batchResult{
+			doneC: make(chan struct{}),
+		},
+	}
+	writer.atxBatch = writer.getBatch()
+	return writer
+}
+
+func (w *AtxWriter) getBatch() map[types.ATXID]atxBatchItem {
+	v := w.pool.Get().(*map[types.ATXID]atxBatchItem)
+	return *v
+}
+
+// putBatch puts back the map into the pool.
+func (w *AtxWriter) putBatch(v map[types.ATXID]atxBatchItem) {
+	clear(v)
+	w.pool.Put(&v)
+}
+
+// Start the forever-loop that flushes the atxs to the DB
+// at-least every `writerDelay`. The caller is responsible
+// to call Start in a different goroutine.
+func (w *AtxWriter) Start(ctx context.Context) {
+	w.ticker.Reset(writerDelay)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-w.ticker.C:
+			// copy-on-write
+			w.atxMu.Lock()
+			if len(w.atxBatch) == 0 {
+				w.atxMu.Unlock()
+				continue
+			}
+			batch := w.atxBatch                                         // copy the existing slice
+			w.atxBatch = w.getBatch()                                   // make a new one
+			res := w.atxBatchResult                                     // copy the result type
+			w.atxBatchResult = &batchResult{doneC: make(chan struct{})} // make a new one
+			w.atxMu.Unlock()
+			start := time.Now()
+			BatchWriteCount.Inc()
+			FlushBatchSize.Add(float64(len(batch)))
+
+			if err := w.db.WithTx(ctx, func(tx sql.Transaction) error {
+				var err error
+				for _, item := range batch {
+					err = atxs.Add(tx, item.Atx, item.Watx.Blob())
+					if err != nil && !errors.Is(err, sql.ErrObjectExists) {
+						WriteBatchErrorsCount.Inc()
+						return fmt.Errorf("add atx to db: %w", err)
+					}
+					err = atxs.SetPost(tx, item.Atx.ID(), item.Watx.PrevATXID, 0,
+						item.Atx.SmesherID, item.Watx.NumUnits, item.Watx.PublishEpoch)
+					if err != nil && !errors.Is(err, sql.ErrObjectExists) {
+						WriteBatchErrorsCount.Inc()
+						return fmt.Errorf("set post: %w", err)
+					}
+				}
+				return nil
+			}); err != nil {
+				res.err = err
+				ErroredBatchCount.Inc()
+				w.logger.Error("flush atxs to db", zap.Error(err))
+			}
+
+			tdiff := time.Since(start)
+			WriteTime.Add(float64(tdiff))
+			AtxWriteTimeHist.Observe(tdiff.Seconds())
+			close(res.doneC)
+			w.putBatch(batch)
+		}
+	}
+}
+
+func (w *AtxWriter) Store(atx *types.ActivationTx, watx *wire.ActivationTxV1) (<-chan struct{}, func() error) {
+	w.atxMu.Lock()
+	defer w.atxMu.Unlock()
+
+	w.atxBatch[atx.ID()] = atxBatchItem{Atx: atx, Watx: watx}
+	br := w.atxBatchResult
+	c := br.doneC
+	return c, br.Error
+}
+
+type batchResult struct {
+	doneC chan struct{}
+	err   error
+}
+
+func (b *batchResult) Error() error {
+	return b.err
+}
+
+type atxBatchItem struct {
+	Atx  *types.ActivationTx
+	Watx *wire.ActivationTxV1
+}
+
+type db interface {
+	WithTx(context.Context, func(sql.Transaction) error) error
+	sql.Executor
+}

--- a/activation/atxwriter/atxwriter_test.go
+++ b/activation/atxwriter/atxwriter_test.go
@@ -1,0 +1,299 @@
+package atxwriter_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/spacemeshos/merkle-tree"
+	"github.com/spacemeshos/poet/shared"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/spacemeshos/go-spacemesh/activation/atxwriter"
+	"github.com/spacemeshos/go-spacemesh/activation/wire"
+	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/sql"
+	"github.com/spacemeshos/go-spacemesh/sql/atxs"
+	"github.com/spacemeshos/go-spacemesh/sql/statesql/migrations"
+)
+
+var (
+	postGenesisEpoch types.EpochID = 2
+	goldenATXID                    = types.RandomATXID()
+	wAtx                           = newInitialATXv1(goldenATXID)
+	atx                            = toAtx(wAtx)
+)
+
+func TestWriteCoalesce_One(t *testing.T) {
+	w, db := newTestAtxWriter(t)
+
+	ch, errfn := w.Store(atx, wAtx)
+	var err error
+	select {
+	case <-ch:
+		err = errfn()
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout")
+	}
+	require.NoError(t, err)
+	has, err := atxs.Has(db, atx.ID())
+	require.True(t, has)
+	require.NoError(t, err)
+}
+
+func TestWriteCoalesce_Duplicates(t *testing.T) {
+	w, db := newTestAtxWriter(t)
+
+	ch, errfn := w.Store(atx, wAtx)
+	_, _ = w.Store(atx, wAtx)
+	var err error
+	select {
+	case <-ch:
+		err = errfn()
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout")
+	}
+	require.NoError(t, err)
+	has, err := atxs.Has(db, atx.ID())
+	require.True(t, has)
+	require.NoError(t, err)
+}
+
+func TestWriteCoalesce_MultipleBatches(t *testing.T) {
+	w, db := newTestAtxWriter(t)
+
+	ch, errfn := w.Store(atx, wAtx)
+	var err error
+	select {
+	case <-ch:
+		err = errfn()
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout")
+	}
+	require.NoError(t, err)
+	has, err := atxs.Has(db, atx.ID())
+	require.True(t, has)
+	require.NoError(t, err)
+
+	wAtx2 := newInitialATXv1(types.RandomATXID())
+	atx2 := toAtx(wAtx)
+
+	ch, errfn = w.Store(atx2, wAtx2)
+	select {
+	case <-ch:
+		err = errfn()
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout")
+	}
+	require.NoError(t, err)
+	has, err = atxs.Has(db, atx2.ID())
+	require.True(t, has)
+	require.NoError(t, err)
+}
+
+func BenchmarkWriteCoalesing(b *testing.B) {
+	a := make([]atxwriter.AtxBatchItem, 100000)
+	for i := 0; i < len(a); i++ {
+		goldenATXID := types.RandomATXID()
+		wAtx := newInitialATXv1(goldenATXID)
+		atx := toAtx(wAtx)
+		a[i] = atxwriter.AtxBatchItem{Atx: atx, Watx: wAtx}
+	}
+
+	b.ResetTimer()
+	b.Run("No Coalesing", func(b *testing.B) {
+		db := newDiskSqlite(b)
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if err := db.WithTx(context.Background(), func(tx *sql.Tx) error {
+				var err error
+				err = atxs.Add(tx, a[i].Atx, a[i].Watx.Blob())
+				if err != nil {
+					b.Fatal(err)
+				}
+				err = atxs.SetPost(tx, a[i].Atx.ID(), a[i].Watx.PrevATXID, 0,
+					a[i].Atx.SmesherID, a[i].Watx.NumUnits)
+				if err != nil {
+					b.Fatal(err)
+				}
+				return nil
+			}); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	// with the coalesing tests, one must take the "ns/op" metrics and divide it
+	// by the number of entries written together to see how many items we're doing
+	// per time unit.
+	b.Run("Coalesing 1000 entries", func(b *testing.B) {
+		db := newDiskSqlite(b)
+		b.ResetTimer()
+		for j := 0; j < b.N; j++ {
+			if err := db.WithTx(context.Background(), func(tx *sql.Tx) error {
+				var err error
+				for i := (j * 1000); i < (j*1000)+1000; i++ {
+					err = atxs.Add(tx, a[i].Atx, a[i].Watx.Blob())
+					if err != nil {
+						b.Fatal(err)
+					}
+					err = atxs.SetPost(tx, a[i].Atx.ID(), a[i].Watx.PrevATXID, 0,
+						a[i].Atx.SmesherID, a[i].Watx.NumUnits)
+					if err != nil {
+						b.Fatal(err)
+					}
+				}
+				return nil
+			}); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("Coalesing 5000 entries", func(b *testing.B) {
+		db := newDiskSqlite(b)
+		b.ResetTimer()
+		for j := 0; j < b.N; j++ {
+			if err := db.WithTx(context.Background(), func(tx *sql.Tx) error {
+				var err error
+				for i := (j * 5000); i < (j*5000)+5000; i++ {
+					err = atxs.Add(tx, a[i].Atx, a[i].Watx.Blob())
+					if err != nil {
+						b.Fatal(err)
+					}
+					err = atxs.SetPost(tx, a[i].Atx.ID(), a[i].Watx.PrevATXID, 0,
+						a[i].Atx.SmesherID, a[i].Watx.NumUnits)
+					if err != nil {
+						b.Fatal(err)
+					}
+				}
+				return nil
+			}); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+func toAtx(watx *wire.ActivationTxV1) *types.ActivationTx {
+	atx := wire.ActivationTxFromWireV1(watx)
+	atx.SetReceived(time.Now())
+	atx.BaseTickHeight = uint64(atx.PublishEpoch)
+	atx.TickCount = 1
+	return atx
+}
+
+func newTestAtxWriter(t testing.TB) (*atxwriter.AtxWriter, *sql.Database) {
+	t.Helper()
+	db := sql.InMemoryTest(t)
+	log := zaptest.NewLogger(t)
+	w := atxwriter.New(db, log)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	t.Cleanup(func() {
+		cancel()
+		<-done
+	})
+	go func() {
+		defer close(done)
+		w.Start(ctx)
+	}()
+	return w, db
+}
+
+func newDiskSqlite(tb testing.TB) *sql.Database {
+	tb.Helper()
+	m21 := migrations.New0021Migration(zap.NewNop(), 1_000_000)
+	migrations, err := sql.StateMigrations()
+	if err != nil {
+		tb.Fatal(err)
+	}
+	dbopts := []sql.Opt{
+		sql.WithMigrations(migrations),
+		sql.WithMigration(m21),
+	}
+	dir := tb.TempDir()
+	sqlDB, err := sql.Open("file:"+filepath.Join(dir, "sql.sql"), dbopts...)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	tb.Cleanup(func() { sqlDB.Close() })
+	return sqlDB
+}
+
+func newInitialATXv1(
+	goldenATXID types.ATXID,
+	opts ...func(*wire.ActivationTxV1),
+) *wire.ActivationTxV1 {
+	nonce := uint64(999)
+	poetRef := types.RandomHash()
+	atx := &wire.ActivationTxV1{
+		InnerActivationTxV1: wire.InnerActivationTxV1{
+			NIPostChallengeV1: wire.NIPostChallengeV1{
+				PrevATXID:        types.EmptyATXID,
+				PublishEpoch:     postGenesisEpoch,
+				PositioningATXID: goldenATXID,
+				CommitmentATXID:  &goldenATXID,
+				InitialPost:      &wire.PostV1{},
+			},
+			NIPost:   newNIPostV1WithPoet(poetRef.Bytes()),
+			VRFNonce: &nonce,
+			Coinbase: types.GenerateAddress([]byte("aaaa")),
+			NumUnits: 100,
+		},
+	}
+	for _, opt := range opts {
+		opt(atx)
+	}
+	return atx
+}
+
+func newMerkleProof(leafs []types.Hash32) (types.MerkleProof, types.Hash32) {
+	tree, err := merkle.NewTreeBuilder().
+		WithHashFunc(shared.HashMembershipTreeNode).
+		WithLeavesToProve(map[uint64]bool{0: true}).
+		Build()
+	if err != nil {
+		panic(err)
+	}
+	for _, m := range leafs {
+		if err := tree.AddLeaf(m[:]); err != nil {
+			panic(err)
+		}
+	}
+	root, nodes := tree.RootAndProof()
+	nodesH32 := make([]types.Hash32, 0, len(nodes))
+	for _, n := range nodes {
+		nodesH32 = append(nodesH32, types.BytesToHash(n))
+	}
+	return types.MerkleProof{
+		Nodes: nodesH32,
+	}, types.BytesToHash(root)
+}
+
+func newNIPostV1WithPoet(poetRef []byte) *wire.NIPostV1 {
+	proof, _ := newMerkleProof([]types.Hash32{
+		types.BytesToHash([]byte("challenge")),
+		types.BytesToHash([]byte("leaf2")),
+		types.BytesToHash([]byte("leaf3")),
+		types.BytesToHash([]byte("leaf4")),
+	})
+
+	return &wire.NIPostV1{
+		Membership: wire.MerkleProofV1{
+			Nodes:     proof.Nodes,
+			LeafIndex: 0,
+		},
+		Post: &wire.PostV1{
+			Nonce:   0,
+			Indices: []byte{1, 2, 3},
+			Pow:     0,
+		},
+		PostMetadata: &wire.PostMetadataV1{
+			Challenge: poetRef,
+		},
+	}
+}

--- a/activation/atxwriter/export_test.go
+++ b/activation/atxwriter/export_test.go
@@ -1,0 +1,3 @@
+package atxwriter
+
+type AtxBatchItem = atxBatchItem

--- a/activation/atxwriter/metrics.go
+++ b/activation/atxwriter/metrics.go
@@ -1,0 +1,47 @@
+package atxwriter
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/spacemeshos/go-spacemesh/metrics"
+)
+
+const (
+	namespace = "activation_write_coalescer"
+)
+
+var BatchWriteCount = metrics.NewSimpleCounter(
+	namespace,
+	"batch_write_count",
+	"number of errors when writing a batch",
+)
+
+var WriteBatchErrorsCount = metrics.NewSimpleCounter(
+	namespace,
+	"write_batch_errors",
+	"number of errors when writing a batch",
+)
+
+var ErroredBatchCount = metrics.NewSimpleCounter(
+	namespace,
+	"errored_batch",
+	"number of batches that errored",
+)
+
+var FlushBatchSize = metrics.NewSimpleCounter(
+	namespace,
+	"flush_batch_size",
+	"size of flushed batch",
+)
+
+var WriteTime = metrics.NewSimpleCounter(
+	namespace,
+	"write_time",
+	"time spent writing the batch (not under lock)",
+)
+
+var AtxWriteTimeHist = metrics.NewHistogramNoLabel(
+	"atx_write_time_hist",
+	namespace,
+	"time spent writing atxs in seconds (histogram)",
+	prometheus.ExponentialBuckets(0.01, 10, 5),
+)

--- a/activation/handler.go
+++ b/activation/handler.go
@@ -11,6 +11,7 @@ import (
 	"go.uber.org/zap/zapcore"
 	"golang.org/x/sync/singleflight"
 
+	"github.com/spacemeshos/go-spacemesh/activation/atxwriter"
 	"github.com/spacemeshos/go-spacemesh/activation/wire"
 	"github.com/spacemeshos/go-spacemesh/atxsdata"
 	"github.com/spacemeshos/go-spacemesh/codec"
@@ -100,6 +101,7 @@ func NewHandler(
 	local p2p.Peer,
 	cdb *datastore.CachedDB,
 	atxsdata *atxsdata.Data,
+	atxWriter *atxwriter.AtxWriter,
 	edVerifier *signing.EdVerifier,
 	c layerClock,
 	pub pubsub.Publisher,
@@ -121,6 +123,7 @@ func NewHandler(
 			local:           local,
 			cdb:             cdb,
 			atxsdata:        atxsdata,
+			atxWriter:       atxWriter,
 			edVerifier:      edVerifier,
 			clock:           c,
 			tickSize:        1,

--- a/metrics/common.go
+++ b/metrics/common.go
@@ -76,10 +76,22 @@ func ReportMessageLatency(protocol, msgType string, latency time.Duration) {
 	receivedMessagesLatency.WithLabelValues(protocol, msgType, sign).Observe(seconds)
 }
 
+// NewHistogram creates a Histogram metrics under the global namespace returns nop if metrics are disabled.
+func NewSimpleCounter(subsystem, name, help string) prometheus.Counter {
+	return promauto.NewCounter(NewCounterOpts(subsystem, name, help))
+}
+
 func NewCounterOpts(ns, name, help string) prometheus.CounterOpts {
 	return prometheus.CounterOpts{
-		Namespace: ns,
+		Namespace: Namespace,
+		Subsystem: ns,
 		Name:      name,
 		Help:      help,
 	}
+}
+
+func NewHistogramNoLabel(name, subsystem, help string, buckets []float64) prometheus.Histogram {
+	return promauto.NewHistogram(
+		prometheus.HistogramOpts{Namespace: Namespace, Subsystem: subsystem, Name: name, Help: help, Buckets: buckets},
+	)
 }


### PR DESCRIPTION
## Motivation

Adds write-coalescing to ATXs written to DB from gossip and sync handlers.
Closes https://github.com/spacemeshos/go-spacemesh/issues/5557

## Description

Supersedes https://github.com/spacemeshos/go-spacemesh/pull/6239


<!-- If applicable please mention the issue addressed by this PR -->
<!-- `Closes #XXXX` links mentioned issues to this PR and automatically closes them when this it's merged -->

<!-- Please describe in detail the changes made. Focus on the reasoning rather than describing the change -->

## Test Plan

<!-- Please specify how these changes were tested (e.g. unit tests, manual testing, etc.) -->

## TODO

<!-- Please tick off the TODOs when completed -->

- [ ] Explain motivation or link existing issue(s)
- [ ] Test changes and document test plan
- [ ] Update documentation as needed
- [ ] Update [changelog](../CHANGELOG.md) as needed
