### PR TITLE
[Merged by Bors] - Avoid global logger in events

### DIFF
--- a/activation/handler_v1.go
+++ b/activation/handler_v1.go
@@ -580,7 +580,13 @@ func (h *HandlerV1) processATX(
 		return nil, fmt.Errorf("cannot store atx %s: %w", atx.ShortString(), err)
 	}
 
-	events.ReportNewActivation(atx)
+	if err := events.ReportNewActivation(atx); err != nil {
+		h.logger.Error("failed to emit activation",
+			log.ZShortStringer("atx_id", atx.ID()),
+			zap.Uint32("epoch", atx.PublishEpoch.Uint32()),
+			zap.Error(err),
+		)
+	}
 	h.logger.Debug("new atx",
 		log.ZContext(ctx),
 		zap.Inline(atx),

--- a/activation/handler_v2.go
+++ b/activation/handler_v2.go
@@ -145,7 +145,13 @@ func (h *HandlerV2) processATX(
 		return fmt.Errorf("cannot store atx %s: %w", atx.ShortString(), err)
 	}
 
-	events.ReportNewActivation(atx)
+	if err := events.ReportNewActivation(atx); err != nil {
+		h.logger.Error("failed to emit activation",
+			log.ZShortStringer("atx_id", atx.ID()),
+			zap.Uint32("epoch", atx.PublishEpoch.Uint32()),
+			zap.Error(err),
+		)
+	}
 	h.logger.Debug("new atx", log.ZContext(ctx), zap.Inline(atx))
 	return err
 }

--- a/api/grpcserver/grpcserver_test.go
+++ b/api/grpcserver/grpcserver_test.go
@@ -1445,7 +1445,7 @@ func TestTransactionService(t *testing.T) {
 			// Give the server-side time to subscribe to events
 			time.Sleep(time.Millisecond * 50)
 
-			events.ReportNewTx(0, globalTx)
+			require.NoError(t, events.ReportNewTx(0, globalTx))
 			res, err := stream.Recv()
 			require.NoError(t, err)
 			require.Nil(t, res.Transaction)
@@ -1470,7 +1470,7 @@ func TestTransactionService(t *testing.T) {
 			// Give the server-side time to subscribe to events
 			time.Sleep(time.Millisecond * 50)
 
-			events.ReportNewTx(0, globalTx)
+			require.NoError(t, events.ReportNewTx(0, globalTx))
 
 			// Verify
 			res, err := stream.Recv()
@@ -1563,7 +1563,7 @@ func TestTransactionService(t *testing.T) {
 
 			// TODO send header after stream has subscribed
 
-			events.ReportNewTx(0, globalTx)
+			require.NoError(t, events.ReportNewTx(0, globalTx))
 
 			for _, stream := range streams {
 				res, err := stream.Recv()
@@ -1593,7 +1593,7 @@ func TestTransactionService(t *testing.T) {
 			time.Sleep(time.Millisecond * 50)
 
 			for range subscriptionChanBufSize * 2 {
-				events.ReportNewTx(0, globalTx)
+				require.NoError(t, events.ReportNewTx(0, globalTx))
 			}
 
 			for range subscriptionChanBufSize {
@@ -1691,15 +1691,15 @@ func TestAccountMeshDataStream_comprehensive(t *testing.T) {
 	time.Sleep(time.Millisecond * 50)
 
 	// publish a tx
-	events.ReportNewTx(0, globalTx)
+	require.NoError(t, events.ReportNewTx(0, globalTx))
 	res, err := stream.Recv()
 	require.NoError(t, err, "got error from stream")
 	checkAccountMeshDataItemTx(t, res.Datum.Datum)
 
 	// test streaming a tx and an atx that are filtered out
 	// these should not be received
-	events.ReportNewTx(0, globalTx2)
-	events.ReportNewActivation(globalAtx2)
+	require.NoError(t, events.ReportNewTx(0, globalTx2))
+	require.NoError(t, events.ReportNewActivation(globalAtx2))
 
 	_, err = stream.Recv()
 	require.Error(t, err)
@@ -1739,20 +1739,20 @@ func TestAccountDataStream_comprehensive(t *testing.T) {
 	// Give the server-side time to subscribe to events
 	time.Sleep(time.Millisecond * 50)
 
-	events.ReportRewardReceived(types.Reward{
+	require.NoError(t, events.ReportRewardReceived(types.Reward{
 		Layer:       layerFirst,
 		TotalReward: rewardAmount,
 		LayerReward: rewardAmount * 2,
 		Coinbase:    addr1,
 		SmesherID:   rewardSmesherID,
-	})
+	}))
 
 	res, err := stream.Recv()
 	require.NoError(t, err)
 	checkAccountDataItemReward(t, res.Datum.Datum)
 
 	// publish an account data update
-	events.ReportAccountUpdate(addr1)
+	require.NoError(t, events.ReportAccountUpdate(addr1))
 
 	res, err = stream.Recv()
 	require.NoError(t, err)
@@ -1760,8 +1760,8 @@ func TestAccountDataStream_comprehensive(t *testing.T) {
 
 	// test streaming a reward and account update that should be filtered out
 	// these should not be received
-	events.ReportAccountUpdate(addr2)
-	events.ReportRewardReceived(types.Reward{Coinbase: addr2})
+	require.NoError(t, events.ReportAccountUpdate(addr2))
+	require.NoError(t, events.ReportRewardReceived(types.Reward{Coinbase: addr2}))
 
 	_, err = stream.Recv()
 	require.Error(t, err)
@@ -1796,19 +1796,19 @@ func TestGlobalStateStream_comprehensive(t *testing.T) {
 	time.Sleep(time.Millisecond * 50)
 
 	// publish a reward
-	events.ReportRewardReceived(types.Reward{
+	require.NoError(t, events.ReportRewardReceived(types.Reward{
 		Layer:       layerFirst,
 		TotalReward: rewardAmount,
 		LayerReward: rewardAmount * 2,
 		Coinbase:    addr1,
 		SmesherID:   rewardSmesherID,
-	})
+	}))
 	res, err := stream.Recv()
 	require.NoError(t, err, "got error from stream")
 	checkGlobalStateDataReward(t, res.Datum.Datum)
 
 	// publish an account data update
-	events.ReportAccountUpdate(addr1)
+	require.NoError(t, events.ReportAccountUpdate(addr1))
 	res, err = stream.Recv()
 	require.NoError(t, err, "got error from stream")
 	checkGlobalStateDataAccountWrapper(t, res.Datum.Datum)
@@ -1817,10 +1817,10 @@ func TestGlobalStateStream_comprehensive(t *testing.T) {
 	layer, err := meshAPIMock.GetLayer(layerFirst)
 	require.NoError(t, err)
 
-	events.ReportLayerUpdate(events.LayerUpdate{
+	require.NoError(t, events.ReportLayerUpdate(events.LayerUpdate{
 		LayerID: layer.Index(),
 		Status:  events.LayerStatusTypeApplied,
-	})
+	}))
 	res, err = stream.Recv()
 	require.NoError(t, err, "got error from stream")
 	checkGlobalStateDataGlobalState(t, res.Datum.Datum)
@@ -1868,10 +1868,10 @@ func TestLayerStream_comprehensive(t *testing.T) {
 	require.NoError(t, err)
 
 	// Act
-	events.ReportLayerUpdate(events.LayerUpdate{
+	require.NoError(t, events.ReportLayerUpdate(events.LayerUpdate{
 		LayerID: layer.Index(),
 		Status:  events.LayerStatusTypeConfirmed,
-	})
+	}))
 
 	// Verify
 	res, err := stream.Recv()

--- a/api/grpcserver/node_service.go
+++ b/api/grpcserver/node_service.go
@@ -133,7 +133,11 @@ func (s *NodeService) StatusStream(_ *pb.StatusStreamRequest, stream pb.NodeServ
 		statusBufFull <-chan struct{}
 	)
 
-	if statusSubscription := events.SubscribeStatus(); statusSubscription != nil {
+	statusSubscription, err := events.SubscribeStatus()
+	if err != nil {
+		return status.Errorf(codes.Internal, "failed to subscribe to status events: %v", err)
+	}
+	if statusSubscription != nil {
 		statusCh, statusBufFull = consumeEvents[events.Status](stream.Context(), statusSubscription)
 	}
 
@@ -180,7 +184,11 @@ func (s *NodeService) ErrorStream(_ *pb.ErrorStreamRequest, stream pb.NodeServic
 		errorsBufFull <-chan struct{}
 	)
 
-	if errorsSubscription := events.SubscribeErrors(); errorsSubscription != nil {
+	errorsSubscription, err := events.SubscribeErrors()
+	if err != nil {
+		return status.Errorf(codes.Internal, "failed to subscribe to error events: %v", err)
+	}
+	if errorsSubscription != nil {
 		errorsCh, errorsBufFull = consumeEvents[events.NodeError](stream.Context(), errorsSubscription)
 	}
 	if err := stream.SendHeader(metadata.MD{}); err != nil {

--- a/api/grpcserver/transaction_service.go
+++ b/api/grpcserver/transaction_service.go
@@ -202,11 +202,19 @@ func (s *TransactionService) TransactionsStateStream(
 		txBufFull, layerBufFull <-chan struct{}
 	)
 
-	if txsSubscription := events.SubscribeTxs(); txsSubscription != nil {
+	txsSubscription, err := events.SubscribeTxs()
+	if err != nil {
+		return status.Errorf(codes.Internal, "failed to subscribe to tx events: %v", err)
+	}
+	if txsSubscription != nil {
 		txCh, txBufFull = consumeEvents[events.Transaction](stream.Context(), txsSubscription)
 	}
 
-	if layersSubscription := events.SubscribeLayers(); layersSubscription != nil {
+	layersSubscription, err := events.SubscribeLayers()
+	if err != nil {
+		return status.Errorf(codes.Internal, "failed to subscribe to layer events: %v", err)
+	}
+	if layersSubscription != nil {
 		layerCh, layerBufFull = consumeEvents[events.LayerUpdate](stream.Context(), layersSubscription)
 	}
 
@@ -265,7 +273,7 @@ func (s *TransactionService) TransactionsStateStream(
 				ctxzap.Error(
 					stream.Context(),
 					"error reading layer data for updated layer",
-					layer.LayerID.Field().Zap(),
+					zap.Uint32("lid", layer.LayerID.Uint32()),
 					zap.Error(err),
 				)
 				return status.Error(codes.Internal, "error reading layer data")
@@ -313,8 +321,8 @@ func (s *TransactionService) TransactionsStateStream(
 								ctxzap.Error(
 									stream.Context(),
 									"could not find transaction from layer",
-									txid.Field().Zap(),
-									layer.Field().Zap(),
+									zap.Stringer("tx_id", txid),
+									zap.Inline(layer),
 									zap.Error(err),
 								)
 								return status.Error(codes.Internal, "error retrieving tx data")

--- a/api/grpcserver/transaction_service_test.go
+++ b/api/grpcserver/transaction_service_test.go
@@ -117,7 +117,7 @@ func TestTransactionService_StreamResults(t *testing.T) {
 
 				var expect []*types.TransactionWithResult
 				for _, rst := range streamed {
-					events.ReportResult(*rst)
+					require.NoError(t, events.ReportResult(*rst))
 					if tc.matcher.match(rst) {
 						expect = append(expect, rst)
 					}

--- a/api/grpcserver/v2alpha1/activation_test.go
+++ b/api/grpcserver/v2alpha1/activation_test.go
@@ -193,7 +193,7 @@ func TestActivationStreamService_Stream(t *testing.T) {
 
 				var expect []*types.ActivationTx
 				for _, rst := range streamed {
-					events.ReportNewActivation(rst.ActivationTx)
+					require.NoError(t, events.ReportNewActivation(rst.ActivationTx))
 					matcher := atxsMatcher{tc.request, ctx}
 					if matcher.match(rst) {
 						expect = append(expect, rst.ActivationTx)

--- a/api/grpcserver/v2alpha1/layer_test.go
+++ b/api/grpcserver/v2alpha1/layer_test.go
@@ -189,7 +189,7 @@ func TestLayerStreamService_Stream(t *testing.T) {
 						Status:  s,
 					}
 
-					events.ReportLayerUpdate(lu)
+					require.NoError(t, events.ReportLayerUpdate(lu))
 					matcher := layersMatcher{tc.request, ctx}
 					if matcher.match(&lu) {
 						expect = append(expect, &rst)

--- a/api/grpcserver/v2alpha1/reward_test.go
+++ b/api/grpcserver/v2alpha1/reward_test.go
@@ -190,7 +190,7 @@ func TestRewardStreamService_Stream(t *testing.T) {
 
 				var expect []*types.Reward
 				for _, rst := range streamed {
-					events.ReportRewardReceived(rst)
+					require.NoError(t, events.ReportRewardReceived(rst))
 					matcher := rewardsMatcher{tc.request, ctx}
 					if matcher.match(&rst) {
 						expect = append(expect, &rst)

--- a/common/types/activation.go
+++ b/common/types/activation.go
@@ -10,7 +10,6 @@ import (
 	"go.uber.org/zap/zapcore"
 
 	"github.com/spacemeshos/go-spacemesh/common/util"
-	"github.com/spacemeshos/go-spacemesh/log"
 )
 
 //go:generate scalegen -types ATXMetadata,MerkleProof,EpochActiveSet
@@ -312,9 +311,6 @@ type NIPost struct {
 // VRFPostIndex is the nonce generated using Pow during post initialization. It is used as a mitigation for
 // grinding of identities for VRF eligibility.
 type VRFPostIndex uint64
-
-// Field returns a log field. Implements the LoggableField interface.
-func (v VRFPostIndex) Field() log.Field { return log.Uint64("vrf_nonce", uint64(v)) }
 
 // Post is an alias to postShared.Proof.
 type Post shared.Proof

--- a/common/types/address.go
+++ b/common/types/address.go
@@ -112,11 +112,6 @@ func (a Address) String() string {
 	return result
 }
 
-// Field returns a log field. Implements the LoggableField interface.
-func (a Address) Field() log.Field {
-	return log.String("address", a.String())
-}
-
 // Format implements fmt.Formatter, forcing the byte slice to be formatted as is,
 // without going through the stringer interface used for logging.
 func (a Address) Format(s fmt.State, c rune) {

--- a/common/types/beacon.go
+++ b/common/types/beacon.go
@@ -4,7 +4,6 @@ import (
 	"encoding/hex"
 
 	"github.com/spacemeshos/go-spacemesh/common/util"
-	"github.com/spacemeshos/go-spacemesh/log"
 )
 
 const (
@@ -27,11 +26,6 @@ func (b Beacon) String() string { return hex.EncodeToString(b[:]) }
 // Bytes gets the byte representation of the underlying hash.
 func (b Beacon) Bytes() []byte {
 	return b[:]
-}
-
-// Field returns a log field. Implements the LoggableField interface.
-func (b Beacon) Field() log.Field {
-	return log.Stringer("beacon", b)
 }
 
 func (b *Beacon) MarshalText() ([]byte, error) {

--- a/common/types/epoch.go
+++ b/common/types/epoch.go
@@ -4,8 +4,6 @@ import (
 	"strconv"
 
 	"github.com/spacemeshos/go-scale"
-
-	"github.com/spacemeshos/go-spacemesh/log"
 )
 
 // EpochID is the running epoch number. It's zero-based, so the genesis epoch has EpochID == 0.
@@ -44,9 +42,6 @@ func (e EpochID) Add(epochs uint32) EpochID {
 	e = EpochID(nl)
 	return e
 }
-
-// Field returns a log field. Implements the LoggableField interface.
-func (e EpochID) Field() log.Field { return log.Uint32("epoch_id", uint32(e)) }
 
 // String returns string representation of the epoch id numeric value.
 func (e EpochID) String() string {

--- a/common/types/hashes.go
+++ b/common/types/hashes.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/spacemeshos/go-spacemesh/common/util"
 	"github.com/spacemeshos/go-spacemesh/hash"
-	"github.com/spacemeshos/go-spacemesh/log"
 )
 
 const (
@@ -204,16 +203,6 @@ func (h *Hash32) SetBytes(b []byte) {
 func (h Hash32) ToHash20() (h20 Hash20) {
 	copy(h20[:], h[:])
 	return
-}
-
-// Field returns a log field. Implements the LoggableField interface.
-func (h Hash20) Field() log.Field {
-	return log.Stringer("hash", h)
-}
-
-// Field returns a log field. Implements the LoggableField interface.
-func (h Hash32) Field() log.Field {
-	return log.Stringer("hash", h)
 }
 
 // EncodeScale implements scale codec interface.

--- a/common/types/layer.go
+++ b/common/types/layer.go
@@ -139,9 +139,6 @@ func (l LayerID) Difference(other LayerID) uint32 {
 	return (l - other).Uint32()
 }
 
-// Field returns a log field. Implements the LoggableField interface.
-func (l LayerID) Field() log.Field { return log.Uint32("layer_id", l.Uint32()) }
-
 // String returns string representation of the layer id numeric value.
 func (l LayerID) String() string {
 	return strconv.FormatUint(uint64(l), 10)
@@ -152,14 +149,6 @@ type Layer struct {
 	index   LayerID
 	ballots []*Ballot
 	blocks  []*Block
-}
-
-// Field returns a log field. Implements the LoggableField interface.
-func (l *Layer) Field() log.Field {
-	return log.String(
-		"layer",
-		fmt.Sprintf("layer_id %d num_ballot %d num_blocks %d", l.index, len(l.ballots), len(l.blocks)),
-	)
 }
 
 // Index returns the layer's ID.

--- a/common/types/nodeid.go
+++ b/common/types/nodeid.go
@@ -6,7 +6,6 @@ import (
 	"github.com/spacemeshos/go-scale"
 
 	"github.com/spacemeshos/go-spacemesh/common/util"
-	"github.com/spacemeshos/go-spacemesh/log"
 )
 
 // BytesToNodeID is a helper to copy buffer into a NodeID.
@@ -38,9 +37,6 @@ func (id NodeID) Bytes() []byte {
 func (id NodeID) ShortString() string {
 	return hex.EncodeToString(id[:3])
 }
-
-// Field returns a log field. Implements the LoggableField interface.
-func (id NodeID) Field() log.Field { return log.Stringer("node_id", id) }
 
 // EmptyNodeID is a canonical empty NodeID.
 var EmptyNodeID NodeID

--- a/common/types/round.go
+++ b/common/types/round.go
@@ -1,9 +1,5 @@
 package types
 
-import (
-	"github.com/spacemeshos/go-spacemesh/log"
-)
-
 // RoundID is the round ID used to run any protocol that requires multiple rounds.
 type RoundID uint32
 
@@ -11,8 +7,3 @@ const (
 	// FirstRound is convenient for initializing the index in a loop.
 	FirstRound = RoundID(0)
 )
-
-// Field returns a log field. Implements the LoggableField interface.
-func (r RoundID) Field() log.Field {
-	return log.Uint32("round_id", uint32(r))
-}

--- a/common/types/transaction.go
+++ b/common/types/transaction.go
@@ -5,9 +5,9 @@ import (
 	"time"
 
 	"github.com/spacemeshos/go-scale"
+	"go.uber.org/zap/zapcore"
 
 	"github.com/spacemeshos/go-spacemesh/hash"
-	"github.com/spacemeshos/go-spacemesh/log"
 )
 
 //go:generate scalegen -types Transaction,Reward,RawTx
@@ -40,9 +40,6 @@ func (id TransactionID) String() string {
 func (id TransactionID) Bytes() []byte {
 	return id[:]
 }
-
-// Field returns a log field. Implements the LoggableField interface.
-func (id TransactionID) Field() log.Field { return log.FieldNamed("tx_id", id.Hash32()) }
 
 // Compare returns true if other (the given TransactionID) is less than this TransactionID, by lexicographic comparison.
 func (id TransactionID) Compare(other TransactionID) bool {
@@ -132,6 +129,15 @@ type Reward struct {
 	LayerReward uint64
 	Coinbase    Address
 	SmesherID   NodeID
+}
+
+func (r Reward) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	enc.AddUint32("layer", r.Layer.Uint32())
+	enc.AddUint64("total_reward", r.TotalReward)
+	enc.AddUint64("layer_reward", r.LayerReward)
+	enc.AddString("coinbase", r.Coinbase.String())
+	enc.AddString("smesher_id", r.SmesherID.String())
+	return nil
 }
 
 // NewRawTx computes id from raw bytes and returns the object.

--- a/common/types/transaction.go
+++ b/common/types/transaction.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/spacemeshos/go-scale"
-	"go.uber.org/zap/zapcore"
 
 	"github.com/spacemeshos/go-spacemesh/hash"
 )
@@ -129,15 +128,6 @@ type Reward struct {
 	LayerReward uint64
 	Coinbase    Address
 	SmesherID   NodeID
-}
-
-func (r Reward) MarshalLogObject(enc zapcore.ObjectEncoder) error {
-	enc.AddUint32("layer", r.Layer.Uint32())
-	enc.AddUint64("total_reward", r.TotalReward)
-	enc.AddUint64("layer_reward", r.LayerReward)
-	enc.AddString("coinbase", r.Coinbase.String())
-	enc.AddString("smesher_id", r.SmesherID.String())
-	return nil
 }
 
 // NewRawTx computes id from raw bytes and returns the object.

--- a/events/subscription_test.go
+++ b/events/subscription_test.go
@@ -18,7 +18,7 @@ func TestSubscribe(t *testing.T) {
 	lid := types.LayerID(10)
 	tx := &types.Transaction{}
 	tx.ID = types.TransactionID{1, 1, 1}
-	ReportNewTx(lid, tx)
+	require.NoError(t, ReportNewTx(lid, tx))
 
 	select {
 	case received := <-sub.Out():
@@ -39,7 +39,7 @@ func TestSubscribeFull(t *testing.T) {
 	for i := 0; i < 3; i++ {
 		tx := &types.Transaction{}
 		tx.ID = types.TransactionID{1, 1, 1}
-		ReportNewTx(lid, tx)
+		require.NoError(t, ReportNewTx(lid, tx))
 	}
 
 	select {

--- a/genvm/vm.go
+++ b/genvm/vm.go
@@ -264,16 +264,12 @@ func (v *VM) Apply(
 				zap.String("account", account.Address.String()),
 				zap.Error(err),
 			)
-		} else {
-			v.logger.Debug("reported account update", zap.Stringer("address", account.Address))
 		}
 		return true
 	})
 	for _, reward := range rewardsResult {
 		if err := events.ReportRewardReceived(reward); err != nil {
 			v.logger.Error("Failed to emit rewards", zap.Uint32("lid", reward.Layer.Uint32()), zap.Error(err))
-		} else {
-			v.logger.Debug("reported reward: %v", zap.Inline(reward))
 		}
 	}
 	hash.PutHasher(hasher)

--- a/log/zap.go
+++ b/log/zap.go
@@ -60,8 +60,6 @@ type Field zap.Field
 // Field satisfies loggable field interface.
 func (f Field) Field() Field { return f }
 
-func (f Field) Zap() zap.Field { return zap.Field(f) }
-
 // FieldNamed returns a field with the provided name instead of the default.
 func FieldNamed(name string, field LoggableField) Field {
 	if field == nil || (reflect.ValueOf(field).Kind() == reflect.Ptr && reflect.ValueOf(field).IsNil()) {
@@ -111,11 +109,6 @@ func ZShortStringer(name string, val ShortString) zap.Field {
 	return zap.Stringer(name, shortStringAdapter{val: val})
 }
 
-// Int returns an int Field.
-func Int(name string, val int) Field {
-	return Field(zap.Int(name, val))
-}
-
 // Uint16 returns an uint32 Field.
 func Uint16(name string, val uint16) Field {
 	return Field(zap.Uint16(name, val))
@@ -124,21 +117,6 @@ func Uint16(name string, val uint16) Field {
 // Uint32 returns an uint32 Field.
 func Uint32(name string, val uint32) Field {
 	return Field(zap.Uint32(name, val))
-}
-
-// Uint64 returns an uint64 Field.
-func Uint64(name string, val uint64) Field {
-	return Field(zap.Uint64(name, val))
-}
-
-// Float64 returns a float64 Field.
-func Float64(name string, val float64) Field {
-	return Field(zap.Float64(name, val))
-}
-
-// Bool returns a bool field.
-func Bool(name string, val bool) Field {
-	return Field(zap.Bool(name, val))
 }
 
 // Time returns a field for time.Time struct value.
@@ -160,11 +138,6 @@ func Err(err error) Field {
 	return Field(zap.NamedError("errmsg", err))
 }
 
-// Object for logging struct fields in namespace.
-func Object(namespace string, object zapcore.ObjectMarshaler) Field {
-	return Field(zap.Object(namespace, object))
-}
-
 // Inline for inline logging.
 func Inline(object zapcore.ObjectMarshaler) Field {
 	return Field(zap.Inline(object))
@@ -173,11 +146,6 @@ func Inline(object zapcore.ObjectMarshaler) Field {
 // Array for logging array efficiently.
 func Array(name string, array zapcore.ArrayMarshaler) Field {
 	return Field(zap.Array(name, array))
-}
-
-// Context inlines requestId and sessionId fields if they are present.
-func Context(ctx context.Context) Field {
-	return Field(zap.Inline(&marshalledContext{Context: ctx}))
 }
 
 func ZContext(ctx context.Context) zap.Field {
@@ -252,11 +220,6 @@ func (l Log) Check(level zapcore.Level) bool {
 	return l.logger.Check(level, "") != nil
 }
 
-// Core returns logger engine.
-func (l Log) Core() zapcore.Core {
-	return l.logger.Core()
-}
-
 // WithName appends a name to a current name.
 func (l Log) WithName(prefix string) Log {
 	lgr := l.logger.Named(prefix)
@@ -326,11 +289,6 @@ func (fl FieldLogger) Warning(msg string, fields ...LoggableField) {
 // Panic prints message with fields.
 func (fl FieldLogger) Panic(msg string, fields ...LoggableField) {
 	fl.l.Panic(msg, unpack(append(fields, String("name", fl.name)))...)
-}
-
-// Fatal prints message with fields.
-func (fl FieldLogger) Fatal(msg string, fields ...LoggableField) {
-	fl.l.Fatal(msg, unpack(append(fields, String("name", fl.name)))...)
 }
 
 // DebugField is only added if debug level is enabled.

--- a/mesh/mesh.go
+++ b/mesh/mesh.go
@@ -170,8 +170,6 @@ func (msh *Mesh) setLatestLayer(lid types.LayerID) {
 		Status:  events.LayerStatusTypeUnknown,
 	}); err != nil {
 		msh.logger.Error("Failed to emit updated layer", zap.Uint32("lid", lid.Uint32()), zap.Error(err))
-	} else {
-		msh.logger.Debug("reported new or updated layer", zap.Uint32("lid", lid.Uint32()))
 	}
 	for {
 		current := msh.LatestLayer()
@@ -181,8 +179,6 @@ func (msh *Mesh) setLatestLayer(lid types.LayerID) {
 		if msh.latestLayer.CompareAndSwap(current, lid) {
 			if err := events.ReportNodeStatusUpdate(); err != nil {
 				msh.logger.Error("Failed to emit status update", zap.Error(err))
-			} else {
-				msh.logger.Debug("reported status update")
 			}
 		}
 	}
@@ -252,8 +248,6 @@ func (msh *Mesh) setProcessedLayer(layerID types.LayerID) error {
 	msh.processedLayer.Store(processed)
 	if err := events.ReportNodeStatusUpdate(); err != nil {
 		msh.logger.Error("Failed to emit status update", zap.Error(err))
-	} else {
-		msh.logger.Debug("reported status update")
 	}
 	return nil
 }
@@ -421,8 +415,6 @@ func (msh *Mesh) applyResults(ctx context.Context, results []result.Layer) error
 					zap.Uint32("lid", layer.Layer.Uint32()),
 					zap.Error(err),
 				)
-			} else {
-				msh.logger.Debug("reported new or updated layer", zap.Uint32("lid", layer.Layer.Uint32()))
 			}
 		}
 		if layer.Layer > msh.LatestLayerInState() {
@@ -507,8 +499,6 @@ func (msh *Mesh) ProcessLayerPerHareOutput(
 		Status:  events.LayerStatusTypeApproved,
 	}); err != nil {
 		msh.logger.Error("Failed to emit updated layer", zap.Uint32("lid", layerID.Uint32()), zap.Error(err))
-	} else {
-		msh.logger.Debug("reported new or updated layer", zap.Uint32("lid", layerID.Uint32()))
 	}
 	if err := msh.saveHareOutput(ctx, layerID, blockID); err != nil {
 		return err

--- a/mesh/mesh.go
+++ b/mesh/mesh.go
@@ -165,17 +165,25 @@ func (msh *Mesh) MeshHash(lid types.LayerID) (types.Hash32, error) {
 
 // setLatestLayer sets the latest layer we saw from the network.
 func (msh *Mesh) setLatestLayer(lid types.LayerID) {
-	events.ReportLayerUpdate(events.LayerUpdate{
+	if err := events.ReportLayerUpdate(events.LayerUpdate{
 		LayerID: lid,
 		Status:  events.LayerStatusTypeUnknown,
-	})
+	}); err != nil {
+		msh.logger.Error("Failed to emit updated layer", zap.Uint32("lid", lid.Uint32()), zap.Error(err))
+	} else {
+		msh.logger.Debug("reported new or updated layer", zap.Uint32("lid", lid.Uint32()))
+	}
 	for {
 		current := msh.LatestLayer()
 		if !lid.After(current) {
 			return
 		}
 		if msh.latestLayer.CompareAndSwap(current, lid) {
-			events.ReportNodeStatusUpdate()
+			if err := events.ReportNodeStatusUpdate(); err != nil {
+				msh.logger.Error("Failed to emit status update", zap.Error(err))
+			} else {
+				msh.logger.Debug("reported status update")
+			}
 		}
 	}
 }
@@ -242,7 +250,11 @@ func (msh *Mesh) setProcessedLayer(layerID types.LayerID) error {
 		return fmt.Errorf("failed to set processed layer %v: %w", processed, err)
 	}
 	msh.processedLayer.Store(processed)
-	events.ReportNodeStatusUpdate()
+	if err := events.ReportNodeStatusUpdate(); err != nil {
+		msh.logger.Error("Failed to emit status update", zap.Error(err))
+	} else {
+		msh.logger.Debug("reported status update")
+	}
 	return nil
 }
 
@@ -401,10 +413,17 @@ func (msh *Mesh) applyResults(ctx context.Context, results []result.Layer) error
 			// in such case we would apply block because of hare, and then we may evict event when block.Valid was set
 			// but before it was saved to database
 			msh.trtl.OnApplied(layer.Layer, layer.Opinion)
-			events.ReportLayerUpdate(events.LayerUpdate{
+			if err := events.ReportLayerUpdate(events.LayerUpdate{
 				LayerID: layer.Layer,
 				Status:  events.LayerStatusTypeApplied,
-			})
+			}); err != nil {
+				msh.logger.Error("Failed to emit updated layer",
+					zap.Uint32("lid", layer.Layer.Uint32()),
+					zap.Error(err),
+				)
+			} else {
+				msh.logger.Debug("reported new or updated layer", zap.Uint32("lid", layer.Layer.Uint32()))
+			}
 		}
 		if layer.Layer > msh.LatestLayerInState() {
 			msh.setLatestLayerInState(layer.Layer)
@@ -483,10 +502,14 @@ func (msh *Mesh) ProcessLayerPerHareOutput(
 	blockID types.BlockID,
 	executed bool,
 ) error {
-	events.ReportLayerUpdate(events.LayerUpdate{
+	if err := events.ReportLayerUpdate(events.LayerUpdate{
 		LayerID: layerID,
 		Status:  events.LayerStatusTypeApproved,
-	})
+	}); err != nil {
+		msh.logger.Error("Failed to emit updated layer", zap.Uint32("lid", layerID.Uint32()), zap.Error(err))
+	} else {
+		msh.logger.Debug("reported new or updated layer", zap.Uint32("lid", layerID.Uint32()))
+	}
 	if err := msh.saveHareOutput(ctx, layerID, blockID); err != nil {
 		return err
 	}

--- a/miner/active_set_generator.go
+++ b/miner/active_set_generator.go
@@ -76,13 +76,13 @@ type activeSetGenerator struct {
 
 func (p *activeSetGenerator) updateFallback(target types.EpochID, set []types.ATXID) {
 	p.log.Info("received trusted activeset update",
-		target.Field().Zap(),
+		zap.Uint32("epoch_id", target.Uint32()),
 		zap.Int("size", len(set)),
 	)
 	p.fallback.Lock()
 	defer p.fallback.Unlock()
 	if _, exists := p.fallback.data[target]; exists {
-		p.log.Debug("fallback active set already exists", target.Field().Zap())
+		p.log.Debug("fallback active set already exists", zap.Uint32("epoch_id", target.Uint32()))
 		return
 	}
 	p.fallback.data[target] = set
@@ -137,7 +137,7 @@ func (p *activeSetGenerator) generate(
 	start := time.Now()
 	if exists {
 		p.log.Info("generating activeset from trusted fallback",
-			target.Field().Zap(),
+			zap.Uint32("epoch_id", target.Uint32()),
 			zap.Int("size", len(fallback)),
 		)
 		var err error
@@ -149,7 +149,7 @@ func (p *activeSetGenerator) generate(
 	} else {
 		epochStart := p.clock.LayerToTime(target.FirstLayer())
 		networkDelay := p.cfg.networkDelay
-		p.log.Info("generating activeset from grades", target.Field().Zap(),
+		p.log.Info("generating activeset from grades", zap.Uint32("epoch_id", target.Uint32()),
 			zap.Time("epoch start", epochStart),
 			zap.Duration("network delay", networkDelay),
 		)
@@ -165,7 +165,7 @@ func (p *activeSetGenerator) generate(
 			setWeight = result.Weight
 		} else {
 			p.log.Info("node was not synced during previous epoch. can't use activeset from grades",
-				target.Field().Zap(),
+				zap.Uint32("epoch_id", target.Uint32()),
 				zap.Time("epoch start", epochStart),
 				zap.Duration("network delay", networkDelay),
 				zap.Int("total", result.Total),
@@ -195,7 +195,7 @@ func (p *activeSetGenerator) generate(
 	}
 	if set != nil {
 		p.log.Info("prepared activeset",
-			target.Field().Zap(),
+			zap.Uint32("epoch_id", target.Uint32()),
 			zap.Int("size", len(set)),
 			zap.Uint64("weight", setWeight),
 			zap.Duration("elapsed", time.Since(start)),

--- a/node/node_identities.go
+++ b/node/node_identities.go
@@ -36,7 +36,7 @@ func (app *App) NewIdentity() error {
 
 	app.log.With().Info("Created new identity",
 		log.String("filename", supervisedIDKeyFileName),
-		signer.PublicKey(),
+		log.ShortStringer("public_key", signer.PublicKey()),
 	)
 	app.signers = []*signing.EdSigner{signer}
 	return nil
@@ -72,7 +72,7 @@ func (app *App) LoadIdentities() error {
 
 		app.log.With().Info("Loaded existing identity",
 			log.String("filename", d.Name()),
-			signer.PublicKey(),
+			log.ShortStringer("public_key", signer.PublicKey()),
 		)
 		signers = append(signers, signer)
 		return nil
@@ -92,7 +92,7 @@ func (app *App) LoadIdentities() error {
 			app.log.With().Error("duplicate key",
 				log.String("filename1", sig.Name()),
 				log.String("filename2", file),
-				sig.PublicKey(),
+				log.String("public_key", sig.PublicKey().ShortString()),
 			)
 			collision = true
 			continue

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -1055,8 +1055,8 @@ func TestAdminEvents_MultiSmesher(t *testing.T) {
 	cfg.Genesis.GenesisTime = time.Now().Add(5 * time.Second).Format(time.RFC3339)
 	types.SetLayersPerEpoch(cfg.LayersPerEpoch)
 
-	logger := logtest.New(t)
-	app := New(WithConfig(&cfg), WithLog(logger))
+	logger := zaptest.NewLogger(t)
+	app := New(WithConfig(&cfg), WithLog(log.NewFromLog(logger)))
 
 	dir := filepath.Join(app.Config.DataDir(), keyDir)
 	require.NoError(t, os.MkdirAll(dir, 0o700))
@@ -1097,7 +1097,7 @@ func TestAdminEvents_MultiSmesher(t *testing.T) {
 	for _, signer := range app.signers {
 		mgr, err := activation.NewPostSetupManager(
 			cfg.POST,
-			logger.Zap(),
+			logger,
 			app.db,
 			app.atxsdata,
 			types.ATXID(app.Config.Genesis.GoldenATX()),
@@ -1108,7 +1108,7 @@ func TestAdminEvents_MultiSmesher(t *testing.T) {
 
 		cfg.SMESHING.Opts.DataDir = t.TempDir()
 		t.Cleanup(launchPostSupervisor(t,
-			logger.Zap(),
+			logger,
 			mgr,
 			signer,
 			"127.0.0.1:10094",

--- a/p2p/upgrade.go
+++ b/p2p/upgrade.go
@@ -224,15 +224,11 @@ func Upgrade(h host.Host, opts ...Opt) (*Host, error) {
 			ConnectedF: func(network.Network, network.Conn) {
 				if err := fh.nodeReporter(); err != nil {
 					fh.logger.Error("Failed to emit status update", zap.Error(err))
-				} else {
-					fh.logger.Debug("reported status update")
 				}
 			},
 			DisconnectedF: func(network.Network, network.Conn) {
 				if err := fh.nodeReporter(); err != nil {
 					fh.logger.Error("Failed to emit status update", zap.Error(err))
-				} else {
-					fh.logger.Debug("reported status update")
 				}
 			},
 		})

--- a/p2p/upgrade_test.go
+++ b/p2p/upgrade_test.go
@@ -16,7 +16,10 @@ func TestConnectionsNotifier(t *testing.T) {
 	counter := [n]atomic.Uint32{}
 	// we count events - not peers
 	for i, host := range mesh.Hosts() {
-		_, err := Upgrade(host, WithNodeReporter(func() { counter[i].Add(1) }))
+		_, err := Upgrade(host, WithNodeReporter(func() error {
+			counter[i].Add(1)
+			return nil
+		}))
 		require.NoError(t, err)
 	}
 

--- a/prune/prune.go
+++ b/prune/prune.go
@@ -56,7 +56,7 @@ func Run(ctx context.Context, p *Pruner, clock *timesync.NodeClock, interval tim
 			current := clock.CurrentLayer()
 			if err := p.Prune(current); err != nil {
 				p.logger.Error("failed to prune",
-					current.Field().Zap(),
+					zap.Uint32("lid", current.Uint32()),
 					zap.Uint32("dist", p.safeDist),
 					zap.Error(err),
 				)

--- a/signing/keys.go
+++ b/signing/keys.go
@@ -4,8 +4,6 @@ import (
 	"encoding/hex"
 
 	"github.com/oasisprotocol/curve25519-voi/primitives/ed25519"
-
-	"github.com/spacemeshos/go-spacemesh/log"
 )
 
 // PrivateKey is an alias to ed25519.PrivateKey.
@@ -26,11 +24,6 @@ func Public(priv PrivateKey) ed25519.PublicKey {
 // NewPublicKey constructs a new public key instance from a byte array.
 func NewPublicKey(pub []byte) *PublicKey {
 	return &PublicKey{pub}
-}
-
-// Field returns a log field. Implements the LoggableField interface.
-func (p *PublicKey) Field() log.Field {
-	return log.String("public_key", p.ShortString())
 }
 
 // Bytes returns the public key as byte array.

--- a/syncer/atxsync/syncer.go
+++ b/syncer/atxsync/syncer.go
@@ -110,10 +110,13 @@ func (s *Syncer) Download(parent context.Context, publish types.EpochID, downloa
 	// in case of immediate we will request epoch info without waiting EpochInfoInterval
 	immediate := len(state) == 0 || (errors.Is(err, sql.ErrNotFound) || !lastSuccess.After(downloadUntil))
 	if !immediate && total == downloaded {
-		s.logger.Debug("sync for epoch was completed before", log.ZContext(parent), publish.Field().Zap())
+		s.logger.Debug("sync for epoch was completed before",
+			log.ZContext(parent),
+			zap.Uint32("epoch_id", publish.Uint32()),
+		)
 		return nil
 	}
-	s.logger.Info("starting atx sync", log.ZContext(parent), publish.Field().Zap())
+	s.logger.Info("starting atx sync", log.ZContext(parent), zap.Uint32("epoch_id", publish.Uint32()))
 	ctx, cancel := context.WithCancel(parent)
 	eg, ctx := errgroup.WithContext(ctx)
 	updates := make(chan epochUpdate, s.cfg.EpochInfoPeers)
@@ -154,7 +157,7 @@ func (s *Syncer) downloadEpochInfo(
 		if interval != 0 {
 			s.logger.Debug(
 				"waiting between epoch info requests",
-				publish.Field().Zap(),
+				zap.Uint32("epoch_id", publish.Uint32()),
 				zap.Duration("duration", interval),
 			)
 		}
@@ -179,7 +182,7 @@ func (s *Syncer) downloadEpochInfo(
 				}
 				s.logger.Warn("failed to download epoch info",
 					log.ZContext(ctx),
-					publish.Field().Zap(),
+					zap.Uint32("epoch_id", publish.Uint32()),
 					zap.String("peer", peer.String()),
 					zap.Error(err),
 				)
@@ -187,7 +190,7 @@ func (s *Syncer) downloadEpochInfo(
 			}
 			s.logger.Info("downloaded epoch info",
 				log.ZContext(ctx),
-				publish.Field().Zap(),
+				zap.Uint32("epoch_id", publish.Uint32()),
 				zap.String("peer", peer.String()),
 				zap.Int("atxs", len(epochData.AtxIDs)),
 			)
@@ -231,7 +234,7 @@ func (s *Syncer) downloadAtxs(
 			s.logger.Info(
 				"atx sync completed",
 				log.ZContext(ctx),
-				publish.Field().Zap(),
+				zap.Uint32("epoch_id", publish.Uint32()),
 				zap.Int("downloaded", len(downloaded)),
 				zap.Int("total", len(state)),
 				zap.Int("unavailable", len(state)-len(downloaded)),
@@ -293,7 +296,7 @@ func (s *Syncer) downloadAtxs(
 			s.logger.Info(
 				"atx sync progress",
 				log.ZContext(ctx),
-				publish.Field().Zap(),
+				zap.Uint32("epoch_id", publish.Uint32()),
 				zap.Int("downloaded", len(downloaded)),
 				zap.Int("total", len(state)),
 				zap.Int("progress", int(progress)),

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -320,7 +320,11 @@ func (s *Syncer) setSyncState(ctx context.Context, newState syncState) {
 			zap.Stringer("last synced", s.getLastSyncedLayer()),
 			zap.Stringer("latest", s.mesh.LatestLayer()),
 			zap.Stringer("processed", s.mesh.ProcessedLayer()))
-		events.ReportNodeStatusUpdate()
+		if err := events.ReportNodeStatusUpdate(); err != nil {
+			s.logger.Error("Failed to emit status update", zap.Error(err))
+		} else {
+			s.logger.Debug("reported status update")
+		}
 	}
 	switch newState {
 	case notSynced:

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -322,8 +322,6 @@ func (s *Syncer) setSyncState(ctx context.Context, newState syncState) {
 			zap.Stringer("processed", s.mesh.ProcessedLayer()))
 		if err := events.ReportNodeStatusUpdate(); err != nil {
 			s.logger.Error("Failed to emit status update", zap.Error(err))
-		} else {
-			s.logger.Debug("reported status update")
 		}
 	}
 	switch newState {

--- a/txs/cache.go
+++ b/txs/cache.go
@@ -724,7 +724,9 @@ func (c *Cache) ApplyLayer(
 				return err
 			}
 		}
-		events.ReportResult(rst)
+		if err := events.ReportResult(rst); err != nil {
+			c.logger.Error("Failed to emit tx results", zap.Stringer("tx_id", rst.ID), zap.Error(err))
+		}
 	}
 
 	for _, tx := range ineffective {

--- a/txs/conservative_state.go
+++ b/txs/conservative_state.go
@@ -128,17 +128,12 @@ func (cs *ConservativeState) AddToCache(ctx context.Context, tx *types.Transacti
 			zap.Stringer("tx_id", tx.ID),
 			zap.Error(err),
 		)
-	} else {
-		cs.logger.Debug("reported tx: %v", zap.Inline(tx))
 	}
-
 	if err := events.ReportAccountUpdate(tx.Principal); err != nil {
 		cs.logger.Error("Failed to emit account update",
 			zap.String("account", tx.Principal.String()),
 			zap.Error(err),
 		)
-	} else {
-		cs.logger.Debug("reported account update", zap.Stringer("address", tx.Principal))
 	}
 	return nil
 }

--- a/txs/conservative_state.go
+++ b/txs/conservative_state.go
@@ -123,8 +123,23 @@ func (cs *ConservativeState) AddToCache(ctx context.Context, tx *types.Transacti
 	if err := cs.cache.Add(ctx, cs.db, tx, received, false); err != nil {
 		return err
 	}
-	events.ReportNewTx(0, tx)
-	events.ReportAccountUpdate(tx.Principal)
+	if err := events.ReportNewTx(0, tx); err != nil {
+		cs.logger.Error("Failed to emit transaction",
+			zap.Stringer("tx_id", tx.ID),
+			zap.Error(err),
+		)
+	} else {
+		cs.logger.Debug("reported tx: %v", zap.Inline(tx))
+	}
+
+	if err := events.ReportAccountUpdate(tx.Principal); err != nil {
+		cs.logger.Error("Failed to emit account update",
+			zap.String("account", tx.Principal.String()),
+			zap.Error(err),
+		)
+	} else {
+		cs.logger.Debug("reported account update", zap.Stringer("address", tx.Principal))
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Motivation

Follow up to this discussion: https://github.com/spacemeshos/go-spacemesh/pull/6252#discussion_r1715578826

Removal of the global logger from (most of) the event package.

## Description

This removes the global logger from most of the `reporter.go` file and removes a few other usages of the `log` package that are not needed any more.

## Test Plan

- existing tests pass

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
