### PR TITLE
[Merged by Bors] - Update time measurement of metrics for proposal builder in 1:n

### DIFF
--- a/miner/metrics.go
+++ b/miner/metrics.go
@@ -18,24 +18,26 @@ var proposalBuild = metrics.NewHistogramWithBuckets(
 ).WithLabelValues()
 
 type latencyTracker struct {
-	start    time.Time
-	data     time.Time
-	tortoise time.Time
-	txs      time.Time
-	hash     time.Time
-	publish  time.Time
+	start time.Time
+	end   time.Time
+
+	data     time.Duration
+	tortoise time.Duration
+	hash     time.Duration
+	txs      time.Duration
+	publish  time.Duration
 }
 
 func (lt *latencyTracker) total() time.Duration {
-	return lt.publish.Sub(lt.start)
+	return lt.end.Sub(lt.start)
 }
 
 func (lt *latencyTracker) MarshalLogObject(encoder zapcore.ObjectEncoder) error {
-	encoder.AddDuration("data", lt.data.Sub(lt.start))
-	encoder.AddDuration("tortoise", lt.tortoise.Sub(lt.data))
-	encoder.AddDuration("hash", lt.hash.Sub(lt.tortoise))
-	encoder.AddDuration("txs", lt.txs.Sub(lt.hash))
-	encoder.AddDuration("publish", lt.publish.Sub(lt.hash))
+	encoder.AddDuration("data", lt.data)
+	encoder.AddDuration("tortoise", lt.tortoise)
+	encoder.AddDuration("hash", lt.hash)
+	encoder.AddDuration("txs", lt.txs)
+	encoder.AddDuration("publish", lt.publish)
 	total := lt.total()
 	encoder.AddDuration("total", total)
 	// arbitrary threshold that we want to highlight as a problem

--- a/miner/proposal_builder.go
+++ b/miner/proposal_builder.go
@@ -635,6 +635,7 @@ func (pb *ProposalBuilder) build(ctx context.Context, lid types.LayerID) error {
 		ss.latency.tortoise = time.Since(start)
 	}
 
+	start = time.Now()
 	meshHash := pb.decideMeshHash(ctx, lid)
 	for _, ss := range signers {
 		ss.latency.hash = time.Since(start)

--- a/miner/proposal_builder.go
+++ b/miner/proposal_builder.go
@@ -558,9 +558,8 @@ func (pb *ProposalBuilder) initSignerData(
 }
 
 func (pb *ProposalBuilder) build(ctx context.Context, lid types.LayerID) error {
-	start := time.Now()
 	for _, ss := range pb.signers.signers {
-		ss.latency.start = start
+		ss.latency.start = time.Now()
 	}
 	if err := pb.initSharedData(ctx, lid); err != nil {
 		return err
@@ -575,6 +574,7 @@ func (pb *ProposalBuilder) build(ctx context.Context, lid types.LayerID) error {
 	eg.SetLimit(pb.cfg.workersLimit)
 	for _, ss := range signers {
 		eg.Go(func() error {
+			start := time.Now()
 			if err := pb.initSignerData(ctx, ss, lid); err != nil {
 				if errors.Is(err, errAtxNotAvailable) {
 					ss.log.Debug("smesher doesn't have atx that targets this epoch",
@@ -601,7 +601,7 @@ func (pb *ProposalBuilder) build(ctx context.Context, lid types.LayerID) error {
 		return err
 	}
 
-	start = time.Now()
+	start := time.Now()
 	any := false
 	for _, ss := range signers {
 		if n := len(ss.session.eligibilities.proofs[lid]); n == 0 {
@@ -671,8 +671,8 @@ func (pb *ProposalBuilder) build(ctx context.Context, lid types.LayerID) error {
 			}
 		}
 
-		start = time.Now()
 		eg.Go(func() error {
+			start := time.Now()
 			proposal := createProposal(
 				&ss.session,
 				pb.shared.beacon,

--- a/miner/proposal_builder_test.go
+++ b/miner/proposal_builder_test.go
@@ -892,7 +892,7 @@ func TestMarshalLog(t *testing.T) {
 		require.NoError(t, session.MarshalLogObject(encoder))
 	})
 	t.Run("latency", func(t *testing.T) {
-		latency := &latencyTracker{start: time.Unix(0, 0), publish: time.Unix(1000, 0)}
+		latency := &latencyTracker{start: time.Unix(0, 0), end: time.Unix(1000, 0)}
 		require.NoError(t, latency.MarshalLogObject(encoder))
 	})
 }


### PR DESCRIPTION
## Motivation

This updates how timing metrics for the proposal builder are calculated.

## Description

At the moment the measured timestamps include waiting times for other identities that might be managed by the node. I updated the `latency` struct to still calculate the total time as before, since for the decision if a proposal is late or not the absolute time between `start` and the publication are relevant, but I changed the in between steps to only measure the time the identity of interest was busy with the step.

## Test Plan

n/a, just updated how metrics are collected

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
