### PR TITLE
chore: revise conn_wait histogram buckets

### DIFF
--- a/sql/metrics.go
+++ b/sql/metrics.go
@@ -23,5 +23,5 @@ var connWaitLatency = metrics.NewHistogramWithBuckets(
 	namespace,
 	"time spent in waiting for a connection from a pool",
 	[]string{},
-	prometheus.ExponentialBuckets(0.01, 2, 20),
+	prometheus.ExponentialBuckets(0.01, 10, 5),
 ).WithLabelValues()


### PR DESCRIPTION
## Motivation

Adjusting histogram buckets to be more meaningful.

## Description

Our current histogram buckets look like this:
```# TYPE spacemesh_database_conn_wait_seconds histogram
spacemesh_database_conn_wait_seconds_bucket{le="0.01"} 2.6961074e+07
spacemesh_database_conn_wait_seconds_bucket{le="0.02"} 2.7044052e+07
spacemesh_database_conn_wait_seconds_bucket{le="0.04"} 2.7070415e+07
spacemesh_database_conn_wait_seconds_bucket{le="0.08"} 2.7082987e+07
spacemesh_database_conn_wait_seconds_bucket{le="0.16"} 2.7096028e+07
spacemesh_database_conn_wait_seconds_bucket{le="0.32"} 2.7102145e+07
spacemesh_database_conn_wait_seconds_bucket{le="0.64"} 2.7102822e+07
spacemesh_database_conn_wait_seconds_bucket{le="1.28"} 2.7102822e+07
spacemesh_database_conn_wait_seconds_bucket{le="2.56"} 2.7102822e+07
spacemesh_database_conn_wait_seconds_bucket{le="5.12"} 2.7102822e+07
spacemesh_database_conn_wait_seconds_bucket{le="10.24"} 2.7102822e+07
spacemesh_database_conn_wait_seconds_bucket{le="20.48"} 2.7102822e+07
spacemesh_database_conn_wait_seconds_bucket{le="40.96"} 2.7102822e+07
spacemesh_database_conn_wait_seconds_bucket{le="81.92"} 2.7102822e+07
spacemesh_database_conn_wait_seconds_bucket{le="163.84"} 2.7102822e+07
spacemesh_database_conn_wait_seconds_bucket{le="327.68"} 2.7102822e+07
spacemesh_database_conn_wait_seconds_bucket{le="655.36"} 2.7102822e+07
spacemesh_database_conn_wait_seconds_bucket{le="1310.72"} 2.7102822e+07
spacemesh_database_conn_wait_seconds_bucket{le="2621.44"} 2.7102822e+07
spacemesh_database_conn_wait_seconds_bucket{le="5242.88"} 2.7102822e+07
spacemesh_database_conn_wait_seconds_bucket{le="+Inf"} 2.7102822e+07
spacemesh_database_conn_wait_seconds_sum 7920.183404650259
spacemesh_database_conn_wait_seconds_count 2.7102822e+07
```

I would argue it is meaningless to know the difference of how many times we were waiting for a connection between 10ms to 20ms and 40ms. Having fewer buckets gives a better overview and knowing the difference between 10ms/100ms/1s/10s/100s is good enough (current histogram includes a bucket for 5200 seconds which is a day and a half).
<!-- If applicable please mention the issue addressed by this PR -->
<!-- `Closes #XXXX` links mentioned issues to this PR and automatically closes them when this it's merged -->

<!-- Please describe in detail the changes made. Focus on the reasoning rather than describing the change -->

## Test Plan

<!-- Please specify how these changes were tested (e.g. unit tests, manual testing, etc.) -->

## TODO

<!-- Please tick off the TODOs when completed -->

- [ ] Explain motivation or link existing issue(s)
- [ ] Test changes and document test plan
- [ ] Update documentation as needed
- [ ] Update [changelog](../CHANGELOG.md) as needed
