### PR TITLE
[backport] api: v2alpha1: Use subquery instead of left join for transaction list. (#6269)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 See [RELEASE](./RELEASE.md) for workflow instructions.
 
+## Release v1.6.8
+
+### Improvements
+* [#6269](https://github.com/spacemeshos/go-spacemesh/pull/6269) Use subquery instead of left join to speed up 
+  transaction list query
+
 ## Release v1.6.7
 
 ### Improvements

--- a/api/grpcserver/v2alpha1/transaction.go
+++ b/api/grpcserver/v2alpha1/transaction.go
@@ -251,19 +251,8 @@ func toTransactionOperations(filter *spacemeshv2alpha1.TransactionRequest) (buil
 			return builder.Operations{}, err
 		}
 		ops.Filter = append(ops.Filter, builder.Op{
-			Group: []builder.Op{
-				{
-					Field: builder.Address,
-					Token: builder.Eq,
-					Value: addr.Bytes(),
-				},
-				{
-					Field: builder.Principal,
-					Token: builder.Eq,
-					Value: addr.Bytes(),
-				},
-			},
-			GroupOperator: builder.Or,
+			Value:       addr.Bytes(),
+			CustomQuery: "id IN (SELECT tid FROM transactions_results_addresses WHERE address = ?1)",
 		})
 	}
 

--- a/sql/builder/builder.go
+++ b/sql/builder/builder.go
@@ -59,6 +59,12 @@ type Op struct {
 
 	Group         []Op
 	GroupOperator operator
+
+	// CustomQuery is used to add custom query. If this is set, Field and Token will be ignored.
+	// This is useful for complex queries that can't be expressed with Field and Token.
+	// Value will be used for custom query if it's not nil.
+	// Remember about setting correct bind index for Value.
+	CustomQuery string
 }
 
 type Modifier struct {
@@ -95,6 +101,14 @@ func FilterFrom(operations Operations) string {
 			}
 		} else {
 			queryBuilder.WriteString(" and")
+		}
+
+		if len(op.CustomQuery) > 0 {
+			queryBuilder.WriteString(fmt.Sprintf("  %s", op.CustomQuery))
+			if op.Value != nil {
+				bindIndex++
+			}
+			continue
 		}
 
 		if len(op.Group) > 0 {

--- a/sql/transactions/transactions.go
+++ b/sql/transactions/transactions.go
@@ -419,8 +419,7 @@ func IterateTransactionsOps(
 ) error {
 	var derr error
 	_, err := db.Exec(`select distinct tx, header, layer, block, timestamp, id, result 
-		from transactions
-		left join transactions_results_addresses on id=tid`+builder.FilterFrom(operations),
+		from transactions`+builder.FilterFrom(operations),
 		builder.BindingsFrom(operations),
 		func(stmt *sql.Statement) bool {
 			var txId types.TransactionID


### PR DESCRIPTION
Removed the LEFT JOIN from IterateTransactionsOps because it was too slow for handling queries.
Instead, a subquery with SELECT is used to retrieve tx ids for addresses used in transactions.