### PR TITLE
[Merged by Bors] - Use ATXData during tortoise init

### DIFF
--- a/atxsdata/data.go
+++ b/atxsdata/data.go
@@ -6,6 +6,7 @@ import (
 	"sync/atomic"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
+	"golang.org/x/exp/maps"
 )
 
 // SAFETY: all exported fields are read-only and are safe to read concurrently.
@@ -145,6 +146,12 @@ func (d *Data) SetMalicious(node types.NodeID) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	d.malicious[node] = struct{}{}
+}
+
+func (d *Data) MaliciousIdentities() []types.NodeID {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	return maps.Keys(d.malicious)
 }
 
 // Get returns atx data.

--- a/atxsdata/data.go
+++ b/atxsdata/data.go
@@ -5,8 +5,9 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/spacemeshos/go-spacemesh/common/types"
 	"golang.org/x/exp/maps"
+
+	"github.com/spacemeshos/go-spacemesh/common/types"
 )
 
 // SAFETY: all exported fields are read-only and are safe to read concurrently.

--- a/tortoise/recover.go
+++ b/tortoise/recover.go
@@ -13,7 +13,6 @@ import (
 	"github.com/spacemeshos/go-spacemesh/sql/beacons"
 	"github.com/spacemeshos/go-spacemesh/sql/blocks"
 	"github.com/spacemeshos/go-spacemesh/sql/certificates"
-	"github.com/spacemeshos/go-spacemesh/sql/identities"
 	"github.com/spacemeshos/go-spacemesh/sql/layers"
 )
 
@@ -60,11 +59,7 @@ func Recover(
 		}
 	}
 
-	malicious, err := identities.GetMalicious(db)
-	if err != nil {
-		return nil, fmt.Errorf("recover malicious %w", err)
-	}
-	for _, id := range malicious {
+	for _, id := range atxdata.MaliciousIdentities() {
 		trtl.OnMalfeasance(id)
 	}
 


### PR DESCRIPTION
## Motivation

Instead of reading information about malicious identities from the DB during tortoise init use atx data.

## Description

The information about which identities are considered malicious is already available in the atx data when tortoise initialises. Instead of reading the information from the DB use the already cached data.

## Test Plan

existing tests pass

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
