### PR TITLE
[Merged by Bors] - Use VACUUM when migrating from DB versions below 21

### DIFF
--- a/config/mainnet.go
+++ b/config/mainnet.go
@@ -79,7 +79,7 @@ func MainnetConfig() Config {
 			MetricsPort:           1010,
 			DatabaseConnections:   16,
 			DatabasePruneInterval: 30 * time.Minute,
-			DatabaseVacuumState:   15,
+			DatabaseVacuumState:   21,
 			PruneActivesetsFrom:   12, // starting from epoch 13 activesets below 12 will be pruned
 			NetworkHRP:            "sm",
 


### PR DESCRIPTION
## Motivation

We need to vacuum the DB after migrations, and with #6085 merged, we need to use VACUUM INTO based migration for recent DB schema updates

## Description

Set `DatabaseVacuumState` to 21 in the mainnet config.

## Test Plan

Verifying on a mainnet node
