### PR TITLE
[Merged by Bors] - feat: add mutex and block profile

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -57,6 +57,8 @@ func AddFlags(flagSet *pflag.FlagSet, cfg *config.Config) (configPath *string) {
 		cfg.LayerAvgSize, "Layer Avg size")
 	flagSet.BoolVar(&cfg.PprofHTTPServer, "pprof-server",
 		cfg.PprofHTTPServer, "enable http pprof server")
+	flagSet.BoolVar(&cfg.PprofMutexProfile, "pprof-mutex-profile", false, "enable pprof mutex profile")
+	flagSet.BoolVar(&cfg.PprofBlockProfile, "pprof-block-profile", false, "enable pprof block profile")
 	flagSet.StringVar(&cfg.PprofHTTPServerListener, "pprof-listener", cfg.PprofHTTPServerListener,
 		"Listen address for pprof server, not safe to expose publicly")
 	flagSet.Uint64Var(&cfg.TickSize, "tick-size", cfg.TickSize, "number of poet leaves in a single tick")

--- a/config/config.go
+++ b/config/config.go
@@ -103,6 +103,8 @@ type BaseConfig struct {
 
 	PprofHTTPServer         bool   `mapstructure:"pprof-server"`
 	PprofHTTPServerListener string `mapstructure:"pprof-listener"`
+	PprofMutexProfile       bool   `mapstructure:"pprof-mutex-profile"`
+	PprofBlockProfile       bool   `mapstructure:"pprof-block-profile"`
 
 	TxsPerProposal int    `mapstructure:"txs-per-proposal"`
 	BlockGasLimit  uint64 `mapstructure:"block-gas-limit"`

--- a/node/node.go
+++ b/node/node.go
@@ -2090,6 +2090,14 @@ func (app *App) startSynchronous(ctx context.Context) (err error) {
 			}
 			return nil
 		})
+		if app.Config.PprofMutexProfile {
+			// this will set the mutex profiling to sample a third of all lock events
+			runtime.SetMutexProfileFraction(3)
+		}
+		if app.Config.PprofBlockProfile {
+			// record block sample for every block event that takes more than 10 milliseconds
+			runtime.SetBlockProfileRate(int(10 * time.Millisecond))
+		}
 	}
 
 	if app.Config.ProfilerURL != "" {


### PR DESCRIPTION
## Motivation

Adds the possibility to profile mutexes and goroutine blocks through `pprof`.

## Description

Simply enable it with `--pprof-mutex-profile` or `--pprof-block-profile`. Right now they sample a third of lock events and goroutine blocking events that take more than 10ms, respectively.
<!-- If applicable please mention the issue addressed by this PR -->
<!-- `Closes #XXXX` links mentioned issues to this PR and automatically closes them when this it's merged -->

<!-- Please describe in detail the changes made. Focus on the reasoning rather than describing the change -->

## Test Plan

<!-- Please specify how these changes were tested (e.g. unit tests, manual testing, etc.) -->

## TODO

<!-- Please tick off the TODOs when completed -->

- [ ] Explain motivation or link existing issue(s)
- [ ] Test changes and document test plan
- [ ] Update documentation as needed
- [ ] Update [changelog](../CHANGELOG.md) as needed
