### PR TITLE
Backport #6287: Replace abandoned GH action for publishing swagger files

### DIFF
--- a/.github/workflows/api-swagger-ui.yml
+++ b/.github/workflows/api-swagger-ui.yml
@@ -9,7 +9,7 @@ on:
   push:
     tags:
       - '*'
-    
+
 jobs:
   check-version:
     runs-on: ubuntu-22.04
@@ -18,7 +18,7 @@ jobs:
     steps:
     - name: Checkout target repository on last release
       uses: actions/checkout@v4
-    
+
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
@@ -43,16 +43,15 @@ jobs:
         ref: 'refs/tags/${{ needs.check-version.outputs.go-sm-api-version }}'
 
     - name: upload to testnet
-      uses: jakejarvis/s3-sync-action@master
-      with:
-        args: --acl public-read --follow-symlinks
+      run: >
+        aws s3 sync api/release/openapi/swagger/src
+        s3://${{ secrets.CLOUDFLARE_TESTNET_API_BUCKET }}/${{ github.ref_name }}
+        --endpoint-url https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com
+        --acl public-read --follow-symlinks
       env:
-          AWS_S3_BUCKET: ${{ secrets.CLOUDFLARE_TESTNET_API_BUCKET }}
           AWS_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_SECRET_ACCESS_KEY }}
-          SOURCE_DIR: api/release/openapi/swagger/src
-          DEST_DIR: '${{ github.ref_name }}'
-          AWS_S3_ENDPOINT: https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com
+          AWS_REGION: us-east-1
 
     - name: update url json file for testnet
       working-directory: api/release/openapi/swagger/src
@@ -61,16 +60,14 @@ jobs:
         curl -o spec_urls.json https://testnet-api-docs.spacemesh.network/spec_urls.json
         new_url="{\"url\":\"https://testnet-api-docs.spacemesh.network/${{ github.ref_name }}/api.swagger.json\",\"name\":\"${{ github.ref_name }}\"}"
         jq ". += [$new_url]" spec_urls.json > tmp.json && mv tmp.json spec_urls.json
-   
+
     - name: upload new testnet json file
-      uses: jakejarvis/s3-sync-action@master
-      with:
-        args: --acl public-read --follow-symlinks
+      run: >
+        aws s3 sync api/release/openapi/swagger/src/spec
+        s3://${{ secrets.CLOUDFLARE_TESTNET_API_BUCKET }}
+        --endpoint-url https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com
+        --acl public-read --follow-symlinks
       env:
-          AWS_S3_BUCKET: ${{ secrets.CLOUDFLARE_TESTNET_API_BUCKET }}
           AWS_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_SECRET_ACCESS_KEY }}
-          SOURCE_DIR: api/release/openapi/swagger/src/spec
-          DEST_DIR: ''
-          AWS_S3_ENDPOINT: https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com
-   
+          AWS_REGION: us-east-1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,6 @@ See [RELEASE](./RELEASE.md) for workflow instructions.
 
 * [#6268](https://github.com/spacemeshos/go-spacemesh/pull/6268) Fix incorrect timing collection for proposal builder.
 
-* [#6278](https://github.com/spacemeshos/go-spacemesh/pull/6278) Reduce logging levels of some messages to reduce noise.
-
 ## Release v1.6.7
 
 ### Improvements


### PR DESCRIPTION
## Motivation

Backport of #6287

## Description

Only backport of #6287 and fixing a double entry in the CHANGELOG.md

## Test Plan

existing tests pass

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
