### PR TITLE
[Merged by Bors] - Fix release gh-action permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
           - os: windows-2022
             outname_sufix: "win-amd64"
     permissions:
-      contents: 'read'
+      contents: 'write'
       id-token: 'write'
     steps:
       - shell: bash


### PR DESCRIPTION
## Motivation

Fix release GH action.

## Description

Restore the `contents: write` permission the release action had by default before workload identity implementation.

