### PR TITLE
Use different settings for windows checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,9 +140,7 @@ jobs:
       - name: Set new git config - Windows
         if: ${{ matrix.os == 'windows-2022' }}
         run: |
-          git config --global pack.window 1
-          git config --global core.compression 0
-          git config --global http.postBuffer 524288000
+          git config --global http.postBuffer 1024M
       - name: checkout
         uses: actions/checkout@v4
         with:
@@ -247,9 +245,7 @@ jobs:
       - name: Set new git config - Windows
         if: ${{ matrix.os == 'windows-2022' }}
         run: |
-          git config --global pack.window 1
-          git config --global core.compression 0
-          git config --global http.postBuffer 524288000
+          git config --global http.postBuffer 1024M
       - name: checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,8 @@ jobs:
       - name: Set new git config - Windows
         if: ${{ matrix.os == 'windows-2022' }}
         run: |
+          git config --global pack.window 1
+          git config --global core.compression 0
           git config --global http.postBuffer 1024M
       - name: checkout
         uses: actions/checkout@v4
@@ -245,6 +247,8 @@ jobs:
       - name: Set new git config - Windows
         if: ${{ matrix.os == 'windows-2022' }}
         run: |
+          git config --global pack.window 1
+          git config --global core.compression 0
           git config --global http.postBuffer 1024M
       - name: checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,9 +41,7 @@ jobs:
       - name: Set new git config - Windows
         if: ${{ matrix.os == 'windows-2022' }}
         run: |
-          git config --global pack.window 1
-          git config --global core.compression 0
-          git config --global http.postBuffer 524288000
+          git config --global http.postBuffer 1024M
       - name: Check out Git repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,8 @@ jobs:
       - name: Set new git config - Windows
         if: ${{ matrix.os == 'windows-2022' }}
         run: |
+          git config --global pack.window 1
+          git config --global core.compression 0
           git config --global http.postBuffer 1024M
       - name: Check out Git repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Motivation

This hopefully makes the windows checkout more stable.

## Description

I increased the `http.postBuffer` size, `core.compression` and `pack.window` with default values take much longer to checkout so I kept these values.

## Test Plan

Checkout on windows works

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
