### PR TITLE
[Merged by Bors] - Fix incorrect permissions for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
           - os: windows-2022
             outname_sufix: "win-amd64"
     permissions:
-      contents: 'write'
+      contents: 'read'
       id-token: 'write'
     steps:
       - shell: bash
@@ -133,7 +133,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: build-and-upload
     permissions:
-      contents: 'read'
+      contents: 'write'
       id-token: 'write'
     steps:
       - name: Download the artifacts


### PR DESCRIPTION
## Motivation

The previous PR #6292 updated the wrong permission, this fixes this.

## Description

The `release` job needs `write` permissions instead of the `build-and-upload` job.

## Test Plan

Release works

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
