### PR TITLE
[Merged by Bors] - Fix flaky TestHare_ReconstructForward

### DIFF
--- a/fetch/wire_types.go
+++ b/fetch/wire_types.go
@@ -120,15 +120,16 @@ type MaliciousIDs struct {
 }
 
 type EpochData struct {
-	// When changing this value also check
-	// - the size of `ResponseMessage.Data` above
-	// - the size of `Response.Data` in `p2p/server/server.go`
-	// - the size of `NodeIDs` in `MaliciousIDs` above
-	// - the size of `Set` in `EpochActiveSet` in common/types/activation.go
-	// - the size of `EligibilityProofs` in the type `Ballot` in common/types/ballot.go
-	// - the size of `Rewards` in the type `InnerBlock` in common/types/block.go
-	// - the size of `Ballots` in the type `LayerData` below
-	// - the size of `Proposals` in the type `Value` in hare3/types.go
+	// When changing this value also check the size of
+	// - `ResponseMessage.Data` above
+	// - `Response.Data` in `p2p/server/server.go`
+	// - `NodeIDs` in `MaliciousIDs` above
+	// - `Set` in `EpochActiveSet` in common/types/activation.go
+	// - `EligibilityProofs` in the type `Ballot` in common/types/ballot.go
+	// - `Rewards` in the type `InnerBlock` in common/types/block.go
+	// - `Ballots` in the type `LayerData` below
+	// - `Proposals` in the type `Value` in hare3/types.go
+	// - `Proposals` and `CompactProposals` in the type `Value` in hare4/types.go
 	AtxIDs []types.ATXID `scale:"max=8000000"`
 }
 

--- a/hare3/hare_test.go
+++ b/hare3/hare_test.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"os"
 	"runtime/pprof"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -22,6 +23,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/hare3/eligibility"
 	"github.com/spacemeshos/go-spacemesh/layerpatrol"
+	"github.com/spacemeshos/go-spacemesh/p2p"
 	"github.com/spacemeshos/go-spacemesh/p2p/pubsub"
 	pmocks "github.com/spacemeshos/go-spacemesh/p2p/pubsub/mocks"
 	"github.com/spacemeshos/go-spacemesh/proposals/store"
@@ -211,7 +213,6 @@ func (n *node) withPublisher() *node {
 
 func (n *node) withHare() *node {
 	logger := zaptest.NewLogger(n.t).Named(fmt.Sprintf("hare=%d", n.i))
-
 	n.nclock = &testNodeClock{
 		genesis:       n.t.start,
 		layerDuration: n.t.layerDuration,
@@ -259,6 +260,10 @@ func (n *node) storeAtx(atx *types.ActivationTx) error {
 	return nil
 }
 
+func (n *node) peerId() p2p.Peer {
+	return p2p.Peer(strconv.Itoa(n.i))
+}
+
 type clusterOpt func(*lockstepCluster)
 
 func withUnits(min, max int) clusterOpt {
@@ -284,6 +289,7 @@ func withSigners(n int) clusterOpt {
 }
 
 func newLockstepCluster(t *tester, opts ...clusterOpt) *lockstepCluster {
+	t.Helper()
 	cluster := &lockstepCluster{t: t}
 	cluster.units.min = 10
 	cluster.units.max = 10
@@ -447,7 +453,7 @@ func (cl *lockstepCluster) setup() {
 			Publish(gomock.Any(), gomock.Any(), gomock.Any()).
 			Do(func(ctx context.Context, _ string, msg []byte) error {
 				for _, other := range cl.nodes {
-					other.hare.Handler(ctx, "self", msg)
+					other.hare.Handler(ctx, n.peerId(), msg)
 				}
 				return nil
 			}).
@@ -510,7 +516,7 @@ func waitForChan[T any](t testing.TB, ch <-chan T, timeout time.Duration, failur
 	var value T
 	select {
 	case <-time.After(timeout):
-		builder := strings.Builder{}
+		var builder strings.Builder
 		pprof.Lookup("goroutine").WriteTo(&builder, 2)
 		t.Fatalf(failureMsg+", waited: %v, stacktraces:\n%s", timeout, builder.String())
 	case value = <-ch:
@@ -521,7 +527,7 @@ func waitForChan[T any](t testing.TB, ch <-chan T, timeout time.Duration, failur
 func sendWithTimeout[T any](t testing.TB, value T, ch chan<- T, timeout time.Duration, failureMsg string) {
 	select {
 	case <-time.After(timeout):
-		builder := strings.Builder{}
+		var builder strings.Builder
 		pprof.Lookup("goroutine").WriteTo(&builder, 2)
 		t.Fatalf(failureMsg+", waited: %v, stacktraces:\n%s", timeout, builder.String())
 	case ch <- value:
@@ -560,6 +566,7 @@ func (t *testTracer) OnMessageSent(m *Message) {
 func (*testTracer) OnMessageReceived(*Message) {}
 
 func testHare(t *testing.T, active, inactive, equivocators int, opts ...clusterOpt) {
+	t.Helper()
 	cfg := DefaultConfig()
 	cfg.LogStats = true
 	tst := &tester{
@@ -910,9 +917,7 @@ func TestProposals(t *testing.T) {
 				atxsdata.AddFromAtx(&atx, false)
 			}
 			for _, proposal := range tc.proposals {
-				if err := proposals.Add(proposal); err != nil {
-					panic(err)
-				}
+				require.NoError(t, proposals.Add(proposal))
 			}
 			for _, id := range tc.malicious {
 				require.NoError(t, identities.SetMalicious(db, id, []byte("non empty"), time.Time{}))

--- a/hare3/hare_test.go
+++ b/hare3/hare_test.go
@@ -276,7 +276,7 @@ func withProposals(fraction float64) clusterOpt {
 }
 
 // withSigners creates N signers in addition to regular active nodes.
-// this signeres will be partitioned in fair fashion across regular active nodes.
+// this signers will be partitioned in fair fashion across regular active nodes.
 func withSigners(n int) clusterOpt {
 	return func(cluster *lockstepCluster) {
 		cluster.signersCount = n
@@ -316,9 +316,7 @@ type lockstepCluster struct {
 
 func (cl *lockstepCluster) addNode(n *node) {
 	n.hare.Start()
-	cl.t.Cleanup(func() {
-		n.hare.Stop()
-	})
+	cl.t.Cleanup(n.hare.Stop)
 	cl.nodes = append(cl.nodes, n)
 }
 
@@ -912,7 +910,9 @@ func TestProposals(t *testing.T) {
 				atxsdata.AddFromAtx(&atx, false)
 			}
 			for _, proposal := range tc.proposals {
-				proposals.Add(proposal)
+				if err := proposals.Add(proposal); err != nil {
+					panic(err)
+				}
 			}
 			for _, id := range tc.malicious {
 				require.NoError(t, identities.SetMalicious(db, id, []byte("non empty"), time.Time{}))

--- a/hare4/hare_test.go
+++ b/hare4/hare_test.go
@@ -45,8 +45,6 @@ import (
 
 const layersPerEpoch = 4
 
-var wait = 10 * time.Second
-
 func TestMain(m *testing.M) {
 	types.SetLayersPerEpoch(layersPerEpoch)
 	res := m.Run()
@@ -323,7 +321,7 @@ func withProposals(fraction float64) clusterOpt {
 }
 
 // withSigners creates N signers in addition to regular active nodes.
-// this signeres will be partitioned in fair fashion across regular active nodes.
+// this signers will be partitioned in fair fashion across regular active nodes.
 func withSigners(n int) clusterOpt {
 	return func(cluster *lockstepCluster) {
 		cluster.signersCount = n
@@ -451,7 +449,7 @@ func (cl *lockstepCluster) genProposalNode(lid types.LayerID, node int) {
 	active := cl.activeSet()
 	n := cl.nodes[node]
 	if n.atx == nil {
-		panic("shouldnt happen")
+		panic("shouldn't happen")
 	}
 	proposal := &types.Proposal{}
 	proposal.Layer = lid
@@ -655,15 +653,15 @@ func sendWithTimeout[T any](t testing.TB, value T, ch chan<- T, timeout time.Dur
 }
 
 func (t *testTracer) waitStopped() types.LayerID {
-	return waitForChan(t.TB, t.stopped, wait, "didn't stop")
+	return waitForChan(t.TB, t.stopped, 10*time.Second, "didn't stop")
 }
 
 func (t *testTracer) waitEligibility() []*types.HareEligibility {
-	return waitForChan(t.TB, t.eligibility, wait, "no eligibility")
+	return waitForChan(t.TB, t.eligibility, 10*time.Second, "no eligibility")
 }
 
 func (t *testTracer) waitSent() *Message {
-	return waitForChan(t.TB, t.sent, wait, "no message")
+	return waitForChan(t.TB, t.sent, 10*time.Second, "no message")
 }
 
 func (*testTracer) OnStart(types.LayerID) {}
@@ -676,21 +674,21 @@ func (t *testTracer) OnStop(lid types.LayerID) {
 }
 
 func (t *testTracer) OnActive(el []*types.HareEligibility) {
-	sendWithTimeout(t.TB, el, t.eligibility, wait, "eligibility can't be sent")
+	sendWithTimeout(t.TB, el, t.eligibility, 10*time.Second, "eligibility can't be sent")
 }
 
 func (t *testTracer) OnMessageSent(m *Message) {
-	sendWithTimeout(t.TB, m, t.sent, wait, "message can't be sent")
+	sendWithTimeout(t.TB, m, t.sent, 10*time.Second, "message can't be sent")
 }
 
 func (*testTracer) OnMessageReceived(*Message) {}
 
 func (t *testTracer) OnCompactIdRequest(*CompactIdRequest) {
-	sendWithTimeout(t.TB, struct{}{}, t.compactReq, wait, "compact req can't be sent")
+	sendWithTimeout(t.TB, struct{}{}, t.compactReq, 10*time.Second, "compact req can't be sent")
 }
 
 func (t *testTracer) OnCompactIdResponse(*CompactIdResponse) {
-	sendWithTimeout(t.TB, struct{}{}, t.compactResp, wait, "compact resp can't be sent")
+	sendWithTimeout(t.TB, struct{}{}, t.compactResp, 10*time.Second, "compact resp can't be sent")
 }
 
 func testHare(t *testing.T, active, inactive, equivocators int, opts ...clusterOpt) {


### PR DESCRIPTION
## Motivation

Fix flaky test.

Closes #6293. 

## Description

The reason the test is flaky is because occasionally the first node sends a hare message before the other nodes have started processing the layer yet. I updated the code to check if the node that "receives" the message has already updated its state to start processing the layer of interest.

## Test Plan

Before the change this would always result in a fail on my machine:

```
go test -race -count=100 -run ^TestHare_ReconstructForward$ github.com/spacemeshos/go-spacemesh/hare4
```

After the change the test seems to be more reliable.

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
