### PR TITLE
[Merged by Bors] - simplify `vmState::Apply`

### DIFF
--- a/api/grpcserver/grpcserver_test.go
+++ b/api/grpcserver/grpcserver_test.go
@@ -2279,8 +2279,7 @@ func TestEventsReceived(t *testing.T) {
 	rewards := []types.CoinbaseReward{
 		{Coinbase: addr2, Weight: types.RatNum{Num: weight.Num().Uint64(), Denom: weight.Denom().Uint64()}},
 	}
-	svm.Apply(vm.ApplyContext{Layer: types.GetEffectiveGenesis()},
-		[]types.Transaction{*globalTx}, rewards)
+	svm.Apply(types.GetEffectiveGenesis(), []types.Transaction{*globalTx}, rewards)
 
 	txRes, err := txStream.Recv()
 	require.NoError(t, err)
@@ -2335,7 +2334,7 @@ func TestTransactionsRewards(t *testing.T) {
 		time.Sleep(50 * time.Millisecond)
 
 		svm := vm.New(statesql.InMemory(), vm.WithLogger(zaptest.NewLogger(t)))
-		_, _, err = svm.Apply(vm.ApplyContext{Layer: types.LayerID(17)}, []types.Transaction{*globalTx}, rewards)
+		_, _, err = svm.Apply(types.LayerID(17), []types.Transaction{*globalTx}, rewards)
 		req.NoError(err)
 
 		data, err := stream.Recv()
@@ -2356,7 +2355,7 @@ func TestTransactionsRewards(t *testing.T) {
 		time.Sleep(50 * time.Millisecond)
 
 		svm := vm.New(statesql.InMemory(), vm.WithLogger(zaptest.NewLogger(t)))
-		_, _, err = svm.Apply(vm.ApplyContext{Layer: types.LayerID(17)}, []types.Transaction{*globalTx}, rewards)
+		_, _, err = svm.Apply(types.LayerID(17), []types.Transaction{*globalTx}, rewards)
 		req.NoError(err)
 
 		data, err := stream.Recv()
@@ -2401,7 +2400,7 @@ func TestVMAccountUpdates(t *testing.T) {
 		})
 	}
 	lid := types.GetEffectiveGenesis().Add(1)
-	_, _, err = svm.Apply(vm.ApplyContext{Layer: lid}, spawns, nil)
+	_, _, err = svm.Apply(lid, spawns, nil)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -2438,7 +2437,7 @@ func TestVMAccountUpdates(t *testing.T) {
 			)),
 		})
 	}
-	_, _, err = svm.Apply(vm.ApplyContext{Layer: lid.Add(1)}, spends, nil)
+	_, _, err = svm.Apply(lid.Add(1), spends, nil)
 	require.NoError(t, err)
 	require.NoError(t, eg.Wait())
 	close(states)

--- a/api/grpcserver/transaction_service_test.go
+++ b/api/grpcserver/transaction_service_test.go
@@ -236,8 +236,12 @@ func TestParseTransactions(t *testing.T) {
 		accounts[i] = types.Account{Address: wallet.Address(pub), Balance: 1e12}
 	}
 	require.NoError(t, vminst.ApplyGenesis(accounts))
-	_, _, err := vminst.Apply(vm.ApplyContext{Layer: types.GetEffectiveGenesis().Add(1)},
-		[]types.Transaction{{RawTx: types.NewRawTx(wallet.SelfSpawn(keys[0], 0))}}, nil)
+	_, _, err := vminst.Apply(
+		types.GetEffectiveGenesis().Add(1),
+		[]types.Transaction{
+			{RawTx: types.NewRawTx(wallet.SelfSpawn(keys[0], 0))},
+		},
+		nil)
 	require.NoError(t, err)
 	mangled := wallet.Spend(keys[0], accounts[3].Address, 100, 0)
 	mangled[len(mangled)-1] -= 1

--- a/api/grpcserver/v2alpha1/transaction_test.go
+++ b/api/grpcserver/v2alpha1/transaction_test.go
@@ -241,8 +241,11 @@ func TestTransactionService_EstimateGas(t *testing.T) {
 		accounts[i] = types.Account{Address: wallet.Address(pub), Balance: 1e12}
 	}
 	require.NoError(t, vminst.ApplyGenesis(accounts))
-	_, _, err := vminst.Apply(vm.ApplyContext{Layer: types.GetEffectiveGenesis().Add(1)},
-		[]types.Transaction{{RawTx: types.NewRawTx(wallet.SelfSpawn(keys[0], 0))}}, nil)
+	_, _, err := vminst.Apply(
+		types.GetEffectiveGenesis().Add(1),
+		[]types.Transaction{{RawTx: types.NewRawTx(wallet.SelfSpawn(keys[0], 0))}},
+		nil,
+	)
 	require.NoError(t, err)
 
 	conn := dialGrpc(t, cfg)
@@ -304,8 +307,11 @@ func TestTransactionService_ParseTransaction(t *testing.T) {
 		accounts[i] = types.Account{Address: wallet.Address(pub), Balance: 1e12}
 	}
 	require.NoError(t, vminst.ApplyGenesis(accounts))
-	_, _, err := vminst.Apply(vm.ApplyContext{Layer: types.GetEffectiveGenesis().Add(1)},
-		[]types.Transaction{{RawTx: types.NewRawTx(wallet.SelfSpawn(keys[0], 0))}}, nil)
+	_, _, err := vminst.Apply(
+		types.GetEffectiveGenesis().Add(1),
+		[]types.Transaction{{RawTx: types.NewRawTx(wallet.SelfSpawn(keys[0], 0))}},
+		nil,
+	)
 	require.NoError(t, err)
 
 	mangled := wallet.Spend(keys[0], accounts[3].Address, 100, 0)

--- a/genvm/rewards.go
+++ b/genvm/rewards.go
@@ -12,13 +12,13 @@ import (
 )
 
 func (v *VM) addRewards(
-	lctx ApplyContext,
+	layer types.LayerID,
 	ss *core.StagedCache,
 	fees uint64,
 	blockRewards []types.CoinbaseReward,
 ) ([]types.Reward, error) {
 	var (
-		layersAfterEffectiveGenesis = lctx.Layer.Difference(types.FirstEffectiveGenesis())
+		layersAfterEffectiveGenesis = layer.Difference(types.FirstEffectiveGenesis())
 		subsidy                     = rewards.TotalSubsidyAtLayer(layersAfterEffectiveGenesis)
 		total                       = subsidy + fees
 		transferred                 uint64
@@ -51,7 +51,7 @@ func (v *VM) addRewards(
 		}
 
 		v.logger.Debug("rewards for coinbase",
-			zap.Uint32("layer", lctx.Layer.Uint32()),
+			zap.Uint32("layer", layer.Uint32()),
 			zap.Stringer("coinbase", blockReward.Coinbase),
 			zap.Stringer("relative weight", &blockReward.Weight),
 			zap.Uint64("subsidy", subsidyReward.Uint64()),
@@ -59,7 +59,7 @@ func (v *VM) addRewards(
 		)
 
 		reward := types.Reward{
-			Layer:       lctx.Layer,
+			Layer:       layer,
 			Coinbase:    blockReward.Coinbase,
 			SmesherID:   blockReward.SmesherID,
 			TotalReward: totalReward.Uint64(),
@@ -77,7 +77,7 @@ func (v *VM) addRewards(
 		transferred += totalReward.Uint64()
 	}
 	v.logger.Debug("rewards for layer",
-		zap.Uint32("layer", lctx.Layer.Uint32()),
+		zap.Uint32("layer", layer.Uint32()),
 		zap.Uint32("after genesis", layersAfterEffectiveGenesis),
 		zap.Uint64("subsidy estimated", subsidy),
 		zap.Uint64("fee", fees),

--- a/mesh/executor.go
+++ b/mesh/executor.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/spacemeshos/go-spacemesh/atxsdata"
 	"github.com/spacemeshos/go-spacemesh/common/types"
-	vm "github.com/spacemeshos/go-spacemesh/genvm"
 	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/sql"
 	"github.com/spacemeshos/go-spacemesh/sql/layers"
@@ -94,7 +93,7 @@ func (e *Executor) ExecuteOptimistic(
 	if err != nil {
 		return nil, err
 	}
-	ineffective, executed, err := e.vm.Apply(vm.ApplyContext{Layer: lid}, executable, crewards)
+	ineffective, executed, err := e.vm.Apply(lid, executable, crewards)
 	if err != nil {
 		return nil, fmt.Errorf("apply txs optimistically: %w", err)
 	}
@@ -150,11 +149,7 @@ func (e *Executor) Execute(ctx context.Context, lid types.LayerID, block *types.
 	if err != nil {
 		return err
 	}
-	ineffective, executed, err := e.vm.Apply(
-		vm.ApplyContext{Layer: block.LayerIndex},
-		executable,
-		rewards,
-	)
+	ineffective, executed, err := e.vm.Apply(block.LayerIndex, executable, rewards)
 	if err != nil {
 		return fmt.Errorf("apply block: %w", err)
 	}
@@ -199,7 +194,7 @@ func (e *Executor) convertRewards(lid types.LayerID, rewards []types.AnyReward) 
 
 func (e *Executor) executeEmpty(ctx context.Context, lid types.LayerID) error {
 	start := time.Now()
-	if _, _, err := e.vm.Apply(vm.ApplyContext{Layer: lid}, nil, nil); err != nil {
+	if _, _, err := e.vm.Apply(lid, nil, nil); err != nil {
 		return fmt.Errorf("apply empty layer: %w", err)
 	}
 	if err := e.cs.UpdateCache(ctx, lid, types.EmptyBlockID, nil, nil); err != nil {

--- a/mesh/interface.go
+++ b/mesh/interface.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
-	vm "github.com/spacemeshos/go-spacemesh/genvm"
 )
 
 //go:generate mockgen -typed -package=mocks -destination=./mocks/mocks.go -source=./interface.go
@@ -20,7 +19,7 @@ type vmState interface {
 	GetStateRoot() (types.Hash32, error)
 	Revert(types.LayerID) error
 	Apply(
-		vm.ApplyContext,
+		types.LayerID,
 		[]types.Transaction,
 		[]types.CoinbaseReward,
 	) ([]types.Transaction, []types.TransactionWithResult, error)

--- a/mesh/mocks/mocks.go
+++ b/mesh/mocks/mocks.go
@@ -14,7 +14,6 @@ import (
 	reflect "reflect"
 
 	types "github.com/spacemeshos/go-spacemesh/common/types"
-	vm "github.com/spacemeshos/go-spacemesh/genvm"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -217,7 +216,7 @@ func (m *MockvmState) EXPECT() *MockvmStateMockRecorder {
 }
 
 // Apply mocks base method.
-func (m *MockvmState) Apply(arg0 vm.ApplyContext, arg1 []types.Transaction, arg2 []types.CoinbaseReward) ([]types.Transaction, []types.TransactionWithResult, error) {
+func (m *MockvmState) Apply(arg0 types.LayerID, arg1 []types.Transaction, arg2 []types.CoinbaseReward) ([]types.Transaction, []types.TransactionWithResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Apply", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]types.Transaction)
@@ -245,13 +244,13 @@ func (c *MockvmStateApplyCall) Return(arg0 []types.Transaction, arg1 []types.Tra
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockvmStateApplyCall) Do(f func(vm.ApplyContext, []types.Transaction, []types.CoinbaseReward) ([]types.Transaction, []types.TransactionWithResult, error)) *MockvmStateApplyCall {
+func (c *MockvmStateApplyCall) Do(f func(types.LayerID, []types.Transaction, []types.CoinbaseReward) ([]types.Transaction, []types.TransactionWithResult, error)) *MockvmStateApplyCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockvmStateApplyCall) DoAndReturn(f func(vm.ApplyContext, []types.Transaction, []types.CoinbaseReward) ([]types.Transaction, []types.TransactionWithResult, error)) *MockvmStateApplyCall {
+func (c *MockvmStateApplyCall) DoAndReturn(f func(types.LayerID, []types.Transaction, []types.CoinbaseReward) ([]types.Transaction, []types.TransactionWithResult, error)) *MockvmStateApplyCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/syncer/state_syncer_test.go
+++ b/syncer/state_syncer_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/common/types/result"
 	"github.com/spacemeshos/go-spacemesh/fetch"
-	vm "github.com/spacemeshos/go-spacemesh/genvm"
 	"github.com/spacemeshos/go-spacemesh/p2p"
 	"github.com/spacemeshos/go-spacemesh/sql/blocks"
 	"github.com/spacemeshos/go-spacemesh/sql/certificates"
@@ -192,11 +191,11 @@ func TestProcessLayers_OpinionsNotAdopted(t *testing.T) {
 					certificates.Add(ts.cdb, lid, &types.Certificate{BlockID: tc.localCert}),
 				)
 				require.NoError(t, blocks.SetValid(ts.cdb, tc.localCert))
-				ts.mVm.EXPECT().Apply(vm.ApplyContext{Layer: lid}, gomock.Any(), gomock.Any())
+				ts.mVm.EXPECT().Apply(lid, gomock.Any(), gomock.Any())
 				ts.mConState.EXPECT().UpdateCache(gomock.Any(), lid, tc.localCert, nil, nil)
 				ts.mVm.EXPECT().GetStateRoot()
 			} else {
-				ts.mVm.EXPECT().Apply(vm.ApplyContext{Layer: lid}, nil, nil)
+				ts.mVm.EXPECT().Apply(lid, nil, nil)
 				ts.mConState.EXPECT().UpdateCache(gomock.Any(), lid, types.EmptyBlockID, nil, nil)
 				ts.mVm.EXPECT().GetStateRoot()
 			}
@@ -309,7 +308,7 @@ func TestProcessLayers_HareTakesTooLong(t *testing.T) {
 		ts.mTortoise.EXPECT().TallyVotes(gomock.Any(), lid)
 		ts.mTortoise.EXPECT().Updates().Return(fixture.RLayers(fixture.RLayer(lid)))
 		ts.mTortoise.EXPECT().OnApplied(lid, gomock.Any())
-		ts.mVm.EXPECT().Apply(vm.ApplyContext{Layer: lid}, nil, nil)
+		ts.mVm.EXPECT().Apply(lid, nil, nil)
 		ts.mConState.EXPECT().UpdateCache(gomock.Any(), lid, types.EmptyBlockID, nil, nil)
 		ts.mVm.EXPECT().GetStateRoot()
 	}
@@ -333,7 +332,7 @@ func TestProcessLayers_OpinionsOptional(t *testing.T) {
 	ts.mTortoise.EXPECT().Updates().Return(fixture.RLayers(fixture.RLayer(lastSynced)))
 	ts.mTortoise.EXPECT().OnApplied(lastSynced, gomock.Any())
 	require.False(t, ts.syncer.stateSynced())
-	ts.mVm.EXPECT().Apply(vm.ApplyContext{Layer: lastSynced}, nil, nil)
+	ts.mVm.EXPECT().Apply(lastSynced, nil, nil)
 	ts.mConState.EXPECT().UpdateCache(gomock.Any(), lastSynced, types.EmptyBlockID, nil, nil)
 	ts.mVm.EXPECT().GetStateRoot()
 	require.NoError(t, ts.syncer.processLayers(context.Background()))


### PR DESCRIPTION
## Motivation

Pass `types.LayerID` instead of `vm.ApplyContext`, a wrapper around a layer.

## Description

The `vm.ApplyContext` struct seems to have held more than just a LayerID. Using it instead of `types.LayerID` makes the interface more complicated than it needs to be and leaks out the `vm` pkg where it shouldn't be imported.

This change will also be useful for the PoC Athena VM integration, in which there will be 2 VMs implementing the `vmState` interface.

## Test Plan

existing tests pass

## TODO

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [ ] Update documentation as needed
- [ ] Update [changelog](../CHANGELOG.md) as needed
