### PR TITLE
[Merged by Bors] - fix slow lookup of previous ATX for (ID, epoch)

### DIFF
--- a/activation/activation_test.go
+++ b/activation/activation_test.go
@@ -138,7 +138,10 @@ func publishAtxV1(
 			return codec.Decode(got, &watx)
 		})
 	require.NoError(tb, atxs.Add(tab.db, toAtx(tb, &watx), watx.Blob()))
-	require.NoError(tb, atxs.SetPost(tab.db, watx.ID(), watx.PrevATXID, 0, watx.SmesherID, watx.NumUnits))
+	require.NoError(
+		tb,
+		atxs.SetPost(tab.db, watx.ID(), watx.PrevATXID, 0, watx.SmesherID, watx.NumUnits, watx.PublishEpoch),
+	)
 	tab.atxsdata.AddFromAtx(toAtx(tb, &watx), false)
 	return &watx
 }

--- a/activation/handler_v1.go
+++ b/activation/handler_v1.go
@@ -483,7 +483,7 @@ func (h *HandlerV1) storeAtx(
 		if err != nil && !errors.Is(err, sql.ErrObjectExists) {
 			return fmt.Errorf("add atx to db: %w", err)
 		}
-		err = atxs.SetPost(tx, atx.ID(), watx.PrevATXID, 0, atx.SmesherID, watx.NumUnits)
+		err = atxs.SetPost(tx, atx.ID(), watx.PrevATXID, 0, atx.SmesherID, watx.NumUnits, watx.PublishEpoch)
 		if err != nil && !errors.Is(err, sql.ErrObjectExists) {
 			return fmt.Errorf("set atx units: %w", err)
 		}

--- a/activation/handler_v2.go
+++ b/activation/handler_v2.go
@@ -871,7 +871,7 @@ func (h *HandlerV2) storeAtx(ctx context.Context, atx *types.ActivationTx, watx 
 			return fmt.Errorf("add atx to db: %w", err)
 		}
 		for id, post := range watx.ids {
-			err = atxs.SetPost(tx, atx.ID(), post.previous, post.previousIndex, id, post.units)
+			err = atxs.SetPost(tx, atx.ID(), post.previous, post.previousIndex, id, post.units, atx.PublishEpoch)
 			if err != nil && !errors.Is(err, sql.ErrObjectExists) {
 				return fmt.Errorf("setting atx units for ID %s: %w", id, err)
 			}

--- a/activation/handler_v2_test.go
+++ b/activation/handler_v2_test.go
@@ -1436,7 +1436,7 @@ func Test_ValidatePreviousATX(t *testing.T) {
 		t.Parallel()
 		prev := &types.ActivationTx{}
 		prev.SetID(types.RandomATXID())
-		require.NoError(t, atxs.SetPost(atxHandler.cdb, prev.ID(), types.EmptyATXID, 0, types.RandomNodeID(), 13))
+		require.NoError(t, atxs.SetPost(atxHandler.cdb, prev.ID(), types.EmptyATXID, 0, types.RandomNodeID(), 13, 0))
 
 		_, err := atxHandler.validatePreviousAtx(types.RandomNodeID(), &wire.SubPostV2{}, []*types.ActivationTx{prev})
 		require.Error(t, err)
@@ -1447,8 +1447,8 @@ func Test_ValidatePreviousATX(t *testing.T) {
 		other := types.RandomNodeID()
 		prev := &types.ActivationTx{}
 		prev.SetID(types.RandomATXID())
-		require.NoError(t, atxs.SetPost(atxHandler.cdb, prev.ID(), types.EmptyATXID, 0, id, 7))
-		require.NoError(t, atxs.SetPost(atxHandler.cdb, prev.ID(), types.EmptyATXID, 0, other, 13))
+		require.NoError(t, atxs.SetPost(atxHandler.cdb, prev.ID(), types.EmptyATXID, 0, id, 7, 0))
+		require.NoError(t, atxs.SetPost(atxHandler.cdb, prev.ID(), types.EmptyATXID, 0, other, 13, 0))
 
 		units, err := atxHandler.validatePreviousAtx(id, &wire.SubPostV2{NumUnits: 100}, []*types.ActivationTx{prev})
 		require.NoError(t, err)
@@ -1468,7 +1468,7 @@ func Test_ValidatePreviousATX(t *testing.T) {
 		other := types.RandomNodeID()
 		prev := &types.ActivationTx{}
 		prev.SetID(types.RandomATXID())
-		require.NoError(t, atxs.SetPost(atxHandler.cdb, prev.ID(), types.EmptyATXID, 0, other, 13))
+		require.NoError(t, atxs.SetPost(atxHandler.cdb, prev.ID(), types.EmptyATXID, 0, other, 13, 0))
 
 		_, err := atxHandler.validatePreviousAtx(id, &wire.SubPostV2{NumUnits: 100}, []*types.ActivationTx{prev})
 		require.Error(t, err)

--- a/api/grpcserver/admin_service_test.go
+++ b/api/grpcserver/admin_service_test.go
@@ -39,7 +39,7 @@ func newAtx(tb testing.TB, db sql.StateDatabase) {
 	atx.SmesherID = types.BytesToNodeID(types.RandomBytes(20))
 	atx.SetReceived(time.Now().Local())
 	require.NoError(tb, atxs.Add(db, atx, types.AtxBlob{}))
-	require.NoError(tb, atxs.SetPost(db, atx.ID(), types.EmptyATXID, 0, atx.SmesherID, atx.NumUnits))
+	require.NoError(tb, atxs.SetPost(db, atx.ID(), types.EmptyATXID, 0, atx.SmesherID, atx.NumUnits, atx.PublishEpoch))
 }
 
 func createMesh(tb testing.TB, db sql.StateDatabase) {

--- a/checkpoint/runner_test.go
+++ b/checkpoint/runner_test.go
@@ -268,7 +268,10 @@ func createMesh(t testing.TB, db sql.StateDatabase, miners []miner, accts []*typ
 	for _, miner := range miners {
 		for _, atx := range miner.atxs {
 			require.NoError(t, atxs.Add(db, atx.ActivationTx, types.AtxBlob{}))
-			require.NoError(t, atxs.SetPost(db, atx.ID(), atx.previous, 0, atx.SmesherID, atx.NumUnits))
+			require.NoError(
+				t,
+				atxs.SetPost(db, atx.ID(), atx.previous, 0, atx.SmesherID, atx.NumUnits, atx.PublishEpoch),
+			)
 		}
 		if proof := miner.malfeasanceProof; len(proof) > 0 {
 			require.NoError(t, identities.SetMalicious(db, miner.atxs[0].SmesherID, proof, time.Now()))
@@ -400,7 +403,7 @@ func TestRunner_Generate_PreservesMarriageATX(t *testing.T) {
 	}
 	atx.SetID(types.RandomATXID())
 	require.NoError(t, atxs.Add(db, atx, types.AtxBlob{}))
-	require.NoError(t, atxs.SetPost(db, atx.ID(), types.EmptyATXID, 0, atx.SmesherID, atx.NumUnits))
+	require.NoError(t, atxs.SetPost(db, atx.ID(), types.EmptyATXID, 0, atx.SmesherID, atx.NumUnits, atx.PublishEpoch))
 
 	fs := afero.NewMemMapFs()
 	dir, err := afero.TempDir(fs, "", "Generate")

--- a/common/types/poet.go
+++ b/common/types/poet.go
@@ -16,7 +16,7 @@ import (
 
 type PoetServer struct {
 	Address string    `mapstructure:"address" json:"address"`
-	Pubkey  Base64Enc `mapstructure:"pubkey" json:"pubkey"`
+	Pubkey  Base64Enc `mapstructure:"pubkey"  json:"pubkey"`
 }
 
 type PoetProofRef Hash32

--- a/sql/statesql/migrations/state_0021_migration_test.go
+++ b/sql/statesql/migrations/state_0021_migration_test.go
@@ -20,7 +20,7 @@ func Test0021Migration(t *testing.T) {
 	schema, err := statesql.Schema()
 	require.NoError(t, err)
 	schema.Migrations = slices.DeleteFunc(schema.Migrations, func(m sql.Migration) bool {
-		return m.Order() == 21
+		return m.Order() >= 21
 	})
 
 	db := sql.InMemory(

--- a/sql/statesql/schema/migrations/0023_posts_has_publish_epoch.sql
+++ b/sql/statesql/schema/migrations/0023_posts_has_publish_epoch.sql
@@ -1,0 +1,12 @@
+ALTER TABLE posts ADD COLUMN publish_epoch UNSIGNED INT;
+
+-- migrate data by iterating over all atxids in posts and inserting epoch for matching atx from atxs table by id column
+UPDATE posts
+SET publish_epoch = (
+    SELECT epoch
+    FROM atxs
+    WHERE atxs.id = posts.atxid
+);
+
+
+CREATE INDEX posts_by_atxid_by_pubkey_epoch ON posts (pubkey, publish_epoch);

--- a/sql/statesql/schema/schema.sql
+++ b/sql/statesql/schema/schema.sql
@@ -1,4 +1,4 @@
-PRAGMA user_version = 22;
+PRAGMA user_version = 23;
 CREATE TABLE accounts
 (
     address        CHAR(24),
@@ -110,8 +110,9 @@ CREATE TABLE posts (
     prev_atxid CHAR(32),
     prev_atx_index INT,
     units INT NOT NULL
-);
+, publish_epoch UNSIGNED INT);
 CREATE UNIQUE INDEX posts_by_atxid_by_pubkey ON posts (atxid, pubkey);
+CREATE INDEX posts_by_atxid_by_pubkey_epoch ON posts (pubkey, publish_epoch);
 CREATE INDEX posts_by_atxid_by_pubkey_prev_atxid ON posts (atxid, pubkey, prev_atxid);
 CREATE TABLE proposal_transactions
 (


### PR DESCRIPTION
## Motivation

Speed up `atxs.PrevIdByNodeId`

## Description

The query used in `atxs.PrevIdByNodeId` became very slow in 1.7 because it joins `atxs` and `posts` table to filter by the epoch from the `atxs` table.

Before:
```
Benchmark_PrevIdByNodeID/1.7-20         	    1960	    533631 ns/op	     714 B/op	      19 allocs/op
Benchmark_PrevIdByNodeID/1.6-20         	   74451	     17354 ns/op	     714 B/op	      19 allocs/op
```

I added `publish_epoch` column to the `posts` table to avoid joining the two tables.

After the change, the performance is equal to the original code:
```
Benchmark_PrevIdByNodeID/1.6-20         	   56253	     18199 ns/op	     713 B/op	      19 allocs/op
Benchmark_PrevIdByNodeID/1.7-20         	   61796	     18966 ns/op	     713 B/op	      19 allocs/op
```

### The benchmark

The benchmark code is not included in the PR because there isn't the "old" implementation to compare with. Below is its code:

```go
func Benchmark_PrevIdByNodeID(b *testing.B) {
	db := statesql.InMemoryTest(b)

	var signers []*signing.EdSigner

	for i := 0; i < 1000; i++ {
		sig, err := signing.NewEdSigner()
		require.NoError(b, err)
		signers = append(signers, sig)
	}

	for epoch := range types.EpochID(30) {
		var prev types.ATXID
		for _, signer := range signers {
			atx := newAtx(b, signer, withPublishEpoch(epoch))
			require.NoError(b, atxs.Add(db, atx, types.AtxBlob{}))
			require.NoError(b, atxs.SetPost(db, atx.ID(), prev, 0, signer.NodeID(), 4, atx.PublishEpoch))
			prev = atx.ID()
		}
	}

	b.Run("1.6", func(b *testing.B) {
		for i := 0; i < b.N; i++ {
			_, err := atxs.PrevIDByNodeID_OLD(db, signers[i%len(signers)].NodeID(), 2)
			require.NoError(b, err)
		}
	})
	b.Run("1.7", func(b *testing.B) {
		for i := 0; i < b.N; i++ {
			_, err := atxs.PrevIDByNodeID(db, signers[i%len(signers)].NodeID(), 20)
			require.NoError(b, err)
		}
	})
}
```
## Test Plan

- existing tests pass
- performance improved

## TODO

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [ ] Update documentation as needed
- [ ] Update [changelog](../CHANGELOG.md) as needed
