### PR TITLE
[Merged by Bors] - support up to 4 poets in merged ATX

### DIFF
--- a/activation/wire/wire_v2.go
+++ b/activation/wire/wire_v2.go
@@ -22,7 +22,7 @@ type ActivationTxV2 struct {
 	// only present in initial ATX
 	Initial      *InitialAtxPartsV2
 	PreviousATXs []types.ATXID `scale:"max=256"`
-	NiPosts      []NiPostsV2   `scale:"max=2"`
+	NiPosts      []NiPostsV2   `scale:"max=4"`
 
 	// The VRF nonce must be valid for the collected space of all included IDs.
 	VRFNonce uint64
@@ -102,7 +102,9 @@ func (atx *ActivationTxV2) merkleTree(tree *merkle.Tree) {
 	for _, niPost := range atx.NiPosts {
 		niPostTree.AddLeaf(niPost.Root(atx.PreviousATXs))
 	}
-	for i := len(atx.NiPosts); i < 2; i++ {
+	// Add empty niposts up to the max scale limit.
+	// This must be updated when the max scale limit is changed.
+	for i := len(atx.NiPosts); i < 4; i++ {
 		niPostTree.AddLeaf(types.EmptyHash32.Bytes())
 	}
 	tree.AddLeaf(niPostTree.Root())

--- a/activation/wire/wire_v2_scale.go
+++ b/activation/wire/wire_v2_scale.go
@@ -45,7 +45,7 @@ func (t *ActivationTxV2) EncodeScale(enc *scale.Encoder) (total int, err error) 
 		total += n
 	}
 	{
-		n, err := scale.EncodeStructSliceWithLimit(enc, t.NiPosts, 2)
+		n, err := scale.EncodeStructSliceWithLimit(enc, t.NiPosts, 4)
 		if err != nil {
 			return total, err
 		}
@@ -129,7 +129,7 @@ func (t *ActivationTxV2) DecodeScale(dec *scale.Decoder) (total int, err error) 
 		t.PreviousATXs = field
 	}
 	{
-		field, n, err := scale.DecodeStructSliceWithLimit[NiPostsV2](dec, 2)
+		field, n, err := scale.DecodeStructSliceWithLimit[NiPostsV2](dec, 4)
 		if err != nil {
 			return total, err
 		}


### PR DESCRIPTION
## Motivation

To support merging identities running on up to 3 fallback poets (on different phase shifts).

## Description

Extended the maximum size of `Niposts` slice in ATX V2 the wire type.

## Test Plan

Updated tests to process a merged ATX with 4 poets.

## TODO

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [ ] Update documentation as needed
- [ ] Update [changelog](../CHANGELOG.md) as needed
