### PR TITLE
[Merged by Bors] - start creating proposal as soon as signer session is initialized

### DIFF
--- a/miner/metrics.go
+++ b/miner/metrics.go
@@ -21,11 +21,12 @@ type latencyTracker struct {
 	start time.Time
 	end   time.Time
 
-	data     time.Duration
-	tortoise time.Duration
-	hash     time.Duration
-	txs      time.Duration
-	publish  time.Duration
+	data      time.Duration
+	tortoise  time.Duration
+	hash      time.Duration
+	activeSet time.Duration
+	txs       time.Duration
+	publish   time.Duration
 }
 
 func (lt *latencyTracker) total() time.Duration {
@@ -34,6 +35,7 @@ func (lt *latencyTracker) total() time.Duration {
 
 func (lt *latencyTracker) MarshalLogObject(encoder zapcore.ObjectEncoder) error {
 	encoder.AddDuration("data", lt.data)
+	encoder.AddDuration("active set", lt.activeSet)
 	encoder.AddDuration("tortoise", lt.tortoise)
 	encoder.AddDuration("hash", lt.hash)
 	encoder.AddDuration("txs", lt.txs)

--- a/miner/mocks/mocks.go
+++ b/miner/mocks/mocks.go
@@ -357,3 +357,65 @@ func (c *MocklayerClockLayerToTimeCall) DoAndReturn(f func(types.LayerID) time.T
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
+
+// MockatxSearch is a mock of atxSearch interface.
+type MockatxSearch struct {
+	ctrl     *gomock.Controller
+	recorder *MockatxSearchMockRecorder
+}
+
+// MockatxSearchMockRecorder is the mock recorder for MockatxSearch.
+type MockatxSearchMockRecorder struct {
+	mock *MockatxSearch
+}
+
+// NewMockatxSearch creates a new mock instance.
+func NewMockatxSearch(ctrl *gomock.Controller) *MockatxSearch {
+	mock := &MockatxSearch{ctrl: ctrl}
+	mock.recorder = &MockatxSearchMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockatxSearch) EXPECT() *MockatxSearchMockRecorder {
+	return m.recorder
+}
+
+// GetIDByEpochAndNodeID mocks base method.
+func (m *MockatxSearch) GetIDByEpochAndNodeID(ctx context.Context, epoch types.EpochID, nodeID types.NodeID) (types.ATXID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetIDByEpochAndNodeID", ctx, epoch, nodeID)
+	ret0, _ := ret[0].(types.ATXID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetIDByEpochAndNodeID indicates an expected call of GetIDByEpochAndNodeID.
+func (mr *MockatxSearchMockRecorder) GetIDByEpochAndNodeID(ctx, epoch, nodeID any) *MockatxSearchGetIDByEpochAndNodeIDCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIDByEpochAndNodeID", reflect.TypeOf((*MockatxSearch)(nil).GetIDByEpochAndNodeID), ctx, epoch, nodeID)
+	return &MockatxSearchGetIDByEpochAndNodeIDCall{Call: call}
+}
+
+// MockatxSearchGetIDByEpochAndNodeIDCall wrap *gomock.Call
+type MockatxSearchGetIDByEpochAndNodeIDCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockatxSearchGetIDByEpochAndNodeIDCall) Return(arg0 types.ATXID, arg1 error) *MockatxSearchGetIDByEpochAndNodeIDCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockatxSearchGetIDByEpochAndNodeIDCall) Do(f func(context.Context, types.EpochID, types.NodeID) (types.ATXID, error)) *MockatxSearchGetIDByEpochAndNodeIDCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockatxSearchGetIDByEpochAndNodeIDCall) DoAndReturn(f func(context.Context, types.EpochID, types.NodeID) (types.ATXID, error)) *MockatxSearchGetIDByEpochAndNodeIDCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}

--- a/miner/proposal_builder.go
+++ b/miner/proposal_builder.go
@@ -64,7 +64,11 @@ type defaultAtxSearch struct {
 	db sql.Executor
 }
 
-func (p defaultAtxSearch) GetIDByEpochAndNodeID(_ context.Context, epoch types.EpochID, nodeID types.NodeID) (types.ATXID, error) {
+func (p defaultAtxSearch) GetIDByEpochAndNodeID(
+	_ context.Context,
+	epoch types.EpochID,
+	nodeID types.NodeID,
+) (types.ATXID, error) {
 	return atxs.GetIDByEpochAndNodeID(p.db, epoch, nodeID)
 }
 

--- a/miner/proposal_builder_test.go
+++ b/miner/proposal_builder_test.go
@@ -250,7 +250,11 @@ type blockedAtxSearch struct {
 	blocked types.NodeID
 }
 
-func (b *blockedAtxSearch) GetIDByEpochAndNodeID(ctx context.Context, epoch types.EpochID, nodeID types.NodeID) (types.ATXID, error) {
+func (b *blockedAtxSearch) GetIDByEpochAndNodeID(
+	ctx context.Context,
+	epoch types.EpochID,
+	nodeID types.NodeID,
+) (types.ATXID, error) {
 	if nodeID == b.blocked {
 		<-ctx.Done()
 		return types.EmptyATXID, ctx.Err()


### PR DESCRIPTION
## Motivation

Speed up creating and publishing a proposal in 1:N setups.

## Description

In the original code, the `ProposalBuilder::build` was logically divided into 3 stages:

1. **in parallel** (up to `cfg.workersLimit` parallelization) initialize signers' sessions (only done once per signer)
2. run tortoise tallying votes, mesh hash calculation etc.
3. **in parallel** create and publish proposals by eligible singers

The problem was that stage 1 had to finish **for all signers** before stage 3 could start. It means that a single slow-to-initialize signer blocked all the others (ready to go).

This PR changes the code to have 2 stages running in parallel:
1. initializes signers' sessions (in parallel)
2. creates and publishes proposals for eligible signers

First, the already initialized signer's sessions are directly fed into stage 2. Then, the remaining uninitialized ones enter stage 1 for initialization. The stage 1 feeds initialized signer sessions to stage 2 via a channel. The culprit is that stage 2 creates proposals as soon as any signer session becomes ready (and is eligible).

Tallying votes and calculating mesh hash still happens once, and it is executed by the signer that first lands in stage 2 (using [sync.OnceValue](https://pkg.go.dev/sync#OnceValue)).

## Test Plan

- existing tests pass
- added a test that verifies if an eligible signer publishes its proposal as soon as possible, even if others are blocked

## TODO

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [ ] Update documentation as needed
- [ ] Update [changelog](../CHANGELOG.md) as needed
