### PR TITLE
[Merged by Bors] - atx: cache poet proofs with lru

### DIFF
--- a/activation/activation.go
+++ b/activation/activation.go
@@ -54,6 +54,7 @@ type PoetConfig struct {
 	InfoCacheTTL                   time.Duration `mapstructure:"info-cache-ttl"`
 	PowParamsCacheTTL              time.Duration `mapstructure:"pow-params-cache-ttl"`
 	MaxRequestRetries              int           `mapstructure:"retry-max"`
+	PoetProofsCache                int           `mapstructure:"poet-proofs-cache"`
 }
 
 func DefaultPoetConfig() PoetConfig {
@@ -62,6 +63,7 @@ func DefaultPoetConfig() PoetConfig {
 		MaxRequestRetries: 10,
 		InfoCacheTTL:      5 * time.Minute,
 		PowParamsCacheTTL: 5 * time.Minute,
+		PoetProofsCache:   200,
 	}
 }
 

--- a/config/mainnet.go
+++ b/config/mainnet.go
@@ -173,6 +173,7 @@ func MainnetConfig() Config {
 			RequestTimeout:    1100 * time.Second,
 			RequestRetryDelay: 10 * time.Second,
 			MaxRequestRetries: 10,
+			PoetProofsCache:   200,
 		},
 		POST: activation.PostConfig{
 			MinNumUnits:   4,

--- a/config/presets/testnet.go
+++ b/config/presets/testnet.go
@@ -126,6 +126,7 @@ func testnet() config.Config {
 
 			InfoCacheTTL:      5 * time.Minute,
 			PowParamsCacheTTL: 5 * time.Minute,
+			PoetProofsCache:   200,
 		},
 		POST: activation.PostConfig{
 			MinNumUnits:   2,

--- a/node/node.go
+++ b/node/node.go
@@ -580,7 +580,10 @@ func (app *App) initServices(ctx context.Context) error {
 	layersPerEpoch := types.GetLayersPerEpoch()
 	lg := app.log
 
-	poetDb := activation.NewPoetDb(app.db, app.addLogger(PoetDbLogger, lg).Zap())
+	poetDb := activation.NewPoetDb(
+		app.db,
+		app.addLogger(PoetDbLogger, lg).Zap(),
+		activation.WithCacheSize(app.Config.POET.PoetProofsCache))
 	postStates := activation.NewPostStates(app.addLogger(PostLogger, lg).Zap())
 	opts := []activation.PostVerifierOpt{
 		activation.WithVerifyingOpts(app.Config.SMESHING.VerifyingOpts),


### PR DESCRIPTION
followup for https://github.com/spacemeshos/go-spacemesh/pull/6326

in current code poet proofs are fetched for every atx submitted to the node, 
they are relatively large (140KB) and account for sizeable chunk of all reads executed on the atx handler codepath (25%).

they are also a perfect case for lru caching, they are mostly reused and replaced from epoch to epoch.

basic stats in recent epochs.

```
select round_id, count(*), max(length(poet)) from poets group by round_id;
25|42|146200
26|45|145936
27|45|145738
28|45|145903
```