### PR TITLE
sql: identities contain large proofs so tree without rowid will be slow to scan

### DIFF
--- a/sql/statesql/schema/migrations/0024_unrowid_idetities.sql
+++ b/sql/statesql/schema/migrations/0024_unrowid_idetities.sql
@@ -1,0 +1,12 @@
+ALTER TABLE identities RENAME TO identities_old;
+CREATE TABLE identities
+(
+    pubkey BLOB PRIMARY KEY,
+    proof  BLOB,
+    marriage_atx CHAR(32)
+);
+
+INSERT INTO identities (pubkey, proof, marriage_atx)
+  SELECT pubkey, proof, marriage_atx FROM identities_old;
+
+DROP TABLE identities_old;


### PR DESCRIPTION
followup for https://github.com/spacemeshos/go-spacemesh/pull/6326/

it is the first part of fixing IsMalicious, the main culprit is the query that includes marriage_atx check.
i will address it either here or in separate change.