### PR TITLE
[Merged by Bors] - chore: Remove unused environment variable in CI step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,8 +206,6 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   unittests:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Motivation

`codecov/codecov-action@v4` doesn't need the defined environment variable, it gains access to the token via the `token` argument passed to it.

## Description

Just removed the unneeded environment variable.

## Test Plan

Existing tests pass

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
