### PR TITLE
[Merged by Bors] - sync: refactor atxsync to avoid updates if same number of retries was persisted

### DIFF
--- a/syncer/atxsync/syncer_test.go
+++ b/syncer/atxsync/syncer_test.go
@@ -125,10 +125,9 @@ func TestSyncer(t *testing.T) {
 		publish := types.EpochID(2)
 		now := time.Now()
 
-		state := map[types.ATXID]int{
-			aid("1"): 0,
-			aid("2"): 0,
-		}
+		state := atxsync.EpochSyncState{}
+		state[aid("1")] = &atxsync.IDSyncState{Tries: 0}
+		state[aid("2")] = &atxsync.IDSyncState{Tries: 0}
 		require.NoError(t, atxsync.SaveSyncState(tester.localdb, publish, state, tester.cfg.AtxsBatch))
 		lastSuccess := now.Add(time.Minute)
 		require.NoError(t, atxsync.SaveRequest(tester.localdb, publish, lastSuccess, 2, 2))


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/d1f07795-d5d3-4301-b5b8-8d9e091c5978)

redundant updates causes a lot of overhead due to the number of atx being close to 6mil. see pprof above for approximate fraction of reads during sync.

this is a simple change to make it much less wasteful until atx syncv2 lands