### PR TITLE
[Merged by Bors] - chore: refactor panics into error handling

### DIFF
--- a/activation/e2e/activation_test.go
+++ b/activation/e2e/activation_test.go
@@ -117,7 +117,8 @@ func Test_BuilderWithMultipleClients(t *testing.T) {
 	)
 	certClient := activation.NewCertifierClient(db, localDB, logger.Named("certifier"))
 	certifier := activation.NewCertifier(localDB, logger, certClient)
-	poetDb := activation.NewPoetDb(db, logger.Named("poetDb"))
+	poetDb, err := activation.NewPoetDb(db, logger.Named("poetDb"))
+	require.NoError(t, err)
 	client, err := poetProver.Client(poetDb, poetCfg, logger, activation.WithCertifier(certifier))
 	require.NoError(t, err)
 

--- a/activation/e2e/atx_merge_test.go
+++ b/activation/e2e/atx_merge_test.go
@@ -220,7 +220,8 @@ func Test_MarryAndMerge(t *testing.T) {
 	verifier, err := activation.NewPostVerifier(cfg, logger, activation.WithVerifyingOpts(verifyingOpts))
 	require.NoError(t, err)
 	t.Cleanup(func() { assert.NoError(t, verifier.Close()) })
-	poetDb := activation.NewPoetDb(db, logger.Named("poetDb"))
+	poetDb, err := activation.NewPoetDb(db, logger.Named("poetDb"))
+	require.NoError(t, err)
 	validator := activation.NewValidator(db, poetDb, cfg, opts.Scrypt, verifier)
 
 	eg, ctx := errgroup.WithContext(context.Background())

--- a/activation/e2e/builds_atx_v2_test.go
+++ b/activation/e2e/builds_atx_v2_test.go
@@ -65,7 +65,8 @@ func TestBuilder_SwitchesToBuildV2(t *testing.T) {
 
 	initPost(t, cfg, opts, sig, goldenATX, grpcCfg, svc)
 
-	poetDb := activation.NewPoetDb(db, logger.Named("poetDb"))
+	poetDb, err := activation.NewPoetDb(db, logger.Named("poetDb"))
+	require.NoError(t, err)
 	verifier, err := activation.NewPostVerifier(cfg, logger.Named("verifier"))
 	require.NoError(t, err)
 	t.Cleanup(func() { assert.NoError(t, verifier.Close()) })

--- a/activation/e2e/checkpoint_merged_test.go
+++ b/activation/e2e/checkpoint_merged_test.go
@@ -57,7 +57,8 @@ func Test_CheckpointAfterMerge(t *testing.T) {
 	verifier, err := activation.NewPostVerifier(cfg, logger, activation.WithVerifyingOpts(verifyingOpts))
 	require.NoError(t, err)
 	t.Cleanup(func() { assert.NoError(t, verifier.Close()) })
-	poetDb := activation.NewPoetDb(db, logger.Named("poetDb"))
+	poetDb, err := activation.NewPoetDb(db, logger.Named("poetDb"))
+	require.NoError(t, err)
 	validator := activation.NewValidator(db, poetDb, cfg, opts.Scrypt, verifier)
 
 	eg, ctx := errgroup.WithContext(context.Background())
@@ -280,7 +281,8 @@ func Test_CheckpointAfterMerge(t *testing.T) {
 	require.Equal(t, marriageATX.ID(), *checkpointedMerged.MarriageATX)
 
 	// 4. Spawn new ATX handler and builder using the new DB
-	poetDb = activation.NewPoetDb(newDB, logger.Named("poetDb"))
+	poetDb, err = activation.NewPoetDb(newDB, logger.Named("poetDb"))
+	require.NoError(t, err)
 	cdb = datastore.NewCachedDB(newDB, logger)
 
 	poetSvc = activation.NewPoetServiceWithClient(poetDb, client, poetCfg, logger)

--- a/activation/e2e/checkpoint_test.go
+++ b/activation/e2e/checkpoint_test.go
@@ -58,7 +58,8 @@ func TestCheckpoint_PublishingSoloATXs(t *testing.T) {
 	initPost(t, cfg, opts, sig, goldenATX, grpcCfg, svc)
 	syncer := syncedSyncer(t)
 
-	poetDb := activation.NewPoetDb(db, logger.Named("poetDb"))
+	poetDb, err := activation.NewPoetDb(db, logger.Named("poetDb"))
+	require.NoError(t, err)
 	verifier, err := activation.NewPostVerifier(cfg, logger.Named("verifier"))
 	require.NoError(t, err)
 	t.Cleanup(func() { assert.NoError(t, verifier.Close()) })
@@ -186,7 +187,8 @@ func TestCheckpoint_PublishingSoloATXs(t *testing.T) {
 	defer newDB.Close()
 
 	// 3. Spawn new ATX handler and builder using the new DB
-	poetDb = activation.NewPoetDb(newDB, logger.Named("poetDb"))
+	poetDb, err = activation.NewPoetDb(newDB, logger.Named("poetDb"))
+	require.NoError(t, err)
 	cdb = datastore.NewCachedDB(newDB, logger)
 	atxdata, err = atxsdata.Warm(newDB, 1, logger)
 	poetService = activation.NewPoetServiceWithClient(poetDb, client, poetCfg, logger)

--- a/activation/e2e/nipost_test.go
+++ b/activation/e2e/nipost_test.go
@@ -188,7 +188,8 @@ func TestNIPostBuilderWithClients(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { assert.NoError(t, verifier.Close()) })
 
-	poetDb := activation.NewPoetDb(db, logger.Named("poetDb"))
+	poetDb, err := activation.NewPoetDb(db, logger.Named("poetDb"))
+	require.NoError(t, err)
 
 	postClient, err := svc.Client(sig.NodeID())
 	require.NoError(t, err)
@@ -271,7 +272,8 @@ func Test_NIPostBuilderWithMultipleClients(t *testing.T) {
 		GracePeriod: epoch / 4,
 	}
 
-	poetDb := activation.NewPoetDb(db, logger.Named("poetDb"))
+	poetDb, err := activation.NewPoetDb(db, logger.Named("poetDb"))
+	require.NoError(t, err)
 	client := ae2e.NewTestPoetClient(len(signers), poetCfg)
 	poetService := activation.NewPoetServiceWithClient(poetDb, client, poetCfg, logger)
 

--- a/activation/e2e/validation_test.go
+++ b/activation/e2e/validation_test.go
@@ -50,7 +50,8 @@ func TestValidator_Validate(t *testing.T) {
 		GracePeriod: epoch / 4,
 	}
 
-	poetDb := activation.NewPoetDb(statesql.InMemory(), logger.Named("poetDb"))
+	poetDb, err := activation.NewPoetDb(statesql.InMemory(), logger.Named("poetDb"))
+	require.NoError(t, err)
 	client := ae2e.NewTestPoetClient(1, poetCfg)
 	poetService := activation.NewPoetServiceWithClient(poetDb, client, poetCfg, logger)
 

--- a/activation/poet_client_test.go
+++ b/activation/poet_client_test.go
@@ -530,7 +530,8 @@ func TestPoetService_CachesCertifierInfo(t *testing.T) {
 
 			cfg := DefaultPoetConfig()
 			cfg.InfoCacheTTL = tc.ttl
-			db := NewPoetDb(statesql.InMemory(), zaptest.NewLogger(t))
+			db, err := NewPoetDb(statesql.InMemory(), zaptest.NewLogger(t))
+			require.NoError(t, err)
 
 			url := &url.URL{Host: "certifier.hello"}
 			pubkey := []byte("pubkey")

--- a/activation/poetdb.go
+++ b/activation/poetdb.go
@@ -44,7 +44,7 @@ type PoetDb struct {
 }
 
 // NewPoetDb returns a new PoET handler.
-func NewPoetDb(db sql.StateDatabase, log *zap.Logger, opts ...PoetDbOption) *PoetDb {
+func NewPoetDb(db sql.StateDatabase, log *zap.Logger, opts ...PoetDbOption) (*PoetDb, error) {
 	options := PoetDbOptions{
 		// in last epochs there are 45 proofs per epoch, with each of them nearly 140KB
 		// 200 is set not to keep multiple epochs, but to account for unexpected growth
@@ -60,13 +60,13 @@ func NewPoetDb(db sql.StateDatabase, log *zap.Logger, opts ...PoetDbOption) *Poe
 	}
 	poetProofsLru, err := lru.New[types.PoetProofRef, *types.PoetProofMessage](options.cacheSize)
 	if err != nil {
-		log.Panic("failed to create PoET proofs LRU cache", zap.Error(err))
+		return nil, fmt.Errorf("create lru: %w", err)
 	}
 	return &PoetDb{
 		sqlDB:         db,
 		poetProofsLru: poetProofsLru,
 		logger:        log,
-	}
+	}, nil
 }
 
 // HasProof returns true if the database contains a proof with the given reference, or false otherwise.

--- a/activation/poetdb_test.go
+++ b/activation/poetdb_test.go
@@ -63,7 +63,8 @@ func getPoetProof(t *testing.T) types.PoetProofMessage {
 func TestPoetDbHappyFlow(t *testing.T) {
 	r := require.New(t)
 	msg := getPoetProof(t)
-	poetDb := NewPoetDb(statesql.InMemory(), zaptest.NewLogger(t))
+	poetDb, err := NewPoetDb(statesql.InMemory(), zaptest.NewLogger(t))
+	r.NoError(err)
 
 	r.NoError(poetDb.Validate(msg.Statement[:], msg.PoetProof, msg.PoetServiceID, msg.RoundID, types.EmptyEdSignature))
 	ref, err := msg.Ref()
@@ -83,10 +84,11 @@ func TestPoetDbHappyFlow(t *testing.T) {
 func TestPoetDbInvalidPoetProof(t *testing.T) {
 	r := require.New(t)
 	msg := getPoetProof(t)
-	poetDb := NewPoetDb(statesql.InMemory(), zaptest.NewLogger(t))
+	poetDb, err := NewPoetDb(statesql.InMemory(), zaptest.NewLogger(t))
+	r.NoError(err)
 	msg.PoetProof.Root = []byte("some other root")
 
-	err := poetDb.Validate(msg.Statement[:], msg.PoetProof, msg.PoetServiceID, msg.RoundID, types.EmptyEdSignature)
+	err = poetDb.Validate(msg.Statement[:], msg.PoetProof, msg.PoetServiceID, msg.RoundID, types.EmptyEdSignature)
 	r.EqualError(
 		err,
 		fmt.Sprintf(
@@ -99,10 +101,11 @@ func TestPoetDbInvalidPoetProof(t *testing.T) {
 func TestPoetDbInvalidPoetStatement(t *testing.T) {
 	r := require.New(t)
 	msg := getPoetProof(t)
-	poetDb := NewPoetDb(statesql.InMemory(), zaptest.NewLogger(t))
+	poetDb, err := NewPoetDb(statesql.InMemory(), zaptest.NewLogger(t))
+	r.NoError(err)
 	msg.Statement = types.CalcHash32([]byte("some other statement"))
 
-	err := poetDb.Validate(msg.Statement[:], msg.PoetProof, msg.PoetServiceID, msg.RoundID, types.EmptyEdSignature)
+	err = poetDb.Validate(msg.Statement[:], msg.PoetProof, msg.PoetServiceID, msg.RoundID, types.EmptyEdSignature)
 	r.EqualError(
 		err,
 		fmt.Sprintf(
@@ -115,9 +118,10 @@ func TestPoetDbInvalidPoetStatement(t *testing.T) {
 func TestPoetDbNonExistingKeys(t *testing.T) {
 	r := require.New(t)
 	msg := getPoetProof(t)
-	poetDb := NewPoetDb(statesql.InMemory(), zaptest.NewLogger(t))
+	poetDb, err := NewPoetDb(statesql.InMemory(), zaptest.NewLogger(t))
+	r.NoError(err)
 
-	_, err := poetDb.GetProofRef(msg.PoetServiceID, "0")
+	_, err = poetDb.GetProofRef(msg.PoetServiceID, "0")
 	r.EqualError(
 		err,
 		fmt.Sprintf(

--- a/fetch/cache.go
+++ b/fetch/cache.go
@@ -1,6 +1,7 @@
 package fetch
 
 import (
+	"fmt"
 	"math/rand/v2"
 	"sync"
 
@@ -9,7 +10,6 @@ import (
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/datastore"
-	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/p2p"
 )
 
@@ -24,12 +24,12 @@ type HashPeersCache struct {
 type HashPeers map[p2p.Peer]struct{}
 
 // NewHashPeersCache creates a new hash-to-peers cache.
-func NewHashPeersCache(size int) *HashPeersCache {
+func NewHashPeersCache(size int) (*HashPeersCache, error) {
 	cache, err := lru.New[types.Hash32, HashPeers](size)
 	if err != nil {
-		log.Panic("could not initialize cache ", err)
+		return nil, fmt.Errorf("create lru: %w", err)
 	}
-	return &HashPeersCache{Cache: cache}
+	return &HashPeersCache{Cache: cache}, nil
 }
 
 // get returns peers for a given hash (non-thread-safe).

--- a/fetch/cache_test.go
+++ b/fetch/cache_test.go
@@ -25,7 +25,8 @@ func getCachedEntry(cache *HashPeersCache, hash types.Hash32) (HashPeers, bool) 
 func TestAdd(t *testing.T) {
 	t.Parallel()
 	t.Run("1Hash3Peers", func(t *testing.T) {
-		cache := NewHashPeersCache(10)
+		cache, err := NewHashPeersCache(10)
+		require.NoError(t, err)
 		hash := types.RandomHash()
 		peer1 := p2p.Peer("test_peer_1")
 		peer2 := p2p.Peer("test_peer_2")
@@ -49,7 +50,8 @@ func TestAdd(t *testing.T) {
 		require.Len(t, hashPeers, 3)
 	})
 	t.Run("2Hashes1Peer", func(t *testing.T) {
-		cache := NewHashPeersCache(10)
+		cache, err := NewHashPeersCache(10)
+		require.NoError(t, err)
 		hash1 := types.RandomHash()
 		hash2 := types.RandomHash()
 		peer := p2p.Peer("test_peer")
@@ -74,7 +76,8 @@ func TestAdd(t *testing.T) {
 func TestGetRandom(t *testing.T) {
 	t.Parallel()
 	t.Run("no hash peers", func(t *testing.T) {
-		cache := NewHashPeersCache(10)
+		cache, err := NewHashPeersCache(10)
+		require.NoError(t, err)
 		hash := types.RandomHash()
 		var seed [32]byte
 		binary.LittleEndian.PutUint64(seed[:], uint64(time.Now().UnixNano()))
@@ -83,7 +86,8 @@ func TestGetRandom(t *testing.T) {
 		require.Empty(t, peers)
 	})
 	t.Run("1Hash3Peers", func(t *testing.T) {
-		cache := NewHashPeersCache(10)
+		cache, err := NewHashPeersCache(10)
+		require.NoError(t, err)
 		hash := types.RandomHash()
 		peer1 := p2p.Peer("test_peer_1")
 		peer2 := p2p.Peer("test_peer_2")
@@ -110,7 +114,8 @@ func TestGetRandom(t *testing.T) {
 		require.ElementsMatch(t, []p2p.Peer{peer1, peer2, peer3}, peers)
 	})
 	t.Run("2Hashes1Peer", func(t *testing.T) {
-		cache := NewHashPeersCache(10)
+		cache, err := NewHashPeersCache(10)
+		require.NoError(t, err)
 		hash1 := types.RandomHash()
 		hash2 := types.RandomHash()
 		peer := p2p.Peer("test_peer")
@@ -138,7 +143,8 @@ func TestGetRandom(t *testing.T) {
 func TestRegisterPeerHashes(t *testing.T) {
 	t.Parallel()
 	t.Run("1Hash2Peers", func(t *testing.T) {
-		cache := NewHashPeersCache(10)
+		cache, err := NewHashPeersCache(10)
+		require.NoError(t, err)
 		hash1 := types.RandomHash()
 		hash2 := types.RandomHash()
 		hash3 := types.RandomHash()
@@ -154,7 +160,8 @@ func TestRegisterPeerHashes(t *testing.T) {
 }
 
 func TestRace(t *testing.T) {
-	cache := NewHashPeersCache(10)
+	cache, err := NewHashPeersCache(10)
+	require.NoError(t, err)
 	hash := types.RandomHash()
 	peer1 := p2p.Peer("test_peer_1")
 	peer2 := p2p.Peer("test_peer_2")

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -271,6 +271,7 @@ func NewFetch(
 ) *Fetch {
 	bs := datastore.NewBlobStore(cdb, proposals)
 
+	hashPeerCache, _ := NewHashPeersCache(cacheSize) // only errors if `cacheSize` is zero or negative
 	f := &Fetch{
 		cfg:         DefaultConfig(),
 		logger:      zap.NewNop(),
@@ -279,7 +280,7 @@ func NewFetch(
 		servers:     map[string]requester{},
 		unprocessed: make(map[types.Hash32]*request),
 		ongoing:     make(map[types.Hash32]*request),
-		hashToPeers: NewHashPeersCache(cacheSize),
+		hashToPeers: hashPeerCache,
 	}
 	for _, opt := range opts {
 		opt(f)

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -268,10 +268,13 @@ func NewFetch(
 	proposals *store.Store,
 	host *p2p.Host,
 	opts ...Option,
-) *Fetch {
+) (*Fetch, error) {
 	bs := datastore.NewBlobStore(cdb, proposals)
 
-	hashPeerCache, _ := NewHashPeersCache(cacheSize) // only errors if `cacheSize` is zero or negative
+	hashPeerCache, err := NewHashPeersCache(cacheSize)
+	if err != nil {
+		return nil, err
+	}
 	f := &Fetch{
 		cfg:         DefaultConfig(),
 		logger:      zap.NewNop(),
@@ -342,7 +345,7 @@ func NewFetch(
 		f.registerServer(host, lyrDataProtocol, server.WrapHandler(h.handleLayerDataReq))
 		f.registerServer(host, OpnProtocol, server.WrapHandler(h.handleLayerOpinionsReq2))
 	}
-	return f
+	return f, nil
 }
 
 func (f *Fetch) registerServer(

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -274,7 +274,8 @@ func NewFetch(
 
 	hashPeerCache, err := NewHashPeersCache(cacheSize)
 	if err != nil {
-		return nil, fmt.Errorf("create hash peer cache: %w", err)
+		// this should never happen, since cacheSize is a constant, but just in case
+		panic(fmt.Errorf("create hash peer cache: %w", err))
 	}
 	f := &Fetch{
 		cfg:         DefaultConfig(),

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"io"
 	"math/rand/v2"
 	"sync"
@@ -273,7 +274,7 @@ func NewFetch(
 
 	hashPeerCache, err := NewHashPeersCache(cacheSize)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("create hash peer cache: %w", err)
 	}
 	f := &Fetch{
 		cfg:         DefaultConfig(),

--- a/fetch/fetch_test.go
+++ b/fetch/fetch_test.go
@@ -404,7 +404,7 @@ func TestFetch_PeerDroppedWhenMessageResultsInValidationReject(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(fetcher.Stop)
 
-	// We set a validatior just for atxs, this validator does not drop connections
+	// We set a validator just for atxs, this validator does not drop connections
 	vf := ValidatorFunc(
 		func(context.Context, types.Hash32, peer.ID, []byte) error { return pubsub.ErrValidationReject },
 	)

--- a/fetch/mesh_data_test.go
+++ b/fetch/mesh_data_test.go
@@ -1003,11 +1003,12 @@ func Test_GetAtxsLimiting(t *testing.T) {
 			client := server.New(wrapHost(mesh.Hosts()[0]), hashProtocol, nil)
 			host, err := p2p.Upgrade(mesh.Hosts()[0])
 			require.NoError(t, err)
-			f := NewFetch(cdb, store.New(), host,
+			f, err := NewFetch(cdb, store.New(), host,
 				WithContext(context.Background()),
 				withServers(map[string]requester{hashProtocol: client}),
 				WithConfig(cfg),
 			)
+			require.NoError(t, err)
 
 			atxValidatorMock := mocks.NewMockSyncValidator(gomock.NewController(t))
 			f.validators = &dataValidators{

--- a/fetch/p2p_test.go
+++ b/fetch/p2p_test.go
@@ -125,10 +125,16 @@ func createP2PFetch(
 		receivedData: make(map[blobKey][]byte),
 	}
 
-	tpf.serverFetch = NewFetch(tpf.serverCDB, tpf.serverPDB, serverHost,
+	fetcher, err := NewFetch(
+		tpf.serverCDB,
+		tpf.serverPDB,
+		serverHost,
 		WithContext(ctx),
 		WithConfig(p2pFetchCfg(serverStreaming)),
-		WithLogger(lg))
+		WithLogger(lg),
+	)
+	require.NoError(t, err)
+	tpf.serverFetch = fetcher
 	vf := ValidatorFunc(
 		func(context.Context, types.Hash32, peer.ID, []byte) error { return nil },
 	)
@@ -140,10 +146,16 @@ func createP2PFetch(
 		return len(serverHost.Mux().Protocols()) != 0
 	}, 10*time.Second, 10*time.Millisecond)
 
-	tpf.clientFetch = NewFetch(tpf.clientCDB, tpf.clientPDB, clientHost,
+	fetcher, err = NewFetch(
+		tpf.clientCDB,
+		tpf.clientPDB,
+		clientHost,
 		WithContext(ctx),
 		WithConfig(p2pFetchCfg(clientStreaming)),
-		WithLogger(lg))
+		WithLogger(lg),
+	)
+	require.NoError(t, err)
+	tpf.clientFetch = fetcher
 	tpf.clientFetch.SetValidators(
 		mkFakeValidator(tpf, "atx"),
 		mkFakeValidator(tpf, "poet"),

--- a/node/node.go
+++ b/node/node.go
@@ -580,10 +580,14 @@ func (app *App) initServices(ctx context.Context) error {
 	layersPerEpoch := types.GetLayersPerEpoch()
 	lg := app.log
 
-	poetDb := activation.NewPoetDb(
+	poetDb, err := activation.NewPoetDb(
 		app.db,
 		app.addLogger(PoetDbLogger, lg).Zap(),
-		activation.WithCacheSize(app.Config.POET.PoetProofsCache))
+		activation.WithCacheSize(app.Config.POET.PoetProofsCache),
+	)
+	if err != nil {
+		return fmt.Errorf("creating poet db: %w", err)
+	}
 	postStates := activation.NewPostStates(app.addLogger(PostLogger, lg).Zap())
 	opts := []activation.PostVerifierOpt{
 		activation.WithVerifyingOpts(app.Config.SMESHING.VerifyingOpts),

--- a/node/node.go
+++ b/node/node.go
@@ -816,11 +816,14 @@ func (app *App) initServices(ctx context.Context) error {
 	)
 
 	flog := app.addLogger(Fetcher, lg)
-	fetcher := fetch.NewFetch(app.cachedDB, proposalsStore, app.host,
+	fetcher, err := fetch.NewFetch(app.cachedDB, proposalsStore, app.host,
 		fetch.WithContext(ctx),
 		fetch.WithConfig(app.Config.FETCH),
 		fetch.WithLogger(flog.Zap()),
 	)
+	if err != nil {
+		return fmt.Errorf("create fetcher: %w", err)
+	}
 	fetcherWrapped.Fetcher = fetcher
 	app.eg.Go(func() error {
 		return blockssync.Sync(ctx, flog.Zap(), msh.MissingBlocks(), fetcher)

--- a/systest/tests/distributed_post_verification_test.go
+++ b/systest/tests/distributed_post_verification_test.go
@@ -160,7 +160,8 @@ func TestPostMalfeasanceProof(t *testing.T) {
 	localDb := localsql.InMemory()
 	certClient := activation.NewCertifierClient(db, localDb, logger.Named("certifier"))
 	certifier := activation.NewCertifier(localDb, logger, certClient)
-	poetDb := activation.NewPoetDb(db, zap.NewNop())
+	poetDb, err := activation.NewPoetDb(db, zap.NewNop())
+	require.NoError(t, err)
 	poetService, err := activation.NewPoetService(
 		poetDb,
 		types.PoetServer{

--- a/systest/tests/poets_test.go
+++ b/systest/tests/poets_test.go
@@ -4,7 +4,6 @@ import (
 	"crypto/ed25519"
 	"encoding/base64"
 	"encoding/hex"
-	"fmt"
 	"math"
 	"testing"
 
@@ -198,11 +197,8 @@ func TestNodesUsingDifferentPoets(t *testing.T) {
 	firstEpochWithEligibility := uint32(math.Max(2.0, float64(first/layersPerEpoch)))
 	epochsInTest := last/layersPerEpoch - firstEpochWithEligibility + 1
 	for id, eligibleEpochs := range smeshers {
-		assert.Len(
-			t,
-			eligibleEpochs,
-			int(epochsInTest),
-			fmt.Sprintf("smesher ID: %v, its epochs: %v", hex.EncodeToString([]byte(id)), eligibleEpochs),
+		assert.Lenf(t, eligibleEpochs, int(epochsInTest),
+			"smesher ID: %v, its epochs: %v", hex.EncodeToString([]byte(id)), eligibleEpochs,
 		)
 	}
 }


### PR DESCRIPTION
## Motivation

Updated some places where `log.Panic` is used and replaced it by returning the error, callers already handle them.

## Description

Return errors in some places where `log.Panic` was used before

## Test Plan

Existing tests pass.

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
