### PR TITLE
identities: refactor is_malicious check to read minimal amount of data

### DIFF
--- a/activation/handler_v1.go
+++ b/activation/handler_v1.go
@@ -454,8 +454,11 @@ func (h *HandlerV1) checkMalicious(
 		return true, nil, nil
 	}
 	proof, err := h.checkDoublePublish(ctx, tx, watx)
-	if proof != nil || err != nil {
-		return true, proof, err
+	if err != nil {
+		return false, nil, err
+	}
+	if proof != nil {
+		return true, proof, nil
 	}
 	proof, err = h.checkWrongPrevAtx(ctx, tx, watx)
 	if err != nil {

--- a/activation/handler_v2.go
+++ b/activation/handler_v2.go
@@ -682,8 +682,13 @@ func (h *HandlerV2) checkMalicious(ctx context.Context, tx sql.Transaction, atx 
 	if malicious {
 		return true, nil
 	}
-	if atx.MarriageATX != nil {
-		receivedProof, err := identities.IsMarriageMalicious(tx, *atx.MarriageATX)
+	marriage := atx.MarriageATX
+	if marriage == nil && len(atx.marriages) > 0 {
+		this := atx.ID()
+		marriage = &this
+	}
+	if marriage != nil {
+		receivedProof, err := identities.IsMarriageMalicious(tx, *marriage)
 		if err != nil {
 			return false, fmt.Errorf("checking if marriage ATX is malicious: %w", err)
 		}

--- a/activation/handler_v2.go
+++ b/activation/handler_v2.go
@@ -683,7 +683,17 @@ func (h *HandlerV2) checkMalicious(ctx context.Context, tx sql.Transaction, atx 
 		return true, nil
 	}
 	if atx.MarriageATX != nil {
-		malicious, err := identities.IsMarriageMalicious(tx, *atx.MarriageATX)
+		receivedProof, err := identities.IsMarriageMalicious(tx, *atx.MarriageATX)
+		if err != nil {
+			return false, fmt.Errorf("checking if marriage ATX is malicious: %w", err)
+		}
+		if receivedProof != nil {
+			err = identities.SetMaliciousBecauseOfMarriage(tx, atx.SmesherID, *receivedProof)
+			if err != nil {
+				return false, fmt.Errorf("setting node as malicious because of marriage: %w", err)
+			}
+			return true, nil
+		}
 	}
 
 	malicious, err = h.checkDoubleMarry(ctx, tx, atx)

--- a/activation/handler_v2.go
+++ b/activation/handler_v2.go
@@ -682,6 +682,9 @@ func (h *HandlerV2) checkMalicious(ctx context.Context, tx sql.Transaction, atx 
 	if malicious {
 		return true, nil
 	}
+	if atx.MarriageATX != nil {
+		malicious, err := identities.IsMarriageMalicious(tx, *atx.MarriageATX)
+	}
 
 	malicious, err = h.checkDoubleMarry(ctx, tx, atx)
 	if err != nil {

--- a/datastore/store.go
+++ b/datastore/store.go
@@ -202,7 +202,7 @@ func (db *CachedDB) Previous(id types.ATXID) ([]types.ATXID, error) {
 func (db *CachedDB) IterateMalfeasanceProofs(
 	iter func(types.NodeID, *wire.MalfeasanceProof) error,
 ) error {
-	ids, err := identities.GetMalicious(db)
+	ids, err := identities.GetNodeIDsWithProofs(db)
 	if err != nil {
 		return err
 	}

--- a/fetch/handler.go
+++ b/fetch/handler.go
@@ -46,7 +46,7 @@ func newHandler(
 
 // handleMaliciousIDsReq returns the IDs of all known malicious nodes.
 func (h *handler) handleMaliciousIDsReq(ctx context.Context, _ []byte) ([]byte, error) {
-	nodes, err := identities.GetMalicious(h.cdb)
+	nodes, err := identities.GetNodeIDsWithProofs(h.cdb)
 	if err != nil {
 		return nil, fmt.Errorf("getting malicious IDs: %w", err)
 	}
@@ -63,7 +63,7 @@ func (h *handler) handleMaliciousIDsReq(ctx context.Context, _ []byte) ([]byte, 
 
 func (h *handler) handleMaliciousIDsReqStream(ctx context.Context, msg []byte, s io.ReadWriter) error {
 	if err := h.streamIDs(ctx, s, func(cbk retrieveCallback) error {
-		nodeIDs, err := identities.GetMalicious(h.cdb)
+		nodeIDs, err := identities.GetNodeIDsWithProofs(h.cdb)
 		if err != nil {
 			return fmt.Errorf("getting malicious IDs: %w", err)
 		}

--- a/hare3/hare.go
+++ b/hare3/hare.go
@@ -341,7 +341,7 @@ func (h *Hare) Handler(ctx context.Context, peer p2p.Peer, buf []byte) error {
 		proof := equivocation.ToMalfeasanceProof()
 		err := h.db.WithTx(context.Background(), func(tx sql.Transaction) error {
 			return identities.SetMalicious(
-				h.db, equivocation.Messages[0].SmesherID, codec.MustEncode(proof), time.Now())
+				tx, equivocation.Messages[0].SmesherID, codec.MustEncode(proof), time.Now())
 		})
 		if err != nil {
 			h.log.Error("failed to save malicious identity", zap.Error(err))

--- a/hare4/hare.go
+++ b/hare4/hare.go
@@ -552,7 +552,7 @@ func (h *Hare) Handler(ctx context.Context, peer p2p.Peer, buf []byte) error {
 		proof := equivocation.ToMalfeasanceProof()
 		err := h.db.WithTx(context.Background(), func(tx sql.Transaction) error {
 			return identities.SetMalicious(
-				h.db, equivocation.Messages[0].SmesherID, codec.MustEncode(proof), time.Now())
+				tx, equivocation.Messages[0].SmesherID, codec.MustEncode(proof), time.Now())
 		})
 		if err != nil {
 			h.log.Error("failed to save malicious identity", zap.Error(err))

--- a/hare4/hare.go
+++ b/hare4/hare.go
@@ -550,8 +550,11 @@ func (h *Hare) Handler(ctx context.Context, peer p2p.Peer, buf []byte) error {
 			zap.Uint32("lid", msg.Layer.Uint32()),
 			zap.Stringer("sender", equivocation.Messages[0].SmesherID))
 		proof := equivocation.ToMalfeasanceProof()
-		if err := identities.SetMalicious(
-			h.db, equivocation.Messages[0].SmesherID, codec.MustEncode(proof), time.Now()); err != nil {
+		err := h.db.WithTx(context.Background(), func(tx sql.Transaction) error {
+			return identities.SetMalicious(
+				h.db, equivocation.Messages[0].SmesherID, codec.MustEncode(proof), time.Now())
+		})
+		if err != nil {
 			h.log.Error("failed to save malicious identity", zap.Error(err))
 		}
 		h.atxsdata.SetMalicious(equivocation.Messages[0].SmesherID)

--- a/sql/identities/identities_test.go
+++ b/sql/identities/identities_test.go
@@ -60,7 +60,7 @@ func TestMalicious(t *testing.T) {
 
 func Test_GetMalicious(t *testing.T) {
 	db := statesql.InMemory()
-	got, err := identities.GetMalicious(db)
+	got, err := identities.GetNodeIDsWithProofs(db)
 	require.NoError(t, err)
 	require.Nil(t, got)
 
@@ -71,7 +71,7 @@ func Test_GetMalicious(t *testing.T) {
 		bad = append(bad, nid)
 		require.NoError(t, identities.SetMalicious(db, nid, types.RandomBytes(11), time.Now().Local()))
 	}
-	got, err = identities.GetMalicious(db)
+	got, err = identities.GetNodeIDsWithProofs(db)
 	require.NoError(t, err)
 	require.Equal(t, bad, got)
 }
@@ -250,7 +250,7 @@ func TestEquivocationSet(t *testing.T) {
 		require.ErrorIs(t, err, sql.ErrNotFound)
 		require.Nil(t, blob.Bytes)
 
-		ids, err := identities.GetMalicious(db)
+		ids, err := identities.GetNodeIDsWithProofs(db)
 		require.NoError(t, err)
 		require.Empty(t, ids)
 	})

--- a/sql/identities/identities_test.go
+++ b/sql/identities/identities_test.go
@@ -274,6 +274,23 @@ func TestEquivocationSet(t *testing.T) {
 			require.True(t, malicious)
 		}
 	})
+	t.Run("marriage received after equivocation", func(t *testing.T) {
+		t.Parallel()
+		db := statesql.InMemory()
+		atx := types.RandomATXID()
+		first := types.RandomNodeID()
+		require.NoError(t, identities.SetMarriage(db, first, &identities.MarriageData{ATX: atx, Index: 0}))
+		require.NoError(t, identities.SetMalicious(db, first, []byte("proof"), time.Now()))
+
+		second := types.RandomNodeID()
+		require.NoError(t, identities.SetMarriage(db, second, &identities.MarriageData{ATX: atx, Index: 1}))
+		require.NoError(t, identities.SetMaliciousBecauseOfMarriage(db, second, time.Time{}))
+		for _, id := range []types.NodeID{first, second} {
+			malicious, err := identities.IsMalicious(db, id)
+			require.NoError(t, err)
+			require.True(t, malicious)
+		}
+	})
 }
 
 func TestEquivocationSetByMarriageATX(t *testing.T) {

--- a/sql/statesql/schema/migrations/0024_identities_speedup.sql
+++ b/sql/statesql/schema/migrations/0024_identities_speedup.sql
@@ -1,0 +1,21 @@
+ALTER TABLE identities RENAME TO identities_old;
+CREATE TABLE identities
+(
+    pubkey VARCHAR PRIMARY KEY,
+    is_malicious BOOLEAN DEFAULT FALSE NOT NULL,
+    proof  BLOB,
+    marriage_atx CHAR(32),
+    received INT DEFAULT 0 NOT NULL, 
+    marriage_atx CHAR(32), 
+    marriage_idx INTEGER, 
+    marriage_target CHAR(32), 
+    marriage_signature CHAR(64)
+);
+
+INSERT INTO identities (pubkey, is_malicious, proof, received, marriage_atx, marriage_idx, marriage_target, marriage_signature)
+  SELECT pubkey, proof IS NOT NULL, proof, received, marriage_atx, marriage_idx, marriage_target, marriage_signature FROM identities_old;
+
+DROP TABLE identities_old;
+
+CREATE INDEX malicious_identities ON identities (pubkey) where is_malicious;
+CREATE INDEX malicious_marriages ON identities (marriage_atx) where is_malicious;

--- a/sql/statesql/schema/migrations/0024_identities_speedup.sql
+++ b/sql/statesql/schema/migrations/0024_identities_speedup.sql
@@ -18,4 +18,4 @@ INSERT INTO identities (pubkey, is_malicious, proof, received, marriage_atx, mar
 DROP TABLE identities_old;
 
 CREATE INDEX malicious_identities ON identities (pubkey) where is_malicious;
-CREATE INDEX malicious_marriages ON identities (marriage_atx) where is_malicious;
+CREATE INDEX identities_marriages ON identities (marriage_atx);

--- a/sql/statesql/schema/migrations/0024_identities_speedup.sql
+++ b/sql/statesql/schema/migrations/0024_identities_speedup.sql
@@ -4,7 +4,6 @@ CREATE TABLE identities
     pubkey VARCHAR PRIMARY KEY,
     is_malicious BOOLEAN DEFAULT FALSE NOT NULL,
     proof  BLOB,
-    marriage_atx CHAR(32),
     received INT DEFAULT 0 NOT NULL, 
     marriage_atx CHAR(32), 
     marriage_idx INTEGER, 

--- a/sql/statesql/schema/schema.sql
+++ b/sql/statesql/schema/schema.sql
@@ -1,4 +1,4 @@
-PRAGMA user_version = 23;
+PRAGMA user_version = 24;
 CREATE TABLE accounts
 (
     address        CHAR(24),
@@ -85,8 +85,15 @@ CREATE TABLE identities
 (
     pubkey VARCHAR PRIMARY KEY,
     is_malicious BOOLEAN DEFAULT FALSE NOT NULL,
-    proof  BLOB
-, received INT DEFAULT 0 NOT NULL, marriage_atx CHAR(32), marriage_idx INTEGER, marriage_target CHAR(32), marriage_signature CHAR(64));
+    proof  BLOB,
+    received INT DEFAULT 0 NOT NULL, 
+    marriage_atx CHAR(32), 
+    marriage_idx INTEGER, 
+    marriage_target CHAR(32), 
+    marriage_signature CHAR(64)
+);
+CREATE INDEX identities_marriages ON identities (marriage_atx);
+CREATE INDEX malicious_identities ON identities (pubkey) where is_malicious;
 CREATE TABLE layers
 (
     id              INT PRIMARY KEY DESC,

--- a/sql/statesql/schema/schema.sql
+++ b/sql/statesql/schema/schema.sql
@@ -85,7 +85,7 @@ CREATE TABLE identities
 (
     pubkey VARCHAR PRIMARY KEY,
     proof  BLOB
-, received INT DEFAULT 0 NOT NULL, marriage_atx CHAR(32), marriage_idx INTEGER, marriage_target CHAR(32), marriage_signature CHAR(64)) WITHOUT ROWID;
+, received INT DEFAULT 0 NOT NULL, marriage_atx CHAR(32), marriage_idx INTEGER, marriage_target CHAR(32), marriage_signature CHAR(64));
 CREATE TABLE layers
 (
     id              INT PRIMARY KEY DESC,

--- a/sql/statesql/schema/schema.sql
+++ b/sql/statesql/schema/schema.sql
@@ -84,6 +84,7 @@ CREATE TABLE certificates
 CREATE TABLE identities
 (
     pubkey VARCHAR PRIMARY KEY,
+    is_malicious BOOLEAN DEFAULT FALSE NOT NULL,
     proof  BLOB
 , received INT DEFAULT 0 NOT NULL, marriage_atx CHAR(32), marriage_idx INTEGER, marriage_target CHAR(32), marriage_signature CHAR(64));
 CREATE TABLE layers


### PR DESCRIPTION
part of https://github.com/spacemeshos/go-spacemesh/pull/6326

in the current implementation IsMalicious has to read whole identities table twice whenever new atx is received.
even if it table relatively small (not GB), it has to scan whole table on every query, best case it is served from memory and then only wastes cpu, in worst case it goes to disk if total amount of memory is low.

changes:
- migration to add rowid to identities table, because the table stores a "large" proof and soon it will store many marriages, querying it without rowid is very inefficient
- two new indexes, index that has only malicious identities, this will make IsMalicious check to read as little as possible from database, and will likely never hit the disk. index with marriages, this is used to filter or update identities with same marriage, as otherwise any query will have to scan whole identities table 
- refactor to invoke IsMalicious once
- mark any new identity as malicious if marriage is malicious, while proof is stored in one place wherever original equivocation happened
- mark all identities within marriage as malicious, when any becomes malicious   