### PR TITLE
[Merged by Bors] - Fix the windows build artifacts name

### DIFF
--- a/Makefile-libs.Inc
+++ b/Makefile-libs.Inc
@@ -27,6 +27,7 @@ ifeq ($(GOOS),windows)
 	platform := windows
 	export PATH := $(PATH):$(BIN_DIR)
 	CGO_LDFLAGS := $(CGO_LDFLAGS) -Wl,-Bstatic -lpthread -Wl,-Bdynamic
+	EXE := .exe
 else
 	TEMP := /tmp
 	ifeq ($(GOOS),darwin)


### PR DESCRIPTION
## Motivation

Fix the  windows build output

## Description

Add on the Makefile-libs.Inc the EXE := .exe
If the GOOS is equal to windows will force the value of EXE = .exe

## Test Plan
Check on the release if the .exe was added on the artifacts. 
I tested the behavior on other Github Repo.

## TODO

<!-- Please tick off the TODOs when completed -->

- [X] Explain motivation or link existing issue(s)
- [X] Test changes and document test plan
- [X] Update documentation as needed
- [X] Update [changelog](../CHANGELOG.md) as needed
