### PR TITLE
[Merged by Bors] - Cleanup Makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,16 @@ LDFLAGS = -ldflags "$(C_LDFLAGS)"
 
 include Makefile-libs.Inc
 
+# Set the correct extension for the executable based on the OS
+# and set the correct ulimit command for the OS
+ifeq ($(OS),Windows_NT)
+	EXE := .exe
+	ULIMIT := ""
+else
+	EXE := ""
+	ULIMIT := ulimit -n 4096;
+endif
+
 UNIT_TESTS ?= $(shell go list ./...  | grep -v systest/tests | grep -v genvm/cmd)
 
 export CGO_ENABLED := 1

--- a/Makefile
+++ b/Makefile
@@ -33,9 +33,7 @@ include Makefile-libs.Inc
 # and set the correct ulimit command for the OS
 ifeq ($(OS),Windows_NT)
 	EXE := .exe
-	ULIMIT := ""
 else
-	EXE := ""
 	ULIMIT := ulimit -n 4096;
 endif
 

--- a/Makefile-libs.Inc
+++ b/Makefile-libs.Inc
@@ -27,7 +27,6 @@ ifeq ($(GOOS),windows)
 	platform := windows
 	export PATH := $(PATH):$(BIN_DIR)
 	CGO_LDFLAGS := $(CGO_LDFLAGS) -Wl,-Bstatic -lpthread -Wl,-Bdynamic
-	EXE := .exe
 else
 	TEMP := /tmp
 	ifeq ($(GOOS),darwin)
@@ -37,7 +36,6 @@ else
 				platform := macos
 		endif
 		CGO_LDFLAGS := $(CGO_LDFLAGS) -Wl,-rpath,@loader_path
-		ULIMIT := ulimit -n 9999;
 	else
 		ifeq ($(GOARCH),arm64)
 				platform := linux-arm64


### PR DESCRIPTION
## Motivation

Follow up for #6351: variables used in the makefile should be defined where they are used if possible. Specifically I moved `EXE` and `ULIMIT` from `Makefile-libs.Inc` to `Makefile`.

## Description

Just moving around variable definitions between `Makefile`s.

## Test Plan

n/a

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
