### PR TITLE
[Merged by Bors] - Fix VRF nonce not stored for non-initial ATXs

### DIFF
--- a/activation/handler_test.go
+++ b/activation/handler_test.go
@@ -37,15 +37,15 @@ import (
 
 const layersPerEpochBig = 1000
 
-func newMerkleProof(t testing.TB, leafs []types.Hash32) (types.MerkleProof, types.Hash32) {
-	t.Helper()
+func newMerkleProof(tb testing.TB, leafs []types.Hash32) (types.MerkleProof, types.Hash32) {
+	tb.Helper()
 	tree, err := merkle.NewTreeBuilder().
 		WithHashFunc(poetShared.HashMembershipTreeNode).
 		WithLeavesToProve(map[uint64]bool{0: true}).
 		Build()
-	require.NoError(t, err)
+	require.NoError(tb, err)
 	for _, m := range leafs {
-		require.NoError(t, tree.AddLeaf(m[:]))
+		require.NoError(tb, tree.AddLeaf(m[:]))
 	}
 	root, nodes := tree.RootAndProof()
 	nodesH32 := make([]types.Hash32, 0, len(nodes))
@@ -57,9 +57,9 @@ func newMerkleProof(t testing.TB, leafs []types.Hash32) (types.MerkleProof, type
 	}, types.BytesToHash(root)
 }
 
-func newNIPostWithPoet(t testing.TB, poetRef []byte) *nipost.NIPostState {
-	t.Helper()
-	proof, _ := newMerkleProof(t, []types.Hash32{
+func newNIPostWithPoet(tb testing.TB, poetRef []byte) *nipost.NIPostState {
+	tb.Helper()
+	proof, _ := newMerkleProof(tb, []types.Hash32{
 		types.BytesToHash([]byte("challenge")),
 		types.BytesToHash([]byte("leaf2")),
 		types.BytesToHash([]byte("leaf3")),
@@ -83,9 +83,9 @@ func newNIPostWithPoet(t testing.TB, poetRef []byte) *nipost.NIPostState {
 	}
 }
 
-func newNIPosV1tWithPoet(t testing.TB, poetRef []byte) *wire.NIPostV1 {
-	t.Helper()
-	proof, _ := newMerkleProof(t, []types.Hash32{
+func newNIPosV1tWithPoet(tb testing.TB, poetRef []byte) *wire.NIPostV1 {
+	tb.Helper()
+	proof, _ := newMerkleProof(tb, []types.Hash32{
 		types.BytesToHash([]byte("challenge")),
 		types.BytesToHash([]byte("leaf2")),
 		types.BytesToHash([]byte("leaf3")),
@@ -108,8 +108,8 @@ func newNIPosV1tWithPoet(t testing.TB, poetRef []byte) *wire.NIPostV1 {
 	}
 }
 
-func toAtx(t testing.TB, watx *wire.ActivationTxV1) *types.ActivationTx {
-	t.Helper()
+func toAtx(tb testing.TB, watx *wire.ActivationTxV1) *types.ActivationTx {
+	tb.Helper()
 	atx := wire.ActivationTxFromWireV1(watx)
 	atx.SetReceived(time.Now())
 	atx.BaseTickHeight = uint64(atx.PublishEpoch)
@@ -196,7 +196,7 @@ func newTestHandlerMocks(tb testing.TB, golden types.ATXID) handlerMocks {
 
 func newTestHandler(tb testing.TB, goldenATXID types.ATXID, opts ...HandlerOption) *testHandler {
 	lg := zaptest.NewLogger(tb)
-	cdb := datastore.NewCachedDB(statesql.InMemory(), lg)
+	cdb := datastore.NewCachedDB(statesql.InMemoryTest(tb), lg)
 	edVerifier := signing.NewEdVerifier()
 
 	mocks := newTestHandlerMocks(tb, goldenATXID)

--- a/node/node.go
+++ b/node/node.go
@@ -424,7 +424,7 @@ type App struct {
 }
 
 func (app *App) loadCheckpoint(ctx context.Context) (*checkpoint.PreservedData, error) {
-	var nodeIDs []types.NodeID
+	nodeIDs := make([]types.NodeID, 0, len(app.signers))
 	if app.Config.Recovery.PreserveOwnAtx {
 		for _, sig := range app.signers {
 			nodeIDs = append(nodeIDs, sig.NodeID())

--- a/proposals/eligibility_validator_test.go
+++ b/proposals/eligibility_validator_test.go
@@ -544,12 +544,12 @@ func TestEligibilityValidator(t *testing.T) {
 					return nil
 				}
 				return &tortoise.BallotData{
-					ID:           ballot.ID(),
-					Layer:        ballot.Layer,
-					ATXID:        ballot.AtxID,
-					Smesher:      ballot.SmesherID,
-					Beacon:       ballot.EpochData.Beacon,
-					Eligiblities: ballot.EpochData.EligibilityCount,
+					ID:            ballot.ID(),
+					Layer:         ballot.Layer,
+					ATXID:         ballot.AtxID,
+					Smesher:       ballot.SmesherID,
+					Beacon:        ballot.EpochData.Beacon,
+					Eligibilities: ballot.EpochData.EligibilityCount,
 				}
 			}).AnyTimes()
 

--- a/proposals/handler_test.go
+++ b/proposals/handler_test.go
@@ -110,7 +110,7 @@ func createTestHandler(t *testing.T) *testHandler {
 		}
 		if ballot.EpochData != nil {
 			data.Beacon = ballot.EpochData.Beacon
-			data.Eligiblities = ballot.EpochData.EligibilityCount
+			data.Eligibilities = ballot.EpochData.EligibilityCount
 		}
 		return data
 	})

--- a/systest/README.md
+++ b/systest/README.md
@@ -27,7 +27,7 @@ This testing setup can run on top of any k8s installation. The instructions belo
     chaos-mesh is used for some tests. See <https://chaos-mesh.org/docs/quick-start/> for more up-to-date instructions.
 
     ```bash
-    curl -sSL https://mirrors.chaos-mesh.org/v2.5.1/install.sh | bash
+    curl -sSL https://mirrors.chaos-mesh.org/v2.6.3/install.sh | bash
     ```
 
 4. Install `loki` to use grafana dashboard.
@@ -39,13 +39,18 @@ This testing setup can run on top of any k8s installation. The instructions belo
     helm repo update
     helm upgrade --install loki grafana/loki-stack  --set grafana.enabled=true,prometheus.enabled=true,prometheus.alertmanager.persistentVolume.enabled=false,prometheus.server.persistentVolume.enabled=false,loki.persistence.enabled=true,loki.persistence.storageClassName=standard,loki.persistence.size=20Gi
     ```
+
 5. Install `gomplate`
 
     In linux amd64 use:
+
+    <!-- markdownlint-disable MD013 -->
     ```bash
     curl -o /usr/local/bin/gomplate -sSL https://github.com/hairyhenderson/gomplate/releases/download/v4.1.0/gomplate_linux-amd64 
     chmod 755 /usr/local/bin/gomplate
     ```
+    <!-- markdownlint-enable MD013 -->
+
     For other OS, please refer to the [releases](https://github.com/hairyhenderson/gomplate/releases) page.
 
 ### Using Grafana and Loki
@@ -155,6 +160,7 @@ poet     0/1     Pending   0          9m13s
 
 then please see more details with
 
+<!-- markdownlint-disable MD013 -->
 ```bash
 ➜  ~ kubectl describe pods poet -n test-adno
 Name:         poet
@@ -166,21 +172,22 @@ Events:
   ----     ------            ----                ----               -------
   Warning  FailedScheduling  69s (x11 over 11m)  default-scheduler  0/1 nodes are available: 1 Insufficient cpu, 1 Insufficient memory.
 ```
+<!-- markdownlint-enable MD013 -->
 
-Most likely you have insufficient CPU or memory and need to make `size` smaller in your `make run` command.
-This is related to minikube setup though and shouldn't be an issue for Kubernetes cluster running in the cloud.
+Most likely you have insufficient CPU or memory and need to make `size` smaller in your `make run` command. This is
+related to minikube setup though and shouldn't be an issue for Kubernetes cluster running in the cloud.
 
 ### Note
 
 * If you are switching between remote and local k8s, you have to run `minikube start` before running the tests locally.
 * If you did `make clean`, you will have to install `loki` again for grafana to be installed.
-* If the code changes in the codebase and you'd like to test the changed code, you must rebuild all images again. E.g. `make dockerbuild-go && make dockerbuild-bs && cd systest && make docker`
+* If the code changes in the codebase and you'd like to test the changed code, you must rebuild all images again. E.g.
+  `make dockerbuild-go && make dockerbuild-bs && cd systest && make docker`
 
 ## Parametrizable tests
 
-Tests are parametrized using configmap that must be created in the same namespace
-where test pod is running. Name of the configmap by default will match name of the pod where
-tests are running.
+Tests are parametrized using configmap that must be created in the same namespace where test pod is running. Name of the
+configmap by default will match name of the pod where tests are running.
 
 Developer can replace configmap that is used in tests by creating a custom one, and updating `configname` variable.
 
@@ -205,9 +212,11 @@ make run properties=properties.env test_name=TestStepCreate
 
 ## Longevity testing
 
-These tests test the clusters over a long period of time. They are therefore disabled by default so that the CI doesn't run them.
+These tests test the clusters over a long period of time. They are therefore disabled by default so that the CI doesn't
+run them.
 
 In order to run them, please define the `LONGEVITY_TEST` environment variable, otherwise they will be skipped:
+
 ```bash
 export LONGEVITY_TESTS=1
 ```
@@ -223,8 +232,8 @@ export namespace=qqq
 make run test_name=TestStepCreate size=10 bootstrap=1m keep=true
 ```
 
-Once that step completes user is able to apply different tasks that either modify the cluster, asserts some
-expectations or enables chaos conditions.
+Once that step completes user is able to apply different tasks that either modify the cluster, asserts some expectations
+or enables chaos conditions.
 
 For example creating a batch of transactions:
 
@@ -250,8 +259,8 @@ All such individual steps can be found in `systest/steps_test.go`.
 
 ### Scheduler
 
-Individual steps may be also scheduled by any software. For simplicity the first version of scheduler is implemented
-in golang (see TestScheduleBasic).
+Individual steps may be also scheduled by any software. For simplicity the first version of scheduler is implemented in
+golang (see TestScheduleBasic).
 
 It launches a test that will execute sub-tests to create transactions, add nodes, verify consistency of the mesh and
 that nodes are eventually synced.
@@ -269,8 +278,8 @@ See available storage classes using:
 kubectl get sc
 ```
 
-For longevity tests standard storage class is not sufficiently fast, and has low amount of allocated resources (iops
-and throughput). Allocated resource also depend on the disk size.
+For longevity tests standard storage class is not sufficiently fast, and has low amount of allocated resources (iops and
+throughput). Allocated resource also depend on the disk size.
 
 On gke for the network with a moderate load `premium-rwo` storage class with 10Gi disk size can be used. It will
 provision ssd disks.
@@ -281,9 +290,8 @@ export storage=premium-rwo=10Gi
 
 ### Schedule chaos tasks for longevity network
 
-Chaos-mesh tasks are scheduled using native chaos-mesh api for flexibility.
-After cluster was created and all pods of the cluster have spawned it is possible to apply
-a predefined set of tasks using kubectl
+Chaos-mesh tasks are scheduled using native chaos-mesh api for flexibility. After cluster was created and all pods of
+the cluster have spawned it is possible to apply a predefined set of tasks using kubectl
 
 ```bash
 kubectl apply -n <namespace> -f ./parameters/chaos

--- a/tortoise/algorithm.go
+++ b/tortoise/algorithm.go
@@ -17,7 +17,7 @@ import (
 // Config for protocol parameters.
 type Config struct {
 	// how long we are waiting for a switch from verifying to full. relevant during rerun.
-	Hdist                uint32 `mapstructure:"tortoise-hdist"`       // hare output lookback distance
+	Hdist                uint32 `mapstructure:"tortoise-hdist"`       // hare output look back distance
 	Zdist                uint32 `mapstructure:"tortoise-zdist"`       // hare result wait distance
 	WindowSize           uint32 `mapstructure:"tortoise-window-size"` // size of the tortoise sliding window (in layers)
 	HistoricalWindowSize []WindowSizeInterval
@@ -424,12 +424,12 @@ type DecodedBallot struct {
 }
 
 type BallotData struct {
-	ID           types.BallotID
-	Layer        types.LayerID
-	ATXID        types.ATXID
-	Smesher      types.NodeID
-	Beacon       types.Beacon
-	Eligiblities uint32
+	ID            types.BallotID
+	Layer         types.LayerID
+	ATXID         types.ATXID
+	Smesher       types.NodeID
+	Beacon        types.Beacon
+	Eligibilities uint32
 }
 
 func (t *Tortoise) GetBallot(id types.BallotID) *BallotData {
@@ -440,12 +440,12 @@ func (t *Tortoise) GetBallot(id types.BallotID) *BallotData {
 		return nil
 	}
 	return &BallotData{
-		ID:           id,
-		Layer:        info.layer,
-		ATXID:        info.reference.atxid,
-		Smesher:      info.reference.smesher,
-		Beacon:       info.reference.beacon,
-		Eligiblities: info.reference.expectedBallots,
+		ID:            id,
+		Layer:         info.layer,
+		ATXID:         info.reference.atxid,
+		Smesher:       info.reference.smesher,
+		Beacon:        info.reference.beacon,
+		Eligibilities: info.reference.expectedBallots,
 	}
 }
 

--- a/tortoise/algorithm_test.go
+++ b/tortoise/algorithm_test.go
@@ -24,19 +24,19 @@ func TestGetBallot(t *testing.T) {
 	s.runOn(trt)
 
 	require.Equal(t, &BallotData{
-		ID:           ref.ID,
-		Layer:        ref.Layer,
-		ATXID:        ref.AtxID,
-		Smesher:      ref.Smesher,
-		Beacon:       ref.EpochData.Beacon,
-		Eligiblities: ref.EpochData.Eligibilities,
+		ID:            ref.ID,
+		Layer:         ref.Layer,
+		ATXID:         ref.AtxID,
+		Smesher:       ref.Smesher,
+		Beacon:        ref.EpochData.Beacon,
+		Eligibilities: ref.EpochData.Eligibilities,
 	}, trt.GetBallot(ref.ID))
 	require.Equal(t, &BallotData{
-		ID:           secondary.ID,
-		Layer:        secondary.Layer,
-		ATXID:        secondary.AtxID,
-		Smesher:      secondary.Smesher,
-		Beacon:       ref.EpochData.Beacon,
-		Eligiblities: ref.EpochData.Eligibilities,
+		ID:            secondary.ID,
+		Layer:         secondary.Layer,
+		ATXID:         secondary.AtxID,
+		Smesher:       secondary.Smesher,
+		Beacon:        ref.EpochData.Beacon,
+		Eligibilities: ref.EpochData.Eligibilities,
 	}, trt.GetBallot(secondary.ID))
 }


### PR DESCRIPTION
## Motivation

#6387 fixed an issue where malfeasance proofs that are created against non-initial ATXs are in some cases invalid, but it introduced another issue where VRF nonces for non-initial ATXs are (in most cases) not stored in the DB which results in ballots not being able to be verified.

This fixes VRF nonces not being stored without breaking malfeasance proofs again.

## Description

The reason malfeasance proofs were invalid was because during validation of non-initial ATXs the handler would set a missing VRF nonce field in the `wire.ActivationTxV1` type to the value of the previous ATX. This will ensure that this value will be stored for the ATX in the DB (since it is needed for VRF Signature validation). However this lead to invalid malfeasance proofs since the signature of the ATX that was changed becomes invalid when the `nil` VRF nonce field is set to some value.

The previous fix in #6387 fixed the issue of creating invalid malfeasance proofs by not modifying the `wire.ActivationTxV1` type during validation. Unfortunately the code storing the new ATX uses the `wire.ActivationTxV1` to generate the domain type `types.ActivationTx` before storing the ATX in the database. Since the wire type now (correctly) doesn't contain a VRF nonce for (almost all) non-initial ATXs, the code storing the ATX would then store `0` as the VRF nonce instead of looking up and re-using the VRF nonce from the previous ATX.

I changed the code to convert the wire type to the domain type earlier in the code to prevent this from happening.

## Test Plan

I updated tests to assert that the correct VRF nonce has been set on the domain type before the ATX is stored during handling.

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
