### PR TITLE
Reset db connection before returning it to the pool

### DIFF
--- a/sql/database.go
+++ b/sql/database.go
@@ -1003,7 +1003,7 @@ func exec(conn *sqlite.Conn, query string, encoder Encoder, decoder Decoder) (in
 	if err != nil {
 		return 0, fmt.Errorf("prepare %s: %w", query, err)
 	}
-    defer stmt.Reset()
+	defer stmt.Reset()
 
 	if encoder != nil {
 		encoder(stmt)


### PR DESCRIPTION
## Motivation

We have seen in logs:
> http: panic serving 127.0.0.1:34652: connection returned to pool has active statement: "select address, balance, next_nonce, max(layer_updated), template, state from accounts group by address order by layer_updated desc limit 100"
as part of http handler recovery function is returning connection to the pool, while it can have pending, non finished statement. 

Code in this patch should fix this issue.

## Test Plan

No new unittests added as the original issue was not reproduced.

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [ ] Test changes and document test plan
- [ ] Update documentation as needed
- [ ] Update [changelog](../CHANGELOG.md) as needed
