### PR TITLE
[Merged by Bors] - Prevent connection pool from emptying upon panics

### DIFF
--- a/sql/database_test.go
+++ b/sql/database_test.go
@@ -21,7 +21,6 @@ func Test_ConReturnedToPool(t *testing.T) {
 	db := InMemory(
 		WithLogger(zaptest.NewLogger(t)),
 		WithConnections(1),
-		WithLatencyMetering(true),
 		WithDatabaseSchema(&Schema{
 			Script: `CREATE TABLE testing1 (
 				id varchar primary key,


### PR DESCRIPTION
## Motivation

Ensure an active statement is reset even if `decoder` in `db.Exec` panics

## Description

Crawshaw panics internally when putting a connection back into the pool that was not reset. `SetInterupt` does this explicitly which is why https://github.com/spacemeshos/go-spacemesh/pull/6407 also fixes this issue. This change has a smaller footprint and adds a test.

## Test Plan

New test for panics in decoder

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
