### PR TITLE
[Merged by Bors] - Improve performance of proposal builder by not DB inserting active set if not necessary

### DIFF
--- a/activation/handler_v1.go
+++ b/activation/handler_v1.go
@@ -500,7 +500,7 @@ func (h *HandlerV1) storeAtx(
 		proof     *mwire.MalfeasanceProof
 		malicious bool
 	)
-	if err := h.cdb.WithTx(ctx, func(tx sql.Transaction) error {
+	if err := h.cdb.WithTxImmediate(ctx, func(tx sql.Transaction) error {
 		var err error
 		malicious, err = identities.IsMalicious(tx, atx.SmesherID)
 		if err != nil {

--- a/activation/handler_v2.go
+++ b/activation/handler_v2.go
@@ -851,7 +851,7 @@ func (h *HandlerV2) checkPrevAtx(ctx context.Context, tx sql.Transaction, atx *a
 
 // Store an ATX in the DB.
 func (h *HandlerV2) storeAtx(ctx context.Context, atx *types.ActivationTx, watx *activationTx) error {
-	if err := h.cdb.WithTx(ctx, func(tx sql.Transaction) error {
+	if err := h.cdb.WithTxImmediate(ctx, func(tx sql.Transaction) error {
 		if len(watx.marriages) != 0 {
 			newMarriageID, err := marriage.NewID(tx)
 			if err != nil {
@@ -927,7 +927,7 @@ func (h *HandlerV2) storeAtx(ctx context.Context, atx *types.ActivationTx, watx 
 	atxs.AtxAdded(h.cdb, atx)
 
 	malicious := false
-	err := h.cdb.WithTx(ctx, func(tx sql.Transaction) error {
+	err := h.cdb.WithTxImmediate(ctx, func(tx sql.Transaction) error {
 		// malfeasance check happens after storing the ATX because storing updates the marriage set
 		// that is needed for the malfeasance proof
 		// TODO(mafa): don't store own ATX if it would mark the node as malicious

--- a/api/grpcserver/transaction_service_test.go
+++ b/api/grpcserver/transaction_service_test.go
@@ -37,7 +37,7 @@ func TestTransactionService_StreamResults(t *testing.T) {
 	gen := fixture.NewTransactionResultGenerator().
 		WithAddresses(2)
 	txs := make([]types.TransactionWithResult, 100)
-	require.NoError(t, db.WithTx(ctx, func(dtx sql.Transaction) error {
+	require.NoError(t, db.WithTxImmediate(ctx, func(dtx sql.Transaction) error {
 		for i := range txs {
 			tx := gen.Next()
 

--- a/api/grpcserver/v2alpha1/transaction_test.go
+++ b/api/grpcserver/v2alpha1/transaction_test.go
@@ -43,7 +43,7 @@ func TestTransactionService_List(t *testing.T) {
 
 	gen := fixture.NewTransactionResultGenerator().WithAddresses(2)
 	txsList := make([]types.TransactionWithResult, 100)
-	require.NoError(t, db.WithTx(ctx, func(dtx sql.Transaction) error {
+	require.NoError(t, db.WithTxImmediate(ctx, func(dtx sql.Transaction) error {
 		for i := range txsList {
 			tx := gen.Next()
 

--- a/blocks/certifier.go
+++ b/blocks/certifier.go
@@ -564,7 +564,7 @@ func (c *Certifier) save(
 	if len(valid)+len(invalid) == 0 {
 		return certificates.Add(c.db, lid, cert)
 	}
-	return c.db.WithTx(ctx, func(dbtx sql.Transaction) error {
+	return c.db.WithTxImmediate(ctx, func(dbtx sql.Transaction) error {
 		if err := certificates.Add(dbtx, lid, cert); err != nil {
 			return err
 		}

--- a/checkpoint/recovery.go
+++ b/checkpoint/recovery.go
@@ -138,7 +138,7 @@ func Recover(
 	}
 	defer localDB.Close()
 	logger.Info("clearing atx and malfeasance sync metadata from local database")
-	if err := localDB.WithTx(ctx, func(tx sql.Transaction) error {
+	if err := localDB.WithTxImmediate(ctx, func(tx sql.Transaction) error {
 		if err := atxsync.Clear(tx); err != nil {
 			return err
 		}
@@ -274,7 +274,7 @@ func RecoverFromLocalFile(
 		zap.Int("num accounts", len(data.accounts)),
 		zap.Int("num atxs", len(data.atxs)),
 	)
-	if err = newDB.WithTx(ctx, func(tx sql.Transaction) error {
+	if err = newDB.WithTxImmediate(ctx, func(tx sql.Transaction) error {
 		for _, acct := range data.accounts {
 			if err = accounts.Update(tx, acct); err != nil {
 				return fmt.Errorf("restore account snapshot: %w", err)

--- a/cmd/merge-nodes/internal/merge_action.go
+++ b/cmd/merge-nodes/internal/merge_action.go
@@ -159,7 +159,7 @@ func MergeDBs(ctx context.Context, dbLog *zap.Logger, from, to string) error {
 	}
 
 	dbLog.Info("merging databases", zap.String("from", from), zap.String("to", to))
-	err = dstDB.WithTx(ctx, func(tx sql.Transaction) error {
+	err = dstDB.WithTxImmediate(ctx, func(tx sql.Transaction) error {
 		enc := func(stmt *sql.Statement) {
 			stmt.BindText(1, filepath.Join(from, localDbFile))
 		}

--- a/common/types/poet.go
+++ b/common/types/poet.go
@@ -19,6 +19,11 @@ type PoetServer struct {
 	Pubkey  Base64Enc `mapstructure:"pubkey"  json:"pubkey"`
 }
 
+func ByteToPoetProofRef(b []byte) (ref PoetProofRef) {
+	copy(ref[:], b)
+	return ref
+}
+
 type PoetProofRef Hash32
 
 func (r *PoetProofRef) String() string {

--- a/datastore/store.go
+++ b/datastore/store.go
@@ -351,7 +351,7 @@ func (bs *BlobStore) Has(hint Hint, key []byte) (bool, error) {
 	case TXDB:
 		return transactions.Has(bs.DB, types.TransactionID(types.BytesToHash(key)))
 	case POETDB:
-		return poets.Has(bs.DB, types.PoetProofRef(key))
+		return poets.Has(bs.DB, types.ByteToPoetProofRef(key))
 	case Malfeasance:
 		return identities.IsMalicious(bs.DB, types.BytesToNodeID(key))
 	case ActiveSet:

--- a/datastore/store.go
+++ b/datastore/store.go
@@ -351,13 +351,11 @@ func (bs *BlobStore) Has(hint Hint, key []byte) (bool, error) {
 	case TXDB:
 		return transactions.Has(bs.DB, types.TransactionID(types.BytesToHash(key)))
 	case POETDB:
-		var ref types.PoetProofRef
-		copy(ref[:], key)
-		return poets.Has(bs.DB, ref)
+		return poets.Has(bs.DB, types.PoetProofRef(key))
 	case Malfeasance:
 		return identities.IsMalicious(bs.DB, types.BytesToNodeID(key))
 	case ActiveSet:
-		return activesets.Has(bs.DB, key)
+		return activesets.Has(bs.DB, types.BytesToHash(key))
 	}
 	return false, fmt.Errorf("blob store not found %s", hint)
 }

--- a/malfeasance/handler.go
+++ b/malfeasance/handler.go
@@ -195,7 +195,7 @@ func (h *Handler) validateAndSave(ctx context.Context, p *wire.MalfeasanceProof)
 		return types.EmptyNodeID, errors.Join(err, pubsub.ErrValidationReject)
 	}
 	proofBytes := codec.MustEncode(p)
-	if err := h.cdb.WithTx(ctx, func(dbtx sql.Transaction) error {
+	if err := h.cdb.WithTxImmediate(ctx, func(dbtx sql.Transaction) error {
 		malicious, err := identities.IsMalicious(dbtx, nodeID)
 		if err != nil {
 			return fmt.Errorf("check known malicious: %w", err)

--- a/mesh/ballotwriter/ballotwriter.go
+++ b/mesh/ballotwriter/ballotwriter.go
@@ -20,7 +20,7 @@ import (
 var writerDelay = 100 * time.Millisecond
 
 type BallotWriter struct {
-	db     db
+	db     sql.StateDatabase
 	logger *zap.Logger
 
 	atxMu sync.Mutex
@@ -30,7 +30,7 @@ type BallotWriter struct {
 	ballotBatchResult *batchResult
 }
 
-func New(db db, logger *zap.Logger) *BallotWriter {
+func New(db sql.StateDatabase, logger *zap.Logger) *BallotWriter {
 	// create a stopped ticker that can be started later
 	timer := time.NewTicker(writerDelay)
 	timer.Stop()
@@ -162,10 +162,4 @@ func (w *BallotWriter) Store(b *types.Ballot) error {
 type batchResult struct {
 	doneC chan struct{}
 	err   error
-}
-
-type db interface {
-	sql.Executor
-
-	WithTxImmediate(context.Context, func(sql.Transaction) error) error
 }

--- a/mesh/ballotwriter/ballotwriter.go
+++ b/mesh/ballotwriter/ballotwriter.go
@@ -78,7 +78,7 @@ func (w *BallotWriter) Start(ctx context.Context) {
 			// we use a context.Background() because: on shutdown the canceling of the
 			// context may exit the transaction halfway and leave the db in some state where it
 			// causes crawshaw to panic on a "not all connections returned to pool".
-			if err := w.db.WithTx(context.Background(), func(tx sql.Transaction) error {
+			if err := w.db.WithTxImmediate(context.Background(), func(tx sql.Transaction) error {
 				for _, ballot := range batch {
 					if !ballot.IsMalicious() {
 						layerBallotStart := time.Now()
@@ -167,5 +167,5 @@ type batchResult struct {
 type db interface {
 	sql.Executor
 
-	WithTx(context.Context, func(sql.Transaction) error) error
+	WithTxImmediate(context.Context, func(sql.Transaction) error) error
 }

--- a/mesh/ballotwriter/ballotwriter_test.go
+++ b/mesh/ballotwriter/ballotwriter_test.go
@@ -123,7 +123,7 @@ func BenchmarkWriteCoalescing(b *testing.B) {
 		db := newDiskSqlite(b)
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			if err := db.WithTx(context.Background(), func(tx sql.Transaction) error {
+			if err := db.WithTxImmediate(context.Background(), func(tx sql.Transaction) error {
 				if err := writeFn(a[i], tx); err != nil {
 					b.Fatal(err)
 				}
@@ -138,7 +138,7 @@ func BenchmarkWriteCoalescing(b *testing.B) {
 		db := newDiskSqlite(b)
 		b.ResetTimer()
 		for j := 0; j < b.N/1000; j++ {
-			if err := db.WithTx(context.Background(), func(tx sql.Transaction) error {
+			if err := db.WithTxImmediate(context.Background(), func(tx sql.Transaction) error {
 				var err error
 				for i := (j * 1000); i < (j*1000)+1000; i++ {
 					if err = writeFn(a[i], tx); err != nil {
@@ -156,7 +156,7 @@ func BenchmarkWriteCoalescing(b *testing.B) {
 		db := newDiskSqlite(b)
 		b.ResetTimer()
 		for j := 0; j < b.N/5000; j++ {
-			if err := db.WithTx(context.Background(), func(tx sql.Transaction) error {
+			if err := db.WithTxImmediate(context.Background(), func(tx sql.Transaction) error {
 				var err error
 				for i := (j * 5000); i < (j*5000)+5000; i++ {
 					if err = writeFn(a[i], tx); err != nil {

--- a/mesh/mesh.go
+++ b/mesh/mesh.go
@@ -95,7 +95,7 @@ func NewMesh(
 	}
 
 	genesis := types.GetEffectiveGenesis()
-	if err = db.WithTx(context.Background(), func(dbtx sql.Transaction) error {
+	if err = db.WithTxImmediate(context.Background(), func(dbtx sql.Transaction) error {
 		if err = layers.SetProcessed(dbtx, genesis); err != nil {
 			return fmt.Errorf("mesh init: %w", err)
 		}
@@ -385,7 +385,7 @@ func (msh *Mesh) applyResults(ctx context.Context, results []result.Layer) error
 				return fmt.Errorf("execute block %v/%v: %w", layer.Layer, target, err)
 			}
 		}
-		if err := msh.cdb.WithTx(ctx, func(dbtx sql.Transaction) error {
+		if err := msh.cdb.WithTxImmediate(ctx, func(dbtx sql.Transaction) error {
 			if err := layers.SetApplied(dbtx, layer.Layer, target); err != nil {
 				return fmt.Errorf("set applied for %v/%v: %w", layer.Layer, target, err)
 			}
@@ -440,7 +440,7 @@ func (msh *Mesh) saveHareOutput(ctx context.Context, lid types.LayerID, bid type
 		certs []certificates.CertValidity
 		err   error
 	)
-	if err = msh.cdb.WithTx(ctx, func(tx sql.Transaction) error {
+	if err = msh.cdb.WithTxImmediate(ctx, func(tx sql.Transaction) error {
 		// check if a certificate has been generated or sync'ed.
 		// - node generated the certificate when it collected enough certify messages
 		// - hare outputs are processed in layer order. i.e. when hare fails for a previous layer N,

--- a/miner/proposal_builder_test.go
+++ b/miner/proposal_builder_test.go
@@ -3,7 +3,6 @@ package miner
 import (
 	"bytes"
 	"context"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -1271,20 +1270,4 @@ func BenchmarkDoubleCache(b *testing.B) {
 	fmt.Println("stack:", m.StackInuse)
 
 	require.Equal(b, types.EmptyATXID, found)
-}
-
-func BenchmarkDB(b *testing.B) {
-	db, err := statesql.Open("file:state.sql")
-	require.NoError(b, err)
-	defer db.Close()
-
-	bytes, err := hex.DecodeString("00003ce28800fadd692c522f7b1db219f675b49108aec7f818e2c4fd935573f6")
-	require.NoError(b, err)
-	nodeID := types.BytesToNodeID(bytes)
-	var found types.ATXID
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		found, _ = atxs.GetByEpochAndNodeID(db, 30, nodeID)
-	}
-	require.NotEqual(b, types.EmptyATXID, found)
 }

--- a/sql/activesets/activesets.go
+++ b/sql/activesets/activesets.go
@@ -18,7 +18,7 @@ func Add(db sql.Executor, id types.Hash32, set *types.EpochActiveSet) error {
 		(id, epoch, active_set)
 		values (?1, ?2, ?3);`,
 		func(stmt *sql.Statement) {
-			stmt.BindBytes(1, id[:])
+			stmt.BindBytes(1, id.Bytes())
 			stmt.BindInt64(2, int64(set.Epoch))
 			stmt.BindBytes(3, codec.MustEncode(set))
 		}, nil)
@@ -100,9 +100,7 @@ func getBlob(ctx context.Context, db sql.Executor, id []byte) ([]byte, error) {
 
 func DeleteBeforeEpoch(db sql.Executor, epoch types.EpochID) error {
 	_, err := db.Exec("delete from activesets where epoch < ?1;",
-		func(stmt *sql.Statement) {
-			stmt.BindInt64(1, int64(epoch))
-		},
+		func(stmt *sql.Statement) { stmt.BindInt64(1, int64(epoch)) },
 		nil,
 	)
 	if err != nil {
@@ -111,10 +109,9 @@ func DeleteBeforeEpoch(db sql.Executor, epoch types.EpochID) error {
 	return nil
 }
 
-func Has(db sql.Executor, id []byte) (bool, error) {
-	rows, err := db.Exec(
-		"select 1 from activesets where id = ?1;",
-		func(stmt *sql.Statement) { stmt.BindBytes(1, id) },
+func Has(db sql.Executor, id types.Hash32) (bool, error) {
+	rows, err := db.Exec("select 1 from activesets where id = ?1;",
+		func(stmt *sql.Statement) { stmt.BindBytes(1, id.Bytes()) },
 		nil,
 	)
 	if err != nil {

--- a/sql/atxs/atxs_test.go
+++ b/sql/atxs/atxs_test.go
@@ -433,7 +433,7 @@ func TestGetIDsByEpochCached(t *testing.T) {
 		require.Equal(t, 11, db.QueryCount())
 	}
 
-	require.NoError(t, db.WithTx(context.Background(), func(tx sql.Transaction) error {
+	require.NoError(t, db.WithTxImmediate(context.Background(), func(tx sql.Transaction) error {
 		atxs.Add(tx, atx5, types.AtxBlob{})
 		return nil
 	}))
@@ -445,7 +445,7 @@ func TestGetIDsByEpochCached(t *testing.T) {
 	require.ElementsMatch(t, []types.ATXID{atx4.ID(), atx5.ID()}, ids3)
 	require.Equal(t, 13, db.QueryCount()) // not incremented after Add
 
-	require.Error(t, db.WithTx(context.Background(), func(tx sql.Transaction) error {
+	require.Error(t, db.WithTxImmediate(context.Background(), func(tx sql.Transaction) error {
 		atxs.Add(tx, atx6, types.AtxBlob{})
 		return errors.New("fail") // rollback
 	}))

--- a/sql/database_test.go
+++ b/sql/database_test.go
@@ -520,7 +520,7 @@ func TestDBClosed(t *testing.T) {
 	require.NoError(t, db.Close())
 	_, err := db.Exec("select 1", nil, nil)
 	require.ErrorIs(t, err, ErrClosed)
-	err = db.WithTx(context.Background(), func(tx Transaction) error { return nil })
+	err = db.WithTxImmediate(context.Background(), func(tx Transaction) error { return nil })
 	require.ErrorIs(t, err, ErrClosed)
 }
 

--- a/sql/schema.go
+++ b/sql/schema.go
@@ -85,7 +85,7 @@ func (s *Schema) SkipMigrations(i ...int) {
 
 // Apply applies the schema to the database.
 func (s *Schema) Apply(db Database) error {
-	return db.WithTx(context.Background(), func(tx Transaction) error {
+	return db.WithTxImmediate(context.Background(), func(tx Transaction) error {
 		scanner := bufio.NewScanner(strings.NewReader(s.Script))
 		scanner.Split(func(data []byte, atEOF bool) (advance int, token []byte, err error) {
 			if i := bytes.Index(data, []byte(";")); i >= 0 {
@@ -147,7 +147,7 @@ func (s *Schema) Migrate(logger *zap.Logger, db Database, before, vacuumState in
 		if m.Order() <= before {
 			continue
 		}
-		if err := db.WithTx(context.Background(), func(tx Transaction) error {
+		if err := db.WithTxImmediate(context.Background(), func(tx Transaction) error {
 			if _, ok := s.skipMigration[m.Order()]; !ok {
 				if err := m.Apply(tx, logger); err != nil {
 					for j := i; j >= 0 && s.Migrations[j].Order() > before; j-- {
@@ -196,7 +196,7 @@ func (s *Schema) MigrateTempDB(logger *zap.Logger, db Database, before int) erro
 		}
 
 		if _, ok := s.skipMigration[m.Order()]; !ok {
-			if err := db.WithTx(context.Background(), func(tx Transaction) error {
+			if err := db.WithTxImmediate(context.Background(), func(tx Transaction) error {
 				return m.Apply(tx, logger)
 			}); err != nil {
 				return fmt.Errorf("apply %s: %w", m.Name(), err)

--- a/sql/transactions/iterator_test.go
+++ b/sql/transactions/iterator_test.go
@@ -64,7 +64,7 @@ func TestIterateResults(t *testing.T) {
 
 	gen := fixture.NewTransactionResultGenerator()
 	txs := make([]types.TransactionWithResult, 100)
-	require.NoError(t, db.WithTx(context.TODO(), func(dtx sql.Transaction) error {
+	require.NoError(t, db.WithTxImmediate(context.Background(), func(dtx sql.Transaction) error {
 		for i := range txs {
 			tx := gen.Next()
 
@@ -148,7 +148,7 @@ func TestIterateSnapshot(t *testing.T) {
 	require.NoError(t, err)
 	gen := fixture.NewTransactionResultGenerator()
 	expect := 10
-	require.NoError(t, db.WithTx(context.Background(), func(dtx sql.Transaction) error {
+	require.NoError(t, db.WithTxImmediate(context.Background(), func(dtx sql.Transaction) error {
 		for i := 0; i < expect; i++ {
 			tx := gen.Next()
 
@@ -176,7 +176,7 @@ func TestIterateSnapshot(t *testing.T) {
 	}()
 	<-initialized
 
-	require.NoError(t, db.WithTx(context.TODO(), func(dtx sql.Transaction) error {
+	require.NoError(t, db.WithTxImmediate(context.Background(), func(dtx sql.Transaction) error {
 		for i := 0; i < 10; i++ {
 			tx := gen.Next()
 

--- a/sql/transactions/transactions_test.go
+++ b/sql/transactions/transactions_test.go
@@ -232,17 +232,17 @@ func TestApply_AlreadyApplied(t *testing.T) {
 	require.NoError(t, transactions.Add(db, tx, time.Now()))
 
 	bid := types.RandomBlockID()
-	require.NoError(t, db.WithTx(context.Background(), func(dtx sql.Transaction) error {
+	require.NoError(t, db.WithTxImmediate(context.Background(), func(dtx sql.Transaction) error {
 		return transactions.AddResult(dtx, tx.ID, &types.TransactionResult{Layer: lid, Block: bid})
 	}))
 
 	// same block applied again
-	require.Error(t, db.WithTx(context.Background(), func(dtx sql.Transaction) error {
+	require.Error(t, db.WithTxImmediate(context.Background(), func(dtx sql.Transaction) error {
 		return transactions.AddResult(dtx, tx.ID, &types.TransactionResult{Layer: lid, Block: bid})
 	}))
 
 	// different block applied again
-	require.Error(t, db.WithTx(context.Background(), func(dtx sql.Transaction) error {
+	require.Error(t, db.WithTxImmediate(context.Background(), func(dtx sql.Transaction) error {
 		return transactions.AddResult(
 			dtx,
 			tx.ID,
@@ -254,7 +254,7 @@ func TestApply_AlreadyApplied(t *testing.T) {
 func TestUndoLayers_Empty(t *testing.T) {
 	db := statesql.InMemoryTest(t)
 
-	require.NoError(t, db.WithTx(context.Background(), func(dtx sql.Transaction) error {
+	require.NoError(t, db.WithTxImmediate(context.Background(), func(dtx sql.Transaction) error {
 		return transactions.UndoLayers(dtx, types.LayerID(199))
 	}))
 }
@@ -273,7 +273,7 @@ func TestApplyAndUndoLayers(t *testing.T) {
 		require.NoError(t, transactions.Add(db, tx, time.Now()))
 		bid := types.RandomBlockID()
 
-		require.NoError(t, db.WithTx(context.Background(), func(dtx sql.Transaction) error {
+		require.NoError(t, db.WithTxImmediate(context.Background(), func(dtx sql.Transaction) error {
 			return transactions.AddResult(dtx, tx.ID, &types.TransactionResult{Layer: lid, Block: bid})
 		}))
 		applied = append(applied, tx.ID)
@@ -285,7 +285,7 @@ func TestApplyAndUndoLayers(t *testing.T) {
 		require.Equal(t, types.APPLIED, mtx.State)
 	}
 	// revert to firstLayer
-	require.NoError(t, db.WithTx(context.Background(), func(dtx sql.Transaction) error {
+	require.NoError(t, db.WithTxImmediate(context.Background(), func(dtx sql.Transaction) error {
 		return transactions.UndoLayers(dtx, firstLayer.Add(1))
 	}))
 
@@ -349,7 +349,7 @@ func TestGetByAddress(t *testing.T) {
 		createTX(t, signer1, signer2Address, 1, 191, 1),
 	}
 	received := time.Now()
-	require.NoError(t, db.WithTx(context.Background(), func(dbtx sql.Transaction) error {
+	require.NoError(t, db.WithTxImmediate(context.Background(), func(dbtx sql.Transaction) error {
 		for _, tx := range txs {
 			require.NoError(t, transactions.Add(dbtx, tx, received))
 			require.NoError(t, transactions.AddResult(dbtx, tx.ID, &types.TransactionResult{Layer: lid}))
@@ -418,7 +418,7 @@ func TestAppliedLayer(t *testing.T) {
 	for _, tx := range txs {
 		require.NoError(t, transactions.Add(db, tx, time.Now()))
 	}
-	require.NoError(t, db.WithTx(context.Background(), func(dtx sql.Transaction) error {
+	require.NoError(t, db.WithTxImmediate(context.Background(), func(dtx sql.Transaction) error {
 		return transactions.AddResult(dtx, txs[0].ID, &types.TransactionResult{Layer: lid, Block: types.BlockID{1, 1}})
 	}))
 
@@ -429,7 +429,7 @@ func TestAppliedLayer(t *testing.T) {
 	_, err = transactions.GetAppliedLayer(db, txs[1].ID)
 	require.ErrorIs(t, err, sql.ErrNotFound)
 
-	require.NoError(t, db.WithTx(context.Background(), func(dtx sql.Transaction) error {
+	require.NoError(t, db.WithTxImmediate(context.Background(), func(dtx sql.Transaction) error {
 		return transactions.UndoLayers(dtx, lid)
 	}))
 	_, err = transactions.GetAppliedLayer(db, txs[0].ID)
@@ -466,7 +466,7 @@ func TestAddressesWithPendingTransactions(t *testing.T) {
 		{Address: principals[0], Nonce: txs[0].Nonce},
 		{Address: principals[1], Nonce: txs[2].Nonce},
 	}, rst)
-	require.NoError(t, db.WithTx(context.Background(), func(dbtx sql.Transaction) error {
+	require.NoError(t, db.WithTxImmediate(context.Background(), func(dbtx sql.Transaction) error {
 		return transactions.AddResult(dbtx, txs[0].ID, &types.TransactionResult{Message: "hey"})
 	}))
 	rst, err = transactions.AddressesWithPendingTransactions(db)
@@ -475,7 +475,7 @@ func TestAddressesWithPendingTransactions(t *testing.T) {
 		{Address: principals[0], Nonce: txs[1].Nonce},
 		{Address: principals[1], Nonce: txs[2].Nonce},
 	}, rst)
-	require.NoError(t, db.WithTx(context.Background(), func(dbtx sql.Transaction) error {
+	require.NoError(t, db.WithTxImmediate(context.Background(), func(dbtx sql.Transaction) error {
 		return transactions.AddResult(dbtx, txs[2].ID, &types.TransactionResult{Message: "hey"})
 	}))
 	rst, err = transactions.AddressesWithPendingTransactions(db)

--- a/syncer/atxsync/syncer.go
+++ b/syncer/atxsync/syncer.go
@@ -332,7 +332,7 @@ func (s *Syncer) downloadAtxs(
 			}
 		}
 
-		if err := s.localdb.WithTx(context.Background(), func(tx sql.Transaction) error {
+		if err := s.localdb.WithTxImmediate(context.Background(), func(tx sql.Transaction) error {
 			err := atxsync.SaveRequest(tx, publish, lastSuccess, int64(len(state)), int64(len(downloaded)))
 			if err != nil {
 				return fmt.Errorf("failed to save request time: %w", err)

--- a/syncer/malsync/syncer.go
+++ b/syncer/malsync/syncer.go
@@ -341,7 +341,7 @@ func (s *Syncer) downloadNodeIDs(ctx context.Context, initial bool, updates chan
 }
 
 func (s *Syncer) updateState(ctx context.Context) error {
-	if err := s.localdb.WithTx(ctx, func(tx sql.Transaction) error {
+	if err := s.localdb.WithTxImmediate(ctx, func(tx sql.Transaction) error {
 		return malsync.UpdateSyncState(tx, s.clock.Now())
 	}); err != nil {
 		if ctx.Err() != nil {
@@ -382,7 +382,9 @@ func (s *Syncer) downloadMalfeasanceProofs(ctx context.Context, initial bool, up
 				return ctx.Err()
 			case update = <-updates:
 				s.logger.Debug("malfeasance sync update",
-					log.ZContext(ctx), zap.Int("count", len(update.nodeIDs)))
+					log.ZContext(ctx),
+					zap.Int("count", len(update.nodeIDs)),
+				)
 				sst.update(update)
 				gotUpdate = true
 			}
@@ -392,7 +394,9 @@ func (s *Syncer) downloadMalfeasanceProofs(ctx context.Context, initial bool, up
 				return ctx.Err()
 			case update = <-updates:
 				s.logger.Debug("malfeasance sync update",
-					log.ZContext(ctx), zap.Int("count", len(update.nodeIDs)))
+					log.ZContext(ctx),
+					zap.Int("count", len(update.nodeIDs)),
+				)
 				sst.update(update)
 				gotUpdate = true
 			default:
@@ -417,7 +421,8 @@ func (s *Syncer) downloadMalfeasanceProofs(ctx context.Context, initial bool, up
 		if len(batch) != 0 {
 			s.logger.Debug("retrieving malfeasant identities",
 				log.ZContext(ctx),
-				zap.Int("count", len(batch)))
+				zap.Int("count", len(batch)),
+			)
 			err := s.fetcher.GetMalfeasanceProofs(ctx, batch)
 			if err != nil {
 				if errors.Is(err, context.Canceled) {

--- a/syncer/malsync/syncer_test.go
+++ b/syncer/malsync/syncer_test.go
@@ -225,8 +225,7 @@ func TestSyncer(t *testing.T) {
 		tester.expectGetProofs(nil)
 		epochStart := tester.clock.Now().Truncate(time.Second)
 		epochEnd := epochStart.Add(10 * time.Minute)
-		require.NoError(t,
-			tester.syncer.EnsureInSync(context.Background(), epochStart, epochEnd))
+		require.NoError(t, tester.syncer.EnsureInSync(context.Background(), epochStart, epochEnd))
 		require.ElementsMatch(t, []types.NodeID{
 			nid("1"), nid("2"), nid("3"), nid("4"),
 		}, maps.Keys(tester.received))
@@ -238,8 +237,7 @@ func TestSyncer(t *testing.T) {
 		}, tester.attempts)
 		tester.clock.Advance(1 * time.Minute)
 		// second call does nothing after recent sync
-		require.NoError(t,
-			tester.syncer.EnsureInSync(context.Background(), epochStart, epochEnd))
+		require.NoError(t, tester.syncer.EnsureInSync(context.Background(), epochStart, epochEnd))
 		require.Zero(t, tester.peerErrCount.n)
 	})
 	t.Run("EnsureInSync with no malfeasant identities", func(t *testing.T) {
@@ -295,7 +293,7 @@ func TestSyncer(t *testing.T) {
 		cancel()
 		eg.Wait()
 	})
-	t.Run("gettings ids from MinSyncPeers peers is enough", func(t *testing.T) {
+	t.Run("getting ids from MinSyncPeers peers is enough", func(t *testing.T) {
 		cfg := DefaultConfig()
 		cfg.MinSyncPeers = 2
 		tester := newTester(t, cfg)
@@ -324,8 +322,7 @@ func TestSyncer(t *testing.T) {
 		}, tester.attempts)
 		tester.clock.Advance(1 * time.Minute)
 		// second call does nothing after recent sync
-		require.NoError(t,
-			tester.syncer.EnsureInSync(context.Background(), epochStart, epochEnd))
+		require.NoError(t, tester.syncer.EnsureInSync(context.Background(), epochStart, epochEnd))
 		require.Equal(t, 1, tester.peerErrCount.n)
 	})
 	t.Run("skip hashes after max retries", func(t *testing.T) {
@@ -352,8 +349,7 @@ func TestSyncer(t *testing.T) {
 		}, tester.attempts)
 		tester.clock.Advance(1 * time.Minute)
 		// second call does nothing after recent sync
-		require.NoError(t,
-			tester.syncer.EnsureInSync(context.Background(), epochStart, epochEnd))
+		require.NoError(t, tester.syncer.EnsureInSync(context.Background(), epochStart, epochEnd))
 	})
 	t.Run("skip hashes after validation reject", func(t *testing.T) {
 		tester := newTester(t, DefaultConfig())
@@ -379,7 +375,6 @@ func TestSyncer(t *testing.T) {
 		}, tester.attempts)
 		tester.clock.Advance(1 * time.Minute)
 		// second call does nothing after recent sync
-		require.NoError(t,
-			tester.syncer.EnsureInSync(context.Background(), epochStart, epochEnd))
+		require.NoError(t, tester.syncer.EnsureInSync(context.Background(), epochStart, epochEnd))
 	})
 }

--- a/txs/cache.go
+++ b/txs/cache.go
@@ -688,7 +688,7 @@ func (c *Cache) ApplyLayer(
 
 	// commit results before reporting them
 	// TODO(dshulyak) save results in vm
-	if err := db.WithTx(context.Background(), func(dbtx sql.Transaction) error {
+	if err := db.WithTxImmediate(context.Background(), func(dbtx sql.Transaction) error {
 		for _, rst := range results {
 			err := transactions.AddResult(dbtx, rst.ID, &rst.TransactionResult)
 			if err != nil {
@@ -835,7 +835,7 @@ func checkApplyOrder(logger *zap.Logger, db sql.StateDatabase, toApply types.Lay
 }
 
 func addToProposal(db sql.StateDatabase, lid types.LayerID, pid types.ProposalID, tids []types.TransactionID) error {
-	return db.WithTx(context.Background(), func(dbtx sql.Transaction) error {
+	return db.WithTxImmediate(context.Background(), func(dbtx sql.Transaction) error {
 		for _, tid := range tids {
 			if err := transactions.AddToProposal(dbtx, tid, lid, pid); err != nil {
 				return fmt.Errorf("add2prop %w", err)
@@ -846,7 +846,7 @@ func addToProposal(db sql.StateDatabase, lid types.LayerID, pid types.ProposalID
 }
 
 func addToBlock(db sql.StateDatabase, lid types.LayerID, bid types.BlockID, tids []types.TransactionID) error {
-	return db.WithTx(context.Background(), func(dbtx sql.Transaction) error {
+	return db.WithTxImmediate(context.Background(), func(dbtx sql.Transaction) error {
 		for _, tid := range tids {
 			if err := transactions.AddToBlock(dbtx, tid, lid, bid); err != nil {
 				return fmt.Errorf("add2block %w", err)
@@ -857,7 +857,7 @@ func addToBlock(db sql.StateDatabase, lid types.LayerID, bid types.BlockID, tids
 }
 
 func undoLayers(db sql.StateDatabase, from types.LayerID) error {
-	return db.WithTx(context.Background(), func(dbtx sql.Transaction) error {
+	return db.WithTxImmediate(context.Background(), func(dbtx sql.Transaction) error {
 		err := transactions.UndoLayers(dbtx, from)
 		if err != nil {
 			return fmt.Errorf("undo %w", err)


### PR DESCRIPTION
## Motivation

Closes #6418

The first proposal created by a node for any identity triggers persisting the activeset that is used by all identities of the node. This can be a slow process (especially when many ATXs are received by the node) and is usually not necessary, because the activeset is most likely already in the DB.

This PR moves persisting the active set to the beginning of an epoch and avoids a DB write if not necessary (which will usually be the case).

## Description

All uses of `WithTx` have been renamed to `WithTxImmediate` (because they are). A new `WithTx` was added that starts a normal instead of an immediate transaction.

This transaction is used to first do a select on the available active sets in the DB and only write the used active set if it doesn't exist yet. Since most nodes use the same active set that is pre-shared this will almost never trigger an actual insert preventing the requirement to acquire a DB write lock and speed up the process.

Additionally I fixed an issue where if beginning a transaction failed (because for instance the TX was canceled already via context), the connection used was not returned to the DB pool. This fixes the flaky `TestSyncer` test in the `malsync` package and ensures this doesn't happen during normal node operation.

## Test Plan

existing tests pass

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
