### PR TITLE
[Merged by Bors] - Fix db-allow-schema-drift handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ See [RELEASE](./RELEASE.md) for workflow instructions.
 
 ### Improvements
 
+* [#6431](https://github.com/spacemeshos/go-spacemesh/pull/6431) Fix db-allow-schema-drift handling
 * [#6408](https://github.com/spacemeshos/go-spacemesh/pull/6408) Prevent empty DB connection pool by freeing connections
   upon errors during DB operations. This mostly fixes issues when a node is under heavy load from the API.
 

--- a/node/node.go
+++ b/node/node.go
@@ -1998,7 +1998,7 @@ func (app *App) setupDBs(ctx context.Context, lg log.Log) error {
 		sql.WithReadOnly(),
 		sql.WithLogger(apiDBLog),
 		sql.WithConnections(app.Config.API.DatabaseConnections),
-		sql.WithAllowSchemaDrift(app.Config.DatabaseSchemaAllowDrift),
+		sql.WithNoCheckSchemaDrift(), // already checked above
 		sql.WithMigrationsDisabled(),
 	)
 	if err != nil {

--- a/node/node.go
+++ b/node/node.go
@@ -1998,6 +1998,7 @@ func (app *App) setupDBs(ctx context.Context, lg log.Log) error {
 		sql.WithReadOnly(),
 		sql.WithLogger(apiDBLog),
 		sql.WithConnections(app.Config.API.DatabaseConnections),
+		sql.WithAllowSchemaDrift(app.Config.DatabaseSchemaAllowDrift),
 		sql.WithMigrationsDisabled(),
 	)
 	if err != nil {


### PR DESCRIPTION
-------

## Motivation

`db-allow-schema-drift` stopped working after adding separate conn pool for the API

## Description

Fix schema drift handling for the API db connection pool

## Test Plan

Verify on a mainnet node