### PR TITLE
[Merged by Bors] - Add govulncheck to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,8 @@ jobs:
           make test-fmt
           make test-tidy
           make test-generate
+      - name: Check for vulnerabilities
+        run: make vulncheck
 
   lint:
     runs-on: ubuntu-22.04

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
 
 GOLANGCI_LINT_VERSION := v1.61.0
 GOTESTSUM_VERSION := v1.12.0
+GOVULNCHECK_VERSION := v1.1.3
 GOSCALE_VERSION := v1.2.0
 MOCKGEN_VERSION := v0.5.0
 
@@ -68,6 +69,7 @@ install:
 	go install github.com/spacemeshos/go-scale/scalegen@$(GOSCALE_VERSION)
 	go install go.uber.org/mock/mockgen@$(MOCKGEN_VERSION)
 	go install gotest.tools/gotestsum@$(GOTESTSUM_VERSION)
+	go install golang.org/x/vuln/cmd/govulncheck@$(GOVULNCHECK_VERSION)
 .PHONY: install
 
 build: go-spacemesh get-profiler get-postrs-service
@@ -145,6 +147,10 @@ lint-fix: get-libs
 cover: get-libs
 	@$(ULIMIT) CGO_LDFLAGS="$(CGO_TEST_LDFLAGS)" go test -coverprofile=cover.out -p 1 -timeout 30m -coverpkg=./... $(UNIT_TESTS)
 .PHONY: cover
+
+vulncheck: get-libs
+	govulncheck ./...
+.PHONY: vulncheck
 
 list-versions:
 	@echo "Latest 5 tagged versions:\n"


### PR DESCRIPTION
## Motivation

`govulncheck` has been stable for quite a while now, but has not yet been included in the `golanci-lint` tool suite. This adds `govulncheck` to the CI and executes its scan during `quicktests` (the scan only takes a few seconds). 

## Description

Added installation of `govulncheck` and `vulncheck` target to the `Makefile` as well as adding `make vulncheck` to `quicktests` action.

## Test Plan

n/a

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
