### PR TITLE
[Merged by Bors] - remove beacon from Syncer

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -852,7 +852,6 @@ func (app *App) initServices(ctx context.Context) error {
 	newSyncer := syncer.NewSyncer(
 		app.cachedDB,
 		app.clock,
-		beaconProtocol,
 		msh,
 		trtl,
 		fetcher,

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -127,7 +127,6 @@ type Syncer struct {
 	atxsyncer    atxSyncer
 	malsyncer    malSyncer
 	ticker       layerTicker
-	beacon       system.BeaconGetter
 	mesh         *mesh.Mesh
 	tortoise     system.Tortoise
 	certHandler  certHandler
@@ -168,7 +167,6 @@ type Syncer struct {
 func NewSyncer(
 	cdb *datastore.CachedDB,
 	ticker layerTicker,
-	beacon system.BeaconGetter,
 	mesh *mesh.Mesh,
 	tortoise system.Tortoise,
 	fetcher fetcher,
@@ -185,7 +183,6 @@ func NewSyncer(
 		atxsyncer:        atxSyncer,
 		malsyncer:        malSyncer,
 		ticker:           ticker,
-		beacon:           beacon,
 		mesh:             mesh,
 		tortoise:         tortoise,
 		certHandler:      ch,
@@ -239,11 +236,6 @@ func (s *Syncer) ListenToATXGossip() bool {
 // IsSynced returns true if the node is in synced state.
 func (s *Syncer) IsSynced(ctx context.Context) bool {
 	return s.getSyncState() == synced
-}
-
-func (s *Syncer) IsBeaconSynced(epoch types.EpochID) bool {
-	_, err := s.beacon.GetBeacon(epoch)
-	return err == nil
 }
 
 // Start starts the main sync loop that tries to sync data for every SyncInterval.

--- a/syncer/syncer_test.go
+++ b/syncer/syncer_test.go
@@ -148,7 +148,6 @@ func newTestSyncer(tb testing.TB, interval time.Duration) *testSyncer {
 	ts.syncer = NewSyncer(
 		ts.cdb,
 		ts.mTicker,
-		ts.mBeacon,
 		ts.msh,
 		ts.mTortoise,
 		nil,
@@ -755,15 +754,6 @@ func TestSyncer_setATXSyncedTwice_NoError(t *testing.T) {
 	require.NotPanics(t, func() { ts.syncer.setATXSynced() })
 }
 
-func TestSyncer_IsBeaconSynced(t *testing.T) {
-	ts := newSyncerWithoutPeriodicRuns(t)
-	epoch := types.EpochID(11)
-	ts.mBeacon.EXPECT().GetBeacon(epoch).Return(types.EmptyBeacon, errors.New("unknown"))
-	require.False(t, ts.syncer.IsBeaconSynced(epoch))
-	ts.mBeacon.EXPECT().GetBeacon(epoch).Return(types.RandomBeacon(), nil)
-	require.True(t, ts.syncer.IsBeaconSynced(epoch))
-}
-
 func TestSynchronize_RecoverFromCheckpoint(t *testing.T) {
 	ts := newSyncerWithoutPeriodicRuns(t)
 	ts.expectDownloadLoop()
@@ -774,7 +764,6 @@ func TestSynchronize_RecoverFromCheckpoint(t *testing.T) {
 	ts.syncer = NewSyncer(
 		ts.cdb,
 		ts.mTicker,
-		ts.mBeacon,
 		ts.msh,
 		ts.mTortoise,
 		nil,

--- a/syncer/syncer_test.go
+++ b/syncer/syncer_test.go
@@ -75,7 +75,6 @@ type testSyncer struct {
 	mDataFetcher *mocks.MockfetchLogic
 	mAtxSyncer   *mocks.MockatxSyncer
 	mMalSyncer   *mocks.MockmalSyncer
-	mBeacon      *smocks.MockBeaconGetter
 	mLyrPatrol   *mocks.MocklayerPatrol
 	mVm          *mmocks.MockvmState
 	mConState    *mmocks.MockconservativeState
@@ -120,7 +119,6 @@ func newTestSyncer(tb testing.TB, interval time.Duration) *testSyncer {
 		mDataFetcher: mocks.NewMockfetchLogic(ctrl),
 		mAtxSyncer:   mocks.NewMockatxSyncer(ctrl),
 		mMalSyncer:   mocks.NewMockmalSyncer(ctrl),
-		mBeacon:      smocks.NewMockBeaconGetter(ctrl),
 		mLyrPatrol:   mocks.NewMocklayerPatrol(ctrl),
 		mVm:          mmocks.NewMockvmState(ctrl),
 		mConState:    mmocks.NewMockconservativeState(ctrl),

--- a/system/mocks/sync.go
+++ b/system/mocks/sync.go
@@ -13,7 +13,6 @@ import (
 	context "context"
 	reflect "reflect"
 
-	types "github.com/spacemeshos/go-spacemesh/common/types"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -39,44 +38,6 @@ func NewMockSyncStateProvider(ctrl *gomock.Controller) *MockSyncStateProvider {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockSyncStateProvider) EXPECT() *MockSyncStateProviderMockRecorder {
 	return m.recorder
-}
-
-// IsBeaconSynced mocks base method.
-func (m *MockSyncStateProvider) IsBeaconSynced(arg0 types.EpochID) bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsBeaconSynced", arg0)
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// IsBeaconSynced indicates an expected call of IsBeaconSynced.
-func (mr *MockSyncStateProviderMockRecorder) IsBeaconSynced(arg0 any) *MockSyncStateProviderIsBeaconSyncedCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsBeaconSynced", reflect.TypeOf((*MockSyncStateProvider)(nil).IsBeaconSynced), arg0)
-	return &MockSyncStateProviderIsBeaconSyncedCall{Call: call}
-}
-
-// MockSyncStateProviderIsBeaconSyncedCall wrap *gomock.Call
-type MockSyncStateProviderIsBeaconSyncedCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockSyncStateProviderIsBeaconSyncedCall) Return(arg0 bool) *MockSyncStateProviderIsBeaconSyncedCall {
-	c.Call = c.Call.Return(arg0)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockSyncStateProviderIsBeaconSyncedCall) Do(f func(types.EpochID) bool) *MockSyncStateProviderIsBeaconSyncedCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSyncStateProviderIsBeaconSyncedCall) DoAndReturn(f func(types.EpochID) bool) *MockSyncStateProviderIsBeaconSyncedCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
 }
 
 // IsSynced mocks base method.

--- a/system/sync.go
+++ b/system/sync.go
@@ -2,8 +2,6 @@ package system
 
 import (
 	"context"
-
-	"github.com/spacemeshos/go-spacemesh/common/types"
 )
 
 //go:generate mockgen -typed -package=mocks -destination=./mocks/sync.go -source=./sync.go
@@ -11,5 +9,4 @@ import (
 // SyncStateProvider defines the interface that provides the node's sync state.
 type SyncStateProvider interface {
 	IsSynced(context.Context) bool
-	IsBeaconSynced(types.EpochID) bool
 }


### PR DESCRIPTION
## Motivation

The `IsBeaconSynced` method of `SyncStateProvider` is not used anywhere.

## Description

Removed `SyncStateProvider::IsBeaconSynced`

## Test Plan

n/a

## TODO

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [ ] Update documentation as needed
- [ ] Update [changelog](../CHANGELOG.md) as needed
