### PR TITLE
[Merged by Bors] - Fix possible deadloop in beacon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ See [RELEASE](./RELEASE.md) for workflow instructions.
 
 ### Improvements
 
-* [#6431](https://github.com/spacemeshos/go-spacemesh/pull/6431) Fix db-allow-schema-drift handling
 * [#6408](https://github.com/spacemeshos/go-spacemesh/pull/6408) Prevent empty DB connection pool by freeing connections
   upon errors during DB operations. This mostly fixes issues when a node is under heavy load from the API.
 
@@ -15,6 +14,10 @@ See [RELEASE](./RELEASE.md) for workflow instructions.
 
 * [#6422](https://github.com/spacemeshos/go-spacemesh/pull/6422) Further improved performance of the proposal building
   process to avoid late proposals.
+
+* [#6431](https://github.com/spacemeshos/go-spacemesh/pull/6431) Fix db-allow-schema-drift handling
+
+* [#6451](https://github.com/spacemeshos/go-spacemesh/pull/6451) Fix a possible deadloop in the beacon protocol.
 
 ## v1.7.6
 

--- a/api/grpcserver/v2alpha1/node_test.go
+++ b/api/grpcserver/v2alpha1/node_test.go
@@ -23,7 +23,8 @@ func TestNodeService_Status(t *testing.T) {
 		timesync.WithLayerDuration(layerDuration),
 		timesync.WithTickInterval(1*time.Second),
 		timesync.WithGenesisTime(time.Now()),
-		timesync.WithLogger(zaptest.NewLogger(t)))
+		timesync.WithLogger(zaptest.NewLogger(t)),
+	)
 	require.NoError(t, err)
 	defer clock.Close()
 

--- a/beacon/beacon.go
+++ b/beacon/beacon.go
@@ -729,16 +729,16 @@ func (pd *ProtocolDriver) listenEpochs(ctx context.Context) {
 				pd.logger.Debug("time sync detected, realigning Beacon")
 				continue
 			}
+			epoch := current.GetEpoch()
+			layer = epoch.Add(1).FirstLayer()
 			if !current.FirstInEpoch() {
 				continue
 			}
-			epoch := current.GetEpoch()
-			layer = epoch.Add(1).FirstLayer()
 
 			pd.setProposalTimeForNextEpoch()
 			pd.logger.Info("processing epoch", zap.Uint32("epoch", epoch.Uint32()))
 			pd.eg.Go(func() error {
-				_ = pd.onNewEpoch(ctx, epoch)
+				pd.onNewEpoch(ctx, epoch)
 				return nil
 			})
 		}


### PR DESCRIPTION
## Motivation

I found a problem in the beacon protocol where if the node wakes up from sleep or syncs its clock via NTP at the wrong moment the go routine running the beacon protocol might end up in a deadloop without ever recovering.

## Description

`listenEpochs` is supposed to wait until the start of an epoch to then start the beacon protocol for that epoch. When the new epoch starts the select case `<-pd.clock.AwaitLayer(layer)` will unlock. This can happen any time after that layer was reached - usually ms, but if the runtime was very busy or the host was hibernating the time between reaching the layer and this case unlocking can extend much longer. The problem is the if a bit further below:

```go
if !current.FirstInEpoch() {
	continue
}
```

if for any reason the signal from the select case was received after the 2nd layer of the epoch already started, this if statement will `continue` the for loop without updating `current` or `layer` resulting in a deadloop.

I fixed the issue by updating `layer` before checking, so that if the node is late it skips participating in the beacon protocol for this epoch and waits for the next.

## Test Plan

Existing tests pass

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
