### PR TITLE
[Merged by Bors] - Fix minor logging nit

### DIFF
--- a/txs/cache.go
+++ b/txs/cache.go
@@ -514,7 +514,7 @@ func (c *Cache) BuildFromTXs(rst []*types.MeshTransaction, blockSeed []byte) err
 			acctsAdded++
 		}
 	}
-	c.logger.Sugar().Debug("added pending tx for %d accounts", acctsAdded)
+	c.logger.Sugar().Debugf("added pending tx for %d accounts", acctsAdded)
 	return nil
 }
 


### PR DESCRIPTION
## Description

Trivial fix for a minor nit found by reading logs from some test run where message was shown as:
```
logger.go:146: 2024-11-13T21:08:32.496Z	DEBUG	added pending tx for %d accounts988
```

## Test Plan

Manual observation for logs.

## TODO

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
