### PR TITLE
[Merged by Bors] - Add nodepool lifecycle for systemtests

### DIFF
--- a/.github/workflows/systest.yml
+++ b/.github/workflows/systest.yml
@@ -100,6 +100,7 @@ jobs:
             --cluster ${{ secrets.CI_CLUSTER_NAME }} \
             --num-nodes 8 \
             --preemptible \
+            --location ${{ secrets.CI_REGION_NAME }} \
             --machine-type ${{ secrets.CI_NODE_MACHINE_TYPE }} \
             --disk-type pd-ssd \
             --disk-size 300GB \

--- a/.github/workflows/systest.yml
+++ b/.github/workflows/systest.yml
@@ -98,7 +98,7 @@ jobs:
 
           gcloud container node-pools create $NODE_POOL_NAME \
             --cluster ${{ secrets.CI_CLUSTER_NAME }} \
-            --num-nodes 8 \
+            --num-nodes 2 \
             --preemptible \
             --location ${{ secrets.CI_REGION_NAME }} \
             --machine-type ${{ secrets.CI_NODE_MACHINE_TYPE }} \

--- a/.github/workflows/systest.yml
+++ b/.github/workflows/systest.yml
@@ -110,6 +110,7 @@ jobs:
             --node-labels env=dev,cluster=${{ secrets.CI_CLUSTER_NAME }},pipeline-id=${{ github.run_id }} \
             --metadata disable-legacy-endpoints=true \
             --service-account ${{ secrets.CI_GKE_NODEPOOL_SA }} \
+            --project ${{ secrets.CI_GCP_PROJECT_ID }} \
             --quiet
 
           echo "Node pool created: $NODE_POOL_NAME"
@@ -182,6 +183,7 @@ jobs:
           gcloud container node-pools delete $NODE_POOL_NAME \
             --cluster ${{ secrets.CI_CLUSTER_NAME }} \
             --location ${{ secrets.CI_REGION_NAME }} \
+            --project ${{ secrets.CI_GCP_PROJECT_ID }} \
             --quiet
           echo "Node pool deleted: $NODE_POOL_NAME"
 

--- a/.github/workflows/systest.yml
+++ b/.github/workflows/systest.yml
@@ -100,7 +100,7 @@ jobs:
             --cluster ${{ secrets.CI_CLUSTER_NAME }} \
             --num-nodes 8 \
             --preemptible \
-            --machine-type ${{ CI_NODE_MACHINE_TYPE }} \
+            --machine-type ${{ secrets.CI_NODE_MACHINE_TYPE }} \
             --disk-type pd-ssd \
             --disk-size 300GB \
             --image-type COS_CONTAINERD \

--- a/.github/workflows/systest.yml
+++ b/.github/workflows/systest.yml
@@ -91,6 +91,28 @@ jobs:
       - name: Configure kubectl
         run: gcloud container clusters get-credentials ${{ secrets.CI_CLUSTER_NAME }} --region ${{ secrets.CI_REGION_NAME }} --project ${{ secrets.CI_GCP_PROJECT_ID }}
 
+      - name: Create Node Pool
+        run: |
+
+          NODE_POOL_NAME="systemtest-${{ github.run_id }}"
+
+          gcloud container node-pools create $NODE_POOL_NAME \
+            --cluster ${{ secrets.CI_CLUSTER_NAME }} \
+            --num-nodes 8 \
+            --preemptible \
+            --machine-type ${{ CI_NODE_MACHINE_TYPE }} \
+            --disk-type pd-ssd \
+            --disk-size 300GB \
+            --image-type COS_CONTAINERD \
+            --enable-autorepair \
+            --no-enable-autoupgrade \
+            --node-labels env=dev,cluster=${{ secrets.CI_CLUSTER_NAME }},pipeline-id=${{ github.run_id }} \
+            --metadata disable-legacy-endpoints=true \
+            --service-account ${{ secrets.CI_GKE_NODEPOOL_SA }} \
+            --quiet
+
+          echo "Node pool created: $NODE_POOL_NAME"
+
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -138,7 +160,7 @@ jobs:
         env:
           test_id: systest-${{ steps.vars.outputs.sha_short }}
           storage: premium-rwo=10Gi
-          node_selector: cloud.google.com/gke-nodepool=systemtest
+          node_selector: pipeline-id=${{ github.run_id }}
           size: 20
           bootstrap: 4m
           level: ${{ inputs.log_level }}
@@ -151,6 +173,16 @@ jobs:
         env:
           test_id: systest-${{ steps.vars.outputs.sha_short }}
         run: make -C systest clean
+      
+      - name: Delete Node Pool
+        if: always()
+        run: |
+          NODE_POOL_NAME="systemtest-${{ github.run_id }}"
+          gcloud container node-pools delete $NODE_POOL_NAME \
+            --cluster ${{ secrets.CI_CLUSTER_NAME }} \
+            --location ${{ secrets.CI_REGION_NAME }} \
+            --quiet
+          echo "Node pool deleted: $NODE_POOL_NAME"
 
   systest-status:
     if: always()


### PR DESCRIPTION
## Motivation

This PR automates the creation and cleanup of GKE node pools specifically for system tests in the CI pipeline. The goal is to provide dynamic, on-demand node pools that can be created before system tests and cleaned up afterward, improving resource utilization and reducing costs.

## Description

- **Node Pool Creation:** A new step has been added to the GitHub Actions pipeline to create a preemptible GKE node pool with a custom name based on the pipeline run ID.
- Node pool labels are added to track the pipeline ID for easier identification.
- **Node Pool Deletion:** A subsequent cleanup step has been added to delete the node pool after system tests are completed, ensuring that no unnecessary resources are left running.

This helps maintain stability in the infrastructure during system tests.
