### PR TITLE
[Merged by Bors] - p2p: server: fix incorrect bufio usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ See [RELEASE](./RELEASE.md) for workflow instructions.
 
 * [#6451](https://github.com/spacemeshos/go-spacemesh/pull/6451) Fix a possible deadloop in the beacon protocol.
 
+* [#6470](https://github.com/spacemeshos/go-spacemesh/pull/6470) Fix I/O buffering issue which could be affecting QUIC connections.
+
 ## v1.7.6
 
 ### Upgrade information

--- a/p2p/server/deadline_adjuster.go
+++ b/p2p/server/deadline_adjuster.go
@@ -166,3 +166,11 @@ func (dadj *deadlineAdjuster) Write(p []byte) (n int, err error) {
 	}
 	return n, nil
 }
+
+// ReadByte implements io.ByteReader, which is needed for varint.ReadUvarint, which is
+// used to read request length.
+func (dadj *deadlineAdjuster) ReadByte() (byte, error) {
+	var b [1]byte
+	_, err := io.ReadFull(dadj, b[:])
+	return b[0], err
+}

--- a/p2p/server/server.go
+++ b/p2p/server/server.go
@@ -303,8 +303,7 @@ func (s *Server) Run(ctx context.Context) error {
 func (s *Server) queueHandler(ctx context.Context, peer peer.ID, stream network.Stream) bool {
 	dadj := newDeadlineAdjuster(stream, s.timeout, s.hardTimeout)
 	defer dadj.Close()
-	rd := bufio.NewReader(dadj)
-	size, err := varint.ReadUvarint(rd)
+	size, err := varint.ReadUvarint(dadj)
 	if err != nil {
 		s.logger.Debug("initial read failed",
 			zap.String("protocol", s.protocol),
@@ -326,7 +325,7 @@ func (s *Server) queueHandler(ctx context.Context, peer peer.ID, stream network.
 		return false
 	}
 	buf := make([]byte, size)
-	_, err = io.ReadFull(rd, buf)
+	_, err = io.ReadFull(dadj, buf)
 	if err != nil {
 		s.logger.Debug("error reading request",
 			zap.String("protocol", s.protocol),


### PR DESCRIPTION
## Motivation

It is not correct to use `bufio.Buffer` to read the initial request
and then passing the underlying stream to the `StreamRequest`
callback, as `bufio.Buffer` may happen to read more data than
necessary, making it unavailable for the `StreamRequest` callback.
This behavior has been obvserved when using QUIC, which tends to
coalesce multiple writes more often.

## Description

This removes unneeded `bufio.Buffer` usage, which should not impact
performance as the buffer was not being used for the actual request
handling, anyway.

## Test Plan

Verified that this fixes QUIC write coalescing issue.