### PR TITLE
[Merged by Bors] - Add Test result tracking to codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,7 +186,6 @@ jobs:
         with:
           lfs: true
           ssh-key: ${{ secrets.GH_ACTION_PRIVATE_KEY }}
-
       - uses: extractions/netrc@v2
         with:
           machine: github.com
@@ -206,6 +205,11 @@ jobs:
         run: make cover
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,6 @@ temp.js
 /cover-all.out
 /trace
 cover.out
-test-report.json
 junit.xml
 coverage.html
 gcloud.json

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ temp.js
 /cover-all.out
 /trace
 cover.out
+test-report.json
+junit.xml
 coverage.html
 gcloud.json
 spacemesh.json

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ GOTESTSUM_VERSION := v1.12.0
 GOVULNCHECK_VERSION := v1.1.3
 GOSCALE_VERSION := v1.2.0
 MOCKGEN_VERSION := v0.5.0
-GO2JUNIT_VERSION := de22d90
 
 # Add an indicator to the branch name if dirty and use commithash if running in detached mode
 ifeq ($(BRANCH),HEAD)
@@ -71,7 +70,6 @@ install:
 	go install go.uber.org/mock/mockgen@$(MOCKGEN_VERSION)
 	go install gotest.tools/gotestsum@$(GOTESTSUM_VERSION)
 	go install golang.org/x/vuln/cmd/govulncheck@$(GOVULNCHECK_VERSION)
-	go install github.com/fasmat/go2junit/cmd/go2junit@$(GO2JUNIT_VERSION)
 .PHONY: install
 
 build: go-spacemesh get-profiler get-postrs-service
@@ -147,9 +145,7 @@ lint-fix: get-libs
 .PHONY: lint-fix
 
 cover: get-libs
-	@$(ULIMIT) CGO_LDFLAGS="$(CGO_TEST_LDFLAGS)" go test -coverprofile=cover.out -json -p 1 -timeout 30m -coverpkg=./... $(UNIT_TESTS) > test-report.json
-	sed -i.bak '/"Action":"output"/d' test-report.json
-	go2junit parse -i test-report.json > junit.xml
+	@$(ULIMIT) CGO_LDFLAGS="$(CGO_TEST_LDFLAGS)" gotestsum --junitfile junit.xml -- -coverprofile=cover.out -p 1 -timeout 30m -coverpkg=./... $(UNIT_TESTS)
 .PHONY: cover
 
 vulncheck: get-libs

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ GOTESTSUM_VERSION := v1.12.0
 GOVULNCHECK_VERSION := v1.1.3
 GOSCALE_VERSION := v1.2.0
 MOCKGEN_VERSION := v0.5.0
+GO2JUNIT_VERSION := de22d90
 
 # Add an indicator to the branch name if dirty and use commithash if running in detached mode
 ifeq ($(BRANCH),HEAD)
@@ -70,6 +71,7 @@ install:
 	go install go.uber.org/mock/mockgen@$(MOCKGEN_VERSION)
 	go install gotest.tools/gotestsum@$(GOTESTSUM_VERSION)
 	go install golang.org/x/vuln/cmd/govulncheck@$(GOVULNCHECK_VERSION)
+	go install github.com/fasmat/go2junit/cmd/go2junit@$(GO2JUNIT_VERSION)
 .PHONY: install
 
 build: go-spacemesh get-profiler get-postrs-service
@@ -145,7 +147,9 @@ lint-fix: get-libs
 .PHONY: lint-fix
 
 cover: get-libs
-	@$(ULIMIT) CGO_LDFLAGS="$(CGO_TEST_LDFLAGS)" go test -coverprofile=cover.out -p 1 -timeout 30m -coverpkg=./... $(UNIT_TESTS)
+	@$(ULIMIT) CGO_LDFLAGS="$(CGO_TEST_LDFLAGS)" go test -coverprofile=cover.out -json -p 1 -timeout 30m -coverpkg=./... $(UNIT_TESTS) > test-report.json
+	sed -i.bak '/"Action":"output"/d' test-report.json
+	go2junit parse -i test-report.json > junit.xml
 .PHONY: cover
 
 vulncheck: get-libs


### PR DESCRIPTION
## Motivation

The changes in this PR allow us to better keep track of flaky tests in our CI.

## Description

I modified the `coverage` job to use `gotestsum` to create both a coverage report in `cover.out` and a junit report in `junit.xml`, which is then uploaded to `codecov` to track tests.

## Test Plan

manual: code coverage workflow succeeds and data is uploaded to codecov

## TODO

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
