### PR TITLE
[Merged by Bors] - fetch: smarter peer selection

### DIFF
--- a/fetch/fetch_test.go
+++ b/fetch/fetch_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/protocol"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -187,7 +188,9 @@ func TestFetch_RequestHashBatchFromPeers(t *testing.T) {
 			f := createFetch(t)
 			f.cfg.MaxRetriesForRequest = 0
 			peer := p2p.Peer("buddy")
-			f.peers.Add(peer)
+			f.peers.Add(peer, func() []protocol.ID {
+				return []protocol.ID{hashProtocol, activeSetProtocol}
+			})
 
 			hsh0 := types.RandomHash()
 			res0 := ResponseMessage{
@@ -259,8 +262,9 @@ func TestFetch_Loop_BatchRequestMax(t *testing.T) {
 	f.cfg.BatchTimeout = 1
 	f.cfg.BatchSize = 2
 	peer := p2p.Peer("buddy")
-	f.peers.Add(peer)
-
+	f.peers.Add(peer, func() []protocol.ID {
+		return []protocol.ID{hashProtocol, activeSetProtocol}
+	})
 	h1 := types.RandomHash()
 	h2 := types.RandomHash()
 	h3 := types.RandomHash()

--- a/fetch/mesh_data_test.go
+++ b/fetch/mesh_data_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	p2phost "github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/protocol"
 	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -137,7 +138,9 @@ func TestFetch_getHashes(t *testing.T) {
 		f.Start()
 		tb.Cleanup(f.Stop)
 		for _, peer := range peers {
-			f.peers.Add(peer)
+			f.peers.Add(peer, func() []protocol.ID {
+				return []protocol.ID{hashProtocol, activeSetProtocol}
+			})
 		}
 		f.mh.EXPECT().ID().Return("self").AnyTimes()
 		f.RegisterPeerHashes(peers[0], hashes[:2])
@@ -249,7 +252,9 @@ func TestFetch_getHashesStreaming(t *testing.T) {
 		f.Start()
 		tb.Cleanup(f.Stop)
 		for _, peer := range peers {
-			f.peers.Add(peer)
+			f.peers.Add(peer, func() []protocol.ID {
+				return []protocol.ID{hashProtocol, activeSetProtocol}
+			})
 		}
 		f.mh.EXPECT().ID().Return("self").AnyTimes()
 		f.RegisterPeerHashes(peers[0], hashes[:2])

--- a/fetch/peers/peers.go
+++ b/fetch/peers/peers.go
@@ -1,6 +1,7 @@
 package peers
 
 import (
+	"slices"
 	"strings"
 	"sync"
 	"time"

--- a/fetch/peers/peers.go
+++ b/fetch/peers/peers.go
@@ -174,10 +174,10 @@ func (p *Peers) selectBest(n int, protocols []protocol.ID) []peer.ID {
 	}
 	best := make([]*data, 0, lth)
 	for _, peer := range p.peers {
-		if protoMap != nil {
+		if len(protocols) > 0 {
 			found := false
 			for _, proto := range peer.protocols() {
-				if _, exist := protoMap[proto]; exist {
+				if slices.Contains(protocols, proto) {
 					found = true
 					break
 				}

--- a/fetch/peers/peers.go
+++ b/fetch/peers/peers.go
@@ -166,13 +166,8 @@ func (p *Peers) SelectBestWithProtocols(n int, protocols []protocol.ID) []peer.I
 }
 
 func (p *Peers) selectBest(n int, protocols []protocol.ID) []peer.ID {
-	var protoMap map[protocol.ID]struct{}
-	if len(protocols) > 0 {
-		protoMap = make(map[protocol.ID]struct{}, len(protocols))
-		for _, proto := range protocols {
-			protoMap[proto] = struct{}{}
-		}
-	}
+	slices.Sort(protocols)
+	slices.Compact(protocols)
 	lth := min(len(p.peers), n)
 	if lth == 0 {
 		return nil

--- a/fetch/peers/peers.go
+++ b/fetch/peers/peers.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/protocol"
 	"go.uber.org/zap/zapcore"
 
 	"github.com/spacemeshos/go-spacemesh/p2p"
@@ -16,6 +17,7 @@ type data struct {
 	success, failures int
 	failRate          float64
 	averageLatency    float64
+	protocols         func() []protocol.ID
 }
 
 func (d *data) latency(global float64) float64 {
@@ -61,14 +63,14 @@ func (p *Peers) Contains(id peer.ID) bool {
 	return exist
 }
 
-func (p *Peers) Add(id peer.ID) bool {
+func (p *Peers) Add(id peer.ID, protocols func() []protocol.ID) bool {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	_, exist := p.peers[id]
 	if exist {
 		return false
 	}
-	p.peers[id] = &data{id: id}
+	p.peers[id] = &data{id: id, protocols: protocols}
 	return true
 }
 
@@ -151,12 +153,44 @@ func (p *Peers) SelectBestFrom(peers []peer.ID) peer.ID {
 func (p *Peers) SelectBest(n int) []peer.ID {
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	return p.selectBest(n, nil)
+}
+
+// SelectBestWithProtocols is similar to SelectBest but filters peers by supported protocols.
+// If protocols is empty, it returns the best peers regardless of the protocol.
+// If protocols is not empty, it returns the best peers that support at least one of the protocols.
+func (p *Peers) SelectBestWithProtocols(n int, protocols []protocol.ID) []peer.ID {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.selectBest(n, protocols)
+}
+
+func (p *Peers) selectBest(n int, protocols []protocol.ID) []peer.ID {
+	var protoMap map[protocol.ID]struct{}
+	if len(protocols) > 0 {
+		protoMap = make(map[protocol.ID]struct{}, len(protocols))
+		for _, proto := range protocols {
+			protoMap[proto] = struct{}{}
+		}
+	}
 	lth := min(len(p.peers), n)
 	if lth == 0 {
 		return nil
 	}
 	best := make([]*data, 0, lth)
 	for _, peer := range p.peers {
+		if protoMap != nil {
+			found := false
+			for _, proto := range peer.protocols() {
+				if _, exist := protoMap[proto]; exist {
+					found = true
+					break
+				}
+			}
+			if !found {
+				continue
+			}
+		}
 		for i := range best {
 			if peer.less(best[i], p.globalLatency) {
 				best[i], peer = peer, best[i]

--- a/fetch/peers/peers.go
+++ b/fetch/peers/peers.go
@@ -168,7 +168,7 @@ func (p *Peers) SelectBestWithProtocols(n int, protocols []protocol.ID) []peer.I
 
 func (p *Peers) selectBest(n int, protocols []protocol.ID) []peer.ID {
 	slices.Sort(protocols)
-	slices.Compact(protocols)
+	protocols = slices.Compact(protocols)
 	lth := min(len(p.peers), n)
 	if lth == 0 {
 		return nil

--- a/sync2/multipeer/multipeer.go
+++ b/sync2/multipeer/multipeer.go
@@ -7,12 +7,17 @@ import (
 	"time"
 
 	"github.com/jonboulle/clockwork"
+	"github.com/libp2p/go-libp2p/core/protocol"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/spacemeshos/go-spacemesh/fetch/peers"
 	"github.com/spacemeshos/go-spacemesh/p2p"
 	"github.com/spacemeshos/go-spacemesh/sync2/rangesync"
+)
+
+const (
+	Protocol = "sync/2"
 )
 
 type syncability struct {
@@ -283,7 +288,7 @@ func (mpr *MultiPeerReconciler) fullSync(ctx context.Context, syncPeers []p2p.Pe
 func (mpr *MultiPeerReconciler) syncOnce(ctx context.Context, lastWasSplit bool) (full bool, err error) {
 	var s syncability
 	for {
-		syncPeers := mpr.peers.SelectBest(mpr.cfg.SyncPeerCount)
+		syncPeers := mpr.peers.SelectBestWithProtocols(mpr.cfg.SyncPeerCount, []protocol.ID{Protocol})
 		mpr.logger.Debug("selected best peers for sync",
 			zap.Int("syncPeerCount", mpr.cfg.SyncPeerCount),
 			zap.Int("totalPeers", mpr.peers.Total()),

--- a/sync2/multipeer/multipeer_test.go
+++ b/sync2/multipeer/multipeer_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/jonboulle/clockwork"
+	"github.com/libp2p/go-libp2p/core/protocol"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 	"go.uber.org/zap/zaptest"
@@ -101,7 +102,7 @@ func (mt *multiPeerSyncTester) addPeers(n int) []p2p.Peer {
 	r := make([]p2p.Peer, n)
 	for i := 0; i < n; i++ {
 		p := p2p.Peer(fmt.Sprintf("peer%d", i+1))
-		mt.peers.Add(p)
+		mt.peers.Add(p, func() []protocol.ID { return []protocol.ID{multipeer.Protocol} })
 		r[i] = p
 	}
 	return r

--- a/sync2/multipeer/split_sync_test.go
+++ b/sync2/multipeer/split_sync_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/jonboulle/clockwork"
+	"github.com/libp2p/go-libp2p/core/protocol"
 	"github.com/stretchr/testify/require"
 	gomock "go.uber.org/mock/gomock"
 	"go.uber.org/zap/zaptest"
@@ -108,7 +109,7 @@ func newTestSplitSync(t testing.TB) *splitSyncTester {
 			AnyTimes()
 	}
 	for _, p := range tst.syncPeers {
-		tst.peers.Add(p)
+		tst.peers.Add(p, func() []protocol.ID { return []protocol.ID{multipeer.Protocol} })
 	}
 	tst.splitSync = multipeer.NewSplitSync(
 		zaptest.NewLogger(t),

--- a/sync2/p2p_test.go
+++ b/sync2/p2p_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/libp2p/go-libp2p/core/protocol"
 	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
@@ -16,6 +17,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/p2p"
 	"github.com/spacemeshos/go-spacemesh/p2p/server"
 	"github.com/spacemeshos/go-spacemesh/sync2"
+	"github.com/spacemeshos/go-spacemesh/sync2/multipeer"
 	"github.com/spacemeshos/go-spacemesh/sync2/rangesync"
 )
 
@@ -88,7 +90,9 @@ func TestP2P(t *testing.T) {
 		ps := peers.New()
 		for m := 0; m < numNodes; m++ {
 			if m != n {
-				ps.Add(mesh.Hosts()[m].ID())
+				ps.Add(mesh.Hosts()[m].ID(), func() []protocol.ID {
+					return []protocol.ID{multipeer.Protocol}
+				})
 			}
 		}
 		cfg := sync2.DefaultConfig()


### PR DESCRIPTION
## Motivation

Most of the time, there are some nodes that already joined the P2P
network but didn't complete their initialization yet, and thus
attempts to e.g. fetch blobs to them end up in stream setup errors
(protocol not supported).
Additionally, during initial phases of `syncv2` testing, we're going
to have a limited number of nodes supporting `sync/2` protocol, and
when choosing peers for `syncv2`, we must only include these peers.

## Description

Add a possibility to select best peers by their supported protocols,
which is used by `syncv2`.
When doing hash requests, only query peers that support hs/1 and as/1
protocols. This avoids querying peers that didn't finish their
initialization and thus didn't start their fetch servers yet.

## Test Plan

Verify how sync works on a node