### PR TITLE
node-split: add PoetInfo method to smesher service API PoC

### DIFF
--- a/activation/interface.go
+++ b/activation/interface.go
@@ -170,6 +170,9 @@ type PoetService interface {
 
 	// TickSize returns tickSize configured for particular PoET service
 	TickSize() uint64
+
+	// Info returns the PoET service info.
+	Info(ctx context.Context) (*types.PoetInfo, error)
 }
 
 // A certifier client that the certifierService uses to obtain certificates

--- a/activation/mocks.go
+++ b/activation/mocks.go
@@ -1885,6 +1885,45 @@ func (c *MockPoetServiceCertifyCall) DoAndReturn(f func(context.Context, types.N
 	return c
 }
 
+// Info mocks base method.
+func (m *MockPoetService) Info(ctx context.Context) (*types.PoetInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Info", ctx)
+	ret0, _ := ret[0].(*types.PoetInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Info indicates an expected call of Info.
+func (mr *MockPoetServiceMockRecorder) Info(ctx any) *MockPoetServiceInfoCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Info", reflect.TypeOf((*MockPoetService)(nil).Info), ctx)
+	return &MockPoetServiceInfoCall{Call: call}
+}
+
+// MockPoetServiceInfoCall wrap *gomock.Call
+type MockPoetServiceInfoCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockPoetServiceInfoCall) Return(arg0 *types.PoetInfo, arg1 error) *MockPoetServiceInfoCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockPoetServiceInfoCall) Do(f func(context.Context) (*types.PoetInfo, error)) *MockPoetServiceInfoCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockPoetServiceInfoCall) DoAndReturn(f func(context.Context) (*types.PoetInfo, error)) *MockPoetServiceInfoCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // Proof mocks base method.
 func (m *MockPoetService) Proof(ctx context.Context, roundID string) (*types.PoetProof, []types.Hash32, error) {
 	m.ctrl.T.Helper()

--- a/activation/poet.go
+++ b/activation/poet.go
@@ -653,6 +653,10 @@ func (c *poetService) Certify(ctx context.Context, id types.NodeID) (*certifier.
 	return c.certifier.Certificate(ctx, id, info.Certifier.Url, info.Certifier.Pubkey)
 }
 
+func (c *poetService) Info(ctx context.Context) (*types.PoetInfo, error) {
+	return c.getInfo(ctx)
+}
+
 func (c *poetService) getInfo(ctx context.Context) (*types.PoetInfo, error) {
 	info, err := c.infoCache.get(func() (*types.PoetInfo, error) {
 		info, err := c.client.Info(ctx)

--- a/activation_service_poc/docker-compose.yml
+++ b/activation_service_poc/docker-compose.yml
@@ -13,6 +13,8 @@ services:
     volumes:
       - /tmp/spacemesh-client:/tmp/spacemesh-client
       - ./config.standalone.client.json:/config.json
+    ports:
+      - 9071:9071
     networks:
       - spacemesh-net
 

--- a/api/grpcserver/v2alpha1/smeshing_identities.go
+++ b/api/grpcserver/v2alpha1/smeshing_identities.go
@@ -6,6 +6,7 @@ import (
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	pb "github.com/spacemeshos/api/release/go/spacemesh/v2alpha1"
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/spacemeshos/go-spacemesh/activation"
@@ -14,14 +15,17 @@ import (
 const SmeshingIdentities = "smeshing_identities_v2alpha1"
 
 type SmeshingIdentitiesService struct {
-	states identityState
+	states      identityState
+	poetClients []activation.PoetService
 }
 
 func NewSmeshingIdentitiesService(
 	states identityState,
+	poetClients []activation.PoetService,
 ) *SmeshingIdentitiesService {
 	return &SmeshingIdentitiesService{
-		states: states,
+		states:      states,
+		poetClients: poetClients,
 	}
 }
 
@@ -81,4 +85,25 @@ func (s *SmeshingIdentitiesService) States(
 	}
 
 	return &pb.IdentityStatesResponse{Identities: pbIdentities}, nil
+}
+
+func (s *SmeshingIdentitiesService) PoetInfo(
+	ctx context.Context,
+	_ *pb.PoetInfoRequest,
+) (*pb.PoetInfoResponse, error) {
+	poets := make(map[string]*pb.PoetInfo)
+	for _, poet := range s.poetClients {
+		info, err := poet.Info(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		poets[poet.Address()] = &pb.PoetInfo{
+			PhaseShift: durationpb.New(info.PhaseShift),
+			CycleGap:   durationpb.New(info.CycleGap),
+		}
+	}
+	return &pb.PoetInfoResponse{
+		Poets: poets,
+	}, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/seehuhn/mt19937 v1.0.0
 	github.com/slok/go-http-metrics v0.13.0
-	github.com/spacemeshos/api/release/go v1.56.1-0.20241118123333-4a30c0bddda2
+	github.com/spacemeshos/api/release/go v1.57.1-0.20241121111351-1e8ac2105be2
 	github.com/spacemeshos/economics v0.1.4
 	github.com/spacemeshos/fixed v0.1.2
 	github.com/spacemeshos/go-scale v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -636,8 +636,8 @@ github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d/go.mod h1:Udh
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
-github.com/spacemeshos/api/release/go v1.56.1-0.20241118123333-4a30c0bddda2 h1:+T5J7rfjQJj8ljfwsWHRO8Gt/wf7Bpo1spFlalYEuAA=
-github.com/spacemeshos/api/release/go v1.56.1-0.20241118123333-4a30c0bddda2/go.mod h1:w/WRxR8JVmaeKqEEyL6DCoQxt3oyZOTv4uQSdMXlucM=
+github.com/spacemeshos/api/release/go v1.57.1-0.20241121111351-1e8ac2105be2 h1:Il+dqna9bjTbhy27cq3Ncpdu8VoPLN0UIHcTuKuhuuY=
+github.com/spacemeshos/api/release/go v1.57.1-0.20241121111351-1e8ac2105be2/go.mod h1:w/WRxR8JVmaeKqEEyL6DCoQxt3oyZOTv4uQSdMXlucM=
 github.com/spacemeshos/economics v0.1.4 h1:twlawrcQhYNqPgyDv08+24EL/OgUKz3d7q+PvJIAND0=
 github.com/spacemeshos/economics v0.1.4/go.mod h1:6HKWKiKdxjVQcGa2z/wA0LR4M/DzKib856bP16yqNmQ=
 github.com/spacemeshos/fixed v0.1.2 h1:pENQ8pXFAqin3f15ZLoOVVeSgcmcFJ0IFdFm4+9u4SM=

--- a/node/node.go
+++ b/node/node.go
@@ -431,6 +431,7 @@ type App struct {
 	malfeasanceHandler    *malfeasance.Handler
 	idStates              *activation.IdentityStateStorage
 	apiProxy              *proxy.Server
+	poetClients           []activation.PoetService
 
 	errCh chan error
 
@@ -1137,6 +1138,7 @@ func (app *App) initServices(ctx context.Context) error {
 		}
 		poetClients = append(poetClients, client)
 	}
+	app.poetClients = poetClients
 
 	nipostBuilder, err := activation.NewNIPostBuilder(
 		app.localDB,
@@ -1713,7 +1715,7 @@ func (app *App) grpcService(svc grpcserver.Service, lg log.Log) (grpcserver.Serv
 		app.grpcServices[svc] = service
 		return service, nil
 	case v2alpha1.SmeshingIdentities:
-		service := v2alpha1.NewSmeshingIdentitiesService(app.idStates)
+		service := v2alpha1.NewSmeshingIdentitiesService(app.idStates, app.poetClients)
 		app.grpcServices[svc] = service
 		return service, nil
 	}


### PR DESCRIPTION
Closes #6478 

This pull request introduces a new endpoint to fetch Poet Infos directly from smesher service API

Enhancements to PoET service:

* [`activation/interface.go`](diffhunk://#diff-19af165265e56812cad68db45da9804aa229355f6a4bc9e45614338425064554R173-R175): Added the `Info` method to the `PoetService` interface to return PoET service information.
* [`activation/poet.go`](diffhunk://#diff-c54d554dd4f82a041c93f4c83dac0846fc78e7fc6a0a14813c35c870c95c7b5aR656-R659): Implemented the `Info` method in the `poetService` struct to retrieve PoET service information.

Modifications to gRPC server:

* [`api/grpcserver/v2alpha1/smeshing_identities.go`](diffhunk://#diff-088a0d3b571ce943cdb073386dcc32e8716e54ce83f83283ace6f25a8a424aeeR19-R28): Updated the `SmeshingIdentitiesService` to include PoET clients and added the `PoetInfo` method to return PoET information. [[1]](diffhunk://#diff-088a0d3b571ce943cdb073386dcc32e8716e54ce83f83283ace6f25a8a424aeeR19-R28) [[2]](diffhunk://#diff-088a0d3b571ce943cdb073386dcc32e8716e54ce83f83283ace6f25a8a424aeeR89-R109)
* [`node/node.go`](diffhunk://#diff-375d57e386f20eaa5f09f02bb9d28bfc48ac3dca18d0325f59492208219e5618R1141): Passed PoET clients to the `SmeshingIdentitiesService` during initialization. [[1]](diffhunk://#diff-375d57e386f20eaa5f09f02bb9d28bfc48ac3dca18d0325f59492208219e5618R1141) [[2]](diffhunk://#diff-375d57e386f20eaa5f09f02bb9d28bfc48ac3dca18d0325f59492208219e5618L1716-R1718)