### PR TITLE
Cleanups in athena poc code

### DIFF
--- a/api/grpcserver/grpcserver_test.go
+++ b/api/grpcserver/grpcserver_test.go
@@ -155,8 +155,8 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	addr1 = wallet.Address(*signer1.PublicKey())
-	addr2 = wallet.Address(*signer2.PublicKey())
+	addr1 = wallet.Address(signer1.PublicKey().Bytes())
+	addr2 = wallet.Address(signer2.PublicKey().Bytes())
 
 	globalAtx = &types.ActivationTx{
 		PublishEpoch: postGenesisEpoch,
@@ -379,7 +379,7 @@ func (t *ConStateAPIMock) Validation(raw types.RawTx) system.ValidationRequest {
 
 func NewTx(nonce uint64, recipient types.Address, signer *signing.EdSigner) *types.Transaction {
 	tx := types.Transaction{TxHeader: &types.TxHeader{}}
-	principal := wallet.Address(*signer.PublicKey())
+	principal := wallet.Address(signer.PublicKey().Bytes())
 	tx.Principal = principal
 	if nonce == 0 {
 		tx2, err := wallet.Spawn(signer.PrivateKey(), 0, sdk.WithGasPrice(0))
@@ -2318,7 +2318,7 @@ func TestTransactionsRewards(t *testing.T) {
 	t.Cleanup(cancel)
 	client := pb.NewGlobalStateServiceClient(dialGrpc(t, cfg))
 
-	address := wallet.Address(*signing.NewPublicKey(types.RandomNodeID().Bytes()))
+	address := wallet.Address(types.RandomNodeID().Bytes())
 	weight := new(big.Rat).SetFloat64(18.7)
 	rewards := []types.CoinbaseReward{{Coinbase: address, Weight: types.RatNumFromBigRat(weight)}}
 
@@ -2388,7 +2388,7 @@ func TestVMAccountUpdates(t *testing.T) {
 		signer, err := signing.NewEdSigner()
 		require.NoError(t, err)
 		keys[i] = signer
-		addr := wallet.Address(*signing.NewPublicKey(signer.NodeID().Bytes()))
+		addr := wallet.Address(signer.NodeID().Bytes())
 		accounts[i] = types.Account{
 			Address: addr,
 			Balance: initial,

--- a/api/grpcserver/transaction_service_test.go
+++ b/api/grpcserver/transaction_service_test.go
@@ -235,7 +235,7 @@ func TestParseTransactions(t *testing.T) {
 		pub, priv, err := ed25519.GenerateKey(rng)
 		require.NoError(t, err)
 		keys[i] = priv
-		addr := wallet.Address(*signing.NewPublicKey(pub))
+		addr := wallet.Address(pub)
 		accounts[i] = types.Account{Address: addr, Balance: 1e12}
 	}
 	// add the wallet template account

--- a/api/grpcserver/v2alpha1/transaction.go
+++ b/api/grpcserver/v2alpha1/transaction.go
@@ -377,29 +377,6 @@ func convertTxState(tx *types.MeshTransaction) *spacemeshv2alpha1.TransactionSta
 	}
 }
 
-type spawnTx struct {
-	Pubkey [32]byte
-}
-
-type spendTx struct {
-	To     types.Address
-	Amount uint64
-}
-
-var spawnSelector, spendSelector athcon.MethodSelector
-
-func init() {
-	var err error
-	spawnSelector, err = athcon.FromString("athexp_spawn")
-	if err != nil {
-		panic(err.Error())
-	}
-	spendSelector, err = athcon.FromString("athexp_spend")
-	if err != nil {
-		panic(err.Error())
-	}
-}
-
 func decodeTxArgs(decoder *scale.Decoder) (any, *core.Address, error) {
 	reg := registry.New()
 	wallet.Register(reg)
@@ -429,26 +406,13 @@ func decodeTxArgs(decoder *scale.Decoder) (any, *core.Address, error) {
 	var payload athcon.Payload
 	err = gossamerScale.Unmarshal(output.Payload, &payload)
 	if err != nil {
-		return nil, nil, fmt.Errorf("%w: tx payload", core.ErrMalformed)
-	}
-	if payload.Selector == nil {
-		return nil, nil, fmt.Errorf("%w: nil method selector", core.ErrMalformed)
+		return nil, nil, fmt.Errorf("%w: tx payload: %w", core.ErrMalformed, err)
 	}
 
-	var txArgs any
-	switch *payload.Selector {
-	case spawnSelector:
-		txArgs = new(spawnTx)
-	case spendSelector:
-		txArgs = new(spendTx)
-	default:
-		return nil, nil, fmt.Errorf("%w: unknown method selector %s", core.ErrMalformed, payload.Selector.String())
-	}
-	err = gossamerScale.Unmarshal(payload.Input, txArgs)
+	txArgs, err := wallet.ParseArgs(payload)
 	if err != nil {
-		return nil, nil, fmt.Errorf("%w: malformed tx arguments payload", core.ErrMalformed)
+		return nil, nil, fmt.Errorf("%w: decoding TX args: %w", core.ErrMalformed, err)
 	}
-
 	return txArgs, &wallet.TemplateAddress, nil
 }
 
@@ -465,14 +429,14 @@ func toTxContents(rawTx []byte) (*spacemeshv2alpha1.TransactionContents,
 	}
 
 	switch args := txArgs.(type) {
-	case *spawnTx:
+	case *wallet.SpawnArgs:
 		res.Contents = &spacemeshv2alpha1.TransactionContents_SingleSigSpawn{
 			SingleSigSpawn: &spacemeshv2alpha1.ContentsSingleSigSpawn{
 				Pubkey: signing.NewPublicKey(args.Pubkey[:]).String(),
 			},
 		}
 		txType = spacemeshv2alpha1.Transaction_TRANSACTION_TYPE_SINGLE_SIG_SPAWN
-	case *spendTx:
+	case *wallet.SpendArgs:
 		res.Contents = &spacemeshv2alpha1.TransactionContents_Send{
 			Send: &spacemeshv2alpha1.ContentsSend{
 				Destination: args.To.String(),

--- a/api/grpcserver/v2alpha1/transaction_test.go
+++ b/api/grpcserver/v2alpha1/transaction_test.go
@@ -235,7 +235,7 @@ func TestTransactionService_EstimateGas(t *testing.T) {
 		pub, priv, err := ed25519.GenerateKey(rng)
 		require.NoError(t, err)
 		keys[i] = priv
-		address := wallet.Address(*signing.NewPublicKey(pub))
+		address := wallet.Address(pub)
 		accounts[i] = types.Account{Address: address, Balance: 1e12}
 	}
 	accounts[len(keys)] = types.Account{
@@ -313,7 +313,7 @@ func TestTransactionService_ParseTransaction(t *testing.T) {
 		pub, priv, err := ed25519.GenerateKey(rng)
 		require.NoError(t, err)
 		keys[i] = priv
-		addr := wallet.Address(*signing.NewPublicKey(pub))
+		addr := wallet.Address(pub)
 		accounts[i] = types.Account{Address: addr, Balance: 1e12}
 	}
 	accounts[len(keys)] = types.Account{
@@ -452,7 +452,7 @@ func TestTransactionServiceSubmitUnsync(t *testing.T) {
 
 	signer, err := signing.NewEdSigner()
 	require.NoError(t, err)
-	addr := wallet.Address(*signer.PublicKey())
+	addr := wallet.Address(signer.PublicKey().Bytes())
 	tx := newTx(t, 0, addr, signer)
 	serializedTx, err := codec.Encode(tx)
 	req.NoError(err, "error serializing tx")
@@ -495,7 +495,7 @@ func TestTransactionServiceSubmitInvalidTx(t *testing.T) {
 
 	signer, err := signing.NewEdSigner()
 	require.NoError(t, err)
-	addr := wallet.Address(*signer.PublicKey())
+	addr := wallet.Address(signer.PublicKey().Bytes())
 	tx := newTx(t, 0, addr, signer)
 	serializedTx, err := codec.Encode(tx)
 	req.NoError(err, "error serializing tx")
@@ -532,7 +532,7 @@ func TestTransactionService_SubmitNoConcurrency(t *testing.T) {
 
 	signer, err := signing.NewEdSigner()
 	require.NoError(t, err)
-	addr := wallet.Address(*signer.PublicKey())
+	addr := wallet.Address(signer.PublicKey().Bytes())
 	tx := newTx(t, 0, addr, signer)
 	for range numTxs {
 		res, err := c.SubmitTransaction(ctx, &spacemeshv2alpha1.SubmitTransactionRequest{
@@ -546,7 +546,7 @@ func TestTransactionService_SubmitNoConcurrency(t *testing.T) {
 
 func newTx(t *testing.T, nonce uint64, recipient types.Address, signer *signing.EdSigner) *types.Transaction {
 	tx := types.Transaction{TxHeader: &types.TxHeader{}}
-	principal := wallet.Address(*signer.PublicKey())
+	principal := wallet.Address(signer.PublicKey().Bytes())
 	tx.Principal = principal
 	if nonce == 0 {
 		tx2, err := wallet.Spawn(signer.PrivateKey(), 0, sdk.WithGasPrice(0))

--- a/common/fixture/atxs.go
+++ b/common/fixture/atxs.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
-	"github.com/spacemeshos/go-spacemesh/signing"
 	"github.com/spacemeshos/go-spacemesh/vm/sdk/wallet"
 )
 
@@ -45,7 +44,7 @@ func (g *AtxsGenerator) WithEpochs(start, n int) *AtxsGenerator {
 func (g *AtxsGenerator) Next(t *testing.T) *types.ActivationTx {
 	var nodeID types.NodeID
 	g.rng.Read(nodeID[:])
-	addr := wallet.Address(*signing.NewPublicKey(nodeID.Bytes()))
+	addr := wallet.Address(nodeID.Bytes())
 
 	atx := &types.ActivationTx{
 		Sequence:     g.rng.Uint64(),

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -480,7 +480,7 @@ func TestSpacemeshApp_TransactionService(t *testing.T) {
 	signer, err := signing.NewEdSigner()
 	require.NoError(t, err)
 	app.signers = []*signing.EdSigner{signer}
-	address := wallet.Address(*signing.NewPublicKey(signer.PublicKey().Bytes()))
+	address := wallet.Address(signer.PublicKey().Bytes())
 
 	appCtx, appCancel := context.WithCancel(context.Background())
 	defer appCancel()

--- a/systest/cluster/cluster.go
+++ b/systest/cluster/cluster.go
@@ -23,7 +23,6 @@ import (
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/config"
 	"github.com/spacemeshos/go-spacemesh/hash"
-	"github.com/spacemeshos/go-spacemesh/signing"
 	"github.com/spacemeshos/go-spacemesh/systest/parameters"
 	"github.com/spacemeshos/go-spacemesh/systest/testcontext"
 	"github.com/spacemeshos/go-spacemesh/vm/sdk/wallet"
@@ -852,7 +851,7 @@ type signer struct {
 }
 
 func (s *signer) Address() types.Address {
-	return wallet.Address(*signing.NewPublicKey(s.Pub))
+	return wallet.Address(s.Pub)
 }
 
 func genSigners(n int) (rst []*signer) {

--- a/vm/cmd/gen/main.go
+++ b/vm/cmd/gen/main.go
@@ -88,7 +88,7 @@ func runNetwork(hrp string, pubkeys []ed25519.PublicKey, privkeys []ed25519.Priv
 
 	// first print the keys and addresses
 	for i, pubkey := range pubkeys {
-		addr := walletSdk.Address(*signing.NewPublicKey(pubkey))
+		addr := walletSdk.Address(pubkey)
 		addrs = append(addrs, addr)
 		t1.AppendRow(table.Row{
 			hex.EncodeToString(pubkey),

--- a/vm/core/context.go
+++ b/vm/core/context.go
@@ -59,7 +59,14 @@ type Context struct {
 	changed map[Address]*Account
 }
 
-func New(genesisID types.Hash20, layer types.LayerID, principal types.Address, loader AccountLoader, registry HandlerRegistry, logger *zap.Logger) (*Context, error) {
+func New(
+	genesisID types.Hash20,
+	layer types.LayerID,
+	principal types.Address,
+	loader AccountLoader,
+	registry HandlerRegistry,
+	logger *zap.Logger,
+) (*Context, error) {
 	principalAccount, err := loader.Get(principal)
 	if err != nil {
 		return nil, fmt.Errorf(

--- a/vm/core/context.go
+++ b/vm/core/context.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"fmt"
+	"maps"
 	"math"
 
 	"github.com/spacemeshos/go-scale"
@@ -62,10 +63,7 @@ type Context struct {
 // Clone returns a shallow copy of the context.
 func (c *Context) Clone() Host {
 	clone := *c
-	clone.changed = make(map[Address]*Account, len(c.changed))
-	for k, v := range c.changed {
-		clone.changed[k] = v
-	}
+	clone.changed = maps.Clone(c.changed)
 	return &clone
 }
 

--- a/vm/core/context.go
+++ b/vm/core/context.go
@@ -387,8 +387,5 @@ func (c *Context) change(account *Account) {
 	if !exist {
 		c.touched = append(c.touched, account.Address)
 	}
-	if c.changed == nil {
-		c.changed = make(map[types.Address]*types.Account)
-	}
 	c.changed[account.Address] = account
 }

--- a/vm/core/context.go
+++ b/vm/core/context.go
@@ -247,6 +247,7 @@ func (c *Context) transfer(from *Account, to Address, amount, max uint64) error 
 	c.change(account)
 	c.Logger.Debug(
 		"transfer",
+		zap.Uint64("transfered", c.transferred),
 		zap.Uint64("amount", amount),
 		zap.Stringer("from", from.Address),
 		zap.Stringer("to", to),
@@ -378,6 +379,9 @@ func (c *Context) change(account *Account) {
 	_, exist := c.changed[account.Address]
 	if !exist {
 		c.touched = append(c.touched, account.Address)
+	}
+	if c.changed == nil {
+		c.changed = make(map[types.Address]*types.Account)
 	}
 	c.changed[account.Address] = account
 }

--- a/vm/core/context.go
+++ b/vm/core/context.go
@@ -30,10 +30,9 @@ type Context struct {
 	LayerID   LayerID
 	GenesisID types.Hash20
 
-	PrincipalAddress   Address
-	PrincipalHandler   Handler
-	PrincipalTemplate  Template
-	PrincipalNextNonce uint64
+	PrincipalAccount  types.Account
+	PrincipalHandler  Handler
+	PrincipalTemplate Template
 
 	ParseOutput ParseOutput
 	Gas         struct {
@@ -60,6 +59,30 @@ type Context struct {
 	changed map[Address]*Account
 }
 
+func New(genesisID types.Hash20, layer types.LayerID, principal types.Address, loader AccountLoader, registry HandlerRegistry, logger *zap.Logger) (*Context, error) {
+	principalAccount, err := loader.Get(principal)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"%w: failed load state for principal %s - %w",
+			ErrInternal,
+			principal,
+			err,
+		)
+	}
+	logger.Debug("loaded principal account state", zap.Inline(&principalAccount))
+
+	return &Context{
+		GenesisID:        genesisID,
+		Registry:         registry,
+		Loader:           loader,
+		LayerID:          layer,
+		Logger:           logger,
+		PrincipalAccount: principalAccount,
+
+		changed: make(map[types.Address]*types.Account),
+	}, nil
+}
+
 // Clone returns a shallow copy of the context.
 func (c *Context) Clone() Host {
 	clone := *c
@@ -67,19 +90,14 @@ func (c *Context) Clone() Host {
 	return &clone
 }
 
-// PrincipalAccount returns the current state of the principal account.
-func (c *Context) PrincipalAccount() (*Account, error) {
-	return c.load(c.PrincipalAddress)
-}
-
 // Principal returns address of the account that signed the transaction and pays for the gas.
 func (c *Context) Principal() Address {
-	return c.PrincipalAddress
+	return c.PrincipalAccount.Address
 }
 
 // NextNonce returns the next nonce of the principal account.
 func (c *Context) NextNonce() uint64 {
-	return c.PrincipalNextNonce
+	return c.PrincipalAccount.NextNonce
 }
 
 // Nonce returns the transaction nonce.
@@ -113,12 +131,8 @@ func (c *Context) GetGenesisID() Hash20 {
 }
 
 // Balance returns the principal account balance.
-func (c *Context) Balance() (uint64, error) {
-	acct, err := c.PrincipalAccount()
-	if err != nil {
-		return 0, err
-	}
-	return acct.Balance, nil
+func (c *Context) Balance() uint64 {
+	return c.PrincipalAccount.Balance
 }
 
 // Template of the principal account.
@@ -189,16 +203,11 @@ func (c *Context) IsSpawn() bool {
 
 // Transfer amount to the address after validation passes.
 func (c *Context) Transfer(to Address, amount uint64) error {
-	acct, err := c.PrincipalAccount()
-	if err != nil {
-		return err
-	}
-	// no-op
 	if amount == 0 {
 		c.Logger.Debug("ignoring zero-value transfer")
 		return nil
 	}
-	return c.transfer(acct, to, amount, c.Header.MaxSpend)
+	return c.transfer(&c.PrincipalAccount, to, amount, c.Header.MaxSpend)
 }
 
 func safeAdd(a, b uint64) (uint64, error) {
@@ -259,13 +268,9 @@ func (c *Context) GasSpent() uint64 {
 
 // Consume gas from the account after validation passes.
 func (c *Context) Consume(gas uint64) (err error) {
-	principalAccount, err := c.PrincipalAccount()
-	if err != nil {
-		return err
-	}
 	amount := gas * c.Header.GasPrice
-	if amount > principalAccount.Balance {
-		amount = principalAccount.Balance
+	if amount > c.Balance() {
+		amount = c.Balance()
 		err = ErrOutOfGas
 	} else if total := c.consumed + gas; total > c.Header.MaxGas {
 		gas = c.Header.MaxGas - c.consumed
@@ -274,12 +279,12 @@ func (c *Context) Consume(gas uint64) (err error) {
 	}
 	c.consumed += gas
 	c.fee += amount
-	principalAccount.Balance -= amount
-	c.change(principalAccount)
+	c.PrincipalAccount.Balance -= amount
+	c.change(&c.PrincipalAccount)
 
 	c.Logger.Debug(
 		"consume",
-		zap.String("principal", c.PrincipalAddress.String()),
+		zap.Stringer("principal", c.Principal()),
 		zap.Uint64("gas", gas),
 		zap.Uint64("fee", amount),
 		zap.Uint64("consumed", c.consumed),
@@ -292,19 +297,15 @@ func (c *Context) Consume(gas uint64) (err error) {
 func (c *Context) Refund() (err error) {
 	// TODO(lane): safe math
 	unspent := c.consumed - c.gasSpent
-	principalAccount, err := c.PrincipalAccount()
-	if err != nil {
-		return err
-	}
 	amount := unspent * c.Header.GasPrice
 	c.consumed -= unspent
 	c.fee -= amount
-	principalAccount.Balance += amount
-	c.change(principalAccount)
+	c.PrincipalAccount.Balance += amount
+	c.change(&c.PrincipalAccount)
 
 	c.Logger.Debug(
 		"refund",
-		zap.String("principal", c.PrincipalAddress.String()),
+		zap.Stringer("principal", c.Principal()),
 		zap.Uint64("consumed", c.consumed),
 		zap.Uint64("gas spent", c.gasSpent),
 		zap.Uint64("unspent gas", unspent),
@@ -316,16 +317,12 @@ func (c *Context) Refund() (err error) {
 
 // Apply is executed if transaction was consumed.
 func (c *Context) Apply(updater AccountUpdater) error {
-	acct, err := c.PrincipalAccount()
-	if err != nil {
-		return err
-	}
-	acct.NextNonce = c.Header.Nonce + 1
-	if err := updater.Update(*acct); err != nil {
+	c.PrincipalAccount.NextNonce = c.Header.Nonce + 1
+	if err := updater.Update(c.PrincipalAccount); err != nil {
 		return fmt.Errorf("%w: %w", ErrInternal, err)
 	}
 	for _, address := range c.touched {
-		if address == c.PrincipalAddress {
+		if address == c.PrincipalAccount.Address {
 			continue
 		}
 		account := c.changed[address]
@@ -361,24 +358,20 @@ func (c *Context) Has(address types.Address) (bool, error) {
 	return true, nil
 }
 
-func (c *Context) Get(address types.Address) (Account, error) {
-	addr, err := c.load(address)
-	return *addr, err
+func (c *Context) Get(address types.Address) (*Account, error) {
+	return c.load(address)
 }
 
 func (c *Context) load(address types.Address) (*Account, error) {
-	if c.changed == nil {
-		c.changed = map[Address]*Account{}
-	}
 	account, exist := c.changed[address]
-	if !exist {
-		loaded, err := c.Loader.Get(address)
-		if err != nil {
-			return nil, fmt.Errorf("%w: error loading account: %w", ErrInternal, err)
-		}
-		account = &loaded
+	if exist {
+		return account, nil
 	}
-	return account, nil
+	loaded, err := c.Loader.Get(address)
+	if err != nil {
+		return nil, fmt.Errorf("%w: error loading account: %w", ErrInternal, err)
+	}
+	return &loaded, nil
 }
 
 func (c *Context) change(account *Account) {

--- a/vm/core/context_test.go
+++ b/vm/core/context_test.go
@@ -5,26 +5,36 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+	"go.uber.org/zap/zaptest"
 
-	"github.com/spacemeshos/go-spacemesh/genvm/core"
-	"github.com/spacemeshos/go-spacemesh/genvm/core/mocks"
+	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/sql/statesql"
+	"github.com/spacemeshos/go-spacemesh/vm/core"
+	"github.com/spacemeshos/go-spacemesh/vm/core/mocks"
+	"github.com/spacemeshos/go-spacemesh/vm/registry"
 )
 
 func TestTransfer(t *testing.T) {
+	var principal types.Address
 	t.Run("NoBalance", func(t *testing.T) {
-		ctx := core.Context{Loader: core.NewStagedCache(core.DBLoader{Executor: statesql.InMemory()})}
-		require.ErrorIs(t, ctx.Transfer(core.Address{}, 100), core.ErrNoBalance)
+		cache := core.NewStagedCache(core.DBLoader{statesql.InMemoryTest(t)})
+		ctx, err := core.New(types.Hash20{}, 0, principal, cache, registry.New(), zaptest.NewLogger(t))
+		require.NoError(t, err)
+		require.ErrorIs(t, ctx.Transfer(principal, 100), core.ErrNoBalance)
 	})
 	t.Run("MaxSpend", func(t *testing.T) {
-		ctx := core.Context{Loader: core.NewStagedCache(core.DBLoader{Executor: statesql.InMemory()})}
+		cache := core.NewStagedCache(core.DBLoader{statesql.InMemoryTest(t)})
+		ctx, err := core.New(types.Hash20{}, 0, principal, cache, registry.New(), zaptest.NewLogger(t))
+		require.NoError(t, err)
 		ctx.PrincipalAccount.Balance = 1000
 		ctx.Header.MaxSpend = 100
 		require.NoError(t, ctx.Transfer(core.Address{1}, 50))
 		require.ErrorIs(t, ctx.Transfer(core.Address{2}, 100), core.ErrMaxSpend)
 	})
 	t.Run("ReducesBalance", func(t *testing.T) {
-		ctx := core.Context{Loader: core.NewStagedCache(core.DBLoader{Executor: statesql.InMemory()})}
+		cache := core.NewStagedCache(core.DBLoader{statesql.InMemoryTest(t)})
+		ctx, err := core.New(types.Hash20{}, 0, principal, cache, registry.New(), zaptest.NewLogger(t))
+		require.NoError(t, err)
 		ctx.PrincipalAccount.Balance = 1000
 		ctx.Header.MaxSpend = 1000
 		for _, amount := range []uint64{50, 100, 200, 255} {
@@ -37,20 +47,27 @@ func TestTransfer(t *testing.T) {
 }
 
 func TestConsume(t *testing.T) {
+	var principal types.Address
 	t.Run("OutOfGas", func(t *testing.T) {
-		ctx := core.Context{}
+		cache := core.NewStagedCache(core.DBLoader{statesql.InMemoryTest(t)})
+		ctx, err := core.New(types.Hash20{}, 0, principal, cache, registry.New(), zaptest.NewLogger(t))
+		require.NoError(t, err)
 		ctx.Header.GasPrice = 1
 		require.ErrorIs(t, ctx.Consume(100), core.ErrOutOfGas)
 	})
 	t.Run("MaxGas", func(t *testing.T) {
-		ctx := core.Context{}
+		cache := core.NewStagedCache(core.DBLoader{statesql.InMemoryTest(t)})
+		ctx, err := core.New(types.Hash20{}, 0, principal, cache, registry.New(), zaptest.NewLogger(t))
+		require.NoError(t, err)
 		ctx.PrincipalAccount.Balance = 200
 		ctx.Header.GasPrice = 2
 		ctx.Header.MaxGas = 10
 		require.ErrorIs(t, ctx.Consume(100), core.ErrMaxGas)
 	})
 	t.Run("ReducesBalance", func(t *testing.T) {
-		ctx := core.Context{}
+		cache := core.NewStagedCache(core.DBLoader{statesql.InMemoryTest(t)})
+		ctx, err := core.New(types.Hash20{}, 0, principal, cache, registry.New(), zaptest.NewLogger(t))
+		require.NoError(t, err)
 		ctx.PrincipalAccount.Balance = 1000
 		ctx.Header.GasPrice = 1
 		ctx.Header.MaxGas = 1000
@@ -64,23 +81,26 @@ func TestConsume(t *testing.T) {
 }
 
 func TestApply(t *testing.T) {
+	var principal types.Address
 	t.Run("UpdatesNonce", func(t *testing.T) {
-		ss := core.NewStagedCache(core.DBLoader{Executor: statesql.InMemory()})
-		ctx := core.Context{Loader: ss}
+		cache := core.NewStagedCache(core.DBLoader{statesql.InMemoryTest(t)})
+		ctx, err := core.New(types.Hash20{}, 0, principal, cache, registry.New(), zaptest.NewLogger(t))
+		require.NoError(t, err)
 		ctx.PrincipalAccount.Address = core.Address{1}
 		ctx.Header.Nonce = 10
 
-		err := ctx.Apply(ss)
+		err = ctx.Apply(cache)
 		require.NoError(t, err)
 
-		account, err := ss.Get(ctx.PrincipalAccount.Address)
+		account, err := cache.Get(ctx.PrincipalAccount.Address)
 		require.NoError(t, err)
 		require.Equal(t, ctx.PrincipalAccount.NextNonce, account.NextNonce)
 	})
 	t.Run("ConsumeMaxGas", func(t *testing.T) {
-		ss := core.NewStagedCache(core.DBLoader{Executor: statesql.InMemory()})
+		cache := core.NewStagedCache(core.DBLoader{statesql.InMemoryTest(t)})
+		ctx, err := core.New(types.Hash20{}, 0, principal, cache, registry.New(), zaptest.NewLogger(t))
+		require.NoError(t, err)
 
-		ctx := core.Context{Loader: ss}
 		ctx.PrincipalAccount.Balance = 1000
 		ctx.Header.GasPrice = 2
 		ctx.Header.MaxGas = 10
@@ -90,12 +110,14 @@ func TestApply(t *testing.T) {
 
 		require.NoError(t, ctx.Consume(5))
 		require.ErrorIs(t, ctx.Consume(100), core.ErrMaxGas)
-		err := ctx.Apply(ss)
+		err = ctx.Apply(cache)
 		require.NoError(t, err)
 		require.Equal(t, ctx.Fee(), ctx.Header.MaxGas*ctx.Header.GasPrice)
 	})
 	t.Run("PreserveTransferOrder", func(t *testing.T) {
-		ctx := core.Context{Loader: core.NewStagedCache(core.DBLoader{Executor: statesql.InMemory()})}
+		cache := core.NewStagedCache(core.DBLoader{statesql.InMemoryTest(t)})
+		ctx, err := core.New(types.Hash20{}, 0, principal, cache, registry.New(), zaptest.NewLogger(t))
+		require.NoError(t, err)
 		ctx.PrincipalAccount.Address = core.Address{1}
 		ctx.PrincipalAccount.Balance = 1000
 		ctx.Header.MaxSpend = 1000
@@ -114,7 +136,7 @@ func TestApply(t *testing.T) {
 			actual = append(actual, account.Address)
 			return nil
 		}).AnyTimes()
-		err := ctx.Apply(updater)
+		err = ctx.Apply(updater)
 		require.NoError(t, err)
 		require.Equal(t, order, actual)
 	})

--- a/vm/core/hash.go
+++ b/vm/core/hash.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/hash"
-	"github.com/spacemeshos/go-spacemesh/signing"
 )
 
 func SigningBody(genesis, tx []byte) []byte {
@@ -28,12 +27,12 @@ func ComputePrincipalFromBlob(template types.Address, blob []byte) Address {
 	return types.GenerateAddress(sum)
 }
 
-func ComputePrincipalFromPubkey(template types.Address, pubkey signing.PublicKey) Address {
+func ComputePrincipalFromPubkey(template types.Address, pubkey []byte) Address {
 	// construct and encode the blob, which is a SCALE-encoded Athena wallet template instance
 	blob, err := scale.Marshal(struct {
 		Nonce, Balance uint64
 		Owner          [32]byte
-	}{0, 0, [32]byte(pubkey.PublicKey)})
+	}{0, 0, [32]byte(pubkey)})
 	if err != nil {
 		panic(fmt.Sprintf("scale-encoding spawn args failed: %s", err))
 	}

--- a/vm/core/mocks/host.go
+++ b/vm/core/mocks/host.go
@@ -41,12 +41,11 @@ func (m *MockHost) EXPECT() *MockHostMockRecorder {
 }
 
 // Balance mocks base method.
-func (m *MockHost) Balance() (uint64, error) {
+func (m *MockHost) Balance() uint64 {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Balance")
 	ret0, _ := ret[0].(uint64)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	return ret0
 }
 
 // Balance indicates an expected call of Balance.
@@ -62,19 +61,19 @@ type MockHostBalanceCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockHostBalanceCall) Return(arg0 uint64, arg1 error) *MockHostBalanceCall {
-	c.Call = c.Call.Return(arg0, arg1)
+func (c *MockHostBalanceCall) Return(arg0 uint64) *MockHostBalanceCall {
+	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockHostBalanceCall) Do(f func() (uint64, error)) *MockHostBalanceCall {
+func (c *MockHostBalanceCall) Do(f func() uint64) *MockHostBalanceCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockHostBalanceCall) DoAndReturn(f func() (uint64, error)) *MockHostBalanceCall {
+func (c *MockHostBalanceCall) DoAndReturn(f func() uint64) *MockHostBalanceCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -194,10 +193,10 @@ func (c *MockHostGasSpentCall) DoAndReturn(f func() uint64) *MockHostGasSpentCal
 }
 
 // Get mocks base method.
-func (m *MockHost) Get(arg0 types.Address) (types.Account, error) {
+func (m *MockHost) Get(arg0 types.Address) (*types.Account, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", arg0)
-	ret0, _ := ret[0].(types.Account)
+	ret0, _ := ret[0].(*types.Account)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -215,19 +214,19 @@ type MockHostGetCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockHostGetCall) Return(arg0 types.Account, arg1 error) *MockHostGetCall {
+func (c *MockHostGetCall) Return(arg0 *types.Account, arg1 error) *MockHostGetCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockHostGetCall) Do(f func(types.Address) (types.Account, error)) *MockHostGetCall {
+func (c *MockHostGetCall) Do(f func(types.Address) (*types.Account, error)) *MockHostGetCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockHostGetCall) DoAndReturn(f func(types.Address) (types.Account, error)) *MockHostGetCall {
+func (c *MockHostGetCall) DoAndReturn(f func(types.Address) (*types.Account, error)) *MockHostGetCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/vm/core/types.go
+++ b/vm/core/types.go
@@ -112,11 +112,11 @@ type Host interface {
 	Spawn(Address, []byte) (Address, error)
 	SetStorage(Address, [32]byte, [32]byte) (StorageStatus, error)
 	Has(Address) (bool, error)
-	Get(Address) (Account, error)
+	Get(Address) (*Account, error)
 	Template() Template
 	Layer() LayerID
 	GetGenesisID() Hash20
-	Balance() (uint64, error)
+	Balance() uint64
 	IsSpawn() bool
 }
 

--- a/vm/host/host_test.go
+++ b/vm/host/host_test.go
@@ -10,11 +10,13 @@ import (
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/sql/statesql"
 	"github.com/spacemeshos/go-spacemesh/vm/core"
+	"github.com/spacemeshos/go-spacemesh/vm/registry"
 )
 
 func getHost(t *testing.T) (*Host, *core.StagedCache) {
 	cache := core.NewStagedCache(core.DBLoader{Executor: statesql.InMemoryTest(t)})
-	ctx := &core.Context{Loader: cache, Logger: zaptest.NewLogger(t)}
+	ctx, err := core.New(types.Hash20{}, 0, types.Address{}, cache, registry.New(), zaptest.NewLogger(t))
+	require.NoError(t, err)
 	host, err := NewHost(ctx)
 	require.NoError(t, err)
 	t.Cleanup(host.Destroy)

--- a/vm/host/mocks/host.go
+++ b/vm/host/mocks/host.go
@@ -41,12 +41,11 @@ func (m *MockHost) EXPECT() *MockHostMockRecorder {
 }
 
 // Balance mocks base method.
-func (m *MockHost) Balance() (uint64, error) {
+func (m *MockHost) Balance() uint64 {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Balance")
 	ret0, _ := ret[0].(uint64)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	return ret0
 }
 
 // Balance indicates an expected call of Balance.
@@ -62,19 +61,19 @@ type MockHostBalanceCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockHostBalanceCall) Return(arg0 uint64, arg1 error) *MockHostBalanceCall {
-	c.Call = c.Call.Return(arg0, arg1)
+func (c *MockHostBalanceCall) Return(arg0 uint64) *MockHostBalanceCall {
+	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockHostBalanceCall) Do(f func() (uint64, error)) *MockHostBalanceCall {
+func (c *MockHostBalanceCall) Do(f func() uint64) *MockHostBalanceCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockHostBalanceCall) DoAndReturn(f func() (uint64, error)) *MockHostBalanceCall {
+func (c *MockHostBalanceCall) DoAndReturn(f func() uint64) *MockHostBalanceCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -194,10 +193,10 @@ func (c *MockHostGasSpentCall) DoAndReturn(f func() uint64) *MockHostGasSpentCal
 }
 
 // Get mocks base method.
-func (m *MockHost) Get(arg0 types.Address) (types.Account, error) {
+func (m *MockHost) Get(arg0 types.Address) (*types.Account, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", arg0)
-	ret0, _ := ret[0].(types.Account)
+	ret0, _ := ret[0].(*types.Account)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -215,19 +214,19 @@ type MockHostGetCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockHostGetCall) Return(arg0 types.Account, arg1 error) *MockHostGetCall {
+func (c *MockHostGetCall) Return(arg0 *types.Account, arg1 error) *MockHostGetCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockHostGetCall) Do(f func(types.Address) (types.Account, error)) *MockHostGetCall {
+func (c *MockHostGetCall) Do(f func(types.Address) (*types.Account, error)) *MockHostGetCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockHostGetCall) DoAndReturn(f func(types.Address) (types.Account, error)) *MockHostGetCall {
+func (c *MockHostGetCall) DoAndReturn(f func(types.Address) (*types.Account, error)) *MockHostGetCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/vm/sdk/wallet/address.go
+++ b/vm/sdk/wallet/address.go
@@ -2,12 +2,11 @@ package wallet
 
 import (
 	"github.com/spacemeshos/go-spacemesh/common/types"
-	"github.com/spacemeshos/go-spacemesh/signing"
 	"github.com/spacemeshos/go-spacemesh/vm/core"
 	"github.com/spacemeshos/go-spacemesh/vm/templates/wallet"
 )
 
 // Address computes wallet address from the public key.
-func Address(pub signing.PublicKey) types.Address {
+func Address(pub []byte) types.Address {
 	return core.ComputePrincipalFromPubkey(wallet.TemplateAddress, pub)
 }

--- a/vm/sdk/wallet/tx.go
+++ b/vm/sdk/wallet/tx.go
@@ -55,7 +55,7 @@ func Spawn(
 
 	// note that principal is computed from pk
 	athenaPayload := vmlib.EncodeTxSpawn(athcon.Bytes32(signing.Public(pk)))
-	principal := core.ComputePrincipalFromPubkey(wallet.TemplateAddress, *signing.NewPublicKey(signing.Public(pk)))
+	principal := core.ComputePrincipalFromPubkey(wallet.TemplateAddress, signing.Public(pk))
 	payload := core.Payload(athenaPayload)
 
 	// The payload is already encoded. Why, might you ask, are we encoding it again?
@@ -88,7 +88,7 @@ func Spend(pk signing.PrivateKey, to types.Address, amount uint64, nonce types.N
 		panic(fmt.Errorf("loading Athena VM: %w", err))
 	}
 
-	principal := core.ComputePrincipalFromPubkey(wallet.TemplateAddress, *signing.NewPublicKey(signing.Public(pk)))
+	principal := core.ComputePrincipalFromPubkey(wallet.TemplateAddress, signing.Public(pk))
 	payload := core.Payload(vmlib.EncodeTxSpend(athcon.Address(to), amount))
 
 	meta := core.Metadata{}

--- a/vm/templates/wallet/methods.go
+++ b/vm/templates/wallet/methods.go
@@ -44,7 +44,7 @@ func ParseArgs(payload athcon.Payload) (any, error) {
 	case spendSelector:
 		txArgs = new(SpendArgs)
 	default:
-		return nil, fmt.Errorf("unknown method selector %s", payload.Selector.String())
+		return nil, fmt.Errorf("unknown method selector %q", payload.Selector.String())
 	}
 	err := gossamerScale.Unmarshal(payload.Input, txArgs)
 	if err != nil {

--- a/vm/templates/wallet/methods.go
+++ b/vm/templates/wallet/methods.go
@@ -1,0 +1,55 @@
+package wallet
+
+import (
+	"errors"
+	"fmt"
+
+	gossamerScale "github.com/ChainSafe/gossamer/pkg/scale"
+	athcon "github.com/athenavm/athena/ffi/athcon/bindings/go"
+
+	"github.com/spacemeshos/go-spacemesh/common/types"
+)
+
+var spawnSelector, spendSelector athcon.MethodSelector
+
+func init() {
+	var err error
+	spawnSelector, err = athcon.FromString("athexp_spawn")
+	if err != nil {
+		panic(err.Error())
+	}
+	spendSelector, err = athcon.FromString("athexp_spend")
+	if err != nil {
+		panic(err.Error())
+	}
+}
+
+type SpawnArgs struct {
+	Pubkey [32]byte
+}
+
+type SpendArgs struct {
+	To     types.Address
+	Amount uint64
+}
+
+func ParseArgs(payload athcon.Payload) (any, error) {
+	if payload.Selector == nil {
+		return nil, errors.New("nil method selector")
+	}
+	var txArgs any
+	switch *payload.Selector {
+	case spawnSelector:
+		txArgs = new(SpawnArgs)
+	case spendSelector:
+		txArgs = new(SpendArgs)
+	default:
+		return nil, fmt.Errorf("unknown method selector %s", payload.Selector.String())
+	}
+	err := gossamerScale.Unmarshal(payload.Input, txArgs)
+	if err != nil {
+		return nil, fmt.Errorf("malformed tx arguments payload: %w", err)
+	}
+
+	return txArgs, nil
+}

--- a/vm/templates/wallet/wallet_test.go
+++ b/vm/templates/wallet/wallet_test.go
@@ -90,17 +90,17 @@ func TestSpawn(t *testing.T) {
 	mockTemplate := types.Account{
 		State: walletTemplate.PROGRAM,
 	}
-	mockHost.EXPECT().Layer().Return(core.LayerID(1)).Times(1)
+	mockHost.EXPECT().Layer().Return(core.LayerID(1))
 	mockHost.EXPECT().Principal().Return(principalAddress).Times(6)
-	mockHost.EXPECT().MaxGas().Return(100000).Times(1)
-	mockHost.EXPECT().SpendGas(uint64(5036)).Times(1)
+	mockHost.EXPECT().MaxGas().Return(100000)
+	mockHost.EXPECT().SpendGas(uint64(5036))
 	mockHost.EXPECT().TemplateAddress().Return(templateAddress).Times(2)
-	mockHost.EXPECT().Nonce().Return(uint64(0)).Times(1)
-	mockHost.EXPECT().IsSpawn().Return(true).Times(1)
-	mockHost.EXPECT().GasSpent().Return(uint64(0)).Times(1)
-	mockHost.EXPECT().Get(templateAddress).Return(mockTemplate, nil).Times(1)
-	mockHost.EXPECT().Get(principalAddress).Return(types.Account{}, nil).Times(1)
-	mockHost.EXPECT().Spawn(gomock.Any(), gomock.Any()).Return(expectedPrincipalAddress, nil).Times(1)
+	mockHost.EXPECT().Nonce().Return(uint64(0))
+	mockHost.EXPECT().IsSpawn().Return(true)
+	mockHost.EXPECT().GasSpent().Return(uint64(0))
+	mockHost.EXPECT().Get(templateAddress).Return(&mockTemplate, nil)
+	mockHost.EXPECT().Get(principalAddress).Return(&types.Account{}, nil)
+	mockHost.EXPECT().Spawn(gomock.Any(), gomock.Any()).Return(expectedPrincipalAddress, nil)
 
 	// point to the library path
 	libPath, err := host.AthenaLibPath()
@@ -145,8 +145,8 @@ func TestVerify(t *testing.T) {
 	mockHost.EXPECT().Principal().Return(types.Address{2}).Times(11)
 	mockHost.EXPECT().MaxGas().Return(100000000).Times(2)
 	mockHost.EXPECT().TemplateAddress().Return(types.Address{1}).Times(3)
-	mockHost.EXPECT().Get(types.Address{1}).Return(mockTemplate, nil).Times(1)
-	mockHost.EXPECT().Get(types.Address{2}).Return(mockWallet, nil).Times(1)
+	mockHost.EXPECT().Get(types.Address{1}).Return(&mockTemplate, nil).Times(1)
+	mockHost.EXPECT().Get(types.Address{2}).Return(&mockWallet, nil).Times(1)
 	mockHost.EXPECT().IsSpawn().Return(false).Times(3)
 	mockHost.EXPECT().Clone().Return(mockHost).Times(2)
 	mockHost.EXPECT().Nonce().Return(uint64(0)).Times(2)

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -580,8 +580,8 @@ func parse(
 
 		computedPrincipal := core.ComputePrincipalFromPubkey(ctx.Header.TemplateAddress, args.Pubkey[:])
 		if computedPrincipal != principal {
-			return nil, nil, fmt.Errorf(
-				"%w: calculated spawn principal does not match %s", core.ErrMalformed, principal.String())
+			return nil, nil, fmt.Errorf("%w: computed spawn principal %q does not match %q",
+				core.ErrMalformed, computedPrincipal.String(), principal.String())
 		}
 	case *wallet.SpendArgs:
 		if ctx.PrincipalAccount.TemplateAddress == nil {

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -560,6 +560,9 @@ func parse(
 		return nil, nil, fmt.Errorf("%w: malformed TX payload: %w", core.ErrMalformed, err)
 	}
 	args, err := wallet.ParseArgs(payload)
+	if err != nil {
+		return nil, nil, fmt.Errorf("%w: parsing TX arguments: %w", core.ErrMalformed, err)
+	}
 
 	// now that the tx has been parsed, we can perform some more sanity checks.
 	// if this is a spawn for an account that was already spawned, we may

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -16,7 +16,6 @@ import (
 	"github.com/spacemeshos/go-spacemesh/events"
 	"github.com/spacemeshos/go-spacemesh/hash"
 	"github.com/spacemeshos/go-spacemesh/log"
-	"github.com/spacemeshos/go-spacemesh/signing"
 	"github.com/spacemeshos/go-spacemesh/sql"
 	"github.com/spacemeshos/go-spacemesh/sql/accounts"
 	"github.com/spacemeshos/go-spacemesh/sql/layers"
@@ -259,7 +258,7 @@ func (v *VM) Apply(
 	ss.IterateChanged(func(account *core.Account) bool {
 		if err := events.ReportAccountUpdate(account.Address); err != nil {
 			v.logger.Error("Failed to emit account update",
-				zap.String("account", account.Address.String()),
+				zap.Stringer("account", account.Address),
 				zap.Error(err),
 			)
 		}
@@ -329,20 +328,17 @@ func (v *VM) execute(
 		if header.GasPrice == 0 {
 			logger.Warn("ineffective transaction. zero gas price",
 				zap.Object("header", header),
-				zap.String("account", ctx.PrincipalAddress.String()),
+				zap.Stringer("account", ctx.Principal()),
 			)
 			ineffective = append(ineffective, types.Transaction{RawTx: tx.GetRaw()})
 			invalidTxCount.Inc()
 			continue
 		}
-		balance, err := ctx.Balance()
-		if err != nil {
-			return nil, nil, 0, fmt.Errorf("%w: error getting balance: %w", core.ErrInternal, err)
-		}
+		balance := ctx.Balance()
 		if intrinsic := core.IntrinsicGas(ctx.Gas.BaseGas, tx.GetRaw().Raw); balance < intrinsic {
 			logger.Warn("ineffective transaction. intrinsic gas not covered",
 				zap.Object("header", header),
-				zap.String("account", ctx.PrincipalAddress.String()),
+				zap.Stringer("account", ctx.Principal()),
 				zap.Uint64("intrinsic gas", intrinsic),
 			)
 			ineffective = append(ineffective, types.Transaction{RawTx: tx.GetRaw()})
@@ -354,7 +350,7 @@ func (v *VM) execute(
 				zap.Uint64("block gas limit", v.cfg.GasLimit),
 				zap.Uint64("current limit", limit),
 				zap.Object("header", header),
-				zap.String("account", ctx.PrincipalAddress.String()),
+				zap.Stringer("account", ctx.Principal()),
 			)
 			ineffective = append(ineffective, types.Transaction{RawTx: tx.GetRaw()})
 			invalidTxCount.Inc()
@@ -365,9 +361,9 @@ func (v *VM) execute(
 		// when saved into database by txs module
 		if !tx.Verified() && !req.Verify() {
 			logger.Warn("ineffective transaction. failed verify",
-				zap.String("txid", tx.GetRaw().ID.String()),
+				zap.Stringer("txid", tx.GetRaw().ID),
 				zap.Object("header", header),
-				zap.String("account", ctx.PrincipalAddress.String()),
+				zap.Stringer("account", ctx.Principal()),
 				zap.Object("payload", ctx.Payload()),
 			)
 			ineffective = append(ineffective, types.Transaction{RawTx: tx.GetRaw()})
@@ -378,7 +374,7 @@ func (v *VM) execute(
 		if ctx.NextNonce() > ctx.Header.Nonce {
 			logger.Warn("ineffective transaction. nonce too low",
 				zap.Object("header", header),
-				zap.String("account", ctx.PrincipalAddress.String()),
+				zap.Stringer("account", ctx.Principal()),
 			)
 			ineffective = append(ineffective, types.Transaction{RawTx: tx.GetRaw(), TxHeader: header})
 			invalidTxCount.Inc()
@@ -387,9 +383,9 @@ func (v *VM) execute(
 
 		t2 := time.Now()
 		logger.Debug("applying transaction",
-			zap.String("txid", tx.GetRaw().ID.String()),
+			zap.Stringer("txid", tx.GetRaw().ID),
 			zap.Object("header", header),
-			zap.String("account", ctx.PrincipalAddress.String()),
+			zap.Stringer("account", ctx.Principal()),
 			zap.Object("payload", ctx.Payload()),
 		)
 
@@ -398,7 +394,7 @@ func (v *VM) execute(
 
 		err = ctx.Consume(ctx.Header.MaxGas)
 		logger.Debug("consumed max gas from principal",
-			zap.String("principal", ctx.PrincipalAddress.String()),
+			zap.Stringer("account", ctx.Principal()),
 			zap.Uint64("maxgas", ctx.Header.MaxGas),
 		)
 		if err == nil {
@@ -411,7 +407,7 @@ func (v *VM) execute(
 				return nil, nil, 0, fmt.Errorf("%w: refunding gas %w", core.ErrInternal, err2)
 			}
 			logger.Debug("refunded gas left to principal",
-				zap.String("principal", ctx.PrincipalAddress.String()),
+				zap.Stringer("principal", ctx.Principal()),
 			)
 		} else {
 			logger.Debug("skipping gas refund for failed tx")
@@ -419,7 +415,7 @@ func (v *VM) execute(
 		if err != nil {
 			logger.Debug("transaction failed",
 				zap.Object("header", header),
-				zap.String("account", ctx.PrincipalAddress.String()),
+				zap.Stringer("account", ctx.Principal()),
 				zap.Error(err),
 			)
 			if errors.Is(err, core.ErrInternal) {
@@ -515,33 +511,15 @@ func parse(
 	if _, err := principal.DecodeScale(decoder); err != nil {
 		return nil, nil, fmt.Errorf("%w failed to decode principal: %w", core.ErrMalformed, err)
 	}
-	principalAccount, err := loader.Get(principal)
+	ctx, err := core.New(cfg.GenesisID, lid, principal, loader, reg, logger)
 	if err != nil {
-		return nil, nil, fmt.Errorf(
-			"%w: failed load state for principal %s - %w",
-			core.ErrInternal,
-			principal,
-			err,
-		)
-	}
-	logger.Debug("loaded principal account state", zap.Inline(&principalAccount))
-
-	ctx := &core.Context{
-		GenesisID:          cfg.GenesisID,
-		Registry:           reg,
-		Loader:             loader,
-		PrincipalAddress:   principal,
-		PrincipalNextNonce: principalAccount.NextNonce,
-		LayerID:            lid,
-		Logger:             logger,
+		return nil, nil, fmt.Errorf("creating new context: %w", err)
 	}
 
-	// There are three cases to consider:
-	// 1. Principal account does not exist at all (and has no balance). In this case, we can fail
-	// the tx immediately.
-	// 2. Principal account exists, and is spawned. In this case, we use the principal account
+	// There are two cases to consider:
+	// 1. Principal account exists, and is spawned. In this case, we use the principal account
 	// template.
-	// 3. Principal account exists as a stub with a nonzero balance, but has not been spawned. In
+	// 2. Principal account exists as a stub with a nonzero balance, but has not been spawned. In
 	// this case, we assume the tx is a self-spawn for the principal, and check that the calculated
 	// principal matches.
 
@@ -550,33 +528,18 @@ func parse(
 	// is passed not explicitly as part of the tx, but implicitly in the args. This simplifies the
 	// logic here considerably.
 
-	ctx.Header.MaxGas = core.ATHENA_GAS_SPEND + core.ATHENA_GAS_VERIFY
-	if principalAccount.Address == (types.Address{}) {
-		// case 1: principal account does not exist at all
-		return nil, nil, fmt.Errorf("%w: principal account %s does not exist", core.ErrMalformed, principal)
-	} else if principalAccount.TemplateAddress != nil {
-		// case 2: principal account exists and is spawned
-		// attempt to load its template handler
-		// Note: the Wallet template is currently the only supported template, so we could skip this
-		// step and hardcode it here. But this is written in a more future-proof fashion, since we
-		// intend to add support for multiple templates soon.
-		ctx.PrincipalHandler = reg.Get(*principalAccount.TemplateAddress)
-		if ctx.PrincipalHandler == nil {
-			return nil, nil, fmt.Errorf("%w: unknown template %s", core.ErrMalformed, principalAccount.TemplateAddress)
-		}
-		ctx.Header.TemplateAddress = *principalAccount.TemplateAddress
-	} else {
-		// case 3: principal account exists but is not spawned
-		// go ahead and assume it's a self-spawn for a Wallet template
-		ctx.PrincipalHandler = reg.Get(wallet.TemplateAddress)
-		if ctx.PrincipalHandler == nil {
-			return nil, nil, fmt.Errorf("%w: wallet template missing", core.ErrInternal)
-		}
-		ctx.Header.TemplateAddress = wallet.TemplateAddress
-		ctx.SpawnTx = true
-		ctx.Header.MaxGas = core.ATHENA_GAS_SPAWN + core.ATHENA_GAS_VERIFY
+	// TODO: a spawn TX should carry the template address from TX
+	// For now, we assume a single-sig wallet template if the principal is not
+	// spawned yet.
+	ctx.Header.TemplateAddress = wallet.TemplateAddress
+	if addr := ctx.PrincipalAccount.TemplateAddress; addr != nil {
+		ctx.Header.TemplateAddress = *addr
 	}
-
+	handler := reg.Get(ctx.Header.TemplateAddress)
+	if handler == nil {
+		return nil, nil, fmt.Errorf("%w: unknown template %s", core.ErrMalformed, ctx.Header.TemplateAddress)
+	}
+	ctx.PrincipalHandler = handler
 	// now that we have a template handler, go ahead and parse the tx
 	output, err := ctx.PrincipalHandler.Parse(decoder)
 	if err != nil {
@@ -591,37 +554,40 @@ func parse(
 	// account will be spawned to the wrong location, but it's much cheaper to perform this check
 	// now and fail fast.
 
-	// in order to calculate the principal, we need to extract the pubkey from the spawn tx
-	var unmarshaled struct {
-		*athcon.MethodSelector
-		signing.PublicKey
-	}
-	err = gossamerScale.Unmarshal(output.Payload, &unmarshaled)
+	var payload athcon.Payload
+	err = gossamerScale.Unmarshal(output.Payload, &payload)
 	if err != nil {
-		return nil, nil, fmt.Errorf("%w: malformed spawn payload", core.ErrMalformed)
+		return nil, nil, fmt.Errorf("%w: malformed TX payload: %w", core.ErrMalformed, err)
 	}
+	args, err := wallet.ParseArgs(payload)
 
 	// now that the tx has been parsed, we can perform some more sanity checks.
 	// if this is a spawn for an account that was already spawned, we may
 	// have assumed above that it was not a spawn. now we can make sure.
 	// that this will also catch a non-spawn tx with an unspawned principal, which we
 	// provisionally assumed was a spawn tx.
-	if spawnSelector, err := athcon.FromString("athexp_spawn"); err != nil {
-		return nil, nil, fmt.Errorf("%w: failed to create spawn selector: %w", core.ErrInternal, err)
-	} else if principalAccount.TemplateAddress != nil && *unmarshaled.MethodSelector == spawnSelector {
-		return nil, nil, fmt.Errorf("%w: principal account already spawned", core.ErrMalformed)
-	} else if ctx.IsSpawn() && *unmarshaled.MethodSelector != spawnSelector {
-		return nil, nil, fmt.Errorf("%w: non-spawn tx with unspawned principal", core.ErrNotSpawned)
-	}
 
-	computedPrincipal := core.ComputePrincipalFromPubkey(
-		ctx.Header.TemplateAddress,
-		unmarshaled.PublicKey,
-	)
+	switch args := args.(type) {
+	case *wallet.SpawnArgs:
+		if ctx.PrincipalAccount.TemplateAddress != nil {
+			return nil, nil, fmt.Errorf("%w: principal account already spawned", core.ErrMalformed)
+		}
+		ctx.SpawnTx = true
+		ctx.Header.MaxGas = core.ATHENA_GAS_SPAWN + core.ATHENA_GAS_VERIFY
 
-	if ctx.IsSpawn() && computedPrincipal != principal {
-		return nil, nil, fmt.Errorf(
-			"%w: calculated spawn principal does not match %s", core.ErrMalformed, principal.String())
+		computedPrincipal := core.ComputePrincipalFromPubkey(ctx.Header.TemplateAddress, args.Pubkey[:])
+		if computedPrincipal != principal {
+			return nil, nil, fmt.Errorf(
+				"%w: calculated spawn principal does not match %s", core.ErrMalformed, principal.String())
+		}
+	case *wallet.SpendArgs:
+		if ctx.PrincipalAccount.TemplateAddress == nil {
+			return nil, nil, fmt.Errorf("%w: non-spawn tx with unspawned principal", core.ErrNotSpawned)
+		}
+
+		ctx.Header.MaxGas = core.ATHENA_GAS_SPEND + core.ATHENA_GAS_VERIFY
+	default:
+		panic("txArgs is guaranteed to be spawn or spend at this point")
 	}
 
 	// At this point we've established that the transaction is correctly formed, but we haven't

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/hash"
-	"github.com/spacemeshos/go-spacemesh/signing"
 	"github.com/spacemeshos/go-spacemesh/sql/accounts"
 	"github.com/spacemeshos/go-spacemesh/sql/layers"
 	"github.com/spacemeshos/go-spacemesh/sql/statesql"
@@ -142,7 +141,7 @@ func (t *tester) addSingleSig(n int) *tester {
 	for i := 0; i < n; i++ {
 		pub, pk, err := ed25519.GenerateKey(t.rng)
 		require.NoError(t, err)
-		address := sdkwallet.Address(*signing.NewPublicKey(pub))
+		address := sdkwallet.Address(pub)
 		t.addAccount(&singlesigAccount{pk, address}, 1_000_000_000)
 	}
 	return t


### PR DESCRIPTION
- factor out code to parse and extract arguments of the built-in wallet template
- cleanup uses of `zap.String()` where `zap.Stringer()` is possible
- cleanup logic in `vm/vm.go::parse()`
- simplify `core.Host` interface, possible by keeping the principal account in the `core.Context`
- fix tests in vm/core/context_test.go, which were testing the genvm context, not the athena one
