### PR TITLE
[Merged by Bors] - sync2: fptree: fix race in SyncedTable

### DIFF
--- a/sync2/sqlstore/syncedtable.go
+++ b/sync2/sqlstore/syncedtable.go
@@ -3,6 +3,7 @@ package sqlstore
 import (
 	"errors"
 	"fmt"
+	"sync"
 
 	"github.com/spacemeshos/go-spacemesh/sql"
 	"github.com/spacemeshos/go-spacemesh/sql/expr"
@@ -24,10 +25,13 @@ type SyncedTable struct {
 	Filter expr.Expr
 	// The binder function for the bind parameters appearing in the filter expression.
 	Binder  Binder
+	mtx     sync.Mutex
 	queries map[string]string
 }
 
 func (st *SyncedTable) cacheQuery(name string, gen func() expr.Statement) string {
+	st.mtx.Lock()
+	defer st.mtx.Unlock()
 	s, ok := st.queries[name]
 	if ok {
 		return s


### PR DESCRIPTION
## Motivation

`SyncedTable` has a tiny cache for query strings to avoid heap-intensive query formatting operations (AST->SQL string) upon each SQL query being run.
The cached query string map was not protected by a mutex.

## Description

Added missing mutex.