### PR TITLE
[athena poc] Fix systests and increase tx verify debugability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,8 @@ jobs:
       nondocchanges: ${{ steps.filter.outputs.nondoc }}
     steps:
       - uses: actions/checkout@v4
-        with:
+        with: 
+          lfs: true
           ssh-key: ${{ secrets.GH_ACTION_PRIVATE_KEY }}
       - uses: dorny/paths-filter@v3
         id: filter
@@ -68,6 +69,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
         with:
+          lfs: true
           ssh-key: ${{ secrets.GH_ACTION_PRIVATE_KEY }}
       - uses: extractions/netrc@v2
         with:
@@ -101,6 +103,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
         with:
+          lfs: true
           ssh-key: ${{ secrets.GH_ACTION_PRIVATE_KEY }}
       - uses: extractions/netrc@v2
         with:
@@ -149,6 +152,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
         with:
+          lfs: true
           ssh-key: ${{ secrets.GH_ACTION_PRIVATE_KEY }}
       - uses: extractions/netrc@v2
         with:

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -25,6 +25,7 @@ jobs:
     - name: checkout
       uses: actions/checkout@v4
       with:
+        lfs: true
         ssh-key: ${{ secrets.GH_ACTION_PRIVATE_KEY }}
 
     - uses: extractions/netrc@v2

--- a/.github/workflows/systest.yml
+++ b/.github/workflows/systest.yml
@@ -64,6 +64,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          lfs: true
           ssh-key: ${{ secrets.GH_ACTION_PRIVATE_KEY }}
 
       - name: Setup kubectl
@@ -175,7 +176,7 @@ jobs:
         env:
           test_id: systest-${{ steps.vars.outputs.sha_short }}
         run: make -C systest clean
-      
+
       - name: Delete Node Pool
         if: always()
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ ENV VERSION=${VERSION}
 RUN set -ex \
    && apt-get update --fix-missing \
    && apt-get install -qy --no-install-recommends \
+   git-lfs \
    unzip sudo \
    ocl-icd-opencl-dev
 

--- a/api/grpcserver/transaction_service.go
+++ b/api/grpcserver/transaction_service.go
@@ -86,8 +86,10 @@ func (s *TransactionService) ParseTransaction(
 	} else if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
-	if in.Verify && !req.Verify() {
-		return nil, status.Error(codes.InvalidArgument, "signature is invalid")
+	if in.Verify {
+		if err := req.Verify(); err != nil {
+			return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("tx failed verification: %v", err))
+		}
 	}
 	tx := types.Transaction{RawTx: raw, TxHeader: header}
 	return &pb.ParseTransactionResponse{Tx: castTransaction(&tx)}, nil

--- a/api/grpcserver/transaction_service_test.go
+++ b/api/grpcserver/transaction_service_test.go
@@ -302,7 +302,7 @@ func TestParseTransactions(t *testing.T) {
 			"mangled signature",
 			mangled,
 			true,
-			expectParseError(codes.InvalidArgument, "signature is invalid"),
+			expectParseError(codes.InvalidArgument, "tx failed verification"),
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {

--- a/api/grpcserver/v2alpha1/transaction.go
+++ b/api/grpcserver/v2alpha1/transaction.go
@@ -157,8 +157,10 @@ func (s *TransactionService) ParseTransaction(
 	} else if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
-	if request.Verify && !req.Verify() {
-		return nil, status.Error(codes.InvalidArgument, "signature is invalid")
+	if request.Verify {
+		if err := req.Verify(); err != nil {
+			return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("tx failed verification: %v", err))
+		}
 	}
 
 	t := &spacemeshv2alpha1.Transaction{

--- a/api/grpcserver/v2alpha1/transaction_test.go
+++ b/api/grpcserver/v2alpha1/transaction_test.go
@@ -393,7 +393,7 @@ func TestTransactionService_ParseTransaction(t *testing.T) {
 		s, ok := status.FromError(err)
 		require.True(t, ok)
 		assert.Equal(t, codes.InvalidArgument, s.Code())
-		assert.Contains(t, s.Message(), "signature is invalid")
+		assert.Contains(t, s.Message(), "tx failed verification")
 	})
 	t.Run("verify transaction contents for spend tx", func(t *testing.T) {
 		addr := accounts[3].Address

--- a/bootstrap.Dockerfile
+++ b/bootstrap.Dockerfile
@@ -2,6 +2,8 @@ FROM golang:1.23 AS builder
 
 WORKDIR /src
 
+RUN apt-get update && apt-get install git-lfs -y
+
 COPY Makefile* .
 COPY go.mod .
 COPY go.sum .

--- a/genvm/vm.go
+++ b/genvm/vm.go
@@ -363,7 +363,7 @@ func (v *VM) execute(
 
 		// NOTE this part is executed only for transactions that weren't verified
 		// when saved into database by txs module
-		if !tx.Verified() && !req.Verify() {
+		if !tx.Verified() && req.Verify() != nil {
 			logger.Warn("ineffective transaction. failed verify",
 				zap.Object("header", header),
 				zap.Object("account", &ctx.PrincipalAccount),
@@ -465,14 +465,17 @@ func (r *Request) Parse() (*core.Header, error) {
 }
 
 // Verify transaction. Will panic if called without Parse completing successfully.
-func (r *Request) Verify() bool {
+func (r *Request) Verify() error {
 	if r.ctx == nil {
 		panic("Verify should be called after successful Parse")
 	}
 	start := time.Now()
 	rst := verify(r.ctx, r.raw.Raw, r.decoder)
 	transactionDurationVerify.Observe(float64(time.Since(start)))
-	return rst
+	if !rst {
+		return errors.New("tx didn't pass verification")
+	}
+	return nil
 }
 
 func parse(

--- a/genvm/vm_test.go
+++ b/genvm/vm_test.go
@@ -1652,9 +1652,12 @@ func testValidation(t *testing.T, tt *tester, template core.Address) {
 			if tc.err != nil {
 				require.ErrorIs(t, err, tc.err)
 			} else {
-				require.Equal(t, tc.verified, req.Verify())
+				err := req.Verify()
 				if tc.verified {
+					require.NoError(t, err)
 					require.Equal(t, tc.header, header)
+				} else {
+					require.Error(t, err)
 				}
 			}
 		})
@@ -2088,7 +2091,7 @@ func TestVaultValidation(t *testing.T) {
 		header, err := req.Parse()
 		require.NoError(t, err)
 		require.NotNil(t, header)
-		require.False(t, req.Verify())
+		require.Error(t, req.Verify())
 	})
 	t.Run("spawn", func(t *testing.T) {
 		principal := tt.accounts[1].getAddress()
@@ -2103,7 +2106,7 @@ func TestVaultValidation(t *testing.T) {
 		header, err := req.Parse()
 		require.NoError(t, err)
 		require.NotNil(t, header)
-		require.False(t, req.Verify())
+		require.Error(t, req.Verify())
 	})
 	t.Run("spend", func(t *testing.T) {
 		principal := tt.accounts[1].getAddress()
@@ -2117,7 +2120,7 @@ func TestVaultValidation(t *testing.T) {
 		header, err := req.Parse()
 		require.NoError(t, err)
 		require.NotNil(t, header)
-		require.False(t, req.Verify())
+		require.Error(t, req.Verify())
 	})
 }
 
@@ -2303,12 +2306,8 @@ func BenchmarkValidation(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			req := tt.Validation(raw)
 			_, err := req.Parse()
-			if err != nil {
-				b.Fatal(err)
-			}
-			if !req.Verify() {
-				b.Fatalf("expected Verify to return true")
-			}
+			require.NoError(b, err)
+			require.NoError(b, req.Verify())
 		}
 	}
 

--- a/system/mocks/vm.go
+++ b/system/mocks/vm.go
@@ -80,10 +80,10 @@ func (c *MockValidationRequestParseCall) DoAndReturn(f func() (*types.TxHeader, 
 }
 
 // Verify mocks base method.
-func (m *MockValidationRequest) Verify() bool {
+func (m *MockValidationRequest) Verify() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Verify")
-	ret0, _ := ret[0].(bool)
+	ret0, _ := ret[0].(error)
 	return ret0
 }
 
@@ -100,19 +100,19 @@ type MockValidationRequestVerifyCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockValidationRequestVerifyCall) Return(arg0 bool) *MockValidationRequestVerifyCall {
+func (c *MockValidationRequestVerifyCall) Return(arg0 error) *MockValidationRequestVerifyCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockValidationRequestVerifyCall) Do(f func() bool) *MockValidationRequestVerifyCall {
+func (c *MockValidationRequestVerifyCall) Do(f func() error) *MockValidationRequestVerifyCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockValidationRequestVerifyCall) DoAndReturn(f func() bool) *MockValidationRequestVerifyCall {
+func (c *MockValidationRequestVerifyCall) DoAndReturn(f func() error) *MockValidationRequestVerifyCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/system/vm.go
+++ b/system/vm.go
@@ -9,5 +9,5 @@ import (
 // ValidationRequest parses transaction and verifies it.
 type ValidationRequest interface {
 	Parse() (*types.TxHeader, error)
-	Verify() bool
+	Verify() error
 }

--- a/txs/conservative_state_test.go
+++ b/txs/conservative_state_test.go
@@ -583,7 +583,7 @@ func TestConsistentHandling(t *testing.T) {
 
 			req := smocks.NewMockValidationRequest(gomock.NewController(t))
 			req.EXPECT().Parse().Return(txs[i].TxHeader, nil)
-			req.EXPECT().Verify().Return(true)
+			req.EXPECT().Verify()
 			instances[0].mvm.EXPECT().Validation(txs[i].RawTx).Return(req)
 
 			failed := smocks.NewMockValidationRequest(gomock.NewController(t))

--- a/txs/handler.go
+++ b/txs/handler.go
@@ -118,8 +118,8 @@ func (th *TxHandler) verifyAndCache(ctx context.Context, expHash types.Hash32, m
 	if header.GasPrice == 0 || header.Fee() == 0 {
 		return fmt.Errorf("%w: zero gas price %s", errParse, raw.ID)
 	}
-	if !req.Verify() {
-		return fmt.Errorf("%w: %s", errVerify, raw.ID)
+	if err := req.Verify(); err != nil {
+		return fmt.Errorf("%w: %s: %w", errVerify, raw.ID, err)
 	}
 	if err := th.state.AddToCache(ctx, tx, time.Now()); err != nil {
 		th.logger.With(log.ZContext(ctx)).Debug("failed to add tx to conservative cache",
@@ -149,9 +149,10 @@ func (th *TxHandler) HandleBlockTransaction(_ context.Context, expHash types.Has
 	req := th.state.Validation(raw)
 	header, err := req.Parse()
 	if err == nil {
-		if req.Verify() {
+		if err := req.Verify(); err == nil {
 			tx.TxHeader = header
 		} else {
+			th.logger.Debug("tx didn't pass verification", zap.Error(err))
 			blockTxCount.WithLabelValues(cantVerify).Inc()
 		}
 	} else {

--- a/txs/handler_test.go
+++ b/txs/handler_test.go
@@ -101,7 +101,7 @@ func Test_HandleBlock(t *testing.T) {
 				req.EXPECT().Parse().Return(tx.TxHeader, tc.parseErr)
 				cstate.EXPECT().Validation(tx.RawTx).Return(req)
 				if tc.parseErr == nil {
-					req.EXPECT().Verify().Return(true)
+					req.EXPECT().Verify()
 					cstate.EXPECT().
 						AddToDB(&types.Transaction{RawTx: tx.RawTx, TxHeader: tx.TxHeader}).
 						Return(tc.addErr)
@@ -149,14 +149,16 @@ func gossipExpectations(
 		req.EXPECT().Parse().Return(tx.TxHeader, parseErr)
 		cstate.EXPECT().Validation(tx.RawTx).Return(req)
 		if parseErr == nil && fee != 0 {
-			req.EXPECT().Verify().Return(verify)
 			if verify {
+				req.EXPECT().Verify()
 				cstate.EXPECT().AddToCache(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
 					func(_ context.Context, got *types.Transaction, _ time.Time) error {
 						assert.Equal(tb, tx.ID, got.ID) // causing ID to be calculated
 						assert.Equal(tb, tx, got)
 						return addErr
 					}).Times(1)
+			} else {
+				req.EXPECT().Verify().Return(errors.New("failed"))
 			}
 		}
 	}

--- a/vm/core/mocks/handler.go
+++ b/vm/core/mocks/handler.go
@@ -15,6 +15,7 @@ import (
 	scale "github.com/spacemeshos/go-scale"
 	core "github.com/spacemeshos/go-spacemesh/vm/core"
 	gomock "go.uber.org/mock/gomock"
+	zap "go.uber.org/zap"
 )
 
 // MockHandler is a mock of Handler interface.
@@ -82,18 +83,18 @@ func (c *MockHandlerExecCall) DoAndReturn(f func(core.Host, core.Payload) ([]byt
 }
 
 // New mocks base method.
-func (m *MockHandler) New(arg0 core.Host) (core.Template, error) {
+func (m *MockHandler) New(arg0 core.Host, arg1 *zap.Logger) (core.Template, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "New", arg0)
+	ret := m.ctrl.Call(m, "New", arg0, arg1)
 	ret0, _ := ret[0].(core.Template)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // New indicates an expected call of New.
-func (mr *MockHandlerMockRecorder) New(arg0 any) *MockHandlerNewCall {
+func (mr *MockHandlerMockRecorder) New(arg0, arg1 any) *MockHandlerNewCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "New", reflect.TypeOf((*MockHandler)(nil).New), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "New", reflect.TypeOf((*MockHandler)(nil).New), arg0, arg1)
 	return &MockHandlerNewCall{Call: call}
 }
 
@@ -109,13 +110,13 @@ func (c *MockHandlerNewCall) Return(arg0 core.Template, arg1 error) *MockHandler
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockHandlerNewCall) Do(f func(core.Host) (core.Template, error)) *MockHandlerNewCall {
+func (c *MockHandlerNewCall) Do(f func(core.Host, *zap.Logger) (core.Template, error)) *MockHandlerNewCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockHandlerNewCall) DoAndReturn(f func(core.Host) (core.Template, error)) *MockHandlerNewCall {
+func (c *MockHandlerNewCall) DoAndReturn(f func(core.Host, *zap.Logger) (core.Template, error)) *MockHandlerNewCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/vm/core/mocks/template.go
+++ b/vm/core/mocks/template.go
@@ -156,10 +156,10 @@ func (c *MockTemplateMaxSpendCall) DoAndReturn(f func([]byte) (uint64, error)) *
 }
 
 // Verify mocks base method.
-func (m *MockTemplate) Verify(arg0 []byte, arg1 *scale.Decoder) bool {
+func (m *MockTemplate) Verify(arg0 []byte, arg1 *scale.Decoder) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Verify", arg0, arg1)
-	ret0, _ := ret[0].(bool)
+	ret0, _ := ret[0].(error)
 	return ret0
 }
 
@@ -176,19 +176,19 @@ type MockTemplateVerifyCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockTemplateVerifyCall) Return(arg0 bool) *MockTemplateVerifyCall {
+func (c *MockTemplateVerifyCall) Return(arg0 error) *MockTemplateVerifyCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockTemplateVerifyCall) Do(f func([]byte, *scale.Decoder) bool) *MockTemplateVerifyCall {
+func (c *MockTemplateVerifyCall) Do(f func([]byte, *scale.Decoder) error) *MockTemplateVerifyCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockTemplateVerifyCall) DoAndReturn(f func([]byte, *scale.Decoder) bool) *MockTemplateVerifyCall {
+func (c *MockTemplateVerifyCall) DoAndReturn(f func([]byte, *scale.Decoder) error) *MockTemplateVerifyCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/vm/core/types.go
+++ b/vm/core/types.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 
 	"github.com/spacemeshos/go-scale"
+	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
@@ -45,7 +46,7 @@ type Handler interface {
 	Exec(Host, Payload) ([]byte, int64, error)
 
 	// New instantiates Template from host context.
-	New(Host) (Template, error)
+	New(Host, *zap.Logger) (Template, error)
 }
 
 //go:generate mockgen -typed -package=mocks -destination=./mocks/template.go github.com/spacemeshos/go-spacemesh/vm/core Template
@@ -62,7 +63,7 @@ type Template interface {
 	// LoadGas is a cost to load account from disk.
 	LoadGas() uint64
 	// Verify security of the transaction.
-	Verify([]byte, *scale.Decoder) bool
+	Verify([]byte, *scale.Decoder) error
 }
 
 //go:generate mockgen -typed -package=mocks -destination=./mocks/loader.go github.com/spacemeshos/go-spacemesh/vm/core AccountLoader

--- a/vm/templates/wallet/handler.go
+++ b/vm/templates/wallet/handler.go
@@ -6,6 +6,7 @@ import (
 
 	athcon "github.com/athenavm/athena/ffi/athcon/bindings/go"
 	"github.com/spacemeshos/go-scale"
+	"go.uber.org/zap"
 
 	"github.com/spacemeshos/go-spacemesh/vm/core"
 	vmhost "github.com/spacemeshos/go-spacemesh/vm/host"
@@ -49,8 +50,8 @@ func (*handler) Parse(decoder *scale.Decoder) (output core.ParseOutput, err erro
 }
 
 // New instatiates single sig wallet with spawn arguments.
-func (*handler) New(host core.Host) (core.Template, error) {
-	return New(host)
+func (*handler) New(host core.Host, logger *zap.Logger) (core.Template, error) {
+	return New(host, logger)
 }
 
 // Pass the transaction into the VM for execution.

--- a/vm/templates/wallet/wallet.go
+++ b/vm/templates/wallet/wallet.go
@@ -8,6 +8,7 @@ import (
 	gossamerScale "github.com/ChainSafe/gossamer/pkg/scale"
 	athcon "github.com/athenavm/athena/ffi/athcon/bindings/go"
 	"github.com/spacemeshos/go-scale"
+	"go.uber.org/zap"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/vm/core"
@@ -15,7 +16,7 @@ import (
 )
 
 // New returns Wallet instance with SpawnArguments.
-func New(host core.Host) (*Wallet, error) {
+func New(host core.Host, logger *zap.Logger) (*Wallet, error) {
 	// Load the template account
 	templateAccount, err := host.Get(host.TemplateAddress())
 	if err != nil {
@@ -38,7 +39,7 @@ func New(host core.Host) (*Wallet, error) {
 	}
 	walletState := walletAccount.State
 
-	return &Wallet{host, templateCode, walletState}, nil
+	return &Wallet{host, templateCode, walletState, logger}, nil
 }
 
 // Wallet is a single-key wallet.
@@ -46,6 +47,7 @@ type Wallet struct {
 	host         core.Host
 	templateCode []byte
 	walletState  []byte
+	logger       *zap.Logger
 }
 
 // MaxSpend returns amount specified in the SpendArguments for Spend method.
@@ -109,11 +111,11 @@ func (s *Wallet) MaxSpend(payload []byte) (uint64, error) {
 }
 
 // Verify the transaction signature using the VM.
-func (s *Wallet) Verify(raw []byte, dec *scale.Decoder) bool {
+func (s *Wallet) Verify(raw []byte, dec *scale.Decoder) error {
 	sig := core.Signature{}
 	n, err := sig.DecodeScale(dec)
 	if err != nil {
-		return false
+		return fmt.Errorf("decoding signature: %w", err)
 	}
 
 	// deconstruct the tx, temporarily removing the signature, and add the genesis ID
@@ -130,12 +132,12 @@ func (s *Wallet) Verify(raw []byte, dec *scale.Decoder) bool {
 		Sig   [64]byte
 	}{rawTx, sig})
 	if err != nil {
-		return false
+		return fmt.Errorf("marshalling verify args: %w", err)
 	}
 
 	maxgas := int64(s.host.MaxGas())
 	if maxgas < 0 {
-		return false
+		return fmt.Errorf("negative maxgas: %d", maxgas)
 	}
 
 	// Instantiate the VM
@@ -143,7 +145,7 @@ func (s *Wallet) Verify(raw []byte, dec *scale.Decoder) bool {
 	host := s.host.Clone()
 	vmhost, err := vmhost.NewHost(host)
 	if err != nil {
-		return false
+		return fmt.Errorf("creating new host: %w", err)
 	}
 	defer vmhost.Destroy()
 
@@ -152,7 +154,7 @@ func (s *Wallet) Verify(raw []byte, dec *scale.Decoder) bool {
 	if s.host.IsSpawn() {
 		if len(s.walletState) != 0 {
 			// TODO(lane): should we allow spawn to be called multiple times on the same account?
-			return false
+			return errors.New("cannot spawn multiple times")
 		}
 
 		// the transaction must already be a spawn tx, so there's no need to modify the payload.
@@ -167,17 +169,16 @@ func (s *Wallet) Verify(raw []byte, dec *scale.Decoder) bool {
 			s.templateCode,
 		)
 		if err != nil {
-			return false
+			return fmt.Errorf("executing auto-spawn: %w", err)
 		}
 
 		// the account should've been spawned
 		walletAccount, err := host.Get(s.host.Principal())
 		if err != nil {
-			return false
+			return fmt.Errorf("spawn failed - account not found: %w", err)
 		}
 		if len(walletAccount.State) == 0 {
-			// this should not happen!
-			return false
+			s.logger.Panic("wallet acount is empty after spawn - this should never happen")
 		}
 		s.walletState = walletAccount.State
 	}
@@ -190,7 +191,7 @@ func (s *Wallet) Verify(raw []byte, dec *scale.Decoder) bool {
 	}
 	payloadEncoded, err := gossamerScale.Marshal(payload)
 	if err != nil {
-		return false
+		return fmt.Errorf("marshaling verify payload: %w", err)
 	}
 	executionPayload := athcon.EncodedExecutionPayload(s.walletState, payloadEncoded)
 
@@ -207,8 +208,16 @@ func (s *Wallet) Verify(raw []byte, dec *scale.Decoder) bool {
 	// consume verify gas
 	// TODO(lane): safe arithmetic/assumption checking
 	s.host.SpendGas(uint64(maxgas) - uint64(gasLeft))
-
-	return err == nil && len(output) == 1 && output[0] == 1
+	if err != nil {
+		return fmt.Errorf("verifying TX: %w", err)
+	}
+	if len(output) == 0 {
+		return errors.New("empty verify output")
+	}
+	if output[0] != 1 {
+		return errors.New("TX didn't pass verification")
+	}
+	return nil
 }
 
 func (s *Wallet) BaseGas() uint64 {

--- a/vm/templates/wallet/wallet_test.go
+++ b/vm/templates/wallet/wallet_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spacemeshos/go-scale"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+	"go.uber.org/zap/zaptest"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/vm/core"
@@ -160,20 +161,20 @@ func TestVerify(t *testing.T) {
 	// empty := types.Hash20{}
 	// mockHost.EXPECT().GetGenesisID().Return(empty).Times(3)
 
-	wallet, err := New(mockHost)
+	wallet, err := New(mockHost, zaptest.NewLogger(t))
 	require.NoError(t, err)
 
 	t.Run("Invalid", func(t *testing.T) {
 		buf64 := types.EdSignature{}
-		require.False(t, wallet.Verify(buf64[:], scale.NewDecoder(bytes.NewReader(buf64[:]))))
+		require.Error(t, wallet.Verify(buf64[:], scale.NewDecoder(bytes.NewReader(buf64[:]))))
 	})
 	t.Run("Empty", func(t *testing.T) {
-		require.False(t, wallet.Verify(nil, scale.NewDecoder(bytes.NewBuffer(nil))))
+		require.Error(t, wallet.Verify(nil, scale.NewDecoder(bytes.NewBuffer(nil))))
 	})
 	t.Run("Valid", func(t *testing.T) {
 		msg := []byte{1, 2, 3}
 		sig := ed25519.Sign(privkeyBytes, msg)
-		require.True(
+		require.NoError(
 			t,
 			wallet.Verify(append(msg, sig...), scale.NewDecoder(bytes.NewReader(sig))),
 		)

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -359,16 +359,19 @@ func (v *VM) execute(
 
 		// NOTE this part is executed only for transactions that weren't verified
 		// when saved into database by txs module
-		if !tx.Verified() && !req.Verify() {
-			logger.Warn("ineffective transaction. failed verify",
-				zap.Stringer("txid", tx.GetRaw().ID),
-				zap.Object("header", header),
-				zap.Stringer("account", ctx.Principal()),
-				zap.Object("payload", ctx.Payload()),
-			)
-			ineffective = append(ineffective, types.Transaction{RawTx: tx.GetRaw()})
-			invalidTxCount.Inc()
-			continue
+		if !tx.Verified() {
+			if err := req.Verify(); err != nil {
+				logger.Warn("ineffective transaction. failed verify",
+					zap.Stringer("txid", tx.GetRaw().ID),
+					zap.Object("header", header),
+					zap.Stringer("account", ctx.Principal()),
+					zap.Object("payload", ctx.Payload()),
+					zap.Error(err),
+				)
+				ineffective = append(ineffective, types.Transaction{RawTx: tx.GetRaw()})
+				invalidTxCount.Inc()
+				continue
+			}
 		}
 
 		if ctx.NextNonce() > ctx.Header.Nonce {
@@ -479,7 +482,7 @@ func (r *Request) Parse() (*core.Header, error) {
 }
 
 // Verify transaction. Will panic if called before Parse completes succcessfully.
-func (r *Request) Verify() bool {
+func (r *Request) Verify() error {
 	if r.ctx == nil {
 		panic("Verify should be called after successful Parse")
 	}
@@ -595,7 +598,7 @@ func parse(
 
 	// At this point we've established that the transaction is correctly formed, but we haven't
 	// yet attempted to validate the signature. That happens later in Verify().
-	ctx.PrincipalTemplate, err = ctx.PrincipalHandler.New(ctx)
+	ctx.PrincipalTemplate, err = ctx.PrincipalHandler.New(ctx, logger.Named("template"))
 	if err != nil {
 		return nil, nil, fmt.Errorf("%w: creating principal handler: %w", core.ErrInternal, err)
 	}
@@ -615,6 +618,6 @@ func parse(
 	return &ctx.Header, ctx, nil
 }
 
-func verify(ctx *core.Context, raw []byte, dec *scale.Decoder) bool {
+func verify(ctx *core.Context, raw []byte, dec *scale.Decoder) error {
 	return ctx.PrincipalTemplate.Verify(raw, dec)
 }

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -1353,9 +1353,12 @@ func testValidation(t *testing.T, tt *tester, template core.Address) {
 			if tc.err != nil {
 				require.ErrorIs(t, err, tc.err)
 			} else {
-				require.Equal(t, tc.verified, req.Verify())
+				err := req.Verify()
 				if tc.verified {
+					require.NoError(t, err)
 					require.Equal(t, tc.header, header)
+				} else {
+					require.Error(t, err)
 				}
 			}
 		})
@@ -1454,12 +1457,8 @@ func BenchmarkValidation(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			req := tt.Validation(raw)
 			_, err := req.Parse()
-			if err != nil {
-				b.Fatal(err)
-			}
-			if !req.Verify() {
-				b.Fatalf("expected Verify to return true")
-			}
+			require.NoError(b, err)
+			require.NoError(b, req.Verify())
 		}
 	}
 


### PR DESCRIPTION
Changed `Template::Verify` to return an error instead of a bool to be able to debug why a TX fails verification (and return this information to the GRPC client submitting the TX).

Systests were failing because the wallet binary, which is now tracked with git-lfs wasn't embedded in the go-spacemesh binary. To fix this, I added `lfs: true` option to `actions/checkout` in GH workflows (were it was missing).