### PR TITLE
Extend systest with option to add split node setup

### DIFF
--- a/activation/activation.go
+++ b/activation/activation.go
@@ -111,6 +111,9 @@ type Builder struct {
 	signers       map[types.NodeID]*signing.EdSigner
 	eg            errgroup.Group
 	stop          context.CancelFunc
+
+	// for node client
+	AlwaysSynced bool
 }
 
 type foundPosAtx struct {
@@ -511,17 +514,20 @@ func (b *Builder) run(ctx context.Context, sig *signing.EdSigner) {
 func (b *Builder) BuildNIPostChallenge(ctx context.Context, nodeID types.NodeID) (*types.NIPostChallenge, error) {
 	logger := b.logger.With(log.ZShortStringer("smesherID", nodeID))
 
-	atxSyncedCh := b.syncer.RegisterForATXSynced()
-	select {
-	case <-atxSyncedCh:
-	default:
-		b.identitiesStates.Set(nodeID, nil, IdentityStateWaitForATXSynced, "")
-	}
+	// assuming node-service is always synced
+	if !b.AlwaysSynced {
+		atxSyncedCh := b.syncer.RegisterForATXSynced()
+		select {
+		case <-atxSyncedCh:
+		default:
+			b.identitiesStates.Set(nodeID, nil, IdentityStateWaitForATXSynced, "")
+		}
 
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	case <-atxSyncedCh:
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-atxSyncedCh:
+		}
 	}
 
 	currentEpochId := b.layerClock.CurrentLayer().GetEpoch()

--- a/activation/post.go
+++ b/activation/post.go
@@ -390,7 +390,8 @@ func (mgr *PostSetupManager) commitmentAtx(ctx context.Context, dataDir string, 
 		}
 
 		// if this node has not published an ATX select the best ATX with `findCommitmentAtx`
-		return mgr.findCommitmentAtx(ctx)
+		// TODO: replace with highestATX api call
+		return mgr.goldenATXID, nil
 	default:
 		return types.EmptyATXID, fmt.Errorf("load metadata: %w", err)
 	}

--- a/activation_service_poc/start.sh
+++ b/activation_service_poc/start.sh
@@ -1,10 +1,8 @@
 #!/bin/bash
-#
-cd ..
-make dockerbuild-go
-cd activation_service_poc
 
-export IMAGE=$(docker images | head -n 2 | tail -n 1 | awk '{print $3}')
+make -C .. dockerbuild-go
+
+export IMAGE=$(docker images | awk 'FNR == 2 { print $3 }')
 
 TIME=$(date -u -d '2 minutes' "+%Y-%m-%dT%H:%M:%S%:z")
 for file in config.standalone.client.json config.standalone.node-service.json;do

--- a/node/node.go
+++ b/node/node.go
@@ -658,32 +658,36 @@ func (app *App) initServices(ctx context.Context) error {
 	)
 	app.validator = validator
 
-	cfg := vm.DefaultConfig()
-	cfg.GasLimit = app.Config.BlockGasLimit
-	cfg.GenesisID = app.Config.Genesis.GenesisID()
-	state := vm.New(app.db,
-		vm.WithConfig(cfg),
-		vm.WithLogger(app.addLogger(VMLogger, lg).Zap()))
-	app.conState = txs.NewConservativeState(state, app.db,
-		txs.WithCSConfig(txs.CSConfig{
-			BlockGasLimit:     app.Config.BlockGasLimit,
-			NumTXsPerProposal: app.Config.TxsPerProposal,
-		}),
-		txs.WithLogger(app.addLogger(ConStateLogger, lg).Zap()))
+	var state *vm.VM
 
-	genesisAccts := app.Config.Genesis.ToAccounts()
-	if len(genesisAccts) > 0 {
-		exists, err := state.AccountExists(genesisAccts[0].Address)
-		if err != nil {
-			return fmt.Errorf(
-				"failed to check genesis account %v: %w",
-				genesisAccts[0].Address,
-				err,
-			)
-		}
-		if !exists {
-			if err = state.ApplyGenesis(genesisAccts); err != nil {
-				return fmt.Errorf("setup genesis: %w", err)
+	if nodeServiceClient == nil {
+		cfg := vm.DefaultConfig()
+		cfg.GasLimit = app.Config.BlockGasLimit
+		cfg.GenesisID = app.Config.Genesis.GenesisID()
+		state = vm.New(app.db,
+			vm.WithConfig(cfg),
+			vm.WithLogger(app.addLogger(VMLogger, lg).Zap()))
+		app.conState = txs.NewConservativeState(state, app.db,
+			txs.WithCSConfig(txs.CSConfig{
+				BlockGasLimit:     app.Config.BlockGasLimit,
+				NumTXsPerProposal: app.Config.TxsPerProposal,
+			}),
+			txs.WithLogger(app.addLogger(ConStateLogger, lg).Zap()))
+
+		genesisAccts := app.Config.Genesis.ToAccounts()
+		if len(genesisAccts) > 0 {
+			exists, err := state.AccountExists(genesisAccts[0].Address)
+			if err != nil {
+				return fmt.Errorf(
+					"failed to check genesis account %v: %w",
+					genesisAccts[0].Address,
+					err,
+				)
+			}
+			if !exists {
+				if err = state.ApplyGenesis(genesisAccts); err != nil {
+					return fmt.Errorf("setup genesis: %w", err)
+				}
 			}
 		}
 	}
@@ -698,17 +702,20 @@ func (app *App) initServices(ctx context.Context) error {
 	)
 
 	vrfVerifier := signing.NewVRFVerifier()
-	beaconProtocol := beacon.New(
-		app.host,
-		app.edVerifier,
-		vrfVerifier,
-		app.cachedDB,
-		app.clock,
-		beacon.WithConfig(app.Config.Beacon),
-		beacon.WithLogger(app.addLogger(BeaconLogger, lg).Zap()),
-	)
-	for _, sig := range app.signers {
-		beaconProtocol.Register(sig)
+	var beaconProtocol *beacon.ProtocolDriver
+	if nodeServiceClient == nil {
+		beaconProtocol = beacon.New(
+			app.host,
+			app.edVerifier,
+			vrfVerifier,
+			app.cachedDB,
+			app.clock,
+			beacon.WithConfig(app.Config.Beacon),
+			beacon.WithLogger(app.addLogger(BeaconLogger, lg).Zap()),
+		)
+		for _, sig := range app.signers {
+			beaconProtocol.Register(sig)
+		}
 	}
 
 	trtlCfg := app.Config.Tortoise
@@ -736,62 +743,73 @@ func (app *App) initServices(ctx context.Context) error {
 		return fmt.Errorf("can't recover tortoise state: %w", err)
 	}
 	app.log.With().Info("tortoise initialized", log.Duration("duration", time.Since(start)))
-	app.eg.Go(func() error {
-		for rst := range beaconProtocol.Results() {
-			events.EmitBeacon(rst.Epoch, rst.Beacon)
-			trtl.OnBeacon(rst.Epoch, rst.Beacon)
-		}
-		app.log.Debug("beacon results watcher exited")
-		return nil
-	})
-
-	executor := mesh.NewExecutor(
-		app.db,
-		app.atxsdata,
-		state,
-		app.conState,
-		app.addLogger(ExecutorLogger, lg).Zap(),
-	)
-	mlog := app.addLogger(MeshLogger, lg).Zap()
-	msh, err := mesh.NewMesh(app.db, app.atxsdata, trtl, executor, app.conState, mlog)
-	if err != nil {
-		return fmt.Errorf("create mesh: %w", err)
+	if nodeServiceClient == nil {
+		app.eg.Go(func() error {
+			for rst := range beaconProtocol.Results() {
+				events.EmitBeacon(rst.Epoch, rst.Beacon)
+				trtl.OnBeacon(rst.Epoch, rst.Beacon)
+			}
+			app.log.Debug("beacon results watcher exited")
+			return nil
+		})
 	}
-
-	app.eg.Go(func() error {
-		msh.Start(ctx)
-		return nil
-	})
-
-	pruner := prune.New(app.db, app.Config.Tortoise.Hdist, app.Config.PruneActivesetsFrom, prune.WithLogger(mlog))
-	if err := pruner.Prune(app.clock.CurrentLayer()); err != nil {
-		return fmt.Errorf("pruner %w", err)
-	}
-	app.eg.Go(func() error {
-		prune.Run(ctx, pruner, app.clock, app.Config.DatabasePruneInterval)
-		return nil
-	})
 
 	fetcherWrapped := &layerFetcher{}
+	var blockHandler *blocks.Handler
+	var msh *mesh.Mesh
+	var executor *mesh.Executor
+	var atxHandler *activation.Handler
 
-	atxHandler := activation.NewHandler(
-		app.host.ID(),
-		app.cachedDB,
-		app.atxsdata,
-		app.edVerifier,
-		app.clock,
-		app.host,
-		fetcherWrapped,
-		goldenATXID,
-		validator,
-		beaconProtocol,
-		trtl,
-		app.addLogger(ATXHandlerLogger, lg).Zap(),
-		activation.WithTickSize(app.Config.TickSize),
-		activation.WithAtxVersions(app.Config.AtxVersions),
-	)
-	for _, sig := range app.signers {
-		atxHandler.Register(sig)
+	if nodeServiceClient == nil {
+		executor = mesh.NewExecutor(
+			app.db,
+			app.atxsdata,
+			state,
+			app.conState,
+			app.addLogger(ExecutorLogger, lg).Zap(),
+		)
+		mlog := app.addLogger(MeshLogger, lg).Zap()
+		msh, err = mesh.NewMesh(app.db, app.atxsdata, trtl, executor, app.conState, mlog)
+		if err != nil {
+			return fmt.Errorf("create mesh: %w", err)
+		}
+
+		app.eg.Go(func() error {
+			msh.Start(ctx)
+			return nil
+		})
+
+		pruner := prune.New(app.db, app.Config.Tortoise.Hdist, app.Config.PruneActivesetsFrom, prune.WithLogger(mlog))
+		if err := pruner.Prune(app.clock.CurrentLayer()); err != nil {
+			return fmt.Errorf("pruner %w", err)
+		}
+		app.eg.Go(func() error {
+			prune.Run(ctx, pruner, app.clock, app.Config.DatabasePruneInterval)
+			return nil
+		})
+
+		blockHandler = blocks.NewHandler(fetcherWrapped, app.db, trtl, msh,
+			blocks.WithLogger(app.addLogger(BlockHandlerLogger, lg).Zap()))
+
+		atxHandler = activation.NewHandler(
+			app.host.ID(),
+			app.cachedDB,
+			app.atxsdata,
+			app.edVerifier,
+			app.clock,
+			app.host,
+			fetcherWrapped,
+			goldenATXID,
+			validator,
+			beaconProtocol,
+			trtl,
+			app.addLogger(ATXHandlerLogger, lg).Zap(),
+			activation.WithTickSize(app.Config.TickSize),
+			activation.WithAtxVersions(app.Config.AtxVersions),
+		)
+		for _, sig := range app.signers {
+			atxHandler.Register(sig)
+		}
 	}
 
 	// we can't have an epoch offset which is greater/equal than the number of layers in an epoch
@@ -804,9 +822,6 @@ func (app *App) initServices(ctx context.Context) error {
 			app.Config.BaseConfig.LayersPerEpoch,
 		)
 	}
-
-	blockHandler := blocks.NewHandler(fetcherWrapped, app.db, trtl, msh,
-		blocks.WithLogger(app.addLogger(BlockHandlerLogger, lg).Zap()))
 
 	app.txHandler = txs.NewTxHandler(
 		app.conState,
@@ -834,91 +849,100 @@ func (app *App) initServices(ctx context.Context) error {
 	)
 	// TODO: genesisMinerWeight is set to app.Config.SpaceToCommit, because PoET ticks are currently hardcoded to 1
 
-	bscfg := app.Config.Bootstrap
-	bscfg.DataDir = app.Config.DataDir()
-	bscfg.Interval = app.Config.LayerDuration / 5
-	app.updater = bootstrap.New(
-		app.clock,
-		bootstrap.WithConfig(bscfg),
-		bootstrap.WithLogger(app.addLogger(BootstrapLogger, lg).Zap()),
-	)
-	if app.Config.Certificate.CommitteeSize == 0 {
-		app.log.With().Warning("certificate committee size is not set, defaulting to hare committee size",
-			log.Uint16("size", app.Config.HARE3.Committee))
-		app.Config.Certificate.CommitteeSize = int(app.Config.HARE3.Committee)
-	}
-	app.Config.Certificate.CertifyThreshold = app.Config.Certificate.CommitteeSize/2 + 1
-	app.Config.Certificate.LayerBuffer = app.Config.Tortoise.Zdist
-	app.Config.Certificate.NumLayersToKeep = app.Config.Tortoise.Zdist * 2
-	app.certifier = blocks.NewCertifier(
-		app.db,
-		app.hOracle,
-		app.edVerifier,
-		app.host,
-		app.clock,
-		beaconProtocol,
-		trtl,
-		blocks.WithCertConfig(app.Config.Certificate),
-		blocks.WithCertifierLogger(app.addLogger(BlockCertLogger, lg).Zap()),
-	)
-	for _, sig := range app.signers {
-		app.certifier.Register(sig)
+	if nodeServiceClient == nil {
+		bscfg := app.Config.Bootstrap
+		bscfg.DataDir = app.Config.DataDir()
+		bscfg.Interval = app.Config.LayerDuration / 5
+		app.updater = bootstrap.New(
+			app.clock,
+			bootstrap.WithConfig(bscfg),
+			bootstrap.WithLogger(app.addLogger(BootstrapLogger, lg).Zap()),
+		)
+
+		if app.Config.Certificate.CommitteeSize == 0 {
+			app.log.With().Warning("certificate committee size is not set, defaulting to hare committee size",
+				log.Uint16("size", app.Config.HARE3.Committee))
+			app.Config.Certificate.CommitteeSize = int(app.Config.HARE3.Committee)
+		}
+		app.Config.Certificate.CertifyThreshold = app.Config.Certificate.CommitteeSize/2 + 1
+		app.Config.Certificate.LayerBuffer = app.Config.Tortoise.Zdist
+		app.Config.Certificate.NumLayersToKeep = app.Config.Tortoise.Zdist * 2
+		app.certifier = blocks.NewCertifier(
+			app.db,
+			app.hOracle,
+			app.edVerifier,
+			app.host,
+			app.clock,
+			beaconProtocol,
+			trtl,
+			blocks.WithCertConfig(app.Config.Certificate),
+			blocks.WithCertifierLogger(app.addLogger(BlockCertLogger, lg).Zap()),
+		)
+		for _, sig := range app.signers {
+			app.certifier.Register(sig)
+		}
 	}
 
-	proposalsStore := store.New(
-		store.WithEvictedLayer(app.clock.CurrentLayer()),
-		store.WithLogger(app.addLogger(ProposalStoreLogger, lg).Zap()),
-		store.WithCapacity(app.Config.Tortoise.Zdist+1),
-	)
-
-	flog := app.addLogger(Fetcher, lg)
-	fetcher, err := fetch.NewFetch(app.cachedDB, proposalsStore, app.host,
-		fetch.WithContext(ctx),
-		fetch.WithConfig(app.Config.FETCH),
-		fetch.WithLogger(flog.Zap()),
-	)
-	if err != nil {
-		return fmt.Errorf("create fetcher: %w", err)
-	}
-	fetcherWrapped.Fetcher = fetcher
-	app.eg.Go(func() error {
-		return blockssync.Sync(ctx, flog.Zap(), msh.MissingBlocks(), fetcher)
-	})
-
+	var fetcher *fetch.Fetch
+	var newSyncer *syncer.Syncer
+	var proposalsStore *store.Store
 	patrol := layerpatrol.New()
-	syncerConf := app.Config.Sync
-	syncerConf.HareDelayLayers = app.Config.Tortoise.Zdist
-	syncerConf.SyncCertDistance = app.Config.Tortoise.Hdist
-	syncerConf.Standalone = app.Config.Standalone
 
-	if app.Config.P2P.MinPeers < app.Config.Sync.MalSync.MinSyncPeers {
-		app.Config.Sync.MalSync.MinSyncPeers = max(1, app.Config.P2P.MinPeers)
+	if nodeServiceClient == nil {
+		proposalsStore = store.New(
+			store.WithEvictedLayer(app.clock.CurrentLayer()),
+			store.WithLogger(app.addLogger(ProposalStoreLogger, lg).Zap()),
+			store.WithCapacity(app.Config.Tortoise.Zdist+1),
+		)
+
+		flog := app.addLogger(Fetcher, lg)
+		fetcher, err = fetch.NewFetch(app.cachedDB, proposalsStore, app.host,
+			fetch.WithContext(ctx),
+			fetch.WithConfig(app.Config.FETCH),
+			fetch.WithLogger(flog.Zap()),
+		)
+		if err != nil {
+			return fmt.Errorf("create fetcher: %w", err)
+		}
+		fetcherWrapped.Fetcher = fetcher
+		app.eg.Go(func() error {
+			return blockssync.Sync(ctx, flog.Zap(), msh.MissingBlocks(), fetcher)
+		})
+
+		syncerConf := app.Config.Sync
+		syncerConf.HareDelayLayers = app.Config.Tortoise.Zdist
+		syncerConf.SyncCertDistance = app.Config.Tortoise.Hdist
+		syncerConf.Standalone = app.Config.Standalone
+
+		if app.Config.P2P.MinPeers < app.Config.Sync.MalSync.MinSyncPeers {
+			app.Config.Sync.MalSync.MinSyncPeers = max(1, app.Config.P2P.MinPeers)
+		}
+		app.syncLogger = app.addLogger(SyncLogger, lg)
+		newSyncer = syncer.NewSyncer(
+			app.cachedDB,
+			app.clock,
+			beaconProtocol,
+			msh,
+			trtl,
+			fetcher,
+			patrol,
+			app.certifier,
+			atxsync.New(fetcher, app.db, app.localDB,
+				atxsync.WithConfig(app.Config.Sync.AtxSync),
+				atxsync.WithLogger(app.syncLogger.Zap()),
+			),
+			malsync.New(fetcher, app.db, app.localDB,
+				malsync.WithConfig(app.Config.Sync.MalSync),
+				malsync.WithLogger(app.syncLogger.Zap()),
+				malsync.WithPeerErrMetric(syncer.MalPeerError),
+			),
+			syncer.WithConfig(syncerConf),
+			syncer.WithLogger(app.syncLogger.Zap()),
+		)
+		// TODO(dshulyak) this needs to be improved, but dependency graph is a bit complicated
+		beaconProtocol.SetSyncState(newSyncer)
+		app.hOracle.SetSync(newSyncer)
 	}
-	app.syncLogger = app.addLogger(SyncLogger, lg)
-	newSyncer := syncer.NewSyncer(
-		app.cachedDB,
-		app.clock,
-		beaconProtocol,
-		msh,
-		trtl,
-		fetcher,
-		patrol,
-		app.certifier,
-		atxsync.New(fetcher, app.db, app.localDB,
-			atxsync.WithConfig(app.Config.Sync.AtxSync),
-			atxsync.WithLogger(app.syncLogger.Zap()),
-		),
-		malsync.New(fetcher, app.db, app.localDB,
-			malsync.WithConfig(app.Config.Sync.MalSync),
-			malsync.WithLogger(app.syncLogger.Zap()),
-			malsync.WithPeerErrMetric(syncer.MalPeerError),
-		),
-		syncer.WithConfig(syncerConf),
-		syncer.WithLogger(app.syncLogger.Zap()),
-	)
-	// TODO(dshulyak) this needs to be improved, but dependency graph is a bit complicated
-	beaconProtocol.SetSyncState(newSyncer)
-	app.hOracle.SetSync(newSyncer)
 
 	err = app.Config.HARE3.Validate(time.Duration(app.Config.Tortoise.Zdist) * app.Config.LayerDuration)
 	if err != nil {
@@ -1008,46 +1032,50 @@ func (app *App) initServices(ctx context.Context) error {
 		hare4:          app.hare4,
 	}
 
-	proposalListener := proposals.NewHandler(
-		app.db,
-		app.atxsdata,
-		propHare,
-		app.edVerifier,
-		app.host,
-		fetcherWrapped,
-		beaconProtocol,
-		msh,
-		trtl,
-		vrfVerifier,
-		app.clock,
-		proposals.WithLogger(app.addLogger(ProposalListenerLogger, lg).Zap()),
-		proposals.WithConfig(proposals.Config{
-			LayerSize:              layerSize,
-			LayersPerEpoch:         layersPerEpoch,
-			GoldenATXID:            goldenATXID,
-			MaxExceptions:          trtlCfg.MaxExceptions,
-			Hdist:                  trtlCfg.Hdist,
-			MinimalActiveSetWeight: trtlCfg.MinimalActiveSetWeight,
-		}),
-	)
+	var proposalListener *proposals.Handler
 
-	app.blockGen = blocks.NewGenerator(
-		app.db,
-		app.atxsdata,
-		proposalsStore,
-		executor,
-		msh,
-		fetcherWrapped,
-		app.certifier,
-		patrol,
-		blocks.WithConfig(blocks.Config{
-			BlockGasLimit:      app.Config.BlockGasLimit,
-			OptFilterThreshold: app.Config.OptFilterThreshold,
-			GenBlockInterval:   500 * time.Millisecond,
-		}),
-		blocks.WithHareOutputChan(app.hareResultsChan),
-		blocks.WithGeneratorLogger(app.addLogger(BlockGenLogger, lg).Zap()),
-	)
+	if nodeServiceClient == nil {
+		proposalListener = proposals.NewHandler(
+			app.db,
+			app.atxsdata,
+			propHare,
+			app.edVerifier,
+			app.host,
+			fetcherWrapped,
+			beaconProtocol,
+			msh,
+			trtl,
+			vrfVerifier,
+			app.clock,
+			proposals.WithLogger(app.addLogger(ProposalListenerLogger, lg).Zap()),
+			proposals.WithConfig(proposals.Config{
+				LayerSize:              layerSize,
+				LayersPerEpoch:         layersPerEpoch,
+				GoldenATXID:            goldenATXID,
+				MaxExceptions:          trtlCfg.MaxExceptions,
+				Hdist:                  trtlCfg.Hdist,
+				MinimalActiveSetWeight: trtlCfg.MinimalActiveSetWeight,
+			}),
+		)
+
+		app.blockGen = blocks.NewGenerator(
+			app.db,
+			app.atxsdata,
+			proposalsStore,
+			executor,
+			msh,
+			fetcherWrapped,
+			app.certifier,
+			patrol,
+			blocks.WithConfig(blocks.Config{
+				BlockGasLimit:      app.Config.BlockGasLimit,
+				OptFilterThreshold: app.Config.OptFilterThreshold,
+				GenBlockInterval:   500 * time.Millisecond,
+			}),
+			blocks.WithHareOutputChan(app.hareResultsChan),
+			blocks.WithGeneratorLogger(app.addLogger(BlockGenLogger, lg).Zap()),
+		)
+	}
 
 	minerGoodAtxPct := 90
 	if app.Config.MinerGoodAtxsPercent > 0 {
@@ -1069,7 +1097,6 @@ func (app *App) initServices(ctx context.Context) error {
 		for _, sig := range app.signers {
 			remoteProposalBuilder.Register(sig)
 		}
-
 		app.remoteProposalBuilder = remoteProposalBuilder
 	} else {
 		proposalBuilder = miner.New(
@@ -1206,6 +1233,9 @@ func (app *App) initServices(ctx context.Context) error {
 		activation.WithPoets(poetClients...),
 		activation.BuilderAtxVersions(app.Config.AtxVersions),
 	)
+	if nodeServiceClient != nil {
+		atxBuilder.AlwaysSynced = true
+	}
 	if len(app.signers) > 1 || app.signers[0].Name() != supervisedIDKeyFileName {
 		// in a remote setup we register eagerly so the atxBuilder can warn about missing connections asap.
 		// Any setup with more than one signer is considered a remote setup. If there is only one signer it
@@ -1229,152 +1259,156 @@ func (app *App) initServices(ctx context.Context) error {
 		return fmt.Errorf("init post service: %w", err)
 	}
 
-	malfeasanceLogger := app.addLogger(MalfeasanceLogger, lg).Zap()
-	activationMH := activation.NewMalfeasanceHandler(
-		app.cachedDB,
-		malfeasanceLogger,
-		app.edVerifier,
-	)
-	meshMH := mesh.NewMalfeasanceHandler(
-		app.cachedDB,
-		app.edVerifier,
-		mesh.WithMalfeasanceLogger(malfeasanceLogger),
-	)
-	hareMH := hare3.NewMalfeasanceHandler(
-		app.cachedDB,
-		app.edVerifier,
-		hare3.WithMalfeasanceLogger(malfeasanceLogger),
-	)
-	invalidPostMH := activation.NewInvalidPostIndexHandler(
-		app.cachedDB,
-		app.edVerifier,
-		app.postVerifier,
-	)
-	invalidPrevMH := activation.NewInvalidPrevATXHandler(app.cachedDB, app.edVerifier)
+	if nodeServiceClient == nil {
+		malfeasanceLogger := app.addLogger(MalfeasanceLogger, lg).Zap()
+		activationMH := activation.NewMalfeasanceHandler(
+			app.cachedDB,
+			malfeasanceLogger,
+			app.edVerifier,
+		)
+		meshMH := mesh.NewMalfeasanceHandler(
+			app.cachedDB,
+			app.edVerifier,
+			mesh.WithMalfeasanceLogger(malfeasanceLogger),
+		)
+		hareMH := hare3.NewMalfeasanceHandler(
+			app.cachedDB,
+			app.edVerifier,
+			hare3.WithMalfeasanceLogger(malfeasanceLogger),
+		)
+		invalidPostMH := activation.NewInvalidPostIndexHandler(
+			app.cachedDB,
+			app.edVerifier,
+			app.postVerifier,
+		)
+		invalidPrevMH := activation.NewInvalidPrevATXHandler(app.cachedDB, app.edVerifier)
 
-	nodeIDs := make([]types.NodeID, 0, len(app.signers))
-	for _, s := range app.signers {
-		nodeIDs = append(nodeIDs, s.NodeID())
-	}
-	app.malfeasanceHandler = malfeasance.NewHandler(
-		app.cachedDB,
-		malfeasanceLogger,
-		app.host.ID(),
-		nodeIDs,
-		trtl,
-	)
-	app.malfeasanceHandler.RegisterHandler(malfeasance.MultipleATXs, activationMH)
-	app.malfeasanceHandler.RegisterHandler(malfeasance.MultipleBallots, meshMH)
-	app.malfeasanceHandler.RegisterHandler(malfeasance.HareEquivocation, hareMH)
-	app.malfeasanceHandler.RegisterHandler(malfeasance.InvalidPostIndex, invalidPostMH)
-	app.malfeasanceHandler.RegisterHandler(malfeasance.InvalidPrevATX, invalidPrevMH)
-
-	fetcher.SetValidators(
-		fetch.ValidatorFunc(
-			pubsub.DropPeerOnSyncValidationReject(atxHandler.HandleSyncedAtx, app.host, lg.Zap()),
-		),
-		fetch.ValidatorFunc(
-			pubsub.DropPeerOnSyncValidationReject(poetDb.ValidateAndStoreMsg, app.host, lg.Zap()),
-		),
-		fetch.ValidatorFunc(
-			pubsub.DropPeerOnSyncValidationReject(
-				proposalListener.HandleSyncedBallot,
-				app.host,
-				lg.Zap(),
-			),
-		),
-		fetch.ValidatorFunc(
-			pubsub.DropPeerOnSyncValidationReject(proposalListener.HandleActiveSet, app.host, lg.Zap()),
-		),
-		fetch.ValidatorFunc(
-			pubsub.DropPeerOnSyncValidationReject(blockHandler.HandleSyncedBlock, app.host, lg.Zap()),
-		),
-		fetch.ValidatorFunc(
-			pubsub.DropPeerOnSyncValidationReject(
-				proposalListener.HandleSyncedProposal,
-				app.host,
-				lg.Zap(),
-			),
-		),
-		fetch.ValidatorFunc(
-			pubsub.DropPeerOnSyncValidationReject(
-				app.txHandler.HandleBlockTransaction,
-				app.host,
-				lg.Zap(),
-			),
-		),
-		fetch.ValidatorFunc(
-			pubsub.DropPeerOnSyncValidationReject(
-				app.txHandler.HandleProposalTransaction,
-				app.host,
-				lg.Zap(),
-			),
-		),
-		fetch.ValidatorFunc(
-			pubsub.DropPeerOnSyncValidationReject(
-				app.malfeasanceHandler.HandleSyncedMalfeasanceProof,
-				app.host,
-				lg.Zap(),
-			),
-		),
-	)
-
-	syncHandler := func(_ context.Context, _ p2p.Peer, _ []byte) error {
-		if newSyncer.ListenToGossip() {
-			return nil
+		nodeIDs := make([]types.NodeID, 0, len(app.signers))
+		for _, s := range app.signers {
+			nodeIDs = append(nodeIDs, s.NodeID())
 		}
-		return errors.New("not synced for gossip")
-	}
-	atxSyncHandler := func(_ context.Context, _ p2p.Peer, _ []byte) error {
-		if newSyncer.ListenToATXGossip() {
-			return nil
-		}
-		return errors.New("not synced for gossip")
-	}
 
-	if app.Config.Beacon.RoundsNumber > 0 {
+		app.malfeasanceHandler = malfeasance.NewHandler(
+			app.cachedDB,
+			malfeasanceLogger,
+			app.host.ID(),
+			nodeIDs,
+			trtl,
+		)
+		app.malfeasanceHandler.RegisterHandler(malfeasance.MultipleATXs, activationMH)
+		app.malfeasanceHandler.RegisterHandler(malfeasance.MultipleBallots, meshMH)
+		app.malfeasanceHandler.RegisterHandler(malfeasance.HareEquivocation, hareMH)
+		app.malfeasanceHandler.RegisterHandler(malfeasance.InvalidPostIndex, invalidPostMH)
+		app.malfeasanceHandler.RegisterHandler(malfeasance.InvalidPrevATX, invalidPrevMH)
+
+		fetcher.SetValidators(
+			fetch.ValidatorFunc(
+				pubsub.DropPeerOnSyncValidationReject(atxHandler.HandleSyncedAtx, app.host, lg.Zap()),
+			),
+			fetch.ValidatorFunc(
+				pubsub.DropPeerOnSyncValidationReject(poetDb.ValidateAndStoreMsg, app.host, lg.Zap()),
+			),
+			fetch.ValidatorFunc(
+				pubsub.DropPeerOnSyncValidationReject(
+					proposalListener.HandleSyncedBallot,
+					app.host,
+					lg.Zap(),
+				),
+			),
+			fetch.ValidatorFunc(
+				pubsub.DropPeerOnSyncValidationReject(proposalListener.HandleActiveSet, app.host, lg.Zap()),
+			),
+			fetch.ValidatorFunc(
+				pubsub.DropPeerOnSyncValidationReject(blockHandler.HandleSyncedBlock, app.host, lg.Zap()),
+			),
+			fetch.ValidatorFunc(
+				pubsub.DropPeerOnSyncValidationReject(
+					proposalListener.HandleSyncedProposal,
+					app.host,
+					lg.Zap(),
+				),
+			),
+			fetch.ValidatorFunc(
+				pubsub.DropPeerOnSyncValidationReject(
+					app.txHandler.HandleBlockTransaction,
+					app.host,
+					lg.Zap(),
+				),
+			),
+			fetch.ValidatorFunc(
+				pubsub.DropPeerOnSyncValidationReject(
+					app.txHandler.HandleProposalTransaction,
+					app.host,
+					lg.Zap(),
+				),
+			),
+			fetch.ValidatorFunc(
+				pubsub.DropPeerOnSyncValidationReject(
+					app.malfeasanceHandler.HandleSyncedMalfeasanceProof,
+					app.host,
+					lg.Zap(),
+				),
+			),
+		)
+
+		syncHandler := func(_ context.Context, _ p2p.Peer, _ []byte) error {
+			if newSyncer.ListenToGossip() {
+				return nil
+			}
+			return errors.New("not synced for gossip")
+		}
+		atxSyncHandler := func(_ context.Context, _ p2p.Peer, _ []byte) error {
+			if newSyncer.ListenToATXGossip() {
+				return nil
+			}
+			return errors.New("not synced for gossip")
+		}
+
+		if app.Config.Beacon.RoundsNumber > 0 {
+			app.host.Register(
+				pubsub.BeaconWeakCoinProtocol,
+				pubsub.ChainGossipHandler(syncHandler, beaconProtocol.HandleWeakCoinProposal),
+				pubsub.WithValidatorInline(true),
+			)
+			app.host.Register(
+				pubsub.BeaconProposalProtocol,
+				pubsub.ChainGossipHandler(syncHandler, beaconProtocol.HandleProposal),
+				pubsub.WithValidatorInline(true),
+			)
+			app.host.Register(
+				pubsub.BeaconFirstVotesProtocol,
+				pubsub.ChainGossipHandler(syncHandler, beaconProtocol.HandleFirstVotes),
+				pubsub.WithValidatorInline(true),
+			)
+			app.host.Register(
+				pubsub.BeaconFollowingVotesProtocol,
+				pubsub.ChainGossipHandler(syncHandler, beaconProtocol.HandleFollowingVotes),
+				pubsub.WithValidatorInline(true),
+			)
+		}
+
 		app.host.Register(
-			pubsub.BeaconWeakCoinProtocol,
-			pubsub.ChainGossipHandler(syncHandler, beaconProtocol.HandleWeakCoinProposal),
-			pubsub.WithValidatorInline(true),
+			pubsub.ProposalProtocol,
+			pubsub.ChainGossipHandler(syncHandler, proposalListener.HandleProposal),
 		)
 		app.host.Register(
-			pubsub.BeaconProposalProtocol,
-			pubsub.ChainGossipHandler(syncHandler, beaconProtocol.HandleProposal),
-			pubsub.WithValidatorInline(true),
+			pubsub.AtxProtocol,
+			pubsub.ChainGossipHandler(atxSyncHandler, atxHandler.HandleGossipAtx),
+			pubsub.WithValidatorConcurrency(app.Config.P2P.GossipAtxValidationThrottle),
 		)
 		app.host.Register(
-			pubsub.BeaconFirstVotesProtocol,
-			pubsub.ChainGossipHandler(syncHandler, beaconProtocol.HandleFirstVotes),
-			pubsub.WithValidatorInline(true),
+			pubsub.TxProtocol,
+			pubsub.ChainGossipHandler(syncHandler, app.txHandler.HandleGossipTransaction),
 		)
 		app.host.Register(
-			pubsub.BeaconFollowingVotesProtocol,
-			pubsub.ChainGossipHandler(syncHandler, beaconProtocol.HandleFollowingVotes),
-			pubsub.WithValidatorInline(true),
+			pubsub.BlockCertify,
+			pubsub.ChainGossipHandler(syncHandler, app.certifier.HandleCertifyMessage),
+		)
+		app.host.Register(
+			pubsub.MalfeasanceProof,
+			pubsub.ChainGossipHandler(atxSyncHandler, app.malfeasanceHandler.HandleMalfeasanceProof),
 		)
 	}
-	app.host.Register(
-		pubsub.ProposalProtocol,
-		pubsub.ChainGossipHandler(syncHandler, proposalListener.HandleProposal),
-	)
-	app.host.Register(
-		pubsub.AtxProtocol,
-		pubsub.ChainGossipHandler(atxSyncHandler, atxHandler.HandleGossipAtx),
-		pubsub.WithValidatorConcurrency(app.Config.P2P.GossipAtxValidationThrottle),
-	)
-	app.host.Register(
-		pubsub.TxProtocol,
-		pubsub.ChainGossipHandler(syncHandler, app.txHandler.HandleGossipTransaction),
-	)
-	app.host.Register(
-		pubsub.BlockCertify,
-		pubsub.ChainGossipHandler(syncHandler, app.certifier.HandleCertifyMessage),
-	)
-	app.host.Register(
-		pubsub.MalfeasanceProof,
-		pubsub.ChainGossipHandler(atxSyncHandler, app.malfeasanceHandler.HandleMalfeasanceProof),
-	)
 
 	app.proposalBuilder = proposalBuilder
 	app.mesh = msh
@@ -1525,20 +1559,30 @@ func (app *App) listenToUpdates(ctx context.Context) {
 }
 
 func (app *App) startServices(ctx context.Context) error {
-	if err := app.fetcher.Start(); err != nil {
-		return fmt.Errorf("start fetcher: %w", err)
-	}
-	app.syncer.Start()
-	app.beaconProtocol.Start(ctx)
-
-	app.blockGen.Start(ctx)
-	app.certifier.Start(ctx)
-	app.eg.Go(func() error {
-		if app.proposalBuilder != nil {
-			return app.proposalBuilder.Run(ctx)
+	if app.fetcher != nil {
+		if err := app.fetcher.Start(); err != nil {
+			return fmt.Errorf("start fetcher: %w", err)
 		}
-		return nil
-	})
+	}
+	if app.syncer != nil {
+		app.syncer.Start()
+	}
+
+	if app.beaconProtocol != nil {
+		app.beaconProtocol.Start(ctx)
+	}
+
+	if app.blockGen != nil {
+		app.blockGen.Start(ctx)
+	}
+	if app.certifier != nil {
+		app.certifier.Start(ctx)
+	}
+	if app.proposalBuilder != nil {
+		app.eg.Go(func() error {
+			return app.proposalBuilder.Run(ctx)
+		})
+	}
 	if app.remoteProposalBuilder != nil {
 		app.eg.Go(func() error {
 			return app.remoteProposalBuilder.Run(ctx)

--- a/systest/Makefile
+++ b/systest/Makefile
@@ -23,6 +23,7 @@ level ?= debug
 bootstrap ?= 5m
 storage ?= standard=1Gi
 node_selector ?=
+node_split_size ?=
 namespace ?=
 count ?= 1
 failfast ?= true
@@ -73,6 +74,7 @@ template:
 	@echo post-init-image=$(post_init_image) >> $(tmpfile)
 	@echo keep=$(keep) >> $(tmpfile)
 	@echo testid=$(test_id) >> $(tmpfile)
+	@echo node-split-size=$(node_split_size) >> $(tmpfile)
 
 .PHONY: config
 config: template

--- a/systest/cluster/cluster.go
+++ b/systest/cluster/cluster.go
@@ -717,7 +717,7 @@ func (c *Cluster) AddSplitNodes(tctx *testcontext.Context, n int, opts ...Deploy
 	// deploy client services
 	dopts = []DeploymentOpt{
 		WithFlags(flags...),
-		WithFlags(Bootnodes(endpoints...), StartSmeshing(true)),
+		WithFlags(StartSmeshing(true)),
 		WithSmeshers(keys[1:]),
 	}
 	clients, err = deployActivationNodes(tctx, node, c.nextSmesher(), c.nextSmesher()+n-1, dopts...)

--- a/systest/cluster/cluster.go
+++ b/systest/cluster/cluster.go
@@ -327,6 +327,16 @@ func (c *Cluster) persistConfigs(ctx *testcontext.Context) error {
 	}
 	_, err = ctx.Client.CoreV1().ConfigMaps(ctx.Namespace).Apply(
 		ctx,
+		corev1.ConfigMap(activationConfigMapName, ctx.Namespace).WithData(map[string]string{
+			attachedSmesherConfig: activationConfig.Get(ctx.Parameters),
+		}),
+		apimetav1.ApplyOptions{FieldManager: "test"},
+	)
+	if err != nil {
+		return fmt.Errorf("apply cfgmap %v/%v: %w", ctx.Namespace, spacemeshConfigMapName, err)
+	}
+	_, err = ctx.Client.CoreV1().ConfigMaps(ctx.Namespace).Apply(
+		ctx,
 		corev1.ConfigMap(certifierConfigMapName, ctx.Namespace).WithData(map[string]string{
 			attachedCertifierConfig: certifierConfig.Get(ctx.Parameters),
 		}),

--- a/systest/cluster/cluster.go
+++ b/systest/cluster/cluster.go
@@ -680,9 +680,18 @@ func (c *Cluster) AddSplitNodes(tctx *testcontext.Context, n int, opts ...Deploy
 		return fmt.Errorf("extracting p2p endpoints %w", err)
 	}
 
+	cfg := SmesherDeploymentConfig{}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	keys := cfg.keys
+
 	// deploy a single node-service
-	dopts := []DeploymentOpt{WithFlags(flags...), WithFlags(Bootnodes(endpoints...), StartSmeshing(false))}
-	dopts = append(dopts, opts...)
+	dopts := []DeploymentOpt{
+		WithFlags(flags...),
+		WithFlags(Bootnodes(endpoints...), StartSmeshing(false)),
+		WithSmeshers(keys[:1]),
+	}
 	clients, err := deployNodes(tctx, smesherApp, c.nextSmesher(), c.nextSmesher()+1, dopts...)
 	if err != nil {
 		return err
@@ -696,8 +705,11 @@ func (c *Cluster) AddSplitNodes(tctx *testcontext.Context, n int, opts ...Deploy
 	}
 
 	// deploy client services
-	dopts = []DeploymentOpt{WithFlags(flags...), WithFlags(Bootnodes(endpoints...), StartSmeshing(true))}
-	dopts = append(dopts, opts...)
+	dopts = []DeploymentOpt{
+		WithFlags(flags...),
+		WithFlags(Bootnodes(endpoints...), StartSmeshing(true)),
+		WithSmeshers(keys[1:]),
+	}
 	clients, err = deployActivationNodes(tctx, node, c.nextSmesher(), c.nextSmesher()+n-1, dopts...)
 	if err != nil {
 		return err

--- a/systest/cluster/cluster.go
+++ b/systest/cluster/cluster.go
@@ -328,7 +328,7 @@ func (c *Cluster) persistConfigs(ctx *testcontext.Context) error {
 	_, err = ctx.Client.CoreV1().ConfigMaps(ctx.Namespace).Apply(
 		ctx,
 		corev1.ConfigMap(activationConfigMapName, ctx.Namespace).WithData(map[string]string{
-			attachedSmesherConfig: activationConfig.Get(ctx.Parameters),
+			attachedActivationConfig: activationConfig.Get(ctx.Parameters),
 		}),
 		apimetav1.ApplyOptions{FieldManager: "test"},
 	)

--- a/systest/cluster/cluster.go
+++ b/systest/cluster/cluster.go
@@ -38,6 +38,7 @@ const (
 	poetApp          = "poet"
 	bootnodeApp      = "boot"
 	smesherApp       = "smesher"
+	activationApp    = "activation"
 	postServiceApp   = "postservice"
 	bootstrapperApp  = "bootstrapper"
 	bootstrapperPort = 80
@@ -161,13 +162,14 @@ func ReuseWait(cctx *testcontext.Context, opts ...Opt) (*Cluster, error) {
 func Default(cctx *testcontext.Context, opts ...Opt) (*Cluster, error) {
 	cl := New(cctx, opts...)
 
-	smeshers := cctx.ClusterSize - cctx.BootnodeSize - cctx.OldSize - cctx.RemoteSize
+	smeshers := cctx.ClusterSize - cctx.BootnodeSize - cctx.OldSize - cctx.RemoteSize - cctx.NodeSplitSize
 
 	cctx.Log.Desugar().Info("Using the following nodes",
 		zap.Int("total", cctx.ClusterSize),
 		zap.Int("bootnodes", cctx.BootnodeSize),
 		zap.Int("smeshers", smeshers),
 		zap.Int("old smeshers", cctx.OldSize),
+		zap.Int("node split setup", cctx.NodeSplitSize),
 		zap.Int("remote", cctx.RemoteSize),
 	)
 
@@ -196,18 +198,26 @@ func Default(cctx *testcontext.Context, opts ...Opt) (*Cluster, error) {
 		return nil, err
 	}
 
-	smesherKeys := keys[cctx.BootnodeSize : cctx.BootnodeSize+smeshers]
+	oldOffset := cctx.BootnodeSize + smeshers
+	smesherKeys := keys[cctx.BootnodeSize:oldOffset]
 	if err := cl.AddSmeshers(cctx, smeshers, WithSmeshers(smesherKeys)); err != nil {
 		return nil, err
 	}
 
-	oldKeys := keys[cctx.BootnodeSize+smeshers : cctx.BootnodeSize+smeshers+cctx.OldSize]
+	remoteOffset := oldOffset + cctx.OldSize
+	oldKeys := keys[oldOffset:remoteOffset]
 	if err := cl.AddSmeshers(cctx, cctx.OldSize, WithSmeshers(oldKeys), WithImage(cctx.OldImage)); err != nil {
 		return nil, err
 	}
 
-	remoteKeys := keys[cctx.BootnodeSize+smeshers+cctx.OldSize:]
+	splitNodeOffset := remoteOffset + cctx.NodeSplitSize
+	remoteKeys := keys[remoteOffset:splitNodeOffset]
 	if err := cl.AddRemoteSmeshers(cctx, cctx.RemoteSize, WithSmeshers(remoteKeys)); err != nil {
+		return nil, err
+	}
+
+	splitNodeKeys := keys[splitNodeOffset:]
+	if err := cl.AddSplitNodes(cctx, cctx.NodeSplitSize, WithSmeshers(splitNodeKeys)); err != nil {
 		return nil, err
 	}
 	return cl, nil
@@ -416,6 +426,16 @@ func (c *Cluster) reuse(cctx *testcontext.Context) error {
 	}
 	c.clients = append(c.clients, clients...)
 	c.smeshers = len(clients)
+
+	clients, err = discoverNodes(cctx, activationApp)
+	if err != nil {
+		return err
+	}
+	for _, node := range clients {
+		cctx.Log.Debugw("discovered existing activation nodes", "name", node.Name)
+	}
+	c.clients = append(c.clients, clients...)
+	c.smeshers += len(clients)
 
 	c.poets, err = discoverNodes(cctx, poetApp)
 	if err != nil {
@@ -633,6 +653,52 @@ func (c *Cluster) AddRemoteSmeshers(tctx *testcontext.Context, n int, opts ...De
 	dopts := []DeploymentOpt{WithFlags(flags...), WithFlags(Bootnodes(endpoints...), StartSmeshing(false))}
 	dopts = append(dopts, opts...)
 	clients, err := deployRemoteNodes(tctx, c.nextSmesher(), c.nextSmesher()+n, c.GoldenATX(), dopts...)
+	if err != nil {
+		return err
+	}
+	c.clients = append(c.clients, clients...)
+	c.smeshers += len(clients)
+	return nil
+}
+
+func (c *Cluster) AddSplitNodes(tctx *testcontext.Context, n int, opts ...DeploymentOpt) error {
+	if n == 0 {
+		return nil
+	}
+	if n == 1 {
+		return errors.New("split nodes size has to be at least 2 while provided size is 1")
+	}
+	if err := c.resourceControl(tctx, n); err != nil {
+		return err
+	}
+	if err := c.persist(tctx); err != nil {
+		return err
+	}
+	flags := maps.Values(c.smesherFlags)
+	endpoints, err := ExtractP2PEndpoints(tctx, c.clients[:c.bootnodes])
+	if err != nil {
+		return fmt.Errorf("extracting p2p endpoints %w", err)
+	}
+
+	// deploy a single node-service
+	dopts := []DeploymentOpt{WithFlags(flags...), WithFlags(Bootnodes(endpoints...), StartSmeshing(false))}
+	dopts = append(dopts, opts...)
+	clients, err := deployNodes(tctx, smesherApp, c.nextSmesher(), c.nextSmesher()+1, dopts...)
+	if err != nil {
+		return err
+	}
+	c.clients = append(c.clients, clients...)
+	c.smeshers += len(clients)
+
+	node := clients[0].Name
+	if err := deployNodeSvc(tctx, node); err != nil {
+		return err
+	}
+
+	// deploy client services
+	dopts = []DeploymentOpt{WithFlags(flags...), WithFlags(Bootnodes(endpoints...), StartSmeshing(true))}
+	dopts = append(dopts, opts...)
+	clients, err = deployActivationNodes(tctx, node, c.nextSmesher(), c.nextSmesher()+n-1, dopts...)
 	if err != nil {
 		return err
 	}

--- a/systest/cluster/cluster.go
+++ b/systest/cluster/cluster.go
@@ -709,8 +709,10 @@ func (c *Cluster) AddSplitNodes(tctx *testcontext.Context, n int, opts ...Deploy
 	c.clients = append(c.clients, clients...)
 	c.smeshers += len(clients)
 
-	node := clients[0].Name
-	if err := deployNodeSvc(tctx, node); err != nil {
+	nodeServer := clients[0]
+	c.Wait(tctx, len(c.clients)-1)
+
+	if err := deployNodeSvc(tctx, nodeServer.Name); err != nil {
 		return err
 	}
 
@@ -720,7 +722,8 @@ func (c *Cluster) AddSplitNodes(tctx *testcontext.Context, n int, opts ...Deploy
 		WithFlags(StartSmeshing(true)),
 		WithSmeshers(keys[1:]),
 	}
-	clients, err = deployActivationNodes(tctx, node, c.nextSmesher(), c.nextSmesher()+n-1, dopts...)
+	clients, err = deployActivationNodes(
+		tctx, nodeServer.Name, c.nextSmesher(), c.nextSmesher()+n-1, dopts...)
 	if err != nil {
 		return err
 	}

--- a/systest/cluster/nodes.go
+++ b/systest/cluster/nodes.go
@@ -52,6 +52,11 @@ var (
 		"configuration for smesher service",
 		fastnet.SmesherConfig,
 	)
+	activationConfig = parameters.String(
+		"activation",
+		"configuration for activation service",
+		fastnet.ActivationConfig,
+	)
 
 	smesherResources = parameters.NewParameter(
 		"smesher_resources",

--- a/systest/cluster/nodes.go
+++ b/systest/cluster/nodes.go
@@ -52,10 +52,30 @@ var (
 		"configuration for smesher service",
 		fastnet.SmesherConfig,
 	)
+	activationConfig = parameters.String(
+		"activation",
+		"configuration for activation service",
+		fastnet.ActivationConfig,
+	)
 
 	smesherResources = parameters.NewParameter(
 		"smesher_resources",
 		"requests and limits for smesher container",
+		&apiv1.ResourceRequirements{
+			Requests: apiv1.ResourceList{
+				apiv1.ResourceCPU:    resource.MustParse("1.3"),
+				apiv1.ResourceMemory: resource.MustParse("800Mi"),
+			},
+			Limits: apiv1.ResourceList{
+				apiv1.ResourceCPU:    resource.MustParse("1.3"),
+				apiv1.ResourceMemory: resource.MustParse("800Mi"),
+			},
+		},
+		toResources,
+	)
+	activationResources = parameters.NewParameter(
+		"smesher_resources",
+		"requests and limits for activation container",
 		&apiv1.ResourceRequirements{
 			Requests: apiv1.ResourceList{
 				apiv1.ResourceCPU:    resource.MustParse("1.3"),
@@ -111,13 +131,15 @@ func toResources(value string) (*apiv1.ResourceRequirements, error) {
 const (
 	configDir = "/etc/config/"
 
-	attachedCertifierConfig = "certifier.yaml"
-	attachedPoetConfig      = "poet.conf"
-	attachedSmesherConfig   = "smesher.json"
+	attachedCertifierConfig  = "certifier.yaml"
+	attachedPoetConfig       = "poet.conf"
+	attachedSmesherConfig    = "smesher.json"
+	attachedActivationConfig = "activation.json"
 
-	certifierConfigMapName = "certifier"
-	poetConfigMapName      = "poet"
-	spacemeshConfigMapName = "spacemesh"
+	certifierConfigMapName  = "certifier"
+	poetConfigMapName       = "poet"
+	spacemeshConfigMapName  = "spacemesh"
+	activationConfigMapName = "activation"
 
 	// smeshers are split in 10 approximately equal buckets
 	// to enable running chaos mesh tasks on the different parts of the cluster.
@@ -731,6 +753,89 @@ func deployNodes(ctx *testcontext.Context, kind string, from, to int, opts ...De
 	return rst, nil
 }
 
+func deployActivationNodes(
+	ctx *testcontext.Context,
+	node string,
+	from, to int,
+	opts ...DeploymentOpt,
+) ([]*NodeClient, error) {
+	ctx.Log.Debugw("deploying activation nodes", "from", from, "to", to)
+	var (
+		eg      errgroup.Group
+		clients = make(chan *NodeClient, to-from)
+		cfg     = SmesherDeploymentConfig{
+			image: ctx.Image,
+		}
+	)
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	if cfg.image == "" {
+		return nil, errors.New("go-spacemesh image must be set")
+	}
+	if delta := to - from; len(cfg.keys) > 0 && len(cfg.keys) != delta {
+		return nil, fmt.Errorf(
+			"keys must be overwritten for all or no members of the cluster: delta %d, keys %d %v",
+			delta,
+			len(cfg.keys),
+			cfg.keys,
+		)
+	}
+	for i := from; i < to; i++ {
+		finalFlags := make([]DeploymentFlag, len(cfg.flags), len(cfg.flags)+ctx.PoetSize)
+		copy(finalFlags, cfg.flags)
+		if !cfg.noDefaultPoets {
+			var poetIds []int
+			for idx := 0; idx < ctx.PoetSize; idx++ {
+				poetIds = append(poetIds, idx)
+			}
+			finalFlags = append(finalFlags, PoetEndpoints(poetIds...))
+		}
+		if ctx.BootstrapperSize > 1 {
+			finalFlags = append(finalFlags, BootstrapperUrl(BootstrapperEndpoint(i%ctx.BootstrapperSize)))
+		} else {
+			finalFlags = append(finalFlags, BootstrapperUrl(BootstrapperEndpoint(0)))
+		}
+
+		var key ed25519.PrivateKey
+		if len(cfg.keys) > 0 {
+			key = cfg.keys[i-from]
+		}
+		eg.Go(func() error {
+			id := fmt.Sprintf("%s-%d", activationApp, i)
+			labels := nodeLabels(activationApp, id)
+			labels["bucket"] = strconv.Itoa(i % buckets)
+			if err := deployActivationNode(
+				ctx, id, node, key, cfg.image, "local.key", labels, finalFlags,
+			); err != nil {
+				return err
+			}
+			clients <- &NodeClient{
+				session: ctx,
+				Node: Node{
+					Name:      id,
+					P2P:       7513,
+					GRPC_PUB:  9092,
+					GRPC_PRIV: 9093,
+				},
+			}
+			return nil
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		return nil, err
+	}
+	close(clients)
+	var rst []*NodeClient
+	for node := range clients {
+		rst = append(rst, node)
+	}
+	sort.Slice(rst, func(i, j int) bool {
+		return decodeOrdinal(rst[i].Name) < decodeOrdinal(rst[j].Name)
+	})
+	return rst, nil
+}
+
 func deployRemoteNodes(
 	ctx *testcontext.Context,
 	from, to int,
@@ -844,6 +949,119 @@ func deleteNode(ctx *testcontext.Context, id string) error {
 	if err := ctx.Client.AppsV1().Deployments(ctx.Namespace).
 		Delete(ctx, id, apimetav1.DeleteOptions{}); err != nil {
 		return err
+	}
+	return nil
+}
+
+func deployActivationNode(
+	ctx *testcontext.Context,
+	id string,
+	node string,
+	key ed25519.PrivateKey,
+	image string,
+	keyName string,
+	labels map[string]string,
+	flags []DeploymentFlag,
+) error {
+	ctx.Log.Debugw("deploying node", "id", id)
+	cmd := []string{
+		"/bin/go-spacemesh",
+		"-c=" + configDir + attachedActivationConfig,
+		"--pprof-server",
+		"--smeshing-opts-datadir=/data/post",
+		"-d=/data",
+		"--log-encoder=json",
+		"--metrics",
+		"--metrics-port=" + strconv.Itoa(prometheusScrapePort),
+		"--node-service-address=", fmt.Sprintf("http://%s:9099", node),
+		"--proxy-api-v2-address", fmt.Sprintf("http://%s:9070", node),
+		"--grpc-json-listener", "0.0.0.0:9071",
+		"--proxy-listener", "0.0.0.0:9072",
+	}
+	for _, flag := range flags {
+		cmd = append(cmd, flag.Flag())
+	}
+
+	podSpec := corev1.PodSpec().
+		WithNodeSelector(ctx.NodeSelector).
+		WithVolumes(
+			corev1.Volume().WithName("config").
+				WithConfigMap(corev1.ConfigMapVolumeSource().WithName(activationConfigMapName)),
+			corev1.Volume().WithName("data").
+				WithEmptyDir(corev1.EmptyDirVolumeSource().
+					WithSizeLimit(resource.MustParse(ctx.Storage.Size))),
+		).
+		WithDNSConfig(corev1.PodDNSConfig().WithOptions(
+			corev1.PodDNSConfigOption().WithName("timeout").WithValue("1"),
+			corev1.PodDNSConfigOption().WithName("attempts").WithValue("5"),
+		)).
+		WithContainers(corev1.Container().
+			WithName("smesher").
+			WithImage(image).
+			WithImagePullPolicy(apiv1.PullIfNotPresent).
+			WithPorts(
+				corev1.ContainerPort().WithContainerPort(7513).WithName("p2p"),
+				corev1.ContainerPort().WithContainerPort(9092).WithName("grpc-pub"),
+				corev1.ContainerPort().WithContainerPort(9093).WithName("grpc-priv"),
+				corev1.ContainerPort().WithContainerPort(9094).WithName("grpc-post"),
+				corev1.ContainerPort().WithContainerPort(prometheusScrapePort).WithName("prometheus"),
+				corev1.ContainerPort().WithContainerPort(phlareScrapePort).WithName("pprof"),
+			).
+			WithVolumeMounts(
+				corev1.VolumeMount().WithName("data").WithMountPath("/data"),
+				corev1.VolumeMount().WithName("config").WithMountPath(configDir),
+			).
+			WithResources(corev1.ResourceRequirements().
+				WithRequests(activationResources.Get(ctx.Parameters).Requests).
+				WithLimits(activationResources.Get(ctx.Parameters).Limits),
+			).
+			WithStartupProbe(
+				corev1.Probe().WithTCPSocket(
+					corev1.TCPSocketAction().WithPort(intstr.FromInt32(9092)),
+				).WithInitialDelaySeconds(10).WithPeriodSeconds(10),
+			).
+			WithEnv(
+				corev1.EnvVar().WithName("GOMAXPROCS").WithValue("4"),
+			).
+			WithCommand(cmd...),
+		)
+
+	if key != nil {
+		podSpec = podSpec.
+			WithInitContainers(
+				corev1.Container().
+					WithName("file-creator").
+					WithImage("busybox").
+					WithCommand("sh", "-c",
+						fmt.Sprintf("mkdir -p /data/identities && echo -n '%x' > /data/identities/%s", key, keyName),
+					).
+					WithVolumeMounts(
+						corev1.VolumeMount().WithName("data").WithMountPath("/data"),
+					),
+			)
+	}
+
+	deployment := appsv1.Deployment(id, ctx.Namespace).
+		WithLabels(labels).
+		WithSpec(appsv1.DeploymentSpec().
+			WithSelector(metav1.LabelSelector().WithMatchLabels(labels)).
+			WithReplicas(1).
+			WithTemplate(corev1.PodTemplateSpec().
+				WithLabels(labels).
+				WithAnnotations(
+					map[string]string{
+						"prometheus.io/port":   strconv.Itoa(prometheusScrapePort),
+						"prometheus.io/scrape": "true",
+					},
+				).
+				WithSpec(podSpec),
+			),
+		)
+	_, err := ctx.Client.AppsV1().
+		Deployments(ctx.Namespace).
+		Apply(ctx, deployment, apimetav1.ApplyOptions{FieldManager: "test"})
+	if err != nil {
+		return fmt.Errorf("apply pod %s: %w", id, err)
 	}
 	return nil
 }

--- a/systest/cluster/nodes.go
+++ b/systest/cluster/nodes.go
@@ -973,7 +973,7 @@ func deployActivationNode(
 		"--log-encoder=json",
 		"--metrics",
 		"--metrics-port=" + strconv.Itoa(prometheusScrapePort),
-		"--node-service-address=", fmt.Sprintf("http://%s:9099", node),
+		"--node-service-address", fmt.Sprintf("http://%s:9099", node),
 		"--proxy-api-v2-address", fmt.Sprintf("http://%s:9070", node),
 		"--grpc-json-listener", "0.0.0.0:9071",
 		"--proxy-listener", "0.0.0.0:9072",

--- a/systest/cluster/nodes.go
+++ b/systest/cluster/nodes.go
@@ -52,11 +52,6 @@ var (
 		"configuration for smesher service",
 		fastnet.SmesherConfig,
 	)
-	activationConfig = parameters.String(
-		"activation",
-		"configuration for activation service",
-		fastnet.ActivationConfig,
-	)
 
 	smesherResources = parameters.NewParameter(
 		"smesher_resources",

--- a/systest/cluster/nodes.go
+++ b/systest/cluster/nodes.go
@@ -513,6 +513,7 @@ func deployNodeSvc(ctx *testcontext.Context, id string) error {
 				corev1.ServicePort().WithName("grpc-pub").WithPort(9092).WithProtocol("TCP"),
 				corev1.ServicePort().WithName("grpc-priv").WithPort(9093).WithProtocol("TCP"),
 				corev1.ServicePort().WithName("grpc-post").WithPort(9094).WithProtocol("TCP"),
+				corev1.ServicePort().WithName("node-service-listener").WithPort(9099).WithProtocol("TCP"),
 			).
 			WithClusterIP("None"),
 		)

--- a/systest/parameters/fastnet/activation.json
+++ b/systest/parameters/fastnet/activation.json
@@ -1,0 +1,52 @@
+{
+    "preset": "fastnet",
+    "main": {
+        "atx-versions": {
+            "2": 2
+        }
+    },
+    "poet": {
+        "phase-shift": "30s",
+        "cycle-gap": "30s",
+        "grace-period": "10s",
+        "positioning-atx-selection-timeout":"7s"
+    },
+    "api": {
+        "grpc-public-listener": "0.0.0.0:9092",
+        "grpc-private-listener": "0.0.0.0:9093",
+    },
+    "fetch": {
+        "servers-metrics": true,
+        "log-peer-stats-interval": "30s",
+        "servers": {
+            "ax/1": {
+                "interval": "1s",
+                "queue": 200,
+                "requests": 100
+            }
+        }
+    },
+    "hare3": {
+        "committeeupgrade": {
+            "layer": 16,
+            "size": 15
+        }
+    },
+    "smeshing": {
+        "smeshing-verifying-opts": {
+            "smeshing-opts-verifying-min-workers": 1000000
+        }
+    },
+    "certifier": {
+        "client": {
+            "max-retries": 10
+        }
+    },
+    "logging": {
+        "log-encoder": "json",
+        "txHandler": "debug",
+        "grpc": "debug",
+        "sync": "debug",
+        "fetcher": "debug"
+    }
+}

--- a/systest/parameters/fastnet/activation.json
+++ b/systest/parameters/fastnet/activation.json
@@ -13,7 +13,7 @@
     },
     "api": {
         "grpc-public-listener": "0.0.0.0:9092",
-        "grpc-private-listener": "0.0.0.0:9093",
+        "grpc-private-listener": "0.0.0.0:9093"
     },
     "fetch": {
         "servers-metrics": true,

--- a/systest/parameters/fastnet/embed.go
+++ b/systest/parameters/fastnet/embed.go
@@ -7,6 +7,9 @@ import (
 //go:embed "smesher.json"
 var SmesherConfig string
 
+//go:embed "activation.json"
+var ActivationConfig string
+
 //go:embed "poet.conf"
 var PoetConfig string
 

--- a/systest/parameters/fastnet/smesher.json
+++ b/systest/parameters/fastnet/smesher.json
@@ -12,6 +12,7 @@
         "positioning-atx-selection-timeout":"7s"
     },
     "api": {
+        "node-service-listener": "0.0.0.0:9099",
         "grpc-public-listener": "0.0.0.0:9092",
         "grpc-private-listener": "0.0.0.0:9093",
         "grpc-post-listener": "0.0.0.0:9094"

--- a/systest/testcontext/context.go
+++ b/systest/testcontext/context.go
@@ -120,6 +120,9 @@ var (
 	bsSize = parameters.Int(
 		"bs-size", "size of bootstrappers", 1,
 	)
+	nodeSplitSize = parameters.Int(
+		"node-split-size", "size of node split setup", 0,
+	)
 	storage = parameters.String(
 		"storage", "<class>=<size> for the storage", "standard=1Gi",
 	)
@@ -172,6 +175,7 @@ type Context struct {
 	RemoteSize        int
 	PoetSize          int
 	OldSize           int
+	NodeSplitSize     int
 	BootstrapperSize  int
 	Generic           client.Client
 	TestID            string
@@ -363,6 +367,7 @@ func New(t *testing.T, opts ...Opt) *Context {
 		RemoteSize:        0,
 		PoetSize:          poetSize.Get(p),
 		OldSize:           0,
+		NodeSplitSize:     nodeSplitSize.Get(p),
 		BootstrapperSize:  bsSize.Get(p),
 		Image:             imageFlag.Get(p),
 		OldImage:          oldImageFlag.Get(p),

--- a/systest/tests/smeshing_test.go
+++ b/systest/tests/smeshing_test.go
@@ -36,7 +36,9 @@ func TestSmeshing(t *testing.T) {
 
 	tctx := testcontext.New(t)
 	tctx.RemoteSize = tctx.ClusterSize / 4 // 25% of nodes are remote
-	tctx.OldSize = tctx.ClusterSize / 4    // 25% of nodes are old
+
+	// commented out for node split testing
+	// tctx.OldSize = tctx.ClusterSize / 4    // 25% of nodes are old
 	vests := vestingAccs{
 		prepareVesting(t, 3, 8, 20, 1e15, 10e15),
 		prepareVesting(t, 5, 8, 20, 1e15, 10e15),


### PR DESCRIPTION
## Motivation

Tune systests to run smeshers as pair of pods - node and activation.

## Description

Note: split node setup will always deploy non smeshing node
to which there will be deployed connected n-1 activation nodes.
Because of that - node-split-size has to be set to 0 or >1.

## Test Plan

Manual testing.

## TODO

- [ ] Check if that's still working with `OldSize != 0`
- [x] Validate with @kacpersaw if config/cmdline args for activation part is correct

