### PR TITLE
node-split poc: add proposal publish failed state

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/seehuhn/mt19937 v1.0.0
 	github.com/slok/go-http-metrics v0.13.0
-	github.com/spacemeshos/api/release/go v1.57.1-0.20241202142709-bdf986ab9486
+	github.com/spacemeshos/api/release/go v1.57.1-0.20241204141106-34acdbfbd074
 	github.com/spacemeshos/economics v0.1.4
 	github.com/spacemeshos/fixed v0.1.2
 	github.com/spacemeshos/go-scale v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -636,8 +636,8 @@ github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d/go.mod h1:Udh
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
-github.com/spacemeshos/api/release/go v1.57.1-0.20241202142709-bdf986ab9486 h1:V123Te6ZoRehQjrOQudNxds8R/eL5OAo9tXybaKgGvc=
-github.com/spacemeshos/api/release/go v1.57.1-0.20241202142709-bdf986ab9486/go.mod h1:w/WRxR8JVmaeKqEEyL6DCoQxt3oyZOTv4uQSdMXlucM=
+github.com/spacemeshos/api/release/go v1.57.1-0.20241204141106-34acdbfbd074 h1:1rBEgFc/QdLYtFc/fhpKi9+lsCV2Oua/aoo8/X6696c=
+github.com/spacemeshos/api/release/go v1.57.1-0.20241204141106-34acdbfbd074/go.mod h1:w/WRxR8JVmaeKqEEyL6DCoQxt3oyZOTv4uQSdMXlucM=
 github.com/spacemeshos/economics v0.1.4 h1:twlawrcQhYNqPgyDv08+24EL/OgUKz3d7q+PvJIAND0=
 github.com/spacemeshos/economics v0.1.4/go.mod h1:6HKWKiKdxjVQcGa2z/wA0LR4M/DzKib856bP16yqNmQ=
 github.com/spacemeshos/fixed v0.1.2 h1:pENQ8pXFAqin3f15ZLoOVVeSgcmcFJ0IFdFm4+9u4SM=

--- a/identity/state.go
+++ b/identity/state.go
@@ -155,6 +155,25 @@ func (s *ATXBroadcasted) APIStateInfo() *pb.IdentityStateInfo {
 }
 
 // proposal.
+type ProposalPublishFailed struct {
+	Error    error
+	Proposal types.ProposalID
+	Layer    types.LayerID
+}
+
+func (s *ProposalPublishFailed) APIStateInfo() *pb.IdentityStateInfo {
+	return &pb.IdentityStateInfo{
+		State: pb.IdentityState_PROPOSAL_PUBLISH_FAILED,
+		Metadata: &pb.IdentityStateInfo_ProposalPublishFailed{
+			ProposalPublishFailed: &pb.ProposalPublishFailedState{
+				Message:  s.Error.Error(),
+				Proposal: s.Proposal.Bytes(),
+				Layer:    s.Layer.Uint32(),
+			},
+		},
+	}
+}
+
 type ProposalPublished struct {
 	Proposal types.ProposalID
 	Layer    types.LayerID

--- a/miner/mocks/remote_mocks.go
+++ b/miner/mocks/remote_mocks.go
@@ -14,6 +14,7 @@ import (
 	reflect "reflect"
 
 	types "github.com/spacemeshos/go-spacemesh/common/types"
+	identity "github.com/spacemeshos/go-spacemesh/identity"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -200,6 +201,42 @@ func (c *MockidentityStatesAddProposalCall) Do(f func(types.NodeID, *types.Propo
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockidentityStatesAddProposalCall) DoAndReturn(f func(types.NodeID, *types.Proposal)) *MockidentityStatesAddProposalCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// Set mocks base method.
+func (m *MockidentityStates) Set(id types.NodeID, publishEpoch *types.EpochID, newState identity.State) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Set", id, publishEpoch, newState)
+}
+
+// Set indicates an expected call of Set.
+func (mr *MockidentityStatesMockRecorder) Set(id, publishEpoch, newState any) *MockidentityStatesSetCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Set", reflect.TypeOf((*MockidentityStates)(nil).Set), id, publishEpoch, newState)
+	return &MockidentityStatesSetCall{Call: call}
+}
+
+// MockidentityStatesSetCall wrap *gomock.Call
+type MockidentityStatesSetCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockidentityStatesSetCall) Return() *MockidentityStatesSetCall {
+	c.Call = c.Call.Return()
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockidentityStatesSetCall) Do(f func(types.NodeID, *types.EpochID, identity.State)) *MockidentityStatesSetCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockidentityStatesSetCall) DoAndReturn(f func(types.NodeID, *types.EpochID, identity.State)) *MockidentityStatesSetCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/miner/remote_proposals.go
+++ b/miner/remote_proposals.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/spacemeshos/go-spacemesh/codec"
 	"github.com/spacemeshos/go-spacemesh/common/types"
+	smesherIdentity "github.com/spacemeshos/go-spacemesh/identity"
 	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/p2p/pubsub"
 	"github.com/spacemeshos/go-spacemesh/signing"
@@ -33,6 +34,7 @@ type identityStates interface {
 		epoch types.EpochID,
 		eligibilities map[types.LayerID][]types.VotingEligibility)
 	AddProposal(id types.NodeID, proposals *types.Proposal)
+	Set(id types.NodeID, publishEpoch *types.EpochID, newState smesherIdentity.State)
 }
 
 type RemoteProposalBuilder struct {
@@ -231,8 +233,14 @@ func (pb *RemoteProposalBuilder) build(
 				zap.Stringer("id", proposal.ID()),
 				zap.Error(err),
 			)
+			pb.identityStates.Set(nodeId, &epoch, &smesherIdentity.ProposalPublishFailed{
+				Error:    err,
+				Proposal: proposal.ID(),
+				Layer:    proposal.Layer,
+			})
+		} else {
+			pb.identityStates.AddProposal(nodeId, proposal)
 		}
-		pb.identityStates.AddProposal(nodeId, proposal)
 	}
 	return nil
 }


### PR DESCRIPTION
## Description

This PR adds support for new state `PROPOSAL_PUBLISH_FAILED`

Error handling improvements:

* [`identity/state.go`](diffhunk://#diff-5530b4d983e4d2c975e259e57c5e6b716077176c9fe05e2b540da075494c11f5R158-R176): Added a new `ProposalPublishFailed` struct and its corresponding `APIStateInfo` method to handle proposal publish failures.
* [`miner/remote_proposals.go`](diffhunk://#diff-cfc4631c43f6e92e7dd50273be5292c83e032d41e8f3085c28c26095658ef644R37): Updated the `identityStates` interface to include a new `Set` method and used it to handle proposal publish failures in the `build` method. [[1]](diffhunk://#diff-cfc4631c43f6e92e7dd50273be5292c83e032d41e8f3085c28c26095658ef644R37) [[2]](diffhunk://#diff-cfc4631c43f6e92e7dd50273be5292c83e032d41e8f3085c28c26095658ef644L234-R244)