### PR TITLE
[Merged by Bors] - Add more info to failing systests

### DIFF
--- a/systest/tests/common.go
+++ b/systest/tests/common.go
@@ -133,6 +133,9 @@ BACKOFF:
 		state, err := states.Recv()
 		s, ok := status.FromError(err)
 		if !ok {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
 			return fmt.Errorf("unknown error: %w", err)
 		}
 		switch s.Code() {
@@ -190,6 +193,9 @@ BACKOFF:
 		layer, err := layers.Recv()
 		s, ok := status.FromError(err)
 		if !ok {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
 			return fmt.Errorf("unknown error: %w", err)
 		}
 		switch s.Code() {
@@ -235,6 +241,9 @@ BACKOFF:
 		proof, err := proofs.Recv()
 		s, ok := status.FromError(err)
 		if !ok {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
 			return fmt.Errorf("unknown error: %w", err)
 		}
 		switch s.Code() {
@@ -337,6 +346,9 @@ BACKOFF:
 		rst, err := rsts.Recv()
 		s, ok := status.FromError(err)
 		if !ok {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
 			return fmt.Errorf("unknown error: %w", err)
 		}
 		switch s.Code() {
@@ -384,6 +396,9 @@ func watchProposals(
 			proposal, err := proposals.Recv()
 			s, ok := status.FromError(err)
 			if !ok {
+				if ctx.Err() != nil {
+					return ctx.Err()
+				}
 				return fmt.Errorf("unknown error: %w", err)
 			}
 			switch s.Code() {


### PR DESCRIPTION
## Motivation

Instead of just printing `unknown error: EOF` add a bit more info as to why watching transaction results sometimes fails.

## Description

Now when transaction results fail to be watched in time for all nodes that didn't complete to stream their information an error will be logged with the clients name and the cause of the issue. Additionally instead of returning `io.EOF` as an unknown error double check if this error is caused by the context that was passed to the stream being cancelled / timed out.

## Test Plan

- existing tests pass and print more info

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
