### PR TITLE
[Merged by Bors] - sync2: do not run sync against already synced peers

### DIFF
--- a/sync2/multipeer/multipeer.go
+++ b/sync2/multipeer/multipeer.go
@@ -182,13 +182,13 @@ func (mpr *MultiPeerReconciler) probePeers(ctx context.Context, syncPeers []p2p.
 		eg.Go(func() error {
 			mpr.logger.Debug("probe peer", zap.Stringer("peer", p))
 			pr, err := mpr.syncBase.Probe(ctx, p)
-			if err != nil {
-				mpr.logger.Warn("error probing the peer", zap.Any("peer", p), zap.Error(err))
-				if errors.Is(err, context.Canceled) {
-					return err
-				}
-			} else {
+			switch {
+			case err == nil:
 				probeCh <- probeResult{p, pr}
+			case errors.Is(err, context.Canceled):
+				return err
+			default:
+				mpr.logger.Warn("error probing the peer", zap.Any("peer", p), zap.Error(err))
 			}
 			return nil
 		})

--- a/sync2/multipeer/multipeer.go
+++ b/sync2/multipeer/multipeer.go
@@ -29,6 +29,8 @@ type syncability struct {
 	splitSyncable []p2p.Peer
 	// Number of peers that are similar enough to this one for full sync
 	nearFullCount int
+	// Number of peers that are in sync with this one
+	inSyncCount int
 }
 
 type runner struct {
@@ -164,9 +166,6 @@ func NewMultiPeerReconciler(
 
 func (mpr *MultiPeerReconciler) probePeers(ctx context.Context, syncPeers []p2p.Peer) (syncability, error) {
 	var s syncability
-	s.syncable = nil
-	s.splitSyncable = nil
-	s.nearFullCount = 0
 	type probeResult struct {
 		p p2p.Peer
 		rangesync.ProbeResult
@@ -204,11 +203,21 @@ func (mpr *MultiPeerReconciler) probePeers(ctx context.Context, syncPeers []p2p.
 	})
 
 	for pr := range probeCh {
+		if pr.InSync {
+			mpr.logger.Debug("peer already in sync",
+				zap.Stringer("peer", pr.p),
+				zap.Int("peerCount", pr.Count),
+				zap.Int("localCount", localCount))
+			s.inSyncCount++
+			continue
+		}
+
 		// We do not consider peers with substantially fewer items than the local
 		// set for active sync. It's these peers' responsibility to request sync
 		// against this node.
 		if pr.Count+mpr.cfg.MaxSyncDiff < localCount {
 			mpr.logger.Debug("skipping peer with low item count",
+				zap.Stringer("peer", pr.p),
 				zap.Int("peerCount", pr.Count),
 				zap.Int("localCount", localCount))
 			continue
@@ -315,9 +324,22 @@ func (mpr *MultiPeerReconciler) syncOnce(ctx context.Context, lastWasSplit bool)
 			if err != nil {
 				return false, err
 			}
+			mpr.logger.Debug("probing peers done",
+				zap.Int("syncableCount", len(s.syncable)),
+				zap.Int("splitSyncableCount", len(s.splitSyncable)),
+				zap.Int("nearFullCount", s.nearFullCount),
+				zap.Int("inSyncCount", s.inSyncCount))
 			if len(s.syncable) != 0 {
 				break
 			}
+		}
+
+		// We try to sync against peers which are not in full sync with this one.
+		// If there are no such peers, but there are some which are in sync with
+		// us, we consider this node to be in sync.
+		if s.inSyncCount > 0 {
+			mpr.sl.NoteSync()
+			return true, nil
 		}
 
 		mpr.logger.Debug("no peers found, waiting", zap.Duration("duration", mpr.cfg.NoPeersRecheckInterval))

--- a/sync2/multipeer/setsyncbase_test.go
+++ b/sync2/multipeer/setsyncbase_test.go
@@ -52,9 +52,9 @@ func TestSetSyncBase(t *testing.T) {
 		t.Parallel()
 		st := newSetSyncBaseTester(t, nil)
 		expPr := rangesync.ProbeResult{
-			FP:    rangesync.RandomFingerprint(),
-			Count: 42,
-			Sim:   0.99,
+			InSync: false,
+			Count:  42,
+			Sim:    0.99,
 		}
 		set := st.expectCopy()
 		st.ps.EXPECT().Probe(gomock.Any(), p2p.Peer("p1"), set, nil, nil).Return(expPr, nil)

--- a/sync2/rangesync/p2p_test.go
+++ b/sync2/rangesync/p2p_test.go
@@ -298,7 +298,7 @@ func testWireProbe(t *testing.T, getRequester getRequesterFunc) {
 	require.NoError(t, err)
 	prA, err := pss.Probe(ctx, cst.srvPeerID, st.setB, nil, nil)
 	require.NoError(t, err)
-	require.Equal(t, infoA.Fingerprint, prA.FP)
+	require.False(t, prA.InSync)
 	require.Equal(t, infoA.Count, prA.Count)
 	require.InDelta(t, 0.98, prA.Sim, 0.05, "sim")
 
@@ -306,7 +306,7 @@ func testWireProbe(t *testing.T, getRequester getRequesterFunc) {
 	require.NoError(t, err)
 	prA, err = pss.Probe(ctx, cst.srvPeerID, st.setB, x, splitInfo.Middle)
 	require.NoError(t, err)
-	require.Equal(t, splitInfo.Parts[0].Fingerprint, prA.FP)
+	require.False(t, prA.InSync)
 	require.Equal(t, splitInfo.Parts[0].Count, prA.Count)
 	require.InDelta(t, 0.98, prA.Sim, 0.1, "sim")
 }

--- a/sync2/rangesync/rangesync.go
+++ b/sync2/rangesync/rangesync.go
@@ -562,13 +562,13 @@ func (rsr *RangeSetReconciler) handleSample(
 	}
 	if info.Fingerprint == msg.Fingerprint() {
 		pr.Sim = 1
-	} else {
-		localSample, err := Sample(info.Items, info.Count, rsr.cfg.SampleSize)
-		if err != nil {
-			return ProbeResult{}, fmt.Errorf("sampling local items: %w", err)
-		}
-		pr.Sim = CalcSim(localSample, msg.Sample())
+		return pr, nil
 	}
+	localSample, err := Sample(info.Items, info.Count, rsr.cfg.SampleSize)
+	if err != nil {
+		return ProbeResult{}, fmt.Errorf("sampling local items: %w", err)
+	}
+	pr.Sim = CalcSim(localSample, msg.Sample())
 	return pr, nil
 }
 

--- a/sync2/rangesync/rangesync.go
+++ b/sync2/rangesync/rangesync.go
@@ -557,8 +557,8 @@ func (rsr *RangeSetReconciler) handleSample(
 ) (pr ProbeResult, err error) {
 	pr.InSync = msg.Fingerprint() == info.Fingerprint
 	pr.Count = msg.Count()
-	if pr.InSync && pr.Count != msg.Count() {
-		return ProbeResult{}, errors.New("mismatched count with matching fingerprint, collision?")
+	if pr.InSync && pr.Count != info.Count {
+		return ProbeResult{}, errors.New("mismatched count with matching fingerprint, possible collision")
 	}
 	if info.Fingerprint == msg.Fingerprint() {
 		pr.Sim = 1

--- a/sync2/rangesync/rangesync.go
+++ b/sync2/rangesync/rangesync.go
@@ -66,8 +66,11 @@ func (t nullTracer) OnRecent(int, int) {}
 
 // ProbeResult contains the result of a probe.
 type ProbeResult struct {
-	// Fingerprint of the range.
-	FP any
+	// True if the peer's range (or full set) is fully in sync with the local range
+	// (or full set).
+	// Note that Sim==1 does not guarantee that the peer is in sync b/c simhash
+	// algorithm is not precise.
+	InSync bool
 	// Number of items in the range.
 	Count int
 	// An estimate of Jaccard similarity coefficient between the sets.
@@ -552,8 +555,11 @@ func (rsr *RangeSetReconciler) handleSample(
 	msg SyncMessage,
 	info RangeInfo,
 ) (pr ProbeResult, err error) {
-	pr.FP = msg.Fingerprint()
+	pr.InSync = msg.Fingerprint() == info.Fingerprint
 	pr.Count = msg.Count()
+	if pr.InSync && pr.Count != msg.Count() {
+		return ProbeResult{}, errors.New("mismatched count with matching fingerprint, collision?")
+	}
 	if info.Fingerprint == msg.Fingerprint() {
 		pr.Sim = 1
 	} else {


### PR DESCRIPTION
## Motivation

Initiating sync against peers which are already in sync wastes network traffic and may cause unneeded database accesses. Before initiating any sync, the node probes its peers, and after the probe it can be immediately seen which nodes are in sync with this one.

## Description

Do not sync against nodes which turn out to be in sync with this one after probing. Consider the node to be in sync and do no syncing at all if all the peers selected for sync are in sync with this node.
