### PR TITLE
[Merged by Bors] - sync2: advance OrderedSet on timer

### DIFF
--- a/sync2/multipeer/setsyncbase.go
+++ b/sync2/multipeer/setsyncbase.go
@@ -80,10 +80,11 @@ func (ssb *SetSyncBase) syncPeer(
 		if err := ssb.handler.Commit(ctx, p, ssb.os, sr); err != nil {
 			return fmt.Errorf("commit: %w", err)
 		}
+		ssb.mtx.Lock()
+		defer ssb.mtx.Unlock()
+		return ssb.os.Advance()
 	}
-	ssb.mtx.Lock()
-	defer ssb.mtx.Unlock()
-	return ssb.os.Advance()
+	return nil
 }
 
 func (ssb *SetSyncBase) Sync(ctx context.Context, p p2p.Peer, x, y rangesync.KeyBytes) error {


### PR DESCRIPTION
## Motivation

`OrderedSet` is bound to a "snapshot" of its table, which is bounded by max `rowid` value. In order for `OrderedSet` to ingest newly added rows, its `Advance()` method must be called, which, in case of `DBSet`, updates the underlying `FPTree` with freshly added entries, which it discovers by selecting items with `rowid` > `maxSnapshotRowID`.

Before this change, `Advance()` was being called after each peer sync, including both incoming sync requests handled by the server and requests initiated by active sync, no matter whether any new items were received. This was causing some unnecessary database access activity which can be avoided.

## Description

With this change, `Advance()` is called after each sync during which the node has received new items, and also once per configured interval (defaults to 1 min), ingesting any items that were added by means of e.g. handling gossiped ATXs or via old sync (in case of server-only `syncv2`) and making them available for following syncs.