### PR TITLE
[Merged by Bors] - Use go version specified by go.mod for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: CI
 
 env:
-  go-version: "1.23"
   GCLOUD_KEY: ${{ secrets.GCLOUD_KEY }}
   PROJECT_NAME: ${{ secrets.PROJECT_NAME }}
   CLUSTER_NAME: ${{ secrets.CLUSTER_NAME }}
@@ -79,7 +78,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           check-latest: true
-          go-version: ${{ env.go-version }}
+          go-version-file: "go.mod"
       - name: fmt, tidy, generate
         run: |
           make install
@@ -110,7 +109,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           check-latest: true
-          go-version: ${{ env.go-version }}
+          go-version-file: "go.mod"
       - name: setup env
         run: make install
       - name: lint
@@ -157,7 +156,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           check-latest: true
-          go-version: ${{ env.go-version }}
+          go-version-file: "go.mod"
           cache: ${{ runner.arch != 'arm64' }}
       - name: setup env
         run: make install
@@ -267,7 +266,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           check-latest: true
-          go-version: ${{ env.go-version }}
+          go-version-file: "go.mod"
           cache: ${{ runner.arch != 'arm64' }}
       - name: Add OpenCL support - Ubuntu
         if: ${{ matrix.os == 'ubuntu-22.04' || matrix.os == 'ubuntu-latest-arm-8-cores' }}


### PR DESCRIPTION
## Motivation

The CI still uses a hard coded go version to build and unit test the node code. Both the release and systest jobs already parse and use the version specified in `go.mod`. This updates the CI to also use the version in `go.mod` instead of a hard coded setting.

## Description

When setting up go on the runner use the version specified in `go.mod` for build and unit test jobs instead of a hard coded version.

## Test Plan

existing tests pass

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
