### PR TITLE
node-split-poc: calculate eligibility on epoch's first layer

### DIFF
--- a/activation/post_supervisor_test.go
+++ b/activation/post_supervisor_test.go
@@ -51,11 +51,11 @@ func newPostManager(tb testing.TB, cfg PostConfig, opts PostSetupOpts) *PostSetu
 		AnyTimes()
 
 	syncer := NewMockSyncer(ctrl)
-	syncer.EXPECT().RegisterForATXSynced().DoAndReturn(func() <-chan struct{} {
-		ch := make(chan struct{})
-		close(ch)
-		return ch
-	})
+	//syncer.EXPECT().RegisterForATXSynced().DoAndReturn(func() <-chan struct{} {
+	//	ch := make(chan struct{})
+	//	close(ch)
+	//	return ch
+	//})
 	db := statesql.InMemoryTest(tb)
 	atxsdata := atxsdata.New()
 	mgr, err := NewPostSetupManager(cfg, zaptest.NewLogger(tb), db, atxsdata, types.RandomATXID(), syncer, validator)

--- a/api/grpcserver/post_service_test.go
+++ b/api/grpcserver/post_service_test.go
@@ -53,11 +53,11 @@ func launchPostSupervisor(
 		AnyTimes()
 
 	syncer := activation.NewMockSyncer(ctrl)
-	syncer.EXPECT().RegisterForATXSynced().DoAndReturn(func() <-chan struct{} {
-		ch := make(chan struct{})
-		close(ch)
-		return ch
-	})
+	//syncer.EXPECT().RegisterForATXSynced().DoAndReturn(func() <-chan struct{} {
+	//	ch := make(chan struct{})
+	//	close(ch)
+	//	return ch
+	//})
 	db := statesql.InMemoryTest(tb)
 	logger := log.Named("post manager")
 	mgr, err := activation.NewPostSetupManager(postCfg, logger, db, atxsdata.New(), goldenATXID, syncer, validator)

--- a/api/grpcserver/post_service_test.go
+++ b/api/grpcserver/post_service_test.go
@@ -97,11 +97,11 @@ func launchPostSupervisorTLS(
 		Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		AnyTimes()
 	syncer := activation.NewMockSyncer(ctrl)
-	syncer.EXPECT().RegisterForATXSynced().DoAndReturn(func() <-chan struct{} {
-		ch := make(chan struct{})
-		close(ch)
-		return ch
-	})
+	//syncer.EXPECT().RegisterForATXSynced().DoAndReturn(func() <-chan struct{} {
+	//	ch := make(chan struct{})
+	//	close(ch)
+	//	return ch
+	//})
 	db := statesql.InMemoryTest(tb)
 	logger := log.Named("post supervisor")
 	mgr, err := activation.NewPostSetupManager(postCfg, logger, db, atxsdata.New(), goldenATXID, syncer, validator)

--- a/api/node/client/client.gen.go
+++ b/api/node/client/client.gen.go
@@ -115,6 +115,9 @@ type ClientInterface interface {
 	// GetActivationPositioningAtxPublishEpoch request
 	GetActivationPositioningAtxPublishEpoch(ctx context.Context, publishEpoch externalRef0.EpochID, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// GetEligibilitySlotsNodeEpoch request
+	GetEligibilitySlotsNodeEpoch(ctx context.Context, node externalRef0.NodeID, epoch externalRef0.EpochID, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// GetHareBeaconEpoch request
 	GetHareBeaconEpoch(ctx context.Context, epoch externalRef0.EpochID, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -163,6 +166,18 @@ func (c *Client) GetActivationLastAtxNodeId(ctx context.Context, nodeId external
 
 func (c *Client) GetActivationPositioningAtxPublishEpoch(ctx context.Context, publishEpoch externalRef0.EpochID, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewGetActivationPositioningAtxPublishEpochRequest(c.Server, publishEpoch)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetEligibilitySlotsNodeEpoch(ctx context.Context, node externalRef0.NodeID, epoch externalRef0.EpochID, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetEligibilitySlotsNodeEpochRequest(c.Server, node, epoch)
 	if err != nil {
 		return nil, err
 	}
@@ -342,6 +357,47 @@ func NewGetActivationPositioningAtxPublishEpochRequest(server string, publishEpo
 	}
 
 	operationPath := fmt.Sprintf("/activation/positioning_atx/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetEligibilitySlotsNodeEpochRequest generates requests for GetEligibilitySlotsNodeEpoch
+func NewGetEligibilitySlotsNodeEpochRequest(server string, node externalRef0.NodeID, epoch externalRef0.EpochID) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "node", runtime.ParamLocationPath, node)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "epoch", runtime.ParamLocationPath, epoch)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/eligibility/slots/%s/%s", pathParam0, pathParam1)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -674,6 +730,9 @@ type ClientWithResponsesInterface interface {
 	// GetActivationPositioningAtxPublishEpochWithResponse request
 	GetActivationPositioningAtxPublishEpochWithResponse(ctx context.Context, publishEpoch externalRef0.EpochID, reqEditors ...RequestEditorFn) (*GetActivationPositioningAtxPublishEpochResponse, error)
 
+	// GetEligibilitySlotsNodeEpochWithResponse request
+	GetEligibilitySlotsNodeEpochWithResponse(ctx context.Context, node externalRef0.NodeID, epoch externalRef0.EpochID, reqEditors ...RequestEditorFn) (*GetEligibilitySlotsNodeEpochResponse, error)
+
 	// GetHareBeaconEpochWithResponse request
 	GetHareBeaconEpochWithResponse(ctx context.Context, epoch externalRef0.EpochID, reqEditors ...RequestEditorFn) (*GetHareBeaconEpochResponse, error)
 
@@ -758,6 +817,30 @@ func (r GetActivationPositioningAtxPublishEpochResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r GetActivationPositioningAtxPublishEpochResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetEligibilitySlotsNodeEpochResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		Slots uint32 `json:"Slots"`
+	}
+}
+
+// Status returns HTTPResponse.Status
+func (r GetEligibilitySlotsNodeEpochResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetEligibilitySlotsNodeEpochResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -938,6 +1021,15 @@ func (c *ClientWithResponses) GetActivationPositioningAtxPublishEpochWithRespons
 	return ParseGetActivationPositioningAtxPublishEpochResponse(rsp)
 }
 
+// GetEligibilitySlotsNodeEpochWithResponse request returning *GetEligibilitySlotsNodeEpochResponse
+func (c *ClientWithResponses) GetEligibilitySlotsNodeEpochWithResponse(ctx context.Context, node externalRef0.NodeID, epoch externalRef0.EpochID, reqEditors ...RequestEditorFn) (*GetEligibilitySlotsNodeEpochResponse, error) {
+	rsp, err := c.GetEligibilitySlotsNodeEpoch(ctx, node, epoch, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetEligibilitySlotsNodeEpochResponse(rsp)
+}
+
 // GetHareBeaconEpochWithResponse request returning *GetHareBeaconEpochResponse
 func (c *ClientWithResponses) GetHareBeaconEpochWithResponse(ctx context.Context, epoch externalRef0.EpochID, reqEditors ...RequestEditorFn) (*GetHareBeaconEpochResponse, error) {
 	rsp, err := c.GetHareBeaconEpoch(ctx, epoch, reqEditors...)
@@ -1070,6 +1162,34 @@ func ParseGetActivationPositioningAtxPublishEpochResponse(rsp *http.Response) (*
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest struct {
 			ID externalRef0.ATXID `json:"ID"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetEligibilitySlotsNodeEpochResponse parses an HTTP response from a GetEligibilitySlotsNodeEpochWithResponse call
+func ParseGetEligibilitySlotsNodeEpochResponse(rsp *http.Response) (*GetEligibilitySlotsNodeEpochResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetEligibilitySlotsNodeEpochResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			Slots uint32 `json:"Slots"`
 		}
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err

--- a/api/node/client/client.gen.go
+++ b/api/node/client/client.gen.go
@@ -827,6 +827,7 @@ type GetEligibilitySlotsNodeEpochResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *struct {
+		Nonce uint64 `json:"Nonce"`
 		Slots uint32 `json:"Slots"`
 	}
 }
@@ -1189,6 +1190,7 @@ func ParseGetEligibilitySlotsNodeEpochResponse(rsp *http.Response) (*GetEligibil
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest struct {
+			Nonce uint64 `json:"Nonce"`
 			Slots uint32 `json:"Slots"`
 		}
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {

--- a/api/node/client/client.go
+++ b/api/node/client/client.go
@@ -252,28 +252,14 @@ func (s *NodeService) Proposal(ctx context.Context, layer types.LayerID, node ty
 func (s *NodeService) CalculateEligibilitySlotsFor(
 	ctx context.Context, node types.NodeID, epoch types.EpochID,
 ) (uint32, types.VRFPostIndex, error) {
-	resp, err := s.client.GetEligibilitySlotsNodeEpoch(ctx, node.String(), externalRef0.EpochID(epoch))
+	resp, err := s.client.GetEligibilitySlotsNodeEpochWithResponse(ctx, node.String(), externalRef0.EpochID(epoch))
 	if err != nil {
 		return 0, 0, err
 	}
-	switch resp.StatusCode {
+	switch resp.StatusCode() {
 	case http.StatusOK:
 	default:
 		return 0, 0, fmt.Errorf("unexpected status: %s", resp.Status)
 	}
-	atxNonce := resp.Header.Get("X-Spacemesh-Atx-Nonce")
-	if atxNonce == "" {
-		return 0, 0, errors.New("missing atx nonce")
-	}
-	nonce, err := strconv.ParseUint(atxNonce, 10, 64)
-	if err != nil {
-		return 0, 0, fmt.Errorf("nonce parse: %w", err)
-	}
-
-	res, err := ParseGetEligibilitySlotsNodeEpochResponse(resp)
-	if err != nil {
-		return 0, 0, fmt.Errorf("response body parse: %w", err)
-	}
-
-	return res.JSON200.Slots, types.VRFPostIndex(nonce), nil
+	return resp.JSON200.Slots, types.VRFPostIndex(resp.JSON200.Nonce), nil
 }

--- a/api/node/client/client.go
+++ b/api/node/client/client.go
@@ -259,7 +259,7 @@ func (s *NodeService) CalculateEligibilitySlotsFor(
 	switch resp.StatusCode() {
 	case http.StatusOK:
 	default:
-		return 0, 0, fmt.Errorf("unexpected status: %s", resp.Status)
+		return 0, 0, fmt.Errorf("unexpected status: %s", resp.Status())
 	}
 	return resp.JSON200.Slots, types.VRFPostIndex(resp.JSON200.Nonce), nil
 }

--- a/api/node/client/client.go
+++ b/api/node/client/client.go
@@ -248,3 +248,32 @@ func (s *NodeService) Proposal(ctx context.Context, layer types.LayerID, node ty
 	}
 	return &prop, nonce, nil
 }
+
+func (s *NodeService) CalculateEligibilitySlotsFor(
+	ctx context.Context, node types.NodeID, epoch types.EpochID,
+) (uint32, types.VRFPostIndex, error) {
+	resp, err := s.client.GetEligibilitySlotsNodeEpoch(ctx, node.String(), externalRef0.EpochID(epoch))
+	if err != nil {
+		return 0, 0, err
+	}
+	switch resp.StatusCode {
+	case http.StatusOK:
+	default:
+		return 0, 0, fmt.Errorf("unexpected status: %s", resp.Status)
+	}
+	atxNonce := resp.Header.Get("X-Spacemesh-Atx-Nonce")
+	if atxNonce == "" {
+		return 0, 0, errors.New("missing atx nonce")
+	}
+	nonce, err := strconv.ParseUint(atxNonce, 10, 64)
+	if err != nil {
+		return 0, 0, fmt.Errorf("nonce parse: %w", err)
+	}
+
+	res, err := ParseGetEligibilitySlotsNodeEpochResponse(resp)
+	if err != nil {
+		return 0, 0, fmt.Errorf("response body parse: %w", err)
+	}
+
+	return res.JSON200.Slots, types.VRFPostIndex(nonce), nil
+}

--- a/api/node/node_service.yaml
+++ b/api/node/node_service.yaml
@@ -278,8 +278,12 @@ paths:
                   Slots:
                     type: integer
                     format: uint32
+                  Nonce:
+                    type: integer
+                    format: uint64
                 required:
                   - Slots
+                  - Nonce
         "500":
             description: could not calculate eligibility slots
 

--- a/api/node/node_service.yaml
+++ b/api/node/node_service.yaml
@@ -251,4 +251,35 @@ paths:
           description: no eligibilities for this node in this epoch
         "500":
           description: could not generate proposal
+  /eligibility/slots/{node}/{epoch}:
+    get:
+      summary: Get epoch eligibility slots for a given node id
+      tags:
+        - "proposals"
+      parameters:
+        - in: path
+          name: node
+          required: true
+          schema:
+              $ref: "models/components.yaml#/components/schemas/NodeID"
+        - in: path
+          name: epoch
+          required: true
+          schema:
+            $ref: "models/components.yaml#/components/schemas/EpochID"
+      responses:
+        "200":
+          description: successfully calculated the slots
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  Slots:
+                    type: integer
+                    format: uint32
+                required:
+                  - Slots
+        "500":
+            description: could not calculate eligibility slots
 

--- a/api/node/server/mocks.go
+++ b/api/node/server/mocks.go
@@ -322,3 +322,43 @@ func (c *MockproposalBuilderBuildForCall) DoAndReturn(f func(context.Context, ty
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
+
+// CalculateEligibilitySlotsFor mocks base method.
+func (m *MockproposalBuilder) CalculateEligibilitySlotsFor(ctx context.Context, node types.NodeID, epoch types.EpochID) (uint32, types.VRFPostIndex, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CalculateEligibilitySlotsFor", ctx, node, epoch)
+	ret0, _ := ret[0].(uint32)
+	ret1, _ := ret[1].(types.VRFPostIndex)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// CalculateEligibilitySlotsFor indicates an expected call of CalculateEligibilitySlotsFor.
+func (mr *MockproposalBuilderMockRecorder) CalculateEligibilitySlotsFor(ctx, node, epoch any) *MockproposalBuilderCalculateEligibilitySlotsForCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CalculateEligibilitySlotsFor", reflect.TypeOf((*MockproposalBuilder)(nil).CalculateEligibilitySlotsFor), ctx, node, epoch)
+	return &MockproposalBuilderCalculateEligibilitySlotsForCall{Call: call}
+}
+
+// MockproposalBuilderCalculateEligibilitySlotsForCall wrap *gomock.Call
+type MockproposalBuilderCalculateEligibilitySlotsForCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockproposalBuilderCalculateEligibilitySlotsForCall) Return(arg0 uint32, arg1 types.VRFPostIndex, arg2 error) *MockproposalBuilderCalculateEligibilitySlotsForCall {
+	c.Call = c.Call.Return(arg0, arg1, arg2)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockproposalBuilderCalculateEligibilitySlotsForCall) Do(f func(context.Context, types.NodeID, types.EpochID) (uint32, types.VRFPostIndex, error)) *MockproposalBuilderCalculateEligibilitySlotsForCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockproposalBuilderCalculateEligibilitySlotsForCall) DoAndReturn(f func(context.Context, types.NodeID, types.EpochID) (uint32, types.VRFPostIndex, error)) *MockproposalBuilderCalculateEligibilitySlotsForCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}

--- a/api/node/server/server.gen.go
+++ b/api/node/server/server.gen.go
@@ -45,6 +45,9 @@ type ServerInterface interface {
 	// Get Positioning ATX ID with given maximum publish epoch
 	// (GET /activation/positioning_atx/{publish_epoch})
 	GetActivationPositioningAtxPublishEpoch(w http.ResponseWriter, r *http.Request, publishEpoch externalRef0.EpochID)
+	// Get epoch eligibility slots for a given node id
+	// (GET /eligibility/slots/{node}/{epoch})
+	GetEligibilitySlotsNodeEpoch(w http.ResponseWriter, r *http.Request, node externalRef0.NodeID, epoch externalRef0.EpochID)
 	// Get the beacon value for an epoch
 	// (GET /hare/beacon/{epoch})
 	GetHareBeaconEpoch(w http.ResponseWriter, r *http.Request, epoch externalRef0.EpochID)
@@ -143,6 +146,40 @@ func (siw *ServerInterfaceWrapper) GetActivationPositioningAtxPublishEpoch(w htt
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.GetActivationPositioningAtxPublishEpoch(w, r, publishEpoch)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetEligibilitySlotsNodeEpoch operation middleware
+func (siw *ServerInterfaceWrapper) GetEligibilitySlotsNodeEpoch(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "node" -------------
+	var node externalRef0.NodeID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "node", r.PathValue("node"), &node, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "node", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "epoch" -------------
+	var epoch externalRef0.EpochID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "epoch", r.PathValue("epoch"), &epoch, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "epoch", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetEligibilitySlotsNodeEpoch(w, r, node, epoch)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -475,6 +512,7 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 	m.HandleFunc("GET "+options.BaseURL+"/activation/atx/{atx_id}", wrapper.GetActivationAtxAtxId)
 	m.HandleFunc("GET "+options.BaseURL+"/activation/last_atx/{node_id}", wrapper.GetActivationLastAtxNodeId)
 	m.HandleFunc("GET "+options.BaseURL+"/activation/positioning_atx/{publish_epoch}", wrapper.GetActivationPositioningAtxPublishEpoch)
+	m.HandleFunc("GET "+options.BaseURL+"/eligibility/slots/{node}/{epoch}", wrapper.GetEligibilitySlotsNodeEpoch)
 	m.HandleFunc("GET "+options.BaseURL+"/hare/beacon/{epoch}", wrapper.GetHareBeaconEpoch)
 	m.HandleFunc("GET "+options.BaseURL+"/hare/round_template/{layer}/{iter}/{round}", wrapper.GetHareRoundTemplateLayerIterRound)
 	m.HandleFunc("GET "+options.BaseURL+"/hare/total_weight/{layer}", wrapper.GetHareTotalWeightLayer)
@@ -572,6 +610,34 @@ func (response GetActivationPositioningAtxPublishEpoch200JSONResponse) VisitGetA
 	w.WriteHeader(200)
 
 	return json.NewEncoder(w).Encode(response)
+}
+
+type GetEligibilitySlotsNodeEpochRequestObject struct {
+	Node  externalRef0.NodeID  `json:"node"`
+	Epoch externalRef0.EpochID `json:"epoch"`
+}
+
+type GetEligibilitySlotsNodeEpochResponseObject interface {
+	VisitGetEligibilitySlotsNodeEpochResponse(w http.ResponseWriter) error
+}
+
+type GetEligibilitySlotsNodeEpoch200JSONResponse struct {
+	Slots uint32 `json:"Slots"`
+}
+
+func (response GetEligibilitySlotsNodeEpoch200JSONResponse) VisitGetEligibilitySlotsNodeEpochResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetEligibilitySlotsNodeEpoch500Response struct {
+}
+
+func (response GetEligibilitySlotsNodeEpoch500Response) VisitGetEligibilitySlotsNodeEpochResponse(w http.ResponseWriter) error {
+	w.WriteHeader(500)
+	return nil
 }
 
 type GetHareBeaconEpochRequestObject struct {
@@ -824,6 +890,9 @@ type StrictServerInterface interface {
 	// Get Positioning ATX ID with given maximum publish epoch
 	// (GET /activation/positioning_atx/{publish_epoch})
 	GetActivationPositioningAtxPublishEpoch(ctx context.Context, request GetActivationPositioningAtxPublishEpochRequestObject) (GetActivationPositioningAtxPublishEpochResponseObject, error)
+	// Get epoch eligibility slots for a given node id
+	// (GET /eligibility/slots/{node}/{epoch})
+	GetEligibilitySlotsNodeEpoch(ctx context.Context, request GetEligibilitySlotsNodeEpochRequestObject) (GetEligibilitySlotsNodeEpochResponseObject, error)
 	// Get the beacon value for an epoch
 	// (GET /hare/beacon/{epoch})
 	GetHareBeaconEpoch(ctx context.Context, request GetHareBeaconEpochRequestObject) (GetHareBeaconEpochResponseObject, error)
@@ -947,6 +1016,33 @@ func (sh *strictHandler) GetActivationPositioningAtxPublishEpoch(w http.Response
 		sh.options.ResponseErrorHandlerFunc(w, r, err)
 	} else if validResponse, ok := response.(GetActivationPositioningAtxPublishEpochResponseObject); ok {
 		if err := validResponse.VisitGetActivationPositioningAtxPublishEpochResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// GetEligibilitySlotsNodeEpoch operation middleware
+func (sh *strictHandler) GetEligibilitySlotsNodeEpoch(w http.ResponseWriter, r *http.Request, node externalRef0.NodeID, epoch externalRef0.EpochID) {
+	var request GetEligibilitySlotsNodeEpochRequestObject
+
+	request.Node = node
+	request.Epoch = epoch
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.GetEligibilitySlotsNodeEpoch(ctx, request.(GetEligibilitySlotsNodeEpochRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetEligibilitySlotsNodeEpoch")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(GetEligibilitySlotsNodeEpochResponseObject); ok {
+		if err := validResponse.VisitGetEligibilitySlotsNodeEpochResponse(w); err != nil {
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {

--- a/api/node/server/server.gen.go
+++ b/api/node/server/server.gen.go
@@ -622,6 +622,7 @@ type GetEligibilitySlotsNodeEpochResponseObject interface {
 }
 
 type GetEligibilitySlotsNodeEpoch200JSONResponse struct {
+	Nonce uint64 `json:"Nonce"`
 	Slots uint32 `json:"Slots"`
 }
 

--- a/api/node/server/server.go
+++ b/api/node/server/server.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -37,6 +38,7 @@ type hare interface {
 
 type proposalBuilder interface {
 	BuildFor(ctx context.Context, layer types.LayerID, node types.NodeID) (*types.Proposal, types.VRFPostIndex, error)
+	CalculateEligibilitySlotsFor(ctx context.Context, node types.NodeID, epoch types.EpochID) (uint32, types.VRFPostIndex, error)
 }
 
 type Server struct {
@@ -361,4 +363,40 @@ func (s *Server) GetProposalLayerNode(ctx context.Context, request GetProposalLa
 		return &proposalResp{}, nil
 	}
 	return &proposalResp{buf: codec.MustEncode(proposal), nonce: nonce}, nil
+}
+
+type eligibilitySlotsResp struct {
+	Slots uint32
+	nonce types.VRFPostIndex
+}
+
+func (p *eligibilitySlotsResp) VisitGetEligibilitySlotsNodeEpochResponse(w http.ResponseWriter) error {
+	w.Header().Add("content-type", "application/json")
+	w.Header().Add("x-spacemesh-atx-nonce", fmt.Sprintf("%d", p.nonce))
+	w.WriteHeader(200)
+
+	if err := json.NewEncoder(w).Encode(p); err != nil {
+		http.Error(w, "failed to encode response", http.StatusInternalServerError)
+		return err
+	}
+	return nil
+}
+
+func (s *Server) GetEligibilitySlotsNodeEpoch(
+	ctx context.Context,
+	request GetEligibilitySlotsNodeEpochRequestObject,
+) (GetEligibilitySlotsNodeEpochResponseObject, error) {
+	hexBuf, err := hex.DecodeString(request.Node)
+	if err != nil {
+		return GetEligibilitySlotsNodeEpoch200JSONResponse{}, err
+	}
+	id := types.BytesToNodeID(hexBuf)
+	epoch := types.EpochID(request.Epoch)
+
+	slots, nonce, err := s.proposals.CalculateEligibilitySlotsFor(ctx, id, epoch)
+	if err != nil {
+		return GetEligibilitySlotsNodeEpoch200JSONResponse{}, err
+	}
+
+	return &eligibilitySlotsResp{Slots: slots, nonce: nonce}, nil
 }

--- a/api/node/server/server.go
+++ b/api/node/server/server.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -366,23 +365,6 @@ func (s *Server) GetProposalLayerNode(ctx context.Context, request GetProposalLa
 	return &proposalResp{buf: codec.MustEncode(proposal), nonce: nonce}, nil
 }
 
-type eligibilitySlotsResp struct {
-	Slots uint32
-	nonce types.VRFPostIndex
-}
-
-func (p *eligibilitySlotsResp) VisitGetEligibilitySlotsNodeEpochResponse(w http.ResponseWriter) error {
-	w.Header().Add("content-type", "application/json")
-	w.Header().Add("x-spacemesh-atx-nonce", fmt.Sprintf("%d", p.nonce))
-	w.WriteHeader(200)
-
-	if err := json.NewEncoder(w).Encode(p); err != nil {
-		http.Error(w, "failed to encode response", http.StatusInternalServerError)
-		return err
-	}
-	return nil
-}
-
 func (s *Server) GetEligibilitySlotsNodeEpoch(
 	ctx context.Context,
 	request GetEligibilitySlotsNodeEpochRequestObject,
@@ -399,5 +381,8 @@ func (s *Server) GetEligibilitySlotsNodeEpoch(
 		return GetEligibilitySlotsNodeEpoch200JSONResponse{}, err
 	}
 
-	return &eligibilitySlotsResp{Slots: slots, nonce: nonce}, nil
+	return GetEligibilitySlotsNodeEpoch200JSONResponse{
+		Slots: slots,
+		Nonce: uint64(nonce),
+	}, nil
 }

--- a/api/node/server/server.go
+++ b/api/node/server/server.go
@@ -38,7 +38,8 @@ type hare interface {
 
 type proposalBuilder interface {
 	BuildFor(ctx context.Context, layer types.LayerID, node types.NodeID) (*types.Proposal, types.VRFPostIndex, error)
-	CalculateEligibilitySlotsFor(ctx context.Context, node types.NodeID, epoch types.EpochID) (uint32, types.VRFPostIndex, error)
+	CalculateEligibilitySlotsFor(
+		ctx context.Context, node types.NodeID, epoch types.EpochID) (uint32, types.VRFPostIndex, error)
 }
 
 type Server struct {

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/seehuhn/mt19937 v1.0.0
 	github.com/slok/go-http-metrics v0.13.0
-	github.com/spacemeshos/api/release/go v1.57.1-0.20241204141106-34acdbfbd074
+	github.com/spacemeshos/api/release/go v1.57.1-0.20241220083912-1cc7c7ecf450
 	github.com/spacemeshos/economics v0.1.4
 	github.com/spacemeshos/fixed v0.1.2
 	github.com/spacemeshos/go-scale v1.2.1

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/seehuhn/mt19937 v1.0.0
 	github.com/slok/go-http-metrics v0.13.0
-	github.com/spacemeshos/api/release/go v1.57.1-0.20241220083912-1cc7c7ecf450
+	github.com/spacemeshos/api/release/go v1.57.1-0.20241220130214-5abb93dcc93d
 	github.com/spacemeshos/economics v0.1.4
 	github.com/spacemeshos/fixed v0.1.2
 	github.com/spacemeshos/go-scale v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -636,8 +636,8 @@ github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d/go.mod h1:Udh
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
-github.com/spacemeshos/api/release/go v1.57.1-0.20241220083912-1cc7c7ecf450 h1:7X5BCzJBwcT2mcQK8J+l6Go+lM1B/wUd0G5VC1siMkU=
-github.com/spacemeshos/api/release/go v1.57.1-0.20241220083912-1cc7c7ecf450/go.mod h1:w/WRxR8JVmaeKqEEyL6DCoQxt3oyZOTv4uQSdMXlucM=
+github.com/spacemeshos/api/release/go v1.57.1-0.20241220130214-5abb93dcc93d h1:x+GsCbysM0J/MJpScsVg7AlKnmCFihqs+SObDMfBttI=
+github.com/spacemeshos/api/release/go v1.57.1-0.20241220130214-5abb93dcc93d/go.mod h1:w/WRxR8JVmaeKqEEyL6DCoQxt3oyZOTv4uQSdMXlucM=
 github.com/spacemeshos/economics v0.1.4 h1:twlawrcQhYNqPgyDv08+24EL/OgUKz3d7q+PvJIAND0=
 github.com/spacemeshos/economics v0.1.4/go.mod h1:6HKWKiKdxjVQcGa2z/wA0LR4M/DzKib856bP16yqNmQ=
 github.com/spacemeshos/fixed v0.1.2 h1:pENQ8pXFAqin3f15ZLoOVVeSgcmcFJ0IFdFm4+9u4SM=

--- a/go.sum
+++ b/go.sum
@@ -636,8 +636,8 @@ github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d/go.mod h1:Udh
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
-github.com/spacemeshos/api/release/go v1.57.1-0.20241204141106-34acdbfbd074 h1:1rBEgFc/QdLYtFc/fhpKi9+lsCV2Oua/aoo8/X6696c=
-github.com/spacemeshos/api/release/go v1.57.1-0.20241204141106-34acdbfbd074/go.mod h1:w/WRxR8JVmaeKqEEyL6DCoQxt3oyZOTv4uQSdMXlucM=
+github.com/spacemeshos/api/release/go v1.57.1-0.20241220083912-1cc7c7ecf450 h1:7X5BCzJBwcT2mcQK8J+l6Go+lM1B/wUd0G5VC1siMkU=
+github.com/spacemeshos/api/release/go v1.57.1-0.20241220083912-1cc7c7ecf450/go.mod h1:w/WRxR8JVmaeKqEEyL6DCoQxt3oyZOTv4uQSdMXlucM=
 github.com/spacemeshos/economics v0.1.4 h1:twlawrcQhYNqPgyDv08+24EL/OgUKz3d7q+PvJIAND0=
 github.com/spacemeshos/economics v0.1.4/go.mod h1:6HKWKiKdxjVQcGa2z/wA0LR4M/DzKib856bP16yqNmQ=
 github.com/spacemeshos/fixed v0.1.2 h1:pENQ8pXFAqin3f15ZLoOVVeSgcmcFJ0IFdFm4+9u4SM=

--- a/identity/state.go
+++ b/identity/state.go
@@ -192,7 +192,6 @@ func (s *ProposalPublished) APIStateInfo() *pb.IdentityStateInfo {
 }
 
 type Eligible struct {
-	Epoch  uint32
 	Layers map[types.LayerID][]types.VotingEligibility
 }
 
@@ -209,7 +208,6 @@ func (s *Eligible) APIStateInfo() *pb.IdentityStateInfo {
 		State: pb.IdentityState_ELIGIBLE,
 		Metadata: &pb.IdentityStateInfo_Eligible{
 			Eligible: &pb.Eligible{
-				Epoch:  s.Epoch,
 				Layers: rst,
 			},
 		},

--- a/identity/state.go
+++ b/identity/state.go
@@ -190,3 +190,28 @@ func (s *ProposalPublished) APIStateInfo() *pb.IdentityStateInfo {
 		},
 	}
 }
+
+type Eligible struct {
+	Epoch  uint32
+	Layers map[types.LayerID][]types.VotingEligibility
+}
+
+func (s *Eligible) APIStateInfo() *pb.IdentityStateInfo {
+	rst := make([]*pb.Eligibility, 0, len(s.Layers))
+	for lid, eligs := range s.Layers {
+		rst = append(rst, &pb.Eligibility{
+			Layer: lid.Uint32(),
+			Count: uint32(len(eligs)),
+		})
+	}
+
+	return &pb.IdentityStateInfo{
+		State: pb.IdentityState_ELIGIBLE,
+		Metadata: &pb.IdentityStateInfo_Eligible{
+			Eligible: &pb.Eligible{
+				Epoch:  s.Epoch,
+				Layers: rst,
+			},
+		},
+	}
+}

--- a/miner/mocks/remote_mocks.go
+++ b/miner/mocks/remote_mocks.go
@@ -42,6 +42,46 @@ func (m *MockproposalService) EXPECT() *MockproposalServiceMockRecorder {
 	return m.recorder
 }
 
+// CalculateEligibilitySlotsFor mocks base method.
+func (m *MockproposalService) CalculateEligibilitySlotsFor(ctx context.Context, node types.NodeID, epoch types.EpochID) (uint32, types.VRFPostIndex, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CalculateEligibilitySlotsFor", ctx, node, epoch)
+	ret0, _ := ret[0].(uint32)
+	ret1, _ := ret[1].(types.VRFPostIndex)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// CalculateEligibilitySlotsFor indicates an expected call of CalculateEligibilitySlotsFor.
+func (mr *MockproposalServiceMockRecorder) CalculateEligibilitySlotsFor(ctx, node, epoch any) *MockproposalServiceCalculateEligibilitySlotsForCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CalculateEligibilitySlotsFor", reflect.TypeOf((*MockproposalService)(nil).CalculateEligibilitySlotsFor), ctx, node, epoch)
+	return &MockproposalServiceCalculateEligibilitySlotsForCall{Call: call}
+}
+
+// MockproposalServiceCalculateEligibilitySlotsForCall wrap *gomock.Call
+type MockproposalServiceCalculateEligibilitySlotsForCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockproposalServiceCalculateEligibilitySlotsForCall) Return(arg0 uint32, arg1 types.VRFPostIndex, arg2 error) *MockproposalServiceCalculateEligibilitySlotsForCall {
+	c.Call = c.Call.Return(arg0, arg1, arg2)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockproposalServiceCalculateEligibilitySlotsForCall) Do(f func(context.Context, types.NodeID, types.EpochID) (uint32, types.VRFPostIndex, error)) *MockproposalServiceCalculateEligibilitySlotsForCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockproposalServiceCalculateEligibilitySlotsForCall) DoAndReturn(f func(context.Context, types.NodeID, types.EpochID) (uint32, types.VRFPostIndex, error)) *MockproposalServiceCalculateEligibilitySlotsForCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // Proposal mocks base method.
 func (m *MockproposalService) Proposal(ctx context.Context, layer types.LayerID, node types.NodeID) (*types.Proposal, uint64, error) {
 	m.ctrl.T.Helper()

--- a/miner/proposal_builder.go
+++ b/miner/proposal_builder.go
@@ -577,6 +577,19 @@ func (pb *ProposalBuilder) initSignerSessionData(
 	return nil
 }
 
+func (pb *ProposalBuilder) CalculateEligibilitySlotsFor(
+	ctx context.Context, node types.NodeID, epoch types.EpochID,
+) (uint32, types.VRFPostIndex, error) {
+	if err := pb.initSharedData(ctx, epoch.FirstLayer()); err != nil {
+		return 0, 0, err
+	}
+	signer := &signerSession{}
+	if err := pb.initSignerSessionData(&signer.session, epoch.FirstLayer(), node); err != nil {
+		return 0, 0, err
+	}
+	return signer.session.eligibilities.slots, signer.session.nonce, nil
+}
+
 func (pb *ProposalBuilder) BuildFor(ctx context.Context,
 	lid types.LayerID,
 	nodeID types.NodeID,

--- a/miner/proposal_builder.go
+++ b/miner/proposal_builder.go
@@ -580,14 +580,11 @@ func (pb *ProposalBuilder) initSignerSessionData(
 func (pb *ProposalBuilder) CalculateEligibilitySlotsFor(
 	ctx context.Context, node types.NodeID, epoch types.EpochID,
 ) (uint32, types.VRFPostIndex, error) {
-	if err := pb.initSharedData(ctx, epoch.FirstLayer()); err != nil {
+	var ss session
+	if err := pb.initSignerSessionData(&ss, epoch.FirstLayer(), node); err != nil {
 		return 0, 0, err
 	}
-	signer := &signerSession{}
-	if err := pb.initSignerSessionData(&signer.session, epoch.FirstLayer(), node); err != nil {
-		return 0, 0, err
-	}
-	return signer.session.eligibilities.slots, signer.session.nonce, nil
+	return ss.eligibilities.slots, ss.nonce, nil
 }
 
 func (pb *ProposalBuilder) BuildFor(ctx context.Context,

--- a/miner/remote_proposals.go
+++ b/miner/remote_proposals.go
@@ -22,6 +22,9 @@ import (
 
 type proposalService interface {
 	Proposal(ctx context.Context, layer types.LayerID, node types.NodeID) (*types.Proposal, uint64, error)
+	CalculateEligibilitySlotsFor(
+		ctx context.Context, node types.NodeID, epoch types.EpochID,
+	) (uint32, types.VRFPostIndex, error)
 }
 
 type beaconService interface {
@@ -175,7 +178,36 @@ func (pb *RemoteProposalBuilder) build(
 
 	for _, signer := range signers {
 		nodeId := signer.signer.NodeID()
-		proposal, nonce, err := pb.proposalSvc.Proposal(ctx, layer, nodeId)
+
+		var proofs map[types.LayerID][]types.VotingEligibility
+		if layer.FirstInEpoch() {
+			slots, nonce, err := pb.proposalSvc.CalculateEligibilitySlotsFor(ctx, nodeId, epoch)
+			if err != nil {
+				pb.logger.Error("calculate eligibility slots error", zap.Error(err))
+				continue
+			}
+
+			nodeElig, ok := eligibilities[nodeId]
+			if !ok {
+				proofs = calcEligibilityProofs(
+					signer.signer.VRFSigner(),
+					epoch,
+					bcn,
+					nonce,
+					slots,
+					pb.cfg.layersPerEpoch,
+				)
+				eligibilities[nodeId] = proofs
+				pb.identityStates.SetEligibilitiesForEpoch(nodeId, epoch, proofs)
+				pb.identityStates.Set(nodeId, &epoch, &smesherIdentity.Eligible{
+					Layers: proofs,
+				})
+			} else {
+				proofs = nodeElig
+			}
+		}
+
+		proposal, _, err := pb.proposalSvc.Proposal(ctx, layer, nodeId)
 		if err != nil {
 			pb.logger.Error("get partial proposal", zap.Error(err))
 			continue
@@ -184,34 +216,6 @@ func (pb *RemoteProposalBuilder) build(
 			// this node signer isn't eligible this epoch, continue
 			pb.logger.Info("node not eligible on this layer. will try later")
 			continue
-		}
-
-		var proofs map[types.LayerID][]types.VotingEligibility
-		if proposal.Ballot.EpochData != nil {
-			nodeElig, ok := eligibilities[nodeId]
-			if !ok {
-				proofs = calcEligibilityProofs(
-					signer.signer.VRFSigner(),
-					epoch,
-					bcn,
-					types.VRFPostIndex(nonce),
-					proposal.Ballot.EpochData.EligibilityCount,
-					pb.cfg.layersPerEpoch,
-				)
-				eligibilities[nodeId] = proofs
-				pb.identityStates.SetEligibilitiesForEpoch(nodeId, epoch, proofs)
-				pb.identityStates.Set(nodeId, &epoch, &smesherIdentity.Eligible{
-					Epoch:  epoch.Uint32(),
-					Layers: proofs,
-				})
-			} else {
-				proofs = nodeElig
-			}
-		} else {
-			proofs, ok = eligibilities[nodeId]
-			if !ok {
-				panic("missing node epoch eligibilities")
-			}
 		}
 
 		eligibilities, ok := proofs[layer]

--- a/miner/remote_proposals.go
+++ b/miner/remote_proposals.go
@@ -200,6 +200,10 @@ func (pb *RemoteProposalBuilder) build(
 				)
 				eligibilities[nodeId] = proofs
 				pb.identityStates.SetEligibilitiesForEpoch(nodeId, epoch, proofs)
+				pb.identityStates.Set(nodeId, &epoch, &smesherIdentity.Eligible{
+					Epoch:  epoch.Uint32(),
+					Layers: proofs,
+				})
 			} else {
 				proofs = nodeElig
 			}

--- a/miner/remote_proposals.go
+++ b/miner/remote_proposals.go
@@ -180,31 +180,28 @@ func (pb *RemoteProposalBuilder) build(
 		nodeId := signer.signer.NodeID()
 
 		var proofs map[types.LayerID][]types.VotingEligibility
-		if layer.FirstInEpoch() {
+		nodeElig, ok := eligibilities[nodeId]
+		if !ok {
 			slots, nonce, err := pb.proposalSvc.CalculateEligibilitySlotsFor(ctx, nodeId, epoch)
 			if err != nil {
 				pb.logger.Error("calculate eligibility slots error", zap.Error(err))
 				continue
 			}
-
-			nodeElig, ok := eligibilities[nodeId]
-			if !ok {
-				proofs = calcEligibilityProofs(
-					signer.signer.VRFSigner(),
-					epoch,
-					bcn,
-					nonce,
-					slots,
-					pb.cfg.layersPerEpoch,
-				)
-				eligibilities[nodeId] = proofs
-				pb.identityStates.SetEligibilitiesForEpoch(nodeId, epoch, proofs)
-				pb.identityStates.Set(nodeId, &epoch, &smesherIdentity.Eligible{
-					Layers: proofs,
-				})
-			} else {
-				proofs = nodeElig
-			}
+			proofs = calcEligibilityProofs(
+				signer.signer.VRFSigner(),
+				epoch,
+				bcn,
+				nonce,
+				slots,
+				pb.cfg.layersPerEpoch,
+			)
+			eligibilities[nodeId] = proofs
+			pb.identityStates.SetEligibilitiesForEpoch(nodeId, epoch, proofs)
+			pb.identityStates.Set(nodeId, &epoch, &smesherIdentity.Eligible{
+				Layers: proofs,
+			})
+		} else {
+			proofs = nodeElig
 		}
 
 		proposal, _, err := pb.proposalSvc.Proposal(ctx, layer, nodeId)

--- a/miner/remote_proposals_test.go
+++ b/miner/remote_proposals_test.go
@@ -73,8 +73,13 @@ func TestRemoteProposals(t *testing.T) {
 			prop := createTestProposal(t, activeSet, lid, meshHash, atxId, nodeId, txIds, beaconVal, 1)
 			return prop, 11, nil
 		}).AnyTimes()
+	prop.EXPECT().CalculateEligibilitySlotsFor(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, nodeId types.NodeID, epoch types.EpochID) (uint32, types.VRFPostIndex, error) {
+			return 1, 11, nil
+		}).AnyTimes()
 	idStates.EXPECT().SetEligibilitiesForEpoch(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 	idStates.EXPECT().AddProposal(gomock.Any(), gomock.Any()).AnyTimes()
+	idStates.EXPECT().Set(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 	go builder.Run(ctx)
 	defer cancel()
 	select {

--- a/node/node.go
+++ b/node/node.go
@@ -1464,9 +1464,12 @@ func (app *App) launchStandalone(ctx context.Context) error {
 		log.Uint32("epoch", epoch.Uint32()),
 		log.Stringer("beacon", value),
 	)
-	if err := app.beaconProtocol.UpdateBeacon(epoch, value); err != nil {
-		return fmt.Errorf("update standalone beacon: %w", err)
+	if app.beaconProtocol != nil {
+		if err := app.beaconProtocol.UpdateBeacon(epoch, value); err != nil {
+			return fmt.Errorf("update standalone beacon: %w", err)
+		}
 	}
+
 	cfg := server.DefaultConfig()
 	cfg.PoetDir = filepath.Join(app.Config.DataDir(), "poet")
 


### PR DESCRIPTION
## Description

This pull request introduces a new API endpoint to calculate eligibility slots for a given node in a specific epoch. With that smesher service can calculate eligibility proofs at the start of the epoch.

Also, fixed standalone mode.

### New API Endpoint for Eligibility Slots:

* [`api/node/client/client.gen.go`](diffhunk://#diff-ea98367b14a2e55c8a83b710fc751dc1fb78f70ceefd2e202f8bf0ba683f3c7eR118-R120): Added `GetEligibilitySlotsNodeEpoch` method to the `ClientInterface` and `ClientWithResponsesInterface`, and implemented the request and response handling for this new endpoint. [[1]](diffhunk://#diff-ea98367b14a2e55c8a83b710fc751dc1fb78f70ceefd2e202f8bf0ba683f3c7eR118-R120) [[2]](diffhunk://#diff-ea98367b14a2e55c8a83b710fc751dc1fb78f70ceefd2e202f8bf0ba683f3c7eR179-R190) [[3]](diffhunk://#diff-ea98367b14a2e55c8a83b710fc751dc1fb78f70ceefd2e202f8bf0ba683f3c7eR377-R417) [[4]](diffhunk://#diff-ea98367b14a2e55c8a83b710fc751dc1fb78f70ceefd2e202f8bf0ba683f3c7eR733-R735) [[5]](diffhunk://#diff-ea98367b14a2e55c8a83b710fc751dc1fb78f70ceefd2e202f8bf0ba683f3c7eR826-R849) [[6]](diffhunk://#diff-ea98367b14a2e55c8a83b710fc751dc1fb78f70ceefd2e202f8bf0ba683f3c7eR1024-R1032) [[7]](diffhunk://#diff-ea98367b14a2e55c8a83b710fc751dc1fb78f70ceefd2e202f8bf0ba683f3c7eR1176-R1203)

### Node Service Enhancements:

* [`api/node/client/client.go`](diffhunk://#diff-386d567a15bbcaaa14407ea90bf9969302f138258e7115820f1ba4ed8c67dab5R251-R279): Added `CalculateEligibilitySlotsFor` method to the `NodeService` to call the new API endpoint and handle the response.

### API Specification Update:

* [`api/node/node_service.yaml`](diffhunk://#diff-5a8855cb7a39051a7f07e861e72fdb73da2a364a9ca7bdd8558a7556358e26efR254-R284): Defined the new `/eligibility/slots/{node}/{epoch}` endpoint in the API specification.

### Server and Middleware Updates:

* [`api/node/server/server.gen.go`](diffhunk://#diff-77be91a4620b6868684e7aa32c8230473d949730acb70cd77ef44a08a9876930R48-R50): Updated server interface and middleware to include the new endpoint, and added corresponding request and response objects. [[1]](diffhunk://#diff-77be91a4620b6868684e7aa32c8230473d949730acb70cd77ef44a08a9876930R48-R50) [[2]](diffhunk://#diff-77be91a4620b6868684e7aa32c8230473d949730acb70cd77ef44a08a9876930R158-R191) [[3]](diffhunk://#diff-77be91a4620b6868684e7aa32c8230473d949730acb70cd77ef44a08a9876930R515) [[4]](diffhunk://#diff-77be91a4620b6868684e7aa32c8230473d949730acb70cd77ef44a08a9876930R615-R642) [[5]](diffhunk://#diff-77be91a4620b6868684e7aa32c8230473d949730acb70cd77ef44a08a9876930R893-R895) [[6]](diffhunk://#diff-77be91a4620b6868684e7aa32c8230473d949730acb70cd77ef44a08a9876930R1026-R1052)
* [`api/node/server/server.go`](diffhunk://#diff-12ccd4cc0620a6f591dad2196c3256c17863b38665e3d39a240aa75d236f53d3R7): Implemented the server-side logic for the new endpoint. [[1]](diffhunk://#diff-12ccd4cc0620a6f591dad2196c3256c17863b38665e3d39a240aa75d236f53d3R7) [[2]](diffhunk://#diff-12ccd4cc0620a6f591dad2196c3256c17863b38665e3d39a240aa75d236f53d3R41-R42) [[3]](diffhunk://#diff-12ccd4cc0620a6f591dad2196c3256c17863b38665e3d39a240aa75d236f53d3R368-R403)

### Mock and Testing Enhancements:

* [`api/node/server/mocks.go`](diffhunk://#diff-e061b7f329131fa8cf63de8766a0e289be070d57fdfc83b0fa42c934430d163aR325-R364): Added mock methods to support testing of the new `CalculateEligibilitySlotsFor` functionality.

### Dependency Update:

* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L43-R43): Updated the `github.com/spacemeshos/api/release/go` dependency to the latest version.
