### PR TITLE
node-split-poc: catch proposal build failed states

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/seehuhn/mt19937 v1.0.0
 	github.com/slok/go-http-metrics v0.13.0
-	github.com/spacemeshos/api/release/go v1.57.1-0.20241220131535-6dc718ac3ae4
+	github.com/spacemeshos/api/release/go v1.57.1-0.20241220141937-3163d0deda38
 	github.com/spacemeshos/economics v0.1.4
 	github.com/spacemeshos/fixed v0.1.2
 	github.com/spacemeshos/go-scale v1.2.1

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/seehuhn/mt19937 v1.0.0
 	github.com/slok/go-http-metrics v0.13.0
-	github.com/spacemeshos/api/release/go v1.57.1-0.20241204141106-34acdbfbd074
+	github.com/spacemeshos/api/release/go v1.57.1-0.20241220131535-6dc718ac3ae4
 	github.com/spacemeshos/economics v0.1.4
 	github.com/spacemeshos/fixed v0.1.2
 	github.com/spacemeshos/go-scale v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -636,8 +636,8 @@ github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d/go.mod h1:Udh
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
-github.com/spacemeshos/api/release/go v1.57.1-0.20241220131535-6dc718ac3ae4 h1:6ySI8PzHr2aCL1OOoodpkax5ZZjVukIVMITuv5eDebg=
-github.com/spacemeshos/api/release/go v1.57.1-0.20241220131535-6dc718ac3ae4/go.mod h1:w/WRxR8JVmaeKqEEyL6DCoQxt3oyZOTv4uQSdMXlucM=
+github.com/spacemeshos/api/release/go v1.57.1-0.20241220141937-3163d0deda38 h1:mUkGRccbzEyFqfP2lSxMy1bprjmBns+7ZSRN9Qxgsl0=
+github.com/spacemeshos/api/release/go v1.57.1-0.20241220141937-3163d0deda38/go.mod h1:w/WRxR8JVmaeKqEEyL6DCoQxt3oyZOTv4uQSdMXlucM=
 github.com/spacemeshos/economics v0.1.4 h1:twlawrcQhYNqPgyDv08+24EL/OgUKz3d7q+PvJIAND0=
 github.com/spacemeshos/economics v0.1.4/go.mod h1:6HKWKiKdxjVQcGa2z/wA0LR4M/DzKib856bP16yqNmQ=
 github.com/spacemeshos/fixed v0.1.2 h1:pENQ8pXFAqin3f15ZLoOVVeSgcmcFJ0IFdFm4+9u4SM=

--- a/go.sum
+++ b/go.sum
@@ -636,8 +636,8 @@ github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d/go.mod h1:Udh
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
-github.com/spacemeshos/api/release/go v1.57.1-0.20241204141106-34acdbfbd074 h1:1rBEgFc/QdLYtFc/fhpKi9+lsCV2Oua/aoo8/X6696c=
-github.com/spacemeshos/api/release/go v1.57.1-0.20241204141106-34acdbfbd074/go.mod h1:w/WRxR8JVmaeKqEEyL6DCoQxt3oyZOTv4uQSdMXlucM=
+github.com/spacemeshos/api/release/go v1.57.1-0.20241220131535-6dc718ac3ae4 h1:6ySI8PzHr2aCL1OOoodpkax5ZZjVukIVMITuv5eDebg=
+github.com/spacemeshos/api/release/go v1.57.1-0.20241220131535-6dc718ac3ae4/go.mod h1:w/WRxR8JVmaeKqEEyL6DCoQxt3oyZOTv4uQSdMXlucM=
 github.com/spacemeshos/economics v0.1.4 h1:twlawrcQhYNqPgyDv08+24EL/OgUKz3d7q+PvJIAND0=
 github.com/spacemeshos/economics v0.1.4/go.mod h1:6HKWKiKdxjVQcGa2z/wA0LR4M/DzKib856bP16yqNmQ=
 github.com/spacemeshos/fixed v0.1.2 h1:pENQ8pXFAqin3f15ZLoOVVeSgcmcFJ0IFdFm4+9u4SM=

--- a/identity/state.go
+++ b/identity/state.go
@@ -155,6 +155,23 @@ func (s *ATXBroadcasted) APIStateInfo() *pb.IdentityStateInfo {
 }
 
 // proposal.
+type ProposalBuildFailed struct {
+	Error error
+	Layer types.LayerID
+}
+
+func (s *ProposalBuildFailed) APIStateInfo() *pb.IdentityStateInfo {
+	return &pb.IdentityStateInfo{
+		State: pb.IdentityState_PROPOSAL_BUILD_FAILED,
+		Metadata: &pb.IdentityStateInfo_ProposalBuildFailed{
+			ProposalBuildFailed: &pb.ProposalBuildFailedState{
+				Message: s.Error.Error(),
+				Layer:   s.Layer.Uint32(),
+			},
+		},
+	}
+}
+
 type ProposalPublishFailed struct {
 	Error    error
 	Proposal types.ProposalID

--- a/miner/remote_proposals.go
+++ b/miner/remote_proposals.go
@@ -148,7 +148,6 @@ func (pb *RemoteProposalBuilder) Run(ctx context.Context) error {
 					zap.Error(err),
 				)
 			}
-
 		}
 	}
 }
@@ -168,6 +167,10 @@ func (pb *RemoteProposalBuilder) build(
 	if !ok {
 		bcn, err = pb.beaconSvc.Beacon(ctx, epoch)
 		if err != nil {
+			pb.identityStates.Set(types.EmptyNodeID, &epoch, &smesherIdentity.ProposalBuildFailed{
+				Error: fmt.Errorf("beacon: %v", err),
+				Layer: layer,
+			})
 			return fmt.Errorf("beacon: %w", err)
 		}
 		beacons[epoch] = bcn
@@ -178,6 +181,10 @@ func (pb *RemoteProposalBuilder) build(
 		proposal, nonce, err := pb.proposalSvc.Proposal(ctx, layer, nodeId)
 		if err != nil {
 			pb.logger.Error("get partial proposal", zap.Error(err))
+			pb.identityStates.Set(nodeId, &epoch, &smesherIdentity.ProposalBuildFailed{
+				Error: fmt.Errorf("get partial proposal: %v", err),
+				Layer: layer,
+			})
 			continue
 		}
 		if proposal == nil {
@@ -223,6 +230,10 @@ func (pb *RemoteProposalBuilder) build(
 		err = proposal.Initialize()
 		if err != nil {
 			pb.logger.Error("failed to initialize proposal", zap.Error(err))
+			pb.identityStates.Set(nodeId, &epoch, &smesherIdentity.ProposalBuildFailed{
+				Error: fmt.Errorf("failed to initialize proposal: %v", err),
+				Layer: layer,
+			})
 			continue
 		}
 		pb.logger.Info("publishing proposal", zap.Inline(proposal))


### PR DESCRIPTION
## Description

This pull request includes several changes to improve error handling and update dependencies in the project. The most important changes include adding a new error type for proposal build failures, updating the `go.mod` file, and enhancing error logging in the `RemoteProposalBuilder` class.

Improvements to error handling:

* [`identity/state.go`](diffhunk://#diff-5530b4d983e4d2c975e259e57c5e6b716077176c9fe05e2b540da075494c11f5R158-R174): Added a new error type `ProposalBuildFailed` and its corresponding `APIStateInfo` method to handle proposal build failures more effectively.
* [`miner/remote_proposals.go`](diffhunk://#diff-cfc4631c43f6e92e7dd50273be5292c83e032d41e8f3085c28c26095658ef644L151): Enhanced error logging in the `RemoteProposalBuilder` class by setting identity states for different error scenarios during the proposal building process. [[1]](diffhunk://#diff-cfc4631c43f6e92e7dd50273be5292c83e032d41e8f3085c28c26095658ef644L151) [[2]](diffhunk://#diff-cfc4631c43f6e92e7dd50273be5292c83e032d41e8f3085c28c26095658ef644R170-R173) [[3]](diffhunk://#diff-cfc4631c43f6e92e7dd50273be5292c83e032d41e8f3085c28c26095658ef644R184-R187) [[4]](diffhunk://#diff-cfc4631c43f6e92e7dd50273be5292c83e032d41e8f3085c28c26095658ef644R233-R236)

Dependency updates:

* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L43-R43): Updated the `github.com/spacemeshos/api/release/go` dependency to a newer version.


