### PR TITLE
[Merged by Bors] - Filter CODEOWNERS in systest's filter-changes job

### DIFF
--- a/.github/workflows/systest.yml
+++ b/.github/workflows/systest.yml
@@ -48,6 +48,7 @@ jobs:
       - uses: dorny/paths-filter@v3
         id: filter
         with:
+          predicate-quantifier: 'every'
           filters: |
             nondoc:
               - '!**/*.md'

--- a/.github/workflows/systest.yml
+++ b/.github/workflows/systest.yml
@@ -51,6 +51,7 @@ jobs:
           filters: |
             nondoc:
               - '!**/*.md'
+              - '!.github/CODEOWNERS'
 
   build-docker-images:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
## Description

This pull request includes a small but important change to the `.github/workflows/systest.yml` file. The change ensures that the `CODEOWNERS` file will not trigger systests.