### PR TITLE
Ensure server is started before handling requests

### DIFF
--- a/p2p/server/interface.go
+++ b/p2p/server/interface.go
@@ -21,6 +21,7 @@ type Host interface {
 	NewStream(context.Context, peer.ID, ...protocol.ID) (network.Stream, error)
 	Network() network.Network
 	ConnManager() connmgr.ConnManager
+	Mux() protocol.Switch
 }
 
 type PeerInfoHost interface {

--- a/p2p/server/server.go
+++ b/p2p/server/server.go
@@ -243,6 +243,22 @@ func (s *Server) peerInfo() peerinfo.PeerInfo {
 }
 
 func (s *Server) Run(ctx context.Context) error {
+	startCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	for {
+		select {
+		case <-startCtx.Done():
+			close(s.stopped)
+			return errors.New("failed to start server")
+		case <-time.After(10 * time.Millisecond):
+		}
+
+		if len(s.h.Mux().Protocols()) > 0 {
+			cancel()
+			break
+		}
+	}
+
 	var eg errgroup.Group
 	for {
 		select {


### PR DESCRIPTION
## Motivation

Fixes #6113. Ensures that when the p2p servier is started requests aren't handled before protocols are available.

## Description

Before doing anything in the `p2p.Server.Run` method ensure that the muxer has at least one protocol available.

## Test Plan

- without this fix `Test_GetAtxsLimiting` fails in about 2% of all test runs on my machine. With this change 500 runs of the test passed without an error.

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
