### PR TITLE
[Merged by Bors] - sync2: eliminate unneeded DB accesses when peers are in sync

### DIFF
--- a/sync2/dbset/dbset.go
+++ b/sync2/dbset/dbset.go
@@ -2,6 +2,7 @@ package dbset
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"maps"
 	"sync"
@@ -118,16 +119,12 @@ func (d *DBSet) Receive(k rangesync.KeyBytes) error {
 	return nil
 }
 
-func (d *DBSet) firstItem() (rangesync.KeyBytes, error) {
-	if err := d.EnsureLoaded(); err != nil {
-		return nil, err
-	}
-	return d.ft.All().First()
-}
-
-// GetRangeInfo returns information about the range of items in the DBSet.
+// RangeInfo returns information about the range of items in the DBSet.
 // Implements rangesync.OrderedSet.
-func (d *DBSet) GetRangeInfo(x, y rangesync.KeyBytes) (rangesync.RangeInfo, error) {
+func (d *DBSet) RangeInfo(x, y rangesync.KeyBytes) (rangesync.RangeInfo, error) {
+	if x == nil || y == nil {
+		return rangesync.RangeInfo{}, errors.New("bad range")
+	}
 	if err := d.EnsureLoaded(); err != nil {
 		return rangesync.RangeInfo{}, err
 	}
@@ -135,17 +132,6 @@ func (d *DBSet) GetRangeInfo(x, y rangesync.KeyBytes) (rangesync.RangeInfo, erro
 		return rangesync.RangeInfo{
 			Items: rangesync.EmptySeqResult(),
 		}, nil
-	}
-	if x == nil || y == nil {
-		if x != nil || y != nil {
-			panic("BUG: GetRangeInfo called with one of x/y nil but not both")
-		}
-		var err error
-		x, err = d.firstItem()
-		if err != nil {
-			return rangesync.RangeInfo{}, fmt.Errorf("getting first item: %w", err)
-		}
-		y = x
 	}
 	fpr, err := d.ft.FingerprintInterval(x, y, -1)
 	if err != nil {
@@ -189,6 +175,20 @@ func (d *DBSet) SplitRange(x, y rangesync.KeyBytes, count int) (rangesync.SplitI
 			},
 		},
 		Middle: sr.Middle,
+	}, nil
+}
+
+// SetInfo returns RangeInfo for the whole DBSet.
+// Implements rangesync.OrderedSet.
+func (d *DBSet) SetInfo() (rangesync.RangeInfo, error) {
+	if err := d.EnsureLoaded(); err != nil {
+		return rangesync.RangeInfo{}, err
+	}
+	fpr := d.ft.FingerprintAll()
+	return rangesync.RangeInfo{
+		Fingerprint: fpr.FP,
+		Count:       int(fpr.Count),
+		Items:       fpr.Items,
 	}, nil
 }
 

--- a/sync2/dbset/dbset_test.go
+++ b/sync2/dbset/dbset_test.go
@@ -44,13 +44,13 @@ func TestDBSet_Empty(t *testing.T) {
 	requireEmpty(t, s.Items())
 	requireEmpty(t, s.Received())
 
-	info, err := s.GetRangeInfo(nil, nil)
+	info, err := s.SetInfo()
 	require.NoError(t, err)
 	require.Equal(t, 0, info.Count)
 	require.Equal(t, "000000000000000000000000", info.Fingerprint.String())
 	requireEmpty(t, info.Items)
 
-	info, err = s.GetRangeInfo(
+	info, err = s.RangeInfo(
 		rangesync.MustParseHexKeyBytes("0000000000000000000000000000000000000000000000000000000000000000"),
 		rangesync.MustParseHexKeyBytes("0000000000000000000000000000000000000000000000000000000000000000"))
 	require.NoError(t, err)
@@ -58,7 +58,7 @@ func TestDBSet_Empty(t *testing.T) {
 	require.Equal(t, "000000000000000000000000", info.Fingerprint.String())
 	requireEmpty(t, info.Items)
 
-	info, err = s.GetRangeInfo(
+	info, err = s.RangeInfo(
 		rangesync.MustParseHexKeyBytes("0000000000000000000000000000000000000000000000000000000000000000"),
 		rangesync.MustParseHexKeyBytes("9999000000000000000000000000000000000000000000000000000000000000"))
 	require.NoError(t, err)
@@ -69,7 +69,7 @@ func TestDBSet_Empty(t *testing.T) {
 
 func TestDBSet(t *testing.T) {
 	ids := []rangesync.KeyBytes{
-		rangesync.MustParseHexKeyBytes("0000000000000000000000000000000000000000000000000000000000000000"),
+		rangesync.MustParseHexKeyBytes("1111111111111111111111111111111111111111111111111111111111111111"),
 		rangesync.MustParseHexKeyBytes("123456789abcdef0000000000000000000000000000000000000000000000000"),
 		rangesync.MustParseHexKeyBytes("5555555555555555555555555555555555555555555555555555555555555555"),
 		rangesync.MustParseHexKeyBytes("8888888888888888888888888888888888888888888888888888888888888888"),
@@ -81,94 +81,126 @@ func TestDBSet(t *testing.T) {
 		IDColumn:  "id",
 	}
 	s := dbset.NewDBSet(db, st, testKeyLen, testDepth)
-	require.Equal(t, "0000000000000000000000000000000000000000000000000000000000000000",
+	require.Equal(t, "1111111111111111111111111111111111111111111111111111111111111111",
 		firstKey(t, s.Items()).String())
 	has, err := s.Has(
 		rangesync.MustParseHexKeyBytes("9876000000000000000000000000000000000000000000000000000000000000"))
 	require.NoError(t, err)
 	require.False(t, has)
 
-	for _, tc := range []struct {
-		xIdx, yIdx       int
-		limit            int
-		fp               string
-		count            int
-		startIdx, endIdx int
-	}{
-		{
-			xIdx:     1,
-			yIdx:     1,
-			limit:    -1,
-			fp:       "642464b773377bbddddddddd",
-			count:    5,
-			startIdx: 1,
-			endIdx:   1,
-		},
-		{
-			xIdx:     -1,
-			yIdx:     -1,
-			limit:    -1,
-			fp:       "642464b773377bbddddddddd",
-			count:    5,
-			startIdx: 0,
-			endIdx:   0,
-		},
-		{
-			xIdx:     0,
-			yIdx:     3,
-			limit:    -1,
-			fp:       "4761032dcfe98ba555555555",
-			count:    3,
-			startIdx: 0,
-			endIdx:   3,
-		},
-		{
-			xIdx:     2,
-			yIdx:     0,
-			limit:    -1,
-			fp:       "761032cfe98ba54ddddddddd",
-			count:    3,
-			startIdx: 2,
-			endIdx:   0,
-		},
-		{
-			xIdx:     3,
-			yIdx:     2,
-			limit:    3,
-			fp:       "2345679abcdef01888888888",
-			count:    3,
-			startIdx: 3,
-			endIdx:   1,
-		},
-	} {
-		name := fmt.Sprintf("%d-%d_%d", tc.xIdx, tc.yIdx, tc.limit)
-		t.Run(name, func(t *testing.T) {
-			var x, y rangesync.KeyBytes
-			if tc.xIdx >= 0 {
+	t.Run("RangeInfo", func(t *testing.T) {
+		for _, tc := range []struct {
+			xIdx, yIdx       int
+			fp               string
+			count            int
+			startIdx, endIdx int
+		}{
+			{
+				xIdx:     1,
+				yIdx:     1,
+				fp:       "753575a662266aaccccccccc",
+				count:    5,
+				startIdx: 1,
+				endIdx:   1,
+			},
+			{
+				xIdx:     0,
+				yIdx:     3,
+				fp:       "5670123cdef89ab444444444",
+				count:    3,
+				startIdx: 0,
+				endIdx:   3,
+			},
+			{
+				xIdx:     2,
+				yIdx:     0,
+				fp:       "761032cfe98ba54ddddddddd",
+				count:    3,
+				startIdx: 2,
+				endIdx:   0,
+			},
+		} {
+			name := fmt.Sprintf("%d-%d", tc.xIdx, tc.yIdx)
+			t.Run(name, func(t *testing.T) {
+				var x, y rangesync.KeyBytes
 				x = ids[tc.xIdx]
 				y = ids[tc.yIdx]
-			}
-			t.Logf("x %v y %v limit %d", x, y, tc.limit)
-			var info rangesync.RangeInfo
-			if tc.limit < 0 {
-				info, err = s.GetRangeInfo(x, y)
+				t.Logf("x %v y %v", x, y)
+				var info rangesync.RangeInfo
+				info, err = s.RangeInfo(x, y)
 				require.NoError(t, err)
-			} else {
+				require.Equal(t, tc.count, info.Count)
+				require.Equal(t, tc.fp, info.Fingerprint.String())
+				require.Equal(t, ids[tc.startIdx], firstKey(t, info.Items))
+				has, err := s.Has(ids[tc.startIdx])
+				require.NoError(t, err)
+				require.True(t, has)
+				has, err = s.Has(ids[tc.endIdx])
+				require.NoError(t, err)
+				require.True(t, has)
+			})
+		}
+	})
+
+	t.Run("SplitRange", func(t *testing.T) {
+		for _, tc := range []struct {
+			xIdx, yIdx       int
+			limit            int
+			fp               string
+			count            int
+			startIdx, endIdx int
+		}{
+			{
+				xIdx:     3,
+				yIdx:     2,
+				limit:    3,
+				fp:       "3254768badcfe10999999999",
+				count:    3,
+				startIdx: 3,
+				endIdx:   1,
+			},
+			{
+				xIdx:     3,
+				yIdx:     3,
+				limit:    2,
+				fp:       "2345679abcdef01888888888",
+				count:    2,
+				startIdx: 3,
+				endIdx:   3,
+			},
+		} {
+			name := fmt.Sprintf("%d-%d_%d", tc.xIdx, tc.yIdx, tc.limit)
+			t.Run(name, func(t *testing.T) {
+				var x, y rangesync.KeyBytes
+				x = ids[tc.xIdx]
+				y = ids[tc.yIdx]
+				t.Logf("x %v y %v limit %d", x, y, tc.limit)
+				var info rangesync.RangeInfo
 				sr, err := s.SplitRange(x, y, tc.limit)
 				require.NoError(t, err)
 				info = sr.Parts[0]
-			}
-			require.Equal(t, tc.count, info.Count)
-			require.Equal(t, tc.fp, info.Fingerprint.String())
-			require.Equal(t, ids[tc.startIdx], firstKey(t, info.Items))
-			has, err := s.Has(ids[tc.startIdx])
-			require.NoError(t, err)
-			require.True(t, has)
-			has, err = s.Has(ids[tc.endIdx])
-			require.NoError(t, err)
-			require.True(t, has)
-		})
-	}
+				require.Equal(t, tc.count, info.Count)
+				require.Equal(t, tc.fp, info.Fingerprint.String())
+				require.Equal(t, ids[tc.startIdx], firstKey(t, info.Items))
+				has, err := s.Has(ids[tc.startIdx])
+				require.NoError(t, err)
+				require.True(t, has)
+				has, err = s.Has(ids[tc.endIdx])
+				require.NoError(t, err)
+				require.True(t, has)
+			})
+		}
+	})
+
+	t.Run("SetInfo", func(t *testing.T) {
+		info, err := s.SetInfo()
+		require.NoError(t, err)
+		require.Equal(t, 5, info.Count)
+		require.Equal(t, "753575a662266aaccccccccc", info.Fingerprint.String())
+		items, err := info.Items.Collect()
+		require.NoError(t, err)
+		require.Equal(t, ids, items)
+	})
 }
 
 func TestDBSet_Receive(t *testing.T) {
@@ -195,7 +227,7 @@ func TestDBSet_Receive(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []rangesync.KeyBytes{newID}, items)
 
-	info, err := s.GetRangeInfo(ids[2], ids[0])
+	info, err := s.RangeInfo(ids[2], ids[0])
 	require.NoError(t, err)
 	require.Equal(t, 2, info.Count)
 	require.Equal(t, "dddddddddddddddddddddddd", info.Fingerprint.String())
@@ -218,7 +250,7 @@ func TestDBSet_Copy(t *testing.T) {
 		firstKey(t, s.Items()).String())
 
 	require.NoError(t, s.WithCopy(context.Background(), func(copy rangesync.OrderedSet) error {
-		info, err := copy.GetRangeInfo(ids[2], ids[0])
+		info, err := copy.RangeInfo(ids[2], ids[0])
 		require.NoError(t, err)
 		require.Equal(t, 2, info.Count)
 		require.Equal(t, "dddddddddddddddddddddddd", info.Fingerprint.String())
@@ -228,7 +260,7 @@ func TestDBSet_Copy(t *testing.T) {
 			"abcdef1234567890000000000000000000000000000000000000000000000000")
 		require.NoError(t, copy.Receive(newID))
 
-		info, err = s.GetRangeInfo(ids[2], ids[0])
+		info, err = s.RangeInfo(ids[2], ids[0])
 		require.NoError(t, err)
 		require.Equal(t, 2, info.Count)
 		require.Equal(t, "dddddddddddddddddddddddd", info.Fingerprint.String())
@@ -236,7 +268,7 @@ func TestDBSet_Copy(t *testing.T) {
 
 		requireEmpty(t, s.Received())
 
-		info, err = s.GetRangeInfo(ids[2], ids[0])
+		info, err = s.RangeInfo(ids[2], ids[0])
 		require.NoError(t, err)
 		require.Equal(t, 2, info.Count)
 		require.Equal(t, "dddddddddddddddddddddddd", info.Fingerprint.String())
@@ -267,13 +299,13 @@ func TestDBItemStore_Advance(t *testing.T) {
 		require.NoError(t, os.EnsureLoaded())
 
 		require.NoError(t, os.WithCopy(context.Background(), func(copy rangesync.OrderedSet) error {
-			info, err := os.GetRangeInfo(ids[0], ids[0])
+			info, err := os.RangeInfo(ids[0], ids[0])
 			require.NoError(t, err)
 			require.Equal(t, 4, info.Count)
 			require.Equal(t, "cfe98ba54761032ddddddddd", info.Fingerprint.String())
 			require.Equal(t, ids[0], firstKey(t, info.Items))
 
-			info, err = copy.GetRangeInfo(ids[0], ids[0])
+			info, err = copy.RangeInfo(ids[0], ids[0])
 			require.NoError(t, err)
 			require.Equal(t, 4, info.Count)
 			require.Equal(t, "cfe98ba54761032ddddddddd", info.Fingerprint.String())
@@ -284,13 +316,13 @@ func TestDBItemStore_Advance(t *testing.T) {
 					"abcdef1234567890000000000000000000000000000000000000000000000000"),
 			})
 
-			info, err = os.GetRangeInfo(ids[0], ids[0])
+			info, err = os.RangeInfo(ids[0], ids[0])
 			require.NoError(t, err)
 			require.Equal(t, 4, info.Count)
 			require.Equal(t, "cfe98ba54761032ddddddddd", info.Fingerprint.String())
 			require.Equal(t, ids[0], firstKey(t, info.Items))
 
-			info, err = copy.GetRangeInfo(ids[0], ids[0])
+			info, err = copy.RangeInfo(ids[0], ids[0])
 			require.NoError(t, err)
 			require.Equal(t, 4, info.Count)
 			require.Equal(t, "cfe98ba54761032ddddddddd", info.Fingerprint.String())
@@ -298,13 +330,13 @@ func TestDBItemStore_Advance(t *testing.T) {
 
 			require.NoError(t, os.Advance())
 
-			info, err = os.GetRangeInfo(ids[0], ids[0])
+			info, err = os.RangeInfo(ids[0], ids[0])
 			require.NoError(t, err)
 			require.Equal(t, 5, info.Count)
 			require.Equal(t, "642464b773377bbddddddddd", info.Fingerprint.String())
 			require.Equal(t, ids[0], firstKey(t, info.Items))
 
-			info, err = copy.GetRangeInfo(ids[0], ids[0])
+			info, err = copy.RangeInfo(ids[0], ids[0])
 			require.NoError(t, err)
 			require.Equal(t, 4, info.Count)
 			require.Equal(t, "cfe98ba54761032ddddddddd", info.Fingerprint.String())
@@ -314,7 +346,7 @@ func TestDBItemStore_Advance(t *testing.T) {
 		}))
 
 		require.NoError(t, os.WithCopy(context.Background(), func(copy rangesync.OrderedSet) error {
-			info, err := copy.GetRangeInfo(ids[0], ids[0])
+			info, err := copy.RangeInfo(ids[0], ids[0])
 			require.NoError(t, err)
 			require.Equal(t, 5, info.Count)
 			require.Equal(t, "642464b773377bbddddddddd", info.Fingerprint.String())

--- a/sync2/fptree/fptree.go
+++ b/sync2/fptree/fptree.go
@@ -362,12 +362,7 @@ func (ft *FPTree) traverseFrom(
 	}
 }
 
-// All returns all the items currently in the tree (including those in the IDStore).
-// The sequence in SeqResult is either empty or infinite.
-// Implements sqlstore.All.
-func (ft *FPTree) All() rangesync.SeqResult {
-	ft.np.lockRead()
-	defer ft.np.unlockRead()
+func (ft *FPTree) all() rangesync.SeqResult {
 	switch {
 	case ft.root == noIndex:
 		return rangesync.EmptySeqResult()
@@ -384,6 +379,15 @@ func (ft *FPTree) All() rangesync.SeqResult {
 		}
 	}
 	return ft.idStore.All()
+}
+
+// All returns all the items currently in the tree (including those in the IDStore).
+// The sequence in SeqResult is either empty or infinite.
+// Implements sqlstore.All.
+func (ft *FPTree) All() rangesync.SeqResult {
+	ft.np.lockRead()
+	defer ft.np.unlockRead()
+	return ft.all()
 }
 
 // From returns all the items in the tree that are greater than or equal to the given key.
@@ -1154,6 +1158,24 @@ func (ft *FPTree) fingerprintInterval(
 	// We apply limit after we have retrieved the next item
 	fpr.Items = fpr.Items.Limit(int(fpr.Count))
 	return fpr, nil
+}
+
+// FingerprintAll returns FingerprintResult for all items in the tree.
+// Unlike FingerprintInterval, it is guaranteed not to query the underlying idStore, so it
+// will never cause database access.
+func (ft *FPTree) FingerprintAll() FPResult {
+	ft.np.lockRead()
+	defer ft.np.unlockRead()
+	if ft.root == noIndex {
+		return FPResult{Items: rangesync.EmptySeqResult()}
+	}
+	count, fp, _ := ft.np.info(ft.root)
+	return FPResult{
+		FP:    fp,
+		Count: count,
+		IType: 0,
+		Items: ft.all().Limit(int(count)),
+	}
 }
 
 // easySplit splits an interval in two parts trying to do it in such way that the first

--- a/sync2/fptree/fptree_test.go
+++ b/sync2/fptree/fptree_test.go
@@ -813,6 +813,26 @@ func TestFPTreeNoIDStoreCalls(t *testing.T) {
 	}
 }
 
+func TestFPTreeFingerprintAll(t *testing.T) {
+	ft := fptree.NewFPTreeWithValues(0, testKeyLen)
+	hashes := []rangesync.KeyBytes{
+		rangesync.MustParseHexKeyBytes("1111111111111111111111111111111111111111111111111111111111111111"),
+		rangesync.MustParseHexKeyBytes("2222222222222222222222222222222222222222222222222222222222222222"),
+		rangesync.MustParseHexKeyBytes("4444444444444444444444444444444444444444444444444444444444444444"),
+		rangesync.MustParseHexKeyBytes("8888888888888888888888888888888888888888888888888888888888888888"),
+	}
+	for _, h := range hashes {
+		ft.RegisterKey(h)
+	}
+	fpr := ft.FingerprintAll()
+	require.Equal(t, "ffffffffffffffffffffffff", fpr.FP.String(), "fp")
+	require.Equal(t, uint32(4), fpr.Count, "count")
+	require.Zero(t, fpr.IType, "itype")
+	items, err := fpr.Items.Limit(int(fpr.Count)).Collect()
+	require.NoError(t, err)
+	require.ElementsMatch(t, hashes, items)
+}
+
 func TestFPTreeClone(t *testing.T) {
 	store := fptree.NewFPTreeWithValues(10, testKeyLen)
 	ft1 := fptree.NewFPTree(10, store, testKeyLen, testDepth)

--- a/sync2/multipeer/multipeer.go
+++ b/sync2/multipeer/multipeer.go
@@ -167,15 +167,16 @@ func DefaultConfig() MultiPeerReconcilerConfig {
 
 // MultiPeerReconciler reconcilies the local set against multiple remote sets.
 type MultiPeerReconciler struct {
-	logger   *zap.Logger
-	cfg      MultiPeerReconcilerConfig
-	syncBase SyncBase
-	peers    *peers.Peers
-	clock    clockwork.Clock
-	keyLen   int
-	maxDepth int
-	runner   syncRunner
-	sl       *syncList
+	logger         *zap.Logger
+	cfg            MultiPeerReconcilerConfig
+	syncBase       SyncBase
+	peers          *peers.Peers
+	clock          clockwork.Clock
+	keyLen         int
+	maxDepth       int
+	runner         syncRunner
+	sl             *syncList
+	syncCycleCount atomic.Uint32
 }
 
 func newMultiPeerReconciler(
@@ -363,6 +364,7 @@ func (mpr *MultiPeerReconciler) fullSync(ctx context.Context, syncPeers []p2p.Pe
 }
 
 func (mpr *MultiPeerReconciler) syncOnce(ctx context.Context, lastWasSplit bool) (full bool, err error) {
+	defer mpr.syncCycleCount.Add(1)
 	var s syncability
 	for {
 		syncPeers := mpr.peers.SelectBestWithProtocols(int(mpr.cfg.SyncPeerCount), []protocol.ID{Protocol})
@@ -500,4 +502,10 @@ LOOP:
 // number of full syncs has happened within the specified duration of time.
 func (mpr *MultiPeerReconciler) Synced() bool {
 	return mpr.sl.Synced()
+}
+
+// SyncCycleCount returns the number of sync cycles that have happened,
+// no matter if they were successful or not.
+func (mpr *MultiPeerReconciler) SyncCycleCount() int {
+	return int(mpr.syncCycleCount.Load())
 }

--- a/sync2/multipeer/setsyncbase.go
+++ b/sync2/multipeer/setsyncbase.go
@@ -38,19 +38,10 @@ func NewSetSyncBase(
 
 // Count implements SyncBase.
 func (ssb *SetSyncBase) Count() (int, error) {
-	// TODO: don't lock on db-bound operations
+	// TODO: don't lock on potentially db-bound operations
 	ssb.mtx.Lock()
 	defer ssb.mtx.Unlock()
-	if empty, err := ssb.os.Empty(); err != nil {
-		return 0, fmt.Errorf("check if the set is empty: %w", err)
-	} else if empty {
-		return 0, nil
-	}
-	x, err := ssb.os.Items().First()
-	if err != nil {
-		return 0, fmt.Errorf("get first item: %w", err)
-	}
-	info, err := ssb.os.GetRangeInfo(x, x)
+	info, err := ssb.os.SetInfo()
 	if err != nil {
 		return 0, fmt.Errorf("get range info: %w", err)
 	}

--- a/sync2/multipeer/setsyncbase_test.go
+++ b/sync2/multipeer/setsyncbase_test.go
@@ -66,7 +66,6 @@ func TestSetSyncBase(t *testing.T) {
 	t.Run("sync", func(t *testing.T) {
 		t.Parallel()
 		st := newSetSyncBaseTester(t, nil)
-
 		os := st.expectCopy()
 		x := rangesync.RandomKeyBytes(32)
 		y := rangesync.RandomKeyBytes(32)
@@ -90,27 +89,10 @@ func TestSetSyncBase(t *testing.T) {
 		st.ssb.Sync(context.Background(), p2p.Peer("p1"), x, y)
 	})
 
-	t.Run("count empty", func(t *testing.T) {
+	t.Run("count", func(t *testing.T) {
 		t.Parallel()
 		st := newSetSyncBaseTester(t, nil)
-
-		st.os.EXPECT().Empty().Return(true, nil)
-		count, err := st.ssb.Count()
-		require.NoError(t, err)
-		require.Zero(t, count)
-	})
-
-	t.Run("count non-empty", func(t *testing.T) {
-		t.Parallel()
-		st := newSetSyncBaseTester(t, nil)
-
-		st.os.EXPECT().Empty().Return(false, nil)
-		items := []rangesync.KeyBytes{
-			rangesync.RandomKeyBytes(32),
-			rangesync.RandomKeyBytes(32),
-		}
-		st.os.EXPECT().Items().Return(rangesync.MakeSeqResult(items))
-		st.os.EXPECT().GetRangeInfo(items[0], items[0]).Return(rangesync.RangeInfo{Count: 2}, nil)
+		st.os.EXPECT().SetInfo().Return(rangesync.RangeInfo{Count: 2}, nil)
 		count, err := st.ssb.Count()
 		require.NoError(t, err)
 		require.Equal(t, 2, count)

--- a/sync2/p2p.go
+++ b/sync2/p2p.go
@@ -132,9 +132,9 @@ func (s *P2PHashSync) Load() error {
 	if err := s.os.EnsureLoaded(); err != nil {
 		return fmt.Errorf("load set: %w", err)
 	}
-	info, err := s.os.GetRangeInfo(nil, nil)
+	info, err := s.os.SetInfo()
 	if err != nil {
-		return fmt.Errorf("get range info: %w", err)
+		return fmt.Errorf("set info: %w", err)
 	}
 	s.logger.Info("done loading the set",
 		zap.Duration("elapsed", time.Since(start)),
@@ -228,4 +228,10 @@ func (s *P2PHashSync) WaitForSync(ctx context.Context) error {
 		}
 	}
 	return nil
+}
+
+// SyncCycleCount returns the number of sync cycles that have happened,
+// no matter if they were successful or not.
+func (s *P2PHashSync) SyncCycleCount() int {
+	return s.reconciler.SyncCycleCount()
 }

--- a/sync2/p2p_test.go
+++ b/sync2/p2p_test.go
@@ -19,9 +19,12 @@ import (
 	"github.com/spacemeshos/go-spacemesh/fetch/peers"
 	"github.com/spacemeshos/go-spacemesh/p2p"
 	"github.com/spacemeshos/go-spacemesh/p2p/server"
+	"github.com/spacemeshos/go-spacemesh/sql"
 	"github.com/spacemeshos/go-spacemesh/sync2"
+	"github.com/spacemeshos/go-spacemesh/sync2/dbset"
 	"github.com/spacemeshos/go-spacemesh/sync2/multipeer"
 	"github.com/spacemeshos/go-spacemesh/sync2/rangesync"
+	"github.com/spacemeshos/go-spacemesh/sync2/sqlstore"
 )
 
 type dumbSet struct {
@@ -133,16 +136,10 @@ func TestP2P(t *testing.T) {
 			require.NoError(t, hsync.Set().WithCopy(
 				context.Background(),
 				func(os rangesync.OrderedSet) error {
-					empty, err := os.Empty()
+					info, err := os.SetInfo()
 					require.NoError(t, err)
-					if empty {
+					if info.Count < numHashes {
 						r = false
-					} else {
-						info, err := os.GetRangeInfo(nil, nil)
-						require.NoError(t, err)
-						if info.Count < numHashes {
-							r = false
-						}
 					}
 					return nil
 				}))
@@ -158,7 +155,9 @@ func TestP2P(t *testing.T) {
 		require.NoError(t, hsync.Set().WithCopy(
 			context.Background(),
 			func(os rangesync.OrderedSet) error {
-				actualItems, err := os.Items().Collect()
+				info, err := os.SetInfo()
+				require.NoError(t, err)
+				actualItems, err := info.Items.Collect()
 				require.NoError(t, err)
 				require.ElementsMatch(t, initialSet, actualItems)
 				return nil
@@ -181,7 +180,150 @@ func TestP2P(t *testing.T) {
 			}
 		}
 		return true
-	}, 30*time.Second, 300*time.Millisecond)
+	}, 30*time.Second, 100*time.Millisecond)
+
+	for _, hsync := range hs {
+		hsync.Stop()
+	}
+}
+
+type insertHandler struct {
+	t  *testing.T
+	db sql.Database
+}
+
+func (ih insertHandler) Commit(
+	ctx context.Context,
+	peer p2p.Peer,
+	base rangesync.OrderedSet,
+	received rangesync.SeqResult,
+) error {
+	items, err := received.Collect()
+	if err != nil {
+		return err
+	}
+	sqlstore.EnsureDBItems(ih.t, ih.db, items)
+	return nil
+}
+
+func TestP2P_DBSet(t *testing.T) {
+	const (
+		numNodes  = 4
+		numHashes = 100
+		keyLen    = 32
+		maxDepth  = 24
+	)
+	logger := zaptest.NewLogger(t)
+	mesh, err := mocknet.FullMeshLinked(numNodes)
+	require.NoError(t, err)
+	st := &sqlstore.SyncedTable{
+		TableName: "foo",
+		IDColumn:  "id",
+	}
+	hs := make([]*sync2.P2PHashSync, numNodes)
+	dbs := make([]sql.Database, numNodes)
+	initialSet := make([]rangesync.KeyBytes, numHashes)
+	for n := range initialSet {
+		initialSet[n] = rangesync.RandomKeyBytes(32)
+	}
+	var eg errgroup.Group
+	defer eg.Wait()
+	for n := range hs {
+		ps := peers.New()
+		for m := 0; m < numNodes; m++ {
+			if m != n {
+				ps.Add(mesh.Hosts()[m].ID(), func() []protocol.ID {
+					return []protocol.ID{multipeer.Protocol}
+				})
+			}
+		}
+		cfg := sync2.DefaultConfig()
+		cfg.SyncInterval = 100 * time.Millisecond
+		cfg.MaxDepth = maxDepth
+		cfg.AdvanceInterval = 200 * time.Millisecond
+		host := mesh.Hosts()[n]
+		var items []rangesync.KeyBytes
+		if n == 0 {
+			items = initialSet
+		}
+		dbs[n] = sqlstore.PopulateDB(t, keyLen, items)
+		ds := dbset.NewDBSet(dbs[n], st, keyLen, maxDepth)
+		d := rangesync.NewDispatcher(logger)
+		srv := d.SetupServer(host, "sync2test", server.WithLog(logger))
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		eg.Go(func() error { return srv.Run(ctx) })
+		hs[n], err = sync2.NewP2PHashSync(
+			// Using real logger for P2PHashSync (and thus RangeSetReconciler)
+			// may cause database access when printing sequences, and in this
+			// test we need to make sure there are no such accesses after the
+			// nodes are in sync.
+			zap.NewNop(),
+			d, "test", ds, keyLen, ps, insertHandler{t: t, db: dbs[n]}, cfg, true)
+		require.NoError(t, err)
+		require.NoError(t, hs[n].Load())
+		require.False(t, hs[n].Synced())
+	}
+
+	require.NoError(t, mesh.ConnectAllButSelf())
+
+	for _, hsync := range hs {
+		hsync.Start()
+	}
+
+	initialInfo, err := hs[0].Set().SetInfo()
+	require.NoError(t, err)
+	require.Equal(t, numHashes, initialInfo.Count)
+
+	require.Eventually(t, func() bool {
+		for _, hsync := range hs {
+			// use a snapshot to avoid races
+			if !hsync.Synced() {
+				return false
+			}
+			r := true
+			require.NoError(t, hsync.Set().WithCopy(
+				context.Background(),
+				func(os rangesync.OrderedSet) error {
+					info, err := os.SetInfo()
+					require.NoError(t, err)
+					if info.Count < numHashes {
+						r = false
+					}
+					require.Equal(t, initialInfo.Fingerprint, info.Fingerprint)
+					return nil
+				}))
+			if !r {
+				return false
+			}
+		}
+		return true
+	}, 30*time.Second, 100*time.Millisecond)
+
+	// Make sure there are no queries to the database made when nodes are already in sync,
+	// except for advancing the DBSet.
+	cycleCounts := make([]int, numNodes)
+	for n, db := range dbs {
+		db.Intercept("noqueries", func(query string) error {
+			if query != `SELECT max("rowid") FROM "foo"` &&
+				query != `SELECT "id" FROM "foo" WHERE "rowid" BETWEEN ? AND ?` {
+				require.Fail(t, "unexpected query: %s", query)
+			}
+			return nil
+		})
+		cycleCounts[n] = hs[n].SyncCycleCount()
+	}
+
+	// Make sure each syncer had 3 cycle counts without any queries except for
+	// advancing the DBSet.
+	require.Eventually(t, func() bool {
+		for n, hsync := range hs {
+			if hsync.SyncCycleCount() <= cycleCounts[n]+3 {
+				return false
+			}
+		}
+		return true
+	}, 30*time.Second, 100*time.Millisecond)
 
 	for _, hsync := range hs {
 		hsync.Stop()

--- a/sync2/rangesync/dumbset.go
+++ b/sync2/rangesync/dumbset.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/md5"
 	"errors"
+	"fmt"
 	"slices"
 	"sync"
 	"time"
@@ -239,16 +240,15 @@ func (ds *DumbSet) getRangeInfo(
 	x, y KeyBytes,
 	count int,
 ) (r RangeInfo, end KeyBytes, err error) {
-	if x == nil && y == nil {
+	if x == nil || y == nil {
 		if len(ds.keys) == 0 {
 			return RangeInfo{
 				Fingerprint: EmptyFingerprint(),
+				Items:       EmptySeqResult(),
 			}, nil, nil
 		}
 		x = ds.keys[0]
 		y = x
-	} else if x == nil || y == nil {
-		panic("BUG: bad X or Y")
 	}
 	rangeItems, start, end := naiveRange(ds.keys, x, y, count)
 	fpFunc := ds.FPFunc
@@ -270,8 +270,11 @@ func (ds *DumbSet) getRangeInfo(
 	return r, end, nil
 }
 
-// GetRangeInfo implements OrderedSet.
-func (ds *DumbSet) GetRangeInfo(x, y KeyBytes) (RangeInfo, error) {
+// RangeInfo implements OrderedSet.
+func (ds *DumbSet) RangeInfo(x, y KeyBytes) (RangeInfo, error) {
+	if x == nil || y == nil {
+		return RangeInfo{}, errors.New("bad range")
+	}
 	ri, _, err := ds.getRangeInfo(x, y, -1)
 	return ri, err
 }
@@ -298,14 +301,13 @@ func (ds *DumbSet) SplitRange(x, y KeyBytes, count int) (SplitInfo, error) {
 	}, nil
 }
 
-// Empty implements OrderedSet.
-func (ds *DumbSet) Empty() (bool, error) {
-	return len(ds.keys) == 0, nil
-}
-
-// Items implements OrderedSet.
-func (ds *DumbSet) Items() SeqResult {
-	return MakeSeqResult(ds.keys)
+// SetInfo implements OrderedSet.
+func (ds *DumbSet) SetInfo() (RangeInfo, error) {
+	ri, _, err := ds.getRangeInfo(nil, nil, -1)
+	if err != nil {
+		panic("unexpected error in SetInfo: " + err.Error())
+	}
+	return ri, nil
 }
 
 // WithCopy implements OrderedSet.
@@ -342,13 +344,16 @@ func (ds *DumbSet) Advance() error {
 
 // Has implements OrderedSet.
 func (ds *DumbSet) Has(k KeyBytes) (bool, error) {
-	sr := ds.Items()
-	for cur := range sr.Seq {
+	info, err := ds.SetInfo()
+	if err != nil {
+		return false, fmt.Errorf("set info: %w", err)
+	}
+	for cur := range info.Items.Seq {
 		if k.Compare(cur) == 0 {
-			return true, sr.Error()
+			return true, info.Items.Error()
 		}
 	}
-	return false, sr.Error()
+	return false, info.Items.Error()
 }
 
 // Release implements OrderedSet.

--- a/sync2/rangesync/dumbset.go
+++ b/sync2/rangesync/dumbset.go
@@ -304,10 +304,7 @@ func (ds *DumbSet) SplitRange(x, y KeyBytes, count int) (SplitInfo, error) {
 // SetInfo implements OrderedSet.
 func (ds *DumbSet) SetInfo() (RangeInfo, error) {
 	ri, _, err := ds.getRangeInfo(nil, nil, -1)
-	if err != nil {
-		panic("unexpected error in SetInfo: " + err.Error())
-	}
-	return ri, nil
+	return ri, err
 }
 
 // WithCopy implements OrderedSet.

--- a/sync2/rangesync/interface.go
+++ b/sync2/rangesync/interface.go
@@ -48,7 +48,7 @@ type OrderedSet interface {
 	// OrderedSet passed to WithCopy callback is expected to be valid outside of the
 	// callback as well.
 	Received() SeqResult
-	// GetRangeInfo returns RangeInfo for the item range in the ordered set,
+	// RangeInfo returns RangeInfo for the item range in the ordered set,
 	// bounded by [x, y).
 	// x == y indicates the whole set.
 	// x < y indicates a normal range starting with x and ending below y.
@@ -56,16 +56,12 @@ type OrderedSet interface {
 	// of the set and from the beginning of the set to y, non-inclusive.
 	// If count >= 0, at most count items are returned, and RangeInfo
 	// is returned for the corresponding subrange of the requested range.
-	// If both x and y are nil, the information for the entire set is returned.
-	// If any of x or y is nil, the other one must be nil as well.
-	GetRangeInfo(x, y KeyBytes) (RangeInfo, error)
+	RangeInfo(x, y KeyBytes) (RangeInfo, error)
 	// SplitRange splits the range roughly after the specified count of items,
 	// returning RangeInfo for the first half and the second half of the range.
 	SplitRange(x, y KeyBytes, count int) (SplitInfo, error)
-	// Items returns the sequence of items in the set.
-	Items() SeqResult
-	// Empty returns true if the set is empty.
-	Empty() (bool, error)
+	// SetInfo returns RangeInfo for the whole set.
+	SetInfo() (RangeInfo, error)
 	// WithCopy runs the specified function, passing to it a temporary shallow copy of
 	// the OrderedSet. The copy is discarded after the function returns, releasing
 	// any resources associated with it.

--- a/sync2/rangesync/mocks/mocks.go
+++ b/sync2/rangesync/mocks/mocks.go
@@ -118,45 +118,6 @@ func (c *MockOrderedSetAdvanceCall) DoAndReturn(f func() error) *MockOrderedSetA
 	return c
 }
 
-// Empty mocks base method.
-func (m *MockOrderedSet) Empty() (bool, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Empty")
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Empty indicates an expected call of Empty.
-func (mr *MockOrderedSetMockRecorder) Empty() *MockOrderedSetEmptyCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Empty", reflect.TypeOf((*MockOrderedSet)(nil).Empty))
-	return &MockOrderedSetEmptyCall{Call: call}
-}
-
-// MockOrderedSetEmptyCall wrap *gomock.Call
-type MockOrderedSetEmptyCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockOrderedSetEmptyCall) Return(arg0 bool, arg1 error) *MockOrderedSetEmptyCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockOrderedSetEmptyCall) Do(f func() (bool, error)) *MockOrderedSetEmptyCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockOrderedSetEmptyCall) DoAndReturn(f func() (bool, error)) *MockOrderedSetEmptyCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // EnsureLoaded mocks base method.
 func (m *MockOrderedSet) EnsureLoaded() error {
 	m.ctrl.T.Helper()
@@ -191,45 +152,6 @@ func (c *MockOrderedSetEnsureLoadedCall) Do(f func() error) *MockOrderedSetEnsur
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockOrderedSetEnsureLoadedCall) DoAndReturn(f func() error) *MockOrderedSetEnsureLoadedCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// GetRangeInfo mocks base method.
-func (m *MockOrderedSet) GetRangeInfo(x, y rangesync.KeyBytes) (rangesync.RangeInfo, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRangeInfo", x, y)
-	ret0, _ := ret[0].(rangesync.RangeInfo)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetRangeInfo indicates an expected call of GetRangeInfo.
-func (mr *MockOrderedSetMockRecorder) GetRangeInfo(x, y any) *MockOrderedSetGetRangeInfoCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRangeInfo", reflect.TypeOf((*MockOrderedSet)(nil).GetRangeInfo), x, y)
-	return &MockOrderedSetGetRangeInfoCall{Call: call}
-}
-
-// MockOrderedSetGetRangeInfoCall wrap *gomock.Call
-type MockOrderedSetGetRangeInfoCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockOrderedSetGetRangeInfoCall) Return(arg0 rangesync.RangeInfo, arg1 error) *MockOrderedSetGetRangeInfoCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockOrderedSetGetRangeInfoCall) Do(f func(rangesync.KeyBytes, rangesync.KeyBytes) (rangesync.RangeInfo, error)) *MockOrderedSetGetRangeInfoCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockOrderedSetGetRangeInfoCall) DoAndReturn(f func(rangesync.KeyBytes, rangesync.KeyBytes) (rangesync.RangeInfo, error)) *MockOrderedSetGetRangeInfoCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -273,44 +195,6 @@ func (c *MockOrderedSetHasCall) DoAndReturn(f func(rangesync.KeyBytes) (bool, er
 	return c
 }
 
-// Items mocks base method.
-func (m *MockOrderedSet) Items() rangesync.SeqResult {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Items")
-	ret0, _ := ret[0].(rangesync.SeqResult)
-	return ret0
-}
-
-// Items indicates an expected call of Items.
-func (mr *MockOrderedSetMockRecorder) Items() *MockOrderedSetItemsCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Items", reflect.TypeOf((*MockOrderedSet)(nil).Items))
-	return &MockOrderedSetItemsCall{Call: call}
-}
-
-// MockOrderedSetItemsCall wrap *gomock.Call
-type MockOrderedSetItemsCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockOrderedSetItemsCall) Return(arg0 rangesync.SeqResult) *MockOrderedSetItemsCall {
-	c.Call = c.Call.Return(arg0)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockOrderedSetItemsCall) Do(f func() rangesync.SeqResult) *MockOrderedSetItemsCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockOrderedSetItemsCall) DoAndReturn(f func() rangesync.SeqResult) *MockOrderedSetItemsCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // Loaded mocks base method.
 func (m *MockOrderedSet) Loaded() bool {
 	m.ctrl.T.Helper()
@@ -345,6 +229,45 @@ func (c *MockOrderedSetLoadedCall) Do(f func() bool) *MockOrderedSetLoadedCall {
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockOrderedSetLoadedCall) DoAndReturn(f func() bool) *MockOrderedSetLoadedCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// RangeInfo mocks base method.
+func (m *MockOrderedSet) RangeInfo(x, y rangesync.KeyBytes) (rangesync.RangeInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RangeInfo", x, y)
+	ret0, _ := ret[0].(rangesync.RangeInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RangeInfo indicates an expected call of RangeInfo.
+func (mr *MockOrderedSetMockRecorder) RangeInfo(x, y any) *MockOrderedSetRangeInfoCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RangeInfo", reflect.TypeOf((*MockOrderedSet)(nil).RangeInfo), x, y)
+	return &MockOrderedSetRangeInfoCall{Call: call}
+}
+
+// MockOrderedSetRangeInfoCall wrap *gomock.Call
+type MockOrderedSetRangeInfoCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockOrderedSetRangeInfoCall) Return(arg0 rangesync.RangeInfo, arg1 error) *MockOrderedSetRangeInfoCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockOrderedSetRangeInfoCall) Do(f func(rangesync.KeyBytes, rangesync.KeyBytes) (rangesync.RangeInfo, error)) *MockOrderedSetRangeInfoCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockOrderedSetRangeInfoCall) DoAndReturn(f func(rangesync.KeyBytes, rangesync.KeyBytes) (rangesync.RangeInfo, error)) *MockOrderedSetRangeInfoCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -460,6 +383,45 @@ func (c *MockOrderedSetRecentCall) Do(f func(time.Time) (rangesync.SeqResult, in
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockOrderedSetRecentCall) DoAndReturn(f func(time.Time) (rangesync.SeqResult, int)) *MockOrderedSetRecentCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// SetInfo mocks base method.
+func (m *MockOrderedSet) SetInfo() (rangesync.RangeInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetInfo")
+	ret0, _ := ret[0].(rangesync.RangeInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SetInfo indicates an expected call of SetInfo.
+func (mr *MockOrderedSetMockRecorder) SetInfo() *MockOrderedSetSetInfoCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetInfo", reflect.TypeOf((*MockOrderedSet)(nil).SetInfo))
+	return &MockOrderedSetSetInfoCall{Call: call}
+}
+
+// MockOrderedSetSetInfoCall wrap *gomock.Call
+type MockOrderedSetSetInfoCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockOrderedSetSetInfoCall) Return(arg0 rangesync.RangeInfo, arg1 error) *MockOrderedSetSetInfoCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockOrderedSetSetInfoCall) Do(f func() (rangesync.RangeInfo, error)) *MockOrderedSetSetInfoCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockOrderedSetSetInfoCall) DoAndReturn(f func() (rangesync.RangeInfo, error)) *MockOrderedSetSetInfoCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/sync2/rangesync/p2p_test.go
+++ b/sync2/rangesync/p2p_test.go
@@ -131,7 +131,11 @@ var startDate = time.Date(2024, 8, 29, 18, 0, 0, 0, time.UTC)
 func (frs *fakeRecentSet) registerAll(_ context.Context) error {
 	frs.timestamps = make(map[string]time.Time)
 	t := startDate
-	items, err := frs.OrderedSet.Items().Collect()
+	info, err := frs.OrderedSet.SetInfo()
+	if err != nil {
+		return err
+	}
+	items, err := info.Items.Collect()
 	if err != nil {
 		return err
 	}
@@ -153,8 +157,11 @@ func (frs *fakeRecentSet) Receive(k rangesync.KeyBytes) error {
 
 // Recent implements OrderedSet.
 func (frs *fakeRecentSet) Recent(since time.Time) (rangesync.SeqResult, int) {
-	var items []rangesync.KeyBytes
-	items, err := frs.OrderedSet.Items().Collect()
+	info, err := frs.OrderedSet.SetInfo()
+	if err != nil {
+		return rangesync.ErrorSeqResult(err), 0
+	}
+	items, err := info.Items.Collect()
 	if err != nil {
 		return rangesync.ErrorSeqResult(err), 0
 	}
@@ -291,10 +298,12 @@ func testWireProbe(t *testing.T, getRequester getRequesterFunc) {
 	logger := zap.NewNop()
 	cst, ctx := newClientServerTester(t, st.setA, getRequester, st.cfg, &tr, clock)
 	pss := rangesync.NewPairwiseSetSyncerInternal(logger, cst.client, "test", st.cfg, &tr, clock)
-	itemsA := st.setA.Items()
+	info, err := st.setA.SetInfo()
+	require.NoError(t, err)
+	itemsA := info.Items
 	x, err := itemsA.First()
 	require.NoError(t, err)
-	infoA, err := st.setA.GetRangeInfo(x, x)
+	infoA, err := st.setA.RangeInfo(x, x)
 	require.NoError(t, err)
 	prA, err := pss.Probe(ctx, cst.srvPeerID, st.setB, nil, nil)
 	require.NoError(t, err)

--- a/sync2/rangesync/rangesync.go
+++ b/sync2/rangesync/rangesync.go
@@ -139,13 +139,15 @@ func NewRangeSetReconciler(logger *zap.Logger, cfg RangeSetReconcilerConfig, os 
 }
 
 func (rsr *RangeSetReconciler) defaultRange() (x, y KeyBytes, err error) {
-	if empty, err := rsr.os.Empty(); err != nil {
-		return nil, nil, fmt.Errorf("checking for empty set: %w", err)
-	} else if empty {
+	info, err := rsr.os.SetInfo()
+	if err != nil {
+		return nil, nil, fmt.Errorf("set info: %w", err)
+	}
+	if info.Count == 0 {
 		return nil, nil, nil
 	}
 
-	x, err = rsr.os.Items().First()
+	x, err = info.Items.First()
 	if err != nil {
 		return nil, nil, fmt.Errorf("get items: %w", err)
 	}
@@ -328,10 +330,13 @@ func (rsr *RangeSetReconciler) messageRange(
 			return nil, nil, errors.New("EmptySet message should not contain a range")
 		}
 		return rsr.defaultRange()
-	case MessageTypeProbe, MessageTypeRecent:
+	case MessageTypeRecent:
 		if x == nil {
 			return rsr.defaultRange()
 		}
+	case MessageTypeProbe:
+		// We can allow x=nil and y=nil for probe messages.
+		// This means probing the whole set and helps avoiding database access.
 	default:
 		if x == nil {
 			return nil, nil, fmt.Errorf("no range for message of type %s", msg.Type())
@@ -403,30 +408,27 @@ func (rsr *RangeSetReconciler) handleMessage(
 		}
 	}
 
+	var info RangeInfo
 	if x == nil {
-		switch msg.Type() {
-		case MessageTypeProbe:
-			rsr.logger.Debug("handleMessage: send empty probe response")
-			if err := s.SendSample(
-				x, y, EmptyFingerprint(), 0, 0, EmptySeqResult(),
-			); err != nil {
-				return false, err
-			}
-		case MessageTypeRecent:
-			return false, rsr.handleRecent(s, msg, x, y, receivedKeys)
+		info, err = rsr.os.SetInfo()
+		if err != nil {
+			return false, fmt.Errorf("set info: %w", err)
 		}
-		return true, nil
+		rsr.logger.Debug("handleMessage: range info for the whole set",
+			zap.Array("items", info.Items),
+			zap.Int("count", info.Count),
+			log.ZShortStringer("fingerprint", info.Fingerprint))
+	} else {
+		info, err = rsr.os.RangeInfo(x, y)
+		if err != nil {
+			return false, fmt.Errorf("range info: %w", err)
+		}
+		rsr.logger.Debug("handleMessage: range info",
+			log.ZShortStringer("x", x), log.ZShortStringer("y", y),
+			zap.Array("items", info.Items),
+			zap.Int("count", info.Count),
+			log.ZShortStringer("fingerprint", info.Fingerprint))
 	}
-
-	info, err := rsr.os.GetRangeInfo(x, y)
-	if err != nil {
-		return false, err
-	}
-	rsr.logger.Debug("handleMessage: range info",
-		log.ZShortStringer("x", x), log.ZShortStringer("y", y),
-		zap.Array("items", info.Items),
-		zap.Int("count", info.Count),
-		log.ZShortStringer("fingerprint", info.Fingerprint))
 
 	switch msg.Type() {
 	case MessageTypeEmptyRange, MessageTypeRangeContents, MessageTypeEmptySet:
@@ -463,7 +465,7 @@ func (rsr *RangeSetReconciler) handleMessage(
 			items = EmptySeqResult()
 			sampleSize = 0
 		}
-		if err := s.SendSample(x, y, info.Fingerprint, info.Count, sampleSize, items); err != nil {
+		if err = s.SendSample(x, y, info.Fingerprint, info.Count, sampleSize, items); err != nil {
 			return false, err
 		}
 		return true, nil
@@ -506,7 +508,7 @@ func (rsr *RangeSetReconciler) initiate(s sender, x, y KeyBytes, haveRecent bool
 		rsr.logger.Debug("initiate: send empty set")
 		return s.SendEmptySet()
 	}
-	info, err := rsr.os.GetRangeInfo(x, y)
+	info, err := rsr.os.RangeInfo(x, y)
 	if err != nil {
 		return fmt.Errorf("get range info: %w", err)
 	}
@@ -560,9 +562,20 @@ func (rsr *RangeSetReconciler) InitiateProbe(
 	x, y KeyBytes,
 ) (RangeInfo, error) {
 	s := sender{c}
-	info, err := rsr.os.GetRangeInfo(x, y)
-	if err != nil {
-		return RangeInfo{}, err
+	var (
+		info RangeInfo
+		err  error
+	)
+	if x == nil {
+		info, err = rsr.os.SetInfo()
+		if err != nil {
+			return RangeInfo{}, fmt.Errorf("set info: %w", err)
+		}
+	} else {
+		info, err = rsr.os.RangeInfo(x, y)
+		if err != nil {
+			return RangeInfo{}, fmt.Errorf("range info: %w", err)
+		}
 	}
 	if err := s.SendProbe(x, y, info.Fingerprint, int(rsr.cfg.SampleSize)); err != nil {
 		return RangeInfo{}, err

--- a/sync2/rangesync/rangesync_test.go
+++ b/sync2/rangesync/rangesync_test.go
@@ -65,9 +65,13 @@ func makeSet(items string) *rangesync.DumbSet {
 }
 
 func setStr(os rangesync.OrderedSet) string {
-	ids, err := os.Items().Collect()
+	info, err := os.SetInfo()
 	if err != nil {
-		panic("set error: " + err.Error())
+		panic("set info error: " + err.Error())
+	}
+	ids, err := info.Items.Collect()
+	if err != nil {
+		panic("collect items error: " + err.Error())
 	}
 	var r strings.Builder
 	for _, id := range ids {
@@ -446,9 +450,13 @@ func newHashSyncTester(tb testing.TB, cfg hashSyncTestConfig) *hashSyncTester {
 }
 
 func (st *hashSyncTester) verify(setA, setB rangesync.OrderedSet) {
-	itemsA, err := setA.Items().Collect()
+	infoA, err := setA.SetInfo()
 	require.NoError(st.tb, err)
-	itemsB, err := setB.Items().Collect()
+	itemsA, err := infoA.Items.Collect()
+	require.NoError(st.tb, err)
+	infoB, err := setB.SetInfo()
+	require.NoError(st.tb, err)
+	itemsB, err := infoB.Items.Collect()
 	require.NoError(st.tb, err)
 	require.Equal(st.tb, itemsA, itemsB)
 	require.Equal(st.tb, st.src, itemsA)

--- a/sync2/sqlstore/testdb.go
+++ b/sync2/sqlstore/testdb.go
@@ -20,15 +20,12 @@ func CreateDB(t *testing.T, keyLen int) sql.Database {
 	return db
 }
 
-// InsertDBItems inserts items into a test database. It is only used for testing.
-func InsertDBItems(t *testing.T, db sql.Database, content []rangesync.KeyBytes) {
+func insertDBItems(t *testing.T, db sql.Database, content []rangesync.KeyBytes, cmd string) {
 	err := db.WithTx(context.Background(), func(tx sql.Transaction) error {
 		for _, id := range content {
-			_, err := tx.Exec(
-				"insert into foo(id) values(?)",
-				func(stmt *sql.Statement) {
-					stmt.BindBytes(1, id)
-				}, nil)
+			_, err := tx.Exec(cmd, func(stmt *sql.Statement) {
+				stmt.BindBytes(1, id)
+			}, nil)
 			if err != nil {
 				return err
 			}
@@ -36,6 +33,17 @@ func InsertDBItems(t *testing.T, db sql.Database, content []rangesync.KeyBytes) 
 		return nil
 	})
 	require.NoError(t, err)
+}
+
+// InsertDBItems inserts items into a test database. It is only used for testing.
+func InsertDBItems(t *testing.T, db sql.Database, content []rangesync.KeyBytes) {
+	insertDBItems(t, db, content, "insert into foo(id) values(?)")
+}
+
+// EnsureDBItems inserts items into a test database, skipping rows with keys that already exist.
+// It is only used for testing.
+func EnsureDBItems(t *testing.T, db sql.Database, content []rangesync.KeyBytes) {
+	insertDBItems(t, db, content, "insert into foo(id) values(?) on conflict do nothing")
 }
 
 // PopulateDB creates a test database and inserts items into it. It is only used for testing.


### PR DESCRIPTION
## Motivation

`FPTree`, and thus `DBSet` hold enough information in memory for peers to decide whether they are in sync or not. In fully synced state, the peers only exchange probe requests that cover the whole set, and we only need to know fingerprint and count of the set. For that, no database queries are necessary.

## Description

This change eliminates unnecessary database access, simplifies `OrderedSet` interface and adds a test case that checks that synced peers do not make any queries except periodic queries needed to advance `DBSet` (include any newly added items).

## Test Plan

The tests need to pass.