### PR TITLE
[Merged by Bors] - node: fix certificate.committee-size on testnet

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -775,7 +775,7 @@ func (app *App) initServices(ctx context.Context) error {
 		return fmt.Errorf("create hare oracle: %w", err)
 	}
 
-	if app.Config.Certificate.CommitteeSize == 0 || !onMainNet(app.Config) {
+	if app.Config.Certificate.CommitteeSize == 0 {
 		app.log.With().Debug("certificate committee size is not set, defaulting to hare committee size",
 			log.Uint16("size", app.Config.HARE3.Committee),
 		)


### PR DESCRIPTION
## Motivation

Fixes #6578.

## Description

Only use half of pre-upgrade hare committee size if certificate.committee-size is set to 0.
Otherwise, use certificate.committee-size which is [200 for testnet](https://github.com/spacemeshos/go-spacemesh/blob/b9057841a0e7ce0997121726e5cde53e015e7930/config/presets/testnet.go#L192), with `CertifyThreshold` being 101.

## Test Plan

Verify that node syncs against testnet.