### PR TITLE
move optional publish epoch into the Event

### DIFF
--- a/activation/activation.go
+++ b/activation/activation.go
@@ -451,11 +451,9 @@ func (b *Builder) run(ctx context.Context, sig *signing.EdSigner) {
 
 		b.logger.Warn("failed to publish atx", zap.Error(err))
 
-		b.identitiesStates.Set(sig.NodeID(), nil,
-			&identity.Retrying{
-				ErrorMsg: err.Error(),
-			},
-		)
+		b.identitiesStates.Set(sig.NodeID(), &identity.Retrying{
+			ErrorMsg: err.Error(),
+		})
 
 		poetErr := &PoetSvcUnstableError{}
 		switch {
@@ -520,7 +518,7 @@ func (b *Builder) BuildNIPostChallenge(ctx context.Context, nodeID types.NodeID)
 	select {
 	case <-atxSyncedCh:
 	default:
-		b.identitiesStates.Set(nodeID, nil, &identity.WaitForATXSynced{})
+		b.identitiesStates.Set(nodeID, &identity.WaitForATXSynced{})
 	}
 
 	select {
@@ -576,7 +574,7 @@ func (b *Builder) BuildNIPostChallenge(ctx context.Context, nodeID types.NodeID)
 		)
 		events.EmitPoetWaitRound(nodeID, currentEpochId, publishEpochId, wait)
 		events.EmitWaitingForPoETRegistrationWindow(nodeID, currentEpochId, publishEpochId, wait)
-		b.identitiesStates.Set(nodeID, &publishEpochId, &identity.WaitingForPoetRegistrationWindow{})
+		b.identitiesStates.Set(nodeID, &identity.WaitingForPoetRegistrationWindow{Publish: publishEpochId})
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
@@ -623,7 +621,7 @@ func (b *Builder) BuildNIPostChallenge(ctx context.Context, nodeID types.NodeID)
 	if err := nipost.AddChallenge(b.localDB, nodeID, challenge); err != nil {
 		return nil, fmt.Errorf("add nipost challenge: %w", err)
 	}
-	b.identitiesStates.Set(nodeID, &challenge.PublishEpoch, &identity.PoetChallengeReady{})
+	b.identitiesStates.Set(nodeID, &identity.PoetChallengeReady{Publish: challenge.PublishEpoch})
 	return challenge, nil
 }
 
@@ -757,7 +755,7 @@ func (b *Builder) PublishActivationTx(ctx context.Context, sig *signing.EdSigner
 		zap.Uint32("current_layer", b.layerClock.CurrentLayer().Uint32()),
 		log.ZShortStringer("smesherID", sig.NodeID()),
 	)
-	b.identitiesStates.Set(sig.NodeID(), &challenge.PublishEpoch, &identity.ATXReady{})
+	b.identitiesStates.Set(sig.NodeID(), &identity.ATXReady{Publish: challenge.PublishEpoch})
 	select {
 	case <-ctx.Done():
 		return fmt.Errorf("wait for publication epoch: %w", ctx.Err())
@@ -808,9 +806,9 @@ func (b *Builder) PublishActivationTx(ctx context.Context, sig *signing.EdSigner
 	)
 	b.identitiesStates.Set(
 		sig.NodeID(),
-		&challenge.PublishEpoch,
 		&identity.ATXBroadcasted{
-			AtxId: atx.ID(),
+			AtxId:   atx.ID(),
+			Publish: challenge.PublishEpoch,
 		},
 	)
 	return nil

--- a/activation/interface.go
+++ b/activation/interface.go
@@ -238,5 +238,5 @@ type PostStates interface {
 }
 
 type IdentityStates interface {
-	Set(id types.NodeID, publishEpoch *types.EpochID, newState identity.State)
+	Set(id types.NodeID, newState identity.State)
 }

--- a/activation/mocks.go
+++ b/activation/mocks.go
@@ -2758,15 +2758,15 @@ func (m *MockIdentityStates) EXPECT() *MockIdentityStatesMockRecorder {
 }
 
 // Set mocks base method.
-func (m *MockIdentityStates) Set(id types.NodeID, publishEpoch *types.EpochID, newState identity.State) {
+func (m *MockIdentityStates) Set(id types.NodeID, newState identity.State) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Set", id, publishEpoch, newState)
+	m.ctrl.Call(m, "Set", id, newState)
 }
 
 // Set indicates an expected call of Set.
-func (mr *MockIdentityStatesMockRecorder) Set(id, publishEpoch, newState any) *MockIdentityStatesSetCall {
+func (mr *MockIdentityStatesMockRecorder) Set(id, newState any) *MockIdentityStatesSetCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Set", reflect.TypeOf((*MockIdentityStates)(nil).Set), id, publishEpoch, newState)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Set", reflect.TypeOf((*MockIdentityStates)(nil).Set), id, newState)
 	return &MockIdentityStatesSetCall{Call: call}
 }
 
@@ -2782,13 +2782,13 @@ func (c *MockIdentityStatesSetCall) Return() *MockIdentityStatesSetCall {
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockIdentityStatesSetCall) Do(f func(types.NodeID, *types.EpochID, identity.State)) *MockIdentityStatesSetCall {
+func (c *MockIdentityStatesSetCall) Do(f func(types.NodeID, identity.State)) *MockIdentityStatesSetCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockIdentityStatesSetCall) DoAndReturn(f func(types.NodeID, *types.EpochID, identity.State)) *MockIdentityStatesSetCall {
+func (c *MockIdentityStatesSetCall) DoAndReturn(f func(types.NodeID, identity.State)) *MockIdentityStatesSetCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/activation/nipost.go
+++ b/activation/nipost.go
@@ -284,10 +284,10 @@ func (nb *NIPostBuilder) BuildNIPost(
 		events.EmitWaitingForPoETRoundEnd(signer.NodeID(), postChallenge.PublishEpoch, curPoetRoundEnd)
 		nb.identityStates.Set(
 			signer.NodeID(),
-			&postChallenge.PublishEpoch,
 			&identity.WaitForPoetRoundEnd{
 				RoundEnd:        curPoetRoundEnd,
 				PublishEpochEnd: publishEpochEnd,
+				Publish:         postChallenge.PublishEpoch,
 			},
 		)
 
@@ -303,9 +303,10 @@ func (nb *NIPostBuilder) BuildNIPost(
 		if err := nipost.UpdatePoetProofRef(nb.localDB, signer.NodeID(), poetProofRef, membership); err != nil {
 			nb.logger.Warn("cannot persist poet proof ref", zap.Error(err))
 		}
-		nb.identityStates.Set(signer.NodeID(), &postChallenge.PublishEpoch,
+		nb.identityStates.Set(signer.NodeID(),
 			&identity.PoetProofReceived{
 				PoetUrl: poetUrl,
+				Publish: postChallenge.PublishEpoch,
 			},
 		)
 	}
@@ -332,14 +333,14 @@ func (nb *NIPostBuilder) BuildNIPost(
 		defer cancel()
 
 		nb.logger.Info("starting post execution", zap.Binary("challenge", poetProofRef[:]))
-		nb.identityStates.Set(signer.NodeID(), &postChallenge.PublishEpoch, &identity.GeneratingPostProof{})
+		nb.identityStates.Set(signer.NodeID(), &identity.GeneratingPostProof{Publish: postChallenge.PublishEpoch})
 
 		startTime := time.Now()
 		proof, postInfo, err := nb.Proof(postCtx, signer.NodeID(), poetProofRef[:], postChallenge)
 		if err != nil {
 			return nil, fmt.Errorf("failed to generate Post: %w", err)
 		}
-		nb.identityStates.Set(signer.NodeID(), &postChallenge.PublishEpoch, &identity.PostProofReady{})
+		nb.identityStates.Set(signer.NodeID(), &identity.PostProofReady{Publish: postChallenge.PublishEpoch})
 
 		postGenDuration := time.Since(startTime)
 
@@ -533,9 +534,10 @@ func (nb *NIPostBuilder) submitPoetChallenges(
 		}
 		return nil, &PoetSvcUnstableError{msg: "failed to submit challenge to any PoET", source: ctx.Err()}
 	}
-	nb.identityStates.Set(signer.NodeID(), &publishEpoch,
+	nb.identityStates.Set(signer.NodeID(),
 		&identity.PoetRegistered{
 			Registrations: existingRegistrations,
+			Publish:       publishEpoch,
 		},
 	)
 

--- a/api/grpcserver/v2alpha1/smeshing_identities.go
+++ b/api/grpcserver/v2alpha1/smeshing_identities.go
@@ -62,10 +62,6 @@ func (s *SmeshingIdentitiesService) States(
 
 			identityStateInfo := info.State.APIStateInfo()
 			identityStateInfo.Time = timestamppb.New(info.Time)
-			if info.PublishEpoch != nil {
-				epoch := info.PublishEpoch.Uint32()
-				identityStateInfo.PublishEpoch = &epoch
-			}
 
 			pbIdentities[nodeId.String()].History = append(pbIdentities[nodeId.String()].History, identityStateInfo)
 		}

--- a/identity/identity.go
+++ b/identity/identity.go
@@ -13,9 +13,8 @@ import (
 var ErrIdentityStateUnknown = errors.New("identity state is unknown")
 
 type StateInfo struct {
-	State        State
-	PublishEpoch *types.EpochID
-	Time         time.Time
+	State State
+	Time  time.Time
 }
 
 type StateStorage struct {
@@ -28,15 +27,10 @@ func NewIdentityStateStorage(db sql.Executor) *StateStorage {
 	}
 }
 
-func (s *StateStorage) Set(
-	id types.NodeID,
-	publishEpoch *types.EpochID,
-	newState State,
-) {
+func (s *StateStorage) Set(id types.NodeID, newState State) {
 	info := StateInfo{
-		State:        newState,
-		PublishEpoch: publishEpoch,
-		Time:         time.Now(),
+		State: newState,
+		Time:  time.Now(),
 	}
 
 	stateBytes, err := marshalState(&info)
@@ -100,7 +94,7 @@ func (s *StateStorage) AddProposal(id types.NodeID, proposal *types.Proposal) {
 	if err := events.InsertProposal(s.db, proposal); err != nil {
 		panic(fmt.Sprintf("failed to insert proposal: %v", err))
 	}
-	s.Set(proposal.SmesherID, nil, &ProposalPublished{
+	s.Set(proposal.SmesherID, &ProposalPublished{
 		Proposal: proposal.ID(),
 		Layer:    proposal.Layer,
 	})

--- a/identity/identity_test.go
+++ b/identity/identity_test.go
@@ -16,7 +16,6 @@ func Test_StatesPersistance(t *testing.T) {
 	// Set some states
 	id1 := types.NodeID{1}
 	id2 := types.NodeID{2}
-	epoch := types.EpochID(42)
 
 	states := []struct {
 		id    types.NodeID
@@ -44,7 +43,7 @@ func Test_StatesPersistance(t *testing.T) {
 
 	// Store states in first storage
 	for _, s := range states {
-		storage1.Set(s.id, &epoch, s.state)
+		storage1.Set(s.id, s.state)
 	}
 	states1 := storage1.All()
 

--- a/identity/serialization.go
+++ b/identity/serialization.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"time"
-
-	"github.com/spacemeshos/go-spacemesh/common/types"
 )
 
 type tag int
@@ -30,9 +28,8 @@ const (
 
 type serializableStateInfo struct {
 	// The tag is used to determine how to deserialize the raw state.
-	Tag          tag
-	PublishEpoch *types.EpochID
-	Time         time.Time
+	Tag  tag
+	Time time.Time
 
 	RawState json.RawMessage
 }
@@ -117,9 +114,8 @@ func unmarshalState(b []byte) (*StateInfo, error) {
 		return nil, err
 	}
 	info := &StateInfo{
-		State:        tagToState(s.Tag),
-		PublishEpoch: s.PublishEpoch,
-		Time:         s.Time,
+		State: tagToState(s.Tag),
+		Time:  s.Time,
 	}
 	if err := json.Unmarshal(s.RawState, info.State); err != nil {
 		return nil, err
@@ -133,10 +129,9 @@ func marshalState(state *StateInfo) ([]byte, error) {
 		return nil, err
 	}
 	s := serializableStateInfo{
-		Tag:          stateToTag(state.State),
-		PublishEpoch: state.PublishEpoch,
-		Time:         state.Time,
-		RawState:     json.RawMessage(rawState),
+		Tag:      stateToTag(state.State),
+		Time:     state.Time,
+		RawState: json.RawMessage(rawState),
 	}
 	return json.Marshal(s)
 }

--- a/identity/serialization_test.go
+++ b/identity/serialization_test.go
@@ -37,18 +37,15 @@ func RequireEqual(t *testing.T, expected, value *StateInfo) {
 		require.EqualValues(t, expected.State, value.State)
 	}
 	require.EqualValues(t, expected.Time.UnixNano(), value.Time.UnixNano())
-	require.EqualValues(t, expected.PublishEpoch, value.PublishEpoch)
 }
 
 func testRoundTrip(t *testing.T, state State) {
 	t.Helper()
 	t.Parallel()
-	epoch := types.EpochID(8)
 	time := time.Now()
 	expected := &StateInfo{
-		State:        state,
-		PublishEpoch: &epoch,
-		Time:         time,
+		State: state,
+		Time:  time,
 	}
 	bytes, err := marshalState(expected)
 	require.NoError(t, err)
@@ -67,13 +64,14 @@ func TestSerializationRoundTrip(t *testing.T) {
 		testRoundTrip(t, &WaitForATXSynced{})
 	})
 	t.Run("state WaitingForPoetRegistrationWindow", func(t *testing.T) {
-		testRoundTrip(t, &WaitingForPoetRegistrationWindow{})
+		testRoundTrip(t, &WaitingForPoetRegistrationWindow{Publish: 5})
 	})
 	t.Run("state PoetChallengeReady", func(t *testing.T) {
-		testRoundTrip(t, &PoetChallengeReady{})
+		testRoundTrip(t, &PoetChallengeReady{Publish: 6})
 	})
 	t.Run("state PoetRegistered", func(t *testing.T) {
 		testRoundTrip(t, &PoetRegistered{
+			Publish: 7,
 			Registrations: []nipost.PoETRegistration{
 				{
 					ChallengeHash: types.RandomHash(),
@@ -86,26 +84,36 @@ func TestSerializationRoundTrip(t *testing.T) {
 	})
 	t.Run("state WaitForPoetRoundEnd", func(t *testing.T) {
 		testRoundTrip(t, &WaitForPoetRoundEnd{
+			Publish:         8,
 			RoundEnd:        time.Now().Add(time.Hour),
 			PublishEpochEnd: time.Now().Add(time.Hour * 10),
 		})
 	})
 	t.Run("state PoetProofReceived", func(t *testing.T) {
 		testRoundTrip(t, &PoetProofReceived{
+			Publish: 9,
 			PoetUrl: "http://poet.sm",
 		})
 	})
 	t.Run("state GeneratingPostProof", func(t *testing.T) {
-		testRoundTrip(t, &GeneratingPostProof{})
+		testRoundTrip(t, &GeneratingPostProof{
+			Publish: 10,
+		})
 	})
 	t.Run("state PostProofReady", func(t *testing.T) {
-		testRoundTrip(t, &PostProofReady{})
+		testRoundTrip(t, &PostProofReady{
+			Publish: 11,
+		})
 	})
 	t.Run("state AtxReady", func(t *testing.T) {
-		testRoundTrip(t, &ATXReady{})
+		testRoundTrip(t, &ATXReady{
+			Publish: 11,
+		})
 	})
 	t.Run("state ATXBroadcasted", func(t *testing.T) {
-		testRoundTrip(t, &WaitingForPoetRegistrationWindow{})
+		testRoundTrip(t, &WaitingForPoetRegistrationWindow{
+			Publish: 12,
+		})
 	})
 	t.Run("state ProposalBuildFailed", func(t *testing.T) {
 		testRoundTrip(t, &ProposalBuildFailed{

--- a/identity/state.go
+++ b/identity/state.go
@@ -38,24 +38,33 @@ func (s *Retrying) APIStateInfo() *pb.IdentityStateInfo {
 }
 
 // poet.
-type WaitingForPoetRegistrationWindow struct{}
+type WaitingForPoetRegistrationWindow struct {
+	Publish types.EpochID
+}
 
 func (s *WaitingForPoetRegistrationWindow) APIStateInfo() *pb.IdentityStateInfo {
+	epoch := s.Publish.Uint32()
 	return &pb.IdentityStateInfo{
-		State: pb.IdentityState_WAITING_FOR_POET_REGISTRATION_WINDOW,
+		State:        pb.IdentityState_WAITING_FOR_POET_REGISTRATION_WINDOW,
+		PublishEpoch: &epoch,
 	}
 }
 
 // building nipost challenge.
-type PoetChallengeReady struct{}
+type PoetChallengeReady struct {
+	Publish types.EpochID
+}
 
 func (s *PoetChallengeReady) APIStateInfo() *pb.IdentityStateInfo {
+	epoch := s.Publish.Uint32()
 	return &pb.IdentityStateInfo{
-		State: pb.IdentityState_POET_CHALLENGE_READY,
+		State:        pb.IdentityState_POET_CHALLENGE_READY,
+		PublishEpoch: &epoch,
 	}
 }
 
 type PoetRegistered struct {
+	Publish       types.EpochID
 	Registrations []nipost.PoETRegistration
 }
 
@@ -70,8 +79,10 @@ func (s *PoetRegistered) APIStateInfo() *pb.IdentityStateInfo {
 		})
 	}
 
+	epoch := s.Publish.Uint32()
 	return &pb.IdentityStateInfo{
-		State: pb.IdentityState_POET_REGISTERED,
+		State:        pb.IdentityState_POET_REGISTERED,
+		PublishEpoch: &epoch,
 		Metadata: &pb.IdentityStateInfo_PoetRegistered{
 			PoetRegistered: &pb.PoetRegisteredState{
 				Registrations: rst,
@@ -84,11 +95,14 @@ func (s *PoetRegistered) APIStateInfo() *pb.IdentityStateInfo {
 type WaitForPoetRoundEnd struct {
 	RoundEnd        time.Time
 	PublishEpochEnd time.Time
+	Publish         types.EpochID
 }
 
 func (s *WaitForPoetRoundEnd) APIStateInfo() *pb.IdentityStateInfo {
+	epoch := s.Publish.Uint32()
 	return &pb.IdentityStateInfo{
-		State: pb.IdentityState_WAIT_FOR_POET_ROUND_END,
+		State:        pb.IdentityState_WAIT_FOR_POET_ROUND_END,
+		PublishEpoch: &epoch,
 		Metadata: &pb.IdentityStateInfo_WaitForPoetRoundEnd{
 			WaitForPoetRoundEnd: &pb.WaitForPoetRoundEndState{
 				RoundEnd:        timestamppb.New(s.RoundEnd),
@@ -100,11 +114,14 @@ func (s *WaitForPoetRoundEnd) APIStateInfo() *pb.IdentityStateInfo {
 
 type PoetProofReceived struct {
 	PoetUrl string
+	Publish types.EpochID
 }
 
 func (s *PoetProofReceived) APIStateInfo() *pb.IdentityStateInfo {
+	epoch := s.Publish.Uint32()
 	return &pb.IdentityStateInfo{
-		State: pb.IdentityState_POET_PROOF_RECEIVED,
+		State:        pb.IdentityState_POET_PROOF_RECEIVED,
+		PublishEpoch: &epoch,
 		Metadata: &pb.IdentityStateInfo_PoetProofReceived{
 			PoetProofReceived: &pb.PoetProofReceivedState{
 				PoetUrl: s.PoetUrl,
@@ -114,38 +131,53 @@ func (s *PoetProofReceived) APIStateInfo() *pb.IdentityStateInfo {
 }
 
 // post.
-type GeneratingPostProof struct{}
+type GeneratingPostProof struct {
+	Publish types.EpochID
+}
 
 func (s *GeneratingPostProof) APIStateInfo() *pb.IdentityStateInfo {
+	epoch := s.Publish.Uint32()
 	return &pb.IdentityStateInfo{
-		State: pb.IdentityState_GENERATING_POST_PROOF,
+		State:        pb.IdentityState_GENERATING_POST_PROOF,
+		PublishEpoch: &epoch,
 	}
 }
 
-type PostProofReady struct{}
+type PostProofReady struct {
+	Publish types.EpochID
+}
 
 func (s *PostProofReady) APIStateInfo() *pb.IdentityStateInfo {
+	epoch := s.Publish.Uint32()
 	return &pb.IdentityStateInfo{
-		State: pb.IdentityState_POST_PROOF_READY,
+		State:        pb.IdentityState_POST_PROOF_READY,
+		PublishEpoch: &epoch,
 	}
 }
 
 // atx.
-type ATXReady struct{}
+type ATXReady struct {
+	Publish types.EpochID
+}
 
 func (s *ATXReady) APIStateInfo() *pb.IdentityStateInfo {
+	epoch := s.Publish.Uint32()
 	return &pb.IdentityStateInfo{
-		State: pb.IdentityState_ATX_READY,
+		State:        pb.IdentityState_ATX_READY,
+		PublishEpoch: &epoch,
 	}
 }
 
 type ATXBroadcasted struct {
-	AtxId types.ATXID
+	AtxId   types.ATXID
+	Publish types.EpochID
 }
 
 func (s *ATXBroadcasted) APIStateInfo() *pb.IdentityStateInfo {
+	epoch := s.Publish.Uint32()
 	return &pb.IdentityStateInfo{
-		State: pb.IdentityState_ATX_BROADCASTED,
+		State:        pb.IdentityState_ATX_BROADCASTED,
+		PublishEpoch: &epoch,
 		Metadata: &pb.IdentityStateInfo_AtxBroadcasted{
 			AtxBroadcasted: &pb.AtxBroadcastedState{
 				AtxId: s.AtxId.Bytes(),

--- a/miner/mocks/remote_mocks.go
+++ b/miner/mocks/remote_mocks.go
@@ -246,15 +246,15 @@ func (c *MockidentityStatesAddProposalCall) DoAndReturn(f func(types.NodeID, *ty
 }
 
 // Set mocks base method.
-func (m *MockidentityStates) Set(id types.NodeID, publishEpoch *types.EpochID, newState identity.State) {
+func (m *MockidentityStates) Set(id types.NodeID, newState identity.State) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Set", id, publishEpoch, newState)
+	m.ctrl.Call(m, "Set", id, newState)
 }
 
 // Set indicates an expected call of Set.
-func (mr *MockidentityStatesMockRecorder) Set(id, publishEpoch, newState any) *MockidentityStatesSetCall {
+func (mr *MockidentityStatesMockRecorder) Set(id, newState any) *MockidentityStatesSetCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Set", reflect.TypeOf((*MockidentityStates)(nil).Set), id, publishEpoch, newState)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Set", reflect.TypeOf((*MockidentityStates)(nil).Set), id, newState)
 	return &MockidentityStatesSetCall{Call: call}
 }
 
@@ -270,13 +270,13 @@ func (c *MockidentityStatesSetCall) Return() *MockidentityStatesSetCall {
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockidentityStatesSetCall) Do(f func(types.NodeID, *types.EpochID, identity.State)) *MockidentityStatesSetCall {
+func (c *MockidentityStatesSetCall) Do(f func(types.NodeID, identity.State)) *MockidentityStatesSetCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockidentityStatesSetCall) DoAndReturn(f func(types.NodeID, *types.EpochID, identity.State)) *MockidentityStatesSetCall {
+func (c *MockidentityStatesSetCall) DoAndReturn(f func(types.NodeID, identity.State)) *MockidentityStatesSetCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/miner/remote_proposals.go
+++ b/miner/remote_proposals.go
@@ -34,7 +34,7 @@ type beaconService interface {
 type identityStates interface {
 	SetEligibilities(id types.NodeID, eligibilities map[types.LayerID][]types.VotingEligibility)
 	AddProposal(id types.NodeID, proposals *types.Proposal)
-	Set(id types.NodeID, publishEpoch *types.EpochID, newState smesherIdentity.State)
+	Set(id types.NodeID, newState smesherIdentity.State)
 }
 
 type RemoteProposalBuilder struct {
@@ -169,7 +169,7 @@ func (pb *RemoteProposalBuilder) build(
 		if err != nil {
 			err = fmt.Errorf("getting beacon: %w", err)
 			for _, s := range signers {
-				pb.identityStates.Set(s.signer.NodeID(), nil, &smesherIdentity.ProposalBuildFailed{
+				pb.identityStates.Set(s.signer.NodeID(), &smesherIdentity.ProposalBuildFailed{
 					ErrorMsg: err.Error(),
 					Layer:    layer,
 				})
@@ -200,7 +200,7 @@ func (pb *RemoteProposalBuilder) build(
 			)
 			eligibilities[nodeId] = proofs
 			pb.identityStates.SetEligibilities(nodeId, proofs)
-			pb.identityStates.Set(nodeId, nil, &smesherIdentity.Eligible{
+			pb.identityStates.Set(nodeId, &smesherIdentity.Eligible{
 				Layers: proofs,
 			})
 		} else {
@@ -210,7 +210,7 @@ func (pb *RemoteProposalBuilder) build(
 		proposal, _, err := pb.proposalSvc.Proposal(ctx, layer, nodeId)
 		if err != nil {
 			pb.logger.Error("get partial proposal", zap.Error(err))
-			pb.identityStates.Set(nodeId, nil, &smesherIdentity.ProposalBuildFailed{
+			pb.identityStates.Set(nodeId, &smesherIdentity.ProposalBuildFailed{
 				ErrorMsg: fmt.Sprintf("get partial proposal: %v", err),
 				Layer:    layer,
 			})
@@ -235,7 +235,7 @@ func (pb *RemoteProposalBuilder) build(
 		err = proposal.Initialize()
 		if err != nil {
 			pb.logger.Error("failed to initialize proposal", zap.Error(err))
-			pb.identityStates.Set(nodeId, nil, &smesherIdentity.ProposalBuildFailed{
+			pb.identityStates.Set(nodeId, &smesherIdentity.ProposalBuildFailed{
 				ErrorMsg: fmt.Sprintf("failed to initialize proposal: %v", err),
 				Layer:    layer,
 			})
@@ -249,7 +249,7 @@ func (pb *RemoteProposalBuilder) build(
 				zap.Stringer("id", proposal.ID()),
 				zap.Error(err),
 			)
-			pb.identityStates.Set(nodeId, nil, &smesherIdentity.ProposalPublishFailed{
+			pb.identityStates.Set(nodeId, &smesherIdentity.ProposalPublishFailed{
 				ErrorMsg: err.Error(),
 				Proposal: proposal.ID(),
 				Layer:    proposal.Layer,

--- a/miner/remote_proposals_test.go
+++ b/miner/remote_proposals_test.go
@@ -79,7 +79,7 @@ func TestRemoteProposals(t *testing.T) {
 		}).AnyTimes()
 	idStates.EXPECT().SetEligibilities(gomock.Any(), gomock.Any()).AnyTimes()
 	idStates.EXPECT().AddProposal(gomock.Any(), gomock.Any()).AnyTimes()
-	idStates.EXPECT().Set(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+	idStates.EXPECT().Set(gomock.Any(), gomock.Any()).AnyTimes()
 	go builder.Run(ctx)
 	defer cancel()
 	select {


### PR DESCRIPTION
Moved `PublishEpoch`, which isn't present for every event (state) into the structures that actually make use of it.