### PR TITLE
enable cors-everywhere on smeshing-service

### DIFF
--- a/activation_service_poc/docker-compose.yml
+++ b/activation_service_poc/docker-compose.yml
@@ -7,7 +7,8 @@ services:
       "-c", "/config.json",
       "--node-service-address", "http://node-service:9099",
       "--grpc-json-listener", "0.0.0.0:9071",
-      "--proxy-api-v2-address", "http://node-service:9070"
+      "--proxy-api-v2-address", "http://node-service:9070",
+      "--json-cors-everywhere"
     ]
     volumes:
       - /tmp/spacemesh-client:/tmp/spacemesh-client
@@ -19,8 +20,10 @@ services:
 
   node-service:
     image: ${IMAGE}
-    command: ["-c", "/config.json",
-              "--grpc-json-listener", "0.0.0.0:9070"]
+    command: [
+      "-c", "/config.json",
+      "--grpc-json-listener", "0.0.0.0:9070",
+    ]
     volumes:
       - /tmp/spacemesh-node-service:/tmp/spacemesh-node-service
       - ./config.standalone.node-service.json:/config.json

--- a/api/proxy/proxy.go
+++ b/api/proxy/proxy.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	"github.com/rs/cors"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 
@@ -29,7 +30,7 @@ type Service interface {
 	Path() string
 }
 
-func NewServer(proxyListener, apiAddress string, logger *zap.Logger, local ...Service) (*Server, error) {
+func NewServer(proxyListener, apiAddress string, corsEverywhere bool, logger *zap.Logger, local ...Service) (*Server, error) {
 	// Validate the API server URL
 	targetURL, err := url.Parse(apiAddress)
 	if err != nil {
@@ -39,6 +40,28 @@ func NewServer(proxyListener, apiAddress string, logger *zap.Logger, local ...Se
 	// Create a reverse proxy
 	proxy := httputil.NewSingleHostReverseProxy(targetURL)
 	mux := http.NewServeMux()
+	var handler http.Handler = mux
+	if corsEverywhere {
+		logger.Info("enabling CORS on PROXY for all origins")
+		c := cors.New(cors.Options{
+			AllowedOrigins: []string{"*"},
+			AllowedMethods: []string{"GET", "POST", "PUT", "DELETE", "OPTIONS", "HEAD"},
+			AllowedHeaders: []string{"*"},
+			ExposedHeaders: []string{
+				"Server",
+				"Date",
+				"Content-Type",
+				"Content-Length",
+				"Connection",
+				"Vary",
+				"X-Final-Url",
+				"Access-Control-Allow-Origin",
+			},
+			AllowCredentials: false,
+			MaxAge:           300,
+		})
+		handler = c.Handler(mux)
+	}
 
 	// Register GRPC services handled locally
 	grpcMux := runtime.NewServeMux()
@@ -57,7 +80,7 @@ func NewServer(proxyListener, apiAddress string, logger *zap.Logger, local ...Se
 	// Initialize the HTTP server
 	server := &http.Server{
 		Addr:         proxyListener,
-		Handler:      mux,
+		Handler:      handler,
 		ReadTimeout:  5 * time.Second,
 		WriteTimeout: 10 * time.Second,
 	}

--- a/api/proxy/proxy.go
+++ b/api/proxy/proxy.go
@@ -30,7 +30,12 @@ type Service interface {
 	Path() string
 }
 
-func NewServer(proxyListener, apiAddress string, corsEverywhere bool, logger *zap.Logger, local ...Service) (*Server, error) {
+func NewServer(
+	proxyListener, apiAddress string,
+	corsEverywhere bool,
+	logger *zap.Logger,
+	local ...Service,
+) (*Server, error) {
 	// Validate the API server URL
 	targetURL, err := url.Parse(apiAddress)
 	if err != nil {

--- a/node/node.go
+++ b/node/node.go
@@ -2006,6 +2006,7 @@ func (app *App) startAPIServices(ctx context.Context) error {
 			p, err := proxy.NewServer(
 				app.Config.API.JSONListener,
 				app.Config.API.ProxyApiV2Address,
+				app.Config.API.JSONCorsEverywhere,
 				logger.Zap(),
 				localSvcs...,
 			)


### PR DESCRIPTION
Enable the CORS-everywhere policy on the smeshing-service, which is using a proxy to talk with the JSON API on the node side.