### PR TITLE
[Merged by Bors] - sync2: fix Advance race

### DIFF
--- a/sync2/multipeer/interface.go
+++ b/sync2/multipeer/interface.go
@@ -16,6 +16,9 @@ import (
 type SyncBase interface {
 	// Count returns the number of items in the set.
 	Count() (int, error)
+	// Advance advances the underlying OrderedSet, loading the items since the last Advance call
+	// or when OrderedSet was first loaded.
+	Advance() error
 	// Sync synchronizes the set with the peer.
 	// It returns a sequence of new keys that were received from the peer and the
 	// number of received items.

--- a/sync2/multipeer/mocks_test.go
+++ b/sync2/multipeer/mocks_test.go
@@ -43,6 +43,44 @@ func (m *MockSyncBase) EXPECT() *MockSyncBaseMockRecorder {
 	return m.recorder
 }
 
+// Advance mocks base method.
+func (m *MockSyncBase) Advance() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Advance")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Advance indicates an expected call of Advance.
+func (mr *MockSyncBaseMockRecorder) Advance() *MockSyncBaseAdvanceCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Advance", reflect.TypeOf((*MockSyncBase)(nil).Advance))
+	return &MockSyncBaseAdvanceCall{Call: call}
+}
+
+// MockSyncBaseAdvanceCall wrap *gomock.Call
+type MockSyncBaseAdvanceCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockSyncBaseAdvanceCall) Return(arg0 error) *MockSyncBaseAdvanceCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockSyncBaseAdvanceCall) Do(f func() error) *MockSyncBaseAdvanceCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockSyncBaseAdvanceCall) DoAndReturn(f func() error) *MockSyncBaseAdvanceCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // Count mocks base method.
 func (m *MockSyncBase) Count() (int, error) {
 	m.ctrl.T.Helper()

--- a/sync2/multipeer/setsyncbase.go
+++ b/sync2/multipeer/setsyncbase.go
@@ -38,7 +38,8 @@ func NewSetSyncBase(
 
 // Count implements SyncBase.
 func (ssb *SetSyncBase) Count() (int, error) {
-	// TODO: don't lock on potentially db-bound operations
+	// In most cases ssb.os.SetInfo will not access the database, so we're not holding
+	// the lock for long here.
 	ssb.mtx.Lock()
 	defer ssb.mtx.Unlock()
 	info, err := ssb.os.SetInfo()
@@ -46,6 +47,13 @@ func (ssb *SetSyncBase) Count() (int, error) {
 		return 0, fmt.Errorf("get range info: %w", err)
 	}
 	return info.Count, nil
+}
+
+// Advance implements SyncBase.
+func (ssb *SetSyncBase) Advance() error {
+	ssb.mtx.Lock()
+	defer ssb.mtx.Unlock()
+	return ssb.os.Advance()
 }
 
 func (ssb *SetSyncBase) syncPeer(

--- a/sync2/p2p.go
+++ b/sync2/p2p.go
@@ -168,7 +168,7 @@ func (s *P2PHashSync) start() (isWaiting bool) {
 					return ctx.Err()
 				case <-ticker.C:
 					s.logger.Debug("advancing OrderedSet on timer")
-					if err := s.os.Advance(); err != nil {
+					if err := s.syncBase.Advance(); err != nil {
 						s.logger.Error("error advancing the set", zap.Error(err))
 					}
 				}


### PR DESCRIPTION
## Motivation

OrderedSet.Advance is not threadsafe, but it's invoked on timer w/o any locking.

## Description

SetSyncBase already has a mutex which it's using for advancing so let's use it when advancing the OrderedSet on timer, too.

## Test Plan

Existing tests must pass.