### PR TITLE
[Merged by Bors] - sql: fix crash in WithConnection when out of connections

### DIFF
--- a/sql/database.go
+++ b/sql/database.go
@@ -818,13 +818,13 @@ func (db *sqliteDatabase) WithConnection(ctx context.Context, exec func(Executor
 	}
 	conCtx, cancel := context.WithCancel(ctx)
 	conn := db.getConn(conCtx)
+	if conn == nil {
+		return ErrNoConnection
+	}
 	defer func() {
 		cancel()
 		db.pool.Put(conn)
 	}()
-	if conn == nil {
-		return ErrNoConnection
-	}
 	return exec(&sqliteConn{queryCache: db.queryCache, db: db, conn: conn})
 }
 

--- a/sql/database.go
+++ b/sql/database.go
@@ -817,14 +817,12 @@ func (db *sqliteDatabase) WithConnection(ctx context.Context, exec func(Executor
 		return ErrClosed
 	}
 	conCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	conn := db.getConn(conCtx)
 	if conn == nil {
 		return ErrNoConnection
 	}
-	defer func() {
-		cancel()
-		db.pool.Put(conn)
-	}()
+	defer db.pool.Put(conn)
 	return exec(&sqliteConn{queryCache: db.queryCache, db: db, conn: conn})
 }
 


### PR DESCRIPTION
## Motivation

`WithConnection` could crash when it ran out of connections.
`WithConnection` is used by `syncv2`.

## Description

Fix crash issue

## Test Plan

Existing tests pass. The problem was visible in `syncv2` `TestP2P_DBset` when it was run for 100+ iterations.