### PR TITLE
[testing] use syncv2 for fastnet / systests

### DIFF
--- a/config/presets/fastnet.go
+++ b/config/presets/fastnet.go
@@ -119,5 +119,7 @@ func fastnet() config.Config {
 	conf.POET.InfoCacheTTL = time.Minute
 	conf.POET.PowParamsCacheTTL = 10 * time.Second
 
+	conf.LOGGING.SyncLoggerLevel = "debug"
+
 	return conf
 }

--- a/config/presets/fastnet.go
+++ b/config/presets/fastnet.go
@@ -55,6 +55,21 @@ func fastnet() config.Config {
 	conf.Sync.AtxSync.EpochInfoPeers = 10
 	conf.Sync.AtxSync.RequestsLimit = 100
 	conf.Sync.MalSync.IDRequestInterval = 20 * time.Second
+	conf.Sync.ReconcSync.Enable = true
+	conf.Sync.ReconcSync.EnableActiveSync = true
+	conf.Sync.ReconcSync.NewAtxSyncCfg.AdvanceInterval = 20 * time.Second
+	conf.Sync.ReconcSync.NewAtxSyncCfg.SyncInterval = 10 * time.Second
+	conf.Sync.ReconcSync.NewAtxSyncCfg.SyncPeerCount = 4
+	conf.Sync.ReconcSync.NewAtxSyncCfg.RetryInterval = 2 * time.Second
+	conf.Sync.ReconcSync.NewAtxSyncCfg.FullSyncednessPeriod = time.Minute
+	conf.Sync.ReconcSync.NewAtxSyncCfg.NoPeersRecheckInterval = 5 * time.Second
+	conf.Sync.ReconcSync.OldAtxSyncCfg.AdvanceInterval = time.Minute
+	conf.Sync.ReconcSync.OldAtxSyncCfg.SyncInterval = time.Minute
+	conf.Sync.ReconcSync.OldAtxSyncCfg.SyncPeerCount = 4
+	conf.Sync.ReconcSync.OldAtxSyncCfg.RetryInterval = 2 * time.Second
+	conf.Sync.ReconcSync.OldAtxSyncCfg.FullSyncednessPeriod = 15 * time.Minute
+	conf.Sync.ReconcSync.OldAtxSyncCfg.NoPeersRecheckInterval = 5 * time.Second
+
 	conf.LayersPerEpoch = 4
 	conf.RegossipAtxInterval = 30 * time.Second
 	conf.FETCH.RequestTimeout = 2 * time.Second

--- a/systest/Makefile
+++ b/systest/Makefile
@@ -38,8 +38,7 @@ ifeq ($(configname),$(test_job_name))
 	run_deps = config
 endif
 
-command := gotestsum --raw-command -- test2json -t -p systest \
- 	/bin/tests -test.v -test.count=$(count) -test.timeout=60m -test.run=$(test_name) -test.parallel=$(clusters) \
+command := /bin/tests -test.v -test.count=$(count) -test.timeout=60m -test.run=$(test_name) -test.parallel=$(clusters) \
 	-test.failfast=$(failfast) -clusters=$(clusters) -level=$(level) -configname=$(configname)
 
 .PHONY: docker


### PR DESCRIPTION
## Motivation

Need to verify that systests pass with syncv2 enabled.

## Description

This enables syncv2 for fastnet, effectively also enabling it for nodes created by systests.