### PR TITLE
[node-split] Fix typo in configuration

### DIFF
--- a/activation_service_poc/demo/docker-compose-testnet-both-local.yml
+++ b/activation_service_poc/demo/docker-compose-testnet-both-local.yml
@@ -30,7 +30,7 @@ services:
         "-c",
         "/config.json",
         "--node-service-address",
-        "http://127.0.0.1:19399",
+        "http://127.0.0.1:19099",
         "--grpc-json-listener",
         "0.0.0.0:19371",
         "--proxy-api-v2-address",


### PR DESCRIPTION
Fix for a typo in configuration of second activation service in both local demo scenario.
