### PR TITLE
[Merged by Bors] - Update malfeasance for double marry

### DIFF
--- a/activation/handler_v2.go
+++ b/activation/handler_v2.go
@@ -727,16 +727,26 @@ func (h *HandlerV2) validatePost(
 	return fmt.Errorf("invalid post for ID %s: %w", nodeID.ShortString(), errInvalid)
 }
 
-func (h *HandlerV2) checkMalicious(ctx context.Context, tx sql.Transaction, atx *activationTx) (bool, error) {
-	malicious, err := malfeasance.IsMalicious(tx, atx.SmesherID)
-	if err != nil {
-		return malicious, fmt.Errorf("checking if node is malicious: %w", err)
-	}
-	if malicious {
-		return true, nil
+func (h *HandlerV2) checkMalicious(
+	ctx context.Context,
+	tx sql.Transaction,
+	atx *activationTx,
+	forceProofPublish bool,
+) (bool, error) {
+	if !forceProofPublish {
+		// normally if we already know that the smesher is malicious we don't need to check further and don't need to
+		// publish a proof, but sometimes we need to force the proof to be published. This is for example the case when
+		// a malicious smesher is double marrying and thereby marks other smeshers as malicious.
+		malicious, err := malfeasance.IsMalicious(tx, atx.SmesherID)
+		if err != nil {
+			return malicious, fmt.Errorf("checking if node is malicious: %w", err)
+		}
+		if malicious {
+			return true, nil
+		}
 	}
 
-	malicious, err = h.checkDoubleMarry(ctx, tx, atx)
+	malicious, err := h.checkDoubleMarry(ctx, tx, atx)
 	if err != nil {
 		return malicious, fmt.Errorf("checking double marry: %w", err)
 	}
@@ -930,6 +940,7 @@ func (h *HandlerV2) checkPrevAtx(ctx context.Context, tx sql.Transaction, atx *a
 
 // Store an ATX in the DB.
 func (h *HandlerV2) storeAtx(ctx context.Context, atx *types.ActivationTx, watx *activationTx) error {
+	malProofNeeded := false
 	if err := h.cdb.WithTxImmediate(ctx, func(tx sql.Transaction) error {
 		if len(watx.marriages) != 0 {
 			newMarriageID, err := marriage.NewID(tx)
@@ -941,7 +952,6 @@ func (h *HandlerV2) storeAtx(ctx context.Context, atx *types.ActivationTx, watx 
 				ATX:    atx.ID(),
 				Target: atx.SmesherID,
 			}
-			malicious := false
 			marriageIDs := make([]marriage.ID, 0)
 			for i, m := range watx.marriages {
 				info.NodeID = m.id
@@ -958,32 +968,29 @@ func (h *HandlerV2) storeAtx(ctx context.Context, atx *types.ActivationTx, watx 
 				case err != nil:
 					return fmt.Errorf("adding marriage: %w", err)
 				}
-				if malicious {
-					continue
-				}
-				malicious, err = malfeasance.IsMalicious(tx, m.id)
-				if err != nil {
-					return fmt.Errorf("checking if node is malicious: %w", err)
-				}
 			}
 			if len(marriageIDs) != 0 {
 				marriageIDs := append(marriageIDs, newMarriageID)
-				combinedID := slices.Min(marriageIDs)
+				newMarriageID = slices.Min(marriageIDs)
 				for _, id := range marriageIDs {
-					if id != combinedID {
-						if err := marriage.UpdateMarriageID(tx, id, combinedID); err != nil {
+					if id != newMarriageID {
+						if err := marriage.UpdateMarriageID(tx, id, newMarriageID); err != nil {
 							return fmt.Errorf("updating marriage ID for %d: %w", id, err)
 						}
 					}
 				}
-				newMarriageID = combinedID
-			}
-			if malicious {
 				nodeIDs, err := marriage.NodeIDsByID(tx, newMarriageID)
 				if err != nil {
 					return fmt.Errorf("fetching node IDs by marriage ID: %w", err)
 				}
 				for _, id := range nodeIDs {
+					malicious, err := malfeasance.IsMalicious(tx, id)
+					if err != nil {
+						return fmt.Errorf("checking if node ID is malicious: %w", err)
+					}
+					if !malicious {
+						malProofNeeded = true
+					}
 					if err := malfeasance.SetMalicious(tx, id, newMarriageID, time.Now()); err != nil {
 						return fmt.Errorf("marking node as malicious: %w", err)
 					}
@@ -1010,11 +1017,12 @@ func (h *HandlerV2) storeAtx(ctx context.Context, atx *types.ActivationTx, watx 
 	err := h.cdb.WithTxImmediate(ctx, func(tx sql.Transaction) error {
 		// malfeasance check happens after storing the ATX because storing updates the marriage set
 		// that is needed for the malfeasance proof
+		//
 		// TODO(mafa): don't store own ATX if it would mark the node as malicious
 		//    this probably needs to be done by validating and storing own ATXs eagerly and skipping validation in
 		//    the gossip handler (not sync!)
 		var err error
-		malicious, err = h.checkMalicious(ctx, tx, watx)
+		malicious, err = h.checkMalicious(ctx, tx, watx, malProofNeeded)
 		return err
 	})
 	if err != nil {

--- a/activation/handler_v2.go
+++ b/activation/handler_v2.go
@@ -495,8 +495,8 @@ func (n nipostSizes) sumUp() (units uint32, weight uint64, err error) {
 
 func (h *HandlerV2) verifyIncludedIDsUniqueness(atx *wire.ActivationTxV2) error {
 	seen := make(map[uint32]struct{})
-	for _, niposts := range atx.NIPosts {
-		for _, post := range niposts.Posts {
+	for _, niPosts := range atx.NIPosts {
+		for _, post := range niPosts.Posts {
 			if _, ok := seen[post.MarriageIndex]; ok {
 				return fmt.Errorf("ID present twice (duplicated marriage index): %d", post.MarriageIndex)
 			}
@@ -528,7 +528,7 @@ func (h *HandlerV2) syntacticallyValidateDeps(
 			return nil, fmt.Errorf("fetching previous atx: %w", err)
 		}
 		if prevAtx.PublishEpoch >= atx.PublishEpoch {
-			err := fmt.Errorf("previous atx is too new (%d >= %d) (%s) ", prevAtx.PublishEpoch, atx.PublishEpoch, prev)
+			err := fmt.Errorf("previous atx (%s) is too new (%d >= %d)", prev, prevAtx.PublishEpoch, atx.PublishEpoch)
 			return nil, err
 		}
 		previousAtxs[i] = prevAtx
@@ -541,9 +541,9 @@ func (h *HandlerV2) syntacticallyValidateDeps(
 
 	// validate previous ATXs
 	nipostSizes := make(nipostSizes, len(atx.NIPosts))
-	for i, niposts := range atx.NIPosts {
+	for i, niPosts := range atx.NIPosts {
 		nipostSizes[i] = new(nipostSize)
-		for _, post := range niposts.Posts {
+		for _, post := range niPosts.Posts {
 			if post.MarriageIndex >= uint32(len(equivocationSet)) {
 				err := fmt.Errorf("marriage index out of bounds: %d > %d", post.MarriageIndex, len(equivocationSet)-1)
 				return nil, err
@@ -563,11 +563,11 @@ func (h *HandlerV2) syntacticallyValidateDeps(
 	}
 
 	// validate poet membership proofs
-	for i, niposts := range atx.NIPosts {
+	for i, niPosts := range atx.NIPosts {
 		// verify PoET memberships in a single go
 		indexedChallenges := make(map[uint64][]byte)
 
-		for _, post := range niposts.Posts {
+		for _, post := range niPosts.Posts {
 			if _, ok := indexedChallenges[post.MembershipLeafIndex]; ok {
 				continue
 			}
@@ -591,10 +591,10 @@ func (h *HandlerV2) syntacticallyValidateDeps(
 		}
 
 		membership := types.MultiMerkleProof{
-			Nodes:       niposts.Membership.Nodes,
+			Nodes:       niPosts.Membership.Nodes,
 			LeafIndices: leafIndices,
 		}
-		leaves, err := h.nipostValidator.PoetMembership(ctx, &membership, niposts.Challenge, poetChallenges)
+		leaves, err := h.nipostValidator.PoetMembership(ctx, &membership, niPosts.Challenge, poetChallenges)
 		if err != nil {
 			return nil, fmt.Errorf("validating poet membership: %w", err)
 		}
@@ -606,7 +606,7 @@ func (h *HandlerV2) syntacticallyValidateDeps(
 		return nil, err
 	}
 
-	// validate all niposts
+	// validate all NIPoSTs
 	if atx.Initial != nil {
 		commitment := atx.Initial.CommitmentATX
 		nipostIdx := 0
@@ -625,8 +625,8 @@ func (h *HandlerV2) syntacticallyValidateDeps(
 	}
 
 	var smesherCommitment *types.ATXID
-	for idx, niposts := range atx.NIPosts {
-		for _, post := range niposts.Posts {
+	for idx, niPosts := range atx.NIPosts {
+		for _, post := range niPosts.Posts {
 			id := equivocationSet[post.MarriageIndex]
 			commitment, err := atxs.CommitmentATX(h.cdb, id)
 			if err != nil {
@@ -635,7 +635,7 @@ func (h *HandlerV2) syntacticallyValidateDeps(
 			if id == atx.SmesherID {
 				smesherCommitment = &commitment
 			}
-			if err := h.validatePost(ctx, id, atx, commitment, niposts.Challenge, post, idx); err != nil {
+			if err := h.validatePost(ctx, id, atx, commitment, niPosts.Challenge, post, idx); err != nil {
 				return nil, err
 			}
 			result.ids[id] = idData{
@@ -847,7 +847,7 @@ func (h *HandlerV2) checkDoubleMerge(ctx context.Context, tx sql.Transaction, at
 	if err != nil {
 		return true, fmt.Errorf("creating double merge proof: %w", err)
 	}
-	return true, h.malPublisher.Publish(ctx, atx.SmesherID, proof)
+	return true, h.malPublisher.Publish(ctx, atx.ActivationTxV2.SmesherID, proof)
 }
 
 func (h *HandlerV2) checkPrevAtx(ctx context.Context, tx sql.Transaction, atx *activationTx) (bool, error) {
@@ -955,7 +955,6 @@ func (h *HandlerV2) storeAtx(ctx context.Context, atx *types.ActivationTx, watx 
 						return fmt.Errorf("find marriage ID for node ID %s: %w", m.id.ShortString(), err)
 					}
 					marriageIDs = append(marriageIDs, id)
-					continue
 				case err != nil:
 					return fmt.Errorf("adding marriage: %w", err)
 				}
@@ -980,8 +979,12 @@ func (h *HandlerV2) storeAtx(ctx context.Context, atx *types.ActivationTx, watx 
 				newMarriageID = combinedID
 			}
 			if malicious {
-				for _, m := range watx.marriages {
-					if err := malfeasance.SetMalicious(tx, m.id, newMarriageID, time.Now()); err != nil {
+				nodeIDs, err := marriage.NodeIDsByID(tx, newMarriageID)
+				if err != nil {
+					return fmt.Errorf("fetching node IDs by marriage ID: %w", err)
+				}
+				for _, id := range nodeIDs {
+					if err := malfeasance.SetMalicious(tx, id, newMarriageID, time.Now()); err != nil {
 						return fmt.Errorf("marking node as malicious: %w", err)
 					}
 				}

--- a/activation/handler_v2.go
+++ b/activation/handler_v2.go
@@ -727,26 +727,16 @@ func (h *HandlerV2) validatePost(
 	return fmt.Errorf("invalid post for ID %s: %w", nodeID.ShortString(), errInvalid)
 }
 
-func (h *HandlerV2) checkMalicious(
-	ctx context.Context,
-	tx sql.Transaction,
-	atx *activationTx,
-	forceProofPublish bool,
-) (bool, error) {
-	if !forceProofPublish {
-		// normally if we already know that the smesher is malicious we don't need to check further and don't need to
-		// publish a proof, but sometimes we need to force the proof to be published. This is for example the case when
-		// a malicious smesher is double marrying and thereby marks other smeshers as malicious.
-		malicious, err := malfeasance.IsMalicious(tx, atx.SmesherID)
-		if err != nil {
-			return malicious, fmt.Errorf("checking if node is malicious: %w", err)
-		}
-		if malicious {
-			return true, nil
-		}
+func (h *HandlerV2) checkMalicious(ctx context.Context, tx sql.Transaction, atx *activationTx) (bool, error) {
+	malicious, err := malfeasance.IsMalicious(tx, atx.SmesherID)
+	if err != nil {
+		return malicious, fmt.Errorf("checking if node is malicious: %w", err)
+	}
+	if malicious {
+		return true, nil
 	}
 
-	malicious, err := h.checkDoubleMarry(ctx, tx, atx)
+	malicious, err = h.checkDoubleMarry(ctx, tx, atx)
 	if err != nil {
 		return malicious, fmt.Errorf("checking double marry: %w", err)
 	}
@@ -940,7 +930,7 @@ func (h *HandlerV2) checkPrevAtx(ctx context.Context, tx sql.Transaction, atx *a
 
 // Store an ATX in the DB.
 func (h *HandlerV2) storeAtx(ctx context.Context, atx *types.ActivationTx, watx *activationTx) error {
-	malProofNeeded := false
+	republishProof := false
 	if err := h.cdb.WithTxImmediate(ctx, func(tx sql.Transaction) error {
 		if len(watx.marriages) != 0 {
 			newMarriageID, err := marriage.NewID(tx)
@@ -952,7 +942,9 @@ func (h *HandlerV2) storeAtx(ctx context.Context, atx *types.ActivationTx, watx 
 				ATX:    atx.ID(),
 				Target: atx.SmesherID,
 			}
-			marriageIDs := make([]marriage.ID, 0)
+			malicious := false
+			marriageIDs := make([]marriage.ID, 1)
+			marriageIDs[0] = newMarriageID
 			for i, m := range watx.marriages {
 				info.NodeID = m.id
 				info.MarriageIndex = i
@@ -968,9 +960,15 @@ func (h *HandlerV2) storeAtx(ctx context.Context, atx *types.ActivationTx, watx 
 				case err != nil:
 					return fmt.Errorf("adding marriage: %w", err)
 				}
+				if malicious {
+					continue
+				}
+				malicious, err = malfeasance.IsMalicious(tx, m.id)
+				if err != nil {
+					return fmt.Errorf("checking if node is malicious: %w", err)
+				}
 			}
-			if len(marriageIDs) != 0 {
-				marriageIDs := append(marriageIDs, newMarriageID)
+			if len(marriageIDs) > 1 {
 				newMarriageID = slices.Min(marriageIDs)
 				for _, id := range marriageIDs {
 					if id != newMarriageID {
@@ -979,6 +977,8 @@ func (h *HandlerV2) storeAtx(ctx context.Context, atx *types.ActivationTx, watx 
 						}
 					}
 				}
+			}
+			if malicious {
 				nodeIDs, err := marriage.NodeIDsByID(tx, newMarriageID)
 				if err != nil {
 					return fmt.Errorf("fetching node IDs by marriage ID: %w", err)
@@ -989,7 +989,7 @@ func (h *HandlerV2) storeAtx(ctx context.Context, atx *types.ActivationTx, watx 
 						return fmt.Errorf("checking if node ID is malicious: %w", err)
 					}
 					if !malicious {
-						malProofNeeded = true
+						republishProof = true
 					}
 					if err := malfeasance.SetMalicious(tx, id, newMarriageID, time.Now()); err != nil {
 						return fmt.Errorf("marking node as malicious: %w", err)
@@ -1021,8 +1021,13 @@ func (h *HandlerV2) storeAtx(ctx context.Context, atx *types.ActivationTx, watx 
 		// TODO(mafa): don't store own ATX if it would mark the node as malicious
 		//    this probably needs to be done by validating and storing own ATXs eagerly and skipping validation in
 		//    the gossip handler (not sync!)
+		if republishProof {
+			malicious = true
+			return h.malPublisher.Republish(ctx, atx.SmesherID)
+		}
+
 		var err error
-		malicious, err = h.checkMalicious(ctx, tx, watx, malProofNeeded)
+		malicious, err = h.checkMalicious(ctx, tx, watx)
 		return err
 	})
 	if err != nil {

--- a/activation/handler_v2_test.go
+++ b/activation/handler_v2_test.go
@@ -1988,7 +1988,7 @@ func Test_Marriages(t *testing.T) {
 		require.NoError(t, err)
 		require.ElementsMatch(t, []types.NodeID{sig.NodeID(), otherSig.NodeID(), otherSig2.NodeID()}, equiv)
 	})
-	t.Run("marring existing malicious equivocation set: marks all malicious and publishes proof", func(t *testing.T) {
+	t.Run("marring existing malicious equivocation set: marks all malicious and republishes proof", func(t *testing.T) {
 		t.Parallel()
 		atxHandler := newV2TestHandler(t, golden)
 
@@ -2019,12 +2019,6 @@ func Test_Marriages(t *testing.T) {
 		atx2.Sign(sig)
 		atxHandler.expectAtxV2(atx2)
 
-		verifier := wire.NewMockMalfeasanceValidator(atxHandler.ctrl)
-		verifier.EXPECT().Signature(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-			DoAndReturn(func(d signing.Domain, nodeID types.NodeID, m []byte, sig types.EdSignature) bool {
-				return atxHandler.edVerifier.Verify(d, nodeID, m, sig)
-			}).AnyTimes()
-
 		atxHandler.mMalPublish.EXPECT().Republish(gomock.Any(), sig.NodeID())
 		err = atxHandler.processATX(context.Background(), "", atx2, time.Now())
 		require.NoError(t, err)
@@ -2042,7 +2036,7 @@ func Test_Marriages(t *testing.T) {
 			require.True(t, m, "expected %s to be malicious", sig)
 		}
 	})
-	t.Run("malicious marring existing equivocation set: marks all malicious and publishes proof", func(t *testing.T) {
+	t.Run("malicious marring existing equivocation set: marks all malicious and republishes proof", func(t *testing.T) {
 		t.Parallel()
 		atxHandler := newV2TestHandler(t, golden)
 
@@ -2071,12 +2065,6 @@ func Test_Marriages(t *testing.T) {
 		}
 		atx2.Sign(sig)
 		atxHandler.expectAtxV2(atx2)
-
-		verifier := wire.NewMockMalfeasanceValidator(atxHandler.ctrl)
-		verifier.EXPECT().Signature(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-			DoAndReturn(func(d signing.Domain, nodeID types.NodeID, m []byte, sig types.EdSignature) bool {
-				return atxHandler.edVerifier.Verify(d, nodeID, m, sig)
-			}).AnyTimes()
 
 		atxHandler.mMalPublish.EXPECT().Republish(gomock.Any(), sig.NodeID())
 		err = atxHandler.processATX(context.Background(), "", atx2, time.Now())

--- a/activation/handler_v2_test.go
+++ b/activation/handler_v2_test.go
@@ -3,6 +3,7 @@ package activation
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math"
 	"slices"
 	"testing"
@@ -996,7 +997,7 @@ func TestHandlerV2_ProcessMergedATX(t *testing.T) {
 			gomock.Any(),
 			merged.SmesherID,
 			gomock.AssignableToTypeOf(&wire.ProofDoubleMerge{}),
-		).DoAndReturn(func(ctx context.Context, id types.NodeID, proof wire.Proof) error {
+		).DoAndReturn(func(ctx context.Context, _ types.NodeID, proof wire.Proof) error {
 			malProof := proof.(*wire.ProofDoubleMerge)
 			nId, err := malProof.Valid(context.Background(), verifier)
 			require.NoError(t, err)
@@ -1504,7 +1505,7 @@ func TestHandlerV2_SyntacticallyValidateDeps(t *testing.T) {
 		atx.Sign(sig)
 
 		_, err := atxHandler.syntacticallyValidateDeps(context.Background(), atx)
-		require.ErrorContains(t, err, "previous atx is too new")
+		require.ErrorContains(t, err, fmt.Sprintf("previous atx (%s) is too new", prev.ID()))
 	})
 	t.Run("previous ATX by different smesher", func(t *testing.T) {
 		atxHandler := newV2TestHandler(t, golden)
@@ -2026,6 +2027,57 @@ func Test_Marriages(t *testing.T) {
 		equiv, err := marriage.NodeIDsByID(atxHandler.cdb, id)
 		require.NoError(t, err)
 		require.ElementsMatch(t, []types.NodeID{sig.NodeID(), otherSig.NodeID(), otherSig2.NodeID()}, equiv)
+
+		for _, sig := range []*signing.EdSigner{sig, otherSig, otherSig2} {
+			m, err := malfeasance.IsMalicious(atxHandler.cdb, sig.NodeID())
+			require.NoError(t, err)
+			require.True(t, m, "expected %s to be malicious", sig)
+		}
+	})
+	t.Run("malicious marring into existing non-malicious equivocation set sets all malicious", func(t *testing.T) {
+		t.Parallel()
+		atxHandler := newV2TestHandler(t, golden)
+
+		otherSig, err := signing.NewEdSigner()
+		require.NoError(t, err)
+		atx, _ := marryIDs(t, atxHandler, []*signing.EdSigner{sig, otherSig}, golden)
+
+		// otherSig2 cannot marry sig, trying to extend its set.
+		otherSig2, err := signing.NewEdSigner()
+		require.NoError(t, err)
+		others2Atx := atxHandler.createAndProcessInitial(otherSig2)
+
+		// otherSig2 becomes malicious in some way
+		err = malfeasance.AddProof(atxHandler.cdb, otherSig2.NodeID(), nil, []byte("proof"), 0, time.Now())
+		require.NoError(t, err)
+
+		atx2 := newSoloATXv2(t, atx.PublishEpoch+1, atx.ID(), atx.ID())
+		atx2.Marriages = []wire.MarriageCertificate{
+			{
+				Signature: sig.Sign(signing.MARRIAGE, sig.NodeID().Bytes()),
+			},
+			{
+				ReferenceAtx: others2Atx.ID(),
+				Signature:    otherSig2.Sign(signing.MARRIAGE, sig.NodeID().Bytes()),
+			},
+		}
+		atx2.Sign(sig)
+		atxHandler.expectAtxV2(atx2)
+		err = atxHandler.processATX(context.Background(), "", atx2, time.Now())
+		require.NoError(t, err)
+
+		// The equivocation set of sig and otherSig were merged
+		id, err := marriage.FindIDByNodeID(atxHandler.cdb, sig.NodeID())
+		require.NoError(t, err)
+		equiv, err := marriage.NodeIDsByID(atxHandler.cdb, id)
+		require.NoError(t, err)
+		require.ElementsMatch(t, []types.NodeID{sig.NodeID(), otherSig.NodeID(), otherSig2.NodeID()}, equiv)
+
+		for _, sig := range []*signing.EdSigner{sig, otherSig, otherSig2} {
+			m, err := malfeasance.IsMalicious(atxHandler.cdb, sig.NodeID())
+			require.NoError(t, err)
+			require.True(t, m, "expected %s to be malicious", sig)
+		}
 	})
 	t.Run("signer must marry self", func(t *testing.T) {
 		t.Parallel()

--- a/activation/handler_v2_test.go
+++ b/activation/handler_v2_test.go
@@ -1987,12 +1987,6 @@ func Test_Marriages(t *testing.T) {
 		equiv, err := marriage.NodeIDsByID(atxHandler.cdb, id)
 		require.NoError(t, err)
 		require.ElementsMatch(t, []types.NodeID{sig.NodeID(), otherSig.NodeID(), otherSig2.NodeID()}, equiv)
-
-		for _, sig := range []*signing.EdSigner{sig, otherSig, otherSig2} {
-			m, err := malfeasance.IsMalicious(atxHandler.cdb, sig.NodeID())
-			require.NoError(t, err)
-			require.True(t, m, "expected %s to be malicious", sig)
-		}
 	})
 	t.Run("marring existing malicious equivocation set: marks all malicious and publishes proof", func(t *testing.T) {
 		t.Parallel()
@@ -2031,17 +2025,7 @@ func Test_Marriages(t *testing.T) {
 				return atxHandler.edVerifier.Verify(d, nodeID, m, sig)
 			}).AnyTimes()
 
-		atxHandler.mMalPublish.EXPECT().Publish(
-			gomock.Any(),
-			sig.NodeID(),
-			gomock.AssignableToTypeOf(&wire.ProofDoubleMarry{}),
-		).DoAndReturn(func(ctx context.Context, _ types.NodeID, proof wire.Proof) error {
-			malProof := proof.(*wire.ProofDoubleMarry)
-			nId, err := malProof.Valid(ctx, verifier)
-			require.NoError(t, err)
-			require.Equal(t, sig.NodeID(), nId)
-			return nil
-		})
+		atxHandler.mMalPublish.EXPECT().Republish(gomock.Any(), sig.NodeID())
 		err = atxHandler.processATX(context.Background(), "", atx2, time.Now())
 		require.NoError(t, err)
 
@@ -2094,17 +2078,7 @@ func Test_Marriages(t *testing.T) {
 				return atxHandler.edVerifier.Verify(d, nodeID, m, sig)
 			}).AnyTimes()
 
-		atxHandler.mMalPublish.EXPECT().Publish(
-			gomock.Any(),
-			sig.NodeID(),
-			gomock.AssignableToTypeOf(&wire.ProofDoubleMarry{}),
-		).DoAndReturn(func(ctx context.Context, _ types.NodeID, proof wire.Proof) error {
-			malProof := proof.(*wire.ProofDoubleMarry)
-			nId, err := malProof.Valid(ctx, verifier)
-			require.NoError(t, err)
-			require.Equal(t, sig.NodeID(), nId)
-			return nil
-		})
+		atxHandler.mMalPublish.EXPECT().Republish(gomock.Any(), sig.NodeID())
 		err = atxHandler.processATX(context.Background(), "", atx2, time.Now())
 		require.NoError(t, err)
 

--- a/activation/handler_v2_test.go
+++ b/activation/handler_v2_test.go
@@ -1987,8 +1987,14 @@ func Test_Marriages(t *testing.T) {
 		equiv, err := marriage.NodeIDsByID(atxHandler.cdb, id)
 		require.NoError(t, err)
 		require.ElementsMatch(t, []types.NodeID{sig.NodeID(), otherSig.NodeID(), otherSig2.NodeID()}, equiv)
+
+		for _, sig := range []*signing.EdSigner{sig, otherSig, otherSig2} {
+			m, err := malfeasance.IsMalicious(atxHandler.cdb, sig.NodeID())
+			require.NoError(t, err)
+			require.True(t, m, "expected %s to be malicious", sig)
+		}
 	})
-	t.Run("marring into existing malicious equivocation set sets identity as malicious", func(t *testing.T) {
+	t.Run("marring existing malicious equivocation set: marks all malicious and publishes proof", func(t *testing.T) {
 		t.Parallel()
 		atxHandler := newV2TestHandler(t, golden)
 
@@ -2018,6 +2024,24 @@ func Test_Marriages(t *testing.T) {
 		}
 		atx2.Sign(sig)
 		atxHandler.expectAtxV2(atx2)
+
+		verifier := wire.NewMockMalfeasanceValidator(atxHandler.ctrl)
+		verifier.EXPECT().Signature(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(d signing.Domain, nodeID types.NodeID, m []byte, sig types.EdSignature) bool {
+				return atxHandler.edVerifier.Verify(d, nodeID, m, sig)
+			}).AnyTimes()
+
+		atxHandler.mMalPublish.EXPECT().Publish(
+			gomock.Any(),
+			sig.NodeID(),
+			gomock.AssignableToTypeOf(&wire.ProofDoubleMarry{}),
+		).DoAndReturn(func(ctx context.Context, _ types.NodeID, proof wire.Proof) error {
+			malProof := proof.(*wire.ProofDoubleMarry)
+			nId, err := malProof.Valid(ctx, verifier)
+			require.NoError(t, err)
+			require.Equal(t, sig.NodeID(), nId)
+			return nil
+		})
 		err = atxHandler.processATX(context.Background(), "", atx2, time.Now())
 		require.NoError(t, err)
 
@@ -2034,7 +2058,7 @@ func Test_Marriages(t *testing.T) {
 			require.True(t, m, "expected %s to be malicious", sig)
 		}
 	})
-	t.Run("malicious marring into existing non-malicious equivocation set sets all malicious", func(t *testing.T) {
+	t.Run("malicious marring existing equivocation set: marks all malicious and publishes proof", func(t *testing.T) {
 		t.Parallel()
 		atxHandler := newV2TestHandler(t, golden)
 
@@ -2063,11 +2087,80 @@ func Test_Marriages(t *testing.T) {
 		}
 		atx2.Sign(sig)
 		atxHandler.expectAtxV2(atx2)
+
+		verifier := wire.NewMockMalfeasanceValidator(atxHandler.ctrl)
+		verifier.EXPECT().Signature(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(d signing.Domain, nodeID types.NodeID, m []byte, sig types.EdSignature) bool {
+				return atxHandler.edVerifier.Verify(d, nodeID, m, sig)
+			}).AnyTimes()
+
+		atxHandler.mMalPublish.EXPECT().Publish(
+			gomock.Any(),
+			sig.NodeID(),
+			gomock.AssignableToTypeOf(&wire.ProofDoubleMarry{}),
+		).DoAndReturn(func(ctx context.Context, _ types.NodeID, proof wire.Proof) error {
+			malProof := proof.(*wire.ProofDoubleMarry)
+			nId, err := malProof.Valid(ctx, verifier)
+			require.NoError(t, err)
+			require.Equal(t, sig.NodeID(), nId)
+			return nil
+		})
 		err = atxHandler.processATX(context.Background(), "", atx2, time.Now())
 		require.NoError(t, err)
 
 		// The equivocation set of sig and otherSig were merged
 		id, err := marriage.FindIDByNodeID(atxHandler.cdb, sig.NodeID())
+		require.NoError(t, err)
+		equiv, err := marriage.NodeIDsByID(atxHandler.cdb, id)
+		require.NoError(t, err)
+		require.ElementsMatch(t, []types.NodeID{sig.NodeID(), otherSig.NodeID(), otherSig2.NodeID()}, equiv)
+
+		for _, sig := range []*signing.EdSigner{sig, otherSig, otherSig2} {
+			m, err := malfeasance.IsMalicious(atxHandler.cdb, sig.NodeID())
+			require.NoError(t, err)
+			require.True(t, m, "expected %s to be malicious", sig)
+		}
+	})
+	t.Run("malicious marring malicious equivocation set: no proof published", func(t *testing.T) {
+		t.Parallel()
+		atxHandler := newV2TestHandler(t, golden)
+
+		otherSig, err := signing.NewEdSigner()
+		require.NoError(t, err)
+		atx, _ := marryIDs(t, atxHandler, []*signing.EdSigner{sig, otherSig}, golden)
+
+		// sig becomes malicious in some way and with it otherSig
+		id, err := marriage.FindIDByNodeID(atxHandler.cdb, sig.NodeID())
+		require.NoError(t, err)
+		require.NoError(t, malfeasance.AddProof(atxHandler.cdb, sig.NodeID(), &id, []byte("proof"), 0, time.Now()))
+		require.NoError(t, malfeasance.SetMalicious(atxHandler.cdb, otherSig.NodeID(), id, time.Now()))
+
+		// otherSig2 cannot marry sig, trying to extend its set.
+		otherSig2, err := signing.NewEdSigner()
+		require.NoError(t, err)
+		others2Atx := atxHandler.createAndProcessInitial(otherSig2)
+
+		// otherSig2 becomes malicious in some way
+		err = malfeasance.AddProof(atxHandler.cdb, otherSig2.NodeID(), nil, []byte("proof"), 0, time.Now())
+		require.NoError(t, err)
+
+		atx2 := newSoloATXv2(t, atx.PublishEpoch+1, atx.ID(), atx.ID())
+		atx2.Marriages = []wire.MarriageCertificate{
+			{
+				Signature: sig.Sign(signing.MARRIAGE, sig.NodeID().Bytes()),
+			},
+			{
+				ReferenceAtx: others2Atx.ID(),
+				Signature:    otherSig2.Sign(signing.MARRIAGE, sig.NodeID().Bytes()),
+			},
+		}
+		atx2.Sign(sig)
+		atxHandler.expectAtxV2(atx2)
+		err = atxHandler.processATX(context.Background(), "", atx2, time.Now())
+		require.NoError(t, err)
+
+		// The equivocation set of sig and otherSig were merged
+		id, err = marriage.FindIDByNodeID(atxHandler.cdb, sig.NodeID())
 		require.NoError(t, err)
 		equiv, err := marriage.NodeIDsByID(atxHandler.cdb, id)
 		require.NoError(t, err)

--- a/activation/handler_v2_test.go
+++ b/activation/handler_v2_test.go
@@ -2223,6 +2223,8 @@ func Test_MarryingMalicious(t *testing.T) {
 			require.NoError(t, malfeasance.AddProof(atxHandler.cdb, malicious, nil, []byte("proof"), 0, time.Now()))
 
 			atxHandler.expectInitialAtxV2(atx)
+			atxHandler.mMalPublish.EXPECT().Republish(gomock.Any(), sig.NodeID())
+
 			err := atxHandler.processATX(context.Background(), "", atx, time.Now())
 			require.NoError(t, err)
 

--- a/activation/interface.go
+++ b/activation/interface.go
@@ -104,9 +104,10 @@ type legacyMalfeasancePublisher interface {
 // atxMalfeasancePublisher is an interface for publishing atx malfeasance proofs.
 //
 // It encapsulates a specific malfeasance proof into a generic ATX malfeasance proof and publishes it by calling
-// the underlying malfeasancePublisher.
+// the underlying malfeasancePublisher. It also allows republishing of existing proofs.
 type atxMalfeasancePublisher interface {
 	Publish(ctx context.Context, nodeID types.NodeID, proof wire.Proof) error
+	Republish(ctx context.Context, nodeID types.NodeID) error
 }
 
 type atxProvider interface {

--- a/activation/malfeasance2.go
+++ b/activation/malfeasance2.go
@@ -50,3 +50,8 @@ func (p *MalfeasanceHandlerV2) Publish(ctx context.Context, id types.NodeID, pro
 	// TODO(mafa): implement me
 	return nil
 }
+
+func (p *MalfeasanceHandlerV2) Republish(ctx context.Context, id types.NodeID) error {
+	// TODO(mafa): implement me
+	return nil
+}

--- a/activation/mocks.go
+++ b/activation/mocks.go
@@ -1217,6 +1217,44 @@ func (c *MockatxMalfeasancePublisherPublishCall) DoAndReturn(f func(context.Cont
 	return c
 }
 
+// Republish mocks base method.
+func (m *MockatxMalfeasancePublisher) Republish(ctx context.Context, nodeID types.NodeID) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Republish", ctx, nodeID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Republish indicates an expected call of Republish.
+func (mr *MockatxMalfeasancePublisherMockRecorder) Republish(ctx, nodeID any) *MockatxMalfeasancePublisherRepublishCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Republish", reflect.TypeOf((*MockatxMalfeasancePublisher)(nil).Republish), ctx, nodeID)
+	return &MockatxMalfeasancePublisherRepublishCall{Call: call}
+}
+
+// MockatxMalfeasancePublisherRepublishCall wrap *gomock.Call
+type MockatxMalfeasancePublisherRepublishCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockatxMalfeasancePublisherRepublishCall) Return(arg0 error) *MockatxMalfeasancePublisherRepublishCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockatxMalfeasancePublisherRepublishCall) Do(f func(context.Context, types.NodeID) error) *MockatxMalfeasancePublisherRepublishCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockatxMalfeasancePublisherRepublishCall) DoAndReturn(f func(context.Context, types.NodeID) error) *MockatxMalfeasancePublisherRepublishCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // MockatxProvider is a mock of atxProvider interface.
 type MockatxProvider struct {
 	ctrl     *gomock.Controller

--- a/malfeasance/handler.go
+++ b/malfeasance/handler.go
@@ -74,7 +74,8 @@ func NewHandler(
 		},
 		[]string{
 			typeLabel,
-		})
+		},
+	)
 	invalidProofCounter := prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: metrics.Namespace,

--- a/systest/tests/smeshing_test.go
+++ b/systest/tests/smeshing_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"sort"
@@ -74,7 +75,12 @@ func testSmeshing(t *testing.T, tctx *testcontext.Context, cl *cluster.Cluster) 
 		includedAll[i] = map[uint32][]*pb.Proposal{}
 	}
 
-	eg, ctx := errgroup.WithContext(tctx)
+	layerDuration := testcontext.LayerDuration.Get(tctx.Parameters)
+	deadline := cl.Genesis().Add(time.Duration(last+2*layersPerEpoch) * layerDuration) // add 2 epochs of buffer
+	ctx, cancel := context.WithDeadline(tctx, deadline)
+	defer cancel()
+
+	eg, ctx := errgroup.WithContext(ctx)
 	for i := range cl.Total() {
 		client := cl.Client(i)
 		tctx.Log.Debugw("watching", "client", client.Name, "i", i)
@@ -82,21 +88,38 @@ func testSmeshing(t *testing.T, tctx *testcontext.Context, cl *cluster.Cluster) 
 			if proposal.Layer.Number < first {
 				return true, nil
 			}
-			tctx.Log.Debugw("received proposal event",
+			if proposal.Layer.Number > last {
+				return false, nil
+			}
+			if proposal.Status == pb.Proposal_Created {
+				tctx.Log.Debugw("received proposal created event",
+					"client", client.Name,
+					"layer", proposal.Layer.Number,
+					"smesher", prettyHex(proposal.Smesher.Id),
+					"eligibilities", len(proposal.Eligibilities),
+				)
+				select {
+				case createdCh <- proposal:
+				case <-ctx.Done():
+					return false, ctx.Err()
+				default:
+					tctx.Log.Errorw("proposal channel is full",
+						"client", client.Name,
+						"layer", proposal.Layer.Number,
+					)
+					return false, errors.New("proposal channel is full")
+				}
+				return true, nil
+			}
+
+			tctx.Log.Debugw("received other proposal event",
 				"client", client.Name,
 				"layer", proposal.Layer.Number,
 				"smesher", prettyHex(proposal.Smesher.Id),
 				"eligibilities", len(proposal.Eligibilities),
 				"status", pb.Proposal_Status_name[int32(proposal.Status)],
 			)
-			if proposal.Layer.Number > last {
-				return false, nil
-			}
-			if proposal.Status == pb.Proposal_Created {
-				createdCh <- proposal
-			} else {
-				includedAll[i][proposal.Layer.Number] = append(includedAll[i][proposal.Layer.Number], proposal)
-			}
+			includedAll[i][proposal.Layer.Number] = append(includedAll[i][proposal.Layer.Number], proposal)
 			return true, nil
 		})
 	}


### PR DESCRIPTION
## Motivation

This updates the handler for ATXv2 to handle double marry correctly when at least one but not all of the involved marriage sets is already known to be malfeasant.

## Description

When an identity marries twice there are 3 possible scenarios:

- all existing marriage sets that are combined are in good standing. In this case we merge the set  and publish a double marry proof.
- all marriage sets that are involved in the combined marriage are known to be malicious. In this case no proof is published and only the local view on the marriage set is updated.
- at least one but not all existing marriage sets that are combined are already known to be malicious. Before, this would - depending on which set is known to be malicious - sometimes only update the local view on malfeasance and not publish a proof. This PR changes this scenario to always update the local view on the marriage set and publish a proof.

## Test Plan

a new unit test was added to cover the changed behaviour

## TODO

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
