### PR TITLE
[Merged by Bors] - sync2: enable server mode by default and adjust settings

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -233,7 +233,7 @@ func defaultBaseConfig() BaseConfig {
 		BlockGasLimit:                math.MaxUint64,
 		OptFilterThreshold:           90,
 		TickSize:                     100,
-		DatabaseConnections:          16,
+		DatabaseConnections:          32,
 		DatabaseSizeMeteringInterval: 10 * time.Minute,
 		DatabasePruneInterval:        30 * time.Minute,
 		DatabaseQueryCacheSizes: DatabaseQueryCacheSizes{

--- a/config/mainnet.go
+++ b/config/mainnet.go
@@ -91,7 +91,7 @@ func MainnetConfig() Config {
 			DataDirParent:           defaultDataDir,
 			FileLock:                filepath.Join(os.TempDir(), "spacemesh.lock"),
 			MetricsPort:             1010,
-			DatabaseConnections:     16,
+			DatabaseConnections:     32,
 			DatabasePruneInterval:   30 * time.Minute,
 			DatabaseVacuumState:     21,
 			DatabaseConnIdleTimeout: 10 * time.Millisecond,

--- a/config/presets/testnet.go
+++ b/config/presets/testnet.go
@@ -79,7 +79,7 @@ func testnet() config.Config {
 			DataDirParent:                defaultdir,
 			FileLock:                     filepath.Join(os.TempDir(), "spacemesh.lock"),
 			MetricsPort:                  1010,
-			DatabaseConnections:          16,
+			DatabaseConnections:          32,
 			DatabaseSizeMeteringInterval: 10 * time.Minute,
 			DatabasePruneInterval:        30 * time.Minute,
 			DatabaseConnIdleTimeout:      10 * time.Millisecond,

--- a/sync2/multipeer/multipeer.go
+++ b/sync2/multipeer/multipeer.go
@@ -149,7 +149,7 @@ func (cfg *MultiPeerReconcilerConfig) Validate(logger *zap.Logger) bool {
 // DefaultConfig returns the default configuration for the MultiPeerReconciler.
 func DefaultConfig() MultiPeerReconcilerConfig {
 	return MultiPeerReconcilerConfig{
-		SyncPeerCount:          20,
+		SyncPeerCount:          10,
 		MinSplitSyncPeers:      2,
 		MinSplitSyncCount:      1000,
 		MaxFullDiff:            10000,

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -61,10 +61,10 @@ type ReconcSyncConfig struct {
 func DefaultConfig() Config {
 	oldAtxSyncCfg := sync2.DefaultConfig()
 	oldAtxSyncCfg.MaxDepth = 16
-	oldAtxSyncCfg.MultiPeerReconcilerConfig.SyncInterval = time.Hour
+	oldAtxSyncCfg.MultiPeerReconcilerConfig.SyncInterval = 10 * time.Hour
 	newAtxSyncCfg := sync2.DefaultConfig()
 	newAtxSyncCfg.MaxDepth = 21
-	newAtxSyncCfg.MultiPeerReconcilerConfig.SyncInterval = 5 * time.Minute
+	newAtxSyncCfg.MultiPeerReconcilerConfig.SyncInterval = 30 * time.Minute
 	return Config{
 		Interval:                 10 * time.Second,
 		EpochEndFraction:         0.5,
@@ -77,7 +77,7 @@ func DefaultConfig() Config {
 		AtxSync:                  atxsync.DefaultConfig(),
 		MalSync:                  malsync.DefaultConfig(),
 		ReconcSync: ReconcSyncConfig{
-			Enable:            false,
+			Enable:            true,
 			EnableActiveSync:  false,
 			OldAtxSyncCfg:     oldAtxSyncCfg,
 			NewAtxSyncCfg:     newAtxSyncCfg,


### PR DESCRIPTION
## Motivation

We need to have syncv2 enabled for everyone for further testing of active syncv2.
Current default settings differ from what was verified on mainnet so far, and need to be made more conservative to be on the safe side.

## Description

* Enable syncv2 server mode by default, keeping active syncv2 off by default for now.
* Increase default N of DB connections to 32 for mainnet / testnet / other configs (was 16).
  * `syncv2` may use more connections b/c it connects to many peers at once.
* Use 10 peers by default for multipeer sync instead of 20 peers.
* Use more conservative settings for syncv2 intervals to avoid unforeseen network overloads.
  * Each old epoch will be synced once per ~10h instead of ~1h (the interval is randomized using random spread).
  * The new epoch (one being actively updated) will be synced once per ~30m instead of ~5m.
  * Note that with `syncv1`, the new epoch is synced once per 4h and old epochs are not synced at all.

## Test Plan

Check on mainnet nodes.