### PR TITLE
use computed multisig template address is UT

### DIFF
--- a/api/grpcserver/v2alpha1/transaction_test.go
+++ b/api/grpcserver/v2alpha1/transaction_test.go
@@ -621,7 +621,7 @@ func TestToTxContents(t *testing.T) {
 			pubStrs = append(pubStrs, p.String())
 		}
 
-		tx, err := sdkmultisig.Spawn(multisig.TemplateAddress, 2, pubs, 0)
+		tx, err := sdkmultisig.Spawn(2, pubs, 0)
 		require.NoError(t, err)
 		agg := sdkmultisig.NewSignatureAggregator(tx)
 		for i := range 2 {

--- a/vm/cmd/gen/multisig.go
+++ b/vm/cmd/gen/multisig.go
@@ -42,7 +42,7 @@ func (m *multiSigWallet) Spawn(opts ...sdk.Opt) *core.Tx {
 	for _, pk := range m.pks {
 		pubs = append(pubs, [32]byte(signing.Public(signing.PrivateKey(pk))))
 	}
-	return sdkmultisig.SpawnTx(multisig.TemplateAddress, m.required, pubs, 0, opts...)
+	return sdkmultisig.SpawnTx(m.required, pubs, 0, opts...)
 }
 
 func (m *multiSigWallet) Spend(recipient types.Address, amount, nonce uint64, opts ...sdk.Opt) *core.Tx {

--- a/vm/sdk/multisig/tx.go
+++ b/vm/sdk/multisig/tx.go
@@ -82,7 +82,6 @@ func EncodeDeployArgs(blob []byte) []byte {
 // Spawn creates a raw SPAWN transaction, which needs to be signed by the required
 // number of signers.
 func SpawnTx(
-	template types.Address,
 	required uint8,
 	pubkeys []core.PublicKey,
 	nonce core.Nonce,
@@ -100,8 +99,8 @@ func SpawnTx(
 	}
 	return &core.Tx{
 		Version:   1,
-		Principal: core.ComputePrincipalFromBlob(template, encodedArgs),
-		Template:  &template,
+		Principal: core.ComputePrincipalFromBlob(multisig.TemplateAddress, encodedArgs),
+		Template:  &multisig.TemplateAddress,
 		Metadata: core.Metadata{
 			Nonce:    nonce,
 			GasPrice: options.GasPrice,
@@ -111,13 +110,12 @@ func SpawnTx(
 }
 
 func Spawn(
-	template types.Address,
 	required uint8,
 	pubkeys []core.PublicKey,
 	nonce core.Nonce,
 	opts ...sdk.Opt,
 ) ([]byte, error) {
-	return codec.Encode(SpawnTx(template, required, pubkeys, nonce, opts...))
+	return codec.Encode(SpawnTx(required, pubkeys, nonce, opts...))
 }
 
 func SpendTx(principal, to types.Address, amount uint64, nonce types.Nonce, opts ...sdk.Opt) *core.Tx {

--- a/vm/sdk/options.go
+++ b/vm/sdk/options.go
@@ -18,7 +18,6 @@ func Defaults() *Options {
 type Options struct {
 	GasPrice  uint64
 	GenesisID types.Hash20
-	Template  *types.Address
 }
 
 // WithGasPrice modifies GasPrice.
@@ -32,12 +31,6 @@ func WithGasPrice(price uint64) Opt {
 func WithGenesisID(id types.Hash20) Opt {
 	return func(opts *Options) {
 		opts.GenesisID = id
-	}
-}
-
-func WithTemplate(t types.Address) Opt {
-	return func(opts *Options) {
-		opts.Template = &t
 	}
 }
 

--- a/vm/sdk/wallet/tx.go
+++ b/vm/sdk/wallet/tx.go
@@ -37,13 +37,9 @@ func DeployTx(pubkey ed25519.PublicKey, nonce core.Nonce, blob []byte, opts ...s
 		return nil, fmt.Errorf("encoding tx payload: %w", err)
 	}
 
-	template := options.Template
-	if template == nil {
-		template = &wallet.TemplateAddress
-	}
 	return &core.Tx{
 		Version:   uint8(sdk.TxVersion),
-		Principal: core.ComputePrincipalFromBlob(*template, pubkey),
+		Principal: core.ComputePrincipalFromBlob(wallet.TemplateAddress, pubkey),
 		Metadata: core.Metadata{
 			Nonce:    nonce,
 			GasPrice: options.GasPrice,
@@ -82,15 +78,10 @@ func SpawnTx(pubkey ed25519.PublicKey, nonce core.Nonce, opts ...sdk.Opt) (*core
 	}
 	defer vmlib.Close()
 
-	template := options.Template
-	if template == nil {
-		template = &wallet.TemplateAddress
-	}
-
 	return &core.Tx{
 		Version:   uint8(sdk.TxVersion),
-		Principal: core.ComputePrincipalFromBlob(*template, pubkey),
-		Template:  template,
+		Principal: core.ComputePrincipalFromBlob(wallet.TemplateAddress, pubkey),
+		Template:  (*types.Address)(&wallet.TemplateAddress),
 		Metadata: core.Metadata{
 			Nonce:    nonce,
 			GasPrice: options.GasPrice,
@@ -140,14 +131,9 @@ func SpendTx(
 	}
 	defer vmlib.Close()
 
-	template := options.Template
-	if template == nil {
-		template = &wallet.TemplateAddress
-	}
-
 	return &core.Tx{
 		Version:   uint8(sdk.TxVersion),
-		Principal: core.ComputePrincipalFromBlob(*template, pubkey),
+		Principal: core.ComputePrincipalFromBlob(wallet.TemplateAddress, pubkey),
 		Metadata: core.Metadata{
 			Nonce:    nonce,
 			GasPrice: options.GasPrice,
@@ -174,14 +160,9 @@ func Spend(pk signing.PrivateKey, to types.Address, amount uint64, nonce types.N
 	}
 	defer vmlib.Close()
 
-	template := options.Template
-	if template == nil {
-		template = &wallet.TemplateAddress
-	}
-
 	tx := core.Tx{
 		Version:   uint8(sdk.TxVersion),
-		Principal: core.ComputePrincipalFromBlob(*template, signing.Public(pk)),
+		Principal: core.ComputePrincipalFromBlob(wallet.TemplateAddress, signing.Public(pk)),
 		Metadata: core.Metadata{
 			Nonce:    nonce,
 			GasPrice: options.GasPrice,

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -116,7 +116,6 @@ type multisigAccount struct {
 	required uint8
 	pks      []ed25519.PrivateKey
 	address  core.Address
-	template core.Address
 }
 
 func (a *multisigAccount) getAddress() core.Address {
@@ -149,7 +148,7 @@ func (a *multisigAccount) selfSpawn(t *tester, nonce core.Nonce, opts ...sdk.Opt
 	for _, pk := range a.pks {
 		pubs = append(pubs, [32]byte(signing.Public(signing.PrivateKey(pk))))
 	}
-	tx, err := sdkmultisig.Spawn(a.template, a.required, pubs, nonce, opts...)
+	tx, err := sdkmultisig.Spawn(a.required, pubs, nonce, opts...)
 	require.NoError(t, err)
 	agg := sdkmultisig.NewSignatureAggregator(tx)
 	for i := range a.required {
@@ -285,7 +284,7 @@ func (t *tester) addSingleSig(n int) *tester {
 	return t
 }
 
-func (t *tester) createMultisig(required, total uint8, template core.Address) *multisigAccount {
+func (t *tester) createMultisig(required, total uint8) *multisigAccount {
 	var pks []ed25519.PrivateKey
 	var pubs []core.PublicKey
 	for range total {
@@ -297,14 +296,13 @@ func (t *tester) createMultisig(required, total uint8, template core.Address) *m
 	return &multisigAccount{
 		required: required,
 		pks:      pks,
-		address:  sdkmultisig.Address(template, required, pubs),
-		template: template,
+		address:  sdkmultisig.Address(multisig.TemplateAddress, required, pubs),
 	}
 }
 
-func (t *tester) addMultisig(template types.Address, total int, required, numKeys uint8) *tester {
+func (t *tester) addMultisig(total int, required, numKeys uint8) *tester {
 	for range total {
-		t.addAccount(t.createMultisig(required, numKeys, template), 1_000_000_000)
+		t.addAccount(t.createMultisig(required, numKeys), 1_000_000_000)
 	}
 	return t
 }
@@ -1412,38 +1410,36 @@ func TestWallets(t *testing.T) {
 		testWallet(t, defaultGasPrice, multisig.TemplateAddress, func(t *testing.T) *tester {
 			return newTester(t).
 				addMultiSigWalletTemplate().
-				addMultisig(multisig.TemplateAddress, funded, 1, 3).
+				addMultisig(funded, 1, 3).
 				applyGenesisWithBalance().
-				addMultisig(multisig.TemplateAddress, total-funded, 1, 3)
+				addMultisig(total-funded, 1, 3)
 		})
 	})
 	t.Run("MultiSig23", func(t *testing.T) {
 		testWallet(t, defaultGasPrice, multisig.TemplateAddress, func(t *testing.T) *tester {
 			return newTester(t).
 				addMultiSigWalletTemplate().
-				addMultisig(multisig.TemplateAddress, funded, 2, 3).
+				addMultisig(funded, 2, 3).
 				applyGenesisWithBalance().
-				addMultisig(multisig.TemplateAddress, total-funded, 2, 3)
+				addMultisig(total-funded, 2, 3)
 		})
 	})
 	t.Run("MultiSig57", func(t *testing.T) {
 		testWallet(t, defaultGasPrice, multisig.TemplateAddress, func(t *testing.T) *tester {
 			return newTester(t).
 				addMultiSigWalletTemplate().
-				addMultisig(multisig.TemplateAddress, funded, 5, 7).
+				addMultisig(funded, 5, 7).
 				applyGenesisWithBalance().
-				addMultisig(multisig.TemplateAddress, total-funded, 5, 7)
+				addMultisig(total-funded, 5, 7)
 		})
 	})
 }
 
 func TestSingleSigWalletDeploy(t *testing.T) {
-	templateAddress := multisig.TemplateAddress
-	tt := newTester(
-		t,
-	).addWalletTemplate().
+	tt := newTester(t).
+		addWalletTemplate().
 		addSingleSig(1).
-		addMultisig(templateAddress, 1, 1, 3).
+		addMultisig(1, 1, 3).
 		applyGenesisWithBalance()
 
 	// 1. Spawn an account to pay for deploying
@@ -1466,13 +1462,13 @@ func TestSingleSigWalletDeploy(t *testing.T) {
 	require.Empty(t, skipped)
 	require.Empty(t, results[0].Message)
 	require.Equal(t, types.TransactionSuccess, results[0].Status)
-	require.Contains(t, results[0].Addresses, templateAddress)
+	require.Contains(t, results[0].Addresses, multisig.TemplateAddress)
 
-	deployedAccount, err := accounts.Latest(tt.db, templateAddress)
+	deployedAccount, err := accounts.Latest(tt.db, multisig.TemplateAddress)
 	require.NoError(t, err)
 
 	logger := zaptest.NewLogger(t)
-	logger.Debug("new template", zap.Stringer("address", templateAddress), zap.Inline(&deployedAccount))
+	logger.Debug("new template", zap.Stringer("address", multisig.TemplateAddress), zap.Inline(&deployedAccount))
 	require.Equal(t, code, deployedAccount.State)
 
 	pAccount1, err := accounts.Latest(tt.db, account.getAddress())
@@ -1493,11 +1489,7 @@ func TestSingleSigWalletDeploy(t *testing.T) {
 	require.Less(t, pAccount2.Balance, pAccount1.Balance)
 
 	// 3. Spawn the new template using the 2nd prefunded account
-	_, _, err = tt.Apply(
-		types.GetEffectiveGenesis(),
-		[]types.Transaction{{RawTx: tt.selfSpawn(1, sdk.WithTemplate(templateAddress))}},
-		nil,
-	)
+	_, _, err = tt.Apply(types.GetEffectiveGenesis(), []types.Transaction{{RawTx: tt.selfSpawn(1)}}, nil)
 	require.NoError(t, err)
 
 	exists, err = tt.AccountExists(tt.accounts[1].getAddress())
@@ -1506,7 +1498,7 @@ func TestSingleSigWalletDeploy(t *testing.T) {
 
 	a, err := accounts.Latest(tt.db, tt.accounts[1].getAddress())
 	require.NoError(t, err)
-	require.Equal(t, &templateAddress, a.TemplateAddress)
+	require.Equal(t, &multisig.TemplateAddress, a.TemplateAddress)
 }
 
 func testValidation(t *testing.T, tt *tester, template core.Address) {


### PR DESCRIPTION
Simplify UTs - the multisig wallet template address is calculated from the hash of the code and it doesn't need to be injected.