### PR TITLE
[Merged by Bors] - Execute delete-pool always if nondocchanges == true

### DIFF
--- a/.github/workflows/systest.yml
+++ b/.github/workflows/systest.yml
@@ -42,7 +42,7 @@ jobs:
   filter-changes:
     runs-on: ubuntu-22.04
     outputs:
-      nondocchanges: ${{ steps.filter.outputs.nondoc }}
+      nondocchanges: ${{ steps.filter.outputs.nondoc || github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3

--- a/.github/workflows/systest.yml
+++ b/.github/workflows/systest.yml
@@ -172,6 +172,7 @@ jobs:
   systest-gke:
     runs-on: ubuntu-22.04
     if: ${{ needs.filter-changes.outputs.nondocchanges == 'true' }}
+    continue-on-error: true
     needs:
       - filter-changes
       - provision-cluster
@@ -260,7 +261,7 @@ jobs:
 
   delete-pool:
     runs-on: ubuntu-22.04
-    if: always()
+    if: ${{ needs.filter-changes.outputs.nondocchanges == 'true' }}
     needs:
       - filter-changes
       - systest-gke


### PR DESCRIPTION
## Motivation

The current systest workflow fails when merging a change that doesn't execute system tests, i.e. only documentation was changed. This should fix the issue.

## Description

Instead of `always()` executing the `delete-pool` step, only execute it when `nondocchanges == true` and set `systest-gke` to `continue-on-error: true`

## Test Plan

n/a

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
