### PR TITLE
[Merged by Bors] - sync2: adjust settings again

### DIFF
--- a/config/mainnet.go
+++ b/config/mainnet.go
@@ -80,11 +80,9 @@ func MainnetConfig() Config {
 	hare4conf.Enable = false
 
 	oldAtxSyncCfg := sync2.DefaultConfig()
-	oldAtxSyncCfg.MultiPeerReconcilerConfig.SyncInterval = time.Hour
 	oldAtxSyncCfg.MaxDepth = 16
 	newAtxSyncCfg := sync2.DefaultConfig()
 	newAtxSyncCfg.MaxDepth = 21
-	newAtxSyncCfg.MultiPeerReconcilerConfig.SyncInterval = 5 * time.Minute
 
 	return Config{
 		BaseConfig: BaseConfig{

--- a/config/mainnet.go
+++ b/config/mainnet.go
@@ -81,8 +81,12 @@ func MainnetConfig() Config {
 
 	oldAtxSyncCfg := sync2.DefaultConfig()
 	oldAtxSyncCfg.MaxDepth = 16
+	oldAtxSyncCfg.MultiPeerReconcilerConfig.SyncInterval = 10 * time.Hour
+	oldAtxSyncCfg.AdvanceInterval = time.Hour
 	newAtxSyncCfg := sync2.DefaultConfig()
 	newAtxSyncCfg.MaxDepth = 21
+	newAtxSyncCfg.MultiPeerReconcilerConfig.SyncInterval = 30 * time.Minute
+	newAtxSyncCfg.AdvanceInterval = 5 * time.Minute
 
 	return Config{
 		BaseConfig: BaseConfig{

--- a/config/presets/fastnet.go
+++ b/config/presets/fastnet.go
@@ -22,6 +22,7 @@ func fastnet() config.Config {
 
 	conf.BaseConfig.OptFilterThreshold = 90
 	conf.BaseConfig.DatabasePruneInterval = time.Minute
+	conf.BaseConfig.DatabaseConnections = 16
 
 	// set for systest TestEquivocation
 	conf.BaseConfig.MinerGoodAtxsPercent = 50

--- a/config/presets/testnet.go
+++ b/config/presets/testnet.go
@@ -69,6 +69,7 @@ func testnet() config.Config {
 
 	oldAtxSyncCfg := sync2.DefaultConfig()
 	oldAtxSyncCfg.MaxDepth = 16
+	oldAtxSyncCfg.MultiPeerReconcilerConfig.SyncInterval = 10 * time.Minute
 	newAtxSyncCfg := sync2.DefaultConfig()
 	newAtxSyncCfg.MaxDepth = 21
 	newAtxSyncCfg.MultiPeerReconcilerConfig.SyncInterval = 5 * time.Minute

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -62,9 +62,11 @@ func DefaultConfig() Config {
 	oldAtxSyncCfg := sync2.DefaultConfig()
 	oldAtxSyncCfg.MaxDepth = 16
 	oldAtxSyncCfg.MultiPeerReconcilerConfig.SyncInterval = 10 * time.Hour
+	oldAtxSyncCfg.AdvanceInterval = time.Hour
 	newAtxSyncCfg := sync2.DefaultConfig()
 	newAtxSyncCfg.MaxDepth = 21
 	newAtxSyncCfg.MultiPeerReconcilerConfig.SyncInterval = 30 * time.Minute
+	newAtxSyncCfg.AdvanceInterval = 5 * time.Minute
 	return Config{
 		Interval:                 10 * time.Second,
 		EpochEndFraction:         0.5,


### PR DESCRIPTION
## Motivation

Need proper defaults for mainnet.
There were systest flakes with `syncv2` server mode enabled possibly due to increased resource usage.

## Description

Use intended 10h for old epoch / 30m for new epoch intervals.
Use 1h DBSet advance interval for old epoch / 5 min for new epoch.
Use 16 DB conns for fastnet.