### PR TITLE
[Merged by Bors] - Specify k8s node version for systemtest nodepool

### DIFF
--- a/.github/workflows/systest.yml
+++ b/.github/workflows/systest.yml
@@ -165,6 +165,7 @@ jobs:
             --metadata disable-legacy-endpoints=true \
             --service-account ${{ secrets.CI_GKE_NODEPOOL_SA }} \
             --project ${{ secrets.CI_GCP_PROJECT_ID }} \
+            --node-version ${{ secrets.CI_GKE_NODEPOOL_VERSION }} \
             --quiet
 
           echo "Node pool created: $NODE_POOL_NAME"


### PR DESCRIPTION
## Motivation

Ensure that the Kubernetes node pool for systest uses a specific, predefined node version rather than the latest available version for the cluster.

## Description

Ensures that the node pool for systests is created with a specific Kubernetes version, as defined in the secrets, instead of automatically using the latest available version for the cluster. This provides better control and stability for testing environments by avoiding potential issues with newer, untested Kubernetes versions.