### PR TITLE
[node-split] Fix cmdline args parsing on smeshing service

### DIFF
--- a/node/smeshing_service.go
+++ b/node/smeshing_service.go
@@ -118,7 +118,7 @@ func GetSmeshingServiceCommand() *cobra.Command {
 		},
 	}
 
-	configPath = cmd.AddNodeServiceFlags(c.PersistentFlags(), &conf)
+	configPath = cmd.AddSmeshingServiceFlags(c.PersistentFlags(), &conf)
 
 	// versionCmd returns the current version of spacemesh.
 	versionCmd := &cobra.Command{


### PR DESCRIPTION
As in title. This fix provides invocation of correct flags setting method for smeshing service.