### PR TITLE
[split-node] Fix args/flags parsing

### DIFF
--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -5,6 +5,7 @@ package main
 import (
 	_ "net/http/pprof"
 	"os"
+	"slices"
 
 	"github.com/spf13/cobra"
 
@@ -34,7 +35,7 @@ func main() { // run the app
 	// TODO: Move version, relay subcommands from node service and smeshing
 	// service subcommands to root command.
 
-	if len(os.Args) > 1 {
+	if len(os.Args) > 1 && !slices.Contains(os.Args, "--help") && !slices.Contains(os.Args, "-h") {
 		firstArg := os.Args[1]
 		foundMatch := false
 		for _, command := range rootCmd.Commands() {


### PR DESCRIPTION
Without this change when no subcommand is set and `--help` is called (or no other option is provided)
help is shown only for "default" subcommand (node) missing information that there are also other subcommands.