### PR TITLE
[Merged by Bors] - sync2: enable server mode for mainnet and testnet

### DIFF
--- a/config/mainnet.go
+++ b/config/mainnet.go
@@ -225,6 +225,7 @@ func MainnetConfig() Config {
 			AtxSync:                  atxsync.DefaultConfig(),
 			MalSync:                  malsync.DefaultConfig(),
 			ReconcSync: syncer.ReconcSyncConfig{
+				Enable:            true,
 				OldAtxSyncCfg:     oldAtxSyncCfg,
 				NewAtxSyncCfg:     newAtxSyncCfg,
 				ParallelLoadLimit: 10,

--- a/config/presets/testnet.go
+++ b/config/presets/testnet.go
@@ -70,9 +70,11 @@ func testnet() config.Config {
 	oldAtxSyncCfg := sync2.DefaultConfig()
 	oldAtxSyncCfg.MaxDepth = 16
 	oldAtxSyncCfg.MultiPeerReconcilerConfig.SyncInterval = 10 * time.Minute
+	oldAtxSyncCfg.MultiPeerReconcilerConfig.SyncPeerCount = 4
 	newAtxSyncCfg := sync2.DefaultConfig()
 	newAtxSyncCfg.MaxDepth = 21
 	newAtxSyncCfg.MultiPeerReconcilerConfig.SyncInterval = 5 * time.Minute
+	newAtxSyncCfg.MultiPeerReconcilerConfig.SyncPeerCount = 4
 
 	return config.Config{
 		Preset: "testnet",
@@ -174,6 +176,7 @@ func testnet() config.Config {
 			AtxSync:                  atxsync.DefaultConfig(),
 			MalSync:                  malsync.DefaultConfig(),
 			ReconcSync: syncer.ReconcSyncConfig{
+				Enable:            true,
 				OldAtxSyncCfg:     oldAtxSyncCfg,
 				NewAtxSyncCfg:     newAtxSyncCfg,
 				ParallelLoadLimit: 10,


### PR DESCRIPTION
## Motivation

`Enable` was not set to true for `ReconcSync` in the mainnet and testnet configs.

## Description

Enable server mode for mainnet and testnet.
For testnet, reduce the number of syncv2 peers to account for low resources allocated to testnet nodes.

## Test Plan

Verify the configs
