### PR TITLE
[Merged by Bors] - Fix failing systest job not blocking merge

### DIFF
--- a/.github/workflows/systest.yml
+++ b/.github/workflows/systest.yml
@@ -173,7 +173,6 @@ jobs:
   systest-gke:
     runs-on: ubuntu-22.04
     if: ${{ needs.filter-changes.outputs.nondocchanges == 'true' }}
-    continue-on-error: true
     needs:
       - filter-changes
       - provision-cluster
@@ -262,9 +261,10 @@ jobs:
 
   delete-pool:
     runs-on: ubuntu-22.04
-    if: ${{ needs.filter-changes.outputs.nondocchanges == 'true' }}
+    if: ${{ needs.provision-cluster.result == 'success' }}
     needs:
       - filter-changes
+      - provision-cluster
       - systest-gke
     timeout-minutes: 20
     permissions:

--- a/.github/workflows/systest.yml
+++ b/.github/workflows/systest.yml
@@ -182,6 +182,9 @@ jobs:
       contents: 'read'
       id-token: 'write'
     steps:
+      - name: fail job
+        run: exit 1
+
       - uses: actions/checkout@v4
         with:
           ssh-key: ${{ secrets.GH_ACTION_PRIVATE_KEY }}

--- a/.github/workflows/systest.yml
+++ b/.github/workflows/systest.yml
@@ -182,9 +182,6 @@ jobs:
       contents: 'read'
       id-token: 'write'
     steps:
-      - name: fail job
-        run: exit 1
-
       - uses: actions/checkout@v4
         with:
           ssh-key: ${{ secrets.GH_ACTION_PRIVATE_KEY }}

--- a/.github/workflows/systest.yml
+++ b/.github/workflows/systest.yml
@@ -264,7 +264,7 @@ jobs:
 
   delete-pool:
     runs-on: ubuntu-22.04
-    if: ${{ needs.provision-cluster.result == 'success' }}
+    if: ${{ always() && needs.provision-cluster.result == 'success' }}
     needs:
       - filter-changes
       - provision-cluster


### PR DESCRIPTION
## Motivation

My previous change in https://github.com/spacemeshos/go-spacemesh/pull/6626 broke `bors merge` to block merging a PR when system tests fail and instead always merged. This should fix this problem.

## Description

`continue-on-error` has the drawback that it sets `systest-gke.result` to `success` even if the job failed (and is displayed as failing in the GH user interface). Instead now I changed the condition to executing `delete-pool` whenever `provision-cluster` was successfully executed after `systest-gke` completes (independently of if `systest-gke` succeeds or not).

## Test Plan

- CHANGELOG PR merges without issues (`delete-pool` isn't executed)
- `delete-pool` is executed when merging this PR
- check the next time system tests fail, that `bors merge` will also fail, but `delete-pool` is still executed.
   - I will test this here by temporarily changing `systest-gke` to `exit 1` and running `bors try` before merging.

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
