### PR TITLE
[Merged by Bors] - Install older version of aws to fix release workflow

### DIFF
--- a/.github/workflows/api-swagger-ui.yml
+++ b/.github/workflows/api-swagger-ui.yml
@@ -42,10 +42,11 @@ jobs:
         fetch-depth: 0
         ref: 'refs/tags/${{ needs.check-version.outputs.go-sm-api-version }}'
 
-    - name: Install aws-cli
-      uses: unfor19/install-aws-cli-action@v1
-      with:
-        version: 2.22.33
+    - name: Install aws-cli on linux
+      run:
+        curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.22.35.zip" -o "awscliv2.zip"
+        unzip awscliv2.zip
+        sudo ./aws/install
     - name: upload to testnet
       run: >
         aws s3 sync api/release/openapi/swagger/src

--- a/.github/workflows/api-swagger-ui.yml
+++ b/.github/workflows/api-swagger-ui.yml
@@ -42,6 +42,10 @@ jobs:
         fetch-depth: 0
         ref: 'refs/tags/${{ needs.check-version.outputs.go-sm-api-version }}'
 
+    - name: Install aws-cli
+      uses: unfor19/install-aws-cli-action@v1
+      with:
+        version: 2.22.33
     - name: upload to testnet
       run: >
         aws s3 sync api/release/openapi/swagger/src

--- a/.github/workflows/api-swagger-ui.yml
+++ b/.github/workflows/api-swagger-ui.yml
@@ -42,11 +42,11 @@ jobs:
         fetch-depth: 0
         ref: 'refs/tags/${{ needs.check-version.outputs.go-sm-api-version }}'
 
-    - name: Install aws-cli on linux
-      run:
+    - name: Install aws-cli
+      run: |
         curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.22.35.zip" -o "awscliv2.zip"
         unzip awscliv2.zip
-        sudo ./aws/install
+        sudo ./aws/install --update
     - name: upload to testnet
       run: >
         aws s3 sync api/release/openapi/swagger/src

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,6 +101,7 @@ jobs:
           mkdir build-zip
           cp ${{ env.OUTNAME }}.zip build-zip
       - name: Install aws-cli
+        if: ${{ matrix.os != '[self-hosted, macOS, ARM64, go-spacemesh]' }}
         uses: unfor19/install-aws-cli-action@v1
         with:
           version: 2.22.33

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,19 +102,19 @@ jobs:
           cp ${{ env.OUTNAME }}.zip build-zip
       - name: Install aws-cli on linux
         if: ${{ matrix.os == 'ubuntu-22.04' }}
-        run:
+        run: |
           curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.22.35.zip" -o "awscliv2.zip"
           unzip awscliv2.zip
           sudo ./aws/install
       - name: Install aws-cli on linux-arm
         if: ${{ matrix.os == 'ubuntu-latest-arm-8-cores' }}
-        run:
+        run: |
           curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64-2.2.35.zip" -o "awscliv2.zip"
           unzip awscliv2.zip
           sudo ./aws/install
       - name: Install aws-cli on mac
         if: ${{ matrix.os == 'macos-13' }}
-        run:
+        run: |
           curl "https://awscli.amazonaws.com/AWSCLIV2-2.22.35.pkg" -o "AWSCLIV2.pkg"
           sudo installer -pkg AWSCLIV2.pkg -target /
       - name: Install aws-cli on windows

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,7 +119,7 @@ jobs:
           sudo installer -pkg AWSCLIV2.pkg -target /
       - name: Install aws-cli on windows
         if: ${{ matrix.os == 'windows-2022' }}
-        run: choco install awscli --version=2.22.35
+        run: choco install awscli --version=2.22.35 --allow-downgrade
       - name: Upload zip to R2
         run: >
           aws s3 sync build-zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,11 +100,26 @@ jobs:
         run: |
           mkdir build-zip
           cp ${{ env.OUTNAME }}.zip build-zip
-      - name: Install aws-cli
-        if: ${{ !contains(matrix.os, 'self-hosted') }}
-        uses: unfor19/install-aws-cli-action@v1
-        with:
-          version: 2.22.33
+      - name: Install aws-cli on linux
+        if: ${{ matrix.os == 'ubuntu-22.04' }}
+        run:
+          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.22.35.zip" -o "awscliv2.zip"
+          unzip awscliv2.zip
+          sudo ./aws/install
+      - name: Install aws-cli on linux-arm
+        if: ${{ matrix.os == 'ubuntu-latest-arm-8-cores' }}
+        run:
+          curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64-2.2.35.zip" -o "awscliv2.zip"
+          unzip awscliv2.zip
+          sudo ./aws/install
+      - name: Install aws-cli on mac
+        if: ${{ matrix.os == 'macos-13' }}
+        run:
+          curl "https://awscli.amazonaws.com/AWSCLIV2-2.22.35.pkg" -o "AWSCLIV2.pkg"
+          sudo installer -pkg AWSCLIV2.pkg -target /
+      - name: Install aws-cli on windows
+        if: ${{ matrix.os == 'windows-2022' }}
+        run: choco install awscli --version=2.22.35
       - name: Upload zip to R2
         run: >
           aws s3 sync build-zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,13 +105,13 @@ jobs:
         run: |
           curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.22.35.zip" -o "awscliv2.zip"
           unzip awscliv2.zip
-          sudo ./aws/install
+          sudo ./aws/install --update
       - name: Install aws-cli on linux-arm
         if: ${{ matrix.os == 'ubuntu-latest-arm-8-cores' }}
         run: |
           curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64-2.2.35.zip" -o "awscliv2.zip"
           unzip awscliv2.zip
-          sudo ./aws/install
+          sudo ./aws/install --update
       - name: Install aws-cli on mac
         if: ${{ matrix.os == 'macos-13' }}
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,7 @@ jobs:
           mkdir build-zip
           cp ${{ env.OUTNAME }}.zip build-zip
       - name: Install aws-cli
-        if: ${{ matrix.os != '[self-hosted, macOS, ARM64, go-spacemesh]' }}
+        if: ${{ !contains(matrix.os, 'self-hosted') }}
         uses: unfor19/install-aws-cli-action@v1
         with:
           version: 2.22.33
@@ -116,7 +116,7 @@ jobs:
             AWS_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_GO_SM_BUILDS_SECRET_ACCESS_KEY }}
             AWS_REGION: us-east-1
       - name: Install coreutils
-        if: ${{ matrix.os == 'macos-13' || matrix.os == '[self-hosted, macOS, ARM64, go-spacemesh]' }}
+        if: ${{ matrix.os == 'macos-13' }}
         run: brew install coreutils
       - name: Calculate the hashsum of the zip file
         if: ${{ matrix.os != 'windows-2022' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,7 +119,9 @@ jobs:
           sudo installer -pkg AWSCLIV2.pkg -target /
       - name: Install aws-cli on windows
         if: ${{ matrix.os == 'windows-2022' }}
-        run: choco install awscli --version=2.22.35 --allow-downgrade
+        run: |
+          choco uninstall awscli
+          choco install awscli --version=2.22.35
       - name: Upload zip to R2
         run: >
           aws s3 sync build-zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -200,6 +200,11 @@ jobs:
         run: |
           mkdir sha256sum
           cp sha256sum.yaml sha256sum
+      - name: Install aws-cli
+        run: |
+          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.22.35.zip" -o "awscliv2.zip"
+          unzip awscliv2.zip
+          sudo ./aws/install --update
       - name: Upload sha256sums to R2
         run: >
           aws s3 sync sha256sum

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,6 +100,10 @@ jobs:
         run: |
           mkdir build-zip
           cp ${{ env.OUTNAME }}.zip build-zip
+      - name: Install aws-cli
+        uses: unfor19/install-aws-cli-action@v1
+        with:
+          version: 2.22.33
       - name: Upload zip to R2
         run: >
           aws s3 sync build-zip


### PR DESCRIPTION
## Motivation

Version 2.23.x of `aws` has a known issue where uploads to cloudflare fail because of checksum errors. Version 2.22.x seems to not be affected by this issue. This PR updates the release and api swagger workflows to install version 2.22.33 before upload to avoid checksum errors.

## Description

I added an additional step to the release and api swagger workflows using `unfor19/install-aws-cli-action` to install a specific version of `aws` instead of using the version already present on the runner.

## Test Plan

- create a test release and see if workflow completes without issues

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
