### PR TITLE
Prune old events based on duration from the cfg

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -156,6 +156,10 @@ type BaseConfig struct {
 	// Address of the node serivce
 	// TODO: add better description.
 	NodeServiceAddress string `mapstructure:"node-service-address"`
+
+	// SmeshingEventsPruneDuration is the time after which smeshing identities events are pruned
+	// Default is 30 days
+	SmeshingEventsPruneDuration time.Duration `mapstructure:"smeshing-events-prune-duration"`
 }
 
 type DatabaseQueryCacheSizes struct {
@@ -251,6 +255,8 @@ func defaultBaseConfig() BaseConfig {
 		PostValidDelay:          12 * time.Hour,
 
 		PprofHTTPServerListener: "localhost:6060",
+
+		SmeshingEventsPruneDuration: 30 * 24 * time.Hour,
 	}
 }
 

--- a/identity/identity.go
+++ b/identity/identity.go
@@ -145,3 +145,7 @@ func (s *StateStorage) AllEligibilities() map[types.NodeID]map[types.LayerID][]t
 	)
 	return eligibilities
 }
+
+func (s *StateStorage) DeleteEventsOlderThan(t time.Time) error {
+	return events.DeleteEventsOlderThan(s.db, t)
+}

--- a/node/node.go
+++ b/node/node.go
@@ -621,6 +621,10 @@ func (app *App) initServices(ctx context.Context) error {
 	postStates := activation.NewPostStates(app.addLogger(PostLogger, lg).Zap())
 
 	app.idStates = identity.NewIdentityStateStorage(app.localDB, app.log.Zap())
+	err = app.idStates.DeleteEventsOlderThan(time.Now().Add(-app.Config.SmeshingEventsPruneDuration))
+	if err != nil {
+		return fmt.Errorf("deleting old identity events: %w", err)
+	}
 
 	opts := []activation.PostVerifierOpt{
 		activation.WithVerifyingOpts(app.Config.SMESHING.VerifyingOpts),

--- a/sql/localsql/events/events.go
+++ b/sql/localsql/events/events.go
@@ -79,3 +79,15 @@ func IterateAllEvents(
 	}
 	return nil
 }
+
+func DeleteEventsOlderThan(db sql.Executor, timestamp time.Time) error {
+	_, err := db.Exec(
+		`DELETE FROM events WHERE timestamp < ?1;`,
+		func(stmt *sql.Statement) {
+			stmt.BindInt64(1, timestamp.UnixMicro())
+		}, nil)
+	if err != nil {
+		return fmt.Errorf("deleting events older than %s: %w", timestamp, err)
+	}
+	return nil
+}

--- a/sql/localsql/events/events_test.go
+++ b/sql/localsql/events/events_test.go
@@ -62,18 +62,15 @@ func TestInsertEventsAndIterate(t *testing.T) {
 func TestDeleteEventsOlderThan(t *testing.T) {
 	db := localsql.InMemoryTest(t)
 
-	type event struct {
-		id        types.NodeID
-		timestamp time.Time
-		event     []byte
-	}
 	for i := range 10 {
-		e := event{
-			id:        types.RandomNodeID(),
-			timestamp: time.Unix(int64(i), 0),
-			event:     types.RandomBytes(10),
-		}
-		require.NoError(t, events.InsertEvent(db, e.id, e.timestamp, 0, e.event))
+		require.NoError(t,
+			events.InsertEvent(db,
+				types.RandomNodeID(),
+				time.Unix(int64(i), 0),
+				0,
+				types.RandomBytes(10),
+			),
+		)
 	}
 	err := events.DeleteEventsOlderThan(db, time.Unix(5, 0))
 	require.NoError(t, err)
@@ -83,7 +80,6 @@ func TestDeleteEventsOlderThan(t *testing.T) {
 		counter += 1
 		return true
 	})
-
 	require.NoError(t, err)
 	require.Equal(t, 5, counter)
 }

--- a/sql/localsql/events/events_test.go
+++ b/sql/localsql/events/events_test.go
@@ -58,3 +58,32 @@ func TestInsertEventsAndIterate(t *testing.T) {
 		require.Equal(t, 1, count)
 	}
 }
+
+func TestDeleteEventsOlderThan(t *testing.T) {
+	db := localsql.InMemoryTest(t)
+
+	type event struct {
+		id        types.NodeID
+		timestamp time.Time
+		event     []byte
+	}
+	for i := range 10 {
+		e := event{
+			id:        types.RandomNodeID(),
+			timestamp: time.Unix(int64(i), 0),
+			event:     types.RandomBytes(10),
+		}
+		require.NoError(t, events.InsertEvent(db, e.id, e.timestamp, 0, e.event))
+	}
+	err := events.DeleteEventsOlderThan(db, time.Unix(5, 0))
+	require.NoError(t, err)
+
+	var counter int
+	err = events.IterateAllEvents(db, builder.Operations{}, func(id types.NodeID, time time.Time, e []byte) bool {
+		counter += 1
+		return true
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, 5, counter)
+}


### PR DESCRIPTION
## Description

This pull request introduces a new feature to prune old smeshing identity events and integrates this functionality into the existing codebase. The most important changes include adding a new configuration parameter, implementing the deletion logic, and invoking this logic during service initialization.

### Configuration Updates:
* [`config/config.go`](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17R159-R162): Added `SmeshingEventsPruneDuration` to the `BaseConfig` struct and set a default value of 30 days in the `defaultBaseConfig` function. [[1]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17R159-R162) [[2]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17R258-R259)

### Deletion Logic:
* [`identity/identity.go`](diffhunk://#diff-b76d6cceaa02245d3d9443d12ee821f7a05e243ac48bece06993316bfafe042fR148-R151): Added a new method `DeleteEventsOlderThan` to the `StateStorage` struct to handle the deletion of old events.
* [`sql/localsql/events/events.go`](diffhunk://#diff-3ea0e5999733f782d39054b7fcd2e7b7a7b2ed734ca8ee1c45c3f6a79dc9e670R82-R93): Implemented the `DeleteEventsOlderThan` function to execute the SQL command for deleting events older than a specified timestamp.

### Service Initialization:
* [`node/node.go`](diffhunk://#diff-375d57e386f20eaa5f09f02bb9d28bfc48ac3dca18d0325f59492208219e5618R624-R627): Modified the `initServices` function to call `DeleteEventsOlderThan` during the initialization of identity states, ensuring old events are pruned based on the configured duration.