### PR TITLE
fix bugs around hare, proposals and systests

### DIFF
--- a/hare3/eligibility/oracle.go
+++ b/hare3/eligibility/oracle.go
@@ -355,7 +355,6 @@ func (o *Oracle) Validate(
 		zap.Int("n", n),
 		zap.Float64("p", p.Float()),
 		zap.Float64("vrf_frac", vrfFrac.Float()),
-		zap.Int("x", x),
 	)
 	return false, nil
 }
@@ -375,7 +374,7 @@ func (o *Oracle) CalcEligibility(
 		return 0, err
 	}
 
-	o.log.Debug("params",
+	o.log.Debug("calculating eligibility",
 		zap.Uint32("layer", layer.Uint32()),
 		zap.Uint32("epoch", layer.GetEpoch().Uint32()),
 		zap.Uint32("round_id", round),

--- a/hare3/hare.go
+++ b/hare3/hare.go
@@ -687,6 +687,9 @@ func (h *Hare) RoundTemplate(layer types.LayerID, round IterRound) *Body {
 	if !ok {
 		return nil
 	}
+	if r.message == nil {
+		return nil
+	}
 	return &r.message.Body
 }
 

--- a/hare3/remote.go
+++ b/hare3/remote.go
@@ -49,9 +49,9 @@ func NewRemoteHare(config Config,
 		beacons:   make(map[types.EpochID]types.Beacon),
 		signers:   make(map[string]*signing.EdSigner),
 		oracle: &legacyOracle{
-			log:    zap.NewNop(),
+			log:    log,
 			oracle: oracle,
-			config: DefaultConfig(),
+			config: config,
 		},
 
 		sessions:  make(map[types.LayerID]*protocol),
@@ -252,8 +252,7 @@ func (h *RemoteHare) signPub(ctx context.Context, session *session, message *Mes
 		msg.Eligibility = *vrf
 		msg.Sender = session.signers[i].NodeID()
 		msg.Signature = session.signers[i].Sign(signing.HARE, msg.ToMetadata().ToBytes())
-		h.log.Info("publishing hare message", zap.Uint32("layer", session.lid.Uint32()),
-			zap.Stringer("beacon", session.beacon))
+		h.log.Debug("publishing hare message", zap.Stringer("beacon", session.beacon), zap.Inline(&msg))
 		if err := h.svc.Publish(ctx, h.config.ProtocolName, msg.ToBytes()); err != nil {
 			h.log.Error("failed to publish", zap.Inline(&msg), zap.Error(err))
 		}

--- a/miner/proposal_builder.go
+++ b/miner/proposal_builder.go
@@ -499,8 +499,8 @@ func (pb *ProposalBuilder) initSharedData(ctx context.Context, current types.Lay
 	})
 }
 
-func (pb *ProposalBuilder) initSignerData(ctx context.Context, ss *signerSession, lid types.LayerID) error {
-	if err := pb.initSignerSessionData(&ss.session, lid, ss.signer.NodeID()); err != nil {
+func (pb *ProposalBuilder) initSignerData(ctx context.Context, ss *signerSession, targetEpoch types.EpochID) error {
+	if err := pb.initSignerSessionData(&ss.session, targetEpoch, ss.signer.NodeID()); err != nil {
 		return fmt.Errorf("init signer session data: %w", err)
 	}
 	if ss.session.eligibilities.proofs == nil {
@@ -527,11 +527,11 @@ func (pb *ProposalBuilder) initSignerData(ctx context.Context, ss *signerSession
 
 func (pb *ProposalBuilder) initSignerSessionData(
 	s *session,
-	lid types.LayerID,
+	targetEpoch types.EpochID,
 	nodeID types.NodeID,
 ) error {
-	if s.epoch != lid.GetEpoch() {
-		*s = session{epoch: lid.GetEpoch()}
+	if s.epoch != targetEpoch {
+		*s = session{epoch: targetEpoch}
 	}
 	if s.atx == types.EmptyATXID {
 		id, atx := pb.atxsdata.GetByEpochAndNodeID(s.epoch, nodeID)
@@ -560,7 +560,7 @@ func (pb *ProposalBuilder) initSignerSessionData(
 			s.beacon = pb.shared.beacon
 			s.eligibilities.slots = proposals.MustGetNumEligibleSlots(
 				s.atxWeight,
-				minweight.Select(lid.GetEpoch(), pb.cfg.minActiveSetWeight),
+				minweight.Select(targetEpoch, pb.cfg.minActiveSetWeight),
 				pb.shared.active.weight,
 				pb.cfg.layerSize,
 				pb.cfg.layersPerEpoch,
@@ -580,8 +580,21 @@ func (pb *ProposalBuilder) initSignerSessionData(
 func (pb *ProposalBuilder) CalculateEligibilitySlotsFor(
 	ctx context.Context, node types.NodeID, epoch types.EpochID,
 ) (uint32, types.VRFPostIndex, error) {
+	currentLayer := pb.clock.CurrentLayer()
+	if currentLayer.Before(epoch.FirstLayer()) {
+		pb.logger.Warn(
+			"not calculating eligibilities before the epoch starts",
+			zap.Uint32("current layer", currentLayer.Uint32()),
+			zap.Uint32("target epoch 1st layer", epoch.FirstLayer().Uint32()),
+		)
+		return 0, 0, errors.New("target epoch has not started yet")
+	}
+
+	if err := pb.initSharedData(ctx, currentLayer); err != nil {
+		return 0, 0, err
+	}
 	var ss session
-	if err := pb.initSignerSessionData(&ss, epoch.FirstLayer(), node); err != nil {
+	if err := pb.initSignerSessionData(&ss, epoch, node); err != nil {
 		return 0, 0, err
 	}
 	return ss.eligibilities.slots, ss.nonce, nil
@@ -597,7 +610,7 @@ func (pb *ProposalBuilder) BuildFor(ctx context.Context,
 
 	signer := &signerSession{}
 
-	if err := pb.initSignerSessionData(&signer.session, lid, nodeID); err != nil {
+	if err := pb.initSignerSessionData(&signer.session, lid.GetEpoch(), nodeID); err != nil {
 		if errors.Is(err, errAtxNotAvailable) {
 			pb.logger.Debug("smesher doesn't have atx that targets this epoch",
 				log.ZContext(ctx),
@@ -722,7 +735,7 @@ func (pb *ProposalBuilder) build(ctx context.Context, lid types.LayerID) error {
 
 			start := time.Now()
 			ss.latency.start = buildStartTime
-			if err := pb.initSignerData(ctx, ss, lid); err != nil {
+			if err := pb.initSignerData(ctx, ss, lid.GetEpoch()); err != nil {
 				if errors.Is(err, errAtxNotAvailable) {
 					ss.log.Debug("smesher doesn't have atx that targets this epoch",
 						log.ZContext(ctx),

--- a/systest/cluster/cluster.go
+++ b/systest/cluster/cluster.go
@@ -179,7 +179,7 @@ func Default(cctx *testcontext.Context, opts ...Opt) (*Cluster, error) {
 
 	keys := make([]ed25519.PrivateKey, cctx.ClusterSize)
 	for i := range keys {
-		keys[i] = cl.accounts.Private(i)
+		keys[i] = cl.Account(i).PrivateKey
 	}
 
 	if err := cl.AddBootnodes(cctx, cctx.BootnodeSize); err != nil {
@@ -324,18 +324,28 @@ func (c *Cluster) persist(ctx *testcontext.Context) error {
 func (c *Cluster) persistConfigs(ctx *testcontext.Context) error {
 	_, err := ctx.Client.CoreV1().ConfigMaps(ctx.Namespace).Apply(
 		ctx,
-		corev1.ConfigMap(spacemeshConfigMapName, ctx.Namespace).WithData(map[string]string{
+		corev1.ConfigMap(nodeConfigMapName, ctx.Namespace).WithData(map[string]string{
 			attachedSmesherConfig: smesherConfig.Get(ctx.Parameters),
 		}),
 		apimetav1.ApplyOptions{FieldManager: "test"},
 	)
 	if err != nil {
-		return fmt.Errorf("apply cfgmap %v/%v: %w", ctx.Namespace, spacemeshConfigMapName, err)
+		return fmt.Errorf("apply cfgmap %v/%v: %w", ctx.Namespace, nodeConfigMapName, err)
+	}
+	_, err = ctx.Client.CoreV1().ConfigMaps(ctx.Namespace).Apply(
+		ctx,
+		corev1.ConfigMap(nodeServiceConfigMapName, ctx.Namespace).WithData(map[string]string{
+			attachedSmesherConfig: nodeServiceConfig.Get(ctx.Parameters),
+		}),
+		apimetav1.ApplyOptions{FieldManager: "test"},
+	)
+	if err != nil {
+		return fmt.Errorf("apply cfgmap %v/%v: %w", ctx.Namespace, smeshingServiceConfigMapName, err)
 	}
 	_, err = ctx.Client.CoreV1().ConfigMaps(ctx.Namespace).Apply(
 		ctx,
 		corev1.ConfigMap(smeshingServiceConfigMapName, ctx.Namespace).WithData(map[string]string{
-			attachedSmeshingServiceConfig: smeshingServiceConfig.Get(ctx.Parameters),
+			attachedSmesherConfig: smeshingServiceConfig.Get(ctx.Parameters),
 		}),
 		apimetav1.ApplyOptions{FieldManager: "test"},
 	)
@@ -616,6 +626,7 @@ type SmesherDeploymentConfig struct {
 	keys  []ed25519.PrivateKey
 
 	image          string
+	configMap      string
 	noDefaultPoets bool
 }
 
@@ -642,6 +653,12 @@ func WithImage(image string) DeploymentOpt {
 func NoDefaultPoets() DeploymentOpt {
 	return func(cfg *SmesherDeploymentConfig) {
 		cfg.noDefaultPoets = true
+	}
+}
+
+func WithConfigMap(configMap string) DeploymentOpt {
+	return func(cfg *SmesherDeploymentConfig) {
+		cfg.configMap = configMap
 	}
 }
 
@@ -722,6 +739,7 @@ func (c *Cluster) AddSplitNodes(tctx *testcontext.Context, n int, opts ...Deploy
 		WithFlags(flags...),
 		WithFlags(Bootnodes(endpoints...), StartSmeshing(false)),
 		WithSmeshers(keys[:1]),
+		WithConfigMap(nodeServiceConfigMapName),
 	}
 	clients, err := deployNodes(tctx, nodeServiceApp, 0, 1, dopts...)
 	if err != nil {
@@ -743,8 +761,7 @@ func (c *Cluster) AddSplitNodes(tctx *testcontext.Context, n int, opts ...Deploy
 		WithFlags(flags...),
 		WithFlags(StartSmeshing(true)),
 	}
-	clients, err = deploySmeshingServiceNodes(
-		tctx, c.nodeService.Name, keys[1:], dopts...)
+	clients, err = deploySmeshingServiceNodes(tctx, c.nodeService.Name, keys[1:], dopts...)
 	if err != nil {
 		return err
 	}
@@ -857,6 +874,14 @@ func (c *Cluster) Clients() []*NodeClient {
 	return c.clients
 }
 
+func (c *Cluster) NodesConnectedToNetwork() []*NodeClient {
+	var nodes []*NodeClient
+	nodes = append(nodes, c.BootNodes...)
+	nodes = append(nodes, c.SmeshingNodes...)
+	nodes = append(nodes, c.nodeService)
+	return nodes
+}
+
 func (c *Cluster) NodeService() *NodeClient {
 	return c.nodeService
 }
@@ -919,21 +944,13 @@ type accounts struct {
 
 func (a *accounts) Account(i int) Account {
 	return Account{
-		PrivateKey: a.Private(i),
-		Address:    a.Address(i),
+		PrivateKey: a.keys[i].PK,
+		Address:    a.keys[i].Address(),
 	}
 }
 
 func (a *accounts) Accounts() int {
 	return len(a.keys)
-}
-
-func (a *accounts) Private(i int) ed25519.PrivateKey {
-	return a.keys[i].PK
-}
-
-func (a *accounts) Address(i int) types.Address {
-	return a.keys[i].Address()
 }
 
 func (a *accounts) Persist(ctx *testcontext.Context) error {

--- a/systest/cluster/nodes.go
+++ b/systest/cluster/nodes.go
@@ -52,6 +52,11 @@ var (
 		"configuration for smesher nodes",
 		fastnet.SmesherConfig,
 	)
+	nodeServiceConfig = parameters.String(
+		"node_service",
+		"configuration for node service",
+		fastnet.NodeServiceConfig,
+	)
 	smeshingServiceConfig = parameters.String(
 		"smeshing_service",
 		"configuration for smeshing service",
@@ -131,15 +136,15 @@ func toResources(value string) (*apiv1.ResourceRequirements, error) {
 const (
 	configDir = "/etc/config/"
 
-	attachedCertifierConfig       = "certifier.yaml"
-	attachedPoetConfig            = "poet.conf"
-	attachedSmesherConfig         = "smesher.json"
-	attachedSmeshingServiceConfig = "smeshing_service.json"
+	attachedCertifierConfig = "certifier.yaml"
+	attachedPoetConfig      = "poet.conf"
+	attachedSmesherConfig   = "smesher.json"
 
 	certifierConfigMapName       = "certifier"
 	poetConfigMapName            = "poet"
-	spacemeshConfigMapName       = "spacemesh"
+	nodeConfigMapName            = "node"
 	smeshingServiceConfigMapName = "smeshing-service"
+	nodeServiceConfigMapName     = "node-service"
 
 	// smeshers are split in 10 approximately equal buckets
 	// to enable running chaos mesh tasks on the different parts of the cluster.
@@ -705,7 +710,8 @@ func deployNodes(ctx *testcontext.Context, kind string, from, to int, opts ...De
 		eg      errgroup.Group
 		clients = make(chan *NodeClient, to-from)
 		cfg     = SmesherDeploymentConfig{
-			image: ctx.Image,
+			image:     ctx.Image,
+			configMap: nodeConfigMapName,
 		}
 	)
 	for _, opt := range opts {
@@ -746,7 +752,7 @@ func deployNodes(ctx *testcontext.Context, kind string, from, to int, opts ...De
 			id := fmt.Sprintf("%s-%d", kind, i)
 			labels := nodeLabels(kind, id)
 			labels["bucket"] = strconv.Itoa(i % buckets)
-			if err := deployNode(ctx, id, key, cfg.image, "local.key", labels, finalFlags); err != nil {
+			if err := deployNode(ctx, id, key, cfg.image, cfg.configMap, "local.key", labels, finalFlags); err != nil {
 				return err
 			}
 			clients <- &NodeClient{
@@ -795,7 +801,7 @@ func deploySmeshingServiceNodes(
 	if cfg.image == "" {
 		return nil, errors.New("go-spacemesh image must be set")
 	}
-	for i, key := range cfg.keys {
+	for i, key := range keys {
 		finalFlags := make([]DeploymentFlag, len(cfg.flags), len(cfg.flags)+ctx.PoetSize)
 		copy(finalFlags, cfg.flags)
 		if !cfg.noDefaultPoets {
@@ -853,7 +859,8 @@ func deployRemoteNodes(
 		eg      errgroup.Group
 		clients = make(chan *NodeClient, to-from)
 		cfg     = SmesherDeploymentConfig{
-			image: ctx.Image,
+			image:     ctx.Image,
+			configMap: nodeConfigMapName,
 		}
 	)
 	for _, opt := range opts {
@@ -891,7 +898,7 @@ func deployRemoteNodes(
 		eg.Go(func() error {
 			labels := nodeLabels(smesherApp, id)
 			labels["bucket"] = strconv.Itoa(i % buckets)
-			if err := deployNode(ctx, id, key, cfg.image, "remote.key", labels, finalFlags); err != nil {
+			if err := deployNode(ctx, id, key, cfg.image, cfg.configMap, "remote.key", labels, finalFlags); err != nil {
 				return err
 			}
 			deployNodeSvc(ctx, id)
@@ -973,11 +980,10 @@ func deploySmeshingServiceNode(
 	cmd := []string{
 		"/bin/go-spacemesh",
 		"smeshing",
-		"-c=" + configDir + attachedSmeshingServiceConfig,
+		"-c=" + configDir + attachedSmesherConfig,
 		"--pprof-server",
 		"--smeshing-opts-datadir=/data/post",
 		"-d=/data",
-		"--log-encoder=json",
 		"--metrics",
 		"--metrics-port=" + strconv.Itoa(prometheusScrapePort),
 		"--node-service-address", fmt.Sprintf("http://%s:9099", node),
@@ -1077,6 +1083,7 @@ func deployNode(
 	id string,
 	key ed25519.PrivateKey,
 	image string,
+	configMap string,
 	keyName string,
 	labels map[string]string,
 	flags []DeploymentFlag,
@@ -1100,7 +1107,7 @@ func deployNode(
 		WithNodeSelector(ctx.NodeSelector).
 		WithVolumes(
 			corev1.Volume().WithName("config").
-				WithConfigMap(corev1.ConfigMapVolumeSource().WithName(spacemeshConfigMapName)),
+				WithConfigMap(corev1.ConfigMapVolumeSource().WithName(configMap)),
 			corev1.Volume().WithName("data").
 				WithEmptyDir(corev1.EmptyDirVolumeSource().WithSizeLimit(resource.MustParse(ctx.Storage.Size))),
 		).

--- a/systest/parameters/fastnet/embed.go
+++ b/systest/parameters/fastnet/embed.go
@@ -7,6 +7,9 @@ import (
 //go:embed "smesher.json"
 var SmesherConfig string
 
+//go:embed "node_service.json"
+var NodeServiceConfig string
+
 //go:embed "smeshing_service.json"
 var SmeshingServiceConfig string
 

--- a/systest/parameters/fastnet/node_service.json
+++ b/systest/parameters/fastnet/node_service.json
@@ -6,6 +6,7 @@
         }
     },
     "api": {
+        "node-service-listener": "0.0.0.0:9099",
         "grpc-public-listener": "0.0.0.0:9092",
         "grpc-private-listener": "0.0.0.0:9093",
         "grpc-post-listener": "0.0.0.0:9094"
@@ -32,16 +33,10 @@
             "smeshing-opts-verifying-min-workers": 1000000
         }
     },
-    "certifier": {
-        "client": {
-            "max-retries": 10
-        }
-    },
     "logging": {
         "log-encoder": "json",
-        "txHandler": "debug",
-        "grpc": "debug",
-        "sync": "debug",
-        "fetcher": "debug"
+        "nodeService": "debug",
+        "sync": "warn",
+        "fetcher": "warn"
     }
 }

--- a/systest/parameters/fastnet/smeshing_service.json
+++ b/systest/parameters/fastnet/smeshing_service.json
@@ -5,12 +5,6 @@
             "2": 2
         }
     },
-    "poet": {
-        "phase-shift": "30s",
-        "cycle-gap": "30s",
-        "grace-period": "10s",
-        "positioning-atx-selection-timeout":"7s"
-    },
     "api": {
         "grpc-public-listener": "0.0.0.0:9092",
         "grpc-private-listener": "0.0.0.0:9093"
@@ -44,9 +38,8 @@
     },
     "logging": {
         "log-encoder": "json",
-        "txHandler": "debug",
-        "grpc": "debug",
-        "sync": "debug",
-        "fetcher": "debug"
+        "atxBuilder": "debug",
+        "hare": "debug",
+        "hareOracle": "debug"
     }
 }

--- a/systest/tests/common.go
+++ b/systest/tests/common.go
@@ -39,11 +39,13 @@ func sendTransactions(
 	batch, amount int,
 ) error {
 	eg, ctx := errgroup.WithContext(ctx)
+	clients := cl.NodesConnectedToNetwork()
 	for i := range cl.Accounts() {
-		client := cl.Client(i % cl.Total())
-		nonce, err := getNonce(ctx, client, cl.Address(i))
+		client := clients[i%len(clients)]
+		account := cl.Account(i)
+		nonce, err := getNonce(ctx, client, account.Address)
 		if err != nil {
-			return fmt.Errorf("get nonce failed (%s: %s): %w", client.Name, cl.Address(i), err)
+			return fmt.Errorf("get nonce failed (%s: %s): %w", client.Name, account.Address, err)
 		}
 		watchLayers(ctx, eg, client, logger, func(layer *pb.LayerStreamResponse) (bool, error) {
 			if layer.Layer.Number.Number >= stop {
@@ -59,10 +61,10 @@ func sendTransactions(
 			if nonce == 0 {
 				logger.Info("address needs to be spawned",
 					zap.String("client", client.Name),
-					zap.Stringer("address", cl.Address(i)),
+					zap.Stringer("address", account.Address),
 				)
-				if err := submitSpawn(ctx, cl, i, client); err != nil {
-					return false, fmt.Errorf("failed to spawn %w", err)
+				if err := submitSpawn(ctx, cl, account, client); err != nil {
+					return false, fmt.Errorf("failed to spawn: %w", err)
 				}
 				nonce++
 				return true, nil
@@ -70,20 +72,20 @@ func sendTransactions(
 			logger.Debug("submitting transactions",
 				zap.Uint32("layer", layer.Layer.Number.Number),
 				zap.String("client", client.Name),
-				zap.Stringer("address", cl.Address(i)),
+				zap.Stringer("address", account.Address),
 				zap.Uint64("nonce", nonce),
 				zap.Int("batch", batch),
 			)
 			for j := range batch {
 				var err error
 				for range 3 { // retry on failure 3 times
-					err = submitSpend(ctx, cl, i, receiver, uint64(amount), nonce+uint64(j), client)
+					err = submitSpend(ctx, cl, account, receiver, uint64(amount), nonce+uint64(j), client)
 					if err == nil {
 						break
 					}
 					logger.Warn("failed to spend",
 						zap.String("client", client.Name),
-						zap.Stringer("address", cl.Address(i)),
+						zap.Stringer("address", account.Address),
 						zap.Uint64("nonce", nonce+uint64(j)),
 						zap.Error(err),
 					)
@@ -501,11 +503,11 @@ func currentBalance(ctx context.Context, client *cluster.NodeClient, address typ
 	return resp.AccountWrapper.StateCurrent.Balance.Value, nil
 }
 
-func submitSpawn(ctx context.Context, cluster *cluster.Cluster, account int, client *cluster.NodeClient) error {
+func submitSpawn(ctx context.Context, cluster *cluster.Cluster, account cluster.Account, client *cluster.NodeClient) error {
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 	_, err := submitTransaction(ctx,
-		wallet.SelfSpawn(cluster.Private(account), 0, sdk.WithGenesisID(cluster.GenesisID())),
+		wallet.SelfSpawn(account.PrivateKey, 0, sdk.WithGenesisID(cluster.GenesisID())),
 		client,
 	)
 	return err
@@ -514,14 +516,14 @@ func submitSpawn(ctx context.Context, cluster *cluster.Cluster, account int, cli
 func submitSpend(
 	ctx context.Context,
 	cluster *cluster.Cluster,
-	account int,
+	account cluster.Account,
 	receiver types.Address,
 	amount, nonce uint64,
 	client *cluster.NodeClient,
 ) error {
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
-	tx := wallet.Spend(cluster.Private(account), receiver, amount, nonce, sdk.WithGenesisID(cluster.GenesisID()))
+	tx := wallet.Spend(account.PrivateKey, receiver, amount, nonce, sdk.WithGenesisID(cluster.GenesisID()))
 	_, err := submitTransaction(ctx, tx, client)
 	return err
 }

--- a/systest/tests/common.go
+++ b/systest/tests/common.go
@@ -503,7 +503,12 @@ func currentBalance(ctx context.Context, client *cluster.NodeClient, address typ
 	return resp.AccountWrapper.StateCurrent.Balance.Value, nil
 }
 
-func submitSpawn(ctx context.Context, cluster *cluster.Cluster, account cluster.Account, client *cluster.NodeClient) error {
+func submitSpawn(
+	ctx context.Context,
+	cluster *cluster.Cluster,
+	account cluster.Account,
+	client *cluster.NodeClient,
+) error {
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 	_, err := submitTransaction(ctx,


### PR DESCRIPTION
Fix few bugs in the node-split:
- fix hare oracle configuration on the smeshing-service side, which caused the hare messages from smeshing-service not pass the crf checks on the node-service (`node did not pass vrf eligibility threshold` error) ,
- fix nil pointer crash on node-service in `Hare::RoundTemplate()` when the ID is not eligible
- fix crash node-service when calculating eligibilities caused by apparent zero active set weight (sporadic, race)
- fix systests: 
  - tests now actually spawn smeshing-services
  - tests use nodes connected to the network for submitting TXs (instead of the smeshing-service)