### PR TITLE
support proxy and token TXs in API

### DIFF
--- a/api/grpcserver/v2alpha1/account.go
+++ b/api/grpcserver/v2alpha1/account.go
@@ -2,6 +2,7 @@ package v2alpha1
 
 import (
 	"context"
+	"encoding/hex"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	spacemeshv2alpha1 "github.com/spacemeshos/api/release/go/spacemesh/v2alpha1"
@@ -73,11 +74,15 @@ func (s *AccountService) List(
 				Counter: account.NextNonce,
 				Balance: account.Balance,
 				Layer:   account.Layer.Uint32(),
+				Storage: make(map[string][]byte, len(account.Storage)),
 			},
 			Projected: &spacemeshv2alpha1.AccountState{
 				Counter: counterProjected,
 				Balance: balanceProjected,
 			},
+		}
+		for _, kv := range account.Storage {
+			item.Current.Storage[hex.EncodeToString(kv.Key[:])] = kv.Value[:]
 		}
 		if account.TemplateAddress != nil {
 			item.Template = account.TemplateAddress.String()

--- a/api/grpcserver/v2alpha1/transaction.go
+++ b/api/grpcserver/v2alpha1/transaction.go
@@ -27,7 +27,9 @@ import (
 	"github.com/spacemeshos/go-spacemesh/sql/transactions"
 	"github.com/spacemeshos/go-spacemesh/system"
 	"github.com/spacemeshos/go-spacemesh/vm/core"
+	"github.com/spacemeshos/go-spacemesh/vm/templates/mint"
 	"github.com/spacemeshos/go-spacemesh/vm/templates/multisig"
+	tokenwallet "github.com/spacemeshos/go-spacemesh/vm/templates/token_wallet"
 	"github.com/spacemeshos/go-spacemesh/vm/templates/wallet"
 )
 
@@ -451,6 +453,19 @@ func toTxContents(rawTx []byte, header *types.TxHeader) (
 				},
 			}
 			txType = spacemeshv2alpha1.Transaction_TRANSACTION_TYPE_DEPLOY
+		case *wallet.ProxyArgs:
+			contents := &spacemeshv2alpha1.TransactionContents_Proxy{
+				Proxy: &spacemeshv2alpha1.ContentsProxy{
+					Destination: args.Destination.String(),
+					Amount:      args.Amount,
+				},
+			}
+			if args.Method != nil {
+				contents.Proxy.Method = args.Method[:]
+			}
+			res.Contents = contents
+			txType = spacemeshv2alpha1.Transaction_TRANSACTION_TYPE_PROXY
+
 		}
 	case multisig.TemplateAddress:
 		txArgs, err := multisig.ParseArgs(payload)
@@ -485,6 +500,54 @@ func toTxContents(rawTx []byte, header *types.TxHeader) (
 				},
 			}
 			txType = spacemeshv2alpha1.Transaction_TRANSACTION_TYPE_DEPLOY
+		}
+	case mint.TemplateAddress:
+		txArgs, err := mint.ParseArgs(payload)
+		if err != nil {
+			return nil, txType, fmt.Errorf("%w: decoding TX args: %w", core.ErrMalformed, err)
+		}
+		switch args := txArgs.(type) {
+		case *mint.SpawnArguments:
+			res.Contents = &spacemeshv2alpha1.TransactionContents_MintSpawn{
+				MintSpawn: &spacemeshv2alpha1.ContentsMintSpawn{
+					Pubkey:    args.Owner.String(),
+					MaxSupply: args.MaxSupply,
+					Price:     args.Price,
+				},
+			}
+			txType = spacemeshv2alpha1.Transaction_TRANSACTION_TYPE_MINT_SPAWN
+		}
+	case tokenwallet.TemplateAddress:
+		txArgs, err := tokenwallet.ParseArgs(payload)
+		if err != nil {
+			return nil, txType, fmt.Errorf("%w: decoding TX args: %w", core.ErrMalformed, err)
+		}
+		switch args := txArgs.(type) {
+		case *tokenwallet.SpawnArguments:
+			res.Contents = &spacemeshv2alpha1.TransactionContents_TokenWalletSpawn{
+				TokenWalletSpawn: &spacemeshv2alpha1.ContentsTokenWalletSpawn{
+					Pubkey:         args.Owner.String(),
+					MintTemplate:   args.MintTemplate.String(),
+					WalletTemplate: args.WalletTemplate.String(),
+				},
+			}
+			txType = spacemeshv2alpha1.Transaction_TRANSACTION_TYPE_TOKEN_WALLET_SPAWN
+		case *tokenwallet.SendTokenArguments:
+			res.Contents = &spacemeshv2alpha1.TransactionContents_TokenWalletSendToken{
+				TokenWalletSendToken: &spacemeshv2alpha1.ContentsTokenWalletSendToken{
+					Destination: args.To.String(),
+					Amount:      args.Amount,
+					TokenId:     args.TokenId.String(),
+				},
+			}
+			txType = spacemeshv2alpha1.Transaction_TRANSACTION_TYPE_TOKEN_WALLET_SEND_TOKEN
+		case *tokenwallet.SpendArguments:
+			res.Contents = &spacemeshv2alpha1.TransactionContents_Send{
+				Send: &spacemeshv2alpha1.ContentsSend{
+					Destination: args.To.String(),
+					Amount:      args.Amount,
+				},
+			}
 		}
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/seehuhn/mt19937 v1.0.0
 	github.com/slok/go-http-metrics v0.13.0
-	github.com/spacemeshos/api/release/go v1.57.1-0.20241210094511-56be061f5f86
+	github.com/spacemeshos/api/release/go v1.57.1-0.20250129124411-4a935887cbbd
 	github.com/spacemeshos/economics v0.1.4
 	github.com/spacemeshos/fixed v0.1.2
 	github.com/spacemeshos/go-scale v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -644,8 +644,8 @@ github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d/go.mod h1:Udh
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
-github.com/spacemeshos/api/release/go v1.57.1-0.20241210094511-56be061f5f86 h1:cDO/aFNK8OCC13kwVDiU60o4QrKgesg2YiAMnmo79qY=
-github.com/spacemeshos/api/release/go v1.57.1-0.20241210094511-56be061f5f86/go.mod h1:Wfalxn+GgsRX32UTZkPkUX952P1bsGRVnCq1/BNHWJU=
+github.com/spacemeshos/api/release/go v1.57.1-0.20250129124411-4a935887cbbd h1:WeXQdbtsJ1xM1aRage/Jxhu5ZTx5hcYItRcRqL4exNk=
+github.com/spacemeshos/api/release/go v1.57.1-0.20250129124411-4a935887cbbd/go.mod h1:Wfalxn+GgsRX32UTZkPkUX952P1bsGRVnCq1/BNHWJU=
 github.com/spacemeshos/economics v0.1.4 h1:twlawrcQhYNqPgyDv08+24EL/OgUKz3d7q+PvJIAND0=
 github.com/spacemeshos/economics v0.1.4/go.mod h1:6HKWKiKdxjVQcGa2z/wA0LR4M/DzKib856bP16yqNmQ=
 github.com/spacemeshos/fixed v0.1.2 h1:pENQ8pXFAqin3f15ZLoOVVeSgcmcFJ0IFdFm4+9u4SM=

--- a/vm/templates/wallet/methods.go
+++ b/vm/templates/wallet/methods.go
@@ -14,6 +14,7 @@ import (
 type DeployArgs struct {
 	Code []byte
 }
+
 type ProxyArgs struct {
 	Destination types.Address
 	Method      *athcon.MethodSelector


### PR DESCRIPTION
Add support for new transactions in the API:
- mint `spawn()` and `spend()`
- token wallet `spawn()`, `sendToken()` and `spend()`
- singlesig wallet `proxy()` (used to call `mint.buy()`)

As well as expose the account storage in the Accounts API.