### PR TITLE
[Merged by Bors] - sync2: don't log ERRORs upon peer sync failures

### DIFF
--- a/sync2/multipeer/multipeer.go
+++ b/sync2/multipeer/multipeer.go
@@ -349,7 +349,7 @@ func (mpr *MultiPeerReconciler) fullSync(ctx context.Context, syncPeers []p2p.Pe
 			default:
 				// failing to sync against a particular peer is not considered
 				// a fatal sync failure, so we just log the error
-				mpr.logger.Error("error syncing peer", zap.Stringer("peer", p), zap.Error(err))
+				mpr.logger.Debug("error syncing peer", zap.Stringer("peer", p), zap.Error(err))
 			}
 			return nil
 		})


### PR DESCRIPTION
## Motivation

Failing to sync against a particular peer should not be considered a serious error. A error will be logged only if all sync peers fail.

## Description

Reduce error level for single peer sync failure.