### PR TITLE
prepared for 1.0.2

### DIFF
--- a/activation_service_poc/demo/config.testnet-16-smesher-service.json
+++ b/activation_service_poc/demo/config.testnet-16-smesher-service.json
@@ -2,7 +2,7 @@
     "api": {
         "grpc-public-listener": "0.0.0.0:9092",
         "grpc-private-listener": "0.0.0.0:9093",
-        "grpc-local-services": ["smeshing_identities_v2alpha1"]
+        "grpc-local-services": ["smeshing_identities_v2beta1"]
     },
     "cache": {
         "atx-size": 1000

--- a/activation_service_poc/demo/docker-compose-testnet-both-local.yml
+++ b/activation_service_poc/demo/docker-compose-testnet-both-local.yml
@@ -1,8 +1,9 @@
 services:
   activation-service-local-1:
-    image: spacemeshos/go-spacemesh:node-split-poc-1.0.0
+    image: spacemeshos/go-spacemesh:node-split-poc-1.0.2
     command:
       [
+        "smeshing",
         "-c",
         "/config.json",
         "--node-service-address",
@@ -28,9 +29,10 @@ services:
       - spacemesh-net-bl
 
   activation-service-local-2:
-    image: spacemeshos/go-spacemesh:node-split-poc-1.0.0
+    image: spacemeshos/go-spacemesh:node-split-poc-1.0.2
     command:
       [
+        "smeshing",
         "-c",
         "/config.json",
         "--node-service-address",
@@ -56,7 +58,7 @@ services:
       - spacemesh-net-bl
 
   node-service-local:
-    image: spacemeshos/go-spacemesh:node-split-poc-1.0.0
+    image: spacemeshos/go-spacemesh:node-split-poc-1.0.2
     command: [
         "-c",
         "/config.json",

--- a/activation_service_poc/demo/docker-compose-testnet-remote-node.yml
+++ b/activation_service_poc/demo/docker-compose-testnet-remote-node.yml
@@ -1,8 +1,9 @@
 services:
   activation-service-remote-1:
-    image: spacemeshos/go-spacemesh:node-split-poc-1.0.0
+    image: spacemeshos/go-spacemesh:node-split-poc-1.0.2
     command:
       [
+        "smeshing",
         "-c",
         "/config.json",
         "--node-service-address",
@@ -28,9 +29,10 @@ services:
       - 19083:19083
 
   activation-service-remote-2:
-    image: spacemeshos/go-spacemesh:node-split-poc-1.0.0
+    image: spacemeshos/go-spacemesh:node-split-poc-1.0.2
     command:
       [
+        "smeshing",
         "-c",
         "/config.json",
         "--node-service-address",


### PR DESCRIPTION
Prepared for new release.  There are cmd changes so adjusted demos and bumped version to 1.0.2 so we will need to tag again, then when someone checks the code then demo have proper cmd execution.