### PR TITLE
Query weights for Hare by epoch

### DIFF
--- a/api/node/client/client.gen.go
+++ b/api/node/client/client.gen.go
@@ -139,11 +139,11 @@ type ClientInterface interface {
 	// GetHareRoundTemplateLayerIterRound request
 	GetHareRoundTemplateLayerIterRound(ctx context.Context, layer externalRef0.LayerID, iter externalRef0.HareIter, round externalRef0.HareRound, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// GetHareTotalWeightLayer request
-	GetHareTotalWeightLayer(ctx context.Context, layer externalRef0.LayerID, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// GetHareTotalWeightEpoch request
+	GetHareTotalWeightEpoch(ctx context.Context, epoch externalRef0.EpochID, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// GetHareWeightNodeIdLayer request
-	GetHareWeightNodeIdLayer(ctx context.Context, nodeId externalRef0.Bytes32, layer externalRef0.LayerID, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// GetHareWeightNodeIdEpoch request
+	GetHareWeightNodeIdEpoch(ctx context.Context, nodeId externalRef0.Bytes32, epoch externalRef0.EpochID, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetProposalLayerNode request
 	GetProposalLayerNode(ctx context.Context, layer externalRef0.LayerID, node externalRef0.Bytes32, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -248,8 +248,8 @@ func (c *Client) GetHareRoundTemplateLayerIterRound(ctx context.Context, layer e
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetHareTotalWeightLayer(ctx context.Context, layer externalRef0.LayerID, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetHareTotalWeightLayerRequest(c.Server, layer)
+func (c *Client) GetHareTotalWeightEpoch(ctx context.Context, epoch externalRef0.EpochID, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetHareTotalWeightEpochRequest(c.Server, epoch)
 	if err != nil {
 		return nil, err
 	}
@@ -260,8 +260,8 @@ func (c *Client) GetHareTotalWeightLayer(ctx context.Context, layer externalRef0
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetHareWeightNodeIdLayer(ctx context.Context, nodeId externalRef0.Bytes32, layer externalRef0.LayerID, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetHareWeightNodeIdLayerRequest(c.Server, nodeId, layer)
+func (c *Client) GetHareWeightNodeIdEpoch(ctx context.Context, nodeId externalRef0.Bytes32, epoch externalRef0.EpochID, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetHareWeightNodeIdEpochRequest(c.Server, nodeId, epoch)
 	if err != nil {
 		return nil, err
 	}
@@ -561,13 +561,13 @@ func NewGetHareRoundTemplateLayerIterRoundRequest(server string, layer externalR
 	return req, nil
 }
 
-// NewGetHareTotalWeightLayerRequest generates requests for GetHareTotalWeightLayer
-func NewGetHareTotalWeightLayerRequest(server string, layer externalRef0.LayerID) (*http.Request, error) {
+// NewGetHareTotalWeightEpochRequest generates requests for GetHareTotalWeightEpoch
+func NewGetHareTotalWeightEpochRequest(server string, epoch externalRef0.EpochID) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
 
-	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "layer", runtime.ParamLocationPath, layer)
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "epoch", runtime.ParamLocationPath, epoch)
 	if err != nil {
 		return nil, err
 	}
@@ -595,8 +595,8 @@ func NewGetHareTotalWeightLayerRequest(server string, layer externalRef0.LayerID
 	return req, nil
 }
 
-// NewGetHareWeightNodeIdLayerRequest generates requests for GetHareWeightNodeIdLayer
-func NewGetHareWeightNodeIdLayerRequest(server string, nodeId externalRef0.Bytes32, layer externalRef0.LayerID) (*http.Request, error) {
+// NewGetHareWeightNodeIdEpochRequest generates requests for GetHareWeightNodeIdEpoch
+func NewGetHareWeightNodeIdEpochRequest(server string, nodeId externalRef0.Bytes32, epoch externalRef0.EpochID) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -608,7 +608,7 @@ func NewGetHareWeightNodeIdLayerRequest(server string, nodeId externalRef0.Bytes
 
 	var pathParam1 string
 
-	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "layer", runtime.ParamLocationPath, layer)
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "epoch", runtime.ParamLocationPath, epoch)
 	if err != nil {
 		return nil, err
 	}
@@ -779,11 +779,11 @@ type ClientWithResponsesInterface interface {
 	// GetHareRoundTemplateLayerIterRoundWithResponse request
 	GetHareRoundTemplateLayerIterRoundWithResponse(ctx context.Context, layer externalRef0.LayerID, iter externalRef0.HareIter, round externalRef0.HareRound, reqEditors ...RequestEditorFn) (*GetHareRoundTemplateLayerIterRoundResponse, error)
 
-	// GetHareTotalWeightLayerWithResponse request
-	GetHareTotalWeightLayerWithResponse(ctx context.Context, layer externalRef0.LayerID, reqEditors ...RequestEditorFn) (*GetHareTotalWeightLayerResponse, error)
+	// GetHareTotalWeightEpochWithResponse request
+	GetHareTotalWeightEpochWithResponse(ctx context.Context, epoch externalRef0.EpochID, reqEditors ...RequestEditorFn) (*GetHareTotalWeightEpochResponse, error)
 
-	// GetHareWeightNodeIdLayerWithResponse request
-	GetHareWeightNodeIdLayerWithResponse(ctx context.Context, nodeId externalRef0.Bytes32, layer externalRef0.LayerID, reqEditors ...RequestEditorFn) (*GetHareWeightNodeIdLayerResponse, error)
+	// GetHareWeightNodeIdEpochWithResponse request
+	GetHareWeightNodeIdEpochWithResponse(ctx context.Context, nodeId externalRef0.Bytes32, epoch externalRef0.EpochID, reqEditors ...RequestEditorFn) (*GetHareWeightNodeIdEpochResponse, error)
 
 	// GetProposalLayerNodeWithResponse request
 	GetProposalLayerNodeWithResponse(ctx context.Context, layer externalRef0.LayerID, node externalRef0.Bytes32, reqEditors ...RequestEditorFn) (*GetProposalLayerNodeResponse, error)
@@ -952,7 +952,7 @@ func (r GetHareRoundTemplateLayerIterRoundResponse) StatusCode() int {
 	return 0
 }
 
-type GetHareTotalWeightLayerResponse struct {
+type GetHareTotalWeightEpochResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *struct {
@@ -961,7 +961,7 @@ type GetHareTotalWeightLayerResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r GetHareTotalWeightLayerResponse) Status() string {
+func (r GetHareTotalWeightEpochResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -969,14 +969,14 @@ func (r GetHareTotalWeightLayerResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r GetHareTotalWeightLayerResponse) StatusCode() int {
+func (r GetHareTotalWeightEpochResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-type GetHareWeightNodeIdLayerResponse struct {
+type GetHareWeightNodeIdEpochResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *struct {
@@ -985,7 +985,7 @@ type GetHareWeightNodeIdLayerResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r GetHareWeightNodeIdLayerResponse) Status() string {
+func (r GetHareWeightNodeIdEpochResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -993,7 +993,7 @@ func (r GetHareWeightNodeIdLayerResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r GetHareWeightNodeIdLayerResponse) StatusCode() int {
+func (r GetHareWeightNodeIdEpochResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -1114,22 +1114,22 @@ func (c *ClientWithResponses) GetHareRoundTemplateLayerIterRoundWithResponse(ctx
 	return ParseGetHareRoundTemplateLayerIterRoundResponse(rsp)
 }
 
-// GetHareTotalWeightLayerWithResponse request returning *GetHareTotalWeightLayerResponse
-func (c *ClientWithResponses) GetHareTotalWeightLayerWithResponse(ctx context.Context, layer externalRef0.LayerID, reqEditors ...RequestEditorFn) (*GetHareTotalWeightLayerResponse, error) {
-	rsp, err := c.GetHareTotalWeightLayer(ctx, layer, reqEditors...)
+// GetHareTotalWeightEpochWithResponse request returning *GetHareTotalWeightEpochResponse
+func (c *ClientWithResponses) GetHareTotalWeightEpochWithResponse(ctx context.Context, epoch externalRef0.EpochID, reqEditors ...RequestEditorFn) (*GetHareTotalWeightEpochResponse, error) {
+	rsp, err := c.GetHareTotalWeightEpoch(ctx, epoch, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseGetHareTotalWeightLayerResponse(rsp)
+	return ParseGetHareTotalWeightEpochResponse(rsp)
 }
 
-// GetHareWeightNodeIdLayerWithResponse request returning *GetHareWeightNodeIdLayerResponse
-func (c *ClientWithResponses) GetHareWeightNodeIdLayerWithResponse(ctx context.Context, nodeId externalRef0.Bytes32, layer externalRef0.LayerID, reqEditors ...RequestEditorFn) (*GetHareWeightNodeIdLayerResponse, error) {
-	rsp, err := c.GetHareWeightNodeIdLayer(ctx, nodeId, layer, reqEditors...)
+// GetHareWeightNodeIdEpochWithResponse request returning *GetHareWeightNodeIdEpochResponse
+func (c *ClientWithResponses) GetHareWeightNodeIdEpochWithResponse(ctx context.Context, nodeId externalRef0.Bytes32, epoch externalRef0.EpochID, reqEditors ...RequestEditorFn) (*GetHareWeightNodeIdEpochResponse, error) {
+	rsp, err := c.GetHareWeightNodeIdEpoch(ctx, nodeId, epoch, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseGetHareWeightNodeIdLayerResponse(rsp)
+	return ParseGetHareWeightNodeIdEpochResponse(rsp)
 }
 
 // GetProposalLayerNodeWithResponse request returning *GetProposalLayerNodeResponse
@@ -1329,15 +1329,15 @@ func ParseGetHareRoundTemplateLayerIterRoundResponse(rsp *http.Response) (*GetHa
 	return response, nil
 }
 
-// ParseGetHareTotalWeightLayerResponse parses an HTTP response from a GetHareTotalWeightLayerWithResponse call
-func ParseGetHareTotalWeightLayerResponse(rsp *http.Response) (*GetHareTotalWeightLayerResponse, error) {
+// ParseGetHareTotalWeightEpochResponse parses an HTTP response from a GetHareTotalWeightEpochWithResponse call
+func ParseGetHareTotalWeightEpochResponse(rsp *http.Response) (*GetHareTotalWeightEpochResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &GetHareTotalWeightLayerResponse{
+	response := &GetHareTotalWeightEpochResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -1357,15 +1357,15 @@ func ParseGetHareTotalWeightLayerResponse(rsp *http.Response) (*GetHareTotalWeig
 	return response, nil
 }
 
-// ParseGetHareWeightNodeIdLayerResponse parses an HTTP response from a GetHareWeightNodeIdLayerWithResponse call
-func ParseGetHareWeightNodeIdLayerResponse(rsp *http.Response) (*GetHareWeightNodeIdLayerResponse, error) {
+// ParseGetHareWeightNodeIdEpochResponse parses an HTTP response from a GetHareWeightNodeIdEpochWithResponse call
+func ParseGetHareWeightNodeIdEpochResponse(rsp *http.Response) (*GetHareWeightNodeIdEpochResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &GetHareWeightNodeIdLayerResponse{
+	response := &GetHareWeightNodeIdEpochResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}

--- a/api/node/client/client.go
+++ b/api/node/client/client.go
@@ -185,8 +185,8 @@ func (s *NodeService) HareRoundTemplate(
 	}
 }
 
-func (s *NodeService) TotalWeight(ctx context.Context, layer types.LayerID) (uint64, error) {
-	resp, err := s.client.GetHareTotalWeightLayerWithResponse(ctx, layer.Uint32())
+func (s *NodeService) TotalWeight(ctx context.Context, epoch types.EpochID) (uint64, error) {
+	resp, err := s.client.GetHareTotalWeightEpochWithResponse(ctx, epoch.Uint32())
 	if err != nil {
 		return 0, fmt.Errorf("get total weight: %w", err)
 	}
@@ -198,8 +198,8 @@ func (s *NodeService) TotalWeight(ctx context.Context, layer types.LayerID) (uin
 	}
 }
 
-func (s *NodeService) MinerWeight(ctx context.Context, layer types.LayerID, node types.NodeID) (uint64, error) {
-	resp, err := s.client.GetHareWeightNodeIdLayerWithResponse(ctx, node.Bytes(), layer.Uint32())
+func (s *NodeService) MinerWeight(ctx context.Context, epoch types.EpochID, node types.NodeID) (uint64, error) {
+	resp, err := s.client.GetHareWeightNodeIdEpochWithResponse(ctx, node.Bytes(), epoch.Uint32())
 	if err != nil {
 		return 0, fmt.Errorf("get miner weight: %w", err)
 	}

--- a/api/node/client/client_e2e_test.go
+++ b/api/node/client/client_e2e_test.go
@@ -204,14 +204,14 @@ func Test_Hare(t *testing.T) {
 	svc, mock := setupE2E(t)
 	t.Run("total weight", func(t *testing.T) {
 		val := uint64(11)
-		mock.hare.EXPECT().TotalWeight(gomock.Any(), gomock.Any()).Return(val, nil)
+		mock.hare.EXPECT().TotalWeight(gomock.Any(), types.EpochID(112)).Return(val, nil)
 		v, err := svc.TotalWeight(context.Background(), 112)
 		require.NoError(t, err)
 		require.Equal(t, v, val)
 	})
 	t.Run("miner weight", func(t *testing.T) {
 		val := uint64(101)
-		mock.hare.EXPECT().MinerWeight(gomock.Any(), gomock.Any(), gomock.Any()).Return(val, nil)
+		mock.hare.EXPECT().MinerWeight(gomock.Any(), gomock.Any(), types.EpochID(113)).Return(val, nil)
 		v, err := svc.MinerWeight(context.Background(), 113, types.NodeID{})
 		require.NoError(t, err)
 		require.Equal(t, v, val)

--- a/api/node/node_service.yaml
+++ b/api/node/node_service.yaml
@@ -167,17 +167,17 @@ paths:
                 $ref: "models/components.yaml#/components/schemas/HareRoundTemplate"
         "204":
           description: did not find a message to retrieve
-  /hare/total_weight/{layer}:
+  /hare/total_weight/{epoch}:
     get:
-      summary: Get the total weight for layer
+      summary: Get the total weight for epoch
       tags:
         - "hare"
       parameters:
         - in: path
-          name: layer
+          name: epoch
           required: true
           schema:
-            $ref: "models/components.yaml#/components/schemas/LayerID"
+            $ref: "models/components.yaml#/components/schemas/EpochID"
       responses:
         "200":
           description: successfully found the total weight
@@ -193,9 +193,9 @@ paths:
                   - weight
         "204":
           description: did not find a message to retrieve
-  /hare/weight/{node_id}/{layer}:
+  /hare/weight/{node_id}/{epoch}:
     get:
-      summary: Get the miner weight in layer
+      summary: Get the miner weight in epoch
       tags:
         - "hare"
       parameters:
@@ -205,10 +205,10 @@ paths:
           schema:
             $ref: "models/components.yaml#/components/schemas/Bytes32"
         - in: path
-          name: layer
+          name: epoch
           required: true
           schema:
-            $ref: "models/components.yaml#/components/schemas/LayerID"
+            $ref: "models/components.yaml#/components/schemas/EpochID"
       responses:
         "200":
           description: successfully found the miner's weight

--- a/api/node/server/mocks.go
+++ b/api/node/server/mocks.go
@@ -168,18 +168,18 @@ func (m *Mockhare) EXPECT() *MockhareMockRecorder {
 }
 
 // MinerWeight mocks base method.
-func (m *Mockhare) MinerWeight(ctx context.Context, node types.NodeID, layer types.LayerID) (uint64, error) {
+func (m *Mockhare) MinerWeight(ctx context.Context, node types.NodeID, epoch types.EpochID) (uint64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MinerWeight", ctx, node, layer)
+	ret := m.ctrl.Call(m, "MinerWeight", ctx, node, epoch)
 	ret0, _ := ret[0].(uint64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // MinerWeight indicates an expected call of MinerWeight.
-func (mr *MockhareMockRecorder) MinerWeight(ctx, node, layer any) *MockhareMinerWeightCall {
+func (mr *MockhareMockRecorder) MinerWeight(ctx, node, epoch any) *MockhareMinerWeightCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MinerWeight", reflect.TypeOf((*Mockhare)(nil).MinerWeight), ctx, node, layer)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MinerWeight", reflect.TypeOf((*Mockhare)(nil).MinerWeight), ctx, node, epoch)
 	return &MockhareMinerWeightCall{Call: call}
 }
 
@@ -195,13 +195,13 @@ func (c *MockhareMinerWeightCall) Return(arg0 uint64, arg1 error) *MockhareMiner
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockhareMinerWeightCall) Do(f func(context.Context, types.NodeID, types.LayerID) (uint64, error)) *MockhareMinerWeightCall {
+func (c *MockhareMinerWeightCall) Do(f func(context.Context, types.NodeID, types.EpochID) (uint64, error)) *MockhareMinerWeightCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockhareMinerWeightCall) DoAndReturn(f func(context.Context, types.NodeID, types.LayerID) (uint64, error)) *MockhareMinerWeightCall {
+func (c *MockhareMinerWeightCall) DoAndReturn(f func(context.Context, types.NodeID, types.EpochID) (uint64, error)) *MockhareMinerWeightCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -245,18 +245,18 @@ func (c *MockhareRoundTemplateCall) DoAndReturn(f func(types.LayerID, hare3.Iter
 }
 
 // TotalWeight mocks base method.
-func (m *Mockhare) TotalWeight(ctx context.Context, layer types.LayerID) (uint64, error) {
+func (m *Mockhare) TotalWeight(ctx context.Context, epoch types.EpochID) (uint64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TotalWeight", ctx, layer)
+	ret := m.ctrl.Call(m, "TotalWeight", ctx, epoch)
 	ret0, _ := ret[0].(uint64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // TotalWeight indicates an expected call of TotalWeight.
-func (mr *MockhareMockRecorder) TotalWeight(ctx, layer any) *MockhareTotalWeightCall {
+func (mr *MockhareMockRecorder) TotalWeight(ctx, epoch any) *MockhareTotalWeightCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TotalWeight", reflect.TypeOf((*Mockhare)(nil).TotalWeight), ctx, layer)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TotalWeight", reflect.TypeOf((*Mockhare)(nil).TotalWeight), ctx, epoch)
 	return &MockhareTotalWeightCall{Call: call}
 }
 
@@ -272,13 +272,13 @@ func (c *MockhareTotalWeightCall) Return(arg0 uint64, arg1 error) *MockhareTotal
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockhareTotalWeightCall) Do(f func(context.Context, types.LayerID) (uint64, error)) *MockhareTotalWeightCall {
+func (c *MockhareTotalWeightCall) Do(f func(context.Context, types.EpochID) (uint64, error)) *MockhareTotalWeightCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockhareTotalWeightCall) DoAndReturn(f func(context.Context, types.LayerID) (uint64, error)) *MockhareTotalWeightCall {
+func (c *MockhareTotalWeightCall) DoAndReturn(f func(context.Context, types.EpochID) (uint64, error)) *MockhareTotalWeightCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/api/node/server/server.gen.go
+++ b/api/node/server/server.gen.go
@@ -66,12 +66,12 @@ type ServerInterface interface {
 	// Get a hare message to sign
 	// (GET /hare/round_template/{layer}/{iter}/{round})
 	GetHareRoundTemplateLayerIterRound(w http.ResponseWriter, r *http.Request, layer externalRef0.LayerID, iter externalRef0.HareIter, round externalRef0.HareRound)
-	// Get the total weight for layer
-	// (GET /hare/total_weight/{layer})
-	GetHareTotalWeightLayer(w http.ResponseWriter, r *http.Request, layer externalRef0.LayerID)
-	// Get the miner weight in layer
-	// (GET /hare/weight/{node_id}/{layer})
-	GetHareWeightNodeIdLayer(w http.ResponseWriter, r *http.Request, nodeId externalRef0.Bytes32, layer externalRef0.LayerID)
+	// Get the total weight for epoch
+	// (GET /hare/total_weight/{epoch})
+	GetHareTotalWeightEpoch(w http.ResponseWriter, r *http.Request, epoch externalRef0.EpochID)
+	// Get the miner weight in epoch
+	// (GET /hare/weight/{node_id}/{epoch})
+	GetHareWeightNodeIdEpoch(w http.ResponseWriter, r *http.Request, nodeId externalRef0.Bytes32, epoch externalRef0.EpochID)
 	// Get a partial proposal for a given node in a layer
 	// (GET /proposal/{layer}/{node})
 	GetProposalLayerNode(w http.ResponseWriter, r *http.Request, layer externalRef0.LayerID, node externalRef0.Bytes32)
@@ -280,22 +280,22 @@ func (siw *ServerInterfaceWrapper) GetHareRoundTemplateLayerIterRound(w http.Res
 	handler.ServeHTTP(w, r)
 }
 
-// GetHareTotalWeightLayer operation middleware
-func (siw *ServerInterfaceWrapper) GetHareTotalWeightLayer(w http.ResponseWriter, r *http.Request) {
+// GetHareTotalWeightEpoch operation middleware
+func (siw *ServerInterfaceWrapper) GetHareTotalWeightEpoch(w http.ResponseWriter, r *http.Request) {
 
 	var err error
 
-	// ------------- Path parameter "layer" -------------
-	var layer externalRef0.LayerID
+	// ------------- Path parameter "epoch" -------------
+	var epoch externalRef0.EpochID
 
-	err = runtime.BindStyledParameterWithOptions("simple", "layer", r.PathValue("layer"), &layer, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	err = runtime.BindStyledParameterWithOptions("simple", "epoch", r.PathValue("epoch"), &epoch, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
 	if err != nil {
-		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "layer", Err: err})
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "epoch", Err: err})
 		return
 	}
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.GetHareTotalWeightLayer(w, r, layer)
+		siw.Handler.GetHareTotalWeightEpoch(w, r, epoch)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -305,8 +305,8 @@ func (siw *ServerInterfaceWrapper) GetHareTotalWeightLayer(w http.ResponseWriter
 	handler.ServeHTTP(w, r)
 }
 
-// GetHareWeightNodeIdLayer operation middleware
-func (siw *ServerInterfaceWrapper) GetHareWeightNodeIdLayer(w http.ResponseWriter, r *http.Request) {
+// GetHareWeightNodeIdEpoch operation middleware
+func (siw *ServerInterfaceWrapper) GetHareWeightNodeIdEpoch(w http.ResponseWriter, r *http.Request) {
 
 	var err error
 
@@ -319,17 +319,17 @@ func (siw *ServerInterfaceWrapper) GetHareWeightNodeIdLayer(w http.ResponseWrite
 		return
 	}
 
-	// ------------- Path parameter "layer" -------------
-	var layer externalRef0.LayerID
+	// ------------- Path parameter "epoch" -------------
+	var epoch externalRef0.EpochID
 
-	err = runtime.BindStyledParameterWithOptions("simple", "layer", r.PathValue("layer"), &layer, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	err = runtime.BindStyledParameterWithOptions("simple", "epoch", r.PathValue("epoch"), &epoch, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
 	if err != nil {
-		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "layer", Err: err})
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "epoch", Err: err})
 		return
 	}
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.GetHareWeightNodeIdLayer(w, r, nodeId, layer)
+		siw.Handler.GetHareWeightNodeIdEpoch(w, r, nodeId, epoch)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -525,8 +525,8 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 	m.HandleFunc("GET "+options.BaseURL+"/eligibility/slots/{node}/{epoch}", wrapper.GetEligibilitySlotsNodeEpoch)
 	m.HandleFunc("GET "+options.BaseURL+"/hare/beacon/{epoch}", wrapper.GetHareBeaconEpoch)
 	m.HandleFunc("GET "+options.BaseURL+"/hare/round_template/{layer}/{iter}/{round}", wrapper.GetHareRoundTemplateLayerIterRound)
-	m.HandleFunc("GET "+options.BaseURL+"/hare/total_weight/{layer}", wrapper.GetHareTotalWeightLayer)
-	m.HandleFunc("GET "+options.BaseURL+"/hare/weight/{node_id}/{layer}", wrapper.GetHareWeightNodeIdLayer)
+	m.HandleFunc("GET "+options.BaseURL+"/hare/total_weight/{epoch}", wrapper.GetHareTotalWeightEpoch)
+	m.HandleFunc("GET "+options.BaseURL+"/hare/weight/{node_id}/{epoch}", wrapper.GetHareWeightNodeIdEpoch)
 	m.HandleFunc("GET "+options.BaseURL+"/proposal/{layer}/{node}", wrapper.GetProposalLayerNode)
 	m.HandleFunc("POST "+options.BaseURL+"/publish/{protocol}", wrapper.PostPublishProtocol)
 
@@ -777,67 +777,67 @@ func (response GetHareRoundTemplateLayerIterRound204Response) VisitGetHareRoundT
 	return nil
 }
 
-type GetHareTotalWeightLayerRequestObject struct {
-	Layer externalRef0.LayerID `json:"layer"`
+type GetHareTotalWeightEpochRequestObject struct {
+	Epoch externalRef0.EpochID `json:"epoch"`
 }
 
-type GetHareTotalWeightLayerResponseObject interface {
-	VisitGetHareTotalWeightLayerResponse(w http.ResponseWriter) error
+type GetHareTotalWeightEpochResponseObject interface {
+	VisitGetHareTotalWeightEpochResponse(w http.ResponseWriter) error
 }
 
-type GetHareTotalWeightLayer200JSONResponse struct {
+type GetHareTotalWeightEpoch200JSONResponse struct {
 	Weight uint64 `json:"weight"`
 }
 
-func (response GetHareTotalWeightLayer200JSONResponse) VisitGetHareTotalWeightLayerResponse(w http.ResponseWriter) error {
+func (response GetHareTotalWeightEpoch200JSONResponse) VisitGetHareTotalWeightEpochResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
 
 	return json.NewEncoder(w).Encode(response)
 }
 
-type GetHareTotalWeightLayer204Response struct {
+type GetHareTotalWeightEpoch204Response struct {
 }
 
-func (response GetHareTotalWeightLayer204Response) VisitGetHareTotalWeightLayerResponse(w http.ResponseWriter) error {
+func (response GetHareTotalWeightEpoch204Response) VisitGetHareTotalWeightEpochResponse(w http.ResponseWriter) error {
 	w.WriteHeader(204)
 	return nil
 }
 
-type GetHareWeightNodeIdLayerRequestObject struct {
+type GetHareWeightNodeIdEpochRequestObject struct {
 	NodeId externalRef0.Bytes32 `json:"node_id"`
-	Layer  externalRef0.LayerID `json:"layer"`
+	Epoch  externalRef0.EpochID `json:"epoch"`
 }
 
-type GetHareWeightNodeIdLayerResponseObject interface {
-	VisitGetHareWeightNodeIdLayerResponse(w http.ResponseWriter) error
+type GetHareWeightNodeIdEpochResponseObject interface {
+	VisitGetHareWeightNodeIdEpochResponse(w http.ResponseWriter) error
 }
 
-type GetHareWeightNodeIdLayer200JSONResponse struct {
+type GetHareWeightNodeIdEpoch200JSONResponse struct {
 	Weight uint64 `json:"weight"`
 }
 
-func (response GetHareWeightNodeIdLayer200JSONResponse) VisitGetHareWeightNodeIdLayerResponse(w http.ResponseWriter) error {
+func (response GetHareWeightNodeIdEpoch200JSONResponse) VisitGetHareWeightNodeIdEpochResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
 
 	return json.NewEncoder(w).Encode(response)
 }
 
-type GetHareWeightNodeIdLayer204Response struct {
+type GetHareWeightNodeIdEpoch204Response struct {
 }
 
-func (response GetHareWeightNodeIdLayer204Response) VisitGetHareWeightNodeIdLayerResponse(w http.ResponseWriter) error {
+func (response GetHareWeightNodeIdEpoch204Response) VisitGetHareWeightNodeIdEpochResponse(w http.ResponseWriter) error {
 	w.WriteHeader(204)
 	return nil
 }
 
-type GetHareWeightNodeIdLayer400PlaintextResponse struct {
+type GetHareWeightNodeIdEpoch400PlaintextResponse struct {
 	Body          io.Reader
 	ContentLength int64
 }
 
-func (response GetHareWeightNodeIdLayer400PlaintextResponse) VisitGetHareWeightNodeIdLayerResponse(w http.ResponseWriter) error {
+func (response GetHareWeightNodeIdEpoch400PlaintextResponse) VisitGetHareWeightNodeIdEpochResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "plain/text")
 	if response.ContentLength != 0 {
 		w.Header().Set("Content-Length", fmt.Sprint(response.ContentLength))
@@ -944,12 +944,12 @@ type StrictServerInterface interface {
 	// Get a hare message to sign
 	// (GET /hare/round_template/{layer}/{iter}/{round})
 	GetHareRoundTemplateLayerIterRound(ctx context.Context, request GetHareRoundTemplateLayerIterRoundRequestObject) (GetHareRoundTemplateLayerIterRoundResponseObject, error)
-	// Get the total weight for layer
-	// (GET /hare/total_weight/{layer})
-	GetHareTotalWeightLayer(ctx context.Context, request GetHareTotalWeightLayerRequestObject) (GetHareTotalWeightLayerResponseObject, error)
-	// Get the miner weight in layer
-	// (GET /hare/weight/{node_id}/{layer})
-	GetHareWeightNodeIdLayer(ctx context.Context, request GetHareWeightNodeIdLayerRequestObject) (GetHareWeightNodeIdLayerResponseObject, error)
+	// Get the total weight for epoch
+	// (GET /hare/total_weight/{epoch})
+	GetHareTotalWeightEpoch(ctx context.Context, request GetHareTotalWeightEpochRequestObject) (GetHareTotalWeightEpochResponseObject, error)
+	// Get the miner weight in epoch
+	// (GET /hare/weight/{node_id}/{epoch})
+	GetHareWeightNodeIdEpoch(ctx context.Context, request GetHareWeightNodeIdEpochRequestObject) (GetHareWeightNodeIdEpochResponseObject, error)
 	// Get a partial proposal for a given node in a layer
 	// (GET /proposal/{layer}/{node})
 	GetProposalLayerNode(ctx context.Context, request GetProposalLayerNodeRequestObject) (GetProposalLayerNodeResponseObject, error)
@@ -1177,25 +1177,25 @@ func (sh *strictHandler) GetHareRoundTemplateLayerIterRound(w http.ResponseWrite
 	}
 }
 
-// GetHareTotalWeightLayer operation middleware
-func (sh *strictHandler) GetHareTotalWeightLayer(w http.ResponseWriter, r *http.Request, layer externalRef0.LayerID) {
-	var request GetHareTotalWeightLayerRequestObject
+// GetHareTotalWeightEpoch operation middleware
+func (sh *strictHandler) GetHareTotalWeightEpoch(w http.ResponseWriter, r *http.Request, epoch externalRef0.EpochID) {
+	var request GetHareTotalWeightEpochRequestObject
 
-	request.Layer = layer
+	request.Epoch = epoch
 
 	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
-		return sh.ssi.GetHareTotalWeightLayer(ctx, request.(GetHareTotalWeightLayerRequestObject))
+		return sh.ssi.GetHareTotalWeightEpoch(ctx, request.(GetHareTotalWeightEpochRequestObject))
 	}
 	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "GetHareTotalWeightLayer")
+		handler = middleware(handler, "GetHareTotalWeightEpoch")
 	}
 
 	response, err := handler(r.Context(), w, r, request)
 
 	if err != nil {
 		sh.options.ResponseErrorHandlerFunc(w, r, err)
-	} else if validResponse, ok := response.(GetHareTotalWeightLayerResponseObject); ok {
-		if err := validResponse.VisitGetHareTotalWeightLayerResponse(w); err != nil {
+	} else if validResponse, ok := response.(GetHareTotalWeightEpochResponseObject); ok {
+		if err := validResponse.VisitGetHareTotalWeightEpochResponse(w); err != nil {
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {
@@ -1203,26 +1203,26 @@ func (sh *strictHandler) GetHareTotalWeightLayer(w http.ResponseWriter, r *http.
 	}
 }
 
-// GetHareWeightNodeIdLayer operation middleware
-func (sh *strictHandler) GetHareWeightNodeIdLayer(w http.ResponseWriter, r *http.Request, nodeId externalRef0.Bytes32, layer externalRef0.LayerID) {
-	var request GetHareWeightNodeIdLayerRequestObject
+// GetHareWeightNodeIdEpoch operation middleware
+func (sh *strictHandler) GetHareWeightNodeIdEpoch(w http.ResponseWriter, r *http.Request, nodeId externalRef0.Bytes32, epoch externalRef0.EpochID) {
+	var request GetHareWeightNodeIdEpochRequestObject
 
 	request.NodeId = nodeId
-	request.Layer = layer
+	request.Epoch = epoch
 
 	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
-		return sh.ssi.GetHareWeightNodeIdLayer(ctx, request.(GetHareWeightNodeIdLayerRequestObject))
+		return sh.ssi.GetHareWeightNodeIdEpoch(ctx, request.(GetHareWeightNodeIdEpochRequestObject))
 	}
 	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "GetHareWeightNodeIdLayer")
+		handler = middleware(handler, "GetHareWeightNodeIdEpoch")
 	}
 
 	response, err := handler(r.Context(), w, r, request)
 
 	if err != nil {
 		sh.options.ResponseErrorHandlerFunc(w, r, err)
-	} else if validResponse, ok := response.(GetHareWeightNodeIdLayerResponseObject); ok {
-		if err := validResponse.VisitGetHareWeightNodeIdLayerResponse(w); err != nil {
+	} else if validResponse, ok := response.(GetHareWeightNodeIdEpochResponseObject); ok {
+		if err := validResponse.VisitGetHareWeightNodeIdEpochResponse(w); err != nil {
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {

--- a/api/node/server/server.go
+++ b/api/node/server/server.go
@@ -33,8 +33,8 @@ type beaconService interface {
 
 type hare interface {
 	RoundTemplate(layer types.LayerID, round hare3.IterRound) *hare3.Body
-	TotalWeight(ctx context.Context, layer types.LayerID) (uint64, error)
-	MinerWeight(ctx context.Context, node types.NodeID, layer types.LayerID) (uint64, error)
+	TotalWeight(ctx context.Context, epoch types.EpochID) (uint64, error)
+	MinerWeight(ctx context.Context, node types.NodeID, epoch types.EpochID) (uint64, error)
 }
 
 type proposalBuilder interface {
@@ -272,35 +272,35 @@ func (s *Server) GetHareRoundTemplateLayerIterRound(ctx context.Context,
 	return resp, nil
 }
 
-func (s *Server) GetHareTotalWeightLayer(ctx context.Context,
-	req GetHareTotalWeightLayerRequestObject,
-) (GetHareTotalWeightLayerResponseObject, error) {
-	weight, err := s.hare.TotalWeight(ctx, types.LayerID(req.Layer))
+func (s *Server) GetHareTotalWeightEpoch(ctx context.Context,
+	req GetHareTotalWeightEpochRequestObject,
+) (GetHareTotalWeightEpochResponseObject, error) {
+	weight, err := s.hare.TotalWeight(ctx, types.EpochID(req.Epoch))
 	if err != nil {
 		return nil, err
 	}
-	return &GetHareTotalWeightLayer200JSONResponse{Weight: weight}, nil
+	return &GetHareTotalWeightEpoch200JSONResponse{Weight: weight}, nil
 }
 
-func (s *Server) GetHareWeightNodeIdLayer(ctx context.Context,
-	request GetHareWeightNodeIdLayerRequestObject,
-) (GetHareWeightNodeIdLayerResponseObject, error) {
+func (s *Server) GetHareWeightNodeIdEpoch(ctx context.Context,
+	request GetHareWeightNodeIdEpochRequestObject,
+) (GetHareWeightNodeIdEpochResponseObject, error) {
 	id, err := models.ParseNodeID(request.NodeId)
 	if err != nil {
 		msg := err.Error()
-		return GetHareWeightNodeIdLayer400PlaintextResponse{
+		return GetHareWeightNodeIdEpoch400PlaintextResponse{
 			Body:          bytes.NewBuffer([]byte(msg)),
 			ContentLength: int64(len(msg)),
 		}, nil
 	}
-	weight, err := s.hare.MinerWeight(ctx, id, types.LayerID(request.Layer))
+	weight, err := s.hare.MinerWeight(ctx, id, types.EpochID(request.Epoch))
 	if err != nil {
 		if errors.Is(err, eligibility.ErrNotActive) {
-			return &GetHareWeightNodeIdLayer200JSONResponse{Weight: 0}, nil
+			return &GetHareWeightNodeIdEpoch200JSONResponse{Weight: 0}, nil
 		}
 		return nil, fmt.Errorf("miner weight: %w", err)
 	}
-	return &GetHareWeightNodeIdLayer200JSONResponse{Weight: weight}, nil
+	return &GetHareWeightNodeIdEpoch200JSONResponse{Weight: weight}, nil
 }
 
 func (s *Server) GetHareBeaconEpoch(ctx context.Context,

--- a/hare3/eligibility/oracle.go
+++ b/hare3/eligibility/oracle.go
@@ -97,20 +97,20 @@ type Oracle struct {
 	db            sql.Executor
 	vrfVerifier   vrfVerifier
 	cfg           Config
-	minerWeightFn func(ctx context.Context, layer types.LayerID, id types.NodeID) (uint64, error)
-	totalWeightFn func(ctx context.Context, layer types.LayerID) (uint64, error)
+	minerWeightFn func(context.Context, types.EpochID, types.NodeID) (uint64, error)
+	totalWeightFn func(context.Context, types.EpochID) (uint64, error)
 	log           *zap.Logger
 }
 
 type Opt func(*Oracle)
 
-func WithMinerWeightFunc(f func(ctx context.Context, layer types.LayerID, id types.NodeID) (uint64, error)) Opt {
+func WithMinerWeightFunc(f func(context.Context, types.EpochID, types.NodeID) (uint64, error)) Opt {
 	return func(o *Oracle) {
 		o.minerWeightFn = f
 	}
 }
 
-func WithTotalWeightFunc(f func(ctx context.Context, layer types.LayerID) (uint64, error)) Opt {
+func WithTotalWeightFunc(f func(context.Context, types.EpochID) (uint64, error)) Opt {
 	return func(o *Oracle) {
 		o.totalWeightFn = f
 	}
@@ -205,16 +205,16 @@ func (o *Oracle) buildVRFMessage(ctx context.Context, layer types.LayerID, round
 	return codec.MustEncode(&VrfMessage{Type: types.EligibilityHare, Beacon: beacon, Round: round, Layer: layer}), nil
 }
 
-func (o *Oracle) totalWeight(ctx context.Context, layer types.LayerID) (uint64, error) {
-	actives, err := o.actives(ctx, o.layerToEpoch(layer))
+func (o *Oracle) totalWeight(ctx context.Context, epoch types.EpochID) (uint64, error) {
+	actives, err := o.actives(ctx, epoch)
 	if err != nil {
 		return 0, err
 	}
 	return actives.total, nil
 }
 
-func (o *Oracle) minerWeight(ctx context.Context, layer types.LayerID, id types.NodeID) (uint64, error) {
-	actives, err := o.actives(ctx, o.layerToEpoch(layer))
+func (o *Oracle) minerWeight(ctx context.Context, epoch types.EpochID, id types.NodeID) (uint64, error) {
+	actives, err := o.actives(ctx, epoch)
 	if err != nil {
 		return 0, err
 	}
@@ -254,7 +254,7 @@ func (o *Oracle) prepareEligibilityCheck(
 
 	// calc hash & check threshold
 	// this is cheap in case the node is not eligible
-	minerWeight, err := o.minerWeightFn(ctx, layer, id)
+	minerWeight, err := o.minerWeightFn(ctx, o.layerToEpoch(layer), id)
 	if err != nil {
 		return 0, fixed.Fixed{}, fixed.Fixed{}, true, err
 	}
@@ -272,7 +272,7 @@ func (o *Oracle) prepareEligibilityCheck(
 	}
 
 	// get active set size
-	totalWeight, err := o.totalWeightFn(ctx, layer)
+	totalWeight, err := o.totalWeightFn(ctx, o.layerToEpoch(layer))
 	if err != nil {
 		logger.Error("failed to get total weight", zap.Error(err))
 		return 0, fixed.Fixed{}, fixed.Fixed{}, true, err
@@ -554,10 +554,10 @@ func (o *Oracle) UpdateActiveSet(epoch types.EpochID, activeSet []types.ATXID) {
 	o.fallback[epoch] = activeSet
 }
 
-func (o *Oracle) TotalWeight(ctx context.Context, layer types.LayerID) (uint64, error) {
-	return o.totalWeightFn(ctx, layer)
+func (o *Oracle) TotalWeight(ctx context.Context, epoch types.EpochID) (uint64, error) {
+	return o.totalWeightFn(ctx, epoch)
 }
 
-func (o *Oracle) MinerWeight(ctx context.Context, node types.NodeID, layer types.LayerID) (uint64, error) {
-	return o.minerWeightFn(ctx, layer, node)
+func (o *Oracle) MinerWeight(ctx context.Context, node types.NodeID, epoch types.EpochID) (uint64, error) {
+	return o.minerWeightFn(ctx, epoch, node)
 }

--- a/hare3/eligibility/oracle.go
+++ b/hare3/eligibility/oracle.go
@@ -206,7 +206,7 @@ func (o *Oracle) buildVRFMessage(ctx context.Context, layer types.LayerID, round
 }
 
 func (o *Oracle) totalWeight(ctx context.Context, layer types.LayerID) (uint64, error) {
-	actives, err := o.actives(ctx, layer)
+	actives, err := o.actives(ctx, o.layerToEpoch(layer))
 	if err != nil {
 		return 0, err
 	}
@@ -214,7 +214,7 @@ func (o *Oracle) totalWeight(ctx context.Context, layer types.LayerID) (uint64, 
 }
 
 func (o *Oracle) minerWeight(ctx context.Context, layer types.LayerID, id types.NodeID) (uint64, error) {
-	actives, err := o.actives(ctx, layer)
+	actives, err := o.actives(ctx, o.layerToEpoch(layer))
 	if err != nil {
 		return 0, err
 	}
@@ -408,22 +408,24 @@ func GenVRF(
 	)
 }
 
-// Returns a map of all active node IDs in the specified layer id.
-func (o *Oracle) actives(ctx context.Context, targetLayer types.LayerID) (*cachedActiveSet, error) {
-	if !targetLayer.After(types.GetEffectiveGenesis()) {
-		return nil, errEmptyActiveSet
-	}
-	targetEpoch := targetLayer.GetEpoch()
+func (o *Oracle) layerToEpoch(layer types.LayerID) types.EpochID {
+	epoch := layer.GetEpoch()
 	// the first bootstrap data targets first epoch after genesis (epoch 2)
 	// and the epoch where checkpoint recovery happens
-	if targetEpoch > types.GetEffectiveGenesis().Add(1).GetEpoch() &&
-		targetLayer.Difference(targetEpoch.FirstLayer()) < o.cfg.ConfidenceParam {
-		targetEpoch -= 1
+	if epoch > types.GetEffectiveGenesis().Add(1).GetEpoch() &&
+		layer.Difference(epoch.FirstLayer()) < o.cfg.ConfidenceParam {
+		epoch -= 1
+	}
+	return epoch
+}
+
+// Returns a set of all active node IDs in the specified epoch.
+func (o *Oracle) actives(ctx context.Context, targetEpoch types.EpochID) (*cachedActiveSet, error) {
+	if !targetEpoch.FirstLayer().After(types.GetEffectiveGenesis()) {
+		return nil, errEmptyActiveSet
 	}
 	o.log.Debug("hare oracle getting active set",
 		log.ZContext(ctx),
-		zap.Uint32("target_layer", targetLayer.Uint32()),
-		zap.Uint32("target_layer_epoch", targetLayer.GetEpoch().Uint32()),
 		zap.Uint32("target_epoch", targetEpoch.Uint32()),
 	)
 
@@ -455,7 +457,7 @@ func (o *Oracle) actives(ctx context.Context, targetLayer types.LayerID) (*cache
 }
 
 func (o *Oracle) ActiveSet(ctx context.Context, targetEpoch types.EpochID) ([]types.ATXID, error) {
-	aset, err := o.actives(ctx, targetEpoch.FirstLayer().Add(o.cfg.ConfidenceParam))
+	aset, err := o.actives(ctx, targetEpoch)
 	if err != nil {
 		return nil, err
 	}

--- a/hare3/eligibility/oracle_test.go
+++ b/hare3/eligibility/oracle_test.go
@@ -485,7 +485,7 @@ func TestActiveSet(t *testing.T) {
 	o.mSyncer.EXPECT().IsSynced(context.Background()).Return(false).AnyTimes()
 	o.createLayerData(targetEpoch.FirstLayer(), numMiners)
 
-	aset, err := o.actives(context.Background(), layer)
+	aset, err := o.actives(context.Background(), o.layerToEpoch(layer))
 	require.NoError(t, err)
 	require.ElementsMatch(
 		t,
@@ -516,11 +516,11 @@ func TestActives(t *testing.T) {
 		o.UpdateActiveSet(types.GetEffectiveGenesis().GetEpoch()+1, bootstrap)
 
 		for lid := types.LayerID(0); lid.Before(first); lid = lid.Add(1) {
-			activeSet, err := o.actives(context.Background(), lid)
+			activeSet, err := o.actives(context.Background(), o.layerToEpoch(lid))
 			require.ErrorIs(t, err, errEmptyActiveSet)
 			require.Nil(t, activeSet)
 		}
-		activeSet, err := o.actives(context.Background(), first)
+		activeSet, err := o.actives(context.Background(), o.layerToEpoch(first))
 		require.NoError(t, err)
 		require.ElementsMatch(
 			t,
@@ -538,7 +538,7 @@ func TestActives(t *testing.T) {
 		o.createLayerData(layer, numMiners)
 
 		start := layer.Add(o.cfg.ConfidenceParam)
-		activeSet, err := o.actives(context.Background(), start)
+		activeSet, err := o.actives(context.Background(), layer.GetEpoch())
 		require.NoError(t, err)
 		require.ElementsMatch(
 			t,
@@ -549,12 +549,12 @@ func TestActives(t *testing.T) {
 		end := (layer.GetEpoch() + 1).FirstLayer().Add(o.cfg.ConfidenceParam)
 
 		for lid := start.Add(1); lid.Before(end); lid = lid.Add(1) {
-			got, err := o.actives(context.Background(), lid)
+			got, err := o.actives(context.Background(), o.layerToEpoch(lid))
 			require.NoError(t, err)
 			// cached
 			require.Equal(t, &activeSet, &got)
 		}
-		got, err := o.actives(context.Background(), end)
+		got, err := o.actives(context.Background(), end.GetEpoch())
 		require.ErrorIs(t, err, errEmptyActiveSet)
 		require.Nil(t, got)
 	})
@@ -571,11 +571,11 @@ func TestActives(t *testing.T) {
 		o.UpdateActiveSet(end.GetEpoch(), fallback)
 
 		for lid := layer; lid.Before(end); lid = lid.Add(1) {
-			got, err := o.actives(context.Background(), lid)
+			got, err := o.actives(context.Background(), o.layerToEpoch(lid))
 			require.ErrorIs(t, err, errEmptyActiveSet)
 			require.Nil(t, got)
 		}
-		activeSet, err := o.actives(context.Background(), end)
+		activeSet, err := o.actives(context.Background(), end.GetEpoch())
 		require.NoError(t, err)
 		require.ElementsMatch(
 			t,
@@ -600,7 +600,7 @@ func TestActives(t *testing.T) {
 		o.createActiveSet(types.EpochID(3).FirstLayer(), fallback)
 		o.UpdateActiveSet(layer.GetEpoch(), fallback)
 
-		activeSet, err := o.actives(context.Background(), layer)
+		activeSet, err := o.actives(context.Background(), o.layerToEpoch(layer))
 		require.NoError(t, err)
 		require.ElementsMatch(
 			t,
@@ -608,7 +608,7 @@ func TestActives(t *testing.T) {
 			maps.Keys(activeSet.set),
 			"assertion relies on the enumeration of identities",
 		)
-		activeSet2, err := o.actives(context.Background(), layer+1)
+		activeSet2, err := o.actives(context.Background(), o.layerToEpoch(layer+1))
 		require.NoError(t, err)
 		require.Equal(t, activeSet, activeSet2)
 	})
@@ -641,7 +641,7 @@ func TestActives_ConcurrentCalls(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(102)
 	runFn := func() {
-		_, err := o.actives(context.Background(), layer)
+		_, err := o.actives(context.Background(), o.layerToEpoch(layer))
 		r.NoError(err)
 		wg.Done()
 	}

--- a/hare3/hare.go
+++ b/hare3/hare.go
@@ -693,10 +693,10 @@ func (h *Hare) RoundTemplate(layer types.LayerID, round IterRound) *Body {
 	return &r.message.Body
 }
 
-func (h *Hare) TotalWeight(ctx context.Context, layer types.LayerID) (uint64, error) {
-	return h.oracle.oracle.TotalWeight(ctx, layer)
+func (h *Hare) TotalWeight(ctx context.Context, epoch types.EpochID) (uint64, error) {
+	return h.oracle.oracle.TotalWeight(ctx, epoch)
 }
 
-func (h *Hare) MinerWeight(ctx context.Context, miner types.NodeID, layer types.LayerID) (uint64, error) {
-	return h.oracle.oracle.MinerWeight(ctx, miner, layer)
+func (h *Hare) MinerWeight(ctx context.Context, miner types.NodeID, epoch types.EpochID) (uint64, error) {
+	return h.oracle.oracle.MinerWeight(ctx, miner, epoch)
 }

--- a/hare3/legacy_oracle.go
+++ b/hare3/legacy_oracle.go
@@ -14,8 +14,8 @@ import (
 type oracle interface {
 	Validate(context.Context, types.LayerID, uint32, int, types.NodeID, types.VrfSignature, uint16) (bool, error)
 	CalcEligibility(context.Context, types.LayerID, uint32, int, types.NodeID, types.VrfSignature) (uint16, error)
-	TotalWeight(ctx context.Context, layer types.LayerID) (uint64, error)
-	MinerWeight(ctx context.Context, node types.NodeID, layer types.LayerID) (uint64, error)
+	TotalWeight(ctx context.Context, epoch types.EpochID) (uint64, error)
+	MinerWeight(ctx context.Context, node types.NodeID, epoch types.EpochID) (uint64, error)
 }
 
 type legacyOracle struct {


### PR DESCRIPTION
Part of #6676.

Both the miner's weight and the cumulative weight stay consistent during the specified epoch. It's inefficient to ask for them every layer. It's much more efficient to ask for epoch and cache the result. Note that the response can now be cached in the HTTP cache for the entire epoch.

This PR changes the API to use epochs instead of layers. 

A following PR will add caching so that the miner and total weight are remembered and not queried again and again on every layer.