### PR TITLE
[Merged by Bors] - Remove fat context from activation builder

### DIFF
--- a/activation/activation.go
+++ b/activation/activation.go
@@ -93,7 +93,6 @@ type Builder struct {
 	layerClock        layerClock
 	syncer            syncer
 	logger            *zap.Logger
-	parentCtx         context.Context
 	poets             []PoetService
 	poetCfg           PoetConfig
 	poetRetryInterval time.Duration
@@ -136,14 +135,6 @@ func WithPostValidityDelay(delay time.Duration) BuilderOption {
 func WithPoetRetryInterval(interval time.Duration) BuilderOption {
 	return func(b *Builder) {
 		b.poetRetryInterval = interval
-	}
-}
-
-// WithContext modifies parent context for background job.
-func WithContext(ctx context.Context) BuilderOption {
-	return func(b *Builder) {
-		// TODO(mafa): fix this
-		b.parentCtx = ctx // nolint:fatcontext
 	}
 }
 
@@ -192,7 +183,6 @@ func NewBuilder(
 	opts ...BuilderOption,
 ) *Builder {
 	b := &Builder{
-		parentCtx:         context.Background(),
 		signers:           make(map[types.NodeID]*signing.EdSigner),
 		conf:              conf,
 		db:                db,
@@ -228,7 +218,13 @@ func (b *Builder) Register(sig *signing.EdSigner) {
 	b.postStates.Set(sig.NodeID(), types.PostStateIdle)
 
 	if b.stop != nil {
-		b.startID(b.parentCtx, sig)
+		ctx, stop := context.WithCancel(context.Background())
+		prevStop := b.stop
+		b.stop = func() {
+			prevStop()
+			stop()
+		}
+		b.startID(ctx, sig)
 	}
 }
 
@@ -268,9 +264,8 @@ func (b *Builder) StartSmeshing(coinbase types.Address) error {
 	}
 
 	b.coinbaseAccount = coinbase
-	ctx, stop := context.WithCancel(b.parentCtx)
+	ctx, stop := context.WithCancel(context.Background())
 	b.stop = stop
-
 	for _, sig := range b.signers {
 		b.startID(ctx, sig)
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -1125,7 +1125,6 @@ func (app *App) initServices(ctx context.Context) error {
 		app.clock,
 		syncer,
 		app.addLogger(ATXBuilderLogger, lg).Zap(),
-		activation.WithContext(ctx),
 		activation.WithPoetConfig(app.Config.POET),
 		// TODO(dshulyak) makes no sense. how we ended using it?
 		activation.WithPoetRetryInterval(app.Config.HARE3.PreroundDelay),


### PR DESCRIPTION
## Motivation

A context should not be stored inside a service but instead only passed to functions, who then block until they either finish work or the context is canceled. This fixes a code where we use context incorrectly.

## Description

Get rid of the context passed to `activation.NewBuilder`.

## Test Plan

existing tests pass

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
