### PR TITLE
fix encoding of bytes in path params to be hex

### DIFF
--- a/activation/poet.go
+++ b/activation/poet.go
@@ -462,7 +462,9 @@ func NewPoetServiceWithClient(
 		opt(service)
 	}
 
-	err := service.verifyPhaseShiftConfiguration(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	defer cancel()
+	err := service.verifyPhaseShiftConfiguration(ctx)
 	switch {
 	case errors.Is(err, errIncompatiblePhaseShift):
 		logger.Fatal("failed to create poet service", zap.String("poet", client.Address()))

--- a/api/node/client/client.gen.go
+++ b/api/node/client/client.gen.go
@@ -117,10 +117,10 @@ func WithRequestEditorFn(fn RequestEditorFn) ClientOption {
 // The interface specification for the client above.
 type ClientInterface interface {
 	// GetActivationAtxAtxId request
-	GetActivationAtxAtxId(ctx context.Context, atxId externalRef0.Bytes32, reqEditors ...RequestEditorFn) (*http.Response, error)
+	GetActivationAtxAtxId(ctx context.Context, atxId externalRef0.Bytes32Hex, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetActivationLastAtxNodeId request
-	GetActivationLastAtxNodeId(ctx context.Context, nodeId externalRef0.Bytes32, reqEditors ...RequestEditorFn) (*http.Response, error)
+	GetActivationLastAtxNodeId(ctx context.Context, nodeId externalRef0.Bytes32Hex, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetActivationPositioningAtxPublishEpoch request
 	GetActivationPositioningAtxPublishEpoch(ctx context.Context, publishEpoch externalRef0.EpochID, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -131,7 +131,7 @@ type ClientInterface interface {
 	PostActivationPublish(ctx context.Context, body PostActivationPublishJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetEligibilitySlotsNodeEpoch request
-	GetEligibilitySlotsNodeEpoch(ctx context.Context, node externalRef0.Bytes32, epoch externalRef0.EpochID, reqEditors ...RequestEditorFn) (*http.Response, error)
+	GetEligibilitySlotsNodeEpoch(ctx context.Context, node externalRef0.Bytes32Hex, epoch externalRef0.EpochID, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetHareBeaconEpoch request
 	GetHareBeaconEpoch(ctx context.Context, epoch externalRef0.EpochID, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -143,16 +143,16 @@ type ClientInterface interface {
 	GetHareTotalWeightEpoch(ctx context.Context, epoch externalRef0.EpochID, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetHareWeightNodeIdEpoch request
-	GetHareWeightNodeIdEpoch(ctx context.Context, nodeId externalRef0.Bytes32, epoch externalRef0.EpochID, reqEditors ...RequestEditorFn) (*http.Response, error)
+	GetHareWeightNodeIdEpoch(ctx context.Context, nodeId externalRef0.Bytes32Hex, epoch externalRef0.EpochID, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetProposalLayerNode request
-	GetProposalLayerNode(ctx context.Context, layer externalRef0.LayerID, node externalRef0.Bytes32, reqEditors ...RequestEditorFn) (*http.Response, error)
+	GetProposalLayerNode(ctx context.Context, layer externalRef0.LayerID, node externalRef0.Bytes32Hex, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// PostPublishProtocolWithBody request with any body
 	PostPublishProtocolWithBody(ctx context.Context, protocol PostPublishProtocolParamsProtocol, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 }
 
-func (c *Client) GetActivationAtxAtxId(ctx context.Context, atxId externalRef0.Bytes32, reqEditors ...RequestEditorFn) (*http.Response, error) {
+func (c *Client) GetActivationAtxAtxId(ctx context.Context, atxId externalRef0.Bytes32Hex, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewGetActivationAtxAtxIdRequest(c.Server, atxId)
 	if err != nil {
 		return nil, err
@@ -164,7 +164,7 @@ func (c *Client) GetActivationAtxAtxId(ctx context.Context, atxId externalRef0.B
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetActivationLastAtxNodeId(ctx context.Context, nodeId externalRef0.Bytes32, reqEditors ...RequestEditorFn) (*http.Response, error) {
+func (c *Client) GetActivationLastAtxNodeId(ctx context.Context, nodeId externalRef0.Bytes32Hex, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewGetActivationLastAtxNodeIdRequest(c.Server, nodeId)
 	if err != nil {
 		return nil, err
@@ -212,7 +212,7 @@ func (c *Client) PostActivationPublish(ctx context.Context, body PostActivationP
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetEligibilitySlotsNodeEpoch(ctx context.Context, node externalRef0.Bytes32, epoch externalRef0.EpochID, reqEditors ...RequestEditorFn) (*http.Response, error) {
+func (c *Client) GetEligibilitySlotsNodeEpoch(ctx context.Context, node externalRef0.Bytes32Hex, epoch externalRef0.EpochID, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewGetEligibilitySlotsNodeEpochRequest(c.Server, node, epoch)
 	if err != nil {
 		return nil, err
@@ -260,7 +260,7 @@ func (c *Client) GetHareTotalWeightEpoch(ctx context.Context, epoch externalRef0
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetHareWeightNodeIdEpoch(ctx context.Context, nodeId externalRef0.Bytes32, epoch externalRef0.EpochID, reqEditors ...RequestEditorFn) (*http.Response, error) {
+func (c *Client) GetHareWeightNodeIdEpoch(ctx context.Context, nodeId externalRef0.Bytes32Hex, epoch externalRef0.EpochID, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewGetHareWeightNodeIdEpochRequest(c.Server, nodeId, epoch)
 	if err != nil {
 		return nil, err
@@ -272,7 +272,7 @@ func (c *Client) GetHareWeightNodeIdEpoch(ctx context.Context, nodeId externalRe
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetProposalLayerNode(ctx context.Context, layer externalRef0.LayerID, node externalRef0.Bytes32, reqEditors ...RequestEditorFn) (*http.Response, error) {
+func (c *Client) GetProposalLayerNode(ctx context.Context, layer externalRef0.LayerID, node externalRef0.Bytes32Hex, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewGetProposalLayerNodeRequest(c.Server, layer, node)
 	if err != nil {
 		return nil, err
@@ -297,7 +297,7 @@ func (c *Client) PostPublishProtocolWithBody(ctx context.Context, protocol PostP
 }
 
 // NewGetActivationAtxAtxIdRequest generates requests for GetActivationAtxAtxId
-func NewGetActivationAtxAtxIdRequest(server string, atxId externalRef0.Bytes32) (*http.Request, error) {
+func NewGetActivationAtxAtxIdRequest(server string, atxId externalRef0.Bytes32Hex) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -331,7 +331,7 @@ func NewGetActivationAtxAtxIdRequest(server string, atxId externalRef0.Bytes32) 
 }
 
 // NewGetActivationLastAtxNodeIdRequest generates requests for GetActivationLastAtxNodeId
-func NewGetActivationLastAtxNodeIdRequest(server string, nodeId externalRef0.Bytes32) (*http.Request, error) {
+func NewGetActivationLastAtxNodeIdRequest(server string, nodeId externalRef0.Bytes32Hex) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -439,7 +439,7 @@ func NewPostActivationPublishRequestWithBody(server string, contentType string, 
 }
 
 // NewGetEligibilitySlotsNodeEpochRequest generates requests for GetEligibilitySlotsNodeEpoch
-func NewGetEligibilitySlotsNodeEpochRequest(server string, node externalRef0.Bytes32, epoch externalRef0.EpochID) (*http.Request, error) {
+func NewGetEligibilitySlotsNodeEpochRequest(server string, node externalRef0.Bytes32Hex, epoch externalRef0.EpochID) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -596,7 +596,7 @@ func NewGetHareTotalWeightEpochRequest(server string, epoch externalRef0.EpochID
 }
 
 // NewGetHareWeightNodeIdEpochRequest generates requests for GetHareWeightNodeIdEpoch
-func NewGetHareWeightNodeIdEpochRequest(server string, nodeId externalRef0.Bytes32, epoch externalRef0.EpochID) (*http.Request, error) {
+func NewGetHareWeightNodeIdEpochRequest(server string, nodeId externalRef0.Bytes32Hex, epoch externalRef0.EpochID) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -637,7 +637,7 @@ func NewGetHareWeightNodeIdEpochRequest(server string, nodeId externalRef0.Bytes
 }
 
 // NewGetProposalLayerNodeRequest generates requests for GetProposalLayerNode
-func NewGetProposalLayerNodeRequest(server string, layer externalRef0.LayerID, node externalRef0.Bytes32) (*http.Request, error) {
+func NewGetProposalLayerNodeRequest(server string, layer externalRef0.LayerID, node externalRef0.Bytes32Hex) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -757,10 +757,10 @@ func WithBaseURL(baseURL string) ClientOption {
 // ClientWithResponsesInterface is the interface specification for the client with responses above.
 type ClientWithResponsesInterface interface {
 	// GetActivationAtxAtxIdWithResponse request
-	GetActivationAtxAtxIdWithResponse(ctx context.Context, atxId externalRef0.Bytes32, reqEditors ...RequestEditorFn) (*GetActivationAtxAtxIdResponse, error)
+	GetActivationAtxAtxIdWithResponse(ctx context.Context, atxId externalRef0.Bytes32Hex, reqEditors ...RequestEditorFn) (*GetActivationAtxAtxIdResponse, error)
 
 	// GetActivationLastAtxNodeIdWithResponse request
-	GetActivationLastAtxNodeIdWithResponse(ctx context.Context, nodeId externalRef0.Bytes32, reqEditors ...RequestEditorFn) (*GetActivationLastAtxNodeIdResponse, error)
+	GetActivationLastAtxNodeIdWithResponse(ctx context.Context, nodeId externalRef0.Bytes32Hex, reqEditors ...RequestEditorFn) (*GetActivationLastAtxNodeIdResponse, error)
 
 	// GetActivationPositioningAtxPublishEpochWithResponse request
 	GetActivationPositioningAtxPublishEpochWithResponse(ctx context.Context, publishEpoch externalRef0.EpochID, reqEditors ...RequestEditorFn) (*GetActivationPositioningAtxPublishEpochResponse, error)
@@ -771,7 +771,7 @@ type ClientWithResponsesInterface interface {
 	PostActivationPublishWithResponse(ctx context.Context, body PostActivationPublishJSONRequestBody, reqEditors ...RequestEditorFn) (*PostActivationPublishResponse, error)
 
 	// GetEligibilitySlotsNodeEpochWithResponse request
-	GetEligibilitySlotsNodeEpochWithResponse(ctx context.Context, node externalRef0.Bytes32, epoch externalRef0.EpochID, reqEditors ...RequestEditorFn) (*GetEligibilitySlotsNodeEpochResponse, error)
+	GetEligibilitySlotsNodeEpochWithResponse(ctx context.Context, node externalRef0.Bytes32Hex, epoch externalRef0.EpochID, reqEditors ...RequestEditorFn) (*GetEligibilitySlotsNodeEpochResponse, error)
 
 	// GetHareBeaconEpochWithResponse request
 	GetHareBeaconEpochWithResponse(ctx context.Context, epoch externalRef0.EpochID, reqEditors ...RequestEditorFn) (*GetHareBeaconEpochResponse, error)
@@ -783,10 +783,10 @@ type ClientWithResponsesInterface interface {
 	GetHareTotalWeightEpochWithResponse(ctx context.Context, epoch externalRef0.EpochID, reqEditors ...RequestEditorFn) (*GetHareTotalWeightEpochResponse, error)
 
 	// GetHareWeightNodeIdEpochWithResponse request
-	GetHareWeightNodeIdEpochWithResponse(ctx context.Context, nodeId externalRef0.Bytes32, epoch externalRef0.EpochID, reqEditors ...RequestEditorFn) (*GetHareWeightNodeIdEpochResponse, error)
+	GetHareWeightNodeIdEpochWithResponse(ctx context.Context, nodeId externalRef0.Bytes32Hex, epoch externalRef0.EpochID, reqEditors ...RequestEditorFn) (*GetHareWeightNodeIdEpochResponse, error)
 
 	// GetProposalLayerNodeWithResponse request
-	GetProposalLayerNodeWithResponse(ctx context.Context, layer externalRef0.LayerID, node externalRef0.Bytes32, reqEditors ...RequestEditorFn) (*GetProposalLayerNodeResponse, error)
+	GetProposalLayerNodeWithResponse(ctx context.Context, layer externalRef0.LayerID, node externalRef0.Bytes32Hex, reqEditors ...RequestEditorFn) (*GetProposalLayerNodeResponse, error)
 
 	// PostPublishProtocolWithBodyWithResponse request with any body
 	PostPublishProtocolWithBodyWithResponse(ctx context.Context, protocol PostPublishProtocolParamsProtocol, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostPublishProtocolResponse, error)
@@ -1044,7 +1044,7 @@ func (r PostPublishProtocolResponse) StatusCode() int {
 }
 
 // GetActivationAtxAtxIdWithResponse request returning *GetActivationAtxAtxIdResponse
-func (c *ClientWithResponses) GetActivationAtxAtxIdWithResponse(ctx context.Context, atxId externalRef0.Bytes32, reqEditors ...RequestEditorFn) (*GetActivationAtxAtxIdResponse, error) {
+func (c *ClientWithResponses) GetActivationAtxAtxIdWithResponse(ctx context.Context, atxId externalRef0.Bytes32Hex, reqEditors ...RequestEditorFn) (*GetActivationAtxAtxIdResponse, error) {
 	rsp, err := c.GetActivationAtxAtxId(ctx, atxId, reqEditors...)
 	if err != nil {
 		return nil, err
@@ -1053,7 +1053,7 @@ func (c *ClientWithResponses) GetActivationAtxAtxIdWithResponse(ctx context.Cont
 }
 
 // GetActivationLastAtxNodeIdWithResponse request returning *GetActivationLastAtxNodeIdResponse
-func (c *ClientWithResponses) GetActivationLastAtxNodeIdWithResponse(ctx context.Context, nodeId externalRef0.Bytes32, reqEditors ...RequestEditorFn) (*GetActivationLastAtxNodeIdResponse, error) {
+func (c *ClientWithResponses) GetActivationLastAtxNodeIdWithResponse(ctx context.Context, nodeId externalRef0.Bytes32Hex, reqEditors ...RequestEditorFn) (*GetActivationLastAtxNodeIdResponse, error) {
 	rsp, err := c.GetActivationLastAtxNodeId(ctx, nodeId, reqEditors...)
 	if err != nil {
 		return nil, err
@@ -1088,7 +1088,7 @@ func (c *ClientWithResponses) PostActivationPublishWithResponse(ctx context.Cont
 }
 
 // GetEligibilitySlotsNodeEpochWithResponse request returning *GetEligibilitySlotsNodeEpochResponse
-func (c *ClientWithResponses) GetEligibilitySlotsNodeEpochWithResponse(ctx context.Context, node externalRef0.Bytes32, epoch externalRef0.EpochID, reqEditors ...RequestEditorFn) (*GetEligibilitySlotsNodeEpochResponse, error) {
+func (c *ClientWithResponses) GetEligibilitySlotsNodeEpochWithResponse(ctx context.Context, node externalRef0.Bytes32Hex, epoch externalRef0.EpochID, reqEditors ...RequestEditorFn) (*GetEligibilitySlotsNodeEpochResponse, error) {
 	rsp, err := c.GetEligibilitySlotsNodeEpoch(ctx, node, epoch, reqEditors...)
 	if err != nil {
 		return nil, err
@@ -1124,7 +1124,7 @@ func (c *ClientWithResponses) GetHareTotalWeightEpochWithResponse(ctx context.Co
 }
 
 // GetHareWeightNodeIdEpochWithResponse request returning *GetHareWeightNodeIdEpochResponse
-func (c *ClientWithResponses) GetHareWeightNodeIdEpochWithResponse(ctx context.Context, nodeId externalRef0.Bytes32, epoch externalRef0.EpochID, reqEditors ...RequestEditorFn) (*GetHareWeightNodeIdEpochResponse, error) {
+func (c *ClientWithResponses) GetHareWeightNodeIdEpochWithResponse(ctx context.Context, nodeId externalRef0.Bytes32Hex, epoch externalRef0.EpochID, reqEditors ...RequestEditorFn) (*GetHareWeightNodeIdEpochResponse, error) {
 	rsp, err := c.GetHareWeightNodeIdEpoch(ctx, nodeId, epoch, reqEditors...)
 	if err != nil {
 		return nil, err
@@ -1133,7 +1133,7 @@ func (c *ClientWithResponses) GetHareWeightNodeIdEpochWithResponse(ctx context.C
 }
 
 // GetProposalLayerNodeWithResponse request returning *GetProposalLayerNodeResponse
-func (c *ClientWithResponses) GetProposalLayerNodeWithResponse(ctx context.Context, layer externalRef0.LayerID, node externalRef0.Bytes32, reqEditors ...RequestEditorFn) (*GetProposalLayerNodeResponse, error) {
+func (c *ClientWithResponses) GetProposalLayerNodeWithResponse(ctx context.Context, layer externalRef0.LayerID, node externalRef0.Bytes32Hex, reqEditors ...RequestEditorFn) (*GetProposalLayerNodeResponse, error) {
 	rsp, err := c.GetProposalLayerNode(ctx, layer, node, reqEditors...)
 	if err != nil {
 		return nil, err

--- a/api/node/client/client.go
+++ b/api/node/client/client.go
@@ -3,6 +3,7 @@ package client
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"net/http"
@@ -54,7 +55,7 @@ func NewNodeServiceClient(server string, logger *zap.Logger, cfg *Config) (*Node
 }
 
 func (s *NodeService) Atx(ctx context.Context, id types.ATXID) (*types.ActivationTx, error) {
-	resp, err := s.client.GetActivationAtxAtxIdWithResponse(ctx, id.Bytes())
+	resp, err := s.client.GetActivationAtxAtxIdWithResponse(ctx, hex.EncodeToString(id.Bytes()))
 	if err != nil {
 		return nil, err
 	}
@@ -69,7 +70,7 @@ func (s *NodeService) Atx(ctx context.Context, id types.ATXID) (*types.Activatio
 }
 
 func (s *NodeService) LastATX(ctx context.Context, nodeID types.NodeID) (*types.ActivationTx, error) {
-	resp, err := s.client.GetActivationLastAtxNodeIdWithResponse(ctx, nodeID.Bytes())
+	resp, err := s.client.GetActivationLastAtxNodeIdWithResponse(ctx, hex.EncodeToString(nodeID.Bytes()))
 	if err != nil {
 		return nil, err
 	}
@@ -199,7 +200,7 @@ func (s *NodeService) TotalWeight(ctx context.Context, epoch types.EpochID) (uin
 }
 
 func (s *NodeService) MinerWeight(ctx context.Context, epoch types.EpochID, node types.NodeID) (uint64, error) {
-	resp, err := s.client.GetHareWeightNodeIdEpochWithResponse(ctx, node.Bytes(), epoch.Uint32())
+	resp, err := s.client.GetHareWeightNodeIdEpochWithResponse(ctx, hex.EncodeToString(node.Bytes()), epoch.Uint32())
 	if err != nil {
 		return 0, fmt.Errorf("get miner weight: %w", err)
 	}
@@ -231,7 +232,7 @@ func (s *NodeService) Beacon(ctx context.Context, epoch types.EpochID) (types.Be
 func (s *NodeService) Proposal(ctx context.Context, layer types.LayerID, node types.NodeID) (
 	*types.Proposal, uint64, error,
 ) {
-	resp, err := s.client.GetProposalLayerNodeWithResponse(ctx, layer.Uint32(), node.Bytes())
+	resp, err := s.client.GetProposalLayerNodeWithResponse(ctx, layer.Uint32(), hex.EncodeToString(node.Bytes()))
 	if err != nil {
 		return nil, 0, fmt.Errorf("get proposal layer: %w", err)
 	}
@@ -325,7 +326,11 @@ func (s *NodeService) Proposal(ctx context.Context, layer types.LayerID, node ty
 func (s *NodeService) CalculateEligibilitySlotsFor(
 	ctx context.Context, node types.NodeID, epoch types.EpochID,
 ) (uint32, types.VRFPostIndex, error) {
-	resp, err := s.client.GetEligibilitySlotsNodeEpochWithResponse(ctx, node.Bytes(), models.EpochID(epoch))
+	resp, err := s.client.GetEligibilitySlotsNodeEpochWithResponse(
+		ctx,
+		hex.EncodeToString(node.Bytes()),
+		models.EpochID(epoch),
+	)
 	if err != nil {
 		return 0, 0, err
 	}

--- a/api/node/models/components.yaml
+++ b/api/node/models/components.yaml
@@ -95,6 +95,11 @@ components:
       format: byte
       minLength: 44
       maxLength: 44
+    Bytes32Hex:
+      type: string
+      format: hex
+      minLength: 64
+      maxLength: 64
     Beacon:
       type: string
       format: byte

--- a/api/node/models/models.gen.go
+++ b/api/node/models/models.gen.go
@@ -32,6 +32,9 @@ type Bytes20 = []byte
 // Bytes32 defines model for Bytes32.
 type Bytes32 = []byte
 
+// Bytes32Hex defines model for Bytes32Hex.
+type Bytes32Hex = string
+
 // EpochData defines model for EpochData.
 type EpochData struct {
 	ActiveSetHash    Bytes32 `json:"ActiveSetHash"`

--- a/api/node/models/models.go
+++ b/api/node/models/models.go
@@ -1,16 +1,43 @@
 package models
 
 import (
+	"encoding/hex"
 	"fmt"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
 )
 
+func ParseBytes32Hex(b Bytes32Hex) ([32]byte, error) {
+	if len(b) != 64 {
+		return [32]byte{}, fmt.Errorf("invalid length: %d (expected 64)", len(b))
+	}
+	hash, err := hex.DecodeString(b)
+	if err != nil {
+		return [32]byte{}, fmt.Errorf("decoding hex: %w", err)
+	}
+	return [32]byte(hash), nil
+}
+
+func ParseNodeIDHex(id Bytes32Hex) (types.NodeID, error) {
+	b32, err := ParseBytes32Hex(id)
+	if err != nil {
+		return types.NodeID{}, err
+	}
+	return types.NodeID(b32), nil
+}
 func ParseNodeID(id Bytes32) (types.NodeID, error) {
 	if len(id) != len(types.NodeID{}) {
 		return types.NodeID{}, fmt.Errorf("invalid node ID length: %d", len(id))
 	}
 	return types.BytesToNodeID(id), nil
+}
+
+func ParseATXIDHex(id Bytes32Hex) (types.ATXID, error) {
+	b32, err := ParseBytes32Hex(id)
+	if err != nil {
+		return types.ATXID{}, err
+	}
+	return types.ATXID(b32), nil
 }
 
 func ParseATXID(id Bytes32) (types.ATXID, error) {

--- a/api/node/models/models.go
+++ b/api/node/models/models.go
@@ -25,6 +25,7 @@ func ParseNodeIDHex(id Bytes32Hex) (types.NodeID, error) {
 	}
 	return types.NodeID(b32), nil
 }
+
 func ParseNodeID(id Bytes32) (types.NodeID, error) {
 	if len(id) != len(types.NodeID{}) {
 		return types.NodeID{}, fmt.Errorf("invalid node ID length: %d", len(id))

--- a/api/node/models/models.go
+++ b/api/node/models/models.go
@@ -11,11 +11,11 @@ func ParseBytes32Hex(b Bytes32Hex) ([32]byte, error) {
 	if len(b) != 64 {
 		return [32]byte{}, fmt.Errorf("invalid length: %d (expected 64)", len(b))
 	}
-	hash, err := hex.DecodeString(b)
+	decoded, err := hex.DecodeString(b)
 	if err != nil {
 		return [32]byte{}, fmt.Errorf("decoding hex: %w", err)
 	}
-	return [32]byte(hash), nil
+	return [32]byte(decoded), nil
 }
 
 func ParseNodeIDHex(id Bytes32Hex) (types.NodeID, error) {

--- a/api/node/node_service.yaml
+++ b/api/node/node_service.yaml
@@ -40,7 +40,7 @@ paths:
           name: node_id
           required: true
           schema:
-            $ref: "models/components.yaml#/components/schemas/Bytes32"
+            $ref: "models/components.yaml#/components/schemas/Bytes32Hex"
       responses:
         "200":
           description: ATX
@@ -68,7 +68,7 @@ paths:
           name: atx_id
           required: true
           schema:
-            $ref: "models/components.yaml#/components/schemas/Bytes32"
+            $ref: "models/components.yaml#/components/schemas/Bytes32Hex"
       responses:
         "200":
           description: ATX
@@ -203,7 +203,7 @@ paths:
           name: node_id
           required: true
           schema:
-            $ref: "models/components.yaml#/components/schemas/Bytes32"
+            $ref: "models/components.yaml#/components/schemas/Bytes32Hex"
         - in: path
           name: epoch
           required: true
@@ -270,7 +270,7 @@ paths:
           name: node
           required: true
           schema:
-            $ref: "models/components.yaml#/components/schemas/Bytes32"
+            $ref: "models/components.yaml#/components/schemas/Bytes32Hex"
       responses:
         "200":
           description: successfully created a partial proposal
@@ -298,7 +298,7 @@ paths:
           name: node
           required: true
           schema:
-            $ref: "models/components.yaml#/components/schemas/Bytes32"
+            $ref: "models/components.yaml#/components/schemas/Bytes32Hex"
         - in: path
           name: epoch
           required: true

--- a/api/node/server/server.gen.go
+++ b/api/node/server/server.gen.go
@@ -47,10 +47,10 @@ type PostActivationPublishJSONRequestBody PostActivationPublishJSONBody
 type ServerInterface interface {
 	// Get ATX by ID
 	// (GET /activation/atx/{atx_id})
-	GetActivationAtxAtxId(w http.ResponseWriter, r *http.Request, atxId externalRef0.Bytes32)
+	GetActivationAtxAtxId(w http.ResponseWriter, r *http.Request, atxId externalRef0.Bytes32Hex)
 	// Get last ATX by node ID
 	// (GET /activation/last_atx/{node_id})
-	GetActivationLastAtxNodeId(w http.ResponseWriter, r *http.Request, nodeId externalRef0.Bytes32)
+	GetActivationLastAtxNodeId(w http.ResponseWriter, r *http.Request, nodeId externalRef0.Bytes32Hex)
 	// Get Positioning ATX ID with given maximum publish epoch
 	// (GET /activation/positioning_atx/{publish_epoch})
 	GetActivationPositioningAtxPublishEpoch(w http.ResponseWriter, r *http.Request, publishEpoch externalRef0.EpochID)
@@ -59,7 +59,7 @@ type ServerInterface interface {
 	PostActivationPublish(w http.ResponseWriter, r *http.Request)
 	// Get eligibility slots for a given node id in given epoch
 	// (GET /eligibility/slots/{node}/{epoch})
-	GetEligibilitySlotsNodeEpoch(w http.ResponseWriter, r *http.Request, node externalRef0.Bytes32, epoch externalRef0.EpochID)
+	GetEligibilitySlotsNodeEpoch(w http.ResponseWriter, r *http.Request, node externalRef0.Bytes32Hex, epoch externalRef0.EpochID)
 	// Get the beacon value for an epoch
 	// (GET /hare/beacon/{epoch})
 	GetHareBeaconEpoch(w http.ResponseWriter, r *http.Request, epoch externalRef0.EpochID)
@@ -71,10 +71,10 @@ type ServerInterface interface {
 	GetHareTotalWeightEpoch(w http.ResponseWriter, r *http.Request, epoch externalRef0.EpochID)
 	// Get the miner weight in epoch
 	// (GET /hare/weight/{node_id}/{epoch})
-	GetHareWeightNodeIdEpoch(w http.ResponseWriter, r *http.Request, nodeId externalRef0.Bytes32, epoch externalRef0.EpochID)
+	GetHareWeightNodeIdEpoch(w http.ResponseWriter, r *http.Request, nodeId externalRef0.Bytes32Hex, epoch externalRef0.EpochID)
 	// Get a partial proposal for a given node in a layer
 	// (GET /proposal/{layer}/{node})
-	GetProposalLayerNode(w http.ResponseWriter, r *http.Request, layer externalRef0.LayerID, node externalRef0.Bytes32)
+	GetProposalLayerNode(w http.ResponseWriter, r *http.Request, layer externalRef0.LayerID, node externalRef0.Bytes32Hex)
 	// Publish a blob in the given p2p protocol
 	// (POST /publish/{protocol})
 	PostPublishProtocol(w http.ResponseWriter, r *http.Request, protocol PostPublishProtocolParamsProtocol)
@@ -95,7 +95,7 @@ func (siw *ServerInterfaceWrapper) GetActivationAtxAtxId(w http.ResponseWriter, 
 	var err error
 
 	// ------------- Path parameter "atx_id" -------------
-	var atxId externalRef0.Bytes32
+	var atxId externalRef0.Bytes32Hex
 
 	err = runtime.BindStyledParameterWithOptions("simple", "atx_id", r.PathValue("atx_id"), &atxId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
 	if err != nil {
@@ -120,7 +120,7 @@ func (siw *ServerInterfaceWrapper) GetActivationLastAtxNodeId(w http.ResponseWri
 	var err error
 
 	// ------------- Path parameter "node_id" -------------
-	var nodeId externalRef0.Bytes32
+	var nodeId externalRef0.Bytes32Hex
 
 	err = runtime.BindStyledParameterWithOptions("simple", "node_id", r.PathValue("node_id"), &nodeId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
 	if err != nil {
@@ -184,7 +184,7 @@ func (siw *ServerInterfaceWrapper) GetEligibilitySlotsNodeEpoch(w http.ResponseW
 	var err error
 
 	// ------------- Path parameter "node" -------------
-	var node externalRef0.Bytes32
+	var node externalRef0.Bytes32Hex
 
 	err = runtime.BindStyledParameterWithOptions("simple", "node", r.PathValue("node"), &node, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
 	if err != nil {
@@ -311,7 +311,7 @@ func (siw *ServerInterfaceWrapper) GetHareWeightNodeIdEpoch(w http.ResponseWrite
 	var err error
 
 	// ------------- Path parameter "node_id" -------------
-	var nodeId externalRef0.Bytes32
+	var nodeId externalRef0.Bytes32Hex
 
 	err = runtime.BindStyledParameterWithOptions("simple", "node_id", r.PathValue("node_id"), &nodeId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
 	if err != nil {
@@ -354,7 +354,7 @@ func (siw *ServerInterfaceWrapper) GetProposalLayerNode(w http.ResponseWriter, r
 	}
 
 	// ------------- Path parameter "node" -------------
-	var node externalRef0.Bytes32
+	var node externalRef0.Bytes32Hex
 
 	err = runtime.BindStyledParameterWithOptions("simple", "node", r.PathValue("node"), &node, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
 	if err != nil {
@@ -534,7 +534,7 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 }
 
 type GetActivationAtxAtxIdRequestObject struct {
-	AtxId externalRef0.Bytes32 `json:"atx_id"`
+	AtxId externalRef0.Bytes32Hex `json:"atx_id"`
 }
 
 type GetActivationAtxAtxIdResponseObject interface {
@@ -578,7 +578,7 @@ func (response GetActivationAtxAtxId404Response) VisitGetActivationAtxAtxIdRespo
 }
 
 type GetActivationLastAtxNodeIdRequestObject struct {
-	NodeId externalRef0.Bytes32 `json:"node_id"`
+	NodeId externalRef0.Bytes32Hex `json:"node_id"`
 }
 
 type GetActivationLastAtxNodeIdResponseObject interface {
@@ -676,8 +676,8 @@ func (response PostActivationPublish400PlaintextResponse) VisitPostActivationPub
 }
 
 type GetEligibilitySlotsNodeEpochRequestObject struct {
-	Node  externalRef0.Bytes32 `json:"node"`
-	Epoch externalRef0.EpochID `json:"epoch"`
+	Node  externalRef0.Bytes32Hex `json:"node"`
+	Epoch externalRef0.EpochID    `json:"epoch"`
 }
 
 type GetEligibilitySlotsNodeEpochResponseObject interface {
@@ -805,8 +805,8 @@ func (response GetHareTotalWeightEpoch204Response) VisitGetHareTotalWeightEpochR
 }
 
 type GetHareWeightNodeIdEpochRequestObject struct {
-	NodeId externalRef0.Bytes32 `json:"node_id"`
-	Epoch  externalRef0.EpochID `json:"epoch"`
+	NodeId externalRef0.Bytes32Hex `json:"node_id"`
+	Epoch  externalRef0.EpochID    `json:"epoch"`
 }
 
 type GetHareWeightNodeIdEpochResponseObject interface {
@@ -852,8 +852,8 @@ func (response GetHareWeightNodeIdEpoch400PlaintextResponse) VisitGetHareWeightN
 }
 
 type GetProposalLayerNodeRequestObject struct {
-	Layer externalRef0.LayerID `json:"layer"`
-	Node  externalRef0.Bytes32 `json:"node"`
+	Layer externalRef0.LayerID    `json:"layer"`
+	Node  externalRef0.Bytes32Hex `json:"node"`
 }
 
 type GetProposalLayerNodeResponseObject interface {
@@ -988,7 +988,7 @@ type strictHandler struct {
 }
 
 // GetActivationAtxAtxId operation middleware
-func (sh *strictHandler) GetActivationAtxAtxId(w http.ResponseWriter, r *http.Request, atxId externalRef0.Bytes32) {
+func (sh *strictHandler) GetActivationAtxAtxId(w http.ResponseWriter, r *http.Request, atxId externalRef0.Bytes32Hex) {
 	var request GetActivationAtxAtxIdRequestObject
 
 	request.AtxId = atxId
@@ -1014,7 +1014,7 @@ func (sh *strictHandler) GetActivationAtxAtxId(w http.ResponseWriter, r *http.Re
 }
 
 // GetActivationLastAtxNodeId operation middleware
-func (sh *strictHandler) GetActivationLastAtxNodeId(w http.ResponseWriter, r *http.Request, nodeId externalRef0.Bytes32) {
+func (sh *strictHandler) GetActivationLastAtxNodeId(w http.ResponseWriter, r *http.Request, nodeId externalRef0.Bytes32Hex) {
 	var request GetActivationLastAtxNodeIdRequestObject
 
 	request.NodeId = nodeId
@@ -1097,7 +1097,7 @@ func (sh *strictHandler) PostActivationPublish(w http.ResponseWriter, r *http.Re
 }
 
 // GetEligibilitySlotsNodeEpoch operation middleware
-func (sh *strictHandler) GetEligibilitySlotsNodeEpoch(w http.ResponseWriter, r *http.Request, node externalRef0.Bytes32, epoch externalRef0.EpochID) {
+func (sh *strictHandler) GetEligibilitySlotsNodeEpoch(w http.ResponseWriter, r *http.Request, node externalRef0.Bytes32Hex, epoch externalRef0.EpochID) {
 	var request GetEligibilitySlotsNodeEpochRequestObject
 
 	request.Node = node
@@ -1204,7 +1204,7 @@ func (sh *strictHandler) GetHareTotalWeightEpoch(w http.ResponseWriter, r *http.
 }
 
 // GetHareWeightNodeIdEpoch operation middleware
-func (sh *strictHandler) GetHareWeightNodeIdEpoch(w http.ResponseWriter, r *http.Request, nodeId externalRef0.Bytes32, epoch externalRef0.EpochID) {
+func (sh *strictHandler) GetHareWeightNodeIdEpoch(w http.ResponseWriter, r *http.Request, nodeId externalRef0.Bytes32Hex, epoch externalRef0.EpochID) {
 	var request GetHareWeightNodeIdEpochRequestObject
 
 	request.NodeId = nodeId
@@ -1231,7 +1231,7 @@ func (sh *strictHandler) GetHareWeightNodeIdEpoch(w http.ResponseWriter, r *http
 }
 
 // GetProposalLayerNode operation middleware
-func (sh *strictHandler) GetProposalLayerNode(w http.ResponseWriter, r *http.Request, layer externalRef0.LayerID, node externalRef0.Bytes32) {
+func (sh *strictHandler) GetProposalLayerNode(w http.ResponseWriter, r *http.Request, layer externalRef0.LayerID, node externalRef0.Bytes32Hex) {
 	var request GetProposalLayerNodeRequestObject
 
 	request.Layer = layer

--- a/api/node/server/server.go
+++ b/api/node/server/server.go
@@ -112,7 +112,7 @@ func (s *Server) GetActivationAtxAtxId(
 	ctx context.Context,
 	request GetActivationAtxAtxIdRequestObject,
 ) (GetActivationAtxAtxIdResponseObject, error) {
-	id, err := models.ParseATXID(request.AtxId)
+	id, err := models.ParseATXIDHex(request.AtxId)
 	if err != nil {
 		msg := err.Error()
 		return GetActivationAtxAtxId400PlaintextResponse{
@@ -129,7 +129,7 @@ func (s *Server) GetActivationAtxAtxId(
 	}
 
 	return GetActivationAtxAtxId200JSONResponse{
-		ID:           request.AtxId,
+		ID:           id.Bytes(),
 		NumUnits:     atx.NumUnits,
 		PublishEpoch: atx.PublishEpoch.Uint32(),
 		Sequence:     &atx.Sequence,
@@ -144,7 +144,7 @@ func (s *Server) GetActivationLastAtxNodeId(
 	ctx context.Context,
 	request GetActivationLastAtxNodeIdRequestObject,
 ) (GetActivationLastAtxNodeIdResponseObject, error) {
-	id, err := models.ParseNodeID(request.NodeId)
+	id, err := models.ParseNodeIDHex(request.NodeId)
 	if err != nil {
 		msg := err.Error()
 		return GetActivationLastAtxNodeId400PlaintextResponse{
@@ -285,7 +285,7 @@ func (s *Server) GetHareTotalWeightEpoch(ctx context.Context,
 func (s *Server) GetHareWeightNodeIdEpoch(ctx context.Context,
 	request GetHareWeightNodeIdEpochRequestObject,
 ) (GetHareWeightNodeIdEpochResponseObject, error) {
-	id, err := models.ParseNodeID(request.NodeId)
+	id, err := models.ParseNodeIDHex(request.NodeId)
 	if err != nil {
 		msg := err.Error()
 		return GetHareWeightNodeIdEpoch400PlaintextResponse{
@@ -316,7 +316,7 @@ func (s *Server) GetHareBeaconEpoch(ctx context.Context,
 func (s *Server) GetProposalLayerNode(ctx context.Context, request GetProposalLayerNodeRequestObject) (
 	GetProposalLayerNodeResponseObject, error,
 ) {
-	id, err := models.ParseNodeID(request.Node)
+	id, err := models.ParseNodeIDHex(request.Node)
 	if err != nil {
 		msg := err.Error()
 		return GetProposalLayerNode400PlaintextResponse{
@@ -401,7 +401,7 @@ func (s *Server) GetEligibilitySlotsNodeEpoch(
 	ctx context.Context,
 	request GetEligibilitySlotsNodeEpochRequestObject,
 ) (GetEligibilitySlotsNodeEpochResponseObject, error) {
-	id, err := models.ParseNodeID(request.Node)
+	id, err := models.ParseNodeIDHex(request.Node)
 	if err != nil {
 		msg := err.Error()
 		return GetEligibilitySlotsNodeEpoch400PlaintextResponse{

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -1328,6 +1328,8 @@ func getTestDefaultConfig(tb testing.TB) *config.Config {
 	cfg.POST.LabelsPerUnit = 32
 	cfg.POST.K2 = 4
 
+	cfg.BaseConfig.PoetServers = nil
+
 	cfg.SMESHING = config.DefaultSmeshingConfig()
 	cfg.SMESHING.Start = false
 	cfg.SMESHING.CoinbaseAccount = types.GenerateAddress([]byte{1}).String()


### PR DESCRIPTION
Fixing invalid encoding of bytes path parameters in the node-service API. Previously they were encoded as comma-separated bytes like:
```
http://127.0.0.1:36637/proposal/10000/243,161,4,243,36,232,61,219,173,52,174,32,221,0,16,11,108,133,168,113,234,178,43,125,216,175,119,36,118,197,121,23
```

Now, they are encoded in hex:
```
http://127.0.0.1:34037/proposal/10000/b09edfc6bebe09f4642b99f4d67ae11d977195b75e9204e27d38318dac08daf
```