### PR TITLE
[Merged by Bors] - don't query prod poets in node tests and add timeout

### DIFF
--- a/activation/poet.go
+++ b/activation/poet.go
@@ -462,7 +462,10 @@ func NewPoetServiceWithClient(
 		opt(service)
 	}
 
-	err := service.verifyPhaseShiftConfiguration(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	defer cancel()
+
+	err := service.verifyPhaseShiftConfiguration(ctx)
 	switch {
 	case errors.Is(err, errIncompatiblePhaseShift):
 		logger.Fatal("failed to create poet service", zap.String("poet", client.Address()))

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -1253,6 +1253,8 @@ func getTestDefaultConfig(tb testing.TB) *config.Config {
 	cfg.POST.LabelsPerUnit = 32
 	cfg.POST.K2 = 4
 
+	cfg.BaseConfig.PoetServers = nil
+
 	cfg.SMESHING = config.DefaultSmeshingConfig()
 	cfg.SMESHING.Start = false
 	cfg.SMESHING.CoinbaseAccount = types.GenerateAddress([]byte{1}).String()


### PR DESCRIPTION
## Motivation

Unit tests in node_test.go query prod poets in `NewPoetServiceWithClient()` and might timeout if poet is not responding.

## Description

The tests should query prod poets. In fact, they don't need to talk with poets at all so I removed all poets from the test config.

I also added missing timeout to the poet query in `NewPoetServiceWithClient()` so it doesn't hang for too long during startup.

## Test Plan

Existing tests pass