### PR TITLE
[Merged by Bors] - Improve test config handling

### DIFF
--- a/activation/e2e/nipost_test.go
+++ b/activation/e2e/nipost_test.go
@@ -92,7 +92,7 @@ func launchPostSupervisor(
 	postCfg activation.PostConfig,
 	postOpts activation.PostSetupOpts,
 ) func() {
-	cmdCfg := activation.DefaultTestPostServiceConfig()
+	cmdCfg := activation.DefaultTestPostServiceConfig(tb)
 	cmdCfg.NodeAddress = fmt.Sprintf("http://%s", cfg.PublicListener)
 	provingOpts := activation.DefaultPostProvingOpts()
 	provingOpts.RandomXMode = activation.PostRandomXModeLight
@@ -105,7 +105,7 @@ func launchPostSupervisor(
 }
 
 func launchServer(tb testing.TB, services ...grpcserver.ServiceAPI) (grpcserver.Config, func()) {
-	cfg := grpcserver.DefaultTestConfig()
+	cfg := grpcserver.DefaultTestConfig(tb)
 
 	// run on random ports
 	server := grpcserver.New("127.0.0.1:0", zaptest.NewLogger(tb).Named("grpc"), cfg)

--- a/activation/post_supervisor.go
+++ b/activation/post_supervisor.go
@@ -13,8 +13,10 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"testing"
 
 	"github.com/spacemeshos/post/initialization"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 
@@ -39,11 +41,9 @@ func DefaultPostServiceConfig() PostSupervisorConfig {
 }
 
 // DefaultTestPostServiceConfig returns the default config for post service in tests.
-func DefaultTestPostServiceConfig() PostSupervisorConfig {
+func DefaultTestPostServiceConfig(tb testing.TB) PostSupervisorConfig {
 	path, err := exec.Command("go", "env", "GOMOD").Output()
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(tb, err)
 
 	return PostSupervisorConfig{
 		PostServiceCmd: filepath.Join(filepath.Dir(string(path)), "build", DefaultPostServiceName),

--- a/activation/post_supervisor_test.go
+++ b/activation/post_supervisor_test.go
@@ -66,7 +66,7 @@ func newPostManager(tb testing.TB, cfg PostConfig, opts PostSetupOpts) *PostSetu
 func Test_PostSupervisor_ErrorOnMissingBinary(t *testing.T) {
 	log := zaptest.NewLogger(t)
 
-	cmdCfg := DefaultTestPostServiceConfig()
+	cmdCfg := DefaultTestPostServiceConfig(t)
 	cmdCfg.PostServiceCmd = "missing"
 	postCfg := DefaultPostConfig()
 	postOpts := DefaultPostSetupOpts()
@@ -93,7 +93,7 @@ func Test_PostSupervisor_StopWithoutStart(t *testing.T) {
 func Test_PostSupervisor_Start_FailPrepare(t *testing.T) {
 	log := zaptest.NewLogger(t).WithOptions(zap.WithFatalHook(calledFatal(t)))
 
-	cmdCfg := DefaultTestPostServiceConfig()
+	cmdCfg := DefaultTestPostServiceConfig(t)
 	postCfg := DefaultPostConfig()
 	postOpts := DefaultPostSetupOpts()
 	postOpts.DataDir = t.TempDir()
@@ -129,7 +129,7 @@ func calledFatal(tb testing.TB) zapcore.CheckWriteHook {
 func Test_PostSupervisor_Start_FailStartSession(t *testing.T) {
 	log := zaptest.NewLogger(t, zaptest.WrapOptions(zap.WithFatalHook(calledFatal(t))))
 
-	cmdCfg := DefaultTestPostServiceConfig()
+	cmdCfg := DefaultTestPostServiceConfig(t)
 	postCfg := DefaultPostConfig()
 	postOpts := DefaultPostSetupOpts()
 	postOpts.DataDir = t.TempDir()
@@ -151,7 +151,7 @@ func Test_PostSupervisor_Start_FailStartSession(t *testing.T) {
 func Test_PostSupervisor_StartsServiceCmd(t *testing.T) {
 	log := zaptest.NewLogger(t)
 
-	cmdCfg := DefaultTestPostServiceConfig()
+	cmdCfg := DefaultTestPostServiceConfig(t)
 	postCfg := DefaultPostConfig()
 	postOpts := testSetupOpts(t)
 	provingOpts := DefaultPostProvingOpts()
@@ -188,7 +188,7 @@ func Test_PostSupervisor_StartsServiceCmd(t *testing.T) {
 func Test_PostSupervisor_Restart_Possible(t *testing.T) {
 	log := zaptest.NewLogger(t)
 
-	cmdCfg := DefaultTestPostServiceConfig()
+	cmdCfg := DefaultTestPostServiceConfig(t)
 	postCfg := DefaultPostConfig()
 	postOpts := testSetupOpts(t)
 	provingOpts := DefaultPostProvingOpts()
@@ -219,7 +219,7 @@ func Test_PostSupervisor_Restart_Possible(t *testing.T) {
 func Test_PostSupervisor_LogFatalOnCrash(t *testing.T) {
 	log := zaptest.NewLogger(t, zaptest.WrapOptions(zap.WithFatalHook(calledFatal(t))))
 
-	cmdCfg := DefaultTestPostServiceConfig()
+	cmdCfg := DefaultTestPostServiceConfig(t)
 	postCfg := DefaultPostConfig()
 	postOpts := testSetupOpts(t)
 	provingOpts := DefaultPostProvingOpts()
@@ -250,7 +250,7 @@ func Test_PostSupervisor_LogFatalOnCrash(t *testing.T) {
 func Test_PostSupervisor_LogFatalOnInvalidConfig(t *testing.T) {
 	log := zaptest.NewLogger(t, zaptest.WrapOptions(zap.WithFatalHook(calledFatal(t))))
 
-	cmdCfg := DefaultTestPostServiceConfig()
+	cmdCfg := DefaultTestPostServiceConfig(t)
 	cmdCfg.NodeAddress = "http://127.0.0.1:9099" // wrong port
 	cmdCfg.MaxRetries = 1                        // speedup test, will fail on 2nd retry (~ 5s)
 	postCfg := DefaultPostConfig()
@@ -282,7 +282,7 @@ func Test_PostSupervisor_LogFatalOnInvalidConfig(t *testing.T) {
 func Test_PostSupervisor_StopOnError(t *testing.T) {
 	log := zaptest.NewLogger(t)
 
-	cmdCfg := DefaultTestPostServiceConfig()
+	cmdCfg := DefaultTestPostServiceConfig(t)
 	postCfg := DefaultPostConfig()
 	postOpts := testSetupOpts(t)
 	provingOpts := DefaultPostProvingOpts()

--- a/api/grpcserver/config.go
+++ b/api/grpcserver/config.go
@@ -2,6 +2,7 @@
 package grpcserver
 
 import (
+	"testing"
 	"time"
 )
 
@@ -74,9 +75,12 @@ const (
 func DefaultConfig() Config {
 	return Config{
 		PublicServices: []Service{
-			GlobalState, Mesh, Transaction, Node, Activation, ActivationV2Alpha1,
-			RewardV2Alpha1, NetworkV2Alpha1, NodeV2Alpha1, LayerV2Alpha1, TransactionV2Alpha1,
-			AccountV2Alpha1, MalfeasanceV2Alpha1,
+			// v1
+			GlobalState, Mesh, Transaction, Node, Activation,
+
+			// v2alpha1
+			ActivationV2Alpha1, RewardV2Alpha1, NetworkV2Alpha1, NodeV2Alpha1,
+			LayerV2Alpha1, TransactionV2Alpha1, AccountV2Alpha1, MalfeasanceV2Alpha1,
 
 			// v2beta1
 			ActivationV2Beta1, RewardV2Beta1, NetworkV2Beta1, NodeV2Beta1,
@@ -84,9 +88,12 @@ func DefaultConfig() Config {
 		},
 		PublicListener: "0.0.0.0:9092",
 		PrivateServices: []Service{
-			Admin, Smesher, Debug, ActivationStreamV2Alpha1,
-			RewardStreamV2Alpha1, LayerStreamV2Alpha1, TransactionStreamV2Alpha1,
-			MalfeasanceStreamV2Alpha1,
+			// v1
+			Admin, Smesher, Debug,
+
+			// v2alpha1
+			ActivationStreamV2Alpha1, RewardStreamV2Alpha1, LayerStreamV2Alpha1,
+			TransactionStreamV2Alpha1, MalfeasanceStreamV2Alpha1,
 
 			// v2beta1
 			ActivationStreamV2Beta1, RewardStreamV2Beta1, LayerStreamV2Beta1,
@@ -107,7 +114,7 @@ func DefaultConfig() Config {
 }
 
 // DefaultTestConfig returns the default config for tests.
-func DefaultTestConfig() Config {
+func DefaultTestConfig(tb testing.TB) Config {
 	conf := DefaultConfig()
 	conf.PublicListener = "127.0.0.1:0"
 	conf.PrivateListener = "127.0.0.1:0"

--- a/api/grpcserver/grpcserver_test.go
+++ b/api/grpcserver/grpcserver_test.go
@@ -400,7 +400,7 @@ func NewTx(nonce uint64, recipient types.Address, signer *signing.EdSigner) *typ
 }
 
 func launchServer(tb testing.TB, services ...ServiceAPI) (Config, func()) {
-	cfg := DefaultTestConfig()
+	cfg := DefaultTestConfig(tb)
 	grpcService, err := NewWithServices(cfg.PublicListener, zaptest.NewLogger(tb).Named("grpc"), cfg, services)
 	require.NoError(tb, err)
 
@@ -432,7 +432,7 @@ func TestNewServersConfig(t *testing.T) {
 	port2, err := getFreePort(0)
 	require.NoError(t, err, "Should be able to establish a connection on a port")
 
-	grpcService := New(fmt.Sprintf(":%d", port1), zaptest.NewLogger(t).Named("grpc"), DefaultTestConfig())
+	grpcService := New(fmt.Sprintf(":%d", port1), zaptest.NewLogger(t).Named("grpc"), DefaultTestConfig(t))
 	jsonService := NewJSONHTTPServer(zaptest.NewLogger(t).Named("grpc.JSON"), fmt.Sprintf(":%d", port2),
 		[]string{}, false)
 
@@ -483,7 +483,7 @@ func TestNewLocalServer(t *testing.T) {
 			genTime := NewMockgenesisTimeAPI(ctrl)
 			syncer := NewMocksyncer(ctrl)
 
-			cfg := DefaultTestConfig()
+			cfg := DefaultTestConfig(t)
 			cfg.PostListener = tc.listener
 			svc := NewNodeService(peerCounter, meshApi, genTime, syncer, "v0.0.0", "cafebabe")
 			grpcService, err := NewWithServices(cfg.PostListener, logger, cfg, []ServiceAPI{svc})
@@ -523,7 +523,7 @@ func setupSmesherService(tb testing.TB, sig *signing.EdSigner) (*smesherServiceC
 		activation.DefaultPostSetupOpts(),
 		sig,
 	)
-	svc.SetPostServiceConfig(activation.DefaultTestPostServiceConfig())
+	svc.SetPostServiceConfig(activation.DefaultTestPostServiceConfig(tb))
 	cfg, cleanup := launchServer(tb, svc)
 	tb.Cleanup(cleanup)
 

--- a/api/grpcserver/grpcserver_tls_test.go
+++ b/api/grpcserver/grpcserver_tls_test.go
@@ -147,7 +147,7 @@ func launchTLSServer(tb testing.TB, certDir string, services ...ServiceAPI) (Con
 	serverCert := filepath.Join(certDir, serverCertName)
 	serverKey := filepath.Join(certDir, serverKeyName)
 
-	cfg := DefaultTestConfig()
+	cfg := DefaultTestConfig(tb)
 	cfg.TLSListener = "127.0.0.1:0"
 	cfg.TLSCACert = caCert
 	cfg.TLSCert = serverCert

--- a/api/grpcserver/http_server_test.go
+++ b/api/grpcserver/http_server_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func launchJsonServer(tb testing.TB, services ...ServiceAPI) (Config, func()) {
-	cfg := DefaultTestConfig()
+	cfg := DefaultTestConfig(tb)
 
 	// run on random port
 	jsonService := NewJSONHTTPServer(zaptest.NewLogger(tb).Named("grpc.JSON"), "127.0.0.1:0",

--- a/api/grpcserver/post_service_test.go
+++ b/api/grpcserver/post_service_test.go
@@ -127,7 +127,7 @@ func Test_GenerateProof(t *testing.T) {
 	opts.ProviderID.SetUint32(initialization.CPUProviderID())
 	opts.Scrypt.N = 2 // Speedup initialization in tests.
 
-	serviceCfg := activation.DefaultTestPostServiceConfig()
+	serviceCfg := activation.DefaultTestPostServiceConfig(t)
 	serviceCfg.NodeAddress = fmt.Sprintf("http://%s", cfg.PublicListener)
 
 	id, postCleanup := launchPostSupervisor(t, log.Named("supervisor"), cfg, serviceCfg, opts)
@@ -175,7 +175,7 @@ func Test_GenerateProof_TLS(t *testing.T) {
 	opts.ProviderID.SetUint32(initialization.CPUProviderID())
 	opts.Scrypt.N = 2 // Speedup initialization in tests.
 
-	serviceCfg := activation.DefaultTestPostServiceConfig()
+	serviceCfg := activation.DefaultTestPostServiceConfig(t)
 	serviceCfg.NodeAddress = fmt.Sprintf("https://%s", cfg.TLSListener)
 	serviceCfg.CACert = filepath.Join(certDir, caCertName)
 	serviceCfg.Cert = filepath.Join(certDir, clientCertName)
@@ -225,7 +225,7 @@ func Test_GenerateProof_Cancel(t *testing.T) {
 	opts.ProviderID.SetUint32(initialization.CPUProviderID())
 	opts.Scrypt.N = 2 // Speedup initialization in tests.
 
-	serviceCfg := activation.DefaultTestPostServiceConfig()
+	serviceCfg := activation.DefaultTestPostServiceConfig(t)
 	serviceCfg.NodeAddress = fmt.Sprintf("http://%s", cfg.PublicListener)
 
 	id, postCleanup := launchPostSupervisor(t, log.Named("supervisor"), cfg, serviceCfg, opts)
@@ -265,7 +265,7 @@ func Test_Metadata(t *testing.T) {
 	opts.ProviderID.SetUint32(initialization.CPUProviderID())
 	opts.Scrypt.N = 2 // Speedup initialization in tests.
 
-	serviceCfg := activation.DefaultTestPostServiceConfig()
+	serviceCfg := activation.DefaultTestPostServiceConfig(t)
 	serviceCfg.NodeAddress = fmt.Sprintf("http://%s", cfg.PublicListener)
 
 	id, postCleanup := launchPostSupervisor(t, log.Named("supervisor"), cfg, serviceCfg, opts)
@@ -309,7 +309,7 @@ func Test_GenerateProof_MultipleServices(t *testing.T) {
 	opts.ProviderID.SetUint32(initialization.CPUProviderID())
 	opts.Scrypt.N = 2 // Speedup initialization in tests.
 
-	serviceCfg := activation.DefaultTestPostServiceConfig()
+	serviceCfg := activation.DefaultTestPostServiceConfig(t)
 	serviceCfg.NodeAddress = fmt.Sprintf("http://%s", cfg.PublicListener)
 
 	// all but one should not be able to register to the node (i.e. open a stream to it).

--- a/api/grpcserver/smesher_service_test.go
+++ b/api/grpcserver/smesher_service_test.go
@@ -60,7 +60,7 @@ func TestStartSmeshingPassesCorrectSmeshingOpts(t *testing.T) {
 	grpcPostService := grpcserver.NewMockgrpcPostService(ctrl)
 	sig, err := signing.NewEdSigner()
 	require.NoError(t, err)
-	cmdCfg := activation.DefaultTestPostServiceConfig()
+	cmdCfg := activation.DefaultTestPostServiceConfig(t)
 	svc := grpcserver.NewSmesherService(
 		smeshingProvider,
 		postSupervisor,
@@ -155,7 +155,7 @@ func TestStartSmeshing_ErrorOnMultiSmeshingSetup(t *testing.T) {
 		activation.DefaultPostSetupOpts(),
 		nil, // no nodeID in multi smesher setup
 	)
-	svc.SetPostServiceConfig(activation.DefaultTestPostServiceConfig())
+	svc.SetPostServiceConfig(activation.DefaultTestPostServiceConfig(t))
 
 	types.SetNetworkHRP("stest")
 	providerID := uint32(7)

--- a/api/grpcserver/v2alpha1/network_test.go
+++ b/api/grpcserver/v2alpha1/network_test.go
@@ -15,7 +15,7 @@ import (
 func TestNetworkService_Info(t *testing.T) {
 	ctx := context.Background()
 	genesis := time.Unix(genTimeUnix, 0)
-	c := config.DefaultTestConfig()
+	c := config.DefaultTestConfig(t)
 
 	svc := NewNetworkService(genesis, &c)
 	cfg, cleanup := launchServer(t, svc)

--- a/api/grpcserver/v2alpha1/v2alpha1_test.go
+++ b/api/grpcserver/v2alpha1/v2alpha1_test.go
@@ -19,7 +19,7 @@ const (
 )
 
 func launchServer(tb testing.TB, services ...grpcserver.ServiceAPI) (grpcserver.Config, func()) {
-	cfg := grpcserver.DefaultTestConfig()
+	cfg := grpcserver.DefaultTestConfig(tb)
 	grpc, err := grpcserver.NewWithServices(cfg.PublicListener, zaptest.NewLogger(tb).Named("grpc"), cfg, services)
 	require.NoError(tb, err)
 

--- a/api/grpcserver/v2beta1/network_test.go
+++ b/api/grpcserver/v2beta1/network_test.go
@@ -15,7 +15,7 @@ import (
 func TestNetworkService_Info(t *testing.T) {
 	ctx := context.Background()
 	genesis := time.Unix(genTimeUnix, 0)
-	c := config.DefaultTestConfig()
+	c := config.DefaultTestConfig(t)
 
 	svc := NewNetworkService(genesis, &c)
 	cfg, cleanup := launchServer(t, svc)

--- a/api/grpcserver/v2beta1/v2alpha1_test.go
+++ b/api/grpcserver/v2beta1/v2alpha1_test.go
@@ -19,7 +19,7 @@ const (
 )
 
 func launchServer(tb testing.TB, services ...grpcserver.ServiceAPI) (grpcserver.Config, func()) {
-	cfg := grpcserver.DefaultTestConfig()
+	cfg := grpcserver.DefaultTestConfig(tb)
 	grpc, err := grpcserver.NewWithServices(cfg.PublicListener, zaptest.NewLogger(tb).Named("grpc"), cfg, services)
 	require.NoError(tb, err)
 

--- a/beacon/beacon_test.go
+++ b/beacon/beacon_test.go
@@ -180,7 +180,7 @@ func TestBeacon_MultipleNodes(t *testing.T) {
 	atxPublishLid := types.LayerID(types.GetLayersPerEpoch()*2 - 1)
 	current := atxPublishLid.Add(1)
 	dbs := make([]*datastore.CachedDB, 0, numNodes)
-	cfg := NodeSimUnitTestConfig()
+	cfg := NodeSimUnitTestConfig(t)
 	bootstrap := types.Beacon{1, 2, 3, 4}
 	now := time.Now()
 	for i := 0; i < numNodes; i++ {
@@ -246,7 +246,7 @@ func TestBeacon_MultipleNodes_OnlyOneHonest(t *testing.T) {
 	atxPublishLid := types.LayerID(types.GetLayersPerEpoch()*2 - 1)
 	current := atxPublishLid.Add(1)
 	dbs := make([]*datastore.CachedDB, 0, numNodes)
-	cfg := NodeSimUnitTestConfig()
+	cfg := NodeSimUnitTestConfig(t)
 	bootstrap := types.Beacon{1, 2, 3, 4}
 	now := time.Now()
 	for i := 0; i < numNodes; i++ {
@@ -300,7 +300,7 @@ func TestBeacon_NoProposals(t *testing.T) {
 	atxPublishLid := types.LayerID(types.GetLayersPerEpoch()*2 - 1)
 	current := atxPublishLid.Add(1)
 	dbs := make([]*datastore.CachedDB, 0, numNodes)
-	cfg := NodeSimUnitTestConfig()
+	cfg := NodeSimUnitTestConfig(t)
 	now := time.Now()
 	bootstrap := types.Beacon{1, 2, 3, 4}
 	for i := 0; i < numNodes; i++ {

--- a/beacon/config.go
+++ b/beacon/config.go
@@ -2,6 +2,7 @@ package beacon
 
 import (
 	"math/big"
+	"testing"
 	"time"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
@@ -69,7 +70,7 @@ func UnitTestConfig() Config {
 }
 
 // NodeSimUnitTestConfig returns configuration for the beacon the unit tests with node simulation .
-func NodeSimUnitTestConfig() Config {
+func NodeSimUnitTestConfig(tb testing.TB) Config {
 	return Config{
 		Kappa:                    40,
 		Q:                        *big.NewRat(1, 3),

--- a/cmd/bootstrapper/generator_test.go
+++ b/cmd/bootstrapper/generator_test.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -27,11 +26,6 @@ import (
 	"github.com/spacemeshos/go-spacemesh/sql/atxs"
 	"github.com/spacemeshos/go-spacemesh/sql/statesql"
 )
-
-func TestMain(m *testing.M) {
-	types.SetLayersPerEpoch(epochLayers)
-	os.Exit(m.Run())
-}
 
 const (
 	epochLayers    = 3
@@ -61,7 +55,7 @@ func createAtxs(tb testing.TB, db sql.Executor, epoch types.EpochID, atxids []ty
 }
 
 func launchServer(tb testing.TB, db sql.StateDatabase) (grpcserver.Config, func()) {
-	cfg := grpcserver.DefaultTestConfig()
+	cfg := grpcserver.DefaultTestConfig(tb)
 	grpcService := grpcserver.New("127.0.0.1:0", zaptest.NewLogger(tb).Named("grpc"), cfg)
 	jsonService := grpcserver.NewJSONHTTPServer(zaptest.NewLogger(tb).Named("grpc.JSON"), "127.0.0.1:0",
 		[]string{}, false)

--- a/config/config.go
+++ b/config/config.go
@@ -7,8 +7,10 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"testing"
 	"time"
 
+	"github.com/spacemeshos/post/initialization"
 	"github.com/spf13/viper"
 
 	"github.com/spacemeshos/go-spacemesh/activation"
@@ -207,15 +209,46 @@ func DefaultConfig() Config {
 }
 
 // DefaultTestConfig returns the default config for tests.
-func DefaultTestConfig() Config {
+func DefaultTestConfig(tb testing.TB) Config {
 	conf := DefaultConfig()
 	conf.BaseConfig = defaultTestConfig()
-	conf.Genesis = DefaultTestGenesisConfig()
-	conf.P2P = p2p.DefaultConfig()
-	conf.API = grpcserver.DefaultTestConfig()
-	conf.POSTService = activation.DefaultTestPostServiceConfig()
-	conf.HARE3.PreroundDelay = 1 * time.Second
-	conf.HARE3.RoundDuration = 1 * time.Second
+	conf.DataDirParent = tb.TempDir()
+	conf.FileLock = filepath.Join(conf.DataDirParent, "spacemesh.lock") // allows multiple configs in one test
+	conf.LayerDuration = 2 * time.Second
+
+	conf.Genesis = DefaultTestGenesisConfig(tb)
+
+	conf.POST.MinNumUnits = 2
+	conf.POST.MaxNumUnits = 4
+	conf.POST.LabelsPerUnit = 32
+	conf.POST.K2 = 4
+
+	conf.SMESHING.CoinbaseAccount = types.GenerateAddress([]byte{1}).String()
+	conf.SMESHING.Opts.DataDir = filepath.Join(conf.DataDirParent, "post")
+	conf.SMESHING.Opts.NumUnits = conf.POST.MinNumUnits + 1
+	conf.SMESHING.Opts.Scrypt.N = 2
+	conf.SMESHING.Opts.ProviderID.SetUint32(initialization.CPUProviderID())
+
+	// is set to 0 to make sync start immediately when node starts
+	conf.P2P.MinPeers = 0
+
+	conf.Tortoise.Hdist = 5
+	conf.Tortoise.Zdist = 5
+
+	conf.API = grpcserver.DefaultTestConfig(tb)
+	conf.POSTService = activation.DefaultTestPostServiceConfig(tb)
+	conf.Beacon = beacon.NodeSimUnitTestConfig(tb)
+
+	conf.HARE3.PreroundDelay = 10 * time.Millisecond
+	conf.HARE3.RoundDuration = 20 * time.Millisecond
+	conf.HARE4.PreroundDelay = 10 * time.Millisecond
+	conf.HARE4.RoundDuration = 20 * time.Millisecond
+
+	conf.Sync.Interval = time.Second
+
+	conf.FETCH.RequestTimeout = 10 * time.Second
+	conf.FETCH.RequestHardTimeout = 20 * time.Second
+	conf.FETCH.BatchSize = 5
 	return conf
 }
 
@@ -228,6 +261,7 @@ func defaultBaseConfig() BaseConfig {
 		MetricsPort:                  1010,
 		ProfilerName:                 "go-spacemesh",
 		LayerDuration:                30 * time.Second,
+		LayerAvgSize:                 5,
 		LayersPerEpoch:               3,
 		TxsPerProposal:               100,
 		BlockGasLimit:                math.MaxUint64,
@@ -266,6 +300,7 @@ func defaultTestConfig() BaseConfig {
 	conf.MetricsPort += 10000
 	conf.NetworkHRP = "stest"
 	types.SetNetworkHRP(conf.NetworkHRP)
+	types.SetLayersPerEpoch(conf.LayersPerEpoch)
 	return conf
 }
 

--- a/config/genesis.go
+++ b/config/genesis.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
@@ -157,7 +158,7 @@ func DefaultGenesisConfig() GenesisConfig {
 }
 
 // DefaultTestGenesisConfig is the default test configuration for the node.
-func DefaultTestGenesisConfig() GenesisConfig {
+func DefaultTestGenesisConfig(tb testing.TB) GenesisConfig {
 	// NOTE(dshulyak) keys in default config are used in some tests
 	return GenesisConfig{
 		ExtraData:   "testnet",

--- a/config/presets/fastnet.go
+++ b/config/presets/fastnet.go
@@ -67,8 +67,8 @@ func fastnet() config.Config {
 	conf.HareEligibility.ConfidenceParam = 2
 
 	conf.POST.K1 = 12
-	conf.POST.K2 = 4
-	conf.POST.K3 = 2
+	conf.POST.K2 = 8
+	conf.POST.K3 = 7
 	conf.POST.LabelsPerUnit = 128
 	conf.POST.MaxNumUnits = 4
 	conf.POST.MinNumUnits = 2

--- a/config/presets/fastnet.go
+++ b/config/presets/fastnet.go
@@ -67,8 +67,8 @@ func fastnet() config.Config {
 	conf.HareEligibility.ConfidenceParam = 2
 
 	conf.POST.K1 = 12
-	conf.POST.K2 = 8
-	conf.POST.K3 = 7
+	conf.POST.K2 = 4
+	conf.POST.K3 = 3
 	conf.POST.LabelsPerUnit = 128
 	conf.POST.MaxNumUnits = 4
 	conf.POST.MinNumUnits = 2

--- a/node/adminservice_api_test.go
+++ b/node/adminservice_api_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestPeerInfoApi(t *testing.T) {
-	cfg := config.DefaultTestConfig()
+	cfg := config.DefaultTestConfig(t)
 	cfg.Genesis.Accounts = nil
 	cfg.P2P.DisableNatPort = true
 	cfg.P2P.Listen = p2p.MustParseAddresses("/ip4/127.0.0.1/tcp/0")

--- a/node/bad_peer_test.go
+++ b/node/bad_peer_test.go
@@ -3,7 +3,6 @@ package node
 import (
 	"context"
 	"encoding/binary"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -30,9 +29,7 @@ func TestPeerDisconnectForMessageResultValidationReject(t *testing.T) {
 	l := logtest.New(t)
 
 	// Make 2 node instances
-	conf1 := config.DefaultTestConfig()
-	conf1.DataDirParent = t.TempDir()
-	conf1.FileLock = filepath.Join(conf1.DataDirParent, "LOCK")
+	conf1 := config.DefaultTestConfig(t)
 	conf1.P2P.Listen = p2p.MustParseAddresses("/ip4/127.0.0.1/tcp/0")
 	conf1.P2P.IP4Blocklist = nil
 	// We setup the api to listen on an OS assigned port, which avoids the second instance getting stuck when
@@ -43,10 +40,8 @@ func TestPeerDisconnectForMessageResultValidationReject(t *testing.T) {
 	// We need to copy the genesis config to ensure that both nodes share the
 	// same genesis ID, otherwise they will not be able to connect to each
 	// other.
-	conf2 := config.DefaultTestConfig()
+	conf2 := config.DefaultTestConfig(t)
 	conf2.Genesis = conf1.Genesis
-	conf2.DataDirParent = t.TempDir()
-	conf2.FileLock = filepath.Join(conf2.DataDirParent, "LOCK")
 	conf2.P2P.Listen = p2p.MustParseAddresses("/ip4/127.0.0.1/tcp/0")
 	conf2.P2P.IP4Blocklist = nil
 	conf2.API.PublicListener = "0.0.0.0:0"

--- a/node/node_identities_test.go
+++ b/node/node_identities_test.go
@@ -15,6 +15,7 @@ import (
 	"go.uber.org/zap/zaptest"
 	"go.uber.org/zap/zaptest/observer"
 
+	"github.com/spacemeshos/go-spacemesh/config"
 	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/log/logtest"
 	"github.com/spacemeshos/go-spacemesh/signing"
@@ -27,7 +28,8 @@ func setupAppWithKeys(tb testing.TB, data ...[]byte) (*App, *observer.ObservedLo
 			return zapcore.NewTee(core, observer)
 		},
 	)))
-	app := New(WithLog(log.NewFromLog(logger)))
+	cfg := config.DefaultTestConfig(tb)
+	app := New(WithLog(log.NewFromLog(logger)), WithConfig(&cfg))
 	app.Config.DataDirParent = tb.TempDir()
 	if len(data) == 0 {
 		return app, observedLogs

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -17,7 +17,6 @@ import (
 
 	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
 	pb "github.com/spacemeshos/api/release/go/spacemesh/v1"
-	"github.com/spacemeshos/post/initialization"
 	"github.com/spacemeshos/post/shared"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -38,7 +37,6 @@ import (
 
 	"github.com/spacemeshos/go-spacemesh/activation"
 	"github.com/spacemeshos/go-spacemesh/api/grpcserver"
-	"github.com/spacemeshos/go-spacemesh/beacon"
 	"github.com/spacemeshos/go-spacemesh/cmd"
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/config"
@@ -75,8 +73,8 @@ func newLogger(buf *bytes.Buffer) log.Log {
 func TestSpacemeshApp_SetLoggers(t *testing.T) {
 	r := require.New(t)
 
-	cfg := getTestDefaultConfig(t)
-	app := New(WithConfig(cfg), WithLog(logtest.New(t)))
+	cfg := config.DefaultTestConfig(t)
+	app := New(WithConfig(&cfg), WithLog(logtest.New(t)))
 
 	var buf1, buf2 bytes.Buffer
 	myLogger := "anton"
@@ -133,8 +131,8 @@ func TestSpacemeshApp_AddLogger(t *testing.T) {
 	var buf bytes.Buffer
 	lg := newLogger(&buf)
 
-	cfg := getTestDefaultConfig(t)
-	app := New(WithConfig(cfg), WithLog(logtest.New(t)))
+	cfg := config.DefaultTestConfig(t)
+	app := New(WithConfig(&cfg), WithLog(logtest.New(t)))
 
 	myLogger := "anton"
 	subLogger := app.addLogger(myLogger, lg)
@@ -169,8 +167,8 @@ func cmdWithRun(run func(*cobra.Command, []string) error) *cobra.Command {
 func TestSpacemeshApp_Cmd(t *testing.T) {
 	r := require.New(t)
 
-	cfg := getTestDefaultConfig(t)
-	app := New(WithConfig(cfg), WithLog(logtest.New(t)))
+	cfg := config.DefaultTestConfig(t)
+	app := New(WithConfig(&cfg), WithLog(logtest.New(t)))
 
 	expected := `unknown command "illegal" for "node"`
 	expected2 := "Error: " + expected + "\nRun 'node --help' for usage.\n"
@@ -211,9 +209,9 @@ func TestSpacemeshApp_GrpcService(t *testing.T) {
 	listener := "127.0.0.1:1242"
 
 	r := require.New(t)
-	cfg := getTestDefaultConfig(t)
+	cfg := config.DefaultTestConfig(t)
 	cfg.API.PublicListener = listener
-	app := New(WithConfig(cfg), WithLog(logtest.New(t)))
+	app := New(WithConfig(&cfg), WithLog(logtest.New(t)))
 	err := app.NewIdentity()
 	require.NoError(t, err)
 
@@ -257,8 +255,8 @@ func TestSpacemeshApp_GrpcService(t *testing.T) {
 
 func TestSpacemeshApp_JsonServiceNotRunning(t *testing.T) {
 	r := require.New(t)
-	cfg := getTestDefaultConfig(t)
-	app := New(WithConfig(cfg), WithLog(logtest.New(t)))
+	cfg := config.DefaultTestConfig(t)
+	app := New(WithConfig(&cfg), WithLog(logtest.New(t)))
 	err := app.NewIdentity()
 	require.NoError(t, err)
 
@@ -289,10 +287,10 @@ func TestSpacemeshApp_JsonService(t *testing.T) {
 	payload := marshalProto(t, &pb.EchoRequest{Msg: &pb.SimpleString{Value: message}})
 	listener := "127.0.0.1:0"
 
-	cfg := getTestDefaultConfig(t)
+	cfg := config.DefaultTestConfig(t)
 	cfg.API.JSONListener = listener
 	cfg.API.PrivateServices = nil
-	app := New(WithConfig(cfg), WithLog(logtest.New(t)))
+	app := New(WithConfig(&cfg), WithLog(logtest.New(t)))
 
 	var err error
 	app.clock, err = timesync.NewClock(
@@ -344,8 +342,8 @@ func TestSpacemeshApp_NodeService(t *testing.T) {
 		zaptest.NewLogger(t, zaptest.WrapOptions(zap.Hooks(events.EventHook()), zap.WithPanicHook(&noopHook{}))),
 	)
 
-	cfg := getTestDefaultConfig(t)
-	app := New(WithConfig(cfg), WithLog(logger))
+	cfg := config.DefaultTestConfig(t)
+	app := New(WithConfig(&cfg), WithLog(logger))
 
 	signer, err := signing.NewEdSigner()
 	require.NoError(t, err)
@@ -364,12 +362,6 @@ func TestSpacemeshApp_NodeService(t *testing.T) {
 		// Give the error channel a buffer
 		events.CloseEventReporter()
 		events.InitializeReporter()
-
-		// Speed things up a little
-		app.Config.Sync.Interval = time.Second
-		app.Config.LayerDuration = 2 * time.Second
-		app.Config.DataDirParent = t.TempDir()
-		app.Config.API.PublicListener = "localhost:0"
 
 		// This will block. We need to run the full app here to make sure that
 		// the various services are reporting events correctly. This could probably
@@ -465,8 +457,7 @@ func TestSpacemeshApp_NodeService(t *testing.T) {
 func TestSpacemeshApp_TransactionService(t *testing.T) {
 	listener := "127.0.0.1:14236"
 
-	cfg := config.DefaultTestConfig()
-	cfg.DataDirParent = t.TempDir()
+	cfg := config.DefaultTestConfig(t)
 	app := New(WithConfig(&cfg), WithLog(logtest.New(t)))
 
 	signer, err := signing.NewEdSigner()
@@ -855,8 +846,8 @@ func TestHRP(t *testing.T) {
 
 func TestGenesisConfig(t *testing.T) {
 	t.Run("config is written to a file", func(t *testing.T) {
-		cfg := getTestDefaultConfig(t)
-		app := New(WithConfig(cfg))
+		cfg := config.DefaultTestConfig(t)
+		app := New(WithConfig(&cfg))
 
 		require.NoError(t, app.Initialize())
 		t.Cleanup(func() { app.Cleanup(context.Background()) })
@@ -867,8 +858,8 @@ func TestGenesisConfig(t *testing.T) {
 	})
 
 	t.Run("no error if no diff", func(t *testing.T) {
-		cfg := getTestDefaultConfig(t)
-		app := New(WithConfig(cfg))
+		cfg := config.DefaultTestConfig(t)
+		app := New(WithConfig(&cfg))
 
 		require.NoError(t, app.Initialize())
 		app.Cleanup(context.Background())
@@ -878,8 +869,8 @@ func TestGenesisConfig(t *testing.T) {
 	})
 
 	t.Run("fatal error on a diff", func(t *testing.T) {
-		cfg := getTestDefaultConfig(t)
-		app := New(WithConfig(cfg))
+		cfg := config.DefaultTestConfig(t)
+		app := New(WithConfig(&cfg))
 
 		require.NoError(t, app.Initialize())
 		t.Cleanup(func() { app.Cleanup(context.Background()) })
@@ -891,9 +882,9 @@ func TestGenesisConfig(t *testing.T) {
 	})
 
 	t.Run("long extra data", func(t *testing.T) {
-		cfg := getTestDefaultConfig(t)
+		cfg := config.DefaultTestConfig(t)
 		cfg.Genesis.ExtraData = string(make([]byte, 256))
-		app := New(WithConfig(cfg))
+		app := New(WithConfig(&cfg))
 
 		require.ErrorContains(t, app.Initialize(), "extra-data")
 	})
@@ -901,8 +892,8 @@ func TestGenesisConfig(t *testing.T) {
 
 func TestFlock(t *testing.T) {
 	t.Run("sanity", func(t *testing.T) {
-		cfg := getTestDefaultConfig(t)
-		app := New(WithConfig(cfg))
+		cfg := config.DefaultTestConfig(t)
+		app := New(WithConfig(&cfg))
 
 		require.NoError(t, app.Lock())
 		t.Cleanup(app.Unlock)
@@ -914,9 +905,9 @@ func TestFlock(t *testing.T) {
 	})
 
 	t.Run("dir doesn't exist", func(t *testing.T) {
-		cfg := getTestDefaultConfig(t)
+		cfg := config.DefaultTestConfig(t)
 		cfg.FileLock = filepath.Join(t.TempDir(), "newdir", "LOCK")
-		app := New(WithConfig(cfg))
+		app := New(WithConfig(&cfg))
 
 		require.NoError(t, app.Lock())
 		t.Cleanup(app.Unlock)
@@ -924,9 +915,9 @@ func TestFlock(t *testing.T) {
 }
 
 func TestEmptyExtraData(t *testing.T) {
-	cfg := getTestDefaultConfig(t)
+	cfg := config.DefaultTestConfig(t)
 	cfg.Genesis.ExtraData = ""
-	app := New(WithConfig(cfg), WithLog(logtest.New(t)))
+	app := New(WithConfig(&cfg), WithLog(logtest.New(t)))
 	require.Error(t, app.Initialize())
 }
 
@@ -941,7 +932,7 @@ func TestAdminEvents(t *testing.T) {
 	cfg.SMESHING.Opts.DataDir = t.TempDir()
 	cfg.SMESHING.Opts.Scrypt.N = 2
 	cfg.SMESHING.Start = true
-	cfg.POSTService.PostServiceCmd = activation.DefaultTestPostServiceConfig().PostServiceCmd
+	cfg.POSTService.PostServiceCmd = activation.DefaultTestPostServiceConfig(t).PostServiceCmd
 
 	cfg.Genesis.GenesisTime = config.Genesis(time.Now().Add(5 * time.Second))
 	types.SetLayersPerEpoch(cfg.LayersPerEpoch)
@@ -1023,7 +1014,7 @@ func TestAdminEvents_MultiSmesher(t *testing.T) {
 	cfg.SMESHING.Opts.Scrypt.N = 2
 	cfg.SMESHING.Start = false
 	cfg.API.PostListener = "0.0.0.0:10094"
-	cfg.POSTService.PostServiceCmd = activation.DefaultTestPostServiceConfig().PostServiceCmd
+	cfg.POSTService.PostServiceCmd = activation.DefaultTestPostServiceConfig(t).PostServiceCmd
 
 	cfg.Genesis.GenesisTime = config.Genesis(time.Now().Add(5 * time.Second))
 	types.SetLayersPerEpoch(cfg.LayersPerEpoch)
@@ -1222,7 +1213,7 @@ func launchPostSupervisor(
 	postCfg activation.PostConfig,
 	postOpts activation.PostSetupOpts,
 ) func() {
-	cmdCfg := activation.DefaultTestPostServiceConfig()
+	cmdCfg := activation.DefaultTestPostServiceConfig(tb)
 	cmdCfg.NodeAddress = fmt.Sprintf("http://%s", address)
 	provingOpts := activation.DefaultPostProvingOpts()
 	provingOpts.RandomXMode = activation.PostRandomXModeLight
@@ -1232,60 +1223,4 @@ func launchPostSupervisor(
 	ps := activation.NewPostSupervisor(log, postCfg, provingOpts, mgr, builder)
 	require.NoError(tb, ps.Start(cmdCfg, postOpts, sig))
 	return func() { assert.NoError(tb, ps.Stop(false)) }
-}
-
-func getTestDefaultConfig(tb testing.TB) *config.Config {
-	cfg := config.MainnetConfig()
-	types.SetNetworkHRP(cfg.NetworkHRP)
-	types.SetLayersPerEpoch(cfg.LayersPerEpoch)
-
-	tmp := tb.TempDir()
-	cfg.DataDirParent = tmp
-	cfg.FileLock = filepath.Join(tmp, "LOCK")
-	cfg.LayerDuration = 20 * time.Second
-
-	// is set to 0 to make sync start immediately when node starts
-	cfg.P2P.MinPeers = 0
-
-	cfg.POST = activation.DefaultPostConfig()
-	cfg.POST.MinNumUnits = 2
-	cfg.POST.MaxNumUnits = 4
-	cfg.POST.LabelsPerUnit = 32
-	cfg.POST.K2 = 4
-
-	cfg.BaseConfig.PoetServers = nil
-
-	cfg.SMESHING = config.DefaultSmeshingConfig()
-	cfg.SMESHING.Start = false
-	cfg.SMESHING.CoinbaseAccount = types.GenerateAddress([]byte{1}).String()
-	cfg.SMESHING.Opts.DataDir = filepath.Join(tmp, "post")
-	cfg.SMESHING.Opts.NumUnits = cfg.POST.MinNumUnits + 1
-	cfg.SMESHING.Opts.Scrypt.N = 2
-	cfg.SMESHING.Opts.ProviderID.SetUint32(initialization.CPUProviderID())
-
-	cfg.HARE3.RoundDuration = 2
-	cfg.HARE3.PreroundDelay = 1
-
-	cfg.HARE4.RoundDuration = 2
-	cfg.HARE4.PreroundDelay = 1
-
-	cfg.LayerAvgSize = 5
-	cfg.LayersPerEpoch = 3
-	cfg.TxsPerProposal = 100
-	cfg.Tortoise.Hdist = 5
-	cfg.Tortoise.Zdist = 5
-
-	cfg.HareEligibility.ConfidenceParam = 1
-	cfg.Sync.Interval = 2 * time.Second
-
-	cfg.FETCH.RequestTimeout = 10 * time.Second
-	cfg.FETCH.RequestHardTimeout = 20 * time.Second
-	cfg.FETCH.BatchSize = 5
-	cfg.FETCH.BatchTimeout = 5 * time.Second
-
-	cfg.Beacon = beacon.NodeSimUnitTestConfig()
-	cfg.Genesis = config.DefaultTestGenesisConfig()
-	cfg.POSTService = activation.DefaultTestPostServiceConfig()
-
-	return &cfg
 }

--- a/node/node_version_check_test.go
+++ b/node/node_version_check_test.go
@@ -14,16 +14,12 @@ import (
 
 func TestUpgradeToV15(t *testing.T) {
 	t.Run("fresh installation - no local DB file", func(t *testing.T) {
-		cfg := config.DefaultTestConfig()
-		cfg.DataDirParent = t.TempDir()
-
+		cfg := config.DefaultTestConfig(t)
 		require.NoError(t, verifyLocalDbMigrations(&cfg))
 	})
 
 	t.Run("migrated DB passes", func(t *testing.T) {
-		cfg := config.DefaultTestConfig()
-		cfg.DataDirParent = t.TempDir()
-
+		cfg := config.DefaultTestConfig(t)
 		uri := path.Join(cfg.DataDir(), localDbFile)
 		localDb, err := localsql.Open(uri)
 		require.NoError(t, err)
@@ -33,9 +29,7 @@ func TestUpgradeToV15(t *testing.T) {
 	})
 
 	t.Run("not fully migrated DB fails", func(t *testing.T) {
-		cfg := config.DefaultTestConfig()
-		cfg.DataDirParent = t.TempDir()
-
+		cfg := config.DefaultTestConfig(t)
 		uri := path.Join(cfg.DataDir(), localDbFile)
 
 		schema, err := statesql.Schema()

--- a/systest/Makefile
+++ b/systest/Makefile
@@ -10,7 +10,7 @@ poet_image ?= $(org)/poet:v0.10.10
 post_service_image ?= $(org)/post-service:v0.8.4
 post_init_image ?= $(org)/postcli:v0.12.10
 smesher_image ?= $(org)/go-spacemesh-dev:$(version_info)
-old_smesher_image ?= $(org)/go-spacemesh-dev:43f582f # TODO: update this after merging, new version updated config
+old_smesher_image ?= $(org)/go-spacemesh-dev:8d89a07 # TODO: update this after merging, new version updated config
 bs_image ?= $(org)/go-spacemesh-dev-bs:$(version_info)
 
 test_id ?= systest-$(version_info)

--- a/systest/Makefile
+++ b/systest/Makefile
@@ -10,7 +10,7 @@ poet_image ?= $(org)/poet:v0.10.10
 post_service_image ?= $(org)/post-service:v0.8.4
 post_init_image ?= $(org)/postcli:v0.12.10
 smesher_image ?= $(org)/go-spacemesh-dev:$(version_info)
-old_smesher_image ?= $(org)/go-spacemesh-dev:8d89a07 # TODO: update this after merging, new version updated config
+old_smesher_image ?= $(org)/go-spacemesh-dev:43f582f # TODO: update this after merging, new version updated config
 bs_image ?= $(org)/go-spacemesh-dev-bs:$(version_info)
 
 test_id ?= systest-$(version_info)


### PR DESCRIPTION
## Motivation

Instead of having a dedicated test config just for the `node` package, adjust the default test config so it works for all tests similarly and fewer tests have to set their own values.

## Description

This PR does multiple things:

- TestConfig functions now take a `testing.TB` parameter so they aren't accidentally called from within production code
- I expanded `config.DefaultTestConfig` to include the parameters that were previously used in `node.getTestConfig`
- I removed some places where tests changed the default test config, without the test actually needing a deviating configuration

## Test Plan

existing tests pass

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
