### PR TITLE
Node-service returns '503 unavailable' until it is ATX-synced

### DIFF
--- a/api/node/client/client_e2e_test.go
+++ b/api/node/client/client_e2e_test.go
@@ -56,10 +56,10 @@ func setupE2E(t *testing.T) (*client.NodeService, *mocks) {
 	listener, err := net.Listen("tcp", "localhost:0")
 	require.NoError(t, err)
 
-	readiness := make(chan struct{})
-	close(readiness)
+	syncer := server.NewMocksyncer(ctrl)
+	syncer.EXPECT().IsSynced(gomock.Any()).Return(true).AnyTimes()
 	server := &http.Server{
-		Handler: activationServiceServer.IntoHandler(http.NewServeMux(), readiness),
+		Handler: activationServiceServer.IntoHandler(http.NewServeMux(), syncer),
 	}
 
 	go server.Serve(listener)

--- a/api/node/client/client_e2e_test.go
+++ b/api/node/client/client_e2e_test.go
@@ -56,8 +56,10 @@ func setupE2E(t *testing.T) (*client.NodeService, *mocks) {
 	listener, err := net.Listen("tcp", "localhost:0")
 	require.NoError(t, err)
 
+	readiness := make(chan struct{})
+	close(readiness)
 	server := &http.Server{
-		Handler: activationServiceServer.IntoHandler(http.NewServeMux()),
+		Handler: activationServiceServer.IntoHandler(http.NewServeMux(), readiness),
 	}
 
 	go server.Serve(listener)

--- a/api/node/server/mocks.go
+++ b/api/node/server/mocks.go
@@ -387,6 +387,68 @@ func (c *MockproposalBuilderCalculateEligibilitySlotsForCall) DoAndReturn(f func
 	return c
 }
 
+// Mocksyncer is a mock of syncer interface.
+type Mocksyncer struct {
+	ctrl     *gomock.Controller
+	recorder *MocksyncerMockRecorder
+	isgomock struct{}
+}
+
+// MocksyncerMockRecorder is the mock recorder for Mocksyncer.
+type MocksyncerMockRecorder struct {
+	mock *Mocksyncer
+}
+
+// NewMocksyncer creates a new mock instance.
+func NewMocksyncer(ctrl *gomock.Controller) *Mocksyncer {
+	mock := &Mocksyncer{ctrl: ctrl}
+	mock.recorder = &MocksyncerMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *Mocksyncer) EXPECT() *MocksyncerMockRecorder {
+	return m.recorder
+}
+
+// IsSynced mocks base method.
+func (m *Mocksyncer) IsSynced(arg0 context.Context) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsSynced", arg0)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsSynced indicates an expected call of IsSynced.
+func (mr *MocksyncerMockRecorder) IsSynced(arg0 any) *MocksyncerIsSyncedCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsSynced", reflect.TypeOf((*Mocksyncer)(nil).IsSynced), arg0)
+	return &MocksyncerIsSyncedCall{Call: call}
+}
+
+// MocksyncerIsSyncedCall wrap *gomock.Call
+type MocksyncerIsSyncedCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MocksyncerIsSyncedCall) Return(arg0 bool) *MocksyncerIsSyncedCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MocksyncerIsSyncedCall) Do(f func(context.Context) bool) *MocksyncerIsSyncedCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MocksyncerIsSyncedCall) DoAndReturn(f func(context.Context) bool) *MocksyncerIsSyncedCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // MockasBytes is a mock of asBytes interface.
 type MockasBytes struct {
 	ctrl     *gomock.Controller

--- a/api/node/server/server.go
+++ b/api/node/server/server.go
@@ -43,6 +43,10 @@ type proposalBuilder interface {
 		ctx context.Context, node types.NodeID, epoch types.EpochID) (uint32, types.VRFPostIndex, error)
 }
 
+type syncer interface {
+	IsSynced(context.Context) bool
+}
+
 type Server struct {
 	atxService activation.AtxService
 	beacons    beaconService
@@ -77,7 +81,7 @@ func NewServer(
 
 // Turn the server into a HTTP handler.
 // It will return '503 Unavailable' until the readiness channel is closed.
-func (s *Server) IntoHandler(mux *http.ServeMux, readiness <-chan struct{}) http.Handler {
+func (s *Server) IntoHandler(mux *http.ServeMux, syncer syncer) http.Handler {
 	loggingMid := func(f nethttp.StrictHTTPHandlerFunc, operationID string) nethttp.StrictHTTPHandlerFunc {
 		return func(ctx context.Context, w http.ResponseWriter, r *http.Request, req any) (any, error) {
 			uuid := uuid.New()
@@ -100,13 +104,11 @@ func (s *Server) IntoHandler(mux *http.ServeMux, readiness <-chan struct{}) http
 	}
 	readinessMid := func(f nethttp.StrictHTTPHandlerFunc, _ string) nethttp.StrictHTTPHandlerFunc {
 		return func(ctx context.Context, w http.ResponseWriter, r *http.Request, req any) (any, error) {
-			select {
-			case <-readiness:
+			if syncer.IsSynced(ctx) {
 				return f(ctx, w, r, req)
-			default:
-				// channel is not closed, service is not ready
+			} else {
 				w.WriteHeader(http.StatusServiceUnavailable)
-				return nil, errors.New("service not ready")
+				return nil, errors.New("service not ready: not in sync with the network")
 			}
 		}
 	}

--- a/api/node/server/server.go
+++ b/api/node/server/server.go
@@ -75,7 +75,9 @@ func NewServer(
 	}
 }
 
-func (s *Server) IntoHandler(mux *http.ServeMux) http.Handler {
+// Turn the server into a HTTP handler.
+// It will return '503 Unavailable' until the readiness channel is closed.
+func (s *Server) IntoHandler(mux *http.ServeMux, readiness <-chan struct{}) http.Handler {
 	loggingMid := func(f nethttp.StrictHTTPHandlerFunc, operationID string) nethttp.StrictHTTPHandlerFunc {
 		return func(ctx context.Context, w http.ResponseWriter, r *http.Request, req any) (any, error) {
 			uuid := uuid.New()
@@ -96,15 +98,20 @@ func (s *Server) IntoHandler(mux *http.ServeMux) http.Handler {
 			return response, err
 		}
 	}
-	return HandlerFromMux(NewStrictHandler(s, []StrictMiddlewareFunc{loggingMid}), mux)
-}
-
-func (s *Server) Start(address string) error {
-	server := &http.Server{
-		Handler: s.IntoHandler(http.NewServeMux()),
-		Addr:    address,
+	readinessMid := func(f nethttp.StrictHTTPHandlerFunc, _ string) nethttp.StrictHTTPHandlerFunc {
+		return func(ctx context.Context, w http.ResponseWriter, r *http.Request, req any) (any, error) {
+			select {
+			case <-readiness:
+				return f(ctx, w, r, req)
+			default:
+				// channel is not closed, service is not ready
+				w.WriteHeader(http.StatusServiceUnavailable)
+				return nil, errors.New("service not ready")
+			}
+		}
 	}
-	return server.ListenAndServe()
+
+	return HandlerFromMux(NewStrictHandler(s, []StrictMiddlewareFunc{readinessMid, loggingMid}), mux)
 }
 
 // GetActivationAtxAtxId implements StrictServerInterface.

--- a/api/node/server/server_test.go
+++ b/api/node/server/server_test.go
@@ -5,12 +5,13 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/spacemeshos/go-spacemesh/activation"
-	types "github.com/spacemeshos/go-spacemesh/common/types"
-	"github.com/spacemeshos/go-spacemesh/p2p/pubsub/mocks"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 	"go.uber.org/zap/zaptest"
+
+	"github.com/spacemeshos/go-spacemesh/activation"
+	types "github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/p2p/pubsub/mocks"
 )
 
 func TestServerReadiness(t *testing.T) {
@@ -23,7 +24,6 @@ func TestServerReadiness(t *testing.T) {
 		mocks.NewMockPublisher(ctrl),
 		NewMockpoetDB(ctrl),
 		NewMockhare(ctrl),
-		NewMockweights(ctrl),
 		NewMockproposalBuilder(ctrl),
 		zaptest.NewLogger(t),
 	)

--- a/api/node/server/server_test.go
+++ b/api/node/server/server_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 	"go.uber.org/zap/zaptest"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/spacemeshos/go-spacemesh/activation"
 	types "github.com/spacemeshos/go-spacemesh/common/types"
@@ -31,30 +32,34 @@ func TestServerReadiness(t *testing.T) {
 	listener, err := net.Listen("tcp", "localhost:0")
 	require.NoError(t, err)
 
-	readiness := make(chan struct{})
+	syncer := NewMocksyncer(ctrl)
 	server := &http.Server{
-		Handler: srv.IntoHandler(http.NewServeMux(), readiness),
+		Handler: srv.IntoHandler(http.NewServeMux(), syncer),
 	}
 
-	go server.Serve(listener)
-	defer server.Close()
+	var eg errgroup.Group
+	eg.Go(func() error {
+		return server.Serve(listener)
+	})
+	t.Cleanup(func() {
+		server.Close()
+		eg.Wait()
+	})
 
-	// Test that server returns 503 when not ready
 	t.Run("returns 503 when not ready", func(t *testing.T) {
-		resp, err := http.Get("http://" + listener.Addr().String() + "/beacon/1")
+		syncer.EXPECT().IsSynced(gomock.Any()).Return(false)
+		resp, err := http.Get("http://" + listener.Addr().String() + "/hare/beacon/1")
 		require.NoError(t, err)
 		require.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
 	})
 
-	// Test that server returns normal response after ready
 	t.Run("succeeds after ready", func(t *testing.T) {
-		close(readiness)
-
+		syncer.EXPECT().IsSynced(gomock.Any()).Return(true)
 		beacons.EXPECT().
 			Beacon(gomock.Any(), gomock.Any()).
 			Return(types.Beacon{1, 2, 3}, nil)
 
-		resp, err := http.Get("http://" + listener.Addr().String() + "/beacon/1")
+		resp, err := http.Get("http://" + listener.Addr().String() + "/hare/beacon/1")
 		require.NoError(t, err)
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 	})

--- a/api/node/server/server_test.go
+++ b/api/node/server/server_test.go
@@ -1,0 +1,61 @@
+package server
+
+import (
+	"net"
+	"net/http"
+	"testing"
+
+	"github.com/spacemeshos/go-spacemesh/activation"
+	types "github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/p2p/pubsub/mocks"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	"go.uber.org/zap/zaptest"
+)
+
+func TestServerReadiness(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	beacons := NewMockbeaconService(ctrl)
+	srv := NewServer(
+		activation.NewMockAtxService(ctrl),
+		beacons,
+		mocks.NewMockPublisher(ctrl),
+		NewMockpoetDB(ctrl),
+		NewMockhare(ctrl),
+		NewMockweights(ctrl),
+		NewMockproposalBuilder(ctrl),
+		zaptest.NewLogger(t),
+	)
+
+	listener, err := net.Listen("tcp", "localhost:0")
+	require.NoError(t, err)
+
+	readiness := make(chan struct{})
+	server := &http.Server{
+		Handler: srv.IntoHandler(http.NewServeMux(), readiness),
+	}
+
+	go server.Serve(listener)
+	defer server.Close()
+
+	// Test that server returns 503 when not ready
+	t.Run("returns 503 when not ready", func(t *testing.T) {
+		resp, err := http.Get("http://" + listener.Addr().String() + "/beacon/1")
+		require.NoError(t, err)
+		require.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+	})
+
+	// Test that server returns normal response after ready
+	t.Run("succeeds after ready", func(t *testing.T) {
+		close(readiness)
+
+		beacons.EXPECT().
+			Beacon(gomock.Any(), gomock.Any()).
+			Return(types.Beacon{1, 2, 3}, nil)
+
+		resp, err := http.Get("http://" + listener.Addr().String() + "/beacon/1")
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+}

--- a/node/node.go
+++ b/node/node.go
@@ -2097,7 +2097,8 @@ func (app *App) startAPIServices(ctx context.Context) error {
 		)
 
 		app.nodeServiceServer = &http.Server{
-			Handler: server.IntoHandler(http.NewServeMux()),
+			// The node-service becomes ready after the initial ATX sync completes.
+			Handler: server.IntoHandler(http.NewServeMux(), app.syncer.RegisterForATXSynced()),
 		}
 		app.eg.Go(func() error { return app.nodeServiceServer.Serve(lis) })
 	}
@@ -2106,6 +2107,11 @@ func (app *App) startAPIServices(ctx context.Context) error {
 }
 
 func (app *App) stopServices(ctx context.Context) {
+	if app.nodeServiceServer != nil {
+		if err := app.nodeServiceServer.Shutdown(ctx); err != nil {
+			app.log.With().Error("error stopping node-service server", log.Err(err))
+		}
+	}
 	if app.jsonAPIServer != nil {
 		if err := app.jsonAPIServer.Shutdown(ctx); err != nil {
 			app.log.With().Error("error stopping json gateway server", log.Err(err))

--- a/node/node.go
+++ b/node/node.go
@@ -2097,8 +2097,8 @@ func (app *App) startAPIServices(ctx context.Context) error {
 		)
 
 		app.nodeServiceServer = &http.Server{
-			// The node-service becomes ready after the initial ATX sync completes.
-			Handler: server.IntoHandler(http.NewServeMux(), app.syncer.RegisterForATXSynced()),
+			// The node-service API is ready only when it's in sync.
+			Handler: server.IntoHandler(http.NewServeMux(), app.syncer),
 		}
 		app.eg.Go(func() error { return app.nodeServiceServer.Serve(lis) })
 	}


### PR DESCRIPTION
## Motivation

The node-service exposes APIs, which require it to be ATX-synced to work properly (e.g `/actvation/last_atx`).

> [!NOTE]  
A similar reasoning should probably be extended to other endpoints as well. 
For example, the endpoint creating proposal templates should probably also return 503 when the node is not synced (not not atx-synced!).
For instance, the "normal" proposal builder skips building a proposal if it's not synced.

## Description

Added middleware that will respond with  `503 unavailable` until the syncer is ATX-synced.

## Test Plan

Added a UT for the server handler with new middleware.
