### PR TITLE
Avoid self-banning when smeshing-service publishes invalid ATX

### DIFF
--- a/activation/handler.go
+++ b/activation/handler.go
@@ -128,7 +128,6 @@ func NewHandler(
 			tortoise:        tortoise,
 			malPublisher:    legacyMalPublisher,
 			malPublisher2:   malPublisher,
-			signers:         make(map[types.NodeID]*signing.EdSigner),
 		},
 
 		v2: &HandlerV2{
@@ -161,10 +160,6 @@ func NewHandler(
 		})))
 
 	return h
-}
-
-func (h *Handler) Register(sig *signing.EdSigner) {
-	h.v1.Register(sig)
 }
 
 // HandleSyncedAtx handles atxs received by sync.

--- a/activation/handler_v1.go
+++ b/activation/handler_v1.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"math/bits"
-	"sync"
 	"time"
 
 	"github.com/spacemeshos/post/shared"
@@ -78,21 +77,6 @@ type HandlerV1 struct {
 	fetcher         system.Fetcher
 	malPublisher    legacyMalfeasancePublisher
 	malPublisher2   atxMalfeasancePublisher
-
-	signerMtx sync.Mutex
-	signers   map[types.NodeID]*signing.EdSigner
-}
-
-func (h *HandlerV1) Register(sig *signing.EdSigner) {
-	h.signerMtx.Lock()
-	defer h.signerMtx.Unlock()
-	if _, exists := h.signers[sig.NodeID()]; exists {
-		h.logger.Error("signing key already registered", log.ZShortStringer("id", sig.NodeID()))
-		return
-	}
-
-	h.logger.Info("registered signing key", log.ZShortStringer("id", sig.NodeID()))
-	h.signers[sig.NodeID()] = sig
 }
 
 func (h *HandlerV1) syntacticallyValidate(ctx context.Context, atx *wire.ActivationTxV1) error {
@@ -337,7 +321,7 @@ func (h *HandlerV1) cacheAtx(ctx context.Context, atx *types.ActivationTx, malic
 }
 
 // checkDoublePublish verifies if a node has already published an ATX in the same epoch.
-func (h *HandlerV1) checkDoublePublish(ctx context.Context, tx sql.Executor, atx *wire.ActivationTxV1) (bool, error) {
+func (h *HandlerV1) checkDoublePublish(ctx context.Context, tx sql.Executor, atx *wire.ActivationTxV1, publishing bool) (bool, error) {
 	prev, err := atxs.GetByEpochAndNodeID(tx, atx.PublishEpoch, atx.SmesherID)
 	if err != nil && !errors.Is(err, sql.ErrNotFound) {
 		return false, err
@@ -347,7 +331,7 @@ func (h *HandlerV1) checkDoublePublish(ctx context.Context, tx sql.Executor, atx
 		return false, nil
 	}
 
-	if _, ok := h.signers[atx.SmesherID]; ok {
+	if publishing {
 		// if we land here we tried to publish 2 ATXs in the same epoch
 		// don't punish ourselves but fail validation and thereby the handling of the incoming ATX
 		return false, fmt.Errorf(
@@ -396,7 +380,7 @@ func (h *HandlerV1) checkDoublePublish(ctx context.Context, tx sql.Executor, atx
 }
 
 // checkWrongPrevAtx verifies if the previous ATX referenced in the ATX is correct.
-func (h *HandlerV1) checkWrongPrevAtx(ctx context.Context, tx sql.Executor, atx *wire.ActivationTxV1) (bool, error) {
+func (h *HandlerV1) checkWrongPrevAtx(ctx context.Context, tx sql.Executor, atx *wire.ActivationTxV1, publishing bool) (bool, error) {
 	expectedPrevID, err := atxs.PrevIDByNodeID(tx, atx.SmesherID, atx.PublishEpoch)
 	if err != nil && !errors.Is(err, sql.ErrNotFound) {
 		return false, fmt.Errorf("get last atx by node id: %w", err)
@@ -405,7 +389,7 @@ func (h *HandlerV1) checkWrongPrevAtx(ctx context.Context, tx sql.Executor, atx 
 		return false, nil
 	}
 
-	if _, ok := h.signers[atx.SmesherID]; ok {
+	if publishing {
 		// if we land here we tried to publish an ATX with a wrong prevATX
 		h.logger.Warn(
 			"Node produced an ATX with a wrong prevATX. This can happened when the node wasn't synced when "+
@@ -473,15 +457,15 @@ func (h *HandlerV1) checkWrongPrevAtx(ctx context.Context, tx sql.Executor, atx 
 	return true, h.malPublisher.PublishProof(ctx, atx.SmesherID, proof)
 }
 
-func (h *HandlerV1) checkMalicious(ctx context.Context, tx sql.Transaction, watx *wire.ActivationTxV1) (bool, error) {
-	malicious, err := h.checkDoublePublish(ctx, tx, watx)
+func (h *HandlerV1) checkMalicious(ctx context.Context, tx sql.Transaction, watx *wire.ActivationTxV1, publishing bool) (bool, error) {
+	malicious, err := h.checkDoublePublish(ctx, tx, watx, publishing)
 	if err != nil {
 		return malicious, fmt.Errorf("check double publish: %w", err)
 	}
 	if malicious {
 		return true, nil
 	}
-	malicious, err = h.checkWrongPrevAtx(ctx, tx, watx)
+	malicious, err = h.checkWrongPrevAtx(ctx, tx, watx, publishing)
 	if err != nil {
 		return malicious, fmt.Errorf("check wrong prev atx: %w", err)
 	}
@@ -489,7 +473,7 @@ func (h *HandlerV1) checkMalicious(ctx context.Context, tx sql.Transaction, watx
 }
 
 // storeAtx stores an ATX and notifies subscribers of the ATXID.
-func (h *HandlerV1) storeAtx(ctx context.Context, atx *types.ActivationTx, watx *wire.ActivationTxV1) error {
+func (h *HandlerV1) storeAtx(ctx context.Context, atx *types.ActivationTx, watx *wire.ActivationTxV1, publishing bool) error {
 	var malicious bool
 	if err := h.cdb.WithTxImmediate(ctx, func(tx sql.Transaction) error {
 		var err error
@@ -503,7 +487,7 @@ func (h *HandlerV1) storeAtx(ctx context.Context, atx *types.ActivationTx, watx 
 		}
 		malicious = malicious || malicious2
 		if !malicious {
-			malicious, err = h.checkMalicious(ctx, tx, watx)
+			malicious, err = h.checkMalicious(ctx, tx, watx, publishing)
 			if err != nil {
 				return fmt.Errorf("check malicious: %w", err)
 			}
@@ -576,7 +560,8 @@ func (h *HandlerV1) processATX(
 		return fmt.Errorf("%w: validating atx %s (deps): %w", pubsub.ErrValidationReject, watx.ID(), err)
 	}
 
-	if err := h.storeAtx(ctx, atx, watx); err != nil {
+	publishing := h.local == peer
+	if err := h.storeAtx(ctx, atx, watx, publishing); err != nil {
 		return fmt.Errorf("cannot store atx %s: %w", atx.ShortString(), err)
 	}
 

--- a/activation/handler_v1.go
+++ b/activation/handler_v1.go
@@ -7,6 +7,7 @@ import (
 	"math/bits"
 	"time"
 
+	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/spacemeshos/post/shared"
 	"github.com/spacemeshos/post/verifying"
 	"go.uber.org/zap"
@@ -321,7 +322,12 @@ func (h *HandlerV1) cacheAtx(ctx context.Context, atx *types.ActivationTx, malic
 }
 
 // checkDoublePublish verifies if a node has already published an ATX in the same epoch.
-func (h *HandlerV1) checkDoublePublish(ctx context.Context, tx sql.Executor, atx *wire.ActivationTxV1, publishing bool) (bool, error) {
+func (h *HandlerV1) checkDoublePublish(
+	ctx context.Context,
+	tx sql.Executor,
+	atx *wire.ActivationTxV1,
+	peer peer.ID,
+) (bool, error) {
 	prev, err := atxs.GetByEpochAndNodeID(tx, atx.PublishEpoch, atx.SmesherID)
 	if err != nil && !errors.Is(err, sql.ErrNotFound) {
 		return false, err
@@ -331,7 +337,7 @@ func (h *HandlerV1) checkDoublePublish(ctx context.Context, tx sql.Executor, atx
 		return false, nil
 	}
 
-	if publishing {
+	if peer == h.local {
 		// if we land here we tried to publish 2 ATXs in the same epoch
 		// don't punish ourselves but fail validation and thereby the handling of the incoming ATX
 		return false, fmt.Errorf(
@@ -380,7 +386,12 @@ func (h *HandlerV1) checkDoublePublish(ctx context.Context, tx sql.Executor, atx
 }
 
 // checkWrongPrevAtx verifies if the previous ATX referenced in the ATX is correct.
-func (h *HandlerV1) checkWrongPrevAtx(ctx context.Context, tx sql.Executor, atx *wire.ActivationTxV1, publishing bool) (bool, error) {
+func (h *HandlerV1) checkWrongPrevAtx(
+	ctx context.Context,
+	tx sql.Executor,
+	atx *wire.ActivationTxV1,
+	peer peer.ID,
+) (bool, error) {
 	expectedPrevID, err := atxs.PrevIDByNodeID(tx, atx.SmesherID, atx.PublishEpoch)
 	if err != nil && !errors.Is(err, sql.ErrNotFound) {
 		return false, fmt.Errorf("get last atx by node id: %w", err)
@@ -389,7 +400,7 @@ func (h *HandlerV1) checkWrongPrevAtx(ctx context.Context, tx sql.Executor, atx 
 		return false, nil
 	}
 
-	if publishing {
+	if peer == h.local {
 		// if we land here we tried to publish an ATX with a wrong prevATX
 		h.logger.Warn(
 			"Node produced an ATX with a wrong prevATX. This can happened when the node wasn't synced when "+
@@ -457,15 +468,20 @@ func (h *HandlerV1) checkWrongPrevAtx(ctx context.Context, tx sql.Executor, atx 
 	return true, h.malPublisher.PublishProof(ctx, atx.SmesherID, proof)
 }
 
-func (h *HandlerV1) checkMalicious(ctx context.Context, tx sql.Transaction, watx *wire.ActivationTxV1, publishing bool) (bool, error) {
-	malicious, err := h.checkDoublePublish(ctx, tx, watx, publishing)
+func (h *HandlerV1) checkMalicious(
+	ctx context.Context,
+	tx sql.Transaction,
+	watx *wire.ActivationTxV1,
+	peer peer.ID,
+) (bool, error) {
+	malicious, err := h.checkDoublePublish(ctx, tx, watx, peer)
 	if err != nil {
 		return malicious, fmt.Errorf("check double publish: %w", err)
 	}
 	if malicious {
 		return true, nil
 	}
-	malicious, err = h.checkWrongPrevAtx(ctx, tx, watx, publishing)
+	malicious, err = h.checkWrongPrevAtx(ctx, tx, watx, peer)
 	if err != nil {
 		return malicious, fmt.Errorf("check wrong prev atx: %w", err)
 	}
@@ -473,7 +489,12 @@ func (h *HandlerV1) checkMalicious(ctx context.Context, tx sql.Transaction, watx
 }
 
 // storeAtx stores an ATX and notifies subscribers of the ATXID.
-func (h *HandlerV1) storeAtx(ctx context.Context, atx *types.ActivationTx, watx *wire.ActivationTxV1, publishing bool) error {
+func (h *HandlerV1) storeAtx(
+	ctx context.Context,
+	atx *types.ActivationTx,
+	watx *wire.ActivationTxV1,
+	peer peer.ID,
+) error {
 	var malicious bool
 	if err := h.cdb.WithTxImmediate(ctx, func(tx sql.Transaction) error {
 		var err error
@@ -487,7 +508,7 @@ func (h *HandlerV1) storeAtx(ctx context.Context, atx *types.ActivationTx, watx 
 		}
 		malicious = malicious || malicious2
 		if !malicious {
-			malicious, err = h.checkMalicious(ctx, tx, watx, publishing)
+			malicious, err = h.checkMalicious(ctx, tx, watx, peer)
 			if err != nil {
 				return fmt.Errorf("check malicious: %w", err)
 			}
@@ -560,8 +581,7 @@ func (h *HandlerV1) processATX(
 		return fmt.Errorf("%w: validating atx %s (deps): %w", pubsub.ErrValidationReject, watx.ID(), err)
 	}
 
-	publishing := h.local == peer
-	if err := h.storeAtx(ctx, atx, watx, publishing); err != nil {
+	if err := h.storeAtx(ctx, atx, watx, peer); err != nil {
 		return fmt.Errorf("cannot store atx %s: %w", atx.ShortString(), err)
 	}
 

--- a/activation/handler_v1_test.go
+++ b/activation/handler_v1_test.go
@@ -582,7 +582,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 			return atx.ID() == watx.ID()
 		}))
 		atxHdlr.mTortoise.EXPECT().OnAtx(watx.PublishEpoch+1, watx.ID(), gomock.Any())
-		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx, watx, false))
+		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx, watx, p2p.Peer("other")))
 
 		atxFromDb, err := atxs.Get(atxHdlr.cdb, atx.ID())
 		require.NoError(t, err)
@@ -601,13 +601,13 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 			return atx.ID() == watx.ID()
 		}))
 		atxHdlr.mTortoise.EXPECT().OnAtx(watx.PublishEpoch+1, watx.ID(), gomock.Any())
-		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx, watx, false))
+		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx, watx, p2p.Peer("other")))
 
 		atxHdlr.mBeacon.EXPECT().OnAtx(gomock.Cond(func(atx *types.ActivationTx) bool {
 			return atx.ID() == watx.ID()
 		}))
 		// Note: tortoise is not informed about the same ATX again
-		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx, watx, false))
+		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx, watx, p2p.Peer("other")))
 	})
 
 	t.Run("stores ATX of malicious identity", func(t *testing.T) {
@@ -625,7 +625,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 			return atx.ID() == watx.ID()
 		}))
 		atxHdlr.mTortoise.EXPECT().OnAtx(watx.PublishEpoch+1, watx.ID(), gomock.Any())
-		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx, watx, false))
+		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx, watx, p2p.Peer("other")))
 
 		atxFromDb, err := atxs.Get(atxHdlr.cdb, atx.ID())
 		require.NoError(t, err)
@@ -644,7 +644,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 			return atx.ID() == watx0.ID()
 		}))
 		atxHdlr.mTortoise.EXPECT().OnAtx(watx0.PublishEpoch+1, watx0.ID(), gomock.Any())
-		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx0, watx0, false))
+		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx0, watx0, p2p.Peer("other")))
 
 		watx1 := newInitialATXv1(t, goldenATXID)
 		watx1.Coinbase = types.GenerateAddress([]byte("aaaa"))
@@ -667,7 +667,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 				return nil
 			},
 		)
-		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx1, watx1, false))
+		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx1, watx1, p2p.Peer("other")))
 	})
 
 	t.Run("another atx for the same epoch for registered ID doesn't create a malfeasance proof", func(t *testing.T) {
@@ -681,7 +681,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 			return atx.ID() == watx0.ID()
 		}))
 		atxHdlr.mTortoise.EXPECT().OnAtx(watx0.PublishEpoch+1, watx0.ID(), gomock.Any())
-		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx0, watx0, false))
+		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx0, watx0, atxHdlr.local))
 
 		watx1 := newInitialATXv1(t, goldenATXID)
 		watx1.Coinbase = types.GenerateAddress([]byte("aaaa"))
@@ -689,7 +689,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 		atx1 := toAtx(t, watx1)
 
 		require.ErrorContains(t,
-			atxHdlr.storeAtx(context.Background(), atx1, watx1, true),
+			atxHdlr.storeAtx(context.Background(), atx1, watx1, atxHdlr.local),
 			fmt.Sprintf("%s already published an ATX", sig.NodeID().ShortString()),
 		)
 	})
@@ -705,7 +705,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 			return atx.ID() == initialATX.ID()
 		}))
 		atxHdlr.mTortoise.EXPECT().OnAtx(initialATX.PublishEpoch+1, initialATX.ID(), gomock.Any())
-		require.NoError(t, atxHdlr.storeAtx(context.Background(), wInitialATX, initialATX, false))
+		require.NoError(t, atxHdlr.storeAtx(context.Background(), wInitialATX, initialATX, p2p.Peer("other")))
 
 		// valid first non-initial ATX
 		watx1 := newChainedActivationTxV1(t, initialATX, goldenATXID)
@@ -716,7 +716,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 			return atx.ID() == watx1.ID()
 		}))
 		atxHdlr.mTortoise.EXPECT().OnAtx(watx1.PublishEpoch+1, watx1.ID(), gomock.Any())
-		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx1, watx1, false))
+		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx1, watx1, p2p.Peer("other")))
 
 		watx2 := newChainedActivationTxV1(t, watx1, goldenATXID)
 		watx2.Sign(sig)
@@ -726,7 +726,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 			return atx.ID() == watx2.ID()
 		}))
 		atxHdlr.mTortoise.EXPECT().OnAtx(watx2.PublishEpoch+1, watx2.ID(), gomock.Any())
-		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx2, watx2, false))
+		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx2, watx2, p2p.Peer("other")))
 
 		// third non-initial ATX references initial ATX as prevATX
 		watx3 := newChainedActivationTxV1(t, initialATX, goldenATXID)
@@ -751,7 +751,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 			},
 		)
 
-		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx3, watx3, false))
+		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx3, watx3, p2p.Peer("other")))
 	})
 
 	t.Run("another atx of v2 with the same prevatx is considered malicious", func(t *testing.T) {
@@ -765,7 +765,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 			return atx.ID() == initialATX.ID()
 		}))
 		atxHdlr.mTortoise.EXPECT().OnAtx(initialATX.PublishEpoch+1, initialATX.ID(), gomock.Any())
-		require.NoError(t, atxHdlr.v1.storeAtx(context.Background(), wInitialATX, initialATX, false))
+		require.NoError(t, atxHdlr.v1.storeAtx(context.Background(), wInitialATX, initialATX, p2p.Peer("other")))
 
 		// valid first non-initial ATX
 		watx1 := newChainedActivationTxV1(t, initialATX, goldenATXID)
@@ -776,7 +776,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 			return atx.ID() == watx1.ID()
 		}))
 		atxHdlr.mTortoise.EXPECT().OnAtx(watx1.PublishEpoch+1, watx1.ID(), gomock.Any())
-		require.NoError(t, atxHdlr.v1.storeAtx(context.Background(), atx1, watx1, false))
+		require.NoError(t, atxHdlr.v1.storeAtx(context.Background(), atx1, watx1, p2p.Peer("other")))
 
 		watx2 := newSoloATXv2(t, watx1.PublishEpoch+1, watx1.ID(), watx1.ID())
 		watx2.Sign(sig)
@@ -812,7 +812,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 			},
 		)
 
-		require.NoError(t, atxHdlr.v1.storeAtx(context.Background(), atx3, watx3, false))
+		require.NoError(t, atxHdlr.v1.storeAtx(context.Background(), atx3, watx3, p2p.Peer("other")))
 	})
 
 	t.Run("another atx with the same prevatx when publishing doesn't create a malfeasance proof", func(t *testing.T) {
@@ -827,7 +827,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 			return atx.ID() == wInitialATX.ID()
 		}))
 		atxHdlr.mTortoise.EXPECT().OnAtx(wInitialATX.PublishEpoch+1, wInitialATX.ID(), gomock.Any())
-		require.NoError(t, atxHdlr.storeAtx(context.Background(), initialAtx, wInitialATX, false))
+		require.NoError(t, atxHdlr.storeAtx(context.Background(), initialAtx, wInitialATX, atxHdlr.local))
 
 		// valid first non-initial ATX
 		watx1 := newChainedActivationTxV1(t, wInitialATX, goldenATXID)
@@ -838,7 +838,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 			return atx.ID() == watx1.ID()
 		}))
 		atxHdlr.mTortoise.EXPECT().OnAtx(watx1.PublishEpoch+1, watx1.ID(), gomock.Any())
-		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx1, watx1, false))
+		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx1, watx1, atxHdlr.local))
 
 		// second non-initial ATX references empty as prevATX
 		watx2 := newInitialATXv1(t, goldenATXID)
@@ -847,7 +847,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 		atx2 := toAtx(t, watx2)
 
 		require.ErrorContains(t,
-			atxHdlr.storeAtx(context.Background(), atx2, watx2, true),
+			atxHdlr.storeAtx(context.Background(), atx2, watx2, atxHdlr.local),
 			fmt.Sprintf("%s referenced incorrect previous ATX", sig.NodeID().ShortString()),
 		)
 	})

--- a/activation/handler_v1_test.go
+++ b/activation/handler_v1_test.go
@@ -54,7 +54,6 @@ func newV1TestHandler(tb testing.TB, goldenATXID types.ATXID) *v1TestHandler {
 			beacon:          mocks.mBeacon,
 			tortoise:        mocks.mTortoise,
 			malPublisher:    mocks.mLegacyMalPublish,
-			signers:         make(map[types.NodeID]*signing.EdSigner),
 		},
 		handlerMocks: mocks,
 	}
@@ -583,7 +582,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 			return atx.ID() == watx.ID()
 		}))
 		atxHdlr.mTortoise.EXPECT().OnAtx(watx.PublishEpoch+1, watx.ID(), gomock.Any())
-		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx, watx))
+		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx, watx, false))
 
 		atxFromDb, err := atxs.Get(atxHdlr.cdb, atx.ID())
 		require.NoError(t, err)
@@ -602,13 +601,13 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 			return atx.ID() == watx.ID()
 		}))
 		atxHdlr.mTortoise.EXPECT().OnAtx(watx.PublishEpoch+1, watx.ID(), gomock.Any())
-		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx, watx))
+		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx, watx, false))
 
 		atxHdlr.mBeacon.EXPECT().OnAtx(gomock.Cond(func(atx *types.ActivationTx) bool {
 			return atx.ID() == watx.ID()
 		}))
 		// Note: tortoise is not informed about the same ATX again
-		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx, watx))
+		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx, watx, false))
 	})
 
 	t.Run("stores ATX of malicious identity", func(t *testing.T) {
@@ -626,7 +625,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 			return atx.ID() == watx.ID()
 		}))
 		atxHdlr.mTortoise.EXPECT().OnAtx(watx.PublishEpoch+1, watx.ID(), gomock.Any())
-		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx, watx))
+		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx, watx, false))
 
 		atxFromDb, err := atxs.Get(atxHdlr.cdb, atx.ID())
 		require.NoError(t, err)
@@ -645,7 +644,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 			return atx.ID() == watx0.ID()
 		}))
 		atxHdlr.mTortoise.EXPECT().OnAtx(watx0.PublishEpoch+1, watx0.ID(), gomock.Any())
-		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx0, watx0))
+		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx0, watx0, false))
 
 		watx1 := newInitialATXv1(t, goldenATXID)
 		watx1.Coinbase = types.GenerateAddress([]byte("aaaa"))
@@ -668,12 +667,11 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 				return nil
 			},
 		)
-		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx1, watx1))
+		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx1, watx1, false))
 	})
 
 	t.Run("another atx for the same epoch for registered ID doesn't create a malfeasance proof", func(t *testing.T) {
 		atxHdlr := newV1TestHandler(t, goldenATXID)
-		atxHdlr.Register(sig)
 
 		watx0 := newInitialATXv1(t, goldenATXID)
 		watx0.Sign(sig)
@@ -683,7 +681,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 			return atx.ID() == watx0.ID()
 		}))
 		atxHdlr.mTortoise.EXPECT().OnAtx(watx0.PublishEpoch+1, watx0.ID(), gomock.Any())
-		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx0, watx0))
+		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx0, watx0, false))
 
 		watx1 := newInitialATXv1(t, goldenATXID)
 		watx1.Coinbase = types.GenerateAddress([]byte("aaaa"))
@@ -691,7 +689,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 		atx1 := toAtx(t, watx1)
 
 		require.ErrorContains(t,
-			atxHdlr.storeAtx(context.Background(), atx1, watx1),
+			atxHdlr.storeAtx(context.Background(), atx1, watx1, true),
 			fmt.Sprintf("%s already published an ATX", sig.NodeID().ShortString()),
 		)
 	})
@@ -707,7 +705,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 			return atx.ID() == initialATX.ID()
 		}))
 		atxHdlr.mTortoise.EXPECT().OnAtx(initialATX.PublishEpoch+1, initialATX.ID(), gomock.Any())
-		require.NoError(t, atxHdlr.storeAtx(context.Background(), wInitialATX, initialATX))
+		require.NoError(t, atxHdlr.storeAtx(context.Background(), wInitialATX, initialATX, false))
 
 		// valid first non-initial ATX
 		watx1 := newChainedActivationTxV1(t, initialATX, goldenATXID)
@@ -718,7 +716,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 			return atx.ID() == watx1.ID()
 		}))
 		atxHdlr.mTortoise.EXPECT().OnAtx(watx1.PublishEpoch+1, watx1.ID(), gomock.Any())
-		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx1, watx1))
+		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx1, watx1, false))
 
 		watx2 := newChainedActivationTxV1(t, watx1, goldenATXID)
 		watx2.Sign(sig)
@@ -728,7 +726,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 			return atx.ID() == watx2.ID()
 		}))
 		atxHdlr.mTortoise.EXPECT().OnAtx(watx2.PublishEpoch+1, watx2.ID(), gomock.Any())
-		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx2, watx2))
+		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx2, watx2, false))
 
 		// third non-initial ATX references initial ATX as prevATX
 		watx3 := newChainedActivationTxV1(t, initialATX, goldenATXID)
@@ -753,7 +751,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 			},
 		)
 
-		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx3, watx3))
+		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx3, watx3, false))
 	})
 
 	t.Run("another atx of v2 with the same prevatx is considered malicious", func(t *testing.T) {
@@ -767,7 +765,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 			return atx.ID() == initialATX.ID()
 		}))
 		atxHdlr.mTortoise.EXPECT().OnAtx(initialATX.PublishEpoch+1, initialATX.ID(), gomock.Any())
-		require.NoError(t, atxHdlr.v1.storeAtx(context.Background(), wInitialATX, initialATX))
+		require.NoError(t, atxHdlr.v1.storeAtx(context.Background(), wInitialATX, initialATX, false))
 
 		// valid first non-initial ATX
 		watx1 := newChainedActivationTxV1(t, initialATX, goldenATXID)
@@ -778,7 +776,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 			return atx.ID() == watx1.ID()
 		}))
 		atxHdlr.mTortoise.EXPECT().OnAtx(watx1.PublishEpoch+1, watx1.ID(), gomock.Any())
-		require.NoError(t, atxHdlr.v1.storeAtx(context.Background(), atx1, watx1))
+		require.NoError(t, atxHdlr.v1.storeAtx(context.Background(), atx1, watx1, false))
 
 		watx2 := newSoloATXv2(t, watx1.PublishEpoch+1, watx1.ID(), watx1.ID())
 		watx2.Sign(sig)
@@ -814,12 +812,11 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 			},
 		)
 
-		require.NoError(t, atxHdlr.v1.storeAtx(context.Background(), atx3, watx3))
+		require.NoError(t, atxHdlr.v1.storeAtx(context.Background(), atx3, watx3, false))
 	})
 
-	t.Run("another atx with the same prevatx for registered ID doesn't create a malfeasance proof", func(t *testing.T) {
+	t.Run("another atx with the same prevatx when publishing doesn't create a malfeasance proof", func(t *testing.T) {
 		atxHdlr := newV1TestHandler(t, goldenATXID)
-		atxHdlr.Register(sig)
 
 		// Act & Assert
 		wInitialATX := newInitialATXv1(t, goldenATXID)
@@ -830,7 +827,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 			return atx.ID() == wInitialATX.ID()
 		}))
 		atxHdlr.mTortoise.EXPECT().OnAtx(wInitialATX.PublishEpoch+1, wInitialATX.ID(), gomock.Any())
-		require.NoError(t, atxHdlr.storeAtx(context.Background(), initialAtx, wInitialATX))
+		require.NoError(t, atxHdlr.storeAtx(context.Background(), initialAtx, wInitialATX, false))
 
 		// valid first non-initial ATX
 		watx1 := newChainedActivationTxV1(t, wInitialATX, goldenATXID)
@@ -841,7 +838,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 			return atx.ID() == watx1.ID()
 		}))
 		atxHdlr.mTortoise.EXPECT().OnAtx(watx1.PublishEpoch+1, watx1.ID(), gomock.Any())
-		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx1, watx1))
+		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx1, watx1, false))
 
 		// second non-initial ATX references empty as prevATX
 		watx2 := newInitialATXv1(t, goldenATXID)
@@ -850,7 +847,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 		atx2 := toAtx(t, watx2)
 
 		require.ErrorContains(t,
-			atxHdlr.storeAtx(context.Background(), atx2, watx2),
+			atxHdlr.storeAtx(context.Background(), atx2, watx2, true),
 			fmt.Sprintf("%s referenced incorrect previous ATX", sig.NodeID().ShortString()),
 		)
 	})

--- a/node/node.go
+++ b/node/node.go
@@ -1260,9 +1260,6 @@ func (app *App) initServices(ctx context.Context) error {
 		activation.WithTickSize(app.Config.TickSize),
 		activation.WithAtxVersions(app.Config.AtxVersions),
 	)
-	for _, sig := range app.signers {
-		atxHandler.Register(sig)
-	}
 	malHandler2.RegisterHandler(malfeasance2.InvalidActivation, atxMalHandler)
 
 	fetcher.SetMalfeasanceProvider(malfeasancePublisher)


### PR DESCRIPTION
Part of #6703 

The current approach of avoiding self-ban during ATX merge won't work, because the IDs behind the smeshing-services aren't registered in the handler. Instead, we can look at the peer ID that the message comes from. If it is our local peer ID, then we know that we validate a message which we published.

This PR only changes this behavior for ATX V1. A follow-up PRs will take care of ATX V2 and other protocols in which the smeshing-service could self-ban (hare, proposals).