### PR TITLE
[Merged by Bors] - Remove unimplemented from v1

### DIFF
--- a/api/grpcserver/admin_service.go
+++ b/api/grpcserver/admin_service.go
@@ -224,7 +224,7 @@ func connKind(kind peerinfo.Kind) pb.ConnectionInfo_Kind {
 	case peerinfo.KindRelayOutbound:
 		return pb.ConnectionInfo_RelayOutbound
 	default:
-		return pb.ConnectionInfo_Uknown
+		return pb.ConnectionInfo_Unknown
 	}
 }
 

--- a/api/grpcserver/globalstate_service.go
+++ b/api/grpcserver/globalstate_service.go
@@ -191,14 +191,6 @@ func (s *GlobalStateService) AccountDataQuery(
 	return res, nil
 }
 
-// SmesherDataQuery returns historical info on smesher rewards.
-func (s *GlobalStateService) SmesherDataQuery(
-	_ context.Context,
-	in *pb.SmesherDataQueryRequest,
-) (*pb.SmesherDataQueryResponse, error) {
-	return nil, status.Errorf(codes.Unimplemented, "DEPRECATED")
-}
-
 // STREAMS
 
 // AccountDataStream exposes a stream of account-related data.
@@ -322,22 +314,6 @@ func (s *GlobalStateService) AccountDataStream(
 			return nil
 		}
 	}
-}
-
-// SmesherRewardStream exposes a stream of smesher rewards.
-func (s *GlobalStateService) SmesherRewardStream(
-	in *pb.SmesherRewardStreamRequest,
-	stream pb.GlobalStateService_SmesherRewardStreamServer,
-) error {
-	return status.Errorf(codes.Unimplemented, "DEPRECATED")
-}
-
-// AppEventStream exposes a stream of emitted app events.
-func (s *GlobalStateService) AppEventStream(
-	*pb.AppEventStreamRequest,
-	pb.GlobalStateService_AppEventStreamServer,
-) error {
-	return status.Errorf(codes.Unimplemented, "this endpoint has not yet been implemented")
 }
 
 // GlobalStateStream exposes a stream of global data data items: rewards, receipts, account info, global state hash.

--- a/api/grpcserver/globalstate_service_test.go
+++ b/api/grpcserver/globalstate_service_test.go
@@ -213,17 +213,7 @@ func TestGlobalStateService(t *testing.T) {
 		checkAccountDataQueryItemReward(t, res.AccountItem[0].Datum)
 		checkAccountDataQueryItemAccount(t, res.AccountItem[1].Datum)
 	})
-	t.Run("AppEventStream", func(t *testing.T) {
-		t.Parallel()
-		c, ctx := setupGlobalStateService(t)
 
-		stream, err := c.AppEventStream(ctx, &pb.AppEventStreamRequest{})
-		// We expect to be able to open the stream but for it to fail upon the first request
-		require.NoError(t, err)
-		_, err = stream.Recv()
-		statusCode := status.Code(err)
-		require.Equal(t, codes.Unimplemented, statusCode)
-	})
 	t.Run("AccountDataStream_emptyAddress", func(t *testing.T) {
 		t.Parallel()
 		c, ctx := setupGlobalStateService(t)

--- a/api/grpcserver/grpcserver_test.go
+++ b/api/grpcserver/grpcserver_test.go
@@ -668,22 +668,6 @@ func TestSmesherService(t *testing.T) {
 		require.Equal(t, addr1, addr)
 	})
 
-	t.Run("MinGas", func(t *testing.T) {
-		t.Parallel()
-		c, ctx := setupSmesherService(t, nil)
-		_, err := c.MinGas(ctx, &emptypb.Empty{})
-		require.Error(t, err)
-		require.Equal(t, codes.Unimplemented, status.Code(err))
-	})
-
-	t.Run("SetMinGas", func(t *testing.T) {
-		t.Parallel()
-		c, ctx := setupSmesherService(t, nil)
-		_, err := c.SetMinGas(ctx, &pb.SetMinGasRequest{})
-		require.Error(t, err)
-		require.Equal(t, codes.Unimplemented, status.Code(err))
-	})
-
 	t.Run("PostSetupComputeProviders", func(t *testing.T) {
 		t.Parallel()
 		c, ctx := setupSmesherService(t, nil)

--- a/api/grpcserver/smesher_service.go
+++ b/api/grpcserver/smesher_service.go
@@ -163,11 +163,6 @@ func (s *SmesherService) StopSmeshing(
 	}, nil
 }
 
-// SmesherID returns the smesher ID of this node.
-func (s *SmesherService) SmesherID(context.Context, *emptypb.Empty) (*pb.SmesherIDResponse, error) {
-	return nil, status.Errorf(codes.Unimplemented, "this endpoint has been deprecated, use `SmesherIDs` instead")
-}
-
 func (s *SmesherService) SmesherIDs(context.Context, *emptypb.Empty) (*pb.SmesherIDsResponse, error) {
 	ids := s.smeshingProvider.SmesherIDs()
 	res := &pb.SmesherIDsResponse{}
@@ -197,24 +192,6 @@ func (s *SmesherService) SetCoinbase(_ context.Context, in *pb.SetCoinbaseReques
 	return &pb.SetCoinbaseResponse{
 		Status: &rpcstatus.Status{Code: int32(code.Code_OK)},
 	}, nil
-}
-
-// MinGas returns the current mingas setting of this node.
-func (s *SmesherService) MinGas(context.Context, *emptypb.Empty) (*pb.MinGasResponse, error) {
-	return nil, status.Errorf(codes.Unimplemented, "this endpoint is not implemented")
-}
-
-// SetMinGas sets the mingas setting of this node.
-func (s *SmesherService) SetMinGas(context.Context, *pb.SetMinGasRequest) (*pb.SetMinGasResponse, error) {
-	return nil, status.Errorf(codes.Unimplemented, "this endpoint is not implemented")
-}
-
-// EstimatedRewards returns estimated smeshing rewards over the next epoch.
-func (s *SmesherService) EstimatedRewards(
-	context.Context,
-	*pb.EstimatedRewardsRequest,
-) (*pb.EstimatedRewardsResponse, error) {
-	return nil, status.Errorf(codes.Unimplemented, "this endpoint is not implemented")
 }
 
 // PostSetupStatus returns post data status.

--- a/api/grpcserver/smesher_service_test.go
+++ b/api/grpcserver/smesher_service_test.go
@@ -336,25 +336,3 @@ func TestSmesherService_PostSetupStatus(t *testing.T) {
 		require.False(t, resp.Status.Opts.Throttle)
 	})
 }
-
-func TestSmesherService_SmesherID(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	smeshingProvider := activation.NewMockSmeshingProvider(ctrl)
-	postSupervisor := grpcserver.NewMockpostSupervisor(ctrl)
-	grpcPostService := grpcserver.NewMockgrpcPostService(ctrl)
-	svc := grpcserver.NewSmesherService(
-		smeshingProvider,
-		postSupervisor,
-		grpcPostService,
-		time.Second,
-		activation.DefaultPostSetupOpts(),
-		nil,
-	)
-
-	resp, err := svc.SmesherID(context.Background(), &emptypb.Empty{})
-	require.Error(t, err)
-	require.Nil(t, resp)
-	statusErr, ok := status.FromError(err)
-	require.True(t, ok)
-	require.Equal(t, codes.Unimplemented, statusErr.Code())
-}

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/seehuhn/mt19937 v1.0.0
 	github.com/slok/go-http-metrics v0.13.0
-	github.com/spacemeshos/api/release/go v1.61.1-0.20250207133756-610990a3d178
+	github.com/spacemeshos/api/release/go v1.61.1-0.20250209132933-beaa1fc703cd
 	github.com/spacemeshos/economics v0.1.4
 	github.com/spacemeshos/fixed v0.1.2
 	github.com/spacemeshos/go-scale v1.2.1

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/seehuhn/mt19937 v1.0.0
 	github.com/slok/go-http-metrics v0.13.0
-	github.com/spacemeshos/api/release/go v1.61.0
+	github.com/spacemeshos/api/release/go v1.61.1-0.20250207133756-610990a3d178
 	github.com/spacemeshos/economics v0.1.4
 	github.com/spacemeshos/fixed v0.1.2
 	github.com/spacemeshos/go-scale v1.2.1

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/seehuhn/mt19937 v1.0.0
 	github.com/slok/go-http-metrics v0.13.0
-	github.com/spacemeshos/api/release/go v1.61.1-0.20250209132933-beaa1fc703cd
+	github.com/spacemeshos/api/release/go v1.62.0
 	github.com/spacemeshos/economics v0.1.4
 	github.com/spacemeshos/fixed v0.1.2
 	github.com/spacemeshos/go-scale v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -630,8 +630,8 @@ github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d/go.mod h1:Udh
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
-github.com/spacemeshos/api/release/go v1.61.1-0.20250207133756-610990a3d178 h1:6d3KnJchKIx3taOEW42G2A93S/grV+Omu36NjY8The0=
-github.com/spacemeshos/api/release/go v1.61.1-0.20250207133756-610990a3d178/go.mod h1:uBm4XPydRb5emOW6TckYzXcSQDyAv4q6Z4ud7HaLzxI=
+github.com/spacemeshos/api/release/go v1.61.1-0.20250209132933-beaa1fc703cd h1:4fO4hQlSIO5hqIDhAsUsJBIYQOdVq2fXP4kFxkgo08E=
+github.com/spacemeshos/api/release/go v1.61.1-0.20250209132933-beaa1fc703cd/go.mod h1:rpNrbXOosY/TVr/2Yvdrw27l6MrarKd0HkFptJSFDMA=
 github.com/spacemeshos/economics v0.1.4 h1:twlawrcQhYNqPgyDv08+24EL/OgUKz3d7q+PvJIAND0=
 github.com/spacemeshos/economics v0.1.4/go.mod h1:6HKWKiKdxjVQcGa2z/wA0LR4M/DzKib856bP16yqNmQ=
 github.com/spacemeshos/fixed v0.1.2 h1:pENQ8pXFAqin3f15ZLoOVVeSgcmcFJ0IFdFm4+9u4SM=

--- a/go.sum
+++ b/go.sum
@@ -630,8 +630,8 @@ github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d/go.mod h1:Udh
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
-github.com/spacemeshos/api/release/go v1.61.0 h1:Jdni0kODbpDL/F7MkbNN1R4ioVC3lHk3TA8E04p/ENc=
-github.com/spacemeshos/api/release/go v1.61.0/go.mod h1:uBm4XPydRb5emOW6TckYzXcSQDyAv4q6Z4ud7HaLzxI=
+github.com/spacemeshos/api/release/go v1.61.1-0.20250207133756-610990a3d178 h1:6d3KnJchKIx3taOEW42G2A93S/grV+Omu36NjY8The0=
+github.com/spacemeshos/api/release/go v1.61.1-0.20250207133756-610990a3d178/go.mod h1:uBm4XPydRb5emOW6TckYzXcSQDyAv4q6Z4ud7HaLzxI=
 github.com/spacemeshos/economics v0.1.4 h1:twlawrcQhYNqPgyDv08+24EL/OgUKz3d7q+PvJIAND0=
 github.com/spacemeshos/economics v0.1.4/go.mod h1:6HKWKiKdxjVQcGa2z/wA0LR4M/DzKib856bP16yqNmQ=
 github.com/spacemeshos/fixed v0.1.2 h1:pENQ8pXFAqin3f15ZLoOVVeSgcmcFJ0IFdFm4+9u4SM=

--- a/go.sum
+++ b/go.sum
@@ -630,8 +630,8 @@ github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d/go.mod h1:Udh
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
-github.com/spacemeshos/api/release/go v1.61.1-0.20250209132933-beaa1fc703cd h1:4fO4hQlSIO5hqIDhAsUsJBIYQOdVq2fXP4kFxkgo08E=
-github.com/spacemeshos/api/release/go v1.61.1-0.20250209132933-beaa1fc703cd/go.mod h1:rpNrbXOosY/TVr/2Yvdrw27l6MrarKd0HkFptJSFDMA=
+github.com/spacemeshos/api/release/go v1.62.0 h1:re2aTHwpiCbxO/SVJEpHItVW298s0X0bwlgf8h3bcEU=
+github.com/spacemeshos/api/release/go v1.62.0/go.mod h1:rpNrbXOosY/TVr/2Yvdrw27l6MrarKd0HkFptJSFDMA=
 github.com/spacemeshos/economics v0.1.4 h1:twlawrcQhYNqPgyDv08+24EL/OgUKz3d7q+PvJIAND0=
 github.com/spacemeshos/economics v0.1.4/go.mod h1:6HKWKiKdxjVQcGa2z/wA0LR4M/DzKib856bP16yqNmQ=
 github.com/spacemeshos/fixed v0.1.2 h1:pENQ8pXFAqin3f15ZLoOVVeSgcmcFJ0IFdFm4+9u4SM=


### PR DESCRIPTION
## Motivation

Followup to https://github.com/spacemeshos/go-spacemesh/pull/6688: removes unimplemented endpoints from v1 API.

See also https://github.com/spacemeshos/api/pull/426 and https://github.com/spacemeshos/api/pull/427

## Description

With V2 API nearing finality, V1 API won't be extended any more. This removes endpoints that are defined but have never been implemented or long depreciated from the node and API definitions.

## Test Plan

existing tests pass

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
