### PR TITLE
[Merged by Bors] - Avoid self malfeasance

### DIFF
--- a/activation/handler.go
+++ b/activation/handler.go
@@ -128,7 +128,6 @@ func NewHandler(
 			tortoise:        tortoise,
 			malPublisher:    legacyMalPublisher,
 			malPublisher2:   malPublisher,
-			signers:         make(map[types.NodeID]*signing.EdSigner),
 		},
 
 		v2: &HandlerV2{
@@ -161,10 +160,6 @@ func NewHandler(
 		})))
 
 	return h
-}
-
-func (h *Handler) Register(sig *signing.EdSigner) {
-	h.v1.Register(sig)
 }
 
 // HandleSyncedAtx handles atxs received by sync.

--- a/activation/handler_v1.go
+++ b/activation/handler_v1.go
@@ -392,7 +392,7 @@ func (h *HandlerV1) checkWrongPrevAtx(
 	atx *wire.ActivationTxV1,
 	peer peer.ID,
 ) (bool, error) {
-	expectedPrevID, err := atxs.PrevIDByNodeID(tx, atx.SmesherID, atx.PublishEpoch)
+	expectedPrevID, err := atxs.PrevIDByNodeID(tx, atx.ID(), atx.SmesherID, atx.PublishEpoch)
 	if err != nil && !errors.Is(err, sql.ErrNotFound) {
 		return false, fmt.Errorf("get last atx by node id: %w", err)
 	}

--- a/activation/handler_v1.go
+++ b/activation/handler_v1.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"math/bits"
-	"sync"
 	"time"
 
 	"github.com/spacemeshos/post/shared"
@@ -78,21 +77,6 @@ type HandlerV1 struct {
 	fetcher         system.Fetcher
 	malPublisher    legacyMalfeasancePublisher
 	malPublisher2   atxMalfeasancePublisher
-
-	signerMtx sync.Mutex
-	signers   map[types.NodeID]*signing.EdSigner
-}
-
-func (h *HandlerV1) Register(sig *signing.EdSigner) {
-	h.signerMtx.Lock()
-	defer h.signerMtx.Unlock()
-	if _, exists := h.signers[sig.NodeID()]; exists {
-		h.logger.Error("signing key already registered", log.ZShortStringer("id", sig.NodeID()))
-		return
-	}
-
-	h.logger.Info("registered signing key", log.ZShortStringer("id", sig.NodeID()))
-	h.signers[sig.NodeID()] = sig
 }
 
 func (h *HandlerV1) syntacticallyValidate(ctx context.Context, atx *wire.ActivationTxV1) error {
@@ -337,7 +321,7 @@ func (h *HandlerV1) cacheAtx(ctx context.Context, atx *types.ActivationTx, malic
 }
 
 // checkDoublePublish verifies if a node has already published an ATX in the same epoch.
-func (h *HandlerV1) checkDoublePublish(ctx context.Context, tx sql.Executor, atx *wire.ActivationTxV1) (bool, error) {
+func (h *HandlerV1) checkDoublePublish(ctx context.Context, tx sql.Executor, atx *wire.ActivationTxV1, publishing bool) (bool, error) {
 	prev, err := atxs.GetByEpochAndNodeID(tx, atx.PublishEpoch, atx.SmesherID)
 	if err != nil && !errors.Is(err, sql.ErrNotFound) {
 		return false, err
@@ -347,7 +331,7 @@ func (h *HandlerV1) checkDoublePublish(ctx context.Context, tx sql.Executor, atx
 		return false, nil
 	}
 
-	if _, ok := h.signers[atx.SmesherID]; ok {
+	if publishing {
 		// if we land here we tried to publish 2 ATXs in the same epoch
 		// don't punish ourselves but fail validation and thereby the handling of the incoming ATX
 		return false, fmt.Errorf(
@@ -396,7 +380,7 @@ func (h *HandlerV1) checkDoublePublish(ctx context.Context, tx sql.Executor, atx
 }
 
 // checkWrongPrevAtx verifies if the previous ATX referenced in the ATX is correct.
-func (h *HandlerV1) checkWrongPrevAtx(ctx context.Context, tx sql.Executor, atx *wire.ActivationTxV1) (bool, error) {
+func (h *HandlerV1) checkWrongPrevAtx(ctx context.Context, tx sql.Executor, atx *wire.ActivationTxV1, publishing bool) (bool, error) {
 	expectedPrevID, err := atxs.PrevIDByNodeID(tx, atx.SmesherID, atx.PublishEpoch)
 	if err != nil && !errors.Is(err, sql.ErrNotFound) {
 		return false, fmt.Errorf("get last atx by node id: %w", err)
@@ -405,7 +389,7 @@ func (h *HandlerV1) checkWrongPrevAtx(ctx context.Context, tx sql.Executor, atx 
 		return false, nil
 	}
 
-	if _, ok := h.signers[atx.SmesherID]; ok {
+	if publishing {
 		// if we land here we tried to publish an ATX with a wrong prevATX
 		h.logger.Warn(
 			"Node produced an ATX with a wrong prevATX. This can happened when the node wasn't synced when "+
@@ -473,15 +457,15 @@ func (h *HandlerV1) checkWrongPrevAtx(ctx context.Context, tx sql.Executor, atx 
 	return true, h.malPublisher.PublishProof(ctx, atx.SmesherID, proof)
 }
 
-func (h *HandlerV1) checkMalicious(ctx context.Context, tx sql.Transaction, watx *wire.ActivationTxV1) (bool, error) {
-	malicious, err := h.checkDoublePublish(ctx, tx, watx)
+func (h *HandlerV1) checkMalicious(ctx context.Context, tx sql.Transaction, watx *wire.ActivationTxV1, publishing bool) (bool, error) {
+	malicious, err := h.checkDoublePublish(ctx, tx, watx, publishing)
 	if err != nil {
 		return malicious, fmt.Errorf("check double publish: %w", err)
 	}
 	if malicious {
 		return true, nil
 	}
-	malicious, err = h.checkWrongPrevAtx(ctx, tx, watx)
+	malicious, err = h.checkWrongPrevAtx(ctx, tx, watx, publishing)
 	if err != nil {
 		return malicious, fmt.Errorf("check wrong prev atx: %w", err)
 	}
@@ -489,7 +473,7 @@ func (h *HandlerV1) checkMalicious(ctx context.Context, tx sql.Transaction, watx
 }
 
 // storeAtx stores an ATX and notifies subscribers of the ATXID.
-func (h *HandlerV1) storeAtx(ctx context.Context, atx *types.ActivationTx, watx *wire.ActivationTxV1) error {
+func (h *HandlerV1) storeAtx(ctx context.Context, atx *types.ActivationTx, watx *wire.ActivationTxV1, publishing bool) error {
 	var malicious bool
 	if err := h.cdb.WithTxImmediate(ctx, func(tx sql.Transaction) error {
 		var err error
@@ -503,7 +487,7 @@ func (h *HandlerV1) storeAtx(ctx context.Context, atx *types.ActivationTx, watx 
 		}
 		malicious = malicious || malicious2
 		if !malicious {
-			malicious, err = h.checkMalicious(ctx, tx, watx)
+			malicious, err = h.checkMalicious(ctx, tx, watx, publishing)
 			if err != nil {
 				return fmt.Errorf("check malicious: %w", err)
 			}
@@ -576,7 +560,8 @@ func (h *HandlerV1) processATX(
 		return fmt.Errorf("%w: validating atx %s (deps): %w", pubsub.ErrValidationReject, watx.ID(), err)
 	}
 
-	if err := h.storeAtx(ctx, atx, watx); err != nil {
+	publishing := h.local == peer
+	if err := h.storeAtx(ctx, atx, watx, publishing); err != nil {
 		return fmt.Errorf("cannot store atx %s: %w", atx.ShortString(), err)
 	}
 

--- a/activation/handler_v1.go
+++ b/activation/handler_v1.go
@@ -7,6 +7,7 @@ import (
 	"math/bits"
 	"time"
 
+	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/spacemeshos/post/shared"
 	"github.com/spacemeshos/post/verifying"
 	"go.uber.org/zap"
@@ -321,7 +322,12 @@ func (h *HandlerV1) cacheAtx(ctx context.Context, atx *types.ActivationTx, malic
 }
 
 // checkDoublePublish verifies if a node has already published an ATX in the same epoch.
-func (h *HandlerV1) checkDoublePublish(ctx context.Context, tx sql.Executor, atx *wire.ActivationTxV1, publishing bool) (bool, error) {
+func (h *HandlerV1) checkDoublePublish(
+	ctx context.Context,
+	tx sql.Executor,
+	atx *wire.ActivationTxV1,
+	peer peer.ID,
+) (bool, error) {
 	prev, err := atxs.GetByEpochAndNodeID(tx, atx.PublishEpoch, atx.SmesherID)
 	if err != nil && !errors.Is(err, sql.ErrNotFound) {
 		return false, err
@@ -331,7 +337,7 @@ func (h *HandlerV1) checkDoublePublish(ctx context.Context, tx sql.Executor, atx
 		return false, nil
 	}
 
-	if publishing {
+	if peer == h.local {
 		// if we land here we tried to publish 2 ATXs in the same epoch
 		// don't punish ourselves but fail validation and thereby the handling of the incoming ATX
 		return false, fmt.Errorf(
@@ -380,7 +386,12 @@ func (h *HandlerV1) checkDoublePublish(ctx context.Context, tx sql.Executor, atx
 }
 
 // checkWrongPrevAtx verifies if the previous ATX referenced in the ATX is correct.
-func (h *HandlerV1) checkWrongPrevAtx(ctx context.Context, tx sql.Executor, atx *wire.ActivationTxV1, publishing bool) (bool, error) {
+func (h *HandlerV1) checkWrongPrevAtx(
+	ctx context.Context,
+	tx sql.Executor,
+	atx *wire.ActivationTxV1,
+	peer peer.ID,
+) (bool, error) {
 	expectedPrevID, err := atxs.PrevIDByNodeID(tx, atx.SmesherID, atx.PublishEpoch)
 	if err != nil && !errors.Is(err, sql.ErrNotFound) {
 		return false, fmt.Errorf("get last atx by node id: %w", err)
@@ -389,7 +400,7 @@ func (h *HandlerV1) checkWrongPrevAtx(ctx context.Context, tx sql.Executor, atx 
 		return false, nil
 	}
 
-	if publishing {
+	if peer == h.local {
 		// if we land here we tried to publish an ATX with a wrong prevATX
 		h.logger.Warn(
 			"Node produced an ATX with a wrong prevATX. This can happened when the node wasn't synced when "+
@@ -457,15 +468,20 @@ func (h *HandlerV1) checkWrongPrevAtx(ctx context.Context, tx sql.Executor, atx 
 	return true, h.malPublisher.PublishProof(ctx, atx.SmesherID, proof)
 }
 
-func (h *HandlerV1) checkMalicious(ctx context.Context, tx sql.Transaction, watx *wire.ActivationTxV1, publishing bool) (bool, error) {
-	malicious, err := h.checkDoublePublish(ctx, tx, watx, publishing)
+func (h *HandlerV1) checkMalicious(
+	ctx context.Context,
+	tx sql.Transaction,
+	watx *wire.ActivationTxV1,
+	peer peer.ID,
+) (bool, error) {
+	malicious, err := h.checkDoublePublish(ctx, tx, watx, peer)
 	if err != nil {
 		return malicious, fmt.Errorf("check double publish: %w", err)
 	}
 	if malicious {
 		return true, nil
 	}
-	malicious, err = h.checkWrongPrevAtx(ctx, tx, watx, publishing)
+	malicious, err = h.checkWrongPrevAtx(ctx, tx, watx, peer)
 	if err != nil {
 		return malicious, fmt.Errorf("check wrong prev atx: %w", err)
 	}
@@ -473,7 +489,12 @@ func (h *HandlerV1) checkMalicious(ctx context.Context, tx sql.Transaction, watx
 }
 
 // storeAtx stores an ATX and notifies subscribers of the ATXID.
-func (h *HandlerV1) storeAtx(ctx context.Context, atx *types.ActivationTx, watx *wire.ActivationTxV1, publishing bool) error {
+func (h *HandlerV1) storeAtx(
+	ctx context.Context,
+	atx *types.ActivationTx,
+	watx *wire.ActivationTxV1,
+	peer peer.ID,
+) error {
 	var malicious bool
 	if err := h.cdb.WithTxImmediate(ctx, func(tx sql.Transaction) error {
 		var err error
@@ -487,7 +508,7 @@ func (h *HandlerV1) storeAtx(ctx context.Context, atx *types.ActivationTx, watx 
 		}
 		malicious = malicious || malicious2
 		if !malicious {
-			malicious, err = h.checkMalicious(ctx, tx, watx, publishing)
+			malicious, err = h.checkMalicious(ctx, tx, watx, peer)
 			if err != nil {
 				return fmt.Errorf("check malicious: %w", err)
 			}
@@ -560,8 +581,7 @@ func (h *HandlerV1) processATX(
 		return fmt.Errorf("%w: validating atx %s (deps): %w", pubsub.ErrValidationReject, watx.ID(), err)
 	}
 
-	publishing := h.local == peer
-	if err := h.storeAtx(ctx, atx, watx, publishing); err != nil {
+	if err := h.storeAtx(ctx, atx, watx, peer); err != nil {
 		return fmt.Errorf("cannot store atx %s: %w", atx.ShortString(), err)
 	}
 

--- a/activation/handler_v1_test.go
+++ b/activation/handler_v1_test.go
@@ -582,7 +582,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 			return atx.ID() == watx.ID()
 		}))
 		atxHdlr.mTortoise.EXPECT().OnAtx(watx.PublishEpoch+1, watx.ID(), gomock.Any())
-		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx, watx, false))
+		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx, watx, p2p.Peer("other")))
 
 		atxFromDb, err := atxs.Get(atxHdlr.cdb, atx.ID())
 		require.NoError(t, err)
@@ -601,13 +601,13 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 			return atx.ID() == watx.ID()
 		}))
 		atxHdlr.mTortoise.EXPECT().OnAtx(watx.PublishEpoch+1, watx.ID(), gomock.Any())
-		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx, watx, false))
+		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx, watx, p2p.Peer("other")))
 
 		atxHdlr.mBeacon.EXPECT().OnAtx(gomock.Cond(func(atx *types.ActivationTx) bool {
 			return atx.ID() == watx.ID()
 		}))
 		// Note: tortoise is not informed about the same ATX again
-		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx, watx, false))
+		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx, watx, p2p.Peer("other")))
 	})
 
 	t.Run("stores ATX of malicious identity", func(t *testing.T) {
@@ -625,7 +625,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 			return atx.ID() == watx.ID()
 		}))
 		atxHdlr.mTortoise.EXPECT().OnAtx(watx.PublishEpoch+1, watx.ID(), gomock.Any())
-		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx, watx, false))
+		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx, watx, p2p.Peer("other")))
 
 		atxFromDb, err := atxs.Get(atxHdlr.cdb, atx.ID())
 		require.NoError(t, err)
@@ -644,7 +644,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 			return atx.ID() == watx0.ID()
 		}))
 		atxHdlr.mTortoise.EXPECT().OnAtx(watx0.PublishEpoch+1, watx0.ID(), gomock.Any())
-		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx0, watx0, false))
+		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx0, watx0, p2p.Peer("other")))
 
 		watx1 := newInitialATXv1(t, goldenATXID)
 		watx1.Coinbase = types.GenerateAddress([]byte("aaaa"))
@@ -667,7 +667,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 				return nil
 			},
 		)
-		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx1, watx1, false))
+		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx1, watx1, p2p.Peer("other")))
 	})
 
 	t.Run("another atx for the same epoch for registered ID doesn't create a malfeasance proof", func(t *testing.T) {
@@ -681,7 +681,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 			return atx.ID() == watx0.ID()
 		}))
 		atxHdlr.mTortoise.EXPECT().OnAtx(watx0.PublishEpoch+1, watx0.ID(), gomock.Any())
-		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx0, watx0, false))
+		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx0, watx0, atxHdlr.local))
 
 		watx1 := newInitialATXv1(t, goldenATXID)
 		watx1.Coinbase = types.GenerateAddress([]byte("aaaa"))
@@ -689,7 +689,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 		atx1 := toAtx(t, watx1)
 
 		require.ErrorContains(t,
-			atxHdlr.storeAtx(context.Background(), atx1, watx1, true),
+			atxHdlr.storeAtx(context.Background(), atx1, watx1, atxHdlr.local),
 			fmt.Sprintf("%s already published an ATX", sig.NodeID().ShortString()),
 		)
 	})
@@ -705,7 +705,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 			return atx.ID() == initialATX.ID()
 		}))
 		atxHdlr.mTortoise.EXPECT().OnAtx(initialATX.PublishEpoch+1, initialATX.ID(), gomock.Any())
-		require.NoError(t, atxHdlr.storeAtx(context.Background(), wInitialATX, initialATX, false))
+		require.NoError(t, atxHdlr.storeAtx(context.Background(), wInitialATX, initialATX, p2p.Peer("other")))
 
 		// valid first non-initial ATX
 		watx1 := newChainedActivationTxV1(t, initialATX, goldenATXID)
@@ -716,7 +716,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 			return atx.ID() == watx1.ID()
 		}))
 		atxHdlr.mTortoise.EXPECT().OnAtx(watx1.PublishEpoch+1, watx1.ID(), gomock.Any())
-		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx1, watx1, false))
+		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx1, watx1, p2p.Peer("other")))
 
 		watx2 := newChainedActivationTxV1(t, watx1, goldenATXID)
 		watx2.Sign(sig)
@@ -726,7 +726,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 			return atx.ID() == watx2.ID()
 		}))
 		atxHdlr.mTortoise.EXPECT().OnAtx(watx2.PublishEpoch+1, watx2.ID(), gomock.Any())
-		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx2, watx2, false))
+		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx2, watx2, p2p.Peer("other")))
 
 		// third non-initial ATX references initial ATX as prevATX
 		watx3 := newChainedActivationTxV1(t, initialATX, goldenATXID)
@@ -751,7 +751,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 			},
 		)
 
-		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx3, watx3, false))
+		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx3, watx3, p2p.Peer("other")))
 	})
 
 	t.Run("another atx of v2 with the same prevatx is considered malicious", func(t *testing.T) {
@@ -765,7 +765,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 			return atx.ID() == initialATX.ID()
 		}))
 		atxHdlr.mTortoise.EXPECT().OnAtx(initialATX.PublishEpoch+1, initialATX.ID(), gomock.Any())
-		require.NoError(t, atxHdlr.v1.storeAtx(context.Background(), wInitialATX, initialATX, false))
+		require.NoError(t, atxHdlr.v1.storeAtx(context.Background(), wInitialATX, initialATX, p2p.Peer("other")))
 
 		// valid first non-initial ATX
 		watx1 := newChainedActivationTxV1(t, initialATX, goldenATXID)
@@ -776,7 +776,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 			return atx.ID() == watx1.ID()
 		}))
 		atxHdlr.mTortoise.EXPECT().OnAtx(watx1.PublishEpoch+1, watx1.ID(), gomock.Any())
-		require.NoError(t, atxHdlr.v1.storeAtx(context.Background(), atx1, watx1, false))
+		require.NoError(t, atxHdlr.v1.storeAtx(context.Background(), atx1, watx1, p2p.Peer("other")))
 
 		watx2 := newSoloATXv2(t, watx1.PublishEpoch+1, watx1.ID(), watx1.ID())
 		watx2.Sign(sig)
@@ -812,7 +812,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 			},
 		)
 
-		require.NoError(t, atxHdlr.v1.storeAtx(context.Background(), atx3, watx3, false))
+		require.NoError(t, atxHdlr.v1.storeAtx(context.Background(), atx3, watx3, p2p.Peer("other")))
 	})
 
 	t.Run("another atx with the same prevatx when publishing doesn't create a malfeasance proof", func(t *testing.T) {
@@ -827,7 +827,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 			return atx.ID() == wInitialATX.ID()
 		}))
 		atxHdlr.mTortoise.EXPECT().OnAtx(wInitialATX.PublishEpoch+1, wInitialATX.ID(), gomock.Any())
-		require.NoError(t, atxHdlr.storeAtx(context.Background(), initialAtx, wInitialATX, false))
+		require.NoError(t, atxHdlr.storeAtx(context.Background(), initialAtx, wInitialATX, atxHdlr.local))
 
 		// valid first non-initial ATX
 		watx1 := newChainedActivationTxV1(t, wInitialATX, goldenATXID)
@@ -838,7 +838,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 			return atx.ID() == watx1.ID()
 		}))
 		atxHdlr.mTortoise.EXPECT().OnAtx(watx1.PublishEpoch+1, watx1.ID(), gomock.Any())
-		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx1, watx1, false))
+		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx1, watx1, atxHdlr.local))
 
 		// second non-initial ATX references empty as prevATX
 		watx2 := newInitialATXv1(t, goldenATXID)
@@ -847,7 +847,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 		atx2 := toAtx(t, watx2)
 
 		require.ErrorContains(t,
-			atxHdlr.storeAtx(context.Background(), atx2, watx2, true),
+			atxHdlr.storeAtx(context.Background(), atx2, watx2, atxHdlr.local),
 			fmt.Sprintf("%s referenced incorrect previous ATX", sig.NodeID().ShortString()),
 		)
 	})

--- a/activation/handler_v1_test.go
+++ b/activation/handler_v1_test.go
@@ -54,7 +54,6 @@ func newV1TestHandler(tb testing.TB, goldenATXID types.ATXID) *v1TestHandler {
 			beacon:          mocks.mBeacon,
 			tortoise:        mocks.mTortoise,
 			malPublisher:    mocks.mLegacyMalPublish,
-			signers:         make(map[types.NodeID]*signing.EdSigner),
 		},
 		handlerMocks: mocks,
 	}
@@ -583,7 +582,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 			return atx.ID() == watx.ID()
 		}))
 		atxHdlr.mTortoise.EXPECT().OnAtx(watx.PublishEpoch+1, watx.ID(), gomock.Any())
-		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx, watx))
+		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx, watx, false))
 
 		atxFromDb, err := atxs.Get(atxHdlr.cdb, atx.ID())
 		require.NoError(t, err)
@@ -602,13 +601,13 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 			return atx.ID() == watx.ID()
 		}))
 		atxHdlr.mTortoise.EXPECT().OnAtx(watx.PublishEpoch+1, watx.ID(), gomock.Any())
-		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx, watx))
+		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx, watx, false))
 
 		atxHdlr.mBeacon.EXPECT().OnAtx(gomock.Cond(func(atx *types.ActivationTx) bool {
 			return atx.ID() == watx.ID()
 		}))
 		// Note: tortoise is not informed about the same ATX again
-		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx, watx))
+		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx, watx, false))
 	})
 
 	t.Run("stores ATX of malicious identity", func(t *testing.T) {
@@ -626,7 +625,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 			return atx.ID() == watx.ID()
 		}))
 		atxHdlr.mTortoise.EXPECT().OnAtx(watx.PublishEpoch+1, watx.ID(), gomock.Any())
-		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx, watx))
+		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx, watx, false))
 
 		atxFromDb, err := atxs.Get(atxHdlr.cdb, atx.ID())
 		require.NoError(t, err)
@@ -645,7 +644,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 			return atx.ID() == watx0.ID()
 		}))
 		atxHdlr.mTortoise.EXPECT().OnAtx(watx0.PublishEpoch+1, watx0.ID(), gomock.Any())
-		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx0, watx0))
+		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx0, watx0, false))
 
 		watx1 := newInitialATXv1(t, goldenATXID)
 		watx1.Coinbase = types.GenerateAddress([]byte("aaaa"))
@@ -668,12 +667,11 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 				return nil
 			},
 		)
-		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx1, watx1))
+		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx1, watx1, false))
 	})
 
 	t.Run("another atx for the same epoch for registered ID doesn't create a malfeasance proof", func(t *testing.T) {
 		atxHdlr := newV1TestHandler(t, goldenATXID)
-		atxHdlr.Register(sig)
 
 		watx0 := newInitialATXv1(t, goldenATXID)
 		watx0.Sign(sig)
@@ -683,7 +681,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 			return atx.ID() == watx0.ID()
 		}))
 		atxHdlr.mTortoise.EXPECT().OnAtx(watx0.PublishEpoch+1, watx0.ID(), gomock.Any())
-		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx0, watx0))
+		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx0, watx0, false))
 
 		watx1 := newInitialATXv1(t, goldenATXID)
 		watx1.Coinbase = types.GenerateAddress([]byte("aaaa"))
@@ -691,7 +689,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 		atx1 := toAtx(t, watx1)
 
 		require.ErrorContains(t,
-			atxHdlr.storeAtx(context.Background(), atx1, watx1),
+			atxHdlr.storeAtx(context.Background(), atx1, watx1, true),
 			fmt.Sprintf("%s already published an ATX", sig.NodeID().ShortString()),
 		)
 	})
@@ -707,7 +705,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 			return atx.ID() == initialATX.ID()
 		}))
 		atxHdlr.mTortoise.EXPECT().OnAtx(initialATX.PublishEpoch+1, initialATX.ID(), gomock.Any())
-		require.NoError(t, atxHdlr.storeAtx(context.Background(), wInitialATX, initialATX))
+		require.NoError(t, atxHdlr.storeAtx(context.Background(), wInitialATX, initialATX, false))
 
 		// valid first non-initial ATX
 		watx1 := newChainedActivationTxV1(t, initialATX, goldenATXID)
@@ -718,7 +716,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 			return atx.ID() == watx1.ID()
 		}))
 		atxHdlr.mTortoise.EXPECT().OnAtx(watx1.PublishEpoch+1, watx1.ID(), gomock.Any())
-		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx1, watx1))
+		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx1, watx1, false))
 
 		watx2 := newChainedActivationTxV1(t, watx1, goldenATXID)
 		watx2.Sign(sig)
@@ -728,7 +726,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 			return atx.ID() == watx2.ID()
 		}))
 		atxHdlr.mTortoise.EXPECT().OnAtx(watx2.PublishEpoch+1, watx2.ID(), gomock.Any())
-		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx2, watx2))
+		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx2, watx2, false))
 
 		// third non-initial ATX references initial ATX as prevATX
 		watx3 := newChainedActivationTxV1(t, initialATX, goldenATXID)
@@ -753,7 +751,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 			},
 		)
 
-		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx3, watx3))
+		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx3, watx3, false))
 	})
 
 	t.Run("another atx of v2 with the same prevatx is considered malicious", func(t *testing.T) {
@@ -767,7 +765,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 			return atx.ID() == initialATX.ID()
 		}))
 		atxHdlr.mTortoise.EXPECT().OnAtx(initialATX.PublishEpoch+1, initialATX.ID(), gomock.Any())
-		require.NoError(t, atxHdlr.v1.storeAtx(context.Background(), wInitialATX, initialATX))
+		require.NoError(t, atxHdlr.v1.storeAtx(context.Background(), wInitialATX, initialATX, false))
 
 		// valid first non-initial ATX
 		watx1 := newChainedActivationTxV1(t, initialATX, goldenATXID)
@@ -778,7 +776,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 			return atx.ID() == watx1.ID()
 		}))
 		atxHdlr.mTortoise.EXPECT().OnAtx(watx1.PublishEpoch+1, watx1.ID(), gomock.Any())
-		require.NoError(t, atxHdlr.v1.storeAtx(context.Background(), atx1, watx1))
+		require.NoError(t, atxHdlr.v1.storeAtx(context.Background(), atx1, watx1, false))
 
 		watx2 := newSoloATXv2(t, watx1.PublishEpoch+1, watx1.ID(), watx1.ID())
 		watx2.Sign(sig)
@@ -814,12 +812,11 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 			},
 		)
 
-		require.NoError(t, atxHdlr.v1.storeAtx(context.Background(), atx3, watx3))
+		require.NoError(t, atxHdlr.v1.storeAtx(context.Background(), atx3, watx3, false))
 	})
 
-	t.Run("another atx with the same prevatx for registered ID doesn't create a malfeasance proof", func(t *testing.T) {
+	t.Run("another atx with the same prevatx when publishing doesn't create a malfeasance proof", func(t *testing.T) {
 		atxHdlr := newV1TestHandler(t, goldenATXID)
-		atxHdlr.Register(sig)
 
 		// Act & Assert
 		wInitialATX := newInitialATXv1(t, goldenATXID)
@@ -830,7 +827,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 			return atx.ID() == wInitialATX.ID()
 		}))
 		atxHdlr.mTortoise.EXPECT().OnAtx(wInitialATX.PublishEpoch+1, wInitialATX.ID(), gomock.Any())
-		require.NoError(t, atxHdlr.storeAtx(context.Background(), initialAtx, wInitialATX))
+		require.NoError(t, atxHdlr.storeAtx(context.Background(), initialAtx, wInitialATX, false))
 
 		// valid first non-initial ATX
 		watx1 := newChainedActivationTxV1(t, wInitialATX, goldenATXID)
@@ -841,7 +838,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 			return atx.ID() == watx1.ID()
 		}))
 		atxHdlr.mTortoise.EXPECT().OnAtx(watx1.PublishEpoch+1, watx1.ID(), gomock.Any())
-		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx1, watx1))
+		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx1, watx1, false))
 
 		// second non-initial ATX references empty as prevATX
 		watx2 := newInitialATXv1(t, goldenATXID)
@@ -850,7 +847,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 		atx2 := toAtx(t, watx2)
 
 		require.ErrorContains(t,
-			atxHdlr.storeAtx(context.Background(), atx2, watx2),
+			atxHdlr.storeAtx(context.Background(), atx2, watx2, true),
 			fmt.Sprintf("%s referenced incorrect previous ATX", sig.NodeID().ShortString()),
 		)
 	})

--- a/activation/handler_v2.go
+++ b/activation/handler_v2.go
@@ -114,7 +114,7 @@ func (h *HandlerV2) processATX(
 		return fmt.Errorf("%w: validating marriages: %w", pubsub.ErrValidationReject, err)
 	}
 
-	atxData, err := h.syntacticallyValidateDeps(ctx, watx)
+	atxData, err := h.syntacticallyValidateDeps(ctx, watx, peer)
 	if err != nil {
 		return fmt.Errorf("%w: validating atx %s (deps): %w", pubsub.ErrValidationReject, watx.ID(), err)
 	}
@@ -142,7 +142,7 @@ func (h *HandlerV2) processATX(
 	atx.SetID(watx.ID())
 	atx.SetReceived(received)
 
-	if err := h.storeAtx(ctx, atx, atxData); err != nil {
+	if err := h.storeAtx(ctx, atx, atxData, peer); err != nil {
 		return fmt.Errorf("cannot store atx %s: %w", atx.ShortString(), err)
 	}
 
@@ -510,6 +510,7 @@ func (h *HandlerV2) verifyIncludedIDsUniqueness(atx *wire.ActivationTxV2) error 
 func (h *HandlerV2) syntacticallyValidateDeps(
 	ctx context.Context,
 	atx *wire.ActivationTxV2,
+	peer p2p.Peer,
 ) (*activationTx, error) {
 	result := activationTx{
 		ActivationTxV2: atx,
@@ -612,7 +613,7 @@ func (h *HandlerV2) syntacticallyValidateDeps(
 		nipostIdx := 0
 		challenge := atx.NIPosts[nipostIdx].Challenge
 		post := atx.NIPosts[nipostIdx].Posts[0]
-		if err := h.validatePost(ctx, atx.SmesherID, atx, commitment, challenge, post, nipostIdx); err != nil {
+		if err := h.validatePost(ctx, atx.SmesherID, atx, peer, commitment, challenge, post, nipostIdx); err != nil {
 			return nil, err
 		}
 		result.ids[atx.SmesherID] = idData{
@@ -635,7 +636,7 @@ func (h *HandlerV2) syntacticallyValidateDeps(
 			if id == atx.SmesherID {
 				smesherCommitment = &commitment
 			}
-			if err := h.validatePost(ctx, id, atx, commitment, niPosts.Challenge, post, idx); err != nil {
+			if err := h.validatePost(ctx, id, atx, peer, commitment, niPosts.Challenge, post, idx); err != nil {
 				return nil, err
 			}
 			result.ids[id] = idData{
@@ -662,6 +663,7 @@ func (h *HandlerV2) validatePost(
 	ctx context.Context,
 	nodeID types.NodeID,
 	atx *wire.ActivationTxV2,
+	peer p2p.Peer,
 	commitment types.ATXID,
 	challenge types.Hash32,
 	post wire.SubPostV2,
@@ -683,6 +685,11 @@ func (h *HandlerV2) validatePost(
 	if !errors.As(err, &errInvalidIdx) {
 		return fmt.Errorf("validating post for ID %s: %w", nodeID.ShortString(), err)
 	}
+
+	if peer == h.local {
+		return fmt.Errorf("invalid post for ID %s: %w", nodeID.ShortString(), errInvalidIdx)
+	}
+
 	h.logger.Debug("ATX with invalid post index",
 		log.ZContext(ctx),
 		zap.Stringer("atx_id", atx.ID()),
@@ -729,15 +736,16 @@ func (h *HandlerV2) validatePost(
 	if err := h.malPublisher.Publish(ctx, nodeID, proof); err != nil {
 		return fmt.Errorf("publishing malfeasance proof for invalid post: %w", err)
 	}
-	return fmt.Errorf("invalid post for ID %s: %w", nodeID.ShortString(), errInvalidIdx)
+	return nil
 }
 
 func (h *HandlerV2) checkMalicious(
 	ctx context.Context,
 	tx sql.Transaction,
 	watx *activationTx,
+	peer p2p.Peer,
 ) (wire.Proof, types.NodeID, error) {
-	proof, nodeID, err := h.checkDoubleMarry(ctx, tx, watx)
+	proof, nodeID, err := h.checkDoubleMarry(ctx, tx, watx, peer)
 	if err != nil {
 		return nil, types.EmptyNodeID, fmt.Errorf("checking double marry: %w", err)
 	}
@@ -745,7 +753,7 @@ func (h *HandlerV2) checkMalicious(
 		return proof, nodeID, nil
 	}
 
-	proof, nodeID, err = h.checkDoubleMerge(ctx, tx, watx)
+	proof, nodeID, err = h.checkDoubleMerge(ctx, tx, watx, peer)
 	if err != nil {
 		return nil, types.EmptyNodeID, fmt.Errorf("checking double merge: %w", err)
 	}
@@ -753,7 +761,7 @@ func (h *HandlerV2) checkMalicious(
 		return proof, nodeID, nil
 	}
 
-	proof, nodeID, err = h.checkPrevAtx(ctx, tx, watx)
+	proof, nodeID, err = h.checkPrevAtx(ctx, tx, watx, peer)
 	if err != nil {
 		return nil, types.EmptyNodeID, fmt.Errorf("checking previous ATX: %w", err)
 	}
@@ -782,6 +790,7 @@ func (h *HandlerV2) checkDoubleMarry(
 	ctx context.Context,
 	tx sql.Transaction,
 	atx *activationTx,
+	peer p2p.Peer,
 ) (wire.Proof, types.NodeID, error) {
 	for _, m := range atx.marriages {
 		info, err := marriage.FindByNodeID(tx, m.id)
@@ -790,6 +799,13 @@ func (h *HandlerV2) checkDoubleMarry(
 		}
 		if info.ATX == atx.ID() {
 			continue
+		}
+
+		if peer == h.local {
+			return nil, types.EmptyNodeID, fmt.Errorf("%s is already married via ATX %s",
+				atx.SmesherID.ShortString(),
+				info.ATX.ShortString(),
+			)
 		}
 
 		otherAtx, err := h.fetchWireAtx(ctx, tx, info.ATX)
@@ -815,6 +831,7 @@ func (h *HandlerV2) checkDoubleMerge(
 	ctx context.Context,
 	tx sql.Transaction,
 	atx *activationTx,
+	peer p2p.Peer,
 ) (wire.Proof, types.NodeID, error) {
 	if atx.MarriageATX == nil {
 		return nil, types.EmptyNodeID, nil
@@ -826,6 +843,14 @@ func (h *HandlerV2) checkDoubleMerge(
 	case err != nil:
 		return nil, types.EmptyNodeID, fmt.Errorf("searching for ATXs with the same marriage ATX: %w", err)
 	}
+
+	if peer == h.local {
+		return nil, types.EmptyNodeID, fmt.Errorf("multiple ATXs with the same marriage ATX %s published in epoch %d",
+			atx.MarriageATX.ShortString(),
+			atx.PublishEpoch,
+		)
+	}
+
 	otherIndex := slices.IndexFunc(ids, func(id types.ATXID) bool { return id != atx.ID() })
 	other := ids[otherIndex]
 
@@ -862,9 +887,10 @@ func (h *HandlerV2) checkPrevAtx(
 	ctx context.Context,
 	tx sql.Transaction,
 	atx *activationTx,
+	peer p2p.Peer,
 ) (wire.Proof, types.NodeID, error) {
 	for id, data := range atx.ids {
-		expectedPrevID, err := atxs.PrevIDByNodeID(tx, id, atx.PublishEpoch)
+		expectedPrevID, err := atxs.PrevIDByNodeID(tx, atx.ID(), id, atx.PublishEpoch)
 		if err != nil && !errors.Is(err, sql.ErrNotFound) {
 			return nil, types.EmptyNodeID, fmt.Errorf("get last atx by node id: %w", err)
 		}
@@ -877,6 +903,13 @@ func (h *HandlerV2) checkPrevAtx(
 			log.ZShortStringer("actual", data.previous),
 			log.ZShortStringer("expected", expectedPrevID),
 		)
+
+		if peer == h.local {
+			return nil, types.EmptyNodeID, fmt.Errorf("multiple ATXs with the same previous ATX %s published by %s",
+				data.previous.ShortString(),
+				id.ShortString(),
+			)
+		}
 
 		collisions, err := atxs.PrevATXCollisions(tx, data.previous, id)
 		switch {
@@ -941,7 +974,7 @@ func (h *HandlerV2) checkPrevAtx(
 }
 
 // Store an ATX in the DB.
-func (h *HandlerV2) storeAtx(ctx context.Context, atx *types.ActivationTx, watx *activationTx) error {
+func (h *HandlerV2) storeAtx(ctx context.Context, atx *types.ActivationTx, watx *activationTx, peer p2p.Peer) error {
 	republishProof := false
 	malicious := false
 	var proof wire.Proof
@@ -1025,17 +1058,15 @@ func (h *HandlerV2) storeAtx(ctx context.Context, atx *types.ActivationTx, watx 
 		}
 
 		if malicious || republishProof {
+			if peer == h.local {
+				return errors.New("not publishing ATXs for malicious nodes")
+			}
 			return nil
 		}
 
-		// malfeasance check happens after storing the ATX because storing updates the marriage set
+		// malfeasance check happens at the end of storing the ATX because storing updates the marriage set
 		// that is needed for the malfeasance proof
-		//
-		// TODO(mafa): don't store own ATX if it would mark the node as malicious
-		// this probably needs to be done by validating and storing own ATXs eagerly and skipping validation in
-		// the gossip handler (not sync!)
-		// see https://github.com/spacemeshos/go-spacemesh/issues/6687
-		proof, nodeID, err = h.checkMalicious(ctx, tx, watx)
+		proof, nodeID, err = h.checkMalicious(ctx, tx, watx, peer)
 		return err
 	}); err != nil {
 		return fmt.Errorf("store atx: %w", err)

--- a/activation/handler_v2_test.go
+++ b/activation/handler_v2_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/spacemeshos/post/shared"
 	"github.com/spacemeshos/post/verifying"
 	"github.com/stretchr/testify/assert"
@@ -211,13 +210,13 @@ func (h *v2TestHandler) createAndProcessInitial(sig *signing.EdSigner) *wire.Act
 func (h *v2TestHandler) processInitial(atx *wire.ActivationTxV2) error {
 	h.tb.Helper()
 	h.expectInitialAtxV2(atx)
-	return h.processATX(context.Background(), peer.ID("peer"), atx, time.Now())
+	return h.processATX(context.Background(), h.local, atx, time.Now())
 }
 
 func (h *v2TestHandler) processSoloAtx(atx *wire.ActivationTxV2) error {
 	h.tb.Helper()
 	h.expectAtxV2(atx)
-	return h.processATX(context.Background(), peer.ID("peer"), atx, time.Now())
+	return h.processATX(context.Background(), h.local, atx, time.Now())
 }
 
 func TestHandlerV2_SyntacticallyValidate(t *testing.T) {
@@ -473,7 +472,6 @@ func TestHandlerV2_SyntacticallyValidate_MergedAtx(t *testing.T) {
 func TestHandlerV2_ProcessSoloATX(t *testing.T) {
 	t.Parallel()
 	golden := types.RandomATXID()
-	peer := peer.ID("other")
 	sig, err := signing.NewEdSigner()
 	require.NoError(t, err)
 
@@ -486,7 +484,7 @@ func TestHandlerV2_ProcessSoloATX(t *testing.T) {
 		atxHandler.tickSize = tickSize
 		atxHandler.expectInitialAtxV2(atx)
 
-		err := atxHandler.processATX(context.Background(), peer, atx, time.Now())
+		err := atxHandler.processATX(context.Background(), atxHandler.local, atx, time.Now())
 		require.NoError(t, err)
 
 		atxFromDb, err := atxs.Get(atxHandler.cdb, atx.ID())
@@ -500,7 +498,7 @@ func TestHandlerV2_ProcessSoloATX(t *testing.T) {
 		require.EqualValues(t, atx.NIPosts[0].Posts[0].NumUnits*poetLeaves/tickSize, atxFromDb.Weight)
 
 		// processing ATX for the second time should skip checks
-		err = atxHandler.processATX(context.Background(), peer, atx, time.Now())
+		err = atxHandler.processATX(context.Background(), atxHandler.local, atx, time.Now())
 		require.NoError(t, err)
 	})
 	t.Run("second ATX", func(t *testing.T) {
@@ -513,7 +511,7 @@ func TestHandlerV2_ProcessSoloATX(t *testing.T) {
 		atx.Sign(sig)
 
 		atxHandler.expectAtxV2(atx)
-		err := atxHandler.processATX(context.Background(), peer, atx, time.Now())
+		err := atxHandler.processATX(context.Background(), atxHandler.local, atx, time.Now())
 		require.NoError(t, err)
 
 		prevAtx, err := atxs.Get(atxHandler.cdb, prev.ID())
@@ -542,7 +540,7 @@ func TestHandlerV2_ProcessSoloATX(t *testing.T) {
 		atx := newSoloATXv2(t, prev.Epoch+1, prev.ID, golden)
 		atx.Sign(sig)
 		atxHandler.expectAtxV2(atx)
-		err := atxHandler.processATX(context.Background(), peer, atx, time.Now())
+		err := atxHandler.processATX(context.Background(), atxHandler.local, atx, time.Now())
 		require.NoError(t, err)
 
 		atxFromDb, err := atxs.Get(atxHandler.cdb, atx.ID())
@@ -560,7 +558,7 @@ func TestHandlerV2_ProcessSoloATX(t *testing.T) {
 		atx.Sign(sig)
 		atxHandler.expectAtxV2(atx)
 
-		err := atxHandler.processATX(context.Background(), peer, atx, time.Now())
+		err := atxHandler.processATX(context.Background(), atxHandler.local, atx, time.Now())
 		require.NoError(t, err)
 
 		atxFromDb, err := atxs.Get(atxHandler.cdb, atx.ID())
@@ -587,7 +585,7 @@ func TestHandlerV2_ProcessSoloATX(t *testing.T) {
 			atx.TotalNumUnits(),
 		).Return(errors.New("vrf nonce is not valid"))
 
-		err = atxHandler.processATX(context.Background(), peer, atx, time.Now())
+		err = atxHandler.processATX(context.Background(), p2p.Peer("other"), atx, time.Now())
 		require.ErrorContains(t, err, "vrf nonce is not valid")
 		require.ErrorIs(t, err, pubsub.ErrValidationReject)
 
@@ -605,7 +603,7 @@ func TestHandlerV2_ProcessSoloATX(t *testing.T) {
 		atx.Sign(sig)
 		atxHandler.expectAtxV2(atx)
 
-		err := atxHandler.processATX(context.Background(), peer, atx, time.Now())
+		err := atxHandler.processATX(context.Background(), atxHandler.local, atx, time.Now())
 		require.NoError(t, err)
 
 		// verify that the ATX was added to the DB and it has the lower effective num units
@@ -622,7 +620,7 @@ func TestHandlerV2_ProcessSoloATX(t *testing.T) {
 
 		atxHandler.mClock.EXPECT().CurrentLayer()
 		atxHandler.expectFetchDeps(atx)
-		err := atxHandler.processATX(context.Background(), peer, atx, time.Now())
+		err := atxHandler.processATX(context.Background(), atxHandler.local, atx, time.Now())
 		require.ErrorContains(t, err, "validating positioning atx")
 		require.ErrorIs(t, err, pubsub.ErrValidationReject)
 
@@ -654,9 +652,8 @@ func marryIDs(
 
 	mATX.Sign(sig)
 	atxHandler.expectInitialAtxV2(mATX)
-	err := atxHandler.processATX(context.Background(), "", mATX, time.Now())
+	err := atxHandler.processATX(context.Background(), atxHandler.local, mATX, time.Now())
 	require.NoError(tb, err)
-
 	return mATX, other
 }
 
@@ -704,7 +701,7 @@ func TestHandlerV2_ProcessMergedATX(t *testing.T) {
 		merged.Sign(sig)
 
 		atxHandler.expectMergedAtxV2(merged, equivocationSet, []uint64{poetLeaves})
-		err := atxHandler.processATX(context.Background(), "", merged, time.Now())
+		err := atxHandler.processATX(context.Background(), atxHandler.local, merged, time.Now())
 		require.NoError(t, err)
 
 		atx, err := atxs.Get(atxHandler.cdb, merged.ID())
@@ -767,7 +764,7 @@ func TestHandlerV2_ProcessMergedATX(t *testing.T) {
 		minPoetLeaves := slices.Min(poetLeaves)
 
 		atxHandler.expectMergedAtxV2(merged, equivocationSet, poetLeaves)
-		err := atxHandler.processATX(context.Background(), "", merged, time.Now())
+		err := atxHandler.processATX(context.Background(), atxHandler.local, merged, time.Now())
 		require.NoError(t, err)
 
 		marriageATX, err := atxs.Get(atxHandler.cdb, mATX.ID())
@@ -817,7 +814,7 @@ func TestHandlerV2_ProcessMergedATX(t *testing.T) {
 		atxHandler.expectFetchDeps(merged)
 		atxHandler.expectVerifyNIPoSTs(merged, equivocationSet, []uint64{200})
 
-		err := atxHandler.processATX(context.Background(), "", merged, time.Now())
+		err := atxHandler.processATX(context.Background(), atxHandler.local, merged, time.Now())
 		require.ErrorContains(t, err, "ATX signer not present in merged ATX")
 		require.ErrorIs(t, err, pubsub.ErrValidationReject)
 	})
@@ -849,7 +846,7 @@ func TestHandlerV2_ProcessMergedATX(t *testing.T) {
 		merged.Sign(sig)
 
 		atxHandler.mClock.EXPECT().CurrentLayer().Return(merged.PublishEpoch.FirstLayer())
-		err := atxHandler.processATX(context.Background(), "", merged, time.Now())
+		err := atxHandler.processATX(context.Background(), atxHandler.local, merged, time.Now())
 		require.ErrorContains(t, err, "ID present twice (duplicated marriage index)")
 		require.ErrorIs(t, err, pubsub.ErrValidationReject)
 	})
@@ -880,7 +877,7 @@ func TestHandlerV2_ProcessMergedATX(t *testing.T) {
 
 		atxHandler.mClock.EXPECT().CurrentLayer().Return(merged.PublishEpoch.FirstLayer())
 		atxHandler.expectFetchDeps(merged)
-		err := atxHandler.processATX(context.Background(), "", merged, time.Now())
+		err := atxHandler.processATX(context.Background(), atxHandler.local, merged, time.Now())
 		require.ErrorIs(t, err, pubsub.ErrValidationReject)
 	})
 	t.Run("previous checkpointed ATX must include every ID", func(t *testing.T) {
@@ -918,7 +915,7 @@ func TestHandlerV2_ProcessMergedATX(t *testing.T) {
 		merged.Sign(sig)
 
 		atxHandler.expectMergedAtxV2(merged, equivocationSet, []uint64{100})
-		err := atxHandler.processATX(context.Background(), "", merged, time.Now())
+		err := atxHandler.processATX(context.Background(), atxHandler.local, merged, time.Now())
 		require.NoError(t, err)
 
 		// checkpoint again but not include one of the IDs
@@ -944,10 +941,10 @@ func TestHandlerV2_ProcessMergedATX(t *testing.T) {
 
 		atxHandler.mClock.EXPECT().CurrentLayer().Return(merged.PublishEpoch.FirstLayer())
 		atxHandler.expectFetchDeps(merged)
-		err = atxHandler.processATX(context.Background(), "", merged, time.Now())
+		err = atxHandler.processATX(context.Background(), atxHandler.local, merged, time.Now())
 		require.ErrorIs(t, err, pubsub.ErrValidationReject)
 	})
-	t.Run("publishing two merged ATXs from one marriage set is malfeasance", func(t *testing.T) {
+	t.Run("publishing two merged ATXs from one marriage set is detected and prevented", func(t *testing.T) {
 		atxHandler := newV2TestHandler(t, golden)
 
 		// Marry 4 IDs
@@ -976,7 +973,75 @@ func TestHandlerV2_ProcessMergedATX(t *testing.T) {
 		merged.Sign(sig)
 
 		atxHandler.expectMergedAtxV2(merged, equivocationSet, []uint64{100})
-		err := atxHandler.processATX(context.Background(), "", merged, time.Now())
+		err := atxHandler.processATX(context.Background(), atxHandler.local, merged, time.Now())
+		require.NoError(t, err)
+
+		// Process a second merged ATX for the same equivocation set, but different IDs
+		merged = newSoloATXv2(t, mATX.PublishEpoch+2, mATX.ID(), mATX.ID())
+		merged.NIPosts[0].Posts = []wire.SubPostV2{}
+		for i := range equivocationSet[:2] {
+			post := wire.SubPostV2{
+				MarriageIndex: uint32(i + 2),
+				PrevATXIndex:  uint32(i),
+				NumUnits:      4,
+			}
+			merged.NIPosts[0].Posts = append(merged.NIPosts[0].Posts, post)
+		}
+
+		mATXID = mATX.ID()
+		merged.MarriageATX = &mATXID
+		merged.PreviousATXs = []types.ATXID{otherATXs[1].ID(), otherATXs[2].ID()}
+		merged.Sign(signers[2])
+
+		atxHandler.mClock.EXPECT().CurrentLayer().Return(merged.PublishEpoch.FirstLayer())
+		atxHandler.mValidator.EXPECT().IsVerifyingFullPost().Return(false)
+		atxHandler.mValidator.EXPECT().VRFNonceV2(
+			merged.SmesherID,
+			gomock.Any(),
+			merged.VRFNonce,
+			merged.TotalNumUnits(),
+		)
+		atxHandler.expectFetchDeps(merged)
+		atxHandler.expectVerifyNIPoSTs(merged, equivocationSet, []uint64{100})
+
+		err = atxHandler.processATX(context.Background(), atxHandler.local, merged, time.Now())
+		require.ErrorContains(t, err, fmt.Sprintf("multiple ATXs with the same marriage ATX %s published in epoch %d",
+			mATX.ID().ShortString(), merged.PublishEpoch),
+		)
+		dbATX, err := atxs.Get(atxHandler.cdb, merged.ID())
+		require.ErrorIs(t, err, sql.ErrNotFound)
+		require.Nil(t, dbATX)
+	})
+	t.Run("handling two merged ATXs from one marriage detects malfeasance and publishes proof", func(t *testing.T) {
+		atxHandler := newV2TestHandler(t, golden)
+
+		// Marry 4 IDs
+		mATX, otherATXs := marryIDs(t, atxHandler, signers, golden)
+		previousATXs := []types.ATXID{mATX.ID()}
+		for _, atx := range otherATXs {
+			previousATXs = append(previousATXs, atx.ID())
+		}
+
+		// Process a merged ATX for 2 IDs
+		merged := newSoloATXv2(t, mATX.PublishEpoch+2, mATX.ID(), mATX.ID())
+		merged.NIPosts[0].Posts = []wire.SubPostV2{}
+		for i := range equivocationSet[:2] {
+			post := wire.SubPostV2{
+				MarriageIndex: uint32(i),
+				PrevATXIndex:  uint32(i),
+				NumUnits:      4,
+			}
+			merged.NIPosts[0].Posts = append(merged.NIPosts[0].Posts, post)
+		}
+
+		mATXID := mATX.ID()
+
+		merged.MarriageATX = &mATXID
+		merged.PreviousATXs = []types.ATXID{mATX.ID(), otherATXs[0].ID()}
+		merged.Sign(sig)
+
+		atxHandler.expectMergedAtxV2(merged, equivocationSet, []uint64{100})
+		err := atxHandler.processATX(context.Background(), atxHandler.local, merged, time.Now())
 		require.NoError(t, err)
 
 		// Process a second merged ATX for the same equivocation set, but different IDs
@@ -1016,11 +1081,94 @@ func TestHandlerV2_ProcessMergedATX(t *testing.T) {
 			require.Equal(t, merged.SmesherID, nId)
 			return nil
 		})
-		err = atxHandler.processATX(context.Background(), "", merged, time.Now())
+		err = atxHandler.processATX(context.Background(), p2p.Peer("other"), merged, time.Now())
 		require.NoError(t, err)
+
+		dbATX, err := atxs.Get(atxHandler.cdb, merged.ID())
+		require.NoError(t, err)
+		require.NotNil(t, dbATX)
+	})
+	t.Run("handling two merged ATXs from one marriage detects malfeasance and publish fails", func(t *testing.T) {
+		atxHandler := newV2TestHandler(t, golden)
+
+		// Marry 4 IDs
+		mATX, otherATXs := marryIDs(t, atxHandler, signers, golden)
+		previousATXs := []types.ATXID{mATX.ID()}
+		for _, atx := range otherATXs {
+			previousATXs = append(previousATXs, atx.ID())
+		}
+
+		// Process a merged ATX for 2 IDs
+		merged := newSoloATXv2(t, mATX.PublishEpoch+2, mATX.ID(), mATX.ID())
+		merged.NIPosts[0].Posts = []wire.SubPostV2{}
+		for i := range equivocationSet[:2] {
+			post := wire.SubPostV2{
+				MarriageIndex: uint32(i),
+				PrevATXIndex:  uint32(i),
+				NumUnits:      4,
+			}
+			merged.NIPosts[0].Posts = append(merged.NIPosts[0].Posts, post)
+		}
+
+		mATXID := mATX.ID()
+
+		merged.MarriageATX = &mATXID
+		merged.PreviousATXs = []types.ATXID{mATX.ID(), otherATXs[0].ID()}
+		merged.Sign(sig)
+
+		atxHandler.expectMergedAtxV2(merged, equivocationSet, []uint64{100})
+		err := atxHandler.processATX(context.Background(), atxHandler.local, merged, time.Now())
+		require.NoError(t, err)
+
+		// Process a second merged ATX for the same equivocation set, but different IDs
+		merged = newSoloATXv2(t, mATX.PublishEpoch+2, mATX.ID(), mATX.ID())
+		merged.NIPosts[0].Posts = []wire.SubPostV2{}
+		for i := range equivocationSet[:2] {
+			post := wire.SubPostV2{
+				MarriageIndex: uint32(i + 2),
+				PrevATXIndex:  uint32(i),
+				NumUnits:      4,
+			}
+			merged.NIPosts[0].Posts = append(merged.NIPosts[0].Posts, post)
+		}
+
+		mATXID = mATX.ID()
+		merged.MarriageATX = &mATXID
+		merged.PreviousATXs = []types.ATXID{otherATXs[1].ID(), otherATXs[2].ID()}
+		merged.Sign(signers[2])
+
+		verifier := wire.NewMockMalfeasanceValidator(atxHandler.ctrl)
+		verifier.EXPECT().Signature(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(d signing.Domain, nodeID types.NodeID, m []byte, sig types.EdSignature) bool {
+				return atxHandler.edVerifier.Verify(d, nodeID, m, sig)
+			}).AnyTimes()
+		verifier.EXPECT().IdentityExists(sig.NodeID()).Return(true, nil).AnyTimes()
+		verifier.EXPECT().IdentityExists(signers[2].NodeID()).Return(true, nil).AnyTimes()
+
+		atxHandler.expectMergedAtxV2(merged, equivocationSet, []uint64{100})
+		atxHandler.mMalPublish.EXPECT().Publish(
+			gomock.Any(),
+			merged.SmesherID,
+			gomock.AssignableToTypeOf(&wire.ProofDoubleMerge{}),
+		).Return(errors.New("publish failed"))
+		err = atxHandler.processATX(context.Background(), p2p.Peer("other"), merged, time.Now())
+		require.NoError(t, err)
+
+		dbATX, err := atxs.Get(atxHandler.cdb, merged.ID())
+		require.NoError(t, err)
+		require.NotNil(t, dbATX)
+
+		observedLogs := atxHandler.observedLogs.FilterLevelExact(zapcore.ErrorLevel)
+		require.Equal(t, 1, observedLogs.Len(), "expected 1 log message")
+		require.Equal(t, zapcore.ErrorLevel, observedLogs.All()[0].Level)
+		require.Equal(t, "failed to publish malfeasance proof", observedLogs.All()[0].Message)
+		require.Equal(t, signers[2].NodeID().String(), observedLogs.All()[0].ContextMap()["smesher_id"])
+		require.Equal(t, merged.ID().ShortString(), observedLogs.All()[0].ContextMap()["atx_id"])
+		require.Equal(t, "publish failed", observedLogs.All()[0].ContextMap()["error"])
 	})
 	t.Run("publishing two merged ATXs (one checkpointed)", func(t *testing.T) {
 		t.Skip("syntactically validating double merge where one ATX is checkpointed isn't implemented yet")
+		// TODO(mafa): implement this
 		atxHandler := newV2TestHandler(t, golden)
 
 		mATX, otherATXs := marryIDs(t, atxHandler, signers, golden)
@@ -1054,7 +1202,7 @@ func TestHandlerV2_ProcessMergedATX(t *testing.T) {
 		// This is syntactically invalid as all nodes in the network
 		// should already have the checkpointed merged ATX.
 		atxHandler.expectMergedAtxV2(merged, equivocationSet, []uint64{100})
-		err := atxHandler.processATX(context.Background(), "", merged, time.Now())
+		err := atxHandler.processATX(context.Background(), atxHandler.local, merged, time.Now())
 		require.Error(t, err)
 	})
 }
@@ -1496,7 +1644,7 @@ func TestHandlerV2_SyntacticallyValidateDeps(t *testing.T) {
 		atx.Initial.CommitmentATX = types.RandomATXID()
 		atx.Sign(sig)
 
-		_, err := atxHandler.syntacticallyValidateDeps(context.Background(), atx)
+		_, err := atxHandler.syntacticallyValidateDeps(context.Background(), atx, atxHandler.local)
 		require.ErrorContains(t, err, "verifying commitment ATX")
 	})
 	t.Run("can't find previous ATX", func(t *testing.T) {
@@ -1505,7 +1653,7 @@ func TestHandlerV2_SyntacticallyValidateDeps(t *testing.T) {
 		atx := newSoloATXv2(t, 0, types.RandomATXID(), golden)
 		atx.Sign(sig)
 
-		_, err := atxHandler.syntacticallyValidateDeps(context.Background(), atx)
+		_, err := atxHandler.syntacticallyValidateDeps(context.Background(), atx, atxHandler.local)
 		require.ErrorContains(t, err, "fetching previous atx")
 	})
 	t.Run("previous ATX too new", func(t *testing.T) {
@@ -1516,7 +1664,7 @@ func TestHandlerV2_SyntacticallyValidateDeps(t *testing.T) {
 		atx := newSoloATXv2(t, 0, prev.ID(), golden)
 		atx.Sign(sig)
 
-		_, err := atxHandler.syntacticallyValidateDeps(context.Background(), atx)
+		_, err := atxHandler.syntacticallyValidateDeps(context.Background(), atx, atxHandler.local)
 		require.ErrorContains(t, err, fmt.Sprintf("previous atx (%s) is too new", prev.ID()))
 	})
 	t.Run("previous ATX by different smesher", func(t *testing.T) {
@@ -1529,7 +1677,7 @@ func TestHandlerV2_SyntacticallyValidateDeps(t *testing.T) {
 		atx := newSoloATXv2(t, 2, prev.ID(), golden)
 		atx.Sign(sig)
 
-		_, err = atxHandler.syntacticallyValidateDeps(context.Background(), atx)
+		_, err = atxHandler.syntacticallyValidateDeps(context.Background(), atx, atxHandler.local)
 		require.Error(t, err)
 	})
 	t.Run("invalid PoST", func(t *testing.T) {
@@ -1550,10 +1698,36 @@ func TestHandlerV2_SyntacticallyValidateDeps(t *testing.T) {
 				gomock.Any(),
 			).
 			Return(errors.New("post failure"))
-		_, err := atxHandler.syntacticallyValidateDeps(context.Background(), atx)
+		_, err := atxHandler.syntacticallyValidateDeps(context.Background(), atx, atxHandler.local)
 		require.ErrorContains(t, err, "post failure")
 	})
-	t.Run("invalid PoST index initial ATX - generates a malfeasance proof", func(t *testing.T) {
+	t.Run("publishing invalid PoST index initial ATX - prevents gossip and errors", func(t *testing.T) {
+		atxHandler := newV2TestHandler(t, golden)
+
+		atx := newInitialATXv2(t, golden)
+		atx.Sign(sig)
+
+		atxHandler.mValidator.EXPECT().PoetMembership(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
+		atxHandler.mValidator.EXPECT().PostV2(
+			context.Background(),
+			atx.SmesherID,
+			atx.Initial.CommitmentATX,
+			wire.PostFromWireV1(&atx.NIPosts[0].Posts[0].Post),
+			atx.NIPosts[0].Challenge.Bytes(),
+			atx.TotalNumUnits(),
+			gomock.Cond(func(opt validatorOption) bool {
+				opts := &validatorOptions{}
+				opt(opts)
+				return opts.postSubsetSeed != nil
+			}),
+		).Return(&verifying.ErrInvalidIndex{Index: 7})
+
+		_, err := atxHandler.syntacticallyValidateDeps(context.Background(), atx, atxHandler.local)
+		vErr := &verifying.ErrInvalidIndex{}
+		require.ErrorAs(t, err, &vErr)
+		require.Equal(t, 7, vErr.Index)
+	})
+	t.Run("handling invalid PoST index initial ATX - publishes malfeasance proof", func(t *testing.T) {
 		atxHandler := newV2TestHandler(t, golden)
 
 		atx := newInitialATXv2(t, golden)
@@ -1641,12 +1815,38 @@ func TestHandlerV2_SyntacticallyValidateDeps(t *testing.T) {
 			require.Equal(t, sig.NodeID(), nId)
 			return nil
 		})
-		_, err := atxHandler.syntacticallyValidateDeps(context.Background(), atx)
+		_, err := atxHandler.syntacticallyValidateDeps(context.Background(), atx, p2p.Peer("other"))
+		require.NoError(t, err)
+	})
+	t.Run("publishing invalid PoST index solo ATX - prevents gossip and errors", func(t *testing.T) {
+		atxHandler := newV2TestHandler(t, golden)
+
+		initialAtx := atxHandler.createAndProcessInitial(sig)
+
+		atx := newSoloATXv2(t, initialAtx.PublishEpoch+1, initialAtx.ID(), initialAtx.ID())
+		atx.Sign(sig)
+
+		atxHandler.mValidator.EXPECT().PoetMembership(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
+		atxHandler.mValidator.EXPECT().PostV2(
+			context.Background(),
+			atx.SmesherID,
+			initialAtx.Initial.CommitmentATX,
+			wire.PostFromWireV1(&atx.NIPosts[0].Posts[0].Post),
+			atx.NIPosts[0].Challenge.Bytes(),
+			atx.TotalNumUnits(),
+			gomock.Cond(func(opt validatorOption) bool {
+				opts := &validatorOptions{}
+				opt(opts)
+				return opts.postSubsetSeed != nil
+			}),
+		).Return(&verifying.ErrInvalidIndex{Index: 7})
+
+		_, err := atxHandler.syntacticallyValidateDeps(context.Background(), atx, atxHandler.local)
 		vErr := &verifying.ErrInvalidIndex{}
 		require.ErrorAs(t, err, &vErr)
 		require.Equal(t, 7, vErr.Index)
 	})
-	t.Run("invalid PoST index solo ATX - generates a malfeasance proof", func(t *testing.T) {
+	t.Run("handling invalid PoST index solo ATX - publishes malfeasance proof", func(t *testing.T) {
 		atxHandler := newV2TestHandler(t, golden)
 
 		initialAtx := atxHandler.createAndProcessInitial(sig)
@@ -1736,12 +1936,71 @@ func TestHandlerV2_SyntacticallyValidateDeps(t *testing.T) {
 			require.Equal(t, sig.NodeID(), nId)
 			return nil
 		})
-		_, err := atxHandler.syntacticallyValidateDeps(context.Background(), atx)
+		atxHandler.mValidator.EXPECT().VRFNonceV2(
+			atx.SmesherID,
+			gomock.Any(),
+			atx.VRFNonce,
+			atx.NIPosts[0].Posts[0].NumUnits,
+		)
+		_, err := atxHandler.syntacticallyValidateDeps(context.Background(), atx, p2p.Peer("other"))
+		require.NoError(t, err)
+	})
+	t.Run("publishing invalid PoST index merged ATX - prevents gossip and errors", func(t *testing.T) {
+		atxHandler := newV2TestHandler(t, golden)
+
+		marrySig, err := signing.NewEdSigner()
+		require.NoError(t, err)
+		pubSig, err := signing.NewEdSigner()
+		require.NoError(t, err)
+
+		// Marry IDs
+		mATX, otherATXs := marryIDs(t, atxHandler, []*signing.EdSigner{marrySig, sig, pubSig}, golden)
+		previousATXs := []types.ATXID{mATX.ID()}
+		for _, atx := range otherATXs {
+			previousATXs = append(previousATXs, atx.ID())
+		}
+
+		// Process a merged ATX
+		merged := newSoloATXv2(t, mATX.PublishEpoch+2, mATX.ID(), mATX.ID())
+		for i, atx := range otherATXs {
+			post := wire.SubPostV2{
+				MarriageIndex: uint32(i + 1),
+				NumUnits:      atx.TotalNumUnits(),
+				PrevATXIndex:  uint32(i + 1),
+			}
+			merged.NIPosts[0].Posts = append(merged.NIPosts[0].Posts, post)
+		}
+		mATXID := mATX.ID()
+		merged.MarriageATX = &mATXID
+
+		merged.PreviousATXs = previousATXs
+		merged.Sign(sig)
+
+		equivocationSet := []types.NodeID{marrySig.NodeID(), sig.NodeID(), pubSig.NodeID()}
+		atxHandler.mValidator.EXPECT().PoetMembership(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
+		for _, post := range merged.NIPosts[0].Posts {
+			call := atxHandler.mValidator.EXPECT().PostV2(
+				context.Background(),
+				equivocationSet[post.MarriageIndex],
+				gomock.Any(),
+				wire.PostFromWireV1(&post.Post),
+				merged.NIPosts[0].Challenge.Bytes(),
+				post.NumUnits,
+				gomock.Any(),
+			)
+			if equivocationSet[post.MarriageIndex] == sig.NodeID() {
+				call.Return(&verifying.ErrInvalidIndex{Index: 7})
+			} else {
+				call.AnyTimes()
+			}
+		}
+
+		_, err = atxHandler.syntacticallyValidateDeps(context.Background(), merged, atxHandler.local)
 		vErr := &verifying.ErrInvalidIndex{}
 		require.ErrorAs(t, err, &vErr)
 		require.Equal(t, 7, vErr.Index)
 	})
-	t.Run("invalid PoST index merged ATX - generates a malfeasance proof", func(t *testing.T) {
+	t.Run("handling invalid PoST index merged ATX - publishes malfeasance proof", func(t *testing.T) {
 		atxHandler := newV2TestHandler(t, golden)
 
 		marrySig, err := signing.NewEdSigner()
@@ -1858,10 +2117,14 @@ func TestHandlerV2_SyntacticallyValidateDeps(t *testing.T) {
 			require.Equal(t, sig.NodeID(), nId)
 			return nil
 		})
-		_, err = atxHandler.syntacticallyValidateDeps(context.Background(), merged)
-		vErr := &verifying.ErrInvalidIndex{}
-		require.ErrorAs(t, err, &vErr)
-		require.Equal(t, 7, vErr.Index)
+		atxHandler.mValidator.EXPECT().VRFNonceV2(
+			merged.SmesherID,
+			gomock.Any(),
+			merged.VRFNonce,
+			merged.TotalNumUnits(),
+		)
+		_, err = atxHandler.syntacticallyValidateDeps(context.Background(), merged, p2p.Peer("other"))
+		require.NoError(t, err)
 	})
 	t.Run("invalid PoET membership proof", func(t *testing.T) {
 		atxHandler := newV2TestHandler(t, golden)
@@ -1872,7 +2135,7 @@ func TestHandlerV2_SyntacticallyValidateDeps(t *testing.T) {
 		atxHandler.mValidator.EXPECT().
 			PoetMembership(gomock.Any(), gomock.Any(), atx.NIPosts[0].Challenge, gomock.Any()).
 			Return(0, errors.New("poet failure"))
-		_, err := atxHandler.syntacticallyValidateDeps(context.Background(), atx)
+		_, err := atxHandler.syntacticallyValidateDeps(context.Background(), atx, atxHandler.local)
 		require.ErrorContains(t, err, "poet failure")
 	})
 }
@@ -1948,333 +2211,491 @@ func Test_Marriages(t *testing.T) {
 		_, err = atxHandler.validateMarriages(atx)
 		require.ErrorContains(t, err, "more than 1 marriage certificate for ID")
 	})
-	t.Run("can't marry twice (separate marriages)", func(t *testing.T) {
+	t.Run("handling double marriage (separate marriages) - malfeasance proof published", func(t *testing.T) {
 		t.Parallel()
-		t.Run("publish succeeds", func(t *testing.T) {
-			t.Parallel()
-			atxHandler := newV2TestHandler(t, golden)
+		atxHandler := newV2TestHandler(t, golden)
 
-			otherSig, err := signing.NewEdSigner()
-			require.NoError(t, err)
-			atx, _ := marryIDs(t, atxHandler, []*signing.EdSigner{sig, otherSig}, golden)
+		otherSig, err := signing.NewEdSigner()
+		require.NoError(t, err)
+		atx, _ := marryIDs(t, atxHandler, []*signing.EdSigner{sig, otherSig}, golden)
 
-			// otherSig2 cannot marry sig, trying to extend its set.
-			otherSig2, err := signing.NewEdSigner()
-			require.NoError(t, err)
-			others2Atx := atxHandler.createAndProcessInitial(otherSig2)
-			atx2 := newSoloATXv2(t, atx.PublishEpoch+1, atx.ID(), atx.ID())
-			atx2.Marriages = []wire.MarriageCertificate{
-				{
-					Signature: sig.Sign(signing.MARRIAGE, sig.NodeID().Bytes()),
-				},
-				{
-					ReferenceAtx: others2Atx.ID(),
-					Signature:    otherSig2.Sign(signing.MARRIAGE, sig.NodeID().Bytes()),
-				},
-			}
-			atx2.Sign(sig)
-			atxHandler.expectAtxV2(atx2)
+		// otherSig2 cannot marry sig, trying to extend its set.
+		otherSig2, err := signing.NewEdSigner()
+		require.NoError(t, err)
+		others2Atx := atxHandler.createAndProcessInitial(otherSig2)
+		atx2 := newSoloATXv2(t, atx.PublishEpoch+1, atx.ID(), atx.ID())
+		atx2.Marriages = []wire.MarriageCertificate{
+			{
+				Signature: sig.Sign(signing.MARRIAGE, sig.NodeID().Bytes()),
+			},
+			{
+				ReferenceAtx: others2Atx.ID(),
+				Signature:    otherSig2.Sign(signing.MARRIAGE, sig.NodeID().Bytes()),
+			},
+		}
+		atx2.Sign(sig)
+		atxHandler.expectAtxV2(atx2)
 
-			verifier := wire.NewMockMalfeasanceValidator(atxHandler.ctrl)
-			verifier.EXPECT().Signature(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-				DoAndReturn(func(d signing.Domain, nodeID types.NodeID, m []byte, sig types.EdSignature) bool {
-					return atxHandler.edVerifier.Verify(d, nodeID, m, sig)
-				}).AnyTimes()
-			verifier.EXPECT().IdentityExists(sig.NodeID()).Return(true, nil).AnyTimes()
+		verifier := wire.NewMockMalfeasanceValidator(atxHandler.ctrl)
+		verifier.EXPECT().Signature(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(d signing.Domain, nodeID types.NodeID, m []byte, sig types.EdSignature) bool {
+				return atxHandler.edVerifier.Verify(d, nodeID, m, sig)
+			}).AnyTimes()
+		verifier.EXPECT().IdentityExists(sig.NodeID()).Return(true, nil).AnyTimes()
 
-			atxHandler.mMalPublish.EXPECT().Publish(
-				gomock.Any(),
-				sig.NodeID(),
-				gomock.AssignableToTypeOf(&wire.ProofDoubleMarry{}),
-			).DoAndReturn(func(ctx context.Context, _ types.NodeID, proof wire.Proof) error {
-				malProof := proof.(*wire.ProofDoubleMarry)
-				nId, err := malProof.Valid(ctx, verifier)
-				require.NoError(t, err)
-				require.Equal(t, sig.NodeID(), nId)
-				return nil
-			})
-			err = atxHandler.processATX(context.Background(), "", atx2, time.Now())
+		atxHandler.mMalPublish.EXPECT().Publish(
+			gomock.Any(),
+			sig.NodeID(),
+			gomock.AssignableToTypeOf(&wire.ProofDoubleMarry{}),
+		).DoAndReturn(func(ctx context.Context, _ types.NodeID, proof wire.Proof) error {
+			malProof := proof.(*wire.ProofDoubleMarry)
+			nId, err := malProof.Valid(ctx, verifier)
 			require.NoError(t, err)
-
-			// The equivocation set of sig and otherSig were merged
-			id, err := marriage.FindIDByNodeID(atxHandler.cdb, sig.NodeID())
-			require.NoError(t, err)
-			equiv, err := marriage.NodeIDsByID(atxHandler.cdb, id)
-			require.NoError(t, err)
-			require.ElementsMatch(t, []types.NodeID{sig.NodeID(), otherSig.NodeID(), otherSig2.NodeID()}, equiv)
+			require.Equal(t, sig.NodeID(), nId)
+			return nil
 		})
+		err = atxHandler.processATX(context.Background(), p2p.Peer("other"), atx2, time.Now())
+		require.NoError(t, err)
 
-		t.Run("publish fails", func(t *testing.T) {
-			t.Parallel()
-			atxHandler := newV2TestHandler(t, golden)
-
-			otherSig, err := signing.NewEdSigner()
-			require.NoError(t, err)
-			atx, _ := marryIDs(t, atxHandler, []*signing.EdSigner{sig, otherSig}, golden)
-
-			// otherSig2 cannot marry sig, trying to extend its set.
-			otherSig2, err := signing.NewEdSigner()
-			require.NoError(t, err)
-			others2Atx := atxHandler.createAndProcessInitial(otherSig2)
-			atx2 := newSoloATXv2(t, atx.PublishEpoch+1, atx.ID(), atx.ID())
-			atx2.Marriages = []wire.MarriageCertificate{
-				{
-					Signature: sig.Sign(signing.MARRIAGE, sig.NodeID().Bytes()),
-				},
-				{
-					ReferenceAtx: others2Atx.ID(),
-					Signature:    otherSig2.Sign(signing.MARRIAGE, sig.NodeID().Bytes()),
-				},
-			}
-			atx2.Sign(sig)
-			atxHandler.expectAtxV2(atx2)
-
-			verifier := wire.NewMockMalfeasanceValidator(atxHandler.ctrl)
-			verifier.EXPECT().Signature(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-				DoAndReturn(func(d signing.Domain, nodeID types.NodeID, m []byte, sig types.EdSignature) bool {
-					return atxHandler.edVerifier.Verify(d, nodeID, m, sig)
-				}).AnyTimes()
-			verifier.EXPECT().IdentityExists(sig.NodeID()).Return(true, nil).AnyTimes()
-
-			atxHandler.mMalPublish.EXPECT().Publish(
-				gomock.Any(),
-				sig.NodeID(),
-				gomock.AssignableToTypeOf(&wire.ProofDoubleMarry{}),
-			).Return(errors.New("publish failed"))
-			err = atxHandler.processATX(context.Background(), "", atx2, time.Now())
-			require.NoError(t, err)
-
-			// The equivocation set of sig and otherSig were merged
-			id, err := marriage.FindIDByNodeID(atxHandler.cdb, sig.NodeID())
-			require.NoError(t, err)
-			equiv, err := marriage.NodeIDsByID(atxHandler.cdb, id)
-			require.NoError(t, err)
-			require.ElementsMatch(t, []types.NodeID{sig.NodeID(), otherSig.NodeID(), otherSig2.NodeID()}, equiv)
-
-			observedLogs := atxHandler.observedLogs.FilterLevelExact(zapcore.ErrorLevel)
-			require.Equal(t, 1, observedLogs.Len(), "expected 1 log message")
-			require.Equal(t, zapcore.ErrorLevel, observedLogs.All()[0].Level)
-			require.Equal(t, "failed to publish malfeasance proof", observedLogs.All()[0].Message)
-			require.Equal(t, sig.NodeID().String(), observedLogs.All()[0].ContextMap()["smesher_id"])
-			require.Equal(t, atx2.ID().ShortString(), observedLogs.All()[0].ContextMap()["atx_id"])
-			require.Equal(t, "publish failed", observedLogs.All()[0].ContextMap()["error"])
-		})
+		// The equivocation set of sig and otherSig were merged
+		id, err := marriage.FindIDByNodeID(atxHandler.cdb, sig.NodeID())
+		require.NoError(t, err)
+		equiv, err := marriage.NodeIDsByID(atxHandler.cdb, id)
+		require.NoError(t, err)
+		require.ElementsMatch(t, []types.NodeID{sig.NodeID(), otherSig.NodeID(), otherSig2.NodeID()}, equiv)
 	})
-	t.Run("marring existing malicious equivocation set: mark all malicious and regossip proof", func(t *testing.T) {
+	t.Run("handling double marriage (separate marriages) - malfeasance publish fails", func(t *testing.T) {
 		t.Parallel()
-		t.Run("regossip succeeds", func(t *testing.T) {
-			t.Parallel()
-			atxHandler := newV2TestHandler(t, golden)
+		atxHandler := newV2TestHandler(t, golden)
 
-			otherSig, err := signing.NewEdSigner()
-			require.NoError(t, err)
-			atx, _ := marryIDs(t, atxHandler, []*signing.EdSigner{sig, otherSig}, golden)
+		otherSig, err := signing.NewEdSigner()
+		require.NoError(t, err)
+		atx, _ := marryIDs(t, atxHandler, []*signing.EdSigner{sig, otherSig}, golden)
 
-			// sig becomes malicious in some way and with it otherSig
-			id, err := marriage.FindIDByNodeID(atxHandler.cdb, sig.NodeID())
-			require.NoError(t, err)
-			require.NoError(t, malfeasance.AddProof(atxHandler.cdb, sig.NodeID(), &id, []byte("proof"), 0, time.Now()))
-			require.NoError(t, malfeasance.SetMalicious(atxHandler.cdb, otherSig.NodeID(), id, time.Now()))
+		// otherSig2 cannot marry sig, trying to extend its set.
+		otherSig2, err := signing.NewEdSigner()
+		require.NoError(t, err)
+		others2Atx := atxHandler.createAndProcessInitial(otherSig2)
+		atx2 := newSoloATXv2(t, atx.PublishEpoch+1, atx.ID(), atx.ID())
+		atx2.Marriages = []wire.MarriageCertificate{
+			{
+				Signature: sig.Sign(signing.MARRIAGE, sig.NodeID().Bytes()),
+			},
+			{
+				ReferenceAtx: others2Atx.ID(),
+				Signature:    otherSig2.Sign(signing.MARRIAGE, sig.NodeID().Bytes()),
+			},
+		}
+		atx2.Sign(sig)
+		atxHandler.expectAtxV2(atx2)
 
-			// otherSig2 cannot marry sig, trying to extend its set.
-			otherSig2, err := signing.NewEdSigner()
-			require.NoError(t, err)
-			others2Atx := atxHandler.createAndProcessInitial(otherSig2)
-			atx2 := newSoloATXv2(t, atx.PublishEpoch+1, atx.ID(), atx.ID())
-			atx2.Marriages = []wire.MarriageCertificate{
-				{
-					Signature: sig.Sign(signing.MARRIAGE, sig.NodeID().Bytes()),
-				},
-				{
-					ReferenceAtx: others2Atx.ID(),
-					Signature:    otherSig2.Sign(signing.MARRIAGE, sig.NodeID().Bytes()),
-				},
-			}
-			atx2.Sign(sig)
-			atxHandler.expectAtxV2(atx2)
+		verifier := wire.NewMockMalfeasanceValidator(atxHandler.ctrl)
+		verifier.EXPECT().Signature(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(d signing.Domain, nodeID types.NodeID, m []byte, sig types.EdSignature) bool {
+				return atxHandler.edVerifier.Verify(d, nodeID, m, sig)
+			}).AnyTimes()
+		verifier.EXPECT().IdentityExists(sig.NodeID()).Return(true, nil).AnyTimes()
 
-			atxHandler.mMalPublish.EXPECT().Regossip(gomock.Any(), sig.NodeID())
-			err = atxHandler.processATX(context.Background(), "", atx2, time.Now())
-			require.NoError(t, err)
+		atxHandler.mMalPublish.EXPECT().Publish(
+			gomock.Any(),
+			sig.NodeID(),
+			gomock.AssignableToTypeOf(&wire.ProofDoubleMarry{}),
+		).Return(errors.New("publish failed"))
+		err = atxHandler.processATX(context.Background(), p2p.Peer("other"), atx2, time.Now())
+		require.NoError(t, err)
 
-			// The equivocation set of sig and otherSig were merged
-			id, err = marriage.FindIDByNodeID(atxHandler.cdb, sig.NodeID())
-			require.NoError(t, err)
-			equiv, err := marriage.NodeIDsByID(atxHandler.cdb, id)
-			require.NoError(t, err)
-			require.ElementsMatch(t, []types.NodeID{sig.NodeID(), otherSig.NodeID(), otherSig2.NodeID()}, equiv)
+		// The equivocation set of sig and otherSig were merged
+		id, err := marriage.FindIDByNodeID(atxHandler.cdb, sig.NodeID())
+		require.NoError(t, err)
+		equiv, err := marriage.NodeIDsByID(atxHandler.cdb, id)
+		require.NoError(t, err)
+		require.ElementsMatch(t, []types.NodeID{sig.NodeID(), otherSig.NodeID(), otherSig2.NodeID()}, equiv)
 
-			for _, sig := range []*signing.EdSigner{sig, otherSig, otherSig2} {
-				m, err := malfeasance.IsMalicious(atxHandler.cdb, sig.NodeID())
-				require.NoError(t, err)
-				require.True(t, m, "expected %s to be malicious", sig)
-			}
-		})
-
-		t.Run("regossip fails", func(t *testing.T) {
-			t.Parallel()
-			atxHandler := newV2TestHandler(t, golden)
-
-			otherSig, err := signing.NewEdSigner()
-			require.NoError(t, err)
-			atx, _ := marryIDs(t, atxHandler, []*signing.EdSigner{sig, otherSig}, golden)
-
-			// sig becomes malicious in some way and with it otherSig
-			id, err := marriage.FindIDByNodeID(atxHandler.cdb, sig.NodeID())
-			require.NoError(t, err)
-			require.NoError(t, malfeasance.AddProof(atxHandler.cdb, sig.NodeID(), &id, []byte("proof"), 0, time.Now()))
-			require.NoError(t, malfeasance.SetMalicious(atxHandler.cdb, otherSig.NodeID(), id, time.Now()))
-
-			// otherSig2 cannot marry sig, trying to extend its set.
-			otherSig2, err := signing.NewEdSigner()
-			require.NoError(t, err)
-			others2Atx := atxHandler.createAndProcessInitial(otherSig2)
-			atx2 := newSoloATXv2(t, atx.PublishEpoch+1, atx.ID(), atx.ID())
-			atx2.Marriages = []wire.MarriageCertificate{
-				{
-					Signature: sig.Sign(signing.MARRIAGE, sig.NodeID().Bytes()),
-				},
-				{
-					ReferenceAtx: others2Atx.ID(),
-					Signature:    otherSig2.Sign(signing.MARRIAGE, sig.NodeID().Bytes()),
-				},
-			}
-			atx2.Sign(sig)
-			atxHandler.expectAtxV2(atx2)
-
-			atxHandler.mMalPublish.EXPECT().Regossip(gomock.Any(), sig.NodeID()).Return(errors.New("regossip failed"))
-			err = atxHandler.processATX(context.Background(), "", atx2, time.Now())
-			require.NoError(t, err)
-
-			// The equivocation set of sig and otherSig were merged
-			id, err = marriage.FindIDByNodeID(atxHandler.cdb, sig.NodeID())
-			require.NoError(t, err)
-			equiv, err := marriage.NodeIDsByID(atxHandler.cdb, id)
-			require.NoError(t, err)
-			require.ElementsMatch(t, []types.NodeID{sig.NodeID(), otherSig.NodeID(), otherSig2.NodeID()}, equiv)
-
-			for _, sig := range []*signing.EdSigner{sig, otherSig, otherSig2} {
-				m, err := malfeasance.IsMalicious(atxHandler.cdb, sig.NodeID())
-				require.NoError(t, err)
-				require.True(t, m, "expected %s to be malicious", sig)
-			}
-
-			observedLogs := atxHandler.observedLogs.FilterLevelExact(zapcore.ErrorLevel)
-			require.Equal(t, 1, observedLogs.Len(), "expected 1 log message")
-			require.Equal(t, zapcore.ErrorLevel, observedLogs.All()[0].Level)
-			require.Equal(t, "failed to regossip malfeasance proof", observedLogs.All()[0].Message)
-			require.Equal(t, sig.NodeID().String(), observedLogs.All()[0].ContextMap()["smesher_id"])
-			require.Equal(t, atx2.ID().ShortString(), observedLogs.All()[0].ContextMap()["atx_id"])
-			require.Equal(t, "regossip failed", observedLogs.All()[0].ContextMap()["error"])
-		})
+		observedLogs := atxHandler.observedLogs.FilterLevelExact(zapcore.ErrorLevel)
+		require.Equal(t, 1, observedLogs.Len(), "expected 1 log message")
+		require.Equal(t, zapcore.ErrorLevel, observedLogs.All()[0].Level)
+		require.Equal(t, "failed to publish malfeasance proof", observedLogs.All()[0].Message)
+		require.Equal(t, sig.NodeID().String(), observedLogs.All()[0].ContextMap()["smesher_id"])
+		require.Equal(t, atx2.ID().ShortString(), observedLogs.All()[0].ContextMap()["atx_id"])
+		require.Equal(t, "publish failed", observedLogs.All()[0].ContextMap()["error"])
 	})
-	t.Run("malicious marring existing equivocation set: mark all malicious and regossip proof", func(t *testing.T) {
+	t.Run("publishing double marriage (separate marriages) - publish prevented", func(t *testing.T) {
 		t.Parallel()
-		t.Run("regossip succeeds", func(t *testing.T) {
-			t.Parallel()
-			atxHandler := newV2TestHandler(t, golden)
+		atxHandler := newV2TestHandler(t, golden)
 
-			otherSig, err := signing.NewEdSigner()
-			require.NoError(t, err)
-			atx, _ := marryIDs(t, atxHandler, []*signing.EdSigner{sig, otherSig}, golden)
+		otherSig, err := signing.NewEdSigner()
+		require.NoError(t, err)
+		atx, _ := marryIDs(t, atxHandler, []*signing.EdSigner{sig, otherSig}, golden)
 
-			// otherSig2 cannot marry sig, trying to extend its set.
-			otherSig2, err := signing.NewEdSigner()
-			require.NoError(t, err)
-			others2Atx := atxHandler.createAndProcessInitial(otherSig2)
+		// otherSig2 cannot marry sig, trying to extend its set.
+		otherSig2, err := signing.NewEdSigner()
+		require.NoError(t, err)
+		others2Atx := atxHandler.createAndProcessInitial(otherSig2)
+		atx2 := newSoloATXv2(t, atx.PublishEpoch+1, atx.ID(), atx.ID())
+		atx2.Marriages = []wire.MarriageCertificate{
+			{
+				Signature: sig.Sign(signing.MARRIAGE, sig.NodeID().Bytes()),
+			},
+			{
+				ReferenceAtx: others2Atx.ID(),
+				Signature:    otherSig2.Sign(signing.MARRIAGE, sig.NodeID().Bytes()),
+			},
+		}
+		atx2.Sign(sig)
 
-			// otherSig2 becomes malicious in some way
-			err = malfeasance.AddProof(atxHandler.cdb, otherSig2.NodeID(), nil, []byte("proof"), 0, time.Now())
-			require.NoError(t, err)
+		atxHandler.mClock.EXPECT().CurrentLayer().Return(atx2.PublishEpoch.FirstLayer())
+		atxHandler.mValidator.EXPECT().IsVerifyingFullPost().Return(false)
+		atxHandler.mValidator.EXPECT().VRFNonceV2(
+			atx2.SmesherID,
+			gomock.Any(),
+			atx2.VRFNonce,
+			atx2.NIPosts[0].Posts[0].NumUnits,
+		)
+		atxHandler.expectFetchDeps(atx2)
+		atxHandler.expectVerifyNIPoST(atx2)
 
-			atx2 := newSoloATXv2(t, atx.PublishEpoch+1, atx.ID(), atx.ID())
-			atx2.Marriages = []wire.MarriageCertificate{
-				{
-					Signature: sig.Sign(signing.MARRIAGE, sig.NodeID().Bytes()),
-				},
-				{
-					ReferenceAtx: others2Atx.ID(),
-					Signature:    otherSig2.Sign(signing.MARRIAGE, sig.NodeID().Bytes()),
-				},
-			}
-			atx2.Sign(sig)
-			atxHandler.expectAtxV2(atx2)
+		err = atxHandler.processATX(context.Background(), atxHandler.local, atx2, time.Now())
+		require.ErrorContains(t, err, fmt.Sprintf("%s is already married via ATX %s",
+			sig.NodeID().ShortString(), atx.ID().ShortString()),
+		)
 
-			atxHandler.mMalPublish.EXPECT().Regossip(gomock.Any(), sig.NodeID())
-			err = atxHandler.processATX(context.Background(), "", atx2, time.Now())
-			require.NoError(t, err)
+		// The equivocation set of sig and otherSig2 were not merged
+		id, err := marriage.FindIDByNodeID(atxHandler.cdb, sig.NodeID())
+		require.NoError(t, err)
+		equiv, err := marriage.NodeIDsByID(atxHandler.cdb, id)
+		require.NoError(t, err)
+		require.ElementsMatch(t, []types.NodeID{sig.NodeID(), otherSig.NodeID()}, equiv)
 
-			// The equivocation set of sig and otherSig were merged
-			id, err := marriage.FindIDByNodeID(atxHandler.cdb, sig.NodeID())
-			require.NoError(t, err)
-			equiv, err := marriage.NodeIDsByID(atxHandler.cdb, id)
-			require.NoError(t, err)
-			require.ElementsMatch(t, []types.NodeID{sig.NodeID(), otherSig.NodeID(), otherSig2.NodeID()}, equiv)
-
-			for _, sig := range []*signing.EdSigner{sig, otherSig, otherSig2} {
-				m, err := malfeasance.IsMalicious(atxHandler.cdb, sig.NodeID())
-				require.NoError(t, err)
-				require.True(t, m, "expected %s to be malicious", sig)
-			}
-		})
-
-		t.Run("regossip fails", func(t *testing.T) {
-			t.Parallel()
-			atxHandler := newV2TestHandler(t, golden)
-
-			otherSig, err := signing.NewEdSigner()
-			require.NoError(t, err)
-			atx, _ := marryIDs(t, atxHandler, []*signing.EdSigner{sig, otherSig}, golden)
-
-			// otherSig2 cannot marry sig, trying to extend its set.
-			otherSig2, err := signing.NewEdSigner()
-			require.NoError(t, err)
-			others2Atx := atxHandler.createAndProcessInitial(otherSig2)
-
-			// otherSig2 becomes malicious in some way
-			err = malfeasance.AddProof(atxHandler.cdb, otherSig2.NodeID(), nil, []byte("proof"), 0, time.Now())
-			require.NoError(t, err)
-
-			atx2 := newSoloATXv2(t, atx.PublishEpoch+1, atx.ID(), atx.ID())
-			atx2.Marriages = []wire.MarriageCertificate{
-				{
-					Signature: sig.Sign(signing.MARRIAGE, sig.NodeID().Bytes()),
-				},
-				{
-					ReferenceAtx: others2Atx.ID(),
-					Signature:    otherSig2.Sign(signing.MARRIAGE, sig.NodeID().Bytes()),
-				},
-			}
-			atx2.Sign(sig)
-			atxHandler.expectAtxV2(atx2)
-
-			atxHandler.mMalPublish.EXPECT().Regossip(gomock.Any(), sig.NodeID()).Return(errors.New("regossip failed"))
-			err = atxHandler.processATX(context.Background(), "", atx2, time.Now())
-			require.NoError(t, err)
-
-			// The equivocation set of sig and otherSig were merged
-			id, err := marriage.FindIDByNodeID(atxHandler.cdb, sig.NodeID())
-			require.NoError(t, err)
-			equiv, err := marriage.NodeIDsByID(atxHandler.cdb, id)
-			require.NoError(t, err)
-			require.ElementsMatch(t, []types.NodeID{sig.NodeID(), otherSig.NodeID(), otherSig2.NodeID()}, equiv)
-
-			for _, sig := range []*signing.EdSigner{sig, otherSig, otherSig2} {
-				m, err := malfeasance.IsMalicious(atxHandler.cdb, sig.NodeID())
-				require.NoError(t, err)
-				require.True(t, m, "expected %s to be malicious", sig)
-			}
-
-			observedLogs := atxHandler.observedLogs.FilterLevelExact(zapcore.ErrorLevel)
-			require.Equal(t, 1, observedLogs.Len(), "expected 1 log message")
-			require.Equal(t, zapcore.ErrorLevel, observedLogs.All()[0].Level)
-			require.Equal(t, "failed to regossip malfeasance proof", observedLogs.All()[0].Message)
-			require.Equal(t, sig.NodeID().String(), observedLogs.All()[0].ContextMap()["smesher_id"])
-			require.Equal(t, atx2.ID().ShortString(), observedLogs.All()[0].ContextMap()["atx_id"])
-			require.Equal(t, "regossip failed", observedLogs.All()[0].ContextMap()["error"])
-		})
+		id, err = marriage.FindIDByNodeID(atxHandler.cdb, otherSig2.NodeID())
+		require.ErrorIs(t, err, sql.ErrNotFound)
+		require.Zero(t, id)
 	})
-	t.Run("malicious marring malicious equivocation set: no proof published", func(t *testing.T) {
+	t.Run("handling marriage into malicious equivocation set: mark all malicious and regossip", func(t *testing.T) {
+		t.Parallel()
+		atxHandler := newV2TestHandler(t, golden)
+
+		otherSig, err := signing.NewEdSigner()
+		require.NoError(t, err)
+		atx, _ := marryIDs(t, atxHandler, []*signing.EdSigner{sig, otherSig}, golden)
+
+		// sig becomes malicious in some way and with it otherSig
+		id, err := marriage.FindIDByNodeID(atxHandler.cdb, sig.NodeID())
+		require.NoError(t, err)
+		require.NoError(t, malfeasance.AddProof(atxHandler.cdb, sig.NodeID(), &id, []byte("proof"), 0, time.Now()))
+		require.NoError(t, malfeasance.SetMalicious(atxHandler.cdb, otherSig.NodeID(), id, time.Now()))
+
+		// otherSig2 cannot marry sig, trying to extend its set.
+		otherSig2, err := signing.NewEdSigner()
+		require.NoError(t, err)
+		others2Atx := atxHandler.createAndProcessInitial(otherSig2)
+		atx2 := newSoloATXv2(t, atx.PublishEpoch+1, atx.ID(), atx.ID())
+		atx2.Marriages = []wire.MarriageCertificate{
+			{
+				Signature: sig.Sign(signing.MARRIAGE, sig.NodeID().Bytes()),
+			},
+			{
+				ReferenceAtx: others2Atx.ID(),
+				Signature:    otherSig2.Sign(signing.MARRIAGE, sig.NodeID().Bytes()),
+			},
+		}
+		atx2.Sign(sig)
+		atxHandler.expectAtxV2(atx2)
+
+		atxHandler.mMalPublish.EXPECT().Regossip(gomock.Any(), sig.NodeID())
+		err = atxHandler.processATX(context.Background(), p2p.Peer("other"), atx2, time.Now())
+		require.NoError(t, err)
+
+		// The equivocation set of sig and otherSig were merged
+		id, err = marriage.FindIDByNodeID(atxHandler.cdb, sig.NodeID())
+		require.NoError(t, err)
+		equiv, err := marriage.NodeIDsByID(atxHandler.cdb, id)
+		require.NoError(t, err)
+		require.ElementsMatch(t, []types.NodeID{sig.NodeID(), otherSig.NodeID(), otherSig2.NodeID()}, equiv)
+
+		for _, sig := range []*signing.EdSigner{sig, otherSig, otherSig2} {
+			m, err := malfeasance.IsMalicious(atxHandler.cdb, sig.NodeID())
+			require.NoError(t, err)
+			require.True(t, m, "expected %s to be malicious", sig)
+		}
+	})
+	t.Run("handling marriage into malicious equivocation set: regossip fails", func(t *testing.T) {
+		t.Parallel()
+		atxHandler := newV2TestHandler(t, golden)
+
+		otherSig, err := signing.NewEdSigner()
+		require.NoError(t, err)
+		atx, _ := marryIDs(t, atxHandler, []*signing.EdSigner{sig, otherSig}, golden)
+
+		// sig becomes malicious in some way and with it otherSig
+		id, err := marriage.FindIDByNodeID(atxHandler.cdb, sig.NodeID())
+		require.NoError(t, err)
+		require.NoError(t, malfeasance.AddProof(atxHandler.cdb, sig.NodeID(), &id, []byte("proof"), 0, time.Now()))
+		require.NoError(t, malfeasance.SetMalicious(atxHandler.cdb, otherSig.NodeID(), id, time.Now()))
+
+		// otherSig2 cannot marry sig, trying to extend its set.
+		otherSig2, err := signing.NewEdSigner()
+		require.NoError(t, err)
+		others2Atx := atxHandler.createAndProcessInitial(otherSig2)
+		atx2 := newSoloATXv2(t, atx.PublishEpoch+1, atx.ID(), atx.ID())
+		atx2.Marriages = []wire.MarriageCertificate{
+			{
+				Signature: sig.Sign(signing.MARRIAGE, sig.NodeID().Bytes()),
+			},
+			{
+				ReferenceAtx: others2Atx.ID(),
+				Signature:    otherSig2.Sign(signing.MARRIAGE, sig.NodeID().Bytes()),
+			},
+		}
+		atx2.Sign(sig)
+		atxHandler.expectAtxV2(atx2)
+
+		atxHandler.mMalPublish.EXPECT().Regossip(gomock.Any(), sig.NodeID()).Return(errors.New("regossip failed"))
+		err = atxHandler.processATX(context.Background(), p2p.Peer("other"), atx2, time.Now())
+		require.NoError(t, err)
+
+		// The equivocation set of sig and otherSig were merged
+		id, err = marriage.FindIDByNodeID(atxHandler.cdb, sig.NodeID())
+		require.NoError(t, err)
+		equiv, err := marriage.NodeIDsByID(atxHandler.cdb, id)
+		require.NoError(t, err)
+		require.ElementsMatch(t, []types.NodeID{sig.NodeID(), otherSig.NodeID(), otherSig2.NodeID()}, equiv)
+
+		for _, sig := range []*signing.EdSigner{sig, otherSig, otherSig2} {
+			m, err := malfeasance.IsMalicious(atxHandler.cdb, sig.NodeID())
+			require.NoError(t, err)
+			require.True(t, m, "expected %s to be malicious", sig)
+		}
+
+		observedLogs := atxHandler.observedLogs.FilterLevelExact(zapcore.ErrorLevel)
+		require.Equal(t, 1, observedLogs.Len(), "expected 1 log message")
+		require.Equal(t, zapcore.ErrorLevel, observedLogs.All()[0].Level)
+		require.Equal(t, "failed to regossip malfeasance proof", observedLogs.All()[0].Message)
+		require.Equal(t, sig.NodeID().String(), observedLogs.All()[0].ContextMap()["smesher_id"])
+		require.Equal(t, atx2.ID().ShortString(), observedLogs.All()[0].ContextMap()["atx_id"])
+		require.Equal(t, "regossip failed", observedLogs.All()[0].ContextMap()["error"])
+	})
+	t.Run("publishing marriage into malicious equivocation set: publish prevented", func(t *testing.T) {
+		t.Parallel()
+		atxHandler := newV2TestHandler(t, golden)
+
+		otherSig, err := signing.NewEdSigner()
+		require.NoError(t, err)
+		atx, _ := marryIDs(t, atxHandler, []*signing.EdSigner{sig, otherSig}, golden)
+
+		// sig becomes malicious in some way and with it otherSig
+		id, err := marriage.FindIDByNodeID(atxHandler.cdb, sig.NodeID())
+		require.NoError(t, err)
+		require.NoError(t, malfeasance.AddProof(atxHandler.cdb, sig.NodeID(), &id, []byte("proof"), 0, time.Now()))
+		require.NoError(t, malfeasance.SetMalicious(atxHandler.cdb, otherSig.NodeID(), id, time.Now()))
+
+		// otherSig2 cannot marry sig, trying to extend its set.
+		otherSig2, err := signing.NewEdSigner()
+		require.NoError(t, err)
+		others2Atx := atxHandler.createAndProcessInitial(otherSig2)
+		atx2 := newSoloATXv2(t, atx.PublishEpoch+1, atx.ID(), atx.ID())
+		atx2.Marriages = []wire.MarriageCertificate{
+			{
+				Signature: sig.Sign(signing.MARRIAGE, sig.NodeID().Bytes()),
+			},
+			{
+				ReferenceAtx: others2Atx.ID(),
+				Signature:    otherSig2.Sign(signing.MARRIAGE, sig.NodeID().Bytes()),
+			},
+		}
+		atx2.Sign(sig)
+
+		atxHandler.mClock.EXPECT().CurrentLayer().Return(atx2.PublishEpoch.FirstLayer())
+		atxHandler.mValidator.EXPECT().IsVerifyingFullPost().Return(false)
+		atxHandler.mValidator.EXPECT().VRFNonceV2(atx2.SmesherID,
+			gomock.Any(),
+			atx2.VRFNonce,
+			atx2.NIPosts[0].Posts[0].NumUnits,
+		)
+		atxHandler.expectFetchDeps(atx2)
+		atxHandler.expectVerifyNIPoST(atx2)
+
+		err = atxHandler.processATX(context.Background(), atxHandler.local, atx2, time.Now())
+		require.ErrorContains(t, err, "not publishing ATXs for malicious nodes")
+
+		// The equivocation set of sig and otherSig were not merged
+		id, err = marriage.FindIDByNodeID(atxHandler.cdb, sig.NodeID())
+		require.NoError(t, err)
+		equiv, err := marriage.NodeIDsByID(atxHandler.cdb, id)
+		require.NoError(t, err)
+		require.ElementsMatch(t, []types.NodeID{sig.NodeID(), otherSig.NodeID()}, equiv)
+
+		for _, sig := range []*signing.EdSigner{sig, otherSig} {
+			m, err := malfeasance.IsMalicious(atxHandler.cdb, sig.NodeID())
+			require.NoError(t, err)
+			require.True(t, m, "expected %s to be malicious", sig)
+		}
+
+		id, err = marriage.FindIDByNodeID(atxHandler.cdb, otherSig2.NodeID())
+		require.ErrorIs(t, err, sql.ErrNotFound)
+		require.Zero(t, id)
+
+		id, err = marriage.FindIDByNodeID(atxHandler.cdb, otherSig2.NodeID())
+		require.ErrorIs(t, err, sql.ErrNotFound)
+		require.Zero(t, id)
+	})
+	t.Run("handling malicious marring existing equivocation set: mark all malicious and regossip", func(t *testing.T) {
+		t.Parallel()
+		atxHandler := newV2TestHandler(t, golden)
+
+		otherSig, err := signing.NewEdSigner()
+		require.NoError(t, err)
+		atx, _ := marryIDs(t, atxHandler, []*signing.EdSigner{sig, otherSig}, golden)
+
+		// otherSig2 cannot marry sig, trying to extend its set.
+		otherSig2, err := signing.NewEdSigner()
+		require.NoError(t, err)
+		others2Atx := atxHandler.createAndProcessInitial(otherSig2)
+
+		// otherSig2 becomes malicious in some way
+		err = malfeasance.AddProof(atxHandler.cdb, otherSig2.NodeID(), nil, []byte("proof"), 0, time.Now())
+		require.NoError(t, err)
+
+		atx2 := newSoloATXv2(t, atx.PublishEpoch+1, atx.ID(), atx.ID())
+		atx2.Marriages = []wire.MarriageCertificate{
+			{
+				Signature: sig.Sign(signing.MARRIAGE, sig.NodeID().Bytes()),
+			},
+			{
+				ReferenceAtx: others2Atx.ID(),
+				Signature:    otherSig2.Sign(signing.MARRIAGE, sig.NodeID().Bytes()),
+			},
+		}
+		atx2.Sign(sig)
+		atxHandler.expectAtxV2(atx2)
+
+		atxHandler.mMalPublish.EXPECT().Regossip(gomock.Any(), sig.NodeID())
+		err = atxHandler.processATX(context.Background(), p2p.Peer("other"), atx2, time.Now())
+		require.NoError(t, err)
+
+		// The equivocation set of sig and otherSig were merged
+		id, err := marriage.FindIDByNodeID(atxHandler.cdb, sig.NodeID())
+		require.NoError(t, err)
+		equiv, err := marriage.NodeIDsByID(atxHandler.cdb, id)
+		require.NoError(t, err)
+		require.ElementsMatch(t, []types.NodeID{sig.NodeID(), otherSig.NodeID(), otherSig2.NodeID()}, equiv)
+
+		for _, sig := range []*signing.EdSigner{sig, otherSig, otherSig2} {
+			m, err := malfeasance.IsMalicious(atxHandler.cdb, sig.NodeID())
+			require.NoError(t, err)
+			require.True(t, m, "expected %s to be malicious", sig)
+		}
+	})
+	t.Run("handling malicious marring existing equivocation set: regossip fails", func(t *testing.T) {
+		t.Parallel()
+		atxHandler := newV2TestHandler(t, golden)
+
+		otherSig, err := signing.NewEdSigner()
+		require.NoError(t, err)
+		atx, _ := marryIDs(t, atxHandler, []*signing.EdSigner{sig, otherSig}, golden)
+
+		// otherSig2 cannot marry sig, trying to extend its set.
+		otherSig2, err := signing.NewEdSigner()
+		require.NoError(t, err)
+		others2Atx := atxHandler.createAndProcessInitial(otherSig2)
+
+		// otherSig2 becomes malicious in some way
+		err = malfeasance.AddProof(atxHandler.cdb, otherSig2.NodeID(), nil, []byte("proof"), 0, time.Now())
+		require.NoError(t, err)
+
+		atx2 := newSoloATXv2(t, atx.PublishEpoch+1, atx.ID(), atx.ID())
+		atx2.Marriages = []wire.MarriageCertificate{
+			{
+				Signature: sig.Sign(signing.MARRIAGE, sig.NodeID().Bytes()),
+			},
+			{
+				ReferenceAtx: others2Atx.ID(),
+				Signature:    otherSig2.Sign(signing.MARRIAGE, sig.NodeID().Bytes()),
+			},
+		}
+		atx2.Sign(sig)
+		atxHandler.expectAtxV2(atx2)
+
+		atxHandler.mMalPublish.EXPECT().Regossip(gomock.Any(), sig.NodeID()).Return(errors.New("regossip failed"))
+		err = atxHandler.processATX(context.Background(), p2p.Peer("other"), atx2, time.Now())
+		require.NoError(t, err)
+
+		// The equivocation set of sig and otherSig were merged
+		id, err := marriage.FindIDByNodeID(atxHandler.cdb, sig.NodeID())
+		require.NoError(t, err)
+		equiv, err := marriage.NodeIDsByID(atxHandler.cdb, id)
+		require.NoError(t, err)
+		require.ElementsMatch(t, []types.NodeID{sig.NodeID(), otherSig.NodeID(), otherSig2.NodeID()}, equiv)
+
+		for _, sig := range []*signing.EdSigner{sig, otherSig, otherSig2} {
+			m, err := malfeasance.IsMalicious(atxHandler.cdb, sig.NodeID())
+			require.NoError(t, err)
+			require.True(t, m, "expected %s to be malicious", sig)
+		}
+
+		observedLogs := atxHandler.observedLogs.FilterLevelExact(zapcore.ErrorLevel)
+		require.Equal(t, 1, observedLogs.Len(), "expected 1 log message")
+		require.Equal(t, zapcore.ErrorLevel, observedLogs.All()[0].Level)
+		require.Equal(t, "failed to regossip malfeasance proof", observedLogs.All()[0].Message)
+		require.Equal(t, sig.NodeID().String(), observedLogs.All()[0].ContextMap()["smesher_id"])
+		require.Equal(t, atx2.ID().ShortString(), observedLogs.All()[0].ContextMap()["atx_id"])
+		require.Equal(t, "regossip failed", observedLogs.All()[0].ContextMap()["error"])
+	})
+	t.Run("publishing malicious marring existing equivocation set: publish prevented", func(t *testing.T) {
+		t.Parallel()
+		atxHandler := newV2TestHandler(t, golden)
+
+		otherSig, err := signing.NewEdSigner()
+		require.NoError(t, err)
+		atx, _ := marryIDs(t, atxHandler, []*signing.EdSigner{sig, otherSig}, golden)
+
+		// otherSig2 cannot marry sig, trying to extend its set.
+		otherSig2, err := signing.NewEdSigner()
+		require.NoError(t, err)
+		others2Atx := atxHandler.createAndProcessInitial(otherSig2)
+
+		// otherSig2 becomes malicious in some way
+		err = malfeasance.AddProof(atxHandler.cdb, otherSig2.NodeID(), nil, []byte("proof"), 0, time.Now())
+		require.NoError(t, err)
+
+		atx2 := newSoloATXv2(t, atx.PublishEpoch+1, atx.ID(), atx.ID())
+		atx2.Marriages = []wire.MarriageCertificate{
+			{
+				Signature: sig.Sign(signing.MARRIAGE, sig.NodeID().Bytes()),
+			},
+			{
+				ReferenceAtx: others2Atx.ID(),
+				Signature:    otherSig2.Sign(signing.MARRIAGE, sig.NodeID().Bytes()),
+			},
+		}
+		atx2.Sign(sig)
+		atxHandler.mClock.EXPECT().CurrentLayer().Return(atx2.PublishEpoch.FirstLayer())
+		atxHandler.mValidator.EXPECT().IsVerifyingFullPost().Return(false)
+		atxHandler.mValidator.EXPECT().VRFNonceV2(
+			atx2.SmesherID,
+			gomock.Any(),
+			atx2.VRFNonce,
+			atx2.NIPosts[0].Posts[0].NumUnits,
+		)
+		atxHandler.expectFetchDeps(atx2)
+		atxHandler.expectVerifyNIPoST(atx2)
+
+		err = atxHandler.processATX(context.Background(), atxHandler.local, atx2, time.Now())
+		require.ErrorContains(t, err, "not publishing ATXs for malicious nodes")
+
+		// The equivocation set of sig and otherSig were not merged
+		id, err := marriage.FindIDByNodeID(atxHandler.cdb, sig.NodeID())
+		require.NoError(t, err)
+		equiv, err := marriage.NodeIDsByID(atxHandler.cdb, id)
+		require.NoError(t, err)
+		require.ElementsMatch(t, []types.NodeID{sig.NodeID(), otherSig.NodeID()}, equiv)
+
+		for _, sig := range []*signing.EdSigner{sig, otherSig} {
+			m, err := malfeasance.IsMalicious(atxHandler.cdb, sig.NodeID())
+			require.NoError(t, err)
+			require.False(t, m, "expected %s to not be malicious", sig)
+		}
+	})
+	t.Run("handling malicious marring malicious equivocation set: no proof published", func(t *testing.T) {
 		t.Parallel()
 		atxHandler := newV2TestHandler(t, golden)
 
@@ -2309,7 +2730,7 @@ func Test_Marriages(t *testing.T) {
 		}
 		atx2.Sign(sig)
 		atxHandler.expectAtxV2(atx2)
-		err = atxHandler.processATX(context.Background(), "", atx2, time.Now())
+		err = atxHandler.processATX(context.Background(), p2p.Peer("other"), atx2, time.Now())
 		require.NoError(t, err)
 
 		// The equivocation set of sig and otherSig were merged
@@ -2343,7 +2764,7 @@ func Test_Marriages(t *testing.T) {
 		atx.Sign(sig)
 
 		atxHandler.mClock.EXPECT().CurrentLayer().AnyTimes()
-		err = atxHandler.processATX(context.Background(), "", atx, time.Now())
+		err = atxHandler.processATX(context.Background(), atxHandler.local, atx, time.Now())
 		require.ErrorContains(t, err, "signer must marry itself")
 		require.ErrorIs(t, err, pubsub.ErrValidationReject)
 	})
@@ -2378,7 +2799,7 @@ func Test_MarryingMalicious(t *testing.T) {
 			atxHandler.expectInitialAtxV2(atx)
 			atxHandler.mMalPublish.EXPECT().Regossip(gomock.Any(), sig.NodeID())
 
-			err := atxHandler.processATX(context.Background(), "", atx, time.Now())
+			err := atxHandler.processATX(context.Background(), p2p.Peer("other"), atx, time.Now())
 			require.NoError(t, err)
 
 			id, err := marriage.FindIDByNodeID(atxHandler.cdb, sig.NodeID())
@@ -2427,7 +2848,7 @@ func Test_CalculatingUnits(t *testing.T) {
 }
 
 func TestContextual_PreviousATX(t *testing.T) {
-	t.Run("invalid previous ATX, both v2", func(t *testing.T) {
+	t.Run("handling invalid previous ATX, both v2", func(t *testing.T) {
 		golden := types.RandomATXID()
 		atxHdlr := newV2TestHandler(t, golden)
 		var (
@@ -2447,7 +2868,7 @@ func TestContextual_PreviousATX(t *testing.T) {
 		soloAtx := newSoloATXv2(t, mATX.PublishEpoch+1, otherAtxs[0].ID(), mATX.ID())
 		soloAtx.Sign(signers[1])
 		atxHdlr.expectAtxV2(soloAtx)
-		err := atxHdlr.processATX(context.Background(), "", soloAtx, time.Now())
+		err := atxHdlr.processATX(context.Background(), atxHdlr.local, soloAtx, time.Now())
 		require.NoError(t, err)
 
 		// create a MergedATX for all IDs
@@ -2486,11 +2907,59 @@ func TestContextual_PreviousATX(t *testing.T) {
 			return nil
 		})
 
-		err = atxHdlr.processATX(context.Background(), "", merged, time.Now())
+		err = atxHdlr.processATX(context.Background(), p2p.Peer("other"), merged, time.Now())
 		require.NoError(t, err)
 	})
+	t.Run("publishing invalid previous ATX, both v2", func(t *testing.T) {
+		golden := types.RandomATXID()
+		atxHdlr := newV2TestHandler(t, golden)
+		var (
+			signers []*signing.EdSigner
+			eqSet   []types.NodeID
+		)
+		for range 3 {
+			sig, err := signing.NewEdSigner()
+			require.NoError(t, err)
+			signers = append(signers, sig)
+			eqSet = append(eqSet, sig.NodeID())
+		}
 
-	t.Run("invalid previous ATX, v1 and v2", func(t *testing.T) {
+		mATX, otherAtxs := marryIDs(t, atxHdlr, signers, golden)
+
+		// signer 1 creates a solo ATX
+		soloAtx := newSoloATXv2(t, mATX.PublishEpoch+1, otherAtxs[0].ID(), mATX.ID())
+		soloAtx.Sign(signers[1])
+		atxHdlr.expectAtxV2(soloAtx)
+		err := atxHdlr.processATX(context.Background(), atxHdlr.local, soloAtx, time.Now())
+		require.NoError(t, err)
+
+		// create a MergedATX for all IDs
+		merged := newSoloATXv2(t, mATX.PublishEpoch+2, mATX.ID(), mATX.ID())
+		post := wire.SubPostV2{
+			MarriageIndex: 1,
+			PrevATXIndex:  1,
+			NumUnits:      soloAtx.TotalNumUnits(),
+		}
+		merged.NIPosts[0].Posts = append(merged.NIPosts[0].Posts, post)
+		// Pass a wrong previous ATX for signer 1. It's already been used for soloATX
+		// (which should be used for the previous ATX for signer 1).
+		merged.PreviousATXs = append(merged.PreviousATXs, otherAtxs[0].ID())
+		mATXID := mATX.ID()
+		merged.MarriageATX = &mATXID
+		merged.Sign(signers[0])
+
+		atxHdlr.mClock.EXPECT().CurrentLayer().Return(merged.PublishEpoch.FirstLayer())
+		atxHdlr.expectFetchDeps(merged)
+		atxHdlr.mValidator.EXPECT().IsVerifyingFullPost().Return(false)
+		atxHdlr.mValidator.EXPECT().VRFNonceV2(merged.SmesherID, gomock.Any(), merged.VRFNonce, merged.TotalNumUnits())
+		atxHdlr.expectVerifyNIPoSTs(merged, eqSet, []uint64{100})
+
+		err = atxHdlr.processATX(context.Background(), atxHdlr.local, merged, time.Now())
+		require.ErrorContains(t, err, fmt.Sprintf("multiple ATXs with the same previous ATX %s published by %s",
+			otherAtxs[0].ID().ShortString(), signers[1].NodeID().ShortString(),
+		))
+	})
+	t.Run("handling invalid previous ATX, v1 and v2", func(t *testing.T) {
 		golden := types.RandomATXID()
 		atxHdlr := newTestHandler(t, golden)
 
@@ -2510,7 +2979,7 @@ func TestContextual_PreviousATX(t *testing.T) {
 		soloAtx := newSoloATXv2(t, atxv1.PublishEpoch+1, atxv1.ID(), atxv1.ID())
 		soloAtx.Sign(sig1)
 		atxHdlr.expectAtxV2(soloAtx)
-		err = atxHdlr.v2.processATX(context.Background(), "", soloAtx, time.Now())
+		err = atxHdlr.v2.processATX(context.Background(), atxHdlr.local, soloAtx, time.Now())
 		require.NoError(t, err)
 
 		sig2, err := signing.NewEdSigner()
@@ -2529,7 +2998,7 @@ func TestContextual_PreviousATX(t *testing.T) {
 		mATX.PublishEpoch = soloAtx.PublishEpoch
 		mATX.Sign(sig2)
 		atxHdlr.expectInitialAtxV2(mATX)
-		err = atxHdlr.v2.processATX(context.Background(), "", mATX, time.Now())
+		err = atxHdlr.v2.processATX(context.Background(), atxHdlr.local, mATX, time.Now())
 		require.NoError(t, err)
 
 		// create a MergedATX for all IDs
@@ -2565,11 +3034,76 @@ func TestContextual_PreviousATX(t *testing.T) {
 			return nil
 		})
 
-		err = atxHdlr.v2.processATX(context.Background(), "", merged, time.Now())
+		err = atxHdlr.v2.processATX(context.Background(), p2p.Peer("other"), merged, time.Now())
 		require.NoError(t, err)
 	})
+	t.Run("publishing invalid previous ATX, v1 and v2", func(t *testing.T) {
+		golden := types.RandomATXID()
+		atxHdlr := newTestHandler(t, golden)
 
-	t.Run("double publish", func(t *testing.T) {
+		sig1, err := signing.NewEdSigner()
+		require.NoError(t, err)
+
+		// signer 1 creates a solo ATX
+		prevATX := newInitialATXv1(t, golden)
+		prevATX.Sign(sig1)
+		atxHdlr.expectAtxV1(prevATX, prevATX.SmesherID)
+		require.NoError(t, atxHdlr.v1.processATX(context.Background(), p2p.NoPeer, prevATX, time.Now()))
+		atxv1 := newChainedActivationTxV1(t, prevATX, prevATX.ID())
+		atxv1.Sign(sig1)
+		atxHdlr.expectAtxV1(atxv1, atxv1.SmesherID)
+		require.NoError(t, atxHdlr.v1.processATX(context.Background(), p2p.NoPeer, atxv1, time.Now()))
+
+		soloAtx := newSoloATXv2(t, atxv1.PublishEpoch+1, atxv1.ID(), atxv1.ID())
+		soloAtx.Sign(sig1)
+		atxHdlr.expectAtxV2(soloAtx)
+		err = atxHdlr.v2.processATX(context.Background(), atxHdlr.local, soloAtx, time.Now())
+		require.NoError(t, err)
+
+		sig2, err := signing.NewEdSigner()
+		require.NoError(t, err)
+		mATX := newInitialATXv2(t, golden)
+		mATX.Marriages = []wire.MarriageCertificate{
+			{
+				ReferenceAtx: types.EmptyATXID,
+				Signature:    sig2.Sign(signing.MARRIAGE, sig2.NodeID().Bytes()),
+			},
+			{
+				ReferenceAtx: soloAtx.ID(),
+				Signature:    sig1.Sign(signing.MARRIAGE, sig2.NodeID().Bytes()),
+			},
+		}
+		mATX.PublishEpoch = soloAtx.PublishEpoch
+		mATX.Sign(sig2)
+		atxHdlr.expectInitialAtxV2(mATX)
+		err = atxHdlr.v2.processATX(context.Background(), atxHdlr.local, mATX, time.Now())
+		require.NoError(t, err)
+
+		// create a MergedATX for all IDs
+		merged := newSoloATXv2(t, mATX.PublishEpoch+2, mATX.ID(), mATX.ID())
+		post := wire.SubPostV2{
+			MarriageIndex: 1,
+			PrevATXIndex:  1,
+			NumUnits:      soloAtx.TotalNumUnits(),
+		}
+		merged.NIPosts[0].Posts = append(merged.NIPosts[0].Posts, post)
+		merged.PreviousATXs = append(merged.PreviousATXs, prevATX.ID())
+		merged.MarriageATX = new(types.ATXID)
+		*merged.MarriageATX = mATX.ID()
+		merged.Sign(sig2)
+
+		atxHdlr.mClock.EXPECT().CurrentLayer().Return(merged.PublishEpoch.FirstLayer())
+		atxHdlr.expectFetchDeps(merged)
+		atxHdlr.mValidator.EXPECT().IsVerifyingFullPost().Return(false)
+		atxHdlr.mValidator.EXPECT().VRFNonceV2(merged.SmesherID, gomock.Any(), merged.VRFNonce, merged.TotalNumUnits())
+		atxHdlr.expectVerifyNIPoSTs(merged, []types.NodeID{sig1.NodeID(), sig2.NodeID()}, []uint64{100})
+
+		err = atxHdlr.v2.processATX(context.Background(), atxHdlr.local, merged, time.Now())
+		require.ErrorContains(t, err, fmt.Sprintf("multiple ATXs with the same previous ATX %s published by %s",
+			prevATX.ID().ShortString(), sig1.NodeID().ShortString(),
+		))
+	})
+	t.Run("handling double publish", func(t *testing.T) {
 		t.Parallel()
 		golden := types.RandomATXID()
 		sig, err := signing.NewEdSigner()
@@ -2595,7 +3129,7 @@ func TestContextual_PreviousATX(t *testing.T) {
 		mATX.Sign(sig)
 
 		atxHdlr.expectInitialAtxV2(mATX)
-		err = atxHdlr.processATX(context.Background(), "", mATX, time.Now())
+		err = atxHdlr.processATX(context.Background(), atxHdlr.local, mATX, time.Now())
 		require.NoError(t, err)
 
 		// publish merged
@@ -2614,7 +3148,7 @@ func TestContextual_PreviousATX(t *testing.T) {
 		merged.Sign(sig)
 
 		atxHdlr.expectMergedAtxV2(merged, []types.NodeID{sig.NodeID(), otherSig.NodeID()}, []uint64{poetLeaves})
-		err = atxHdlr.processATX(context.Background(), "", merged, time.Now())
+		err = atxHdlr.processATX(context.Background(), atxHdlr.local, merged, time.Now())
 		require.NoError(t, err)
 
 		// The otherSig tries to publish alone in the same epoch.
@@ -2642,8 +3176,77 @@ func TestContextual_PreviousATX(t *testing.T) {
 			return nil
 		})
 
-		err = atxHdlr.processATX(context.Background(), "", doubled, time.Now())
+		err = atxHdlr.processATX(context.Background(), p2p.Peer("other"), doubled, time.Now())
 		require.NoError(t, err)
+	})
+	t.Run("preventing double publish", func(t *testing.T) {
+		t.Parallel()
+		golden := types.RandomATXID()
+		sig, err := signing.NewEdSigner()
+		require.NoError(t, err)
+
+		atxHdlr := newV2TestHandler(t, golden)
+
+		// marry
+		otherSig, err := signing.NewEdSigner()
+		require.NoError(t, err)
+		othersAtx := atxHdlr.createAndProcessInitial(otherSig)
+
+		mATX := newInitialATXv2(t, golden)
+		mATX.Marriages = []wire.MarriageCertificate{
+			{
+				Signature: sig.Sign(signing.MARRIAGE, sig.NodeID().Bytes()),
+			},
+			{
+				ReferenceAtx: othersAtx.ID(),
+				Signature:    otherSig.Sign(signing.MARRIAGE, sig.NodeID().Bytes()),
+			},
+		}
+		mATX.Sign(sig)
+
+		atxHdlr.expectInitialAtxV2(mATX)
+		err = atxHdlr.processATX(context.Background(), atxHdlr.local, mATX, time.Now())
+		require.NoError(t, err)
+
+		// publish merged
+		merged := newSoloATXv2(t, mATX.PublishEpoch+2, mATX.ID(), mATX.ID())
+		post := wire.SubPostV2{
+			MarriageIndex: 1,
+			NumUnits:      othersAtx.TotalNumUnits(),
+			PrevATXIndex:  1,
+		}
+		merged.NIPosts[0].Posts = append(merged.NIPosts[0].Posts, post)
+
+		mATXID := mATX.ID()
+		merged.MarriageATX = &mATXID
+
+		merged.PreviousATXs = []types.ATXID{mATX.ID(), othersAtx.ID()}
+		merged.Sign(sig)
+
+		atxHdlr.expectMergedAtxV2(merged, []types.NodeID{sig.NodeID(), otherSig.NodeID()}, []uint64{poetLeaves})
+		err = atxHdlr.processATX(context.Background(), atxHdlr.local, merged, time.Now())
+		require.NoError(t, err)
+
+		// The otherSig tries to publish alone in the same epoch.
+		// This is malfeasance as it tries include his PoST twice.
+		doubled := newSoloATXv2(t, merged.PublishEpoch, othersAtx.ID(), othersAtx.ID())
+		doubled.Sign(otherSig)
+
+		atxHdlr.mClock.EXPECT().CurrentLayer().Return(doubled.PublishEpoch.FirstLayer())
+		atxHdlr.mValidator.EXPECT().IsVerifyingFullPost().Return(false)
+		atxHdlr.mValidator.EXPECT().VRFNonceV2(
+			doubled.SmesherID,
+			gomock.Any(),
+			doubled.VRFNonce,
+			doubled.NIPosts[0].Posts[0].NumUnits,
+		)
+		atxHdlr.expectFetchDeps(doubled)
+		atxHdlr.expectVerifyNIPoST(doubled)
+
+		err = atxHdlr.processATX(context.Background(), atxHdlr.local, doubled, time.Now())
+		require.ErrorContains(t, err, fmt.Sprintf("multiple ATXs with the same previous ATX %s published by %s",
+			othersAtx.ID().ShortString(), otherSig.NodeID().ShortString(),
+		))
 	})
 }
 

--- a/node/node.go
+++ b/node/node.go
@@ -890,9 +890,6 @@ func (app *App) initServices(ctx context.Context) error {
 		activation.WithTickSize(app.Config.TickSize),
 		activation.WithAtxVersions(app.Config.AtxVersions),
 	)
-	for _, sig := range app.signers {
-		atxHandler.Register(sig)
-	}
 
 	blockHandler := blocks.NewHandler(
 		fetcher,

--- a/sql/atxs/atxs.go
+++ b/sql/atxs/atxs.go
@@ -244,12 +244,19 @@ func GetLastIDByNodeID(db sql.Executor, nodeID types.NodeID) (id types.ATXID, er
 	return id, err
 }
 
-// PrevIDByNodeID returns the previous ATX ID for a given node ID and public epoch.
-// It returns the newest ATX ID containing PoST of the given node ID that was published in or before the given epoch.
-func PrevIDByNodeID(db sql.Executor, nodeID types.NodeID, pubEpoch types.EpochID) (id types.ATXID, err error) {
+// PrevIDByNodeID returns the previous ATX ID for a given node ID and public epoch, ignoring current if present in the
+// DB (to avoid returning the same ATX ID).
+// It returns the newest ATX ID containing a PoST of the given node ID that was published in or before the given epoch.
+func PrevIDByNodeID(
+	db sql.Executor,
+	current types.ATXID,
+	nodeID types.NodeID,
+	pubEpoch types.EpochID,
+) (id types.ATXID, err error) {
 	enc := func(stmt *sql.Statement) {
 		stmt.BindBytes(1, nodeID.Bytes())
 		stmt.BindInt64(2, int64(pubEpoch))
+		stmt.BindBytes(3, current.Bytes())
 	}
 	dec := func(stmt *sql.Statement) bool {
 		stmt.ColumnBytes(0, id[:])
@@ -258,7 +265,7 @@ func PrevIDByNodeID(db sql.Executor, nodeID types.NodeID, pubEpoch types.EpochID
 
 	if rows, err := db.Exec(`
 		SELECT atxid FROM posts
-		WHERE pubkey = ?1 AND publish_epoch <= ?2
+		WHERE pubkey = ?1 AND publish_epoch <= ?2 AND atxid != ?3
 		ORDER BY publish_epoch DESC
 		LIMIT 1;`, enc, dec); err != nil {
 		return types.EmptyATXID, fmt.Errorf("exec nodeID %v, epoch %d: %w", nodeID, pubEpoch, err)

--- a/sql/atxs/atxs_test.go
+++ b/sql/atxs/atxs_test.go
@@ -1301,7 +1301,7 @@ func Test_Previous(t *testing.T) {
 func TestPrevIDByNodeID(t *testing.T) {
 	t.Run("no previous ATXs", func(t *testing.T) {
 		db := statesql.InMemoryTest(t)
-		_, err := atxs.PrevIDByNodeID(db, types.RandomNodeID(), 0)
+		_, err := atxs.PrevIDByNodeID(db, types.EmptyATXID, types.RandomNodeID(), 0)
 		require.ErrorIs(t, err, sql.ErrNotFound)
 	})
 	t.Run("filters by epoch", func(t *testing.T) {
@@ -1315,22 +1315,49 @@ func TestPrevIDByNodeID(t *testing.T) {
 
 		atx2 := newAtx(t, sig, withPublishEpoch(2))
 		require.NoError(t, atxs.Add(db, atx2, types.AtxBlob{}))
-		require.NoError(t, atxs.SetPost(db, atx2.ID(), types.EmptyATXID, 0, sig.NodeID(), 4, atx2.PublishEpoch))
+		require.NoError(t, atxs.SetPost(db, atx2.ID(), atx1.ID(), 0, sig.NodeID(), 4, atx2.PublishEpoch))
 
-		_, err = atxs.PrevIDByNodeID(db, sig.NodeID(), 0)
+		_, err = atxs.PrevIDByNodeID(db, types.EmptyATXID, sig.NodeID(), 0)
 		require.ErrorIs(t, err, sql.ErrNotFound)
 
-		prevID, err := atxs.PrevIDByNodeID(db, sig.NodeID(), 1)
+		prevID, err := atxs.PrevIDByNodeID(db, types.EmptyATXID, sig.NodeID(), 1)
 		require.NoError(t, err)
 		require.Equal(t, atx1.ID(), prevID)
 
-		prevID, err = atxs.PrevIDByNodeID(db, sig.NodeID(), 2)
+		prevID, err = atxs.PrevIDByNodeID(db, types.EmptyATXID, sig.NodeID(), 2)
 		require.NoError(t, err)
 		require.Equal(t, atx2.ID(), prevID)
 
-		prevID, err = atxs.PrevIDByNodeID(db, sig.NodeID(), 3)
+		prevID, err = atxs.PrevIDByNodeID(db, types.EmptyATXID, sig.NodeID(), 3)
 		require.NoError(t, err)
 		require.Equal(t, atx2.ID(), prevID)
+	})
+	t.Run("ignores given ATX", func(t *testing.T) {
+		db := statesql.InMemoryTest(t)
+		sig, err := signing.NewEdSigner()
+		require.NoError(t, err)
+
+		atx1 := newAtx(t, sig, withPublishEpoch(1))
+		require.NoError(t, atxs.Add(db, atx1, types.AtxBlob{}))
+		require.NoError(t, atxs.SetPost(db, atx1.ID(), types.EmptyATXID, 0, sig.NodeID(), 4, atx1.PublishEpoch))
+
+		atx2 := newAtx(t, sig, withPublishEpoch(2))
+		require.NoError(t, atxs.Add(db, atx2, types.AtxBlob{}))
+		require.NoError(t, atxs.SetPost(db, atx2.ID(), atx1.ID(), 0, sig.NodeID(), 4, atx2.PublishEpoch))
+
+		// when checking with ATX1 previous is empty for epoch 1
+		prevID, err := atxs.PrevIDByNodeID(db, atx1.ID(), sig.NodeID(), 1)
+		require.ErrorIs(t, err, sql.ErrNotFound)
+		require.Equal(t, types.EmptyATXID, prevID)
+
+		// when checking with ATX2 previous is ATX1 for epoch 1
+		prevID, err = atxs.PrevIDByNodeID(db, atx2.ID(), sig.NodeID(), 1)
+		require.NoError(t, err)
+		require.Equal(t, atx1.ID(), prevID)
+
+		prevID, err = atxs.PrevIDByNodeID(db, atx2.ID(), sig.NodeID(), 2)
+		require.NoError(t, err)
+		require.Equal(t, atx1.ID(), prevID)
 	})
 	t.Run("the previous is merged and ID is not the signer", func(t *testing.T) {
 		db := statesql.InMemoryTest(t)
@@ -1352,7 +1379,7 @@ func TestPrevIDByNodeID(t *testing.T) {
 		require.NoError(t, atxs.SetPost(db, atx2.ID(), atx1.ID(), 0, sig.NodeID(), 4, atx2.PublishEpoch))
 		require.NoError(t, atxs.SetPost(db, atx2.ID(), atx1.ID(), 0, types.RandomNodeID(), 12, atx2.PublishEpoch))
 
-		prevID, err := atxs.PrevIDByNodeID(db, id, 3)
+		prevID, err := atxs.PrevIDByNodeID(db, atx2.ID(), id, 3)
 		require.NoError(t, err)
 		require.Equal(t, atx1.ID(), prevID)
 	})


### PR DESCRIPTION
## Motivation

This backports the changes from #6707 and #6705 to `develop`.

## Description

No additional changes, I cherry picked the commits from the two PRs and resolved conflicts.

## Test Plan

existing tests pass

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
