### PR TITLE
Factor out a separate structure for the smeshing service 

### DIFF
--- a/.github/workflows/systest.yml
+++ b/.github/workflows/systest.yml
@@ -9,6 +9,9 @@ on:
       log_level:
         description: "Log level"
         default: "debug"
+      gotestsum_fmt:
+        description: "Logging format of gotestsum"
+        default: "pkgname-and-test-fails"
   push:
     branches:
       - staging
@@ -251,7 +254,7 @@ jobs:
           level: ${{ inputs.log_level }}
           clusters: 4
           norbac: 1
-        run: make -C systest run test_name=${{ inputs.test_name }}
+        run: make -C systest run test_name=${{ inputs.test_name }} gotestsum_fmt=${{ inputs.gotestsum_fmt }}
 
       - name: Delete pod
         if: always()

--- a/api/grpcserver/config.go
+++ b/api/grpcserver/config.go
@@ -76,6 +76,7 @@ const (
 	MalfeasanceV2Beta1        Service = "malfeasance_v2beta1"
 	MalfeasanceStreamV2Beta1  Service = "malfeasance_stream_v2beta1"
 	SmeshingIdentitiesV2Beta1 Service = "smeshing_identities_v2beta1"
+	SmeshingV2Beta1           Service = "smeshing_v2beta1"
 )
 
 // DefaultConfig defines the default configuration options for api.

--- a/api/grpcserver/smeshing_svc_debug_service.go
+++ b/api/grpcserver/smeshing_svc_debug_service.go
@@ -1,0 +1,116 @@
+package grpcserver
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	pb "github.com/spacemeshos/api/release/go/spacemesh/v1"
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	"github.com/spacemeshos/go-spacemesh/events"
+)
+
+type SmeshingServiceDebugService struct {
+	loggers map[string]*zap.AtomicLevel
+}
+
+// RegisterService registers this service with a grpc server instance.
+func (d *SmeshingServiceDebugService) RegisterService(server *grpc.Server) {
+	pb.RegisterDebugServiceServer(server, d)
+}
+
+func (d *SmeshingServiceDebugService) RegisterHandlerService(mux *runtime.ServeMux) error {
+	return pb.RegisterDebugServiceHandlerServer(context.Background(), mux, d)
+}
+
+// NewSmeshingServiceDebugService creates a new grpc service using config data.
+func NewSmeshingServiceDebugService(loggers map[string]*zap.AtomicLevel) *SmeshingServiceDebugService {
+	return &SmeshingServiceDebugService{
+		loggers: loggers,
+	}
+}
+
+// Accounts returns current counter and balance for all accounts.
+func (d *SmeshingServiceDebugService) Accounts(
+	ctx context.Context,
+	in *pb.AccountsRequest,
+) (*pb.AccountsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method Accounts not implemented")
+}
+
+// NetworkInfo query provides NetworkInfoResponse.
+func (d *SmeshingServiceDebugService) NetworkInfo(
+	ctx context.Context,
+	_ *emptypb.Empty,
+) (*pb.NetworkInfoResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method NetworkInfo not implemented")
+}
+
+// ActiveSet query provides hare active set for the specified epoch.
+func (d *SmeshingServiceDebugService) ActiveSet(
+	ctx context.Context,
+	req *pb.ActiveSetRequest,
+) (*pb.ActiveSetResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ActiveSet not implemented")
+}
+
+// ProposalsStream streams all proposals confirmed by hare.
+func (d *SmeshingServiceDebugService) ProposalsStream(
+	_ *emptypb.Empty,
+	stream pb.DebugService_ProposalsStreamServer,
+) error {
+	sub := events.SubscribeProposals()
+	if sub == nil {
+		return status.Errorf(codes.FailedPrecondition, "event reporting is not enabled")
+	}
+	eventch, fullch := consumeEvents[events.EventProposal](stream.Context(), sub)
+	// send empty header after subscribing to the channel.
+	// this is optional but allows subscriber to wait until stream is fully initialized.
+	if err := stream.SendHeader(metadata.MD{}); err != nil {
+		return status.Errorf(codes.Unavailable, "can't send header")
+	}
+	for {
+		select {
+		case <-stream.Context().Done():
+			return nil
+		case <-fullch:
+			return status.Errorf(codes.Canceled, "buffer is full")
+		case ev := <-eventch:
+			if err := stream.Send(castEventProposal(&ev)); err != nil {
+				return fmt.Errorf("send to stream: %w", err)
+			}
+		}
+	}
+}
+
+func (d *SmeshingServiceDebugService) ChangeLogLevel(
+	ctx context.Context,
+	req *pb.ChangeLogLevelRequest,
+) (*emptypb.Empty, error) {
+	level, err := zap.ParseAtomicLevel(req.GetLevel())
+	if err != nil {
+		return nil, fmt.Errorf("parse level: %w", err)
+	}
+
+	if req.GetModule() == "*" {
+		for _, logger := range d.loggers {
+			logger.SetLevel(level.Level())
+		}
+		return nil, nil
+	}
+
+	logger, ok := d.loggers[req.GetModule()]
+	if !ok {
+		return nil, fmt.Errorf("cannot find logger %v", req.GetModule())
+	}
+
+	logger.SetLevel(level.Level())
+
+	return &emptypb.Empty{}, nil
+}

--- a/api/node/client/client.go
+++ b/api/node/client/client.go
@@ -37,6 +37,9 @@ type Config struct {
 }
 
 func NewNodeServiceClient(server string, logger *zap.Logger, cfg *Config) (*NodeService, error) {
+	if server == "" {
+		return nil, errors.New("missing node-service server address")
+	}
 	retryableClient := retryablehttp.Client{
 		Logger:       &retryableHttpLogger{logger},
 		RetryWaitMin: cfg.RetryWaitMin,

--- a/api/node/client/client_test.go
+++ b/api/node/client/client_test.go
@@ -1,0 +1,15 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+)
+
+func TestNewNodeServiceClient(t *testing.T) {
+	t.Run("missing server address", func(t *testing.T) {
+		_, err := NewNodeServiceClient("", zaptest.NewLogger(t), &Config{})
+		require.ErrorContains(t, err, "missing node-service server address")
+	})
+}

--- a/common/types/address.go
+++ b/common/types/address.go
@@ -100,12 +100,16 @@ func (a Address) IsEmpty() bool {
 
 // String implements fmt.Stringer.
 func (a Address) String() string {
+	return a.StringWithHRP(NetworkHRP())
+}
+
+func (a Address) StringWithHRP(hrp string) string {
 	dataConverted, err := bech32.ConvertBits(a[:], 8, 5, true)
 	if err != nil {
 		log.Panic("error converting bech32 bits: ", err.Error())
 	}
 
-	result, err := bech32.Encode(NetworkHRP(), dataConverted)
+	result, err := bech32.Encode(hrp, dataConverted)
 	if err != nil {
 		log.Panic("error encoding to bech32: ", err.Error())
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -218,7 +218,7 @@ func DefaultConfig() Config {
 func DefaultTestConfig() Config {
 	conf := DefaultConfig()
 	conf.BaseConfig = defaultTestConfig()
-	conf.Genesis = DefaultTestGenesisConfig()
+	conf.Genesis = DefaultTestGenesisConfig(conf.NetworkHRP)
 	conf.P2P = p2p.DefaultConfig()
 	conf.API = grpcserver.DefaultTestConfig()
 	conf.POSTService = activation.DefaultTestPostServiceConfig()

--- a/config/genesis.go
+++ b/config/genesis.go
@@ -152,21 +152,21 @@ func DefaultGenesisConfig() GenesisConfig {
 	return GenesisConfig{
 		ExtraData:   "mainnet",
 		GenesisTime: Genesis(time.Now()),
-		Accounts:    generateGenesisAccounts(),
+		Accounts:    generateGenesisAccounts("sm"),
 	}
 }
 
 // DefaultTestGenesisConfig is the default test configuration for the node.
-func DefaultTestGenesisConfig() GenesisConfig {
+func DefaultTestGenesisConfig(hrp string) GenesisConfig {
 	// NOTE(dshulyak) keys in default config are used in some tests
 	return GenesisConfig{
 		ExtraData:   "testnet",
 		GenesisTime: Genesis(time.Now()),
-		Accounts:    generateGenesisAccounts(),
+		Accounts:    generateGenesisAccounts(hrp),
 	}
 }
 
-func generateGenesisAccounts() map[string]uint64 {
+func generateGenesisAccounts(hrp string) map[string]uint64 {
 	acc1Signer, err := signing.NewEdSigner(
 		signing.WithPrivateKey(util.FromHex(Account1Private)),
 	)
@@ -184,7 +184,7 @@ func generateGenesisAccounts() map[string]uint64 {
 	// we default to 10^8 SMH per account which is 10^17 smidge
 	// each genesis account starts off with 10^17 smidge
 	return map[string]uint64{
-		types.GenerateAddress(acc1Signer.PublicKey().Bytes()).String(): 100000000000000000,
-		types.GenerateAddress(acc2Signer.PublicKey().Bytes()).String(): 100000000000000000,
+		types.GenerateAddress(acc1Signer.PublicKey().Bytes()).StringWithHRP(hrp): 100000000000000000,
+		types.GenerateAddress(acc2Signer.PublicKey().Bytes()).StringWithHRP(hrp): 100000000000000000,
 	}
 }

--- a/config/logging.go
+++ b/config/logging.go
@@ -25,6 +25,7 @@ type LoggerConfig struct {
 	StateDbLoggerLevel           string `mapstructure:"stateDb"`
 	BeaconLoggerLevel            string `mapstructure:"beacon"`
 	CachedDBLoggerLevel          string `mapstructure:"cachedDb"`
+	PoetLoggerLevel              string `mapstructure:"poet"`
 	PoetDbLoggerLevel            string `mapstructure:"poetDb"`
 	TrtlLoggerLevel              string `mapstructure:"trtl"`
 	AtxHandlerLevel              string `mapstructure:"atxHandler"`

--- a/config/mainnet.go
+++ b/config/mainnet.go
@@ -247,3 +247,140 @@ func MainnetConfig() Config {
 		Certifier: activation.DefaultCertifierConfig(),
 	}
 }
+
+func MainnetSmeshingServiceConfig() Config {
+	genesisTime, err := time.Parse(time.RFC3339, "2023-07-14T08:00:00Z")
+	if err != nil {
+		panic(err)
+	}
+
+	var postPowDifficulty activation.PowDifficulty
+	difficulty := []byte("000dfb23b0979b4b000000000000000000000000000000000000000000000000")
+	if err := postPowDifficulty.UnmarshalText(difficulty); err != nil {
+		panic(err)
+	}
+
+	smeshing := DefaultSmeshingConfig()
+	smeshing.ProvingOpts.Nonces = 288
+	smeshing.ProvingOpts.Threads = uint(runtime.NumCPU() * 3 / 4)
+	if smeshing.ProvingOpts.Threads < 1 {
+		smeshing.ProvingOpts.Threads = 1
+	}
+	hare3conf := hare3.DefaultConfig()
+	hare3conf.Committee = 400
+	hare3conf.Enable = true
+	hare3conf.EnableLayer = 35117
+	hare3conf.CommitteeUpgrade = &hare3.CommitteeUpgrade{
+		Layer: 105_720, // July 15, 2024, 10:00:00 AM UTC
+		Size:  50,
+	}
+
+	hare4conf := hare4.DefaultConfig()
+	hare4conf.Enable = false
+
+	return Config{
+		BaseConfig: BaseConfig{
+			DataDirParent:           defaultDataDir,
+			FileLock:                filepath.Join(os.TempDir(), "spacemesh.lock"),
+			MetricsPort:             1010,
+			DatabaseConnections:     32,
+			DatabasePruneInterval:   30 * time.Minute,
+			DatabaseVacuumState:     21,
+			DatabaseConnIdleTimeout: 10 * time.Millisecond,
+			NetworkHRP:              "sm",
+
+			LayerDuration:  5 * time.Minute,
+			LayerAvgSize:   50,
+			LayersPerEpoch: 4032,
+
+			TickSize: 9331200,
+			PoetServers: []types.PoetServer{
+				{
+					Address: "https://mainnet-poet-0.spacemesh.network",
+					Pubkey:  types.MustBase64FromString("cFnqCS5oER7GOX576oPtahlxB/1y95aDibdK7RHQFVg="),
+				},
+				{
+					Address: "https://mainnet-poet-1.spacemesh.network",
+					Pubkey:  types.MustBase64FromString("Qh1efxY4YhoYBEXKPTiHJ/a7n1GsllRSyweQKO3j7m0="),
+				},
+				{
+					Address: "https://poet-110.spacemesh.network",
+					Pubkey:  types.MustBase64FromString("8Qqgid+37eyY7ik+EA47Nd5TrQjXolbv2Mdgir243No="),
+				},
+				{
+					Address: "https://poet-111.spacemesh.network",
+					Pubkey:  types.MustBase64FromString("caIV0Ym59L3RqbVAL6UrCPwr+z+lwe2TBj57QWnAgtM="),
+				},
+				{
+					Address: "https://poet-112.spacemesh.network",
+					Pubkey:  types.MustBase64FromString("5p/mPvmqhwdvf8U0GVrNq/9IN/HmZj5hCkFLAN04g1E="),
+				},
+			},
+			RegossipAtxInterval:     2 * time.Hour,
+			PostValidDelay:          time.Duration(math.MaxInt64),
+			PprofHTTPServerListener: "localhost:6060",
+		},
+		Genesis: GenesisConfig{
+			GenesisTime: Genesis(genesisTime),
+			ExtraData:   "00000000000000000001a6bc150307b5c1998045752b3c87eccf3c013036f3cc",
+			Accounts:    MainnetAccounts(),
+		},
+		Tortoise: tortoise.Config{
+			Hdist: 10,
+			Zdist: 2,
+		},
+		HARE3: hare3conf,
+		HARE4: hare4conf,
+		HareEligibility: eligibility.Config{
+			ConfidenceParam: 200,
+		},
+		POET: activation.PoetConfig{
+			PhaseShift:                     240 * time.Hour,
+			CycleGap:                       12 * time.Hour,
+			GracePeriod:                    1 * time.Hour,
+			PositioningATXSelectionTimeout: 50 * time.Minute,
+			InfoCacheTTL:                   5 * time.Minute,
+			PowParamsCacheTTL:              5 * time.Minute,
+			// RequestTimeout = RequestRetryDelay * 2 * MaxRequestRetries*(MaxRequestRetries+1)/2
+			RequestTimeout:    1100 * time.Second,
+			RequestRetryDelay: 10 * time.Second,
+			MaxRequestRetries: 10,
+			PoetProofsCache:   200,
+		},
+		POST: activation.PostConfig{
+			MinNumUnits:   4,
+			MaxNumUnits:   math.MaxUint32,
+			LabelsPerUnit: 4294967296,
+			K1:            26,
+			K2:            37,
+			K3:            1,
+			PowDifficulty: postPowDifficulty,
+		},
+		API: grpcserver.Config{
+			PublicServices: []grpcserver.Service{
+				grpcserver.SmeshingIdentitiesV2Beta1,
+				grpcserver.SmeshingV2Beta1,
+			},
+			PublicListener: "0.0.0.0:9092",
+			PrivateServices: []grpcserver.Service{
+				grpcserver.Smesher,
+			},
+			PrivateListener:        "127.0.0.1:9093",
+			PostServices:           []grpcserver.Service{grpcserver.Post, grpcserver.PostInfo},
+			PostListener:           "127.0.0.1:0",
+			TLSServices:            []grpcserver.Service{grpcserver.Post, grpcserver.PostInfo},
+			TLSListener:            "",
+			JSONListener:           "127.0.0.1:9094",
+			JSONCorsAllowedOrigins: []string{""},
+			JSONCorsEverywhere:     false,
+			GrpcSendMsgSize:        1024 * 1024 * 10,
+			GrpcRecvMsgSize:        1024 * 1024 * 10,
+			SmesherStreamInterval:  time.Second,
+			DatabaseConnections:    16,
+		},
+		SMESHING:    smeshing,
+		POSTService: activation.DefaultPostServiceConfig(),
+		LOGGING:     DefaultLoggingConfig(),
+		Certifier:   activation.DefaultCertifierConfig(),
+	}
+}

--- a/config/mainnet.go
+++ b/config/mainnet.go
@@ -249,138 +249,29 @@ func MainnetConfig() Config {
 }
 
 func MainnetSmeshingServiceConfig() Config {
-	genesisTime, err := time.Parse(time.RFC3339, "2023-07-14T08:00:00Z")
-	if err != nil {
-		panic(err)
+	cfg := MainnetConfig()
+
+	cfg.API = grpcserver.Config{
+		PublicServices: []grpcserver.Service{
+			grpcserver.SmeshingIdentitiesV2Beta1,
+			grpcserver.SmeshingV2Beta1,
+		},
+		PublicListener: "0.0.0.0:9092",
+		PrivateServices: []grpcserver.Service{
+			grpcserver.Smesher,
+		},
+		PrivateListener:        "127.0.0.1:9093",
+		PostServices:           []grpcserver.Service{grpcserver.Post, grpcserver.PostInfo},
+		PostListener:           "127.0.0.1:0",
+		TLSServices:            []grpcserver.Service{grpcserver.Post, grpcserver.PostInfo},
+		TLSListener:            "",
+		JSONListener:           "127.0.0.1:9094",
+		JSONCorsAllowedOrigins: []string{""},
+		JSONCorsEverywhere:     false,
+		GrpcSendMsgSize:        1024 * 1024 * 10,
+		GrpcRecvMsgSize:        1024 * 1024 * 10,
+		SmesherStreamInterval:  time.Second,
+		DatabaseConnections:    16,
 	}
-
-	var postPowDifficulty activation.PowDifficulty
-	difficulty := []byte("000dfb23b0979b4b000000000000000000000000000000000000000000000000")
-	if err := postPowDifficulty.UnmarshalText(difficulty); err != nil {
-		panic(err)
-	}
-
-	smeshing := DefaultSmeshingConfig()
-	smeshing.ProvingOpts.Nonces = 288
-	smeshing.ProvingOpts.Threads = uint(runtime.NumCPU() * 3 / 4)
-	if smeshing.ProvingOpts.Threads < 1 {
-		smeshing.ProvingOpts.Threads = 1
-	}
-	hare3conf := hare3.DefaultConfig()
-	hare3conf.Committee = 400
-	hare3conf.Enable = true
-	hare3conf.EnableLayer = 35117
-	hare3conf.CommitteeUpgrade = &hare3.CommitteeUpgrade{
-		Layer: 105_720, // July 15, 2024, 10:00:00 AM UTC
-		Size:  50,
-	}
-
-	hare4conf := hare4.DefaultConfig()
-	hare4conf.Enable = false
-
-	return Config{
-		BaseConfig: BaseConfig{
-			DataDirParent:           defaultDataDir,
-			FileLock:                filepath.Join(os.TempDir(), "spacemesh.lock"),
-			MetricsPort:             1010,
-			DatabaseConnections:     32,
-			DatabasePruneInterval:   30 * time.Minute,
-			DatabaseVacuumState:     21,
-			DatabaseConnIdleTimeout: 10 * time.Millisecond,
-			NetworkHRP:              "sm",
-
-			LayerDuration:  5 * time.Minute,
-			LayerAvgSize:   50,
-			LayersPerEpoch: 4032,
-
-			TickSize: 9331200,
-			PoetServers: []types.PoetServer{
-				{
-					Address: "https://mainnet-poet-0.spacemesh.network",
-					Pubkey:  types.MustBase64FromString("cFnqCS5oER7GOX576oPtahlxB/1y95aDibdK7RHQFVg="),
-				},
-				{
-					Address: "https://mainnet-poet-1.spacemesh.network",
-					Pubkey:  types.MustBase64FromString("Qh1efxY4YhoYBEXKPTiHJ/a7n1GsllRSyweQKO3j7m0="),
-				},
-				{
-					Address: "https://poet-110.spacemesh.network",
-					Pubkey:  types.MustBase64FromString("8Qqgid+37eyY7ik+EA47Nd5TrQjXolbv2Mdgir243No="),
-				},
-				{
-					Address: "https://poet-111.spacemesh.network",
-					Pubkey:  types.MustBase64FromString("caIV0Ym59L3RqbVAL6UrCPwr+z+lwe2TBj57QWnAgtM="),
-				},
-				{
-					Address: "https://poet-112.spacemesh.network",
-					Pubkey:  types.MustBase64FromString("5p/mPvmqhwdvf8U0GVrNq/9IN/HmZj5hCkFLAN04g1E="),
-				},
-			},
-			RegossipAtxInterval:     2 * time.Hour,
-			PostValidDelay:          time.Duration(math.MaxInt64),
-			PprofHTTPServerListener: "localhost:6060",
-		},
-		Genesis: GenesisConfig{
-			GenesisTime: Genesis(genesisTime),
-			ExtraData:   "00000000000000000001a6bc150307b5c1998045752b3c87eccf3c013036f3cc",
-			Accounts:    MainnetAccounts(),
-		},
-		Tortoise: tortoise.Config{
-			Hdist: 10,
-			Zdist: 2,
-		},
-		HARE3: hare3conf,
-		HARE4: hare4conf,
-		HareEligibility: eligibility.Config{
-			ConfidenceParam: 200,
-		},
-		POET: activation.PoetConfig{
-			PhaseShift:                     240 * time.Hour,
-			CycleGap:                       12 * time.Hour,
-			GracePeriod:                    1 * time.Hour,
-			PositioningATXSelectionTimeout: 50 * time.Minute,
-			InfoCacheTTL:                   5 * time.Minute,
-			PowParamsCacheTTL:              5 * time.Minute,
-			// RequestTimeout = RequestRetryDelay * 2 * MaxRequestRetries*(MaxRequestRetries+1)/2
-			RequestTimeout:    1100 * time.Second,
-			RequestRetryDelay: 10 * time.Second,
-			MaxRequestRetries: 10,
-			PoetProofsCache:   200,
-		},
-		POST: activation.PostConfig{
-			MinNumUnits:   4,
-			MaxNumUnits:   math.MaxUint32,
-			LabelsPerUnit: 4294967296,
-			K1:            26,
-			K2:            37,
-			K3:            1,
-			PowDifficulty: postPowDifficulty,
-		},
-		API: grpcserver.Config{
-			PublicServices: []grpcserver.Service{
-				grpcserver.SmeshingIdentitiesV2Beta1,
-				grpcserver.SmeshingV2Beta1,
-			},
-			PublicListener: "0.0.0.0:9092",
-			PrivateServices: []grpcserver.Service{
-				grpcserver.Smesher,
-			},
-			PrivateListener:        "127.0.0.1:9093",
-			PostServices:           []grpcserver.Service{grpcserver.Post, grpcserver.PostInfo},
-			PostListener:           "127.0.0.1:0",
-			TLSServices:            []grpcserver.Service{grpcserver.Post, grpcserver.PostInfo},
-			TLSListener:            "",
-			JSONListener:           "127.0.0.1:9094",
-			JSONCorsAllowedOrigins: []string{""},
-			JSONCorsEverywhere:     false,
-			GrpcSendMsgSize:        1024 * 1024 * 10,
-			GrpcRecvMsgSize:        1024 * 1024 * 10,
-			SmesherStreamInterval:  time.Second,
-			DatabaseConnections:    16,
-		},
-		SMESHING:    smeshing,
-		POSTService: activation.DefaultPostServiceConfig(),
-		LOGGING:     DefaultLoggingConfig(),
-		Certifier:   activation.DefaultCertifierConfig(),
-	}
+	return cfg
 }

--- a/node/lock.go
+++ b/node/lock.go
@@ -12,17 +12,22 @@ import (
 
 func lock(path string) (unlock func() error, err error) {
 	lockDir := filepath.Dir(path)
-	if _, err := os.Stat(lockDir); errors.Is(err, fs.ErrNotExist) {
+	_, err = os.Stat(lockDir)
+	switch {
+	case errors.Is(err, fs.ErrNotExist):
 		err := os.Mkdir(lockDir, os.ModePerm)
 		if err != nil {
 			return nil, fmt.Errorf("creating dir %s for lock %s: %w", lockDir, path, err)
 		}
+	case err != nil:
+		return nil, fmt.Errorf("checking filelock %s directory existence: %w", lockDir, err)
 	}
 	fl := flock.New(path)
 	locked, err := fl.TryLock()
 	if err != nil {
-		return nil, fmt.Errorf("flock %s: %w", path, err)
-	} else if !locked {
+		return nil, fmt.Errorf("trying to obtain filelock %s: %w", path, err)
+	}
+	if !locked {
 		return nil, fmt.Errorf("only one spacemesh instance should be running (locking file %s)", fl.Path())
 	}
 	return fl.Unlock, nil

--- a/node/lock.go
+++ b/node/lock.go
@@ -1,0 +1,29 @@
+package node
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/gofrs/flock"
+)
+
+func lock(path string) (unlock func() error, err error) {
+	lockDir := filepath.Dir(path)
+	if _, err := os.Stat(lockDir); errors.Is(err, fs.ErrNotExist) {
+		err := os.Mkdir(lockDir, os.ModePerm)
+		if err != nil {
+			return nil, fmt.Errorf("creating dir %s for lock %s: %w", lockDir, path, err)
+		}
+	}
+	fl := flock.New(path)
+	locked, err := fl.TryLock()
+	if err != nil {
+		return nil, fmt.Errorf("flock %s: %w", path, err)
+	} else if !locked {
+		return nil, fmt.Errorf("only one spacemesh instance should be running (locking file %s)", fl.Path())
+	}
+	return fl.Unlock, nil
+}

--- a/node/lock_test.go
+++ b/node/lock_test.go
@@ -1,0 +1,68 @@
+package node
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLock(t *testing.T) {
+	t.Run("creates lock directory if not exists", func(t *testing.T) {
+		dir := t.TempDir()
+		lockPath := filepath.Join(dir, "subdir", "node.lock")
+
+		unlock, err := lock(lockPath)
+		require.NoError(t, err)
+		defer unlock()
+
+		// Verify directory was created
+		_, err = os.Stat(filepath.Dir(lockPath))
+		require.NoError(t, err)
+	})
+	t.Run("prevents multiple locks", func(t *testing.T) {
+		dir := t.TempDir()
+		lockPath := filepath.Join(dir, "node.lock")
+
+		// First lock
+		unlock1, err := lock(lockPath)
+		require.NoError(t, err)
+		defer unlock1()
+
+		// Second lock attempt should fail
+		unlock2, err := lock(lockPath)
+		require.Error(t, err)
+		require.Nil(t, unlock2)
+		require.Contains(t, err.Error(), "only one spacemesh instance should be running")
+	})
+	t.Run("unlock releases the lock", func(t *testing.T) {
+		dir := t.TempDir()
+		lockPath := filepath.Join(dir, "node.lock")
+
+		// First lock
+		unlock1, err := lock(lockPath)
+		require.NoError(t, err)
+
+		// Release first lock
+		require.NoError(t, unlock1())
+
+		// Should be able to acquire second lock
+		unlock2, err := lock(lockPath)
+		require.NoError(t, err)
+		defer unlock2()
+	})
+	t.Run("unlock is idempotent", func(t *testing.T) {
+		dir := t.TempDir()
+		lockPath := filepath.Join(dir, "node.lock")
+
+		unlock, err := lock(lockPath)
+		require.NoError(t, err)
+
+		// First unlock
+		require.NoError(t, unlock())
+
+		// Second unlock should not error
+		require.NoError(t, unlock())
+	})
+}

--- a/node/logging.go
+++ b/node/logging.go
@@ -1,0 +1,44 @@
+package node
+
+import (
+	"fmt"
+
+	"github.com/mitchellh/mapstructure"
+	"go.uber.org/zap"
+
+	"github.com/spacemeshos/go-spacemesh/config"
+)
+
+type loggers struct {
+	levels map[string]*zap.AtomicLevel
+}
+
+func newLoggers(cfg *config.LoggerConfig) (*loggers, error) {
+	logLevels := map[string]string{}
+	if err := mapstructure.Decode(cfg, &logLevels); err != nil {
+		return nil, fmt.Errorf("error decoding mapstructure: %w", err)
+	}
+	delete(logLevels, "log-encoder")
+
+	levels := make(map[string]*zap.AtomicLevel, len(logLevels))
+	for name, levelStr := range logLevels {
+		var lvl zap.AtomicLevel
+		if err := lvl.UnmarshalText([]byte(levelStr)); err != nil {
+			return nil, fmt.Errorf("unmarshaling zap log level: %w", err)
+		}
+		levels[name] = &lvl
+	}
+
+	return &loggers{levels}, nil
+}
+
+func (l *loggers) add(name string, base *zap.Logger) *zap.Logger {
+	lvl, ok := l.levels[name]
+	if !ok {
+		newLvl := zap.NewAtomicLevel()
+		lvl = &newLvl
+		l.levels[name] = lvl
+	}
+
+	return base.WithOptions(zap.IncreaseLevel(lvl)).Named(name)
+}

--- a/node/node.go
+++ b/node/node.go
@@ -507,7 +507,7 @@ func applyGenesis(gpath string, genesis config.GenesisConfig) error {
 		}
 		return nil
 	}
-	if diff := cmp.Diff(&existing, &genesis); len(diff) > 0 {
+	if diff := existing.Diff(&genesis); len(diff) > 0 {
 		return fmt.Errorf(
 			"genesis config updated after node initialization, "+
 				"if this update is required delete config "+

--- a/node/node.go
+++ b/node/node.go
@@ -118,6 +118,7 @@ const (
 	ApiStateDBLogger        = "apiStateDB"
 	BeaconLogger            = "beacon"
 	CachedDBLogger          = "cachedDB"
+	PoetLogger              = "poet"
 	PoetDbLogger            = "poetDb"
 	TrtlLogger              = "trtl"
 	ATXHandlerLogger        = "atxHandler"

--- a/node/node.go
+++ b/node/node.go
@@ -21,7 +21,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	pyroscope "github.com/grafana/pyroscope-go"
 	grpc_logsettable "github.com/grpc-ecosystem/go-grpc-middleware/logging/settable"
 	grpczap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap"

--- a/node/node.go
+++ b/node/node.go
@@ -21,7 +21,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/gofrs/flock"
+	"github.com/google/go-cmp/cmp"
 	pyroscope "github.com/grafana/pyroscope-go"
 	grpc_logsettable "github.com/grpc-ecosystem/go-grpc-middleware/logging/settable"
 	grpczap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap"
@@ -179,16 +179,21 @@ func GetNodeServiceCommand() *cobra.Command {
 				return fmt.Errorf("ensure folders exist: %w", err)
 			}
 
-			if err := app.Lock(); err != nil {
+			unlock, err := lock(conf.FileLock)
+			if err != nil {
 				return fmt.Errorf("getting exclusive file lock: %w", err)
 			}
-			defer app.Unlock()
+			defer func() {
+				if err := unlock(); err != nil {
+					lg.Error("failed to unlock file", zap.String("path", conf.FileLock), zap.Error(err))
+				}
+			}()
 
 			if err := app.Initialize(); err != nil {
 				return fmt.Errorf("initializing app: %w", err)
 			}
 
-			err := app.LoadIdentities()
+			err = app.LoadIdentities()
 			switch {
 			case errors.Is(err, fs.ErrNotExist):
 				app.log.Info("Identity file not found. Creating new identity...")
@@ -386,56 +391,53 @@ func New(opts ...Option) *App {
 // App is the cli app singleton.
 type App struct {
 	*cobra.Command
-	fileLock              *flock.Flock
-	signers               []*signing.EdSigner
-	Config                *config.Config
-	db                    sql.StateDatabase
-	apiDB                 sql.StateDatabase
-	cachedDB              *datastore.CachedDB
-	dbMetrics             *dbmetrics.DBMetricsCollector
-	localDB               sql.LocalDatabase
-	grpcPublicServer      *grpcserver.Server
-	grpcPrivateServer     *grpcserver.Server
-	grpcPostServer        *grpcserver.Server
-	grpcTLSServer         *grpcserver.Server
-	jsonAPIServer         *grpcserver.JSONHTTPServer
-	nodeServiceServer     *http.Server
-	grpcServices          map[grpcserver.Service]grpcserver.ServiceAPI
-	pprofService          *http.Server
-	profilerService       *pyroscope.Profiler
-	syncer                *syncer.Syncer
-	remoteProposalBuilder *miner.RemoteProposalBuilder
-	proposalBuilder       *miner.ProposalBuilder
-	mesh                  *mesh.Mesh
-	atxsdata              *atxsdata.Data
-	clock                 *timesync.NodeClock
-	hare3                 *hare3.Hare
-	hare4                 *hare4.Hare
-	remoteHare            *hare3.RemoteHare
-	hareResultsChan       chan hare4.ConsensusOutput
-	activeSetCache        *eligibility.ActiveSetCache
-	blockGen              *blocks.Generator
-	certifier             *blocks.Certifier
-	atxBuilder            *activation.Builder
-	atxHandler            *activation.Handler
-	txHandler             *txs.TxHandler
-	validator             *activation.Validator
-	edVerifier            *signing.EdVerifier
-	beaconProtocol        *beacon.ProtocolDriver
-	log                   log.Log
-	syncLogger            log.Log
-	conState              *txs.ConservativeState
-	fetcher               *fetch.Fetch
-	ptimesync             *peersync.Sync
-	updater               *bootstrap.Updater
-	poetDb                *activation.PoetDb
-	postVerifier          activation.PostVerifier
-	postSupervisor        *activation.PostSupervisor
-	malfeasanceHandler    *malfeasance.Handler
-	malfeasance2Handler   *malfeasance2.Handler
-	idStates              *identity.StateStorage
-	apiProxy              *proxy.Server
-	poetClients           []activation.PoetService
+	signers             []*signing.EdSigner
+	Config              *config.Config
+	db                  sql.StateDatabase
+	apiDB               sql.StateDatabase
+	cachedDB            *datastore.CachedDB
+	dbMetrics           *dbmetrics.DBMetricsCollector
+	localDB             sql.LocalDatabase
+	grpcPublicServer    *grpcserver.Server
+	grpcPrivateServer   *grpcserver.Server
+	grpcPostServer      *grpcserver.Server
+	grpcTLSServer       *grpcserver.Server
+	jsonAPIServer       *grpcserver.JSONHTTPServer
+	nodeServiceServer   *http.Server
+	grpcServices        map[grpcserver.Service]grpcserver.ServiceAPI
+	pprofService        *http.Server
+	profilerService     *pyroscope.Profiler
+	syncer              *syncer.Syncer
+	proposalBuilder     *miner.ProposalBuilder
+	mesh                *mesh.Mesh
+	atxsdata            *atxsdata.Data
+	clock               *timesync.NodeClock
+	hare3               *hare3.Hare
+	hare4               *hare4.Hare
+	hareResultsChan     chan hare4.ConsensusOutput
+	activeSetCache      *eligibility.ActiveSetCache
+	blockGen            *blocks.Generator
+	certifier           *blocks.Certifier
+	atxBuilder          *activation.Builder
+	atxHandler          *activation.Handler
+	txHandler           *txs.TxHandler
+	validator           *activation.Validator
+	edVerifier          *signing.EdVerifier
+	beaconProtocol      *beacon.ProtocolDriver
+	log                 log.Log
+	syncLogger          log.Log
+	conState            *txs.ConservativeState
+	fetcher             *fetch.Fetch
+	ptimesync           *peersync.Sync
+	updater             *bootstrap.Updater
+	poetDb              *activation.PoetDb
+	postVerifier        activation.PostVerifier
+	postSupervisor      *activation.PostSupervisor
+	malfeasanceHandler  *malfeasance.Handler
+	malfeasance2Handler *malfeasance2.Handler
+	idStates            *identity.StateStorage
+	apiProxy            *proxy.Server
+	poetClients         []activation.PoetService
 
 	errCh chan error
 
@@ -470,67 +472,18 @@ func (app *App) Started() <-chan struct{} {
 	return app.started
 }
 
-// Lock locks the app for exclusive use. It returns an error if the app is already locked.
-func (app *App) Lock() error {
-	lockDir := filepath.Dir(app.Config.FileLock)
-	if _, err := os.Stat(lockDir); errors.Is(err, fs.ErrNotExist) {
-		err := os.Mkdir(lockDir, os.ModePerm)
-		if err != nil {
-			return fmt.Errorf("creating dir %s for lock %s: %w", lockDir, app.Config.FileLock, err)
-		}
-	}
-	fl := flock.New(app.Config.FileLock)
-	locked, err := fl.TryLock()
-	if err != nil {
-		return fmt.Errorf("flock %s: %w", app.Config.FileLock, err)
-	} else if !locked {
-		return fmt.Errorf("only one spacemesh instance should be running (locking file %s)", fl.Path())
-	}
-	app.fileLock = fl
-	return nil
-}
-
-// Unlock unlocks the app. It is a no-op if the app is not locked.
-func (app *App) Unlock() {
-	if app.fileLock == nil {
-		return
-	}
-	if err := app.fileLock.Unlock(); err != nil {
-		app.log.With().Error("failed to unlock file",
-			log.String("path", app.fileLock.Path()),
-			log.Err(err),
-		)
-	}
-}
-
 // Initialize parses and validates the node configuration and sets up logging.
 func (app *App) Initialize() error {
 	gpath := filepath.Join(app.Config.DataDir(), genesisFileName)
-	var existing config.GenesisConfig
-	if err := existing.LoadFromFile(gpath); err != nil {
-		if !errors.Is(err, fs.ErrNotExist) {
-			return fmt.Errorf("failed to load genesis config at %s: %w", gpath, err)
-		}
-		if err := app.Config.Genesis.Validate(); err != nil {
-			return err
-		}
-		if err := app.Config.Genesis.WriteToFile(gpath); err != nil {
-			return fmt.Errorf("failed to write genesis config to %s: %w", gpath, err)
-		}
-	} else {
-		diff := existing.Diff(&app.Config.Genesis)
-		if len(diff) > 0 {
-			app.log.Error("genesis config updated after node initialization, if this update is required delete config"+
-				" at %s.\ndiff:\n%s", gpath, diff,
-			)
-			return errors.New("genesis config updated after node initialization")
-		}
+	if err := applyGenesis(gpath, app.Config.Genesis); err != nil {
+		return err
 	}
 
 	// override default config in timesync since timesync is using TimeConfigValues
 	timeCfg.TimeConfigValues = app.Config.TIME
 
-	app.setupLogging()
+	events.InitializeReporter()
+	app.log.Info("%s", getAppInfo(app.Config.Genesis))
 	app.log.Info("Welcome to Spacemesh. Spacemesh full node is starting...")
 
 	public.Version.WithLabelValues(cmd.Version).Set(1)
@@ -539,13 +492,31 @@ func (app *App) Initialize() error {
 	return nil
 }
 
-// setupLogging configured the app logging system.
-func (app *App) setupLogging() {
-	app.log.Info("%s", app.getAppInfo())
-	events.InitializeReporter()
+func applyGenesis(gpath string, genesis config.GenesisConfig) error {
+	var existing config.GenesisConfig
+	if err := existing.LoadFromFile(gpath); err != nil {
+		if !errors.Is(err, fs.ErrNotExist) {
+			return fmt.Errorf("loading genesis config at %s: %w", gpath, err)
+		}
+		if err := genesis.Validate(); err != nil {
+			return err
+		}
+		if err := genesis.WriteToFile(gpath); err != nil {
+			return fmt.Errorf("writing genesis config to %s: %w", gpath, err)
+		}
+		return nil
+	}
+	if diff := cmp.Diff(&existing, &genesis); len(diff) > 0 {
+		return fmt.Errorf(
+			"genesis config updated after node initialization, "+
+				"if this update is required delete config "+
+				"at %s.\ndiff:\n%s", gpath, diff,
+		)
+	}
+	return nil
 }
 
-func (app *App) getAppInfo() string {
+func getAppInfo(genesis config.GenesisConfig) string {
 	return fmt.Sprintf(
 		"App version: %s. Git: %s - %s . Go Version: %s. OS: %s-%s . Genesis %s",
 		cmd.Version,
@@ -554,7 +525,7 @@ func (app *App) getAppInfo() string {
 		runtime.Version(),
 		runtime.GOOS,
 		runtime.GOARCH,
-		app.Config.Genesis.GenesisID().String(),
+		genesis.GenesisID().String(),
 	)
 }
 
@@ -583,7 +554,6 @@ func (app *App) addLogger(name string, logger log.Log) log.Log {
 	return logger.WithName(name)
 }
 
-// SetLogLevel updates the log level of an existing logger.
 func (app *App) SetLogLevel(name, loglevel string) error {
 	lvl, ok := app.loggers[name]
 	if !ok {
@@ -1547,11 +1517,6 @@ func (app *App) startServices(ctx context.Context) error {
 			return app.proposalBuilder.Run(ctx)
 		})
 	}
-	if app.remoteProposalBuilder != nil {
-		app.eg.Go(func() error {
-			return app.remoteProposalBuilder.Run(ctx)
-		})
-	}
 
 	if app.Config.SMESHING.CoinbaseAccount != "" {
 		coinbaseAddr, err := types.StringToAddress(app.Config.SMESHING.CoinbaseAccount)
@@ -2226,54 +2191,22 @@ func (app *App) stopServices(ctx context.Context) {
 }
 
 func (app *App) setupDBs(ctx context.Context, lg log.Log) error {
-	dbPath := app.Config.DataDir()
-	if err := os.MkdirAll(dbPath, os.ModePerm); err != nil {
-		return fmt.Errorf("failed to create %s: %w", dbPath, err)
-	}
 	dbLog := app.addLogger(StateDbLogger, lg).Zap()
-	schema, err := statemigrations.SchemaWithInCodeMigrations(*app.Config)
+	db, err := openStateDB(app.Config, dbLog)
 	if err != nil {
-		return fmt.Errorf("error loading db schema: %w", err)
+		return err
 	}
-	if len(app.Config.DatabaseSkipMigrations) > 0 {
-		schema.SkipMigrations(app.Config.DatabaseSkipMigrations...)
-	}
-	dbopts := []sql.Opt{
-		sql.WithLogger(dbLog),
-		sql.WithDatabaseSchema(schema),
-		sql.WithConnections(app.Config.DatabaseConnections),
-		sql.WithLatencyMetering(app.Config.DatabaseLatencyMetering),
-		sql.WithVacuumState(app.Config.DatabaseVacuumState),
-		sql.WithAllowSchemaDrift(app.Config.DatabaseSchemaAllowDrift),
-		sql.WithQueryCache(app.Config.DatabaseQueryCache),
-		sql.WithQueryCacheSizes(map[sql.QueryCacheKind]int{
-			atxs.CacheKindEpochATXs:           app.Config.DatabaseQueryCacheSizes.EpochATXs,
-			atxs.CacheKindATXBlob:             app.Config.DatabaseQueryCacheSizes.ATXBlob,
-			activesets.CacheKindActiveSetBlob: app.Config.DatabaseQueryCacheSizes.ActiveSetBlob,
-		}),
-		sql.WithConnIdleTimeout(app.Config.DatabaseConnIdleTimeout),
-		sql.WithDBName("state"),
-	}
-	sqlDB, err := statesql.Open("file:"+filepath.Join(dbPath, dbFile), dbopts...)
-	if err != nil {
-		return fmt.Errorf("open sqlite db: %w", err)
-	}
-	app.db = sqlDB
-
-	apiDBLog := app.addLogger(ApiStateDBLogger, lg).Zap()
-	apiSqlDB, err := statesql.Open("file:"+filepath.Join(dbPath, dbFile),
-		sql.WithReadOnly(),
-		sql.WithLogger(apiDBLog),
-		sql.WithConnections(app.Config.API.DatabaseConnections),
-		sql.WithNoCheckSchemaDrift(), // already checked above
-		sql.WithMigrationsDisabled(),
-		sql.WithConnIdleTimeout(app.Config.DatabaseConnIdleTimeout),
-		sql.WithDBName("state-api"),
+	app.db = db
+	app.cachedDB = datastore.NewCachedDB(db, app.addLogger(CachedDBLogger, lg).Zap(),
+		datastore.WithConfig(app.Config.Cache),
+		datastore.WithConsensusCache(app.atxsdata),
 	)
+
+	db, err = openApiStateDb(app.Config, app.addLogger(ApiStateDBLogger, lg).Zap())
 	if err != nil {
-		return fmt.Errorf("open sqlite db: %w", err)
+		return err
 	}
-	app.apiDB = apiSqlDB
+	app.apiDB = db
 
 	if app.Config.CollectMetrics && app.Config.DatabaseSizeMeteringInterval != 0 {
 		app.dbMetrics = dbmetrics.NewDBMetricsCollector(
@@ -2303,28 +2236,84 @@ func (app *App) setupDBs(ctx context.Context, lg log.Log) error {
 		app.atxsdata = data
 		app.log.With().Info("cache warmup", log.Duration("duration", time.Since(start)))
 	}
-	app.cachedDB = datastore.NewCachedDB(sqlDB, app.addLogger(CachedDBLogger, lg).Zap(),
-		datastore.WithConfig(app.Config.Cache),
-		datastore.WithConsensusCache(app.atxsdata),
-	)
 
+	localDB, err := openLocalDb(app.Config, dbLog)
+	if err != nil {
+		return err
+	}
+
+	app.localDB = localDB
+	return nil
+}
+
+func openStateDB(cfg *config.Config, logger *zap.Logger) (sql.StateDatabase, error) {
+	dbPath := cfg.DataDir()
+	if err := os.MkdirAll(dbPath, os.ModePerm); err != nil {
+		return nil, fmt.Errorf("failed to create %s: %w", dbPath, err)
+	}
+	schema, err := statemigrations.SchemaWithInCodeMigrations(*cfg)
+	if err != nil {
+		return nil, fmt.Errorf("error loading db schema: %w", err)
+	}
+	if len(cfg.DatabaseSkipMigrations) > 0 {
+		schema.SkipMigrations(cfg.DatabaseSkipMigrations...)
+	}
+	dbopts := []sql.Opt{
+		sql.WithLogger(logger),
+		sql.WithDatabaseSchema(schema),
+		sql.WithConnections(cfg.DatabaseConnections),
+		sql.WithLatencyMetering(cfg.DatabaseLatencyMetering),
+		sql.WithVacuumState(cfg.DatabaseVacuumState),
+		sql.WithAllowSchemaDrift(cfg.DatabaseSchemaAllowDrift),
+		sql.WithQueryCache(cfg.DatabaseQueryCache),
+		sql.WithQueryCacheSizes(map[sql.QueryCacheKind]int{
+			atxs.CacheKindEpochATXs:           cfg.DatabaseQueryCacheSizes.EpochATXs,
+			atxs.CacheKindATXBlob:             cfg.DatabaseQueryCacheSizes.ATXBlob,
+			activesets.CacheKindActiveSetBlob: cfg.DatabaseQueryCacheSizes.ActiveSetBlob,
+		}),
+		sql.WithConnIdleTimeout(cfg.DatabaseConnIdleTimeout),
+		sql.WithDBName("state"),
+	}
+	sqlDB, err := statesql.Open("file:"+filepath.Join(dbPath, dbFile), dbopts...)
+	if err != nil {
+		return nil, fmt.Errorf("open state sqlite db: %w", err)
+	}
+	return sqlDB, nil
+}
+
+func openApiStateDb(cfg *config.Config, logger *zap.Logger) (sql.StateDatabase, error) {
+	apiSqlDB, err := statesql.Open("file:"+filepath.Join(cfg.DataDir(), dbFile),
+		sql.WithReadOnly(),
+		sql.WithLogger(logger),
+		sql.WithConnections(cfg.API.DatabaseConnections),
+		sql.WithNoCheckSchemaDrift(),
+		sql.WithMigrationsDisabled(),
+		sql.WithConnIdleTimeout(cfg.DatabaseConnIdleTimeout),
+		sql.WithDBName("state-api"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("open api-state sqlite db: %w", err)
+	}
+	return apiSqlDB, nil
+}
+
+func openLocalDb(cfg *config.Config, logger *zap.Logger) (sql.LocalDatabase, error) {
 	lSchema, err := localmigrations.SchemaWithInCodeMigrations()
 	if err != nil {
-		return fmt.Errorf("error loading db schema: %w", err)
+		return nil, fmt.Errorf("error loading db schema: %w", err)
 	}
-	localDB, err := localsql.Open("file:"+filepath.Join(dbPath, localDbFile),
-		sql.WithLogger(dbLog),
+	localDB, err := localsql.Open("file:"+filepath.Join(cfg.DataDir(), localDbFile),
+		sql.WithLogger(logger),
 		sql.WithDatabaseSchema(lSchema),
-		sql.WithConnections(app.Config.DatabaseConnections),
-		sql.WithAllowSchemaDrift(app.Config.DatabaseSchemaAllowDrift),
-		sql.WithConnIdleTimeout(app.Config.DatabaseConnIdleTimeout),
+		sql.WithConnections(cfg.DatabaseConnections),
+		sql.WithAllowSchemaDrift(cfg.DatabaseSchemaAllowDrift),
+		sql.WithConnIdleTimeout(cfg.DatabaseConnIdleTimeout),
 		sql.WithDBName("local"),
 	)
 	if err != nil {
-		return fmt.Errorf("open sqlite db: %w", err)
+		return nil, fmt.Errorf("open local sqlite db: %w", err)
 	}
-	app.localDB = localDB
-	return nil
+	return localDB, nil
 }
 
 // Start starts the Spacemesh node service and initializes all relevant

--- a/node/node.go
+++ b/node/node.go
@@ -186,7 +186,7 @@ func GetNodeServiceCommand() *cobra.Command {
 			}
 			defer func() {
 				if err := unlock(); err != nil {
-					lg.Error("failed to unlock file", zap.String("path", conf.FileLock), zap.Error(err))
+					lg.Zap().Error("failed to unlock file", zap.String("path", conf.FileLock), zap.Error(err))
 				}
 			}()
 

--- a/node/node_identities.go
+++ b/node/node_identities.go
@@ -7,6 +7,9 @@ import (
 	"os"
 	"path/filepath"
 
+	"go.uber.org/zap"
+
+	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/signing"
 )
@@ -20,33 +23,50 @@ const (
 // NewIdentity creates a new identity, saves it to `keyDir/supervisedIDKeyFileName` in the config directory and
 // initializes app.signers with that identity.
 func (app *App) NewIdentity() error {
-	dir := filepath.Join(app.Config.DataDir(), keyDir)
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		return fmt.Errorf("failed to create directory for identity file: %w", err)
-	}
-
-	keyFile := filepath.Join(dir, supervisedIDKeyFileName)
-	signer, err := signing.NewEdSigner(
-		signing.WithPrefix(app.Config.Genesis.GenesisID().Bytes()),
-		signing.ToFile(keyFile),
-	)
+	signer, err := newIdentity(app.Config.DataDir(), app.Config.Genesis.GenesisID(), app.log.Zap())
 	if err != nil {
-		return fmt.Errorf("failed to create identity: %w", err)
+		return err
 	}
-
-	app.log.With().Info("Created new identity",
-		log.String("filename", supervisedIDKeyFileName),
-		log.ShortStringer("public_key", signer.PublicKey()),
-	)
 	app.signers = []*signing.EdSigner{signer}
 	return nil
 }
 
+func newIdentity(datadir string, genesisID types.Hash20, logger *zap.Logger) (*signing.EdSigner, error) {
+	dir := filepath.Join(datadir, keyDir)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, fmt.Errorf("failed to create directory for identity file: %w", err)
+	}
+
+	keyFile := filepath.Join(dir, supervisedIDKeyFileName)
+	signer, err := signing.NewEdSigner(
+		signing.WithPrefix(genesisID.Bytes()),
+		signing.ToFile(keyFile),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create identity: %w", err)
+	}
+
+	logger.Info("Created new identity",
+		zap.String("filename", supervisedIDKeyFileName),
+		log.ZShortStringer("public_key", signer.PublicKey()),
+	)
+	return signer, nil
+}
+
 // LoadIdentities loads all existing identities from the config directory.
 func (app *App) LoadIdentities() error {
+	signers, err := loadIdentities(app.Config.DataDir(), app.Config.Genesis.GenesisID(), app.log.Zap())
+	if err != nil {
+		return err
+	}
+	app.signers = signers
+	return nil
+}
+
+func loadIdentities(datadir string, genesisID types.Hash20, logger *zap.Logger) ([]*signing.EdSigner, error) {
 	signers := make([]*signing.EdSigner, 0)
 
-	dir := filepath.Join(app.Config.DataDir(), keyDir)
+	dir := filepath.Join(datadir, keyDir)
 	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return fmt.Errorf("failed to walk directory at %s: %w", path, err)
@@ -64,24 +84,24 @@ func (app *App) LoadIdentities() error {
 
 		signer, err := signing.NewEdSigner(
 			signing.FromFile(path),
-			signing.WithPrefix(app.Config.Genesis.GenesisID().Bytes()),
+			signing.WithPrefix(genesisID.Bytes()),
 		)
 		if err != nil {
 			return fmt.Errorf("failed to construct identity %s: %w", d.Name(), err)
 		}
 
-		app.log.With().Info("Loaded existing identity",
-			log.String("filename", d.Name()),
-			log.ShortStringer("public_key", signer.PublicKey()),
+		logger.Info("Loaded existing identity",
+			zap.String("filename", d.Name()),
+			log.ZShortStringer("public_key", signer.PublicKey()),
 		)
 		signers = append(signers, signer)
 		return nil
 	})
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if len(signers) == 0 {
-		return fmt.Errorf("no identity files found: %w", fs.ErrNotExist)
+		return nil, fmt.Errorf("no identity files found: %w", fs.ErrNotExist)
 	}
 
 	// make sure all keys are unique
@@ -89,10 +109,10 @@ func (app *App) LoadIdentities() error {
 	collision := false
 	for _, sig := range signers {
 		if file, ok := seen[sig.PublicKey().String()]; ok {
-			app.log.With().Error("duplicate key",
-				log.String("filename1", sig.Name()),
-				log.String("filename2", file),
-				log.String("public_key", sig.PublicKey().ShortString()),
+			logger.Error("duplicate key",
+				zap.String("filename1", sig.Name()),
+				zap.String("filename2", file),
+				zap.String("public_key", sig.PublicKey().ShortString()),
 			)
 			collision = true
 			continue
@@ -100,26 +120,25 @@ func (app *App) LoadIdentities() error {
 		seen[sig.PublicKey().String()] = sig.Name()
 	}
 	if collision {
-		return errors.New("duplicate key found in identity files")
+		return nil, errors.New("duplicate key found in identity files")
 	}
 
 	if len(signers) > 1 {
-		app.log.Info("Loaded %d identities from disk", len(signers))
+		logger.Sugar().Infof("Loaded %d identities from disk", len(signers))
 		for _, sig := range signers {
 			if sig.Name() == supervisedIDKeyFileName {
-				app.log.Error(
+				logger.Sugar().Errorf(
 					"Identities contain key for supervised smeshing (%s). This is not supported in remote smeshing.",
 					supervisedIDKeyFileName,
 				)
-				app.log.Error(
+				logger.Sugar().Errorf(
 					"Ensure you do not have a file named %s in your identities directory when using remote smeshing.",
 					supervisedIDKeyFileName,
 				)
-				return errors.New("supervised key found in remote smeshing mode")
+				return nil, errors.New("supervised key found in remote smeshing mode")
 			}
 		}
 	}
 
-	app.signers = signers
-	return nil
+	return signers, nil
 }

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -1288,14 +1288,20 @@ func launchPostSupervisor(
 }
 
 func getTestDefaultConfig(tb testing.TB) *config.Config {
-	cfg := config.MainnetConfig()
+	cfg := testConfigFrom(tb, config.MainnetConfig())
+	// FIXME: unfortunately, many tests depend on globals being set.
 	types.SetNetworkHRP(cfg.NetworkHRP)
 	types.SetLayersPerEpoch(cfg.LayersPerEpoch)
 
+	return cfg
+}
+
+func testConfigFrom(tb testing.TB, cfg config.Config) *config.Config {
 	tmp := tb.TempDir()
 	cfg.DataDirParent = tmp
 	cfg.FileLock = filepath.Join(tmp, "LOCK")
 	cfg.LayerDuration = 20 * time.Second
+	cfg.NetworkHRP = "test"
 
 	// is set to 0 to make sync start immediately when node starts
 	cfg.P2P.MinPeers = 0
@@ -1310,7 +1316,7 @@ func getTestDefaultConfig(tb testing.TB) *config.Config {
 
 	cfg.SMESHING = config.DefaultSmeshingConfig()
 	cfg.SMESHING.Start = false
-	cfg.SMESHING.CoinbaseAccount = types.GenerateAddress([]byte{1}).String()
+	cfg.SMESHING.CoinbaseAccount = types.GenerateAddress([]byte{1}).StringWithHRP(cfg.NetworkHRP)
 	cfg.SMESHING.Opts.DataDir = filepath.Join(tmp, "post")
 	cfg.SMESHING.Opts.NumUnits = cfg.POST.MinNumUnits + 1
 	cfg.SMESHING.Opts.Scrypt.N = 2
@@ -1337,7 +1343,7 @@ func getTestDefaultConfig(tb testing.TB) *config.Config {
 	cfg.FETCH.BatchTimeout = 5 * time.Second
 
 	cfg.Beacon = beacon.NodeSimUnitTestConfig()
-	cfg.Genesis = config.DefaultTestGenesisConfig()
+	cfg.Genesis = config.DefaultTestGenesisConfig(cfg.NetworkHRP)
 	cfg.POSTService = activation.DefaultTestPostServiceConfig()
 
 	return &cfg

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -976,30 +976,6 @@ func TestGenesisConfig(t *testing.T) {
 	})
 }
 
-func TestFlock(t *testing.T) {
-	t.Run("sanity", func(t *testing.T) {
-		cfg := getTestDefaultConfig(t)
-		app := New(WithConfig(cfg))
-
-		require.NoError(t, app.Lock())
-		t.Cleanup(app.Unlock)
-
-		app1 := *app
-		require.ErrorContains(t, app1.Lock(), "only one spacemesh instance")
-		app.Unlock()
-		require.NoError(t, app.Lock())
-	})
-
-	t.Run("dir doesn't exist", func(t *testing.T) {
-		cfg := getTestDefaultConfig(t)
-		cfg.FileLock = filepath.Join(t.TempDir(), "newdir", "LOCK")
-		app := New(WithConfig(cfg))
-
-		require.NoError(t, app.Lock())
-		t.Cleanup(app.Unlock)
-	})
-}
-
 func TestEmptyExtraData(t *testing.T) {
 	cfg := getTestDefaultConfig(t)
 	cfg.Genesis.ExtraData = ""

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -1288,15 +1288,7 @@ func launchPostSupervisor(
 }
 
 func getTestDefaultConfig(tb testing.TB) *config.Config {
-	cfg := testConfigFrom(tb, config.MainnetConfig())
-	// FIXME: unfortunately, many tests depend on globals being set.
-	types.SetNetworkHRP(cfg.NetworkHRP)
-	types.SetLayersPerEpoch(cfg.LayersPerEpoch)
-
-	return cfg
-}
-
-func testConfigFrom(tb testing.TB, cfg config.Config) *config.Config {
+	cfg := config.MainnetConfig()
 	tmp := tb.TempDir()
 	cfg.DataDirParent = tmp
 	cfg.FileLock = filepath.Join(tmp, "LOCK")
@@ -1345,6 +1337,10 @@ func testConfigFrom(tb testing.TB, cfg config.Config) *config.Config {
 	cfg.Beacon = beacon.NodeSimUnitTestConfig()
 	cfg.Genesis = config.DefaultTestGenesisConfig(cfg.NetworkHRP)
 	cfg.POSTService = activation.DefaultTestPostServiceConfig()
+
+	// FIXME: unfortunately, many tests depend on globals being set.
+	types.SetNetworkHRP(cfg.NetworkHRP)
+	types.SetLayersPerEpoch(cfg.LayersPerEpoch)
 
 	return &cfg
 }

--- a/node/smeshing_service.go
+++ b/node/smeshing_service.go
@@ -6,23 +6,33 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"maps"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"syscall"
 	"time"
 
 	pyroscope "github.com/grafana/pyroscope-go"
+	grpczap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/keepalive"
 
 	"github.com/spacemeshos/go-spacemesh/activation"
 	"github.com/spacemeshos/go-spacemesh/api/grpcserver"
+	"github.com/spacemeshos/go-spacemesh/api/grpcserver/v2beta1"
 	"github.com/spacemeshos/go-spacemesh/api/node/client"
 	nodeclient "github.com/spacemeshos/go-spacemesh/api/node/client"
+	"github.com/spacemeshos/go-spacemesh/api/proxy"
+	"github.com/spacemeshos/go-spacemesh/atxsdata"
 	"github.com/spacemeshos/go-spacemesh/beacon"
 	"github.com/spacemeshos/go-spacemesh/cmd"
 	"github.com/spacemeshos/go-spacemesh/common/types"
@@ -30,21 +40,17 @@ import (
 	"github.com/spacemeshos/go-spacemesh/events"
 	"github.com/spacemeshos/go-spacemesh/hare3"
 	"github.com/spacemeshos/go-spacemesh/hare3/eligibility"
-	"github.com/spacemeshos/go-spacemesh/hare4"
-	"github.com/spacemeshos/go-spacemesh/hash"
 	"github.com/spacemeshos/go-spacemesh/identity"
-	"github.com/spacemeshos/go-spacemesh/log"
-	"github.com/spacemeshos/go-spacemesh/mesh"
 	"github.com/spacemeshos/go-spacemesh/metrics"
-	"github.com/spacemeshos/go-spacemesh/metrics/public"
 	"github.com/spacemeshos/go-spacemesh/miner"
 	"github.com/spacemeshos/go-spacemesh/signing"
+	"github.com/spacemeshos/go-spacemesh/sql"
+	dbmetrics "github.com/spacemeshos/go-spacemesh/sql/metrics"
 	"github.com/spacemeshos/go-spacemesh/timesync"
-	timeCfg "github.com/spacemeshos/go-spacemesh/timesync/config"
 )
 
 func GetSmeshingServiceCommand() *cobra.Command {
-	conf := config.MainnetConfig()
+	conf := config.MainnetSmeshingServiceConfig()
 	var configPath *string
 	c := &cobra.Command{
 		Use:   "smeshing",
@@ -54,60 +60,46 @@ func GetSmeshingServiceCommand() *cobra.Command {
 				return err
 			}
 
-			// NOTE(dshulyak) this needs to be max level so that child logger can can be current level or below.
-			// otherwise it will fail later when child logger will try to increase level.
 			encoder := zapcore.NewConsoleEncoder(zap.NewDevelopmentEncoderConfig())
 			if conf.LOGGING.Encoder == config.JSONLogEncoder {
 				encoder = zapcore.NewJSONEncoder(zap.NewDevelopmentEncoderConfig())
 			}
-			lg := log.NewWithLevel("node", zap.NewAtomicLevelAt(zap.DebugLevel), encoder, events.EventHook())
+			core := zapcore.NewCore(encoder, zapcore.AddSync(os.Stdout), zap.DebugLevel)
+			lg := zap.New(zapcore.RegisterHooks(core, events.EventHook())).Named("node")
 
-			app := New(WithConfig(&conf), WithLog(lg))
+			events.InitializeReporter()
+			lg.Info(getAppInfo(conf.Genesis))
+			lg.Info("Welcome to Spacemesh. Spacemesh activation service is starting...")
+
+			app, err := NewSmeshingService(&conf, lg)
+			if err != nil {
+				return fmt.Errorf("creating smeshing service app: %w", err)
+			}
+			unlock, err := lock(conf.FileLock)
+			if err != nil {
+				return err
+			}
+			defer func() {
+				if err := unlock(); err != nil {
+					lg.Error("failed to unlock file", zap.String("path", conf.FileLock), zap.Error(err))
+				}
+			}()
 
 			// os.Interrupt for all systems, especially windows, syscall.SIGTERM is mainly for docker.
 			ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 			defer cancel()
 
-			types.SetLayersPerEpoch(app.Config.LayersPerEpoch)
-			// ensure all data folders exist
-			if err := os.MkdirAll(app.Config.DataDir(), 0o700); err != nil {
-				return fmt.Errorf("ensure folders exist: %w", err)
-			}
-
-			if err := app.Lock(); err != nil {
-				return fmt.Errorf("getting exclusive file lock: %w", err)
-			}
-			defer app.Unlock()
-
-			if err := app.Initialize(); err != nil {
-				return fmt.Errorf("initializing app: %w", err)
-			}
-
-			err := app.LoadIdentities()
-			switch {
-			case errors.Is(err, fs.ErrNotExist):
-				app.log.Info("Identity file not found. Creating new identity...")
-				if err := app.NewIdentity(); err != nil {
-					return fmt.Errorf("creating new identity: %w", err)
-				}
-			case err != nil:
-				return fmt.Errorf("loading identities: %w", err)
-			}
-
-			// Don't print usage on error from this point forward
-			c.SilenceUsage = true
-
 			// This blocks until the context is finished or until an error is produced
-			err = app.StartSmeshingService(ctx)
-			cleanupCtx, cleanupCancel := context.WithTimeout(
-				context.Background(),
-				30*time.Second,
-			)
+			if err := app.Start(ctx); err != nil {
+				lg.Error("app failed", zap.Error(err))
+			}
+
+			cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cleanupCancel()
 			done := make(chan struct{}, 1)
 			// FIXME: per https://github.com/spacemeshos/go-spacemesh/issues/3830
 			go func() {
-				app.Cleanup(cleanupCtx)
+				app.stopServices(cleanupCtx)
 				close(done)
 			}()
 			select {
@@ -115,7 +107,7 @@ func GetSmeshingServiceCommand() *cobra.Command {
 			case <-cleanupCtx.Done():
 				app.log.Error("app failed to clean up in time")
 			}
-			return err
+			return nil
 		},
 	}
 
@@ -135,53 +127,92 @@ func GetSmeshingServiceCommand() *cobra.Command {
 	return c
 }
 
-// Initialize parses and validates the node configuration and sets up logging.
-func (app *App) InitializeSmeshingService() error {
-	gpath := filepath.Join(app.Config.DataDir(), genesisFileName)
-	var existing config.GenesisConfig
-	if err := existing.LoadFromFile(gpath); err != nil {
-		if !errors.Is(err, fs.ErrNotExist) {
-			return fmt.Errorf("failed to load genesis config at %s: %w", gpath, err)
-		}
-		if err := app.Config.Genesis.Validate(); err != nil {
-			return err
-		}
-		if err := app.Config.Genesis.WriteToFile(gpath); err != nil {
-			return fmt.Errorf("failed to write genesis config to %s: %w", gpath, err)
-		}
-	} else {
-		diff := existing.Diff(&app.Config.Genesis)
-		if len(diff) > 0 {
-			app.log.Error("genesis config updated after node initialization, if this update is required delete config"+
-				" at %s.\ndiff:\n%s", gpath, diff,
-			)
-			return errors.New("genesis config updated after node initialization")
-		}
-	}
+type SmeshingService struct {
+	signers           []*signing.EdSigner
+	config            *config.Config
+	db                sql.StateDatabase // FIXME: remove
+	dbMetrics         *dbmetrics.DBMetricsCollector
+	localDB           sql.LocalDatabase
+	grpcPublicServer  *grpcserver.Server
+	grpcPrivateServer *grpcserver.Server
+	grpcPostServer    *grpcserver.Server
+	grpcTLSServer     *grpcserver.Server
+	jsonAPIServer     *grpcserver.JSONHTTPServer
+	grpcServices      map[grpcserver.Service]grpcserver.ServiceAPI
+	pprofService      *http.Server
+	profilerService   *pyroscope.Profiler
+	proposalsBuilder  *miner.RemoteProposalBuilder
+	clock             *timesync.NodeClock
+	remoteHare        *hare3.RemoteHare
+	atxBuilder        *activation.Builder
+	validator         *activation.Validator
+	log               *zap.Logger
+	postVerifier      activation.PostVerifier
+	postSupervisor    *activation.PostSupervisor
+	idStates          *identity.StateStorage
+	apiProxy          *proxy.Server
+	poetClients       []activation.PoetService
 
-	// override default config in timesync since timesync is using TimeConfigValues
-	timeCfg.TimeConfigValues = app.Config.TIME
+	errCh chan error
 
-	app.setupLogging()
-	app.log.Info("Welcome to Spacemesh. Spacemesh activation service is starting...")
-
-	public.Version.WithLabelValues(cmd.Version).Set(1)
-	public.SmeshingOptsProvingNonces.Set(float64(app.Config.SMESHING.ProvingOpts.Nonces))
-	public.SmeshingOptsProvingThreads.Set(float64(app.Config.SMESHING.ProvingOpts.Threads))
-	return nil
+	loggers *loggers
+	eg      errgroup.Group
+	started chan struct{}
 }
 
-func (app *App) initSmeshingServiceServices(ctx context.Context) error {
-	layerSize := app.Config.LayerAvgSize
+func NewSmeshingService(cfg *config.Config, logger *zap.Logger) (*SmeshingService, error) {
+	loggers, err := newLoggers(&cfg.LOGGING)
+	if err != nil {
+		return nil, fmt.Errorf("parsing loggers config: %w", err)
+	}
+
+	types.SetLayersPerEpoch(cfg.LayersPerEpoch)
+	types.SetNetworkHRP(cfg.NetworkHRP)
+
+	// ensure all data folders exist
+	if err := os.MkdirAll(cfg.DataDir(), 0o700); err != nil {
+		return nil, fmt.Errorf("ensure folders exist: %w", err)
+	}
+
+	signers, err := loadIdentities(cfg.DataDir(), cfg.Genesis.GenesisID(), logger)
+	switch {
+	case errors.Is(err, fs.ErrNotExist):
+		logger.Info("Identity file not found. Creating new identity...")
+		signer, err := newIdentity(cfg.DataDir(), cfg.Genesis.GenesisID(), logger)
+		if err != nil {
+			return nil, fmt.Errorf("creating new identity: %w", err)
+		}
+		signers = []*signing.EdSigner{signer}
+	case err != nil:
+		return nil, fmt.Errorf("loading identities: %w", err)
+	}
+
+	gpath := filepath.Join(cfg.DataDir(), genesisFileName)
+	if err := applyGenesis(gpath, cfg.Genesis); err != nil {
+		return nil, err
+	}
+
+	return &SmeshingService{
+		config:       cfg,
+		loggers:      loggers,
+		log:          logger,
+		signers:      signers,
+		grpcServices: make(map[grpcserver.Service]grpcserver.ServiceAPI),
+		started:      make(chan struct{}),
+	}, nil
+}
+
+func (app *SmeshingService) initServices(ctx context.Context) error {
+	layerSize := app.config.LayerAvgSize
 	layersPerEpoch := types.GetLayersPerEpoch()
 	lg := app.log
 
 	var nodeServiceClient *client.NodeService
-	listenAddress := app.Config.BaseConfig.NodeServiceAddress
-	logger := app.addLogger(NodeServiceClientLogger, lg).Zap()
+	listenAddress := app.config.BaseConfig.NodeServiceAddress
+	logger := app.loggers.add(NodeServiceClientLogger, lg)
 	cfg := &nodeclient.Config{
-		RetryWaitMin: time.Millisecond * 500,
-		RetryWaitMax: time.Second,
+		RetryWaitMin: time.Second,
+		RetryWaitMax: time.Second * 30,
 		RetryMax:     10,
 	}
 	var err error
@@ -192,18 +223,18 @@ func (app *App) initSmeshingServiceServices(ctx context.Context) error {
 
 	poetDb, err := activation.NewPoetDb(
 		app.db,
-		app.addLogger(PoetDbLogger, lg).Zap(),
-		activation.WithCacheSize(app.Config.POET.PoetProofsCache),
+		app.loggers.add(PoetDbLogger, lg),
+		activation.WithCacheSize(app.config.POET.PoetProofsCache),
 	)
 	if err != nil {
 		return fmt.Errorf("creating poet db: %w", err)
 	}
-	postStates := activation.NewPostStates(app.addLogger(PostLogger, lg).Zap())
+	postStates := activation.NewPostStates(app.loggers.add(PostLogger, lg))
 
-	app.idStates = identity.NewIdentityStateStorage(app.localDB, app.log.Zap())
+	app.idStates = identity.NewIdentityStateStorage(app.localDB, app.log)
 
 	opts := []activation.PostVerifierOpt{
-		activation.WithVerifyingOpts(app.Config.SMESHING.VerifyingOpts),
+		activation.WithVerifyingOpts(app.config.SMESHING.VerifyingOpts),
 		activation.WithAutoscaling(postStates),
 	}
 	for _, sig := range app.signers {
@@ -211,8 +242,8 @@ func (app *App) initSmeshingServiceServices(ctx context.Context) error {
 	}
 
 	verifier, err := activation.NewPostVerifier(
-		app.Config.POST,
-		app.addLogger(NipostValidatorLogger, lg).Zap(),
+		app.config.POST,
+		app.loggers.add(NipostValidatorLogger, lg),
 		opts...,
 	)
 	if err != nil {
@@ -220,37 +251,26 @@ func (app *App) initSmeshingServiceServices(ctx context.Context) error {
 	}
 	app.postVerifier = verifier
 
-	validator := activation.NewValidator(
+	app.validator = activation.NewValidator(
 		app.db,
 		poetDb,
-		app.Config.POST,
-		app.Config.SMESHING.Opts.Scrypt,
+		app.config.POST,
+		app.config.SMESHING.Opts.Scrypt,
 		app.postVerifier,
 	)
-	app.validator = validator
 
-	goldenATXID := types.ATXID(app.Config.Genesis.GoldenATX())
+	goldenATXID := types.ATXID(app.config.Genesis.GoldenATX())
 	if goldenATXID == types.EmptyATXID {
 		return errors.New("invalid golden atx id")
 	}
 
-	app.edVerifier = signing.NewEdVerifier(
-		signing.WithVerifierPrefix(app.Config.Genesis.GenesisID().Bytes()),
-	)
-
-	vrfVerifier := signing.NewVRFVerifier()
-
-	var msh *mesh.Mesh
-	var atxHandler *activation.Handler
-
 	// we can't have an epoch offset which is greater/equal than the number of layers in an epoch
-
-	if app.Config.HareEligibility.ConfidenceParam >= app.Config.BaseConfig.LayersPerEpoch {
+	if app.config.HareEligibility.ConfidenceParam >= app.config.BaseConfig.LayersPerEpoch {
 		return fmt.Errorf(
 			"confidence param should be smaller than layers per epoch. eligibility-confidence-param: %d. "+
 				"layers-per-epoch: %d",
-			app.Config.HareEligibility.ConfidenceParam,
-			app.Config.BaseConfig.LayersPerEpoch,
+			app.config.HareEligibility.ConfidenceParam,
+			app.config.BaseConfig.LayersPerEpoch,
 		)
 	}
 
@@ -259,25 +279,22 @@ func (app *App) initSmeshingServiceServices(ctx context.Context) error {
 	hOracle, err := eligibility.New(
 		cachedWeights,
 		beaconProvider,
-		vrfVerifier,
-		app.Config.LayersPerEpoch,
-		eligibility.WithConfig(app.Config.HareEligibility),
-		eligibility.WithLogger(app.addLogger(HareOracleLogger, lg).Zap()),
+		signing.NewVRFVerifier(),
+		app.config.LayersPerEpoch,
+		eligibility.WithConfig(app.config.HareEligibility),
+		eligibility.WithLogger(app.loggers.add(HareOracleLogger, lg)),
 	)
 	if err != nil {
 		return fmt.Errorf("create hare oracle: %w", err)
 	}
 
-	err = app.Config.HARE3.Validate(time.Duration(app.Config.Tortoise.Zdist) * app.Config.LayerDuration)
+	err = app.config.HARE3.Validate(time.Duration(app.config.Tortoise.Zdist) * app.config.LayerDuration)
 	if err != nil {
 		return err
 	}
-	logger = app.addLogger(HareLogger, lg).Zap()
-
-	// should be removed after hare4 transition is complete
-	app.hareResultsChan = make(chan hare4.ConsensusOutput, 32)
+	logger = app.loggers.add(HareLogger, lg)
 	app.remoteHare = hare3.NewRemoteHare(
-		app.Config.HARE3,
+		app.config.HARE3,
 		app.clock,
 		nodeServiceClient,
 		beaconProvider,
@@ -296,23 +313,23 @@ func (app *App) initSmeshingServiceServices(ctx context.Context) error {
 		nodeServiceClient,
 		layerSize,
 		layersPerEpoch,
-		app.addLogger(ProposalBuilderLogger, lg).Zap(),
+		app.loggers.add(ProposalBuilderLogger, lg),
 		app.idStates,
 	)
 	for _, sig := range app.signers {
 		remoteProposalBuilder.Register(sig)
 	}
-	app.remoteProposalBuilder = remoteProposalBuilder
+	app.proposalsBuilder = remoteProposalBuilder
 
 	postSetupMgr, err := activation.NewPostSetupManager(
-		app.Config.POST,
-		app.addLogger(PostLogger, lg).Zap(),
+		app.config.POST,
+		app.loggers.add(PostLogger, lg),
 		app.db,
-		app.atxsdata,
+		atxsdata.New(), // FIXME: remove this dependency
 		goldenATXID,
 		nil,
 		app.validator,
-		activation.PostValidityDelay(app.Config.PostValidDelay),
+		activation.PostValidityDelay(app.config.PostValidDelay),
 	)
 	if err != nil {
 		return fmt.Errorf("create post setup manager: %v", err)
@@ -323,27 +340,27 @@ func (app *App) initSmeshingServiceServices(ctx context.Context) error {
 		return fmt.Errorf("init post grpc service: %w", err)
 	}
 
-	nipostLogger := app.addLogger(NipostBuilderLogger, lg).Zap()
+	nipostLogger := app.loggers.add(NipostBuilderLogger, lg)
 	client := activation.NewCertifierClient(
 		app.db,
 		app.localDB,
 		nipostLogger,
-		activation.WithCertifierClientConfig(app.Config.Certifier.Client),
+		activation.WithCertifierClientConfig(app.config.Certifier.Client),
 	)
 	poetCertifier := activation.NewCertifier(app.localDB, nipostLogger, client)
 
-	poetClients := make([]activation.PoetService, 0, len(app.Config.PoetServers))
-	for _, server := range app.Config.PoetServers {
+	poetClients := make([]activation.PoetService, 0, len(app.config.PoetServers))
+	for _, server := range app.config.PoetServers {
 		client, err := activation.NewPoetService(
 			poetDb,
 			server,
-			app.Config.POET,
-			lg.Zap().Named("poet"),
-			app.Config.TickSize,
+			app.config.POET,
+			app.loggers.add("poet", app.log),
+			app.config.TickSize,
 			activation.WithCertifier(poetCertifier),
 		)
 		if err != nil {
-			app.log.Panic("failed to create poet client with address %v: %v", server.Address, err)
+			app.log.Sugar().Panicf("failed to create poet client with address %v: %v", server.Address, err)
 		}
 		poetClients = append(poetClients, client)
 	}
@@ -353,7 +370,7 @@ func (app *App) initSmeshingServiceServices(ctx context.Context) error {
 		app.localDB,
 		grpcPostService.(*grpcserver.PostService),
 		nipostLogger,
-		app.Config.POET,
+		app.config.POET,
 		app.clock,
 		app.validator,
 		activation.NipostbuilderWithPostStates(postStates),
@@ -366,7 +383,7 @@ func (app *App) initSmeshingServiceServices(ctx context.Context) error {
 
 	builderConfig := activation.Config{
 		GoldenATXID:      goldenATXID,
-		RegossipInterval: app.Config.RegossipAtxInterval,
+		RegossipInterval: app.config.RegossipAtxInterval,
 	}
 
 	atxBuilder := activation.NewBuilder(
@@ -379,14 +396,14 @@ func (app *App) initSmeshingServiceServices(ctx context.Context) error {
 		nipostBuilder,
 		app.clock,
 		alwaysSyncedSyncer{},
-		app.addLogger(ATXBuilderLogger, lg).Zap(),
-		activation.WithPoetConfig(app.Config.POET),
+		app.loggers.add(ATXBuilderLogger, lg),
+		activation.WithPoetConfig(app.config.POET),
 		// TODO(dshulyak) makes no sense. how we ended using it?
-		activation.WithPoetRetryInterval(app.Config.HARE3.PreroundDelay),
+		activation.WithPoetRetryInterval(app.config.HARE3.PreroundDelay),
 		activation.WithPostStates(postStates),
 		activation.WithIdentityStates(app.idStates),
 		activation.WithPoets(poetClients...),
-		activation.BuilderAtxVersions(app.Config.AtxVersions),
+		activation.BuilderAtxVersions(app.config.AtxVersions),
 	)
 
 	if len(app.signers) > 1 || app.signers[0].Name() != supervisedIDKeyFileName {
@@ -402,9 +419,9 @@ func (app *App) initSmeshingServiceServices(ctx context.Context) error {
 		}
 	}
 	app.postSupervisor = activation.NewPostSupervisor(
-		app.log.Zap(),
-		app.Config.POST,
-		app.Config.SMESHING.ProvingOpts,
+		app.log,
+		app.config.POST,
+		app.config.SMESHING.ProvingOpts,
 		postSetupMgr,
 		atxBuilder,
 	)
@@ -412,28 +429,22 @@ func (app *App) initSmeshingServiceServices(ctx context.Context) error {
 		return fmt.Errorf("init post service: %w", err)
 	}
 
-	app.mesh = msh
 	app.atxBuilder = atxBuilder
-	app.atxHandler = atxHandler
-	app.poetDb = poetDb
 
 	return nil
 }
 
-func (app *App) startSmeshingServiceServices(ctx context.Context) error {
-	if app.remoteProposalBuilder == nil {
-		panic("remote proposal builder can not be nil at this point")
-	}
+func (app *SmeshingService) startServices(ctx context.Context) error {
 	app.eg.Go(func() error {
-		return app.remoteProposalBuilder.Run(ctx)
+		return app.proposalsBuilder.Run(ctx)
 	})
 
-	if app.Config.SMESHING.CoinbaseAccount != "" {
-		coinbaseAddr, err := types.StringToAddress(app.Config.SMESHING.CoinbaseAccount)
+	if app.config.SMESHING.CoinbaseAccount != "" {
+		coinbaseAddr, err := types.StringToAddress(app.config.SMESHING.CoinbaseAccount)
 		if err != nil {
 			return fmt.Errorf(
 				"parse CoinbaseAccount address on start `%s`: %w",
-				app.Config.SMESHING.CoinbaseAccount,
+				app.config.SMESHING.CoinbaseAccount,
 				err,
 			)
 		}
@@ -448,14 +459,14 @@ func (app *App) startSmeshingServiceServices(ctx context.Context) error {
 // StartSmeshingService starts the Spacemesh activation service and
 // initializes all relevant services according to command line
 // arguments provided.
-func (app *App) StartSmeshingService(ctx context.Context) error {
-	if err := app.verifyVersionUpgrades(); err != nil {
+func (app *SmeshingService) Start(ctx context.Context) error {
+	if err := verifyLocalDbMigrations(app.config); err != nil {
 		return fmt.Errorf("version upgrade verification failed: %w", err)
 	}
 
 	err := app.startSmeshingServiceSynchronous(ctx)
 	if err != nil {
-		app.log.With().Error("failed to start App", log.Err(err))
+		app.log.Error("failed to start App", zap.Error(err))
 		return err
 	}
 	defer events.ReportError(events.NodeError{
@@ -473,61 +484,60 @@ func (app *App) StartSmeshingService(ctx context.Context) error {
 	}
 }
 
-func (app *App) startSmeshingServiceSynchronous(ctx context.Context) (err error) {
+func (app *SmeshingService) startSmeshingServiceSynchronous(ctx context.Context) (err error) {
 	// notify anyone who might be listening that the app has finished starting.
 	// this can be used by, e.g., app tests.
 	defer close(app.started)
-
-	// Create a contextual logger for local usage (lower-level modules will create their own contextual loggers
-	// using context passed down to them)
-	logger := app.log.WithContext(ctx)
 
 	hostname, err := os.Hostname()
 	if err != nil {
 		return fmt.Errorf("error reading hostname: %w", err)
 	}
 
-	logger.With().Info("starting spacemesh",
-		log.String("data-dir", app.Config.DataDir()),
-		log.String("post-dir", app.Config.SMESHING.Opts.DataDir),
-		log.String("hostname", hostname),
+	app.log.Info("starting spacemesh",
+		zap.String("data-dir", app.config.DataDir()),
+		zap.String("post-dir", app.config.SMESHING.Opts.DataDir),
+		zap.String("hostname", hostname),
 	)
 
-	if err := os.MkdirAll(app.Config.DataDir(), 0o700); err != nil {
+	if err := os.MkdirAll(app.config.DataDir(), 0o700); err != nil {
 		return fmt.Errorf(
 			"data-dir %s not found or could not be created: %w",
-			app.Config.DataDir(),
+			app.config.DataDir(),
 			err,
 		)
 	}
 
 	/* Setup monitoring */
-	app.errCh = make(chan error, 100)
-	if app.Config.PprofHTTPServer {
-		logger.With().Info("starting pprof server", log.String("address", app.Config.PprofHTTPServerListener))
-		app.pprofService = &http.Server{Addr: app.Config.PprofHTTPServerListener}
+	app.errCh = make(chan error, 5)
+	if app.config.PprofHTTPServer {
+		app.log.Info("starting pprof server", zap.String("address", app.config.PprofHTTPServerListener))
+		app.pprofService = &http.Server{}
+		lis, err := net.Listen("tcp", app.config.PprofHTTPServerListener)
+		if err != nil {
+			return fmt.Errorf("starting pprof server: %w", err)
+		}
 		app.eg.Go(func() error {
-			if err := app.pprofService.ListenAndServe(); err != nil {
+			err := app.pprofService.Serve(lis)
+			if err != nil {
 				app.errCh <- fmt.Errorf("cannot start pprof http server: %w", err)
 			}
-			return nil
+			return err
 		})
-		if app.Config.PprofMutexProfile {
+		if app.config.PprofMutexProfile {
 			// this will set the mutex profiling to sample a third of all lock events
 			runtime.SetMutexProfileFraction(3)
 		}
-		if app.Config.PprofBlockProfile {
+		if app.config.PprofBlockProfile {
 			// record block sample for every block event that takes more than 10 milliseconds
 			runtime.SetBlockProfileRate(int(10 * time.Millisecond))
 		}
 	}
 
-	if app.Config.ProfilerURL != "" {
+	if app.config.ProfilerURL != "" {
 		app.profilerService, err = pyroscope.Start(pyroscope.Config{
-			ApplicationName: app.Config.ProfilerName,
-			// app.Config.ProfilerURL should be the pyroscope server address
-			// TODO: AuthToken? no need right now since server isn't public
-			ServerAddress: app.Config.ProfilerURL,
+			ApplicationName: app.config.ProfilerName,
+			ServerAddress:   app.config.ProfilerURL,
 			// by default all profilers are enabled,
 		})
 		if err != nil {
@@ -537,39 +547,40 @@ func (app *App) startSmeshingServiceSynchronous(ctx context.Context) (err error)
 
 	/* Initialize all protocol services */
 	app.clock, err = timesync.NewClock(
-		timesync.WithLayerDuration(app.Config.LayerDuration),
+		timesync.WithLayerDuration(app.config.LayerDuration),
 		timesync.WithTickInterval(1*time.Second),
-		timesync.WithGenesisTime(app.Config.Genesis.GenesisTime.Time()),
-		timesync.WithLogger(app.addLogger(ClockLogger, logger).Zap()),
+		timesync.WithGenesisTime(app.config.Genesis.GenesisTime.Time()),
+		timesync.WithLogger(app.loggers.add(ClockLogger, app.log)),
 	)
 	if err != nil {
 		return fmt.Errorf("cannot create clock: %w", err)
 	}
 
-	if err := app.setupDBs(ctx, logger); err != nil {
+	if err := app.setupDBs(ctx); err != nil {
 		return err
 	}
 
-	if err := app.initSmeshingServiceServices(ctx); err != nil {
+	if err := app.initServices(ctx); err != nil {
 		return fmt.Errorf("init services: %w", err)
 	}
 
-	if app.Config.CollectMetrics {
-		metrics.StartMetricsServer(app.Config.MetricsPort)
+	if app.config.CollectMetrics {
+		metrics.StartMetricsServer(app.config.MetricsPort)
 	}
 
-	if app.Config.PublicMetrics.MetricsURL != "" {
-		id := hash.Sum([]byte(app.host.ID()))
+	if app.config.PublicMetrics.MetricsURL != "" {
 		metrics.StartPushingMetrics(
-			app.Config.PublicMetrics.MetricsURL,
-			app.Config.PublicMetrics.MetricsPushUser,
-			app.Config.PublicMetrics.MetricsPushPass,
-			app.Config.PublicMetrics.MetricsPushHeader,
-			app.Config.PublicMetrics.MetricsPushPeriod,
-			types.Hash32(id).ShortString(), app.Config.Genesis.GenesisID().ShortString())
+			app.config.PublicMetrics.MetricsURL,
+			app.config.PublicMetrics.MetricsPushUser,
+			app.config.PublicMetrics.MetricsPushPass,
+			app.config.PublicMetrics.MetricsPushHeader,
+			app.config.PublicMetrics.MetricsPushPeriod,
+			app.signers[0].NodeID().ShortString(),
+			app.config.Genesis.GenesisID().ShortString(),
+		)
 	}
 
-	if err := app.startSmeshingServiceServices(ctx); err != nil {
+	if err := app.startServices(ctx); err != nil {
 		return fmt.Errorf("start services: %w", err)
 	}
 
@@ -581,4 +592,439 @@ func (app *App) startSmeshingServiceSynchronous(ctx context.Context) (err error)
 	app.log.Info("app started")
 
 	return nil
+}
+
+func (app *SmeshingService) grpcService(svc grpcserver.Service, logger *zap.Logger) (grpcserver.ServiceAPI, error) {
+	if service, ok := app.grpcServices[svc]; ok {
+		return service, nil
+	}
+
+	switch svc {
+	case grpcserver.Debug:
+		service := grpcserver.NewSmeshingServiceDebugService(app.loggers.levels)
+		app.grpcServices[svc] = service
+		return service, nil
+	case grpcserver.Smesher:
+		var sig *signing.EdSigner
+		if len(app.signers) == 1 && app.signers[0].Name() == supervisedIDKeyFileName {
+			// StartSmeshing is only supported in a supervised setup (single signer)
+			sig = app.signers[0]
+		}
+		postService, err := app.grpcService(grpcserver.Post, logger)
+		if err != nil {
+			return nil, err
+		}
+		service := grpcserver.NewSmesherService(
+			app.atxBuilder,
+			app.postSupervisor,
+			postService.(*grpcserver.PostService),
+			app.config.API.SmesherStreamInterval,
+			app.config.SMESHING.Opts,
+			sig,
+		)
+		app.grpcServices[svc] = service
+		return service, nil
+	case grpcserver.Post:
+		service := grpcserver.NewPostService(app.loggers.add(PostServiceLogger, logger))
+		isCoinbaseSet := app.config.SMESHING.CoinbaseAccount != ""
+		if !isCoinbaseSet {
+			app.log.Warn("coinbase account is not set, connections from remote post services will be rejected")
+		}
+		service.AllowConnections(isCoinbaseSet)
+		app.grpcServices[svc] = service
+		return service, nil
+	case grpcserver.PostInfo:
+		service := grpcserver.NewPostInfoService(app.atxBuilder)
+		app.grpcServices[svc] = service
+		return service, nil
+	case v2beta1.SmeshingIdentities:
+		service := v2beta1.NewSmeshingIdentitiesService(app.idStates, app.poetClients, app.config.POET)
+		app.grpcServices[svc] = service
+		return service, nil
+	case v2beta1.Smeshing:
+		service := v2beta1.NewSmeshingService(cmd.Version, cmd.Commit)
+		app.grpcServices[svc] = service
+		return service, nil
+	}
+	return nil, fmt.Errorf("unknown service %s", svc)
+}
+
+func (app *SmeshingService) startAPIServices(ctx context.Context) error {
+	logger := app.loggers.add(GRPCLogger, app.log)
+	grpczap.SetGrpcLoggerV2(grpcLog, logger)
+
+	var (
+		publicSvcs        = make(map[grpcserver.Service]grpcserver.ServiceAPI, len(app.config.API.PublicServices))
+		privateSvcs       = make(map[grpcserver.Service]grpcserver.ServiceAPI, len(app.config.API.PrivateServices))
+		postSvcs          = make(map[grpcserver.Service]grpcserver.ServiceAPI, len(app.config.API.PostServices))
+		authenticatedSvcs = make(map[grpcserver.Service]grpcserver.ServiceAPI, len(app.config.API.TLSServices))
+	)
+
+	// check services for uniques across all endpoints
+	for _, svc := range app.config.API.PublicServices {
+		if _, exists := publicSvcs[svc]; exists {
+			return fmt.Errorf("can't start more than one %s on public grpc endpoint", svc)
+		}
+		gsvc, err := app.grpcService(svc, app.log)
+		if err != nil {
+			return err
+		}
+		logger.Info("registering public service", zap.String("name", svc))
+		publicSvcs[svc] = gsvc
+	}
+	for _, svc := range app.config.API.PrivateServices {
+		if _, exists := privateSvcs[svc]; exists {
+			return fmt.Errorf("can't start more than one %s on private grpc endpoint", svc)
+		}
+		gsvc, err := app.grpcService(svc, app.log)
+		if err != nil {
+			return err
+		}
+		logger.Info("registering private service", zap.String("name", svc))
+		privateSvcs[svc] = gsvc
+	}
+	for _, svc := range app.config.API.PostServices {
+		if _, exists := postSvcs[svc]; exists {
+			return fmt.Errorf("can't start more than one %s on post grpc endpoint", svc)
+		}
+		gsvc, err := app.grpcService(svc, app.log)
+		if err != nil {
+			return err
+		}
+		logger.Info("registering post service", zap.String("name", svc))
+		postSvcs[svc] = gsvc
+	}
+	for _, svc := range app.config.API.TLSServices {
+		if _, exists := authenticatedSvcs[svc]; exists {
+			return fmt.Errorf("can't start more than one %s on authenticated grpc endpoint", svc)
+		}
+		gsvc, err := app.grpcService(svc, app.log)
+		if err != nil {
+			return err
+		}
+		logger.Info("registering authenticated service", zap.String("name", svc))
+		authenticatedSvcs[svc] = gsvc
+	}
+
+	// start servers if at least one endpoint is defined for them
+	if len(publicSvcs) > 0 {
+		var err error
+		app.grpcPublicServer, err = grpcserver.NewWithServices(
+			app.config.API.PublicListener,
+			logger,
+			app.config.API,
+			slices.Collect(maps.Values(publicSvcs)),
+			// public server needs restriction on max connection age to prevent attacks
+			grpc.KeepaliveParams(keepalive.ServerParameters{
+				MaxConnectionIdle:     2 * time.Hour,
+				MaxConnectionAge:      3 * time.Hour,
+				MaxConnectionAgeGrace: 10 * time.Minute,
+				Time:                  time.Minute,
+				Timeout:               10 * time.Second,
+			}),
+		)
+		if err != nil {
+			return err
+		}
+		if err := app.grpcPublicServer.Start(); err != nil {
+			return err
+		}
+		logger.Info("public grpc service started",
+			zap.String("address", app.config.API.PublicListener),
+			zap.Array("services", zapcore.ArrayMarshalerFunc(func(encoder zapcore.ArrayEncoder) error {
+				for _, svc := range slices.Sorted(maps.Keys(publicSvcs)) {
+					encoder.AppendString(svc)
+				}
+				return nil
+			})),
+		)
+	}
+	if len(privateSvcs) > 0 {
+		var err error
+		app.grpcPrivateServer, err = grpcserver.NewWithServices(
+			app.config.API.PrivateListener,
+			logger,
+			app.config.API,
+			slices.Collect(maps.Values(privateSvcs)),
+		)
+		if err != nil {
+			return err
+		}
+		if err := app.grpcPrivateServer.Start(); err != nil {
+			return err
+		}
+		logger.Info("private grpc service started",
+			zap.String("address", app.config.API.PrivateListener),
+			zap.Array("services", zapcore.ArrayMarshalerFunc(func(encoder zapcore.ArrayEncoder) error {
+				for _, svc := range slices.Sorted(maps.Keys(privateSvcs)) {
+					encoder.AppendString(svc)
+				}
+				return nil
+			})),
+		)
+	}
+	if len(postSvcs) > 0 && app.config.API.PostListener != "" {
+		var err error
+		app.grpcPostServer, err = grpcserver.NewWithServices(
+			app.config.API.PostListener,
+			logger,
+			app.config.API,
+			slices.Collect(maps.Values(postSvcs)),
+		)
+		if err != nil {
+			return err
+		}
+		if err := app.grpcPostServer.Start(); err != nil {
+			return err
+		}
+		logger.Info("post grpc service started",
+			zap.String("address", app.config.API.PostListener),
+			zap.Array("services", zapcore.ArrayMarshalerFunc(func(encoder zapcore.ArrayEncoder) error {
+				for _, svc := range slices.Sorted(maps.Keys(postSvcs)) {
+					encoder.AppendString(svc)
+				}
+				return nil
+			})),
+		)
+
+		host, port, err := net.SplitHostPort(app.grpcPostServer.BoundAddress)
+		if err != nil {
+			return fmt.Errorf("parse grpc-post-listener: %w", err)
+		}
+		ip := net.ParseIP(host)
+		if ip.IsUnspecified() { // 0.0.0.0 isn't a valid address to connect to on windows
+			host = "127.0.0.1"
+		}
+		app.config.POSTService.NodeAddress = fmt.Sprintf("http://%s:%s", host, port)
+		svc, err := app.grpcService(grpcserver.Smesher, app.log)
+		if err != nil {
+			return err
+		}
+		svc.(*grpcserver.SmesherService).SetPostServiceConfig(app.config.POSTService)
+		if app.config.SMESHING.Start {
+			if app.config.SMESHING.CoinbaseAccount == "" {
+				return errors.New("smeshing enabled but no coinbase account provided")
+			}
+			if len(app.signers) > 1 || app.signers[0].Name() != supervisedIDKeyFileName {
+				app.log.Error("supervised smeshing cannot be started in a remote or multi-smeshing setup")
+				app.log.Sugar().Errorf(
+					"if you run a supervised node ensure your key file is named %s and try again",
+					supervisedIDKeyFileName,
+				)
+				return errors.New("smeshing enabled in remote setup")
+			}
+			if err := app.postSupervisor.Start(
+				app.config.POSTService,
+				app.config.SMESHING.Opts,
+				app.signers[0],
+			); err != nil {
+				return fmt.Errorf("start post service: %w", err)
+			}
+		} else if len(app.signers) == 1 && app.signers[0].Name() == supervisedIDKeyFileName {
+			// supervised setup but not started
+			app.log.Info("smeshing not started, waiting to be triggered via smesher api")
+		}
+	}
+
+	if len(authenticatedSvcs) > 0 && app.config.API.TLSListener != "" {
+		var err error
+		app.grpcTLSServer, err = grpcserver.NewTLS(
+			logger,
+			app.config.API,
+			slices.Collect(maps.Values(authenticatedSvcs)),
+		)
+		if err != nil {
+			return err
+		}
+		if err := app.grpcTLSServer.Start(); err != nil {
+			return err
+		}
+		logger.Info("authenticated grpc service started",
+			zap.String("address", app.config.API.TLSListener),
+			zap.Array("services", zapcore.ArrayMarshalerFunc(func(encoder zapcore.ArrayEncoder) error {
+				for _, svc := range slices.Sorted(maps.Keys(authenticatedSvcs)) {
+					encoder.AppendString(svc)
+				}
+				return nil
+			})),
+		)
+	}
+
+	if len(app.config.API.JSONListener) > 0 {
+		if len(publicSvcs) == 0 {
+			return errors.New("start json server without public services")
+		}
+		if len(app.config.API.ProxyApiV2Address) > 0 {
+			var localSvcs []proxy.Service
+			for _, svcName := range app.config.API.NonProxiedServices {
+				svc, err := app.grpcService(svcName, logger)
+				if err != nil {
+					return fmt.Errorf("creating smeshing id service: %w", err)
+				}
+				if svc, ok := svc.(proxy.Service); ok {
+					localSvcs = append(localSvcs, svc)
+				} else {
+					return fmt.Errorf("cannot use service %q as non-proxied local service", svcName)
+				}
+			}
+
+			p, err := proxy.NewServer(
+				app.config.API.JSONListener,
+				app.config.API.ProxyApiV2Address,
+				app.config.API.JSONCorsEverywhere,
+				logger,
+				localSvcs...,
+			)
+			if err != nil {
+				return err
+			}
+			app.apiProxy = p
+
+			if err = p.Start(); err != nil {
+				return err
+			}
+			logger.Info("json proxy listener started",
+				zap.String("address", app.config.API.JSONListener),
+				zap.String("proxying to", app.config.API.ProxyApiV2Address),
+				zap.Array("services", zapcore.ArrayMarshalerFunc(func(encoder zapcore.ArrayEncoder) error {
+					for _, svc := range slices.Sorted(maps.Keys(publicSvcs)) {
+						encoder.AppendString(svc)
+					}
+					return nil
+				})),
+			)
+		} else {
+			app.jsonAPIServer = grpcserver.NewJSONHTTPServer(
+				logger.Named("JSON"),
+				app.config.API.JSONListener,
+				app.config.API.JSONCorsAllowedOrigins,
+				app.config.API.JSONCorsEverywhere,
+				app.config.CollectMetrics,
+			)
+
+			if err := app.jsonAPIServer.StartService(slices.Collect(maps.Values(publicSvcs))...); err != nil {
+				return fmt.Errorf("start listen server: %w", err)
+			}
+			logger.Info("json listener started",
+				zap.String("address", app.config.API.JSONListener),
+				zap.Array("services", zapcore.ArrayMarshalerFunc(func(encoder zapcore.ArrayEncoder) error {
+					for _, svc := range slices.Sorted(maps.Keys(publicSvcs)) {
+						encoder.AppendString(svc)
+					}
+					return nil
+				})),
+			)
+		}
+	}
+
+	return nil
+}
+
+func (app *SmeshingService) setupDBs(ctx context.Context) error {
+	dbLog := app.loggers.add(StateDbLogger, app.log)
+	// FIXME: remove need for state DB
+	db, err := openStateDB(app.config, dbLog)
+	if err != nil {
+		return err
+	}
+	app.db = db
+
+	if app.config.CollectMetrics && app.config.DatabaseSizeMeteringInterval != 0 {
+		app.dbMetrics = dbmetrics.NewDBMetricsCollector(
+			ctx,
+			app.db,
+			dbLog,
+			app.config.DatabaseSizeMeteringInterval,
+		)
+	}
+
+	localDB, err := openLocalDb(app.config, dbLog)
+	if err != nil {
+		return err
+	}
+
+	app.localDB = localDB
+	return nil
+}
+
+func (app *SmeshingService) stopServices(ctx context.Context) {
+	app.log.Info("app stopping services...")
+	defer app.log.Info("...finished stopping services")
+
+	if app.jsonAPIServer != nil {
+		if err := app.jsonAPIServer.Shutdown(ctx); err != nil {
+			app.log.Error("error stopping json gateway server", zap.Error(err))
+		}
+	}
+	if app.grpcPublicServer != nil {
+		app.log.Info("stopping public grpc service")
+		app.grpcPublicServer.Close() // err is always nil
+	}
+	if app.grpcPrivateServer != nil {
+		app.log.Info("stopping private grpc service")
+		app.grpcPrivateServer.Close() // err is always nil
+	}
+	if app.grpcPostServer != nil {
+		app.log.Info("stopping local grpc service")
+		app.grpcPostServer.Close() // err is always nil
+	}
+	if app.grpcTLSServer != nil {
+		app.log.Info("stopping tls grpc service")
+		app.grpcTLSServer.Close() // err is always nil
+	}
+
+	if app.clock != nil {
+		app.clock.Close()
+	}
+
+	if app.atxBuilder != nil {
+		app.atxBuilder.StopSmeshing(false)
+	}
+
+	if app.postVerifier != nil {
+		app.postVerifier.Close()
+	}
+
+	if app.postSupervisor != nil {
+		if err := app.postSupervisor.Stop(false); err != nil {
+			app.log.Error("error stopping local post service", zap.Error(err))
+		}
+	}
+
+	if app.db != nil {
+		if err := app.db.Close(); err != nil {
+			app.log.Warn("db exited with error", zap.Error(err))
+		}
+	}
+	if app.dbMetrics != nil {
+		app.dbMetrics.Close()
+	}
+	if app.localDB != nil {
+		if err := app.localDB.Close(); err != nil {
+			app.log.Warn("local db exited with error", zap.Error(err))
+		}
+	}
+
+	if app.pprofService != nil {
+		if err := app.pprofService.Close(); err != nil {
+			app.log.Warn("pprof service exited with error", zap.Error(err))
+		}
+	}
+	if app.profilerService != nil {
+		if err := app.profilerService.Stop(); err != nil {
+			app.log.Warn("profiler service exited with error", zap.Error(err))
+		}
+	}
+	if app.apiProxy != nil {
+		if err := app.apiProxy.Stop(); err != nil {
+			app.log.Warn("proxy server exited with error", zap.Error(err))
+		}
+	}
+	app.eg.Wait()
+
+	events.CloseEventReporter()
+	// SetGrpcLogger unfortunately is global
+	// this ensures that a test-logger isn't used after the app shuts down
+	// by e.g. a grpc connection to the node that is still open - like in TestSpacemeshApp_NodeService
+	grpczap.SetGrpcLoggerV2(grpcLog, zap.NewNop())
 }

--- a/node/smeshing_service.go
+++ b/node/smeshing_service.go
@@ -71,10 +71,6 @@ func GetSmeshingServiceCommand() *cobra.Command {
 			lg.Info(getAppInfo(conf.Genesis))
 			lg.Info("Welcome to Spacemesh. Spacemesh activation service is starting...")
 
-			app, err := NewSmeshingService(&conf, lg)
-			if err != nil {
-				return fmt.Errorf("creating smeshing service app: %w", err)
-			}
 			unlock, err := lock(conf.FileLock)
 			if err != nil {
 				return err
@@ -84,6 +80,11 @@ func GetSmeshingServiceCommand() *cobra.Command {
 					lg.Error("failed to unlock file", zap.String("path", conf.FileLock), zap.Error(err))
 				}
 			}()
+
+			app, err := NewSmeshingService(&conf, lg)
+			if err != nil {
+				return fmt.Errorf("creating smeshing service app: %w", err)
+			}
 
 			// os.Interrupt for all systems, especially windows, syscall.SIGTERM is mainly for docker.
 			ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)

--- a/node/smeshing_service.go
+++ b/node/smeshing_service.go
@@ -204,14 +204,13 @@ func NewSmeshingService(cfg *config.Config, logger *zap.Logger) (*SmeshingServic
 	layersPerEpoch := types.GetLayersPerEpoch()
 
 	var nodeServiceClient *client.NodeService
-	listenAddress := cfg.BaseConfig.NodeServiceAddress
 	nodeClientLog := loggers.add(NodeServiceClientLogger, logger)
 	nodeClientCfg := &nodeclient.Config{
 		RetryWaitMin: time.Second,
 		RetryWaitMax: time.Second * 30,
 		RetryMax:     10,
 	}
-	nodeServiceClient, err = nodeclient.NewNodeServiceClient(listenAddress, nodeClientLog, nodeClientCfg)
+	nodeServiceClient, err = nodeclient.NewNodeServiceClient(cfg.NodeServiceAddress, nodeClientLog, nodeClientCfg)
 	if err != nil {
 		return nil, fmt.Errorf("creating node service client: %w", err)
 	}

--- a/node/smeshing_service.go
+++ b/node/smeshing_service.go
@@ -9,6 +9,7 @@ import (
 	"maps"
 	"net"
 	"net/http"
+	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -503,10 +504,12 @@ func (app *SmeshingService) start(ctx context.Context) (err error) {
 	/* Setup monitoring */
 	if app.config.PprofHTTPServer {
 		app.log.Info("starting pprof server", zap.String("address", app.config.PprofHTTPServerListener))
-		app.pprofService = &http.Server{}
 		lis, err := net.Listen("tcp", app.config.PprofHTTPServerListener)
 		if err != nil {
 			return fmt.Errorf("starting pprof server: %w", err)
+		}
+		app.pprofService = &http.Server{
+			Addr: lis.Addr().String(),
 		}
 		app.eg.Go(func() error {
 			err := app.pprofService.Serve(lis)

--- a/node/smeshing_service.go
+++ b/node/smeshing_service.go
@@ -45,7 +45,6 @@ import (
 	"github.com/spacemeshos/go-spacemesh/miner"
 	"github.com/spacemeshos/go-spacemesh/signing"
 	"github.com/spacemeshos/go-spacemesh/sql"
-	dbmetrics "github.com/spacemeshos/go-spacemesh/sql/metrics"
 	"github.com/spacemeshos/go-spacemesh/timesync"
 )
 
@@ -128,11 +127,13 @@ func GetSmeshingServiceCommand() *cobra.Command {
 }
 
 type SmeshingService struct {
-	signers           []*signing.EdSigner
-	config            *config.Config
-	db                sql.StateDatabase // FIXME: remove
-	dbMetrics         *dbmetrics.DBMetricsCollector
-	localDB           sql.LocalDatabase
+	log     *zap.Logger
+	loggers *loggers
+	signers []*signing.EdSigner
+	config  *config.Config
+	db      sql.StateDatabase // FIXME: remove
+	localDB sql.LocalDatabase
+
 	grpcPublicServer  *grpcserver.Server
 	grpcPrivateServer *grpcserver.Server
 	grpcPostServer    *grpcserver.Server
@@ -141,23 +142,20 @@ type SmeshingService struct {
 	grpcServices      map[grpcserver.Service]grpcserver.ServiceAPI
 	pprofService      *http.Server
 	profilerService   *pyroscope.Profiler
-	proposalsBuilder  *miner.RemoteProposalBuilder
-	clock             *timesync.NodeClock
-	remoteHare        *hare3.RemoteHare
-	atxBuilder        *activation.Builder
-	validator         *activation.Validator
-	log               *zap.Logger
-	postVerifier      activation.PostVerifier
-	postSupervisor    *activation.PostSupervisor
-	idStates          *identity.StateStorage
 	apiProxy          *proxy.Server
-	poetClients       []activation.PoetService
 
-	errCh chan error
+	proposalsBuilder *miner.RemoteProposalBuilder
+	clock            *timesync.NodeClock
+	remoteHare       *hare3.RemoteHare
+	atxBuilder       *activation.Builder
+	postVerifier     activation.PostVerifier
+	postSupervisor   *activation.PostSupervisor
+	idStates         *identity.StateStorage
+	poetClients      []activation.PoetService
 
-	loggers *loggers
-	eg      errgroup.Group
 	started chan struct{}
+	errCh   chan error
+	eg      errgroup.Group
 }
 
 func NewSmeshingService(cfg *config.Config, logger *zap.Logger) (*SmeshingService, error) {
@@ -172,6 +170,15 @@ func NewSmeshingService(cfg *config.Config, logger *zap.Logger) (*SmeshingServic
 	// ensure all data folders exist
 	if err := os.MkdirAll(cfg.DataDir(), 0o700); err != nil {
 		return nil, fmt.Errorf("ensure folders exist: %w", err)
+	}
+
+	if err := verifyLocalDbMigrations(cfg); err != nil {
+		return nil, fmt.Errorf("version upgrade verification failed: %w", err)
+	}
+
+	localDB, stateDB, err := setupDBs(cfg, loggers.add(StateDbLogger, logger))
+	if err != nil {
+		return nil, err
 	}
 
 	signers, err := loadIdentities(cfg.DataDir(), cfg.Genesis.GenesisID(), logger)
@@ -192,85 +199,61 @@ func NewSmeshingService(cfg *config.Config, logger *zap.Logger) (*SmeshingServic
 		return nil, err
 	}
 
-	return &SmeshingService{
-		config:       cfg,
-		loggers:      loggers,
-		log:          logger,
-		signers:      signers,
-		grpcServices: make(map[grpcserver.Service]grpcserver.ServiceAPI),
-		started:      make(chan struct{}),
-	}, nil
-}
-
-func (app *SmeshingService) initServices(ctx context.Context) error {
-	layerSize := app.config.LayerAvgSize
+	layerSize := cfg.LayerAvgSize
 	layersPerEpoch := types.GetLayersPerEpoch()
-	lg := app.log
 
 	var nodeServiceClient *client.NodeService
-	listenAddress := app.config.BaseConfig.NodeServiceAddress
-	logger := app.loggers.add(NodeServiceClientLogger, lg)
-	cfg := &nodeclient.Config{
+	listenAddress := cfg.BaseConfig.NodeServiceAddress
+	nodeClientLog := loggers.add(NodeServiceClientLogger, logger)
+	nodeClientCfg := &nodeclient.Config{
 		RetryWaitMin: time.Second,
 		RetryWaitMax: time.Second * 30,
 		RetryMax:     10,
 	}
-	var err error
-	nodeServiceClient, err = nodeclient.NewNodeServiceClient(listenAddress, logger, cfg)
+	nodeServiceClient, err = nodeclient.NewNodeServiceClient(listenAddress, nodeClientLog, nodeClientCfg)
 	if err != nil {
-		return fmt.Errorf("creating node service client: %w", err)
+		return nil, fmt.Errorf("creating node service client: %w", err)
 	}
 
 	poetDb, err := activation.NewPoetDb(
-		app.db,
-		app.loggers.add(PoetDbLogger, lg),
-		activation.WithCacheSize(app.config.POET.PoetProofsCache),
+		stateDB,
+		loggers.add(PoetDbLogger, logger),
+		activation.WithCacheSize(cfg.POET.PoetProofsCache),
 	)
 	if err != nil {
-		return fmt.Errorf("creating poet db: %w", err)
+		return nil, fmt.Errorf("creating poet db: %w", err)
 	}
-	postStates := activation.NewPostStates(app.loggers.add(PostLogger, lg))
+	idStates := identity.NewIdentityStateStorage(localDB, logger)
 
-	app.idStates = identity.NewIdentityStateStorage(app.localDB, app.log)
-
-	opts := []activation.PostVerifierOpt{
-		activation.WithVerifyingOpts(app.config.SMESHING.VerifyingOpts),
-		activation.WithAutoscaling(postStates),
-	}
-	for _, sig := range app.signers {
-		opts = append(opts, activation.WithPrioritizedID(sig.NodeID()))
-	}
-
-	verifier, err := activation.NewPostVerifier(
-		app.config.POST,
-		app.loggers.add(NipostValidatorLogger, lg),
-		opts...,
+	postVerifier, err := activation.NewPostVerifier(
+		cfg.POST,
+		loggers.add(NipostValidatorLogger, logger),
+		activation.WithVerifyingOpts(cfg.SMESHING.VerifyingOpts),
 	)
 	if err != nil {
-		return fmt.Errorf("creating post verifier: %w", err)
+		return nil, fmt.Errorf("creating post verifier: %w", err)
 	}
-	app.postVerifier = verifier
 
-	app.validator = activation.NewValidator(
-		app.db,
+	validator := activation.NewValidator(
+		stateDB,
 		poetDb,
-		app.config.POST,
-		app.config.SMESHING.Opts.Scrypt,
-		app.postVerifier,
+		cfg.POST,
+		cfg.SMESHING.Opts.Scrypt,
+		postVerifier,
 	)
 
-	goldenATXID := types.ATXID(app.config.Genesis.GoldenATX())
+	goldenATXID := types.ATXID(cfg.Genesis.GoldenATX())
 	if goldenATXID == types.EmptyATXID {
-		return errors.New("invalid golden atx id")
+		return nil, errors.New("invalid golden atx id")
 	}
 
 	// we can't have an epoch offset which is greater/equal than the number of layers in an epoch
-	if app.config.HareEligibility.ConfidenceParam >= app.config.BaseConfig.LayersPerEpoch {
-		return fmt.Errorf(
+	if cfg.HareEligibility.ConfidenceParam >= cfg.BaseConfig.LayersPerEpoch {
+		return nil, fmt.Errorf(
 			"confidence param should be smaller than layers per epoch. eligibility-confidence-param: %d. "+
 				"layers-per-epoch: %d",
-			app.config.HareEligibility.ConfidenceParam,
-			app.config.BaseConfig.LayersPerEpoch,
+			cfg.HareEligibility.ConfidenceParam,
+			cfg.BaseConfig.LayersPerEpoch,
 		)
 	}
 
@@ -280,133 +263,140 @@ func (app *SmeshingService) initServices(ctx context.Context) error {
 		cachedWeights,
 		beaconProvider,
 		signing.NewVRFVerifier(),
-		app.config.LayersPerEpoch,
-		eligibility.WithConfig(app.config.HareEligibility),
-		eligibility.WithLogger(app.loggers.add(HareOracleLogger, lg)),
+		cfg.LayersPerEpoch,
+		eligibility.WithConfig(cfg.HareEligibility),
+		eligibility.WithLogger(loggers.add(HareOracleLogger, logger)),
 	)
 	if err != nil {
-		return fmt.Errorf("create hare oracle: %w", err)
+		return nil, fmt.Errorf("create hare oracle: %w", err)
 	}
 
-	err = app.config.HARE3.Validate(time.Duration(app.config.Tortoise.Zdist) * app.config.LayerDuration)
+	clock, err := timesync.NewClock(
+		timesync.WithLayerDuration(cfg.LayerDuration),
+		timesync.WithTickInterval(1*time.Second),
+		timesync.WithGenesisTime(cfg.Genesis.GenesisTime.Time()),
+		timesync.WithLogger(loggers.add(ClockLogger, logger)),
+	)
 	if err != nil {
-		return err
+		return nil, fmt.Errorf("cannot create clock: %w", err)
 	}
-	logger = app.loggers.add(HareLogger, lg)
-	app.remoteHare = hare3.NewRemoteHare(
-		app.config.HARE3,
-		app.clock,
+
+	if err := cfg.HARE3.Validate(time.Duration(cfg.Tortoise.Zdist) * cfg.LayerDuration); err != nil {
+		return nil, err
+	}
+	remoteHare := hare3.NewRemoteHare(
+		cfg.HARE3,
+		clock,
 		nodeServiceClient,
 		beaconProvider,
 		hOracle,
-		logger,
+		loggers.add(HareLogger, logger),
 	)
-	for _, sig := range app.signers {
-		app.remoteHare.Register(sig)
+	for _, sig := range signers {
+		remoteHare.Register(sig)
 	}
-	app.remoteHare.Start(ctx)
 
-	remoteProposalBuilder := miner.NewRemoteBuilder(
-		app.clock,
+	proposalBuilder := miner.NewRemoteBuilder(
+		clock,
 		nodeServiceClient,
 		beaconProvider,
 		nodeServiceClient,
 		layerSize,
 		layersPerEpoch,
-		app.loggers.add(ProposalBuilderLogger, lg),
-		app.idStates,
+		loggers.add(ProposalBuilderLogger, logger),
+		idStates,
 	)
-	for _, sig := range app.signers {
-		remoteProposalBuilder.Register(sig)
+	for _, sig := range signers {
+		proposalBuilder.Register(sig)
 	}
-	app.proposalsBuilder = remoteProposalBuilder
 
 	postSetupMgr, err := activation.NewPostSetupManager(
-		app.config.POST,
-		app.loggers.add(PostLogger, lg),
-		app.db,
+		cfg.POST,
+		loggers.add(PostLogger, logger),
+		stateDB,
 		atxsdata.New(), // FIXME: remove this dependency
 		goldenATXID,
 		nil,
-		app.validator,
-		activation.PostValidityDelay(app.config.PostValidDelay),
+		validator,
+		activation.PostValidityDelay(cfg.PostValidDelay),
 	)
 	if err != nil {
-		return fmt.Errorf("create post setup manager: %v", err)
+		return nil, fmt.Errorf("create post setup manager: %v", err)
 	}
 
-	grpcPostService, err := app.grpcService(grpcserver.Post, lg)
-	if err != nil {
-		return fmt.Errorf("init post grpc service: %w", err)
-	}
-
-	nipostLogger := app.loggers.add(NipostBuilderLogger, lg)
+	nipostLogger := loggers.add(NipostBuilderLogger, logger)
 	client := activation.NewCertifierClient(
-		app.db,
-		app.localDB,
+		stateDB,
+		localDB,
 		nipostLogger,
-		activation.WithCertifierClientConfig(app.config.Certifier.Client),
+		activation.WithCertifierClientConfig(cfg.Certifier.Client),
 	)
-	poetCertifier := activation.NewCertifier(app.localDB, nipostLogger, client)
+	poetCertifier := activation.NewCertifier(localDB, nipostLogger, client)
 
-	poetClients := make([]activation.PoetService, 0, len(app.config.PoetServers))
-	for _, server := range app.config.PoetServers {
+	poetClients := make([]activation.PoetService, 0, len(cfg.PoetServers))
+	for _, server := range cfg.PoetServers {
 		client, err := activation.NewPoetService(
 			poetDb,
 			server,
-			app.config.POET,
-			app.loggers.add("poet", app.log),
-			app.config.TickSize,
+			cfg.POET,
+			loggers.add(PoetLogger, logger),
+			cfg.TickSize,
 			activation.WithCertifier(poetCertifier),
 		)
 		if err != nil {
-			app.log.Sugar().Panicf("failed to create poet client with address %v: %v", server.Address, err)
+			return nil, fmt.Errorf("creating poet client for %s: %w", server, err)
 		}
 		poetClients = append(poetClients, client)
 	}
-	app.poetClients = poetClients
+	grpcServices := make(map[grpcserver.Service]grpcserver.ServiceAPI)
+
+	grpcPostService := grpcserver.NewPostService(loggers.add(PostServiceLogger, logger))
+	isCoinbaseSet := cfg.SMESHING.CoinbaseAccount != ""
+	if !isCoinbaseSet {
+		logger.Warn("coinbase account is not set, connections from remote post services will be rejected")
+	}
+	grpcPostService.AllowConnections(isCoinbaseSet)
+	grpcServices[grpcserver.Post] = grpcPostService
 
 	nipostBuilder, err := activation.NewNIPostBuilder(
-		app.localDB,
-		grpcPostService.(*grpcserver.PostService),
+		localDB,
+		grpcPostService,
 		nipostLogger,
-		app.config.POET,
-		app.clock,
-		app.validator,
-		activation.NipostbuilderWithPostStates(postStates),
-		activation.NipostbuilderWithIdentityStates(app.idStates),
+		cfg.POET,
+		clock,
+		validator,
+		activation.NipostbuilderWithIdentityStates(idStates),
 		activation.WithPoetServices(poetClients...),
 	)
 	if err != nil {
-		return fmt.Errorf("create nipost builder: %w", err)
+		return nil, fmt.Errorf("create nipost builder: %w", err)
 	}
 
 	builderConfig := activation.Config{
 		GoldenATXID:      goldenATXID,
-		RegossipInterval: app.config.RegossipAtxInterval,
+		RegossipInterval: cfg.RegossipAtxInterval,
 	}
 
 	atxBuilder := activation.NewBuilder(
 		builderConfig,
-		app.localDB,
+		localDB,
 		poetDb,
 		nodeServiceClient,
 		nodeServiceClient,
-		app.validator,
+		validator,
 		nipostBuilder,
-		app.clock,
+		clock,
 		alwaysSyncedSyncer{},
-		app.loggers.add(ATXBuilderLogger, lg),
-		activation.WithPoetConfig(app.config.POET),
+		loggers.add(ATXBuilderLogger, logger),
+		activation.WithPoetConfig(cfg.POET),
 		// TODO(dshulyak) makes no sense. how we ended using it?
-		activation.WithPoetRetryInterval(app.config.HARE3.PreroundDelay),
-		activation.WithPostStates(postStates),
-		activation.WithIdentityStates(app.idStates),
+		activation.WithPoetRetryInterval(cfg.HARE3.PreroundDelay),
+		activation.WithIdentityStates(idStates),
 		activation.WithPoets(poetClients...),
-		activation.BuilderAtxVersions(app.config.AtxVersions),
+		activation.BuilderAtxVersions(cfg.AtxVersions),
 	)
 
-	if len(app.signers) > 1 || app.signers[0].Name() != supervisedIDKeyFileName {
+	if len(signers) > 1 || signers[0].Name() != supervisedIDKeyFileName {
 		// in a remote setup we register eagerly so the atxBuilder can warn about missing connections asap.
 		// Any setup with more than one signer is considered a remote setup. If there is only one signer it
 		// is considered a remote setup if the key for the signer has not been sourced from `supervisedIDKeyFileName`.
@@ -414,27 +404,46 @@ func (app *SmeshingService) initServices(ctx context.Context) error {
 		// In a supervised setup the postSetupManager will register at the atxBuilder when
 		// it finished initializing, to avoid warning about a missing connection when the supervised post
 		// service isn't ready yet.
-		for _, sig := range app.signers {
+		for _, sig := range signers {
 			atxBuilder.Register(sig)
 		}
 	}
-	app.postSupervisor = activation.NewPostSupervisor(
-		app.log,
-		app.config.POST,
-		app.config.SMESHING.ProvingOpts,
+	postSupervisor := activation.NewPostSupervisor(
+		logger,
+		cfg.POST,
+		cfg.SMESHING.ProvingOpts,
 		postSetupMgr,
 		atxBuilder,
 	)
 	if err != nil {
-		return fmt.Errorf("init post service: %w", err)
+		return nil, fmt.Errorf("init post service: %w", err)
 	}
 
-	app.atxBuilder = atxBuilder
+	return &SmeshingService{
+		db:           stateDB,
+		localDB:      localDB,
+		config:       cfg,
+		loggers:      loggers,
+		log:          logger,
+		signers:      signers,
+		grpcServices: grpcServices,
 
-	return nil
+		proposalsBuilder: proposalBuilder,
+		clock:            clock,
+		remoteHare:       remoteHare,
+		atxBuilder:       atxBuilder,
+		postVerifier:     postVerifier,
+		postSupervisor:   postSupervisor,
+		idStates:         idStates,
+		poetClients:      poetClients,
+
+		errCh:   make(chan error, 5),
+		started: make(chan struct{}),
+	}, nil
 }
 
 func (app *SmeshingService) startServices(ctx context.Context) error {
+	app.remoteHare.Start(ctx)
 	app.eg.Go(func() error {
 		return app.proposalsBuilder.Run(ctx)
 	})
@@ -460,19 +469,11 @@ func (app *SmeshingService) startServices(ctx context.Context) error {
 // initializes all relevant services according to command line
 // arguments provided.
 func (app *SmeshingService) Start(ctx context.Context) error {
-	if err := verifyLocalDbMigrations(app.config); err != nil {
-		return fmt.Errorf("version upgrade verification failed: %w", err)
-	}
-
-	err := app.startSmeshingServiceSynchronous(ctx)
+	err := app.start(ctx)
 	if err != nil {
 		app.log.Error("failed to start App", zap.Error(err))
 		return err
 	}
-	defer events.ReportError(events.NodeError{
-		Msg:   "node is shutting down",
-		Level: zapcore.InfoLevel,
-	})
 
 	// app blocks until it receives a signal to exit
 	// this signal may come from the node or from sig-abort (ctrl-c)
@@ -484,32 +485,22 @@ func (app *SmeshingService) Start(ctx context.Context) error {
 	}
 }
 
-func (app *SmeshingService) startSmeshingServiceSynchronous(ctx context.Context) (err error) {
-	// notify anyone who might be listening that the app has finished starting.
-	// this can be used by, e.g., app tests.
+func (app *SmeshingService) start(ctx context.Context) (err error) {
 	defer close(app.started)
 
 	hostname, err := os.Hostname()
 	if err != nil {
-		return fmt.Errorf("error reading hostname: %w", err)
+		app.log.Warn("couldn't read hostname", zap.Error(err))
+		hostname = "unknown"
 	}
 
-	app.log.Info("starting spacemesh",
+	app.log.Info("starting smeshing service",
 		zap.String("data-dir", app.config.DataDir()),
 		zap.String("post-dir", app.config.SMESHING.Opts.DataDir),
 		zap.String("hostname", hostname),
 	)
 
-	if err := os.MkdirAll(app.config.DataDir(), 0o700); err != nil {
-		return fmt.Errorf(
-			"data-dir %s not found or could not be created: %w",
-			app.config.DataDir(),
-			err,
-		)
-	}
-
 	/* Setup monitoring */
-	app.errCh = make(chan error, 5)
 	if app.config.PprofHTTPServer {
 		app.log.Info("starting pprof server", zap.String("address", app.config.PprofHTTPServerListener))
 		app.pprofService = &http.Server{}
@@ -543,25 +534,6 @@ func (app *SmeshingService) startSmeshingServiceSynchronous(ctx context.Context)
 		if err != nil {
 			return fmt.Errorf("cannot start profiling client: %w", err)
 		}
-	}
-
-	/* Initialize all protocol services */
-	app.clock, err = timesync.NewClock(
-		timesync.WithLayerDuration(app.config.LayerDuration),
-		timesync.WithTickInterval(1*time.Second),
-		timesync.WithGenesisTime(app.config.Genesis.GenesisTime.Time()),
-		timesync.WithLogger(app.loggers.add(ClockLogger, app.log)),
-	)
-	if err != nil {
-		return fmt.Errorf("cannot create clock: %w", err)
-	}
-
-	if err := app.setupDBs(ctx); err != nil {
-		return err
-	}
-
-	if err := app.initServices(ctx); err != nil {
-		return fmt.Errorf("init services: %w", err)
 	}
 
 	if app.config.CollectMetrics {
@@ -920,31 +892,19 @@ func (app *SmeshingService) startAPIServices(ctx context.Context) error {
 	return nil
 }
 
-func (app *SmeshingService) setupDBs(ctx context.Context) error {
-	dbLog := app.loggers.add(StateDbLogger, app.log)
+func setupDBs(cfg *config.Config, logger *zap.Logger) (sql.LocalDatabase, sql.StateDatabase, error) {
 	// FIXME: remove need for state DB
-	db, err := openStateDB(app.config, dbLog)
+	db, err := openStateDB(cfg, logger)
 	if err != nil {
-		return err
-	}
-	app.db = db
-
-	if app.config.CollectMetrics && app.config.DatabaseSizeMeteringInterval != 0 {
-		app.dbMetrics = dbmetrics.NewDBMetricsCollector(
-			ctx,
-			app.db,
-			dbLog,
-			app.config.DatabaseSizeMeteringInterval,
-		)
+		return nil, nil, err
 	}
 
-	localDB, err := openLocalDb(app.config, dbLog)
+	localDB, err := openLocalDb(cfg, logger)
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
 
-	app.localDB = localDB
-	return nil
+	return localDB, db, nil
 }
 
 func (app *SmeshingService) stopServices(ctx context.Context) {
@@ -973,36 +933,19 @@ func (app *SmeshingService) stopServices(ctx context.Context) {
 		app.grpcTLSServer.Close() // err is always nil
 	}
 
-	if app.clock != nil {
-		app.clock.Close()
+	app.clock.Close()
+	app.atxBuilder.StopSmeshing(false)
+	app.postVerifier.Close()
+
+	if err := app.postSupervisor.Stop(false); err != nil {
+		app.log.Error("error stopping local post service", zap.Error(err))
 	}
 
-	if app.atxBuilder != nil {
-		app.atxBuilder.StopSmeshing(false)
+	if err := app.db.Close(); err != nil {
+		app.log.Warn("db exited with error", zap.Error(err))
 	}
-
-	if app.postVerifier != nil {
-		app.postVerifier.Close()
-	}
-
-	if app.postSupervisor != nil {
-		if err := app.postSupervisor.Stop(false); err != nil {
-			app.log.Error("error stopping local post service", zap.Error(err))
-		}
-	}
-
-	if app.db != nil {
-		if err := app.db.Close(); err != nil {
-			app.log.Warn("db exited with error", zap.Error(err))
-		}
-	}
-	if app.dbMetrics != nil {
-		app.dbMetrics.Close()
-	}
-	if app.localDB != nil {
-		if err := app.localDB.Close(); err != nil {
-			app.log.Warn("local db exited with error", zap.Error(err))
-		}
+	if err := app.localDB.Close(); err != nil {
+		app.log.Warn("local db exited with error", zap.Error(err))
 	}
 
 	if app.pprofService != nil {

--- a/node/smeshing_service.go
+++ b/node/smeshing_service.go
@@ -100,7 +100,7 @@ func GetSmeshingServiceCommand() *cobra.Command {
 			done := make(chan struct{}, 1)
 			// FIXME: per https://github.com/spacemeshos/go-spacemesh/issues/3830
 			go func() {
-				app.stopServices(cleanupCtx)
+				app.Close(cleanupCtx)
 				close(done)
 			}()
 			select {
@@ -160,6 +160,9 @@ type SmeshingService struct {
 	eg      errgroup.Group
 }
 
+// NewSmeshingService creates a new instance of the smeshing service
+//
+// NOTE: The user must call .Close() on the returned instance if err != nil.
 func NewSmeshingService(cfg *config.Config, logger *zap.Logger) (*SmeshingService, error) {
 	loggers, err := newLoggers(&cfg.LOGGING)
 	if err != nil {
@@ -910,7 +913,7 @@ func setupDBs(cfg *config.Config, logger *zap.Logger) (sql.LocalDatabase, sql.St
 	return localDB, db, nil
 }
 
-func (app *SmeshingService) stopServices(ctx context.Context) {
+func (app *SmeshingService) Close(ctx context.Context) {
 	app.log.Info("app stopping services...")
 	defer app.log.Info("...finished stopping services")
 

--- a/node/smeshing_service_test.go
+++ b/node/smeshing_service_test.go
@@ -38,6 +38,9 @@ func TestNewSmeshingService(t *testing.T) {
 		service, err := NewSmeshingService(cfg, zaptest.NewLogger(t))
 		require.NoError(t, err)
 		require.NotNil(t, service)
+		defer func() {
+			service.Close(context.Background())
+		}()
 
 		// Verify DataDir was created
 		dataDir := cfg.DataDir()
@@ -50,6 +53,10 @@ func TestNewSmeshingService(t *testing.T) {
 		service, err := NewSmeshingService(cfg, zaptest.NewLogger(t))
 		require.NoError(t, err)
 		require.NotNil(t, service)
+		defer func() {
+			service.Close(context.Background())
+		}()
+
 		require.Len(t, service.signers, 1)
 
 		// Verify identity file was created
@@ -65,6 +72,9 @@ func TestSmeshingService_Start(t *testing.T) {
 
 		service, err := NewSmeshingService(cfg, zaptest.NewLogger(t))
 		require.NoError(t, err)
+		defer func() {
+			service.Close(context.Background())
+		}()
 
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
@@ -103,6 +113,9 @@ func TestSmeshingService_StartSmeshing(t *testing.T) {
 		cfg := getSmeshingServiceTestConfig(t)
 		service, err := NewSmeshingService(cfg, zaptest.NewLogger(t))
 		require.NoError(t, err)
+		defer func() {
+			service.Close(context.Background())
+		}()
 
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 		defer cancel()
@@ -117,6 +130,9 @@ func TestSmeshingService_StartSmeshing(t *testing.T) {
 
 		service, err := NewSmeshingService(cfg, zaptest.NewLogger(t))
 		require.NoError(t, err)
+		defer func() {
+			service.Close(context.Background())
+		}()
 
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 		defer cancel()
@@ -132,6 +148,9 @@ func TestSmeshingService_GRPCServices(t *testing.T) {
 		cfg := getSmeshingServiceTestConfig(t)
 		service, err := NewSmeshingService(cfg, zaptest.NewLogger(t))
 		require.NoError(t, err)
+		defer func() {
+			service.Close(context.Background())
+		}()
 
 		services := []grpcserver.Service{
 			grpcserver.Debug,
@@ -151,29 +170,13 @@ func TestSmeshingService_GRPCServices(t *testing.T) {
 		cfg := getSmeshingServiceTestConfig(t)
 		service, err := NewSmeshingService(cfg, zaptest.NewLogger(t))
 		require.NoError(t, err)
+		defer func() {
+			service.Close(context.Background())
+		}()
 
 		api, err := service.grpcService("unknown", zaptest.NewLogger(t))
 		require.Error(t, err)
 		require.Nil(t, api)
-	})
-}
-
-func TestSmeshingService_StopServices(t *testing.T) {
-	t.Run("stops all services", func(t *testing.T) {
-		cfg := getSmeshingServiceTestConfig(t)
-		service, err := NewSmeshingService(cfg, zaptest.NewLogger(t))
-		require.NoError(t, err)
-
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
-
-		err = service.start(ctx)
-		require.NoError(t, err)
-
-		stopCtx, stopCancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer stopCancel()
-
-		service.stopServices(stopCtx)
 	})
 }
 
@@ -185,15 +188,14 @@ func TestSmeshingService_PprofServer(t *testing.T) {
 	cfg.PprofMutexProfile = true
 	service, err := NewSmeshingService(cfg, zaptest.NewLogger(t))
 	require.NoError(t, err)
+	defer func() {
+		service.Close(context.Background())
+	}()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
 
 	require.NoError(t, service.start(ctx))
-	defer func() {
-		cancel()
-		service.stopServices(context.Background())
-	}()
 
 	url := fmt.Sprintf("http://%s/debug/pprof/", service.pprofService.Addr)
 	require.Eventually(t, func() bool {

--- a/node/smeshing_service_test.go
+++ b/node/smeshing_service_test.go
@@ -1,0 +1,211 @@
+package node
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	pb "github.com/spacemeshos/api/release/go/spacemesh/v1"
+	"github.com/spacemeshos/post/initialization"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/spacemeshos/go-spacemesh/activation"
+	"github.com/spacemeshos/go-spacemesh/api/grpcserver"
+	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/config"
+)
+
+func getSmeshingServiceTestConfig(tb testing.TB) *config.Config {
+	cfg := config.MainnetSmeshingServiceConfig()
+
+	tmp := tb.TempDir()
+	cfg.DataDirParent = tmp
+	cfg.FileLock = filepath.Join(tmp, "LOCK")
+	cfg.LayerDuration = 20 * time.Second
+
+	cfg.API.PublicListener = "127.0.0.1:0"
+	cfg.API.PrivateListener = "127.0.0.1:0"
+	cfg.API.JSONListener = "127.0.0.1:0"
+
+	cfg.POST = activation.DefaultPostConfig()
+	cfg.POST.MinNumUnits = 2
+	cfg.POST.MaxNumUnits = 4
+	cfg.POST.LabelsPerUnit = 32
+	cfg.POST.K2 = 4
+
+	cfg.BaseConfig.PoetServers = nil
+
+	cfg.SMESHING = config.DefaultSmeshingConfig()
+	cfg.SMESHING.Start = false
+	cfg.SMESHING.CoinbaseAccount = types.GenerateAddress([]byte{1}).StringWithHRP(cfg.NetworkHRP)
+	cfg.SMESHING.Opts.DataDir = filepath.Join(tmp, "post")
+	cfg.SMESHING.Opts.NumUnits = cfg.POST.MinNumUnits + 1
+	cfg.SMESHING.Opts.Scrypt.N = 2
+	cfg.SMESHING.Opts.ProviderID.SetUint32(initialization.CPUProviderID())
+
+	cfg.HARE3.RoundDuration = 2
+	cfg.HARE3.PreroundDelay = 1
+
+	cfg.HARE4.RoundDuration = 2
+	cfg.HARE4.PreroundDelay = 1
+
+	cfg.LayerAvgSize = 5
+	cfg.LayersPerEpoch = 3
+	cfg.TxsPerProposal = 100
+	cfg.Tortoise.Zdist = 5
+
+	cfg.HareEligibility.ConfidenceParam = 1
+
+	cfg.Genesis = config.DefaultTestGenesisConfig()
+	cfg.POSTService = activation.DefaultTestPostServiceConfig()
+
+	return &cfg
+}
+
+func TestNewSmeshingService(t *testing.T) {
+	t.Run("creates new service with valid config", func(t *testing.T) {
+		cfg := getSmeshingServiceTestConfig(t)
+		service, err := NewSmeshingService(cfg, zaptest.NewLogger(t))
+		require.NoError(t, err)
+		require.NotNil(t, service)
+
+		// Verify DataDir was created
+		dataDir := cfg.DataDir()
+		_, err = os.Stat(dataDir)
+		require.NoError(t, err, "DataDir should exist")
+	})
+
+	t.Run("creates identity if not exists", func(t *testing.T) {
+		cfg := getSmeshingServiceTestConfig(t)
+		service, err := NewSmeshingService(cfg, zaptest.NewLogger(t))
+		require.NoError(t, err)
+		require.NotNil(t, service)
+		require.Len(t, service.signers, 1)
+
+		// Verify identity file was created
+		_, err = os.Stat(filepath.Join(cfg.DataDir(), "identities", "local.key"))
+		require.NoError(t, err)
+	})
+}
+
+func TestSmeshingService_Start(t *testing.T) {
+	t.Run("starts API services", func(t *testing.T) {
+		cfg := getSmeshingServiceTestConfig(t)
+		cfg.API.PublicServices = []grpcserver.Service{grpcserver.Debug}
+
+		service, err := NewSmeshingService(cfg, zaptest.NewLogger(t))
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		errCh := make(chan error)
+		go func() {
+			errCh <- service.Start(ctx)
+		}()
+		select {
+		case <-service.started:
+		case <-ctx.Done():
+			t.Fatal("not started on time")
+		}
+
+		conn, err := grpc.NewClient(
+			service.grpcPublicServer.BoundAddress,
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		)
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, conn.Close()) })
+
+		client := pb.NewDebugServiceClient(conn)
+		resp, err := client.ChangeLogLevel(ctx, &pb.ChangeLogLevelRequest{
+			Module: "poet",
+			Level:  "DEBUG",
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+	})
+}
+
+func TestSmeshingService_StartSmeshing(t *testing.T) {
+	t.Run("starts smeshing with valid coinbase", func(t *testing.T) {
+		cfg := getSmeshingServiceTestConfig(t)
+		service, err := NewSmeshingService(cfg, zaptest.NewLogger(t))
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		err = service.startServices(ctx)
+		require.NoError(t, err)
+	})
+
+	t.Run("fails with invalid coinbase", func(t *testing.T) {
+		cfg := getSmeshingServiceTestConfig(t)
+		cfg.SMESHING.CoinbaseAccount = "invalid-address"
+
+		service, err := NewSmeshingService(cfg, zaptest.NewLogger(t))
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		err = service.startServices(ctx)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "parse CoinbaseAccount address")
+	})
+}
+
+func TestSmeshingService_GRPCServices(t *testing.T) {
+	t.Run("initializes all grpc services", func(t *testing.T) {
+		cfg := getSmeshingServiceTestConfig(t)
+		service, err := NewSmeshingService(cfg, zaptest.NewLogger(t))
+		require.NoError(t, err)
+
+		services := []grpcserver.Service{
+			grpcserver.Debug,
+			grpcserver.Smesher,
+			grpcserver.Post,
+			grpcserver.PostInfo,
+		}
+
+		for _, svc := range services {
+			api, err := service.grpcService(svc, zaptest.NewLogger(t))
+			require.NoError(t, err)
+			require.NotNil(t, api)
+		}
+	})
+
+	t.Run("fails with unknown service", func(t *testing.T) {
+		cfg := getSmeshingServiceTestConfig(t)
+		service, err := NewSmeshingService(cfg, zaptest.NewLogger(t))
+		require.NoError(t, err)
+
+		api, err := service.grpcService("unknown", zaptest.NewLogger(t))
+		require.Error(t, err)
+		require.Nil(t, api)
+	})
+}
+
+func TestSmeshingService_StopServices(t *testing.T) {
+	t.Run("stops all services", func(t *testing.T) {
+		cfg := getSmeshingServiceTestConfig(t)
+		service, err := NewSmeshingService(cfg, zaptest.NewLogger(t))
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		err = service.start(ctx)
+		require.NoError(t, err)
+
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer stopCancel()
+
+		service.stopServices(stopCtx)
+	})
+}

--- a/node/smeshing_service_test.go
+++ b/node/smeshing_service_test.go
@@ -11,8 +11,10 @@ import (
 
 	pb "github.com/spacemeshos/api/release/go/spacemesh/v1"
 	"github.com/spacemeshos/post/initialization"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
@@ -106,10 +108,12 @@ func TestSmeshingService_Start(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 
-		errCh := make(chan error)
-		go func() {
-			errCh <- service.Start(ctx)
-		}()
+		var eg errgroup.Group
+		eg.Go(func() error {
+			return service.Start(ctx)
+		})
+		t.Cleanup(func() { assert.NoError(t, eg.Wait()) })
+
 		select {
 		case <-service.started:
 		case <-ctx.Done():

--- a/node/smeshing_service_test.go
+++ b/node/smeshing_service_test.go
@@ -77,9 +77,7 @@ func TestNewSmeshingService(t *testing.T) {
 		service, err := NewSmeshingService(cfg, zaptest.NewLogger(t))
 		require.NoError(t, err)
 		require.NotNil(t, service)
-		defer func() {
-			service.Close(context.Background())
-		}()
+		defer service.Close(context.Background())
 
 		// Verify DataDir was created
 		dataDir := cfg.DataDir()
@@ -92,9 +90,7 @@ func TestNewSmeshingService(t *testing.T) {
 		service, err := NewSmeshingService(cfg, zaptest.NewLogger(t))
 		require.NoError(t, err)
 		require.NotNil(t, service)
-		defer func() {
-			service.Close(context.Background())
-		}()
+		defer service.Close(context.Background())
 
 		require.Len(t, service.signers, 1)
 
@@ -111,9 +107,7 @@ func TestSmeshingService_Start(t *testing.T) {
 
 		service, err := NewSmeshingService(cfg, zaptest.NewLogger(t))
 		require.NoError(t, err)
-		defer func() {
-			service.Close(context.Background())
-		}()
+		defer service.Close(context.Background())
 
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
@@ -152,9 +146,7 @@ func TestSmeshingService_StartSmeshing(t *testing.T) {
 		cfg := getSmeshingServiceTestConfig(t)
 		service, err := NewSmeshingService(cfg, zaptest.NewLogger(t))
 		require.NoError(t, err)
-		defer func() {
-			service.Close(context.Background())
-		}()
+		defer service.Close(context.Background())
 
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 		defer cancel()
@@ -169,9 +161,7 @@ func TestSmeshingService_StartSmeshing(t *testing.T) {
 
 		service, err := NewSmeshingService(cfg, zaptest.NewLogger(t))
 		require.NoError(t, err)
-		defer func() {
-			service.Close(context.Background())
-		}()
+		defer service.Close(context.Background())
 
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 		defer cancel()
@@ -187,9 +177,7 @@ func TestSmeshingService_GRPCServices(t *testing.T) {
 		cfg := getSmeshingServiceTestConfig(t)
 		service, err := NewSmeshingService(cfg, zaptest.NewLogger(t))
 		require.NoError(t, err)
-		defer func() {
-			service.Close(context.Background())
-		}()
+		defer service.Close(context.Background())
 
 		services := []grpcserver.Service{
 			grpcserver.Debug,
@@ -209,9 +197,7 @@ func TestSmeshingService_GRPCServices(t *testing.T) {
 		cfg := getSmeshingServiceTestConfig(t)
 		service, err := NewSmeshingService(cfg, zaptest.NewLogger(t))
 		require.NoError(t, err)
-		defer func() {
-			service.Close(context.Background())
-		}()
+		defer service.Close(context.Background())
 
 		api, err := service.grpcService("unknown", zaptest.NewLogger(t))
 		require.Error(t, err)
@@ -227,9 +213,7 @@ func TestSmeshingService_PprofServer(t *testing.T) {
 	cfg.PprofMutexProfile = true
 	service, err := NewSmeshingService(cfg, zaptest.NewLogger(t))
 	require.NoError(t, err)
-	defer func() {
-		service.Close(context.Background())
-	}()
+	defer service.Close(context.Background())
 
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()

--- a/node/smeshing_service_test.go
+++ b/node/smeshing_service_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	pb "github.com/spacemeshos/api/release/go/spacemesh/v1"
-	"github.com/spacemeshos/post/initialization"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
@@ -18,57 +17,19 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
-	"github.com/spacemeshos/go-spacemesh/activation"
 	"github.com/spacemeshos/go-spacemesh/api/grpcserver"
-	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/config"
 )
 
 func getSmeshingServiceTestConfig(tb testing.TB) *config.Config {
-	cfg := config.MainnetSmeshingServiceConfig()
+	cfg := testConfigFrom(tb, config.MainnetSmeshingServiceConfig())
 
-	tmp := tb.TempDir()
-	cfg.DataDirParent = tmp
-	cfg.FileLock = filepath.Join(tmp, "LOCK")
-	cfg.LayerDuration = 20 * time.Second
-
+	cfg.NodeServiceAddress = "stub address"
 	cfg.API.PublicListener = "127.0.0.1:0"
 	cfg.API.PrivateListener = "127.0.0.1:0"
 	cfg.API.JSONListener = "127.0.0.1:0"
 
-	cfg.POST = activation.DefaultPostConfig()
-	cfg.POST.MinNumUnits = 2
-	cfg.POST.MaxNumUnits = 4
-	cfg.POST.LabelsPerUnit = 32
-	cfg.POST.K2 = 4
-
-	cfg.BaseConfig.PoetServers = nil
-
-	cfg.SMESHING = config.DefaultSmeshingConfig()
-	cfg.SMESHING.Start = false
-	cfg.SMESHING.CoinbaseAccount = types.GenerateAddress([]byte{1}).StringWithHRP(cfg.NetworkHRP)
-	cfg.SMESHING.Opts.DataDir = filepath.Join(tmp, "post")
-	cfg.SMESHING.Opts.NumUnits = cfg.POST.MinNumUnits + 1
-	cfg.SMESHING.Opts.Scrypt.N = 2
-	cfg.SMESHING.Opts.ProviderID.SetUint32(initialization.CPUProviderID())
-
-	cfg.HARE3.RoundDuration = 2
-	cfg.HARE3.PreroundDelay = 1
-
-	cfg.HARE4.RoundDuration = 2
-	cfg.HARE4.PreroundDelay = 1
-
-	cfg.LayerAvgSize = 5
-	cfg.LayersPerEpoch = 3
-	cfg.TxsPerProposal = 100
-	cfg.Tortoise.Zdist = 5
-
-	cfg.HareEligibility.ConfidenceParam = 1
-
-	cfg.Genesis = config.DefaultTestGenesisConfig()
-	cfg.POSTService = activation.DefaultTestPostServiceConfig()
-
-	return &cfg
+	return cfg
 }
 
 func TestNewSmeshingService(t *testing.T) {

--- a/node/smeshing_service_test.go
+++ b/node/smeshing_service_test.go
@@ -2,6 +2,8 @@ package node
 
 import (
 	"context"
+	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
@@ -208,4 +210,31 @@ func TestSmeshingService_StopServices(t *testing.T) {
 
 		service.stopServices(stopCtx)
 	})
+}
+
+func TestSmeshingService_PprofServer(t *testing.T) {
+	cfg := getSmeshingServiceTestConfig(t)
+	cfg.PprofHTTPServer = true
+	cfg.PprofHTTPServerListener = ":0"
+	cfg.PprofBlockProfile = true
+	cfg.PprofMutexProfile = true
+	service, err := NewSmeshingService(cfg, zaptest.NewLogger(t))
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	require.NoError(t, service.start(ctx))
+	defer func() {
+		cancel()
+		service.stopServices(context.Background())
+	}()
+
+	url := fmt.Sprintf("http://%s/debug/pprof/", service.pprofService.Addr)
+	require.Eventually(t, func() bool {
+		resp, err := http.Get(url)
+		require.NoError(t, err, url)
+		resp.Body.Close()
+		return http.StatusOK == resp.StatusCode
+	}, time.Second*10, time.Millisecond*100)
 }

--- a/node/smeshing_service_test.go
+++ b/node/smeshing_service_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	pb "github.com/spacemeshos/api/release/go/spacemesh/v1"
+	"github.com/spacemeshos/post/initialization"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
@@ -17,19 +18,57 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
+	"github.com/spacemeshos/go-spacemesh/activation"
 	"github.com/spacemeshos/go-spacemesh/api/grpcserver"
+	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/config"
 )
 
 func getSmeshingServiceTestConfig(tb testing.TB) *config.Config {
-	cfg := testConfigFrom(tb, config.MainnetSmeshingServiceConfig())
+	cfg := config.MainnetSmeshingServiceConfig()
+
+	tmp := tb.TempDir()
+	cfg.DataDirParent = tmp
+	cfg.FileLock = filepath.Join(tmp, "LOCK")
+	cfg.LayerDuration = 20 * time.Second
 
 	cfg.NodeServiceAddress = "stub address"
 	cfg.API.PublicListener = "127.0.0.1:0"
 	cfg.API.PrivateListener = "127.0.0.1:0"
 	cfg.API.JSONListener = "127.0.0.1:0"
 
-	return cfg
+	cfg.POST = activation.DefaultPostConfig()
+	cfg.POST.MinNumUnits = 2
+	cfg.POST.MaxNumUnits = 4
+	cfg.POST.LabelsPerUnit = 32
+	cfg.POST.K2 = 4
+
+	cfg.BaseConfig.PoetServers = nil
+
+	cfg.SMESHING = config.DefaultSmeshingConfig()
+	cfg.SMESHING.Start = false
+	cfg.SMESHING.CoinbaseAccount = types.GenerateAddress([]byte{1}).StringWithHRP(cfg.NetworkHRP)
+	cfg.SMESHING.Opts.DataDir = filepath.Join(tmp, "post")
+	cfg.SMESHING.Opts.NumUnits = cfg.POST.MinNumUnits + 1
+	cfg.SMESHING.Opts.Scrypt.N = 2
+	cfg.SMESHING.Opts.ProviderID.SetUint32(initialization.CPUProviderID())
+
+	cfg.HARE3.RoundDuration = 2
+	cfg.HARE3.PreroundDelay = 1
+
+	cfg.HARE4.RoundDuration = 2
+	cfg.HARE4.PreroundDelay = 1
+
+	cfg.LayerAvgSize = 5
+	cfg.LayersPerEpoch = 3
+	cfg.Tortoise.Zdist = 5
+
+	cfg.HareEligibility.ConfidenceParam = 1
+
+	cfg.Genesis = config.DefaultTestGenesisConfig(cfg.NetworkHRP)
+	cfg.POSTService = activation.DefaultTestPostServiceConfig()
+
+	return &cfg
 }
 
 func TestNewSmeshingService(t *testing.T) {

--- a/systest/Makefile
+++ b/systest/Makefile
@@ -39,7 +39,7 @@ ifeq ($(configname),$(test_job_name))
 	run_deps = config
 endif
 
-command := gotestsum --raw-command -- test2json -t -p systest \
+command := gotestsum -f standard-verbose --raw-command -- test2json -t -p systest \
  	/bin/tests -test.v -test.count=$(count) -test.timeout=60m -test.run=$(test_name) -test.parallel=$(clusters) \
 	-test.failfast=$(failfast) -clusters=$(clusters) -level=$(level) -configname=$(configname)
 

--- a/systest/Makefile
+++ b/systest/Makefile
@@ -28,6 +28,7 @@ namespace ?=
 count ?= 1
 failfast ?= true
 
+gotestsum_fmt ?= standard-verbose
 configname ?= $(test_job_name)
 smesher_config ?= parameters/fastnet/smesher.json
 poet_config ?= parameters/fastnet/poet.conf
@@ -39,7 +40,7 @@ ifeq ($(configname),$(test_job_name))
 	run_deps = config
 endif
 
-command := gotestsum -f standard-verbose --raw-command -- test2json -t -p systest \
+command := gotestsum -f $(gotestsum_fmt) --raw-command -- test2json -t -p systest \
  	/bin/tests -test.v -test.count=$(count) -test.timeout=60m -test.run=$(test_name) -test.parallel=$(clusters) \
 	-test.failfast=$(failfast) -clusters=$(clusters) -level=$(level) -configname=$(configname)
 

--- a/systest/parameters/fastnet/smeshing_service.json
+++ b/systest/parameters/fastnet/smeshing_service.json
@@ -7,18 +7,14 @@
     },
     "api": {
         "grpc-public-listener": "0.0.0.0:9092",
-        "grpc-private-listener": "0.0.0.0:9093"
-    },
-    "fetch": {
-        "servers-metrics": true,
-        "log-peer-stats-interval": "30s",
-        "servers": {
-            "ax/1": {
-                "interval": "1s",
-                "queue": 200,
-                "requests": 100
-            }
-        }
+        "grpc-private-listener": "0.0.0.0:9093",
+        "privateServices": [
+            "smesher",
+            "debug"
+        ],
+        "publicServices": [
+            "smeshing_identities_v2beta1"
+        ]
     },
     "hare3": {
         "committeeupgrade": {


### PR DESCRIPTION
Created a separate structure `SmeshingService` factored out of the `App`, which contains only things and services needed by the smeshing-service.

Closes #6639 

Greatly refactored creating services for the SmeshingService. Everything needed (like atxBuilder, proposalbuilder etc.) is created directly in the constructor. It solves the problems of unknown dependencies between components (e.g. leading to nil pointer exceptions during any refactoring) - first all components are created as local variables and the `SmeshingService` structure is constructed at the end.

The `SmeshingService` has a dedicated `grpcServices()` method that allows creating only GRPC services that make sense for it.