### PR TITLE
Avoid setting Http Code twice in syncer middleware

### DIFF
--- a/api/node/server/server.go
+++ b/api/node/server/server.go
@@ -108,13 +108,20 @@ func (s *Server) IntoHandler(mux *http.ServeMux, syncer syncer) http.Handler {
 			return response, err
 		}
 	}
-	readinessMid := func(f nethttp.StrictHTTPHandlerFunc, _ string) nethttp.StrictHTTPHandlerFunc {
+	readinessMid := func(f nethttp.StrictHTTPHandlerFunc, operationID string) nethttp.StrictHTTPHandlerFunc {
 		return func(ctx context.Context, w http.ResponseWriter, r *http.Request, req any) (any, error) {
 			if syncer.IsSynced(ctx) {
 				return f(ctx, w, r, req)
 			} else {
+				s.logger.Debug("received request while not synced",
+					zap.String("path", r.URL.Path),
+					zap.String("method", r.Method),
+					zap.String("operation", operationID),
+				)
+
 				w.WriteHeader(http.StatusServiceUnavailable)
-				return nil, errors.New("service not ready: not in sync with the network")
+				w.Write([]byte("service not ready: not in sync with the network"))
+				return nil, nil
 			}
 		}
 	}


### PR DESCRIPTION
## Motivation

`http.ResponseWriter` can only be called once per request to avoid it being set twice return no error in the middleware but instead write the error to the response body and log the problem

## Description

As stated in Motivation

## Test Plan

n/a

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
