### PR TITLE
[Merged by Bors] - Reduce k3 for fastnet

### DIFF
--- a/config/presets/fastnet.go
+++ b/config/presets/fastnet.go
@@ -22,7 +22,7 @@ func fastnet() config.Config {
 
 	conf.BaseConfig.OptFilterThreshold = 90
 	conf.BaseConfig.DatabasePruneInterval = time.Minute
-	conf.BaseConfig.DatabaseConnections = 20
+	conf.BaseConfig.DatabaseConnections = 16
 
 	// set for systest TestEquivocation
 	conf.BaseConfig.MinerGoodAtxsPercent = 50
@@ -68,7 +68,7 @@ func fastnet() config.Config {
 
 	conf.POST.K1 = 12
 	conf.POST.K2 = 4
-	conf.POST.K3 = 3
+	conf.POST.K3 = 1
 	conf.POST.LabelsPerUnit = 128
 	conf.POST.MaxNumUnits = 4
 	conf.POST.MinNumUnits = 2

--- a/systest/tests/distributed_post_verification_test.go
+++ b/systest/tests/distributed_post_verification_test.go
@@ -75,12 +75,13 @@ func TestPostMalfeasanceProof(t *testing.T) {
 
 	// Prepare cluster
 	ctx.PoetSize = 1 // one poet guarantees everybody gets the same proof
-	ctx.ClusterSize = 8
+	ctx.ClusterSize = 4
 	cl := cluster.New(ctx, cluster.WithKeys(10))
 	require.NoError(t, cl.AddPoets(ctx))
 	require.NoError(t, cl.AddBootnodes(ctx, 1))
 	require.NoError(t, cl.AddBootstrappers(ctx))
-	require.NoError(t, cl.AddSmeshers(ctx, ctx.ClusterSize-cl.Total(), cluster.WithFlags(cluster.PostK3(1))))
+	// a k3 of 3 with 4 smeshers should find the malicious post in ~ 99.6% of all test runs
+	require.NoError(t, cl.AddSmeshers(ctx, ctx.ClusterSize-cl.Total(), cluster.WithFlags(cluster.PostK3(3))))
 
 	logger := ctx.Log.Desugar().WithOptions(zap.IncreaseLevel(zap.InfoLevel), zap.WithCaller(false))
 	cfg := getConfig(t, logger, cl, ctx)


### PR DESCRIPTION
## Motivation

A k3 of 3 is too computational expensive for system tests to be stable since nodes will be throttled due to high CPU consumption. This PR reduces k3 back to 1 in an attempt to make them more stable again.

## Description

k3 was raised to decrease the probability of not detecting a malicious PoST in `TestPostMalfeasanceProof`. Instead we now keep k3 low for all tests and only increase it to 3 in this test, which should still detect the malfeasance with a probability of ~99.6% (or in 255 out of 256 test runs)

## Test Plan

n/a

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
