### PR TITLE
add path descriptors for DebugService and SmeshingService

### DIFF
--- a/api/grpcserver/debug_service.go
+++ b/api/grpcserver/debug_service.go
@@ -31,6 +31,10 @@ type DebugService struct {
 	loggers  map[string]*zap.AtomicLevel
 }
 
+func (s *DebugService) Path() string {
+	return "/spacemesh.v1.DebugService/"
+}
+
 // RegisterService registers this service with a grpc server instance.
 func (d *DebugService) RegisterService(server *grpc.Server) {
 	pb.RegisterDebugServiceServer(server, d)

--- a/api/grpcserver/v2beta1/smeshing.go
+++ b/api/grpcserver/v2beta1/smeshing.go
@@ -24,6 +24,10 @@ type SmeshingService struct {
 	appCommit  string
 }
 
+func (s *SmeshingService) Path() string {
+	return "/spacemesh.v2beta1.SmeshingService/"
+}
+
 func (s *SmeshingService) Version(
 	_ context.Context,
 	_ *spacemeshv2beta1.SmeshingVersionRequest,

--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/seehuhn/mt19937 v1.0.0
 	github.com/slok/go-http-metrics v0.13.0
-	github.com/spacemeshos/api/release/go v1.60.1-0.20250212142412-5b4c92ab1f7c
+	github.com/spacemeshos/api/release/go v1.60.1-0.20250212215909-24744be30bca
 	github.com/spacemeshos/economics v0.1.4
 	github.com/spacemeshos/fixed v0.1.2
 	github.com/spacemeshos/go-scale v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -637,8 +637,8 @@ github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d/go.mod h1:Udh
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
-github.com/spacemeshos/api/release/go v1.60.1-0.20250212142412-5b4c92ab1f7c h1:uODDBdgK17xEHND428fCPNChtSUFYv4c9wyDUrplYag=
-github.com/spacemeshos/api/release/go v1.60.1-0.20250212142412-5b4c92ab1f7c/go.mod h1:QnZOhlUupLbfogjCmo9uf/PRYRNCFNFCKqgD8tRL7dM=
+github.com/spacemeshos/api/release/go v1.60.1-0.20250212215909-24744be30bca h1:szk4m3eLkZZ9qCfo7bcPaK4TZhH77TqwYbSd+Z+2ozM=
+github.com/spacemeshos/api/release/go v1.60.1-0.20250212215909-24744be30bca/go.mod h1:QnZOhlUupLbfogjCmo9uf/PRYRNCFNFCKqgD8tRL7dM=
 github.com/spacemeshos/economics v0.1.4 h1:twlawrcQhYNqPgyDv08+24EL/OgUKz3d7q+PvJIAND0=
 github.com/spacemeshos/economics v0.1.4/go.mod h1:6HKWKiKdxjVQcGa2z/wA0LR4M/DzKib856bP16yqNmQ=
 github.com/spacemeshos/fixed v0.1.2 h1:pENQ8pXFAqin3f15ZLoOVVeSgcmcFJ0IFdFm4+9u4SM=


### PR DESCRIPTION
A service needs to implement `Path()` method to be registerable as a local service.