### PR TITLE
dont return 500 from /eligibility/slots when no ATX

### DIFF
--- a/api/node/client/client_e2e_test.go
+++ b/api/node/client/client_e2e_test.go
@@ -255,8 +255,8 @@ func Test_Hare(t *testing.T) {
 }
 
 func TestProposals(t *testing.T) {
-	svc, mock := setupE2E(t)
 	t.Run("build for", func(t *testing.T) {
+		svc, mock := setupE2E(t)
 		p := createProposal(t, true)
 		mock.proposals.EXPECT().BuildFor(gomock.Any(), gomock.Any(), gomock.Any()).Return(p, 0, nil)
 		prop, _, err := svc.Proposal(context.Background(), p.Layer, p.SmesherID)
@@ -264,13 +264,35 @@ func TestProposals(t *testing.T) {
 		prop.MustInitialize()
 		require.EqualValues(t, p, prop)
 	})
-	svc, mock = setupE2E(t)
 	t.Run("build for - no eligibility", func(t *testing.T) {
+		svc, mock := setupE2E(t)
 		p := createProposal(t, false)
 		mock.proposals.EXPECT().BuildFor(gomock.Any(), gomock.Any(), gomock.Any()).Return(p, 0, nil)
 		prop, _, err := svc.Proposal(context.Background(), types.LayerID(112), types.NodeID{})
 		require.NoError(t, err)
 		require.Empty(t, prop)
+	})
+}
+
+func TestCalculateEligibilitySlots(t *testing.T) {
+	t.Run("smesher has eligibility", func(t *testing.T) {
+		svc, mock := setupE2E(t)
+		node := types.RandomNodeID()
+		epoch := types.EpochID(5)
+		mock.proposals.EXPECT().CalculateEligibilitySlotsFor(gomock.Any(), node, epoch).Return(10, 11111, nil)
+		slots, vrfNonce, err := svc.CalculateEligibilitySlotsFor(context.Background(), node, epoch)
+		require.NoError(t, err)
+		require.EqualValues(t, 10, slots)
+		require.EqualValues(t, 11111, vrfNonce)
+	})
+	t.Run("smesher doesn't have an ATX - 0 slots returned", func(t *testing.T) {
+		svc, mock := setupE2E(t)
+		node := types.RandomNodeID()
+		epoch := types.EpochID(5)
+		mock.proposals.EXPECT().CalculateEligibilitySlotsFor(gomock.Any(), node, epoch).Return(0, 0, nil)
+		slots, _, err := svc.CalculateEligibilitySlotsFor(context.Background(), node, epoch)
+		require.NoError(t, err)
+		require.Zero(t, slots)
 	})
 }
 

--- a/miner/proposal_builder.go
+++ b/miner/proposal_builder.go
@@ -595,7 +595,17 @@ func (pb *ProposalBuilder) CalculateEligibilitySlotsFor(
 	}
 	var ss session
 	if err := pb.initSignerSessionData(&ss, epoch, node); err != nil {
-		return 0, 0, err
+		if errors.Is(err, errAtxNotAvailable) {
+			pb.logger.Debug("smesher doesn't have atx that targets this epoch",
+				log.ZContext(ctx),
+				log.ZShortStringer("smesherID", node),
+				zap.Uint32("epoch", epoch.Uint32()),
+			)
+			// no atx in epoch means not eligible in epoch
+			return 0, 0, nil
+		} else {
+			return 0, 0, err
+		}
 	}
 	return ss.eligibilities.slots, ss.nonce, nil
 }

--- a/miner/proposal_builder_test.go
+++ b/miner/proposal_builder_test.go
@@ -1212,6 +1212,41 @@ func TestGradeAtx(t *testing.T) {
 	}
 }
 
+func TestProposalBuilder_CalculateEligibilitySlotsFor(t *testing.T) {
+	t.Run("returns 0 when node doesn't have an ATX", func(t *testing.T) {
+		clock := mocks.NewMocklayerClock(gomock.NewController(t))
+		stateDB := statesql.InMemoryTest(t)
+		atxsdata := atxsdata.New()
+		pb := New(
+			clock,
+			stateDB,
+			localsql.InMemoryTest(t),
+			atxsdata,
+			nil,
+			nil,
+			nil,
+			nil,
+			WithLogger(zaptest.NewLogger(t)),
+		)
+		nodeID := types.NodeID{1, 2, 3}
+		epoch := types.EpochID(6)
+
+		require.NoError(t, beacons.Add(stateDB, epoch, types.Beacon{1}))
+		clock.EXPECT().CurrentLayer().Return(epoch.FirstLayer())
+		firstLayerTime := time.Now().Add(-time.Minute)
+		clock.EXPECT().LayerToTime(epoch.FirstLayer()).Return(firstLayerTime)
+
+		atx := gatx(types.RandomATXID(), epoch-1, types.RandomNodeID(), 10)
+		atxsdata.AddFromAtx(atx, false)
+		require.NoError(t, atxs.Add(stateDB, atx, types.AtxBlob{}))
+
+		slots, nonce, err := pb.CalculateEligibilitySlotsFor(context.Background(), nodeID, epoch)
+		require.NoError(t, err)
+		require.Equal(t, uint32(0), slots)
+		require.Equal(t, types.VRFPostIndex(0), nonce)
+	})
+}
+
 func BenchmarkCache(b *testing.B) {
 	runtime.GC()
 	cache := make(map[types.ATXID]*atxsdata.ATX, 10_000_000)


### PR DESCRIPTION
Previously, it would return a 500 because the error wasn't handled properly. When a smesher doesn't have an ATX it should return 200 with slots = 0.