### PR TITLE
workaround for broken testnet hare3 protocol name

### DIFF
--- a/api/node/client/client.go
+++ b/api/node/client/client.go
@@ -129,6 +129,12 @@ func (s *NodeService) Publish(ctx context.Context, proto string, blob []byte) er
 	// The `hare3.DefaultProtocolName` contains slashes which
 	// makes it unsuitable for a path parameter,
 	// thus we change it to hare3 here and backwards on the server side.
+	// FIXME: we check if `proto == ""` because the testnet config has
+	// empty hare3 proto in `config/presets/testenet.go`.
+	// Remove it after fixing the testnet preset.
+	if proto == "" {
+		proto = "testnet-hare3-workaround"
+	}
 	if proto == hare3.DefaultProtocolName {
 		proto = "hare3"
 	}

--- a/api/node/client/client.go
+++ b/api/node/client/client.go
@@ -130,7 +130,7 @@ func (s *NodeService) Publish(ctx context.Context, proto string, blob []byte) er
 	// makes it unsuitable for a path parameter,
 	// thus we change it to hare3 here and backwards on the server side.
 	// FIXME: we check if `proto == ""` because the testnet config has
-	// empty hare3 proto in `config/presets/testenet.go`.
+	// empty hare3 proto in `config/presets/testnet.go`.
 	// Remove it after fixing the testnet preset.
 	if proto == "" {
 		proto = "testnet-hare3-workaround"

--- a/api/node/server/server.go
+++ b/api/node/server/server.go
@@ -261,6 +261,13 @@ func (s *Server) PostPublishProtocol(
 	}
 
 	protocol := string(request.Protocol)
+	// FIXME: we check if `proto == "testnet-hare3-workaround"` as a workaround for
+	// an empty hare3 proto in `config/presets/testnet.go`.
+	// The client set "testnet-hare3-workaround" and we change back to "".
+	// Remove it after fixing the testnet preset.
+	if protocol == "testnet-hare3-workaround" {
+		protocol = ""
+	}
 	if protocol == "hare3" {
 		// Revert protocol change (avoiding slashes) done on the client side.
 		// TODO: hare3 takes that from configuration what also should be done


### PR DESCRIPTION
On the current testnet the hare3 protocol is set to `""`:  https://github.com/spacemeshos/go-spacemesh/blob/31275468f9f8870df5a39edb56b309638fffc54b/config/presets/testnet.go#L62-L64

The workaround is to use a special `"testnet-hare3-workaround"` proto in the API, which stands for "hare3". It will be used only in place of empty protocol (so it doesn't interfere with mainnet).