### PR TITLE
[Merged by Bors] - remove unused TimeConfigValues global

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -90,7 +90,6 @@ import (
 	"github.com/spacemeshos/go-spacemesh/syncer/malsync"
 	"github.com/spacemeshos/go-spacemesh/system"
 	"github.com/spacemeshos/go-spacemesh/timesync"
-	timeCfg "github.com/spacemeshos/go-spacemesh/timesync/config"
 	"github.com/spacemeshos/go-spacemesh/timesync/peersync"
 	"github.com/spacemeshos/go-spacemesh/tortoise"
 	"github.com/spacemeshos/go-spacemesh/txs"

--- a/node/node.go
+++ b/node/node.go
@@ -521,9 +521,6 @@ func (app *App) Initialize() error {
 		}
 	}
 
-	// override default config in timesync since timesync is using TimeConfigValues
-	timeCfg.TimeConfigValues = app.Config.TIME
-
 	app.setupLogging()
 	app.log.Info("Welcome to Spacemesh. Spacemesh full node is starting...")
 

--- a/timesync/config/config.go
+++ b/timesync/config/config.go
@@ -4,11 +4,6 @@ import (
 	"github.com/spacemeshos/go-spacemesh/timesync/peersync"
 )
 
-// ConfigValues specifies  default values for node config params.
-var (
-	TimeConfigValues = DefaultConfig()
-)
-
 // TimeConfig specifies the timesync params for ntp.
 type TimeConfig struct {
 	Peersync peersync.Config `mapstructure:"peersync"`
@@ -17,9 +12,7 @@ type TimeConfig struct {
 // DefaultConfig defines the default tymesync configuration.
 func DefaultConfig() TimeConfig {
 	// TimeConfigValues defines default values for all time and ntp related params.
-	TimeConfigValues := TimeConfig{
+	return TimeConfig{
 		Peersync: peersync.DefaultConfig(),
 	}
-
-	return TimeConfigValues
 }

--- a/timesync/config/config.go
+++ b/timesync/config/config.go
@@ -9,7 +9,7 @@ type TimeConfig struct {
 	Peersync peersync.Config `mapstructure:"peersync"`
 }
 
-// DefaultConfig defines the default tymesync configuration.
+// DefaultConfig defines the default timesync configuration.
 func DefaultConfig() TimeConfig {
 	// TimeConfigValues defines default values for all time and ntp related params.
 	return TimeConfig{


### PR DESCRIPTION
## Motivation

`TimeConfigValues` global is unused.