### PR TITLE
Node-Split: Handle 0 eligibility slots correctly

### DIFF
--- a/api/node/client/client.go
+++ b/api/node/client/client.go
@@ -246,7 +246,7 @@ func (s *NodeService) Proposal(ctx context.Context, layer types.LayerID, node ty
 	case http.StatusOK:
 	case http.StatusNoContent:
 		// special case - no error but also no proposal, means
-		// we're no eligible this epoch with this node ID
+		// we're not eligible this epoch with this node ID
 		return nil, 0, nil
 	default:
 		return nil, 0, fmt.Errorf("unexpected status: %q", resp.Status())

--- a/miner/remote_proposals.go
+++ b/miner/remote_proposals.go
@@ -188,7 +188,19 @@ func (pb *RemoteProposalBuilder) build(
 		if !ok {
 			slots, nonce, err := pb.proposalSvc.CalculateEligibilitySlotsFor(ctx, nodeId, epoch)
 			if err != nil {
-				pb.logger.Error("calculate eligibility slots error", zap.Error(err))
+				pb.logger.Error("calculate eligibility slots error",
+					log.ZContext(ctx),
+					zap.Stringer("node", nodeId),
+					zap.Error(err),
+				)
+				continue
+			}
+			if slots == 0 {
+				pb.logger.Info("node not eligible in this epoch, will try later",
+					log.ZContext(ctx),
+					zap.Stringer("node", nodeId),
+					zap.Uint32("epoch", epoch.Uint32()),
+				)
 				continue
 			}
 			proofs = calcEligibilityProofs(
@@ -210,7 +222,11 @@ func (pb *RemoteProposalBuilder) build(
 
 		proposal, _, err := pb.proposalSvc.Proposal(ctx, layer, nodeId)
 		if err != nil {
-			pb.logger.Error("get partial proposal", zap.Error(err))
+			pb.logger.Error("get partial proposal",
+				log.ZContext(ctx),
+				zap.Stringer("node", nodeId),
+				zap.Error(err),
+			)
 			pb.identityStates.Set(nodeId, &smesherIdentity.ProposalBuildFailed{
 				ErrorMsg: fmt.Sprintf("get partial proposal: %v", err),
 				Layer:    layer,
@@ -219,18 +235,28 @@ func (pb *RemoteProposalBuilder) build(
 		}
 		if proposal == nil {
 			// this node signer isn't eligible this epoch, continue
-			pb.logger.Info("node not eligible on this layer. will try later")
+			pb.logger.Info("node not eligible on this layer: no proposal received, will try later",
+				log.ZContext(ctx),
+				zap.Stringer("node", nodeId),
+				zap.Uint32("lid", layer.Uint32()),
+			)
 			continue
 		}
 
-		eligibilities, ok := proofs[layer]
+		// TODO(mafa): I don't think this belongs here, either do this check before requesting a proposal
+		// (client decides about eligibilities) or don't do it at all (server decides eligibilities)
+		eligProofs, ok := proofs[layer]
 		if !ok {
 			// not eligible in this layer, continue
-			pb.logger.Info("node not eligible in this layer, will try later")
+			pb.logger.Info("node not eligible in this layer, will try later",
+				log.ZContext(ctx),
+				zap.Stringer("node", nodeId),
+				zap.Uint32("lid", layer.Uint32()),
+			)
 			continue
 		}
 
-		proposal.EligibilityProofs = eligibilities
+		proposal.EligibilityProofs = eligProofs
 		proposal.Ballot.Signature = signer.signer.Sign(signing.BALLOT, proposal.Ballot.SignedBytes())
 		proposal.Signature = signer.signer.Sign(signing.PROPOSAL, proposal.SignedBytes())
 		err = proposal.Initialize()


### PR DESCRIPTION
## Motivation

Before https://github.com/spacemeshos/go-spacemesh/pull/6727 0 eligibility slots were handled differently (identity was skipped in proposal creation). This restores the old behavior without reverting back to 500 HTTP codes and (incorreclty) reporting errors in eligibility calculation.

## Description

Now when 0 slots are returned for a given identity from the node the identity is skipped from proposal creation (as it would have been before https://github.com/spacemeshos/go-spacemesh/pull/6727) instead of returning with an empty map/slice of eligibilities.

## Test Plan

existing tests pass

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
