### PR TITLE
[Merged by Bors] - Stability improvements to unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ else
 	ULIMIT := ulimit -n 4096;
 endif
 
-UNIT_TESTS ?= $(shell go list ./...  | grep -v systest/tests | grep -v genvm/cmd)
+UNIT_TESTS ?= $(shell go list ./...  | grep -v systest/tests | grep -v hare4)
 
 export CGO_ENABLED := 1
 export CGO_CFLAGS := $(CGO_CFLAGS) -DSQLITE_ENABLE_DBSTAT_VTAB=1

--- a/api/grpcserver/v2alpha1/malfeasance.go
+++ b/api/grpcserver/v2alpha1/malfeasance.go
@@ -160,7 +160,7 @@ func (s *MalfeasanceStreamService) Stream(
 		case errors.Is(err, io.EOF):
 			return nil
 		case err != nil:
-			return status.Error(codes.Internal, err.Error())
+			return err
 		}
 	}
 
@@ -179,7 +179,7 @@ func (s *MalfeasanceStreamService) Stream(
 		case errors.Is(err, io.EOF):
 			return nil
 		case err != nil:
-			return status.Error(codes.Internal, err.Error())
+			return err
 		}
 	}
 
@@ -197,9 +197,10 @@ func (s *MalfeasanceStreamService) Stream(
 	eventsFull := sub.Full()
 
 	if err := stream.SendHeader(metadata.MD{}); err != nil {
-		return status.Errorf(codes.Unavailable, "can't send header")
+		ctxzap.Debug(stream.Context(), "failed to send stream header",
+			zap.Error(err),
+		)
 	}
-
 	for {
 		select {
 		// process pending events first
@@ -221,7 +222,7 @@ func (s *MalfeasanceStreamService) Stream(
 			case errors.Is(err, io.EOF):
 				return nil
 			case err != nil:
-				return status.Error(codes.Internal, err.Error())
+				return err
 			}
 		default:
 			select {
@@ -243,7 +244,7 @@ func (s *MalfeasanceStreamService) Stream(
 				case errors.Is(err, io.EOF):
 					return nil
 				case err != nil:
-					return status.Error(codes.Internal, err.Error())
+					return err
 				}
 			case <-eventsFull:
 				return status.Error(codes.Canceled, "buffer overflow")

--- a/api/grpcserver/v2alpha1/malfeasance_test.go
+++ b/api/grpcserver/v2alpha1/malfeasance_test.go
@@ -370,8 +370,9 @@ func TestMalfeasanceStreamService_Stream(t *testing.T) {
 		}
 		stream, err := client.Stream(context.Background(), request)
 		require.NoError(t, err)
-		_, err = stream.Header()
+		md, err := stream.Header()
 		require.NoError(t, err)
+		require.Equal(t, []string{"application/grpc"}, md.Get("content-type"))
 
 		expect := make([]types.NodeID, 0, len(request.SmesherId))
 		for _, rst := range streamed {

--- a/api/grpcserver/v2alpha1/network.go
+++ b/api/grpcserver/v2alpha1/network.go
@@ -11,19 +11,23 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
-	"github.com/spacemeshos/go-spacemesh/config"
 )
 
 const (
 	Network = "network_v2alpha1"
 )
 
-func NewNetworkService(genesisTime time.Time, config *config.Config) *NetworkService {
+func NewNetworkService(
+	genesisTime time.Time,
+	genesisID types.Hash20,
+	layerDuration time.Duration,
+	labelsPerUnit uint64,
+) *NetworkService {
 	return &NetworkService{
 		genesisTime:   genesisTime,
-		genesisID:     config.Genesis.GenesisID(),
-		layerDuration: config.LayerDuration,
-		labelsPerUnit: config.POST.LabelsPerUnit,
+		genesisID:     genesisID,
+		layerDuration: layerDuration,
+		labelsPerUnit: labelsPerUnit,
 	}
 }
 

--- a/api/grpcserver/v2alpha1/network_test.go
+++ b/api/grpcserver/v2alpha1/network_test.go
@@ -9,15 +9,19 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
-	"github.com/spacemeshos/go-spacemesh/config"
 )
 
 func TestNetworkService_Info(t *testing.T) {
 	ctx := context.Background()
 	genesis := time.Unix(genTimeUnix, 0)
-	c := config.DefaultTestConfig(t)
+	genesisID := types.Hash20{1, 2, 3}
+	layerDuration := 10 * time.Second
+	labelsPerUnit := uint64(10)
+	types.SetNetworkHRP("spacemesh")
+	types.SetEffectiveGenesis(20)
+	types.SetLayersPerEpoch(100)
 
-	svc := NewNetworkService(genesis, &c)
+	svc := NewNetworkService(genesis, genesisID, layerDuration, labelsPerUnit)
 	cfg, cleanup := launchServer(t, svc)
 	t.Cleanup(cleanup)
 
@@ -29,11 +33,11 @@ func TestNetworkService_Info(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Equal(t, genesis.UTC(), info.GenesisTime.AsTime().UTC())
-		require.Equal(t, c.LayerDuration, info.LayerDuration.AsDuration())
-		require.Equal(t, c.Genesis.GenesisID().Bytes(), info.GenesisId)
+		require.Equal(t, layerDuration, info.LayerDuration.AsDuration())
+		require.Equal(t, genesisID.Bytes(), info.GenesisId)
 		require.Equal(t, types.NetworkHRP(), info.Hrp)
 		require.Equal(t, types.GetEffectiveGenesis().Uint32(), info.EffectiveGenesisLayer)
 		require.Equal(t, types.GetLayersPerEpoch(), info.LayersPerEpoch)
-		require.Equal(t, c.POST.LabelsPerUnit, info.LabelsPerUnit)
+		require.Equal(t, labelsPerUnit, info.LabelsPerUnit)
 	})
 }

--- a/api/grpcserver/v2beta1/malfeasance.go
+++ b/api/grpcserver/v2beta1/malfeasance.go
@@ -160,7 +160,7 @@ func (s *MalfeasanceStreamService) Stream(
 		case errors.Is(err, io.EOF):
 			return nil
 		case err != nil:
-			return status.Error(codes.Internal, err.Error())
+			return err
 		}
 	}
 
@@ -179,7 +179,7 @@ func (s *MalfeasanceStreamService) Stream(
 		case errors.Is(err, io.EOF):
 			return nil
 		case err != nil:
-			return status.Error(codes.Internal, err.Error())
+			return err
 		}
 	}
 
@@ -197,9 +197,10 @@ func (s *MalfeasanceStreamService) Stream(
 	eventsFull := sub.Full()
 
 	if err := stream.SendHeader(metadata.MD{}); err != nil {
-		return status.Errorf(codes.Unavailable, "can't send header")
+		ctxzap.Debug(stream.Context(), "failed to send stream header",
+			zap.Error(err),
+		)
 	}
-
 	for {
 		select {
 		// process pending events first
@@ -221,7 +222,7 @@ func (s *MalfeasanceStreamService) Stream(
 			case errors.Is(err, io.EOF):
 				return nil
 			case err != nil:
-				return status.Error(codes.Internal, err.Error())
+				return err
 			}
 		default:
 			select {
@@ -243,7 +244,7 @@ func (s *MalfeasanceStreamService) Stream(
 				case errors.Is(err, io.EOF):
 					return nil
 				case err != nil:
-					return status.Error(codes.Internal, err.Error())
+					return err
 				}
 			case <-eventsFull:
 				return status.Error(codes.Canceled, "buffer overflow")

--- a/api/grpcserver/v2beta1/malfeasance_test.go
+++ b/api/grpcserver/v2beta1/malfeasance_test.go
@@ -370,8 +370,9 @@ func TestMalfeasanceStreamService_Stream(t *testing.T) {
 		}
 		stream, err := client.Stream(context.Background(), request)
 		require.NoError(t, err)
-		_, err = stream.Header()
+		md, err := stream.Header()
 		require.NoError(t, err)
+		require.Equal(t, []string{"application/grpc"}, md.Get("content-type"))
 
 		expect := make([]types.NodeID, 0, len(request.SmesherId))
 		for _, rst := range streamed {

--- a/api/grpcserver/v2beta1/network.go
+++ b/api/grpcserver/v2beta1/network.go
@@ -11,19 +11,23 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
-	"github.com/spacemeshos/go-spacemesh/config"
 )
 
 const (
 	Network = "network_v2beta1"
 )
 
-func NewNetworkService(genesisTime time.Time, config *config.Config) *NetworkService {
+func NewNetworkService(
+	genesisTime time.Time,
+	genesisID types.Hash20,
+	layerDuration time.Duration,
+	labelsPerUnit uint64,
+) *NetworkService {
 	return &NetworkService{
 		genesisTime:   genesisTime,
-		genesisID:     config.Genesis.GenesisID(),
-		layerDuration: config.LayerDuration,
-		labelsPerUnit: config.POST.LabelsPerUnit,
+		genesisID:     genesisID,
+		layerDuration: layerDuration,
+		labelsPerUnit: labelsPerUnit,
 	}
 }
 

--- a/api/grpcserver/v2beta1/network_test.go
+++ b/api/grpcserver/v2beta1/network_test.go
@@ -9,15 +9,19 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
-	"github.com/spacemeshos/go-spacemesh/config"
 )
 
 func TestNetworkService_Info(t *testing.T) {
 	ctx := context.Background()
 	genesis := time.Unix(genTimeUnix, 0)
-	c := config.DefaultTestConfig(t)
+	genesisID := types.Hash20{1, 2, 3}
+	layerDuration := 10 * time.Second
+	labelsPerUnit := uint64(10)
+	types.SetNetworkHRP("spacemesh")
+	types.SetEffectiveGenesis(20)
+	types.SetLayersPerEpoch(100)
 
-	svc := NewNetworkService(genesis, &c)
+	svc := NewNetworkService(genesis, genesisID, layerDuration, labelsPerUnit)
 	cfg, cleanup := launchServer(t, svc)
 	t.Cleanup(cleanup)
 
@@ -29,11 +33,11 @@ func TestNetworkService_Info(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Equal(t, genesis.UTC(), info.GenesisTime.AsTime().UTC())
-		require.Equal(t, c.LayerDuration, info.LayerDuration.AsDuration())
-		require.Equal(t, c.Genesis.GenesisID().Bytes(), info.GenesisId)
+		require.Equal(t, layerDuration, info.LayerDuration.AsDuration())
+		require.Equal(t, genesisID.Bytes(), info.GenesisId)
 		require.Equal(t, types.NetworkHRP(), info.Hrp)
 		require.Equal(t, types.GetEffectiveGenesis().Uint32(), info.EffectiveGenesisLayer)
 		require.Equal(t, types.GetLayersPerEpoch(), info.LayersPerEpoch)
-		require.Equal(t, c.POST.LabelsPerUnit, info.LabelsPerUnit)
+		require.Equal(t, labelsPerUnit, info.LabelsPerUnit)
 	})
 }

--- a/config/config.go
+++ b/config/config.go
@@ -7,10 +7,8 @@ import (
 	"math"
 	"os"
 	"path/filepath"
-	"testing"
 	"time"
 
-	"github.com/spacemeshos/post/initialization"
 	"github.com/spf13/viper"
 
 	"github.com/spacemeshos/go-spacemesh/activation"
@@ -182,7 +180,7 @@ type SmeshingConfig struct {
 // DefaultConfig returns the default configuration for a spacemesh node.
 func DefaultConfig() Config {
 	return Config{
-		BaseConfig:      defaultBaseConfig(),
+		BaseConfig:      DefaultBaseConfig(),
 		Genesis:         DefaultGenesisConfig(),
 		Tortoise:        tortoise.DefaultConfig(),
 		P2P:             p2p.DefaultConfig(),
@@ -208,52 +206,8 @@ func DefaultConfig() Config {
 	}
 }
 
-// DefaultTestConfig returns the default config for tests.
-func DefaultTestConfig(tb testing.TB) Config {
-	conf := DefaultConfig()
-	conf.BaseConfig = defaultTestConfig()
-	conf.DataDirParent = tb.TempDir()
-	conf.FileLock = filepath.Join(conf.DataDirParent, "spacemesh.lock") // allows multiple configs in one test
-	conf.LayerDuration = 2 * time.Second
-
-	conf.Genesis = DefaultTestGenesisConfig(tb)
-
-	conf.POST.MinNumUnits = 2
-	conf.POST.MaxNumUnits = 4
-	conf.POST.LabelsPerUnit = 32
-	conf.POST.K2 = 4
-
-	conf.SMESHING.CoinbaseAccount = types.GenerateAddress([]byte{1}).String()
-	conf.SMESHING.Opts.DataDir = filepath.Join(conf.DataDirParent, "post")
-	conf.SMESHING.Opts.NumUnits = conf.POST.MinNumUnits + 1
-	conf.SMESHING.Opts.Scrypt.N = 2
-	conf.SMESHING.Opts.ProviderID.SetUint32(initialization.CPUProviderID())
-
-	// is set to 0 to make sync start immediately when node starts
-	conf.P2P.MinPeers = 0
-
-	conf.Tortoise.Hdist = 5
-	conf.Tortoise.Zdist = 5
-
-	conf.API = grpcserver.DefaultTestConfig(tb)
-	conf.POSTService = activation.DefaultTestPostServiceConfig(tb)
-	conf.Beacon = beacon.NodeSimUnitTestConfig(tb)
-
-	conf.HARE3.PreroundDelay = 10 * time.Millisecond
-	conf.HARE3.RoundDuration = 20 * time.Millisecond
-	conf.HARE4.PreroundDelay = 10 * time.Millisecond
-	conf.HARE4.RoundDuration = 20 * time.Millisecond
-
-	conf.Sync.Interval = time.Second
-
-	conf.FETCH.RequestTimeout = 10 * time.Second
-	conf.FETCH.RequestHardTimeout = 20 * time.Second
-	conf.FETCH.BatchSize = 5
-	return conf
-}
-
 // DefaultBaseConfig returns a default configuration for spacemesh.
-func defaultBaseConfig() BaseConfig {
+func DefaultBaseConfig() BaseConfig {
 	return BaseConfig{
 		DataDirParent:                defaultDataDir,
 		FileLock:                     filepath.Join(os.TempDir(), "spacemesh.lock"),
@@ -293,15 +247,6 @@ func DefaultSmeshingConfig() SmeshingConfig {
 		ProvingOpts:     activation.DefaultPostProvingOpts(),
 		VerifyingOpts:   activation.DefaultPostVerifyingOpts(),
 	}
-}
-
-func defaultTestConfig() BaseConfig {
-	conf := defaultBaseConfig()
-	conf.MetricsPort += 10000
-	conf.NetworkHRP = "stest"
-	types.SetNetworkHRP(conf.NetworkHRP)
-	types.SetLayersPerEpoch(conf.LayersPerEpoch)
-	return conf
 }
 
 // LoadConfig load the config file.

--- a/config/genesis.go
+++ b/config/genesis.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"strconv"
-	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
@@ -152,16 +151,6 @@ func DefaultGenesisConfig() GenesisConfig {
 	// NOTE(dshulyak) keys in default config are used in some tests
 	return GenesisConfig{
 		ExtraData:   "mainnet",
-		GenesisTime: Genesis(time.Now()),
-		Accounts:    generateGenesisAccounts(),
-	}
-}
-
-// DefaultTestGenesisConfig is the default test configuration for the node.
-func DefaultTestGenesisConfig(tb testing.TB) GenesisConfig {
-	// NOTE(dshulyak) keys in default config are used in some tests
-	return GenesisConfig{
-		ExtraData:   "testnet",
 		GenesisTime: Genesis(time.Now()),
 		Accounts:    generateGenesisAccounts(),
 	}

--- a/node/adminservice_api_test.go
+++ b/node/adminservice_api_test.go
@@ -12,13 +12,12 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/spacemeshos/go-spacemesh/api/grpcserver"
-	"github.com/spacemeshos/go-spacemesh/config"
 	"github.com/spacemeshos/go-spacemesh/log/logtest"
 	"github.com/spacemeshos/go-spacemesh/p2p"
 )
 
 func TestPeerInfoApi(t *testing.T) {
-	cfg := config.DefaultTestConfig(t)
+	cfg := getTestConfig(t)
 	cfg.Genesis.Accounts = nil
 	cfg.P2P.DisableNatPort = true
 	cfg.P2P.Listen = p2p.MustParseAddresses("/ip4/127.0.0.1/tcp/0")

--- a/node/bad_peer_test.go
+++ b/node/bad_peer_test.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/spacemeshos/go-spacemesh/codec"
 	"github.com/spacemeshos/go-spacemesh/common/types"
-	"github.com/spacemeshos/go-spacemesh/config"
 	"github.com/spacemeshos/go-spacemesh/log/logtest"
 	"github.com/spacemeshos/go-spacemesh/p2p"
 	ps "github.com/spacemeshos/go-spacemesh/p2p/pubsub"
@@ -29,7 +28,7 @@ func TestPeerDisconnectForMessageResultValidationReject(t *testing.T) {
 	l := logtest.New(t)
 
 	// Make 2 node instances
-	conf1 := config.DefaultTestConfig(t)
+	conf1 := getTestConfig(t)
 	conf1.P2P.Listen = p2p.MustParseAddresses("/ip4/127.0.0.1/tcp/0")
 	conf1.P2P.IP4Blocklist = nil
 	// We setup the api to listen on an OS assigned port, which avoids the second instance getting stuck when
@@ -40,7 +39,7 @@ func TestPeerDisconnectForMessageResultValidationReject(t *testing.T) {
 	// We need to copy the genesis config to ensure that both nodes share the
 	// same genesis ID, otherwise they will not be able to connect to each
 	// other.
-	conf2 := config.DefaultTestConfig(t)
+	conf2 := getTestConfig(t)
 	conf2.Genesis = conf1.Genesis
 	conf2.P2P.Listen = p2p.MustParseAddresses("/ip4/127.0.0.1/tcp/0")
 	conf2.P2P.IP4Blocklist = nil

--- a/node/node.go
+++ b/node/node.go
@@ -1605,7 +1605,9 @@ func (app *App) grpcService(svc grpcserver.Service, lg log.Log) (grpcserver.Serv
 	case v2alpha1.Network:
 		service := v2alpha1.NewNetworkService(
 			app.clock.GenesisTime(),
-			app.Config,
+			app.Config.Genesis.GenesisID(),
+			app.Config.LayerDuration,
+			app.Config.POST.LabelsPerUnit,
 		)
 		app.grpcServices[svc] = service
 		return service, nil
@@ -1661,7 +1663,9 @@ func (app *App) grpcService(svc grpcserver.Service, lg log.Log) (grpcserver.Serv
 	case v2beta1.Network:
 		service := v2beta1.NewNetworkService(
 			app.clock.GenesisTime(),
-			app.Config,
+			app.Config.Genesis.GenesisID(),
+			app.Config.LayerDuration,
+			app.Config.POST.LabelsPerUnit,
 		)
 		app.grpcServices[svc] = service
 		return service, nil

--- a/node/node_identities_test.go
+++ b/node/node_identities_test.go
@@ -15,7 +15,6 @@ import (
 	"go.uber.org/zap/zaptest"
 	"go.uber.org/zap/zaptest/observer"
 
-	"github.com/spacemeshos/go-spacemesh/config"
 	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/log/logtest"
 	"github.com/spacemeshos/go-spacemesh/signing"
@@ -28,7 +27,7 @@ func setupAppWithKeys(tb testing.TB, data ...[]byte) (*App, *observer.ObservedLo
 			return zapcore.NewTee(core, observer)
 		},
 	)))
-	cfg := config.DefaultTestConfig(tb)
+	cfg := getTestConfig(tb)
 	app := New(WithLog(log.NewFromLog(logger)), WithConfig(&cfg))
 	app.Config.DataDirParent = tb.TempDir()
 	if len(data) == 0 {

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -17,6 +17,7 @@ import (
 
 	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
 	pb "github.com/spacemeshos/api/release/go/spacemesh/v1"
+	"github.com/spacemeshos/post/initialization"
 	"github.com/spacemeshos/post/shared"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -37,6 +38,7 @@ import (
 
 	"github.com/spacemeshos/go-spacemesh/activation"
 	"github.com/spacemeshos/go-spacemesh/api/grpcserver"
+	"github.com/spacemeshos/go-spacemesh/beacon"
 	"github.com/spacemeshos/go-spacemesh/cmd"
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/config"
@@ -73,7 +75,7 @@ func newLogger(buf *bytes.Buffer) log.Log {
 func TestSpacemeshApp_SetLoggers(t *testing.T) {
 	r := require.New(t)
 
-	cfg := config.DefaultTestConfig(t)
+	cfg := getTestConfig(t)
 	app := New(WithConfig(&cfg), WithLog(logtest.New(t)))
 
 	var buf1, buf2 bytes.Buffer
@@ -131,7 +133,7 @@ func TestSpacemeshApp_AddLogger(t *testing.T) {
 	var buf bytes.Buffer
 	lg := newLogger(&buf)
 
-	cfg := config.DefaultTestConfig(t)
+	cfg := getTestConfig(t)
 	app := New(WithConfig(&cfg), WithLog(logtest.New(t)))
 
 	myLogger := "anton"
@@ -167,7 +169,7 @@ func cmdWithRun(run func(*cobra.Command, []string) error) *cobra.Command {
 func TestSpacemeshApp_Cmd(t *testing.T) {
 	r := require.New(t)
 
-	cfg := config.DefaultTestConfig(t)
+	cfg := getTestConfig(t)
 	app := New(WithConfig(&cfg), WithLog(logtest.New(t)))
 
 	expected := `unknown command "illegal" for "node"`
@@ -209,7 +211,7 @@ func TestSpacemeshApp_GrpcService(t *testing.T) {
 	listener := "127.0.0.1:1242"
 
 	r := require.New(t)
-	cfg := config.DefaultTestConfig(t)
+	cfg := getTestConfig(t)
 	cfg.API.PublicListener = listener
 	app := New(WithConfig(&cfg), WithLog(logtest.New(t)))
 	err := app.NewIdentity()
@@ -255,7 +257,7 @@ func TestSpacemeshApp_GrpcService(t *testing.T) {
 
 func TestSpacemeshApp_JsonServiceNotRunning(t *testing.T) {
 	r := require.New(t)
-	cfg := config.DefaultTestConfig(t)
+	cfg := getTestConfig(t)
 	app := New(WithConfig(&cfg), WithLog(logtest.New(t)))
 	err := app.NewIdentity()
 	require.NoError(t, err)
@@ -287,7 +289,7 @@ func TestSpacemeshApp_JsonService(t *testing.T) {
 	payload := marshalProto(t, &pb.EchoRequest{Msg: &pb.SimpleString{Value: message}})
 	listener := "127.0.0.1:0"
 
-	cfg := config.DefaultTestConfig(t)
+	cfg := getTestConfig(t)
 	cfg.API.JSONListener = listener
 	cfg.API.PrivateServices = nil
 	app := New(WithConfig(&cfg), WithLog(logtest.New(t)))
@@ -342,7 +344,7 @@ func TestSpacemeshApp_NodeService(t *testing.T) {
 		zaptest.NewLogger(t, zaptest.WrapOptions(zap.Hooks(events.EventHook()), zap.WithPanicHook(&noopHook{}))),
 	)
 
-	cfg := config.DefaultTestConfig(t)
+	cfg := getTestConfig(t)
 	app := New(WithConfig(&cfg), WithLog(logger))
 
 	signer, err := signing.NewEdSigner()
@@ -457,7 +459,7 @@ func TestSpacemeshApp_NodeService(t *testing.T) {
 func TestSpacemeshApp_TransactionService(t *testing.T) {
 	listener := "127.0.0.1:14236"
 
-	cfg := config.DefaultTestConfig(t)
+	cfg := getTestConfig(t)
 	app := New(WithConfig(&cfg), WithLog(logtest.New(t)))
 
 	signer, err := signing.NewEdSigner()
@@ -846,7 +848,7 @@ func TestHRP(t *testing.T) {
 
 func TestGenesisConfig(t *testing.T) {
 	t.Run("config is written to a file", func(t *testing.T) {
-		cfg := config.DefaultTestConfig(t)
+		cfg := getTestConfig(t)
 		app := New(WithConfig(&cfg))
 
 		require.NoError(t, app.Initialize())
@@ -858,7 +860,7 @@ func TestGenesisConfig(t *testing.T) {
 	})
 
 	t.Run("no error if no diff", func(t *testing.T) {
-		cfg := config.DefaultTestConfig(t)
+		cfg := getTestConfig(t)
 		app := New(WithConfig(&cfg))
 
 		require.NoError(t, app.Initialize())
@@ -869,7 +871,7 @@ func TestGenesisConfig(t *testing.T) {
 	})
 
 	t.Run("fatal error on a diff", func(t *testing.T) {
-		cfg := config.DefaultTestConfig(t)
+		cfg := getTestConfig(t)
 		app := New(WithConfig(&cfg))
 
 		require.NoError(t, app.Initialize())
@@ -882,7 +884,7 @@ func TestGenesisConfig(t *testing.T) {
 	})
 
 	t.Run("long extra data", func(t *testing.T) {
-		cfg := config.DefaultTestConfig(t)
+		cfg := getTestConfig(t)
 		cfg.Genesis.ExtraData = string(make([]byte, 256))
 		app := New(WithConfig(&cfg))
 
@@ -892,7 +894,7 @@ func TestGenesisConfig(t *testing.T) {
 
 func TestFlock(t *testing.T) {
 	t.Run("sanity", func(t *testing.T) {
-		cfg := config.DefaultTestConfig(t)
+		cfg := getTestConfig(t)
 		app := New(WithConfig(&cfg))
 
 		require.NoError(t, app.Lock())
@@ -905,7 +907,7 @@ func TestFlock(t *testing.T) {
 	})
 
 	t.Run("dir doesn't exist", func(t *testing.T) {
-		cfg := config.DefaultTestConfig(t)
+		cfg := getTestConfig(t)
 		cfg.FileLock = filepath.Join(t.TempDir(), "newdir", "LOCK")
 		app := New(WithConfig(&cfg))
 
@@ -915,7 +917,7 @@ func TestFlock(t *testing.T) {
 }
 
 func TestEmptyExtraData(t *testing.T) {
-	cfg := config.DefaultTestConfig(t)
+	cfg := getTestConfig(t)
 	cfg.Genesis.ExtraData = ""
 	app := New(WithConfig(&cfg), WithLog(logtest.New(t)))
 	require.Error(t, app.Initialize())
@@ -1223,4 +1225,54 @@ func launchPostSupervisor(
 	ps := activation.NewPostSupervisor(log, postCfg, provingOpts, mgr, builder)
 	require.NoError(tb, ps.Start(cmdCfg, postOpts, sig))
 	return func() { assert.NoError(tb, ps.Stop(false)) }
+}
+
+// getTestConfig returns the default config for tests.
+func getTestConfig(tb testing.TB) config.Config {
+	conf := config.DefaultConfig()
+	conf.MetricsPort += 10000
+	conf.NetworkHRP = "stest"
+
+	types.SetNetworkHRP(conf.NetworkHRP)
+	types.SetLayersPerEpoch(conf.LayersPerEpoch)
+
+	conf.DataDirParent = tb.TempDir()
+	conf.FileLock = filepath.Join(conf.DataDirParent, "spacemesh.lock") // allows multiple configs in one test
+	conf.LayerDuration = 2 * time.Second
+
+	conf.Genesis.ExtraData = "testnet"
+	conf.Genesis.Accounts = map[string]uint64{}
+
+	conf.POST.MinNumUnits = 2
+	conf.POST.MaxNumUnits = 4
+	conf.POST.LabelsPerUnit = 32
+	conf.POST.K2 = 4
+
+	conf.SMESHING.CoinbaseAccount = types.GenerateAddress([]byte{1}).String()
+	conf.SMESHING.Opts.DataDir = filepath.Join(conf.DataDirParent, "post")
+	conf.SMESHING.Opts.NumUnits = conf.POST.MinNumUnits + 1
+	conf.SMESHING.Opts.Scrypt.N = 2
+	conf.SMESHING.Opts.ProviderID.SetUint32(initialization.CPUProviderID())
+
+	// is set to 0 to make sync start immediately when node starts
+	conf.P2P.MinPeers = 0
+
+	conf.Tortoise.Hdist = 5
+	conf.Tortoise.Zdist = 5
+
+	conf.API = grpcserver.DefaultTestConfig(tb)
+	conf.POSTService = activation.DefaultTestPostServiceConfig(tb)
+	conf.Beacon = beacon.NodeSimUnitTestConfig(tb)
+
+	conf.HARE3.PreroundDelay = 10 * time.Millisecond
+	conf.HARE3.RoundDuration = 20 * time.Millisecond
+	conf.HARE4.PreroundDelay = 10 * time.Millisecond
+	conf.HARE4.RoundDuration = 20 * time.Millisecond
+
+	conf.Sync.Interval = time.Second
+
+	conf.FETCH.RequestTimeout = 10 * time.Second
+	conf.FETCH.RequestHardTimeout = 20 * time.Second
+	conf.FETCH.BatchSize = 5
+	return conf
 }

--- a/node/node_version_check_test.go
+++ b/node/node_version_check_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/spacemeshos/go-spacemesh/config"
 	"github.com/spacemeshos/go-spacemesh/sql"
 	"github.com/spacemeshos/go-spacemesh/sql/localsql"
 	"github.com/spacemeshos/go-spacemesh/sql/statesql"
@@ -14,12 +13,12 @@ import (
 
 func TestUpgradeToV15(t *testing.T) {
 	t.Run("fresh installation - no local DB file", func(t *testing.T) {
-		cfg := config.DefaultTestConfig(t)
+		cfg := getTestConfig(t)
 		require.NoError(t, verifyLocalDbMigrations(&cfg))
 	})
 
 	t.Run("migrated DB passes", func(t *testing.T) {
-		cfg := config.DefaultTestConfig(t)
+		cfg := getTestConfig(t)
 		uri := path.Join(cfg.DataDir(), localDbFile)
 		localDb, err := localsql.Open(uri)
 		require.NoError(t, err)
@@ -29,7 +28,7 @@ func TestUpgradeToV15(t *testing.T) {
 	})
 
 	t.Run("not fully migrated DB fails", func(t *testing.T) {
-		cfg := config.DefaultTestConfig(t)
+		cfg := getTestConfig(t)
 		uri := path.Join(cfg.DataDir(), localDbFile)
 
 		schema, err := statesql.Schema()

--- a/systest/tests/common.go
+++ b/systest/tests/common.go
@@ -238,6 +238,11 @@ BACKOFF:
 	if err != nil {
 		return err
 	}
+	defer proofs.CloseSend()
+	_, err = proofs.Header()
+	if err != nil {
+		return fmt.Errorf("malfeasance stream header: %w", err)
+	}
 	for {
 		proof, err := proofs.Recv()
 		s, ok := status.FromError(err)
@@ -258,6 +263,7 @@ BACKOFF:
 			if retries == attempts {
 				return errors.New("malfeasance stream unavailable")
 			}
+			proofs.CloseSend()
 			retries++
 			time.Sleep(retryBackoff)
 			goto BACKOFF


### PR DESCRIPTION
## Motivation

`hare4` has been quite flaky recently, so I added it to the excluded test packages in the `Makefile`. It is still built but not tested any more. Additionally I moved test configuration from the `config` package to the `node` package.

## Description

The test configuration should only be required by the `node` package. Moving it there ensures it is not used in other places (like in `api/grpcserver` packages as it was before the change).

## Test Plan

existing tests pass

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
