### PR TITLE
`SmeshingServiceDebugService` implements `proxy.Service`

### DIFF
--- a/api/grpcserver/smeshing_svc_debug_service.go
+++ b/api/grpcserver/smeshing_svc_debug_service.go
@@ -20,6 +20,10 @@ type SmeshingServiceDebugService struct {
 	loggers map[string]*zap.AtomicLevel
 }
 
+func (s *SmeshingServiceDebugService) Path() string {
+	return "/spacemesh.v1.DebugService/"
+}
+
 // RegisterService registers this service with a grpc server instance.
 func (d *SmeshingServiceDebugService) RegisterService(server *grpc.Server) {
 	pb.RegisterDebugServiceServer(server, d)


### PR DESCRIPTION
Add missing `Path()` method to allow exposing `SmeshingServiceDebugService` as non-proxied local service.

>[!NOTE]
Tests will come in a followup PR