### PR TITLE
test non-proxied services

### DIFF
--- a/node/smeshing_service_test.go
+++ b/node/smeshing_service_test.go
@@ -1,8 +1,10 @@
 package node
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -72,6 +74,7 @@ func getSmeshingServiceTestConfig(tb testing.TB) *config.Config {
 }
 
 func TestNewSmeshingService(t *testing.T) {
+	t.Parallel()
 	t.Run("creates new service with valid config", func(t *testing.T) {
 		cfg := getSmeshingServiceTestConfig(t)
 		service, err := NewSmeshingService(cfg, zaptest.NewLogger(t))
@@ -101,6 +104,7 @@ func TestNewSmeshingService(t *testing.T) {
 }
 
 func TestSmeshingService_Start(t *testing.T) {
+	t.Parallel()
 	t.Run("starts API services", func(t *testing.T) {
 		cfg := getSmeshingServiceTestConfig(t)
 		cfg.API.PublicServices = []grpcserver.Service{grpcserver.Debug}
@@ -142,6 +146,7 @@ func TestSmeshingService_Start(t *testing.T) {
 }
 
 func TestSmeshingService_StartSmeshing(t *testing.T) {
+	t.Parallel()
 	t.Run("starts smeshing with valid coinbase", func(t *testing.T) {
 		cfg := getSmeshingServiceTestConfig(t)
 		service, err := NewSmeshingService(cfg, zaptest.NewLogger(t))
@@ -173,6 +178,7 @@ func TestSmeshingService_StartSmeshing(t *testing.T) {
 }
 
 func TestSmeshingService_GRPCServices(t *testing.T) {
+	t.Parallel()
 	t.Run("initializes all grpc services", func(t *testing.T) {
 		cfg := getSmeshingServiceTestConfig(t)
 		service, err := NewSmeshingService(cfg, zaptest.NewLogger(t))
@@ -205,7 +211,66 @@ func TestSmeshingService_GRPCServices(t *testing.T) {
 	})
 }
 
+func TestSmeshingService_NonProxiedServices(t *testing.T) {
+	t.Parallel()
+	cfg := getSmeshingServiceTestConfig(t)
+	cfg.API.ProxyApiV2Address = "http://127.0.0.1:10000"
+	cfg.API.NonProxiedServices = []grpcserver.Service{
+		grpcserver.SmeshingV2Beta1,
+		grpcserver.SmeshingIdentitiesV2Beta1,
+		grpcserver.Debug,
+	}
+
+	service, err := NewSmeshingService(cfg, zaptest.NewLogger(t))
+	require.NoError(t, err)
+	defer service.Close(context.Background())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, service.start(ctx))
+
+	baseUrl := fmt.Sprintf("http://%s", service.apiProxy.BoundAddress)
+
+	t.Run("can reach debug service", func(t *testing.T) {
+		require.Eventually(t, func() bool {
+			url := baseUrl + "/spacemesh.v1.DebugService/ChangeLogLevel"
+			resp, err := http.Post(url, "application/json", bytes.NewBuffer([]byte(`{"module":"grpc", "level":"debug"}`)))
+			require.NoError(t, err, url)
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err, url)
+			t.Logf("status: %s, body: '%s'", resp.Status, body)
+			resp.Body.Close()
+			return http.StatusOK == resp.StatusCode
+		}, time.Second*10, time.Millisecond*100)
+	})
+	t.Run("can reach smeshing service", func(t *testing.T) {
+		require.Eventually(t, func() bool {
+			url := baseUrl + "/spacemesh.v2beta1.SmeshingService/Version"
+			resp, err := http.Get(url)
+			require.NoError(t, err, url)
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err, url)
+			t.Logf("status: %s, body: '%s'", resp.Status, body)
+			resp.Body.Close()
+			return http.StatusOK == resp.StatusCode
+		}, time.Second*10, time.Millisecond*100)
+	})
+	t.Run("can reach smeshing identities service", func(t *testing.T) {
+		require.Eventually(t, func() bool {
+			url := baseUrl + "/spacemesh.v2beta1.SmeshingIdentitiesService/PoetInfo"
+			resp, err := http.Get(url)
+			require.NoError(t, err, url)
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err, url)
+			t.Logf("status: %s, body: '%s'", resp.Status, body)
+			resp.Body.Close()
+			return http.StatusOK == resp.StatusCode
+		}, time.Second*10, time.Millisecond*100)
+	})
+}
+
 func TestSmeshingService_PprofServer(t *testing.T) {
+	t.Parallel()
 	cfg := getSmeshingServiceTestConfig(t)
 	cfg.PprofHTTPServer = true
 	cfg.PprofHTTPServerListener = ":0"

--- a/node/smeshing_service_test.go
+++ b/node/smeshing_service_test.go
@@ -74,7 +74,6 @@ func getSmeshingServiceTestConfig(tb testing.TB) *config.Config {
 }
 
 func TestNewSmeshingService(t *testing.T) {
-	t.Parallel()
 	t.Run("creates new service with valid config", func(t *testing.T) {
 		cfg := getSmeshingServiceTestConfig(t)
 		service, err := NewSmeshingService(cfg, zaptest.NewLogger(t))
@@ -104,7 +103,6 @@ func TestNewSmeshingService(t *testing.T) {
 }
 
 func TestSmeshingService_Start(t *testing.T) {
-	t.Parallel()
 	t.Run("starts API services", func(t *testing.T) {
 		cfg := getSmeshingServiceTestConfig(t)
 		cfg.API.PublicServices = []grpcserver.Service{grpcserver.Debug}
@@ -146,7 +144,6 @@ func TestSmeshingService_Start(t *testing.T) {
 }
 
 func TestSmeshingService_StartSmeshing(t *testing.T) {
-	t.Parallel()
 	t.Run("starts smeshing with valid coinbase", func(t *testing.T) {
 		cfg := getSmeshingServiceTestConfig(t)
 		service, err := NewSmeshingService(cfg, zaptest.NewLogger(t))
@@ -178,7 +175,6 @@ func TestSmeshingService_StartSmeshing(t *testing.T) {
 }
 
 func TestSmeshingService_GRPCServices(t *testing.T) {
-	t.Parallel()
 	t.Run("initializes all grpc services", func(t *testing.T) {
 		cfg := getSmeshingServiceTestConfig(t)
 		service, err := NewSmeshingService(cfg, zaptest.NewLogger(t))
@@ -212,7 +208,6 @@ func TestSmeshingService_GRPCServices(t *testing.T) {
 }
 
 func TestSmeshingService_NonProxiedServices(t *testing.T) {
-	t.Parallel()
 	cfg := getSmeshingServiceTestConfig(t)
 	cfg.API.ProxyApiV2Address = "http://127.0.0.1:10000"
 	cfg.API.NonProxiedServices = []grpcserver.Service{
@@ -274,7 +269,6 @@ func TestSmeshingService_NonProxiedServices(t *testing.T) {
 }
 
 func TestSmeshingService_PprofServer(t *testing.T) {
-	t.Parallel()
 	cfg := getSmeshingServiceTestConfig(t)
 	cfg.PprofHTTPServer = true
 	cfg.PprofHTTPServerListener = ":0"

--- a/node/smeshing_service_test.go
+++ b/node/smeshing_service_test.go
@@ -234,7 +234,11 @@ func TestSmeshingService_NonProxiedServices(t *testing.T) {
 	t.Run("can reach debug service", func(t *testing.T) {
 		require.Eventually(t, func() bool {
 			url := baseUrl + "/spacemesh.v1.DebugService/ChangeLogLevel"
-			resp, err := http.Post(url, "application/json", bytes.NewBuffer([]byte(`{"module":"grpc", "level":"debug"}`)))
+			resp, err := http.Post(
+				url,
+				"application/json",
+				bytes.NewBuffer([]byte(`{"module":"grpc", "level":"debug"}`)),
+			)
 			require.NoError(t, err, url)
 			body, err := io.ReadAll(resp.Body)
 			require.NoError(t, err, url)


### PR DESCRIPTION
Added unit tests to see if non-proxied local GRPC services can be exposed on the JSON listener when the API proxy is enabled.