### PR TITLE
Added node-service-listener cli option

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,6 +13,9 @@ import (
 
 func AddNodeServiceFlags(flagSet *pflag.FlagSet, cfg *config.Config) *string {
 	configPath := AddCommonFlags(flagSet, cfg)
+
+	flagSet.StringVar(&cfg.API.NodeServiceListener, "node-service-listener",
+		cfg.API.NodeServiceListener, "Listener for the node service")
 	return configPath
 }
 


### PR DESCRIPTION
so... when I was meant to fix it first I accidentally fixed `node-service-address` in https://github.com/spacemeshos/go-spacemesh/pull/6740 wrongly, and then we reverted it. But actually from day0 it was node-service-listener missing...