### PR TITLE
[Merged by Bors] - increase hare commitee size in systests

### DIFF
--- a/systest/parameters/fastnet/smesher.json
+++ b/systest/parameters/fastnet/smesher.json
@@ -28,9 +28,10 @@
         }
     },
     "hare3": {
+        "log-stats": true,
         "committeeupgrade": {
             "layer": 16,
-            "size": 15
+            "size": 50
         }
     },
     "smeshing": {


### PR DESCRIPTION
## Motivation

Fix flaky `TestSmeshing` systest

## Description

The `TestSmeshing` systest was found to be flaky because, sporadically, hare participants active in the preround hare round don't have enough eligibility in total to pass the minimum threshold for tallying up proposal votes. In effect, all proposals in this layer are dropped and the test fails - there is an empty layer and transactions aren't executed.

An example:

A set of received messages from all active participants in the preround:
```
{"L":"DEBUG","T":"2025-02-27T10:05:24.707Z","N":"node.hare","M":"on message","lid":20,"iter":0,"round":"preround","sender":"59b5bf","full":["a68c98747e","c444574941","5ade203487","8ffe47d8af","42ddcd8de6","0b4b007b42"],"vrf_count":1,"atxgrade":5,"malicious":false,"hash":"2b1f516a0f","round":"propose"}
{"L":"DEBUG","T":"2025-02-27T10:05:24.707Z","N":"node.hare","M":"on message","lid":20,"iter":0,"round":"preround","sender":"67df90","full":["5ade203487","c444574941","a68c98747e","42ddcd8de6","0b4b007b42","8ffe47d8af"],"vrf_count":1,"atxgrade":5,"malicious":false,"hash":"47445d13b1","round":"propose"}
{"L":"DEBUG","T":"2025-02-27T10:05:24.707Z","N":"node.hare","M":"on message","lid":20,"iter":0,"round":"preround","sender":"168d76","full":["5ade203487","8ffe47d8af","42ddcd8de6","a68c98747e","c444574941","0b4b007b42"],"vrf_count":4,"atxgrade":5,"malicious":false,"hash":"c96862c3a8","round":"propose"}
{"L":"DEBUG","T":"2025-02-27T10:05:24.707Z","N":"node.hare","M":"on message","lid":20,"iter":0,"round":"preround","sender":"485a6b","full":["a68c98747e","0b4b007b42","5ade203487","8ffe47d8af","c444574941","42ddcd8de6"],"vrf_count":1,"atxgrade":5,"malicious":false,"hash":"5dc7aea850","round":"propose"}
```

Note that the summed `vrf_count` (which stands for the eligibilities (the number of votes)) equal 7. The threshold for the number votes a proposal needs to get to be picked is `commitee_size / 2 + 1 = 8`. In this situation all proposals are dropped:
```
{"L":"INFO","T":"2025-02-27T10:05:25.400Z","N":"node.hare","M":"gossip threshold: dropping item","total":7,"valid":7,"id":"c444574941","threshold":8}
{"L":"INFO","T":"2025-02-27T10:05:25.400Z","N":"node.hare","M":"gossip threshold: dropping item","total":7,"valid":7,"id":"5ade203487","threshold":8}
{"L":"INFO","T":"2025-02-27T10:05:25.400Z","N":"node.hare","M":"gossip threshold: dropping item","total":7,"valid":7,"id":"8ffe47d8af","threshold":8}
{"L":"INFO","T":"2025-02-27T10:05:25.400Z","N":"node.hare","M":"gossip threshold: dropping item","total":7,"valid":7,"id":"42ddcd8de6","threshold":8}
{"L":"INFO","T":"2025-02-27T10:05:25.400Z","N":"node.hare","M":"gossip threshold: dropping item","total":7,"valid":7,"id":"0b4b007b42","threshold":8}
{"L":"INFO","T":"2025-02-27T10:05:25.400Z","N":"node.hare","M":"gossip threshold: dropping item","total":7,"valid":7,"id":"a68c98747e","threshold":8}

{"L":"DEBUG","T":"2025-02-27T10:05:25.400Z","N":"node.hare.hare3_tracer","M":"message sent","lid":0,"iter":0,"round":"propose","sender":"000000","full":[],"vrf_count":0}
                                                                                                                                                 ^^^^^^^^^^ 
                                                                                                                                                 empty list
```

In order to lower the probability of this happening, this PR increases the committee size from 15 to 50 (as on the mainnet).