### PR TITLE
[Merged by Bors] - Fix a possible deadlock in ATXv1 handler

### DIFF
--- a/activation/handler_test.go
+++ b/activation/handler_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/spacemeshos/merkle-tree"
 	poetShared "github.com/spacemeshos/poet/shared"
-	"github.com/spacemeshos/post/shared"
 	"github.com/spacemeshos/post/verifying"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -266,12 +265,20 @@ func TestHandler_PostMalfeasanceProofs(t *testing.T) {
 			func(ctx context.Context, _ types.NodeID, mp *mwire.MalfeasanceProof) error {
 				require.Equal(t, mwire.InvalidPostIndex, mp.Proof.Type)
 
-				postVerifier := NewMockPostVerifier(atxHdlr.ctrl)
-				postVerifier.EXPECT().
-					Verify(context.Background(), (*shared.Proof)(atx.NIPost.Post), gomock.Any(), gomock.Any()).
+				validator := NewMocknipostValidator(atxHdlr.ctrl)
+				validator.EXPECT().
+					Post(
+						context.Background(),
+						gomock.Any(),
+						gomock.Any(),
+						wire.PostFromWireV1(atx.NIPost.Post),
+						gomock.Any(),
+						gomock.Any(),
+						gomock.Any(),
+					).
 					Return(&verifying.ErrInvalidIndex{Index: 2})
 
-				mh := NewInvalidPostIndexHandler(atxHdlr.cdb, atxHdlr.edVerifier, postVerifier)
+				mh := NewInvalidPostIndexHandler(atxHdlr.cdb, atxHdlr.edVerifier, validator)
 				nodeID, err := mh.Validate(context.Background(), mp.Proof.Data)
 				require.NoError(t, err)
 				require.Equal(t, sig.NodeID(), nodeID)
@@ -309,12 +316,20 @@ func TestHandler_PostMalfeasanceProofs(t *testing.T) {
 			func(ctx context.Context, _ types.NodeID, mp *mwire.MalfeasanceProof) error {
 				require.Equal(t, mwire.InvalidPostIndex, mp.Proof.Type)
 
-				postVerifier := NewMockPostVerifier(atxHdlr.ctrl)
-				postVerifier.EXPECT().
-					Verify(context.Background(), (*shared.Proof)(atx.NIPost.Post), gomock.Any(), gomock.Any()).
+				validator := NewMocknipostValidator(atxHdlr.ctrl)
+				validator.EXPECT().
+					Post(
+						context.Background(),
+						gomock.Any(),
+						gomock.Any(),
+						wire.PostFromWireV1(atx.NIPost.Post),
+						gomock.Any(),
+						gomock.Any(),
+						gomock.Any(),
+					).
 					Return(&verifying.ErrInvalidIndex{Index: 2})
 
-				mh := NewInvalidPostIndexHandler(atxHdlr.cdb, atxHdlr.edVerifier, postVerifier)
+				mh := NewInvalidPostIndexHandler(atxHdlr.cdb, atxHdlr.edVerifier, validator)
 				nodeID, err := mh.Validate(context.Background(), mp.Proof.Data)
 				require.NoError(t, err)
 				require.Equal(t, sig.NodeID(), nodeID)

--- a/activation/handler_v1.go
+++ b/activation/handler_v1.go
@@ -327,20 +327,20 @@ func (h *HandlerV1) checkDoublePublish(
 	tx sql.Executor,
 	atx *wire.ActivationTxV1,
 	peer peer.ID,
-) (bool, error) {
+) (*mwire.MalfeasanceProof, error) {
 	prev, err := atxs.GetByEpochAndNodeID(tx, atx.PublishEpoch, atx.SmesherID)
 	if err != nil && !errors.Is(err, sql.ErrNotFound) {
-		return false, err
+		return nil, err
 	}
 	if prev == types.EmptyATXID || prev == atx.ID() {
 		// no ATX previously published for this epoch, or we are handling the same ATX again
-		return false, nil
+		return nil, nil
 	}
 
 	if peer == h.local {
 		// if we land here we tried to publish 2 ATXs in the same epoch
 		// don't punish ourselves but fail validation and thereby the handling of the incoming ATX
-		return false, fmt.Errorf(
+		return nil, fmt.Errorf(
 			"%s already published an ATX in epoch %d",
 			atx.SmesherID.ShortString(),
 			atx.PublishEpoch,
@@ -355,7 +355,7 @@ func (h *HandlerV1) checkDoublePublish(
 	)
 	prevSignature, err := atxSignature(ctx, tx, prev)
 	if err != nil {
-		return false, fmt.Errorf("extracting signature for malfeasance proof: %w", err)
+		return nil, fmt.Errorf("extracting signature for malfeasance proof: %w", err)
 	}
 
 	atxProof := mwire.AtxProof{
@@ -382,7 +382,7 @@ func (h *HandlerV1) checkDoublePublish(
 			Data: &atxProof,
 		},
 	}
-	return true, h.malPublisher.PublishProof(ctx, atx.SmesherID, proof)
+	return proof, nil
 }
 
 // checkWrongPrevAtx verifies if the previous ATX referenced in the ATX is correct.
@@ -391,13 +391,13 @@ func (h *HandlerV1) checkWrongPrevAtx(
 	tx sql.Executor,
 	atx *wire.ActivationTxV1,
 	peer peer.ID,
-) (bool, error) {
+) (*mwire.MalfeasanceProof, wire.Proof, error) {
 	expectedPrevID, err := atxs.PrevIDByNodeID(tx, atx.ID(), atx.SmesherID, atx.PublishEpoch)
 	if err != nil && !errors.Is(err, sql.ErrNotFound) {
-		return false, fmt.Errorf("get last atx by node id: %w", err)
+		return nil, nil, fmt.Errorf("get last atx by node id: %w", err)
 	}
 	if expectedPrevID == atx.PrevATXID {
-		return false, nil
+		return nil, nil, nil
 	}
 
 	if peer == h.local {
@@ -410,7 +410,7 @@ func (h *HandlerV1) checkWrongPrevAtx(
 			log.ZShortStringer("expected", expectedPrevID),
 			log.ZShortStringer("actual", atx.PrevATXID),
 		)
-		return false, fmt.Errorf("%s referenced incorrect previous ATX", atx.SmesherID.ShortString())
+		return nil, nil, fmt.Errorf("%s referenced incorrect previous ATX", atx.SmesherID.ShortString())
 	}
 
 	h.logger.Debug("smesher referenced the wrong previous in published ATX",
@@ -422,37 +422,37 @@ func (h *HandlerV1) checkWrongPrevAtx(
 	atx2ID, err := atxs.AtxWithPrevious(tx, atx.PrevATXID, atx.SmesherID)
 	switch {
 	case errors.Is(err, sql.ErrNotFound):
-		return false, nil
+		return nil, nil, nil
 	case err != nil:
-		return false, fmt.Errorf("fetching atx with previous %s: %w", atx.PrevATXID, err)
+		return nil, nil, fmt.Errorf("fetching atx with previous %s: %w", atx.PrevATXID, err)
 	case atx2ID == atx.ID():
 		// We retrieved the same ATX, which means this ATX is already in the DB.
 		// We don't need to look for a different ATX with the same previous ATX
 		// because if there are already 2 with the same previous ATX, the
 		// malfeasance proof was already generated.
-		return false, nil
+		return nil, nil, nil
 	}
 
 	var blob sql.Blob
 	v, err := atxs.LoadBlob(ctx, tx, atx2ID.Bytes(), &blob)
 	if err != nil {
-		return false, err
+		return nil, nil, err
 	}
 	if v != types.AtxV1 {
 		var watx2 wire.ActivationTxV2
 		if err := codec.Decode(blob.Bytes, &watx2); err != nil {
-			return false, fmt.Errorf("decoding previous atx: %w", err)
+			return nil, nil, fmt.Errorf("decoding previous atx: %w", err)
 		}
 		proof, err := wire.NewInvalidPrevAtxProofV1(tx, &watx2, atx, atx.SmesherID)
 		if err != nil {
-			return false, fmt.Errorf("creating invalid previous ATX proof: %w", err)
+			return nil, nil, fmt.Errorf("creating invalid previous ATX proof: %w", err)
 		}
-		return true, h.malPublisher2.Publish(ctx, atx.SmesherID, proof)
+		return nil, proof, nil
 	}
 
 	var watx2 wire.ActivationTxV1
 	if err := codec.Decode(blob.Bytes, &watx2); err != nil {
-		return false, fmt.Errorf("decoding previous atx: %w", err)
+		return nil, nil, fmt.Errorf("decoding previous atx: %w", err)
 	}
 
 	proof := &mwire.MalfeasanceProof{
@@ -465,7 +465,7 @@ func (h *HandlerV1) checkWrongPrevAtx(
 			},
 		},
 	}
-	return true, h.malPublisher.PublishProof(ctx, atx.SmesherID, proof)
+	return proof, nil, nil
 }
 
 func (h *HandlerV1) checkMalicious(
@@ -473,19 +473,19 @@ func (h *HandlerV1) checkMalicious(
 	tx sql.Transaction,
 	watx *wire.ActivationTxV1,
 	peer peer.ID,
-) (bool, error) {
-	malicious, err := h.checkDoublePublish(ctx, tx, watx, peer)
+) (*mwire.MalfeasanceProof, wire.Proof, error) {
+	proof, err := h.checkDoublePublish(ctx, tx, watx, peer)
 	if err != nil {
-		return malicious, fmt.Errorf("check double publish: %w", err)
+		return proof, nil, fmt.Errorf("check double publish: %w", err)
 	}
-	if malicious {
-		return true, nil
+	if proof != nil {
+		return proof, nil, nil
 	}
-	malicious, err = h.checkWrongPrevAtx(ctx, tx, watx, peer)
+	proof, proof2, err := h.checkWrongPrevAtx(ctx, tx, watx, peer)
 	if err != nil {
-		return malicious, fmt.Errorf("check wrong prev atx: %w", err)
+		return proof, nil, fmt.Errorf("check wrong prev atx: %w", err)
 	}
-	return malicious, nil
+	return proof, proof2, nil
 }
 
 // storeAtx stores an ATX and notifies subscribers of the ATXID.
@@ -495,7 +495,9 @@ func (h *HandlerV1) storeAtx(
 	watx *wire.ActivationTxV1,
 	peer peer.ID,
 ) error {
-	var malicious bool
+	malicious := false
+	var proof *mwire.MalfeasanceProof // legacy malfeasance proofs
+	var proof2 wire.Proof             // new malfeasance proofs
 	if err := h.cdb.WithTxImmediate(ctx, func(tx sql.Transaction) error {
 		var err error
 		malicious, err = identities.IsMalicious(tx, atx.SmesherID)
@@ -508,7 +510,7 @@ func (h *HandlerV1) storeAtx(
 		}
 		malicious = malicious || malicious2
 		if !malicious {
-			malicious, err = h.checkMalicious(ctx, tx, watx, peer)
+			proof, proof2, err = h.checkMalicious(ctx, tx, watx, peer)
 			if err != nil {
 				return fmt.Errorf("check malicious: %w", err)
 			}
@@ -528,8 +530,29 @@ func (h *HandlerV1) storeAtx(
 		return fmt.Errorf("store atx: %w", err)
 	}
 
+	switch {
+	case proof != nil:
+		// new legacy malfeasance proof for identity created, publish proof (= persist and gossip)
+		if err := h.malPublisher.PublishProof(ctx, atx.SmesherID, proof); err != nil {
+			h.logger.Error("failed to publish malfeasance proof",
+				zap.Stringer("atx_id", atx.ID()),
+				zap.Stringer("smesher_id", atx.SmesherID),
+				zap.Error(err),
+			)
+		}
+	case proof2 != nil:
+		// new malfeasance proof for identity created, publish proof (= persist and gossip)
+		if err := h.malPublisher2.Publish(ctx, atx.SmesherID, proof2); err != nil {
+			h.logger.Error("failed to publish malfeasance proof",
+				zap.Stringer("atx_id", atx.ID()),
+				zap.Stringer("smesher_id", atx.SmesherID),
+				zap.Error(err),
+			)
+		}
+	}
+
 	h.beacon.OnAtx(atx)
-	if added := h.cacheAtx(atx, malicious); added != nil {
+	if added := h.cacheAtx(atx, malicious || proof != nil || proof2 != nil); added != nil {
 		h.tortoise.OnAtx(atx.TargetEpoch(), atx.ID(), added)
 	}
 

--- a/activation/handler_v1_test.go
+++ b/activation/handler_v1_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/spacemeshos/post/shared"
 	"github.com/spacemeshos/post/verifying"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -375,12 +374,20 @@ func TestHandlerV1_SyntacticallyValidateAtx(t *testing.T) {
 					return nil
 				}))
 
-				postVerifier := NewMockPostVerifier(atxHdlr.ctrl)
-				postVerifier.EXPECT().
-					Verify(context.Background(), (*shared.Proof)(watx.NIPost.Post), gomock.Any(), gomock.Any()).
+				validator := NewMocknipostValidator(atxHdlr.ctrl)
+				validator.EXPECT().
+					Post(
+						context.Background(),
+						gomock.Any(),
+						gomock.Any(),
+						wire.PostFromWireV1(watx.NIPost.Post),
+						gomock.Any(),
+						gomock.Any(),
+						gomock.Any(),
+					).
 					Return(&verifying.ErrInvalidIndex{Index: 2})
 
-				mh := NewInvalidPostIndexHandler(atxHdlr.cdb, atxHdlr.edVerifier, postVerifier)
+				mh := NewInvalidPostIndexHandler(atxHdlr.cdb, atxHdlr.edVerifier, validator)
 				nodeID, err := mh.Validate(context.Background(), mp.Proof.Data)
 				require.NoError(t, err)
 				require.Equal(t, sig.NodeID(), nodeID)

--- a/activation/handler_v1_test.go
+++ b/activation/handler_v1_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/p2p"
 	"github.com/spacemeshos/go-spacemesh/p2p/pubsub"
 	"github.com/spacemeshos/go-spacemesh/signing"
+	"github.com/spacemeshos/go-spacemesh/sql"
 	"github.com/spacemeshos/go-spacemesh/sql/atxs"
 	"github.com/spacemeshos/go-spacemesh/sql/identities"
 	"github.com/spacemeshos/go-spacemesh/sql/malfeasance"
@@ -361,6 +362,18 @@ func TestHandlerV1_SyntacticallyValidateAtx(t *testing.T) {
 		atxHdlr.mLegacyMalPublish.EXPECT().PublishProof(context.Background(), watx.SmesherID, gomock.Any()).DoAndReturn(
 			func(ctx context.Context, _ types.NodeID, mp *mwire.MalfeasanceProof) error {
 				require.Equal(t, mwire.InvalidPostIndex, mp.Proof.Type)
+
+				// check if no transaction is currently open in the DB, since otherwise it could cause a deadlock
+				require.NoError(t, atxHdlr.cdb.WithTxImmediate(ctx, func(tx sql.Transaction) error {
+					mal, err := identities.IsMalicious(tx, sig.NodeID())
+					require.NoError(t, err)
+					require.False(t, mal)
+
+					mal, err = malfeasance.IsMalicious(tx, sig.NodeID())
+					require.NoError(t, err)
+					require.False(t, mal)
+					return nil
+				}))
 
 				postVerifier := NewMockPostVerifier(atxHdlr.ctrl)
 				postVerifier.EXPECT().
@@ -707,6 +720,18 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 			func(ctx context.Context, _ types.NodeID, mp *mwire.MalfeasanceProof) error {
 				require.Equal(t, mwire.MultipleATXs, mp.Proof.Type)
 
+				// check if no transaction is currently open in the DB, since otherwise it could cause a deadlock
+				require.NoError(t, atxHdlr.cdb.WithTxImmediate(ctx, func(tx sql.Transaction) error {
+					mal, err := identities.IsMalicious(tx, sig.NodeID())
+					require.NoError(t, err)
+					require.False(t, mal)
+
+					mal, err = malfeasance.IsMalicious(tx, sig.NodeID())
+					require.NoError(t, err)
+					require.False(t, mal)
+					return nil
+				}))
+
 				mh := NewMalfeasanceHandler(atxHdlr.cdb, atxHdlr.logger, atxHdlr.edVerifier)
 				nodeID, err := mh.Validate(context.Background(), mp.Proof.Data)
 				require.NoError(t, err)
@@ -715,6 +740,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 			},
 		)
 		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx1, watx1, p2p.Peer("other")))
+		require.True(t, atxHdlr.atxsdata.IsMalicious(atx1.SmesherID))
 	})
 
 	t.Run("another atx for the same epoch for registered ID doesn't create a malfeasance proof", func(t *testing.T) {
@@ -790,6 +816,18 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 			func(ctx context.Context, _ types.NodeID, mp *mwire.MalfeasanceProof) error {
 				require.Equal(t, mwire.InvalidPrevATX, mp.Proof.Type)
 
+				// check if no transaction is currently open in the DB, since otherwise it could cause a deadlock
+				require.NoError(t, atxHdlr.cdb.WithTxImmediate(ctx, func(tx sql.Transaction) error {
+					mal, err := identities.IsMalicious(tx, sig.NodeID())
+					require.NoError(t, err)
+					require.False(t, mal)
+
+					mal, err = malfeasance.IsMalicious(tx, sig.NodeID())
+					require.NoError(t, err)
+					require.False(t, mal)
+					return nil
+				}))
+
 				mh := NewInvalidPrevATXHandler(atxHdlr.cdb, atxHdlr.edVerifier)
 				nodeID, err := mh.Validate(context.Background(), mp.Proof.Data)
 				require.NoError(t, err)
@@ -799,6 +837,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 		)
 
 		require.NoError(t, atxHdlr.storeAtx(context.Background(), atx3, watx3, p2p.Peer("other")))
+		require.True(t, atxHdlr.atxsdata.IsMalicious(atx3.SmesherID))
 	})
 
 	t.Run("another atx of v2 with the same prevatx is considered malicious", func(t *testing.T) {
@@ -851,6 +890,18 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 
 		atxHdlr.mMalPublish.EXPECT().Publish(context.Background(), sig.NodeID(), gomock.Any()).DoAndReturn(
 			func(ctx context.Context, _ types.NodeID, proof wire.Proof) error {
+				// check if no transaction is currently open in the DB, since otherwise it could cause a deadlock
+				require.NoError(t, atxHdlr.cdb.WithTxImmediate(ctx, func(tx sql.Transaction) error {
+					mal, err := identities.IsMalicious(tx, sig.NodeID())
+					require.NoError(t, err)
+					require.False(t, mal)
+
+					mal, err = malfeasance.IsMalicious(tx, sig.NodeID())
+					require.NoError(t, err)
+					require.False(t, mal)
+					return nil
+				}))
+
 				malProof := proof.(*wire.ProofInvalidPrevAtxV1)
 				nId, err := malProof.Valid(context.Background(), verifier)
 				require.NoError(t, err)
@@ -860,6 +911,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 		)
 
 		require.NoError(t, atxHdlr.v1.storeAtx(context.Background(), atx3, watx3, p2p.Peer("other")))
+		require.True(t, atxHdlr.v1.atxsdata.IsMalicious(atx3.SmesherID))
 	})
 
 	t.Run("another atx with the same prevatx when publishing doesn't create a malfeasance proof", func(t *testing.T) {

--- a/activation/malfeasance.go
+++ b/activation/malfeasance.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/spacemeshos/post/shared"
-	"github.com/spacemeshos/post/verifying"
 	"go.uber.org/zap"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
@@ -98,20 +96,20 @@ func (mh *MalfeasanceHandler) ReportLabel() string {
 type InvalidPostIndexHandler struct {
 	db sql.Executor
 
-	edVerifier   *signing.EdVerifier
-	postVerifier PostVerifier
+	edVerifier *signing.EdVerifier
+	validator  nipostValidatorV1
 }
 
 func NewInvalidPostIndexHandler(
 	db sql.Executor,
 	edVerifier *signing.EdVerifier,
-	postVerifier PostVerifier,
+	validator nipostValidatorV1,
 ) *InvalidPostIndexHandler {
 	return &InvalidPostIndexHandler{
 		db: db,
 
-		edVerifier:   edVerifier,
-		postVerifier: postVerifier,
+		edVerifier: edVerifier,
+		validator:  validator,
 	}
 }
 
@@ -145,19 +143,18 @@ func (mh *InvalidPostIndexHandler) Validate(ctx context.Context, data wire.Proof
 		}
 		commitmentAtx = &atx
 	}
-	post := (*shared.Proof)(atx.NIPost.Post)
-	meta := &shared.ProofMetadata{
-		NodeId:          atx.SmesherID.Bytes(),
-		CommitmentAtxId: commitmentAtx.Bytes(),
-		NumUnits:        atx.NumUnits,
-		Challenge:       atx.NIPost.PostMetadata.Challenge,
-		LabelsPerUnit:   atx.NIPost.PostMetadata.LabelsPerUnit,
+	meta := &types.PostMetadata{
+		Challenge:     atx.NIPost.PostMetadata.Challenge,
+		LabelsPerUnit: atx.NIPost.PostMetadata.LabelsPerUnit,
 	}
-	if err := mh.postVerifier.Verify(
+	if err := mh.validator.Post(
 		ctx,
-		post,
+		atx.SmesherID,
+		*commitmentAtx,
+		(*types.Post)(atx.NIPost.Post),
 		meta,
-		WithVerifierOptions(verifying.SelectedIndex(int(proof.InvalidIdx))),
+		atx.NumUnits,
+		PostIndex(int(proof.InvalidIdx)),
 	); err != nil {
 		return atx.SmesherID, nil
 	}

--- a/activation/malfeasance_test.go
+++ b/activation/malfeasance_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/spacemeshos/post/shared"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 	"go.uber.org/zap"
@@ -235,20 +234,20 @@ func TestMalfeasanceHandler_Validate(t *testing.T) {
 type testInvalidPostIndexHandler struct {
 	*InvalidPostIndexHandler
 
-	mockPostVerifier *MockPostVerifier
+	mocknipostValidator *MocknipostValidator
 }
 
 func newTestInvalidPostIndexHandler(tb testing.TB) *testInvalidPostIndexHandler {
 	db := statesql.InMemoryTest(tb)
 
 	ctrl := gomock.NewController(tb)
-	postVerifier := NewMockPostVerifier(ctrl)
+	postVerifier := NewMocknipostValidator(ctrl)
 
 	h := NewInvalidPostIndexHandler(db, signing.NewEdVerifier(), postVerifier)
 	return &testInvalidPostIndexHandler{
 		InvalidPostIndexHandler: h,
 
-		mockPostVerifier: postVerifier,
+		mocknipostValidator: postVerifier,
 	}
 }
 
@@ -289,22 +288,22 @@ func TestInvalidPostIndexHandler_Validate(t *testing.T) {
 			InvalidIdx: 7,
 		}
 
-		postProof := &shared.Proof{
+		postProof := &types.Post{
 			Nonce:   atx.NIPost.Post.Nonce,
 			Indices: atx.NIPost.Post.Indices,
 			Pow:     atx.NIPost.Post.Pow,
 		}
-		meta := &shared.ProofMetadata{
-			NodeId:          atx.SmesherID.Bytes(),
-			CommitmentAtxId: atx.NIPostChallengeV1.CommitmentATXID.Bytes(),
-
+		meta := &types.PostMetadata{
 			Challenge:     atx.NIPost.PostMetadata.Challenge,
-			NumUnits:      atx.NumUnits,
 			LabelsPerUnit: atx.NIPost.PostMetadata.LabelsPerUnit,
 		}
-		h.mockPostVerifier.EXPECT().Verify(gomock.Any(),
+		h.mocknipostValidator.EXPECT().Post(
+			gomock.Any(),
+			atx.SmesherID,
+			*atx.NIPostChallengeV1.CommitmentATXID,
 			postProof,
 			meta,
+			atx.NumUnits,
 			gomock.Any(),
 		).Return(errors.New("invalid post"))
 		nodeID, err := h.Validate(context.Background(), proof)
@@ -348,22 +347,22 @@ func TestInvalidPostIndexHandler_Validate(t *testing.T) {
 			InvalidIdx: 7,
 		}
 
-		postProof := &shared.Proof{
+		postProof := &types.Post{
 			Nonce:   atx.NIPost.Post.Nonce,
 			Indices: atx.NIPost.Post.Indices,
 			Pow:     atx.NIPost.Post.Pow,
 		}
-		meta := &shared.ProofMetadata{
-			NodeId:          atx.SmesherID.Bytes(),
-			CommitmentAtxId: atx.NIPostChallengeV1.CommitmentATXID.Bytes(),
-
+		meta := &types.PostMetadata{
 			Challenge:     atx.NIPost.PostMetadata.Challenge,
-			NumUnits:      atx.NumUnits,
 			LabelsPerUnit: atx.NIPost.PostMetadata.LabelsPerUnit,
 		}
-		h.mockPostVerifier.EXPECT().Verify(gomock.Any(),
+		h.mocknipostValidator.EXPECT().Post(
+			gomock.Any(),
+			atx.SmesherID,
+			*atx.NIPostChallengeV1.CommitmentATXID,
 			postProof,
 			meta,
+			atx.NumUnits,
 			gomock.Any(),
 		).Return(nil)
 		nodeID, err := h.Validate(context.Background(), proof)

--- a/node/node.go
+++ b/node/node.go
@@ -1175,7 +1175,7 @@ func (app *App) initServices(ctx context.Context) error {
 	invalidPostMH := activation.NewInvalidPostIndexHandler(
 		app.cachedDB,
 		app.edVerifier,
-		app.postVerifier,
+		validator,
 	)
 	invalidPrevMH := activation.NewInvalidPrevATXHandler(app.cachedDB, app.edVerifier)
 

--- a/node/node_integrity_test.go
+++ b/node/node_integrity_test.go
@@ -36,11 +36,24 @@ func TestCheckDBValidity(t *testing.T) {
 	edVerifier := signing.NewEdVerifier(
 		signing.WithVerifierPrefix(cfg.Genesis.GenesisID().Bytes()),
 	)
+	poetDb, err := activation.NewPoetDb(
+		db,
+		logger.Named("poet_db"),
+		activation.WithCacheSize(cfg.POET.PoetProofsCache),
+	)
+	require.NoError(t, err)
 	postVerifier, err := activation.NewPostVerifier(
 		cfg.POST,
 		logger.Named("post_verifier"),
 	)
 	require.NoError(t, err)
+	validator := activation.NewValidator(
+		db,
+		poetDb,
+		cfg.POST,
+		cfg.SMESHING.Opts.Scrypt,
+		postVerifier,
+	)
 
 	malfeasanceLogger := logger.Named("malfeasance")
 	activationMH := activation.NewMalfeasanceHandler(
@@ -61,7 +74,7 @@ func TestCheckDBValidity(t *testing.T) {
 	invalidPostMH := activation.NewInvalidPostIndexHandler(
 		db,
 		edVerifier,
-		postVerifier,
+		validator,
 	)
 	invalidPrevMH := activation.NewInvalidPrevATXHandler(db, edVerifier)
 


### PR DESCRIPTION
## Motivation

This fixes a possible deadlock in ATXv1 handler that can cause a node to get stuck syncing ATXs.

## Description

The problem is that when detecting a malicious ATX in `checkMalfeasance` the node opens a nested DB transaction by calling `Publish`/`PublishProof` on the legacy or new malfeasance publisher. These methods are locking on the same tables (`identities`/`malfeasance`) as are already locked by `storeAtx` of the ATXv1 handler.

In ATXv2 this is not an issue because there the malfeasance publisher is not called from within the TX, so there is no possibility for this deadlock.

## Test Plan

I updated the existing tests that check for malfeasance proofs being published to also open a DB transaction when `Publish`/`PublishProof` is called. Without the changes those tests would deadlock and timeout with the test failing. With the updated code the tests pass again (i.e. the deadlock isn't present any more).

## TODO

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
