### PR TITLE
[Merged by Bors] - fix cleaning up 'kubectl wait' processes when running systest

### DIFF
--- a/systest/wait_for_job.sh
+++ b/systest/wait_for_job.sh
@@ -1,15 +1,32 @@
 #!/bin/bash
 set -u
+
+# Function to clean up background processes
+cleanup() {
+    # Kill both background processes if they exist
+    if [[ -n "${complete_id:-}" ]]; then
+        kill $complete_id 2>/dev/null || true
+    fi
+    if [[ -n "${fail_id:-}" ]]; then
+        kill $fail_id 2>/dev/null || true
+    fi
+
+    # Make sure there are no kubectl wait processes left for this job
+    pkill -f "kubectl wait --for=condition=.*job/$test_job_name" 2>/dev/null || true
+
+    exit ${1:-$exit_code}
+}
+
+# Set up trap to ensure cleanup happens on exit
+trap 'cleanup' EXIT INT TERM
+
 echo Waiting for job/$test_job_name to complete or fail
+
+# Start the wait processes
 kubectl wait --for=condition=complete job/$test_job_name --timeout=-1s & complete_id=$!
-kubectl wait --for=condition=failed job/$test_job_name --timeout=-1s && exit 1 & fail_id=$!
+kubectl wait --for=condition=failed job/$test_job_name --timeout=-1s  && exit 1 & fail_id=$!
+
+# Wait for either process to finish
 wait -n $complete_id $fail_id
 exit_code=$?
 
-if [[ $exit_code -eq 0 ]]; then
-    kill $fail_id
-else
-    kill $complete_id
-fi
-
-exit $exit_code


### PR DESCRIPTION
## Motivation

The script waiting for systest job to finish sometimes leaks a `kubectl wait` process running in the background.

## Description

Example:

```sh
> ps aux | grep kubect
bartosz   631304  0.0  0.1 5479936 43968 pts/1   Sl   Mar04   0:03 kubectl wait --for=condition=failed job/systest-ffda2d3e5-1741085557 --timeout=-1s
```

Fix the cleaning up of wait processes in the script.