### PR TITLE
Update runner on CI and Release workflows.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
           - ubuntu-22.04
           - ubuntu-latest-arm-8-cores
           - macos-13
-          - [self-hosted, macOS, ARM64, go-spacemesh]
+          - [self-hosted, macOS, ARM64, smapp]
           - windows-2022
     steps:
       - name: Add OpenCL support - Ubuntu
@@ -222,7 +222,7 @@ jobs:
           - ubuntu-latest-arm-8-cores
           # FIXME: reenable the macos runner
           # - macos-13
-          - [self-hosted, macOS, ARM64, go-spacemesh]
+          - [self-hosted, macOS, ARM64, smapp]
           - windows-2022
     steps:
       # as we use some request to localhost, sometimes it gives us flaky tests. try to disable tcp offloading for fix it
@@ -233,7 +233,7 @@ jobs:
           sudo ethtool -K eth0 tx off
           sudo ethtool -K eth0 rx off
       - name: disable TCP/UDP offload - MacOS
-        if: ${{ matrix.os == 'macos-13' || matrix.os == '[self-hosted, macOS, ARM64, go-spacemesh]' }}
+        if: ${{ matrix.os == 'macos-13' || matrix.os == '[self-hosted, macOS, ARM64, smapp]' }}
         run: |
           sudo sysctl -w net.link.generic.system.hwcksum_tx=0
           sudo sysctl -w net.link.generic.system.hwcksum_rx=0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
             outname_sufix: "linux-arm64"
           - os: macos-13
             outname_sufix: "mac-amd64"
-          - os: [self-hosted, macOS, ARM64, go-spacemesh]
+          - os: [self-hosted, macOS, ARM64, smapp]
             outname_sufix: "mac-arm64"
           - os: windows-2022
             outname_sufix: "win-amd64"


### PR DESCRIPTION
## Motivation
This PR aims to replace the `sm-macmini-m2pro` runner, as it is no longer needed.
## Description
- **Runner Replacement in workflows**: The `sm-macmini-m2pro` runner has been replaced with the `SDMM134` runner in the CI and Release GitHub Actions workflows. This change reflects updated workflow requirements