### PR TITLE
[Merged by Bors] - Change malfeasance streaming guarantees

### DIFF
--- a/api/grpcserver/v2alpha1/malfeasance.go
+++ b/api/grpcserver/v2alpha1/malfeasance.go
@@ -163,6 +163,16 @@ func (s *MalfeasanceStreamService) Stream(
 	request *spacemeshv2alpha1.MalfeasanceStreamRequest,
 	stream spacemeshv2alpha1.MalfeasanceStreamService_StreamServer,
 ) error {
+	var sub subscription
+	if request.Watch {
+		var err error
+		sub, err = s.events.SubscribeMatched(request)
+		if err != nil {
+			return status.Error(codes.Internal, err.Error())
+		}
+		defer sub.Close()
+	}
+
 	legacyProofs, err := fetchLegacyFromDB(
 		stream.Context(),
 		s.db,
@@ -201,15 +211,10 @@ func (s *MalfeasanceStreamService) Stream(
 		}
 	}
 
-	if !request.Watch {
+	if sub == nil {
 		return nil
 	}
 
-	sub, err := s.events.SubscribeMatched(request)
-	if err != nil {
-		return status.Error(codes.Internal, err.Error())
-	}
-	defer sub.Close()
 	eventsOut := sub.Out()
 	eventsFull := sub.Full()
 

--- a/api/grpcserver/v2beta1/malfeasance.go
+++ b/api/grpcserver/v2beta1/malfeasance.go
@@ -163,6 +163,16 @@ func (s *MalfeasanceStreamService) Stream(
 	request *spacemeshv2beta1.MalfeasanceStreamRequest,
 	stream spacemeshv2beta1.MalfeasanceStreamService_StreamServer,
 ) error {
+	var sub subscription
+	if request.Watch {
+		var err error
+		sub, err = s.events.SubscribeMatched(request)
+		if err != nil {
+			return status.Error(codes.Internal, err.Error())
+		}
+		defer sub.Close()
+	}
+
 	legacyProofs, err := fetchLegacyFromDB(
 		stream.Context(),
 		s.db,
@@ -201,15 +211,10 @@ func (s *MalfeasanceStreamService) Stream(
 		}
 	}
 
-	if !request.Watch {
+	if sub == nil {
 		return nil
 	}
 
-	sub, err := s.events.SubscribeMatched(request)
-	if err != nil {
-		return status.Error(codes.Internal, err.Error())
-	}
-	defer sub.Close()
 	eventsOut := sub.Out()
 	eventsFull := sub.Full()
 


### PR DESCRIPTION
## Motivation

The malfeasance stream (v2alpha1 and v2beta1) right now guarantees that every malfeasance event is streamed at most once, this changes the guarantee to at least once.

## Description

When streaming proofs we read them from the DB and from the event bus. Without caching we can only guarantee that we stream every proof at most once or at least once. At the moment we have occasional systest fails because the proof we are looking for has not been streamed, due to the event being missed while reading from the DB.

To ensure the systests are not failing because of a missed event, I change the behavior to possibly stream the same proof twice. For the systest this doesn't matter, since we only check if we received the proof at all.

De-duplicating on the server side is costly: requires caching and deduplicating of proofs already sent for every connected client. So instead I think the best way is to put the de-duplication effort on the client.

## Test Plan

n/a

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
