### PR TITLE
[Merged by Bors] - Prepare v1.8.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,18 +2,37 @@
 
 See [RELEASE](./RELEASE.md) for workflow instructions.
 
+## v1.8.0
+
+### Highlights
+
+This release will enable syncv2 fully to sync ATXs for all nodes. This should greatly reduce the time it takes to sync
+a node from genesis and the amount of data that is needed to be exchanged with the network to keep a node in sync. The
+improvements are enabled automatically after upgrading to this version and no user action is needed.
+
+Development on ATXv2 has concluded and the feature is now enabled on mainnet. Nodes will produce the new ATX format
+starting from epoch 45 and ever epoch after. The new ATXs also comes with new malfeasance proofs that are more efficient
+in terms of data size and more easily extendable in the future.
+
+### Improvements
+
+* [#6777](https://github.com/spacemeshos/go-spacemesh/pull/6777) Change malfeasance streaming guarantees for v2alpha1
+  and v2beta1. Now instead of guaranteeing that every proof will be streamed at most once, the guarantee is that every
+  proof will be streamed at least once. This ensures that no malfeasance proofs are missed when streaming, but shifts
+  responsibilities for deduplication to clients.
+
 ## v1.7.17
 
 ### Improvements
 
-- [#6756](https://github.com/spacemeshos/go-spacemesh/pull/6756) Fixed possible deadlock in ATX handler which
+* [#6756](https://github.com/spacemeshos/go-spacemesh/pull/6756) Fixed possible deadlock in ATX handler which
   sometimes results in sync from genesis getting stuck.
 
 ## v1.7.16
 
 ### Improvements
 
-- [#6746](https://github.com/spacemeshos/go-spacemesh/pull/6746) Fixed malfeasance sync not starting in
+* [#6746](https://github.com/spacemeshos/go-spacemesh/pull/6746) Fixed malfeasance sync not starting in
   the first ATX V2 epoch.
 
 ## v1.7.15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ in terms of data size and more easily extendable in the future.
   proof will be streamed at least once. This ensures that no malfeasance proofs are missed when streaming, but shifts
   responsibilities for deduplication to clients.
 
+* [#6779](https://github.com/spacemeshos/go-spacemesh/pull/6779) Fixed the malfeasance publisher not emitting events.
+  This caused the node to miss malfeasance proofs when streaming via the GRPC API.
+
 ## v1.7.17
 
 ### Improvements

--- a/config/mainnet.go
+++ b/config/mainnet.go
@@ -136,6 +136,10 @@ func MainnetConfig() Config {
 			ATXGradeDelay:           30 * time.Minute,
 			PostValidDelay:          time.Duration(math.MaxInt64),
 			PprofHTTPServerListener: "localhost:6060",
+
+			AtxVersions: activation.AtxVersions{
+				types.EpochID(45): types.AtxV2,
+			},
 		},
 		Genesis: GenesisConfig{
 			GenesisTime: Genesis(genesisTime),
@@ -226,6 +230,7 @@ func MainnetConfig() Config {
 			MalSync:                  malsync.DefaultConfig(),
 			ReconcSync: syncer.ReconcSyncConfig{
 				Enable:            true,
+				EnableActiveSync:  true,
 				OldAtxSyncCfg:     oldAtxSyncCfg,
 				NewAtxSyncCfg:     newAtxSyncCfg,
 				ParallelLoadLimit: 10,


### PR DESCRIPTION
## Motivation

This prepares the node for the `v1.8.0` release.

## Description

I updated the CHANGELOG with information about the recent changes and enabled both syncv2 and ATXv2 (starting from epoch 45) in the mainnet config.

## Test Plan

n/a

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
