### PR TITLE
[Merged by Bors] - Fix Malfeasance publishers not emitting events

### DIFF
--- a/malfeasance/handler_test.go
+++ b/malfeasance/handler_test.go
@@ -176,8 +176,8 @@ spacemesh_malfeasance_num_invalid_proofs{type="multiATXs"} 1
 		events.InitializeReporter()
 		defer events.CloseEventReporter()
 		sub, err := events.SubscribeMatched(func(event *events.EventMalfeasance) bool { return true })
-		defer sub.Close()
 		require.NoError(t, err)
+		defer sub.Close()
 
 		h.mockTrt.EXPECT().OnMalfeasance(nodeID)
 		err = h.HandleGossip(t.Context(), "peer", codec.MustEncode(gossip))
@@ -319,8 +319,8 @@ spacemesh_malfeasance_num_invalid_proofs{type="mal"} 1
 		events.InitializeReporter()
 		defer events.CloseEventReporter()
 		sub, err := events.SubscribeMatched(func(event *events.EventMalfeasance) bool { return true })
-		defer sub.Close()
 		require.NoError(t, err)
+		defer sub.Close()
 
 		expectedHash := types.RandomHash()
 		h.mockTrt.EXPECT().OnMalfeasance(nodeID)
@@ -423,8 +423,8 @@ spacemesh_malfeasance_num_invalid_proofs{type="multiATXs"} 1
 		events.InitializeReporter()
 		defer events.CloseEventReporter()
 		sub, err := events.SubscribeMatched(func(event *events.EventMalfeasance) bool { return true })
-		defer sub.Close()
 		require.NoError(t, err)
+		defer sub.Close()
 
 		h.mockTrt.EXPECT().OnMalfeasance(nodeID)
 		err = h.HandleSynced(t.Context(), types.Hash32(nodeID), "peer", proofBytes)

--- a/malfeasance/handler_test.go
+++ b/malfeasance/handler_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/codec"
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/datastore"
+	"github.com/spacemeshos/go-spacemesh/events"
 	"github.com/spacemeshos/go-spacemesh/malfeasance/wire"
 	"github.com/spacemeshos/go-spacemesh/p2p"
 	"github.com/spacemeshos/go-spacemesh/p2p/pubsub"
@@ -172,8 +173,14 @@ spacemesh_malfeasance_num_invalid_proofs{type="multiATXs"} 1
 			},
 		}
 
+		events.InitializeReporter()
+		defer events.CloseEventReporter()
+		sub, err := events.SubscribeMatched(func(event *events.EventMalfeasance) bool { return true })
+		defer sub.Close()
+		require.NoError(t, err)
+
 		h.mockTrt.EXPECT().OnMalfeasance(nodeID)
-		err := h.HandleGossip(t.Context(), "peer", codec.MustEncode(gossip))
+		err = h.HandleGossip(t.Context(), "peer", codec.MustEncode(gossip))
 		require.NoError(t, err)
 
 		var blob sql.Blob
@@ -186,6 +193,13 @@ spacemesh_malfeasance_num_invalid_proofs{type="multiATXs"} 1
 spacemesh_malfeasance_num_proofs{type="multiATXs"} 1
 `
 		require.NoError(t, testutil.CollectAndCompare(h.numProofs, strings.NewReader(expected)))
+
+		select {
+		case ev := <-sub.Out():
+			require.Equal(t, nodeID, ev.Smesher)
+		case <-time.After(5 * time.Second):
+			require.FailNow(t, "timed out waiting for event")
+		}
 	})
 
 	t.Run("new proof is noop", func(t *testing.T) {
@@ -302,9 +316,15 @@ spacemesh_malfeasance_num_invalid_proofs{type="mal"} 1
 			},
 		}
 
+		events.InitializeReporter()
+		defer events.CloseEventReporter()
+		sub, err := events.SubscribeMatched(func(event *events.EventMalfeasance) bool { return true })
+		defer sub.Close()
+		require.NoError(t, err)
+
 		expectedHash := types.RandomHash()
 		h.mockTrt.EXPECT().OnMalfeasance(nodeID)
-		err := h.HandleSynced(
+		err = h.HandleSynced(
 			t.Context(),
 			expectedHash,
 			"peer",
@@ -326,6 +346,13 @@ spacemesh_malfeasance_num_invalid_proofs{type="mal"} 1
 spacemesh_malfeasance_num_proofs{type="multiATXs"} 1
 `
 		require.NoError(t, testutil.CollectAndCompare(h.numProofs, strings.NewReader(expected))) // proof is still valid
+
+		select {
+		case ev := <-sub.Out():
+			require.Equal(t, nodeID, ev.Smesher)
+		case <-time.After(5 * time.Second):
+			require.FailNow(t, "timed out waiting for event")
+		}
 	})
 
 	t.Run("invalid proof", func(t *testing.T) {
@@ -393,8 +420,14 @@ spacemesh_malfeasance_num_invalid_proofs{type="multiATXs"} 1
 		}
 		proofBytes := codec.MustEncode(proof)
 
+		events.InitializeReporter()
+		defer events.CloseEventReporter()
+		sub, err := events.SubscribeMatched(func(event *events.EventMalfeasance) bool { return true })
+		defer sub.Close()
+		require.NoError(t, err)
+
 		h.mockTrt.EXPECT().OnMalfeasance(nodeID)
-		err := h.HandleSynced(t.Context(), types.Hash32(nodeID), "peer", proofBytes)
+		err = h.HandleSynced(t.Context(), types.Hash32(nodeID), "peer", proofBytes)
 		require.NoError(t, err)
 
 		var blob sql.Blob
@@ -407,6 +440,13 @@ spacemesh_malfeasance_num_invalid_proofs{type="multiATXs"} 1
 spacemesh_malfeasance_num_proofs{type="multiATXs"} 1
 `
 		require.NoError(t, testutil.CollectAndCompare(h.numProofs, strings.NewReader(expected)))
+
+		select {
+		case ev := <-sub.Out():
+			require.Equal(t, nodeID, ev.Smesher)
+		case <-time.After(5 * time.Second):
+			require.FailNow(t, "timed out waiting for event")
+		}
 	})
 
 	t.Run("new proof is noop", func(t *testing.T) {

--- a/malfeasance/publisher.go
+++ b/malfeasance/publisher.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/codec"
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/datastore"
+	"github.com/spacemeshos/go-spacemesh/events"
 	"github.com/spacemeshos/go-spacemesh/malfeasance/wire"
 	"github.com/spacemeshos/go-spacemesh/p2p/pubsub"
 	"github.com/spacemeshos/go-spacemesh/sql/identities"
@@ -56,6 +57,7 @@ func (p *Publisher) PublishProof(ctx context.Context, smesherID types.NodeID, pr
 
 	p.cdb.CacheMalfeasanceProof(smesherID, codec.MustEncode(proof))
 	p.tortoise.OnMalfeasance(smesherID)
+	events.ReportMalfeasance(smesherID)
 
 	// Only gossip the proof if we are synced (to not spam the network with proofs others probably already have).
 	if !p.sync.ListenToATXGossip() {

--- a/malfeasance/publisher_test.go
+++ b/malfeasance/publisher_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/codec"
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/datastore"
+	"github.com/spacemeshos/go-spacemesh/events"
 	"github.com/spacemeshos/go-spacemesh/malfeasance/wire"
 	"github.com/spacemeshos/go-spacemesh/p2p/pubsub"
 	"github.com/spacemeshos/go-spacemesh/p2p/pubsub/mocks"
@@ -81,12 +82,25 @@ func TestMalfeasancePublisher(t *testing.T) {
 				return nil
 			})
 
-		err := malPublisher.PublishProof(t.Context(), nodeID, proof)
+		events.InitializeReporter()
+		defer events.CloseEventReporter()
+		sub, err := events.SubscribeMatched(func(event *events.EventMalfeasance) bool { return true })
+		require.NoError(t, err)
+		defer sub.Close()
+
+		err = malPublisher.PublishProof(t.Context(), nodeID, proof)
 		require.NoError(t, err)
 
 		malicious, err := identities.IsMalicious(malPublisher.cdb, nodeID)
 		require.NoError(t, err)
 		require.True(t, malicious)
+
+		select {
+		case ev := <-sub.Out():
+			require.Equal(t, nodeID, ev.Smesher)
+		case <-time.After(5 * time.Second):
+			require.FailNow(t, "timed out waiting for event")
+		}
 	})
 
 	t.Run("PublishProof when not in sync", func(t *testing.T) {
@@ -101,16 +115,29 @@ func TestMalfeasancePublisher(t *testing.T) {
 			},
 		}
 
+		events.InitializeReporter()
+		defer events.CloseEventReporter()
+		sub, err := events.SubscribeMatched(func(event *events.EventMalfeasance) bool { return true })
+		require.NoError(t, err)
+		defer sub.Close()
+
 		malPublisher.mTortoise.EXPECT().OnMalfeasance(nodeID)
 		malPublisher.mSyncer.EXPECT().ListenToATXGossip().Return(false)
 
-		err := malPublisher.PublishProof(t.Context(), nodeID, proof)
+		err = malPublisher.PublishProof(t.Context(), nodeID, proof)
 		require.NoError(t, err)
 
-		// proof is only persisted but not published
+		// proof is persisted but not published
 		malicious, err := identities.IsMalicious(malPublisher.cdb, nodeID)
 		require.NoError(t, err)
 		require.True(t, malicious)
+
+		select {
+		case ev := <-sub.Out():
+			require.Equal(t, nodeID, ev.Smesher)
+		case <-time.After(5 * time.Second):
+			require.FailNow(t, "timed out waiting for event")
+		}
 	})
 
 	t.Run("PublishProof when already marked as malicious", func(t *testing.T) {

--- a/malfeasance2/handler_test.go
+++ b/malfeasance2/handler_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/spacemeshos/go-spacemesh/codec"
 	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/events"
 	"github.com/spacemeshos/go-spacemesh/malfeasance2"
 	"github.com/spacemeshos/go-spacemesh/p2p"
 	"github.com/spacemeshos/go-spacemesh/p2p/pubsub"
@@ -107,11 +108,7 @@ func TestRegister(t *testing.T) {
 }
 
 func TestHandler_HandleSync(t *testing.T) {
-	t.Parallel()
-
 	t.Run("malformed data", func(t *testing.T) {
-		t.Parallel()
-
 		th := newTestHandler(t)
 
 		err := th.HandleSynced(t.Context(), types.EmptyHash32, "peer", []byte("malformed"))
@@ -127,7 +124,6 @@ spacemesh_malfeasance2_num_invalid_proofs{domain="mal",type="unknown"} 1
 	})
 
 	t.Run("unknown version", func(t *testing.T) {
-		t.Parallel()
 		th := newTestHandler(t)
 
 		proof := &malfeasance2.MalfeasanceProof{
@@ -140,7 +136,6 @@ spacemesh_malfeasance2_num_invalid_proofs{domain="mal",type="unknown"} 1
 	})
 
 	t.Run("unknown domain", func(t *testing.T) {
-		t.Parallel()
 		th := newTestHandler(t)
 
 		proof := &malfeasance2.MalfeasanceProof{
@@ -154,7 +149,6 @@ spacemesh_malfeasance2_num_invalid_proofs{domain="mal",type="unknown"} 1
 	})
 
 	t.Run("invalid proof", func(t *testing.T) {
-		t.Parallel()
 		th := newTestHandler(t)
 		invalidProof := []byte("invalid")
 		handlerError := errors.New("invalid proof")
@@ -183,7 +177,6 @@ spacemesh_malfeasance2_num_invalid_proofs{domain="mal",type="unknown"} 0
 	})
 
 	t.Run("valid proof", func(t *testing.T) {
-		t.Parallel()
 		th := newTestHandler(t)
 		validProof := []byte("valid")
 		nodeID := types.RandomNodeID()
@@ -205,6 +198,12 @@ spacemesh_malfeasance2_num_invalid_proofs{domain="mal",type="unknown"} 0
 			},
 		)
 
+		events.InitializeReporter()
+		defer events.CloseEventReporter()
+		sub, err := events.SubscribeMatched(func(event *events.EventMalfeasance) bool { return true })
+		defer sub.Close()
+		require.NoError(t, err)
+
 		proof := &malfeasance2.MalfeasanceProof{
 			Version: 0,
 			RefATXs: []types.ATXID{atxID},
@@ -212,7 +211,7 @@ spacemesh_malfeasance2_num_invalid_proofs{domain="mal",type="unknown"} 0
 			Proof:   validProof,
 		}
 
-		err := th.HandleSynced(t.Context(), types.Hash32(nodeID), "peer", codec.MustEncode(proof))
+		err = th.HandleSynced(t.Context(), types.Hash32(nodeID), "peer", codec.MustEncode(proof))
 		require.NoError(t, err)
 
 		expected := `
@@ -225,10 +224,16 @@ spacemesh_malfeasance2_num_proofs{domain="ATX",type="invalidPost"} 1
 		malicious, err := malfeasance.IsMalicious(th.db, nodeID)
 		require.NoError(t, err)
 		require.True(t, malicious)
+
+		select {
+		case ev := <-sub.Out():
+			require.Equal(t, nodeID, ev.Smesher)
+		case <-time.After(5 * time.Second):
+			require.FailNow(t, "timed out waiting for event")
+		}
 	})
 
 	t.Run("valid proof, married identity", func(t *testing.T) {
-		t.Parallel()
 		th := newTestHandler(t)
 		validProof := []byte("valid")
 		nodeIDs := make([]types.NodeID, 20)
@@ -277,6 +282,12 @@ spacemesh_malfeasance2_num_proofs{domain="ATX",type="invalidPost"} 1
 			},
 		)
 
+		events.InitializeReporter()
+		defer events.CloseEventReporter()
+		sub, err := events.SubscribeMatched(func(event *events.EventMalfeasance) bool { return true })
+		defer sub.Close()
+		require.NoError(t, err)
+
 		proof := &malfeasance2.MalfeasanceProof{
 			Version: 0,
 			RefATXs: []types.ATXID{mATXID},
@@ -284,7 +295,7 @@ spacemesh_malfeasance2_num_proofs{domain="ATX",type="invalidPost"} 1
 			Proof:   validProof,
 		}
 
-		err := th.HandleSynced(t.Context(), types.Hash32(nodeIDs[0]), "peer", codec.MustEncode(proof))
+		err = th.HandleSynced(t.Context(), types.Hash32(nodeIDs[0]), "peer", codec.MustEncode(proof))
 		require.NoError(t, err)
 
 		expected := `
@@ -299,10 +310,20 @@ spacemesh_malfeasance2_num_proofs{domain="ATX",type="invalidPost"} 1
 			require.NoError(t, err)
 			require.True(t, malicious)
 		}
+
+		eventNodeIDs := make([]types.NodeID, 0, len(nodeIDs))
+		for range nodeIDs {
+			select {
+			case ev := <-sub.Out():
+				eventNodeIDs = append(eventNodeIDs, ev.Smesher)
+			case <-time.After(5 * time.Second):
+				require.FailNow(t, "timed out waiting for event")
+			}
+		}
+		require.ElementsMatch(t, nodeIDs, eventNodeIDs)
 	})
 
 	t.Run("valid proof, fail to fetch reference ATX", func(t *testing.T) {
-		t.Parallel()
 		th := newTestHandler(t)
 		validProof := []byte("valid")
 		nodeID := types.RandomNodeID()
@@ -331,7 +352,6 @@ spacemesh_malfeasance2_num_proofs{domain="ATX",type="invalidPost"} 1
 	})
 
 	t.Run("valid proof, no reference ATX but identity is known", func(t *testing.T) {
-		t.Parallel()
 		th := newTestHandler(t)
 		validProof := []byte("valid")
 		nodeID := types.RandomNodeID()
@@ -347,6 +367,12 @@ spacemesh_malfeasance2_num_proofs{domain="ATX",type="invalidPost"} 1
 		th.RegisterHandler(malfeasance2.InvalidActivation, mockHandler)
 		th.mockTrt.EXPECT().OnMalfeasance(nodeID)
 
+		events.InitializeReporter()
+		defer events.CloseEventReporter()
+		sub, err := events.SubscribeMatched(func(event *events.EventMalfeasance) bool { return true })
+		defer sub.Close()
+		require.NoError(t, err)
+
 		proof := &malfeasance2.MalfeasanceProof{
 			Version: 0,
 			// no reference ATX
@@ -354,7 +380,7 @@ spacemesh_malfeasance2_num_proofs{domain="ATX",type="invalidPost"} 1
 			Proof:  validProof,
 		}
 
-		err := th.HandleSynced(t.Context(), types.Hash32(nodeID), "peer", codec.MustEncode(proof))
+		err = th.HandleSynced(t.Context(), types.Hash32(nodeID), "peer", codec.MustEncode(proof))
 		require.NoError(t, err)
 
 		expected := `
@@ -367,10 +393,16 @@ spacemesh_malfeasance2_num_proofs{domain="ATX",type="invalidPost"} 1
 		malicious, err := malfeasance.IsMalicious(th.db, nodeID)
 		require.NoError(t, err)
 		require.True(t, malicious)
+
+		select {
+		case ev := <-sub.Out():
+			require.Equal(t, nodeID, ev.Smesher)
+		case <-time.After(5 * time.Second):
+			require.FailNow(t, "timed out waiting for event")
+		}
 	})
 
 	t.Run("valid proof, wrong hash", func(t *testing.T) {
-		t.Parallel()
 		th := newTestHandler(t)
 		validProof := []byte("valid")
 		nodeID := types.RandomNodeID()
@@ -414,10 +446,7 @@ spacemesh_malfeasance2_num_invalid_proofs{domain="mal",type="unknown"} 0
 }
 
 func TestHandler_HandleGossip(t *testing.T) {
-	t.Parallel()
-
 	t.Run("malformed data", func(t *testing.T) {
-		t.Parallel()
 		th := newTestHandler(t)
 
 		err := th.HandleGossip(t.Context(), "peer", []byte("malformed"))
@@ -433,7 +462,6 @@ spacemesh_malfeasance2_num_invalid_proofs{domain="mal",type="unknown"} 1
 	})
 
 	t.Run("self peer", func(t *testing.T) {
-		t.Parallel()
 		th := newTestHandler(t)
 
 		// ignore messages from self
@@ -442,7 +470,6 @@ spacemesh_malfeasance2_num_invalid_proofs{domain="mal",type="unknown"} 1
 	})
 
 	t.Run("unknown version", func(t *testing.T) {
-		t.Parallel()
 		th := newTestHandler(t)
 
 		proof := &malfeasance2.MalfeasanceProof{
@@ -455,7 +482,6 @@ spacemesh_malfeasance2_num_invalid_proofs{domain="mal",type="unknown"} 1
 	})
 
 	t.Run("unknown domain", func(t *testing.T) {
-		t.Parallel()
 		th := newTestHandler(t)
 
 		proof := &malfeasance2.MalfeasanceProof{
@@ -469,7 +495,6 @@ spacemesh_malfeasance2_num_invalid_proofs{domain="mal",type="unknown"} 1
 	})
 
 	t.Run("invalid proof", func(t *testing.T) {
-		t.Parallel()
 		th := newTestHandler(t)
 		invalidProof := []byte("invalid")
 		handlerError := errors.New("invalid proof")
@@ -498,7 +523,6 @@ spacemesh_malfeasance2_num_invalid_proofs{domain="mal",type="unknown"} 0
 	})
 
 	t.Run("valid proof", func(t *testing.T) {
-		t.Parallel()
 		th := newTestHandler(t)
 		validProof := []byte("valid")
 		nodeID := types.RandomNodeID()
@@ -520,6 +544,12 @@ spacemesh_malfeasance2_num_invalid_proofs{domain="mal",type="unknown"} 0
 			},
 		)
 
+		events.InitializeReporter()
+		defer events.CloseEventReporter()
+		sub, err := events.SubscribeMatched(func(event *events.EventMalfeasance) bool { return true })
+		defer sub.Close()
+		require.NoError(t, err)
+
 		proof := &malfeasance2.MalfeasanceProof{
 			Version: 0,
 			RefATXs: []types.ATXID{atxID},
@@ -527,7 +557,7 @@ spacemesh_malfeasance2_num_invalid_proofs{domain="mal",type="unknown"} 0
 			Proof:   validProof,
 		}
 
-		err := th.HandleGossip(t.Context(), "peer", codec.MustEncode(proof))
+		err = th.HandleGossip(t.Context(), "peer", codec.MustEncode(proof))
 		require.NoError(t, err)
 
 		expected := `
@@ -541,10 +571,16 @@ spacemesh_malfeasance2_num_proofs{domain="ATX",type="invalidPost"} 1
 		malicious, err := malfeasance.IsMalicious(th.db, nodeID)
 		require.NoError(t, err)
 		require.True(t, malicious)
+
+		select {
+		case ev := <-sub.Out():
+			require.Equal(t, nodeID, ev.Smesher)
+		case <-time.After(5 * time.Second):
+			require.FailNow(t, "timed out waiting for event")
+		}
 	})
 
 	t.Run("valid proof, married identity", func(t *testing.T) {
-		t.Parallel()
 		th := newTestHandler(t)
 		validProof := []byte("valid")
 		nodeIDs := make([]types.NodeID, 20)
@@ -581,6 +617,12 @@ spacemesh_malfeasance2_num_proofs{domain="ATX",type="invalidPost"} 1
 		th.mockFetch.EXPECT().RegisterPeerHashes(p2p.Peer("peer"), []types.Hash32{mATXID.Hash32()})
 		th.mockFetch.EXPECT().GetAtxs(gomock.Any(), []types.ATXID{mATXID}, gomock.Any()).Return(nil)
 
+		events.InitializeReporter()
+		defer events.CloseEventReporter()
+		sub, err := events.SubscribeMatched(func(event *events.EventMalfeasance) bool { return true })
+		defer sub.Close()
+		require.NoError(t, err)
+
 		proof := &malfeasance2.MalfeasanceProof{
 			Version: 0,
 			RefATXs: []types.ATXID{mATXID},
@@ -607,10 +649,20 @@ spacemesh_malfeasance2_num_proofs{domain="ATX",type="invalidPost"} 1
 		require.NoError(t, err)
 		require.Equal(t, malfeasance2.InvalidActivation, malfeasance2.ProofDomain(domain))
 		require.Equal(t, validProof, dbProof)
+
+		eventNodeIDs := make([]types.NodeID, 0, len(nodeIDs))
+		for range nodeIDs {
+			select {
+			case ev := <-sub.Out():
+				eventNodeIDs = append(eventNodeIDs, ev.Smesher)
+			case <-time.After(5 * time.Second):
+				require.FailNow(t, "timed out waiting for event")
+			}
+		}
+		require.ElementsMatch(t, nodeIDs, eventNodeIDs)
 	})
 
 	t.Run("valid proof, fail to fetch reference ATX", func(t *testing.T) {
-		t.Parallel()
 		th := newTestHandler(t)
 		validProof := []byte("valid")
 		nodeID := types.RandomNodeID()
@@ -639,7 +691,6 @@ spacemesh_malfeasance2_num_proofs{domain="ATX",type="invalidPost"} 1
 	})
 
 	t.Run("valid proof, no reference ATX but identity is known", func(t *testing.T) {
-		t.Parallel()
 		th := newTestHandler(t)
 		validProof := []byte("valid")
 		nodeID := types.RandomNodeID()
@@ -655,6 +706,12 @@ spacemesh_malfeasance2_num_proofs{domain="ATX",type="invalidPost"} 1
 		th.RegisterHandler(malfeasance2.InvalidActivation, mockHandler)
 		th.mockTrt.EXPECT().OnMalfeasance(nodeID)
 
+		events.InitializeReporter()
+		defer events.CloseEventReporter()
+		sub, err := events.SubscribeMatched(func(event *events.EventMalfeasance) bool { return true })
+		defer sub.Close()
+		require.NoError(t, err)
+
 		proof := &malfeasance2.MalfeasanceProof{
 			Version: 0,
 			// no reference ATX
@@ -662,7 +719,7 @@ spacemesh_malfeasance2_num_proofs{domain="ATX",type="invalidPost"} 1
 			Proof:  validProof,
 		}
 
-		err := th.HandleGossip(t.Context(), "peer", codec.MustEncode(proof))
+		err = th.HandleGossip(t.Context(), "peer", codec.MustEncode(proof))
 		require.NoError(t, err)
 
 		expected := `
@@ -675,10 +732,16 @@ spacemesh_malfeasance2_num_proofs{domain="ATX",type="invalidPost"} 1
 		malicious, err := malfeasance.IsMalicious(th.db, nodeID)
 		require.NoError(t, err)
 		require.True(t, malicious)
+
+		select {
+		case ev := <-sub.Out():
+			require.Equal(t, nodeID, ev.Smesher)
+		case <-time.After(5 * time.Second):
+			require.FailNow(t, "timed out waiting for event")
+		}
 	})
 
 	t.Run("valid proof for known malicious identity", func(t *testing.T) {
-		t.Parallel()
 		th := newTestHandler(t)
 		validProof := []byte("valid")
 		nodeID := types.RandomNodeID()
@@ -696,6 +759,12 @@ spacemesh_malfeasance2_num_proofs{domain="ATX",type="invalidPost"} 1
 		th.mockFetch.EXPECT().RegisterPeerHashes(p2p.Peer("peer"), []types.Hash32{atxID.Hash32()})
 		th.mockFetch.EXPECT().GetAtxs(gomock.Any(), []types.ATXID{atxID}, gomock.Any()).Return(nil)
 
+		events.InitializeReporter()
+		defer events.CloseEventReporter()
+		sub, err := events.SubscribeMatched(func(event *events.EventMalfeasance) bool { return true })
+		defer sub.Close()
+		require.NoError(t, err)
+
 		proof := &malfeasance2.MalfeasanceProof{
 			Version: 0,
 			RefATXs: []types.ATXID{atxID},
@@ -704,7 +773,7 @@ spacemesh_malfeasance2_num_proofs{domain="ATX",type="invalidPost"} 1
 		}
 		proofBytes := codec.MustEncode(proof)
 
-		err := malfeasance.AddProof(th.db, nodeID, nil, proofBytes, int(malfeasance2.InvalidActivation), time.Now())
+		err = malfeasance.AddProof(th.db, nodeID, nil, proofBytes, int(malfeasance2.InvalidActivation), time.Now())
 		require.NoError(t, err)
 
 		err = th.HandleGossip(t.Context(), "peer", proofBytes)
@@ -716,6 +785,13 @@ spacemesh_malfeasance2_num_proofs{domain="ATX",type="invalidPost"} 1
 spacemesh_malfeasance2_num_proofs{domain="ATX",type="invalidPost"} 1
 `
 		require.NoError(t, testutil.CollectAndCompare(th.NumValidProofs(), strings.NewReader(expected)))
+
+		select {
+		case ev := <-sub.Out():
+			require.Equal(t, nodeID, ev.Smesher)
+		case <-time.After(5 * time.Second):
+			require.FailNow(t, "timed out waiting for event")
+		}
 	})
 }
 

--- a/malfeasance2/handler_test.go
+++ b/malfeasance2/handler_test.go
@@ -201,8 +201,8 @@ spacemesh_malfeasance2_num_invalid_proofs{domain="mal",type="unknown"} 0
 		events.InitializeReporter()
 		defer events.CloseEventReporter()
 		sub, err := events.SubscribeMatched(func(event *events.EventMalfeasance) bool { return true })
-		defer sub.Close()
 		require.NoError(t, err)
+		defer sub.Close()
 
 		proof := &malfeasance2.MalfeasanceProof{
 			Version: 0,
@@ -285,8 +285,8 @@ spacemesh_malfeasance2_num_proofs{domain="ATX",type="invalidPost"} 1
 		events.InitializeReporter()
 		defer events.CloseEventReporter()
 		sub, err := events.SubscribeMatched(func(event *events.EventMalfeasance) bool { return true })
-		defer sub.Close()
 		require.NoError(t, err)
+		defer sub.Close()
 
 		proof := &malfeasance2.MalfeasanceProof{
 			Version: 0,
@@ -370,8 +370,8 @@ spacemesh_malfeasance2_num_proofs{domain="ATX",type="invalidPost"} 1
 		events.InitializeReporter()
 		defer events.CloseEventReporter()
 		sub, err := events.SubscribeMatched(func(event *events.EventMalfeasance) bool { return true })
-		defer sub.Close()
 		require.NoError(t, err)
+		defer sub.Close()
 
 		proof := &malfeasance2.MalfeasanceProof{
 			Version: 0,
@@ -547,8 +547,8 @@ spacemesh_malfeasance2_num_invalid_proofs{domain="mal",type="unknown"} 0
 		events.InitializeReporter()
 		defer events.CloseEventReporter()
 		sub, err := events.SubscribeMatched(func(event *events.EventMalfeasance) bool { return true })
-		defer sub.Close()
 		require.NoError(t, err)
+		defer sub.Close()
 
 		proof := &malfeasance2.MalfeasanceProof{
 			Version: 0,
@@ -620,8 +620,8 @@ spacemesh_malfeasance2_num_proofs{domain="ATX",type="invalidPost"} 1
 		events.InitializeReporter()
 		defer events.CloseEventReporter()
 		sub, err := events.SubscribeMatched(func(event *events.EventMalfeasance) bool { return true })
-		defer sub.Close()
 		require.NoError(t, err)
+		defer sub.Close()
 
 		proof := &malfeasance2.MalfeasanceProof{
 			Version: 0,
@@ -709,8 +709,8 @@ spacemesh_malfeasance2_num_proofs{domain="ATX",type="invalidPost"} 1
 		events.InitializeReporter()
 		defer events.CloseEventReporter()
 		sub, err := events.SubscribeMatched(func(event *events.EventMalfeasance) bool { return true })
-		defer sub.Close()
 		require.NoError(t, err)
+		defer sub.Close()
 
 		proof := &malfeasance2.MalfeasanceProof{
 			Version: 0,
@@ -762,8 +762,8 @@ spacemesh_malfeasance2_num_proofs{domain="ATX",type="invalidPost"} 1
 		events.InitializeReporter()
 		defer events.CloseEventReporter()
 		sub, err := events.SubscribeMatched(func(event *events.EventMalfeasance) bool { return true })
-		defer sub.Close()
 		require.NoError(t, err)
+		defer sub.Close()
 
 		proof := &malfeasance2.MalfeasanceProof{
 			Version: 0,

--- a/malfeasance2/publisher.go
+++ b/malfeasance2/publisher.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/spacemeshos/go-spacemesh/codec"
 	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/events"
 	"github.com/spacemeshos/go-spacemesh/log"
 	"github.com/spacemeshos/go-spacemesh/p2p/pubsub"
 	"github.com/spacemeshos/go-spacemesh/sql"
@@ -145,6 +146,7 @@ func (p *Publisher) PublishATXProof(ctx context.Context, nodeID types.NodeID, pr
 	}
 	for _, nodeID := range set {
 		p.tortoise.OnMalfeasance(nodeID)
+		events.ReportMalfeasance(nodeID)
 	}
 	return p.publish(ctx, set, refATXs, proof, ProofDomain(InvalidActivation))
 }

--- a/malfeasance2/publisher_test.go
+++ b/malfeasance2/publisher_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/spacemeshos/go-spacemesh/codec"
 	"github.com/spacemeshos/go-spacemesh/common/types"
+	"github.com/spacemeshos/go-spacemesh/events"
 	"github.com/spacemeshos/go-spacemesh/malfeasance2"
 	"github.com/spacemeshos/go-spacemesh/p2p/pubsub"
 	"github.com/spacemeshos/go-spacemesh/p2p/pubsub/mocks"
@@ -71,10 +72,7 @@ func newTestPublisher(tb testing.TB) *testPublisher {
 }
 
 func TestPublishATXProof(t *testing.T) {
-	t.Parallel()
-
 	t.Run("not married and in sync", func(t *testing.T) {
-		t.Parallel()
 		tp := newTestPublisher(t)
 		proof := types.RandomBytes(10)
 		nodeID := types.RandomNodeID()
@@ -91,21 +89,33 @@ func TestPublishATXProof(t *testing.T) {
 			Proof:   proof,
 		}
 
+		events.InitializeReporter()
+		defer events.CloseEventReporter()
+		sub, err := events.SubscribeMatched(func(event *events.EventMalfeasance) bool { return true })
+		require.NoError(t, err)
+		defer sub.Close()
+
 		tp.mockTrt.EXPECT().OnMalfeasance(nodeID)
 		tp.mockSync.EXPECT().ListenToATXGossip().Return(true)
 		tp.mockPub.EXPECT().Publish(gomock.Any(), pubsub.MalfeasanceProof2, codec.MustEncode(malfeasanceProof))
 
-		err := tp.PublishATXProof(t.Context(), nodeID, proof, false)
+		err = tp.PublishATXProof(t.Context(), nodeID, proof, false)
 		require.NoError(t, err)
 
 		dbProof, domain, err := malfeasance.NodeIDProof(tp.db, nodeID)
 		require.NoError(t, err)
 		require.Equal(t, malfeasance2.InvalidActivation, malfeasance2.ProofDomain(domain))
 		require.Equal(t, proof, dbProof)
+
+		select {
+		case ev := <-sub.Out():
+			require.Equal(t, nodeID, ev.Smesher)
+		case <-time.After(5 * time.Second):
+			require.FailNow(t, "timed out waiting for event")
+		}
 	})
 
 	t.Run("not married and in sync, allow without refATXs", func(t *testing.T) {
-		t.Parallel()
 		tp := newTestPublisher(t)
 		proof := types.RandomBytes(10)
 		nodeID := types.RandomNodeID()
@@ -117,21 +127,33 @@ func TestPublishATXProof(t *testing.T) {
 			Proof:   proof,
 		}
 
+		events.InitializeReporter()
+		defer events.CloseEventReporter()
+		sub, err := events.SubscribeMatched(func(event *events.EventMalfeasance) bool { return true })
+		require.NoError(t, err)
+		defer sub.Close()
+
 		tp.mockTrt.EXPECT().OnMalfeasance(nodeID)
 		tp.mockSync.EXPECT().ListenToATXGossip().Return(true)
 		tp.mockPub.EXPECT().Publish(gomock.Any(), pubsub.MalfeasanceProof2, codec.MustEncode(malfeasanceProof))
 
-		err := tp.PublishATXProof(t.Context(), nodeID, proof, true)
+		err = tp.PublishATXProof(t.Context(), nodeID, proof, true)
 		require.NoError(t, err)
 
 		dbProof, domain, err := malfeasance.NodeIDProof(tp.db, nodeID)
 		require.NoError(t, err)
 		require.Equal(t, malfeasance2.InvalidActivation, malfeasance2.ProofDomain(domain))
 		require.Equal(t, proof, dbProof)
+
+		select {
+		case ev := <-sub.Out():
+			require.Equal(t, nodeID, ev.Smesher)
+		case <-time.After(5 * time.Second):
+			require.FailNow(t, "timed out waiting for event")
+		}
 	})
 
 	t.Run("not married, in sync, but failed to gossip", func(t *testing.T) {
-		t.Parallel()
 		tp := newTestPublisher(t)
 		proof := types.RandomBytes(10)
 		nodeID := types.RandomNodeID()
@@ -148,13 +170,19 @@ func TestPublishATXProof(t *testing.T) {
 			Proof:   proof,
 		}
 
+		events.InitializeReporter()
+		defer events.CloseEventReporter()
+		sub, err := events.SubscribeMatched(func(event *events.EventMalfeasance) bool { return true })
+		require.NoError(t, err)
+		defer sub.Close()
+
 		tp.mockTrt.EXPECT().OnMalfeasance(nodeID)
 		tp.mockSync.EXPECT().ListenToATXGossip().Return(true)
 		errPublish := errors.New("failed to publish")
 		tp.mockPub.EXPECT().Publish(gomock.Any(), pubsub.MalfeasanceProof2, codec.MustEncode(malfeasanceProof)).
 			Return(errPublish)
 
-		err := tp.PublishATXProof(t.Context(), nodeID, proof, false)
+		err = tp.PublishATXProof(t.Context(), nodeID, proof, false)
 		require.ErrorIs(t, err, errPublish)
 
 		logs := tp.observedLogs.FilterLevelExact(zap.ErrorLevel)
@@ -168,10 +196,16 @@ func TestPublishATXProof(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, malfeasance2.InvalidActivation, malfeasance2.ProofDomain(domain))
 		require.Equal(t, proof, dbProof)
+
+		select {
+		case ev := <-sub.Out():
+			require.Equal(t, nodeID, ev.Smesher)
+		case <-time.After(5 * time.Second):
+			require.FailNow(t, "timed out waiting for event")
+		}
 	})
 
 	t.Run("not married, not in sync", func(t *testing.T) {
-		t.Parallel()
 		tp := newTestPublisher(t)
 		proof := types.RandomBytes(10)
 		nodeID := types.RandomNodeID()
@@ -181,38 +215,62 @@ func TestPublishATXProof(t *testing.T) {
 		atx.SetID(types.RandomATXID())
 		require.NoError(t, atxs.Add(tp.db, atx, types.AtxBlob{}))
 
+		events.InitializeReporter()
+		defer events.CloseEventReporter()
+		sub, err := events.SubscribeMatched(func(event *events.EventMalfeasance) bool { return true })
+		require.NoError(t, err)
+		defer sub.Close()
+
 		tp.mockTrt.EXPECT().OnMalfeasance(nodeID)
 		tp.mockSync.EXPECT().ListenToATXGossip().Return(false) // results in no gossip but only storing the proof
 
-		err := tp.PublishATXProof(t.Context(), nodeID, proof, false)
+		err = tp.PublishATXProof(t.Context(), nodeID, proof, false)
 		require.NoError(t, err)
 
 		dbProof, domain, err := malfeasance.NodeIDProof(tp.db, nodeID)
 		require.NoError(t, err)
 		require.Equal(t, malfeasance2.InvalidActivation, malfeasance2.ProofDomain(domain))
 		require.Equal(t, proof, dbProof)
+
+		select {
+		case ev := <-sub.Out():
+			require.Equal(t, nodeID, ev.Smesher)
+		case <-time.After(5 * time.Second):
+			require.FailNow(t, "timed out waiting for event")
+		}
 	})
 
 	t.Run("not married, not in sync, allow no ref ATXs", func(t *testing.T) {
-		t.Parallel()
 		tp := newTestPublisher(t)
 		proof := types.RandomBytes(10)
 		nodeID := types.RandomNodeID()
 
+		events.InitializeReporter()
+		defer events.CloseEventReporter()
+		sub, err := events.SubscribeMatched(func(event *events.EventMalfeasance) bool { return true })
+		require.NoError(t, err)
+		defer sub.Close()
+
 		tp.mockTrt.EXPECT().OnMalfeasance(nodeID)
 		tp.mockSync.EXPECT().ListenToATXGossip().Return(false) // results in no gossip but only storing the proof
 
-		err := tp.PublishATXProof(t.Context(), nodeID, proof, true)
+		err = tp.PublishATXProof(t.Context(), nodeID, proof, true)
 		require.NoError(t, err)
 
 		dbProof, domain, err := malfeasance.NodeIDProof(tp.db, nodeID)
 		require.NoError(t, err)
 		require.Equal(t, malfeasance2.InvalidActivation, malfeasance2.ProofDomain(domain))
 		require.Equal(t, proof, dbProof)
+
+		select {
+		case ev := <-sub.Out():
+			require.Equal(t, nodeID, ev.Smesher)
+		case <-time.After(5 * time.Second):
+			require.FailNow(t, "timed out waiting for event")
+		}
 	})
 
 	t.Run("married and in sync", func(t *testing.T) {
-		t.Parallel()
 		tp := newTestPublisher(t)
 		proof := types.RandomBytes(10)
 		nodeIDs := make([]types.NodeID, 20)
@@ -265,6 +323,12 @@ func TestPublishATXProof(t *testing.T) {
 			Proof:   proof,
 		}
 
+		events.InitializeReporter()
+		defer events.CloseEventReporter()
+		sub, err := events.SubscribeMatched(func(event *events.EventMalfeasance) bool { return true })
+		require.NoError(t, err)
+		defer sub.Close()
+
 		for _, nodeID := range nodeIDs {
 			tp.mockTrt.EXPECT().OnMalfeasance(nodeID)
 		}
@@ -296,10 +360,20 @@ func TestPublishATXProof(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, malfeasance2.InvalidActivation, malfeasance2.ProofDomain(domain))
 		require.Equal(t, proof, dbProof)
+
+		eventNodeIDs := make([]types.NodeID, 0, len(nodeIDs))
+		for range nodeIDs {
+			select {
+			case ev := <-sub.Out():
+				eventNodeIDs = append(eventNodeIDs, ev.Smesher)
+			case <-time.After(5 * time.Second):
+				require.FailNow(t, "timed out waiting for event")
+			}
+		}
+		require.ElementsMatch(t, nodeIDs, eventNodeIDs)
 	})
 
 	t.Run("identity already malicious", func(t *testing.T) {
-		t.Parallel()
 		tp := newTestPublisher(t)
 		proof := types.RandomBytes(10)
 		nodeID := types.RandomNodeID()
@@ -330,7 +404,6 @@ func TestPublishATXProof(t *testing.T) {
 	})
 
 	t.Run("married and all already malicious", func(t *testing.T) {
-		t.Parallel()
 		tp := newTestPublisher(t)
 		proof := types.RandomBytes(10)
 		nodeIDs := make([]types.NodeID, 20)
@@ -414,7 +487,6 @@ func TestPublishATXProof(t *testing.T) {
 	})
 
 	t.Run("married and some already malicious", func(t *testing.T) {
-		t.Parallel()
 		tp := newTestPublisher(t)
 		proof := types.RandomBytes(10)
 		nodeIDs := make([]types.NodeID, 20)
@@ -479,6 +551,12 @@ func TestPublishATXProof(t *testing.T) {
 			Proof:   proof,
 		}
 
+		events.InitializeReporter()
+		defer events.CloseEventReporter()
+		sub, err := events.SubscribeMatched(func(event *events.EventMalfeasance) bool { return true })
+		require.NoError(t, err)
+		defer sub.Close()
+
 		for _, nodeID := range nodeIDs { // only the last 10 were not already marked as malicious
 			tp.mockTrt.EXPECT().OnMalfeasance(nodeID)
 		}
@@ -523,6 +601,17 @@ func TestPublishATXProof(t *testing.T) {
 		require.Contains(t, logs.All()[20].Message, "persisted malfeasance proof")
 		require.Equal(t, zap.DebugLevel, logs.All()[21].Level)
 		require.Contains(t, logs.All()[21].Message, "broadcast malfeasance proof")
+
+		eventNodeIDs := make([]types.NodeID, 0, len(nodeIDs))
+		for range nodeIDs {
+			select {
+			case ev := <-sub.Out():
+				eventNodeIDs = append(eventNodeIDs, ev.Smesher)
+			case <-time.After(5 * time.Second):
+				require.FailNow(t, "timed out waiting for event")
+			}
+		}
+		require.ElementsMatch(t, nodeIDs, eventNodeIDs)
 	})
 }
 


### PR DESCRIPTION
## Motivation

The publishers for legacy and new malfeasance didn't emit events for the newly detected malicious identities. This adds event emission to both publishers.

## Description

Only the malfeasance handlers were emitting events which means that a node that detected malicious behavior itself, instead of syncing a proof or receiving it via gossip, would not report that back to some components of the node. Most importantly this causes a client that is connected via GRPC to a node streaming malfeasance proofs to possibly not receive such a proof.

## Test Plan

Updated existing tests to assert that events for newly detected malfeasants are emitted.

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
