### PR TITLE
[Merged by Bors] - Update presets for syncv2 and atxv2

### DIFF
--- a/config/presets/fastnet.go
+++ b/config/presets/fastnet.go
@@ -10,6 +10,9 @@ import (
 	"github.com/spacemeshos/go-spacemesh/activation"
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/config"
+	"github.com/spacemeshos/go-spacemesh/fetch"
+	"github.com/spacemeshos/go-spacemesh/sync2"
+	"github.com/spacemeshos/go-spacemesh/syncer"
 )
 
 func init() {
@@ -26,6 +29,11 @@ func fastnet() config.Config {
 
 	// set for systest TestEquivocation
 	conf.BaseConfig.MinerGoodAtxsPercent = 50
+
+	// switch on ATXv2 in epoch 2
+	conf.BaseConfig.AtxVersions = activation.AtxVersions{
+		types.EpochID(2): types.AtxV2,
+	}
 
 	// node will select atxs that were received at least 4 seconds before start of the epoch
 	// for activeset.
@@ -50,14 +58,39 @@ func fastnet() config.Config {
 
 	conf.LayerAvgSize = 50
 	conf.LayerDuration = 15 * time.Second
+	conf.LayersPerEpoch = 4
+	conf.RegossipAtxInterval = 15 * time.Second
+
 	conf.Sync.Interval = 5 * time.Second
 	conf.Sync.GossipDuration = 10 * time.Second
 	conf.Sync.AtxSync.EpochInfoInterval = 1 * time.Second
 	conf.Sync.AtxSync.EpochInfoPeers = 10
 	conf.Sync.AtxSync.RequestsLimit = 100
 	conf.Sync.MalSync.IDRequestInterval = 20 * time.Second
-	conf.LayersPerEpoch = 4
-	conf.RegossipAtxInterval = 30 * time.Second
+
+	oldAtxSyncCfg := sync2.DefaultConfig()
+	oldAtxSyncCfg.MaxDepth = 16
+	oldAtxSyncCfg.MultiPeerReconcilerConfig.SyncInterval = 15 * time.Second
+	oldAtxSyncCfg.AdvanceInterval = 3 * time.Second
+	newAtxSyncCfg := sync2.DefaultConfig()
+	newAtxSyncCfg.MaxDepth = 21
+	newAtxSyncCfg.MultiPeerReconcilerConfig.SyncInterval = 5 * time.Second
+	newAtxSyncCfg.AdvanceInterval = time.Second
+
+	conf.Sync.ReconcSync = syncer.ReconcSyncConfig{
+		Enable:            true,
+		EnableActiveSync:  true,
+		OldAtxSyncCfg:     oldAtxSyncCfg,
+		NewAtxSyncCfg:     newAtxSyncCfg,
+		ParallelLoadLimit: 10,
+		HardTimeout:       5 * time.Second,
+		ServerConfig: fetch.ServerConfig{
+			Queue:    200,
+			Requests: 100,
+			Interval: time.Second,
+		},
+	}
+
 	conf.FETCH.RequestTimeout = 2 * time.Second
 
 	conf.Tortoise.Hdist = 4

--- a/config/presets/fastnet.go
+++ b/config/presets/fastnet.go
@@ -10,9 +10,6 @@ import (
 	"github.com/spacemeshos/go-spacemesh/activation"
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/config"
-	"github.com/spacemeshos/go-spacemesh/fetch"
-	"github.com/spacemeshos/go-spacemesh/sync2"
-	"github.com/spacemeshos/go-spacemesh/syncer"
 )
 
 func init() {
@@ -68,28 +65,20 @@ func fastnet() config.Config {
 	conf.Sync.AtxSync.RequestsLimit = 100
 	conf.Sync.MalSync.IDRequestInterval = 20 * time.Second
 
-	oldAtxSyncCfg := sync2.DefaultConfig()
-	oldAtxSyncCfg.MaxDepth = 16
-	oldAtxSyncCfg.MultiPeerReconcilerConfig.SyncInterval = 15 * time.Second
-	oldAtxSyncCfg.AdvanceInterval = 3 * time.Second
-	newAtxSyncCfg := sync2.DefaultConfig()
-	newAtxSyncCfg.MaxDepth = 21
-	newAtxSyncCfg.MultiPeerReconcilerConfig.SyncInterval = 5 * time.Second
-	newAtxSyncCfg.AdvanceInterval = time.Second
-
-	conf.Sync.ReconcSync = syncer.ReconcSyncConfig{
-		Enable:            true,
-		EnableActiveSync:  true,
-		OldAtxSyncCfg:     oldAtxSyncCfg,
-		NewAtxSyncCfg:     newAtxSyncCfg,
-		ParallelLoadLimit: 10,
-		HardTimeout:       5 * time.Second,
-		ServerConfig: fetch.ServerConfig{
-			Queue:    200,
-			Requests: 100,
-			Interval: time.Second,
-		},
-	}
+	conf.Sync.ReconcSync.Enable = true
+	conf.Sync.ReconcSync.EnableActiveSync = true
+	conf.Sync.ReconcSync.NewAtxSyncCfg.AdvanceInterval = 20 * time.Second
+	conf.Sync.ReconcSync.NewAtxSyncCfg.SyncInterval = 10 * time.Second
+	conf.Sync.ReconcSync.NewAtxSyncCfg.SyncPeerCount = 4
+	conf.Sync.ReconcSync.NewAtxSyncCfg.RetryInterval = 2 * time.Second
+	conf.Sync.ReconcSync.NewAtxSyncCfg.FullSyncednessPeriod = time.Minute
+	conf.Sync.ReconcSync.NewAtxSyncCfg.NoPeersRecheckInterval = 5 * time.Second
+	conf.Sync.ReconcSync.OldAtxSyncCfg.AdvanceInterval = time.Minute
+	conf.Sync.ReconcSync.OldAtxSyncCfg.SyncInterval = time.Minute
+	conf.Sync.ReconcSync.OldAtxSyncCfg.SyncPeerCount = 4
+	conf.Sync.ReconcSync.OldAtxSyncCfg.RetryInterval = 2 * time.Second
+	conf.Sync.ReconcSync.OldAtxSyncCfg.FullSyncednessPeriod = 15 * time.Minute
+	conf.Sync.ReconcSync.OldAtxSyncCfg.NoPeersRecheckInterval = 5 * time.Second
 
 	conf.FETCH.RequestTimeout = 2 * time.Second
 

--- a/config/presets/standalone.go
+++ b/config/presets/standalone.go
@@ -12,9 +12,6 @@ import (
 	"github.com/spacemeshos/go-spacemesh/activation"
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/config"
-	"github.com/spacemeshos/go-spacemesh/fetch"
-	"github.com/spacemeshos/go-spacemesh/sync2"
-	"github.com/spacemeshos/go-spacemesh/syncer"
 )
 
 func init() {
@@ -42,31 +39,9 @@ func standalone() config.Config {
 
 	conf.LayerAvgSize = 50
 	conf.LayerDuration = 6 * time.Second
-	conf.Sync.Interval = 3 * time.Second
 	conf.LayersPerEpoch = 10
 
-	oldAtxSyncCfg := sync2.DefaultConfig()
-	oldAtxSyncCfg.MaxDepth = 16
-	oldAtxSyncCfg.MultiPeerReconcilerConfig.SyncInterval = 15 * time.Second
-	oldAtxSyncCfg.AdvanceInterval = 3 * time.Second
-	newAtxSyncCfg := sync2.DefaultConfig()
-	newAtxSyncCfg.MaxDepth = 21
-	newAtxSyncCfg.MultiPeerReconcilerConfig.SyncInterval = 5 * time.Second
-	newAtxSyncCfg.AdvanceInterval = time.Second
-
-	conf.Sync.ReconcSync = syncer.ReconcSyncConfig{
-		Enable:            true,
-		EnableActiveSync:  true,
-		OldAtxSyncCfg:     oldAtxSyncCfg,
-		NewAtxSyncCfg:     newAtxSyncCfg,
-		ParallelLoadLimit: 10,
-		HardTimeout:       5 * time.Second,
-		ServerConfig: fetch.ServerConfig{
-			Queue:    200,
-			Requests: 100,
-			Interval: time.Second,
-		},
-	}
+	conf.Sync.Interval = 3 * time.Second
 
 	conf.HARE3.Enable = true
 	conf.HARE3.PreroundDelay = 1 * time.Second

--- a/config/presets/standalone.go
+++ b/config/presets/standalone.go
@@ -12,6 +12,9 @@ import (
 	"github.com/spacemeshos/go-spacemesh/activation"
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/config"
+	"github.com/spacemeshos/go-spacemesh/fetch"
+	"github.com/spacemeshos/go-spacemesh/sync2"
+	"github.com/spacemeshos/go-spacemesh/syncer"
 )
 
 func init() {
@@ -21,6 +24,11 @@ func init() {
 func standalone() config.Config {
 	conf := config.DefaultConfig()
 	conf.NetworkHRP = "standalone"
+
+	// switch on ATXv2 in epoch 2
+	conf.BaseConfig.AtxVersions = activation.AtxVersions{
+		types.EpochID(2): types.AtxV2,
+	}
 
 	conf.TIME.Peersync.Disable = true
 	conf.Standalone = true
@@ -36,6 +44,29 @@ func standalone() config.Config {
 	conf.LayerDuration = 6 * time.Second
 	conf.Sync.Interval = 3 * time.Second
 	conf.LayersPerEpoch = 10
+
+	oldAtxSyncCfg := sync2.DefaultConfig()
+	oldAtxSyncCfg.MaxDepth = 16
+	oldAtxSyncCfg.MultiPeerReconcilerConfig.SyncInterval = 15 * time.Second
+	oldAtxSyncCfg.AdvanceInterval = 3 * time.Second
+	newAtxSyncCfg := sync2.DefaultConfig()
+	newAtxSyncCfg.MaxDepth = 21
+	newAtxSyncCfg.MultiPeerReconcilerConfig.SyncInterval = 5 * time.Second
+	newAtxSyncCfg.AdvanceInterval = time.Second
+
+	conf.Sync.ReconcSync = syncer.ReconcSyncConfig{
+		Enable:            true,
+		EnableActiveSync:  true,
+		OldAtxSyncCfg:     oldAtxSyncCfg,
+		NewAtxSyncCfg:     newAtxSyncCfg,
+		ParallelLoadLimit: 10,
+		HardTimeout:       5 * time.Second,
+		ServerConfig: fetch.ServerConfig{
+			Queue:    200,
+			Requests: 100,
+			Interval: time.Second,
+		},
+	}
 
 	conf.HARE3.Enable = true
 	conf.HARE3.PreroundDelay = 1 * time.Second

--- a/config/presets/testnet.go
+++ b/config/presets/testnet.go
@@ -181,6 +181,7 @@ func testnet() config.Config {
 			MalSync:                  malsync.DefaultConfig(),
 			ReconcSync: syncer.ReconcSyncConfig{
 				Enable:            true,
+				EnableActiveSync:  true,
 				OldAtxSyncCfg:     oldAtxSyncCfg,
 				NewAtxSyncCfg:     newAtxSyncCfg,
 				ParallelLoadLimit: 10,

--- a/config/presets/testnet.go
+++ b/config/presets/testnet.go
@@ -102,6 +102,10 @@ func testnet() config.Config {
 			ATXGradeDelay:       30 * time.Minute,
 
 			PprofHTTPServerListener: "localhost:6060",
+
+			AtxVersions: activation.AtxVersions{
+				types.EpochID(2): types.AtxV2,
+			},
 		},
 		Genesis: config.GenesisConfig{
 			GenesisTime: config.Genesis(genesisTime),

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -82,7 +82,7 @@ func DefaultConfig() Config {
 		MalSync:                  malsync.DefaultConfig(),
 		ReconcSync: ReconcSyncConfig{
 			Enable:            true,
-			EnableActiveSync:  false,
+			EnableActiveSync:  true,
 			OldAtxSyncCfg:     oldAtxSyncCfg,
 			NewAtxSyncCfg:     newAtxSyncCfg,
 			ParallelLoadLimit: 10,

--- a/systest/Makefile
+++ b/systest/Makefile
@@ -10,7 +10,7 @@ poet_image ?= $(org)/poet:v0.10.11
 post_service_image ?= $(org)/post-service:v0.8.4
 post_init_image ?= $(org)/postcli:v0.12.11
 smesher_image ?= $(org)/go-spacemesh-dev:$(version_info)
-old_smesher_image ?= $(org)/go-spacemesh-dev:f44b6b6 # replace with v1.8.0 before release
+old_smesher_image ?= $(org)/go-spacemesh-dev:adc5cfd # replace with v1.8.0 before release
 bs_image ?= $(org)/go-spacemesh-dev-bs:$(version_info)
 
 test_id ?= systest-$(version_info)

--- a/systest/Makefile
+++ b/systest/Makefile
@@ -10,7 +10,7 @@ poet_image ?= $(org)/poet:v0.10.11
 post_service_image ?= $(org)/post-service:v0.8.4
 post_init_image ?= $(org)/postcli:v0.12.11
 smesher_image ?= $(org)/go-spacemesh-dev:$(version_info)
-old_smesher_image ?= $(org)/go-spacemesh-dev:v1.7.17
+old_smesher_image ?= $(org)/go-spacemesh-dev:f44b6b6 # replace with v1.8.0 before release
 bs_image ?= $(org)/go-spacemesh-dev-bs:$(version_info)
 
 test_id ?= systest-$(version_info)

--- a/systest/parameters/fastnet/smesher.json
+++ b/systest/parameters/fastnet/smesher.json
@@ -1,10 +1,5 @@
 {
     "preset": "fastnet",
-    "main": {
-        "atx-versions": {
-            "2": 2
-        }
-    },
     "poet": {
         "phase-shift": "30s",
         "cycle-gap": "30s",


### PR DESCRIPTION
## Motivation

https://github.com/spacemeshos/go-spacemesh/pull/6778 enabled syncv2 and ATXv2 on mainnet. This PR updates the configuration for `fastnet`, `testnet` and `standalone` to also enable syncv2 and ATXv2.

## Description

By default ATXv2 is now enabled on all networks in epoch 2 (so we have 1 epoch of ATXv1 to reflect that there is a transition of ATX versions). Syncv2 is enabled by default es well.

> [!WARNING]  
> The ATXv2 configuration MUST be manually adjusted for existing networks to target an epoch in the future or those networks will break after updating.

## Test Plan

existing tests pass

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
