### PR TITLE
[Merged by Bors] - Do not use context for immediate db transactions

### DIFF
--- a/activation/handler_v1.go
+++ b/activation/handler_v1.go
@@ -498,7 +498,7 @@ func (h *HandlerV1) storeAtx(
 	malicious := false
 	var proof *mwire.MalfeasanceProof // legacy malfeasance proofs
 	var proof2 wire.Proof             // new malfeasance proofs
-	if err := h.cdb.WithTxImmediate(ctx, func(tx sql.Transaction) error {
+	if err := h.cdb.WithTxImmediate(func(tx sql.Transaction) error {
 		var err error
 		malicious, err = identities.IsMalicious(tx, atx.SmesherID)
 		if err != nil {

--- a/activation/handler_v1_test.go
+++ b/activation/handler_v1_test.go
@@ -363,7 +363,7 @@ func TestHandlerV1_SyntacticallyValidateAtx(t *testing.T) {
 				require.Equal(t, mwire.InvalidPostIndex, mp.Proof.Type)
 
 				// check if no transaction is currently open in the DB, since otherwise it could cause a deadlock
-				require.NoError(t, atxHdlr.cdb.WithTxImmediate(ctx, func(tx sql.Transaction) error {
+				require.NoError(t, atxHdlr.cdb.WithTxImmediate(func(tx sql.Transaction) error {
 					mal, err := identities.IsMalicious(tx, sig.NodeID())
 					require.NoError(t, err)
 					require.False(t, mal)
@@ -728,7 +728,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 				require.Equal(t, mwire.MultipleATXs, mp.Proof.Type)
 
 				// check if no transaction is currently open in the DB, since otherwise it could cause a deadlock
-				require.NoError(t, atxHdlr.cdb.WithTxImmediate(ctx, func(tx sql.Transaction) error {
+				require.NoError(t, atxHdlr.cdb.WithTxImmediate(func(tx sql.Transaction) error {
 					mal, err := identities.IsMalicious(tx, sig.NodeID())
 					require.NoError(t, err)
 					require.False(t, mal)
@@ -824,7 +824,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 				require.Equal(t, mwire.InvalidPrevATX, mp.Proof.Type)
 
 				// check if no transaction is currently open in the DB, since otherwise it could cause a deadlock
-				require.NoError(t, atxHdlr.cdb.WithTxImmediate(ctx, func(tx sql.Transaction) error {
+				require.NoError(t, atxHdlr.cdb.WithTxImmediate(func(tx sql.Transaction) error {
 					mal, err := identities.IsMalicious(tx, sig.NodeID())
 					require.NoError(t, err)
 					require.False(t, mal)
@@ -898,7 +898,7 @@ func TestHandlerV1_StoreAtx(t *testing.T) {
 		atxHdlr.mMalPublish.EXPECT().Publish(t.Context(), sig.NodeID(), gomock.Any()).DoAndReturn(
 			func(ctx context.Context, _ types.NodeID, proof wire.Proof) error {
 				// check if no transaction is currently open in the DB, since otherwise it could cause a deadlock
-				require.NoError(t, atxHdlr.cdb.WithTxImmediate(ctx, func(tx sql.Transaction) error {
+				require.NoError(t, atxHdlr.cdb.WithTxImmediate(func(tx sql.Transaction) error {
 					mal, err := identities.IsMalicious(tx, sig.NodeID())
 					require.NoError(t, err)
 					require.False(t, mal)

--- a/activation/handler_v2.go
+++ b/activation/handler_v2.go
@@ -979,7 +979,7 @@ func (h *HandlerV2) storeAtx(ctx context.Context, atx *types.ActivationTx, watx 
 	malicious := false
 	var proof wire.Proof
 	var nodeID types.NodeID
-	if err := h.cdb.WithTxImmediate(ctx, func(tx sql.Transaction) error {
+	if err := h.cdb.WithTxImmediate(func(tx sql.Transaction) error {
 		if len(watx.marriages) != 0 {
 			newMarriageID, err := marriage.NewID(tx)
 			if err != nil {

--- a/api/grpcserver/v1/transaction_service_test.go
+++ b/api/grpcserver/v1/transaction_service_test.go
@@ -137,9 +137,6 @@ func TestTransactionService_StreamResults(t *testing.T) {
 func BenchmarkStreamResults(b *testing.B) {
 	db := statesql.InMemoryTest(b)
 
-	ctx, cancel := context.WithTimeout(b.Context(), 10*time.Second)
-	defer cancel()
-
 	var (
 		gen      = fixture.NewTransactionResultGenerator().WithAddresses(10_000)
 		count    = map[types.Address]int{}
@@ -147,7 +144,7 @@ func BenchmarkStreamResults(b *testing.B) {
 		maxcount int
 		start    = time.Now()
 	)
-	tx, err := db.Tx(ctx)
+	tx, err := db.Tx()
 	require.NoError(b, err)
 	for range 1_000 {
 		rst := gen.Next()
@@ -173,6 +170,9 @@ func BenchmarkStreamResults(b *testing.B) {
 	b.Logf("setup took %s", time.Since(start))
 	b.ResetTimer()
 	b.ReportAllocs()
+
+	ctx, cancel := context.WithTimeout(b.Context(), 10*time.Second)
+	defer cancel()
 
 	stats := runtime.MemStats{}
 	for range b.N {

--- a/api/grpcserver/v1/transaction_service_test.go
+++ b/api/grpcserver/v1/transaction_service_test.go
@@ -37,7 +37,7 @@ func TestTransactionService_StreamResults(t *testing.T) {
 	gen := fixture.NewTransactionResultGenerator().
 		WithAddresses(2)
 	txs := make([]types.TransactionWithResult, 100)
-	require.NoError(t, db.WithTxImmediate(ctx, func(dtx sql.Transaction) error {
+	require.NoError(t, db.WithTxImmediate(func(dtx sql.Transaction) error {
 		for i := range txs {
 			tx := gen.Next()
 

--- a/api/grpcserver/v2alpha1/malfeasance.go
+++ b/api/grpcserver/v2alpha1/malfeasance.go
@@ -63,7 +63,7 @@ func (s *MalfeasanceService) List(
 	}
 
 	result := &spacemeshv2alpha1.MalfeasanceList{}
-	err := s.db.WithTx(ctx, func(tx sql.Transaction) error {
+	err := s.db.WithTx(func(tx sql.Transaction) error {
 		legacyCount, err := identities.CountMalicious(tx)
 		if err != nil {
 			return status.Error(codes.Internal, err.Error())

--- a/api/grpcserver/v2alpha1/transaction_test.go
+++ b/api/grpcserver/v2alpha1/transaction_test.go
@@ -43,7 +43,7 @@ func TestTransactionService_List(t *testing.T) {
 
 	gen := fixture.NewTransactionResultGenerator().WithAddresses(2)
 	txsList := make([]types.TransactionWithResult, 100)
-	require.NoError(t, db.WithTxImmediate(ctx, func(dtx sql.Transaction) error {
+	require.NoError(t, db.WithTxImmediate(func(dtx sql.Transaction) error {
 		for i := range txsList {
 			tx := gen.Next()
 

--- a/api/grpcserver/v2beta1/malfeasance.go
+++ b/api/grpcserver/v2beta1/malfeasance.go
@@ -63,7 +63,7 @@ func (s *MalfeasanceService) List(
 	}
 
 	result := &spacemeshv2beta1.MalfeasanceList{}
-	err := s.db.WithTx(ctx, func(tx sql.Transaction) error {
+	err := s.db.WithTx(func(tx sql.Transaction) error {
 		legacyCount, err := identities.CountMalicious(tx)
 		if err != nil {
 			return status.Error(codes.Internal, err.Error())

--- a/api/grpcserver/v2beta1/transaction_test.go
+++ b/api/grpcserver/v2beta1/transaction_test.go
@@ -43,7 +43,7 @@ func TestTransactionService_List(t *testing.T) {
 
 	gen := fixture.NewTransactionResultGenerator().WithAddresses(2)
 	txsList := make([]types.TransactionWithResult, 100)
-	require.NoError(t, db.WithTxImmediate(ctx, func(dtx sql.Transaction) error {
+	require.NoError(t, db.WithTxImmediate(func(dtx sql.Transaction) error {
 		for i := range txsList {
 			tx := gen.Next()
 

--- a/atxsdata/warmup.go
+++ b/atxsdata/warmup.go
@@ -1,7 +1,6 @@
 package atxsdata
 
 import (
-	"context"
 	"fmt"
 	"time"
 
@@ -21,7 +20,7 @@ func Warm(db sql.StateDatabase, keep types.EpochID, logger *zap.Logger, signers 
 	for _, sig := range signers {
 		cache.Register(sig)
 	}
-	tx, err := db.Tx(context.Background())
+	tx, err := db.Tx()
 	if err != nil {
 		return nil, err
 	}

--- a/atxsdata/warmup_test.go
+++ b/atxsdata/warmup_test.go
@@ -80,7 +80,7 @@ func TestWarmup(t *testing.T) {
 		exec := sql.NewMockExecutor(gomock.NewController(t))
 		call := 0
 		fail := 0
-		tx, err := db.Tx(t.Context())
+		tx, err := db.Tx()
 		require.NoError(t, err)
 		defer tx.Release()
 		exec.EXPECT().

--- a/blocks/certifier.go
+++ b/blocks/certifier.go
@@ -564,7 +564,7 @@ func (c *Certifier) save(
 	if len(valid)+len(invalid) == 0 {
 		return certificates.Add(c.db, lid, cert)
 	}
-	return c.db.WithTxImmediate(ctx, func(dbtx sql.Transaction) error {
+	return c.db.WithTxImmediate(func(dbtx sql.Transaction) error {
 		if err := certificates.Add(dbtx, lid, cert); err != nil {
 			return err
 		}

--- a/checkpoint/recovery.go
+++ b/checkpoint/recovery.go
@@ -138,7 +138,7 @@ func Recover(
 	}
 	defer localDB.Close()
 	logger.Info("clearing atx and malfeasance sync metadata from local database")
-	if err := localDB.WithTxImmediate(ctx, func(tx sql.Transaction) error {
+	if err := localDB.WithTxImmediate(func(tx sql.Transaction) error {
 		if err := atxsync.Clear(tx); err != nil {
 			return err
 		}
@@ -274,7 +274,7 @@ func RecoverFromLocalFile(
 		zap.Int("num accounts", len(data.accounts)),
 		zap.Int("num atxs", len(data.atxs)),
 	)
-	if err = newDB.WithTxImmediate(ctx, func(tx sql.Transaction) error {
+	if err = newDB.WithTxImmediate(func(tx sql.Transaction) error {
 		for _, acct := range data.accounts {
 			if err = accounts.Update(tx, acct); err != nil {
 				return fmt.Errorf("restore account snapshot: %w", err)

--- a/checkpoint/runner.go
+++ b/checkpoint/runner.go
@@ -52,7 +52,7 @@ func checkpointDB(
 		},
 	}
 
-	tx, err := db.Tx(ctx)
+	tx, err := db.Tx()
 	if err != nil {
 		return nil, fmt.Errorf("create db tx: %w", err)
 	}

--- a/cmd/merge-nodes/internal/merge_action.go
+++ b/cmd/merge-nodes/internal/merge_action.go
@@ -159,7 +159,7 @@ func MergeDBs(ctx context.Context, dbLog *zap.Logger, from, to string) error {
 	}
 
 	dbLog.Info("merging databases", zap.String("from", from), zap.String("to", to))
-	err = dstDB.WithTxImmediate(ctx, func(tx sql.Transaction) error {
+	err = dstDB.WithTxImmediate(func(tx sql.Transaction) error {
 		enc := func(stmt *sql.Statement) {
 			stmt.BindText(1, filepath.Join(from, localDbFile))
 		}

--- a/fetch/handler.go
+++ b/fetch/handler.go
@@ -102,7 +102,7 @@ func (h *handler) handleLegacyMaliciousIDsReqStream(ctx context.Context, _ p2p.P
 
 func (h *handler) handleMaliciousIDsReqStream(ctx context.Context, _ p2p.Peer, _ []byte, s io.ReadWriter) error {
 	err := h.streamIDs(ctx, s, func(cbk retrieveCallback) error {
-		return h.db.WithTxImmediate(ctx, func(tx sql.Transaction) error {
+		return h.db.WithTxImmediate(func(tx sql.Transaction) error {
 			total, err := malfeasance.Count(tx)
 			if err != nil {
 				return fmt.Errorf("counting malicious nodes: %w", err)

--- a/fetch/handler.go
+++ b/fetch/handler.go
@@ -59,7 +59,7 @@ func (h *handler) handleLegacyMaliciousIDsReq(ctx context.Context, _ p2p.Peer, _
 
 // handleMaliciousIDsReq returns the IDs of all known malicious nodes.
 func (h *handler) handleMaliciousIDsReq(ctx context.Context, _ p2p.Peer, _ []byte) ([]byte, error) {
-	tx, err := h.db.TxImmediate(ctx)
+	tx, err := h.db.TxImmediate()
 	if err != nil {
 		return nil, fmt.Errorf("starting transaction: %w", err)
 	}

--- a/genvm/vm.go
+++ b/genvm/vm.go
@@ -2,7 +2,6 @@ package vm
 
 import (
 	"bytes"
-	"context"
 	"errors"
 	"fmt"
 	"time"
@@ -122,7 +121,7 @@ func (v *VM) GetAllAccounts() ([]*types.Account, error) {
 }
 
 func (v *VM) revert(lid types.LayerID) error {
-	tx, err := v.db.Tx(context.Background())
+	tx, err := v.db.Tx()
 	if err != nil {
 		return err
 	}
@@ -173,7 +172,7 @@ func (v *VM) GetBalance(address types.Address) (uint64, error) {
 
 // ApplyGenesis saves list of accounts for genesis.
 func (v *VM) ApplyGenesis(genesis []types.Account) error {
-	tx, err := v.db.Tx(context.Background())
+	tx, err := v.db.Tx()
 	if err != nil {
 		return err
 	}
@@ -221,7 +220,7 @@ func (v *VM) Apply(
 	encoder := scale.NewEncoder(hasher)
 	total := 0
 
-	tx, err := v.db.TxImmediate(context.Background())
+	tx, err := v.db.TxImmediate()
 	if err != nil {
 		return nil, nil, err
 	}

--- a/malfeasance/handler.go
+++ b/malfeasance/handler.go
@@ -236,7 +236,7 @@ func (h *Handler) validateAndSave(ctx context.Context, p *wire.MalfeasanceProof)
 		return types.EmptyNodeID, errors.Join(err, pubsub.ErrValidationReject)
 	}
 	proofBytes := codec.MustEncode(p)
-	if err := h.cdb.WithTxImmediate(ctx, func(dbtx sql.Transaction) error {
+	if err := h.cdb.WithTxImmediate(func(dbtx sql.Transaction) error {
 		malicious, err := identities.IsMalicious(dbtx, nodeID)
 		if err != nil {
 			return fmt.Errorf("check known malicious: %w", err)

--- a/malfeasance2/handler.go
+++ b/malfeasance2/handler.go
@@ -313,7 +313,7 @@ func (h *Handler) storeProof(ctx context.Context, nodeIDs []types.NodeID, proof 
 	// Persisting the proof in the DB has to be done within a transaction to ensure consistency. The ATX handler could
 	// update the (or merge multiple) marriage set in parallel, so we need to make sure data is consistent while we
 	// update the malfeasance table.
-	return h.db.WithTxImmediate(ctx, func(tx sql.Transaction) error {
+	return h.db.WithTxImmediate(func(tx sql.Transaction) error {
 		if len(nodeIDs) == 1 {
 			// smesher is not married
 			if err := malfeasance.AddProof(tx, nodeIDs[0], nil, proof, int(domain), time.Now()); err != nil {

--- a/malfeasance2/publisher.go
+++ b/malfeasance2/publisher.go
@@ -152,7 +152,7 @@ func (p *Publisher) PublishATXProof(ctx context.Context, nodeID types.NodeID, pr
 }
 
 func (p *Publisher) Regossip(ctx context.Context, nodeID types.NodeID) error {
-	tx, err := p.db.TxImmediate(ctx)
+	tx, err := p.db.TxImmediate()
 	if err != nil {
 		return fmt.Errorf("starting transaction: %w", err)
 	}
@@ -234,7 +234,7 @@ func (p *Publisher) publish(
 }
 
 func (p *Publisher) ProofByID(ctx context.Context, nodeID types.NodeID) ([]byte, error) {
-	tx, err := p.db.TxImmediate(ctx)
+	tx, err := p.db.TxImmediate()
 	if err != nil {
 		return nil, fmt.Errorf("starting transaction: %w", err)
 	}

--- a/malfeasance2/publisher.go
+++ b/malfeasance2/publisher.go
@@ -53,7 +53,7 @@ func (p *Publisher) PublishATXProof(ctx context.Context, nodeID types.NodeID, pr
 	// Persisting the proof in the DB has to be done within a transaction to ensure consistency. The ATX handler could
 	// update the (or merge multiple) marriage set in parallel, so we need to make sure data is consistent while we
 	// update the malfeasance table.
-	err := p.db.WithTxImmediate(ctx, func(tx sql.Transaction) error {
+	err := p.db.WithTxImmediate(func(tx sql.Transaction) error {
 		marriageID, err := marriage.FindIDByNodeID(tx, nodeID)
 		switch {
 		case errors.Is(err, sql.ErrNotFound): // smesher is not married

--- a/mesh/ballotwriter/ballotwriter.go
+++ b/mesh/ballotwriter/ballotwriter.go
@@ -75,10 +75,7 @@ func (w *BallotWriter) Start(ctx context.Context) {
 			FlushBatchSize.Add(float64(len(batch)))
 
 			var ballotAddDur, layerBallotDur time.Duration
-			// we use a context.Background() because: on shutdown the canceling of the
-			// context may exit the transaction halfway and leave the db in some state where it
-			// causes crawshaw to panic on a "not all connections returned to pool".
-			if err := w.db.WithTxImmediate(context.Background(), func(tx sql.Transaction) error {
+			if err := w.db.WithTxImmediate(func(tx sql.Transaction) error {
 				for _, ballot := range batch {
 					if !ballot.IsMalicious() {
 						layerBallotStart := time.Now()

--- a/mesh/ballotwriter/ballotwriter_test.go
+++ b/mesh/ballotwriter/ballotwriter_test.go
@@ -124,7 +124,7 @@ func BenchmarkWriteCoalescing(b *testing.B) {
 		db := newDiskSqlite(b)
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			if err := db.WithTxImmediate(b.Context(), func(tx sql.Transaction) error {
+			if err := db.WithTxImmediate(func(tx sql.Transaction) error {
 				if err := writeFn(a[i], tx); err != nil {
 					b.Fatal(err)
 				}
@@ -139,7 +139,7 @@ func BenchmarkWriteCoalescing(b *testing.B) {
 		db := newDiskSqlite(b)
 		b.ResetTimer()
 		for j := 0; j < b.N/1000; j++ {
-			if err := db.WithTxImmediate(b.Context(), func(tx sql.Transaction) error {
+			if err := db.WithTxImmediate(func(tx sql.Transaction) error {
 				var err error
 				for i := (j * 1000); i < (j*1000)+1000; i++ {
 					if err = writeFn(a[i], tx); err != nil {
@@ -157,7 +157,7 @@ func BenchmarkWriteCoalescing(b *testing.B) {
 		db := newDiskSqlite(b)
 		b.ResetTimer()
 		for j := 0; j < b.N/5000; j++ {
-			if err := db.WithTxImmediate(b.Context(), func(tx sql.Transaction) error {
+			if err := db.WithTxImmediate(func(tx sql.Transaction) error {
 				var err error
 				for i := (j * 5000); i < (j*5000)+5000; i++ {
 					if err = writeFn(a[i], tx); err != nil {

--- a/mesh/mesh.go
+++ b/mesh/mesh.go
@@ -95,7 +95,7 @@ func NewMesh(
 	}
 
 	genesis := types.GetEffectiveGenesis()
-	if err = db.WithTxImmediate(context.Background(), func(dbtx sql.Transaction) error {
+	if err = db.WithTxImmediate(func(dbtx sql.Transaction) error {
 		if err = layers.SetProcessed(dbtx, genesis); err != nil {
 			return fmt.Errorf("mesh init: %w", err)
 		}
@@ -389,7 +389,7 @@ func (msh *Mesh) applyResults(ctx context.Context, results []result.Layer) error
 				return fmt.Errorf("execute block %v/%v: %w", layer.Layer, target, err)
 			}
 		}
-		if err := msh.cdb.WithTxImmediate(ctx, func(dbtx sql.Transaction) error {
+		if err := msh.cdb.WithTxImmediate(func(dbtx sql.Transaction) error {
 			if err := layers.SetApplied(dbtx, layer.Layer, target); err != nil {
 				return fmt.Errorf("set applied for %v/%v: %w", layer.Layer, target, err)
 			}
@@ -444,7 +444,7 @@ func (msh *Mesh) saveHareOutput(ctx context.Context, lid types.LayerID, bid type
 		certs []certificates.CertValidity
 		err   error
 	)
-	if err = msh.cdb.WithTxImmediate(ctx, func(tx sql.Transaction) error {
+	if err = msh.cdb.WithTxImmediate(func(tx sql.Transaction) error {
 		// check if a certificate has been generated or sync'ed.
 		// - node generated the certificate when it collected enough certify messages
 		// - hare outputs are processed in layer order. i.e. when hare fails for a previous layer N,

--- a/miner/proposal_builder.go
+++ b/miner/proposal_builder.go
@@ -483,7 +483,7 @@ func (pb *ProposalBuilder) initSharedData(ctx context.Context, current types.Lay
 	//
 	// Additionally all activesets that are older than 2 epochs are deleted at the beginning of an epoch anyway, but
 	// maybe we should revisit this when activesets are no longer bootstrapped.
-	return pb.db.WithTxImmediate(ctx, func(tx sql.Transaction) error {
+	return pb.db.WithTxImmediate(func(tx sql.Transaction) error {
 		yes, err := activesets.Has(tx, pb.shared.active.id)
 		if err != nil {
 			return err

--- a/sql/database.go
+++ b/sql/database.go
@@ -635,8 +635,7 @@ type Database interface {
 	// statement.
 	// It then commits the transaction if the exec function doesn't return an error,
 	// and rolls it back otherwise.
-	// If the context is canceled, the currently running SQL statement is interrupted.
-	WithTxImmediate(ctx context.Context, exec func(Transaction) error) error
+	WithTxImmediate(exec func(Transaction) error) error
 	// WithConnection executes the provided function with a connection from the
 	// database pool.
 	// If many queries are to be executed in a row, but there's no need for an
@@ -788,8 +787,8 @@ func (db *sqliteDatabase) TxImmediate(ctx context.Context) (Transaction, error) 
 }
 
 // WithTxImmediate implements Database.
-func (db *sqliteDatabase) WithTxImmediate(ctx context.Context, exec func(Transaction) error) error {
-	return db.withTx(ctx, beginImmediate, exec)
+func (db *sqliteDatabase) WithTxImmediate(exec func(Transaction) error) error {
+	return db.withTx(context.Background(), beginImmediate, exec)
 }
 
 func (db *sqliteDatabase) runInterceptors(query string) error {

--- a/sql/database.go
+++ b/sql/database.go
@@ -601,13 +601,17 @@ type Interceptor func(query string) error
 type Database interface {
 	Executor
 	QueryCache
+
 	// Close closes the database.
 	Close() error
+
 	// QueryCount returns the number of queries executed on the database.
 	QueryCount() int
+
 	// QueryCache returns the query cache for this database, if it's present,
 	// or nil otherwise.
 	QueryCache() QueryCache
+
 	// Tx creates deferred sqlite transaction.
 	//
 	// Deferred transactions are not started until the first statement.
@@ -615,20 +619,21 @@ type Database interface {
 	// after one of the write statements.
 	//
 	// https://www.sqlite.org/lang_transaction.html
-	Tx(ctx context.Context) (Transaction, error)
+	Tx() (Transaction, error)
+
 	// WithTx starts a new transaction and passes it to the exec function.
 	// It then commits the transaction if the exec function doesn't return an error,
 	// and rolls it back otherwise.
-	// If the context is canceled, the currently running SQL statement is interrupted.
-	WithTx(ctx context.Context, exec func(Transaction) error) error
+	WithTx(exec func(Transaction) error) error
+
 	// TxImmediate begins a new immediate transaction on the database, that is,
 	// a transaction that starts a write immediately without waiting for a write
 	// statement.
 	// The transaction returned from this function must always be released by calling
 	// its Release method. Release rolls back the transaction if it hasn't been
 	// committed.
-	// If the context is canceled, the currently running SQL statement is interrupted.
-	TxImmediate(ctx context.Context) (Transaction, error)
+	TxImmediate() (Transaction, error)
+
 	// WithTxImmediate starts a new immediate transaction and passes it to the exec
 	// function.
 	// An immediate transaction is started immediately, without waiting for a write
@@ -636,6 +641,7 @@ type Database interface {
 	// It then commits the transaction if the exec function doesn't return an error,
 	// and rolls it back otherwise.
 	WithTxImmediate(exec func(Transaction) error) error
+
 	// WithConnection executes the provided function with a connection from the
 	// database pool.
 	// If many queries are to be executed in a row, but there's no need for an
@@ -643,14 +649,15 @@ type Database interface {
 	// WAL checkpointing, it may be preferable to use a single connection for
 	// it to avoid database pool overhead.
 	// The connection is released back to the pool after the function returns.
-	// If the context is canceled, the currently running SQL statement is interrupted.
-	WithConnection(ctx context.Context, exec func(Executor) error) error
+	WithConnection(exec func(Executor) error) error
+
 	// Intercept adds an interceptor function to the database. The interceptor
 	// functions are invoked upon each query on the database, including queries
 	// executed within transactions.
 	// The query will fail if the interceptor returns an error.
 	// The interceptor can later be removed using RemoveInterceptor with the same key.
 	Intercept(key string, fn Interceptor)
+
 	// RemoveInterceptor removes the interceptor function with specified key from the database.
 	RemoveInterceptor(key string)
 }
@@ -686,9 +693,9 @@ type sqliteDatabase struct {
 
 var _ Database = &sqliteDatabase{}
 
-func (db *sqliteDatabase) getConn(ctx context.Context) *sqlite.Conn {
+func (db *sqliteDatabase) getConn() *sqlite.Conn {
 	start := time.Now()
-	conn := db.pool.Get(ctx)
+	conn := db.pool.Get(context.Background())
 	if conn != nil && db.connWaitLatency != nil {
 		db.connWaitLatency.Observe(time.Since(start).Seconds())
 		db.poolUsage.Inc()
@@ -703,27 +710,24 @@ func (db *sqliteDatabase) putConn(conn *sqlite.Conn) {
 	}
 }
 
-func (db *sqliteDatabase) getTx(ctx context.Context, initstmt string) (*sqliteTx, error) {
+func (db *sqliteDatabase) getTx(initstmt string) (*sqliteTx, error) {
 	if db.closed {
 		return nil, ErrClosed
 	}
-	conCtx, cancel := context.WithCancel(ctx)
-	conn := db.getConn(conCtx)
+	conn := db.getConn()
 	if conn == nil {
-		cancel()
 		return nil, ErrNoConnection
 	}
-	tx := &sqliteTx{queryCache: db.queryCache, db: db, conn: conn, freeConn: cancel}
+	tx := &sqliteTx{queryCache: db.queryCache, db: db, conn: conn}
 	if err := tx.begin(initstmt); err != nil {
-		cancel()
 		db.putConn(conn)
 		return nil, err
 	}
 	return tx, nil
 }
 
-func (db *sqliteDatabase) withTx(ctx context.Context, initstmt string, exec func(Transaction) error) (err error) {
-	tx, err := db.getTx(ctx, initstmt)
+func (db *sqliteDatabase) withTx(initstmt string, exec func(Transaction) error) (err error) {
+	tx, err := db.getTx(initstmt)
 	if err != nil {
 		return err
 	}
@@ -739,7 +743,7 @@ func (db *sqliteDatabase) withTx(ctx context.Context, initstmt string, exec func
 }
 
 func (db *sqliteDatabase) startExclusive() error {
-	conn := db.getConn(context.Background())
+	conn := db.getConn()
 	if conn == nil {
 		return ErrNoConnection
 	}
@@ -772,23 +776,23 @@ func (db *sqliteDatabase) startExclusive() error {
 }
 
 // Tx implements Database.
-func (db *sqliteDatabase) Tx(ctx context.Context) (Transaction, error) {
-	return db.getTx(ctx, beginDefault)
+func (db *sqliteDatabase) Tx() (Transaction, error) {
+	return db.getTx(beginDefault)
 }
 
 // WithTx implements Database.
-func (db *sqliteDatabase) WithTx(ctx context.Context, exec func(Transaction) error) error {
-	return db.withTx(ctx, beginDefault, exec)
+func (db *sqliteDatabase) WithTx(exec func(Transaction) error) error {
+	return db.withTx(beginDefault, exec)
 }
 
 // TxImmediate implements Database.
-func (db *sqliteDatabase) TxImmediate(ctx context.Context) (Transaction, error) {
-	return db.getTx(ctx, beginImmediate)
+func (db *sqliteDatabase) TxImmediate() (Transaction, error) {
+	return db.getTx(beginImmediate)
 }
 
 // WithTxImmediate implements Database.
 func (db *sqliteDatabase) WithTxImmediate(exec func(Transaction) error) error {
-	return db.withTx(context.Background(), beginImmediate, exec)
+	return db.withTx(beginImmediate, exec)
 }
 
 func (db *sqliteDatabase) runInterceptors(query string) error {
@@ -819,7 +823,7 @@ func (db *sqliteDatabase) Exec(query string, encoder Encoder, decoder Decoder) (
 		return 0, ErrClosed
 	}
 	db.queryCount.Add(1)
-	conn := db.getConn(context.Background())
+	conn := db.getConn()
 	if conn == nil {
 		return 0, ErrNoConnection
 	}
@@ -848,13 +852,11 @@ func (db *sqliteDatabase) Close() error {
 }
 
 // WithConnection implements Database.
-func (db *sqliteDatabase) WithConnection(ctx context.Context, toCall func(Executor) error) error {
+func (db *sqliteDatabase) WithConnection(toCall func(Executor) error) error {
 	if db.closed {
 		return ErrClosed
 	}
-	conCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	c := newLazyConn(conCtx, db)
+	c := newLazyConn(db)
 	defer c.release()
 	return toCall(c)
 }
@@ -1126,7 +1128,6 @@ type sqliteTx struct {
 	*queryCache
 	db        *sqliteDatabase
 	conn      *sqlite.Conn
-	freeConn  func()
 	committed bool
 	err       error
 }
@@ -1155,12 +1156,10 @@ func (tx *sqliteTx) Commit() error {
 func (tx *sqliteTx) Release() error {
 	defer tx.db.putConn(tx.conn)
 	if tx.committed {
-		tx.freeConn()
 		return nil
 	}
 	stmt := tx.conn.Prep("ROLLBACK")
 	_, tx.err = stmt.Step()
-	tx.freeConn()
 	return mapSqliteError(tx.err)
 }
 
@@ -1193,12 +1192,12 @@ type lazyConn struct {
 	connMtx sync.Mutex
 }
 
-func newLazyConn(ctx context.Context, db *sqliteDatabase) *lazyConn {
+func newLazyConn(db *sqliteDatabase) *lazyConn {
 	return &lazyConn{
 		queryCache: db.queryCache,
 		db:         db,
 		getConn: func() *sqlite.Conn {
-			return db.getConn(ctx)
+			return db.getConn()
 		},
 	}
 }

--- a/sql/database_test.go
+++ b/sql/database_test.go
@@ -1,7 +1,6 @@
 package sql
 
 import (
-	"context"
 	"errors"
 	"os"
 	"path/filepath"
@@ -37,7 +36,7 @@ func Test_ConReturnedToPool(t *testing.T) {
 		})
 	})
 
-	con := db.pool.Get(context.Background())
+	con := db.pool.Get(t.Context())
 	require.NotNil(t, con, "connection was not returned")
 }
 

--- a/sql/database_test.go
+++ b/sql/database_test.go
@@ -37,9 +37,7 @@ func Test_ConReturnedToPool(t *testing.T) {
 		})
 	})
 
-	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
-	defer cancel()
-	con := db.pool.Get(ctx)
+	con := db.pool.Get(context.Background())
 	require.NotNil(t, con, "connection was not returned")
 }
 
@@ -56,7 +54,7 @@ func Test_Transaction_Isolation(t *testing.T) {
 		}),
 		WithNoCheckSchemaDrift(),
 	)
-	tx, err := db.Tx(t.Context())
+	tx, err := db.Tx()
 	require.NoError(t, err)
 
 	key := "dsada"
@@ -643,7 +641,7 @@ func TestExclusive(t *testing.T) {
 func TestConnection(t *testing.T) {
 	db := InMemoryTest(t)
 	var r int
-	require.NoError(t, db.WithConnection(t.Context(), func(ex Executor) error {
+	require.NoError(t, db.WithConnection(func(ex Executor) error {
 		n, err := ex.Exec("select ?", func(stmt *Statement) {
 			stmt.BindInt64(1, 42)
 		}, func(stmt *Statement) bool {
@@ -656,7 +654,7 @@ func TestConnection(t *testing.T) {
 		return nil
 	}))
 
-	require.Error(t, db.WithConnection(t.Context(), func(Executor) error {
+	require.Error(t, db.WithConnection(func(Executor) error {
 		return errors.New("error")
 	}))
 }
@@ -668,7 +666,7 @@ func TestConnection_Idle(t *testing.T) {
 	}
 	require.Zero(t, numConns())
 	db := InMemoryTest(t, WithDBName(dbName))
-	require.NoError(t, db.WithConnection(t.Context(), func(ex Executor) error {
+	require.NoError(t, db.WithConnection(func(ex Executor) error {
 		for range 3 {
 			for range 3 {
 				_, err := ex.Exec("select 1", nil, func(stmt *Statement) bool {

--- a/sql/database_test.go
+++ b/sql/database_test.go
@@ -521,7 +521,7 @@ func TestDBClosed(t *testing.T) {
 	require.NoError(t, db.Close())
 	_, err := db.Exec("select 1", nil, nil)
 	require.ErrorIs(t, err, ErrClosed)
-	err = db.WithTxImmediate(t.Context(), func(tx Transaction) error { return nil })
+	err = db.WithTxImmediate(func(tx Transaction) error { return nil })
 	require.ErrorIs(t, err, ErrClosed)
 }
 

--- a/sql/schema.go
+++ b/sql/schema.go
@@ -3,7 +3,6 @@ package sql
 import (
 	"bufio"
 	"bytes"
-	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -88,7 +87,7 @@ func (s *Schema) SkipMigrations(i ...int) {
 
 // Apply applies the schema to the database.
 func (s *Schema) Apply(db Database) error {
-	return db.WithTxImmediate(context.Background(), func(tx Transaction) error {
+	return db.WithTxImmediate(func(tx Transaction) error {
 		scanner := bufio.NewScanner(strings.NewReader(s.Script))
 		scanner.Split(func(data []byte, atEOF bool) (advance int, token []byte, err error) {
 			if i := bytes.Index(data, []byte(";")); i >= 0 {
@@ -150,7 +149,7 @@ func (s *Schema) Migrate(logger *zap.Logger, db Database, before, vacuumState in
 		if m.Order() <= before {
 			continue
 		}
-		if err := db.WithTxImmediate(context.Background(), func(tx Transaction) error {
+		if err := db.WithTxImmediate(func(tx Transaction) error {
 			if _, ok := s.skipMigration[m.Order()]; !ok {
 				if err := m.Apply(tx, logger); err != nil {
 					for j := i; j >= 0 && s.Migrations[j].Order() > before; j-- {
@@ -199,7 +198,7 @@ func (s *Schema) MigrateTempDB(logger *zap.Logger, db Database, before int) erro
 		}
 
 		if _, ok := s.skipMigration[m.Order()]; !ok {
-			if err := db.WithTxImmediate(context.Background(), func(tx Transaction) error {
+			if err := db.WithTxImmediate(func(tx Transaction) error {
 				return m.Apply(tx, logger)
 			}); err != nil {
 				return fmt.Errorf("apply %s: %w", m.Name(), err)

--- a/sql/transactions/iterator_test.go
+++ b/sql/transactions/iterator_test.go
@@ -63,7 +63,7 @@ func TestIterateResults(t *testing.T) {
 
 	gen := fixture.NewTransactionResultGenerator()
 	txs := make([]types.TransactionWithResult, 100)
-	require.NoError(t, db.WithTxImmediate(t.Context(), func(dtx sql.Transaction) error {
+	require.NoError(t, db.WithTxImmediate(func(dtx sql.Transaction) error {
 		for i := range txs {
 			tx := gen.Next()
 
@@ -147,7 +147,7 @@ func TestIterateSnapshot(t *testing.T) {
 	require.NoError(t, err)
 	gen := fixture.NewTransactionResultGenerator()
 	expect := 10
-	require.NoError(t, db.WithTxImmediate(t.Context(), func(dtx sql.Transaction) error {
+	require.NoError(t, db.WithTxImmediate(func(dtx sql.Transaction) error {
 		for i := 0; i < expect; i++ {
 			tx := gen.Next()
 
@@ -175,7 +175,7 @@ func TestIterateSnapshot(t *testing.T) {
 	}()
 	<-initialized
 
-	require.NoError(t, db.WithTxImmediate(t.Context(), func(dtx sql.Transaction) error {
+	require.NoError(t, db.WithTxImmediate(func(dtx sql.Transaction) error {
 		for i := 0; i < 10; i++ {
 			tx := gen.Next()
 

--- a/sql/transactions/transactions_test.go
+++ b/sql/transactions/transactions_test.go
@@ -231,17 +231,17 @@ func TestApply_AlreadyApplied(t *testing.T) {
 	require.NoError(t, transactions.Add(db, tx, time.Now()))
 
 	bid := types.RandomBlockID()
-	require.NoError(t, db.WithTxImmediate(t.Context(), func(dtx sql.Transaction) error {
+	require.NoError(t, db.WithTxImmediate(func(dtx sql.Transaction) error {
 		return transactions.AddResult(dtx, tx.ID, &types.TransactionResult{Layer: lid, Block: bid})
 	}))
 
 	// same block applied again
-	require.Error(t, db.WithTxImmediate(t.Context(), func(dtx sql.Transaction) error {
+	require.Error(t, db.WithTxImmediate(func(dtx sql.Transaction) error {
 		return transactions.AddResult(dtx, tx.ID, &types.TransactionResult{Layer: lid, Block: bid})
 	}))
 
 	// different block applied again
-	require.Error(t, db.WithTxImmediate(t.Context(), func(dtx sql.Transaction) error {
+	require.Error(t, db.WithTxImmediate(func(dtx sql.Transaction) error {
 		return transactions.AddResult(
 			dtx,
 			tx.ID,
@@ -253,7 +253,7 @@ func TestApply_AlreadyApplied(t *testing.T) {
 func TestUndoLayers_Empty(t *testing.T) {
 	db := statesql.InMemoryTest(t)
 
-	require.NoError(t, db.WithTxImmediate(t.Context(), func(dtx sql.Transaction) error {
+	require.NoError(t, db.WithTxImmediate(func(dtx sql.Transaction) error {
 		return transactions.UndoLayers(dtx, types.LayerID(199))
 	}))
 }
@@ -272,7 +272,7 @@ func TestApplyAndUndoLayers(t *testing.T) {
 		require.NoError(t, transactions.Add(db, tx, time.Now()))
 		bid := types.RandomBlockID()
 
-		require.NoError(t, db.WithTxImmediate(t.Context(), func(dtx sql.Transaction) error {
+		require.NoError(t, db.WithTxImmediate(func(dtx sql.Transaction) error {
 			return transactions.AddResult(dtx, tx.ID, &types.TransactionResult{Layer: lid, Block: bid})
 		}))
 		applied = append(applied, tx.ID)
@@ -284,7 +284,7 @@ func TestApplyAndUndoLayers(t *testing.T) {
 		require.Equal(t, types.APPLIED, mtx.State)
 	}
 	// revert to firstLayer
-	require.NoError(t, db.WithTxImmediate(t.Context(), func(dtx sql.Transaction) error {
+	require.NoError(t, db.WithTxImmediate(func(dtx sql.Transaction) error {
 		return transactions.UndoLayers(dtx, firstLayer.Add(1))
 	}))
 
@@ -348,7 +348,7 @@ func TestGetByAddress(t *testing.T) {
 		createTX(t, signer1, signer2Address, 1, 191, 1),
 	}
 	received := time.Now()
-	require.NoError(t, db.WithTxImmediate(t.Context(), func(dbtx sql.Transaction) error {
+	require.NoError(t, db.WithTxImmediate(func(dbtx sql.Transaction) error {
 		for _, tx := range txs {
 			require.NoError(t, transactions.Add(dbtx, tx, received))
 			require.NoError(t, transactions.AddResult(dbtx, tx.ID, &types.TransactionResult{Layer: lid}))
@@ -417,7 +417,7 @@ func TestAppliedLayer(t *testing.T) {
 	for _, tx := range txs {
 		require.NoError(t, transactions.Add(db, tx, time.Now()))
 	}
-	require.NoError(t, db.WithTxImmediate(t.Context(), func(dtx sql.Transaction) error {
+	require.NoError(t, db.WithTxImmediate(func(dtx sql.Transaction) error {
 		return transactions.AddResult(dtx, txs[0].ID, &types.TransactionResult{Layer: lid, Block: types.BlockID{1, 1}})
 	}))
 
@@ -428,7 +428,7 @@ func TestAppliedLayer(t *testing.T) {
 	_, err = transactions.GetAppliedLayer(db, txs[1].ID)
 	require.ErrorIs(t, err, sql.ErrNotFound)
 
-	require.NoError(t, db.WithTxImmediate(t.Context(), func(dtx sql.Transaction) error {
+	require.NoError(t, db.WithTxImmediate(func(dtx sql.Transaction) error {
 		return transactions.UndoLayers(dtx, lid)
 	}))
 	_, err = transactions.GetAppliedLayer(db, txs[0].ID)
@@ -465,7 +465,7 @@ func TestAddressesWithPendingTransactions(t *testing.T) {
 		{Address: principals[0], Nonce: txs[0].Nonce},
 		{Address: principals[1], Nonce: txs[2].Nonce},
 	}, rst)
-	require.NoError(t, db.WithTxImmediate(t.Context(), func(dbtx sql.Transaction) error {
+	require.NoError(t, db.WithTxImmediate(func(dbtx sql.Transaction) error {
 		return transactions.AddResult(dbtx, txs[0].ID, &types.TransactionResult{Message: "hey"})
 	}))
 	rst, err = transactions.AddressesWithPendingTransactions(db)
@@ -474,7 +474,7 @@ func TestAddressesWithPendingTransactions(t *testing.T) {
 		{Address: principals[0], Nonce: txs[1].Nonce},
 		{Address: principals[1], Nonce: txs[2].Nonce},
 	}, rst)
-	require.NoError(t, db.WithTxImmediate(t.Context(), func(dbtx sql.Transaction) error {
+	require.NoError(t, db.WithTxImmediate(func(dbtx sql.Transaction) error {
 		return transactions.AddResult(dbtx, txs[2].ID, &types.TransactionResult{Message: "hey"})
 	}))
 	rst, err = transactions.AddressesWithPendingTransactions(db)

--- a/sync2/dbset/dbset.go
+++ b/sync2/dbset/dbset.go
@@ -1,7 +1,6 @@
 package dbset
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"maps"
@@ -229,7 +228,7 @@ func (d *DBSet) Advance() error {
 
 // WithCopy invokes the specified function, passing it a temporary copy of the DBSet.
 // Implements rangesync.OrderedSet.
-func (d *DBSet) WithCopy(ctx context.Context, toCall func(rangesync.OrderedSet) error) error {
+func (d *DBSet) WithCopy(toCall func(rangesync.OrderedSet) error) error {
 	if err := d.EnsureLoaded(); err != nil {
 		return fmt.Errorf("loading DBSet: %w", err)
 	}
@@ -249,7 +248,7 @@ func (d *DBSet) WithCopy(ctx context.Context, toCall func(rangesync.OrderedSet) 
 	defer ds.release()
 	db, ok := d.db.(sql.Database)
 	if ok {
-		return db.WithConnection(ctx, func(ex sql.Executor) error {
+		return db.WithConnection(func(ex sql.Executor) error {
 			ds.db = ex
 			return toCall(ds)
 		})

--- a/sync2/dbset/dbset_test.go
+++ b/sync2/dbset/dbset_test.go
@@ -248,7 +248,7 @@ func TestDBSet_Copy(t *testing.T) {
 	require.Equal(t, "0000000000000000000000000000000000000000000000000000000000000000",
 		firstKey(t, s.Items()).String())
 
-	require.NoError(t, s.WithCopy(t.Context(), func(copy rangesync.OrderedSet) error {
+	require.NoError(t, s.WithCopy(func(copy rangesync.OrderedSet) error {
 		info, err := copy.RangeInfo(ids[2], ids[0])
 		require.NoError(t, err)
 		require.Equal(t, 2, info.Count)
@@ -297,7 +297,7 @@ func TestDBItemStore_Advance(t *testing.T) {
 	verifyDS := func(db sql.Database, os rangesync.OrderedSet) {
 		require.NoError(t, os.EnsureLoaded())
 
-		require.NoError(t, os.WithCopy(t.Context(), func(copy rangesync.OrderedSet) error {
+		require.NoError(t, os.WithCopy(func(copy rangesync.OrderedSet) error {
 			info, err := os.RangeInfo(ids[0], ids[0])
 			require.NoError(t, err)
 			require.Equal(t, 4, info.Count)
@@ -344,7 +344,7 @@ func TestDBItemStore_Advance(t *testing.T) {
 			return nil
 		}))
 
-		require.NoError(t, os.WithCopy(t.Context(), func(copy rangesync.OrderedSet) error {
+		require.NoError(t, os.WithCopy(func(copy rangesync.OrderedSet) error {
 			info, err := copy.RangeInfo(ids[0], ids[0])
 			require.NoError(t, err)
 			require.Equal(t, 5, info.Count)
@@ -363,7 +363,7 @@ func TestDBItemStore_Advance(t *testing.T) {
 	t.Run("DBSet copy", func(t *testing.T) {
 		db := sqlstore.PopulateDB(t, testKeyLen, ids)
 		origSet := dbset.NewDBSet(db, st, testKeyLen, testDepth)
-		require.NoError(t, origSet.WithCopy(t.Context(), func(copy rangesync.OrderedSet) error {
+		require.NoError(t, origSet.WithCopy(func(copy rangesync.OrderedSet) error {
 			verifyDS(db, copy)
 			return nil
 		}))
@@ -403,7 +403,7 @@ func TestDBSet_Added(t *testing.T) {
 		rangesync.MustParseHexKeyBytes("4444444444444444444444444444444444444444444444444444444444444444"),
 	}, recvd)
 
-	require.NoError(t, s.WithCopy(t.Context(), func(copy rangesync.OrderedSet) error {
+	require.NoError(t, s.WithCopy(func(copy rangesync.OrderedSet) error {
 		recvd1, err := copy.(*dbset.DBSet).Received().FirstN(3)
 		require.NoError(t, err)
 		require.ElementsMatch(t, recvd, recvd1)

--- a/sync2/dbset/p2p_test.go
+++ b/sync2/dbset/p2p_test.go
@@ -53,7 +53,7 @@ func populateFoo(t testing.TB, rows []fooRow) (db sql.Database, dir string) {
 	t.Cleanup(func() {
 		require.NoError(t, db.Close())
 	})
-	require.NoError(t, db.WithTx(t.Context(), func(tx sql.Transaction) error {
+	require.NoError(t, db.WithTx(func(tx sql.Transaction) error {
 		_, err := tx.Exec(
 			"create table foo(id char(32) not null primary key, received int)",
 			nil, nil)
@@ -112,7 +112,7 @@ func stopTimer(tb testing.TB) {
 
 func dbFromRows(t testing.TB, rows []fooRow) sql.Transaction {
 	db, _ := populateFoo(t, rows)
-	tx, err := db.Tx(t.Context())
+	tx, err := db.Tx()
 	require.NoError(t, err)
 	t.Cleanup(func() { tx.Release() })
 	return tx
@@ -186,7 +186,7 @@ func runSync(
 	cfg.MaxReconcDiff = 1 // always reconcile
 	pssA := rangesync.NewPairwiseSetSyncerInternal(syncLogger.Named("sideA"), nil, "test", cfg, &tr, clock)
 	d := rangesync.NewDispatcher(log)
-	require.NoError(t, setA.WithCopy(t.Context(), func(copyA rangesync.OrderedSet) error {
+	require.NoError(t, setA.WithCopy(func(copyA rangesync.OrderedSet) error {
 		syncSetA := copyA.(*dbset.DBSet)
 		pssA.Register(d, syncSetA)
 		srv := server.New(mesh.Hosts()[0], proto,
@@ -220,7 +220,7 @@ func runSync(
 			syncLogger.Named("sideB"), client, "test", cfg, &tr, clock)
 
 		tStart := time.Now()
-		require.NoError(t, setB.WithCopy(t.Context(), func(copyB rangesync.OrderedSet) error {
+		require.NoError(t, setB.WithCopy(func(copyB rangesync.OrderedSet) error {
 			syncSetB := copyB.(*dbset.DBSet)
 			require.NoError(t, pssB.Sync(ctx, srvPeerID, syncSetB, x, x))
 			stopTimer(t)
@@ -531,7 +531,7 @@ func copyDB(t testing.TB, srcDir, dstDir string) sql.Transaction {
 	db, err := sql.Open("file:"+filepath.Join(dstDir, "temp.db"),
 		sql.WithNoCheckSchemaDrift())
 	require.NoError(t, err)
-	tx, err := db.Tx(t.Context())
+	tx, err := db.Tx()
 	require.NoError(t, err)
 	t.Cleanup(func() { tx.Release() })
 	return tx

--- a/sync2/fptree/fptree_test.go
+++ b/sync2/fptree/fptree_test.go
@@ -629,7 +629,7 @@ func makeDBBackedFPTree(t *testing.T) []*fptree.FPTree {
 		TableName: "foo",
 		IDColumn:  "id",
 	}
-	tx, err := db.Tx(t.Context())
+	tx, err := db.Tx()
 	require.NoError(t, err)
 	t.Cleanup(func() { tx.Release() })
 	sts, err := st.Snapshot(tx)

--- a/sync2/multipeer/setsyncbase.go
+++ b/sync2/multipeer/setsyncbase.go
@@ -62,7 +62,7 @@ func (ssb *SetSyncBase) syncPeer(
 	toCall func(rangesync.OrderedSet) error,
 ) error {
 	sr := rangesync.EmptySeqResult()
-	if err := ssb.os.WithCopy(ctx, func(os rangesync.OrderedSet) error {
+	if err := ssb.os.WithCopy(func(os rangesync.OrderedSet) error {
 		if err := toCall(os); err != nil {
 			return err
 		}
@@ -101,7 +101,7 @@ func (ssb *SetSyncBase) Serve(ctx context.Context, p p2p.Peer, stream io.ReadWri
 // Probe implements SyncBase.
 func (ssb *SetSyncBase) Probe(ctx context.Context, p p2p.Peer) (pr rangesync.ProbeResult, err error) {
 	// Use a snapshot of the store to avoid holding the mutex for a long time
-	if err := ssb.os.WithCopy(ctx, func(os rangesync.OrderedSet) error {
+	if err := ssb.os.WithCopy(func(os rangesync.OrderedSet) error {
 		pr, err = ssb.ps.Probe(ctx, p, os, nil, nil)
 		if err != nil {
 			return fmt.Errorf("probing peer %s: %w", p, err)

--- a/sync2/multipeer/setsyncbase_test.go
+++ b/sync2/multipeer/setsyncbase_test.go
@@ -40,8 +40,8 @@ func newSetSyncBaseTester(t *testing.T, os rangesync.OrderedSet) *setSyncBaseTes
 
 func (st *setSyncBaseTester) expectCopy() *mocks.MockOrderedSet {
 	copy := mocks.NewMockOrderedSet(st.ctrl)
-	st.os.EXPECT().WithCopy(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, toCall func(rangesync.OrderedSet) error) error {
+	st.os.EXPECT().WithCopy(gomock.Any()).DoAndReturn(
+		func(toCall func(rangesync.OrderedSet) error) error {
 			return toCall(copy)
 		})
 	return copy

--- a/sync2/p2p_test.go
+++ b/sync2/p2p_test.go
@@ -138,16 +138,14 @@ func TestP2P(t *testing.T) {
 				return false
 			}
 			r := true
-			require.NoError(t, hsync.Set().WithCopy(
-				t.Context(),
-				func(os rangesync.OrderedSet) error {
-					info, err := os.SetInfo()
-					require.NoError(t, err)
-					if info.Count < numHashes {
-						r = false
-					}
-					return nil
-				}))
+			require.NoError(t, hsync.Set().WithCopy(func(os rangesync.OrderedSet) error {
+				info, err := os.SetInfo()
+				require.NoError(t, err)
+				if info.Count < numHashes {
+					r = false
+				}
+				return nil
+			}))
 			if !r {
 				return false
 			}
@@ -157,16 +155,14 @@ func TestP2P(t *testing.T) {
 
 	advCounts := make([]int, len(hs))
 	for n, hsync := range hs {
-		require.NoError(t, hsync.Set().WithCopy(
-			t.Context(),
-			func(os rangesync.OrderedSet) error {
-				info, err := os.SetInfo()
-				require.NoError(t, err)
-				actualItems, err := info.Items.Collect()
-				require.NoError(t, err)
-				require.ElementsMatch(t, initialSet, actualItems)
-				return nil
-			}))
+		require.NoError(t, hsync.Set().WithCopy(func(os rangesync.OrderedSet) error {
+			info, err := os.SetInfo()
+			require.NoError(t, err)
+			actualItems, err := info.Items.Collect()
+			require.NoError(t, err)
+			require.ElementsMatch(t, initialSet, actualItems)
+			return nil
+		}))
 		// OrderedSet is advanced after each sync.
 		// The first set may not be advanced initially here b/c it does
 		// not receive any new items.
@@ -287,17 +283,15 @@ func TestP2P_DBSet(t *testing.T) {
 				return false
 			}
 			r := true
-			require.NoError(t, hsync.Set().WithCopy(
-				t.Context(),
-				func(os rangesync.OrderedSet) error {
-					info, err := os.SetInfo()
-					require.NoError(t, err)
-					if info.Count < numHashes {
-						r = false
-					}
-					require.Equal(t, initialInfo.Fingerprint, info.Fingerprint)
-					return nil
-				}))
+			require.NoError(t, hsync.Set().WithCopy(func(os rangesync.OrderedSet) error {
+				info, err := os.SetInfo()
+				require.NoError(t, err)
+				if info.Count < numHashes {
+					r = false
+				}
+				require.Equal(t, initialInfo.Fingerprint, info.Fingerprint)
+				return nil
+			}))
 			if !r {
 				return false
 			}

--- a/sync2/rangesync/dumbset.go
+++ b/sync2/rangesync/dumbset.go
@@ -1,7 +1,6 @@
 package rangesync
 
 import (
-	"context"
 	"crypto/md5"
 	"errors"
 	"fmt"
@@ -12,7 +11,7 @@ import (
 	"github.com/spacemeshos/go-spacemesh/hash"
 )
 
-// stringToFP conversts a string to a Fingerprint.
+// stringToFP converts a string to a Fingerprint.
 // It is only used in tests.
 func stringToFP(s string) Fingerprint {
 	h := md5.New()
@@ -308,7 +307,7 @@ func (ds *DumbSet) SetInfo() (RangeInfo, error) {
 }
 
 // WithCopy implements OrderedSet.
-func (ds *DumbSet) WithCopy(_ context.Context, toCall func(OrderedSet) error) error {
+func (ds *DumbSet) WithCopy(toCall func(OrderedSet) error) error {
 	ds.copyMtx.Lock()
 	copy := &DumbSet{
 		keys:              slices.Clone(ds.keys),

--- a/sync2/rangesync/interface.go
+++ b/sync2/rangesync/interface.go
@@ -40,14 +40,17 @@ type OrderedSet interface {
 	// It should not perform any additional actions related to handling
 	// the received key.
 	Add(k KeyBytes) error
+
 	// Receive handles a new key received from the peer.
 	// It should not add the key to the set.
 	Receive(k KeyBytes) error
+
 	// Received returns the sequence containing all the items received from the peer.
 	// Unlike other methods, SeqResult returned by Received called on a copy of the
 	// OrderedSet passed to WithCopy callback is expected to be valid outside of the
 	// callback as well.
 	Received() SeqResult
+
 	// RangeInfo returns RangeInfo for the item range in the ordered set,
 	// bounded by [x, y).
 	// x == y indicates the whole set.
@@ -57,29 +60,37 @@ type OrderedSet interface {
 	// If count >= 0, at most count items are returned, and RangeInfo
 	// is returned for the corresponding subrange of the requested range.
 	RangeInfo(x, y KeyBytes) (RangeInfo, error)
+
 	// SplitRange splits the range roughly after the specified count of items,
 	// returning RangeInfo for the first half and the second half of the range.
 	SplitRange(x, y KeyBytes, count int) (SplitInfo, error)
+
 	// SetInfo returns RangeInfo for the whole set.
 	SetInfo() (RangeInfo, error)
+
 	// WithCopy runs the specified function, passing to it a temporary shallow copy of
 	// the OrderedSet. The copy is discarded after the function returns, releasing
 	// any resources associated with it.
 	// The list of received items as returned by Received is inherited by the copy.
-	WithCopy(ctx context.Context, toCall func(OrderedSet) error) error
+	WithCopy(toCall func(OrderedSet) error) error
+
 	// Recent returns an Iterator that yields the items added since the specified
 	// timestamp. Some OrderedSet implementations may not have Recent implemented, in
 	// which case it should return an empty sequence.
 	Recent(since time.Time) (SeqResult, int)
+
 	// Loaded returns true if the set is loaded and ready for use.
 	Loaded() bool
+
 	// EnsureLoaded ensures that the set is loaded and ready for use.
 	// It may do nothing in case of in-memory sets, but may trigger loading
 	// from database in case of database-backed sets.
 	EnsureLoaded() error
+
 	// Advance advances the set by including the items since the set was last loaded
 	// or advanced.
 	Advance() error
+
 	// Has returns true if the specified key is present in OrderedSet.
 	Has(KeyBytes) (bool, error)
 }

--- a/sync2/rangesync/mocks/mocks.go
+++ b/sync2/rangesync/mocks/mocks.go
@@ -10,7 +10,6 @@
 package mocks
 
 import (
-	context "context"
 	reflect "reflect"
 	time "time"
 
@@ -466,17 +465,17 @@ func (c *MockOrderedSetSplitRangeCall) DoAndReturn(f func(rangesync.KeyBytes, ra
 }
 
 // WithCopy mocks base method.
-func (m *MockOrderedSet) WithCopy(ctx context.Context, toCall func(rangesync.OrderedSet) error) error {
+func (m *MockOrderedSet) WithCopy(toCall func(rangesync.OrderedSet) error) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WithCopy", ctx, toCall)
+	ret := m.ctrl.Call(m, "WithCopy", toCall)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // WithCopy indicates an expected call of WithCopy.
-func (mr *MockOrderedSetMockRecorder) WithCopy(ctx, toCall any) *MockOrderedSetWithCopyCall {
+func (mr *MockOrderedSetMockRecorder) WithCopy(toCall any) *MockOrderedSetWithCopyCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithCopy", reflect.TypeOf((*MockOrderedSet)(nil).WithCopy), ctx, toCall)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithCopy", reflect.TypeOf((*MockOrderedSet)(nil).WithCopy), toCall)
 	return &MockOrderedSetWithCopyCall{Call: call}
 }
 
@@ -492,13 +491,13 @@ func (c *MockOrderedSetWithCopyCall) Return(arg0 error) *MockOrderedSetWithCopyC
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockOrderedSetWithCopyCall) Do(f func(context.Context, func(rangesync.OrderedSet) error) error) *MockOrderedSetWithCopyCall {
+func (c *MockOrderedSetWithCopyCall) Do(f func(func(rangesync.OrderedSet) error) error) *MockOrderedSetWithCopyCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockOrderedSetWithCopyCall) DoAndReturn(f func(context.Context, func(rangesync.OrderedSet) error) error) *MockOrderedSetWithCopyCall {
+func (c *MockOrderedSetWithCopyCall) DoAndReturn(f func(func(rangesync.OrderedSet) error) error) *MockOrderedSetWithCopyCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/sync2/sqlstore/testdb.go
+++ b/sync2/sqlstore/testdb.go
@@ -20,7 +20,7 @@ func CreateDB(t *testing.T, keyLen int) sql.Database {
 }
 
 func insertDBItems(t *testing.T, db sql.Database, content []rangesync.KeyBytes, cmd string) {
-	err := db.WithTx(t.Context(), func(tx sql.Transaction) error {
+	err := db.WithTx(func(tx sql.Transaction) error {
 		for _, id := range content {
 			_, err := tx.Exec(cmd, func(stmt *sql.Statement) {
 				stmt.BindBytes(1, id)

--- a/syncer/atxsync/syncer.go
+++ b/syncer/atxsync/syncer.go
@@ -332,7 +332,7 @@ func (s *Syncer) downloadAtxs(
 			}
 		}
 
-		if err := s.localdb.WithTxImmediate(context.Background(), func(tx sql.Transaction) error {
+		if err := s.localdb.WithTxImmediate(func(tx sql.Transaction) error {
 			err := atxsync.SaveRequest(tx, publish, lastSuccess, int64(len(state)), int64(len(downloaded)))
 			if err != nil {
 				return fmt.Errorf("failed to save request time: %w", err)

--- a/syncer/malsync/syncer.go
+++ b/syncer/malsync/syncer.go
@@ -439,31 +439,19 @@ func (s *Syncer) downloadNodeIDs(ctx context.Context, initial bool, updates chan
 	}
 }
 
-func (s *Syncer) updateLegacyState(ctx context.Context) error {
-	if err := s.localDB.WithTxImmediate(ctx, func(tx sql.Transaction) error {
+func (s *Syncer) updateLegacyState() error {
+	if err := s.localDB.WithTxImmediate(func(tx sql.Transaction) error {
 		return malsync.UpdateLegacySyncState(tx, s.clock.Now())
 	}); err != nil {
-		if ctx.Err() != nil {
-			// FIXME: with crawshaw, canceling the context which has been used to get
-			// a connection from the pool may cause "database: no free connection" errors.
-			// Related: #6273
-			err = ctx.Err()
-		}
 		return fmt.Errorf("error updating legacy malsync state: %w", err)
 	}
 	return nil
 }
 
-func (s *Syncer) updateState(ctx context.Context) error {
-	if err := s.localDB.WithTxImmediate(ctx, func(tx sql.Transaction) error {
+func (s *Syncer) updateState() error {
+	if err := s.localDB.WithTxImmediate(func(tx sql.Transaction) error {
 		return malsync.UpdateSyncState(tx, s.clock.Now())
 	}); err != nil {
-		if ctx.Err() != nil {
-			// FIXME: with crawshaw, canceling the context which has been used to get
-			// a connection from the pool may cause "database: no free connection" errors.
-			// Related: #6273
-			err = ctx.Err()
-		}
 		return fmt.Errorf("error updating malsync state: %w", err)
 	}
 
@@ -481,13 +469,13 @@ func (s *Syncer) downloadLegacyMalfeasanceProofs(ctx context.Context, initial bo
 		if nothingToDownload {
 			sst.done()
 			if initial && sst.numSyncedPeers() >= s.cfg.MinSyncPeers {
-				if err := s.updateLegacyState(ctx); err != nil {
+				if err := s.updateLegacyState(); err != nil {
 					return err
 				}
 				s.logger.Info("initial sync of legacy malfeasance proofs completed", log.ZContext(ctx))
 				return nil
 			} else if !initial && gotUpdate {
-				if err := s.updateLegacyState(ctx); err != nil {
+				if err := s.updateLegacyState(); err != nil {
 					return err
 				}
 			}
@@ -577,13 +565,13 @@ func (s *Syncer) downloadMalfeasanceProofs(ctx context.Context, initial bool, up
 		if nothingToDownload {
 			sst.done()
 			if initial && sst.numSyncedPeers() >= s.cfg.MinSyncPeers {
-				if err := s.updateState(ctx); err != nil {
+				if err := s.updateState(); err != nil {
 					return err
 				}
 				s.logger.Info("initial sync of malfeasance proofs completed", log.ZContext(ctx))
 				return nil
 			} else if !initial && gotUpdate {
-				if err := s.updateState(ctx); err != nil {
+				if err := s.updateState(); err != nil {
 					return err
 				}
 			}

--- a/txs/cache.go
+++ b/txs/cache.go
@@ -405,7 +405,7 @@ func (ac *accountCache) resetAfterApply(
 }
 
 func (ac *accountCache) evictPendingNonce(db sql.StateDatabase) error {
-	return db.WithTxImmediate(context.Background(), func(tx sql.Transaction) error {
+	return db.WithTxImmediate(func(tx sql.Transaction) error {
 		txIds, err := transactions.GetAcctPendingToNonce(tx, ac.addr, ac.startNonce)
 		if err != nil {
 			return fmt.Errorf("get pending to nonce: %w", err)
@@ -711,7 +711,7 @@ func (c *Cache) ApplyLayer(
 
 	// commit results before reporting them
 	// TODO(dshulyak) save results in vm
-	if err := db.WithTxImmediate(context.Background(), func(dbtx sql.Transaction) error {
+	if err := db.WithTxImmediate(func(dbtx sql.Transaction) error {
 		for _, rst := range results {
 			err := transactions.AddResult(dbtx, rst.ID, &rst.TransactionResult)
 			if err != nil {
@@ -863,7 +863,7 @@ func checkApplyOrder(logger *zap.Logger, db sql.StateDatabase, toApply types.Lay
 }
 
 func addToProposal(db sql.StateDatabase, lid types.LayerID, pid types.ProposalID, tids []types.TransactionID) error {
-	return db.WithTxImmediate(context.Background(), func(dbtx sql.Transaction) error {
+	return db.WithTxImmediate(func(dbtx sql.Transaction) error {
 		for _, tid := range tids {
 			if err := transactions.AddToProposal(dbtx, tid, lid, pid); err != nil {
 				return fmt.Errorf("add2prop %w", err)
@@ -874,7 +874,7 @@ func addToProposal(db sql.StateDatabase, lid types.LayerID, pid types.ProposalID
 }
 
 func addToBlock(db sql.StateDatabase, lid types.LayerID, bid types.BlockID, tids []types.TransactionID) error {
-	return db.WithTxImmediate(context.Background(), func(dbtx sql.Transaction) error {
+	return db.WithTxImmediate(func(dbtx sql.Transaction) error {
 		for _, tid := range tids {
 			if err := transactions.AddToBlock(dbtx, tid, lid, bid); err != nil {
 				return fmt.Errorf("add2block %w", err)
@@ -885,7 +885,7 @@ func addToBlock(db sql.StateDatabase, lid types.LayerID, bid types.BlockID, tids
 }
 
 func undoLayers(db sql.StateDatabase, from types.LayerID) error {
-	return db.WithTxImmediate(context.Background(), func(dbtx sql.Transaction) error {
+	return db.WithTxImmediate(func(dbtx sql.Transaction) error {
 		err := transactions.UndoLayers(dbtx, from)
 		if err != nil {
 			return fmt.Errorf("undo %w", err)


### PR DESCRIPTION
## Motivation

Canceling context leaves broken connections in the pool, possibly leading to `SQLITE_BUSY` errors.

## Description

Avoid errors by never passing the context to `WithTxImmediate()`.

A side effect might be having to wait for a write transaction to complete when shutting down the app.
But in most cases, write transactions should not take too long to complete. If this problem arises, we might want to alter `sqliteDatabase.WithTxImmediate()` implementation to pass some other context internally which is canceled when the database is closed, and somehow arrange for that context to be canceled when the startup context is canceled, but likely this will not be needed.
