### PR TITLE
[Merged by Bors] - Disable syncv2 and update CHANGELOG for v1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,6 @@ See [RELEASE](./RELEASE.md) for workflow instructions.
 
 ### Highlights
 
-This release will enable syncv2 fully to sync ATXs for all nodes. This should greatly reduce the time it takes to sync
-a node from genesis and the amount of data that is needed to be exchanged with the network to keep a node in sync. The
-improvements are enabled automatically after upgrading to this version and no user action is needed.
-
 Development on ATXv2 has concluded and the feature is now enabled on mainnet. Nodes will produce the new ATX format
 starting from epoch 45 and ever epoch after. The new ATXs also comes with new malfeasance proofs that are more efficient
 in terms of data size and more easily extendable in the future.

--- a/config/mainnet.go
+++ b/config/mainnet.go
@@ -230,7 +230,7 @@ func MainnetConfig() Config {
 			MalSync:                  malsync.DefaultConfig(),
 			ReconcSync: syncer.ReconcSyncConfig{
 				Enable:            true,
-				EnableActiveSync:  true,
+				EnableActiveSync:  false,
 				OldAtxSyncCfg:     oldAtxSyncCfg,
 				NewAtxSyncCfg:     newAtxSyncCfg,
 				ParallelLoadLimit: 10,

--- a/config/presets/fastnet.go
+++ b/config/presets/fastnet.go
@@ -66,7 +66,7 @@ func fastnet() config.Config {
 	conf.Sync.MalSync.IDRequestInterval = 20 * time.Second
 
 	conf.Sync.ReconcSync.Enable = true
-	conf.Sync.ReconcSync.EnableActiveSync = true
+	conf.Sync.ReconcSync.EnableActiveSync = false
 	conf.Sync.ReconcSync.NewAtxSyncCfg.AdvanceInterval = 20 * time.Second
 	conf.Sync.ReconcSync.NewAtxSyncCfg.SyncInterval = 10 * time.Second
 	conf.Sync.ReconcSync.NewAtxSyncCfg.SyncPeerCount = 4

--- a/config/presets/testnet.go
+++ b/config/presets/testnet.go
@@ -181,7 +181,7 @@ func testnet() config.Config {
 			MalSync:                  malsync.DefaultConfig(),
 			ReconcSync: syncer.ReconcSyncConfig{
 				Enable:            true,
-				EnableActiveSync:  true,
+				EnableActiveSync:  false,
 				OldAtxSyncCfg:     oldAtxSyncCfg,
 				NewAtxSyncCfg:     newAtxSyncCfg,
 				ParallelLoadLimit: 10,


### PR DESCRIPTION
## Motivation

Disable syncv2 for all networks and update CHANGELOG accordingly.

## Description

Because some issues showed up when testing syncv2 with mainnet we do not automatically enable it by default with the upcoming `v1.8.0` release.

## Test Plan

existing tests pass

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
