### PR TITLE
[Merged by Bors] - fix race in fptree (sync v2)

### DIFF
--- a/sync2/fptree/fptree.go
+++ b/sync2/fptree/fptree.go
@@ -617,6 +617,8 @@ func (ft *FPTree) storeValues() bool {
 // If this function returns true and the tree doesn't store the values, the key may be
 // contained in the tree.
 func (ft *FPTree) CheckKey(k rangesync.KeyBytes) bool {
+	ft.np.lockRead()
+	defer ft.np.unlockRead()
 	// We're unlikely to be able to find a node with the full prefix, but if we can
 	// find a leaf node with matching partial prefix, that's good enough except
 	// that we also need to check the node's fingerprint.


### PR DESCRIPTION
## Motivation

Fix race condition in `FPTree` (sync v2).

## Description

Race caught when syncing from scratch on a binary build with the race detector (`-race` flag). Example report:

```
==================
WARNING: DATA RACE
Write at 0x00c03a3258bc by goroutine 8553232:
  github.com/spacemeshos/go-spacemesh/sync2/fptree.(*rcPool[go.shape.struct { github.com/spacemeshos/go-spacemesh/sync2/fptree.fp github.com/spacemeshos/go-spacemesh/sync2/rangesync.Fingerprint; github.com/spacemeshos/go-spacemesh/sync2/fptree.c uint32; github.com/spacemeshos/go-spacemesh/sync2/fptree.l github.com/spacemeshos/go-spacemesh/sync2/fptree.nodeIndex; github.com/spacemeshos/go-spacemesh/sync2/fptree.r github.com/spacemeshos/go-spacemesh/sync2/fptree.nodeIndex },go.shape.uint32]).release()
      /home/bartosz/workspace/go-spacemesh/sync2/fptree/refcountpool.go:98 +0xc4
  github.com/spacemeshos/go-spacemesh/sync2/fptree.(*nodePool).release()
      /home/bartosz/workspace/go-spacemesh/sync2/fptree/nodepool.go:184 +0xb9
  github.com/spacemeshos/go-spacemesh/sync2/fptree.(*nodePool).release()
      /home/bartosz/workspace/go-spacemesh/sync2/fptree/nodepool.go:192 +0xee
  github.com/spacemeshos/go-spacemesh/sync2/fptree.(*nodePool).release()
      /home/bartosz/workspace/go-spacemesh/sync2/fptree/nodepool.go:189 +0xda
  github.com/spacemeshos/go-spacemesh/sync2/fptree.(*nodePool).release()
      /home/bartosz/workspace/go-spacemesh/sync2/fptree/nodepool.go:192 +0xee
  github.com/spacemeshos/go-spacemesh/sync2/fptree.(*nodePool).release()
      /home/bartosz/workspace/go-spacemesh/sync2/fptree/nodepool.go:189 +0xda
  github.com/spacemeshos/go-spacemesh/sync2/fptree.(*nodePool).release()
      /home/bartosz/workspace/go-spacemesh/sync2/fptree/nodepool.go:192 +0xee
  github.com/spacemeshos/go-spacemesh/sync2/fptree.(*nodePool).release()
      /home/bartosz/workspace/go-spacemesh/sync2/fptree/nodepool.go:192 +0xee
  github.com/spacemeshos/go-spacemesh/sync2/fptree.(*nodePool).release()
      /home/bartosz/workspace/go-spacemesh/sync2/fptree/nodepool.go:189 +0xda
  github.com/spacemeshos/go-spacemesh/sync2/fptree.(*nodePool).release()
      /home/bartosz/workspace/go-spacemesh/sync2/fptree/nodepool.go:189 +0xda
  github.com/spacemeshos/go-spacemesh/sync2/fptree.(*nodePool).release()
      /home/bartosz/workspace/go-spacemesh/sync2/fptree/nodepool.go:189 +0xda
  github.com/spacemeshos/go-spacemesh/sync2/fptree.(*nodePool).release()
      /home/bartosz/workspace/go-spacemesh/sync2/fptree/nodepool.go:189 +0xda
  github.com/spacemeshos/go-spacemesh/sync2/fptree.(*nodePool).release()
      /home/bartosz/workspace/go-spacemesh/sync2/fptree/nodepool.go:189 +0xda
  github.com/spacemeshos/go-spacemesh/sync2/fptree.(*nodePool).release()
      /home/bartosz/workspace/go-spacemesh/sync2/fptree/nodepool.go:192 +0xee
  github.com/spacemeshos/go-spacemesh/sync2/fptree.(*nodePool).release()
      /home/bartosz/workspace/go-spacemesh/sync2/fptree/nodepool.go:192 +0xee
  github.com/spacemeshos/go-spacemesh/sync2/fptree.(*FPTree).Release()
      /home/bartosz/workspace/go-spacemesh/sync2/fptree/fptree.go:430 +0xf9
  github.com/spacemeshos/go-spacemesh/sync2/dbset.(*DBSet).release()
      /home/bartosz/workspace/go-spacemesh/sync2/dbset/dbset.go:289 +0x6a
  github.com/spacemeshos/go-spacemesh/sync2/dbset.(*DBSet).WithCopy.deferwrap1()
      /home/bartosz/workspace/go-spacemesh/sync2/dbset/dbset.go:248 +0x1f
  runtime.deferreturn()
      /home/bartosz/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.1.linux-amd64/src/runtime/panic.go:610 +0x5d
  github.com/spacemeshos/go-spacemesh/sql.(*sqliteDatabase).WithConnection()
      /home/bartosz/workspace/go-spacemesh/sql/database.go:861 +0x288
  github.com/spacemeshos/go-spacemesh/sql/statesql.(*database).WithConnection()
      <autogenerated>:1 +0x4d
  github.com/spacemeshos/go-spacemesh/sync2/dbset.(*DBSet).WithCopy()
      /home/bartosz/workspace/go-spacemesh/sync2/dbset/dbset.go:251 +0x76e
  github.com/spacemeshos/go-spacemesh/sync2/multipeer.(*SetSyncBase).syncPeer()
      /home/bartosz/workspace/go-spacemesh/sync2/multipeer/setsyncbase.go:65 +0x1ec
  github.com/spacemeshos/go-spacemesh/sync2/multipeer.(*SetSyncBase).Sync()
      /home/bartosz/workspace/go-spacemesh/sync2/multipeer/setsyncbase.go:90 +0x211
  github.com/spacemeshos/go-spacemesh/sync2/multipeer.(*splitSync).startPeerSync.func1()
      /home/bartosz/workspace/go-spacemesh/sync2/multipeer/split_sync.go:89 +0x16a
  golang.org/x/sync/errgroup.(*Group).Go.func1()
      /home/bartosz/go/pkg/mod/golang.org/x/sync@v0.12.0/errgroup/errgroup.go:78 +0x91

Previous read at 0x00c03a3258bc by goroutine 8554412:
  github.com/spacemeshos/go-spacemesh/sync2/fptree.(*rcPool[go.shape.struct { github.com/spacemeshos/go-spacemesh/sync2/fptree.fp github.com/spacemeshos/go-spacemesh/sync2/rangesync.Fingerprint; github.com/spacemeshos/go-spacemesh/sync2/fptree.c uint32; github.com/spacemeshos/go-spacemesh/sync2/fptree.l github.com/spacemeshos/go-spacemesh/sync2/fptree.nodeIndex; github.com/spacemeshos/go-spacemesh/sync2/fptree.r github.com/spacemeshos/go-spacemesh/sync2/fptree.nodeIndex },go.shape.uint32]).entry()
      /home/bartosz/workspace/go-spacemesh/sync2/fptree/refcountpool.go:52 +0x67
  github.com/spacemeshos/go-spacemesh/sync2/fptree.(*rcPool[go.shape.struct { github.com/spacemeshos/go-spacemesh/sync2/fptree.fp github.com/spacemeshos/go-spacemesh/sync2/rangesync.Fingerprint; github.com/spacemeshos/go-spacemesh/sync2/fptree.c uint32; github.com/spacemeshos/go-spacemesh/sync2/fptree.l github.com/spacemeshos/go-spacemesh/sync2/fptree.nodeIndex; github.com/spacemeshos/go-spacemesh/sync2/fptree.r github.com/spacemeshos/go-spacemesh/sync2/fptree.nodeIndex },go.shape.uint32]).item()
      /home/bartosz/workspace/go-spacemesh/sync2/fptree/refcountpool.go:46 +0x64
  github.com/spacemeshos/go-spacemesh/sync2/fptree.(*nodePool).leaf()
      /home/bartosz/workspace/go-spacemesh/sync2/fptree/nodepool.go:137 +0x32
  github.com/spacemeshos/go-spacemesh/sync2/fptree.(*FPTree).followPrefix()
      /home/bartosz/workspace/go-spacemesh/sync2/fptree/fptree.go:645 +0x33c
  github.com/spacemeshos/go-spacemesh/sync2/fptree.(*FPTree).CheckKey()
      /home/bartosz/workspace/go-spacemesh/sync2/fptree/fptree.go:623 +0x12c
  github.com/spacemeshos/go-spacemesh/sync2/dbset.(*DBSet).Has()
      /home/bartosz/workspace/go-spacemesh/sync2/dbset/dbset.go:269 +0x78
  github.com/spacemeshos/go-spacemesh/sync2.(*ATXHandler).setupState-range1()
      /home/bartosz/workspace/go-spacemesh/sync2/atxs.go:73 +0x137
  github.com/spacemeshos/go-spacemesh/sync2/dbset.(*DBSet).Received.func1()
      /home/bartosz/workspace/go-spacemesh/sync2/dbset/dbset.go:89 +0xe7
  github.com/spacemeshos/go-spacemesh/sync2.(*ATXHandler).setupState()
      /home/bartosz/workspace/go-spacemesh/sync2/atxs.go:72 +0x34a
  github.com/spacemeshos/go-spacemesh/sync2.(*ATXHandler).Commit()
      /home/bartosz/workspace/go-spacemesh/sync2/atxs.go:135 +0x189
  github.com/spacemeshos/go-spacemesh/sync2/multipeer.(*SetSyncBase).syncPeer()
      /home/bartosz/workspace/go-spacemesh/sync2/multipeer/setsyncbase.go:79 +0x491
  github.com/spacemeshos/go-spacemesh/sql.(*sqliteDatabase).WithConnection()
      /home/bartosz/workspace/go-spacemesh/sql/database.go:861 +0x288
  github.com/spacemeshos/go-spacemesh/sql/statesql.(*database).WithConnection()
      <autogenerated>:1 +0x4d
  github.com/spacemeshos/go-spacemesh/sync2/dbset.(*DBSet).WithCopy()
      /home/bartosz/workspace/go-spacemesh/sync2/dbset/dbset.go:251 +0x76e
  github.com/spacemeshos/go-spacemesh/sync2/multipeer.(*SetSyncBase).syncPeer()
      /home/bartosz/workspace/go-spacemesh/sync2/multipeer/setsyncbase.go:65 +0x1ec
  github.com/spacemeshos/go-spacemesh/sync2/multipeer.(*SetSyncBase).Sync()
      /home/bartosz/workspace/go-spacemesh/sync2/multipeer/setsyncbase.go:90 +0x211
  github.com/spacemeshos/go-spacemesh/sync2/multipeer.(*splitSync).startPeerSync.func1()
      /home/bartosz/workspace/go-spacemesh/sync2/multipeer/split_sync.go:89 +0x16a
  golang.org/x/sync/errgroup.(*Group).Go.func1()
      /home/bartosz/go/pkg/mod/golang.org/x/sync@v0.12.0/errgroup/errgroup.go:78 +0x91

Goroutine 8553232 (running) created at:
  golang.org/x/sync/errgroup.(*Group).Go()
      /home/bartosz/go/pkg/mod/golang.org/x/sync@v0.12.0/errgroup/errgroup.go:75 +0x124
  github.com/spacemeshos/go-spacemesh/sync2/multipeer.(*splitSync).startPeerSync()
      /home/bartosz/workspace/go-spacemesh/sync2/multipeer/split_sync.go:88 +0x288
  github.com/spacemeshos/go-spacemesh/sync2/multipeer.(*splitSync).Sync()
      /home/bartosz/workspace/go-spacemesh/sync2/multipeer/split_sync.go:188 +0x3ea
  github.com/spacemeshos/go-spacemesh/sync2/multipeer.(*runner).SplitSync()
      /home/bartosz/workspace/go-spacemesh/sync2/multipeer/multipeer.go:46 +0x2a4
  github.com/spacemeshos/go-spacemesh/sync2/multipeer.(*MultiPeerReconciler).syncOnce()
      /home/bartosz/workspace/go-spacemesh/sync2/multipeer/multipeer.go:411 +0xfd2
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).SelectBestWithProtocols()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:166 +0x104
  github.com/spacemeshos/go-spacemesh/sync2/multipeer.(*MultiPeerReconciler).syncOnce()
      /home/bartosz/workspace/go-spacemesh/sync2/multipeer/multipeer.go:370 +0x1f1
  github.com/spacemeshos/go-spacemesh/sync2/multipeer.(*MultiPeerReconciler).Run()
      /home/bartosz/workspace/go-spacemesh/sync2/multipeer/multipeer.go:473 +0x127
  github.com/spacemeshos/go-spacemesh/sync2.(*P2PHashSync).start.func1.1()
      /home/bartosz/workspace/go-spacemesh/sync2/p2p.go:157 +0x109
  golang.org/x/sync/errgroup.(*Group).Go.func1()
      /home/bartosz/go/pkg/mod/golang.org/x/sync@v0.12.0/errgroup/errgroup.go:78 +0x91

Goroutine 8554412 (running) created at:
  golang.org/x/sync/errgroup.(*Group).Go()
      /home/bartosz/go/pkg/mod/golang.org/x/sync@v0.12.0/errgroup/errgroup.go:75 +0x124
  github.com/spacemeshos/go-spacemesh/sync2/multipeer.(*splitSync).startPeerSync()
      /home/bartosz/workspace/go-spacemesh/sync2/multipeer/split_sync.go:88 +0x288
  github.com/spacemeshos/go-spacemesh/sync2/multipeer.(*splitSync).Sync()
      /home/bartosz/workspace/go-spacemesh/sync2/multipeer/split_sync.go:188 +0x3ea
  github.com/spacemeshos/go-spacemesh/sync2/multipeer.(*runner).SplitSync()
      /home/bartosz/workspace/go-spacemesh/sync2/multipeer/multipeer.go:46 +0x2a4
  github.com/spacemeshos/go-spacemesh/sync2/multipeer.(*MultiPeerReconciler).syncOnce()
      /home/bartosz/workspace/go-spacemesh/sync2/multipeer/multipeer.go:411 +0xfd2
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).selectBest()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:180 +0x38f
  github.com/spacemeshos/go-spacemesh/fetch/peers.(*Peers).SelectBestWithProtocols()
      /home/bartosz/workspace/go-spacemesh/fetch/peers/peers.go:166 +0x104
  github.com/spacemeshos/go-spacemesh/sync2/multipeer.(*MultiPeerReconciler).syncOnce()
      /home/bartosz/workspace/go-spacemesh/sync2/multipeer/multipeer.go:370 +0x1f1
  github.com/spacemeshos/go-spacemesh/sync2/multipeer.(*MultiPeerReconciler).Run()
      /home/bartosz/workspace/go-spacemesh/sync2/multipeer/multipeer.go:473 +0x127
  github.com/spacemeshos/go-spacemesh/sync2.(*P2PHashSync).start.func1.1()
      /home/bartosz/workspace/go-spacemesh/sync2/p2p.go:157 +0x109
  golang.org/x/sync/errgroup.(*Group).Go.func1()
      /home/bartosz/go/pkg/mod/golang.org/x/sync@v0.12.0/errgroup/errgroup.go:78 +0x91
==================
```