### PR TITLE
[Merged by Bors] - set db connection idle timeout to 500ms

### DIFF
--- a/config/mainnet.go
+++ b/config/mainnet.go
@@ -96,7 +96,7 @@ func MainnetConfig() Config {
 			DatabaseConnections:     32,
 			DatabasePruneInterval:   30 * time.Minute,
 			DatabaseVacuumState:     21,
-			DatabaseConnIdleTimeout: 10 * time.Millisecond,
+			DatabaseConnIdleTimeout: 500 * time.Millisecond,
 			PruneActivesetsFrom:     12, // starting from epoch 13 activesets below 12 will be pruned
 			NetworkHRP:              "sm",
 

--- a/config/presets/fastnet.go
+++ b/config/presets/fastnet.go
@@ -23,6 +23,7 @@ func fastnet() config.Config {
 	conf.BaseConfig.OptFilterThreshold = 90
 	conf.BaseConfig.DatabasePruneInterval = time.Minute
 	conf.BaseConfig.DatabaseConnections = 16
+	conf.BaseConfig.DatabaseConnIdleTimeout = 500 * time.Millisecond
 
 	// set for systest TestEquivocation
 	conf.BaseConfig.MinerGoodAtxsPercent = 50

--- a/config/presets/standalone.go
+++ b/config/presets/standalone.go
@@ -26,6 +26,7 @@ func standalone() config.Config {
 	conf.BaseConfig.AtxVersions = activation.AtxVersions{
 		types.EpochID(2): types.AtxV2,
 	}
+	conf.BaseConfig.DatabaseConnIdleTimeout = 500 * time.Millisecond
 
 	conf.TIME.Peersync.Disable = true
 	conf.Standalone = true

--- a/config/presets/testnet.go
+++ b/config/presets/testnet.go
@@ -85,7 +85,7 @@ func testnet() config.Config {
 			DatabaseConnections:          32,
 			DatabaseSizeMeteringInterval: 10 * time.Minute,
 			DatabasePruneInterval:        30 * time.Minute,
-			DatabaseConnIdleTimeout:      10 * time.Millisecond,
+			DatabaseConnIdleTimeout:      500 * time.Millisecond,
 			NetworkHRP:                   "stest",
 
 			LayerDuration:  5 * time.Minute,


### PR DESCRIPTION
## Description
Increase `DatabaseConnIdleTimeout` to 500ms to reduce the possibility of `SQLITE_BUSY` errors.