### PR TITLE
[Merged by Bors] - Fix some config options not configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -945,6 +945,7 @@ and permanent ineligibility for rewards.
   If you are not using a remote post service you do not need to adjust anything. If you are using a remote setup
   make sure your post service now connects to `grpc-post-listener` instead of `grpc-private-listener`. If you are
   connecting to a remote post service over the internet we strongly recommend using mTLS via `grpc-tls-listener`.
+
 * [#5601](https://github.com/spacemeshos/go-spacemesh/pull/5601) measure latency from all requests in sync
   This improves peers selection logic, mainly to prevent asking slow peers for collection of atxs, which often blocks sync.
 

--- a/activation/post_supervisor.go
+++ b/activation/post_supervisor.go
@@ -52,14 +52,16 @@ func DefaultTestPostServiceConfig(tb testing.TB) PostSupervisorConfig {
 	}
 }
 
+// PostSupervisorConfig holds the configuration for the post service.
+// This is not intended to be configurable by the user.
 type PostSupervisorConfig struct {
-	PostServiceCmd string
-	NodeAddress    string
-	MaxRetries     int
+	PostServiceCmd string // path to the post service binary, configurable for testing
+	NodeAddress    string // address of the node, configurable for testing, set automatically during startup
+	MaxRetries     int    // only for testing, not used in production
 
-	CACert string
-	Cert   string
-	Key    string
+	CACert string // only for testing, not used in production
+	Cert   string // only for testing, not used in production
+	Key    string // only for testing, not used in production
 }
 
 // PostSupervisor manages a local post service.

--- a/blocks/certifier.go
+++ b/blocks/certifier.go
@@ -33,10 +33,10 @@ var (
 
 // CertConfig is the config for Certifier.
 type CertConfig struct {
-	CommitteeSize    int `mapstructure:"committee-size"`
-	CertifyThreshold int
-	LayerBuffer      uint32
-	NumLayersToKeep  uint32
+	CommitteeSize    int    `mapstructure:"committee-size"`
+	CertifyThreshold int    `mapstructure:"-"` // not configurable, overwritten by CommitteeSize/2 + 1
+	LayerBuffer      uint32 `mapstructure:"-"` // not configurable, overwritten by tortoise.Config.Zdist
+	NumLayersToKeep  uint32 `mapstructure:"-"` // not configurable, overwritten by tortoise.Config.Zdist * 2
 }
 
 func defaultCertConfig() CertConfig {

--- a/bootstrap/updater.go
+++ b/bootstrap/updater.go
@@ -57,8 +57,8 @@ type Config struct {
 	URL     string `mapstructure:"bootstrap-url"`
 	Version string `mapstructure:"bootstrap-version"`
 
-	DataDir  string
-	Interval time.Duration
+	DataDir  string        `mapstructure:"-"` // not configurable, overwritten by BaseConfig.DataDir()
+	Interval time.Duration `mapstructure:"-"` // not configurable, overwritten by BaseConfig.LayerDuration / 5
 }
 
 func DefaultConfig() Config {

--- a/config/config.go
+++ b/config/config.go
@@ -49,31 +49,31 @@ func init() {
 // Config defines the top level configuration for a spacemesh node.
 type Config struct {
 	BaseConfig      `mapstructure:"main"`
-	Preset          string                     `mapstructure:"preset"`
-	Genesis         GenesisConfig              `mapstructure:"genesis"`
-	PublicMetrics   PublicMetrics              `mapstructure:"public-metrics"`
-	Tortoise        tortoise.Config            `mapstructure:"tortoise"`
-	P2P             p2p.Config                 `mapstructure:"p2p"`
-	API             grpcserver.Config          `mapstructure:"api"`
-	HARE3           hare3.Config               `mapstructure:"hare3"`
-	HARE4           hare4.Config               `mapstructure:"hare4"`
-	HareEligibility eligibility.Config         `mapstructure:"hare-eligibility"`
-	Certificate     blocks.CertConfig          `mapstructure:"certificate"`
-	Beacon          beacon.Config              `mapstructure:"beacon"`
-	TIME            timeConfig.TimeConfig      `mapstructure:"time"`
-	VM              vm.Config                  `mapstructure:"vm"`
-	Certifier       activation.CertifierConfig `mapstructure:"certifier"`
-	POST            activation.PostConfig      `mapstructure:"post"`
-	POSTService     activation.PostSupervisorConfig
-	POET            activation.PoetConfig      `mapstructure:"poet"`
-	SMESHING        SmeshingConfig             `mapstructure:"smeshing"`
-	LOGGING         LoggerConfig               `mapstructure:"logging"`
-	FETCH           fetch.Config               `mapstructure:"fetch"`
-	Bootstrap       bootstrap.Config           `mapstructure:"bootstrap"`
-	Sync            syncer.Config              `mapstructure:"syncer"`
-	Recovery        checkpoint.Config          `mapstructure:"recovery"`
-	Cache           datastore.Config           `mapstructure:"cache"`
-	ActiveSet       miner.ActiveSetPreparation `mapstructure:"active-set-preparation"`
+	Preset          string                          `mapstructure:"preset"`
+	Genesis         GenesisConfig                   `mapstructure:"genesis"`
+	PublicMetrics   PublicMetrics                   `mapstructure:"public-metrics"`
+	Tortoise        tortoise.Config                 `mapstructure:"tortoise"`
+	P2P             p2p.Config                      `mapstructure:"p2p"`
+	API             grpcserver.Config               `mapstructure:"api"`
+	HARE3           hare3.Config                    `mapstructure:"hare3"`
+	HARE4           hare4.Config                    `mapstructure:"hare4"`
+	HareEligibility eligibility.Config              `mapstructure:"hare-eligibility"`
+	Certificate     blocks.CertConfig               `mapstructure:"certificate"`
+	Beacon          beacon.Config                   `mapstructure:"beacon"`
+	TIME            timeConfig.TimeConfig           `mapstructure:"time"`
+	VM              vm.Config                       `mapstructure:"vm"`
+	Certifier       activation.CertifierConfig      `mapstructure:"certifier"`
+	POST            activation.PostConfig           `mapstructure:"post"`
+	POSTService     activation.PostSupervisorConfig `mapstructure:"-"` // not configurable by the user
+	POET            activation.PoetConfig           `mapstructure:"poet"`
+	SMESHING        SmeshingConfig                  `mapstructure:"smeshing"`
+	LOGGING         LoggerConfig                    `mapstructure:"logging"`
+	FETCH           fetch.Config                    `mapstructure:"fetch"`
+	Bootstrap       bootstrap.Config                `mapstructure:"bootstrap"`
+	Sync            syncer.Config                   `mapstructure:"syncer"`
+	Recovery        checkpoint.Config               `mapstructure:"recovery"`
+	Cache           datastore.Config                `mapstructure:"cache"`
+	ActiveSet       miner.ActiveSetPreparation      `mapstructure:"active-set-preparation"`
 }
 
 // DataDir returns the absolute path to use for the node's data. This is the tilde-expanded path given in the config

--- a/config/presets/fastnet.go
+++ b/config/presets/fastnet.go
@@ -10,7 +10,6 @@ import (
 	"github.com/spacemeshos/go-spacemesh/activation"
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/config"
-	"github.com/spacemeshos/go-spacemesh/hare3"
 )
 
 func init() {
@@ -47,11 +46,6 @@ func fastnet() config.Config {
 	conf.HARE3.PreroundDelay = 3 * time.Second
 	conf.HARE3.RoundDuration = 700 * time.Millisecond
 	conf.HARE3.IterationsLimit = 2
-
-	conf.HARE3.CommitteeUpgrade = &hare3.CommitteeUpgrade{
-		Layer: 16,
-		Size:  50,
-	}
 
 	conf.P2P.MinPeers = 10
 

--- a/genvm/vm.go
+++ b/genvm/vm.go
@@ -39,8 +39,8 @@ func WithLogger(logger *zap.Logger) Opt {
 
 // Config defines the configuration options for vm.
 type Config struct {
-	GasLimit  uint64
-	GenesisID types.Hash20
+	GasLimit  uint64       `mapstructure:"-"` // not configurable, overwritten by BaseConfig.BlockGasLimit
+	GenesisID types.Hash20 `mapstructure:"-"` // not configurable, overwritten by GenesisConfig.GenesisID()
 }
 
 // DefaultConfig returns the default RewardConfig.

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,6 @@ require (
 	github.com/libp2p/go-libp2p-record v0.3.1
 	github.com/libp2p/go-msgio v0.3.0
 	github.com/libp2p/go-yamux/v4 v4.0.2
-	github.com/mitchellh/mapstructure v1.5.0
 	github.com/multiformats/go-multiaddr v0.15.0
 	github.com/multiformats/go-varint v0.0.7
 	github.com/natefinch/atomic v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -408,8 +408,6 @@ github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1/go.mod h1:pD8Rv
 github.com/minio/sha256-simd v0.1.1-0.20190913151208-6de447530771/go.mod h1:B5e1o+1/KgNmWrSQK08Y6Z1Vb5pwIktudl0J58iy0KM=
 github.com/minio/sha256-simd v1.0.1 h1:6kaan5IFmwTNynnKKpDHe6FWHohJOHhCPchzK49dzMM=
 github.com/minio/sha256-simd v1.0.1/go.mod h1:Pz6AKMiUdngCLpeTL/RJY1M9rUuPMYujV5xJjtbRSN8=
-github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
-github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/node/mapstructureutil/addresslist.go
+++ b/node/mapstructureutil/addresslist.go
@@ -3,7 +3,7 @@ package mapstructureutil
 import (
 	"reflect"
 
-	"github.com/mitchellh/mapstructure"
+	"github.com/go-viper/mapstructure/v2"
 
 	"github.com/spacemeshos/go-spacemesh/p2p"
 )

--- a/node/mapstructureutil/atxversions.go
+++ b/node/mapstructureutil/atxversions.go
@@ -3,7 +3,7 @@ package mapstructureutil
 import (
 	"reflect"
 
-	"github.com/mitchellh/mapstructure"
+	"github.com/go-viper/mapstructure/v2"
 
 	"github.com/spacemeshos/go-spacemesh/activation"
 )

--- a/node/mapstructureutil/bigrat.go
+++ b/node/mapstructureutil/bigrat.go
@@ -5,7 +5,7 @@ import (
 	"math/big"
 	"reflect"
 
-	"github.com/mitchellh/mapstructure"
+	"github.com/go-viper/mapstructure/v2"
 )
 
 // BigRatDecodeFunc mapstructure decode func for big.Rat.

--- a/node/mapstructureutil/deprecated.go
+++ b/node/mapstructureutil/deprecated.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"reflect"
 
-	"github.com/mitchellh/mapstructure"
+	"github.com/go-viper/mapstructure/v2"
 
 	"github.com/spacemeshos/go-spacemesh/log"
 )

--- a/node/mapstructureutil/postproviderid.go
+++ b/node/mapstructureutil/postproviderid.go
@@ -5,7 +5,7 @@ import (
 	"math"
 	"reflect"
 
-	"github.com/mitchellh/mapstructure"
+	"github.com/go-viper/mapstructure/v2"
 
 	"github.com/spacemeshos/go-spacemesh/activation"
 )
@@ -23,7 +23,7 @@ func PostProviderIDDecodeFunc() mapstructure.DecodeHookFunc {
 			if value > math.MaxUint32 || value < 0 || value != math.Trunc(value) {
 				return nil, fmt.Errorf("invalid provider ID value: %v", value)
 			}
-			id := activation.PostProviderID{}
+			var id activation.PostProviderID
 			id.SetUint32(uint32(value))
 			return id, nil
 		case reflect.String:

--- a/node/node.go
+++ b/node/node.go
@@ -316,7 +316,11 @@ func LoadConfig(cfg *config.Config, preset string, src io.Reader) error {
 	opts := []viper.DecoderConfigOption{
 		viper.DecodeHook(hook),
 		WithZeroFields(),
-		WithIgnoreUntagged(),
+		// Disabled because it was broken for some time with `github.com/spf13/viper` `v1.19.0` and now
+		// previously untagged fields are used in existing configs.
+		// Instead of now tagging all untagged fields we will just allow them and disable fields explicitly that
+		// must not be configurable.
+		// WithIgnoreUntagged(),
 		WithErrorUnused(),
 	}
 	if err := v.Unmarshal(cfg, opts...); err != nil {

--- a/p2p/host.go
+++ b/p2p/host.go
@@ -122,8 +122,8 @@ const (
 
 // Config for all things related to p2p layer.
 type Config struct {
-	DataDir            string
-	LogLevel           zapcore.Level
+	DataDir            string        `mapstructure:"-"` // not configurable, overwritten by "`BaseConfig.DataDir()`/p2p"
+	LogLevel           zapcore.Level `mapstructure:"-"` // not configurable, overwritten by LoggerConfig.P2PLoggerLevel
 	GracePeersShutdown time.Duration `mapstructure:"gracepeersshutdown"`
 	MaxMessageSize     int           `mapstructure:"maxmessagesize"`
 

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -34,13 +34,13 @@ import (
 type Config struct {
 	Interval         time.Duration `mapstructure:"interval"`
 	EpochEndFraction float64       `mapstructure:"epochendfraction"`
-	HareDelayLayers  uint32
-	SyncCertDistance uint32
+	HareDelayLayers  uint32        `mapstructure:"-"` // not configurable, overwritten by tortoise.Config.Zdist
+	SyncCertDistance uint32        `mapstructure:"-"` // not configurable, overwritten by tortoise.Config.Hdist
 	// TallyVotesFrequency how often to tally votes during layers sync.
 	// Setting this to 0.25 will tally votes after downloading data for quarter of the epoch.
 	TallyVotesFrequency      float64
-	MaxStaleDuration         time.Duration `mapstructure:"maxstaleduration"`
-	Standalone               bool
+	MaxStaleDuration         time.Duration    `mapstructure:"maxstaleduration"`
+	Standalone               bool             `mapstructure:"-"` // not configurable, overwritten by BaseCfg.Standalone
 	GossipDuration           time.Duration    `mapstructure:"gossipduration"`
 	DisableMeshAgreement     bool             `mapstructure:"disable-mesh-agreement"`
 	OutOfSyncThresholdLayers uint32           `mapstructure:"out-of-sync-threshold"`

--- a/systest/Makefile
+++ b/systest/Makefile
@@ -10,7 +10,7 @@ poet_image ?= $(org)/poet:v0.10.11
 post_service_image ?= $(org)/post-service:v0.8.4
 post_init_image ?= $(org)/postcli:v0.12.11
 smesher_image ?= $(org)/go-spacemesh-dev:$(version_info)
-old_smesher_image ?= $(org)/go-spacemesh-dev:7587316 # replace with v1.8.0 before release
+old_smesher_image ?= $(org)/go-spacemesh-dev:v1.8.1
 bs_image ?= $(org)/go-spacemesh-dev-bs:$(version_info)
 
 test_id ?= systest-$(version_info)

--- a/systest/parameters/fastnet/smesher.json
+++ b/systest/parameters/fastnet/smesher.json
@@ -23,7 +23,11 @@
         }
     },
     "hare3": {
-        "log-stats": true
+        "log-stats": true,
+        "committeeupgrade": {
+            "layer": 16,
+            "size": 50
+        }
     },
     "smeshing": {
         "smeshing-verifying-opts": {

--- a/tortoise/algorithm.go
+++ b/tortoise/algorithm.go
@@ -34,7 +34,7 @@ type Config struct {
 	// CollectDetails sets numbers of layers to collect details.
 	// Must be less than WindowSize.
 	CollectDetails uint32 `mapstructure:"tortoise-collect-details"`
-	LayerSize      uint32
+	LayerSize      uint32 `mapstructure:"-"` // not configurable, overwritten by BaseConfig.LayerAvgSize
 }
 
 type WindowSizeInterval struct {


### PR DESCRIPTION
## Motivation

With https://github.com/spacemeshos/go-spacemesh/pull/6796 a bug in `viper` was fixed that allowed setting untagged config options although we didn't allow that via https://pkg.go.dev/github.com/go-viper/mapstructure/v2#DecoderConfig.IgnoreUntaggedFields.

Since some of those fields actually need to be configurable, I disabled the `IgnoreUntaggedFields` config setting and went through the config to manually disable all configuration values that should (or cannot) be configured by the user.

## Description

By default all configuration values can now be set again, this restores the behaviour we had before updating `viper`. However the reason we initially didn't allow to change untagged values was because some of them cause security issues, are ignored/overwritten by the node anyway or just don't make sense to expose to a user/operator of a node.

For more details see also: https://github.com/spacemeshos/go-spacemesh/pull/5466 and https://github.com/spacemeshos/go-spacemesh/pull/5276

The behaviour of the following config settings was changed:

- `config.Tortoise.LayerSize`: always overwritten by `config.LayerAvgSize`
- `config.P2P.DataDir`: always overwritten by `filepath.Join(config.DataDir(), "p2p")`
- `config.P2P.LogLevel`: always overwritten by `config.Logging.P2PLoggerLevel`
- `config.Certificate.CertifyThreshold`: always overwritten by `config.Certificate.CommitteeSize/2 + 1`
- `config.Certificate.LayerBuffer`: always overwritten by `config.Tortoise.Zdist`
- `config.Certificate.NumLayersToKeep`: always overwritten by `config.Tortoise.Zdist * 2`
- `config.VM.GasLimit`: always overwritten by `config.BlockGasLimit`
- `config.VM.GenesisID`: always overwritten by `config.GenesisConfig.GenesisID()`
- `config.POSTService`: values in this struct should only be change able for tests, for prod the used values are derived from values in other parts of the config
- `config.Bootstrap.DataDir`: always overwritten by `config.DataDirParent`
- `config.Bootstrap.Interval`: always overwritten by `config.LayerDuration / 5`
- `config.Sync.HareDelayLayers`: always overwritten by `config.Tortoise.Zdist`
- `config.Sync.SyncCertDistance`: always overwritten by `app.Config.Tortoise.Hdist`
- `config.Sync.Standalone`: always overwritten by `app.Config.Standalone`

Additionally I restored `smesher.json` for system tests as it was before merging https://github.com/spacemeshos/go-spacemesh/pull/6796 and set the old smesher image to `v1.8.1` to ensure any future changes are compatible to the latest released spacemesh version. 

## Test Plan

existing tests pass

## TODO

<!-- Please tick off the TODOs when completed -->

- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed
- [x] Update [changelog](../CHANGELOG.md) as needed
