### PR TITLE
[Merged by Bors] - Use in-memory ATX cache for ActivationService/Highest

### DIFF
--- a/api/grpcserver/v2beta1/activation.go
+++ b/api/grpcserver/v2beta1/activation.go
@@ -17,6 +17,7 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
+	"github.com/spacemeshos/go-spacemesh/atxsdata"
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/events"
 	"github.com/spacemeshos/go-spacemesh/sql"
@@ -162,16 +163,18 @@ func toAtx(atx *types.ActivationTx) *spacemeshv2beta1.Activation {
 	}
 }
 
-func NewActivationService(db sql.Executor, goldenAtx types.ATXID) *ActivationService {
+func NewActivationService(db sql.Executor, goldenAtx types.ATXID, atxdata *atxsdata.Data) *ActivationService {
 	return &ActivationService{
 		db:        db,
 		goldenAtx: goldenAtx,
+		atxdata:   atxdata,
 	}
 }
 
 type ActivationService struct {
 	goldenAtx types.ATXID
 	db        sql.Executor
+	atxdata   *atxsdata.Data
 }
 
 func (s *ActivationService) RegisterService(server *grpc.Server) {
@@ -240,15 +243,14 @@ func (s *ActivationService) Highest(
 	_ context.Context,
 	_ *spacemeshv2beta1.HighestRequest,
 ) (*spacemeshv2beta1.HighestResponse, error) {
-	highest, err := atxs.GetIDWithMaxHeight(s.db, types.EmptyNodeID, atxs.FilterAll)
-	if err != nil {
+	highest := s.atxdata.FindHighestHonest()
+	if highest == types.EmptyATXID {
 		return &spacemeshv2beta1.HighestResponse{
 			Activation: &spacemeshv2beta1.Activation{
 				Id: s.goldenAtx.Bytes(),
 			},
 		}, nil
 	}
-
 	atx, err := atxs.Get(s.db, highest)
 	if err != nil || atx == nil {
 		return nil, status.Error(codes.NotFound, fmt.Sprintf("atx id %v not found: %s", highest, err))

--- a/api/grpcserver/v2beta1/activation_test.go
+++ b/api/grpcserver/v2beta1/activation_test.go
@@ -13,6 +13,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/spacemeshos/go-spacemesh/atxsdata"
 	"github.com/spacemeshos/go-spacemesh/common/fixture"
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/events"
@@ -34,7 +35,7 @@ func TestActivationService_List(t *testing.T) {
 		}
 
 		goldenAtx := types.ATXID{2, 3, 4}
-		svc := NewActivationService(db, goldenAtx)
+		svc := NewActivationService(db, goldenAtx, atxsdata.New())
 		cfg, cleanup := launchServer(t, svc)
 		t.Cleanup(cleanup)
 
@@ -246,7 +247,7 @@ func TestActivationService_ActivationsCount(t *testing.T) {
 	}
 
 	goldenAtx := types.ATXID{2, 3, 4}
-	svc := NewActivationService(db, goldenAtx)
+	svc := NewActivationService(db, goldenAtx, atxsdata.New())
 	cfg, cleanup := launchServer(t, svc)
 	t.Cleanup(cleanup)
 
@@ -284,7 +285,8 @@ func TestActivationService_Highest(t *testing.T) {
 		ctx := t.Context()
 
 		goldenAtx := types.ATXID{2, 3, 4}
-		svc := NewActivationService(db, goldenAtx)
+		atxdata := atxsdata.New()
+		svc := NewActivationService(db, goldenAtx, atxdata)
 		cfg, cleanup := launchServer(t, svc)
 		t.Cleanup(cleanup)
 
@@ -292,14 +294,16 @@ func TestActivationService_Highest(t *testing.T) {
 		client := spacemeshv2beta1.NewActivationServiceClient(conn)
 
 		atx := &types.ActivationTx{
-			Sequence:     rand.Uint64(),
-			PublishEpoch: 0,
-			Coinbase:     types.GenerateAddress(types.RandomBytes(32)),
-			NumUnits:     rand.Uint32(),
+			Sequence:       rand.Uint64(),
+			PublishEpoch:   0,
+			BaseTickHeight: 100,
+			Coinbase:       types.GenerateAddress(types.RandomBytes(32)),
+			NumUnits:       rand.Uint32(),
 		}
 		id := types.RandomATXID()
 		atx.SetID(id)
 		require.NoError(t, atxs.Add(db, atx, types.AtxBlob{}))
+		atxdata.AddFromAtx(atx, false)
 
 		res, err := client.Highest(ctx, &spacemeshv2beta1.HighestRequest{})
 		require.NoError(t, err)
@@ -316,7 +320,7 @@ func TestActivationService_Highest(t *testing.T) {
 		ctx := t.Context()
 
 		goldenAtx := types.ATXID{2, 3, 4}
-		svc := NewActivationService(db, goldenAtx)
+		svc := NewActivationService(db, goldenAtx, atxsdata.New())
 		cfg, cleanup := launchServer(t, svc)
 		t.Cleanup(cleanup)
 

--- a/atxsdata/data.go
+++ b/atxsdata/data.go
@@ -1,11 +1,12 @@
 package atxsdata
 
 import (
+	"cmp"
+	"iter"
+	"maps"
 	"slices"
 	"sync"
 	"sync/atomic"
-
-	"golang.org/x/exp/maps"
 
 	"github.com/spacemeshos/go-spacemesh/common/types"
 	"github.com/spacemeshos/go-spacemesh/signing"
@@ -177,7 +178,7 @@ func (d *Data) SetMalicious(node types.NodeID) {
 	d.malicious[node] = struct{}{}
 }
 
-func (d *Data) MaliciousIdentities() []types.NodeID {
+func (d *Data) MaliciousIdentities() iter.Seq[types.NodeID] {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 	return maps.Keys(d.malicious)
@@ -254,6 +255,10 @@ func NotMalicious(d *Data, atx *ATX, _ lockGuard) bool {
 func (d *Data) IterateInEpoch(epoch types.EpochID, fn func(types.ATXID, *ATX), filters ...AtxFilter) {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
+	d.iterateInEpoch(epoch, fn, filters...)
+}
+
+func (d *Data) iterateInEpoch(epoch types.EpochID, fn func(types.ATXID, *ATX), filters ...AtxFilter) {
 	ecache, exists := d.epochs[epoch]
 	if !exists {
 		return
@@ -271,22 +276,16 @@ func (d *Data) IterateInEpoch(epoch types.EpochID, fn func(types.ATXID, *ATX), f
 
 func (d *Data) IterateHighTicksInEpoch(target types.EpochID, fn func(types.ATXID) bool) {
 	type candidate struct {
-		id types.ATXID
-		*ATX
+		id     types.ATXID
+		Height uint64
 	}
 	candidates := make([]candidate, 0, d.Size(target))
 	d.IterateInEpoch(target, func(id types.ATXID, atx *ATX) {
-		candidates = append(candidates, candidate{id: id, ATX: atx})
+		candidates = append(candidates, candidate{id: id, Height: atx.Height})
 	}, NotMalicious)
 
 	slices.SortFunc(candidates, func(a, b candidate) int {
-		switch {
-		case a.Height < b.Height:
-			return 1
-		case a.Height > b.Height:
-			return -1
-		}
-		return 0
+		return cmp.Compare(b.Height, a.Height)
 	})
 
 	for _, c := range candidates {
@@ -294,6 +293,40 @@ func (d *Data) IterateHighTicksInEpoch(target types.EpochID, fn func(types.ATXID
 			return
 		}
 	}
+}
+
+// FindHighestHonest looks for a heightest ATX in the most recent 2 epochs.
+func (d *Data) FindHighestHonest() types.ATXID {
+	type candidateATX struct {
+		id     types.ATXID
+		Height uint64
+	}
+
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	epochsDescending := slices.SortedFunc(
+		maps.Keys(d.epochs),
+		func(a, b types.EpochID) int {
+			return cmp.Compare(b, a)
+		},
+	)
+	var candidate candidateATX
+	for _, target := range epochsDescending[0:min(2, len(epochsDescending))] {
+		d.iterateInEpoch(
+			target,
+			func(id types.ATXID, atx *ATX) {
+				if atx.Height > candidate.Height {
+					candidate = candidateATX{
+						id:     id,
+						Height: atx.Height,
+					}
+				}
+			},
+			NotMalicious,
+		)
+	}
+
+	return candidate.id
 }
 
 func (d *Data) MissingInEpoch(epoch types.EpochID, atxs []types.ATXID) []types.ATXID {

--- a/atxsdata/data_test.go
+++ b/atxsdata/data_test.go
@@ -379,3 +379,113 @@ func BenchmarkGetByNodeID_Managed(b *testing.B) {
 		})
 	}
 }
+
+func TestFindHighestHonest(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty data returns empty ATXID", func(t *testing.T) {
+		data := New()
+		id := data.FindHighestHonest()
+		require.Equal(t, types.EmptyATXID, id)
+	})
+
+	t.Run("returns highest ATX from most recent epoch", func(t *testing.T) {
+		data := New()
+
+		// Add ATXs to epoch 1
+		atx1ID := types.ATXID{1}
+		atx1 := &ATX{
+			Node:   types.NodeID{1},
+			Height: 100,
+		}
+		data.AddAtx(1, atx1ID, atx1)
+
+		// Add ATXs to epoch 2 (more recent)
+		atx2ID := types.ATXID{2}
+		atx2 := &ATX{
+			Node:   types.NodeID{2},
+			Height: 50, // Lower height
+		}
+		data.AddAtx(2, atx2ID, atx2)
+
+		atx3ID := types.ATXID{3}
+		atx3 := &ATX{
+			Node:   types.NodeID{3},
+			Height: 150, // Higher height
+		}
+		data.AddAtx(2, atx3ID, atx3)
+
+		// Should return the highest ATX from epoch 2
+		id := data.FindHighestHonest()
+		require.Equal(t, atx3ID, id)
+	})
+
+	t.Run("ignores malicious ATXs", func(t *testing.T) {
+		data := New()
+
+		// Add honest ATX to epoch 2
+		honestID := types.ATXID{1}
+		honest := &ATX{
+			Node:   types.NodeID{1},
+			Height: 100,
+		}
+		data.AddAtx(2, honestID, honest)
+
+		// Add malicious ATX to epoch 2 with higher height
+		maliciousID := types.ATXID{2}
+		malicious := &ATX{
+			Node:   types.NodeID{2},
+			Height: 200, // Higher height but malicious
+		}
+		data.AddAtx(2, maliciousID, malicious)
+		data.SetMalicious(malicious.Node)
+
+		// Should return the honest ATX despite lower height
+		id := data.FindHighestHonest()
+		require.Equal(t, honestID, id)
+	})
+
+	t.Run("handles more than two epochs correctly", func(t *testing.T) {
+		data := New()
+
+		// Add ATXs to multiple epochs
+		for epoch := types.EpochID(1); epoch <= 5; epoch++ {
+			atxID := types.ATXID{byte(epoch)}
+			atx := &ATX{
+				Node:   types.NodeID{byte(epoch)},
+				Height: uint64(epoch * 100), // Height increases with epoch
+			}
+			data.AddAtx(epoch, atxID, atx)
+		}
+
+		// Should consider only epochs 4 and 5, and return the highest from those
+		id := data.FindHighestHonest()
+
+		// Highest should be from epoch 5
+		expectedID := types.ATXID{5}
+		require.Equal(t, expectedID, id)
+	})
+
+	t.Run("returns ATX from the most recent epoch when multiple ATXs have same height", func(t *testing.T) {
+		data := New()
+
+		// Add multiple ATXs with same height to the same epoch
+		atx1ID := types.ATXID{1}
+		atx1 := &ATX{
+			Node:   types.NodeID{1},
+			Height: 100,
+		}
+		data.AddAtx(2, atx1ID, atx1)
+
+		atx2ID := types.ATXID{2}
+		atx2 := &ATX{
+			Node:   types.NodeID{2},
+			Height: 100, // Same height
+		}
+		data.AddAtx(3, atx2ID, atx2)
+
+		// The method should return one of them (implementation dependent)
+		id := data.FindHighestHonest()
+		require.Equal(t, atx2ID, id)
+	})
+}

--- a/node/node.go
+++ b/node/node.go
@@ -1635,7 +1635,7 @@ func (app *App) grpcService(svc grpcserver.Service, lg log.Log) (grpcserver.Serv
 		return service, nil
 	// v2beta1
 	case grpcserver.ActivationV2Beta1:
-		service := v2beta1.NewActivationService(app.apiDB, types.ATXID(app.Config.Genesis.GoldenATX()))
+		service := v2beta1.NewActivationService(app.apiDB, types.ATXID(app.Config.Genesis.GoldenATX()), app.atxsdata)
 		app.grpcServices[svc] = service
 		return service, nil
 	case grpcserver.ActivationStreamV2Beta1:

--- a/tortoise/recover.go
+++ b/tortoise/recover.go
@@ -59,7 +59,7 @@ func Recover(
 		}
 	}
 
-	for _, id := range atxdata.MaliciousIdentities() {
+	for id := range atxdata.MaliciousIdentities() {
 		trtl.OnMalfeasance(id)
 	}
 


### PR DESCRIPTION
## Motivation

The endpoint `spacemesh.v2beta1.ActivationService.Highest` got extremely slow with increased DB size.

## Description
Example:
```sh
time grpcurl -plaintext  localhost:9102 spacemesh.v2beta1.ActivationService.Highest
...

real    0m18.224s
user    0m0.014s
sys     0m0.012s
```

The highest ATX can be found in the in-memory ATX cache (the `atxsdata`). This PR changes the GRPC handler to use it.

## Test Plan

Added unittests and compared the speed with (unchanged) v2alpha1:

```sh
❯ time curl -X POST "http://localhost:9104/spacemesh.v2alpha1.ActivationService/Highest" -d "{}"
{"activation":{"id":"A2eOJxUA/rGs9ERImDuO6fyewV9NEMHjmcr0kI2CHKI=","smesherId":"47LoRjTePHk5JkmtgkQfqc1AsA57y38rJpoht7vKurQ=","publishEpoch":10,"coinbase":"sm1qqqqqqq74s7v3sr7f2wt046c58ed02qeqsk0knc76320y","weight":"408366","height":"94122","numUnits":42}}
________________________________________________________
Executed in    1.58 secs      fish           external
   usr time    3.72 millis    0.00 millis    3.72 millis
   sys time   11.28 millis    1.24 millis   10.04 millis
```

```sh
❯ time curl "http://localhost:9104/spacemesh.v2beta1.ActivationService/Highest" -d "{}"
{"activation":{"id":"18kP2z30Tc427THjx39IWb4QPRUUiMfLYdOJrKco3Y0=","smesherId":"jASEYxxwH1ZMRBlsjHzpJ3Pa9deFZDW3ThxkKtist0E=","publishEpoch":10,"coinbase":"sm1qqqqqqq74s7v3sr7f2wt046c58ed02qeqsk0knc76320y","weight":"816732","height":"94122","numUnits":84}}
________________________________________________________
Executed in   41.77 millis    fish           external
   usr time   36.35 millis   34.54 millis    1.80 millis
   sys time   10.58 millis    6.24 millis    4.34 millis
```
