### PR TITLE
[Merged by Bors] - return error in ATX V2 handler on known ATX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 See [RELEASE](./RELEASE.md) for workflow instructions.
 
+## UNRELEASED
+
+### Improvements
+
+* [#6823](https://github.com/spacemeshos/go-spacemesh/pull/6823) Fixed an issue where the node would repeatably
+  broadcast ATXs it already has seen, causing unnecessary network traffic.
+
 ## v1.8.2
 
 ### Improvements

--- a/activation/handler_v2.go
+++ b/activation/handler_v2.go
@@ -83,7 +83,7 @@ func (h *HandlerV2) processATX(
 		return fmt.Errorf("failed to check if atx exists: %w", err)
 	}
 	if exists {
-		return nil
+		return fmt.Errorf("%w: %s", errKnownAtx, watx.ID())
 	}
 
 	h.logger.Debug(

--- a/activation/handler_v2_test.go
+++ b/activation/handler_v2_test.go
@@ -499,7 +499,7 @@ func TestHandlerV2_ProcessSoloATX(t *testing.T) {
 
 		// processing ATX for the second time should skip checks
 		err = atxHandler.processATX(t.Context(), atxHandler.local, atx, time.Now())
-		require.NoError(t, err)
+		require.ErrorIs(t, err, errKnownAtx)
 	})
 	t.Run("second ATX", func(t *testing.T) {
 		t.Parallel()


### PR DESCRIPTION
## Motivation

Returning an error prevents rebroadcasting the ATX

## Description

Otherwise, there is a risk of a group of nodes DDOSing themselves by rebroadcasting the same ATXs in circles.