### PR TITLE
ci: bind workflow inputs via env before shell

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -65,8 +65,10 @@ jobs:
 
     - name: Push docker images to dockerhub
       if: inputs.custom_image_tag
+      env:
+        CUSTOM_IMAGE_TAG: ${{ inputs.custom_image_tag }}
       run: |
-        export DOCKER_IMAGE_VERSION="${{ inputs.custom_image_tag }}" TAG_SUFIX=$SUFIX
+        export DOCKER_IMAGE_VERSION="$CUSTOM_IMAGE_TAG" TAG_SUFIX=$SUFIX
         make dockerpush-only
         make dockerpush-bs-only
 
@@ -104,8 +106,10 @@ jobs:
 
     - name: Push docker manifest to dockerhub
       if: inputs.custom_image_tag
+      env:
+        CUSTOM_IMAGE_TAG: ${{ inputs.custom_image_tag }}
       run: |
-        export DOCKER_IMAGE_VERSION="${{ inputs.custom_image_tag }}"
+        export DOCKER_IMAGE_VERSION="$CUSTOM_IMAGE_TAG"
         make dockerpush-go-manifest
         make dockerpush-bs-manifest
         

--- a/.github/workflows/systest.yml
+++ b/.github/workflows/systest.yml
@@ -251,7 +251,8 @@ jobs:
           level: ${{ inputs.log_level }}
           clusters: 4
           norbac: 1
-        run: make -C systest run test_name=${{ inputs.test_name }}
+          test_name: ${{ inputs.test_name }}
+        run: make -C systest run test_name=$test_name
 
       - name: Delete pod
         if: always()


### PR DESCRIPTION
## Summary
Bind workflow `inputs.*` into step `env:` before shell use in:
- `dockerhub.yml` (`custom_image_tag`)
- `systest.yml` (`test_name`; `log_level` was already env-bound)

Keeps `${{ }}` expansions out of `run:` scripts. `if:` conditions are unchanged.

## Test plan
- [ ] Confirm workflow YAML still validates
- [ ] Optional: dry-run dockerhub with custom_image_tag / systest dispatch

Made with [Cursor](https://cursor.com)